### PR TITLE
Add durable Docker setup for Amp orbs

### DIFF
--- a/.agents/resume
+++ b/.agents/resume
@@ -1,4 +1,47 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "No persistent services require restart."
+socket_group="$(id -gn)"
+
+for command in amp docker sudo; do
+  if ! command -v "$command" >/dev/null; then
+    echo "Missing $command; run .agents/setup before .agents/resume" >&2
+    exit 1
+  fi
+done
+if [[ ! -x /usr/sbin/dockerd ]]; then
+  echo "Missing dockerd; run .agents/setup before .agents/resume" >&2
+  exit 1
+fi
+
+printf -v daemon_command \
+  'exec sudo /usr/sbin/dockerd --group %q' \
+  "$socket_group"
+
+echo "Starting supervised Docker service..."
+amp orb service start docker --cwd "$HOME" --command "$daemon_command"
+env -u DOCKER_HOST -u DOCKER_CONTEXT docker context use default >/dev/null
+
+docker_ready=0
+for _ in {1..30}; do
+  if env -u DOCKER_HOST -u DOCKER_CONTEXT docker info >/dev/null 2>&1; then
+    docker_ready=1
+    break
+  fi
+  sleep 1
+done
+if ((docker_ready == 0)); then
+  echo "Docker did not become ready" >&2
+  amp orb service status docker >&2 || true
+  amp orb service logs docker >&2 || true
+  exit 1
+fi
+
+buildx_inspect="$(env -u DOCKER_HOST -u DOCKER_CONTEXT docker buildx inspect default)"
+if ! grep -Eq '^Driver:[[:space:]]+docker$' <<<"$buildx_inspect"; then
+  echo "Docker Buildx default builder is not using the docker driver" >&2
+  printf '%s\n' "$buildx_inspect" >&2
+  exit 1
+fi
+
+echo "Docker is ready on the default context."

--- a/.agents/resume
+++ b/.agents/resume
@@ -1,47 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-socket_group="$(id -gn)"
-
-for command in amp docker sudo; do
+for command in docker sudo systemctl timeout; do
   if ! command -v "$command" >/dev/null; then
     echo "Missing $command; run .agents/setup before .agents/resume" >&2
     exit 1
   fi
 done
-if [[ ! -x /usr/sbin/dockerd ]]; then
-  echo "Missing dockerd; run .agents/setup before .agents/resume" >&2
-  exit 1
-fi
 
-printf -v daemon_command \
-  'exec sudo /usr/sbin/dockerd --group %q' \
-  "$socket_group"
-
-echo "Starting supervised Docker service..."
-amp orb service start docker --cwd "$HOME" --command "$daemon_command"
-env -u DOCKER_HOST -u DOCKER_CONTEXT docker context use default >/dev/null
-
-docker_ready=0
-for _ in {1..30}; do
-  if env -u DOCKER_HOST -u DOCKER_CONTEXT docker info >/dev/null 2>&1; then
-    docker_ready=1
-    break
-  fi
-  sleep 1
-done
-if ((docker_ready == 0)); then
-  echo "Docker did not become ready" >&2
-  amp orb service status docker >&2 || true
-  amp orb service logs docker >&2 || true
-  exit 1
-fi
-
-buildx_inspect="$(env -u DOCKER_HOST -u DOCKER_CONTEXT docker buildx inspect default)"
-if ! grep -Eq '^Driver:[[:space:]]+docker$' <<<"$buildx_inspect"; then
-  echo "Docker Buildx default builder is not using the docker driver" >&2
-  printf '%s\n' "$buildx_inspect" >&2
-  exit 1
-fi
-
-echo "Docker is ready on the default context."
+timeout 8s sudo systemctl start docker
+timeout 1s sudo docker info >/dev/null
+echo "Docker is ready."

--- a/.agents/setup
+++ b/.agents/setup
@@ -4,66 +4,50 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 mise_bin="$HOME/.local/bin/mise"
 bk_version="3.54.1"
