### PR TITLE
ci: run Buildkite pipeline on hosted agents

### DIFF
--- a/.buildkite/hosted-smoke-aggregator.yml
+++ b/.buildkite/hosted-smoke-aggregator.yml
@@ -1,3 +1,6 @@
+agents:
+  queue: "hosted"
+
 steps:
   - label: ":white_check_mark: Hosted smoke targets settled"
     key: "hosted-smoke-terminal"
@@ -32,8 +35,6 @@ steps:
         allow_failure: true
       - step: "phase-5-native-after-runtime"
         allow_failure: true
-    agents:
-      queue: "elastic-runners"
     command: |
       set -euo pipefail
       failed=0

--- a/.buildkite/hosted-smoke-control.yml
+++ b/.buildkite/hosted-smoke-control.yml
@@ -1,3 +1,6 @@
+agents:
+  queue: "hosted"
+
 steps:
   - label: ":pipeline: Load hosted smoke aggregator"
     key: "hosted-smoke-aggregator-loader"
@@ -14,6 +17,4 @@ steps:
         allow_failure: true
       - step: "phase-5-runtime-continuation-loader"
         allow_failure: true
-    agents:
-      queue: "elastic-runners"
     command: "buildkite-agent pipeline upload .buildkite/hosted-smoke-aggregator.yml"

--- a/.buildkite/phase-0-shell-oracle.yml
+++ b/.buildkite/phase-0-shell-oracle.yml
@@ -1,3 +1,6 @@
+agents:
+  queue: "hosted"
+
 steps:
   - label: ":git: Materialize exact shell fixture"
     key: phase-0-shell-prepare

--- a/.buildkite/phase-0-transport-probe/README.md
+++ b/.buildkite/phase-0-transport-probe/README.md
@@ -8,14 +8,14 @@ This probe is intentionally dormant: local tests capture commands and never call
 
 ## Signed-pipeline scope
 
-Buildkite signed pipelines are outside this initial transport probe. Run the probe on the existing `elastic-runners` queue without secrets, provider tokens, privileged containers, or other production capabilities. The signed, build-bound plan envelope remains mandatory and is a separate trust mechanism: `PHASE0_SIGN_JSON` signs plan bindings and markers, and `PHASE0_VERIFY_JSON` verifies them before runtime use.
+Buildkite signed pipelines are outside this initial transport probe. Run the probe on the existing `hosted` queue without secrets, provider tokens, privileged containers, or other production capabilities. The signed, build-bound plan envelope remains mandatory and is a separate trust mechanism: `PHASE0_SIGN_JSON` signs plan bindings and markers, and `PHASE0_VERIFY_JSON` verifies them before runtime use.
 
 Signed-pipeline compatibility is deferred to the hardening phase as optional defence in depth for installations that already require it. It must use keys separate from the plan-envelope signer when implemented.
 
 The live probe also requires:
 
 - `jq` and `sha256sum` on the runtime queue;
-- `PHASE0_RUNTIME_QUEUE`, `PHASE0_EVENT_NAME`, `PHASE0_REPOSITORY`, `PHASE0_REF`, 40-character `PHASE0_COMMIT`, canonical `PHASE0_EVENT_DIGEST`, runtime-owned JSON `PHASE0_LOCAL_CAPABILITIES` (for example `["network"]`), and a disposable build-level `PHASE0_REDACTION_SECRET` canary; and
+- `PHASE0_RUNTIME_QUEUE=hosted`, `PHASE0_EVENT_NAME`, `PHASE0_REPOSITORY`, `PHASE0_REF`, 40-character `PHASE0_COMMIT`, canonical `PHASE0_EVENT_DIGEST`, runtime-owned JSON `PHASE0_LOCAL_CAPABILITIES` (for example `["network"]`), and a disposable build-level `PHASE0_REDACTION_SECRET` canary; and
 - immutable organization and pipeline UUIDs exposed as `BUILDKITE_ORGANIZATION_ID` and `BUILDKITE_PIPELINE_ID` by the probe installation until the live environment-variable oracle confirms their source.
 
 The build must use the exact commit supplied in `PHASE0_COMMIT`. Static and generated jobs run the checked-in probe from that checkout. The checked-in signing helper derives a public, disposable key, so it demonstrates signature transport and rejection but grants no production authority. KMS-backed plan signing and checkout-free compiler isolation remain later security gates.

--- a/.buildkite/phase-0-transport-probe/pipeline.yml
+++ b/.buildkite/phase-0-transport-probe/pipeline.yml
@@ -1,9 +1,10 @@
+agents:
+  queue: "hosted"
+
 steps:
   - label: ":pipeline: Phase 0 transport importer"
     key: "phase0-transport-importer"
     command: ".buildkite/phase-0-transport-probe/probe.sh bootstrap"
-    agents:
-      queue: "elastic-runners"
     env:
       PHASE0_SIGN_JSON: "scripts/phase-0-sign-json"
       PHASE0_VERIFY_JSON: "scripts/phase-0-verify-json"
