### PR TITLE
test: add migration POC suite

### DIFF
--- a/.buildkite/migration-poc-continuation.yml
+++ b/.buildkite/migration-poc-continuation.yml
@@ -1,0 +1,14 @@
+agents:
+  queue: "hosted"
+
+steps:
+  - label: ":white_check_mark: Migration POC suite settled"
+    key: "migration-poc-suite-terminal"
+    depends_on:
+      - step: "gha-poc-basic"
+        allow_failure: true
+      - step: "gha-poc-artifact-consumer"
+        allow_failure: true
+      - step: "gha-poc-advanced"
+        allow_failure: true
+    command: "echo 'Basic, artifact, and advanced migration POCs settled.'"

--- a/.buildkite/migration-poc.yml
+++ b/.buildkite/migration-poc.yml
@@ -1,0 +1,41 @@
+agents:
+  queue: "hosted"
+
+steps:
+  - label: ":test_tube: Basic migration POC importer"
+    key: "migration-poc-basic-importer"
+    timeout_in_minutes: 15
+    retry:
+      automatic: false
+    plugins:
+      - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
+          version: "2026.5.12"
+    command: "scripts/migration-poc-import testdata/poc/.github/workflows/basic.yml"
+
+  - label: ":package: Artifact migration POC importer"
+    key: "migration-poc-artifact-importer"
+    timeout_in_minutes: 15
+    retry:
+      automatic: false
+    plugins:
+      - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
+          version: "2026.5.12"
+    command: "scripts/migration-poc-import testdata/poc/.github/workflows/artifacts.yml"
+
+  - label: ":rocket: Advanced migration POC importer"
+    key: "migration-poc-advanced-importer"
+    timeout_in_minutes: 15
+    retry:
+      automatic: false
+    plugins:
+      - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
+          version: "2026.5.12"
+    command: "scripts/migration-poc-import testdata/poc/.github/workflows/advanced.yml"
+
+  - label: ":pipeline: Migration POC continuation loader"
+    key: "migration-poc-continuation-loader"
+    depends_on:
+      - "migration-poc-basic-importer"
+      - "migration-poc-artifact-importer"
+      - "migration-poc-advanced-importer"
+    command: "buildkite-agent pipeline upload .buildkite/migration-poc-continuation.yml"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -70,6 +70,11 @@ steps:
     if: build.env("PHASE6_PROBE") == "cache-roundtrip" && build.env("SMOKE_PROBE") != "hosted"
     command: "buildkite-agent pipeline upload .buildkite/phase-6-cache-roundtrip.yml"
 
+  - label: ":rocket: Load migration POC suite"
+    key: "migration-poc-loader"
+    if: build.env("POC_SUITE") == "migration"
+    command: "buildkite-agent pipeline upload .buildkite/migration-poc.yml"
+
   - label: ":pipeline: Load consolidated hosted smoke proof"
     key: "hosted-smoke-loader"
     if: build.env("SMOKE_PROBE") == "hosted"

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -315,15 +315,17 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 	if document.Agents.Queue != "hosted" {
 		t.Fatalf("default pipeline queue = %q, want hosted", document.Agents.Queue)
 	}
