### PR TITLE
Probe hosted Docker capabilities for Phase 5

### DIFF
--- a/.buildkite/phase-5-capabilities-continuation.yml
+++ b/.buildkite/phase-5-capabilities-continuation.yml
@@ -1,0 +1,9 @@
+steps:
+  - label: ":white_check_mark: Phase 5 capability probe settled"
+    key: "phase-5-native-after-hosted-docker"
+    depends_on:
+      - step: "phase-5-hosted-docker-probe"
+        allow_failure: true
+    agents:
+      queue: "elastic-runners"
+    command: "echo 'Phase 5 hosted Docker capability probe settled'"

--- a/.buildkite/phase-5-capabilities.yml
+++ b/.buildkite/phase-5-capabilities.yml
@@ -1,0 +1,18 @@
+steps:
+  - label: ":pipeline: Phase 5 capability importer"
+    key: "phase-5-capabilities-importer"
+    agents:
+      queue: "elastic-runners"
+    command: |
+      set -euo pipefail
+      scripts/phase-0-shell-oracle-checkout "$$PHASE5_COMMIT"
+      test -z "$$(git status --porcelain --untracked-files=all)"
+      buildkite-agent pipeline upload --no-interpolation --reject-secrets .buildkite/phase-5-hosted-probe.yml
+
+  - label: ":pipeline: Phase 5 continuation loader"
+    key: "phase-5-continuation-loader"
+    depends_on: "phase-5-capabilities-importer"
+    allow_dependency_failure: true
+    agents:
+      queue: "elastic-runners"
+    command: "buildkite-agent pipeline upload .buildkite/phase-5-capabilities-continuation.yml"

--- a/.buildkite/phase-5-hosted-probe.yml
+++ b/.buildkite/phase-5-hosted-probe.yml
@@ -1,0 +1,9 @@
+steps:
+  - label: ":docker: Phase 5 hosted Docker capabilities"
+    key: "phase-5-hosted-docker-probe"
+    agents:
+      queue: "hosted"
+    timeout_in_minutes: 15
+    retry:
+      automatic: false
+    command: "scripts/phase-5-hosted-docker-probe"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -34,6 +34,13 @@ steps:
     agents:
       queue: "elastic-runners"
 
