### PR TITLE
Add Phase 6 summary annotation proof

### DIFF
--- a/.buildkite/hosted-smoke-aggregator.yml
+++ b/.buildkite/hosted-smoke-aggregator.yml
@@ -23,6 +23,8 @@ steps:
         allow_failure: true
       - step: "phase-5-hosted-runtime-probe"
         allow_failure: true
+      - step: "gha-summary-annotation"
+        allow_failure: true
       - step: "phase-2-native-after-shell"
         allow_failure: true
       - step: "phase-3-native-after-concurrent"
@@ -34,6 +36,8 @@ steps:
       - step: "phase-5-native-after-docker-action"
         allow_failure: true
       - step: "phase-5-native-after-runtime"
+        allow_failure: true
+      - step: "phase-6-native-after-summary"
         allow_failure: true
     command: |
       set -euo pipefail
@@ -48,12 +52,14 @@ steps:
         phase-5-hosted-docker-probe \
         gha-docker-action \
         phase-5-hosted-runtime-probe \
+        gha-summary-annotation \
         phase-2-native-after-shell \
         phase-3-native-after-concurrent \
         phase-4-native-after-actions \
         phase-5-native-after-hosted-docker \
         phase-5-native-after-docker-action \
-        phase-5-native-after-runtime
+        phase-5-native-after-runtime \
+        phase-6-native-after-summary
       do
         outcome="$$(buildkite-agent step get "outcome" --step "$$step")"
         printf '%s: %s\n' "$$step" "$$outcome"

--- a/.buildkite/hosted-smoke-control.yml
+++ b/.buildkite/hosted-smoke-control.yml
@@ -17,4 +17,6 @@ steps:
         allow_failure: true
       - step: "phase-5-runtime-continuation-loader"
         allow_failure: true
+      - step: "phase-6-summary-continuation-loader"
+        allow_failure: true
     command: "buildkite-agent pipeline upload .buildkite/hosted-smoke-aggregator.yml"

--- a/.buildkite/phase-6-summary-continuation.yml
+++ b/.buildkite/phase-6-summary-continuation.yml
@@ -1,0 +1,10 @@
+agents:
+  queue: "hosted"
+
+steps:
+  - label: ":white_check_mark: Phase 6 summary annotation settled"
+    key: "phase-6-native-after-summary"
+    depends_on:
+      - step: "gha-summary-annotation"
+        allow_failure: true
+    command: "echo 'Phase 6 summary annotation job settled before API verification'"

--- a/.buildkite/phase-6-summary.yml
+++ b/.buildkite/phase-6-summary.yml
@@ -1,0 +1,31 @@
+agents:
+  queue: "hosted"
+
+steps:
+  - label: ":memo: Phase 6 summary annotation importer"
+    key: "phase-6-summary-importer"
+    timeout_in_minutes: 15
+    retry:
+      automatic: false
+    plugins:
+      - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
+          version: "2026.5.12"
+    command: |
+      set -euo pipefail
+      commit="$${PHASE6_COMMIT:-$${SMOKE_COMMIT:-}}"
+      scripts/phase-0-shell-oracle-checkout "$$commit"
+      test -z "$$(git status --porcelain --untracked-files=all)"
+      distribution_root="$$(mktemp -d "$${TMPDIR:-/tmp}/buildkite-gha-phase6-summary.XXXXXXXX")"
+      trap 'rm -rf -- "$$distribution_root"' EXIT
+      runtime_version="0.0.0-phase6.$$commit"
+      CGO_ENABLED=0 mise exec -- go build -trimpath -buildvcs=false -ldflags "-X main.version=$$runtime_version" -o "$$distribution_root/buildkite-gha" ./cmd/buildkite-gha
+      "$$distribution_root/buildkite-gha" upload \
+        --event-path testdata/smoke/events/push.json \
+        --runtime-queue hosted \
+        testdata/phase6/.github/workflows/summary-annotation.yml
+
+  - label: ":pipeline: Phase 6 summary annotation continuation loader"
+    key: "phase-6-summary-continuation-loader"
+    depends_on: "phase-6-summary-importer"
+    allow_dependency_failure: true
+    command: "buildkite-agent pipeline upload .buildkite/phase-6-summary-continuation.yml"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -45,6 +45,11 @@ steps:
     if: build.env("PHASE5_PROBE") == "runtime" && build.env("SMOKE_PROBE") != "hosted"
     command: "buildkite-agent pipeline upload .buildkite/phase-5-runtime.yml"
 