-	if len(document.Steps) != 17 {
-		t.Fatalf("default pipeline = %#v, want fourteen gated loaders, repository checks, wait, and release", document.Steps)
-	}
 	steps := make(map[string]struct {
 		command     string
 		condition   string
 		environment map[string]string
 	}, len(document.Steps))
 	for _, step := range document.Steps {
+		if step.Key != "" {
+			if _, exists := steps[step.Key]; exists {
+				t.Fatalf("default pipeline repeats step key %q", step.Key)
+			}
+		}
 		steps[step.Key] = struct {
 			command     string
 			condition   string
@@ -335,6 +337,9 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 	}
 	if got := steps["checks"].environment["BUILDKITE_GHA_LIVE_REQUIRED"]; got != "1" {
 		t.Fatalf("repository checks BUILDKITE_GHA_LIVE_REQUIRED = %q, want required live prerequisites", got)
+	}
+	if got := steps["migration-poc-loader"]; got.command != "buildkite-agent pipeline upload .buildkite/migration-poc.yml" || got.condition != `build.env("POC_SUITE") == "migration"` {
+		t.Fatalf("migration POC loader = %#v", got)
 	}
 	if got := steps["publish-release"]; got.command != "mise exec -- scripts/ci-buildkite-release" || got.condition != "build.tag != null" {
 		t.Fatalf("release publisher = %#v", got)

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -372,6 +372,22 @@ jobs:
 	if prepare.SourcePath != "./.github/workflows/caller.yml" || finish.SourcePath != "./.github/workflows/caller.yml" {
 		t.Fatalf("caller source provenance = %q / %q", prepare.SourcePath, finish.SourcePath)
 	}
+	plans, err := CompilePlans(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-untrusted")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 4 {
+		t.Fatalf("plans = %d, want 4", len(plans))
+	}
+	secondPlan, err := plan.Encode(plans[2])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(plans[3].NeedSources, map[string][]plan.NeedSource{
+		"delegated.second": {{StepKey: second.Key, PlanDigest: transport.Digest(secondPlan)}},
+	}) {
+		t.Fatalf("downstream reusable-workflow plan needs = %#v", plans[3].NeedSources)
+	}
 }
 
 func TestCompileExpandsMatrixReusableCallsDeterministically(t *testing.T) {

--- a/internal/compiler/smoke_manifest_test.go
+++ b/internal/compiler/smoke_manifest_test.go
@@ -45,7 +45,7 @@ func TestSmokeManifestInventory(t *testing.T) {
 		t.Fatalf("schema = %q", manifest.Schema)
 	}
 
-	wantOrder := []string{"smoke-shell", "smoke-concurrent", "smoke-ci", "smoke-artifact", "phase4-public-actions", "phase5-docker-action", "phase5-container-runtime", "phase6-summary-annotation", "phase6-workflow-command-annotations", "phase6-upload-artifact", "phase6-cache-v6", "unsupported-job-container", "unsupported-service-container"}
+	wantOrder := []string{"smoke-shell", "smoke-concurrent", "smoke-ci", "smoke-artifact", "migration-poc-basic", "migration-poc-artifacts", "migration-poc-advanced", "phase4-public-actions", "phase5-docker-action", "phase5-container-runtime", "phase6-summary-annotation", "phase6-workflow-command-annotations", "phase6-upload-artifact", "phase6-cache-v6", "unsupported-job-container", "unsupported-service-container"}
 	if len(manifest.Fixtures) != len(wantOrder) {
 		t.Fatalf("fixtures = %d, want %d", len(manifest.Fixtures), len(wantOrder))
 	}
@@ -86,7 +86,7 @@ func TestSmokeManifestInventory(t *testing.T) {
 	}
 
 	var checkedIn []string
-	for _, pattern := range []string{"testdata/smoke/.github/workflows/*.yml", "testdata/phase4/.github/workflows/*.yml", "testdata/phase5/.github/workflows/*.yml.tmpl", "testdata/phase5/runtime/.github/workflows/*.yml", "testdata/phase6/.github/workflows/*.yml", "testdata/unsupported/.github/workflows/*.yml"} {
+	for _, pattern := range []string{"testdata/smoke/.github/workflows/*.yml", "testdata/poc/.github/workflows/basic.yml", "testdata/poc/.github/workflows/artifacts.yml", "testdata/poc/.github/workflows/advanced.yml", "testdata/phase4/.github/workflows/*.yml", "testdata/phase5/.github/workflows/*.yml.tmpl", "testdata/phase5/runtime/.github/workflows/*.yml", "testdata/phase6/.github/workflows/*.yml", "testdata/unsupported/.github/workflows/*.yml"} {
 		matches, err := filepath.Glob(filepath.Join(root, filepath.FromSlash(pattern)))
 		if err != nil {
 			t.Fatal(err)

--- a/internal/expression/expression.go
+++ b/internal/expression/expression.go
@@ -31,16 +31,17 @@ type Expression struct {
 
 // Context contains the Phase 0 values available while evaluating a template.
 type Context struct {
-	Inputs      map[string]string
-	Matrix      map[string]any
-	Steps       map[string]map[string]string
-	Needs       map[string]map[string]string
-	NeedResults map[string]string
-	Secrets     map[string]string
-	Vars        map[string]string
-	Env         map[string]string
-	GitHub      map[string]any
-	Services    map[string]map[string]string
+	Inputs       map[string]string
+	Matrix       map[string]any
+	Steps        map[string]map[string]string
+	StepStatuses map[string]StepStatus
+	Needs        map[string]map[string]string
+	NeedResults  map[string]string
+	Secrets      map[string]string
+	Vars         map[string]string
+	Env          map[string]string
+	GitHub       map[string]any
+	Services     map[string]map[string]string
 }
 
 // StepStatus contains the values exposed for one completed step while
@@ -722,6 +723,19 @@ func evaluateReference(reference string, context Context) (string, error) {
 			return "", fmt.Errorf("expression references unavailable step %q", path[0])
 		}
 		return findString(outputs, path[2]), nil
+	case len(path) == 2 && strings.EqualFold(root, "steps"):
+		for candidate, status := range context.StepStatuses {
+			if !strings.EqualFold(candidate, path[0]) {
+				continue
+			}
+			switch {
+			case strings.EqualFold(path[1], "outcome"):
+				return status.Outcome, nil
+			case strings.EqualFold(path[1], "conclusion"):
+				return status.Conclusion, nil
+			}
+		}
+		return "", fmt.Errorf("expression references unavailable step %q", path[0])
 	case len(path) == 3 && strings.EqualFold(root, "needs") && strings.EqualFold(path[1], "outputs"):
 		outputs, ok := findOutputs(context.Needs, path[0])
 		if !ok {

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -29,16 +29,19 @@ func TestParseUsesExpressionSyntaxFrontend(t *testing.T) {
 func TestEvaluateIsSinglePass(t *testing.T) {
 	literal := "literal ${{ matrix.secret }} and ${{"
 	context := Context{
-		Inputs:      map[string]string{"value": literal},
-		Matrix:      map[string]any{"value": literal, "secret": "reevaluated"},
-		Steps:       map[string]map[string]string{"producer": {"value": literal}},
-		Needs:       map[string]map[string]string{"producer": {"value": literal}},
-		NeedResults: map[string]string{"producer": "success"},
+		Inputs:       map[string]string{"value": literal},
+		Matrix:       map[string]any{"value": literal, "secret": "reevaluated"},
+		Steps:        map[string]map[string]string{"producer": {"value": literal}},
+		StepStatuses: map[string]StepStatus{"producer": {Outcome: "failure", Conclusion: "success"}},
+		Needs:        map[string]map[string]string{"producer": {"value": literal}},
+		NeedResults:  map[string]string{"producer": "success"},
 	}
 	tests := map[string]string{
 		"${{ inputs.value }}":                 literal,
 		"${{ matrix.value }}":                 literal,
 		"${{ steps.Producer.outputs.value }}": literal,
+		"${{ steps.Producer.outcome }}":       "failure",
+		"${{ steps.Producer.conclusion }}":    "success",
 		"${{ needs.Producer.outputs.value }}": literal,
 		"${{ needs.Producer.result }}":        "success",
 		"before ${{ inputs.value }} after":    "before " + literal + " after",
@@ -146,6 +149,7 @@ func TestEvaluateFailsClosed(t *testing.T) {
 		{name: "unavailable github value", template: "${{ github.sha }}", want: `unavailable github value "sha"`},
 		{name: "unavailable matrix value", template: "${{ matrix.missing }}", want: `unavailable matrix value "missing"`},
 		{name: "unavailable step", template: "${{ steps.missing.outputs.value }}", want: `unavailable step "missing"`},
+		{name: "unavailable step outcome", template: "${{ steps.missing.outcome }}", want: `unavailable step "missing"`},
 		{name: "unavailable need", template: "${{ needs.missing.outputs.value }}", want: `unavailable need "missing"`},
 		{name: "unavailable need result", template: "${{ needs.missing.result }}", want: `unavailable need "missing"`},
 		{name: "unterminated", template: "${{ inputs.value", want: "unterminated expression"},

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -28,6 +28,7 @@ const MaxStepTargets = 256
 
 var digestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
 var targetPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,255}$`)
+var logicalJobIDPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)*$`)
 var secretNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 var actionLockIDPattern = regexp.MustCompile(`^a-[0-9a-f]{16}$`)
 var commitPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
@@ -389,7 +390,7 @@ func (job Job) Validate() error {
 	needIDs := make(map[string]struct{}, len(job.NeedSources))
 	sourcedDependencies := make(map[string]struct{}, len(job.Dependencies))
 	for name, sources := range job.NeedSources {
-		if !targetPattern.MatchString(name) || len(sources) == 0 || len(sources) > MaxNeedProducers {
+		if len(name) > 255 || !logicalJobIDPattern.MatchString(name) || len(sources) == 0 || len(sources) > MaxNeedProducers {
 			return fmt.Errorf("job plan contains invalid prerequisite %q", name)
 		}
 		id := strings.ToLower(name)

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -162,6 +162,24 @@ func TestValidateBindsEveryDependencyToOneLogicalNeed(t *testing.T) {
 	}
 }
 
+func TestValidateAllowsNamespacedLogicalNeed(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("4", 64)
+	job := validJob()
+	job.Dependencies = []string{"gha-delegated-second"}
+	job.NeedSources = map[string][]NeedSource{
+		"delegated.second": {{StepKey: "gha-delegated-second", PlanDigest: digest}},
+	}
+	if err := job.Validate(); err != nil {
+		t.Fatal(err)
+	}
+
+	delete(job.NeedSources, "delegated.second")
+	job.NeedSources["delegated/second"] = []NeedSource{{StepKey: "gha-delegated-second", PlanDigest: digest}}
+	if err := job.Validate(); err == nil || !strings.Contains(err.Error(), "invalid prerequisite") {
+		t.Fatalf("Validate() error = %v, want invalid namespaced prerequisite rejection", err)
+	}
+}
+
 func TestPlanBoundaryRequiresConcreteCapabilities(t *testing.T) {
 	job := validJob()
 	job.RequiredCapabilities = nil

--- a/internal/runtime/concurrent.go
+++ b/internal/runtime/concurrent.go
@@ -198,7 +198,12 @@ func commitStepExecution(execution stepExecution, jobResult *JobResult, eval *ex
 	mergeInto(jobResult.State, execution.result.State)
 	appendJobSummary(&jobResult.Summary, &jobResult.summaryTruncated, execution.result.Summary, execution.result.summaryTruncated)
 	jobResult.Artifacts = append(jobResult.Artifacts, execution.result.Artifacts...)
-	statuses[id] = expression.StepStatus{Outcome: execution.outcome, Conclusion: execution.conclusion, Outputs: execution.result.Outputs}
+	status := expression.StepStatus{Outcome: execution.outcome, Conclusion: execution.conclusion, Outputs: execution.result.Outputs}
+	statuses[id] = status
+	if eval.StepStatuses == nil {
+		eval.StepStatuses = make(map[string]expression.StepStatus)
+	}
+	eval.StepStatuses[id] = status
 	if execution.conclusion != "success" {
 		return fmt.Errorf("step %q: %w", execution.step.ID, execution.err)
 	}
@@ -221,17 +226,27 @@ func commitResultEnvironment(env map[string]string, result Result) {
 
 func cloneExpressionContext(in expression.Context) expression.Context {
 	return expression.Context{
-		Inputs:      cloneStrings(in.Inputs),
-		Matrix:      cloneAnyMap(in.Matrix),
-		Steps:       cloneNestedStrings(in.Steps),
-		Needs:       cloneNestedStrings(in.Needs),
-		NeedResults: cloneStrings(in.NeedResults),
-		Secrets:     cloneStrings(in.Secrets),
-		Vars:        cloneStrings(in.Vars),
-		Env:         cloneStrings(in.Env),
-		GitHub:      cloneAnyMap(in.GitHub),
-		Services:    cloneNestedStrings(in.Services),
+		Inputs:       cloneStrings(in.Inputs),
+		Matrix:       cloneAnyMap(in.Matrix),
+		Steps:        cloneNestedStrings(in.Steps),
+		StepStatuses: cloneStepStatuses(in.StepStatuses),
+		Needs:        cloneNestedStrings(in.Needs),
+		NeedResults:  cloneStrings(in.NeedResults),
+		Secrets:      cloneStrings(in.Secrets),
+		Vars:         cloneStrings(in.Vars),
+		Env:          cloneStrings(in.Env),
+		GitHub:       cloneAnyMap(in.GitHub),
+		Services:     cloneNestedStrings(in.Services),
 	}
+}
+
+func cloneStepStatuses(in map[string]expression.StepStatus) map[string]expression.StepStatus {
+	out := make(map[string]expression.StepStatus, len(in))
+	for name, status := range in {
+		status.Outputs = cloneStrings(status.Outputs)
+		out[name] = status
+	}
+	return out
 }
 
 func cloneNestedStrings(in map[string]map[string]string) map[string]map[string]string {

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -120,12 +120,13 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 	}
 	processor := newCommandProcessor(r.stdout(), r.stderr())
 	eval := expression.Context{
-		Matrix:      job.Matrix,
-		Steps:       make(map[string]map[string]string, len(job.Steps)),
-		Needs:       needOutputs(job.Needs),
-		NeedResults: needResults(job.Needs),
-		Vars:        job.Vars,
-		GitHub:      githubContext(job),
+		Matrix:       job.Matrix,
+		Steps:        make(map[string]map[string]string, len(job.Steps)),
+		StepStatuses: make(map[string]expression.StepStatus, len(job.Steps)),
+		Needs:        needOutputs(job.Needs),
+		NeedResults:  needResults(job.Needs),
+		Vars:         job.Vars,
+		GitHub:       githubContext(job),
 	}
 	jobResult := JobResult{Conclusion: "failure", Outputs: map[string]string{}, Env: map[string]string{}, State: map[string]string{}, Artifacts: []transport.ResultArtifact{}}
 	for _, name := range sortedKeys(job.Needs) {
@@ -298,7 +299,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 	}
 	eval.Env = jobResult.Env
 	var posts postRegistry
-	statuses := make(map[string]expression.StepStatus, len(job.Steps))
+	statuses := eval.StepStatuses
 	supervisor := newBackgroundSupervisor(maxActiveBackgroundSteps)
 
 	var runErr error
@@ -1149,7 +1150,8 @@ func (r Runner) runCompositeMetadata(ctx context.Context, processor *commandProc
 	result := newResult()
 	eval.Inputs = inputs
 	eval.Steps = make(map[string]map[string]string)
-	statuses := make(map[string]expression.StepStatus)
+	eval.StepStatuses = make(map[string]expression.StepStatus)
+	statuses := eval.StepStatuses
 	compositeEnv := mergeStepEnvironment(jobEnv, stepEnv)
 	compositeEnv["GITHUB_ACTION_PATH"] = actionPath
 	var runErr error

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -749,7 +749,8 @@ echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
 echo "LEVEL=file" >> "$GITHUB_ENV"
 echo "secret=${{ secrets.CANARY }}"`},
 		{ID: "soft", Kind: "run", Command: "exit 7", ContinueOnError: true},
-		{ID: "after-soft", Kind: "run", Condition: "steps.soft.outcome == 'failure' && steps.soft.conclusion == 'success'", Command: `test "$LEVEL" = file
+		{ID: "after-soft", Kind: "run", Condition: "steps.soft.outcome == 'failure' && steps.soft.conclusion == 'success'", Env: map[string]string{"SOFT_OUTCOME": "${{ steps.soft.outcome }}"}, Command: `test "$LEVEL" = file
+test "$SOFT_OUTCOME:${{ steps.soft.conclusion }}" = failure:success
 case "$PATH" in "$GITHUB_WORKSPACE/bin"*) ;; *) exit 9 ;; esac
 echo after-soft`},
 	})

--- a/internal/transport/model.go
+++ b/internal/transport/model.go
@@ -33,6 +33,7 @@ const (
 var (
 	digestPattern             = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
 	keyPattern                = regexp.MustCompile(`^[A-Za-z0-9_-]{1,255}$`)
+	logicalJobIDPattern       = regexp.MustCompile(`^[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)*$`)
 	uuidPattern               = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
 	commitPattern             = regexp.MustCompile(`^[0-9a-f]{40}$`)
 	resultArtifactIDPattern   = regexp.MustCompile(`^[1-9][0-9]{0,19}$`)

--- a/internal/transport/results.go
+++ b/internal/transport/results.go
@@ -183,7 +183,7 @@ func LoadNeeds(ctx context.Context, agent Agent, root, buildID string, sources m
 	needs := make(map[string]NeedResult, len(sources))
 	for _, name := range names {
 		producers := append([]ResultSource(nil), sources[name]...)
-		if !keyPattern.MatchString(name) || len(producers) == 0 || len(producers) > MaxResultProducers {
+		if len(name) > 255 || !logicalJobIDPattern.MatchString(name) || len(producers) == 0 || len(producers) > MaxResultProducers {
 			return nil, fmt.Errorf("logical need %q has no valid producers", name)
 		}
 		sort.Slice(producers, func(i, j int) bool { return producers[i].StepKey < producers[j].StepKey })

--- a/internal/transport/results_test.go
+++ b/internal/transport/results_test.go
@@ -132,14 +132,14 @@ func TestLoadNeedsMapsLogicalFanInToVerifiedProducers(t *testing.T) {
 			secondPath: mustManifest(t, resultManifest(testJobID2, second.StepKey, second.PlanDigest, "failure", Output{Name: "second", Value: "two"})),
 		},
 	}
-	needs, err := LoadNeeds(context.Background(), Agent{Runner: runner}, t.TempDir(), testBuildID, map[string][]ResultSource{"build": {second, first}})
+	needs, err := LoadNeeds(context.Background(), Agent{Runner: runner}, t.TempDir(), testBuildID, map[string][]ResultSource{"reusable.build": {second, first}})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if needs["build"].Result != "failure" || !reflect.DeepEqual(needs["build"].Outputs, map[string]string{"first": "one", "second": "two"}) || len(needs["build"].Producers) != 2 || len(needs["build"].Artifacts) != 1 {
+	if needs["reusable.build"].Result != "failure" || !reflect.DeepEqual(needs["reusable.build"].Outputs, map[string]string{"first": "one", "second": "two"}) || len(needs["reusable.build"].Producers) != 2 || len(needs["reusable.build"].Artifacts) != 1 {
 		t.Fatalf("needs = %#v", needs)
 	}
-	if got := needs["build"].Artifacts[0]; got.Artifact != firstManifest.Artifacts[0] || got.Producer != firstManifest.Producer {
+	if got := needs["reusable.build"].Artifacts[0]; got.Artifact != firstManifest.Artifacts[0] || got.Producer != firstManifest.Producer {
 		t.Fatalf("retained artifact authority = %#v", got)
 	}
 
@@ -147,6 +147,10 @@ func TestLoadNeedsMapsLogicalFanInToVerifiedProducers(t *testing.T) {
 	_, err = LoadNeeds(context.Background(), Agent{Runner: runner}, t.TempDir(), testBuildID, map[string][]ResultSource{"build": {first, second}})
 	if err == nil || !strings.Contains(err.Error(), "conflicting matrix output") {
 		t.Fatalf("LoadNeeds() error = %v, want ambiguous matrix output rejection", err)
+	}
+	_, err = LoadNeeds(context.Background(), Agent{Runner: runner}, t.TempDir(), testBuildID, map[string][]ResultSource{"reusable/build": {first}})
+	if err == nil || !strings.Contains(err.Error(), "has no valid producers") {
+		t.Fatalf("LoadNeeds() error = %v, want invalid logical need rejection", err)
 	}
 }
 

--- a/mise.toml
+++ b/mise.toml
@@ -31,7 +31,7 @@ run = "golangci-lint run"
 
 [tasks."lint:shell"]
 description = "Lint shell scripts"
-run = "shellcheck -x .buildkite/phase-0-transport-probe/probe.sh scripts/ci-buildkite-release scripts/phase-0-shell-oracle-checkout scripts/phase-0-sign-json scripts/phase-0-verify-json scripts/phase-5-hosted-docker-probe scripts/phase-5-hosted-runtime-probe scripts/phase-6-artifact-roundtrip-verify scripts/phase-6-cache-roundtrip-verify scripts/phase-6-summary-annotation-verify scripts/phase-6-upload-artifact-verify scripts/phase-6-workflow-annotations-verify scripts/release scripts/smoke-local testdata/actions/docker/entrypoint.sh testdata/phase5/runtime/.github/actions/docker/entrypoint.sh"
+run = "shellcheck -x .buildkite/phase-0-transport-probe/probe.sh scripts/ci-buildkite-release scripts/migration-poc-import scripts/phase-0-shell-oracle-checkout scripts/phase-0-sign-json scripts/phase-0-verify-json scripts/phase-5-hosted-docker-probe scripts/phase-5-hosted-runtime-probe scripts/phase-6-artifact-roundtrip-verify scripts/phase-6-cache-roundtrip-verify scripts/phase-6-summary-annotation-verify scripts/phase-6-upload-artifact-verify scripts/phase-6-workflow-annotations-verify scripts/release scripts/smoke-local testdata/actions/docker/entrypoint.sh testdata/phase5/runtime/.github/actions/docker/entrypoint.sh"
 
 [tasks.vet]
 description = "Run go vet"

--- a/scripts/migration-poc-import
+++ b/scripts/migration-poc-import
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# != 1 )); then
+  echo 'usage: scripts/migration-poc-import <workflow>' >&2
+  exit 2
+fi
+
+workflow=$1
+case "$workflow" in
+  testdata/poc/.github/workflows/basic.yml | \
+    testdata/poc/.github/workflows/artifacts.yml | \
+    testdata/poc/.github/workflows/advanced.yml) ;;
+  *)
+    echo "unsupported migration POC workflow: $workflow" >&2
+    exit 2
+    ;;
+esac
+
+commit=${POC_COMMIT:?POC_COMMIT is required}
+scripts/phase-0-shell-oracle-checkout "$commit"
+test "${BUILDKITE_COMMIT:?BUILDKITE_COMMIT is required}" = "$commit"
+test -z "$(git status --porcelain --untracked-files=all)"
+
+if grep -q 'actions/cache@' "$workflow"; then
+  : "${BUILDKITE_GHA_CACHE_URL:?BUILDKITE_GHA_CACHE_URL is required by the advanced POC}"
+fi
+
+distribution_root=$(mktemp -d "${TMPDIR:-/tmp}/buildkite-gha-migration-poc.XXXXXXXX")
+event_path=$(mktemp "${TMPDIR:-/tmp}/buildkite-gha-migration-event.XXXXXXXX.json")
+compiled_workflow=$(mktemp "$(dirname "$workflow")/.migration-poc.XXXXXXXX.yml")
+trap 'rm -rf -- "$distribution_root"; rm -f -- "$event_path" "$compiled_workflow"' EXIT
+
+nonce=${BUILDKITE_BUILD_NUMBER:?BUILDKITE_BUILD_NUMBER is required}
+sed "s/__POC_NONCE__/$nonce/g" "$workflow" > "$compiled_workflow"
+if grep -q '__POC_NONCE__' "$compiled_workflow"; then
+  echo "failed to substitute migration POC nonce in $workflow" >&2
+  exit 1
+fi
+
+branch=${BUILDKITE_BRANCH:?BUILDKITE_BRANCH is required}
+jq -n \
+  --arg ref "refs/heads/$branch" \
+  --arg sha "$commit" \
+  '{
+    provider: "github",
+    event: "push",
+    repository: {
+      owner: "buildkite",
+      name: "buildkite-gha",
+      clone_url: "https://github.com/buildkite/buildkite-gha.git",
+      default_branch: "main"
+    },
+    ref: $ref,
+    sha: $sha,
+    actor: "buildkite-gha-migration-poc",
+    payload: {ref: $ref}
+  }' > "$event_path"
+
+runtime_version="0.0.0-poc.$commit"
+CGO_ENABLED=0 mise exec -- go build -trimpath -buildvcs=false \
+  -ldflags "-X main.version=$runtime_version" \
+  -o "$distribution_root/buildkite-gha" ./cmd/buildkite-gha
+
+"$distribution_root/buildkite-gha" upload \
+  --event-path "$event_path" \
+  --runtime-queue hosted \
+  "$compiled_workflow"

--- a/scripts/smoke-local
+++ b/scripts/smoke-local
@@ -22,7 +22,7 @@ cd "$root"
 jq -e '
   keys == ["fixtures", "schema"] and
   .schema == "buildkite-gha/smoke-manifest/v1" and
-  (.fixtures | type == "array" and length == 13) and
+  (.fixtures | type == "array" and length > 0) and
   all(.fixtures[];
     keys == ["action_preflight", "event", "evidence", "expectation", "id", "note", "workflow"] and
     (.id | test("^[a-z0-9]+(?:-[a-z0-9]+)*$")) and

--- a/testdata/poc/.github/workflows/advanced.yml
+++ b/testdata/poc/.github/workflows/advanced.yml
@@ -1,0 +1,117 @@
+name: Migration POC - advanced delivery
+
+on:
+  push:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  POC_CACHE_KEY: migration-poc-v1-__POC_NONCE__
+  POC_CACHE_PAYLOAD: migration-poc-payload:__POC_NONCE__
+
+jobs:
+  quality:
+    uses: ./.github/workflows/reusable-quality.yml
+    with:
+      package: ./internal/action/integration
+
+  cache-producer:
+    name: Populate dependency cache
+    needs: quality
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Restore build-unique cache
+        id: cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .migration-cache
+          key: ${{ env.POC_CACHE_KEY }}
+
+      - name: Require miss and create payload
+        shell: bash
+        env:
+          CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
+        run: |
+          test "$CACHE_HIT" != true
+          mkdir -p .migration-cache
+          printf '%s\n' "$POC_CACHE_PAYLOAD" > .migration-cache/payload.txt
+
+  advanced-package:
+    name: Restore cache and package payload
+    needs: cache-producer
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Restore producer cache
+        id: cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .migration-cache
+          key: ${{ env.POC_CACHE_KEY }}
+
+      - name: Require cache hit
+        shell: bash
+        env:
+          CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
+        run: |
+          test "$CACHE_HIT" = true
+          test "$(cat .migration-cache/payload.txt)" = "$POC_CACHE_PAYLOAD"
+
+      - name: Exercise continue-on-error
+        id: expected-failure
+        continue-on-error: true
+        shell: bash
+        run: exit 7
+
+      - name: Verify continued outcome
+        if: steps.expected-failure.outcome == 'failure'
+        shell: bash
+        run: test "${{ steps.expected-failure.outcome }}" = failure
+
+      - name: Upload restored payload
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: migration-poc-payload
+          path: .migration-cache/payload.txt
+          if-no-files-found: error
+
+  advanced-verify:
+    name: Verify payload (${{ matrix.variant }})
+    needs: advanced-package
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [primary, secondary]
+    steps:
+      - name: Download payload
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: migration-poc-payload
+          path: payload
+
+      - name: Verify payload
+        shell: bash
+        env:
+          VARIANT: ${{ matrix.variant }}
+        run: |
+          test "$(cat payload/payload.txt)" = "$POC_CACHE_PAYLOAD"
+          echo "::warning title=Migration POC::$VARIANT verified the cached artifact"
+          {
+            echo "## Advanced migration POC: $VARIANT"
+            echo
+            echo 'Reusable workflow, cache, artifact, matrix, and annotation checks passed.'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  poc-advanced:
+    name: Advanced POC complete
+    needs: advanced-verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Confirm fan-in
+        shell: bash
+        run: echo 'Both matrix consumers completed.'

--- a/testdata/poc/.github/workflows/advanced.yml
+++ b/testdata/poc/.github/workflows/advanced.yml
@@ -27,7 +27,7 @@ jobs:
         id: cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: .migration-cache
+          path: migration-cache
           key: ${{ env.POC_CACHE_KEY }}
 
       - name: Require miss and create payload
@@ -36,8 +36,8 @@ jobs:
           CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
         run: |
           test "$CACHE_HIT" != true
-          mkdir -p .migration-cache
-          printf '%s\n' "$POC_CACHE_PAYLOAD" > .migration-cache/payload.txt
+          mkdir -p migration-cache
+          printf '%s\n' "$POC_CACHE_PAYLOAD" > migration-cache/payload.txt
 
   advanced-package:
     name: Restore cache and package payload
@@ -49,7 +49,7 @@ jobs:
         id: cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: .migration-cache
+          path: migration-cache
           key: ${{ env.POC_CACHE_KEY }}
 
       - name: Require cache hit
@@ -58,7 +58,7 @@ jobs:
           CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
         run: |
           test "$CACHE_HIT" = true
-          test "$(cat .migration-cache/payload.txt)" = "$POC_CACHE_PAYLOAD"
+          test "$(cat migration-cache/payload.txt)" = "$POC_CACHE_PAYLOAD"
 
       - name: Exercise continue-on-error
         id: expected-failure
@@ -75,7 +75,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: migration-poc-payload
-          path: .migration-cache/payload.txt
+          path: migration-cache/payload.txt
           if-no-files-found: error
 
   advanced-verify:

--- a/testdata/poc/.github/workflows/artifacts.yml
+++ b/testdata/poc/.github/workflows/artifacts.yml
@@ -1,0 +1,77 @@
+name: Migration POC - build artifact
+
+on:
+  push:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  poc-artifact-producer:
+    name: Build and publish CLI
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      archive-digest: ${{ steps.upload.outputs.artifact-digest }}
+    steps:
+      - name: Checkout the event commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: "1.26.5"
+          cache: "false"
+          token: ""
+
+      - name: Build distributable
+        shell: bash
+        run: |
+          mkdir -p dist
+          CGO_ENABLED=0 go build -trimpath -o dist/buildkite-gha ./cmd/buildkite-gha
+          printf '%s\n' "$GITHUB_SHA" > dist/source-commit.txt
+
+      - name: Upload distributable
+        id: upload
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: migration-poc-cli
+          path: dist
+          if-no-files-found: error
+
+  poc-artifact-consumer:
+    name: Consume and verify CLI
+    needs: poc-artifact-producer
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Download distributable
+        id: download
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: migration-poc-cli
+          path: download
+
+      - name: Verify distributable
+        shell: bash
+        env:
+          ARCHIVE_DIGEST: ${{ needs.poc-artifact-producer.outputs.archive-digest }}
+          DOWNLOAD_PATH: ${{ steps.download.outputs.download-path }}
+        run: |
+          [[ "$ARCHIVE_DIGEST" =~ ^[0-9a-f]{64}$ ]]
+          [[ "$DOWNLOAD_PATH" == /*/download ]]
+          test "$(cat download/source-commit.txt)" = "$GITHUB_SHA"
+          chmod +x download/buildkite-gha
+          download/buildkite-gha --version
+
+      - name: Publish summary
+        shell: bash
+        env:
+          ARCHIVE_DIGEST: ${{ needs.poc-artifact-producer.outputs.archive-digest }}
+        run: |
+          {
+            echo '## Artifact migration POC'
+            echo
+            echo "Built, transferred, and executed the CLI artifact ($ARCHIVE_DIGEST)."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/testdata/poc/.github/workflows/basic.yml
+++ b/testdata/poc/.github/workflows/basic.yml
@@ -1,0 +1,51 @@
+name: Migration POC - basic CI
+
+on:
+  push:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  POC_SUITE: basic
+
+jobs:
+  poc-basic:
+    name: Basic Go CI
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout the event commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: "1.26.5"
+          cache: "false"
+          token: ""
+
+      - name: Run focused tests
+        id: tests
+        shell: bash
+        run: |
+          go test ./internal/expression ./internal/workflow
+          echo "result=passed" >> "$GITHUB_OUTPUT"
+
+      - name: Verify step output
+        if: steps.tests.outputs.result == 'passed'
+        shell: bash
+        env:
+          RESULT: ${{ steps.tests.outputs.result }}
+        run: test "$RESULT" = passed
+
+      - name: Publish summary
+        shell: bash
+        run: |
+          {
+            echo '## Basic migration POC'
+            echo
+            echo 'Checkout, setup-go, conditions, outputs, and focused tests passed.'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/testdata/poc/.github/workflows/reusable-quality.yml
+++ b/testdata/poc/.github/workflows/reusable-quality.yml
@@ -1,0 +1,34 @@
+name: Migration POC - reusable quality check
+
+on:
+  workflow_call:
+    inputs:
+      package:
+        description: Go package to test
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Reusable package check
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout the event commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: "1.26.5"
+          cache: "false"
+          token: ""
+
+      - name: Test requested package
+        shell: bash
+        env:
+          PACKAGE: ${{ inputs.package }}
+        run: go test "$PACKAGE"

--- a/testdata/poc/README.md
+++ b/testdata/poc/README.md
@@ -1,0 +1,42 @@
+# Migration POC suite
+
+These workflows exercise common GitHub Actions migration shapes as one
+exact-commit Buildkite proof, rather than adding more phase-numbered probes:
+
+- `basic.yml`: checkout, tool setup, shell tests, conditions, outputs, and a job
+  summary.
+- `artifacts.yml`: build, job outputs, a direct producer-to-consumer artifact
+  handoff, and execution of the downloaded binary.
+- `advanced.yml`: a local reusable workflow, cache v6 miss/save/hit lifecycle,
+  `continue-on-error`, artifact handoff, matrix fan-out/fan-in, summaries, and
+  workflow-command annotations.
+
+The suite stays within the `hosted-tokenless` admission profile. It does not
+imply support for secrets, job or service containers, remote reusable
+workflows, moving action refs, broad artifact modes, or cache versions other
+than the audited actions/cache v6.1.0 commit.
+
+## Hosted run
+
+Run the suite against one exact commit:
+
+```sh
+commit=$(git rev-parse HEAD)
+bk build create \
+  --pipeline buildkite/buildkite-gha \
+  --branch "$(git branch --show-current)" \
+  --commit "$commit" \
+  -e POC_SUITE=migration \
+  -e POC_COMMIT="$commit" \
+  -e BUILDKITE_GHA_CACHE_URL=https://isaacsu-ghacs.buildkite.dev
+```
+
+`POC_COMMIT` must be a full lowercase Git object ID. The importer generates an
+event bound to that same commit and substitutes the Buildkite build number into
+the cache key, making the expected producer miss and dependent consumer hit
+repeatable.
+
+The historical phase fixtures and their recorded observations remain the
+conformance ledger. After this replacement suite has hosted runtime evidence,
+the duplicated phase-specific importer/continuation scaffolding can be removed
+separately without discarding those fixtures or claims.

--- a/testdata/smoke/manifest.json
+++ b/testdata/smoke/manifest.json
@@ -38,6 +38,33 @@
       "action_preflight": "hosted-tokenless"
     },
     {
+      "id": "migration-poc-basic",
+      "workflow": "testdata/poc/.github/workflows/basic.yml",
+      "event": "testdata/smoke/events/push.json",
+      "expectation": "compile-pass",
+      "evidence": "This migration-oriented aggregate is locally validated and deterministically compiled; its exact-commit hosted proof is pending.",
+      "note": "Exercises checkout, setup-go, shell tests, conditions, outputs, and a job summary without expanding the supported profile.",
+      "action_preflight": "hosted-tokenless"
+    },
+    {
+      "id": "migration-poc-artifacts",
+      "workflow": "testdata/poc/.github/workflows/artifacts.yml",
+      "event": "testdata/smoke/events/push.json",
+      "expectation": "compile-pass",
+      "evidence": "This migration-oriented aggregate is locally validated and deterministically compiled; its exact-commit hosted proof is pending.",
+      "note": "Exercises build, job outputs, exact-name direct-needs artifact transfer, and downloaded binary execution.",
+      "action_preflight": "hosted-tokenless"
+    },
+    {
+      "id": "migration-poc-advanced",
+      "workflow": "testdata/poc/.github/workflows/advanced.yml",
+      "event": "testdata/smoke/events/push.json",
+      "expectation": "compile-pass",
+      "evidence": "This migration-oriented aggregate is locally validated and deterministically compiled; its exact-commit hosted proof is pending.",
+      "note": "Exercises a local reusable workflow, cache v6, continue-on-error, artifact transfer, matrix fan-out and fan-in, summaries, and annotations.",
+      "action_preflight": "hosted-tokenless"
+    },
+    {
       "id": "phase4-public-actions",
       "workflow": "testdata/phase4/.github/workflows/public-actions.yml",
       "event": "testdata/phase4/events/public-checkout.json",


### PR DESCRIPTION
## Summary

- add basic, artifact, and advanced migration POCs with one exact-commit hosted dispatcher
- exercise checkout/setup, job outputs, artifact transfer, a local reusable workflow, cache v6, matrix fan-out/fan-in, summaries, and annotations
- fix plan and result hydration for namespaced local reusable-workflow dependencies discovered by the advanced POC
- keep historical phase fixtures as the conformance ledger; defer deletion of duplicate hosted replay scaffolding until this replacement has runtime evidence
- replace brittle pipeline and smoke-inventory size assertions with structural contract checks

## Validation

- `mise run check`
- `mise run smoke:profile` (all three POCs admitted before the GitHub API rate limit was exhausted; a later repeat was externally rate-limited)
- `git diff --check`

## Hosted proof

After merge, or from this exact branch commit, dispatch with:

```sh
commit=$(git rev-parse HEAD)
bk build create \\
  --pipeline buildkite/buildkite-gha \\
  --branch feat/migration-poc-suite \\
  --commit \"$commit\" \\
  -e POC_SUITE=migration \\
  -e POC_COMMIT=\"$commit\" \\
  -e BUILDKITE_GHA_CACHE_URL=https://isaacsu-ghacs.buildkite.dev
```