### PR TITLE
test: avoid race detector sleep in Docker fakes

### DIFF
--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -46,7 +46,7 @@ func newJobDocker(t *testing.T, scenario string) fakeJobDocker {
 		t.Fatal(err)
 	}
 	wrapper := filepath.Join(root, "docker")
-	text := "#!/bin/sh\nJOB_DOCKER_ROOT=" + strconv.Quote(root) + " JOB_DOCKER_SCENARIO=" + strconv.Quote(scenario) + " exec " + strconv.Quote(exe) + " -test.run=^TestJobContainerFakeDockerProcess$ -- \"$@\"\n"
+	text := "#!/bin/sh\nGORACE=atexit_sleep_ms=0 JOB_DOCKER_ROOT=" + strconv.Quote(root) + " JOB_DOCKER_SCENARIO=" + strconv.Quote(scenario) + " exec " + strconv.Quote(exe) + " -test.run=^TestJobContainerFakeDockerProcess$ -- \"$@\"\n"
 	if err := os.WriteFile(wrapper, []byte(text), 0o700); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -46,6 +46,7 @@ func newJobDocker(t *testing.T, scenario string) fakeJobDocker {
 		t.Fatal(err)
 	}
 	wrapper := filepath.Join(root, "docker")
+	// Avoid the race runtime's one-second exit sleep on every fake Docker call.
 	text := "#!/bin/sh\nGORACE=atexit_sleep_ms=0 JOB_DOCKER_ROOT=" + strconv.Quote(root) + " JOB_DOCKER_SCENARIO=" + strconv.Quote(scenario) + " exec " + strconv.Quote(exe) + " -test.run=^TestJobContainerFakeDockerProcess$ -- \"$@\"\n"
 	if err := os.WriteFile(wrapper, []byte(text), 0o700); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary

- disable the race detector's exit sleep only for fake-Docker helper processes
- keep race instrumentation and the production subprocess environment allowlist unchanged
- reduce the full race suite from roughly nine minutes to under thirty seconds locally

## Why

The container tests repeatedly execute their own race-instrumented test binary to fake Docker commands. Go's race runtime sleeps for one second at process exit by default, so hundreds of helper invocations dominated the Repository checks step.

## Verification

- `go test -race ./... -count=1` (26.41s)
- `go test ./internal/runtime -count=1` (14.36s)
- `go test -race ./internal/runtime -count=1` (28.26s, previously ~529s)
- `git diff --check`
- `gofmt -d internal/runtime/containers_test.go`

Oracle reviewed the change and recommended approval with no blocking findings.