### PR TITLE
Centralize action integration classification

### DIFF
--- a/internal/action/integration/integration.go
+++ b/internal/action/integration/integration.go
@@ -43,10 +43,13 @@ type Descriptor struct {
 }
 
 var catalog = map[Identity]Descriptor{
-	{Source: "github", Repository: "actions/checkout"}:          {Adapter: AdapterCheckoutExactEventSHA},
-	{Source: "github", Repository: "actions/cache"}:             {Service: ServiceCache},
-	{Source: "github", Repository: "actions/upload-artifact"}:   {Service: ServiceArtifact},
-	{Source: "github", Repository: "actions/download-artifact"}: {Service: ServiceArtifact},
+	{Source: "github", Repository: "actions/checkout"}:                       {Adapter: AdapterCheckoutExactEventSHA},
+	{Source: "github", Repository: "actions/cache"}:                          {Service: ServiceCache},
+	{Source: "github", Repository: "actions/cache", Path: "restore"}:         {Service: ServiceCache},
+	{Source: "github", Repository: "actions/cache", Path: "save"}:            {Service: ServiceCache},
+	{Source: "github", Repository: "actions/upload-artifact"}:                {Service: ServiceArtifact},
+	{Source: "github", Repository: "actions/upload-artifact", Path: "merge"}: {Service: ServiceArtifact},
+	{Source: "github", Repository: "actions/download-artifact"}:              {Service: ServiceArtifact},
 }
 
 // Lookup returns the integration for an exact canonical action identity.

--- a/internal/action/integration/integration.go
+++ b/internal/action/integration/integration.go
@@ -1,0 +1,99 @@
+// Package integration classifies actions with Buildkite-specific execution or
+// service requirements.
+package integration
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Identity is the canonical, resolved portion of an action lock used for
+// integration matching. The immutable commit and source digest remain runtime
+// verification evidence rather than catalog selectors.
+type Identity struct {
+	Source     string
+	Repository string
+	Path       string
+}
+
+// Adapter identifies a runtime replacement for an action's upstream lifecycle.
+type Adapter string
+
+const (
+	// AdapterCheckoutExactEventSHA checks out the event repository at its exact
+	// event SHA without executing actions/checkout's JavaScript lifecycle.
+	AdapterCheckoutExactEventSHA Adapter = "checkout-exact-event-sha-v1"
+)
+
+// Service identifies an Actions runtime service used by a known action.
+// Service classification supports admission diagnostics only: services may be
+// used transitively and must not be provisioned based solely on this catalog.
+type Service string
+
+const (
+	ServiceArtifact Service = "artifact"
+	ServiceCache    Service = "cache"
+)
+
+// Descriptor records Buildkite-specific handling for one exact action identity.
+type Descriptor struct {
+	Adapter Adapter
+	Service Service
+}
+
+var catalog = map[Identity]Descriptor{
+	{Source: "github", Repository: "actions/checkout"}:          {Adapter: AdapterCheckoutExactEventSHA},
+	{Source: "github", Repository: "actions/cache"}:             {Service: ServiceCache},
+	{Source: "github", Repository: "actions/upload-artifact"}:   {Service: ServiceArtifact},
+	{Source: "github", Repository: "actions/download-artifact"}: {Service: ServiceArtifact},
+}
+
+// Lookup returns the integration for an exact canonical action identity.
+func Lookup(identity Identity) (Descriptor, bool) {
+	descriptor, ok := catalog[identity]
+	return descriptor, ok
+}
+
+// ValidateCheckoutInputs enforces the input contract implemented by the
+// tokenless exact-event-SHA checkout adapter.
+func ValidateCheckoutInputs(inputs map[string]string, repository, sha string) error {
+	names := make([]string, 0, len(inputs))
+	for name := range inputs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	seen := make(map[string]bool, len(names))
+	for _, name := range names {
+		value := inputs[name]
+		normalized := strings.ToLower(name)
+		if seen[normalized] {
+			return fmt.Errorf("duplicate case-insensitive input %q is unsupported; Phase 6 is required", name)
+		}
+		seen[normalized] = true
+		switch normalized {
+		case "repository":
+			if strings.EqualFold(value, repository) {
+				continue
+			}
+		case "ref":
+			if value == sha {
+				continue
+			}
+		case "persist-credentials":
+			if value == "false" {
+				continue
+			}
+		case "fetch-depth":
+			if value == "1" {
+				continue
+			}
+		case "clean", "set-safe-directory":
+			if value == "true" {
+				continue
+			}
+		}
+		return fmt.Errorf("explicit input %q is unsupported (including empty values); Phase 6 is required", name)
+	}
+	return nil
+}

