### PR TITLE
Bound aggregate job summaries

### DIFF
--- a/internal/runtime/concurrent.go
+++ b/internal/runtime/concurrent.go
@@ -196,7 +196,7 @@ func commitStepExecution(execution stepExecution, jobResult *JobResult, eval *ex
 	commitResultEnvironment(jobResult.Env, execution.result)
 	eval.Env = jobResult.Env
 	mergeInto(jobResult.State, execution.result.State)
-	jobResult.Summary += execution.result.Summary
+	appendJobSummary(&jobResult.Summary, &jobResult.summaryTruncated, execution.result.Summary, execution.result.summaryTruncated)
 	statuses[id] = expression.StepStatus{Outcome: execution.outcome, Conclusion: execution.conclusion, Outputs: execution.result.Outputs}
 	if execution.conclusion != "success" {
 		return fmt.Errorf("step %q: %w", execution.step.ID, execution.err)

--- a/internal/runtime/files.go
+++ b/internal/runtime/files.go
@@ -27,9 +27,10 @@ type commandFiles struct {
 }
 
 type fileCommandEffects struct {
-	paths    []string
-	pathBase string
-	pathSet  bool
+	paths        []string
+	pathBase     string
+	pathSet      bool
+	summaryBytes int64
 }
 
 func newCommandFiles() (commandFiles, error) {
@@ -97,27 +98,33 @@ func (files commandFiles) cleanup() error {
 }
 
 func (files commandFiles) apply(result *Result, state map[string]string) (fileCommandEffects, error) {
-	if err := files.checkSizeBudget(); err != nil {
+	summaryBytes, err := files.checkSizeBudget()
+	if err != nil {
 		return fileCommandEffects{}, err
 	}
+	effects := fileCommandEffects{summaryBytes: summaryBytes}
 	outputs, outputErr := files.parseCommandFile(files.output)
 	env, envErr := files.parseCommandFile(files.env)
 	states, stateErr := files.parseCommandFile(files.state)
-	summary, summaryErr := files.readBoundedFile(files.summary, maxCommandFileBytes)
+	var summary []byte
+	var summaryErr error
+	if summaryBytes <= maxCommandFileBytes {
+		summary, summaryErr = files.readBoundedFile(files.summary, maxCommandFileBytes)
+	}
 	paths, pathErr := files.parsePathFile(files.path)
 	if outputErr != nil || envErr != nil || stateErr != nil || summaryErr != nil || pathErr != nil {
-		return fileCommandEffects{}, errors.Join(outputErr, envErr, stateErr, summaryErr, pathErr)
+		return effects, errors.Join(outputErr, envErr, stateErr, summaryErr, pathErr)
 	}
 	for name := range env {
 		if strings.EqualFold(name, "NODE_OPTIONS") {
-			return fileCommandEffects{}, errors.New("GITHUB_ENV may not set NODE_OPTIONS")
+			return effects, errors.New("GITHUB_ENV may not set NODE_OPTIONS")
 		}
 		upper := strings.ToUpper(name)
 		if strings.HasPrefix(upper, "GITHUB_") || strings.HasPrefix(upper, "RUNNER_") {
-			return fileCommandEffects{}, fmt.Errorf("GITHUB_ENV may not set reserved variable %s", name)
+			return effects, fmt.Errorf("GITHUB_ENV may not set reserved variable %s", name)
 		}
 	}
-	effects := fileCommandEffects{paths: paths}
+	effects.paths = paths
 	if pathBase, ok := env["PATH"]; ok {
 		effects.pathBase = pathBase
 		effects.pathSet = true
@@ -137,31 +144,38 @@ func (files commandFiles) apply(result *Result, state map[string]string) (fileCo
 			state[name] = value
 		}
 	}
-	result.Summary += string(summary)
+	appendJobSummary(&result.Summary, &result.summaryTruncated, string(summary), false)
 	result.Paths = append(result.Paths, paths...)
 	return effects, nil
 }
 
-func (files commandFiles) checkSizeBudget() error {
+func (files commandFiles) checkSizeBudget() (int64, error) {
 	var total int64
+	var summaryBytes int64
 	for _, path := range []string{files.output, files.env, files.state, files.summary, files.path} {
 		file, err := files.retained(path)
 		if err != nil {
-			return err
+			return 0, err
 		}
 		info, err := file.Stat()
 		if err != nil {
-			return fmt.Errorf("stat file command %s: %w", filepath.Base(path), err)
+			return 0, fmt.Errorf("stat file command %s: %w", filepath.Base(path), err)
+		}
+		if path == files.summary {
+			summaryBytes = info.Size()
+			if summaryBytes > maxCommandFileBytes {
+				continue
+			}
 		}
 		if info.Size() > maxCommandFileBytes {
-			return fmt.Errorf("file command %s exceeds the %d-byte limit", filepath.Base(path), maxCommandFileBytes)
+			return 0, fmt.Errorf("file command %s exceeds the %d-byte limit", filepath.Base(path), maxCommandFileBytes)
 		}
 		total += info.Size()
 	}
 	if total > maxCommandFilesBytes {
-		return fmt.Errorf("file commands exceed the %d-byte aggregate limit", maxCommandFilesBytes)
+		return 0, fmt.Errorf("file commands exceed the %d-byte aggregate limit", maxCommandFilesBytes)
 	}
-	return nil
+	return summaryBytes, nil
 }
 
 func (files commandFiles) parseCommandFile(path string) (map[string]string, error) {

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -27,6 +27,8 @@ type JobResult struct {
 	Env        map[string]string `json:"env,omitempty"`
 	State      map[string]string `json:"state,omitempty"`
 	Summary    string            `json:"summary,omitempty"`
+
+	summaryTruncated bool
 }
 
 const maxJobOutputBytes = 1024
@@ -309,7 +311,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 			preResult, preErr := r.prepareRemoteAction(runCtx, processor, step, strconv.Itoa(stepIndex), jobResult.Env, eval, &posts, actions, prepared, &preStatus, nil)
 			commitResultEnvironment(jobResult.Env, preResult)
 			mergeInto(jobResult.State, preResult.State)
-			jobResult.Summary += preResult.Summary
+			appendJobSummary(&jobResult.Summary, &jobResult.summaryTruncated, preResult.Summary, preResult.summaryTruncated)
 			eval.Env = jobResult.Env
 			if preErr != nil {
 				preStatus.unsuccessful = true
@@ -413,7 +415,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		postErr := r.runJavaScriptPhase(cleanupCtx, processor, post.node, post.action, post.action.Post, post.state, post.state, &postResult)
 		mergeInto(jobResult.Env, postResult.Env)
 		mergeInto(jobResult.State, postResult.State)
-		jobResult.Summary += postResult.Summary
+		appendJobSummary(&jobResult.Summary, &jobResult.summaryTruncated, postResult.Summary, postResult.summaryTruncated)
 		if postErr != nil {
 			runErr = errors.Join(runErr, fmt.Errorf("post action %q: %w", post.action.Name, postErr))
 		}
@@ -445,6 +447,12 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 }
 
 func scrubJobResult(result JobResult, sensitiveValues []string) JobResult {
+	sort.Slice(sensitiveValues, func(i, j int) bool {
+		if len(sensitiveValues[i]) != len(sensitiveValues[j]) {
+			return len(sensitiveValues[i]) > len(sensitiveValues[j])
+		}
+		return sensitiveValues[i] < sensitiveValues[j]
+	})
 	scrub := func(value string) string {
 		for _, sensitive := range sensitiveValues {
 			if sensitive != "" {
@@ -462,8 +470,40 @@ func scrubJobResult(result JobResult, sensitiveValues []string) JobResult {
 	for name, value := range result.State {
 		result.State[name] = scrub(value)
 	}
-	result.Summary = scrub(result.Summary)
+	summary, summaryTruncated := result.Summary, result.summaryTruncated
+	for _, sensitive := range sensitiveValues {
+		if sensitive != "" {
+			summary = strings.ReplaceAll(summary, sensitive, "***")
+			summary, summaryTruncated = boundJobSummary(summary, summaryTruncated)
+		}
+	}
+	result.Summary, result.summaryTruncated = boundJobSummary(summary, summaryTruncated)
+	if result.summaryTruncated {
+		result.Summary = trimSensitiveSummarySuffix(result.Summary, sensitiveValues)
+	}
+	result.Summary = finalizeJobSummary(result.Summary, result.summaryTruncated)
 	return result
+}
+
+func trimSensitiveSummarySuffix(summary string, sensitiveValues []string) string {
+	for {
+		trimmed := false
+		for _, sensitive := range sensitiveValues {
+			for prefixBytes := min(len(sensitive)-1, len(summary)); prefixBytes > 0; prefixBytes-- {
+				if strings.HasSuffix(summary, sensitive[:prefixBytes]) {
+					summary = summary[:len(summary)-prefixBytes]
+					trimmed = true
+					break
+				}
+			}
+			if trimmed {
+				break
+			}
+		}
+		if !trimmed {
+			return summary
+		}
+	}
 }
 
 func (r Runner) resolveSecrets(ctx context.Context, processor *commandProcessor, names []string) (map[string]string, error) {
@@ -811,7 +851,7 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 			}
 			result.Paths = append(result.Paths, childResult.Paths...)
 			mergeInto(result.State, childResult.State)
-			result.Summary += childResult.Summary
+			appendJobSummary(&result.Summary, &result.summaryTruncated, childResult.Summary, childResult.summaryTruncated)
 			if childErr != nil {
 				status.unsuccessful = true
 				err = errors.Join(err, fmt.Errorf("composite action step %d: %w", i+1, childErr))
@@ -1100,7 +1140,7 @@ func (r Runner) runCompositeMetadata(ctx context.Context, processor *commandProc
 		}
 		result.Paths = append(result.Paths, stepResult.Paths...)
 		mergeInto(result.State, stepResult.State)
-		result.Summary += stepResult.Summary
+		appendJobSummary(&result.Summary, &result.summaryTruncated, stepResult.Summary, stepResult.summaryTruncated)
 		if id != "" {
 			eval.Steps[id] = stepResult.Outputs
 			outcome := "success"

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/buildkite/buildkite-gha/internal/action/source"
 )
@@ -28,6 +29,10 @@ const (
 	defaultInterruptGrace = 7500 * time.Millisecond
 	defaultTerminateGrace = 2500 * time.Millisecond
 	maxStreamLineBytes    = 1024 * 1024
+	// Match Buildkite's maximum annotation body size.
+	maxJobSummaryBytes = 1024 * 1024
+
+	jobSummaryTruncationNotice = "\n\n---\n_Job summary truncated at the 1 MiB limit._\n"
 )
 
 // Runner executes verified actions using explicitly configured host tools.
@@ -96,8 +101,53 @@ type Result struct {
 	Summary string
 	Paths   []string
 
-	pathBase    string
-	pathBaseSet bool
+	pathBase         string
+	pathBaseSet      bool
+	summaryTruncated bool
+}
+
+// appendJobSummary is the only summary aggregation path. It preserves a
+// deterministic UTF-8 prefix and reserves room for a final truncation notice.
+func appendJobSummary(summary *string, truncated *bool, next string, nextTruncated bool) {
+	if *truncated || (next == "" && !nextTruncated) {
+		return
+	}
+	if !nextTruncated && len(*summary) <= maxJobSummaryBytes && len(next) <= maxJobSummaryBytes-len(*summary) {
+		*summary += next
+		return
+	}
+
+	prefixLimit := maxJobSummaryBytes - len(jobSummaryTruncationNotice)
+	if len(*summary) > prefixLimit {
+		*summary = utf8Prefix(*summary, prefixLimit)
+	} else {
+		*summary += utf8Prefix(next, prefixLimit-len(*summary))
+	}
+	*truncated = true
+}
+
+func utf8Prefix(value string, limit int) string {
+	if len(value) <= limit {
+		return value
+	}
+	for limit > 0 && !utf8.RuneStart(value[limit]) {
+		limit--
+	}
+	return value[:limit]
+}
+
+func finalizeJobSummary(summary string, truncated bool) string {
+	if truncated {
+		return summary + jobSummaryTruncationNotice
+	}
+	return summary
+}
+
+func boundJobSummary(summary string, truncated bool) (string, bool) {
+	var bounded string
+	var boundedTruncated bool
+	appendJobSummary(&bounded, &boundedTruncated, summary, truncated)
+	return bounded, boundedTruncated
 }
 
 // RunDocker builds and executes an explicitly resolved local Docker action.
@@ -323,7 +373,8 @@ func (r Runner) runDocker(ctx context.Context, processor *commandProcessor, acti
 	if runErr != nil {
 		runErr = fmt.Errorf("run Docker action %q: %w", action.Name, runErr)
 	}
-	_, fileErr := files.apply(&result, nil)
+	effects, fileErr := files.apply(&result, nil)
+	effects.reportSummaryUploadFailure(processor)
 	if fileErr != nil {
 		fileErr = fmt.Errorf("process Docker action %q file commands: %w", action.Name, fileErr)
 	}
@@ -523,6 +574,7 @@ func (r Runner) runProcess(ctx context.Context, processor *commandProcessor, dir
 		runErr = r.runStreaming(ctx, processor, dir, env, name, args...)
 	}
 	effects, fileErr := files.apply(result, state)
+	effects.reportSummaryUploadFailure(processor)
 	if fileErr == nil && (effects.pathSet || len(effects.paths) > 0) {
 		pathEnv := map[string]string{"PATH": env["PATH"]}
 		if effects.pathSet {
@@ -532,6 +584,13 @@ func (r Runner) runProcess(ctx context.Context, processor *commandProcessor, dir
 		result.Env["PATH"] = pathEnv["PATH"]
 	}
 	return errors.Join(runErr, fileErr)
+}
+
+func (effects fileCommandEffects) reportSummaryUploadFailure(processor *commandProcessor) {
+	if effects.summaryBytes <= maxCommandFileBytes {
+		return
+	}
+	processor.process(processor.stderr, fmt.Sprintf("GITHUB_STEP_SUMMARY upload skipped: content is %d bytes; maximum is %d bytes", effects.summaryBytes, maxCommandFileBytes))
 }
 
 func (r Runner) runStreaming(ctx context.Context, processor *commandProcessor, dir string, env map[string]string, name string, args ...string) error {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -21,6 +21,7 @@ import (
 	"syscall"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/buildkite/buildkite-gha/internal/action/metadata"
 	"github.com/buildkite/buildkite-gha/internal/action/source"
@@ -1098,6 +1099,62 @@ test "${{ steps.two.outputs.value }}" = output-two`},
 	}
 }
 
+func TestBackgroundSummariesAreBoundedInCommitOrder(t *testing.T) {
+	supervisor := newBackgroundSupervisor(2)
+	releaseFirst := make(chan struct{})
+	completionOrder := make(chan string, 2)
+	first := plan.Step{ID: "first"}
+	second := plan.Step{ID: "second"}
+	summaryBytes := maxJobSummaryBytes * 3 / 4
+
+	supervisor.start(context.Background(), first.ID,
+		func(context.Context) stepExecution {
+			<-releaseFirst
+			completionOrder <- first.ID
+			result := newResult()
+			result.Summary = strings.Repeat("a", summaryBytes)
+			return classifyStepExecution(context.Background(), context.Background(), first, result, nil)
+		},
+		func(ctx context.Context) stepExecution {
+			return cancelledStepExecution(context.Background(), ctx, first)
+		},
+	)
+	supervisor.start(context.Background(), second.ID,
+		func(context.Context) stepExecution {
+			completionOrder <- second.ID
+			close(releaseFirst)
+			result := newResult()
+			result.Summary = strings.Repeat("b", summaryBytes)
+			return classifyStepExecution(context.Background(), context.Background(), second, result, nil)
+		},
+		func(ctx context.Context) stepExecution {
+			return cancelledStepExecution(context.Background(), ctx, second)
+		},
+	)
+
+	jobResult := JobResult{Env: map[string]string{}, State: map[string]string{}}
+	eval := expression.Context{Steps: map[string]map[string]string{}}
+	statuses := map[string]expression.StepStatus{}
+	for _, execution := range supervisor.waitAll() {
+		if err := commitStepExecution(execution, &jobResult, &eval, statuses); err != nil {
+			t.Fatal(err)
+		}
+	}
+	jobResult.Summary = finalizeJobSummary(jobResult.Summary, jobResult.summaryTruncated)
+
+	if got := []string{<-completionOrder, <-completionOrder}; !slices.Equal(got, []string{second.ID, first.ID}) {
+		t.Fatalf("completion order = %v, want second then first", got)
+	}
+	if len(jobResult.Summary) > maxJobSummaryBytes || !strings.HasSuffix(jobResult.Summary, jobSummaryTruncationNotice) {
+		t.Fatalf("summary bytes = %d, suffix present = %v", len(jobResult.Summary), strings.HasSuffix(jobResult.Summary, jobSummaryTruncationNotice))
+	}
+	prefix := strings.TrimSuffix(jobResult.Summary, jobSummaryTruncationNotice)
+	wantPrefix := strings.Repeat("a", summaryBytes) + strings.Repeat("b", len(prefix)-summaryBytes)
+	if prefix != wantPrefix {
+		t.Fatalf("summary did not preserve commit order")
+	}
+}
+
 func TestConcurrentPathEffectsComposeWithLiveBarrierState(t *testing.T) {
 	workspace := t.TempDir()
 	workflowPath := ".github/workflows/test.yml"
@@ -1730,6 +1787,69 @@ func TestJavaScriptPreMainPostFilesAndMasking(t *testing.T) {
 	}
 }
 
+func TestPostActionSummaryOverflowIsTruncatedWithoutFailingJob(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	writeFixtureFile(t, workspace, ".github/actions/summary/action.yml", `name: Summary writer
+runs:
+  using: node24
+  main: main.js
+  post: post.js
+`)
+	writeFixtureFile(t, workspace, ".github/actions/summary/main.js", "")
+	writeFixtureFile(t, workspace, ".github/actions/summary/post.js", "")
+	fakeNode := filepath.Join(workspace, "node24")
+	writeFixtureFile(t, workspace, "node24", `#!/bin/sh
+set -eu
+if [ "${1:-}" = --version ]; then
+  echo v24.0.0
+  exit 0
+fi
+case "${1##*/}" in
+  main.js) head -c "$MAIN_SUMMARY_BYTES" /dev/zero | tr '\000' m >> "$GITHUB_STEP_SUMMARY" ;;
+  post.js) printf 'post-summary-must-be-truncated\n' >> "$GITHUB_STEP_SUMMARY" ;;
+esac
+`)
+	if err := os.Chmod(fakeNode, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "summary", Kind: "uses", Uses: "./.github/actions/summary"}})
+	job.Env = map[string]string{"MAIN_SUMMARY_BYTES": strconv.Itoa(maxJobSummaryBytes)}
+
+	result, err := (Runner{Node24: fakeNode}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	if len(result.Summary) > maxJobSummaryBytes || strings.Contains(result.Summary, "post-summary-must-be-truncated") || !strings.HasSuffix(result.Summary, jobSummaryTruncationNotice) {
+		t.Fatalf("RunJob() summary bytes = %d, suffix present = %v", len(result.Summary), strings.HasSuffix(result.Summary, jobSummaryTruncationNotice))
+	}
+}
+
+func TestOversizedStepSummaryIsNonFatalAndDiscarded(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{
+		{ID: "oversized", Kind: "run", Shell: "sh", Command: `
+printf 'SUMMARY_EFFECT=preserved\n' >> "$GITHUB_ENV"
+head -c "$SUMMARY_BYTES" /dev/zero | tr '\000' x >> "$GITHUB_STEP_SUMMARY"`},
+		{ID: "after", Kind: "run", Shell: "sh", Command: `
+test "$SUMMARY_EFFECT" = preserved
+printf 'retained summary\n' >> "$GITHUB_STEP_SUMMARY"`},
+	})
+	job.Env = map[string]string{"SUMMARY_BYTES": strconv.Itoa(maxCommandFileBytes + 1)}
+	var logs bytes.Buffer
+
+	result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" || result.Env["SUMMARY_EFFECT"] != "preserved" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	if result.Summary != "retained summary\n" || !strings.Contains(logs.String(), "GITHUB_STEP_SUMMARY upload skipped") {
+		t.Fatalf("RunJob() summary = %q, logs = %q", result.Summary, logs.String())
+	}
+}
+
 func TestPostActionsRunLIFOAfterMainFailure(t *testing.T) {
 	node := requireNode24(t)
 	var logs bytes.Buffer
@@ -2022,8 +2142,24 @@ func TestFileCommandAggregateLimits(t *testing.T) {
 		t.Fatal(err)
 	}
 	result = newResult()
-	if _, err := files.apply(&result, nil); err == nil || !strings.Contains(err.Error(), "summary exceeds") {
-		t.Fatalf("apply() error = %v, want summary size limit", err)
+	effects, err := files.apply(&result, nil)
+	if err != nil || result.Summary != "" || effects.summaryBytes != maxCommandFileBytes+1 {
+		t.Fatalf("oversized summary result = %#v, effects = %#v, error = %v", result, effects, err)
+	}
+
+	if err := os.WriteFile(files.summary, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(files.output, bytes.Repeat([]byte("x"), maxCommandFileBytes+1), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	result = newResult()
+	if _, err := files.apply(&result, nil); err == nil || !strings.Contains(err.Error(), "output exceeds") {
+		t.Fatalf("apply() error = %v, want output size limit", err)
+	}
+
+	if err := os.WriteFile(files.output, nil, 0o600); err != nil {
+		t.Fatal(err)
 	}
 
 	for _, path := range []string{files.output, files.env, files.state} {
@@ -2037,6 +2173,57 @@ func TestFileCommandAggregateLimits(t *testing.T) {
 	result = newResult()
 	if _, err := files.apply(&result, nil); err == nil || !strings.Contains(err.Error(), "aggregate limit") {
 		t.Fatalf("apply() error = %v, want aggregate size limit", err)
+	}
+}
+
+func TestJobSummaryTruncationPreservesUTF8(t *testing.T) {
+	var summary string
+	var truncated bool
+	prefixBytes := maxJobSummaryBytes - 1
+	appendJobSummary(&summary, &truncated, strings.Repeat("a", prefixBytes), false)
+	appendJobSummary(&summary, &truncated, "€ and omitted text", false)
+	summary = finalizeJobSummary(summary, truncated)
+
+	if !truncated || len(summary) > maxJobSummaryBytes || !utf8.ValidString(summary) {
+		t.Fatalf("summary truncated = %v, bytes = %d, valid UTF-8 = %v", truncated, len(summary), utf8.ValidString(summary))
+	}
+	if strings.Contains(summary, "€") || !strings.HasSuffix(summary, jobSummaryTruncationNotice) {
+		t.Fatalf("summary split a UTF-8 rune or omitted its truncation notice")
+	}
+}
+
+func TestJobSummaryRemainsBoundedAfterSecretScrubbing(t *testing.T) {
+	secret := "xx"
+	result := JobResult{Summary: strings.Repeat(secret, maxJobSummaryBytes/len(secret))}
+	result = scrubJobResult(result, []string{secret})
+
+	if len(result.Summary) > maxJobSummaryBytes || !utf8.ValidString(result.Summary) {
+		t.Fatalf("scrubbed summary bytes = %d, valid UTF-8 = %v", len(result.Summary), utf8.ValidString(result.Summary))
+	}
+	if strings.Contains(result.Summary, secret) || !strings.HasSuffix(result.Summary, jobSummaryTruncationNotice) {
+		t.Fatalf("scrubbed summary leaked the secret or omitted its truncation notice")
+	}
+}
+
+func TestTruncatedJobSummaryDoesNotExposePartialSecret(t *testing.T) {
+	secret := "partial-secret-token"
+	prefixBytes := maxJobSummaryBytes - len(jobSummaryTruncationNotice)
+	visibleSecretBytes := len(secret) / 2
+	contents := strings.Repeat("a", prefixBytes-visibleSecretBytes) + secret + strings.Repeat("z", len(jobSummaryTruncationNotice))
+	result := JobResult{}
+	appendJobSummary(&result.Summary, &result.summaryTruncated, contents, false)
+
+	result = scrubJobResult(result, []string{secret})
+	if strings.Contains(result.Summary, secret[:visibleSecretBytes]) || !strings.HasSuffix(result.Summary, jobSummaryTruncationNotice) {
+		t.Fatalf("truncated summary retained a partial secret suffix")
+	}
+}
+
+func TestJobSummarySecretScrubbingIsOrderIndependent(t *testing.T) {
+	first := scrubJobResult(JobResult{Summary: "overlapping-secret"}, []string{"overlapping", "overlapping-secret"})
+	second := scrubJobResult(JobResult{Summary: "overlapping-secret"}, []string{"overlapping-secret", "overlapping"})
+	if first.Summary != "***" || second.Summary != first.Summary {
+		t.Fatalf("scrubbed summaries = %q and %q, want deterministic longest match", first.Summary, second.Summary)
 	}
 }
 


### PR DESCRIPTION
## Summary

- route pre, main, background, composite, nested, and post-action summaries through one deterministic accumulator
- cap the final job summary at 1 MiB with UTF-8-safe truncation and a clear notice
- preserve secret redaction safety when masking expands or intersects the truncation boundary
- treat an oversized per-step summary as a non-fatal upload failure while preserving the step's other effects

## Why

Job summaries were individually bounded but could grow without limit while being combined across a job. Establishing this runtime contract separately keeps the follow-up Buildkite annotation publication focused on presentation and transport.

## Testing

- `mise run check`