@@ -15,5 +16,3 @@ steps:
     key: "phase0-native-after-import"
     depends_on: "phase0-transport-importer"
     command: ".buildkite/phase-0-transport-probe/probe.sh native"
-    agents:
-      queue: "elastic-runners"

--- a/.buildkite/phase-2-upload-continuation.yml
+++ b/.buildkite/phase-2-upload-continuation.yml
@@ -1,3 +1,6 @@
+agents:
+  queue: "hosted"
+
 steps:
   - label: ":white_check_mark: Phase 2 native dependency extension"
     key: "phase-2-native-after-shell"
@@ -6,6 +9,4 @@ steps:
         allow_failure: true
       - step: "gha-consumer-91934b28b00f"
         allow_failure: true
-    agents:
-      queue: "elastic-runners"
     command: "echo 'All Phase 2 shell jobs settled before native continuation'"

--- a/.buildkite/phase-2-upload.yml
+++ b/.buildkite/phase-2-upload.yml
@@ -1,8 +1,9 @@
+agents:
+  queue: "hosted"
+
 steps:
   - label: ":pipeline: Phase 2 unprivileged importer"
     key: "phase-2-upload-importer"
-    agents:
-      queue: "elastic-runners"
     plugins:
       - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
           version: "2026.5.12"
@@ -22,6 +23,4 @@ steps:
     key: "phase-2-continuation-loader"
     depends_on: "phase-2-upload-importer"
     allow_dependency_failure: true
-    agents:
-      queue: "elastic-runners"
     command: "buildkite-agent pipeline upload .buildkite/phase-2-upload-continuation.yml"

--- a/.buildkite/phase-3-upload-continuation.yml
+++ b/.buildkite/phase-3-upload-continuation.yml
@@ -1,9 +1,10 @@
+agents:
+  queue: "hosted"
+
 steps:
   - label: ":white_check_mark: Phase 3 native dependency extension"
     key: "phase-3-native-after-concurrent"
     depends_on:
       - step: "gha-observe"
         allow_failure: true
-    agents:
-      queue: "elastic-runners"
     command: "echo 'All Phase 3 concurrent jobs settled before native continuation'"

--- a/.buildkite/phase-3-upload.yml
+++ b/.buildkite/phase-3-upload.yml
@@ -1,8 +1,9 @@
+agents:
+  queue: "hosted"
+
 steps:
   - label: ":pipeline: Phase 3 concurrent importer"
     key: "phase-3-upload-importer"
-    agents:
-      queue: "elastic-runners"
     plugins:
       - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
           version: "2026.5.12"
@@ -22,6 +23,4 @@ steps:
     key: "phase-3-continuation-loader"
     depends_on: "phase-3-upload-importer"
     allow_dependency_failure: true
-    agents:
-      queue: "elastic-runners"
     command: "buildkite-agent pipeline upload .buildkite/phase-3-upload-continuation.yml"

--- a/.buildkite/phase-4-upload-continuation.yml
+++ b/.buildkite/phase-4-upload-continuation.yml
@@ -1,9 +1,10 @@
+agents:
+  queue: "hosted"
+
 steps:
   - label: ":white_check_mark: Phase 4 native dependency extension"
     key: "phase-4-native-after-actions"
     depends_on:
       - step: "gha-public-actions"
         allow_failure: true
-    agents:
-      queue: "elastic-runners"
     command: "echo 'Phase 4 actions jobs settled before native continuation'"

--- a/.buildkite/phase-4-upload.yml
+++ b/.buildkite/phase-4-upload.yml
@@ -1,8 +1,9 @@
+agents:
+  queue: "hosted"
+
 steps:
   - label: ":pipeline: Phase 4 actions importer"
     key: "phase-4-upload-importer"
-    agents:
-      queue: "elastic-runners"
     plugins:
       - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
           version: "2026.5.12"
@@ -26,6 +27,4 @@ steps:
     key: "phase-4-continuation-loader"
     depends_on: "phase-4-upload-importer"
     allow_dependency_failure: true
-    agents:
-      queue: "elastic-runners"
     command: "buildkite-agent pipeline upload .buildkite/phase-4-upload-continuation.yml"

--- a/.buildkite/phase-5-capabilities-continuation.yml
+++ b/.buildkite/phase-5-capabilities-continuation.yml
@@ -1,9 +1,10 @@
+agents:
+  queue: "hosted"
+
 steps:
   - label: ":white_check_mark: Phase 5 capability probe settled"
     key: "phase-5-native-after-hosted-docker"
     depends_on:
       - step: "phase-5-hosted-docker-probe"
         allow_failure: true
-    agents:
-      queue: "elastic-runners"
     command: "echo 'Phase 5 hosted Docker capability probe settled'"

--- a/.buildkite/phase-5-capabilities.yml
+++ b/.buildkite/phase-5-capabilities.yml
@@ -1,8 +1,9 @@
+agents:
+  queue: "hosted"
+
 steps:
   - label: ":pipeline: Phase 5 capability importer"
     key: "phase-5-capabilities-importer"
