### PR TITLE
Add classified smoke and compatibility harness

### DIFF
--- a/.buildkite/hosted-smoke-aggregator.yml
+++ b/.buildkite/hosted-smoke-aggregator.yml
@@ -2,9 +2,13 @@ steps:
   - label: ":white_check_mark: Hosted smoke targets settled"
     key: "hosted-smoke-terminal"
     depends_on:
+      - step: "gha-producer"
+        allow_failure: true
       - step: "gha-consumer-5ebbc197d87b"
         allow_failure: true
       - step: "gha-consumer-91934b28b00f"
+        allow_failure: true
+      - step: "gha-concurrent"
         allow_failure: true
       - step: "gha-observe"
         allow_failure: true
@@ -26,4 +30,30 @@ steps:
         allow_failure: true
     agents:
       queue: "elastic-runners"
-    command: "echo 'All hosted smoke targets settled'"
+    command: |
+      set -euo pipefail
+      failed=0
+      for step in \
+        gha-producer \
+        gha-consumer-5ebbc197d87b \
+        gha-consumer-91934b28b00f \
+        gha-concurrent \
+        gha-observe \
+        gha-public-actions \
+        phase-5-hosted-docker-probe \
+        gha-docker-action \
+        phase-2-native-after-shell \
+        phase-3-native-after-concurrent \
+        phase-4-native-after-actions \
+        phase-5-native-after-hosted-docker \
+        phase-5-native-after-docker-action
+      do
+        outcome="$$(buildkite-agent step get "outcome" --step "$$step")"
+        printf '%s: %s\n' "$$step" "$$outcome"
+        [[ "$$outcome" == passed ]] || failed=1
+      done
+      if (( failed != 0 )); then
+        echo 'One or more hosted smoke targets failed' >&2
+        exit 1
+      fi
+      echo 'All hosted smoke targets passed'

--- a/.buildkite/hosted-smoke-aggregator.yml
+++ b/.buildkite/hosted-smoke-aggregator.yml
@@ -1,0 +1,29 @@
+steps:
+  - label: ":white_check_mark: Hosted smoke targets settled"
+    key: "hosted-smoke-terminal"
+    depends_on:
+      - step: "gha-consumer-5ebbc197d87b"
+        allow_failure: true
+      - step: "gha-consumer-91934b28b00f"
+        allow_failure: true
+      - step: "gha-observe"
+        allow_failure: true
+      - step: "gha-public-actions"
+        allow_failure: true
+      - step: "phase-5-hosted-docker-probe"
+        allow_failure: true
+      - step: "gha-docker-action"
+        allow_failure: true
+      - step: "phase-2-native-after-shell"
+        allow_failure: true
+      - step: "phase-3-native-after-concurrent"
+        allow_failure: true
+      - step: "phase-4-native-after-actions"
+        allow_failure: true
+      - step: "phase-5-native-after-hosted-docker"
+        allow_failure: true
+      - step: "phase-5-native-after-docker-action"
+        allow_failure: true
+    agents:
+      queue: "elastic-runners"
+    command: "echo 'All hosted smoke targets settled'"

--- a/.buildkite/hosted-smoke-control.yml
+++ b/.buildkite/hosted-smoke-control.yml
@@ -1,0 +1,17 @@
+steps:
+  - label: ":pipeline: Load hosted smoke aggregator"
+    key: "hosted-smoke-aggregator-loader"
+    depends_on:
+      - step: "phase-2-continuation-loader"
+        allow_failure: true
+      - step: "phase-3-continuation-loader"
+        allow_failure: true
+      - step: "phase-4-continuation-loader"
+        allow_failure: true
+      - step: "phase-5-continuation-loader"
+        allow_failure: true
+      - step: "phase-5-docker-action-continuation-loader"
+        allow_failure: true
+    agents:
+      queue: "elastic-runners"
+    command: "buildkite-agent pipeline upload .buildkite/hosted-smoke-aggregator.yml"

--- a/.buildkite/phase-2-upload.yml
+++ b/.buildkite/phase-2-upload.yml
@@ -8,7 +8,8 @@ steps:
           version: "2026.5.12"
     command: |
       set -euo pipefail
-      scripts/phase-0-shell-oracle-checkout "$$PHASE2_COMMIT"
+      commit="$${PHASE2_COMMIT:-$${SMOKE_COMMIT:-}}"
+      scripts/phase-0-shell-oracle-checkout "$$commit"
       distribution_root="$$(mktemp -d "$${TMPDIR:-/tmp}/buildkite-gha-phase2.XXXXXXXX")"
       trap 'rm -rf -- "$$distribution_root"' EXIT
       mise exec -- go build -trimpath -buildvcs=false -o "$$distribution_root/buildkite-gha" ./cmd/buildkite-gha
@@ -20,6 +21,7 @@ steps:
   - label: ":pipeline: Phase 2 continuation loader"
     key: "phase-2-continuation-loader"
     depends_on: "phase-2-upload-importer"
+    allow_dependency_failure: true
     agents:
       queue: "elastic-runners"
     command: "buildkite-agent pipeline upload .buildkite/phase-2-upload-continuation.yml"

--- a/.buildkite/phase-3-upload.yml
+++ b/.buildkite/phase-3-upload.yml
@@ -8,7 +8,8 @@ steps:
           version: "2026.5.12"
     command: |
       set -euo pipefail
-      scripts/phase-0-shell-oracle-checkout "$$PHASE3_COMMIT"
+      commit="$${PHASE3_COMMIT:-$${SMOKE_COMMIT:-}}"
+      scripts/phase-0-shell-oracle-checkout "$$commit"
       distribution_root="$$(mktemp -d "$${TMPDIR:-/tmp}/buildkite-gha-phase3.XXXXXXXX")"
       trap 'rm -rf -- "$$distribution_root"' EXIT
       mise exec -- go build -trimpath -buildvcs=false -o "$$distribution_root/buildkite-gha" ./cmd/buildkite-gha
@@ -20,6 +21,7 @@ steps:
   - label: ":pipeline: Phase 3 continuation loader"
     key: "phase-3-continuation-loader"
     depends_on: "phase-3-upload-importer"
+    allow_dependency_failure: true
     agents:
       queue: "elastic-runners"
     command: "buildkite-agent pipeline upload .buildkite/phase-3-upload-continuation.yml"

--- a/.buildkite/phase-4-upload.yml
+++ b/.buildkite/phase-4-upload.yml
@@ -8,11 +8,12 @@ steps:
           version: "2026.5.12"
     command: |
       set -euo pipefail
-      scripts/phase-0-shell-oracle-checkout "$$PHASE4_COMMIT"
+      commit="$${PHASE4_COMMIT:-$${SMOKE_COMMIT:-}}"
+      scripts/phase-0-shell-oracle-checkout "$$commit"
       test -z "$$(git status --porcelain --untracked-files=all)"
       distribution_root="$$(mktemp -d "$${TMPDIR:-/tmp}/buildkite-gha-phase4.XXXXXXXX")"
       trap 'rm -rf -- "$$distribution_root"' EXIT
-      runtime_version="0.0.0-phase4.$${PHASE4_COMMIT}"
+      runtime_version="0.0.0-phase4.$$commit"
       mise exec -- go build -trimpath -buildvcs=false -ldflags "-X main.version=$$runtime_version" -o "$$distribution_root/buildkite-gha" ./cmd/buildkite-gha
       BUILDKITE_GHA_NODE20="$$(mise where node@20)/bin/node" \
       BUILDKITE_GHA_NODE24="$$(mise where node@24)/bin/node" \

--- a/.buildkite/phase-5-capabilities.yml
+++ b/.buildkite/phase-5-capabilities.yml
@@ -5,7 +5,8 @@ steps:
       queue: "elastic-runners"
     command: |
       set -euo pipefail
-      scripts/phase-0-shell-oracle-checkout "$$PHASE5_COMMIT"
+      commit="$${PHASE5_COMMIT:-$${SMOKE_COMMIT:-}}"
+      scripts/phase-0-shell-oracle-checkout "$$commit"
       test -z "$$(git status --porcelain --untracked-files=all)"
       buildkite-agent pipeline upload --no-interpolation --reject-secrets .buildkite/phase-5-hosted-probe.yml
 

--- a/.buildkite/phase-5-docker-action.yml
+++ b/.buildkite/phase-5-docker-action.yml
@@ -11,14 +11,15 @@ steps:
           version: "2026.5.12"
     command: |
       set -euo pipefail
-      scripts/phase-0-shell-oracle-checkout "$$PHASE5_COMMIT"
+      commit="$${PHASE5_COMMIT:-$${SMOKE_COMMIT:-}}"
+      scripts/phase-0-shell-oracle-checkout "$$commit"
       test -z "$$(git status --porcelain --untracked-files=all)"
       proof_root="$$(mktemp -d "$${TMPDIR:-/tmp}/buildkite-gha-phase5-action.XXXXXXXX")"
       trap 'rm -rf -- "$$proof_root"' EXIT
       mkdir -p "$$proof_root/.github/workflows"
       cp testdata/phase5/.github/workflows/docker-action.yml.tmpl \
         "$$proof_root/.github/workflows/docker-action.yml"
-      runtime_version="0.0.0-phase5.$${PHASE5_COMMIT}"
+      runtime_version="0.0.0-phase5.$$commit"
       mise exec -- go build -trimpath -buildvcs=false -ldflags "-X main.version=$$runtime_version" -o "$$proof_root/buildkite-gha" ./cmd/buildkite-gha
       BUILDKITE_GHA_NODE20="$$(mise where node@20)/bin/node" \
       BUILDKITE_GHA_NODE24="$$(mise where node@24)/bin/node" \

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,36 +15,55 @@ steps:
 
   - label: ":pipeline: Load Phase 2 upload proof"
     key: "phase-2-upload-loader"
-    if: build.env("PHASE2_PROBE") == "upload"
+    if: build.env("PHASE2_PROBE") == "upload" && build.env("SMOKE_PROBE") != "hosted"
     command: "buildkite-agent pipeline upload .buildkite/phase-2-upload.yml"
     agents:
       queue: "elastic-runners"
 
   - label: ":pipeline: Load Phase 3 concurrent proof"
     key: "phase-3-upload-loader"
-    if: build.env("PHASE3_PROBE") == "concurrent"
+    if: build.env("PHASE3_PROBE") == "concurrent" && build.env("SMOKE_PROBE") != "hosted"
     command: "buildkite-agent pipeline upload .buildkite/phase-3-upload.yml"
     agents:
       queue: "elastic-runners"
 
   - label: ":pipeline: Load Phase 4 actions proof"
     key: "phase-4-upload-loader"
-    if: build.env("PHASE4_PROBE") == "actions"
+    if: build.env("PHASE4_PROBE") == "actions" && build.env("SMOKE_PROBE") != "hosted"
     command: "buildkite-agent pipeline upload .buildkite/phase-4-upload.yml"
     agents:
       queue: "elastic-runners"
 
   - label: ":docker: Load Phase 5 hosted Docker probe"
     key: "phase-5-capabilities-loader"
-    if: build.env("PHASE5_PROBE") == "capabilities"
+    if: build.env("PHASE5_PROBE") == "capabilities" && build.env("SMOKE_PROBE") != "hosted"
     command: "buildkite-agent pipeline upload .buildkite/phase-5-capabilities.yml"
     agents:
       queue: "elastic-runners"
 
   - label: ":docker: Load Phase 5 Dockerfile action proof"
     key: "phase-5-docker-action-loader"
-    if: build.env("PHASE5_PROBE") == "docker-action"
+    if: build.env("PHASE5_PROBE") == "docker-action" && build.env("SMOKE_PROBE") != "hosted"
     command: "buildkite-agent pipeline upload .buildkite/phase-5-docker-action.yml"
+    agents:
+      queue: "elastic-runners"
+
+  - label: ":pipeline: Load consolidated hosted smoke proof"
+    key: "hosted-smoke-loader"
+    if: build.env("SMOKE_PROBE") == "hosted"
+    command: |
+      set -euo pipefail
+      commit="$${SMOKE_COMMIT:?SMOKE_COMMIT is required}"
+      [[ "$$commit" =~ ^[0-9a-f]{40}$$ ]]
+      scripts/phase-0-shell-oracle-checkout "$$commit"
+      test "$${BUILDKITE_COMMIT:?BUILDKITE_COMMIT is required}" = "$$commit"
+      test -z "$$(git status --porcelain --untracked-files=all)"
+      buildkite-agent pipeline upload .buildkite/phase-2-upload.yml
+      buildkite-agent pipeline upload .buildkite/phase-3-upload.yml
+      buildkite-agent pipeline upload .buildkite/phase-4-upload.yml
+      buildkite-agent pipeline upload .buildkite/phase-5-capabilities.yml
+      buildkite-agent pipeline upload .buildkite/phase-5-docker-action.yml
+      buildkite-agent pipeline upload .buildkite/hosted-smoke-control.yml
     agents:
       queue: "elastic-runners"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -55,6 +55,17 @@ steps:
       set -euo pipefail
       commit="$${SMOKE_COMMIT:?SMOKE_COMMIT is required}"
       [[ "$$commit" =~ ^[0-9a-f]{40}$$ ]]
+      for phase_commit in \
+        "$${PHASE2_COMMIT:-}" \
+        "$${PHASE3_COMMIT:-}" \
+        "$${PHASE4_COMMIT:-}" \
+        "$${PHASE5_COMMIT:-}"
+      do
+        [[ -z "$$phase_commit" || "$$phase_commit" == "$$commit" ]] || {
+          echo "phase-specific commit $$phase_commit conflicts with SMOKE_COMMIT" >&2
+          exit 1
+        }
+      done
       scripts/phase-0-shell-oracle-checkout "$$commit"
       test "$${BUILDKITE_COMMIT:?BUILDKITE_COMMIT is required}" = "$$commit"
       test -z "$$(git status --porcelain --untracked-files=all)"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,6 @@
