### PR TITLE
Implement bounded download-artifact adapter

### DIFF
--- a/.buildkite/hosted-smoke-aggregator.yml
+++ b/.buildkite/hosted-smoke-aggregator.yml
@@ -29,6 +29,12 @@ steps:
         allow_failure: true
       - step: "gha-upload-artifact"
         allow_failure: true
+      - step: "gha-artifact-producer"
+        allow_failure: true
+      - step: "gha-artifact-consumer-5ebbc197d87b"
+        allow_failure: true
+      - step: "gha-artifact-consumer-91934b28b00f"
+        allow_failure: true
       - step: "phase-2-native-after-shell"
         allow_failure: true
       - step: "phase-3-native-after-concurrent"
@@ -47,6 +53,8 @@ steps:
         allow_failure: true
       - step: "phase-6-native-after-upload-artifact"
         allow_failure: true
+      - step: "phase-6-native-after-artifact-roundtrip"
+        allow_failure: true
     command: |
       set -euo pipefail
       failed=0
@@ -63,6 +71,9 @@ steps:
         gha-summary-annotation \
         gha-workflow-command-annotations \
         gha-upload-artifact \
+        gha-artifact-producer \
+        gha-artifact-consumer-5ebbc197d87b \
+        gha-artifact-consumer-91934b28b00f \
         phase-2-native-after-shell \
         phase-3-native-after-concurrent \
         phase-4-native-after-actions \
@@ -71,7 +82,8 @@ steps:
         phase-5-native-after-runtime \
         phase-6-native-after-summary \
         phase-6-native-after-annotations \
-        phase-6-native-after-upload-artifact
+        phase-6-native-after-upload-artifact \
+        phase-6-native-after-artifact-roundtrip
       do
         outcome="$$(buildkite-agent step get "outcome" --step "$$step")"
         printf '%s: %s\n' "$$step" "$$outcome"

--- a/.buildkite/hosted-smoke-control.yml
+++ b/.buildkite/hosted-smoke-control.yml
@@ -23,4 +23,6 @@ steps:
         allow_failure: true
       - step: "phase-6-upload-artifact-continuation-loader"
         allow_failure: true
+      - step: "phase-6-artifact-roundtrip-continuation-loader"
+        allow_failure: true
     command: "buildkite-agent pipeline upload .buildkite/hosted-smoke-aggregator.yml"

--- a/.buildkite/phase-6-artifact-roundtrip-continuation.yml
+++ b/.buildkite/phase-6-artifact-roundtrip-continuation.yml
@@ -1,0 +1,14 @@
+agents:
+  queue: "hosted"
+
+steps:
+  - label: ":white_check_mark: Phase 6 artifact roundtrip settled"
+    key: "phase-6-native-after-artifact-roundtrip"
+    depends_on:
+      - step: "gha-artifact-producer"
+        allow_failure: true
+      - step: "gha-artifact-consumer-5ebbc197d87b"
+        allow_failure: true
+      - step: "gha-artifact-consumer-91934b28b00f"
+        allow_failure: true
+    command: "echo 'Phase 6 artifact producer and both consumers settled before API verification'"

--- a/.buildkite/phase-6-artifact-roundtrip.yml
+++ b/.buildkite/phase-6-artifact-roundtrip.yml
@@ -1,0 +1,35 @@
+agents:
+  queue: "hosted"
+
+steps:
+  - label: ":package: Phase 6 artifact roundtrip importer"
+    key: "phase-6-artifact-roundtrip-importer"
+    timeout_in_minutes: 15
+    retry:
+      automatic: false
+    plugins:
+      - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
+          version: "2026.5.12"
+    command: |
+      set -euo pipefail
+      commit="$${PHASE6_COMMIT:-$${SMOKE_COMMIT:-}}"
+      scripts/phase-0-shell-oracle-checkout "$$commit"
+      test -z "$$(git status --porcelain --untracked-files=all)"
+      distribution_root="$$(mktemp -d "$${TMPDIR:-/tmp}/buildkite-gha-phase6-artifact-roundtrip.XXXXXXXX")"
+      trap 'rm -rf -- "$$distribution_root"' EXIT
+      runtime_version="0.0.0-phase6.$$commit"
+      CGO_ENABLED=0 mise exec -- go build -trimpath -buildvcs=false -ldflags "-X main.version=$$runtime_version" -o "$$distribution_root/buildkite-gha" ./cmd/buildkite-gha
+      proof_workflow="$$distribution_root/artifact.yml"
+      nonce="$${BUILDKITE_BUILD_NUMBER:?BUILDKITE_BUILD_NUMBER is required}"
+      sed "s/__PHASE6_ARTIFACT_NONCE__/$$nonce/g" testdata/smoke/.github/workflows/artifact.yml > "$$proof_workflow"
+      ! grep -q '__PHASE6_ARTIFACT_NONCE__' "$$proof_workflow"
+      "$$distribution_root/buildkite-gha" upload \
+        --event-path testdata/smoke/events/push.json \
+        --runtime-queue hosted \
+        "$$proof_workflow"
+
+  - label: ":pipeline: Phase 6 artifact roundtrip continuation loader"
+    key: "phase-6-artifact-roundtrip-continuation-loader"
+    depends_on: "phase-6-artifact-roundtrip-importer"
+    allow_dependency_failure: true
+    command: "buildkite-agent pipeline upload .buildkite/phase-6-artifact-roundtrip-continuation.yml"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -60,6 +60,11 @@ steps:
     if: build.env("PHASE6_PROBE") == "upload-artifact" && build.env("SMOKE_PROBE") != "hosted"
     command: "buildkite-agent pipeline upload .buildkite/phase-6-upload-artifact.yml"
 
+  - label: ":package: Load Phase 6 artifact roundtrip proof"
+    key: "phase-6-artifact-roundtrip-loader"
+    if: build.env("PHASE6_PROBE") == "artifact-roundtrip" && build.env("SMOKE_PROBE") != "hosted"
+    command: "buildkite-agent pipeline upload .buildkite/phase-6-artifact-roundtrip.yml"
+
   - label: ":pipeline: Load consolidated hosted smoke proof"
     key: "hosted-smoke-loader"
     if: build.env("SMOKE_PROBE") == "hosted"
@@ -91,6 +96,7 @@ steps:
       buildkite-agent pipeline upload .buildkite/phase-6-summary.yml
       buildkite-agent pipeline upload .buildkite/phase-6-annotations.yml
       buildkite-agent pipeline upload .buildkite/phase-6-upload-artifact.yml
+      buildkite-agent pipeline upload .buildkite/phase-6-artifact-roundtrip.yml
       buildkite-agent pipeline upload .buildkite/hosted-smoke-control.yml
 
   - label: ":go: Repository checks"

--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ The plugin path currently supports:
   and pre/main/post actions;
 - public, credential-free checkout of the event repository at its exact commit;
   and
-- bounded native uploads for the audited `actions/upload-artifact` v4 commit.
+- bounded native upload and exact-name download for the audited artifact v4 commits.
 
 It does **not** currently support:
 
 - private repositories or private actions;
 - workflow secrets, `GITHUB_TOKEN`, GitHub-compatible OIDC, or protected queues;
-- `actions/cache` or `actions/download-artifact`;
+- `actions/cache`, artifact merge/all/pattern/ID modes, or cross-run downloads;
 - runtime condition access to the `github.event` payload;
 - exhaustive validation of condition functions before execution;
 - job containers or service containers through the production plugin path;

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -43,9 +43,10 @@ artifact, cache, token, or OIDC service that this project does not provide.
 | Step summaries | Supported | Published as job-scoped Buildkite annotations with a stable context. Requires Buildkite Agent v3.112 or newer. Oversized per-step summaries are skipped without failing the job; aggregate job summaries are bounded to 1 MiB. |
 | Workflow commands | Supported subset | `::add-mask`, `::stop-commands`, `::warning`, and `::error` are supported. Warnings and errors retain title/file/range metadata and publish under separate, stable job-scoped contexts without changing step or job conclusions. Each aggregate is bounded to 1 MiB and requires Buildkite Agent v3.112 or newer for publication. `::notice`, groups, command echo control, and legacy commands are not supported. |
 | `actions/upload-artifact` | Narrow support | The audited v4 commit supports bounded literal files/directories, ZIP compression levels, hidden-file selection, exact no-file behavior, and native Buildkite publication. See the explicit limits below. |
+| `actions/download-artifact` | Narrow support | The audited v4.3.0 commit supports one exact literal name from verified direct `needs`, extracting directly to a clean workspace-relative path. |
 | Job and service containers | Not admitted | Implemented and runtime-proven, but still outside production `hosted-tokenless` policy. |
 | `docker://` actions | Not supported | Private images, credentials, arbitrary options, volumes, and privileged containers are also rejected. |
-| Artifact download and cache actions | Not supported | They compile but fail profile admission until their Buildkite-backed adapters exist. |
+| Artifact cache and broad download modes | Not supported | Cache, merge, IDs, patterns, all-artifact, cross-repository, and cross-run modes fail admission or input validation. |
 | Private repositories or actions | Not supported | The preview has no private-source capability broker. |
 | Secrets and provider tokens | Not supported | Includes `GITHUB_TOKEN`, GitHub App tokens, and protected environment grants. |
 | OIDC | Not supported | GitHub-compatible and migration OIDC flows are deferred. |
@@ -142,8 +143,14 @@ and `artifact-digest` as the bare SHA-256 of the stored ZIP, matching the useful
 shape of the upstream outputs. `artifact-url` is not fabricated because a
 GitHub run-scoped URL does not exist. The authoritative terminal result binds
 the ID and digest to the native Buildkite path, archive size, file count, and
-producer. `actions/download-artifact` remains unsupported until its consumer
-adapter can resolve that exact manifest contract across jobs.
+producer. The consumer recognizes only
+`actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093`.
+It scans only verified manifests from direct `needs`, requires one
+exact-name match, downloads by the bound producer job UUID,
+and verifies size and SHA-256 before preflighting and extracting the bounded
+ZIP. Omitted `path` means workspace root; `download-path` is absolute. Digest
+mismatch is fatal (stricter than upstream). GitHub URLs and metadata are not
+fabricated. Hosted roundtrip proof remains pending.
 
 ### Failures stay explicit
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -66,9 +66,10 @@ applies the same `hosted-tokenless` admission policy as production `upload`.
 It does not install Node or run action code. An `admitted` result is policy
 evidence, not runtime evidence.
 
-The exact audited `actions/upload-artifact` commit passes admission through its
-bounded native adapter. Cache actions, artifact download/merge, and unsupported
-upload commits still fail admission. Job and service container fixtures have
+The exact audited `actions/upload-artifact` and exact-name
+`actions/download-artifact` commits pass admission through bounded native
+adapters. Cache actions, artifact merge/broad download modes, and unsupported
+commits still fail admission. Job and service container fixtures have
 separate hosted runtime evidence but remain outside production admission.
 
 ### Hosted runtime proofs
@@ -96,6 +97,8 @@ phase selector only for targeted diagnosis:
 | Complete container runtime | `PHASE5_PROBE=runtime`, `PHASE5_COMMIT=<commit>` |
 | Job summary annotation | `PHASE6_PROBE=summary`, `PHASE6_COMMIT=<commit>` |
 | Workflow warning/error annotations | `PHASE6_PROBE=annotations`, `PHASE6_COMMIT=<commit>` |
+| Upload-artifact publication | `PHASE6_PROBE=upload-artifact`, `PHASE6_COMMIT=<commit>` |
+| Artifact producer/consumer roundtrip | `PHASE6_PROBE=artifact-roundtrip`, `PHASE6_COMMIT=<commit>` |
 
 Summary annotation publication is advisory, so the generated job's successful
 outcome does not by itself prove that Buildkite persisted the annotation. After
@@ -122,6 +125,20 @@ This verifier requires the generated job to pass even though it emitted an
 `::error` command, then checks exactly one job-scoped `warning` annotation and
 one job-scoped `error` annotation, their checked-in body fragments, and the
 absence of the registered masking canary.