-    agents:
-      queue: "elastic-runners"
     command: |
       set -euo pipefail
       commit="$${PHASE5_COMMIT:-$${SMOKE_COMMIT:-}}"
@@ -14,6 +15,4 @@ steps:
     key: "phase-5-continuation-loader"
     depends_on: "phase-5-capabilities-importer"
     allow_dependency_failure: true
-    agents:
-      queue: "elastic-runners"
     command: "buildkite-agent pipeline upload .buildkite/phase-5-capabilities-continuation.yml"

--- a/.buildkite/phase-5-docker-action-continuation.yml
+++ b/.buildkite/phase-5-docker-action-continuation.yml
@@ -1,9 +1,10 @@
+agents:
+  queue: "hosted"
+
 steps:
   - label: ":white_check_mark: Phase 5 Dockerfile action dependency extension"
     key: "phase-5-native-after-docker-action"
     depends_on:
       - step: "gha-docker-action"
         allow_failure: true
-    agents:
-      queue: "elastic-runners"
     command: "echo 'Phase 5 Dockerfile action settled before native continuation'"

--- a/.buildkite/phase-5-docker-action.yml
+++ b/.buildkite/phase-5-docker-action.yml
@@ -1,8 +1,9 @@
+agents:
+  queue: "hosted"
+
 steps:
   - label: ":pipeline: Phase 5 Dockerfile action importer"
     key: "phase-5-docker-action-importer"
-    agents:
-      queue: "elastic-runners"
     timeout_in_minutes: 15
     retry:
       automatic: false
@@ -32,6 +33,4 @@ steps:
     key: "phase-5-docker-action-continuation-loader"
     depends_on: "phase-5-docker-action-importer"
     allow_dependency_failure: true
-    agents:
-      queue: "elastic-runners"
     command: "buildkite-agent pipeline upload .buildkite/phase-5-docker-action-continuation.yml"

--- a/.buildkite/phase-5-hosted-probe.yml
+++ b/.buildkite/phase-5-hosted-probe.yml
@@ -1,8 +1,9 @@
+agents:
+  queue: "hosted"
+
 steps:
   - label: ":docker: Phase 5 hosted Docker capabilities"
     key: "phase-5-hosted-docker-probe"
-    agents:
-      queue: "hosted"
     timeout_in_minutes: 15
     retry:
       automatic: false

--- a/.buildkite/phase-5-runtime-continuation.yml
+++ b/.buildkite/phase-5-runtime-continuation.yml
@@ -1,9 +1,10 @@
+agents:
+  queue: "hosted"
+
 steps:
   - label: ":white_check_mark: Phase 5 container runtime settled"
     key: "phase-5-native-after-runtime"
     depends_on:
       - step: "phase-5-hosted-runtime-probe"
         allow_failure: true
-    agents:
-      queue: "elastic-runners"
     command: "echo 'Phase 5 hosted container runtime proof settled'"

--- a/.buildkite/phase-5-runtime-probe.yml
+++ b/.buildkite/phase-5-runtime-probe.yml
@@ -1,8 +1,9 @@
+agents:
+  queue: "hosted"
+
 steps:
   - label: ":docker: Phase 5 container runtime"
     key: "phase-5-hosted-runtime-probe"
-    agents:
-      queue: "hosted"
     timeout_in_minutes: 25
     retry:
       automatic: false

--- a/.buildkite/phase-5-runtime.yml
+++ b/.buildkite/phase-5-runtime.yml
@@ -1,8 +1,9 @@
+agents:
+  queue: "hosted"
+
 steps:
   - label: ":pipeline: Phase 5 container runtime importer"
     key: "phase-5-runtime-importer"
-    agents:
-      queue: "elastic-runners"
     retry:
       automatic: false
     command: |
@@ -16,6 +17,4 @@ steps:
     key: "phase-5-runtime-continuation-loader"
     depends_on: "phase-5-runtime-importer"
     allow_dependency_failure: true
-    agents:
-      queue: "elastic-runners"
     command: "buildkite-agent pipeline upload .buildkite/phase-5-runtime-continuation.yml"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,62 +1,49 @@
 env:
   MISE_JOBS: "1"
 
+agents:
+  queue: "hosted"
+
 steps:
   - label: ":test_tube: Load Phase 0 shell oracle"
     key: "phase-0-shell-oracle-loader"
     if: build.env("PHASE0_PROBE") == "shell"
     command: "buildkite-agent pipeline upload .buildkite/phase-0-shell-oracle.yml"
-    agents:
-      queue: "elastic-runners"
 
   - label: ":test_tube: Load Phase 0 transport probe"
     key: "phase-0-transport-probe-loader"
     if: build.env("PHASE0_PROBE") == "transport"
     command: "buildkite-agent pipeline upload .buildkite/phase-0-transport-probe/pipeline.yml"
