### PR TITLE
Fix Phase 6 artifact roundtrip proof workflow root

### DIFF
--- a/.buildkite/phase-6-artifact-roundtrip.yml
+++ b/.buildkite/phase-6-artifact-roundtrip.yml
@@ -16,10 +16,11 @@ steps:
       scripts/phase-0-shell-oracle-checkout "$$commit"
       test -z "$$(git status --porcelain --untracked-files=all)"
       distribution_root="$$(mktemp -d "$${TMPDIR:-/tmp}/buildkite-gha-phase6-artifact-roundtrip.XXXXXXXX")"
-      trap 'rm -rf -- "$$distribution_root"' EXIT
+      proof_workflow=
+      trap 'rm -rf -- "$$distribution_root"; [[ -z "$$proof_workflow" ]] || rm -f -- "$$proof_workflow"' EXIT
       runtime_version="0.0.0-phase6.$$commit"
       CGO_ENABLED=0 mise exec -- go build -trimpath -buildvcs=false -ldflags "-X main.version=$$runtime_version" -o "$$distribution_root/buildkite-gha" ./cmd/buildkite-gha
-      proof_workflow="$$distribution_root/artifact.yml"
+      proof_workflow="$$(mktemp testdata/smoke/.github/workflows/.phase-6-artifact-roundtrip.XXXXXXXX.yml)"
       nonce="$${BUILDKITE_BUILD_NUMBER:?BUILDKITE_BUILD_NUMBER is required}"
       sed "s/__PHASE6_ARTIFACT_NONCE__/$$nonce/g" testdata/smoke/.github/workflows/artifact.yml > "$$proof_workflow"
       ! grep -q '__PHASE6_ARTIFACT_NONCE__' "$$proof_workflow"

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -1188,6 +1188,8 @@ func TestPhase6ArtifactRoundtripProofContract(t *testing.T) {
 		`automatic: false`,
 		`runtime_version="0.0.0-phase6.$$commit"`,
 		`go build -trimpath -buildvcs=false -ldflags "-X main.version=$$runtime_version"`,
+		`[[ -z "$$proof_workflow" ]] || rm -f -- "$$proof_workflow"`,
+		`proof_workflow="$$(mktemp testdata/smoke/.github/workflows/.phase-6-artifact-roundtrip.XXXXXXXX.yml)"`,
 		`nonce="$${BUILDKITE_BUILD_NUMBER:?BUILDKITE_BUILD_NUMBER is required}"`,
 		`sed "s/__PHASE6_ARTIFACT_NONCE__/$$nonce/g" testdata/smoke/.github/workflows/artifact.yml`,
 		`! grep -q '__PHASE6_ARTIFACT_NONCE__' "$$proof_workflow"`,


### PR DESCRIPTION
## Summary

The first hosted artifact-roundtrip proof failed in its importer with:

```
buildkite-gha: upload: build plan for job "artifact-producer": workflow path must identify a repository root
```

Nonce injection wrote the generated workflow under the external distribution temp directory. The compiler intentionally recognizes repository workflows only under a `.github/workflows` directory, so action-lock construction had no repository root.

This change:

- creates the generated workflow under the fixture's checked-in `.github/workflows` directory
- retains the external private directory for the built distribution
- guarantees cleanup of both temporary paths through the importer exit trap
- pins this path and cleanup behavior in the pipeline contract test

## Verification

- reproduced the importer compile locally with an injected build nonce and all three jobs
- confirmed the generated workflow is removed after the command exits
- `mise exec -- go test ./internal/buildkite`
- `mise run lint:shell`
- `mise run check`