### PR TITLE
Add durable Docker orb setup

### DIFF
--- a/.agents/resume
+++ b/.agents/resume
@@ -1,4 +1,96 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "No persistent services require restart."
+uid="$(id -u)"
+runtime_dir="/tmp/user-$uid"
+docker_data_dir="$HOME/.local/share/docker-rootless"
+docker_context="buildkite-gha-rootless"
+docker_endpoint="unix://$runtime_dir/docker.sock"
+default_socket="/var/run/docker.sock"
+rootless_socket="$runtime_dir/docker.sock"
+
+for command in amp docker rootlesskit slirp4netns fuse-overlayfs; do
+  if ! command -v "$command" >/dev/null; then
+    echo "Missing $command; run .agents/setup before .agents/resume" >&2
+    exit 1
+  fi
+done
+if [[ ! -x /usr/share/docker.io/contrib/dockerd-rootless.sh ]]; then
+  echo "Missing dockerd-rootless.sh; run .agents/setup before .agents/resume" >&2
+  exit 1
+fi
+if [[ ! -d "$docker_data_dir" ]] || [[ "$(stat -c %u "$docker_data_dir")" != "$uid" ]]; then
+  echo "Docker data directory is missing or not owned by the current user; run .agents/setup" >&2
+  exit 1
+fi
+if [[ ! -c /dev/net/tun ]]; then
+  echo "/dev/net/tun is unavailable; rootless Docker cannot start" >&2
+  exit 1
+fi
+
+if [[ "$(stat -c %a /dev/net/tun)" != "666" ]]; then
+  sudo chmod 0666 /dev/net/tun
+fi
+if [[ -L "$runtime_dir" ]] || { [[ -e "$runtime_dir" ]] && [[ ! -d "$runtime_dir" ]]; }; then
+  echo "Refusing to use unsafe runtime directory at $runtime_dir" >&2
+  exit 1
+elif [[ -d "$runtime_dir" ]]; then
+  if [[ "$(stat -c %u "$runtime_dir")" != "$uid" ]]; then
+    echo "Runtime directory is not owned by the current user: $runtime_dir" >&2
+    exit 1
+  fi
+  chmod 0700 "$runtime_dir"
+else
+  install -d -m 0700 "$runtime_dir"
+fi
+
+# Buildx reserves "default" for this conventional endpoint; live tests inspect it explicitly.
+if [[ -e "$default_socket" ]] || [[ -L "$default_socket" ]]; then
+  if [[ ! -L "$default_socket" ]] || [[ "$(readlink "$default_socket")" != "$rootless_socket" ]]; then
+    echo "Refusing to replace unrelated Docker socket at $default_socket" >&2
+    exit 1
+  fi
+else
+  sudo ln -s "$rootless_socket" "$default_socket"
+fi
+
+printf -v daemon_command \
+  'export PATH=/usr/sbin:/usr/bin:/sbin:/bin; export XDG_RUNTIME_DIR=%q; export DOCKERD_ROOTLESS_ROOTLESSKIT_NET=slirp4netns; export DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS="--disable-host-loopback=false"; exec /usr/share/docker.io/contrib/dockerd-rootless.sh --data-root %q --storage-driver=fuse-overlayfs --exec-opt native.cgroupdriver=cgroupfs --host-gateway-ip=10.0.2.2' \
+  "$runtime_dir" "$docker_data_dir"
+
+echo "Starting supervised rootless Docker service..."
+amp orb service start docker-rootless --cwd "$HOME" --command "$daemon_command"
+
+if env -u DOCKER_HOST -u DOCKER_CONTEXT docker context inspect "$docker_context" >/dev/null 2>&1; then
+  current_endpoint="$(env -u DOCKER_HOST -u DOCKER_CONTEXT docker context inspect "$docker_context" --format '{{.Endpoints.docker.Host}}')"
+  if [[ "$current_endpoint" != "$docker_endpoint" ]]; then
+    env -u DOCKER_HOST -u DOCKER_CONTEXT docker context update "$docker_context" --docker "host=$docker_endpoint" >/dev/null
+  fi
+else
+  env -u DOCKER_HOST -u DOCKER_CONTEXT docker context create "$docker_context" --docker "host=$docker_endpoint" >/dev/null
+fi
+env -u DOCKER_HOST -u DOCKER_CONTEXT docker context use "$docker_context" >/dev/null
+
+docker_ready=0
+for _ in {1..30}; do
+  if env -u DOCKER_HOST -u DOCKER_CONTEXT docker --context "$docker_context" info >/dev/null 2>&1; then
+    docker_ready=1
+    break
+  fi
+  sleep 1
+done
+if ((docker_ready == 0)); then
+  echo "Rootless Docker did not become ready" >&2
+  amp orb service status docker-rootless >&2 || true
+  amp orb service logs docker-rootless >&2 || true
+  exit 1
+fi
+
+buildx_inspect="$(env -u DOCKER_HOST -u DOCKER_CONTEXT docker buildx inspect default)"
+if ! grep -Eq '^Driver:[[:space:]]+docker$' <<<"$buildx_inspect"; then
+  echo "Docker Buildx default builder is not using the docker driver" >&2
+  printf '%s\n' "$buildx_inspect" >&2
+  exit 1
+fi
+
+echo "Rootless Docker is ready on context $docker_context."

