### PR TITLE
Implement bounded actions/cache v6 service

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,14 +78,17 @@ The plugin path currently supports:
 - timeouts, `continue-on-error`, masking, summaries, warning/error annotations,
   and pre/main/post actions;
 - public, credential-free checkout of the event repository at its exact commit;
-  and
-- bounded native upload and exact-name download for the audited artifact v4 commits.
+- bounded native upload and exact-name download for the audited artifact v4
+  commits; and
+- the audited `actions/cache` v6.1.0 commit through a configured compatible
+  cache-v2 Results service.
 
 It does **not** currently support:
 
 - private repositories or private actions;
 - workflow secrets, `GITHUB_TOKEN`, GitHub-compatible OIDC, or protected queues;
-- `actions/cache`, artifact merge/all/pattern/ID modes, or cross-run downloads;
+- `actions/cache` v4/v5 or unrecognized v6 commits, artifact
+  merge/all/pattern/ID modes, or cross-run downloads;
 - runtime condition access to the `github.event` payload;
 - exhaustive validation of condition functions before execution;
 - job containers or service containers through the production plugin path;

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -22,7 +22,8 @@ There are three different compatibility claims:
 
 Compilation alone is not admission, and admission does not execute arbitrary
 action code. In particular, an otherwise valid action may depend on a GitHub
-artifact, cache, token, or OIDC service that this project does not provide.
+artifact, token, OIDC, or unrecognized cache service that this project does not
+provide.
 
 ## Support matrix
 
@@ -44,9 +45,10 @@ artifact, cache, token, or OIDC service that this project does not provide.
 | Workflow commands | Supported subset | `::add-mask`, `::stop-commands`, `::warning`, and `::error` are supported. Warnings and errors retain title/file/range metadata and publish under separate, stable job-scoped contexts without changing step or job conclusions. Each aggregate is bounded to 1 MiB and requires Buildkite Agent v3.112 or newer for publication. `::notice`, groups, command echo control, and legacy commands are not supported. |
 | `actions/upload-artifact` | Narrow support | The audited v4 commit supports bounded literal files/directories, ZIP compression levels, hidden-file selection, exact no-file behavior, and native Buildkite publication. See the explicit limits below. |
 | `actions/download-artifact` | Narrow support | The audited v4.3.0 commit supports one exact literal name from verified direct `needs`, extracting directly to a clean workspace-relative path. |
+| `actions/cache` | Narrow v6 support | Only the audited v6.1.0 commit is admitted. It runs the stock ESM cache-v2 client with job-bound Buildkite credentials and requires an operator-configured compatible Results service. Hosted runtime proof is still pending. |
 | Job and service containers | Not admitted | Implemented and runtime-proven, but still outside production `hosted-tokenless` policy. |
 | `docker://` actions | Not supported | Private images, credentials, arbitrary options, volumes, and privileged containers are also rejected. |
-| Artifact cache and broad download modes | Not supported | Cache, merge, IDs, patterns, all-artifact, cross-repository, and cross-run modes fail admission or input validation. |
+| Other cache clients and broad artifact modes | Not supported | `actions/cache` v4/v5 and unrecognized v6 commits, artifact merge, IDs, patterns, all-artifact, cross-repository, and cross-run modes fail admission or input validation. |
 | Private repositories or actions | Not supported | The preview has no private-source capability broker. |
 | Secrets and provider tokens | Not supported | Includes `GITHUB_TOKEN`, GitHub App tokens, and protected environment grants. |
 | OIDC | Not supported | GitHub-compatible and migration OIDC flows are deferred. |
@@ -152,6 +154,43 @@ ZIP. Omitted `path` means workspace root; `download-path` is absolute. Digest
 mismatch is fatal (stricter than upstream). GitHub URLs and metadata are not
 fabricated. Exact-commit Buildkite build 270 and its independent artifact
 observation prove the producer-to-two-consumer roundtrip contract.
+
+### Cache v6 uses the standard cache-v2 protocol
+
+The cache integration recognizes only
+`actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9` (v6.1.0), including
+the `restore` and `save` entry points from that same immutable source tree.
+Older majors and every other commit fail closed. Unlike the artifact actions,
+the runtime does not replace the upstream implementation: it executes the
+audited action's stock Node 24 ESM lifecycle and supplies the standard
+cache-v2 environment only to that verified action invocation.
+
+Before each pre, main, or post phase that runs, the runtime posts an empty body
+to the current job's
+`/v3/jobs/<BUILDKITE_JOB_ID>/ghac_tokens` Agent API endpoint using the ambient
+`BUILDKITE_AGENT_ACCESS_TOKEN`. The returned short-lived token is registered
+with both the local log scrubber and `buildkite-agent redactor add` before the
+action starts. A fresh token is minted for post-save rather than retaining a
+main-phase credential. The runtime exposes only `ACTIONS_CACHE_SERVICE_V2`,
+`ACTIONS_RESULTS_URL`, and `ACTIONS_RUNTIME_TOKEN` to the cache action; it does
+not forward the Agent job token, persist cache credentials into job state, or
+expose them to ordinary actions.
+
+Operators must set `BUILDKITE_GHA_CACHE_URL` to the origin-only URL of the
+compatible Results service; a non-root path is rejected because the stock
+cache-v2 client uses root-relative Twirp endpoints. The Buildkite organization
+must also have GHAC token minting enabled, and jobs must be able to reach both
+that service and the Agent API.
+The service-issued token scopes cache access to the current organization and
+pipeline, grants writes only for an authorized ref, and limits cross-repository
+pull requests to the read-only default-branch scope. Missing configuration,
+disabled minting, malformed responses, redirects, or failed redaction stop the
+cache action before its JavaScript executes.
+
+This is an implemented and admitted contract, not yet a runtime-proof claim.
+The follow-up hosted fixture must independently demonstrate a miss, post-action
+save, and later restore hit at an exact implementation commit before the smoke
+inventory can mark cache v6 `runtime-pass`.
 
 ### Failures stay explicit
 

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -1175,7 +1175,7 @@ Result: executable on Buildkite, partially provider-dependent
 
 ✓ 6 jobs and 14 static matrix instances compile
 ✓ JavaScript, composite, and Docker action capabilities are available
