### PR TITLE
ci: Standardize Go tooling with mise

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,9 +1,16 @@
 steps:
   - label: ":go: Repository checks"
     key: "checks"
-    command: >-
-      docker run --rm
-      --volume "$$PWD:/work"
-      --workdir /work
-      golang:1.26.5-bookworm@sha256:1ecb7edf62a0408027bd5729dfd6b1b8766e578e8df93995b225dfd0944eb651
-      bash -ceu 'apt-get update >/dev/null && apt-get install -y --no-install-recommends jq >/dev/null && make check'
+    plugins:
+      - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
+          version: "2026.5.12"
+    command: "mise run check"
+    cache:
+      paths:
+        - "~/.local/share/mise"
+        - "~/.cache/mise"
+        - "~/.local/state/mise"
+      size: "20g"
+      name: "mise-cache"
+    agents:
+      queue: "hosted"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,13 +4,6 @@ steps:
     plugins:
       - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
           version: "2026.5.12"
-    command: "mise run check"
-    cache:
-      paths:
-        - "~/.local/share/mise"
-        - "~/.cache/mise"
-        - "~/.local/state/mise"
-      size: "20g"
-      name: "mise-cache"
+    command: "mise run --jobs 1 check"
     agents:
-      queue: "hosted"
+      queue: "elastic-runners"

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,23 @@
-.PHONY: check plan-fixtures test vet
+.PHONY: build check lint plan-fixtures test test-race vet
 
 check:
-	@test -z "$$(gofmt -l .)" || (gofmt -l . && exit 1)
-	go test ./...
-	go vet ./...
-	$(MAKE) plan-fixtures
+	mise run check
+
+build:
+	mise run build
+
+lint:
+	mise run lint:go
+	mise run lint:shell
 
 plan-fixtures:
-	python3 testdata/plans/validate.py
+	mise run plan-fixtures
 
 test:
-	go test ./...
+	mise run test
+
+test-race:
+	mise run test:race
 
 vet:
-	go vet ./...
+	mise run vet

--- a/README.md
+++ b/README.md
@@ -44,18 +44,23 @@ services and job containers, conditions, timeouts, cancellation, and
 
 ## Development
 
-Go 1.26.5 or later in the Go 1.26 release line is recommended. The Go tool can
-select the pinned toolchain automatically when `GOTOOLCHAIN=auto` is enabled.
+The repository pins Go and its lint tools with mise. Trust the configuration
+once, then install the toolchain:
+
+```sh
+mise trust mise.toml
+mise install
+```
 
 Run the repository checks with:
 
 ```sh
-make check
+mise run check
 ```
 
-The command verifies formatting, runs the unit tests and `go vet`, and checks
-the signed plan-envelope fixtures. Run `go test -race ./...` separately for the
-race-enabled suite.
+The command verifies formatting, builds the commands, runs the standard and
+race-enabled tests, runs `go vet`, golangci-lint, and shellcheck, and checks the
+signed plan-envelope fixtures. `make check` remains as a convenience alias.
 
 ## License
 

--- a/internal/buildkite/pipeline.go
+++ b/internal/buildkite/pipeline.go
@@ -62,24 +62,24 @@ func Emit(pipeline Pipeline) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("job %q: %w", job.Key, err)
 		}
-		fmt.Fprintf(&out, "  - label: %s\n", yamlScalar(job.Label))
-		fmt.Fprintf(&out, "    key: %s\n", yamlScalar(job.Key))
-		fmt.Fprintf(&out, "    command: %s\n", yamlScalar("buildkite-gha run-job --plan "+planPath))
+		_, _ = fmt.Fprintf(&out, "  - label: %s\n", yamlScalar(job.Label))
+		_, _ = fmt.Fprintf(&out, "    key: %s\n", yamlScalar(job.Key))
+		_, _ = fmt.Fprintf(&out, "    command: %s\n", yamlScalar("buildkite-gha run-job --plan "+planPath))
 		out.WriteString("    agents:\n")
-		fmt.Fprintf(&out, "      queue: %s\n", yamlScalar(job.Queue))
+		_, _ = fmt.Fprintf(&out, "      queue: %s\n", yamlScalar(job.Queue))
 		out.WriteString("    checkout:\n      skip: true\n")
 		out.WriteString("    env:\n")
