### PR TITLE
Set up Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a single Go CLI product (`buildkite-gha`). There are **no long-running
+services, databases, or web servers** — "running the app" means invoking the
+CLI. Manual GUI testing does not apply.
+
+### Toolchain (managed by mise)
+
+- The toolchain (Go 1.26.5, Node 20/24, `golangci-lint`, `shellcheck`, `jq`,
+  `goreleaser`, `svu`) is pinned in `mise.toml` and installed with `mise`.
+- `mise` is installed at `~/.local/bin/mise` and activated for interactive
+  shells via `~/.bashrc`. The startup update script runs `mise install`, so
+  the toolchain is already present at session start.
+- In non-interactive shells where `mise` is not activated, prefix commands with
+  `mise exec -- <cmd>` (e.g. `mise exec -- go test ./...`) or run tasks with
+  `mise run <task>`. `GOTOOLCHAIN=local` is set by mise, so a bare system `go`
+  outside mise may try to fetch a toolchain — prefer going through mise.
+
+### Lint / test / build / run
+
+- Standard commands live in `mise.toml` (tasks) and `Makefile`; see also
+  `docs/development.md`. The aggregate gate is `mise run check` (alias
+  `make check`), which runs: format, build, test, test:race, lint:go,
+  lint:shell, vet, plan-fixtures, smoke:local, release:check.
+- Run the CLI directly: `go run ./cmd/buildkite-gha <command>` (commands:
+  `validate`, `compile`, `upload`, `run-job`; plus `help`, `--version`).
+
+### Non-obvious caveats
+
+- `compile` and `upload` require `--event-path <event.json>`; `validate` does
+  not. Sample event snapshots live under `testdata/smoke/events/` and
+  `testdata/phase4/events/`.
+- `mise run plan-fixtures` shells out to `python3` (system Python is fine; it is
+  not pinned by mise).
+- `mise run smoke:local` is network-free and part of `check`. `mise run
+  smoke:profile` and the hosted runtime proofs (`bk build create ...`) require
+  network access / Buildkite SaaS and are **optional** — not needed for local
+  dev, build, or the default check gate.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for `buildkite-gha` (a Go CLI, no long-running services) so future cloud agents can lint, test, build, and run the tool.

- Installs `mise` and the pinned toolchain (Go 1.26.5, Node 20/24, `golangci-lint`, `shellcheck`, `jq`, `goreleaser`, `svu`) per `mise.toml`.
- Update script: `mise trust`, `mise install`, `mise exec -- go mod download`.
- Adds `AGENTS.md` with durable, non-obvious startup/run caveats (mise usage, `GOTOOLCHAIN=local`, `--event-path` requirement for `compile`/`upload`, network-optional smoke lanes).

## Verification

Full gate `mise run check` passes: format, build, test, test:race, lint:go, lint:shell, vet, plan-fixtures, smoke:local, release:check.

Hello-world (core functionality) — validated and compiled a GitHub Actions workflow into deterministic Buildkite pipeline YAML:

```
$ buildkite-gha validate testdata/smoke/.github/workflows/ci.yml
Result: compilable
✓ 2 logical jobs and 2 static instances compile

$ buildkite-gha compile --event-path testdata/smoke/events/push.json testdata/smoke/.github/workflows/ci.yml
steps:
  - label: "producer"
    key: "gha-producer"
    ...
  - label: "consumer"
    key: "gha-consumer"
    depends_on:
      - step: "gha-producer"
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f524d797-7dd4-47bd-8932-659c12a43482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f524d797-7dd4-47bd-8932-659c12a43482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