--- a/.agents/resume
+++ b/.agents/resume
@@ -1,88 +1,39 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-uid="$(id -u)"
-runtime_dir="/tmp/user-$uid"
-docker_data_dir="$HOME/.local/share/docker-rootless"
-docker_context="buildkite-gha-rootless"
-docker_endpoint="unix://$runtime_dir/docker.sock"
-default_socket="/var/run/docker.sock"
-rootless_socket="$runtime_dir/docker.sock"
+socket_group="$(id -gn)"
 
-for command in amp docker rootlesskit slirp4netns fuse-overlayfs; do
+for command in amp docker sudo; do
   if ! command -v "$command" >/dev/null; then
     echo "Missing $command; run .agents/setup before .agents/resume" >&2
     exit 1
   fi
 done
-if [[ ! -x /usr/share/docker.io/contrib/dockerd-rootless.sh ]]; then
-  echo "Missing dockerd-rootless.sh; run .agents/setup before .agents/resume" >&2
+if [[ ! -x /usr/sbin/dockerd ]]; then
+  echo "Missing dockerd; run .agents/setup before .agents/resume" >&2
   exit 1
-fi
-if [[ ! -d "$docker_data_dir" ]] || [[ "$(stat -c %u "$docker_data_dir")" != "$uid" ]]; then
-  echo "Docker data directory is missing or not owned by the current user; run .agents/setup" >&2
-  exit 1
-fi
-if [[ ! -c /dev/net/tun ]]; then
-  echo "/dev/net/tun is unavailable; rootless Docker cannot start" >&2
-  exit 1
-fi
-
-if [[ "$(stat -c %a /dev/net/tun)" != "666" ]]; then
-  sudo chmod 0666 /dev/net/tun
-fi
-if [[ -L "$runtime_dir" ]] || { [[ -e "$runtime_dir" ]] && [[ ! -d "$runtime_dir" ]]; }; then
-  echo "Refusing to use unsafe runtime directory at $runtime_dir" >&2
-  exit 1
-elif [[ -d "$runtime_dir" ]]; then
-  if [[ "$(stat -c %u "$runtime_dir")" != "$uid" ]]; then
-    echo "Runtime directory is not owned by the current user: $runtime_dir" >&2
-    exit 1
-  fi
-  chmod 0700 "$runtime_dir"
-else
-  install -d -m 0700 "$runtime_dir"
-fi
-
-# Buildx reserves "default" for this conventional endpoint; live tests inspect it explicitly.
-if [[ -e "$default_socket" ]] || [[ -L "$default_socket" ]]; then
-  if [[ ! -L "$default_socket" ]] || [[ "$(readlink "$default_socket")" != "$rootless_socket" ]]; then
-    echo "Refusing to replace unrelated Docker socket at $default_socket" >&2
-    exit 1
-  fi
-else
-  sudo ln -s "$rootless_socket" "$default_socket"
 fi
 
 printf -v daemon_command \