-gh_version="2.96.0"
+docker_packages=(docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin)
 
-if ! dpkg-query -W -f='${db:Status-Abbrev}' docker.io 2>/dev/null | grep -Fqx 'ii '; then
-  echo "Installing Docker packages..."
-  policy_rc_created=0
-  cleanup_policy_rc() {
-    if ((policy_rc_created)); then
-      sudo rm -f /usr/sbin/policy-rc.d
-    fi
-  }
-  trap cleanup_policy_rc EXIT
-  if [[ ! -e /usr/sbin/policy-rc.d ]]; then
-    printf '#!/bin/sh\nexit 101\n' | sudo tee /usr/sbin/policy-rc.d >/dev/null
-    sudo chmod 0755 /usr/sbin/policy-rc.d
-    policy_rc_created=1
+missing_docker_packages=()
+for package in "${docker_packages[@]}"; do
+  if ! dpkg-query -W -f='${db:Status-Abbrev}' "$package" 2>/dev/null | grep -Fqx 'ii '; then
+    missing_docker_packages+=("$package")
   fi
-  sudo env DEBIAN_FRONTEND=noninteractive apt-get update
-  sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y docker.io
-  cleanup_policy_rc
-  policy_rc_created=0
-  trap - EXIT
+done
+
+if ((${#missing_docker_packages[@]} > 0)); then
+  echo "Installing Docker from its official Debian repository..."
+  sudo install -m 0755 -d /etc/apt/keyrings
+  sudo curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+  sudo chmod a+r /etc/apt/keyrings/docker.asc
+  docker_arch="$(dpkg --print-architecture)"
+  # shellcheck disable=SC1091
+  . /etc/os-release
+  docker_codename="$VERSION_CODENAME"
+  printf 'deb [arch=%s signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian %s stable\n' \
+    "$docker_arch" "$docker_codename" \
+    | sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
+  sudo apt-get update -qq
+  sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq "${docker_packages[@]}"
 fi
 
-# The package units are not used: the daemon is supervised by Amp.
-sudo systemctl disable --now docker.service docker.socket containerd.service >/dev/null
+sudo systemctl enable --now docker
+if ! id -nG "$USER" | tr ' ' '\n' | grep -Fqx docker; then
+  sudo usermod -aG docker "$USER"
+fi
 
-buildx_version="v0.35.0"
-case "$(uname -m)" in
-  x86_64)
-    buildx_arch="amd64"
-    buildx_sha256="d41ece72044243b4f58b343441ae37446d9c29a7d6b5e11c61847bbcf8f7dfda"
-    ;;
-  aarch64|arm64)
-    buildx_arch="arm64"
-    buildx_sha256="c4248d6cbc4a619a7e0b4609c11e509ad4ac0b475e1c64817c0ac20c5d90c766"
-    ;;
-  *)
-    echo "Unsupported architecture for Docker Buildx: $(uname -m)" >&2
-    exit 1
-    ;;
-esac
+if ! sudo docker info >/dev/null; then
+  echo "Docker did not become ready during setup" >&2
+  exit 1
+fi
+buildx_inspect="$(sudo docker buildx inspect default)"
+if ! grep -Eq '^Driver:[[:space:]]+docker$' <<<"$buildx_inspect"; then
+  echo "Docker Buildx default builder is not using the docker driver" >&2
+  printf '%s\n' "$buildx_inspect" >&2
+  exit 1
+fi
 