-		fmt.Fprintf(&out, "      BUILDKITE_GHA_PLAN_DIGEST: %s\n", yamlScalar(job.PlanDigest))
-		fmt.Fprintf(&out, "      BUILDKITE_GHA_PLAN_PATH: %s\n", yamlScalar(planPath))
-		fmt.Fprintf(&out, "      BUILDKITE_GHA_PLAN_PRODUCER: %s\n", yamlScalar(pipeline.CompilerStep))
+		_, _ = fmt.Fprintf(&out, "      BUILDKITE_GHA_PLAN_DIGEST: %s\n", yamlScalar(job.PlanDigest))
+		_, _ = fmt.Fprintf(&out, "      BUILDKITE_GHA_PLAN_PATH: %s\n", yamlScalar(planPath))
+		_, _ = fmt.Fprintf(&out, "      BUILDKITE_GHA_PLAN_PRODUCER: %s\n", yamlScalar(pipeline.CompilerStep))
 		if job.Concurrency != 0 {
-			fmt.Fprintf(&out, "    concurrency: %d\n", job.Concurrency)
-			fmt.Fprintf(&out, "    concurrency_group: %s\n", yamlScalar(job.ConcurrencyGroup))
+			_, _ = fmt.Fprintf(&out, "    concurrency: %d\n", job.Concurrency)
+			_, _ = fmt.Fprintf(&out, "    concurrency_group: %s\n", yamlScalar(job.ConcurrencyGroup))
 		}
 		out.WriteString("    depends_on:\n")
-		fmt.Fprintf(&out, "      - step: %s\n        allow_failure: false\n", yamlScalar(pipeline.CompilerStep))
+		_, _ = fmt.Fprintf(&out, "      - step: %s\n        allow_failure: false\n", yamlScalar(pipeline.CompilerStep))
 		for _, dependency := range job.Dependencies {
-			fmt.Fprintf(&out, "      - step: %s\n        allow_failure: true\n", yamlScalar(dependency))
+			_, _ = fmt.Fprintf(&out, "      - step: %s\n        allow_failure: true\n", yamlScalar(dependency))
 		}
 	}
 	return out.Bytes(), nil

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -122,7 +122,7 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 	if err := yaml.Unmarshal(source, &document); err != nil {
 		t.Fatalf("parse default pipeline: %v", err)
 	}
-	if len(document.Steps) != 1 || document.Steps[0].Key != "checks" || document.Steps[0].Command != "mise run check" {
+	if len(document.Steps) != 1 || document.Steps[0].Key != "checks" || document.Steps[0].Command != "mise run --jobs 1 check" {
 		t.Fatalf("default pipeline = %#v, want one repository check step", document.Steps)
 	}
 }

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -122,9 +122,7 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 	if err := yaml.Unmarshal(source, &document); err != nil {
 		t.Fatalf("parse default pipeline: %v", err)
 	}