-  'export PATH=/usr/sbin:/usr/bin:/sbin:/bin; export XDG_RUNTIME_DIR=%q; export DOCKERD_ROOTLESS_ROOTLESSKIT_NET=slirp4netns; export DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS="--disable-host-loopback=false"; exec /usr/share/docker.io/contrib/dockerd-rootless.sh --data-root %q --storage-driver=fuse-overlayfs --exec-opt native.cgroupdriver=cgroupfs --host-gateway-ip=10.0.2.2' \
-  "$runtime_dir" "$docker_data_dir"
+  'exec sudo /usr/sbin/dockerd --group %q' \
+  "$socket_group"
 
-echo "Starting supervised rootless Docker service..."
-amp orb service start docker-rootless --cwd "$HOME" --command "$daemon_command"
-
-if env -u DOCKER_HOST -u DOCKER_CONTEXT docker context inspect "$docker_context" >/dev/null 2>&1; then
-  current_endpoint="$(env -u DOCKER_HOST -u DOCKER_CONTEXT docker context inspect "$docker_context" --format '{{.Endpoints.docker.Host}}')"
-  if [[ "$current_endpoint" != "$docker_endpoint" ]]; then
-    env -u DOCKER_HOST -u DOCKER_CONTEXT docker context update "$docker_context" --docker "host=$docker_endpoint" >/dev/null
-  fi
-else
-  env -u DOCKER_HOST -u DOCKER_CONTEXT docker context create "$docker_context" --docker "host=$docker_endpoint" >/dev/null
-fi
-env -u DOCKER_HOST -u DOCKER_CONTEXT docker context use "$docker_context" >/dev/null
+echo "Starting supervised Docker service..."
+amp orb service start docker --cwd "$HOME" --command "$daemon_command"
+env -u DOCKER_HOST -u DOCKER_CONTEXT docker context use default >/dev/null
 
 docker_ready=0
 for _ in {1..30}; do
-  if env -u DOCKER_HOST -u DOCKER_CONTEXT docker --context "$docker_context" info >/dev/null 2>&1; then
+  if env -u DOCKER_HOST -u DOCKER_CONTEXT docker info >/dev/null 2>&1; then
     docker_ready=1
     break
   fi
   sleep 1
 done
 if ((docker_ready == 0)); then
-  echo "Rootless Docker did not become ready" >&2
-  amp orb service status docker-rootless >&2 || true
-  amp orb service logs docker-rootless >&2 || true
+  echo "Docker did not become ready" >&2
+  amp orb service status docker >&2 || true
+  amp orb service logs docker >&2 || true
   exit 1
 fi
 
@@ -93,4 +44,4 @@ if ! grep -Eq '^Driver:[[:space:]]+docker$' <<<"$buildx_inspect"; then
   exit 1
 fi
 
-echo "Rootless Docker is ready on context $docker_context."
+echo "Docker is ready on the default context."

--- a/.agents/setup
+++ b/.agents/setup
@@ -3,6 +3,8 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 mise_bin="$HOME/.local/bin/mise"
+bk_version="3.54.1"
+gh_version="2.96.0"
 docker_packages=(docker.io uidmap dbus-user-session fuse-overlayfs slirp4netns rootlesskit)
 
 missing_packages=()
@@ -99,15 +101,39 @@ case ":$PATH:" in
   *":$HOME/.local/bin:"*) ;;
   *) export PATH="$HOME/.local/bin:$PATH" ;;
 esac
+# buildkite-gha mise shims
+case ":$PATH:" in
+  *":$HOME/.local/share/mise/shims:"*) ;;
+  *) export PATH="$HOME/.local/share/mise/shims:$PATH" ;;
+esac
 if [[ -x "$HOME/.local/bin/mise" ]]; then
   eval "$("$HOME/.local/bin/mise" activate bash)"
 fi
 EOF
 fi
 
+shims_marker="# buildkite-gha mise shims"
+if ! grep -Fqx "$shims_marker" "$HOME/.bash_profile" 2>/dev/null; then
+  cat >> "$HOME/.bash_profile" <<'EOF'
+
+# buildkite-gha mise shims
+case ":$PATH:" in
+  *":$HOME/.local/share/mise/shims:"*) ;;
+  *) export PATH="$HOME/.local/share/mise/shims:$PATH" ;;
+esac
+EOF
+fi
+
 echo "Installing pinned development tools..."
 "$mise_bin" trust "$repo_root/mise.toml"
 "$mise_bin" install
