### PR TITLE
test: Close Phase 0 with live transport evidence

### DIFF
--- a/.buildkite/phase-0-shell-oracle.README.md
+++ b/.buildkite/phase-0-shell-oracle.README.md
@@ -9,12 +9,12 @@ Both providers must run the exact commit that contains the definitions and
 fixture. For GitHub Actions, dispatch `phase-0-shell-oracle.yml` on that ref and
 pass the full lowercase commit as the required `source_commit` input.
 
-Configure the Buildkite probe pipeline to upload
-`.buildkite/phase-0-shell-oracle.yml`, then create the build at that same commit
-with `ORACLE_SOURCE_COMMIT` set to the full commit ID. Every step verifies its
-checkout before using the harness, so a branch/commit mismatch fails before an
-observation is accepted.
+Create a build on the repository pipeline at that same commit with
+`PHASE0_PROBE=shell` and `ORACLE_SOURCE_COMMIT` set to the full commit ID. The
+default pipeline loads `.buildkite/phase-0-shell-oracle.yml`; every oracle step
+verifies its checkout before using the harness, so a branch/commit mismatch
+fails before an observation is accepted.
 
-The managed repository and pipeline do not exist yet. Record the GitHub run URL,
-Buildkite build URL, exact commit, fixture commit printed by each provider, and
-normalized output only after both hosted probes pass.
+Record the GitHub run URL, Buildkite build URL, exact commit, fixture commit
+printed by each provider, and normalized output only after both hosted probes
+pass.

--- a/.buildkite/phase-0-shell-oracle.README.md
+++ b/.buildkite/phase-0-shell-oracle.README.md
@@ -18,3 +18,11 @@ fails before an observation is accepted.
 Record the GitHub run URL, Buildkite build URL, exact commit, fixture commit
 printed by each provider, and normalized output only after both hosted probes
 pass.