--- a/internal/action/integration/integration_test.go
+++ b/internal/action/integration/integration_test.go
@@ -1,0 +1,68 @@
+package integration
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLookupMatchesCanonicalRootActions(t *testing.T) {
+	tests := []struct {
+		identity Identity
+		want     Descriptor
+	}{
+		{Identity{Source: "github", Repository: "actions/checkout"}, Descriptor{Adapter: AdapterCheckoutExactEventSHA}},
+		{Identity{Source: "github", Repository: "actions/cache"}, Descriptor{Service: ServiceCache}},
+		{Identity{Source: "github", Repository: "actions/upload-artifact"}, Descriptor{Service: ServiceArtifact}},
+		{Identity{Source: "github", Repository: "actions/download-artifact"}, Descriptor{Service: ServiceArtifact}},
+	}
+	for _, test := range tests {
+		t.Run(test.identity.Repository, func(t *testing.T) {
+			got, ok := Lookup(test.identity)
+			if !ok || got != test.want {
+				t.Fatalf("Lookup(%#v) = %#v, %t, want %#v, true", test.identity, got, ok, test.want)
+			}
+		})
+	}
+}
+
+func TestLookupDoesNotBroadenCanonicalIdentity(t *testing.T) {
+	for _, identity := range []Identity{
+		{Source: "workspace", Repository: "actions/checkout"},
+		{Source: "github", Repository: "Actions/Checkout"},
+		{Source: "github", Repository: "actions/checkout", Path: "nested"},
+		{Source: "github", Repository: "actions/cache", Path: "nested"},
+		{Source: "github", Repository: "owner/action"},
+	} {
+		if descriptor, ok := Lookup(identity); ok {
+			t.Fatalf("Lookup(%#v) = %#v, true, want no integration", identity, descriptor)
+		}
+	}
+}
+
+func TestValidateCheckoutInputs(t *testing.T) {
+	repository, sha := "buildkite/buildkite-gha", strings.Repeat("a", 40)
+	for _, inputs := range []map[string]string{
+		nil,
+		{"repository": "BUILDKITE/BUILDKITE-GHA", "ref": sha, "fetch-depth": "1", "persist-credentials": "false", "clean": "true", "set-safe-directory": "true"},
+	} {
+		if err := ValidateCheckoutInputs(inputs, repository, sha); err != nil {
+			t.Fatalf("ValidateCheckoutInputs(%#v) = %v", inputs, err)
+		}
+	}
+
+	for name, inputs := range map[string]map[string]string{
+		"token":                {"token": ""},
+		"foreign repository":   {"repository": "other/repository"},
+		"foreign ref":          {"ref": strings.Repeat("b", 40)},
+		"submodules":           {"submodules": "true"},
+		"path":                 {"path": "nested"},
+		"persist credentials":  {"persist-credentials": "true"},
+		"case-colliding names": {"Repository": repository, "repository": repository},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := ValidateCheckoutInputs(inputs, repository, sha); err == nil || !strings.Contains(err.Error(), "Phase 6") {
+				t.Fatalf("ValidateCheckoutInputs(%#v) = %v, want Phase 6 rejection", inputs, err)
+			}
+		})
+	}
+}

