### PR TITLE
Complete Phase 5 container runtime

### DIFF
--- a/.buildkite/hosted-smoke-aggregator.yml
+++ b/.buildkite/hosted-smoke-aggregator.yml
@@ -18,6 +18,8 @@ steps:
         allow_failure: true
       - step: "gha-docker-action"
         allow_failure: true
+      - step: "phase-5-hosted-runtime-probe"
+        allow_failure: true
       - step: "phase-2-native-after-shell"
         allow_failure: true
       - step: "phase-3-native-after-concurrent"
@@ -27,6 +29,8 @@ steps:
       - step: "phase-5-native-after-hosted-docker"
         allow_failure: true
       - step: "phase-5-native-after-docker-action"
+        allow_failure: true
+      - step: "phase-5-native-after-runtime"
         allow_failure: true
     agents:
       queue: "elastic-runners"
@@ -42,11 +46,13 @@ steps:
         gha-public-actions \
         phase-5-hosted-docker-probe \
         gha-docker-action \
+        phase-5-hosted-runtime-probe \
         phase-2-native-after-shell \
         phase-3-native-after-concurrent \
         phase-4-native-after-actions \
         phase-5-native-after-hosted-docker \
-        phase-5-native-after-docker-action
+        phase-5-native-after-docker-action \
+        phase-5-native-after-runtime
       do
         outcome="$$(buildkite-agent step get "outcome" --step "$$step")"
         printf '%s: %s\n' "$$step" "$$outcome"

--- a/.buildkite/hosted-smoke-control.yml
+++ b/.buildkite/hosted-smoke-control.yml
@@ -12,6 +12,8 @@ steps:
         allow_failure: true
       - step: "phase-5-docker-action-continuation-loader"
         allow_failure: true
+      - step: "phase-5-runtime-continuation-loader"
+        allow_failure: true
     agents:
       queue: "elastic-runners"
     command: "buildkite-agent pipeline upload .buildkite/hosted-smoke-aggregator.yml"

--- a/.buildkite/phase-2-upload.yml
+++ b/.buildkite/phase-2-upload.yml
@@ -12,7 +12,7 @@ steps:
       scripts/phase-0-shell-oracle-checkout "$$commit"
       distribution_root="$$(mktemp -d "$${TMPDIR:-/tmp}/buildkite-gha-phase2.XXXXXXXX")"
       trap 'rm -rf -- "$$distribution_root"' EXIT
-      mise exec -- go build -trimpath -buildvcs=false -o "$$distribution_root/buildkite-gha" ./cmd/buildkite-gha
+      CGO_ENABLED=0 mise exec -- go build -trimpath -buildvcs=false -o "$$distribution_root/buildkite-gha" ./cmd/buildkite-gha
       "$$distribution_root/buildkite-gha" upload \
         --event-path testdata/smoke/events/push.json \
         --runtime-queue hosted \

--- a/.buildkite/phase-3-upload.yml
+++ b/.buildkite/phase-3-upload.yml
@@ -12,7 +12,7 @@ steps:
       scripts/phase-0-shell-oracle-checkout "$$commit"
       distribution_root="$$(mktemp -d "$${TMPDIR:-/tmp}/buildkite-gha-phase3.XXXXXXXX")"
       trap 'rm -rf -- "$$distribution_root"' EXIT
-      mise exec -- go build -trimpath -buildvcs=false -o "$$distribution_root/buildkite-gha" ./cmd/buildkite-gha
+      CGO_ENABLED=0 mise exec -- go build -trimpath -buildvcs=false -o "$$distribution_root/buildkite-gha" ./cmd/buildkite-gha
       "$$distribution_root/buildkite-gha" upload \
         --event-path testdata/smoke/events/push.json \
         --runtime-queue hosted \

--- a/.buildkite/phase-4-upload.yml
+++ b/.buildkite/phase-4-upload.yml
@@ -14,7 +14,7 @@ steps:
       distribution_root="$$(mktemp -d "$${TMPDIR:-/tmp}/buildkite-gha-phase4.XXXXXXXX")"
       trap 'rm -rf -- "$$distribution_root"' EXIT
       runtime_version="0.0.0-phase4.$$commit"
-      mise exec -- go build -trimpath -buildvcs=false -ldflags "-X main.version=$$runtime_version" -o "$$distribution_root/buildkite-gha" ./cmd/buildkite-gha
+      CGO_ENABLED=0 mise exec -- go build -trimpath -buildvcs=false -ldflags "-X main.version=$$runtime_version" -o "$$distribution_root/buildkite-gha" ./cmd/buildkite-gha
       BUILDKITE_GHA_NODE20="$$(mise where node@20)/bin/node" \
       BUILDKITE_GHA_NODE24="$$(mise where node@24)/bin/node" \
       "$$distribution_root/buildkite-gha" upload \

--- a/.buildkite/phase-5-docker-action.yml
+++ b/.buildkite/phase-5-docker-action.yml
@@ -20,7 +20,7 @@ steps:
       cp testdata/phase5/.github/workflows/docker-action.yml.tmpl \
         "$$proof_root/.github/workflows/docker-action.yml"
       runtime_version="0.0.0-phase5.$$commit"
-      mise exec -- go build -trimpath -buildvcs=false -ldflags "-X main.version=$$runtime_version" -o "$$proof_root/buildkite-gha" ./cmd/buildkite-gha
+      CGO_ENABLED=0 mise exec -- go build -trimpath -buildvcs=false -ldflags "-X main.version=$$runtime_version" -o "$$proof_root/buildkite-gha" ./cmd/buildkite-gha
       BUILDKITE_GHA_NODE20="$$(mise where node@20)/bin/node" \
       BUILDKITE_GHA_NODE24="$$(mise where node@24)/bin/node" \
       "$$proof_root/buildkite-gha" upload \

--- a/.buildkite/phase-5-runtime-continuation.yml
+++ b/.buildkite/phase-5-runtime-continuation.yml
@@ -1,0 +1,9 @@
+steps:
+  - label: ":white_check_mark: Phase 5 container runtime settled"
+    key: "phase-5-native-after-runtime"
+    depends_on:
+      - step: "phase-5-hosted-runtime-probe"
+        allow_failure: true
+    agents:
+      queue: "elastic-runners"
+    command: "echo 'Phase 5 hosted container runtime proof settled'"

--- a/.buildkite/phase-5-runtime-probe.yml
+++ b/.buildkite/phase-5-runtime-probe.yml
@@ -1,0 +1,12 @@
+steps:
+  - label: ":docker: Phase 5 container runtime"
+    key: "phase-5-hosted-runtime-probe"
+    agents:
+      queue: "hosted"
+    timeout_in_minutes: 25
+    retry:
+      automatic: false
+    plugins:
+      - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
+          version: "2026.5.12"
+    command: "scripts/phase-5-hosted-runtime-probe"

--- a/.buildkite/phase-5-runtime.yml
+++ b/.buildkite/phase-5-runtime.yml
@@ -1,0 +1,21 @@
+steps:
+  - label: ":pipeline: Phase 5 container runtime importer"
+    key: "phase-5-runtime-importer"
+    agents:
+      queue: "elastic-runners"
+    retry:
+      automatic: false
+    command: |
+      set -euo pipefail
+      commit="$${PHASE5_COMMIT:-$${SMOKE_COMMIT:-}}"
+      scripts/phase-0-shell-oracle-checkout "$$commit"
+      test -z "$$(git status --porcelain --untracked-files=all)"
+      buildkite-agent pipeline upload --no-interpolation --reject-secrets .buildkite/phase-5-runtime-probe.yml
+
+  - label: ":pipeline: Phase 5 container runtime continuation loader"
+    key: "phase-5-runtime-continuation-loader"
+    depends_on: "phase-5-runtime-importer"
+    allow_dependency_failure: true
+    agents:
+      queue: "elastic-runners"
+    command: "buildkite-agent pipeline upload .buildkite/phase-5-runtime-continuation.yml"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -51,6 +51,13 @@ steps:
     agents:
       queue: "elastic-runners"
 
+  - label: ":docker: Load Phase 5 container runtime proof"
+    key: "phase-5-runtime-loader"
+    if: build.env("PHASE5_PROBE") == "runtime" && build.env("SMOKE_PROBE") != "hosted"
+    command: "buildkite-agent pipeline upload .buildkite/phase-5-runtime.yml"
+    agents:
+      queue: "elastic-runners"
+
   - label: ":pipeline: Load consolidated hosted smoke proof"
     key: "hosted-smoke-loader"
     if: build.env("SMOKE_PROBE") == "hosted"
@@ -77,6 +84,7 @@ steps:
       buildkite-agent pipeline upload .buildkite/phase-4-upload.yml
       buildkite-agent pipeline upload .buildkite/phase-5-capabilities.yml
       buildkite-agent pipeline upload .buildkite/phase-5-docker-action.yml
+      buildkite-agent pipeline upload .buildkite/phase-5-runtime.yml
       buildkite-agent pipeline upload .buildkite/hosted-smoke-control.yml
     agents:
       queue: "elastic-runners"

--- a/README.md
+++ b/README.md
@@ -7,10 +7,9 @@ compatibility runtime, without creating a GitHub Actions run.
 
 The Phase 0 semantic foundation, Phase 1 static compiler, Phase 2 shell
 runtime, Phase 3 concurrent-step runtime, Phase 4 JavaScript/composite action
-runtime, and the Dockerfile-action entry slice of Phase 5 are implemented. The
-compiler validates the supported graph, expands local reusable workflows and
-matrices, applies queue policy, produces immutable job plans, and emits a
-Buildkite pipeline.
+runtime, and Phase 5 container runtime are implemented. The compiler validates
+the supported graph, expands local reusable workflows and matrices, applies
+queue policy, produces immutable job plans, and emits a Buildkite pipeline.
 
 ## Commands
 
@@ -96,9 +95,28 @@ actions run from a private staged copy of the verified source, require the local
 Buildx `default` Docker driver, use fixed workspace and file-command mounts, and
 receive runtime-owned names and labels with bounded cleanup. Docker and host
 steps share the job's security boundary; installations that require host-level
-isolation must run each job in a disposable VM. `docker://` images, Docker
-lifecycle overrides, arbitrary Docker options, services, and job containers
-remain outside the executable subset. In Buildkite,
+isolation must run each job in a disposable VM.
+
+Schema-v4 plans additionally support one persistent job container and declared
+service containers. Shell, JavaScript, and composite steps execute in the job
+container; Dockerfile actions and services run as siblings on one runtime-owned
+network. Container jobs reach services by their service IDs. Host jobs remain
+host processes and reach published service ports through
+`127.0.0.1:${{ job.services.<id>.ports[<port>] }}`; sibling Dockerfile actions
+join the service network. Declared image users remain in effect, service and
+Docker-action entrypoints are preserved, and the runtime owns the persistent
+job-container command. Images are pulled anonymously with a private Docker
+configuration. Runtime names, networks, labels, mounts, process trees, and
+cleanup are owned exactly and cleaned under bounded contexts.
+
+Only literal public images, environment values, and ports are accepted.
+Credentials, private registries, arbitrary Docker options or volumes,
+privileged containers, host Docker socket mounts, devices, arbitrary host
+mounts, and `docker://` action images remain unsupported. Production
+`hosted-tokenless` upload also continues to reject job- and service-container
+provenance: the broader container runtime is currently exercised through the
+checked-in compiler-to-Runner hosted proof, while normal upload admits only the
+compiler-proven Dockerfile-action slice. In Buildkite,
 `run-job` verifies the exact build, job, step, and plan digest before resolving
 each prerequisite from its attributed producer artifact, then publishes the
 terminal result under a bounded cleanup context; metadata is only a best-effort
@@ -149,9 +167,12 @@ mise run smoke:local
 This validates the manifest, performs static workflow validation, and compiles
 the supported fixtures twice to verify deterministic output. It also checks
 the expected-negative classifications: workflows using the official GitHub
-artifact and cache actions compile, while job and service containers fail
-static compilation. A passing local smoke run is compile-time evidence only;
-it is explicitly not proof that a workflow runs successfully.
+artifact and cache actions compile but remain runtime-unsupported. Job and
+service container fixtures compile deterministically and are classified
+`runtime-pass` from the exact-commit hosted Phase 5 proof, while remaining
+outside production `hosted-tokenless` admission. A passing local smoke run is
+compile-time evidence only; it is explicitly not proof that a workflow runs
+successfully.
 
 For an opt-in public-network preflight, run:
 
@@ -190,8 +211,9 @@ bk build create --pipeline buildkite/buildkite-gha \
 ```
 
 The aggregate collects the Phase 2 shell/upload proof, Phase 3 concurrent-step
-proof, Phase 4 public-action proof, and both Phase 5 Docker proofs (hosted Docker
-capabilities and the Dockerfile action). It retains each phase's independent
+proof, Phase 4 public-action proof, and three Phase 5 proofs: hosted Docker
+capabilities, the production Dockerfile-action slice, and the complete
+compiler-to-Runner container runtime. It retains each phase's independent
 importer and continuation loader rather than flattening their topology. The
 phase-specific selectors below remain available for targeted diagnosis.
 
@@ -236,6 +258,16 @@ builds and runs the verified action on `hosted`, propagates its output, and must
 settle before the separately uploaded native Buildkite continuation. The
 matching differential is
 `.github/workflows/phase-5-docker-action-oracle.yml`.
+
+The complete Phase 5 runtime proof is intentionally separate from production
+upload admission. Start an exact-commit build with `PHASE5_PROBE=runtime` and
+`PHASE5_COMMIT=<full commit>` to load `.buildkite/phase-5-runtime.yml`. It runs
+the checked-in two-job fixture through the compiler and Runner on hosted Docker,
+covering persistent container state, services from container and host jobs,
+JavaScript/composite/Dockerfile actions, process-tree cancellation, diagnostics,
+masking, and exact cleanup. [Buildkite build 136](https://buildkite.com/buildkite/buildkite-gha/builds/136)
+passed all required live tests without skips against exact runtime-evidence
+commit `50db2cf89ba23c0e051d7d57cc03e115606768e5`.
 
 ## License
 

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -1203,10 +1203,11 @@ Explicitly defer from beta unless implementation evidence changes the order:
   20 and 24 executable bytes for action workflows; the repository distribution
   pins these runtimes to 20.20.2 and 24.18.0. Shell-only uploads remain
   unchanged and require no Node runtime. This path remains `EventUntrusted`,
-  fixed to the ambient-clean, tokenless hosted queue, and accepts only no
-  capability or `network`; private remote action or repository source, provider
-  tokens, secrets, Docker, privileged queues, and other protected capabilities
-  fail closed.
+  fixed to the ambient-clean, tokenless hosted queue, and accepts no capability,
+  `network`, or the Phase 5 compiler-proven Dockerfile-action provenance.
+  Private remote action or repository source, provider tokens, secrets, job- or
+  service-container provenance, privileged queues, and other protected
+  capabilities fail closed.
   Because this repository is private, the historical live evidence is split:
   the former proof importer used a synthetic public event to prove anonymous
   checkout and portable setup actions on Buildkite, while the GitHub-hosted
@@ -1214,20 +1215,23 @@ Explicitly defer from beta unless implementation evidence changes the order:
   JavaScript/composite fixture. This does not claim a same-workflow private
   checkout proof on Buildkite. The migrated normal path now has separate exact
   Buildkite and GitHub-hosted evidence below.
-- Phase 5 entry evidence is implemented without yet authorizing Docker in the
-  production upload path. An exact-commit, fixed-`hosted` probe demonstrates a
-  runnable local Docker daemon, bind mounts and ownership, private-network DNS,
-  health checks, dynamic loopback port publication, observable TERM handling,
-  and exact-label cleanup. Buildkite Hosted Agents provide a disposable,
-  isolated virtualized environment for each job and destroy it regardless of
-  exit status. The queue's active Buildx builder is remote and cluster-scoped,
-  however, so anonymous Dockerfile builds must select the local `default`
-  Docker driver explicitly rather than execute untrusted `RUN` instructions in
-  the remote builder's persistent shared cache. The first production slice
-  remains limited to Dockerfile-backed local and anonymous public actions;
-  `docker://`, Docker pre/post entrypoints, job containers, services, private
-  registries, arbitrary options, protected capabilities, and privileged queues
-  continue to fail closed until their owning slices land.
+- Phase 5 is complete. Schema-v4 plans own one persistent job container,
+  service containers for container and host jobs, network aliases and ports,
+  health diagnostics, host/container path translation, Dockerfile actions, and
+  bounded cancellation and cleanup. Shell, JavaScript, and composite steps run
+  in the persistent job container; services and Dockerfile actions are siblings
+  on one runtime-owned network. Host jobs remain host processes and receive
+  loopback-only published service ports. Image pulls are anonymous through a
+  private Docker configuration, and Dockerfile builds explicitly select the
+  local `default` driver so workflow code remains inside the disposable hosted
+  job VM rather than the queue's remote shared builder. That VM is the isolation
+  boundary; fixed mounts, networks, labels, and cleanup prevent resource
+  confusion but do not sandbox mutually trusted steps within one job. Normal
+  `hosted-tokenless` upload remains limited to compiler-proven Dockerfile-backed
+  local and anonymous public actions. Job- and service-container provenance,
+  `docker://`, Docker lifecycle overrides, private registries, arbitrary
+  options, credentials, protected capabilities, and privileged queues continue
+  to fail closed.
 - The first work wave is integrated: the Go/CLI foundation is runnable,
   ADR 0001 records the actionlint/act reuse boundary, and ADR 0002 plus schemas
   and eight conformance cases preserve the Phase 0 signed-envelope transport
@@ -1263,7 +1267,7 @@ Explicitly defer from beta unless implementation evidence changes the order:
   an authoritative completion order.
 - All local tests, race tests, vet, schema fixtures, shell checks, and offline
   pipeline validation pass. A default `.buildkite/pipeline.yml` now runs the
-  repository checks, and all four smoke compiler outputs pass the current
+  repository checks, and all compilable smoke-manifest outputs pass the current
   Buildkite Agent's `pipeline upload --dry-run --no-interpolation` parser.
 - The smoke inventory now separates compilation, production-policy admission,
   and runtime evidence. `mise run smoke:local` is network-free: it validates
@@ -1277,17 +1281,18 @@ Explicitly defer from beta unless implementation evidence changes the order:
   `buildkite-gha validate --profile hosted-tokenless --event-path <path>
   --format text|json <workflow>`. Expected-negative fixtures preserve current
   boundaries: official GitHub artifact/cache actions compile but are denied
-  admission pending Phase 6, while job and service containers fail static
-  compilation.
+  admission pending Phase 6. Job and service containers compile to schema-v4
+  plans and have hosted runtime evidence, while production admission rejects
+  their container provenance.
 - A consolidated exact-commit hosted dispatcher is available with
   `SMOKE_PROBE=hosted` and `SMOKE_COMMIT=<full commit>`. It aggregates the
   Phase 2 shell/upload, Phase 3 concurrent, Phase 4 public-action, Phase 5
-  hosted-Docker capability, and Phase 5 Dockerfile-action proofs. The dispatcher
-  deliberately uploads each existing importer and continuation independently,
-  then settles their generated and native terminal steps; it does not flatten
-  the importer/continuation topology. Existing `PHASE2_PROBE`, `PHASE3_PROBE`,
-  `PHASE4_PROBE`, and both `PHASE5_PROBE` selectors remain available for
-  targeted runs.
+  hosted-Docker capability, Phase 5 Dockerfile-action, and Phase 5 complete
+  container-runtime proofs. The dispatcher deliberately uploads each existing
+  importer and continuation independently, then settles their generated and
+  native terminal steps; it does not flatten the importer/continuation topology.
+  Existing `PHASE2_PROBE`, `PHASE3_PROBE`, `PHASE4_PROBE`, and all three
+  `PHASE5_PROBE` selectors remain available for targeted runs.
 
 Phase 4 live evidence:
 
@@ -1301,7 +1306,7 @@ Phase 4 live evidence:
   ran the same implementation commit against the private repository. Its
   producer and consumer passed the JavaScript/composite differential fixture.
 
