### PR TITLE
fix: align expression handling across boundaries

### DIFF
--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -105,7 +105,7 @@ func TestCompileBundleDoesNotExposeEventValues(t *testing.T) {
 }
 
 func TestCompileBundleDeclaresSecretCapabilityAndNames(t *testing.T) {
-	source := []byte("name: secrets\non: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    env:\n      TOKEN: ${{ secrets.deploy_token }}\n    steps:\n      - run: echo \\\"${{ secrets.CANARY }}\\\"\n")
+	source := []byte("name: secrets\non: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    env:\n      TOKEN: ${{ secrets['deploy_token'] }}\n    steps:\n      - run: echo \\\"${{ secrets.CANARY }}\\\"\n")
 	event := readFile(t, smokePath("events", "push.json"))
 	bundle, err := CompileBundle("workflow.yml", source, event, "0.0.0-test", testDistributionDigest, "gha-importer")
 	if err != nil {
@@ -114,6 +114,14 @@ func TestCompileBundleDeclaresSecretCapabilityAndNames(t *testing.T) {
 	job := bundle.Plans[0].Job
 	if !reflect.DeepEqual(job.RequiredSecrets, []string{"CANARY", "DEPLOY_TOKEN"}) || !reflect.DeepEqual(job.RequiredCapabilities, []string{"secrets"}) {
 		t.Fatalf("secret boundary = names %#v capabilities %#v", job.RequiredSecrets, job.RequiredCapabilities)
+	}
+}
+
+func TestCompileBundleRejectsDynamicSecretIndex(t *testing.T) {
+	source := []byte("name: secrets\non: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    env:\n      SECRET_NAME: TOKEN\n      TOKEN: ${{ secrets[env.SECRET_NAME] }}\n    steps:\n      - run: true\n")
+	_, err := CompileBundle("workflow.yml", source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err == nil || !strings.Contains(err.Error(), "expression index must be a string literal") {
+		t.Fatalf("CompileBundle() error = %v, want dynamic secret index rejection", err)
 	}
 }
 

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -11,7 +11,6 @@ import (
 	"math/big"
 	"path/filepath"
 	"reflect"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -27,8 +26,6 @@ const (
 	schema             = "buildkite-gha/compiler-ir/v0"
 	maxMatrixInstances = 256
 )
-
-var secretReferencePattern = regexp.MustCompile(`(?i)\$\{\{\s*secrets\.([A-Za-z_][A-Za-z0-9_]*)\s*\}\}`)
 
 // Event is the explicit provider event snapshot supplied to compilation.
 type Event struct {
@@ -252,7 +249,10 @@ func compilePlans(ir IR, compilerVersion, compilerDistributionDigest string) ([]
 				needSources[logicalNeed] = append(needSources[logicalNeed], plan.NeedSource{StepKey: dependency, PlanDigest: digest})
 			}
 		}
-		secrets := requiredSecrets(instance)
+		secrets, err := requiredSecrets(instance)
+		if err != nil {
+			return nil, fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err)
+		}
 		if len(secrets) != 0 {
 			capabilities = append(capabilities, "secrets")
 			sort.Strings(capabilities)
@@ -301,30 +301,41 @@ func compilePlans(ir IR, compilerVersion, compilerDistributionDigest string) ([]
 	return plans, nil
 }
 
-func requiredSecrets(instance JobInstance) []string {
+func requiredSecrets(instance JobInstance) ([]string, error) {
 	found := map[string]string{}
-	collect := func(value string) {
-		for _, match := range secretReferencePattern.FindAllStringSubmatch(value, -1) {
-			name := strings.ToUpper(match[1])
+	collect := func(value string) error {
+		names, err := expression.SecretReferences(value)
+		if err != nil {
+			return err
+		}
+		for _, name := range names {
 			found[name] = name
 		}
+		return nil
 	}
-	collect(instance.If)
-	collect(instance.DefaultShell)
-	collect(instance.DefaultWorkingDirectory)
-	for _, value := range instance.Env {
-		collect(value)
+	for _, value := range []string{instance.If, instance.DefaultShell, instance.DefaultWorkingDirectory} {
+		if err := collect(value); err != nil {
+			return nil, err
+		}
 	}
-	for _, value := range instance.Outputs {
-		collect(value)
+	for _, values := range []map[string]string{instance.Env, instance.Outputs} {
+		for _, name := range sortedValueKeys(values) {
+			if err := collect(values[name]); err != nil {
+				return nil, err
+			}
+		}
 	}
 	for _, step := range instance.Steps {
 		for _, value := range []string{step.Run, step.If, step.Shell, step.WorkingDirectory} {
-			collect(value)
+			if err := collect(value); err != nil {
+				return nil, err
+			}
 		}
 		for _, values := range []map[string]string{step.Env, step.With} {
-			for _, value := range values {
-				collect(value)
+			for _, name := range sortedValueKeys(values) {
+				if err := collect(values[name]); err != nil {
+					return nil, err
+				}
 			}
 		}
 	}
@@ -333,7 +344,7 @@ func requiredSecrets(instance JobInstance) []string {
 		names = append(names, name)
 	}
 	sort.Strings(names)
-	return names
+	return names, nil
 }
 
 func planSpan(span workflow.Span) plan.Span {

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -435,6 +435,97 @@ jobs:
 	}
 }
 
+func TestCompileSubstitutesReusableInputsInConditions(t *testing.T) {
+	repository := t.TempDir()
+	callerPath := writeWorkflow(t, repository, "caller.yml", `on: push
+jobs:
+  enabled-call:
+    uses: ./.github/workflows/reusable.yml
+    with:
+      enabled: true
+      label: deploy
+  disabled-call:
+    uses: ./.github/workflows/reusable.yml
+    with:
+      enabled: false
+`)
+	writeWorkflow(t, repository, "reusable.yml", `on:
+  workflow_call:
+    inputs:
+      enabled:
+        type: boolean
+        required: true
+      label:
+        type: string
+jobs:
+  gated:
+    if: inputs.enabled
+    runs-on: ubuntu-latest
+    steps:
+      - if: ${{ inputs.enabled }}
+        run: echo enabled
+  string-gated:
+    if: ${{ inputs.label }}
+    runs-on: ubuntu-latest
+    steps:
+      - if: inputs.label
+        run: echo non-empty
+`)
+
+	plans, err := CompilePlans(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-untrusted")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 4 {
+		t.Fatalf("plans = %d, want boolean and string jobs for both calls", len(plans))
+	}
+	conditions := make(map[string][2]string, len(plans))
+	for _, job := range plans {
+		conditions[job.Workflow.LogicalJobID] = [2]string{job.Condition, job.Steps[0].Condition}
+	}
+	if got := conditions["enabled-call.gated"]; got != [2]string{"true", "true"} {
+		t.Fatalf("enabled conditions = %#v, want statically substituted true", got)
+	}
+	if got := conditions["disabled-call.gated"]; got != [2]string{"false", "false"} {
+		t.Fatalf("disabled conditions = %#v, want statically substituted false", got)
+	}
+	if got := conditions["enabled-call.string-gated"]; got != [2]string{"'deploy'", "'deploy'"} {
+		t.Fatalf("non-empty string conditions = %#v, want a quoted expression literal", got)
+	}
+	if got := conditions["disabled-call.string-gated"]; got != [2]string{"''", "''"} {
+		t.Fatalf("empty string conditions = %#v, want a falsy quoted expression literal", got)
+	}
+}
+
+func TestCompileRejectsComplexReusableInputConditions(t *testing.T) {
+	repository := t.TempDir()
+	callerPath := writeWorkflow(t, repository, "caller.yml", `on: push
+jobs:
+  call:
+    uses: ./.github/workflows/reusable.yml
+    with:
+      enabled: true
+`)
+	writeWorkflow(t, repository, "reusable.yml", `on:
+  workflow_call:
+    inputs:
+      enabled:
+        type: boolean
+        required: true
+jobs:
+  gated:
+    if: ${{ inputs.enabled && github.ref }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo enabled
+`)
+
+	_, err := CompilePlans(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-untrusted")
+	if err == nil || !strings.Contains(err.Error(), "reusable-workflow input expression is not statically resolvable") {
+		t.Fatalf("CompilePlans() error = %v, want complex input condition rejection", err)
+	}
+}
+
 func TestCompilePlansResolveReusableLocalActionsFromRepositoryRoot(t *testing.T) {
 	repository := t.TempDir()
 	callerPath := writeWorkflow(t, repository, "caller.yml", "on: push\njobs:\n  delegated:\n    uses: ./.github/workflows/reusable.yml\n")

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -19,7 +19,8 @@ const (
 	maxFlattenedJobs         = 1024
 )
 
-var staticInputExpression = regexp.MustCompile(`\$\{\{\s*inputs\.([A-Za-z_][A-Za-z0-9_-]*)\s*\}\}`)
+var staticInputExpression = regexp.MustCompile(`(?i)\$\{\{\s*inputs\.([A-Za-z_][A-Za-z0-9_-]*)\s*\}\}`)
+var staticInputCondition = regexp.MustCompile(`(?i)^\s*(?:\$\{\{\s*inputs\.([A-Za-z_][A-Za-z0-9_-]*)\s*\}\}|inputs\.([A-Za-z_][A-Za-z0-9_-]*))\s*$`)
 var staticValueExpression = regexp.MustCompile(`^\s*\$\{\{\s*(inputs|matrix)\.([A-Za-z_][A-Za-z0-9_-]*)\s*\}\}\s*$`)
 
 type sourcedJob struct {
@@ -387,6 +388,7 @@ func applyStaticInputs(job workflow.Job, inputs map[string]any) workflow.Job {
 		return job
 	}
 	job.Name = replaceStaticInputs(job.Name, inputs)
+	job.If = replaceStaticInputCondition(job.If, inputs)
 	job.DefaultShell = replaceStaticInputs(job.DefaultShell, inputs)
 	job.DefaultWorkingDirectory = replaceStaticInputs(job.DefaultWorkingDirectory, inputs)
 	job.Env = replaceMapInputs(job.Env, inputs)
@@ -417,6 +419,7 @@ func applyStaticInputs(job workflow.Job, inputs map[string]any) workflow.Job {
 		step.Uses = replaceStaticInputs(step.Uses, inputs)
 		step.Shell = replaceStaticInputs(step.Shell, inputs)
 		step.WorkingDirectory = replaceStaticInputs(step.WorkingDirectory, inputs)
+		step.If = replaceStaticInputCondition(step.If, inputs)
 		step.Env = replaceMapInputs(step.Env, inputs)
 		step.With = replaceMapInputs(step.With, inputs)
 	}
@@ -424,6 +427,11 @@ func applyStaticInputs(job workflow.Job, inputs map[string]any) workflow.Job {
 }
 
 func rejectUnresolvedInputExpressions(path string, job workflow.Job) error {
+	if usesInputs, err := expression.ConditionUsesContext(job.If, "inputs"); err != nil {
+		return jobError(path, job, fmt.Sprintf("parse reusable-workflow job condition: %v", err))
+	} else if usesInputs {
+		return jobError(path, job, "reusable-workflow input expression is not statically resolvable")
+	}
 	jobValues := []string{job.Name, job.DefaultShell, job.DefaultWorkingDirectory}
 	jobValues = append(jobValues, job.RunsOn...)
 	jobValues = appendMapValues(jobValues, job.Env)
@@ -461,7 +469,12 @@ func rejectUnresolvedInputExpressions(path string, job workflow.Job) error {
 		}
 	}
 	for _, step := range job.Steps {
-		stepValues := []string{step.Name, step.Run, step.Uses, step.Shell, step.WorkingDirectory, step.If}
+		if usesInputs, err := expression.ConditionUsesContext(step.If, "inputs"); err != nil {
+			return locatedJobError(path, job, step.Span.Start.Line, step.Span.Start.Column, fmt.Sprintf("parse reusable-workflow step condition: %v", err))
+		} else if usesInputs {
+			return locatedJobError(path, job, step.Span.Start.Line, step.Span.Start.Column, "reusable-workflow input expression is not statically resolvable")
+		}
+		stepValues := []string{step.Name, step.Run, step.Uses, step.Shell, step.WorkingDirectory}
 		stepValues = appendMapValues(stepValues, step.Env)
 		stepValues = appendMapValues(stepValues, step.With)
 		for _, value := range stepValues {
@@ -587,6 +600,26 @@ func replaceMapInputs(values map[string]string, inputs map[string]any) map[strin
 		out[name] = replaceStaticInputs(value, inputs)
 	}
 	return out
+}
+
+func replaceStaticInputCondition(value string, inputs map[string]any) string {
+	match := staticInputCondition.FindStringSubmatch(value)
+	if match == nil {
+		return value
+	}
+	inputName := match[1]
+	if inputName == "" {
+		inputName = match[2]
+	}
+	for name, input := range inputs {
+		if strings.EqualFold(name, inputName) {
+			if text, ok := input.(string); ok {
+				return "'" + strings.ReplaceAll(text, "'", "''") + "'"
+			}
+			return fmt.Sprint(input)
+		}
+	}
+	return value
 }
 
 func replaceStaticInputs(value string, inputs map[string]any) string {

--- a/internal/expression/expression.go
+++ b/internal/expression/expression.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 
 	"github.com/rhysd/actionlint"
@@ -142,6 +143,117 @@ func EvaluateCompileTemplate(template string, context CompileContext) (string, e
 			return "", fmt.Errorf("expression in runner label resolved to %T, want a scalar", value)
 		}
 		remaining = remaining[end+len(close):]
+	}
+}
+
+// SecretReferences returns the statically named secrets referenced by a
+// template. Dynamic indexes fail closed because the runtime cannot determine
+// which values to resolve and register with the log redactor before execution.
+func SecretReferences(template string) ([]string, error) {
+	found := map[string]struct{}{}
+	err := visitTemplateExpressions(template, func(expression actionlint.ExprNode) error {
+		var referenceErr error
+		actionlint.VisitExprNode(expression, func(node, parent actionlint.ExprNode, entering bool) {
+			if !entering || referenceErr != nil {
+				return
+			}
+			switch node.(type) {
+			case *actionlint.VariableNode, *actionlint.ObjectDerefNode, *actionlint.IndexAccessNode:
+			default:
+				return
+			}
+			root, path, err := referencePath(node)
+			if !strings.EqualFold(root, "secrets") {
+				return
+			}
+			if err != nil {
+				referenceErr = fmt.Errorf("secret reference: %w", err)
+				return
+			}
+			if len(path) == 0 {
+				switch parent := parent.(type) {
+				case *actionlint.ObjectDerefNode:
+					if parent.Receiver == node {
+						return
+					}
+				case *actionlint.IndexAccessNode:
+					if parent.Operand == node {
+						return
+					}
+				}
+				referenceErr = fmt.Errorf("secret reference must name exactly one secret")
+				return
+			}
+			if len(path) != 1 {
+				referenceErr = fmt.Errorf("secret reference must name exactly one secret")
+				return
+			}
+			found[strings.ToUpper(path[0])] = struct{}{}
+		})
+		return referenceErr
+	})
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(found))
+	for name := range found {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// ConditionUsesContext reports whether a condition references a named context.
+// Conditions may omit the normal ${{ ... }} delimiters.
+func ConditionUsesContext(source, contextName string) (bool, error) {
+	condition := strings.TrimSpace(source)
+	if condition == "" {
+		return false, nil
+	}
+	if strings.HasPrefix(condition, "${{") && strings.HasSuffix(condition, "}}") {
+		condition = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(condition, "${{"), "}}"))
+	}
+	node, parseErr := actionlint.NewExprParser().Parse(actionlint.NewExprLexer(condition + "}}"))
+	if parseErr != nil {
+		return false, fmt.Errorf("parse condition: %w", parseErr)
+	}
+	found := false
+	actionlint.VisitExprNode(node, func(node, _ actionlint.ExprNode, entering bool) {
+		if !entering || found {
+			return
+		}
+		switch node.(type) {
+		case *actionlint.VariableNode, *actionlint.ObjectDerefNode, *actionlint.IndexAccessNode:
+		default:
+			return
+		}
+		root, _, _ := referencePath(node)
+		found = strings.EqualFold(root, contextName)
+	})
+	return found, nil
+}
+
+func visitTemplateExpressions(template string, visit func(actionlint.ExprNode) error) error {
+	const open = "${{"
+	remaining := template
+	for {
+		start := strings.Index(remaining, open)
+		if start < 0 {
+			return nil
+		}
+		source := remaining[start+len(open):]
+		_, consumed, lexErr := actionlint.LexExpression(source)
+		if lexErr != nil {
+			return fmt.Errorf("invalid expression: %w", lexErr)
+		}
+		node, err := actionlint.NewExprParser().Parse(actionlint.NewExprLexer(source[:consumed]))
+		if err != nil {
+			return fmt.Errorf("invalid expression: %w", err)
+		}
+		if err := visit(node); err != nil {
+			return err
+		}
+		remaining = source[consumed:]
 	}
 }
 
@@ -431,11 +543,11 @@ func referencePath(node actionlint.ExprNode) (string, []string, error) {
 		}
 		index, ok := node.Index.(*actionlint.StringNode)
 		if !ok {
-			return "", nil, fmt.Errorf("compile-time index must be a string literal")
+			return root, nil, fmt.Errorf("expression index must be a string literal")
 		}
 		return root, append(path, index.Value), nil
 	default:
-		return "", nil, fmt.Errorf("unsupported compile-time reference")
+		return "", nil, fmt.Errorf("unsupported expression reference")
 	}
 }
 
@@ -547,47 +659,55 @@ func Evaluate(template string, context Context) (string, error) {
 }
 
 func evaluateReference(reference string, context Context) (string, error) {
-	parts := strings.Split(reference, ".")
+	node, parseErr := actionlint.NewExprParser().Parse(actionlint.NewExprLexer(reference + "}}"))
+	if parseErr != nil {
+		return "", fmt.Errorf("invalid expression: %w", parseErr)
+	}
+	root, path, err := referencePath(node)
+	if err != nil {
+		return "", err
+	}
 	switch {
-	case len(parts) >= 2 && parts[0] == "github":
-		value, ok := lookupRuntimeValue(context.GitHub, parts[1:])
+	case len(path) >= 1 && strings.EqualFold(root, "github"):
+		value, ok := lookupRuntimeValue(context.GitHub, path)
 		if !ok {
-			return "", fmt.Errorf("expression references unavailable github value %q", strings.Join(parts[1:], "."))
+			return "", fmt.Errorf("expression references unavailable github value %q", strings.Join(path, "."))
 		}
 		return fmt.Sprint(value), nil
-	case len(parts) == 2 && parts[0] == "inputs":
-		return context.Inputs[parts[1]], nil
-	case len(parts) == 2 && parts[0] == "matrix":
-		value, ok := context.Matrix[parts[1]]
-		if !ok {
-			return "", fmt.Errorf("expression references unavailable matrix value %q", parts[1])
+	case len(path) == 1 && strings.EqualFold(root, "inputs"):
+		return findString(context.Inputs, path[0]), nil
+	case len(path) == 1 && strings.EqualFold(root, "matrix"):
+		for name, value := range context.Matrix {
+			if strings.EqualFold(name, path[0]) {
+				return fmt.Sprint(value), nil
+			}
 		}
-		return fmt.Sprint(value), nil
-	case len(parts) == 2 && parts[0] == "secrets":
-		return findString(context.Secrets, parts[1]), nil
-	case len(parts) == 2 && parts[0] == "vars":
-		return findString(context.Vars, parts[1]), nil
-	case len(parts) == 2 && parts[0] == "env":
-		return findString(context.Env, parts[1]), nil
-	case len(parts) == 4 && parts[0] == "steps" && parts[2] == "outputs":
-		outputs, ok := findOutputs(context.Steps, parts[1])
+		return "", fmt.Errorf("expression references unavailable matrix value %q", path[0])
+	case len(path) == 1 && strings.EqualFold(root, "secrets"):
+		return findString(context.Secrets, path[0]), nil
+	case len(path) == 1 && strings.EqualFold(root, "vars"):
+		return findString(context.Vars, path[0]), nil
+	case len(path) == 1 && strings.EqualFold(root, "env"):
+		return findString(context.Env, path[0]), nil
+	case len(path) == 3 && strings.EqualFold(root, "steps") && strings.EqualFold(path[1], "outputs"):
+		outputs, ok := findOutputs(context.Steps, path[0])
 		if !ok {
-			return "", fmt.Errorf("expression references unavailable step %q", parts[1])
+			return "", fmt.Errorf("expression references unavailable step %q", path[0])
 		}
-		return outputs[parts[3]], nil
-	case len(parts) == 4 && parts[0] == "needs" && parts[2] == "outputs":
-		outputs, ok := findOutputs(context.Needs, parts[1])
+		return findString(outputs, path[2]), nil
+	case len(path) == 3 && strings.EqualFold(root, "needs") && strings.EqualFold(path[1], "outputs"):
+		outputs, ok := findOutputs(context.Needs, path[0])
 		if !ok {
-			return "", fmt.Errorf("expression references unavailable need %q", parts[1])
+			return "", fmt.Errorf("expression references unavailable need %q", path[0])
 		}
-		return outputs[parts[3]], nil
-	case len(parts) == 3 && parts[0] == "needs" && parts[2] == "result":
+		return findString(outputs, path[2]), nil
+	case len(path) == 2 && strings.EqualFold(root, "needs") && strings.EqualFold(path[1], "result"):
 		for candidate, result := range context.NeedResults {
-			if strings.EqualFold(candidate, parts[1]) {
+			if strings.EqualFold(candidate, path[0]) {
 				return result, nil
 			}
 		}
-		return "", fmt.Errorf("expression references unavailable need %q", parts[1])
+		return "", fmt.Errorf("expression references unavailable need %q", path[0])
 	default:
 		return "", fmt.Errorf("unsupported expression %q", reference)
 	}

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -1,6 +1,7 @@
 package expression
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -55,6 +56,53 @@ func TestEvaluateIsSinglePass(t *testing.T) {
 	got, err := Evaluate("${{ inputs.value }}:${{ matrix.secret }}", context)
 	if err != nil || got != literal+":reevaluated" {
 		t.Fatalf("Evaluate() = %q, %v, want both original expressions evaluated once", got, err)
+	}
+}
+
+func TestEvaluateSupportsStaticIndexReferences(t *testing.T) {
+	context := Context{
+		Matrix:  map[string]any{"shell": "bash"},
+		Secrets: map[string]string{"TOKEN": "secret-value"},
+	}
+	got, err := Evaluate("${{ matrix['shell'] }}:${{ secrets['TOKEN'] }}", context)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "bash:secret-value" {
+		t.Fatalf("Evaluate() = %q, want static index references", got)
+	}
+	if _, err := Evaluate("${{ secrets[env.NAME] }}", context); err == nil || !strings.Contains(err.Error(), "index must be a string literal") {
+		t.Fatalf("Evaluate() dynamic index error = %v", err)
+	}
+}
+
+func TestSecretReferencesUsesExpressionAST(t *testing.T) {
+	template := "${{ secrets.dot_token }}:${{ secrets['BRACKET_TOKEN'] }}:${{ secrets.DOT_TOKEN }}:${{ matrix.value }}:${{ 'not }} a delimiter' }}"
+	got, err := SecretReferences(template)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"BRACKET_TOKEN", "DOT_TOKEN"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("SecretReferences() = %#v, want %#v", got, want)
+	}
+	if _, err := SecretReferences("${{ secrets[env.NAME] }}"); err == nil || !strings.Contains(err.Error(), "index must be a string literal") {
+		t.Fatalf("SecretReferences() dynamic index error = %v", err)
+	}
+	if _, err := SecretReferences("${{ toJSON(secrets) }}"); err == nil || !strings.Contains(err.Error(), "must name exactly one secret") {
+		t.Fatalf("SecretReferences() whole-context error = %v", err)
+	}
+}
+
+func TestConditionUsesContextSupportsOptionalDelimiters(t *testing.T) {
+	for _, condition := range []string{"inputs.enabled", "${{ inputs.enabled }}", "inputs.enabled && github.ref"} {
+		usesInputs, err := ConditionUsesContext(condition, "inputs")
+		if err != nil || !usesInputs {
+			t.Fatalf("ConditionUsesContext(%q) = %v, %v, want true", condition, usesInputs, err)
+		}
+	}
+	usesInputs, err := ConditionUsesContext("github.ref", "inputs")
+	if err != nil || usesInputs {
+		t.Fatalf("ConditionUsesContext(github.ref) = %v, %v, want false", usesInputs, err)
 	}
 }
 

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -385,22 +385,24 @@ func (r Runner) runJobStep(ctx context.Context, processor *commandProcessor, wor
 		if err != nil {
 			return result, err
 		}
-		shell, err := expression.Evaluate(step.Shell, eval)
-		if err != nil {
-			return result, err
-		}
+		shell := step.Shell
 		if shell == "" {
 			shell = job.DefaultShell
+		}
+		shell, err = expression.Evaluate(shell, eval)
+		if err != nil {
+			return result, err
 		}
 		if shell == "" {
 			shell = "bash"
 		}
-		workingDirectory, err := expression.Evaluate(step.WorkingDirectory, eval)
-		if err != nil {
-			return result, err
-		}
+		workingDirectory := step.WorkingDirectory
 		if workingDirectory == "" {
 			workingDirectory = job.DefaultWorkingDirectory
+		}
+		workingDirectory, err = expression.Evaluate(workingDirectory, eval)
+		if err != nil {
+			return result, err
 		}
 		dir, err := workspacePath(workspace, workingDirectory)
 		if err != nil {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -81,6 +82,123 @@ echo after-soft`},
 	}
 	if strings.Contains(logs.String(), "mask-me") || !strings.Contains(logs.String(), "secret=***") || !strings.Contains(logs.String(), "after-soft") {
 		t.Fatalf("RunJob() logs = %q", logs.String())
+	}
+}
+
+func TestCompiledRunDefaultsEvaluateAtRuntime(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/defaults.yml"
+	source := `on: push
+jobs:
+  matrix-defaults:
+    strategy:
+      matrix:
+        shell: [bash]
+        dir: [matrix]
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
+        working-directory: ${{ matrix.dir }}
+    steps:
+      - run: test "$(basename "$PWD")" = matrix
+  env-defaults:
+    runs-on: ubuntu-latest
+    env:
+      DEFAULT_SHELL: bash
+      DEFAULT_DIR: env
+    defaults:
+      run:
+        shell: ${{ env.DEFAULT_SHELL }}
+        working-directory: ${{ env.DEFAULT_DIR }}
+    steps:
+      - run: test "$(basename "$PWD")" = env
+  vars-defaults:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: ${{ vars.DEFAULT_SHELL }}
+        working-directory: ${{ vars.DEFAULT_DIR }}
+    steps:
+      - run: test "$(basename "$PWD")" = vars
+  explicit-precedence:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: unsupported-default
+        working-directory: missing-default
+    steps:
+      - shell: sh
+        working-directory: ${{ vars.OVERRIDE_DIR }}
+        run: test "$(basename "$PWD")" = override
+`
+	writeFixtureFile(t, workspace, workflowPath, source)
+	for _, directory := range []string{"matrix", "env", "vars", "override"} {
+		if err := os.Mkdir(filepath.Join(workspace, directory), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	event, err := os.ReadFile(fixturePath(t, "smoke", "events", "push.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	plans, err := compiler.CompilePlansWithOptions(
+		filepath.Join(workspace, workflowPath),
+		[]byte(source),
+		event,
+		"0.0.0-test",
+		"sha256:"+strings.Repeat("2", 64),
+		compiler.Options{
+			EventTrust: compiler.EventUntrusted,
+			Vars: compiler.VariableSources{Bridge: map[string]string{
+				"DEFAULT_SHELL": "bash",
+				"DEFAULT_DIR":   "vars",
+				"OVERRIDE_DIR":  "override",
+			}},
+			Runners: compiler.RunnerPolicy{
+				Labels:          map[string]string{"ubuntu-latest": "gha-untrusted"},
+				UntrustedQueues: []string{"gha-untrusted"},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 4 {
+		t.Fatalf("plans = %d, want four defaults cases", len(plans))
+	}
+	for _, job := range plans {
+		result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+		if err != nil || result.Conclusion != "success" {
+			t.Fatalf("RunJob(%s) result = %#v, error = %v", job.Workflow.LogicalJobID, result, err)
+		}
+	}
+}
+
+func TestCompiledBracketSecretResolvesAndMasks(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/secrets.yml"
+	source := "on: push\njobs:\n  secrets:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo \"secret=${{ secrets['TOKEN'] }}\"\n"
+	writeFixtureFile(t, workspace, workflowPath, source)
+	event, err := os.ReadFile(fixturePath(t, "smoke", "events", "push.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	plans, err := compiler.CompilePlans(filepath.Join(workspace, workflowPath), []byte(source), event, "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 1 || !slices.Equal(plans[0].RequiredSecrets, []string{"TOKEN"}) || !plans[0].HasCapability("secrets") {
+		t.Fatalf("compiled secret boundary = %#v", plans)
+	}
+	var logs bytes.Buffer
+	redactor := &testRedactor{}
+	result, err := (Runner{Stdout: &logs, Stderr: &logs, Secrets: testSecretResolver{"TOKEN": "secret-value"}, Redactor: redactor}).RunJob(context.Background(), plans[0], workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	if strings.Contains(logs.String(), "secret-value") || !strings.Contains(logs.String(), "secret=***") || !slices.Equal(redactor.values, []string{"secret-value"}) {
+		t.Fatalf("logs = %q, redactions = %#v", logs.String(), redactor.values)
 	}
 }
 


### PR DESCRIPTION
## Description

Fix three expression-boundary issues identified while testing Phases 1–3:

- Resolve reusable-workflow inputs in job and step conditions
- Support static bracket-form secret references such as `secrets['TOKEN']`
- Evaluate job-level `defaults.run` expressions at runtime

## Changes

### Reusable-workflow conditions

- Substitute whole job and step conditions that directly reference static `inputs.*`
- Preserve input types when constructing conditions, including quoted string literals
- Support conditions with and without `${{ }}` delimiters
- Reject more complex residual `inputs.*` conditions at compile time instead of allowing them to fail at runtime

### Secret references

- Replace regex-based secret discovery with expression AST traversal
- Treat dot and static bracket forms equivalently
- Deterministically populate required secrets and the `secrets` capability
- Reject dynamic indexes and whole-context secret access
- Resolve bracket-form references at runtime and register their values for log masking

### Run defaults

- Apply explicit-step-over-job-default precedence first
- Evaluate the effective shell and working directory in the runtime expression context
- Cover `matrix`, `env`, and `vars` expressions for both default fields
- Verify explicit step settings avoid evaluating overridden defaults

## Verification

- `go test ./...`
- `go test -race ./internal/expression ./internal/compiler ./internal/runtime`
- `go vet ./...`
- `golangci-lint run`
- `git diff --check`

