### PR TITLE
feat: Compile static workflow graphs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,4 @@
+steps:
+  - label: ":go: Repository checks"
+    key: "checks"
+    command: "make check"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,9 @@
 steps:
   - label: ":go: Repository checks"
     key: "checks"
-    command: "make check"
+    command: >-
+      docker run --rm
+      --volume "$$PWD:/work"
+      --workdir /work
+      golang:1.26.5-bookworm@sha256:1ecb7edf62a0408027bd5729dfd6b1b8766e578e8df93995b225dfd0944eb651
+      bash -ceu 'apt-get update >/dev/null && apt-get install -y --no-install-recommends jq >/dev/null && make check'

--- a/README.md
+++ b/README.md
@@ -5,35 +5,41 @@ Actions workflows as native Buildkite builds. It will compile workflow jobs
 into Buildkite pipeline jobs and execute each job's Actions steps inside a
 compatibility runtime, without creating a GitHub Actions run.
 
-The Phase 0 semantic foundation is merged, and Phase 1 static compiler work is
-underway. Local validation, source-ordered static matrix expansion, and the
-needs-free job runtime are implemented. Pipeline upload and the hosted GitHub
-Actions/Buildkite differential and transport proofs remain incomplete.
+The Phase 0 semantic foundation and Phase 1 static compiler are implemented.
+The compiler validates the supported graph, expands local reusable workflows
+and matrices, applies queue policy, produces immutable job plans, and emits a
+Buildkite pipeline. Pipeline upload and the hosted GitHub Actions/Buildkite
+differential and transport proofs remain incomplete.
 
 ## Commands
 
 The current command surface is:
 
 ```text
-buildkite-gha validate [--event-path <path>] <workflow>
-buildkite-gha compile --event-path <path> <workflow>
+buildkite-gha validate [--event-path <path>] [--format text|json] <workflow>
+buildkite-gha compile --event-path <path> [--format pipeline|ir-json] <workflow>
 buildkite-gha upload <workflow>                         # not implemented
 buildkite-gha run-job --plan <path> [--result <path>]
 ```
 
-`compile` writes deterministic Phase 0 JSON IR, not Buildkite pipeline YAML.
-The event file must contain the provider, event name, repository owner and
-name, ref, SHA, actor, and payload snapshot. Static matrices support
-source-ordered products, `include`, `exclude`, typed scalar values, and exact
-dependency fan-out. The compiler rejects dynamic graph expressions, reusable
-workflows, unsupported runtime features, and deterministic key collisions.
+`compile` writes deterministic Buildkite pipeline YAML by default;
+`--format ir-json` exposes the owned compiler IR for inspection. The event file
+must contain the provider, event name, repository owner and name, ref, SHA,
+actor, and payload snapshot. Static matrices support source-ordered products,
+`include`, `exclude`, typed scalar values, and exact dependency fan-out. Local
+reusable workflows are flattened with bounded depth and graph size. Runner
+labels are mapped through a fail-closed policy, and unattested event files can
+target only the untrusted queue. The emitted YAML references content-addressed
+plans, but `compile` does not materialize or upload those artifacts; that
+transport remains behind the unimplemented `upload` command.
 
 `run-job` consumes a versioned job plan and supports the current Linux shell
-and local Node 24 JavaScript, composite, and Docker action spikes. Compiled job
-plans with `needs` are rejected until producer-attributed result manifests can be
-injected at runtime; remote action resolution, services and job containers,
-conditions, timeouts, cancellation, and `continue-on-error` are also outside
-the current executable subset. Use `buildkite-gha help`,
+and local Node 24 JavaScript, composite, and Docker action spikes. Static plans
+record dependency IDs, but producer-attributed result manifests are not yet
+injected into downstream runtime `needs` contexts, so `run-job` refuses every
+plan with static dependencies. Remote action resolution,
+services and job containers, conditions, timeouts, cancellation, and
+`continue-on-error` are also outside the current executable subset. Use `buildkite-gha help`,
 `buildkite-gha help <command>`, or `buildkite-gha --version` for exact usage.
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Actions workflows as native Buildkite builds. It will compile workflow jobs
 into Buildkite pipeline jobs and execute each job's Actions steps inside a
 compatibility runtime, without creating a GitHub Actions run.
 
-The project is in Phase 0. Local validation, static compilation, and the
-needs-free job runtime are implemented as semantic spikes. Pipeline upload and
-the hosted GitHub Actions/Buildkite differential and transport proofs remain
-unimplemented or blocked on the managed test infrastructure.
+The Phase 0 semantic foundation is merged, and Phase 1 static compiler work is
+underway. Local validation, source-ordered static matrix expansion, and the
+needs-free job runtime are implemented. Pipeline upload and the hosted GitHub
+Actions/Buildkite differential and transport proofs remain incomplete.
 
 ## Commands
 
@@ -23,9 +23,10 @@ buildkite-gha run-job --plan <path> [--result <path>]
 
 `compile` writes deterministic Phase 0 JSON IR, not Buildkite pipeline YAML.
 The event file must contain the provider, event name, repository owner and
-name, ref, SHA, actor, and payload snapshot. The compiler rejects dynamic graph
-expressions, matrix `include`/`exclude`, reusable workflows, unsupported runtime
-features, and deterministic key collisions.
+name, ref, SHA, actor, and payload snapshot. Static matrices support
+source-ordered products, `include`, `exclude`, typed scalar values, and exact
+dependency fan-out. The compiler rejects dynamic graph expressions, reusable
+workflows, unsupported runtime features, and deterministic key collisions.
 
 `run-job` consumes a versioned job plan and supports the current Linux shell
 and local Node 24 JavaScript, composite, and Docker action spikes. Compiled job

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -1055,9 +1055,14 @@ Explicitly defer from beta unless implementation evidence changes the order:
   `testdata/smoke` corpus are committed on `main`.
 - The Phase 0 implementation is merged on `main`. Its remaining live oracles
   are operational gates rather than unmerged foundation work.
-- Phase 1 implementation has started. Its first slice implements static matrix
-  `include`/`exclude`, typed values, source-order expansion, and exact
-  dependency fan-out; Buildkite pipeline emission is the next slice.
+- Phase 1 is implemented. The static compiler now owns compile-time contexts,
+  explicit variable snapshots, bounded local reusable-workflow flattening,
+  matrix and dependency expansion, fail-closed runner policy, immutable job
+  plans, Buildkite pipeline YAML, and text/JSON compatibility reports.
+  Generated downstream plans remain deliberately non-executable until Phase 2
+  wires producer-attributed result manifests, and `compile` does not yet
+  materialize or upload the content-addressed plan artifacts referenced by its
+  pipeline output.
 - The first work wave is integrated: the Go/CLI foundation is runnable,
   ADR 0001 records the actionlint/act reuse boundary, and ADR 0002 plus schemas
   and eight conformance cases define the signed plan-envelope trust contract.
@@ -1073,25 +1078,23 @@ Explicitly defer from beta unless implementation evidence changes the order:
   dormant probe cover immutable artifacts, dependency policy, producer
   attribution, bounded canonical signed bindings and markers, and fail-closed
   upload recovery.
-- The end-of-phase Deep Analysis pass is integrated: compiler output validates
-  against the owned plan schema, every job with `needs` now fails closed until
-  result-manifest injection exists, expression substitution is single-pass,
+- The Phase 0 Deep Analysis pass is integrated: compiler output validates
+  against the owned plan schema, expression substitution is single-pass,
   runtime output is bounded without pipe deadlocks, inherited environment is
   allowlisted, and transport artifacts are materialized from verified bytes in
   a confined root before upload.
 - All local tests, race tests, vet, schema fixtures, shell checks, and offline
-  pipeline validation pass. The managed GitHub repository and Buildkite
-  pipeline now exist, but the first builds stopped at the managed bootstrap's
-  default `buildkite-agent pipeline upload` because the repository has no
-  `.buildkite/pipeline.yml`. Hosted differential execution and the real
-  transport, signing, interruption, and dependency-extension oracles have not
-  run yet.
+  pipeline validation pass. A default `.buildkite/pipeline.yml` now runs the
+  repository checks, and all three smoke compiler outputs pass the current
+  Buildkite Agent's `pipeline upload --dry-run --no-interpolation` parser.
+  Hosted differential execution and the real transport, signing, interruption,
+  and dependency-extension oracles have not run yet.
 
 Phase 0 spike support snapshot:
 
 | Boundary | Proven locally | Explicit gap or live gate |
 | --- | --- | --- |
-| Compile | Actionlint-backed owned model, deterministic static graph and matrix expansion, source spans, stable keys, schema-valid versioned owned job plans; the first Phase 1 slice adds source-ordered matrix `include`/`exclude`, typed scalar values, and exact dependency fan-out | Dynamic graph expressions, every versioned job plan with `needs`, reusable-workflow jobs, and expression-derived `runs-on` fail closed |
+| Compile | Actionlint-backed owned model, deterministic compile-time context and vars evaluation, bounded local reusable-workflow flattening, source-ordered matrix `include`/`exclude`, exact dependency fan-out, policy-selected queues, schema-valid versioned plans, and Buildkite pipeline YAML | Runtime-dependent graph expressions, remote reusable workflows, unsupported operating systems, and unmapped runner labels fail closed |
 | Execute | Needs-free Bash/sh steps and local Node 24, composite, and Dockerfile actions; outputs, environment, state, summaries, masking, failure results, and LIFO post-actions | Remote actions, nested composite actions, all dependency-result semantics, conditions, services/job containers, timeouts, cancellation, and `continue-on-error` fail closed |
 | Differential | Isolated committed fixture, canonical capture/comparison, and offline-validated GitHub Actions and Buildkite definitions | Neither hosted provider definition has run against the same committed revision |
 | Transport | Confined materialization of verified content-addressed plan and binding bytes, deterministic two-job upload, strict compiler edges, failure-settling logical edges, producer-bound manifests, signed markers, and exact command capture | Real artifact ordering/selection, metadata visibility, upload atomicity, importer dependency extension, and per-dependency failure behavior require a live build |

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -1053,7 +1053,11 @@ Explicitly defer from beta unless implementation evidence changes the order:
 
 - The repository baseline, reviewed architecture plan, and staged
   `testdata/smoke` corpus are committed on `main`.
-- Phase 0 implementation is active on `lox/phase-0`.
+- The Phase 0 implementation is merged on `main`. Its remaining live oracles
+  are operational gates rather than unmerged foundation work.
+- Phase 1 implementation has started. Its first slice implements static matrix
+  `include`/`exclude`, typed values, source-order expansion, and exact
+  dependency fan-out; Buildkite pipeline emission is the next slice.
 - The first work wave is integrated: the Go/CLI foundation is runnable,
   ADR 0001 records the actionlint/act reuse boundary, and ADR 0002 plus schemas
   and eight conformance cases define the signed plan-envelope trust contract.
@@ -1076,16 +1080,18 @@ Explicitly defer from beta unless implementation evidence changes the order:
   allowlisted, and transport artifacts are materialized from verified bytes in
   a confined root before upload.
 - All local tests, race tests, vet, schema fixtures, shell checks, and offline
-  pipeline validation pass. Phase 0 is not complete: the managed internal
-  GitHub repository and Buildkite pipeline do not exist yet, so neither hosted
-  differential execution nor the real transport, signing, interruption, and
-  dependency-extension oracles have run.
+  pipeline validation pass. The managed GitHub repository and Buildkite
+  pipeline now exist, but the first builds stopped at the managed bootstrap's
+  default `buildkite-agent pipeline upload` because the repository has no
+  `.buildkite/pipeline.yml`. Hosted differential execution and the real
+  transport, signing, interruption, and dependency-extension oracles have not
+  run yet.
 
 Phase 0 spike support snapshot:
 
 | Boundary | Proven locally | Explicit gap or live gate |
 | --- | --- | --- |
-| Compile | Actionlint-backed owned model, deterministic static graph and matrix expansion, source spans, stable keys, schema-valid versioned owned job plans | Dynamic graph expressions, every job with `needs`, matrix `include`/`exclude`, reusable-workflow jobs, and expression-derived `runs-on` fail closed |
+| Compile | Actionlint-backed owned model, deterministic static graph and matrix expansion, source spans, stable keys, schema-valid versioned owned job plans; the first Phase 1 slice adds source-ordered matrix `include`/`exclude`, typed scalar values, and exact dependency fan-out | Dynamic graph expressions, every versioned job plan with `needs`, reusable-workflow jobs, and expression-derived `runs-on` fail closed |
 | Execute | Needs-free Bash/sh steps and local Node 24, composite, and Dockerfile actions; outputs, environment, state, summaries, masking, failure results, and LIFO post-actions | Remote actions, nested composite actions, all dependency-result semantics, conditions, services/job containers, timeouts, cancellation, and `continue-on-error` fail closed |
 | Differential | Isolated committed fixture, canonical capture/comparison, and offline-validated GitHub Actions and Buildkite definitions | Neither hosted provider definition has run against the same committed revision |
 | Transport | Confined materialization of verified content-addressed plan and binding bytes, deterministic two-job upload, strict compiler edges, failure-settling logical edges, producer-bound manifests, signed markers, and exact command capture | Real artifact ordering/selection, metadata visibility, upload atomicity, importer dependency extension, and per-dependency failure behavior require a live build |

