### PR TITLE
Cache verified Node runtimes for action jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ queue policy, produces immutable job plans, and emits a Buildkite pipeline.
 
 ## Quick start
 
-For a public GitHub repository on a Linux x86-64 Buildkite importer agent with
-`mise` on `PATH`, add the
+For a public GitHub repository on a Linux x86-64 Buildkite importer agent, add
+the
 [GitHub Actions Buildkite plugin](https://github.com/buildkite-plugins/github-actions-buildkite-plugin)
 to `pipeline.yml`:
 
@@ -94,10 +94,10 @@ For workflows containing JavaScript actions, `mise` selects exactly Node
 node@<exact-version> -- node <entry>`, so repository mise configuration cannot
 change compatibility selection. `MISE_*` workflow environment overrides are
 not passed through this compatibility launcher; shell steps are unaffected.
-For action workflows, the importer requires mise 2026.5.12, validates its
-executable, and uploads a deterministic compressed copy as a content-addressed
-artifact. Generated jobs verify and use that copy, so the fixed hosted queue
-does not need mise preinstalled. Job
+For action workflows, the plugin installs and verifies mise 2026.5.12 when
+needed. The importer uploads a deterministic compressed copy as a
+content-addressed artifact. Generated jobs verify and use that copy, so neither
+the importer nor the fixed hosted queue needs mise preinstalled. Job
 containers resolve the exact host mise installation and bind-mount its Node
 executable; mise is not required in the image. Node executables are never
 release or Buildkite artifacts.

--- a/README.md
+++ b/README.md
@@ -89,18 +89,21 @@ closed.
 The path is intentionally unsigned: ordinary Buildkite dynamic uploads do not
 need plan signing merely to run public, tokenless code.
 
-For workflows containing JavaScript actions, `mise` selects exactly Node
-20.20.2 or 24.18.0. Host actions run as `mise --no-config exec
-node@<exact-version> -- node <entry>`, so repository mise configuration cannot
-change compatibility selection. `MISE_*` workflow environment overrides are
-not passed through this compatibility launcher; shell steps are unaffected.
+For workflows containing JavaScript actions, `mise --no-config` installs
+exactly Node 20.20.2 or 24.18.0 through its pinned core backend. The runtime
+digest-verifies and directly invokes that Node executable, so repository mise
+configuration and `MISE_*` workflow environment overrides cannot change
+compatibility selection. Shell-step environments are unaffected.
 For action workflows, the plugin installs and verifies mise 2026.5.12 when
 needed. The importer uploads a deterministic compressed copy as a
 content-addressed artifact. Generated jobs verify and use that copy, so neither
-the importer nor the fixed hosted queue needs mise preinstalled. Job
-containers resolve the exact host mise installation and bind-mount its Node
-executable; mise is not required in the image. Node executables are never
-release or Buildkite artifacts.
+the importer nor the fixed hosted queue needs mise preinstalled. Generated
+action jobs automatically attach a pipeline-scoped Buildkite cache volume for
+mise-managed Node installations. Cache misses remain correct, and cached Node
+executables are checked against the official Linux x86-64 release digest and
+reinstalled on mismatch before use. Job containers bind-mount that verified
+host Node executable; mise is not required in the image. Node executables are
+never release or Buildkite artifacts.
 
 `run-job` consumes a versioned job plan and executes Linux Bash and sh steps in
 a fresh checkout-free workspace. The runtime supports env and working-directory
@@ -177,7 +180,9 @@ optional installation-specific defence in depth.
 
 The plugin in [Quick start](#quick-start) is the recommended installation. For
 direct CLI use, install `mise`; the runtime asks it to install and cache exact
-Node 20.20.2 and 24.18.0 versions as needed. The official mise-installed Node
+Node 20.20.2 and 24.18.0 versions as needed. Direct `upload` invocation requires
+mise 2026.5.12 on the importer `PATH` for action workflows; `validate` and
+`compile` do not install Node or require mise. The official mise-installed Node
 binaries used by JavaScript actions require glibc 2.28 or newer; the static Go
 CLI does not. Download
 `buildkite-gha_Linux_x86_64.tar.gz` and `checksums.txt`

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -834,10 +834,12 @@ at barriers, and the cross-stream masking race.
 - managed Node distributions rather than assuming the host's `node` is
   compatible.
 
-The release archive contains only the static Go CLI and LICENSE. Agents require
-mise 2026.5.12 on the importer PATH. For action workflows, upload validates and
-deterministically archives that pinned importer mise executable, transports it
-as a content-addressed artifact, and re-verifies it in every generated job. Host
+The release archive contains only the static Go CLI and LICENSE. The installer
+plugin bootstraps mise 2026.5.12, verifies its pinned release archive and exact
+cached executable tree by SHA-256, and follows the shared Buildkite hosted-cache
+and agent-cache conventions. For action workflows, upload deterministically
+archives that pinned importer mise executable, transports it as a
+content-addressed artifact, and re-verifies it in every generated job. Host
 actions execute with configuration disabled using exactly `mise --no-config
 exec node@20.20.2 -- node <entry>` or Node 24.18.0, never a fuzzy major and
 never repository mise configuration. `MISE_*` workflow environment overrides
@@ -1022,20 +1024,21 @@ Publish checksummed releases. Add signatures, provenance attestations, and
 SBOMs in Phase 9. The initial supported distribution is Linux x86-64; Linux
 arm64 can follow once action/runtime compatibility is measured.
 
-Distributions provide the static bridge CLI and LICENSE. The importer requires
-the pinned mise version, and action workflows transport its verified executable
-as a content-addressed artifact so generated hosted jobs can resolve exact Node
-versions without preinstalled mise. Every generated job must execute the same
-bridge version that produced its plan unless the plan schema explicitly permits
-a compatible newer runtime.
+Distributions provide the static bridge CLI and LICENSE. The installer plugin
+provides the pinned, verified mise executable, and action workflows transport
+it as a content-addressed artifact so generated hosted jobs can resolve exact
+Node versions without preinstalled mise. Every generated job must execute the
+same bridge version that produced its plan unless the plan schema explicitly
+permits a compatible newer runtime.
 
 The v0.1 preview bootstrap is implemented as one reproducible Linux x86-64
 archive containing only the static CLI and LICENSE, plus the
 `github-actions#v0.1.0` installer plugin. The plugin downloads an exact public
 release, verifies its checksum and fixed archive layout, caches the verified
-distribution, verifies the importer mise version, and invokes the fixed
-hosted-tokenless upload path. Node 20.20.2 and 24.18.0 are installed by mise on
-demand; official mise-installed Node binaries require glibc 2.28 or newer.
+distribution, installs and digest-verifies the pinned mise executable, and
+invokes the fixed hosted-tokenless upload path. Node 20.20.2 and 24.18.0 are
+installed by mise on demand; official mise-installed Node binaries require
+glibc 2.28 or newer.
 The source repository must be public before the initial tag because plugin
 installation intentionally uses anonymous release downloads. Release
 signatures, provenance attestations, and SBOMs remain Phase 9 work and are not

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -839,16 +839,24 @@ plugin bootstraps mise 2026.5.12, verifies its pinned release archive and exact
 cached executable tree by SHA-256, and follows the shared Buildkite hosted-cache
 and agent-cache conventions. For action workflows, upload deterministically
 archives that pinned importer mise executable, transports it as a
-content-addressed artifact, and re-verifies it in every generated job. Host
-actions execute with configuration disabled using exactly `mise --no-config
-exec node@20.20.2 -- node <entry>` or Node 24.18.0, never a fuzzy major and
-never repository mise configuration. `MISE_*` workflow environment overrides
-are withheld from that launcher, while ordinary shell steps retain them. For
-job containers, the host resolves that exact mise installation and mounts the
+content-addressed artifact, and re-verifies it in every generated action job.
+The runtime installs exactly `core:node@20.20.2` or `core:node@24.18.0` with
+mise configuration disabled, digest-verifies the resulting Node executable,
+and invokes that exact path directly. It never uses a fuzzy major, a data-dir
+plugin, repository mise configuration, or an unverified tool-bin `PATH`.
+`MISE_*` workflow environment overrides therefore cannot redirect compatibility
+Node; ordinary shell steps retain them.
+Generated action jobs declare a dedicated, pipeline-scoped Buildkite hosted
+cache volume and use a runtime-owned `MISE_DATA_DIR`; the cache is a best-effort
+accelerator, not an authority. The runtime checks cached Node executable bytes
+against the official Linux x86-64 release digest, removes and reinstalls a
+mismatch through the transported mise executable, and fails closed if the
+replacement still differs. Shell-only jobs do not attach this cache. For job
+containers, the host resolves that verified Node installation and mounts the
 Node executable; mise is not required in the image. Node runtime bytes are not
 release or Buildkite artifacts. Official mise-installed Node binaries require
-glibc 2.28+ when JavaScript actions run; that is not a requirement of the
-static Go CLI.
+glibc 2.28+ when JavaScript actions run; that is not a requirement of the static
+Go CLI.
 
 #### Composite actions
 
@@ -1037,8 +1045,10 @@ archive containing only the static CLI and LICENSE, plus the
 release, verifies its checksum and fixed archive layout, caches the verified
 distribution, installs and digest-verifies the pinned mise executable, and
 invokes the fixed hosted-tokenless upload path. Node 20.20.2 and 24.18.0 are
-installed by mise on demand; official mise-installed Node binaries require
-glibc 2.28 or newer.
+installed by mise on demand into an automatically attached, integration-owned
+hosted cache volume. Cached Node executables are digest-verified before use, so
+cache sharing across builds is an optimization rather than a trust boundary.
+Official mise-installed Node binaries require glibc 2.28 or newer.
 The source repository must be public before the initial tag because plugin
 installation intentionally uses anonymous release downloads. Release
 signatures, provenance attestations, and SBOMs remain Phase 9 work and are not

--- a/internal/buildkite/pipeline.go
+++ b/internal/buildkite/pipeline.go
@@ -17,6 +17,7 @@ const toolDirectory = ".buildkite-gha/tools"
 
 var identifierPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,255}$`)
 var digestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+var toolVersionPattern = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+$`)
 var uuidPattern = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 
 // Pipeline is the validated input required to emit generated compatibility jobs.