+  - label: ":docker: Load Phase 5 hosted Docker probe"
+    key: "phase-5-capabilities-loader"
+    if: build.env("PHASE5_PROBE") == "capabilities"
+    command: "buildkite-agent pipeline upload .buildkite/phase-5-capabilities.yml"
+    agents:
+      queue: "elastic-runners"
+
   - label: ":go: Repository checks"
     key: "checks"
     plugins:

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -1272,7 +1272,7 @@ Phase 5 entry evidence:
 
 - [Buildkite build 102](https://buildkite.com/buildkite/buildkite-gha/builds/102)
   ran exact implementation commit
-  `b3a4c4c3513c9a763b2e0ea09428d7d83e41336e`. The checked-in probe observed the
+  `b3a4c4c96d97812e5c087057cda0fdaf1a79bb19`. The checked-in probe observed the
   hosted queue's active remote Buildx driver, selected and verified the local
   `default` Docker driver, then passed pinned pull, build-and-load, execution,
   requested UID/GID bind ownership, private-network HTTP by alias, container

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -1270,9 +1270,9 @@ Phase 4 live evidence:
 
 Phase 5 entry evidence:
 
-- [Buildkite build 99](https://buildkite.com/buildkite/buildkite-gha/builds/99)
+- [Buildkite build 102](https://buildkite.com/buildkite/buildkite-gha/builds/102)
   ran exact implementation commit
-  `e98724a21c111c0d399f95a0bda2e54a0147af8e`. The checked-in probe observed the
+  `b3a4c4c3513c9a763b2e0ea09428d7d83e41336e`. The checked-in probe observed the
   hosted queue's active remote Buildx driver, selected and verified the local
   `default` Docker driver, then passed pinned pull, build-and-load, execution,
   requested UID/GID bind ownership, private-network HTTP by alias, container
@@ -2034,7 +2034,7 @@ them in the phase that first needs the capability:
    payload Buildkite exposes, whether the service must receive GitHub App
    webhooks directly, and whether a small Buildkite platform API is missing.
 2. Phase 5 uses direct Hosted Agent execution for the tokenless Dockerfile
-   action slice. Exact-commit build 99 proved the local `default` Docker driver,
+   action slice. Exact-commit build 102 proved the local `default` Docker driver,
    bind/path behavior, private networking, health, loopback publication,
    signals, and cleanup. A compatibility image remains deferred until job
    containers or tool-cache differences demonstrate a concrete need.

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -1204,6 +1204,20 @@ Explicitly defer from beta unless implementation evidence changes the order:
   JavaScript/composite fixture. This does not claim a same-workflow private
   checkout proof on Buildkite. The migrated normal path now has separate exact
   Buildkite and GitHub-hosted evidence below.
+- Phase 5 entry evidence is implemented without yet authorizing Docker in the
+  production upload path. An exact-commit, fixed-`hosted` probe demonstrates a
+  runnable local Docker daemon, bind mounts and ownership, private-network DNS,
+  health checks, dynamic loopback port publication, observable TERM handling,
+  and exact-label cleanup. Buildkite Hosted Agents provide a disposable,
+  isolated virtualized environment for each job and destroy it regardless of
+  exit status. The queue's active Buildx builder is remote and cluster-scoped,
+  however, so anonymous Dockerfile builds must select the local `default`
+  Docker driver explicitly rather than execute untrusted `RUN` instructions in
+  the remote builder's persistent shared cache. The first production slice
+  remains limited to Dockerfile-backed local and anonymous public actions;
+  `docker://`, Docker pre/post entrypoints, job containers, services, private
+  registries, arbitrary options, protected capabilities, and privileged queues
+  continue to fail closed until their owning slices land.
 - The first work wave is integrated: the Go/CLI foundation is runnable,
   ADR 0001 records the actionlint/act reuse boundary, and ADR 0002 plus schemas
   and eight conformance cases preserve the Phase 0 signed-envelope transport
@@ -1253,6 +1267,21 @@ Phase 4 live evidence:
 - [GitHub Actions run 30069516646](https://github.com/buildkite/buildkite-gha/actions/runs/30069516646)
   ran the same implementation commit against the private repository. Its
   producer and consumer passed the JavaScript/composite differential fixture.
+
+Phase 5 entry evidence:
+
+- [Buildkite build 99](https://buildkite.com/buildkite/buildkite-gha/builds/99)
+  ran exact implementation commit
+  `e98724a21c111c0d399f95a0bda2e54a0147af8e`. The checked-in probe observed the
+  hosted queue's active remote Buildx driver, selected and verified the local
+  `default` Docker driver, then passed pinned pull, build-and-load, execution,
+  requested UID/GID bind ownership, private-network HTTP by alias, container
+  health, dynamic loopback publication, TERM observation, and exact-label
+  cleanup. The separate continuation settled only after the hosted probe.
+- This establishes capability and queue-isolation evidence, not production
+  Docker authorization. Normal `buildkite-gha upload` still rejects the
+  `docker` capability until the staged-source, cancellation, bounded cleanup,
+  and policy work below is implemented and reviewed.
 
 - [Buildkite build 72](https://buildkite.com/buildkite/buildkite-gha/builds/72)
   ran exact implementation commit
@@ -1527,7 +1556,7 @@ Definition of done:
 - Private action authentication is either implemented safely or rejected
   clearly.
 
-### Phase 5 — Containers and services
+### Phase 5 — Containers and services (entry capability proven)
 
 Implement the Linux Docker execution backend for:
 
@@ -1538,6 +1567,31 @@ Implement the Linux Docker execution backend for:
 - health checks and service failure logs;
 - host/container path translation; and
 - orphan cleanup.
+
+Implementation order and fixed boundaries:
+
+1. Harden Dockerfile-backed actions first. Build only a private staged copy of
+   the verified action tree, select `buildx build --builder default --load`, use
+   fixed structured mounts and bridge-owned labels, and stop/remove containers
+   and images under an independent bounded cleanup context.
+2. Admit only local and anonymously resolved public Dockerfile actions on the
+   fixed tokenless `hosted` queue. Continue rejecting `docker://` images,
+   Docker pre/post entrypoints, arbitrary Docker options, private registries,
+   credentials, provider tokens, host namespaces, devices, socket mounts, and
+   privileged capabilities.
+3. Add persistent job containers and path translation only after Docker action
+   lifecycle, command-file processing, masking, cancellation, and cleanup pass
+   differential and exact-commit evidence.
+4. Add services, aliases, port context, health diagnostics, and startup/orphan
+   reconciliation on the same runtime-owned backend. Do not translate imported
+   container definitions into workflow-controlled Buildkite plugins.
+
+The hosted default remote builder is not an authorization boundary for
+anonymous Dockerfiles: it has cluster-scoped persistent caching. The tokenless
+path must use the probed local `default` Docker driver so Dockerfile execution
+remains inside the disposable job environment. Any future use of remote
+builders for untrusted plans, or any elevated Docker option, is a separate
+product and security decision.
 
 Definition of done:
 
@@ -1979,16 +2033,21 @@ them in the phase that first needs the capability:
 1. Phase 6 control-plane work will determine which authenticated GitHub event
    payload Buildkite exposes, whether the service must receive GitHub App
    webhooks directly, and whether a small Buildkite platform API is missing.
-2. Phase 5 container work will choose direct Hosted Agent execution versus a
-   compatibility image from measured tool-cache and Docker behavior.
+2. Phase 5 uses direct Hosted Agent execution for the tokenless Dockerfile
+   action slice. Exact-commit build 99 proved the local `default` Docker driver,
+   bind/path behavior, private networking, health, loopback publication,
+   signals, and cleanup. A compatibility image remains deferred until job
+   containers or tool-cache differences demonstrate a concrete need.
 3. Phase 6 will choose job-local protocol adapters versus recognized built-ins
    for cache and artifact actions.
 4. Phase 4 will set the customer-beta event and expression subset from the
    hosted differential corpus.
 5. Phase 6 will define Cursor Origin checkout, event, pull-request, Job OIDC,
    and short-lived capability contracts alongside the GitHub provider adapter.
-6. Phases 5 and 9 will define the queue capabilities and trust properties
-   required for Docker and privileged workloads.
+6. The fixed Buildkite `hosted` queue's documented per-job disposable isolation
+   and the Phase 5 probe are sufficient for tokenless, non-privileged Dockerfile
+   actions built on the local driver. Phases 6 and 9 still own authorization and
+   queue policy for protected Docker capabilities and privileged workloads.
 7. Phase 6 will define the GitHub App installation-token compatibility contract
    for `github.token` and `GITHUB_TOKEN`, including repository/permission
    narrowing and documented differences from native Actions tokens. Tokenless

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -551,7 +551,7 @@ func TestPhase5HostedDockerCapabilityProbeContract(t *testing.T) {
 		t.Fatal(err)
 	}
 	text := string(probe)
-	for _, fragment := range []string{"set -euo pipefail", `${PHASE5_COMMIT:?}`, `scripts/phase-0-shell-oracle-checkout "$PHASE5_COMMIT"`, "alpine@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1", `buildx build --load`, `127.0.0.1::8080`, `wget -qO- http://phase5-server:8080/phase5-marker`, `/dev/tcp/127.0.0.1/$1`, `trap cleanup EXIT`, `trap 'exit 130' INT`, `trap 'exit 143' TERM`, `--filter "label=${label_key}=${owner}"`, `timeout 30s`, `docker stop --time 5`, `term-observed`, `(( probe_failed == 0 ))`, "COPY marker"} {
+	for _, fragment := range []string{"set -euo pipefail", `${PHASE5_COMMIT:?}`, `scripts/phase-0-shell-oracle-checkout "$PHASE5_COMMIT"`, "busybox@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028", `buildx build --load`, `127.0.0.1::8080`, `wget -qO- http://phase5-server:8080/phase5-marker`, `/dev/tcp/127.0.0.1/$1`, `trap cleanup EXIT`, `trap 'exit 130' INT`, `trap 'exit 143' TERM`, `--filter "label=${label_key}=${owner}"`, `timeout 30s`, `docker stop --time 5`, `term-observed`, `(( probe_failed == 0 ))`, "COPY marker"} {
 		if !strings.Contains(text, fragment) {
 			t.Fatalf("Phase 5 probe lacks %q", fragment)
 		}

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -551,7 +551,7 @@ func TestPhase5HostedDockerCapabilityProbeContract(t *testing.T) {
 		t.Fatal(err)
 	}
 	text := string(probe)
-	for _, fragment := range []string{"set -euo pipefail", `${PHASE5_COMMIT:?}`, `scripts/phase-0-shell-oracle-checkout "$PHASE5_COMMIT"`, "busybox@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028", `buildx build --load`, `127.0.0.1::8080`, `wget -qO- http://phase5-server:8080/phase5-marker`, `/dev/tcp/127.0.0.1/$1`, `trap cleanup EXIT`, `trap 'exit 130' INT`, `trap 'exit 143' TERM`, `--filter "label=${label_key}=${owner}"`, `timeout 30s`, `docker stop --time 5`, `term-observed`, `(( probe_failed == 0 ))`, "COPY marker"} {
+	for _, fragment := range []string{"set -euo pipefail", `${PHASE5_COMMIT:?}`, `scripts/phase-0-shell-oracle-checkout "$PHASE5_COMMIT"`, "busybox@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028", `buildx inspect default`, `buildx build --builder default --load`, `default-docker-driver`, `127.0.0.1::8080`, `wget -qO- http://phase5-server:8080/phase5-marker`, `/dev/tcp/127.0.0.1/$1`, `trap cleanup EXIT`, `trap 'exit 130' INT`, `trap 'exit 143' TERM`, `--filter "label=${label_key}=${owner}"`, `timeout 30s`, `docker stop --time 5`, `term-observed`, `(( probe_failed == 0 ))`, "COPY marker"} {
 		if !strings.Contains(text, fragment) {
 			t.Fatalf("Phase 5 probe lacks %q", fragment)
 		}

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -551,7 +551,7 @@ func TestPhase5HostedDockerCapabilityProbeContract(t *testing.T) {
 		t.Fatal(err)
 	}
 	text := string(probe)
-	for _, fragment := range []string{"set -euo pipefail", `${PHASE5_COMMIT:?}`, `scripts/phase-0-shell-oracle-checkout "$PHASE5_COMMIT"`, "busybox@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028", `buildx inspect default`, `buildx build --builder default --load`, `default-docker-driver`, `127.0.0.1::8080`, `wget -qO- http://phase5-server:8080/phase5-marker`, `/dev/tcp/127.0.0.1/$1`, `trap cleanup EXIT`, `trap 'exit 130' INT`, `trap 'exit 143' TERM`, `--filter "label=${label_key}=${owner}"`, `timeout 30s`, `docker stop --time 5`, `term-observed`, `(( probe_failed == 0 ))`, "COPY marker"} {
+	for _, fragment := range []string{"set -euo pipefail", `${PHASE5_COMMIT:?}`, `scripts/phase-0-shell-oracle-checkout "$PHASE5_COMMIT"`, "busybox@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028", `buildx inspect default`, `buildx build --builder default --load`, `default-docker-driver`, `127.0.0.1::8080`, `wget -qO- http://phase5-server:8080/phase5-marker`, `/dev/tcp/127.0.0.1/$1`, `trap cleanup EXIT`, `trap - EXIT`, `exit "$final"`, `trap 'exit 130' INT`, `trap 'exit 143' TERM`, `docker container ls --all --quiet`, `--filter "label=${label_key}=${owner}"`, `timeout 30s`, `docker stop --time 5`, `term-observed`, `record bind-requested fail`, `record signal-stop fail`, `(( probe_failed == 0 ))`, "COPY marker"} {
 		if !strings.Contains(text, fragment) {
 			t.Fatalf("Phase 5 probe lacks %q", fragment)
 		}

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -551,7 +551,7 @@ func TestPhase5HostedDockerCapabilityProbeContract(t *testing.T) {
 		t.Fatal(err)
 	}
 	text := string(probe)
-	for _, fragment := range []string{"set -euo pipefail", `${PHASE5_COMMIT:?}`, `scripts/phase-0-shell-oracle-checkout "$PHASE5_COMMIT"`, "alpine@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1", `127.0.0.1::8080`, `wget -qO- http://phase5-server:8080/phase5-marker`, `/dev/tcp/127.0.0.1/$1`, `trap cleanup EXIT`, `trap 'exit 130' INT`, `trap 'exit 143' TERM`, `--filter "label=${label_key}=${owner}"`, `timeout 30s`, `docker stop --time 5`, `term-observed`, "COPY marker"} {
+	for _, fragment := range []string{"set -euo pipefail", `${PHASE5_COMMIT:?}`, `scripts/phase-0-shell-oracle-checkout "$PHASE5_COMMIT"`, "alpine@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1", `buildx build --load`, `127.0.0.1::8080`, `wget -qO- http://phase5-server:8080/phase5-marker`, `/dev/tcp/127.0.0.1/$1`, `trap cleanup EXIT`, `trap 'exit 130' INT`, `trap 'exit 143' TERM`, `--filter "label=${label_key}=${owner}"`, `timeout 30s`, `docker stop --time 5`, `term-observed`, `(( probe_failed == 0 ))`, "COPY marker"} {
 		if !strings.Contains(text, fragment) {
 			t.Fatalf("Phase 5 probe lacks %q", fragment)
 		}

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -208,8 +208,8 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 	if err := yaml.Unmarshal(source, &document); err != nil {
 		t.Fatalf("parse default pipeline: %v", err)
 	}
-	if len(document.Steps) != 6 {
-		t.Fatalf("default pipeline = %#v, want five gated probe loaders and repository checks", document.Steps)
+	if len(document.Steps) != 7 {
+		t.Fatalf("default pipeline = %#v, want six gated loaders plus repository checks", document.Steps)
 	}
 	steps := make(map[string]struct {
 		command   string
@@ -238,6 +238,9 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 	}
 	if got := steps["phase-4-upload-loader"]; got.command != "buildkite-agent pipeline upload .buildkite/phase-4-upload.yml" || got.condition != `build.env("PHASE4_PROBE") == "actions"` {
 		t.Fatalf("Phase 4 upload loader = %#v", got)
+	}
+	if got := steps["phase-5-capabilities-loader"]; got.command != "buildkite-agent pipeline upload .buildkite/phase-5-capabilities.yml" || got.condition != `build.env("PHASE5_PROBE") == "capabilities"` {
+		t.Fatalf("Phase 5 capability loader = %#v", got)
 	}
 }
 
@@ -489,6 +492,74 @@ func TestPhase4UploadProofUsesTrustedManagedActionsPath(t *testing.T) {
 	}
 	if len(continuation.Steps) != 1 || continuation.Steps[0].Key != "phase-4-native-after-actions" || continuation.Steps[0].Agents.Queue != "elastic-runners" || len(continuation.Steps[0].DependsOn) != 1 || continuation.Steps[0].DependsOn[0].Step != "gha-public-actions" || !continuation.Steps[0].DependsOn[0].AllowFailure {
 		t.Fatalf("Phase 4 continuation = %#v", continuation.Steps)
+	}
+}
+
+func TestPhase5HostedDockerCapabilityProbeContract(t *testing.T) {
+	root := filepath.Join("..", "..")
+	type step struct {
+		Key                    string `yaml:"key"`
+		Command                string `yaml:"command"`
+		DependsOn              any    `yaml:"depends_on"`
+		AllowDependencyFailure bool   `yaml:"allow_dependency_failure"`
+		Timeout                int    `yaml:"timeout_in_minutes"`
+		Agents                 struct {
+			Queue string `yaml:"queue"`
+		} `yaml:"agents"`
+		Retry struct {
+			Automatic bool `yaml:"automatic"`
+		} `yaml:"retry"`
+	}
+	read := func(name string) ([]byte, []step) {
+		t.Helper()
+		body, err := os.ReadFile(filepath.Join(root, ".buildkite", name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var document struct {
+			Steps []step `yaml:"steps"`
+		}
+		if err := yaml.Unmarshal(body, &document); err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		return body, document.Steps
+	}
+	importerBody, importer := read("phase-5-capabilities.yml")
+	if len(importer) != 2 || importer[0].Key != "phase-5-capabilities-importer" || importer[0].Agents.Queue != "elastic-runners" || importer[1].Key != "phase-5-continuation-loader" || importer[1].Agents.Queue != "elastic-runners" || fmt.Sprint(importer[1].DependsOn) != "phase-5-capabilities-importer" || !importer[1].AllowDependencyFailure || importer[1].Command != "buildkite-agent pipeline upload .buildkite/phase-5-capabilities-continuation.yml" {
+		t.Fatalf("Phase 5 importer = %#v", importer)
+	}
+	for _, fragment := range []string{`scripts/phase-0-shell-oracle-checkout "$$PHASE5_COMMIT"`, `git status --porcelain --untracked-files=all`, `pipeline upload --no-interpolation --reject-secrets .buildkite/phase-5-hosted-probe.yml`} {
+		if !strings.Contains(string(importerBody), fragment) {
+			t.Fatalf("Phase 5 importer lacks %q", fragment)
+		}
+	}
+	hostedBody, hosted := read("phase-5-hosted-probe.yml")
+	if len(hosted) != 1 || hosted[0].Key != "phase-5-hosted-docker-probe" || hosted[0].Agents.Queue != "hosted" || hosted[0].Timeout != 15 || hosted[0].Retry.Automatic || hosted[0].Command != "scripts/phase-5-hosted-docker-probe" || !strings.Contains(string(hostedBody), "automatic: false") {
+		t.Fatalf("Phase 5 hosted pipeline = %#v\n%s", hosted, hostedBody)
+	}
+	_, continuation := read("phase-5-capabilities-continuation.yml")
+	if len(continuation) != 1 || continuation[0].Key != "phase-5-native-after-hosted-docker" || continuation[0].Agents.Queue != "elastic-runners" {
+		t.Fatalf("Phase 5 continuation = %#v", continuation)
+	}
+	continuationBody, _ := os.ReadFile(filepath.Join(root, ".buildkite", "phase-5-capabilities-continuation.yml"))
+	if !strings.Contains(string(continuationBody), `step: "phase-5-hosted-docker-probe"`) || !strings.Contains(string(continuationBody), `allow_failure: true`) {
+		t.Fatalf("Phase 5 continuation dependency is not failure-tolerant: %s", continuationBody)
+	}
+
+	probe, err := os.ReadFile(filepath.Join(root, "scripts", "phase-5-hosted-docker-probe"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(probe)
+	for _, fragment := range []string{"set -euo pipefail", `${PHASE5_COMMIT:?}`, `scripts/phase-0-shell-oracle-checkout "$PHASE5_COMMIT"`, "alpine@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1", `127.0.0.1::8080`, `wget -qO- http://phase5-server:8080/phase5-marker`, `/dev/tcp/127.0.0.1/$1`, `trap cleanup EXIT`, `trap 'exit 130' INT`, `trap 'exit 143' TERM`, `--filter "label=${label_key}=${owner}"`, `timeout 30s`, `docker stop --time 5`, `term-observed`, "COPY marker"} {
+		if !strings.Contains(text, fragment) {
+			t.Fatalf("Phase 5 probe lacks %q", fragment)
+		}
+	}
+	for _, forbidden := range []string{"--privileged", "--network host", "/var/run/docker.sock", "docker prune", "docker system prune", "docker image prune", "docker container prune", "docker network prune", "printenv", " env"} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("Phase 5 probe contains forbidden %q", forbidden)
+		}
 	}
 }
 

--- a/mise.toml
+++ b/mise.toml
@@ -29,7 +29,7 @@ run = "golangci-lint run"
 
 [tasks."lint:shell"]
 description = "Lint shell scripts"
-run = "shellcheck -x .buildkite/phase-0-transport-probe/probe.sh scripts/phase-0-shell-oracle-checkout scripts/phase-0-sign-json scripts/phase-0-verify-json testdata/actions/docker/entrypoint.sh"
+run = "shellcheck -x .buildkite/phase-0-transport-probe/probe.sh scripts/phase-0-shell-oracle-checkout scripts/phase-0-sign-json scripts/phase-0-verify-json scripts/phase-5-hosted-docker-probe testdata/actions/docker/entrypoint.sh"
 
 [tasks.vet]
 description = "Run go vet"

--- a/scripts/phase-5-hosted-docker-probe
+++ b/scripts/phase-5-hosted-docker-probe
@@ -94,8 +94,8 @@ printf 'phase5\n' > "$work/marker"
 cat > "$work/Dockerfile" <<'EOF'
 FROM alpine@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1
 COPY marker /phase5-marker
-HEALTHCHECK --interval=1s --timeout=2s --retries=10 CMD wget -q -O /dev/null http://127.0.0.1:8080/phase5-marker || exit 1
-CMD ["httpd", "-f", "-p", "8080", "-h", "/"]
+HEALTHCHECK --interval=1s --timeout=2s --retries=10 CMD busybox wget -q -O /dev/null http://127.0.0.1:8080/phase5-marker || exit 1
+CMD ["busybox", "httpd", "-f", "-p", "8080", "-h", "/"]
 EOF
 if timeout 10s docker buildx version >/dev/null 2>&1; then
   build=(docker buildx build --load)

--- a/scripts/phase-5-hosted-docker-probe
+++ b/scripts/phase-5-hosted-docker-probe
@@ -28,13 +28,15 @@ safe_detail() {
 }
 
 cleanup() {
-  local prior=$? leftovers=0 verification_failed=0 result
-  (( cleanup_ran == 0 )) || return "$prior"
+  local prior=$? final leftovers=0 verification_failed=0 result
+  final="$prior"
+  trap - EXIT
+  (( cleanup_ran == 0 )) || exit "$final"
   cleanup_ran=1
   if (( created == 0 )); then
     [[ -z "$work" ]] || rm -rf -- "$work"
     record cleanup skip nothing-created
-    return "$prior"
+    exit "$final"
   fi
   set +e
   # Positional parameters are intentionally expanded by the bounded child shell.
@@ -44,8 +46,13 @@ cleanup() {
     docker network rm "$5" >/dev/null 2>&1 || true
     docker image rm -f "$6" >/dev/null 2>&1 || true
   ' _ "$server" "$client" "$publisher" "$signal" "$network" "$image"
-  for kind in container network image; do
-    if ! result="$(timeout 10s docker "$kind" ls -q --filter "label=${label_key}=${owner}" 2>/dev/null)"; then
+  if ! result="$(timeout 10s docker container ls --all --quiet --filter "label=${label_key}=${owner}" 2>/dev/null)"; then
+    verification_failed=1
+  elif [[ -n "$result" ]]; then
+    leftovers=1
+  fi
+  for kind in network image; do
+    if ! result="$(timeout 10s docker "$kind" ls --quiet --filter "label=${label_key}=${owner}" 2>/dev/null)"; then
       verification_failed=1
     elif [[ -n "$result" ]]; then
       leftovers=1
@@ -55,14 +62,16 @@ cleanup() {
   set -e
   if (( leftovers )); then
     record cleanup fail leftovers
-    return 1
+    (( prior != 0 )) || final=1
+    exit "$final"
   fi
   if (( verification_failed )); then
     record cleanup fail verification-unavailable
-    return 1
+    (( prior != 0 )) || final=1
+    exit "$final"
   fi
   record cleanup pass exact-label-empty
-  return "$prior"
+  exit "$final"
 }
 trap cleanup EXIT
 trap 'exit 130' INT
@@ -120,8 +129,8 @@ if timeout 30s docker run --rm --label "${label_key}=${owner}" -v "$work/mount:/
     record bind-default pass "$category"
   else record bind-default fail write-failed; fi
 else
-  record bind-requested not-applicable endpoint-path-model
-  record bind-default not-applicable endpoint-path-model
+  record bind-requested fail endpoint-path-model
+  record bind-default fail endpoint-path-model
 fi
 
 if timeout 30s docker network create --label "${label_key}=${owner}" "$network" >/dev/null 2>&1; then
@@ -154,7 +163,7 @@ if (( bind_supported )); then
     if timeout 15s docker stop --time 5 "$signal" >/dev/null 2>&1 && [[ -f "$work/signal/term" ]] && [[ "$(cat "$work/signal/term")" == term ]]; then record signal-stop pass term-observed; else record signal-stop fail forced-or-unobserved; fi
   else record signal-stop fail container-unavailable; fi
 else
-  record signal-stop not-applicable endpoint-path-model
+  record signal-stop fail bind-prerequisite-missing
 fi
 
 rm -rf -- "$work"

--- a/scripts/phase-5-hosted-docker-probe
+++ b/scripts/phase-5-hosted-docker-probe
@@ -105,6 +105,10 @@ else
 fi
 if timeout 180s "${build[@]}" --label "${label_key}=${owner}" -t "$image" "$work" >/dev/null 2>&1; then created=1; record build pass loaded-marker-layer; else record build fail loaded-marker-layer; exit 1; fi
 if timeout 30s docker run --rm --label "${label_key}=${owner}" "$image" test -f /www/phase5-marker >/dev/null 2>&1; then record run pass marker-present; else record run fail marker-missing; fi
+if timeout 30s docker run --rm --label "${label_key}=${owner}" "$image" busybox --list 2>/dev/null | grep -qx httpd; then record httpd-applet pass available; else record httpd-applet fail unavailable; fi
+# The single-quoted container script intentionally expands its own process ID.
+# shellcheck disable=SC2016
+if timeout 30s docker run --rm --label "${label_key}=${owner}" "$image" sh -c 'busybox httpd -f -p 8080 -h /www & server=$!; trap "kill $server" EXIT; sleep 1; busybox wget -qO- http://127.0.0.1:8080/phase5-marker | busybox grep -qx phase5' >/dev/null 2>&1; then record http-selftest pass loopback-reachable; else record http-selftest fail loopback-unreachable; fi
 
 mkdir "$work/mount"; printf x > "$work/mount/owned"; uid="$(id -u)"; gid="$(id -g)"
 if timeout 30s docker run --rm --label "${label_key}=${owner}" -v "$work/mount:/probe" --user "$uid:$gid" "$image" sh -c 'printf y > /probe/requested' >/dev/null 2>&1; then
@@ -124,7 +128,7 @@ if timeout 30s docker network create --label "${label_key}=${owner}" "$network" 
   created=1
   if timeout 30s docker run -d --label "${label_key}=${owner}" --name "$server" --network "$network" --network-alias phase5-server "$image" >/dev/null 2>&1; then
     created=1
-    if timeout 30s docker run --rm --label "${label_key}=${owner}" --name "$client" --network "$network" "$image_base" sh -c 'wget -qO- http://phase5-server:8080/phase5-marker | grep -qx phase5' >/dev/null 2>&1; then record bridge-dns pass alias-http-reachable; else record bridge-dns fail alias-http-unreachable; fi
+    if timeout 30s docker run --rm --label "${label_key}=${owner}" --name "$client" --network "$network" "$image_base" sh -c 'busybox wget -qO- http://phase5-server:8080/phase5-marker | busybox grep -qx phase5' >/dev/null 2>&1; then record bridge-dns pass alias-http-reachable; else record bridge-dns fail alias-http-unreachable; fi
     health=starting
     for _ in {1..20}; do health="$(timeout 5s docker inspect --format '{{.State.Health.Status}}' "$server" 2>/dev/null || true)"; [[ "$health" == healthy ]] && break; sleep 1; done
     if [[ "$health" == healthy ]]; then record health pass healthy; else record health fail not-healthy; fi

--- a/scripts/phase-5-hosted-docker-probe
+++ b/scripts/phase-5-hosted-docker-probe
@@ -98,11 +98,11 @@ COPY marker /www/phase5-marker
 HEALTHCHECK --interval=1s --timeout=2s --retries=10 CMD busybox wget -q -O /dev/null http://127.0.0.1:8080/phase5-marker || exit 1
 CMD ["busybox", "httpd", "-f", "-p", "8080", "-h", "/www"]
 EOF
-if timeout 10s docker buildx version >/dev/null 2>&1; then
-  build=(docker buildx build --load)
-else
-  build=(docker build)
-fi
+if ! timeout 10s docker buildx version >/dev/null 2>&1; then record local-builder fail buildx-unavailable; exit 1; fi
+local_driver="$(timeout 10s docker buildx inspect default 2>/dev/null | awk '/^Driver:/ {print $2; exit}' || true)"
+if [[ "$local_driver" != docker ]]; then record local-builder fail default-is-not-local; exit 1; fi
+record local-builder pass default-docker-driver
+build=(docker buildx build --builder default --load)
 if timeout 180s "${build[@]}" --label "${label_key}=${owner}" -t "$image" "$work" >/dev/null 2>&1; then created=1; record build pass loaded-marker-layer; else record build fail loaded-marker-layer; exit 1; fi
 if timeout 30s docker run --rm --label "${label_key}=${owner}" "$image" test -f /www/phase5-marker >/dev/null 2>&1; then record run pass marker-present; else record run fail marker-missing; fi
 if timeout 30s docker run --rm --label "${label_key}=${owner}" "$image" busybox --list 2>/dev/null | grep -qx httpd; then record httpd-applet pass available; else record httpd-applet fail unavailable; fi

--- a/scripts/phase-5-hosted-docker-probe
+++ b/scripts/phase-5-hosted-docker-probe
@@ -93,9 +93,10 @@ work="$(mktemp -d "${TMPDIR:-/tmp}/phase5-probe.XXXXXXXX")"
 printf 'phase5\n' > "$work/marker"
 cat > "$work/Dockerfile" <<'EOF'
 FROM alpine@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1
-COPY marker /phase5-marker
+RUN mkdir /www
+COPY marker /www/phase5-marker
 HEALTHCHECK --interval=1s --timeout=2s --retries=10 CMD busybox wget -q -O /dev/null http://127.0.0.1:8080/phase5-marker || exit 1
-CMD ["busybox", "httpd", "-f", "-p", "8080", "-h", "/"]
+CMD ["busybox", "httpd", "-f", "-p", "8080", "-h", "/www"]
 EOF
 if timeout 10s docker buildx version >/dev/null 2>&1; then
   build=(docker buildx build --load)
@@ -103,7 +104,7 @@ else
   build=(docker build)
 fi
 if timeout 180s "${build[@]}" --label "${label_key}=${owner}" -t "$image" "$work" >/dev/null 2>&1; then created=1; record build pass loaded-marker-layer; else record build fail loaded-marker-layer; exit 1; fi
-if timeout 30s docker run --rm --label "${label_key}=${owner}" "$image" test -f /phase5-marker >/dev/null 2>&1; then record run pass marker-present; else record run fail marker-missing; fi
+if timeout 30s docker run --rm --label "${label_key}=${owner}" "$image" test -f /www/phase5-marker >/dev/null 2>&1; then record run pass marker-present; else record run fail marker-missing; fi
 
 mkdir "$work/mount"; printf x > "$work/mount/owned"; uid="$(id -u)"; gid="$(id -g)"
 if timeout 30s docker run --rm --label "${label_key}=${owner}" -v "$work/mount:/probe" --user "$uid:$gid" "$image" sh -c 'printf y > /probe/requested' >/dev/null 2>&1; then

--- a/scripts/phase-5-hosted-docker-probe
+++ b/scripts/phase-5-hosted-docker-probe
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-readonly image_base='alpine@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1'
+readonly image_base='busybox@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028'
 readonly label_key='com.buildkite.buildkite-gha.phase5-owner'
 readonly suffix="${BUILDKITE_JOB_ID:-unknown}"
 readonly safe_suffix="${suffix//[^A-Za-z0-9]/}"
@@ -92,7 +92,7 @@ record pull pass pinned-image
 work="$(mktemp -d "${TMPDIR:-/tmp}/phase5-probe.XXXXXXXX")"
 printf 'phase5\n' > "$work/marker"
 cat > "$work/Dockerfile" <<'EOF'
-FROM alpine@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1
+FROM busybox@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028
 RUN mkdir /www
 COPY marker /www/phase5-marker
 HEALTHCHECK --interval=1s --timeout=2s --retries=10 CMD busybox wget -q -O /dev/null http://127.0.0.1:8080/phase5-marker || exit 1

--- a/scripts/phase-5-hosted-docker-probe
+++ b/scripts/phase-5-hosted-docker-probe
@@ -15,8 +15,12 @@ work=''
 created=0
 cleanup_ran=0
 bind_supported=0
+probe_failed=0
 
-record() { printf 'PHASE5|%s|%s|%s\n' "$1" "$2" "$3"; }
+record() {
+  printf 'PHASE5|%s|%s|%s\n' "$1" "$2" "$3"
+  [[ "$2" != fail ]] || probe_failed=1
+}
 safe_detail() {
   local value="$1"
   [[ "$value" =~ ^[A-Za-z0-9._:/@+-]{1,128}$ ]] && printf '%s' "$value" || printf 'unsafe-detail-redacted'
@@ -92,7 +96,12 @@ COPY marker /phase5-marker
 HEALTHCHECK --interval=1s --timeout=2s --retries=10 CMD wget -q -O /dev/null http://127.0.0.1:8080/phase5-marker || exit 1
 CMD ["httpd", "-f", "-p", "8080", "-h", "/"]
 EOF
-if timeout 120s docker build --label "${label_key}=${owner}" -t "$image" "$work" >/dev/null 2>&1; then created=1; record build pass marker-layer; else record build fail marker-layer; exit 1; fi
+if timeout 10s docker buildx version >/dev/null 2>&1; then
+  build=(docker buildx build --load)
+else
+  build=(docker build)
+fi
+if timeout 180s "${build[@]}" --label "${label_key}=${owner}" -t "$image" "$work" >/dev/null 2>&1; then created=1; record build pass loaded-marker-layer; else record build fail loaded-marker-layer; exit 1; fi
 if timeout 30s docker run --rm --label "${label_key}=${owner}" "$image" test -f /phase5-marker >/dev/null 2>&1; then record run pass marker-present; else record run fail marker-missing; fi
 
 mkdir "$work/mount"; printf x > "$work/mount/owned"; uid="$(id -u)"; gid="$(id -g)"
@@ -138,3 +147,4 @@ fi
 
 rm -rf -- "$work"
 work=''
+(( probe_failed == 0 ))

--- a/scripts/phase-5-hosted-docker-probe
+++ b/scripts/phase-5-hosted-docker-probe
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly image_base='alpine@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1'
+readonly label_key='com.buildkite.buildkite-gha.phase5-owner'
+readonly suffix="${BUILDKITE_JOB_ID:-unknown}"
+readonly safe_suffix="${suffix//[^A-Za-z0-9]/}"
+readonly owner="phase5-${safe_suffix:0:48}-$$"
+readonly image="buildkite-gha-phase5-${safe_suffix:0:24}-$$"
+readonly network="buildkite-gha-phase5-${safe_suffix:0:24}-$$"
+readonly server="buildkite-gha-phase5-server-${safe_suffix:0:24}-$$"
+readonly client="buildkite-gha-phase5-client-${safe_suffix:0:24}-$$"
+readonly signal="buildkite-gha-phase5-signal-${safe_suffix:0:24}-$$"
+work=''
+created=0
+cleanup_ran=0
+bind_supported=0
+
+record() { printf 'PHASE5|%s|%s|%s\n' "$1" "$2" "$3"; }
+safe_detail() {
+  local value="$1"
+  [[ "$value" =~ ^[A-Za-z0-9._:/@+-]{1,128}$ ]] && printf '%s' "$value" || printf 'unsafe-detail-redacted'
+}
+
+cleanup() {
+  local prior=$? leftovers=0 verification_failed=0 result
+  (( cleanup_ran == 0 )) || return "$prior"
+  cleanup_ran=1
+  if (( created == 0 )); then
+    [[ -z "$work" ]] || rm -rf -- "$work"
+    record cleanup skip nothing-created
+    return "$prior"
+  fi
+  set +e
+  # Positional parameters are intentionally expanded by the bounded child shell.
+  # shellcheck disable=SC2016
+  timeout 30s bash -c '
+    docker rm -f "$1" "$2" "$3" >/dev/null 2>&1 || true
+    docker network rm "$4" >/dev/null 2>&1 || true
+    docker image rm -f "$5" >/dev/null 2>&1 || true
+  ' _ "$server" "$client" "$signal" "$network" "$image"
+  for kind in container network image; do
+    if ! result="$(timeout 10s docker "$kind" ls -q --filter "label=${label_key}=${owner}" 2>/dev/null)"; then
+      verification_failed=1
+    elif [[ -n "$result" ]]; then
+      leftovers=1
+    fi
+  done
+  [[ -z "$work" ]] || rm -rf -- "$work"
+  set -e
+  if (( leftovers )); then
+    record cleanup fail leftovers
+    return 1
+  fi
+  if (( verification_failed )); then
+    record cleanup fail verification-unavailable
+    return 1
+  fi
+  record cleanup pass exact-label-empty
+  return "$prior"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+: "${PHASE5_COMMIT:?}"
+scripts/phase-0-shell-oracle-checkout "$PHASE5_COMMIT"
+record platform pass "$(safe_detail "$(uname -s)-$(uname -m)")"
+
+if ! command -v docker >/dev/null 2>&1; then record docker-client unavailable not-found; exit 1; fi
+record docker-client available command-found
+if ! timeout 20s docker version >/dev/null 2>&1; then record docker-daemon unavailable version-failed; exit 1; fi
+record docker-daemon available version-ok
+
+host_class="unset"
+[[ -n "${DOCKER_HOST:-}" ]] && host_class="set"
+context="$(timeout 10s docker context show 2>/dev/null || true)"
+context="$(safe_detail "${context:-unavailable}")"
+driver="$(timeout 10s docker buildx inspect 2>/dev/null | awk '/^Driver:/ {print $2; exit}' || true)"
+case "$driver" in docker|docker-container|remote) ;; '') driver=unavailable ;; *) driver=other ;; esac
+record transport pass "host-${host_class}.context-${context}.builder-${driver}"
+rootless="$(timeout 10s docker info --format '{{json .SecurityOptions}}' 2>/dev/null || true)"
+if [[ "$rootless" == *rootless* ]]; then record daemon-mode pass rootless; else record daemon-mode pass rootful-or-not-advertised; fi
+
+if ! timeout 120s docker pull "$image_base" >/dev/null 2>&1; then record pull fail pinned-image; exit 1; fi
+record pull pass pinned-image
+work="$(mktemp -d "${TMPDIR:-/tmp}/phase5-probe.XXXXXXXX")"
+printf 'phase5\n' > "$work/marker"
+cat > "$work/Dockerfile" <<'EOF'
+FROM alpine@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1
+COPY marker /phase5-marker
+HEALTHCHECK --interval=1s --timeout=2s --retries=10 CMD wget -q -O /dev/null http://127.0.0.1:8080/phase5-marker || exit 1
+CMD ["httpd", "-f", "-p", "8080", "-h", "/"]
+EOF
+if timeout 120s docker build --label "${label_key}=${owner}" -t "$image" "$work" >/dev/null 2>&1; then created=1; record build pass marker-layer; else record build fail marker-layer; exit 1; fi
+if timeout 30s docker run --rm --label "${label_key}=${owner}" "$image" test -f /phase5-marker >/dev/null 2>&1; then record run pass marker-present; else record run fail marker-missing; fi
+
+mkdir "$work/mount"; printf x > "$work/mount/owned"; uid="$(id -u)"; gid="$(id -g)"
+if timeout 30s docker run --rm --label "${label_key}=${owner}" -v "$work/mount:/probe" --user "$uid:$gid" "$image" sh -c 'printf y > /probe/requested' >/dev/null 2>&1; then
+  ownership="$(stat -c '%u:%g' "$work/mount/requested")"
+  if [[ "$ownership" == "$uid:$gid" ]]; then bind_supported=1; record bind-requested pass requested-uid-gid; else record bind-requested fail ownership-mismatch; fi
+  if timeout 30s docker run --rm --label "${label_key}=${owner}" -v "$work/mount:/probe" "$image" sh -c 'printf z > /probe/default' >/dev/null 2>&1; then
+    default_owner="$(stat -c '%u:%g' "$work/mount/default")"
+    [[ "$default_owner" == '0:0' ]] && category=root || category=non-root
+    record bind-default pass "$category"
+  else record bind-default fail write-failed; fi
+else
+  record bind-requested not-applicable endpoint-path-model
+  record bind-default not-applicable endpoint-path-model
+fi
+
+if timeout 30s docker network create --label "${label_key}=${owner}" "$network" >/dev/null 2>&1; then
+  created=1
+  if timeout 30s docker run -d --label "${label_key}=${owner}" --name "$server" --network "$network" --network-alias phase5-server -p 127.0.0.1::8080 "$image" >/dev/null 2>&1; then
+    created=1
+    if timeout 30s docker run --rm --label "${label_key}=${owner}" --name "$client" --network "$network" "$image_base" sh -c 'wget -qO- http://phase5-server:8080/phase5-marker | grep -qx phase5' >/dev/null 2>&1; then record bridge-dns pass alias-http-reachable; else record bridge-dns fail alias-http-unreachable; fi
+    port="$(timeout 10s docker port "$server" 8080/tcp 2>/dev/null || true)"
+    # The single-quoted child script intentionally reads its positional argument.
+    # shellcheck disable=SC2016
+    if [[ "$port" =~ ^127\.0\.0\.1:([0-9]+)$ ]] && timeout 10s bash -c 'exec 3<>"/dev/tcp/127.0.0.1/$1"; printf "GET /phase5-marker HTTP/1.0\r\n\r\n" >&3; grep -q phase5 <&3' _ "${BASH_REMATCH[1]}" >/dev/null 2>&1; then record host-port pass dynamic-loopback-reachable; else record host-port not-applicable endpoint-publication-model; fi
+    health=starting
+    for _ in {1..20}; do health="$(timeout 5s docker inspect --format '{{.State.Health.Status}}' "$server" 2>/dev/null || true)"; [[ "$health" == healthy ]] && break; sleep 1; done
+    if [[ "$health" == healthy ]]; then record health pass healthy; else record health fail not-healthy; fi
+    if timeout 15s docker stop --time 5 "$server" >/dev/null 2>&1; then record server-stop pass bounded; else record server-stop fail timeout; fi
+  else record server-run fail unavailable; fi
+else record bridge-network fail unavailable; fi
+
+if (( bind_supported )); then
+  mkdir "$work/signal"
+  if timeout 30s docker run -d --label "${label_key}=${owner}" --name "$signal" -v "$work/signal:/probe" "$image" sh -c 'trap "printf term > /probe/term; exit 0" TERM INT; while :; do sleep 1 & wait $!; done' >/dev/null 2>&1; then
+    created=1
+    sleep 1
+    if timeout 15s docker stop --time 5 "$signal" >/dev/null 2>&1 && [[ -f "$work/signal/term" ]] && [[ "$(cat "$work/signal/term")" == term ]]; then record signal-stop pass term-observed; else record signal-stop fail forced-or-unobserved; fi
+  else record signal-stop fail container-unavailable; fi
+else
+  record signal-stop not-applicable endpoint-path-model
+fi
+
+rm -rf -- "$work"
+work=''

--- a/scripts/phase-5-hosted-docker-probe
+++ b/scripts/phase-5-hosted-docker-probe
@@ -10,6 +10,7 @@ readonly image="buildkite-gha-phase5-${safe_suffix:0:24}-$$"
 readonly network="buildkite-gha-phase5-${safe_suffix:0:24}-$$"
 readonly server="buildkite-gha-phase5-server-${safe_suffix:0:24}-$$"
 readonly client="buildkite-gha-phase5-client-${safe_suffix:0:24}-$$"
+readonly publisher="buildkite-gha-phase5-publisher-${safe_suffix:0:24}-$$"
 readonly signal="buildkite-gha-phase5-signal-${safe_suffix:0:24}-$$"
 work=''
 created=0
@@ -39,10 +40,10 @@ cleanup() {
   # Positional parameters are intentionally expanded by the bounded child shell.
   # shellcheck disable=SC2016
   timeout 30s bash -c '
-    docker rm -f "$1" "$2" "$3" >/dev/null 2>&1 || true
-    docker network rm "$4" >/dev/null 2>&1 || true
-    docker image rm -f "$5" >/dev/null 2>&1 || true
-  ' _ "$server" "$client" "$signal" "$network" "$image"
+    docker rm -f "$1" "$2" "$3" "$4" >/dev/null 2>&1 || true
+    docker network rm "$5" >/dev/null 2>&1 || true
+    docker image rm -f "$6" >/dev/null 2>&1 || true
+  ' _ "$server" "$client" "$publisher" "$signal" "$network" "$image"
   for kind in container network image; do
     if ! result="$(timeout 10s docker "$kind" ls -q --filter "label=${label_key}=${owner}" 2>/dev/null)"; then
       verification_failed=1
@@ -120,19 +121,25 @@ fi
 
 if timeout 30s docker network create --label "${label_key}=${owner}" "$network" >/dev/null 2>&1; then
   created=1
-  if timeout 30s docker run -d --label "${label_key}=${owner}" --name "$server" --network "$network" --network-alias phase5-server -p 127.0.0.1::8080 "$image" >/dev/null 2>&1; then
+  if timeout 30s docker run -d --label "${label_key}=${owner}" --name "$server" --network "$network" --network-alias phase5-server "$image" >/dev/null 2>&1; then
     created=1
     if timeout 30s docker run --rm --label "${label_key}=${owner}" --name "$client" --network "$network" "$image_base" sh -c 'wget -qO- http://phase5-server:8080/phase5-marker | grep -qx phase5' >/dev/null 2>&1; then record bridge-dns pass alias-http-reachable; else record bridge-dns fail alias-http-unreachable; fi
-    port="$(timeout 10s docker port "$server" 8080/tcp 2>/dev/null || true)"
-    # The single-quoted child script intentionally reads its positional argument.
-    # shellcheck disable=SC2016
-    if [[ "$port" =~ ^127\.0\.0\.1:([0-9]+)$ ]] && timeout 10s bash -c 'exec 3<>"/dev/tcp/127.0.0.1/$1"; printf "GET /phase5-marker HTTP/1.0\r\n\r\n" >&3; grep -q phase5 <&3' _ "${BASH_REMATCH[1]}" >/dev/null 2>&1; then record host-port pass dynamic-loopback-reachable; else record host-port not-applicable endpoint-publication-model; fi
     health=starting
     for _ in {1..20}; do health="$(timeout 5s docker inspect --format '{{.State.Health.Status}}' "$server" 2>/dev/null || true)"; [[ "$health" == healthy ]] && break; sleep 1; done
     if [[ "$health" == healthy ]]; then record health pass healthy; else record health fail not-healthy; fi
     if timeout 15s docker stop --time 5 "$server" >/dev/null 2>&1; then record server-stop pass bounded; else record server-stop fail timeout; fi
   else record server-run fail unavailable; fi
 else record bridge-network fail unavailable; fi
+
+if timeout 30s docker run -d --label "${label_key}=${owner}" --name "$publisher" -p 127.0.0.1::8080 "$image" >/dev/null 2>&1; then
+  created=1
+  port="$(timeout 10s docker port "$publisher" 8080/tcp 2>/dev/null || true)"
+  # The single-quoted child script intentionally reads its positional argument.
+  # shellcheck disable=SC2016
+  if [[ "$port" =~ ^127\.0\.0\.1:([0-9]+)$ ]] && timeout 10s bash -c 'exec 3<>"/dev/tcp/127.0.0.1/$1"; printf "GET /phase5-marker HTTP/1.0\r\n\r\n" >&3; grep -q phase5 <&3' _ "${BASH_REMATCH[1]}" >/dev/null 2>&1; then record host-port pass dynamic-loopback-reachable; else record host-port fail endpoint-publication-unreachable; fi
+else
+  record host-port fail publication-unavailable
+fi
 
 if (( bind_supported )); then
   mkdir "$work/signal"


### PR DESCRIPTION
## Summary

- add a dormant exact-commit capability probe on the fixed Buildkite `hosted` queue
- prove local build/run, bind ownership, private networking, health, ports, TERM handling, and exact-label cleanup
- force untrusted Dockerfile builds onto Buildx's local `default` Docker driver rather than the hosted cluster's persistent remote builder
- preserve the separate importer/continuation upload invariant and record the resulting Phase 5 boundary in the plan

This PR does **not** authorize Docker in normal `buildkite-gha upload` jobs.

## Security boundary

Buildkite Hosted Agents document a disposable isolated virtualized environment per job. The probe found the active Buildx builder is remote and cluster-scoped, so the checked-in proof explicitly verifies and selects `--builder default`, whose driver is local `docker`. No privileged mode, host networking, devices, socket mounts, private credentials, fixed host ports, broad inspection, or prune operations are used.

## Evidence

- Buildkite build 99 at exact commit `e98724a21c111c0d399f95a0bda2e54a0147af8e`: https://buildkite.com/buildkite/buildkite-gha/builds/99
- focused Go pipeline tests pass
- shellcheck passes
- Oracle reviewed the probe and approved proceeding to the constrained Dockerfile-action slice after local-builder evidence
