### PR TITLE
Publish job summaries as Buildkite annotations

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -40,7 +40,7 @@ artifact, cache, token, or OIDC service that this project does not provide.
 | Anonymous public actions | Supported | Sources are resolved to immutable commits and complete trees are verified. |
 | `actions/checkout` | Narrow support | Public `github.com` event repository, exact event SHA, workspace root, shallow credential-free fetch. |
 | Dockerfile actions | Supported subset | Only compiler-verified local or anonymous public Dockerfile actions are admitted. |
-| Step summaries | Not surfaced | The runtime processes `GITHUB_STEP_SUMMARY`, but production generated jobs do not publish it to the Buildkite UI. |
+| Step summaries | Supported | Published as job-scoped Buildkite annotations with a stable context. Requires Buildkite Agent v3.112 or newer. Oversized per-step summaries are skipped without failing the job; aggregate job summaries are bounded to 1 MiB. |
 | Job and service containers | Not admitted | Implemented and runtime-proven, but still outside production `hosted-tokenless` policy. |
 | `docker://` actions | Not supported | Private images, credentials, arbitrary options, volumes, and privileged containers are also rejected. |
 | Artifact and cache actions | Not supported | They compile but fail profile admission until Buildkite-backed adapters exist. |

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -918,8 +918,10 @@ mask values to `buildkite-agent redactor add` before subsequent output is
 written. A secret printed before it is registered cannot be retroactively
 protected.
 
-Step summaries should become job-scoped Buildkite annotations when supported,
-with a stable context and artifact fallback for oversized content.
+Step summaries become job-scoped Buildkite annotations when supported, with a
+stable context. Oversized per-step summaries are rejected without failing the
+job, matching GitHub Actions, while the aggregate annotation is truncated to
+Buildkite's 1 MiB body limit.
 
 Parallel step logs need explicit step identity. Prefer live prefixed output and
 per-step completion summaries over buffering all output until completion.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -249,6 +249,9 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 		if publication.MetadataMirrorError != nil {
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: warning: result metadata mirror: %v\n", publication.MetadataMirrorError)
 		}
+		if publication.SummaryAnnotationError != nil {
+			_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: warning: job summary annotation: %v\n", publication.SummaryAnnotationError)
+		}
 		if err != nil {
 			runErr = errors.Join(runErr, fmt.Errorf("publish terminal result: %w", err))
 		}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/buildkite/buildkite-gha/internal/compatibility"
 	"github.com/buildkite/buildkite-gha/internal/compiler"
 	"github.com/buildkite/buildkite-gha/internal/plan"
+	gharuntime "github.com/buildkite/buildkite-gha/internal/runtime"
 	"github.com/buildkite/buildkite-gha/internal/transport"
 	"go.yaml.in/yaml/v4"
 )
@@ -761,13 +762,14 @@ type cliCommand struct {
 }
 
 type cliCaptureRunner struct {
-	commands      []cliCommand
-	failAt        int
-	failMetadata  bool
-	jobByStep     map[string]string
-	dataByPath    map[string][]byte
-	uploaded      map[string][]byte
-	contextErrors []error
+	commands       []cliCommand
+	failAt         int
+	failMetadata   bool
+	failAnnotation bool
+	jobByStep      map[string]string
+	dataByPath     map[string][]byte
+	uploaded       map[string][]byte
+	contextErrors  []error
 }
 
 func (r *cliCaptureRunner) Run(ctx context.Context, dir, name string, args []string, stdin []byte) ([]byte, error) {
@@ -802,6 +804,9 @@ func (r *cliCaptureRunner) Run(ctx context.Context, dir, name string, args []str
 	}
 	if r.failMetadata && len(args) >= 2 && args[0] == "meta-data" && args[1] == "set" {
 		return nil, errors.New("metadata unavailable")
+	}
+	if r.failAnnotation && len(args) > 0 && args[0] == "annotate" {
+		return nil, errors.New("annotation unavailable")
 	}
 	return nil, nil
 }
@@ -969,6 +974,65 @@ func TestRunJobHydratesNeedsAndPublishesAuthoritativeResult(t *testing.T) {
 	}
 }
 