-✓ actions/cache@v4 uses the Buildkite cache adapter
+✓ actions/cache@v6.1.0 uses the Buildkite cache-v2 service
 ! release job calls api.github.com and will not be portable to Cursor Origin
 ✗ windows-latest is not supported by queue mapping "hosted-linux"
 ```
@@ -1325,6 +1325,17 @@ Explicitly defer from beta unless implementation evidence changes the order:
   full producer-to-two-consumer matrix roundtrip, verified terminal manifests,
   exact native archive binding, build-unique payload, and compatible output,
   so the smoke inventory records the fixture as `runtime-pass`.
+  Cache support now admits only
+  `actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9` (v6.1.0) and runs
+  that stock Node 24 ESM implementation against the standard cache-v2 protocol.
+  The runtime mints a fresh, job-bound GHAC token for each action lifecycle
+  phase, registers it with both redaction layers before execution, and exposes
+  the three cache-v2 variables only to the verified cache action. The ambient
+  Agent job token never enters action code or plan/result state. Older majors,
+  other commits, unsafe mint responses, redirects, missing service
+  configuration, and redaction failure all fail closed. The checked-in fixture
+  is `compile-pass`; a separate exact-commit hosted miss/save/restore proof is
+  still required before claiming `runtime-pass`.
 - The first work wave is integrated: the Go/CLI foundation is runnable,
   ADR 0001 records the actionlint/act reuse boundary, and ADR 0002 plus schemas
   and eight conformance cases preserve the Phase 0 signed-envelope transport
@@ -1373,8 +1384,10 @@ Explicitly defer from beta unless implementation evidence changes the order:
 - The profile is also exposed as the text/JSON workflow preflight
   `buildkite-gha validate --profile hosted-tokenless --event-path <path>
   --format text|json <workflow>`. Expected-negative fixtures preserve current
-  boundaries: cache actions, artifact merge and broad download modes, and
-  unsupported commits are denied admission or input validation. Job and service
+  boundaries: unsupported cache commits, artifact merge and broad download
+  modes, and unsupported artifact commits are denied admission or input
+  validation. The exact cache v6.1.0 fixture is admitted but intentionally
+  remains `compile-pass` until hosted service evidence exists. Job and service
   containers compile to schema-v4 plans and have hosted runtime evidence, while
   production admission rejects their container provenance.
 - A consolidated exact-commit hosted dispatcher is available with
@@ -1808,17 +1821,20 @@ Definition of done:
 
 ### Phase 6 — Core services and protected capability control plane
 
-Deliver two explicit tracks. Tokenless Buildkite-backed adapters remain local to
-the job:
+Deliver two explicit tracks. Buildkite-backed compatibility integrations use
+the narrowest available boundary:
 
-- cache restore/save;
-- artifact upload/download;
+- cache restore/save through the stock audited cache-v2 client, a compatible
+  Results service, and short-lived job-bound GHAC credentials;
+- artifact upload/download through bounded native adapters;
 - public checkout under GitHub and Cursor Origin provider adapters; and
 - step summaries and annotations.
 
 Prefer documented Buildkite storage and Agent interfaces. If an action toolkit
-requires an HTTP protocol, run a job-local compatibility endpoint or provide a
-well-defined adapter rather than proxying GitHub's private service.
+requires an HTTP protocol, use an explicitly configured compatible service or
+provide a well-defined adapter rather than proxying GitHub's private service.
+Cache credentials authorize storage access only; they are distinct from the
+provider-feature grants below.
 
 Protected provider features use the supporting control-plane service:
 
@@ -1836,14 +1852,17 @@ Protected provider features use the supporting control-plane service:
 
 Delivery slices:
 
-1. Ship tokenless cache, artifact, summary, and public-checkout adapters without
-   a service dependency.
-2. Prove Job OIDC authentication, build/job binding, GitHub provenance checks,
+1. Ship artifact, summary, and public-checkout adapters without a service
+   dependency.
+2. Run only the audited `actions/cache` v6.1.0 client against cache-v2, minting
+   short-lived credentials through the exact current Buildkite job and keeping
+   all Agent authority outside action code.
+3. Prove Job OIDC authentication, build/job binding, GitHub provenance checks,
    policy evaluation, and signed no-op grants before returning credentials.
-3. Add private checkout, private actions, and private reusable-workflow source
+4. Add private checkout, private actions, and private reusable-workflow source
    access through the narrowest practical credential or download interface.
-4. Add scoped GitHub tokens, selected secrets, and environment grants.
-5. Prefer direct Buildkite OIDC migration, then add only explicitly supported
+5. Add scoped GitHub tokens, selected secrets, and environment grants.
+6. Prefer direct Buildkite OIDC migration, then add only explicitly supported
    compatibility-issuer claims for providers that cannot consume it directly.
 
 Definition of done:
@@ -1852,8 +1871,8 @@ Definition of done:
   producer and verifies the same contents in both consumer matrix instances on
   GitHub Actions and `buildkite-gha`.
 - Common official cache and artifact actions work without a GitHub Actions run.
-- Artifact and cache keys cannot cross organization/build boundaries
-  unexpectedly.
+- Artifact identities remain build-bound; cache keys remain confined to their
+  organization, pipeline, and authorized ref scopes.
 - Cursor Origin checkout does not require a GitHub repository mirror.
 - Private checkout and actions use repository-scoped, least-privilege access
   without exposing a reusable service credential to the compiler.
@@ -1946,10 +1965,12 @@ buildkite-gha validate --profile hosted-tokenless \
 
 Admission is policy evidence, not execution evidence. The exact audited
 `actions/upload-artifact` commit and exact-name `actions/download-artifact`
-commit are admitted through bounded native adapters; cache actions, artifact
-merge and broad download modes, and unsupported commits remain rejected.
-Unknown generic action dependencies are not declared executable merely because
-the profile admits them.
+commit are admitted through bounded native adapters. The exact audited
+`actions/cache` v6.1.0 commit is admitted through the cache-v2 credential
+boundary; all other cache commits, artifact merge and broad download modes, and
+unsupported artifact commits remain rejected. Unknown generic action
+dependencies are not declared executable merely because the profile admits
+them.
 
 The manual hosted aggregate is dispatched against one exact full commit:
 
@@ -1980,7 +2001,10 @@ Start with `testdata/smoke` rather than an external workflow catalog:
   composite actions, including masking, state, summaries, post-actions, and
   environment propagation; and
 - `artifact.yml` is dormant until Phase 6, when it proves upload/download
-  compatibility and content preservation across jobs.
+  compatibility and content preservation across jobs; and
+- `testdata/phase6/.github/workflows/cache-v6.yml` preserves the exact audited
+  cache-v2 admission contract until the separate hosted roundtrip proof can
+  promote it from `compile-pass` to `runtime-pass`.
 
 The fixture owns its event input, local actions, and expected observations. All
 external actions use immutable commits. Add narrow repository-owned regression
@@ -2116,7 +2140,7 @@ compatibility may justify Buildkite additions:
   skipped;
 - richer logical sub-step/timeline presentation inside one command job;
 - targeted matrix-sibling cancellation;
-- Buildkite-backed cache APIs suitable for Actions toolkit adapters;
+- a productionized cache-v2 Results service and discoverable endpoint contract;
 - Buildkite Job OIDC claims and APIs sufficient for short-lived provider token
   brokering;
 - Origin event/context integration;
@@ -2292,17 +2316,15 @@ them in the phase that first needs the capability:
    the local `default` Docker driver and queue prerequisites; build 136 proved
    the complete container runtime. A compatibility image remains deferred until
    tool-cache differences demonstrate a concrete need.
-3. Phase 6 will choose job-local protocol adapters versus recognized built-ins
-   for cache and artifact actions.
-4. Phase 4 will set the customer-beta event and expression subset from the
+3. Phase 4 will set the customer-beta event and expression subset from the
    hosted differential corpus.
-5. Phase 6 will define Cursor Origin checkout, event, pull-request, Job OIDC,
+4. Phase 6 will define Cursor Origin checkout, event, pull-request, Job OIDC,
    and short-lived capability contracts alongside the GitHub provider adapter.
-6. The fixed Buildkite `hosted` queue's documented per-job disposable isolation
+5. The fixed Buildkite `hosted` queue's documented per-job disposable isolation
    and the Phase 5 probe are sufficient for tokenless, non-privileged Dockerfile
    actions built on the local driver. Phases 6 and 9 still own authorization and
    queue policy for protected Docker capabilities and privileged workloads.
-7. Phase 6 will define the GitHub App installation-token compatibility contract
+6. Phase 6 will define the GitHub App installation-token compatibility contract
    for `github.token` and `GITHUB_TOKEN`, including repository/permission
    narrowing and documented differences from native Actions tokens. Tokenless
    workflows remain the default until then.

--- a/internal/action/integration/integration.go
+++ b/internal/action/integration/integration.go
@@ -38,6 +38,9 @@ const (
 	// archive semantics this adapter implements.
 	UploadArtifactCommit   = "ea165f8d65b6e75b540449e92b4886f43607fa02"
 	DownloadArtifactCommit = "d3f86a106a0bac45b974a628896c90dbdf5c8093"
+	// CacheCommit is the only actions/cache implementation admitted to the
+	// Buildkite-backed cache-v2 service.
+	CacheCommit = "55cc8345863c7cc4c66a329aec7e433d2d1c52a9"
 
 	MaxUploadArtifactNameBytes = 255
 	MaxUploadArtifactRoots     = 32
@@ -81,6 +84,14 @@ func ValidateUploadArtifactCommit(commit string) error {
 func ValidateDownloadArtifactCommit(commit string) error {
 	if commit != DownloadArtifactCommit {
 		return fmt.Errorf("actions/download-artifact native adapter supports only commit %s, resolved %q; Phase 6 is required", DownloadArtifactCommit, commit)
+	}
+	return nil
+}
+
+// ValidateCacheCommit rejects cache client and protocol drift from v6.1.0.
+func ValidateCacheCommit(commit string) error {
+	if commit != CacheCommit {
+		return fmt.Errorf("buildkite cache-v2 service supports only actions/cache v6.1.0 commit %s, resolved %q", CacheCommit, commit)
 	}
 	return nil
 }

--- a/internal/action/integration/integration_test.go
+++ b/internal/action/integration/integration_test.go
@@ -66,6 +66,15 @@ func TestUploadArtifactCommitIsExact(t *testing.T) {
 	}
 }
 
+func TestCacheCommitIsExactV6(t *testing.T) {
+	if err := ValidateCacheCommit(CacheCommit); err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateCacheCommit(strings.Repeat("0", 40)); err == nil || !strings.Contains(err.Error(), "v6.1.0") {
+		t.Fatalf("unrecognized cache commit error = %v", err)
+	}
+}
+
 func TestValidateUploadArtifactInputs(t *testing.T) {
 	for _, inputs := range []map[string]string{
 		{"path": "payload/result.txt"},

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -209,6 +209,24 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 		}
 		actionMaterializer = store
 	}
+	var cacheCredentials gharuntime.CacheCredentialProvider
+	cacheRequired, err := cacheServiceRequired(job.Actions)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: %v\n", err)
+		return 1
+	}
+	if cacheRequired {
+		cacheCredentials, err = gharuntime.NewAgentCacheCredentials(gharuntime.AgentCacheConfig{
+			Endpoint:   os.Getenv("BUILDKITE_AGENT_ENDPOINT"),
+			JobID:      os.Getenv("BUILDKITE_JOB_ID"),
+			JobToken:   os.Getenv("BUILDKITE_AGENT_ACCESS_TOKEN"),
+			ResultsURL: os.Getenv("BUILDKITE_GHA_CACHE_URL"),
+		})
+		if err != nil {
+			_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: configure actions/cache v6 service: %v\n", err)
+			return 1
+		}
+	}
 	runner := gharuntime.Runner{
 		Stdout:      stdout,
 		Stderr:      stderr,
@@ -219,6 +237,7 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 		Redactor:    gharuntime.AgentRedactor{Executable: os.Getenv("BUILDKITE_GHA_AGENT")},
 		Actions:     actionMaterializer,
 		Artifacts:   agent,
+		Cache:       cacheCredentials,
 	}
 	runner.RuntimeExecutable, err = os.Executable()
 	if err != nil {
@@ -299,6 +318,20 @@ func hasGitHubActionLocks(locks []plan.ActionLock) bool {
 		}
 	}
 	return false
+}
+
+func cacheServiceRequired(locks []plan.ActionLock) (bool, error) {
+	required := false
+	for _, lock := range locks {
+		descriptor, _ := actionintegration.Lookup(actionintegration.Identity{Source: lock.Source, Repository: lock.Repository, Path: lock.Path})
+		if descriptor.Service == actionintegration.ServiceCache {
+			required = true
+			if err := actionintegration.ValidateCacheCommit(lock.Commit); err != nil {
+				return false, fmt.Errorf("unsupported cache action: %w", err)
+			}
+		}
+	}
+	return required, nil
 }
 
 func resultProducer(job plan.Job, planDigest string) (transport.Producer, bool, error) {
@@ -730,6 +763,12 @@ func validateUnprivilegedBundle(bundle compiler.Bundle) error {
 		}
 		for _, action := range artifact.Job.Actions {
 			descriptor, _ := actionintegration.Lookup(actionintegration.Identity{Source: action.Source, Repository: action.Repository, Path: action.Path})
+			if descriptor.Service == actionintegration.ServiceCache {
+				if err := actionintegration.ValidateCacheCommit(action.Commit); err != nil {
+					return fmt.Errorf("job %q uses unsupported cache action: %w", artifact.Job.Workflow.LogicalJobID, err)
+				}
+				continue
+			}
 			if descriptor.Service != "" {
 				return fmt.Errorf("job %q uses action %q, which requires the unavailable GitHub Actions %s service; Phase 6 is required", artifact.Job.Workflow.LogicalJobID, action.Repository, descriptor.Service)
 			}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -685,9 +685,6 @@ func TestUnprivilegedUploadRejectsKnownGitHubServiceActions(t *testing.T) {
 		service string
 	}{
 		{plan.ActionLock{Source: "github", Repository: "actions/upload-artifact", Path: "merge"}, "artifact"},
-		{plan.ActionLock{Source: "github", Repository: "actions/cache"}, "cache"},
-		{plan.ActionLock{Source: "github", Repository: "actions/cache", Path: "restore"}, "cache"},
-		{plan.ActionLock{Source: "github", Repository: "actions/cache", Path: "save"}, "cache"},
 	}
 	for _, test := range tests {
 		name := test.action.Repository
@@ -704,6 +701,49 @@ func TestUnprivilegedUploadRejectsKnownGitHubServiceActions(t *testing.T) {
 				t.Fatalf("validateUnprivilegedBundle(%#v) error = %v", test.action, err)
 			}
 		})
+	}
+}
+
+func TestUnprivilegedUploadAllowsOnlyAuditedCacheV6Commit(t *testing.T) {
+	for _, path := range []string{"", "restore", "save"} {
+		action := plan.ActionLock{Source: "github", Repository: "actions/cache", Path: path, Commit: actionintegration.CacheCommit}
+		bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: plan.Job{
+			Workflow: plan.Workflow{LogicalJobID: "cache-v6"},
+			Actions:  []plan.ActionLock{action},
+		}}}}
+		if err := validateUnprivilegedBundle(bundle); err != nil {
+			t.Fatalf("validateUnprivilegedBundle(%#v) error = %v", action, err)
+		}
+	}
+
+	action := plan.ActionLock{Source: "github", Repository: "actions/cache", Commit: strings.Repeat("0", 40)}
+	bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: plan.Job{
+		Workflow: plan.Workflow{LogicalJobID: "cache-old"},
+		Actions:  []plan.ActionLock{action},
+	}}}}
+	if err := validateUnprivilegedBundle(bundle); err == nil || !strings.Contains(err.Error(), "v6.1.0") {
+		t.Fatalf("validateUnprivilegedBundle(%#v) error = %v", action, err)
+	}
+}
+
+func TestCacheServiceRequiredUsesOnlyAuditedCacheV6Locks(t *testing.T) {
+	required, err := cacheServiceRequired([]plan.ActionLock{{Source: "github", Repository: "owner/action", Commit: strings.Repeat("a", 40)}})
+	if err != nil || required {
+		t.Fatalf("ordinary action cache requirement = %v, %v", required, err)
+	}
+
+	locks := []plan.ActionLock{
+		{Source: "github", Repository: "owner/action", Commit: strings.Repeat("a", 40)},
+		{Source: "github", Repository: "actions/cache", Path: "restore", Commit: actionintegration.CacheCommit},
+	}
+	required, err = cacheServiceRequired(locks)
+	if err != nil || !required {
+		t.Fatalf("nested cache v6 requirement = %v, %v", required, err)
+	}
+
+	locks[1].Commit = strings.Repeat("b", 40)
+	if _, err := cacheServiceRequired(locks); err == nil || !strings.Contains(err.Error(), actionintegration.CacheCommit) {
+		t.Fatalf("unsupported cache lock error = %v", err)
 	}
 }
 

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -186,6 +186,11 @@ func (b *actionLockBuilder) describe(ctx context.Context, raw string) (string, p
 			return "", plan.ActionLock{}, "", "", err
 		}
 	}
+	if descriptor.Service == actionintegration.ServiceCache {
+		if err := actionintegration.ValidateCacheCommit(lock.Commit); err != nil {
+			return "", plan.ActionLock{}, "", "", err
+		}
+	}
 	b.caps["network"] = true
 	return key, lock, materialized.RepositoryRoot, ref.Path, nil
 }

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -178,6 +178,38 @@ func TestCompileActionLocksDeterministic(t *testing.T) {
 	}
 }
 
+func TestCompileActionLocksAllowsOnlyCacheV6Commit(t *testing.T) {
+	workspace, remote := t.TempDir(), t.TempDir()
+	for _, path := range []string{"", "restore", "save"} {
+		writeAction(t, remote, path, "name: cache v6\nruns:\n  using: node24\n  main: index.js\n")
+	}
+	for _, path := range []string{"", "restore", "save"} {
+		name := "root"
+		if path != "" {
+			name = path
+		}
+		t.Run(name, func(t *testing.T) {
+			uses := "actions/cache"
+			if path != "" {
+				uses += "/" + path
+			}
+			uses += "@" + actionintegration.CacheCommit
+			_, locks, capabilities, err := compileActionLocks(context.Background(), workspace, &fakeActionSource{root: remote, calls: map[string]int{}}, []string{uses})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(locks) != 1 || locks[0].Commit != actionintegration.CacheCommit || !reflect.DeepEqual(capabilities, []string{"network"}) {
+				t.Fatalf("cache v6 locks/capabilities = %#v / %#v", locks, capabilities)
+			}
+		})
+	}
+
+	_, _, _, err := compileActionLocks(context.Background(), workspace, &fakeActionSource{root: remote, calls: map[string]int{}}, []string{"actions/cache@" + strings.Repeat("b", 40)})
+	if err == nil || !strings.Contains(err.Error(), actionintegration.CacheCommit) || !strings.Contains(err.Error(), "v6.1.0") {
+		t.Fatalf("unsupported actions/cache commit error = %v", err)
+	}
+}
+
 func TestPublicActionSourceNil(t *testing.T) {
 	_, _, err := (PublicActionSource{}).Fetch(context.Background(), source.Reference{})
 	if err == nil {

--- a/internal/compiler/smoke_manifest_test.go
+++ b/internal/compiler/smoke_manifest_test.go
@@ -45,7 +45,7 @@ func TestSmokeManifestInventory(t *testing.T) {
 		t.Fatalf("schema = %q", manifest.Schema)
 	}
 
-	wantOrder := []string{"smoke-shell", "smoke-concurrent", "smoke-ci", "smoke-artifact", "phase4-public-actions", "phase5-docker-action", "phase5-container-runtime", "phase6-summary-annotation", "phase6-workflow-command-annotations", "phase6-upload-artifact", "unsupported-cache-service", "unsupported-job-container", "unsupported-service-container"}
+	wantOrder := []string{"smoke-shell", "smoke-concurrent", "smoke-ci", "smoke-artifact", "phase4-public-actions", "phase5-docker-action", "phase5-container-runtime", "phase6-summary-annotation", "phase6-workflow-command-annotations", "phase6-upload-artifact", "phase6-cache-v6", "unsupported-job-container", "unsupported-service-container"}
 	if len(manifest.Fixtures) != len(wantOrder) {
 		t.Fatalf("fixtures = %d, want %d", len(manifest.Fixtures), len(wantOrder))
 	}

--- a/internal/runtime/actions.go
+++ b/internal/runtime/actions.go
@@ -70,6 +70,11 @@ func usesDownloadArtifactAdapter(lock plan.ActionLock) bool {
 	return descriptor.Adapter == actionintegration.AdapterDownloadArtifactBuildkite
 }
 
+func usesCacheService(lock plan.ActionLock) bool {
+	descriptor, _ := actionintegration.Lookup(actionintegration.Identity{Source: lock.Source, Repository: lock.Repository, Path: lock.Path})
+	return descriptor.Service == actionintegration.ServiceCache
+}
+
 func (r *actionLockResolver) source(selector plan.ActionSelector) (string, error) {
 	if r == nil || selector.Lock == "" {
 		return "", fmt.Errorf("resolve action lock: selector is missing")
@@ -102,6 +107,11 @@ func (r *actionLockResolver) resolve(ctx context.Context, selector plan.ActionSe
 	}
 	if usesDownloadArtifactAdapter(entry.lock) {
 		if err := actionintegration.ValidateDownloadArtifactCommit(entry.lock.Commit); err != nil {
+			return metadata.Metadata{}, plan.ActionLock{}, err
+		}
+	}
+	if usesCacheService(entry.lock) {
+		if err := actionintegration.ValidateCacheCommit(entry.lock.Commit); err != nil {
 			return metadata.Metadata{}, plan.ActionLock{}, err
 		}
 	}

--- a/internal/runtime/cache_service.go
+++ b/internal/runtime/cache_service.go
@@ -1,0 +1,203 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const cacheCredentialResponseLimit = 64 << 10
+
+var cacheRuntimeTokenPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$`)
+
+// CacheCredentials are the short-lived values exposed only to one verified
+// actions/cache lifecycle phase.
+type CacheCredentials struct {
+	ResultsURL string
+	Token      string
+}
+
+// CacheCredentialProvider mints one action-scoped cache credential at a time.
+type CacheCredentialProvider interface {
+	Credentials(context.Context) (CacheCredentials, error)
+}
+
+// AgentCacheConfig identifies the exact current Buildkite job and cache-v2
+// service. Endpoint and JobToken are runtime authority and are never forwarded
+// to action code.
+type AgentCacheConfig struct {
+	Endpoint   string
+	JobID      string
+	JobToken   string
+	ResultsURL string
+	Client     *http.Client
+}
+
+// AgentCacheCredentials mints GHAC tokens through Buildkite's job-bound Agent
+// API endpoint.
+type AgentCacheCredentials struct {
+	mintURL    string
+	jobToken   string
+	resultsURL string
+	client     *http.Client
+}
+
+func NewAgentCacheCredentials(config AgentCacheConfig) (*AgentCacheCredentials, error) {
+	mintURL, err := agentCacheMintURL(config.Endpoint, config.JobID)
+	if err != nil {
+		return nil, err
+	}
+	if config.JobToken == "" || strings.ContainsAny(config.JobToken, "\r\n") {
+		return nil, fmt.Errorf("cache Agent job token is required")
+	}
+	resultsURL, err := normalizeCacheResultsURL(config.ResultsURL)
+	if err != nil {
+		return nil, err
+	}
+	client := config.Client
+	if client == nil {
+		client = &http.Client{Timeout: 15 * time.Second}
+	}
+	bounded := *client
+	bounded.Jar = nil
+	bounded.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	if bounded.Timeout == 0 {
+		bounded.Timeout = 15 * time.Second
+	}
+	return &AgentCacheCredentials{mintURL: mintURL, jobToken: config.JobToken, resultsURL: resultsURL, client: &bounded}, nil
+}
+
+func (c *AgentCacheCredentials) Credentials(ctx context.Context) (CacheCredentials, error) {
+	if c == nil {
+		return CacheCredentials{}, fmt.Errorf("cache credentials are not configured")
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, c.mintURL, http.NoBody)
+	if err != nil {
+		return CacheCredentials{}, fmt.Errorf("create cache credential request: %w", err)
+	}
+	request.Header.Set("Authorization", "Token "+c.jobToken)
+	request.Header.Set("Accept", "application/json")
+	response, err := c.client.Do(request)
+	if err != nil {
+		return CacheCredentials{}, fmt.Errorf("request cache credential: %w", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, cacheCredentialResponseLimit))
+		return CacheCredentials{}, cacheCredentialStatusError(response.StatusCode)
+	}
+	payload, err := io.ReadAll(io.LimitReader(response.Body, cacheCredentialResponseLimit+1))
+	if err != nil {
+		return CacheCredentials{}, fmt.Errorf("read cache credential response: %w", err)
+	}
+	if len(payload) > cacheCredentialResponseLimit {
+		return CacheCredentials{}, fmt.Errorf("cache credential response exceeds the %d-byte limit", cacheCredentialResponseLimit)
+	}
+	decoder := json.NewDecoder(strings.NewReader(string(payload)))
+	decoder.DisallowUnknownFields()
+	var body struct {
+		Token string `json:"token"`
+	}
+	if err := decoder.Decode(&body); err != nil {
+		return CacheCredentials{}, fmt.Errorf("decode cache credential response: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return CacheCredentials{}, fmt.Errorf("cache credential response has trailing data")
+	}
+	if len(body.Token) > 16<<10 || !cacheRuntimeTokenPattern.MatchString(body.Token) {
+		return CacheCredentials{}, fmt.Errorf("cache credential response contains an invalid token")
+	}
+	return CacheCredentials{ResultsURL: c.resultsURL, Token: body.Token}, nil
+}
+
+func agentCacheMintURL(endpoint, jobID string) (string, error) {
+	if !validBuildkiteJobID(jobID) {
+		return "", fmt.Errorf("cache Agent job ID is required")
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil || u.Scheme != "http" && u.Scheme != "https" || u.Host == "" || u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+		return "", fmt.Errorf("safe cache Agent endpoint is required")
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + "/jobs/" + jobID + "/ghac_tokens"
+	u.RawPath = ""
+	return u.String(), nil
+}
+
+func normalizeCacheResultsURL(value string) (string, error) {
+	u, err := url.Parse(value)
+	if err != nil || u.Scheme != "http" && u.Scheme != "https" || u.Host == "" || u.User != nil || u.RawQuery != "" || u.Fragment != "" || u.Path != "" && u.Path != "/" {
+		return "", fmt.Errorf("safe cache Results service URL is required")
+	}
+	u.Path = "/"
+	u.RawPath = ""
+	return u.String(), nil
+}
+
+func validBuildkiteJobID(value string) bool {
+	if len(value) != 36 {
+		return false
+	}
+	for index, character := range []byte(value) {
+		if index == 8 || index == 13 || index == 18 || index == 23 {
+			if character != '-' {
+				return false
+			}
+			continue
+		}
+		if character < '0' || character > '9' && character < 'a' || character > 'f' {
+			return false
+		}
+	}
+	return true
+}
+
+func cacheCredentialStatusError(status int) error {
+	switch status {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return fmt.Errorf("cache credential request was denied")
+	case http.StatusNotFound:
+		return fmt.Errorf("cache credential service is not enabled for this organization")
+	case http.StatusUnprocessableEntity:
+		return fmt.Errorf("cache credential request rejected the current build provenance")
+	case http.StatusTooManyRequests:
+		return fmt.Errorf("cache credential service is rate limited")
+	default:
+		return fmt.Errorf("cache credential service returned HTTP %d", status)
+	}
+}
+
+func (r Runner) cacheActionEnvironment(ctx context.Context, processor *commandProcessor) (map[string]string, error) {
+	if r.Cache == nil {
+		return nil, fmt.Errorf("cache credential provider is not configured")
+	}
+	credentials, err := r.Cache.Credentials(ctx)
+	if err != nil {
+		return nil, err
+	}
+	resultsURL, err := normalizeCacheResultsURL(credentials.ResultsURL)
+	if err != nil {
+		return nil, err
+	}
+	if len(credentials.Token) > 16<<10 || !cacheRuntimeTokenPattern.MatchString(credentials.Token) {
+		return nil, fmt.Errorf("cache credential provider returned an invalid token")
+	}
+	if r.Redactor == nil {
+		return nil, fmt.Errorf("cache credential provider requires a redactor")
+	}
+	processor.addMask(credentials.Token)
+	if err := r.Redactor.AddRedaction(ctx, credentials.Token); err != nil {
+		return nil, processor.scrubError(err)
+	}
+	return map[string]string{
+		"ACTIONS_CACHE_SERVICE_V2": "true",
+		"ACTIONS_RESULTS_URL":      resultsURL,
+		"ACTIONS_RUNTIME_TOKEN":    credentials.Token,
+	}, nil
+}

--- a/internal/runtime/cache_service_test.go
+++ b/internal/runtime/cache_service_test.go
@@ -1,0 +1,295 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	actionintegration "github.com/buildkite/buildkite-gha/internal/action/integration"
+	"github.com/buildkite/buildkite-gha/internal/action/source"
+	"github.com/buildkite/buildkite-gha/internal/plan"
+)
+
+const testCacheJobID = "11111111-1111-4111-8111-111111111111"
+
+type cacheCredentialProviderFunc func(context.Context) (CacheCredentials, error)
+
+func (f cacheCredentialProviderFunc) Credentials(ctx context.Context) (CacheCredentials, error) {
+	return f(ctx)
+}
+
+func TestAgentCacheCredentialsMintsBoundedJobCredential(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Error(err)
+		}
+		if r.Method != http.MethodPost || r.URL.EscapedPath() != "/v3/jobs/"+testCacheJobID+"/ghac_tokens" || r.URL.RawQuery != "" {
+			t.Errorf("request = %s %s", r.Method, r.URL.String())
+		}
+		if r.Header.Get("Authorization") != "Token job-secret" || r.Header.Get("Accept") != "application/json" || len(body) != 0 {
+			t.Errorf("request headers/body = %#v / %q", r.Header, body)
+		}
+		_, _ = io.WriteString(w, `{"token":"header.payload.signature"}`)
+	}))
+	defer server.Close()
+
+	provider, err := NewAgentCacheCredentials(AgentCacheConfig{
+		Endpoint: server.URL + "/v3/",
+		JobID:    testCacheJobID, JobToken: "job-secret",
+		ResultsURL: server.URL,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	credentials, err := provider.Credentials(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 || credentials.Token != "header.payload.signature" || credentials.ResultsURL != server.URL+"/" {
+		t.Fatalf("calls/credentials = %d / %#v", calls, credentials)
+	}
+}
+
+func TestAgentCacheCredentialsRejectsUnsafeConfiguration(t *testing.T) {
+	valid := AgentCacheConfig{
+		Endpoint: "https://agent.example/v3", JobID: testCacheJobID,
+		JobToken: "job-token", ResultsURL: "https://cache.example",
+	}
+	for name, mutate := range map[string]func(*AgentCacheConfig){
+		"missing endpoint":       func(c *AgentCacheConfig) { c.Endpoint = "" },
+		"endpoint credentials":   func(c *AgentCacheConfig) { c.Endpoint = "https://user@agent.example/v3" },
+		"endpoint query":         func(c *AgentCacheConfig) { c.Endpoint += "?redirect=other" },
+		"invalid job ID":         func(c *AgentCacheConfig) { c.JobID = "../other" },
+		"missing job token":      func(c *AgentCacheConfig) { c.JobToken = "" },
+		"job token header split": func(c *AgentCacheConfig) { c.JobToken = "secret\r\nOther: value" },
+		"missing results URL":    func(c *AgentCacheConfig) { c.ResultsURL = "" },
+		"results credentials":    func(c *AgentCacheConfig) { c.ResultsURL = "https://user@cache.example/v2" },
+		"results path":           func(c *AgentCacheConfig) { c.ResultsURL += "/v2" },
+		"results query":          func(c *AgentCacheConfig) { c.ResultsURL += "?token=value" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := valid
+			mutate(&config)
+			if _, err := NewAgentCacheCredentials(config); err == nil {
+				t.Fatalf("NewAgentCacheCredentials(%#v) succeeded", config)
+			}
+		})
+	}
+}
+
+func TestAgentCacheCredentialsRejectsRedirectsAndUntrustedResponses(t *testing.T) {
+	secret := "must.not.leak"
+	for _, test := range []struct {
+		name   string
+		status int
+		body   string
+		want   string
+	}{
+		{"denied", http.StatusForbidden, secret, "denied"},
+		{"disabled", http.StatusNotFound, secret, "not enabled"},
+		{"invalid provenance", http.StatusUnprocessableEntity, secret, "provenance"},
+		{"rate limited", http.StatusTooManyRequests, secret, "rate limited"},
+		{"unexpected status", http.StatusBadGateway, secret, "HTTP 502"},
+		{"malformed JSON", http.StatusOK, `{"token":`, "decode"},
+		{"unknown field", http.StatusOK, `{"token":"a.b.c","other":true}`, "unknown field"},
+		{"trailing JSON", http.StatusOK, `{"token":"a.b.c"}{}`, "trailing data"},
+		{"invalid token", http.StatusOK, `{"token":"not-a-jwt"}`, "invalid token"},
+		{"oversized", http.StatusOK, `{"token":"a.b.c"}` + strings.Repeat(" ", cacheCredentialResponseLimit), "exceeds"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(test.status)
+				_, _ = io.WriteString(w, test.body)
+			}))
+			defer server.Close()
+			provider, err := NewAgentCacheCredentials(AgentCacheConfig{
+				Endpoint: server.URL, JobID: testCacheJobID, JobToken: "job-token", ResultsURL: server.URL,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = provider.Credentials(context.Background())
+			if err == nil || !strings.Contains(err.Error(), test.want) || strings.Contains(err.Error(), secret) {
+				t.Fatalf("Credentials() error = %v, want %q without response body", err, test.want)
+			}
+		})
+	}
+
+	var redirected bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/elsewhere" {
+			redirected = true
+			_, _ = io.WriteString(w, `{"token":"a.b.c"}`)
+			return
+		}
+		http.Redirect(w, r, "/elsewhere", http.StatusTemporaryRedirect)
+	}))
+	defer server.Close()
+	provider, err := NewAgentCacheCredentials(AgentCacheConfig{
+		Endpoint: server.URL, JobID: testCacheJobID, JobToken: "job-token", ResultsURL: server.URL,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := provider.Credentials(context.Background()); err == nil || !strings.Contains(err.Error(), "HTTP 307") || redirected {
+		t.Fatalf("redirect Credentials() error/redirected = %v / %v", err, redirected)
+	}
+}
+
+func TestAgentCacheCredentialsHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	provider, err := NewAgentCacheCredentials(AgentCacheConfig{
+		Endpoint: "https://agent.invalid/v3", JobID: testCacheJobID,
+		JobToken: "job-token", ResultsURL: "https://cache.example",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := provider.Credentials(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Credentials() error = %v, want cancellation", err)
+	}
+}
+
+type sequenceCacheCredentials struct {
+	mu     sync.Mutex
+	tokens []string
+	calls  int
+}
+
+func (p *sequenceCacheCredentials) Credentials(context.Context) (CacheCredentials, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.calls >= len(p.tokens) {
+		return CacheCredentials{}, fmt.Errorf("unexpected cache credential request")
+	}
+	token := p.tokens[p.calls]
+	p.calls++
+	return CacheCredentials{ResultsURL: "https://cache.example", Token: token}, nil
+}
+
+func TestCacheV6LifecycleUsesFreshIsolatedCredentials(t *testing.T) {
+	node := requireNode24(t)
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/cache.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: cache lifecycle\n")
+	remote := t.TempDir()
+	writeFixtureFile(t, remote, "package.json", `{"type":"module"}`)
+	writeFixtureFile(t, remote, "action.yml", "name: cache v6\nruns:\n  using: node24\n  pre: pre.js\n  main: main.js\n  post: post.js\n")
+	for _, phase := range []string{"pre", "main", "post"} {
+		program := fmt.Sprintf(`import fs from "node:fs";
+const required = ["ACTIONS_CACHE_SERVICE_V2", "ACTIONS_RESULTS_URL", "ACTIONS_RUNTIME_TOKEN"];
+for (const name of required) if (!process.env[name]) throw new Error("missing " + name);
+if (process.env.BUILDKITE_AGENT_ACCESS_TOKEN) throw new Error("job credential leaked");
+if (process.env.ACTIONS_CACHE_URL) throw new Error("legacy cache URL leaked");
+fs.appendFileSync(process.env.LIFECYCLE_LOG, "%s|" + process.env.ACTIONS_RUNTIME_TOKEN + "|" + process.env.ACTIONS_RESULTS_URL + "|" + process.env.ACTIONS_CACHE_SERVICE_V2 + "\n");
+console.log("credential=" + process.env.ACTIONS_RUNTIME_TOKEN);
+`, phase)
+		writeFixtureFile(t, remote, phase+".js", program)
+	}
+	writeFixtureFile(t, remote, "ordinary/action.yml", "name: ordinary\nruns:\n  using: node24\n  main: index.js\n")
+	writeFixtureFile(t, remote, "ordinary/index.js", `import fs from "node:fs";
+for (const name of ["ACTIONS_CACHE_SERVICE_V2", "ACTIONS_RESULTS_URL", "ACTIONS_RUNTIME_TOKEN", "BUILDKITE_AGENT_ACCESS_TOKEN"])
+  if (process.env[name]) throw new Error(name + " leaked");
+fs.appendFileSync(process.env.LIFECYCLE_LOG, "ordinary\n");
+`)
+	digest, err := source.DigestTree(remote)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cacheID, ordinaryID := remoteLifecycleLockID(1), remoteLifecycleLockID(2)
+	lifecycle := filepath.Join(workspace, "lifecycle.log")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{
+		{ID: "ordinary", Kind: "uses", Uses: "owner/repo/ordinary@v1", Action: &plan.ActionSelector{Lock: ordinaryID}},
+		{ID: "cache", Kind: "uses", Uses: "actions/cache@" + actionintegration.CacheCommit, Action: &plan.ActionSelector{Lock: cacheID}},
+	})
+	job.Schema = plan.SchemaV3
+	job.RequiredCapabilities = []string{"network"}
+	job.Env = map[string]string{"LIFECYCLE_LOG": lifecycle}
+	job.Actions = []plan.ActionLock{
+		{ID: cacheID, Source: "github", Repository: "actions/cache", RequestedRef: actionintegration.CacheCommit, Commit: actionintegration.CacheCommit, SourceDigest: digest},
+		{ID: ordinaryID, Source: "github", Repository: "owner/repo", RequestedRef: "v1", Commit: strings.Repeat("a", 40), Path: "ordinary", SourceDigest: digest},
+	}
+	provider := &sequenceCacheCredentials{tokens: []string{"header.pre.signature", "header.main.signature", "header.post.signature"}}
+	redactor := &testRedactor{}
+	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}
+	var logs bytes.Buffer
+	t.Setenv("BUILDKITE_AGENT_ACCESS_TOKEN", "job-token-must-not-leak")
+	result, err := (Runner{
+		Node24: node, Actions: materializer, Cache: provider, Redactor: redactor,
+		Stdout: &logs, Stderr: &logs,
+	}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v, logs = %q", result, err, logs.String())
+	}
+	contents, err := os.ReadFile(lifecycle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "pre|header.pre.signature|https://cache.example/|true\nordinary\nmain|header.main.signature|https://cache.example/|true\npost|header.post.signature|https://cache.example/|true\n"
+	if string(contents) != want {
+		t.Fatalf("lifecycle = %q, want %q", contents, want)
+	}
+	if provider.calls != 3 || fmt.Sprint(redactor.values) != fmt.Sprint(provider.tokens) {
+		t.Fatalf("credential calls/redactions = %d / %#v", provider.calls, redactor.values)
+	}
+	for _, token := range provider.tokens {
+		if strings.Contains(logs.String(), token) {
+			t.Fatalf("logs contain cache credential %q: %q", token, logs.String())
+		}
+	}
+	if !strings.Contains(logs.String(), "credential=***") {
+		t.Fatalf("logs do not contain masked credential: %q", logs.String())
+	}
+	for _, name := range []string{"ACTIONS_CACHE_SERVICE_V2", "ACTIONS_RESULTS_URL", "ACTIONS_RUNTIME_TOKEN", "BUILDKITE_AGENT_ACCESS_TOKEN"} {
+		if result.Env[name] != "" {
+			t.Fatalf("result environment persisted %s", name)
+		}
+	}
+
+	job.Actions[0].Commit = strings.Repeat("b", 40)
+	if _, err := (Runner{Node24: node, Actions: materializer, Cache: provider, Redactor: redactor}).RunJob(context.Background(), job, workspace); err == nil || !strings.Contains(err.Error(), actionintegration.CacheCommit) {
+		t.Fatalf("unsupported runtime cache commit error = %v", err)
+	}
+}
+
+type failingCacheRedactor struct{ token string }
+
+func (r failingCacheRedactor) AddRedaction(context.Context, string) error {
+	return fmt.Errorf("redactor rejected %s", r.token)
+}
+
+func TestCacheV6RedactorFailureAbortsBeforeExecutionAndScrubsToken(t *testing.T) {
+	token := "header.secret.signature"
+	actionRoot := t.TempDir()
+	marker := filepath.Join(actionRoot, "executed")
+	writeFixtureFile(t, actionRoot, "main.js", `require("node:fs").writeFileSync(process.env.MARKER, "executed")`)
+	provider := cacheCredentialProviderFunc(func(context.Context) (CacheCredentials, error) {
+		return CacheCredentials{ResultsURL: "https://cache.example", Token: token}, nil
+	})
+	var logs bytes.Buffer
+	processor := newCommandProcessor(&logs, &logs)
+	result := newResult()
+	result.Env["MARKER"] = marker
+	err := (Runner{Cache: provider, Redactor: failingCacheRedactor{token: token}}).runJavaScriptPhase(
+		context.Background(), processor, "node", JavaScriptAction{Name: "cache", Path: actionRoot, Main: "main.js", Cache: true}, "main.js", nil, nil, &result,
+	)
+	if err == nil || strings.Contains(err.Error(), token) || !strings.Contains(err.Error(), "***") {
+		t.Fatalf("runJavaScriptPhase() error = %v", err)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("action marker exists or stat failed unexpectedly: %v", err)
+	}
+}

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -404,7 +404,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		runErr = errors.Join(runErr, runCtx.Err())
 	}
 