+
+Artifact publication and consumption require independent native-storage
+observations after their targeted or aggregate builds settle:
+
+```sh
+scripts/phase-6-upload-artifact-verify <build-number> <commit>
+scripts/phase-6-artifact-roundtrip-verify <build-number> <commit>
+```
+
+The upload verifier binds the archive, terminal manifest, producer, digest,
+contents, and action outputs. The roundtrip verifier additionally requires the
+producer and both consumer matrix jobs to pass, checks all three terminal
+manifests, and confirms both consumers observed the exact payload and compatible
+absolute `download-path` output.
 
 The phase definitions under `.buildkite/` and the [active
 plan](plans/2026-07-22-buildkite-gha.md#current-progress) document the exact

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -1313,6 +1313,17 @@ Explicitly defer from beta unless implementation evidence changes the order:
   exact-commit artifact observation prove publication, attribution, manifest
   binding, archive integrity and contents, hidden-file exclusion, and compatible
   action outputs, so the separate upload-only fixture is now `runtime-pass`.
+  The consumer-side slice recognizes only the audited `actions/download-artifact`
+  v4.3.0 commit and one exact literal artifact name from verified direct
+  `needs`. It preserves the manifest's exact producer job UUID through runtime
+  hydration, revalidates native path, compressed size, digest, file count, ZIP
+  member paths and expanded bytes, then extracts directly to a confined
+  workspace-relative destination and exposes the compatible absolute
+  `download-path` output. Run-wide listing, IDs, patterns, merge, cross-run,
+  cross-repository, symlink, traversal, and special-file behavior fail closed.
+  The full producer-to-two-consumer fixture remains `compile-pass` until an
+  exact-commit hosted roundtrip and independent read-only observation establish
+  runtime evidence.
 - The first work wave is integrated: the Go/CLI foundation is runnable,
   ADR 0001 records the actionlint/act reuse boundary, and ADR 0002 plus schemas
   and eight conformance cases preserve the Phase 0 signed-envelope transport
@@ -1361,17 +1372,17 @@ Explicitly defer from beta unless implementation evidence changes the order:
 - The profile is also exposed as the text/JSON workflow preflight
   `buildkite-gha validate --profile hosted-tokenless --event-path <path>
   --format text|json <workflow>`. Expected-negative fixtures preserve current
-  boundaries: official GitHub artifact/cache actions compile but are denied
-  admission pending Phase 6. Job and service containers compile to schema-v4
-  plans and have hosted runtime evidence, while production admission rejects
-  their container provenance.
+  boundaries: cache actions, artifact merge and broad download modes, and
+  unsupported commits are denied admission or input validation. Job and service
+  containers compile to schema-v4 plans and have hosted runtime evidence, while
+  production admission rejects their container provenance.
 - A consolidated exact-commit hosted dispatcher is available with
   `SMOKE_PROBE=hosted` and `SMOKE_COMMIT=<full commit>`. It aggregates the
   Phase 2 shell/upload, Phase 3 concurrent, Phase 4 public-action, Phase 5
   hosted-Docker capability, Phase 5 Dockerfile-action, and Phase 5 complete
-  container-runtime proofs, plus the Phase 6 job-summary and workflow-command
-  annotation proofs. The dispatcher deliberately uploads each existing
-  importer and continuation
+  container-runtime proofs, plus the Phase 6 job-summary, workflow-command,
+  upload-artifact, and artifact-roundtrip proofs. The dispatcher deliberately
+  uploads each existing importer and continuation
   independently, then settles their generated and native terminal steps; it
   does not flatten the importer/continuation topology. Existing `PHASE2_PROBE`,
   `PHASE3_PROBE`, `PHASE4_PROBE`, all three `PHASE5_PROBE`, and `PHASE6_PROBE`
@@ -1918,10 +1929,11 @@ buildkite-gha validate --profile hosted-tokenless \
 ```
 
 Admission is policy evidence, not execution evidence. The exact audited
-`actions/upload-artifact` commit is admitted through its bounded native adapter;
-cache actions, artifact download/merge, and unsupported upload commits remain
-rejected. Unknown generic action dependencies are not declared executable
-merely because the profile admits them.
+`actions/upload-artifact` commit and exact-name `actions/download-artifact`
+commit are admitted through bounded native adapters; cache actions, artifact
+merge and broad download modes, and unsupported commits remain rejected.
+Unknown generic action dependencies are not declared executable merely because
+the profile admits them.
 
 The manual hosted aggregate is dispatched against one exact full commit:
 
@@ -1934,12 +1946,13 @@ bk build create --pipeline buildkite/buildkite-gha \
 ```
 
 It gathers Phase 2 shell/upload, Phase 3 concurrency, Phase 4 public actions,
-and the three Phase 5 Docker capability, Dockerfile-action, and complete
-container-runtime proofs in one build. Each phase still owns an independent
-importer and continuation loader; a final aggregate waits for all generated and
-native terminal evidence, including failures, without changing those security
-or dependency boundaries. Keep the phase-specific selectors for focused reruns
-and fault isolation.
+the three Phase 5 Docker capability, Dockerfile-action, and complete
+container-runtime proofs, and the implemented Phase 6 visibility and artifact
+proofs in one build. Each phase still owns an independent importer and
+continuation loader; a final aggregate waits for all generated and native
+terminal evidence, including failures, without changing those security or
+dependency boundaries. Keep the phase-specific selectors for focused reruns and
+fault isolation.
 
 ### Initial checked-in corpus
 

--- a/internal/action/integration/integration.go
+++ b/internal/action/integration/integration.go
@@ -31,9 +31,13 @@ const (
 	// AdapterUploadArtifactBuildkite stores the pinned upload-artifact action as
 	// a Buildkite-native ZIP without executing its JavaScript lifecycle.
 	AdapterUploadArtifactBuildkite Adapter = "upload-artifact-buildkite-v1"
+	// AdapterDownloadArtifactBuildkite extracts one producer-attributed native
+	// archive without using the GitHub Actions artifact service.
+	AdapterDownloadArtifactBuildkite Adapter = "download-artifact-buildkite-v1"
 	// UploadArtifactCommit is the only upstream implementation whose input and
 	// archive semantics this adapter implements.
-	UploadArtifactCommit = "ea165f8d65b6e75b540449e92b4886f43607fa02"
+	UploadArtifactCommit   = "ea165f8d65b6e75b540449e92b4886f43607fa02"
+	DownloadArtifactCommit = "d3f86a106a0bac45b974a628896c90dbdf5c8093"
 
 	MaxUploadArtifactNameBytes = 255
 	MaxUploadArtifactRoots     = 32
@@ -63,13 +67,49 @@ var catalog = map[Identity]Descriptor{
 	{Source: "github", Repository: "actions/cache", Path: "save"}:            {Service: ServiceCache},
 	{Source: "github", Repository: "actions/upload-artifact"}:                {Adapter: AdapterUploadArtifactBuildkite},
 	{Source: "github", Repository: "actions/upload-artifact", Path: "merge"}: {Service: ServiceArtifact},
-	{Source: "github", Repository: "actions/download-artifact"}:              {Service: ServiceArtifact},
+	{Source: "github", Repository: "actions/download-artifact"}:              {Adapter: AdapterDownloadArtifactBuildkite},
 }
 
 // ValidateUploadArtifactCommit rejects semantic drift from the audited action.
 func ValidateUploadArtifactCommit(commit string) error {
 	if commit != UploadArtifactCommit {
 		return fmt.Errorf("actions/upload-artifact native adapter supports only commit %s, resolved %q; Phase 6 is required", UploadArtifactCommit, commit)
+	}
+	return nil
+}
+
+func ValidateDownloadArtifactCommit(commit string) error {
+	if commit != DownloadArtifactCommit {
+		return fmt.Errorf("actions/download-artifact native adapter supports only commit %s, resolved %q; Phase 6 is required", DownloadArtifactCommit, commit)
+	}
+	return nil
+}
+
+// ValidateDownloadArtifactInputs implements only v4.3.0 exact-name mode.
+func ValidateDownloadArtifactInputs(inputs map[string]string) error {
+	allowed := map[string]bool{"name": true, "path": true, "merge-multiple": true}
+	seen := map[string]bool{}
+	for _, name := range sortedNames(inputs) {
+		lower := strings.ToLower(name)
+		if seen[lower] {
+			return fmt.Errorf("duplicate case-insensitive input %q is unsupported; Phase 6 is required", name)
+		}
+		seen[lower] = true
+		if !allowed[lower] {
+			return fmt.Errorf("input %q is unsupported by the bounded download-artifact adapter; Phase 6 is required", name)
+		}
+	}
+	name, ok := inputFold(inputs, "name")
+	if !ok || strings.Contains(name, "${{") || ValidateUploadArtifactName(name) != nil {
+		return fmt.Errorf("required input %q must be an exact literal artifact name", "name")
+	}
+	if value, ok := inputFold(inputs, "path"); ok {
+		if value == "" || strings.Contains(value, "${{") || len(value) > MaxUploadArtifactPathBytes || strings.Contains(value, "\\") || !filepath.IsLocal(value) || path.Clean(value) != value {
+			return fmt.Errorf("input %q must be a clean workspace-relative literal", "path")
+		}
+	}
+	if value, ok := inputFold(inputs, "merge-multiple"); ok && !uploadArtifactFalse(value) {
+		return fmt.Errorf("input %q may only be omitted or false; Phase 6 is required", "merge-multiple")
 	}
 	return nil
 }

--- a/internal/action/integration/integration_test.go
+++ b/internal/action/integration/integration_test.go
@@ -16,7 +16,7 @@ func TestLookupMatchesKnownCanonicalActions(t *testing.T) {
 		{Identity{Source: "github", Repository: "actions/cache", Path: "save"}, Descriptor{Service: ServiceCache}},
 		{Identity{Source: "github", Repository: "actions/upload-artifact"}, Descriptor{Adapter: AdapterUploadArtifactBuildkite}},
 		{Identity{Source: "github", Repository: "actions/upload-artifact", Path: "merge"}, Descriptor{Service: ServiceArtifact}},
-		{Identity{Source: "github", Repository: "actions/download-artifact"}, Descriptor{Service: ServiceArtifact}},
+		{Identity{Source: "github", Repository: "actions/download-artifact"}, Descriptor{Adapter: AdapterDownloadArtifactBuildkite}},
 	}
 	for _, test := range tests {
 		name := test.identity.Repository
@@ -27,6 +27,31 @@ func TestLookupMatchesKnownCanonicalActions(t *testing.T) {
 			got, ok := Lookup(test.identity)
 			if !ok || got != test.want {
 				t.Fatalf("Lookup(%#v) = %#v, %t, want %#v, true", test.identity, got, ok, test.want)
+			}
+		})
+	}
+}
+
+func TestDownloadArtifactExactContract(t *testing.T) {
+	if err := ValidateDownloadArtifactCommit(DownloadArtifactCommit); err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateDownloadArtifactCommit(strings.Repeat("0", 40)); err == nil {
+		t.Fatal("unrecognized commit accepted")
+	}
+	for _, inputs := range []map[string]string{{"name": "payload"}, {"Name": "payload", "path": "out", "merge-multiple": "False"}} {
+		if err := ValidateDownloadArtifactInputs(inputs); err != nil {
+			t.Fatalf("valid inputs rejected: %v", err)
+		}
+	}
+	for name, inputs := range map[string]map[string]string{
+		"all": nil, "expression": {"name": "${{ x }}"}, "absolute": {"name": "x", "path": "/tmp"},
+		"merge": {"name": "x", "merge-multiple": "true"}, "ids": {"name": "x", "artifact-ids": "1"},
+		"duplicate": {"name": "x", "Name": "y"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if ValidateDownloadArtifactInputs(inputs) == nil {
+				t.Fatal("unsupported inputs accepted")
 			}
 		})
 	}

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -315,8 +315,8 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 	if document.Agents.Queue != "hosted" {
 		t.Fatalf("default pipeline queue = %q, want hosted", document.Agents.Queue)
 	}