-buildx_dir="$HOME/.docker/cli-plugins"
-buildx_plugin="$buildx_dir/docker-buildx"
-install -d -m 0755 "$buildx_dir"
-if [[ ! -f "$buildx_plugin" ]] || [[ "$(sha256sum "$buildx_plugin" | awk '{print $1}')" != "$buildx_sha256" ]]; then
-  echo "Installing Docker Buildx $buildx_version..."
-  buildx_temp="$(mktemp)"
-  if ! curl -fsSL \
-    "https://github.com/docker/buildx/releases/download/$buildx_version/buildx-$buildx_version.linux-$buildx_arch" \
-    -o "$buildx_temp"; then
-    rm -f "$buildx_temp"
-    exit 1
-  fi
-  if ! printf '%s  %s\n' "$buildx_sha256" "$buildx_temp" | sha256sum -c - >/dev/null; then
-    rm -f "$buildx_temp"
-    exit 1
-  fi
-  install -m 0755 "$buildx_temp" "$buildx_plugin"
-  rm -f "$buildx_temp"
+if ! command -v gh >/dev/null; then
+  echo "Missing preinstalled GitHub CLI" >&2
+  exit 1
 fi
 
 echo "Installing mise if needed..."
@@ -107,12 +91,9 @@ echo "Installing pinned development tools..."
 "$mise_bin" trust "$repo_root/mise.toml"
 "$mise_bin" install
 
-echo "Installing pinned orb CLIs..."
-"$mise_bin" use --global --pin --yes \
-  "aqua:buildkite/cli@$bk_version" \
-  "gh@$gh_version"
+echo "Installing the pinned Buildkite CLI..."
+"$mise_bin" use --global --pin --yes "aqua:buildkite/cli@$bk_version"
 "$mise_bin" exec -- bk version >/dev/null
-"$mise_bin" exec -- gh --version >/dev/null
 
 echo "Downloading Go modules..."
 "$mise_bin" exec -- go mod download

--- a/.agents/setup
+++ b/.agents/setup
@@ -3,6 +3,68 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 mise_bin="$HOME/.local/bin/mise"
+bk_version="3.54.1"
+gh_version="2.96.0"
+
+if ! dpkg-query -W -f='${db:Status-Abbrev}' docker.io 2>/dev/null | grep -Fqx 'ii '; then
+  echo "Installing Docker packages..."
+  policy_rc_created=0
+  cleanup_policy_rc() {
+    if ((policy_rc_created)); then
+      sudo rm -f /usr/sbin/policy-rc.d
+    fi
+  }
+  trap cleanup_policy_rc EXIT
+  if [[ ! -e /usr/sbin/policy-rc.d ]]; then
+    printf '#!/bin/sh\nexit 101\n' | sudo tee /usr/sbin/policy-rc.d >/dev/null
+    sudo chmod 0755 /usr/sbin/policy-rc.d
+    policy_rc_created=1
+  fi
+  sudo env DEBIAN_FRONTEND=noninteractive apt-get update
+  sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y docker.io
+  cleanup_policy_rc
+  policy_rc_created=0
+  trap - EXIT
+fi
+
+# The package units are not used: the daemon is supervised by Amp.
+sudo systemctl disable --now docker.service docker.socket containerd.service >/dev/null
+
+buildx_version="v0.35.0"
+case "$(uname -m)" in
+  x86_64)
+    buildx_arch="amd64"
+    buildx_sha256="d41ece72044243b4f58b343441ae37446d9c29a7d6b5e11c61847bbcf8f7dfda"
+    ;;
+  aarch64|arm64)
+    buildx_arch="arm64"
+    buildx_sha256="c4248d6cbc4a619a7e0b4609c11e509ad4ac0b475e1c64817c0ac20c5d90c766"
+    ;;
+  *)
+    echo "Unsupported architecture for Docker Buildx: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+buildx_dir="$HOME/.docker/cli-plugins"
+buildx_plugin="$buildx_dir/docker-buildx"
+install -d -m 0755 "$buildx_dir"
+if [[ ! -f "$buildx_plugin" ]] || [[ "$(sha256sum "$buildx_plugin" | awk '{print $1}')" != "$buildx_sha256" ]]; then
+  echo "Installing Docker Buildx $buildx_version..."
+  buildx_temp="$(mktemp)"
+  if ! curl -fsSL \
+    "https://github.com/docker/buildx/releases/download/$buildx_version/buildx-$buildx_version.linux-$buildx_arch" \
+    -o "$buildx_temp"; then
+    rm -f "$buildx_temp"
+    exit 1
+  fi
+  if ! printf '%s  %s\n' "$buildx_sha256" "$buildx_temp" | sha256sum -c - >/dev/null; then
+    rm -f "$buildx_temp"
+    exit 1
+  fi
+  install -m 0755 "$buildx_temp" "$buildx_plugin"
+  rm -f "$buildx_temp"
+fi
 
 echo "Installing mise if needed..."
 if [[ ! -x "$mise_bin" ]]; then