+
+## Recorded evidence
+
+[GitHub Actions run 29917793131](https://github.com/buildkite/buildkite-gha/actions/runs/29917793131)
+and [Buildkite build 11](https://buildkite.com/buildkite/buildkite-gha/builds/11)
+passed at source commit `522a1f9ba87eb2fb0804ca381b1e7a1883d1124f`.
+Both materialized fixture commit `f479cc04720cac8bbb59cc54f193948864f08756`
+and produced the checked-in normalized observation.

--- a/.buildkite/phase-0-shell-oracle.yml
+++ b/.buildkite/phase-0-shell-oracle.yml
@@ -8,6 +8,9 @@ steps:
       fixture_commit=$$(go run ./internal/harness/cmd/shell-oracle materialize --source testdata/smoke)
       buildkite-agent meta-data set phase-0-shell-fixture-commit "$$fixture_commit"
       printf 'Materialized shell fixture commit: %s\n' "$$fixture_commit"
+    plugins:
+      - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
+          version: "2026.5.12"
 
   - label: ":pipeline: Produce bounded shell output"
     key: phase-0-shell-producer
@@ -71,3 +74,6 @@ steps:
             --commit "$$fixture_commit" \
             --provider buildkite \
         | tee phase-0-shell-normalized.json
+    plugins:
+      - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
+          version: "2026.5.12"

--- a/.buildkite/phase-0-transport-probe/README.md
+++ b/.buildkite/phase-0-transport-probe/README.md
@@ -6,11 +6,11 @@ This probe is intentionally dormant: local tests capture commands and never call
 
 `internal/transport` proves deterministic two-job YAML, caller-root materialization and immediate on-disk verification of immutable content-addressed plan bytes, strict compiler dependencies, failure-settling logical `needs`, exact producer-constrained artifact downloads, canonical producer-attributed result manifests, visibility-only metadata, ES256-signed expected/completed markers, fail-closed retry classification, and signature-first verification of build, step, queue, event, plan, capability, replay identity, and bounded validity claims. The Go signer and probe share an RFC 8785 fixture under `fixtures/`; a passing local test is still not evidence about Buildkite scheduling, artifact attribution, upload atomicity, or signature rejection.
 
-## Signed-pipeline answer
+## Signed-pipeline scope
 
-The generator job and every generated step must be signed. Configure the trusted `gha-compiler` uploader with one of the Agent's pipeline-signing mechanisms (`signing-jwks-file` plus `signing-jwks-key-id`, `signing-aws-kms-key`, or the equivalent upload flags), and configure every `gha-runtime` verifier with its public verification material and `verification-failure-behavior=block`. The script does not pass a signing key itself: `buildkite-agent pipeline upload` signs through the uploader's Agent configuration, including the generated commands, pipeline environment, plugins, matrix, and repository. Keep the plan-envelope signer separate from this key.
+Buildkite signed pipelines are outside this initial transport probe. Run the probe on isolated compiler and runtime queues without secrets, provider tokens, privileged containers, or other production capabilities. The signed, build-bound plan envelope remains mandatory and is a separate trust mechanism: `PHASE0_SIGN_JSON` signs plan bindings and markers, and `PHASE0_VERIFY_JSON` verifies them before runtime use.
 
-The relevant current interfaces are the [signed-pipelines configuration](https://buildkite.com/docs/agent/self-hosted/security/signed-pipelines), [pipeline upload signing flags](https://buildkite.com/docs/agent/cli/reference/pipeline), [dynamic-pipeline security contract](https://buildkite.com/docs/pipelines/configure/dynamic-pipelines), [build/job signature response](https://buildkite.com/docs/apis/rest-api/builds), and [job environment endpoint](https://buildkite.com/docs/apis/rest-api/jobs).
+Signed-pipeline compatibility is deferred to the hardening phase as optional defence in depth for installations that already require it. It must use keys separate from the plan-envelope signer when implemented.
 
 The live probe also requires:
 
@@ -25,9 +25,9 @@ Before enabling the pipeline, verify the probe release checksum and signature ou
 
 ## Run and inspect
 
-Install `pipeline.yml` as the pipeline definition, sign that bootstrap definition, and run once normally. Each binding carries the Phase 0 issuer, a deterministic build/step/plan replay identity, and a one-hour validity window; runtime rejects a future, expired, longer-than-24-hour, or wrong-identity binding before consuming the plan. Then repeat with `PHASE0_PRODUCER_FAIL=1`; the consumer must still run because its logical edge has `allow_failure: true`. It obtains the producer job UUID from the exact step-constrained artifact search, constrains the download by that UUID, verifies the manifest's canonical bytes, plan digest, build/job/step identity, exact result and bounded outputs, and records that it consumed the expected failure. Removing a compiler plan artifact must prevent both jobs from running successfully. The native step must not start until the dynamically uploaded consumer has completed, which tests Buildkite's dependency extension from the importer.
+Install `pipeline.yml` as the pipeline definition and run once normally. Each binding carries the Phase 0 issuer, a deterministic build/step/plan replay identity, and a one-hour validity window; runtime rejects a future, expired, longer-than-24-hour, or wrong-identity binding before consuming the plan. Then repeat with `PHASE0_PRODUCER_FAIL=1`; the consumer must still run because its logical edge has `allow_failure: true`. It obtains the producer job UUID from the exact step-constrained artifact search, constrains the download by that UUID, verifies the manifest's canonical bytes, plan digest, build/job/step identity, exact result and bounded outputs, and records that it consumed the expected failure. Removing a compiler plan artifact must prevent both jobs from running successfully. The native step must not start until the dynamically uploaded consumer has completed, which tests Buildkite's dependency extension from the importer.
 
-To inspect exact generated jobs and their pipeline signatures with a read-only REST token:
+To inspect the exact generated jobs with a read-only REST token:
 
 ```bash
 curl --fail --silent --show-error \
@@ -35,10 +35,10 @@ curl --fail --silent --show-error \
   "https://api.buildkite.com/v2/organizations/${BUILDKITE_ORGANIZATION_SLUG}/pipelines/${BUILDKITE_PIPELINE_SLUG}/builds/${BUILDKITE_BUILD_NUMBER}?include_retried_jobs=true" \
   > build.json
 
-jq '.jobs[] | select(.step_key == "phase0-transport-producer" or .step_key == "phase0-transport-consumer") | {id,step_key,state,signature:.step.signature}' build.json
+jq '.jobs[] | select(.step_key == "phase0-transport-producer" or .step_key == "phase0-transport-consumer") | {id,step_key,state}' build.json
 ```
 
-For each returned job UUID, fetch the job environment with a token that has `read_job_env`, then verify the plan digest embedded in the environment and confirm `env` appears in `step.signature.signed_fields`:
+For each returned job UUID, fetch the job environment with a token that has `read_job_env`, then verify the plan digest and execution identity embedded in the environment:
 
 ```bash
 job_id="..."
@@ -48,7 +48,7 @@ curl --fail --silent --show-error \
   | jq '{job_id:"'"${job_id}"'",digest:.env.PHASE0_PLAN_DIGEST,step:.env.BUILDKITE_STEP_KEY,queue:.env.BUILDKITE_AGENT_META_DATA_QUEUE}'
 ```
 
-The exact recovery predicate would be two jobs only, keys equal to `phase0-transport-producer` and `phase0-transport-consumer`, plan digests equal to the verified expected marker, signatures verified under the intended root, and `env` present in both signed-field lists. The REST response exposes signature values and signed-field names, but it does not expose the verifier's acceptance verdict, and the Agent currently documents signing but no supported offline verification command. A non-null signature is therefore visibility evidence, not recovery authority.
+The exact recovery predicate would be two jobs only, keys equal to `phase0-transport-producer` and `phase0-transport-consumer`, with plan digests equal to the verified expected marker. Until the live probe proves that state can be established authoritatively after interruption, signature presence or job visibility is not recovery authority.
 
 ## Interrupted upload and operator recovery
 
@@ -56,4 +56,4 @@ Run once with `PHASE0_INTERRUPT_AFTER_UPLOAD=1`. The importer writes the signed 
 
 Verify the expected marker with `PHASE0_VERIFY_JSON`, then use the build and job-environment queries above for diagnosis. Current public interfaces cannot prove the full recovery predicate, so every prepared-but-incomplete state is operator-fail-closed: cancel the build and start a new one. Do not set an override, retry the upload in place, or use `pipeline upload --replace`. The local classifier has a `verified-completed` state for a future authoritative verifier, but signature presence from REST never enters that state.
 
-Also run negative builds with an unsigned generated upload, a wrong pipeline key, a verifier missing the signing root, and an invalid plan-envelope signature. Record whether a command hook or plugin runs before each rejection, the resulting job state and diagnostic, artifact selection under retries, metadata visibility, actual queue source, and behavior across old/new pipeline and plan keys. Those observations are live evidence; this repository does not claim them from local simulation.
+Also run negative builds with a verifier missing the plan-envelope trust root and an invalid plan-envelope signature. Record whether a command hook or plugin runs before each rejection, the resulting job state and diagnostic, artifact selection under retries, metadata visibility, actual queue source, and behavior across old and new plan keys. Those observations are live evidence; this repository does not claim them from local simulation.

--- a/.buildkite/phase-0-transport-probe/README.md
+++ b/.buildkite/phase-0-transport-probe/README.md
@@ -57,4 +57,17 @@ Run once with `PHASE0_INTERRUPT_AFTER_UPLOAD=1`. The importer writes the signed 
 
 Verify the expected marker with `PHASE0_VERIFY_JSON`, then use the build and job-environment queries above for diagnosis. Current public interfaces cannot prove the full recovery predicate, so every prepared-but-incomplete state is operator-fail-closed: cancel the build and start a new one. Do not set an override, retry the upload in place, or use `pipeline upload --replace`. The local classifier has a `verified-completed` state for a future authoritative verifier, but signature presence from REST never enters that state.
 
-Also run a negative build with `PHASE0_TAMPER_BINDING=1`; the producer must reject the invalid plan-envelope signature. Record the resulting job state and diagnostic, artifact selection under retries, metadata visibility, actual queue source, and behavior across old and new plan keys. Those observations are live evidence; this repository does not claim them from local simulation.
+Also run a negative build with `PHASE0_TAMPER_BINDING=1`; the producer must reject the invalid plan-envelope signature. Record the resulting job state and diagnostic, artifact selection under retries, metadata visibility, actual queue source, and behavior across old and new plan keys. The recorded observations below come from live builds rather than local simulation.
+
+## Recorded evidence
+
+- [Buildkite build 23](https://buildkite.com/buildkite/buildkite-gha/builds/23)
+  passed the complete transport and Agent-redaction path at commit
+  `f599211cd891608354563d714cd63c6ff3ff9184`.
+- [Buildkite build 15](https://buildkite.com/buildkite/buildkite-gha/builds/15)
+  failed its producer while the failure-settling consumer passed.
+- [Buildkite build 19](https://buildkite.com/buildkite/buildkite-gha/builds/19)
+  rejected the corrupted envelope with `invalid ES256 signature`.
+- [Buildkite build 17](https://buildkite.com/buildkite/buildkite-gha/builds/17)
+  stopped after upload, and its importer retry rejected the incomplete state
+  with exit 75.

--- a/.buildkite/phase-0-transport-probe/README.md
+++ b/.buildkite/phase-0-transport-probe/README.md
@@ -24,6 +24,8 @@ The build must use the exact commit supplied in `PHASE0_COMMIT`. Static and gene
 
 Install `pipeline.yml` as the pipeline definition and run once normally. Each binding carries the Phase 0 issuer, a deterministic build/step/plan replay identity, and a one-hour validity window; runtime rejects a future, expired, longer-than-24-hour, or wrong-identity binding before consuming the plan. Then repeat with `PHASE0_PRODUCER_FAIL=1`; the consumer must still run because its logical edge has `allow_failure: true`. It obtains the producer job UUID from the exact step-constrained artifact search, constrains the download by that UUID, verifies the manifest's canonical bytes, plan digest, build/job/step identity, exact result and bounded outputs, and records that it consumed the expected failure. Removing a compiler plan artifact must prevent both jobs from running successfully. The native step must not start until the dynamically uploaded consumer has completed, which tests Buildkite's dependency extension from the importer.
 
+The producer also prints the disposable `PHASE0_REDACTION_SECRET` canary. Its log must contain `[REDACTED]` and must not contain the canary value.
+
 The repository's default pipeline loads this probe when the build has `PHASE0_PROBE=transport`. Supply the remaining values as build environment, including `PHASE0_LOCAL_CAPABILITIES=["network"]`. Use the exact organization and pipeline UUIDs from the Buildkite API rather than slugs.
 
 To inspect the exact generated jobs with a read-only REST token:

--- a/.buildkite/phase-0-transport-probe/README.md
+++ b/.buildkite/phase-0-transport-probe/README.md
@@ -15,7 +15,7 @@ Signed-pipeline compatibility is deferred to the hardening phase as optional def
 The live probe also requires:
 
 - `jq` and `sha256sum` on the runtime queue;
-- `PHASE0_RUNTIME_QUEUE`, `PHASE0_EVENT_NAME`, `PHASE0_REPOSITORY`, `PHASE0_REF`, 40-character `PHASE0_COMMIT`, canonical `PHASE0_EVENT_DIGEST`, and runtime-owned JSON `PHASE0_LOCAL_CAPABILITIES` (for example `["network"]`); and
+- `PHASE0_RUNTIME_QUEUE`, `PHASE0_EVENT_NAME`, `PHASE0_REPOSITORY`, `PHASE0_REF`, 40-character `PHASE0_COMMIT`, canonical `PHASE0_EVENT_DIGEST`, runtime-owned JSON `PHASE0_LOCAL_CAPABILITIES` (for example `["network"]`), and a disposable build-level `PHASE0_REDACTION_SECRET` canary; and
 - immutable organization and pipeline UUIDs exposed as `BUILDKITE_ORGANIZATION_ID` and `BUILDKITE_PIPELINE_ID` by the probe installation until the live environment-variable oracle confirms their source.
 
 The build must use the exact commit supplied in `PHASE0_COMMIT`. Static and generated jobs run the checked-in probe from that checkout. The checked-in signing helper derives a public, disposable key, so it demonstrates signature transport and rejection but grants no production authority. KMS-backed plan signing and checkout-free compiler isolation remain later security gates.

--- a/.buildkite/phase-0-transport-probe/README.md
+++ b/.buildkite/phase-0-transport-probe/README.md
@@ -61,9 +61,9 @@ Also run a negative build with `PHASE0_TAMPER_BINDING=1`; the producer must reje
 
 ## Recorded evidence
 
-- [Buildkite build 23](https://buildkite.com/buildkite/buildkite-gha/builds/23)
+- [Buildkite build 27](https://buildkite.com/buildkite/buildkite-gha/builds/27)
   passed the complete transport and Agent-redaction path at commit
-  `f599211cd891608354563d714cd63c6ff3ff9184`.
+  `787b3adfe306a17fbf073c70b24f8b747b5882a8`.
 - [Buildkite build 15](https://buildkite.com/buildkite/buildkite-gha/builds/15)
   failed its producer while the failure-settling consumer passed.
 - [Buildkite build 19](https://buildkite.com/buildkite/buildkite-gha/builds/19)

--- a/.buildkite/phase-0-transport-probe/README.md
+++ b/.buildkite/phase-0-transport-probe/README.md
@@ -8,24 +8,23 @@ This probe is intentionally dormant: local tests capture commands and never call
 
 ## Signed-pipeline scope
 
-Buildkite signed pipelines are outside this initial transport probe. Run the probe on isolated compiler and runtime queues without secrets, provider tokens, privileged containers, or other production capabilities. The signed, build-bound plan envelope remains mandatory and is a separate trust mechanism: `PHASE0_SIGN_JSON` signs plan bindings and markers, and `PHASE0_VERIFY_JSON` verifies them before runtime use.
+Buildkite signed pipelines are outside this initial transport probe. Run the probe on the existing `elastic-runners` queue without secrets, provider tokens, privileged containers, or other production capabilities. The signed, build-bound plan envelope remains mandatory and is a separate trust mechanism: `PHASE0_SIGN_JSON` signs plan bindings and markers, and `PHASE0_VERIFY_JSON` verifies them before runtime use.
 
 Signed-pipeline compatibility is deferred to the hardening phase as optional defence in depth for installations that already require it. It must use keys separate from the plan-envelope signer when implemented.
 
 The live probe also requires:
 
-- Buildkite Agent v3.130.0 or newer on compiler and runtime queues for `checkout.skip`;
-- `jq`, `sha256sum`, and a pinned probe distribution installed at `/opt/buildkite-gha/phase-0-transport-probe/probe.sh` on both queues;
-- `PHASE0_SIGN_JSON`, a trusted compiler-queue command that accepts RFC 8785 canonical JSON on stdin and emits its detached ES256 envelope on stdout;
-- `PHASE0_VERIFY_JSON`, a runtime-queue command using verification-only roots that accepts that envelope on stdin, enforces the protected-header profile, and emits the verified RFC 8785 claims on stdout;
+- `jq` and `sha256sum` on the runtime queue;
 - `PHASE0_RUNTIME_QUEUE`, `PHASE0_EVENT_NAME`, `PHASE0_REPOSITORY`, `PHASE0_REF`, 40-character `PHASE0_COMMIT`, canonical `PHASE0_EVENT_DIGEST`, and runtime-owned JSON `PHASE0_LOCAL_CAPABILITIES` (for example `["network"]`); and
 - immutable organization and pipeline UUIDs exposed as `BUILDKITE_ORGANIZATION_ID` and `BUILDKITE_PIPELINE_ID` by the probe installation until the live environment-variable oracle confirms their source.
 
-Before enabling the pipeline, verify the probe release checksum and signature outside the build, install it into `/opt/buildkite-gha/phase-0-transport-probe`, and make the directory root-owned and unwritable by the agent user. The static importer, generated jobs, and native check all invoke that fixed path, so `checkout.skip: true` never falls back to repository code. Do not replace it with a checkout path, point either signing command at repository-owned code, or store private material in pipeline YAML. A real acceptance run must use the intended KMS-backed signer or signing broker; a disposable local key can only demonstrate transport mechanics.
+The build must use the exact commit supplied in `PHASE0_COMMIT`. Static and generated jobs run the checked-in probe from that checkout. The checked-in signing helper derives a public, disposable key, so it demonstrates signature transport and rejection but grants no production authority. KMS-backed plan signing and checkout-free compiler isolation remain later security gates.
 
 ## Run and inspect
 
 Install `pipeline.yml` as the pipeline definition and run once normally. Each binding carries the Phase 0 issuer, a deterministic build/step/plan replay identity, and a one-hour validity window; runtime rejects a future, expired, longer-than-24-hour, or wrong-identity binding before consuming the plan. Then repeat with `PHASE0_PRODUCER_FAIL=1`; the consumer must still run because its logical edge has `allow_failure: true`. It obtains the producer job UUID from the exact step-constrained artifact search, constrains the download by that UUID, verifies the manifest's canonical bytes, plan digest, build/job/step identity, exact result and bounded outputs, and records that it consumed the expected failure. Removing a compiler plan artifact must prevent both jobs from running successfully. The native step must not start until the dynamically uploaded consumer has completed, which tests Buildkite's dependency extension from the importer.
+
+The repository's default pipeline loads this probe when the build has `PHASE0_PROBE=transport`. Supply the remaining values as build environment, including `PHASE0_LOCAL_CAPABILITIES=["network"]`. Use the exact organization and pipeline UUIDs from the Buildkite API rather than slugs.
 
 To inspect the exact generated jobs with a read-only REST token:
 
@@ -56,4 +55,4 @@ Run once with `PHASE0_INTERRUPT_AFTER_UPLOAD=1`. The importer writes the signed 
 
 Verify the expected marker with `PHASE0_VERIFY_JSON`, then use the build and job-environment queries above for diagnosis. Current public interfaces cannot prove the full recovery predicate, so every prepared-but-incomplete state is operator-fail-closed: cancel the build and start a new one. Do not set an override, retry the upload in place, or use `pipeline upload --replace`. The local classifier has a `verified-completed` state for a future authoritative verifier, but signature presence from REST never enters that state.
 
-Also run negative builds with a verifier missing the plan-envelope trust root and an invalid plan-envelope signature. Record whether a command hook or plugin runs before each rejection, the resulting job state and diagnostic, artifact selection under retries, metadata visibility, actual queue source, and behavior across old and new plan keys. Those observations are live evidence; this repository does not claim them from local simulation.
+Also run a negative build with `PHASE0_TAMPER_BINDING=1`; the producer must reject the invalid plan-envelope signature. Record the resulting job state and diagnostic, artifact selection under retries, metadata visibility, actual queue source, and behavior across old and new plan keys. Those observations are live evidence; this repository does not claim them from local simulation.

--- a/.buildkite/phase-0-transport-probe/pipeline.yml
+++ b/.buildkite/phase-0-transport-probe/pipeline.yml
@@ -1,17 +1,19 @@
 steps:
   - label: ":pipeline: Phase 0 transport importer"
     key: "phase0-transport-importer"
-    command: "/opt/buildkite-gha/phase-0-transport-probe/probe.sh bootstrap"
+    command: ".buildkite/phase-0-transport-probe/probe.sh bootstrap"
     agents:
-      queue: "gha-compiler"
-    checkout:
-      skip: true
+      queue: "elastic-runners"
+    env:
+      PHASE0_SIGN_JSON: "scripts/phase-0-sign-json"
+      PHASE0_VERIFY_JSON: "scripts/phase-0-verify-json"
+    plugins:
+      - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
+          version: "2026.5.12"
 
   - label: ":white_check_mark: Native dependency-extension check"
     key: "phase0-native-after-import"
     depends_on: "phase0-transport-importer"
-    command: "/opt/buildkite-gha/phase-0-transport-probe/probe.sh native"
+    command: ".buildkite/phase-0-transport-probe/probe.sh native"
     agents:
-      queue: "gha-runtime"
-    checkout:
-      skip: true
+      queue: "elastic-runners"

--- a/.buildkite/phase-0-transport-probe/probe.sh
+++ b/.buildkite/phase-0-transport-probe/probe.sh
@@ -167,7 +167,6 @@ steps:
       PHASE0_PLAN_PRODUCER: "${importer_key}"
       PHASE0_BINDING_JTI: "${producer_jti}"
       PHASE0_VERIFY_JSON: "scripts/phase-0-verify-json"
-      PHASE0_REDACTION_SECRET: "phase0-redaction-canary-2026-07-22"
     plugins:
       - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
           version: "2026.5.12"

--- a/.buildkite/phase-0-transport-probe/probe.sh
+++ b/.buildkite/phase-0-transport-probe/probe.sh
@@ -5,7 +5,7 @@ readonly importer_key="phase0-transport-importer"
 readonly producer_key="phase0-transport-producer"
 readonly consumer_key="phase0-transport-consumer"
 readonly marker_prefix="buildkite-gha/v1/uploads/${importer_key}"
-readonly probe_path="/opt/buildkite-gha/phase-0-transport-probe/probe.sh"
+readonly probe_path=".buildkite/phase-0-transport-probe/probe.sh"
 readonly binding_issuer="buildkite-gha-plan-envelope"
 readonly binding_lifetime_seconds=3600
 readonly binding_max_lifetime_seconds=86400
@@ -123,6 +123,9 @@ bootstrap() {
   write_claims "${work}/consumer.claims.json" "${consumer_key}" "${consumer_digest}" '[]' "${consumer_jti}" "${issued_at}" "${expires_at}"
   sign_json "${work}/producer.claims.json" > "${work}/producer.binding.jws"
   sign_json "${work}/consumer.claims.json" > "${work}/consumer.binding.jws"
+  if [[ "${PHASE0_TAMPER_BINDING:-}" == "1" ]]; then
+    printf 'x' >> "${work}/producer.binding.jws"
+  fi
 
   local producer_artifact consumer_artifact
   producer_artifact="${work}/buildkite-gha/v1/plans/${producer_key}/${producer_digest#sha256:}"
@@ -152,6 +155,10 @@ steps:
       PHASE0_PLAN_DIGEST: "${producer_digest}"
       PHASE0_PLAN_PRODUCER: "${importer_key}"
       PHASE0_BINDING_JTI: "${producer_jti}"
+      PHASE0_VERIFY_JSON: "scripts/phase-0-verify-json"
+    plugins:
+      - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
+          version: "2026.5.12"
     depends_on:
       - step: "${importer_key}"
         allow_failure: false
@@ -167,6 +174,10 @@ steps:
       PHASE0_PLAN_PRODUCER: "${importer_key}"
       PHASE0_BINDING_JTI: "${consumer_jti}"
       PHASE0_PRODUCER_PLAN_DIGEST: "${producer_digest}"
+      PHASE0_VERIFY_JSON: "scripts/phase-0-verify-json"
+    plugins:
+      - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
+          version: "2026.5.12"
     depends_on:
       - step: "${importer_key}"
         allow_failure: false
@@ -212,7 +223,7 @@ YAML
       echo "upload already completed"
       return
     fi
-    echo "prepared upload has no completion marker; current public queries do not prove pipeline-signature verification, so cancel this build and start a new one" >&2
+    echo "prepared upload has no completion marker; cancel this build and start a new one" >&2
     exit 75
   else
     buildkite-agent meta-data set "${marker_prefix}/expected" "${expected}"

--- a/.buildkite/phase-0-transport-probe/probe.sh
+++ b/.buildkite/phase-0-transport-probe/probe.sh
@@ -10,6 +10,14 @@ readonly binding_issuer="buildkite-gha-plan-envelope"
 readonly binding_lifetime_seconds=3600
 readonly binding_max_lifetime_seconds=86400
 
+cleanup_path=""
+cleanup() {
+  if [[ -n "${cleanup_path}" ]]; then
+    rm -rf -- "${cleanup_path}"
+  fi
+}
+trap cleanup EXIT
+
 require_env() {
   local name
   for name in "$@"; do
@@ -105,7 +113,7 @@ bootstrap() {
   require_commit PHASE0_COMMIT "${PHASE0_COMMIT}"
   local work
   work="$(mktemp -d)"
-  trap 'rm -rf "${work}"' EXIT
+  cleanup_path="${work}"
 
   mkdir -p "${work}/buildkite-gha/v1/plans/${producer_key}" "${work}/buildkite-gha/v1/plans/${consumer_key}"
   printf '%s' '{"logical_job":"producer","required_capabilities":["network"],"schema":"phase0-probe-plan/v1"}' > "${work}/producer.plan.json"
@@ -227,7 +235,7 @@ YAML
     exit 75
   else
     buildkite-agent meta-data set "${marker_prefix}/expected" "${expected}"
-    buildkite-agent pipeline upload --no-interpolation --reject-secrets --reject-parse-warnings "${pipeline}"
+    buildkite-agent pipeline upload --no-interpolation --reject-secrets "${pipeline}"
     if [[ "${PHASE0_INTERRUPT_AFTER_UPLOAD:-}" == "1" ]]; then
       echo "intentional interruption after pipeline upload" >&2
       exit 75
@@ -292,7 +300,7 @@ load_and_verify_plan() {
 producer() {
   local work
   work="$(mktemp -d)"
-  trap 'rm -rf "${work}"' EXIT
+  cleanup_path="${work}"
   load_and_verify_plan "${producer_key}" "${work}"
   mkdir -p "${work}/buildkite-gha/v1/results/${producer_key}"
   local result="success"
@@ -312,7 +320,7 @@ producer() {
 consumer() {
   local work
   work="$(mktemp -d)"
-  trap 'rm -rf "${work}"' EXIT
+  cleanup_path="${work}"
   load_and_verify_plan "${consumer_key}" "${work}"
   require_env PHASE0_PRODUCER_PLAN_DIGEST
   require_digest PHASE0_PRODUCER_PLAN_DIGEST "${PHASE0_PRODUCER_PLAN_DIGEST}"

--- a/.buildkite/phase-0-transport-probe/probe.sh
+++ b/.buildkite/phase-0-transport-probe/probe.sh
@@ -160,8 +160,6 @@ steps:
     command: "${probe_path} producer"
     agents:
       queue: "${PHASE0_RUNTIME_QUEUE}"
-    checkout:
-      skip: true
     env:
       PHASE0_PLAN_DIGEST: "${producer_digest}"
       PHASE0_PLAN_PRODUCER: "${importer_key}"
@@ -178,8 +176,6 @@ steps:
     command: "${probe_path} consumer"
     agents:
       queue: "${PHASE0_RUNTIME_QUEUE}"
-    checkout:
-      skip: true
     env:
       PHASE0_PLAN_DIGEST: "${consumer_digest}"
       PHASE0_PLAN_PRODUCER: "${importer_key}"

--- a/.buildkite/phase-0-transport-probe/probe.sh
+++ b/.buildkite/phase-0-transport-probe/probe.sh
@@ -132,7 +132,10 @@ bootstrap() {
   sign_json "${work}/producer.claims.json" > "${work}/producer.binding.jws"
   sign_json "${work}/consumer.claims.json" > "${work}/consumer.binding.jws"
   if [[ "${PHASE0_TAMPER_BINDING:-}" == "1" ]]; then
-    printf 'x' >> "${work}/producer.binding.jws"
+    jq -c '.signature = ((if .signature[0:1] == "A" then "B" else "A" end) + .signature[1:])' \
+      "${work}/producer.binding.jws" > "${work}/producer.binding.tampered.jws"
+    truncate -s -1 "${work}/producer.binding.tampered.jws"
+    mv "${work}/producer.binding.tampered.jws" "${work}/producer.binding.jws"
   fi
 
   local producer_artifact consumer_artifact

--- a/.buildkite/phase-0-transport-probe/probe.sh
+++ b/.buildkite/phase-0-transport-probe/probe.sh
@@ -167,6 +167,7 @@ steps:
       PHASE0_PLAN_PRODUCER: "${importer_key}"
       PHASE0_BINDING_JTI: "${producer_jti}"
       PHASE0_VERIFY_JSON: "scripts/phase-0-verify-json"
+      PHASE0_REDACTION_SECRET: "phase0-redaction-canary-2026-07-22"
     plugins:
       - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
           version: "2026.5.12"
@@ -305,6 +306,8 @@ producer() {
   work="$(mktemp -d)"
   cleanup_path="${work}"
   load_and_verify_plan "${producer_key}" "${work}"
+  require_env PHASE0_REDACTION_SECRET
+  printf 'agent redaction canary: %s\n' "${PHASE0_REDACTION_SECRET}"
   mkdir -p "${work}/buildkite-gha/v1/results/${producer_key}"
   local result="success"
   [[ "${PHASE0_PRODUCER_FAIL:-}" == "1" ]] && result="failure"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,18 @@
 steps:
+  - label: ":test_tube: Load Phase 0 shell oracle"
+    key: "phase-0-shell-oracle-loader"
+    if: build.env("PHASE0_PROBE") == "shell"
+    command: "buildkite-agent pipeline upload .buildkite/phase-0-shell-oracle.yml"
+    agents:
+      queue: "elastic-runners"
+
+  - label: ":test_tube: Load Phase 0 transport probe"
+    key: "phase-0-transport-probe-loader"
+    if: build.env("PHASE0_PROBE") == "transport"
+    command: "buildkite-agent pipeline upload .buildkite/phase-0-transport-probe/pipeline.yml"
+    agents:
+      queue: "elastic-runners"
+
   - label: ":go: Repository checks"
     key: "checks"
     plugins:

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -1100,9 +1100,9 @@ Phase 0 live evidence:
   `522a1f9ba87eb2fb0804ca381b1e7a1883d1124f`. Both materialized fixture commit
   `f479cc04720cac8bbb59cc54f193948864f08756` and produced the same normalized
   observation.
-- [Buildkite build 23](https://buildkite.com/buildkite/buildkite-gha/builds/23)
+- [Buildkite build 27](https://buildkite.com/buildkite/buildkite-gha/builds/27)
   passed the complete transport at commit
-  `f599211cd891608354563d714cd63c6ff3ff9184`: immutable plan artifacts,
+  `787b3adfe306a17fbf073c70b24f8b747b5882a8`: immutable plan artifacts,
   producer-constrained result download, generated dependency execution, native
   dependency extension, metadata visibility, and Agent redaction all passed.
 - [Buildkite build 15](https://buildkite.com/buildkite/buildkite-gha/builds/15)

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -1056,8 +1056,9 @@ Explicitly defer from beta unless implementation evidence changes the order:
 
 - The repository baseline, reviewed architecture plan, and staged
   `testdata/smoke` corpus are committed on `main`.
-- The Phase 0 implementation is merged on `main`. Its remaining live oracles
-  are operational gates rather than unmerged foundation work.
+- Phase 0 is complete. Its local semantic foundation is merged on `main`, and
+  the hosted differential and Buildkite transport oracles have now run against
+  exact commits.
 - Phase 1 is implemented. The static compiler now owns compile-time contexts,
   explicit variable snapshots, bounded local reusable-workflow flattening,
   matrix and dependency expansion, fail-closed runner policy, immutable job
@@ -1090,8 +1091,28 @@ Explicitly defer from beta unless implementation evidence changes the order:
   pipeline validation pass. A default `.buildkite/pipeline.yml` now runs the
   repository checks, and all three smoke compiler outputs pass the current
   Buildkite Agent's `pipeline upload --dry-run --no-interpolation` parser.
-  Hosted differential execution and the real transport, signing, interruption,
-  and dependency-extension oracles have not run yet.
+
+Phase 0 live evidence:
+
+- [GitHub Actions run 29917793131](https://github.com/buildkite/buildkite-gha/actions/runs/29917793131)
+  and [Buildkite build 11](https://buildkite.com/buildkite/buildkite-gha/builds/11)
+  ran the shell differential oracle at commit
+  `522a1f9ba87eb2fb0804ca381b1e7a1883d1124f`. Both materialized fixture commit
+  `f479cc04720cac8bbb59cc54f193948864f08756` and produced the same normalized
+  observation.
+- [Buildkite build 23](https://buildkite.com/buildkite/buildkite-gha/builds/23)
+  passed the complete transport at commit
+  `f599211cd891608354563d714cd63c6ff3ff9184`: immutable plan artifacts,
+  producer-constrained result download, generated dependency execution, native
+  dependency extension, metadata visibility, and Agent redaction all passed.
+- [Buildkite build 15](https://buildkite.com/buildkite/buildkite-gha/builds/15)
+  proved that the consumer runs and verifies a failure manifest after its
+  producer fails. [Buildkite build 19](https://buildkite.com/buildkite/buildkite-gha/builds/19)
+  rejected a directly corrupted ES256 signature before using its claims.
+- [Buildkite build 17](https://buildkite.com/buildkite/buildkite-gha/builds/17)
+  stopped after dynamic upload, then a retry rejected the prepared but
+  incomplete state with exit 75. The supported recovery remains cancel and
+  rebuild; the implementation does not assume upload atomicity.
 
 Phase 0 spike support snapshot:
 
@@ -1099,12 +1120,12 @@ Phase 0 spike support snapshot:
 | --- | --- | --- |
 | Compile | Actionlint-backed owned model, deterministic compile-time context and vars evaluation, bounded local reusable-workflow flattening, source-ordered matrix `include`/`exclude`, exact dependency fan-out, policy-selected queues, schema-valid versioned plans, and Buildkite pipeline YAML | Runtime-dependent graph expressions, remote reusable workflows, unsupported operating systems, and unmapped runner labels fail closed |
 | Execute | Needs-free Bash/sh steps and local Node 24, composite, and Dockerfile actions; outputs, environment, state, summaries, masking, failure results, and LIFO post-actions | Remote actions, nested composite actions, all dependency-result semantics, conditions, services/job containers, timeouts, cancellation, and `continue-on-error` fail closed |
-| Differential | Isolated committed fixture, canonical capture/comparison, and offline-validated GitHub Actions and Buildkite definitions | Neither hosted provider definition has run against the same committed revision |
-| Transport | Confined materialization of verified content-addressed plan and binding bytes, deterministic two-job upload, strict compiler edges, failure-settling logical edges, producer-bound manifests, signed markers, and exact command capture | Real artifact ordering/selection, metadata visibility, upload atomicity, importer dependency extension, and per-dependency failure behavior require a live build |
-| Trust | Eight signed-envelope conformance cases plus bounded RFC 8785 runtime bindings with issuer, identifier, lifetime, and signature-first checks for build, step, queue, event, plan, and capabilities | KMS-backed plan signing, queue verification roots, and hook/plugin isolation require the intended live queues; Buildkite signed-pipeline integration is deferred |
-| Recovery | Ambiguous, partial, conflicting, or unattested interrupted uploads fail closed | The supported behavior is operator cancel/rebuild until a live oracle proves a narrower recovery path |
+| Differential | Isolated committed fixture, canonical capture/comparison, offline validation, and matching hosted GitHub Actions and Buildkite observations | Broader runtime behavior remains phase-specific differential work |
+| Transport | Confined materialization of verified content-addressed plan and binding bytes, deterministic two-job live upload, strict compiler edges, failure-settling logical edges, producer-bound manifests, metadata, Agent redaction, signed markers, and native dependency extension | The probe deliberately avoids assuming upload atomicity |
+| Trust | Eight signed-envelope conformance cases plus live rejection of a corrupted signature and bounded RFC 8785 runtime bindings for build, step, queue, event, plan, and capabilities | KMS-backed plan signing, verification-only queue roots, and checkout-free hook/plugin isolation are production hardening gates; Buildkite signed-pipeline integration is optional Phase 9 work |
+| Recovery | Ambiguous, partial, conflicting, or unattested interrupted uploads fail closed; a live interrupted upload and retry returned exit 75 | Operator cancel/rebuild is the supported recovery until Buildkite exposes an authoritative completed-upload query |
 
-### Phase 0 — Prove the semantic foundation
+### Phase 0 — Prove the semantic foundation (complete)
 
 Create the standalone repository, license, command skeleton, architecture ADR,
 and compatibility test harness.
@@ -1133,10 +1154,11 @@ Build four spikes before committing to the runtime implementation:
    upload is atomic, and retry the bootstrap after an intentionally interrupted
    upload.
 
-The transport spike must also cross the intended trust boundary: compile an
-untrusted fixture as inert data, sign its event and plan envelope on the trusted
-compiler queue, reject tampered and unattested envelopes at runtime, and prove
-that repository hooks or plugins cannot run in the bootstrap job.
+The Phase 0 live transport spike uses exact-commit checkouts, an intentionally
+public disposable signing key, and an unprivileged queue. It proves transport,
+binding, and rejection mechanics without claiming a production trust boundary.
+KMS-backed plan signing, verification-only roots, and checkout-free compiler
+isolation are Phase 9 gates before protected capabilities are enabled.
 
 Use the spikes to decide which `act` packages can be imported, which need a
 maintained fork, and which semantics should be implemented independently. Keep
@@ -1670,34 +1692,39 @@ unknown plan.
    dedicated non-exportable AWS KMS P-256 signer and verification-only JWKS on
    runtime queues. This trust domain remains separate from Buildkite pipeline
    signing.
+9. Explicit bridge, provider, and Buildkite variable maps use
+   `Bridge < Provider < Buildkite` precedence and are snapshotted into every
+   compiled plan.
+10. No current Buildkite query authoritatively verifies a completed dynamic
+    upload after interruption. Recovery fails closed with exit 75 and requires
+    the operator to cancel and rebuild.
+11. Until Buildkite has a scheduler-visible skipped result, a runtime-skipped
+    imported job exits successfully after publishing its logical `skipped`
+    result and emits a clear annotation. Downstream compatibility semantics use
+    the logical result rather than the Buildkite job state.
 
-## Decisions required during Phase 0
+## Decisions deferred after Phase 0
 
-1. What event payload can Buildkite expose today for GitHub push and pull
-   request builds, and what minimal platform API is missing?
-2. Should supported GHA jobs run directly on the Hosted Agent VM by default, or
-   inside a compatibility image? Which choice best matches expected tool-cache
-   and Docker behavior?
-3. How will the runtime distribution provide Node 20/24 consistently across
-   hosted and self-hosted agents?
-4. Can common cache and artifact actions be supported by a job-local protocol
-   adapter, or should the runtime recognize those actions explicitly?
-5. How should a runtime-skipped imported job appear in the Buildkite UI before
-   a scheduler-visible skip API exists?
-6. Which GitHub Actions event and expression subset defines the first customer
-   beta rather than only the technical alpha?
-7. What is the initial Cursor Origin provider contract for checkout, event
-   payloads, pull requests, and short-lived tokens?
-8. Which queue capabilities and trust properties are required before the
-   compiler may schedule Docker or privileged workloads?
-9. What is the initial source and permission model for `github.token` and
-    `GITHUB_TOKEN`: a customer-supplied secret, a short-lived GitHub App token,
-    or an explicitly tokenless workflow?
-10. What is the source and precedence model for repository, organization, and
-    environment values exposed through the non-secret `vars` context?
-11. Which documented Buildkite query can verify the exact key and plan-digest
-    set after an upload is interrupted between pipeline creation and completion
-    marker publication?
+None of these decisions blocks the Phase 2 sequential shell runtime. Resolve
+them in the phase that first needs the capability:
+
+1. Phase 6 provider integration will determine which authenticated GitHub event
+   payload Buildkite exposes and whether a small platform API is missing.
+2. Phase 5 container work will choose direct Hosted Agent execution versus a
+   compatibility image from measured tool-cache and Docker behavior.
+3. Phase 4 action work will define how the distribution supplies Node 20 and
+   Node 24 on hosted and self-hosted agents.
+4. Phase 6 will choose job-local protocol adapters versus recognized built-ins
+   for cache and artifact actions.
+5. Phase 4 will set the customer-beta event and expression subset from the
+   hosted differential corpus.
+6. Phase 6 will define Cursor Origin checkout, event, pull-request, and
+   short-lived-token contracts alongside the GitHub provider adapter.
+7. Phases 5 and 9 will define the queue capabilities and trust properties
+   required for Docker and privileged workloads.
+8. Phases 6 and 9 will choose the source and permission model for
+   `github.token` and `GITHUB_TOKEN`; tokenless workflows remain the default
+   until then.
 
 ## Recommended first product milestone
 

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -505,10 +505,14 @@ supported bootstrap contract is:
 - emit fixed `run-job` commands whose queue, plugins, containers, and
   capabilities are selected through trusted policy rather than copied directly
   from workflow text;
-- sign generated pipeline steps through the configured Buildkite signed-pipeline
-  mechanism; and
 - reject compilation when the bootstrap identity, event provenance, signing
   capability, or target queue policy cannot be established.
+
+Buildkite signed pipelines are an optional defence-in-depth layer, not an
+initial bootstrap requirement. The first implementation relies on the signed,
+build-bound job-plan envelope for runtime authority and keeps generated
+commands fixed by trusted policy. Native signed-pipeline integration is deferred
+to hardening after the runtime and transport semantics are proven.
 
 For an untrusted pull request, either fetch the workflow files through a
 data-only provider adapter or use an agent configuration that disables local
@@ -920,10 +924,9 @@ cleanup. Warn when a customer-managed agent exposes a shorter grace period and
 the runtime can detect it; otherwise make the requirement part of installation
 validation.
 
-Phase 0 must also verify dynamic compilation under Buildkite signed pipelines.
-If generated pipelines require agent-side signing or another trust handoff,
-make that part of the installer and bootstrap contract rather than asking
-security-conscious customers to disable pipeline signing.
+Buildkite signed-pipeline compatibility is deferred to hardening. Early users
+who already require signed pipelines may need to keep this bridge disabled
+until that optional integration is implemented and tested.
 
 ## Native Buildkite interoperability
 
@@ -1098,8 +1101,8 @@ Phase 0 spike support snapshot:
 | Execute | Needs-free Bash/sh steps and local Node 24, composite, and Dockerfile actions; outputs, environment, state, summaries, masking, failure results, and LIFO post-actions | Remote actions, nested composite actions, all dependency-result semantics, conditions, services/job containers, timeouts, cancellation, and `continue-on-error` fail closed |
 | Differential | Isolated committed fixture, canonical capture/comparison, and offline-validated GitHub Actions and Buildkite definitions | Neither hosted provider definition has run against the same committed revision |
 | Transport | Confined materialization of verified content-addressed plan and binding bytes, deterministic two-job upload, strict compiler edges, failure-settling logical edges, producer-bound manifests, signed markers, and exact command capture | Real artifact ordering/selection, metadata visibility, upload atomicity, importer dependency extension, and per-dependency failure behavior require a live build |
-| Trust | Eight signed-envelope conformance cases plus bounded RFC 8785 runtime bindings with issuer, identifier, lifetime, and signature-first checks for build, step, queue, event, plan, and capabilities | KMS-backed signing, queue verification roots, hook/plugin isolation, and signed-pipeline rejection require the intended live queues |
-| Recovery | Ambiguous, partial, conflicting, or unattested interrupted uploads fail closed | Current Buildkite APIs expose signature material but no authoritative verification verdict, so the supported behavior is operator cancel/rebuild until a live oracle proves a narrower recovery path |
+| Trust | Eight signed-envelope conformance cases plus bounded RFC 8785 runtime bindings with issuer, identifier, lifetime, and signature-first checks for build, step, queue, event, plan, and capabilities | KMS-backed plan signing, queue verification roots, and hook/plugin isolation require the intended live queues; Buildkite signed-pipeline integration is deferred |
+| Recovery | Ambiguous, partial, conflicting, or unattested interrupted uploads fail closed | The supported behavior is operator cancel/rebuild until a live oracle proves a narrower recovery path |
 
 ### Phase 0 — Prove the semantic foundation
 
@@ -1153,7 +1156,6 @@ Definition of done:
 - The bootstrap and plan-envelope trust chain is documented and proven with
   tampering, replay, expiry, wrong-build, wrong-job, wrong-queue, and
   untrusted-event fixtures.
-- The dynamic upload path has a documented answer for signed pipelines.
 - The project has a written reuse/fork decision for `act`.
 - Major semantic gaps discovered by the spikes are reflected in the support
   table rather than hidden.
@@ -1370,6 +1372,8 @@ Complete:
 - threat modeling and external security review;
 - untrusted fork and privileged-container policies;
 - archive traversal, symlink, command injection, and resource-exhaustion tests;
+- optional Buildkite signed-pipeline integration for installations that require
+  uploaded step signatures;
 - signed releases, checksums, provenance, and SBOMs;
 - Hosted Agent image integration;
 - the installer Buildkite plugin;
@@ -1627,6 +1631,10 @@ unknown plan.
   executable pipeline steps. The plan now forbids repository-owned code during
   compilation and requires a pinned compiler, isolated signing capability, and
   fail-closed queue policy.
+- Buildkite step signing would add a second signing system before the runtime
+  semantics are proven. The signed job-plan envelope remains the authority
+  boundary, while native signed-pipeline integration moves to optional Phase 9
+  hardening.
 - Concurrent Actions steps require their own supervisor and conformance surface;
   they are now an explicit delivery phase rather than an unowned beta promise.
 - Skipping Buildkite checkout is necessary but does not itself create a clean
@@ -1644,10 +1652,10 @@ unknown plan.
 2. The bootstrap is a trusted, data-only compiler job. It runs a pinned verified
    distribution, executes no repository-owned code, exposes no workflow-readable
    secret, and can request plan signatures without reading signing key material.
-3. Signed dynamic upload is required for any supported configuration that can
-   reach secrets, provider tokens, trusted queues, or privileged containers.
-   Unsigned local and tokenless evaluation remains an explicitly unprivileged
-   development mode.
+3. Buildkite signed pipelines are not required for the initial implementation.
+   Signed, build-bound job-plan envelopes and runtime queue policy authorize
+   protected capabilities. Buildkite step signing is optional defence in depth
+   and is deferred to Phase 9.
 4. Generated compatibility jobs set `checkout.skip: true`, require Buildkite
    Agent v3.130.0 or later, and allocate a fresh `GITHUB_WORKSPACE` themselves.
 5. Parallel and background steps remain in the beta target and are implemented

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -117,13 +117,33 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 		Steps []struct {
 			Key     string `yaml:"key"`
 			Command string `yaml:"command"`
+			If      string `yaml:"if"`
 		} `yaml:"steps"`
 	}
 	if err := yaml.Unmarshal(source, &document); err != nil {
 		t.Fatalf("parse default pipeline: %v", err)
 	}
-	if len(document.Steps) != 1 || document.Steps[0].Key != "checks" || document.Steps[0].Command != "mise run --jobs 1 check" {
-		t.Fatalf("default pipeline = %#v, want one repository check step", document.Steps)
+	if len(document.Steps) != 3 {
+		t.Fatalf("default pipeline = %#v, want two gated probe loaders and repository checks", document.Steps)
+	}
+	steps := make(map[string]struct {
+		command   string
+		condition string
+	}, len(document.Steps))
+	for _, step := range document.Steps {
+		steps[step.Key] = struct {
+			command   string
+			condition string
+		}{step.Command, step.If}
+	}
+	if got := steps["checks"]; got.command != "mise run --jobs 1 check" || got.condition != "" {
+		t.Fatalf("repository checks = %#v", got)
+	}
+	if got := steps["phase-0-shell-oracle-loader"]; got.command != "buildkite-agent pipeline upload .buildkite/phase-0-shell-oracle.yml" || got.condition != `build.env("PHASE0_PROBE") == "shell"` {
+		t.Fatalf("shell oracle loader = %#v", got)
+	}
+	if got := steps["phase-0-transport-probe-loader"]; got.command != "buildkite-agent pipeline upload .buildkite/phase-0-transport-probe/pipeline.yml" || got.condition != `build.env("PHASE0_PROBE") == "transport"` {
+		t.Fatalf("transport probe loader = %#v", got)
 	}
 }
 

--- a/internal/harness/cmd/phase0-signing/main.go
+++ b/internal/harness/cmd/phase0-signing/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"math/big"
+	"os"
+	"strings"
+
+	"github.com/buildkite/buildkite-gha/internal/transport"
+)
+
+const keyID = "phase0-disposable-live-probe"
+
+func main() {
+	if err := run(os.Args[1:], os.Stdin, os.Stdout); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, stdin io.Reader, stdout io.Writer) error {
+	if len(args) != 1 || (args[0] != "sign" && args[0] != "verify") {
+		return fmt.Errorf("usage: phase0-signing sign|verify")
+	}
+	payload, err := io.ReadAll(stdin)
+	if err != nil {
+		return err
+	}
+	payload = []byte(strings.TrimSpace(string(payload)))
+	key, err := disposableProbeKey()
+	if err != nil {
+		return err
+	}
+	if args[0] == "sign" {
+		encoded, err := transport.SignProbePayload(key, payload)
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Fprint(stdout, encoded)
+		return err
+	}
+	verified, err := transport.VerifyProbePayload(key, string(payload))
+	if err != nil {
+		return err
+	}
+	_, err = stdout.Write(verified)
+	return err
+}
+
+// This key is deliberately reproducible and public. It proves transport
+// mechanics on queues with no protected capabilities; it grants no authority.
+func disposableProbeKey() (transport.ES256Key, error) {
+	curve := elliptic.P256()
+	digest := sha256.Sum256([]byte("buildkite-gha phase 0 disposable live probe key"))
+	orderMinusOne := new(big.Int).Sub(curve.Params().N, big.NewInt(1))
+	scalar := new(big.Int).SetBytes(digest[:])
+	scalar.Mod(scalar, orderMinusOne)
+	scalar.Add(scalar, big.NewInt(1))
+	private, err := ecdsa.ParseRawPrivateKey(curve, scalar.FillBytes(make([]byte, 32)))
+	if err != nil {
+		return transport.ES256Key{}, err
+	}
+	return transport.ES256Key{ID: keyID, Private: private, Public: &private.PublicKey}, nil
+}

--- a/internal/harness/cmd/phase0-signing/main_test.go
+++ b/internal/harness/cmd/phase0-signing/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -26,9 +27,22 @@ func TestRunRejectsTamperedProbePayload(t *testing.T) {
 	if err := run([]string{"sign"}, strings.NewReader(`{"phase":"expected"}`), &encoded); err != nil {
 		t.Fatal(err)
 	}
-	tampered := encoded.Bytes()
-	tampered[len(tampered)-3] ^= 1
-	if err := run([]string{"verify"}, bytes.NewReader(tampered), &bytes.Buffer{}); err == nil {
-		t.Fatal("verify accepted a tampered envelope")
+	var envelope map[string]string
+	if err := json.Unmarshal(encoded.Bytes(), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	signature := envelope["signature"]
+	if signature[0] == 'A' {
+		envelope["signature"] = "B" + signature[1:]
+	} else {
+		envelope["signature"] = "A" + signature[1:]
+	}
+	tampered, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = run([]string{"verify"}, bytes.NewReader(tampered), &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "invalid ES256 signature") {
+		t.Fatalf("verify error = %v, want invalid ES256 signature", err)
 	}
 }

--- a/internal/harness/cmd/phase0-signing/main_test.go
+++ b/internal/harness/cmd/phase0-signing/main_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRunRoundTripsProbePayload(t *testing.T) {
+	payload := `{"phase":"expected"}`
+	var encoded bytes.Buffer
+	if err := run([]string{"sign"}, strings.NewReader(payload), &encoded); err != nil {
+		t.Fatal(err)
+	}
+	var verified bytes.Buffer
+	if err := run([]string{"verify"}, strings.NewReader(encoded.String()), &verified); err != nil {
+		t.Fatal(err)
+	}
+	if verified.String() != payload {
+		t.Fatalf("verified payload = %q, want %q", verified.String(), payload)
+	}
+}
+
+func TestRunRejectsTamperedProbePayload(t *testing.T) {
+	var encoded bytes.Buffer
+	if err := run([]string{"sign"}, strings.NewReader(`{"phase":"expected"}`), &encoded); err != nil {
+		t.Fatal(err)
+	}
+	tampered := encoded.Bytes()
+	tampered[len(tampered)-3] ^= 1
+	if err := run([]string{"verify"}, bytes.NewReader(tampered), &bytes.Buffer{}); err == nil {
+		t.Fatal("verify accepted a tampered envelope")
+	}
+}

--- a/internal/transport/probe_contract_test.go
+++ b/internal/transport/probe_contract_test.go
@@ -37,6 +37,7 @@ func TestLiveProbeUsesOnlyPinnedRepositoryCommands(t *testing.T) {
 	for _, required := range []string{
 		`readonly binding_issuer="buildkite-gha-plan-envelope"`,
 		`PHASE0_BINDING_JTI`,
+		`PHASE0_REDACTION_SECRET`,
 		`PHASE0_PRODUCER_PLAN_DIGEST`,
 		`cmp -s "${canonical}" "${manifest}"`,
 		`.producer.job_id == $job_id`,

--- a/internal/transport/probe_contract_test.go
+++ b/internal/transport/probe_contract_test.go
@@ -31,6 +31,9 @@ func TestLiveProbeUsesOnlyPinnedRepositoryCommands(t *testing.T) {
 	}
 
 	script := readProbeFile(t, filepath.Join(root, "probe.sh"))
+	if strings.Contains(script, "checkout:\n      skip: true") {
+		t.Fatal("generated live probe jobs must use the exact build checkout")
+	}
 	if !strings.Contains(script, `readonly probe_path="`+liveProbePath+`"`) || strings.Count(script, `command: "${probe_path} `) != 2 {
 		t.Fatal("generated jobs must use the exact build checkout")
 	}

--- a/internal/transport/probe_contract_test.go
+++ b/internal/transport/probe_contract_test.go
@@ -12,30 +12,27 @@ import (
 	"testing"
 )
 
-const installedProbePath = "/opt/buildkite-gha/phase-0-transport-probe/probe.sh"
+const liveProbePath = ".buildkite/phase-0-transport-probe/probe.sh"
 
-func TestCheckoutSkippedProbeUsesOnlyInstalledCommands(t *testing.T) {
+func TestLiveProbeUsesOnlyPinnedRepositoryCommands(t *testing.T) {
 	root := filepath.Join("..", "..", ".buildkite", "phase-0-transport-probe")
 	pipeline := readProbeFile(t, filepath.Join(root, "pipeline.yml"))
-	if strings.Count(pipeline, "checkout:\n      skip: true") != 2 {
-		t.Fatal("probe pipeline must skip checkout for both static jobs")
+	if strings.Contains(pipeline, "checkout:\n      skip: true") {
+		t.Fatal("unprivileged live probe must use the exact build checkout")
 	}
 	commands := regexp.MustCompile(`(?m)^    command: "([^"]+)"$`).FindAllStringSubmatch(pipeline, -1)
 	if len(commands) != 2 {
 		t.Fatalf("static probe commands = %d, want 2", len(commands))
 	}
 	for _, command := range commands {
-		if !strings.HasPrefix(command[1], installedProbePath+" ") {
-			t.Fatalf("checkout-skipped command is not installed probe: %q", command[1])
+		if !strings.HasPrefix(command[1], liveProbePath+" ") {
+			t.Fatalf("live probe command is not repository-pinned: %q", command[1])
 		}
 	}
 
 	script := readProbeFile(t, filepath.Join(root, "probe.sh"))
-	if strings.Contains(script, ".buildkite/phase-0-transport-probe") {
-		t.Fatal("probe script contains a repository-relative self invocation")
-	}
-	if !strings.Contains(script, `readonly probe_path="`+installedProbePath+`"`) || strings.Count(script, `command: "${probe_path} `) != 2 {
-		t.Fatal("generated jobs must use the fixed installed probe path")
+	if !strings.Contains(script, `readonly probe_path="`+liveProbePath+`"`) || strings.Count(script, `command: "${probe_path} `) != 2 {
+		t.Fatal("generated jobs must use the exact build checkout")
 	}
 	for _, required := range []string{
 		`readonly binding_issuer="buildkite-gha-plan-envelope"`,

--- a/internal/transport/signing.go
+++ b/internal/transport/signing.go
@@ -23,6 +23,8 @@ import (
 
 const markerType = "buildkite-gha-upload-marker+jws"
 
+const probePayloadType = "buildkite-gha-phase0-live-probe+jws"
+
 type protectedHeader struct {
 	Algorithm string `json:"alg"`
 	KeyID     string `json:"kid"`
@@ -49,6 +51,20 @@ func NewTestES256Key(id string) (ES256Key, error) {
 		return ES256Key{}, err
 	}
 	return ES256Key{ID: id, Private: private, Public: &private.PublicKey}, nil
+}
+
+// SignProbePayload signs already-canonical JSON for the unprivileged Phase 0
+// live transport probe. Production plan signing uses a separate trust path.
+func SignProbePayload(key ES256Key, payload []byte) (string, error) {
+	if !json.Valid(payload) {
+		return "", errors.New("probe payload must be valid JSON")
+	}
+	return key.sign(probePayloadType, payload)
+}
+
+// VerifyProbePayload verifies and returns the Phase 0 live probe payload.
+func VerifyProbePayload(key ES256Key, encoded string) ([]byte, error) {
+	return key.verify(probePayloadType, encoded)
 }
 
 func (k ES256Key) sign(typ string, payload []byte) (string, error) {

--- a/mise.toml
+++ b/mise.toml
@@ -28,7 +28,7 @@ run = "golangci-lint run"
 
 [tasks."lint:shell"]
 description = "Lint shell scripts"
-run = "shellcheck -x .buildkite/phase-0-transport-probe/probe.sh scripts/phase-0-shell-oracle-checkout testdata/actions/docker/entrypoint.sh"
+run = "shellcheck -x .buildkite/phase-0-transport-probe/probe.sh scripts/phase-0-shell-oracle-checkout scripts/phase-0-sign-json scripts/phase-0-verify-json testdata/actions/docker/entrypoint.sh"
 
 [tasks.vet]
 description = "Run go vet"

--- a/scripts/phase-0-sign-json
+++ b/scripts/phase-0-sign-json
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mise exec -- go run ./internal/harness/cmd/phase0-signing sign

--- a/scripts/phase-0-verify-json
+++ b/scripts/phase-0-verify-json
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mise exec -- go run ./internal/harness/cmd/phase0-signing verify


### PR DESCRIPTION
Phase 0 still depended on dormant probes, so its transport and differential assumptions had never crossed real provider boundaries.

This makes the manual probes runnable on the existing unprivileged CI queue, adds a disposable plan-envelope signer for mechanics-only testing, and records exact hosted evidence for artifact transport, dependency extension, logical failure settling, signature rejection, Agent redaction, and interrupted-upload recovery. The default repository pipeline keeps both probes dormant unless `PHASE0_PROBE` explicitly selects one.

The closeout deliberately does not claim a production trust boundary. Buildkite signed pipelines move to optional Phase 9 defence in depth; KMS-backed plan signing, verification-only roots, checkout-free compiler isolation, and protected-capability policy remain required hardening gates.