-	if len(document.Steps) != 15 {
-		t.Fatalf("default pipeline = %#v, want twelve gated loaders, repository checks, wait, and release", document.Steps)
+	if len(document.Steps) != 16 {
+		t.Fatalf("default pipeline = %#v, want thirteen gated loaders, repository checks, wait, and release", document.Steps)
 	}
 	steps := make(map[string]struct {
 		command     string
@@ -372,6 +372,9 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 	if got := steps["phase-6-upload-artifact-loader"]; got.command != "buildkite-agent pipeline upload .buildkite/phase-6-upload-artifact.yml" || got.condition != `build.env("PHASE6_PROBE") == "upload-artifact" && build.env("SMOKE_PROBE") != "hosted"` {
 		t.Fatalf("Phase 6 upload-artifact loader = %#v", got)
 	}
+	if got := steps["phase-6-artifact-roundtrip-loader"]; got.command != "buildkite-agent pipeline upload .buildkite/phase-6-artifact-roundtrip.yml" || got.condition != `build.env("PHASE6_PROBE") == "artifact-roundtrip" && build.env("SMOKE_PROBE") != "hosted"` {
+		t.Fatalf("Phase 6 artifact roundtrip loader = %#v", got)
+	}
 	hosted := steps["hosted-smoke-loader"]
 	if hosted.condition != `build.env("SMOKE_PROBE") == "hosted"` {
 		t.Fatalf("hosted smoke loader = %#v", hosted)
@@ -394,7 +397,7 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 			t.Fatalf("hosted smoke loader lacks %q:\n%s", required, hosted.command)
 		}
 	}
-	for _, fragment := range []string{"phase-2-upload.yml", "phase-3-upload.yml", "phase-4-upload.yml", "phase-5-capabilities.yml", "phase-5-docker-action.yml", "phase-5-runtime.yml", "phase-6-summary.yml", "phase-6-annotations.yml", "phase-6-upload-artifact.yml", "hosted-smoke-control.yml"} {
+	for _, fragment := range []string{"phase-2-upload.yml", "phase-3-upload.yml", "phase-4-upload.yml", "phase-5-capabilities.yml", "phase-5-docker-action.yml", "phase-5-runtime.yml", "phase-6-summary.yml", "phase-6-annotations.yml", "phase-6-upload-artifact.yml", "phase-6-artifact-roundtrip.yml", "hosted-smoke-control.yml"} {
 		if count := strings.Count(hosted.command, "buildkite-agent pipeline upload .buildkite/"+fragment); count != 1 {
 			t.Fatalf("hosted smoke loader uploads %s %d times:\n%s", fragment, count, hosted.command)
 		}
@@ -1171,6 +1174,124 @@ func TestPhase6UploadArtifactProofContract(t *testing.T) {
 	}
 }
 
+func TestPhase6ArtifactRoundtripProofContract(t *testing.T) {
+	root := filepath.Join("..", "..")
+	importerBody, err := os.ReadFile(filepath.Join(root, ".buildkite", "phase-6-artifact-roundtrip.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(importerBody)
+	for _, fragment := range []string{
+		`commit="$${PHASE6_COMMIT:-$${SMOKE_COMMIT:-}}"`,
+		`scripts/phase-0-shell-oracle-checkout "$$commit"`,
+		`test -z "$$(git status --porcelain --untracked-files=all)"`,
+		`automatic: false`,
+		`runtime_version="0.0.0-phase6.$$commit"`,
+		`go build -trimpath -buildvcs=false -ldflags "-X main.version=$$runtime_version"`,
+		`nonce="$${BUILDKITE_BUILD_NUMBER:?BUILDKITE_BUILD_NUMBER is required}"`,
+		`sed "s/__PHASE6_ARTIFACT_NONCE__/$$nonce/g" testdata/smoke/.github/workflows/artifact.yml`,
+		`! grep -q '__PHASE6_ARTIFACT_NONCE__' "$$proof_workflow"`,
+		`"$$distribution_root/buildkite-gha" upload`,
+		`--event-path testdata/smoke/events/push.json`,
+		`--runtime-queue hosted`,
+		`"$$proof_workflow"`,
+	} {
+		if !strings.Contains(text, fragment) {
+			t.Fatalf("Phase 6 artifact roundtrip importer lacks %q:\n%s", fragment, importerBody)
+		}
+	}
+	var upload struct {
+		Steps []struct {
+			Key                    string `yaml:"key"`
+			Command                string `yaml:"command"`
+			DependsOn              string `yaml:"depends_on"`
+			AllowDependencyFailure bool   `yaml:"allow_dependency_failure"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(importerBody, &upload); err != nil {
+		t.Fatal(err)
+	}
+	if len(upload.Steps) != 2 || upload.Steps[0].Key != "phase-6-artifact-roundtrip-importer" {
+		t.Fatalf("Phase 6 artifact roundtrip importer = %#v", upload.Steps)
+	}
+	loader := upload.Steps[1]
+	if loader.Key != "phase-6-artifact-roundtrip-continuation-loader" || loader.DependsOn != "phase-6-artifact-roundtrip-importer" || !loader.AllowDependencyFailure || loader.Command != "buildkite-agent pipeline upload .buildkite/phase-6-artifact-roundtrip-continuation.yml" {
+		t.Fatalf("Phase 6 artifact roundtrip continuation loader = %#v", loader)
+	}
+
+	continuationBody, err := os.ReadFile(filepath.Join(root, ".buildkite", "phase-6-artifact-roundtrip-continuation.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, fragment := range []string{
+		`key: "phase-6-native-after-artifact-roundtrip"`,
+		`step: "gha-artifact-producer"`,
+		`step: "gha-artifact-consumer-5ebbc197d87b"`,
+		`step: "gha-artifact-consumer-91934b28b00f"`,
+		`allow_failure: true`,
+	} {
+		if !strings.Contains(string(continuationBody), fragment) {
+			t.Fatalf("Phase 6 artifact roundtrip continuation lacks %q: %s", fragment, continuationBody)
+		}
+	}
+
+	fixture, err := os.ReadFile(filepath.Join(root, "testdata", "smoke", ".github", "workflows", "artifact.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixtureText := string(fixture)
+	for _, fragment := range []string{
+		"artifact-producer:",
+		"artifact-consumer:",
+		"needs: artifact-producer",
+		"actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02",
+		"actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093",
+		"PHASE6_ARTIFACT_PAYLOAD: smoke-artifact:__PHASE6_ARTIFACT_NONCE__",
+		"steps.download.outputs.download-path",
+		"PHASE6_ARTIFACT_ROUNDTRIP=",
+	} {
+		if !strings.Contains(fixtureText, fragment) {
+			t.Fatalf("Phase 6 artifact roundtrip fixture lacks %q: %s", fragment, fixture)
+		}
+	}
+
+	verifierPath := filepath.Join(root, "scripts", "phase-6-artifact-roundtrip-verify")
+	verifier, err := os.ReadFile(verifierPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(verifierPath)
+	if err != nil || info.Mode()&0o111 == 0 {
+		t.Fatalf("Phase 6 artifact roundtrip verifier is not executable: %v", err)
+	}
+	verifierText := string(verifier)
+	for _, fragment := range []string{
+		"set -euo pipefail",
+		`expected_commit=$2`,
+		`bk --no-pager api "/pipelines/$pipeline/builds/$build_number"`,
+		`producer_key=gha-artifact-producer`,
+		`consumer_one_key=gha-artifact-consumer-5ebbc197d87b`,
+		`consumer_two_key=gha-artifact-consumer-91934b28b00f`,
+		`^buildkite-gha/v1/artifacts/[0-9a-f]{64}`,
+		`.schema == "buildkite-gha/result-manifest/v2"`,
+		`.artifacts[0].name == "smoke-payload"`,
+		`sha256sum "$archive_file"`,
+		`archive_payload_digest=`,
+		`unzip -Z1 "$archive_file"`,
+		`PHASE6_ARTIFACT_ROUNDTRIP=`,
+		`PHASE6_ARTIFACT_ROUNDTRIP_OBSERVATION=`,
+	} {
+		if !strings.Contains(verifierText, fragment) {
+			t.Fatalf("Phase 6 artifact roundtrip verifier lacks %q", fragment)
+		}
+	}
+	for _, forbidden := range []string{"BUILDKITE_API_TOKEN", "Authorization:", "bk auth token"} {
+		if strings.Contains(verifierText, forbidden) {
+			t.Fatalf("Phase 6 artifact roundtrip verifier handles credentials directly through %q", forbidden)
+		}
+	}
+}
+
 func TestHostedSmokeControlAndAggregatorDependencies(t *testing.T) {
 	type dependency struct {
 		Step         string `yaml:"step"`
@@ -1211,9 +1332,9 @@ func TestHostedSmokeControlAndAggregatorDependencies(t *testing.T) {
 	if control.Key != "hosted-smoke-aggregator-loader" || control.Command != "buildkite-agent pipeline upload .buildkite/hosted-smoke-aggregator.yml" {
 		t.Fatalf("control step = %#v", control)
 	}
-	assertSet("control", control.DependsOn, map[string]bool{"phase-2-continuation-loader": true, "phase-3-continuation-loader": true, "phase-4-continuation-loader": true, "phase-5-continuation-loader": true, "phase-5-docker-action-continuation-loader": true, "phase-5-runtime-continuation-loader": true, "phase-6-summary-continuation-loader": true, "phase-6-annotations-continuation-loader": true, "phase-6-upload-artifact-continuation-loader": true})
+	assertSet("control", control.DependsOn, map[string]bool{"phase-2-continuation-loader": true, "phase-3-continuation-loader": true, "phase-4-continuation-loader": true, "phase-5-continuation-loader": true, "phase-5-docker-action-continuation-loader": true, "phase-5-runtime-continuation-loader": true, "phase-6-summary-continuation-loader": true, "phase-6-annotations-continuation-loader": true, "phase-6-upload-artifact-continuation-loader": true, "phase-6-artifact-roundtrip-continuation-loader": true})
 	generated := map[string]bool{}
-	for _, name := range []string{"phase-2-upload-continuation.yml", "phase-3-upload-continuation.yml", "phase-4-upload-continuation.yml", "phase-5-capabilities-continuation.yml", "phase-5-docker-action-continuation.yml", "phase-5-runtime-continuation.yml", "phase-6-summary-continuation.yml", "phase-6-annotations-continuation.yml", "phase-6-upload-artifact-continuation.yml"} {
+	for _, name := range []string{"phase-2-upload-continuation.yml", "phase-3-upload-continuation.yml", "phase-4-upload-continuation.yml", "phase-5-capabilities-continuation.yml", "phase-5-docker-action-continuation.yml", "phase-5-runtime-continuation.yml", "phase-6-summary-continuation.yml", "phase-6-annotations-continuation.yml", "phase-6-upload-artifact-continuation.yml", "phase-6-artifact-roundtrip-continuation.yml"} {
 		continuation := read(name)
 		for _, dependency := range continuation.DependsOn {
 			generated[dependency.Step] = true
@@ -1223,7 +1344,7 @@ func TestHostedSmokeControlAndAggregatorDependencies(t *testing.T) {
 	for key := range generated {
 		want[key] = true
 	}
-	for _, key := range []string{"gha-producer", "gha-concurrent", "phase-2-native-after-shell", "phase-3-native-after-concurrent", "phase-4-native-after-actions", "phase-5-native-after-hosted-docker", "phase-5-native-after-docker-action", "phase-5-native-after-runtime", "phase-6-native-after-summary", "phase-6-native-after-annotations", "phase-6-native-after-upload-artifact"} {
+	for _, key := range []string{"gha-producer", "gha-concurrent", "gha-artifact-producer", "gha-artifact-consumer-5ebbc197d87b", "gha-artifact-consumer-91934b28b00f", "phase-2-native-after-shell", "phase-3-native-after-concurrent", "phase-4-native-after-actions", "phase-5-native-after-hosted-docker", "phase-5-native-after-docker-action", "phase-5-native-after-runtime", "phase-6-native-after-summary", "phase-6-native-after-annotations", "phase-6-native-after-upload-artifact", "phase-6-native-after-artifact-roundtrip"} {
 		want[key] = true
 	}
 	aggregator := read("hosted-smoke-aggregator.yml")
@@ -1236,7 +1357,7 @@ func TestHostedSmokeControlAndAggregatorDependencies(t *testing.T) {
 			t.Fatalf("aggregator command does not inspect generated step %q: %s", key, aggregator.Command)
 		}
 	}
-	for _, key := range []string{"gha-producer", "gha-concurrent", "phase-2-native-after-shell", "phase-3-native-after-concurrent", "phase-4-native-after-actions", "phase-5-native-after-hosted-docker", "phase-5-native-after-docker-action", "phase-5-native-after-runtime", "phase-6-native-after-summary", "phase-6-native-after-annotations", "phase-6-native-after-upload-artifact"} {
+	for _, key := range []string{"gha-producer", "gha-concurrent", "gha-artifact-producer", "gha-artifact-consumer-5ebbc197d87b", "gha-artifact-consumer-91934b28b00f", "phase-2-native-after-shell", "phase-3-native-after-concurrent", "phase-4-native-after-actions", "phase-5-native-after-hosted-docker", "phase-5-native-after-docker-action", "phase-5-native-after-runtime", "phase-6-native-after-summary", "phase-6-native-after-annotations", "phase-6-native-after-upload-artifact", "phase-6-native-after-artifact-roundtrip"} {
 		if !strings.Contains(aggregator.Command, key) {
 			t.Fatalf("aggregator command does not inspect required step %q: %s", key, aggregator.Command)
 		}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -685,7 +685,6 @@ func TestUnprivilegedUploadRejectsKnownGitHubServiceActions(t *testing.T) {
 		service string
 	}{
 		{plan.ActionLock{Source: "github", Repository: "actions/upload-artifact", Path: "merge"}, "artifact"},
-		{plan.ActionLock{Source: "github", Repository: "actions/download-artifact"}, "artifact"},
 		{plan.ActionLock{Source: "github", Repository: "actions/cache"}, "cache"},
 		{plan.ActionLock{Source: "github", Repository: "actions/cache", Path: "restore"}, "cache"},
 		{plan.ActionLock{Source: "github", Repository: "actions/cache", Path: "save"}, "cache"},
@@ -705,6 +704,13 @@ func TestUnprivilegedUploadRejectsKnownGitHubServiceActions(t *testing.T) {
 				t.Fatalf("validateUnprivilegedBundle(%#v) error = %v", test.action, err)
 			}
 		})
+	}
+}
+
+func TestUnprivilegedUploadAllowsNativeDownloadArtifactAdapter(t *testing.T) {
+	bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: plan.Job{Workflow: plan.Workflow{LogicalJobID: "consumer"}, Actions: []plan.ActionLock{{Source: "github", Repository: "actions/download-artifact", Commit: actionintegration.DownloadArtifactCommit}}}}}}
+	if err := validateUnprivilegedBundle(bundle); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -181,6 +181,11 @@ func (b *actionLockBuilder) describe(ctx context.Context, raw string) (string, p
 			return "", plan.ActionLock{}, "", "", err
 		}
 	}
+	if descriptor.Adapter == actionintegration.AdapterDownloadArtifactBuildkite {
+		if err := actionintegration.ValidateDownloadArtifactCommit(lock.Commit); err != nil {
+			return "", plan.ActionLock{}, "", "", err
+		}
+	}
 	b.caps["network"] = true
 	return key, lock, materialized.RepositoryRoot, ref.Path, nil
 }

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -428,6 +428,58 @@ func TestUploadArtifactAdapterInputAndCommitBoundary(t *testing.T) {
 	}
 }
 
+func TestDownloadArtifactAdapterInputCommitAndNeedsBoundary(t *testing.T) {
+	workspace, remote := t.TempDir(), t.TempDir()
+	workflowPath := filepath.Join(workspace, ".github", "workflows", "artifact.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeAction(t, remote, "", "name: artifact action\nruns:\n  using: node20\n  main: index.js\n")
+	compile := func(commit, needs, with string) ([]plan.Job, error) {
+		workflow := []byte("on: push\njobs:\n  producer:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/upload-artifact@" + actionintegration.UploadArtifactCommit + "\n        with:\n          path: payload\n  consumer:\n" + needs + "    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/download-artifact@" + commit + "\n" + with)
+		if err := os.WriteFile(workflowPath, workflow, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return CompilePlansWithOptions(workflowPath, workflow, pushEvent(t), "phase6-test", testDistributionDigest, Options{
+			EventTrust: EventUntrusted,
+			Runners: RunnerPolicy{
+				Labels:          map[string]string{"ubuntu-latest": "hosted"},
+				UntrustedQueues: []string{"hosted"},
+			},
+			ResolveActions: true,
+			ActionSource:   &fakeActionSource{root: remote, calls: map[string]int{}},
+		})
+	}
+
+	plans, err := compile(actionintegration.DownloadArtifactCommit, "    needs: producer\n", "        with:\n          name: payload\n          path: out\n          merge-multiple: false\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 2 || len(plans[1].NeedSources["producer"]) != 1 || plans[1].Actions[0].Commit != actionintegration.DownloadArtifactCommit {
+		t.Fatalf("download-artifact plans = %#v", plans)
+	}
+
+	for name, with := range map[string]string{
+		"missing name":  "        with:\n          path: out\n",
+		"pattern":       "        with:\n          name: payload\n          pattern: 'payload-*'\n",
+		"merge":         "        with:\n          name: payload\n          merge-multiple: true\n",
+		"absolute path": "        with:\n          name: payload\n          path: /tmp/out\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := compile(actionintegration.DownloadArtifactCommit, "    needs: producer\n", with)
+			if err == nil || !strings.Contains(err.Error(), "bounded download-artifact adapter") {
+				t.Fatalf("CompilePlansWithOptions() error = %v", err)
+			}
+		})
+	}
+	if _, err := compile(actionintegration.DownloadArtifactCommit, "", "        with:\n          name: payload\n"); err == nil || !strings.Contains(err.Error(), "direct needs producer") {
+		t.Fatalf("needs-free download-artifact error = %v", err)
+	}
+	if _, err := compile(strings.Repeat("b", 40), "    needs: producer\n", "        with:\n          name: payload\n"); err == nil || !strings.Contains(err.Error(), actionintegration.DownloadArtifactCommit) {
+		t.Fatalf("unsupported download-artifact commit error = %v", err)
+	}
+}
+
 func TestPhase4ContinuationDependsOnCompiledPublicActionsTerminal(t *testing.T) {
 	remote := t.TempDir()
 	writeAction(t, remote, "", "name: remote\nruns:\n  using: node24\n  main: index.js\n")

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -299,6 +299,16 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 						return nil, nil, fmt.Errorf("%s:%d:%d: bounded upload-artifact adapter: %w", instance.SourcePath, span.Line, span.Column, err)
 					}
 				}
+				if descriptor.Adapter == actionintegration.AdapterDownloadArtifactBuildkite {
+					if err := actionintegration.ValidateDownloadArtifactInputs(instance.Steps[stepIndex].With); err != nil {
+						span := instance.Steps[stepIndex].Span.Start
+						return nil, nil, fmt.Errorf("%s:%d:%d: bounded download-artifact adapter: %w", instance.SourcePath, span.Line, span.Column, err)
+					}
+					if len(instance.LogicalNeeds) == 0 {
+						span := instance.Steps[stepIndex].Span.Start
+						return nil, nil, fmt.Errorf("%s:%d:%d: bounded download-artifact adapter requires at least one direct needs producer", instance.SourcePath, span.Line, span.Column)
+					}
+				}
 			}
 			jobSchema = plan.SchemaV3
 			actions = locks

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -78,9 +78,20 @@ type Target struct {
 }
 
 type Need struct {
-	Result  string            `json:"result"`
-	Outputs map[string]string `json:"outputs,omitempty"`
+	Result    string            `json:"result"`
+	Outputs   map[string]string `json:"outputs,omitempty"`
+	Artifacts []NeedArtifact    `json:"-"`
 }
+
+// NeedArtifact is verified runtime-only native storage authority.
+type NeedArtifact struct {
+	Name, ID, Path, Digest string
+	Size                   int64
+	FileCount              int
+	Producer               NeedProducer
+}
+
+type NeedProducer struct{ BuildID, JobID, StepKey string }
 
 // NeedSource binds one logical prerequisite to an exact generated producer
 // and immutable plan. Buildkite scheduling still uses Dependencies; runtimes

--- a/internal/runtime/actions.go
+++ b/internal/runtime/actions.go
@@ -65,6 +65,11 @@ func usesUploadArtifactAdapter(lock plan.ActionLock) bool {
 	return descriptor.Adapter == actionintegration.AdapterUploadArtifactBuildkite
 }
 
+func usesDownloadArtifactAdapter(lock plan.ActionLock) bool {
+	descriptor, _ := actionintegration.Lookup(actionintegration.Identity{Source: lock.Source, Repository: lock.Repository, Path: lock.Path})
+	return descriptor.Adapter == actionintegration.AdapterDownloadArtifactBuildkite
+}
+
 func (r *actionLockResolver) source(selector plan.ActionSelector) (string, error) {
 	if r == nil || selector.Lock == "" {
 		return "", fmt.Errorf("resolve action lock: selector is missing")
@@ -92,6 +97,11 @@ func (r *actionLockResolver) resolve(ctx context.Context, selector plan.ActionSe
 	}
 	if usesUploadArtifactAdapter(entry.lock) {
 		if err := actionintegration.ValidateUploadArtifactCommit(entry.lock.Commit); err != nil {
+			return metadata.Metadata{}, plan.ActionLock{}, err
+		}
+	}
+	if usesDownloadArtifactAdapter(entry.lock) {
+		if err := actionintegration.ValidateDownloadArtifactCommit(entry.lock.Commit); err != nil {
 			return metadata.Metadata{}, plan.ActionLock{}, err
 		}
 	}

--- a/internal/runtime/download_artifact.go
+++ b/internal/runtime/download_artifact.go
@@ -26,8 +26,9 @@ type downloadMember struct {
 	size int64
 }
 
-func (r Runner) runDownloadArtifact(ctx context.Context, processor *commandProcessor, workspace string, needs map[string]plan.Need, inputs map[string]string) (Result, error) {
-	result := newResult()
+func (r Runner) runDownloadArtifact(ctx context.Context, processor *commandProcessor, workspace string, needs map[string]plan.Need, inputs map[string]string) (result Result, returnErr error) {
+	result = newResult()
+	defer func() { returnErr = processor.scrubError(returnErr) }()
 	if err := ctx.Err(); err != nil {
 		return result, err
 	}

--- a/internal/runtime/download_artifact.go
+++ b/internal/runtime/download_artifact.go
@@ -26,7 +26,7 @@ type downloadMember struct {
 	size int64
 }
 
-func (r Runner) runDownloadArtifact(ctx context.Context, workspace string, needs map[string]plan.Need, inputs map[string]string) (Result, error) {
+func (r Runner) runDownloadArtifact(ctx context.Context, processor *commandProcessor, workspace string, needs map[string]plan.Need, inputs map[string]string) (Result, error) {
 	result := newResult()
 	if err := ctx.Err(); err != nil {
 		return result, err
@@ -39,6 +39,11 @@ func (r Runner) runDownloadArtifact(ctx context.Context, workspace string, needs
 		values[strings.ToLower(k)] = v
 	}
 	name, destinationRelative := values["name"], "."
+	for _, mask := range processor.maskValues() {
+		if mask != "" && strings.Contains(name, mask) {
+			return result, errors.New("artifact name contains a registered mask and cannot be downloaded")
+		}
+	}
 	if p := values["path"]; p != "" {
 		destinationRelative = filepath.FromSlash(p)
 	}
@@ -60,7 +65,7 @@ func (r Runner) runDownloadArtifact(ctx context.Context, workspace string, needs
 		}
 	}
 	if len(matches) != 1 {
-		return result, fmt.Errorf("artifact %q has %d verified matches across direct needs, want exactly one", name, len(matches))
+		return result, fmt.Errorf("artifact lookup found %d verified matches across direct needs, want exactly one", len(matches))
 	}
 	if r.Artifacts == nil {
 		return result, fmt.Errorf("native artifact store is not configured")

--- a/internal/runtime/download_artifact.go
+++ b/internal/runtime/download_artifact.go
@@ -1,0 +1,283 @@
+package runtime
+
+import (
+	"archive/zip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"unicode/utf8"
+
+	actionintegration "github.com/buildkite/buildkite-gha/internal/action/integration"
+	"github.com/buildkite/buildkite-gha/internal/plan"
+	"github.com/buildkite/buildkite-gha/internal/transport"
+)
+
+type downloadMember struct {
+	file *zip.File
+	name string
+	size int64
+}
+
+func (r Runner) runDownloadArtifact(ctx context.Context, workspace string, needs map[string]plan.Need, inputs map[string]string) (Result, error) {
+	result := newResult()
+	if err := ctx.Err(); err != nil {
+		return result, err
+	}
+	if err := actionintegration.ValidateDownloadArtifactInputs(inputs); err != nil {
+		return result, fmt.Errorf("bounded download-artifact adapter: %w", err)
+	}
+	values := map[string]string{}
+	for k, v := range inputs {
+		values[strings.ToLower(k)] = v
+	}
+	name, destinationRelative := values["name"], "."
+	if p := values["path"]; p != "" {
+		destinationRelative = filepath.FromSlash(p)
+	}
+	logicalWorkspace, err := filepath.Abs(workspace)
+	if err != nil {
+		return result, err
+	}
+	resolvedWorkspace, err := filepath.EvalSymlinks(logicalWorkspace)
+	if err != nil {
+		return result, fmt.Errorf("resolve download workspace: %w", err)
+	}
+	absDestination := filepath.Join(logicalWorkspace, destinationRelative)
+	var matches []plan.NeedArtifact
+	for _, need := range needs {
+		for _, artifact := range need.Artifacts {
+			if artifact.Name == name {
+				matches = append(matches, artifact)
+			}
+		}
+	}
+	if len(matches) != 1 {
+		return result, fmt.Errorf("artifact %q has %d verified matches across direct needs, want exactly one", name, len(matches))
+	}
+	if r.Artifacts == nil {
+		return result, fmt.Errorf("native artifact store is not configured")
+	}
+	artifact := matches[0]
+	temporary, err := os.MkdirTemp("", "buildkite-gha-download-")
+	if err != nil {
+		return result, err
+	}
+	defer func() { _ = os.RemoveAll(temporary) }()
+	if err := r.Artifacts.DownloadArtifact(ctx, artifact.Path, temporary, artifact.Producer.JobID); err != nil {
+		return result, fmt.Errorf("download native artifact: %w", err)
+	}
+	archivePath := filepath.Join(temporary, filepath.FromSlash(artifact.Path))
+	regular := 0
+	if err := filepath.WalkDir(temporary, func(filename string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil || !info.Mode().IsRegular() || filename != archivePath {
+			return fmt.Errorf("download contained an unexpected file %q", filename)
+		}
+		regular++
+		return nil
+	}); err != nil {
+		return result, fmt.Errorf("download must contain exactly the expected archive: %w", err)
+	}
+	if regular != 1 {
+		return result, fmt.Errorf("download contained %d regular files, want exactly the expected archive", regular)
+	}
+	info, err := os.Lstat(archivePath)
+	if err != nil || !info.Mode().IsRegular() {
+		return result, fmt.Errorf("downloaded archive is not the expected regular file")
+	}
+	if info.Size() != artifact.Size {
+		return result, fmt.Errorf("downloaded archive size mismatch")
+	}
+	if err := verifyDownloadDigest(ctx, archivePath, artifact.Digest, artifact.Size); err != nil {
+		return result, err
+	}
+	if err := extractDownloadZIP(ctx, archivePath, resolvedWorkspace, destinationRelative, artifact.FileCount); err != nil {
+		return result, err
+	}
+	result.Outputs["download-path"] = absDestination
+	return result, nil
+}
+
+func verifyDownloadDigest(ctx context.Context, filename, digest string, size int64) error {
+	f, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	h := sha256.New()
+	n, copyErr := io.Copy(h, io.LimitReader(contextReader{ctx: ctx, reader: f}, transport.MaxResultArtifactSizeBytes+1))
+	closeErr := f.Close()
+	if err := errors.Join(copyErr, closeErr); err != nil {
+		return err
+	}
+	if n != size || "sha256:"+hex.EncodeToString(h.Sum(nil)) != digest {
+		return fmt.Errorf("downloaded archive digest mismatch")
+	}
+	return ctx.Err()
+}
+
+func extractDownloadZIP(ctx context.Context, filename, workspace, destination string, expectedCount int) error {
+	z, err := zip.OpenReader(filename)
+	if err != nil {
+		return fmt.Errorf("open artifact ZIP: %w", err)
+	}
+	defer func() { _ = z.Close() }()
+	if len(z.File) != expectedCount || len(z.File) > transport.MaxResultArtifactFileCount {
+		return fmt.Errorf("artifact ZIP file count mismatch")
+	}
+	seen, folded := map[string]bool{}, map[string]bool{}
+	members := make([]downloadMember, 0, len(z.File))
+	var expanded int64
+	for _, f := range z.File {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		name := f.Name
+		if !validArtifactMember(name) || seen[name] || folded[strings.ToLower(name)] {
+			return fmt.Errorf("unsafe or duplicate artifact ZIP member %q", name)
+		}
+		if f.Method != zip.Store && f.Method != zip.Deflate || !f.Mode().IsRegular() || f.FileInfo().IsDir() {
+			return fmt.Errorf("artifact ZIP member %q is not a supported regular file", name)
+		}
+		if f.UncompressedSize64 > uint64(transport.MaxResultArtifactSizeBytes) || expanded > transport.MaxResultArtifactSizeBytes-int64(f.UncompressedSize64) {
+			return fmt.Errorf("artifact expanded bytes exceed 1 GiB")
+		}
+		expanded += int64(f.UncompressedSize64)
+		seen[name], folded[strings.ToLower(name)] = true, true
+		members = append(members, downloadMember{file: f, name: name, size: int64(f.UncompressedSize64)})
+	}
+	workspaceRoot, err := os.OpenRoot(workspace)
+	if err != nil {
+		return fmt.Errorf("open download workspace: %w", err)
+	}
+	defer func() { _ = workspaceRoot.Close() }()
+	if err := validateDownloadDirectory(workspaceRoot, destination); err != nil {
+		return err
+	}
+	if err := workspaceRoot.MkdirAll(destination, 0o755); err != nil {
+		return err
+	}
+	if err := validateDownloadDirectory(workspaceRoot, destination); err != nil {
+		return err
+	}
+	root, err := workspaceRoot.OpenRoot(destination)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = root.Close() }()
+	if err := preflightDestination(root, members); err != nil {
+		return err
+	}
+	for _, member := range members {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if dir := path.Dir(member.name); dir != "." {
+			if err := root.MkdirAll(filepath.FromSlash(dir), 0o755); err != nil {
+				return err
+			}
+			if err := validateDownloadDirectory(root, filepath.FromSlash(dir)); err != nil {
+				return err
+			}
+		}
+		in, err := member.file.Open()
+		if err != nil {
+			return err
+		}
+		out, err := root.OpenFile(filepath.FromSlash(member.name), os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW|syscall.O_NONBLOCK, 0o644)
+		if err != nil {
+			_ = in.Close()
+			return fmt.Errorf("open artifact destination %q: %w", member.name, err)
+		}
+		info, statErr := out.Stat()
+		if statErr != nil || !info.Mode().IsRegular() {
+			return errors.Join(fmt.Errorf("artifact destination %q is not a regular file", member.name), statErr, out.Close(), in.Close())
+		}
+		if err := out.Chmod(0o644); err != nil {
+			return errors.Join(err, out.Close(), in.Close())
+		}
+		n, copyErr := io.Copy(out, io.LimitReader(contextReader{ctx: ctx, reader: in}, member.size+1))
+		err = errors.Join(copyErr, out.Close(), in.Close())
+		if err != nil {
+			return err
+		}
+		if n != member.size {
+			return fmt.Errorf("artifact ZIP member %q size mismatch", member.name)
+		}
+	}
+	return ctx.Err()
+}
+
+func validArtifactMember(name string) bool {
+	if name == "" || name == "." || len(name) > actionintegration.MaxUploadArtifactPathBytes || !utf8.ValidString(name) || strings.ContainsAny(name, "\\\x00") || path.Clean(name) != name || strings.HasPrefix(name, "/") {
+		return false
+	}
+	if len(strings.Split(name, "/")) > 256 {
+		return false
+	}
+	for _, r := range name {
+		if r < 0x20 || r == 0x7f {
+			return false
+		}
+	}
+	return true
+}
+
+func validateDownloadDirectory(root *os.Root, directory string) error {
+	if directory == "." {
+		return nil
+	}
+	current := ""
+	for _, component := range strings.Split(filepath.ToSlash(directory), "/") {
+		current = path.Join(current, component)
+		info, err := root.Lstat(filepath.FromSlash(current))
+		if os.IsNotExist(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return fmt.Errorf("artifact path component %q is not a real directory", current)
+		}
+	}
+	return nil
+}
+
+func preflightDestination(root *os.Root, members []downloadMember) error {
+	for _, member := range members {
+		current := ""
+		parts := strings.Split(member.name, "/")
+		for i, part := range parts {
+			current = path.Join(current, part)
+			info, err := root.Lstat(filepath.FromSlash(current))
+			if os.IsNotExist(err) {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if i < len(parts)-1 {
+				if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+					return fmt.Errorf("artifact path component %q is not a directory", current)
+				}
+			} else if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+				return fmt.Errorf("artifact destination collision %q is not a regular file", current)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/runtime/download_artifact_test.go
+++ b/internal/runtime/download_artifact_test.go
@@ -1,0 +1,298 @@
+package runtime
+
+import (
+	"archive/zip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+
+	actionintegration "github.com/buildkite/buildkite-gha/internal/action/integration"
+	"github.com/buildkite/buildkite-gha/internal/action/source"
+	"github.com/buildkite/buildkite-gha/internal/plan"
+	"github.com/buildkite/buildkite-gha/internal/transport"
+)
+
+type downloadStore struct {
+	archive string
+	path    string
+	jobID   string
+	extra   bool
+}
+
+func (s *downloadStore) UploadArtifactFrom(context.Context, string, string) error { return nil }
+func (s *downloadStore) DownloadArtifact(_ context.Context, path, destination, jobID string) error {
+	s.path = path
+	s.jobID = jobID
+	target := filepath.Join(destination, filepath.FromSlash(path))
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return err
+	}
+	b, err := os.ReadFile(s.archive)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(target, b, 0o644); err != nil {
+		return err
+	}
+	if s.extra {
+		return os.WriteFile(filepath.Join(destination, "unexpected"), []byte("extra"), 0o644)
+	}
+	return nil
+}
+
+func testDownloadZIP(t *testing.T, names ...string) (string, int64, string) {
+	t.Helper()
+	filename := filepath.Join(t.TempDir(), "artifact.zip")
+	f, err := os.Create(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	z := zip.NewWriter(f)
+	for _, name := range names {
+		w, err := z.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write([]byte("payload")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := z.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(b)
+	return filename, int64(len(b)), "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func TestDownloadArtifactExactNeedAndDirectExtraction(t *testing.T) {
+	archive, size, digest := testDownloadZIP(t, "nested/result.txt")
+	store := &downloadStore{archive: archive}
+	workspace := t.TempDir()
+	need := plan.NeedArtifact{Name: "payload", ID: "42", Path: "buildkite-gha/v1/artifacts/" + strings.Repeat("a", 64) + ".zip", Digest: digest, Size: size, FileCount: 1, Producer: plan.NeedProducer{JobID: "11111111-1111-4111-8111-111111111111"}}
+	result, err := (Runner{Artifacts: store}).runDownloadArtifact(context.Background(), workspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{need}}}, map[string]string{"name": "payload", "path": "out"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if store.path != need.Path || store.jobID != need.Producer.JobID {
+		t.Fatalf("download identity = %q / %q", store.path, store.jobID)
+	}
+	if got, _ := os.ReadFile(filepath.Join(workspace, "out", "nested", "result.txt")); string(got) != "payload" {
+		t.Fatalf("contents = %q", got)
+	}
+	want, _ := filepath.Abs(filepath.Join(workspace, "out"))
+	if result.Outputs["download-path"] != want {
+		t.Fatalf("download-path = %q", result.Outputs["download-path"])
+	}
+	if _, err := (Runner{Artifacts: store}).runDownloadArtifact(context.Background(), workspace, map[string]plan.Need{}, map[string]string{"name": "payload"}); err == nil {
+		t.Fatal("missing artifact accepted")
+	}
+	if _, err := (Runner{Artifacts: store}).runDownloadArtifact(context.Background(), workspace, map[string]plan.Need{"a": {Artifacts: []plan.NeedArtifact{need}}, "b": {Artifacts: []plan.NeedArtifact{need}}}, map[string]string{"name": "payload"}); err == nil {
+		t.Fatal("ambiguous artifact accepted")
+	}
+	if _, err := (Runner{Artifacts: store}).runDownloadArtifact(context.Background(), workspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{need}}}, map[string]string{"name": "Payload"}); err == nil {
+		t.Fatal("non-exact artifact name accepted")
+	}
+}
+
+func TestDownloadArtifactRejectsUnsafeZIPAndDigest(t *testing.T) {
+	for _, name := range []string{"../escape", "/absolute", "dir/../escape", "a\\b"} {
+		t.Run(name, func(t *testing.T) {
+			archive, _, _ := testDownloadZIP(t, name)
+			if err := extractDownloadZIP(context.Background(), archive, t.TempDir(), ".", 1); err == nil {
+				t.Fatal("unsafe member accepted")
+			}
+		})
+	}
+	archive, _, _ := testDownloadZIP(t, "A.txt", "a.txt")
+	if err := extractDownloadZIP(context.Background(), archive, t.TempDir(), ".", 2); err == nil || !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("case-folding collision error = %v", err)
+	}
+	archive, size, _ := testDownloadZIP(t, "ok")
+	if err := verifyDownloadDigest(context.Background(), archive, "sha256:"+strings.Repeat("0", 64), size); err == nil {
+		t.Fatal("bad digest accepted")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := verifyDownloadDigest(ctx, archive, "", size); err == nil {
+		t.Fatal("cancellation ignored")
+	}
+	if err := extractDownloadZIP(ctx, archive, t.TempDir(), ".", 1); !errors.Is(err, context.Canceled) {
+		t.Fatalf("extraction cancellation error = %v", err)
+	}
+}
+
+func TestDownloadArtifactRejectsManifestAndDownloadMismatch(t *testing.T) {
+	archive, size, digest := testDownloadZIP(t, "result.txt")
+	base := plan.NeedArtifact{Name: "payload", Path: "buildkite-gha/v1/artifacts/" + strings.Repeat("b", 64) + ".zip", Digest: digest, Size: size, FileCount: 1, Producer: plan.NeedProducer{JobID: "11111111-1111-4111-8111-111111111111"}}
+	for _, test := range []struct {
+		name  string
+		alter func(*plan.NeedArtifact, *downloadStore)
+	}{
+		{name: "size", alter: func(a *plan.NeedArtifact, _ *downloadStore) { a.Size++ }},
+		{name: "file count", alter: func(a *plan.NeedArtifact, _ *downloadStore) { a.FileCount++ }},
+		{name: "extra download", alter: func(_ *plan.NeedArtifact, s *downloadStore) { s.extra = true }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			artifact := base
+			store := &downloadStore{archive: archive}
+			test.alter(&artifact, store)
+			_, err := (Runner{Artifacts: store}).runDownloadArtifact(context.Background(), t.TempDir(), map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{artifact}}}, map[string]string{"name": "payload"})
+			if err == nil {
+				t.Fatal("mismatched download accepted")
+			}
+		})
+	}
+}
+
+func TestDownloadArtifactDestinationCollisions(t *testing.T) {
+	archive, _, _ := testDownloadZIP(t, "nested/result.txt")
+	workspace := t.TempDir()
+	regular := filepath.Join(workspace, "regular")
+	if err := os.MkdirAll(filepath.Join(regular, "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(regular, "nested", "result.txt"), []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := extractDownloadZIP(context.Background(), archive, workspace, "regular", 1); err != nil {
+		t.Fatalf("replace regular file: %v", err)
+	}
+	if got, err := os.ReadFile(filepath.Join(regular, "nested", "result.txt")); err != nil || string(got) != "payload" {
+		t.Fatalf("replaced contents = %q, %v", got, err)
+	}
+
+	for _, test := range []struct {
+		name   string
+		create func(string) error
+	}{
+		{name: "directory", create: func(name string) error { return os.MkdirAll(name, 0o755) }},
+		{name: "symlink", create: func(name string) error { return os.Symlink("elsewhere", name) }},
+		{name: "fifo", create: func(name string) error { return syscall.Mkfifo(name, 0o600) }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			destination := filepath.Join(workspace, test.name)
+			if err := os.MkdirAll(filepath.Join(destination, "nested"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := test.create(filepath.Join(destination, "nested", "result.txt")); err != nil {
+				t.Fatal(err)
+			}
+			if err := extractDownloadZIP(context.Background(), archive, workspace, test.name, 1); err == nil {
+				t.Fatal("non-regular destination accepted")
+			}
+		})
+	}
+}
+
+func TestDownloadArtifactRejectsDestinationSymlinkEscape(t *testing.T) {
+	archive, _, _ := testDownloadZIP(t, "result.txt")
+	workspace, outside := t.TempDir(), t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(workspace, "linked")); err != nil {
+		t.Fatal(err)
+	}
+	if err := extractDownloadZIP(context.Background(), archive, workspace, "linked/out", 1); err == nil {
+		t.Fatal("symlinked destination accepted")
+	}
+	if _, err := os.Stat(filepath.Join(outside, "out", "result.txt")); !os.IsNotExist(err) {
+		t.Fatalf("outside destination was mutated: %v", err)
+	}
+}
+
+func TestDownloadArtifactRejectsUnsupportedMemberAndExpandedSize(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		method uint16
+		mode   os.FileMode
+		size   uint64
+	}{
+		{name: "directory", method: zip.Store, mode: os.ModeDir | 0o755},
+		{name: "symlink", method: zip.Store, mode: os.ModeSymlink | 0o777},
+		{name: "method", method: 99, mode: 0o644},
+		{name: "expanded size", method: zip.Store, mode: 0o644, size: uint64(transport.MaxResultArtifactSizeBytes) + 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			filename := filepath.Join(t.TempDir(), "raw.zip")
+			out, err := os.Create(filename)
+			if err != nil {
+				t.Fatal(err)
+			}
+			zw := zip.NewWriter(out)
+			header := &zip.FileHeader{Name: "entry", Method: test.method, UncompressedSize64: test.size, CompressedSize64: 0}
+			header.SetMode(test.mode)
+			if _, err := zw.CreateRaw(header); err != nil {
+				t.Fatal(err)
+			}
+			if err := errors.Join(zw.Close(), out.Close()); err != nil {
+				t.Fatal(err)
+			}
+			if err := extractDownloadZIP(context.Background(), filename, t.TempDir(), ".", 1); err == nil {
+				t.Fatal("unsupported ZIP member accepted")
+			}
+		})
+	}
+}
+
+func TestDownloadArtifactAdapterBypassesVerifiedUpstreamLifecycle(t *testing.T) {
+	archive, size, digest := testDownloadZIP(t, "result.txt")
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/download.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: download proof\n")
+	remote := t.TempDir()
+	writeFixtureFile(t, remote, "action.yml", "name: download artifact\nruns:\n  using: node20\n  pre: dist/pre.js\n  main: dist/main.js\n  post: dist/post.js\n")
+	for _, phase := range []string{"pre", "main", "post"} {
+		writeFixtureFile(t, remote, "dist/"+phase+".js", "throw new Error('adapter must not execute upstream JavaScript')\n")
+	}
+	sourceDigest, err := source.DigestTree(remote)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lockID := "a-0000000000000002"
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{
+		ID: "download", Kind: "uses", Uses: "actions/download-artifact@" + actionintegration.DownloadArtifactCommit,
+		With:   map[string]string{"name": "payload", "path": "downloaded"},
+		Action: &plan.ActionSelector{Lock: lockID},
+	}})
+	job.Schema = plan.SchemaV3
+	job.RequiredCapabilities = []string{"network"}
+	job.Outputs = map[string]string{"download_path": "${{ steps.download.outputs.download-path }}"}
+	job.Actions = []plan.ActionLock{{
+		ID: lockID, Source: "github", Repository: "actions/download-artifact", RequestedRef: actionintegration.DownloadArtifactCommit,
+		Commit: actionintegration.DownloadArtifactCommit, SourceDigest: sourceDigest,
+	}}
+	artifact := plan.NeedArtifact{
+		Name: "payload", ID: "42", Path: "buildkite-gha/v1/artifacts/" + strings.Repeat("c", 64) + ".zip",
+		Digest: digest, Size: size, FileCount: 1,
+		Producer: plan.NeedProducer{BuildID: "11111111-1111-4111-8111-111111111111", JobID: "22222222-2222-4222-8222-222222222222", StepKey: "gha-producer"},
+	}
+	job.Needs = map[string]plan.Need{"producer": {Result: "success", Artifacts: []plan.NeedArtifact{artifact}}}
+	store := &downloadStore{archive: archive}
+	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, ActionRoot: remote, SourceDigest: sourceDigest}}
+	result, err := (Runner{Actions: materializer, Artifacts: store}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" || result.Outputs["download_path"] != filepath.Join(workspace, "downloaded") {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	if materializer.calls != 1 || store.path != artifact.Path || store.jobID != artifact.Producer.JobID {
+		t.Fatalf("materializations/download = %d / %q / %q", materializer.calls, store.path, store.jobID)
+	}
+	if got, err := os.ReadFile(filepath.Join(workspace, "downloaded", "result.txt")); err != nil || string(got) != "payload" {
+		t.Fatalf("downloaded contents = %q, %v", got, err)
+	}
+
+	job.Actions[0].Commit = strings.Repeat("b", 40)
+	if _, err := (Runner{Actions: materializer, Artifacts: store}).RunJob(context.Background(), job, workspace); err == nil || !strings.Contains(err.Error(), actionintegration.DownloadArtifactCommit) {
+		t.Fatalf("unsupported runtime commit error = %v", err)
+	}
+}

--- a/internal/runtime/download_artifact_test.go
+++ b/internal/runtime/download_artifact_test.go
@@ -119,6 +119,26 @@ func TestDownloadArtifactRejectsMaskedNameWithoutDisclosure(t *testing.T) {
 	}
 }
 
+func TestDownloadArtifactScrubsMaskedMemberFromDestinationErrors(t *testing.T) {
+	const maskedMember = "runtime-secret-path"
+	archive, size, digest := testDownloadZIP(t, maskedMember)
+	workspace := t.TempDir()
+	if err := os.Mkdir(filepath.Join(workspace, maskedMember), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	processor := newCommandProcessor(io.Discard, io.Discard)
+	processor.addMask(maskedMember)
+	artifact := plan.NeedArtifact{
+		Name: "payload", Path: "buildkite-gha/v1/artifacts/" + strings.Repeat("d", 64) + ".zip",
+		Digest: digest, Size: size, FileCount: 1,
+		Producer: plan.NeedProducer{JobID: "11111111-1111-4111-8111-111111111111"},
+	}
+	_, err := (Runner{Artifacts: &downloadStore{archive: archive}}).runDownloadArtifact(context.Background(), processor, workspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{artifact}}}, map[string]string{"name": "payload"})
+	if err == nil || strings.Contains(err.Error(), maskedMember) || !strings.Contains(err.Error(), "***") {
+		t.Fatalf("masked destination error = %v", err)
+	}
+}
+
 func TestDownloadArtifactRejectsUnsafeZIPAndDigest(t *testing.T) {
 	for _, name := range []string{"../escape", "/absolute", "dir/../escape", "a\\b"} {
 		t.Run(name, func(t *testing.T) {

--- a/internal/runtime/download_artifact_test.go
+++ b/internal/runtime/download_artifact_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -81,8 +82,9 @@ func TestDownloadArtifactExactNeedAndDirectExtraction(t *testing.T) {
 	archive, size, digest := testDownloadZIP(t, "nested/result.txt")
 	store := &downloadStore{archive: archive}
 	workspace := t.TempDir()
+	processor := newCommandProcessor(io.Discard, io.Discard)
 	need := plan.NeedArtifact{Name: "payload", ID: "42", Path: "buildkite-gha/v1/artifacts/" + strings.Repeat("a", 64) + ".zip", Digest: digest, Size: size, FileCount: 1, Producer: plan.NeedProducer{JobID: "11111111-1111-4111-8111-111111111111"}}
-	result, err := (Runner{Artifacts: store}).runDownloadArtifact(context.Background(), workspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{need}}}, map[string]string{"name": "payload", "path": "out"})
+	result, err := (Runner{Artifacts: store}).runDownloadArtifact(context.Background(), processor, workspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{need}}}, map[string]string{"name": "payload", "path": "out"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,14 +98,24 @@ func TestDownloadArtifactExactNeedAndDirectExtraction(t *testing.T) {
 	if result.Outputs["download-path"] != want {
 		t.Fatalf("download-path = %q", result.Outputs["download-path"])
 	}
-	if _, err := (Runner{Artifacts: store}).runDownloadArtifact(context.Background(), workspace, map[string]plan.Need{}, map[string]string{"name": "payload"}); err == nil {
+	if _, err := (Runner{Artifacts: store}).runDownloadArtifact(context.Background(), processor, workspace, map[string]plan.Need{}, map[string]string{"name": "payload"}); err == nil || strings.Contains(err.Error(), "payload") {
 		t.Fatal("missing artifact accepted")
 	}
-	if _, err := (Runner{Artifacts: store}).runDownloadArtifact(context.Background(), workspace, map[string]plan.Need{"a": {Artifacts: []plan.NeedArtifact{need}}, "b": {Artifacts: []plan.NeedArtifact{need}}}, map[string]string{"name": "payload"}); err == nil {
+	if _, err := (Runner{Artifacts: store}).runDownloadArtifact(context.Background(), processor, workspace, map[string]plan.Need{"a": {Artifacts: []plan.NeedArtifact{need}}, "b": {Artifacts: []plan.NeedArtifact{need}}}, map[string]string{"name": "payload"}); err == nil || strings.Contains(err.Error(), "payload") {
 		t.Fatal("ambiguous artifact accepted")
 	}
-	if _, err := (Runner{Artifacts: store}).runDownloadArtifact(context.Background(), workspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{need}}}, map[string]string{"name": "Payload"}); err == nil {
+	if _, err := (Runner{Artifacts: store}).runDownloadArtifact(context.Background(), processor, workspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{need}}}, map[string]string{"name": "Payload"}); err == nil || strings.Contains(err.Error(), "Payload") {
 		t.Fatal("non-exact artifact name accepted")
+	}
+}
+
+func TestDownloadArtifactRejectsMaskedNameWithoutDisclosure(t *testing.T) {
+	const maskedName = "runtime-secret-artifact"
+	processor := newCommandProcessor(io.Discard, io.Discard)
+	processor.addMask(maskedName)
+	_, err := (Runner{}).runDownloadArtifact(context.Background(), processor, t.TempDir(), nil, map[string]string{"name": maskedName})
+	if err == nil || strings.Contains(err.Error(), maskedName) || !strings.Contains(err.Error(), "registered mask") {
+		t.Fatalf("masked artifact lookup error = %v", err)
 	}
 }
 
@@ -149,7 +161,7 @@ func TestDownloadArtifactRejectsManifestAndDownloadMismatch(t *testing.T) {
 			artifact := base
 			store := &downloadStore{archive: archive}
 			test.alter(&artifact, store)
-			_, err := (Runner{Artifacts: store}).runDownloadArtifact(context.Background(), t.TempDir(), map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{artifact}}}, map[string]string{"name": "payload"})
+			_, err := (Runner{Artifacts: store}).runDownloadArtifact(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{artifact}}}, map[string]string{"name": "payload"})
 			if err == nil {
 				t.Fatal("mismatched download accepted")
 			}

--- a/internal/runtime/download_artifact_test.go
+++ b/internal/runtime/download_artifact_test.go
@@ -139,6 +139,26 @@ func TestDownloadArtifactScrubsMaskedMemberFromDestinationErrors(t *testing.T) {
 	}
 }
 
+func TestDownloadArtifactScrubsQuotedMaskedDestinationFromErrors(t *testing.T) {
+	const maskedDestination = `runtime"secret`
+	archive, size, digest := testDownloadZIP(t, "result.txt")
+	workspace := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workspace, maskedDestination), []byte("collision"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	processor := newCommandProcessor(io.Discard, io.Discard)
+	processor.addMask(maskedDestination)
+	artifact := plan.NeedArtifact{
+		Name: "payload", Path: "buildkite-gha/v1/artifacts/" + strings.Repeat("e", 64) + ".zip",
+		Digest: digest, Size: size, FileCount: 1,
+		Producer: plan.NeedProducer{JobID: "11111111-1111-4111-8111-111111111111"},
+	}
+	_, err := (Runner{Artifacts: &downloadStore{archive: archive}}).runDownloadArtifact(context.Background(), processor, workspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{artifact}}}, map[string]string{"name": "payload", "path": maskedDestination})
+	if err == nil || strings.Contains(err.Error(), maskedDestination) || strings.Contains(err.Error(), `runtime\"secret`) || !strings.Contains(err.Error(), "***") {
+		t.Fatalf("quoted masked destination error = %v", err)
+	}
+}
+
 func TestDownloadArtifactRejectsUnsafeZIPAndDigest(t *testing.T) {
 	for _, name := range []string{"../escape", "/absolute", "dir/../escape", "a\\b"} {
 		t.Run(name, func(t *testing.T) {

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -317,7 +317,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 				runErr = errors.Join(runErr, fmt.Errorf("prepare action %q: %w", step.Uses, err))
 				break
 			}
-			if entry := actions.locks[step.Action.Lock]; entry != nil && usesUploadArtifactAdapter(entry.lock) {
+			if entry := actions.locks[step.Action.Lock]; entry != nil && (usesUploadArtifactAdapter(entry.lock) || usesDownloadArtifactAdapter(entry.lock)) {
 				continue
 			}
 			preResult, preErr := r.prepareRemoteAction(runCtx, processor, step, strconv.Itoa(stepIndex), jobResult.Env, eval, &posts, actions, prepared, &preStatus, nil)
@@ -821,7 +821,7 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 		// The checkout adapter replaces the verified action's JavaScript
 		// lifecycle as one indivisible operation. Do not register upstream
 		// checkout cleanup for a main phase that this runtime never executes.
-		if usesCheckoutAdapter(lock) || usesUploadArtifactAdapter(lock) {
+		if usesCheckoutAdapter(lock) || usesUploadArtifactAdapter(lock) || usesDownloadArtifactAdapter(lock) {
 			return result, nil
 		}
 		runPre, err := evaluateLifecycleCondition(action.Runs.PreIf, status.unsuccessful, ctx.Err() != nil)
@@ -990,6 +990,13 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 				return result, err
 			}
 			return r.runUploadArtifact(ctx, processor, workspace, inputs)
+		}
+		if usesDownloadArtifactAdapter(lock) {
+			inputs, err := evaluateMap(step.With, eval)
+			if err != nil {
+				return result, err
+			}
+			return r.runDownloadArtifact(ctx, workspace, job.Needs, inputs)
 		}
 	} else {
 		if !strings.HasPrefix(step.Uses, "./") {

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -996,7 +996,7 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 			if err != nil {
 				return result, err
 			}
-			return r.runDownloadArtifact(ctx, workspace, job.Needs, inputs)
+			return r.runDownloadArtifact(ctx, processor, workspace, job.Needs, inputs)
 		}
 	} else {
 		if !strings.HasPrefix(step.Uses, "./") {

--- a/internal/runtime/needs.go
+++ b/internal/runtime/needs.go
@@ -32,7 +32,12 @@ func ResolveNeeds(ctx context.Context, agent transport.Agent, root, buildID stri
 	}
 	needs := make(map[string]plan.Need, len(verified))
 	for name, result := range verified {
-		needs[name] = plan.Need{Result: result.Result, Outputs: result.Outputs}
+		need := plan.Need{Result: result.Result, Outputs: result.Outputs}
+		for _, retained := range result.Artifacts {
+			a, p := retained.Artifact, retained.Producer
+			need.Artifacts = append(need.Artifacts, plan.NeedArtifact{Name: a.Name, ID: a.ID, Path: a.Path, Digest: a.Digest, Size: a.Size, FileCount: a.FileCount, Producer: plan.NeedProducer{BuildID: p.BuildID, JobID: p.JobID, StepKey: p.StepKey}})
+		}
+		needs[name] = need
 	}
 	return needs, nil
 }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1248,6 +1248,37 @@ func (p *commandProcessor) maskValues() []string {
 	return append([]string(nil), p.masks...)
 }
 
+type scrubbedCommandError struct {
+	cause   error
+	message string
+}
+
+func (e scrubbedCommandError) Error() string { return e.message }
+func (e scrubbedCommandError) Unwrap() error { return e.cause }
+
+func (p *commandProcessor) scrubError(err error) error {
+	if err == nil {
+		return nil
+	}
+	masks := p.maskValues()
+	sort.Slice(masks, func(i, j int) bool {
+		if len(masks[i]) != len(masks[j]) {
+			return len(masks[i]) > len(masks[j])
+		}
+		return masks[i] < masks[j]
+	})
+	message := err.Error()
+	for _, mask := range masks {
+		if mask != "" {
+			message = strings.ReplaceAll(message, mask, "***")
+		}
+	}
+	if message == err.Error() {
+		return err
+	}
+	return scrubbedCommandError{cause: err, message: message}
+}
+
 func (p *commandProcessor) workflowCommandAnnotations() (warnings string, warningsTruncated bool, errors string, errorsTruncated bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1260,7 +1260,19 @@ func (p *commandProcessor) scrubError(err error) error {
 	if err == nil {
 		return nil
 	}
-	masks := p.maskValues()
+	registered := p.maskValues()
+	masks := make([]string, 0, len(registered)*2)
+	for _, mask := range registered {
+		if mask == "" {
+			continue
+		}
+		masks = append(masks, mask)
+		quoted := strconv.Quote(mask)
+		escaped := quoted[1 : len(quoted)-1]
+		if escaped != mask {
+			masks = append(masks, escaped)
+		}
+	}
 	sort.Slice(masks, func(i, j int) bool {
 		if len(masks[i]) != len(masks[j]) {
 			return len(masks[i]) > len(masks[j])
@@ -1269,9 +1281,7 @@ func (p *commandProcessor) scrubError(err error) error {
 	})
 	message := err.Error()
 	for _, mask := range masks {
-		if mask != "" {
-			message = strings.ReplaceAll(message, mask, "***")
-		}
+		message = strings.ReplaceAll(message, mask, "***")
 	}
 	if message == err.Error() {
 		return err

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -61,7 +61,7 @@ type Runner struct {
 	Secrets           SecretResolver
 	Redactor          Redactor
 	Actions           ActionMaterializer
-	Artifacts         ArtifactUploader
+	Artifacts         ArtifactStore
 	runnerTemp        string
 	implicitJobPATH   string
 	explicitJobPATH   bool

--- a/internal/runtime/upload_artifact.go
+++ b/internal/runtime/upload_artifact.go
@@ -18,15 +18,15 @@ import (
 	"sync"
 	"syscall"
 	"time"
-	"unicode/utf8"
 
 	actionintegration "github.com/buildkite/buildkite-gha/internal/action/integration"
 	"github.com/buildkite/buildkite-gha/internal/transport"
 )
 
-// ArtifactUploader is the narrow native storage boundary used by the adapter.
-type ArtifactUploader interface {
+// ArtifactStore is the narrow native storage boundary shared by both adapters.
+type ArtifactStore interface {
 	UploadArtifactFrom(context.Context, string, string) error
+	DownloadArtifact(context.Context, string, string, string) error
 }
 
 type artifactRegistry struct {
@@ -350,7 +350,7 @@ func collectUploadFiles(ctx context.Context, workspace string, roots []string, h
 		if old, ok := seen[lower]; ok {
 			return nil, fmt.Errorf("duplicate or case-colliding archive paths %q and %q", old, name)
 		}
-		if len(name) > actionintegration.MaxUploadArtifactPathBytes || !utf8.ValidString(name) || strings.ContainsAny(name, `":<>|*?`+"\r\n\\") {
+		if !validArtifactMember(name) || strings.ContainsAny(name, `":<>|*?`) {
 			return nil, fmt.Errorf("archive path %q contains forbidden characters", name)
 		}
 		seen[lower] = name

--- a/internal/runtime/upload_artifact_test.go
+++ b/internal/runtime/upload_artifact_test.go
@@ -32,6 +32,10 @@ type captureArtifactUploader struct {
 	err     error
 }
 
+func (u *captureArtifactUploader) DownloadArtifact(context.Context, string, string, string) error {
+	return errors.New("unexpected artifact download")
+}
+
 func (u *captureArtifactUploader) UploadArtifactFrom(_ context.Context, root, path string) error {
 	if u.err != nil {
 		return u.err
@@ -86,6 +90,25 @@ func TestUploadArtifactCanIncludeHiddenFiles(t *testing.T) {
 	}
 	if got := readUploadZIP(t, uploader.uploads[0].data); !reflect.DeepEqual(got, map[string]string{".hidden": "included"}) {
 		t.Fatalf("archive entries = %#v", got)
+	}
+}
+
+func TestUploadArtifactRejectsPathsTheConsumerCannotExtract(t *testing.T) {
+	workspace := t.TempDir()
+	writeFixtureFile(t, workspace, "control\tcharacter", "unsafe")
+	if _, err := collectUploadFiles(context.Background(), workspace, []string{"control\tcharacter"}, false); err == nil || !strings.Contains(err.Error(), "forbidden characters") {
+		t.Fatalf("control character error = %v", err)
+	}
+
+	components := make([]string, 258)
+	components[0] = "deep"
+	for i := 1; i < len(components)-1; i++ {
+		components[i] = "d"
+	}
+	components[len(components)-1] = "file"
+	writeFixtureFile(t, workspace, filepath.Join(components...), "too deep")
+	if _, err := collectUploadFiles(context.Background(), workspace, []string{"deep"}, false); err == nil || !strings.Contains(err.Error(), "forbidden characters") {
+		t.Fatalf("deep path error = %v", err)
 	}
 }
 

--- a/internal/transport/results.go
+++ b/internal/transport/results.go
@@ -22,6 +22,12 @@ type NeedResult struct {
 	Result    string
 	Outputs   map[string]string
 	Producers []Producer
+	Artifacts []NeedArtifact
+}
+
+type NeedArtifact struct {
+	Artifact ResultArtifact
+	Producer Producer
 }
 
 // Publication records the authoritative artifact and non-fatal visibility
@@ -192,6 +198,9 @@ func LoadNeeds(ctx context.Context, agent Agent, root, buildID string, sources m
 				return nil, fmt.Errorf("load logical need %q: %w", name, err)
 			}
 			need.Producers = append(need.Producers, manifest.Producer)
+			for _, artifact := range manifest.Artifacts {
+				need.Artifacts = append(need.Artifacts, NeedArtifact{Artifact: artifact, Producer: manifest.Producer})
+			}
 			need.Result = aggregateResult(need.Result, manifest.Result)
 			for _, output := range manifest.Outputs {
 				lower := strings.ToLower(output.Name)

--- a/internal/transport/results_test.go
+++ b/internal/transport/results_test.go
@@ -123,10 +123,12 @@ func TestLoadNeedsMapsLogicalFanInToVerifiedProducers(t *testing.T) {
 	second := ResultSource{StepKey: "gha-build-two", PlanDigest: Digest([]byte("two-plan"))}
 	firstPath := ResultPath(first.StepKey, first.PlanDigest)
 	secondPath := ResultPath(second.StepKey, second.PlanDigest)
+	firstManifest := resultManifest(testJobID, first.StepKey, first.PlanDigest, "success", Output{Name: "first", Value: "one"})
+	firstManifest.Artifacts = []ResultArtifact{resultArtifact("payload", "1", strings.Repeat("a", 64))}
 	runner := &resultRunner{
 		jobByStep: map[string]string{first.StepKey: testJobID, second.StepKey: testJobID2},
 		dataByPath: map[string][]byte{
-			firstPath:  mustManifest(t, resultManifest(testJobID, first.StepKey, first.PlanDigest, "success", Output{Name: "first", Value: "one"})),
+			firstPath:  mustManifest(t, firstManifest),
 			secondPath: mustManifest(t, resultManifest(testJobID2, second.StepKey, second.PlanDigest, "failure", Output{Name: "second", Value: "two"})),
 		},
 	}
@@ -134,8 +136,11 @@ func TestLoadNeedsMapsLogicalFanInToVerifiedProducers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if needs["build"].Result != "failure" || !reflect.DeepEqual(needs["build"].Outputs, map[string]string{"first": "one", "second": "two"}) || len(needs["build"].Producers) != 2 {
+	if needs["build"].Result != "failure" || !reflect.DeepEqual(needs["build"].Outputs, map[string]string{"first": "one", "second": "two"}) || len(needs["build"].Producers) != 2 || len(needs["build"].Artifacts) != 1 {
 		t.Fatalf("needs = %#v", needs)
+	}
+	if got := needs["build"].Artifacts[0]; got.Artifact != firstManifest.Artifacts[0] || got.Producer != firstManifest.Producer {
+		t.Fatalf("retained artifact authority = %#v", got)
 	}
 
 	runner.dataByPath[secondPath] = mustManifest(t, resultManifest(testJobID2, second.StepKey, second.PlanDigest, "success", Output{Name: "first", Value: "different"}))

--- a/mise.toml
+++ b/mise.toml
@@ -31,7 +31,7 @@ run = "golangci-lint run"
 
 [tasks."lint:shell"]
 description = "Lint shell scripts"
-run = "shellcheck -x .buildkite/phase-0-transport-probe/probe.sh scripts/ci-buildkite-release scripts/phase-0-shell-oracle-checkout scripts/phase-0-sign-json scripts/phase-0-verify-json scripts/phase-5-hosted-docker-probe scripts/phase-5-hosted-runtime-probe scripts/phase-6-summary-annotation-verify scripts/phase-6-upload-artifact-verify scripts/phase-6-workflow-annotations-verify scripts/release scripts/smoke-local testdata/actions/docker/entrypoint.sh testdata/phase5/runtime/.github/actions/docker/entrypoint.sh"
+run = "shellcheck -x .buildkite/phase-0-transport-probe/probe.sh scripts/ci-buildkite-release scripts/phase-0-shell-oracle-checkout scripts/phase-0-sign-json scripts/phase-0-verify-json scripts/phase-5-hosted-docker-probe scripts/phase-5-hosted-runtime-probe scripts/phase-6-artifact-roundtrip-verify scripts/phase-6-summary-annotation-verify scripts/phase-6-upload-artifact-verify scripts/phase-6-workflow-annotations-verify scripts/release scripts/smoke-local testdata/actions/docker/entrypoint.sh testdata/phase5/runtime/.github/actions/docker/entrypoint.sh"
 
 [tasks.vet]
 description = "Run go vet"

--- a/scripts/phase-6-artifact-roundtrip-verify
+++ b/scripts/phase-6-artifact-roundtrip-verify
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# != 2 )) || [[ ! $1 =~ ^[1-9][0-9]*$ ]] || [[ ! $2 =~ ^[0-9a-f]{40}$ ]]; then
+  echo 'usage: scripts/phase-6-artifact-roundtrip-verify <build-number> <commit>' >&2
+  exit 2
+fi
+
+readonly build_number=$1
+readonly expected_commit=$2
+readonly pipeline=${PHASE6_PIPELINE_SLUG:-buildkite-gha}
+readonly producer_key=gha-artifact-producer
+readonly consumer_one_key=gha-artifact-consumer-5ebbc197d87b
+readonly consumer_two_key=gha-artifact-consumer-91934b28b00f
+readonly expected_payload="smoke-artifact:$build_number"
+
+command -v bk >/dev/null
+command -v jq >/dev/null
+command -v sha256sum >/dev/null
+command -v unzip >/dev/null
+
+build="$(bk --no-pager api "/pipelines/$pipeline/builds/$build_number")"
+commit="$(jq -r '.commit // ""' <<<"$build")"
+if [[ $commit != "$expected_commit" ]]; then
+  echo "build $build_number ran commit $commit, expected $expected_commit" >&2
+  exit 1
+fi
+readonly commit
+build_id="$(jq -r '.id // ""' <<<"$build")"
+readonly build_id
+
+job_id() {
+  local step_key=$1
+  local -a matches
+  mapfile -t matches < <(jq -r --arg step_key "$step_key" '.jobs[] | select(.step_key == $step_key) | .id' <<<"$build")
+  if (( ${#matches[@]} != 1 )) || [[ ! ${matches[0]} =~ ^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$ ]]; then
+    echo "build $build_number has ${#matches[@]} jobs with step key $step_key; expected exactly one" >&2
+    return 1
+  fi
+  if ! jq -e --arg job_id "${matches[0]}" '.jobs[] | select(.id == $job_id) | .state == "passed"' <<<"$build" >/dev/null; then
+    echo "artifact roundtrip job ${matches[0]} ($step_key) did not pass" >&2
+    return 1
+  fi
+  printf '%s\n' "${matches[0]}"
+}
+
+producer_job="$(job_id "$producer_key")"
+consumer_one_job="$(job_id "$consumer_one_key")"
+consumer_two_job="$(job_id "$consumer_two_key")"
+readonly producer_job consumer_one_job consumer_two_job
+
+producer_artifacts="$(bk --no-pager api "/jobs/$producer_job/artifacts?per_page=100")"
+if ! jq -e --arg job_id "$producer_job" --arg step_key "$producer_key" '
+  length == 2 and
+  all(.[]; .job_id == $job_id and .state == "finished") and
+  ([.[] | select(.path | test("^buildkite-gha/v1/artifacts/[0-9a-f]{64}\\.zip$"))] | length) == 1 and
+  ([.[] | select(.path | test("^buildkite-gha/v1/results/" + $step_key + "/[0-9a-f]{64}\\.json$"))] | length) == 1
+' <<<"$producer_artifacts" >/dev/null; then
+  echo "producer $producer_job does not have exactly one native archive and one terminal manifest" >&2
+  exit 1
+fi
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/buildkite-gha-phase6-roundtrip-verify.XXXXXXXX")"
+trap 'rm -rf -- "$work"' EXIT
+
+download_job_artifacts() {
+  local job=$1
+  local artifacts=$2
+  local id
+  while IFS= read -r id; do
+    (
+      cd "$work"
+      bk --no-pager artifacts download "$id" --build "$build_number" --job-uuid "$job" --pipeline "$pipeline"
+    )
+  done < <(jq -r '.[].id' <<<"$artifacts")
+}
+
+download_job_artifacts "$producer_job" "$producer_artifacts"
+archive_path="$(jq -r '.[] | select(.path | test("^buildkite-gha/v1/artifacts/")) | .path' <<<"$producer_artifacts")"
+producer_manifest_path="$(jq -r '.[] | select(.path | test("^buildkite-gha/v1/results/")) | .path' <<<"$producer_artifacts")"
+readonly archive_path producer_manifest_path
+readonly archive_file="$work/$archive_path"
+readonly producer_manifest="$work/$producer_manifest_path"
+
+archive_size="$(wc -c < "$archive_file" | tr -d ' ')"
+archive_digest="sha256:$(sha256sum "$archive_file" | cut -d ' ' -f 1)"
+readonly archive_size archive_digest
+producer_plan_digest="sha256:${producer_manifest_path##*/}"
+producer_plan_digest=${producer_plan_digest%.json}
+readonly producer_plan_digest
+if ! jq -e \
+  --arg build_id "$build_id" \
+  --arg job_id "$producer_job" \
+  --arg step_key "$producer_key" \
+  --arg plan_digest "$producer_plan_digest" \
+  --arg archive_path "$archive_path" \
+  --arg archive_digest "$archive_digest" \
+  --argjson archive_size "$archive_size" '
+    .schema == "buildkite-gha/result-manifest/v2" and
+    .plan_digest == $plan_digest and
+    .producer == {build_id: $build_id, job_id: $job_id, step_key: $step_key} and
+    .result == "success" and .outputs == [] and
+    (.artifacts | length) == 1 and
+    .artifacts[0].name == "smoke-payload" and
+    (.artifacts[0].id | test("^[1-9][0-9]{0,19}$")) and
+    .artifacts[0].path == $archive_path and
+    .artifacts[0].digest == $archive_digest and
+    .artifacts[0].size == $archive_size and
+    .artifacts[0].file_count == 1
+  ' "$producer_manifest" >/dev/null
+then
+  echo "producer manifest does not bind the exact native artifact" >&2
+  exit 1
+fi
+mapfile -t entries < <(unzip -Z1 "$archive_file")
+archive_payload="$(unzip -p "$archive_file" result.txt)"
+archive_payload_digest="sha256:$(unzip -p "$archive_file" result.txt | sha256sum | cut -d ' ' -f 1)"
+readonly archive_payload archive_payload_digest
+if (( ${#entries[@]} != 1 )) || [[ ${entries[0]} != result.txt ]] || [[ $archive_payload != "$expected_payload" ]]; then
+  printf 'unexpected producer archive: entries=%s\n' "${entries[*]}" >&2
+  exit 1
+fi
+
+verify_consumer() {
+  local job=$1
+  local step_key=$2
+  local variant=$3
+  local artifacts manifest_path plan_digest log
+  artifacts="$(bk --no-pager api "/jobs/$job/artifacts?per_page=100")"
+  if ! jq -e --arg job_id "$job" --arg step_key "$step_key" '
+    length == 1 and .[0].job_id == $job_id and .[0].state == "finished" and
+    (.[0].path | test("^buildkite-gha/v1/results/" + $step_key + "/[0-9a-f]{64}\\.json$"))
+  ' <<<"$artifacts" >/dev/null; then
+    echo "consumer $job does not have exactly one terminal manifest" >&2
+    return 1
+  fi
+  download_job_artifacts "$job" "$artifacts"
+  manifest_path="$(jq -r '.[0].path' <<<"$artifacts")"
+  plan_digest="sha256:${manifest_path##*/}"
+  plan_digest=${plan_digest%.json}
+  if ! jq -e \
+    --arg build_id "$build_id" \
+    --arg job_id "$job" \
+    --arg step_key "$step_key" \
+    --arg plan_digest "$plan_digest" '
+      .schema == "buildkite-gha/result-manifest/v2" and
+      .plan_digest == $plan_digest and
+      .producer == {build_id: $build_id, job_id: $job_id, step_key: $step_key} and
+      .result == "success" and .outputs == [] and .artifacts == []
+    ' "$work/$manifest_path" >/dev/null
+  then
+    echo "consumer $job terminal manifest is not exact" >&2
+    return 1
+  fi
+  log="$(bk --no-pager api "/jobs/$job/log" | jq -r '.content // ""')"
+  if ! grep -E -- "PHASE6_ARTIFACT_ROUNDTRIP=\\{\"artifact\":\"smoke-artifact:$build_number\",\"variant\":\"$variant\",\"file_digest\":\"$archive_payload_digest\",\"download_path\":\"/[^\"]*/payload\"\\}" <<<"$log" >/dev/null; then
+    echo "consumer $job log lacks the $variant content and download-path observation" >&2
+    return 1
+  fi
+}
+
+verify_consumer "$consumer_one_job" "$consumer_one_key" one
+verify_consumer "$consumer_two_job" "$consumer_two_key" two
+
+printf 'PHASE6_ARTIFACT_ROUNDTRIP_OBSERVATION={"build":%s,"commit":"%s","producer_job":"%s","consumer_jobs":["%s","%s"],"name":"smoke-payload","path":"%s","digest":"%s","size":%s,"file_count":1,"payload_digest":"%s"}\n' \
+  "$build_number" "$commit" "$producer_job" "$consumer_one_job" "$consumer_two_job" "$archive_path" "$archive_digest" "$archive_size" "$archive_payload_digest"

--- a/testdata/smoke/.github/workflows/artifact.yml
+++ b/testdata/smoke/.github/workflows/artifact.yml
@@ -7,15 +7,18 @@ on:
 permissions:
   contents: read
 
+env:
+  PHASE6_ARTIFACT_PAYLOAD: smoke-artifact:__PHASE6_ARTIFACT_NONCE__
+
 jobs:
-  producer:
+  artifact-producer:
     runs-on: ubuntu-latest
     steps:
       - name: Create payload
         shell: bash
         run: |
           mkdir -p payload
-          printf '%s\n' "smoke-artifact" > payload/result.txt
+          printf '%s\n' "$PHASE6_ARTIFACT_PAYLOAD" > payload/result.txt
 
       - name: Upload payload
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -24,18 +27,16 @@ jobs:
           path: payload/result.txt
           if-no-files-found: error
 
-  consumer:
-    needs: producer
+  artifact-consumer:
+    needs: artifact-producer
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         variant: [one, two]
     steps:
-      - name: Checkout fixture repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
       - name: Download payload
+        id: download
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: smoke-payload
@@ -44,10 +45,20 @@ jobs:
       - name: Verify artifact
         shell: bash
         env:
+          DOWNLOAD_PATH: ${{ steps.download.outputs.download-path }}
+          EXPECTED_PAYLOAD: ${{ env.PHASE6_ARTIFACT_PAYLOAD }}
           VARIANT: ${{ matrix.variant }}
         run: |
           result=$(cat payload/result.txt)
-          test "$result" = "smoke-artifact"
-          printf '{"artifact":"%s","variant":"%s"}\n' \
-            "$result" "$VARIANT" > observation.json
-          diff -u "expected/artifact-observation-$VARIANT.json" observation.json
+          result_digest="sha256:$(sha256sum payload/result.txt | cut -d ' ' -f 1)"
+          expected_digest="sha256:$(printf '%s\n' "$EXPECTED_PAYLOAD" | sha256sum | cut -d ' ' -f 1)"
+          test "$result" = "$EXPECTED_PAYLOAD"
+          test "$result_digest" = "$expected_digest"
+          [[ "$DOWNLOAD_PATH" == /*/payload ]]
+          printf '{"artifact":"%s","variant":"%s","file_digest":"%s"}\n' \
+            "$result" "$VARIANT" "$result_digest" > observation.json
+          printf '{"artifact":"%s","variant":"%s","file_digest":"%s"}\n' \
+            "$EXPECTED_PAYLOAD" "$VARIANT" "$expected_digest" > expected.json
+          diff -u expected.json observation.json
+          printf 'PHASE6_ARTIFACT_ROUNDTRIP={"artifact":"%s","variant":"%s","file_digest":"%s","download_path":"%s"}\n' \
+            "$result" "$VARIANT" "$result_digest" "$DOWNLOAD_PATH"

--- a/testdata/smoke/README.md
+++ b/testdata/smoke/README.md
@@ -31,7 +31,7 @@ Expectations have these precise meanings:
 - `runtime-pass`: runtime evidence exists outside this compile-only harness;
   local validation and deterministic compilation remain required.
 - `runtime-unsupported`: compilation is required, but a runtime dependency is
-  intentionally unsupported (currently artifact download and cache services).
+  intentionally unsupported (currently the cache service).
 - `future`: the fixture is inventoried but not yet required to compile.
 
 Run `mise run smoke:local` to strictly validate the manifest, JSON-validate
@@ -44,13 +44,15 @@ Run `mise run smoke:profile` for the opt-in networked preflight of entries marke
 the same admission policy as production upload without installing or executing
 Node. Admission does not execute action code or prove that a generic action is
 independent of GitHub-only artifact, cache, token, or OIDC services.
-The exact audited `actions/upload-artifact` commit is admitted through its
-bounded native adapter. Cache actions, artifact download/merge, and unsupported
-upload commits remain rejected; the profile leaves unknown generic service
-dependencies as an explicit warning rather than guessing from arbitrary action
-source. Runtime-pass job and service container fixtures are deliberately not
-marked for this profile: their execution is proven separately, while production
-hosted-tokenless admission continues to reject their container provenance.
+The exact audited `actions/upload-artifact` and exact-name
+`actions/download-artifact` commits are admitted through bounded native
+adapters. Cache actions, artifact merge and broad download modes, and
+unsupported commits remain rejected; the profile leaves unknown generic
+service dependencies as an explicit warning rather than guessing from
+arbitrary action source. Runtime-pass job and service container fixtures are
+deliberately not marked for this profile: their execution is proven separately,
+while production hosted-tokenless admission continues to reject their container
+provenance.
 
 `events/push.json` is deterministic and its repository SHA is intentionally
 synthetic. End-to-end runs involving checkout must bind the event to the real

--- a/testdata/smoke/manifest.json
+++ b/testdata/smoke/manifest.json
@@ -32,9 +32,9 @@
       "id": "smoke-artifact",
       "workflow": "testdata/smoke/.github/workflows/artifact.yml",
       "event": "testdata/smoke/events/push.json",
-      "expectation": "runtime-unsupported",
-      "evidence": "Compilation is covered, but GitHub artifact service emulation is deferred.",
-      "note": "Upload-artifact and download-artifact require hosted service compatibility.",
+      "expectation": "compile-pass",
+      "evidence": "The bounded native upload and exact-name download adapters have focused local coverage; hosted roundtrip observation is pending.",
+      "note": "Only pinned exact-commit, direct-needs, exact-name native artifact transfer is supported.",
       "action_preflight": "hosted-tokenless"
     },
     {


### PR DESCRIPTION
## Summary

- add an exact-commit native adapter for `actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093`
- resolve one exact literal artifact name only from digest-verified terminal manifests belonging to direct `needs` producers
- constrain native download to the manifest's exact producer job UUID and artifact path, then revalidate size, SHA-256, ZIP count/size/member safety before confined direct extraction
- reject all/pattern/ID/merge/cross-run modes, ambiguous producers, expressions, traversal, symlinks, and special-file collisions
- add a producer-to-two-consumer Phase 6 hosted proof and independent verifier; keep the smoke classification at `compile-pass` until exact-commit hosted evidence is recorded

## Compatibility boundary

The supported path is deliberately narrow: exact literal `name`, optional clean workspace-relative `path`, omitted or false `merge-multiple`, and a direct logical `needs` edge. Omitted `path` extracts into the workspace root and `download-path` remains absolute. Existing regular files may be overwritten; non-regular collisions fail closed.

The adapter still verifies the pinned upstream action source and metadata, but replaces its JavaScript lifecycle only after that immutable verification succeeds.

## Verification

- `mise exec -- go test ./internal/runtime ./internal/action/integration ./internal/transport ./internal/compiler ./internal/cli ./internal/buildkite`
- `mise run lint:shell`
- `mise run smoke:local`
- `mise run check`