### PR TITLE
Publish workflow command annotations

### DIFF
--- a/.buildkite/hosted-smoke-aggregator.yml
+++ b/.buildkite/hosted-smoke-aggregator.yml
@@ -25,6 +25,8 @@ steps:
         allow_failure: true
       - step: "gha-summary-annotation"
         allow_failure: true
+      - step: "gha-workflow-command-annotations"
+        allow_failure: true
       - step: "phase-2-native-after-shell"
         allow_failure: true
       - step: "phase-3-native-after-concurrent"
@@ -38,6 +40,8 @@ steps:
       - step: "phase-5-native-after-runtime"
         allow_failure: true
       - step: "phase-6-native-after-summary"
+        allow_failure: true
+      - step: "phase-6-native-after-annotations"
         allow_failure: true
     command: |
       set -euo pipefail
@@ -53,13 +57,15 @@ steps:
         gha-docker-action \
         phase-5-hosted-runtime-probe \
         gha-summary-annotation \
+        gha-workflow-command-annotations \
         phase-2-native-after-shell \
         phase-3-native-after-concurrent \
         phase-4-native-after-actions \
         phase-5-native-after-hosted-docker \
         phase-5-native-after-docker-action \
         phase-5-native-after-runtime \
-        phase-6-native-after-summary
+        phase-6-native-after-summary \
+        phase-6-native-after-annotations
       do
         outcome="$$(buildkite-agent step get "outcome" --step "$$step")"
         printf '%s: %s\n' "$$step" "$$outcome"

--- a/.buildkite/hosted-smoke-control.yml
+++ b/.buildkite/hosted-smoke-control.yml
@@ -19,4 +19,6 @@ steps:
         allow_failure: true
       - step: "phase-6-summary-continuation-loader"
         allow_failure: true
+      - step: "phase-6-annotations-continuation-loader"
+        allow_failure: true
     command: "buildkite-agent pipeline upload .buildkite/hosted-smoke-aggregator.yml"

--- a/.buildkite/phase-6-annotations-continuation.yml
+++ b/.buildkite/phase-6-annotations-continuation.yml
@@ -1,0 +1,10 @@
+agents:
+  queue: "hosted"
+
+steps:
+  - label: ":white_check_mark: Phase 6 workflow command annotations settled"
+    key: "phase-6-native-after-annotations"
+    depends_on:
+      - step: "gha-workflow-command-annotations"
+        allow_failure: true
+    command: "echo 'Phase 6 workflow command annotation job settled before API verification'"

--- a/.buildkite/phase-6-annotations.yml
+++ b/.buildkite/phase-6-annotations.yml
@@ -1,0 +1,31 @@
+agents:
+  queue: "hosted"
+
+steps:
+  - label: ":warning: Phase 6 workflow command annotation importer"
+    key: "phase-6-annotations-importer"
+    timeout_in_minutes: 15
+    retry:
+      automatic: false
+    plugins:
+      - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
+          version: "2026.5.12"
+    command: |
+      set -euo pipefail
+      commit="$${PHASE6_COMMIT:-$${SMOKE_COMMIT:-}}"
+      scripts/phase-0-shell-oracle-checkout "$$commit"
+      test -z "$$(git status --porcelain --untracked-files=all)"
+      distribution_root="$$(mktemp -d "$${TMPDIR:-/tmp}/buildkite-gha-phase6-annotations.XXXXXXXX")"
+      trap 'rm -rf -- "$$distribution_root"' EXIT
+      runtime_version="0.0.0-phase6.$$commit"
+      CGO_ENABLED=0 mise exec -- go build -trimpath -buildvcs=false -ldflags "-X main.version=$$runtime_version" -o "$$distribution_root/buildkite-gha" ./cmd/buildkite-gha
+      "$$distribution_root/buildkite-gha" upload \
+        --event-path testdata/smoke/events/push.json \
+        --runtime-queue hosted \
+        testdata/phase6/.github/workflows/workflow-command-annotations.yml
+
+  - label: ":pipeline: Phase 6 workflow command annotation continuation loader"
+    key: "phase-6-annotations-continuation-loader"
+    depends_on: "phase-6-annotations-importer"
+    allow_dependency_failure: true
+    command: "buildkite-agent pipeline upload .buildkite/phase-6-annotations-continuation.yml"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -50,6 +50,11 @@ steps:
     if: build.env("PHASE6_PROBE") == "summary" && build.env("SMOKE_PROBE") != "hosted"
     command: "buildkite-agent pipeline upload .buildkite/phase-6-summary.yml"
 
+  - label: ":warning: Load Phase 6 workflow command annotation proof"
+    key: "phase-6-annotations-loader"
+    if: build.env("PHASE6_PROBE") == "annotations" && build.env("SMOKE_PROBE") != "hosted"
+    command: "buildkite-agent pipeline upload .buildkite/phase-6-annotations.yml"
+
   - label: ":pipeline: Load consolidated hosted smoke proof"
     key: "hosted-smoke-loader"
     if: build.env("SMOKE_PROBE") == "hosted"
@@ -79,6 +84,7 @@ steps:
       buildkite-agent pipeline upload .buildkite/phase-5-docker-action.yml
       buildkite-agent pipeline upload .buildkite/phase-5-runtime.yml
       buildkite-agent pipeline upload .buildkite/phase-6-summary.yml
+      buildkite-agent pipeline upload .buildkite/phase-6-annotations.yml
       buildkite-agent pipeline upload .buildkite/hosted-smoke-control.yml
 
   - label: ":go: Repository checks"

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ The plugin path currently supports:
 - static matrices, `needs`, outputs, and local reusable workflows;
 - the currently implemented job and step condition subset;
 - background, wait, cancellation, and parallel step controls;
-- timeouts, `continue-on-error`, masking, and pre/main/post actions; and
+- timeouts, `continue-on-error`, masking, summaries, warning/error annotations,
+  and pre/main/post actions; and
 - public, credential-free checkout of the event repository at its exact commit.
 
 It does **not** currently support:
@@ -85,7 +86,6 @@ It does **not** currently support:
 - `actions/cache`, `actions/upload-artifact`, or `actions/download-artifact`;
 - runtime condition access to the `github.event` payload;
 - exhaustive validation of condition functions before execution;
-- publishing `GITHUB_STEP_SUMMARY` content to the Buildkite UI;
 - job containers or service containers through the production plugin path;
 - privileged containers, arbitrary Docker options, or `docker://` actions; or
 - Windows or macOS jobs.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -41,6 +41,7 @@ artifact, cache, token, or OIDC service that this project does not provide.
 | `actions/checkout` | Narrow support | Public `github.com` event repository, exact event SHA, workspace root, shallow credential-free fetch. |
 | Dockerfile actions | Supported subset | Only compiler-verified local or anonymous public Dockerfile actions are admitted. |
 | Step summaries | Supported | Published as job-scoped Buildkite annotations with a stable context. Requires Buildkite Agent v3.112 or newer. Oversized per-step summaries are skipped without failing the job; aggregate job summaries are bounded to 1 MiB. |
+| Workflow commands | Supported subset | `::add-mask`, `::stop-commands`, `::warning`, and `::error` are supported. Warnings and errors retain title/file/range metadata and publish under separate, stable job-scoped contexts without changing step or job conclusions. Each aggregate is bounded to 1 MiB and requires Buildkite Agent v3.112 or newer for publication. `::notice`, groups, command echo control, and legacy commands are not supported. |
 | Job and service containers | Not admitted | Implemented and runtime-proven, but still outside production `hosted-tokenless` policy. |
 | `docker://` actions | Not supported | Private images, credentials, arbitrary options, volumes, and privileged containers are also rejected. |
 | Artifact and cache actions | Not supported | They compile but fail profile admission until Buildkite-backed adapters exist. |
@@ -62,6 +63,12 @@ workspace, environment-file updates, action state, and cleanup lifecycle.
 Docker is another execution backend within that job—not a security boundary
 between mutually untrusted steps. Use a disposable job VM when workflow code
 must be isolated from other jobs or the agent host.
+
+Step summaries and workflow-command warnings/errors are visibility-only
+Buildkite annotations. Their publication is attempted after the authoritative
+logical result; an annotation API failure is reported as a warning but does not
+rewrite an otherwise successful job. Successfully parsed warning/error command
+lines are consumed and their decoded messages remain visible in the job log.
 
 ### Concurrent steps stay inside the job
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -94,6 +94,7 @@ phase selector only for targeted diagnosis:
 | Dockerfile action path | `PHASE5_PROBE=docker-action`, `PHASE5_COMMIT=<commit>` |
 | Complete container runtime | `PHASE5_PROBE=runtime`, `PHASE5_COMMIT=<commit>` |
 | Job summary annotation | `PHASE6_PROBE=summary`, `PHASE6_COMMIT=<commit>` |
+| Workflow warning/error annotations | `PHASE6_PROBE=annotations`, `PHASE6_COMMIT=<commit>` |
 
 Summary annotation publication is advisory, so the generated job's successful
 outcome does not by itself prove that Buildkite persisted the annotation. After
@@ -108,6 +109,18 @@ The verifier reads only the generated job and its annotations. It requires
 the build to match the expected exact commit and exactly one `info` annotation
 with context `buildkite-gha-job-summary`, job scope, and both checked-in summary
 fragments.