@@ -18,9 +80,26 @@ case ":$PATH:" in
   *":$HOME/.local/bin:"*) ;;
   *) export PATH="$HOME/.local/bin:$PATH" ;;
 esac
+# buildkite-gha mise shims
+case ":$PATH:" in
+  *":$HOME/.local/share/mise/shims:"*) ;;
+  *) export PATH="$HOME/.local/share/mise/shims:$PATH" ;;
+esac
 if [[ -x "$HOME/.local/bin/mise" ]]; then
   eval "$("$HOME/.local/bin/mise" activate bash)"
 fi
+EOF
+fi
+
+shims_marker="# buildkite-gha mise shims"
+if ! grep -Fqx "$shims_marker" "$HOME/.bash_profile" 2>/dev/null; then
+  cat >> "$HOME/.bash_profile" <<'EOF'
+
+# buildkite-gha mise shims
+case ":$PATH:" in
+  *":$HOME/.local/share/mise/shims:"*) ;;
+  *) export PATH="$HOME/.local/share/mise/shims:$PATH" ;;
+esac
 EOF
 fi
 
@@ -28,7 +107,16 @@ echo "Installing pinned development tools..."
 "$mise_bin" trust "$repo_root/mise.toml"
 "$mise_bin" install
 
+echo "Installing pinned orb CLIs..."
+"$mise_bin" use --global --pin --yes \
+  "aqua:buildkite/cli@$bk_version" \
+  "gh@$gh_version"
+"$mise_bin" exec -- bk version >/dev/null
+"$mise_bin" exec -- gh --version >/dev/null
+
 echo "Downloading Go modules..."
 "$mise_bin" exec -- go mod download
+
+"$repo_root/.agents/resume"
 
 echo "Orb setup complete."


### PR DESCRIPTION
## Summary

- follow Amp's documented Docker setup for orbs using Docker's official Debian repository
- install `docker-ce`, `docker-ce-cli`, `containerd.io`, packaged Buildx, and Docker Compose
- enable the systemd Docker service and add the orb user to the `docker` group
- keep resume bounded below Amp's 10-second blocking window: at most eight seconds to start Docker and one second to verify it
- install the Buildkite CLI v3.54.1 globally through mise and verify Amp's preinstalled GitHub CLI remains available

## Validation

- repeated `.agents/setup` and `.agents/resume` runs
- Docker CE 29.6.2 with `overlay2`, systemd cgroups, and `/var/lib/docker`
- fresh user session has direct non-root Docker access through the `docker` group
- packaged `docker buildx` v0.35.0 reports default driver `docker`; Docker Compose is v5.3.1
- supervised service stop/resume completed in 1.5 seconds with image persistence
- `docker run --rm alpine:3.20 ...`
- host-gateway HTTP access from the default bridge and a user-created network
- `BUILDKITE_GHA_LIVE_REQUIRED=1 go test ./internal/runtime -run '^TestLiveJobContainerJavaScriptCompositeAndPost$' -count=1 -v`
- Bash syntax, ShellCheck, and `git diff --check`

Probe containers, networks, listeners, and services were removed after validation.

Membership in the `docker` group grants root-equivalent access inside the dedicated per-thread orb. Test containers are not given the Docker socket.