### PR TITLE
feat: Add the concurrent step runtime

### DIFF
--- a/.buildkite/phase-0-shell-oracle.README.md
+++ b/.buildkite/phase-0-shell-oracle.README.md
@@ -1,4 +1,4 @@
-# Phase 0 shell differential oracle
+# Runtime differential oracle
 
 The checked-in GitHub Actions and Buildkite definitions are manual Phase 0
 probes. They reproduce the staged `testdata/smoke` shell workflow on each
@@ -7,7 +7,8 @@ committed expectation. Offline validation does not count as hosted evidence.
 
 Both providers must run the exact commit that contains the definitions and
 fixture. For GitHub Actions, dispatch `phase-0-shell-oracle.yml` on that ref and
-pass the full lowercase commit as the required `source_commit` input.
+pass the full lowercase commit as the required `source_commit` input. The
+default `target=shell` preserves the Phase 0 oracle.
 
 Create a build on the repository pipeline at that same commit with
 `PHASE0_PROBE=shell` and `ORACLE_SOURCE_COMMIT` set to the full commit ID. The
@@ -26,3 +27,16 @@ and [Buildkite build 11](https://buildkite.com/buildkite/buildkite-gha/builds/11
 passed at source commit `522a1f9ba87eb2fb0804ca381b1e7a1883d1124f`.
 Both materialized fixture commit `f479cc04720cac8bbb59cc54f193948864f08756`
 and produced the checked-in normalized observation.
+
+## Phase 3 concurrent-step probe
+
+Dispatch the same GitHub workflow at the exact Phase 3 commit with
+`target=concurrent`. The concurrent job's outputs and steps are checked to be
+identical to `testdata/smoke/.github/workflows/concurrent.yml`; the hosted run
+captures its observation and compares it with the expected fixture through the
+same exact materialized commit.
+
+Create a Buildkite build at that commit with `PHASE3_PROBE=concurrent` and
+`PHASE3_COMMIT` set to the full commit ID. The separate upload importer and
+continuation loader preserve the dynamic-upload ordering invariant, and the
+native continuation waits for the generated terminal observer.

--- a/.buildkite/phase-3-upload-continuation.yml
+++ b/.buildkite/phase-3-upload-continuation.yml
@@ -1,0 +1,9 @@
+steps:
+  - label: ":white_check_mark: Phase 3 native dependency extension"
+    key: "phase-3-native-after-concurrent"
+    depends_on:
+      - step: "gha-observe"
+        allow_failure: true
+    agents:
+      queue: "elastic-runners"
+    command: "echo 'All Phase 3 concurrent jobs settled before native continuation'"

--- a/.buildkite/phase-3-upload.yml
+++ b/.buildkite/phase-3-upload.yml
@@ -1,0 +1,25 @@
+steps:
+  - label: ":pipeline: Phase 3 concurrent importer"
+    key: "phase-3-upload-importer"
+    agents:
+      queue: "elastic-runners"
+    plugins:
+      - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
+          version: "2026.5.12"
+    command: |
+      set -euo pipefail
+      scripts/phase-0-shell-oracle-checkout "$$PHASE3_COMMIT"
+      distribution_root="$$(mktemp -d "$${TMPDIR:-/tmp}/buildkite-gha-phase3.XXXXXXXX")"
+      trap 'rm -rf -- "$$distribution_root"' EXIT
+      mise exec -- go build -trimpath -buildvcs=false -o "$$distribution_root/buildkite-gha" ./cmd/buildkite-gha
+      "$$distribution_root/buildkite-gha" upload \
+        --event-path testdata/smoke/events/push.json \
+        --runtime-queue hosted \
+        testdata/smoke/.github/workflows/concurrent.yml
+
+  - label: ":pipeline: Phase 3 continuation loader"
+    key: "phase-3-continuation-loader"
+    depends_on: "phase-3-upload-importer"
+    agents:
+      queue: "elastic-runners"
+    command: "buildkite-agent pipeline upload .buildkite/phase-3-upload-continuation.yml"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,6 +20,13 @@ steps:
     agents:
       queue: "elastic-runners"
 
+  - label: ":pipeline: Load Phase 3 concurrent proof"
+    key: "phase-3-upload-loader"
+    if: build.env("PHASE3_PROBE") == "concurrent"
+    command: "buildkite-agent pipeline upload .buildkite/phase-3-upload.yml"
+    agents:
+      queue: "elastic-runners"
+
   - label: ":go: Repository checks"
     key: "checks"
     plugins:

--- a/.github/workflows/phase-0-shell-oracle.yml
+++ b/.github/workflows/phase-0-shell-oracle.yml
@@ -7,6 +7,14 @@ on:
         description: Full commit containing this oracle definition and fixture
         required: true
         type: string
+      target:
+        description: Runtime target to compare
+        required: false
+        default: shell
+        type: choice
+        options:
+          - shell
+          - concurrent
 
 permissions:
   contents: read
@@ -45,6 +53,7 @@ jobs:
           printf 'Materialized shell fixture commit: %s\n' "$fixture_commit"
 
   producer:
+    if: inputs.target == 'shell'
     needs: prepare
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -59,6 +68,7 @@ jobs:
           printf 'result=smoke-shell\n' >> "$GITHUB_OUTPUT"
 
   consumer:
+    if: inputs.target == 'shell'
     needs: [prepare, producer]
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -87,6 +97,7 @@ jobs:
           retention-days: 1
 
   compare:
+    if: inputs.target == 'shell'
     needs: [prepare, consumer]
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -126,3 +137,294 @@ jobs:
                 --commit "$FIXTURE_COMMIT" \
                 --provider github \
             | tee phase-0-shell-normalized.json
+
+  concurrent:
+    if: inputs.target == 'concurrent'
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      targeted: ${{ steps.verify-targets.outputs.value }}
+      failure: ${{ steps.verify-failure.outputs.value }}
+      queue_max: ${{ steps.verify-queue.outputs.value }}
+      cancel: ${{ steps.verify-cancel.outputs.value }}
+      parallel: ${{ steps.verify-parallel.outputs.value }}
+      implicit: ${{ steps.implicit.outputs.value }}
+    steps:
+      - id: target-one
+        shell: bash
+        run: |
+          sleep 0.05
+          echo "TARGET_ONE=one" >> "$GITHUB_ENV"
+          echo "value=one" >> "$GITHUB_OUTPUT"
+          touch "$RUNNER_TEMP/target-one.done"
+        background: true
+
+      - id: target-two
+        shell: bash
+        run: |
+          sleep 0.05
+          echo "TARGET_TWO=two" >> "$GITHUB_ENV"
+          echo "value=two" >> "$GITHUB_OUTPUT"
+          touch "$RUNNER_TEMP/target-two.done"
+        background: true
+
+      - name: Verify completed effects remain private before a barrier
+        shell: bash
+        run: |
+          while [ ! -f "$RUNNER_TEMP/target-one.done" ] || [ ! -f "$RUNNER_TEMP/target-two.done" ]; do sleep 0.01; done
+          test -z "$TARGET_ONE"
+          test -z "$TARGET_TWO"
+
+      - wait: target-one
+
+      - name: Verify targeted barrier visibility
+        shell: bash
+        run: |
+          test "$TARGET_ONE" = one
+          test -z "$TARGET_TWO"
+          test "${{ steps.target-one.outputs.value }}" = one
+
+      - wait-all:
+
+      - id: verify-targets
+        name: Verify full barrier visibility
+        shell: bash
+        run: |
+          test "$TARGET_ONE" = one
+          test "$TARGET_TWO" = two
+          test "${{ steps.target-two.outputs.value }}" = two
+          echo "value=targeted-and-full" >> "$GITHUB_OUTPUT"
+
+      - id: expected-failure
+        shell: bash
+        run: exit 7
+        background: true
+
+      - wait: expected-failure
+        continue-on-error: true
+
+      - id: verify-failure
+        if: steps.expected-failure.outcome == 'failure'
+        shell: bash
+        run: echo "value=failure-at-wait" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare bounded queue probe
+        shell: bash
+        run: |
+          cat > "$RUNNER_TEMP/phase3-queue-worker" <<'SCRIPT'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          id="$1"
+          lock="$RUNNER_TEMP/phase3-queue-lock"
+          active_file="$RUNNER_TEMP/phase3-queue-active"
+          max_file="$RUNNER_TEMP/phase3-queue-max"
+          starts_file="$RUNNER_TEMP/phase3-queue-starts"
+          acquire() { while ! mkdir "$lock" 2>/dev/null; do sleep 0.01; done; }
+          release() { rmdir "$lock"; }
+          acquire
+          active=0
+          [ ! -f "$active_file" ] || active=$(cat "$active_file")
+          active=$((active + 1))
+          echo "$active" > "$active_file"
+          maximum=0
+          [ ! -f "$max_file" ] || maximum=$(cat "$max_file")
+          if [ "$active" -gt "$maximum" ]; then echo "$active" > "$max_file"; fi
+          echo "$id" >> "$starts_file"
+          release
+          while [ ! -f "$RUNNER_TEMP/phase3-queue-release" ]; do sleep 0.01; done
+          acquire
+          active=$(cat "$active_file")
+          echo $((active - 1)) > "$active_file"
+          release
+          SCRIPT
+          chmod +x "$RUNNER_TEMP/phase3-queue-worker"
+
+      - id: queued-01
+        run: '"$RUNNER_TEMP/phase3-queue-worker" 01'
+        background: true
+      - id: queued-02
+        run: '"$RUNNER_TEMP/phase3-queue-worker" 02'
+        background: true
+      - id: queued-03
+        run: '"$RUNNER_TEMP/phase3-queue-worker" 03'
+        background: true
+      - id: queued-04
+        run: '"$RUNNER_TEMP/phase3-queue-worker" 04'
+        background: true
+      - id: queued-05
+        run: '"$RUNNER_TEMP/phase3-queue-worker" 05'
+        background: true
+      - id: queued-06
+        run: '"$RUNNER_TEMP/phase3-queue-worker" 06'
+        background: true
+      - id: queued-07
+        run: '"$RUNNER_TEMP/phase3-queue-worker" 07'
+        background: true
+      - id: queued-08
+        run: '"$RUNNER_TEMP/phase3-queue-worker" 08'
+        background: true
+      - id: queued-09
+        run: '"$RUNNER_TEMP/phase3-queue-worker" 09'
+        background: true
+      - id: queued-10
+        run: '"$RUNNER_TEMP/phase3-queue-worker" 10'
+        background: true
+      - id: queued-11
+        run: '"$RUNNER_TEMP/phase3-queue-worker" 11'
+        background: true
+
+      - name: Release the first ten queued workers
+        shell: bash
+        run: |
+          while :; do
+            started=0
+            [ ! -f "$RUNNER_TEMP/phase3-queue-starts" ] || started=$(wc -l < "$RUNNER_TEMP/phase3-queue-starts")
+            [ "$started" -eq 10 ] && break
+            sleep 0.01
+          done
+          sleep 0.1
+          test "$(wc -l < "$RUNNER_TEMP/phase3-queue-starts")" -eq 10
+          touch "$RUNNER_TEMP/phase3-queue-release"
+
+      - wait-all:
+
+      - id: verify-queue
+        shell: bash
+        run: |
+          test "$(cat "$RUNNER_TEMP/phase3-queue-max")" -eq 10
+          test "$(wc -l < "$RUNNER_TEMP/phase3-queue-starts")" -eq 11
+          echo "value=10" >> "$GITHUB_OUTPUT"
+
+      - id: masker
+        shell: bash
+        run: |
+          echo "::add-mask::phase3-cross-stream-secret"
+          sleep 0.05
+          touch "$RUNNER_TEMP/phase3-mask-ready"
+        background: true
+
+      - name: Emit a cross-stream masked probe
+        shell: bash
+        run: |
+          while [ ! -f "$RUNNER_TEMP/phase3-mask-ready" ]; do sleep 0.01; done
+          echo "PHASE3_MASK_PROBE=phase3-cross-stream-secret"
+
+      - wait: masker
+
+      - id: cancellable
+        shell: bash
+        run: |
+          trap 'echo graceful > "$RUNNER_TEMP/phase3-cancelled"; exit 0' TERM
+          touch "$RUNNER_TEMP/phase3-cancel-ready"
+          while :; do sleep 1; done
+        background: true
+
+      - name: Wait for cancellable step to start
+        run: while [ ! -f "$RUNNER_TEMP/phase3-cancel-ready" ]; do sleep 0.01; done
+
+      - cancel: cancellable
+
+      - id: verify-cancel
+        if: steps.cancellable.outcome == 'cancelled'
+        shell: bash
+        run: |
+          test "$(cat "$RUNNER_TEMP/phase3-cancelled")" = graceful
+          echo "value=graceful" >> "$GITHUB_OUTPUT"
+
+      - parallel:
+          - id: parallel-one
+            run: |
+              sleep 0.05
+              echo "value=one" >> "$GITHUB_OUTPUT"
+          - id: parallel-two
+            run: |
+              sleep 0.05
+              echo "value=two" >> "$GITHUB_OUTPUT"
+
+      - id: verify-parallel
+        shell: bash
+        run: |
+          test "${{ steps.parallel-one.outputs.value }}" = one
+          test "${{ steps.parallel-two.outputs.value }}" = two
+          echo "value=parallel" >> "$GITHUB_OUTPUT"
+
+      - id: implicit
+        shell: bash
+        run: |
+          sleep 0.05
+          echo "value=implicit-wait-all" >> "$GITHUB_OUTPUT"
+        background: true
+
+  concurrent-observe:
+    if: inputs.target == 'concurrent'
+    needs: [prepare, concurrent]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Capture concurrent runtime observation
+        env:
+          TARGETED: ${{ needs.concurrent.outputs.targeted }}
+          FAILURE: ${{ needs.concurrent.outputs.failure }}
+          QUEUE_MAX: ${{ needs.concurrent.outputs.queue_max }}
+          CANCEL: ${{ needs.concurrent.outputs.cancel }}
+          PARALLEL: ${{ needs.concurrent.outputs.parallel }}
+          IMPLICIT: ${{ needs.concurrent.outputs.implicit }}
+        shell: bash
+        run: |
+          test "$TARGETED" = targeted-and-full
+          test "$FAILURE" = failure-at-wait
+          test "$QUEUE_MAX" = 10
+          test "$CANCEL" = graceful
+          test "$PARALLEL" = parallel
+          test "$IMPLICIT" = implicit-wait-all
+          printf 'PHASE3_OBSERVATION={"cancel":"%s","failure":"%s","implicit":"%s","parallel":"%s","queue_max":%s,"targeted":"%s"}\n' \
+            "$CANCEL" "$FAILURE" "$IMPLICIT" "$PARALLEL" "$QUEUE_MAX" "$TARGETED" \
+            | tee phase-3-concurrent-observation.log
+
+      - name: Upload captured observation
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: github-concurrent-observation
+          path: phase-3-concurrent-observation.log
+          if-no-files-found: error
+          retention-days: 1
+
+  concurrent-compare:
+    if: inputs.target == 'concurrent'
+    needs: [prepare, concurrent-observe]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout exact source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ inputs.source_commit }}
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Download captured observation
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          name: github-concurrent-observation
+
+      - name: Normalize and compare
+        env:
+          FIXTURE_COMMIT: ${{ needs.prepare.outputs.fixture_commit }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts/phase-0-shell-oracle-checkout "$SOURCE_COMMIT"
+          go run ./internal/harness/cmd/shell-oracle compare \
+            --source testdata/smoke \
+            --commit "$FIXTURE_COMMIT" \
+            --provider github \
+            --target concurrent \
+            < phase-3-concurrent-observation.log \
+            | tee phase-3-concurrent-normalized.json

--- a/.github/workflows/phase-0-shell-oracle.yml
+++ b/.github/workflows/phase-0-shell-oracle.yml
@@ -200,9 +200,9 @@ jobs:
         shell: bash
         run: exit 7
         background: true
+        continue-on-error: true
 
       - wait: expected-failure
-        continue-on-error: true
 
       - id: verify-failure
         if: steps.expected-failure.outcome == 'failure'

--- a/.github/workflows/phase-0-shell-oracle.yml
+++ b/.github/workflows/phase-0-shell-oracle.yml
@@ -315,7 +315,7 @@ jobs:
       - id: cancellable
         shell: bash
         run: |
-          trap 'echo graceful > "$RUNNER_TEMP/phase3-cancelled"; exit 0' TERM
+          trap 'echo graceful > "$RUNNER_TEMP/phase3-cancelled"; exit 0' INT
           touch "$RUNNER_TEMP/phase3-cancel-ready"
           while :; do sleep 1; done
         background: true

--- a/README.md
+++ b/README.md
@@ -57,8 +57,12 @@ cancellation, `::add-mask` log and result protection, and step
 `continue-on-error`. Background steps, targeted and full barriers, explicit
 cancellation, and parallel groups share a ten-active-step supervisor. Their
 effects and failures become visible only at the covering barrier, and an
-implicit final barrier runs before bounded cleanup. Other workflow commands are
-not yet implemented. Secret names resolve only through the explicit
+implicit final barrier runs before bounded cleanup. On Unix, cancellation sends
+`SIGINT` to the complete step process group, escalates to `SIGTERM` after 7.5
+seconds, then uses `SIGKILL` after another 2.5 seconds. GitHub uses the same
+timing against only the direct process; the bridge intentionally terminates the
+complete process tree. Other workflow commands are not yet implemented. Secret
+names resolve only through the explicit
 `BUILDKITE_GHA_SECRET_` namespace and are registered with the Buildkite Agent
 redactor before execution. Remote action resolution, services, and job
 containers remain outside the executable subset; local Node 24, composite, and

--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@ Actions workflows as native Buildkite builds. It will compile workflow jobs
 into Buildkite pipeline jobs and execute each job's Actions steps inside a
 compatibility runtime, without creating a GitHub Actions run.
 
-The Phase 0 semantic foundation, Phase 1 static compiler, and unprivileged
-event-file upload path are implemented. The compiler validates the supported
-graph, expands local reusable workflows and matrices, applies queue policy,
-produces immutable job plans, and emits a Buildkite pipeline.
+The Phase 0 semantic foundation, Phase 1 static compiler, Phase 2 shell
+runtime, and Phase 3 concurrent-step runtime are implemented. The compiler
+validates the supported graph, expands local reusable workflows and matrices,
+applies queue policy, produces immutable job plans, and emits a Buildkite
+pipeline.
 
 ## Commands
 
@@ -44,29 +45,32 @@ are fixed independently of the flag value, so CLI input cannot grant access to
 another queue. Trusted installation-specific queue policy remains deferred.
 This path is intentionally unsigned and does not claim the KMS-backed plan
 authority required for production use. It also rejects action steps because
-its generated jobs have empty, checkout-free workspaces; only shell steps are
-currently executable through this path, and any declared runtime capability
-causes the upload to fail closed.
+its generated jobs have empty, checkout-free workspaces; only shell steps and
+their concurrent control primitives are currently executable through this
+path, and any declared runtime capability causes the upload to fail closed.
 
 `run-job` consumes a versioned job plan and executes Linux Bash and sh steps in
-a fresh checkout-free workspace. The sequential runtime supports env and
-working-directory precedence, file commands, job and step conditions, bounded
-prerequisite results and outputs supplied by the transport layer, timeouts,
-process-tree cancellation, `::add-mask` log and result protection, and step
-`continue-on-error`. Other workflow commands are not yet implemented. Secret names
-resolve only through the explicit `BUILDKITE_GHA_SECRET_` namespace and are
-registered with the Buildkite Agent redactor before execution. Remote action
-resolution, services, job containers, and concurrent steps remain outside the
-executable subset; local Node 24, composite, and Docker action spikes still
-require an explicitly materialized and source-bound workspace. In Buildkite,
-`run-job` verifies the exact build, job, step, and plan digest before resolving
-each prerequisite from its attributed producer artifact, then publishes the
-terminal result under a bounded cleanup context; metadata is only a best-effort
-mirror. Identity, plan-decode, and digest failures happen before a producer can
-publish a trusted manifest, and retrying a producer can make artifact selection
-ambiguous; consumers fail closed in both cases, so retry the whole build. Use
-`buildkite-gha help`, `buildkite-gha help <command>`, or
-`buildkite-gha --version` for exact usage.
+a fresh checkout-free workspace. The runtime supports env and working-directory
+precedence, file commands, job and step conditions, bounded prerequisite
+results and outputs supplied by the transport layer, timeouts, process-tree
+cancellation, `::add-mask` log and result protection, and step
+`continue-on-error`. Background steps, targeted and full barriers, explicit
+cancellation, and parallel groups share a ten-active-step supervisor. Their
+effects and failures become visible only at the covering barrier, and an
+implicit final barrier runs before bounded cleanup. Other workflow commands are
+not yet implemented. Secret names resolve only through the explicit
+`BUILDKITE_GHA_SECRET_` namespace and are registered with the Buildkite Agent
+redactor before execution. Remote action resolution, services, and job
+containers remain outside the executable subset; local Node 24, composite, and
+Docker action spikes still require an explicitly materialized and source-bound
+workspace. In Buildkite, `run-job` verifies the exact build, job, step, and plan
+digest before resolving each prerequisite from its attributed producer
+artifact, then publishes the terminal result under a bounded cleanup context;
+metadata is only a best-effort mirror. Identity, plan-decode, and digest
+failures happen before a producer can publish a trusted manifest, and retrying
+a producer can make artifact selection ambiguous; consumers fail closed in
+both cases, so retry the whole build. Use `buildkite-gha help`,
+`buildkite-gha help <command>`, or `buildkite-gha --version` for exact usage.
 
 ## Development
 
@@ -94,6 +98,12 @@ checks. Start an exact-commit build with `PHASE2_PROBE=upload` and
 trusted importer runs on `elastic-runners`; generated checkout-free jobs run on
 the ephemeral `hosted` queue, whose Agent version supports native checkout
 suppression.
+
+The Phase 3 proof uses the same importer boundary. Start an exact-commit build
+with `PHASE3_PROBE=concurrent` and `PHASE3_COMMIT=<full commit>` to load
+`.buildkite/phase-3-upload.yml`. To run the matching GitHub-hosted differential,
+dispatch `.github/workflows/phase-0-shell-oracle.yml` on that ref with the same
+`source_commit` and `target=concurrent`.
 
 ## License
 

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -733,8 +733,9 @@ process execution:
 - perform an implicit `wait-all` before post-job cleanup;
 - preserve wait/cancel behavior even though wait controls do not use normal
   step `if` evaluation;
-- send termination followed by forced termination after the documented grace
-  period for `cancel`; and
+- send `SIGINT`, then `SIGTERM` after 7.5 seconds, then force termination after
+  another 2.5 seconds for `cancel`; unlike GitHub's direct-process signaling,
+  apply each signal to the complete process group; and
 - reject parallel/background controls inside composite actions where GitHub
   does not permit them.
 
@@ -1331,8 +1332,8 @@ contract:
 - barrier-scoped visibility for outputs, environment changes, paths, and
   failures;
 - implicit `wait-all` before post-job cleanup;
-- graceful cancellation followed by forced process-tree termination after the
-  documented grace period;
+- `SIGINT` cancellation followed by `SIGTERM` after 7.5 seconds and forced
+  process-tree termination after another 2.5 seconds;
 - serialized workflow-command and mask registration across concurrent output
   streams.
 

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -140,8 +140,8 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 	if err := yaml.Unmarshal(source, &document); err != nil {
 		t.Fatalf("parse default pipeline: %v", err)
 	}
-	if len(document.Steps) != 4 {
-		t.Fatalf("default pipeline = %#v, want three gated probe loaders and repository checks", document.Steps)
+	if len(document.Steps) != 5 {
+		t.Fatalf("default pipeline = %#v, want four gated probe loaders and repository checks", document.Steps)
 	}
 	steps := make(map[string]struct {
 		command   string
@@ -164,6 +164,9 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 	}
 	if got := steps["phase-2-upload-loader"]; got.command != "buildkite-agent pipeline upload .buildkite/phase-2-upload.yml" || got.condition != `build.env("PHASE2_PROBE") == "upload"` {
 		t.Fatalf("Phase 2 upload loader = %#v", got)
+	}
+	if got := steps["phase-3-upload-loader"]; got.command != "buildkite-agent pipeline upload .buildkite/phase-3-upload.yml" || got.condition != `build.env("PHASE3_PROBE") == "concurrent"` {
+		t.Fatalf("Phase 3 upload loader = %#v", got)
 	}
 }
 
@@ -260,6 +263,66 @@ func TestPhase2UploadProofUsesPinnedUnprivilegedPath(t *testing.T) {
 	}
 	if len(generatedConsumers) != 0 {
 		t.Fatalf("Phase 2 continuation omits generated consumers: %#v", generatedConsumers)
+	}
+}
+
+func TestPhase3UploadProofPreservesSeparateContinuationLoader(t *testing.T) {
+	source, err := os.ReadFile(filepath.Join("..", "..", ".buildkite", "phase-3-upload.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(source)
+	for _, required := range []string{
+		`scripts/phase-0-shell-oracle-checkout "$$PHASE3_COMMIT"`,
+		`mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2`,
+		`mise exec -- go build -trimpath -buildvcs=false`,
+		`--event-path testdata/smoke/events/push.json`,
+		`--runtime-queue hosted`,
+		`testdata/smoke/.github/workflows/concurrent.yml`,
+	} {
+		if !strings.Contains(text, required) {
+			t.Fatalf("Phase 3 upload proof lacks %q:\n%s", required, source)
+		}
+	}
+	var upload struct {
+		Steps []struct {
+			Key       string `yaml:"key"`
+			Command   string `yaml:"command"`
+			DependsOn string `yaml:"depends_on"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(source, &upload); err != nil {
+		t.Fatal(err)
+	}
+	if len(upload.Steps) != 2 || upload.Steps[0].Key != "phase-3-upload-importer" {
+		t.Fatalf("Phase 3 upload proof = %#v", upload.Steps)
+	}
+	if upload.Steps[1].Key != "phase-3-continuation-loader" || upload.Steps[1].DependsOn != "phase-3-upload-importer" || upload.Steps[1].Command != "buildkite-agent pipeline upload .buildkite/phase-3-upload-continuation.yml" {
+		t.Fatalf("Phase 3 continuation loader = %#v", upload.Steps[1])
+	}
+
+	continuationSource, err := os.ReadFile(filepath.Join("..", "..", ".buildkite", "phase-3-upload-continuation.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var continuation struct {
+		Steps []struct {
+			Key       string `yaml:"key"`
+			DependsOn []struct {
+				Step         string `yaml:"step"`
+				AllowFailure bool   `yaml:"allow_failure"`
+			} `yaml:"depends_on"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(continuationSource, &continuation); err != nil {
+		t.Fatal(err)
+	}
+	if len(continuation.Steps) != 1 || continuation.Steps[0].Key != "phase-3-native-after-concurrent" || len(continuation.Steps[0].DependsOn) != 1 {
+		t.Fatalf("Phase 3 continuation = %#v", continuation.Steps)
+	}
+	dependency := continuation.Steps[0].DependsOn[0]
+	if dependency.Step != "gha-observe" || !dependency.AllowFailure {
+		t.Fatalf("Phase 3 continuation dependency = %#v", dependency)
 	}
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -508,9 +508,6 @@ func validateUnprivilegedBundle(bundle compiler.Bundle) error {
 			if step.Kind == "uses" || step.Uses != "" {
 				return fmt.Errorf("job %q contains action step %q, unavailable to checkout-free unprivileged upload", artifact.Job.Workflow.LogicalJobID, step.ID)
 			}
-			if step.Background || step.Kind == "wait" || step.Kind == "wait-all" || step.Kind == "cancel" {
-				return fmt.Errorf("job %q contains concurrent step %q, unavailable until the Phase 3 supervisor is active", artifact.Job.Workflow.LogicalJobID, step.ID)
-			}
 		}
 		for _, capability := range artifact.Job.RequiredCapabilities {
 			return fmt.Errorf("job %q requires capability %q, unavailable to unprivileged upload", artifact.Job.Workflow.LogicalJobID, capability)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -508,6 +508,9 @@ func validateUnprivilegedBundle(bundle compiler.Bundle) error {
 			if step.Kind == "uses" || step.Uses != "" {
 				return fmt.Errorf("job %q contains action step %q, unavailable to checkout-free unprivileged upload", artifact.Job.Workflow.LogicalJobID, step.ID)
 			}
+			if step.Background || step.Kind == "wait" || step.Kind == "wait-all" || step.Kind == "cancel" {
+				return fmt.Errorf("job %q contains concurrent step %q, unavailable until the Phase 3 supervisor is active", artifact.Job.Workflow.LogicalJobID, step.ID)
+			}
 		}
 		for _, capability := range artifact.Job.RequiredCapabilities {
 			return fmt.Errorf("job %q requires capability %q, unavailable to unprivileged upload", artifact.Job.Workflow.LogicalJobID, capability)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -199,6 +199,50 @@ func TestRunUploadCompilesArtifactsAndUploadsSelfContainedPipeline(t *testing.T)
 	}
 }
 
+func TestRunUploadCompilesConcurrentSmokePipeline(t *testing.T) {
+	workflowPath := filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "concurrent.yml")
+	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_STEP_KEY", "phase-3-upload-importer")
+	runner := &cliCaptureRunner{}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"upload", "--event-path", eventPath, "--runtime-queue", "hosted", workflowPath}, &stdout, &stderr, "dev", runner); code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Uploaded 2 jobs") || stderr.Len() != 0 {
+		t.Fatalf("stdout = %q, stderr = %q", stdout.String(), stderr.String())
+	}
+	if len(runner.commands) != 4 {
+		t.Fatalf("commands = %#v, want distribution, two plans, and pipeline", runner.commands)
+	}
+
+	var pipeline struct {
+		Steps []struct {
+			Key    string `yaml:"key"`
+			Agents struct {
+				Queue string `yaml:"queue"`
+			} `yaml:"agents"`
+			DependsOn []struct {
+				Step         string `yaml:"step"`
+				AllowFailure bool   `yaml:"allow_failure"`
+			} `yaml:"depends_on"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(runner.commands[3].stdin, &pipeline); err != nil {
+		t.Fatalf("uploaded pipeline YAML: %v", err)
+	}
+	if len(pipeline.Steps) != 2 {
+		t.Fatalf("uploaded steps = %#v", pipeline.Steps)
+	}
+	if pipeline.Steps[0].Key != "gha-concurrent" || pipeline.Steps[0].Agents.Queue != "hosted" || len(pipeline.Steps[0].DependsOn) != 1 || pipeline.Steps[0].DependsOn[0].Step != "phase-3-upload-importer" || pipeline.Steps[0].DependsOn[0].AllowFailure {
+		t.Fatalf("concurrent step = %#v", pipeline.Steps[0])
+	}
+	observer := pipeline.Steps[1]
+	if observer.Key != "gha-observe" || observer.Agents.Queue != "hosted" || len(observer.DependsOn) != 2 || observer.DependsOn[0].Step != "phase-3-upload-importer" || observer.DependsOn[0].AllowFailure || observer.DependsOn[1].Step != "gha-concurrent" || !observer.DependsOn[1].AllowFailure {
+		t.Fatalf("observer step = %#v", observer)
+	}
+}
+
 func TestRunUploadFailsClosedBeforePipeline(t *testing.T) {
 	workflowPath := filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "shell.yml")
 	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
@@ -241,20 +285,18 @@ func TestUnprivilegedUploadRejectsActionSteps(t *testing.T) {
 	}
 }
 
-func TestUnprivilegedUploadRejectsConcurrentStepsUntilSupervisorIsActive(t *testing.T) {
-	for _, step := range []plan.Step{
-		{ID: "background", Kind: "run", Command: "true", Background: true},
-		{ID: "wait", Kind: "wait", Targets: []string{"background"}},
-		{ID: "wait-all", Kind: "wait-all"},
-		{ID: "cancel", Kind: "cancel", Targets: []string{"background"}},
-	} {
-		bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: plan.Job{
-			Workflow: plan.Workflow{LogicalJobID: "concurrent-job"},
-			Steps:    []plan.Step{step},
-		}}}}
-		if err := validateUnprivilegedBundle(bundle); err == nil || !strings.Contains(err.Error(), "concurrent step") {
-			t.Fatalf("validateUnprivilegedBundle(%#v) error = %v, want concurrent-step rejection", step, err)
-		}
+func TestUnprivilegedUploadAllowsCapabilityFreeConcurrentShellSteps(t *testing.T) {
+	bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: plan.Job{
+		Workflow: plan.Workflow{LogicalJobID: "concurrent-job"},
+		Steps: []plan.Step{
+			{ID: "background", Kind: "run", Command: "true", Background: true},
+			{ID: "wait", Kind: "wait", Targets: []string{"background"}},
+			{ID: "wait-all", Kind: "wait-all"},
+			{ID: "cancel", Kind: "cancel", Targets: []string{"background"}},
+		},
+	}}}}
+	if err := validateUnprivilegedBundle(bundle); err != nil {
+		t.Fatalf("validateUnprivilegedBundle() error = %v", err)
 	}
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -241,6 +241,23 @@ func TestUnprivilegedUploadRejectsActionSteps(t *testing.T) {
 	}
 }
 
+func TestUnprivilegedUploadRejectsConcurrentStepsUntilSupervisorIsActive(t *testing.T) {
+	for _, step := range []plan.Step{
+		{ID: "background", Kind: "run", Command: "true", Background: true},
+		{ID: "wait", Kind: "wait", Targets: []string{"background"}},
+		{ID: "wait-all", Kind: "wait-all"},
+		{ID: "cancel", Kind: "cancel", Targets: []string{"background"}},
+	} {
+		bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: plan.Job{
+			Workflow: plan.Workflow{LogicalJobID: "concurrent-job"},
+			Steps:    []plan.Step{step},
+		}}}}
+		if err := validateUnprivilegedBundle(bundle); err == nil || !strings.Contains(err.Error(), "concurrent step") {
+			t.Fatalf("validateUnprivilegedBundle(%#v) error = %v, want concurrent-step rejection", step, err)
+		}
+	}
+}
+
 type cliCommand struct {
 	dir   string
 	name  string

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -58,8 +58,8 @@ func TestCompileBundleCompilesSmokeCorpus(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(workflows) != 3 {
-		t.Fatalf("smoke workflows = %d, want 3", len(workflows))
+	if len(workflows) != 4 {
+		t.Fatalf("smoke workflows = %d, want 4", len(workflows))
 	}
 	event := readFile(t, smokePath("events", "push.json"))
 	for _, path := range workflows {

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -229,7 +229,7 @@ func compilePlans(ir IR, compilerVersion, compilerDistributionDigest string) ([]
 			}
 			span := planSpan(step.Span)
 			steps[i] = plan.Step{
-				ID: id, Name: step.Name, Kind: step.Kind, Command: step.Run, Uses: step.Uses,
+				ID: id, Name: step.Name, Kind: step.Kind, Background: step.Background, Targets: append([]string(nil), step.Targets...), Command: step.Run, Uses: step.Uses,
 				Shell: step.Shell, WorkingDirectory: step.WorkingDirectory,
 				Env: cloneMap(step.Env), With: cloneMap(step.With), Condition: step.If,
 				ContinueOnError: step.ContinueOnError, TimeoutMinutes: step.TimeoutMinutes, Source: &span,

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -844,6 +844,12 @@ jobs:
         continue-on-error: true
       - wait-all:
       - cancel: first
+      - parallel:
+          - run: echo ${{ secrets.PARALLEL_TOKEN }}
+            env:
+              PARALLEL_SECRET: ${{ secrets.PARALLEL_TOKEN }}
+          - id: named-parallel
+            run: echo named
 `)
 	plans, err := CompilePlans(path, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
 	if err != nil {
@@ -853,7 +859,7 @@ jobs:
 		t.Fatalf("plans = %#v, want one v2 plan", plans)
 	}
 	steps := plans[0].Steps
-	if len(steps) != 5 || !steps[0].Background || !steps[1].Background {
+	if len(steps) != 8 || !steps[0].Background || !steps[1].Background {
 		t.Fatalf("background plan steps = %#v", steps)
 	}
 	if steps[2].Kind != "wait" || !reflect.DeepEqual(steps[2].Targets, []string{"first", "second"}) || !steps[2].ContinueOnError {
@@ -861,6 +867,15 @@ jobs:
 	}
 	if steps[3].Kind != "wait-all" || steps[4].Kind != "cancel" || !reflect.DeepEqual(steps[4].Targets, []string{"first"}) {
 		t.Fatalf("plan controls = %#v", steps[3:])
+	}
+	if !steps[5].Background || !steps[6].Background || steps[5].ID == "" || steps[6].ID != "named-parallel" {
+		t.Fatalf("lowered parallel members = %#v", steps[5:7])
+	}
+	if steps[7].Kind != "wait" || !reflect.DeepEqual(steps[7].Targets, []string{steps[5].ID, "named-parallel"}) {
+		t.Fatalf("lowered parallel barrier = %#v", steps[7])
+	}
+	if !reflect.DeepEqual(plans[0].RequiredSecrets, []string{"PARALLEL_TOKEN"}) || !plans[0].HasCapability("secrets") {
+		t.Fatalf("parallel secrets = %#v, capabilities = %#v", plans[0].RequiredSecrets, plans[0].RequiredCapabilities)
 	}
 }
 

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -840,8 +840,8 @@ jobs:
       - id: second
         run: echo second
         background: true
-      - wait: [first, second]
         continue-on-error: true
+      - wait: [first, second]
       - wait-all:
       - cancel: first
       - parallel:
@@ -862,7 +862,7 @@ jobs:
 	if len(steps) != 8 || !steps[0].Background || !steps[1].Background {
 		t.Fatalf("background plan steps = %#v", steps)
 	}
-	if steps[2].Kind != "wait" || !reflect.DeepEqual(steps[2].Targets, []string{"first", "second"}) || !steps[2].ContinueOnError {
+	if !steps[1].ContinueOnError || steps[2].Kind != "wait" || !reflect.DeepEqual(steps[2].Targets, []string{"first", "second"}) || steps[2].ContinueOnError {
 		t.Fatalf("targeted plan barrier = %#v", steps[2])
 	}
 	if steps[3].Kind != "wait-all" || steps[4].Kind != "cancel" || !reflect.DeepEqual(steps[4].Targets, []string{"first"}) {

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -54,7 +54,7 @@ func TestCompileShellGoldenGraph(t *testing.T) {
 
 func TestCompileIsByteIdenticalAndCoversSmokeCorpus(t *testing.T) {
 	eventSource := readFile(t, smokePath("events", "push.json"))
-	for _, name := range []string{"shell.yml", "ci.yml", "artifact.yml"} {
+	for _, name := range []string{"shell.yml", "concurrent.yml", "ci.yml", "artifact.yml"} {
 		t.Run(name, func(t *testing.T) {
 			path := smokePath(".github", "workflows", name)
 			source := readFile(t, path)
@@ -876,6 +876,20 @@ jobs:
 	}
 	if !reflect.DeepEqual(plans[0].RequiredSecrets, []string{"PARALLEL_TOKEN"}) || !plans[0].HasCapability("secrets") {
 		t.Fatalf("parallel secrets = %#v, capabilities = %#v", plans[0].RequiredSecrets, plans[0].RequiredCapabilities)
+	}
+}
+
+func TestConcurrentSmokeTerminalKeyMatchesNativeContinuation(t *testing.T) {
+	path := smokePath(".github", "workflows", "concurrent.yml")
+	plans, err := CompilePlans(path, readFile(t, path), readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 2 || plans[0].Target.StepKey != "gha-concurrent" || plans[1].Target.StepKey != "gha-observe" {
+		t.Fatalf("concurrent smoke targets = %#v", plans)
+	}
+	if !reflect.DeepEqual(plans[1].Dependencies, []string{"gha-concurrent"}) {
+		t.Fatalf("observer dependencies = %#v", plans[1].Dependencies)
 	}
 }
 

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -826,6 +826,44 @@ jobs:
 	}
 }
 
+func TestCompilePlansOwnsConcurrentStepControls(t *testing.T) {
+	path := smokePath(".github", "workflows", "concurrent.yml")
+	source := []byte(`name: concurrent plan
+on: push
+jobs:
+  concurrent:
+    runs-on: ubuntu-latest
+    steps:
+      - id: first
+        run: echo first
+        background: true
+      - id: second
+        run: echo second
+        background: true
+      - wait: [first, second]
+        continue-on-error: true
+      - wait-all:
+      - cancel: first
+`)
+	plans, err := CompilePlans(path, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 1 || plans[0].Schema != plan.SchemaV2 {
+		t.Fatalf("plans = %#v, want one v2 plan", plans)
+	}
+	steps := plans[0].Steps
+	if len(steps) != 5 || !steps[0].Background || !steps[1].Background {
+		t.Fatalf("background plan steps = %#v", steps)
+	}
+	if steps[2].Kind != "wait" || !reflect.DeepEqual(steps[2].Targets, []string{"first", "second"}) || !steps[2].ContinueOnError {
+		t.Fatalf("targeted plan barrier = %#v", steps[2])
+	}
+	if steps[3].Kind != "wait-all" || steps[4].Kind != "cancel" || !reflect.DeepEqual(steps[4].Targets, []string{"first"}) {
+		t.Fatalf("plan controls = %#v", steps[3:])
+	}
+}
+
 func TestCompilePlansRecordsStaticDependenciesWithVerifiedNeedSources(t *testing.T) {
 	path := smokePath(".github", "workflows", "shell.yml")
 	plans, err := CompilePlans(path, readFile(t, path), readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
@@ -998,7 +1036,7 @@ func TestCompiledPlansValidateAgainstVersionedSchema(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	schemaSource := readFile(t, filepath.Join("..", "..", "schemas", "job-plan-v1.schema.json"))
+	schemaSource := readFile(t, filepath.Join("..", "..", "schemas", "job-plan-v2.schema.json"))
 	var schemaDocument any
 	if err := json.Unmarshal(schemaSource, &schemaDocument); err != nil {
 		t.Fatal(err)

--- a/internal/compiler/testdata/shell.pipeline.golden.yml
+++ b/internal/compiler/testdata/shell.pipeline.golden.yml
@@ -1,28 +1,28 @@
 steps:
   - label: "producer"
     key: "gha-producer"
-    command: "set -euo pipefail\nbootstrap_dir=\"$(mktemp -d \"${TMPDIR:-/tmp}/buildkite-gha.XXXXXXXX\")\"\ntrap 'rm -rf -- \"$bootstrap_dir\"' EXIT\nbuildkite-agent artifact download '.buildkite-gha/distributions/2222222222222222222222222222222222222222222222222222222222222222/buildkite-gha' \"$bootstrap_dir\" --step 'gha-importer'\nbuildkite-agent artifact download '.buildkite-gha/plans/3ab11157376c6fcf6419f4aa518d1a8ed1d9b64db1e249c38483f5d0742081bf.json' \"$bootstrap_dir\" --step 'gha-importer'\ndistribution=\"$bootstrap_dir/.buildkite-gha/distributions/2222222222222222222222222222222222222222222222222222222222222222/buildkite-gha\"\nplan=\"$bootstrap_dir/.buildkite-gha/plans/3ab11157376c6fcf6419f4aa518d1a8ed1d9b64db1e249c38483f5d0742081bf.json\"\nactual_distribution_digest=\"$(sha256sum \"$distribution\" | awk '{print \"sha256:\" $1}')\"\ntest \"$actual_distribution_digest\" = 'sha256:2222222222222222222222222222222222222222222222222222222222222222'\nchmod 0500 \"$distribution\"\n\"$distribution\" run-job --plan \"$plan\""
+    command: "set -euo pipefail\nbootstrap_dir=\"$(mktemp -d \"${TMPDIR:-/tmp}/buildkite-gha.XXXXXXXX\")\"\ntrap 'rm -rf -- \"$bootstrap_dir\"' EXIT\nbuildkite-agent artifact download '.buildkite-gha/distributions/2222222222222222222222222222222222222222222222222222222222222222/buildkite-gha' \"$bootstrap_dir\" --step 'gha-importer'\nbuildkite-agent artifact download '.buildkite-gha/plans/d7286589fecd60e590f1e59cd975f7ad104fd0752cecd8a89ff025ce89c4eca2.json' \"$bootstrap_dir\" --step 'gha-importer'\ndistribution=\"$bootstrap_dir/.buildkite-gha/distributions/2222222222222222222222222222222222222222222222222222222222222222/buildkite-gha\"\nplan=\"$bootstrap_dir/.buildkite-gha/plans/d7286589fecd60e590f1e59cd975f7ad104fd0752cecd8a89ff025ce89c4eca2.json\"\nactual_distribution_digest=\"$(sha256sum \"$distribution\" | awk '{print \"sha256:\" $1}')\"\ntest \"$actual_distribution_digest\" = 'sha256:2222222222222222222222222222222222222222222222222222222222222222'\nchmod 0500 \"$distribution\"\n\"$distribution\" run-job --plan \"$plan\""
     agents:
       queue: "gha-untrusted"
     checkout:
       skip: true
     env:
-      BUILDKITE_GHA_PLAN_DIGEST: "sha256:3ab11157376c6fcf6419f4aa518d1a8ed1d9b64db1e249c38483f5d0742081bf"
-      BUILDKITE_GHA_PLAN_PATH: ".buildkite-gha/plans/3ab11157376c6fcf6419f4aa518d1a8ed1d9b64db1e249c38483f5d0742081bf.json"
+      BUILDKITE_GHA_PLAN_DIGEST: "sha256:d7286589fecd60e590f1e59cd975f7ad104fd0752cecd8a89ff025ce89c4eca2"
+      BUILDKITE_GHA_PLAN_PATH: ".buildkite-gha/plans/d7286589fecd60e590f1e59cd975f7ad104fd0752cecd8a89ff025ce89c4eca2.json"
       BUILDKITE_GHA_PLAN_PRODUCER: "gha-importer"
     depends_on:
       - step: "gha-importer"
         allow_failure: false
   - label: "consumer (variant=one)"
     key: "gha-consumer-5ebbc197d87b"
-    command: "set -euo pipefail\nbootstrap_dir=\"$(mktemp -d \"${TMPDIR:-/tmp}/buildkite-gha.XXXXXXXX\")\"\ntrap 'rm -rf -- \"$bootstrap_dir\"' EXIT\nbuildkite-agent artifact download '.buildkite-gha/distributions/2222222222222222222222222222222222222222222222222222222222222222/buildkite-gha' \"$bootstrap_dir\" --step 'gha-importer'\nbuildkite-agent artifact download '.buildkite-gha/plans/05bc2b1c62bd8f9843199f56089a6cc1587ca71add082091091eb3a3c377fccc.json' \"$bootstrap_dir\" --step 'gha-importer'\ndistribution=\"$bootstrap_dir/.buildkite-gha/distributions/2222222222222222222222222222222222222222222222222222222222222222/buildkite-gha\"\nplan=\"$bootstrap_dir/.buildkite-gha/plans/05bc2b1c62bd8f9843199f56089a6cc1587ca71add082091091eb3a3c377fccc.json\"\nactual_distribution_digest=\"$(sha256sum \"$distribution\" | awk '{print \"sha256:\" $1}')\"\ntest \"$actual_distribution_digest\" = 'sha256:2222222222222222222222222222222222222222222222222222222222222222'\nchmod 0500 \"$distribution\"\n\"$distribution\" run-job --plan \"$plan\""
+    command: "set -euo pipefail\nbootstrap_dir=\"$(mktemp -d \"${TMPDIR:-/tmp}/buildkite-gha.XXXXXXXX\")\"\ntrap 'rm -rf -- \"$bootstrap_dir\"' EXIT\nbuildkite-agent artifact download '.buildkite-gha/distributions/2222222222222222222222222222222222222222222222222222222222222222/buildkite-gha' \"$bootstrap_dir\" --step 'gha-importer'\nbuildkite-agent artifact download '.buildkite-gha/plans/87f9d57de2a880a092696d9a734220313c5719bc9c6f80f34beb87ddae3f5f07.json' \"$bootstrap_dir\" --step 'gha-importer'\ndistribution=\"$bootstrap_dir/.buildkite-gha/distributions/2222222222222222222222222222222222222222222222222222222222222222/buildkite-gha\"\nplan=\"$bootstrap_dir/.buildkite-gha/plans/87f9d57de2a880a092696d9a734220313c5719bc9c6f80f34beb87ddae3f5f07.json\"\nactual_distribution_digest=\"$(sha256sum \"$distribution\" | awk '{print \"sha256:\" $1}')\"\ntest \"$actual_distribution_digest\" = 'sha256:2222222222222222222222222222222222222222222222222222222222222222'\nchmod 0500 \"$distribution\"\n\"$distribution\" run-job --plan \"$plan\""
     agents:
       queue: "gha-untrusted"
     checkout:
       skip: true
     env:
-      BUILDKITE_GHA_PLAN_DIGEST: "sha256:05bc2b1c62bd8f9843199f56089a6cc1587ca71add082091091eb3a3c377fccc"
-      BUILDKITE_GHA_PLAN_PATH: ".buildkite-gha/plans/05bc2b1c62bd8f9843199f56089a6cc1587ca71add082091091eb3a3c377fccc.json"
+      BUILDKITE_GHA_PLAN_DIGEST: "sha256:87f9d57de2a880a092696d9a734220313c5719bc9c6f80f34beb87ddae3f5f07"
+      BUILDKITE_GHA_PLAN_PATH: ".buildkite-gha/plans/87f9d57de2a880a092696d9a734220313c5719bc9c6f80f34beb87ddae3f5f07.json"
       BUILDKITE_GHA_PLAN_PRODUCER: "gha-importer"
     depends_on:
       - step: "gha-importer"
@@ -31,14 +31,14 @@ steps:
         allow_failure: true
   - label: "consumer (variant=two)"
     key: "gha-consumer-91934b28b00f"
-    command: "set -euo pipefail\nbootstrap_dir=\"$(mktemp -d \"${TMPDIR:-/tmp}/buildkite-gha.XXXXXXXX\")\"\ntrap 'rm -rf -- \"$bootstrap_dir\"' EXIT\nbuildkite-agent artifact download '.buildkite-gha/distributions/2222222222222222222222222222222222222222222222222222222222222222/buildkite-gha' \"$bootstrap_dir\" --step 'gha-importer'\nbuildkite-agent artifact download '.buildkite-gha/plans/8ea926ee39a5fc0f13f1f35460bba48aa7430194eae526b674e8a85c7862ae34.json' \"$bootstrap_dir\" --step 'gha-importer'\ndistribution=\"$bootstrap_dir/.buildkite-gha/distributions/2222222222222222222222222222222222222222222222222222222222222222/buildkite-gha\"\nplan=\"$bootstrap_dir/.buildkite-gha/plans/8ea926ee39a5fc0f13f1f35460bba48aa7430194eae526b674e8a85c7862ae34.json\"\nactual_distribution_digest=\"$(sha256sum \"$distribution\" | awk '{print \"sha256:\" $1}')\"\ntest \"$actual_distribution_digest\" = 'sha256:2222222222222222222222222222222222222222222222222222222222222222'\nchmod 0500 \"$distribution\"\n\"$distribution\" run-job --plan \"$plan\""
+    command: "set -euo pipefail\nbootstrap_dir=\"$(mktemp -d \"${TMPDIR:-/tmp}/buildkite-gha.XXXXXXXX\")\"\ntrap 'rm -rf -- \"$bootstrap_dir\"' EXIT\nbuildkite-agent artifact download '.buildkite-gha/distributions/2222222222222222222222222222222222222222222222222222222222222222/buildkite-gha' \"$bootstrap_dir\" --step 'gha-importer'\nbuildkite-agent artifact download '.buildkite-gha/plans/f4c7b6ef3aeb2ccd2b3a0f31d2c9d7c41a54b90864f42fe6fd06cb2d3dddcda9.json' \"$bootstrap_dir\" --step 'gha-importer'\ndistribution=\"$bootstrap_dir/.buildkite-gha/distributions/2222222222222222222222222222222222222222222222222222222222222222/buildkite-gha\"\nplan=\"$bootstrap_dir/.buildkite-gha/plans/f4c7b6ef3aeb2ccd2b3a0f31d2c9d7c41a54b90864f42fe6fd06cb2d3dddcda9.json\"\nactual_distribution_digest=\"$(sha256sum \"$distribution\" | awk '{print \"sha256:\" $1}')\"\ntest \"$actual_distribution_digest\" = 'sha256:2222222222222222222222222222222222222222222222222222222222222222'\nchmod 0500 \"$distribution\"\n\"$distribution\" run-job --plan \"$plan\""
     agents:
       queue: "gha-untrusted"
     checkout:
       skip: true
     env:
-      BUILDKITE_GHA_PLAN_DIGEST: "sha256:8ea926ee39a5fc0f13f1f35460bba48aa7430194eae526b674e8a85c7862ae34"
-      BUILDKITE_GHA_PLAN_PATH: ".buildkite-gha/plans/8ea926ee39a5fc0f13f1f35460bba48aa7430194eae526b674e8a85c7862ae34.json"
+      BUILDKITE_GHA_PLAN_DIGEST: "sha256:f4c7b6ef3aeb2ccd2b3a0f31d2c9d7c41a54b90864f42fe6fd06cb2d3dddcda9"
+      BUILDKITE_GHA_PLAN_PATH: ".buildkite-gha/plans/f4c7b6ef3aeb2ccd2b3a0f31d2c9d7c41a54b90864f42fe6fd06cb2d3dddcda9.json"
       BUILDKITE_GHA_PLAN_PRODUCER: "gha-importer"
     depends_on:
       - step: "gha-importer"

--- a/internal/compiler/testdata/shell.plans.golden.json
+++ b/internal/compiler/testdata/shell.plans.golden.json
@@ -1,6 +1,6 @@
 [
   {
-    "schema": "https://buildkite.com/schemas/buildkite-gha/job-plan-v1.schema.json",
+    "schema": "https://buildkite.com/schemas/buildkite-gha/job-plan-v2.schema.json",
     "compiler": {
       "version": "0.0.0-test",
       "distribution_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
@@ -68,7 +68,7 @@
     ]
   },
   {
-    "schema": "https://buildkite.com/schemas/buildkite-gha/job-plan-v1.schema.json",
+    "schema": "https://buildkite.com/schemas/buildkite-gha/job-plan-v2.schema.json",
     "compiler": {
       "version": "0.0.0-test",
       "distribution_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
@@ -102,7 +102,7 @@
       "producer": [
         {
           "step_key": "gha-producer",
-          "plan_digest": "sha256:3ab11157376c6fcf6419f4aa518d1a8ed1d9b64db1e249c38483f5d0742081bf"
+          "plan_digest": "sha256:d7286589fecd60e590f1e59cd975f7ad104fd0752cecd8a89ff025ce89c4eca2"
         }
       ]
     },
@@ -131,7 +131,7 @@
     ]
   },
   {
-    "schema": "https://buildkite.com/schemas/buildkite-gha/job-plan-v1.schema.json",
+    "schema": "https://buildkite.com/schemas/buildkite-gha/job-plan-v2.schema.json",
     "compiler": {
       "version": "0.0.0-test",
       "distribution_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
@@ -165,7 +165,7 @@
       "producer": [
         {
           "step_key": "gha-producer",
-          "plan_digest": "sha256:3ab11157376c6fcf6419f4aa518d1a8ed1d9b64db1e249c38483f5d0742081bf"
+          "plan_digest": "sha256:d7286589fecd60e590f1e59cd975f7ad104fd0752cecd8a89ff025ce89c4eca2"
         }
       ]
     },

--- a/internal/harness/cmd/shell-oracle/main.go
+++ b/internal/harness/cmd/shell-oracle/main.go
@@ -41,13 +41,23 @@ func run(ctx context.Context, args []string) error {
 	case "compare":
 		commit := flags.String("commit", "", "exact materialized fixture commit")
 		provider := flags.String("provider", "", "provider that produced standard input")
+		target := flags.String("target", "shell", "fixture target to compare: shell or concurrent")
 		if err := flags.Parse(args[1:]); err != nil {
 			return err
 		}
 		if flags.NArg() != 0 {
 			return fmt.Errorf("compare accepts observations on standard input only")
 		}
-		normalized, err := harness.CompareShellOracle(ctx, *source, *commit, *provider, os.Stdin)
+		var normalized []byte
+		var err error
+		switch *target {
+		case "shell":
+			normalized, err = harness.CompareShellOracle(ctx, *source, *commit, *provider, os.Stdin)
+		case "concurrent":
+			normalized, err = harness.CompareConcurrentOracle(ctx, *source, *commit, *provider, os.Stdin)
+		default:
+			return fmt.Errorf("unknown compare target %q", *target)
+		}
 		if err != nil {
 			return err
 		}

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -242,6 +242,36 @@ func CaptureShellOutput(provider string, output io.Reader) (Capture, error) {
 	return capture, nil
 }
 
+// CaptureConcurrentOutput extracts the single portable observation emitted by
+// concurrent.yml after all Phase 3 assertions have passed.
+func CaptureConcurrentOutput(provider string, output io.Reader) (Capture, error) {
+	const marker = "PHASE3_OBSERVATION="
+	capture := Capture{Provider: provider}
+	scanner := bufio.NewScanner(output)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		index := strings.Index(line, marker)
+		if index < 0 {
+			continue
+		}
+		document := json.RawMessage(strings.TrimSpace(line[index+len(marker):]))
+		var value map[string]any
+		if err := decodeJSON(document, &value); err != nil {
+			return Capture{}, fmt.Errorf("decode concurrent observation: %w", err)
+		}
+		capture.Observations = append(capture.Observations, Record{Identity: "concurrent", Document: document})
+	}
+	if err := scanner.Err(); err != nil {
+		return Capture{}, fmt.Errorf("read concurrent output: %w", err)
+	}
+	expected := Capture{Observations: []Record{{Identity: "concurrent", Document: json.RawMessage(`{"cancel":"graceful","failure":"failure-at-wait","implicit":"implicit-wait-all","parallel":"parallel","queue_max":10,"targeted":"targeted-and-full"}`)}}}
+	if err := Compare(expected, capture); err != nil {
+		return Capture{}, fmt.Errorf("capture concurrent target: %w", err)
+	}
+	return capture, nil
+}
+
 // ReadObservation reads a JSON observation below root. Absolute paths, parent
 // traversal, and symlinks that resolve outside root are rejected.
 func ReadObservation(root, identity, path string) (Record, error) {

--- a/internal/harness/oracle_config_test.go
+++ b/internal/harness/oracle_config_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -108,11 +109,47 @@ func TestGitHubShellOracleDefinitionIsManualAndPinned(t *testing.T) {
 	if required := yamlMap(t, sourceCommit, "source_commit")["required"]; required != true {
 		t.Fatalf("source_commit required = %#v, want true", required)
 	}
+	target := yamlMap(t, inputs["target"], "target")
+	if target["default"] != "shell" || !reflect.DeepEqual(target["options"], []any{"shell", "concurrent"}) {
+		t.Fatalf("target input = %#v, want shell default and exact target choices", target)
+	}
 	assertDefinitionText(t, path, []string{
 		"internal/harness/cmd/shell-oracle materialize",
 		"internal/harness/cmd/shell-oracle compare",
 		"--provider github",
 		"scripts/phase-0-shell-oracle-checkout",
+	})
+}
+
+func TestGitHubConcurrentOracleMatchesSmokeFixture(t *testing.T) {
+	fixturePath := filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "concurrent.yml")
+	fixture := readYAMLMap(t, fixturePath)
+	fixtureJob := yamlMap(t, yamlMap(t, fixture["jobs"], "fixture jobs")["concurrent"], "fixture concurrent job")
+
+	oraclePath := filepath.Join("..", "..", ".github", "workflows", "phase-0-shell-oracle.yml")
+	oracle := readYAMLMap(t, oraclePath)
+	oracleJobs := yamlMap(t, oracle["jobs"], "oracle jobs")
+	oracleJob := yamlMap(t, oracleJobs["concurrent"], "oracle concurrent job")
+	for _, field := range []string{"outputs", "steps"} {
+		if !reflect.DeepEqual(oracleJob[field], fixtureJob[field]) {
+			t.Fatalf("concurrent oracle %s differs from smoke fixture", field)
+		}
+	}
+	if oracleJob["if"] != "inputs.target == 'concurrent'" || oracleJob["needs"] != "prepare" {
+		t.Fatalf("concurrent oracle selection or preparation edge = %#v", oracleJob)
+	}
+	if _, ok := oracleJobs["concurrent-observe"]; !ok {
+		t.Fatal("concurrent oracle has no observation job")
+	}
+	if _, ok := oracleJobs["concurrent-compare"]; !ok {
+		t.Fatal("concurrent oracle has no comparison job")
+	}
+	assertDefinitionText(t, oraclePath, []string{
+		"PHASE3_OBSERVATION=",
+		"github-concurrent-observation",
+		"--target concurrent",
+		"needs: [prepare, concurrent]",
+		"needs: [prepare, concurrent-observe]",
 	})
 }
 

--- a/internal/harness/shell_oracle.go
+++ b/internal/harness/shell_oracle.go
@@ -11,6 +11,7 @@ import (
 )
 
 const shellExpectedCapturePath = "expected/shell-capture.json"
+const concurrentExpectedCapturePath = "expected/concurrent-capture.json"
 
 var shellFixtureIdentity = CommitIdentity{
 	Name:  "buildkite-gha shell oracle",
@@ -28,6 +29,16 @@ func MaterializeShellFixture(ctx context.Context, source string) (*Repository, e
 // fixture commit, captures provider output, and compares its normalized form
 // with the checked-in portable expectation.
 func CompareShellOracle(ctx context.Context, source, expectedCommit, provider string, output io.Reader) (result []byte, err error) {
+	return compareFixtureOracle(ctx, source, expectedCommit, provider, shellExpectedCapturePath, output, CaptureShellOutput)
+}
+
+// CompareConcurrentOracle compares the Phase 3 concurrent-step observation
+// with the portable expectation in the same exact materialized fixture.
+func CompareConcurrentOracle(ctx context.Context, source, expectedCommit, provider string, output io.Reader) (result []byte, err error) {
+	return compareFixtureOracle(ctx, source, expectedCommit, provider, concurrentExpectedCapturePath, output, CaptureConcurrentOutput)
+}
+
+func compareFixtureOracle(ctx context.Context, source, expectedCommit, provider, expectedPath string, output io.Reader, captureOutput func(string, io.Reader) (Capture, error)) (result []byte, err error) {
 	if expectedCommit == "" {
 		return nil, errors.New("expected fixture commit is required")
 	}
@@ -46,7 +57,7 @@ func CompareShellOracle(ctx context.Context, source, expectedCommit, provider st
 		return nil, fmt.Errorf("fixture commit differs: expected %s, got %s", expectedCommit, repository.Commit)
 	}
 
-	capture, err := CaptureShellOutput(provider, output)
+	capture, err := captureOutput(provider, output)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +70,7 @@ func CompareShellOracle(ctx context.Context, source, expectedCommit, provider st
 	if err != nil {
 		return nil, fmt.Errorf("open materialized fixture: %w", err)
 	}
-	expected, readErr := root.ReadFile(shellExpectedCapturePath)
+	expected, readErr := root.ReadFile(expectedPath)
 	if err := errors.Join(readErr, root.Close()); err != nil {
 		return nil, fmt.Errorf("read expected shell capture: %w", err)
 	}

--- a/internal/harness/shell_oracle_test.go
+++ b/internal/harness/shell_oracle_test.go
@@ -58,6 +58,27 @@ func TestShellOracleRejectsCommitAndCaptureDrift(t *testing.T) {
 	}
 }
 
+func TestConcurrentOracleMaterializesAndComparesExactFixture(t *testing.T) {
+	source := smokeFixturePath()
+	repository, err := MaterializeShellFixture(context.Background(), source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commit := repository.Commit
+	if err := repository.Close(); err != nil {
+		t.Fatal(err)
+	}
+	output := strings.NewReader(`prefix PHASE3_OBSERVATION={"targeted":"targeted-and-full","queue_max":10,"parallel":"parallel","implicit":"implicit-wait-all","failure":"failure-at-wait","cancel":"graceful"}`)
+	got, err := CompareConcurrentOracle(context.Background(), source, commit, "test", output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `{"observations":[{"identity":"concurrent","document":{"cancel":"graceful","failure":"failure-at-wait","implicit":"implicit-wait-all","parallel":"parallel","queue_max":10,"targeted":"targeted-and-full"}}],"lifecycle":[]}`
+	if string(got) != want {
+		t.Fatalf("CompareConcurrentOracle() = %s, want %s", got, want)
+	}
+}
+
 func smokeFixturePath() string {
 	return "../../testdata/smoke"
 }

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -375,7 +375,7 @@ func (job Job) Validate() error {
 }
 
 func validateControlStep(step Step, backgroundIDs map[string]struct{}) error {
-	if step.Background || step.Command != "" || step.Uses != "" || step.Shell != "" || step.WorkingDirectory != "" || len(step.Env) != 0 || len(step.With) != 0 || step.Condition != "" || step.TimeoutMinutes != 0 {
+	if step.Background || step.Command != "" || step.Uses != "" || step.Shell != "" || step.WorkingDirectory != "" || len(step.Env) != 0 || len(step.With) != 0 || step.Condition != "" || step.ContinueOnError || step.TimeoutMinutes != 0 {
 		return fmt.Errorf("control step %q contains incompatible execution fields", step.ID)
 	}
 	switch step.Kind {
@@ -391,9 +391,6 @@ func validateControlStep(step Step, backgroundIDs map[string]struct{}) error {
 	case "cancel":
 		if len(step.Targets) != 1 {
 			return fmt.Errorf("cancel step %q must target exactly one background step", step.ID)
-		}
-		if step.ContinueOnError {
-			return fmt.Errorf("cancel step %q cannot continue on error", step.ID)
 		}
 	}
 	seen := make(map[string]struct{}, len(step.Targets))

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -11,9 +11,14 @@ import (
 	"strings"
 )
 
-const Schema = "https://buildkite.com/schemas/buildkite-gha/job-plan-v1.schema.json"
+const (
+	SchemaV1 = "https://buildkite.com/schemas/buildkite-gha/job-plan-v1.schema.json"
+	SchemaV2 = "https://buildkite.com/schemas/buildkite-gha/job-plan-v2.schema.json"
+	Schema   = SchemaV2
+)
 
 const MaxNeedProducers = 256
+const MaxStepTargets = 256
 
 var digestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
 var targetPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,255}$`)
@@ -72,6 +77,8 @@ type Step struct {
 	ID               string            `json:"id"`
 	Name             string            `json:"name,omitempty"`
 	Kind             string            `json:"kind"`
+	Background       bool              `json:"background,omitempty"`
+	Targets          []string          `json:"targets,omitempty"`
 	Command          string            `json:"command,omitempty"`
 	Uses             string            `json:"uses,omitempty"`
 	Shell            string            `json:"shell,omitempty"`
@@ -212,7 +219,7 @@ func Encode(job Job) ([]byte, error) {
 }
 
 func (job Job) Validate() error {
-	if job.Schema != Schema {
+	if job.Schema != SchemaV1 && job.Schema != SchemaV2 {
 		return fmt.Errorf("unsupported job plan schema %q", job.Schema)
 	}
 	if job.Compiler.Version == "" || !digestPattern.MatchString(job.Compiler.DistributionDigest) {
@@ -313,6 +320,7 @@ func (job Job) Validate() error {
 		return fmt.Errorf("job plan contains no steps")
 	}
 	ids := make(map[string]struct{}, len(job.Steps))
+	backgroundIDs := make(map[string]struct{})
 	for i, step := range job.Steps {
 		if step.ID == "" {
 			return fmt.Errorf("job plan step %d has no deterministic id", i+1)
@@ -331,17 +339,75 @@ func (job Job) Validate() error {
 		if len(step.Condition) > 65536 {
 			return fmt.Errorf("job plan step %q condition exceeds 65536 bytes", step.ID)
 		}
+		if job.Schema == SchemaV1 && (step.Background || len(step.Targets) != 0 || step.Kind != "run" && step.Kind != "uses") {
+			return fmt.Errorf("job plan v1 step %q contains concurrent-step fields", step.ID)
+		}
 		switch step.Kind {
 		case "run":
 			if strings.TrimSpace(step.Command) == "" {
 				return fmt.Errorf("run step %q has no command", step.ID)
 			}
+			if step.Uses != "" || len(step.Targets) != 0 {
+				return fmt.Errorf("run step %q contains incompatible action or control fields", step.ID)
+			}
+			if step.Background {
+				backgroundIDs[id] = struct{}{}
+			}
 		case "uses":
 			if strings.TrimSpace(step.Uses) == "" {
 				return fmt.Errorf("action step %q has no action reference", step.ID)
 			}
+			if step.Command != "" || len(step.Targets) != 0 {
+				return fmt.Errorf("action step %q contains incompatible run or control fields", step.ID)
+			}
+			if step.Background {
+				backgroundIDs[id] = struct{}{}
+			}
+		case "wait", "wait-all", "cancel":
+			if err := validateControlStep(step, backgroundIDs); err != nil {
+				return err
+			}
 		default:
 			return fmt.Errorf("step %q has unsupported kind %q", step.ID, step.Kind)
+		}
+	}
+	return nil
+}
+
+func validateControlStep(step Step, backgroundIDs map[string]struct{}) error {
+	if step.Background || step.Command != "" || step.Uses != "" || step.Shell != "" || step.WorkingDirectory != "" || len(step.Env) != 0 || len(step.With) != 0 || step.Condition != "" || step.TimeoutMinutes != 0 {
+		return fmt.Errorf("control step %q contains incompatible execution fields", step.ID)
+	}
+	switch step.Kind {
+	case "wait":
+		if len(step.Targets) == 0 || len(step.Targets) > MaxStepTargets {
+			return fmt.Errorf("wait step %q must target between 1 and %d background steps", step.ID, MaxStepTargets)
+		}
+	case "wait-all":
+		if len(step.Targets) != 0 {
+			return fmt.Errorf("wait-all step %q cannot target individual steps", step.ID)
+		}
+		return nil
+	case "cancel":
+		if len(step.Targets) != 1 {
+			return fmt.Errorf("cancel step %q must target exactly one background step", step.ID)
+		}
+		if step.ContinueOnError {
+			return fmt.Errorf("cancel step %q cannot continue on error", step.ID)
+		}
+	}
+	seen := make(map[string]struct{}, len(step.Targets))
+	for _, target := range step.Targets {
+		if !targetPattern.MatchString(target) {
+			return fmt.Errorf("control step %q has invalid target %q", step.ID, target)
+		}
+		key := strings.ToLower(target)
+		if _, exists := seen[key]; exists {
+			return fmt.Errorf("control step %q repeats target %q", step.ID, target)
+		}
+		seen[key] = struct{}{}
+		if _, exists := backgroundIDs[key]; !exists {
+			return fmt.Errorf("control step %q target %q is not a prior background step", step.ID, target)
 		}
 	}
 	return nil

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -38,7 +38,7 @@ func TestDecodeFailsClosed(t *testing.T) {
 	}{
 		{name: "unknown field", source: strings.Replace(string(encoded), `"steps":`, `"unexpected":true,"steps":`, 1), want: "unknown field"},
 		{name: "duplicate key", source: strings.Replace(string(encoded), `"schema":`, `"schema":"duplicate","schema":`, 1), want: "duplicate JSON key"},
-		{name: "unknown schema", source: strings.Replace(string(encoded), Schema, "job-plan-v2", 1), want: "unsupported job plan schema"},
+		{name: "unknown schema", source: strings.Replace(string(encoded), Schema, "job-plan-v3", 1), want: "unsupported job plan schema"},
 		{name: "trailing JSON", source: string(encoded) + `{}`, want: "multiple JSON values"},
 	}
 	for _, test := range tests {
@@ -69,6 +69,45 @@ func TestValidateRejectsOutOfRangeTimeouts(t *testing.T) {
 	job.Steps[0].TimeoutMinutes = -1
 	if err := job.Validate(); err == nil || !strings.Contains(err.Error(), "step-1") {
 		t.Fatalf("Validate() error = %v, want step timeout error", err)
+	}
+}
+
+func TestValidateConcurrentStepTopology(t *testing.T) {
+	job := validJob()
+	job.Steps = []Step{
+		{ID: "producer", Kind: "run", Command: "true", Background: true},
+		{ID: "barrier", Kind: "wait", Targets: []string{"PRODUCER"}},
+		{ID: "all", Kind: "wait-all"},
+		{ID: "stop", Kind: "cancel", Targets: []string{"producer"}},
+	}
+	if err := job.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+
+	tests := []struct {
+		name string
+		step Step
+		want string
+	}{
+		{name: "forward target", step: Step{ID: "wait", Kind: "wait", Targets: []string{"later"}}, want: "not a prior background step"},
+		{name: "duplicate target", step: Step{ID: "wait", Kind: "wait", Targets: []string{"producer", "PRODUCER"}}, want: "repeats target"},
+		{name: "wait all target", step: Step{ID: "wait", Kind: "wait-all", Targets: []string{"producer"}}, want: "cannot target"},
+		{name: "control payload", step: Step{ID: "wait", Kind: "wait-all", Command: "true"}, want: "incompatible execution fields"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			job := validJob()
+			if test.name == "duplicate target" || test.name == "wait all target" {
+				job.Steps[0].ID = "producer"
+				job.Steps[0].Background = true
+				job.Steps = append(job.Steps, test.step)
+			} else {
+				job.Steps = []Step{test.step, {ID: "later", Kind: "run", Command: "true", Background: true}}
+			}
+			if err := job.Validate(); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Validate() error = %v, want %q", err, test.want)
+			}
+		})
 	}
 }
 

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -93,6 +93,7 @@ func TestValidateConcurrentStepTopology(t *testing.T) {
 		{name: "duplicate target", step: Step{ID: "wait", Kind: "wait", Targets: []string{"producer", "PRODUCER"}}, want: "repeats target"},
 		{name: "wait all target", step: Step{ID: "wait", Kind: "wait-all", Targets: []string{"producer"}}, want: "cannot target"},
 		{name: "control payload", step: Step{ID: "wait", Kind: "wait-all", Command: "true"}, want: "incompatible execution fields"},
+		{name: "control continue on error", step: Step{ID: "wait", Kind: "wait-all", ContinueOnError: true}, want: "incompatible execution fields"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/runtime/concurrent.go
+++ b/internal/runtime/concurrent.go
@@ -18,7 +18,6 @@ var errExplicitBackgroundCancel = errors.New("background step explicitly cancell
 type stepExecution struct {
 	step       plan.Step
 	result     Result
-	post       *registeredPost
 	err        error
 	outcome    string
 	conclusion string
@@ -156,19 +155,19 @@ func (s *backgroundSupervisor) commitCompleted(tasks []*backgroundTask) []stepEx
 	return executions
 }
 
-func (r Runner) executePlanStep(jobCtx, runCtx context.Context, processor *commandProcessor, workspace string, job plan.Job, step plan.Step, jobEnv map[string]string, eval expression.Context) stepExecution {
+func (r Runner) executePlanStep(jobCtx, runCtx context.Context, processor *commandProcessor, workspace string, job plan.Job, step plan.Step, jobEnv map[string]string, eval expression.Context, posts *postRegistry) stepExecution {
 	stepCtx := runCtx
 	cancelStep := func() {}
 	if step.TimeoutMinutes > 0 {
 		stepCtx, cancelStep = context.WithTimeout(runCtx, durationMinutes(step.TimeoutMinutes))
 	}
-	result, post, err := r.runJobStep(stepCtx, processor, workspace, job, step, jobEnv, eval)
+	result, err := r.runJobStep(stepCtx, processor, workspace, job, step, jobEnv, eval, posts)
 	cancelStep()
-	return classifyStepExecution(jobCtx, runCtx, step, result, post, err)
+	return classifyStepExecution(jobCtx, runCtx, step, result, err)
 }
 
-func classifyStepExecution(jobCtx, runCtx context.Context, step plan.Step, result Result, post *registeredPost, err error) stepExecution {
-	execution := stepExecution{step: step, result: result, post: post, err: err, outcome: "success", conclusion: "success"}
+func classifyStepExecution(jobCtx, runCtx context.Context, step plan.Step, result Result, err error) stepExecution {
+	execution := stepExecution{step: step, result: result, err: err, outcome: "success", conclusion: "success"}
 	if err == nil {
 		return execution
 	}
@@ -188,10 +187,10 @@ func cancelledStepExecution(jobCtx, runCtx context.Context, step plan.Step) step
 	if err == nil {
 		err = context.Canceled
 	}
-	return classifyStepExecution(jobCtx, runCtx, step, newResult(), nil, err)
+	return classifyStepExecution(jobCtx, runCtx, step, newResult(), err)
 }
 
-func commitStepExecution(execution stepExecution, jobResult *JobResult, eval *expression.Context, statuses map[string]expression.StepStatus, posts *[]registeredPost) error {
+func commitStepExecution(execution stepExecution, jobResult *JobResult, eval *expression.Context, statuses map[string]expression.StepStatus) error {
 	id := strings.ToLower(execution.step.ID)
 	eval.Steps[id] = execution.result.Outputs
 	env := execution.result.Env
@@ -208,9 +207,6 @@ func commitStepExecution(execution stepExecution, jobResult *JobResult, eval *ex
 	eval.Env = jobResult.Env
 	mergeInto(jobResult.State, execution.result.State)
 	jobResult.Summary += execution.result.Summary
-	if execution.post != nil {
-		*posts = append(*posts, *execution.post)
-	}
 	statuses[id] = expression.StepStatus{Outcome: execution.outcome, Conclusion: execution.conclusion, Outputs: execution.result.Outputs}
 	if execution.conclusion != "success" {
 		return fmt.Errorf("step %q: %w", execution.step.ID, execution.err)

--- a/internal/runtime/concurrent.go
+++ b/internal/runtime/concurrent.go
@@ -194,7 +194,16 @@ func cancelledStepExecution(jobCtx, runCtx context.Context, step plan.Step) step
 func commitStepExecution(execution stepExecution, jobResult *JobResult, eval *expression.Context, statuses map[string]expression.StepStatus, posts *[]registeredPost) error {
 	id := strings.ToLower(execution.step.ID)
 	eval.Steps[id] = execution.result.Outputs
-	mergeInto(jobResult.Env, execution.result.Env)
+	env := execution.result.Env
+	if len(execution.result.Paths) > 0 {
+		env = cloneStrings(env)
+		if execution.result.pathBaseSet {
+			env["PATH"] = execution.result.pathBase
+		} else {
+			delete(env, "PATH")
+		}
+	}
+	mergeInto(jobResult.Env, env)
 	applyPaths(jobResult.Env, execution.result.Paths)
 	eval.Env = jobResult.Env
 	mergeInto(jobResult.State, execution.result.State)

--- a/internal/runtime/concurrent.go
+++ b/internal/runtime/concurrent.go
@@ -1,0 +1,202 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/buildkite/buildkite-gha/internal/expression"
+	"github.com/buildkite/buildkite-gha/internal/plan"
+)
+
+const maxActiveBackgroundSteps = 10
+
+type stepExecution struct {
+	step       plan.Step
+	result     Result
+	post       *registeredPost
+	err        error
+	outcome    string
+	conclusion string
+}
+
+type backgroundTask struct {
+	id        string
+	done      chan struct{}
+	run       func() stepExecution
+	execution stepExecution
+	committed bool
+}
+
+// backgroundSupervisor owns private task admission and completion state. It
+// never mutates workflow-visible job state; the RunJob goroutine does that only
+// after a covering barrier returns completed executions.
+type backgroundSupervisor struct {
+	mu     sync.Mutex
+	limit  int
+	active int
+	tasks  map[string]*backgroundTask
+	order  []*backgroundTask
+	queue  []*backgroundTask
+}
+
+func newBackgroundSupervisor(limit int) *backgroundSupervisor {
+	return &backgroundSupervisor{limit: limit, tasks: make(map[string]*backgroundTask)}
+}
+
+func (s *backgroundSupervisor) start(id string, run func() stepExecution) {
+	task := &backgroundTask{id: strings.ToLower(id), done: make(chan struct{}), run: run}
+	s.mu.Lock()
+	s.tasks[task.id] = task
+	s.order = append(s.order, task)
+	s.queue = append(s.queue, task)
+	s.dispatchLocked()
+	s.mu.Unlock()
+}
+
+func (s *backgroundSupervisor) dispatchLocked() {
+	for s.active < s.limit && len(s.queue) != 0 {
+		task := s.queue[0]
+		s.queue = s.queue[1:]
+		s.active++
+		go func() {
+			execution := task.run()
+			s.mu.Lock()
+			task.execution = execution
+			s.active--
+			close(task.done)
+			s.dispatchLocked()
+			s.mu.Unlock()
+		}()
+	}
+}
+
+func (s *backgroundSupervisor) wait(targets []string) []stepExecution {
+	s.mu.Lock()
+	tasks := make([]*backgroundTask, 0, len(targets))
+	for _, target := range targets {
+		task := s.tasks[strings.ToLower(target)]
+		if task != nil && !task.committed {
+			tasks = append(tasks, task)
+		}
+	}
+	s.mu.Unlock()
+	return s.commitCompleted(tasks)
+}
+
+func (s *backgroundSupervisor) waitAll() []stepExecution {
+	s.mu.Lock()
+	tasks := make([]*backgroundTask, 0, len(s.order))
+	for _, task := range s.order {
+		if !task.committed {
+			tasks = append(tasks, task)
+		}
+	}
+	s.mu.Unlock()
+	return s.commitCompleted(tasks)
+}
+
+func (s *backgroundSupervisor) commitCompleted(tasks []*backgroundTask) []stepExecution {
+	for _, task := range tasks {
+		<-task.done
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	executions := make([]stepExecution, 0, len(tasks))
+	for _, task := range tasks {
+		if task.committed {
+			continue
+		}
+		task.committed = true
+		executions = append(executions, task.execution)
+	}
+	return executions
+}
+
+func (r Runner) executePlanStep(jobCtx, runCtx context.Context, processor *commandProcessor, workspace string, job plan.Job, step plan.Step, jobEnv map[string]string, eval expression.Context) stepExecution {
+	stepCtx := runCtx
+	cancelStep := func() {}
+	if step.TimeoutMinutes > 0 {
+		stepCtx, cancelStep = context.WithTimeout(runCtx, durationMinutes(step.TimeoutMinutes))
+	}
+	result, post, err := r.runJobStep(stepCtx, processor, workspace, job, step, jobEnv, eval)
+	cancelStep()
+
+	execution := stepExecution{step: step, result: result, post: post, err: err, outcome: "success", conclusion: "success"}
+	if err == nil {
+		return execution
+	}
+	execution.outcome = "failure"
+	if jobCtx.Err() != nil {
+		execution.outcome = "cancelled"
+	}
+	execution.conclusion = execution.outcome
+	if step.ContinueOnError && execution.outcome == "failure" {
+		execution.conclusion = "success"
+	}
+	return execution
+}
+
+func commitStepExecution(execution stepExecution, jobResult *JobResult, eval *expression.Context, statuses map[string]expression.StepStatus, posts *[]registeredPost) error {
+	id := strings.ToLower(execution.step.ID)
+	eval.Steps[id] = execution.result.Outputs
+	mergeInto(jobResult.Env, execution.result.Env)
+	applyPaths(jobResult.Env, execution.result.Paths)
+	eval.Env = jobResult.Env
+	mergeInto(jobResult.State, execution.result.State)
+	jobResult.Summary += execution.result.Summary
+	if execution.post != nil {
+		*posts = append(*posts, *execution.post)
+	}
+	statuses[id] = expression.StepStatus{Outcome: execution.outcome, Conclusion: execution.conclusion, Outputs: execution.result.Outputs}
+	if execution.conclusion != "success" {
+		return fmt.Errorf("step %q: %w", execution.step.ID, execution.err)
+	}
+	return nil
+}
+
+func cloneExpressionContext(in expression.Context) expression.Context {
+	return expression.Context{
+		Inputs:      cloneStrings(in.Inputs),
+		Matrix:      cloneAnyMap(in.Matrix),
+		Steps:       cloneNestedStrings(in.Steps),
+		Needs:       cloneNestedStrings(in.Needs),
+		NeedResults: cloneStrings(in.NeedResults),
+		Secrets:     cloneStrings(in.Secrets),
+		Vars:        cloneStrings(in.Vars),
+		Env:         cloneStrings(in.Env),
+		GitHub:      cloneAnyMap(in.GitHub),
+	}
+}
+
+func cloneNestedStrings(in map[string]map[string]string) map[string]map[string]string {
+	out := make(map[string]map[string]string, len(in))
+	for name, values := range in {
+		out[name] = cloneStrings(values)
+	}
+	return out
+}
+
+func cloneAnyMap(in map[string]any) map[string]any {
+	out := make(map[string]any, len(in))
+	for name, value := range in {
+		out[name] = cloneAny(value)
+	}
+	return out
+}
+
+func cloneAny(value any) any {
+	switch value := value.(type) {
+	case map[string]any:
+		return cloneAnyMap(value)
+	case []any:
+		out := make([]any, len(value))
+		for i := range value {
+			out[i] = cloneAny(value[i])
+		}
+		return out
+	default:
+		return value
+	}
+}

--- a/internal/runtime/concurrent.go
+++ b/internal/runtime/concurrent.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -11,6 +12,8 @@ import (
 )
 
 const maxActiveBackgroundSteps = 10
+
+var errExplicitBackgroundCancel = errors.New("background step explicitly cancelled")
 
 type stepExecution struct {
 	step       plan.Step
@@ -22,10 +25,16 @@ type stepExecution struct {
 }
 
 type backgroundTask struct {
-	id        string
-	done      chan struct{}
-	run       func() stepExecution
+	id     string
+	ctx    context.Context
+	cancel context.CancelCauseFunc
+	done   chan struct{}
+	run    func(context.Context) stepExecution
+	// cancelled may run while the supervisor mutex is held and must not block.
+	cancelled func(context.Context) stepExecution
 	execution stepExecution
+	started   bool
+	finished  bool
 	committed bool
 }
 
@@ -45,8 +54,9 @@ func newBackgroundSupervisor(limit int) *backgroundSupervisor {
 	return &backgroundSupervisor{limit: limit, tasks: make(map[string]*backgroundTask)}
 }
 
-func (s *backgroundSupervisor) start(id string, run func() stepExecution) {
-	task := &backgroundTask{id: strings.ToLower(id), done: make(chan struct{}), run: run}
+func (s *backgroundSupervisor) start(parent context.Context, id string, run, cancelled func(context.Context) stepExecution) {
+	ctx, cancel := context.WithCancelCause(parent)
+	task := &backgroundTask{id: strings.ToLower(id), ctx: ctx, cancel: cancel, done: make(chan struct{}), run: run, cancelled: cancelled}
 	s.mu.Lock()
 	s.tasks[task.id] = task
 	s.order = append(s.order, task)
@@ -59,17 +69,49 @@ func (s *backgroundSupervisor) dispatchLocked() {
 	for s.active < s.limit && len(s.queue) != 0 {
 		task := s.queue[0]
 		s.queue = s.queue[1:]
+		if task.ctx.Err() != nil {
+			s.finishLocked(task, task.cancelled(task.ctx))
+			continue
+		}
+		task.started = true
 		s.active++
 		go func() {
-			execution := task.run()
+			execution := task.run(task.ctx)
 			s.mu.Lock()
-			task.execution = execution
 			s.active--
-			close(task.done)
+			s.finishLocked(task, execution)
 			s.dispatchLocked()
 			s.mu.Unlock()
 		}()
 	}
+}
+
+func (s *backgroundSupervisor) finishLocked(task *backgroundTask, execution stepExecution) {
+	task.execution = execution
+	task.finished = true
+	task.cancel(nil)
+	close(task.done)
+}
+
+func (s *backgroundSupervisor) cancel(target string) []stepExecution {
+	s.mu.Lock()
+	task := s.tasks[strings.ToLower(target)]
+	if task == nil || task.committed {
+		s.mu.Unlock()
+		return nil
+	}
+	task.cancel(errExplicitBackgroundCancel)
+	if !task.started && !task.finished {
+		for i, queued := range s.queue {
+			if queued == task {
+				s.queue = append(s.queue[:i], s.queue[i+1:]...)
+				break
+			}
+		}
+		s.finishLocked(task, task.cancelled(task.ctx))
+	}
+	s.mu.Unlock()
+	return s.commitCompleted([]*backgroundTask{task})
 }
 
 func (s *backgroundSupervisor) wait(targets []string) []stepExecution {
@@ -122,13 +164,16 @@ func (r Runner) executePlanStep(jobCtx, runCtx context.Context, processor *comma
 	}
 	result, post, err := r.runJobStep(stepCtx, processor, workspace, job, step, jobEnv, eval)
 	cancelStep()
+	return classifyStepExecution(jobCtx, runCtx, step, result, post, err)
+}
 
+func classifyStepExecution(jobCtx, runCtx context.Context, step plan.Step, result Result, post *registeredPost, err error) stepExecution {
 	execution := stepExecution{step: step, result: result, post: post, err: err, outcome: "success", conclusion: "success"}
 	if err == nil {
 		return execution
 	}
 	execution.outcome = "failure"
-	if jobCtx.Err() != nil {
+	if jobCtx.Err() != nil || errors.Is(context.Cause(runCtx), errExplicitBackgroundCancel) {
 		execution.outcome = "cancelled"
 	}
 	execution.conclusion = execution.outcome
@@ -136,6 +181,14 @@ func (r Runner) executePlanStep(jobCtx, runCtx context.Context, processor *comma
 		execution.conclusion = "success"
 	}
 	return execution
+}
+
+func cancelledStepExecution(jobCtx, runCtx context.Context, step plan.Step) stepExecution {
+	err := context.Cause(runCtx)
+	if err == nil {
+		err = context.Canceled
+	}
+	return classifyStepExecution(jobCtx, runCtx, step, newResult(), nil, err)
 }
 
 func commitStepExecution(execution stepExecution, jobResult *JobResult, eval *expression.Context, statuses map[string]expression.StepStatus, posts *[]registeredPost) error {

--- a/internal/runtime/files.go
+++ b/internal/runtime/files.go
@@ -25,6 +25,12 @@ type commandFiles struct {
 	path    string
 }
 
+type fileCommandEffects struct {
+	paths    []string
+	pathBase string
+	pathSet  bool
+}
+
 func newCommandFiles() (commandFiles, error) {
 	dir, err := os.MkdirTemp("", "buildkite-gha-files-")
 	if err != nil {
@@ -46,9 +52,9 @@ func newCommandFiles() (commandFiles, error) {
 	return files, nil
 }
 
-func (files commandFiles) apply(result *Result, state map[string]string) error {
+func (files commandFiles) apply(result *Result, state map[string]string) (fileCommandEffects, error) {
 	if err := files.checkSizeBudget(); err != nil {
-		return err
+		return fileCommandEffects{}, err
 	}
 	outputs, outputErr := parseCommandFile(files.output)
 	env, envErr := parseCommandFile(files.env)
@@ -56,16 +62,24 @@ func (files commandFiles) apply(result *Result, state map[string]string) error {
 	summary, summaryErr := readBoundedFile(files.summary, maxCommandFileBytes)
 	paths, pathErr := parsePathFile(files.path)
 	if outputErr != nil || envErr != nil || stateErr != nil || summaryErr != nil || pathErr != nil {
-		return errors.Join(outputErr, envErr, stateErr, summaryErr, pathErr)
+		return fileCommandEffects{}, errors.Join(outputErr, envErr, stateErr, summaryErr, pathErr)
 	}
 	for name := range env {
 		if strings.EqualFold(name, "NODE_OPTIONS") {
-			return errors.New("GITHUB_ENV may not set NODE_OPTIONS")
+			return fileCommandEffects{}, errors.New("GITHUB_ENV may not set NODE_OPTIONS")
 		}
 		upper := strings.ToUpper(name)
 		if strings.HasPrefix(upper, "GITHUB_") || strings.HasPrefix(upper, "RUNNER_") {
-			return fmt.Errorf("GITHUB_ENV may not set reserved variable %s", name)
+			return fileCommandEffects{}, fmt.Errorf("GITHUB_ENV may not set reserved variable %s", name)
 		}
+	}
+	effects := fileCommandEffects{paths: paths}
+	if pathBase, ok := env["PATH"]; ok {
+		effects.pathBase = pathBase
+		effects.pathSet = true
+		result.pathBase = pathBase
+		result.pathBaseSet = true
+		result.Paths = result.Paths[:0]
 	}
 	for name, value := range outputs {
 		result.Outputs[name] = value
@@ -81,7 +95,7 @@ func (files commandFiles) apply(result *Result, state map[string]string) error {
 	}
 	result.Summary += string(summary)
 	result.Paths = append(result.Paths, paths...)
-	return nil
+	return effects, nil
 }
 
 func (files commandFiles) checkSizeBudget() error {

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -57,11 +57,6 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (Job
 	if err := job.Validate(); err != nil {
 		return JobResult{}, err
 	}
-	for _, step := range job.Steps {
-		if step.Kind == "cancel" {
-			return JobResult{}, fmt.Errorf("step %q requires concurrent-step cancellation, which is not active in this runtime", step.ID)
-		}
-	}
 	for _, capability := range job.RequiredCapabilities {
 		if capability != "docker" && capability != "secrets" {
 			return JobResult{}, fmt.Errorf("capability %q is unsupported in the job runtime", capability)
@@ -148,6 +143,17 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (Job
 
 	var runErr error
 	for _, step := range job.Steps {
+		if step.Kind == "cancel" {
+			for _, execution := range supervisor.cancel(step.Targets[0]) {
+				targetErr := commitStepExecution(execution, &jobResult, &eval, statuses, &posts)
+				if execution.conclusion != "cancelled" {
+					runErr = errors.Join(runErr, targetErr)
+				}
+			}
+			statuses[strings.ToLower(step.ID)] = expression.StepStatus{Outcome: "success", Conclusion: "success", Outputs: map[string]string{}}
+			eval.Steps[strings.ToLower(step.ID)] = map[string]string{}
+			continue
+		}
 		if step.Kind == "wait" || step.Kind == "wait-all" {
 			var completed []stepExecution
 			if step.Kind == "wait" {
@@ -193,9 +199,14 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (Job
 		evalSnapshot := cloneExpressionContext(eval)
 		if step.Background {
 			step := step
-			supervisor.start(step.ID, func() stepExecution {
-				return r.executePlanStep(ctx, runCtx, processor, workspace, job, step, jobEnv, evalSnapshot)
-			})
+			supervisor.start(runCtx, step.ID,
+				func(stepCtx context.Context) stepExecution {
+					return r.executePlanStep(ctx, stepCtx, processor, workspace, job, step, jobEnv, evalSnapshot)
+				},
+				func(stepCtx context.Context) stepExecution {
+					return cancelledStepExecution(ctx, stepCtx, step)
+				},
+			)
 			continue
 		}
 		execution := r.executePlanStep(ctx, runCtx, processor, workspace, job, step, jobEnv, evalSnapshot)

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -506,6 +506,12 @@ func (r Runner) runCompositeMetadata(ctx context.Context, processor *commandProc
 			return result, err
 		}
 		mergeInto(result.Env, stepResult.Env)
+		if stepResult.pathBaseSet {
+			result.pathBase = stepResult.pathBase
+			result.pathBaseSet = true
+			result.Paths = result.Paths[:0]
+		}
+		result.Paths = append(result.Paths, stepResult.Paths...)
 		mergeInto(result.State, stepResult.State)
 		result.Summary += stepResult.Summary
 		if step.ID != "" {

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/buildkite/buildkite-gha/internal/action/metadata"
@@ -32,6 +33,26 @@ type registeredPost struct {
 	action JavaScriptAction
 	state  map[string]string
 	node   string
+}
+
+type postRegistry struct {
+	mu    sync.Mutex
+	posts []registeredPost
+}
+
+func (r *postRegistry) register(post *registeredPost) {
+	if post == nil {
+		return
+	}
+	r.mu.Lock()
+	r.posts = append(r.posts, *post)
+	r.mu.Unlock()
+}
+
+func (r *postRegistry) snapshot() []registeredPost {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]registeredPost(nil), r.posts...)
 }
 
 // VerifyWorkflow binds a plan to the workflow bytes in the supplied workspace.
@@ -137,7 +158,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (Job
 		runCtx, cancelJob = context.WithTimeout(ctx, durationMinutes(job.TimeoutMinutes))
 	}
 	defer cancelJob()
-	posts := make([]registeredPost, 0)
+	var posts postRegistry
 	statuses := make(map[string]expression.StepStatus, len(job.Steps))
 	supervisor := newBackgroundSupervisor(maxActiveBackgroundSteps)
 
@@ -145,7 +166,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (Job
 	for _, step := range job.Steps {
 		if step.Kind == "cancel" {
 			for _, execution := range supervisor.cancel(step.Targets[0]) {
-				targetErr := commitStepExecution(execution, &jobResult, &eval, statuses, &posts)
+				targetErr := commitStepExecution(execution, &jobResult, &eval, statuses)
 				if execution.conclusion != "cancelled" {
 					runErr = errors.Join(runErr, targetErr)
 				}
@@ -163,7 +184,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (Job
 			}
 			var barrierErr error
 			for _, execution := range completed {
-				barrierErr = errors.Join(barrierErr, commitStepExecution(execution, &jobResult, &eval, statuses, &posts))
+				barrierErr = errors.Join(barrierErr, commitStepExecution(execution, &jobResult, &eval, statuses))
 			}
 			outcome, conclusion := "success", "success"
 			if barrierErr != nil {
@@ -197,7 +218,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (Job
 			step := step
 			supervisor.start(runCtx, step.ID,
 				func(stepCtx context.Context) stepExecution {
-					return r.executePlanStep(ctx, stepCtx, processor, workspace, job, step, jobEnv, evalSnapshot)
+					return r.executePlanStep(ctx, stepCtx, processor, workspace, job, step, jobEnv, evalSnapshot, &posts)
 				},
 				func(stepCtx context.Context) stepExecution {
 					return cancelledStepExecution(ctx, stepCtx, step)
@@ -205,11 +226,11 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (Job
 			)
 			continue
 		}
-		execution := r.executePlanStep(ctx, runCtx, processor, workspace, job, step, jobEnv, evalSnapshot)
-		runErr = errors.Join(runErr, commitStepExecution(execution, &jobResult, &eval, statuses, &posts))
+		execution := r.executePlanStep(ctx, runCtx, processor, workspace, job, step, jobEnv, evalSnapshot, &posts)
+		runErr = errors.Join(runErr, commitStepExecution(execution, &jobResult, &eval, statuses))
 	}
 	for _, execution := range supervisor.waitAll() {
-		runErr = errors.Join(runErr, commitStepExecution(execution, &jobResult, &eval, statuses, &posts))
+		runErr = errors.Join(runErr, commitStepExecution(execution, &jobResult, &eval, statuses))
 	}
 	if runCtx.Err() != nil {
 		runErr = errors.Join(runErr, runCtx.Err())
@@ -217,8 +238,9 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (Job
 
 	cleanupCtx, cancel := context.WithTimeout(context.Background(), r.cleanupTimeout())
 	defer cancel()
-	for i := len(posts) - 1; i >= 0; i-- {
-		post := posts[i]
+	registeredPosts := posts.snapshot()
+	for i := len(registeredPosts) - 1; i >= 0; i-- {
+		post := registeredPosts[i]
 		postResult := newResult()
 		postResult.Env = cloneStrings(jobResult.Env)
 		postErr := r.runJavaScriptPhase(cleanupCtx, processor, post.node, post.action, post.action.Post, post.state, post.state, &postResult)
@@ -352,20 +374,20 @@ func mergeStepEnvironment(base map[string]string, overlays ...map[string]string)
 	return out
 }
 
-func (r Runner) runJobStep(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, step plan.Step, jobEnv map[string]string, eval expression.Context) (Result, *registeredPost, error) {
+func (r Runner) runJobStep(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, step plan.Step, jobEnv map[string]string, eval expression.Context, posts *postRegistry) (Result, error) {
 	stepEnv, err := evaluateMap(step.Env, eval)
 	if err != nil {
-		return newResult(), nil, err
+		return newResult(), err
 	}
 	result := newResult()
 	if step.Kind == "run" {
 		script, err := expression.Evaluate(step.Command, eval)
 		if err != nil {
-			return result, nil, err
+			return result, err
 		}
 		shell, err := expression.Evaluate(step.Shell, eval)
 		if err != nil {
-			return result, nil, err
+			return result, err
 		}
 		if shell == "" {
 			shell = job.DefaultShell
@@ -375,95 +397,96 @@ func (r Runner) runJobStep(ctx context.Context, processor *commandProcessor, wor
 		}
 		workingDirectory, err := expression.Evaluate(step.WorkingDirectory, eval)
 		if err != nil {
-			return result, nil, err
+			return result, err
 		}
 		if workingDirectory == "" {
 			workingDirectory = job.DefaultWorkingDirectory
 		}
 		dir, err := workspacePath(workspace, workingDirectory)
 		if err != nil {
-			return result, nil, err
+			return result, err
 		}
 		args, err := shellCommand(shell, script)
 		if err != nil {
-			return result, nil, err
+			return result, err
 		}
 		runEnv := mergeStepEnvironment(jobEnv, stepEnv)
 		err = r.runProcess(ctx, processor, dir, runEnv, &result, nil, args[0], args[1:]...)
-		return result, nil, err
+		return result, err
 	}
 
 	if !strings.HasPrefix(step.Uses, "./") {
-		return result, nil, fmt.Errorf("remote action %q is unsupported in the Phase 0 runtime", step.Uses)
+		return result, fmt.Errorf("remote action %q is unsupported in the Phase 0 runtime", step.Uses)
 	}
 	if err := VerifyWorkflow(job, workspace); err != nil {
-		return result, nil, err
+		return result, err
 	}
 	action, err := metadata.Load(workspace, step.Uses)
 	if err != nil {
-		return result, nil, err
+		return result, err
 	}
 	actionRuntime, err := action.Runtime()
 	if err != nil {
-		return result, nil, fmt.Errorf("action %q uses %w", step.Uses, err)
+		return result, fmt.Errorf("action %q uses %w", step.Uses, err)
 	}
 	actionPath := action.Path
 	inputs, err := evaluateMap(step.With, eval)
 	if err != nil {
-		return result, nil, err
+		return result, err
 	}
 	inputs, err = resolveActionInputs(action, inputs, eval)
 	if err != nil {
-		return result, nil, err
+		return result, err
 	}
 	actionEval := eval
 	actionEval.Inputs = inputs
 	switch actionRuntime {
 	case metadata.RuntimeNode24:
 		if action.Runs.Main == "" {
-			return result, nil, fmt.Errorf("JavaScript action %q has no main entry point", step.Uses)
+			return result, fmt.Errorf("JavaScript action %q has no main entry point", step.Uses)
 		}
 		if !supportedLifecycleCondition(action.Runs.PreIf) || !supportedLifecycleCondition(action.Runs.PostIf) {
-			return result, nil, fmt.Errorf("JavaScript action %q uses unsupported pre-if or post-if", step.Uses)
+			return result, fmt.Errorf("JavaScript action %q uses unsupported pre-if or post-if", step.Uses)
 		}
 		node, err := DiscoverNode24(r.Node24, r.ManagedNodeRoot)
 		if err != nil {
-			return result, nil, err
+			return result, err
 		}
 		actionEnv := mergeStepEnvironment(jobEnv, stepEnv)
 		javascript := JavaScriptAction{Name: actionName(action, step), Path: actionPath, Pre: action.Runs.Pre, Main: action.Runs.Main, Post: action.Runs.Post, Inputs: inputs, Env: actionEnv}
 		state := map[string]string{}
 		post := postFor(javascript, state, node)
+		posts.register(post)
 		if javascript.Pre != "" {
 			if err := r.runJavaScriptPhase(ctx, processor, node, javascript, javascript.Pre, nil, state, &result); err != nil {
-				return result, post, err
+				return result, err
 			}
 		}
 		if err := r.runJavaScriptPhase(ctx, processor, node, javascript, javascript.Main, nil, state, &result); err != nil {
-			return result, post, err
+			return result, err
 		}
-		return result, post, nil
+		return result, nil
 	case metadata.RuntimeComposite:
 		composite, err := r.runCompositeMetadata(ctx, processor, workspace, actionPath, action, inputs, jobEnv, stepEnv, actionEval)
-		return composite, nil, err
+		return composite, err
 	case metadata.RuntimeDocker:
 		if !job.HasCapability("docker") {
-			return result, nil, fmt.Errorf("docker action %q requires the plan's docker capability", step.Uses)
+			return result, fmt.Errorf("docker action %q requires the plan's docker capability", step.Uses)
 		}
 		if action.Runs.PreEntrypoint != "" || action.Runs.PostEntrypoint != "" || action.Runs.Entrypoint != "" || len(action.Runs.Args) != 0 {
-			return result, nil, fmt.Errorf("docker action %q uses unsupported entrypoint, arguments, or pre/post lifecycle", step.Uses)
+			return result, fmt.Errorf("docker action %q uses unsupported entrypoint, arguments, or pre/post lifecycle", step.Uses)
 		}
 		if action.Runs.Image != "Dockerfile" {
-			return result, nil, fmt.Errorf("docker action image %q is unsupported; Phase 0 requires a local Dockerfile", action.Runs.Image)
+			return result, fmt.Errorf("docker action image %q is unsupported; Phase 0 requires a local Dockerfile", action.Runs.Image)
 		}
 		dockerEnv, err := evaluateMap(action.Runs.Env, actionEval)
 		if err != nil {
-			return result, nil, err
+			return result, err
 		}
 		result, err := r.runDocker(ctx, processor, DockerAction{Name: actionName(action, step), Path: actionPath, Workspace: workspace, Env: mergeStepEnvironment(jobEnv, stepEnv, actionInputEnv(inputs), dockerEnv)})
-		return result, nil, err
+		return result, err
 	}
-	return result, nil, fmt.Errorf("action %q uses unsupported runtime %q", step.Uses, actionRuntime)
+	return result, fmt.Errorf("action %q uses unsupported runtime %q", step.Uses, actionRuntime)
 }
 
 func (r Runner) runCompositeMetadata(ctx context.Context, processor *commandProcessor, workspace, actionPath string, action metadata.Metadata, inputs, jobEnv, stepEnv map[string]string, eval expression.Context) (Result, error) {

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -172,11 +172,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (Job
 					outcome = "cancelled"
 				}
 				conclusion = outcome
-				if step.ContinueOnError && outcome == "failure" {
-					conclusion = "success"
-				} else {
-					runErr = errors.Join(runErr, fmt.Errorf("step %q: %w", step.ID, barrierErr))
-				}
+				runErr = errors.Join(runErr, fmt.Errorf("step %q: %w", step.ID, barrierErr))
 			}
 			statuses[strings.ToLower(step.ID)] = expression.StepStatus{Outcome: outcome, Conclusion: conclusion, Outputs: map[string]string{}}
 			eval.Steps[strings.ToLower(step.ID)] = map[string]string{}

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -58,13 +58,13 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (Job
 		return JobResult{}, err
 	}
 	for _, step := range job.Steps {
-		if step.Background || step.Kind == "wait" || step.Kind == "wait-all" || step.Kind == "cancel" {
-			return JobResult{}, fmt.Errorf("step %q requires the concurrent-step supervisor, which is not active in this runtime", step.ID)
+		if step.Kind == "cancel" {
+			return JobResult{}, fmt.Errorf("step %q requires concurrent-step cancellation, which is not active in this runtime", step.ID)
 		}
 	}
 	for _, capability := range job.RequiredCapabilities {
 		if capability != "docker" && capability != "secrets" {
-			return JobResult{}, fmt.Errorf("capability %q is unsupported in the sequential runtime", capability)
+			return JobResult{}, fmt.Errorf("capability %q is unsupported in the job runtime", capability)
 		}
 	}
 	if len(job.Dependencies) != 0 && len(job.Needs) == 0 {
@@ -144,9 +144,39 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (Job
 	defer cancelJob()
 	posts := make([]registeredPost, 0)
 	statuses := make(map[string]expression.StepStatus, len(job.Steps))
+	supervisor := newBackgroundSupervisor(maxActiveBackgroundSteps)
 
 	var runErr error
 	for _, step := range job.Steps {
+		if step.Kind == "wait" || step.Kind == "wait-all" {
+			var completed []stepExecution
+			if step.Kind == "wait" {
+				completed = supervisor.wait(step.Targets)
+			} else {
+				completed = supervisor.waitAll()
+			}
+			var barrierErr error
+			for _, execution := range completed {
+				barrierErr = errors.Join(barrierErr, commitStepExecution(execution, &jobResult, &eval, statuses, &posts))
+			}
+			outcome, conclusion := "success", "success"
+			if barrierErr != nil {
+				outcome = "failure"
+				if ctx.Err() != nil {
+					outcome = "cancelled"
+				}
+				conclusion = outcome
+				if step.ContinueOnError && outcome == "failure" {
+					conclusion = "success"
+				} else {
+					runErr = errors.Join(runErr, fmt.Errorf("step %q: %w", step.ID, barrierErr))
+				}
+			}
+			statuses[strings.ToLower(step.ID)] = expression.StepStatus{Outcome: outcome, Conclusion: conclusion, Outputs: map[string]string{}}
+			eval.Steps[strings.ToLower(step.ID)] = map[string]string{}
+			continue
+		}
+
 		condition := expression.ConditionContext{Needs: eval.Needs, NeedResults: eval.NeedResults, Steps: statuses, Env: jobResult.Env, Vars: job.Vars, Matrix: job.Matrix, GitHub: eval.GitHub, Failure: runErr != nil, Unsuccessful: runErr != nil, Cancelled: runCtx.Err() != nil}
 		run, err := expression.EvaluateCondition(step.Condition, condition)
 		if err != nil {
@@ -158,36 +188,21 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (Job
 			eval.Steps[strings.ToLower(step.ID)] = map[string]string{}
 			continue
 		}
-		stepCtx := runCtx
-		cancelStep := func() {}
-		if step.TimeoutMinutes > 0 {
-			stepCtx, cancelStep = context.WithTimeout(runCtx, durationMinutes(step.TimeoutMinutes))
+
+		jobEnv := cloneStrings(jobResult.Env)
+		evalSnapshot := cloneExpressionContext(eval)
+		if step.Background {
+			step := step
+			supervisor.start(step.ID, func() stepExecution {
+				return r.executePlanStep(ctx, runCtx, processor, workspace, job, step, jobEnv, evalSnapshot)
+			})
+			continue
 		}
-		result, post, err := r.runJobStep(stepCtx, processor, workspace, job, step, jobResult.Env, eval)
-		cancelStep()
-		eval.Steps[strings.ToLower(step.ID)] = result.Outputs
-		mergeInto(jobResult.Env, result.Env)
-		applyPaths(jobResult.Env, result.Paths)
-		eval.Env = jobResult.Env
-		mergeInto(jobResult.State, result.State)
-		jobResult.Summary += result.Summary
-		if post != nil {
-			posts = append(posts, *post)
-		}
-		outcome, conclusion := "success", "success"
-		if err != nil {
-			outcome = "failure"
-			if ctx.Err() != nil {
-				outcome = "cancelled"
-			}
-			conclusion = outcome
-			if step.ContinueOnError && outcome == "failure" {
-				conclusion = "success"
-			} else {
-				runErr = errors.Join(runErr, fmt.Errorf("step %q: %w", step.ID, err))
-			}
-		}
-		statuses[strings.ToLower(step.ID)] = expression.StepStatus{Outcome: outcome, Conclusion: conclusion, Outputs: result.Outputs}
+		execution := r.executePlanStep(ctx, runCtx, processor, workspace, job, step, jobEnv, evalSnapshot)
+		runErr = errors.Join(runErr, commitStepExecution(execution, &jobResult, &eval, statuses, &posts))
+	}
+	for _, execution := range supervisor.waitAll() {
+		runErr = errors.Join(runErr, commitStepExecution(execution, &jobResult, &eval, statuses, &posts))
 	}
 	if runCtx.Err() != nil {
 		runErr = errors.Join(runErr, runCtx.Err())

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -57,6 +57,11 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (Job
 	if err := job.Validate(); err != nil {
 		return JobResult{}, err
 	}
+	for _, step := range job.Steps {
+		if step.Background || step.Kind == "wait" || step.Kind == "wait-all" || step.Kind == "cancel" {
+			return JobResult{}, fmt.Errorf("step %q requires the concurrent-step supervisor, which is not active in this runtime", step.ID)
+		}
+	}
 	for _, capability := range job.RequiredCapabilities {
 		if capability != "docker" && capability != "secrets" {
 			return JobResult{}, fmt.Errorf("capability %q is unsupported in the sequential runtime", capability)

--- a/internal/runtime/process_other.go
+++ b/internal/runtime/process_other.go
@@ -11,7 +11,7 @@ import (
 
 func configureProcessGroup(_ *exec.Cmd) {}
 
-func terminateProcessGroup(ctx context.Context, pid int, _ time.Duration, finished <-chan struct{}) {
+func terminateProcessGroup(ctx context.Context, pid int, _, _ time.Duration, finished <-chan struct{}) {
 	select {
 	case <-ctx.Done():
 		if process, err := os.FindProcess(pid); err == nil {

--- a/internal/runtime/process_unix.go
+++ b/internal/runtime/process_unix.go
@@ -13,13 +13,24 @@ func configureProcessGroup(command *exec.Cmd) {
 	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 }
 
-func terminateProcessGroup(ctx context.Context, pid int, grace time.Duration, finished <-chan struct{}) {
+func terminateProcessGroup(ctx context.Context, pid int, interruptGrace, terminateGrace time.Duration, finished <-chan struct{}) {
 	select {
 	case <-ctx.Done():
-		_ = syscall.Kill(-pid, syscall.SIGTERM)
+		_ = syscall.Kill(-pid, syscall.SIGINT)
 	case <-finished:
 		return
 	}
+	if waitForProcessGroupExit(pid, interruptGrace) {
+		return
+	}
+	_ = syscall.Kill(-pid, syscall.SIGTERM)
+	if waitForProcessGroupExit(pid, terminateGrace) {
+		return
+	}
+	_ = syscall.Kill(-pid, syscall.SIGKILL)
+}
+
+func waitForProcessGroupExit(pid int, grace time.Duration) bool {
 	timer := time.NewTimer(grace)
 	defer timer.Stop()
 	ticker := time.NewTicker(10 * time.Millisecond)
@@ -27,11 +38,10 @@ func terminateProcessGroup(ctx context.Context, pid int, grace time.Duration, fi
 	for {
 		select {
 		case <-timer.C:
-			_ = syscall.Kill(-pid, syscall.SIGKILL)
-			return
+			return false
 		case <-ticker.C:
 			if err := syscall.Kill(-pid, 0); err == syscall.ESRCH {
-				return
+				return true
 			}
 		}
 	}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -18,9 +18,11 @@ import (
 )
 
 const (
-	defaultCleanupTimeout   = 10 * time.Second
-	defaultTerminationGrace = 2 * time.Second
-	maxStreamLineBytes      = 1024 * 1024
+	defaultCleanupTimeout = 10 * time.Second
+	// Match actions/runner ProcessInvoker's graceful cancellation windows.
+	defaultInterruptGrace = 7500 * time.Millisecond
+	defaultTerminateGrace = 2500 * time.Millisecond
+	maxStreamLineBytes    = 1024 * 1024
 )
 
 // Runner executes local actions using explicitly configured host tools.
@@ -31,6 +33,8 @@ type Runner struct {
 	ManagedNodeRoot string
 	Docker          string
 	CleanupTimeout  time.Duration
+	InterruptGrace  time.Duration
+	TerminateGrace  time.Duration
 	Secrets         SecretResolver
 	Redactor        Redactor
 }
@@ -123,7 +127,7 @@ func (r Runner) runDocker(ctx context.Context, processor *commandProcessor, acti
 		"--env", "GITHUB_STEP_SUMMARY=/github/file_commands/summary",
 		image,
 	)
-	if err := runStreaming(ctx, processor, "", nil, docker, args...); err != nil {
+	if err := r.runStreaming(ctx, processor, "", nil, docker, args...); err != nil {
 		return result, fmt.Errorf("run Docker action %q: %w", action.Name, err)
 	}
 	if _, err := files.apply(&result, nil); err != nil {
@@ -160,7 +164,7 @@ func (r Runner) runProcess(ctx context.Context, processor *commandProcessor, dir
 		"GITHUB_STATE":        files.state,
 		"GITHUB_STEP_SUMMARY": files.summary,
 	})
-	runErr := runStreaming(ctx, processor, dir, env, name, args...)
+	runErr := r.runStreaming(ctx, processor, dir, env, name, args...)
 	effects, fileErr := files.apply(result, state)
 	if fileErr == nil && (effects.pathSet || len(effects.paths) > 0) {
 		pathEnv := map[string]string{"PATH": env["PATH"]}
@@ -173,7 +177,7 @@ func (r Runner) runProcess(ctx context.Context, processor *commandProcessor, dir
 	return errors.Join(runErr, fileErr)
 }
 
-func runStreaming(ctx context.Context, processor *commandProcessor, dir string, env map[string]string, name string, args ...string) error {
+func (r Runner) runStreaming(ctx context.Context, processor *commandProcessor, dir string, env map[string]string, name string, args ...string) error {
 	cmd := exec.Command(name, args...)
 	cmd.Dir = dir
 	cmd.Env = processEnv(env)
@@ -190,7 +194,7 @@ func runStreaming(ctx context.Context, processor *commandProcessor, dir string, 
 		return err
 	}
 	finished := make(chan struct{})
-	go terminateProcessGroup(ctx, cmd.Process.Pid, defaultTerminationGrace, finished)
+	go terminateProcessGroup(ctx, cmd.Process.Pid, r.interruptGrace(), r.terminateGrace(), finished)
 
 	var wg sync.WaitGroup
 	streamErrs := make([]error, 2)
@@ -216,6 +220,20 @@ func runStreaming(ctx context.Context, processor *commandProcessor, dir string, 
 		waitErr = fmt.Errorf("process %s: %w", name, waitErr)
 	}
 	return errors.Join(waitErr, streamErrs[0], streamErrs[1])
+}
+
+func (r Runner) interruptGrace() time.Duration {
+	if r.InterruptGrace > 0 {
+		return r.InterruptGrace
+	}
+	return defaultInterruptGrace
+}
+
+func (r Runner) terminateGrace() time.Duration {
+	if r.TerminateGrace > 0 {
+		return r.TerminateGrace
+	}
+	return defaultTerminateGrace
 }
 
 func streamLines(reader io.Reader, process func(string), suppress func()) error {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -194,7 +194,11 @@ func (r Runner) runStreaming(ctx context.Context, processor *commandProcessor, d
 		return err
 	}
 	finished := make(chan struct{})
-	go terminateProcessGroup(ctx, cmd.Process.Pid, r.interruptGrace(), r.terminateGrace(), finished)
+	terminationDone := make(chan struct{})
+	go func() {
+		defer close(terminationDone)
+		terminateProcessGroup(ctx, cmd.Process.Pid, r.interruptGrace(), r.terminateGrace(), finished)
+	}()
 
 	var wg sync.WaitGroup
 	streamErrs := make([]error, 2)
@@ -213,6 +217,7 @@ func (r Runner) runStreaming(ctx context.Context, processor *commandProcessor, d
 	wg.Wait()
 	waitErr := cmd.Wait()
 	close(finished)
+	<-terminationDone
 	if ctx.Err() != nil {
 		waitErr = ctx.Err()
 	}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -62,6 +62,9 @@ type Result struct {
 	State   map[string]string
 	Summary string
 	Paths   []string
+
+	pathBase    string
+	pathBaseSet bool
 }
 
 // RunDocker builds and executes an explicitly resolved local Docker action.
@@ -123,7 +126,7 @@ func (r Runner) runDocker(ctx context.Context, processor *commandProcessor, acti
 	if err := runStreaming(ctx, processor, "", nil, docker, args...); err != nil {
 		return result, fmt.Errorf("run Docker action %q: %w", action.Name, err)
 	}
-	if err := files.apply(&result, nil); err != nil {
+	if _, err := files.apply(&result, nil); err != nil {
 		return result, fmt.Errorf("process Docker action %q file commands: %w", action.Name, err)
 	}
 	return result, nil
@@ -131,6 +134,9 @@ func (r Runner) runDocker(ctx context.Context, processor *commandProcessor, acti
 
 func (r Runner) runJavaScriptPhase(ctx context.Context, processor *commandProcessor, node string, action JavaScriptAction, entry string, stateEnv, stateOut map[string]string, result *Result) error {
 	env := mergeStringMaps(result.Env, action.Env, actionInputEnv(action.Inputs))
+	if path, ok := result.Env["PATH"]; ok {
+		env["PATH"] = path
+	}
 	env["GITHUB_ACTION_PATH"] = action.Path
 	for name, value := range stateEnv {
 		env["STATE_"+name] = value
@@ -155,16 +161,14 @@ func (r Runner) runProcess(ctx context.Context, processor *commandProcessor, dir
 		"GITHUB_STEP_SUMMARY": files.summary,
 	})
 	runErr := runStreaming(ctx, processor, dir, env, name, args...)
-	pathStart := len(result.Paths)
-	fileErr := files.apply(result, state)
-	if fileErr == nil && len(result.Paths) > pathStart {
+	effects, fileErr := files.apply(result, state)
+	if fileErr == nil && (effects.pathSet || len(effects.paths) > 0) {
 		pathEnv := map[string]string{"PATH": env["PATH"]}
-		if result.Env["PATH"] != "" {
-			pathEnv["PATH"] = result.Env["PATH"]
+		if effects.pathSet {
+			pathEnv["PATH"] = effects.pathBase
 		}
-		applyPaths(pathEnv, result.Paths[pathStart:])
+		applyPaths(pathEnv, effects.paths)
 		result.Env["PATH"] = pathEnv["PATH"]
-		result.Paths = result.Paths[:pathStart]
 	}
 	return errors.Join(runErr, fileErr)
 }

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/buildkite/buildkite-gha/internal/compiler"
 	"github.com/buildkite/buildkite-gha/internal/expression"
 	"github.com/buildkite/buildkite-gha/internal/plan"
 )
@@ -446,6 +447,44 @@ func TestConcurrentStreamsShareMaskRegistration(t *testing.T) {
 	}
 	if strings.Contains(logs.String(), "cross-stream-secret") || !strings.Contains(logs.String(), "probe ***") {
 		t.Fatalf("RunJob() logs = %q", logs.String())
+	}
+}
+
+func TestConcurrentSmokeWorkflowEndToEnd(t *testing.T) {
+	workspace := fixturePath(t, "smoke")
+	workflowPath := filepath.Join(workspace, ".github", "workflows", "concurrent.yml")
+	source, err := os.ReadFile(workflowPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	event, err := os.ReadFile(filepath.Join(workspace, "events", "push.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	plans, err := compiler.CompilePlans(workflowPath, source, event, "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 2 {
+		t.Fatalf("plans = %#v, want concurrent and observer", plans)
+	}
+	var logs bytes.Buffer
+	runner := Runner{Stdout: &logs, Stderr: &logs}
+	concurrent, err := runner.RunJob(context.Background(), plans[0], workspace)
+	if err != nil || concurrent.Conclusion != "success" {
+		t.Fatalf("concurrent result = %#v, error = %v, logs = %q", concurrent, err, logs.String())
+	}
+	plans[1].Needs = map[string]plan.Need{"concurrent": {Result: concurrent.Conclusion, Outputs: concurrent.Outputs}}
+	observer, err := runner.RunJob(context.Background(), plans[1], workspace)
+	if err != nil || observer.Conclusion != "success" {
+		t.Fatalf("observer result = %#v, error = %v, logs = %q", observer, err, logs.String())
+	}
+	if strings.Contains(logs.String(), "phase3-cross-stream-secret") || !strings.Contains(logs.String(), "PHASE3_MASK_PROBE=***") {
+		t.Fatalf("concurrent masking logs = %q", logs.String())
+	}
+	want := `PHASE3_OBSERVATION={"cancel":"graceful","failure":"failure-at-wait","implicit":"implicit-wait-all","parallel":"parallel","queue_max":10,"targeted":"targeted-and-full"}`
+	if !strings.Contains(logs.String(), want) {
+		t.Fatalf("concurrent observation missing from logs = %q", logs.String())
 	}
 }
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -387,7 +387,7 @@ func TestBackgroundFailureSurfacesAtWait(t *testing.T) {
 	}
 }
 
-func TestBackgroundAndBarrierContinueOnError(t *testing.T) {
+func TestBackgroundContinueOnError(t *testing.T) {
 	workspace := t.TempDir()
 	workflowPath := ".github/workflows/test.yml"
 	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
@@ -396,16 +396,13 @@ func TestBackgroundAndBarrierContinueOnError(t *testing.T) {
 		{ID: "soft-background", Kind: "run", Background: true, ContinueOnError: true, Command: "exit 7"},
 		{ID: "wait-soft", Kind: "wait", Targets: []string{"soft-background"}},
 		{ID: "after-soft", Kind: "run", Condition: "steps.soft-background.outcome == 'failure' && steps.soft-background.conclusion == 'success'", Command: "echo after-soft"},
-		{ID: "hard-background", Kind: "run", Background: true, Command: "exit 8"},
-		{ID: "soft-barrier", Kind: "wait", Targets: []string{"hard-background"}, ContinueOnError: true},
-		{ID: "after-barrier", Kind: "run", Condition: "steps.soft-barrier.outcome == 'failure' && steps.soft-barrier.conclusion == 'success'", Command: "echo after-barrier"},
 	})
 
 	result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
-	if !strings.Contains(logs.String(), "after-soft") || !strings.Contains(logs.String(), "after-barrier") {
+	if !strings.Contains(logs.String(), "after-soft") {
 		t.Fatalf("RunJob() logs = %q", logs.String())
 	}
 }

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -15,6 +15,8 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -126,23 +128,263 @@ func TestFailureConditionsAndCancellation(t *testing.T) {
 	}
 }
 
-func TestConcurrentPlansFailClosedBeforeProcessExecution(t *testing.T) {
+func TestCancelPlansFailClosedBeforeProcessExecution(t *testing.T) {
 	workspace := t.TempDir()
 	workflowPath := ".github/workflows/test.yml"
 	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
 	marker := filepath.Join(workspace, "must-not-exist")
-	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{
-		ID:         "background",
-		Kind:       "run",
-		Command:    "touch " + marker,
-		Background: true,
-	}})
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{
+		{ID: "background", Kind: "run", Command: "touch " + marker, Background: true},
+		{ID: "cancel", Kind: "cancel", Targets: []string{"background"}},
+	})
 	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
-	if err == nil || !strings.Contains(err.Error(), "requires the concurrent-step supervisor") {
-		t.Fatalf("RunJob() result = %#v, error = %v, want supervisor rejection", result, err)
+	if err == nil || !strings.Contains(err.Error(), "requires concurrent-step cancellation") {
+		t.Fatalf("RunJob() result = %#v, error = %v, want cancellation rejection", result, err)
 	}
 	if _, statErr := os.Stat(marker); !errors.Is(statErr, os.ErrNotExist) {
-		t.Fatalf("concurrent plan reached process execution: %v", statErr)
+		t.Fatalf("cancel plan reached process execution: %v", statErr)
+	}
+}
+
+func TestBackgroundEffectsCommitAtCoveringBarriers(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	oneDone := filepath.Join(workspace, "one.done")
+	twoDone := filepath.Join(workspace, "two.done")
+	pathEntry := filepath.Join(workspace, "from-background")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{
+		{ID: "one", Kind: "run", Background: true, Command: `
+echo "ONE=committed-one" >> "$GITHUB_ENV"
+echo "value=output-one" >> "$GITHUB_OUTPUT"
+echo "$PATH_ENTRY" >> "$GITHUB_PATH"
+echo one-summary >> "$GITHUB_STEP_SUMMARY"
+touch "$ONE_DONE"`},
+		{ID: "two", Kind: "run", Background: true, Command: `
+echo "TWO=committed-two" >> "$GITHUB_ENV"
+echo "value=output-two" >> "$GITHUB_OUTPUT"
+touch "$TWO_DONE"`},
+		{ID: "before-wait", Kind: "run", Command: `
+while [ ! -f "$ONE_DONE" ] || [ ! -f "$TWO_DONE" ]; do sleep 0.01; done
+test -z "$ONE"
+test -z "$TWO"
+case "$PATH" in "$PATH_ENTRY"*) exit 1 ;; esac`},
+		{ID: "wait-one", Kind: "wait", Targets: []string{"one"}},
+		{ID: "after-targeted-wait", Kind: "run", Command: `
+test "$ONE" = committed-one
+test -z "$TWO"
+test "${{ steps.one.outputs.value }}" = output-one
+case "$PATH" in "$PATH_ENTRY"*) ;; *) exit 1 ;; esac`},
+		{ID: "wait-all", Kind: "wait-all"},
+		{ID: "after-wait-all", Kind: "run", Command: `
+test "$ONE" = committed-one
+test "$TWO" = committed-two
+test "${{ steps.two.outputs.value }}" = output-two`},
+	})
+	job.Env = map[string]string{"ONE_DONE": oneDone, "TWO_DONE": twoDone, "PATH_ENTRY": pathEntry}
+	job.Outputs = map[string]string{"one": "${{ steps.one.outputs.value }}", "two": "${{ steps.two.outputs.value }}"}
+
+	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	if err != nil {
+		t.Fatalf("RunJob() error = %v", err)
+	}
+	if result.Conclusion != "success" || result.Outputs["one"] != "output-one" || result.Outputs["two"] != "output-two" {
+		t.Fatalf("RunJob() result = %#v", result)
+	}
+	if result.Summary != "one-summary\n" {
+		t.Fatalf("RunJob() summary = %q", result.Summary)
+	}
+}
+
+func TestBackgroundFailureSurfacesAtWait(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	marker := filepath.Join(workspace, "failed.done")
+	var logs bytes.Buffer
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{
+		{ID: "failure", Kind: "run", Background: true, Command: `echo "FAILED_EFFECT=visible" >> "$GITHUB_ENV"; touch "$FAILURE_DONE"; exit 9`},
+		{ID: "before-wait", Kind: "run", Command: `while [ ! -f "$FAILURE_DONE" ]; do sleep 0.01; done; test -z "$FAILED_EFFECT"; echo before-barrier`},
+		{ID: "wait", Kind: "wait", Targets: []string{"failure"}},
+		{ID: "default-after-wait", Kind: "run", Command: "echo must-not-run"},
+		{ID: "recover", Kind: "run", Condition: "failure() && steps.failure.outcome == 'failure'", Command: `test "$FAILED_EFFECT" = visible; echo recovered`},
+	})
+	job.Env = map[string]string{"FAILURE_DONE": marker}
+
+	result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	if err == nil || result.Conclusion != "failure" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	if !strings.Contains(logs.String(), "before-barrier") || !strings.Contains(logs.String(), "recovered") || strings.Contains(logs.String(), "must-not-run") {
+		t.Fatalf("RunJob() logs = %q", logs.String())
+	}
+}
+
+func TestBackgroundAndBarrierContinueOnError(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	var logs bytes.Buffer
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{
+		{ID: "soft-background", Kind: "run", Background: true, ContinueOnError: true, Command: "exit 7"},
+		{ID: "wait-soft", Kind: "wait", Targets: []string{"soft-background"}},
+		{ID: "after-soft", Kind: "run", Condition: "steps.soft-background.outcome == 'failure' && steps.soft-background.conclusion == 'success'", Command: "echo after-soft"},
+		{ID: "hard-background", Kind: "run", Background: true, Command: "exit 8"},
+		{ID: "soft-barrier", Kind: "wait", Targets: []string{"hard-background"}, ContinueOnError: true},
+		{ID: "after-barrier", Kind: "run", Condition: "steps.soft-barrier.outcome == 'failure' && steps.soft-barrier.conclusion == 'success'", Command: "echo after-barrier"},
+	})
+
+	result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	if !strings.Contains(logs.String(), "after-soft") || !strings.Contains(logs.String(), "after-barrier") {
+		t.Fatalf("RunJob() logs = %q", logs.String())
+	}
+}
+
+func TestSkippedBackgroundAndRepeatedWaitAreCommittedAtMostOnce(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{
+		{ID: "skipped", Kind: "run", Background: true, Condition: "false", Command: "exit 1"},
+		{ID: "wait-skipped", Kind: "wait", Targets: []string{"skipped"}},
+		{ID: "completed", Kind: "run", Background: true, Command: `echo once >> "$GITHUB_STEP_SUMMARY"`},
+		{ID: "first-wait", Kind: "wait", Targets: []string{"completed"}},
+		{ID: "second-wait", Kind: "wait", Targets: []string{"completed"}},
+		{ID: "verify", Kind: "run", Condition: "steps.skipped.conclusion == 'skipped'", Command: "true"},
+	})
+
+	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" || result.Summary != "once\n" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+}
+
+func TestBackgroundOutputsFailClosedBeforeBarrier(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{
+		{ID: "background", Kind: "run", Background: true, Command: `echo "value=private" >> "$GITHUB_OUTPUT"`},
+		{ID: "premature-reader", Kind: "run", Command: `echo "${{ steps.background.outputs.value }}"`},
+	})
+
+	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	if err == nil || result.Conclusion != "failure" || !strings.Contains(err.Error(), "unavailable step") {
+		t.Fatalf("RunJob() result = %#v, error = %v, want unavailable background output", result, err)
+	}
+}
+
+func TestBackgroundSupervisorBoundsActiveWorkAndQueuesFIFO(t *testing.T) {
+	supervisor := newBackgroundSupervisor(maxActiveBackgroundSteps)
+	release := make(chan struct{})
+	var active atomic.Int32
+	var maximum atomic.Int32
+	var started atomic.Int32
+	for i := 0; i < maxActiveBackgroundSteps+2; i++ {
+		supervisor.start(strconv.Itoa(i), func() stepExecution {
+			current := active.Add(1)
+			for current > maximum.Load() && !maximum.CompareAndSwap(maximum.Load(), current) {
+			}
+			started.Add(1)
+			<-release
+			active.Add(-1)
+			return stepExecution{}
+		})
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for started.Load() != maxActiveBackgroundSteps && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := started.Load(); got != maxActiveBackgroundSteps {
+		t.Fatalf("started = %d, want %d before release", got, maxActiveBackgroundSteps)
+	}
+	close(release)
+	if got := len(supervisor.waitAll()); got != maxActiveBackgroundSteps+2 {
+		t.Fatalf("completed = %d, want %d", got, maxActiveBackgroundSteps+2)
+	}
+	if got := maximum.Load(); got != maxActiveBackgroundSteps {
+		t.Fatalf("maximum active = %d, want %d", got, maxActiveBackgroundSteps)
+	}
+
+	fifo := newBackgroundSupervisor(1)
+	firstRelease := make(chan struct{})
+	var mu sync.Mutex
+	var order []string
+	start := func(id string, wait <-chan struct{}) {
+		fifo.start(id, func() stepExecution {
+			mu.Lock()
+			order = append(order, id)
+			mu.Unlock()
+			if wait != nil {
+				<-wait
+			}
+			return stepExecution{}
+		})
+	}
+	start("first", firstRelease)
+	start("second", nil)
+	start("third", nil)
+	close(firstRelease)
+	fifo.waitAll()
+	mu.Lock()
+	gotOrder := strings.Join(order, ",")
+	mu.Unlock()
+	if gotOrder != "first,second,third" {
+		t.Fatalf("start order = %q, want FIFO", gotOrder)
+	}
+}
+
+func TestImplicitWaitAllPrecedesPostCleanup(t *testing.T) {
+	node := requireNode24(t)
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	writeFixtureFile(t, workspace, ".github/actions/background/action.yml", "name: Background lifecycle\nruns:\n  using: node24\n  main: main.js\n  post: post.js\n")
+	writeFixtureFile(t, workspace, ".github/actions/background/main.js", `
+const fs = require('fs')
+setTimeout(() => {
+  fs.appendFileSync(process.env.GITHUB_ENV, 'BACKGROUND_READY=true\n')
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, 'value=implicit\n')
+}, 50)
+`)
+	writeFixtureFile(t, workspace, ".github/actions/background/post.js", `
+if (process.env.BACKGROUND_READY !== 'true') process.exit(9)
+console.log('post-after-implicit-wait')
+`)
+	var logs bytes.Buffer
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "background", Kind: "uses", Uses: "./.github/actions/background", Background: true}})
+	job.Outputs = map[string]string{"value": "${{ steps.background.outputs.value }}"}
+
+	result, err := (Runner{Node24: node, Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" || result.Outputs["value"] != "implicit" || result.Env["BACKGROUND_READY"] != "true" {
+		t.Fatalf("RunJob() result = %#v, error = %v, logs = %q", result, err, logs.String())
+	}
+	if !strings.Contains(logs.String(), "post-after-implicit-wait") {
+		t.Fatalf("RunJob() logs = %q", logs.String())
+	}
+}
+
+func TestConcurrentStreamsShareMaskRegistration(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	marker := filepath.Join(workspace, "mask.ready")
+	var logs bytes.Buffer
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{
+		{ID: "masker", Kind: "run", Background: true, Command: `echo '::add-mask::cross-stream-secret'; sleep 0.05; touch "$MASK_READY"`},
+		{ID: "other-stream", Kind: "run", Command: `while [ ! -f "$MASK_READY" ]; do sleep 0.01; done; echo 'probe cross-stream-secret'`},
+		{ID: "wait", Kind: "wait-all"},
+	})
+	job.Env = map[string]string{"MASK_READY": marker}
+	result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	if strings.Contains(logs.String(), "cross-stream-secret") || !strings.Contains(logs.String(), "probe ***") {
+		t.Fatalf("RunJob() logs = %q", logs.String())
 	}
 }
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -126,6 +126,26 @@ func TestFailureConditionsAndCancellation(t *testing.T) {
 	}
 }
 
+func TestConcurrentPlansFailClosedBeforeProcessExecution(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	marker := filepath.Join(workspace, "must-not-exist")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{
+		ID:         "background",
+		Kind:       "run",
+		Command:    "touch " + marker,
+		Background: true,
+	}})
+	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	if err == nil || !strings.Contains(err.Error(), "requires the concurrent-step supervisor") {
+		t.Fatalf("RunJob() result = %#v, error = %v, want supervisor rejection", result, err)
+	}
+	if _, statErr := os.Stat(marker); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("concurrent plan reached process execution: %v", statErr)
+	}
+}
+
 func TestCancellationTerminatesChildProcessGroup(t *testing.T) {
 	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
 		t.Skip("process groups are implemented for the initial Linux runtime and Darwin development hosts")

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -185,6 +185,38 @@ func TestCancelQueuedBackgroundNeverStartsIt(t *testing.T) {
 	}
 }
 
+func TestCancelQueuedBackgroundNeverRegistersPostAction(t *testing.T) {
+	node := requireNode24(t)
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	writeFixtureFile(t, workspace, ".github/actions/queued/action.yml", "name: Queued lifecycle\nruns:\n  using: node24\n  main: main.js\n  post: post.js\n")
+	writeFixtureFile(t, workspace, ".github/actions/queued/main.js", "console.log('queued-main-must-not-run')\n")
+	writeFixtureFile(t, workspace, ".github/actions/queued/post.js", "console.log('queued-post-must-not-run')\n")
+	release := filepath.Join(workspace, "release")
+	steps := make([]plan.Step, 0, maxActiveBackgroundSteps+4)
+	for i := 0; i < maxActiveBackgroundSteps; i++ {
+		steps = append(steps, plan.Step{ID: fmt.Sprintf("blocker-%d", i), Kind: "run", Background: true, Command: `while [ ! -f "$RELEASE" ]; do sleep 0.01; done`})
+	}
+	steps = append(steps,
+		plan.Step{ID: "queued", Kind: "uses", Uses: "./.github/actions/queued", Background: true},
+		plan.Step{ID: "cancel-queued", Kind: "cancel", Targets: []string{"queued"}},
+		plan.Step{ID: "release", Kind: "run", Command: `touch "$RELEASE"`},
+		plan.Step{ID: "wait", Kind: "wait-all"},
+	)
+	job := runtimePlan(t, workspace, workflowPath, steps)
+	job.Env = map[string]string{"RELEASE": release}
+	var logs bytes.Buffer
+
+	result, err := (Runner{Node24: node, Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	if strings.Contains(logs.String(), "queued-main-must-not-run") || strings.Contains(logs.String(), "queued-post-must-not-run") {
+		t.Fatalf("queued cancelled action ran lifecycle phase: %q", logs.String())
+	}
+}
+
 func TestFailureBeforeCancelStillFailsJob(t *testing.T) {
 	workspace := t.TempDir()
 	workflowPath := ".github/workflows/test.yml"
@@ -810,6 +842,38 @@ func TestPostActionsRunLIFOAfterMainFailure(t *testing.T) {
 	two := strings.Index(logs.String(), "lifecycle:post:two")
 	if two < 0 || one < 0 || two > one {
 		t.Errorf("post logs are not LIFO: %q", logs.String())
+	}
+}
+
+func TestConcurrentPostActionsRunLIFOByRegistration(t *testing.T) {
+	node := requireNode24(t)
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	writeFixtureFile(t, workspace, ".github/actions/background/action.yml", "name: Background lifecycle\nruns:\n  using: node24\n  main: main.js\n  post: post.js\n")
+	writeFixtureFile(t, workspace, ".github/actions/background/main.js", "require('fs').writeFileSync(process.env.READY, 'ready')\nsetTimeout(() => {}, 100)\n")
+	writeFixtureFile(t, workspace, ".github/actions/background/post.js", "console.log('post:background')\n")
+	writeFixtureFile(t, workspace, ".github/actions/foreground/action.yml", "name: Foreground lifecycle\nruns:\n  using: node24\n  main: main.js\n  post: post.js\n")
+	writeFixtureFile(t, workspace, ".github/actions/foreground/main.js", "console.log('main:foreground')\n")
+	writeFixtureFile(t, workspace, ".github/actions/foreground/post.js", "console.log('post:foreground')\n")
+	ready := filepath.Join(workspace, "background.ready")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{
+		{ID: "background", Kind: "uses", Uses: "./.github/actions/background", Background: true},
+		{ID: "await-background", Kind: "run", Command: `while [ ! -f "$READY" ]; do sleep 0.01; done`},
+		{ID: "foreground", Kind: "uses", Uses: "./.github/actions/foreground"},
+		{ID: "wait-background", Kind: "wait", Targets: []string{"background"}},
+	})
+	job.Env = map[string]string{"READY": ready}
+	var logs bytes.Buffer
+
+	result, err := (Runner{Node24: node, Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v, logs = %q", result, err, logs.String())
+	}
+	background := strings.Index(logs.String(), "post:background")
+	foreground := strings.Index(logs.String(), "post:foreground")
+	if foreground < 0 || background < 0 || foreground > background {
+		t.Fatalf("concurrent post logs are not registration-order LIFO: %q", logs.String())
 	}
 }
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -694,6 +694,58 @@ while :; do sleep 1; done`)
 	}
 }
 
+func TestCancellationWaitsForProcessGroupCleanupAfterOutputCloses(t *testing.T) {
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+		t.Skip("process groups are implemented for the initial Linux runtime and Darwin development hosts")
+	}
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "child.pid")
+	ready := filepath.Join(dir, "ready")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if _, err := os.Stat(ready); err == nil {
+				cancel()
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		cancel()
+	}()
+	started := time.Now()
+	runner := Runner{InterruptGrace: 50 * time.Millisecond, TerminateGrace: 50 * time.Millisecond}
+	err := runner.runStreaming(ctx, newCommandProcessor(io.Discard, io.Discard), "", map[string]string{"PID_FILE": pidFile, "READY": ready}, "bash", "-c", `
+(trap '' INT TERM; exec >/dev/null 2>&1; while :; do sleep 1; done) &
+echo $! > "$PID_FILE"
+trap 'exit 0' INT
+touch "$READY"
+while :; do sleep 1; done`)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("runStreaming() error = %v, want cancellation", err)
+	}
+	if elapsed := time.Since(started); elapsed < 90*time.Millisecond {
+		t.Fatalf("runStreaming() returned before process-group escalation completed: %s", elapsed)
+	}
+	contents, readErr := os.ReadFile(pidFile)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	pid, parseErr := strconv.Atoi(strings.TrimSpace(string(contents)))
+	if parseErr != nil {
+		t.Fatal(parseErr)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(pid, 0); errors.Is(err, syscall.ESRCH) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("child process %d survived completed cancellation", pid)
+}
+
 func TestExplicitCancelTerminatesBackgroundProcessGroup(t *testing.T) {
 	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
 		t.Skip("process groups are implemented for the initial Linux runtime and Darwin development hosts")

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -256,6 +256,113 @@ test "${{ steps.two.outputs.value }}" = output-two`},
 	}
 }
 
+func TestConcurrentPathEffectsComposeWithLiveBarrierState(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	oneDone := filepath.Join(workspace, "one.done")
+	twoDone := filepath.Join(workspace, "two.done")
+	onePath := filepath.Join(workspace, "background-one")
+	twoPath := filepath.Join(workspace, "background-two")
+	foregroundPath := filepath.Join(workspace, "foreground")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{
+		{ID: "one", Kind: "run", Background: true, Command: `echo "$ONE_PATH" >> "$GITHUB_PATH"; touch "$ONE_DONE"`},
+		{ID: "two", Kind: "run", Background: true, Command: `echo "$TWO_PATH" >> "$GITHUB_PATH"; touch "$TWO_DONE"`},
+		{ID: "foreground", Kind: "run", Command: `
+while [ ! -f "$ONE_DONE" ] || [ ! -f "$TWO_DONE" ]; do sleep 0.01; done
+echo "$FOREGROUND_PATH" >> "$GITHUB_PATH"`},
+		{ID: "wait-all", Kind: "wait-all"},
+		{ID: "verify", Kind: "run", Command: `
+want="$TWO_PATH:$ONE_PATH:$FOREGROUND_PATH:"
+case "$PATH" in "$want"*) ;; *) exit 1 ;; esac
+test "$(printf '%s' "$PATH" | tr ':' '\n' | grep -Fxc "$ONE_PATH")" -eq 1
+test "$(printf '%s' "$PATH" | tr ':' '\n' | grep -Fxc "$TWO_PATH")" -eq 1
+test "$(printf '%s' "$PATH" | tr ':' '\n' | grep -Fxc "$FOREGROUND_PATH")" -eq 1`},
+	})
+	job.Env = map[string]string{
+		"ONE_DONE": oneDone, "TWO_DONE": twoDone,
+		"ONE_PATH": onePath, "TWO_PATH": twoPath, "FOREGROUND_PATH": foregroundPath,
+	}
+
+	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	if err != nil {
+		t.Fatalf("RunJob() error = %v", err)
+	}
+	if result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v", result)
+	}
+}
+
+func TestBackgroundCompositePathEffectsComposeAtBarrier(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	writeFixtureFile(t, workspace, ".github/actions/path/action.yml", `name: Path writer
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: echo "$COMPOSITE_PATH" >> "$GITHUB_PATH"
+`)
+	compositePath := filepath.Join(workspace, "composite")
+	foregroundPath := filepath.Join(workspace, "foreground")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{
+		{ID: "composite", Kind: "uses", Uses: "./.github/actions/path", Background: true},
+		{ID: "foreground", Kind: "run", Command: `echo "$FOREGROUND_PATH" >> "$GITHUB_PATH"`},
+		{ID: "wait", Kind: "wait", Targets: []string{"composite"}},
+		{ID: "verify", Kind: "run", Command: `case "$PATH" in "$COMPOSITE_PATH:$FOREGROUND_PATH:"*) ;; *) exit 1 ;; esac`},
+	})
+	job.Env = map[string]string{"COMPOSITE_PATH": compositePath, "FOREGROUND_PATH": foregroundPath}
+
+	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	if err != nil {
+		t.Fatalf("RunJob() error = %v", err)
+	}
+	if result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v", result)
+	}
+}
+
+func TestJavaScriptMainSeesPrePathEffects(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	writeFixtureFile(t, workspace, ".github/actions/path/action.yml", `name: JavaScript path writer
+runs:
+  using: node24
+  pre: pre.js
+  main: main.js
+`)
+	writeFixtureFile(t, workspace, ".github/actions/path/pre.js", "")
+	writeFixtureFile(t, workspace, ".github/actions/path/main.js", "")
+	fakeNode := filepath.Join(workspace, "node24")
+	writeFixtureFile(t, workspace, "node24", `#!/bin/sh
+set -eu
+if [ "${1:-}" = --version ]; then
+  echo v24.0.0
+  exit 0
+fi
+case "${1##*/}" in
+  pre.js) printf '%s\n' "$PATH_ENTRY" >> "$GITHUB_PATH" ;;
+  main.js) case ":$PATH:" in *":$PATH_ENTRY:"*) ;; *) exit 9 ;; esac ;;
+esac
+`)
+	if err := os.Chmod(fakeNode, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	pathEntry := filepath.Join(workspace, "from-pre")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "javascript", Kind: "uses", Uses: "./.github/actions/path"}})
+	job.Env = map[string]string{"PATH_ENTRY": pathEntry}
+
+	result, err := (Runner{Node24: fakeNode}).RunJob(context.Background(), job, workspace)
+	if err != nil {
+		t.Fatalf("RunJob() error = %v", err)
+	}
+	if result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v", result)
+	}
+}
+
 func TestBackgroundFailureSurfacesAtWait(t *testing.T) {
 	workspace := t.TempDir()
 	workflowPath := ".github/workflows/test.yml"
@@ -773,7 +880,7 @@ func TestFileCommandParsing(t *testing.T) {
 		t.Fatal(err)
 	}
 	result := newResult()
-	if err := files.apply(&result, nil); err == nil || !strings.Contains(err.Error(), "NODE_OPTIONS") {
+	if _, err := files.apply(&result, nil); err == nil || !strings.Contains(err.Error(), "NODE_OPTIONS") {
 		t.Fatalf("commandFiles.apply() error = %v, want NODE_OPTIONS rejection", err)
 	}
 }
@@ -806,7 +913,7 @@ func TestFileCommandAggregateLimits(t *testing.T) {
 		t.Fatal(err)
 	}
 	result := newResult()
-	if err := files.apply(&result, nil); err == nil || !strings.Contains(err.Error(), "entry limit") {
+	if _, err := files.apply(&result, nil); err == nil || !strings.Contains(err.Error(), "entry limit") {
 		t.Fatalf("apply() error = %v, want entry limit", err)
 	}
 
@@ -817,7 +924,7 @@ func TestFileCommandAggregateLimits(t *testing.T) {
 		t.Fatal(err)
 	}
 	result = newResult()
-	if err := files.apply(&result, nil); err == nil || !strings.Contains(err.Error(), "summary exceeds") {
+	if _, err := files.apply(&result, nil); err == nil || !strings.Contains(err.Error(), "summary exceeds") {
 		t.Fatalf("apply() error = %v, want summary size limit", err)
 	}
 
@@ -830,7 +937,7 @@ func TestFileCommandAggregateLimits(t *testing.T) {
 		t.Fatal(err)
 	}
 	result = newResult()
-	if err := files.apply(&result, nil); err == nil || !strings.Contains(err.Error(), "aggregate limit") {
+	if _, err := files.apply(&result, nil); err == nil || !strings.Contains(err.Error(), "aggregate limit") {
 		t.Fatalf("apply() error = %v, want aggregate size limit", err)
 	}
 }

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -128,21 +128,80 @@ func TestFailureConditionsAndCancellation(t *testing.T) {
 	}
 }
 
-func TestCancelPlansFailClosedBeforeProcessExecution(t *testing.T) {
+func TestExplicitCancelCommitsEffectsWithoutFailingJob(t *testing.T) {
 	workspace := t.TempDir()
 	workflowPath := ".github/workflows/test.yml"
 	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
-	marker := filepath.Join(workspace, "must-not-exist")
+	ready := filepath.Join(workspace, "background.ready")
+	terminated := filepath.Join(workspace, "background.terminated")
+	var logs bytes.Buffer
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{
-		{ID: "background", Kind: "run", Command: "touch " + marker, Background: true},
+		{ID: "background", Kind: "run", Background: true, Command: `
+echo "CANCEL_EFFECT=visible" >> "$GITHUB_ENV"
+trap 'touch "$TERMINATED"; exit 0' TERM
+touch "$READY"
+while :; do sleep 1; done`},
+		{ID: "await-start", Kind: "run", Command: `while [ ! -f "$READY" ]; do sleep 0.01; done`},
 		{ID: "cancel", Kind: "cancel", Targets: []string{"background"}},
+		{ID: "cancel-again", Kind: "cancel", Targets: []string{"background"}},
+		{ID: "after-cancel", Kind: "run", Condition: "steps.background.outcome == 'cancelled' && steps.cancel.conclusion == 'success' && steps.cancel-again.conclusion == 'success'", Command: `test "$CANCEL_EFFECT" = visible; test -f "$TERMINATED"; echo after-cancel`},
 	})
-	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
-	if err == nil || !strings.Contains(err.Error(), "requires concurrent-step cancellation") {
-		t.Fatalf("RunJob() result = %#v, error = %v, want cancellation rejection", result, err)
+	job.Env = map[string]string{"READY": ready, "TERMINATED": terminated}
+	result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" || result.Env["CANCEL_EFFECT"] != "visible" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
-	if _, statErr := os.Stat(marker); !errors.Is(statErr, os.ErrNotExist) {
-		t.Fatalf("cancel plan reached process execution: %v", statErr)
+	if !strings.Contains(logs.String(), "after-cancel") {
+		t.Fatalf("RunJob() logs = %q", logs.String())
+	}
+}
+
+func TestCancelQueuedBackgroundNeverStartsIt(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	release := filepath.Join(workspace, "release")
+	queuedMarker := filepath.Join(workspace, "queued-started")
+	steps := make([]plan.Step, 0, maxActiveBackgroundSteps+4)
+	for i := 0; i < maxActiveBackgroundSteps; i++ {
+		steps = append(steps, plan.Step{ID: fmt.Sprintf("blocker-%d", i), Kind: "run", Background: true, Command: `while [ ! -f "$RELEASE" ]; do sleep 0.01; done`})
+	}
+	steps = append(steps,
+		plan.Step{ID: "queued", Kind: "run", Background: true, Command: `touch "$QUEUED_MARKER"`},
+		plan.Step{ID: "cancel-queued", Kind: "cancel", Targets: []string{"queued"}},
+		plan.Step{ID: "release", Kind: "run", Command: `test ! -e "$QUEUED_MARKER"; touch "$RELEASE"`},
+		plan.Step{ID: "wait", Kind: "wait-all"},
+	)
+	job := runtimePlan(t, workspace, workflowPath, steps)
+	job.Env = map[string]string{"RELEASE": release, "QUEUED_MARKER": queuedMarker}
+
+	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	if _, statErr := os.Stat(queuedMarker); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("queued canceled step ran: %v", statErr)
+	}
+}
+
+func TestFailureBeforeCancelStillFailsJob(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	failedPID := filepath.Join(workspace, "failed.pid")
+	var logs bytes.Buffer
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{
+		{ID: "background", Kind: "run", Background: true, Command: `echo $$ > "$FAILED_PID"; exit 7`},
+		{ID: "await-failure", Kind: "run", Command: `while [ ! -f "$FAILED_PID" ]; do sleep 0.01; done; while kill -0 "$(cat "$FAILED_PID")" 2>/dev/null; do sleep 0.01; done; sleep 0.05`},
+		{ID: "cancel", Kind: "cancel", Targets: []string{"background"}},
+		{ID: "default-after-cancel", Kind: "run", Command: "echo must-not-run"},
+		{ID: "recover", Kind: "run", Condition: "failure()", Command: "echo recovered"},
+	})
+	job.Env = map[string]string{"FAILED_PID": failedPID}
+
+	result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	if err == nil || result.Conclusion != "failure" || !strings.Contains(logs.String(), "recovered") || strings.Contains(logs.String(), "must-not-run") {
+		t.Fatalf("RunJob() result = %#v, error = %v, logs = %q", result, err, logs.String())
 	}
 }
 
@@ -249,11 +308,13 @@ func TestSkippedBackgroundAndRepeatedWaitAreCommittedAtMostOnce(t *testing.T) {
 	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{
 		{ID: "skipped", Kind: "run", Background: true, Condition: "false", Command: "exit 1"},
+		{ID: "cancel-skipped", Kind: "cancel", Targets: []string{"skipped"}},
 		{ID: "wait-skipped", Kind: "wait", Targets: []string{"skipped"}},
 		{ID: "completed", Kind: "run", Background: true, Command: `echo once >> "$GITHUB_STEP_SUMMARY"`},
 		{ID: "first-wait", Kind: "wait", Targets: []string{"completed"}},
+		{ID: "cancel-completed", Kind: "cancel", Targets: []string{"completed"}},
 		{ID: "second-wait", Kind: "wait", Targets: []string{"completed"}},
-		{ID: "verify", Kind: "run", Condition: "steps.skipped.conclusion == 'skipped'", Command: "true"},
+		{ID: "verify", Kind: "run", Condition: "steps.skipped.conclusion == 'skipped' && steps.cancel-skipped.conclusion == 'success' && steps.cancel-completed.conclusion == 'success'", Command: "true"},
 	})
 
 	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
@@ -284,7 +345,7 @@ func TestBackgroundSupervisorBoundsActiveWorkAndQueuesFIFO(t *testing.T) {
 	var maximum atomic.Int32
 	var started atomic.Int32
 	for i := 0; i < maxActiveBackgroundSteps+2; i++ {
-		supervisor.start(strconv.Itoa(i), func() stepExecution {
+		supervisor.start(context.Background(), strconv.Itoa(i), func(context.Context) stepExecution {
 			current := active.Add(1)
 			for current > maximum.Load() && !maximum.CompareAndSwap(maximum.Load(), current) {
 			}
@@ -292,7 +353,7 @@ func TestBackgroundSupervisorBoundsActiveWorkAndQueuesFIFO(t *testing.T) {
 			<-release
 			active.Add(-1)
 			return stepExecution{}
-		})
+		}, func(context.Context) stepExecution { return stepExecution{} })
 	}
 	deadline := time.Now().Add(2 * time.Second)
 	for started.Load() != maxActiveBackgroundSteps && time.Now().Before(deadline) {
@@ -314,7 +375,7 @@ func TestBackgroundSupervisorBoundsActiveWorkAndQueuesFIFO(t *testing.T) {
 	var mu sync.Mutex
 	var order []string
 	start := func(id string, wait <-chan struct{}) {
-		fifo.start(id, func() stepExecution {
+		fifo.start(context.Background(), id, func(context.Context) stepExecution {
 			mu.Lock()
 			order = append(order, id)
 			mu.Unlock()
@@ -322,7 +383,7 @@ func TestBackgroundSupervisorBoundsActiveWorkAndQueuesFIFO(t *testing.T) {
 				<-wait
 			}
 			return stepExecution{}
-		})
+		}, func(context.Context) stepExecution { return stepExecution{} })
 	}
 	start("first", firstRelease)
 	start("second", nil)
@@ -415,6 +476,44 @@ func TestCancellationTerminatesChildProcessGroup(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("child process %d survived cancellation", pid)
+}
+
+func TestExplicitCancelTerminatesBackgroundProcessGroup(t *testing.T) {
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+		t.Skip("process groups are implemented for the initial Linux runtime and Darwin development hosts")
+	}
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	pidFile := filepath.Join(workspace, "child.pid")
+	ready := filepath.Join(workspace, "background.ready")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{
+		{ID: "background", Kind: "run", Background: true, Command: `(trap '' TERM; sleep 30) & echo $! > "$PID_FILE"; touch "$READY"; wait`},
+		{ID: "await-start", Kind: "run", Command: `while [ ! -f "$READY" ]; do sleep 0.01; done`},
+		{ID: "cancel", Kind: "cancel", Targets: []string{"background"}},
+	})
+	job.Env = map[string]string{"PID_FILE": pidFile, "READY": ready}
+
+	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	contents, err := os.ReadFile(pidFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(contents)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(pid, 0); errors.Is(err, syscall.ESRCH) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("explicitly canceled child process %d survived", pid)
 }
 
 func TestJobConditionConsumesNeedResultAndOutput(t *testing.T) {
@@ -562,6 +661,28 @@ func TestCancellationStillRunsRegisteredPostAction(t *testing.T) {
 	defer cancel()
 	result, err := (Runner{Node24: node, Stdout: &logs, Stderr: &logs}).RunJob(ctx, job, workspace)
 	if !errors.Is(err, context.DeadlineExceeded) || result.Conclusion != "cancelled" || !strings.Contains(logs.String(), "post-after-cancel") {
+		t.Fatalf("RunJob() result = %#v, error = %v, logs = %q", result, err, logs.String())
+	}
+}
+
+func TestExplicitBackgroundCancelStillRunsRegisteredPostAction(t *testing.T) {
+	node := requireNode24(t)
+	workspace := t.TempDir()
+	writeFixtureFile(t, workspace, ".github/workflows/test.yml", "name: runtime test\n")
+	writeFixtureFile(t, workspace, ".github/actions/cancel/action.yml", "name: Explicit cancellation cleanup\nruns:\n  using: node24\n  main: main.js\n  post: post.js\n")
+	writeFixtureFile(t, workspace, ".github/actions/cancel/main.js", "require('fs').writeFileSync(process.env.READY, 'ready')\nsetInterval(() => {}, 30000)\n")
+	writeFixtureFile(t, workspace, ".github/actions/cancel/post.js", "console.log('post-after-explicit-cancel')\n")
+	ready := filepath.Join(workspace, "action.ready")
+	var logs bytes.Buffer
+	job := runtimePlan(t, workspace, ".github/workflows/test.yml", []plan.Step{
+		{ID: "background", Kind: "uses", Uses: "./.github/actions/cancel", Background: true},
+		{ID: "await-start", Kind: "run", Command: `while [ ! -f "$READY" ]; do sleep 0.01; done`},
+		{ID: "cancel", Kind: "cancel", Targets: []string{"background"}},
+	})
+	job.Env = map[string]string{"READY": ready}
+
+	result, err := (Runner{Node24: node, Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" || !strings.Contains(logs.String(), "post-after-explicit-cancel") {
 		t.Fatalf("RunJob() result = %#v, error = %v, logs = %q", result, err, logs.String())
 	}
 }

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -139,7 +139,7 @@ func TestExplicitCancelCommitsEffectsWithoutFailingJob(t *testing.T) {
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{
 		{ID: "background", Kind: "run", Background: true, Command: `
 echo "CANCEL_EFFECT=visible" >> "$GITHUB_ENV"
-trap 'touch "$TERMINATED"; exit 0' TERM
+trap 'touch "$TERMINATED"; exit 0' INT
 touch "$READY"
 while :; do sleep 1; done`},
 		{ID: "await-start", Kind: "run", Command: `while [ ! -f "$READY" ]; do sleep 0.01; done`},
@@ -599,7 +599,7 @@ func TestCancellationTerminatesChildProcessGroup(t *testing.T) {
 	pidFile := filepath.Join(t.TempDir(), "child.pid")
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
-	err := runStreaming(ctx, newCommandProcessor(io.Discard, io.Discard), "", map[string]string{"PID_FILE": pidFile}, "sh", "-c", `(trap '' TERM; sleep 30) & echo $! > "$PID_FILE"; wait`)
+	err := (Runner{InterruptGrace: 50 * time.Millisecond, TerminateGrace: 50 * time.Millisecond}).runStreaming(ctx, newCommandProcessor(io.Discard, io.Discard), "", map[string]string{"PID_FILE": pidFile}, "sh", "-c", `(trap '' INT TERM; sleep 30) & echo $! > "$PID_FILE"; wait`)
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("runStreaming() error = %v, want deadline", err)
 	}
@@ -621,6 +621,47 @@ func TestCancellationTerminatesChildProcessGroup(t *testing.T) {
 	t.Fatalf("child process %d survived cancellation", pid)
 }
 
+func TestCancellationEscalatesFromInterruptToTermination(t *testing.T) {
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+		t.Skip("process groups are implemented for the initial Linux runtime and Darwin development hosts")
+	}
+	dir := t.TempDir()
+	ready := filepath.Join(dir, "ready")
+	signals := filepath.Join(dir, "signals")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cancelled := make(chan struct{})
+	go func() {
+		defer close(cancelled)
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if _, err := os.Stat(ready); err == nil {
+				cancel()
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		cancel()
+	}()
+	runner := Runner{InterruptGrace: 50 * time.Millisecond, TerminateGrace: 500 * time.Millisecond}
+	err := runner.runStreaming(ctx, newCommandProcessor(io.Discard, io.Discard), "", map[string]string{"READY": ready, "SIGNALS": signals}, "bash", "-c", `
+trap 'printf "INT\n" >> "$SIGNALS"' INT
+trap 'printf "TERM\n" >> "$SIGNALS"; exit 0' TERM
+touch "$READY"
+while :; do sleep 1; done`)
+	<-cancelled
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("runStreaming() error = %v, want cancellation", err)
+	}
+	contents, readErr := os.ReadFile(signals)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if got := string(contents); got != "INT\nTERM\n" {
+		t.Fatalf("signal order = %q, want SIGINT then SIGTERM", got)
+	}
+}
+
 func TestExplicitCancelTerminatesBackgroundProcessGroup(t *testing.T) {
 	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
 		t.Skip("process groups are implemented for the initial Linux runtime and Darwin development hosts")
@@ -631,13 +672,13 @@ func TestExplicitCancelTerminatesBackgroundProcessGroup(t *testing.T) {
 	pidFile := filepath.Join(workspace, "child.pid")
 	ready := filepath.Join(workspace, "background.ready")
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{
-		{ID: "background", Kind: "run", Background: true, Command: `(trap '' TERM; sleep 30) & echo $! > "$PID_FILE"; touch "$READY"; wait`},
+		{ID: "background", Kind: "run", Background: true, Command: `(trap '' INT TERM; sleep 30) & echo $! > "$PID_FILE"; touch "$READY"; wait`},
 		{ID: "await-start", Kind: "run", Command: `while [ ! -f "$READY" ]; do sleep 0.01; done`},
 		{ID: "cancel", Kind: "cancel", Targets: []string{"background"}},
 	})
 	job.Env = map[string]string{"PID_FILE": pidFile, "READY": ready}
 
-	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{InterruptGrace: 50 * time.Millisecond, TerminateGrace: 50 * time.Millisecond}).RunJob(context.Background(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -961,7 +1002,7 @@ func TestRunStreamingDrainsOversizedLineAndPreservesMasking(t *testing.T) {
 	processor := newCommandProcessor(&logs, &logs)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	err = runStreaming(ctx, processor, "", map[string]string{"GO_WANT_RUNTIME_LONG_LINE": "1"}, executable, "-test.run=^TestLongLineChildProcess$")
+	err = (Runner{}).runStreaming(ctx, processor, "", map[string]string{"GO_WANT_RUNTIME_LONG_LINE": "1"}, executable, "-test.run=^TestLongLineChildProcess$")
 	if err == nil || !strings.Contains(err.Error(), "stdout stream: line exceeds 1048576-byte limit and was discarded") {
 		t.Fatalf("runStreaming() error = %v, want oversized-line diagnostic", err)
 	}
@@ -1007,7 +1048,7 @@ func TestProcessEnvironmentIsExplicitAndUsable(t *testing.T) {
 	var logs bytes.Buffer
 	processor := newCommandProcessor(&logs, &logs)
 	command := `test -n "$PATH" && test -n "$HOME" && test -n "$TMPDIR" && test "$DECLARED" = visible && test -z "${BUILDKITE_AGENT_ACCESS_TOKEN:-}" && printf '%s\n' environment-ok`
-	if err := runStreaming(context.Background(), processor, "", map[string]string{"DECLARED": "visible"}, "sh", "-c", command); err != nil {
+	if err := (Runner{}).runStreaming(context.Background(), processor, "", map[string]string{"DECLARED": "visible"}, "sh", "-c", command); err != nil {
 		t.Fatalf("runStreaming() error = %v", err)
 	}
 	if logs.String() != "environment-ok\n" {

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -98,6 +98,8 @@ type Step struct {
 	ID               string            `json:"id,omitempty"`
 	Name             string            `json:"name,omitempty"`
 	Kind             string            `json:"kind"`
+	Background       bool              `json:"background,omitempty"`
+	Targets          []string          `json:"targets,omitempty"`
 	Run              string            `json:"run,omitempty"`
 	Uses             string            `json:"uses,omitempty"`
 	Shell            string            `json:"shell,omitempty"`

--- a/internal/workflow/parse.go
+++ b/internal/workflow/parse.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/buildkite/buildkite-gha/internal/expression"
@@ -16,6 +17,7 @@ type stepConcurrency struct {
 	Kind       string
 	Background bool
 	Targets    []string
+	Parallel   []Step
 }
 
 type expectedActionlintDiagnostic struct {
@@ -230,6 +232,24 @@ func adaptJob(path string, in *actionlint.Job, scalars map[Position]any, concurr
 		control, hasConcurrency := concurrency[stepPosition]
 		if hasConcurrency {
 			delete(concurrency, stepPosition)
+		}
+		if control.Kind == "parallel" {
+			targets := make([]string, 0, len(control.Parallel))
+			for i, member := range control.Parallel {
+				if member.ID == "" {
+					member.ID = parallelStepID(stepPosition, i+1)
+				}
+				member.Background = true
+				targets = append(targets, member.ID)
+				out.Steps = append(out.Steps, member)
+				out.Span.End = member.Span.End
+			}
+			barrierSpan := pointSpan(step.Pos)
+			barrierSpan.End = out.Span.End
+			barrier := Step{ID: parallelBarrierID(stepPosition), Kind: "wait", Targets: targets, Span: barrierSpan}
+			out.Steps = append(out.Steps, barrier)
+			out.Span.End = barrier.Span.End
+			continue
 		}
 		owned := Step{Background: control.Background, Targets: append([]string(nil), control.Targets...), Span: pointSpan(step.Pos)}
 		if step.ID != nil {
@@ -564,7 +584,23 @@ func parseStepConcurrency(path string, step *yaml.Node) (stepConcurrency, expect
 
 	kind := controlKinds[0]
 	if kind == "parallel" {
-		return stepConcurrency{}, expectedActionlintDiagnostic{}, false, yamlNodeError(path, entries[kind], "parallel steps are not yet supported by the Phase 3 runtime")
+		if len(entries) != 1 {
+			names := make([]string, 0, len(entries))
+			for name := range entries {
+				names = append(names, name)
+			}
+			sort.Strings(names)
+			for _, name := range names {
+				if name != kind {
+					return stepConcurrency{}, expectedActionlintDiagnostic{}, false, yamlNodeError(path, mappingKey(step, name), fmt.Sprintf("parallel control does not support %q", name))
+				}
+			}
+		}
+		members, err := parseParallelSteps(path, entries[kind])
+		if err != nil {
+			return stepConcurrency{}, expectedActionlintDiagnostic{}, false, err
+		}
+		return stepConcurrency{Kind: kind, Parallel: members}, expectedActionlintDiagnostic{Position: nodePosition(step), Prefix: missingStepExecutionDiagnostic}, true, nil
 	}
 	allowed := map[string]bool{"name": true, kind: true}
 	if kind == "wait" || kind == "wait-all" {
@@ -595,6 +631,206 @@ func parseStepConcurrency(path string, step *yaml.Node) (stepConcurrency, expect
 		control.Targets = targets
 	}
 	return control, expectedActionlintDiagnostic{Position: nodePosition(step), Prefix: missingStepExecutionDiagnostic}, true, nil
+}
+
+func parseParallelSteps(path string, node *yaml.Node) ([]Step, error) {
+	if node.Kind != yaml.SequenceNode || len(node.Content) == 0 {
+		return nil, yamlNodeError(path, node, "parallel requires a non-empty list of run or uses steps")
+	}
+	steps := make([]Step, 0, len(node.Content))
+	for _, child := range node.Content {
+		step, err := parseParallelStep(path, child)
+		if err != nil {
+			return nil, err
+		}
+		steps = append(steps, step)
+	}
+	return steps, nil
+}
+
+func parseParallelStep(path string, node *yaml.Node) (Step, error) {
+	if node.Kind != yaml.MappingNode {
+		return Step{}, yamlNodeError(path, node, "parallel member must be a run or uses step")
+	}
+	entries := mappingEntries(node)
+	allowed := map[string]bool{
+		"id": true, "name": true, "run": true, "uses": true, "shell": true, "working-directory": true,
+		"env": true, "with": true, "if": true, "continue-on-error": true, "timeout-minutes": true,
+	}
+	for name := range entries {
+		if !allowed[name] {
+			return Step{}, yamlNodeError(path, mappingKey(node, name), fmt.Sprintf("parallel member does not support %q", name))
+		}
+	}
+	run, hasRun := entries["run"]
+	uses, hasUses := entries["uses"]
+	if hasRun == hasUses {
+		return Step{}, yamlNodeError(path, node, "parallel member must declare exactly one of run or uses")
+	}
+	if err := validateParallelStepSyntax(path, node); err != nil {
+		return Step{}, err
+	}
+	execution := run
+	if hasUses {
+		execution = uses
+	}
+	if execution.Kind != yaml.ScalarNode || execution.ShortTag() == "!!null" || strings.TrimSpace(execution.Value) == "" {
+		return Step{}, yamlNodeError(path, execution, "parallel member execution must be a non-empty scalar")
+	}
+	step := Step{Span: yamlStepSpan(node, execution)}
+	var err error
+	if step.ID, err = optionalString(entries["id"]); err != nil {
+		return Step{}, yamlNodeError(path, entries["id"], "parallel member id must be a string")
+	}
+	if step.Name, err = optionalScalar(entries["name"]); err != nil {
+		return Step{}, yamlNodeError(path, entries["name"], "parallel member name must be a scalar")
+	}
+	if step.If, err = optionalScalar(entries["if"]); err != nil {
+		return Step{}, yamlNodeError(path, entries["if"], "parallel member if must be a scalar")
+	}
+	if step.Env, err = scalarMap(entries["env"]); err != nil {
+		return Step{}, yamlNodeError(path, entries["env"], "parallel member env must be a scalar mapping")
+	}
+	if value := entries["continue-on-error"]; value != nil {
+		if value.Kind != yaml.ScalarNode || value.ShortTag() != "!!bool" {
+			return Step{}, yamlNodeError(path, value, "parallel member continue-on-error must be a literal boolean")
+		}
+		if err := value.Decode(&step.ContinueOnError); err != nil {
+			return Step{}, yamlNodeError(path, value, "parallel member continue-on-error must be a literal boolean")
+		}
+	}
+	if value := entries["timeout-minutes"]; value != nil {
+		if value.Kind != yaml.ScalarNode || value.ShortTag() != "!!int" && value.ShortTag() != "!!float" {
+			return Step{}, yamlNodeError(path, value, "parallel member timeout-minutes must be a literal number")
+		}
+		step.TimeoutMinutes, err = strconv.ParseFloat(value.Value, 64)
+		if err != nil {
+			return Step{}, yamlNodeError(path, value, "parallel member timeout-minutes must be a literal number")
+		}
+	}
+	if hasRun {
+		if entries["with"] != nil {
+			return Step{}, yamlNodeError(path, mappingKey(node, "with"), "parallel run member does not support with")
+		}
+		step.Kind = "run"
+		step.Run = run.Value
+		if step.Shell, err = optionalScalar(entries["shell"]); err != nil {
+			return Step{}, yamlNodeError(path, entries["shell"], "parallel member shell must be a scalar")
+		}
+		if step.WorkingDirectory, err = optionalScalar(entries["working-directory"]); err != nil {
+			return Step{}, yamlNodeError(path, entries["working-directory"], "parallel member working-directory must be a scalar")
+		}
+		return step, nil
+	}
+	if entries["shell"] != nil || entries["working-directory"] != nil {
+		return Step{}, yamlNodeError(path, node, "parallel uses member cannot declare shell or working-directory")
+	}
+	step.Kind = "uses"
+	step.Uses = uses.Value
+	if step.With, err = scalarMap(entries["with"]); err != nil {
+		return Step{}, yamlNodeError(path, entries["with"], "parallel member with must be a scalar mapping")
+	}
+	for name, value := range step.With {
+		lower := strings.ToLower(name)
+		if lower != name {
+			delete(step.With, name)
+			step.With[lower] = value
+		}
+	}
+	_, hasEntrypoint := step.With["entrypoint"]
+	_, hasArgs := step.With["args"]
+	if strings.HasPrefix(strings.ToLower(step.Uses), "docker://") && (hasEntrypoint || hasArgs) {
+		return Step{}, yamlNodeError(path, entries["with"], "parallel docker action member uses unsupported entrypoint or args overrides")
+	}
+	return step, nil
+}
+
+func validateParallelStepSyntax(path string, step *yaml.Node) error {
+	stringNode := func(value string) *yaml.Node {
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: value}
+	}
+	mappingNode := func(content ...*yaml.Node) *yaml.Node {
+		return &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map", Content: content}
+	}
+	document := yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{
+		mappingNode(
+			stringNode("on"), stringNode("push"),
+			stringNode("jobs"), mappingNode(
+				stringNode("parallel"), mappingNode(
+					stringNode("runs-on"), stringNode("ubuntu-latest"),
+					stringNode("steps"), &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq", Content: []*yaml.Node{step}},
+				),
+			),
+		),
+	}}
+	source, err := yaml.Marshal(&document)
+	if err != nil {
+		return yamlNodeError(path, step, fmt.Sprintf("validate parallel member: %v", err))
+	}
+	_, errs := actionlint.Parse(source)
+	if len(errs) != 0 {
+		return yamlNodeError(path, step, fmt.Sprintf("invalid parallel member: %s", errs[0].Message))
+	}
+	return nil
+}
+
+func optionalString(node *yaml.Node) (string, error) {
+	if node == nil {
+		return "", nil
+	}
+	if node.Kind != yaml.ScalarNode || node.ShortTag() != "!!str" || node.Value == "" {
+		return "", fmt.Errorf("value is not a string")
+	}
+	return node.Value, nil
+}
+
+func optionalScalar(node *yaml.Node) (string, error) {
+	if node == nil {
+		return "", nil
+	}
+	if node.Kind != yaml.ScalarNode || node.ShortTag() == "!!null" {
+		return "", fmt.Errorf("value is not a scalar")
+	}
+	return node.Value, nil
+}
+
+func scalarMap(node *yaml.Node) (map[string]string, error) {
+	if node == nil {
+		return nil, nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("value is not a mapping")
+	}
+	values := make(map[string]string, len(node.Content)/2)
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key, value := node.Content[i], node.Content[i+1]
+		if key.Kind != yaml.ScalarNode || key.ShortTag() != "!!str" || key.Value == "" || value.Kind != yaml.ScalarNode {
+			return nil, fmt.Errorf("mapping contains a non-scalar entry")
+		}
+		values[key.Value] = value.Value
+	}
+	return values, nil
+}
+
+func parallelStepID(position Position, member int) string {
+	return fmt.Sprintf("__parallel_%d_%d_%d", position.Line, position.Column, member)
+}
+
+func parallelBarrierID(position Position) string {
+	return fmt.Sprintf("__parallel_%d_%d_wait", position.Line, position.Column)
+}
+
+func yamlStepSpan(step, execution *yaml.Node) Span {
+	span := Span{Start: nodePosition(step), End: nodePosition(execution)}
+	for _, r := range execution.Value {
+		if r == '\n' {
+			span.End.Line++
+			span.End.Column = 1
+		} else {
+			span.End.Column++
+		}
+	}
+	return span
 }
 
 func filterActionlintDiagnostics(path string, errs []*actionlint.Error, expected []expectedActionlintDiagnostic) error {

--- a/internal/workflow/parse.go
+++ b/internal/workflow/parse.go
@@ -603,9 +603,6 @@ func parseStepConcurrency(path string, step *yaml.Node) (stepConcurrency, expect
 		return stepConcurrency{Kind: kind, Parallel: members}, expectedActionlintDiagnostic{Position: nodePosition(step), Prefix: missingStepExecutionDiagnostic}, true, nil
 	}
 	allowed := map[string]bool{"name": true, kind: true}
-	if kind == "wait" || kind == "wait-all" {
-		allowed["continue-on-error"] = true
-	}
 	for name := range entries {
 		if !allowed[name] {
 			return stepConcurrency{}, expectedActionlintDiagnostic{}, false, yamlNodeError(path, mappingKey(step, name), fmt.Sprintf("%s control does not support %q", kind, name))

--- a/internal/workflow/parse.go
+++ b/internal/workflow/parse.go
@@ -3,21 +3,47 @@ package workflow
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/buildkite/buildkite-gha/internal/expression"
 	"github.com/rhysd/actionlint"
 	"go.yaml.in/yaml/v4"
 )
 
+const missingStepExecutionDiagnostic = "step must run script with \"run\" section or run action with \"uses\" section"
+
+type stepConcurrency struct {
+	Kind       string
+	Background bool
+	Targets    []string
+}
+
+type expectedActionlintDiagnostic struct {
+	Position Position
+	Prefix   string
+}
+
+type concurrencySyntax struct {
+	Steps       map[Position]stepConcurrency
+	Diagnostics []expectedActionlintDiagnostic
+}
+
 // Parse uses actionlint as the syntax frontend and immediately converts its AST
 // into the owned workflow model.
 func Parse(path string, source []byte) (*Workflow, error) {
-	parsed, errs := actionlint.Parse(source)
-	if len(errs) != 0 {
-		err := errs[0]
-		return nil, fmt.Errorf("%s:%d:%d: %s", path, err.Line, err.Column, err.Message)
+	var document yaml.Node
+	if err := yaml.Unmarshal(source, &document); err != nil {
+		return nil, fmt.Errorf("%s: parse workflow YAML: %w", path, err)
 	}
-	scalars, err := scalarValues(source)
+	concurrency, err := parseConcurrencySyntax(path, &document)
+	if err != nil {
+		return nil, err
+	}
+	parsed, errs := actionlint.Parse(source)
+	if err := filterActionlintDiagnostics(path, errs, concurrency.Diagnostics); err != nil {
+		return nil, err
+	}
+	scalars, err := scalarValues(&document)
 	if err != nil {
 		return nil, fmt.Errorf("%s: parse scalar values: %w", path, err)
 	}
@@ -68,7 +94,7 @@ func Parse(path string, source []byte) (*Workflow, error) {
 	}
 	sort.Strings(ids)
 	for _, id := range ids {
-		job, err := adaptJob(path, parsed.Jobs[id], scalars)
+		job, err := adaptJob(path, parsed.Jobs[id], scalars, concurrency.Steps)
 		if err != nil {
 			return nil, err
 		}
@@ -81,10 +107,24 @@ func Parse(path string, source []byte) (*Workflow, error) {
 		}
 		owned.Jobs = append(owned.Jobs, job)
 	}
+	if len(concurrency.Steps) != 0 {
+		positions := make([]Position, 0, len(concurrency.Steps))
+		for position := range concurrency.Steps {
+			positions = append(positions, position)
+		}
+		sort.Slice(positions, func(i, j int) bool {
+			if positions[i].Line != positions[j].Line {
+				return positions[i].Line < positions[j].Line
+			}
+			return positions[i].Column < positions[j].Column
+		})
+		position := positions[0]
+		return nil, fmt.Errorf("%s:%d:%d: concurrent step did not match the pinned actionlint syntax tree", path, position.Line, position.Column)
+	}
 	return owned, nil
 }
 
-func adaptJob(path string, in *actionlint.Job, scalars map[Position]any) (Job, error) {
+func adaptJob(path string, in *actionlint.Job, scalars map[Position]any, concurrency map[Position]stepConcurrency) (Job, error) {
 	out := Job{ID: in.ID.Value, Span: pointSpan(in.Pos)}
 	if in.WorkflowCall != nil {
 		call := in.WorkflowCall
@@ -186,7 +226,12 @@ func adaptJob(path string, in *actionlint.Job, scalars map[Position]any) (Job, e
 	}
 
 	for _, step := range in.Steps {
-		owned := Step{Span: pointSpan(step.Pos)}
+		stepPosition := Position{Line: step.Pos.Line, Column: step.Pos.Col}
+		control, hasConcurrency := concurrency[stepPosition]
+		if hasConcurrency {
+			delete(concurrency, stepPosition)
+		}
+		owned := Step{Background: control.Background, Targets: append([]string(nil), control.Targets...), Span: pointSpan(step.Pos)}
 		if step.ID != nil {
 			owned.ID = step.ID.Value
 		}
@@ -236,11 +281,19 @@ func adaptJob(path string, in *actionlint.Job, scalars map[Position]any) (Job, e
 				}
 			}
 			owned.Span = spanFrom(step.Pos, exec.Uses.Value)
+		case nil:
+			if control.Kind == "" {
+				return Job{}, locatedError(path, step.Pos, in.ID.Value, "unsupported step execution kind")
+			}
+			owned.Kind = control.Kind
 		default:
 			return Job{}, locatedError(path, step.Pos, in.ID.Value, "unsupported step execution kind")
 		}
 		out.Steps = append(out.Steps, owned)
 		out.Span.End = owned.Span.End
+	}
+	if err := validateStepConcurrency(path, in.ID.Value, out.Steps); err != nil {
+		return Job{}, err
 	}
 	return out, nil
 }
@@ -415,14 +468,10 @@ func adaptValue(in actionlint.RawYAMLValue, scalars map[Position]any) any {
 	}
 }
 
-func scalarValues(source []byte) (map[Position]any, error) {
+func scalarValues(document *yaml.Node) (map[Position]any, error) {
 	// actionlint's raw scalar model intentionally discards YAML scalar tags.
 	// Join a YAML node tree by source position so quoted strings remain distinct
 	// from the booleans, numbers, and nulls used in matrix contexts.
-	var document yaml.Node
-	if err := yaml.Unmarshal(source, &document); err != nil {
-		return nil, err
-	}
 	values := make(map[Position]any)
 	var walk func(*yaml.Node) error
 	walk = func(node *yaml.Node) error {
@@ -443,10 +492,233 @@ func scalarValues(source []byte) (map[Position]any, error) {
 		}
 		return nil
 	}
-	if err := walk(&document); err != nil {
+	if err := walk(document); err != nil {
 		return nil, err
 	}
 	return values, nil
+}
+
+func parseConcurrencySyntax(path string, document *yaml.Node) (concurrencySyntax, error) {
+	syntax := concurrencySyntax{Steps: map[Position]stepConcurrency{}}
+	root := document
+	if root.Kind == yaml.DocumentNode && len(root.Content) != 0 {
+		root = root.Content[0]
+	}
+	jobs := mappingValue(root, "jobs")
+	if jobs == nil || jobs.Kind != yaml.MappingNode {
+		return syntax, nil
+	}
+	for i := 0; i+1 < len(jobs.Content); i += 2 {
+		job := jobs.Content[i+1]
+		steps := mappingValue(job, "steps")
+		if steps == nil || steps.Kind != yaml.SequenceNode {
+			continue
+		}
+		for _, step := range steps.Content {
+			if step.Kind != yaml.MappingNode {
+				continue
+			}
+			parsed, diagnostic, ok, err := parseStepConcurrency(path, step)
+			if err != nil {
+				return concurrencySyntax{}, err
+			}
+			if !ok {
+				continue
+			}
+			position := nodePosition(step)
+			syntax.Steps[position] = parsed
+			syntax.Diagnostics = append(syntax.Diagnostics, diagnostic)
+		}
+	}
+	return syntax, nil
+}
+
+func parseStepConcurrency(path string, step *yaml.Node) (stepConcurrency, expectedActionlintDiagnostic, bool, error) {
+	entries := mappingEntries(step)
+	background, hasBackground := entries["background"]
+	controlKinds := make([]string, 0, 3)
+	for _, kind := range []string{"wait", "wait-all", "cancel", "parallel"} {
+		if _, ok := entries[kind]; ok {
+			controlKinds = append(controlKinds, kind)
+		}
+	}
+	if !hasBackground && len(controlKinds) == 0 {
+		return stepConcurrency{}, expectedActionlintDiagnostic{}, false, nil
+	}
+	if len(controlKinds) > 1 || len(controlKinds) != 0 && (hasBackground || entries["run"] != nil || entries["uses"] != nil) {
+		return stepConcurrency{}, expectedActionlintDiagnostic{}, false, yamlNodeError(path, step, "concurrent step must declare exactly one execution or control kind")
+	}
+	if hasBackground {
+		if entries["run"] == nil && entries["uses"] == nil {
+			return stepConcurrency{}, expectedActionlintDiagnostic{}, false, yamlNodeError(path, background, "background is only valid on run or uses steps")
+		}
+		if background.ShortTag() != "!!bool" || background.Value != "true" {
+			return stepConcurrency{}, expectedActionlintDiagnostic{}, false, yamlNodeError(path, background, "background must be the literal true")
+		}
+		key := mappingKey(step, "background")
+		return stepConcurrency{Background: true}, expectedActionlintDiagnostic{
+			Position: nodePosition(key),
+			Prefix:   "unexpected key \"background\" for step to ",
+		}, true, nil
+	}
+
+	kind := controlKinds[0]
+	if kind == "parallel" {
+		return stepConcurrency{}, expectedActionlintDiagnostic{}, false, yamlNodeError(path, entries[kind], "parallel steps are not yet supported by the Phase 3 runtime")
+	}
+	allowed := map[string]bool{"name": true, kind: true}
+	if kind == "wait" || kind == "wait-all" {
+		allowed["continue-on-error"] = true
+	}
+	for name := range entries {
+		if !allowed[name] {
+			return stepConcurrency{}, expectedActionlintDiagnostic{}, false, yamlNodeError(path, mappingKey(step, name), fmt.Sprintf("%s control does not support %q", kind, name))
+		}
+	}
+	control := stepConcurrency{Kind: kind}
+	switch kind {
+	case "wait":
+		targets, err := stringList(entries[kind])
+		if err != nil || len(targets) == 0 {
+			return stepConcurrency{}, expectedActionlintDiagnostic{}, false, yamlNodeError(path, entries[kind], "wait requires one step id or a non-empty list of step ids")
+		}
+		control.Targets = targets
+	case "wait-all":
+		if entries[kind].ShortTag() != "!!null" {
+			return stepConcurrency{}, expectedActionlintDiagnostic{}, false, yamlNodeError(path, entries[kind], "wait-all does not accept a value")
+		}
+	case "cancel":
+		targets, err := stringList(entries[kind])
+		if err != nil || len(targets) != 1 || entries[kind].Kind != yaml.ScalarNode {
+			return stepConcurrency{}, expectedActionlintDiagnostic{}, false, yamlNodeError(path, entries[kind], "cancel requires exactly one step id")
+		}
+		control.Targets = targets
+	}
+	return control, expectedActionlintDiagnostic{Position: nodePosition(step), Prefix: missingStepExecutionDiagnostic}, true, nil
+}
+
+func filterActionlintDiagnostics(path string, errs []*actionlint.Error, expected []expectedActionlintDiagnostic) error {
+	matched := make([]bool, len(expected))
+	for _, actionlintErr := range errs {
+		match := -1
+		for i, diagnostic := range expected {
+			if !matched[i] && diagnostic.Position.Line == actionlintErr.Line && diagnostic.Position.Column == actionlintErr.Column && strings.HasPrefix(actionlintErr.Message, diagnostic.Prefix) {
+				match = i
+				break
+			}
+		}
+		if match >= 0 {
+			matched[match] = true
+			continue
+		}
+		return fmt.Errorf("%s:%d:%d: %s", path, actionlintErr.Line, actionlintErr.Column, actionlintErr.Message)
+	}
+	for i, ok := range matched {
+		if !ok {
+			diagnostic := expected[i]
+			return fmt.Errorf("%s:%d:%d: actionlint concurrency diagnostic changed; pinned parser contract must be reviewed", path, diagnostic.Position.Line, diagnostic.Position.Column)
+		}
+	}
+	return nil
+}
+
+func validateStepConcurrency(path, jobID string, steps []Step) error {
+	background := make(map[string]struct{})
+	for _, step := range steps {
+		if step.Background && step.ID != "" {
+			background[strings.ToLower(step.ID)] = struct{}{}
+		}
+		if step.Kind != "wait" && step.Kind != "cancel" {
+			continue
+		}
+		seen := make(map[string]struct{}, len(step.Targets))
+		for _, target := range step.Targets {
+			key := strings.ToLower(target)
+			if _, duplicate := seen[key]; duplicate {
+				return workflowSpanError(path, step.Span, jobID, fmt.Sprintf("%s repeats background step %q", step.Kind, target))
+			}
+			seen[key] = struct{}{}
+			if _, ok := background[key]; !ok {
+				return workflowSpanError(path, step.Span, jobID, fmt.Sprintf("%s target %q is not a prior background step with an id", step.Kind, target))
+			}
+		}
+	}
+	return nil
+}
+
+func mappingEntries(node *yaml.Node) map[string]*yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return map[string]*yaml.Node{}
+	}
+	entries := make(map[string]*yaml.Node, len(node.Content)/2)
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		entries[node.Content[i].Value] = node.Content[i+1]
+	}
+	return entries
+}
+
+func mappingValue(node *yaml.Node, name string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == name {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}
+
+func mappingKey(node *yaml.Node, name string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == name {
+			return node.Content[i]
+		}
+	}
+	return nil
+}
+
+func stringList(node *yaml.Node) ([]string, error) {
+	if node == nil {
+		return nil, fmt.Errorf("missing value")
+	}
+	switch node.Kind {
+	case yaml.ScalarNode:
+		if node.ShortTag() != "!!str" || node.Value == "" {
+			return nil, fmt.Errorf("value is not a step id")
+		}
+		return []string{node.Value}, nil
+	case yaml.SequenceNode:
+		values := make([]string, 0, len(node.Content))
+		for _, child := range node.Content {
+			if child.Kind != yaml.ScalarNode || child.ShortTag() != "!!str" || child.Value == "" {
+				return nil, fmt.Errorf("value is not a step id")
+			}
+			values = append(values, child.Value)
+		}
+		return values, nil
+	default:
+		return nil, fmt.Errorf("value is not a string or list")
+	}
+}
+
+func nodePosition(node *yaml.Node) Position {
+	if node == nil {
+		return Position{}
+	}
+	return Position{Line: node.Line, Column: node.Column}
+}
+
+func yamlNodeError(path string, node *yaml.Node, message string) error {
+	position := nodePosition(node)
+	return fmt.Errorf("%s:%d:%d: %s", path, position.Line, position.Column, message)
+}
+
+func workflowSpanError(path string, span Span, jobID, message string) error {
+	return fmt.Errorf("%s:%d:%d: job %q: %s", path, span.Start.Line, span.Start.Column, jobID, message)
 }
 
 func adaptExpression(in *actionlint.String) (expression.Expression, error) {

--- a/internal/workflow/parse_test.go
+++ b/internal/workflow/parse_test.go
@@ -90,14 +90,23 @@ jobs:
         wait-all:
       - name: Stop producer
         cancel: producer
+      - parallel:
+          - name: Parallel shell
+            run: echo shell
+            env:
+              MEMBER: shell
+          - id: parallel-action
+            uses: ./action
+            with:
+              Message: hello
 `)
 	parsed, err := Parse("workflow.yml", source)
 	if err != nil {
 		t.Fatal(err)
 	}
 	steps := parsed.Jobs[0].Steps
-	if len(steps) != 4 {
-		t.Fatalf("steps = %#v, want four steps", steps)
+	if len(steps) != 7 {
+		t.Fatalf("steps = %#v, want seven lowered steps", steps)
 	}
 	if steps[0].Kind != "run" || !steps[0].Background || steps[0].ID != "producer" {
 		t.Fatalf("background step = %#v", steps[0])
@@ -111,6 +120,43 @@ jobs:
 	if steps[3].Kind != "cancel" || len(steps[3].Targets) != 1 || steps[3].Targets[0] != "producer" {
 		t.Fatalf("cancel = %#v", steps[3])
 	}
+	if steps[4].Kind != "run" || !steps[4].Background || steps[4].ID == "" || steps[4].Env["MEMBER"] != "shell" {
+		t.Fatalf("parallel shell member = %#v", steps[4])
+	}
+	if steps[5].Kind != "uses" || !steps[5].Background || steps[5].ID != "parallel-action" || steps[5].With["message"] != "hello" {
+		t.Fatalf("parallel action member = %#v", steps[5])
+	}
+	if steps[6].Kind != "wait" || len(steps[6].Targets) != 2 || steps[6].Targets[0] != steps[4].ID || steps[6].Targets[1] != steps[5].ID {
+		t.Fatalf("parallel barrier = %#v", steps[6])
+	}
+}
+
+func TestParseParallelOwnsBooleanSpellingsAndDeterministicIDs(t *testing.T) {
+	source := []byte(`on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - parallel:
+          - run: echo one
+            continue-on-error: True
+          - run: echo two
+            continue-on-error: False
+`)
+	parsed, err := Parse("workflow.yml", source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	steps := parsed.Jobs[0].Steps
+	if len(steps) != 3 || steps[0].ID != "__parallel_6_9_1" || steps[1].ID != "__parallel_6_9_2" || steps[2].ID != "__parallel_6_9_wait" {
+		t.Fatalf("parallel ids = %#v", steps)
+	}
+	if !steps[0].ContinueOnError || steps[1].ContinueOnError {
+		t.Fatalf("parallel continue-on-error values = %v, %v", steps[0].ContinueOnError, steps[1].ContinueOnError)
+	}
+	if steps[2].Span.End.Line < steps[1].Span.End.Line {
+		t.Fatalf("parallel barrier span = %#v, final member span = %#v", steps[2].Span, steps[1].Span)
+	}
 }
 
 func TestParseConcurrentControlsFailClosed(t *testing.T) {
@@ -123,7 +169,12 @@ func TestParseConcurrentControlsFailClosed(t *testing.T) {
 		{name: "unknown target", steps: "      - wait: future\n      - id: future\n        run: true\n        background: true\n", want: `wait target "future" is not a prior background step`},
 		{name: "duplicate target", steps: "      - id: work\n        run: true\n        background: true\n      - wait: [work, WORK]\n", want: `wait repeats background step "WORK"`},
 		{name: "conditional control", steps: "      - wait-all:\n        if: always()\n", want: `wait-all control does not support "if"`},
-		{name: "parallel deferred", steps: "      - parallel:\n          - run: true\n", want: "parallel steps are not yet supported"},
+		{name: "empty parallel", steps: "      - parallel: []\n", want: "parallel requires a non-empty list"},
+		{name: "nested background", steps: "      - parallel:\n          - run: true\n            background: true\n", want: `parallel member does not support "background"`},
+		{name: "parallel member execution", steps: "      - parallel:\n          - run: true\n            uses: ./action\n", want: "parallel member must declare exactly one"},
+		{name: "parallel outer field", steps: "      - name: group\n        parallel:\n          - run: true\n", want: `parallel control does not support "name"`},
+		{name: "parallel outer fields deterministic", steps: "      - name: group\n        id: group\n        parallel:\n          - run: true\n", want: `parallel control does not support "id"`},
+		{name: "parallel docker overrides", steps: "      - parallel:\n          - uses: docker://example/image\n            with:\n              Entrypoint: /bin/sh\n", want: "unsupported entrypoint or args overrides"},
 		{name: "unmatched actionlint error", steps: "      - run: true\n        background: true\n        unexpected: true\n", want: `unexpected key "unexpected"`},
 	}
 	for _, test := range tests {

--- a/internal/workflow/parse_test.go
+++ b/internal/workflow/parse_test.go
@@ -131,6 +131,42 @@ jobs:
 	}
 }
 
+func TestParseParallelMembersRetainEnclosingExpressionContext(t *testing.T) {
+	source := []byte(`on: push
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      artifact: ${{ steps.produce.outputs.artifact }}
+    steps:
+      - id: produce
+        run: echo "artifact=ready" >> "$GITHUB_OUTPUT"
+  test:
+    needs: prepare
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    steps:
+      - id: prior
+        run: echo "ready=true" >> "$GITHUB_OUTPUT"
+      - parallel:
+          - if: steps.prior.outputs.ready == 'true'
+            env:
+              MATRIX_OS: ${{ matrix.os }}
+              NEED_VALUE: ${{ needs.prepare.outputs.artifact }}
+            run: test "$MATRIX_OS" = ubuntu-latest && test "$NEED_VALUE" = ready
+`)
+	parsed, err := Parse("workflow.yml", source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	steps := parsed.Jobs[1].Steps
+	if len(steps) != 3 || steps[1].If != "steps.prior.outputs.ready == 'true'" || steps[1].Env["MATRIX_OS"] != "${{ matrix.os }}" || steps[1].Env["NEED_VALUE"] != "${{ needs.prepare.outputs.artifact }}" {
+		t.Fatalf("parallel member context expressions = %#v", steps)
+	}
+}
+
 func TestParseParallelOwnsBooleanSpellingsAndDeterministicIDs(t *testing.T) {
 	source := []byte(`on: push
 jobs:

--- a/internal/workflow/parse_test.go
+++ b/internal/workflow/parse_test.go
@@ -72,6 +72,71 @@ func TestParseRetainsSequentialRuntimeControls(t *testing.T) {
 	}
 }
 
+func TestParseRetainsConcurrentRuntimeControls(t *testing.T) {
+	source := []byte(`name: concurrent runtime
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Background producer
+        id: producer
+        run: echo ok
+        background: true
+      - name: Targeted barrier
+        wait: [producer]
+        continue-on-error: true
+      - name: Full barrier
+        wait-all:
+      - name: Stop producer
+        cancel: producer
+`)
+	parsed, err := Parse("workflow.yml", source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	steps := parsed.Jobs[0].Steps
+	if len(steps) != 4 {
+		t.Fatalf("steps = %#v, want four steps", steps)
+	}
+	if steps[0].Kind != "run" || !steps[0].Background || steps[0].ID != "producer" {
+		t.Fatalf("background step = %#v", steps[0])
+	}
+	if steps[1].Kind != "wait" || len(steps[1].Targets) != 1 || steps[1].Targets[0] != "producer" || !steps[1].ContinueOnError {
+		t.Fatalf("targeted wait = %#v", steps[1])
+	}
+	if steps[2].Kind != "wait-all" || len(steps[2].Targets) != 0 {
+		t.Fatalf("wait-all = %#v", steps[2])
+	}
+	if steps[3].Kind != "cancel" || len(steps[3].Targets) != 1 || steps[3].Targets[0] != "producer" {
+		t.Fatalf("cancel = %#v", steps[3])
+	}
+}
+
+func TestParseConcurrentControlsFailClosed(t *testing.T) {
+	tests := []struct {
+		name  string
+		steps string
+		want  string
+	}{
+		{name: "background false", steps: "      - run: true\n        background: false\n", want: "background must be the literal true"},
+		{name: "unknown target", steps: "      - wait: future\n      - id: future\n        run: true\n        background: true\n", want: `wait target "future" is not a prior background step`},
+		{name: "duplicate target", steps: "      - id: work\n        run: true\n        background: true\n      - wait: [work, WORK]\n", want: `wait repeats background step "WORK"`},
+		{name: "conditional control", steps: "      - wait-all:\n        if: always()\n", want: `wait-all control does not support "if"`},
+		{name: "parallel deferred", steps: "      - parallel:\n          - run: true\n", want: "parallel steps are not yet supported"},
+		{name: "unmatched actionlint error", steps: "      - run: true\n        background: true\n        unexpected: true\n", want: `unexpected key "unexpected"`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source := "on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n" + test.steps
+			_, err := Parse("workflow.yml", []byte(source))
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Parse() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
 func TestParseMatrixPreservesDeclarationOrderAndCombinationSpans(t *testing.T) {
 	source := []byte(`on: push
 jobs:

--- a/internal/workflow/parse_test.go
+++ b/internal/workflow/parse_test.go
@@ -83,9 +83,9 @@ jobs:
         id: producer
         run: echo ok
         background: true
+        continue-on-error: true
       - name: Targeted barrier
         wait: [producer]
-        continue-on-error: true
       - name: Full barrier
         wait-all:
       - name: Stop producer
@@ -108,10 +108,10 @@ jobs:
 	if len(steps) != 7 {
 		t.Fatalf("steps = %#v, want seven lowered steps", steps)
 	}
-	if steps[0].Kind != "run" || !steps[0].Background || steps[0].ID != "producer" {
+	if steps[0].Kind != "run" || !steps[0].Background || steps[0].ID != "producer" || !steps[0].ContinueOnError {
 		t.Fatalf("background step = %#v", steps[0])
 	}
-	if steps[1].Kind != "wait" || len(steps[1].Targets) != 1 || steps[1].Targets[0] != "producer" || !steps[1].ContinueOnError {
+	if steps[1].Kind != "wait" || len(steps[1].Targets) != 1 || steps[1].Targets[0] != "producer" || steps[1].ContinueOnError {
 		t.Fatalf("targeted wait = %#v", steps[1])
 	}
 	if steps[2].Kind != "wait-all" || len(steps[2].Targets) != 0 {
@@ -169,6 +169,7 @@ func TestParseConcurrentControlsFailClosed(t *testing.T) {
 		{name: "unknown target", steps: "      - wait: future\n      - id: future\n        run: true\n        background: true\n", want: `wait target "future" is not a prior background step`},
 		{name: "duplicate target", steps: "      - id: work\n        run: true\n        background: true\n      - wait: [work, WORK]\n", want: `wait repeats background step "WORK"`},
 		{name: "conditional control", steps: "      - wait-all:\n        if: always()\n", want: `wait-all control does not support "if"`},
+		{name: "continue-on-error control", steps: "      - wait-all:\n        continue-on-error: true\n", want: `wait-all control does not support "continue-on-error"`},
 		{name: "empty parallel", steps: "      - parallel: []\n", want: "parallel requires a non-empty list"},
 		{name: "nested background", steps: "      - parallel:\n          - run: true\n            background: true\n", want: `parallel member does not support "background"`},
 		{name: "parallel member execution", steps: "      - parallel:\n          - run: true\n            uses: ./action\n", want: "parallel member must declare exactly one"},

--- a/schemas/job-plan-v2.schema.json
+++ b/schemas/job-plan-v2.schema.json
@@ -1,0 +1,190 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://buildkite.com/schemas/buildkite-gha/job-plan-v2.schema.json",
+  "title": "buildkite-gha job plan v2",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "compiler",
+    "workflow",
+    "event",
+    "target",
+    "required_capabilities",
+    "steps"
+  ],
+  "properties": {
+    "schema": {"const": "https://buildkite.com/schemas/buildkite-gha/job-plan-v2.schema.json"},
+    "compiler": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["version", "distribution_digest"],
+      "properties": {
+        "version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$"},
+        "distribution_digest": {"$ref": "#/$defs/digest"}
+      }
+    },
+    "workflow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "digest", "logical_job_id"],
+      "properties": {
+        "path": {"type": "string", "minLength": 1, "maxLength": 1024},
+        "digest": {"$ref": "#/$defs/digest"},
+        "logical_job_id": {"type": "string", "minLength": 1, "maxLength": 255}
+      }
+    },
+    "event": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider", "name", "payload_digest"],
+      "properties": {
+        "provider": {"enum": ["github", "cursor-origin"]},
+        "name": {"type": "string", "pattern": "^[A-Za-z0-9_.-]+$", "maxLength": 128},
+        "payload_digest": {"$ref": "#/$defs/digest"},
+        "repository": {"type": "string", "maxLength": 512},
+        "ref": {"type": "string", "maxLength": 1024},
+        "sha": {"type": "string", "maxLength": 128},
+        "actor": {"type": "string", "maxLength": 256}
+      }
+    },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["step_key", "queue"],
+      "properties": {
+        "step_key": {"$ref": "#/$defs/buildkiteName"},
+        "queue": {"$ref": "#/$defs/buildkiteName"}
+      }
+    },
+    "required_capabilities": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {"$ref": "#/$defs/capability"},
+      "maxItems": 16
+    },
+    "required_secrets": {
+      "type": "array",
+      "items": {"type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"},
+      "uniqueItems": true,
+      "maxItems": 128
+    },
+    "matrix": {"type": "object"},
+    "vars": {"$ref": "#/$defs/stringMap"},
+    "dependencies": {
+      "type": "array",
+      "items": {"type": "string", "pattern": "^[A-Za-z0-9_-]{1,255}$"},
+      "uniqueItems": true
+    },
+    "need_sources": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "minItems": 1,
+        "maxItems": 256,
+        "uniqueItems": true,
+        "items": {"$ref": "#/$defs/needSource"}
+      }
+    },
+    "env": {"$ref": "#/$defs/stringMap"},
+    "condition": {"type": "string", "maxLength": 65536},
+    "timeout_minutes": {"type": "number", "exclusiveMinimum": 0, "maximum": 360},
+    "default_shell": {"type": "string"},
+    "default_working_directory": {"type": "string"},
+    "outputs": {"$ref": "#/$defs/stringMap"},
+    "steps": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 1000,
+      "items": {"$ref": "#/$defs/step"}
+    }
+  },
+  "$defs": {
+    "digest": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "buildkiteName": {"type": "string", "pattern": "^[A-Za-z0-9_-]+$", "minLength": 1, "maxLength": 255},
+    "capability": {
+      "enum": ["network", "docker", "privileged-container", "secrets", "provider-token-read", "provider-token-write"]
+    },
+    "stringMap": {"type": "object", "additionalProperties": {"type": "string"}},
+    "needSource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["step_key", "plan_digest"],
+      "properties": {
+        "step_key": {"$ref": "#/$defs/buildkiteName"},
+        "plan_digest": {"$ref": "#/$defs/digest"}
+      }
+    },
+    "position": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["line", "column"],
+      "properties": {
+        "line": {"type": "integer", "minimum": 0},
+        "column": {"type": "integer", "minimum": 0}
+      }
+    },
+    "span": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["start", "end"],
+      "properties": {
+        "start": {"$ref": "#/$defs/position"},
+        "end": {"$ref": "#/$defs/position"}
+      }
+    },
+    "step": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "kind"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1, "maxLength": 255},
+        "name": {"type": "string"},
+        "kind": {"enum": ["run", "uses", "wait", "wait-all", "cancel"]},
+        "background": {"type": "boolean"},
+        "targets": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 256,
+          "uniqueItems": true,
+          "items": {"type": "string", "pattern": "^[A-Za-z0-9_-]{1,255}$"}
+        },
+        "command": {"type": "string", "maxLength": 1048576},
+        "uses": {"type": "string", "maxLength": 1024},
+        "shell": {"type": "string"},
+        "working_directory": {"type": "string"},
+        "env": {"$ref": "#/$defs/stringMap"},
+        "with": {"$ref": "#/$defs/stringMap"},
+        "condition": {"type": "string", "maxLength": 65536},
+        "continue_on_error": {"type": "boolean"},
+        "timeout_minutes": {"type": "number", "exclusiveMinimum": 0, "maximum": 360},
+        "source": {"$ref": "#/$defs/span"}
+      },
+      "allOf": [
+        {"if": {"properties": {"kind": {"const": "run"}}}, "then": {"required": ["command"]}},
+        {"if": {"properties": {"kind": {"const": "uses"}}}, "then": {"required": ["uses"]}},
+        {"if": {"properties": {"kind": {"const": "wait"}}}, "then": {"required": ["targets"]}},
+        {"if": {"properties": {"kind": {"const": "wait-all"}}}, "then": {"not": {"required": ["targets"]}}},
+        {"if": {"properties": {"kind": {"const": "cancel"}}}, "then": {"required": ["targets"], "properties": {"targets": {"maxItems": 1}}}},
+        {
+          "if": {"properties": {"kind": {"enum": ["wait", "wait-all", "cancel"]}}},
+          "then": {
+            "not": {
+              "anyOf": [
+                {"required": ["background"]},
+                {"required": ["command"]},
+                {"required": ["uses"]},
+                {"required": ["shell"]},
+                {"required": ["working_directory"]},
+                {"required": ["env"]},
+                {"required": ["with"]},
+                {"required": ["condition"]},
+                {"required": ["timeout_minutes"]}
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/schemas/job-plan-v2.schema.json
+++ b/schemas/job-plan-v2.schema.json
@@ -179,6 +179,7 @@
                 {"required": ["env"]},
                 {"required": ["with"]},
                 {"required": ["condition"]},
+                {"required": ["continue_on_error"]},
                 {"required": ["timeout_minutes"]}
               ]
             }

--- a/testdata/smoke/.github/workflows/concurrent.yml
+++ b/testdata/smoke/.github/workflows/concurrent.yml
@@ -1,0 +1,246 @@
+name: buildkite-gha concurrent smoke
+
+on:
+  push:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  concurrent:
+    runs-on: ubuntu-latest
+    outputs:
+      targeted: ${{ steps.verify-targets.outputs.value }}
+      failure: ${{ steps.verify-failure.outputs.value }}
+      queue_max: ${{ steps.verify-queue.outputs.value }}
+      cancel: ${{ steps.verify-cancel.outputs.value }}
+      parallel: ${{ steps.verify-parallel.outputs.value }}
+      implicit: ${{ steps.implicit.outputs.value }}
+    steps:
+      - id: target-one
+        shell: bash
+        run: |
+          sleep 0.05
+          echo "TARGET_ONE=one" >> "$GITHUB_ENV"
+          echo "value=one" >> "$GITHUB_OUTPUT"
+          touch "$RUNNER_TEMP/target-one.done"
+        background: true
+
+      - id: target-two
+        shell: bash
+        run: |
+          sleep 0.05
+          echo "TARGET_TWO=two" >> "$GITHUB_ENV"
+          echo "value=two" >> "$GITHUB_OUTPUT"
+          touch "$RUNNER_TEMP/target-two.done"
+        background: true
+
+      - name: Verify completed effects remain private before a barrier
+        shell: bash
+        run: |
+          while [ ! -f "$RUNNER_TEMP/target-one.done" ] || [ ! -f "$RUNNER_TEMP/target-two.done" ]; do sleep 0.01; done
+          test -z "$TARGET_ONE"
+          test -z "$TARGET_TWO"
+
+      - wait: target-one
+
+      - name: Verify targeted barrier visibility
+        shell: bash
+        run: |
+          test "$TARGET_ONE" = one
+          test -z "$TARGET_TWO"
+          test "${{ steps.target-one.outputs.value }}" = one
+
+      - wait-all:
+
+      - id: verify-targets
+        name: Verify full barrier visibility
+        shell: bash
+        run: |
+          test "$TARGET_ONE" = one
+          test "$TARGET_TWO" = two
+          test "${{ steps.target-two.outputs.value }}" = two
+          echo "value=targeted-and-full" >> "$GITHUB_OUTPUT"
+
+      - id: expected-failure
+        shell: bash
+        run: exit 7
+        background: true
+
+      - wait: expected-failure
+        continue-on-error: true
+
+      - id: verify-failure
+        if: steps.expected-failure.outcome == 'failure'
+        shell: bash
+        run: echo "value=failure-at-wait" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare bounded queue probe
+        shell: bash
+        run: |
+          cat > "$RUNNER_TEMP/phase3-queue-worker" <<'SCRIPT'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          id="$1"
+          lock="$RUNNER_TEMP/phase3-queue-lock"
+          active_file="$RUNNER_TEMP/phase3-queue-active"
+          max_file="$RUNNER_TEMP/phase3-queue-max"
+          starts_file="$RUNNER_TEMP/phase3-queue-starts"
+          acquire() { while ! mkdir "$lock" 2>/dev/null; do sleep 0.01; done; }
+          release() { rmdir "$lock"; }
+          acquire
+          active=0
+          [ ! -f "$active_file" ] || active=$(cat "$active_file")
+          active=$((active + 1))
+          echo "$active" > "$active_file"
+          maximum=0
+          [ ! -f "$max_file" ] || maximum=$(cat "$max_file")
+          if [ "$active" -gt "$maximum" ]; then echo "$active" > "$max_file"; fi
+          echo "$id" >> "$starts_file"
+          release
+          while [ ! -f "$RUNNER_TEMP/phase3-queue-release" ]; do sleep 0.01; done
+          acquire
+          active=$(cat "$active_file")
+          echo $((active - 1)) > "$active_file"
+          release
+          SCRIPT
+          chmod +x "$RUNNER_TEMP/phase3-queue-worker"
+
+      - id: queued-01
+        run: '"$RUNNER_TEMP/phase3-queue-worker" 01'
+        background: true
+      - id: queued-02
+        run: '"$RUNNER_TEMP/phase3-queue-worker" 02'
+        background: true
+      - id: queued-03
+        run: '"$RUNNER_TEMP/phase3-queue-worker" 03'
+        background: true
+      - id: queued-04
+        run: '"$RUNNER_TEMP/phase3-queue-worker" 04'
+        background: true
+      - id: queued-05
+        run: '"$RUNNER_TEMP/phase3-queue-worker" 05'
+        background: true
+      - id: queued-06
+        run: '"$RUNNER_TEMP/phase3-queue-worker" 06'
+        background: true
+      - id: queued-07
+        run: '"$RUNNER_TEMP/phase3-queue-worker" 07'
+        background: true
+      - id: queued-08
+        run: '"$RUNNER_TEMP/phase3-queue-worker" 08'
+        background: true
+      - id: queued-09
+        run: '"$RUNNER_TEMP/phase3-queue-worker" 09'
+        background: true
+      - id: queued-10
+        run: '"$RUNNER_TEMP/phase3-queue-worker" 10'
+        background: true
+      - id: queued-11
+        run: '"$RUNNER_TEMP/phase3-queue-worker" 11'
+        background: true
+
+      - name: Release the first ten queued workers
+        shell: bash
+        run: |
+          while :; do
+            started=0
+            [ ! -f "$RUNNER_TEMP/phase3-queue-starts" ] || started=$(wc -l < "$RUNNER_TEMP/phase3-queue-starts")
+            [ "$started" -eq 10 ] && break
+            sleep 0.01
+          done
+          sleep 0.1
+          test "$(wc -l < "$RUNNER_TEMP/phase3-queue-starts")" -eq 10
+          touch "$RUNNER_TEMP/phase3-queue-release"
+
+      - wait-all:
+
+      - id: verify-queue
+        shell: bash
+        run: |
+          test "$(cat "$RUNNER_TEMP/phase3-queue-max")" -eq 10
+          test "$(wc -l < "$RUNNER_TEMP/phase3-queue-starts")" -eq 11
+          echo "value=10" >> "$GITHUB_OUTPUT"
+
+      - id: masker
+        shell: bash
+        run: |
+          echo "::add-mask::phase3-cross-stream-secret"
+          sleep 0.05
+          touch "$RUNNER_TEMP/phase3-mask-ready"
+        background: true
+
+      - name: Emit a cross-stream masked probe
+        shell: bash
+        run: |
+          while [ ! -f "$RUNNER_TEMP/phase3-mask-ready" ]; do sleep 0.01; done
+          echo "PHASE3_MASK_PROBE=phase3-cross-stream-secret"
+
+      - wait: masker
+
+      - id: cancellable
+        shell: bash
+        run: |
+          trap 'echo graceful > "$RUNNER_TEMP/phase3-cancelled"; exit 0' TERM
+          touch "$RUNNER_TEMP/phase3-cancel-ready"
+          while :; do sleep 1; done
+        background: true
+
+      - name: Wait for cancellable step to start
+        run: while [ ! -f "$RUNNER_TEMP/phase3-cancel-ready" ]; do sleep 0.01; done
+
+      - cancel: cancellable
+
+      - id: verify-cancel
+        if: steps.cancellable.outcome == 'cancelled'
+        shell: bash
+        run: |
+          test "$(cat "$RUNNER_TEMP/phase3-cancelled")" = graceful
+          echo "value=graceful" >> "$GITHUB_OUTPUT"
+
+      - parallel:
+          - id: parallel-one
+            run: |
+              sleep 0.05
+              echo "value=one" >> "$GITHUB_OUTPUT"
+          - id: parallel-two
+            run: |
+              sleep 0.05
+              echo "value=two" >> "$GITHUB_OUTPUT"
+
+      - id: verify-parallel
+        shell: bash
+        run: |
+          test "${{ steps.parallel-one.outputs.value }}" = one
+          test "${{ steps.parallel-two.outputs.value }}" = two
+          echo "value=parallel" >> "$GITHUB_OUTPUT"
+
+      - id: implicit
+        shell: bash
+        run: |
+          sleep 0.05
+          echo "value=implicit-wait-all" >> "$GITHUB_OUTPUT"
+        background: true
+
+  observe:
+    needs: concurrent
+    runs-on: ubuntu-latest
+    steps:
+      - name: Capture concurrent runtime observation
+        env:
+          TARGETED: ${{ needs.concurrent.outputs.targeted }}
+          FAILURE: ${{ needs.concurrent.outputs.failure }}
+          QUEUE_MAX: ${{ needs.concurrent.outputs.queue_max }}
+          CANCEL: ${{ needs.concurrent.outputs.cancel }}
+          PARALLEL: ${{ needs.concurrent.outputs.parallel }}
+          IMPLICIT: ${{ needs.concurrent.outputs.implicit }}
+        shell: bash
+        run: |
+          test "$TARGETED" = targeted-and-full
+          test "$FAILURE" = failure-at-wait
+          test "$QUEUE_MAX" = 10
+          test "$CANCEL" = graceful
+          test "$PARALLEL" = parallel
+          test "$IMPLICIT" = implicit-wait-all
+          printf 'PHASE3_OBSERVATION={"cancel":"%s","failure":"%s","implicit":"%s","parallel":"%s","queue_max":%s,"targeted":"%s"}\n' \
+            "$CANCEL" "$FAILURE" "$IMPLICIT" "$PARALLEL" "$QUEUE_MAX" "$TARGETED"

--- a/testdata/smoke/.github/workflows/concurrent.yml
+++ b/testdata/smoke/.github/workflows/concurrent.yml
@@ -181,7 +181,7 @@ jobs:
       - id: cancellable
         shell: bash
         run: |
-          trap 'echo graceful > "$RUNNER_TEMP/phase3-cancelled"; exit 0' TERM
+          trap 'echo graceful > "$RUNNER_TEMP/phase3-cancelled"; exit 0' INT
           touch "$RUNNER_TEMP/phase3-cancel-ready"
           while :; do sleep 1; done
         background: true

--- a/testdata/smoke/.github/workflows/concurrent.yml
+++ b/testdata/smoke/.github/workflows/concurrent.yml
@@ -66,9 +66,9 @@ jobs:
         shell: bash
         run: exit 7
         background: true
+        continue-on-error: true
 
       - wait: expected-failure
-        continue-on-error: true
 
       - id: verify-failure
         if: steps.expected-failure.outcome == 'failure'

--- a/testdata/smoke/README.md
+++ b/testdata/smoke/README.md
@@ -10,12 +10,15 @@ workflow is executable:
 
 1. `shell.yml` is the first runtime target. It has two logical jobs, a static
    consumer matrix, shell steps, and a bounded `needs` output.
-2. `ci.yml` adds checkout plus local JavaScript and composite actions, including
+2. `concurrent.yml` adds background, targeted and full waits, cancellation,
+   bounded queueing, parallel lowering, implicit cleanup, and concurrent
+   masking probes.
+3. `ci.yml` adds checkout plus local JavaScript and composite actions, including
    output, environment-file, masking, summary, and post-action events.
-3. `artifact.yml` adds GitHub artifact-action compatibility and verifies one
+4. `artifact.yml` adds GitHub artifact-action compatibility and verifies one
    payload in both consumer matrix instances.
 
-All three workflows are compiler fixtures from Phase 1 onward. Only promote a
+All four workflows are compiler fixtures from Phase 1 onward. Only promote a
 workflow into a required runtime lane when its owning phase is implemented.
 
 `events/push.json` is a deterministic compile fixture, so its repository SHA is

--- a/testdata/smoke/expected/concurrent-capture.json
+++ b/testdata/smoke/expected/concurrent-capture.json
@@ -1,0 +1,16 @@
+{
+  "observations": [
+    {
+      "identity": "concurrent",
+      "document": {
+        "cancel": "graceful",
+        "failure": "failure-at-wait",
+        "implicit": "implicit-wait-all",
+        "parallel": "parallel",
+        "queue_max": 10,
+        "targeted": "targeted-and-full"
+      }
+    }
+  ],
+  "lifecycle": []
+}


### PR DESCRIPTION
## Summary

- parse and validate `background`, `wait`, `wait-all`, `cancel`, and `parallel` through the owned workflow and plan boundaries
- execute concurrent shell steps with a ten-active-task FIFO supervisor, barrier-scoped effects and failures, implicit final drain, and bounded LIFO cleanup
- gracefully cancel background process groups before forced termination and serialize workflow-command masking across concurrent streams
- preserve ordered `GITHUB_PATH` deltas against live barrier state across shell, JavaScript, and composite phases
- add deterministic local, Buildkite, and GitHub-hosted differential proof wiring for the concurrent smoke fixture

## Security and compatibility boundaries

- the unsigned upload path remains fixed to the `hosted` queue, shell-only, capability-free, and development-only
- action steps and every declared runtime capability remain rejected on that path
- signed-pipeline integration, services, job containers, remote/local actions through unsigned upload, and other workflow commands remain deferred
- unsupported syntax and expressions continue to fail closed
- generated-job import and native continuation loading remain separate to preserve Buildkite's reverse dynamic-upload ordering invariant

## Verification

- `mise run --jobs 1 check`
- formatting, build, unit tests, race tests, golangci-lint, shellcheck, vet, and all eight plan-envelope fixtures pass
- significant implementation and proof milestones reviewed with Oracle
- [GitHub-hosted exact-commit concurrent differential](https://github.com/buildkite/buildkite-gha/actions/runs/29986665118) passed at `d1e29f48bda3a16525f5627e64f32f2272b8f672`
- [Buildkite PR CI build 49](https://buildkite.com/buildkite/buildkite-gha/builds/49) passed
- [Gated native Buildkite Phase 3 proof](https://buildkite.com/buildkite/buildkite-gha/builds/50) passed at exact commit `d1e29f48bda3a16525f5627e64f32f2272b8f672`, including the importer, generated concurrent job, observer, separate continuation loader, native dependency extension, and repository checks