### PR TITLE
docs: clarify current product experience

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -103,7 +103,7 @@ steps:
   - label: ":rocket: Publish release"
     key: "publish-release"
     # Credential isolation is enforced by the external Buildkite Secret policy,
-    # not by this scheduling condition. See README.md.
+    # not by this scheduling condition. See docs/development.md.
     if: build.tag != null
     plugins:
       - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:

--- a/README.md
+++ b/README.md
@@ -22,14 +22,19 @@ to your Buildkite `pipeline.yml`:
 ```yaml
 steps:
   - label: ":github: Test"
+    key: "gha-ci"
     plugins:
-      - github-actions#v0.1.0:
+      - github-actions#aca805f6eb2965201d4edaa57f3eec8ef9ea7ccb:
           workflow: .github/workflows/ci.yml
 ```
 
-The plugin downloads and verifies the matching `buildkite-gha` release,
-derives the event context from the Buildkite build, and uploads the generated
-jobs to the fixed `hosted` queue.
+The companion plugin has not published a `v0.1.0` tag yet, so this preview
+example pins its reviewed initial commit. Use `github-actions#v0.1.0` after that
+tag is published; do not replace the pin with a floating branch.
+
+The plugin downloads and verifies `buildkite-gha` v0.1.0 by default, derives the
+event context from the Buildkite build, and uploads the generated jobs to the
+fixed `hosted` queue.
 
 Configure push, pull request, schedule, and manual triggers in Buildkite.
 The workflow's `on:` block describes GitHub Actions events; it does not create
@@ -45,7 +50,7 @@ steps:
   - label: ":github: Test"
     key: "gha-ci"
     plugins:
-      - github-actions#v0.1.0:
+      - github-actions#aca805f6eb2965201d4edaa57f3eec8ef9ea7ccb:
           workflow: .github/workflows/ci.yml
 
   - label: ":rocket: Deploy"
@@ -67,15 +72,15 @@ The plugin path currently supports:
 - supported local and public Dockerfile actions;
 - static matrices, `needs`, conditions, outputs, and local reusable workflows;
 - background, wait, cancellation, and parallel step controls;
-- timeouts, `continue-on-error`, masking, summaries, and pre/main/post actions;
-  and
+- timeouts, `continue-on-error`, masking, and pre/main/post actions; and
 - public, credential-free checkout of the event repository at its exact commit.
 
-It does **not** currently admit:
+It does **not** currently support:
 
 - private repositories or private actions;
 - workflow secrets, `GITHUB_TOKEN`, GitHub-compatible OIDC, or protected queues;
 - `actions/cache`, `actions/upload-artifact`, or `actions/download-artifact`;
+- publishing `GITHUB_STEP_SUMMARY` content to the Buildkite UI;
 - job containers or service containers through the production plugin path;
 - privileged containers, arbitrary Docker options, or `docker://` actions; or
 - Windows or macOS jobs.

--- a/README.md
+++ b/README.md
@@ -36,9 +36,11 @@ The plugin downloads and verifies `buildkite-gha` v0.1.0 by default, derives the
 event context from the Buildkite build, and uploads the generated jobs to the
 fixed `hosted` queue.
 
-Configure push, pull request, schedule, and manual triggers in Buildkite.
-The workflow's `on:` block describes GitHub Actions events; it does not create
-or change Buildkite triggers.
+Configure branch, tag, and pull request triggers in Buildkite. The plugin
+derives a `pull_request` context for pull request builds and a `push` context
+for every other build. Scheduled and manual Buildkite builds therefore do not
+receive `schedule` or `workflow_dispatch` contexts or dispatch inputs. The
+workflow's `on:` block does not create or change Buildkite triggers.
 
 ### Mix imported and native jobs
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ The plugin path currently supports:
 - Linux Bash and `sh` steps;
 - JavaScript, composite, local, and anonymous public actions;
 - supported local and public Dockerfile actions;
-- static matrices, `needs`, conditions, outputs, and local reusable workflows;
+- static matrices, `needs`, outputs, and local reusable workflows;
+- the currently implemented job and step condition subset;
 - background, wait, cancellation, and parallel step controls;
 - timeouts, `continue-on-error`, masking, and pre/main/post actions; and
 - public, credential-free checkout of the event repository at its exact commit.
@@ -82,6 +83,8 @@ It does **not** currently support:
 - private repositories or private actions;
 - workflow secrets, `GITHUB_TOKEN`, GitHub-compatible OIDC, or protected queues;
 - `actions/cache`, `actions/upload-artifact`, or `actions/download-artifact`;
+- runtime condition access to the `github.event` payload;
+- exhaustive validation of condition functions before execution;
 - publishing `GITHUB_STEP_SUMMARY` content to the Buildkite UI;
 - job containers or service containers through the production plugin path;
 - privileged containers, arbitrary Docker options, or `docker://` actions; or
@@ -120,7 +123,9 @@ buildkite-gha validate \
 
 An `admitted` result means the plans satisfy upload policy. It does not execute
 the workflow or prove that arbitrary action code is independent of GitHub-only
-services. JSON output is available with `--format json`.
+services. Condition validation is also not yet exhaustive: some unsupported
+functions or runtime contexts fail only when the job runs. JSON output is
+available with `--format json`.
 
 ## What gets translated?
 

--- a/README.md
+++ b/README.md
@@ -1,355 +1,166 @@
 # buildkite-gha
 
-`buildkite-gha` is an experimental compatibility layer for running GitHub
-Actions workflows as native Buildkite builds. It will compile workflow jobs
-into Buildkite pipeline jobs and execute each job's Actions steps inside a
-compatibility runtime, without creating a GitHub Actions run.
+Run a GitHub Actions workflow as native Buildkite jobs—without creating a
+GitHub Actions run.
 
-The Phase 0 semantic foundation, Phase 1 static compiler, Phase 2 shell
-runtime, Phase 3 concurrent-step runtime, Phase 4 JavaScript/composite action
-runtime, and Phase 5 container runtime are implemented. The compiler validates
-the supported graph, expands local reusable workflows and matrices, applies
-queue policy, produces immutable job plans, and emits a Buildkite pipeline.
+`buildkite-gha` translates each workflow job (and each static matrix entry)
+into a Buildkite job, then runs that job's Actions steps in a compatibility
+runtime. Buildkite remains the source of truth for scheduling, logs, retries,
+cancellation, and the build UI.
 