+
+Workflow-command annotation publication is also advisory. Verify its distinct
+warning and error contexts independently after the annotations proof settles:
+
+```sh
+scripts/phase-6-workflow-annotations-verify <build-number> <commit>
+```
+
+This verifier requires the generated job to pass even though it emitted an
+`::error` command, then checks exactly one job-scoped `warning` annotation and
+one job-scoped `error` annotation, their checked-in body fragments, and the
+absence of the registered masking canary.
 
 The phase definitions under `.buildkite/` and the [active
 plan](plans/2026-07-22-buildkite-gha.md#current-progress) document the exact

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -908,10 +908,13 @@ Implement the observable Actions contracts for:
 - `::stop-commands`; and
 - supported legacy command behavior and security restrictions.
 
-The Phase 2 shell runtime implements `::add-mask` only. It applies dynamically
-registered masks to subsequent log lines and rejects or scrubs them from the
-bounded job result before transport; annotations, groups, stop-commands, and
-legacy workflow commands remain later compatibility work.
+The runtime implements `::add-mask`, `::stop-commands`, `::warning`, and
+`::error`. It applies dynamically registered masks to subsequent log lines and
+scrubs all registered values from bounded job results before transport.
+Warnings and errors retain supported source metadata and publish as separate
+job-scoped Buildkite annotations without changing conclusions. Notices,
+groups, command echo control, and legacy workflow commands remain later
+compatibility work.
 
 Map warnings and errors to Buildkite log output and annotations. Map dynamic
 mask values to `buildkite-agent redactor add` before subsequent output is
@@ -1295,6 +1298,11 @@ Explicitly defer from beta unless implementation evidence changes the order:
   requires an independent read-only API observation of its context, scope,
   style, and body. Build 242 and its API observation now establish that runtime
   evidence, so the smoke inventory records the fixture as `runtime-pass`.
+  Workflow `::warning` and `::error` commands now use the same bounded,
+  secret-scrubbed advisory publication boundary with separate stable warning
+  and error contexts; they do not change step or job conclusions. Its distinct
+  checked-in hosted fixture remains `compile-pass` until the read-only verifier
+  observes both persisted annotations at an exact commit.
 - The first work wave is integrated: the Go/CLI foundation is runnable,
   ADR 0001 records the actionlint/act reuse boundary, and ADR 0002 plus schemas
   and eight conformance cases preserve the Phase 0 signed-envelope transport
@@ -1351,8 +1359,9 @@ Explicitly defer from beta unless implementation evidence changes the order:
   `SMOKE_PROBE=hosted` and `SMOKE_COMMIT=<full commit>`. It aggregates the
   Phase 2 shell/upload, Phase 3 concurrent, Phase 4 public-action, Phase 5
   hosted-Docker capability, Phase 5 Dockerfile-action, and Phase 5 complete
-  container-runtime proofs, plus the Phase 6 job-summary annotation proof. The
-  dispatcher deliberately uploads each existing importer and continuation
+  container-runtime proofs, plus the Phase 6 job-summary and workflow-command
+  annotation proofs. The dispatcher deliberately uploads each existing
+  importer and continuation
   independently, then settles their generated and native terminal steps; it
   does not flatten the importer/continuation topology. Existing `PHASE2_PROBE`,
   `PHASE3_PROBE`, `PHASE4_PROBE`, all three `PHASE5_PROBE`, and `PHASE6_PROBE`

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -315,8 +315,8 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 	if document.Agents.Queue != "hosted" {
 		t.Fatalf("default pipeline queue = %q, want hosted", document.Agents.Queue)
 	}
-	if len(document.Steps) != 13 {
-		t.Fatalf("default pipeline = %#v, want ten gated loaders, repository checks, wait, and release", document.Steps)
+	if len(document.Steps) != 14 {
+		t.Fatalf("default pipeline = %#v, want eleven gated loaders, repository checks, wait, and release", document.Steps)
 	}
 	steps := make(map[string]struct {
 		command     string
@@ -366,6 +366,9 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 	if got := steps["phase-6-summary-loader"]; got.command != "buildkite-agent pipeline upload .buildkite/phase-6-summary.yml" || got.condition != `build.env("PHASE6_PROBE") == "summary" && build.env("SMOKE_PROBE") != "hosted"` {
 		t.Fatalf("Phase 6 summary annotation loader = %#v", got)
 	}
+	if got := steps["phase-6-annotations-loader"]; got.command != "buildkite-agent pipeline upload .buildkite/phase-6-annotations.yml" || got.condition != `build.env("PHASE6_PROBE") == "annotations" && build.env("SMOKE_PROBE") != "hosted"` {
+		t.Fatalf("Phase 6 workflow command annotation loader = %#v", got)
+	}
 	hosted := steps["hosted-smoke-loader"]
 	if hosted.condition != `build.env("SMOKE_PROBE") == "hosted"` {
 		t.Fatalf("hosted smoke loader = %#v", hosted)
@@ -388,7 +391,7 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 			t.Fatalf("hosted smoke loader lacks %q:\n%s", required, hosted.command)
 		}
 	}
-	for _, fragment := range []string{"phase-2-upload.yml", "phase-3-upload.yml", "phase-4-upload.yml", "phase-5-capabilities.yml", "phase-5-docker-action.yml", "phase-5-runtime.yml", "phase-6-summary.yml", "hosted-smoke-control.yml"} {
+	for _, fragment := range []string{"phase-2-upload.yml", "phase-3-upload.yml", "phase-4-upload.yml", "phase-5-capabilities.yml", "phase-5-docker-action.yml", "phase-5-runtime.yml", "phase-6-summary.yml", "phase-6-annotations.yml", "hosted-smoke-control.yml"} {
 		if count := strings.Count(hosted.command, "buildkite-agent pipeline upload .buildkite/"+fragment); count != 1 {
 			t.Fatalf("hosted smoke loader uploads %s %d times:\n%s", fragment, count, hosted.command)
 		}
@@ -961,6 +964,104 @@ func TestPhase6SummaryAnnotationProofContract(t *testing.T) {
 	}
 }
 
+func TestPhase6WorkflowCommandAnnotationProofContract(t *testing.T) {
+	root := filepath.Join("..", "..")
+	importerBody, err := os.ReadFile(filepath.Join(root, ".buildkite", "phase-6-annotations.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(importerBody)
+	for _, fragment := range []string{
+		`commit="$${PHASE6_COMMIT:-$${SMOKE_COMMIT:-}}"`,
+		`scripts/phase-0-shell-oracle-checkout "$$commit"`,
+		`test -z "$$(git status --porcelain --untracked-files=all)"`,
+		`automatic: false`,
+		`runtime_version="0.0.0-phase6.$$commit"`,
+		`go build -trimpath -buildvcs=false -ldflags "-X main.version=$$runtime_version"`,
+		`"$$distribution_root/buildkite-gha" upload`,
+		`--event-path testdata/smoke/events/push.json`,
+		`--runtime-queue hosted`,
+		`testdata/phase6/.github/workflows/workflow-command-annotations.yml`,
+	} {
+		if !strings.Contains(text, fragment) {
+			t.Fatalf("Phase 6 workflow annotation importer lacks %q:\n%s", fragment, importerBody)
+		}
+	}
+	var upload struct {
+		Steps []struct {
+			Key                    string `yaml:"key"`
+			Command                string `yaml:"command"`
+			DependsOn              string `yaml:"depends_on"`
+			AllowDependencyFailure bool   `yaml:"allow_dependency_failure"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(importerBody, &upload); err != nil {
+		t.Fatal(err)
+	}
+	if len(upload.Steps) != 2 || upload.Steps[0].Key != "phase-6-annotations-importer" {
+		t.Fatalf("Phase 6 workflow annotation importer = %#v", upload.Steps)
+	}
+	loader := upload.Steps[1]
+	if loader.Key != "phase-6-annotations-continuation-loader" || loader.DependsOn != "phase-6-annotations-importer" || !loader.AllowDependencyFailure || loader.Command != "buildkite-agent pipeline upload .buildkite/phase-6-annotations-continuation.yml" {
+		t.Fatalf("Phase 6 workflow annotation continuation loader = %#v", loader)
+	}
+
+	continuationBody, err := os.ReadFile(filepath.Join(root, ".buildkite", "phase-6-annotations-continuation.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(continuationBody), `key: "phase-6-native-after-annotations"`) || !strings.Contains(string(continuationBody), `step: "gha-workflow-command-annotations"`) || !strings.Contains(string(continuationBody), `allow_failure: true`) {
+		t.Fatalf("Phase 6 workflow annotation continuation is not failure-tolerant: %s", continuationBody)
+	}
+
+	fixture, err := os.ReadFile(filepath.Join(root, "testdata", "phase6", ".github", "workflows", "workflow-command-annotations.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixtureText := string(fixture)
+	for _, fragment := range []string{"::warning title=Phase 6 warning", "::error title=Phase 6 error", "PHASE6_WARNING_OBSERVATION=stdout-with-location", "PHASE6_ERROR_OBSERVATION=stderr-outcome-neutral", "::add-mask::$canary", "phase6-workflow-command-secret"} {
+		if !strings.Contains(fixtureText, fragment) {
+			t.Fatalf("Phase 6 workflow annotation fixture lacks %q: %s", fragment, fixture)
+		}
+	}
+
+	verifierPath := filepath.Join(root, "scripts", "phase-6-workflow-annotations-verify")
+	verifier, err := os.ReadFile(verifierPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(verifierPath)
+	if err != nil || info.Mode()&0o111 == 0 {
+		t.Fatalf("Phase 6 workflow annotation verifier is not executable: %v", err)
+	}
+	verifierText := string(verifier)
+	for _, fragment := range []string{
+		"set -euo pipefail",
+		`expected_commit=$2`,
+		`bk --no-pager api "/pipelines/$pipeline/builds/$build_number"`,
+		`$commit != "$expected_commit"`,
+		`step_key=gha-workflow-command-annotations`,
+		`warning_context=buildkite-gha-workflow-warnings`,
+		`error_context=buildkite-gha-workflow-errors`,
+		`bk --no-pager api "/jobs/$job_id/annotations"`,
+		`($warnings | length) == 1`,
+		`($errors | length) == 1`,
+		`$warnings[0].style == "warning"`,
+		`$errors[0].style == "error"`,
+		`contains($masked_canary) | not`,
+		`PHASE6_WORKFLOW_ANNOTATION_OBSERVATION=`,
+	} {
+		if !strings.Contains(verifierText, fragment) {
+			t.Fatalf("Phase 6 workflow annotation verifier lacks %q", fragment)
+		}
+	}
+	for _, forbidden := range []string{"BUILDKITE_API_TOKEN", "Authorization:", "bk auth token"} {
+		if strings.Contains(verifierText, forbidden) {
+			t.Fatalf("Phase 6 workflow annotation verifier handles credentials directly through %q", forbidden)
+		}
+	}
+}
+
 func TestHostedSmokeControlAndAggregatorDependencies(t *testing.T) {
 	type dependency struct {
 		Step         string `yaml:"step"`
@@ -1001,9 +1102,9 @@ func TestHostedSmokeControlAndAggregatorDependencies(t *testing.T) {
 	if control.Key != "hosted-smoke-aggregator-loader" || control.Command != "buildkite-agent pipeline upload .buildkite/hosted-smoke-aggregator.yml" {
 		t.Fatalf("control step = %#v", control)
 	}
-	assertSet("control", control.DependsOn, map[string]bool{"phase-2-continuation-loader": true, "phase-3-continuation-loader": true, "phase-4-continuation-loader": true, "phase-5-continuation-loader": true, "phase-5-docker-action-continuation-loader": true, "phase-5-runtime-continuation-loader": true, "phase-6-summary-continuation-loader": true})
+	assertSet("control", control.DependsOn, map[string]bool{"phase-2-continuation-loader": true, "phase-3-continuation-loader": true, "phase-4-continuation-loader": true, "phase-5-continuation-loader": true, "phase-5-docker-action-continuation-loader": true, "phase-5-runtime-continuation-loader": true, "phase-6-summary-continuation-loader": true, "phase-6-annotations-continuation-loader": true})
 	generated := map[string]bool{}
-	for _, name := range []string{"phase-2-upload-continuation.yml", "phase-3-upload-continuation.yml", "phase-4-upload-continuation.yml", "phase-5-capabilities-continuation.yml", "phase-5-docker-action-continuation.yml", "phase-5-runtime-continuation.yml", "phase-6-summary-continuation.yml"} {
+	for _, name := range []string{"phase-2-upload-continuation.yml", "phase-3-upload-continuation.yml", "phase-4-upload-continuation.yml", "phase-5-capabilities-continuation.yml", "phase-5-docker-action-continuation.yml", "phase-5-runtime-continuation.yml", "phase-6-summary-continuation.yml", "phase-6-annotations-continuation.yml"} {
 		continuation := read(name)
 		for _, dependency := range continuation.DependsOn {
 			generated[dependency.Step] = true
@@ -1013,7 +1114,7 @@ func TestHostedSmokeControlAndAggregatorDependencies(t *testing.T) {
 	for key := range generated {
 		want[key] = true
 	}
-	for _, key := range []string{"gha-producer", "gha-concurrent", "phase-2-native-after-shell", "phase-3-native-after-concurrent", "phase-4-native-after-actions", "phase-5-native-after-hosted-docker", "phase-5-native-after-docker-action", "phase-5-native-after-runtime", "phase-6-native-after-summary"} {
+	for _, key := range []string{"gha-producer", "gha-concurrent", "phase-2-native-after-shell", "phase-3-native-after-concurrent", "phase-4-native-after-actions", "phase-5-native-after-hosted-docker", "phase-5-native-after-docker-action", "phase-5-native-after-runtime", "phase-6-native-after-summary", "phase-6-native-after-annotations"} {
 		want[key] = true
 	}
 	aggregator := read("hosted-smoke-aggregator.yml")
@@ -1026,7 +1127,7 @@ func TestHostedSmokeControlAndAggregatorDependencies(t *testing.T) {
 			t.Fatalf("aggregator command does not inspect generated step %q: %s", key, aggregator.Command)
 		}
 	}
-	for _, key := range []string{"gha-producer", "gha-concurrent", "phase-2-native-after-shell", "phase-3-native-after-concurrent", "phase-4-native-after-actions", "phase-5-native-after-hosted-docker", "phase-5-native-after-docker-action", "phase-5-native-after-runtime", "phase-6-native-after-summary"} {
+	for _, key := range []string{"gha-producer", "gha-concurrent", "phase-2-native-after-shell", "phase-3-native-after-concurrent", "phase-4-native-after-actions", "phase-5-native-after-hosted-docker", "phase-5-native-after-docker-action", "phase-5-native-after-runtime", "phase-6-native-after-summary", "phase-6-native-after-annotations"} {
 		if !strings.Contains(aggregator.Command, key) {
 			t.Fatalf("aggregator command does not inspect required step %q: %s", key, aggregator.Command)
 		}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -252,6 +252,12 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 		if publication.SummaryAnnotationError != nil {
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: warning: job summary annotation: %v\n", publication.SummaryAnnotationError)
 		}
+		if publication.WarningAnnotationError != nil {
+			_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: warning: workflow warning annotation: %v\n", publication.WarningAnnotationError)
+		}
+		if publication.ErrorAnnotationError != nil {
+			_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: warning: workflow error annotation: %v\n", publication.ErrorAnnotationError)
+		}
 		if err != nil {
 			runErr = errors.Join(runErr, fmt.Errorf("publish terminal result: %w", err))
 		}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1033,6 +1033,82 @@ func TestRunJobPublishesSummaryAsAdvisoryJobAnnotation(t *testing.T) {
 	}
 }
 
+func TestRunJobPublishesWorkflowCommandsAsAdvisoryJobAnnotations(t *testing.T) {
+	diagnostics := "printf '%s\\n' '::warning title=Lint::warning body'; printf '%s\\n' '::error file=main.go,line=7::error body' >&2"
+	tests := []struct {
+		name           string
+		command        string
+		failAnnotation bool
+		wantAnnotation bool
+		wantWarning    bool
+		wantResult     string
+		wantCode       int
+	}{
+		{name: "published without changing success", command: diagnostics, wantAnnotation: true, wantResult: "success"},
+		{name: "published after job failure", command: diagnostics + "; exit 7", wantAnnotation: true, wantResult: "failure", wantCode: 1},
+		{name: "publication failure is advisory", command: diagnostics, failAnnotation: true, wantAnnotation: true, wantWarning: true, wantResult: "success"},
+		{name: "empty diagnostics are a no-op", command: "true", wantResult: "success"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			job := cliRunJobPlan()
+			job.Steps[0].Command = test.command
+			planPath, planDigest := writeCLIJobPlan(t, job)
+			setCLIJobIdentity(t, job, planDigest)
+			runner := &cliCaptureRunner{failAnnotation: test.failAnnotation}
+			var stdout, stderr bytes.Buffer
+
+			if code := run([]string{"run-job", "--plan", planPath}, &stdout, &stderr, "dev", runner); code != test.wantCode {
+				t.Fatalf("run() code = %d, stderr = %q, want %d", code, stderr.String(), test.wantCode)
+			}
+			if result := publishedCLIManifest(t, runner, job, planDigest); result.Result != test.wantResult {
+				t.Fatalf("published result = %q, want %q", result.Result, test.wantResult)
+			}
+			var annotations []cliCommand
+			for _, command := range runner.commands {
+				if len(command.args) > 0 && command.args[0] == "annotate" {
+					annotations = append(annotations, command)
+				}
+			}
+			if !test.wantAnnotation {
+				if len(annotations) != 0 {
+					t.Fatalf("annotations = %#v, want none", annotations)
+				}
+				return
+			}
+			want := []struct {
+				context, style, body string
+			}{
+				{context: "buildkite-gha-workflow-warnings", style: "warning", body: "warning body"},
+				{context: "buildkite-gha-workflow-errors", style: "error", body: "error body"},
+			}
+			if len(annotations) != len(want) {
+				t.Fatalf("annotations = %#v, want warning and error", annotations)
+			}
+			for i, expected := range want {
+				wantArgs := []string{"annotate", "--scope", "job", "--job", cliTestJobID, "--context", expected.context, "--style", expected.style}
+				if !slices.Equal(annotations[i].args, wantArgs) || !strings.Contains(string(annotations[i].stdin), expected.body) {
+					t.Errorf("annotation %d = %#v, want args %#v and body containing %q", i, annotations[i], wantArgs, expected.body)
+				}
+			}
+			for _, command := range runner.commands[len(runner.commands)-len(want):] {
+				if len(command.args) == 0 || command.args[0] != "annotate" {
+					t.Fatalf("trailing command = %#v, want annotations after authoritative publication", command)
+				}
+			}
+			gotWarning := strings.Contains(stderr.String(), "warning: workflow warning annotation") && strings.Contains(stderr.String(), "warning: workflow error annotation")
+			if gotWarning != test.wantWarning {
+				t.Fatalf("stderr = %q, advisory warnings present = %v, want %v", stderr.String(), gotWarning, test.wantWarning)
+			}
+			for _, contextErr := range runner.contextErrors[len(runner.contextErrors)-len(want):] {
+				if contextErr != nil {
+					t.Fatalf("annotation inherited cancelled context: %v", contextErr)
+				}
+			}
+		})
+	}
+}
+
 func TestRunJobPublishesEveryTerminalResultAfterCancellation(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -1077,7 +1153,7 @@ func TestRunJobPublishesEveryTerminalResultAfterCancellation(t *testing.T) {
 	}
 }
 
-func TestPublishTerminalResultAnnotatesCancelledJobSummaryWithFreshContext(t *testing.T) {
+func TestPublishTerminalResultAnnotatesCancelledJobWithFreshContext(t *testing.T) {
 	job := cliRunJobPlan()
 	planDigest := transport.Digest([]byte("cancelled-plan"))
 	producer := transport.Producer{BuildID: cliTestBuildID, JobID: cliTestJobID, StepKey: job.Target.StepKey}
@@ -1089,17 +1165,27 @@ func TestPublishTerminalResultAnnotatesCancelledJobSummaryWithFreshContext(t *te
 		job,
 		planDigest,
 		producer,
-		gharuntime.JobResult{Conclusion: "cancelled", Summary: "summary before cancellation\n"},
+		gharuntime.JobResult{
+			Conclusion:         "cancelled",
+			Summary:            "summary before cancellation\n",
+			WarningAnnotations: "warning before cancellation\n",
+			ErrorAnnotations:   "error before cancellation\n",
+		},
 	)
-	if err != nil || publication.SummaryAnnotationError != nil {
+	if err != nil || publication.SummaryAnnotationError != nil || publication.WarningAnnotationError != nil || publication.ErrorAnnotationError != nil {
 		t.Fatalf("publishTerminalResult() publication = %#v, error = %v", publication, err)
 	}
-	last := runner.commands[len(runner.commands)-1]
-	if len(last.args) == 0 || last.args[0] != "annotate" || string(last.stdin) != "summary before cancellation\n" {
-		t.Fatalf("last command = %#v, want cancelled job summary annotation", last)
+	wantBodies := []string{"summary before cancellation\n", "warning before cancellation\n", "error before cancellation\n"}
+	commands := runner.commands[len(runner.commands)-len(wantBodies):]
+	for i, command := range commands {
+		if len(command.args) == 0 || command.args[0] != "annotate" || string(command.stdin) != wantBodies[i] {
+			t.Errorf("annotation %d = %#v, want cancelled job annotation body %q", i, command, wantBodies[i])
+		}
 	}
-	if runner.contextErrors[len(runner.contextErrors)-1] != nil {
-		t.Fatalf("annotation inherited cancelled context: %v", runner.contextErrors[len(runner.contextErrors)-1])
+	for _, contextErr := range runner.contextErrors[len(runner.contextErrors)-len(wantBodies):] {
+		if contextErr != nil {
+			t.Fatalf("annotation inherited cancelled context: %v", contextErr)
+		}
 	}
 }
 

--- a/internal/compiler/smoke_manifest_test.go
+++ b/internal/compiler/smoke_manifest_test.go
@@ -45,7 +45,7 @@ func TestSmokeManifestInventory(t *testing.T) {
 		t.Fatalf("schema = %q", manifest.Schema)
 	}
 
-	wantOrder := []string{"smoke-shell", "smoke-concurrent", "smoke-ci", "smoke-artifact", "phase4-public-actions", "phase5-docker-action", "phase5-container-runtime", "phase6-summary-annotation", "unsupported-cache-service", "unsupported-job-container", "unsupported-service-container"}
+	wantOrder := []string{"smoke-shell", "smoke-concurrent", "smoke-ci", "smoke-artifact", "phase4-public-actions", "phase5-docker-action", "phase5-container-runtime", "phase6-summary-annotation", "phase6-workflow-command-annotations", "unsupported-cache-service", "unsupported-job-container", "unsupported-service-container"}
 	if len(manifest.Fixtures) != len(wantOrder) {
 		t.Fatalf("fixtures = %d, want %d", len(manifest.Fixtures), len(wantOrder))
 	}

--- a/internal/runtime/containers.go
+++ b/internal/runtime/containers.go
@@ -345,7 +345,7 @@ func (b *jobContainerBackend) serviceDiagnostics(processor *commandProcessor, na
 	output, _ := boundedDockerCombinedOutput(ctx, b.env, b.docker, "logs", "--tail", serviceLogTail, name)
 	for _, line := range strings.Split(strings.TrimSuffix(strings.ReplaceAll(output, "\r\n", "\n"), "\n"), "\n") {
 		if line != "" {
-			processor.process(processor.stderr, line)
+			_ = processor.process(processor.stderr, line)
 		}
 	}
 }

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -493,15 +493,15 @@ func scrubJobResult(result JobResult, sensitiveValues []string) JobResult {
 }
 
 func scrubWorkflowCommandAnnotations(value string, truncated bool, sensitiveValues []string) (string, bool) {
-	annotationSensitiveValues := make([]string, 0, len(sensitiveValues)*2)
+	annotationSensitiveValues := make([]string, 0, len(sensitiveValues))
 	for _, sensitive := range sensitiveValues {
 		if sensitive == "" {
 			continue
 		}
-		annotationSensitiveValues = append(annotationSensitiveValues, sensitive)
-		if encoded := commandHTML(sensitive); encoded != sensitive {
-			annotationSensitiveValues = append(annotationSensitiveValues, encoded)
-		}
+		// User-controlled annotation content is rendered through commandHTML.
+		// Scrubbing that same valid UTF-8 representation prevents invalid raw
+		// mask bytes from splitting a rendered multibyte rune.
+		annotationSensitiveValues = append(annotationSensitiveValues, commandHTML(sensitive))
 	}
 	sort.Slice(annotationSensitiveValues, func(i, j int) bool {
 		if len(annotationSensitiveValues[i]) != len(annotationSensitiveValues[j]) {

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -22,13 +22,17 @@ import (
 
 // JobResult is the bounded logical result returned to the transport layer.
 type JobResult struct {
-	Conclusion string            `json:"conclusion"`
-	Outputs    map[string]string `json:"outputs,omitempty"`
-	Env        map[string]string `json:"env,omitempty"`
-	State      map[string]string `json:"state,omitempty"`
-	Summary    string            `json:"summary,omitempty"`
+	Conclusion         string            `json:"conclusion"`
+	Outputs            map[string]string `json:"outputs,omitempty"`
+	Env                map[string]string `json:"env,omitempty"`
+	State              map[string]string `json:"state,omitempty"`
+	Summary            string            `json:"summary,omitempty"`
+	WarningAnnotations string            `json:"warning_annotations,omitempty"`
+	ErrorAnnotations   string            `json:"error_annotations,omitempty"`
 
-	summaryTruncated bool
+	summaryTruncated  bool
+	warningsTruncated bool
+	errorsTruncated   bool
 }
 
 const maxJobOutputBytes = 1024
@@ -421,6 +425,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		}
 	}
 
+	jobResult.WarningAnnotations, jobResult.warningsTruncated, jobResult.ErrorAnnotations, jobResult.errorsTruncated = processor.workflowCommandAnnotations()
 	sensitiveValues := processor.maskValues()
 	for _, name := range sortedKeys(job.Outputs) {
 		template := job.Outputs[name]
@@ -479,19 +484,54 @@ func scrubJobResult(result JobResult, sensitiveValues []string) JobResult {
 	}
 	result.Summary, result.summaryTruncated = boundJobSummary(summary, summaryTruncated)
 	if result.summaryTruncated {
-		result.Summary = trimSensitiveSummarySuffix(result.Summary, sensitiveValues)
+		result.Summary = trimSensitiveSuffix(result.Summary, sensitiveValues)
 	}
 	result.Summary = finalizeJobSummary(result.Summary, result.summaryTruncated)
+	result.WarningAnnotations, result.warningsTruncated = scrubWorkflowCommandAnnotations(result.WarningAnnotations, result.warningsTruncated, sensitiveValues)
+	result.ErrorAnnotations, result.errorsTruncated = scrubWorkflowCommandAnnotations(result.ErrorAnnotations, result.errorsTruncated, sensitiveValues)
 	return result
 }
 
-func trimSensitiveSummarySuffix(summary string, sensitiveValues []string) string {
+func scrubWorkflowCommandAnnotations(value string, truncated bool, sensitiveValues []string) (string, bool) {
+	annotationSensitiveValues := make([]string, 0, len(sensitiveValues)*2)
+	for _, sensitive := range sensitiveValues {
+		if sensitive == "" {
+			continue
+		}
+		annotationSensitiveValues = append(annotationSensitiveValues, sensitive)
+		if encoded := commandHTML(sensitive); encoded != sensitive {
+			annotationSensitiveValues = append(annotationSensitiveValues, encoded)
+		}
+	}
+	sort.Slice(annotationSensitiveValues, func(i, j int) bool {
+		if len(annotationSensitiveValues[i]) != len(annotationSensitiveValues[j]) {
+			return len(annotationSensitiveValues[i]) > len(annotationSensitiveValues[j])
+		}
+		return annotationSensitiveValues[i] < annotationSensitiveValues[j]
+	})
+	for _, sensitive := range annotationSensitiveValues {
+		value = strings.ReplaceAll(value, sensitive, "***")
+		var bounded string
+		var boundedTruncated bool
+		appendBoundedText(&bounded, &boundedTruncated, value, truncated, maxJobAnnotationBytes, workflowCommandTruncationNotice)
+		value, truncated = bounded, boundedTruncated
+	}
+	var bounded string
+	var boundedTruncated bool
+	appendBoundedText(&bounded, &boundedTruncated, value, truncated, maxJobAnnotationBytes, workflowCommandTruncationNotice)
+	if boundedTruncated {
+		bounded = trimSensitiveSuffix(bounded, annotationSensitiveValues) + workflowCommandTruncationNotice
+	}
+	return bounded, boundedTruncated
+}
+
+func trimSensitiveSuffix(value string, sensitiveValues []string) string {
 	for {
 		trimmed := false
 		for _, sensitive := range sensitiveValues {
-			for prefixBytes := min(len(sensitive)-1, len(summary)); prefixBytes > 0; prefixBytes-- {
-				if strings.HasSuffix(summary, sensitive[:prefixBytes]) {
-					summary = summary[:len(summary)-prefixBytes]
+			for prefixBytes := min(len(sensitive)-1, len(value)); prefixBytes > 0; prefixBytes-- {
+				if strings.HasSuffix(value, sensitive[:prefixBytes]) {
+					value = value[:len(value)-prefixBytes]
 					trimmed = true
 					break
 				}
@@ -501,7 +541,7 @@ func trimSensitiveSummarySuffix(summary string, sensitiveValues []string) string
 			}
 		}
 		if !trimmed {
-			return summary
+			return value
 		}
 	}
 }

--- a/internal/runtime/needs.go
+++ b/internal/runtime/needs.go
@@ -9,7 +9,11 @@ import (
 	"github.com/buildkite/buildkite-gha/internal/transport"
 )
 
-const jobSummaryAnnotationContext = "buildkite-gha-job-summary"
+const (
+	jobSummaryAnnotationContext = "buildkite-gha-job-summary"
+	jobWarningAnnotationContext = "buildkite-gha-workflow-warnings"
+	jobErrorAnnotationContext   = "buildkite-gha-workflow-errors"
+)
 
 // ResolveNeeds converts compiler-owned producer identities into the verified
 // logical results and outputs consumed by runtime expression contexts.
@@ -58,15 +62,29 @@ func PublishJobResult(ctx context.Context, agent transport.Agent, root, workflow
 		if publishErr != nil {
 			return publication, errors.Join(fmt.Errorf("validate terminal result: %w", err), fmt.Errorf("publish bounded terminal result: %w", publishErr))
 		}
-		publishJobSummary(ctx, agent, producer.JobID, result.Summary, &publication)
+		publishJobAnnotations(ctx, agent, producer.JobID, result, &publication)
 		return publication, fmt.Errorf("validate terminal result: %w", err)
 	}
 	publication, err := transport.PublishResult(ctx, agent, root, workflow, instance, manifest)
 	if err != nil {
 		return publication, err
 	}
-	publishJobSummary(ctx, agent, producer.JobID, result.Summary, &publication)
+	publishJobAnnotations(ctx, agent, producer.JobID, result, &publication)
 	return publication, nil
+}
+
+func publishJobAnnotations(ctx context.Context, agent transport.Agent, jobID string, result JobResult, publication *transport.Publication) {
+	publishJobSummary(ctx, agent, jobID, result.Summary, publication)
+	if result.WarningAnnotations != "" {
+		if err := agent.AnnotateJob(ctx, jobID, jobWarningAnnotationContext, "warning", result.WarningAnnotations); err != nil {
+			publication.WarningAnnotationError = fmt.Errorf("publish workflow warnings: %w", err)
+		}
+	}
+	if result.ErrorAnnotations != "" {
+		if err := agent.AnnotateJob(ctx, jobID, jobErrorAnnotationContext, "error", result.ErrorAnnotations); err != nil {
+			publication.ErrorAnnotationError = fmt.Errorf("publish workflow errors: %w", err)
+		}
+	}
 }
 
 func publishJobSummary(ctx context.Context, agent transport.Agent, jobID, summary string, publication *transport.Publication) {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -557,7 +557,6 @@ func (r Runner) runJavaScriptPhase(ctx context.Context, processor *commandProces
 }
 
 func (r Runner) runProcess(ctx context.Context, processor *commandProcessor, dir string, env map[string]string, result *Result, state map[string]string, name string, args ...string) error {
-	commandFailures := processor.commandFailureCount()
 	var files commandFiles
 	var err error
 	if r.jobContainer != nil {
@@ -595,18 +594,14 @@ func (r Runner) runProcess(ctx context.Context, processor *commandProcessor, dir
 		applyPaths(pathEnv, effects.paths)
 		result.Env["PATH"] = pathEnv["PATH"]
 	}
-	var commandErr error
-	if processor.commandFailureCount() != commandFailures {
-		commandErr = errors.New("invalid ::stop-commands workflow command")
-	}
-	return errors.Join(runErr, fileErr, commandErr)
+	return errors.Join(runErr, fileErr)
 }
 
 func (effects fileCommandEffects) reportSummaryUploadFailure(processor *commandProcessor) {
 	if effects.summaryBytes <= maxCommandFileBytes {
 		return
 	}
-	processor.process(processor.stderr, fmt.Sprintf("GITHUB_STEP_SUMMARY upload skipped: content is %d bytes; maximum is %d bytes", effects.summaryBytes, maxCommandFileBytes))
+	_ = processor.process(processor.stderr, fmt.Sprintf("GITHUB_STEP_SUMMARY upload skipped: content is %d bytes; maximum is %d bytes", effects.summaryBytes, maxCommandFileBytes))
 }
 
 func (r Runner) runStreaming(ctx context.Context, processor *commandProcessor, dir string, env map[string]string, name string, args ...string) error {
@@ -657,12 +652,17 @@ func (r Runner) runStreaming(ctx context.Context, processor *commandProcessor, d
 	streamErrs := make([]error, 2)
 	stream := func(index int, label string, reader io.Reader, target io.Writer) {
 		defer wg.Done()
-		streamErrs[index] = streamLines(reader, func(line string) {
-			processor.process(target, line)
+		var commandErr error
+		streamErr := streamLines(reader, func(line string) {
+			commandErr = errors.Join(commandErr, processor.process(target, line))
 		}, processor.suppress)
-		if streamErrs[index] != nil {
-			streamErrs[index] = fmt.Errorf("%s stream: %w", label, streamErrs[index])
+		if streamErr != nil {
+			streamErr = fmt.Errorf("%s stream: %w", label, streamErr)
 		}
+		if commandErr != nil {
+			commandErr = fmt.Errorf("%s stream: %w", label, commandErr)
+		}
+		streamErrs[index] = errors.Join(streamErr, commandErr)
 	}
 	wg.Add(2)
 	go stream(0, "stdout", stdout, processor.stdout)
@@ -705,6 +705,9 @@ func streamLines(reader io.Reader, process func(string), suppress func()) error 
 			contentBytes := len(line) + len(fragment)
 			if err == nil {
 				contentBytes--
+				if len(fragment) > 1 && fragment[len(fragment)-2] == '\r' {
+					contentBytes--
+				}
 			}
 			if contentBytes > maxStreamLineBytes {
 				line = line[:0]
@@ -719,7 +722,7 @@ func streamLines(reader io.Reader, process func(string), suppress func()) error 
 		if err == nil {
 			if oversized {
 			} else {
-				process(strings.TrimSuffix(string(line), "\n"))
+				process(trimStreamLineEnding(string(line)))
 			}
 			line = line[:0]
 			oversized = false
@@ -731,7 +734,7 @@ func streamLines(reader io.Reader, process func(string), suppress func()) error 
 		if errors.Is(err, io.EOF) {
 			if oversized {
 			} else if len(line) != 0 {
-				process(string(line))
+				process(trimStreamLineEnding(string(line)))
 			}
 			if sawOversized {
 				return fmt.Errorf("line exceeds %d-byte limit and was discarded", maxStreamLineBytes)
@@ -743,6 +746,11 @@ func streamLines(reader io.Reader, process func(string), suppress func()) error 
 		}
 		return err
 	}
+}
+
+func trimStreamLineEnding(line string) string {
+	line = strings.TrimSuffix(line, "\n")
+	return strings.TrimSuffix(line, "\r")
 }
 
 const (
@@ -1102,15 +1110,14 @@ func sortedKeys[V any](values map[string]V) []string {
 }
 
 type commandProcessor struct {
-	mu              sync.Mutex
-	stdout          io.Writer
-	stderr          io.Writer
-	masks           []string
-	warnings        workflowCommandAnnotationBuffer
-	errors          workflowCommandAnnotationBuffer
-	stopToken       string
-	commandFailures uint64
-	discard         bool
+	mu        sync.Mutex
+	stdout    io.Writer
+	stderr    io.Writer
+	masks     []string
+	warnings  workflowCommandAnnotationBuffer
+	errors    workflowCommandAnnotationBuffer
+	stopToken string
+	discard   bool
 }
 
 type workflowCommandAnnotationBuffer struct {
@@ -1133,11 +1140,13 @@ func newCommandProcessor(stdout, stderr io.Writer) *commandProcessor {
 	return &commandProcessor{stdout: stdout, stderr: stderr}
 }
 
-func (p *commandProcessor) process(target io.Writer, line string) {
+var errInvalidWorkflowCommandStopToken = errors.New("invalid ::stop-commands workflow command")
+
+func (p *commandProcessor) process(target io.Writer, line string) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.discard {
-		return
+		return nil
 	}
 	command, isCommand := parseWorkflowCommand(line)
 	if p.stopToken != "" {
@@ -1145,38 +1154,38 @@ func (p *commandProcessor) process(target io.Writer, line string) {
 			p.stopToken = ""
 		}
 		p.writeMaskedLineLocked(target, line)
-		return
+		return nil
 	}
 	if isCommand {
 		switch {
 		case strings.EqualFold(command.name, "add-mask"):
 			p.addMaskLocked(command.message)
-			return
+			return nil
 		case strings.EqualFold(command.name, "stop-commands"):
 			if !validWorkflowCommandStopToken(command.message) {
 				const message = "invalid ::stop-commands token: token is empty or collides with a workflow command"
-				p.commandFailures++
 				p.appendWorkflowCommandLocked(&p.errors, workflowErrorAnnotationHeading, "Error", parsedWorkflowCommand{message: message})
 				p.writeWorkflowCommandMessageLocked(target, "error", message)
-				return
+				return errInvalidWorkflowCommandStopToken
 			}
 			p.stopToken = command.message
 			if len(command.message) > 6 {
 				p.addMaskLocked(command.message)
 			}
 			p.writeMaskedLineLocked(target, line)
-			return
+			return nil
 		case strings.EqualFold(command.name, "warning"):
 			p.appendWorkflowCommandLocked(&p.warnings, workflowWarningAnnotationHeading, "Warning", command)
 			p.writeWorkflowCommandMessageLocked(target, "warning", command.message)
-			return
+			return nil
 		case strings.EqualFold(command.name, "error"):
 			p.appendWorkflowCommandLocked(&p.errors, workflowErrorAnnotationHeading, "Error", command)
 			p.writeWorkflowCommandMessageLocked(target, "error", command.message)
-			return
+			return nil
 		}
 	}
 	p.writeMaskedLineLocked(target, line)
+	return nil
 }
 
 func validWorkflowCommandStopToken(token string) bool {
@@ -1239,12 +1248,6 @@ func (p *commandProcessor) workflowCommandAnnotations() (warnings string, warnin
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.warnings.body, p.warnings.truncated, p.errors.body, p.errors.truncated
-}
-
-func (p *commandProcessor) commandFailureCount() uint64 {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return p.commandFailures
 }
 
 func (p *commandProcessor) addMaskLocked(value string) {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1193,9 +1193,9 @@ func validWorkflowCommandStopToken(token string) bool {
 		return false
 	}
 	for _, command := range []string{
-		"add-mask", "add-path", "debug", "echo", "endgroup", "error", "group",
-		"internal-set-repo-path", "notice", "save-state", "set-env", "set-output",
-		"set-repo-path", "stop-commands", "warning",
+		"add-mask", "add-matcher", "add-path", "debug", "echo", "endgroup", "error", "group",
+		"internal-set-repo-path", "notice", "remove-matcher", "save-state", "set-env",
+		"set-output", "set-repo-path", "stop-commands", "warning",
 	} {
 		if strings.EqualFold(token, command) {
 			return false

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1343,6 +1343,7 @@ func renderWorkflowCommand(severity string, command parsedWorkflowCommand) strin
 }
 
 func commandHTML(value string) string {
+	value = strings.ToValidUTF8(value, "\uFFFD")
 	value = strings.ReplaceAll(value, "\r\n", "\n")
 	value = strings.ReplaceAll(value, "\r", "\n")
 	return strings.ReplaceAll(html.EscapeString(value), "\n", "<br>\n")

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -9,15 +9,18 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"html"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/buildkite/buildkite-gha/internal/action/source"
@@ -30,9 +33,13 @@ const (
 	defaultTerminateGrace = 2500 * time.Millisecond
 	maxStreamLineBytes    = 1024 * 1024
 	// Match Buildkite's maximum annotation body size.
-	maxJobSummaryBytes = 1024 * 1024
+	maxJobAnnotationBytes = 1024 * 1024
+	maxJobSummaryBytes    = maxJobAnnotationBytes
 
-	jobSummaryTruncationNotice = "\n\n---\n_Job summary truncated at the 1 MiB limit._\n"
+	jobSummaryTruncationNotice       = "\n\n---\n_Job summary truncated at the 1 MiB limit._\n"
+	workflowCommandTruncationNotice  = "\n\n---\n_Workflow command annotations truncated at the 1 MiB limit._\n"
+	workflowWarningAnnotationHeading = "## GitHub Actions warnings\n\n"
+	workflowErrorAnnotationHeading   = "## GitHub Actions errors\n\n"
 )
 
 // Runner executes verified actions using explicitly configured host tools.
@@ -109,19 +116,23 @@ type Result struct {
 // appendJobSummary is the only summary aggregation path. It preserves a
 // deterministic UTF-8 prefix and reserves room for a final truncation notice.
 func appendJobSummary(summary *string, truncated *bool, next string, nextTruncated bool) {
+	appendBoundedText(summary, truncated, next, nextTruncated, maxJobSummaryBytes, jobSummaryTruncationNotice)
+}
+
+func appendBoundedText(value *string, truncated *bool, next string, nextTruncated bool, limit int, notice string) {
 	if *truncated || (next == "" && !nextTruncated) {
 		return
 	}
-	if !nextTruncated && len(*summary) <= maxJobSummaryBytes && len(next) <= maxJobSummaryBytes-len(*summary) {
-		*summary += next
+	if !nextTruncated && len(*value) <= limit && len(next) <= limit-len(*value) {
+		*value += next
 		return
 	}
 
-	prefixLimit := maxJobSummaryBytes - len(jobSummaryTruncationNotice)
-	if len(*summary) > prefixLimit {
-		*summary = utf8Prefix(*summary, prefixLimit)
+	prefixLimit := limit - len(notice)
+	if len(*value) > prefixLimit {
+		*value = utf8Prefix(*value, prefixLimit)
 	} else {
-		*summary += utf8Prefix(next, prefixLimit-len(*summary))
+		*value += utf8Prefix(next, prefixLimit-len(*value))
 	}
 	*truncated = true
 }
@@ -546,6 +557,7 @@ func (r Runner) runJavaScriptPhase(ctx context.Context, processor *commandProces
 }
 
 func (r Runner) runProcess(ctx context.Context, processor *commandProcessor, dir string, env map[string]string, result *Result, state map[string]string, name string, args ...string) error {
+	commandFailures := processor.commandFailureCount()
 	var files commandFiles
 	var err error
 	if r.jobContainer != nil {
@@ -583,7 +595,11 @@ func (r Runner) runProcess(ctx context.Context, processor *commandProcessor, dir
 		applyPaths(pathEnv, effects.paths)
 		result.Env["PATH"] = pathEnv["PATH"]
 	}
-	return errors.Join(runErr, fileErr)
+	var commandErr error
+	if processor.commandFailureCount() != commandFailures {
+		commandErr = errors.New("invalid ::stop-commands workflow command")
+	}
+	return errors.Join(runErr, fileErr, commandErr)
 }
 
 func (effects fileCommandEffects) reportSummaryUploadFailure(processor *commandProcessor) {
@@ -1086,11 +1102,31 @@ func sortedKeys[V any](values map[string]V) []string {
 }
 
 type commandProcessor struct {
-	mu      sync.Mutex
-	stdout  io.Writer
-	stderr  io.Writer
-	masks   []string
-	discard bool
+	mu              sync.Mutex
+	stdout          io.Writer
+	stderr          io.Writer
+	masks           []string
+	warnings        workflowCommandAnnotationBuffer
+	errors          workflowCommandAnnotationBuffer
+	stopToken       string
+	commandFailures uint64
+	discard         bool
+}
+
+type workflowCommandAnnotationBuffer struct {
+	body      string
+	truncated bool
+}
+
+type parsedWorkflowCommand struct {
+	name       string
+	properties map[string]string
+	message    string
+}
+
+type workflowCommandMetadata struct {
+	label string
+	value string
 }
 
 func newCommandProcessor(stdout, stderr io.Writer) *commandProcessor {
@@ -1103,14 +1139,82 @@ func (p *commandProcessor) process(target io.Writer, line string) {
 	if p.discard {
 		return
 	}
-	if value, ok := workflowCommand(line, "add-mask"); ok {
-		p.addMaskLocked(value)
+	command, isCommand := parseWorkflowCommand(line)
+	if p.stopToken != "" {
+		if isCommand && strings.EqualFold(command.name, p.stopToken) {
+			p.stopToken = ""
+		}
+		p.writeMaskedLineLocked(target, line)
 		return
 	}
+	if isCommand {
+		switch {
+		case strings.EqualFold(command.name, "add-mask"):
+			p.addMaskLocked(command.message)
+			return
+		case strings.EqualFold(command.name, "stop-commands"):
+			if !validWorkflowCommandStopToken(command.message) {
+				const message = "invalid ::stop-commands token: token is empty or collides with a workflow command"
+				p.commandFailures++
+				p.appendWorkflowCommandLocked(&p.errors, workflowErrorAnnotationHeading, "Error", parsedWorkflowCommand{message: message})
+				p.writeWorkflowCommandMessageLocked(target, "error", message)
+				return
+			}
+			p.stopToken = command.message
+			if len(command.message) > 6 {
+				p.addMaskLocked(command.message)
+			}
+			p.writeMaskedLineLocked(target, line)
+			return
+		case strings.EqualFold(command.name, "warning"):
+			p.appendWorkflowCommandLocked(&p.warnings, workflowWarningAnnotationHeading, "Warning", command)
+			p.writeWorkflowCommandMessageLocked(target, "warning", command.message)
+			return
+		case strings.EqualFold(command.name, "error"):
+			p.appendWorkflowCommandLocked(&p.errors, workflowErrorAnnotationHeading, "Error", command)
+			p.writeWorkflowCommandMessageLocked(target, "error", command.message)
+			return
+		}
+	}
+	p.writeMaskedLineLocked(target, line)
+}
+
+func validWorkflowCommandStopToken(token string) bool {
+	if token == "" || strings.EqualFold(token, "pause-logging") {
+		return false
+	}
+	for _, command := range []string{
+		"add-mask", "add-path", "debug", "echo", "endgroup", "error", "group",
+		"internal-set-repo-path", "notice", "save-state", "set-env", "set-output",
+		"set-repo-path", "stop-commands", "warning",
+	} {
+		if strings.EqualFold(token, command) {
+			return false
+		}
+	}
+	return true
+}
+
+func (p *commandProcessor) writeWorkflowCommandMessageLocked(target io.Writer, severity, message string) {
+	if message == "" {
+		return
+	}
+	p.writeMaskedLineLocked(target, severity+": "+message)
+}
+
+func (p *commandProcessor) writeMaskedLineLocked(target io.Writer, line string) {
 	for _, mask := range p.masks {
 		line = strings.ReplaceAll(line, mask, "***")
 	}
 	_, _ = fmt.Fprintln(target, line)
+}
+
+func (p *commandProcessor) appendWorkflowCommandLocked(buffer *workflowCommandAnnotationBuffer, heading, severity string, command parsedWorkflowCommand) {
+	fragment := renderWorkflowCommand(severity, command)
+	if buffer.body == "" {
+		fragment = heading + fragment
+	}
+	appendBoundedText(&buffer.body, &buffer.truncated, fragment, false, maxJobAnnotationBytes, workflowCommandTruncationNotice)
 }
 
 func (p *commandProcessor) suppress() {
@@ -1131,6 +1235,18 @@ func (p *commandProcessor) maskValues() []string {
 	return append([]string(nil), p.masks...)
 }
 
+func (p *commandProcessor) workflowCommandAnnotations() (warnings string, warningsTruncated bool, errors string, errorsTruncated bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.warnings.body, p.warnings.truncated, p.errors.body, p.errors.truncated
+}
+
+func (p *commandProcessor) commandFailureCount() uint64 {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.commandFailures
+}
+
 func (p *commandProcessor) addMaskLocked(value string) {
 	if value == "" {
 		return
@@ -1143,24 +1259,136 @@ func (p *commandProcessor) addMaskLocked(value string) {
 	}
 }
 
-func workflowCommand(line, command string) (string, bool) {
+func parseWorkflowCommand(line string) (parsedWorkflowCommand, bool) {
+	line = strings.TrimLeftFunc(line, unicode.IsSpace)
 	if !strings.HasPrefix(line, "::") {
-		return "", false
+		return parsedWorkflowCommand{}, false
 	}
 	separator := strings.Index(line[2:], "::")
 	if separator < 0 {
-		return "", false
+		return parsedWorkflowCommand{}, false
 	}
 	separator += 2
 	header := line[2:separator]
-	name, _, _ := strings.Cut(header, " ")
-	if !strings.EqualFold(name, command) {
-		return "", false
+	name, propertyList, hasProperties := strings.Cut(header, " ")
+	if name == "" {
+		return parsedWorkflowCommand{}, false
 	}
-	return decodeCommandValue(line[separator+2:]), true
+	properties := map[string]string{}
+	if hasProperties {
+		for _, property := range strings.Split(strings.TrimSpace(propertyList), ",") {
+			name, value, ok := strings.Cut(property, "=")
+			if !ok || name == "" || value == "" {
+				continue
+			}
+			properties[strings.ToLower(name)] = decodeCommandProperty(value)
+		}
+	}
+	return parsedWorkflowCommand{name: name, properties: properties, message: decodeCommandValue(line[separator+2:])}, true
 }
 
 func decodeCommandValue(value string) string {
 	replacer := strings.NewReplacer("%0D", "\r", "%0A", "\n", "%25", "%")
 	return replacer.Replace(value)
+}
+
+func decodeCommandProperty(value string) string {
+	replacer := strings.NewReplacer("%0D", "\r", "%0A", "\n", "%3A", ":", "%2C", ",", "%25", "%")
+	return replacer.Replace(value)
+}
+
+func renderWorkflowCommand(severity string, command parsedWorkflowCommand) string {
+	var body strings.Builder
+	body.WriteString("### ")
+	body.WriteString(severity)
+	body.WriteString("\n\n")
+	metadata := []workflowCommandMetadata{
+		{label: "Title", value: command.properties["title"]},
+		{label: "File", value: command.properties["file"]},
+	}
+	line, endLine, column, endColumn := workflowCommandLocation(command.properties)
+	metadata = append(metadata,
+		workflowCommandMetadata{label: "Line", value: line},
+		workflowCommandMetadata{label: "End line", value: endLine},
+		workflowCommandMetadata{label: "Column", value: column},
+		workflowCommandMetadata{label: "End column", value: endColumn},
+	)
+	hasMetadata := false
+	for _, item := range metadata {
+		if item.value == "" {
+			continue
+		}
+		if !hasMetadata {
+			body.WriteString("<p>")
+			hasMetadata = true
+		} else {
+			body.WriteString("<br>\n")
+		}
+		body.WriteString("<strong>")
+		body.WriteString(item.label)
+		body.WriteString(":</strong> <code>")
+		body.WriteString(commandHTML(item.value))
+		body.WriteString("</code>")
+	}
+	if hasMetadata {
+		body.WriteString("</p>\n\n")
+	}
+	body.WriteString("<p>")
+	body.WriteString(commandHTML(command.message))
+	body.WriteString("</p>\n\n")
+	return body.String()
+}
+
+func commandHTML(value string) string {
+	value = strings.ReplaceAll(value, "\r\n", "\n")
+	value = strings.ReplaceAll(value, "\r", "\n")
+	return strings.ReplaceAll(html.EscapeString(value), "\n", "<br>\n")
+}
+
+func workflowCommandLocation(properties map[string]string) (line, endLine, column, endColumn string) {
+	line, lineNumberOK := workflowCommandCoordinate(properties["line"])
+	endLine, endLineNumberOK := workflowCommandCoordinate(properties["endline"])
+	column, columnNumberOK := workflowCommandCoordinate(properties["col"])
+	endColumn, endColumnNumberOK := workflowCommandCoordinate(properties["endcolumn"])
+	lineProperty, endLineProperty := properties["line"], properties["endline"]
+
+	if !lineNumberOK && endLineNumberOK {
+		line, lineNumberOK = endLine, true
+		lineProperty = endLineProperty
+	}
+	if !columnNumberOK && endColumnNumberOK {
+		column, columnNumberOK = endColumn, true
+	}
+	if !lineNumberOK && (columnNumberOK || endColumnNumberOK) {
+		column, endColumn = "", ""
+		columnNumberOK, endColumnNumberOK = false, false
+	}
+	// Match actions/runner's original-property comparison: textual forms such
+	// as line=01,endLine=1 describe different lines for column-range purposes.
+	if lineNumberOK && endLineNumberOK && lineProperty != endLineProperty {
+		column, endColumn = "", ""
+		columnNumberOK, endColumnNumberOK = false, false
+	}
+	if lineNumberOK && endLineNumberOK && coordinateNumber(endLine) < coordinateNumber(line) {
+		line, endLine = "", ""
+	}
+	if columnNumberOK && endColumnNumberOK && coordinateNumber(endColumn) < coordinateNumber(column) {
+		column, endColumn = "", ""
+	}
+	return line, endLine, column, endColumn
+}
+
+func workflowCommandCoordinate(value string) (string, bool) {
+	if value == "" {
+		return "", false
+	}
+	if _, err := strconv.ParseInt(strings.TrimSpace(value), 10, 32); err != nil {
+		return "", false
+	}
+	return value, true
+}
+
+func coordinateNumber(value string) int64 {
+	number, _ := strconv.ParseInt(strings.TrimSpace(value), 10, 32)
+	return number
 }

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -2550,6 +2550,19 @@ func TestWorkflowCommandAnnotationsNormalizeInvalidUTF8(t *testing.T) {
 	}
 }
 
+func TestWorkflowCommandAnnotationScrubbingPreservesUTF8(t *testing.T) {
+	processor := newCommandProcessor(io.Discard, io.Discard)
+	_ = processor.process(io.Discard, "::warning::café")
+	_ = processor.process(io.Discard, "::warning::masked "+string([]byte{0xC3}))
+	_ = processor.process(io.Discard, "::add-mask::"+string([]byte{0xC3}))
+
+	warnings, truncated, _, _ := processor.workflowCommandAnnotations()
+	result := scrubJobResult(JobResult{WarningAnnotations: warnings, warningsTruncated: truncated}, processor.maskValues())
+	if !utf8.ValidString(result.WarningAnnotations) || !strings.Contains(result.WarningAnnotations, "café") || !strings.Contains(result.WarningAnnotations, "masked ***") || strings.Contains(result.WarningAnnotations, "\uFFFD") {
+		t.Fatalf("scrubbed warning annotation = %q, valid UTF-8 = %v", result.WarningAnnotations, utf8.ValidString(result.WarningAnnotations))
+	}
+}
+
 func TestWorkflowCommandAnnotationsRemainBoundedAfterSecretScrubbing(t *testing.T) {
 	secret := "x"
 	result := JobResult{WarningAnnotations: strings.Repeat(secret, maxJobAnnotationBytes)}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -2532,6 +2532,24 @@ func TestWorkflowCommandAnnotationsAreConcurrentAndUTF8Bounded(t *testing.T) {
 	}
 }
 
+func TestWorkflowCommandAnnotationsNormalizeInvalidUTF8(t *testing.T) {
+	processor := newCommandProcessor(io.Discard, io.Discard)
+	command := `printf '::warning title=bad\377,file=bad\376.go::bad\375\n'`
+	if err := (Runner{}).runStreaming(context.Background(), processor, "", nil, "sh", "-c", command); err != nil {
+		t.Fatalf("runStreaming() error = %v", err)
+	}
+
+	warnings, truncated, _, _ := processor.workflowCommandAnnotations()
+	if truncated || !utf8.ValidString(warnings) || strings.Count(warnings, "\uFFFD") != 3 {
+		t.Fatalf("warning annotation = %q, truncated = %v, valid UTF-8 = %v", warnings, truncated, utf8.ValidString(warnings))
+	}
+	for _, fragment := range []string{"<strong>Title:</strong> <code>bad\uFFFD</code>", "<strong>File:</strong> <code>bad\uFFFD.go</code>", "<p>bad\uFFFD</p>"} {
+		if !strings.Contains(warnings, fragment) {
+			t.Fatalf("warning annotation lacks %q: %q", fragment, warnings)
+		}
+	}
+}
+
 func TestWorkflowCommandAnnotationsRemainBoundedAfterSecretScrubbing(t *testing.T) {
 	secret := "x"
 	result := JobResult{WarningAnnotations: strings.Repeat(secret, maxJobAnnotationBytes)}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -2458,24 +2458,28 @@ printf '%s\n' '::stop-commands::warning'
 }
 
 func TestInvalidWorkflowCommandStopTokenFailsTheStep(t *testing.T) {
-	workspace := t.TempDir()
-	workflowPath := ".github/workflows/test.yml"
-	writeFixtureFile(t, workspace, workflowPath, "name: invalid workflow command stop token\n")
-	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{
-		ID: "invalid-stop", Kind: "run", Shell: "sh",
-		Command: "printf '%s\\n' '::stop-commands::warning'\nprintf '%s\\n' '::warning::commands remain active'",
-	}})
-	var logs bytes.Buffer
+	for _, token := range []string{"warning", "add-matcher", "remove-matcher"} {
+		t.Run(token, func(t *testing.T) {
+			workspace := t.TempDir()
+			workflowPath := ".github/workflows/test.yml"
+			writeFixtureFile(t, workspace, workflowPath, "name: invalid workflow command stop token\n")
+			job := runtimePlan(t, workspace, workflowPath, []plan.Step{{
+				ID: "invalid-stop", Kind: "run", Shell: "sh",
+				Command: fmt.Sprintf("printf '%%s\\n' '::stop-commands::%s'\nprintf '%%s\\n' '::warning::commands remain active'", token),
+			}})
+			var logs bytes.Buffer
 
-	result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
-	if err == nil || !strings.Contains(err.Error(), "invalid ::stop-commands workflow command") || result.Conclusion != "failure" {
-		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
-	}
-	if !strings.Contains(result.ErrorAnnotations, "invalid ::stop-commands token") || !strings.Contains(result.WarningAnnotations, "commands remain active") {
-		t.Fatalf("RunJob() warnings = %q, errors = %q", result.WarningAnnotations, result.ErrorAnnotations)
-	}
-	if !strings.Contains(logs.String(), "error: invalid ::stop-commands token") {
-		t.Fatalf("RunJob() logs = %q, want invalid-token diagnostic", logs.String())
+			result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+			if err == nil || !strings.Contains(err.Error(), "invalid ::stop-commands workflow command") || result.Conclusion != "failure" {
+				t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+			}
+			if !strings.Contains(result.ErrorAnnotations, "invalid ::stop-commands token") || !strings.Contains(result.WarningAnnotations, "commands remain active") {
+				t.Fatalf("RunJob() warnings = %q, errors = %q", result.WarningAnnotations, result.ErrorAnnotations)
+			}
+			if !strings.Contains(logs.String(), "error: invalid ::stop-commands token") {
+				t.Fatalf("RunJob() logs = %q, want invalid-token diagnostic", logs.String())
+			}
+		})
 	}
 }
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -2266,18 +2266,22 @@ func TestRunStreamingDrainsOversizedLineAndPreservesMasking(t *testing.T) {
 
 func TestStreamLineLimitIncludesContentNotNewline(t *testing.T) {
 	want := strings.Repeat("x", maxStreamLineBytes)
-	var lines []string
-	suppressed := false
-	err := streamLines(strings.NewReader(want+"\nnext\n"), func(line string) {
-		lines = append(lines, line)
-	}, func() {
-		suppressed = true
-	})
-	if err != nil || suppressed {
-		t.Fatalf("streamLines() = %v, suppressed = %v", err, suppressed)
-	}
-	if len(lines) != 2 || lines[0] != want || lines[1] != "next" {
-		t.Fatalf("streamLines() returned %d lines with unexpected content", len(lines))
+	for _, ending := range []string{"\n", "\r\n"} {
+		t.Run(fmt.Sprintf("ending-%q", ending), func(t *testing.T) {
+			var lines []string
+			suppressed := false
+			err := streamLines(strings.NewReader(want+ending+"next"+ending), func(line string) {
+				lines = append(lines, line)
+			}, func() {
+				suppressed = true
+			})
+			if err != nil || suppressed {
+				t.Fatalf("streamLines() = %v, suppressed = %v", err, suppressed)
+			}
+			if len(lines) != 2 || lines[0] != want || lines[1] != "next" {
+				t.Fatalf("streamLines() returned %#v", lines)
+			}
+		})
 	}
 }
 
@@ -2337,12 +2341,12 @@ func TestWorkflowCommandParsingIsCaseInsensitiveAndExact(t *testing.T) {
 func TestWorkflowCommandsProduceBoundedMaskedJobAnnotations(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	processor := newCommandProcessor(&stdout, &stderr)
-	processor.process(&stdout, "::warning title=Unsafe <title>,file=cmd%2Cmain.go,line=12,endLine=12,col=3,endColumn=5::late-secret <late-secret-tag> <warning>")
-	processor.process(&stdout, "::add-mask::late-secret")
-	processor.process(&stdout, "::add-mask::<late-secret-tag>")
-	processor.process(&stderr, "::add-mask::early-secret")
-	processor.process(&stderr, "::error file=main.go,line=invalid,endLine=9,col=2,endColumn=4::early-secret <error>")
-	processor.process(&stdout, "::warning without a delimiter")
+	_ = processor.process(&stdout, "::warning title=Unsafe <title>,file=cmd%2Cmain.go,line=12,endLine=12,col=3,endColumn=5::late-secret <late-secret-tag> <warning>")
+	_ = processor.process(&stdout, "::add-mask::late-secret")
+	_ = processor.process(&stdout, "::add-mask::<late-secret-tag>")
+	_ = processor.process(&stderr, "::add-mask::early-secret")
+	_ = processor.process(&stderr, "::error file=main.go,line=invalid,endLine=9,col=2,endColumn=4::early-secret <error>")
+	_ = processor.process(&stdout, "::warning without a delimiter")
 
 	warnings, warningsTruncated, commandErrors, errorsTruncated := processor.workflowCommandAnnotations()
 	result := scrubJobResult(JobResult{
@@ -2382,10 +2386,10 @@ func TestWorkflowCommandsProduceBoundedMaskedJobAnnotations(t *testing.T) {
 func TestWorkflowCommandStopTokenPreventsAccidentalAnnotations(t *testing.T) {
 	var logs bytes.Buffer
 	processor := newCommandProcessor(&logs, &logs)
-	processor.process(&logs, "::stop-commands::phase6-stop-token")
-	processor.process(&logs, "::warning::untrusted warning-shaped output")
-	processor.process(&logs, "::phase6-stop-token::")
-	processor.process(&logs, "::warning::collected warning")
+	_ = processor.process(&logs, "::stop-commands::phase6-stop-token")
+	_ = processor.process(&logs, "::warning::untrusted warning-shaped output")
+	_ = processor.process(&logs, "::phase6-stop-token::")
+	_ = processor.process(&logs, "::warning::collected warning")
 
 	warnings, truncated, commandErrors, _ := processor.workflowCommandAnnotations()
 	if truncated || commandErrors != "" || strings.Contains(warnings, "untrusted warning-shaped output") || !strings.Contains(warnings, "collected warning") {
@@ -2393,6 +2397,63 @@ func TestWorkflowCommandStopTokenPreventsAccidentalAnnotations(t *testing.T) {
 	}
 	if !strings.Contains(logs.String(), "::warning::untrusted warning-shaped output") || strings.Contains(logs.String(), "::warning::collected warning") || strings.Contains(logs.String(), "phase6-stop-token") {
 		t.Fatalf("logs = %q, want stopped command as masked ordinary output", logs.String())
+	}
+}
+
+func TestWorkflowCommandStopTokenHandlesCRLFStreams(t *testing.T) {
+	var logs bytes.Buffer
+	processor := newCommandProcessor(&logs, &logs)
+	command := `printf '::stop-commands::crlf-stop-token\r\n'
+printf '::warning::untrusted warning-shaped output\r\n'
+printf '::crlf-stop-token::\r\n'
+printf '::add-mask::crlf-secret\r\n'
+printf 'masked after resume: crlf-secret\r\n'`
+	if err := (Runner{}).runStreaming(context.Background(), processor, "", nil, "sh", "-c", command); err != nil {
+		t.Fatalf("runStreaming() error = %v", err)
+	}
+	warnings, _, commandErrors, _ := processor.workflowCommandAnnotations()
+	if warnings != "" || commandErrors != "" {
+		t.Fatalf("workflow command annotations = %q, errors = %q", warnings, commandErrors)
+	}
+	if !strings.Contains(logs.String(), "::warning::untrusted warning-shaped output") || !strings.Contains(logs.String(), "masked after resume: ***") || strings.Contains(logs.String(), "crlf-secret") || strings.Contains(logs.String(), "\r") {
+		t.Fatalf("logs = %q, want resumed masking with normalized CRLF records", logs.String())
+	}
+	commandWithEscapedCR, ok := parseWorkflowCommand("::warning::preserved%0D")
+	if !ok || commandWithEscapedCR.message != "preserved\r" {
+		t.Fatalf("parseWorkflowCommand() = %#v, %v, want escaped carriage return", commandWithEscapedCR, ok)
+	}
+}
+
+func TestRunStreamingScopesWorkflowCommandFailuresToInvocation(t *testing.T) {
+	processor := newCommandProcessor(io.Discard, io.Discard)
+	ready := filepath.Join(t.TempDir(), "clean-ready")
+	release := filepath.Join(t.TempDir(), "release-clean")
+	cleanDone := make(chan error, 1)
+	go func() {
+		cleanDone <- (Runner{}).runStreaming(context.Background(), processor, "", map[string]string{"READY": ready, "RELEASE": release}, "sh", "-c", `
+: > "$READY"
+while [ ! -e "$RELEASE" ]; do sleep .01; done
+printf '%s\n' 'clean invocation completed'`)
+	}()
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if _, err := os.Stat(ready); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("clean invocation did not become ready")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	invalidErr := (Runner{}).runStreaming(context.Background(), processor, "", map[string]string{"RELEASE": release}, "sh", "-c", `
+printf '%s\n' '::stop-commands::warning'
+: > "$RELEASE"`)
+	cleanErr := <-cleanDone
+	if !errors.Is(invalidErr, errInvalidWorkflowCommandStopToken) {
+		t.Fatalf("invalid runStreaming() error = %v", invalidErr)
+	}
+	if cleanErr != nil {
+		t.Fatalf("overlapping clean runStreaming() inherited command failure: %v", cleanErr)
 	}
 }
 
@@ -2448,7 +2509,7 @@ func TestWorkflowCommandAnnotationsAreConcurrentAndUTF8Bounded(t *testing.T) {
 		go func(worker int) {
 			defer group.Done()
 			for message := 0; message < 50; message++ {
-				processor.process(io.Discard, fmt.Sprintf("::warning::worker-%d-message-%d", worker, message))
+				_ = processor.process(io.Discard, fmt.Sprintf("::warning::worker-%d-message-%d", worker, message))
 			}
 		}(worker)
 	}
@@ -2459,7 +2520,7 @@ func TestWorkflowCommandAnnotationsAreConcurrentAndUTF8Bounded(t *testing.T) {
 	}
 
 	processor = newCommandProcessor(io.Discard, io.Discard)
-	processor.process(io.Discard, "::warning::"+strings.Repeat("€", maxJobAnnotationBytes))
+	_ = processor.process(io.Discard, "::warning::"+strings.Repeat("€", maxJobAnnotationBytes))
 	warnings, truncated, _, _ = processor.workflowCommandAnnotations()
 	result := scrubJobResult(JobResult{WarningAnnotations: warnings, warningsTruncated: truncated}, nil)
 	if !truncated || len(result.WarningAnnotations) > maxJobAnnotationBytes || !utf8.ValidString(result.WarningAnnotations) || !strings.HasSuffix(result.WarningAnnotations, workflowCommandTruncationNotice) {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -2309,11 +2309,170 @@ func TestProcessEnvironmentIsExplicitAndUsable(t *testing.T) {
 }
 
 func TestWorkflowCommandParsingIsCaseInsensitiveAndExact(t *testing.T) {
-	if got, ok := workflowCommand("::ADD-MASK::secret%250Avalue", "add-mask"); !ok || got != "secret%0Avalue" {
-		t.Fatalf("workflowCommand() = %q, %v", got, ok)
+	mask, ok := parseWorkflowCommand(" \t::ADD-MASK::secret%250Avalue")
+	if !ok || !strings.EqualFold(mask.name, "add-mask") || mask.message != "secret%0Avalue" {
+		t.Fatalf("parseWorkflowCommand() = %#v, %v", mask, ok)
 	}
-	if _, ok := workflowCommand("::add-mask-extra::secret", "add-mask"); ok {
-		t.Fatal("workflowCommand() accepted a different command name")
+	extra, ok := parseWorkflowCommand("::add-mask-extra::secret")
+	if !ok || strings.EqualFold(extra.name, "add-mask") {
+		t.Fatalf("parseWorkflowCommand() accepted %q as add-mask", extra.name)
+	}
+	command, ok := parseWorkflowCommand("::WaRnInG title=Deploy%3A prod,file=src%2Cmain.go,line=12,endLine=12,col=3,endColumn=5,broken,unknown=value::first%0Asecond%250A")
+	if !ok || !strings.EqualFold(command.name, "warning") || command.message != "first\nsecond%0A" {
+		t.Fatalf("parseWorkflowCommand() = %#v, %v", command, ok)
+	}
+	wantProperties := map[string]string{
+		"title": "Deploy: prod", "file": "src,main.go", "line": "12", "endline": "12", "col": "3", "endcolumn": "5", "unknown": "value",
+	}
+	if !maps.Equal(command.properties, wantProperties) {
+		t.Fatalf("properties = %#v, want %#v", command.properties, wantProperties)
+	}
+	for _, malformed := range []string{"", "prefix::warning::message", "::warning without a delimiter", "::::message"} {
+		if _, ok := parseWorkflowCommand(malformed); ok {
+			t.Fatalf("parseWorkflowCommand(%q) succeeded", malformed)
+		}
+	}
+}
+
+func TestWorkflowCommandsProduceBoundedMaskedJobAnnotations(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	processor := newCommandProcessor(&stdout, &stderr)
+	processor.process(&stdout, "::warning title=Unsafe <title>,file=cmd%2Cmain.go,line=12,endLine=12,col=3,endColumn=5::late-secret <late-secret-tag> <warning>")
+	processor.process(&stdout, "::add-mask::late-secret")
+	processor.process(&stdout, "::add-mask::<late-secret-tag>")
+	processor.process(&stderr, "::add-mask::early-secret")
+	processor.process(&stderr, "::error file=main.go,line=invalid,endLine=9,col=2,endColumn=4::early-secret <error>")
+	processor.process(&stdout, "::warning without a delimiter")
+
+	warnings, warningsTruncated, commandErrors, errorsTruncated := processor.workflowCommandAnnotations()
+	result := scrubJobResult(JobResult{
+		WarningAnnotations: warnings, warningsTruncated: warningsTruncated,
+		ErrorAnnotations: commandErrors, errorsTruncated: errorsTruncated,
+	}, processor.maskValues())
+	if warningsTruncated || errorsTruncated {
+		t.Fatal("small workflow command annotations were truncated")
+	}
+	for _, secret := range []string{"late-secret", "late-secret-tag", "early-secret"} {
+		if strings.Contains(result.WarningAnnotations, secret) || strings.Contains(result.ErrorAnnotations, secret) {
+			t.Fatalf("annotations leaked %q: warnings = %q, errors = %q", secret, result.WarningAnnotations, result.ErrorAnnotations)
+		}
+	}
+	for _, fragment := range []string{
+		"## GitHub Actions warnings", "### Warning", "Unsafe &lt;title&gt;", "cmd,main.go", "<strong>Line:</strong> <code>12</code>", "*** &lt;warning&gt;",
+	} {
+		if !strings.Contains(result.WarningAnnotations, fragment) {
+			t.Errorf("warning annotation lacks %q: %q", fragment, result.WarningAnnotations)
+		}
+	}
+	for _, fragment := range []string{
+		"## GitHub Actions errors", "### Error", "<strong>Line:</strong> <code>9</code>", "<strong>Column:</strong> <code>2</code>", "*** &lt;error&gt;",
+	} {
+		if !strings.Contains(result.ErrorAnnotations, fragment) {
+			t.Errorf("error annotation lacks %q: %q", fragment, result.ErrorAnnotations)
+		}
+	}
+	if strings.Contains(stdout.String(), "::warning title=") || !strings.Contains(stdout.String(), "warning: late-secret <late-secret-tag> <warning>") || !strings.Contains(stdout.String(), "::warning without a delimiter") {
+		t.Fatalf("stdout = %q, want rendered command message and ordinary malformed command", stdout.String())
+	}
+	if strings.Contains(stderr.String(), "::error") || !strings.Contains(stderr.String(), "error: *** <error>") {
+		t.Fatalf("stderr = %q, want masked rendered error", stderr.String())
+	}
+}
+
+func TestWorkflowCommandStopTokenPreventsAccidentalAnnotations(t *testing.T) {
+	var logs bytes.Buffer
+	processor := newCommandProcessor(&logs, &logs)
+	processor.process(&logs, "::stop-commands::phase6-stop-token")
+	processor.process(&logs, "::warning::untrusted warning-shaped output")
+	processor.process(&logs, "::phase6-stop-token::")
+	processor.process(&logs, "::warning::collected warning")
+
+	warnings, truncated, commandErrors, _ := processor.workflowCommandAnnotations()
+	if truncated || commandErrors != "" || strings.Contains(warnings, "untrusted warning-shaped output") || !strings.Contains(warnings, "collected warning") {
+		t.Fatalf("workflow command annotations = %q, errors = %q, truncated = %v", warnings, commandErrors, truncated)
+	}
+	if !strings.Contains(logs.String(), "::warning::untrusted warning-shaped output") || strings.Contains(logs.String(), "::warning::collected warning") || strings.Contains(logs.String(), "phase6-stop-token") {
+		t.Fatalf("logs = %q, want stopped command as masked ordinary output", logs.String())
+	}
+}
+
+func TestInvalidWorkflowCommandStopTokenFailsTheStep(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: invalid workflow command stop token\n")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{
+		ID: "invalid-stop", Kind: "run", Shell: "sh",
+		Command: "printf '%s\\n' '::stop-commands::warning'\nprintf '%s\\n' '::warning::commands remain active'",
+	}})
+	var logs bytes.Buffer
+
+	result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	if err == nil || !strings.Contains(err.Error(), "invalid ::stop-commands workflow command") || result.Conclusion != "failure" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	if !strings.Contains(result.ErrorAnnotations, "invalid ::stop-commands token") || !strings.Contains(result.WarningAnnotations, "commands remain active") {
+		t.Fatalf("RunJob() warnings = %q, errors = %q", result.WarningAnnotations, result.ErrorAnnotations)
+	}
+	if !strings.Contains(logs.String(), "error: invalid ::stop-commands token") {
+		t.Fatalf("RunJob() logs = %q, want invalid-token diagnostic", logs.String())
+	}
+}
+
+func TestRunJobCollectsWarningAndErrorCommandsWithoutChangingConclusion(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: workflow command annotations\n")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{
+		ID: "diagnostics", Kind: "run", Shell: "sh",
+		Command: "printf '%s\\n' '::warning title=Compiler::warning from stdout'\nprintf '%s\\n' '::error file=main.go,line=7::error from stderr' >&2",
+	}})
+	var stdout, stderr bytes.Buffer
+
+	result, err := (Runner{Stdout: &stdout, Stderr: &stderr}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	if !strings.Contains(result.WarningAnnotations, "warning from stdout") || !strings.Contains(result.ErrorAnnotations, "error from stderr") {
+		t.Fatalf("RunJob() warnings = %q, errors = %q", result.WarningAnnotations, result.ErrorAnnotations)
+	}
+	if strings.Contains(stdout.String(), "::warning") || strings.Contains(stderr.String(), "::error") {
+		t.Fatalf("RunJob() echoed raw workflow command: stdout = %q, stderr = %q", stdout.String(), stderr.String())
+	}
+}
+
+func TestWorkflowCommandAnnotationsAreConcurrentAndUTF8Bounded(t *testing.T) {
+	processor := newCommandProcessor(io.Discard, io.Discard)
+	var group sync.WaitGroup
+	for worker := 0; worker < 2; worker++ {
+		group.Add(1)
+		go func(worker int) {
+			defer group.Done()
+			for message := 0; message < 50; message++ {
+				processor.process(io.Discard, fmt.Sprintf("::warning::worker-%d-message-%d", worker, message))
+			}
+		}(worker)
+	}
+	group.Wait()
+	warnings, truncated, _, _ := processor.workflowCommandAnnotations()
+	if truncated || strings.Count(warnings, "### Warning") != 100 {
+		t.Fatalf("concurrent warning annotation count = %d, truncated = %v", strings.Count(warnings, "### Warning"), truncated)
+	}
+
+	processor = newCommandProcessor(io.Discard, io.Discard)
+	processor.process(io.Discard, "::warning::"+strings.Repeat("€", maxJobAnnotationBytes))
+	warnings, truncated, _, _ = processor.workflowCommandAnnotations()
+	result := scrubJobResult(JobResult{WarningAnnotations: warnings, warningsTruncated: truncated}, nil)
+	if !truncated || len(result.WarningAnnotations) > maxJobAnnotationBytes || !utf8.ValidString(result.WarningAnnotations) || !strings.HasSuffix(result.WarningAnnotations, workflowCommandTruncationNotice) {
+		t.Fatalf("bounded warnings bytes = %d, truncated = %v, valid UTF-8 = %v", len(result.WarningAnnotations), truncated, utf8.ValidString(result.WarningAnnotations))
+	}
+}
+
+func TestWorkflowCommandAnnotationsRemainBoundedAfterSecretScrubbing(t *testing.T) {
+	secret := "x"
+	result := JobResult{WarningAnnotations: strings.Repeat(secret, maxJobAnnotationBytes)}
+	result = scrubJobResult(result, []string{secret})
+	if len(result.WarningAnnotations) > maxJobAnnotationBytes || !utf8.ValidString(result.WarningAnnotations) || strings.Contains(result.WarningAnnotations, secret) || !strings.HasSuffix(result.WarningAnnotations, workflowCommandTruncationNotice) {
+		t.Fatalf("scrubbed warnings bytes = %d, valid UTF-8 = %v", len(result.WarningAnnotations), utf8.ValidString(result.WarningAnnotations))
 	}
 }
 

--- a/internal/transport/results.go
+++ b/internal/transport/results.go
@@ -31,6 +31,8 @@ type Publication struct {
 	ManifestDigest         string
 	MetadataMirrorError    error
 	SummaryAnnotationError error
+	WarningAnnotationError error
+	ErrorAnnotationError   error
 }
 
 // SearchArtifactProducer resolves exactly one artifact owner under the

--- a/mise.toml
+++ b/mise.toml
@@ -31,7 +31,7 @@ run = "golangci-lint run"
 
 [tasks."lint:shell"]
 description = "Lint shell scripts"
-run = "shellcheck -x .buildkite/phase-0-transport-probe/probe.sh scripts/ci-buildkite-release scripts/phase-0-shell-oracle-checkout scripts/phase-0-sign-json scripts/phase-0-verify-json scripts/phase-5-hosted-docker-probe scripts/phase-5-hosted-runtime-probe scripts/phase-6-summary-annotation-verify scripts/release scripts/smoke-local testdata/actions/docker/entrypoint.sh testdata/phase5/runtime/.github/actions/docker/entrypoint.sh"
+run = "shellcheck -x .buildkite/phase-0-transport-probe/probe.sh scripts/ci-buildkite-release scripts/phase-0-shell-oracle-checkout scripts/phase-0-sign-json scripts/phase-0-verify-json scripts/phase-5-hosted-docker-probe scripts/phase-5-hosted-runtime-probe scripts/phase-6-summary-annotation-verify scripts/phase-6-workflow-annotations-verify scripts/release scripts/smoke-local testdata/actions/docker/entrypoint.sh testdata/phase5/runtime/.github/actions/docker/entrypoint.sh"
 
 [tasks.vet]
 description = "Run go vet"

--- a/scripts/phase-6-workflow-annotations-verify
+++ b/scripts/phase-6-workflow-annotations-verify
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# != 2 )) || [[ ! $1 =~ ^[1-9][0-9]*$ ]] || [[ ! $2 =~ ^[0-9a-f]{40}$ ]]; then
+  echo 'usage: scripts/phase-6-workflow-annotations-verify <build-number> <commit>' >&2
+  exit 2
+fi
+
+readonly build_number=$1
+readonly expected_commit=$2
+readonly pipeline=${PHASE6_PIPELINE_SLUG:-buildkite-gha}
+readonly step_key=gha-workflow-command-annotations
+readonly warning_context=buildkite-gha-workflow-warnings
+readonly error_context=buildkite-gha-workflow-errors
+readonly masked_canary=phase6-workflow-command-secret
+
+command -v bk >/dev/null
+command -v jq >/dev/null
+
+build="$(bk --no-pager api "/pipelines/$pipeline/builds/$build_number")"
+if ! jq -e '.jobs | type == "array"' <<<"$build" >/dev/null; then
+  echo "build $build_number API response has no jobs array" >&2
+  exit 1
+fi
+commit="$(jq -r '.commit // ""' <<<"$build")"
+if [[ $commit != "$expected_commit" ]]; then
+  echo "build $build_number ran commit $commit, expected $expected_commit" >&2
+  exit 1
+fi
+readonly commit
+
+mapfile -t job_ids < <(jq -r --arg step_key "$step_key" '.jobs[] | select(.step_key == $step_key) | .id' <<<"$build")
+if (( ${#job_ids[@]} != 1 )) || [[ ! ${job_ids[0]} =~ ^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$ ]]; then
+  echo "build $build_number has ${#job_ids[@]} jobs with step key $step_key; expected exactly one" >&2
+  exit 1
+fi
+readonly job_id=${job_ids[0]}
+
+if ! jq -e --arg job_id "$job_id" '.jobs[] | select(.id == $job_id) | .state == "passed"' <<<"$build" >/dev/null; then
+  echo "generated workflow command annotation job $job_id did not pass" >&2
+  exit 1
+fi
+
+annotations="$(bk --no-pager api "/jobs/$job_id/annotations")"
+if ! jq -e \
+  --arg warning_context "$warning_context" \
+  --arg error_context "$error_context" \
+  --arg job_id "$job_id" \
+  --arg masked_canary "$masked_canary" \
+  '
+    [.[] | select(.context == $warning_context)] as $warnings |
+    [.[] | select(.context == $error_context)] as $errors |
+    ($warnings | length) == 1 and
+    ($errors | length) == 1 and
+    $warnings[0].scope == "job" and
+    $warnings[0].job_id == $job_id and
+    $warnings[0].style == "warning" and
+    ($warnings[0].body_html | contains("Phase 6 warning")) and
+    ($warnings[0].body_html | contains("workflow-command-annotations.yml")) and
+    ($warnings[0].body_html | contains("Line:")) and
+    ($warnings[0].body_html | contains("13")) and
+    ($warnings[0].body_html | contains("Column:")) and
+    ($warnings[0].body_html | contains("PHASE6_WARNING_OBSERVATION=stdout-with-location")) and
+    ($warnings[0].body_html | contains("masked diagnostic")) and
+    ($warnings[0].body_html | contains($masked_canary) | not) and
+    $errors[0].scope == "job" and
+    $errors[0].job_id == $job_id and
+    $errors[0].style == "error" and
+    ($errors[0].body_html | contains("Phase 6 error")) and
+    ($errors[0].body_html | contains("18")) and
+    ($errors[0].body_html | contains("PHASE6_ERROR_OBSERVATION=stderr-outcome-neutral"))
+  ' <<<"$annotations" >/dev/null
+then
+  echo "job $job_id does not have the exact Phase 6 workflow command annotation contract" >&2
+  exit 1
+fi
+
+printf 'PHASE6_WORKFLOW_ANNOTATION_OBSERVATION={"build":%s,"commit":"%s","job":"%s","warning_context":"%s","error_context":"%s","scope":"job","warning_style":"warning","error_style":"error"}\n' \
+  "$build_number" "$commit" "$job_id" "$warning_context" "$error_context"

--- a/scripts/smoke-local
+++ b/scripts/smoke-local
@@ -22,7 +22,7 @@ cd "$root"
 jq -e '
   keys == ["fixtures", "schema"] and
   .schema == "buildkite-gha/smoke-manifest/v1" and
-  (.fixtures | type == "array" and length == 11) and
+  (.fixtures | type == "array" and length == 12) and
   all(.fixtures[];
     keys == ["action_preflight", "event", "evidence", "expectation", "id", "note", "workflow"] and
     (.id | test("^[a-z0-9]+(?:-[a-z0-9]+)*$")) and

--- a/testdata/phase6/.github/workflows/workflow-command-annotations.yml
+++ b/testdata/phase6/.github/workflows/workflow-command-annotations.yml
@@ -1,0 +1,25 @@
+name: Phase 6 workflow command annotations
+
+on:
+  push:
+
+jobs:
+  workflow-command-annotations:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Emit a warning from stdout
+        shell: bash
+        run: |
+          printf '%s\n' '::warning title=Phase 6 warning,file=.github/workflows/workflow-command-annotations.yml,line=13,endLine=13,col=3,endColumn=8::PHASE6_WARNING_OBSERVATION=stdout-with-location'
+
+      - name: Emit an error from stderr without failing the job
+        shell: bash
+        run: |
+          printf '%s\n' '::error title=Phase 6 error,file=.github/workflows/workflow-command-annotations.yml,line=18::PHASE6_ERROR_OBSERVATION=stderr-outcome-neutral' >&2
+
+      - name: Prove late annotation masking
+        shell: bash
+        run: |
+          canary='phase6-workflow-command-secret'
+          printf '%s\n' "::warning title=Masked warning::masked diagnostic $canary"
+          printf '%s\n' "::add-mask::$canary"

--- a/testdata/smoke/manifest.json
+++ b/testdata/smoke/manifest.json
@@ -74,6 +74,15 @@
       "action_preflight": "none"
     },
     {
+      "id": "phase6-workflow-command-annotations",
+      "workflow": "testdata/phase6/.github/workflows/workflow-command-annotations.yml",
+      "event": "testdata/smoke/events/push.json",
+      "expectation": "compile-pass",
+      "evidence": "Local runtime and publication tests cover warning and error annotations; the checked-in exact-commit hosted proof still requires an API observation.",
+      "note": "Do not classify this fixture as runtime-pass until the read-only verifier confirms both persisted job-scoped annotations.",
+      "action_preflight": "none"
+    },
+    {
       "id": "unsupported-cache-service",
       "workflow": "testdata/unsupported/.github/workflows/cache.yml",
       "event": "testdata/smoke/events/push.json",


### PR DESCRIPTION
## Summary

- interpret GitHub Actions `::warning` and `::error` commands across the shared runtime output boundary, preserving supported title/file/range metadata and Actions-compatible escaping
- aggregate secret-scrubbed warning and error bodies under stable job-scoped Buildkite contexts, each UTF-8 safely bounded to 1 MiB and published only after the authoritative terminal result
- keep diagnostics outcome-neutral and annotation failures advisory, while honoring `::stop-commands` and failing invalid stop tokens closed
- add a distinct exact-commit Phase 6 hosted fixture and read-only API verifier without rewriting the recorded build-242 summary proof

## Contract

- warning context/style: `buildkite-gha-workflow-warnings` / `warning`
- error context/style: `buildkite-gha-workflow-errors` / `error`
- parsed command syntax is consumed; decoded messages remain in logs
- failed and cancelled jobs still publish collected diagnostics
- `::notice`, groups, command echo control, and legacy commands remain unsupported

## Verification

- `mise run check`
- focused runtime/transport/CLI/compiler/pipeline tests, including race coverage
- deterministic local compilation of `testdata/phase6/.github/workflows/workflow-command-annotations.yml`

The new smoke fixture deliberately remains `compile-pass` until a hosted build and `scripts/phase-6-workflow-annotations-verify` independently observe both persisted annotations at this exact commit.