### PR TITLE
fix: serialize repository checks

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -76,6 +76,8 @@ steps:
 
   - label: ":go: Repository checks"
     key: "checks"
+    env:
+      BUILDKITE_GHA_LIVE_REQUIRED: "1"
     plugins:
       - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
           version: "2026.5.12"

--- a/docs/development.md
+++ b/docs/development.md
@@ -19,6 +19,10 @@ mise run check
 race-enabled tests, runs `go vet`, golangci-lint, and shellcheck, validates the
 signed plan-envelope fixtures, checks deterministic smoke compilation, and
 validates the release configuration. `make check` is a convenience alias.
+The standard and race-enabled suites run serially because their live container
+tests inspect daemon-wide Docker resources. Local runs may skip those tests when
+Docker or managed Node is unavailable; the hosted repository check requires the
+live prerequisites and fails rather than silently losing Phase 5 coverage.
 
 Focused tasks are also available:
 

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -300,9 +300,10 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 			Queue string `yaml:"queue"`
 		} `yaml:"agents"`
 		Steps []struct {
-			Key     string `yaml:"key"`
-			Command string `yaml:"command"`
-			If      string `yaml:"if"`
+			Key     string            `yaml:"key"`
+			Command string            `yaml:"command"`
+			If      string            `yaml:"if"`
+			Env     map[string]string `yaml:"env"`
 		} `yaml:"steps"`
 	}
 	if err := yaml.Unmarshal(source, &document); err != nil {
@@ -318,17 +319,22 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 		t.Fatalf("default pipeline = %#v, want nine gated loaders, repository checks, wait, and release", document.Steps)
 	}
 	steps := make(map[string]struct {
-		command   string
-		condition string
+		command     string
+		condition   string
+		environment map[string]string
 	}, len(document.Steps))
 	for _, step := range document.Steps {
 		steps[step.Key] = struct {
-			command   string
-			condition string
-		}{step.Command, step.If}
+			command     string
+			condition   string
+			environment map[string]string
+		}{command: step.Command, condition: step.If, environment: step.Env}
 	}
 	if got := steps["checks"]; got.command != "mise run --jobs 1 check" || got.condition != "" {
 		t.Fatalf("repository checks = %#v", got)
+	}
+	if got := steps["checks"].environment["BUILDKITE_GHA_LIVE_REQUIRED"]; got != "1" {
+		t.Fatalf("repository checks BUILDKITE_GHA_LIVE_REQUIRED = %q, want required live prerequisites", got)
 	}
 	if got := steps["publish-release"]; got.command != "mise exec -- scripts/ci-buildkite-release" || got.condition != "build.tag != null" {
 		t.Fatalf("release publisher = %#v", got)

--- a/mise.toml
+++ b/mise.toml
@@ -64,5 +64,4 @@ run = "./scripts/smoke-local --profile hosted-tokenless"
 
 [tasks.check]
 description = "Run formatting, build, tests, lint, vet, and fixture checks"
-depends = ["format", "build", "test", "test:race", "lint:go", "lint:shell", "vet", "plan-fixtures", "smoke:local", "release:check"]
-run = "true"
+run = "mise run --jobs 1 format ::: build ::: test ::: test:race ::: lint:go ::: lint:shell ::: vet ::: plan-fixtures ::: smoke:local ::: release:check"


### PR DESCRIPTION
## Summary

- run the aggregate repository checks serially so standard and race-enabled Docker suites cannot observe each other’s resources
- require live Docker and managed Node prerequisites in the hosted repository check
- assert and document the hosted-versus-local prerequisite behavior

## Why

`mise run check` previously scheduled `test` and `test:race` concurrently. Their daemon-wide Docker leak assertions could see resources owned by the other test process and report false leaks. Hosted checks could also silently skip Phase 5 coverage when a live prerequisite was unavailable.

## Verification

- `mise exec -- go test ./internal/buildkite`
- `mise exec -- go clean -testcache && BUILDKITE_GHA_LIVE_REQUIRED=1 mise run check`
- confirmed no `buildkite-gha-*` Docker containers, networks, or images remained