+  - label: ":memo: Load Phase 6 summary annotation proof"
+    key: "phase-6-summary-loader"
+    if: build.env("PHASE6_PROBE") == "summary" && build.env("SMOKE_PROBE") != "hosted"
+    command: "buildkite-agent pipeline upload .buildkite/phase-6-summary.yml"
+
   - label: ":pipeline: Load consolidated hosted smoke proof"
     key: "hosted-smoke-loader"
     if: build.env("SMOKE_PROBE") == "hosted"
@@ -56,7 +61,8 @@ steps:
         "$${PHASE2_COMMIT:-}" \
         "$${PHASE3_COMMIT:-}" \
         "$${PHASE4_COMMIT:-}" \
-        "$${PHASE5_COMMIT:-}"
+        "$${PHASE5_COMMIT:-}" \
+        "$${PHASE6_COMMIT:-}"
       do
         [[ -z "$$phase_commit" || "$$phase_commit" == "$$commit" ]] || {
           echo "phase-specific commit $$phase_commit conflicts with SMOKE_COMMIT" >&2
@@ -72,6 +78,7 @@ steps:
       buildkite-agent pipeline upload .buildkite/phase-5-capabilities.yml
       buildkite-agent pipeline upload .buildkite/phase-5-docker-action.yml
       buildkite-agent pipeline upload .buildkite/phase-5-runtime.yml
+      buildkite-agent pipeline upload .buildkite/phase-6-summary.yml
       buildkite-agent pipeline upload .buildkite/hosted-smoke-control.yml
 
   - label: ":go: Repository checks"

--- a/docs/development.md
+++ b/docs/development.md
@@ -93,6 +93,21 @@ phase selector only for targeted diagnosis:
 | Hosted Docker prerequisites | `PHASE5_PROBE=capabilities`, `PHASE5_COMMIT=<commit>` |
 | Dockerfile action path | `PHASE5_PROBE=docker-action`, `PHASE5_COMMIT=<commit>` |
 | Complete container runtime | `PHASE5_PROBE=runtime`, `PHASE5_COMMIT=<commit>` |
+| Job summary annotation | `PHASE6_PROBE=summary`, `PHASE6_COMMIT=<commit>` |
+
+Summary annotation publication is advisory, so the generated job's successful
+outcome does not by itself prove that Buildkite persisted the annotation. After
+the targeted or aggregate build settles, use an authenticated `bk` CLI with
+`read_builds` access to verify the job-scoped annotation independently:
+
+```sh
+scripts/phase-6-summary-annotation-verify <build-number> <commit>
+```
+
+The verifier reads only the generated job and its annotations. It requires
+the build to match the expected exact commit and exactly one `info` annotation
+with context `buildkite-gha-job-summary`, job scope, and both checked-in summary
+fragments.
 
 The phase definitions under `.buildkite/` and the [active
 plan](plans/2026-07-22-buildkite-gha.md#current-progress) document the exact

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -1293,8 +1293,8 @@ Explicitly defer from beta unless implementation evidence changes the order:
   compiles `testdata/phase6/.github/workflows/summary-annotation.yml`, settles
   the generated job through the existing importer/continuation topology, and
   requires an independent read-only API observation of its context, scope,
-  style, and body. Until that observation is recorded, the smoke inventory
-  retains the fixture as `compile-pass` rather than runtime evidence.
+  style, and body. Build 242 and its API observation now establish that runtime
+  evidence, so the smoke inventory records the fixture as `runtime-pass`.
 - The first work wave is integrated: the Go/CLI foundation is runnable,
   ADR 0001 records the actionlint/act reuse boundary, and ADR 0002 plus schemas
   and eight conformance cases preserve the Phase 0 signed-envelope transport
@@ -1351,11 +1351,12 @@ Explicitly defer from beta unless implementation evidence changes the order:
   `SMOKE_PROBE=hosted` and `SMOKE_COMMIT=<full commit>`. It aggregates the
   Phase 2 shell/upload, Phase 3 concurrent, Phase 4 public-action, Phase 5
   hosted-Docker capability, Phase 5 Dockerfile-action, and Phase 5 complete
-  container-runtime proofs. The dispatcher deliberately uploads each existing
-  importer and continuation independently, then settles their generated and
-  native terminal steps; it does not flatten the importer/continuation topology.
-  Existing `PHASE2_PROBE`, `PHASE3_PROBE`, `PHASE4_PROBE`, and all three
-  `PHASE5_PROBE` selectors remain available for targeted runs.
+  container-runtime proofs, plus the Phase 6 job-summary annotation proof. The
+  dispatcher deliberately uploads each existing importer and continuation
+  independently, then settles their generated and native terminal steps; it
+  does not flatten the importer/continuation topology. Existing `PHASE2_PROBE`,
+  `PHASE3_PROBE`, `PHASE4_PROBE`, all three `PHASE5_PROBE`, and `PHASE6_PROBE`
+  selectors remain available for targeted runs.
 
 Phase 4 live evidence:
 
@@ -1413,6 +1414,18 @@ Phase 5 evidence:
   deterministic conformance tests. Build 53 documented the reason for the
   split by failing the credential-scrubbed anonymous fetch of this private
   repository; no private credential was added or forwarded.
+
+Phase 6 evidence:
+
+- [Buildkite build 242](https://buildkite.com/buildkite/buildkite-gha/builds/242)
+  ran exact implementation commit
+  `fad3b797fc682e7c0a56c5c8c35392e526ef26ca`. The exact-commit importer
+  compiled and uploaded the checked-in Phase 6 summary fixture, and generated
+  job `019fb552-eb6b-43db-b084-7ed041c10db5` passed.
+- The independent read-only API verifier found exactly one annotation on that
+  job with context `buildkite-gha-job-summary`, job scope, `info` style, and
+  both checked-in body fragments. This API observation is required evidence
+  because annotation failure remains advisory and cannot change job outcome.
 
 Phase 2 live evidence:
 

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -1288,6 +1288,13 @@ Explicitly defer from beta unless implementation evidence changes the order:
   `docker://`, Docker lifecycle overrides, private registries, arbitrary
   options, credentials, protected capabilities, and privileged queues continue
   to fail closed.
+- Phase 6 has begun with bounded job summaries and advisory job-scoped
+  Buildkite annotation publication. The checked-in exact-commit hosted proof
+  compiles `testdata/phase6/.github/workflows/summary-annotation.yml`, settles
+  the generated job through the existing importer/continuation topology, and
+  requires an independent read-only API observation of its context, scope,
+  style, and body. Until that observation is recorded, the smoke inventory
+  retains the fixture as `compile-pass` rather than runtime evidence.
 - The first work wave is integrated: the Go/CLI foundation is runnable,
   ADR 0001 records the actionlint/act reuse boundary, and ADR 0002 plus schemas
   and eight conformance cases preserve the Phase 0 signed-envelope transport

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -315,8 +315,8 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 	if document.Agents.Queue != "hosted" {
 		t.Fatalf("default pipeline queue = %q, want hosted", document.Agents.Queue)
 	}
-	if len(document.Steps) != 12 {
-		t.Fatalf("default pipeline = %#v, want nine gated loaders, repository checks, wait, and release", document.Steps)
+	if len(document.Steps) != 13 {
+		t.Fatalf("default pipeline = %#v, want ten gated loaders, repository checks, wait, and release", document.Steps)
 	}
 	steps := make(map[string]struct {
 		command     string
@@ -363,6 +363,9 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 	if got := steps["phase-5-runtime-loader"]; got.command != "buildkite-agent pipeline upload .buildkite/phase-5-runtime.yml" || got.condition != `build.env("PHASE5_PROBE") == "runtime" && build.env("SMOKE_PROBE") != "hosted"` {
 		t.Fatalf("Phase 5 container runtime loader = %#v", got)
 	}
+	if got := steps["phase-6-summary-loader"]; got.command != "buildkite-agent pipeline upload .buildkite/phase-6-summary.yml" || got.condition != `build.env("PHASE6_PROBE") == "summary" && build.env("SMOKE_PROBE") != "hosted"` {
+		t.Fatalf("Phase 6 summary annotation loader = %#v", got)
+	}
 	hosted := steps["hosted-smoke-loader"]
 	if hosted.condition != `build.env("SMOKE_PROBE") == "hosted"` {
 		t.Fatalf("hosted smoke loader = %#v", hosted)
@@ -374,6 +377,7 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 		`"$${PHASE3_COMMIT:-}"`,
 		`"$${PHASE4_COMMIT:-}"`,
 		`"$${PHASE5_COMMIT:-}"`,
+		`"$${PHASE6_COMMIT:-}"`,
 		`[[ -z "$$phase_commit" || "$$phase_commit" == "$$commit" ]]`,
 		`phase-specific commit $$phase_commit conflicts with SMOKE_COMMIT`,
 		`scripts/phase-0-shell-oracle-checkout "$$commit"`,
@@ -384,7 +388,7 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 			t.Fatalf("hosted smoke loader lacks %q:\n%s", required, hosted.command)
 		}
 	}
-	for _, fragment := range []string{"phase-2-upload.yml", "phase-3-upload.yml", "phase-4-upload.yml", "phase-5-capabilities.yml", "phase-5-docker-action.yml", "phase-5-runtime.yml", "hosted-smoke-control.yml"} {
+	for _, fragment := range []string{"phase-2-upload.yml", "phase-3-upload.yml", "phase-4-upload.yml", "phase-5-capabilities.yml", "phase-5-docker-action.yml", "phase-5-runtime.yml", "phase-6-summary.yml", "hosted-smoke-control.yml"} {
 		if count := strings.Count(hosted.command, "buildkite-agent pipeline upload .buildkite/"+fragment); count != 1 {
 			t.Fatalf("hosted smoke loader uploads %s %d times:\n%s", fragment, count, hosted.command)
 		}
@@ -861,6 +865,102 @@ func TestPhase5ContainerRuntimeProofContract(t *testing.T) {
 	}
 }
 
+func TestPhase6SummaryAnnotationProofContract(t *testing.T) {
+	root := filepath.Join("..", "..")
+	importerBody, err := os.ReadFile(filepath.Join(root, ".buildkite", "phase-6-summary.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(importerBody)
+	for _, fragment := range []string{
+		`commit="$${PHASE6_COMMIT:-$${SMOKE_COMMIT:-}}"`,
+		`scripts/phase-0-shell-oracle-checkout "$$commit"`,
+		`test -z "$$(git status --porcelain --untracked-files=all)"`,
+		`automatic: false`,
+		`runtime_version="0.0.0-phase6.$$commit"`,
+		`go build -trimpath -buildvcs=false -ldflags "-X main.version=$$runtime_version"`,
+		`"$$distribution_root/buildkite-gha" upload`,
+		`--event-path testdata/smoke/events/push.json`,
+		`--runtime-queue hosted`,
+		`testdata/phase6/.github/workflows/summary-annotation.yml`,
+	} {
+		if !strings.Contains(text, fragment) {
+			t.Fatalf("Phase 6 summary importer lacks %q:\n%s", fragment, importerBody)
+		}
+	}
+	var upload struct {
+		Steps []struct {
+			Key                    string `yaml:"key"`
+			Command                string `yaml:"command"`
+			DependsOn              string `yaml:"depends_on"`
+			AllowDependencyFailure bool   `yaml:"allow_dependency_failure"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(importerBody, &upload); err != nil {
+		t.Fatal(err)
+	}
+	if len(upload.Steps) != 2 || upload.Steps[0].Key != "phase-6-summary-importer" {
+		t.Fatalf("Phase 6 summary importer = %#v", upload.Steps)
+	}
+	loader := upload.Steps[1]
+	if loader.Key != "phase-6-summary-continuation-loader" || loader.DependsOn != "phase-6-summary-importer" || !loader.AllowDependencyFailure || loader.Command != "buildkite-agent pipeline upload .buildkite/phase-6-summary-continuation.yml" {
+		t.Fatalf("Phase 6 summary continuation loader = %#v", loader)
+	}
+
+	continuationBody, err := os.ReadFile(filepath.Join(root, ".buildkite", "phase-6-summary-continuation.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(continuationBody), `key: "phase-6-native-after-summary"`) || !strings.Contains(string(continuationBody), `step: "gha-summary-annotation"`) || !strings.Contains(string(continuationBody), `allow_failure: true`) {
+		t.Fatalf("Phase 6 summary continuation is not failure-tolerant: %s", continuationBody)
+	}
+
+	fixture, err := os.ReadFile(filepath.Join(root, "testdata", "phase6", ".github", "workflows", "summary-annotation.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(string(fixture), `GITHUB_STEP_SUMMARY`) != 3 || !strings.Contains(string(fixture), "Phase 6 job summary annotation proof") || !strings.Contains(string(fixture), "PHASE6_SUMMARY_OBSERVATION=job-scoped-annotation") {
+		t.Fatalf("Phase 6 summary fixture does not append both proof fragments: %s", fixture)
+	}
+
+	verifierPath := filepath.Join(root, "scripts", "phase-6-summary-annotation-verify")
+	verifier, err := os.ReadFile(verifierPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(verifierPath)
+	if err != nil || info.Mode()&0o111 == 0 {
+		t.Fatalf("Phase 6 summary verifier is not executable: %v", err)
+	}
+	verifierText := string(verifier)
+	for _, fragment := range []string{
+		"set -euo pipefail",
+		`expected_commit=$2`,
+		`bk --no-pager api "/pipelines/$pipeline/builds/$build_number"`,
+		`commit="$(jq -r '.commit // ""' <<<"$build")"`,
+		`$commit != "$expected_commit"`,
+		`step_key=gha-summary-annotation`,
+		`context=buildkite-gha-job-summary`,
+		`bk --no-pager api "/jobs/$job_id/annotations"`,
+		`($matches | length) == 1`,
+		`$matches[0].scope == "job"`,
+		`$matches[0].job_id == $job_id`,
+		`$matches[0].style == "info"`,
+		`PHASE6_SUMMARY_OBSERVATION=job-scoped-annotation`,
+		`PHASE6_SUMMARY_ANNOTATION_OBSERVATION=`,
+		`"$build_number" "$commit" "$job_id" "$context"`,
+	} {
+		if !strings.Contains(verifierText, fragment) {
+			t.Fatalf("Phase 6 summary verifier lacks %q", fragment)
+		}
+	}
+	for _, forbidden := range []string{"BUILDKITE_API_TOKEN", "Authorization:", "bk auth token"} {
+		if strings.Contains(verifierText, forbidden) {
+			t.Fatalf("Phase 6 summary verifier handles credentials directly through %q", forbidden)
+		}
+	}
+}
+
 func TestHostedSmokeControlAndAggregatorDependencies(t *testing.T) {
 	type dependency struct {
 		Step         string `yaml:"step"`
@@ -901,9 +1001,9 @@ func TestHostedSmokeControlAndAggregatorDependencies(t *testing.T) {
 	if control.Key != "hosted-smoke-aggregator-loader" || control.Command != "buildkite-agent pipeline upload .buildkite/hosted-smoke-aggregator.yml" {
 		t.Fatalf("control step = %#v", control)
 	}
-	assertSet("control", control.DependsOn, map[string]bool{"phase-2-continuation-loader": true, "phase-3-continuation-loader": true, "phase-4-continuation-loader": true, "phase-5-continuation-loader": true, "phase-5-docker-action-continuation-loader": true, "phase-5-runtime-continuation-loader": true})
+	assertSet("control", control.DependsOn, map[string]bool{"phase-2-continuation-loader": true, "phase-3-continuation-loader": true, "phase-4-continuation-loader": true, "phase-5-continuation-loader": true, "phase-5-docker-action-continuation-loader": true, "phase-5-runtime-continuation-loader": true, "phase-6-summary-continuation-loader": true})
 	generated := map[string]bool{}
-	for _, name := range []string{"phase-2-upload-continuation.yml", "phase-3-upload-continuation.yml", "phase-4-upload-continuation.yml", "phase-5-capabilities-continuation.yml", "phase-5-docker-action-continuation.yml", "phase-5-runtime-continuation.yml"} {
+	for _, name := range []string{"phase-2-upload-continuation.yml", "phase-3-upload-continuation.yml", "phase-4-upload-continuation.yml", "phase-5-capabilities-continuation.yml", "phase-5-docker-action-continuation.yml", "phase-5-runtime-continuation.yml", "phase-6-summary-continuation.yml"} {
 		continuation := read(name)
 		for _, dependency := range continuation.DependsOn {
 			generated[dependency.Step] = true
@@ -913,7 +1013,7 @@ func TestHostedSmokeControlAndAggregatorDependencies(t *testing.T) {
 	for key := range generated {
 		want[key] = true
 	}
-	for _, key := range []string{"gha-producer", "gha-concurrent", "phase-2-native-after-shell", "phase-3-native-after-concurrent", "phase-4-native-after-actions", "phase-5-native-after-hosted-docker", "phase-5-native-after-docker-action", "phase-5-native-after-runtime"} {
+	for _, key := range []string{"gha-producer", "gha-concurrent", "phase-2-native-after-shell", "phase-3-native-after-concurrent", "phase-4-native-after-actions", "phase-5-native-after-hosted-docker", "phase-5-native-after-docker-action", "phase-5-native-after-runtime", "phase-6-native-after-summary"} {
 		want[key] = true
 	}
 	aggregator := read("hosted-smoke-aggregator.yml")
@@ -926,7 +1026,7 @@ func TestHostedSmokeControlAndAggregatorDependencies(t *testing.T) {
 			t.Fatalf("aggregator command does not inspect generated step %q: %s", key, aggregator.Command)
 		}
 	}
-	for _, key := range []string{"gha-producer", "gha-concurrent", "phase-2-native-after-shell", "phase-3-native-after-concurrent", "phase-4-native-after-actions", "phase-5-native-after-hosted-docker", "phase-5-native-after-docker-action", "phase-5-native-after-runtime"} {
+	for _, key := range []string{"gha-producer", "gha-concurrent", "phase-2-native-after-shell", "phase-3-native-after-concurrent", "phase-4-native-after-actions", "phase-5-native-after-hosted-docker", "phase-5-native-after-docker-action", "phase-5-native-after-runtime", "phase-6-native-after-summary"} {
 		if !strings.Contains(aggregator.Command, key) {
 			t.Fatalf("aggregator command does not inspect required step %q: %s", key, aggregator.Command)
 		}

--- a/internal/compiler/smoke_manifest_test.go
+++ b/internal/compiler/smoke_manifest_test.go
@@ -45,7 +45,7 @@ func TestSmokeManifestInventory(t *testing.T) {
 		t.Fatalf("schema = %q", manifest.Schema)
 	}
 
-	wantOrder := []string{"smoke-shell", "smoke-concurrent", "smoke-ci", "smoke-artifact", "phase4-public-actions", "phase5-docker-action", "phase5-container-runtime", "unsupported-cache-service", "unsupported-job-container", "unsupported-service-container"}
+	wantOrder := []string{"smoke-shell", "smoke-concurrent", "smoke-ci", "smoke-artifact", "phase4-public-actions", "phase5-docker-action", "phase5-container-runtime", "phase6-summary-annotation", "unsupported-cache-service", "unsupported-job-container", "unsupported-service-container"}
 	if len(manifest.Fixtures) != len(wantOrder) {
 		t.Fatalf("fixtures = %d, want %d", len(manifest.Fixtures), len(wantOrder))
 	}
@@ -86,7 +86,7 @@ func TestSmokeManifestInventory(t *testing.T) {
 	}
 
 	var checkedIn []string
-	for _, pattern := range []string{"testdata/smoke/.github/workflows/*.yml", "testdata/phase4/.github/workflows/*.yml", "testdata/phase5/.github/workflows/*.yml.tmpl", "testdata/phase5/runtime/.github/workflows/*.yml", "testdata/unsupported/.github/workflows/*.yml"} {
+	for _, pattern := range []string{"testdata/smoke/.github/workflows/*.yml", "testdata/phase4/.github/workflows/*.yml", "testdata/phase5/.github/workflows/*.yml.tmpl", "testdata/phase5/runtime/.github/workflows/*.yml", "testdata/phase6/.github/workflows/*.yml", "testdata/unsupported/.github/workflows/*.yml"} {
 		matches, err := filepath.Glob(filepath.Join(root, filepath.FromSlash(pattern)))
 		if err != nil {
 			t.Fatal(err)

--- a/mise.toml
+++ b/mise.toml
@@ -31,7 +31,7 @@ run = "golangci-lint run"
 
 [tasks."lint:shell"]
 description = "Lint shell scripts"
-run = "shellcheck -x .buildkite/phase-0-transport-probe/probe.sh scripts/ci-buildkite-release scripts/phase-0-shell-oracle-checkout scripts/phase-0-sign-json scripts/phase-0-verify-json scripts/phase-5-hosted-docker-probe scripts/phase-5-hosted-runtime-probe scripts/release scripts/smoke-local testdata/actions/docker/entrypoint.sh testdata/phase5/runtime/.github/actions/docker/entrypoint.sh"
+run = "shellcheck -x .buildkite/phase-0-transport-probe/probe.sh scripts/ci-buildkite-release scripts/phase-0-shell-oracle-checkout scripts/phase-0-sign-json scripts/phase-0-verify-json scripts/phase-5-hosted-docker-probe scripts/phase-5-hosted-runtime-probe scripts/phase-6-summary-annotation-verify scripts/release scripts/smoke-local testdata/actions/docker/entrypoint.sh testdata/phase5/runtime/.github/actions/docker/entrypoint.sh"
 
 [tasks.vet]
 description = "Run go vet"

--- a/scripts/phase-6-summary-annotation-verify
+++ b/scripts/phase-6-summary-annotation-verify
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# != 2 )) || [[ ! $1 =~ ^[1-9][0-9]*$ ]] || [[ ! $2 =~ ^[0-9a-f]{40}$ ]]; then
+  echo 'usage: scripts/phase-6-summary-annotation-verify <build-number> <commit>' >&2
+  exit 2
+fi
+
+readonly build_number=$1
+readonly expected_commit=$2
+readonly pipeline=${PHASE6_PIPELINE_SLUG:-buildkite-gha}
+readonly step_key=gha-summary-annotation
+readonly context=buildkite-gha-job-summary
+
+command -v bk >/dev/null
+command -v jq >/dev/null
+
+build="$(bk --no-pager api "/pipelines/$pipeline/builds/$build_number")"
+if ! jq -e '.jobs | type == "array"' <<<"$build" >/dev/null; then
+  echo "build $build_number API response has no jobs array" >&2
+  exit 1
+fi
+commit="$(jq -r '.commit // ""' <<<"$build")"
+if [[ $commit != "$expected_commit" ]]; then
+  echo "build $build_number ran commit $commit, expected $expected_commit" >&2
+  exit 1
+fi
+readonly commit
+
+mapfile -t job_ids < <(jq -r --arg step_key "$step_key" '.jobs[] | select(.step_key == $step_key) | .id' <<<"$build")
+if (( ${#job_ids[@]} != 1 )) || [[ ! ${job_ids[0]} =~ ^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$ ]]; then
+  echo "build $build_number has ${#job_ids[@]} jobs with step key $step_key; expected exactly one" >&2
+  exit 1
+fi
+readonly job_id=${job_ids[0]}
+
+if ! jq -e --arg job_id "$job_id" '.jobs[] | select(.id == $job_id) | .state == "passed"' <<<"$build" >/dev/null; then
+  echo "generated summary job $job_id did not pass" >&2
+  exit 1
+fi
+
+annotations="$(bk --no-pager api "/jobs/$job_id/annotations")"
+if ! jq -e \
+  --arg context "$context" \
+  --arg job_id "$job_id" \
+  '
+    [.[] | select(.context == $context)] as $matches |
+    ($matches | length) == 1 and
+    $matches[0].scope == "job" and
+    $matches[0].job_id == $job_id and
+    $matches[0].style == "info" and
+    ($matches[0].body_html | contains("Phase 6 job summary annotation proof")) and
+    ($matches[0].body_html | contains("buildkite-gha")) and
+    ($matches[0].body_html | contains("PHASE6_SUMMARY_OBSERVATION=job-scoped-annotation"))
+  ' <<<"$annotations" >/dev/null
+then
+  echo "job $job_id does not have the exact Phase 6 summary annotation contract" >&2
+  exit 1
+fi
+
+printf 'PHASE6_SUMMARY_ANNOTATION_OBSERVATION={"build":%s,"commit":"%s","job":"%s","context":"%s","scope":"job","style":"info"}\n' \
+  "$build_number" "$commit" "$job_id" "$context"

--- a/scripts/smoke-local
+++ b/scripts/smoke-local
@@ -22,7 +22,7 @@ cd "$root"
 jq -e '
   keys == ["fixtures", "schema"] and
   .schema == "buildkite-gha/smoke-manifest/v1" and
-  (.fixtures | type == "array" and length == 10) and
+  (.fixtures | type == "array" and length == 11) and
   all(.fixtures[];
     keys == ["action_preflight", "event", "evidence", "expectation", "id", "note", "workflow"] and
     (.id | test("^[a-z0-9]+(?:-[a-z0-9]+)*$")) and

--- a/testdata/phase6/.github/workflows/summary-annotation.yml
+++ b/testdata/phase6/.github/workflows/summary-annotation.yml
@@ -1,0 +1,25 @@
+name: Phase 6 summary annotation
+
+on:
+  push:
+
+jobs:
+  summary-annotation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write the summary heading
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### Phase 6 job summary annotation proof
+
+          `buildkite-gha` collected this Markdown from `GITHUB_STEP_SUMMARY`.
+          EOF
+
+      - name: Append the summary observation
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+
+          `PHASE6_SUMMARY_OBSERVATION=job-scoped-annotation`
+          EOF

--- a/testdata/smoke/README.md
+++ b/testdata/smoke/README.md
@@ -19,8 +19,9 @@ workflow is executable:
    payload in both consumer matrix instances.
 
 `manifest.json` is the authoritative, ordered compatibility inventory for
-these workflows and the related Phase 4 and Phase 5 fixtures. Every entry names
-its deterministic compile event and records the separate runtime evidence.
+these workflows and the related Phase 4, Phase 5, and Phase 6 fixtures. Every
+entry names its deterministic compile event and records the separate runtime
+evidence.
 
 Expectations have these precise meanings:
 

--- a/testdata/smoke/manifest.json
+++ b/testdata/smoke/manifest.json
@@ -65,6 +65,15 @@
       "action_preflight": "none"
     },
     {
+      "id": "phase6-summary-annotation",
+      "workflow": "testdata/phase6/.github/workflows/summary-annotation.yml",
+      "event": "testdata/smoke/events/push.json",
+      "expectation": "compile-pass",
+      "evidence": "Summary aggregation and annotation invocation have local coverage; the exact-commit hosted API observation is pending.",
+      "note": "The hosted proof requires an independent read of the generated job annotation because publication is advisory.",
+      "action_preflight": "none"
+    },
+    {
       "id": "unsupported-cache-service",
       "workflow": "testdata/unsupported/.github/workflows/cache.yml",
       "event": "testdata/smoke/events/push.json",

--- a/testdata/smoke/manifest.json
+++ b/testdata/smoke/manifest.json
@@ -68,9 +68,9 @@
       "id": "phase6-summary-annotation",
       "workflow": "testdata/phase6/.github/workflows/summary-annotation.yml",
       "event": "testdata/smoke/events/push.json",
-      "expectation": "compile-pass",
-      "evidence": "Summary aggregation and annotation invocation have local coverage; the exact-commit hosted API observation is pending.",
-      "note": "The hosted proof requires an independent read of the generated job annotation because publication is advisory.",
+      "expectation": "runtime-pass",
+      "evidence": "Exact-commit Buildkite build 242 and a read-only API observation proved the persisted job-scoped summary annotation contract.",
+      "note": "The verifier bound build 242, implementation commit fad3b797fc682e7c0a56c5c8c35392e526ef26ca, and generated job 019fb552-eb6b-43db-b084-7ed041c10db5.",
       "action_preflight": "none"
     },
     {


### PR DESCRIPTION
## Summary

- add a checked-in Phase 6 workflow that appends two known `GITHUB_STEP_SUMMARY` fragments
- add an exact-commit hosted importer and failure-tolerant continuation using the established Phase 5 proof topology
- register targeted `PHASE6_PROBE=summary` and consolidated hosted-smoke dispatch
- add a read-only post-build verifier for the persisted job-scoped annotation

## Proof contract

A passing generated job is not sufficient evidence because summary annotation publication is intentionally advisory. After the build settles, `scripts/phase-6-summary-annotation-verify <build-number> <commit>` queries Buildkite through an already-authenticated `bk` CLI and requires:

- the build ran the expected exact commit
- exactly one passed `gha-summary-annotation` job exists
- exactly one annotation uses context `buildkite-gha-job-summary`
- its scope is `job`, its job UUID matches, and its style is `info`
- its rendered body contains both checked-in summary fragments

No API credential is passed to generated workflow code or handled directly by the verifier.

## Verification

- `mise run check`
- verifier exercised against a mock `bk api` response
- `mise run smoke:local` after recording the runtime evidence

## Live proof

[Buildkite build 242](https://buildkite.com/buildkite/buildkite-gha/builds/242) ran exact proof commit `fad3b797fc682e7c0a56c5c8c35392e526ef26ca` and passed. The independent API verifier returned:

```text
PHASE6_SUMMARY_ANNOTATION_OBSERVATION={"build":242,"commit":"fad3b797fc682e7c0a56c5c8c35392e526ef26ca","job":"019fb552-eb6b-43db-b084-7ed041c10db5","context":"buildkite-gha-job-summary","scope":"job","style":"info"}
```

The smoke inventory now records this fixture as `runtime-pass`.