### PR TITLE
Add Phase 6 cache roundtrip proof

### DIFF
--- a/.buildkite/phase-6-cache-roundtrip-continuation.yml
+++ b/.buildkite/phase-6-cache-roundtrip-continuation.yml
@@ -1,0 +1,12 @@
+agents:
+  queue: "hosted"
+
+steps:
+  - label: ":white_check_mark: Phase 6 cache roundtrip settled"
+    key: "phase-6-native-after-cache-roundtrip"
+    depends_on:
+      - step: "gha-cache-producer"
+        allow_failure: true
+      - step: "gha-cache-consumer"
+        allow_failure: true
+    command: "echo 'Phase 6 cache producer and dependent consumer settled before API verification'"

--- a/.buildkite/phase-6-cache-roundtrip.yml
+++ b/.buildkite/phase-6-cache-roundtrip.yml
@@ -1,0 +1,36 @@
+agents:
+  queue: "hosted"
+
+steps:
+  - label: ":floppy_disk: Phase 6 cache roundtrip importer"
+    key: "phase-6-cache-roundtrip-importer"
+    timeout_in_minutes: 15
+    retry:
+      automatic: false
+    plugins:
+      - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
+          version: "2026.5.12"
+    command: |
+      set -euo pipefail
+      commit="$${PHASE6_COMMIT:-$${SMOKE_COMMIT:-}}"
+      scripts/phase-0-shell-oracle-checkout "$$commit"
+      test -z "$$(git status --porcelain --untracked-files=all)"
+      distribution_root="$$(mktemp -d "$${TMPDIR:-/tmp}/buildkite-gha-phase6-cache-roundtrip.XXXXXXXX")"
+      proof_workflow=
+      trap 'rm -rf -- "$$distribution_root"; [[ -z "$$proof_workflow" ]] || rm -f -- "$$proof_workflow"' EXIT
+      runtime_version="0.0.0-phase6.$$commit"
+      CGO_ENABLED=0 mise exec -- go build -trimpath -buildvcs=false -ldflags "-X main.version=$$runtime_version" -o "$$distribution_root/buildkite-gha" ./cmd/buildkite-gha
+      proof_workflow="$$(mktemp testdata/phase6/.github/workflows/.phase-6-cache-roundtrip.XXXXXXXX.yml)"
+      nonce="$${BUILDKITE_BUILD_NUMBER:?BUILDKITE_BUILD_NUMBER is required}"
+      sed "s/__PHASE6_CACHE_NONCE__/$$nonce/g" testdata/phase6/.github/workflows/cache-v6.yml > "$$proof_workflow"
+      ! grep -q '__PHASE6_CACHE_NONCE__' "$$proof_workflow"
+      "$$distribution_root/buildkite-gha" upload \
+        --event-path testdata/smoke/events/push.json \
+        --runtime-queue hosted \
+        "$$proof_workflow"
+
+  - label: ":pipeline: Phase 6 cache roundtrip continuation loader"
+    key: "phase-6-cache-roundtrip-continuation-loader"
+    depends_on: "phase-6-cache-roundtrip-importer"
+    allow_dependency_failure: true
+    command: "buildkite-agent pipeline upload .buildkite/phase-6-cache-roundtrip-continuation.yml"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -65,6 +65,11 @@ steps:
     if: build.env("PHASE6_PROBE") == "artifact-roundtrip" && build.env("SMOKE_PROBE") != "hosted"
     command: "buildkite-agent pipeline upload .buildkite/phase-6-artifact-roundtrip.yml"
 
+  - label: ":floppy_disk: Load Phase 6 cache roundtrip proof"
+    key: "phase-6-cache-roundtrip-loader"
+    if: build.env("PHASE6_PROBE") == "cache-roundtrip" && build.env("SMOKE_PROBE") != "hosted"
+    command: "buildkite-agent pipeline upload .buildkite/phase-6-cache-roundtrip.yml"
+
   - label: ":pipeline: Load consolidated hosted smoke proof"
     key: "hosted-smoke-loader"
     if: build.env("SMOKE_PROBE") == "hosted"