@@ -24,6 +25,7 @@ type Pipeline struct {
 	CompilerStep       string
 	DistributionDigest string
 	MiseDigest         string
+	MiseVersion        string
 	Jobs               []Job
 }
 
@@ -45,6 +47,17 @@ func MisePath(digest string) (string, error) {
 	return toolDirectory + "/mise/" + strings.TrimPrefix(digest, "sha256:") + "/mise.gz", nil
 }
 
+// MiseDataDir returns the runtime-owned hosted cache path for one exact mise
+// version. The generated cache path triggers Buildkite's documented
+// /cache/bkcache volume mount; cache contents are an accelerator, never an
+// authority.
+func MiseDataDir(version string) (string, error) {
+	if !toolVersionPattern.MatchString(version) {
+		return "", fmt.Errorf("invalid mise version %q", version)
+	}
+	return "/cache/bkcache/buildkite-gha/mise/" + version, nil
+}
+
 // Job describes one expanded workflow job after queue policy has been applied.
 type Job struct {
 	Key              string
@@ -52,6 +65,7 @@ type Job struct {
 	Queue            string
 	PlanDigest       string
 	Dependencies     []string
+	UsesActions      bool
 	ConcurrencyGroup string
 	Concurrency      int
 }
@@ -81,11 +95,18 @@ func Emit(pipeline Pipeline) ([]byte, error) {
 		return nil, err
 	}
 	var misePath string
+	var miseDataDir string
 	if pipeline.MiseDigest != "" {
 		misePath, err = MisePath(pipeline.MiseDigest)
 		if err != nil {
 			return nil, err
 		}
+		miseDataDir, err = MiseDataDir(pipeline.MiseVersion)
+		if err != nil {
+			return nil, err
+		}
+	} else if pipeline.MiseVersion != "" {
+		return nil, fmt.Errorf("mise version requires a mise digest")
 	}
 	var out bytes.Buffer
 	out.WriteString("steps:\n")
@@ -96,6 +117,7 @@ func Emit(pipeline Pipeline) ([]byte, error) {
 		}
 		_, _ = fmt.Fprintf(&out, "  - label: %s\n", yamlScalar(job.Label))
 		_, _ = fmt.Fprintf(&out, "    key: %s\n", yamlScalar(job.Key))
+		usesMise := misePath != "" && job.UsesActions
 		commands := []string{
 			"set -euo pipefail",
 			`bootstrap_dir="$(mktemp -d "${TMPDIR:-/tmp}/buildkite-gha.XXXXXXXX")"`,
@@ -108,7 +130,7 @@ func Emit(pipeline Pipeline) ([]byte, error) {
 			"test \"$actual_distribution_digest\" = " + shellQuote(pipeline.DistributionDigest),
 			`chmod 0500 "$distribution"`,
 		}
-		if misePath != "" {
+		if usesMise {
 			commands = append(commands,
 				"buildkite-agent artifact download "+shellQuote(misePath)+` "$bootstrap_dir" --step `+shellQuote(pipeline.CompilerStep),
 				"mise_archive=\"$bootstrap_dir/"+misePath+`"`,
@@ -126,10 +148,19 @@ func Emit(pipeline Pipeline) ([]byte, error) {
 		out.WriteString("    agents:\n")
 		_, _ = fmt.Fprintf(&out, "      queue: %s\n", yamlScalar(job.Queue))
 		out.WriteString("    checkout:\n      skip: true\n")
+		if usesMise {
+			out.WriteString("    cache:\n")
+			out.WriteString("      paths:\n")
+			out.WriteString("        - \".buildkite-gha/cache-volume\"\n")
+			out.WriteString("      name: \"buildkite-gha\"\n")
+		}
 		out.WriteString("    env:\n")
 		_, _ = fmt.Fprintf(&out, "      BUILDKITE_GHA_PLAN_DIGEST: %s\n", yamlScalar(job.PlanDigest))
 		_, _ = fmt.Fprintf(&out, "      BUILDKITE_GHA_PLAN_PATH: %s\n", yamlScalar(planPath))
 		_, _ = fmt.Fprintf(&out, "      BUILDKITE_GHA_PLAN_PRODUCER: %s\n", yamlScalar(pipeline.CompilerStep))
+		if usesMise {
+			_, _ = fmt.Fprintf(&out, "      BUILDKITE_GHA_MISE_DATA_DIR: %s\n", yamlScalar(miseDataDir))
+		}
 		if job.Concurrency != 0 {
 			_, _ = fmt.Fprintf(&out, "    concurrency: %d\n", job.Concurrency)
 			_, _ = fmt.Fprintf(&out, "    concurrency_group: %s\n", yamlScalar(job.ConcurrencyGroup))

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -84,7 +84,9 @@ func TestEmitGolden(t *testing.T) {
 	}
 	if !strings.Contains(string(first), `artifact download '.buildkite-gha/distributions/`) ||
 		!strings.Contains(string(first), `artifact download '.buildkite-gha/plans/`) ||
-		strings.Contains(string(first), "go run") {
+		strings.Contains(string(first), "go run") ||
+		strings.Contains(string(first), "cache:") ||
+		strings.Contains(string(first), "BUILDKITE_GHA_MISE_DATA_DIR") {
 		t.Fatalf("generated jobs are not self-contained:\n%s", first)
 	}
 	if strings.Count(string(first), `--step 'gha-importer'`) != 6 {
@@ -101,7 +103,8 @@ func TestEmitMiseBootstrap(t *testing.T) {
 		CompilerStep:       "importer",
 		DistributionDigest: testDigest("distribution"),
 		MiseDigest:         digest,
-		Jobs:               []Job{{Key: "action", Label: "Action", Queue: "hosted", PlanDigest: testDigest("plan")}},
+		MiseVersion:        "2026.5.12",
+		Jobs:               []Job{{Key: "action", Label: "Action", Queue: "hosted", PlanDigest: testDigest("plan"), UsesActions: true}},
 	}
 	output, err := Emit(pipeline)
 	if err != nil {
@@ -114,6 +117,11 @@ func TestEmitMiseBootstrap(t *testing.T) {
 	var document struct {
 		Steps []struct {
 			Command string `yaml:"command"`
+			Cache   struct {
+				Paths []string `yaml:"paths"`
+				Name  string   `yaml:"name"`
+			} `yaml:"cache"`
+			Env map[string]string `yaml:"env"`
 		} `yaml:"steps"`
 	}
 	if err := yaml.Unmarshal(output, &document); err != nil {
@@ -135,6 +143,13 @@ func TestEmitMiseBootstrap(t *testing.T) {
 			t.Fatalf("mise bootstrap missing %q:\n%s", want, command)
 		}
 	}
+	step := document.Steps[0]
+	if step.Cache.Name != "buildkite-gha" || len(step.Cache.Paths) != 1 || step.Cache.Paths[0] != ".buildkite-gha/cache-volume" {
+		t.Fatalf("mise cache volume = %#v", step.Cache)
+	}
+	if step.Env["BUILDKITE_GHA_MISE_DATA_DIR"] != "/cache/bkcache/buildkite-gha/mise/2026.5.12" {
+		t.Fatalf("mise data directory = %q", step.Env["BUILDKITE_GHA_MISE_DATA_DIR"])
+	}
 }
 
 func TestMisePathValidation(t *testing.T) {
@@ -145,6 +160,48 @@ func TestMisePathValidation(t *testing.T) {
 	}
 	if _, err := MisePath("sha256:nope"); err == nil {
 		t.Fatal("MisePath() accepted an invalid digest")
+	}
+	dataDir, err := MiseDataDir("2026.5.12")
+	if err != nil || dataDir != "/cache/bkcache/buildkite-gha/mise/2026.5.12" {
+		t.Fatalf("MiseDataDir() = %q, %v", dataDir, err)
+	}
+	if _, err := MiseDataDir("latest"); err == nil {
+		t.Fatal("MiseDataDir() accepted an unpinned version")
+	}
+}
+
+func TestEmitMiseCacheOnlyForActionJobs(t *testing.T) {
+	output, err := Emit(Pipeline{
+		CompilerStep:       "importer",
+		DistributionDigest: testDigest("distribution"),
+		MiseDigest:         testDigest("mise"),
+		MiseVersion:        "2026.5.12",
+		Jobs: []Job{
+			{Key: "action", Label: "Action", Queue: "hosted", PlanDigest: testDigest("action-plan"), UsesActions: true},
+			{Key: "shell", Label: "Shell", Queue: "hosted", PlanDigest: testDigest("shell-plan")},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document struct {
+		Steps []struct {
+			Key     string            `yaml:"key"`
+			Command string            `yaml:"command"`
+			Cache   any               `yaml:"cache"`
+			Env     map[string]string `yaml:"env"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(output, &document); err != nil {
+		t.Fatal(err)
+	}
+	for _, step := range document.Steps {
+		if step.Key == "action" && (step.Cache == nil || step.Env["BUILDKITE_GHA_MISE_DATA_DIR"] == "" || !strings.Contains(step.Command, "/tools/mise/")) {
+			t.Fatalf("action job lacks managed mise: %#v", step)
+		}
+		if step.Key == "shell" && (step.Cache != nil || step.Env["BUILDKITE_GHA_MISE_DATA_DIR"] != "" || strings.Contains(step.Command, "/tools/mise/")) {
+			t.Fatalf("shell job gained managed mise: %#v", step)
+		}
 	}
 }
 
@@ -157,6 +214,8 @@ func TestEmitRejectsInvalidGraphsAndIdentifiers(t *testing.T) {
 	}{
 		{name: "empty", in: Pipeline{CompilerStep: "compiler", DistributionDigest: digest}, want: "at least one generated job"},
 		{name: "bad distribution digest", in: Pipeline{CompilerStep: "compiler", DistributionDigest: "sha256:nope", Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: digest}}}, want: "invalid distribution digest"},
+		{name: "mise digest without version", in: Pipeline{CompilerStep: "compiler", DistributionDigest: digest, MiseDigest: digest, Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: testDigest("mise-plan")}}}, want: "invalid mise version"},
+		{name: "mise version without digest", in: Pipeline{CompilerStep: "compiler", DistributionDigest: digest, MiseVersion: "2026.5.12", Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: testDigest("mise-version-plan")}}}, want: "mise version requires a mise digest"},
 		{name: "unknown dependency", in: Pipeline{CompilerStep: "compiler", Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: digest, Dependencies: []string{"missing"}}}}, want: "unknown dependency"},
 		{name: "cycle", in: Pipeline{CompilerStep: "compiler", Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: testDigest("one"), Dependencies: []string{"two"}}, {Key: "two", Label: "Two", Queue: "queue", PlanDigest: testDigest("two"), Dependencies: []string{"one"}}}}, want: "contains a cycle"},
 		{name: "duplicate key", in: Pipeline{CompilerStep: "compiler", Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: testDigest("one")}, {Key: "one", Label: "Other", Queue: "queue", PlanDigest: testDigest("other")}}}, want: "duplicate generated step key"},

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -209,13 +209,14 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 		actionMaterializer = store
 	}
 	runner := gharuntime.Runner{
-		Stdout:   stdout,
-		Stderr:   stderr,
-		Docker:   os.Getenv("BUILDKITE_GHA_DOCKER"),
-		Git:      os.Getenv("BUILDKITE_GHA_GIT"),
-		Secrets:  gharuntime.EnvironmentSecrets{},
-		Redactor: gharuntime.AgentRedactor{Executable: os.Getenv("BUILDKITE_GHA_AGENT")},
-		Actions:  actionMaterializer,
+		Stdout:      stdout,
+		Stderr:      stderr,
+		MiseDataDir: prepareMiseDataDir(os.Getenv("BUILDKITE_GHA_MISE_DATA_DIR"), stderr),
+		Docker:      os.Getenv("BUILDKITE_GHA_DOCKER"),
+		Git:         os.Getenv("BUILDKITE_GHA_GIT"),
+		Secrets:     gharuntime.EnvironmentSecrets{},
+		Redactor:    gharuntime.AgentRedactor{Executable: os.Getenv("BUILDKITE_GHA_AGENT")},
+		Actions:     actionMaterializer,
 	}
 	runner.RuntimeExecutable, err = os.Executable()
 	if err != nil {
@@ -256,6 +257,28 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 		return 1
 	}
 	return 0
+}
+
+func prepareMiseDataDir(path string, stderr io.Writer) string {
+	if path == "" {
+		return ""
+	}
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: warning: mise cache %q is invalid; using the ephemeral agent cache: %v\n", path, err)
+		return ""
+	}
+	if err := os.MkdirAll(absolute, 0o755); err != nil {
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: warning: mise cache %q is unavailable; using the ephemeral agent cache: %v\n", path, err)
+		return ""
+	}
+	resolved, resolveErr := filepath.EvalSymlinks(absolute)
+	info, statErr := os.Lstat(absolute)
+	if resolveErr != nil || resolved != absolute || statErr != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: warning: mise cache %q is not a real directory; using the ephemeral agent cache\n", path)
+		return ""
+	}
+	return absolute
 }
 
 func hasGitHubActionLocks(locks []plan.ActionLock) bool {
@@ -666,6 +689,7 @@ func compileHostedTokenless(ctx context.Context, workflowPath string, workflowSo
 		}
 		miseArtifact = &artifact
 		options.MiseDigest = artifact.Digest
+		options.MiseVersion = managedMiseVersion
 	}
 	bundle, err := compiler.CompileBundleContext(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, options)
 	if err != nil {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -293,6 +293,7 @@ func TestRunUploadCompilesArtifactsAndUploadsSelfContainedPipeline(t *testing.T)
 		Steps []struct {
 			Key     string `yaml:"key"`
 			Command string `yaml:"command"`
+			Cache   any    `yaml:"cache"`
 			Agents  struct {
 				Queue string `yaml:"queue"`
 			} `yaml:"agents"`
@@ -312,6 +313,9 @@ func TestRunUploadCompilesArtifactsAndUploadsSelfContainedPipeline(t *testing.T)
 		t.Fatalf("uploaded steps = %#v", pipeline.Steps)
 	}
 	for _, step := range pipeline.Steps {
+		if step.Cache != nil {
+			t.Fatalf("shell-only step %q unexpectedly configures a runtime cache: %#v", step.Key, step.Cache)
+		}
 		if !step.Checkout.Skip || step.Agents.Queue != "hosted" || len(step.DependsOn) == 0 || step.DependsOn[0].Step != "phase-2-importer" || step.DependsOn[0].AllowFailure {
 			t.Fatalf("step %q lacks isolated checkout or exact importer dependency: %#v", step.Key, step)
 		}
@@ -449,6 +453,11 @@ func TestRunUploadJavaScriptActionTransportsMiseWithoutNode(t *testing.T) {
 	var pipeline struct {
 		Steps []struct {
 			Command string `yaml:"command"`
+			Cache   struct {
+				Paths []string `yaml:"paths"`
+				Name  string   `yaml:"name"`
+			} `yaml:"cache"`
+			Env map[string]string `yaml:"env"`
 		} `yaml:"steps"`
 	}
 	if err := yaml.Unmarshal(runner.commands[3].stdin, &pipeline); err != nil {
@@ -460,6 +469,41 @@ func TestRunUploadJavaScriptActionTransportsMiseWithoutNode(t *testing.T) {
 	command := pipeline.Steps[0].Command
 	if !strings.Contains(command, ".buildkite-gha/tools/mise/") || !strings.Contains(command, `export PATH="$bootstrap_dir:$PATH"`) || strings.Contains(command, "BUILDKITE_GHA_NODE") || strings.Contains(command, ".buildkite-gha/runtimes") {
 		t.Fatalf("generated pipeline does not use the mise runtime boundary:\n%s", command)
+	}
+	step := pipeline.Steps[0]
+	if step.Cache.Name != "buildkite-gha" || len(step.Cache.Paths) != 1 || step.Cache.Paths[0] != ".buildkite-gha/cache-volume" {
+		t.Fatalf("generated action cache = %#v", step.Cache)
+	}
+	if step.Env["BUILDKITE_GHA_MISE_DATA_DIR"] != "/cache/bkcache/buildkite-gha/mise/2026.5.12" {
+		t.Fatalf("generated mise data directory = %q", step.Env["BUILDKITE_GHA_MISE_DATA_DIR"])
+	}
+}
+
+func TestPrepareMiseDataDirFallsBackWhenCacheIsUnavailable(t *testing.T) {
+	var stderr bytes.Buffer
+	dir := filepath.Join(t.TempDir(), "mise")
+	if got := prepareMiseDataDir(dir, &stderr); got != dir || stderr.Len() != 0 {
+		t.Fatalf("prepareMiseDataDir() = %q, stderr = %q", got, stderr.String())
+	}
+
+	file := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stderr.Reset()
+	if got := prepareMiseDataDir(file, &stderr); got != "" || !strings.Contains(stderr.String(), "using the ephemeral agent cache") {
+		t.Fatalf("prepareMiseDataDir(file) = %q, stderr = %q", got, stderr.String())
+	}
+
+	parent := t.TempDir()
+	target := t.TempDir()
+	link := filepath.Join(parent, "linked-cache")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	stderr.Reset()
+	if got := prepareMiseDataDir(filepath.Join(link, "mise"), &stderr); got != "" || !strings.Contains(stderr.String(), "not a real directory") {
+		t.Fatalf("prepareMiseDataDir(symlink) = %q, stderr = %q", got, stderr.String())
 	}
 }
 

--- a/internal/compiler/bundle.go
+++ b/internal/compiler/bundle.go
@@ -88,6 +88,7 @@ func CompileBundleContext(ctx context.Context, path string, source, eventSource 
 			Queue:        ir.Jobs[i].Queue,
 			PlanDigest:   digest,
 			Dependencies: append([]string(nil), ir.Jobs[i].Needs...),
+			UsesActions:  planUsesActions(job),
 		}
 		if ir.Jobs[i].MaxParallel != nil {
 			jobs[i].Concurrency = *ir.Jobs[i].MaxParallel
@@ -98,10 +99,20 @@ func CompileBundleContext(ctx context.Context, path string, source, eventSource 
 		CompilerStep:       compilerStep,
 		DistributionDigest: compilerDistributionDigest,
 		MiseDigest:         options.MiseDigest,
+		MiseVersion:        options.MiseVersion,
 		Jobs:               jobs,
 	})
 	if err != nil {
 		return Bundle{}, fmt.Errorf("emit Buildkite pipeline: %w", err)
 	}
 	return Bundle{IR: ir, Plans: artifacts, Pipeline: pipeline}, nil
+}
+
+func planUsesActions(job plan.Job) bool {
+	for _, step := range job.Steps {
+		if step.Action != nil {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/compiler/config.go
+++ b/internal/compiler/config.go
@@ -47,7 +47,8 @@ type Options struct {
 	ActionSource   ActionSource
 	// MiseDigest is runtime transport policy only. It is emitted into generated
 	// pipeline bootstrap commands and never changes compiler IR or plans.
-	MiseDigest string
+	MiseDigest  string
+	MiseVersion string
 }
 
 func defaultOptions() Options {

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -93,6 +93,9 @@ func VerifyWorkflow(job plan.Job, workspace string) error {
 // RunJob executes the plan's ordered steps and always drains registered post actions.
 func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (final JobResult, runJobErr error) {
 	callerWorkspace := workspace != ""
+	if r.nodeVerification == nil {
+		r.nodeVerification = &managedNodeVerification{paths: make(map[int]string, 2)}
+	}
 	if err := job.Validate(); err != nil {
 		return JobResult{}, err
 	}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -742,7 +742,7 @@ func (r Runner) installAndVerifyMiseNode(ctx context.Context, major int, mise st
 		if installErr := r.installMiseNode(ctx, mise, tool); installErr != nil {
 			return "", fmt.Errorf("replace invalid cached %s: %w", tool, installErr)
 		}
-		installation, node, err = r.miseNodeInstallation(ctx, major, mise)
+		_, node, err = r.miseNodeInstallation(ctx, major, mise)
 		if err == nil {
 			err = verifyManagedNodeExecutable(ctx, major, node, r.nodeDigest(major))
 		}
@@ -882,7 +882,7 @@ func verifyManagedNodeExecutable(ctx context.Context, major int, path, want stri
 	}
 	got := hex.EncodeToString(hash.Sum(nil))
 	if got != want {
-		return fmt.Errorf("Node %d executable digest %s does not match expected digest %s", major, got, want)
+		return fmt.Errorf("node %d executable digest %s does not match expected digest %s", major, got, want)
 	}
 	cmd := exec.CommandContext(ctx, path, "--version")
 	cmd.Env = processEnv(nil)
@@ -892,14 +892,17 @@ func verifyManagedNodeExecutable(ctx context.Context, major int, path, want stri
 	if err != nil {
 		return fmt.Errorf("verify exact Node %d executable: %w: %s", major, err, strings.TrimSpace(stderr.String()))
 	}
-	wantVersion := fmt.Sprintf("v%d", major)
-	if major == 20 {
+	var wantVersion string
+	switch major {
+	case 20:
 		wantVersion = "v" + Node20Version
-	} else if major == 24 {
+	case 24:
 		wantVersion = "v" + Node24Version
+	default:
+		wantVersion = fmt.Sprintf("v%d", major)
 	}
 	if strings.TrimSpace(string(out)) != wantVersion {
-		return fmt.Errorf("Node %d executable reported %q, want %q", major, strings.TrimSpace(string(out)), wantVersion)
+		return fmt.Errorf("node %d executable reported %q, want %q", major, strings.TrimSpace(string(out)), wantVersion)
 	}
 	return nil
 }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -5,6 +5,7 @@ import (
 	"bufio"
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -37,6 +38,7 @@ type Runner struct {
 	Node24            string
 	ManagedNodeRoot   string
 	Mise              string
+	MiseDataDir       string
 	Docker            string
 	RuntimeExecutable string
 	Git               string
@@ -51,6 +53,13 @@ type Runner struct {
 	explicitJobPATH   bool
 	jobContainer      *jobContainerBackend
 	jobDocker         *jobContainerBackend
+	nodeVerification  *managedNodeVerification
+	nodeDigests       map[int]string
+}
+
+type managedNodeVerification struct {
+	mu    sync.Mutex
+	paths map[int]string
 }
 
 // JavaScriptAction is an already-resolved local JavaScript action.
@@ -479,17 +488,6 @@ func (r Runner) runJavaScriptPhase(ctx context.Context, processor *commandProces
 		entrypoint = r.jobContainer.containerPath(entrypoint)
 	}
 	name, args := node, []string{entrypoint}
-	if r.usesMiseNode(action.nodeMajor) && r.jobContainer == nil {
-		name = node
-		args = []string{"--no-config", "exec", nodeTool(action.nodeMajor), "--", "node", entrypoint}
-		// The compatibility runtime owns mise configuration. Workflow values
-		// remain available to shell steps but cannot redirect Node selection.
-		for key := range env {
-			if strings.HasPrefix(key, "MISE_") {
-				delete(env, key)
-			}
-		}
-	}
 	if err := r.runProcess(ctx, processor, action.Path, env, result, stateOut, name, args...); err != nil {
 		return fmt.Errorf("JavaScript action %q entry %q: %w", action.Name, entry, err)
 	}
@@ -675,25 +673,20 @@ func streamLines(reader io.Reader, process func(string), suppress func()) error 
 const (
 	Node20Version = "20.20.2"
 	Node24Version = "24.18.0"
+	// Digests are for bin/node in the official Linux x86-64 release archives.
+	node20Digest = "6295488653f0d93b0a157841746fef7e72cc4328cfb60c4bbe0ca2668a836ffd"
+	node24Digest = "41a74efb34cbde5c7632cdac0cf8bd1a14d0b8d73dc1e82755014d9a9ce70f5c"
 )
 
 func nodeTool(major int) string {
 	switch major {
 	case 20:
-		return "node@" + Node20Version
+		return "core:node@" + Node20Version
 	case 24:
-		return "node@" + Node24Version
+		return "core:node@" + Node24Version
 	default:
 		return ""
 	}
-}
-
-func (r Runner) usesMiseNode(major int) bool {
-	explicit := r.Node24
-	if major == 20 {
-		explicit = r.Node20
-	}
-	return explicit == "" && r.ManagedNodeRoot == ""
 }
 
 func (r Runner) discoverNode(ctx context.Context, major int, explicit string) (string, error) {
@@ -712,61 +705,203 @@ func (r Runner) discoverNode(ctx context.Context, major int, explicit string) (s
 			return "", fmt.Errorf("mise is required to run JavaScript actions: %w", err)
 		}
 	}
-	cmd := exec.CommandContext(ctx, mise, "--no-config", "exec", tool, "--", "node", "--version")
-	cmd.Env = processEnv(nil)
-	var stderr strings.Builder
-	cmd.Stderr = &stderr
-	out, err := cmd.Output()
-	if err != nil {
-		if ctx.Err() != nil {
-			return "", ctx.Err()
-		}
-		return "", fmt.Errorf("verify exact %s with mise: %w: %s", tool, err, strings.TrimSpace(stderr.String()))
-	}
-	want := strings.TrimPrefix(tool, "node@")
-	if strings.TrimSpace(string(out)) != "v"+want {
-		return "", fmt.Errorf("mise %s reported %q, want %q", tool, strings.TrimSpace(string(out)), "v"+want)
-	}
-	return mise, nil
+	return r.installAndVerifyMiseNode(ctx, major, mise)
 }
 
 func (r Runner) resolveMiseNodePath(ctx context.Context, major int) (string, error) {
-	mise, err := r.discoverNode(ctx, major, "")
+	return r.discoverNode(ctx, major, "")
+}
+
+func (r Runner) miseEnv() map[string]string {
+	if r.MiseDataDir == "" {
+		return nil
+	}
+	return map[string]string{"MISE_DATA_DIR": r.MiseDataDir}
+}
+
+func (r Runner) installAndVerifyMiseNode(ctx context.Context, major int, mise string) (string, error) {
+	if r.nodeVerification != nil {
+		r.nodeVerification.mu.Lock()
+		defer r.nodeVerification.mu.Unlock()
+		if path := r.nodeVerification.paths[major]; path != "" {
+			return path, nil
+		}
+	}
+	tool := nodeTool(major)
+	if err := r.installMiseNode(ctx, mise, tool); err != nil {
+		return "", err
+	}
+	installation, node, err := r.miseNodeInstallation(ctx, major, mise)
+	if err == nil {
+		err = verifyManagedNodeExecutable(ctx, major, node, r.nodeDigest(major))
+	}
+	if err != nil && r.MiseDataDir != "" {
+		if removeErr := removeManagedNodeInstallation(r.MiseDataDir, installation); removeErr != nil {
+			return "", errors.Join(fmt.Errorf("cached Node %d failed validation: %w", major, err), removeErr)
+		}
+		if installErr := r.installMiseNode(ctx, mise, tool); installErr != nil {
+			return "", fmt.Errorf("replace invalid cached %s: %w", tool, installErr)
+		}
+		installation, node, err = r.miseNodeInstallation(ctx, major, mise)
+		if err == nil {
+			err = verifyManagedNodeExecutable(ctx, major, node, r.nodeDigest(major))
+		}
+		if err != nil {
+			return "", fmt.Errorf("replacement %s failed validation: %w", tool, err)
+		}
+	}
 	if err != nil {
 		return "", err
 	}
+	if r.nodeVerification != nil {
+		r.nodeVerification.paths[major] = node
+	}
+	return node, nil
+}
+
+func (r Runner) installMiseNode(ctx context.Context, mise, tool string) error {
+	cmd := exec.CommandContext(ctx, mise, "--no-config", "install", tool)
+	cmd.Env = processEnv(r.miseEnv())
+	var output strings.Builder
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		return fmt.Errorf("install exact %s with mise: %w: %s", tool, err, strings.TrimSpace(output.String()))
+	}
+	return nil
+}
+
+func (r Runner) nodeDigest(major int) string {
+	if digest := r.nodeDigests[major]; digest != "" {
+		return digest
+	}
+	switch major {
+	case 20:
+		return node20Digest
+	case 24:
+		return node24Digest
+	default:
+		return ""
+	}
+}
+
+func (r Runner) miseNodeInstallation(ctx context.Context, major int, mise string) (string, string, error) {
 	tool := nodeTool(major)
 	cmd := exec.CommandContext(ctx, mise, "--no-config", "where", tool)
+	cmd.Env = processEnv(r.miseEnv())
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "", "", fmt.Errorf("resolve cached %s installation: %w: %s", tool, err, strings.TrimSpace(stderr.String()))
+	}
+	installation, err := filepath.Abs(strings.TrimSpace(string(out)))
+	if err != nil {
+		return "", "", fmt.Errorf("resolve %s installation path: %w", tool, err)
+	}
+	if r.MiseDataDir != "" {
+		dataDir, err := filepath.Abs(r.MiseDataDir)
+		if err != nil {
+			return "", "", fmt.Errorf("resolve mise data directory: %w", err)
+		}
+		resolvedDataDir, err := filepath.EvalSymlinks(dataDir)
+		if err != nil || resolvedDataDir != dataDir {
+			return "", "", errors.New("mise data directory contains a symlink")
+		}
+		resolvedInstallation, err := filepath.EvalSymlinks(installation)
+		if err != nil || resolvedInstallation != installation {
+			return "", "", fmt.Errorf("mise-resolved %s installation contains a symlink", tool)
+		}
+		relative, err := filepath.Rel(dataDir, installation)
+		if err != nil || relative == "." || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+			return "", "", fmt.Errorf("mise resolved %s outside its runtime-owned data directory", tool)
+		}
+	}
+	node := filepath.Join(installation, "bin", "node")
+	info, err := os.Lstat(node)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return installation, node, fmt.Errorf("mise-resolved %s executable is not a regular file", tool)
+	}
+	resolvedNode, err := filepath.EvalSymlinks(node)
+	if err != nil || resolvedNode != node {
+		return installation, node, fmt.Errorf("mise-resolved %s executable contains a symlink", tool)
+	}
+	return installation, node, nil
+}
+
+func removeManagedNodeInstallation(dataDir, installation string) error {
+	dataDir, err := filepath.Abs(dataDir)
+	if err != nil {
+		return fmt.Errorf("resolve mise data directory: %w", err)
+	}
+	resolvedDataDir, err := filepath.EvalSymlinks(dataDir)
+	if err != nil || resolvedDataDir != dataDir {
+		return errors.New("refusing to remove Node installation through a symlinked mise data directory")
+	}
+	installation, err = filepath.Abs(installation)
+	if err != nil {
+		return fmt.Errorf("resolve cached Node installation: %w", err)
+	}
+	relative, err := filepath.Rel(dataDir, installation)
+	if err != nil || relative == "." || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return errors.New("refusing to remove Node installation outside the mise data directory")
+	}
+	current := dataDir
+	for _, component := range strings.Split(relative, string(filepath.Separator)) {
+		current = filepath.Join(current, component)
+		info, err := os.Lstat(current)
+		if err != nil {
+			return fmt.Errorf("inspect cached Node installation: %w", err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to remove cached Node installation through symlink %q", current)
+		}
+	}
+	if err := os.RemoveAll(installation); err != nil {
+		return fmt.Errorf("remove invalid cached Node installation: %w", err)
+	}
+	return nil
+}
+
+func verifyManagedNodeExecutable(ctx context.Context, major int, path, want string) error {
+	if want == "" {
+		return fmt.Errorf("unsupported Node runtime major %d", major)
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open Node %d executable: %w", major, err)
+	}
+	hash := sha256.New()
+	_, copyErr := io.Copy(hash, file)
+	closeErr := file.Close()
+	if err := errors.Join(copyErr, closeErr); err != nil {
+		return fmt.Errorf("hash Node %d executable: %w", major, err)
+	}
+	got := hex.EncodeToString(hash.Sum(nil))
+	if got != want {
+		return fmt.Errorf("Node %d executable digest %s does not match expected digest %s", major, got, want)
+	}
+	cmd := exec.CommandContext(ctx, path, "--version")
 	cmd.Env = processEnv(nil)
 	var stderr strings.Builder
 	cmd.Stderr = &stderr
 	out, err := cmd.Output()
 	if err != nil {
-		if ctx.Err() != nil {
-			return "", ctx.Err()
-		}
-		return "", fmt.Errorf("resolve exact %s installation with mise: %w: %s", tool, err, strings.TrimSpace(stderr.String()))
+		return fmt.Errorf("verify exact Node %d executable: %w: %s", major, err, strings.TrimSpace(stderr.String()))
 	}
-	node, err := discoverNodeContext(ctx, major, filepath.Join(strings.TrimSpace(string(out)), "bin", "node"), "")
-	if err != nil {
-		return "", err
+	wantVersion := fmt.Sprintf("v%d", major)
+	if major == 20 {
+		wantVersion = "v" + Node20Version
+	} else if major == 24 {
+		wantVersion = "v" + Node24Version
 	}
-	cmd = exec.CommandContext(ctx, node, "--version")
-	cmd.Env = processEnv(nil)
-	stderr.Reset()
-	cmd.Stderr = &stderr
-	out, err = cmd.Output()
-	if err != nil {
-		if ctx.Err() != nil {
-			return "", ctx.Err()
-		}
-		return "", fmt.Errorf("verify exact %s executable: %w: %s", tool, err, strings.TrimSpace(stderr.String()))
+	if strings.TrimSpace(string(out)) != wantVersion {
+		return fmt.Errorf("Node %d executable reported %q, want %q", major, strings.TrimSpace(string(out)), wantVersion)
 	}
-	want := "v" + strings.TrimPrefix(tool, "node@")
-	if strings.TrimSpace(string(out)) != want {
-		return "", fmt.Errorf("mise-resolved %s executable reported %q, want %q", tool, strings.TrimSpace(string(out)), want)
-	}
-	return node, nil
+	return nil
 }
 
 // DiscoverNode resolves an explicit Node binary or a binary in the managed
@@ -854,6 +989,8 @@ func mapEnv(values map[string]string) []string {
 }
 
 func processEnv(overrides map[string]string) []string {
+	// This allowlist is also the mise trust boundary: ambient MISE_* values must
+	// never redirect compatibility runtime downloads or verification.
 	values := make(map[string]string, 6+len(overrides))
 	for _, name := range []string{"PATH", "HOME", "TMPDIR", "LANG", "LC_ALL", "LC_CTYPE"} {
 		if value, ok := os.LookupEnv(name); ok {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -2190,21 +2190,32 @@ func TestDiscoverNodeManagedAndWrongExplicitVersion(t *testing.T) {
 func TestMiseNodeSelectionIsExactAndConfigFree(t *testing.T) {
 	root := t.TempDir()
 	log := filepath.Join(root, "args")
+	dataDir := filepath.Join(root, "data")
+	installation := filepath.Join(dataDir, "installs", "node", Node20Version)
+	node := filepath.Join(installation, "bin", "node")
+	nodeBytes := []byte("#!/bin/sh\nprintf 'v20.20.2\\n'\n")
+	if err := os.MkdirAll(filepath.Dir(node), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(node, nodeBytes, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	mise := filepath.Join(root, "mise")
-	writeFixtureFile(t, root, "mise", fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$*\" >> %q\nprintf 'mise install progress\\n' >&2\ncase \"$*\" in *node@20.20.2*) printf 'v20.20.2\\n';; *) exit 9;; esac\n", log))
+	writeFixtureFile(t, root, "mise", fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$*\" >> %q\nprintf 'mise progress\\n' >&2\ncase \"$2\" in install) :;; where) printf '%%s\\n' %q;; *) exit 9;; esac\n", log, installation))
 	if err := os.Chmod(mise, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	r := Runner{Mise: mise}
+	digest := sha256.Sum256(nodeBytes)
+	r := Runner{Mise: mise, MiseDataDir: dataDir, nodeDigests: map[int]string{20: hex.EncodeToString(digest[:])}}
 	got, err := r.discoverNode(context.Background(), 20, "")
-	if err != nil || got != mise {
+	if err != nil || got != node {
 		t.Fatalf("discoverNode() = %q, %v", got, err)
 	}
 	data, err := os.ReadFile(log)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(data) != "--no-config exec node@20.20.2 -- node --version\n" {
+	if string(data) != "--no-config install core:node@20.20.2\n--no-config where core:node@20.20.2\n" {
 		t.Fatalf("mise arguments = %q", data)
 	}
 }
@@ -2218,50 +2229,136 @@ func TestMiseNodePathIgnoresProgressOnStderr(t *testing.T) {
 	node := filepath.Join(nodeRoot, "bin", "node")
 	writeNodeExecutable(t, node, 24)
 	mise := filepath.Join(root, "mise")
-	writeFixtureFile(t, root, "mise", fmt.Sprintf("#!/bin/sh\nprintf 'mise progress\\n' >&2\ncase \"$2\" in exec) printf 'v24.18.0\\n';; where) printf '%%s\\n' %q;; *) exit 9;; esac\n", nodeRoot))
+	writeFixtureFile(t, root, "mise", fmt.Sprintf("#!/bin/sh\nprintf 'mise progress\\n' >&2\ncase \"$2\" in install) :;; where) printf '%%s\\n' %q;; *) exit 9;; esac\n", nodeRoot))
 	if err := os.Chmod(mise, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := (Runner{Mise: mise}).resolveMiseNodePath(context.Background(), 24); err == nil || !strings.Contains(err.Error(), `reported "v24.99.0", want "v24.18.0"`) {
-		t.Fatalf("resolveMiseNodePath() error = %v, want exact executable version rejection", err)
-	}
-	if err := os.WriteFile(node, []byte("#!/bin/sh\nprintf 'v24.18.0\\n'\n"), 0o755); err != nil {
+	wrongBytes, err := os.ReadFile(node)
+	if err != nil {
 		t.Fatal(err)
 	}
-	got, err := (Runner{Mise: mise}).resolveMiseNodePath(context.Background(), 24)
+	wrongDigest := sha256.Sum256(wrongBytes)
+	if _, err := (Runner{Mise: mise, nodeDigests: map[int]string{24: hex.EncodeToString(wrongDigest[:])}}).resolveMiseNodePath(context.Background(), 24); err == nil || !strings.Contains(err.Error(), `reported "v24.99.0", want "v24.18.0"`) {
+		t.Fatalf("resolveMiseNodePath() error = %v, want exact executable version rejection", err)
+	}
+	correctBytes := []byte("#!/bin/sh\nprintf 'v24.18.0\\n'\n")
+	if err := os.WriteFile(node, correctBytes, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	correctDigest := sha256.Sum256(correctBytes)
+	got, err := (Runner{Mise: mise, nodeDigests: map[int]string{24: hex.EncodeToString(correctDigest[:])}}).resolveMiseNodePath(context.Background(), 24)
 	if err != nil || got != filepath.Join(nodeRoot, "bin", "node") {
 		t.Fatalf("resolveMiseNodePath() = %q, %v", got, err)
 	}
 }
 
-func TestJavaScriptPhaseUsesMiseForItsMajorWhenOtherMajorIsExplicit(t *testing.T) {
+func TestManagedMiseCacheReplacesNodeWithWrongDigest(t *testing.T) {
 	root := t.TempDir()
-	log := filepath.Join(root, "args")
+	dataDir := filepath.Join(root, "data")
+	installation := filepath.Join(dataDir, "installs", "node", Node24Version)
+	node := filepath.Join(installation, "bin", "node")
+	if err := os.MkdirAll(filepath.Dir(node), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	poisoned := []byte("#!/bin/sh\nprintf 'v24.18.0\\n'\n# poisoned\n")
+	if err := os.WriteFile(node, poisoned, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	replacement := []byte("#!/bin/sh\nprintf 'v24.18.0\\n'\n# replacement\n")
+	digest := sha256.Sum256(replacement)
 	mise := filepath.Join(root, "mise")
-	writeFixtureFile(t, root, "mise", fmt.Sprintf("#!/bin/sh\nprintf '%%s|MISE_DATA_DIR=%%s\\n' \"$*\" \"${MISE_DATA_DIR-unset}\" >> %q\ncase \"$*\" in *--version) printf 'v24.18.0\\n';; esac\n", log))
+	script := fmt.Sprintf(`#!/bin/sh
+node=%q
+installation=%q
+case "$2" in
+  install)
+    if [ ! -x "$node" ]; then
+      mkdir -p "$(dirname "$node")"
+      cat > "$node" <<'NODE'
+%sNODE
+      chmod 0755 "$node"
+    fi
+    ;;
+  where) printf '%%s\n' "$installation" ;;
+  *) exit 9 ;;
+esac
+`, node, installation, replacement)
+	if err := os.WriteFile(mise, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	verification := &managedNodeVerification{paths: make(map[int]string)}
+	runner := Runner{
+		Mise:             mise,
+		MiseDataDir:      dataDir,
+		nodeDigests:      map[int]string{24: hex.EncodeToString(digest[:])},
+		nodeVerification: verification,
+	}
+	if got, err := runner.discoverNode(context.Background(), 24, ""); err != nil || got != node {
+		t.Fatalf("discoverNode() = %q, %v", got, err)
+	}
+	got, err := os.ReadFile(node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, replacement) || verification.paths[24] != node {
+		t.Fatalf("replacement node = %q, verified = %#v", got, verification.paths)
+	}
+}
+
+func TestManagedMiseCacheRefusesSymlinkedRemoval(t *testing.T) {
+	dataDir := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(dataDir, "installs")); err != nil {
+		t.Fatal(err)
+	}
+	installation := filepath.Join(dataDir, "installs", "node", Node24Version)
+	if err := removeManagedNodeInstallation(dataDir, installation); err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("removeManagedNodeInstallation() error = %v", err)
+	}
+	if _, err := os.Stat(outside); err != nil {
+		t.Fatalf("outside directory was affected: %v", err)
+	}
+}
+
+func TestJavaScriptPhaseUsesVerifiedMiseNodeWithoutWorkflowRedirection(t *testing.T) {
+	root := t.TempDir()
+	log := filepath.Join(root, "node-args")
+	dataDir := filepath.Join(root, "mise-data")
+	installation := filepath.Join(dataDir, "installs", "node", Node24Version)
+	node := filepath.Join(installation, "bin", "node")
+	if err := os.MkdirAll(filepath.Dir(node), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	nodeBytes := []byte(fmt.Sprintf("#!/bin/sh\nif [ \"${1:-}\" = --version ]; then printf 'v24.18.0\\n'; else printf '%%s|MISE_DATA_DIR=%%s\\n' \"$*\" \"${MISE_DATA_DIR-unset}\" >> %q; fi\n", log))
+	if err := os.WriteFile(node, nodeBytes, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mise := filepath.Join(root, "mise")
+	writeFixtureFile(t, root, "mise", fmt.Sprintf("#!/bin/sh\ncase \"$2\" in install) :;; where) printf '%%s\\n' %q;; *) exit 9;; esac\n", installation))
 	if err := os.Chmod(mise, 0o700); err != nil {
 		t.Fatal(err)
 	}
 	writeFixtureFile(t, root, "main.js", "")
 	node20 := filepath.Join(root, "node20")
 	writeNodeExecutable(t, node20, 20)
-	runner := Runner{Mise: mise, Node20: node20}
-	node, err := runner.discoverNode(context.Background(), 24, "")
+	digest := sha256.Sum256(nodeBytes)
+	runner := Runner{Mise: mise, MiseDataDir: dataDir, Node20: node20, nodeDigests: map[int]string{24: hex.EncodeToString(digest[:])}}
+	resolvedNode, err := runner.discoverNode(context.Background(), 24, "")
 	if err != nil {
 		t.Fatal(err)
 	}
 	result := newResult()
 	action := JavaScriptAction{Name: "mise", Path: root, Main: "main.js", Env: map[string]string{"MISE_DATA_DIR": "/workflow-controlled"}, nodeMajor: 24}
-	if err := runner.runJavaScriptPhase(context.Background(), newCommandProcessor(io.Discard, io.Discard), node, action, action.Main, nil, nil, &result); err != nil {
+	if err := runner.runJavaScriptPhase(context.Background(), newCommandProcessor(io.Discard, io.Discard), resolvedNode, action, action.Main, nil, nil, &result); err != nil {
 		t.Fatal(err)
 	}
 	data, err := os.ReadFile(log)
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "--no-config exec node@24.18.0 -- node --version|MISE_DATA_DIR=unset\n--no-config exec node@24.18.0 -- node " + filepath.Join(root, "main.js") + "|MISE_DATA_DIR=unset\n"
+	want := filepath.Join(root, "main.js") + "|MISE_DATA_DIR=/workflow-controlled\n"
 	if string(data) != want {
-		t.Fatalf("mise invocations = %q, want %q", data, want)
+		t.Fatalf("Node invocations = %q, want %q", data, want)
 	}
 }
 
@@ -2275,12 +2372,22 @@ func TestMiseMissingIsClear(t *testing.T) {
 
 func TestMiseNodeSelectionRejectsWrongExactVersion(t *testing.T) {
 	root := t.TempDir()
+	installation := filepath.Join(root, "node")
+	node := filepath.Join(installation, "bin", "node")
+	if err := os.MkdirAll(filepath.Dir(node), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	nodeBytes := []byte("#!/bin/sh\nprintf 'v24.18.1\\n'\n")
+	if err := os.WriteFile(node, nodeBytes, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	mise := filepath.Join(root, "mise")
-	writeFixtureFile(t, root, "mise", "#!/bin/sh\nprintf 'v24.18.1\\n'\n")
+	writeFixtureFile(t, root, "mise", fmt.Sprintf("#!/bin/sh\ncase \"$2\" in install) :;; where) printf '%%s\\n' %q;; *) exit 9;; esac\n", installation))
 	if err := os.Chmod(mise, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	_, err := (Runner{Mise: mise}).discoverNode(context.Background(), 24, "")
+	digest := sha256.Sum256(nodeBytes)
+	_, err := (Runner{Mise: mise, nodeDigests: map[int]string{24: hex.EncodeToString(digest[:])}}).discoverNode(context.Background(), 24, "")
 	if err == nil || !strings.Contains(err.Error(), `reported "v24.18.1", want "v24.18.0"`) {
 		t.Fatalf("discoverNode() error = %v", err)
 	}


### PR DESCRIPTION
## Summary

- document that the installer plugin bootstraps and verifies pinned mise, so importer agents do not need it preinstalled
- attach a dedicated Buildkite hosted cache volume only to generated action jobs
- install exact Node 20.20.2/24.18.0 through mise's pinned core backend, verify official executable digests, and invoke the verified binary directly
- reject symlinked cache paths and repair a wrong-digest cached Node installation once before failing closed

## Product experience

The user-facing setup remains one plugin entry:

```yaml
plugins:
  - github-actions#v0.1.0:
      workflow: .github/workflows/ci.yml
```

No preinstalled mise or additional cache plugin is required. Cache misses remain correct, and shell-only jobs do not attach the runtime cache.

Companion plugin: https://github.com/buildkite-plugins/github-actions-buildkite-plugin/pull/1

## Verification

- targeted Buildkite/compiler/CLI/runtime tests pass
- exact mise and Node release hashes independently verified against upstream release assets
- Oracle security review approved after one iteration
- full `mise run --jobs 1 check` passes locally