-	if len(document.Steps) != 1 || document.Steps[0].Key != "checks" ||
-		!strings.Contains(document.Steps[0].Command, "golang:1.26.5-bookworm@sha256:") ||
-		!strings.Contains(document.Steps[0].Command, "make check") {
+	if len(document.Steps) != 1 || document.Steps[0].Key != "checks" || document.Steps[0].Command != "mise run check" {
 		t.Fatalf("default pipeline = %#v, want one repository check step", document.Steps)
 	}
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -42,13 +42,13 @@ var commandUsage = map[string]string{
 // Run executes the command and returns its process exit code.
 func Run(args []string, stdout, stderr io.Writer, version string) int {
 	if len(args) == 0 {
-		fmt.Fprint(stderr, usage)
+		_, _ = fmt.Fprint(stderr, usage)
 		return 2
 	}
 
 	switch args[0] {
 	case "-h", "--help":
-		fmt.Fprint(stdout, usage)
+		_, _ = fmt.Fprint(stdout, usage)
 		return 0
 	case "help":
 		return help(args[1:], stdout, stderr)
@@ -56,17 +56,17 @@ func Run(args []string, stdout, stderr io.Writer, version string) int {
 		if len(args) != 1 {
 			return usageError(stderr, "%s does not accept arguments", args[0])
 		}
-		fmt.Fprintf(stdout, "buildkite-gha %s\n", version)
+		_, _ = fmt.Fprintf(stdout, "buildkite-gha %s\n", version)
 		return 0
 	default:
 		if commandHelp, ok := commandUsage[args[0]]; ok {
 			if len(args) == 2 && (args[1] == "-h" || args[1] == "--help") {
-				fmt.Fprint(stdout, commandHelp)
+				_, _ = fmt.Fprint(stdout, commandHelp)
 				if args[0] == "compile" {
-					fmt.Fprint(stdout, "\nPipeline output references content-addressed plans; compile does not materialize or upload those artifacts.\n")
+					_, _ = fmt.Fprint(stdout, "\nPipeline output references content-addressed plans; compile does not materialize or upload those artifacts.\n")
 				}
 				if args[0] == "upload" {
-					fmt.Fprintf(stdout, "\nThe %s command is not implemented yet.\n", args[0])
+					_, _ = fmt.Fprintf(stdout, "\nThe %s command is not implemented yet.\n", args[0])
 				}
 				return 0
 			}
@@ -78,7 +78,7 @@ func Run(args []string, stdout, stderr io.Writer, version string) int {
 			case "run-job":
 				return runJob(args[1:], stdout, stderr, version)
 			default:
-				fmt.Fprintf(stderr, "buildkite-gha: %s: not implemented\n", args[0])
+				_, _ = fmt.Fprintf(stderr, "buildkite-gha: %s: not implemented\n", args[0])
 				return 1
 			}
 		}
@@ -89,7 +89,7 @@ func Run(args []string, stdout, stderr io.Writer, version string) int {
 
 func help(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
-		fmt.Fprint(stdout, usage)
+		_, _ = fmt.Fprint(stdout, usage)
 		return 0
 	}
 	if len(args) != 1 {
@@ -101,12 +101,12 @@ func help(args []string, stdout, stderr io.Writer) int {
 		return usageError(stderr, "unknown command %q", args[0])
 	}
 
-	fmt.Fprint(stdout, commandHelp)
+	_, _ = fmt.Fprint(stdout, commandHelp)
 	if args[0] == "compile" {
-		fmt.Fprint(stdout, "\nPipeline output references content-addressed plans; compile does not materialize or upload those artifacts.\n")
+		_, _ = fmt.Fprint(stdout, "\nPipeline output references content-addressed plans; compile does not materialize or upload those artifacts.\n")
 	}
 	if args[0] == "upload" {
-		fmt.Fprintf(stdout, "\nThe %s command is not implemented yet.\n", args[0])
+		_, _ = fmt.Fprintf(stdout, "\nThe %s command is not implemented yet.\n", args[0])
 	}
 	return 0
 }
@@ -118,32 +118,32 @@ func runJob(args []string, stdout, stderr io.Writer, version string) int {
 	}
 	source, err := os.ReadFile(planPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "buildkite-gha: run-job: %v\n", err)
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: %v\n", err)
 		return 1
 	}
 	if expected := os.Getenv("BUILDKITE_GHA_PLAN_DIGEST"); expected != "" {
 		actual := transport.Digest(source)
 		if actual != expected {
-			fmt.Fprintf(stderr, "buildkite-gha: run-job: plan digest %q does not match expected digest %q\n", actual, expected)
+			_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: plan digest %q does not match expected digest %q\n", actual, expected)
 			return 1
 		}
 	}
 	job, err := plan.Decode(source)
 	if err != nil {
-		fmt.Fprintf(stderr, "buildkite-gha: run-job: %v\n", err)
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: %v\n", err)
 		return 1
 	}
 	if job.Compiler.Version != version {
-		fmt.Fprintf(stderr, "buildkite-gha: run-job: plan compiler version %q does not match runtime version %q\n", job.Compiler.Version, version)
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: plan compiler version %q does not match runtime version %q\n", job.Compiler.Version, version)
 		return 1
 	}
 	if err := verifyBuildkiteTarget(job); err != nil {
-		fmt.Fprintf(stderr, "buildkite-gha: run-job: %v\n", err)
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: %v\n", err)
 		return 1
 	}
 	workspace, err := os.Getwd()
 	if err != nil {
-		fmt.Fprintf(stderr, "buildkite-gha: run-job: resolve workspace: %v\n", err)
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: resolve workspace: %v\n", err)
 		return 1
 	}
 	runner := gharuntime.Runner{
@@ -159,17 +159,17 @@ func runJob(args []string, stdout, stderr io.Writer, version string) int {
 	if resultPath != "" && result.Conclusion != "" {
 		encoded, err := json.MarshalIndent(result, "", "  ")
 		if err != nil {
-			fmt.Fprintf(stderr, "buildkite-gha: run-job: encode result: %v\n", err)
+			_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: encode result: %v\n", err)
 			return 1
 		}
 		encoded = append(encoded, '\n')
 		if err := os.WriteFile(resultPath, encoded, 0o600); err != nil {
-			fmt.Fprintf(stderr, "buildkite-gha: run-job: write result: %v\n", err)
+			_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: write result: %v\n", err)
 			return 1
 		}
 	}
 	if err != nil {
-		fmt.Fprintf(stderr, "buildkite-gha: run-job: %v\n", err)
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: %v\n", err)
 		return 1
 	}
 	return 0
@@ -208,7 +208,7 @@ func verifyBuildkiteTarget(job plan.Job) error {
 	stepKey := os.Getenv("BUILDKITE_STEP_KEY")
 	queue := os.Getenv("BUILDKITE_AGENT_META_DATA_QUEUE")
 	if os.Getenv("BUILDKITE") != "" && (stepKey == "" || queue == "") {
-		return fmt.Errorf("Buildkite execution requires BUILDKITE_STEP_KEY and BUILDKITE_AGENT_META_DATA_QUEUE")
+		return fmt.Errorf("buildkite execution requires BUILDKITE_STEP_KEY and BUILDKITE_AGENT_META_DATA_QUEUE")
 	}
 	if stepKey != "" && stepKey != job.Target.StepKey {
 		return fmt.Errorf("plan targets step %q, executing step is %q", job.Target.StepKey, stepKey)
@@ -226,7 +226,7 @@ func validate(args []string, stdout, stderr io.Writer) int {
 	}
 	source, err := os.ReadFile(workflowPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "buildkite-gha: validate: %v\n", err)
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: %v\n", err)
 		return 1
 	}
 
@@ -236,19 +236,19 @@ func validate(args []string, stdout, stderr io.Writer) int {
 	} else {
 		event, readErr := os.ReadFile(eventPath)
 		if readErr != nil {
-			fmt.Fprintf(stderr, "buildkite-gha: validate: %v\n", readErr)
+			_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: %v\n", readErr)
 			return 1
 		}
 		report, err = compiler.ValidateEvent(workflowPath, source, event)
 	}
 	if err != nil {
 		if writeErr := compatibility.Write(stdout, format, compatibility.Blocked(workflowPath, err)); writeErr != nil {
-			fmt.Fprintf(stderr, "buildkite-gha: validate: write report: %v\n", writeErr)
+			_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: write report: %v\n", writeErr)
 		}
 		return 1
 	}
 	if err := compatibility.Write(stdout, format, compatibility.Compilable(workflowPath, report.LogicalJobs, report.Instances)); err != nil {
-		fmt.Fprintf(stderr, "buildkite-gha: validate: write report: %v\n", err)
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: write report: %v\n", err)
 		return 1
 	}
 	return 0
@@ -290,12 +290,12 @@ func compile(args []string, stdout, stderr io.Writer, version string) int {
 	}
 	source, err := os.ReadFile(workflowPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "buildkite-gha: compile: %v\n", err)
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: compile: %v\n", err)
 		return 1
 	}
 	event, err := os.ReadFile(eventPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "buildkite-gha: compile: %v\n", err)
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: compile: %v\n", err)
 		return 1
 	}
 	var result []byte
@@ -304,7 +304,7 @@ func compile(args []string, stdout, stderr io.Writer, version string) int {
 	} else {
 		digest, digestErr := executableDigest()
 		if digestErr != nil {
-			fmt.Fprintf(stderr, "buildkite-gha: compile: %v\n", digestErr)
+			_, _ = fmt.Fprintf(stderr, "buildkite-gha: compile: %v\n", digestErr)
 			return 1
 		}
 		bundle, compileErr := compiler.CompileBundle(workflowPath, source, event, version, digest, "gha-importer")
@@ -312,11 +312,11 @@ func compile(args []string, stdout, stderr io.Writer, version string) int {
 		result = bundle.Pipeline
 	}
 	if err != nil {
-		fmt.Fprintf(stderr, "buildkite-gha: compile: %v\n", err)
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: compile: %v\n", err)
 		return 1
 	}
 	if _, err := stdout.Write(result); err != nil {
-		fmt.Fprintf(stderr, "buildkite-gha: compile: write output: %v\n", err)
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: compile: write output: %v\n", err)
 		return 1
 	}
 	return 0
@@ -394,7 +394,7 @@ func workflowArgs(args []string) (workflowPath, eventPath string, err error) {
 }
 
 func usageError(stderr io.Writer, format string, args ...any) int {
-	fmt.Fprintf(stderr, "buildkite-gha: "+format+"\n\n", args...)
-	fmt.Fprint(stderr, usage)
+	_, _ = fmt.Fprintf(stderr, "buildkite-gha: "+format+"\n\n", args...)
+	_, _ = fmt.Fprint(stderr, usage)
 	return 2
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -196,6 +196,9 @@ func TestRunJobExecutesBoundPlanAndWritesResult(t *testing.T) {
 	}
 	planDigest := sha256.Sum256(encoded)
 	t.Setenv("BUILDKITE_GHA_PLAN_DIGEST", "sha256:"+hex.EncodeToString(planDigest[:]))
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_STEP_KEY", job.Target.StepKey)
+	t.Setenv("BUILDKITE_AGENT_META_DATA_QUEUE", job.Target.Queue)
 	oldDirectory, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -690,7 +690,7 @@ func TestCompileBoundsReusableWorkflowGraphExpansion(t *testing.T) {
 	var callee strings.Builder
 	callee.WriteString("on: workflow_call\njobs:\n")
 	for i := 0; i < 5; i++ {
-		fmt.Fprintf(&callee, "  job%d:\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n", i)
+		_, _ = fmt.Fprintf(&callee, "  job%d:\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n", i)
 	}
 	writeWorkflow(t, repository, "reusable.yml", callee.String())
 	_, err := Compile(path, readFile(t, path), readFile(t, smokePath("events", "push.json")))

--- a/internal/expression/expression.go
+++ b/internal/expression/expression.go
@@ -109,7 +109,7 @@ func EvaluateCompileTemplate(template string, context CompileContext) (string, e
 		case string:
 			evaluated.WriteString(value)
 		case bool, json.Number, float64, int:
-			fmt.Fprint(&evaluated, value)
+			_, _ = fmt.Fprint(&evaluated, value)
 		default:
 			return "", fmt.Errorf("expression in runner label resolved to %T, want a scalar", value)
 		}

--- a/internal/harness/cmd/shell-oracle/main.go
+++ b/internal/harness/cmd/shell-oracle/main.go
@@ -11,7 +11,7 @@ import (
 
 func main() {
 	if err := run(context.Background(), os.Args[1:]); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		_, _ = fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -441,7 +441,7 @@ func treeDigest(root string) (string, error) {
 			return err
 		}
 		if relative == "." {
-			fmt.Fprintf(hash, "d . %o\x00", info.Mode().Perm())
+			_, _ = fmt.Fprintf(hash, "d . %o\x00", info.Mode().Perm())
 			return nil
 		}
 		if entry.Name() == ".git" {
@@ -452,13 +452,13 @@ func treeDigest(root string) (string, error) {
 			return err
 		}
 		if entry.IsDir() {
-			fmt.Fprintf(hash, "d %s %o\x00", filepath.ToSlash(relative), info.Mode().Perm())
+			_, _ = fmt.Fprintf(hash, "d %s %o\x00", filepath.ToSlash(relative), info.Mode().Perm())
 			return nil
 		}
 		if !info.Mode().IsRegular() {
 			return fmt.Errorf("fixture entry %q is not a regular file", relative)
 		}
-		fmt.Fprintf(hash, "f %s %o %d\x00", filepath.ToSlash(relative), info.Mode().Perm(), info.Size())
+		_, _ = fmt.Fprintf(hash, "f %s %o %d\x00", filepath.ToSlash(relative), info.Mode().Perm(), info.Size())
 		file, err := os.Open(path)
 		if err != nil {
 			return err
@@ -505,8 +505,7 @@ func copyTree(source, destination string) error {
 		}
 		targetFile, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_EXCL, info.Mode().Perm())
 		if err != nil {
-			sourceFile.Close()
-			return err
+			return errors.Join(err, sourceFile.Close())
 		}
 		_, copyErr := io.Copy(targetFile, sourceFile)
 		if err := errors.Join(copyErr, targetFile.Close(), sourceFile.Close()); err != nil {

--- a/internal/runtime/files.go
+++ b/internal/runtime/files.go
@@ -38,8 +38,7 @@ func newCommandFiles() (commandFiles, error) {
 	}
 	for _, path := range []string{files.output, files.env, files.state, files.summary} {
 		if err := os.WriteFile(path, nil, 0o600); err != nil {
-			os.RemoveAll(dir)
-			return commandFiles{}, fmt.Errorf("create file-command file: %w", err)
+			return commandFiles{}, errors.Join(fmt.Errorf("create file-command file: %w", err), os.RemoveAll(dir))
 		}
 	}
 	return files, nil
@@ -104,7 +103,7 @@ func readBoundedFile(path string, limit int64) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 	contents, err := io.ReadAll(io.LimitReader(file, limit+1))
 	if err != nil {
 		return nil, err
@@ -120,7 +119,7 @@ func parseCommandFile(path string) (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	values := make(map[string]string)
 	scanner := bufio.NewScanner(file)

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -232,13 +232,13 @@ func (r Runner) runJobStep(ctx context.Context, processor *commandProcessor, wor
 		return composite, nil, err
 	case metadata.RuntimeDocker:
 		if !job.HasCapability("docker") {
-			return result, nil, fmt.Errorf("Docker action %q requires the plan's docker capability", step.Uses)
+			return result, nil, fmt.Errorf("docker action %q requires the plan's docker capability", step.Uses)
 		}
 		if action.Runs.PreEntrypoint != "" || action.Runs.PostEntrypoint != "" || action.Runs.Entrypoint != "" || len(action.Runs.Args) != 0 {
-			return result, nil, fmt.Errorf("Docker action %q uses unsupported entrypoint, arguments, or pre/post lifecycle", step.Uses)
+			return result, nil, fmt.Errorf("docker action %q uses unsupported entrypoint, arguments, or pre/post lifecycle", step.Uses)
 		}
 		if action.Runs.Image != "Dockerfile" {
-			return result, nil, fmt.Errorf("Docker action image %q is unsupported; Phase 0 requires a local Dockerfile", action.Runs.Image)
+			return result, nil, fmt.Errorf("docker action image %q is unsupported; Phase 0 requires a local Dockerfile", action.Runs.Image)
 		}
 		dockerEnv, err := evaluateMap(action.Runs.Env, actionEval)
 		if err != nil {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -97,7 +97,7 @@ func (r Runner) runDocker(ctx context.Context, processor *commandProcessor, acti
 	if err != nil {
 		return result, err
 	}
-	defer os.RemoveAll(files.dir)
+	defer func() { _ = os.RemoveAll(files.dir) }()
 	args := []string{"run", "--rm", "--volume", files.dir + ":/github/file_commands"}
 	if action.Workspace != "" {
 		args = append(args, "--volume", action.Workspace+":/github/workspace")
@@ -141,7 +141,7 @@ func (r Runner) runProcess(ctx context.Context, processor *commandProcessor, dir
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(files.dir)
+	defer func() { _ = os.RemoveAll(files.dir) }()
 	env = mergeStringMaps(env, map[string]string{
 		"GITHUB_OUTPUT":       files.output,
 		"GITHUB_ENV":          files.env,
@@ -262,7 +262,7 @@ func DiscoverNode24(explicit, managedRoot string) (string, error) {
 			filepath.Join(managedRoot, "bin", name),
 		)
 	} else {
-		return "", errors.New("Node 24 is not configured: set Runner.Node24 or Runner.ManagedNodeRoot")
+		return "", errors.New("node 24 is not configured: set Runner.Node24 or Runner.ManagedNodeRoot")
 	}
 
 	var failures []string
@@ -280,7 +280,7 @@ func DiscoverNode24(explicit, managedRoot string) (string, error) {
 		}
 		failures = append(failures, fmt.Sprintf("%s: reported %q", candidate, version))
 	}
-	return "", fmt.Errorf("Node 24 discovery failed: %s", strings.Join(failures, "; "))
+	return "", fmt.Errorf("node 24 discovery failed: %s", strings.Join(failures, "; "))
 }
 
 func newResult() Result {
@@ -378,7 +378,7 @@ func (p *commandProcessor) process(target io.Writer, line string) {
 	for _, mask := range p.masks {
 		line = strings.ReplaceAll(line, mask, "***")
 	}
-	fmt.Fprintln(target, line)
+	_, _ = fmt.Fprintln(target, line)
 }
 
 func (p *commandProcessor) suppress() {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -157,7 +157,7 @@ func TestFileCommandParsing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(files.dir)
+	defer func() { _ = os.RemoveAll(files.dir) }()
 	if err := os.WriteFile(files.env, []byte("NODE_OPTIONS=--require bad\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -188,7 +188,7 @@ func TestFileCommandAggregateLimits(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(files.dir)
+	defer func() { _ = os.RemoveAll(files.dir) }()
 
 	many := strings.Repeat("value=x\n", maxCommandEntries+1)
 	if err := os.WriteFile(files.output, []byte(many), 0o600); err != nil {
@@ -282,9 +282,9 @@ func TestLongLineChildProcess(t *testing.T) {
 	if os.Getenv("GO_WANT_RUNTIME_LONG_LINE") != "1" {
 		return
 	}
-	fmt.Fprintln(os.Stdout, "::add-mask::runtime-stream-secret")
-	fmt.Fprintln(os.Stdout, strings.Repeat("x", maxStreamLineBytes+1)+"runtime-stream-secret")
-	fmt.Fprintln(os.Stdout, "after long line: runtime-stream-secret")
+	_, _ = fmt.Fprintln(os.Stdout, "::add-mask::runtime-stream-secret")
+	_, _ = fmt.Fprintln(os.Stdout, strings.Repeat("x", maxStreamLineBytes+1)+"runtime-stream-secret")
+	_, _ = fmt.Fprintln(os.Stdout, "after long line: runtime-stream-secret")
 }
 
 func TestProcessEnvironmentIsExplicitAndUsable(t *testing.T) {

--- a/internal/transport/boundary.go
+++ b/internal/transport/boundary.go
@@ -131,7 +131,7 @@ func materializePlans(root string, plans []PlanArtifact) (map[string]materialize
 	if err != nil {
 		return nil, fmt.Errorf("open plan artifact root: %w", err)
 	}
-	defer rootFS.Close()
+	defer func() { _ = rootFS.Close() }()
 
 	materialized := make(map[string]materializedPlan, len(plans))
 	for _, plan := range plans {

--- a/internal/transport/model.go
+++ b/internal/transport/model.go
@@ -86,7 +86,7 @@ func EmitTwoJobPipeline(compilerStep string, jobs []Job) ([]byte, error) {
 		return nil, fmt.Errorf("invalid compiler step key %q", compilerStep)
 	}
 	if len(jobs) != 2 {
-		return nil, fmt.Errorf("Phase 0 transport requires exactly two generated jobs, got %d", len(jobs))
+		return nil, fmt.Errorf("phase 0 transport requires exactly two generated jobs, got %d", len(jobs))
 	}
 	seen := map[string]bool{}
 	var out bytes.Buffer
@@ -96,20 +96,20 @@ func EmitTwoJobPipeline(compilerStep string, jobs []Job) ([]byte, error) {
 			return nil, err
 		}
 		seen[job.Key] = true
-		fmt.Fprintf(&out, "  - label: %s\n", yamlString(job.Label))
-		fmt.Fprintf(&out, "    key: %s\n", yamlString(job.Key))
-		fmt.Fprintf(&out, "    command: %s\n", yamlString(job.Command))
-		fmt.Fprintf(&out, "    agents:\n      queue: %s\n", yamlString(job.Queue))
+		_, _ = fmt.Fprintf(&out, "  - label: %s\n", yamlString(job.Label))
+		_, _ = fmt.Fprintf(&out, "    key: %s\n", yamlString(job.Key))
+		_, _ = fmt.Fprintf(&out, "    command: %s\n", yamlString(job.Command))
+		_, _ = fmt.Fprintf(&out, "    agents:\n      queue: %s\n", yamlString(job.Queue))
 		out.WriteString("    checkout:\n      skip: true\n")
 		out.WriteString("    env:\n")
-		fmt.Fprintf(&out, "      BUILDKITE_GHA_PLAN_DIGEST: %s\n", yamlString(job.Plan.Digest))
-		fmt.Fprintf(&out, "      BUILDKITE_GHA_PLAN_PRODUCER: %s\n", yamlString(compilerStep))
+		_, _ = fmt.Fprintf(&out, "      BUILDKITE_GHA_PLAN_DIGEST: %s\n", yamlString(job.Plan.Digest))
+		_, _ = fmt.Fprintf(&out, "      BUILDKITE_GHA_PLAN_PRODUCER: %s\n", yamlString(compilerStep))
 		out.WriteString("    depends_on:\n")
-		fmt.Fprintf(&out, "      - step: %s\n        allow_failure: false\n", yamlString(compilerStep))
+		_, _ = fmt.Fprintf(&out, "      - step: %s\n        allow_failure: false\n", yamlString(compilerStep))
 		dependencies := append([]Dependency(nil), job.Dependencies...)
 		sort.Slice(dependencies, func(i, j int) bool { return dependencies[i].StepKey < dependencies[j].StepKey })
 		for _, dependency := range dependencies {
-			fmt.Fprintf(&out, "      - step: %s\n        allow_failure: true\n", yamlString(dependency.StepKey))
+			_, _ = fmt.Fprintf(&out, "      - step: %s\n        allow_failure: true\n", yamlString(dependency.StepKey))
 		}
 	}
 	return out.Bytes(), nil

--- a/internal/transport/signing.go
+++ b/internal/transport/signing.go
@@ -269,7 +269,7 @@ func normalizeIntent(intent UploadIntent) (UploadIntent, error) {
 	}
 	intent.Jobs = append([]UploadJob(nil), intent.Jobs...)
 	if len(intent.Jobs) != 2 {
-		return UploadIntent{}, fmt.Errorf("Phase 0 upload intent requires exactly two jobs, got %d", len(intent.Jobs))
+		return UploadIntent{}, fmt.Errorf("phase 0 upload intent requires exactly two jobs, got %d", len(intent.Jobs))
 	}
 	sort.Slice(intent.Jobs, func(i, j int) bool { return intent.Jobs[i].Key < intent.Jobs[j].Key })
 	for i, job := range intent.Jobs {

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,48 @@
+[tools]
+go = "1.26.5"
+golangci-lint = "2.12.2"
+jq = "1.8.2"
+shellcheck = "0.11.0"
+
+[env]
+GOTOOLCHAIN = "local"
+
+[tasks.format]
+description = "Check Go formatting"
+run = '''
+unformatted="$(gofmt -l .)"
+test -z "$unformatted" || { printf '%s\n' "$unformatted"; exit 1; }
+'''
+
+[tasks.test]
+description = "Run the Go test suite"
+run = "go test ./..."
+
+[tasks."test:race"]
+description = "Run the race-enabled Go test suite"
+run = "go test -race ./..."
+
+[tasks."lint:go"]
+description = "Lint Go code"
+run = "golangci-lint run"
+
+[tasks."lint:shell"]
+description = "Lint shell scripts"
+run = "shellcheck -x .buildkite/phase-0-transport-probe/probe.sh testdata/actions/docker/entrypoint.sh"
+
+[tasks.vet]
+description = "Run go vet"
+run = "go vet ./..."
+
+[tasks.build]
+description = "Build all Go commands"
+run = "go build ./..."
+
+[tasks.plan-fixtures]
+description = "Validate signed plan-envelope fixtures"
+run = "python3 testdata/plans/validate.py"
+
+[tasks.check]
+description = "Run formatting, build, tests, lint, vet, and fixture checks"
+depends = ["format", "build", "test", "test:race", "lint:go", "lint:shell", "vet", "plan-fixtures"]
+run = "true"

--- a/mise.toml
+++ b/mise.toml
@@ -28,7 +28,7 @@ run = "golangci-lint run"
 
 [tasks."lint:shell"]
 description = "Lint shell scripts"
-run = "shellcheck -x .buildkite/phase-0-transport-probe/probe.sh testdata/actions/docker/entrypoint.sh"
+run = "shellcheck -x .buildkite/phase-0-transport-probe/probe.sh scripts/phase-0-shell-oracle-checkout testdata/actions/docker/entrypoint.sh"
 
 [tasks.vet]
 description = "Run go vet"


### PR DESCRIPTION
The repository’s Go toolchain and CI environment were split between host-installed tools and a one-off Docker command, which made local and Buildkite checks diverge. This follows the current `buildkite/cleanroom` pattern: versions and tasks live in `mise.toml`, and Buildkite installs them through the commit-pinned mise plugin on the Docker-capable elastic queue.

`mise run check` is now the single full gate for formatting, builds, standard and race-enabled tests, `go vet`, golangci-lint, shellcheck, and the signed plan fixtures. Buildkite runs that task graph serially because both test variants exercise a shared Docker daemon. The Makefile remains as a compatibility wrapper, and the newly enforced Go lint findings have been resolved rather than excluded.