--- a/docs/development.md
+++ b/docs/development.md
@@ -68,9 +68,11 @@ evidence, not runtime evidence.
 
 The exact audited `actions/upload-artifact` and exact-name
 `actions/download-artifact` commits pass admission through bounded native
-adapters. Cache actions, artifact merge/broad download modes, and unsupported
-commits still fail admission. Job and service container fixtures have
-separate hosted runtime evidence but remain outside production admission.
+adapters. The exact audited `actions/cache` v6.1.0 commit also passes through
+its cache-v2 credential boundary. Other cache commits, artifact merge/broad
+download modes, and unsupported artifact commits still fail admission. Job and
+service container fixtures have separate hosted runtime evidence but remain
+outside production admission.
 
 ### Hosted runtime proofs
 
@@ -99,6 +101,7 @@ phase selector only for targeted diagnosis:
 | Workflow warning/error annotations | `PHASE6_PROBE=annotations`, `PHASE6_COMMIT=<commit>` |
 | Upload-artifact publication | `PHASE6_PROBE=upload-artifact`, `PHASE6_COMMIT=<commit>` |
 | Artifact producer/consumer roundtrip | `PHASE6_PROBE=artifact-roundtrip`, `PHASE6_COMMIT=<commit>` |
+| Cache miss/save/restore roundtrip | `PHASE6_PROBE=cache-roundtrip`, `PHASE6_COMMIT=<commit>` |
 
 Summary annotation publication is advisory, so the generated job's successful
 outcome does not by itself prove that Buildkite persisted the annotation. After
@@ -139,6 +142,32 @@ contents, and action outputs. The roundtrip verifier additionally requires the
 producer and both consumer matrix jobs to pass, checks all three terminal
 manifests, and confirms both consumers observed the exact payload and compatible
 absolute `download-path` output.