-    agents:
-      queue: "elastic-runners"
 
   - label: ":pipeline: Load Phase 2 upload proof"
     key: "phase-2-upload-loader"
     if: build.env("PHASE2_PROBE") == "upload" && build.env("SMOKE_PROBE") != "hosted"
     command: "buildkite-agent pipeline upload .buildkite/phase-2-upload.yml"
-    agents:
-      queue: "elastic-runners"
 
   - label: ":pipeline: Load Phase 3 concurrent proof"
     key: "phase-3-upload-loader"
     if: build.env("PHASE3_PROBE") == "concurrent" && build.env("SMOKE_PROBE") != "hosted"
     command: "buildkite-agent pipeline upload .buildkite/phase-3-upload.yml"
-    agents:
-      queue: "elastic-runners"
 
   - label: ":pipeline: Load Phase 4 actions proof"
     key: "phase-4-upload-loader"
     if: build.env("PHASE4_PROBE") == "actions" && build.env("SMOKE_PROBE") != "hosted"
     command: "buildkite-agent pipeline upload .buildkite/phase-4-upload.yml"
-    agents:
-      queue: "elastic-runners"
 
   - label: ":docker: Load Phase 5 hosted Docker probe"
     key: "phase-5-capabilities-loader"
     if: build.env("PHASE5_PROBE") == "capabilities" && build.env("SMOKE_PROBE") != "hosted"
     command: "buildkite-agent pipeline upload .buildkite/phase-5-capabilities.yml"
-    agents:
-      queue: "elastic-runners"
 
   - label: ":docker: Load Phase 5 Dockerfile action proof"
     key: "phase-5-docker-action-loader"
     if: build.env("PHASE5_PROBE") == "docker-action" && build.env("SMOKE_PROBE") != "hosted"
     command: "buildkite-agent pipeline upload .buildkite/phase-5-docker-action.yml"
-    agents:
-      queue: "elastic-runners"
 
   - label: ":docker: Load Phase 5 container runtime proof"
     key: "phase-5-runtime-loader"
     if: build.env("PHASE5_PROBE") == "runtime" && build.env("SMOKE_PROBE") != "hosted"
     command: "buildkite-agent pipeline upload .buildkite/phase-5-runtime.yml"
-    agents:
-      queue: "elastic-runners"
 
   - label: ":pipeline: Load consolidated hosted smoke proof"
     key: "hosted-smoke-loader"
@@ -86,8 +73,6 @@ steps:
       buildkite-agent pipeline upload .buildkite/phase-5-docker-action.yml
       buildkite-agent pipeline upload .buildkite/phase-5-runtime.yml
       buildkite-agent pipeline upload .buildkite/hosted-smoke-control.yml
-    agents:
-      queue: "elastic-runners"
 
   - label: ":go: Repository checks"
     key: "checks"
@@ -95,8 +80,6 @@ steps:
       - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
           version: "2026.5.12"
     command: "mise run --jobs 1 check"
-    agents:
-      queue: "elastic-runners"
 
   - wait: ~
 
@@ -109,5 +92,3 @@ steps:
       - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
           version: "2026.5.12"
     command: "mise exec -- scripts/ci-buildkite-release"
-    agents:
-      queue: "elastic-runners"

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -239,20 +239,61 @@ func TestEmitRejectsInvalidGraphsAndIdentifiers(t *testing.T) {
 	}
 }
 