+env:
+  MISE_JOBS: "1"
+
 steps:
   - label: ":test_tube: Load Phase 0 shell oracle"
     key: "phase-0-shell-oracle-loader"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Buildkite pipeline.
 The current command surface is:
 
 ```text
-buildkite-gha validate [--event-path <path>] [--format text|json] <workflow>
+buildkite-gha validate [--event-path <path>] [--profile hosted-tokenless] [--format text|json] <workflow>
 buildkite-gha compile --event-path <path> [--format pipeline|ir-json] <workflow>
 buildkite-gha upload --event-path <path> --runtime-queue hosted <workflow>
 buildkite-gha run-job --plan <path> [--result <path>]
@@ -137,6 +137,63 @@ mise run check
 The command verifies formatting, builds the commands, runs the standard and
 race-enabled tests, runs `go vet`, golangci-lint, and shellcheck, and checks the
 signed plan-envelope fixtures. `make check` remains as a convenience alias.
+
+### Smoke and compatibility preflight
+
+Run the network-free smoke inventory with:
+
+```sh
+mise run smoke:local
+```
+
+This validates the manifest, performs static workflow validation, and compiles
+the supported fixtures twice to verify deterministic output. It also checks
+the expected-negative classifications: workflows using the official GitHub
+artifact and cache actions compile, while job and service containers fail
+static compilation. A passing local smoke run is compile-time evidence only;
+it is explicitly not proof that a workflow runs successfully.
+
+For an opt-in public-network preflight, run:
+
+```sh
+mise run smoke:profile
+```
+
+This anonymously resolves the selected public actions, prepares the managed
+Node runtimes, and applies the same `hosted-tokenless` production admission
+policy used by `upload`. The known official artifact and cache actions compile
+but fail admission until the Phase 6 adapters exist. An `admitted` result is
+not runtime proof and does not imply that an arbitrary admitted action is
+executable or independent of GitHub-only services.
+
+Use the same policy as a focused workflow compatibility preflight, with either
+human-readable or machine-readable output:
+
+```sh
+buildkite-gha validate --profile hosted-tokenless \
+  --event-path .buildkite/events/current.json --format text \
+  .github/workflows/ci.yml
+
+buildkite-gha validate --profile hosted-tokenless \
+  --event-path .buildkite/events/current.json --format json \
+  .github/workflows/ci.yml
+```
+
+To aggregate the implemented hosted runtime proofs in one exact-commit build:
+
+```sh
+commit=$(git rev-parse HEAD)
+test ${#commit} -eq 40
+bk build create --pipeline buildkite/buildkite-gha \
+  --branch "$(git branch --show-current)" --commit "$commit" \
+  --env SMOKE_PROBE=hosted --env SMOKE_COMMIT="$commit" --yes
+```
+
+The aggregate collects the Phase 2 shell/upload proof, Phase 3 concurrent-step
+proof, Phase 4 public-action proof, and both Phase 5 Docker proofs (hosted Docker
+capabilities and the Dockerfile action). It retains each phase's independent
+importer and continuation loader rather than flattening their topology. The
+phase-specific selectors below remain available for targeted diagnosis.
 
 The gated live development proof uses the same pinned mise plugin as repository
 checks. Start an exact-commit build with `PHASE2_PROBE=upload` and

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -1265,6 +1265,29 @@ Explicitly defer from beta unless implementation evidence changes the order:
   pipeline validation pass. A default `.buildkite/pipeline.yml` now runs the
   repository checks, and all four smoke compiler outputs pass the current
   Buildkite Agent's `pipeline upload --dry-run --no-interpolation` parser.
+- The smoke inventory now separates compilation, production-policy admission,
+  and runtime evidence. `mise run smoke:local` is network-free: it validates
+  the manifest and workflows and checks deterministic compilation, but is not
+  runtime proof. `mise run smoke:profile` opts into public-network action
+  resolution and managed-runtime preparation, then applies the same
+  `hosted-tokenless` admission policy as production upload. An `admitted`
+  result is still not runtime proof and does not establish that a generic
+  action can execute without an unimplemented GitHub service.
+- The profile is also exposed as the text/JSON workflow preflight
+  `buildkite-gha validate --profile hosted-tokenless --event-path <path>
+  --format text|json <workflow>`. Expected-negative fixtures preserve current
+  boundaries: official GitHub artifact/cache actions compile but are denied
+  admission pending Phase 6, while job and service containers fail static
+  compilation.
+- A consolidated exact-commit hosted dispatcher is available with
+  `SMOKE_PROBE=hosted` and `SMOKE_COMMIT=<full commit>`. It aggregates the
+  Phase 2 shell/upload, Phase 3 concurrent, Phase 4 public-action, Phase 5
+  hosted-Docker capability, and Phase 5 Dockerfile-action proofs. The dispatcher
+  deliberately uploads each existing importer and continuation independently,
+  then settles their generated and native terminal steps; it does not flatten
+  the importer/continuation topology. Existing `PHASE2_PROBE`, `PHASE3_PROBE`,
+  `PHASE4_PROBE`, and both `PHASE5_PROBE` selectors remain available for
+  targeted runs.
 
 Phase 4 live evidence:
 
@@ -1739,6 +1762,48 @@ separate compatibility projects with their own host, shell, path, and container
 semantics.
 
 ## Test strategy
+
+### Smoke and manual admission lanes
+
+The checked-in smoke manifest is a classified inventory, not a claim that
+arbitrary common workflows are supported. The required local gate is
+`mise run smoke:local`; it uses no network, performs manifest and static
+validation, and compares two nonempty compilations byte-for-byte. Compilation
+success is never runtime evidence. Its expected-negative fixtures require job
+and service containers to remain compile-time incompatible at the current
+boundary.
+
+`mise run smoke:profile` is an opt-in networked lane. It resolves anonymous
+public action sources, prepares the pinned managed Node runtimes, compiles the
+plans, and evaluates the production `hosted-tokenless` admission policy. The
+equivalent operator-facing preflight is:
+
+```bash
+buildkite-gha validate --profile hosted-tokenless \
+  --event-path <event.json> --format text|json <workflow.yml>
+```
+
+Admission is policy evidence, not execution evidence. In particular, known
+official artifact and cache actions compile but must be rejected until Phase 6
+provides their service adapters. Unknown generic action dependencies are not
+declared executable merely because the profile admits them.
+
+The manual hosted aggregate is dispatched against one exact full commit:
+
+```bash
+commit=$(git rev-parse HEAD)
+test ${#commit} -eq 40
+bk build create --pipeline buildkite/buildkite-gha \
+  --branch "$(git branch --show-current)" --commit "$commit" \
+  --env SMOKE_PROBE=hosted --env SMOKE_COMMIT="$commit" --yes
+```
+
+It gathers Phase 2 shell/upload, Phase 3 concurrency, Phase 4 public actions,
+and both Phase 5 Docker proofs in one build. Each phase still owns an independent
+importer and continuation loader; a final aggregate waits for all generated and
+native terminal evidence, including failures, without changing those security
+or dependency boundaries. Keep the phase-specific selectors for focused
+reruns and fault isolation.
 
 ### Initial checked-in corpus
 

--- a/internal/action/metadata/metadata.go
+++ b/internal/action/metadata/metadata.go
@@ -28,19 +28,27 @@ type Metadata struct {
 	Inputs      map[string]Input  `yaml:"inputs"`
 	Outputs     map[string]Output `yaml:"outputs"`
 	Runs        Runs              `yaml:"runs"`
+	Branding    Branding          `yaml:"branding"`
 }
 
 // Input declares one action input.
 type Input struct {
-	Description string  `yaml:"description"`
-	Required    bool    `yaml:"required"`
-	Default     *string `yaml:"default"`
+	Description        string  `yaml:"description"`
+	DeprecationMessage string  `yaml:"deprecationMessage"`
+	Required           bool    `yaml:"required"`
+	Default            *string `yaml:"default"`
 }
 
 // Output declares one action output.
 type Output struct {
 	Description string `yaml:"description"`
 	Value       string `yaml:"value"`
+}
+
+// Branding declares inert Marketplace presentation metadata.
+type Branding struct {
+	Icon  string `yaml:"icon"`
+	Color string `yaml:"color"`
 }
 
 // Runs declares how an action executes.

--- a/internal/action/metadata/metadata_test.go
+++ b/internal/action/metadata/metadata_test.go
@@ -111,13 +111,19 @@ func TestValidateDockerEntrypoints(t *testing.T) {
 func TestLoadIsStrictAndConfined(t *testing.T) {
 	t.Run("official declarative fields", func(t *testing.T) {
 		root := t.TempDir()
-		writeAction(t, root, "action.yml", "name: Setup tool\ndescription: Installs a tool\nauthor: GitHub\nruns:\n  using: node24\n  main: dist/index.js\n")
+		writeAction(t, root, "action.yml", "name: Setup tool\ndescription: Installs a tool\nauthor: GitHub\ninputs:\n  version:\n    deprecationMessage: Use version-file instead\nbranding:\n  icon: package\n  color: blue\nruns:\n  using: node24\n  main: dist/index.js\n")
 		action, err := Load(root, ".")
 		if err != nil {
 			t.Fatal(err)
 		}
 		if action.Author != "GitHub" {
 			t.Fatalf("Load() author = %q, want GitHub", action.Author)
+		}
+		if action.Inputs["version"].DeprecationMessage != "Use version-file instead" {
+			t.Fatalf("Load() deprecation message = %q", action.Inputs["version"].DeprecationMessage)
+		}
+		if action.Branding.Icon != "package" || action.Branding.Color != "blue" {
+			t.Fatalf("Load() branding = %#v", action.Branding)
 		}
 	})
 
@@ -126,6 +132,14 @@ func TestLoadIsStrictAndConfined(t *testing.T) {
 		writeAction(t, root, "action.yml", "unexpected: true\nruns:\n  using: node24\n")
 		if _, err := Load(root, "."); err == nil || !strings.Contains(err.Error(), "field unexpected not found") {
 			t.Fatalf("Load() error = %v, want unknown field rejection", err)
+		}
+	})
+
+	t.Run("unknown nested field", func(t *testing.T) {
+		root := t.TempDir()
+		writeAction(t, root, "action.yml", "branding:\n  unexpected: true\nruns:\n  using: node24\n")
+		if _, err := Load(root, "."); err == nil || !strings.Contains(err.Error(), "field unexpected not found") {
+			t.Fatalf("Load() error = %v, want nested unknown field rejection", err)
 		}
 	})
 

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -257,6 +257,12 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 	for _, required := range []string{
 		`commit="$${SMOKE_COMMIT:?SMOKE_COMMIT is required}"`,
 		`[[ "$$commit" =~ ^[0-9a-f]{40}$$ ]]`,
+		`"$${PHASE2_COMMIT:-}"`,
+		`"$${PHASE3_COMMIT:-}"`,
+		`"$${PHASE4_COMMIT:-}"`,
+		`"$${PHASE5_COMMIT:-}"`,
+		`[[ -z "$$phase_commit" || "$$phase_commit" == "$$commit" ]]`,
+		`phase-specific commit $$phase_commit conflicts with SMOKE_COMMIT`,
 		`scripts/phase-0-shell-oracle-checkout "$$commit"`,
 		`test "$${BUILDKITE_COMMIT:?BUILDKITE_COMMIT is required}" = "$$commit"`,
 		`git status --porcelain --untracked-files=all`,
@@ -725,14 +731,29 @@ func TestHostedSmokeControlAndAggregatorDependencies(t *testing.T) {
 	for key := range generated {
 		want[key] = true
 	}
-	for _, key := range []string{"phase-2-native-after-shell", "phase-3-native-after-concurrent", "phase-4-native-after-actions", "phase-5-native-after-hosted-docker", "phase-5-native-after-docker-action"} {
+	for _, key := range []string{"gha-producer", "gha-concurrent", "phase-2-native-after-shell", "phase-3-native-after-concurrent", "phase-4-native-after-actions", "phase-5-native-after-hosted-docker", "phase-5-native-after-docker-action"} {
 		want[key] = true
 	}
 	aggregator := read("hosted-smoke-aggregator.yml")
-	if aggregator.Key != "hosted-smoke-terminal" || aggregator.Agents.Queue != "elastic-runners" || aggregator.Command != "echo 'All hosted smoke targets settled'" {
+	if aggregator.Key != "hosted-smoke-terminal" || aggregator.Agents.Queue != "elastic-runners" {
 		t.Fatalf("aggregator step = %#v", aggregator)
 	}
 	assertSet("aggregator", aggregator.DependsOn, want)
+	for key := range generated {
+		if !strings.Contains(aggregator.Command, key) {
+			t.Fatalf("aggregator command does not inspect generated step %q: %s", key, aggregator.Command)
+		}
+	}
+	for _, key := range []string{"gha-producer", "gha-concurrent", "phase-2-native-after-shell", "phase-3-native-after-concurrent", "phase-4-native-after-actions", "phase-5-native-after-hosted-docker", "phase-5-native-after-docker-action"} {
+		if !strings.Contains(aggregator.Command, key) {
+			t.Fatalf("aggregator command does not inspect required step %q: %s", key, aggregator.Command)
+		}
+	}
+	for _, fragment := range []string{`buildkite-agent step get "outcome"`, `[[ "$$outcome" == passed ]] || failed=1`, `exit 1`, `All hosted smoke targets passed`} {
+		if !strings.Contains(aggregator.Command, fragment) {
+			t.Fatalf("aggregator command lacks %q: %s", fragment, aggregator.Command)
+		}
+	}
 }
 
 func TestPlanPathIsContentAddressed(t *testing.T) {

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -199,6 +199,7 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 		t.Fatal(err)
 	}
 	var document struct {
+		Env   map[string]string `yaml:"env"`
 		Steps []struct {
 			Key     string `yaml:"key"`
 			Command string `yaml:"command"`
@@ -210,6 +211,9 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 	}
 	if err := yaml.Unmarshal(source, &document); err != nil {
 		t.Fatalf("parse default pipeline: %v", err)
+	}
+	if document.Env["MISE_JOBS"] != "1" {
+		t.Fatalf("default pipeline MISE_JOBS = %q, want serial tool installation", document.Env["MISE_JOBS"])
 	}
 	if len(document.Steps) != 9 {
 		t.Fatalf("default pipeline = %#v, want eight gated loaders plus repository checks", document.Steps)

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -203,23 +203,28 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 			Key     string `yaml:"key"`
 			Command string `yaml:"command"`
 			If      string `yaml:"if"`
+			Agents  struct {
+				Queue string `yaml:"queue"`
+			} `yaml:"agents"`
 		} `yaml:"steps"`
 	}
 	if err := yaml.Unmarshal(source, &document); err != nil {
 		t.Fatalf("parse default pipeline: %v", err)
 	}
-	if len(document.Steps) != 8 {
-		t.Fatalf("default pipeline = %#v, want seven gated loaders plus repository checks", document.Steps)
+	if len(document.Steps) != 9 {
+		t.Fatalf("default pipeline = %#v, want eight gated loaders plus repository checks", document.Steps)
 	}
 	steps := make(map[string]struct {
 		command   string
 		condition string
+		queue     string
 	}, len(document.Steps))
 	for _, step := range document.Steps {
 		steps[step.Key] = struct {
 			command   string
 			condition string
-		}{step.Command, step.If}
+			queue     string
+		}{step.Command, step.If, step.Agents.Queue}
 	}
 	if got := steps["checks"]; got.command != "mise run --jobs 1 check" || got.condition != "" {
 		t.Fatalf("repository checks = %#v", got)
@@ -230,20 +235,43 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 	if got := steps["phase-0-transport-probe-loader"]; got.command != "buildkite-agent pipeline upload .buildkite/phase-0-transport-probe/pipeline.yml" || got.condition != `build.env("PHASE0_PROBE") == "transport"` {
 		t.Fatalf("transport probe loader = %#v", got)
 	}
-	if got := steps["phase-2-upload-loader"]; got.command != "buildkite-agent pipeline upload .buildkite/phase-2-upload.yml" || got.condition != `build.env("PHASE2_PROBE") == "upload"` {
+	if got := steps["phase-2-upload-loader"]; got.command != "buildkite-agent pipeline upload .buildkite/phase-2-upload.yml" || got.condition != `build.env("PHASE2_PROBE") == "upload" && build.env("SMOKE_PROBE") != "hosted"` {
 		t.Fatalf("Phase 2 upload loader = %#v", got)
 	}
-	if got := steps["phase-3-upload-loader"]; got.command != "buildkite-agent pipeline upload .buildkite/phase-3-upload.yml" || got.condition != `build.env("PHASE3_PROBE") == "concurrent"` {
+	if got := steps["phase-3-upload-loader"]; got.command != "buildkite-agent pipeline upload .buildkite/phase-3-upload.yml" || got.condition != `build.env("PHASE3_PROBE") == "concurrent" && build.env("SMOKE_PROBE") != "hosted"` {
 		t.Fatalf("Phase 3 upload loader = %#v", got)
 	}
-	if got := steps["phase-4-upload-loader"]; got.command != "buildkite-agent pipeline upload .buildkite/phase-4-upload.yml" || got.condition != `build.env("PHASE4_PROBE") == "actions"` {
+	if got := steps["phase-4-upload-loader"]; got.command != "buildkite-agent pipeline upload .buildkite/phase-4-upload.yml" || got.condition != `build.env("PHASE4_PROBE") == "actions" && build.env("SMOKE_PROBE") != "hosted"` {
 		t.Fatalf("Phase 4 upload loader = %#v", got)
 	}
-	if got := steps["phase-5-capabilities-loader"]; got.command != "buildkite-agent pipeline upload .buildkite/phase-5-capabilities.yml" || got.condition != `build.env("PHASE5_PROBE") == "capabilities"` {
+	if got := steps["phase-5-capabilities-loader"]; got.command != "buildkite-agent pipeline upload .buildkite/phase-5-capabilities.yml" || got.condition != `build.env("PHASE5_PROBE") == "capabilities" && build.env("SMOKE_PROBE") != "hosted"` {
 		t.Fatalf("Phase 5 capability loader = %#v", got)
 	}
-	if got := steps["phase-5-docker-action-loader"]; got.command != "buildkite-agent pipeline upload .buildkite/phase-5-docker-action.yml" || got.condition != `build.env("PHASE5_PROBE") == "docker-action"` {
+	if got := steps["phase-5-docker-action-loader"]; got.command != "buildkite-agent pipeline upload .buildkite/phase-5-docker-action.yml" || got.condition != `build.env("PHASE5_PROBE") == "docker-action" && build.env("SMOKE_PROBE") != "hosted"` {
 		t.Fatalf("Phase 5 Dockerfile action loader = %#v", got)
+	}
+	hosted := steps["hosted-smoke-loader"]
+	if hosted.condition != `build.env("SMOKE_PROBE") == "hosted"` || hosted.queue != "elastic-runners" {
+		t.Fatalf("hosted smoke loader = %#v", hosted)
+	}
+	for _, required := range []string{
+		`commit="$${SMOKE_COMMIT:?SMOKE_COMMIT is required}"`,
+		`[[ "$$commit" =~ ^[0-9a-f]{40}$$ ]]`,
+		`scripts/phase-0-shell-oracle-checkout "$$commit"`,
+		`test "$${BUILDKITE_COMMIT:?BUILDKITE_COMMIT is required}" = "$$commit"`,
+		`git status --porcelain --untracked-files=all`,
+	} {
+		if !strings.Contains(hosted.command, required) {
+			t.Fatalf("hosted smoke loader lacks %q:\n%s", required, hosted.command)
+		}
+	}
+	for _, fragment := range []string{"phase-2-upload.yml", "phase-3-upload.yml", "phase-4-upload.yml", "phase-5-capabilities.yml", "phase-5-docker-action.yml", "hosted-smoke-control.yml"} {
+		if count := strings.Count(hosted.command, "buildkite-agent pipeline upload .buildkite/"+fragment); count != 1 {
+			t.Fatalf("hosted smoke loader uploads %s %d times:\n%s", fragment, count, hosted.command)
+		}
+	}
+	if strings.Contains(hosted.command, "--replace") {
+		t.Fatalf("hosted smoke loader uses replacement upload:\n%s", hosted.command)
 	}
 }
 
@@ -254,7 +282,8 @@ func TestPhase2UploadProofUsesPinnedUnprivilegedPath(t *testing.T) {
 	}
 	text := string(source)
 	for _, required := range []string{
-		`scripts/phase-0-shell-oracle-checkout "$$PHASE2_COMMIT"`,
+		`commit="$${PHASE2_COMMIT:-$${SMOKE_COMMIT:-}}"`,
+		`scripts/phase-0-shell-oracle-checkout "$$commit"`,
 		`mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2`,
 		`mise exec -- go build -trimpath -buildvcs=false`,
 		`--event-path testdata/smoke/events/push.json`,
@@ -267,10 +296,11 @@ func TestPhase2UploadProofUsesPinnedUnprivilegedPath(t *testing.T) {
 	}
 	var document struct {
 		Steps []struct {
-			Key       string `yaml:"key"`
-			Command   string `yaml:"command"`
-			DependsOn string `yaml:"depends_on"`
-			Agents    struct {
+			Key                    string `yaml:"key"`
+			Command                string `yaml:"command"`
+			DependsOn              string `yaml:"depends_on"`
+			AllowDependencyFailure bool   `yaml:"allow_dependency_failure"`
+			Agents                 struct {
 				Queue string `yaml:"queue"`
 			} `yaml:"agents"`
 		} `yaml:"steps"`
@@ -281,7 +311,7 @@ func TestPhase2UploadProofUsesPinnedUnprivilegedPath(t *testing.T) {
 	if len(document.Steps) != 2 || document.Steps[0].Key != "phase-2-upload-importer" || document.Steps[0].Agents.Queue != "elastic-runners" {
 		t.Fatalf("Phase 2 upload proof = %#v", document.Steps)
 	}
-	if document.Steps[1].Key != "phase-2-continuation-loader" || document.Steps[1].DependsOn != "phase-2-upload-importer" || document.Steps[1].Agents.Queue != "elastic-runners" || document.Steps[1].Command != "buildkite-agent pipeline upload .buildkite/phase-2-upload-continuation.yml" {
+	if document.Steps[1].Key != "phase-2-continuation-loader" || document.Steps[1].DependsOn != "phase-2-upload-importer" || !document.Steps[1].AllowDependencyFailure || document.Steps[1].Agents.Queue != "elastic-runners" || document.Steps[1].Command != "buildkite-agent pipeline upload .buildkite/phase-2-upload-continuation.yml" {
 		t.Fatalf("Phase 2 continuation loader = %#v", document.Steps[1])
 	}
 
@@ -350,7 +380,8 @@ func TestPhase3UploadProofPreservesSeparateContinuationLoader(t *testing.T) {
 	}
 	text := string(source)
 	for _, required := range []string{
-		`scripts/phase-0-shell-oracle-checkout "$$PHASE3_COMMIT"`,
+		`commit="$${PHASE3_COMMIT:-$${SMOKE_COMMIT:-}}"`,
+		`scripts/phase-0-shell-oracle-checkout "$$commit"`,
 		`mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2`,
 		`mise exec -- go build -trimpath -buildvcs=false`,
 		`--event-path testdata/smoke/events/push.json`,
@@ -363,9 +394,10 @@ func TestPhase3UploadProofPreservesSeparateContinuationLoader(t *testing.T) {
 	}
 	var upload struct {
 		Steps []struct {
-			Key       string `yaml:"key"`
-			Command   string `yaml:"command"`
-			DependsOn string `yaml:"depends_on"`
+			Key                    string `yaml:"key"`
+			Command                string `yaml:"command"`
+			DependsOn              string `yaml:"depends_on"`
+			AllowDependencyFailure bool   `yaml:"allow_dependency_failure"`
 		} `yaml:"steps"`
 	}
 	if err := yaml.Unmarshal(source, &upload); err != nil {
@@ -374,7 +406,7 @@ func TestPhase3UploadProofPreservesSeparateContinuationLoader(t *testing.T) {
 	if len(upload.Steps) != 2 || upload.Steps[0].Key != "phase-3-upload-importer" {
 		t.Fatalf("Phase 3 upload proof = %#v", upload.Steps)
 	}
-	if upload.Steps[1].Key != "phase-3-continuation-loader" || upload.Steps[1].DependsOn != "phase-3-upload-importer" || upload.Steps[1].Command != "buildkite-agent pipeline upload .buildkite/phase-3-upload-continuation.yml" {
+	if upload.Steps[1].Key != "phase-3-continuation-loader" || upload.Steps[1].DependsOn != "phase-3-upload-importer" || !upload.Steps[1].AllowDependencyFailure || upload.Steps[1].Command != "buildkite-agent pipeline upload .buildkite/phase-3-upload-continuation.yml" {
 		t.Fatalf("Phase 3 continuation loader = %#v", upload.Steps[1])
 	}
 
@@ -432,11 +464,12 @@ func TestPhase4UploadProofUsesTrustedManagedActionsPath(t *testing.T) {
 		t.Fatalf("Phase 4 public checkout identity drifted: event=%#v workflow=%s", publicEvent, workflowSource)
 	}
 	for _, required := range []string{
-		`scripts/phase-0-shell-oracle-checkout "$$PHASE4_COMMIT"`,
+		`commit="$${PHASE4_COMMIT:-$${SMOKE_COMMIT:-}}"`,
+		`scripts/phase-0-shell-oracle-checkout "$$commit"`,
 		`test -z "$$(git status --porcelain --untracked-files=all)"`,
 		`mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2`,
 		`version: "2026.5.12"`,
-		`runtime_version="0.0.0-phase4.$${PHASE4_COMMIT}"`,
+		`runtime_version="0.0.0-phase4.$$commit"`,
 		`go build -trimpath -buildvcs=false -ldflags "-X main.version=$$runtime_version"`,
 		`BUILDKITE_GHA_NODE20="$$(mise where node@20)/bin/node"`,
 		`BUILDKITE_GHA_NODE24="$$(mise where node@24)/bin/node"`,
@@ -531,7 +564,8 @@ func TestPhase5HostedDockerCapabilityProbeContract(t *testing.T) {
 	if len(importer) != 2 || importer[0].Key != "phase-5-capabilities-importer" || importer[0].Agents.Queue != "elastic-runners" || importer[1].Key != "phase-5-continuation-loader" || importer[1].Agents.Queue != "elastic-runners" || fmt.Sprint(importer[1].DependsOn) != "phase-5-capabilities-importer" || !importer[1].AllowDependencyFailure || importer[1].Command != "buildkite-agent pipeline upload .buildkite/phase-5-capabilities-continuation.yml" {
 		t.Fatalf("Phase 5 importer = %#v", importer)
 	}
-	for _, fragment := range []string{`scripts/phase-0-shell-oracle-checkout "$$PHASE5_COMMIT"`, `git status --porcelain --untracked-files=all`, `pipeline upload --no-interpolation --reject-secrets .buildkite/phase-5-hosted-probe.yml`} {
+	for _, fragment := range []string{`commit="$${PHASE5_COMMIT:-$${SMOKE_COMMIT:-}}"`,
+		`scripts/phase-0-shell-oracle-checkout "$$commit"`, `git status --porcelain --untracked-files=all`, `pipeline upload --no-interpolation --reject-secrets .buildkite/phase-5-hosted-probe.yml`} {
 		if !strings.Contains(string(importerBody), fragment) {
 			t.Fatalf("Phase 5 importer lacks %q", fragment)
 		}
@@ -554,7 +588,7 @@ func TestPhase5HostedDockerCapabilityProbeContract(t *testing.T) {
 		t.Fatal(err)
 	}
 	text := string(probe)
-	for _, fragment := range []string{"set -euo pipefail", `${PHASE5_COMMIT:?}`, `scripts/phase-0-shell-oracle-checkout "$PHASE5_COMMIT"`, "busybox@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028", `buildx inspect default`, `buildx build --builder default --load`, `default-docker-driver`, `127.0.0.1::8080`, `wget -qO- http://phase5-server:8080/phase5-marker`, `/dev/tcp/127.0.0.1/$1`, `trap cleanup EXIT`, `trap - EXIT`, `exit "$final"`, `trap 'exit 130' INT`, `trap 'exit 143' TERM`, `docker container ls --all --quiet`, `--filter "label=${label_key}=${owner}"`, `timeout 30s`, `docker stop --time 5`, `term-observed`, `record bind-requested fail`, `record signal-stop fail`, `(( probe_failed == 0 ))`, "COPY marker"} {
+	for _, fragment := range []string{"set -euo pipefail", `commit=${PHASE5_COMMIT:-${SMOKE_COMMIT:-}}`, `scripts/phase-0-shell-oracle-checkout "$commit"`, "busybox@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028", `buildx inspect default`, `buildx build --builder default --load`, `default-docker-driver`, `127.0.0.1::8080`, `wget -qO- http://phase5-server:8080/phase5-marker`, `/dev/tcp/127.0.0.1/$1`, `trap cleanup EXIT`, `trap - EXIT`, `exit "$final"`, `trap 'exit 130' INT`, `trap 'exit 143' TERM`, `docker container ls --all --quiet`, `--filter "label=${label_key}=${owner}"`, `timeout 30s`, `docker stop --time 5`, `term-observed`, `record bind-requested fail`, `record signal-stop fail`, `(( probe_failed == 0 ))`, "COPY marker"} {
 		if !strings.Contains(text, fragment) {
 			t.Fatalf("Phase 5 probe lacks %q", fragment)
 		}
@@ -574,11 +608,12 @@ func TestPhase5DockerfileActionUploadProofContract(t *testing.T) {
 	}
 	text := string(importerBody)
 	for _, fragment := range []string{
-		`scripts/phase-0-shell-oracle-checkout "$$PHASE5_COMMIT"`,
+		`commit="$${PHASE5_COMMIT:-$${SMOKE_COMMIT:-}}"`,
+		`scripts/phase-0-shell-oracle-checkout "$$commit"`,
 		`test -z "$$(git status --porcelain --untracked-files=all)"`,
 		`automatic: false`,
 		`cp testdata/phase5/.github/workflows/docker-action.yml.tmpl`,
-		`runtime_version="0.0.0-phase5.$${PHASE5_COMMIT}"`,
+		`runtime_version="0.0.0-phase5.$$commit"`,
 		`go build -trimpath -buildvcs=false -ldflags "-X main.version=$$runtime_version"`,
 		`BUILDKITE_GHA_NODE20="$$(mise where node@20)/bin/node"`,
 		`BUILDKITE_GHA_NODE24="$$(mise where node@24)/bin/node"`,
@@ -633,6 +668,71 @@ func TestPhase5DockerfileActionUploadProofContract(t *testing.T) {
 	if !strings.Contains(string(templateBody), action) || !strings.Contains(string(githubBody), action) || !strings.Contains(string(templateBody), observation) || !strings.Contains(string(githubBody), observation) {
 		t.Fatalf("Phase 5 Dockerfile differential fixtures drifted:\ntemplate:\n%s\nGitHub:\n%s", templateBody, githubBody)
 	}
+}
+
+func TestHostedSmokeControlAndAggregatorDependencies(t *testing.T) {
+	type dependency struct {
+		Step         string `yaml:"step"`
+		AllowFailure bool   `yaml:"allow_failure"`
+	}
+	type smokeStep struct {
+		Key       string       `yaml:"key"`
+		Command   string       `yaml:"command"`
+		DependsOn []dependency `yaml:"depends_on"`
+		Agents    struct {
+			Queue string `yaml:"queue"`
+		} `yaml:"agents"`
+	}
+	read := func(name string) smokeStep {
+		t.Helper()
+		body, err := os.ReadFile(filepath.Join("..", "..", ".buildkite", name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var document struct {
+			Steps []smokeStep `yaml:"steps"`
+		}
+		if err := yaml.Unmarshal(body, &document); err != nil || len(document.Steps) != 1 {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		return document.Steps[0]
+	}
+	assertSet := func(name string, dependencies []dependency, want map[string]bool) {
+		t.Helper()
+		if len(dependencies) != len(want) {
+			t.Fatalf("%s dependencies = %#v", name, dependencies)
+		}
+		for _, dependency := range dependencies {
+			if !want[dependency.Step] || !dependency.AllowFailure {
+				t.Fatalf("%s dependency = %#v", name, dependency)
+			}
+			delete(want, dependency.Step)
+		}
+	}
+	control := read("hosted-smoke-control.yml")
+	if control.Key != "hosted-smoke-aggregator-loader" || control.Agents.Queue != "elastic-runners" || control.Command != "buildkite-agent pipeline upload .buildkite/hosted-smoke-aggregator.yml" {
+		t.Fatalf("control step = %#v", control)
+	}
+	assertSet("control", control.DependsOn, map[string]bool{"phase-2-continuation-loader": true, "phase-3-continuation-loader": true, "phase-4-continuation-loader": true, "phase-5-continuation-loader": true, "phase-5-docker-action-continuation-loader": true})
+	generated := map[string]bool{}
+	for _, name := range []string{"phase-2-upload-continuation.yml", "phase-3-upload-continuation.yml", "phase-4-upload-continuation.yml", "phase-5-capabilities-continuation.yml", "phase-5-docker-action-continuation.yml"} {
+		continuation := read(name)
+		for _, dependency := range continuation.DependsOn {
+			generated[dependency.Step] = true
+		}
+	}
+	want := map[string]bool{}
+	for key := range generated {
+		want[key] = true
+	}
+	for _, key := range []string{"phase-2-native-after-shell", "phase-3-native-after-concurrent", "phase-4-native-after-actions", "phase-5-native-after-hosted-docker", "phase-5-native-after-docker-action"} {
+		want[key] = true
+	}
+	aggregator := read("hosted-smoke-aggregator.yml")
+	if aggregator.Key != "hosted-smoke-terminal" || aggregator.Agents.Queue != "elastic-runners" || aggregator.Command != "echo 'All hosted smoke targets settled'" {
+		t.Fatalf("aggregator step = %#v", aggregator)
+	}
+	assertSet("aggregator", aggregator.DependsOn, want)
 }
 
 func TestPlanPathIsContentAddressed(t *testing.T) {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -40,7 +40,7 @@ Run "buildkite-gha help <command>" for command help.
 `
 
 var commandUsage = map[string]string{
-	"validate": "Usage: buildkite-gha validate [--event-path <path>] [--format text|json] <workflow>\n",
+	"validate": "Usage: buildkite-gha validate [--event-path <path>] [--profile hosted-tokenless] [--format text|json] <workflow>\n",
 	"compile":  "Usage: buildkite-gha compile --event-path <path> [--format pipeline|ir-json] <workflow>\n",
 	"upload":   "Usage: buildkite-gha upload --event-path <path> --runtime-queue hosted <workflow>\n",
 	"run-job":  "Usage: buildkite-gha run-job --plan <path> [--result <path>]\n",
@@ -49,6 +49,7 @@ var commandUsage = map[string]string{
 const (
 	resultPublicationTimeout = 10 * time.Second
 	unprivilegedRuntimeQueue = "hosted"
+	hostedTokenlessProfile   = "hosted-tokenless"
 )
 
 // Run executes the command and returns its process exit code.
@@ -81,6 +82,9 @@ func run(args []string, stdout, stderr io.Writer, version string, agentRunner tr
 				if args[0] == "compile" {
 					_, _ = fmt.Fprint(stdout, "\nPipeline output references content-addressed plans; compile does not materialize or upload those artifacts.\n")
 				}
+				if args[0] == "validate" {
+					_, _ = fmt.Fprint(stdout, "\nThe hosted-tokenless profile resolves actions and applies production upload policy without executing jobs or proving arbitrary action runtime compatibility.\n")
+				}
 				if args[0] == "upload" {
 					_, _ = fmt.Fprint(stdout, "\nThis is the unsigned, unprivileged event-file path; it does not grant production plan authority.\n")
 				}
@@ -88,7 +92,7 @@ func run(args []string, stdout, stderr io.Writer, version string, agentRunner tr
 			}
 			switch args[0] {
 			case "validate":
-				return validate(args[1:], stdout, stderr)
+				return validate(args[1:], stdout, stderr, version)
 			case "compile":
 				return compile(args[1:], stdout, stderr, version)
 			case "upload":
@@ -120,6 +124,9 @@ func help(args []string, stdout, stderr io.Writer) int {
 	}
 
 	_, _ = fmt.Fprint(stdout, commandHelp)
+	if args[0] == "validate" {
+		_, _ = fmt.Fprint(stdout, "\nThe hosted-tokenless profile resolves actions and applies production upload policy without executing jobs or proving arbitrary action runtime compatibility.\n")
+	}
 	if args[0] == "compile" {
 		_, _ = fmt.Fprint(stdout, "\nPipeline output references content-addressed plans; compile does not materialize or upload those artifacts.\n")
 	}
@@ -349,33 +356,81 @@ func verifyBuildkiteTarget(job plan.Job) error {
 	return nil
 }
 
-func validate(args []string, stdout, stderr io.Writer) int {
-	workflowPath, eventPath, format, err := validateArgs(args)
+func validate(args []string, stdout, stderr io.Writer, version string) int {
+	workflowPath, eventPath, format, profile, err := validateArgs(args)
 	if err != nil {
 		return usageError(stderr, "validate: %v", err)
+	}
+	if profile != "" && eventPath == "" {
+		return usageError(stderr, "validate: --event-path is required with --profile")
 	}
 	source, err := os.ReadFile(workflowPath)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: %v\n", err)
 		return 1
 	}
+	var event []byte
+	if eventPath != "" {
+		event, err = os.ReadFile(eventPath)
+		if err != nil {
+			_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: %v\n", err)
+			return 1
+		}
+	}
 
 	var report compiler.Report
 	if eventPath == "" {
 		report, err = compiler.Validate(workflowPath, source)
 	} else {
-		event, readErr := os.ReadFile(eventPath)
-		if readErr != nil {
-			_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: %v\n", readErr)
-			return 1
-		}
 		report, err = compiler.ValidateEvent(workflowPath, source, event)
 	}
 	if err != nil {
-		if writeErr := compatibility.Write(stdout, format, compatibility.Blocked(workflowPath, err)); writeErr != nil {
-			_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: write report: %v\n", writeErr)
+		if profile == "" {
+			if writeErr := compatibility.Write(stdout, format, compatibility.Blocked(workflowPath, err)); writeErr != nil {
+				_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: write report: %v\n", writeErr)
+			}
+		} else if writeErr := compatibility.WriteProfile(stdout, format, compatibility.ProfileCompileBlocked(workflowPath, profile, err)); writeErr != nil {
+			_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: write profile report: %v\n", writeErr)
 		}
 		return 1
+	}
+	if profile != "" {
+		executablePath, _, distributionDigest, executableErr := executable()
+		if executableErr != nil {
+			if writeErr := compatibility.WriteProfile(stdout, format, compatibility.ProfileNotEvaluated(workflowPath, profile, report.LogicalJobs, report.Instances, "E_ENVIRONMENT", executableErr)); writeErr != nil {
+				_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: write profile report: %v\n", writeErr)
+			}
+			return 1
+		}
+		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
+		preflight, profileErr := compileHostedTokenless(ctx, workflowPath, source, event, version, distributionDigest, "buildkite-gha-profile-importer", executablePath)
+		if profileErr != nil {
+			if ctx.Err() != nil || errors.Is(profileErr, context.Canceled) {
+				_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: profile evaluation interrupted: %v\n", profileErr)
+				return 1
+			}
+			var failure *hostedTokenlessFailure
+			if errors.As(profileErr, &failure) && failure.Kind == hostedTokenlessAdmissionFailure {
+				if writeErr := compatibility.WriteProfile(stdout, format, compatibility.ProfileBlocked(workflowPath, profile, report.LogicalJobs, report.Instances, profileErr)); writeErr != nil {
+					_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: write profile report: %v\n", writeErr)
+				}
+				return 1
+			}
+			code := "E_PROFILE_EVALUATION"
+			if errors.As(profileErr, &failure) && failure.Kind == hostedTokenlessEnvironmentFailure {
+				code = "E_ENVIRONMENT"
+			}
+			if writeErr := compatibility.WriteProfile(stdout, format, compatibility.ProfileNotEvaluated(workflowPath, profile, report.LogicalJobs, report.Instances, code, profileErr)); writeErr != nil {
+				_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: write profile report: %v\n", writeErr)
+			}
+			return 1
+		}
+		if writeErr := compatibility.WriteProfile(stdout, format, compatibility.Admitted(workflowPath, profile, report.LogicalJobs, report.Instances, preflight.HasActions)); writeErr != nil {
+			_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: write profile report: %v\n", writeErr)
+			return 1
+		}
+		return 0
 	}
 	if err := compatibility.Write(stdout, format, compatibility.Compilable(workflowPath, report.LogicalJobs, report.Instances)); err != nil {
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: write report: %v\n", err)
@@ -384,30 +439,43 @@ func validate(args []string, stdout, stderr io.Writer) int {
 	return 0
 }
 
-func validateArgs(args []string) (workflowPath, eventPath, format string, err error) {
+func validateArgs(args []string) (workflowPath, eventPath, format, profile string, err error) {
 	format = "text"
 	filtered := make([]string, 0, len(args))
 	formatSeen := false
+	profileSeen := false
 	for i := 0; i < len(args); i++ {
-		if args[i] != "--format" {
+		if args[i] != "--format" && args[i] != "--profile" {
 			filtered = append(filtered, args[i])
 			continue
 		}
-		if formatSeen {
-			return "", "", "", fmt.Errorf("--format may only be specified once")
+		option := args[i]
+		if option == "--format" && formatSeen {
+			return "", "", "", "", fmt.Errorf("--format may only be specified once")
 		}
-		formatSeen = true
+		if option == "--profile" && profileSeen {
+			return "", "", "", "", fmt.Errorf("--profile may only be specified once")
+		}
 		i++
 		if i == len(args) {
-			return "", "", "", fmt.Errorf("--format requires text or json")
+			return "", "", "", "", fmt.Errorf("%s requires a value", option)
 		}
-		format = args[i]
-		if format != "text" && format != "json" {
-			return "", "", "", fmt.Errorf("--format must be text or json")
+		if option == "--format" {
+			formatSeen = true
+			format = args[i]
+			if format != "text" && format != "json" {
+				return "", "", "", "", fmt.Errorf("--format must be text or json")
+			}
+		} else {
+			profileSeen = true
+			profile = args[i]
+			if profile != hostedTokenlessProfile {
+				return "", "", "", "", fmt.Errorf("--profile must be %q", hostedTokenlessProfile)
+			}
 		}
 	}
 	workflowPath, eventPath, err = workflowArgs(filtered)
-	return workflowPath, eventPath, format, err
+	return workflowPath, eventPath, format, profile, err
 }
 
 func compile(args []string, stdout, stderr io.Writer, version string) int {
@@ -479,89 +547,22 @@ func upload(args []string, stdout, stderr io.Writer, version string, agent trans
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
 		return 1
 	}
-	preflight, err := compiler.Compile(workflowPath, workflowSource, eventSource)
-	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
-		return 1
-	}
-	var ir compiler.IR
-	if err := json.Unmarshal(preflight, &ir); err != nil {
-		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: decode compiler preflight: %v\n", err)
-		return 1
-	}
-	hasActions := irUsesActions(ir)
-	options := compiler.Options{
-		EventTrust: compiler.EventUntrusted,
-		Runners: compiler.RunnerPolicy{
-			Labels: map[string]string{
-				"ubuntu-latest": unprivilegedRuntimeQueue,
-				"ubuntu-24.04":  unprivilegedRuntimeQueue,
-				"ubuntu-22.04":  unprivilegedRuntimeQueue,
-			},
-			UntrustedQueues: []string{unprivilegedRuntimeQueue},
-		},
-	}
-	artifacts := make([]transport.Artifact, 0)
-	var nodeArtifacts []transport.Artifact
-	if hasActions {
-		actionRoot, err := os.MkdirTemp("", "buildkite-gha-action-source-")
-		if err != nil {
-			_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: create action source store: %v\n", err)
-			return 1
-		}
-		defer func() { _ = os.RemoveAll(actionRoot) }()
-		resolver, err := actionsource.NewResolver(nil)
-		if err != nil {
-			_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: configure public action resolver: %v\n", err)
-			return 1
-		}
-		store, err := actionsource.NewStore(actionRoot, nil)
-		if err != nil {
-			_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: configure action source store: %v\n", err)
-			return 1
-		}
-		options.ResolveActions = true
-		options.ActionSource = compiler.PublicActionSource{Resolver: resolver, Store: store}
-		var digests map[int]string
-		nodeArtifacts, digests, err = managedNodeArtifacts(executablePath)
-		if err != nil {
-			_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
-			return 1
-		}
-		options.NodeRuntimeDigests = digests
-	}
-
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
-	bundle, err := compiler.CompileBundleContext(
-		ctx,
-		workflowPath,
-		workflowSource,
-		eventSource,
-		version,
-		distributionDigest,
-		importerStep,
-		options,
-	)
+	preflight, err := compileHostedTokenless(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, executablePath)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
 		return 1
 	}
-	if err := validateUnprivilegedBundle(bundle); err != nil {
-		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
-		return 1
-	}
-	if !hasActions && bundleUsesActions(bundle) {
-		_, _ = fmt.Fprintln(stderr, "buildkite-gha: upload: final compilation introduced actions absent from preflight")
-		return 1
-	}
+	bundle := preflight.Bundle
+	artifacts := make([]transport.Artifact, 0, 1+len(preflight.NodeArtifacts)+len(bundle.Plans))
 	distributionPath, err := buildkitepipeline.DistributionPath(distributionDigest)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
 		return 1
 	}
 	artifacts = append(artifacts, transport.Artifact{Path: distributionPath, Digest: distributionDigest, Contents: executableContents})
-	artifacts = append(artifacts, nodeArtifacts...)
+	artifacts = append(artifacts, preflight.NodeArtifacts...)
 	for _, jobPlan := range bundle.Plans {
 		artifacts = append(artifacts, transport.Artifact{Path: jobPlan.Path, Digest: jobPlan.Digest, Contents: jobPlan.Contents})
 	}
@@ -578,6 +579,90 @@ func upload(args []string, stdout, stderr io.Writer, version string, agent trans
 	}
 	_, _ = fmt.Fprintf(stdout, "Uploaded %d jobs from %s with importer %s.\n", len(bundle.Plans), executablePath, importerStep)
 	return 0
+}
+
+type hostedTokenlessCompilation struct {
+	Bundle        compiler.Bundle
+	NodeArtifacts []transport.Artifact
+	HasActions    bool
+}
+
+type hostedTokenlessFailureKind string
+
+const (
+	hostedTokenlessEnvironmentFailure hostedTokenlessFailureKind = "environment"
+	hostedTokenlessEvaluationFailure  hostedTokenlessFailureKind = "evaluation"
+	hostedTokenlessAdmissionFailure   hostedTokenlessFailureKind = "admission"
+)
+
+type hostedTokenlessFailure struct {
+	Kind hostedTokenlessFailureKind
+	Err  error
+}
+
+func (e *hostedTokenlessFailure) Error() string { return e.Err.Error() }
+func (e *hostedTokenlessFailure) Unwrap() error { return e.Err }
+
+func hostedTokenlessError(kind hostedTokenlessFailureKind, err error) error {
+	return &hostedTokenlessFailure{Kind: kind, Err: err}
+}
+
+func compileHostedTokenless(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, executablePath string) (hostedTokenlessCompilation, error) {
+	preflight, err := compiler.Compile(workflowPath, workflowSource, eventSource)
+	if err != nil {
+		return hostedTokenlessCompilation{}, hostedTokenlessError(hostedTokenlessEvaluationFailure, err)
+	}
+	var ir compiler.IR
+	if err := json.Unmarshal(preflight, &ir); err != nil {
+		return hostedTokenlessCompilation{}, hostedTokenlessError(hostedTokenlessEvaluationFailure, fmt.Errorf("decode compiler preflight: %w", err))
+	}
+	hasActions := irUsesActions(ir)
+	options := compiler.Options{
+		EventTrust: compiler.EventUntrusted,
+		Runners: compiler.RunnerPolicy{
+			Labels: map[string]string{
+				"ubuntu-latest": unprivilegedRuntimeQueue,
+				"ubuntu-24.04":  unprivilegedRuntimeQueue,
+				"ubuntu-22.04":  unprivilegedRuntimeQueue,
+			},
+			UntrustedQueues: []string{unprivilegedRuntimeQueue},
+		},
+	}
+	var nodeArtifacts []transport.Artifact
+	if hasActions {
+		actionRoot, err := os.MkdirTemp("", "buildkite-gha-action-source-")
+		if err != nil {
+			return hostedTokenlessCompilation{}, hostedTokenlessError(hostedTokenlessEnvironmentFailure, fmt.Errorf("create action source store: %w", err))
+		}
+		defer func() { _ = os.RemoveAll(actionRoot) }()
+		resolver, err := actionsource.NewResolver(nil)
+		if err != nil {
+			return hostedTokenlessCompilation{}, hostedTokenlessError(hostedTokenlessEnvironmentFailure, fmt.Errorf("configure public action resolver: %w", err))
+		}
+		store, err := actionsource.NewStore(actionRoot, nil)
+		if err != nil {
+			return hostedTokenlessCompilation{}, hostedTokenlessError(hostedTokenlessEnvironmentFailure, fmt.Errorf("configure public action source store: %w", err))
+		}
+		options.ResolveActions = true
+		options.ActionSource = compiler.PublicActionSource{Resolver: resolver, Store: store}
+		var digests map[int]string
+		nodeArtifacts, digests, err = managedNodeArtifacts(executablePath)
+		if err != nil {
+			return hostedTokenlessCompilation{}, hostedTokenlessError(hostedTokenlessEnvironmentFailure, err)
+		}
+		options.NodeRuntimeDigests = digests
+	}
+	bundle, err := compiler.CompileBundleContext(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, options)
+	if err != nil {
+		return hostedTokenlessCompilation{}, hostedTokenlessError(hostedTokenlessEvaluationFailure, err)
+	}
+	if err := validateUnprivilegedBundle(bundle); err != nil {
+		return hostedTokenlessCompilation{}, hostedTokenlessError(hostedTokenlessAdmissionFailure, err)
+	}
+	if !hasActions && bundleUsesActions(bundle) {
+		return hostedTokenlessCompilation{}, hostedTokenlessError(hostedTokenlessEvaluationFailure, fmt.Errorf("final compilation introduced actions absent from preflight"))
+	}
+	return hostedTokenlessCompilation{Bundle: bundle, NodeArtifacts: nodeArtifacts, HasActions: hasActions}, nil
 }
 
 func validateUnprivilegedBundle(bundle compiler.Bundle) error {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -675,6 +675,21 @@ func validateUnprivilegedBundle(bundle compiler.Bundle) error {
 				return fmt.Errorf("job %q requires capability %q, unavailable to unprivileged upload", artifact.Job.Workflow.LogicalJobID, capability)
 			}
 		}
+		for _, action := range artifact.Job.Actions {
+			if action.Source != "github" {
+				continue
+			}
+			var service string
+			switch strings.ToLower(action.Repository) {
+			case "actions/upload-artifact", "actions/download-artifact":
+				service = "artifact"
+			case "actions/cache":
+				service = "cache"
+			}
+			if service != "" {
+				return fmt.Errorf("job %q uses action %q, which requires the unavailable GitHub Actions %s service; Phase 6 is required", artifact.Job.Workflow.LogicalJobID, action.Repository, service)
+			}
+		}
 	}
 	return nil
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -103,6 +103,60 @@ func TestRunValidateAndCompile(t *testing.T) {
 		if report.Result != "incompatible" || len(report.Diagnostics) != 1 || report.Diagnostics[0].Code != "E_COMPILE" {
 			t.Fatalf("report = %#v", report)
 		}
+
+		stdout.Reset()
+		stderr.Reset()
+		if code := Run([]string{"validate", "--profile", "hosted-tokenless", "--format", "json", "--event-path", eventPath, workflow}, &stdout, &stderr, "dev"); code != 1 {
+			t.Fatalf("profile Run() code = %d, want 1; stderr = %q", code, stderr.String())
+		}
+		var profileReport compatibility.ProfileReport
+		if err := json.Unmarshal(stdout.Bytes(), &profileReport); err != nil {
+			t.Fatal(err)
+		}
+		if profileReport.Result != "incompatible" || profileReport.Compile.Result != "incompatible" || profileReport.Admission.Result != "not-evaluated" || len(profileReport.Diagnostics) != 1 || profileReport.Diagnostics[0].Code != "E_COMPILE" {
+			t.Fatalf("profile report = %#v", profileReport)
+		}
+	})
+
+	t.Run("validate hosted tokenless profile", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		args := []string{"validate", "--profile", "hosted-tokenless", "--format", "json", "--event-path", eventPath, workflowPath}
+		runner := &cliCaptureRunner{}
+		if code := run(args, &stdout, &stderr, "dev", runner); code != 0 {
+			t.Fatalf("Run() code = %d, stderr = %q", code, stderr.String())
+		}
+		if len(runner.commands) != 0 {
+			t.Fatalf("profile validation made Buildkite calls: %#v", runner.commands)
+		}
+		var report compatibility.ProfileReport
+		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+			t.Fatal(err)
+		}
+		if report.Result != "admitted" || report.Profile != "hosted-tokenless" || report.Compile.Instances != 3 || report.Admission.Result != "admitted" || len(report.Diagnostics) != 0 {
+			t.Fatalf("profile report = %#v", report)
+		}
+	})
+
+	t.Run("validate profile requires event", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		if code := Run([]string{"validate", "--profile", "hosted-tokenless", workflowPath}, &stdout, &stderr, "dev"); code != 2 || !strings.Contains(stderr.String(), "--event-path is required with --profile") {
+			t.Fatalf("Run() code = %d, stderr = %q", code, stderr.String())
+		}
+	})
+
+	t.Run("validate profile importer cannot collide with generated key", func(t *testing.T) {
+		workflow := filepath.Join(t.TempDir(), "profile.yml")
+		if err := os.WriteFile(workflow, []byte("on: push\njobs:\n  profile:\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		var stdout, stderr bytes.Buffer
+		if code := Run([]string{"validate", "--profile", "hosted-tokenless", "--format", "json", "--event-path", eventPath, workflow}, &stdout, &stderr, "dev"); code != 0 {
+			t.Fatalf("Run() code = %d, stderr = %q", code, stderr.String())
+		}
+		var report compatibility.ProfileReport
+		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil || report.Result != "admitted" {
+			t.Fatalf("profile report = %#v, error = %v", report, err)
+		}
 	})
 
 	t.Run("compile", func(t *testing.T) {
@@ -135,6 +189,73 @@ func TestRunValidateAndCompile(t *testing.T) {
 			t.Fatalf("compile IR = %#v, error = %v", ir, err)
 		}
 	})
+}
+
+func TestValidateHostedTokenlessProfileResolvesActionsWithoutClaimingRuntime(t *testing.T) {
+	root := t.TempDir()
+	workflowPath := filepath.Join(root, ".github", "workflows", "action.yml")
+	actionPath := filepath.Join(root, ".github", "actions", "local")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(actionPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(workflowPath, []byte("on: push\njobs:\n  action:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: ./.github/actions/local\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(actionPath, "action.yml"), []byte("runs:\n  using: node24\n  main: main.js\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(actionPath, "main.js"), []byte("console.log('local action')\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BUILDKITE_GHA_NODE20", writeFakeNode(t, root, 20))
+	t.Setenv("BUILDKITE_GHA_NODE24", writeFakeNode(t, root, 24))
+	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"validate", "--profile", "hosted-tokenless", "--format", "json", "--event-path", eventPath, workflowPath}, &stdout, &stderr, "dev"); code != 0 {
+		t.Fatalf("Run() code = %d, stderr = %q", code, stderr.String())
+	}
+	var report compatibility.ProfileReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if report.Result != "admitted" || len(report.Diagnostics) != 1 || report.Diagnostics[0].Code != "W_ACTION_RUNTIME_UNKNOWN" {
+		t.Fatalf("profile report = %#v", report)
+	}
+
+	t.Setenv("BUILDKITE_GHA_NODE20", filepath.Join(root, "missing-node20"))
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"validate", "--profile", "hosted-tokenless", "--format", "json", "--event-path", eventPath, workflowPath}, &stdout, &stderr, "dev"); code != 1 {
+		t.Fatalf("environment Run() code = %d, want 1; stderr = %q", code, stderr.String())
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if report.Result != "indeterminate" || report.Admission.Result != "not-evaluated" || len(report.Diagnostics) != 1 || report.Diagnostics[0].Code != "E_ENVIRONMENT" {
+		t.Fatalf("environment profile report = %#v", report)
+	}
+}
+
+func TestValidateHostedTokenlessProfileRejectsProtectedCapabilityAfterCompile(t *testing.T) {
+	workflowPath := filepath.Join(t.TempDir(), "secret.yml")
+	if err := os.WriteFile(workflowPath, []byte("on: push\njobs:\n  secret:\n    runs-on: ubuntu-latest\n    env:\n      TOKEN: ${{ secrets.TOKEN }}\n    steps:\n      - run: true\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"validate", "--profile", "hosted-tokenless", "--format", "json", "--event-path", eventPath, workflowPath}, &stdout, &stderr, "dev"); code != 1 {
+		t.Fatalf("Run() code = %d, want 1; stderr = %q", code, stderr.String())
+	}
+	var report compatibility.ProfileReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if report.Result != "not-admitted" || report.Compile.Result != "compilable" || report.Admission.Result != "not-admitted" || len(report.Diagnostics) != 1 || report.Diagnostics[0].Code != "E_PROFILE" || !strings.Contains(report.Diagnostics[0].Message, `capability "secrets"`) {
+		t.Fatalf("profile report = %#v", report)
+	}
 }
 
 func TestRunUploadCompilesArtifactsAndUploadsSelfContainedPipeline(t *testing.T) {
@@ -897,8 +1018,14 @@ func TestArgumentParsersRejectRepeatedOptions(t *testing.T) {
 	if _, _, err := workflowArgs([]string{"--event-path", "one", "--event-path", "two", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
 		t.Fatalf("workflowArgs() error = %v, want duplicate option error", err)
 	}
-	if _, _, _, err := validateArgs([]string{"--format", "json", "--format", "text", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
+	if _, _, _, _, err := validateArgs([]string{"--format", "json", "--format", "text", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
 		t.Fatalf("validateArgs() error = %v, want duplicate format error", err)
+	}
+	if _, _, _, _, err := validateArgs([]string{"--profile", "hosted-tokenless", "--profile", "hosted-tokenless", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
+		t.Fatalf("validateArgs() error = %v, want duplicate profile error", err)
+	}
+	if _, _, _, _, err := validateArgs([]string{"--profile", "unknown", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), `must be "hosted-tokenless"`) {
+		t.Fatalf("validateArgs() error = %v, want unknown profile error", err)
 	}
 	if _, _, _, err := compileArgs([]string{"--format", "pipeline", "--format", "ir-json", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
 		t.Fatalf("compileArgs() error = %v, want duplicate format error", err)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -597,6 +597,25 @@ func TestUnprivilegedUploadRejectsDockerWithoutCompilerProvenance(t *testing.T) 
 	}
 }
 
+func TestUnprivilegedUploadRejectsKnownGitHubServiceActions(t *testing.T) {
+	for repository, service := range map[string]string{
+		"actions/upload-artifact":   "artifact",
+		"actions/download-artifact": "artifact",
+		"actions/cache":             "cache",
+	} {
+		t.Run(repository, func(t *testing.T) {
+			bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: plan.Job{
+				Workflow: plan.Workflow{LogicalJobID: "service-action"},
+				Actions:  []plan.ActionLock{{Source: "github", Repository: repository}},
+			}}}}
+			err := validateUnprivilegedBundle(bundle)
+			if err == nil || !strings.Contains(err.Error(), "GitHub Actions "+service+" service") || !strings.Contains(err.Error(), "Phase 6") {
+				t.Fatalf("validateUnprivilegedBundle(%q) error = %v", repository, err)
+			}
+		})
+	}
+}
+
 func TestDeterministicGzip(t *testing.T) {
 	source := []byte("exact node executable bytes\n")
 	first, err := deterministicGzip(source)

--- a/internal/compatibility/report.go
+++ b/internal/compatibility/report.go
@@ -9,6 +9,9 @@ import (
 
 const Schema = "buildkite-gha/compatibility-report/v1"
 
+// ProfileSchema distinguishes static compilation from profile admission.
+const ProfileSchema = "buildkite-gha/compatibility-report/v2"
+
 // Diagnostic is one actionable compatibility finding.
 type Diagnostic struct {
 	Level   string `json:"level"`
@@ -23,6 +26,26 @@ type Report struct {
 	Result      string       `json:"result"`
 	LogicalJobs int          `json:"logical_jobs"`
 	Instances   int          `json:"instances"`
+	Diagnostics []Diagnostic `json:"diagnostics"`
+}
+
+// Stage is one independently reported compatibility boundary.
+type Stage struct {
+	Result      string `json:"result"`
+	LogicalJobs int    `json:"logical_jobs,omitempty"`
+	Instances   int    `json:"instances,omitempty"`
+}
+
+// ProfileReport describes static compilation and admission under a named
+// execution profile. Admission proves plan construction and policy only; it is
+// not a claim that arbitrary action code will execute successfully.
+type ProfileReport struct {
+	Schema      string       `json:"schema"`
+	Workflow    string       `json:"workflow"`
+	Profile     string       `json:"profile"`
+	Result      string       `json:"result"`
+	Compile     Stage        `json:"compile"`
+	Admission   Stage        `json:"admission"`
 	Diagnostics []Diagnostic `json:"diagnostics"`
 }
 
@@ -43,6 +66,58 @@ func Blocked(workflow string, err error) Report {
 	}
 }
 
+// Admitted constructs a report for plans accepted by the named profile.
+func Admitted(workflow, profile string, logicalJobs, instances int, actionRuntimeUnknown bool) ProfileReport {
+	diagnostics := []Diagnostic{}
+	if actionRuntimeUnknown {
+		diagnostics = append(diagnostics, Diagnostic{
+			Level: "warning",
+			Code:  "W_ACTION_RUNTIME_UNKNOWN",
+			Message: "resolved action metadata cannot prove that arbitrary action code " +
+				"is independent of GitHub-only runtime services",
+		})
+	}
+	return ProfileReport{
+		Schema: ProfileSchema, Workflow: workflow, Profile: profile, Result: "admitted",
+		Compile:   Stage{Result: "compilable", LogicalJobs: logicalJobs, Instances: instances},
+		Admission: Stage{Result: "admitted"}, Diagnostics: diagnostics,
+	}
+}
+
+// ProfileBlocked constructs a report for a workflow that compiles but whose
+// plans cannot be admitted by the named profile.
+func ProfileBlocked(workflow, profile string, logicalJobs, instances int, err error) ProfileReport {
+	return ProfileReport{
+		Schema: ProfileSchema, Workflow: workflow, Profile: profile, Result: "not-admitted",
+		Compile:   Stage{Result: "compilable", LogicalJobs: logicalJobs, Instances: instances},
+		Admission: Stage{Result: "not-admitted"}, Diagnostics: []Diagnostic{{
+			Level: "error", Code: "E_PROFILE", Message: err.Error(),
+		}},
+	}
+}
+
+// ProfileNotEvaluated constructs a report when the workflow compiles but the
+// local environment cannot complete profile evaluation.
+func ProfileNotEvaluated(workflow, profile string, logicalJobs, instances int, code string, err error) ProfileReport {
+	return ProfileReport{
+		Schema: ProfileSchema, Workflow: workflow, Profile: profile, Result: "indeterminate",
+		Compile:   Stage{Result: "compilable", LogicalJobs: logicalJobs, Instances: instances},
+		Admission: Stage{Result: "not-evaluated"}, Diagnostics: []Diagnostic{{
+			Level: "error", Code: code, Message: err.Error(),
+		}},
+	}
+}
+
+// ProfileCompileBlocked constructs a report when static compilation prevents
+// the named profile from being evaluated.
+func ProfileCompileBlocked(workflow, profile string, err error) ProfileReport {
+	return ProfileReport{
+		Schema: ProfileSchema, Workflow: workflow, Profile: profile, Result: "incompatible",
+		Compile: Stage{Result: "incompatible"}, Admission: Stage{Result: "not-evaluated"},
+		Diagnostics: []Diagnostic{{Level: "error", Code: "E_COMPILE", Message: err.Error()}},
+	}
+}
+
 // Write renders a report as text or deterministic indented JSON.
 func Write(w io.Writer, format string, report Report) error {
 	switch format {
@@ -56,6 +131,46 @@ func Write(w io.Writer, format string, report Report) error {
 		}
 		for _, diagnostic := range report.Diagnostics {
 			if _, err := fmt.Fprintf(w, "✗ [%s] %s\n", diagnostic.Code, diagnostic.Message); err != nil {
+				return err
+			}
+		}
+		return nil
+	case "json":
+		encoder := json.NewEncoder(w)
+		encoder.SetEscapeHTML(false)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(report)
+	default:
+		return fmt.Errorf("unsupported compatibility report format %q", format)
+	}
+}
+
+// WriteProfile renders a staged profile report as text or deterministic JSON.
+func WriteProfile(w io.Writer, format string, report ProfileReport) error {
+	switch format {
+	case "text":
+		if _, err := fmt.Fprintf(w, "Workflow: %s\nProfile: %s\nResult: %s\nCompile: %s\n", report.Workflow, report.Profile, report.Result, report.Compile.Result); err != nil {
+			return err
+		}
+		if report.Compile.Result == "compilable" {
+			if _, err := fmt.Fprintf(w, "✓ %d logical jobs and %d static instances compile\n", report.Compile.LogicalJobs, report.Compile.Instances); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintf(w, "Admission: %s\n", report.Admission.Result); err != nil {
+			return err
+		}
+		if report.Admission.Result == "admitted" {
+			if _, err := fmt.Fprintln(w, "✓ plans resolve and satisfy the profile's upload policy"); err != nil {
+				return err
+			}
+		}
+		for _, diagnostic := range report.Diagnostics {
+			marker := "✗"
+			if diagnostic.Level == "warning" {
+				marker = "!"
+			}
+			if _, err := fmt.Fprintf(w, "%s [%s] %s\n", marker, diagnostic.Code, diagnostic.Message); err != nil {
 				return err
 			}
 		}

--- a/internal/compatibility/report_test.go
+++ b/internal/compatibility/report_test.go
@@ -42,3 +42,59 @@ func TestWriteRejectsUnknownFormat(t *testing.T) {
 		t.Fatal("Write() accepted unknown format")
 	}
 }
+
+func TestWriteProfileReportsStagesWithoutOverclaimingRuntime(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		report ProfileReport
+		want   []string
+	}{
+		{
+			name:   "admitted actions retain unknown runtime",
+			report: Admitted("ci.yml", "hosted-tokenless", 2, 3, true),
+			want:   []string{"Result: admitted", "Admission: admitted", "W_ACTION_RUNTIME_UNKNOWN"},
+		},
+		{
+			name:   "profile rejection preserves compile success",
+			report: ProfileBlocked("ci.yml", "hosted-tokenless", 2, 3, errors.New("secrets unavailable")),
+			want:   []string{"Result: not-admitted", "Compile: compilable", "[E_PROFILE] secrets unavailable"},
+		},
+		{
+			name:   "environment failure leaves admission unknown",
+			report: ProfileNotEvaluated("ci.yml", "hosted-tokenless", 2, 3, "E_ENVIRONMENT", errors.New("Node 24 unavailable")),
+			want:   []string{"Result: indeterminate", "Admission: not-evaluated", "[E_ENVIRONMENT] Node 24 unavailable"},
+		},
+		{
+			name:   "compile rejection does not evaluate admission",
+			report: ProfileCompileBlocked("ci.yml", "hosted-tokenless", errors.New("dynamic matrix")),
+			want:   []string{"Result: incompatible", "Admission: not-evaluated", "[E_COMPILE] dynamic matrix"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var text bytes.Buffer
+			if err := WriteProfile(&text, "text", test.report); err != nil {
+				t.Fatal(err)
+			}
+			for _, want := range test.want {
+				if !strings.Contains(text.String(), want) {
+					t.Fatalf("text = %q, want %q", text.String(), want)
+				}
+			}
+
+			var encoded bytes.Buffer
+			if err := WriteProfile(&encoded, "json", test.report); err != nil {
+				t.Fatal(err)
+			}
+			var decoded ProfileReport
+			if err := json.Unmarshal(encoded.Bytes(), &decoded); err != nil {
+				t.Fatal(err)
+			}
+			if decoded.Schema != ProfileSchema || decoded.Result != test.report.Result {
+				t.Fatalf("decoded report = %#v", decoded)
+			}
+		})
+	}
+	if err := WriteProfile(&bytes.Buffer{}, "yaml", Admitted("ci.yml", "hosted-tokenless", 1, 1, false)); err == nil {
+		t.Fatal("WriteProfile() accepted unknown format")
+	}
+}

--- a/internal/compiler/smoke_manifest_test.go
+++ b/internal/compiler/smoke_manifest_test.go
@@ -1,0 +1,113 @@
+package compiler
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestSmokeManifestInventory(t *testing.T) {
+	type fixture struct {
+		ID              string `json:"id"`
+		Workflow        string `json:"workflow"`
+		Event           string `json:"event"`
+		Expectation     string `json:"expectation"`
+		Evidence        string `json:"evidence"`
+		Note            string `json:"note"`
+		ActionPreflight string `json:"action_preflight"`
+	}
+	var manifest struct {
+		Schema   string    `json:"schema"`
+		Fixtures []fixture `json:"fixtures"`
+	}
+	root := filepath.Join("..", "..")
+	f, err := os.Open(filepath.Join(root, "testdata", "smoke", "manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	decoder := json.NewDecoder(f)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&manifest); err != nil {
+		t.Fatal(err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		t.Fatalf("trailing manifest value: %v", err)
+	}
+	if manifest.Schema != "buildkite-gha/smoke-manifest/v1" {
+		t.Fatalf("schema = %q", manifest.Schema)
+	}
+
+	wantOrder := []string{"smoke-shell", "smoke-concurrent", "smoke-ci", "smoke-artifact", "phase4-public-actions", "phase5-docker-action"}
+	if len(manifest.Fixtures) != len(wantOrder) {
+		t.Fatalf("fixtures = %d, want %d", len(manifest.Fixtures), len(wantOrder))
+	}
+	idPattern := regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
+	ids, pairs, inventoried := map[string]bool{}, map[string]bool{}, []string{}
+	for i, fixture := range manifest.Fixtures {
+		if fixture.ID != wantOrder[i] {
+			t.Fatalf("fixture %d ID = %q, want %q", i, fixture.ID, wantOrder[i])
+		}
+		if !idPattern.MatchString(fixture.ID) || ids[fixture.ID] {
+			t.Fatalf("invalid or duplicate ID %q", fixture.ID)
+		}
+		ids[fixture.ID] = true
+		if fixture.Expectation != "compile-pass" && fixture.Expectation != "runtime-pass" && fixture.Expectation != "runtime-unsupported" && fixture.Expectation != "future" {
+			t.Fatalf("%s: invalid expectation %q", fixture.ID, fixture.Expectation)
+		}
+		if fixture.ActionPreflight != "none" && fixture.ActionPreflight != "hosted-tokenless" {
+			t.Fatalf("%s: invalid action preflight %q", fixture.ID, fixture.ActionPreflight)
+		}
+		if strings.TrimSpace(fixture.Evidence) == "" || strings.TrimSpace(fixture.Note) == "" {
+			t.Fatalf("%s: evidence and note are required", fixture.ID)
+		}
+		for _, path := range []string{fixture.Workflow, fixture.Event} {
+			clean := filepath.ToSlash(filepath.Clean(filepath.FromSlash(path)))
+			if !strings.HasPrefix(path, "testdata/") || filepath.IsAbs(path) || clean != path || slicesContain(strings.Split(path, "/"), "..") {
+				t.Fatalf("%s: unsafe path %q", fixture.ID, path)
+			}
+			if info, err := os.Stat(filepath.Join(root, filepath.FromSlash(path))); err != nil || !info.Mode().IsRegular() {
+				t.Fatalf("%s: missing regular file %q: %v", fixture.ID, path, err)
+			}
+		}
+		pair := fixture.Workflow + "\x00" + fixture.Event
+		if pairs[pair] {
+			t.Fatalf("duplicate workflow/event pair for %s", fixture.ID)
+		}
+		pairs[pair] = true
+		inventoried = append(inventoried, fixture.Workflow)
+	}
+
+	var checkedIn []string
+	for _, pattern := range []string{"testdata/smoke/.github/workflows/*.yml", "testdata/phase4/.github/workflows/*.yml", "testdata/phase5/.github/workflows/*.yml.tmpl"} {
+		matches, err := filepath.Glob(filepath.Join(root, filepath.FromSlash(pattern)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, match := range matches {
+			checkedIn = append(checkedIn, filepath.ToSlash(strings.TrimPrefix(match, root+string(filepath.Separator))))
+		}
+	}
+	sort.Strings(checkedIn)
+	sortedInventory := append([]string(nil), inventoried...)
+	sort.Strings(sortedInventory)
+	if fmt.Sprint(sortedInventory) != fmt.Sprint(checkedIn) {
+		t.Fatalf("inventory = %v, checked-in workflows = %v", sortedInventory, checkedIn)
+	}
+}
+
+func slicesContain(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/compiler/smoke_manifest_test.go
+++ b/internal/compiler/smoke_manifest_test.go
@@ -45,7 +45,7 @@ func TestSmokeManifestInventory(t *testing.T) {
 		t.Fatalf("schema = %q", manifest.Schema)
 	}
 
-	wantOrder := []string{"smoke-shell", "smoke-concurrent", "smoke-ci", "smoke-artifact", "phase4-public-actions", "phase5-docker-action"}
+	wantOrder := []string{"smoke-shell", "smoke-concurrent", "smoke-ci", "smoke-artifact", "phase4-public-actions", "phase5-docker-action", "unsupported-cache-service", "unsupported-job-container", "unsupported-service-container"}
 	if len(manifest.Fixtures) != len(wantOrder) {
 		t.Fatalf("fixtures = %d, want %d", len(manifest.Fixtures), len(wantOrder))
 	}
@@ -59,7 +59,7 @@ func TestSmokeManifestInventory(t *testing.T) {
 			t.Fatalf("invalid or duplicate ID %q", fixture.ID)
 		}
 		ids[fixture.ID] = true
-		if fixture.Expectation != "compile-pass" && fixture.Expectation != "runtime-pass" && fixture.Expectation != "runtime-unsupported" && fixture.Expectation != "future" {
+		if fixture.Expectation != "compile-pass" && fixture.Expectation != "compile-unsupported" && fixture.Expectation != "runtime-pass" && fixture.Expectation != "runtime-unsupported" && fixture.Expectation != "future" {
 			t.Fatalf("%s: invalid expectation %q", fixture.ID, fixture.Expectation)
 		}
 		if fixture.ActionPreflight != "none" && fixture.ActionPreflight != "hosted-tokenless" {
@@ -86,7 +86,7 @@ func TestSmokeManifestInventory(t *testing.T) {
 	}
 
 	var checkedIn []string
-	for _, pattern := range []string{"testdata/smoke/.github/workflows/*.yml", "testdata/phase4/.github/workflows/*.yml", "testdata/phase5/.github/workflows/*.yml.tmpl"} {
+	for _, pattern := range []string{"testdata/smoke/.github/workflows/*.yml", "testdata/phase4/.github/workflows/*.yml", "testdata/phase5/.github/workflows/*.yml.tmpl", "testdata/unsupported/.github/workflows/*.yml"} {
 		matches, err := filepath.Glob(filepath.Join(root, filepath.FromSlash(pattern)))
 		if err != nil {
 			t.Fatal(err)

--- a/internal/compiler/smoke_manifest_test.go
+++ b/internal/compiler/smoke_manifest_test.go
@@ -1,6 +1,7 @@
 package compiler
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -28,12 +29,11 @@ func TestSmokeManifestInventory(t *testing.T) {
 		Fixtures []fixture `json:"fixtures"`
 	}
 	root := filepath.Join("..", "..")
-	f, err := os.Open(filepath.Join(root, "testdata", "smoke", "manifest.json"))
+	source, err := os.ReadFile(filepath.Join(root, "testdata", "smoke", "manifest.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer f.Close()
-	decoder := json.NewDecoder(f)
+	decoder := json.NewDecoder(bytes.NewReader(source))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(&manifest); err != nil {
 		t.Fatal(err)

--- a/mise.toml
+++ b/mise.toml
@@ -29,7 +29,7 @@ run = "golangci-lint run"
 
 [tasks."lint:shell"]
 description = "Lint shell scripts"
-run = "shellcheck -x .buildkite/phase-0-transport-probe/probe.sh scripts/phase-0-shell-oracle-checkout scripts/phase-0-sign-json scripts/phase-0-verify-json scripts/phase-5-hosted-docker-probe testdata/actions/docker/entrypoint.sh"
+run = "shellcheck -x .buildkite/phase-0-transport-probe/probe.sh scripts/phase-0-shell-oracle-checkout scripts/phase-0-sign-json scripts/phase-0-verify-json scripts/phase-5-hosted-docker-probe scripts/smoke-local testdata/actions/docker/entrypoint.sh"
 
 [tasks.vet]
 description = "Run go vet"
@@ -43,7 +43,11 @@ run = "go build ./..."
 description = "Validate signed plan-envelope fixtures"
 run = "python3 testdata/plans/validate.py"
 
+[tasks."smoke:local"]
+description = "Validate and deterministically compile the local smoke inventory"
+run = "./scripts/smoke-local"
+
 [tasks.check]
 description = "Run formatting, build, tests, lint, vet, and fixture checks"
-depends = ["format", "build", "test", "test:race", "lint:go", "lint:shell", "vet", "plan-fixtures"]
+depends = ["format", "build", "test", "test:race", "lint:go", "lint:shell", "vet", "plan-fixtures", "smoke:local"]
 run = "true"

--- a/mise.toml
+++ b/mise.toml
@@ -47,6 +47,10 @@ run = "python3 testdata/plans/validate.py"
 description = "Validate and deterministically compile the local smoke inventory"
 run = "./scripts/smoke-local"
 
+[tasks."smoke:profile"]
+description = "Resolve actions and apply the hosted-tokenless profile to smoke fixtures"
+run = "./scripts/smoke-local --profile hosted-tokenless"
+
 [tasks.check]
 description = "Run formatting, build, tests, lint, vet, and fixture checks"
 depends = ["format", "build", "test", "test:race", "lint:go", "lint:shell", "vet", "plan-fixtures", "smoke:local"]

--- a/scripts/phase-5-hosted-docker-probe
+++ b/scripts/phase-5-hosted-docker-probe
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+commit=${PHASE5_COMMIT:-${SMOKE_COMMIT:-}}
+scripts/phase-0-shell-oracle-checkout "$commit"
+
 readonly image_base='busybox@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028'
 readonly label_key='com.buildkite.buildkite-gha.phase5-owner'
 readonly suffix="${BUILDKITE_JOB_ID:-unknown}"
@@ -77,8 +80,6 @@ trap cleanup EXIT
 trap 'exit 130' INT
 trap 'exit 143' TERM
 
-: "${PHASE5_COMMIT:?}"
-scripts/phase-0-shell-oracle-checkout "$PHASE5_COMMIT"
 record platform pass "$(safe_detail "$(uname -s)-$(uname -m)")"
 
 if ! command -v docker >/dev/null 2>&1; then record docker-client unavailable not-found; exit 1; fi

--- a/scripts/smoke-local
+++ b/scripts/smoke-local
@@ -4,6 +4,14 @@ set -euo pipefail
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 readonly root
 readonly manifest="$root/testdata/smoke/manifest.json"
+profile=""
+if (( $# != 0 )); then
+  [[ $# == 2 && "$1" == --profile && "$2" == hosted-tokenless ]] || {
+    echo 'usage: scripts/smoke-local [--profile hosted-tokenless]' >&2
+    exit 2
+  }
+  profile="$2"
+fi
 work="$(mktemp -d "${TMPDIR:-/tmp}/buildkite-gha-smoke.XXXXXXXX")"
 trap 'rm -rf -- "$work"' EXIT
 
@@ -29,8 +37,12 @@ jq -e '
 ' "$manifest" >/dev/null
 
 mise exec -- go build -o "$work/buildkite-gha" ./cmd/buildkite-gha
+if [[ -n "$profile" ]]; then
+  node20="$(mise where node@20)/bin/node"
+  node24="$(mise where node@24)/bin/node"
+fi
 
-while IFS=$'\t' read -r id workflow event expectation; do
+while IFS=$'\t' read -r id workflow event expectation action_preflight; do
   [[ -f "$root/$workflow" ]] || { echo "$id: missing workflow $workflow" >&2; exit 1; }
   [[ -f "$root/$event" ]] || { echo "$id: missing event $event" >&2; exit 1; }
   echo "$id: classification=$expectation"
@@ -44,7 +56,17 @@ while IFS=$'\t' read -r id workflow event expectation; do
   [[ -s "$work/$id.first" ]] || { echo "$id: empty pipeline" >&2; exit 1; }
   cmp -s "$work/$id.first" "$work/$id.second" || { echo "$id: nondeterministic pipeline" >&2; exit 1; }
   echo "$id: validate=pass compile=deterministic"
-done < <(jq -r '.fixtures[] | [.id, .workflow, .event, .expectation] | @tsv' "$manifest")
+  if [[ -n "$profile" && "$action_preflight" == "$profile" ]]; then
+    BUILDKITE_GHA_NODE20="$node20" BUILDKITE_GHA_NODE24="$node24" \
+      "$work/buildkite-gha" validate --profile "$profile" --format json \
+      --event-path "$root/$event" "$root/$workflow" >"$work/$id.profile.json"
+    jq -e '.result == "admitted" and .admission.result == "admitted"' "$work/$id.profile.json" >/dev/null
+    echo "$id: profile=$profile admission=pass runtime=not-proven"
+  fi
+done < <(jq -r '.fixtures[] | [.id, .workflow, .event, .expectation, .action_preflight] | @tsv' "$manifest")
 
 echo 'PASS: local smoke inventory validated and compiled deterministically.'
 echo 'CAVEAT: successful compilation is not runtime evidence; classifications come from the manifest.'
+if [[ -n "$profile" ]]; then
+  echo 'CAVEAT: profile admission resolves actions and applies upload policy but does not execute arbitrary action code.'
+fi

--- a/scripts/smoke-local
+++ b/scripts/smoke-local
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly root
+readonly manifest="$root/testdata/smoke/manifest.json"
+work="$(mktemp -d "${TMPDIR:-/tmp}/buildkite-gha-smoke.XXXXXXXX")"
+trap 'rm -rf -- "$work"' EXIT
+
+cd "$root"
+
+[[ "$(jq --version)" == jq-1.8.2 ]] || { echo 'smoke-local requires mise-pinned jq 1.8.2' >&2; exit 1; }
+
+jq -e '
+  keys == ["fixtures", "schema"] and
+  .schema == "buildkite-gha/smoke-manifest/v1" and
+  (.fixtures | type == "array" and length == 6) and
+  all(.fixtures[];
+    keys == ["action_preflight", "event", "evidence", "expectation", "id", "note", "workflow"] and
+    (.id | test("^[a-z0-9]+(?:-[a-z0-9]+)*$")) and
+    (.workflow | type == "string" and length > 0 and startswith("testdata/") and (contains("..") | not)) and
+    (.event | type == "string" and length > 0 and startswith("testdata/") and (contains("..") | not)) and
+    (.expectation | IN("compile-pass", "runtime-pass", "runtime-unsupported", "future")) and
+    (.action_preflight | IN("none", "hosted-tokenless")) and
+    (.evidence | type == "string" and length > 0) and
+    (.note | type == "string" and length > 0)) and
+  ([.fixtures[].id] | length == (unique | length)) and
+  ([.fixtures[] | [.workflow, .event] | join("\u0000")] | length == (unique | length))
+' "$manifest" >/dev/null
+
+mise exec -- go build -o "$work/buildkite-gha" ./cmd/buildkite-gha
+
+while IFS=$'\t' read -r id workflow event expectation; do
+  [[ -f "$root/$workflow" ]] || { echo "$id: missing workflow $workflow" >&2; exit 1; }
+  [[ -f "$root/$event" ]] || { echo "$id: missing event $event" >&2; exit 1; }
+  echo "$id: classification=$expectation"
+  if [[ "$expectation" == future ]]; then
+    echo "$id: skipped=inventory-only"
+    continue
+  fi
+  "$work/buildkite-gha" validate --format json --event-path "$root/$event" "$root/$workflow" | jq -e '.result == "compilable"' >/dev/null
+  "$work/buildkite-gha" compile --event-path "$root/$event" "$root/$workflow" >"$work/$id.first"
+  "$work/buildkite-gha" compile --event-path "$root/$event" "$root/$workflow" >"$work/$id.second"
+  [[ -s "$work/$id.first" ]] || { echo "$id: empty pipeline" >&2; exit 1; }
+  cmp -s "$work/$id.first" "$work/$id.second" || { echo "$id: nondeterministic pipeline" >&2; exit 1; }
+  echo "$id: validate=pass compile=deterministic"
+done < <(jq -r '.fixtures[] | [.id, .workflow, .event, .expectation] | @tsv' "$manifest")
+
+echo 'PASS: local smoke inventory validated and compiled deterministically.'
+echo 'CAVEAT: successful compilation is not runtime evidence; classifications come from the manifest.'

--- a/scripts/smoke-local
+++ b/scripts/smoke-local
@@ -22,13 +22,13 @@ cd "$root"
 jq -e '
   keys == ["fixtures", "schema"] and
   .schema == "buildkite-gha/smoke-manifest/v1" and
-  (.fixtures | type == "array" and length == 6) and
+  (.fixtures | type == "array" and length == 9) and
   all(.fixtures[];
     keys == ["action_preflight", "event", "evidence", "expectation", "id", "note", "workflow"] and
     (.id | test("^[a-z0-9]+(?:-[a-z0-9]+)*$")) and
     (.workflow | type == "string" and length > 0 and startswith("testdata/") and (contains("..") | not)) and
     (.event | type == "string" and length > 0 and startswith("testdata/") and (contains("..") | not)) and
-    (.expectation | IN("compile-pass", "runtime-pass", "runtime-unsupported", "future")) and
+    (.expectation | IN("compile-pass", "compile-unsupported", "runtime-pass", "runtime-unsupported", "future")) and
     (.action_preflight | IN("none", "hosted-tokenless")) and
     (.evidence | type == "string" and length > 0) and
     (.note | type == "string" and length > 0)) and
@@ -50,6 +50,15 @@ while IFS=$'\t' read -r id workflow event expectation action_preflight; do
     echo "$id: skipped=inventory-only"
     continue
   fi
+  if [[ "$expectation" == compile-unsupported ]]; then
+    if "$work/buildkite-gha" validate --format json --event-path "$root/$event" "$root/$workflow" >"$work/$id.validation.json"; then
+      echo "$id: validation unexpectedly succeeded" >&2
+      exit 1
+    fi
+    jq -e '.result == "incompatible" and any(.diagnostics[]; .code == "E_COMPILE")' "$work/$id.validation.json" >/dev/null
+    echo "$id: validate=expected-incompatible"
+    continue
+  fi
   "$work/buildkite-gha" validate --format json --event-path "$root/$event" "$root/$workflow" | jq -e '.result == "compilable"' >/dev/null
   "$work/buildkite-gha" compile --event-path "$root/$event" "$root/$workflow" >"$work/$id.first"
   "$work/buildkite-gha" compile --event-path "$root/$event" "$root/$workflow" >"$work/$id.second"
@@ -57,15 +66,23 @@ while IFS=$'\t' read -r id workflow event expectation action_preflight; do
   cmp -s "$work/$id.first" "$work/$id.second" || { echo "$id: nondeterministic pipeline" >&2; exit 1; }
   echo "$id: validate=pass compile=deterministic"
   if [[ -n "$profile" && "$action_preflight" == "$profile" ]]; then
+    profile_status=0
     BUILDKITE_GHA_NODE20="$node20" BUILDKITE_GHA_NODE24="$node24" \
       "$work/buildkite-gha" validate --profile "$profile" --format json \
-      --event-path "$root/$event" "$root/$workflow" >"$work/$id.profile.json"
-    jq -e '.result == "admitted" and .admission.result == "admitted"' "$work/$id.profile.json" >/dev/null
-    echo "$id: profile=$profile admission=pass runtime=not-proven"
+      --event-path "$root/$event" "$root/$workflow" >"$work/$id.profile.json" || profile_status=$?
+    if [[ "$expectation" == runtime-unsupported ]]; then
+      [[ "$profile_status" == 1 ]] || { echo "$id: profile unexpectedly exited $profile_status" >&2; exit 1; }
+      jq -e '.result == "not-admitted" and .admission.result == "not-admitted" and any(.diagnostics[]; .code == "E_PROFILE" and (.message | test("requires the unavailable GitHub Actions (artifact|cache) service; Phase 6 is required$")))' "$work/$id.profile.json" >/dev/null
+      echo "$id: profile=$profile admission=expected-rejection"
+    else
+      [[ "$profile_status" == 0 ]] || { echo "$id: profile unexpectedly exited $profile_status" >&2; exit 1; }
+      jq -e '.result == "admitted" and .admission.result == "admitted"' "$work/$id.profile.json" >/dev/null
+      echo "$id: profile=$profile admission=pass runtime=not-proven"
+    fi
   fi
 done < <(jq -r '.fixtures[] | [.id, .workflow, .event, .expectation, .action_preflight] | @tsv' "$manifest")
 
-echo 'PASS: local smoke inventory validated and compiled deterministically.'
+echo 'PASS: local smoke inventory matched its compile and rejection classifications.'
 echo 'CAVEAT: successful compilation is not runtime evidence; classifications come from the manifest.'
 if [[ -n "$profile" ]]; then
   echo 'CAVEAT: profile admission resolves actions and applies upload policy but does not execute arbitrary action code.'

--- a/testdata/smoke/README.md
+++ b/testdata/smoke/README.md
@@ -37,6 +37,12 @@ each workflow, and compare two nonempty pipeline compilations byte for byte.
 The default harness does not parse emitted YAML, fetch actions, or execute
 workflows; successful compilation is not runtime evidence.
 
+Run `mise run smoke:profile` for the opt-in networked preflight of entries marked
+`hosted-tokenless`. It anonymously resolves actions, prepares the managed Node
+runtimes, compiles plans, and applies the same admission policy as production
+upload. Admission does not execute action code or prove that a generic action
+is independent of GitHub-only artifact, cache, token, or OIDC services.
+
 `events/push.json` is deterministic and its repository SHA is intentionally
 synthetic. End-to-end runs involving checkout must bind the event to the real
 fixture repository and commit. External actions remain pinned to immutable

--- a/testdata/smoke/README.md
+++ b/testdata/smoke/README.md
@@ -26,10 +26,11 @@ Expectations have these precise meanings:
 
 - `compile-pass`: validation and deterministic compilation are required. Any
   cited component runtime evidence does not establish full fixture execution.
+- `compile-unsupported`: validation must fail with a stable compile diagnostic.
 - `runtime-pass`: runtime evidence exists outside this compile-only harness;
   local validation and deterministic compilation remain required.
 - `runtime-unsupported`: compilation is required, but a runtime dependency is
-  intentionally unsupported (currently GitHub artifact services).
+  intentionally unsupported (currently GitHub artifact and cache services).
 - `future`: the fixture is inventoried but not yet required to compile.
 
 Run `mise run smoke:local` to strictly validate the manifest, JSON-validate
@@ -42,6 +43,9 @@ Run `mise run smoke:profile` for the opt-in networked preflight of entries marke
 runtimes, compiles plans, and applies the same admission policy as production
 upload. Admission does not execute action code or prove that a generic action
 is independent of GitHub-only artifact, cache, token, or OIDC services.
+Known official cache and artifact actions are rejected until their Phase 6
+adapters exist; the profile leaves unknown generic service dependencies as an
+explicit warning rather than guessing from arbitrary action source.
 
 `events/push.json` is deterministic and its repository SHA is intentionally
 synthetic. End-to-end runs involving checkout must bind the event to the real

--- a/testdata/smoke/README.md
+++ b/testdata/smoke/README.md
@@ -1,4 +1,4 @@
-# Smoke workflow fixture
+# Smoke workflow fixtures
 
 This directory is a self-contained repository fixture for the first
 `buildkite-gha` vertical slice. A differential-test harness should materialize
@@ -18,13 +18,26 @@ workflow is executable:
 4. `artifact.yml` adds GitHub artifact-action compatibility and verifies one
    payload in both consumer matrix instances.
 
-All four workflows are compiler fixtures from Phase 1 onward. Only promote a
-workflow into a required runtime lane when its owning phase is implemented.
+`manifest.json` is the authoritative, ordered compatibility inventory for
+these workflows and the related Phase 4 and Phase 5 fixtures. Every entry names
+its deterministic compile event and records the separate runtime evidence.
 
-`events/push.json` is a deterministic compile fixture, so its repository SHA is
-intentionally synthetic. End-to-end runs must bind the envelope to the real
-fixture repository and commit created by the harness before `actions/checkout`
-executes.
+Expectations have these precise meanings:
 
-The external actions are pinned to immutable commits. Update them intentionally
-and record any resulting observation change in the same commit.
+- `compile-pass`: validation and deterministic compilation are required. Any
+  cited component runtime evidence does not establish full fixture execution.
+- `runtime-pass`: runtime evidence exists outside this compile-only harness;
+  local validation and deterministic compilation remain required.
+- `runtime-unsupported`: compilation is required, but a runtime dependency is
+  intentionally unsupported (currently GitHub artifact services).
+- `future`: the fixture is inventoried but not yet required to compile.
+
+Run `mise run smoke:local` to strictly validate the manifest, JSON-validate
+each workflow, and compare two nonempty pipeline compilations byte for byte.
+The default harness does not parse emitted YAML, fetch actions, or execute
+workflows; successful compilation is not runtime evidence.
+
+`events/push.json` is deterministic and its repository SHA is intentionally
+synthetic. End-to-end runs involving checkout must bind the event to the real
+fixture repository and commit. External actions remain pinned to immutable
+commits and should be updated intentionally with their runtime evidence.

--- a/testdata/smoke/manifest.json
+++ b/testdata/smoke/manifest.json
@@ -26,7 +26,7 @@
       "expectation": "compile-pass",
       "evidence": "Local JavaScript and composite action components have runtime tests; the complete hosted fixture does not.",
       "note": "Component runtime evidence must not be read as full workflow runtime evidence.",
-      "action_preflight": "none"
+      "action_preflight": "hosted-tokenless"
     },
     {
       "id": "smoke-artifact",
@@ -35,7 +35,7 @@
       "expectation": "runtime-unsupported",
       "evidence": "Compilation is covered, but GitHub artifact service emulation is deferred.",
       "note": "Upload-artifact and download-artifact require hosted service compatibility.",
-      "action_preflight": "none"
+      "action_preflight": "hosted-tokenless"
     },
     {
       "id": "phase4-public-actions",
@@ -44,7 +44,7 @@
       "expectation": "runtime-pass",
       "evidence": "The pinned public checkout and setup action proof has runtime coverage.",
       "note": "The local harness compiles only and never fetches these actions.",
-      "action_preflight": "none"
+      "action_preflight": "hosted-tokenless"
     },
     {
       "id": "phase5-docker-action",
@@ -53,7 +53,7 @@
       "expectation": "runtime-pass",
       "evidence": "The pinned public Dockerfile action proof has hosted runtime coverage.",
       "note": "The deterministic smoke event matches the production Phase 5 proof input.",
-      "action_preflight": "none"
+      "action_preflight": "hosted-tokenless"
     }
   ]
 }

--- a/testdata/smoke/manifest.json
+++ b/testdata/smoke/manifest.json
@@ -1,0 +1,59 @@
+{
+  "schema": "buildkite-gha/smoke-manifest/v1",
+  "fixtures": [
+    {
+      "id": "smoke-shell",
+      "workflow": "testdata/smoke/.github/workflows/shell.yml",
+      "event": "testdata/smoke/events/push.json",
+      "expectation": "runtime-pass",
+      "evidence": "Shell workflow runtime observations pass in the local runtime coverage.",
+      "note": "Primary shell and matrix runtime smoke fixture.",
+      "action_preflight": "none"
+    },
+    {
+      "id": "smoke-concurrent",
+      "workflow": "testdata/smoke/.github/workflows/concurrent.yml",
+      "event": "testdata/smoke/events/push.json",
+      "expectation": "runtime-pass",
+      "evidence": "Concurrent-step barriers, cancellation, and queueing have local runtime coverage.",
+      "note": "Exercises the concurrent workflow extensions.",
+      "action_preflight": "none"
+    },
+    {
+      "id": "smoke-ci",
+      "workflow": "testdata/smoke/.github/workflows/ci.yml",
+      "event": "testdata/smoke/events/push.json",
+      "expectation": "compile-pass",
+      "evidence": "Local JavaScript and composite action components have runtime tests; the complete hosted fixture does not.",
+      "note": "Component runtime evidence must not be read as full workflow runtime evidence.",
+      "action_preflight": "none"
+    },
+    {
+      "id": "smoke-artifact",
+      "workflow": "testdata/smoke/.github/workflows/artifact.yml",
+      "event": "testdata/smoke/events/push.json",
+      "expectation": "runtime-unsupported",
+      "evidence": "Compilation is covered, but GitHub artifact service emulation is deferred.",
+      "note": "Upload-artifact and download-artifact require hosted service compatibility.",
+      "action_preflight": "none"
+    },
+    {
+      "id": "phase4-public-actions",
+      "workflow": "testdata/phase4/.github/workflows/public-actions.yml",
+      "event": "testdata/phase4/events/public-checkout.json",
+      "expectation": "runtime-pass",
+      "evidence": "The pinned public checkout and setup action proof has runtime coverage.",
+      "note": "The local harness compiles only and never fetches these actions.",
+      "action_preflight": "none"
+    },
+    {
+      "id": "phase5-docker-action",
+      "workflow": "testdata/phase5/.github/workflows/docker-action.yml.tmpl",
+      "event": "testdata/smoke/events/push.json",
+      "expectation": "runtime-pass",
+      "evidence": "The pinned public Dockerfile action proof has hosted runtime coverage.",
+      "note": "The deterministic smoke event matches the production Phase 5 proof input.",
+      "action_preflight": "none"
+    }
+  ]
+}

--- a/testdata/smoke/manifest.json
+++ b/testdata/smoke/manifest.json
@@ -54,6 +54,33 @@
       "evidence": "The pinned public Dockerfile action proof has hosted runtime coverage.",
       "note": "The deterministic smoke event matches the production Phase 5 proof input.",
       "action_preflight": "hosted-tokenless"
+    },
+    {
+      "id": "unsupported-cache-service",
+      "workflow": "testdata/unsupported/.github/workflows/cache.yml",
+      "event": "testdata/smoke/events/push.json",
+      "expectation": "runtime-unsupported",
+      "evidence": "The production hosted-tokenless policy rejects the known GitHub Actions cache service dependency.",
+      "note": "Phase 6 owns the Buildkite cache compatibility adapter.",
+      "action_preflight": "hosted-tokenless"
+    },
+    {
+      "id": "unsupported-job-container",
+      "workflow": "testdata/unsupported/.github/workflows/job-container.yml",
+      "event": "testdata/smoke/events/push.json",
+      "expectation": "compile-unsupported",
+      "evidence": "Static validation rejects job containers at the owned compatibility boundary.",
+      "note": "This negative fixture prevents compile success from implying job-container support.",
+      "action_preflight": "none"
+    },
+    {
+      "id": "unsupported-service-container",
+      "workflow": "testdata/unsupported/.github/workflows/service-container.yml",
+      "event": "testdata/smoke/events/push.json",
+      "expectation": "compile-unsupported",
+      "evidence": "Static validation rejects service containers at the owned compatibility boundary.",
+      "note": "This negative fixture prevents compile success from implying service-container support.",
+      "action_preflight": "none"
     }
   ]
 }

--- a/testdata/unsupported/.github/workflows/cache.yml
+++ b/testdata/unsupported/.github/workflows/cache.yml
@@ -1,0 +1,18 @@
+name: Unsupported cache service
+
+on:
+  push:
+
+jobs:
+  cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create cache payload
+        shell: bash
+        run: mkdir -p cache-data && echo payload > cache-data/value
+
+      - name: Cache payload
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: cache-data
+          key: unsupported-cache-fixture

--- a/testdata/unsupported/.github/workflows/job-container.yml
+++ b/testdata/unsupported/.github/workflows/job-container.yml
@@ -1,0 +1,11 @@
+name: Unsupported job container
+
+on:
+  push:
+
+jobs:
+  container:
+    runs-on: ubuntu-latest
+    container: node:24
+    steps:
+      - run: node --version

--- a/testdata/unsupported/.github/workflows/service-container.yml
+++ b/testdata/unsupported/.github/workflows/service-container.yml
@@ -1,0 +1,13 @@
+name: Unsupported service container
+
+on:
+  push:
+
+jobs:
+  service:
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7
+    steps:
+      - run: true


### PR DESCRIPTION
## Summary

- add a network-free classified smoke inventory with deterministic compilation and expected-negative fixtures
- add the hosted-tokenless compatibility preflight using the production action-resolution and admission path
- add an exact-commit hosted dispatcher that aggregates the Phase 2-5 runtime proofs and propagates every target outcome
- document practical local, profile, and hosted manual testing workflows

## Boundaries

- profile admission is policy evidence, not arbitrary action runtime proof
- official GitHub artifact/cache actions remain rejected pending Phase 6 adapters
- job and service containers remain statically unsupported
- the hosted dispatcher preserves each phase's independent importer/continuation topology

## Verification

- `mise run --jobs 1 check`
- `mise run smoke:profile`
- Oracle reviews at the profile-policy and hosted-aggregation boundaries
