### PR TITLE
Record Phase 6 workflow annotation proof

### DIFF
--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -1300,9 +1300,9 @@ Explicitly defer from beta unless implementation evidence changes the order:
   evidence, so the smoke inventory records the fixture as `runtime-pass`.
   Workflow `::warning` and `::error` commands now use the same bounded,
   secret-scrubbed advisory publication boundary with separate stable warning
-  and error contexts; they do not change step or job conclusions. Its distinct
-  checked-in hosted fixture remains `compile-pass` until the read-only verifier
-  observes both persisted annotations at an exact commit.
+  and error contexts; they do not change step or job conclusions. Build 252
+  and its exact-commit API observation prove both persisted annotations and
+  masking, so the distinct checked-in hosted fixture is now `runtime-pass`.
 - The first work wave is integrated: the Go/CLI foundation is runnable,
   ADR 0001 records the actionlint/act reuse boundary, and ADR 0002 plus schemas
   and eight conformance cases preserve the Phase 0 signed-envelope transport
@@ -1435,6 +1435,18 @@ Phase 6 evidence:
   job with context `buildkite-gha-job-summary`, job scope, `info` style, and
   both checked-in body fragments. This API observation is required evidence
   because annotation failure remains advisory and cannot change job outcome.
+- [Buildkite build 252](https://buildkite.com/buildkite/buildkite-gha/builds/252)
+  ran exact merged implementation commit
+  `4050f0c884eef0f54a77c27958abe3ca21ede9e0`. The exact-commit importer
+  compiled and uploaded the checked-in workflow-command fixture, and generated
+  job `019fb5d6-f314-4294-b991-7ceb540604b7` passed even though it emitted an
+  `::error` command.
+- The independent read-only API verifier found exactly one job-scoped `warning`
+  annotation with context `buildkite-gha-workflow-warnings` and one job-scoped
+  `error` annotation with context `buildkite-gha-workflow-errors`. It verified
+  both checked-in body contracts and the absence of the registered masking
+  canary; successful job outcome alone would not establish this advisory
+  publication evidence.
 
 Phase 2 live evidence:
 

--- a/testdata/smoke/manifest.json
+++ b/testdata/smoke/manifest.json
@@ -77,9 +77,9 @@
       "id": "phase6-workflow-command-annotations",
       "workflow": "testdata/phase6/.github/workflows/workflow-command-annotations.yml",
       "event": "testdata/smoke/events/push.json",
-      "expectation": "compile-pass",
-      "evidence": "Local runtime and publication tests cover warning and error annotations; the checked-in exact-commit hosted proof still requires an API observation.",
-      "note": "Do not classify this fixture as runtime-pass until the read-only verifier confirms both persisted job-scoped annotations.",
+      "expectation": "runtime-pass",
+      "evidence": "Exact-commit Buildkite build 252 and a read-only API observation proved both persisted job-scoped workflow-command annotation contracts.",
+      "note": "The verifier bound build 252, merged implementation commit 4050f0c884eef0f54a77c27958abe3ca21ede9e0, and generated job 019fb5d6-f314-4294-b991-7ceb540604b7.",
       "action_preflight": "none"
     },
     {


### PR DESCRIPTION
## Summary

- record exact-commit Buildkite build 252 and its independent annotation API observation
- promote the workflow-command annotation fixture from `compile-pass` to `runtime-pass`
- bind the evidence to merged commit `4050f0c`, generated job `019fb5d6-f314-4294-b991-7ceb540604b7`, both job-scoped contexts, styles, and masking verification

## Validation

- `mise exec -- go test ./internal/compiler -count=1`
- `mise run smoke:local`
- `jq empty testdata/smoke/manifest.json`
- `git diff --check`