+
+The cache roundtrip is intentionally excluded from `SMOKE_PROBE=hosted` while
+job-bound GHAC token minting is feature-disabled. Once minting is enabled and
+`BUILDKITE_GHA_CACHE_URL` names the reachable cache-v2 Results origin, dispatch
+the targeted proof against an exact commit:
+
+```sh
+commit=$(git rev-parse HEAD)
+test ${#commit} -eq 40
+bk build create --pipeline buildkite/buildkite-gha \
+  --branch "$(git branch --show-current)" --commit "$commit" \
+  --env PHASE6_PROBE=cache-roundtrip --env PHASE6_COMMIT="$commit" --yes
+```
+
+The producer requires a miss for its build-unique exact key, creates the
+payload, and relies on the registered cache post action to save it. Its direct
+dependent must then restore an exact hit and verify the payload digest. After
+both generated jobs settle, independently bind those observations to the build,
+commit, job IDs, key, and digest:
+
+```sh
+scripts/phase-6-cache-roundtrip-verify <build-number> <commit>
+```
+
+Do not promote the fixture from `compile-pass` or claim hosted cache evidence
+until that command succeeds for a hosted build.
 
 The phase definitions under `.buildkite/` and the [active
 plan](plans/2026-07-22-buildkite-gha.md#current-progress) document the exact

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -1334,8 +1334,14 @@ Explicitly defer from beta unless implementation evidence changes the order:
   Agent job token never enters action code or plan/result state. Older majors,
   other commits, unsafe mint responses, redirects, missing service
   configuration, and redaction failure all fail closed. The checked-in fixture
-  is `compile-pass`; a separate exact-commit hosted miss/save/restore proof is
-  still required before claiming `runtime-pass`.
+  now forms an exact-commit targeted hosted proof: it requires a build-unique
+  exact-key miss, creates a deterministic payload, saves through the registered
+  post action, and requires a direct dependent to restore an exact hit and
+  verify the payload digest. A read-only verifier binds those observations to
+  the exact build, commit, and generated job IDs. Job-bound GHAC token minting
+  remains feature-disabled, so the proof is deliberately absent from the
+  aggregate hosted dispatcher and the fixture remains `compile-pass` with no
+  hosted runtime claim.
 - The first work wave is integrated: the Go/CLI foundation is runnable,
   ADR 0001 records the actionlint/act reuse boundary, and ADR 0002 plus schemas
   and eight conformance cases preserve the Phase 0 signed-envelope transport
@@ -1396,7 +1402,8 @@ Explicitly defer from beta unless implementation evidence changes the order:
   hosted-Docker capability, Phase 5 Dockerfile-action, and Phase 5 complete
   container-runtime proofs, plus the Phase 6 job-summary, workflow-command,
   upload-artifact, and artifact-roundtrip proofs. The dispatcher deliberately
-  uploads each existing importer and continuation
+  excludes the feature-gated cache roundtrip until GHAC token minting is
+  enabled, and uploads each included importer and continuation
   independently, then settles their generated and native terminal steps; it
   does not flatten the importer/continuation topology. Existing `PHASE2_PROBE`,
   `PHASE3_PROBE`, `PHASE4_PROBE`, all three `PHASE5_PROBE`, and `PHASE6_PROBE`
@@ -1510,6 +1517,11 @@ Phase 6 evidence:
   was `sha256:e4a73e073cfea509c8fe18aa5ddedbfbcd9342de0b4c5372e6105c6f28f1f151`;
   the payload digest was
   `sha256:33dc6db44d6acaabdf47645944927ab2ce139bb7caabe9e23a82c71621ae239c`.
+- The cache-v2 roundtrip workflow, exact-commit importer, failure-tolerant
+  settlement step, and independent verifier are checked in but have no hosted
+  evidence yet. The proof remains dormant until job-bound GHAC token minting is
+  feature-enabled; compilation or profile admission alone must not be recorded
+  as a miss/save/restore result.
 
 Phase 2 live evidence:
 
@@ -2003,8 +2015,9 @@ Start with `testdata/smoke` rather than an external workflow catalog:
 - `artifact.yml` is dormant until Phase 6, when it proves upload/download
   compatibility and content preservation across jobs; and
 - `testdata/phase6/.github/workflows/cache-v6.yml` preserves the exact audited
-  cache-v2 admission contract until the separate hosted roundtrip proof can
-  promote it from `compile-pass` to `runtime-pass`.
+  cache-v2 admission contract and the targeted build-unique miss, post-save,
+  and dependent exact-hit proof. It remains `compile-pass` until token minting
+  is enabled and the independent hosted verifier succeeds.
 
 The fixture owns its event input, local actions, and expected observations. All
 external actions use immutable commits. Add narrow repository-owned regression

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -315,8 +315,8 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 	if document.Agents.Queue != "hosted" {
 		t.Fatalf("default pipeline queue = %q, want hosted", document.Agents.Queue)
 	}
-	if len(document.Steps) != 16 {
-		t.Fatalf("default pipeline = %#v, want thirteen gated loaders, repository checks, wait, and release", document.Steps)
+	if len(document.Steps) != 17 {
+		t.Fatalf("default pipeline = %#v, want fourteen gated loaders, repository checks, wait, and release", document.Steps)
 	}
 	steps := make(map[string]struct {
 		command     string
@@ -375,6 +375,9 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 	if got := steps["phase-6-artifact-roundtrip-loader"]; got.command != "buildkite-agent pipeline upload .buildkite/phase-6-artifact-roundtrip.yml" || got.condition != `build.env("PHASE6_PROBE") == "artifact-roundtrip" && build.env("SMOKE_PROBE") != "hosted"` {
 		t.Fatalf("Phase 6 artifact roundtrip loader = %#v", got)
 	}
+	if got := steps["phase-6-cache-roundtrip-loader"]; got.command != "buildkite-agent pipeline upload .buildkite/phase-6-cache-roundtrip.yml" || got.condition != `build.env("PHASE6_PROBE") == "cache-roundtrip" && build.env("SMOKE_PROBE") != "hosted"` {
+		t.Fatalf("Phase 6 cache roundtrip loader = %#v", got)
+	}
 	hosted := steps["hosted-smoke-loader"]
 	if hosted.condition != `build.env("SMOKE_PROBE") == "hosted"` {
 		t.Fatalf("hosted smoke loader = %#v", hosted)
@@ -401,6 +404,9 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 		if count := strings.Count(hosted.command, "buildkite-agent pipeline upload .buildkite/"+fragment); count != 1 {
 			t.Fatalf("hosted smoke loader uploads %s %d times:\n%s", fragment, count, hosted.command)
 		}
+	}
+	if strings.Contains(hosted.command, "phase-6-cache-roundtrip") {
+		t.Fatalf("hosted smoke loader includes the feature-gated cache proof:\n%s", hosted.command)
 	}
 	if strings.Contains(hosted.command, "--replace") {
 		t.Fatalf("hosted smoke loader uses replacement upload:\n%s", hosted.command)
@@ -1291,6 +1297,141 @@ func TestPhase6ArtifactRoundtripProofContract(t *testing.T) {
 		if strings.Contains(verifierText, forbidden) {
 			t.Fatalf("Phase 6 artifact roundtrip verifier handles credentials directly through %q", forbidden)
 		}
+	}
+}
+
+func TestPhase6CacheRoundtripProofContract(t *testing.T) {
+	root := filepath.Join("..", "..")
+	importerBody, err := os.ReadFile(filepath.Join(root, ".buildkite", "phase-6-cache-roundtrip.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(importerBody)
+	for _, fragment := range []string{
+		`commit="$${PHASE6_COMMIT:-$${SMOKE_COMMIT:-}}"`,
+		`scripts/phase-0-shell-oracle-checkout "$$commit"`,
+		`test -z "$$(git status --porcelain --untracked-files=all)"`,
+		`automatic: false`,
+		`runtime_version="0.0.0-phase6.$$commit"`,
+		`go build -trimpath -buildvcs=false -ldflags "-X main.version=$$runtime_version"`,
+		`[[ -z "$$proof_workflow" ]] || rm -f -- "$$proof_workflow"`,
+		`proof_workflow="$$(mktemp testdata/phase6/.github/workflows/.phase-6-cache-roundtrip.XXXXXXXX.yml)"`,
+		`nonce="$${BUILDKITE_BUILD_NUMBER:?BUILDKITE_BUILD_NUMBER is required}"`,
+		`sed "s/__PHASE6_CACHE_NONCE__/$$nonce/g" testdata/phase6/.github/workflows/cache-v6.yml`,
+		`! grep -q '__PHASE6_CACHE_NONCE__' "$$proof_workflow"`,
+		`"$$distribution_root/buildkite-gha" upload`,
+		`--event-path testdata/smoke/events/push.json`,
+		`--runtime-queue hosted`,
+		`"$$proof_workflow"`,
+	} {
+		if !strings.Contains(text, fragment) {
+			t.Fatalf("Phase 6 cache roundtrip importer lacks %q:\n%s", fragment, importerBody)
+		}
+	}
+	var upload struct {
+		Steps []struct {
+			Key                    string `yaml:"key"`
+			Command                string `yaml:"command"`
+			DependsOn              string `yaml:"depends_on"`
+			AllowDependencyFailure bool   `yaml:"allow_dependency_failure"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(importerBody, &upload); err != nil {
+		t.Fatal(err)
+	}
+	if len(upload.Steps) != 2 || upload.Steps[0].Key != "phase-6-cache-roundtrip-importer" {
+		t.Fatalf("Phase 6 cache roundtrip importer = %#v", upload.Steps)
+	}
+	loader := upload.Steps[1]
+	if loader.Key != "phase-6-cache-roundtrip-continuation-loader" || loader.DependsOn != "phase-6-cache-roundtrip-importer" || !loader.AllowDependencyFailure || loader.Command != "buildkite-agent pipeline upload .buildkite/phase-6-cache-roundtrip-continuation.yml" {
+		t.Fatalf("Phase 6 cache roundtrip continuation loader = %#v", loader)
+	}
+
+	continuationBody, err := os.ReadFile(filepath.Join(root, ".buildkite", "phase-6-cache-roundtrip-continuation.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, fragment := range []string{
+		`key: "phase-6-native-after-cache-roundtrip"`,
+		`step: "gha-cache-producer"`,
+		`step: "gha-cache-consumer"`,
+		`allow_failure: true`,
+	} {
+		if !strings.Contains(string(continuationBody), fragment) {
+			t.Fatalf("Phase 6 cache roundtrip continuation lacks %q: %s", fragment, continuationBody)
+		}
+	}
+
+	fixture, err := os.ReadFile(filepath.Join(root, "testdata", "phase6", ".github", "workflows", "cache-v6.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixtureText := string(fixture)
+	for _, fragment := range []string{
+		"cache-producer:",
+		"cache-consumer:",
+		"needs: cache-producer",
+		"actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9",
+		"PHASE6_CACHE_KEY: phase6-cache-roundtrip-__PHASE6_CACHE_NONCE__",
+		`CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}`,
+		`test "$CACHE_HIT" != true`,
+		`test "$CACHE_HIT" = true`,
+		"PHASE6_CACHE_PRODUCER=",
+		"PHASE6_CACHE_CONSUMER=",
+	} {
+		if !strings.Contains(fixtureText, fragment) {
+			t.Fatalf("Phase 6 cache roundtrip fixture lacks %q: %s", fragment, fixture)
+		}
+	}
+	if count := strings.Count(fixtureText, "actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9"); count != 2 {
+		t.Fatalf("Phase 6 cache roundtrip fixture has %d audited cache action invocations, want two", count)
+	}
+	if strings.Contains(fixtureText, "restore-keys:") {
+		t.Fatal("Phase 6 cache roundtrip fixture permits a non-exact restore")
+	}
+
+	verifierPath := filepath.Join(root, "scripts", "phase-6-cache-roundtrip-verify")
+	verifier, err := os.ReadFile(verifierPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(verifierPath)
+	if err != nil || info.Mode()&0o111 == 0 {
+		t.Fatalf("Phase 6 cache roundtrip verifier is not executable: %v", err)
+	}
+	verifierText := string(verifier)
+	for _, fragment := range []string{
+		"set -euo pipefail",
+		`expected_commit=$2`,
+		`bk --no-pager api "/pipelines/$pipeline/builds/$build_number"`,
+		`producer_key=gha-cache-producer`,
+		`consumer_key=gha-cache-consumer`,
+		`$consumer_started < $producer_finished`,
+		`bk --no-pager api "/jobs/$producer_job/log"`,
+		`bk --no-pager api "/jobs/$consumer_job/log"`,
+		`expected_key="phase6-cache-roundtrip-$build_number"`,
+		`payload_digest="sha256:$(printf '%s\n' "$expected_payload" | sha256sum`,
+		`"cache_hit\":\"\"`,
+		`"cache_hit\":\"true\"`,
+		`prefix_count != 1 || $exact_count != 1`,
+		`PHASE6_CACHE_ROUNDTRIP_OBSERVATION=`,
+	} {
+		if !strings.Contains(verifierText, fragment) {
+			t.Fatalf("Phase 6 cache roundtrip verifier lacks %q", fragment)
+		}
+	}
+	for _, forbidden := range []string{"BUILDKITE_API_TOKEN", "Authorization:", "bk auth token", "ACTIONS_RUNTIME_TOKEN", "ACTIONS_RESULTS_URL"} {
+		if strings.Contains(verifierText, forbidden) {
+			t.Fatalf("Phase 6 cache roundtrip verifier handles credentials or service configuration directly through %q", forbidden)
+		}
+	}
+
+	miseBody, err := os.ReadFile(filepath.Join(root, "mise.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(miseBody), "scripts/phase-6-cache-roundtrip-verify") {
+		t.Fatal("Phase 6 cache roundtrip verifier is absent from shell lint")
 	}
 }
 

--- a/mise.toml
+++ b/mise.toml
@@ -31,7 +31,7 @@ run = "golangci-lint run"
 
 [tasks."lint:shell"]
 description = "Lint shell scripts"
-run = "shellcheck -x .buildkite/phase-0-transport-probe/probe.sh scripts/ci-buildkite-release scripts/phase-0-shell-oracle-checkout scripts/phase-0-sign-json scripts/phase-0-verify-json scripts/phase-5-hosted-docker-probe scripts/phase-5-hosted-runtime-probe scripts/phase-6-artifact-roundtrip-verify scripts/phase-6-summary-annotation-verify scripts/phase-6-upload-artifact-verify scripts/phase-6-workflow-annotations-verify scripts/release scripts/smoke-local testdata/actions/docker/entrypoint.sh testdata/phase5/runtime/.github/actions/docker/entrypoint.sh"
+run = "shellcheck -x .buildkite/phase-0-transport-probe/probe.sh scripts/ci-buildkite-release scripts/phase-0-shell-oracle-checkout scripts/phase-0-sign-json scripts/phase-0-verify-json scripts/phase-5-hosted-docker-probe scripts/phase-5-hosted-runtime-probe scripts/phase-6-artifact-roundtrip-verify scripts/phase-6-cache-roundtrip-verify scripts/phase-6-summary-annotation-verify scripts/phase-6-upload-artifact-verify scripts/phase-6-workflow-annotations-verify scripts/release scripts/smoke-local testdata/actions/docker/entrypoint.sh testdata/phase5/runtime/.github/actions/docker/entrypoint.sh"
 
 [tasks.vet]
 description = "Run go vet"

--- a/scripts/phase-6-cache-roundtrip-verify
+++ b/scripts/phase-6-cache-roundtrip-verify
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# != 2 )) || [[ ! $1 =~ ^[1-9][0-9]*$ ]] || [[ ! $2 =~ ^[0-9a-f]{40}$ ]]; then
+  echo 'usage: scripts/phase-6-cache-roundtrip-verify <build-number> <commit>' >&2
+  exit 2
+fi
+
+readonly build_number=$1
+readonly expected_commit=$2
+readonly pipeline=${PHASE6_PIPELINE_SLUG:-buildkite-gha}
+readonly producer_key=gha-cache-producer
+readonly consumer_key=gha-cache-consumer
+readonly expected_key="phase6-cache-roundtrip-$build_number"
+readonly expected_payload="phase6-cache-payload:$build_number"
+
+command -v bk >/dev/null
+command -v jq >/dev/null
+command -v sha256sum >/dev/null
+
+build="$(bk --no-pager api "/pipelines/$pipeline/builds/$build_number")"
+commit="$(jq -r '.commit // ""' <<<"$build")"
+if [[ $commit != "$expected_commit" ]]; then
+  echo "build $build_number ran commit $commit, expected $expected_commit" >&2
+  exit 1
+fi
+readonly commit
+
+job_id() {
+  local step_key=$1
+  local -a matches
+  mapfile -t matches < <(jq -r --arg step_key "$step_key" '.jobs[] | select(.step_key == $step_key) | .id' <<<"$build")
+  if (( ${#matches[@]} != 1 )) || [[ ! ${matches[0]} =~ ^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$ ]]; then
+    echo "build $build_number has ${#matches[@]} jobs with step key $step_key; expected exactly one" >&2
+    return 1
+  fi
+  if ! jq -e --arg job_id "${matches[0]}" '.jobs[] | select(.id == $job_id) | .state == "passed"' <<<"$build" >/dev/null; then
+    echo "cache roundtrip job ${matches[0]} ($step_key) did not pass" >&2
+    return 1
+  fi
+  printf '%s\n' "${matches[0]}"
+}
+
+producer_job="$(job_id "$producer_key")"
+consumer_job="$(job_id "$consumer_key")"
+readonly producer_job consumer_job
+
+producer_finished="$(jq -r --arg job_id "$producer_job" '.jobs[] | select(.id == $job_id) | .finished_at // ""' <<<"$build")"
+consumer_started="$(jq -r --arg job_id "$consumer_job" '.jobs[] | select(.id == $job_id) | .started_at // ""' <<<"$build")"
+readonly producer_finished consumer_started
+if [[ -z $producer_finished || -z $consumer_started || $consumer_started < $producer_finished ]]; then
+  echo "consumer $consumer_job did not start after producer $producer_job settled" >&2
+  exit 1
+fi
+
+producer_log="$(bk --no-pager api "/jobs/$producer_job/log" | jq -r '.content // ""')"
+consumer_log="$(bk --no-pager api "/jobs/$consumer_job/log" | jq -r '.content // ""')"
+readonly producer_log consumer_log
+payload_digest="sha256:$(printf '%s\n' "$expected_payload" | sha256sum | cut -d ' ' -f 1)"
+readonly payload_digest
+producer_prefix=PHASE6_CACHE_PRODUCER=
+consumer_prefix=PHASE6_CACHE_CONSUMER=
+expected_producer="${producer_prefix}{\"key\":\"$expected_key\",\"cache_hit\":\"\",\"payload\":\"$expected_payload\",\"payload_digest\":\"$payload_digest\",\"nonce\":\"$build_number\"}"
+expected_consumer="${consumer_prefix}{\"key\":\"$expected_key\",\"cache_hit\":\"true\",\"payload\":\"$expected_payload\",\"payload_digest\":\"$payload_digest\",\"nonce\":\"$build_number\"}"
+readonly producer_prefix consumer_prefix expected_producer expected_consumer
+
+verify_observation() {
+  local name=$1
+  local log=$2
+  local prefix=$3
+  local expected=$4
+  local prefix_count exact_count
+  prefix_count="$(grep -Fc "$prefix" <<<"$log" || true)"
+  exact_count="$(grep -Fc "$expected" <<<"$log" || true)"
+  if [[ $prefix_count != 1 || $exact_count != 1 ]]; then
+    echo "$name log has $prefix_count observations and $exact_count exact matches; expected one of each" >&2
+    return 1
+  fi
+}
+
+verify_observation producer "$producer_log" "$producer_prefix" "$expected_producer"
+verify_observation consumer "$consumer_log" "$consumer_prefix" "$expected_consumer"
+
+printf 'PHASE6_CACHE_ROUNDTRIP_OBSERVATION={"build":%s,"commit":"%s","producer_job":"%s","consumer_job":"%s","key":"%s","producer_cache_hit":"","consumer_cache_hit":"true","payload_digest":"%s"}\n' \
+  "$build_number" "$commit" "$producer_job" "$consumer_job" "$expected_key" "$payload_digest"

--- a/testdata/phase6/.github/workflows/cache-v6.yml
+++ b/testdata/phase6/.github/workflows/cache-v6.yml
@@ -3,16 +3,59 @@ name: Phase 6 actions/cache v6
 on:
   push:
 
+permissions:
+  contents: read
+
+env:
+  PHASE6_CACHE_KEY: phase6-cache-roundtrip-__PHASE6_CACHE_NONCE__
+  PHASE6_CACHE_PAYLOAD: phase6-cache-payload:__PHASE6_CACHE_NONCE__
+  PHASE6_CACHE_NONCE: __PHASE6_CACHE_NONCE__
+
 jobs:
-  cache:
+  cache-producer:
     runs-on: ubuntu-latest
     steps:
-      - name: Create cache payload
-        shell: bash
-        run: mkdir -p cache-data && echo payload > cache-data/value
-
-      - name: Cache payload
+      - name: Restore build-unique cache
+        id: cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: cache-data
-          key: phase6-cache-v6-fixture
+          key: ${{ env.PHASE6_CACHE_KEY }}
+
+      - name: Require miss and create payload
+        shell: bash
+        env:
+          CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
+        run: |
+          test "$CACHE_HIT" != true
+          test ! -e cache-data/value
+          mkdir -p cache-data
+          printf '%s\n' "$PHASE6_CACHE_PAYLOAD" > cache-data/value
+          payload_digest="sha256:$(sha256sum cache-data/value | cut -d ' ' -f 1)"
+          printf 'PHASE6_CACHE_PRODUCER={"key":"%s","cache_hit":"%s","payload":"%s","payload_digest":"%s","nonce":"%s"}\n' \
+            "$PHASE6_CACHE_KEY" "$CACHE_HIT" "$PHASE6_CACHE_PAYLOAD" "$payload_digest" "$PHASE6_CACHE_NONCE"
+
+  cache-consumer:
+    needs: cache-producer
+    runs-on: ubuntu-latest
+    steps:
+      - name: Restore producer cache
+        id: cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: cache-data
+          key: ${{ env.PHASE6_CACHE_KEY }}
+
+      - name: Require hit and verify payload
+        shell: bash
+        env:
+          CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
+        run: |
+          test "$CACHE_HIT" = true
+          payload=$(cat cache-data/value)
+          test "$payload" = "$PHASE6_CACHE_PAYLOAD"
+          payload_digest="sha256:$(sha256sum cache-data/value | cut -d ' ' -f 1)"
+          expected_digest="sha256:$(printf '%s\n' "$PHASE6_CACHE_PAYLOAD" | sha256sum | cut -d ' ' -f 1)"
+          test "$payload_digest" = "$expected_digest"
+          printf 'PHASE6_CACHE_CONSUMER={"key":"%s","cache_hit":"%s","payload":"%s","payload_digest":"%s","nonce":"%s"}\n' \
+            "$PHASE6_CACHE_KEY" "$CACHE_HIT" "$payload" "$payload_digest" "$PHASE6_CACHE_NONCE"

--- a/testdata/smoke/manifest.json
+++ b/testdata/smoke/manifest.json
@@ -96,8 +96,8 @@
       "workflow": "testdata/phase6/.github/workflows/cache-v6.yml",
       "event": "testdata/smoke/events/push.json",
       "expectation": "compile-pass",
-      "evidence": "Compiler and runtime conformance tests admit only the audited actions/cache v6.1.0 commit and execute its ESM pre/main/post lifecycle with isolated per-phase cache-v2 credentials.",
-      "note": "Admission is not hosted runtime evidence; a separate exact-commit miss/save/restore proof remains required.",
+      "evidence": "Compiler and runtime conformance tests admit only the audited actions/cache v6.1.0 commit and execute its ESM pre/main/post lifecycle with isolated per-phase cache-v2 credentials; an exact-commit hosted roundtrip harness is checked in.",
+      "note": "Admission and the dormant proof harness are not hosted runtime evidence. Keep this compile-pass until job-bound GHAC token minting is enabled and a verified miss, post-save, and dependent restore hit succeeds.",
       "action_preflight": "hosted-tokenless"
     },
     {


### PR DESCRIPTION
## Summary

- expand the exact `actions/cache` v6.1.0 fixture into a build-unique producer/consumer miss, post-save, and exact-hit roundtrip
- add an exact-commit targeted importer, failure-tolerant settlement step, and independent build/job/log verifier
- keep the proof out of the aggregate hosted suite and the fixture at `compile-pass` while job-bound GHAC token minting remains disabled
- document the eventual targeted dispatch and verification procedure

## Verification

- `mise run check`
- `mise run smoke:profile`
- `git diff --check`

No hosted runtime evidence is claimed or attempted in this PR because token minting is not enabled yet.
