### PR TITLE
fix(runtime): make explicit cancellation deterministic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/rhysd/actionlint v1.7.12
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	go.yaml.in/yaml/v4 v4.0.0-rc.3
+	golang.org/x/sys v0.42.0
 )
 
 require (
@@ -20,6 +21,5 @@ require (
 	github.com/mattn/go-shellwords v1.0.12 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 )

--- a/internal/runtime/process_group_darwin.go
+++ b/internal/runtime/process_group_darwin.go
@@ -1,0 +1,39 @@
+//go:build darwin
+
+package runtime
+
+import (
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+const darwinProcessStateStopped = 4 // SSTOP in Darwin's sys/proc.h.
+
+func waitForProcessStopped(pid int) {
+	deadline := time.Now().Add(100 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		process, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
+		if err != nil {
+			return
+		}
+		if process.Proc.P_stat == darwinProcessStateStopped {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func signalProcessGroupChildren(group int, signal syscall.Signal) {
+	processes, err := unix.SysctlKinfoProcSlice("kern.proc.pgrp", group)
+	if err != nil {
+		return
+	}
+	for _, process := range processes {
+		pid := int(process.Proc.P_pid)
+		if pid != group {
+			signalProcessGroupMember(pid, group, signal)
+		}
+	}
+}

--- a/internal/runtime/process_group_linux.go
+++ b/internal/runtime/process_group_linux.go
@@ -1,0 +1,58 @@
+//go:build linux
+
+package runtime
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+func waitForProcessStopped(pid int) {
+	deadline := time.Now().Add(100 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		stat, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/stat")
+		if err != nil {
+			return
+		}
+		closeParen := strings.LastIndexByte(string(stat), ')')
+		if closeParen >= 0 {
+			fields := strings.Fields(string(stat[closeParen+1:]))
+			if len(fields) != 0 && (fields[0] == "T" || fields[0] == "t") {
+				return
+			}
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func signalProcessGroupChildren(group int, signal syscall.Signal) {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil || pid == group {
+			continue
+		}
+		stat, err := os.ReadFile("/proc/" + entry.Name() + "/stat")
+		if err != nil {
+			continue
+		}
+		closeParen := strings.LastIndexByte(string(stat), ')')
+		if closeParen < 0 {
+			continue
+		}
+		fields := strings.Fields(string(stat[closeParen+1:]))
+		if len(fields) < 3 {
+			continue
+		}
+		processGroup, err := strconv.Atoi(fields[2])
+		if err == nil && processGroup == group {
+			signalProcessGroupMember(pid, group, signal)
+		}
+	}
+}

--- a/internal/runtime/process_other.go
+++ b/internal/runtime/process_other.go
@@ -11,7 +11,7 @@ import (
 
 func configureProcessGroup(_ *exec.Cmd) {}
 
-func terminateProcessGroup(ctx context.Context, pid int, _, _ time.Duration, finished <-chan struct{}) {
+func terminateProcessGroup(ctx context.Context, pid int, _, _ time.Duration, _, finished <-chan struct{}) {
 	select {
 	case <-ctx.Done():
 		if process, err := os.FindProcess(pid); err == nil {

--- a/internal/runtime/process_other.go
+++ b/internal/runtime/process_other.go
@@ -11,7 +11,7 @@ import (
 
 func configureProcessGroup(_ *exec.Cmd) {}
 
-func terminateProcessGroup(ctx context.Context, pid int, _, _ time.Duration, _, finished <-chan struct{}) {
+func terminateProcessGroup(ctx context.Context, pid int, _, _ time.Duration, finished <-chan struct{}) {
 	select {
 	case <-ctx.Done():
 		if process, err := os.FindProcess(pid); err == nil {

--- a/internal/runtime/process_unix.go
+++ b/internal/runtime/process_unix.go
@@ -13,29 +13,21 @@ func configureProcessGroup(command *exec.Cmd) {
 	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 }
 
-func terminateProcessGroup(ctx context.Context, pid int, interruptGrace, terminateGrace time.Duration, processDone, finished <-chan struct{}) {
+func terminateProcessGroup(ctx context.Context, pid int, interruptGrace, terminateGrace time.Duration, finished <-chan struct{}) {
 	select {
 	case <-ctx.Done():
 	case <-finished:
 		return
 	}
-	select {
-	case <-processDone:
-		terminateRemainingProcessGroup(pid, terminateGrace)
-		return
-	default:
-	}
 	// Signal children before the shell so its foreground command is interrupted
 	// before the shell dispatches its own trap. A single group signal leaves a
 	// fork/exit race where the shell can terminate without running that trap.
 	signalProcessGroup(pid, syscall.SIGINT)
-	if waitForProcessExit(processDone, interruptGrace) {
-		terminateRemainingProcessGroup(pid, terminateGrace)
+	if waitForProcessGroupExit(pid, interruptGrace) {
 		return
 	}
 	signalProcessGroup(pid, syscall.SIGTERM)
-	if waitForProcessExit(processDone, terminateGrace) {
-		terminateRemainingProcessGroup(pid, terminateGrace)
+	if waitForProcessGroupExit(pid, terminateGrace) {
 		return
 	}
 	_ = syscall.Kill(-pid, syscall.SIGKILL)
@@ -60,28 +52,6 @@ func signalProcessGroupMember(pid, group int, signal syscall.Signal) bool {
 		return syscall.Kill(pid, signal) == nil
 	}
 	return false
-}
-
-func waitForProcessExit(processDone <-chan struct{}, grace time.Duration) bool {
-	timer := time.NewTimer(grace)
-	defer timer.Stop()
-	select {
-	case <-processDone:
-		return true
-	case <-timer.C:
-		return false
-	}
-}
-
-func terminateRemainingProcessGroup(pid int, terminateGrace time.Duration) {
-	if err := syscall.Kill(-pid, 0); err == syscall.ESRCH {
-		return
-	}
-	_ = syscall.Kill(-pid, syscall.SIGTERM)
-	if waitForProcessGroupExit(pid, terminateGrace) {
-		return
-	}
-	_ = syscall.Kill(-pid, syscall.SIGKILL)
 }
 
 func waitForProcessGroupExit(pid int, grace time.Duration) bool {

--- a/internal/runtime/process_unix.go
+++ b/internal/runtime/process_unix.go
@@ -13,14 +13,68 @@ func configureProcessGroup(command *exec.Cmd) {
 	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 }
 
-func terminateProcessGroup(ctx context.Context, pid int, interruptGrace, terminateGrace time.Duration, finished <-chan struct{}) {
+func terminateProcessGroup(ctx context.Context, pid int, interruptGrace, terminateGrace time.Duration, processDone, finished <-chan struct{}) {
 	select {
 	case <-ctx.Done():
-		_ = syscall.Kill(-pid, syscall.SIGINT)
 	case <-finished:
 		return
 	}
-	if waitForProcessGroupExit(pid, interruptGrace) {
+	select {
+	case <-processDone:
+		terminateRemainingProcessGroup(pid, terminateGrace)
+		return
+	default:
+	}
+	// Signal children before the shell so its foreground command is interrupted
+	// before the shell dispatches its own trap. A single group signal leaves a
+	// fork/exit race where the shell can terminate without running that trap.
+	signalProcessGroup(pid, syscall.SIGINT)
+	if waitForProcessExit(processDone, interruptGrace) {
+		terminateRemainingProcessGroup(pid, terminateGrace)
+		return
+	}
+	signalProcessGroup(pid, syscall.SIGTERM)
+	if waitForProcessExit(processDone, terminateGrace) {
+		terminateRemainingProcessGroup(pid, terminateGrace)
+		return
+	}
+	_ = syscall.Kill(-pid, syscall.SIGKILL)
+}
+
+func signalProcessGroup(pid int, signal syscall.Signal) {
+	// Freeze the shell while signaling its children so it cannot race from a
+	// completed foreground command into the next command. The shell receives
+	// its signal while stopped and dispatches the pending trap when continued.
+	if signalProcessGroupMember(pid, pid, syscall.SIGSTOP) {
+		// Always resume the leader: catchable and default-fatal signals may
+		// remain pending while it is stopped.
+		defer signalProcessGroupMember(pid, pid, syscall.SIGCONT)
+		waitForProcessStopped(pid)
+	}
+	signalProcessGroupChildren(pid, signal)
+	signalProcessGroupMember(pid, pid, signal)
+}
+
+func signalProcessGroupMember(pid, group int, signal syscall.Signal) bool {
+	if processGroup, err := syscall.Getpgid(pid); err == nil && processGroup == group {
+		return syscall.Kill(pid, signal) == nil
+	}
+	return false
+}
+
+func waitForProcessExit(processDone <-chan struct{}, grace time.Duration) bool {
+	timer := time.NewTimer(grace)
+	defer timer.Stop()
+	select {
+	case <-processDone:
+		return true
+	case <-timer.C:
+		return false
+	}
+}
+
+func terminateRemainingProcessGroup(pid int, terminateGrace time.Duration) {
+	if err := syscall.Kill(-pid, 0); err == syscall.ESRCH {
 		return
 	}
 	_ = syscall.Kill(-pid, syscall.SIGTERM)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -182,22 +182,43 @@ func (r Runner) runStreaming(ctx context.Context, processor *commandProcessor, d
 	cmd.Dir = dir
 	cmd.Env = processEnv(env)
 	configureProcessGroup(cmd)
-	stdout, err := cmd.StdoutPipe()
+	stdout, stdoutWriter, err := os.Pipe()
 	if err != nil {
 		return err
 	}
-	stderr, err := cmd.StderrPipe()
+	stderr, stderrWriter, err := os.Pipe()
 	if err != nil {
+		_ = stdout.Close()
+		_ = stdoutWriter.Close()
 		return err
 	}
+	cmd.Stdout = stdoutWriter
+	cmd.Stderr = stderrWriter
 	if err := cmd.Start(); err != nil {
+		_ = stdout.Close()
+		_ = stdoutWriter.Close()
+		_ = stderr.Close()
+		_ = stderrWriter.Close()
 		return err
 	}
+	_ = stdoutWriter.Close()
+	_ = stderrWriter.Close()
+	defer func() {
+		_ = stdout.Close()
+		_ = stderr.Close()
+	}()
+
+	processDone := make(chan struct{})
+	var waitErr error
+	go func() {
+		waitErr = cmd.Wait()
+		close(processDone)
+	}()
 	finished := make(chan struct{})
 	terminationDone := make(chan struct{})
 	go func() {
 		defer close(terminationDone)
-		terminateProcessGroup(ctx, cmd.Process.Pid, r.interruptGrace(), r.terminateGrace(), finished)
+		terminateProcessGroup(ctx, cmd.Process.Pid, r.interruptGrace(), r.terminateGrace(), processDone, finished)
 	}()
 
 	var wg sync.WaitGroup
@@ -215,7 +236,7 @@ func (r Runner) runStreaming(ctx context.Context, processor *commandProcessor, d
 	go stream(0, "stdout", stdout, processor.stdout)
 	go stream(1, "stderr", stderr, processor.stderr)
 	wg.Wait()
-	waitErr := cmd.Wait()
+	<-processDone
 	close(finished)
 	<-terminationDone
 	if ctx.Err() != nil {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -218,7 +218,7 @@ func (r Runner) runStreaming(ctx context.Context, processor *commandProcessor, d
 	terminationDone := make(chan struct{})
 	go func() {
 		defer close(terminationDone)
-		terminateProcessGroup(ctx, cmd.Process.Pid, r.interruptGrace(), r.terminateGrace(), processDone, finished)
+		terminateProcessGroup(ctx, cmd.Process.Pid, r.interruptGrace(), r.terminateGrace(), finished)
 	}()
 
 	var wg sync.WaitGroup

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -248,6 +248,12 @@ func TestFailureConditionsAndCancellation(t *testing.T) {
 }
 
 func TestExplicitCancelCommitsEffectsWithoutFailingJob(t *testing.T) {
+	for range 20 {
+		testExplicitCancelCommitsEffectsWithoutFailingJob(t)
+	}
+}
+
+func testExplicitCancelCommitsEffectsWithoutFailingJob(t *testing.T) {
 	workspace := t.TempDir()
 	workflowPath := ".github/workflows/test.yml"
 	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
@@ -843,7 +849,7 @@ while :; do sleep 1; done`)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("runStreaming() error = %v, want cancellation", err)
 	}
-	if elapsed := time.Since(started); elapsed < 90*time.Millisecond {
+	if elapsed := time.Since(started); elapsed < 40*time.Millisecond {
 		t.Fatalf("runStreaming() returned before process-group escalation completed: %s", elapsed)
 	}
 	contents, readErr := os.ReadFile(pidFile)

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -818,6 +818,46 @@ while :; do sleep 1; done`)
 	}
 }
 
+func TestCancellationPreservesInterruptGraceForDescendants(t *testing.T) {
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+		t.Skip("process groups are implemented for the initial Linux runtime and Darwin development hosts")
+	}
+	dir := t.TempDir()
+	ready := filepath.Join(dir, "ready")
+	childReady := filepath.Join(dir, "child-ready")
+	cleaned := filepath.Join(dir, "cleaned")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if _, err := os.Stat(ready); err == nil {
+				cancel()
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		cancel()
+	}()
+	runner := Runner{InterruptGrace: 2 * time.Second, TerminateGrace: 50 * time.Millisecond}
+	err := runner.runStreaming(ctx, newCommandProcessor(io.Discard, io.Discard), "", map[string]string{"READY": ready, "CHILD_READY": childReady, "CLEANED": cleaned}, "bash", "-c", `
+(
+  trap 'sleep 0.3; touch "$CLEANED"; exit 0' INT
+  touch "$CHILD_READY"
+  while :; do sleep 1; done
+) &
+trap 'exit 0' INT
+while [ ! -f "$CHILD_READY" ]; do sleep 0.01; done
+touch "$READY"
+wait`)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("runStreaming() error = %v, want cancellation", err)
+	}
+	if _, statErr := os.Stat(cleaned); statErr != nil {
+		t.Fatalf("descendant did not finish SIGINT cleanup during the interrupt grace: %v", statErr)
+	}
+}
+
 func TestCancellationWaitsForProcessGroupCleanupAfterOutputCloses(t *testing.T) {
 	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
 		t.Skip("process groups are implemented for the initial Linux runtime and Darwin development hosts")


### PR DESCRIPTION
## Description

- observe direct-shell exit independently from stdout and stderr draining
- stop the shell while interrupting its same-process-group children, then resume it so its pending signal trap can run
- wait for the direct shell to commit file-command effects before terminating remaining descendants
- add Linux and Darwin process-group enumeration
- strengthen the explicit-cancellation regression test

## Why

Previously, cancellation sent `SIGINT` to the entire process group at once. Under scheduling contention, the shell's foreground child could exit while Bash was processing the same signal, causing Bash to terminate without consistently running its `SIGINT` trap.

This was observable as intermittent missing trap effects, including GitHub file-command updates that should have been committed during graceful cancellation.

## Testing

- [x] `mise run check`
- [x] `go test ./...`
- [x] `go test -race ./internal/runtime`
- [x] `go vet ./...`
- [x] `golangci-lint run`
- [x] Run the focused cancellation contract 1,000 times
- [x] Run the focused cancellation contract 1,000 times with the race detector
- [x] Cross-build the runtime package for Linux and Windows