-	postCtx, cancelPosts := postPhaseContext(ctx, r.postActionTimeout(), r.cleanupTimeout())
+	postCtx, cancelPosts := postPhaseContext(runCtx, r.postActionTimeout(), r.cleanupTimeout())
 	defer cancelPosts()
 	registeredPosts := posts.snapshot()
 	for i := len(registeredPosts) - 1; i >= 0; i-- {

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -404,8 +404,8 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		runErr = errors.Join(runErr, runCtx.Err())
 	}
 
-	cleanupCtx, cancel := context.WithTimeout(context.Background(), r.cleanupTimeout())
-	defer cancel()
+	postCtx, cancelPosts := postPhaseContext(ctx, r.postActionTimeout(), r.cleanupTimeout())
+	defer cancelPosts()
 	registeredPosts := posts.snapshot()
 	for i := len(registeredPosts) - 1; i >= 0; i-- {
 		post := registeredPosts[i]
@@ -424,7 +424,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		}
 		postResult := newResult()
 		postResult.Env = cloneStrings(jobResult.Env)
-		postErr := r.runJavaScriptPhase(cleanupCtx, processor, post.node, post.action, post.action.Post, post.state, post.state, &postResult)
+		postErr := r.runJavaScriptPhase(postCtx, processor, post.node, post.action, post.action.Post, post.state, post.state, &postResult)
 		mergeInto(jobResult.Env, postResult.Env)
 		mergeInto(jobResult.State, postResult.State)
 		appendJobSummary(&jobResult.Summary, &jobResult.summaryTruncated, postResult.Summary, postResult.summaryTruncated)