+
+echo "Installing pinned orb CLIs..."
+"$mise_bin" use --global --pin --yes \
+  "aqua:buildkite/cli@$bk_version" \
+  "gh@$gh_version"
+"$mise_bin" exec -- bk version >/dev/null
+"$mise_bin" exec -- gh --version >/dev/null
 
 echo "Downloading Go modules..."
 "$mise_bin" exec -- go mod download

--- a/.agents/setup
+++ b/.agents/setup
@@ -3,6 +3,87 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 mise_bin="$HOME/.local/bin/mise"
+docker_packages=(docker.io uidmap dbus-user-session fuse-overlayfs slirp4netns rootlesskit)
+
+missing_packages=()
+for package in "${docker_packages[@]}"; do
+  if ! dpkg-query -W -f='${db:Status-Abbrev}' "$package" 2>/dev/null | grep -Fqx 'ii '; then
+    missing_packages+=("$package")
+  fi
+done
+
+if ((${#missing_packages[@]} > 0)); then
+  echo "Installing rootless Docker packages..."
+  policy_rc_created=0
+  cleanup_policy_rc() {
+    if ((policy_rc_created)); then
+      sudo rm -f /usr/sbin/policy-rc.d
+    fi
+  }
+  trap cleanup_policy_rc EXIT
+  if [[ ! -e /usr/sbin/policy-rc.d ]]; then
+    printf '#!/bin/sh\nexit 101\n' | sudo tee /usr/sbin/policy-rc.d >/dev/null
+    sudo chmod 0755 /usr/sbin/policy-rc.d
+    policy_rc_created=1
+  fi
+  sudo env DEBIAN_FRONTEND=noninteractive apt-get update
+  sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y "${missing_packages[@]}"
+  cleanup_policy_rc
+  policy_rc_created=0
+  trap - EXIT
+fi
+
+# The package units are not used: the rootless daemon is supervised by Amp.
+sudo systemctl disable --now docker.service docker.socket containerd.service >/dev/null
+
+username="$(id -un)"
+for subid_file in /etc/subuid /etc/subgid; do
+  if ! awk -F: -v username="$username" '
+    $1 == username && $3 >= 65536 { found = 1 }
+    END { exit !found }
+  ' "$subid_file"; then
+    printf '%s:100000:65536\n' "$username" | sudo tee -a "$subid_file" >/dev/null
+  fi
+done
+
+docker_data_dir="$HOME/.local/share/docker-rootless"
+install -d -m 0700 "$docker_data_dir"
+
+buildx_version="v0.35.0"
+case "$(uname -m)" in
+  x86_64)
+    buildx_arch="amd64"
+    buildx_sha256="d41ece72044243b4f58b343441ae37446d9c29a7d6b5e11c61847bbcf8f7dfda"
+    ;;
+  aarch64|arm64)
+    buildx_arch="arm64"
+    buildx_sha256="c4248d6cbc4a619a7e0b4609c11e509ad4ac0b475e1c64817c0ac20c5d90c766"
+    ;;
+  *)
+    echo "Unsupported architecture for Docker Buildx: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+buildx_dir="$HOME/.docker/cli-plugins"
+buildx_plugin="$buildx_dir/docker-buildx"
+install -d -m 0755 "$buildx_dir"
+if [[ ! -f "$buildx_plugin" ]] || [[ "$(sha256sum "$buildx_plugin" | awk '{print $1}')" != "$buildx_sha256" ]]; then
+  echo "Installing Docker Buildx $buildx_version..."
+  buildx_temp="$(mktemp)"
+  if ! curl -fsSL \
+    "https://github.com/docker/buildx/releases/download/$buildx_version/buildx-$buildx_version.linux-$buildx_arch" \
+    -o "$buildx_temp"; then
+    rm -f "$buildx_temp"
+    exit 1
+  fi
+  if ! printf '%s  %s\n' "$buildx_sha256" "$buildx_temp" | sha256sum -c - >/dev/null; then
+    rm -f "$buildx_temp"
+    exit 1
+  fi
+  install -m 0755 "$buildx_temp" "$buildx_plugin"
+  rm -f "$buildx_temp"
+fi
 
 echo "Installing mise if needed..."
 if [[ ! -x "$mise_bin" ]]; then