-Phase 5 entry evidence:
+Phase 5 evidence:
 
 - [Buildkite build 102](https://buildkite.com/buildkite/buildkite-gha/builds/102)
   ran exact implementation commit
@@ -1311,10 +1316,18 @@ Phase 5 entry evidence:
   requested UID/GID bind ownership, private-network HTTP by alias, container
   health, dynamic loopback publication, TERM observation, and exact-label
   cleanup. The separate continuation settled only after the hosted probe.
-- This establishes capability and queue-isolation evidence, not production
-  Docker authorization. Normal `buildkite-gha upload` still rejects the
-  `docker` capability until the staged-source, cancellation, bounded cleanup,
-  and policy work below is implemented and reviewed.
+- Build 102 establishes capability and queue-isolation prerequisites. It does
+  not by itself authorize Docker; the separately reviewed Dockerfile-action
+  path is the only Docker provenance admitted by normal tokenless upload.
+- [Buildkite build 136](https://buildkite.com/buildkite/buildkite-gha/builds/136)
+  ran exact runtime-evidence commit
+  `50db2cf89ba23c0e051d7d57cc03e115606768e5`. All seven required live tests
+  passed without skips. The compiler-to-Runner proof covered a persistent job
+  container, services from container and host jobs, service DNS and loopback
+  ports, JavaScript/composite/Dockerfile action lifecycle, process-tree
+  cancellation, masked health diagnostics, and exact owned-resource cleanup.
+  This proves the broader runtime implementation; it does not broaden
+  `hosted-tokenless` admission to job- or service-container provenance.
 
 - [Buildkite build 72](https://buildkite.com/buildkite/buildkite-gha/builds/72)
   ran exact implementation commit
@@ -1386,7 +1399,7 @@ Phase 0 spike support snapshot:
 | Boundary | Proven locally | Explicit gap or live gate |
 | --- | --- | --- |
 | Compile | Actionlint-backed owned model, deterministic compile-time context and vars evaluation, bounded local reusable-workflow flattening, source-ordered matrix `include`/`exclude`, exact dependency fan-out, policy-selected queues, schema-valid versioned plans, and Buildkite pipeline YAML | Runtime-dependent graph expressions, remote reusable workflows, unsupported operating systems, and unmapped runner labels fail closed |
-| Execute | Sequential Bash/sh steps; fresh workspaces; bounded prerequisite, step, and job outputs; environment, path, state, and summary files; status conditions; masking; timeouts; process-group cancellation; `continue-on-error`; and bounded LIFO post-actions | Producer result hydration still enters through the transport boundary; remote actions, nested composite actions, services/job containers, concurrent steps, and unsupported expression/coercion forms fail closed |
+| Execute | Bash/sh steps; ten-active-step concurrency with barrier-scoped effects; JavaScript, composite, and Dockerfile actions; persistent job containers; services for container and host jobs; fresh workspaces; bounded prerequisite, step, and job outputs; file commands; conditions; masking; timeouts; process-tree cancellation; `continue-on-error`; bounded LIFO post-actions; and exact container cleanup | Producer result hydration enters through the transport boundary; private actions, `docker://` actions, protected credentials, arbitrary container options, unsupported operating systems, and unsupported expression/coercion forms fail closed |
 | Differential | Isolated committed fixture, canonical capture/comparison, offline validation, and matching hosted GitHub Actions and Buildkite observations | Broader runtime behavior remains phase-specific differential work |
 | Transport | Confined materialization of verified content-addressed plan and binding bytes, deterministic two-job live upload, strict compiler edges, failure-settling logical edges, producer-bound manifests, metadata, Agent redaction, signed markers, and native dependency extension | The probe deliberately avoids assuming upload atomicity |
 | Authorization | Eight signed-envelope conformance cases plus live rejection of a corrupted signature prove bounded signing and verification mechanics only | Protected capabilities require Buildkite Job OIDC authentication, provider provenance and policy verification, narrow signed grants, runtime exchange checks, and auditability; Buildkite signed-pipeline integration remains optional Phase 9 work |
@@ -1589,7 +1602,7 @@ Definition of done:
 - Private action authentication is either implemented safely or rejected
   clearly.
 
-### Phase 5 — Containers and services (entry capability proven)
+### Phase 5 — Containers and services (complete)
 
 Implement the Linux Docker execution backend for:
 
@@ -1601,7 +1614,7 @@ Implement the Linux Docker execution backend for:
 - host/container path translation; and
 - orphan cleanup.
 
-Implementation order and fixed boundaries:
+Implemented order and fixed boundaries:
 
 1. Harden Dockerfile-backed actions first. Build only a private staged copy of
    the verified action tree, select `buildx build --builder default --load`, use
@@ -1612,12 +1625,12 @@ Implementation order and fixed boundaries:
    Docker pre/post entrypoints, arbitrary Docker options, private registries,
    credentials, provider tokens, host namespaces, devices, socket mounts, and
    privileged capabilities.
-3. Add persistent job containers and path translation only after Docker action
-   lifecycle, command-file processing, masking, cancellation, and cleanup pass
-   differential and exact-commit evidence.
-4. Add services, aliases, port context, health diagnostics, and startup/orphan
-   reconciliation on the same runtime-owned backend. Do not translate imported
-   container definitions into workflow-controlled Buildkite plugins.
+3. Persistent job containers and path translation landed after Docker action
+   lifecycle, command-file processing, masking, cancellation, and cleanup
+   passed conformance coverage.
+4. Services, aliases, port context, health diagnostics, and startup/orphan
+   cleanup use the same runtime-owned backend. Imported container definitions
+   are not translated into workflow-controlled Buildkite plugins.
 
 The runtime's fixed mounts, translated paths, private Docker configuration,
 owned labels, and bounded cleanup preserve Actions behavior and prevent
@@ -1637,13 +1650,14 @@ product and security decision.
 
 Definition of done:
 
-- Container and host-job fixtures observe GHA-compatible workspace paths and
-  service connectivity.
-- Failed health checks produce useful Buildkite diagnostics.
-- Cancellation and agent loss do not routinely leave containers or networks.
-- Workflow-declared privileged options are subject to explicit queue policy;
-  direct commands inside a job remain governed by that queue's job-level
-  isolation.
+- The exact-commit hosted container and host-job fixtures observe compatible
+  workspace paths and service connectivity.
+- Failed health checks produce bounded, masked Buildkite diagnostics.
+- Cancellation terminates owned process trees and container resources under a
+  bounded cleanup context. Hosted VM destruction is the terminal guarantee on
+  agent loss.
+- Workflow-declared privileged options remain rejected. Direct commands inside
+  a job remain governed by that queue's job-level isolation.
 
 ### Phase 6 — Core services and protected capability control plane
 
@@ -1769,9 +1783,9 @@ The checked-in smoke manifest is a classified inventory, not a claim that
 arbitrary common workflows are supported. The required local gate is
 `mise run smoke:local`; it uses no network, performs manifest and static
 validation, and compares two nonempty compilations byte-for-byte. Compilation
-success is never runtime evidence. Its expected-negative fixtures require job
-and service containers to remain compile-time incompatible at the current
-boundary.
+success is never runtime evidence. Job and service container entries are marked
+`runtime-pass` only because exact-commit hosted build 136 ran their plans; they
+remain excluded from the production admission profile.
 
 `mise run smoke:profile` is an opt-in networked lane. It resolves anonymous
 public action sources, prepares the pinned managed Node runtimes, compiles the
@@ -1799,11 +1813,12 @@ bk build create --pipeline buildkite/buildkite-gha \
 ```
 
 It gathers Phase 2 shell/upload, Phase 3 concurrency, Phase 4 public actions,
-and both Phase 5 Docker proofs in one build. Each phase still owns an independent
+and the three Phase 5 Docker capability, Dockerfile-action, and complete
+container-runtime proofs in one build. Each phase still owns an independent
 importer and continuation loader; a final aggregate waits for all generated and
 native terminal evidence, including failures, without changing those security
-or dependency boundaries. Keep the phase-specific selectors for focused
-reruns and fault isolation.
+or dependency boundaries. Keep the phase-specific selectors for focused reruns
+and fault isolation.
 
 ### Initial checked-in corpus
 
@@ -2123,11 +2138,10 @@ them in the phase that first needs the capability:
 1. Phase 6 control-plane work will determine which authenticated GitHub event
    payload Buildkite exposes, whether the service must receive GitHub App
    webhooks directly, and whether a small Buildkite platform API is missing.
-2. Phase 5 uses direct Hosted Agent execution for the tokenless Dockerfile
-   action slice. Exact-commit build 102 proved the local `default` Docker driver,
-   bind/path behavior, private networking, health, loopback publication,
-   signals, and cleanup. A compatibility image remains deferred until job
-   containers or tool-cache differences demonstrate a concrete need.
+2. Phase 5 uses direct Hosted Agent execution. Exact-commit build 102 proved
+   the local `default` Docker driver and queue prerequisites; build 136 proved
+   the complete container runtime. A compatibility image remains deferred until
+   tool-cache differences demonstrate a concrete need.
 3. Phase 6 will choose job-local protocol adapters versus recognized built-ins
    for cache and artifact actions.
 4. Phase 4 will set the customer-beta event and expression subset from the

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -215,8 +215,8 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 	if document.Env["MISE_JOBS"] != "1" {
 		t.Fatalf("default pipeline MISE_JOBS = %q, want serial tool installation", document.Env["MISE_JOBS"])
 	}
-	if len(document.Steps) != 9 {
-		t.Fatalf("default pipeline = %#v, want eight gated loaders plus repository checks", document.Steps)
+	if len(document.Steps) != 10 {
+		t.Fatalf("default pipeline = %#v, want nine gated loaders plus repository checks", document.Steps)
 	}
 	steps := make(map[string]struct {
 		command   string
@@ -254,6 +254,9 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 	if got := steps["phase-5-docker-action-loader"]; got.command != "buildkite-agent pipeline upload .buildkite/phase-5-docker-action.yml" || got.condition != `build.env("PHASE5_PROBE") == "docker-action" && build.env("SMOKE_PROBE") != "hosted"` {
 		t.Fatalf("Phase 5 Dockerfile action loader = %#v", got)
 	}
+	if got := steps["phase-5-runtime-loader"]; got.command != "buildkite-agent pipeline upload .buildkite/phase-5-runtime.yml" || got.condition != `build.env("PHASE5_PROBE") == "runtime" && build.env("SMOKE_PROBE") != "hosted"` {
+		t.Fatalf("Phase 5 container runtime loader = %#v", got)
+	}
 	hosted := steps["hosted-smoke-loader"]
 	if hosted.condition != `build.env("SMOKE_PROBE") == "hosted"` || hosted.queue != "elastic-runners" {
 		t.Fatalf("hosted smoke loader = %#v", hosted)
@@ -275,7 +278,7 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 			t.Fatalf("hosted smoke loader lacks %q:\n%s", required, hosted.command)
 		}
 	}
-	for _, fragment := range []string{"phase-2-upload.yml", "phase-3-upload.yml", "phase-4-upload.yml", "phase-5-capabilities.yml", "phase-5-docker-action.yml", "hosted-smoke-control.yml"} {
+	for _, fragment := range []string{"phase-2-upload.yml", "phase-3-upload.yml", "phase-4-upload.yml", "phase-5-capabilities.yml", "phase-5-docker-action.yml", "phase-5-runtime.yml", "hosted-smoke-control.yml"} {
 		if count := strings.Count(hosted.command, "buildkite-agent pipeline upload .buildkite/"+fragment); count != 1 {
 			t.Fatalf("hosted smoke loader uploads %s %d times:\n%s", fragment, count, hosted.command)
 		}
@@ -680,6 +683,96 @@ func TestPhase5DockerfileActionUploadProofContract(t *testing.T) {
 	}
 }
 
+func TestPhase5ContainerRuntimeProofContract(t *testing.T) {
+	root := filepath.Join("..", "..")
+	read := func(name string) []byte {
+		t.Helper()
+		body, err := os.ReadFile(filepath.Join(root, ".buildkite", name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return body
+	}
+	importerBody := read("phase-5-runtime.yml")
+	var importer struct {
+		Steps []struct {
+			Key                    string `yaml:"key"`
+			Command                string `yaml:"command"`
+			DependsOn              string `yaml:"depends_on"`
+			AllowDependencyFailure bool   `yaml:"allow_dependency_failure"`
+			Agents                 struct {
+				Queue string `yaml:"queue"`
+			} `yaml:"agents"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(importerBody, &importer); err != nil {
+		t.Fatal(err)
+	}
+	if len(importer.Steps) != 2 || importer.Steps[0].Key != "phase-5-runtime-importer" || importer.Steps[0].Agents.Queue != "elastic-runners" {
+		t.Fatalf("Phase 5 runtime importer = %#v", importer.Steps)
+	}
+	loader := importer.Steps[1]
+	if loader.Key != "phase-5-runtime-continuation-loader" || loader.DependsOn != "phase-5-runtime-importer" || !loader.AllowDependencyFailure || loader.Agents.Queue != "elastic-runners" || loader.Command != "buildkite-agent pipeline upload .buildkite/phase-5-runtime-continuation.yml" {
+		t.Fatalf("Phase 5 runtime continuation loader = %#v", loader)
+	}
+	for _, fragment := range []string{
+		`commit="$${PHASE5_COMMIT:-$${SMOKE_COMMIT:-}}"`,
+		`scripts/phase-0-shell-oracle-checkout "$$commit"`,
+		`git status --porcelain --untracked-files=all`,
+		`pipeline upload --no-interpolation --reject-secrets .buildkite/phase-5-runtime-probe.yml`,
+		`automatic: false`,
+	} {
+		if !strings.Contains(string(importerBody), fragment) {
+			t.Fatalf("Phase 5 runtime importer lacks %q:\n%s", fragment, importerBody)
+		}
+	}
+
+	probeBody := read("phase-5-runtime-probe.yml")
+	for _, fragment := range []string{`key: "phase-5-hosted-runtime-probe"`, `queue: "hosted"`, `timeout_in_minutes: 25`, `automatic: false`, `mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2`, `command: "scripts/phase-5-hosted-runtime-probe"`} {
+		if !strings.Contains(string(probeBody), fragment) {
+			t.Fatalf("Phase 5 runtime probe pipeline lacks %q:\n%s", fragment, probeBody)
+		}
+	}
+	continuationBody := read("phase-5-runtime-continuation.yml")
+	for _, fragment := range []string{`key: "phase-5-native-after-runtime"`, `step: "phase-5-hosted-runtime-probe"`, `allow_failure: true`, `queue: "elastic-runners"`} {
+		if !strings.Contains(string(continuationBody), fragment) {
+			t.Fatalf("Phase 5 runtime continuation lacks %q:\n%s", fragment, continuationBody)
+		}
+	}
+
+	script, err := os.ReadFile(filepath.Join(root, "scripts", "phase-5-hosted-runtime-probe"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(script)
+	for _, fragment := range []string{
+		"set -euo pipefail",
+		`commit=${PHASE5_COMMIT:-${SMOKE_COMMIT:-}}`,
+		`scripts/phase-0-shell-oracle-checkout "$commit"`,
+		`git status --porcelain --untracked-files=all`,
+		`docker buildx inspect default`,
+		`CGO_ENABLED=0 mise exec -- go build`,
+		`BUILDKITE_GHA_LIVE_REQUIRED=1`,
+		`BUILDKITE_GHA_TEST_RUNTIME="$runtime"`,
+		`BUILDKITE_GHA_TEST_NODE24="$node24"`,
+		`go test ./internal/runtime -count=1 -timeout=20m`,
+		`TestLivePhase5CompiledContainerRuntime`,
+		`TestLivePhase5ManifestContainerFixtures`,
+		`TestLivePhase5UnhealthyServiceDiagnostics`,
+		`--- SKIP:`,
+		`PHASE5_RUNTIME_OBSERVATION=`,
+	} {
+		if !strings.Contains(text, fragment) {
+			t.Fatalf("Phase 5 runtime probe script lacks %q", fragment)
+		}
+	}
+	for _, forbidden := range []string{"--privileged", "--network host", "/var/run/docker.sock", "docker prune", "docker system prune", "printenv"} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("Phase 5 runtime probe contains forbidden %q", forbidden)
+		}
+	}
+}
+
 func TestHostedSmokeControlAndAggregatorDependencies(t *testing.T) {
 	type dependency struct {
 		Step         string `yaml:"step"`
@@ -723,9 +816,9 @@ func TestHostedSmokeControlAndAggregatorDependencies(t *testing.T) {
 	if control.Key != "hosted-smoke-aggregator-loader" || control.Agents.Queue != "elastic-runners" || control.Command != "buildkite-agent pipeline upload .buildkite/hosted-smoke-aggregator.yml" {
 		t.Fatalf("control step = %#v", control)
 	}
-	assertSet("control", control.DependsOn, map[string]bool{"phase-2-continuation-loader": true, "phase-3-continuation-loader": true, "phase-4-continuation-loader": true, "phase-5-continuation-loader": true, "phase-5-docker-action-continuation-loader": true})
+	assertSet("control", control.DependsOn, map[string]bool{"phase-2-continuation-loader": true, "phase-3-continuation-loader": true, "phase-4-continuation-loader": true, "phase-5-continuation-loader": true, "phase-5-docker-action-continuation-loader": true, "phase-5-runtime-continuation-loader": true})
 	generated := map[string]bool{}
-	for _, name := range []string{"phase-2-upload-continuation.yml", "phase-3-upload-continuation.yml", "phase-4-upload-continuation.yml", "phase-5-capabilities-continuation.yml", "phase-5-docker-action-continuation.yml"} {
+	for _, name := range []string{"phase-2-upload-continuation.yml", "phase-3-upload-continuation.yml", "phase-4-upload-continuation.yml", "phase-5-capabilities-continuation.yml", "phase-5-docker-action-continuation.yml", "phase-5-runtime-continuation.yml"} {
 		continuation := read(name)
 		for _, dependency := range continuation.DependsOn {
 			generated[dependency.Step] = true
@@ -735,7 +828,7 @@ func TestHostedSmokeControlAndAggregatorDependencies(t *testing.T) {
 	for key := range generated {
 		want[key] = true
 	}
-	for _, key := range []string{"gha-producer", "gha-concurrent", "phase-2-native-after-shell", "phase-3-native-after-concurrent", "phase-4-native-after-actions", "phase-5-native-after-hosted-docker", "phase-5-native-after-docker-action"} {
+	for _, key := range []string{"gha-producer", "gha-concurrent", "phase-2-native-after-shell", "phase-3-native-after-concurrent", "phase-4-native-after-actions", "phase-5-native-after-hosted-docker", "phase-5-native-after-docker-action", "phase-5-native-after-runtime"} {
 		want[key] = true
 	}
 	aggregator := read("hosted-smoke-aggregator.yml")
@@ -748,7 +841,7 @@ func TestHostedSmokeControlAndAggregatorDependencies(t *testing.T) {
 			t.Fatalf("aggregator command does not inspect generated step %q: %s", key, aggregator.Command)
 		}
 	}
-	for _, key := range []string{"gha-producer", "gha-concurrent", "phase-2-native-after-shell", "phase-3-native-after-concurrent", "phase-4-native-after-actions", "phase-5-native-after-hosted-docker", "phase-5-native-after-docker-action"} {
+	for _, key := range []string{"gha-producer", "gha-concurrent", "phase-2-native-after-shell", "phase-3-native-after-concurrent", "phase-4-native-after-actions", "phase-5-native-after-hosted-docker", "phase-5-native-after-docker-action", "phase-5-native-after-runtime"} {
 		if !strings.Contains(aggregator.Command, key) {
 			t.Fatalf("aggregator command does not inspect required step %q: %s", key, aggregator.Command)
 		}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -191,7 +191,7 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 		defer func() { _ = os.RemoveAll(artifactRoot) }()
 	}
 	var actionMaterializer gharuntime.ActionMaterializer
-	if job.Schema == plan.SchemaV3 && hasGitHubActionLocks(job.Actions) {
+	if (job.Schema == plan.SchemaV3 || job.Schema == plan.SchemaV4) && hasGitHubActionLocks(job.Actions) {
 		actionCache, err := os.MkdirTemp("", "buildkite-gha-actions-")
 		if err != nil {
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: create action cache: %v\n", err)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"slices"
 	"strings"
 	"syscall"
 	"time"
@@ -668,7 +669,10 @@ func compileHostedTokenless(ctx context.Context, workflowPath string, workflowSo
 func validateUnprivilegedBundle(bundle compiler.Bundle) error {
 	for _, artifact := range bundle.Plans {
 		for _, capability := range artifact.Job.RequiredCapabilities {
-			if capability == "docker" && artifact.Authorization.DockerCapabilitySource != "dockerfile-actions" {
+			if capability == "docker" && !slices.Equal(artifact.Authorization.DockerCapabilitySources, []string{"dockerfile-actions"}) {
+				if slices.Contains(artifact.Authorization.DockerCapabilitySources, "job-containers") || slices.Contains(artifact.Authorization.DockerCapabilitySources, "service-containers") {
+					return fmt.Errorf("job %q uses job or service containers; runtime not implemented", artifact.Job.Workflow.LogicalJobID)
+				}
 				return fmt.Errorf("job %q requires docker without compiler-verified Dockerfile action provenance", artifact.Job.Workflow.LogicalJobID)
 			}
 			if capability != "network" && capability != "docker" {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -63,6 +63,9 @@ func run(args []string, stdout, stderr io.Writer, version string, agentRunner tr
 		_, _ = fmt.Fprint(stderr, usage)
 		return 2
 	}
+	if args[0] == gharuntime.ContainerProcessHelperCommand {
+		return gharuntime.RunContainerProcessHelper(args[1:])
+	}
 
 	switch args[0] {
 	case "-h", "--help":
@@ -213,6 +216,11 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 		Secrets:         gharuntime.EnvironmentSecrets{},
 		Redactor:        gharuntime.AgentRedactor{Executable: os.Getenv("BUILDKITE_GHA_AGENT")},
 		Actions:         actionMaterializer,
+	}
+	runner.RuntimeExecutable, err = os.Executable()
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: resolve runtime executable: %v\n", err)
+		return 1
 	}
 	var result gharuntime.JobResult
 	var runErr error
@@ -671,7 +679,7 @@ func validateUnprivilegedBundle(bundle compiler.Bundle) error {
 		for _, capability := range artifact.Job.RequiredCapabilities {
 			if capability == "docker" && !slices.Equal(artifact.Authorization.DockerCapabilitySources, []string{"dockerfile-actions"}) {
 				if slices.Contains(artifact.Authorization.DockerCapabilitySources, "job-containers") || slices.Contains(artifact.Authorization.DockerCapabilitySources, "service-containers") {
-					return fmt.Errorf("job %q uses job or service containers; runtime not implemented", artifact.Job.Workflow.LogicalJobID)
+					return fmt.Errorf("job %q uses job or service containers, which hosted-tokenless upload does not admit", artifact.Job.Workflow.LogicalJobID)
 				}
 				return fmt.Errorf("job %q requires docker without compiler-verified Dockerfile action provenance", artifact.Job.Workflow.LogicalJobID)
 			}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -580,7 +580,7 @@ func TestUnprivilegedUploadAllowsPublicAndDockerfileActionCapabilities(t *testin
 			Workflow:             plan.Workflow{LogicalJobID: "action-job"},
 			RequiredCapabilities: capabilities,
 			Steps:                []plan.Step{{ID: "action", Kind: "uses", Uses: "owner/example@commit"}},
-		}, Authorization: compiler.PlanAuthorization{DockerCapabilitySource: "dockerfile-actions"}}}}
+		}, Authorization: compiler.PlanAuthorization{DockerCapabilitySources: []string{"dockerfile-actions"}}}}}
 		if err := validateUnprivilegedBundle(bundle); err != nil {
 			t.Fatalf("validateUnprivilegedBundle(%v) error = %v", capabilities, err)
 		}
@@ -594,6 +594,21 @@ func TestUnprivilegedUploadRejectsDockerWithoutCompilerProvenance(t *testing.T) 
 	}}}}
 	if err := validateUnprivilegedBundle(bundle); err == nil || !strings.Contains(err.Error(), "without compiler-verified Dockerfile action provenance") {
 		t.Fatalf("validateUnprivilegedBundle() error = %v, want Docker provenance rejection", err)
+	}
+}
+
+func TestUnprivilegedUploadRejectsContainerProvenance(t *testing.T) {
+	for _, sources := range [][]string{
+		{"job-containers"},
+		{"service-containers"},
+		{"dockerfile-actions", "job-containers", "service-containers"},
+	} {
+		bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: plan.Job{
+			Workflow: plan.Workflow{LogicalJobID: "container-job"}, RequiredCapabilities: []string{"docker", "network"},
+		}, Authorization: compiler.PlanAuthorization{DockerCapabilitySources: sources}}}}
+		if err := validateUnprivilegedBundle(bundle); err == nil || !strings.Contains(err.Error(), "runtime not implemented") {
+			t.Fatalf("validateUnprivilegedBundle(%v) error = %v", sources, err)
+		}
 	}
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -606,7 +606,7 @@ func TestUnprivilegedUploadRejectsContainerProvenance(t *testing.T) {
 		bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: plan.Job{
 			Workflow: plan.Workflow{LogicalJobID: "container-job"}, RequiredCapabilities: []string{"docker", "network"},
 		}, Authorization: compiler.PlanAuthorization{DockerCapabilitySources: sources}}}}
-		if err := validateUnprivilegedBundle(bundle); err == nil || !strings.Contains(err.Error(), "runtime not implemented") {
+		if err := validateUnprivilegedBundle(bundle); err == nil || !strings.Contains(err.Error(), "hosted-tokenless upload does not admit") {
 			t.Fatalf("validateUnprivilegedBundle(%v) error = %v", sources, err)
 		}
 	}

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -266,6 +266,53 @@ jobs:
 	}
 }
 
+func TestCompilePlansLocksLocalActionsWithoutRemoteResolution(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := filepath.Join(workspace, ".github", "workflows", "actions.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeAction(t, workspace, "local", "name: local\nruns:\n  using: node24\n  main: index.js\n")
+	workflow := []byte(`on: push
+jobs:
+  actions:
+    runs-on: ubuntu-latest
+    container: node:24
+    services:
+      redis:
+        image: redis:7
+    steps:
+      - uses: ./local
+`)
+	first, err := CompilePlans(workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, "gha-untrusted")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := CompilePlans(workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, "gha-untrusted")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Fatal("workspace action plans are not deterministic")
+	}
+	if len(first) != 1 || first[0].Schema != plan.SchemaV4 || len(first[0].Actions) != 1 || first[0].Actions[0].Source != "workspace" || first[0].Steps[0].Action == nil {
+		t.Fatalf("workspace action plan = %#v", first)
+	}
+}
+
+func TestCompilePlansContainersWithRemoteActionsRequireResolution(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := filepath.Join(workspace, ".github", "workflows", "actions.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	workflow := []byte("on: push\njobs:\n  actions:\n    runs-on: ubuntu-latest\n    container: node:24\n    steps:\n      - uses: owner/action@v1\n")
+	_, err := CompilePlans(workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, "gha-untrusted")
+	if err == nil || !strings.Contains(err.Error(), "containers with remote actions require action resolution through upload or profile validation") {
+		t.Fatalf("CompilePlans() error = %v", err)
+	}
+}
+
 func TestTokenlessCheckoutAdapterInputBoundary(t *testing.T) {
 	workspace, remote := t.TempDir(), t.TempDir()
 	workflowPath := filepath.Join(workspace, ".github", "workflows", "checkout.yml")

--- a/internal/compiler/bundle.go
+++ b/internal/compiler/bundle.go
@@ -23,7 +23,7 @@ type PlanArtifact struct {
 // It is deliberately not part of the encoded plan: runtimes independently
 // enforce capabilities, while upload policy relies only on fresh compilation.
 type PlanAuthorization struct {
-	DockerCapabilitySource string
+	DockerCapabilitySources []string
 }
 
 // Bundle is the complete deterministic output of static compilation.

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -74,27 +74,29 @@ type WorkflowSource struct {
 
 // JobInstance is one statically expanded job in the owned IR.
 type JobInstance struct {
-	Key                     string            `json:"key"`
-	LogicalJobID            string            `json:"logical_job_id"`
-	Label                   string            `json:"label"`
-	Needs                   []string          `json:"needs,omitempty"`
-	LogicalNeeds            []string          `json:"logical_needs,omitempty"`
-	RunsOn                  []string          `json:"runs_on"`
-	Queue                   string            `json:"queue"`
-	Matrix                  map[string]any    `json:"matrix,omitempty"`
-	FailFast                *bool             `json:"fail_fast,omitempty"`
-	MaxParallel             *int              `json:"max_parallel,omitempty"`
-	Steps                   []workflow.Step   `json:"steps"`
-	Env                     map[string]string `json:"env,omitempty"`
-	If                      string            `json:"if,omitempty"`
-	TimeoutMinutes          float64           `json:"timeout_minutes,omitempty"`
-	DefaultShell            string            `json:"default_shell,omitempty"`
-	DefaultWorkingDirectory string            `json:"default_working_directory,omitempty"`
-	Outputs                 map[string]string `json:"outputs,omitempty"`
-	SourcePath              string            `json:"source_path"`
-	SourceDigest            string            `json:"source_digest"`
-	RepositoryRoot          string            `json:"-"`
-	Source                  workflow.Span     `json:"source"`
+	Key                     string              `json:"key"`
+	LogicalJobID            string              `json:"logical_job_id"`
+	Label                   string              `json:"label"`
+	Needs                   []string            `json:"needs,omitempty"`
+	LogicalNeeds            []string            `json:"logical_needs,omitempty"`
+	RunsOn                  []string            `json:"runs_on"`
+	Queue                   string              `json:"queue"`
+	Matrix                  map[string]any      `json:"matrix,omitempty"`
+	FailFast                *bool               `json:"fail_fast,omitempty"`
+	MaxParallel             *int                `json:"max_parallel,omitempty"`
+	Steps                   []workflow.Step     `json:"steps"`
+	Env                     map[string]string   `json:"env,omitempty"`
+	If                      string              `json:"if,omitempty"`
+	TimeoutMinutes          float64             `json:"timeout_minutes,omitempty"`
+	DefaultShell            string              `json:"default_shell,omitempty"`
+	DefaultWorkingDirectory string              `json:"default_working_directory,omitempty"`
+	Outputs                 map[string]string   `json:"outputs,omitempty"`
+	Container               *workflow.Container `json:"container,omitempty"`
+	Services                []workflow.Service  `json:"services,omitempty"`
+	SourcePath              string              `json:"source_path"`
+	SourceDigest            string              `json:"source_digest"`
+	RepositoryRoot          string              `json:"-"`
+	Source                  workflow.Span       `json:"source"`
 }
 
 // Report summarizes successful workflow validation.
@@ -277,7 +279,7 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 			actions = locks
 			capabilities = actionCapabilities
 			if slices.Contains(actionCapabilities, "docker") {
-				authorization.DockerCapabilitySource = "dockerfile-actions"
+				authorization.DockerCapabilitySources = append(authorization.DockerCapabilitySources, "dockerfile-actions")
 			}
 		} else {
 			var err error
@@ -285,6 +287,19 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 			if err != nil {
 				return nil, nil, fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err)
 			}
+		}
+		if instance.Container != nil || len(instance.Services) != 0 {
+			jobSchema = plan.SchemaV4
+			capabilities = append(capabilities, "docker", "network")
+			sort.Strings(capabilities)
+			capabilities = slices.Compact(capabilities)
+			if instance.Container != nil {
+				authorization.DockerCapabilitySources = append(authorization.DockerCapabilitySources, "job-containers")
+			}
+			if len(instance.Services) != 0 {
+				authorization.DockerCapabilitySources = append(authorization.DockerCapabilitySources, "service-containers")
+			}
+			sort.Strings(authorization.DockerCapabilitySources)
 		}
 		needSources := make(map[string][]plan.NeedSource, len(instance.LogicalNeeds))
 		for _, logicalNeed := range instance.LogicalNeeds {
@@ -337,6 +352,15 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 			Outputs:                 instance.Outputs,
 			Steps:                   steps,
 			Actions:                 actions,
+		}
+		if instance.Container != nil {
+			job.Container = &plan.Container{Image: instance.Container.Image, Env: cloneMap(instance.Container.Env), Ports: append([]string(nil), instance.Container.Ports...)}
+		}
+		if len(instance.Services) != 0 {
+			job.Services = make(map[string]plan.Container, len(instance.Services))
+		}
+		for _, service := range instance.Services {
+			job.Services[service.Name] = plan.Container{Image: service.Container.Image, Env: cloneMap(service.Container.Env), Ports: append([]string(nil), service.Container.Ports...)}
 		}
 		if err := job.Validate(); err != nil {
 			return nil, nil, fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err)
@@ -604,6 +628,8 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 				DefaultShell:            job.DefaultShell,
 				DefaultWorkingDirectory: job.DefaultWorkingDirectory,
 				Outputs:                 cloneMap(job.Outputs),
+				Container:               job.Container,
+				Services:                append([]workflow.Service(nil), job.Services...),
 				SourcePath:              jobPath,
 				SourceDigest:            sourceDigests[id],
 				RepositoryRoot:          sourceRoots[id],

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -259,7 +259,17 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 		var actions []plan.ActionLock
 		var capabilities []string
 		var authorization PlanAuthorization
-		if options.ResolveActions && len(actionRefs) != 0 {
+		lockActions := options.ResolveActions
+		if len(actionRefs) != 0 && !lockActions {
+			lockActions = true
+			for _, ref := range actionRefs {
+				if !strings.HasPrefix(ref, "./") {
+					lockActions = false
+					break
+				}
+			}
+		}
+		if lockActions && len(actionRefs) != 0 {
 			for _, i := range actionIndexes {
 				if strings.HasPrefix(strings.ToLower(instance.Steps[i].Uses), "actions/checkout@") {
 					if err := validateCheckoutInputs(instance.Steps[i].With, ir.Event.Repository.Owner+"/"+ir.Event.Repository.Name, ir.Event.SHA); err != nil {
@@ -289,6 +299,9 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 			}
 		}
 		if instance.Container != nil || len(instance.Services) != 0 {
+			if len(actionRefs) != 0 && !lockActions {
+				return nil, nil, fmt.Errorf("build plan for job %q: containers with remote actions require action resolution through upload or profile validation", instance.LogicalJobID)
+			}
 			jobSchema = plan.SchemaV4
 			capabilities = append(capabilities, "docker", "network")
 			sort.Strings(capabilities)

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -1284,4 +1285,15 @@ func readFile(t *testing.T, path string) []byte {
 		t.Fatal(err)
 	}
 	return source
+}
+
+func TestCompilePlansEmitV4ForContainers(t *testing.T) {
+	workflowSource := []byte("on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    container: node:24\n    services:\n      redis: {image: redis:7}\n    steps:\n      - run: true\n")
+	plans, err := CompilePlans("containers.yml", workflowSource, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("1", 64), "gha-untrusted")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 1 || plans[0].Schema != plan.SchemaV4 || plans[0].Container == nil || len(plans[0].Services) != 1 || !slices.Equal(plans[0].RequiredCapabilities, []string{"docker", "network"}) {
+		t.Fatalf("container plan = %#v", plans)
+	}
 }

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -1124,6 +1124,9 @@ func TestCompilePlansAcceptsNode20LocalAction(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(actionDir, "action.yml"), []byte("runs:\n  using: node20\n  main: index.js\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(actionDir, "index.js"), []byte("// fixture\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	source := []byte("on: push\njobs:\n  node20:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: ./.github/actions/node20\n")
 	if _, err := CompilePlans(workflowPath, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted"); err != nil {
 		t.Fatalf("CompilePlans() error = %v, want node20 support", err)

--- a/internal/compiler/config.go
+++ b/internal/compiler/config.go
@@ -40,8 +40,9 @@ type Options struct {
 	Vars       VariableSources
 	Runners    RunnerPolicy
 	EventTrust EventTrust
-	// ResolveActions enables immutable v3 action locking independently of event
-	// trust. ActionSource is required only when a workflow uses remote actions.
+	// ResolveActions enables immutable remote action locking independently of
+	// event trust. Workspace-local actions are always locked without network
+	// access. ActionSource is required only when a workflow uses remote actions.
 	ResolveActions     bool
 	ActionSource       ActionSource
 	NodeRuntimeDigests map[int]string

--- a/internal/compiler/smoke_manifest_test.go
+++ b/internal/compiler/smoke_manifest_test.go
@@ -45,7 +45,7 @@ func TestSmokeManifestInventory(t *testing.T) {
 		t.Fatalf("schema = %q", manifest.Schema)
 	}
 
-	wantOrder := []string{"smoke-shell", "smoke-concurrent", "smoke-ci", "smoke-artifact", "phase4-public-actions", "phase5-docker-action", "unsupported-cache-service", "unsupported-job-container", "unsupported-service-container"}
+	wantOrder := []string{"smoke-shell", "smoke-concurrent", "smoke-ci", "smoke-artifact", "phase4-public-actions", "phase5-docker-action", "phase5-container-runtime", "unsupported-cache-service", "unsupported-job-container", "unsupported-service-container"}
 	if len(manifest.Fixtures) != len(wantOrder) {
 		t.Fatalf("fixtures = %d, want %d", len(manifest.Fixtures), len(wantOrder))
 	}
@@ -86,7 +86,7 @@ func TestSmokeManifestInventory(t *testing.T) {
 	}
 
 	var checkedIn []string
-	for _, pattern := range []string{"testdata/smoke/.github/workflows/*.yml", "testdata/phase4/.github/workflows/*.yml", "testdata/phase5/.github/workflows/*.yml.tmpl", "testdata/unsupported/.github/workflows/*.yml"} {
+	for _, pattern := range []string{"testdata/smoke/.github/workflows/*.yml", "testdata/phase4/.github/workflows/*.yml", "testdata/phase5/.github/workflows/*.yml.tmpl", "testdata/phase5/runtime/.github/workflows/*.yml", "testdata/unsupported/.github/workflows/*.yml"} {
 		matches, err := filepath.Glob(filepath.Join(root, filepath.FromSlash(pattern)))
 		if err != nil {
 			t.Fatal(err)

--- a/internal/expression/expression.go
+++ b/internal/expression/expression.go
@@ -40,6 +40,7 @@ type Context struct {
 	Vars        map[string]string
 	Env         map[string]string
 	GitHub      map[string]any
+	Services    map[string]map[string]string
 }
 
 // StepStatus contains the values exposed for one completed step while
@@ -61,6 +62,7 @@ type ConditionContext struct {
 	Vars         map[string]string
 	Matrix       map[string]any
 	GitHub       map[string]any
+	Services     map[string]map[string]string
 	Failure      bool
 	Cancelled    bool
 	Unsuccessful bool
@@ -368,6 +370,8 @@ func evaluateConditionNode(node actionlint.ExprNode, context ConditionContext) (
 
 func resolveConditionReference(root string, path []string, context ConditionContext) (any, error) {
 	switch {
+	case len(path) == 4 && strings.EqualFold(root, "job") && strings.EqualFold(path[0], "services") && strings.EqualFold(path[2], "ports"):
+		return resolveServicePort(context.Services, path[1], path[3], "condition")
 	case strings.EqualFold(root, "github"):
 		if value, ok := lookupRuntimeValue(context.GitHub, path); ok {
 			return value, nil
@@ -544,11 +548,17 @@ func referencePath(node actionlint.ExprNode) (string, []string, error) {
 		if err != nil {
 			return "", nil, err
 		}
-		index, ok := node.Index.(*actionlint.StringNode)
-		if !ok {
-			return root, nil, fmt.Errorf("expression index must be a string literal")
+		switch index := node.Index.(type) {
+		case *actionlint.StringNode:
+			return root, append(path, index.Value), nil
+		case *actionlint.IntNode:
+			if !strings.EqualFold(root, "job") || len(path) != 3 || !strings.EqualFold(path[0], "services") || !strings.EqualFold(path[2], "ports") {
+				return root, nil, fmt.Errorf("expression variable %q does not support numeric indices", root)
+			}
+			return root, append(path, fmt.Sprint(index.Value)), nil
+		default:
+			return root, nil, fmt.Errorf("expression index must be a string literal or integer literal")
 		}
-		return root, append(path, index.Value), nil
 	default:
 		return "", nil, fmt.Errorf("unsupported expression reference")
 	}
@@ -582,6 +592,18 @@ func resolveCompileReference(root string, path []string, context CompileContext)
 		}
 	}
 	return current, nil
+}
+
+func resolveServicePort(services map[string]map[string]string, service, port, kind string) (string, error) {
+	for id, ports := range services {
+		if strings.EqualFold(id, service) {
+			if value, ok := ports[port]; ok {
+				return value, nil
+			}
+			return "", fmt.Errorf("%s references unavailable service port %s.%s", kind, service, port)
+		}
+	}
+	return "", fmt.Errorf("%s references unavailable service %q", kind, service)
 }
 
 func objectValue(value any, name string) (any, bool, error) {
@@ -671,6 +693,8 @@ func evaluateReference(reference string, context Context) (string, error) {
 		return "", err
 	}
 	switch {
+	case len(path) == 4 && strings.EqualFold(root, "job") && strings.EqualFold(path[0], "services") && strings.EqualFold(path[2], "ports"):
+		return resolveServicePort(context.Services, path[1], path[3], "expression")
 	case len(path) >= 1 && strings.EqualFold(root, "github"):
 		value, ok := lookupRuntimeValue(context.GitHub, path)
 		if !ok {

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -76,6 +76,37 @@ func TestEvaluateSupportsStaticIndexReferences(t *testing.T) {
 	}
 }
 
+func TestServicePortIsTheOnlyRuntimeJobExpression(t *testing.T) {
+	services := map[string]map[string]string{"redis": {"6379": "49152"}}
+	context := Context{Services: services, Env: map[string]string{"PORT": "6379"}}
+	for _, reference := range []string{"job.services.redis.ports[6379]", "JOB.Services.REDIS.Ports[6379]", "job.services.REDIS.ports['6379']"} {
+		got, err := Evaluate("${{ "+reference+" }}", context)
+		if err != nil || got != "49152" {
+			t.Fatalf("Evaluate(%q) = %q, %v", reference, got, err)
+		}
+	}
+	if got, err := EvaluateCondition("job.services.Redis.ports[6379] == '49152'", ConditionContext{Services: services}); err != nil || !got {
+		t.Fatalf("service condition = %v, %v", got, err)
+	}
+	for _, reference := range []string{"job.services.missing.ports[6379]", "job.services.redis.ports[1234]", "job.services.redis.ports[env.PORT]", "job.status"} {
+		if _, err := Evaluate("${{ "+reference+" }}", context); err == nil {
+			t.Errorf("Evaluate(%q) unexpectedly succeeded", reference)
+		}
+	}
+	for _, reference := range []string{"matrix[0]", "env[0]", "github.event.items[0]"} {
+		if _, err := Evaluate("${{ "+reference+" }}", context); err == nil || !strings.Contains(err.Error(), "does not support numeric indices") {
+			t.Errorf("Evaluate(%q) numeric index error = %v", reference, err)
+		}
+	}
+	expr, err := Parse("${{ job.services.redis.ports[6379] }}", 1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := EvaluateCompile(expr, CompileContext{}); err == nil {
+		t.Fatal("compile-time job context unexpectedly succeeded")
+	}
+}
+
 func TestSecretReferencesUsesExpressionAST(t *testing.T) {
 	template := "${{ secrets.dot_token }}:${{ secrets['BRACKET_TOKEN'] }}:${{ secrets.DOT_TOKEN }}:${{ matrix.value }}:${{ 'not }} a delimiter' }}"
 	got, err := SecretReferences(template)

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -19,6 +19,7 @@ const (
 	SchemaV1 = "https://buildkite.com/schemas/buildkite-gha/job-plan-v1.schema.json"
 	SchemaV2 = "https://buildkite.com/schemas/buildkite-gha/job-plan-v2.schema.json"
 	SchemaV3 = "https://buildkite.com/schemas/buildkite-gha/job-plan-v3.schema.json"
+	SchemaV4 = "https://buildkite.com/schemas/buildkite-gha/job-plan-v4.schema.json"
 	Schema   = SchemaV2
 )
 
@@ -30,6 +31,10 @@ var targetPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,255}$`)
 var secretNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 var actionLockIDPattern = regexp.MustCompile(`^a-[0-9a-f]{16}$`)
 var commitPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
+var containerImagePattern = regexp.MustCompile(`^[a-z0-9]+(?:[._-][a-z0-9]+)*(?:/[a-z0-9]+(?:[._-][a-z0-9]+)*)*(?::[A-Za-z0-9_][A-Za-z0-9_.-]{0,127})?(?:@sha256:[0-9a-f]{64})?$`)
+var containerEnvKeyPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+var containerPortPattern = regexp.MustCompile(`^(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(?::(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]))?(?:/(?:tcp|udp))?$`)
+var serviceNamePattern = regexp.MustCompile(`^[a-z_][a-z0-9_-]{0,254}$`)
 
 type ActionSelector struct {
 	Lock string `json:"lock"`
@@ -114,6 +119,12 @@ type Step struct {
 	Source           *Span             `json:"source,omitempty"`
 }
 
+type Container struct {
+	Image string            `json:"image"`
+	Env   map[string]string `json:"env,omitempty"`
+	Ports []string          `json:"ports,omitempty"`
+}
+
 // Job is one immutable, compiler-selected workflow job instance.
 type Job struct {
 	Schema               string                  `json:"schema"`
@@ -129,15 +140,17 @@ type Job struct {
 	NeedSources          map[string][]NeedSource `json:"need_sources,omitempty"`
 	// Needs is populated only from verified producer-attributed manifests at
 	// runtime. It is never accepted from or encoded into an immutable plan.
-	Needs                   map[string]Need   `json:"-"`
-	Env                     map[string]string `json:"env,omitempty"`
-	Condition               string            `json:"condition,omitempty"`
-	TimeoutMinutes          float64           `json:"timeout_minutes,omitempty"`
-	DefaultShell            string            `json:"default_shell,omitempty"`
-	DefaultWorkingDirectory string            `json:"default_working_directory,omitempty"`
-	Outputs                 map[string]string `json:"outputs,omitempty"`
-	Steps                   []Step            `json:"steps"`
-	Actions                 []ActionLock      `json:"actions,omitempty"`
+	Needs                   map[string]Need      `json:"-"`
+	Env                     map[string]string    `json:"env,omitempty"`
+	Condition               string               `json:"condition,omitempty"`
+	TimeoutMinutes          float64              `json:"timeout_minutes,omitempty"`
+	DefaultShell            string               `json:"default_shell,omitempty"`
+	DefaultWorkingDirectory string               `json:"default_working_directory,omitempty"`
+	Outputs                 map[string]string    `json:"outputs,omitempty"`
+	Steps                   []Step               `json:"steps"`
+	Actions                 []ActionLock         `json:"actions,omitempty"`
+	Container               *Container           `json:"container,omitempty"`
+	Services                map[string]Container `json:"services,omitempty"`
 }
 
 // Decode rejects unknown fields and trailing JSON so schema drift fails closed.
@@ -266,11 +279,14 @@ func Encode(job Job) ([]byte, error) {
 }
 
 func (job Job) Validate() error {
-	if job.Schema != SchemaV1 && job.Schema != SchemaV2 && job.Schema != SchemaV3 {
+	if job.Schema != SchemaV1 && job.Schema != SchemaV2 && job.Schema != SchemaV3 && job.Schema != SchemaV4 {
 		return fmt.Errorf("unsupported job plan schema %q", job.Schema)
 	}
-	if job.Schema != SchemaV3 && (len(job.Actions) != 0 || hasStepActions(job.Steps)) {
+	if job.Schema != SchemaV3 && job.Schema != SchemaV4 && (len(job.Actions) != 0 || hasStepActions(job.Steps)) {
 		return fmt.Errorf("job plan %s does not support action locks", job.Schema)
+	}
+	if job.Schema != SchemaV4 && (job.Container != nil || len(job.Services) != 0) {
+		return fmt.Errorf("job plan %s does not support containers or services", job.Schema)
 	}
 	if job.Compiler.Version == "" || !digestPattern.MatchString(job.Compiler.DistributionDigest) {
 		return fmt.Errorf("job plan compiler version and distribution digest are required")
@@ -307,6 +323,30 @@ func (job Job) Validate() error {
 			return fmt.Errorf("job plan repeats capability %q", capability)
 		}
 		capabilities[capability] = struct{}{}
+	}
+	if job.Container != nil || len(job.Services) != 0 {
+		if _, ok := capabilities["docker"]; !ok {
+			return fmt.Errorf("job containers and services require docker capability")
+		}
+		if _, ok := capabilities["network"]; !ok {
+			return fmt.Errorf("job containers and services require network capability")
+		}
+		if job.Container != nil {
+			if err := validateContainer(job.Container.Image, job.Container.Env, job.Container.Ports); err != nil {
+				return fmt.Errorf("job container: %w", err)
+			}
+		}
+		if len(job.Services) > 32 {
+			return fmt.Errorf("job plan has more than 32 services")
+		}
+		for name, service := range job.Services {
+			if !serviceNamePattern.MatchString(name) {
+				return fmt.Errorf("service name %q must be lowercase and valid", name)
+			}
+			if err := validateContainer(service.Image, service.Env, service.Ports); err != nil {
+				return fmt.Errorf("service %q: %w", name, err)
+			}
+		}
 	}
 	if !sort.StringsAreSorted(job.RequiredSecrets) {
 		return fmt.Errorf("job plan required secrets must be sorted")
@@ -424,9 +464,42 @@ func (job Job) Validate() error {
 			return fmt.Errorf("step %q has unsupported kind %q", step.ID, step.Kind)
 		}
 	}
-	if job.Schema == SchemaV3 {
+	if job.Schema == SchemaV3 || job.Schema == SchemaV4 {
 		if err := validateActionLocks(job); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+func validateContainer(image string, env map[string]string, ports []string) error {
+	if len(image) == 0 || len(image) > 512 || !containerImagePattern.MatchString(image) {
+		return fmt.Errorf("invalid image reference")
+	}
+	if len(env) > 256 {
+		return fmt.Errorf("environment has more than 256 entries")
+	}
+	total := 0
+	for key, value := range env {
+		if !containerEnvKeyPattern.MatchString(key) || len(key) > 255 || len(value) > 65536 {
+			return fmt.Errorf("invalid environment entry %q", key)
+		}
+		total += len(key) + len(value)
+	}
+	if total > 1048576 {
+		return fmt.Errorf("environment exceeds 1048576 bytes")
+	}
+	if len(ports) > 128 {
+		return fmt.Errorf("more than 128 ports")
+	}
+	seen := map[string]bool{}
+	for _, port := range ports {
+		if seen[port] {
+			return fmt.Errorf("repeated port %q", port)
+		}
+		seen[port] = true
+		if !containerPortPattern.MatchString(port) {
+			return fmt.Errorf("invalid port %q", port)
 		}
 	}
 	return nil

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -480,3 +480,99 @@ func validJob() Job {
 		Steps:                []Step{{ID: "step-1", Kind: "run", Command: "true"}},
 	}
 }
+
+func TestV4ContainerContractAndLegacyRejection(t *testing.T) {
+	job := validJob()
+	job.Schema = SchemaV4
+	job.RequiredCapabilities = []string{"docker", "network"}
+	job.Container = &Container{Image: "node:24", Env: map[string]string{"NODE_ENV": "test"}, Ports: []string{"8080"}}
+	job.Services = map[string]Container{"redis": {Image: "redis:7", Ports: []string{"6379:6379"}}}
+	job.Steps = []Step{{ID: "local", Kind: "uses", Uses: "./actions/build", Action: &ActionSelector{Lock: "a-0000000000000001"}}}
+	job.Actions = []ActionLock{{ID: "a-0000000000000001", Source: "workspace", Path: "actions/build", SourceDigest: "sha256:" + strings.Repeat("a", 64)}}
+	encoded, err := Encode(job)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Decode(encoded); err != nil {
+		t.Fatal(err)
+	}
+	schemaSource, err := os.ReadFile(filepath.Join("..", "..", "schemas", "job-plan-v4.schema.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var schemaDocument, planDocument any
+	if err := json.Unmarshal(schemaSource, &schemaDocument); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(encoded, &planDocument); err != nil {
+		t.Fatal(err)
+	}
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource(SchemaV4, schemaDocument); err != nil {
+		t.Fatal(err)
+	}
+	schema, err := compiler.Compile(SchemaV4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := schema.Validate(planDocument); err != nil {
+		t.Fatalf("v4 plan does not validate against schema: %v", err)
+	}
+	job.Actions = nil
+	job.Steps = []Step{{ID: "step-1", Kind: "run", Command: "true"}}
+	for _, schema := range []string{SchemaV1, SchemaV2, SchemaV3} {
+		job.Schema = schema
+		if err := job.Validate(); err == nil || !strings.Contains(err.Error(), "does not support containers") {
+			t.Fatalf("Validate(%s) error = %v", schema, err)
+		}
+	}
+}
+
+func TestContainerPortGrammarMatchesSchema(t *testing.T) {
+	schemaSource, err := os.ReadFile(filepath.Join("..", "..", "schemas", "job-plan-v4.schema.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var schemaDocument any
+	if err := json.Unmarshal(schemaSource, &schemaDocument); err != nil {
+		t.Fatal(err)
+	}
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource(SchemaV4, schemaDocument); err != nil {
+		t.Fatal(err)
+	}
+	schema, err := compiler.Compile(SchemaV4)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		port  string
+		valid bool
+	}{
+		{"0", false}, {"1", true}, {"65535", true}, {"65536", false},
+		{"8080:80", true}, {"0:80", false}, {"8080:65536", false},
+		{"53/udp", true}, {"443/tcp", true}, {"443/sctp", false},
+		{"08", false}, {"+80", false}, {"80/udp/tcp", false},
+	} {
+		t.Run(test.port, func(t *testing.T) {
+			goValid := validateContainer("node:24", nil, []string{test.port}) == nil
+			job := validJob()
+			job.Schema = SchemaV4
+			job.RequiredCapabilities = []string{"docker", "network"}
+			job.Container = &Container{Image: "node:24", Ports: []string{test.port}}
+			encoded, err := json.Marshal(job)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var document any
+			if err := json.Unmarshal(encoded, &document); err != nil {
+				t.Fatal(err)
+			}
+			schemaValid := schema.Validate(document) == nil
+			if goValid != test.valid || schemaValid != test.valid {
+				t.Fatalf("Go valid = %t, schema valid = %t, want %t", goValid, schemaValid, test.valid)
+			}
+		})
+	}
+}

--- a/internal/runtime/concurrent.go
+++ b/internal/runtime/concurrent.go
@@ -229,6 +229,7 @@ func cloneExpressionContext(in expression.Context) expression.Context {
 		Vars:        cloneStrings(in.Vars),
 		Env:         cloneStrings(in.Env),
 		GitHub:      cloneAnyMap(in.GitHub),
+		Services:    cloneNestedStrings(in.Services),
 	}
 }
 

--- a/internal/runtime/containers.go
+++ b/internal/runtime/containers.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -48,6 +50,7 @@ type jobContainerBackend struct {
 	mounts                    []containerMount
 	nodeMu                    sync.Mutex
 	probedNodes               map[string]bool
+	servicePorts              map[string]map[string]string
 }
 
 func privateDocker(r Runner) (string, string, map[string]string, error) {
@@ -81,7 +84,10 @@ func (r Runner) startJobContainer(ctx context.Context, processor *commandProcess
 		return nil, err
 	}
 	id := hex.EncodeToString(nonce[:])
-	b := &jobContainerBackend{runner: r, docker: docker, env: env, config: config, owner: "com.buildkite.gha.owner=" + id, container: "buildkite-gha-job-" + id, network: "buildkite-gha-network-" + id, workspace: workspace, temp: temp}
+	b := &jobContainerBackend{runner: r, docker: docker, env: env, config: config, owner: "com.buildkite.gha.owner=" + id, network: "buildkite-gha-network-" + id, workspace: workspace, temp: temp, servicePorts: make(map[string]map[string]string)}
+	if spec.Image != "" {
+		b.container = "buildkite-gha-job-" + id
+	}
 	b.mounts = []containerMount{{host: workspace, target: jobContainerWorkspace}, {host: temp, target: jobContainerTemp}}
 	for _, m := range extra {
 		if err := validateContainerMount(m); err != nil {
@@ -116,24 +122,32 @@ func (r Runner) startJobContainer(ctx context.Context, processor *commandProcess
 	if err = validateDockerMountPath(temp); err != nil {
 		return nil, err
 	}
-	runtimeExecutable := r.RuntimeExecutable
-	if runtimeExecutable == "" {
-		runtimeExecutable, err = os.Executable()
+	var runtimeExecutable string
+	if spec.Image != "" {
+		runtimeExecutable = r.RuntimeExecutable
+		if runtimeExecutable == "" {
+			runtimeExecutable, err = os.Executable()
+			if err != nil {
+				return nil, fmt.Errorf("resolve runtime executable: %w", err)
+			}
+		}
+		runtimeExecutable, err = filepath.Abs(runtimeExecutable)
 		if err != nil {
 			return nil, fmt.Errorf("resolve runtime executable: %w", err)
 		}
+		if err = validateDockerMountFile(runtimeExecutable); err != nil {
+			return nil, err
+		}
 	}
-	runtimeExecutable, err = filepath.Abs(runtimeExecutable)
-	if err != nil {
-		return nil, fmt.Errorf("resolve runtime executable: %w", err)
+	if spec.Image != "" {
+		if err = r.runStreaming(ctx, newCommandProcessor(r.stdout(), r.stderr()), "", env, docker, "pull", spec.Image); err != nil {
+			return nil, fmt.Errorf("pull job container image: %w", err)
+		}
 	}
-	if err = validateDockerMountFile(runtimeExecutable); err != nil {
-		return nil, err
+	pulled := map[string]bool{}
+	if spec.Image != "" {
+		pulled[spec.Image] = true
 	}
-	if err = r.runStreaming(ctx, newCommandProcessor(r.stdout(), r.stderr()), "", env, docker, "pull", spec.Image); err != nil {
-		return nil, fmt.Errorf("pull job container image: %w", err)
-	}
-	pulled := map[string]bool{spec.Image: true}
 	for _, serviceID := range sortedKeys(services) {
 		image := services[serviceID].Image
 		if pulled[image] {
@@ -172,6 +186,14 @@ func (r Runner) startJobContainer(ctx context.Context, processor *commandProcess
 			return nil, fmt.Errorf("start service %q: %w", service.id, err)
 		}
 	}
+	for _, service := range b.services {
+		ports, portErr := b.readServicePorts(ctx, service.id, service.name, services[service.id].Ports)
+		if portErr != nil {
+			b.serviceDiagnostics(processor, service.name)
+			return nil, portErr
+		}
+		b.servicePorts[service.id] = ports
+	}
 	readinessCtx, cancelReadiness := context.WithTimeout(ctx, serviceReadinessAttempts*serviceReadinessInterval)
 	defer cancelReadiness()
 	for _, service := range b.services {
@@ -179,47 +201,98 @@ func (r Runner) startJobContainer(ctx context.Context, processor *commandProcess
 			return nil, err
 		}
 	}
-	args := []string{"create", "--name", b.container, "--label", b.owner, "--network", b.network,
-		"--mount", "type=bind,source=" + workspace + ",target=" + jobContainerWorkspace,
-		"--mount", "type=bind,source=" + temp + ",target=" + jobContainerTemp,
-		"--mount", "type=bind,source=" + runtimeExecutable + ",target=" + jobContainerRuntime + ",readonly",
-		"--workdir", jobContainerWorkspace, "--entrypoint", "sh"}
-	for _, m := range b.mounts[2:] {
-		mount := "type=bind,source=" + m.host + ",target=" + m.target
-		if m.readonly {
-			mount += ",readonly"
+	if spec.Image != "" {
+		args := []string{"create", "--name", b.container, "--label", b.owner, "--network", b.network,
+			"--mount", "type=bind,source=" + workspace + ",target=" + jobContainerWorkspace,
+			"--mount", "type=bind,source=" + temp + ",target=" + jobContainerTemp,
+			"--mount", "type=bind,source=" + runtimeExecutable + ",target=" + jobContainerRuntime + ",readonly",
+			"--workdir", jobContainerWorkspace, "--entrypoint", "sh"}
+		for _, m := range b.mounts[2:] {
+			mount := "type=bind,source=" + m.host + ",target=" + m.target
+			if m.readonly {
+				mount += ",readonly"
+			}
+			args = append(args, "--mount", mount)
 		}
-		args = append(args, "--mount", mount)
-	}
-	for _, name := range sortedKeys(spec.Env) {
-		args = append(args, "--env", name+"="+spec.Env[name])
-	}
-	args = appendPublishedPorts(args, spec.Ports)
-	args = append(args, spec.Image, "-c", "while :; do sleep 3600; done")
-	if _, err = boundedDockerOutput(ctx, env, docker, args...); err != nil {
-		return nil, fmt.Errorf("create job container: %w", err)
-	}
-	if _, err = boundedDockerOutput(ctx, env, docker, "start", b.container); err != nil {
-		return nil, fmt.Errorf("start job container: %w", err)
-	}
-	probePID := jobContainerTemp + "/startup-probe.pid"
-	out, probeErr := boundedDockerOutput(ctx, env, docker, "exec", b.container, jobContainerRuntime, ContainerProcessHelperCommand, "run", probePID, "sh", "-c", `printf '%s' "$PATH"`)
-	if probeErr != nil {
-		return nil, fmt.Errorf("job container runtime helper failed to start (the mounted executable must be a self-contained Linux executable and the image must provide sh): %w", probeErr)
-	}
-	_ = os.Remove(filepath.Join(temp, "startup-probe.pid"))
-	b.imagePATH = out
-	for _, m := range b.mounts[2:] {
-		if !m.readonly || !m.probe {
-			continue
+		for _, name := range sortedKeys(spec.Env) {
+			args = append(args, "--env", name+"="+spec.Env[name])
 		}
-		probe := "test -r \"$1\" && test -x \"$1\""
-		if _, e := boundedDockerOutput(ctx, env, docker, "exec", b.container, "sh", "-c", probe, "sh", m.target); e != nil {
-			return nil, fmt.Errorf("read-only job container mount %q is not readable/traversable by the image USER: %w", m.target, e)
+		args = appendPublishedPorts(args, spec.Ports)
+		args = append(args, spec.Image, "-c", "while :; do sleep 3600; done")
+		if _, err = boundedDockerOutput(ctx, env, docker, args...); err != nil {
+			return nil, fmt.Errorf("create job container: %w", err)
+		}
+		if _, err = boundedDockerOutput(ctx, env, docker, "start", b.container); err != nil {
+			return nil, fmt.Errorf("start job container: %w", err)
+		}
+		probePID := jobContainerTemp + "/startup-probe.pid"
+		out, probeErr := boundedDockerOutput(ctx, env, docker, "exec", b.container, jobContainerRuntime, ContainerProcessHelperCommand, "run", probePID, "sh", "-c", `printf '%s' "$PATH"`)
+		if probeErr != nil {
+			return nil, fmt.Errorf("job container runtime helper failed to start (the mounted executable must be a self-contained Linux executable and the image must provide sh): %w", probeErr)
+		}
+		_ = os.Remove(filepath.Join(temp, "startup-probe.pid"))
+		b.imagePATH = out
+		for _, m := range b.mounts[2:] {
+			if !m.readonly || !m.probe {
+				continue
+			}
+			probe := "test -r \"$1\" && test -x \"$1\""
+			if _, e := boundedDockerOutput(ctx, env, docker, "exec", b.container, "sh", "-c", probe, "sh", m.target); e != nil {
+				return nil, fmt.Errorf("read-only job container mount %q is not readable/traversable by the image USER: %w", m.target, e)
+			}
 		}
 	}
 	ok = true
 	return b, nil
+}
+
+var dockerPortLine = regexp.MustCompile(`^([0-9]+)/(tcp|udp) -> 127\.0\.0\.1:([0-9]+)$`)
+
+func (b *jobContainerBackend) readServicePorts(ctx context.Context, id, name string, declared []string) (map[string]string, error) {
+	want := map[string]bool{}
+	for _, publication := range declared {
+		parts := strings.SplitN(publication, "/", 2)
+		proto := "tcp"
+		if len(parts) == 2 {
+			proto = parts[1]
+		}
+		container := parts[0]
+		if i := strings.LastIndex(container, ":"); i >= 0 {
+			container = container[i+1:]
+		}
+		want[container+"/"+proto] = true
+	}
+	out, err := boundedDockerOutput(ctx, b.env, b.docker, "port", name)
+	if err != nil {
+		return nil, fmt.Errorf("query service %q ports: %w", id, err)
+	}
+	got, result := map[string]bool{}, map[string]string{}
+	for _, line := range strings.Split(strings.TrimSuffix(strings.ReplaceAll(out, "\r\n", "\n"), "\n"), "\n") {
+		if line == "" && out == "" {
+			continue
+		}
+		m := dockerPortLine.FindStringSubmatch(line)
+		if m == nil {
+			return nil, fmt.Errorf("service %q has malformed Docker port output %q", id, line)
+		}
+		cp, e1 := strconv.Atoi(m[1])
+		hp, e2 := strconv.Atoi(m[3])
+		key := m[1] + "/" + m[2]
+		if e1 != nil || e2 != nil || cp < 1 || cp > 65535 || hp < 1 || hp > 65535 || !want[key] {
+			return nil, fmt.Errorf("service %q has invalid or undeclared port mapping %q", id, line)
+		}
+		got[key] = true
+		// GitHub's runner exposes ports in a dictionary keyed only by numeric
+		// container port, so later Docker mappings intentionally replace earlier
+		// TCP/UDP mappings for the same port.
+		result[m[1]] = m[3]
+	}
+	for key := range want {
+		if !got[key] {
+			return nil, fmt.Errorf("service %q is missing declared port mapping %s", id, key)
+		}
+	}
+	return result, nil
 }
 
 func appendPublishedPorts(args, ports []string) []string {
@@ -454,14 +527,18 @@ func (b *jobContainerBackend) cleanup() error {
 			}
 		}
 	}
-	out, queryErr := boundedDockerOutput(ctx, b.env, b.docker, "ps", "--all", "--quiet", "--filter", "label="+b.owner, "--filter", "name=^/"+b.container+"$")
-	if queryErr != nil {
-		err = errors.Join(err, fmt.Errorf("query job container: %w", queryErr))
-	}
-	if queryErr != nil || strings.TrimSpace(out) != "" {
-		_, e := boundedDockerOutput(ctx, b.env, b.docker, "rm", "--force", b.container)
-		if e != nil {
-			err = errors.Join(err, fmt.Errorf("remove job container: %w", e))
+	var out string
+	var queryErr error
+	if b.container != "" {
+		out, queryErr = boundedDockerOutput(ctx, b.env, b.docker, "ps", "--all", "--quiet", "--filter", "label="+b.owner, "--filter", "name=^/"+b.container+"$")
+		if queryErr != nil {
+			err = errors.Join(err, fmt.Errorf("query job container: %w", queryErr))
+		}
+		if queryErr != nil || strings.TrimSpace(out) != "" {
+			_, e := boundedDockerOutput(ctx, b.env, b.docker, "rm", "--force", b.container)
+			if e != nil {
+				err = errors.Join(err, fmt.Errorf("remove job container: %w", e))
+			}
 		}
 	}
 	out, queryErr = boundedDockerOutput(ctx, b.env, b.docker, "network", "ls", "--quiet", "--filter", "label="+b.owner, "--filter", "name=^"+b.network+"$")

--- a/internal/runtime/containers.go
+++ b/internal/runtime/containers.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/buildkite/buildkite-gha/internal/plan"
@@ -19,6 +21,12 @@ const jobContainerWorkspace = "/__w/repo/repo"
 const jobContainerTemp = "/__w/_temp"
 const jobContainerRuntime = "/__buildkite-gha/runtime"
 
+type containerMount struct {
+	host, target string
+	readonly     bool
+	probe        bool
+}
+
 type jobContainerBackend struct {
 	runner                    Runner
 	docker                    string
@@ -27,6 +35,9 @@ type jobContainerBackend struct {
 	owner, container, network string
 	workspace, temp           string
 	imagePATH                 string
+	mounts                    []containerMount
+	nodeMu                    sync.Mutex
+	probedNodes               map[string]bool
 }
 
 func privateDocker(r Runner) (string, string, map[string]string, error) {
@@ -49,7 +60,7 @@ func privateDocker(r Runner) (string, string, map[string]string, error) {
 	return docker, config, map[string]string{"DOCKER_CONFIG": config}, nil
 }
 
-func (r Runner) startJobContainer(ctx context.Context, workspace, temp string, spec plan.Container) (_ *jobContainerBackend, err error) {
+func (r Runner) startJobContainer(ctx context.Context, workspace, temp string, spec plan.Container, extra ...containerMount) (_ *jobContainerBackend, err error) {
 	docker, config, env, err := privateDocker(r)
 	if err != nil {
 		return nil, err
@@ -61,6 +72,28 @@ func (r Runner) startJobContainer(ctx context.Context, workspace, temp string, s
 	}
 	id := hex.EncodeToString(nonce[:])
 	b := &jobContainerBackend{runner: r, docker: docker, env: env, config: config, owner: "com.buildkite.gha.owner=" + id, container: "buildkite-gha-job-" + id, network: "buildkite-gha-network-" + id, workspace: workspace, temp: temp}
+	b.mounts = []containerMount{{host: workspace, target: jobContainerWorkspace}, {host: temp, target: jobContainerTemp}}
+	for _, m := range extra {
+		if err := validateContainerMount(m); err != nil {
+			_ = os.RemoveAll(config)
+			return nil, err
+		}
+		duplicate := false
+		for _, old := range b.mounts {
+			if old.host == m.host && old.target == m.target {
+				duplicate = true
+				break
+			}
+			if old.host == m.host || old.target == m.target {
+				_ = os.RemoveAll(config)
+				return nil, fmt.Errorf("conflicting job container mount mapping %q to %q", m.host, m.target)
+			}
+		}
+		if duplicate {
+			continue
+		}
+		b.mounts = append(b.mounts, m)
+	}
 	ok := false
 	defer func() {
 		if !ok {
@@ -98,6 +131,13 @@ func (r Runner) startJobContainer(ctx context.Context, workspace, temp string, s
 		"--mount", "type=bind,source=" + temp + ",target=" + jobContainerTemp,
 		"--mount", "type=bind,source=" + runtimeExecutable + ",target=" + jobContainerRuntime + ",readonly",
 		"--workdir", jobContainerWorkspace, "--entrypoint", "sh"}
+	for _, m := range b.mounts[2:] {
+		mount := "type=bind,source=" + m.host + ",target=" + m.target
+		if m.readonly {
+			mount += ",readonly"
+		}
+		args = append(args, "--mount", mount)
+	}
 	for _, name := range sortedKeys(spec.Env) {
 		args = append(args, "--env", name+"="+spec.Env[name])
 	}
@@ -115,18 +155,31 @@ func (r Runner) startJobContainer(ctx context.Context, workspace, temp string, s
 	}
 	_ = os.Remove(filepath.Join(temp, "startup-probe.pid"))
 	b.imagePATH = out
+	for _, m := range b.mounts[2:] {
+		if !m.readonly || !m.probe {
+			continue
+		}
+		probe := "test -r \"$1\" && test -x \"$1\""
+		if _, e := boundedDockerOutput(ctx, env, docker, "exec", b.container, "sh", "-c", probe, "sh", m.target); e != nil {
+			return nil, fmt.Errorf("read-only job container mount %q is not readable/traversable by the image USER: %w", m.target, e)
+		}
+	}
 	ok = true
 	return b, nil
 }
 
 func (b *jobContainerBackend) containerPath(path string) string {
-	if rel, err := filepath.Rel(b.workspace, path); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return filepath.ToSlash(filepath.Join(jobContainerWorkspace, rel))
+	best, bestLen := path, -1
+	mounts := b.mounts
+	if len(mounts) == 0 {
+		mounts = []containerMount{{host: b.workspace, target: jobContainerWorkspace}, {host: b.temp, target: jobContainerTemp}}
 	}
-	if rel, err := filepath.Rel(b.temp, path); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return filepath.ToSlash(filepath.Join(jobContainerTemp, rel))
+	for _, m := range mounts {
+		if rel, err := filepath.Rel(m.host, path); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && len(m.host) > bestLen {
+			best, bestLen = filepath.ToSlash(filepath.Join(m.target, rel)), len(m.host)
+		}
 	}
-	return path
+	return best
 }
 
 func (b *jobContainerBackend) exec(ctx context.Context, r Runner, processor *commandProcessor, dir string, env map[string]string, name string, argv ...string) error {
@@ -182,6 +235,62 @@ func (b *jobContainerBackend) exec(ctx context.Context, r Runner, processor *com
 		_ = os.Remove(pidfile + containerCancellationMarkerSuffix)
 		return errors.Join(ctx.Err(), terminateErr)
 	}
+}
+
+func validateContainerMount(m containerMount) error {
+	if m.host == "" || !filepath.IsAbs(m.host) || strings.ContainsAny(m.host, ",\"'\n\r\x00") {
+		return fmt.Errorf("job container mount source %q cannot be represented by Docker mount grammar", m.host)
+	}
+	info, err := os.Stat(m.host)
+	if err != nil {
+		return fmt.Errorf("validate job container mount source %q: %w", m.host, err)
+	}
+	if !info.IsDir() && !info.Mode().IsRegular() {
+		return fmt.Errorf("job container mount source %q is not a regular file or directory", m.host)
+	}
+	if !filepath.IsAbs(m.target) || strings.ContainsAny(m.target, ",\"'\n\r\x00") || filepath.Clean(m.target) != m.target {
+		return fmt.Errorf("job container mount target %q is invalid", m.target)
+	}
+	return nil
+}
+
+func remoteMountTarget(repository, commit string) string {
+	sum := sha256.Sum256([]byte(strings.ToLower(repository) + "\x00" + commit))
+	return fmt.Sprintf("/__w/_actions/%x", sum[:16])
+}
+
+func (b *jobContainerBackend) probeNode(ctx context.Context, host string, major int) error {
+	abs, err := filepath.Abs(host)
+	if err != nil {
+		return err
+	}
+	target := b.containerPath(abs)
+	if target == abs {
+		return fmt.Errorf("node %d runtime is not mounted in the job container", major)
+	}
+	key := fmt.Sprintf("%d:%s", major, target)
+	b.nodeMu.Lock()
+	if b.probedNodes[key] {
+		b.nodeMu.Unlock()
+		return nil
+	}
+	b.nodeMu.Unlock()
+
+	out, err := boundedDockerOutput(ctx, b.env, b.docker, "exec", b.container, target, "--version")
+	if err != nil {
+		return fmt.Errorf("mounted Node %d is incompatible with job container image: %w", major, err)
+	}
+	version := strings.TrimSpace(out)
+	if !strings.HasPrefix(version, fmt.Sprintf("v%d.", major)) {
+		return fmt.Errorf("mounted Node %d in job container reported %q; exact major %d is required", major, version, major)
+	}
+	b.nodeMu.Lock()
+	if b.probedNodes == nil {
+		b.probedNodes = map[string]bool{}
+	}
+	b.probedNodes[key] = true
+	b.nodeMu.Unlock()
+	return nil
 }
 
 func (b *jobContainerBackend) translatePATH(value string) string {

--- a/internal/runtime/containers.go
+++ b/internal/runtime/containers.go
@@ -21,10 +21,19 @@ const jobContainerWorkspace = "/__w/repo/repo"
 const jobContainerTemp = "/__w/_temp"
 const jobContainerRuntime = "/__buildkite-gha/runtime"
 
+const serviceReadinessAttempts = 30
+const serviceReadinessInterval = time.Second
+const serviceLogTail = "200"
+const serviceDiagnosticTimeout = 3 * time.Second
+
 type containerMount struct {
 	host, target string
 	readonly     bool
 	probe        bool
+}
+
+type serviceContainer struct {
+	id, name string
 }
 
 type jobContainerBackend struct {
@@ -33,6 +42,7 @@ type jobContainerBackend struct {
 	env                       map[string]string
 	config                    string
 	owner, container, network string
+	services                  []serviceContainer
 	workspace, temp           string
 	imagePATH                 string
 	mounts                    []containerMount
@@ -60,7 +70,7 @@ func privateDocker(r Runner) (string, string, map[string]string, error) {
 	return docker, config, map[string]string{"DOCKER_CONFIG": config}, nil
 }
 
-func (r Runner) startJobContainer(ctx context.Context, workspace, temp string, spec plan.Container, extra ...containerMount) (_ *jobContainerBackend, err error) {
+func (r Runner) startJobContainer(ctx context.Context, processor *commandProcessor, workspace, temp string, spec plan.Container, services map[string]plan.Container, extra ...containerMount) (_ *jobContainerBackend, err error) {
 	docker, config, env, err := privateDocker(r)
 	if err != nil {
 		return nil, err
@@ -123,8 +133,51 @@ func (r Runner) startJobContainer(ctx context.Context, workspace, temp string, s
 	if err = r.runStreaming(ctx, newCommandProcessor(r.stdout(), r.stderr()), "", env, docker, "pull", spec.Image); err != nil {
 		return nil, fmt.Errorf("pull job container image: %w", err)
 	}
+	pulled := map[string]bool{spec.Image: true}
+	for _, serviceID := range sortedKeys(services) {
+		image := services[serviceID].Image
+		if pulled[image] {
+			continue
+		}
+		if err = r.runStreaming(ctx, processor, "", env, docker, "pull", image); err != nil {
+			return nil, fmt.Errorf("pull service %q image: %w", serviceID, err)
+		}
+		pulled[image] = true
+	}
 	if _, err = boundedDockerOutput(ctx, env, docker, "network", "create", "--label", b.owner, b.network); err != nil {
 		return nil, fmt.Errorf("create job container network: %w", err)
+	}
+	for _, serviceID := range sortedKeys(services) {
+		service := services[serviceID]
+		serviceNonce, randomErr := randomHex()
+		if randomErr != nil {
+			return nil, fmt.Errorf("create service %q identity: %w", serviceID, randomErr)
+		}
+		name := "buildkite-gha-service-" + serviceNonce
+		// Track the exact name before create: Docker may create the container and
+		// still return an ambiguous client/transport error.
+		b.services = append(b.services, serviceContainer{id: serviceID, name: name})
+		serviceArgs := []string{"create", "--name", name, "--label", b.owner, "--network", b.network, "--network-alias", serviceID}
+		for _, key := range sortedKeys(service.Env) {
+			serviceArgs = append(serviceArgs, "--env", key+"="+service.Env[key])
+		}
+		serviceArgs = appendPublishedPorts(serviceArgs, service.Ports)
+		serviceArgs = append(serviceArgs, service.Image)
+		if _, err = boundedDockerOutput(ctx, env, docker, serviceArgs...); err != nil {
+			return nil, fmt.Errorf("create service %q: %w", serviceID, err)
+		}
+	}
+	for _, service := range b.services {
+		if _, err = boundedDockerOutput(ctx, env, docker, "start", service.name); err != nil {
+			return nil, fmt.Errorf("start service %q: %w", service.id, err)
+		}
+	}
+	readinessCtx, cancelReadiness := context.WithTimeout(ctx, serviceReadinessAttempts*serviceReadinessInterval)
+	defer cancelReadiness()
+	for _, service := range b.services {
+		if err = b.waitForService(readinessCtx, processor, service.id, service.name); err != nil {
+			return nil, err
+		}
 	}
 	args := []string{"create", "--name", b.container, "--label", b.owner, "--network", b.network,
 		"--mount", "type=bind,source=" + workspace + ",target=" + jobContainerWorkspace,
@@ -141,6 +194,7 @@ func (r Runner) startJobContainer(ctx context.Context, workspace, temp string, s
 	for _, name := range sortedKeys(spec.Env) {
 		args = append(args, "--env", name+"="+spec.Env[name])
 	}
+	args = appendPublishedPorts(args, spec.Ports)
 	args = append(args, spec.Image, "-c", "while :; do sleep 3600; done")
 	if _, err = boundedDockerOutput(ctx, env, docker, args...); err != nil {
 		return nil, fmt.Errorf("create job container: %w", err)
@@ -166,6 +220,61 @@ func (r Runner) startJobContainer(ctx context.Context, workspace, temp string, s
 	}
 	ok = true
 	return b, nil
+}
+
+func appendPublishedPorts(args, ports []string) []string {
+	for _, port := range ports {
+		if strings.Contains(strings.SplitN(port, "/", 2)[0], ":") {
+			args = append(args, "--publish", "127.0.0.1:"+port)
+		} else {
+			args = append(args, "--publish", "127.0.0.1::"+port)
+		}
+	}
+	return args
+}
+
+func (b *jobContainerBackend) waitForService(ctx context.Context, processor *commandProcessor, serviceID, name string) error {
+	const format = `{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}`
+	for attempt := 0; attempt < serviceReadinessAttempts; attempt++ {
+		status, err := boundedDockerOutput(ctx, b.env, b.docker, "inspect", "--format", format, name)
+		if err != nil {
+			if ctx.Err() != nil {
+				return fmt.Errorf("wait for service %q readiness: %w", serviceID, ctx.Err())
+			}
+			b.serviceDiagnostics(processor, name)
+			return fmt.Errorf("inspect service %q readiness: %w", serviceID, err)
+		}
+		switch strings.TrimSpace(status) {
+		case "healthy", "running":
+			return nil
+		case "unhealthy", "exited", "dead":
+			b.serviceDiagnostics(processor, name)
+			return fmt.Errorf("service %q failed readiness with status %q", serviceID, strings.TrimSpace(status))
+		}
+		if attempt+1 < serviceReadinessAttempts {
+			timer := time.NewTimer(serviceReadinessInterval)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				b.serviceDiagnostics(processor, name)
+				return fmt.Errorf("wait for service %q readiness: %w", serviceID, ctx.Err())
+			case <-timer.C:
+			}
+		}
+	}
+	b.serviceDiagnostics(processor, name)
+	return fmt.Errorf("service %q readiness timed out after %d attempts", serviceID, serviceReadinessAttempts)
+}
+
+func (b *jobContainerBackend) serviceDiagnostics(processor *commandProcessor, name string) {
+	ctx, cancel := context.WithTimeout(context.Background(), serviceDiagnosticTimeout)
+	defer cancel()
+	output, _ := boundedDockerCombinedOutput(ctx, b.env, b.docker, "logs", "--tail", serviceLogTail, name)
+	for _, line := range strings.Split(strings.TrimSuffix(strings.ReplaceAll(output, "\r\n", "\n"), "\n"), "\n") {
+		if line != "" {
+			processor.process(processor.stderr, line)
+		}
+	}
 }
 
 func (b *jobContainerBackend) containerPath(path string) string {
@@ -325,9 +434,26 @@ func randomHex() (string, error) {
 }
 
 func (b *jobContainerBackend) cleanup() error {
-	ctx, cancel := context.WithTimeout(context.Background(), b.runner.cleanupTimeout())
+	// Each service gets enough budget for its graceful stop in addition to the
+	// base budget, which remains reserved for the job, network, and verification.
+	ctx, cancel := context.WithTimeout(context.Background(), jobContainerCleanupTimeout(b.runner.cleanupTimeout(), len(b.services)))
 	defer cancel()
 	var err error
+	for i := len(b.services) - 1; i >= 0; i-- {
+		name := b.services[i].name
+		out, queryErr := boundedDockerOutput(ctx, b.env, b.docker, "ps", "--all", "--quiet", "--filter", "label="+b.owner, "--filter", "name=^/"+name+"$")
+		if queryErr != nil {
+			err = errors.Join(err, fmt.Errorf("query service container: %w", queryErr))
+		}
+		if queryErr != nil || strings.TrimSpace(out) != "" {
+			if _, e := boundedDockerOutput(ctx, b.env, b.docker, "stop", "--time", "2", name); e != nil {
+				err = errors.Join(err, fmt.Errorf("stop service container: %w", e))
+			}
+			if _, e := boundedDockerOutput(ctx, b.env, b.docker, "rm", "--force", name); e != nil {
+				err = errors.Join(err, fmt.Errorf("remove service container: %w", e))
+			}
+		}
+	}
 	out, queryErr := boundedDockerOutput(ctx, b.env, b.docker, "ps", "--all", "--quiet", "--filter", "label="+b.owner, "--filter", "name=^/"+b.container+"$")
 	if queryErr != nil {
 		err = errors.Join(err, fmt.Errorf("query job container: %w", queryErr))
@@ -358,4 +484,8 @@ func (b *jobContainerBackend) cleanup() error {
 	}
 	_ = os.RemoveAll(b.config)
 	return err
+}
+
+func jobContainerCleanupTimeout(base time.Duration, services int) time.Duration {
+	return base + time.Duration(services)*3*time.Second
 }

--- a/internal/runtime/containers.go
+++ b/internal/runtime/containers.go
@@ -1,0 +1,252 @@
+package runtime
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/buildkite/buildkite-gha/internal/plan"
+)
+
+const jobContainerWorkspace = "/__w/repo/repo"
+const jobContainerTemp = "/__w/_temp"
+const jobContainerRuntime = "/__buildkite-gha/runtime"
+
+type jobContainerBackend struct {
+	runner                    Runner
+	docker                    string
+	env                       map[string]string
+	config                    string
+	owner, container, network string
+	workspace, temp           string
+	imagePATH                 string
+}
+
+func privateDocker(r Runner) (string, string, map[string]string, error) {
+	docker := r.Docker
+	var err error
+	if docker == "" {
+		docker, err = exec.LookPath("docker")
+	}
+	if err != nil {
+		return "", "", nil, fmt.Errorf("discover Docker: %w", err)
+	}
+	config, err := os.MkdirTemp("", "buildkite-gha-docker-config-")
+	if err != nil {
+		return "", "", nil, fmt.Errorf("create private Docker configuration: %w", err)
+	}
+	if err := os.Chmod(config, 0o700); err != nil {
+		_ = os.RemoveAll(config)
+		return "", "", nil, err
+	}
+	return docker, config, map[string]string{"DOCKER_CONFIG": config}, nil
+}
+
+func (r Runner) startJobContainer(ctx context.Context, workspace, temp string, spec plan.Container) (_ *jobContainerBackend, err error) {
+	docker, config, env, err := privateDocker(r)
+	if err != nil {
+		return nil, err
+	}
+	var nonce [16]byte
+	if _, err = rand.Read(nonce[:]); err != nil {
+		_ = os.RemoveAll(config)
+		return nil, err
+	}
+	id := hex.EncodeToString(nonce[:])
+	b := &jobContainerBackend{runner: r, docker: docker, env: env, config: config, owner: "com.buildkite.gha.owner=" + id, container: "buildkite-gha-job-" + id, network: "buildkite-gha-network-" + id, workspace: workspace, temp: temp}
+	ok := false
+	defer func() {
+		if !ok {
+			err = errors.Join(err, b.cleanup())
+		}
+	}()
+	if err = validateDockerMountPath(workspace); err != nil {
+		return nil, err
+	}
+	if err = validateDockerMountPath(temp); err != nil {
+		return nil, err
+	}
+	runtimeExecutable := r.RuntimeExecutable
+	if runtimeExecutable == "" {
+		runtimeExecutable, err = os.Executable()
+		if err != nil {
+			return nil, fmt.Errorf("resolve runtime executable: %w", err)
+		}
+	}
+	runtimeExecutable, err = filepath.Abs(runtimeExecutable)
+	if err != nil {
+		return nil, fmt.Errorf("resolve runtime executable: %w", err)
+	}
+	if err = validateDockerMountFile(runtimeExecutable); err != nil {
+		return nil, err
+	}
+	if err = r.runStreaming(ctx, newCommandProcessor(r.stdout(), r.stderr()), "", env, docker, "pull", spec.Image); err != nil {
+		return nil, fmt.Errorf("pull job container image: %w", err)
+	}
+	if _, err = boundedDockerOutput(ctx, env, docker, "network", "create", "--label", b.owner, b.network); err != nil {
+		return nil, fmt.Errorf("create job container network: %w", err)
+	}
+	args := []string{"create", "--name", b.container, "--label", b.owner, "--network", b.network,
+		"--mount", "type=bind,source=" + workspace + ",target=" + jobContainerWorkspace,
+		"--mount", "type=bind,source=" + temp + ",target=" + jobContainerTemp,
+		"--mount", "type=bind,source=" + runtimeExecutable + ",target=" + jobContainerRuntime + ",readonly",
+		"--workdir", jobContainerWorkspace, "--entrypoint", "sh"}
+	for _, name := range sortedKeys(spec.Env) {
+		args = append(args, "--env", name+"="+spec.Env[name])
+	}
+	args = append(args, spec.Image, "-c", "while :; do sleep 3600; done")
+	if _, err = boundedDockerOutput(ctx, env, docker, args...); err != nil {
+		return nil, fmt.Errorf("create job container: %w", err)
+	}
+	if _, err = boundedDockerOutput(ctx, env, docker, "start", b.container); err != nil {
+		return nil, fmt.Errorf("start job container: %w", err)
+	}
+	probePID := jobContainerTemp + "/startup-probe.pid"
+	out, probeErr := boundedDockerOutput(ctx, env, docker, "exec", b.container, jobContainerRuntime, ContainerProcessHelperCommand, "run", probePID, "sh", "-c", `printf '%s' "$PATH"`)
+	if probeErr != nil {
+		return nil, fmt.Errorf("job container runtime helper failed to start (the mounted executable must be a self-contained Linux executable and the image must provide sh): %w", probeErr)
+	}
+	_ = os.Remove(filepath.Join(temp, "startup-probe.pid"))
+	b.imagePATH = out
+	ok = true
+	return b, nil
+}
+
+func (b *jobContainerBackend) containerPath(path string) string {
+	if rel, err := filepath.Rel(b.workspace, path); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return filepath.ToSlash(filepath.Join(jobContainerWorkspace, rel))
+	}
+	if rel, err := filepath.Rel(b.temp, path); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return filepath.ToSlash(filepath.Join(jobContainerTemp, rel))
+	}
+	return path
+}
+
+func (b *jobContainerBackend) exec(ctx context.Context, r Runner, processor *commandProcessor, dir string, env map[string]string, name string, argv ...string) error {
+	nonce, err := randomHex()
+	if err != nil {
+		return fmt.Errorf("create container exec identity: %w", err)
+	}
+	pidfile := filepath.Join(b.temp, "exec-"+nonce+".pid")
+	containerPID := b.containerPath(pidfile)
+	args := []string{"exec", "--workdir", b.containerPath(dir)}
+	for _, key := range sortedKeys(env) {
+		value := env[key]
+		if key == "PATH" {
+			value = b.translatePATH(value)
+		} else {
+			value = b.containerPath(value)
+		}
+		args = append(args, "--env", key+"="+value)
+	}
+	args = append(args, b.container, jobContainerRuntime, ContainerProcessHelperCommand, "run", containerPID, name)
+	args = append(args, argv...)
+	dockerCtx, stopDocker := context.WithCancel(context.Background())
+	defer stopDocker()
+	done := make(chan error, 1)
+	dockerRunner := r
+	dockerRunner.InterruptGrace = 100 * time.Millisecond
+	dockerRunner.TerminateGrace = 100 * time.Millisecond
+	go func() {
+		done <- dockerRunner.runStreaming(dockerCtx, processor, "", b.env, b.docker, args...)
+	}()
+	select {
+	case err := <-done:
+		_ = os.Remove(pidfile)
+		_ = os.Remove(pidfile + containerCancellationMarkerSuffix)
+		return err
+	case <-ctx.Done():
+		terminationBound := containerPIDPublicationWait + r.interruptGrace() + r.terminateGrace() + 250*time.Millisecond
+		cleanup, cancel := context.WithTimeout(context.Background(), terminationBound)
+		_, terminateErr := boundedDockerOutput(cleanup, b.env, b.docker, "exec", b.container, jobContainerRuntime, ContainerProcessHelperCommand, "terminate", containerPID, r.interruptGrace().String(), r.terminateGrace().String())
+		cancel()
+		stopDocker()
+		local := time.NewTimer(time.Second)
+		select {
+		case <-done:
+			if !local.Stop() {
+				<-local.C
+			}
+		case <-local.C:
+			terminateErr = errors.Join(terminateErr, errors.New("local Docker exec client did not stop within 1s"))
+			<-done
+		}
+		_ = os.Remove(pidfile)
+		_ = os.Remove(pidfile + containerCancellationMarkerSuffix)
+		return errors.Join(ctx.Err(), terminateErr)
+	}
+}
+
+func (b *jobContainerBackend) translatePATH(value string) string {
+	parts := filepath.SplitList(value)
+	for i := range parts {
+		parts[i] = b.containerPath(parts[i])
+	}
+	return strings.Join(parts, string(os.PathListSeparator))
+}
+
+func validateDockerMountFile(path string) error {
+	if path == "" || !filepath.IsAbs(path) || strings.ContainsAny(path, ",\"'\n\r\x00") {
+		return fmt.Errorf("runtime executable path cannot be represented by Docker mount grammar")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("validate Docker mount file %q: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("validate Docker mount file %q: not a regular file", path)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		return fmt.Errorf("validate Docker mount file %q: not executable", path)
+	}
+	return nil
+}
+
+func randomHex() (string, error) {
+	var n [8]byte
+	_, err := rand.Read(n[:])
+	return hex.EncodeToString(n[:]), err
+}
+
+func (b *jobContainerBackend) cleanup() error {
+	ctx, cancel := context.WithTimeout(context.Background(), b.runner.cleanupTimeout())
+	defer cancel()
+	var err error
+	out, queryErr := boundedDockerOutput(ctx, b.env, b.docker, "ps", "--all", "--quiet", "--filter", "label="+b.owner, "--filter", "name=^/"+b.container+"$")
+	if queryErr != nil {
+		err = errors.Join(err, fmt.Errorf("query job container: %w", queryErr))
+	}
+	if queryErr != nil || strings.TrimSpace(out) != "" {
+		_, e := boundedDockerOutput(ctx, b.env, b.docker, "rm", "--force", b.container)
+		if e != nil {
+			err = errors.Join(err, fmt.Errorf("remove job container: %w", e))
+		}
+	}
+	out, queryErr = boundedDockerOutput(ctx, b.env, b.docker, "network", "ls", "--quiet", "--filter", "label="+b.owner, "--filter", "name=^"+b.network+"$")
+	if queryErr != nil {
+		err = errors.Join(err, fmt.Errorf("query job network: %w", queryErr))
+	}
+	if queryErr != nil || strings.TrimSpace(out) != "" {
+		_, e := boundedDockerOutput(ctx, b.env, b.docker, "network", "rm", b.network)
+		if e != nil {
+			err = errors.Join(err, fmt.Errorf("remove job network: %w", e))
+		}
+	}
+	for _, q := range [][]string{{"ps", "--all", "--quiet", "--filter", "label=" + b.owner}, {"network", "ls", "--quiet", "--filter", "label=" + b.owner}} {
+		out, e := boundedDockerOutput(ctx, b.env, b.docker, q...)
+		if e != nil {
+			err = errors.Join(err, fmt.Errorf("verify owned Docker cleanup query: %w", e))
+		} else if strings.TrimSpace(out) != "" {
+			err = errors.Join(err, fmt.Errorf("verify owned Docker cleanup: leftover resources %q", strings.TrimSpace(out)))
+		}
+	}
+	_ = os.RemoveAll(b.config)
+	return err
+}

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -131,7 +131,23 @@ func TestJobContainerFakeDockerProcess(t *testing.T) {
 		os.Exit(42)
 	}
 	container, network := filepath.Join(root, "container"), filepath.Join(root, "network")
+	actionContainer, actionImage := filepath.Join(root, "action-container"), filepath.Join(root, "action-image")
 	switch key {
+	case "buildx":
+		if len(args) > 1 && args[1] == "inspect" {
+			fmt.Print("Driver: docker\n")
+			os.Exit(0)
+		}
+		if len(args) > 1 && args[1] == "build" {
+			_ = os.WriteFile(actionImage, nil, 0o600)
+			for i := 0; i+1 < len(args); i++ {
+				if args[i] == "--label" {
+					_ = os.WriteFile(filepath.Join(root, "action-owner"), []byte(args[i+1]), 0o600)
+				}
+			}
+			os.Exit(0)
+		}
+		os.Exit(46)
 	case "pull":
 		os.Exit(0)
 	case "network-create":
@@ -176,13 +192,59 @@ func TestJobContainerFakeDockerProcess(t *testing.T) {
 		if scenario == "query-fail" && strings.Contains(strings.Join(args, " "), "name=") {
 			os.Exit(43)
 		}
-		if _, err := os.Stat(container); err == nil {
+		joined := strings.Join(args, " ")
+		owner, _ := os.ReadFile(filepath.Join(root, "action-owner"))
+		isAction := strings.Contains(joined, "buildkite-gha-container-") || (len(owner) != 0 && strings.Contains(joined, string(owner)))
+		path := container
+		if isAction {
+			path = actionContainer
+		}
+		if _, err := os.Stat(path); err == nil {
 			fmt.Print("container-id")
 		}
 		os.Exit(0)
-	case "rm":
-		_ = os.Remove(container)
+	case "run":
+		var files string
+		for _, arg := range args {
+			if strings.HasPrefix(arg, "type=bind,source=") && strings.HasSuffix(arg, ",target=/github/file_commands") {
+				files = strings.TrimSuffix(strings.TrimPrefix(arg, "type=bind,source="), ",target=/github/file_commands")
+			}
+		}
+		if files == "" {
+			os.Exit(47)
+		}
+		_ = os.WriteFile(actionContainer, nil, 0o600)
+		_ = os.WriteFile(filepath.Join(files, "output"), []byte("container=ran\n"), 0o600)
+		_ = os.WriteFile(filepath.Join(files, "env"), []byte("DOCKER_RUNTIME_SEEN=true\n"), 0o600)
+		_ = os.WriteFile(filepath.Join(files, "path"), []byte("/fake/action/bin\n"), 0o600)
+		_ = os.WriteFile(filepath.Join(files, "state"), []byte("docker_state=seen\n"), 0o600)
+		_ = os.WriteFile(filepath.Join(files, "summary"), []byte("docker action summary\n"), 0o600)
+		fmt.Print("::add-mask::sibling-secret\nmasked: sibling-secret\n")
+		if scenario == "fail-action-run" {
+			os.Exit(48)
+		}
 		os.Exit(0)
+	case "stop":
+		os.Exit(0)
+	case "rm":
+		if strings.Contains(strings.Join(args, " "), "buildkite-gha-container-") {
+			_ = os.Remove(actionContainer)
+		} else {
+			_ = os.Remove(container)
+		}
+		os.Exit(0)
+	case "image":
+		if len(args) > 1 && args[1] == "ls" {
+			if _, err := os.Stat(actionImage); err == nil {
+				fmt.Print("image-id")
+			}
+			os.Exit(0)
+		}
+		if len(args) > 1 && args[1] == "rm" {
+			_ = os.Remove(actionImage)
+			os.Exit(0)
+		}
+		os.Exit(46)
 	case "network-ls":
 		if scenario == "query-fail" && strings.Contains(strings.Join(args, " "), "name=") {
 			os.Exit(44)
@@ -983,10 +1045,11 @@ func TestRunJobContainerWorkspaceActionRemainsLazy(t *testing.T) {
 	}
 }
 
-func TestRunJobContainerRejectsDockerActionsUntilSiblingBackend(t *testing.T) {
+func TestRunJobContainerRunsDockerActionsAsSiblings(t *testing.T) {
 	t.Run("workspace", func(t *testing.T) {
 		f := newJobDocker(t, "")
 		workspace := fixturePath(t)
+		var logs bytes.Buffer
 		lockID := remoteLifecycleLockID(1)
 		job := runtimePlan(t, workspace, "smoke/.github/workflows/ci.yml", []plan.Step{{
 			ID: "docker", Kind: "uses", Uses: "./actions/docker", Action: &plan.ActionSelector{Lock: lockID},
@@ -994,15 +1057,43 @@ func TestRunJobContainerRejectsDockerActionsUntilSiblingBackend(t *testing.T) {
 		job.Schema = plan.SchemaV4
 		job.RequiredCapabilities = []string{"docker", "network"}
 		job.Container = &plan.Container{Image: "debian:bookworm-slim"}
+		job.Env = map[string]string{"WORKSPACE_CHILD": filepath.Join(workspace, "child")}
 		job.Actions = []plan.ActionLock{{ID: lockID, Source: "workspace", Path: "actions/docker", SourceDigest: digestTree(t, filepath.Join(workspace, "actions/docker"))}}
-		_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(context.Background(), job, workspace)
-		if err == nil || !strings.Contains(err.Error(), "unsupported until Phase 5 M3b") {
-			t.Fatalf("workspace Docker action error = %v", err)
+		job.Outputs = map[string]string{"container": "${{ steps.docker.outputs.container }}"}
+		result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+		if err != nil || result.Outputs["container"] != "ran" || result.Env["DOCKER_RUNTIME_SEEN"] != "true" || result.State["docker_state"] != "seen" || result.Summary != "docker action summary\n" || !strings.HasPrefix(result.Env["PATH"], "/fake/action/bin:") {
+			t.Fatalf("workspace Docker action result = %#v, error = %v", result, err)
 		}
-		for _, call := range f.calls(t) {
-			if len(call.Args) != 0 && (call.Args[0] == "buildx" || call.Args[0] == "run") {
-				t.Fatalf("workspace Docker action executed nested Docker command: %#v", call.Args)
+		if strings.Contains(logs.String(), "sibling-secret") {
+			t.Fatalf("mask leaked in logs: %q", logs.String())
+		}
+		calls := f.calls(t)
+		create, run := jobDockerCallIndex(calls, "create"), jobDockerCallIndex(calls, "run")
+		if create < 0 || run < 0 || jobDockerCallIndex(calls, "buildx", "build") < 0 {
+			t.Fatalf("sibling build/run absent: %#v", calls)
+		}
+		network := argumentAfter(t, calls[create].Args, "--network")
+		if got := argumentAfter(t, calls[run].Args, "--network"); got != network {
+			t.Fatalf("sibling network = %q, want %q", got, network)
+		}
+		joined := strings.Join(calls[run].Args, " ")
+		for _, want := range []string{"source=" + workspace + ",target=/github/workspace", "target=/github/runner_temp", "target=/github/file_commands", "WORKSPACE_CHILD=/github/workspace/child"} {
+			if !strings.Contains(joined, want) {
+				t.Fatalf("sibling run missing %q: %#v", want, calls[run].Args)
 			}
+		}
+		if slices.Contains(calls[run].Args, "--user") {
+			t.Fatalf("sibling run overrides image user: %#v", calls[run].Args)
+		}
+		networkRemove := jobDockerCallIndex(calls, "network", "rm")
+		actionRemove := -1
+		for i, call := range calls {
+			if len(call.Args) >= 3 && call.Args[0] == "rm" && strings.HasPrefix(call.Args[2], "buildkite-gha-container-") {
+				actionRemove = i
+			}
+		}
+		if actionRemove < 0 || networkRemove < actionRemove {
+			t.Fatalf("job network removed before action cleanup: %#v", calls)
 		}
 	})
 
@@ -1023,14 +1114,63 @@ func TestRunJobContainerRejectsDockerActionsUntilSiblingBackend(t *testing.T) {
 		job.Container = &plan.Container{Image: "debian:bookworm-slim"}
 		job.Actions = []plan.ActionLock{remoteLifecycleLock(lockID, "docker", digest, nil)}
 		materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, ActionRoot: filepath.Join(remote, "docker"), SourceDigest: digest}}
-		_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Actions: materializer}).RunJob(context.Background(), job, workspace)
-		if err == nil || !strings.Contains(err.Error(), "unsupported until Phase 5 M3b") {
-			t.Fatalf("remote Docker action error = %v", err)
+		result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Actions: materializer}).RunJob(context.Background(), job, workspace)
+		if err != nil || result.Env["DOCKER_RUNTIME_SEEN"] != "true" {
+			t.Fatalf("remote Docker action result = %#v, error = %v", result, err)
 		}
-		if calls := f.calls(t); len(calls) != 0 {
-			t.Fatalf("remote Docker action reached Docker before preflight rejection: %#v", calls)
+		if materializer.calls != 1 {
+			t.Fatalf("remote materialization calls = %d, want 1", materializer.calls)
+		}
+		calls := f.calls(t)
+		if jobDockerCallIndex(calls, "buildx", "build") < 0 || jobDockerCallIndex(calls, "run") < 0 {
+			t.Fatalf("remote Docker action did not build and run: %#v", calls)
+		}
+		create := jobDockerCallIndex(calls, "create")
+		if create < 0 {
+			t.Fatalf("job container create absent: %#v", calls)
+		}
+		for _, arg := range calls[create].Args {
+			if strings.Contains(arg, "source="+remote+",") {
+				t.Fatalf("remote Docker-only source was unnecessarily mounted in the job container: %#v", calls[create].Args)
+			}
 		}
 	})
+}
+
+func TestRunJobContainerSiblingDockerFailureCleansActionAndJobResources(t *testing.T) {
+	f := newJobDocker(t, "fail-action-run")
+	workspace := fixturePath(t)
+	lockID := remoteLifecycleLockID(1)
+	job := runtimePlan(t, workspace, "smoke/.github/workflows/ci.yml", []plan.Step{{
+		ID: "docker", Kind: "uses", Uses: "./actions/docker", Action: &plan.ActionSelector{Lock: lockID},
+	}})
+	job.Schema = plan.SchemaV4
+	job.RequiredCapabilities = []string{"docker", "network"}
+	job.Container = &plan.Container{Image: "debian:bookworm-slim"}
+	job.Actions = []plan.ActionLock{{ID: lockID, Source: "workspace", Path: "actions/docker", SourceDigest: digestTree(t, filepath.Join(workspace, "actions/docker"))}}
+	_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(context.Background(), job, workspace)
+	if err == nil || !strings.Contains(err.Error(), "run Docker action") {
+		t.Fatalf("sibling Docker action failure = %v", err)
+	}
+	calls := f.calls(t)
+	for _, command := range [][]string{{"rm", "--force"}, {"image", "rm", "--force"}, {"network", "rm"}} {
+		if jobDockerCallIndex(calls, command...) < 0 {
+			t.Fatalf("cleanup command %v absent: %#v", command, calls)
+		}
+	}
+	actionRemove := jobDockerCallIndex(calls, "rm", "--force")
+	jobNetworkRemove := jobDockerCallIndex(calls, "network", "rm")
+	if actionRemove < 0 || jobNetworkRemove < actionRemove {
+		t.Fatalf("job network cleanup raced action cleanup: %#v", calls)
+	}
+}
+
+func TestRunDockerRejectsMismatchedJobContainerPaths(t *testing.T) {
+	r := Runner{jobContainer: &jobContainerBackend{workspace: "/owned/workspace", temp: "/owned/temp"}}
+	_, err := r.runDocker(context.Background(), newCommandProcessor(nil, nil), DockerAction{Workspace: "/other/workspace", runnerTemp: "/owned/temp"})
+	if err == nil || !strings.Contains(err.Error(), "must match the job container's owned host paths") {
+		t.Fatalf("mismatched sibling paths error = %v", err)
+	}
 }
 
 func TestRunJobContainerJavaScriptCancellationRunsPost(t *testing.T) {

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -1,0 +1,581 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/buildkite/buildkite-gha/internal/plan"
+)
+
+// fakeJobDocker deliberately goes through a shell and a fresh copy of this test
+// process.  Thus tests exercise exec.Cmd cancellation, pipes, quoting and argv
+// boundaries rather than an in-process mock of Docker.
+type fakeJobDocker struct{ path, root string }
+
+type jobDockerCall struct {
+	Args          []string `json:"args"`
+	Config        string   `json:"config"`
+	ConfigMode    int      `json:"config_mode"`
+	ConfigEntries int      `json:"config_entries"`
+	Host          *string  `json:"host"`
+	Context       *string  `json:"context"`
+	Builder       *string  `json:"builder"`
+	Kit           *string  `json:"kit"`
+}
+
+func newJobDocker(t *testing.T, scenario string) fakeJobDocker {
+	t.Helper()
+	root := t.TempDir()
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrapper := filepath.Join(root, "docker")
+	text := "#!/bin/sh\nJOB_DOCKER_ROOT=" + strconv.Quote(root) + " JOB_DOCKER_SCENARIO=" + strconv.Quote(scenario) + " exec " + strconv.Quote(exe) + " -test.run=^TestJobContainerFakeDockerProcess$ -- \"$@\"\n"
+	if err := os.WriteFile(wrapper, []byte(text), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("JOB_DOCKER_ROOT", root)
+	t.Setenv("JOB_DOCKER_SCENARIO", scenario)
+	return fakeJobDocker{wrapper, root}
+}
+
+func (f fakeJobDocker) calls(t *testing.T) []jobDockerCall {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(f.root, "calls"))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out []jobDockerCall
+	for _, line := range strings.Split(strings.TrimSpace(string(b)), "\n") {
+		var c jobDockerCall
+		if err := json.Unmarshal([]byte(line), &c); err != nil {
+			t.Fatalf("decode call %q: %v", line, err)
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+func envPointer(name string) *string {
+	if v, ok := os.LookupEnv(name); ok {
+		return &v
+	}
+	return nil
+}
+
+func TestJobContainerFakeDockerProcess(t *testing.T) {
+	root := os.Getenv("JOB_DOCKER_ROOT")
+	if root == "" {
+		t.Skip("Docker child mode")
+	}
+	args := append([]string(nil), os.Args[slices.Index(os.Args, "--")+1:]...)
+	config := os.Getenv("DOCKER_CONFIG")
+	info, err := os.Stat(config)
+	if err != nil {
+		os.Exit(90)
+	}
+	entries, err := os.ReadDir(config)
+	if err != nil {
+		os.Exit(91)
+	}
+	c := jobDockerCall{Args: args, Config: config, ConfigMode: int(info.Mode().Perm()), ConfigEntries: len(entries), Host: envPointer("DOCKER_HOST"), Context: envPointer("DOCKER_CONTEXT"), Builder: envPointer("BUILDX_BUILDER"), Kit: envPointer("BUILDKIT_HOST")}
+	b, _ := json.Marshal(c)
+	b = append(b, '\n')
+	f, err := os.OpenFile(filepath.Join(root, "calls"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		os.Exit(92)
+	}
+	_ = syscall.Flock(int(f.Fd()), syscall.LOCK_EX)
+	_, _ = f.Write(b)
+	_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	_ = f.Close()
+	if len(args) == 0 {
+		os.Exit(2)
+	}
+	scenario := os.Getenv("JOB_DOCKER_SCENARIO")
+	key := args[0]
+	if key == "network" && len(args) > 1 {
+		key += "-" + args[1]
+	}
+	if scenario == "block-pull" && key == "pull" {
+		select {}
+	}
+	if scenario == "fail-pull" && key == "pull" {
+		os.Exit(42)
+	}
+	container, network := filepath.Join(root, "container"), filepath.Join(root, "network")
+	switch key {
+	case "pull":
+		os.Exit(0)
+	case "network-create":
+		_ = os.WriteFile(network, nil, 0o600)
+		if scenario == "fail-network-create" {
+			os.Exit(42)
+		}
+		os.Exit(0)
+	case "create":
+		for i := 0; i+1 < len(args); i++ {
+			if args[i] == "--mount" {
+				p := strings.Split(args[i+1], ",")
+				var src, dst string
+				for _, x := range p {
+					if strings.HasPrefix(x, "source=") {
+						src = strings.TrimPrefix(x, "source=")
+					}
+					if strings.HasPrefix(x, "target=") {
+						dst = strings.TrimPrefix(x, "target=")
+					}
+				}
+				if src != "" {
+					_ = os.WriteFile(filepath.Join(root, "mount-"+strings.ReplaceAll(dst, "/", "_")), []byte(src), 0o600)
+				}
+			}
+		}
+		_ = os.WriteFile(container, nil, 0o600)
+		if scenario == "fail-create" {
+			os.Exit(42)
+		}
+		os.Exit(0)
+	case "start":
+		if scenario == "fail-start" {
+			os.Exit(42)
+		}
+		os.Exit(0)
+	case "ps":
+		if scenario == "query-fail" && strings.Contains(strings.Join(args, " "), "name=") {
+			os.Exit(43)
+		}
+		if _, err := os.Stat(container); err == nil {
+			fmt.Print("container-id")
+		}
+		os.Exit(0)
+	case "rm":
+		_ = os.Remove(container)
+		os.Exit(0)
+	case "network-ls":
+		if scenario == "query-fail" && strings.Contains(strings.Join(args, " "), "name=") {
+			os.Exit(44)
+		}
+		if scenario == "leftover" && !strings.Contains(strings.Join(args, " "), "name=") {
+			fmt.Print("stray")
+			os.Exit(0)
+		}
+		if scenario == "verify-fail" && !strings.Contains(strings.Join(args, " "), "name=") {
+			os.Exit(45)
+		}
+		if _, err := os.Stat(network); err == nil {
+			fmt.Print("network-id")
+		}
+		os.Exit(0)
+	case "network-rm":
+		_ = os.Remove(network)
+		os.Exit(0)
+	case "exec":
+		startupProbe := strings.Contains(strings.Join(args, "\x00"), "startup-probe.pid")
+		if (scenario == "fail-probe" && startupProbe) || (scenario == "fail-step" && !startupProbe) {
+			os.Exit(42)
+		}
+		fakeJobDockerExec(root, args)
+	default:
+		os.Exit(46)
+	}
+}
+
+func fakeJobDockerExec(root string, args []string) {
+	var wd string
+	env := map[string]string{}
+	i := 1
+	for i < len(args) {
+		if args[i] == "--workdir" {
+			wd = args[i+1]
+			i += 2
+			continue
+		}
+		if args[i] == "--env" {
+			p := strings.SplitN(args[i+1], "=", 2)
+			env[p[0]] = p[1]
+			i += 2
+			continue
+		}
+		break
+	}
+	if i >= len(args) {
+		os.Exit(2)
+	}
+	i++ // container
+	if i+3 >= len(args) || args[i+1] != ContainerProcessHelperCommand {
+		os.Exit(2)
+	}
+	helper := args[i+2:]
+	translate := func(p string) string {
+		for _, m := range []struct{ c, f string }{{jobContainerWorkspace, "mount-___w_repo_repo"}, {jobContainerTemp, "mount-___w__temp"}, {jobContainerRuntime, "mount-___buildkite-gha_runtime"}} {
+			if strings.HasPrefix(p, m.c) {
+				host, _ := os.ReadFile(filepath.Join(root, m.f))
+				return filepath.Join(string(host), strings.TrimPrefix(p, m.c))
+			}
+		}
+		return p
+	}
+	if helper[0] == "run" && len(helper) >= 5 && helper[1] == jobContainerTemp+"/startup-probe.pid" {
+		fmt.Print("/image/bin:/usr/bin")
+		os.Exit(0)
+	}
+	if len(helper) > 1 {
+		helper[1] = translate(helper[1])
+	}
+	if helper[0] == "run" {
+		for j := 2; j < len(helper); j++ {
+			if strings.HasPrefix(helper[j], "/") {
+				helper[j] = translate(helper[j])
+			}
+		}
+	}
+	for k, v := range env {
+		if k == "PATH" {
+			parts := strings.Split(v, ":")
+			for j := range parts {
+				parts[j] = translate(parts[j])
+			}
+			v = strings.Join(parts, ":")
+		} else {
+			v = translate(v)
+		}
+		_ = os.Setenv(k, v)
+	}
+	if wd != "" {
+		_ = os.Chdir(translate(wd))
+	}
+	os.Exit(RunContainerProcessHelper(helper))
+}
+
+func jobContainerPlan(t *testing.T, workspace string, steps []plan.Step) plan.Job {
+	t.Helper()
+	if len(steps) == 0 {
+		steps = []plan.Step{{ID: "noop", Kind: "run", Shell: "sh", Command: "true"}}
+	}
+	writeFixtureFile(t, workspace, ".github/workflows/container.yml", "jobs: {}\n")
+	j := runtimePlan(t, workspace, ".github/workflows/container.yml", steps)
+	j.Schema = plan.SchemaV4
+	j.RequiredCapabilities = []string{"docker", "network"}
+	j.Container = &plan.Container{Image: "alpine:3.20"}
+	return j
+}
+
+func TestRunJobContainerLifecycleAndEnvironment(t *testing.T) {
+	f := newJobDocker(t, "")
+	workspace := t.TempDir()
+	_ = os.Chmod(workspace, 0o750)
+	nested := filepath.Join(workspace, "nested")
+	_ = os.Mkdir(nested, 0o755)
+	t.Setenv("DOCKER_HOST", "bad")
+	t.Setenv("DOCKER_CONTEXT", "bad")
+	t.Setenv("BUILDX_BUILDER", "bad")
+	t.Setenv("BUILDKIT_HOST", "bad")
+	j := jobContainerPlan(t, workspace, []plan.Step{{ID: "one", Kind: "run", Shell: "sh", WorkingDirectory: "nested", Env: map[string]string{"P": "step"}, Command: `test "$PATH" = /image/bin:/usr/bin; test "$P" = step; test "$PWD" = "$GITHUB_WORKSPACE/nested"; echo E=ok >> "$GITHUB_ENV"; echo O=out >> "$GITHUB_OUTPUT"; echo /extra >> "$GITHUB_PATH"; echo S=state >> "$GITHUB_STATE"; echo summary >> "$GITHUB_STEP_SUMMARY"`}, {ID: "two", Kind: "run", Shell: "sh", Command: `test "$E" = ok; case "$PATH" in /extra:*) ;; *) exit 8;; esac`}})
+	j.Env = map[string]string{"P": "job"}
+	j.Container.Env = map[string]string{"P": "container"}
+	j.Outputs = map[string]string{"observed": "${{ steps.one.outputs.O }}"}
+	r, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(context.Background(), j, workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Env["E"] != "ok" || r.Outputs["observed"] != "out" || r.State["S"] != "state" || r.Summary != "summary\n" || !strings.HasPrefix(r.Env["PATH"], "/extra:") {
+		t.Fatalf("result %#v", r)
+	}
+	if m, _ := os.Stat(workspace); m.Mode().Perm() != 0o750 {
+		t.Fatalf("workspace mode %o", m.Mode().Perm())
+	}
+	calls := f.calls(t)
+	if len(calls) != 13 {
+		t.Fatalf("calls=%d: %#v", len(calls), calls)
+	}
+	want := []string{"pull", "network create", "create", "start", "exec", "exec", "exec", "ps", "rm", "network ls", "network rm", "ps", "network ls"}
+	for i, c := range calls {
+		if c.ConfigMode != 0o700 || c.ConfigEntries != 0 || c.Host != nil || c.Context != nil || c.Builder != nil || c.Kit != nil {
+			t.Fatalf("private env call %d: %#v", i, c)
+		}
+		if i < len(want) && !strings.HasPrefix(strings.Join(c.Args, " "), want[i]) {
+			t.Fatalf("call %d=%q want %q", i, c.Args, want[i])
+		}
+	}
+	create := strings.Join(calls[2].Args, " ")
+	for _, s := range []string{"target=" + jobContainerWorkspace, "target=" + jobContainerTemp, "target=" + jobContainerRuntime + ",readonly", "--workdir " + jobContainerWorkspace} {
+		if !strings.Contains(create, s) {
+			t.Errorf("create missing %q", s)
+		}
+	}
+	if strings.Contains(create, "--user") {
+		t.Error("unexpected user override")
+	}
+}
+
+func TestRunJobContainerSetupFailuresCleanOwnedResources(t *testing.T) {
+	for _, stage := range []string{"pull", "network-create", "create", "start", "probe", "step"} {
+		t.Run(stage, func(t *testing.T) {
+			f := newJobDocker(t, "fail-"+stage)
+			w := t.TempDir()
+			if err := os.Chmod(w, 0o750); err != nil {
+				t.Fatal(err)
+			}
+			j := jobContainerPlan(t, w, nil)
+			_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(context.Background(), j, w)
+			if err == nil {
+				t.Fatal("expected failure")
+			}
+			calls := f.calls(t)
+			removedContainer, removedNetwork := false, false
+			for _, c := range calls {
+				joined := strings.Join(c.Args, " ")
+				if strings.HasPrefix(joined, "rm ") && !strings.Contains(joined, "buildkite-gha-job-") {
+					t.Fatalf("unowned removal %q", joined)
+				}
+				removedContainer = removedContainer || strings.HasPrefix(joined, "rm --force buildkite-gha-job-")
+				if strings.HasPrefix(joined, "network rm") && !strings.Contains(joined, "buildkite-gha-network-") {
+					t.Fatalf("unowned removal %q", joined)
+				}
+				removedNetwork = removedNetwork || strings.HasPrefix(joined, "network rm buildkite-gha-network-")
+			}
+			if stage == "pull" {
+				if removedContainer || removedNetwork {
+					t.Fatalf("removed resources before pull completed: %#v", calls)
+				}
+			} else if !removedNetwork || (stage != "network-create" && !removedContainer) {
+				t.Fatalf("incomplete %s cleanup: container=%t network=%t calls=%#v", stage, removedContainer, removedNetwork, calls)
+			}
+			if info, statErr := os.Stat(w); statErr != nil || info.Mode().Perm() != 0o750 {
+				t.Fatalf("workspace mode after %s = %v, %v", stage, info, statErr)
+			}
+		})
+	}
+}
+
+func TestRunJobContainerCleanupQueryFailureStillRemovesExactResources(t *testing.T) {
+	f := newJobDocker(t, "query-fail")
+	w := t.TempDir()
+	j := jobContainerPlan(t, w, nil)
+	_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(context.Background(), j, w)
+	if err == nil || !strings.Contains(err.Error(), "query job") {
+		t.Fatalf("error=%v", err)
+	}
+	joined := fmt.Sprint(f.calls(t))
+	if !strings.Contains(joined, "rm --force buildkite-gha-job-") || !strings.Contains(joined, "network rm buildkite-gha-network-") {
+		t.Fatalf("cleanup %s", joined)
+	}
+}
+
+func TestRunJobContainerReportsLeftoverAndVerificationFailure(t *testing.T) {
+	for _, s := range []string{"leftover", "verify-fail"} {
+		t.Run(s, func(t *testing.T) {
+			f := newJobDocker(t, s)
+			w := t.TempDir()
+			j := jobContainerPlan(t, w, nil)
+			_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(context.Background(), j, w)
+			if err == nil || !strings.Contains(err.Error(), "verify owned Docker cleanup") {
+				t.Fatalf("error=%v", err)
+			}
+		})
+	}
+}
+
+func startTestBackend(t *testing.T, f fakeJobDocker) (*jobContainerBackend, string) {
+	w := t.TempDir()
+	tmp := t.TempDir()
+	b, e := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], InterruptGrace: 20 * time.Millisecond, TerminateGrace: 20 * time.Millisecond}).startJobContainer(context.Background(), w, tmp, plan.Container{Image: "alpine:3.20"})
+	if e != nil {
+		t.Fatal(e)
+	}
+	return b, w
+}
+
+func TestRunJobContainerCancellationTargetsProcessTree(t *testing.T) {
+	f := newJobDocker(t, "")
+	b, w := startTestBackend(t, f)
+	marker := filepath.Join(w, "alive")
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- b.exec(ctx, b.runner, newCommandProcessor(os.Stdout, os.Stderr), w, map[string]string{}, "sh", "-c", `trap '' TERM INT; sleep 30 & echo $! > alive; wait`)
+	}()
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	select {
+	case e := <-done:
+		if !errors.Is(e, context.Canceled) {
+			t.Fatalf("%v", e)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("cancellation hung")
+	}
+	pidb, _ := os.ReadFile(marker)
+	if p, _ := strconv.Atoi(strings.TrimSpace(string(pidb))); p > 0 && syscall.Kill(p, 0) == nil {
+		t.Fatalf("child %d alive", p)
+	}
+	_ = b.cleanup()
+	calls := f.calls(t)
+	n := 0
+	for _, c := range calls {
+		if len(c.Args) > 5 && c.Args[0] == "exec" && strings.Contains(strings.Join(c.Args, " "), " terminate ") {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Fatalf("terminate calls=%d", n)
+	}
+}
+
+func TestRunJobContainerConcurrentExecUsesUniquePIDFiles(t *testing.T) {
+	f := newJobDocker(t, "")
+	b, w := startTestBackend(t, f)
+	c1, x := context.WithCancel(context.Background())
+	d1 := make(chan error, 1)
+	d2 := make(chan error, 1)
+	go func() {
+		d1 <- b.exec(c1, b.runner, newCommandProcessor(os.Stdout, os.Stderr), w, nil, "sh", "-c", "sleep 30")
+	}()
+	go func() {
+		d2 <- b.exec(context.Background(), b.runner, newCommandProcessor(os.Stdout, os.Stderr), w, nil, "sh", "-c", "sleep .3")
+	}()
+	time.Sleep(100 * time.Millisecond)
+	x()
+	<-d1
+	<-d2
+	_ = b.cleanup()
+	runs := map[string]bool{}
+	terms := map[string]bool{}
+	for _, c := range f.calls(t) {
+		a := c.Args
+		for i, v := range a {
+			if v == ContainerProcessHelperCommand && i+2 < len(a) {
+				if a[i+1] == "run" {
+					runs[a[i+2]] = true
+				}
+				if a[i+1] == "terminate" {
+					terms[a[i+2]] = true
+				}
+			}
+		}
+	}
+	if len(runs) < 3 || len(terms) != 1 {
+		t.Fatalf("runs=%v terms=%v", runs, terms)
+	}
+}
+
+func TestRunJobContainerBarrierVisibility(t *testing.T) {
+	f := newJobDocker(t, "")
+	w := t.TempDir()
+	j := jobContainerPlan(t, w, []plan.Step{{ID: "bg", Kind: "run", Shell: "sh", Background: true, Command: `sleep .15; echo LATE=yes >> "$GITHUB_ENV"; echo value=x >> "$GITHUB_OUTPUT"; echo /late >> "$GITHUB_PATH"`}, {ID: "before", Kind: "run", Shell: "sh", Command: `test -z "${LATE-}"`}, {ID: "wait", Kind: "wait", Targets: []string{"bg"}}, {ID: "after", Kind: "run", Shell: "sh", Command: `test "$LATE" = yes; case "$PATH" in /late:*) ;; *) exit 9;; esac`}})
+	if _, e := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(context.Background(), j, w); e != nil {
+		t.Fatal(e)
+	}
+}
+
+func TestRunJobContainerRejectsDeferredFeaturesBeforeDocker(t *testing.T) {
+	for _, feature := range []string{"service", "action", "port"} {
+		t.Run(feature, func(t *testing.T) {
+			f := newJobDocker(t, "")
+			w := t.TempDir()
+			j := jobContainerPlan(t, w, nil)
+			m := &fakeActionMaterializer{}
+			switch feature {
+			case "action":
+				j.Steps = []plan.Step{{Kind: "uses", Uses: "x"}}
+			case "service":
+				j.Services = map[string]plan.Container{"db": {Image: "x"}}
+			case "port":
+				j.Container.Ports = []string{"8080"}
+			}
+			if _, e := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Actions: m}).RunJob(context.Background(), j, w); e == nil {
+				t.Fatal("accepted")
+			}
+			if len(f.calls(t)) != 0 || m.calls != 0 {
+				t.Fatalf("docker/materializer called")
+			}
+		})
+	}
+}
+
+func TestRunJobContainerTimeoutCoversSetup(t *testing.T) {
+	f := newJobDocker(t, "block-pull")
+	w := t.TempDir()
+	j := jobContainerPlan(t, w, nil)
+	j.TimeoutMinutes = .001
+	start := time.Now()
+	_, e := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], CleanupTimeout: 100 * time.Millisecond}).RunJob(context.Background(), j, w)
+	if !errors.Is(e, context.DeadlineExceeded) || time.Since(start) > 2*time.Second {
+		t.Fatalf("error=%v elapsed=%s", e, time.Since(start))
+	}
+}
+
+func TestJobContainerPATHTranslationPreservesEmptyComponents(t *testing.T) {
+	root := t.TempDir()
+	b := jobContainerBackend{workspace: filepath.Join(root, "work"), temp: filepath.Join(root, "temp")}
+	value := ":" + filepath.Join(b.workspace, "bin") + ":" + filepath.Join(b.temp, "tools") + ":"
+	want := ":" + jobContainerWorkspace + "/bin:" + jobContainerTemp + "/tools:"
+	if got := b.translatePATH(value); got != want {
+		t.Fatalf("%q want %q", got, want)
+	}
+}
+
+func TestValidateDockerMountFileRequiresExistingRegularExecutableSafeAbsoluteFile(t *testing.T) {
+	d := t.TempDir()
+	for _, p := range []string{d, "relative", filepath.Join(d, "missing")} {
+		if validateDockerMountFile(p) == nil {
+			t.Fatalf("accepted %q", p)
+		}
+	}
+	p := filepath.Join(d, "runtime")
+	_ = os.WriteFile(p, nil, 0o600)
+	if validateDockerMountFile(p) == nil {
+		t.Fatal("accepted non-executable")
+	}
+	_ = os.Chmod(p, 0o700)
+	if e := validateDockerMountFile(p); e != nil {
+		t.Fatal(e)
+	}
+	bad := filepath.Join(d, "bad,name")
+	_ = os.WriteFile(bad, nil, 0o700)
+	if validateDockerMountFile(bad) == nil {
+		t.Fatal("accepted mount-unsafe path")
+	}
+}
+
+func liveContainerJob(t *testing.T, docker string, steps []plan.Step) JobResult {
+	w := t.TempDir()
+	j := jobContainerPlan(t, w, steps)
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	r, e := (Runner{Docker: docker, RuntimeExecutable: os.Args[0], InterruptGrace: 100 * time.Millisecond, TerminateGrace: 100 * time.Millisecond}).RunJob(ctx, j, w)
+	if e != nil {
+		t.Fatal(e)
+	}
+	return r
+}
+func TestLiveJobContainerPersistsAcrossShellSteps(t *testing.T) {
+	d := requireDocker(t)
+	liveContainerJob(t, d, []plan.Step{{ID: "a", Kind: "run", Shell: "sh", Command: "touch persisted"}, {ID: "b", Kind: "run", Shell: "sh", Command: "test -f persisted"}})
+}
+func TestLiveJobContainerDefaultNonRootUser(t *testing.T) {
+	d := requireDocker(t)
+	liveContainerJob(t, d, []plan.Step{{ID: "u", Kind: "run", Shell: "sh", Command: `test "$(id -u)" = 0`}})
+}
+func TestLiveJobContainerCancellationKillsProcessTree(t *testing.T) {
+	d := requireDocker(t)
+	liveContainerJob(t, d, []plan.Step{
+		{ID: "bg", Kind: "run", Shell: "sh", Background: true, Command: "sleep 30 & wait"},
+		{ID: "cancel", Kind: "cancel", Targets: []string{"bg"}},
+	})
+}

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -1,11 +1,14 @@
 package runtime
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -14,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/buildkite/buildkite-gha/internal/action/source"
 	"github.com/buildkite/buildkite-gha/internal/plan"
 )
 
@@ -68,6 +72,15 @@ func (f fakeJobDocker) calls(t *testing.T) []jobDockerCall {
 		out = append(out, c)
 	}
 	return out
+}
+
+func jobDockerCallIndex(calls []jobDockerCall, command ...string) int {
+	for i, call := range calls {
+		if len(call.Args) >= len(command) && slices.Equal(call.Args[:len(command)], command) {
+			return i
+		}
+	}
+	return -1
 }
 
 func envPointer(name string) *string {
@@ -142,6 +155,10 @@ func TestJobContainerFakeDockerProcess(t *testing.T) {
 				}
 				if src != "" {
 					_ = os.WriteFile(filepath.Join(root, "mount-"+strings.ReplaceAll(dst, "/", "_")), []byte(src), 0o600)
+					mf, _ := os.OpenFile(filepath.Join(root, "mounts"), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+					mb, _ := json.Marshal(struct{ Target, Source string }{dst, src})
+					_, _ = mf.Write(append(mb, '\n'))
+					_ = mf.Close()
 				}
 			}
 		}
@@ -189,13 +206,13 @@ func TestJobContainerFakeDockerProcess(t *testing.T) {
 		if (scenario == "fail-probe" && startupProbe) || (scenario == "fail-step" && !startupProbe) {
 			os.Exit(42)
 		}
-		fakeJobDockerExec(root, args)
+		fakeJobDockerExec(root, scenario, args)
 	default:
 		os.Exit(46)
 	}
 }
 
-func fakeJobDockerExec(root string, args []string) {
+func fakeJobDockerExec(root, scenario string, args []string) {
 	var wd string
 	env := map[string]string{}
 	i := 1
@@ -217,19 +234,53 @@ func fakeJobDockerExec(root string, args []string) {
 		os.Exit(2)
 	}
 	i++ // container
-	if i+3 >= len(args) || args[i+1] != ContainerProcessHelperCommand {
+	if i >= len(args) {
 		os.Exit(2)
 	}
-	helper := args[i+2:]
 	translate := func(p string) string {
-		for _, m := range []struct{ c, f string }{{jobContainerWorkspace, "mount-___w_repo_repo"}, {jobContainerTemp, "mount-___w__temp"}, {jobContainerRuntime, "mount-___buildkite-gha_runtime"}} {
-			if strings.HasPrefix(p, m.c) {
-				host, _ := os.ReadFile(filepath.Join(root, m.f))
-				return filepath.Join(string(host), strings.TrimPrefix(p, m.c))
+		type mount struct{ Target, Source string }
+		var best mount
+		data, _ := os.ReadFile(filepath.Join(root, "mounts"))
+		for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+			var m mount
+			if json.Unmarshal([]byte(line), &m) == nil && (p == m.Target || strings.HasPrefix(p, m.Target+"/")) && len(m.Target) > len(best.Target) {
+				best = m
 			}
+		}
+		if best.Target != "" {
+			return filepath.Join(best.Source, strings.TrimPrefix(p, best.Target))
 		}
 		return p
 	}
+	// Setup mount probes and Node compatibility probes intentionally bypass the
+	// process helper in production, just as real docker exec does.
+	if args[i] == "sh" && i+4 < len(args) && args[i+1] == "-c" {
+		args[i+4] = translate(args[i+4])
+		if scenario == "fail-mount-probe" {
+			os.Exit(42)
+		}
+		if err := syscall.Exec("/bin/sh", args[i:], os.Environ()); err != nil {
+			os.Exit(126)
+		}
+	}
+	if strings.HasPrefix(args[i], "/") && i+1 < len(args) && args[i+1] == "--version" {
+		if scenario == "wrong-node-major" {
+			fmt.Print("v20.0.0\n")
+			os.Exit(0)
+		}
+		if scenario == "incompatible-node" {
+			os.Exit(126)
+		}
+		nodeArgs := append([]string(nil), args[i:]...)
+		nodeArgs[0] = translate(nodeArgs[0])
+		if err := syscall.Exec(nodeArgs[0], nodeArgs, os.Environ()); err != nil {
+			os.Exit(126)
+		}
+	}
+	if i+2 >= len(args) || args[i+1] != ContainerProcessHelperCommand {
+		os.Exit(2)
+	}
+	helper := append([]string(nil), args[i+2:]...)
 	if helper[0] == "run" && len(helper) >= 5 && helper[1] == jobContainerTemp+"/startup-probe.pid" {
 		fmt.Print("/image/bin:/usr/bin")
 		os.Exit(0)
@@ -530,6 +581,497 @@ func TestJobContainerPATHTranslationPreservesEmptyComponents(t *testing.T) {
 	}
 }
 
+func TestContainerPathUsesLongestReadOnlyMount(t *testing.T) {
+	root := t.TempDir()
+	repository := filepath.Join(root, "repository")
+	selected := filepath.Join(repository, "selected")
+	b := jobContainerBackend{mounts: []containerMount{
+		{host: repository, target: "/__w/_actions/repository", readonly: true},
+		{host: selected, target: "/__w/_actions/selected", readonly: true},
+	}}
+	if got, want := b.containerPath(filepath.Join(selected, "dist", "index.js")), "/__w/_actions/selected/dist/index.js"; got != want {
+		t.Fatalf("containerPath = %q, want %q", got, want)
+	}
+
+	file := filepath.Join(root, "runtime")
+	if err := os.WriteFile(file, nil, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, mounts := range [][]containerMount{
+		{{host: "relative", target: "/valid", readonly: true}},
+		{{host: file, target: "relative", readonly: true}},
+		{{host: file, target: "/bad,target", readonly: true}},
+	} {
+		if err := validateContainerMount(mounts[0]); err == nil {
+			t.Fatalf("accepted invalid mount %#v", mounts[0])
+		}
+	}
+}
+
+func TestRunJobContainerNodeProbeFailureCleansOwnedResources(t *testing.T) {
+	for _, scenario := range []string{"wrong-node-major", "incompatible-node"} {
+		t.Run(scenario, func(t *testing.T) {
+			f := newJobDocker(t, scenario)
+			w := t.TempDir()
+			writeFixtureFile(t, w, "unused/action.yml", "name: probe\nruns:\n  using: node24\n  main: main.js\n")
+			writeFixtureFile(t, w, "unused/main.js", "")
+			node := filepath.Join(t.TempDir(), "node")
+			if err := os.WriteFile(node, []byte("#!/bin/sh\necho v24.0.0\n"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			j := jobContainerPlan(t, w, nil)
+			lockID := remoteLifecycleLockID(1)
+			j.Steps = []plan.Step{{ID: "action", Kind: "uses", Uses: "./unused", Action: &plan.ActionSelector{Lock: lockID}}}
+			j.Actions = []plan.ActionLock{{ID: lockID, Source: "workspace", Path: "unused", SourceDigest: digestTree(t, filepath.Join(w, "unused"))}}
+			_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node24: node}).RunJob(context.Background(), j, w)
+			if err == nil || (!strings.Contains(err.Error(), "exact major") && !strings.Contains(err.Error(), "incompatible")) {
+				t.Fatalf("error = %v", err)
+			}
+			calls := f.calls(t)
+			joined := fmt.Sprint(calls)
+			if !strings.Contains(joined, "rm --force buildkite-gha-job-") || !strings.Contains(joined, "network rm buildkite-gha-network-") {
+				t.Fatalf("owned resources not cleaned: %s", joined)
+			}
+			for _, call := range calls {
+				if strings.Contains(strings.Join(call.Args, " "), ContainerProcessHelperCommand+" run") && !strings.Contains(strings.Join(call.Args, " "), "startup-probe") {
+					t.Fatalf("action lifecycle executed before failed Node probe: %#v", call.Args)
+				}
+			}
+		})
+	}
+}
+
+func TestRunJobContainerDoesNotProbeConfiguredNodeWithoutActions(t *testing.T) {
+	f := newJobDocker(t, "incompatible-node")
+	w := t.TempDir()
+	node := filepath.Join(t.TempDir(), "node")
+	if err := os.WriteFile(node, []byte("#!/bin/sh\necho v24.0.0\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	j := jobContainerPlan(t, w, []plan.Step{{ID: "shell", Kind: "run", Shell: "sh", Command: "true"}})
+	if _, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node24: node}).RunJob(context.Background(), j, w); err != nil {
+		t.Fatal(err)
+	}
+	for _, call := range f.calls(t) {
+		if slices.Contains(call.Args, "type=bind,source="+node+",target=/__buildkite-gha/node24,readonly") || slices.Contains(call.Args, "/__buildkite-gha/node24") {
+			t.Fatalf("actionless container job mounted or probed Node: %#v", call.Args)
+		}
+	}
+}
+
+func TestRunJobContainerDoesNotProbeConfiguredNodeForCompositeOnlyActions(t *testing.T) {
+	f := newJobDocker(t, "incompatible-node")
+	w := t.TempDir()
+	writeFixtureFile(t, w, "composite/action.yml", "name: composite only\nruns:\n  using: composite\n  steps:\n    - shell: sh\n      run: echo COMPOSITE_ONLY=seen >> \"$GITHUB_ENV\"\n")
+	node := filepath.Join(t.TempDir(), "missing-node")
+	lockID := remoteLifecycleLockID(1)
+	j := jobContainerPlan(t, w, []plan.Step{{ID: "composite", Kind: "uses", Uses: "./composite", Action: &plan.ActionSelector{Lock: lockID}}})
+	j.Actions = []plan.ActionLock{{ID: lockID, Source: "workspace", Path: "composite", SourceDigest: digestTree(t, filepath.Join(w, "composite"))}}
+	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node24: node}).RunJob(context.Background(), j, w)
+	if err != nil || result.Env["COMPOSITE_ONLY"] != "seen" {
+		t.Fatalf("composite-only container result = %#v, error = %v", result, err)
+	}
+	for _, call := range f.calls(t) {
+		if slices.Contains(call.Args, "/__buildkite-gha/node24") && slices.Contains(call.Args, "--version") {
+			t.Fatalf("composite-only container probed Node: %#v", call.Args)
+		}
+	}
+}
+
+func TestRunJobContainerReadOnlyMountProbeFailureCleansOwnedResources(t *testing.T) {
+	f := newJobDocker(t, "fail-mount-probe")
+	w := t.TempDir()
+	remote := t.TempDir()
+	writeFixtureFile(t, remote, "selected/action.yml", "name: remote\nruns:\n  using: composite\n  steps: []\n")
+	digest := digestTree(t, remote)
+	j := jobContainerPlan(t, w, nil)
+	lockID := remoteLifecycleLockID(1)
+	j.Steps = []plan.Step{{ID: "action", Kind: "uses", Uses: remoteLifecycleUses("selected"), Action: &plan.ActionSelector{Lock: lockID}}}
+	j.Actions = []plan.ActionLock{remoteLifecycleLock(lockID, "selected", digest, nil)}
+	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, ActionRoot: filepath.Join(remote, "selected"), SourceDigest: digest}}
+	_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Actions: materializer}).RunJob(context.Background(), j, w)
+	if err == nil || !strings.Contains(err.Error(), "not readable/traversable") {
+		t.Fatalf("read-only mount probe error = %v", err)
+	}
+	calls := f.calls(t)
+	joined := fmt.Sprint(calls)
+	if !strings.Contains(joined, "rm --force buildkite-gha-job-") || !strings.Contains(joined, "network rm buildkite-gha-network-") {
+		t.Fatalf("owned resources not cleaned: %s", joined)
+	}
+	if len(calls) == 0 {
+		t.Fatal("Docker was not called")
+	}
+	if _, statErr := os.Stat(calls[0].Config); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("private Docker config remains after mount probe failure: %v", statErr)
+	}
+}
+
+func TestRunJobContainerSkippedRemoteJavaScriptDoesNotRequireNode(t *testing.T) {
+	f := newJobDocker(t, "incompatible-node")
+	w := t.TempDir()
+	remote := t.TempDir()
+	writeFixtureFile(t, remote, "selected/action.yml", "name: skipped remote\nruns:\n  using: node24\n  main: main.js\n  post: post.js\n")
+	writeFixtureFile(t, remote, "selected/main.js", "")
+	writeFixtureFile(t, remote, "selected/post.js", "")
+	digest := digestTree(t, remote)
+	lockID := remoteLifecycleLockID(1)
+	j := jobContainerPlan(t, w, []plan.Step{{ID: "skipped", Kind: "uses", Uses: remoteLifecycleUses("selected"), Condition: "false", Action: &plan.ActionSelector{Lock: lockID}}})
+	j.Actions = []plan.ActionLock{remoteLifecycleLock(lockID, "selected", digest, nil)}
+	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, ActionRoot: filepath.Join(remote, "selected"), SourceDigest: digest}}
+	missingNode := filepath.Join(t.TempDir(), "missing-node")
+	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node24: missingNode, Actions: materializer}).RunJob(context.Background(), j, w)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("skipped remote JavaScript result = %#v, error = %v", result, err)
+	}
+	for _, call := range f.calls(t) {
+		if slices.Contains(call.Args, "--version") {
+			t.Fatalf("skipped remote JavaScript probed Node: %#v", call.Args)
+		}
+	}
+}
+
+func TestRunJobContainerJavaScriptLifecycle(t *testing.T) {
+	f := newJobDocker(t, "")
+	workspace := fixturePath(t)
+	node := requireNode24(t)
+	lockID := remoteLifecycleLockID(1)
+	job := runtimePlan(t, workspace, "smoke/.github/workflows/ci.yml", []plan.Step{{
+		ID: "javascript", Kind: "uses", Uses: "./actions/javascript",
+		With:   map[string]string{"message": "container", "order": "single"},
+		Action: &plan.ActionSelector{Lock: lockID},
+	}})
+	job.Schema = plan.SchemaV4
+	job.RequiredCapabilities = []string{"docker", "network"}
+	job.Container = &plan.Container{Image: "debian:bookworm-slim"}
+	job.Actions = []plan.ActionLock{{
+		ID: lockID, Source: "workspace", Path: "actions/javascript",
+		SourceDigest: digestTree(t, filepath.Join(workspace, "actions", "javascript")),
+	}}
+	job.Outputs = map[string]string{"result": "${{ steps.javascript.outputs.result }}"}
+	var logs bytes.Buffer
+	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node24: node, Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outputs["result"] != "container-javascript" || result.Env["RUNTIME_SEEN"] != "true" || result.State["pre"] != "ready" || result.State["phase"] != "main" || result.Summary != "runtime main summary\nruntime post single\n" {
+		t.Fatalf("container JavaScript result = %#v", result)
+	}
+	if strings.Contains(logs.String(), "runtime-secret-value") {
+		t.Fatalf("container JavaScript logs leaked mask: %q", logs.String())
+	}
+	for _, event := range []string{"lifecycle:pre", "lifecycle:main", "masked probe: ***", "lifecycle:post:single"} {
+		if !strings.Contains(logs.String(), event) {
+			t.Fatalf("container JavaScript logs omit %q: %q", event, logs.String())
+		}
+	}
+	pre, main, post := strings.Index(logs.String(), "lifecycle:pre"), strings.Index(logs.String(), "lifecycle:main"), strings.Index(logs.String(), "lifecycle:post:single")
+	if pre < 0 || pre > main || main > post {
+		t.Fatalf("container JavaScript lifecycle order = %q", logs.String())
+	}
+	calls := f.calls(t)
+	createIndex := jobDockerCallIndex(calls, "create")
+	if createIndex < 0 {
+		t.Fatalf("Docker create absent: %#v", calls)
+	}
+	create := calls[createIndex].Args
+	nodeMount := "type=bind,source=" + node + ",target=/__buildkite-gha/node24,readonly"
+	if !slices.Contains(create, nodeMount) || slices.Contains(create, "--user") {
+		t.Fatalf("container JavaScript create mounts/user = %#v", create)
+	}
+	seenLifecycleExec := false
+	for _, call := range calls {
+		joined := strings.Join(call.Args, "\x00")
+		if !strings.Contains(joined, ContainerProcessHelperCommand+"\x00run") || !strings.Contains(joined, "/actions/javascript/") {
+			continue
+		}
+		seenLifecycleExec = true
+		if !strings.Contains(joined, "/__buildkite-gha/node24") || !strings.Contains(joined, "GITHUB_ACTION_PATH="+jobContainerWorkspace+"/actions/javascript") {
+			t.Fatalf("container JavaScript paths were not translated: %#v", call.Args)
+		}
+	}
+	if !seenLifecycleExec {
+		t.Fatalf("container JavaScript exec absent: %#v", calls)
+	}
+}
+
+func TestRunJobContainerCompositeAndNestedJavaScript(t *testing.T) {
+	f := newJobDocker(t, "")
+	workspace := t.TempDir()
+	writeFixtureFile(t, workspace, ".github/workflows/container.yml", "name: nested container actions\n")
+	for _, name := range []string{"top", "nested"} {
+		writeFixtureFile(t, workspace, ".github/actions/"+name+"/action.yml", "name: "+name+"\nruns:\n  using: node24\n  main: main.js\n  post: post.js\n")
+		writeFixtureFile(t, workspace, ".github/actions/"+name+"/main.js", "")
+		writeFixtureFile(t, workspace, ".github/actions/"+name+"/post.js", "")
+	}
+	writeFixtureFile(t, workspace, ".github/actions/composite/action.yml", `name: Nested lifecycle
+runs:
+  using: composite
+  steps:
+    - shell: sh
+      run: echo COMPOSITE_SEEN=yes >> "$GITHUB_ENV"
+    - id: child
+      uses: ./.github/actions/nested
+`)
+	fakeNode := filepath.Join(workspace, "node24")
+	writeFixtureFile(t, workspace, "node24", `#!/bin/sh
+set -eu
+if [ "${1:-}" = --version ]; then echo v24.0.0; exit 0; fi
+action=$(basename "$(dirname "$1")")
+phase=$(basename "$1" .js)
+printf '%s:%s\n' "$action" "$phase" >> "$LIFECYCLE_LOG"
+`)
+	if err := os.Chmod(fakeNode, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	lifecycle := filepath.Join(workspace, "lifecycle.log")
+	topID, compositeID, nestedID := remoteLifecycleLockID(1), remoteLifecycleLockID(2), remoteLifecycleLockID(3)
+	job := runtimePlan(t, workspace, ".github/workflows/container.yml", []plan.Step{
+		{ID: "top", Kind: "uses", Uses: "./.github/actions/top", Action: &plan.ActionSelector{Lock: topID}},
+		{ID: "composite", Kind: "uses", Uses: "./.github/actions/composite", Action: &plan.ActionSelector{Lock: compositeID}},
+		{ID: "verify", Kind: "run", Shell: "sh", Command: `test "$COMPOSITE_SEEN" = yes`},
+	})
+	job.Schema = plan.SchemaV4
+	job.RequiredCapabilities = []string{"docker", "network"}
+	job.Container = &plan.Container{Image: "debian:bookworm-slim"}
+	job.Env = map[string]string{"LIFECYCLE_LOG": lifecycle}
+	job.Actions = []plan.ActionLock{
+		{ID: topID, Source: "workspace", Path: ".github/actions/top", SourceDigest: digestTree(t, filepath.Join(workspace, ".github/actions/top"))},
+		{ID: compositeID, Source: "workspace", Path: ".github/actions/composite", SourceDigest: digestTree(t, filepath.Join(workspace, ".github/actions/composite")), Children: map[string]plan.ActionSelector{"./.github/actions/nested": {Lock: nestedID}}},
+		{ID: nestedID, Source: "workspace", Path: ".github/actions/nested", SourceDigest: digestTree(t, filepath.Join(workspace, ".github/actions/nested"))},
+	}
+	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node24: fakeNode}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("container nested actions result = %#v, error = %v", result, err)
+	}
+	events, err := os.ReadFile(lifecycle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(events), "top:main\nnested:main\nnested:post\ntop:post\n"; got != want {
+		t.Fatalf("container nested lifecycle = %q, want %q", got, want)
+	}
+}
+
+func TestRunJobContainerRemoteActionsMountedReadOnly(t *testing.T) {
+	f := newJobDocker(t, "")
+	workspace := t.TempDir()
+	writeFixtureFile(t, workspace, ".github/workflows/container.yml", "name: remote container action\n")
+	remote := t.TempDir()
+	writeFixtureFile(t, remote, "selected/action.yml", "name: remote\nruns:\n  using: node24\n  main: main.js\n")
+	writeFixtureFile(t, remote, "selected/main.js", `require("node:fs").appendFileSync(process.env.GITHUB_OUTPUT, "remote=yes\n")
+`)
+	digest := digestTree(t, remote)
+	lockID := remoteLifecycleLockID(1)
+	job := runtimePlan(t, workspace, ".github/workflows/container.yml", []plan.Step{{
+		ID: "remote", Kind: "uses", Uses: remoteLifecycleUses("selected"), Action: &plan.ActionSelector{Lock: lockID},
+	}})
+	job.Schema = plan.SchemaV4
+	job.RequiredCapabilities = []string{"docker", "network"}
+	job.Container = &plan.Container{Image: "debian:bookworm-slim"}
+	job.Actions = []plan.ActionLock{remoteLifecycleLock(lockID, "selected", digest, nil)}
+	job.Outputs = map[string]string{"remote": "${{ steps.remote.outputs.remote }}"}
+	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, ActionRoot: filepath.Join(remote, "selected"), SourceDigest: digest}}
+	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node24: requireNode24(t), Actions: materializer}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Outputs["remote"] != "yes" {
+		t.Fatalf("remote container action result = %#v, error = %v", result, err)
+	}
+	if materializer.calls != 1 {
+		t.Fatalf("remote materialization calls = %d, want 1", materializer.calls)
+	}
+	calls := f.calls(t)
+	createIndex := jobDockerCallIndex(calls, "create")
+	if createIndex < 0 {
+		t.Fatalf("Docker create absent: %#v", calls)
+	}
+	target := remoteMountTarget("owner/repo", strings.Repeat("a", 40))
+	wantMount := "type=bind,source=" + remote + ",target=" + target + ",readonly"
+	count := 0
+	for _, arg := range calls[createIndex].Args {
+		if arg == wantMount {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("remote readonly root mount count = %d in %#v", count, calls[createIndex].Args)
+	}
+	if jobDockerCallIndex(calls, "create") <= 0 {
+		t.Fatalf("remote materialization was not completed before Docker create")
+	}
+}
+
+func TestRunJobContainerRemoteChildOfWorkspaceCompositeMountedBeforeCreate(t *testing.T) {
+	f := newJobDocker(t, "")
+	workspace := t.TempDir()
+	writeFixtureFile(t, workspace, ".github/workflows/container.yml", "name: nested remote container action\n")
+	writeFixtureFile(t, workspace, ".github/actions/composite/action.yml", `name: workspace parent
+runs:
+  using: composite
+  steps:
+    - uses: owner/repo/selected@v1
+`)
+	remote := t.TempDir()
+	writeFixtureFile(t, remote, "selected/action.yml", "name: remote child\nruns:\n  using: node24\n  main: main.js\n")
+	writeFixtureFile(t, remote, "selected/main.js", "")
+	node := filepath.Join(workspace, "node24")
+	writeFixtureFile(t, workspace, "node24", `#!/bin/sh
+set -eu
+if [ "${1:-}" = --version ]; then echo v24.0.0; exit 0; fi
+echo NESTED_REMOTE=seen >> "$GITHUB_ENV"
+`)
+	if err := os.Chmod(node, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	localID, remoteID := remoteLifecycleLockID(1), remoteLifecycleLockID(2)
+	digest := digestTree(t, remote)
+	job := runtimePlan(t, workspace, ".github/workflows/container.yml", []plan.Step{{
+		ID: "composite", Kind: "uses", Uses: "./.github/actions/composite", Action: &plan.ActionSelector{Lock: localID},
+	}})
+	job.Schema = plan.SchemaV4
+	job.RequiredCapabilities = []string{"docker", "network"}
+	job.Container = &plan.Container{Image: "debian:bookworm-slim"}
+	job.Actions = []plan.ActionLock{
+		{ID: localID, Source: "workspace", Path: ".github/actions/composite", SourceDigest: digestTree(t, filepath.Join(workspace, ".github/actions/composite")), Children: map[string]plan.ActionSelector{remoteLifecycleUses("selected"): {Lock: remoteID}}},
+		remoteLifecycleLock(remoteID, "selected", digest, nil),
+	}
+	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, ActionRoot: filepath.Join(remote, "selected"), SourceDigest: digest}}
+	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node24: node, Actions: materializer}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Env["NESTED_REMOTE"] != "seen" {
+		t.Fatalf("nested remote container action result = %#v, error = %v", result, err)
+	}
+	if materializer.calls != 1 {
+		t.Fatalf("nested remote materialization calls = %d, want 1", materializer.calls)
+	}
+	calls := f.calls(t)
+	createIndex := jobDockerCallIndex(calls, "create")
+	if createIndex < 0 {
+		t.Fatalf("Docker create absent: %#v", calls)
+	}
+	wantMount := "type=bind,source=" + remote + ",target=" + remoteMountTarget("owner/repo", strings.Repeat("a", 40)) + ",readonly"
+	if !slices.Contains(calls[createIndex].Args, wantMount) {
+		t.Fatalf("nested remote source was not mounted at create: %#v", calls[createIndex].Args)
+	}
+}
+
+func TestRunJobContainerWorkspaceActionRemainsLazy(t *testing.T) {
+	f := newJobDocker(t, "")
+	workspace := t.TempDir()
+	writeFixtureFile(t, workspace, ".github/workflows/container.yml", "name: lazy container action\n")
+	actionSource := t.TempDir()
+	actionYAML := "name: lazy\nruns:\n  using: node24\n  main: main.js\n"
+	mainJS := `require("node:fs").appendFileSync(process.env.GITHUB_OUTPUT, "lazy=ready\n")
+`
+	writeFixtureFile(t, actionSource, "action.yml", actionYAML)
+	writeFixtureFile(t, actionSource, "main.js", mainJS)
+	lockID := remoteLifecycleLockID(1)
+	lazyDir := ".github/actions/lazy"
+	create := fmt.Sprintf("mkdir -p %s; printf '%%s' %s | base64 -d > %s/action.yml; printf '%%s' %s | base64 -d > %s/main.js",
+		lazyDir, base64.StdEncoding.EncodeToString([]byte(actionYAML)), lazyDir,
+		base64.StdEncoding.EncodeToString([]byte(mainJS)), lazyDir)
+	job := runtimePlan(t, workspace, ".github/workflows/container.yml", []plan.Step{
+		{ID: "populate", Kind: "run", Shell: "sh", Command: create},
+		{ID: "lazy", Kind: "uses", Uses: "./" + lazyDir, Action: &plan.ActionSelector{Lock: lockID}},
+	})
+	job.Schema = plan.SchemaV4
+	job.RequiredCapabilities = []string{"docker", "network"}
+	job.Container = &plan.Container{Image: "debian:bookworm-slim"}
+	job.Actions = []plan.ActionLock{{ID: lockID, Source: "workspace", Path: lazyDir, SourceDigest: digestTree(t, actionSource)}}
+	job.Outputs = map[string]string{"lazy": "${{ steps.lazy.outputs.lazy }}"}
+	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node24: requireNode24(t)}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Outputs["lazy"] != "ready" {
+		t.Fatalf("lazy container action result = %#v, error = %v", result, err)
+	}
+}
+
+func TestRunJobContainerRejectsDockerActionsUntilSiblingBackend(t *testing.T) {
+	t.Run("workspace", func(t *testing.T) {
+		f := newJobDocker(t, "")
+		workspace := fixturePath(t)
+		lockID := remoteLifecycleLockID(1)
+		job := runtimePlan(t, workspace, "smoke/.github/workflows/ci.yml", []plan.Step{{
+			ID: "docker", Kind: "uses", Uses: "./actions/docker", Action: &plan.ActionSelector{Lock: lockID},
+		}})
+		job.Schema = plan.SchemaV4
+		job.RequiredCapabilities = []string{"docker", "network"}
+		job.Container = &plan.Container{Image: "debian:bookworm-slim"}
+		job.Actions = []plan.ActionLock{{ID: lockID, Source: "workspace", Path: "actions/docker", SourceDigest: digestTree(t, filepath.Join(workspace, "actions/docker"))}}
+		_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(context.Background(), job, workspace)
+		if err == nil || !strings.Contains(err.Error(), "unsupported until Phase 5 M3b") {
+			t.Fatalf("workspace Docker action error = %v", err)
+		}
+		for _, call := range f.calls(t) {
+			if len(call.Args) != 0 && (call.Args[0] == "buildx" || call.Args[0] == "run") {
+				t.Fatalf("workspace Docker action executed nested Docker command: %#v", call.Args)
+			}
+		}
+	})
+
+	t.Run("remote preflight", func(t *testing.T) {
+		f := newJobDocker(t, "")
+		workspace := t.TempDir()
+		writeFixtureFile(t, workspace, ".github/workflows/container.yml", "name: remote Docker rejection\n")
+		remote := t.TempDir()
+		writeFixtureFile(t, remote, "docker/action.yml", "name: docker\nruns:\n  using: docker\n  image: Dockerfile\n")
+		writeFixtureFile(t, remote, "docker/Dockerfile", "FROM scratch\n")
+		digest := digestTree(t, remote)
+		lockID := remoteLifecycleLockID(1)
+		job := runtimePlan(t, workspace, ".github/workflows/container.yml", []plan.Step{{
+			ID: "docker", Kind: "uses", Uses: remoteLifecycleUses("docker"), Action: &plan.ActionSelector{Lock: lockID},
+		}})
+		job.Schema = plan.SchemaV4
+		job.RequiredCapabilities = []string{"docker", "network"}
+		job.Container = &plan.Container{Image: "debian:bookworm-slim"}
+		job.Actions = []plan.ActionLock{remoteLifecycleLock(lockID, "docker", digest, nil)}
+		materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, ActionRoot: filepath.Join(remote, "docker"), SourceDigest: digest}}
+		_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Actions: materializer}).RunJob(context.Background(), job, workspace)
+		if err == nil || !strings.Contains(err.Error(), "unsupported until Phase 5 M3b") {
+			t.Fatalf("remote Docker action error = %v", err)
+		}
+		if calls := f.calls(t); len(calls) != 0 {
+			t.Fatalf("remote Docker action reached Docker before preflight rejection: %#v", calls)
+		}
+	})
+}
+
+func TestRunJobContainerJavaScriptCancellationRunsPost(t *testing.T) {
+	f := newJobDocker(t, "")
+	workspace := t.TempDir()
+	writeFixtureFile(t, workspace, ".github/workflows/container.yml", "name: cancelled container action\n")
+	writeFixtureFile(t, workspace, ".github/actions/cancel/action.yml", "name: cancel\nruns:\n  using: node24\n  main: main.js\n  post: post.js\n")
+	writeFixtureFile(t, workspace, ".github/actions/cancel/main.js", `require("node:fs").writeFileSync(process.env.READY, "ready"); setInterval(() => {}, 30000)
+`)
+	writeFixtureFile(t, workspace, ".github/actions/cancel/post.js", `require("node:fs").writeFileSync(process.env.POST_MARKER, "post")
+`)
+	ready, postMarker := filepath.Join(workspace, "ready"), filepath.Join(workspace, "post-ran")
+	lockID := remoteLifecycleLockID(1)
+	job := runtimePlan(t, workspace, ".github/workflows/container.yml", []plan.Step{
+		{ID: "background", Kind: "uses", Uses: "./.github/actions/cancel", Background: true, Action: &plan.ActionSelector{Lock: lockID}},
+		{ID: "await", Kind: "run", Shell: "sh", Command: `while [ ! -f "$READY" ]; do sleep .01; done`},
+		{ID: "cancel", Kind: "cancel", Targets: []string{"background"}},
+	})
+	job.Schema = plan.SchemaV4
+	job.RequiredCapabilities = []string{"docker", "network"}
+	job.Container = &plan.Container{Image: "debian:bookworm-slim"}
+	job.Env = map[string]string{"READY": ready, "POST_MARKER": postMarker}
+	job.Actions = []plan.ActionLock{{ID: lockID, Source: "workspace", Path: ".github/actions/cancel", SourceDigest: digestTree(t, filepath.Join(workspace, ".github/actions/cancel"))}}
+	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node24: requireNode24(t), InterruptGrace: 20 * time.Millisecond, TerminateGrace: 20 * time.Millisecond, CleanupTimeout: 15 * time.Second}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("cancelled container JavaScript result = %#v, error = %v", result, err)
+	}
+	if contents, readErr := os.ReadFile(postMarker); readErr != nil || string(contents) != "post" {
+		t.Fatalf("cancelled container JavaScript post = %q, %v", contents, readErr)
+	}
+	terminateCalls := 0
+	for _, call := range f.calls(t) {
+		if strings.Contains(strings.Join(call.Args, "\x00"), ContainerProcessHelperCommand+"\x00terminate") {
+			terminateCalls++
+		}
+	}
+	if terminateCalls != 1 {
+		t.Fatalf("cancelled container JavaScript terminate calls = %d, want 1", terminateCalls)
+	}
+}
+
 func TestValidateDockerMountFileRequiresExistingRegularExecutableSafeAbsoluteFile(t *testing.T) {
 	d := t.TempDir()
 	for _, p := range []string{d, "relative", filepath.Join(d, "missing")} {
@@ -558,11 +1100,24 @@ func liveContainerJob(t *testing.T, docker string, steps []plan.Step) JobResult 
 	j := jobContainerPlan(t, w, steps)
 	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 	defer cancel()
-	r, e := (Runner{Docker: docker, RuntimeExecutable: os.Args[0], InterruptGrace: 100 * time.Millisecond, TerminateGrace: 100 * time.Millisecond}).RunJob(ctx, j, w)
+	r, e := (Runner{Docker: docker, RuntimeExecutable: buildLiveContainerRuntime(t), InterruptGrace: 100 * time.Millisecond, TerminateGrace: 100 * time.Millisecond}).RunJob(ctx, j, w)
 	if e != nil {
 		t.Fatal(e)
 	}
 	return r
+}
+
+func buildLiveContainerRuntime(t *testing.T) string {
+	t.Helper()
+	root := filepath.Dir(fixturePath(t))
+	binary := filepath.Join(t.TempDir(), "buildkite-gha")
+	command := exec.Command("go", "build", "-trimpath", "-buildvcs=false", "-o", binary, "./cmd/buildkite-gha")
+	command.Dir = root
+	command.Env = append(os.Environ(), "CGO_ENABLED=0")
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("build static container runtime: %v: %s", err, output)
+	}
+	return binary
 }
 func TestLiveJobContainerPersistsAcrossShellSteps(t *testing.T) {
 	d := requireDocker(t)
@@ -570,7 +1125,14 @@ func TestLiveJobContainerPersistsAcrossShellSteps(t *testing.T) {
 }
 func TestLiveJobContainerDefaultNonRootUser(t *testing.T) {
 	d := requireDocker(t)
-	liveContainerJob(t, d, []plan.Step{{ID: "u", Kind: "run", Shell: "sh", Command: `test "$(id -u)" = 0`}})
+	w := t.TempDir()
+	j := jobContainerPlan(t, w, []plan.Step{{ID: "u", Kind: "run", Shell: "sh", Command: `test "$(id -u)" != 0`}})
+	j.Container.Image = "nginxinc/nginx-unprivileged:stable-alpine"
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	if _, err := (Runner{Docker: d, RuntimeExecutable: buildLiveContainerRuntime(t)}).RunJob(ctx, j, w); err != nil {
+		t.Fatal(err)
+	}
 }
 func TestLiveJobContainerCancellationKillsProcessTree(t *testing.T) {
 	d := requireDocker(t)
@@ -578,4 +1140,45 @@ func TestLiveJobContainerCancellationKillsProcessTree(t *testing.T) {
 		{ID: "bg", Kind: "run", Shell: "sh", Background: true, Command: "sleep 30 & wait"},
 		{ID: "cancel", Kind: "cancel", Targets: []string{"bg"}},
 	})
+}
+
+func TestLiveJobContainerJavaScriptCompositeAndPost(t *testing.T) {
+	docker := requireDocker(t)
+	workspace := t.TempDir()
+	writeFixtureFile(t, workspace, ".github/workflows/container.yml", "name: live container actions\n")
+	writeFixtureFile(t, workspace, ".github/actions/js/action.yml", "name: js\nruns:\n  using: node24\n  main: main.js\n  post: post.js\n")
+	writeFixtureFile(t, workspace, ".github/actions/js/main.js", `require("node:fs").appendFileSync(process.env.GITHUB_OUTPUT, "value=live\n")
+`)
+	writeFixtureFile(t, workspace, ".github/actions/js/post.js", `require("node:fs").writeFileSync(process.env.GITHUB_WORKSPACE + "/post-ran", "yes")
+`)
+	writeFixtureFile(t, workspace, ".github/actions/composite/action.yml", `name: composite
+runs:
+  using: composite
+  steps:
+    - shell: sh
+      run: echo COMPOSITE_LIVE=yes >> "$GITHUB_ENV"
+`)
+	jsID, compositeID := remoteLifecycleLockID(1), remoteLifecycleLockID(2)
+	job := runtimePlan(t, workspace, ".github/workflows/container.yml", []plan.Step{
+		{ID: "js", Kind: "uses", Uses: "./.github/actions/js", Action: &plan.ActionSelector{Lock: jsID}},
+		{ID: "composite", Kind: "uses", Uses: "./.github/actions/composite", Action: &plan.ActionSelector{Lock: compositeID}},
+		{ID: "verify", Kind: "run", Shell: "sh", Command: `test "$COMPOSITE_LIVE" = yes`},
+	})
+	job.Schema = plan.SchemaV4
+	job.RequiredCapabilities = []string{"docker", "network"}
+	job.Container = &plan.Container{Image: "node:24-bookworm-slim"}
+	job.Actions = []plan.ActionLock{
+		{ID: jsID, Source: "workspace", Path: ".github/actions/js", SourceDigest: digestTree(t, filepath.Join(workspace, ".github/actions/js"))},
+		{ID: compositeID, Source: "workspace", Path: ".github/actions/composite", SourceDigest: digestTree(t, filepath.Join(workspace, ".github/actions/composite"))},
+	}
+	job.Outputs = map[string]string{"value": "${{ steps.js.outputs.value }}"}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	result, err := (Runner{Docker: docker, RuntimeExecutable: buildLiveContainerRuntime(t), Node24: requireNode24(t)}).RunJob(ctx, job, workspace)
+	if err != nil || result.Outputs["value"] != "live" || result.Env["COMPOSITE_LIVE"] != "yes" {
+		t.Fatalf("live container actions result = %#v, error = %v", result, err)
+	}
+	if contents, readErr := os.ReadFile(filepath.Join(workspace, "post-ran")); readErr != nil || string(contents) != "yes" {
+		t.Fatalf("live container post = %q, %v", contents, readErr)
+	}
 }

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/buildkite/buildkite-gha/internal/action/source"
+	"github.com/buildkite/buildkite-gha/internal/compiler"
 	"github.com/buildkite/buildkite-gha/internal/plan"
 )
 
@@ -1572,6 +1573,12 @@ func liveContainerJob(t *testing.T, docker string, steps []plan.Step) JobResult 
 
 func buildLiveContainerRuntime(t *testing.T) string {
 	t.Helper()
+	if explicit := os.Getenv("BUILDKITE_GHA_TEST_RUNTIME"); explicit != "" {
+		if err := validateDockerMountFile(explicit); err != nil {
+			t.Fatalf("BUILDKITE_GHA_TEST_RUNTIME is not a mount-safe executable: %v", err)
+		}
+		return explicit
+	}
 	root := filepath.Dir(fixturePath(t))
 	binary := filepath.Join(t.TempDir(), "buildkite-gha")
 	command := exec.Command("go", "build", "-trimpath", "-buildvcs=false", "-o", binary, "./cmd/buildkite-gha")
@@ -1644,4 +1651,190 @@ runs:
 	if contents, readErr := os.ReadFile(filepath.Join(workspace, "post-ran")); readErr != nil || string(contents) != "yes" {
 		t.Fatalf("live container post = %q, %v", contents, readErr)
 	}
+}
+
+func TestLivePhase5CompiledContainerRuntime(t *testing.T) {
+	workspace := t.TempDir()
+	if err := os.CopyFS(workspace, os.DirFS(fixturePath(t, "phase5", "runtime"))); err != nil {
+		t.Fatalf("copy Phase 5 fixture: %v", err)
+	}
+	workflowPath := filepath.Join(workspace, ".github", "workflows", "runtime.yml")
+	workflowSource, err := os.ReadFile(workflowPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	eventSource, err := os.ReadFile(fixturePath(t, "smoke", "events", "push.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle, err := compiler.CompileBundleWithOptions(workflowPath, workflowSource, eventSource, "phase5-live", "sha256:"+strings.Repeat("2", 64), "phase5-live-importer", compiler.Options{
+		EventTrust: compiler.EventUntrusted,
+		Runners: compiler.RunnerPolicy{
+			Labels:          map[string]string{"ubuntu-latest": "gha-untrusted"},
+			UntrustedQueues: []string{"gha-untrusted"},
+		},
+		ResolveActions: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bundle.Plans) != 2 {
+		t.Fatalf("compiled plans = %d, want 2", len(bundle.Plans))
+	}
+	for _, artifact := range bundle.Plans {
+		job := artifact.Job
+		if job.Schema != plan.SchemaV4 || !slices.Equal(job.RequiredCapabilities, []string{"docker", "network"}) {
+			t.Fatalf("compiled %s plan boundary = schema %q, capabilities %#v", job.Workflow.LogicalJobID, job.Schema, job.RequiredCapabilities)
+		}
+		wantSources := []string{"dockerfile-actions", "service-containers"}
+		if job.Workflow.LogicalJobID == "container-runtime" {
+			wantSources = []string{"dockerfile-actions", "job-containers", "service-containers"}
+		}
+		if !slices.Equal(artifact.Authorization.DockerCapabilitySources, wantSources) {
+			t.Fatalf("compiled %s Docker provenance = %#v, want %#v", job.Workflow.LogicalJobID, artifact.Authorization.DockerCapabilitySources, wantSources)
+		}
+	}
+	docker := requireDocker(t)
+	node24 := requireNode24(t)
+	before := liveDockerOwnedResources(t, docker)
+	runtimeExecutable := buildLiveContainerRuntime(t)
+	seen := map[string]bool{}
+	for _, artifact := range bundle.Plans {
+		job := artifact.Job
+		var logs bytes.Buffer
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		result, runErr := (Runner{Docker: docker, RuntimeExecutable: runtimeExecutable, Node24: node24, Stdout: &logs, Stderr: &logs}).RunJob(ctx, job, workspace)
+		cancel()
+		if runErr != nil || result.Conclusion != "success" {
+			t.Fatalf("run %s result = %#v, error = %v, logs = %q", job.Workflow.LogicalJobID, result, runErr, logs.String())
+		}
+		wantObservation := strings.TrimSuffix(job.Workflow.LogicalJobID, "-runtime") + "-runtime"
+		if result.Outputs["observation"] != wantObservation {
+			t.Fatalf("run %s observation = %q, want %q", job.Workflow.LogicalJobID, result.Outputs["observation"], wantObservation)
+		}
+		if strings.Contains(logs.String(), "phase5-javascript-secret") || strings.Contains(logs.String(), "phase5-docker-secret") {
+			t.Fatalf("run %s leaked a registered mask: %q", job.Workflow.LogicalJobID, logs.String())
+		}
+		if job.Workflow.LogicalJobID == "container-runtime" {
+			for _, want := range []string{"phase5 JavaScript main\n", "phase5 Docker action summary\n", "phase5 JavaScript post\n"} {
+				if !strings.Contains(result.Summary, want) {
+					t.Fatalf("container summary lacks %q: %q", want, result.Summary)
+				}
+			}
+		}
+		seen[job.Workflow.LogicalJobID] = true
+	}
+	if !seen["container-runtime"] || !seen["host-runtime"] {
+		t.Fatalf("executed logical jobs = %#v", seen)
+	}
+	if contents, readErr := os.ReadFile(filepath.Join(workspace, "phase5-post-ran")); readErr != nil || string(contents) != "yes" {
+		t.Fatalf("compiled container post marker = %q, %v", contents, readErr)
+	}
+	if after := liveDockerOwnedResources(t, docker); !slices.Equal(after, before) {
+		t.Fatalf("Phase 5 runtime leaked owned Docker resources: before=%#v after=%#v", before, after)
+	}
+}
+
+func TestLivePhase5ManifestContainerFixtures(t *testing.T) {
+	docker := requireDocker(t)
+	workspace := t.TempDir()
+	if err := os.CopyFS(workspace, os.DirFS(fixturePath(t, "unsupported"))); err != nil {
+		t.Fatalf("copy smoke fixture root: %v", err)
+	}
+	eventSource, err := os.ReadFile(fixturePath(t, "smoke", "events", "push.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtimeExecutable := buildLiveContainerRuntime(t)
+	before := liveDockerOwnedResources(t, docker)
+	for _, test := range []struct {
+		name       string
+		provenance string
+		logicalJob string
+	}{
+		{name: "job-container.yml", provenance: "job-containers", logicalJob: "container"},
+		{name: "service-container.yml", provenance: "service-containers", logicalJob: "service"},
+	} {
+		workflowPath := filepath.Join(workspace, ".github", "workflows", test.name)
+		workflowSource, readErr := os.ReadFile(workflowPath)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		bundle, compileErr := compiler.CompileBundle(workflowPath, workflowSource, eventSource, "phase5-live", "sha256:"+strings.Repeat("2", 64), "phase5-live-importer")
+		if compileErr != nil {
+			t.Fatalf("compile %s: %v", test.name, compileErr)
+		}
+		if len(bundle.Plans) != 1 || bundle.Plans[0].Job.Schema != plan.SchemaV4 || bundle.Plans[0].Job.Workflow.LogicalJobID != test.logicalJob || !slices.Equal(bundle.Plans[0].Authorization.DockerCapabilitySources, []string{test.provenance}) {
+			t.Fatalf("compiled %s boundary = %#v", test.name, bundle.Plans)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+		result, runErr := (Runner{Docker: docker, RuntimeExecutable: runtimeExecutable}).RunJob(ctx, bundle.Plans[0].Job, workspace)
+		cancel()
+		if runErr != nil || result.Conclusion != "success" {
+			t.Fatalf("run %s result = %#v, error = %v", test.name, result, runErr)
+		}
+	}
+	if after := liveDockerOwnedResources(t, docker); !slices.Equal(after, before) {
+		t.Fatalf("manifest container fixtures leaked owned Docker resources: before=%#v after=%#v", before, after)
+	}
+}
+
+func TestLivePhase5UnhealthyServiceDiagnostics(t *testing.T) {
+	docker := requireDocker(t)
+	contextDir := t.TempDir()
+	dockerfile := `FROM busybox@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028
+HEALTHCHECK --interval=1s --timeout=1s --retries=1 CMD exit 1
+CMD ["sh", "-c", "echo phase5-health-diagnostic >&2; sleep 300"]
+`
+	if err := os.WriteFile(filepath.Join(contextDir, "Dockerfile"), []byte(dockerfile), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	image := "buildkite-gha-phase5-unhealthy-" + strconv.FormatInt(time.Now().UnixNano(), 36)
+	command := exec.Command(docker, "buildx", "build", "--builder", "default", "--load", "--tag", image, contextDir)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("build unhealthy service: %v: %s", err, output)
+	}
+	t.Cleanup(func() { _ = exec.Command(docker, "image", "rm", "--force", image).Run() })
+	workspace := t.TempDir()
+	writeFixtureFile(t, workspace, ".github/workflows/health.yml", "name: health diagnostics\n")
+	job := runtimePlan(t, workspace, ".github/workflows/health.yml", []plan.Step{{ID: "unreachable", Kind: "run", Shell: "sh", Command: "true"}})
+	job.Schema = plan.SchemaV4
+	job.RequiredCapabilities = []string{"docker", "network"}
+	job.Services = map[string]plan.Container{"unhealthy": {Image: image}}
+	var logs bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	_, err := (Runner{Docker: docker, Stdout: &logs, Stderr: &logs}).RunJob(ctx, job, workspace)
+	if err == nil || !strings.Contains(err.Error(), `service "unhealthy" failed readiness with status "unhealthy"`) {
+		t.Fatalf("unhealthy service error = %v, logs = %q", err, logs.String())
+	}
+	if !strings.Contains(logs.String(), "phase5-health-diagnostic") {
+		t.Fatalf("unhealthy service diagnostic absent: %q", logs.String())
+	}
+}
+
+func liveDockerOwnedResources(t *testing.T, docker string) []string {
+	t.Helper()
+	queries := []struct {
+		kind string
+		args []string
+	}{
+		{kind: "container", args: []string{"container", "ls", "--all", "--format", "{{.Names}}", "--filter", "name=buildkite-gha-"}},
+		{kind: "network", args: []string{"network", "ls", "--format", "{{.Name}}", "--filter", "name=buildkite-gha-network-"}},
+		{kind: "image", args: []string{"image", "ls", "--format", "{{.Repository}}", "--filter", "reference=buildkite-gha-image-*"}},
+	}
+	var resources []string
+	for _, query := range queries {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		output, err := exec.CommandContext(ctx, docker, query.args...).CombinedOutput()
+		cancel()
+		if err != nil {
+			t.Fatalf("query live Docker %s resources: %v: %s", query.kind, err, output)
+		}
+		for _, name := range strings.Fields(string(output)) {
+			resources = append(resources, query.kind+":"+name)
+		}
+	}
+	slices.Sort(resources)
+	return resources
 }

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -1795,6 +1795,13 @@ CMD ["sh", "-c", "echo phase5-health-diagnostic >&2; sleep 300"]
 		t.Fatalf("build unhealthy service: %v: %s", err, output)
 	}
 	t.Cleanup(func() { _ = exec.Command(docker, "image", "rm", "--force", image).Run() })
+	// Other live fixtures exercise anonymous pulls. Keep this one-off local image
+	// in the daemon so this test can isolate readiness diagnostics and cleanup.
+	dockerWrapper := filepath.Join(t.TempDir(), "docker")
+	wrapper := "#!/bin/sh\nif [ \"$1\" = pull ]; then exit 0; fi\nexec " + strconv.Quote(docker) + " \"$@\"\n"
+	if err := os.WriteFile(dockerWrapper, []byte(wrapper), 0o700); err != nil {
+		t.Fatal(err)
+	}
 	workspace := t.TempDir()
 	writeFixtureFile(t, workspace, ".github/workflows/health.yml", "name: health diagnostics\n")
 	job := runtimePlan(t, workspace, ".github/workflows/health.yml", []plan.Step{{ID: "unreachable", Kind: "run", Shell: "sh", Command: "true"}})
@@ -1804,7 +1811,7 @@ CMD ["sh", "-c", "echo phase5-health-diagnostic >&2; sleep 300"]
 	var logs bytes.Buffer
 	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 	defer cancel()
-	_, err := (Runner{Docker: docker, Stdout: &logs, Stderr: &logs}).RunJob(ctx, job, workspace)
+	_, err := (Runner{Docker: dockerWrapper, Stdout: &logs, Stderr: &logs}).RunJob(ctx, job, workspace)
 	if err == nil || !strings.Contains(err.Error(), `service "unhealthy" failed readiness with status "unhealthy"`) {
 		t.Fatalf("unhealthy service error = %v, logs = %q", err, logs.String())
 	}

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -132,6 +132,12 @@ func TestJobContainerFakeDockerProcess(t *testing.T) {
 	}
 	container, network := filepath.Join(root, "container"), filepath.Join(root, "network")
 	actionContainer, actionImage := filepath.Join(root, "action-container"), filepath.Join(root, "action-image")
+	containerPath := func(name string) string {
+		if strings.HasPrefix(name, "buildkite-gha-service-") {
+			return filepath.Join(root, "service-"+name)
+		}
+		return container
+	}
 	switch key {
 	case "buildx":
 		if len(args) > 1 && args[1] == "inspect" {
@@ -157,7 +163,11 @@ func TestJobContainerFakeDockerProcess(t *testing.T) {
 		}
 		os.Exit(0)
 	case "create":
+		name := ""
 		for i := 0; i+1 < len(args); i++ {
+			if args[i] == "--name" {
+				name = args[i+1]
+			}
 			if args[i] == "--mount" {
 				p := strings.Split(args[i+1], ",")
 				var src, dst string
@@ -178,7 +188,17 @@ func TestJobContainerFakeDockerProcess(t *testing.T) {
 				}
 			}
 		}
-		_ = os.WriteFile(container, nil, 0o600)
+		_ = os.WriteFile(containerPath(name), nil, 0o600)
+		if scenario == "fail-later-service-create" && strings.HasPrefix(name, "buildkite-gha-service-") {
+			counter := filepath.Join(root, "service-create-count")
+			data, _ := os.ReadFile(counter)
+			n, _ := strconv.Atoi(string(data))
+			n++
+			_ = os.WriteFile(counter, []byte(strconv.Itoa(n)), 0o600)
+			if n == 2 {
+				os.Exit(42)
+			}
+		}
 		if scenario == "fail-create" {
 			os.Exit(42)
 		}
@@ -188,6 +208,31 @@ func TestJobContainerFakeDockerProcess(t *testing.T) {
 			os.Exit(42)
 		}
 		os.Exit(0)
+	case "inspect":
+		name := args[len(args)-1]
+		if _, err := os.Stat(containerPath(name)); err != nil {
+			os.Exit(1)
+		}
+		switch scenario {
+		case "service-unhealthy":
+			fmt.Print("unhealthy\n")
+		case "service-starting":
+			counter := filepath.Join(root, "inspect-count")
+			data, _ := os.ReadFile(counter)
+			n, _ := strconv.Atoi(string(data))
+			_ = os.WriteFile(counter, []byte(strconv.Itoa(n+1)), 0o600)
+			if n == 0 {
+				fmt.Print("starting\n")
+			} else {
+				fmt.Print("healthy\n")
+			}
+		default:
+			fmt.Print("running\n")
+		}
+		os.Exit(0)
+	case "logs":
+		fmt.Print("diagnostic sibling-secret\n")
+		os.Exit(0)
 	case "ps":
 		if scenario == "query-fail" && strings.Contains(strings.Join(args, " "), "name=") {
 			os.Exit(43)
@@ -196,6 +241,12 @@ func TestJobContainerFakeDockerProcess(t *testing.T) {
 		owner, _ := os.ReadFile(filepath.Join(root, "action-owner"))
 		isAction := strings.Contains(joined, "buildkite-gha-container-") || (len(owner) != 0 && strings.Contains(joined, string(owner)))
 		path := container
+		for _, arg := range args {
+			if strings.HasPrefix(arg, "name=^/buildkite-gha-service-") {
+				name := strings.TrimSuffix(strings.TrimPrefix(arg, "name=^/"), "$")
+				path = containerPath(name)
+			}
+		}
 		if isAction {
 			path = actionContainer
 		}
@@ -227,10 +278,11 @@ func TestJobContainerFakeDockerProcess(t *testing.T) {
 	case "stop":
 		os.Exit(0)
 	case "rm":
-		if strings.Contains(strings.Join(args, " "), "buildkite-gha-container-") {
+		joined := strings.Join(args, " ")
+		if strings.Contains(joined, "buildkite-gha-container-") {
 			_ = os.Remove(actionContainer)
 		} else {
-			_ = os.Remove(container)
+			_ = os.Remove(containerPath(args[len(args)-1]))
 		}
 		os.Exit(0)
 	case "image":
@@ -436,6 +488,158 @@ func TestRunJobContainerLifecycleAndEnvironment(t *testing.T) {
 	}
 }
 
+func TestRunJobContainerServicesLifecycleAndArguments(t *testing.T) {
+	f := newJobDocker(t, "")
+	w := t.TempDir()
+	j := jobContainerPlan(t, w, nil)
+	j.Container.Ports = []string{"8080", "5432:5432", "9000:90/udp"}
+	j.Services = map[string]plan.Container{
+		"z-cache": {Image: "redis:7", Env: map[string]string{"Z": "last", "A": "first"}, Ports: j.Container.Ports},
+		"a-db":    {Image: "postgres:16", Env: map[string]string{"B": "two"}},
+	}
+	if _, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(context.Background(), j, w); err != nil {
+		t.Fatal(err)
+	}
+	calls := f.calls(t)
+	var creates, starts, inspects []jobDockerCall
+	for _, c := range calls {
+		switch c.Args[0] {
+		case "create":
+			creates = append(creates, c)
+		case "start":
+			starts = append(starts, c)
+		case "inspect":
+			inspects = append(inspects, c)
+		}
+	}
+	if len(creates) != 3 || len(starts) != 3 || len(inspects) != 2 || jobDockerCallIndex(calls, "inspect") < jobDockerCallIndex(calls, "start")+1 {
+		t.Fatalf("unexpected service lifecycle: %#v", calls)
+	}
+	// Sorted IDs retain their association with aliases/images, and all service
+	// creates and starts precede readiness inspection.
+	if strings.Join(creates[0].Args, " ") == "" || !strings.Contains(strings.Join(creates[0].Args, " "), "--network-alias a-db") || creates[0].Args[len(creates[0].Args)-1] != "postgres:16" || !strings.Contains(strings.Join(creates[1].Args, " "), "--network-alias z-cache") || creates[1].Args[len(creates[1].Args)-1] != "redis:7" {
+		t.Fatalf("service order/association: %#v", creates)
+	}
+	firstInspect := jobDockerCallIndex(calls, "inspect")
+	startsBeforeInspect := 0
+	for i := 0; i < firstInspect; i++ {
+		if calls[i].Args[0] == "start" {
+			startsBeforeInspect++
+		}
+	}
+	if startsBeforeInspect != 2 {
+		t.Fatalf("only %d service starts preceded readiness", startsBeforeInspect)
+	}
+	serviceArgs := strings.Join(creates[1].Args, " ")
+	jobArgs := strings.Join(creates[2].Args, " ")
+	for _, want := range []string{"--env A=first --env Z=last", "--publish 127.0.0.1::8080", "--publish 127.0.0.1:5432:5432", "--publish 127.0.0.1:9000:90/udp"} {
+		if !strings.Contains(serviceArgs, want) && strings.HasPrefix(want, "--env") || (!strings.HasPrefix(want, "--env") && (!strings.Contains(serviceArgs, want) || !strings.Contains(jobArgs, want))) {
+			t.Errorf("missing %q: service=%q job=%q", want, serviceArgs, jobArgs)
+		}
+	}
+	network := creates[0].Args[slices.Index(creates[0].Args, "--network")+1]
+	if !strings.Contains(serviceArgs, "--network "+network) || !strings.Contains(jobArgs, "--network "+network) {
+		t.Error("containers do not share exact network")
+	}
+	forbidden := []string{"--privileged", "docker.sock", "--device", "--network host", "--pid host", "--user", "--volume"}
+	for _, create := range creates[:2] {
+		joined := strings.Join(create.Args, " ")
+		for _, bad := range forbidden {
+			if strings.Contains(joined, bad) {
+				t.Errorf("service introduced forbidden argument %q", bad)
+			}
+		}
+	}
+	// Successful cleanup is reverse service order, then job, network, verification.
+	joined := fmt.Sprint(calls)
+	zrm, arm := strings.Index(joined, "rm --force "+creates[1].Args[2]), strings.Index(joined, "rm --force "+creates[0].Args[2])
+	jobrm, netrm := strings.Index(joined, "rm --force "+creates[2].Args[2]), strings.Index(joined, "network rm")
+	if zrm < 0 || zrm >= arm || arm >= jobrm || jobrm >= netrm {
+		t.Fatalf("cleanup order: %s", joined)
+	}
+}
+
+func TestRunJobContainerServiceFailureDiagnosticsAreMasked(t *testing.T) {
+	f := newJobDocker(t, "service-unhealthy")
+	w, tmp := t.TempDir(), t.TempDir()
+	var output bytes.Buffer
+	p := newCommandProcessor(&output, &output)
+	p.addMask("sibling-secret")
+	_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).startJobContainer(context.Background(), p, w, tmp, plan.Container{Image: "alpine"}, map[string]plan.Container{"db": {Image: "postgres"}})
+	if err == nil || !strings.Contains(err.Error(), `service "db"`) || !strings.Contains(err.Error(), `status "unhealthy"`) {
+		t.Fatalf("error=%v", err)
+	}
+	if strings.Contains(output.String(), "sibling-secret") || !strings.Contains(output.String(), "***") || jobDockerCallIndex(f.calls(t), "logs", "--tail", "200") < 0 {
+		t.Fatalf("unmasked or missing diagnostics: %q", output.String())
+	}
+}
+
+func TestRunJobContainerLaterServiceCreateFailureCleansExactServices(t *testing.T) {
+	f := newJobDocker(t, "fail-later-service-create")
+	w, tmp := t.TempDir(), t.TempDir()
+	_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).startJobContainer(context.Background(), newCommandProcessor(os.Stdout, os.Stderr), w, tmp, plan.Container{Image: "alpine"}, map[string]plan.Container{"a": {Image: "one"}, "b": {Image: "two"}})
+	if err == nil {
+		t.Fatal("expected create failure")
+	}
+	calls := f.calls(t)
+	creates, removes := 0, 0
+	for _, c := range calls {
+		if c.Args[0] == "create" {
+			creates++
+		}
+		if c.Args[0] == "rm" && strings.HasPrefix(c.Args[len(c.Args)-1], "buildkite-gha-service-") {
+			removes++
+		}
+	}
+	if creates != 2 || removes != 2 {
+		t.Fatalf("ambiguous create cleanup incomplete: %#v", calls)
+	}
+}
+
+func TestRunJobContainerServiceReadinessCancellationCleansEverything(t *testing.T) {
+	f := newJobDocker(t, "service-starting")
+	w, tmp := t.TempDir(), t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).startJobContainer(ctx, newCommandProcessor(os.Stdout, os.Stderr), w, tmp, plan.Container{Image: "alpine"}, map[string]plan.Container{"db": {Image: "postgres"}})
+		done <- err
+	}()
+	deadline := time.Now().Add(10 * time.Second)
+	for jobDockerCallIndex(f.calls(t), "inspect") < 0 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	err := <-done
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error=%v", err)
+	}
+	joined := fmt.Sprint(f.calls(t))
+	if !strings.Contains(joined, "rm --force buildkite-gha-service-") || !strings.Contains(joined, "network rm buildkite-gha-network-") {
+		t.Fatalf("incomplete cancellation cleanup: %s", joined)
+	}
+}
+
+func TestJobContainerCleanupBudgetScalesToMaximumServices(t *testing.T) {
+	if got, want := jobContainerCleanupTimeout(10*time.Second, 32), 106*time.Second; got != want {
+		t.Fatalf("cleanup timeout = %s, want %s", got, want)
+	}
+}
+
+func TestRunJobRejectsHostServicesBeforeDocker(t *testing.T) {
+	f := newJobDocker(t, "")
+	w := t.TempDir()
+	j := jobContainerPlan(t, w, nil)
+	j.Container = nil
+	j.Services = map[string]plan.Container{"db": {Image: "postgres"}}
+	if _, err := (Runner{Docker: f.path}).RunJob(context.Background(), j, w); err == nil || !strings.Contains(err.Error(), "M4b") {
+		t.Fatalf("error=%v", err)
+	}
+	if len(f.calls(t)) != 0 {
+		t.Fatal("Docker called for rejected host services")
+	}
+}
+
 func TestRunJobContainerSetupFailuresCleanOwnedResources(t *testing.T) {
 	for _, stage := range []string{"pull", "network-create", "create", "start", "probe", "step"} {
 		t.Run(stage, func(t *testing.T) {
@@ -507,7 +711,7 @@ func TestRunJobContainerReportsLeftoverAndVerificationFailure(t *testing.T) {
 func startTestBackend(t *testing.T, f fakeJobDocker) (*jobContainerBackend, string) {
 	w := t.TempDir()
 	tmp := t.TempDir()
-	b, e := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], InterruptGrace: 20 * time.Millisecond, TerminateGrace: 20 * time.Millisecond}).startJobContainer(context.Background(), w, tmp, plan.Container{Image: "alpine:3.20"})
+	b, e := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], InterruptGrace: 20 * time.Millisecond, TerminateGrace: 20 * time.Millisecond}).startJobContainer(context.Background(), newCommandProcessor(os.Stdout, os.Stderr), w, tmp, plan.Container{Image: "alpine:3.20"}, nil)
 	if e != nil {
 		t.Fatal(e)
 	}
@@ -597,7 +801,7 @@ func TestRunJobContainerBarrierVisibility(t *testing.T) {
 }
 
 func TestRunJobContainerRejectsDeferredFeaturesBeforeDocker(t *testing.T) {
-	for _, feature := range []string{"service", "action", "port"} {
+	for _, feature := range []string{"action"} {
 		t.Run(feature, func(t *testing.T) {
 			f := newJobDocker(t, "")
 			w := t.TempDir()

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -164,9 +164,13 @@ func TestJobContainerFakeDockerProcess(t *testing.T) {
 		os.Exit(0)
 	case "create":
 		name := ""
+		var publications []string
 		for i := 0; i+1 < len(args); i++ {
 			if args[i] == "--name" {
 				name = args[i+1]
+			}
+			if args[i] == "--publish" {
+				publications = append(publications, args[i+1])
 			}
 			if args[i] == "--mount" {
 				p := strings.Split(args[i+1], ",")
@@ -189,6 +193,9 @@ func TestJobContainerFakeDockerProcess(t *testing.T) {
 			}
 		}
 		_ = os.WriteFile(containerPath(name), nil, 0o600)
+		if strings.HasPrefix(name, "buildkite-gha-service-") {
+			_ = os.WriteFile(containerPath(name)+".ports", []byte(strings.Join(publications, "\n")), 0o600)
+		}
 		if scenario == "fail-later-service-create" && strings.HasPrefix(name, "buildkite-gha-service-") {
 			counter := filepath.Join(root, "service-create-count")
 			data, _ := os.ReadFile(counter)
@@ -206,6 +213,30 @@ func TestJobContainerFakeDockerProcess(t *testing.T) {
 	case "start":
 		if scenario == "fail-start" {
 			os.Exit(42)
+		}
+		os.Exit(0)
+	case "port":
+		if scenario == "malformed-port" {
+			fmt.Print("6379/tcp -> 0.0.0.0:49152\n")
+			os.Exit(0)
+		}
+		data, _ := os.ReadFile(containerPath(args[len(args)-1]) + ".ports")
+		for _, publication := range strings.Split(string(data), "\n") {
+			if publication == "" {
+				continue
+			}
+			publication = strings.TrimPrefix(publication, "127.0.0.1:")
+			parts := strings.SplitN(publication, "/", 2)
+			proto := "tcp"
+			if len(parts) == 2 {
+				proto = parts[1]
+			}
+			mapping := strings.Split(parts[0], ":")
+			containerPort, hostPort := mapping[len(mapping)-1], "49152"
+			if len(mapping) > 1 && mapping[len(mapping)-2] != "" {
+				hostPort = mapping[len(mapping)-2]
+			}
+			fmt.Printf("%s/%s -> 127.0.0.1:%s\n", containerPort, proto, hostPort)
 		}
 		os.Exit(0)
 	case "inspect":
@@ -574,6 +605,21 @@ func TestRunJobContainerServiceFailureDiagnosticsAreMasked(t *testing.T) {
 	}
 }
 
+func TestRunJobContainerMalformedServicePortsIncludeMaskedDiagnostics(t *testing.T) {
+	f := newJobDocker(t, "malformed-port")
+	w, tmp := t.TempDir(), t.TempDir()
+	var output bytes.Buffer
+	p := newCommandProcessor(&output, &output)
+	p.addMask("sibling-secret")
+	_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).startJobContainer(context.Background(), p, w, tmp, plan.Container{}, map[string]plan.Container{"db": {Image: "postgres", Ports: []string{"6379"}}})
+	if err == nil || !strings.Contains(err.Error(), `service "db" has malformed Docker port output`) {
+		t.Fatalf("error=%v", err)
+	}
+	if strings.Contains(output.String(), "sibling-secret") || !strings.Contains(output.String(), "***") || jobDockerCallIndex(f.calls(t), "logs", "--tail", "200") < 0 {
+		t.Fatalf("unmasked or missing diagnostics: %q", output.String())
+	}
+}
+
 func TestRunJobContainerLaterServiceCreateFailureCleansExactServices(t *testing.T) {
 	f := newJobDocker(t, "fail-later-service-create")
 	w, tmp := t.TempDir(), t.TempDir()
@@ -620,23 +666,100 @@ func TestRunJobContainerServiceReadinessCancellationCleansEverything(t *testing.
 	}
 }
 
+func TestRunHostJobServiceReadinessCancellationCleansEverything(t *testing.T) {
+	f := newJobDocker(t, "service-starting")
+	w, tmp := t.TempDir(), t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := (Runner{Docker: f.path}).startJobContainer(ctx, newCommandProcessor(os.Stdout, os.Stderr), w, tmp, plan.Container{}, map[string]plan.Container{"db": {Image: "postgres"}})
+		done <- err
+	}()
+	deadline := time.Now().Add(10 * time.Second)
+	for jobDockerCallIndex(f.calls(t), "inspect") < 0 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	err := <-done
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error=%v", err)
+	}
+	joined := fmt.Sprint(f.calls(t))
+	if !strings.Contains(joined, "rm --force buildkite-gha-service-") || !strings.Contains(joined, "network rm buildkite-gha-network-") || strings.Contains(joined, "rm --force buildkite-gha-job-") {
+		t.Fatalf("incomplete or over-broad host-service cancellation cleanup: %s", joined)
+	}
+}
+
 func TestJobContainerCleanupBudgetScalesToMaximumServices(t *testing.T) {
 	if got, want := jobContainerCleanupTimeout(10*time.Second, 32), 106*time.Second; got != want {
 		t.Fatalf("cleanup timeout = %s, want %s", got, want)
 	}
 }
 
-func TestRunJobRejectsHostServicesBeforeDocker(t *testing.T) {
+func TestRunJobHostServicesLifecycle(t *testing.T) {
 	f := newJobDocker(t, "")
 	w := t.TempDir()
 	j := jobContainerPlan(t, w, nil)
 	j.Container = nil
-	j.Services = map[string]plan.Container{"db": {Image: "postgres"}}
-	if _, err := (Runner{Docker: f.path}).RunJob(context.Background(), j, w); err == nil || !strings.Contains(err.Error(), "M4b") {
-		t.Fatalf("error=%v", err)
+	j.Services = map[string]plan.Container{"db": {Image: "postgres", Ports: []string{"6379"}}}
+	j.Steps = []plan.Step{{ID: "host", Kind: "run", Shell: "sh", Env: map[string]string{"SERVICE_PORT": "${{ job.services.db.ports[6379] }}"}, Command: `test "$SERVICE_PORT" = 49152`}}
+	if _, err := (Runner{Docker: f.path}).RunJob(context.Background(), j, w); err != nil {
+		t.Fatal(err)
 	}
-	if len(f.calls(t)) != 0 {
-		t.Fatal("Docker called for rejected host services")
+	for _, call := range f.calls(t) {
+		if call.Args[0] == "exec" {
+			t.Fatalf("host service job used persistent container exec: %#v", call.Args)
+		}
+	}
+}
+
+func TestRunHostJobServicesExposePortsAndNetworkToDockerActions(t *testing.T) {
+	f := newJobDocker(t, "")
+	workspace := fixturePath(t)
+	lockID := remoteLifecycleLockID(1)
+	job := runtimePlan(t, workspace, "smoke/.github/workflows/ci.yml", []plan.Step{
+		{ID: "host", Kind: "run", Shell: "sh", Env: map[string]string{"SERVICE_PORT": "${{ job.services.redis.ports[6379] }}"}, Command: `test "$SERVICE_PORT" = 49152`},
+		{ID: "docker", Kind: "uses", Uses: "./actions/docker", With: map[string]string{"expected_file": "${{ job.services.redis.ports[6379] }}"}, Env: map[string]string{"SERVICE_PORT": "${{ job.services.redis.ports['6379'] }}"}, Action: &plan.ActionSelector{Lock: lockID}},
+	})
+	job.Schema = plan.SchemaV4
+	job.RequiredCapabilities = []string{"docker", "network"}
+	job.Services = map[string]plan.Container{"redis": {Image: "redis:7", Ports: []string{"6379"}}}
+	job.Actions = []plan.ActionLock{{ID: lockID, Source: "workspace", Path: "actions/docker", SourceDigest: digestTree(t, filepath.Join(workspace, "actions/docker"))}}
+	if _, err := (Runner{Docker: f.path}).RunJob(context.Background(), job, workspace); err != nil {
+		t.Fatal(err)
+	}
+	calls := f.calls(t)
+	if jobDockerCallIndex(calls, "exec") >= 0 {
+		t.Fatalf("host-service job unexpectedly used persistent container exec: %#v", calls)
+	}
+	create, run := jobDockerCallIndex(calls, "create"), jobDockerCallIndex(calls, "run")
+	if create < 0 || run < 0 {
+		t.Fatalf("host-service Docker action calls absent: %#v", calls)
+	}
+	network := argumentAfter(t, calls[create].Args, "--network")
+	if got := argumentAfter(t, calls[run].Args, "--network"); got != network {
+		t.Fatalf("Docker action network = %q, want %q", got, network)
+	}
+	joined := strings.Join(calls[run].Args, " ")
+	for _, want := range []string{"--env INPUT_EXPECTED_FILE=49152", "--env SERVICE_PORT=49152"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("Docker action did not receive service expression %q: %#v", want, calls[run].Args)
+		}
+	}
+	if jobDockerCallIndex(calls, "network", "rm") < run {
+		t.Fatalf("host-service network removed before Docker action: %#v", calls)
+	}
+}
+
+func TestRunJobHostServicePortProtocolCollisionIsDeterministic(t *testing.T) {
+	f := newJobDocker(t, "")
+	w := t.TempDir()
+	j := jobContainerPlan(t, w, nil)
+	j.Container = nil
+	j.Services = map[string]plan.Container{"db": {Image: "postgres", Ports: []string{"41001:6379/tcp", "41002:6379/udp"}}}
+	j.Steps = []plan.Step{{ID: "host", Kind: "run", Shell: "sh", Env: map[string]string{"SERVICE_PORT": "${{ job.services.db.ports[6379] }}"}, Command: `test "$SERVICE_PORT" = 41002`}}
+	if _, err := (Runner{Docker: f.path}).RunJob(context.Background(), j, w); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -810,10 +933,6 @@ func TestRunJobContainerRejectsDeferredFeaturesBeforeDocker(t *testing.T) {
 			switch feature {
 			case "action":
 				j.Steps = []plan.Step{{Kind: "uses", Uses: "x"}}
-			case "service":
-				j.Services = map[string]plan.Container{"db": {Image: "x"}}
-			case "port":
-				j.Container.Ports = []string{"8080"}
 			}
 			if _, e := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Actions: m}).RunJob(context.Background(), j, w); e == nil {
 				t.Fatal("accepted")

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -520,6 +520,26 @@ func TestRunJobContainerLifecycleAndEnvironment(t *testing.T) {
 	}
 }
 
+func TestRunJobContainerDefaultsRunStepsToSh(t *testing.T) {
+	f := newJobDocker(t, "")
+	workspace := t.TempDir()
+	j := jobContainerPlan(t, workspace, []plan.Step{{ID: "default", Kind: "run", Command: "true"}})
+	if _, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(context.Background(), j, workspace); err != nil {
+		t.Fatal(err)
+	}
+	for _, call := range f.calls(t) {
+		i := slices.Index(call.Args, ContainerProcessHelperCommand)
+		if i < 0 || len(call.Args) < i+7 || call.Args[len(call.Args)-1] != "true" {
+			continue
+		}
+		if got, want := call.Args[i+3:], []string{"sh", "-e", "-c", "true"}; !slices.Equal(got, want) {
+			t.Fatalf("default container shell argv = %#v, want %#v", got, want)
+		}
+		return
+	}
+	t.Fatal("default-shell container exec call not found")
+}
+
 func TestRunJobContainerServicesLifecycleAndArguments(t *testing.T) {
 	f := newJobDocker(t, "")
 	w := t.TempDir()

--- a/internal/runtime/files.go
+++ b/internal/runtime/files.go
@@ -33,7 +33,11 @@ type fileCommandEffects struct {
 }
 
 func newCommandFiles() (commandFiles, error) {
-	dir, err := os.MkdirTemp("", "buildkite-gha-files-")
+	return newCommandFilesUnder("")
+}
+
+func newCommandFilesUnder(parent string) (commandFiles, error) {
+	dir, err := os.MkdirTemp(parent, "buildkite-gha-files-")
 	if err != nil {
 		return commandFiles{}, fmt.Errorf("create file-command directory: %w", err)
 	}

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -96,13 +96,8 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 	if err := job.Validate(); err != nil {
 		return JobResult{}, err
 	}
-	if len(job.Services) != 0 {
-		return JobResult{}, fmt.Errorf("service containers are not supported until Phase 5 M4")
-	}
-	if job.Container != nil {
-		if len(job.Container.Ports) != 0 {
-			return JobResult{}, fmt.Errorf("job container ports are not supported until Phase 5 M4")
-		}
+	if len(job.Services) != 0 && job.Container == nil {
+		return JobResult{}, fmt.Errorf("services on host jobs are not supported until Phase 5 M4b")
 	}
 	for _, capability := range job.RequiredCapabilities {
 		if capability != "docker" && capability != "secrets" && capability != "network" {
@@ -250,7 +245,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 				return jobResult, mountErr
 			}
 		}
-		backend, setupErr := r.startJobContainer(runCtx, workspace, runnerTemp, *job.Container, containerMounts...)
+		backend, setupErr := r.startJobContainer(runCtx, processor, workspace, runnerTemp, *job.Container, job.Services, containerMounts...)
 		if setupErr != nil {
 			return jobResult, setupErr
 		}

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -230,9 +230,6 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 			if entrypointErr := action.ValidateEntrypoints(actionRuntime); entrypointErr != nil {
 				return jobResult, fmt.Errorf("prepare action lock %q: %w", lock.ID, entrypointErr)
 			}
-			if actionRuntime == metadata.RuntimeDocker {
-				return jobResult, fmt.Errorf("docker actions in job containers are unsupported until Phase 5 M3b")
-			}
 		}
 		for _, step := range job.Steps {
 			if step.Kind != "uses" || step.Action == nil {
@@ -571,9 +568,6 @@ func (r Runner) verifyRemoteActionTree(ctx context.Context, actions *actionLockR
 	if err := action.ValidateEntrypoints(runtime); err != nil {
 		return err
 	}
-	if r.jobContainer != nil && runtime == metadata.RuntimeDocker {
-		return fmt.Errorf("docker actions in job containers are unsupported until Phase 5 M3b")
-	}
 	if runtime != metadata.RuntimeComposite {
 		return nil
 	}
@@ -602,14 +596,6 @@ func (r Runner) actionContainerMounts(ctx context.Context, actions *actionLockRe
 		entry.mu.Lock()
 		material := entry.material
 		entry.mu.Unlock()
-		if material != nil {
-			target := remoteMountTarget(entry.lock.Repository, entry.lock.Commit)
-			m := containerMount{host: material.RepositoryRoot, target: target, readonly: true, probe: true}
-			if old, ok := byTarget[target]; ok && old.host != m.host {
-				return nil, fmt.Errorf("conflicting verified action roots for %q", target)
-			}
-			byTarget[target] = m
-		}
 
 		var action metadata.Metadata
 		switch lock.Source {
@@ -637,6 +623,14 @@ func (r Runner) actionContainerMounts(ctx context.Context, actions *actionLockRe
 		actionRuntime, err := action.Runtime()
 		if err != nil {
 			return nil, err
+		}
+		if material != nil && actionRuntime != metadata.RuntimeDocker {
+			target := remoteMountTarget(entry.lock.Repository, entry.lock.Commit)
+			m := containerMount{host: material.RepositoryRoot, target: target, readonly: true, probe: true}
+			if old, ok := byTarget[target]; ok && old.host != m.host {
+				return nil, fmt.Errorf("conflicting verified action roots for %q", target)
+			}
+			byTarget[target] = m
 		}
 		switch actionRuntime {
 		case metadata.RuntimeNode20:
@@ -969,9 +963,6 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 		composite, err := r.runCompositeMetadata(ctx, processor, workspace, job, actionPath, action, inputs, invocationID, jobEnv, stepEnv, actionEval, posts, actions, prepared, actionLock, actionStack)
 		return composite, err
 	case metadata.RuntimeDocker:
-		if r.jobContainer != nil {
-			return result, fmt.Errorf("docker action %q in a job container is unsupported until Phase 5 M3b", step.Uses)
-		}
 		if !job.HasCapability("docker") {
 			return result, fmt.Errorf("docker action %q requires the plan's docker capability", step.Uses)
 		}

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -96,9 +96,6 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 	if err := job.Validate(); err != nil {
 		return JobResult{}, err
 	}
-	if len(job.Services) != 0 && job.Container == nil {
-		return JobResult{}, fmt.Errorf("services on host jobs are not supported until Phase 5 M4b")
-	}
 	for _, capability := range job.RequiredCapabilities {
 		if capability != "docker" && capability != "secrets" && capability != "network" {
 			return JobResult{}, fmt.Errorf("capability %q is unsupported in the job runtime", capability)
@@ -250,6 +247,16 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 			return jobResult, setupErr
 		}
 		r.jobContainer = backend
+		r.jobDocker = backend
+		eval.Services = backend.servicePorts
+		defer func() { runJobErr = errors.Join(runJobErr, backend.cleanup()) }()
+	} else if len(job.Services) != 0 {
+		backend, setupErr := r.startJobContainer(runCtx, processor, workspace, runnerTemp, plan.Container{}, job.Services)
+		if setupErr != nil {
+			return jobResult, setupErr
+		}
+		r.jobDocker = backend
+		eval.Services = backend.servicePorts
 		defer func() { runJobErr = errors.Join(runJobErr, backend.cleanup()) }()
 	}
 	jobResult.Env = mergeStepEnvironment(standardEnvironment(job, workspace, runnerTemp), jobEnv)
@@ -344,7 +351,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 			continue
 		}
 
-		condition := expression.ConditionContext{Needs: eval.Needs, NeedResults: eval.NeedResults, Steps: statuses, Env: jobResult.Env, Vars: job.Vars, Matrix: job.Matrix, GitHub: eval.GitHub, Failure: runErr != nil, Unsuccessful: runErr != nil, Cancelled: runCtx.Err() != nil}
+		condition := expression.ConditionContext{Needs: eval.Needs, NeedResults: eval.NeedResults, Steps: statuses, Env: jobResult.Env, Vars: job.Vars, Matrix: job.Matrix, GitHub: eval.GitHub, Services: eval.Services, Failure: runErr != nil, Unsuccessful: runErr != nil, Cancelled: runCtx.Err() != nil}
 		run, err := expression.EvaluateCondition(step.Condition, condition)
 		if err != nil {
 			runErr = errors.Join(runErr, fmt.Errorf("step %q condition: %w", step.ID, err))
@@ -1008,7 +1015,7 @@ func (r Runner) runCompositeMetadata(ctx context.Context, processor *commandProc
 		// rebuilding the map so a child's declared env cannot leak to siblings.
 		eval.Env = mergeStringMaps(compositeEnv, result.Env)
 		id := strings.ToLower(step.ID)
-		condition := expression.ConditionContext{Inputs: eval.Inputs, Needs: eval.Needs, NeedResults: eval.NeedResults, Steps: statuses, Env: eval.Env, Vars: eval.Vars, Matrix: eval.Matrix, GitHub: eval.GitHub, Failure: runErr != nil, Unsuccessful: runErr != nil, Cancelled: ctx.Err() != nil}
+		condition := expression.ConditionContext{Inputs: eval.Inputs, Needs: eval.Needs, NeedResults: eval.NeedResults, Steps: statuses, Env: eval.Env, Vars: eval.Vars, Matrix: eval.Matrix, GitHub: eval.GitHub, Services: eval.Services, Failure: runErr != nil, Unsuccessful: runErr != nil, Cancelled: ctx.Err() != nil}
 		run, err := expression.EvaluateCondition(step.If, condition)
 		if err != nil {
 			runErr = errors.Join(runErr, fmt.Errorf("composite action step %d condition: %w", i+1, err))

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/buildkite/buildkite-gha/internal/action/metadata"
+	actionsource "github.com/buildkite/buildkite-gha/internal/action/source"
 	"github.com/buildkite/buildkite-gha/internal/expression"
 	"github.com/buildkite/buildkite-gha/internal/plan"
 )
@@ -101,11 +102,6 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 	if job.Container != nil {
 		if len(job.Container.Ports) != 0 {
 			return JobResult{}, fmt.Errorf("job container ports are not supported until Phase 5 M4")
-		}
-		for _, step := range job.Steps {
-			if step.Kind == "uses" {
-				return JobResult{}, fmt.Errorf("actions in job containers are not supported until Phase 5 M3")
-			}
 		}
 	}
 	for _, capability := range job.RequiredCapabilities {
@@ -212,8 +208,52 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 	if job.HasCapability("docker") {
 		r.runnerTemp = runnerTemp
 	}
+	actions := newActionLockResolver(job, workspace, r.Actions)
+	var containerMounts []containerMount
 	if job.Container != nil {
-		backend, setupErr := r.startJobContainer(runCtx, workspace, runnerTemp, *job.Container)
+		// Remote children of workspace composites are already present in the
+		// immutable lock graph even when the workspace action itself must remain
+		// lazy. Materialize every remote lock now because bind mounts cannot be
+		// added after the persistent container is created.
+		for _, lock := range job.Actions {
+			if lock.Source != "github" {
+				continue
+			}
+			action, _, resolveErr := actions.resolve(runCtx, plan.ActionSelector{Lock: lock.ID})
+			if resolveErr != nil {
+				return jobResult, fmt.Errorf("prepare action lock %q: %w", lock.ID, resolveErr)
+			}
+			actionRuntime, runtimeErr := action.Runtime()
+			if runtimeErr != nil {
+				return jobResult, fmt.Errorf("prepare action lock %q: %w", lock.ID, runtimeErr)
+			}
+			if entrypointErr := action.ValidateEntrypoints(actionRuntime); entrypointErr != nil {
+				return jobResult, fmt.Errorf("prepare action lock %q: %w", lock.ID, entrypointErr)
+			}
+			if actionRuntime == metadata.RuntimeDocker {
+				return jobResult, fmt.Errorf("docker actions in job containers are unsupported until Phase 5 M3b")
+			}
+		}
+		for _, step := range job.Steps {
+			if step.Kind != "uses" || step.Action == nil {
+				continue
+			}
+			if source, sourceErr := actions.source(*step.Action); sourceErr != nil {
+				return jobResult, sourceErr
+			} else if source == "github" {
+				if verifyErr := r.verifyRemoteActionTree(runCtx, actions, *step.Action, nil); verifyErr != nil {
+					return jobResult, fmt.Errorf("prepare action %q: %w", step.Uses, verifyErr)
+				}
+			}
+		}
+		if len(job.Actions) != 0 {
+			var mountErr error
+			containerMounts, mountErr = r.actionContainerMounts(runCtx, actions)
+			if mountErr != nil {
+				return jobResult, mountErr
+			}
+		}
+		backend, setupErr := r.startJobContainer(runCtx, workspace, runnerTemp, *job.Container, containerMounts...)
 		if setupErr != nil {
 			return jobResult, setupErr
 		}
@@ -236,7 +276,6 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		}
 	}
 	eval.Env = jobResult.Env
-	actions := newActionLockResolver(job, workspace, r.Actions)
 	var posts postRegistry
 	statuses := make(map[string]expression.StepStatus, len(job.Steps))
 	supervisor := newBackgroundSupervisor(maxActiveBackgroundSteps)
@@ -244,7 +283,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 	var runErr error
 	prepared := remotePreparations{}
 	preStatus := remotePreparationStatus{}
-	if job.Schema == plan.SchemaV3 {
+	if job.Schema == plan.SchemaV3 || job.Schema == plan.SchemaV4 {
 		for stepIndex, step := range job.Steps {
 			if step.Kind != "uses" {
 				continue
@@ -532,6 +571,9 @@ func (r Runner) verifyRemoteActionTree(ctx context.Context, actions *actionLockR
 	if err := action.ValidateEntrypoints(runtime); err != nil {
 		return err
 	}
+	if r.jobContainer != nil && runtime == metadata.RuntimeDocker {
+		return fmt.Errorf("docker actions in job containers are unsupported until Phase 5 M3b")
+	}
 	if runtime != metadata.RuntimeComposite {
 		return nil
 	}
@@ -549,6 +591,95 @@ func (r Runner) verifyRemoteActionTree(ctx context.Context, actions *actionLockR
 		}
 	}
 	return nil
+}
+
+func (r Runner) actionContainerMounts(ctx context.Context, actions *actionLockResolver) ([]containerMount, error) {
+	byTarget := map[string]containerMount{}
+	requiredNode := map[int]bool{}
+	unknownWorkspaceRuntime := false
+	for _, lock := range actions.job.Actions {
+		entry := actions.locks[lock.ID]
+		entry.mu.Lock()
+		material := entry.material
+		entry.mu.Unlock()
+		if material != nil {
+			target := remoteMountTarget(entry.lock.Repository, entry.lock.Commit)
+			m := containerMount{host: material.RepositoryRoot, target: target, readonly: true, probe: true}
+			if old, ok := byTarget[target]; ok && old.host != m.host {
+				return nil, fmt.Errorf("conflicting verified action roots for %q", target)
+			}
+			byTarget[target] = m
+		}
+
+		var action metadata.Metadata
+		switch lock.Source {
+		case "github":
+			var err error
+			action, _, err = actions.resolve(ctx, plan.ActionSelector{Lock: lock.ID})
+			if err != nil {
+				return nil, err
+			}
+		case "workspace":
+			loaded, err := metadata.Load(actions.workspace, lock.Path)
+			if err != nil {
+				unknownWorkspaceRuntime = true
+				continue
+			}
+			digest, err := actionsource.DigestTree(loaded.Path)
+			if err != nil || digest != lock.SourceDigest {
+				unknownWorkspaceRuntime = true
+				continue
+			}
+			action = loaded
+		default:
+			return nil, fmt.Errorf("unsupported action lock source %q", lock.Source)
+		}
+		actionRuntime, err := action.Runtime()
+		if err != nil {
+			return nil, err
+		}
+		switch actionRuntime {
+		case metadata.RuntimeNode20:
+			requiredNode[20] = true
+		case metadata.RuntimeNode24:
+			requiredNode[24] = true
+		}
+	}
+	for major, path := range map[int]string{20: r.Node20, 24: r.Node24} {
+		if path == "" || (!unknownWorkspaceRuntime && !requiredNode[major]) {
+			continue
+		}
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			return nil, err
+		}
+		info, err := os.Stat(abs)
+		if err != nil || !info.Mode().IsRegular() || info.Mode().Perm()&0o111 == 0 {
+			continue
+		}
+		byTarget[fmt.Sprintf("/__buildkite-gha/node%d", major)] = containerMount{host: abs, target: fmt.Sprintf("/__buildkite-gha/node%d", major), readonly: true}
+	}
+	needManagedNodeRoot := unknownWorkspaceRuntime && (r.Node20 == "" || r.Node24 == "")
+	for major := range requiredNode {
+		if map[int]string{20: r.Node20, 24: r.Node24}[major] == "" {
+			needManagedNodeRoot = true
+		}
+	}
+	if r.ManagedNodeRoot != "" && needManagedNodeRoot {
+		abs, err := filepath.Abs(r.ManagedNodeRoot)
+		if err != nil {
+			return nil, err
+		}
+		if info, statErr := os.Stat(abs); statErr == nil && info.IsDir() {
+			byTarget["/__buildkite-gha/nodes"] = containerMount{host: abs, target: "/__buildkite-gha/nodes", readonly: true}
+		}
+	}
+	keys := sortedKeys(byTarget)
+	out := make([]containerMount, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, byTarget[key])
+	}
+	return out, nil
 }
 
 func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProcessor, step plan.Step, invocationID string, jobEnv map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations, status *remotePreparationStatus, inheritedEvalErr error) (Result, error) {
@@ -594,12 +725,8 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 		if runtime == metadata.RuntimeNode20 {
 			major, explicit = 20, r.Node20
 		}
-		node, err := DiscoverNode(major, explicit, r.ManagedNodeRoot)
-		if err != nil {
-			return result, err
-		}
-		javascript := JavaScriptAction{Name: actionName(action, step), Path: action.Path, Pre: action.Runs.Pre, Main: action.Runs.Main, Post: action.Runs.Post}
-		invocation := &preparedInvocation{action: javascript, state: map[string]string{}, node: node}
+		javascript := JavaScriptAction{Name: actionName(action, step), Path: action.Path, Pre: action.Runs.Pre, Main: action.Runs.Main, Post: action.Runs.Post, nodeMajor: major}
+		invocation := &preparedInvocation{action: javascript, state: map[string]string{}}
 		prepared[invocationID] = invocation
 		if javascript.Pre != "" && runPre {
 			if inheritedEvalErr != nil {
@@ -620,6 +747,11 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 			javascript.Inputs = inputs
 			javascript.Env = mergeStepEnvironment(jobEnv, stepEnv)
 			invocation.action = javascript
+			node, err := DiscoverNode(major, explicit, r.ManagedNodeRoot)
+			if err != nil {
+				return result, err
+			}
+			invocation.node = node
 			posts.register(postForInvocation(invocation, action.Runs.PostIf))
 			invocation.postRegistered = true
 			if err := r.runJavaScriptPhase(ctx, processor, node, javascript, javascript.Pre, nil, invocation.state, &result); err != nil {
@@ -719,7 +851,7 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 
 	var action metadata.Metadata
 	var actionLock *plan.ActionLock
-	if job.Schema == plan.SchemaV3 {
+	if job.Schema == plan.SchemaV3 || job.Schema == plan.SchemaV4 {
 		if step.Action == nil {
 			return result, fmt.Errorf("action %q has no immutable selector", step.Uses)
 		}
@@ -799,11 +931,16 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 			return result, err
 		}
 		actionEnv := mergeStepEnvironment(jobEnv, stepEnv)
-		javascript := JavaScriptAction{Name: actionName(action, step), Path: actionPath, Pre: action.Runs.Pre, Main: action.Runs.Main, Post: action.Runs.Post, Inputs: inputs, Env: actionEnv}
+		javascript := JavaScriptAction{Name: actionName(action, step), Path: actionPath, Pre: action.Runs.Pre, Main: action.Runs.Main, Post: action.Runs.Post, Inputs: inputs, Env: actionEnv, nodeMajor: major}
 		state := map[string]string{}
 		wasPrepared := false
 		if invocation := prepared[invocationID]; invocation != nil {
-			javascript, state, node, wasPrepared = invocation.action, invocation.state, invocation.node, true
+			javascript, state, wasPrepared = invocation.action, invocation.state, true
+			if invocation.node != "" {
+				node = invocation.node
+			} else {
+				invocation.node = node
+			}
 			// Preserve invocation state while evaluating inputs and environment
 			// again with every main-visible effect committed.
 			javascript.Inputs = inputs
@@ -832,6 +969,9 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 		composite, err := r.runCompositeMetadata(ctx, processor, workspace, job, actionPath, action, inputs, invocationID, jobEnv, stepEnv, actionEval, posts, actions, prepared, actionLock, actionStack)
 		return composite, err
 	case metadata.RuntimeDocker:
+		if r.jobContainer != nil {
+			return result, fmt.Errorf("docker action %q in a job container is unsupported until Phase 5 M3b", step.Uses)
+		}
 		if !job.HasCapability("docker") {
 			return result, fmt.Errorf("docker action %q requires the plan's docker capability", step.Uses)
 		}

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -95,6 +95,9 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 	if err := job.Validate(); err != nil {
 		return JobResult{}, err
 	}
+	if job.Container != nil || len(job.Services) != 0 {
+		return JobResult{}, fmt.Errorf("job and service container runtime is not implemented")
+	}
 	for _, capability := range job.RequiredCapabilities {
 		if capability != "docker" && capability != "secrets" && capability != "network" {
 			return JobResult{}, fmt.Errorf("capability %q is unsupported in the job runtime", capability)

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -822,7 +822,11 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 			return result, err
 		}
 		if shell == "" {
-			shell = "bash"
+			if r.jobContainer != nil {
+				shell = "sh"
+			} else {
+				shell = "bash"
+			}
 		}
 		workingDirectory := step.WorkingDirectory
 		if workingDirectory == "" {

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -95,8 +95,18 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 	if err := job.Validate(); err != nil {
 		return JobResult{}, err
 	}
-	if job.Container != nil || len(job.Services) != 0 {
-		return JobResult{}, fmt.Errorf("job and service container runtime is not implemented")
+	if len(job.Services) != 0 {
+		return JobResult{}, fmt.Errorf("service containers are not supported until Phase 5 M4")
+	}
+	if job.Container != nil {
+		if len(job.Container.Ports) != 0 {
+			return JobResult{}, fmt.Errorf("job container ports are not supported until Phase 5 M4")
+		}
+		for _, step := range job.Steps {
+			if step.Kind == "uses" {
+				return JobResult{}, fmt.Errorf("actions in job containers are not supported until Phase 5 M3")
+			}
+		}
 	}
 	for _, capability := range job.RequiredCapabilities {
 		if capability != "docker" && capability != "secrets" && capability != "network" {
@@ -141,8 +151,14 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		jobResult.Conclusion = "skipped"
 		return jobResult, nil
 	}
+	runCtx := ctx
+	cancelJob := func() {}
+	if job.TimeoutMinutes > 0 {
+		runCtx, cancelJob = context.WithTimeout(ctx, durationMinutes(job.TimeoutMinutes))
+	}
+	defer cancelJob()
 
-	secrets, err := r.resolveSecrets(ctx, processor, job.RequiredSecrets)
+	secrets, err := r.resolveSecrets(runCtx, processor, job.RequiredSecrets)
 	if err != nil {
 		return jobResult, err
 	}
@@ -196,9 +212,22 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 	if job.HasCapability("docker") {
 		r.runnerTemp = runnerTemp
 	}
+	if job.Container != nil {
+		backend, setupErr := r.startJobContainer(runCtx, workspace, runnerTemp, *job.Container)
+		if setupErr != nil {
+			return jobResult, setupErr
+		}
+		r.jobContainer = backend
+		defer func() { runJobErr = errors.Join(runJobErr, backend.cleanup()) }()
+	}
 	jobResult.Env = mergeStepEnvironment(standardEnvironment(job, workspace, runnerTemp), jobEnv)
-	if path, ok := os.LookupEnv("PATH"); ok && jobResult.Env["PATH"] == "" {
-		jobResult.Env["PATH"] = path
+	if r.jobContainer != nil && !explicitJobPATH {
+		jobResult.Env["PATH"] = r.jobContainer.imagePATH
+	}
+	if r.jobContainer == nil {
+		if path, ok := os.LookupEnv("PATH"); ok && jobResult.Env["PATH"] == "" {
+			jobResult.Env["PATH"] = path
+		}
 	}
 	if job.HasCapability("docker") {
 		r.explicitJobPATH = explicitJobPATH
@@ -208,12 +237,6 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 	}
 	eval.Env = jobResult.Env
 	actions := newActionLockResolver(job, workspace, r.Actions)
-	runCtx := ctx
-	cancelJob := func() {}
-	if job.TimeoutMinutes > 0 {
-		runCtx, cancelJob = context.WithTimeout(runCtx, durationMinutes(job.TimeoutMinutes))
-	}
-	defer cancelJob()
 	var posts postRegistry
 	statuses := make(map[string]expression.StepStatus, len(job.Steps))
 	supervisor := newBackgroundSupervisor(maxActiveBackgroundSteps)

--- a/internal/runtime/process_helper.go
+++ b/internal/runtime/process_helper.go
@@ -1,0 +1,117 @@
+package runtime
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"syscall"
+	"time"
+)
+
+const ContainerProcessHelperCommand = "__container-process"
+const containerCancellationMarkerSuffix = ".cancel"
+const containerPIDPublicationWait = 500 * time.Millisecond
+
+// RunContainerProcessHelper implements the private process helper entry point.
+// It returns an exit status suitable for os.Exit.
+func RunContainerProcessHelper(args []string) int {
+	if len(args) < 2 {
+		_, _ = fmt.Fprintln(os.Stderr, "buildkite-gha: internal container process helper: invalid arguments")
+		return 2
+	}
+	switch args[0] {
+	case "run":
+		if len(args) < 3 {
+			return helperUsage()
+		}
+		marker := args[1] + containerCancellationMarkerSuffix
+		if _, err := os.Stat(marker); err == nil {
+			return 130
+		} else if !os.IsNotExist(err) {
+			return 1
+		}
+		cmd := exec.Command(args[2], args[3:]...)
+		cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+		cmd.Env = os.Environ()
+		configureProcessGroup(cmd)
+		if err := cmd.Start(); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "buildkite-gha: internal container process helper: start: %v\n", err)
+			return 1
+		}
+		if err := os.WriteFile(args[1], []byte(strconv.Itoa(cmd.Process.Pid)+"\n"), 0o600); err != nil {
+			terminateProcessGroupNow(cmd.Process.Pid, 0, 0)
+			_ = cmd.Wait()
+			_, _ = fmt.Fprintf(os.Stderr, "buildkite-gha: internal container process helper: write PID file: %v\n", err)
+			return 1
+		}
+		if _, err := os.Stat(marker); err == nil {
+			terminateProcessGroupNow(cmd.Process.Pid, 0, 0)
+		} else if !os.IsNotExist(err) {
+			terminateProcessGroupNow(cmd.Process.Pid, 0, 0)
+		}
+		err := cmd.Wait()
+		if err == nil {
+			return 0
+		}
+		var exit *exec.ExitError
+		if errors.As(err, &exit) {
+			if status, ok := exit.Sys().(syscall.WaitStatus); ok {
+				if status.Signaled() {
+					return 128 + int(status.Signal())
+				}
+				return status.ExitStatus()
+			}
+		}
+		return 1
+	case "terminate":
+		if len(args) != 4 {
+			return helperUsage()
+		}
+		interrupt, e1 := time.ParseDuration(args[2])
+		terminate, e2 := time.ParseDuration(args[3])
+		if e1 != nil || e2 != nil || interrupt < 0 || terminate < 0 {
+			return helperUsage()
+		}
+		if err := os.WriteFile(args[1]+containerCancellationMarkerSuffix, nil, 0o600); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "buildkite-gha: internal container process helper: write cancellation marker: %v\n", err)
+			return 1
+		}
+		deadline := time.Now().Add(containerPIDPublicationWait)
+		var pid int
+		for {
+			data, err := os.ReadFile(args[1])
+			if err == nil {
+				pid, err = strconv.Atoi(stringTrimSpace(data))
+				if err == nil && pid > 0 {
+					break
+				}
+			}
+			if time.Now().After(deadline) {
+				return 0
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		terminateProcessGroupNow(pid, interrupt, terminate)
+		return 0
+	default:
+		return helperUsage()
+	}
+}
+
+func helperUsage() int {
+	_, _ = fmt.Fprintln(os.Stderr, "buildkite-gha: internal container process helper: invalid arguments")
+	return 2
+}
+
+func stringTrimSpace(b []byte) string {
+	start, end := 0, len(b)
+	for start < end && (b[start] == ' ' || b[start] == '\n' || b[start] == '\r' || b[start] == '\t') {
+		start++
+	}
+	for end > start && (b[end-1] == ' ' || b[end-1] == '\n' || b[end-1] == '\r' || b[end-1] == '\t') {
+		end--
+	}
+	return string(b[start:end])
+}

--- a/internal/runtime/process_helper_test.go
+++ b/internal/runtime/process_helper_test.go
@@ -1,0 +1,89 @@
+//go:build linux
+
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestContainerProcessHelperStrictArguments(t *testing.T) {
+	for _, args := range [][]string{nil, {"unknown", "pid"}, {"run", "pid"}, {"terminate", "pid", "bad", "1s"}, {"terminate", "pid", "1s"}} {
+		if got := RunContainerProcessHelper(args); got != 2 {
+			t.Fatalf("RunContainerProcessHelper(%q) = %d, want 2", args, got)
+		}
+	}
+}
+
+func TestContainerProcessHelperRunRecordsChildAndReturnsStatus(t *testing.T) {
+	pidfile := filepath.Join(t.TempDir(), "child.pid")
+	if got := RunContainerProcessHelper([]string{"run", pidfile, "sh", "-c", "exit 23"}); got != 23 {
+		t.Fatalf("status = %d, want 23", got)
+	}
+	data, err := os.ReadFile(pidfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pid, err := strconv.Atoi(stringTrimSpace(data))
+	if err != nil || pid <= 0 {
+		t.Fatalf("PID file = %q, err = %v", data, err)
+	}
+}
+
+func TestContainerProcessHelperTerminatesProcessGroup(t *testing.T) {
+	pidfile := filepath.Join(t.TempDir(), "child.pid")
+	done := make(chan int, 1)
+	go func() {
+		done <- RunContainerProcessHelper([]string{"run", pidfile, "sh", "-c", "trap '' INT TERM; sleep 30 & wait"})
+	}()
+	deadline := time.Now().Add(time.Second)
+	for {
+		if _, err := os.Stat(pidfile); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("PID file was not created")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if got := RunContainerProcessHelper([]string{"terminate", pidfile, "10ms", "10ms"}); got != 0 {
+		t.Fatalf("terminate status = %d", got)
+	}
+	select {
+	case status := <-done:
+		if status != 128+int(syscall.SIGINT) && status != 128+int(syscall.SIGTERM) && status != 128+int(syscall.SIGKILL) {
+			t.Fatalf("run status = %d, want terminating signal status", status)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("helper did not terminate process group")
+	}
+}
+
+func TestContainerProcessHelperTerminateToleratesMissingPIDFile(t *testing.T) {
+	start := time.Now()
+	if got := RunContainerProcessHelper([]string{"terminate", filepath.Join(t.TempDir(), "missing"), "1ms", "1ms"}); got != 0 {
+		t.Fatalf("status = %d", got)
+	}
+	if elapsed := time.Since(start); elapsed < 450*time.Millisecond || elapsed > time.Second {
+		t.Fatalf("race wait = %v, want approximately 500ms", elapsed)
+	}
+}
+
+func TestContainerProcessHelperCancelBeforePIDPreventsLateCommandStart(t *testing.T) {
+	dir := t.TempDir()
+	pidfile := filepath.Join(dir, "late.pid")
+	started := filepath.Join(dir, "started")
+	if got := RunContainerProcessHelper([]string{"terminate", pidfile, "0", "0"}); got != 0 {
+		t.Fatalf("terminate status = %d", got)
+	}
+	if got := RunContainerProcessHelper([]string{"run", pidfile, "sh", "-c", "touch \"$1\"", "sh", started}); got != 130 {
+		t.Fatalf("late run status = %d", got)
+	}
+	if _, err := os.Stat(started); !os.IsNotExist(err) {
+		t.Fatalf("late command started: %v", err)
+	}
+}

--- a/internal/runtime/process_other.go
+++ b/internal/runtime/process_other.go
@@ -20,3 +20,9 @@ func terminateProcessGroup(ctx context.Context, pid int, _, _ time.Duration, fin
 	case <-finished:
 	}
 }
+
+func terminateProcessGroupNow(pid int, _, _ time.Duration) {
+	if process, err := os.FindProcess(pid); err == nil {
+		_ = process.Kill()
+	}
+}

--- a/internal/runtime/process_unix.go
+++ b/internal/runtime/process_unix.go
@@ -22,6 +22,10 @@ func terminateProcessGroup(ctx context.Context, pid int, interruptGrace, termina
 	// Signal children before the shell so its foreground command is interrupted
 	// before the shell dispatches its own trap. A single group signal leaves a
 	// fork/exit race where the shell can terminate without running that trap.
+	terminateProcessGroupNow(pid, interruptGrace, terminateGrace)
+}
+
+func terminateProcessGroupNow(pid int, interruptGrace, terminateGrace time.Duration) {
 	signalProcessGroup(pid, syscall.SIGINT)
 	if waitForProcessGroupExit(pid, interruptGrace) {
 		return

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -60,6 +60,8 @@ type JavaScriptAction struct {
 	Post   string
 	Inputs map[string]string
 	Env    map[string]string
+
+	nodeMajor int
 }
 
 // DockerAction is an already-resolved local Docker action.
@@ -428,7 +430,19 @@ func (r Runner) runJavaScriptPhase(ctx context.Context, processor *commandProces
 	for name, value := range stateEnv {
 		env["STATE_"+name] = value
 	}
-	if err := r.runProcess(ctx, processor, action.Path, env, result, stateOut, node, filepath.Join(action.Path, entry)); err != nil {
+	entrypoint := filepath.Join(action.Path, entry)
+	if r.jobContainer != nil {
+		if err := r.jobContainer.probeNode(ctx, node, action.nodeMajor); err != nil {
+			return err
+		}
+		absNode, err := filepath.Abs(node)
+		if err != nil {
+			return err
+		}
+		node = r.jobContainer.containerPath(absNode)
+		entrypoint = r.jobContainer.containerPath(entrypoint)
+	}
+	if err := r.runProcess(ctx, processor, action.Path, env, result, stateOut, node, entrypoint); err != nil {
 		return fmt.Errorf("JavaScript action %q entry %q: %w", action.Name, entry, err)
 	}
 	return nil

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -141,6 +141,9 @@ func (r Runner) runDocker(ctx context.Context, processor *commandProcessor, acti
 	if action.Workspace == "" || action.runnerTemp == "" {
 		return result, errors.New("docker workspace and runner temp are required")
 	}
+	if r.jobContainer != nil && (action.Workspace != r.jobContainer.workspace || action.runnerTemp != r.jobContainer.temp) {
+		return result, errors.New("docker action workspace and runner temp must match the job container's owned host paths")
+	}
 	docker := r.Docker
 	if docker == "" {
 		docker, err = exec.LookPath("docker")
@@ -265,14 +268,32 @@ func (r Runner) runDocker(ctx context.Context, processor *commandProcessor, acti
 		}
 	}
 	args := []string{"run", "--name", container, "--label", owner, "--mount", "type=bind,source=" + files.dir + ",target=/github/file_commands"}
+	if r.jobContainer != nil {
+		args = append(args, "--network", r.jobContainer.network)
+	}
 	if action.Workspace != "" {
 		args = append(args, "--mount", "type=bind,source="+action.Workspace+",target=/github/workspace", "--mount", "type=bind,source="+action.runnerTemp+",target=/github/runner_temp", "--workdir", "/github/workspace")
+	}
+	var siblingPaths *jobContainerBackend
+	if r.jobContainer != nil {
+		siblingPaths = &jobContainerBackend{mounts: []containerMount{
+			{host: action.Workspace, target: "/github/workspace"},
+			{host: action.runnerTemp, target: "/github/runner_temp"},
+		}}
 	}
 	for _, name := range sortedKeys(action.Env) {
 		if name == "RUNNER_TOOL_CACHE" || (name == "PATH" && !action.explicitPATH) || name == "GITHUB_WORKSPACE" || name == "RUNNER_TEMP" {
 			continue
 		}
-		args = append(args, "--env", name+"="+action.Env[name])
+		value := action.Env[name]
+		if siblingPaths != nil {
+			if name == "PATH" {
+				value = siblingPaths.translatePATH(value)
+			} else {
+				value = siblingPaths.containerPath(value)
+			}
+		}
+		args = append(args, "--env", name+"="+value)
 	}
 	if action.Workspace != "" {
 		args = append(args, "--env", "GITHUB_WORKSPACE=/github/workspace")

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -31,22 +31,24 @@ const (
 
 // Runner executes verified actions using explicitly configured host tools.
 type Runner struct {
-	Stdout          io.Writer
-	Stderr          io.Writer
-	Node20          string
-	Node24          string
-	ManagedNodeRoot string
-	Docker          string
-	Git             string
-	CleanupTimeout  time.Duration
-	InterruptGrace  time.Duration
-	TerminateGrace  time.Duration
-	Secrets         SecretResolver
-	Redactor        Redactor
-	Actions         ActionMaterializer
-	runnerTemp      string
-	implicitJobPATH string
-	explicitJobPATH bool
+	Stdout            io.Writer
+	Stderr            io.Writer
+	Node20            string
+	Node24            string
+	ManagedNodeRoot   string
+	Docker            string
+	RuntimeExecutable string
+	Git               string
+	CleanupTimeout    time.Duration
+	InterruptGrace    time.Duration
+	TerminateGrace    time.Duration
+	Secrets           SecretResolver
+	Redactor          Redactor
+	Actions           ActionMaterializer
+	runnerTemp        string
+	implicitJobPATH   string
+	explicitJobPATH   bool
+	jobContainer      *jobContainerBackend
 }
 
 // JavaScriptAction is an already-resolved local JavaScript action.
@@ -433,19 +435,33 @@ func (r Runner) runJavaScriptPhase(ctx context.Context, processor *commandProces
 }
 
 func (r Runner) runProcess(ctx context.Context, processor *commandProcessor, dir string, env map[string]string, result *Result, state map[string]string, name string, args ...string) error {
-	files, err := newCommandFiles()
+	var files commandFiles
+	var err error
+	if r.jobContainer != nil {
+		files, err = newCommandFilesUnder(r.runnerTemp)
+	} else {
+		files, err = newCommandFiles()
+	}
 	if err != nil {
 		return err
 	}
 	defer func() { _ = files.cleanup() }()
-	env = mergeStringMaps(env, map[string]string{
-		"GITHUB_OUTPUT":       files.output,
-		"GITHUB_ENV":          files.env,
-		"GITHUB_PATH":         files.path,
-		"GITHUB_STATE":        files.state,
-		"GITHUB_STEP_SUMMARY": files.summary,
-	})
-	runErr := r.runStreaming(ctx, processor, dir, env, name, args...)
+	commandPaths := map[string]string{"GITHUB_OUTPUT": files.output, "GITHUB_ENV": files.env, "GITHUB_PATH": files.path, "GITHUB_STATE": files.state, "GITHUB_STEP_SUMMARY": files.summary}
+	if r.jobContainer != nil {
+		if err := files.allowContainerWrites(); err != nil {
+			return err
+		}
+		for key, path := range commandPaths {
+			commandPaths[key] = r.jobContainer.containerPath(path)
+		}
+	}
+	env = mergeStringMaps(env, commandPaths)
+	var runErr error
+	if r.jobContainer != nil {
+		runErr = r.jobContainer.exec(ctx, r, processor, dir, env, name, args...)
+	} else {
+		runErr = r.runStreaming(ctx, processor, dir, env, name, args...)
+	}
 	effects, fileErr := files.apply(result, state)
 	if fileErr == nil && (effects.pathSet || len(effects.paths) > 0) {
 		pathEnv := map[string]string{"PATH": env["PATH"]}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -49,6 +49,7 @@ type Runner struct {
 	implicitJobPATH   string
 	explicitJobPATH   bool
 	jobContainer      *jobContainerBackend
+	jobDocker         *jobContainerBackend
 }
 
 // JavaScriptAction is an already-resolved local JavaScript action.
@@ -268,8 +269,8 @@ func (r Runner) runDocker(ctx context.Context, processor *commandProcessor, acti
 		}
 	}
 	args := []string{"run", "--name", container, "--label", owner, "--mount", "type=bind,source=" + files.dir + ",target=/github/file_commands"}
-	if r.jobContainer != nil {
-		args = append(args, "--network", r.jobContainer.network)
+	if r.jobDocker != nil {
+		args = append(args, "--network", r.jobDocker.network)
 	}
 	if action.Workspace != "" {
 		args = append(args, "--mount", "type=bind,source="+action.Workspace+",target=/github/workspace", "--mount", "type=bind,source="+action.runnerTemp+",target=/github/runner_temp", "--workdir", "/github/workspace")

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -423,6 +423,19 @@ func boundedDockerOutput(ctx context.Context, env map[string]string, docker stri
 	return output.String(), err
 }
 
+func boundedDockerCombinedOutput(ctx context.Context, env map[string]string, docker string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, docker, args...)
+	cmd.Env = processEnv(env)
+	var output strings.Builder
+	w := &limitedWriter{writer: &output, remaining: 4096}
+	cmd.Stdout, cmd.Stderr = w, w
+	err := cmd.Run()
+	if w.exceeded {
+		return output.String(), fmt.Errorf("docker output exceeds limit")
+	}
+	return output.String(), err
+}
+
 type limitedWriter struct {
 	writer    io.Writer
 	remaining int

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -3266,7 +3266,7 @@ func requireNode24(t *testing.T) string {
 			}
 		}
 	}
-	t.Skip("Node 24 unavailable: set BUILDKITE_GHA_TEST_NODE24 or install managed Node 24 with `mise install node@24`")
+	livePrerequisiteUnavailable(t, "Node 24 unavailable: set BUILDKITE_GHA_TEST_NODE24 or install managed Node 24 with `mise install node@24`")
 	return ""
 }
 
@@ -3274,15 +3274,24 @@ func requireDocker(t *testing.T) string {
 	t.Helper()
 	docker, err := exec.LookPath("docker")
 	if err != nil {
-		t.Skip("Docker unavailable: docker executable not found")
+		livePrerequisiteUnavailable(t, "Docker unavailable: docker executable not found")
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if output, err := exec.CommandContext(ctx, docker, "info", "--format", "{{.ServerVersion}}").CombinedOutput(); err != nil {
-		t.Skipf("Docker unavailable: daemon probe failed: %v: %s", err, strings.TrimSpace(string(output)))
+		livePrerequisiteUnavailable(t, "Docker unavailable: daemon probe failed: %v: %s", err, strings.TrimSpace(string(output)))
 	}
 	if output, err := exec.CommandContext(ctx, docker, "buildx", "inspect", "default", "--format", "{{.Driver}}").CombinedOutput(); err != nil || string(output) != "docker\n" {
-		t.Skipf("Docker unavailable: default Buildx builder is not the local docker driver: %v: %s", err, strings.TrimSpace(string(output)))
+		livePrerequisiteUnavailable(t, "Docker unavailable: default Buildx builder is not the local docker driver: %v: %s", err, strings.TrimSpace(string(output)))
 	}
 	return docker
+}
+
+func livePrerequisiteUnavailable(t *testing.T, format string, args ...any) {
+	t.Helper()
+	message := fmt.Sprintf(format, args...)
+	if os.Getenv("BUILDKITE_GHA_LIVE_REQUIRED") == "1" {
+		t.Fatal(message)
+	}
+	t.Skip(message)
 }

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -2263,8 +2263,8 @@ func main() {
 	if result.Outputs["nonroot"] != "written" {
 		t.Fatalf("Docker result = %#v", result)
 	}
-	if contents, err := os.ReadFile(filepath.Join(workspace, "nonroot-workspace")); err != nil || string(contents) != "written" {
-		t.Fatalf("non-root workspace write = %q, %v", contents, err)
+	if info, err := os.Stat(filepath.Join(workspace, "nonroot-workspace")); err != nil || info.Size() != int64(len("written")) {
+		t.Fatalf("non-root workspace output = %v, %v", info, err)
 	}
 	after, err := os.Stat(workspace)
 	if err != nil || after.Mode().Perm() != before.Mode().Perm() {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -3281,7 +3281,7 @@ func requireDocker(t *testing.T) string {
 	if output, err := exec.CommandContext(ctx, docker, "info", "--format", "{{.ServerVersion}}").CombinedOutput(); err != nil {
 		livePrerequisiteUnavailable(t, "Docker unavailable: daemon probe failed: %v: %s", err, strings.TrimSpace(string(output)))
 	}
-	if output, err := exec.CommandContext(ctx, docker, "buildx", "inspect", "default", "--format", "{{.Driver}}").CombinedOutput(); err != nil || string(output) != "docker\n" {
+	if output, err := exec.CommandContext(ctx, docker, "buildx", "inspect", "default").CombinedOutput(); err != nil || dockerBuilderDriver(string(output)) != "docker" {
 		livePrerequisiteUnavailable(t, "Docker unavailable: default Buildx builder is not the local docker driver: %v: %s", err, strings.TrimSpace(string(output)))
 	}
 	return docker

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -49,10 +49,27 @@ type Job struct {
 	If                      string                 `json:"if,omitempty"`
 	TimeoutMinutes          float64                `json:"timeout_minutes,omitempty"`
 	Outputs                 map[string]string      `json:"outputs,omitempty"`
+	Container               *Container             `json:"container,omitempty"`
+	Services                []Service              `json:"services,omitempty"`
 	DefaultShell            string                 `json:"default_shell,omitempty"`
 	DefaultWorkingDirectory string                 `json:"default_working_directory,omitempty"`
 	Steps                   []Step                 `json:"steps"`
 	Span                    Span                   `json:"span"`
+}
+
+// Container is the statically owned subset of a GitHub Actions container.
+type Container struct {
+	Image string            `json:"image"`
+	Env   map[string]string `json:"env,omitempty"`
+	Ports []string          `json:"ports,omitempty"`
+	Span  Span              `json:"span"`
+}
+
+// Service is a named service container. Services are sorted by Name because
+// actionlint v1.7.12 exposes them as a map and does not retain source order.
+type Service struct {
+	Name      string    `json:"name"`
+	Container Container `json:"container"`
 }
 
 // ReusableWorkflowCall is a job-level invocation of another workflow.

--- a/internal/workflow/parse.go
+++ b/internal/workflow/parse.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -36,6 +37,9 @@ func Parse(path string, source []byte) (*Workflow, error) {
 	var document yaml.Node
 	if err := yaml.Unmarshal(source, &document); err != nil {
 		return nil, fmt.Errorf("%s: parse workflow YAML: %w", path, err)
+	}
+	if err := validateRawContainers(path, &document); err != nil {
+		return nil, err
 	}
 	concurrency, err := parseConcurrencySyntax(path, &document)
 	if err != nil {
@@ -126,6 +130,105 @@ func Parse(path string, source []byte) (*Workflow, error) {
 	return owned, nil
 }
 
+var containerImagePattern = regexp.MustCompile(`^[a-z0-9]+(?:[._-][a-z0-9]+)*(?:/[a-z0-9]+(?:[._-][a-z0-9]+)*)*(?::[A-Za-z0-9_][A-Za-z0-9_.-]{0,127})?(?:@sha256:[0-9a-f]{64})?$`)
+var containerEnvKeyPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+var containerPortPattern = regexp.MustCompile(`^(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(?::(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]))?(?:/(?:tcp|udp))?$`)
+
+// validateRawContainers deliberately walks only the owned container locations.
+// actionlint normalizes maps (including service IDs), so the raw tree is also
+// the authoritative source for diagnostics.
+func validateRawContainers(path string, document *yaml.Node) error {
+	root := document
+	if root.Kind == yaml.DocumentNode && len(root.Content) != 0 {
+		root = root.Content[0]
+	}
+	jobs := mappingValue(root, "jobs")
+	if jobs == nil || jobs.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(jobs.Content); i += 2 {
+		job := jobs.Content[i+1]
+		if container := mappingValue(job, "container"); container != nil {
+			if err := validateRawContainer(path, container); err != nil {
+				return err
+			}
+		}
+		services := mappingValue(job, "services")
+		if services == nil || services.Kind != yaml.MappingNode {
+			continue
+		}
+		if len(services.Content)/2 > 32 {
+			return rawError(path, services, "container services have more than 32 entries")
+		}
+		for j := 0; j+1 < len(services.Content); j += 2 {
+			name, container := services.Content[j], services.Content[j+1]
+			if name.Value != strings.ToLower(name.Value) || !serviceIDPattern.MatchString(name.Value) {
+				return rawError(path, name, fmt.Sprintf("invalid service ID %q; service IDs must be lowercase", name.Value))
+			}
+			if err := validateRawContainer(path, container); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func rawError(path string, node *yaml.Node, message string) error {
+	return fmt.Errorf("%s:%d:%d: %s", path, node.Line, node.Column, message)
+}
+
+func validateRawContainer(path string, node *yaml.Node) error {
+	image := node
+	if node.Kind == yaml.MappingNode {
+		image = mappingValue(node, "image")
+		for _, control := range []string{"credentials", "volumes", "options"} {
+			if key := mappingKey(node, control); key != nil {
+				return rawError(path, key, "container "+control+" are unsupported")
+			}
+		}
+	}
+	if image == nil || image.Kind != yaml.ScalarNode || len(image.Value) > 512 || !containerImagePattern.MatchString(image.Value) {
+		if image == nil {
+			image = node
+		}
+		return rawError(path, image, "invalid container image")
+	}
+	env := mappingValue(node, "env")
+	if env != nil && env.Kind == yaml.MappingNode {
+		if len(env.Content)/2 > 256 {
+			return rawError(path, env, "container environment has more than 256 entries")
+		}
+		total := 0
+		for i := 0; i+1 < len(env.Content); i += 2 {
+			key, value := env.Content[i], env.Content[i+1]
+			if len(key.Value) > 255 || !containerEnvKeyPattern.MatchString(key.Value) {
+				return rawError(path, key, "invalid container environment key")
+			}
+			if value.Kind != yaml.ScalarNode || len(value.Value) > 65536 {
+				return rawError(path, value, "invalid container environment value")
+			}
+			total += len(key.Value) + len(value.Value)
+		}
+		if total > 1048576 {
+			return rawError(path, env, "container environment exceeds 1048576 bytes")
+		}
+	}
+	ports := mappingValue(node, "ports")
+	if ports != nil && ports.Kind == yaml.SequenceNode {
+		if len(ports.Content) > 128 {
+			return rawError(path, ports, "container has more than 128 ports")
+		}
+		seen := map[string]bool{}
+		for _, port := range ports.Content {
+			if port.Kind != yaml.ScalarNode || !containerPortPattern.MatchString(port.Value) || seen[port.Value] {
+				return rawError(path, port, "invalid or repeated container port")
+			}
+			seen[port.Value] = true
+		}
+	}
+	return nil
+}
+
 func adaptJob(path string, in *actionlint.Job, scalars map[Position]any, concurrency map[Position]stepConcurrency) (Job, error) {
 	out := Job{ID: in.ID.Value, Span: pointSpan(in.Pos)}
 	if in.WorkflowCall != nil {
@@ -149,8 +252,33 @@ func adaptJob(path string, in *actionlint.Job, scalars map[Position]any, concurr
 	if in.If != nil {
 		out.If = in.If.Value
 	}
-	if in.Container != nil || in.Services != nil {
-		return Job{}, locatedError(path, in.Pos, in.ID.Value, "job and service containers are unsupported in the Phase 0 runtime")
+	if in.Container != nil {
+		container, err := adaptContainer(path, in.ID.Value, in.Container)
+		if err != nil {
+			return Job{}, err
+		}
+		out.Container = &container
+	}
+	if in.Services != nil {
+		if in.Services.Expression != nil {
+			return Job{}, locatedError(path, in.Services.Expression.Pos, in.ID.Value, "expression-valued services are unsupported")
+		}
+		names := make([]string, 0, len(in.Services.Value))
+		for name := range in.Services.Value {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			service := in.Services.Value[name]
+			if service == nil || service.Name == nil || service.Container == nil || !serviceIDPattern.MatchString(service.Name.Value) {
+				return Job{}, locatedError(path, in.Services.Pos, in.ID.Value, fmt.Sprintf("invalid service ID %q", name))
+			}
+			container, err := adaptContainer(path, in.ID.Value, service.Container)
+			if err != nil {
+				return Job{}, err
+			}
+			out.Services = append(out.Services, Service{Name: service.Name.Value, Container: container})
+		}
 	}
 	if in.ContinueOnError != nil {
 		return Job{}, locatedError(path, in.Pos, in.ID.Value, "job continue-on-error is unsupported")
@@ -347,6 +475,44 @@ func adaptEnv(in *actionlint.Env) map[string]string {
 		out[variable.Name.Value] = variable.Value.Value
 	}
 	return out
+}
+
+var serviceIDPattern = regexp.MustCompile(`^[a-z_][a-z0-9_-]*$`)
+
+func adaptContainer(path, jobID string, in *actionlint.Container) (Container, error) {
+	if in.Image == nil || strings.TrimSpace(in.Image.Value) == "" {
+		return Container{}, locatedError(path, in.Pos, jobID, "container image must be a non-empty literal")
+	}
+	if in.Image.ContainsExpression() {
+		return Container{}, locatedError(path, in.Image.Pos, jobID, "expression-valued container image is unsupported")
+	}
+	if in.Credentials != nil {
+		return Container{}, locatedError(path, in.Credentials.Pos, jobID, "container credentials are unsupported")
+	}
+	if len(in.Volumes) != 0 {
+		return Container{}, locatedError(path, in.Volumes[0].Pos, jobID, "container volumes are unsupported")
+	}
+	if in.Options != nil {
+		return Container{}, locatedError(path, in.Options.Pos, jobID, "container options are unsupported")
+	}
+	if in.Env != nil && in.Env.Expression != nil {
+		return Container{}, locatedError(path, in.Env.Expression.Pos, jobID, "expression-valued container env is unsupported")
+	}
+	if in.Env != nil {
+		for _, variable := range in.Env.Vars {
+			if variable.Value.ContainsExpression() {
+				return Container{}, locatedError(path, variable.Value.Pos, jobID, "expression-valued container env is unsupported")
+			}
+		}
+	}
+	out := Container{Image: in.Image.Value, Env: adaptEnv(in.Env), Span: pointSpan(in.Pos)}
+	for _, port := range in.Ports {
+		if port.ContainsExpression() {
+			return Container{}, locatedError(path, port.Pos, jobID, "expression-valued container port is unsupported")
+		}
+		out.Ports = append(out.Ports, port.Value)
+	}
+	return out, nil
 }
 
 func mergeEnv(base, override map[string]string) map[string]string {

--- a/internal/workflow/parse_test.go
+++ b/internal/workflow/parse_test.go
@@ -56,6 +56,66 @@ func TestParsePreservesEnvironmentVariableCase(t *testing.T) {
 	}
 }
 
+func TestParseOwnsLiteralContainersAndSortsServices(t *testing.T) {
+	source := []byte("on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    container:\n      image: node:24\n      env: {NODE_ENV: test}\n      ports: [8080]\n    services:\n      zed: {image: redis:7}\n      alpha: {image: postgres:16, ports: ['5432:5432']}\n    steps:\n      - run: true\n")
+	parsed, err := Parse("containers.yml", source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	job := parsed.Jobs[0]
+	if job.Container == nil || job.Container.Image != "node:24" || job.Container.Env["NODE_ENV"] != "test" || len(job.Services) != 2 || job.Services[0].Name != "alpha" || job.Services[1].Name != "zed" {
+		t.Fatalf("owned containers = %#v / %#v", job.Container, job.Services)
+	}
+}
+
+func TestParseRejectsUnsupportedContainerControls(t *testing.T) {
+	for name, body := range map[string]string{
+		"credentials": "credentials: {username: me, password: secret}",
+		"volumes":     "volumes: ['/tmp:/tmp']",
+		"options":     "options: --privileged",
+	} {
+		t.Run(name, func(t *testing.T) {
+			source := []byte("on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    container:\n      image: node:24\n      " + body + "\n    steps:\n      - run: true\n")
+			if _, err := Parse("containers.yml", source); err == nil || !strings.Contains(err.Error(), name) {
+				t.Fatalf("Parse() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestContainerValidationIsScopedAndSourceLocated(t *testing.T) {
+	unrelated := []byte("on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: owner/action@v1\n        with: {image: node:24, options: --privileged}\n")
+	if _, err := Parse("scoped.yml", unrelated); err != nil {
+		t.Fatalf("unrelated action inputs were treated as a container: %v", err)
+	}
+	for _, test := range []struct {
+		name, field, want string
+	}{
+		{"image", "image: INVALID IMAGE", "bad.yml:6:14:"},
+		{"env-key", "image: node:24\n      env: {'bad-key': ok}", "bad.yml:7:13:"},
+		{"env-value", "image: node:24\n      env: {OK: '" + strings.Repeat("x", 65537) + "'}", "bad.yml:7:17:"},
+		{"port", "image: node:24\n      ports: ['65536/tcp']", "bad.yml:7:15:"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			source := []byte("on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    container:\n      " + test.field + "\n    steps: [{run: true}]\n")
+			if _, err := Parse("bad.yml", source); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Parse() error = %v, want location %s", err, test.want)
+			}
+		})
+	}
+}
+
+func TestParseContainerShortForms(t *testing.T) {
+	source := []byte("on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    container: node:24\n    services:\n      redis: redis:7\n      postgres: {image: postgres:16, ports: ['5432:5432/udp']}\n    steps: [{run: true}]\n")
+	parsed, err := Parse("short.yml", source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Jobs[0].Container.Image != "node:24" || len(parsed.Jobs[0].Services) != 2 {
+		t.Fatalf("containers = %#v, %#v", parsed.Jobs[0].Container, parsed.Jobs[0].Services)
+	}
+}
+
 func TestParseRetainsSequentialRuntimeControls(t *testing.T) {
 	source := []byte("name: runtime\non: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    if: always()\n    timeout-minutes: 5\n    steps:\n      - run: echo ok\n        if: success()\n        timeout-minutes: 2\n        continue-on-error: true\n")
 	parsed, err := Parse("workflow.yml", source)

--- a/mise.toml
+++ b/mise.toml
@@ -29,7 +29,7 @@ run = "golangci-lint run"
 
 [tasks."lint:shell"]
 description = "Lint shell scripts"
-run = "shellcheck -x .buildkite/phase-0-transport-probe/probe.sh scripts/phase-0-shell-oracle-checkout scripts/phase-0-sign-json scripts/phase-0-verify-json scripts/phase-5-hosted-docker-probe scripts/smoke-local testdata/actions/docker/entrypoint.sh"
+run = "shellcheck -x .buildkite/phase-0-transport-probe/probe.sh scripts/phase-0-shell-oracle-checkout scripts/phase-0-sign-json scripts/phase-0-verify-json scripts/phase-5-hosted-docker-probe scripts/phase-5-hosted-runtime-probe scripts/smoke-local testdata/actions/docker/entrypoint.sh testdata/phase5/runtime/.github/actions/docker/entrypoint.sh"
 
 [tasks.vet]
 description = "Run go vet"

--- a/schemas/job-plan-v4.schema.json
+++ b/schemas/job-plan-v4.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://buildkite.com/schemas/buildkite-gha/job-plan-v4.schema.json",
+  "title": "buildkite-gha job plan v4",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "compiler", "workflow", "event", "target", "required_capabilities", "steps"],
+  "properties": {
+    "schema": {"const": "https://buildkite.com/schemas/buildkite-gha/job-plan-v4.schema.json"},
+    "compiler": {"type": "object", "additionalProperties": false, "required": ["version", "distribution_digest"], "properties": {"version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$"}, "distribution_digest": {"$ref": "#/$defs/digest"}}},
+    "workflow": {"type": "object", "additionalProperties": false, "required": ["path", "digest", "logical_job_id"], "properties": {"path": {"type": "string", "minLength": 1, "maxLength": 1024}, "digest": {"$ref": "#/$defs/digest"}, "logical_job_id": {"type": "string", "minLength": 1, "maxLength": 255}}},
+    "event": {"type": "object", "additionalProperties": false, "required": ["provider", "name", "payload_digest"], "properties": {"provider": {"enum": ["github", "cursor-origin"]}, "name": {"type": "string", "pattern": "^[A-Za-z0-9_.-]+$", "maxLength": 128}, "payload_digest": {"$ref": "#/$defs/digest"}, "repository": {"type": "string", "maxLength": 512}, "ref": {"type": "string", "maxLength": 1024}, "sha": {"type": "string", "maxLength": 128}, "actor": {"type": "string", "maxLength": 256}}},
+    "target": {"type": "object", "additionalProperties": false, "required": ["step_key", "queue"], "properties": {"step_key": {"$ref": "#/$defs/buildkiteName"}, "queue": {"$ref": "#/$defs/buildkiteName"}}},
+    "required_capabilities": {"type": "array", "uniqueItems": true, "items": {"$ref": "#/$defs/capability"}, "maxItems": 16},
+    "required_secrets": {"type": "array", "items": {"type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"}, "uniqueItems": true, "maxItems": 128},
+    "matrix": {"type": "object"},
+    "vars": {"$ref": "#/$defs/stringMap"},
+    "dependencies": {"type": "array", "items": {"$ref": "#/$defs/buildkiteName"}, "uniqueItems": true},
+    "need_sources": {"type": "object", "additionalProperties": {"type": "array", "minItems": 1, "maxItems": 256, "uniqueItems": true, "items": {"$ref": "#/$defs/needSource"}}},
+    "env": {"$ref": "#/$defs/stringMap"},
+    "condition": {"type": "string", "maxLength": 65536},
+    "timeout_minutes": {"type": "number", "exclusiveMinimum": 0, "maximum": 360},
+    "default_shell": {"type": "string"},
+    "default_working_directory": {"type": "string"},
+    "outputs": {"$ref": "#/$defs/stringMap"},
+    "steps": {"type": "array", "minItems": 1, "maxItems": 1000, "items": {"$ref": "#/$defs/step"}},
+    "actions": {"type": "array", "maxItems": 1024, "items": {"$ref": "#/$defs/actionLock"}},
+    "container": {"$ref": "#/$defs/container"},
+    "services": {"type": "object", "maxProperties": 32, "propertyNames": {"pattern": "^[a-z_][a-z0-9_-]{0,254}$"}, "additionalProperties": {"$ref": "#/$defs/container"}}
+  },
+  "$defs": {
+    "digest": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "buildkiteName": {"type": "string", "pattern": "^[A-Za-z0-9_-]+$", "minLength": 1, "maxLength": 255},
+    "capability": {"enum": ["network", "docker", "privileged-container", "secrets", "provider-token-read", "provider-token-write"]},
+    "stringMap": {"type": "object", "additionalProperties": {"type": "string"}},
+    "needSource": {"type": "object", "additionalProperties": false, "required": ["step_key", "plan_digest"], "properties": {"step_key": {"$ref": "#/$defs/buildkiteName"}, "plan_digest": {"$ref": "#/$defs/digest"}}},
+    "position": {"type": "object", "additionalProperties": false, "required": ["line", "column"], "properties": {"line": {"type": "integer", "minimum": 0}, "column": {"type": "integer", "minimum": 0}}},
+    "span": {"type": "object", "additionalProperties": false, "required": ["start", "end"], "properties": {"start": {"$ref": "#/$defs/position"}, "end": {"$ref": "#/$defs/position"}}},
+    "selector": {"type": "object", "additionalProperties": false, "required": ["lock"], "properties": {"lock": {"type": "string", "pattern": "^a-[0-9a-f]{16}$"}}},
+    "path": {"type": "string", "minLength": 1, "maxLength": 1024, "pattern": "^[^/\\\\\\x00-\\x1f\\x7f]{1,255}(?:/[^/\\\\\\x00-\\x1f\\x7f]{1,255})*$", "not": {"pattern": "(^|/)\\.\\.?(/|$)"}},
+    "repository": {"type": "string", "maxLength": 140, "pattern": "^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?/[a-z0-9](?:[a-z0-9_.-]{0,98}[a-z0-9])?$"},
+    "actionLock": {
+      "type": "object", "additionalProperties": false,
+      "required": ["id", "source", "source_digest"],
+      "properties": {
+        "id": {"type": "string", "pattern": "^a-[0-9a-f]{16}$"}, "source": {"enum": ["workspace", "github"]},
+        "repository": {"$ref": "#/$defs/repository"}, "requested_ref": {"type": "string", "minLength": 1, "maxLength": 1024, "pattern": "^[^\\x00-\\x1f\\x7f]+$"},
+        "commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"}, "path": {"$ref": "#/$defs/path"}, "source_digest": {"$ref": "#/$defs/digest"},
+        "children": {"type": "object", "maxProperties": 1024, "propertyNames": {"minLength": 1, "maxLength": 2048, "pattern": "^[^\\x00-\\x1f\\x7f]+$"}, "additionalProperties": {"$ref": "#/$defs/selector"}}
+      },
+      "allOf": [
+        {"if": {"properties": {"source": {"const": "workspace"}}, "required": ["source"]}, "then": {"not": {"anyOf": [{"required": ["repository"]}, {"required": ["requested_ref"]}, {"required": ["commit"]}]}}},
+        {"if": {"properties": {"source": {"const": "github"}}, "required": ["source"]}, "then": {"required": ["repository", "requested_ref", "commit"]}}
+      ]
+    },
+    "container": {"type": "object", "additionalProperties": false, "required": ["image"], "properties": {"image": {"$ref": "#/$defs/image"}, "env": {"$ref": "#/$defs/containerEnv"}, "ports": {"type": "array", "maxItems": 128, "uniqueItems": true, "items": {"type": "string", "pattern": "^(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(?::(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]))?(?:/(?:tcp|udp))?$"}}}},
+    "containerEnv": {"type": "object", "maxProperties": 256, "propertyNames": {"pattern": "^[A-Za-z_][A-Za-z0-9_]{0,254}$"}, "additionalProperties": {"type": "string", "maxLength": 65536}},
+    "image": {"type": "string", "minLength": 1, "maxLength": 512, "pattern": "^[a-z0-9]+(?:[._-][a-z0-9]+)*(?:/[a-z0-9]+(?:[._-][a-z0-9]+)*)*(?::[A-Za-z0-9_][A-Za-z0-9_.-]{0,127})?(?:@sha256:[0-9a-f]{64})?$"},
+    "step": {
+      "type": "object", "additionalProperties": false, "required": ["id", "kind"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1, "maxLength": 255}, "name": {"type": "string"}, "kind": {"enum": ["run", "uses", "wait", "wait-all", "cancel"]}, "background": {"type": "boolean"},
+        "targets": {"type": "array", "minItems": 1, "maxItems": 256, "uniqueItems": true, "items": {"$ref": "#/$defs/buildkiteName"}},
+        "command": {"type": "string", "maxLength": 1048576}, "uses": {"type": "string", "maxLength": 1024}, "action": {"$ref": "#/$defs/selector"}, "shell": {"type": "string"}, "working_directory": {"type": "string"},
+        "env": {"$ref": "#/$defs/stringMap"}, "with": {"$ref": "#/$defs/stringMap"}, "condition": {"type": "string", "maxLength": 65536}, "continue_on_error": {"type": "boolean"}, "timeout_minutes": {"type": "number", "exclusiveMinimum": 0, "maximum": 360}, "source": {"$ref": "#/$defs/span"}
+      },
+      "allOf": [
+        {"if": {"properties": {"kind": {"const": "run"}}, "required": ["kind"]}, "then": {"required": ["command"], "not": {"anyOf": [{"required": ["uses"]}, {"required": ["targets"]}, {"required": ["action"]}]}}},
+        {"if": {"properties": {"kind": {"const": "uses"}}, "required": ["kind"]}, "then": {"required": ["uses", "action"]}},
+        {"if": {"properties": {"kind": {"const": "wait"}}, "required": ["kind"]}, "then": {"required": ["targets"], "not": {"required": ["action"]}}},
+        {"if": {"properties": {"kind": {"const": "wait-all"}}, "required": ["kind"]}, "then": {"not": {"anyOf": [{"required": ["targets"]}, {"required": ["action"]}]}}},
+        {"if": {"properties": {"kind": {"const": "cancel"}}, "required": ["kind"]}, "then": {"required": ["targets"], "properties": {"targets": {"maxItems": 1}}, "not": {"required": ["action"]}}},
+        {"if": {"properties": {"kind": {"enum": ["wait", "wait-all", "cancel"]}}, "required": ["kind"]}, "then": {"not": {"anyOf": [{"required": ["background"]}, {"required": ["command"]}, {"required": ["uses"]}, {"required": ["shell"]}, {"required": ["working_directory"]}, {"required": ["env"]}, {"required": ["with"]}, {"required": ["condition"]}, {"required": ["continue_on_error"]}, {"required": ["timeout_minutes"]}, {"required": ["action"]}]}}}
+      ]
+    }
+  }
+}

--- a/scripts/phase-5-hosted-runtime-probe
+++ b/scripts/phase-5-hosted-runtime-probe
@@ -7,7 +7,8 @@ test -z "$(git status --porcelain --untracked-files=all)"
 
 command -v docker >/dev/null
 timeout 20s docker version >/dev/null
-test "$(timeout 10s docker buildx inspect default --format '{{.Driver}}')" = docker
+driver="$(timeout 10s docker buildx inspect default 2>/dev/null | awk '/^Driver:/ {print $2; exit}')"
+test "$driver" = docker
 
 work="$(mktemp -d "${TMPDIR:-/tmp}/buildkite-gha-phase5-runtime.XXXXXXXX")"
 trap 'rm -rf -- "$work"' EXIT

--- a/scripts/phase-5-hosted-runtime-probe
+++ b/scripts/phase-5-hosted-runtime-probe
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+commit=${PHASE5_COMMIT:-${SMOKE_COMMIT:-}}
+scripts/phase-0-shell-oracle-checkout "$commit"
+test -z "$(git status --porcelain --untracked-files=all)"
+
+command -v docker >/dev/null
+timeout 20s docker version >/dev/null
+test "$(timeout 10s docker buildx inspect default --format '{{.Driver}}')" = docker
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/buildkite-gha-phase5-runtime.XXXXXXXX")"
+trap 'rm -rf -- "$work"' EXIT
+
+runtime="$work/buildkite-gha"
+CGO_ENABLED=0 mise exec -- go build -trimpath -buildvcs=false -o "$runtime" ./cmd/buildkite-gha
+node24="$(mise where node@24)/bin/node"
+
+readonly tests='^(TestLiveJobContainerPersistsAcrossShellSteps|TestLiveJobContainerDefaultNonRootUser|TestLiveJobContainerCancellationKillsProcessTree|TestLiveJobContainerJavaScriptCompositeAndPost|TestLivePhase5CompiledContainerRuntime|TestLivePhase5ManifestContainerFixtures|TestLivePhase5UnhealthyServiceDiagnostics)$'
+output="$work/live-tests.log"
+set +e
+BUILDKITE_GHA_LIVE_REQUIRED=1 \
+BUILDKITE_GHA_TEST_RUNTIME="$runtime" \
+BUILDKITE_GHA_TEST_NODE24="$node24" \
+  mise exec -- go test ./internal/runtime -count=1 -timeout=20m -run "$tests" -v 2>&1 | tee "$output"
+status=${PIPESTATUS[0]}
+set -e
+(( status == 0 ))
+
+for test in \
+  TestLiveJobContainerPersistsAcrossShellSteps \
+  TestLiveJobContainerDefaultNonRootUser \
+  TestLiveJobContainerCancellationKillsProcessTree \
+  TestLiveJobContainerJavaScriptCompositeAndPost \
+  TestLivePhase5CompiledContainerRuntime \
+  TestLivePhase5ManifestContainerFixtures \
+  TestLivePhase5UnhealthyServiceDiagnostics
+do
+  grep -F -- "--- PASS: $test " "$output" >/dev/null
+done
+if grep -F -- '--- SKIP:' "$output" >/dev/null; then
+  echo 'Phase 5 live runtime proof skipped a required test' >&2
+  exit 1
+fi
+
+echo 'PHASE5_RUNTIME_OBSERVATION={"container":"persistent","services":"container-and-host","actions":"javascript-composite-docker","cleanup":"verified"}'

--- a/scripts/smoke-local
+++ b/scripts/smoke-local
@@ -22,7 +22,7 @@ cd "$root"
 jq -e '
   keys == ["fixtures", "schema"] and
   .schema == "buildkite-gha/smoke-manifest/v1" and
-  (.fixtures | type == "array" and length == 9) and
+  (.fixtures | type == "array" and length == 10) and
   all(.fixtures[];
     keys == ["action_preflight", "event", "evidence", "expectation", "id", "note", "workflow"] and
     (.id | test("^[a-z0-9]+(?:-[a-z0-9]+)*$")) and

--- a/scripts/smoke-local
+++ b/scripts/smoke-local
@@ -36,7 +36,7 @@ jq -e '
   ([.fixtures[] | [.workflow, .event] | join("\u0000")] | length == (unique | length))
 ' "$manifest" >/dev/null
 
-mise exec -- go build -o "$work/buildkite-gha" ./cmd/buildkite-gha
+CGO_ENABLED=0 mise exec -- go build -o "$work/buildkite-gha" ./cmd/buildkite-gha
 if [[ -n "$profile" ]]; then
   node20="$(mise where node@20)/bin/node"
   node24="$(mise where node@24)/bin/node"

--- a/testdata/phase5/runtime/.github/actions/composite/action.yml
+++ b/testdata/phase5/runtime/.github/actions/composite/action.yml
@@ -1,0 +1,24 @@
+name: Phase 5 composite action
+description: Exercises nested expression and environment propagation in a job container.
+
+inputs:
+  message:
+    description: Value to transform.
+    required: true
+
+outputs:
+  result:
+    description: Transformed value.
+    value: ${{ steps.transform.outputs.result }}
+
+runs:
+  using: composite
+  steps:
+    - name: Transform value
+      id: transform
+      shell: sh
+      env:
+        MESSAGE: ${{ inputs.message }}
+      run: |
+        echo "result=$MESSAGE-composite" >> "$GITHUB_OUTPUT"
+        echo 'PHASE5_COMPOSITE_ENV=seen' >> "$GITHUB_ENV"

--- a/testdata/phase5/runtime/.github/actions/docker/Dockerfile
+++ b/testdata/phase5/runtime/.github/actions/docker/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/bin/sh", "/entrypoint.sh"]

--- a/testdata/phase5/runtime/.github/actions/docker/action.yml
+++ b/testdata/phase5/runtime/.github/actions/docker/action.yml
@@ -1,0 +1,21 @@
+name: Phase 5 Dockerfile action
+description: Exercises workspace file commands and service access from a sibling container.
+
+inputs:
+  expected_file:
+    description: Workspace-relative file that must be visible in the container.
+    required: true
+  service_host:
+    description: Job-network service alias.
+    required: true
+  service_port:
+    description: Job-network service port.
+    required: true
+
+outputs:
+  container:
+    description: Confirms that the Docker action ran.
+
+runs:
+  using: docker
+  image: Dockerfile

--- a/testdata/phase5/runtime/.github/actions/docker/entrypoint.sh
+++ b/testdata/phase5/runtime/.github/actions/docker/entrypoint.sh
@@ -4,6 +4,8 @@ set -eu
 test "$GITHUB_WORKSPACE" = /github/workspace
 test -f "$GITHUB_WORKSPACE/$INPUT_EXPECTED_FILE"
 
+# The Redis protocol frame contains a literal "$4" bulk-string length.
+# shellcheck disable=SC2016
 reply="$(printf '*1\r\n$4\r\nPING\r\n' | nc -w 3 "$INPUT_SERVICE_HOST" "$INPUT_SERVICE_PORT")"
 case "$reply" in
   +PONG*) ;;

--- a/testdata/phase5/runtime/.github/actions/docker/entrypoint.sh
+++ b/testdata/phase5/runtime/.github/actions/docker/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+
+test "$GITHUB_WORKSPACE" = /github/workspace
+test -f "$GITHUB_WORKSPACE/$INPUT_EXPECTED_FILE"
+
+reply="$(printf '*1\r\n$4\r\nPING\r\n' | nc -w 3 "$INPUT_SERVICE_HOST" "$INPUT_SERVICE_PORT")"
+case "$reply" in
+  +PONG*) ;;
+  *) exit 1 ;;
+esac
+
+printf '%s\n' 'container=ran' >> "$GITHUB_OUTPUT"
+printf '%s\n' 'PHASE5_DOCKER_ENV=seen' >> "$GITHUB_ENV"
+printf '%s\n' 'phase5 Docker action summary' >> "$GITHUB_STEP_SUMMARY"
+printf '%s\n' '::add-mask::phase5-docker-secret'
+printf '%s\n' 'masked Docker probe: phase5-docker-secret'

--- a/testdata/phase5/runtime/.github/actions/javascript/action.yml
+++ b/testdata/phase5/runtime/.github/actions/javascript/action.yml
@@ -1,0 +1,17 @@
+name: Phase 5 JavaScript action
+description: Exercises Node lifecycle and file commands inside a persistent job container.
+
+inputs:
+  message:
+    description: Value to transform.
+    required: true
+
+outputs:
+  result:
+    description: Transformed value.
+
+runs:
+  using: node24
+  main: main.js
+  post: post.js
+  post-if: always()

--- a/testdata/phase5/runtime/.github/actions/javascript/main.js
+++ b/testdata/phase5/runtime/.github/actions/javascript/main.js
@@ -1,0 +1,13 @@
+const fs = require("node:fs");
+
+const message = process.env.INPUT_MESSAGE;
+if (!message) {
+  throw new Error("message input is required");
+}
+
+fs.appendFileSync(process.env.GITHUB_OUTPUT, `result=${message}-javascript\n`);
+fs.appendFileSync(process.env.GITHUB_ENV, "PHASE5_JAVASCRIPT_ENV=seen\n");
+fs.appendFileSync(process.env.GITHUB_STATE, "phase=main\n");
+fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, "phase5 JavaScript main\n");
+console.log("::add-mask::phase5-javascript-secret");
+console.log("masked JavaScript probe: phase5-javascript-secret");

--- a/testdata/phase5/runtime/.github/actions/javascript/post.js
+++ b/testdata/phase5/runtime/.github/actions/javascript/post.js
@@ -1,0 +1,8 @@
+const fs = require("node:fs");
+
+if (process.env.STATE_phase !== "main") {
+  throw new Error(`unexpected phase state: ${process.env.STATE_phase || "missing"}`);
+}
+
+fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/phase5-post-ran`, "yes");
+fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, "phase5 JavaScript post\n");

--- a/testdata/phase5/runtime/.github/workflows/runtime.yml
+++ b/testdata/phase5/runtime/.github/workflows/runtime.yml
@@ -1,0 +1,144 @@
+name: Phase 5 container runtime
+
+on:
+  push:
+
+jobs:
+  container-runtime:
+    runs-on: ubuntu-latest
+    container:
+      image: node:24-bookworm-slim
+      env:
+        PHASE5_CONTAINER_ENV: literal
+    services:
+      redis:
+        image: redis@sha256:c9d92d840fd011c908f040592857c724ae6d877f2aba5c40ad963276507386b2
+        ports:
+          - 6379
+    outputs:
+      observation: ${{ steps.verify.outputs.observation }}
+    steps:
+      - name: Establish persistent container state
+        id: shell
+        shell: sh
+        run: |
+          test "$GITHUB_WORKSPACE" = /__w/repo/repo
+          test "$RUNNER_TEMP" = /__w/_temp
+          test "$PHASE5_CONTAINER_ENV" = literal
+          printf '%s\n' persisted > phase5-persisted
+          echo 'PHASE5_SHELL_ENV=seen' >> "$GITHUB_ENV"
+          echo 'value=shell' >> "$GITHUB_OUTPUT"
+
+      - name: Reach service by job-network alias
+        shell: sh
+        run: |
+          test -f phase5-persisted
+          test "$PHASE5_SHELL_ENV" = seen
+          node <<'NODE'
+          const net = require('node:net');
+          let attempts = 0;
+          function connect() {
+            const socket = net.createConnection(6379, 'redis');
+            socket.setTimeout(1000);
+            socket.once('connect', () => socket.write('*1\r\n$4\r\nPING\r\n'));
+            socket.once('data', (data) => {
+              socket.destroy();
+              if (data.toString().includes('+PONG')) process.exit(0);
+              retry();
+            });
+            socket.once('timeout', () => { socket.destroy(); retry(); });
+            socket.once('error', retry);
+          }
+          function retry() {
+            if (++attempts >= 30) process.exit(1);
+            setTimeout(connect, 200);
+          }
+          connect();
+          NODE
+
+      - name: Run JavaScript lifecycle
+        id: javascript
+        uses: ./.github/actions/javascript
+        with:
+          message: phase5
+
+      - name: Run composite action
+        id: composite
+        uses: ./.github/actions/composite
+        with:
+          message: ${{ steps.javascript.outputs.result }}
+
+      - name: Run sibling Dockerfile action
+        id: docker
+        uses: ./.github/actions/docker
+        with:
+          expected_file: phase5-persisted
+          service_host: redis
+          service_port: 6379
+
+      - name: Verify container observations
+        id: verify
+        shell: sh
+        env:
+          JAVASCRIPT_RESULT: ${{ steps.javascript.outputs.result }}
+          COMPOSITE_RESULT: ${{ steps.composite.outputs.result }}
+          DOCKER_RESULT: ${{ steps.docker.outputs.container }}
+        run: |
+          test "$JAVASCRIPT_RESULT" = phase5-javascript
+          test "$COMPOSITE_RESULT" = phase5-javascript-composite
+          test "$DOCKER_RESULT" = ran
+          test "$PHASE5_JAVASCRIPT_ENV" = seen
+          test "$PHASE5_COMPOSITE_ENV" = seen
+          test "$PHASE5_DOCKER_ENV" = seen
+          echo 'observation=container-runtime' >> "$GITHUB_OUTPUT"
+
+  host-runtime:
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis@sha256:c9d92d840fd011c908f040592857c724ae6d877f2aba5c40ad963276507386b2
+        ports:
+          - 6379
+    outputs:
+      observation: ${{ steps.verify.outputs.observation }}
+    steps:
+      - name: Reach service through loopback publication
+        shell: bash
+        env:
+          REDIS_PORT: ${{ job.services.redis.ports[6379] }}
+        run: |
+          test -n "$REDIS_PORT"
+          connected=0
+          for _ in {1..30}; do
+            reply=''
+            if exec 3<>"/dev/tcp/127.0.0.1/$REDIS_PORT"; then
+              printf '*1\r\n$4\r\nPING\r\n' >&3
+              IFS= read -r -t 1 reply <&3 || true
+              exec 3<&- 3>&-
+              if [[ "$reply" == +PONG* ]]; then
+                connected=1
+                break
+              fi
+            fi
+            sleep .2
+          done
+          test "$connected" = 1
+
+      - name: Reach service from sibling Dockerfile action
+        id: docker
+        uses: ./.github/actions/docker
+        with:
+          expected_file: .github/workflows/runtime.yml
+          service_host: redis
+          service_port: 6379
+
+      - name: Verify host observations
+        id: verify
+        shell: bash
+        env:
+          DOCKER_RESULT: ${{ steps.docker.outputs.container }}
+        run: |
+          test "$GITHUB_WORKSPACE" != /__w/repo/repo
+          test "$DOCKER_RESULT" = ran
+          test "$PHASE5_DOCKER_ENV" = seen
+          echo 'observation=host-runtime' >> "$GITHUB_OUTPUT"

--- a/testdata/smoke/README.md
+++ b/testdata/smoke/README.md
@@ -45,7 +45,10 @@ upload. Admission does not execute action code or prove that a generic action
 is independent of GitHub-only artifact, cache, token, or OIDC services.
 Known official cache and artifact actions are rejected until their Phase 6
 adapters exist; the profile leaves unknown generic service dependencies as an
-explicit warning rather than guessing from arbitrary action source.
+explicit warning rather than guessing from arbitrary action source. Runtime-pass
+job and service container fixtures are deliberately not marked for this profile:
+their execution is proven separately, while production hosted-tokenless
+admission continues to reject their container provenance.
 
 `events/push.json` is deterministic and its repository SHA is intentionally
 synthetic. End-to-end runs involving checkout must bind the event to the real

--- a/testdata/smoke/manifest.json
+++ b/testdata/smoke/manifest.json
@@ -68,18 +68,18 @@
       "id": "unsupported-job-container",
       "workflow": "testdata/unsupported/.github/workflows/job-container.yml",
       "event": "testdata/smoke/events/push.json",
-      "expectation": "compile-unsupported",
-      "evidence": "Static validation rejects job containers at the owned compatibility boundary.",
-      "note": "This negative fixture prevents compile success from implying job-container support.",
+      "expectation": "compile-pass",
+      "evidence": "Compilation emits plan v4 for the owned job-container contract.",
+      "note": "This is a contract-only fixture and is not a runtime-pass smoke test.",
       "action_preflight": "none"
     },
     {
       "id": "unsupported-service-container",
       "workflow": "testdata/unsupported/.github/workflows/service-container.yml",
       "event": "testdata/smoke/events/push.json",
-      "expectation": "compile-unsupported",
-      "evidence": "Static validation rejects service containers at the owned compatibility boundary.",
-      "note": "This negative fixture prevents compile success from implying service-container support.",
+      "expectation": "compile-pass",
+      "evidence": "Compilation emits plan v4 for the owned service-container contract.",
+      "note": "This is a contract-only fixture and is not a runtime-pass smoke test.",
       "action_preflight": "none"
     }
   ]

--- a/testdata/smoke/manifest.json
+++ b/testdata/smoke/manifest.json
@@ -56,6 +56,15 @@
       "action_preflight": "hosted-tokenless"
     },
     {
+      "id": "phase5-container-runtime",
+      "workflow": "testdata/phase5/runtime/.github/workflows/runtime.yml",
+      "event": "testdata/smoke/events/push.json",
+      "expectation": "runtime-pass",
+      "evidence": "The complete compiler-to-Runner container fixture passed in exact-commit Buildkite build 136.",
+      "note": "Hosted-tokenless admission still rejects its job- and service-container provenance.",
+      "action_preflight": "none"
+    },
+    {
       "id": "unsupported-cache-service",
       "workflow": "testdata/unsupported/.github/workflows/cache.yml",
       "event": "testdata/smoke/events/push.json",
@@ -68,18 +77,18 @@
       "id": "unsupported-job-container",
       "workflow": "testdata/unsupported/.github/workflows/job-container.yml",
       "event": "testdata/smoke/events/push.json",
-      "expectation": "compile-pass",
-      "evidence": "Compilation emits plan v4 for the owned job-container contract.",
-      "note": "This is a contract-only fixture and is not a runtime-pass smoke test.",
+      "expectation": "runtime-pass",
+      "evidence": "The plan-v4 job-container fixture passed in exact-commit Buildkite build 136.",
+      "note": "Hosted-tokenless admission still rejects job-container provenance.",
       "action_preflight": "none"
     },
     {
       "id": "unsupported-service-container",
       "workflow": "testdata/unsupported/.github/workflows/service-container.yml",
       "event": "testdata/smoke/events/push.json",
-      "expectation": "compile-pass",
-      "evidence": "Compilation emits plan v4 for the owned service-container contract.",
-      "note": "This is a contract-only fixture and is not a runtime-pass smoke test.",
+      "expectation": "runtime-pass",
+      "evidence": "The plan-v4 service-container fixture passed in exact-commit Buildkite build 136.",
+      "note": "Hosted-tokenless admission still rejects service-container provenance.",
       "action_preflight": "none"
     }
   ]


### PR DESCRIPTION
## Summary

- add schema-v4 job and service container contracts with strict literal-only validation
- run shell, JavaScript, composite, Dockerfile actions, and services through one owned container backend
- preserve host-job execution while publishing service ports on loopback and connecting sibling Docker actions to the service network
- enforce exact resource ownership, bounded cancellation/cleanup, private Docker configuration, and masked diagnostics
- add complete compiler-to-Runner hosted conformance coverage and promote the Phase 5 smoke fixtures
- document the disposable Buildkite job VM as the isolation boundary and retain the narrow hosted-tokenless admission boundary

Production `hosted-tokenless` upload still admits only compiler-proven Dockerfile-action provenance. Job- and service-container provenance remains rejected.

## Validation

- `mise run --jobs 1 check`
- Phase 5 hosted runtime proof: https://buildkite.com/buildkite/buildkite-gha/builds/136
- final exact-commit consolidated hosted smoke: https://buildkite.com/buildkite/buildkite-gha/builds/140 (running)

## Review

- Oracle reviewed the plan contract, job containers, services, live proof, smoke promotion, and final documentation boundaries
- `amp review` was run at the major milestones; all findings were resolved