@@ -619,6 +619,7 @@ func standardEnvironment(job plan.Job, workspace, runnerTemp string) map[string]
 		"GITHUB_JOB":        job.Workflow.LogicalJobID,
 		"GITHUB_REF":        job.Event.Ref,
 		"GITHUB_REPOSITORY": job.Event.Repository,
+		"GITHUB_SERVER_URL": "https://github.com",
 		"GITHUB_SHA":        job.Event.SHA,
 		"GITHUB_WORKSPACE":  workspace,
 		"RUNNER_OS":         "Linux",
@@ -838,7 +839,7 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 		if runtime == metadata.RuntimeNode20 {
 			major, explicit = 20, r.Node20
 		}
-		javascript := JavaScriptAction{Name: actionName(action, step), Path: action.Path, Pre: action.Runs.Pre, Main: action.Runs.Main, Post: action.Runs.Post, nodeMajor: major}
+		javascript := JavaScriptAction{Name: actionName(action, step), Path: action.Path, Pre: action.Runs.Pre, Main: action.Runs.Main, Post: action.Runs.Post, Cache: usesCacheService(lock), nodeMajor: major}
 		invocation := &preparedInvocation{action: javascript, state: map[string]string{}}
 		prepared[invocationID] = invocation
 		if javascript.Pre != "" && runPre {
@@ -1062,7 +1063,7 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 			return result, err
 		}
 		actionEnv := mergeStepEnvironment(jobEnv, stepEnv)
