### PR TITLE
Use a valid Buildkite release secret key

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,14 +199,21 @@ token.
 
 The release step's tag condition prevents accidental publication; it is not a
 secret boundary because pull-request code can upload arbitrary Buildkite
-steps. `BUILDKITE_GHA_GITHUB_RELEASE_TOKEN` must be a Buildkite Secret that is
-unavailable to the public CI pipeline. Run tagged releases in a dedicated
-release pipeline configured to build upstream tags only, and restrict the
-secret's access policy to that pipeline's immutable `pipeline_id` and webhook
-`build_source`. The webhook policy does not distinguish tag and pull-request
-webhooks, so the release pipeline's tag-only provider filter is a load-bearing
-part of this boundary. Do not expose the token through a shared agent
-environment hook or to ordinary branch and pull-request jobs.
+steps. Create a fine-grained GitHub token scoped only to this repository with
+Contents read/write permission, then store it as the `GITHUB_RELEASE_TOKEN`
+Buildkite Secret in the release pipeline's cluster. Run tagged releases in a
+dedicated release pipeline configured to build upstream tags only, and use an
+access policy containing only that pipeline's immutable ID and webhook source:
+
+```yaml
+- pipeline_id: "<release-pipeline-uuid>"
+  build_source: "webhook"
+```
+
+The webhook policy does not distinguish tag and pull-request webhooks, so the
+release pipeline's tag-only provider filter is a load-bearing part of this
+boundary. Do not expose the token through a shared agent environment hook or to
+ordinary branch and pull-request jobs.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ token.
 The release step's tag condition prevents accidental publication; it is not a
 secret boundary because pull-request code can upload arbitrary Buildkite
 steps. Create a fine-grained GitHub token scoped only to this repository with
-Contents read/write permission, then store it as the `GITHUB_RELEASE_TOKEN`
+Contents read/write permission, then store it as the `GHA_GITHUB_RELEASE_TOKEN`
 Buildkite Secret in the release pipeline's cluster. Run tagged releases in a
 dedicated release pipeline configured to build upstream tags only, and use an
 access policy containing only that pipeline's immutable ID and webhook source:

--- a/scripts/ci-buildkite-release
+++ b/scripts/ci-buildkite-release
@@ -23,8 +23,8 @@ tag_commit="$(git rev-list -n 1 "$BUILDKITE_TAG^{commit}")" || die 'release tag 
 [[ "$tag_commit" == "$BUILDKITE_COMMIT" ]] || die "tag resolves to ${tag_commit}, not BUILDKITE_COMMIT"
 [[ "$(git rev-parse HEAD)" == "$BUILDKITE_COMMIT" ]] || die 'checked-out HEAD does not match BUILDKITE_COMMIT'
 
-github_token="$(buildkite-agent secret get GITHUB_RELEASE_TOKEN)"
+github_token="$(buildkite-agent secret get GHA_GITHUB_RELEASE_TOKEN)"
 github_token="${github_token//$'\r'/}"
-[[ -n "$github_token" ]] || die 'GITHUB_RELEASE_TOKEN is empty'
+[[ -n "$github_token" ]] || die 'GHA_GITHUB_RELEASE_TOKEN is empty'
 export GITHUB_TOKEN="$github_token"
 goreleaser release --clean

--- a/scripts/ci-buildkite-release
+++ b/scripts/ci-buildkite-release
@@ -23,8 +23,8 @@ tag_commit="$(git rev-list -n 1 "$BUILDKITE_TAG^{commit}")" || die 'release tag 
 [[ "$tag_commit" == "$BUILDKITE_COMMIT" ]] || die "tag resolves to ${tag_commit}, not BUILDKITE_COMMIT"
 [[ "$(git rev-parse HEAD)" == "$BUILDKITE_COMMIT" ]] || die 'checked-out HEAD does not match BUILDKITE_COMMIT'
 
-github_token="$(buildkite-agent secret get BUILDKITE_GHA_GITHUB_RELEASE_TOKEN)"
+github_token="$(buildkite-agent secret get GITHUB_RELEASE_TOKEN)"
 github_token="${github_token//$'\r'/}"
-[[ -n "$github_token" ]] || die 'BUILDKITE_GHA_GITHUB_RELEASE_TOKEN is empty'
+[[ -n "$github_token" ]] || die 'GITHUB_RELEASE_TOKEN is empty'
 export GITHUB_TOKEN="$github_token"
 goreleaser release --clean


### PR DESCRIPTION
## Summary
- replace the invalid `BUILDKITE_GHA_GITHUB_RELEASE_TOKEN` Buildkite Secret key with the project-scoped `GHA_GITHUB_RELEASE_TOKEN`
- document the required fine-grained GitHub permission and release-pipeline-only access policy

Buildkite Secret keys cannot begin with `BUILDKITE` or `BK`, so the previous release credential could not be created.

## Validation
- `mise run lint:shell`
- `bash -n scripts/ci-buildkite-release`
- `git diff --check`