-## Quick start
+> [!IMPORTANT]
+> This is an experimental v0.1 preview for **public, tokenless, Linux x86-64
+> workflows**. It deliberately rejects workflows that need private source,
+> secrets, provider tokens, or other protected capabilities.
 
-For a public GitHub repository on a Linux x86-64 Buildkite importer agent, add
-the
-[GitHub Actions Buildkite plugin](https://github.com/buildkite-plugins/github-actions-buildkite-plugin)
-to `pipeline.yml`:
+## Try an existing workflow
+
+Add the [GitHub Actions Buildkite
+plugin](https://github.com/buildkite-plugins/github-actions-buildkite-plugin)
+to your Buildkite `pipeline.yml`:
 
 ```yaml
 steps:
-  - label: ":github: GitHub Actions"
+  - label: ":github: Test"
     plugins:
       - github-actions#v0.1.0:
           workflow: .github/workflows/ci.yml
 ```
 
-The plugin downloads and verifies the matching public CLI distribution. The
-CLI derives the event snapshot from Buildkite, compiles the workflow, and
-uploads native Buildkite jobs to the fixed `hosted` queue. GitHub Actions `on:`
-does not configure Buildkite triggers; configure those on the Buildkite
-pipeline and select the workflow explicitly in the plugin.
+The plugin downloads and verifies the matching `buildkite-gha` release,
+derives the event context from the Buildkite build, and uploads the generated
+jobs to the fixed `hosted` queue.
 
-This v0.1 preview is intended for public, tokenless workflows. It covers shell,
-JavaScript, composite, local, and supported Dockerfile actions, plus matrices,
-local reusable workflows, conditions, job dependencies, concurrent steps,
-services, and job containers in the underlying runtime. The drop-in upload
-path remains narrower: private actions, workflow secrets, GitHub-compatible
-OIDC, artifact/cache actions, privileged queues, and job or service containers
-fail closed. Use a disposable job VM when the workflow needs host isolation.
+Configure push, pull request, schedule, and manual triggers in Buildkite.
+The workflow's `on:` block describes GitHub Actions events; it does not create
+or change Buildkite triggers.
 
-## Commands
+### Mix imported and native jobs
 
-The current command surface is:
-
-```text
-buildkite-gha validate [--event-path <path>] [--profile hosted-tokenless] [--format text|json] <workflow>
-buildkite-gha compile --event-path <path> [--format pipeline|ir-json] <workflow>
-buildkite-gha upload [--event-path <path>] --runtime-queue hosted <workflow>
-buildkite-gha run-job --plan <path> [--result <path>]
-```
-
-`compile` writes deterministic Buildkite pipeline YAML by default;
-`--format ir-json` exposes the owned compiler IR for inspection. The event file
-must contain the provider, event name, repository owner and name, ref, SHA,
-actor, and payload snapshot. Static matrices support source-ordered products,
-`include`, `exclude`, typed scalar values, and exact dependency fan-out. Local
-reusable workflows are flattened with bounded depth and graph size. Runner
-labels are mapped through a fail-closed policy, and unattested event files can
-target only the untrusted queue. The emitted YAML references content-addressed
-plans and the exact compiler executable, but `compile` does not materialize or
-upload those artifacts.
-
-`upload` is the Buildkite importer path for unattested compatibility events. It
-requires `BUILDKITE_STEP_KEY`. With `--event-path`, it reads an explicit event
-file; without one, it derives a bounded GitHub compatibility snapshot from the
-current Buildkite repository, commit, branch, tag, or pull-request environment.
-Buildkite repository and author fields can be modified or unverified, and pull
-requests deliberately use the exact Buildkite commit with a
-`refs/pull/<number>/head` compatibility ref rather than claiming GitHub merge
-semantics. Neither input mode authorizes protected capabilities. The command
-compiles the deterministic bundle, materializes and uploads the exact
-executable and every content-addressed plan, then uses
-`buildkite-agent pipeline upload --no-interpolation --reject-secrets`. Generated
-jobs skip checkout, download their artifacts from the exact importer into a
-fresh temporary directory, verify their digests, and run the plan.
-This tokenless development path requires `--runtime-queue hosted` and rejects
-every other queue. Its supported Linux label mapping and queue allowlist are
-fixed independently of the flag value, so CLI input cannot grant access to
-another queue. The path remains `EventUntrusted`, ambient-clean, and tokenless;
-only capability-free jobs, jobs whose sole declared capability is `network`,
-and jobs whose `docker` capability was derived by the same compiler invocation
-solely from supported Dockerfile actions are accepted. Local and anonymously
-resolved public Dockerfile actions may run through that last boundary. Private
-remote action or repository source, provider tokens, secrets, job or service
-containers, privileged queues, and all other protected capabilities fail
-closed.
-The path is intentionally unsigned: ordinary Buildkite dynamic uploads do not
-need plan signing merely to run public, tokenless code.
-
-For workflows containing JavaScript actions, `mise --no-config` installs
-exactly Node 20.20.2 or 24.18.0 through its pinned core backend. The runtime
-digest-verifies and directly invokes that Node executable, so repository mise
-configuration and `MISE_*` workflow environment overrides cannot change
-compatibility selection. Shell-step environments are unaffected.
-For action workflows, the plugin installs and verifies mise 2026.5.12 when
-needed. The importer uploads a deterministic compressed copy as a
-content-addressed artifact. Generated jobs verify and use that copy, so neither
-the importer nor the fixed hosted queue needs mise preinstalled. Generated
-action jobs automatically attach a pipeline-scoped Buildkite cache volume for
-mise-managed Node installations. Cache misses remain correct, and cached Node
-executables are checked against the official Linux x86-64 release digest and
-reinstalled on mismatch before use. Job containers bind-mount that verified
-host Node executable; mise is not required in the image. Node executables are
-never release or Buildkite artifacts.
-
-`run-job` consumes a versioned job plan and executes Linux Bash and sh steps in
-a fresh checkout-free workspace. The runtime supports env and working-directory
-precedence, file commands, job and step conditions, bounded prerequisite
-results and outputs supplied by the transport layer, timeouts, process-tree
-cancellation, `::add-mask` log and result protection, and step
-`continue-on-error`. Background steps, targeted and full barriers, explicit
-cancellation, and parallel groups share a ten-active-step supervisor. Their
-effects and failures become visible only at the covering barrier, and an
-implicit final barrier runs before bounded cleanup. On Unix, cancellation sends
-`SIGINT` to the complete step process group, escalates to `SIGTERM` after 7.5
-seconds, then uses `SIGKILL` after another 2.5 seconds. GitHub uses the same
-timing against only the direct process; the bridge intentionally terminates the
-complete process tree. Other workflow commands are not yet implemented. Secret
-names resolve only through the explicit
-`BUILDKITE_GHA_SECRET_` namespace and are registered with the Buildkite Agent
-redactor before execution. Action-resolved v3 plans additionally support managed
-Node 20/24 JavaScript actions, local and nested composite actions, global LIFO
-pre/main/post lifecycle, and anonymous public GitHub action sources bound to
-exact commits and verified repository digests. The narrow tokenless checkout
-adapter accepts only github.com, the public event repository, its exact event
-SHA, the workspace root, and a credential-free shallow fetch; private checkout,
-provider tokens, alternate repositories or refs, and credential persistence
-remain deferred. Action resolution is independent of event trust. Normal
-`upload` accepts capability-free local actions and anonymous public actions
-that require only network access, plus the supported Dockerfile-action subset
-when its `docker` capability has same-process compiler provenance. Dockerfile
-actions run from a private staged copy of the verified source, require the local
-Buildx `default` Docker driver, use fixed workspace and file-command mounts, and
-receive runtime-owned names and labels with bounded cleanup. Docker and host
-steps share the job's security boundary; installations that require host-level
-isolation must run each job in a disposable VM.
-
-Schema-v4 plans additionally support one persistent job container and declared
-service containers. Shell, JavaScript, and composite steps execute in the job
-container; Dockerfile actions and services run as siblings on one runtime-owned
-network. Container jobs reach services by their service IDs. Host jobs remain
-host processes and reach published service ports through
-`127.0.0.1:${{ job.services.<id>.ports[<port>] }}`; sibling Dockerfile actions
-join the service network. Declared image users remain in effect, service and
-Docker-action entrypoints are preserved, and the runtime owns the persistent
-job-container command. Images are pulled anonymously with a private Docker
-configuration. Runtime names, networks, labels, mounts, process trees, and
-cleanup are owned exactly and cleaned under bounded contexts.
-
-Only literal public images, environment values, and ports are accepted.
-Credentials, private registries, arbitrary Docker options or volumes,
-privileged containers, host Docker socket mounts, devices, arbitrary host
-mounts, and `docker://` action images remain unsupported. Production
-`hosted-tokenless` upload also continues to reject job- and service-container
-provenance: the broader container runtime is currently exercised through the
-checked-in compiler-to-Runner hosted proof, while normal upload admits only the
-compiler-proven Dockerfile-action slice. In Buildkite,
-`run-job` verifies the exact build, job, step, and plan digest before resolving
-each prerequisite from its attributed producer artifact, then publishes the
-terminal result under a bounded cleanup context; metadata is only a best-effort
-mirror. Identity, plan-decode, and digest failures happen before a producer can
-publish a verified manifest, and retrying a producer can make artifact selection
-ambiguous;
-consumers fail closed in both cases, so retry the whole build. Use
-`buildkite-gha help`, `buildkite-gha help <command>`, or
-`buildkite-gha --version` for exact usage.
-
-Public, anonymous, tokenless actions on the fixed hosted queue do not need a
-supporting service. Future protected capabilities—private source, GitHub tokens,
-secrets, environments, compatible OIDC, and privileged queues—will use a
-control-plane service authenticated with Buildkite Job OIDC. That service must
-independently verify GitHub event provenance and customer policy before issuing
-a narrow, expiring grant. Canonical plan digests protect transport integrity;
-they do not authorize those capabilities. Buildkite pipeline signing remains
-optional installation-specific defence in depth.
-
-## Installation
-
-The plugin in [Quick start](#quick-start) is the recommended installation. For
-direct CLI use, install `mise`; the runtime asks it to install and cache exact
-Node 20.20.2 and 24.18.0 versions as needed. Direct `upload` invocation requires
-mise 2026.5.12 on the importer `PATH` for action workflows; `validate` and
-`compile` do not install Node or require mise. The official mise-installed Node
-binaries used by JavaScript actions require glibc 2.28 or newer; the static Go
-CLI does not. Download
-`buildkite-gha_Linux_x86_64.tar.gz` and `checksums.txt`
-from the GitHub release, verify the archive against the checksum file, and
-extract it to a stable location. The archive contains only `buildkite-gha` and
-`LICENSE`.
-
-Maintainers run `mise run release` from a clean, up-to-date `main`. This creates
-and pushes the next conventional-commit-derived v0 tag. The resulting webhook
-build runs the repository checks, then creates the GitHub release and uploads
-the archive and checksum. A failed publication can be retried from the same tag
-build; existing draft assets are replaced.
-The source repository must be public before the initial tag is pushed because
-the companion plugin intentionally downloads release assets without a GitHub
-token.
-
-The release step's tag condition prevents accidental publication; it is not a
-secret boundary because pull-request code can upload arbitrary Buildkite
-steps. Create a fine-grained GitHub token scoped only to this repository with
-Contents read/write permission, then store it as the `GHA_GITHUB_RELEASE_TOKEN`
-Buildkite Secret in the pipeline's cluster. Restrict it to webhook-created `v*`
-tag builds in this pipeline:
+The imported workflow is an ordinary dynamic part of the Buildkite pipeline.
+A native job can depend on the importer and will wait for the jobs it uploads:
 
 ```yaml
-- pipeline_id: "019f8835-5873-4a64-850e-ba117a339d87"
-  build_source: "webhook"
-  build_branch: "v*"
+steps:
+  - label: ":github: Test"
+    key: "gha-ci"
+    plugins:
+      - github-actions#v0.1.0:
+          workflow: .github/workflows/ci.yml
+
+  - label: ":rocket: Deploy"
+    key: "deploy"
+    depends_on: "gha-ci"
+    command: .buildkite/deploy.sh
 ```
 
-Buildkite records a tag webhook's tag name as its build branch, so the source and
-branch claims exclude ordinary branch and pull-request webhook builds. The
-publisher independently verifies that the upstream tag, checked-out commit, and
-Buildkite commit agree before retrieving the token. Do not expose the token
-through a shared agent environment hook.
+This gives teams a migration path: start with the existing Actions workflow,
+then move work into native Buildkite jobs over time. Automatic replacement of
+a named imported job is planned, but is not part of this preview.
 
-## Development
+## Is my workflow a fit?
 
-The repository pins Go and its lint tools with mise. Trust the configuration
-once, then install the toolchain:
+The plugin path currently supports:
+
+- Linux Bash and `sh` steps;
+- JavaScript, composite, local, and anonymous public actions;
+- supported local and public Dockerfile actions;
+- static matrices, `needs`, conditions, outputs, and local reusable workflows;
+- background, wait, cancellation, and parallel step controls;
+- timeouts, `continue-on-error`, masking, summaries, and pre/main/post actions;
+  and
+- public, credential-free checkout of the event repository at its exact commit.
+
+It does **not** currently admit:
+
+- private repositories or private actions;
+- workflow secrets, `GITHUB_TOKEN`, GitHub-compatible OIDC, or protected queues;
+- `actions/cache`, `actions/upload-artifact`, or `actions/download-artifact`;
+- job containers or service containers through the production plugin path;
+- privileged containers, arbitrary Docker options, or `docker://` actions; or
+- Windows or macOS jobs.
+
+The underlying runtime has broader container coverage than the production
+plugin currently exposes. See the [compatibility and CLI guide](docs/compatibility.md)
+for the exact distinction and intentional behavior differences.
+
+## Check before running
+
+Static validation does not contact Buildkite or execute the workflow:
 
 ```sh
-mise trust mise.toml
-mise install
+buildkite-gha validate .github/workflows/ci.yml
 ```
 
-Run the repository checks with:
+For example, a workflow with one producer and a two-entry consumer matrix
+reports:
 
-```sh
-mise run check
+```text
+Workflow: .github/workflows/ci.yml
+Result: compilable
+✓ 2 logical jobs and 3 static instances compile
 ```
 
-The command verifies formatting, builds the commands, runs the standard and
-race-enabled tests, runs `go vet`, golangci-lint, and shellcheck, and checks the
-signed plan-envelope fixtures. `make check` remains as a convenience alias.
-
-### Smoke and compatibility preflight
-
-Run the network-free smoke inventory with:
+To also resolve public actions and apply the same policy as the plugin's
+`hosted-tokenless` upload, provide an event snapshot:
 
 ```sh
-mise run smoke:local
-```
-
-This validates the manifest, performs static workflow validation, and compiles
-the supported fixtures twice to verify deterministic output. It also checks
-the expected-negative classifications: workflows using the official GitHub
-artifact and cache actions compile but remain runtime-unsupported. Job and
-service container fixtures compile deterministically and are classified
-`runtime-pass` from the exact-commit hosted Phase 5 proof, while remaining
-outside production `hosted-tokenless` admission. A passing local smoke run is
-compile-time evidence only; it is explicitly not proof that a workflow runs
-successfully.
-
-For an opt-in public-network preflight, run:
-
-```sh
-mise run smoke:profile
-```
-
-This anonymously resolves the selected public actions and applies the same
-`hosted-tokenless` production admission policy used by `upload`, without
-installing or executing Node. The known official artifact and cache actions
-compile but fail admission until the Phase 6 adapters exist. An `admitted`
-result is not runtime proof and does not imply that an arbitrary admitted
-action is executable or independent of GitHub-only services.
-
-Use the same policy as a focused workflow compatibility preflight, with either
-human-readable or machine-readable output:
-
-```sh
-buildkite-gha validate --profile hosted-tokenless \
-  --event-path .buildkite/events/current.json --format text \
-  .github/workflows/ci.yml
-
-buildkite-gha validate --profile hosted-tokenless \
-  --event-path .buildkite/events/current.json --format json \
+buildkite-gha validate \
+  --profile hosted-tokenless \
+  --event-path .buildkite/events/current.json \
   .github/workflows/ci.yml
 ```
 
-To aggregate the implemented hosted runtime proofs in one exact-commit build:
+An `admitted` result means the plans satisfy upload policy. It does not execute
+the workflow or prove that arbitrary action code is independent of GitHub-only
+services. JSON output is available with `--format json`.
 
-```sh
-commit=$(git rev-parse HEAD)
-test ${#commit} -eq 40
-bk build create --pipeline buildkite/buildkite-gha \
-  --branch "$(git branch --show-current)" --commit "$commit" \
-  --env SMOKE_PROBE=hosted --env SMOKE_COMMIT="$commit" --yes
+## What gets translated?
+
+| GitHub Actions | Buildkite |
+| --- | --- |
+| Workflow run | Build |
+| Job | Command job |
+| Matrix entry | Command job with a stable key |
+| `needs` | `depends_on` plus verified result transport |
+| `runs-on` | Fail-closed queue policy |
+| Job output | Producer-attributed result artifact |
+| Step | Runs inside the job compatibility runtime |
+
+Steps are intentionally **not** translated into separate Buildkite jobs. They
+share a workspace, environment changes, action state, containers, and
+post-action lifecycle in GitHub Actions, so they must stay inside one job here
+too.
+
+```diagram
+┌──────────────────────────┐
+│ Actions workflow + event │
+└────────────┬─────────────┘
+             ▼
+┌──────────────────────────┐
+│ Validate and compile     │
+│ jobs, matrices, policy   │
+└────────────┬─────────────┘
+             ▼
+┌──────────────────────────┐
+│ Native Buildkite jobs    │
+│ one runtime per GHA job  │
+└────────────┬─────────────┘
+             ▼
+┌──────────────────────────┐
+│ Buildkite logs + results │
+└──────────────────────────┘
 ```
 
-The aggregate collects the Phase 2 shell/upload proof, Phase 3 concurrent-step
-proof, Phase 4 public-action proof, and three Phase 5 proofs: hosted Docker
-capabilities, the production Dockerfile-action slice, and the complete
-compiler-to-Runner container runtime. It retains each phase's independent
-importer and continuation loader rather than flattening their topology. The
-phase-specific selectors below remain available for targeted diagnosis.
+## Documentation
 
-The gated live development proof uses the same pinned mise plugin as repository
-checks. Start an exact-commit build with `PHASE2_PROBE=upload` and
-`PHASE2_COMMIT=<full commit>` to load `.buildkite/phase-2-upload.yml`. The
-exact-commit importer runs on `elastic-runners`; generated checkout-free jobs
-run on the ephemeral `hosted` queue, whose Agent version supports native
-checkout suppression.
+- [Compatibility, behavior differences, and direct CLI use](docs/compatibility.md)
+- [Development, smoke tests, and releases](docs/development.md)
+- [Active product and implementation plan](docs/plans/2026-07-22-buildkite-gha.md)
+- [Architecture decisions](docs/architecture/)
 
-The Phase 3 proof uses the same importer boundary. Start an exact-commit build
-with `PHASE3_PROBE=concurrent` and `PHASE3_COMMIT=<full commit>` to load
-`.buildkite/phase-3-upload.yml`. To run the matching GitHub-hosted differential,
-dispatch `.github/workflows/phase-0-shell-oracle.yml` on that ref with the same
-`source_commit` and `target=concurrent`.
-
-The Phase 4 proof is deliberately split because this repository is private and
-the implemented checkout boundary is public and tokenless. Start an exact-commit
-build with `PHASE4_PROBE=actions` and `PHASE4_COMMIT=<full commit>` to load
-`.buildkite/phase-4-upload.yml`. Its policy-controlled importer compiles an
-unattested synthetic public event in `testdata/phase4` by invoking the exact
-built production CLI; the separate continuation loader remains. Generated jobs
-anonymously check out the exact pinned `actions/checkout` commit, execute pinned
-`setup-node` and `setup-go`, verify exact tool versions, and settle before the
-native Buildkite continuation. `.github/workflows/phase-4-actions-oracle.yml`
-separately runs on GitHub against this private repository to exercise local
-JavaScript/composite outputs and lifecycle. The split does not claim that
-Buildkite executed those private local actions; Buildkite runtime coverage for
-them remains in the conformance suite. The production-upload evidence is
-[Buildkite build 79](https://buildkite.com/buildkite/buildkite-gha/builds/79)
-and [GitHub Actions run 30069516646](https://github.com/buildkite/buildkite-gha/actions/runs/30069516646),
-both against exact implementation commit
-`c5b9c56762e94ce2084a7fe7223c5f18a432e2bc`. Historical
-[Buildkite build 72](https://buildkite.com/buildkite/buildkite-gha/builds/72)
-remains evidence for the former proof importer.
-
-The Phase 5 Dockerfile-action proof uses the same policy-controlled importer
-and pinned public action as its GitHub-hosted differential. Start an exact-commit
-build with `PHASE5_PROBE=docker-action` and `PHASE5_COMMIT=<full commit>` to
-load `.buildkite/phase-5-docker-action.yml`. The generated checkout-free job
-builds and runs the verified action on `hosted`, propagates its output, and must
-settle before the separately uploaded native Buildkite continuation. The
-matching differential is
-`.github/workflows/phase-5-docker-action-oracle.yml`.
-
-The complete Phase 5 runtime proof is intentionally separate from production
-upload admission. Start an exact-commit build with `PHASE5_PROBE=runtime` and
-`PHASE5_COMMIT=<full commit>` to load `.buildkite/phase-5-runtime.yml`. It runs
-the checked-in two-job fixture through the compiler and Runner on hosted Docker,
-covering persistent container state, services from container and host jobs,
-JavaScript/composite/Dockerfile actions, process-tree cancellation, diagnostics,
-masking, and exact cleanup. [Buildkite build 136](https://buildkite.com/buildkite/buildkite-gha/builds/136)
-passed all required live tests without skips against exact runtime-evidence
-commit `50db2cf89ba23c0e051d7d57cc03e115606768e5`.
+Use `buildkite-gha help`, `buildkite-gha help <command>`, or
+`buildkite-gha --version` for the exact installed command surface.
 
 ## License
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -40,6 +40,7 @@ artifact, cache, token, or OIDC service that this project does not provide.
 | Anonymous public actions | Supported | Sources are resolved to immutable commits and complete trees are verified. |
 | `actions/checkout` | Narrow support | Public `github.com` event repository, exact event SHA, workspace root, shallow credential-free fetch. |
 | Dockerfile actions | Supported subset | Only compiler-verified local or anonymous public Dockerfile actions are admitted. |
+| Step summaries | Not surfaced | The runtime processes `GITHUB_STEP_SUMMARY`, but production generated jobs do not publish it to the Buildkite UI. |
 | Job and service containers | Not admitted | Implemented and runtime-proven, but still outside production `hosted-tokenless` policy. |
 | `docker://` actions | Not supported | Private images, credentials, arbitrary options, volumes, and privileged containers are also rejected. |
 | Artifact and cache actions | Not supported | They compile but fail profile admission until Buildkite-backed adapters exist. |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -94,6 +94,13 @@ Buildkite. `buildkite-gha` uses the event snapshot to populate Actions contexts;
 it does not subscribe to GitHub events or turn workflow `on:` entries into
 Buildkite triggers.
 
+The plugin derives `pull_request` for Buildkite pull request builds and `push`
+for branch, tag, scheduled, and manual builds. It does not currently provide
+`schedule` or `workflow_dispatch` contexts or dispatch inputs. A scheduled or
+manual trigger is therefore compatible only when the workflow expects push
+semantics. The direct CLI accepts explicit event snapshots as documented below,
+but the plugin does not expose that option yet.
+
 For pull requests, the plugin uses the exact Buildkite commit and a
 `refs/pull/<number>/head` compatibility ref. It does not claim GitHub's merge-ref
 semantics when Buildkite has not supplied them.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -33,7 +33,7 @@ artifact, cache, token, or OIDC service that this project does not provide.
 | Static job graphs and `needs` | Supported | Dependencies and logical results are preserved. |
 | Static matrices | Supported | Includes typed values, `include`, `exclude`, and exact dependency fan-out. |
 | Local reusable workflows | Supported when statically resolvable | Remote and runtime-dependent reusable workflows are deferred. |
-| Job and step conditions | Supported subset | Unsupported expression forms fail validation rather than being approximated. |
+| Job and step conditions | Supported subset | Syntax is checked, but not every runtime function or context limitation is preflighted. Some unsupported expressions fail only when the job runs. |
 | Concurrent step controls | Supported | Includes `background`, `wait`, `wait-all`, `cancel`, and `parallel`. |
 | JavaScript actions | Supported | Managed, digest-verified Node 20 and 24 runtimes are used. |
 | Composite and local actions | Supported | Nested composites and global pre/main/post ordering are supported. |
@@ -193,9 +193,13 @@ not call Buildkite, install Node, or execute workflow code.
 }
 ```
 
-This snapshot keeps compile-time and runtime Actions contexts consistent. It is
-compatibility data, not proof that the event is trustworthy, and cannot
-authorize a protected capability.
+The snapshot supplies the compile-time Actions context. Generated plans retain
+the event name, repository, ref, SHA, actor, and a payload digest, but not the
+payload object itself. Runtime conditions can use those retained identity fields
+but cannot currently access `github.event`; an expression such as
+`github.event.action` may therefore pass validation and fail when the job runs.
+The snapshot is compatibility data, not proof that the event is trustworthy,
+and cannot authorize a protected capability.
 
 ### Compile
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,228 @@
+# Compatibility and CLI guide
+
+This guide describes the behavior available to users today. The
+[active plan](plans/2026-07-22-buildkite-gha.md) also contains implemented
+internals, future product ideas, and deferred decisions; those are not support
+promises unless they appear here.
+
+## The current execution profile
+
+The plugin and `upload` command use one fixed profile: `hosted-tokenless`.
+It is designed for public code that can run without protected credentials on a
+Linux x86-64 Buildkite Hosted Agent. Unsupported or privileged requests fail
+before the generated jobs are uploaded.
+
+There are three different compatibility claims:
+
+1. **Compilable** — the workflow syntax and static job graph can be translated.
+2. **Admitted** — action sources resolve and the generated plans satisfy the
+   `hosted-tokenless` upload policy.
+3. **Runtime-proven** — the repository's conformance or hosted test suite has
+   executed that behavior successfully.
+
+Compilation alone is not admission, and admission does not execute arbitrary
+action code. In particular, an otherwise valid action may depend on a GitHub
+artifact, cache, token, or OIDC service that this project does not provide.
+
+## Support matrix
+
+| Area | Production plugin | Notes |
+| --- | --- | --- |
+| Linux x86-64 host jobs | Supported | `ubuntu-latest`, `ubuntu-24.04`, and `ubuntu-22.04` map to the fixed `hosted` queue. |
+| Bash and `sh` steps | Supported | Includes environment and working-directory precedence. |
+| Static job graphs and `needs` | Supported | Dependencies and logical results are preserved. |
+| Static matrices | Supported | Includes typed values, `include`, `exclude`, and exact dependency fan-out. |
+| Local reusable workflows | Supported when statically resolvable | Remote and runtime-dependent reusable workflows are deferred. |
+| Job and step conditions | Supported subset | Unsupported expression forms fail validation rather than being approximated. |
+| Concurrent step controls | Supported | Includes `background`, `wait`, `wait-all`, `cancel`, and `parallel`. |
+| JavaScript actions | Supported | Managed, digest-verified Node 20 and 24 runtimes are used. |
+| Composite and local actions | Supported | Nested composites and global pre/main/post ordering are supported. |
+| Anonymous public actions | Supported | Sources are resolved to immutable commits and complete trees are verified. |
+| `actions/checkout` | Narrow support | Public `github.com` event repository, exact event SHA, workspace root, shallow credential-free fetch. |
+| Dockerfile actions | Supported subset | Only compiler-verified local or anonymous public Dockerfile actions are admitted. |
+| Job and service containers | Not admitted | Implemented and runtime-proven, but still outside production `hosted-tokenless` policy. |
+| `docker://` actions | Not supported | Private images, credentials, arbitrary options, volumes, and privileged containers are also rejected. |
+| Artifact and cache actions | Not supported | They compile but fail profile admission until Buildkite-backed adapters exist. |
+| Private repositories or actions | Not supported | The preview has no private-source capability broker. |
+| Secrets and provider tokens | Not supported | Includes `GITHUB_TOKEN`, GitHub App tokens, and protected environment grants. |
+| OIDC | Not supported | GitHub-compatible and migration OIDC flows are deferred. |
+| Windows and macOS | Not supported | Unmapped runner labels fail validation. |
+
+## User-visible behavior
+
+### Buildkite owns the run
+
+No shadow GitHub Actions run is created. Workflow jobs and matrix entries are
+visible as Buildkite jobs, with Buildkite scheduling, logs, cancellation,
+retries, and status.
+
+Actions steps remain inside one compatibility runtime because they share a
+workspace, environment-file updates, action state, and cleanup lifecycle.
+Docker is another execution backend within that job—not a security boundary
+between mutually untrusted steps. Use a disposable job VM when workflow code
+must be isolated from other jobs or the agent host.
+
+### Concurrent steps stay inside the job
+
+Background and parallel work use a bounded, ten-active-step supervisor rather
+than creating more Buildkite jobs. For example:
+
+```yaml
+steps:
+  - id: lint
+    run: ./scripts/lint
+    background: true
+
+  - id: test
+    run: ./scripts/test
+    background: true
+
+  - wait-all:
+```
+
+A background step's outputs, environment changes, and failures become visible
+at the covering `wait` or `wait-all`. Remaining work is joined by an implicit
+final `wait-all` before post-action cleanup. Use `cancel: <step-id>` for targeted
+cancellation or `parallel:` for a fixed inline group. These controls preserve
+one job workspace and lifecycle.
+
+### Buildkite owns triggers
+
+Select the workflow explicitly in the plugin and configure pipeline triggers in
+Buildkite. `buildkite-gha` uses the event snapshot to populate Actions contexts;
+it does not subscribe to GitHub events or turn workflow `on:` entries into
+Buildkite triggers.
+
+For pull requests, the plugin uses the exact Buildkite commit and a
+`refs/pull/<number>/head` compatibility ref. It does not claim GitHub's merge-ref
+semantics when Buildkite has not supplied them.
+
+### Checkout starts clean
+
+Generated jobs skip Buildkite's default checkout and allocate a fresh Actions
+workspace. A supported `actions/checkout` step performs a credential-free,
+shallow checkout of the public event repository at the exact event SHA. Private
+checkout, alternate repositories or refs, and credential persistence are not
+available in the preview.
+
+### Failures stay explicit
+
+Unsupported syntax, runner labels, action types, and protected capabilities
+fail closed. The bridge does not silently choose a nearby behavior.
+
+A runtime-skipped Actions job currently appears successful to Buildkite while
+publishing its logical `skipped` result. Downstream imported jobs use that
+logical result. This is a UI difference until Buildkite has a scheduler-visible
+skipped job state.
+
+If producer identity or result artifact selection becomes ambiguous—for
+example, after retrying an individual producer—consumers fail closed. Retry the
+whole build rather than one imported job.
+
+Cancellation targets the complete process tree: `SIGINT`, then `SIGTERM` after
+7.5 seconds, then `SIGKILL` after another 2.5 seconds. GitHub uses the same
+timing for the direct process, but `buildkite-gha` deliberately avoids leaving
+child processes behind.
+
+## Use the CLI directly
+
+The [plugin](https://github.com/buildkite-plugins/github-actions-buildkite-plugin)
+is the recommended installation. For direct use, download
+`buildkite-gha_Linux_x86_64.tar.gz` and `checksums.txt` from the matching GitHub
+[release](https://github.com/buildkite/buildkite-gha/releases), verify the
+archive checksum, and extract it to a stable location. The archive contains
+`buildkite-gha` and `LICENSE`.
+
+Action workflows also require mise 2026.5.12 on the importer `PATH` when
+invoking `upload` directly. The runtime uses it with repository configuration
+disabled to install exact Node 20.20.2 or 24.18.0 releases. Those Node binaries
+require glibc 2.28 or newer; the static Go CLI does not. `validate` and
+`compile` do not install Node or require mise.
+
+### Validate
+
+Validate the static workflow subset without an event:
+
+```sh
+buildkite-gha validate .github/workflows/ci.yml
+```
+
+Apply the production profile with human-readable or machine-readable output:
+
+```sh
+buildkite-gha validate --profile hosted-tokenless \
+  --event-path .buildkite/events/current.json --format text \
+  .github/workflows/ci.yml
+
+buildkite-gha validate --profile hosted-tokenless \
+  --event-path .buildkite/events/current.json --format json \
+  .github/workflows/ci.yml
+```
+
+Profile validation may access the public network to resolve actions. It does
+not call Buildkite, install Node, or execute workflow code.
+
+### Event snapshots
+
+`compile` and profile validation take an explicit, bounded event snapshot:
+
+```json
+{
+  "provider": "github",
+  "event": "push",
+  "repository": {
+    "owner": "acme",
+    "name": "widgets",
+    "clone_url": "https://github.com/acme/widgets.git",
+    "default_branch": "main"
+  },
+  "ref": "refs/heads/main",
+  "sha": "0123456789abcdef0123456789abcdef01234567",
+  "actor": "octocat",
+  "payload": {
+    "ref": "refs/heads/main"
+  }
+}
+```
+
+This snapshot keeps compile-time and runtime Actions contexts consistent. It is
+compatibility data, not proof that the event is trustworthy, and cannot
+authorize a protected capability.
+
+### Compile
+
+Render deterministic Buildkite pipeline YAML, or inspect the compiler IR:
+
+```sh
+buildkite-gha compile --event-path .buildkite/events/current.json \
+  .github/workflows/ci.yml
+
+buildkite-gha compile --event-path .buildkite/events/current.json \
+  --format ir-json .github/workflows/ci.yml
+```
+
+The pipeline output references content-addressed plans and the exact compiler
+executable. `compile` is read-only: it does not materialize those artifacts or
+upload a pipeline, so piping its output directly to a real Buildkite upload is
+not a complete execution path.
+
+### Upload
+
+`upload` is the in-build command used by the plugin:
+
+```sh
+buildkite-gha upload --runtime-queue hosted .github/workflows/ci.yml
+```
+
+It requires `BUILDKITE=true` and `BUILDKITE_STEP_KEY`. Without `--event-path`,
+it derives a bounded compatibility snapshot from the current Buildkite build.
+With `--event-path`, it uses that explicit snapshot. Both paths remain
+unattested and tokenless.
+
+The command uploads the exact executable and content-addressed plans before
+calling `buildkite-agent pipeline upload --no-interpolation --reject-secrets`.
+The queue argument is intentionally fixed to `hosted`; it cannot be used to
+select a more privileged queue.
+
+`run-job` is an internal command emitted into generated jobs. Users should not
+need to invoke it directly.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,143 @@
+# Development and release guide
+
+## Set up the toolchain
+
+The repository pins Go and all lint and release tools with mise:
+
+```sh
+mise trust mise.toml
+mise install
+```
+
+Run the complete repository check with:
+
+```sh
+mise run check
+```
+
+`check` verifies formatting, builds the commands, runs standard and
+race-enabled tests, runs `go vet`, golangci-lint, and shellcheck, validates the
+signed plan-envelope fixtures, checks deterministic smoke compilation, and
+validates the release configuration. `make check` is a convenience alias.
+
+Focused tasks are also available:
+
+```sh
+mise run format
+mise run build
+mise run test
+mise run test:race
+mise run lint:go
+mise run lint:shell
+mise run vet
+mise run plan-fixtures
+```
+
+## Understand the smoke lanes
+
+The smoke inventory deliberately separates three kinds of evidence.
+
+### Network-free compilation
+
+```sh
+mise run smoke:local
+```
+
+This validates the manifest and workflow syntax, then compiles each supported
+fixture twice to check deterministic output. Expected-negative fixtures are
+also checked. A pass is compile-time evidence only; it does not prove that a
+workflow executes successfully.
+
+See [`testdata/smoke/README.md`](../testdata/smoke/README.md) for the inventory
+and the precise meaning of each expectation.
+
+### Production-policy preflight
+
+```sh
+mise run smoke:profile
+```
+
+This opt-in networked lane anonymously resolves selected public actions and
+applies the same `hosted-tokenless` admission policy as production `upload`.
+It does not install Node or run action code. An `admitted` result is policy
+evidence, not runtime evidence.
+
+Known artifact and cache actions compile but fail admission. Job and service
+container fixtures have separate hosted runtime evidence but remain outside
+production admission.
+
+### Hosted runtime proofs
+
+Run all implemented hosted proofs against one exact commit:
+
+```sh
+commit=$(git rev-parse HEAD)
+test ${#commit} -eq 40
+bk build create --pipeline buildkite/buildkite-gha \
+  --branch "$(git branch --show-current)" --commit "$commit" \
+  --env SMOKE_PROBE=hosted --env SMOKE_COMMIT="$commit" --yes
+```
+
+The aggregate retains each phase's importer and continuation topology. Use a
+phase selector only for targeted diagnosis:
+
+| Coverage | Build environment |
+| --- | --- |
+| Sequential shell and upload | `PHASE2_PROBE=upload`, `PHASE2_COMMIT=<commit>` |
+| Concurrent step controls | `PHASE3_PROBE=concurrent`, `PHASE3_COMMIT=<commit>` |
+| Public JavaScript/composite actions | `PHASE4_PROBE=actions`, `PHASE4_COMMIT=<commit>` |
+| Hosted Docker prerequisites | `PHASE5_PROBE=capabilities`, `PHASE5_COMMIT=<commit>` |
+| Dockerfile action path | `PHASE5_PROBE=docker-action`, `PHASE5_COMMIT=<commit>` |
+| Complete container runtime | `PHASE5_PROBE=runtime`, `PHASE5_COMMIT=<commit>` |
+
+The phase definitions under `.buildkite/` and the [active
+plan](plans/2026-07-22-buildkite-gha.md#current-progress) document the exact
+coverage, differential oracles, commits, and historical Buildkite evidence.
+
+## Architecture and plans
+
+- [ADR 0001](architecture/0001-upstream-actions-reuse.md) explains why the
+  compiler uses actionlint while act and the official runner remain behavioral
+  references.
+- [ADR 0002](architecture/0002-plan-envelope-trust-boundary.md) preserves the
+  superseded Phase 0 signing experiment and its conformance history.
+- The [active plan](plans/2026-07-22-buildkite-gha.md) tracks implementation
+  phases, evidence, future UX, and deferred decisions. Current user-facing
+  behavior belongs in the [README](../README.md) and [compatibility
+  guide](compatibility.md), not only in the plan.
+
+## Publish a release
+
+From a clean, up-to-date `main`, run:
+
+```sh
+mise run release
+```
+
+The script runs `check`, chooses the next conventional-commit-derived v0 tag,
+and pushes it. The tag webhook build reruns repository checks, creates the
+GitHub release, and uploads the Linux x86-64 archive and checksum. Publication
+can be retried from the same tag build; existing draft assets are replaced.
+
+The source repository must be public before the first tag is pushed because the
+companion plugin intentionally downloads release assets without a GitHub token.
+
+### Release credential policy
+
+The pipeline tag condition prevents accidental publication, but it is not a
+secret boundary: pull request code can upload arbitrary Buildkite steps. Store
+a fine-grained GitHub token with repository-scoped Contents read/write access as
+the `GHA_GITHUB_RELEASE_TOKEN` Buildkite Secret, restricted to webhook-created
+`v*` tag builds in the release pipeline:
+
+```yaml
+- pipeline_id: "019f8835-5873-4a64-850e-ba117a339d87"
+  build_source: "webhook"
+  build_branch: "v*"
+```
+
+Buildkite records a tag webhook's tag name as the build branch, so these claims
+exclude ordinary branch and pull request webhook builds. The publisher also
+verifies that the upstream tag, checked-out commit, and Buildkite commit agree
+before retrieving the token. Never expose this token through a shared agent
+environment hook.

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -2,8 +2,14 @@
 
 Status: **Active**
 Date: 2026-07-22
-Last reviewed: 2026-07-24
+Last reviewed: 2026-07-27
 Target repository: `buildkite/buildkite-gha`
+
+> This is the active product and implementation plan. It records future UX,
+> implementation detail, delivery evidence, and deferred decisions together.
+> For behavior users can rely on today, start with the [README](../../README.md)
+> and [compatibility guide](../compatibility.md). A planned example is not a
+> support promise until it is reflected in those user-facing docs.
 
 ## Summary
 
@@ -194,6 +200,12 @@ them out of metadata, artifacts, generated YAML, and debug diagnostics.
   into that trust model.
 
 ## User experience
+
+This section preserves the intended product experience, including future
+syntax and migration features. The implemented command surface and current
+examples are documented in the [README](../../README.md) and [compatibility
+guide](../compatibility.md); implementation mechanics remain in this plan and
+the architecture records.
 
 ### Commands
 


### PR DESCRIPTION
## Summary

- turn the README into a concise onboarding path with quick-start, migration, compatibility, and validation examples
- add a current compatibility/CLI guide that distinguishes compilable, admitted, and runtime-proven behavior
- move contributor checks, hosted proof instructions, and release operations into a development guide
- make the active plan's current-vs-future status explicit and update the release pipeline's documentation pointer

## Validation

- `go test ./internal/cli ./internal/workflow`
- validated the documented concurrent-step example with `buildkite-gha validate`
- checked all local Markdown link targets
- `git diff --check`