-		javascript := JavaScriptAction{Name: actionName(action, step), Path: actionPath, Pre: action.Runs.Pre, Main: action.Runs.Main, Post: action.Runs.Post, Inputs: inputs, Env: actionEnv, nodeMajor: major}
+		javascript := JavaScriptAction{Name: actionName(action, step), Path: actionPath, Pre: action.Runs.Pre, Main: action.Runs.Main, Post: action.Runs.Post, Inputs: inputs, Env: actionEnv, Cache: actionLock != nil && usesCacheService(*actionLock), nodeMajor: major}
 		state := map[string]string{}
 		wasPrepared := false
 		if invocation := prepared[invocationID]; invocation != nil {
@@ -1387,6 +1388,44 @@ func (r Runner) cleanupTimeout() time.Duration {
 		return r.CleanupTimeout
 	}
 	return defaultCleanupTimeout
+}
+
+func (r Runner) postActionTimeout() time.Duration {
+	if r.PostActionTimeout > 0 {
+		return r.PostActionTimeout
+	}
+	// Preserve the existing test/operator override while separating the normal
+	// post-action budget from short resource cleanup.
+	if r.CleanupTimeout > 0 {
+		return r.CleanupTimeout
+	}
+	return defaultPostActionTimeout
+}
+
+// postPhaseContext gives JavaScript post actions one bounded shared budget.
+// Cancellation still permits the existing short cleanup grace before stopping
+// an in-flight post action.
+func postPhaseContext(parent context.Context, timeout, cancelGrace time.Duration) (context.Context, context.CancelFunc) {
+	postCtx, cancelPosts := context.WithTimeout(context.Background(), timeout)
+	postDone := make(chan struct{})
+	var once sync.Once
+	go func() {
+		select {
+		case <-parent.Done():
+			timer := time.NewTimer(cancelGrace)
+			defer timer.Stop()
+			select {
+			case <-timer.C:
+				cancelPosts()
+			case <-postDone:
+			}
+		case <-postDone:
+		}
+	}()
+	return postCtx, func() {
+		once.Do(func() { close(postDone) })
+		cancelPosts()
+	}
 }
 
 func cloneStrings(in map[string]string) map[string]string {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -28,7 +28,8 @@ import (
 )
 
 const (
-	defaultCleanupTimeout = 10 * time.Second
+	defaultCleanupTimeout    = 10 * time.Second
+	defaultPostActionTimeout = 10 * time.Minute
 	// Match actions/runner ProcessInvoker's graceful cancellation windows.
 	defaultInterruptGrace = 7500 * time.Millisecond
 	defaultTerminateGrace = 2500 * time.Millisecond
@@ -56,12 +57,14 @@ type Runner struct {
 	RuntimeExecutable string
 	Git               string
 	CleanupTimeout    time.Duration
+	PostActionTimeout time.Duration
 	InterruptGrace    time.Duration
 	TerminateGrace    time.Duration
 	Secrets           SecretResolver
 	Redactor          Redactor
 	Actions           ActionMaterializer
 	Artifacts         ArtifactStore
+	Cache             CacheCredentialProvider
 	runnerTemp        string
 	implicitJobPATH   string
 	explicitJobPATH   bool
@@ -86,6 +89,7 @@ type JavaScriptAction struct {
 	Post   string
 	Inputs map[string]string
 	Env    map[string]string
+	Cache  bool
 
 	nodeMajor int
 }
@@ -540,6 +544,14 @@ func (r Runner) runJavaScriptPhase(ctx context.Context, processor *commandProces
 	env["GITHUB_ACTION_PATH"] = action.Path
 	for name, value := range stateEnv {
 		env["STATE_"+name] = value
+	}
+	if action.Cache {
+		cacheEnv, err := r.cacheActionEnvironment(ctx, processor)
+		if err != nil {
+			return fmt.Errorf("configure actions/cache v6 service: %w", err)
+		}
+		delete(env, "ACTIONS_CACHE_URL")
+		env = mergeStringMaps(env, cacheEnv)
 	}
 	entrypoint := filepath.Join(action.Path, entry)
 	if r.jobContainer != nil {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1996,6 +1996,43 @@ func TestPostActionsUseBoundedCleanupContext(t *testing.T) {
 	}
 }
 
+func TestJobTimeoutLimitsPostActionsToCleanupGrace(t *testing.T) {
+	workspace := t.TempDir()
+	writeFixtureFile(t, workspace, ".github/workflows/test.yml", "name: runtime test\n")
+	writeFixtureFile(t, workspace, ".github/actions/slow/action.yml", "name: Job timeout post\nruns:\n  using: node24\n  main: main.js\n  post: post.js\n")
+	writeFixtureFile(t, workspace, ".github/actions/slow/main.js", "")
+	writeFixtureFile(t, workspace, ".github/actions/slow/post.js", "")
+	postStarted := filepath.Join(workspace, "post-started")
+	fakeNode := filepath.Join(workspace, "node24")
+	writeFixtureFile(t, workspace, "node24", `#!/bin/sh
+set -eu
+if [ "${1:-}" = --version ]; then echo v24.0.0; exit 0; fi
+if [ "$(basename "$1")" = post.js ]; then : > "$POST_STARTED"; fi
+sleep 30
+`)
+	if err := os.Chmod(fakeNode, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	job := runtimePlan(t, workspace, ".github/workflows/test.yml", []plan.Step{{ID: "slow", Kind: "uses", Uses: "./.github/actions/slow"}})
+	job.TimeoutMinutes = 0.001
+	job.Env = map[string]string{"POST_STARTED": postStarted}
+	runner := Runner{
+		Node24: fakeNode, CleanupTimeout: 250 * time.Millisecond, PostActionTimeout: 3 * time.Second,
+		InterruptGrace: 20 * time.Millisecond, TerminateGrace: 20 * time.Millisecond,
+	}
+	started := time.Now()
+	result, err := runner.RunJob(context.Background(), job, workspace)
+	if !errors.Is(err, context.DeadlineExceeded) || result.Conclusion != "failure" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	if _, err := os.Stat(postStarted); err != nil {
+		t.Fatalf("post action did not start during cleanup grace: %v", err)
+	}
+	if elapsed := time.Since(started); elapsed > 2*time.Second {
+		t.Fatalf("job-timeout cleanup took %s, want cleanup grace rather than 3s post budget", elapsed)
+	}
+}
+
 func TestCancellationStillRunsRegisteredPostAction(t *testing.T) {
 	node := requireNode24(t)
 	workspace := t.TempDir()

--- a/internal/runtime/secrets.go
+++ b/internal/runtime/secrets.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 // SecretResolver resolves only names declared by the verified job plan.
@@ -38,8 +39,9 @@ func (r AgentRedactor) AddRedaction(ctx context.Context, value string) error {
 	if executable == "" {
 		executable = "buildkite-agent"
 	}
-	command := exec.CommandContext(ctx, executable, "redactor", "add", value)
+	command := exec.CommandContext(ctx, executable, "redactor", "add")
 	command.Env = os.Environ()
+	command.Stdin = strings.NewReader(value)
 	if output, err := command.CombinedOutput(); err != nil {
 		return fmt.Errorf("register secret with Buildkite Agent redactor: %w: %s", err, output)
 	}

--- a/testdata/phase6/.github/workflows/cache-v6.yml
+++ b/testdata/phase6/.github/workflows/cache-v6.yml
@@ -1,4 +1,4 @@
-name: Unsupported cache service
+name: Phase 6 actions/cache v6
 
 on:
   push:
@@ -12,7 +12,7 @@ jobs:
         run: mkdir -p cache-data && echo payload > cache-data/value
 
       - name: Cache payload
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: cache-data
-          key: unsupported-cache-fixture
+          key: phase6-cache-v6-fixture

--- a/testdata/smoke/manifest.json
+++ b/testdata/smoke/manifest.json
@@ -92,12 +92,12 @@
       "action_preflight": "hosted-tokenless"
     },
     {
-      "id": "unsupported-cache-service",
-      "workflow": "testdata/unsupported/.github/workflows/cache.yml",
+      "id": "phase6-cache-v6",
+      "workflow": "testdata/phase6/.github/workflows/cache-v6.yml",
       "event": "testdata/smoke/events/push.json",
-      "expectation": "runtime-unsupported",
-      "evidence": "The production hosted-tokenless policy rejects the known GitHub Actions cache service dependency.",
-      "note": "Phase 6 owns the Buildkite cache compatibility adapter.",
+      "expectation": "compile-pass",
+      "evidence": "Compiler and runtime conformance tests admit only the audited actions/cache v6.1.0 commit and execute its ESM pre/main/post lifecycle with isolated per-phase cache-v2 credentials.",
+      "note": "Admission is not hosted runtime evidence; a separate exact-commit miss/save/restore proof remains required.",
       "action_preflight": "hosted-tokenless"
     },
     {


### PR DESCRIPTION
## Summary

- admit only `actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9` (v6.1.0), including its `restore` and `save` entry points; v4, v5, and every other commit fail closed
- run the audited stock Node 24 ESM/cache-v2 lifecycle rather than maintaining a second cache implementation
- mint a fresh job-bound GHAC token for each pre/main/post phase and inject only `ACTIONS_CACHE_SERVICE_V2`, `ACTIONS_RESULTS_URL`, and `ACTIONS_RUNTIME_TOKEN` into that verified invocation
- keep the Buildkite Agent job credential out of action code and plan/result state, and register each cache token with local and Agent redaction before execution
- add a bounded, redirect-free client for `POST /v3/jobs/:job_id/ghac_tokens`, strict response parsing, origin-only Results URL validation, and a realistic post-action budget for cache save
- promote the former unsupported cache fixture to an admitted Phase 6 v6 fixture while retaining `compile-pass` until a separate hosted miss/save/restore proof lands

## Operational contract

Cache jobs require:

- the normal `BUILDKITE_AGENT_ENDPOINT`, `BUILDKITE_JOB_ID`, and `BUILDKITE_AGENT_ACCESS_TOKEN` job environment
- `BUILDKITE_GHA_CACHE_URL` set by the operator to the origin-only URL of the compatible cache-v2 Results service
- GHAC token minting enabled for the Buildkite organization

A URL path is rejected because the stock v6 client uses root-relative Twirp endpoints and would otherwise silently discard it.

## Verification

- `mise run check`
- `mise run smoke:profile`

The networked profile resolved the exact public v6.1.0 action source and admitted the new fixture. Hosted runtime proof is intentionally deferred to the follow-up miss → post-save → restore fixture.