+func TestCheckedInPipelinesTargetHostedQueue(t *testing.T) {
+	root := filepath.Join("..", "..", ".buildkite")
+	count := 0
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || (filepath.Ext(path) != ".yml" && filepath.Ext(path) != ".yaml") {
+			return nil
+		}
+		body, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		var document struct {
+			Agents struct {
+				Queue string `yaml:"queue"`
+			} `yaml:"agents"`
+			Steps []any `yaml:"steps"`
+		}
+		if err := yaml.Unmarshal(body, &document); err != nil {
+			t.Errorf("parse %s: %v", path, err)
+			return nil
+		}
+		if document.Agents.Queue != "hosted" {
+			t.Errorf("%s root queue = %q, want hosted", path, document.Agents.Queue)
+		}
+		if len(document.Steps) == 0 {
+			t.Errorf("%s has no steps", path)
+		}
+		count++
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count == 0 {
+		t.Fatal("no checked-in Buildkite pipelines found")
+	}
+}
+
 func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 	source, err := os.ReadFile(filepath.Join("..", "..", ".buildkite", "pipeline.yml"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	var document struct {
-		Env   map[string]string `yaml:"env"`
+		Env    map[string]string `yaml:"env"`
+		Agents struct {
+			Queue string `yaml:"queue"`
+		} `yaml:"agents"`
 		Steps []struct {
 			Key     string `yaml:"key"`
 			Command string `yaml:"command"`
 			If      string `yaml:"if"`
-			Agents  struct {
-				Queue string `yaml:"queue"`
-			} `yaml:"agents"`
 		} `yaml:"steps"`
 	}
 	if err := yaml.Unmarshal(source, &document); err != nil {
@@ -261,25 +302,26 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 	if document.Env["MISE_JOBS"] != "1" {
 		t.Fatalf("default pipeline MISE_JOBS = %q, want serial tool installation", document.Env["MISE_JOBS"])
 	}
+	if document.Agents.Queue != "hosted" {
+		t.Fatalf("default pipeline queue = %q, want hosted", document.Agents.Queue)
+	}
 	if len(document.Steps) != 12 {
 		t.Fatalf("default pipeline = %#v, want nine gated loaders, repository checks, wait, and release", document.Steps)
 	}
 	steps := make(map[string]struct {
 		command   string
 		condition string
-		queue     string
 	}, len(document.Steps))
 	for _, step := range document.Steps {
 		steps[step.Key] = struct {
 			command   string
 			condition string
-			queue     string
-		}{step.Command, step.If, step.Agents.Queue}
+		}{step.Command, step.If}
 	}
 	if got := steps["checks"]; got.command != "mise run --jobs 1 check" || got.condition != "" {
 		t.Fatalf("repository checks = %#v", got)
 	}
-	if got := steps["publish-release"]; got.command != "mise exec -- scripts/ci-buildkite-release" || got.condition != "build.tag != null" || got.queue != "elastic-runners" {
+	if got := steps["publish-release"]; got.command != "mise exec -- scripts/ci-buildkite-release" || got.condition != "build.tag != null" {
 		t.Fatalf("release publisher = %#v", got)
 	}
 	if got := steps["phase-0-shell-oracle-loader"]; got.command != "buildkite-agent pipeline upload .buildkite/phase-0-shell-oracle.yml" || got.condition != `build.env("PHASE0_PROBE") == "shell"` {
@@ -307,7 +349,7 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 		t.Fatalf("Phase 5 container runtime loader = %#v", got)
 	}
 	hosted := steps["hosted-smoke-loader"]
-	if hosted.condition != `build.env("SMOKE_PROBE") == "hosted"` || hosted.queue != "elastic-runners" {
+	if hosted.condition != `build.env("SMOKE_PROBE") == "hosted"` {
 		t.Fatalf("hosted smoke loader = %#v", hosted)
 	}
 	for _, required := range []string{
@@ -362,18 +404,15 @@ func TestPhase2UploadProofUsesPinnedUnprivilegedPath(t *testing.T) {
 			Command                string `yaml:"command"`
 			DependsOn              string `yaml:"depends_on"`
 			AllowDependencyFailure bool   `yaml:"allow_dependency_failure"`
-			Agents                 struct {
-				Queue string `yaml:"queue"`
-			} `yaml:"agents"`
 		} `yaml:"steps"`
 	}
 	if err := yaml.Unmarshal(source, &document); err != nil {
 		t.Fatal(err)
 	}
-	if len(document.Steps) != 2 || document.Steps[0].Key != "phase-2-upload-importer" || document.Steps[0].Agents.Queue != "elastic-runners" {
+	if len(document.Steps) != 2 || document.Steps[0].Key != "phase-2-upload-importer" {
 		t.Fatalf("Phase 2 upload proof = %#v", document.Steps)
 	}
-	if document.Steps[1].Key != "phase-2-continuation-loader" || document.Steps[1].DependsOn != "phase-2-upload-importer" || !document.Steps[1].AllowDependencyFailure || document.Steps[1].Agents.Queue != "elastic-runners" || document.Steps[1].Command != "buildkite-agent pipeline upload .buildkite/phase-2-upload-continuation.yml" {
+	if document.Steps[1].Key != "phase-2-continuation-loader" || document.Steps[1].DependsOn != "phase-2-upload-importer" || !document.Steps[1].AllowDependencyFailure || document.Steps[1].Command != "buildkite-agent pipeline upload .buildkite/phase-2-upload-continuation.yml" {
 		t.Fatalf("Phase 2 continuation loader = %#v", document.Steps[1])
 	}
 
@@ -554,19 +593,16 @@ func TestPhase4UploadProofUsesTrustedManagedActionsPath(t *testing.T) {
 			Command                string `yaml:"command"`
 			DependsOn              string `yaml:"depends_on"`
 			AllowDependencyFailure bool   `yaml:"allow_dependency_failure"`
-			Agents                 struct {
-				Queue string `yaml:"queue"`
-			} `yaml:"agents"`
 		} `yaml:"steps"`
 	}
 	if err := yaml.Unmarshal(source, &upload); err != nil {
 		t.Fatal(err)
 	}
-	if len(upload.Steps) != 2 || upload.Steps[0].Key != "phase-4-upload-importer" || upload.Steps[0].Agents.Queue != "elastic-runners" {
+	if len(upload.Steps) != 2 || upload.Steps[0].Key != "phase-4-upload-importer" {
 		t.Fatalf("Phase 4 upload proof = %#v", upload.Steps)
 	}
 	loader := upload.Steps[1]
-	if loader.Key != "phase-4-continuation-loader" || loader.DependsOn != "phase-4-upload-importer" || !loader.AllowDependencyFailure || loader.Agents.Queue != "elastic-runners" || loader.Command != "buildkite-agent pipeline upload .buildkite/phase-4-upload-continuation.yml" {
+	if loader.Key != "phase-4-continuation-loader" || loader.DependsOn != "phase-4-upload-importer" || !loader.AllowDependencyFailure || loader.Command != "buildkite-agent pipeline upload .buildkite/phase-4-upload-continuation.yml" {
 		t.Fatalf("Phase 4 continuation loader = %#v", loader)
 	}
 	continuationSource, err := os.ReadFile(filepath.Join("..", "..", ".buildkite", "phase-4-upload-continuation.yml"))
@@ -580,15 +616,12 @@ func TestPhase4UploadProofUsesTrustedManagedActionsPath(t *testing.T) {
 				Step         string `yaml:"step"`
 				AllowFailure bool   `yaml:"allow_failure"`
 			} `yaml:"depends_on"`
-			Agents struct {
-				Queue string `yaml:"queue"`
-			} `yaml:"agents"`
 		} `yaml:"steps"`
 	}
 	if err := yaml.Unmarshal(continuationSource, &continuation); err != nil {
 		t.Fatal(err)
 	}
-	if len(continuation.Steps) != 1 || continuation.Steps[0].Key != "phase-4-native-after-actions" || continuation.Steps[0].Agents.Queue != "elastic-runners" || len(continuation.Steps[0].DependsOn) != 1 || continuation.Steps[0].DependsOn[0].Step != "gha-public-actions" || !continuation.Steps[0].DependsOn[0].AllowFailure {
+	if len(continuation.Steps) != 1 || continuation.Steps[0].Key != "phase-4-native-after-actions" || len(continuation.Steps[0].DependsOn) != 1 || continuation.Steps[0].DependsOn[0].Step != "gha-public-actions" || !continuation.Steps[0].DependsOn[0].AllowFailure {
 		t.Fatalf("Phase 4 continuation = %#v", continuation.Steps)
 	}
 }
@@ -601,10 +634,7 @@ func TestPhase5HostedDockerCapabilityProbeContract(t *testing.T) {
 		DependsOn              any    `yaml:"depends_on"`
 		AllowDependencyFailure bool   `yaml:"allow_dependency_failure"`
 		Timeout                int    `yaml:"timeout_in_minutes"`
-		Agents                 struct {
-			Queue string `yaml:"queue"`
-		} `yaml:"agents"`
-		Retry struct {
+		Retry                  struct {
 			Automatic bool `yaml:"automatic"`
 		} `yaml:"retry"`
 	}
@@ -623,7 +653,7 @@ func TestPhase5HostedDockerCapabilityProbeContract(t *testing.T) {
 		return body, document.Steps
 	}
 	importerBody, importer := read("phase-5-capabilities.yml")
-	if len(importer) != 2 || importer[0].Key != "phase-5-capabilities-importer" || importer[0].Agents.Queue != "elastic-runners" || importer[1].Key != "phase-5-continuation-loader" || importer[1].Agents.Queue != "elastic-runners" || fmt.Sprint(importer[1].DependsOn) != "phase-5-capabilities-importer" || !importer[1].AllowDependencyFailure || importer[1].Command != "buildkite-agent pipeline upload .buildkite/phase-5-capabilities-continuation.yml" {
+	if len(importer) != 2 || importer[0].Key != "phase-5-capabilities-importer" || importer[1].Key != "phase-5-continuation-loader" || fmt.Sprint(importer[1].DependsOn) != "phase-5-capabilities-importer" || !importer[1].AllowDependencyFailure || importer[1].Command != "buildkite-agent pipeline upload .buildkite/phase-5-capabilities-continuation.yml" {
 		t.Fatalf("Phase 5 importer = %#v", importer)
 	}
 	for _, fragment := range []string{`commit="$${PHASE5_COMMIT:-$${SMOKE_COMMIT:-}}"`,
@@ -633,11 +663,11 @@ func TestPhase5HostedDockerCapabilityProbeContract(t *testing.T) {
 		}
 	}
 	hostedBody, hosted := read("phase-5-hosted-probe.yml")
-	if len(hosted) != 1 || hosted[0].Key != "phase-5-hosted-docker-probe" || hosted[0].Agents.Queue != "hosted" || hosted[0].Timeout != 15 || hosted[0].Retry.Automatic || hosted[0].Command != "scripts/phase-5-hosted-docker-probe" || !strings.Contains(string(hostedBody), "automatic: false") {
+	if len(hosted) != 1 || hosted[0].Key != "phase-5-hosted-docker-probe" || hosted[0].Timeout != 15 || hosted[0].Retry.Automatic || hosted[0].Command != "scripts/phase-5-hosted-docker-probe" || !strings.Contains(string(hostedBody), "automatic: false") {
 		t.Fatalf("Phase 5 hosted pipeline = %#v\n%s", hosted, hostedBody)
 	}
 	_, continuation := read("phase-5-capabilities-continuation.yml")
-	if len(continuation) != 1 || continuation[0].Key != "phase-5-native-after-hosted-docker" || continuation[0].Agents.Queue != "elastic-runners" {
+	if len(continuation) != 1 || continuation[0].Key != "phase-5-native-after-hosted-docker" {
 		t.Fatalf("Phase 5 continuation = %#v", continuation)
 	}
 	continuationBody, _ := os.ReadFile(filepath.Join(root, ".buildkite", "phase-5-capabilities-continuation.yml"))
@@ -693,19 +723,16 @@ func TestPhase5DockerfileActionUploadProofContract(t *testing.T) {
 			Command                string `yaml:"command"`
 			DependsOn              string `yaml:"depends_on"`
 			AllowDependencyFailure bool   `yaml:"allow_dependency_failure"`
-			Agents                 struct {
-				Queue string `yaml:"queue"`
-			} `yaml:"agents"`
 		} `yaml:"steps"`
 	}
 	if err := yaml.Unmarshal(importerBody, &upload); err != nil {
 		t.Fatal(err)
 	}
-	if len(upload.Steps) != 2 || upload.Steps[0].Key != "phase-5-docker-action-importer" || upload.Steps[0].Agents.Queue != "elastic-runners" {
+	if len(upload.Steps) != 2 || upload.Steps[0].Key != "phase-5-docker-action-importer" {
 		t.Fatalf("Phase 5 Dockerfile action importer = %#v", upload.Steps)
 	}
 	loader := upload.Steps[1]
-	if loader.Key != "phase-5-docker-action-continuation-loader" || loader.DependsOn != "phase-5-docker-action-importer" || !loader.AllowDependencyFailure || loader.Agents.Queue != "elastic-runners" || loader.Command != "buildkite-agent pipeline upload .buildkite/phase-5-docker-action-continuation.yml" {
+	if loader.Key != "phase-5-docker-action-continuation-loader" || loader.DependsOn != "phase-5-docker-action-importer" || !loader.AllowDependencyFailure || loader.Command != "buildkite-agent pipeline upload .buildkite/phase-5-docker-action-continuation.yml" {
 		t.Fatalf("Phase 5 Dockerfile action continuation loader = %#v", loader)
 	}
 
@@ -749,19 +776,16 @@ func TestPhase5ContainerRuntimeProofContract(t *testing.T) {
 			Command                string `yaml:"command"`
 			DependsOn              string `yaml:"depends_on"`
 			AllowDependencyFailure bool   `yaml:"allow_dependency_failure"`
-			Agents                 struct {
-				Queue string `yaml:"queue"`
-			} `yaml:"agents"`
 		} `yaml:"steps"`
 	}
 	if err := yaml.Unmarshal(importerBody, &importer); err != nil {
 		t.Fatal(err)
 	}
-	if len(importer.Steps) != 2 || importer.Steps[0].Key != "phase-5-runtime-importer" || importer.Steps[0].Agents.Queue != "elastic-runners" {
+	if len(importer.Steps) != 2 || importer.Steps[0].Key != "phase-5-runtime-importer" {
 		t.Fatalf("Phase 5 runtime importer = %#v", importer.Steps)
 	}
 	loader := importer.Steps[1]
-	if loader.Key != "phase-5-runtime-continuation-loader" || loader.DependsOn != "phase-5-runtime-importer" || !loader.AllowDependencyFailure || loader.Agents.Queue != "elastic-runners" || loader.Command != "buildkite-agent pipeline upload .buildkite/phase-5-runtime-continuation.yml" {
+	if loader.Key != "phase-5-runtime-continuation-loader" || loader.DependsOn != "phase-5-runtime-importer" || !loader.AllowDependencyFailure || loader.Command != "buildkite-agent pipeline upload .buildkite/phase-5-runtime-continuation.yml" {
 		t.Fatalf("Phase 5 runtime continuation loader = %#v", loader)
 	}
 	for _, fragment := range []string{
@@ -783,7 +807,7 @@ func TestPhase5ContainerRuntimeProofContract(t *testing.T) {
 		}
 	}
 	continuationBody := read("phase-5-runtime-continuation.yml")
-	for _, fragment := range []string{`key: "phase-5-native-after-runtime"`, `step: "phase-5-hosted-runtime-probe"`, `allow_failure: true`, `queue: "elastic-runners"`} {
+	for _, fragment := range []string{`key: "phase-5-native-after-runtime"`, `step: "phase-5-hosted-runtime-probe"`, `allow_failure: true`} {
 		if !strings.Contains(string(continuationBody), fragment) {
 			t.Fatalf("Phase 5 runtime continuation lacks %q:\n%s", fragment, continuationBody)
 		}
@@ -831,9 +855,6 @@ func TestHostedSmokeControlAndAggregatorDependencies(t *testing.T) {
 		Key       string       `yaml:"key"`
 		Command   string       `yaml:"command"`
 		DependsOn []dependency `yaml:"depends_on"`
-		Agents    struct {
-			Queue string `yaml:"queue"`
-		} `yaml:"agents"`
 	}
 	read := func(name string) smokeStep {
 		t.Helper()
@@ -862,7 +883,7 @@ func TestHostedSmokeControlAndAggregatorDependencies(t *testing.T) {
 		}
 	}
 	control := read("hosted-smoke-control.yml")
-	if control.Key != "hosted-smoke-aggregator-loader" || control.Agents.Queue != "elastic-runners" || control.Command != "buildkite-agent pipeline upload .buildkite/hosted-smoke-aggregator.yml" {
+	if control.Key != "hosted-smoke-aggregator-loader" || control.Command != "buildkite-agent pipeline upload .buildkite/hosted-smoke-aggregator.yml" {
 		t.Fatalf("control step = %#v", control)
 	}
 	assertSet("control", control.DependsOn, map[string]bool{"phase-2-continuation-loader": true, "phase-3-continuation-loader": true, "phase-4-continuation-loader": true, "phase-5-continuation-loader": true, "phase-5-docker-action-continuation-loader": true, "phase-5-runtime-continuation-loader": true})
@@ -881,7 +902,7 @@ func TestHostedSmokeControlAndAggregatorDependencies(t *testing.T) {
 		want[key] = true
 	}
 	aggregator := read("hosted-smoke-aggregator.yml")
-	if aggregator.Key != "hosted-smoke-terminal" || aggregator.Agents.Queue != "elastic-runners" {
+	if aggregator.Key != "hosted-smoke-terminal" {
 		t.Fatalf("aggregator step = %#v", aggregator)
 	}
 	assertSet("aggregator", aggregator.DependsOn, want)

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -257,7 +257,11 @@ func TestCheckedInPipelinesTargetHostedQueue(t *testing.T) {
 			Agents struct {
 				Queue string `yaml:"queue"`
 			} `yaml:"agents"`
-			Steps []any `yaml:"steps"`
+			Steps []struct {
+				Agents struct {
+					Queue string `yaml:"queue"`
+				} `yaml:"agents"`
+			} `yaml:"steps"`
 		}
 		if err := yaml.Unmarshal(body, &document); err != nil {
 			t.Errorf("parse %s: %v", path, err)
@@ -268,6 +272,11 @@ func TestCheckedInPipelinesTargetHostedQueue(t *testing.T) {
 		}
 		if len(document.Steps) == 0 {
 			t.Errorf("%s has no steps", path)
+		}
+		for index, step := range document.Steps {
+			if step.Agents.Queue != "" && step.Agents.Queue != "hosted" {
+				t.Errorf("%s step %d overrides queue with %q, want hosted", path, index, step.Agents.Queue)
+			}
 		}
 		count++
 		return nil

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1115,7 +1115,7 @@ func TestArgumentParsersRejectRepeatedOptions(t *testing.T) {
 	if _, _, _, err := uploadArgs([]string{"workflow.yml"}); err == nil || !strings.Contains(err.Error(), "is required") {
 		t.Fatalf("uploadArgs() error = %v, want required runtime queue error", err)
 	}
-	if _, _, _, err := uploadArgs([]string{"--runtime-queue", "elastic-runners", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), `must be "hosted"`) {
+	if _, _, _, err := uploadArgs([]string{"--runtime-queue", "custom-runners", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), `must be "hosted"`) {
 		t.Fatalf("uploadArgs() error = %v, want fixed runtime queue error", err)
 	}
 }


### PR DESCRIPTION
## Summary

- make `hosted` the root queue for every checked-in Buildkite pipeline document
- remove the control-plane dependency on the unreliable `elastic-runners` queue while retaining explicit generated runtime queue bindings
- update the dormant transport probe instructions and add an invariant test covering all checked-in pipeline YAML and rejecting non-hosted step overrides

This avoids the elastic runner failure mode seen in [Buildkite build 190](https://buildkite.com/buildkite/buildkite-gha/builds/190/list?sid=019fa5ca-243e-44dd-abd4-eeb517a7127d&tab=output).

## Testing

- `mise run --jobs 1 check`
- `go test ./internal/buildkite` after addressing Oracle review

## Oracle review

Oracle recommended approval and found one test-hardening issue: a future step-level queue override could bypass the root queue invariant. Commit `34561ed` now rejects any checked-in non-hosted step override.

## Rollout checks

- ensure the Buildkite UI-defined bootstrap/pipeline-upload step also targets `hosted`; repository YAML cannot select the agent that uploads the root document
- confirm `GHA_GITHUB_RELEASE_TOKEN` remains available to the tagged release job on the hosted queue before the next release
- disable the elastic queue only after a complete hosted build passes