--- a/internal/action/integration/integration_test.go
+++ b/internal/action/integration/integration_test.go
@@ -5,18 +5,25 @@ import (
 	"testing"
 )
 
-func TestLookupMatchesCanonicalRootActions(t *testing.T) {
+func TestLookupMatchesKnownCanonicalActions(t *testing.T) {
 	tests := []struct {
 		identity Identity
 		want     Descriptor
 	}{
 		{Identity{Source: "github", Repository: "actions/checkout"}, Descriptor{Adapter: AdapterCheckoutExactEventSHA}},
 		{Identity{Source: "github", Repository: "actions/cache"}, Descriptor{Service: ServiceCache}},
+		{Identity{Source: "github", Repository: "actions/cache", Path: "restore"}, Descriptor{Service: ServiceCache}},
+		{Identity{Source: "github", Repository: "actions/cache", Path: "save"}, Descriptor{Service: ServiceCache}},
 		{Identity{Source: "github", Repository: "actions/upload-artifact"}, Descriptor{Service: ServiceArtifact}},
+		{Identity{Source: "github", Repository: "actions/upload-artifact", Path: "merge"}, Descriptor{Service: ServiceArtifact}},
 		{Identity{Source: "github", Repository: "actions/download-artifact"}, Descriptor{Service: ServiceArtifact}},
 	}
 	for _, test := range tests {
-		t.Run(test.identity.Repository, func(t *testing.T) {
+		name := test.identity.Repository
+		if test.identity.Path != "" {
+			name += "/" + test.identity.Path
+		}
+		t.Run(name, func(t *testing.T) {
 			got, ok := Lookup(test.identity)
 			if !ok || got != test.want {
 				t.Fatalf("Lookup(%#v) = %#v, %t, want %#v, true", test.identity, got, ok, test.want)
@@ -31,6 +38,8 @@ func TestLookupDoesNotBroadenCanonicalIdentity(t *testing.T) {
 		{Source: "github", Repository: "Actions/Checkout"},
 		{Source: "github", Repository: "actions/checkout", Path: "nested"},
 		{Source: "github", Repository: "actions/cache", Path: "nested"},
+		{Source: "github", Repository: "actions/upload-artifact", Path: "nested"},
+		{Source: "github", Repository: "actions/download-artifact", Path: "nested"},
 		{Source: "github", Repository: "owner/action"},
 	} {
 		if descriptor, ok := Lookup(identity); ok {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -19,6 +19,7 @@ import (
 	"syscall"
 	"time"
 
+	actionintegration "github.com/buildkite/buildkite-gha/internal/action/integration"
 	actionsource "github.com/buildkite/buildkite-gha/internal/action/source"
 	buildkitepipeline "github.com/buildkite/buildkite-gha/internal/buildkite"
 	"github.com/buildkite/buildkite-gha/internal/compatibility"
@@ -718,18 +719,9 @@ func validateUnprivilegedBundle(bundle compiler.Bundle) error {
 			}
 		}
 		for _, action := range artifact.Job.Actions {
-			if action.Source != "github" {
-				continue
-			}
-			var service string
-			switch strings.ToLower(action.Repository) {
-			case "actions/upload-artifact", "actions/download-artifact":
-				service = "artifact"
-			case "actions/cache":
-				service = "cache"
-			}
-			if service != "" {
-				return fmt.Errorf("job %q uses action %q, which requires the unavailable GitHub Actions %s service; Phase 6 is required", artifact.Job.Workflow.LogicalJobID, action.Repository, service)
+			descriptor, _ := actionintegration.Lookup(actionintegration.Identity{Source: action.Source, Repository: action.Repository, Path: action.Path})
+			if descriptor.Service != "" {
+				return fmt.Errorf("job %q uses action %q, which requires the unavailable GitHub Actions %s service; Phase 6 is required", artifact.Job.Workflow.LogicalJobID, action.Repository, descriptor.Service)
 			}
 		}
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -677,19 +677,30 @@ func TestUnprivilegedUploadRejectsContainerProvenance(t *testing.T) {
 }
 
 func TestUnprivilegedUploadRejectsKnownGitHubServiceActions(t *testing.T) {
-	for repository, service := range map[string]string{
-		"actions/upload-artifact":   "artifact",
-		"actions/download-artifact": "artifact",
-		"actions/cache":             "cache",
-	} {
-		t.Run(repository, func(t *testing.T) {
+	tests := []struct {
+		action  plan.ActionLock
+		service string
+	}{
+		{plan.ActionLock{Source: "github", Repository: "actions/upload-artifact"}, "artifact"},
+		{plan.ActionLock{Source: "github", Repository: "actions/upload-artifact", Path: "merge"}, "artifact"},
+		{plan.ActionLock{Source: "github", Repository: "actions/download-artifact"}, "artifact"},
+		{plan.ActionLock{Source: "github", Repository: "actions/cache"}, "cache"},
+		{plan.ActionLock{Source: "github", Repository: "actions/cache", Path: "restore"}, "cache"},
+		{plan.ActionLock{Source: "github", Repository: "actions/cache", Path: "save"}, "cache"},
+	}
+	for _, test := range tests {
+		name := test.action.Repository
+		if test.action.Path != "" {
+			name += "/" + test.action.Path
+		}
+		t.Run(name, func(t *testing.T) {
 			bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: plan.Job{
 				Workflow: plan.Workflow{LogicalJobID: "service-action"},
-				Actions:  []plan.ActionLock{{Source: "github", Repository: repository}},
+				Actions:  []plan.ActionLock{test.action},
 			}}}}
 			err := validateUnprivilegedBundle(bundle)
-			if err == nil || !strings.Contains(err.Error(), "GitHub Actions "+service+" service") || !strings.Contains(err.Error(), "Phase 6") {
-				t.Fatalf("validateUnprivilegedBundle(%q) error = %v", repository, err)
+			if err == nil || !strings.Contains(err.Error(), "GitHub Actions "+test.service+" service") || !strings.Contains(err.Error(), "Phase 6") {
+				t.Fatalf("validateUnprivilegedBundle(%#v) error = %v", test.action, err)
 			}
 		})
 	}
@@ -699,6 +710,8 @@ func TestUnprivilegedUploadDoesNotBroadenKnownServiceActionIdentity(t *testing.T
 	for _, action := range []plan.ActionLock{
 		{Source: "workspace", Repository: "actions/cache"},
 		{Source: "github", Repository: "actions/cache", Path: "nested"},
+		{Source: "github", Repository: "actions/upload-artifact", Path: "nested"},
+		{Source: "github", Repository: "actions/download-artifact", Path: "nested"},
 		{Source: "github", Repository: "owner/action"},
 	} {
 		bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: plan.Job{

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -695,6 +695,22 @@ func TestUnprivilegedUploadRejectsKnownGitHubServiceActions(t *testing.T) {
 	}
 }
 
+func TestUnprivilegedUploadDoesNotBroadenKnownServiceActionIdentity(t *testing.T) {
+	for _, action := range []plan.ActionLock{
+		{Source: "workspace", Repository: "actions/cache"},
+		{Source: "github", Repository: "actions/cache", Path: "nested"},
+		{Source: "github", Repository: "owner/action"},
+	} {
+		bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: plan.Job{
+			Workflow: plan.Workflow{LogicalJobID: "ordinary-action"},
+			Actions:  []plan.ActionLock{action},
+		}}}}
+		if err := validateUnprivilegedBundle(bundle); err != nil {
+			t.Fatalf("validateUnprivilegedBundle(%#v) error = %v", action, err)
+		}
+	}
+}
+
 func TestBundleUsesActionsDetectsStepsAndLocks(t *testing.T) {
 	for _, job := range []plan.Job{
 		{Steps: []plan.Step{{Kind: "uses"}}},

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"unicode"
 
+	actionintegration "github.com/buildkite/buildkite-gha/internal/action/integration"
 	"github.com/buildkite/buildkite-gha/internal/action/metadata"
 	"github.com/buildkite/buildkite-gha/internal/expression"
 	"github.com/buildkite/buildkite-gha/internal/plan"
@@ -270,20 +271,28 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 			}
 		}
 		if lockActions && len(actionRefs) != 0 {
-			for _, i := range actionIndexes {
-				if strings.HasPrefix(strings.ToLower(instance.Steps[i].Uses), "actions/checkout@") {
-					if err := validateCheckoutInputs(instance.Steps[i].With, ir.Event.Repository.Owner+"/"+ir.Event.Repository.Name, ir.Event.SHA); err != nil {
-						span := instance.Steps[i].Span.Start
-						return nil, nil, fmt.Errorf("%s:%d:%d: tokenless checkout adapter: %w", instance.SourcePath, span.Line, span.Column, err)
-					}
-				}
-			}
 			selectors, locks, actionCapabilities, err := compileActionLocks(ctx, instance.RepositoryRoot, actionSource, actionRefs)
 			if err != nil {
 				return nil, nil, fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err)
 			}
+			locksByID := make(map[string]plan.ActionLock, len(locks))
+			for _, lock := range locks {
+				locksByID[lock.ID] = lock
+			}
 			for i, selector := range selectors {
-				steps[actionIndexes[i]].Action = &plan.ActionSelector{Lock: selector.Lock}
+				stepIndex := actionIndexes[i]
+				steps[stepIndex].Action = &plan.ActionSelector{Lock: selector.Lock}
+				lock, ok := locksByID[selector.Lock]
+				if !ok {
+					return nil, nil, fmt.Errorf("build plan for job %q: action lock %q is missing", instance.LogicalJobID, selector.Lock)
+				}
+				descriptor, _ := actionintegration.Lookup(actionintegration.Identity{Source: lock.Source, Repository: lock.Repository, Path: lock.Path})
+				if descriptor.Adapter == actionintegration.AdapterCheckoutExactEventSHA {
+					if err := actionintegration.ValidateCheckoutInputs(instance.Steps[stepIndex].With, ir.Event.Repository.Owner+"/"+ir.Event.Repository.Name, ir.Event.SHA); err != nil {
+						span := instance.Steps[stepIndex].Span.Start
+						return nil, nil, fmt.Errorf("%s:%d:%d: tokenless checkout adapter: %w", instance.SourcePath, span.Line, span.Column, err)
+					}
+				}
 			}
 			jobSchema = plan.SchemaV3
 			actions = locks
@@ -388,48 +397,6 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 		authorizations = append(authorizations, authorization)
 	}
 	return plans, authorizations, nil
-}
-
-func validateCheckoutInputs(inputs map[string]string, repository, sha string) error {
-	names := make([]string, 0, len(inputs))
-	for name := range inputs {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	seen := make(map[string]bool, len(names))
-	for _, name := range names {
-		value := inputs[name]
-		normalized := strings.ToLower(name)
-		if seen[normalized] {
-			return fmt.Errorf("duplicate case-insensitive input %q is unsupported; Phase 6 is required", name)
-		}
-		seen[normalized] = true
-		switch normalized {
-		case "repository":
-			if !strings.EqualFold(value, repository) {
-				return fmt.Errorf("input %q is unsupported; Phase 6 is required", name)
-			}
-		case "ref":
-			if value != sha {
-				return fmt.Errorf("input %q is unsupported; Phase 6 is required", name)
-			}
-		case "persist-credentials":
-			if value != "false" {
-				return fmt.Errorf("input %q is unsupported; Phase 6 is required", name)
-			}
-		case "fetch-depth":
-			if value != "1" {
-				return fmt.Errorf("input %q is unsupported; Phase 6 is required", name)
-			}
-		case "clean", "set-safe-directory":
-			if value != "true" {
-				return fmt.Errorf("input %q is unsupported; Phase 6 is required", name)
-			}
-		default:
-			return fmt.Errorf("explicit input %q is unsupported (including empty values); Phase 6 is required", name)
-		}
-	}
-	return nil
 }
 
 func requiredSecrets(instance JobInstance) ([]string, error) {

--- a/internal/runtime/actions.go
+++ b/internal/runtime/actions.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 
+	actionintegration "github.com/buildkite/buildkite-gha/internal/action/integration"
 	"github.com/buildkite/buildkite-gha/internal/action/metadata"
 	"github.com/buildkite/buildkite-gha/internal/action/source"
 	"github.com/buildkite/buildkite-gha/internal/plan"
@@ -52,6 +53,11 @@ func newActionLockResolver(job plan.Job, workspace string, materializer ActionMa
 		r.locks[lock.ID] = &actionLockEntry{lock: lock}
 	}
 	return r
+}
+
+func usesCheckoutAdapter(lock plan.ActionLock) bool {
+	descriptor, _ := actionintegration.Lookup(actionintegration.Identity{Source: lock.Source, Repository: lock.Repository, Path: lock.Path})
+	return descriptor.Adapter == actionintegration.AdapterCheckoutExactEventSHA
 }
 
 func (r *actionLockResolver) source(selector plan.ActionSelector) (string, error) {

--- a/internal/runtime/checkout.go
+++ b/internal/runtime/checkout.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 
+	actionintegration "github.com/buildkite/buildkite-gha/internal/action/integration"
 	"github.com/buildkite/buildkite-gha/internal/plan"
 )
 
@@ -20,8 +21,8 @@ func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, wo
 	if job.Event.Provider != "github" || !checkoutRepositoryPattern.MatchString(job.Event.Repository) || !checkoutSHAPattern.MatchString(job.Event.SHA) {
 		return result, fmt.Errorf("tokenless checkout adapter requires a valid github.com event repository and exact SHA; Phase 6 is required for other events")
 	}
-	if err := validateCheckoutRuntimeInputs(inputs, job.Event.Repository, job.Event.SHA); err != nil {
-		return result, err
+	if err := actionintegration.ValidateCheckoutInputs(inputs, job.Event.Repository, job.Event.SHA); err != nil {
+		return result, fmt.Errorf("tokenless checkout adapter: %w", err)
 	}
 	entries, err := os.ReadDir(workspace)
 	if err != nil {
@@ -73,40 +74,4 @@ func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, wo
 	result.Outputs["ref"] = job.Event.Ref
 	result.Outputs["commit"] = job.Event.SHA
 	return result, nil
-}
-
-func validateCheckoutRuntimeInputs(inputs map[string]string, repository, sha string) error {
-	seen := make(map[string]bool, len(inputs))
-	for _, name := range sortedKeys(inputs) {
-		value := inputs[name]
-		normalized := strings.ToLower(name)
-		if seen[normalized] {
-			return fmt.Errorf("tokenless checkout adapter does not support duplicate case-insensitive input %q; Phase 6 is required", name)
-		}
-		seen[normalized] = true
-		switch normalized {
-		case "repository":
-			if strings.EqualFold(value, repository) {
-				continue
-			}
-		case "ref":
-			if value == sha {
-				continue
-			}
-		case "persist-credentials":
-			if value == "false" {
-				continue
-			}
-		case "fetch-depth":
-			if value == "1" {
-				continue
-			}
-		case "clean", "set-safe-directory":
-			if value == "true" {
-				continue
-			}
-		}
-		return fmt.Errorf("tokenless checkout adapter does not support explicit input %q (including empty token); Phase 6 is required", name)
-	}
-	return nil
 }

--- a/internal/runtime/checkout_test.go
+++ b/internal/runtime/checkout_test.go
@@ -144,36 +144,15 @@ esac
 
 func TestTokenlessCheckoutAdapterRejectsUnsupportedInputsAndState(t *testing.T) {
 	repository, sha := "buildkite/buildkite-gha", strings.Repeat("a", 40)
-	for name, inputs := range map[string]map[string]string{
-		"token":                {"token": ""},
-		"foreign repository":   {"repository": "other/repository"},
-		"foreign ref":          {"ref": strings.Repeat("b", 40)},
-		"submodules":           {"submodules": "true"},
-		"path":                 {"path": "nested"},
-		"persist credentials":  {"persist-credentials": "true"},
-		"case-colliding names": {"Repository": repository, "repository": repository},
-	} {
-		t.Run(name, func(t *testing.T) {
-			if err := validateCheckoutRuntimeInputs(inputs, repository, sha); err == nil || !strings.Contains(err.Error(), "Phase 6") {
-				t.Fatalf("validateCheckoutRuntimeInputs() error = %v", err)
-			}
-		})
-	}
-	for _, inputs := range []map[string]string{
-		nil,
-		{"repository": "BUILDKITE/BUILDKITE-GHA", "ref": sha, "fetch-depth": "1", "persist-credentials": "false", "clean": "true", "set-safe-directory": "true"},
-	} {
-		if err := validateCheckoutRuntimeInputs(inputs, repository, sha); err != nil {
-			t.Fatalf("validateCheckoutRuntimeInputs(%#v) = %v", inputs, err)
-		}
-	}
-
 	processor := newCommandProcessor(io.Discard, io.Discard)
+	job := plan.Job{Event: plan.Event{Provider: "github", Repository: repository, SHA: sha}}
+	if _, err := (Runner{}).runCheckout(context.Background(), processor, t.TempDir(), job, map[string]string{"token": ""}); err == nil || !strings.Contains(err.Error(), "Phase 6") {
+		t.Fatalf("runCheckout() unsupported input error = %v", err)
+	}
 	workspace := t.TempDir()
 	if err := os.WriteFile(filepath.Join(workspace, "occupied"), []byte("x"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	job := plan.Job{Event: plan.Event{Provider: "github", Repository: repository, SHA: sha}}
 	if _, err := (Runner{}).runCheckout(context.Background(), processor, workspace, job, nil); err == nil || !strings.Contains(err.Error(), "empty workspace") {
 		t.Fatalf("nonempty workspace error = %v", err)
 	}

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -725,7 +725,7 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 		// The checkout adapter replaces the verified action's JavaScript
 		// lifecycle as one indivisible operation. Do not register upstream
 		// checkout cleanup for a main phase that this runtime never executes.
-		if lock.Source == "github" && lock.Repository == "actions/checkout" && lock.Path == "" {
+		if usesCheckoutAdapter(lock) {
 			return result, nil
 		}
 		runPre, err := evaluateLifecycleCondition(action.Runs.PreIf, status.unsuccessful, ctx.Err() != nil)
@@ -881,7 +881,7 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 			return result, err
 		}
 		action, actionLock = resolvedAction, &lock
-		if lock.Source == "github" && lock.Repository == "actions/checkout" && lock.Path == "" {
+		if usesCheckoutAdapter(lock) {
 			inputs, err := evaluateMap(step.With, eval)
 			if err != nil {
 				return result, err


### PR DESCRIPTION
## Summary

- add a single exact-match catalog for Buildkite-specific action integrations, keyed by canonical action-lock source, repository, and path
- classify checkout lifecycle replacement and known cache/artifact service clients from resolved locks
- share the tokenless checkout input contract between compilation and runtime validation
- remove duplicated compiler, admission, and runtime identity checks

## Why

Earlier phases accumulated separate interpretations of official actions across compilation, hosted admission, and execution. Those checks could drift as Phase 6 adds service support.

The catalog is deliberately a classifier rather than a handler framework. Immutable commit and source-digest verification remain in the existing action-lock path. Cache and artifact provisioning remain job-level service concerns, including the direct Cache v2 direction in buildkite/buildkite#31795; catalog entries provide only known-client admission diagnostics.

Matching is exact, so nested, workspace, or noncanonical actions do not acquire built-in behavior. No job-plan schema changes are required.

## Verification

- `mise run check`