+func TestRunJobPublishesSummaryAsAdvisoryJobAnnotation(t *testing.T) {
+	tests := []struct {
+		name           string
+		command        string
+		failAnnotation bool
+		wantAnnotation bool
+		wantWarning    bool
+		wantResult     string
+		wantCode       int
+	}{
+		{name: "published", command: `printf '### Job summary\n\nPassed.\n' >> "$GITHUB_STEP_SUMMARY"`, wantAnnotation: true, wantResult: "success"},
+		{name: "published after job failure", command: `printf '### Job summary\n\nPassed.\n' >> "$GITHUB_STEP_SUMMARY"; exit 7`, wantAnnotation: true, wantResult: "failure", wantCode: 1},
+		{name: "failure is advisory", command: `printf '### Job summary\n\nPassed.\n' >> "$GITHUB_STEP_SUMMARY"`, failAnnotation: true, wantAnnotation: true, wantWarning: true, wantResult: "success"},
+		{name: "empty summary is a no-op", command: "true", wantResult: "success"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			job := cliRunJobPlan()
+			job.Steps[0].Command = test.command
+			planPath, planDigest := writeCLIJobPlan(t, job)
+			setCLIJobIdentity(t, job, planDigest)
+			runner := &cliCaptureRunner{failAnnotation: test.failAnnotation}
+			var stdout, stderr bytes.Buffer
+
+			if code := run([]string{"run-job", "--plan", planPath}, &stdout, &stderr, "dev", runner); code != test.wantCode {
+				t.Fatalf("run() code = %d, stderr = %q, want %d", code, stderr.String(), test.wantCode)
+			}
+			if result := publishedCLIManifest(t, runner, job, planDigest); result.Result != test.wantResult {
+				t.Fatalf("published result = %q, want %q", result.Result, test.wantResult)
+			}
+			var annotations []cliCommand
+			for _, command := range runner.commands {
+				if len(command.args) > 0 && command.args[0] == "annotate" {
+					annotations = append(annotations, command)
+				}
+			}
+			if !test.wantAnnotation {
+				if len(annotations) != 0 {
+					t.Fatalf("annotations = %#v, want none", annotations)
+				}
+				return
+			}
+			wantArgs := []string{"annotate", "--scope", "job", "--job", cliTestJobID, "--context", "buildkite-gha-job-summary", "--style", "info"}
+			if len(annotations) != 1 || !slices.Equal(annotations[0].args, wantArgs) || string(annotations[0].stdin) != "### Job summary\n\nPassed.\n" {
+				t.Fatalf("annotations = %#v", annotations)
+			}
+			if last := runner.commands[len(runner.commands)-1]; len(last.args) == 0 || last.args[0] != "annotate" {
+				t.Fatalf("last command = %#v, want annotation after authoritative publication", last)
+			}
+			if gotWarning := strings.Contains(stderr.String(), "warning: job summary annotation"); gotWarning != test.wantWarning {
+				t.Fatalf("stderr = %q, warning present = %v, want %v", stderr.String(), gotWarning, test.wantWarning)
+			}
+			if runner.contextErrors[len(runner.contextErrors)-1] != nil {
+				t.Fatalf("annotation inherited cancelled context: %v", runner.contextErrors[len(runner.contextErrors)-1])
+			}
+		})
+	}
+}
+
 func TestRunJobPublishesEveryTerminalResultAfterCancellation(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -1010,6 +1074,32 @@ func TestRunJobPublishesEveryTerminalResultAfterCancellation(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestPublishTerminalResultAnnotatesCancelledJobSummaryWithFreshContext(t *testing.T) {
+	job := cliRunJobPlan()
+	planDigest := transport.Digest([]byte("cancelled-plan"))
+	producer := transport.Producer{BuildID: cliTestBuildID, JobID: cliTestJobID, StepKey: job.Target.StepKey}
+	runner := &cliCaptureRunner{}
+
+	publication, err := publishTerminalResult(
+		transport.Agent{Runner: runner},
+		t.TempDir(),
+		job,
+		planDigest,
+		producer,
+		gharuntime.JobResult{Conclusion: "cancelled", Summary: "summary before cancellation\n"},
+	)
+	if err != nil || publication.SummaryAnnotationError != nil {
+		t.Fatalf("publishTerminalResult() publication = %#v, error = %v", publication, err)
+	}
+	last := runner.commands[len(runner.commands)-1]
+	if len(last.args) == 0 || last.args[0] != "annotate" || string(last.stdin) != "summary before cancellation\n" {
+		t.Fatalf("last command = %#v, want cancelled job summary annotation", last)
+	}
+	if runner.contextErrors[len(runner.contextErrors)-1] != nil {
+		t.Fatalf("annotation inherited cancelled context: %v", runner.contextErrors[len(runner.contextErrors)-1])
 	}
 }
 
@@ -1088,6 +1178,7 @@ func TestRunJobFailsWhenAuthoritativePublicationFails(t *testing.T) {
 
 func TestRunJobPublishesBoundedFailureForUnrepresentableOutputs(t *testing.T) {
 	job := cliRunJobPlan()
+	job.Steps[0].Command = `printf 'summary from malformed result\n' >> "$GITHUB_STEP_SUMMARY"`
 	job.Outputs = make(map[string]string, transport.MaxResultOutputs+1)
 	for i := 0; i <= transport.MaxResultOutputs; i++ {
 		job.Outputs[fmt.Sprintf("output_%02d", i)] = "value"
@@ -1102,6 +1193,10 @@ func TestRunJobPublishesBoundedFailureForUnrepresentableOutputs(t *testing.T) {
 	manifest := publishedCLIManifest(t, runner, job, planDigest)
 	if manifest.Result != "failure" || len(manifest.Outputs) != 0 {
 		t.Fatalf("published result = %#v, want bounded failure without outputs", manifest)
+	}
+	last := runner.commands[len(runner.commands)-1]
+	if len(last.args) == 0 || last.args[0] != "annotate" || string(last.stdin) != "summary from malformed result\n" {
+		t.Fatalf("last command = %#v, want summary annotation after bounded failure", last)
 	}
 }
 

--- a/internal/runtime/needs.go
+++ b/internal/runtime/needs.go
@@ -9,6 +9,8 @@ import (
 	"github.com/buildkite/buildkite-gha/internal/transport"
 )
 
+const jobSummaryAnnotationContext = "buildkite-gha-job-summary"
+
 // ResolveNeeds converts compiler-owned producer identities into the verified
 // logical results and outputs consumed by runtime expression contexts.
 func ResolveNeeds(ctx context.Context, agent transport.Agent, root, buildID string, sources map[string][]plan.NeedSource) (map[string]plan.Need, error) {
@@ -56,7 +58,22 @@ func PublishJobResult(ctx context.Context, agent transport.Agent, root, workflow
 		if publishErr != nil {
 			return publication, errors.Join(fmt.Errorf("validate terminal result: %w", err), fmt.Errorf("publish bounded terminal result: %w", publishErr))
 		}
+		publishJobSummary(ctx, agent, producer.JobID, result.Summary, &publication)
 		return publication, fmt.Errorf("validate terminal result: %w", err)
 	}
-	return transport.PublishResult(ctx, agent, root, workflow, instance, manifest)
+	publication, err := transport.PublishResult(ctx, agent, root, workflow, instance, manifest)
+	if err != nil {
+		return publication, err
+	}
+	publishJobSummary(ctx, agent, producer.JobID, result.Summary, &publication)
+	return publication, nil
+}
+
+func publishJobSummary(ctx context.Context, agent transport.Agent, jobID, summary string, publication *transport.Publication) {
+	if summary == "" {
+		return
+	}
+	if err := agent.AnnotateJob(ctx, jobID, jobSummaryAnnotationContext, "info", summary); err != nil {
+		publication.SummaryAnnotationError = fmt.Errorf("publish job summary: %w", err)
+	}
 }

--- a/internal/transport/boundary.go
+++ b/internal/transport/boundary.go
@@ -10,6 +10,12 @@ import (
 	"path/filepath"
 	"slices"
 	"sort"
+	"unicode/utf8"
+)
+
+const (
+	maxAnnotationBodyBytes         = 1024 * 1024
+	maxAnnotationContextCharacters = 100
 )
 
 // Runner is the only process boundary used by the Buildkite adapter.
@@ -69,6 +75,27 @@ func (a Agent) GetMetadata(ctx context.Context, key string) ([]byte, error) {
 
 func (a Agent) UploadPipeline(ctx context.Context, pipeline []byte) error {
 	_, err := a.run(ctx, []string{"pipeline", "upload", "--no-interpolation", "--reject-secrets"}, pipeline)
+	return err
+}
+
+// AnnotateJob publishes Markdown through stdin under a job-scoped context.
+// Reusing the context updates the annotation instead of duplicating it.
+func (a Agent) AnnotateJob(ctx context.Context, jobID, annotationContext, style, body string) error {
+	if !uuidPattern.MatchString(jobID) {
+		return fmt.Errorf("invalid annotation job ID %q", jobID)
+	}
+	if !utf8.ValidString(annotationContext) || utf8.RuneCountInString(annotationContext) < 1 || utf8.RuneCountInString(annotationContext) > maxAnnotationContextCharacters {
+		return fmt.Errorf("annotation context must be valid UTF-8 between 1 and %d characters", maxAnnotationContextCharacters)
+	}
+	switch style {
+	case "success", "info", "warning", "error":
+	default:
+		return fmt.Errorf("invalid annotation style %q", style)
+	}
+	if body == "" || len(body) > maxAnnotationBodyBytes || !utf8.ValidString(body) {
+		return fmt.Errorf("annotation body must be valid UTF-8 between 1 and %d bytes", maxAnnotationBodyBytes)
+	}
+	_, err := a.run(ctx, []string{"annotate", "--scope", "job", "--job", jobID, "--context", annotationContext, "--style", style}, []byte(body))
 	return err
 }
 

--- a/internal/transport/model_test.go
+++ b/internal/transport/model_test.go
@@ -182,6 +182,44 @@ func TestAgentUsesExactProducerAndSafeUploadFlags(t *testing.T) {
 	}
 }
 
+func TestAgentPublishesBoundedJobAnnotationThroughStdin(t *testing.T) {
+	runner := &captureRunner{}
+	agent := Agent{Runner: runner}
+	body := "### Job summary\n\nPassed.\n"
+	if err := agent.AnnotateJob(context.Background(), testJobID, "buildkite-gha-job-summary", "info", body); err != nil {
+		t.Fatal(err)
+	}
+	want := capturedCommand{
+		name:  "buildkite-agent",
+		args:  []string{"annotate", "--scope", "job", "--job", testJobID, "--context", "buildkite-gha-job-summary", "--style", "info"},
+		stdin: body,
+	}
+	if !reflect.DeepEqual(runner.commands, []capturedCommand{want}) {
+		t.Fatalf("commands = %#v, want %#v", runner.commands, want)
+	}
+
+	for _, test := range []struct {
+		name, jobID, context, style, body string
+	}{
+		{name: "invalid job", jobID: "not-a-job", context: "summary", style: "info", body: "body"},
+		{name: "empty context", jobID: testJobID, style: "info", body: "body"},
+		{name: "oversized context", jobID: testJobID, context: strings.Repeat("x", maxAnnotationContextCharacters+1), style: "info", body: "body"},
+		{name: "invalid context UTF-8", jobID: testJobID, context: string([]byte{0xff}), style: "info", body: "body"},
+		{name: "invalid style", jobID: testJobID, context: "summary", style: "default", body: "body"},
+		{name: "empty body", jobID: testJobID, context: "summary", style: "info"},
+		{name: "oversized body", jobID: testJobID, context: "summary", style: "info", body: strings.Repeat("x", maxAnnotationBodyBytes+1)},
+		{name: "invalid UTF-8", jobID: testJobID, context: "summary", style: "info", body: string([]byte{0xff})},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			validationRunner := &captureRunner{}
+			err := (Agent{Runner: validationRunner}).AnnotateJob(context.Background(), test.jobID, test.context, test.style, test.body)
+			if err == nil || len(validationRunner.commands) != 0 {
+				t.Fatalf("AnnotateJob() error = %v, commands = %#v", err, validationRunner.commands)
+			}
+		})
+	}
+}
+
 func TestUploadArtifactsMaterializesContentBeforePipeline(t *testing.T) {
 	root := t.TempDir()
 	plan := Artifact{Path: ".buildkite-gha/plans/plan.json", Contents: []byte("plan\n")}

--- a/internal/transport/results.go
+++ b/internal/transport/results.go
@@ -24,12 +24,13 @@ type NeedResult struct {
 	Producers []Producer
 }
 
-// Publication records the authoritative artifact and any non-fatal metadata
-// mirror failure. Consumers never use the mirror to make runtime decisions.
+// Publication records the authoritative artifact and non-fatal visibility
+// failures. Consumers never use metadata or annotations as runtime authority.
 type Publication struct {
-	Path                string
-	ManifestDigest      string
-	MetadataMirrorError error
+	Path                   string
+	ManifestDigest         string
+	MetadataMirrorError    error
+	SummaryAnnotationError error
 }
 
 // SearchArtifactProducer resolves exactly one artifact owner under the


### PR DESCRIPTION
## Summary

- publish non-empty, bounded and scrubbed job summaries as job-scoped Buildkite annotations
- use a stable context so retries update rather than duplicate the annotation
- keep annotation failures advisory and preserve the authoritative terminal result manifest
- document the Buildkite Agent v3.112+ requirement and summary size behavior

## Contract

The runtime invokes `buildkite-agent annotate` with Markdown on stdin, `--scope job`, the validated Buildkite job UUID, context `buildkite-gha-job-summary`, and `info` style. Publication happens only after the authoritative result artifact and metadata mirrors have been attempted. Empty summaries are a no-op; summaries from failed and cancelled jobs are still eligible for publication.

## Verification

- `mise run check`
- focused transport/runtime/CLI tests cover argument and stdin shape, validation, stable ordering, advisory failure, empty summaries, failed/cancelled jobs, and malformed-result fallback