@@ -30,5 +111,7 @@ echo "Installing pinned development tools..."
 
 echo "Downloading Go modules..."
 "$mise_bin" exec -- go mod download
+
+"$repo_root/.agents/resume"
 
 echo "Orb setup complete."

--- a/.agents/setup
+++ b/.agents/setup
@@ -5,17 +5,9 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 mise_bin="$HOME/.local/bin/mise"
 bk_version="3.54.1"
 gh_version="2.96.0"
-docker_packages=(docker.io uidmap dbus-user-session fuse-overlayfs slirp4netns rootlesskit)
 
-missing_packages=()
-for package in "${docker_packages[@]}"; do
-  if ! dpkg-query -W -f='${db:Status-Abbrev}' "$package" 2>/dev/null | grep -Fqx 'ii '; then
-    missing_packages+=("$package")
-  fi
-done
-
-if ((${#missing_packages[@]} > 0)); then
-  echo "Installing rootless Docker packages..."
+if ! dpkg-query -W -f='${db:Status-Abbrev}' docker.io 2>/dev/null | grep -Fqx 'ii '; then
+  echo "Installing Docker packages..."
   policy_rc_created=0
   cleanup_policy_rc() {
     if ((policy_rc_created)); then
@@ -29,27 +21,14 @@ if ((${#missing_packages[@]} > 0)); then
     policy_rc_created=1
   fi
   sudo env DEBIAN_FRONTEND=noninteractive apt-get update
-  sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y "${missing_packages[@]}"
+  sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y docker.io
   cleanup_policy_rc
   policy_rc_created=0
   trap - EXIT
 fi
 
-# The package units are not used: the rootless daemon is supervised by Amp.
+# The package units are not used: the daemon is supervised by Amp.
 sudo systemctl disable --now docker.service docker.socket containerd.service >/dev/null
-
-username="$(id -un)"
-for subid_file in /etc/subuid /etc/subgid; do
-  if ! awk -F: -v username="$username" '
-    $1 == username && $3 >= 65536 { found = 1 }
-    END { exit !found }
-  ' "$subid_file"; then
-    printf '%s:100000:65536\n' "$username" | sudo tee -a "$subid_file" >/dev/null
-  fi
-done
-
-docker_data_dir="$HOME/.local/share/docker-rootless"
-install -d -m 0700 "$docker_data_dir"
 
 buildx_version="v0.35.0"
 case "$(uname -m)" in


### PR DESCRIPTION
## Summary

- install `docker.io` without starting its package-managed Docker or containerd units
- run the rootful daemon exclusively through Amp's service supervisor, exposing the conventional `/var/run/docker.sock` to the orb user's group
- use Docker's persistent `/var/lib/docker` data directory, default context, native `overlay2` storage, and systemd cgroups
- install checksum-pinned Docker Buildx v0.35.0 and keep its default builder on the local Docker driver
- install the Buildkite CLI v3.54.1 and GitHub CLI v2.96.0 globally through mise, with login-shell shim activation

## Validation

- repeated `.agents/setup` and `.agents/resume` runs
- supervised daemon stop/resume with image persistence
- `docker info`: Docker 20.10.24, `overlay2`, systemd cgroups, `/var/lib/docker`
- `docker run --rm alpine:3.20 ...`
- `docker buildx inspect default` reports driver `docker`
- host-gateway HTTP access from the default bridge and a user-created network
- `BUILDKITE_GHA_LIVE_REQUIRED=1 go test ./internal/runtime -run '^TestLiveJobContainerJavaScriptCompositeAndPost$' -count=1 -v`
- fresh login shell resolves mise, `bk version 3.54.1`, and `gh version 2.96.0`
- Bash syntax, ShellCheck, and `git diff --check`

Probe containers, networks, listeners, and services were removed after validation. The package-managed Docker, socket, and containerd units remain disabled and inactive; only the Amp-supervised Docker service remains running.

The Docker socket grants root-equivalent access inside the dedicated per-thread orb. Test containers are not given that socket.