--- a/internal/buildkite/pipeline.go
+++ b/internal/buildkite/pipeline.go
@@ -1,0 +1,182 @@
+// Package buildkite emits deterministic Buildkite pipeline YAML from trusted,
+// integration-neutral job descriptions.
+package buildkite
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+const planDirectory = ".buildkite-gha/plans"
+
+var identifierPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,255}$`)
+var digestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+var uuidPattern = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+// Pipeline is the trusted input required to emit generated compatibility jobs.
+type Pipeline struct {
+	CompilerStep string
+	Jobs         []Job
+}
+
+// Job describes one expanded workflow job after queue policy has been applied.
+type Job struct {
+	Key              string
+	Label            string
+	Queue            string
+	PlanDigest       string
+	Dependencies     []string
+	ConcurrencyGroup string
+	Concurrency      int
+}
+
+// PlanPath returns the fixed local path for a content-addressed job plan.
+func PlanPath(digest string) (string, error) {
+	if !digestPattern.MatchString(digest) {
+		return "", fmt.Errorf("invalid plan digest %q", digest)
+	}
+	return planDirectory + "/" + strings.TrimPrefix(digest, "sha256:") + ".json", nil
+}
+
+// Emit validates and emits stable YAML terminated by a newline.
+func Emit(pipeline Pipeline) ([]byte, error) {
+	if !validStepKey(pipeline.CompilerStep) {
+		return nil, fmt.Errorf("invalid compiler step key %q", pipeline.CompilerStep)
+	}
+	if len(pipeline.Jobs) == 0 {
+		return nil, fmt.Errorf("pipeline requires at least one generated job")
+	}
+	jobs, err := orderJobs(pipeline.CompilerStep, pipeline.Jobs)
+	if err != nil {
+		return nil, err
+	}
+
+	var out bytes.Buffer
+	out.WriteString("steps:\n")
+	for _, job := range jobs {
+		planPath, err := PlanPath(job.PlanDigest)
+		if err != nil {
+			return nil, fmt.Errorf("job %q: %w", job.Key, err)
+		}
+		fmt.Fprintf(&out, "  - label: %s\n", yamlScalar(job.Label))
+		fmt.Fprintf(&out, "    key: %s\n", yamlScalar(job.Key))
+		fmt.Fprintf(&out, "    command: %s\n", yamlScalar("buildkite-gha run-job --plan "+planPath))
+		out.WriteString("    agents:\n")
+		fmt.Fprintf(&out, "      queue: %s\n", yamlScalar(job.Queue))
+		out.WriteString("    checkout:\n      skip: true\n")
+		out.WriteString("    env:\n")
+		fmt.Fprintf(&out, "      BUILDKITE_GHA_PLAN_DIGEST: %s\n", yamlScalar(job.PlanDigest))
+		fmt.Fprintf(&out, "      BUILDKITE_GHA_PLAN_PATH: %s\n", yamlScalar(planPath))
+		fmt.Fprintf(&out, "      BUILDKITE_GHA_PLAN_PRODUCER: %s\n", yamlScalar(pipeline.CompilerStep))
+		if job.Concurrency != 0 {
+			fmt.Fprintf(&out, "    concurrency: %d\n", job.Concurrency)
+			fmt.Fprintf(&out, "    concurrency_group: %s\n", yamlScalar(job.ConcurrencyGroup))
+		}
+		out.WriteString("    depends_on:\n")
+		fmt.Fprintf(&out, "      - step: %s\n        allow_failure: false\n", yamlScalar(pipeline.CompilerStep))
+		for _, dependency := range job.Dependencies {
+			fmt.Fprintf(&out, "      - step: %s\n        allow_failure: true\n", yamlScalar(dependency))
+		}
+	}
+	return out.Bytes(), nil
+}
+
+func orderJobs(compilerStep string, input []Job) ([]Job, error) {
+	jobs := make(map[string]Job, len(input))
+	digests := make(map[string]string, len(input))
+	indegree := make(map[string]int, len(input))
+	dependents := make(map[string][]string, len(input))
+	for _, job := range input {
+		if err := validateJob(compilerStep, job); err != nil {
+			return nil, err
+		}
+		if _, exists := jobs[job.Key]; exists {
+			return nil, fmt.Errorf("duplicate generated step key %q", job.Key)
+		}
+		if other, exists := digests[job.PlanDigest]; exists {
+			return nil, fmt.Errorf("jobs %q and %q share plan digest %s", other, job.Key, job.PlanDigest)
+		}
+		digests[job.PlanDigest] = job.Key
+		job.Dependencies = append([]string(nil), job.Dependencies...)
+		sort.Strings(job.Dependencies)
+		for i, dependency := range job.Dependencies {
+			if i > 0 && dependency == job.Dependencies[i-1] {
+				return nil, fmt.Errorf("job %q repeats dependency %q", job.Key, dependency)
+			}
+		}
+		jobs[job.Key] = job
+		indegree[job.Key] = len(job.Dependencies)
+	}
+	for key, job := range jobs {
+		for _, dependency := range job.Dependencies {
+			if _, exists := jobs[dependency]; !exists {
+				return nil, fmt.Errorf("job %q has unknown dependency %q", key, dependency)
+			}
+			dependents[dependency] = append(dependents[dependency], key)
+		}
+	}
+	ready := make([]string, 0, len(jobs))
+	for key, degree := range indegree {
+		if degree == 0 {
+			ready = append(ready, key)
+		}
+	}
+	sort.Strings(ready)
+	ordered := make([]Job, 0, len(jobs))
+	for len(ready) > 0 {
+		key := ready[0]
+		ready = ready[1:]
+		ordered = append(ordered, jobs[key])
+		for _, dependent := range dependents[key] {
+			indegree[dependent]--
+			if indegree[dependent] == 0 {
+				ready = append(ready, dependent)
+				sort.Strings(ready)
+			}
+		}
+	}
+	if len(ordered) != len(jobs) {
+		return nil, fmt.Errorf("generated job graph contains a cycle")
+	}
+	return ordered, nil
+}
+
+func validateJob(compilerStep string, job Job) error {
+	if !validStepKey(job.Key) || job.Key == compilerStep {
+		return fmt.Errorf("invalid generated step key %q", job.Key)
+	}
+	if job.Label == "" {
+		return fmt.Errorf("job %q requires a label", job.Key)
+	}
+	if !identifierPattern.MatchString(job.Queue) {
+		return fmt.Errorf("job %q has invalid queue %q", job.Key, job.Queue)
+	}
+	if _, err := PlanPath(job.PlanDigest); err != nil {
+		return fmt.Errorf("job %q: %w", job.Key, err)
+	}
+	if job.Concurrency < 0 {
+		return fmt.Errorf("job %q has invalid concurrency %d", job.Key, job.Concurrency)
+	}
+	if job.Concurrency > 0 && job.ConcurrencyGroup == "" || job.Concurrency == 0 && job.ConcurrencyGroup != "" {
+		return fmt.Errorf("job %q requires concurrency and concurrency group together", job.Key)
+	}
+	for _, dependency := range job.Dependencies {
+		if !validStepKey(dependency) || dependency == compilerStep || dependency == job.Key {
+			return fmt.Errorf("job %q has invalid dependency %q", job.Key, dependency)
+		}
+	}
+	return nil
+}
+
+func validStepKey(key string) bool {
+	return identifierPattern.MatchString(key) && !uuidPattern.MatchString(key)
+}
+
+func yamlScalar(value string) string {
+	encoded, _ := json.Marshal(value)
+	return string(encoded)
+}

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -1,0 +1,143 @@
+package buildkite
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/buildkite-gha/internal/transport"
+	"go.yaml.in/yaml/v4"
+)
+
+func TestEmitGolden(t *testing.T) {
+	producerDigest := testDigest("producer plan")
+	consumerOneDigest := testDigest("consumer one plan")
+	consumerTwoDigest := testDigest("consumer two plan")
+	pipeline := Pipeline{
+		CompilerStep: "gha-importer",
+		Jobs: []Job{
+			{Key: "gha-consumer-two", Label: `Consumer ($VALUE, variant="two")`, Queue: "gha-linux", PlanDigest: consumerTwoDigest, Dependencies: []string{"gha-producer"}, ConcurrencyGroup: "buildkite-gha/shell/consumer", Concurrency: 2},
+			{Key: "gha-producer", Label: "Producer", Queue: "gha-linux", PlanDigest: producerDigest},
+			{Key: "gha-consumer-one", Label: "Consumer (variant=one)", Queue: "gha-linux", PlanDigest: consumerOneDigest, Dependencies: []string{"gha-producer"}, ConcurrencyGroup: "buildkite-gha/shell/consumer", Concurrency: 2},
+		},
+	}
+	first, err := Emit(pipeline)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := Emit(pipeline)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Fatal("repeated emission was not byte-identical")
+	}
+	want, err := os.ReadFile(filepath.Join("testdata", "pipeline.golden.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(first, want) {
+		t.Fatalf("pipeline changed\nwant:\n%s\ngot:\n%s", want, first)
+	}
+	var document struct {
+		Steps []struct {
+			Key      string `yaml:"key"`
+			Checkout struct {
+				Skip bool `yaml:"skip"`
+			} `yaml:"checkout"`
+			DependsOn []struct {
+				Step         string `yaml:"step"`
+				AllowFailure bool   `yaml:"allow_failure"`
+			} `yaml:"depends_on"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(first, &document); err != nil {
+		t.Fatalf("parse emitted YAML: %v", err)
+	}
+	if len(document.Steps) != 3 {
+		t.Fatalf("emitted steps = %#v", document.Steps)
+	}
+	for _, step := range document.Steps {
+		if !step.Checkout.Skip {
+			t.Fatalf("step %q does not skip checkout", step.Key)
+		}
+		if len(step.DependsOn) == 0 || step.DependsOn[0].Step != "gha-importer" || step.DependsOn[0].AllowFailure {
+			t.Fatalf("step %q lacks strict compiler dependency: %#v", step.Key, step.DependsOn)
+		}
+		for _, dependency := range step.DependsOn[1:] {
+			if !dependency.AllowFailure {
+				t.Fatalf("step %q logical dependency is strict: %#v", step.Key, dependency)
+			}
+		}
+	}
+	if !strings.Contains(string(first), `Consumer ($VALUE, variant=\"two\")`) {
+		t.Fatal("runtime dollar sign or quoted label did not survive scalar encoding")
+	}
+}
+
+func TestEmitRejectsInvalidGraphsAndIdentifiers(t *testing.T) {
+	digest := testDigest("plan")
+	tests := []struct {
+		name string
+		in   Pipeline
+		want string
+	}{
+		{name: "empty", in: Pipeline{CompilerStep: "compiler"}, want: "at least one generated job"},
+		{name: "unknown dependency", in: Pipeline{CompilerStep: "compiler", Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: digest, Dependencies: []string{"missing"}}}}, want: "unknown dependency"},
+		{name: "cycle", in: Pipeline{CompilerStep: "compiler", Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: testDigest("one"), Dependencies: []string{"two"}}, {Key: "two", Label: "Two", Queue: "queue", PlanDigest: testDigest("two"), Dependencies: []string{"one"}}}}, want: "contains a cycle"},
+		{name: "duplicate key", in: Pipeline{CompilerStep: "compiler", Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: testDigest("one")}, {Key: "one", Label: "Other", Queue: "queue", PlanDigest: testDigest("other")}}}, want: "duplicate generated step key"},
+		{name: "duplicate digest", in: Pipeline{CompilerStep: "compiler", Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: digest}, {Key: "two", Label: "Two", Queue: "queue", PlanDigest: digest}}}, want: "share plan digest"},
+		{name: "duplicate dependency", in: Pipeline{CompilerStep: "compiler", Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: testDigest("one")}, {Key: "two", Label: "Two", Queue: "queue", PlanDigest: testDigest("two"), Dependencies: []string{"one", "one"}}}}, want: "repeats dependency"},
+		{name: "self dependency", in: Pipeline{CompilerStep: "compiler", Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: digest, Dependencies: []string{"one"}}}}, want: "invalid dependency"},
+		{name: "compiler dependency", in: Pipeline{CompilerStep: "compiler", Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: digest, Dependencies: []string{"compiler"}}}}, want: "invalid dependency"},
+		{name: "compiler collision", in: Pipeline{CompilerStep: "compiler", Jobs: []Job{{Key: "compiler", Label: "One", Queue: "queue", PlanDigest: digest}}}, want: "invalid generated step key"},
+		{name: "UUID compiler", in: Pipeline{CompilerStep: "123e4567-e89b-12d3-a456-426614174000", Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: digest}}}, want: "invalid compiler step key"},
+		{name: "UUID key", in: Pipeline{CompilerStep: "compiler", Jobs: []Job{{Key: "123e4567-e89b-12d3-a456-426614174000", Label: "One", Queue: "queue", PlanDigest: digest}}}, want: "invalid generated step key"},
+		{name: "bad digest", in: Pipeline{CompilerStep: "compiler", Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: "sha256:nope"}}}, want: "invalid plan digest"},
+		{name: "partial concurrency", in: Pipeline{CompilerStep: "compiler", Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: digest, Concurrency: 2}}}, want: "concurrency and concurrency group together"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Emit(tt.in)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Emit() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
+	source, err := os.ReadFile(filepath.Join("..", "..", ".buildkite", "pipeline.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document struct {
+		Steps []struct {
+			Key     string `yaml:"key"`
+			Command string `yaml:"command"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(source, &document); err != nil {
+		t.Fatalf("parse default pipeline: %v", err)
+	}
+	if len(document.Steps) != 1 || document.Steps[0].Key != "checks" || document.Steps[0].Command != "make check" {
+		t.Fatalf("default pipeline = %#v, want one repository check step", document.Steps)
+	}
+}
+
+func TestPlanPathIsContentAddressed(t *testing.T) {
+	digest := testDigest("plan")
+	path, err := PlanPath(digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path != ".buildkite-gha/plans/64879f7d6b960a01909762d911a32d4582c20010c5641ee90278b644a9e3b525.json" {
+		t.Fatalf("PlanPath() = %q", path)
+	}
+}
+
+func testDigest(contents string) string {
+	return transport.Digest([]byte(contents))
+}

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -122,7 +122,9 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 	if err := yaml.Unmarshal(source, &document); err != nil {
 		t.Fatalf("parse default pipeline: %v", err)
 	}
-	if len(document.Steps) != 1 || document.Steps[0].Key != "checks" || document.Steps[0].Command != "make check" {
+	if len(document.Steps) != 1 || document.Steps[0].Key != "checks" ||
+		!strings.Contains(document.Steps[0].Command, "golang:1.26.5-bookworm@sha256:") ||
+		!strings.Contains(document.Steps[0].Command, "make check") {
 		t.Fatalf("default pipeline = %#v, want one repository check step", document.Steps)
 	}
 }

--- a/internal/buildkite/testdata/pipeline.golden.yml
+++ b/internal/buildkite/testdata/pipeline.golden.yml
@@ -1,0 +1,51 @@
+steps:
+  - label: "Producer"
+    key: "gha-producer"
+    command: "buildkite-gha run-job --plan .buildkite-gha/plans/591e07fdba7d05faf56f9dda91d5eb28d16f324799a667ec3d1e68ae0665292f.json"
+    agents:
+      queue: "gha-linux"
+    checkout:
+      skip: true
+    env:
+      BUILDKITE_GHA_PLAN_DIGEST: "sha256:591e07fdba7d05faf56f9dda91d5eb28d16f324799a667ec3d1e68ae0665292f"
+      BUILDKITE_GHA_PLAN_PATH: ".buildkite-gha/plans/591e07fdba7d05faf56f9dda91d5eb28d16f324799a667ec3d1e68ae0665292f.json"
+      BUILDKITE_GHA_PLAN_PRODUCER: "gha-importer"
+    depends_on:
+      - step: "gha-importer"
+        allow_failure: false
+  - label: "Consumer (variant=one)"
+    key: "gha-consumer-one"
+    command: "buildkite-gha run-job --plan .buildkite-gha/plans/c097b0b78bdbb6d837314048161418606c7f123242fee95967b48998dd6b2a0c.json"
+    agents:
+      queue: "gha-linux"
+    checkout:
+      skip: true
+    env:
+      BUILDKITE_GHA_PLAN_DIGEST: "sha256:c097b0b78bdbb6d837314048161418606c7f123242fee95967b48998dd6b2a0c"
+      BUILDKITE_GHA_PLAN_PATH: ".buildkite-gha/plans/c097b0b78bdbb6d837314048161418606c7f123242fee95967b48998dd6b2a0c.json"
+      BUILDKITE_GHA_PLAN_PRODUCER: "gha-importer"
+    concurrency: 2
+    concurrency_group: "buildkite-gha/shell/consumer"
+    depends_on:
+      - step: "gha-importer"
+        allow_failure: false
+      - step: "gha-producer"
+        allow_failure: true
+  - label: "Consumer ($VALUE, variant=\"two\")"
+    key: "gha-consumer-two"
+    command: "buildkite-gha run-job --plan .buildkite-gha/plans/34fed30c7e0cef60eae62467fdddf2990ac6f6f6fa0145f7eed8fbe9c6e4fdfd.json"
+    agents:
+      queue: "gha-linux"
+    checkout:
+      skip: true
+    env:
+      BUILDKITE_GHA_PLAN_DIGEST: "sha256:34fed30c7e0cef60eae62467fdddf2990ac6f6f6fa0145f7eed8fbe9c6e4fdfd"
+      BUILDKITE_GHA_PLAN_PATH: ".buildkite-gha/plans/34fed30c7e0cef60eae62467fdddf2990ac6f6f6fa0145f7eed8fbe9c6e4fdfd.json"
+      BUILDKITE_GHA_PLAN_PRODUCER: "gha-importer"
+    concurrency: 2
+    concurrency_group: "buildkite-gha/shell/consumer"
+    depends_on:
+      - step: "gha-importer"
+        allow_failure: false
+      - step: "gha-producer"
+        allow_failure: true

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -3,6 +3,7 @@ package cli
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -11,9 +12,11 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/buildkite/buildkite-gha/internal/compatibility"
 	"github.com/buildkite/buildkite-gha/internal/compiler"
 	"github.com/buildkite/buildkite-gha/internal/plan"
 	gharuntime "github.com/buildkite/buildkite-gha/internal/runtime"
+	"github.com/buildkite/buildkite-gha/internal/transport"
 )
 
 const usage = `Usage:
@@ -22,7 +25,7 @@ const usage = `Usage:
 
 Commands:
   validate  Validate the supported static workflow subset
-  compile   Compile a workflow to deterministic JSON IR
+  compile   Compile a workflow to deterministic Buildkite pipeline YAML
   upload    Compile and upload a Buildkite pipeline
   run-job   Run a compiled job plan
 
@@ -30,8 +33,8 @@ Run "buildkite-gha help <command>" for command help.
 `
 
 var commandUsage = map[string]string{
-	"validate": "Usage: buildkite-gha validate [--event-path <path>] <workflow>\n",
-	"compile":  "Usage: buildkite-gha compile --event-path <path> <workflow>\n",
+	"validate": "Usage: buildkite-gha validate [--event-path <path>] [--format text|json] <workflow>\n",
+	"compile":  "Usage: buildkite-gha compile --event-path <path> [--format pipeline|ir-json] <workflow>\n",
 	"upload":   "Usage: buildkite-gha upload <workflow>\n",
 	"run-job":  "Usage: buildkite-gha run-job --plan <path> [--result <path>]\n",
 }
@@ -59,6 +62,9 @@ func Run(args []string, stdout, stderr io.Writer, version string) int {
 		if commandHelp, ok := commandUsage[args[0]]; ok {
 			if len(args) == 2 && (args[1] == "-h" || args[1] == "--help") {
 				fmt.Fprint(stdout, commandHelp)
+				if args[0] == "compile" {
+					fmt.Fprint(stdout, "\nPipeline output references content-addressed plans; compile does not materialize or upload those artifacts.\n")
+				}
 				if args[0] == "upload" {
 					fmt.Fprintf(stdout, "\nThe %s command is not implemented yet.\n", args[0])
 				}
@@ -68,7 +74,7 @@ func Run(args []string, stdout, stderr io.Writer, version string) int {
 			case "validate":
 				return validate(args[1:], stdout, stderr)
 			case "compile":
-				return compile(args[1:], stdout, stderr)
+				return compile(args[1:], stdout, stderr, version)
 			case "run-job":
 				return runJob(args[1:], stdout, stderr, version)
 			default:
@@ -96,6 +102,9 @@ func help(args []string, stdout, stderr io.Writer) int {
 	}
 
 	fmt.Fprint(stdout, commandHelp)
+	if args[0] == "compile" {
+		fmt.Fprint(stdout, "\nPipeline output references content-addressed plans; compile does not materialize or upload those artifacts.\n")
+	}
 	if args[0] == "upload" {
 		fmt.Fprintf(stdout, "\nThe %s command is not implemented yet.\n", args[0])
 	}
@@ -111,6 +120,13 @@ func runJob(args []string, stdout, stderr io.Writer, version string) int {
 	if err != nil {
 		fmt.Fprintf(stderr, "buildkite-gha: run-job: %v\n", err)
 		return 1
+	}
+	if expected := os.Getenv("BUILDKITE_GHA_PLAN_DIGEST"); expected != "" {
+		actual := transport.Digest(source)
+		if actual != expected {
+			fmt.Fprintf(stderr, "buildkite-gha: run-job: plan digest %q does not match expected digest %q\n", actual, expected)
+			return 1
+		}
 	}
 	job, err := plan.Decode(source)
 	if err != nil {
@@ -204,7 +220,7 @@ func verifyBuildkiteTarget(job plan.Job) error {
 }
 
 func validate(args []string, stdout, stderr io.Writer) int {
-	workflowPath, eventPath, err := workflowArgs(args)
+	workflowPath, eventPath, format, err := validateArgs(args)
 	if err != nil {
 		return usageError(stderr, "validate: %v", err)
 	}
@@ -226,15 +242,46 @@ func validate(args []string, stdout, stderr io.Writer) int {
 		report, err = compiler.ValidateEvent(workflowPath, source, event)
 	}
 	if err != nil {
-		fmt.Fprintf(stderr, "buildkite-gha: validate: %v\n", err)
+		if writeErr := compatibility.Write(stdout, format, compatibility.Blocked(workflowPath, err)); writeErr != nil {
+			fmt.Fprintf(stderr, "buildkite-gha: validate: write report: %v\n", writeErr)
+		}
 		return 1
 	}
-	fmt.Fprintf(stdout, "%s: valid for static compilation (%d logical jobs, %d instances); run-job validates the Phase 0 execution subset\n", workflowPath, report.LogicalJobs, report.Instances)
+	if err := compatibility.Write(stdout, format, compatibility.Compilable(workflowPath, report.LogicalJobs, report.Instances)); err != nil {
+		fmt.Fprintf(stderr, "buildkite-gha: validate: write report: %v\n", err)
+		return 1
+	}
 	return 0
 }
 
-func compile(args []string, stdout, stderr io.Writer) int {
-	workflowPath, eventPath, err := workflowArgs(args)
+func validateArgs(args []string) (workflowPath, eventPath, format string, err error) {
+	format = "text"
+	filtered := make([]string, 0, len(args))
+	formatSeen := false
+	for i := 0; i < len(args); i++ {
+		if args[i] != "--format" {
+			filtered = append(filtered, args[i])
+			continue
+		}
+		if formatSeen {
+			return "", "", "", fmt.Errorf("--format may only be specified once")
+		}
+		formatSeen = true
+		i++
+		if i == len(args) {
+			return "", "", "", fmt.Errorf("--format requires text or json")
+		}
+		format = args[i]
+		if format != "text" && format != "json" {
+			return "", "", "", fmt.Errorf("--format must be text or json")
+		}
+	}
+	workflowPath, eventPath, err = workflowArgs(filtered)
+	return workflowPath, eventPath, format, err
+}
+
+func compile(args []string, stdout, stderr io.Writer, version string) int {
+	workflowPath, eventPath, format, err := compileArgs(args)
 	if err != nil {
 		return usageError(stderr, "compile: %v", err)
 	}
@@ -251,7 +298,19 @@ func compile(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "buildkite-gha: compile: %v\n", err)
 		return 1
 	}
-	result, err := compiler.Compile(workflowPath, source, event)
+	var result []byte
+	if format == "ir-json" {
+		result, err = compiler.Compile(workflowPath, source, event)
+	} else {
+		digest, digestErr := executableDigest()
+		if digestErr != nil {
+			fmt.Fprintf(stderr, "buildkite-gha: compile: %v\n", digestErr)
+			return 1
+		}
+		bundle, compileErr := compiler.CompileBundle(workflowPath, source, event, version, digest, "gha-importer")
+		err = compileErr
+		result = bundle.Pipeline
+	}
 	if err != nil {
 		fmt.Fprintf(stderr, "buildkite-gha: compile: %v\n", err)
 		return 1
@@ -261,6 +320,45 @@ func compile(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	return 0
+}
+
+func compileArgs(args []string) (workflowPath, eventPath, format string, err error) {
+	format = "pipeline"
+	filtered := make([]string, 0, len(args))
+	formatSeen := false
+	for i := 0; i < len(args); i++ {
+		if args[i] != "--format" {
+			filtered = append(filtered, args[i])
+			continue
+		}
+		if formatSeen {
+			return "", "", "", fmt.Errorf("--format may only be specified once")
+		}
+		formatSeen = true
+		i++
+		if i == len(args) {
+			return "", "", "", fmt.Errorf("--format requires pipeline or ir-json")
+		}
+		format = args[i]
+		if format != "pipeline" && format != "ir-json" {
+			return "", "", "", fmt.Errorf("--format must be pipeline or ir-json")
+		}
+	}
+	workflowPath, eventPath, err = workflowArgs(filtered)
+	return workflowPath, eventPath, format, err
+}
+
+func executableDigest() (string, error) {
+	path, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("locate compiler executable: %w", err)
+	}
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read compiler executable: %w", err)
+	}
+	sum := sha256.Sum256(contents)
+	return fmt.Sprintf("sha256:%x", sum), nil
 }
 
 func workflowArgs(args []string) (workflowPath, eventPath string, err error) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -10,8 +10,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/buildkite/buildkite-gha/internal/compatibility"
 	"github.com/buildkite/buildkite-gha/internal/compiler"
 	"github.com/buildkite/buildkite-gha/internal/plan"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestRunHelpAndVersion(t *testing.T) {
@@ -70,11 +72,40 @@ func TestRunValidateAndCompile(t *testing.T) {
 		if code := Run([]string{"validate", workflowPath}, &stdout, &stderr, "dev"); code != 0 {
 			t.Fatalf("Run() code = %d, stderr = %q", code, stderr.String())
 		}
-		if want := "2 logical jobs, 3 instances"; !strings.Contains(stdout.String(), want) {
+		if want := "2 logical jobs and 3 static instances"; !strings.Contains(stdout.String(), want) {
 			t.Fatalf("Run() stdout = %q, want %q", stdout.String(), want)
 		}
-		if !strings.Contains(stdout.String(), "run-job validates the Phase 0 execution subset") {
-			t.Fatalf("Run() stdout = %q, want explicit runtime boundary", stdout.String())
+	})
+
+	t.Run("validate json", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		if code := Run([]string{"validate", "--format", "json", workflowPath}, &stdout, &stderr, "dev"); code != 0 {
+			t.Fatalf("Run() code = %d, stderr = %q", code, stderr.String())
+		}
+		var report compatibility.Report
+		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+			t.Fatal(err)
+		}
+		if report.Result != "compilable" || report.Instances != 3 {
+			t.Fatalf("report = %#v", report)
+		}
+	})
+
+	t.Run("validate json blocker", func(t *testing.T) {
+		workflow := filepath.Join(t.TempDir(), "dynamic.yml")
+		if err := os.WriteFile(workflow, []byte("on: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    strategy:\n      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}\n    steps:\n      - run: true\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		var stdout, stderr bytes.Buffer
+		if code := Run([]string{"validate", "--format", "json", workflow}, &stdout, &stderr, "dev"); code != 1 {
+			t.Fatalf("Run() code = %d, want 1; stderr = %q", code, stderr.String())
+		}
+		var report compatibility.Report
+		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+			t.Fatal(err)
+		}
+		if report.Result != "incompatible" || len(report.Diagnostics) != 1 || report.Diagnostics[0].Code != "E_COMPILE" {
+			t.Fatalf("report = %#v", report)
 		}
 	})
 
@@ -84,15 +115,28 @@ func TestRunValidateAndCompile(t *testing.T) {
 		if code := Run(args, &stdout, &stderr, "dev"); code != 0 {
 			t.Fatalf("Run() code = %d, stderr = %q", code, stderr.String())
 		}
+		var pipeline struct {
+			Steps []struct {
+				Key string `yaml:"key"`
+			} `yaml:"steps"`
+		}
+		if err := yaml.Unmarshal(stdout.Bytes(), &pipeline); err != nil {
+			t.Fatalf("compile output is not pipeline YAML: %v", err)
+		}
+		if len(pipeline.Steps) != 3 {
+			t.Fatalf("compiled steps = %d, want 3", len(pipeline.Steps))
+		}
+	})
+
+	t.Run("compile ir json", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		args := []string{"compile", "--format", "ir-json", workflowPath, "--event-path", eventPath}
+		if code := Run(args, &stdout, &stderr, "dev"); code != 0 {
+			t.Fatalf("Run() code = %d, stderr = %q", code, stderr.String())
+		}
 		var ir compiler.IR
-		if err := json.Unmarshal(stdout.Bytes(), &ir); err != nil {
-			t.Fatalf("compile output is not JSON: %v", err)
-		}
-		if len(ir.Jobs) != 3 {
-			t.Fatalf("compiled jobs = %d, want 3", len(ir.Jobs))
-		}
-		if !ir.Execution.Supported || ir.Execution.Reason == "" {
-			t.Fatalf("compile output execution boundary = %#v, want supported Phase 0 boundary", ir.Execution)
+		if err := json.Unmarshal(stdout.Bytes(), &ir); err != nil || len(ir.Jobs) != 3 {
+			t.Fatalf("compile IR = %#v, error = %v", ir, err)
 		}
 	})
 }
@@ -150,6 +194,8 @@ func TestRunJobExecutesBoundPlanAndWritesResult(t *testing.T) {
 	if err := os.WriteFile(planPath, encoded, 0o600); err != nil {
 		t.Fatal(err)
 	}
+	planDigest := sha256.Sum256(encoded)
+	t.Setenv("BUILDKITE_GHA_PLAN_DIGEST", "sha256:"+hex.EncodeToString(planDigest[:]))
 	oldDirectory, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)
@@ -170,6 +216,12 @@ func TestRunJobExecutesBoundPlanAndWritesResult(t *testing.T) {
 	if !strings.Contains(string(result), `"result": "cli-ok"`) {
 		t.Fatalf("result = %s", result)
 	}
+	stdout.Reset()
+	stderr.Reset()
+	t.Setenv("BUILDKITE_GHA_PLAN_DIGEST", "sha256:"+strings.Repeat("0", 64))
+	if code := Run([]string{"run-job", "--plan", planPath}, &stdout, &stderr, "dev"); code != 1 || !strings.Contains(stderr.String(), "does not match expected digest") {
+		t.Fatalf("Run() code = %d, stderr = %q, want digest mismatch", code, stderr.String())
+	}
 	job.Compiler.Version = "0.0.0-other"
 	encoded, err = plan.Encode(job)
 	if err != nil {
@@ -178,6 +230,8 @@ func TestRunJobExecutesBoundPlanAndWritesResult(t *testing.T) {
 	if err := os.WriteFile(planPath, encoded, 0o600); err != nil {
 		t.Fatal(err)
 	}
+	planDigest = sha256.Sum256(encoded)
+	t.Setenv("BUILDKITE_GHA_PLAN_DIGEST", "sha256:"+hex.EncodeToString(planDigest[:]))
 	stdout.Reset()
 	stderr.Reset()
 	if code := Run([]string{"run-job", "--plan", planPath}, &stdout, &stderr, "dev"); code != 1 || !strings.Contains(stderr.String(), "does not match runtime version") {
@@ -205,6 +259,12 @@ func TestArgumentParsersRejectRepeatedOptions(t *testing.T) {
 	}
 	if _, _, err := workflowArgs([]string{"--event-path", "one", "--event-path", "two", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
 		t.Fatalf("workflowArgs() error = %v, want duplicate option error", err)
+	}
+	if _, _, _, err := validateArgs([]string{"--format", "json", "--format", "text", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
+		t.Fatalf("validateArgs() error = %v, want duplicate format error", err)
+	}
+	if _, _, _, err := compileArgs([]string{"--format", "pipeline", "--format", "ir-json", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
+		t.Fatalf("compileArgs() error = %v, want duplicate format error", err)
 	}
 }
 

--- a/internal/compatibility/report.go
+++ b/internal/compatibility/report.go
@@ -1,0 +1,71 @@
+// Package compatibility renders stable human and machine-readable validation reports.
+package compatibility
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+const Schema = "buildkite-gha/compatibility-report/v1"
+
+// Diagnostic is one actionable compatibility finding.
+type Diagnostic struct {
+	Level   string `json:"level"`
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// Report describes whether a workflow can enter the static compiler.
+type Report struct {
+	Schema      string       `json:"schema"`
+	Workflow    string       `json:"workflow"`
+	Result      string       `json:"result"`
+	LogicalJobs int          `json:"logical_jobs"`
+	Instances   int          `json:"instances"`
+	Diagnostics []Diagnostic `json:"diagnostics"`
+}
+
+// Compilable constructs a successful compile-level report.
+func Compilable(workflow string, logicalJobs, instances int) Report {
+	return Report{
+		Schema: Schema, Workflow: workflow, Result: "compilable",
+		LogicalJobs: logicalJobs, Instances: instances, Diagnostics: []Diagnostic{},
+	}
+}
+
+// Blocked constructs a failed compile-level report without exposing input data beyond the diagnostic.
+func Blocked(workflow string, err error) Report {
+	return Report{
+		Schema: Schema, Workflow: workflow, Result: "incompatible", Diagnostics: []Diagnostic{{
+			Level: "error", Code: "E_COMPILE", Message: err.Error(),
+		}},
+	}
+}
+
+// Write renders a report as text or deterministic indented JSON.
+func Write(w io.Writer, format string, report Report) error {
+	switch format {
+	case "text":
+		if _, err := fmt.Fprintf(w, "Workflow: %s\nResult: %s\n", report.Workflow, report.Result); err != nil {
+			return err
+		}
+		if report.Result == "compilable" {
+			_, err := fmt.Fprintf(w, "✓ %d logical jobs and %d static instances compile\n", report.LogicalJobs, report.Instances)
+			return err
+		}
+		for _, diagnostic := range report.Diagnostics {
+			if _, err := fmt.Fprintf(w, "✗ [%s] %s\n", diagnostic.Code, diagnostic.Message); err != nil {
+				return err
+			}
+		}
+		return nil
+	case "json":
+		encoder := json.NewEncoder(w)
+		encoder.SetEscapeHTML(false)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(report)
+	default:
+		return fmt.Errorf("unsupported compatibility report format %q", format)
+	}
+}

--- a/internal/compatibility/report_test.go
+++ b/internal/compatibility/report_test.go
@@ -1,0 +1,44 @@
+package compatibility
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestWriteReports(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		format string
+		report Report
+		want   string
+	}{
+		{name: "text success", format: "text", report: Compilable("ci.yml", 2, 3), want: "✓ 2 logical jobs and 3 static instances compile"},
+		{name: "text failure", format: "text", report: Blocked("ci.yml", errors.New("unsupported operating system")), want: "[E_COMPILE] unsupported operating system"},
+		{name: "json", format: "json", report: Compilable("ci.yml", 2, 3), want: `"schema": "buildkite-gha/compatibility-report/v1"`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var output bytes.Buffer
+			if err := Write(&output, test.format, test.report); err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(output.String(), test.want) {
+				t.Fatalf("output = %q, want %q", output.String(), test.want)
+			}
+			if test.format == "json" {
+				var decoded Report
+				if err := json.Unmarshal(output.Bytes(), &decoded); err != nil {
+					t.Fatalf("invalid JSON report: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestWriteRejectsUnknownFormat(t *testing.T) {
+	if err := Write(&bytes.Buffer{}, "yaml", Compilable("ci.yml", 1, 1)); err == nil {
+		t.Fatal("Write() accepted unknown format")
+	}
+}

--- a/internal/compiler/bundle.go
+++ b/internal/compiler/bundle.go
@@ -1,0 +1,87 @@
+package compiler
+
+import (
+	"fmt"
+	"strings"
+
+	buildkitepipeline "github.com/buildkite/buildkite-gha/internal/buildkite"
+	"github.com/buildkite/buildkite-gha/internal/plan"
+	"github.com/buildkite/buildkite-gha/internal/transport"
+)
+
+// PlanArtifact is one immutable encoded job plan and its content-addressed path.
+type PlanArtifact struct {
+	Job      plan.Job
+	Digest   string
+	Path     string
+	Contents []byte
+}
+
+// Bundle is the complete deterministic output of static compilation.
+type Bundle struct {
+	IR       IR
+	Plans    []PlanArtifact
+	Pipeline []byte
+}
+
+// CompileBundle compiles an unattested event snapshot with the fail-closed
+// default runner policy.
+func CompileBundle(path string, source, eventSource []byte, compilerVersion, compilerDistributionDigest, compilerStep string) (Bundle, error) {
+	return CompileBundleWithOptions(path, source, eventSource, compilerVersion, compilerDistributionDigest, compilerStep, defaultOptions())
+}
+
+// CompileBundleWithOptions produces versioned plans and the Buildkite pipeline
+// that schedules their exact static dependency graph.
+func CompileBundleWithOptions(path string, source, eventSource []byte, compilerVersion, compilerDistributionDigest, compilerStep string, options Options) (Bundle, error) {
+	if compilerVersion == "" {
+		return Bundle{}, fmt.Errorf("compiler version is required")
+	}
+	if !strings.HasPrefix(compilerDistributionDigest, "sha256:") {
+		return Bundle{}, fmt.Errorf("compiler distribution digest is required")
+	}
+	ir, err := compile(path, source, eventSource, options)
+	if err != nil {
+		return Bundle{}, err
+	}
+	plans, err := compilePlans(ir, compilerVersion, compilerDistributionDigest)
+	if err != nil {
+		return Bundle{}, err
+	}
+	if len(plans) != len(ir.Jobs) {
+		return Bundle{}, fmt.Errorf("compiler produced %d plans for %d job instances", len(plans), len(ir.Jobs))
+	}
+
+	artifacts := make([]PlanArtifact, len(plans))
+	jobs := make([]buildkitepipeline.Job, len(plans))
+	for i, job := range plans {
+		if job.Target.StepKey != ir.Jobs[i].Key || job.Target.Queue != ir.Jobs[i].Queue {
+			return Bundle{}, fmt.Errorf("plan %d target %q/%q does not match job instance %q/%q", i, job.Target.StepKey, job.Target.Queue, ir.Jobs[i].Key, ir.Jobs[i].Queue)
+		}
+		contents, err := plan.Encode(job)
+		if err != nil {
+			return Bundle{}, fmt.Errorf("encode plan for job %q: %w", job.Workflow.LogicalJobID, err)
+		}
+		digest := transport.Digest(contents)
+		planPath, err := buildkitepipeline.PlanPath(digest)
+		if err != nil {
+			return Bundle{}, fmt.Errorf("locate plan for job %q: %w", job.Workflow.LogicalJobID, err)
+		}
+		artifacts[i] = PlanArtifact{Job: job, Digest: digest, Path: planPath, Contents: contents}
+		jobs[i] = buildkitepipeline.Job{
+			Key:          ir.Jobs[i].Key,
+			Label:        ir.Jobs[i].Label,
+			Queue:        ir.Jobs[i].Queue,
+			PlanDigest:   digest,
+			Dependencies: append([]string(nil), ir.Jobs[i].Needs...),
+		}
+		if ir.Jobs[i].MaxParallel != nil {
+			jobs[i].Concurrency = *ir.Jobs[i].MaxParallel
+			jobs[i].ConcurrencyGroup = "buildkite-gha/" + strings.TrimPrefix(ir.Workflow.Digest, "sha256:") + "/" + ir.Jobs[i].LogicalJobID
+		}
+	}
+	pipeline, err := buildkitepipeline.Emit(buildkitepipeline.Pipeline{CompilerStep: compilerStep, Jobs: jobs})
+	if err != nil {
+		return Bundle{}, fmt.Errorf("emit Buildkite pipeline: %w", err)
+	}
+	return Bundle{IR: ir, Plans: artifacts, Pipeline: pipeline}, nil
+}

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -1,0 +1,118 @@
+package compiler
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"go.yaml.in/yaml/v4"
+)
+
+const testDistributionDigest = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+
+func TestCompileBundleGoldenAndDeterministic(t *testing.T) {
+	path := smokePath(".github", "workflows", "shell.yml")
+	source := readFile(t, path)
+	event := readFile(t, smokePath("events", "push.json"))
+	first, err := CompileBundle(path, source, event, "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := CompileBundle(path, source, event, "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Fatal("repeated bundle compilation was not byte-identical")
+	}
+	if len(first.Plans) != 3 || len(first.IR.Jobs) != 3 {
+		t.Fatalf("bundle jobs/plans = %d/%d, want 3/3", len(first.IR.Jobs), len(first.Plans))
+	}
+	producer := first.IR.Jobs[0].Key
+	for i, artifact := range first.Plans {
+		if artifact.Path != ".buildkite-gha/plans/"+strings.TrimPrefix(artifact.Digest, "sha256:")+".json" {
+			t.Fatalf("plan %d path = %q", i, artifact.Path)
+		}
+		if i == 0 && len(artifact.Job.Dependencies) != 0 {
+			t.Fatalf("producer dependencies = %#v", artifact.Job.Dependencies)
+		}
+		if i > 0 && !reflect.DeepEqual(artifact.Job.Dependencies, []string{producer}) {
+			t.Fatalf("consumer dependencies = %#v, want %q", artifact.Job.Dependencies, producer)
+		}
+	}
+	wantPipeline := readFile(t, filepath.Join("testdata", "shell.pipeline.golden.yml"))
+	if !bytes.Equal(first.Pipeline, wantPipeline) {
+		t.Fatalf("pipeline changed\nwant:\n%s\ngot:\n%s", wantPipeline, first.Pipeline)
+	}
+	wantPlans := readFile(t, filepath.Join("testdata", "shell.plans.golden.json"))
+	if !bytes.Equal(encodeGoldenPlans(t, first.Plans), wantPlans) {
+		t.Fatalf("plans changed; update shell.plans.golden.json intentionally")
+	}
+}
+
+func TestCompileBundleCompilesSmokeCorpus(t *testing.T) {
+	workflows, err := filepath.Glob(smokePath(".github", "workflows", "*.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(workflows) != 3 {
+		t.Fatalf("smoke workflows = %d, want 3", len(workflows))
+	}
+	event := readFile(t, smokePath("events", "push.json"))
+	for _, path := range workflows {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			bundle, err := CompileBundle(path, readFile(t, path), event, "0.0.0-test", testDistributionDigest, "gha-importer")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(bundle.Plans) == 0 || len(bundle.Pipeline) == 0 {
+				t.Fatalf("empty bundle: %#v", bundle)
+			}
+			var document map[string]any
+			if err := yaml.Unmarshal(bundle.Pipeline, &document); err != nil {
+				t.Fatalf("pipeline YAML: %v", err)
+			}
+		})
+	}
+}
+
+func TestCompileBundleDoesNotExposeEventValues(t *testing.T) {
+	path := smokePath(".github", "workflows", "shell.yml")
+	var event map[string]any
+	if err := json.Unmarshal(readFile(t, smokePath("events", "push.json")), &event); err != nil {
+		t.Fatal(err)
+	}
+	event["payload"].(map[string]any)["private_fixture_value"] = "super-secret-value"
+	eventSource, err := json.Marshal(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle, err := CompileBundle(path, readFile(t, path), eventSource, "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(bundle.Pipeline, []byte("super-secret-value")) {
+		t.Fatal("pipeline contains an event payload value")
+	}
+	for _, artifact := range bundle.Plans {
+		if bytes.Contains(artifact.Contents, []byte("super-secret-value")) {
+			t.Fatalf("plan %q contains an event payload value", artifact.Job.Target.StepKey)
+		}
+	}
+}
+
+func encodeGoldenPlans(t *testing.T, artifacts []PlanArtifact) []byte {
+	t.Helper()
+	plans := make([]json.RawMessage, len(artifacts))
+	for i, artifact := range artifacts {
+		plans[i] = json.RawMessage(bytes.TrimSpace(artifact.Contents))
+	}
+	encoded, err := json.MarshalIndent(plans, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return append(encoded, '\n')
+}

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -87,6 +87,8 @@ type JobInstance struct {
 	DefaultShell            string            `json:"default_shell,omitempty"`
 	DefaultWorkingDirectory string            `json:"default_working_directory,omitempty"`
 	Outputs                 map[string]string `json:"outputs,omitempty"`
+	SourcePath              string            `json:"source_path"`
+	SourceDigest            string            `json:"source_digest"`
 	Source                  workflow.Span     `json:"source"`
 }
 
@@ -105,7 +107,7 @@ func Validate(path string, source []byte) (Report, error) {
 	}
 	options := defaultOptions()
 	event := Event{Trust: options.EventTrust, Payload: map[string]any{}}
-	instances, err := expand(path, parsed, compileContext(event, nil), options)
+	instances, err := expand(path, source, parsed, compileContext(event, nil), options)
 	if err != nil {
 		return Report{}, err
 	}
@@ -132,7 +134,7 @@ func ValidateEventWithOptions(path string, source, eventSource []byte, options O
 		return Report{}, err
 	}
 	event.Trust = options.EventTrust
-	instances, err := expand(path, parsed, compileContext(event, options.Vars.snapshot()), options)
+	instances, err := expand(path, source, parsed, compileContext(event, options.Vars.snapshot()), options)
 	if err != nil {
 		return Report{}, err
 	}
@@ -232,8 +234,8 @@ func CompilePlansWithOptions(path string, source, eventSource []byte, compilerVe
 				Version: compilerVersion, DistributionDigest: compilerDistributionDigest,
 			},
 			Workflow: plan.Workflow{
-				Path:         ir.Workflow.Path,
-				Digest:       ir.Workflow.Digest,
+				Path:         instance.SourcePath,
+				Digest:       instance.SourceDigest,
 				LogicalJobID: instance.LogicalJobID,
 			},
 			Event: plan.Event{
@@ -278,7 +280,7 @@ func compile(path string, source, eventSource []byte, options Options) (IR, erro
 	}
 	event.Trust = options.EventTrust
 	vars := options.Vars.snapshot()
-	jobs, err := expand(path, parsed, compileContext(event, vars), options)
+	jobs, err := expand(path, source, parsed, compileContext(event, vars), options)
 	if err != nil {
 		return IR{}, err
 	}
@@ -350,11 +352,23 @@ func compileContext(event Event, vars map[string]string) expression.CompileConte
 	}
 }
 
-func expand(path string, parsed *workflow.Workflow, context expression.CompileContext, options Options) ([]JobInstance, error) {
-	jobs := make(map[string]workflow.Job, len(parsed.Jobs))
-	for _, job := range parsed.Jobs {
+func expand(path string, source []byte, parsed *workflow.Workflow, context expression.CompileContext, options Options) ([]JobInstance, error) {
+	resolved, err := resolveReusableWorkflows(path, source, parsed)
+	if err != nil {
+		return nil, err
+	}
+	jobs := make(map[string]workflow.Job, len(resolved))
+	sourcePaths := make(map[string]string, len(resolved))
+	sourceDigests := make(map[string]string, len(resolved))
+	for _, sourced := range resolved {
+		job := sourced.Job
+		if _, exists := jobs[job.ID]; exists {
+			return nil, jobError(sourced.path, job, fmt.Sprintf("flattened job id %q collides with another job", job.ID))
+		}
 		jobs[job.ID] = job
-		if err := supported(path, job); err != nil {
+		sourcePaths[job.ID] = sourced.path
+		sourceDigests[job.ID] = sourced.digest
+		if err := supported(sourced.path, job); err != nil {
 			return nil, err
 		}
 	}
@@ -367,25 +381,26 @@ func expand(path string, parsed *workflow.Workflow, context expression.CompileCo
 	instanceKeys := make(map[string]string)
 	for _, id := range order {
 		job := jobs[id]
-		matrices, err := expandMatrix(path, job, context)
+		jobPath := sourcePaths[id]
+		matrices, err := expandMatrix(jobPath, job, context)
 		if err != nil {
 			return nil, err
 		}
 		for _, matrix := range matrices {
 			labels, err := resolveRunsOn(job, context, matrix)
 			if err != nil {
-				return nil, locatedJobError(path, job, runsOnPosition(job).Line, runsOnPosition(job).Column, err.Error())
+				return nil, locatedJobError(jobPath, job, runsOnPosition(job).Line, runsOnPosition(job).Column, err.Error())
 			}
 			queue, err := options.Runners.resolve(labels, options.EventTrust)
 			if err != nil {
-				return nil, locatedJobError(path, job, runsOnPosition(job).Line, runsOnPosition(job).Column, err.Error())
+				return nil, locatedJobError(jobPath, job, runsOnPosition(job).Line, runsOnPosition(job).Column, err.Error())
 			}
 			key, err := instanceKey(job.ID, matrix)
 			if err != nil {
-				return nil, jobError(path, job, fmt.Sprintf("create deterministic instance key: %v", err))
+				return nil, jobError(jobPath, job, fmt.Sprintf("create deterministic instance key: %v", err))
 			}
 			if existingJob, exists := instanceKeys[key]; exists {
-				return nil, jobError(path, job, fmt.Sprintf("deterministic instance key %q collides with another instance from job %q", key, existingJob))
+				return nil, jobError(jobPath, job, fmt.Sprintf("deterministic instance key %q collides with another instance from job %q", key, existingJob))
 			}
 			instanceKeys[key] = job.ID
 			instance := JobInstance{
@@ -403,6 +418,8 @@ func expand(path string, parsed *workflow.Workflow, context expression.CompileCo
 				DefaultShell:            job.DefaultShell,
 				DefaultWorkingDirectory: job.DefaultWorkingDirectory,
 				Outputs:                 cloneMap(job.Outputs),
+				SourcePath:              jobPath,
+				SourceDigest:            sourceDigests[id],
 				Source:                  job.Span,
 			}
 			for _, need := range job.Needs {
@@ -423,8 +440,8 @@ func expand(path string, parsed *workflow.Workflow, context expression.CompileCo
 }
 
 func supported(path string, job workflow.Job) error {
-	if job.Reusable {
-		return jobError(path, job, "reusable-workflow jobs are unsupported in the Phase 0 compiler")
+	if job.Reusable != nil {
+		return jobError(path, job, "internal error: unresolved reusable-workflow job")
 	}
 	if len(job.RunsOn) == 0 && job.RunsOnExpr == nil {
 		return jobError(path, job, "runs-on must resolve statically")

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -89,6 +89,7 @@ type JobInstance struct {
 	Outputs                 map[string]string `json:"outputs,omitempty"`
 	SourcePath              string            `json:"source_path"`
 	SourceDigest            string            `json:"source_digest"`
+	RepositoryRoot          string            `json:"-"`
 	Source                  workflow.Span     `json:"source"`
 }
 
@@ -186,11 +187,10 @@ func CompilePlansWithOptions(path string, source, eventSource []byte, compilerVe
 	if err != nil {
 		return nil, err
 	}
-	for _, instance := range ir.Jobs {
-		if len(instance.LogicalNeeds) != 0 {
-			return nil, fmt.Errorf("build plan for job %q: jobs with needs are unsupported until producer result manifests can be injected at runtime", instance.LogicalJobID)
-		}
-	}
+	return compilePlans(ir, compilerVersion, compilerDistributionDigest)
+}
+
+func compilePlans(ir IR, compilerVersion, compilerDistributionDigest string) ([]plan.Job, error) {
 	payload, err := json.Marshal(ir.Event.Payload)
 	if err != nil {
 		return nil, fmt.Errorf("encode event payload: %w", err)
@@ -224,7 +224,7 @@ func CompilePlansWithOptions(path string, source, eventSource []byte, compilerVe
 				Env: cloneMap(step.Env), With: cloneMap(step.With), Source: &span,
 			}
 		}
-		capabilities, err := requiredCapabilities(path, instance.Steps)
+		capabilities, err := requiredCapabilities(instance.RepositoryRoot, instance.SourcePath, instance.Steps)
 		if err != nil {
 			return nil, fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err)
 		}
@@ -245,6 +245,7 @@ func CompilePlansWithOptions(path string, source, eventSource []byte, compilerVe
 			RequiredCapabilities:    capabilities,
 			Matrix:                  instance.Matrix,
 			Vars:                    cloneMap(ir.Vars),
+			Dependencies:            append([]string(nil), instance.Needs...),
 			Env:                     instance.Env,
 			DefaultShell:            instance.DefaultShell,
 			DefaultWorkingDirectory: instance.DefaultWorkingDirectory,
@@ -360,6 +361,7 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 	jobs := make(map[string]workflow.Job, len(resolved))
 	sourcePaths := make(map[string]string, len(resolved))
 	sourceDigests := make(map[string]string, len(resolved))
+	sourceRoots := make(map[string]string, len(resolved))
 	for _, sourced := range resolved {
 		job := sourced.Job
 		if _, exists := jobs[job.ID]; exists {
@@ -368,6 +370,7 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 		jobs[job.ID] = job
 		sourcePaths[job.ID] = sourced.path
 		sourceDigests[job.ID] = sourced.digest
+		sourceRoots[job.ID] = sourced.root
 		if err := supported(sourced.path, job); err != nil {
 			return nil, err
 		}
@@ -420,6 +423,7 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 				Outputs:                 cloneMap(job.Outputs),
 				SourcePath:              jobPath,
 				SourceDigest:            sourceDigests[id],
+				RepositoryRoot:          sourceRoots[id],
 				Source:                  job.Span,
 			}
 			for _, need := range job.Needs {
@@ -865,13 +869,16 @@ func instanceKey(jobID string, matrix map[string]any) (string, error) {
 	return prefix + "-" + hex.EncodeToString(digest[:6]), nil
 }
 
-func requiredCapabilities(workflowPath string, steps []workflow.Step) ([]string, error) {
+func requiredCapabilities(repositoryRoot, workflowPath string, steps []workflow.Step) ([]string, error) {
 	capabilities := map[string]struct{}{}
 	for _, step := range steps {
 		if step.Kind != "uses" || !strings.HasPrefix(step.Uses, "./") {
 			continue
 		}
-		action, err := loadLocalAction(workflowPath, step.Uses)
+		if repositoryRoot == "" {
+			return nil, fmt.Errorf("resolve local action %q: workflow path %q must identify a repository root", step.Uses, workflowPath)
+		}
+		action, err := loadLocalAction(repositoryRoot, step.Uses)
 		if err != nil {
 			return nil, err
 		}
@@ -891,12 +898,7 @@ func requiredCapabilities(workflowPath string, steps []workflow.Step) ([]string,
 	return out, nil
 }
 
-func loadLocalAction(workflowPath, uses string) (metadata.Metadata, error) {
-	workflowDir := filepath.Dir(filepath.Clean(workflowPath))
-	if filepath.Base(workflowDir) != "workflows" || filepath.Base(filepath.Dir(workflowDir)) != ".github" {
-		return metadata.Metadata{}, fmt.Errorf("resolve local action %q: workflow path must be under .github/workflows", uses)
-	}
-	repositoryRoot := filepath.Dir(filepath.Dir(workflowDir))
+func loadLocalAction(repositoryRoot, uses string) (metadata.Metadata, error) {
 	relativeActionPath := filepath.Clean(filepath.FromSlash(strings.TrimPrefix(uses, "./")))
 	return metadata.Load(repositoryRoot, relativeActionPath)
 }

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 	"unicode"
@@ -372,9 +373,6 @@ func supported(path string, job workflow.Job) error {
 	if job.Matrix.Expression != nil {
 		return locatedJobError(path, job, job.Matrix.Expression.Span.Start.Line, job.Matrix.Expression.Span.Start.Column, "runtime-dependent matrix expressions are unsupported")
 	}
-	if job.Matrix.HasInclude || job.Matrix.HasExclude {
-		return locatedJobError(path, job, job.Matrix.Span.Start.Line, job.Matrix.Span.Start.Column, "matrix include/exclude are unsupported in the Phase 0 compiler")
-	}
 	for _, row := range job.Matrix.Rows {
 		if row.Expression != nil {
 			return locatedJobError(path, job, row.Expression.Span.Start.Line, row.Expression.Span.Start.Column, fmt.Sprintf("runtime-dependent matrix expression for %q is unsupported", row.Name))
@@ -399,6 +397,9 @@ func expandMatrix(path string, job workflow.Job) ([]map[string]any, error) {
 		return []map[string]any{nil}, nil
 	}
 	matrices := []map[string]any{{}}
+	if len(job.Matrix.Rows) == 0 {
+		matrices = nil
+	}
 	for _, row := range job.Matrix.Rows {
 		if len(row.Values) == 0 {
 			return nil, jobError(path, job, fmt.Sprintf("matrix dimension %q has no values", row.Name))
@@ -419,7 +420,97 @@ func expandMatrix(path string, job workflow.Job) ([]map[string]any, error) {
 		}
 		matrices = next
 	}
+
+	matrices = excludeMatrixCombinations(matrices, job.Matrix.Exclude)
+	// Includes may overwrite values added by earlier includes, but not original
+	// dimensions. Standalone combinations are never candidates for later entries.
+	type includedMatrix struct {
+		values   map[string]any
+		original map[string]any
+	}
+	included := make([]includedMatrix, len(matrices))
+	for i, matrix := range matrices {
+		included[i] = includedMatrix{values: matrix, original: cloneAnyMap(matrix)}
+	}
+	for _, combination := range job.Matrix.Include {
+		values := matrixCombinationValues(combination)
+		matched := false
+		for i := range included {
+			if included[i].original == nil || !includeCompatible(included[i].original, values) {
+				continue
+			}
+			for key, value := range values {
+				included[i].values[key] = value
+			}
+			matched = true
+		}
+		if !matched {
+			included = append(included, includedMatrix{values: cloneAnyMap(values)})
+		}
+		if len(included) > maxMatrixInstances {
+			return nil, jobError(path, job, fmt.Sprintf("matrix expands beyond %d instances", maxMatrixInstances))
+		}
+	}
+	matrices = matrices[:0]
+	for _, matrix := range included {
+		matrices = append(matrices, matrix.values)
+	}
 	return matrices, nil
+}
+
+func excludeMatrixCombinations(matrices []map[string]any, exclusions []workflow.MatrixCombination) []map[string]any {
+	if len(exclusions) == 0 {
+		return matrices
+	}
+	out := matrices[:0]
+	for _, matrix := range matrices {
+		excluded := false
+		for _, exclusion := range exclusions {
+			if matrixMatches(matrix, matrixCombinationValues(exclusion)) {
+				excluded = true
+				break
+			}
+		}
+		if !excluded {
+			out = append(out, matrix)
+		}
+	}
+	return out
+}
+
+func matrixMatches(matrix, pattern map[string]any) bool {
+	for key, expected := range pattern {
+		actual, ok := matrix[key]
+		if !ok || !reflect.DeepEqual(actual, expected) {
+			return false
+		}
+	}
+	return true
+}
+
+func includeCompatible(original, values map[string]any) bool {
+	for key, value := range values {
+		if originalValue, exists := original[key]; exists && !reflect.DeepEqual(originalValue, value) {
+			return false
+		}
+	}
+	return true
+}
+
+func matrixCombinationValues(combination workflow.MatrixCombination) map[string]any {
+	out := make(map[string]any, len(combination.Values))
+	for key, value := range combination.Values {
+		out[key] = value.Data
+	}
+	return out
+}
+
+func cloneAnyMap(in map[string]any) map[string]any {
+	out := make(map[string]any, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
 }
 
 func topologicalOrder(path string, jobs map[string]workflow.Job) ([]string, error) {

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -8,13 +8,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/big"
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"unicode"
 
 	"github.com/buildkite/buildkite-gha/internal/action/metadata"
+	"github.com/buildkite/buildkite-gha/internal/expression"
 	"github.com/buildkite/buildkite-gha/internal/plan"
 	"github.com/buildkite/buildkite-gha/internal/workflow"
 )
@@ -28,6 +31,7 @@ const (
 type Event struct {
 	Provider   string         `json:"provider"`
 	Event      string         `json:"event"`
+	Trust      EventTrust     `json:"trust"`
 	Repository Repository     `json:"repository"`
 	Ref        string         `json:"ref"`
 	SHA        string         `json:"sha"`
@@ -48,6 +52,7 @@ type IR struct {
 	Schema    string            `json:"schema"`
 	Workflow  WorkflowSource    `json:"workflow"`
 	Event     Event             `json:"event"`
+	Vars      map[string]string `json:"vars,omitempty"`
 	Execution ExecutionBoundary `json:"execution"`
 	Jobs      []JobInstance     `json:"jobs"`
 }
@@ -73,6 +78,7 @@ type JobInstance struct {
 	Needs                   []string          `json:"needs,omitempty"`
 	LogicalNeeds            []string          `json:"logical_needs,omitempty"`
 	RunsOn                  []string          `json:"runs_on"`
+	Queue                   string            `json:"queue"`
 	Matrix                  map[string]any    `json:"matrix,omitempty"`
 	FailFast                *bool             `json:"fail_fast,omitempty"`
 	MaxParallel             *int              `json:"max_parallel,omitempty"`
@@ -97,7 +103,9 @@ func Validate(path string, source []byte) (Report, error) {
 	if err != nil {
 		return Report{}, err
 	}
-	instances, err := expand(path, parsed)
+	options := defaultOptions()
+	event := Event{Trust: options.EventTrust, Payload: map[string]any{}}
+	instances, err := expand(path, parsed, compileContext(event, nil), options)
 	if err != nil {
 		return Report{}, err
 	}
@@ -106,16 +114,41 @@ func Validate(path string, source []byte) (Report, error) {
 
 // ValidateEvent validates both the supported static graph and its event input.
 func ValidateEvent(path string, source, eventSource []byte) (Report, error) {
-	if _, err := parseEvent(eventSource); err != nil {
+	return ValidateEventWithOptions(path, source, eventSource, defaultOptions())
+}
+
+// ValidateEventWithOptions validates the graph against explicit variables and
+// runner policy without producing compiler output.
+func ValidateEventWithOptions(path string, source, eventSource []byte, options Options) (Report, error) {
+	if err := options.validate(); err != nil {
 		return Report{}, err
 	}
-	return Validate(path, source)
+	parsed, err := workflow.Parse(path, source)
+	if err != nil {
+		return Report{}, err
+	}
+	event, err := parseEvent(eventSource)
+	if err != nil {
+		return Report{}, err
+	}
+	event.Trust = options.EventTrust
+	instances, err := expand(path, parsed, compileContext(event, options.Vars.snapshot()), options)
+	if err != nil {
+		return Report{}, err
+	}
+	return Report{LogicalJobs: len(parsed.Jobs), Instances: len(instances)}, nil
 }
 
 // Compile parses a workflow and event, expands its static graph, and returns
 // stable JSON bytes terminated by a newline.
 func Compile(path string, source, eventSource []byte) ([]byte, error) {
-	ir, err := compile(path, source, eventSource)
+	return CompileWithOptions(path, source, eventSource, defaultOptions())
+}
+
+// CompileWithOptions compiles using an explicit non-secret variable snapshot,
+// event trust classification, and runner policy.
+func CompileWithOptions(path string, source, eventSource []byte, options Options) ([]byte, error) {
+	ir, err := compile(path, source, eventSource, options)
 	if err != nil {
 		return nil, err
 	}
@@ -131,16 +164,23 @@ func Compile(path string, source, eventSource []byte) ([]byte, error) {
 
 // CompilePlans connects the owned compiler IR to one versioned plan per job instance.
 func CompilePlans(path string, source, eventSource []byte, compilerVersion, compilerDistributionDigest, targetQueue string) ([]plan.Job, error) {
+	if targetQueue != "gha-untrusted" {
+		return nil, fmt.Errorf("unattested event snapshots may only target queue %q; use CompilePlansWithOptions for authenticated events", "gha-untrusted")
+	}
+	options := defaultOptions()
+	return CompilePlansWithOptions(path, source, eventSource, compilerVersion, compilerDistributionDigest, options)
+}
+
+// CompilePlansWithOptions creates one plan per job using compiler-selected
+// queues and the same snapshotted vars used for graph construction.
+func CompilePlansWithOptions(path string, source, eventSource []byte, compilerVersion, compilerDistributionDigest string, options Options) ([]plan.Job, error) {
 	if compilerVersion == "" {
 		return nil, fmt.Errorf("compiler version is required")
-	}
-	if targetQueue == "" {
-		return nil, fmt.Errorf("target queue is required")
 	}
 	if !strings.HasPrefix(compilerDistributionDigest, "sha256:") {
 		return nil, fmt.Errorf("compiler distribution digest is required")
 	}
-	ir, err := compile(path, source, eventSource)
+	ir, err := compile(path, source, eventSource, options)
 	if err != nil {
 		return nil, err
 	}
@@ -199,9 +239,10 @@ func CompilePlans(path string, source, eventSource []byte, compilerVersion, comp
 			Event: plan.Event{
 				Provider: ir.Event.Provider, Name: ir.Event.Event, PayloadDigest: "sha256:" + hex.EncodeToString(eventDigest[:]),
 			},
-			Target:                  plan.Target{StepKey: instance.Key, Queue: targetQueue},
+			Target:                  plan.Target{StepKey: instance.Key, Queue: instance.Queue},
 			RequiredCapabilities:    capabilities,
 			Matrix:                  instance.Matrix,
+			Vars:                    cloneMap(ir.Vars),
 			Env:                     instance.Env,
 			DefaultShell:            instance.DefaultShell,
 			DefaultWorkingDirectory: instance.DefaultWorkingDirectory,
@@ -223,7 +264,10 @@ func planSpan(span workflow.Span) plan.Span {
 	}
 }
 
-func compile(path string, source, eventSource []byte) (IR, error) {
+func compile(path string, source, eventSource []byte, options Options) (IR, error) {
+	if err := options.validate(); err != nil {
+		return IR{}, err
+	}
 	parsed, err := workflow.Parse(path, source)
 	if err != nil {
 		return IR{}, err
@@ -232,7 +276,9 @@ func compile(path string, source, eventSource []byte) (IR, error) {
 	if err != nil {
 		return IR{}, err
 	}
-	jobs, err := expand(path, parsed)
+	event.Trust = options.EventTrust
+	vars := options.Vars.snapshot()
+	jobs, err := expand(path, parsed, compileContext(event, vars), options)
 	if err != nil {
 		return IR{}, err
 	}
@@ -241,6 +287,7 @@ func compile(path string, source, eventSource []byte) (IR, error) {
 		Schema:   schema,
 		Workflow: WorkflowSource{Path: path, Name: parsed.Name, Digest: "sha256:" + hex.EncodeToString(digest[:])},
 		Event:    event,
+		Vars:     vars,
 		Execution: ExecutionBoundary{
 			Supported: true,
 			Reason:    "run-job supports the fail-closed Phase 0 shell and local-action subset",
@@ -253,11 +300,19 @@ func parseEvent(source []byte) (Event, error) {
 	if len(bytes.TrimSpace(source)) == 0 {
 		return Event{}, fmt.Errorf("event snapshot is required")
 	}
-	var event Event
+	var input struct {
+		Provider   string         `json:"provider"`
+		Event      string         `json:"event"`
+		Repository Repository     `json:"repository"`
+		Ref        string         `json:"ref"`
+		SHA        string         `json:"sha"`
+		Actor      string         `json:"actor"`
+		Payload    map[string]any `json:"payload"`
+	}
 	decoder := json.NewDecoder(bytes.NewReader(source))
 	decoder.UseNumber()
 	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&event); err != nil {
+	if err := decoder.Decode(&input); err != nil {
 		return Event{}, fmt.Errorf("parse event snapshot: %w", err)
 	}
 	if err := decoder.Decode(&struct{}{}); err != io.EOF {
@@ -266,16 +321,36 @@ func parseEvent(source []byte) (Event, error) {
 		}
 		return Event{}, fmt.Errorf("parse event snapshot: %w", err)
 	}
-	if strings.TrimSpace(event.Provider) == "" || strings.TrimSpace(event.Event) == "" || strings.TrimSpace(event.Repository.Owner) == "" || strings.TrimSpace(event.Repository.Name) == "" || strings.TrimSpace(event.Ref) == "" || strings.TrimSpace(event.SHA) == "" || strings.TrimSpace(event.Actor) == "" {
+	if strings.TrimSpace(input.Provider) == "" || strings.TrimSpace(input.Event) == "" || strings.TrimSpace(input.Repository.Owner) == "" || strings.TrimSpace(input.Repository.Name) == "" || strings.TrimSpace(input.Ref) == "" || strings.TrimSpace(input.SHA) == "" || strings.TrimSpace(input.Actor) == "" {
 		return Event{}, fmt.Errorf("event snapshot requires provider, event, repository owner/name, ref, sha, and actor")
 	}
-	if event.Payload == nil {
-		event.Payload = map[string]any{}
+	if input.Payload == nil {
+		input.Payload = map[string]any{}
 	}
-	return event, nil
+	return Event{
+		Provider: input.Provider, Event: input.Event, Repository: input.Repository,
+		Ref: input.Ref, SHA: input.SHA, Actor: input.Actor, Payload: input.Payload,
+	}, nil
 }
 
-func expand(path string, parsed *workflow.Workflow) ([]JobInstance, error) {
+func compileContext(event Event, vars map[string]string) expression.CompileContext {
+	repository := event.Repository.Owner + "/" + event.Repository.Name
+	return expression.CompileContext{
+		GitHub: map[string]any{
+			"event_name":       event.Event,
+			"event":            event.Payload,
+			"repository":       repository,
+			"repository_owner": event.Repository.Owner,
+			"ref":              event.Ref,
+			"sha":              event.SHA,
+			"actor":            event.Actor,
+		},
+		Event: event.Payload,
+		Vars:  vars,
+	}
+}
+
+func expand(path string, parsed *workflow.Workflow, context expression.CompileContext, options Options) ([]JobInstance, error) {
 	jobs := make(map[string]workflow.Job, len(parsed.Jobs))
 	for _, job := range parsed.Jobs {
 		jobs[job.ID] = job
@@ -292,11 +367,19 @@ func expand(path string, parsed *workflow.Workflow) ([]JobInstance, error) {
 	instanceKeys := make(map[string]string)
 	for _, id := range order {
 		job := jobs[id]
-		matrices, err := expandMatrix(path, job)
+		matrices, err := expandMatrix(path, job, context)
 		if err != nil {
 			return nil, err
 		}
 		for _, matrix := range matrices {
+			labels, err := resolveRunsOn(job, context, matrix)
+			if err != nil {
+				return nil, locatedJobError(path, job, runsOnPosition(job).Line, runsOnPosition(job).Column, err.Error())
+			}
+			queue, err := options.Runners.resolve(labels, options.EventTrust)
+			if err != nil {
+				return nil, locatedJobError(path, job, runsOnPosition(job).Line, runsOnPosition(job).Column, err.Error())
+			}
 			key, err := instanceKey(job.ID, matrix)
 			if err != nil {
 				return nil, jobError(path, job, fmt.Sprintf("create deterministic instance key: %v", err))
@@ -309,7 +392,8 @@ func expand(path string, parsed *workflow.Workflow) ([]JobInstance, error) {
 				Key:                     key,
 				LogicalJobID:            job.ID,
 				Label:                   instanceLabel(job, matrix),
-				RunsOn:                  append([]string(nil), job.RunsOn...),
+				RunsOn:                  labels,
+				Queue:                   queue,
 				LogicalNeeds:            append([]string(nil), job.Needs...),
 				Matrix:                  matrix,
 				FailFast:                job.FailFast,
@@ -342,10 +426,7 @@ func supported(path string, job workflow.Job) error {
 	if job.Reusable {
 		return jobError(path, job, "reusable-workflow jobs are unsupported in the Phase 0 compiler")
 	}
-	if job.RunsOnExpr != nil {
-		return locatedJobError(path, job, job.RunsOnExpr.Span.Start.Line, job.RunsOnExpr.Span.Start.Column, "runtime-dependent runs-on expressions are unsupported")
-	}
-	if len(job.RunsOn) == 0 {
+	if len(job.RunsOn) == 0 && job.RunsOnExpr == nil {
 		return jobError(path, job, "runs-on must resolve statically")
 	}
 	ids := make(map[string]struct{}, len(job.Steps))
@@ -367,17 +448,6 @@ func supported(path string, job workflow.Job) error {
 			return locatedJobError(path, job, step.Span.Start.Line, step.Span.Start.Column, "step timeouts are unsupported in the Phase 0 runtime")
 		}
 	}
-	if job.Matrix == nil {
-		return nil
-	}
-	if job.Matrix.Expression != nil {
-		return locatedJobError(path, job, job.Matrix.Expression.Span.Start.Line, job.Matrix.Expression.Span.Start.Column, "runtime-dependent matrix expressions are unsupported")
-	}
-	for _, row := range job.Matrix.Rows {
-		if row.Expression != nil {
-			return locatedJobError(path, job, row.Expression.Span.Start.Line, row.Expression.Span.Start.Column, fmt.Sprintf("runtime-dependent matrix expression for %q is unsupported", row.Name))
-		}
-	}
 	return nil
 }
 
@@ -392,15 +462,23 @@ func cloneMap(in map[string]string) map[string]string {
 	return out
 }
 
-func expandMatrix(path string, job workflow.Job) ([]map[string]any, error) {
+func expandMatrix(path string, job workflow.Job, context expression.CompileContext) ([]map[string]any, error) {
 	if job.Matrix == nil {
 		return []map[string]any{nil}, nil
 	}
+	matrix, err := resolveMatrix(job.Matrix, context)
+	if err != nil {
+		position := job.Matrix.Span.Start
+		if job.Matrix.Expression != nil {
+			position = workflow.Position{Line: job.Matrix.Expression.Span.Start.Line, Column: job.Matrix.Expression.Span.Start.Column}
+		}
+		return nil, locatedJobError(path, job, position.Line, position.Column, err.Error())
+	}
 	matrices := []map[string]any{{}}
-	if len(job.Matrix.Rows) == 0 {
+	if len(matrix.Rows) == 0 {
 		matrices = nil
 	}
-	for _, row := range job.Matrix.Rows {
+	for _, row := range matrix.Rows {
 		if len(row.Values) == 0 {
 			return nil, jobError(path, job, fmt.Sprintf("matrix dimension %q has no values", row.Name))
 		}
@@ -421,7 +499,7 @@ func expandMatrix(path string, job workflow.Job) ([]map[string]any, error) {
 		matrices = next
 	}
 
-	matrices = excludeMatrixCombinations(matrices, job.Matrix.Exclude)
+	matrices = excludeMatrixCombinations(matrices, matrix.Exclude)
 	// Includes may overwrite values added by earlier includes, but not original
 	// dimensions. Standalone combinations are never candidates for later entries.
 	type includedMatrix struct {
@@ -432,7 +510,7 @@ func expandMatrix(path string, job workflow.Job) ([]map[string]any, error) {
 	for i, matrix := range matrices {
 		included[i] = includedMatrix{values: matrix, original: cloneAnyMap(matrix)}
 	}
-	for _, combination := range job.Matrix.Include {
+	for _, combination := range matrix.Include {
 		values := matrixCombinationValues(combination)
 		matched := false
 		for i := range included {
@@ -455,7 +533,149 @@ func expandMatrix(path string, job workflow.Job) ([]map[string]any, error) {
 	for _, matrix := range included {
 		matrices = append(matrices, matrix.values)
 	}
+	if len(matrices) == 0 {
+		return nil, jobError(path, job, "matrix excludes every combination")
+	}
 	return matrices, nil
+}
+
+func resolveMatrix(matrix *workflow.Matrix, context expression.CompileContext) (*workflow.Matrix, error) {
+	if matrix.Expression != nil {
+		value, err := expression.EvaluateCompile(*matrix.Expression, context)
+		if err != nil {
+			return nil, matrixExpressionError(err)
+		}
+		object, ok := value.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("matrix expression resolved to %T, want object", value)
+		}
+		return matrixFromObject(object)
+	}
+	resolved := *matrix
+	resolved.Rows = make([]workflow.MatrixRow, len(matrix.Rows))
+	for i, row := range matrix.Rows {
+		resolved.Rows[i] = row
+		if row.Expression == nil {
+			resolved.Rows[i].Values = append([]workflow.Value(nil), row.Values...)
+			continue
+		}
+		value, err := expression.EvaluateCompile(*row.Expression, context)
+		if err != nil {
+			return nil, fmt.Errorf("matrix dimension %q: %w", row.Name, matrixExpressionError(err))
+		}
+		values, ok := value.([]any)
+		if !ok {
+			return nil, fmt.Errorf("matrix dimension %q resolved to %T, want array", row.Name, value)
+		}
+		resolved.Rows[i].Expression = nil
+		resolved.Rows[i].Values = make([]workflow.Value, len(values))
+		for j, value := range values {
+			resolved.Rows[i].Values[j] = workflow.Value{Data: value, Span: row.Span}
+		}
+	}
+	return &resolved, nil
+}
+
+func matrixExpressionError(err error) error {
+	if strings.Contains(err.Error(), `compile-time context "needs"`) || strings.Contains(err.Error(), `compile-time context "steps"`) {
+		return fmt.Errorf("runtime-dependent matrix expressions are unsupported: %w", err)
+	}
+	return fmt.Errorf("matrix expression cannot be resolved at compile time: %w", err)
+}
+
+func matrixFromObject(object map[string]any) (*workflow.Matrix, error) {
+	keys := make([]string, 0, len(object))
+	for key := range object {
+		if key != "include" && key != "exclude" {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	matrix := &workflow.Matrix{}
+	for _, key := range keys {
+		values, ok := object[key].([]any)
+		if !ok {
+			return nil, fmt.Errorf("matrix dimension %q resolved to %T, want array", key, object[key])
+		}
+		row := workflow.MatrixRow{Name: key, Values: make([]workflow.Value, len(values))}
+		for i, value := range values {
+			row.Values[i] = workflow.Value{Data: value}
+		}
+		matrix.Rows = append(matrix.Rows, row)
+	}
+	var err error
+	if matrix.Include, err = matrixCombinationsFromValue("include", object["include"]); err != nil {
+		return nil, err
+	}
+	if matrix.Exclude, err = matrixCombinationsFromValue("exclude", object["exclude"]); err != nil {
+		return nil, err
+	}
+	return matrix, nil
+}
+
+func matrixCombinationsFromValue(name string, value any) ([]workflow.MatrixCombination, error) {
+	if value == nil {
+		return nil, nil
+	}
+	items, ok := value.([]any)
+	if !ok {
+		return nil, fmt.Errorf("matrix %s resolved to %T, want array", name, value)
+	}
+	combinations := make([]workflow.MatrixCombination, len(items))
+	for i, item := range items {
+		object, ok := item.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("matrix %s entry %d resolved to %T, want object", name, i, item)
+		}
+		values := make(map[string]workflow.Value, len(object))
+		for key, value := range object {
+			values[key] = workflow.Value{Data: value}
+		}
+		combinations[i] = workflow.MatrixCombination{Values: values}
+	}
+	return combinations, nil
+}
+
+func resolveRunsOn(job workflow.Job, context expression.CompileContext, matrix map[string]any) ([]string, error) {
+	context.Matrix = matrix
+	if job.RunsOnExpr != nil {
+		value, err := expression.EvaluateCompile(*job.RunsOnExpr, context)
+		if err != nil {
+			return nil, fmt.Errorf("runs-on expression cannot be resolved at compile time: %w", err)
+		}
+		switch value := value.(type) {
+		case string:
+			return []string{value}, nil
+		case []any:
+			labels := make([]string, len(value))
+			for i, item := range value {
+				label, ok := item.(string)
+				if !ok {
+					return nil, fmt.Errorf("runs-on expression item %d resolved to %T, want string", i, item)
+				}
+				labels[i] = label
+			}
+			return labels, nil
+		default:
+			return nil, fmt.Errorf("runs-on expression resolved to %T, want string or array", value)
+		}
+	}
+	labels := make([]string, len(job.RunsOn))
+	for i, label := range job.RunsOn {
+		resolved, err := expression.EvaluateCompileTemplate(label, context)
+		if err != nil {
+			return nil, fmt.Errorf("runs-on label %q cannot be resolved at compile time: %w", label, err)
+		}
+		labels[i] = resolved
+	}
+	return labels, nil
+}
+
+func runsOnPosition(job workflow.Job) workflow.Position {
+	if job.RunsOnExpr != nil {
+		return workflow.Position{Line: job.RunsOnExpr.Span.Start.Line, Column: job.RunsOnExpr.Span.Start.Column}
+	}
+	return job.Span.Start
 }
 
 func excludeMatrixCombinations(matrices []map[string]any, exclusions []workflow.MatrixCombination) []map[string]any {
@@ -481,7 +701,7 @@ func excludeMatrixCombinations(matrices []map[string]any, exclusions []workflow.
 func matrixMatches(matrix, pattern map[string]any) bool {
 	for key, expected := range pattern {
 		actual, ok := matrix[key]
-		if !ok || !reflect.DeepEqual(actual, expected) {
+		if !ok || !matrixValuesEqual(actual, expected) {
 			return false
 		}
 	}
@@ -490,11 +710,67 @@ func matrixMatches(matrix, pattern map[string]any) bool {
 
 func includeCompatible(original, values map[string]any) bool {
 	for key, value := range values {
-		if originalValue, exists := original[key]; exists && !reflect.DeepEqual(originalValue, value) {
+		if originalValue, exists := original[key]; exists && !matrixValuesEqual(originalValue, value) {
 			return false
 		}
 	}
 	return true
+}
+
+func matrixValuesEqual(left, right any) bool {
+	if leftNumber, ok := matrixNumber(left); ok {
+		rightNumber, rightOK := matrixNumber(right)
+		return rightOK && leftNumber.Cmp(rightNumber) == 0
+	}
+	switch left := left.(type) {
+	case []any:
+		right, ok := right.([]any)
+		if !ok || len(left) != len(right) {
+			return false
+		}
+		for i := range left {
+			if !matrixValuesEqual(left[i], right[i]) {
+				return false
+			}
+		}
+		return true
+	case map[string]any:
+		right, ok := right.(map[string]any)
+		if !ok || len(left) != len(right) {
+			return false
+		}
+		for key, value := range left {
+			other, ok := right[key]
+			if !ok || !matrixValuesEqual(value, other) {
+				return false
+			}
+		}
+		return true
+	default:
+		return reflect.DeepEqual(left, right)
+	}
+}
+
+func matrixNumber(value any) (*big.Rat, bool) {
+	var text string
+	switch value := value.(type) {
+	case json.Number:
+		text = value.String()
+	default:
+		reflected := reflect.ValueOf(value)
+		switch reflected.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			text = strconv.FormatInt(reflected.Int(), 10)
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			text = strconv.FormatUint(reflected.Uint(), 10)
+		case reflect.Float32, reflect.Float64:
+			text = strconv.FormatFloat(reflected.Float(), 'g', -1, reflected.Type().Bits())
+		default:
+			return nil, false
+		}
+	}
+	number, ok := new(big.Rat).SetString(text)
+	return number, ok
 }
 
 func matrixCombinationValues(combination workflow.MatrixCombination) map[string]any {

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -366,7 +366,7 @@ jobs:
 	if first.SourcePath != "./.github/workflows/reusable.yml" || first.SourceDigest != wantCalleeDigest || first.Steps[0].Run != `echo "hello true"` {
 		t.Fatalf("callee provenance/input = %q / %q / %q, want repository-relative path, digest, and statically substituted input", first.SourcePath, first.SourceDigest, first.Steps[0].Run)
 	}
-	if prepare.SourcePath != callerPath || finish.SourcePath != callerPath {
+	if prepare.SourcePath != "./.github/workflows/caller.yml" || finish.SourcePath != "./.github/workflows/caller.yml" {
 		t.Fatalf("caller source provenance = %q / %q", prepare.SourcePath, finish.SourcePath)
 	}
 }
@@ -434,12 +434,52 @@ jobs:
 	}
 }
 
+func TestCompilePlansResolveReusableLocalActionsFromRepositoryRoot(t *testing.T) {
+	repository := t.TempDir()
+	callerPath := writeWorkflow(t, repository, "caller.yml", "on: push\njobs:\n  delegated:\n    uses: ./.github/workflows/reusable.yml\n")
+	writeWorkflow(t, repository, "reusable.yml", "on: workflow_call\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: ./.github/actions/docker\n")
+	actionDir := filepath.Join(repository, ".github", "actions", "docker")
+	if err := os.MkdirAll(actionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(actionDir, "action.yml"), []byte("runs:\n  using: docker\n  image: Dockerfile\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	plans, err := CompilePlans(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-untrusted")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 1 || !reflect.DeepEqual(plans[0].RequiredCapabilities, []string{"docker"}) || plans[0].Workflow.Path != "./.github/workflows/reusable.yml" {
+		t.Fatalf("reusable local-action plan = %#v", plans)
+	}
+}
+
 func TestCompileRejectsUnsafeOrDynamicReusableWorkflowCalls(t *testing.T) {
+	t.Run("input workflow symlink escape", func(t *testing.T) {
+		repository := t.TempDir()
+		workflowDir := filepath.Join(repository, ".github", "workflows")
+		if err := os.MkdirAll(workflowDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		outside := filepath.Join(t.TempDir(), "outside.yml")
+		if err := os.WriteFile(outside, []byte("on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(workflowDir, "escaped.yml")
+		if err := os.Symlink(outside, path); err != nil {
+			t.Fatal(err)
+		}
+		_, err := Compile(path, readFile(t, path), readFile(t, smokePath("events", "push.json")))
+		if err == nil || !strings.Contains(err.Error(), "escapes repository root") {
+			t.Fatalf("Compile() error = %v, want input workflow symlink confinement rejection", err)
+		}
+	})
+
 	t.Run("remote", func(t *testing.T) {
 		repository := t.TempDir()
 		path := writeWorkflow(t, repository, "caller.yml", "on: push\njobs:\n  call:\n    uses: owner/repository/.github/workflows/reusable.yml@main\n")
 		_, err := Compile(path, readFile(t, path), readFile(t, smokePath("events", "push.json")))
-		if err == nil || !strings.Contains(err.Error(), "only repository-local ./ paths are supported") || !strings.Contains(err.Error(), path+":4:11") {
+		if err == nil || !strings.Contains(err.Error(), "only repository-local ./ paths are supported") || !strings.Contains(err.Error(), "./.github/workflows/caller.yml:4:11") {
 			t.Fatalf("Compile() error = %v, want source-located remote rejection", err)
 		}
 	})
@@ -455,7 +495,7 @@ jobs:
 `)
 		writeWorkflow(t, repository, "reusable.yml", "on:\n  workflow_call:\n    inputs:\n      target:\n        type: string\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n")
 		_, err := Compile(path, readFile(t, path), readFile(t, smokePath("events", "push.json")))
-		if err == nil || !strings.Contains(err.Error(), `input "target" is not statically resolvable`) || !strings.Contains(err.Error(), path+":6:15") {
+		if err == nil || !strings.Contains(err.Error(), `input "target" is not statically resolvable`) || !strings.Contains(err.Error(), "./.github/workflows/caller.yml:6:15") {
 			t.Fatalf("Compile() error = %v, want source-located runtime input rejection", err)
 		}
 	})
@@ -567,6 +607,16 @@ jobs:
 }
 
 func TestCompileRejectsRuntimeExpressionsLaunderedThroughReusableInputs(t *testing.T) {
+	t.Run("matrix expression", func(t *testing.T) {
+		repository := t.TempDir()
+		path := writeWorkflow(t, repository, "caller.yml", "on: push\njobs:\n  call:\n    strategy:\n      matrix: ${{ fromJSON(vars.MATRIX) }}\n    uses: ./.github/workflows/reusable.yml\n")
+		writeWorkflow(t, repository, "reusable.yml", "on: workflow_call\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n")
+		_, err := Compile(path, readFile(t, path), readFile(t, smokePath("events", "push.json")))
+		if err == nil || !strings.Contains(err.Error(), "expression-valued reusable-workflow matrices are unsupported") {
+			t.Fatalf("Compile() error = %v, want explicit call-matrix rejection", err)
+		}
+	})
+
 	t.Run("matrix value", func(t *testing.T) {
 		repository := t.TempDir()
 		path := writeWorkflow(t, repository, "caller.yml", `on: push
@@ -775,11 +825,19 @@ jobs:
 	}
 }
 
-func TestCompilePlansRejectsNeedsWithoutRuntimeManifestInjection(t *testing.T) {
+func TestCompilePlansRecordsStaticDependenciesWithoutRuntimeResults(t *testing.T) {
 	path := smokePath(".github", "workflows", "shell.yml")
-	_, err := CompilePlans(path, readFile(t, path), readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
-	if err == nil || !strings.Contains(err.Error(), "jobs with needs are unsupported until producer result manifests can be injected at runtime") {
-		t.Fatalf("CompilePlans() error = %v, want needs boundary", err)
+	plans, err := CompilePlans(path, readFile(t, path), readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 3 || len(plans[0].Dependencies) != 0 {
+		t.Fatalf("plans = %#v, want producer plus two consumers", plans)
+	}
+	for _, consumer := range plans[1:] {
+		if !reflect.DeepEqual(consumer.Dependencies, []string{plans[0].Target.StepKey}) || consumer.Needs != nil {
+			t.Fatalf("consumer dependencies/results = %#v / %#v", consumer.Dependencies, consumer.Needs)
+		}
 	}
 }
 
@@ -843,8 +901,7 @@ func TestLocalActionCapabilityResolutionStaysWithinRepository(t *testing.T) {
 	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	workflowPath := filepath.Join(workflowDir, "escape.yml")
-	_, err := loadLocalAction(workflowPath, "./../../outside")
+	_, err := loadLocalAction(repository, "./../../outside")
 	if err == nil || !strings.Contains(err.Error(), "escapes") {
 		t.Fatalf("loadLocalAction() error = %v, want repository escape error", err)
 	}
@@ -860,7 +917,7 @@ func TestLocalActionCapabilityResolutionStaysWithinRepository(t *testing.T) {
 	if err := os.Symlink(outside, filepath.Join(actionsDir, "escaped")); err != nil {
 		t.Fatal(err)
 	}
-	_, err = loadLocalAction(workflowPath, "./.github/actions/escaped")
+	_, err = loadLocalAction(repository, "./.github/actions/escaped")
 	if err == nil || !strings.Contains(err.Error(), "escapes") {
 		t.Fatalf("loadLocalAction() symlink error = %v, want repository escape error", err)
 	}
@@ -871,15 +928,28 @@ func TestLocalActionCapabilityResolutionStaysWithinRepository(t *testing.T) {
 	if err := os.Symlink(filepath.Join(outside, "action.yml"), filepath.Join(metadataEscape, "action.yml")); err != nil {
 		t.Fatal(err)
 	}
-	_, err = loadLocalAction(workflowPath, "./.github/actions/metadata-escaped")
+	_, err = loadLocalAction(repository, "./.github/actions/metadata-escaped")
 	if err == nil || !strings.Contains(err.Error(), "escapes") {
 		t.Fatalf("loadLocalAction() metadata symlink error = %v, want repository escape error", err)
 	}
 }
 
+func TestWorkflowRepositoryNormalizesInMemoryWorkflowPath(t *testing.T) {
+	repository := t.TempDir()
+	path := filepath.Join(repository, ".github", "workflows", "memory.yml")
+	root, canonical, err := workflowRepository(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantCanonical := filepath.Join(root, ".github", "workflows", "memory.yml")
+	if canonical != wantCanonical {
+		t.Fatalf("workflow repository = %q / %q, want canonical path %q", root, canonical, wantCanonical)
+	}
+}
+
 func TestCompiledPlansValidateAgainstVersionedSchema(t *testing.T) {
-	path := smokePath(".github", "workflows", "schema-fixture.yml")
-	source := []byte("on: push\njobs:\n  schema:\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n")
+	path := smokePath(".github", "workflows", "shell.yml")
+	source := readFile(t, path)
 	plans, err := CompilePlans(path, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -2,7 +2,10 @@ package compiler
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -287,6 +290,407 @@ jobs:
 	if err == nil || !strings.Contains(err.Error(), "matrix excludes every combination") {
 		t.Fatalf("Compile() error = %v, want empty matrix rejection", err)
 	}
+}
+
+func TestCompileExpandsLocalReusableWorkflowWithNamespacesAndDependencies(t *testing.T) {
+	repository := t.TempDir()
+	callerPath := writeWorkflow(t, repository, "caller.yml", `on: push
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - run: prepare
+  delegated:
+    name: delegated tests
+    needs: prepare
+    uses: ./.github/workflows/reusable.yml
+    with:
+      message: hello
+      enabled: true
+  finish:
+    needs: delegated
+    runs-on: ubuntu-latest
+    steps:
+      - run: finish
+`)
+	calleePath := writeWorkflow(t, repository, "reusable.yml", `on:
+  workflow_call:
+    inputs:
+      message:
+        type: string
+        required: true
+      enabled:
+        type: boolean
+        required: true
+jobs:
+  first:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ inputs.message }} ${{ inputs.enabled }}"
+  second:
+    needs: first
+    runs-on: ubuntu-latest
+    steps:
+      - run: second
+`)
+	result, err := Compile(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ir IR
+	if err := json.Unmarshal(result, &ir); err != nil {
+		t.Fatal(err)
+	}
+	if len(ir.Jobs) != 4 {
+		t.Fatalf("jobs = %d, want 4", len(ir.Jobs))
+	}
+	byID := make(map[string]JobInstance, len(ir.Jobs))
+	for _, job := range ir.Jobs {
+		byID[job.LogicalJobID] = job
+	}
+	prepare := byID["prepare"]
+	first := byID["delegated.first"]
+	second := byID["delegated.second"]
+	finish := byID["finish"]
+	if !reflect.DeepEqual(first.Needs, []string{prepare.Key}) || !reflect.DeepEqual(first.LogicalNeeds, []string{"prepare"}) {
+		t.Fatalf("callee root needs = %#v / %#v, want caller prerequisite", first.Needs, first.LogicalNeeds)
+	}
+	if !reflect.DeepEqual(second.Needs, []string{first.Key}) || !reflect.DeepEqual(finish.Needs, []string{second.Key}) {
+		t.Fatalf("callee/caller dependencies = %#v / %#v", second.Needs, finish.Needs)
+	}
+	if first.Key != "gha-delegated-first" || first.Label != "delegated tests / first" {
+		t.Fatalf("callee identity = key %q label %q", first.Key, first.Label)
+	}
+	calleeDigest := sha256.Sum256(readFile(t, calleePath))
+	wantCalleeDigest := "sha256:" + hex.EncodeToString(calleeDigest[:])
+	if first.SourcePath != "./.github/workflows/reusable.yml" || first.SourceDigest != wantCalleeDigest || first.Steps[0].Run != `echo "hello true"` {
+		t.Fatalf("callee provenance/input = %q / %q / %q, want repository-relative path, digest, and statically substituted input", first.SourcePath, first.SourceDigest, first.Steps[0].Run)
+	}
+	if prepare.SourcePath != callerPath || finish.SourcePath != callerPath {
+		t.Fatalf("caller source provenance = %q / %q", prepare.SourcePath, finish.SourcePath)
+	}
+}
+
+func TestCompileExpandsMatrixReusableCallsDeterministically(t *testing.T) {
+	repository := t.TempDir()
+	callerPath := writeWorkflow(t, repository, "caller.yml", `on: push
+jobs:
+  delegated:
+    strategy:
+      matrix:
+        target: [ubuntu-22.04, ubuntu-24.04]
+    uses: ./.github/workflows/reusable.yml
+    with:
+      target: ${{ matrix.target }}
+`)
+	writeWorkflow(t, repository, "reusable.yml", `on:
+  workflow_call:
+    inputs:
+      target:
+        type: string
+        required: true
+jobs:
+  test:
+    name: test ${{ inputs.target }}
+    runs-on: ${{ inputs.target }}
+    steps:
+      - run: echo ${{ inputs.target }}
+`)
+
+	first, err := Compile(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := Compile(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Fatal("reusable-workflow matrix compilation was not byte-identical")
+	}
+	var ir IR
+	if err := json.Unmarshal(first, &ir); err != nil {
+		t.Fatal(err)
+	}
+	if len(ir.Jobs) != 2 || ir.Jobs[0].LogicalJobID == ir.Jobs[1].LogicalJobID || ir.Jobs[0].Key == ir.Jobs[1].Key {
+		t.Fatalf("matrix reusable jobs = %#v, want two namespaced identities", ir.Jobs)
+	}
+	runs := []string{ir.Jobs[0].Steps[0].Run, ir.Jobs[1].Steps[0].Run}
+	sort.Strings(runs)
+	if !reflect.DeepEqual(runs, []string{"echo ubuntu-22.04", "echo ubuntu-24.04"}) {
+		t.Fatalf("statically resolved matrix inputs = %#v", runs)
+	}
+	runners := []string{ir.Jobs[0].RunsOn[0], ir.Jobs[1].RunsOn[0]}
+	sort.Strings(runners)
+	if !reflect.DeepEqual(runners, []string{"ubuntu-22.04", "ubuntu-24.04"}) {
+		t.Fatalf("statically resolved runs-on inputs = %#v", runners)
+	}
+	plans, err := CompilePlans(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 2 || plans[0].Workflow.Path != "./.github/workflows/reusable.yml" || plans[0].Workflow.Digest != ir.Jobs[0].SourceDigest {
+		t.Fatalf("callee plan provenance = %#v, want callee path and digest", plans)
+	}
+}
+
+func TestCompileRejectsUnsafeOrDynamicReusableWorkflowCalls(t *testing.T) {
+	t.Run("remote", func(t *testing.T) {
+		repository := t.TempDir()
+		path := writeWorkflow(t, repository, "caller.yml", "on: push\njobs:\n  call:\n    uses: owner/repository/.github/workflows/reusable.yml@main\n")
+		_, err := Compile(path, readFile(t, path), readFile(t, smokePath("events", "push.json")))
+		if err == nil || !strings.Contains(err.Error(), "only repository-local ./ paths are supported") || !strings.Contains(err.Error(), path+":4:11") {
+			t.Fatalf("Compile() error = %v, want source-located remote rejection", err)
+		}
+	})
+
+	t.Run("runtime input", func(t *testing.T) {
+		repository := t.TempDir()
+		path := writeWorkflow(t, repository, "caller.yml", `on: push
+jobs:
+  call:
+    uses: ./.github/workflows/reusable.yml
+    with:
+      target: ${{ needs.prepare.outputs.target }}
+`)
+		writeWorkflow(t, repository, "reusable.yml", "on:\n  workflow_call:\n    inputs:\n      target:\n        type: string\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n")
+		_, err := Compile(path, readFile(t, path), readFile(t, smokePath("events", "push.json")))
+		if err == nil || !strings.Contains(err.Error(), `input "target" is not statically resolvable`) || !strings.Contains(err.Error(), path+":6:15") {
+			t.Fatalf("Compile() error = %v, want source-located runtime input rejection", err)
+		}
+	})
+
+	t.Run("symlink escape", func(t *testing.T) {
+		repository := t.TempDir()
+		path := writeWorkflow(t, repository, "caller.yml", "on: push\njobs:\n  call:\n    uses: ./.github/workflows/escaped.yml\n")
+		outside := filepath.Join(t.TempDir(), "outside.yml")
+		if err := os.WriteFile(outside, []byte("on: workflow_call\njobs: {}\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(outside, filepath.Join(repository, ".github", "workflows", "escaped.yml")); err != nil {
+			t.Fatal(err)
+		}
+		_, err := Compile(path, readFile(t, path), readFile(t, smokePath("events", "push.json")))
+		if err == nil || !strings.Contains(err.Error(), "escapes repository root") {
+			t.Fatalf("Compile() error = %v, want symlink confinement rejection", err)
+		}
+	})
+}
+
+func TestCompileRejectsReusableWorkflowCyclesAndDepthOverflow(t *testing.T) {
+	t.Run("cycle", func(t *testing.T) {
+		repository := t.TempDir()
+		path := writeWorkflow(t, repository, "a.yml", "on: push\njobs:\n  call:\n    uses: ./.github/workflows/b.yml\n")
+		writeWorkflow(t, repository, "b.yml", "on: workflow_call\njobs:\n  call:\n    uses: ./.github/workflows/a.yml\n")
+		_, err := Compile(path, readFile(t, path), readFile(t, smokePath("events", "push.json")))
+		if err == nil || !strings.Contains(err.Error(), "reusable-workflow cycle detected") || !strings.Contains(err.Error(), "a.yml -> .github/workflows/b.yml -> .github/workflows/a.yml") {
+			t.Fatalf("Compile() error = %v, want explicit cycle", err)
+		}
+	})
+
+	t.Run("depth", func(t *testing.T) {
+		repository := t.TempDir()
+		for i := 0; i <= maxReusableWorkflowDepth; i++ {
+			on := "workflow_call"
+			if i == 0 {
+				on = "push"
+			}
+			writeWorkflow(t, repository, fmt.Sprintf("%d.yml", i), fmt.Sprintf("on: %s\njobs:\n  call:\n    uses: ./.github/workflows/%d.yml\n", on, i+1))
+		}
+		path := filepath.Join(repository, ".github", "workflows", "0.yml")
+		_, err := Compile(path, readFile(t, path), readFile(t, smokePath("events", "push.json")))
+		if err == nil || !strings.Contains(err.Error(), fmt.Sprintf("exceeds maximum depth %d", maxReusableWorkflowDepth)) {
+			t.Fatalf("Compile() error = %v, want explicit depth limit", err)
+		}
+	})
+}
+
+func TestCompileResolvesInputsBeforeNestedReusableCallMatrices(t *testing.T) {
+	repository := t.TempDir()
+	callerPath := writeWorkflow(t, repository, "caller.yml", `on: push
+jobs:
+  middle:
+    uses: ./.github/workflows/middle.yml
+    with:
+      target: linux
+`)
+	writeWorkflow(t, repository, "middle.yml", `on:
+  workflow_call:
+    inputs:
+      target:
+        type: string
+        required: true
+jobs:
+  leaf:
+    name: leaf ${{ inputs.target }}
+    strategy:
+      matrix:
+        target: ["${{ inputs.target }}", arm]
+    uses: ./.github/workflows/leaf.yml
+    with:
+      target: ${{ matrix.target }}
+`)
+	writeWorkflow(t, repository, "leaf.yml", `on:
+  workflow_call:
+    inputs:
+      target:
+        type: string
+        required: true
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ${{ inputs.target }}
+`)
+
+	result, err := Compile(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ir IR
+	if err := json.Unmarshal(result, &ir); err != nil {
+		t.Fatal(err)
+	}
+	if len(ir.Jobs) != 2 {
+		t.Fatalf("jobs = %d, want 2 nested matrix instances", len(ir.Jobs))
+	}
+	runs := []string{ir.Jobs[0].Steps[0].Run, ir.Jobs[1].Steps[0].Run}
+	sort.Strings(runs)
+	if !reflect.DeepEqual(runs, []string{"echo arm", "echo linux"}) {
+		t.Fatalf("nested static inputs = %#v", runs)
+	}
+	for _, job := range ir.Jobs {
+		if !strings.HasPrefix(job.Label, "middle / leaf linux") {
+			t.Fatalf("nested label = %q, want substituted caller input", job.Label)
+		}
+	}
+}
+
+func TestCompileRejectsRuntimeExpressionsLaunderedThroughReusableInputs(t *testing.T) {
+	t.Run("matrix value", func(t *testing.T) {
+		repository := t.TempDir()
+		path := writeWorkflow(t, repository, "caller.yml", `on: push
+jobs:
+  call:
+    strategy:
+      matrix:
+        target: ["${{ github.ref_name }}"]
+    uses: ./.github/workflows/reusable.yml
+    with:
+      target: ${{ matrix.target }}
+`)
+		writeWorkflow(t, repository, "reusable.yml", "on:\n  workflow_call:\n    inputs:\n      target:\n        type: string\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo ${{ inputs.target }}\n")
+		_, err := Compile(path, readFile(t, path), readFile(t, smokePath("events", "push.json")))
+		if err == nil || !strings.Contains(err.Error(), "runtime-dependent reusable-workflow matrix value is unsupported") {
+			t.Fatalf("Compile() error = %v, want matrix expression rejection", err)
+		}
+	})
+
+	t.Run("callee body", func(t *testing.T) {
+		repository := t.TempDir()
+		path := writeWorkflow(t, repository, "caller.yml", "on: push\njobs:\n  call:\n    uses: ./.github/workflows/reusable.yml\n    with:\n      enabled: true\n")
+		writeWorkflow(t, repository, "reusable.yml", `on:
+  workflow_call:
+    inputs:
+      enabled:
+        type: boolean
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ${{ inputs.enabled && 'yes' || 'no' }}
+`)
+		_, err := Compile(path, readFile(t, path), readFile(t, smokePath("events", "push.json")))
+		if err == nil || !strings.Contains(err.Error(), "reusable-workflow input expression is not statically resolvable") {
+			t.Fatalf("Compile() error = %v, want complex input rejection", err)
+		}
+	})
+}
+
+func TestCompileRejectsFlattenedReusableJobIDCollisions(t *testing.T) {
+	repository := t.TempDir()
+	suffix, err := matrixDigest(map[string]any{"target": "linux"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := writeWorkflow(t, repository, "caller.yml", fmt.Sprintf(`on: push
+jobs:
+  call:
+    strategy:
+      matrix:
+        target: [linux, arm]
+    uses: ./.github/workflows/reusable.yml
+  call-%s:
+    uses: ./.github/workflows/reusable.yml
+`, suffix))
+	writeWorkflow(t, repository, "reusable.yml", "on: workflow_call\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n")
+	_, err = Compile(path, readFile(t, path), readFile(t, smokePath("events", "push.json")))
+	if err == nil || !strings.Contains(err.Error(), "flattened job id") || !strings.Contains(err.Error(), "collides with another job") {
+		t.Fatalf("Compile() error = %v, want fail-closed flattened ID collision", err)
+	}
+}
+
+func TestCompileBoundsReusableWorkflowGraphExpansion(t *testing.T) {
+	repository := t.TempDir()
+	values := make([]string, maxMatrixInstances)
+	for i := range values {
+		values[i] = fmt.Sprint(i)
+	}
+	path := writeWorkflow(t, repository, "caller.yml", fmt.Sprintf("on: push\njobs:\n  call:\n    strategy:\n      matrix:\n        value: [%s]\n    uses: ./.github/workflows/reusable.yml\n", strings.Join(values, ", ")))
+	var callee strings.Builder
+	callee.WriteString("on: workflow_call\njobs:\n")
+	for i := 0; i < 5; i++ {
+		fmt.Fprintf(&callee, "  job%d:\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n", i)
+	}
+	writeWorkflow(t, repository, "reusable.yml", callee.String())
+	_, err := Compile(path, readFile(t, path), readFile(t, smokePath("events", "push.json")))
+	if err == nil || !strings.Contains(err.Error(), fmt.Sprintf("graph expands beyond %d jobs", maxFlattenedJobs)) {
+		t.Fatalf("Compile() error = %v, want bounded graph rejection", err)
+	}
+}
+
+func TestCompileRejectsRequiredReusableWorkflowSecrets(t *testing.T) {
+	repository := t.TempDir()
+	path := writeWorkflow(t, repository, "caller.yml", "on: push\njobs:\n  call:\n    uses: ./.github/workflows/reusable.yml\n")
+	writeWorkflow(t, repository, "reusable.yml", `on:
+  workflow_call:
+    secrets:
+      token:
+        required: true
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+`)
+	_, err := Compile(path, readFile(t, path), readFile(t, smokePath("events", "push.json")))
+	if err == nil || !strings.Contains(err.Error(), `requires unsupported secret "token"`) {
+		t.Fatalf("Compile() error = %v, want required secret rejection", err)
+	}
+}
+
+func TestCompileReusableInputDiagnosticsAreDeterministic(t *testing.T) {
+	repository := t.TempDir()
+	path := writeWorkflow(t, repository, "caller.yml", "on: push\njobs:\n  call:\n    uses: ./.github/workflows/reusable.yml\n    with:\n      zed: z\n      alpha: a\n")
+	writeWorkflow(t, repository, "reusable.yml", "on: workflow_call\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n")
+	for i := 0; i < 20; i++ {
+		_, err := Compile(path, readFile(t, path), readFile(t, smokePath("events", "push.json")))
+		if err == nil || !strings.Contains(err.Error(), `input "alpha" is not declared`) {
+			t.Fatalf("Compile() error = %v, want alphabetically first input diagnostic", err)
+		}
+	}
+}
+
+func writeWorkflow(t *testing.T, repository, name, source string) string {
+	t.Helper()
+	path := filepath.Join(repository, ".github", "workflows", name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(source), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
 }
 
 func TestCompileRejectsRuntimeDependentGraphExpression(t *testing.T) {

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
+	"sort"
 	"strings"
 	"testing"
 
@@ -64,6 +66,169 @@ func TestCompileIsByteIdenticalAndCoversSmokeCorpus(t *testing.T) {
 				t.Fatal("repeated compilation was not byte-identical")
 			}
 		})
+	}
+}
+
+func TestCompileExpandsMatrixIncludeExcludeAndDependencies(t *testing.T) {
+	source := []byte(`name: matrix conformance
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        fruit: [apple, pear]
+        animal: [cat, dog]
+        exclude:
+          - fruit: pear
+            animal: dog
+        include:
+          - color: green
+          - color: pink
+            animal: cat
+          - fruit: banana
+          - fruit: banana
+            animal: cat
+    steps:
+      - run: true
+  report:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+`)
+	got, err := Compile("matrix.yml", source, readFile(t, smokePath("events", "push.json")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ir IR
+	if err := json.Unmarshal(got, &ir); err != nil {
+		t.Fatal(err)
+	}
+	if len(ir.Jobs) != 6 {
+		t.Fatalf("jobs = %d, want five matrix instances and one dependent", len(ir.Jobs))
+	}
+	wantMatrices := []map[string]any{
+		{"animal": "cat", "color": "pink", "fruit": "apple"},
+		{"animal": "dog", "color": "green", "fruit": "apple"},
+		{"animal": "cat", "color": "pink", "fruit": "pear"},
+		{"fruit": "banana"},
+		{"animal": "cat", "fruit": "banana"},
+	}
+	for i, want := range wantMatrices {
+		if !reflect.DeepEqual(ir.Jobs[i].Matrix, want) {
+			t.Fatalf("matrix instance %d = %#v, want %#v", i, ir.Jobs[i].Matrix, want)
+		}
+	}
+	report := ir.Jobs[5]
+	if report.LogicalJobID != "report" || len(report.Needs) != len(wantMatrices) {
+		t.Fatalf("dependent job = %#v, want dependency on all matrix instances", report)
+	}
+	wantNeeds := make([]string, len(wantMatrices))
+	for i := range wantMatrices {
+		wantNeeds[i] = ir.Jobs[i].Key
+	}
+	sort.Strings(wantNeeds)
+	for i, need := range report.Needs {
+		if need != wantNeeds[i] {
+			t.Fatalf("dependency %d = %q, want %q", i, need, wantNeeds[i])
+		}
+	}
+}
+
+func TestCompileRejectsRuntimeDependentMatrixInclude(t *testing.T) {
+	source := []byte(`on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        include: ${{ fromJSON(vars.INCLUDE) }}
+    steps:
+      - run: true
+`)
+	_, err := Compile("dynamic-include.yml", source, readFile(t, smokePath("events", "push.json")))
+	if err == nil || !strings.Contains(err.Error(), "runtime-dependent matrix include expressions are unsupported") {
+		t.Fatalf("Compile() error = %v, want explicit include expression error", err)
+	}
+	if !strings.Contains(err.Error(), "dynamic-include.yml:8:18") {
+		t.Fatalf("Compile() error = %v, want source location", err)
+	}
+}
+
+func TestCompileExpandsIncludeOnlyMatrixAsDistinctJobs(t *testing.T) {
+	source := []byte(`on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - fruit: banana
+          - fruit: apple
+            color: green
+    steps:
+      - run: true
+`)
+	got, err := Compile("include-only.yml", source, readFile(t, smokePath("events", "push.json")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ir IR
+	if err := json.Unmarshal(got, &ir); err != nil {
+		t.Fatal(err)
+	}
+	want := []map[string]any{{"fruit": "banana"}, {"color": "green", "fruit": "apple"}}
+	if len(ir.Jobs) != len(want) {
+		t.Fatalf("jobs = %d, want %d", len(ir.Jobs), len(want))
+	}
+	for i := range want {
+		if !reflect.DeepEqual(ir.Jobs[i].Matrix, want[i]) {
+			t.Fatalf("matrix instance %d = %#v, want %#v", i, ir.Jobs[i].Matrix, want[i])
+		}
+	}
+}
+
+func TestCompilePreservesStaticMatrixScalarTypes(t *testing.T) {
+	source := []byte(`on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [12, "14"]
+        experimental: [true, false]
+        exclude:
+          - version: 12
+            experimental: false
+        include:
+          - version: 16
+            experimental: false
+    steps:
+      - run: true
+`)
+	got, err := Compile("typed-matrix.yml", source, readFile(t, smokePath("events", "push.json")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ir IR
+	if err := json.Unmarshal(got, &ir); err != nil {
+		t.Fatal(err)
+	}
+	want := []map[string]any{
+		{"experimental": true, "version": float64(12)},
+		{"experimental": true, "version": "14"},
+		{"experimental": false, "version": "14"},
+		{"experimental": false, "version": float64(16)},
+	}
+	if len(ir.Jobs) != len(want) {
+		t.Fatalf("jobs = %d, want %d", len(ir.Jobs), len(want))
+	}
+	for i := range want {
+		if !reflect.DeepEqual(ir.Jobs[i].Matrix, want[i]) {
+			t.Fatalf("matrix instance %d = %#v, want %#v", i, ir.Jobs[i].Matrix, want[i])
+		}
 	}
 }
 

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -232,6 +232,63 @@ jobs:
 	}
 }
 
+func TestCompileMatchesStaticIncludeExcludeAgainstExpressionNumbers(t *testing.T) {
+	source := []byte(`on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: ${{ fromJSON(vars.VERSIONS) }}
+        exclude:
+          - version: 12
+        include:
+          - version: 14.0
+            experimental: true
+    steps:
+      - run: true
+`)
+	compiled, err := CompileWithOptions("numeric-matrix.yml", source, readFile(t, smokePath("events", "push.json")), Options{
+		EventTrust: EventTrusted,
+		Vars:       VariableSources{Bridge: map[string]string{"VERSIONS": `[12,14]`}},
+		Runners:    RunnerPolicy{Labels: map[string]string{"ubuntu-latest": "linux"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ir IR
+	if err := json.Unmarshal(compiled, &ir); err != nil {
+		t.Fatal(err)
+	}
+	if len(ir.Jobs) != 1 || ir.Jobs[0].Matrix["version"] != float64(14) || ir.Jobs[0].Matrix["experimental"] != true {
+		t.Fatalf("numeric matrix jobs = %#v, want one included version 14 job", ir.Jobs)
+	}
+}
+
+func TestCompileRejectsMatrixThatExcludesEveryCombination(t *testing.T) {
+	source := []byte(`on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [12]
+        exclude:
+          - version: 12
+    steps:
+      - run: true
+  report:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+`)
+	_, err := Compile("empty-matrix.yml", source, readFile(t, smokePath("events", "push.json")))
+	if err == nil || !strings.Contains(err.Error(), "matrix excludes every combination") {
+		t.Fatalf("Compile() error = %v, want empty matrix rejection", err)
+	}
+}
+
 func TestCompileRejectsRuntimeDependentGraphExpression(t *testing.T) {
 	source := []byte(`name: dynamic
 on: push
@@ -274,7 +331,7 @@ jobs:
         with:
           message: ${{ steps.javascript.outputs.result }}
 `)
-	plans, err := CompilePlans(path, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-runtime")
+	plans, err := CompilePlans(path, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -297,7 +354,7 @@ jobs:
 	if producer.RequiredCapabilities == nil || len(producer.RequiredCapabilities) != 0 {
 		t.Fatalf("required capabilities = %#v, want concrete empty array", producer.RequiredCapabilities)
 	}
-	second, err := CompilePlans(path, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-runtime")
+	second, err := CompilePlans(path, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -316,7 +373,7 @@ jobs:
 
 func TestCompilePlansRejectsNeedsWithoutRuntimeManifestInjection(t *testing.T) {
 	path := smokePath(".github", "workflows", "shell.yml")
-	_, err := CompilePlans(path, readFile(t, path), readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-runtime")
+	_, err := CompilePlans(path, readFile(t, path), readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
 	if err == nil || !strings.Contains(err.Error(), "jobs with needs are unsupported until producer result manifests can be injected at runtime") {
 		t.Fatalf("CompilePlans() error = %v, want needs boundary", err)
 	}
@@ -333,7 +390,7 @@ func TestCompilePlansDerivesDockerCapability(t *testing.T) {
 		t.Fatal(err)
 	}
 	source := []byte("on: push\njobs:\n  docker:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: ./.github/actions/docker\n")
-	plans, err := CompilePlans(workflowPath, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-runtime")
+	plans, err := CompilePlans(workflowPath, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -353,7 +410,7 @@ func TestCompilePlansRejectsNode20LocalAction(t *testing.T) {
 		t.Fatal(err)
 	}
 	source := []byte("on: push\njobs:\n  node20:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: ./.github/actions/node20\n")
-	_, err := CompilePlans(workflowPath, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-runtime")
+	_, err := CompilePlans(workflowPath, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
 	if err == nil || !strings.Contains(err.Error(), `uses unsupported runtime "node20"`) {
 		t.Fatalf("CompilePlans() error = %v, want node20 fail-closed boundary", err)
 	}
@@ -370,7 +427,7 @@ func TestCompilePlansRejectsRuntimeInvalidActionMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 	source := []byte("on: push\njobs:\n  invalid:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: ./.github/actions/invalid\n")
-	_, err := CompilePlans(workflowPath, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-runtime")
+	_, err := CompilePlans(workflowPath, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
 	if err == nil || !strings.Contains(err.Error(), "field unexpected not found") {
 		t.Fatalf("CompilePlans() error = %v, want strict action metadata rejection", err)
 	}
@@ -419,7 +476,7 @@ func TestLocalActionCapabilityResolutionStaysWithinRepository(t *testing.T) {
 func TestCompiledPlansValidateAgainstVersionedSchema(t *testing.T) {
 	path := smokePath(".github", "workflows", "schema-fixture.yml")
 	source := []byte("on: push\njobs:\n  schema:\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n")
-	plans, err := CompilePlans(path, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-runtime")
+	plans, err := CompilePlans(path, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -476,6 +533,7 @@ func TestCompileRejectsInvalidEventSnapshots(t *testing.T) {
 		wanted string
 	}{
 		{name: "unknown field", event: strings.Replace(valid, `"actor":`, `"unexpected":true,"actor":`, 1), wanted: "unknown field"},
+		{name: "self-asserted trust", event: strings.Replace(valid, `"actor":`, `"trust":"trusted","actor":`, 1), wanted: `unknown field "trust"`},
 		{name: "trailing value", event: valid + `{}`, wanted: "multiple JSON values"},
 		{name: "missing ref", event: strings.Replace(valid, `"ref": "refs/heads/main"`, `"ref": ""`, 1), wanted: "ref, sha, and actor"},
 		{name: "missing actor", event: strings.Replace(valid, `"actor": "buildkite-gha-smoke"`, `"actor": ""`, 1), wanted: "ref, sha, and actor"},

--- a/internal/compiler/config.go
+++ b/internal/compiler/config.go
@@ -1,0 +1,167 @@
+package compiler
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+var queuePattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,255}$`)
+
+// EventTrust is the compiler's authenticated classification of an event.
+type EventTrust string
+
+const (
+	EventTrusted   EventTrust = "trusted"
+	EventUntrusted EventTrust = "untrusted"
+)
+
+// VariableSources are explicit non-secret inputs to the vars context.
+// Precedence is Bridge < Provider < Buildkite, so the build-specific snapshot
+// wins over repository defaults without reading arbitrary process environment.
+type VariableSources struct {
+	Bridge    map[string]string
+	Provider  map[string]string
+	Buildkite map[string]string
+}
+
+// RunnerPolicy maps every accepted Linux runner label to a Buildkite queue.
+// Multi-label targets are accepted only when every label maps to the same
+// queue. Untrusted events are additionally restricted to UntrustedQueues.
+type RunnerPolicy struct {
+	Labels          map[string]string
+	UntrustedQueues []string
+}
+
+// Options are the complete non-secret graph-construction inputs beyond the
+// workflow and canonical event snapshot.
+type Options struct {
+	Vars       VariableSources
+	Runners    RunnerPolicy
+	EventTrust EventTrust
+}
+
+func defaultOptions() Options {
+	return Options{
+		// The convenience wrappers accept a local event path with no attestation,
+		// so their fixed policy is tokenless and untrusted by construction.
+		EventTrust: EventUntrusted,
+		Runners: RunnerPolicy{Labels: map[string]string{
+			"ubuntu-latest": "gha-untrusted",
+			"ubuntu-24.04":  "gha-untrusted",
+			"ubuntu-22.04":  "gha-untrusted",
+		}, UntrustedQueues: []string{"gha-untrusted"}},
+	}
+}
+
+func (options Options) validate() error {
+	if options.EventTrust != EventTrusted && options.EventTrust != EventUntrusted {
+		return fmt.Errorf("event trust must be %q or %q", EventTrusted, EventUntrusted)
+	}
+	if len(options.Runners.Labels) == 0 {
+		return fmt.Errorf("runner policy requires at least one label mapping")
+	}
+	labels := make(map[string]string, len(options.Runners.Labels))
+	for label, queue := range options.Runners.Labels {
+		if strings.TrimSpace(label) == "" || strings.TrimSpace(queue) == "" {
+			return fmt.Errorf("runner policy labels and queues must be non-empty")
+		}
+		if !queuePattern.MatchString(queue) {
+			return fmt.Errorf("runner policy queue %q is invalid", queue)
+		}
+		normalized := strings.ToLower(strings.TrimSpace(label))
+		if existing, ok := labels[normalized]; ok && existing != queue {
+			return fmt.Errorf("runner label %q has conflicting queue mappings", label)
+		}
+		labels[normalized] = queue
+	}
+	for _, queue := range options.Runners.UntrustedQueues {
+		if !queuePattern.MatchString(queue) {
+			return fmt.Errorf("untrusted queue allowlist contains invalid queue %q", queue)
+		}
+	}
+	for _, varsSource := range []struct {
+		name   string
+		values map[string]string
+	}{
+		{name: "bridge", values: options.Vars.Bridge},
+		{name: "provider", values: options.Vars.Provider},
+		{name: "buildkite", values: options.Vars.Buildkite},
+	} {
+		sourceName, source := varsSource.name, varsSource.values
+		names := make(map[string]string, len(source))
+		for name := range source {
+			if strings.TrimSpace(name) == "" {
+				return fmt.Errorf("vars source contains an empty variable name")
+			}
+			normalized := strings.ToUpper(name)
+			if existing, ok := names[normalized]; ok {
+				return fmt.Errorf("%s vars source contains case-colliding names %q and %q", sourceName, existing, name)
+			}
+			names[normalized] = name
+		}
+	}
+	return nil
+}
+
+func (sources VariableSources) snapshot() map[string]string {
+	vars := make(map[string]string, len(sources.Bridge)+len(sources.Provider)+len(sources.Buildkite))
+	for _, source := range []map[string]string{sources.Bridge, sources.Provider, sources.Buildkite} {
+		for name, value := range source {
+			vars[strings.ToUpper(name)] = value
+		}
+	}
+	if len(vars) == 0 {
+		return nil
+	}
+	return vars
+}
+
+func (policy RunnerPolicy) resolve(labels []string, trust EventTrust) (string, error) {
+	if len(labels) == 0 {
+		return "", fmt.Errorf("runs-on must resolve to at least one label")
+	}
+	var queue string
+	for _, label := range labels {
+		normalized := strings.ToLower(strings.TrimSpace(label))
+		if unsupportedOS(normalized) {
+			return "", fmt.Errorf("unsupported operating system runner label %q", label)
+		}
+		mapped, ok := policy.Labels[normalized]
+		if !ok {
+			for configured, candidate := range policy.Labels {
+				if strings.ToLower(strings.TrimSpace(configured)) == normalized {
+					mapped, ok = candidate, true
+					break
+				}
+			}
+		}
+		if !ok {
+			return "", fmt.Errorf("runner label %q is not mapped by policy", label)
+		}
+		if queue != "" && queue != mapped {
+			return "", fmt.Errorf("runner labels resolve to conflicting queues %q and %q", queue, mapped)
+		}
+		queue = mapped
+	}
+	if trust == EventUntrusted && !contains(policy.UntrustedQueues, queue) {
+		allowlist := append([]string(nil), policy.UntrustedQueues...)
+		sort.Strings(allowlist)
+		return "", fmt.Errorf("untrusted event cannot target queue %q; allowed queues: %s", queue, strings.Join(allowlist, ", "))
+	}
+	return queue, nil
+}
+
+func unsupportedOS(label string) bool {
+	return strings.HasPrefix(label, "windows-") || strings.HasPrefix(label, "macos-") || label == "windows" || label == "macos"
+}
+
+func contains(values []string, wanted string) bool {
+	for _, value := range values {
+		if value == wanted {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/compiler/config_test.go
+++ b/internal/compiler/config_test.go
@@ -1,0 +1,207 @@
+package compiler
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestCompileOptionsSnapshotVarsWithDeterministicPrecedence(t *testing.T) {
+	workflow := []byte(`on: push
+jobs:
+  test:
+    runs-on: ${{ vars.RUNNER }}
+    strategy:
+      matrix:
+        version: ${{ fromJSON(vars.VERSIONS) }}
+    steps:
+      - run: true
+`)
+	options := Options{
+		EventTrust: EventTrusted,
+		Vars: VariableSources{
+			Bridge:    map[string]string{"runner": "ubuntu-22.04", "versions": `["bridge"]`, "SOURCE": "bridge"},
+			Provider:  map[string]string{"RUNNER": "ubuntu-24.04", "VERSIONS": `["provider"]`, "source": "provider"},
+			Buildkite: map[string]string{"VERSIONS": `[12,"14"]`, "SOURCE": "buildkite"},
+		},
+		Runners: RunnerPolicy{Labels: map[string]string{"ubuntu-24.04": "linux-trusted"}},
+	}
+	first, err := CompileWithOptions("vars.yml", workflow, pushEvent(t), options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := CompileWithOptions("vars.yml", workflow, pushEvent(t), options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Fatal("repeated compilation with the same snapshots was not byte-identical")
+	}
+	var ir IR
+	if err := json.Unmarshal(first, &ir); err != nil {
+		t.Fatal(err)
+	}
+	wantVars := map[string]string{"RUNNER": "ubuntu-24.04", "VERSIONS": `[12,"14"]`, "SOURCE": "buildkite"}
+	if !reflect.DeepEqual(ir.Vars, wantVars) {
+		t.Fatalf("vars snapshot = %#v, want %#v", ir.Vars, wantVars)
+	}
+	if len(ir.Jobs) != 2 || ir.Jobs[0].Queue != "linux-trusted" || ir.Jobs[0].Matrix["version"] != float64(12) || ir.Jobs[1].Matrix["version"] != "14" {
+		t.Fatalf("compiled jobs = %#v", ir.Jobs)
+	}
+}
+
+func TestCompileOptionsRejectCaseCollisionsWithinOneVarsSource(t *testing.T) {
+	workflow := []byte("on: push\njobs:\n  test:\n    runs-on: ubuntu-24.04\n    steps:\n      - run: true\n")
+	_, err := CompileWithOptions("vars.yml", workflow, pushEvent(t), Options{
+		EventTrust: EventTrusted,
+		Vars:       VariableSources{Bridge: map[string]string{"Deploy_Env": "one", "DEPLOY_ENV": "two"}},
+		Runners:    RunnerPolicy{Labels: map[string]string{"ubuntu-24.04": "linux"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "bridge vars source contains case-colliding names") {
+		t.Fatalf("CompileWithOptions() error = %v, want vars collision", err)
+	}
+}
+
+func TestRunsOnPolicySeparatesTrustedAndUntrustedEvents(t *testing.T) {
+	workflow := []byte("on: push\njobs:\n  test:\n    runs-on: ubuntu-24.04\n    steps:\n      - run: true\n")
+	policy := RunnerPolicy{Labels: map[string]string{"ubuntu-24.04": "linux-privileged"}}
+	trusted := Options{EventTrust: EventTrusted, Runners: policy}
+	if _, err := CompileWithOptions("trusted.yml", workflow, pushEvent(t), trusted); err != nil {
+		t.Fatalf("trusted compilation failed: %v", err)
+	}
+
+	untrusted := Options{EventTrust: EventUntrusted, Runners: policy}
+	_, err := CompileWithOptions("untrusted.yml", workflow, pushEvent(t), untrusted)
+	if err == nil || !strings.Contains(err.Error(), `untrusted event cannot target queue "linux-privileged"`) {
+		t.Fatalf("untrusted compilation error = %v", err)
+	}
+
+	policy.UntrustedQueues = []string{"linux-privileged"}
+	untrusted.Runners = policy
+	compiled, err := CompileWithOptions("untrusted.yml", workflow, pushEvent(t), untrusted)
+	if err != nil {
+		t.Fatalf("allowlisted untrusted compilation failed: %v", err)
+	}
+	var ir IR
+	if err := json.Unmarshal(compiled, &ir); err != nil {
+		t.Fatal(err)
+	}
+	if ir.Event.Trust != EventUntrusted || ir.Jobs[0].Queue != "linux-privileged" {
+		t.Fatalf("untrusted compiler output = %#v", ir)
+	}
+}
+
+func TestCompileEvaluatesGitHubEventVarsAndMatrixForRunsOn(t *testing.T) {
+	workflow := []byte(`on: push
+jobs:
+  test:
+    strategy:
+      matrix: ${{ fromJSON(vars.MATRIX) }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - run: true
+  event:
+    runs-on: runner-${{ github.event_name }}-${{ event.channel }}
+    steps:
+      - run: true
+`)
+	event := strings.Replace(string(pushEvent(t)), `"payload": {`, `"payload": {"channel":"stable",`, 1)
+	options := Options{
+		EventTrust: EventTrusted,
+		Vars:       VariableSources{Bridge: map[string]string{"MATRIX": `{"os":["ubuntu-22.04","ubuntu-24.04"]}`}},
+		Runners: RunnerPolicy{Labels: map[string]string{
+			"ubuntu-22.04":       "linux",
+			"ubuntu-24.04":       "linux",
+			"runner-push-stable": "event-linux",
+		}},
+	}
+	compiled, err := CompileWithOptions("contexts.yml", workflow, []byte(event), options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ir IR
+	if err := json.Unmarshal(compiled, &ir); err != nil {
+		t.Fatal(err)
+	}
+	if len(ir.Jobs) != 3 || ir.Jobs[0].Queue != "event-linux" || ir.Jobs[1].Queue != "linux" || ir.Jobs[2].Queue != "linux" {
+		t.Fatalf("context-selected queues = %#v", ir.Jobs)
+	}
+}
+
+func TestRunsOnPolicyFailsClosedWithLocatedDiagnostics(t *testing.T) {
+	tests := []struct {
+		name   string
+		runsOn string
+		vars   map[string]string
+		labels map[string]string
+		want   string
+	}{
+		{name: "unsupported operating system", runsOn: "windows-latest", labels: map[string]string{"windows-latest": "windows"}, want: `unsupported operating system runner label "windows-latest"`},
+		{name: "unmapped label", runsOn: "ubuntu-20.04", labels: map[string]string{"ubuntu-24.04": "linux"}, want: `runner label "ubuntu-20.04" is not mapped by policy`},
+		{name: "unresolved expression", runsOn: "${{ vars.RUNNER }}", labels: map[string]string{"ubuntu-24.04": "linux"}, want: `unavailable value "vars.runner"`},
+		{name: "conflicting labels", runsOn: "[self-hosted, linux]", labels: map[string]string{"self-hosted": "one", "linux": "two"}, want: "runner labels resolve to conflicting queues"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			workflow := []byte("on: push\njobs:\n  test:\n    runs-on: " + test.runsOn + "\n    steps:\n      - run: true\n")
+			_, err := CompileWithOptions("policy.yml", workflow, pushEvent(t), Options{
+				EventTrust: EventTrusted,
+				Vars:       VariableSources{Bridge: test.vars},
+				Runners:    RunnerPolicy{Labels: test.labels},
+			})
+			if err == nil || !strings.Contains(err.Error(), test.want) || !strings.Contains(err.Error(), "policy.yml:") {
+				t.Fatalf("CompileWithOptions() error = %v, want located %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestDefaultCompilePolicyIsUntrustedAndFixedToTokenlessQueue(t *testing.T) {
+	workflow := []byte("on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n")
+	compiled, err := Compile("default.yml", workflow, pushEvent(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ir IR
+	if err := json.Unmarshal(compiled, &ir); err != nil {
+		t.Fatal(err)
+	}
+	if ir.Event.Trust != EventUntrusted || ir.Jobs[0].Queue != "gha-untrusted" {
+		t.Fatalf("default compiler trust boundary = event %q, queue %q", ir.Event.Trust, ir.Jobs[0].Queue)
+	}
+	_, err = CompilePlans("default.yml", workflow, pushEvent(t), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "privileged")
+	if err == nil || !strings.Contains(err.Error(), `unattested event snapshots may only target queue "gha-untrusted"`) {
+		t.Fatalf("CompilePlans() privileged default error = %v", err)
+	}
+}
+
+func TestCompilePlansUsePolicyQueueAndContainOnlyNonSecretVars(t *testing.T) {
+	t.Setenv("BUILDKITE_GHA_TEST_SECRET", "resolved-secret-value")
+	workflow := []byte("on: push\njobs:\n  test:\n    runs-on: ubuntu-24.04\n    steps:\n      - run: echo '${{ secrets.TOKEN }}'\n")
+	options := Options{
+		EventTrust: EventTrusted,
+		Vars:       VariableSources{Bridge: map[string]string{"PUBLIC": "snapshotted"}},
+		Runners:    RunnerPolicy{Labels: map[string]string{"ubuntu-24.04": "linux"}},
+	}
+	plans, err := CompilePlansWithOptions("plan.yml", workflow, pushEvent(t), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 1 || plans[0].Target.Queue != "linux" || plans[0].Vars["PUBLIC"] != "snapshotted" {
+		t.Fatalf("compiled plans = %#v", plans)
+	}
+	encoded, err := json.Marshal(plans)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(encoded, []byte("resolved-secret-value")) || !bytes.Contains(encoded, []byte(`${{ secrets.TOKEN }}`)) {
+		t.Fatalf("plan contains resolved secret material: %s", encoded)
+	}
+}
+
+func pushEvent(t *testing.T) []byte {
+	t.Helper()
+	return readFile(t, smokePath("events", "push.json"))
+}

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -1,0 +1,661 @@
+package compiler
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/buildkite/buildkite-gha/internal/expression"
+	"github.com/buildkite/buildkite-gha/internal/workflow"
+)
+
+const (
+	maxReusableWorkflowDepth = 4
+	maxFlattenedJobs         = 1024
+)
+
+var staticInputExpression = regexp.MustCompile(`\$\{\{\s*inputs\.([A-Za-z_][A-Za-z0-9_-]*)\s*\}\}`)
+var staticValueExpression = regexp.MustCompile(`^\s*\$\{\{\s*(inputs|matrix)\.([A-Za-z_][A-Za-z0-9_-]*)\s*\}\}\s*$`)
+
+type sourcedJob struct {
+	workflow.Job
+	path   string
+	digest string
+}
+
+type reusableResolver struct {
+	root     string
+	stack    []string
+	expanded int
+}
+
+func resolveReusableWorkflows(path string, source []byte, parsed *workflow.Workflow) ([]sourcedJob, error) {
+	digest := "sha256:" + sha256Sum(source)
+	if !hasReusableCall(parsed) {
+		jobs := make([]sourcedJob, len(parsed.Jobs))
+		for i, job := range parsed.Jobs {
+			jobs[i] = sourcedJob{Job: job, path: path, digest: digest}
+		}
+		return jobs, nil
+	}
+
+	root, canonicalPath, err := workflowRepository(path)
+	if err != nil {
+		return nil, err
+	}
+	resolver := reusableResolver{root: root, stack: []string{canonicalPath}}
+	return resolver.resolve(path, digest, parsed, "", "", nil, nil, 0)
+}
+
+func hasReusableCall(parsed *workflow.Workflow) bool {
+	for _, job := range parsed.Jobs {
+		if job.Reusable != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func (resolver *reusableResolver) resolve(path, digest string, parsed *workflow.Workflow, namespace, labelPrefix string, inputs map[string]any, externalNeeds []string, depth int) ([]sourcedJob, error) {
+	jobs := make(map[string]workflow.Job, len(parsed.Jobs))
+	for _, job := range parsed.Jobs {
+		jobs[job.ID] = job
+	}
+	order, err := topologicalOrder(path, jobs)
+	if err != nil {
+		return nil, err
+	}
+
+	replacements := make(map[string][]string, len(jobs))
+	var resolved []sourcedJob
+	for _, id := range order {
+		job := jobs[id]
+		job = applyStaticInputs(job, inputs)
+		if parsed.Callable {
+			if err := rejectUnresolvedInputExpressions(path, job); err != nil {
+				return nil, err
+			}
+		}
+		if job.Reusable != nil {
+			if err := rejectCallMatrixExpressions(path, job); err != nil {
+				return nil, err
+			}
+		}
+		needs := replacementNeeds(job.Needs, replacements)
+		if len(job.Needs) == 0 {
+			needs = append(needs, externalNeeds...)
+			sort.Strings(needs)
+		}
+		if job.Reusable == nil {
+			job.ID = namespacedJobID(namespace, job.ID)
+			job.Needs = needs
+			if labelPrefix != "" {
+				name := job.Name
+				if name == "" {
+					name = id
+				}
+				job.Name = labelPrefix + " / " + name
+			}
+			resolver.expanded++
+			if resolver.expanded > maxFlattenedJobs {
+				return nil, jobError(path, job, fmt.Sprintf("reusable-workflow graph expands beyond %d jobs", maxFlattenedJobs))
+			}
+			resolved = append(resolved, sourcedJob{Job: job, path: path, digest: digest})
+			replacements[id] = []string{job.ID}
+			continue
+		}
+
+		call := job.Reusable
+		if call.Secrets || call.InheritSecrets {
+			return nil, locatedJobError(path, job, call.Span.Start.Line, call.Span.Start.Column, "reusable-workflow secrets are runtime-dependent and unsupported")
+		}
+		if depth >= maxReusableWorkflowDepth {
+			return nil, locatedJobError(path, job, call.Span.Start.Line, call.Span.Start.Column, fmt.Sprintf("reusable-workflow nesting exceeds maximum depth %d", maxReusableWorkflowDepth))
+		}
+		calleePath, err := resolver.localWorkflowPath(call.Uses)
+		if err != nil {
+			return nil, locatedJobError(path, job, call.Span.Start.Line, call.Span.Start.Column, err.Error())
+		}
+		if cycle := resolver.cycle(calleePath); cycle != "" {
+			return nil, locatedJobError(path, job, call.Span.Start.Line, call.Span.Start.Column, "reusable-workflow cycle detected: "+cycle)
+		}
+		source, err := os.ReadFile(calleePath)
+		if err != nil {
+			return nil, locatedJobError(path, job, call.Span.Start.Line, call.Span.Start.Column, fmt.Sprintf("read local reusable workflow %q: %v", call.Uses, err))
+		}
+		callee, err := workflow.Parse(calleePath, source)
+		if err != nil {
+			return nil, err
+		}
+		if !callee.Callable {
+			return nil, locatedJobError(path, job, call.Span.Start.Line, call.Span.Start.Column, fmt.Sprintf("local reusable workflow %q does not declare on.workflow_call", call.Uses))
+		}
+		if len(callee.RequiredCallSecrets) != 0 {
+			return nil, locatedJobError(path, job, call.Span.Start.Line, call.Span.Start.Column, fmt.Sprintf("local reusable workflow %q requires unsupported secret %q", call.Uses, callee.RequiredCallSecrets[0]))
+		}
+		calleeSourcePath, err := filepath.Rel(resolver.root, calleePath)
+		if err != nil {
+			return nil, locatedJobError(path, job, call.Span.Start.Line, call.Span.Start.Column, fmt.Sprintf("locate local reusable workflow %q: %v", call.Uses, err))
+		}
+		calleeSourcePath = "./" + filepath.ToSlash(calleeSourcePath)
+		calleeDigest := "sha256:" + sha256Sum(source)
+
+		matrices, err := expandMatrix(path, job, expression.CompileContext{})
+		if err != nil {
+			return nil, err
+		}
+		var terminals []string
+		callNamespaces := make(map[string]struct{}, len(matrices))
+		for _, matrix := range matrices {
+			callInputs, err := resolveCallInputs(path, job, call, callee, inputs, matrix)
+			if err != nil {
+				return nil, err
+			}
+			component := job.ID
+			if len(matrices) > 1 {
+				suffix, err := matrixDigest(matrix)
+				if err != nil {
+					return nil, jobError(path, job, fmt.Sprintf("namespace reusable-workflow matrix: %v", err))
+				}
+				component += "-" + suffix
+			}
+			callNamespace := namespacedJobID(namespace, component)
+			if _, exists := callNamespaces[callNamespace]; exists {
+				return nil, jobError(path, job, fmt.Sprintf("reusable-workflow matrix produces duplicate namespace %q", callNamespace))
+			}
+			callNamespaces[callNamespace] = struct{}{}
+			callLabel := job.Name
+			if callLabel == "" {
+				callLabel = job.ID
+			}
+			if len(matrix) != 0 {
+				callLabel = instanceLabel(job, matrix)
+			}
+			if labelPrefix != "" {
+				callLabel = labelPrefix + " / " + callLabel
+			}
+
+			resolver.stack = append(resolver.stack, calleePath)
+			calleeJobs, err := resolver.resolve(calleeSourcePath, calleeDigest, callee, callNamespace, callLabel, callInputs, needs, depth+1)
+			resolver.stack = resolver.stack[:len(resolver.stack)-1]
+			if err != nil {
+				return nil, err
+			}
+			resolved = append(resolved, calleeJobs...)
+			terminals = append(terminals, terminalJobIDs(calleeJobs)...)
+		}
+		sort.Strings(terminals)
+		replacements[id] = terminals
+	}
+	return resolved, nil
+}
+
+func replacementNeeds(needs []string, replacements map[string][]string) []string {
+	var out []string
+	for _, need := range needs {
+		out = append(out, replacements[need]...)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func terminalJobIDs(jobs []sourcedJob) []string {
+	needed := make(map[string]struct{})
+	for _, job := range jobs {
+		for _, need := range job.Needs {
+			needed[need] = struct{}{}
+		}
+	}
+	var terminals []string
+	for _, job := range jobs {
+		if _, ok := needed[job.ID]; !ok {
+			terminals = append(terminals, job.ID)
+		}
+	}
+	sort.Strings(terminals)
+	return terminals
+}
+
+func namespacedJobID(namespace, id string) string {
+	if namespace == "" {
+		return id
+	}
+	return namespace + "." + id
+}
+
+func resolveCallInputs(path string, job workflow.Job, call *workflow.ReusableWorkflowCall, callee *workflow.Workflow, parentInputs, matrix map[string]any) (map[string]any, error) {
+	values := make(map[string]any, len(call.Inputs))
+	for _, name := range sortedValueKeys(call.Inputs) {
+		value := call.Inputs[name]
+		if _, ok := callee.CallInputs[name]; !ok {
+			return nil, locatedJobError(path, job, value.Span.Start.Line, value.Span.Start.Column, fmt.Sprintf("input %q is not declared by reusable workflow %q", name, call.Uses))
+		}
+		resolved := value.Data
+		if text, ok := resolved.(string); ok && strings.Contains(text, "${{") {
+			var err error
+			resolved, err = evaluateStaticCallValue(text, parentInputs, matrix)
+			if err != nil {
+				return nil, locatedJobError(path, job, value.Span.Start.Line, value.Span.Start.Column, fmt.Sprintf("reusable-workflow input %q is not statically resolvable: %v", name, err))
+			}
+		}
+		values[name] = resolved
+	}
+
+	resolved := make(map[string]any, len(callee.CallInputs))
+	for _, name := range sortedValueKeys(callee.CallInputs) {
+		declaration := callee.CallInputs[name]
+		value, supplied := values[name]
+		ok := supplied
+		if !ok && declaration.Default != nil {
+			value, ok = declaration.Default.Data, true
+			if text, isString := value.(string); isString && strings.Contains(text, "${{") {
+				return nil, locatedJobError(call.Uses, job, declaration.Default.Span.Start.Line, declaration.Default.Span.Start.Column, fmt.Sprintf("default for reusable-workflow input %q is not statically resolvable", name))
+			}
+		}
+		if !ok {
+			if declaration.Required {
+				return nil, locatedJobError(path, job, call.Span.Start.Line, call.Span.Start.Column, fmt.Sprintf("required reusable-workflow input %q is missing", name))
+			}
+			value = zeroInputValue(declaration.Type)
+		}
+		if !inputTypeMatches(declaration.Type, value) {
+			locationPath := path
+			span := call.Span
+			if supplied {
+				span = call.Inputs[name].Span
+			} else if declaration.Default != nil {
+				locationPath = call.Uses
+				span = declaration.Default.Span
+			}
+			return nil, locatedJobError(locationPath, job, span.Start.Line, span.Start.Column, fmt.Sprintf("reusable-workflow input %q must be %s", name, declaration.Type))
+		}
+		if containsExpression(value) {
+			return nil, locatedJobError(path, job, call.Span.Start.Line, call.Span.Start.Column, fmt.Sprintf("reusable-workflow input %q is not statically resolvable", name))
+		}
+		resolved[name] = value
+	}
+	return resolved, nil
+}
+
+func evaluateStaticCallValue(value string, inputs, matrix map[string]any) (any, error) {
+	if match := staticValueExpression.FindStringSubmatch(value); match != nil {
+		values := inputs
+		if match[1] == "matrix" {
+			values = matrix
+		}
+		for name, value := range values {
+			if strings.EqualFold(name, match[2]) {
+				if containsExpression(value) {
+					return nil, fmt.Errorf("expression references runtime-dependent %s value %q", match[1], match[2])
+				}
+				return value, nil
+			}
+		}
+		return nil, fmt.Errorf("expression references unavailable %s value %q", match[1], match[2])
+	}
+	resolved := replaceStaticInputs(value, inputs)
+	if hasInputExpression(resolved) {
+		return nil, fmt.Errorf("expression references an unavailable or unsupported input")
+	}
+	return expression.Evaluate(resolved, expression.Context{Matrix: matrix})
+}
+
+func containsExpression(value any) bool {
+	switch value := value.(type) {
+	case string:
+		return strings.Contains(value, "${{")
+	case []any:
+		for _, element := range value {
+			if containsExpression(element) {
+				return true
+			}
+		}
+	case map[string]any:
+		for _, element := range value {
+			if containsExpression(element) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func sortedValueKeys[V any](values map[string]V) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func zeroInputValue(inputType string) any {
+	if inputType == "boolean" {
+		return false
+	}
+	if inputType == "number" {
+		return 0
+	}
+	return ""
+}
+
+func inputTypeMatches(inputType string, value any) bool {
+	switch inputType {
+	case "boolean":
+		_, ok := value.(bool)
+		return ok
+	case "number":
+		switch value.(type) {
+		case int, int64, uint64, float64, json.Number:
+			return true
+		default:
+			return false
+		}
+	case "string":
+		_, ok := value.(string)
+		return ok
+	default:
+		return false
+	}
+}
+
+func applyStaticInputs(job workflow.Job, inputs map[string]any) workflow.Job {
+	if len(inputs) == 0 {
+		return job
+	}
+	job.Name = replaceStaticInputs(job.Name, inputs)
+	job.DefaultShell = replaceStaticInputs(job.DefaultShell, inputs)
+	job.DefaultWorkingDirectory = replaceStaticInputs(job.DefaultWorkingDirectory, inputs)
+	job.Env = replaceMapInputs(job.Env, inputs)
+	job.Outputs = replaceMapInputs(job.Outputs, inputs)
+	job.RunsOn = append([]string(nil), job.RunsOn...)
+	for i := range job.RunsOn {
+		job.RunsOn[i] = replaceStaticInputs(job.RunsOn[i], inputs)
+	}
+	if job.RunsOnExpr != nil {
+		resolved := replaceStaticInputs(job.RunsOnExpr.Text, inputs)
+		if !strings.Contains(resolved, "${{") {
+			job.RunsOn = []string{resolved}
+			job.RunsOnExpr = nil
+		} else {
+			expr := *job.RunsOnExpr
+			expr.Text = resolved
+			job.RunsOnExpr = &expr
+		}
+	}
+	if job.Matrix != nil {
+		job.Matrix = cloneMatrixWithInputs(job.Matrix, inputs)
+	}
+	job.Steps = append([]workflow.Step(nil), job.Steps...)
+	for i := range job.Steps {
+		step := &job.Steps[i]
+		step.Name = replaceStaticInputs(step.Name, inputs)
+		step.Run = replaceStaticInputs(step.Run, inputs)
+		step.Uses = replaceStaticInputs(step.Uses, inputs)
+		step.Shell = replaceStaticInputs(step.Shell, inputs)
+		step.WorkingDirectory = replaceStaticInputs(step.WorkingDirectory, inputs)
+		step.Env = replaceMapInputs(step.Env, inputs)
+		step.With = replaceMapInputs(step.With, inputs)
+	}
+	return job
+}
+
+func rejectUnresolvedInputExpressions(path string, job workflow.Job) error {
+	jobValues := []string{job.Name, job.DefaultShell, job.DefaultWorkingDirectory}
+	jobValues = append(jobValues, job.RunsOn...)
+	jobValues = appendMapValues(jobValues, job.Env)
+	jobValues = appendMapValues(jobValues, job.Outputs)
+	if job.RunsOnExpr != nil {
+		jobValues = append(jobValues, job.RunsOnExpr.Text)
+	}
+	if job.Matrix != nil {
+		if job.Matrix.Expression != nil {
+			jobValues = append(jobValues, job.Matrix.Expression.Text)
+		}
+		for _, row := range job.Matrix.Rows {
+			if row.Expression != nil {
+				jobValues = append(jobValues, row.Expression.Text)
+			}
+			for _, value := range row.Values {
+				if containsInputExpression(value.Data) {
+					return locatedJobError(path, job, value.Span.Start.Line, value.Span.Start.Column, "reusable-workflow input expression is not statically resolvable")
+				}
+			}
+		}
+		for _, combinations := range [][]workflow.MatrixCombination{job.Matrix.Include, job.Matrix.Exclude} {
+			for _, combination := range combinations {
+				for _, value := range combination.Values {
+					if containsInputExpression(value.Data) {
+						return locatedJobError(path, job, value.Span.Start.Line, value.Span.Start.Column, "reusable-workflow input expression is not statically resolvable")
+					}
+				}
+			}
+		}
+	}
+	for _, value := range jobValues {
+		if hasInputExpression(value) {
+			return jobError(path, job, "reusable-workflow input expression is not statically resolvable")
+		}
+	}
+	for _, step := range job.Steps {
+		stepValues := []string{step.Name, step.Run, step.Uses, step.Shell, step.WorkingDirectory, step.If}
+		stepValues = appendMapValues(stepValues, step.Env)
+		stepValues = appendMapValues(stepValues, step.With)
+		for _, value := range stepValues {
+			if hasInputExpression(value) {
+				return locatedJobError(path, job, step.Span.Start.Line, step.Span.Start.Column, "reusable-workflow input expression is not statically resolvable")
+			}
+		}
+	}
+	return nil
+}
+
+func rejectCallMatrixExpressions(path string, job workflow.Job) error {
+	if job.Matrix == nil {
+		return nil
+	}
+	for _, row := range job.Matrix.Rows {
+		for _, value := range row.Values {
+			if containsExpression(value.Data) {
+				return locatedJobError(path, job, value.Span.Start.Line, value.Span.Start.Column, "runtime-dependent reusable-workflow matrix value is unsupported")
+			}
+		}
+	}
+	for _, combinations := range [][]workflow.MatrixCombination{job.Matrix.Include, job.Matrix.Exclude} {
+		for _, combination := range combinations {
+			for _, value := range combination.Values {
+				if containsExpression(value.Data) {
+					return locatedJobError(path, job, value.Span.Start.Line, value.Span.Start.Column, "runtime-dependent reusable-workflow matrix value is unsupported")
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func appendMapValues(out []string, values map[string]string) []string {
+	for _, value := range values {
+		out = append(out, value)
+	}
+	return out
+}
+
+func containsInputExpression(value any) bool {
+	switch value := value.(type) {
+	case string:
+		return hasInputExpression(value)
+	case []any:
+		for _, element := range value {
+			if containsInputExpression(element) {
+				return true
+			}
+		}
+	case map[string]any:
+		for _, element := range value {
+			if containsInputExpression(element) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasInputExpression(value string) bool {
+	for {
+		start := strings.Index(value, "${{")
+		if start < 0 {
+			return false
+		}
+		value = value[start+3:]
+		end := strings.Index(value, "}}")
+		if end < 0 {
+			return false
+		}
+		if strings.Contains(strings.ToLower(value[:end]), "inputs.") {
+			return true
+		}
+		value = value[end+2:]
+	}
+}
+
+func cloneMatrixWithInputs(matrix *workflow.Matrix, inputs map[string]any) *workflow.Matrix {
+	out := *matrix
+	out.Rows = append([]workflow.MatrixRow(nil), matrix.Rows...)
+	for i := range out.Rows {
+		out.Rows[i].Values = append([]workflow.Value(nil), out.Rows[i].Values...)
+		for j := range out.Rows[i].Values {
+			if text, ok := out.Rows[i].Values[j].Data.(string); ok {
+				out.Rows[i].Values[j].Data = replaceStaticInputs(text, inputs)
+			}
+		}
+	}
+	out.Include = cloneMatrixCombinations(matrix.Include, inputs)
+	out.Exclude = cloneMatrixCombinations(matrix.Exclude, inputs)
+	return &out
+}
+
+func cloneMatrixCombinations(combinations []workflow.MatrixCombination, inputs map[string]any) []workflow.MatrixCombination {
+	out := make([]workflow.MatrixCombination, len(combinations))
+	for i, combination := range combinations {
+		out[i] = combination
+		out[i].Values = make(map[string]workflow.Value, len(combination.Values))
+		for name, value := range combination.Values {
+			if text, ok := value.Data.(string); ok {
+				value.Data = replaceStaticInputs(text, inputs)
+			}
+			out[i].Values[name] = value
+		}
+	}
+	return out
+}
+
+func replaceMapInputs(values map[string]string, inputs map[string]any) map[string]string {
+	if values == nil {
+		return nil
+	}
+	out := make(map[string]string, len(values))
+	for name, value := range values {
+		out[name] = replaceStaticInputs(value, inputs)
+	}
+	return out
+}
+
+func replaceStaticInputs(value string, inputs map[string]any) string {
+	return staticInputExpression.ReplaceAllStringFunc(value, func(match string) string {
+		parts := staticInputExpression.FindStringSubmatch(match)
+		for name, value := range inputs {
+			if strings.EqualFold(name, parts[1]) {
+				return fmt.Sprint(value)
+			}
+		}
+		return match
+	})
+}
+
+func workflowRepository(path string) (string, string, error) {
+	absPath, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return "", "", fmt.Errorf("resolve workflow path: %w", err)
+	}
+	workflowDir := filepath.Dir(absPath)
+	if filepath.Base(workflowDir) != "workflows" || filepath.Base(filepath.Dir(workflowDir)) != ".github" {
+		return "", "", fmt.Errorf("%s: local reusable workflows require the caller under .github/workflows", path)
+	}
+	root, err := filepath.EvalSymlinks(filepath.Dir(filepath.Dir(workflowDir)))
+	if err != nil {
+		return "", "", fmt.Errorf("resolve repository root for %q: %w", path, err)
+	}
+	canonicalPath, err := filepath.EvalSymlinks(absPath)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve workflow path %q: %w", path, err)
+	}
+	if err := requireWithinRepository(root, canonicalPath); err != nil {
+		return "", "", fmt.Errorf("resolve workflow path %q: %w", path, err)
+	}
+	return root, canonicalPath, nil
+}
+
+func (resolver *reusableResolver) localWorkflowPath(uses string) (string, error) {
+	if !strings.HasPrefix(uses, "./") {
+		return "", fmt.Errorf("reusable workflow %q is remote or runtime-dependent; only repository-local ./ paths are supported", uses)
+	}
+	relative := filepath.Clean(filepath.FromSlash(strings.TrimPrefix(uses, "./")))
+	if filepath.Dir(relative) != filepath.Join(".github", "workflows") {
+		return "", fmt.Errorf("local reusable workflow %q must name a file directly under .github/workflows", uses)
+	}
+	candidate := filepath.Join(resolver.root, relative)
+	if err := requireWithinRepository(resolver.root, candidate); err != nil {
+		return "", fmt.Errorf("resolve local reusable workflow %q: %w", uses, err)
+	}
+	resolved, err := filepath.EvalSymlinks(candidate)
+	if err != nil {
+		return "", fmt.Errorf("resolve local reusable workflow %q: %w", uses, err)
+	}
+	if err := requireWithinRepository(resolver.root, resolved); err != nil {
+		return "", fmt.Errorf("resolve local reusable workflow %q: %w", uses, err)
+	}
+	return resolved, nil
+}
+
+func requireWithinRepository(root, path string) error {
+	relative, err := filepath.Rel(root, path)
+	if err != nil {
+		return err
+	}
+	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("resolved path %q escapes repository root %q", path, root)
+	}
+	return nil
+}
+
+func (resolver *reusableResolver) cycle(path string) string {
+	for i, existing := range resolver.stack {
+		if existing == path {
+			chain := append(append([]string(nil), resolver.stack[i:]...), path)
+			for j := range chain {
+				chain[j] = filepath.ToSlash(strings.TrimPrefix(chain[j], resolver.root+string(filepath.Separator)))
+			}
+			return strings.Join(chain, " -> ")
+		}
+	}
+	return ""
+}
+
+func matrixDigest(matrix map[string]any) (string, error) {
+	canonical, err := json.Marshal(matrix)
+	if err != nil {
+		return "", err
+	}
+	digest := sha256Sum(canonical)
+	return digest[:12], nil
+}
+
+func sha256Sum(value []byte) string {
+	digest := sha256.Sum256(value)
+	return fmt.Sprintf("%x", digest[:])
+}

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -26,6 +26,7 @@ type sourcedJob struct {
 	workflow.Job
 	path   string
 	digest string
+	root   string
 }
 
 type reusableResolver struct {
@@ -37,9 +38,22 @@ type reusableResolver struct {
 func resolveReusableWorkflows(path string, source []byte, parsed *workflow.Workflow) ([]sourcedJob, error) {
 	digest := "sha256:" + sha256Sum(source)
 	if !hasReusableCall(parsed) {
+		sourcePath := path
+		root := ""
+		if isRepositoryWorkflowPath(path) {
+			repositoryRoot, canonicalPath, err := workflowRepository(path)
+			if err != nil {
+				return nil, err
+			}
+			root = repositoryRoot
+			sourcePath, err = repositoryWorkflowPath(repositoryRoot, canonicalPath)
+			if err != nil {
+				return nil, err
+			}
+		}
 		jobs := make([]sourcedJob, len(parsed.Jobs))
 		for i, job := range parsed.Jobs {
-			jobs[i] = sourcedJob{Job: job, path: path, digest: digest}
+			jobs[i] = sourcedJob{Job: job, path: sourcePath, digest: digest, root: root}
 		}
 		return jobs, nil
 	}
@@ -48,8 +62,12 @@ func resolveReusableWorkflows(path string, source []byte, parsed *workflow.Workf
 	if err != nil {
 		return nil, err
 	}
+	sourcePath, err := repositoryWorkflowPath(root, canonicalPath)
+	if err != nil {
+		return nil, err
+	}
 	resolver := reusableResolver{root: root, stack: []string{canonicalPath}}
-	return resolver.resolve(path, digest, parsed, "", "", nil, nil, 0)
+	return resolver.resolve(sourcePath, digest, parsed, "", "", nil, nil, 0)
 }
 
 func hasReusableCall(parsed *workflow.Workflow) bool {
@@ -105,7 +123,7 @@ func (resolver *reusableResolver) resolve(path, digest string, parsed *workflow.
 			if resolver.expanded > maxFlattenedJobs {
 				return nil, jobError(path, job, fmt.Sprintf("reusable-workflow graph expands beyond %d jobs", maxFlattenedJobs))
 			}
-			resolved = append(resolved, sourcedJob{Job: job, path: path, digest: digest})
+			resolved = append(resolved, sourcedJob{Job: job, path: path, digest: digest, root: resolver.root})
 			replacements[id] = []string{job.ID}
 			continue
 		}
@@ -459,7 +477,13 @@ func rejectCallMatrixExpressions(path string, job workflow.Job) error {
 	if job.Matrix == nil {
 		return nil
 	}
+	if job.Matrix.Expression != nil {
+		return locatedJobError(path, job, job.Matrix.Expression.Span.Start.Line, job.Matrix.Expression.Span.Start.Column, "expression-valued reusable-workflow matrices are unsupported")
+	}
 	for _, row := range job.Matrix.Rows {
+		if row.Expression != nil {
+			return locatedJobError(path, job, row.Expression.Span.Start.Line, row.Expression.Span.Start.Column, fmt.Sprintf("expression-valued reusable-workflow matrix dimension %q is unsupported", row.Name))
+		}
 		for _, value := range row.Values {
 			if containsExpression(value.Data) {
 				return locatedJobError(path, job, value.Span.Start.Line, value.Span.Start.Column, "runtime-dependent reusable-workflow matrix value is unsupported")
@@ -577,6 +601,11 @@ func replaceStaticInputs(value string, inputs map[string]any) string {
 	})
 }
 
+func isRepositoryWorkflowPath(path string) bool {
+	workflowDir := filepath.Dir(filepath.Clean(path))
+	return filepath.Base(workflowDir) == "workflows" && filepath.Base(filepath.Dir(workflowDir)) == ".github"
+}
+
 func workflowRepository(path string) (string, string, error) {
 	absPath, err := filepath.Abs(filepath.Clean(path))
 	if err != nil {
@@ -586,18 +615,37 @@ func workflowRepository(path string) (string, string, error) {
 	if filepath.Base(workflowDir) != "workflows" || filepath.Base(filepath.Dir(workflowDir)) != ".github" {
 		return "", "", fmt.Errorf("%s: local reusable workflows require the caller under .github/workflows", path)
 	}
-	root, err := filepath.EvalSymlinks(filepath.Dir(filepath.Dir(workflowDir)))
+	repositoryDir := filepath.Dir(filepath.Dir(workflowDir))
+	root, err := filepath.EvalSymlinks(repositoryDir)
 	if err != nil {
 		return "", "", fmt.Errorf("resolve repository root for %q: %w", path, err)
 	}
 	canonicalPath, err := filepath.EvalSymlinks(absPath)
 	if err != nil {
-		return "", "", fmt.Errorf("resolve workflow path %q: %w", path, err)
+		if !os.IsNotExist(err) {
+			return "", "", fmt.Errorf("resolve workflow path %q: %w", path, err)
+		}
+		relative, relativeErr := filepath.Rel(repositoryDir, absPath)
+		if relativeErr != nil {
+			return "", "", fmt.Errorf("resolve workflow path %q: %w", path, relativeErr)
+		}
+		canonicalPath = filepath.Join(root, relative)
 	}
 	if err := requireWithinRepository(root, canonicalPath); err != nil {
 		return "", "", fmt.Errorf("resolve workflow path %q: %w", path, err)
 	}
 	return root, canonicalPath, nil
+}
+
+func repositoryWorkflowPath(root, canonicalPath string) (string, error) {
+	relative, err := filepath.Rel(root, canonicalPath)
+	if err != nil {
+		return "", fmt.Errorf("locate workflow %q in repository: %w", canonicalPath, err)
+	}
+	if err := requireWithinRepository(root, canonicalPath); err != nil {
+		return "", fmt.Errorf("locate workflow %q in repository: %w", canonicalPath, err)
+	}
+	return "./" + filepath.ToSlash(relative), nil
 }
 
 func (resolver *reusableResolver) localWorkflowPath(uses string) (string, error) {

--- a/internal/compiler/testdata/shell.pipeline.golden.yml
+++ b/internal/compiler/testdata/shell.pipeline.golden.yml
@@ -1,0 +1,47 @@
+steps:
+  - label: "producer"
+    key: "gha-producer"
+    command: "buildkite-gha run-job --plan .buildkite-gha/plans/2a9b179ecc1a074d2d29b02d2751f5b67137d16877c64459cad0b6dee9bcbde3.json"
+    agents:
+      queue: "gha-untrusted"
+    checkout:
+      skip: true
+    env:
+      BUILDKITE_GHA_PLAN_DIGEST: "sha256:2a9b179ecc1a074d2d29b02d2751f5b67137d16877c64459cad0b6dee9bcbde3"
+      BUILDKITE_GHA_PLAN_PATH: ".buildkite-gha/plans/2a9b179ecc1a074d2d29b02d2751f5b67137d16877c64459cad0b6dee9bcbde3.json"
+      BUILDKITE_GHA_PLAN_PRODUCER: "gha-importer"
+    depends_on:
+      - step: "gha-importer"
+        allow_failure: false
+  - label: "consumer (variant=one)"
+    key: "gha-consumer-5ebbc197d87b"
+    command: "buildkite-gha run-job --plan .buildkite-gha/plans/293f2a32d81db23b39190dcace7644d8b44f247c6727a477116f777cdc9b2b60.json"
+    agents:
+      queue: "gha-untrusted"
+    checkout:
+      skip: true
+    env:
+      BUILDKITE_GHA_PLAN_DIGEST: "sha256:293f2a32d81db23b39190dcace7644d8b44f247c6727a477116f777cdc9b2b60"
+      BUILDKITE_GHA_PLAN_PATH: ".buildkite-gha/plans/293f2a32d81db23b39190dcace7644d8b44f247c6727a477116f777cdc9b2b60.json"
+      BUILDKITE_GHA_PLAN_PRODUCER: "gha-importer"
+    depends_on:
+      - step: "gha-importer"
+        allow_failure: false
+      - step: "gha-producer"
+        allow_failure: true
+  - label: "consumer (variant=two)"
+    key: "gha-consumer-91934b28b00f"
+    command: "buildkite-gha run-job --plan .buildkite-gha/plans/aa6e9bd048cb5824912d2bfa18078e4045d3a2a41ce799f5ace943f894d8f77a.json"
+    agents:
+      queue: "gha-untrusted"
+    checkout:
+      skip: true
+    env:
+      BUILDKITE_GHA_PLAN_DIGEST: "sha256:aa6e9bd048cb5824912d2bfa18078e4045d3a2a41ce799f5ace943f894d8f77a"
+      BUILDKITE_GHA_PLAN_PATH: ".buildkite-gha/plans/aa6e9bd048cb5824912d2bfa18078e4045d3a2a41ce799f5ace943f894d8f77a.json"
+      BUILDKITE_GHA_PLAN_PRODUCER: "gha-importer"
+    depends_on:
+      - step: "gha-importer"
+        allow_failure: false
+      - step: "gha-producer"
+        allow_failure: true

--- a/internal/compiler/testdata/shell.plans.golden.json
+++ b/internal/compiler/testdata/shell.plans.golden.json
@@ -1,0 +1,148 @@
+[
+  {
+    "schema": "https://buildkite.com/schemas/buildkite-gha/job-plan-v1.schema.json",
+    "compiler": {
+      "version": "0.0.0-test",
+      "distribution_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+    },
+    "workflow": {
+      "path": "./.github/workflows/shell.yml",
+      "digest": "sha256:867a8bad267d5a4c135722f4651c6fa4e83f88ebab50bc0bdf5cf3f391e279ae",
+      "logical_job_id": "producer"
+    },
+    "event": {
+      "provider": "github",
+      "name": "push",
+      "payload_digest": "sha256:090ba1b9ca860d37bb4ca7492549a8a347caac3490f763399e6498622c9b47f9"
+    },
+    "target": {
+      "step_key": "gha-producer",
+      "queue": "gha-untrusted"
+    },
+    "required_capabilities": [],
+    "outputs": {
+      "result": "${{ steps.produce.outputs.result }}"
+    },
+    "steps": [
+      {
+        "id": "produce",
+        "name": "Produce bounded output",
+        "kind": "run",
+        "command": "echo \"result=smoke-shell\" \u003e\u003e \"$GITHUB_OUTPUT\"",
+        "shell": "bash",
+        "source": {
+          "start": {
+            "line": 15,
+            "column": 9
+          },
+          "end": {
+            "line": 15,
+            "column": 54
+          }
+        }
+      }
+    ]
+  },
+  {
+    "schema": "https://buildkite.com/schemas/buildkite-gha/job-plan-v1.schema.json",
+    "compiler": {
+      "version": "0.0.0-test",
+      "distribution_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+    },
+    "workflow": {
+      "path": "./.github/workflows/shell.yml",
+      "digest": "sha256:867a8bad267d5a4c135722f4651c6fa4e83f88ebab50bc0bdf5cf3f391e279ae",
+      "logical_job_id": "consumer"
+    },
+    "event": {
+      "provider": "github",
+      "name": "push",
+      "payload_digest": "sha256:090ba1b9ca860d37bb4ca7492549a8a347caac3490f763399e6498622c9b47f9"
+    },
+    "target": {
+      "step_key": "gha-consumer-5ebbc197d87b",
+      "queue": "gha-untrusted"
+    },
+    "required_capabilities": [],
+    "matrix": {
+      "variant": "one"
+    },
+    "dependencies": [
+      "gha-producer"
+    ],
+    "steps": [
+      {
+        "id": "step-1",
+        "name": "Consume bounded output",
+        "kind": "run",
+        "command": "test \"$RESULT\" = \"smoke-shell\"\nprintf 'SMOKE_OBSERVATION={\"result\":\"%s\",\"variant\":\"%s\"}\\n' \\\n  \"$RESULT\" \"$VARIANT\"\n",
+        "shell": "bash",
+        "env": {
+          "RESULT": "${{ needs.producer.outputs.result }}",
+          "VARIANT": "${{ matrix.variant }}"
+        },
+        "source": {
+          "start": {
+            "line": 28,
+            "column": 9
+          },
+          "end": {
+            "line": 31,
+            "column": 1
+          }
+        }
+      }
+    ]
+  },
+  {
+    "schema": "https://buildkite.com/schemas/buildkite-gha/job-plan-v1.schema.json",
+    "compiler": {
+      "version": "0.0.0-test",
+      "distribution_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+    },
+    "workflow": {
+      "path": "./.github/workflows/shell.yml",
+      "digest": "sha256:867a8bad267d5a4c135722f4651c6fa4e83f88ebab50bc0bdf5cf3f391e279ae",
+      "logical_job_id": "consumer"
+    },
+    "event": {
+      "provider": "github",
+      "name": "push",
+      "payload_digest": "sha256:090ba1b9ca860d37bb4ca7492549a8a347caac3490f763399e6498622c9b47f9"
+    },
+    "target": {
+      "step_key": "gha-consumer-91934b28b00f",
+      "queue": "gha-untrusted"
+    },
+    "required_capabilities": [],
+    "matrix": {
+      "variant": "two"
+    },
+    "dependencies": [
+      "gha-producer"
+    ],
+    "steps": [
+      {
+        "id": "step-1",
+        "name": "Consume bounded output",
+        "kind": "run",
+        "command": "test \"$RESULT\" = \"smoke-shell\"\nprintf 'SMOKE_OBSERVATION={\"result\":\"%s\",\"variant\":\"%s\"}\\n' \\\n  \"$RESULT\" \"$VARIANT\"\n",
+        "shell": "bash",
+        "env": {
+          "RESULT": "${{ needs.producer.outputs.result }}",
+          "VARIANT": "${{ matrix.variant }}"
+        },
+        "source": {
+          "start": {
+            "line": 28,
+            "column": 9
+          },
+          "end": {
+            "line": 31,
+            "column": 1
+          }
+        }
+      }
+    ]
+  }
+]

--- a/internal/expression/expression.go
+++ b/internal/expression/expression.go
@@ -2,7 +2,9 @@
 package expression
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/rhysd/actionlint"
@@ -34,15 +36,23 @@ type Context struct {
 	Needs  map[string]map[string]string
 }
 
+// CompileContext contains the non-secret values available while constructing
+// a workflow graph. Values are snapshots supplied by the compiler; evaluation
+// never reads the process environment or a secret provider.
+type CompileContext struct {
+	GitHub map[string]any
+	Event  map[string]any
+	Vars   map[string]string
+	Matrix map[string]any
+}
+
 // Parse validates a complete ${{ ... }} expression using actionlint and returns
 // an owned representation.
 func Parse(text string, line, column int) (Expression, error) {
-	trimmed := strings.TrimSpace(text)
-	if !strings.HasPrefix(trimmed, "${{") || !strings.HasSuffix(trimmed, "}}") {
-		return Expression{}, fmt.Errorf("expected a complete ${{ ... }} expression")
+	body, err := expressionBody(text)
+	if err != nil {
+		return Expression{}, err
 	}
-
-	body := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(trimmed, "${{"), "}}"))
 	parser := actionlint.NewExprParser()
 	if _, err := parser.Parse(actionlint.NewExprLexer(body + "}}")); err != nil {
 		return Expression{}, fmt.Errorf("invalid expression: %w", err)
@@ -55,6 +65,207 @@ func Parse(text string, line, column int) (Expression, error) {
 			End:   endPosition(line, column, text),
 		},
 	}, nil
+}
+
+// EvaluateCompile evaluates one complete graph-time expression. The supported
+// surface is intentionally limited to literals, github/event/vars/matrix
+// references, and fromJSON applied to one of those values.
+func EvaluateCompile(expr Expression, context CompileContext) (any, error) {
+	body, err := expressionBody(expr.Text)
+	if err != nil {
+		return nil, err
+	}
+	node, parseErr := actionlint.NewExprParser().Parse(actionlint.NewExprLexer(body + "}}"))
+	if parseErr != nil {
+		return nil, fmt.Errorf("invalid expression: %w", parseErr)
+	}
+	return evaluateCompileNode(node, context)
+}
+
+// EvaluateCompileTemplate substitutes supported graph-time expressions once.
+func EvaluateCompileTemplate(template string, context CompileContext) (string, error) {
+	const open, close = "${{", "}}"
+	var evaluated strings.Builder
+	remaining := template
+	for {
+		start := strings.Index(remaining, open)
+		if start < 0 {
+			evaluated.WriteString(remaining)
+			return evaluated.String(), nil
+		}
+		evaluated.WriteString(remaining[:start])
+		end := strings.Index(remaining[start+len(open):], close)
+		if end < 0 {
+			return "", fmt.Errorf("unterminated expression")
+		}
+		end += start + len(open)
+		text := remaining[start : end+len(close)]
+		value, err := EvaluateCompile(Expression{Text: text}, context)
+		if err != nil {
+			return "", err
+		}
+		switch value := value.(type) {
+		case nil:
+		case string:
+			evaluated.WriteString(value)
+		case bool, json.Number, float64, int:
+			fmt.Fprint(&evaluated, value)
+		default:
+			return "", fmt.Errorf("expression in runner label resolved to %T, want a scalar", value)
+		}
+		remaining = remaining[end+len(close):]
+	}
+}
+
+func expressionBody(text string) (string, error) {
+	trimmed := strings.TrimSpace(text)
+	if !strings.HasPrefix(trimmed, "${{") || !strings.HasSuffix(trimmed, "}}") {
+		return "", fmt.Errorf("expected a complete ${{ ... }} expression")
+	}
+	body := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(trimmed, "${{"), "}}"))
+	if strings.Contains(body, "}}") {
+		return "", fmt.Errorf("expression contains an embedded closing delimiter")
+	}
+	return body, nil
+}
+
+func evaluateCompileNode(node actionlint.ExprNode, context CompileContext) (any, error) {
+	switch node := node.(type) {
+	case *actionlint.NullNode:
+		return nil, nil
+	case *actionlint.BoolNode:
+		return node.Value, nil
+	case *actionlint.IntNode:
+		return node.Value, nil
+	case *actionlint.FloatNode:
+		return node.Value, nil
+	case *actionlint.StringNode:
+		return node.Value, nil
+	case *actionlint.VariableNode, *actionlint.ObjectDerefNode, *actionlint.IndexAccessNode:
+		root, path, err := referencePath(node)
+		if err != nil {
+			return nil, err
+		}
+		return resolveCompileReference(root, path, context)
+	case *actionlint.FuncCallNode:
+		if !strings.EqualFold(node.Callee, "fromJSON") || len(node.Args) != 1 {
+			return nil, fmt.Errorf("unsupported compile-time function %q", node.Callee)
+		}
+		value, err := evaluateCompileNode(node.Args[0], context)
+		if err != nil {
+			return nil, err
+		}
+		text, ok := value.(string)
+		if !ok {
+			return nil, fmt.Errorf("fromJSON argument resolved to %T, want string", value)
+		}
+		return decodeJSONValue(text)
+	default:
+		return nil, fmt.Errorf("unsupported compile-time expression")
+	}
+}
+
+func referencePath(node actionlint.ExprNode) (string, []string, error) {
+	switch node := node.(type) {
+	case *actionlint.VariableNode:
+		return node.Name, nil, nil
+	case *actionlint.ObjectDerefNode:
+		root, path, err := referencePath(node.Receiver)
+		return root, append(path, node.Property), err
+	case *actionlint.IndexAccessNode:
+		root, path, err := referencePath(node.Operand)
+		if err != nil {
+			return "", nil, err
+		}
+		index, ok := node.Index.(*actionlint.StringNode)
+		if !ok {
+			return "", nil, fmt.Errorf("compile-time index must be a string literal")
+		}
+		return root, append(path, index.Value), nil
+	default:
+		return "", nil, fmt.Errorf("unsupported compile-time reference")
+	}
+}
+
+func resolveCompileReference(root string, path []string, context CompileContext) (any, error) {
+	var current any
+	switch {
+	case strings.EqualFold(root, "github"):
+		current = context.GitHub
+	case strings.EqualFold(root, "event"):
+		current = context.Event
+	case strings.EqualFold(root, "vars"):
+		current = context.Vars
+	case strings.EqualFold(root, "matrix"):
+		current = context.Matrix
+	default:
+		return nil, fmt.Errorf("unsupported compile-time context %q", root)
+	}
+	for _, part := range path {
+		var (
+			ok  bool
+			err error
+		)
+		current, ok, err = objectValue(current, part)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, fmt.Errorf("compile-time expression references unavailable value %q", root+"."+strings.Join(path, "."))
+		}
+	}
+	return current, nil
+}
+
+func objectValue(value any, name string) (any, bool, error) {
+	switch value := value.(type) {
+	case map[string]any:
+		var (
+			found      any
+			matchedKey string
+		)
+		for candidate, item := range value {
+			if strings.EqualFold(candidate, name) {
+				if matchedKey != "" {
+					return nil, false, fmt.Errorf("compile-time object contains ambiguous properties %q and %q", matchedKey, candidate)
+				}
+				found, matchedKey = item, candidate
+			}
+		}
+		if matchedKey != "" {
+			return found, true, nil
+		}
+	case map[string]string:
+		var (
+			found      string
+			matchedKey string
+		)
+		for candidate, item := range value {
+			if strings.EqualFold(candidate, name) {
+				if matchedKey != "" {
+					return nil, false, fmt.Errorf("compile-time object contains ambiguous properties %q and %q", matchedKey, candidate)
+				}
+				found, matchedKey = item, candidate
+			}
+		}
+		if matchedKey != "" {
+			return found, true, nil
+		}
+	}
+	return nil, false, nil
+}
+
+func decodeJSONValue(source string) (any, error) {
+	decoder := json.NewDecoder(strings.NewReader(source))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, fmt.Errorf("fromJSON argument is invalid JSON: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return nil, fmt.Errorf("fromJSON argument contains multiple JSON values")
+	}
+	return value, nil
 }
 
 // Evaluate substitutes the supported Phase 0 expressions in a template once.

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -18,6 +18,11 @@ func TestParseUsesExpressionSyntaxFrontend(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "invalid expression") {
 		t.Fatalf("Parse() error = %v, want syntax error", err)
 	}
+
+	_, err = Parse("${{ vars.RUNNER }} }}", 1, 1)
+	if err == nil || !strings.Contains(err.Error(), "embedded closing delimiter") {
+		t.Fatalf("Parse() error = %v, want embedded delimiter rejection", err)
+	}
 }
 
 func TestEvaluateIsSinglePass(t *testing.T) {
@@ -68,6 +73,75 @@ func TestEvaluateFailsClosed(t *testing.T) {
 			_, err := Evaluate(test.template, Context{})
 			if err == nil || !strings.Contains(err.Error(), test.want) {
 				t.Fatalf("Evaluate() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestEvaluateCompileSupportsGraphContextsAndFromJSON(t *testing.T) {
+	context := CompileContext{
+		GitHub: map[string]any{"event_name": "push", "event": map[string]any{"action": "opened"}},
+		Event:  map[string]any{"action": "opened"},
+		Vars:   map[string]string{"RUNNERS": `["ubuntu-24.04","ubuntu-22.04"]`},
+		Matrix: map[string]any{"os": "ubuntu-24.04"},
+	}
+	tests := []struct {
+		expression string
+		want       any
+	}{
+		{expression: "${{ github.event_name }}", want: "push"},
+		{expression: "${{ github.event.action }}", want: "opened"},
+		{expression: "${{ event.action }}", want: "opened"},
+		{expression: "${{ matrix.os }}", want: "ubuntu-24.04"},
+	}
+	for _, test := range tests {
+		expr, err := Parse(test.expression, 1, 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, err := EvaluateCompile(expr, context)
+		if err != nil {
+			t.Fatalf("EvaluateCompile(%q) error = %v", test.expression, err)
+		}
+		if got != test.want {
+			t.Fatalf("EvaluateCompile(%q) = %#v, want %#v", test.expression, got, test.want)
+		}
+	}
+
+	expr, err := Parse("${{ fromJSON(vars.RUNNERS) }}", 1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := EvaluateCompile(expr, context)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runners, ok := got.([]any)
+	if !ok || len(runners) != 2 || runners[0] != "ubuntu-24.04" {
+		t.Fatalf("fromJSON runners = %#v", got)
+	}
+}
+
+func TestEvaluateCompileFailsClosed(t *testing.T) {
+	tests := []struct {
+		expression string
+		want       string
+	}{
+		{expression: "${{ secrets.TOKEN }}", want: `unsupported compile-time context "secrets"`},
+		{expression: "${{ vars.MISSING }}", want: `unavailable value "vars.missing"`},
+		{expression: "${{ hashFiles('go.sum') }}", want: `unsupported compile-time function "hashFiles"`},
+		{expression: "${{ fromJSON(vars.BAD) }}", want: "invalid JSON"},
+		{expression: "${{ event.Ref }}", want: "ambiguous properties"},
+	}
+	for _, test := range tests {
+		t.Run(test.expression, func(t *testing.T) {
+			expr, err := Parse(test.expression, 1, 1)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = EvaluateCompile(expr, CompileContext{Vars: map[string]string{"BAD": "["}, Event: map[string]any{"ref": "one", "REF": "two"}})
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("EvaluateCompile() error = %v, want %q", err, test.want)
 			}
 		})
 	}

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -75,6 +75,7 @@ type Job struct {
 	Target                  Target            `json:"target"`
 	RequiredCapabilities    []string          `json:"required_capabilities"`
 	Matrix                  map[string]any    `json:"matrix,omitempty"`
+	Vars                    map[string]string `json:"vars,omitempty"`
 	Needs                   map[string]Need   `json:"needs,omitempty"`
 	Env                     map[string]string `json:"env,omitempty"`
 	DefaultShell            string            `json:"default_shell,omitempty"`

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -76,6 +76,7 @@ type Job struct {
 	RequiredCapabilities    []string          `json:"required_capabilities"`
 	Matrix                  map[string]any    `json:"matrix,omitempty"`
 	Vars                    map[string]string `json:"vars,omitempty"`
+	Dependencies            []string          `json:"dependencies,omitempty"`
 	Needs                   map[string]Need   `json:"needs,omitempty"`
 	Env                     map[string]string `json:"env,omitempty"`
 	DefaultShell            string            `json:"default_shell,omitempty"`
@@ -216,6 +217,20 @@ func (job Job) Validate() error {
 			return fmt.Errorf("job plan repeats capability %q", capability)
 		}
 		capabilities[capability] = struct{}{}
+	}
+	if !sort.StringsAreSorted(job.Dependencies) {
+		return fmt.Errorf("job plan dependencies must be sorted")
+	}
+	dependencies := make(map[string]struct{}, len(job.Dependencies))
+	for _, dependency := range job.Dependencies {
+		if !targetPattern.MatchString(dependency) || strings.EqualFold(dependency, job.Target.StepKey) {
+			return fmt.Errorf("job plan contains invalid dependency %q", dependency)
+		}
+		id := strings.ToLower(dependency)
+		if _, exists := dependencies[id]; exists {
+			return fmt.Errorf("job plan repeats dependency %q", dependency)
+		}
+		dependencies[id] = struct{}{}
 	}
 	if len(job.Steps) == 0 {
 		return fmt.Errorf("job plan contains no steps")

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -59,6 +59,27 @@ func TestValidateRejectsAmbiguousSteps(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsInvalidStaticDependencies(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		dependencies []string
+		want         string
+	}{
+		{name: "unsorted", dependencies: []string{"gha-z", "gha-a"}, want: "must be sorted"},
+		{name: "duplicate", dependencies: []string{"gha-a", "gha-a"}, want: "repeats dependency"},
+		{name: "self", dependencies: []string{"gha-test"}, want: "invalid dependency"},
+		{name: "invalid", dependencies: []string{"gha/a"}, want: "invalid dependency"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			job := validJob()
+			job.Dependencies = test.dependencies
+			if err := job.Validate(); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Validate() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
 func TestPlanBoundaryRequiresConcreteCapabilities(t *testing.T) {
 	job := validJob()
 	job.RequiredCapabilities = nil

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -62,6 +62,9 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (Job
 			return JobResult{}, fmt.Errorf("capability %q is unsupported in the Phase 0 runtime", capability)
 		}
 	}
+	if len(job.Dependencies) != 0 {
+		return JobResult{}, fmt.Errorf("prerequisite result transport is not wired for this phase; refusing to run job with %d static dependencies", len(job.Dependencies))
+	}
 	if err := VerifyWorkflow(job, workspace); err != nil {
 		return JobResult{}, err
 	}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -20,6 +20,17 @@ import (
 	"github.com/buildkite/buildkite-gha/internal/plan"
 )
 
+func TestRunJobRejectsStaticDependenciesUntilResultTransportExists(t *testing.T) {
+	workspace := t.TempDir()
+	writeFixtureFile(t, workspace, ".github/workflows/test.yml", "name: dependency boundary\n")
+	job := runtimePlan(t, workspace, ".github/workflows/test.yml", []plan.Step{{ID: "run", Kind: "run", Command: "true"}})
+	job.Dependencies = []string{"gha-producer"}
+	job.Needs = map[string]plan.Need{"producer": {Result: "success"}}
+	if _, err := (Runner{}).RunJob(context.Background(), job, workspace); err == nil || !strings.Contains(err.Error(), "result transport is not wired") {
+		t.Fatalf("RunJob() error = %v, want fail-closed dependency boundary", err)
+	}
+}
+
 func TestJavaScriptPreMainPostFilesAndMasking(t *testing.T) {
 	node := requireNode24(t)
 	var logs bytes.Buffer

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -47,9 +47,15 @@ type Job struct {
 type Matrix struct {
 	Rows       []MatrixRow            `json:"rows,omitempty"`
 	Expression *expression.Expression `json:"expression,omitempty"`
-	HasInclude bool                   `json:"has_include,omitempty"`
-	HasExclude bool                   `json:"has_exclude,omitempty"`
+	Include    []MatrixCombination    `json:"include,omitempty"`
+	Exclude    []MatrixCombination    `json:"exclude,omitempty"`
 	Span       Span                   `json:"span"`
+}
+
+// MatrixCombination is one include or exclude entry with source-located values.
+type MatrixCombination struct {
+	Values map[string]Value `json:"values"`
+	Span   Span             `json:"span"`
 }
 
 // MatrixRow is one named matrix dimension.

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -17,11 +17,21 @@ type Span struct {
 
 // Workflow is the actionlint-independent syntax needed by the Phase 0 compiler.
 type Workflow struct {
-	Name                    string            `json:"name,omitempty"`
-	Env                     map[string]string `json:"env,omitempty"`
-	DefaultShell            string            `json:"default_shell,omitempty"`
-	DefaultWorkingDirectory string            `json:"default_working_directory,omitempty"`
-	Jobs                    []Job             `json:"jobs"`
+	Name                    string               `json:"name,omitempty"`
+	Env                     map[string]string    `json:"env,omitempty"`
+	DefaultShell            string               `json:"default_shell,omitempty"`
+	DefaultWorkingDirectory string               `json:"default_working_directory,omitempty"`
+	CallInputs              map[string]CallInput `json:"call_inputs,omitempty"`
+	RequiredCallSecrets     []string             `json:"required_call_secrets,omitempty"`
+	Callable                bool                 `json:"callable,omitempty"`
+	Jobs                    []Job                `json:"jobs"`
+}
+
+// CallInput declares one statically resolvable workflow_call input.
+type CallInput struct {
+	Type     string `json:"type"`
+	Required bool   `json:"required,omitempty"`
+	Default  *Value `json:"default,omitempty"`
 }
 
 // Job is one logical GitHub Actions job.
@@ -34,13 +44,22 @@ type Job struct {
 	Matrix                  *Matrix                `json:"matrix,omitempty"`
 	FailFast                *bool                  `json:"fail_fast,omitempty"`
 	MaxParallel             *int                   `json:"max_parallel,omitempty"`
-	Reusable                bool                   `json:"reusable_workflow,omitempty"`
+	Reusable                *ReusableWorkflowCall  `json:"reusable_workflow,omitempty"`
 	Env                     map[string]string      `json:"env,omitempty"`
 	Outputs                 map[string]string      `json:"outputs,omitempty"`
 	DefaultShell            string                 `json:"default_shell,omitempty"`
 	DefaultWorkingDirectory string                 `json:"default_working_directory,omitempty"`
 	Steps                   []Step                 `json:"steps"`
 	Span                    Span                   `json:"span"`
+}
+
+// ReusableWorkflowCall is a job-level invocation of another workflow.
+type ReusableWorkflowCall struct {
+	Uses           string           `json:"uses"`
+	Inputs         map[string]Value `json:"inputs,omitempty"`
+	Secrets        bool             `json:"secrets,omitempty"`
+	InheritSecrets bool             `json:"inherit_secrets,omitempty"`
+	Span           Span             `json:"span"`
 }
 
 // Matrix retains either static rows or a deferred expression.

--- a/internal/workflow/parse.go
+++ b/internal/workflow/parse.go
@@ -38,6 +38,29 @@ func Parse(path string, source []byte) (*Workflow, error) {
 			owned.DefaultWorkingDirectory = parsed.Defaults.Run.WorkingDirectory.Value
 		}
 	}
+	if call, ok := parsed.FindWorkflowCallEvent(); ok {
+		owned.Callable = true
+		if len(call.Inputs) != 0 {
+			owned.CallInputs = make(map[string]CallInput, len(call.Inputs))
+		}
+		for _, input := range call.Inputs {
+			ownedInput := CallInput{Type: workflowCallInputType(input.Type), Required: input.IsRequired()}
+			if input.Default != nil {
+				value := Value{Data: scalarAt(input.Default, scalars), Span: spanFrom(input.Default.Pos, input.Default.Value)}
+				ownedInput.Default = &value
+			}
+			owned.CallInputs[input.ID] = ownedInput
+		}
+		for name, secret := range call.Secrets {
+			if secret.Required != nil && secret.Required.Expression != nil {
+				return nil, locatedError(path, secret.Required.Expression.Pos, "workflow", fmt.Sprintf("expression-valued required flag for workflow_call secret %q is unsupported", name))
+			}
+			if secret.Required != nil && secret.Required.Value {
+				owned.RequiredCallSecrets = append(owned.RequiredCallSecrets, name)
+			}
+		}
+		sort.Strings(owned.RequiredCallSecrets)
+	}
 
 	ids := make([]string, 0, len(parsed.Jobs))
 	for id := range parsed.Jobs {
@@ -62,7 +85,25 @@ func Parse(path string, source []byte) (*Workflow, error) {
 }
 
 func adaptJob(path string, in *actionlint.Job, scalars map[Position]any) (Job, error) {
-	out := Job{ID: in.ID.Value, Reusable: in.WorkflowCall != nil, Span: pointSpan(in.Pos)}
+	out := Job{ID: in.ID.Value, Span: pointSpan(in.Pos)}
+	if in.WorkflowCall != nil {
+		call := in.WorkflowCall
+		out.Reusable = &ReusableWorkflowCall{
+			Uses:           call.Uses.Value,
+			Secrets:        len(call.Secrets) != 0,
+			InheritSecrets: call.InheritSecrets,
+			Span:           spanFrom(call.Uses.Pos, call.Uses.Value),
+		}
+		if len(call.Inputs) != 0 {
+			out.Reusable.Inputs = make(map[string]Value, len(call.Inputs))
+			for name, input := range call.Inputs {
+				out.Reusable.Inputs[name] = Value{
+					Data: scalarAt(input.Value, scalars),
+					Span: spanFrom(input.Value.Pos, input.Value.Value),
+				}
+			}
+		}
+	}
 	if in.If != nil {
 		return Job{}, locatedError(path, in.If.Pos, in.ID.Value, "job conditions are unsupported in the Phase 0 runtime")
 	}
@@ -116,10 +157,16 @@ func adaptJob(path string, in *actionlint.Job, scalars map[Position]any) (Job, e
 
 	if in.Strategy != nil {
 		if in.Strategy.FailFast != nil {
+			if in.Strategy.FailFast.Expression != nil {
+				return Job{}, locatedError(path, in.Strategy.FailFast.Expression.Pos, in.ID.Value, "expression-valued matrix fail-fast is unsupported")
+			}
 			v := in.Strategy.FailFast.Value
 			out.FailFast = &v
 		}
 		if in.Strategy.MaxParallel != nil {
+			if in.Strategy.MaxParallel.Expression != nil {
+				return Job{}, locatedError(path, in.Strategy.MaxParallel.Expression.Pos, in.ID.Value, "expression-valued matrix max-parallel is unsupported")
+			}
 			v := in.Strategy.MaxParallel.Value
 			out.MaxParallel = &v
 		}
@@ -144,9 +191,15 @@ func adaptJob(path string, in *actionlint.Job, scalars map[Position]any) (Job, e
 			owned.If = step.If.Value
 		}
 		if step.ContinueOnError != nil {
+			if step.ContinueOnError.Expression != nil {
+				return Job{}, locatedError(path, step.ContinueOnError.Expression.Pos, in.ID.Value, "expression-valued step continue-on-error is unsupported")
+			}
 			owned.ContinueOnError = step.ContinueOnError.Value
 		}
 		if step.TimeoutMinutes != nil {
+			if step.TimeoutMinutes.Expression != nil {
+				return Job{}, locatedError(path, step.TimeoutMinutes.Expression.Pos, in.ID.Value, "expression-valued step timeout-minutes is unsupported")
+			}
 			owned.TimeoutMinutes = step.TimeoutMinutes.Value
 		}
 		if step.Env != nil && step.Env.Expression != nil {
@@ -184,6 +237,26 @@ func adaptJob(path string, in *actionlint.Job, scalars map[Position]any) (Job, e
 		out.Span.End = owned.Span.End
 	}
 	return out, nil
+}
+
+func workflowCallInputType(inputType actionlint.WorkflowCallEventInputType) string {
+	switch inputType {
+	case actionlint.WorkflowCallEventInputTypeBoolean:
+		return "boolean"
+	case actionlint.WorkflowCallEventInputTypeNumber:
+		return "number"
+	case actionlint.WorkflowCallEventInputTypeString:
+		return "string"
+	default:
+		return ""
+	}
+}
+
+func scalarAt(value *actionlint.String, scalars map[Position]any) any {
+	if scalar, ok := scalars[Position{Line: value.Pos.Line, Column: value.Pos.Col}]; ok {
+		return scalar
+	}
+	return value.Value
 }
 
 func adaptEnv(in *actionlint.Env) map[string]string {

--- a/internal/workflow/parse.go
+++ b/internal/workflow/parse.go
@@ -264,8 +264,8 @@ func adaptEnv(in *actionlint.Env) map[string]string {
 		return nil
 	}
 	out := make(map[string]string, len(in.Vars))
-	for name, variable := range in.Vars {
-		out[name] = variable.Value.Value
+	for _, variable := range in.Vars {
+		out[variable.Name.Value] = variable.Value.Value
 	}
 	return out
 }

--- a/internal/workflow/parse.go
+++ b/internal/workflow/parse.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/buildkite/buildkite-gha/internal/expression"
 	"github.com/rhysd/actionlint"
+	"go.yaml.in/yaml/v4"
 )
 
 // Parse uses actionlint as the syntax frontend and immediately converts its AST
@@ -15,6 +16,10 @@ func Parse(path string, source []byte) (*Workflow, error) {
 	if len(errs) != 0 {
 		err := errs[0]
 		return nil, fmt.Errorf("%s:%d:%d: %s", path, err.Line, err.Column, err.Message)
+	}
+	scalars, err := scalarValues(source)
+	if err != nil {
+		return nil, fmt.Errorf("%s: parse scalar values: %w", path, err)
 	}
 
 	owned := &Workflow{}
@@ -40,7 +45,7 @@ func Parse(path string, source []byte) (*Workflow, error) {
 	}
 	sort.Strings(ids)
 	for _, id := range ids {
-		job, err := adaptJob(path, parsed.Jobs[id])
+		job, err := adaptJob(path, parsed.Jobs[id], scalars)
 		if err != nil {
 			return nil, err
 		}
@@ -56,7 +61,7 @@ func Parse(path string, source []byte) (*Workflow, error) {
 	return owned, nil
 }
 
-func adaptJob(path string, in *actionlint.Job) (Job, error) {
+func adaptJob(path string, in *actionlint.Job, scalars map[Position]any) (Job, error) {
 	out := Job{ID: in.ID.Value, Reusable: in.WorkflowCall != nil, Span: pointSpan(in.Pos)}
 	if in.If != nil {
 		return Job{}, locatedError(path, in.If.Pos, in.ID.Value, "job conditions are unsupported in the Phase 0 runtime")
@@ -119,7 +124,7 @@ func adaptJob(path string, in *actionlint.Job) (Job, error) {
 			out.MaxParallel = &v
 		}
 		if in.Strategy.Matrix != nil {
-			matrix, err := adaptMatrix(path, in.ID.Value, in.Strategy.Matrix)
+			matrix, err := adaptMatrix(path, in.ID.Value, in.Strategy.Matrix, scalars)
 			if err != nil {
 				return Job{}, err
 			}
@@ -206,12 +211,8 @@ func mergeEnv(base, override map[string]string) map[string]string {
 	return out
 }
 
-func adaptMatrix(path, jobID string, in *actionlint.Matrix) (*Matrix, error) {
-	out := &Matrix{
-		HasInclude: in.Include != nil,
-		HasExclude: in.Exclude != nil,
-		Span:       pointSpan(in.Pos),
-	}
+func adaptMatrix(path, jobID string, in *actionlint.Matrix, scalars map[Position]any) (*Matrix, error) {
+	out := &Matrix{Span: pointSpan(in.Pos)}
 	if in.Expression != nil {
 		expr, err := adaptExpression(in.Expression)
 		if err != nil {
@@ -224,10 +225,19 @@ func adaptMatrix(path, jobID string, in *actionlint.Matrix) (*Matrix, error) {
 	for name := range in.Rows {
 		names = append(names, name)
 	}
-	sort.Strings(names)
+	sort.Slice(names, func(i, j int) bool {
+		left, right := matrixRowPosition(in.Rows[names[i]]), matrixRowPosition(in.Rows[names[j]])
+		if left.Line != right.Line {
+			return left.Line < right.Line
+		}
+		if left.Col != right.Col {
+			return left.Col < right.Col
+		}
+		return names[i] < names[j]
+	})
 	for _, name := range names {
 		row := in.Rows[name]
-		owned := MatrixRow{Name: row.Name.Value, Span: pointSpan(row.Name.Pos)}
+		owned := MatrixRow{Name: name, Span: pointSpan(matrixRowPosition(row))}
 		if row.Expression != nil {
 			expr, err := adaptExpression(row.Expression)
 			if err != nil {
@@ -236,35 +246,128 @@ func adaptMatrix(path, jobID string, in *actionlint.Matrix) (*Matrix, error) {
 			owned.Expression = &expr
 		}
 		for _, value := range row.Values {
-			owned.Values = append(owned.Values, Value{Data: adaptValue(value), Span: spanFrom(value.Pos(), value.String())})
+			owned.Values = append(owned.Values, Value{Data: adaptValue(value, scalars), Span: spanFrom(value.Pos(), value.String())})
 		}
 		out.Rows = append(out.Rows, owned)
 		if len(owned.Values) > 0 {
 			out.Span.End = owned.Values[len(owned.Values)-1].Span.End
 		}
 	}
+	var err error
+	out.Include, err = adaptMatrixCombinations(path, jobID, "include", in.Include, scalars)
+	if err != nil {
+		return nil, err
+	}
+	out.Exclude, err = adaptMatrixCombinations(path, jobID, "exclude", in.Exclude, scalars)
+	if err != nil {
+		return nil, err
+	}
+	for _, combinations := range [][]MatrixCombination{out.Include, out.Exclude} {
+		for _, combination := range combinations {
+			if positionAfter(combination.Span.End, out.Span.End) {
+				out.Span.End = combination.Span.End
+			}
+		}
+	}
 	return out, nil
 }
 
-func adaptValue(in actionlint.RawYAMLValue) any {
+func matrixRowPosition(row *actionlint.MatrixRow) *actionlint.Pos {
+	if row.Name != nil {
+		return row.Name.Pos
+	}
+	return row.Expression.Pos
+}
+
+func adaptMatrixCombinations(path, jobID, section string, in *actionlint.MatrixCombinations, scalars map[Position]any) ([]MatrixCombination, error) {
+	if in == nil {
+		return nil, nil
+	}
+	if in.Expression != nil {
+		return nil, locatedError(path, in.Expression.Pos, jobID, fmt.Sprintf("runtime-dependent matrix %s expressions are unsupported", section))
+	}
+	out := make([]MatrixCombination, 0, len(in.Combinations))
+	for _, combination := range in.Combinations {
+		if combination.Expression != nil {
+			return nil, locatedError(path, combination.Expression.Pos, jobID, fmt.Sprintf("runtime-dependent matrix %s expressions are unsupported", section))
+		}
+		owned := MatrixCombination{Values: make(map[string]Value, len(combination.Assigns))}
+		for name, assignment := range combination.Assigns {
+			value := Value{Data: adaptValue(assignment.Value, scalars), Span: spanFrom(assignment.Value.Pos(), assignment.Value.String())}
+			owned.Values[name] = value
+			start := Position{Line: assignment.Key.Pos.Line, Column: assignment.Key.Pos.Col}
+			if owned.Span.Start.Line == 0 || positionAfter(owned.Span.Start, start) {
+				owned.Span.Start = start
+			}
+			if positionAfter(value.Span.End, owned.Span.End) {
+				owned.Span.End = value.Span.End
+			}
+		}
+		out = append(out, owned)
+	}
+	return out, nil
+}
+
+func positionAfter(left, right Position) bool {
+	return left.Line > right.Line || left.Line == right.Line && left.Column > right.Column
+}
+
+func adaptValue(in actionlint.RawYAMLValue, scalars map[Position]any) any {
 	switch value := in.(type) {
 	case *actionlint.RawYAMLString:
+		if scalar, ok := scalars[Position{Line: value.Pos().Line, Column: value.Pos().Col}]; ok {
+			return scalar
+		}
 		return value.Value
 	case *actionlint.RawYAMLArray:
 		out := make([]any, 0, len(value.Elems))
 		for _, elem := range value.Elems {
-			out = append(out, adaptValue(elem))
+			out = append(out, adaptValue(elem, scalars))
 		}
 		return out
 	case *actionlint.RawYAMLObject:
 		out := make(map[string]any, len(value.Props))
 		for key, property := range value.Props {
-			out[key] = adaptValue(property)
+			out[key] = adaptValue(property, scalars)
 		}
 		return out
 	default:
 		return value.String()
 	}
+}
+
+func scalarValues(source []byte) (map[Position]any, error) {
+	// actionlint's raw scalar model intentionally discards YAML scalar tags.
+	// Join a YAML node tree by source position so quoted strings remain distinct
+	// from the booleans, numbers, and nulls used in matrix contexts.
+	var document yaml.Node
+	if err := yaml.Unmarshal(source, &document); err != nil {
+		return nil, err
+	}
+	values := make(map[Position]any)
+	var walk func(*yaml.Node) error
+	walk = func(node *yaml.Node) error {
+		if node.Kind == yaml.ScalarNode {
+			value := any(node.Value)
+			switch node.ShortTag() {
+			case "!!bool", "!!int", "!!float", "!!null":
+				if err := node.Decode(&value); err != nil {
+					return err
+				}
+			}
+			values[Position{Line: node.Line, Column: node.Column}] = value
+		}
+		for _, child := range node.Content {
+			if err := walk(child); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if err := walk(&document); err != nil {
+		return nil, err
+	}
+	return values, nil
 }
 
 func adaptExpression(in *actionlint.String) (expression.Expression, error) {

--- a/internal/workflow/parse_test.go
+++ b/internal/workflow/parse_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -68,5 +69,63 @@ jobs:
 	}
 	if matrix.Span.End.Line != 14 {
 		t.Fatalf("matrix span end = %#v, want final exclude value on line 14", matrix.Span.End)
+	}
+}
+
+func TestParseOwnsReusableWorkflowCallsAndInputDeclarations(t *testing.T) {
+	source := []byte(`on:
+  workflow_call:
+    inputs:
+      enabled:
+        type: boolean
+        default: true
+      target:
+        type: string
+        required: true
+jobs:
+  nested:
+    uses: ./.github/workflows/nested.yml
+    with:
+      enabled: false
+      target: linux
+`)
+	parsed, err := Parse(".github/workflows/reusable.yml", source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !parsed.Callable || len(parsed.CallInputs) != 2 {
+		t.Fatalf("workflow_call = %#v, want two owned inputs", parsed.CallInputs)
+	}
+	if got := parsed.CallInputs["enabled"].Default.Data; got != true {
+		t.Fatalf("enabled default = %#v, want typed true", got)
+	}
+	call := parsed.Jobs[0].Reusable
+	if call == nil || call.Uses != "./.github/workflows/nested.yml" {
+		t.Fatalf("reusable call = %#v", call)
+	}
+	if got := call.Inputs["enabled"].Data; got != false {
+		t.Fatalf("enabled call input = %#v, want typed false", got)
+	}
+}
+
+func TestParseRejectsExpressionValuedExecutionScalars(t *testing.T) {
+	tests := []struct {
+		name    string
+		snippet string
+		want    string
+	}{
+		{name: "fail fast", snippet: "    strategy:\n      fail-fast: ${{ inputs.flag }}\n      matrix:\n        os: [ubuntu-latest]\n    steps:\n      - run: true\n", want: "expression-valued matrix fail-fast is unsupported"},
+		{name: "max parallel", snippet: "    strategy:\n      max-parallel: ${{ inputs.count }}\n      matrix:\n        os: [ubuntu-latest]\n    steps:\n      - run: true\n", want: "expression-valued matrix max-parallel is unsupported"},
+		{name: "continue on error", snippet: "    steps:\n      - run: true\n        continue-on-error: ${{ matrix.experimental }}\n", want: "expression-valued step continue-on-error is unsupported"},
+		{name: "timeout", snippet: "    steps:\n      - run: true\n        timeout-minutes: ${{ inputs.timeout }}\n", want: "expression-valued step timeout-minutes is unsupported"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source := "on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n" + test.snippet
+			_, err := Parse("expressions.yml", []byte(source))
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Parse() error = %v, want %q", err, test.want)
+			}
+		})
 	}
 }

--- a/internal/workflow/parse_test.go
+++ b/internal/workflow/parse_test.go
@@ -36,6 +36,26 @@ func TestParseSmokeWorkflowsIntoOwnedModel(t *testing.T) {
 	}
 }
 
+func TestParsePreservesEnvironmentVariableCase(t *testing.T) {
+	source := []byte("on: push\nenv:\n  WorkflowValue: workflow\njobs:\n  build:\n    runs-on: ubuntu-latest\n    env:\n      JobValue: job\n    steps:\n      - run: true\n        env:\n          STEP_VALUE: step\n")
+	parsed, err := Parse("env.yml", source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, check := range []struct {
+		env        map[string]string
+		key, value string
+	}{
+		{parsed.Env, "WorkflowValue", "workflow"},
+		{parsed.Jobs[0].Env, "JobValue", "job"},
+		{parsed.Jobs[0].Steps[0].Env, "STEP_VALUE", "step"},
+	} {
+		if check.env[check.key] != check.value {
+			t.Fatalf("env = %#v, want %s=%s", check.env, check.key, check.value)
+		}
+	}
+}
+
 func TestParseMatrixPreservesDeclarationOrderAndCombinationSpans(t *testing.T) {
 	source := []byte(`on: push
 jobs:

--- a/internal/workflow/parse_test.go
+++ b/internal/workflow/parse_test.go
@@ -34,3 +34,39 @@ func TestParseSmokeWorkflowsIntoOwnedModel(t *testing.T) {
 		})
 	}
 }
+
+func TestParseMatrixPreservesDeclarationOrderAndCombinationSpans(t *testing.T) {
+	source := []byte(`on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        fruit: [apple, pear]
+        animal: [cat, dog]
+        include:
+          - color: green
+            animal: cat
+        exclude:
+          - fruit: pear
+            animal: dog
+    steps:
+      - run: true
+`)
+	parsed, err := Parse("matrix.yml", source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	matrix := parsed.Jobs[0].Matrix
+	if matrix.Rows[0].Name != "fruit" || matrix.Rows[1].Name != "animal" {
+		t.Fatalf("matrix rows = %#v, want declaration order", matrix.Rows)
+	}
+	for _, combination := range []MatrixCombination{matrix.Include[0], matrix.Exclude[0]} {
+		if combination.Span.Start.Line == 0 || positionAfter(combination.Span.Start, combination.Span.End) {
+			t.Fatalf("invalid matrix combination span: %#v", combination.Span)
+		}
+	}
+	if matrix.Span.End.Line != 14 {
+		t.Fatalf("matrix span end = %#v, want final exclude value on line 14", matrix.Span.End)
+	}
+}

--- a/schemas/job-plan-v1.schema.json
+++ b/schemas/job-plan-v1.schema.json
@@ -60,6 +60,7 @@
       "maxItems": 16
     },
     "matrix": {"type": "object"},
+    "vars": {"$ref": "#/$defs/stringMap"},
     "needs": {
       "type": "object",
       "additionalProperties": {

--- a/schemas/job-plan-v1.schema.json
+++ b/schemas/job-plan-v1.schema.json
@@ -61,6 +61,11 @@
     },
     "matrix": {"type": "object"},
     "vars": {"$ref": "#/$defs/stringMap"},
+    "dependencies": {
+      "type": "array",
+      "items": {"type": "string", "pattern": "^[A-Za-z0-9_-]{1,255}$"},
+      "uniqueItems": true
+    },
     "needs": {
       "type": "object",
       "additionalProperties": {


### PR DESCRIPTION
The repository has the Phase 0 execution and trust foundations, but it cannot yet turn a supported GitHub Actions workflow into a native Buildkite job graph. This adds the Phase 1 static compiler so workflows can be checked, expanded, and inspected before any runtime or artifact transport is involved.

The compiler now builds deterministic compile-time contexts, expands matrices and repository-local reusable workflows, applies a fail-closed runner policy, produces versioned content-addressed job plans, and emits Buildkite pipeline YAML. `validate` also has stable text and JSON compatibility reports, while `compile --format ir-json` keeps the owned intermediate representation available for debugging.

For example, the shell smoke workflow becomes one producer and two matrix consumers with exact dependency fan-out. Generated jobs carry the expected plan digest and refuse dependency-bearing execution until Phase 2 provides producer-attributed result manifests, so this phase does not overstate the current runtime or transport boundary.
