### PR TITLE
feat: preserve reusable workflow results

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ The plugin path currently supports:
 - Linux Bash and `sh` steps;
 - JavaScript, composite, local, and anonymous public actions;
 - supported local and public Dockerfile actions;
-- static matrices, `needs`, outputs, and local reusable workflows;
+- static matrices, ordinary `needs` and outputs, and local reusable workflows
+  with statically resolved inputs and caller-visible results;
 - the currently implemented job and step condition subset;
 - background, wait, cancellation, and parallel step controls;
 - timeouts, `continue-on-error`, masking, summaries, warning/error annotations,
@@ -92,6 +93,7 @@ It does **not** currently support:
 - runtime condition access to the `github.event` payload;
 - exhaustive validation of condition functions before execution;
 - job containers or service containers through the production plugin path;
+- declared local reusable-workflow outputs and reusable-call conditions;
 - privileged containers, arbitrary Docker options, or `docker://` actions; or
 - Windows or macOS jobs.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -33,7 +33,7 @@ provide.
 | Bash and `sh` steps | Supported | Includes environment and working-directory precedence. |
 | Static job graphs and `needs` | Supported | Dependencies and logical results are preserved. |
 | Static matrices | Supported | Includes typed values, `include`, `exclude`, and exact dependency fan-out. |
-| Local reusable workflows | Supported when statically resolvable | Remote and runtime-dependent reusable workflows are deferred. |
+| Local reusable workflows | Supported subset | Statically resolvable local calls preserve source-level `needs` names and expose an aggregate `needs.<call>.result` from every callee job. Caller prerequisites inherited by callee roots are status-only. Declared call outputs and call-level conditions are not yet supported; remote and runtime-dependent reusable workflows are deferred. |
 | Job and step conditions | Supported subset | Syntax is checked, but not every runtime function or context limitation is preflighted. Some unsupported expressions fail only when the job runs. |
 | Concurrent step controls | Supported | Includes `background`, `wait`, `wait-all`, `cancel`, and `parallel`. |
 | JavaScript actions | Supported | Managed, digest-verified Node 20 and 24 runtimes are used. |

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -1374,6 +1374,15 @@ Explicitly defer from beta unless implementation evidence changes the order:
   best-effort UI/query mirror. Matrix fan-in with conflicting output values
   currently fails closed because the public artifact contract does not expose
   an authoritative completion order.
+- Static local reusable-workflow calls retain the source-level name written in
+  each consumer's `needs`, and a caller's `needs.<call>.result` aggregates the
+  verified manifests from every flattened callee job rather than only terminal
+  jobs. Schema-v5 plans carry an explicit output projection for call aliases;
+  the current empty projection prevents undeclared callee job outputs from
+  leaking while declared `workflow_call.outputs` remain a follow-up. Caller
+  prerequisites inherited by callee roots are likewise status-only: their
+  outputs are not exposed inside the called workflow. Call-level conditions
+  fail closed instead of being silently discarded.
 - All local tests, race tests, vet, schema fixtures, shell checks, and offline
   pipeline validation pass. A default `.buildkite/pipeline.yml` now runs the
   repository checks, and all compilable smoke-manifest outputs pass the current

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -195,7 +195,7 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 		defer func() { _ = os.RemoveAll(artifactRoot) }()
 	}
 	var actionMaterializer gharuntime.ActionMaterializer
-	if (job.Schema == plan.SchemaV3 || job.Schema == plan.SchemaV4) && hasGitHubActionLocks(job.Actions) {
+	if (job.Schema == plan.SchemaV3 || job.Schema == plan.SchemaV4 || job.Schema == plan.SchemaV5) && hasGitHubActionLocks(job.Actions) {
 		actionCache, err := os.MkdirTemp("", "buildkite-gha-actions-")
 		if err != nil {
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: create action cache: %v\n", err)
@@ -247,7 +247,7 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 	var result gharuntime.JobResult
 	var runErr error
 	if len(job.NeedSources) != 0 {
-		job.Needs, runErr = gharuntime.ResolveNeeds(ctx, agent, artifactRoot, producer.BuildID, job.NeedSources)
+		job.Needs, runErr = gharuntime.ResolveNeeds(ctx, agent, artifactRoot, producer.BuildID, job.NeedSources, job.NeedOutputs)
 		if runErr != nil {
 			runErr = fmt.Errorf("hydrate prerequisite results: %w", runErr)
 		}

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	schema             = "buildkite-gha/compiler-ir/v0"
+	schema             = "buildkite-gha/compiler-ir/v1"
 	maxMatrixInstances = 256
 )
 
@@ -75,29 +75,39 @@ type WorkflowSource struct {
 
 // JobInstance is one statically expanded job in the owned IR.
 type JobInstance struct {
-	Key                     string              `json:"key"`
-	LogicalJobID            string              `json:"logical_job_id"`
-	Label                   string              `json:"label"`
-	Needs                   []string            `json:"needs,omitempty"`
-	LogicalNeeds            []string            `json:"logical_needs,omitempty"`
-	RunsOn                  []string            `json:"runs_on"`
-	Queue                   string              `json:"queue"`
-	Matrix                  map[string]any      `json:"matrix,omitempty"`
-	FailFast                *bool               `json:"fail_fast,omitempty"`
-	MaxParallel             *int                `json:"max_parallel,omitempty"`
-	Steps                   []workflow.Step     `json:"steps"`
-	Env                     map[string]string   `json:"env,omitempty"`
-	If                      string              `json:"if,omitempty"`
-	TimeoutMinutes          float64             `json:"timeout_minutes,omitempty"`
-	DefaultShell            string              `json:"default_shell,omitempty"`
-	DefaultWorkingDirectory string              `json:"default_working_directory,omitempty"`
-	Outputs                 map[string]string   `json:"outputs,omitempty"`
-	Container               *workflow.Container `json:"container,omitempty"`
-	Services                []workflow.Service  `json:"services,omitempty"`
-	SourcePath              string              `json:"source_path"`
-	SourceDigest            string              `json:"source_digest"`
-	RepositoryRoot          string              `json:"-"`
-	Source                  workflow.Span       `json:"source"`
+	Key                     string                  `json:"key"`
+	LogicalJobID            string                  `json:"logical_job_id"`
+	Label                   string                  `json:"label"`
+	Needs                   []string                `json:"needs,omitempty"`
+	NeedGroups              map[string][]string     `json:"need_groups,omitempty"`
+	NeedOutputs             map[string][]NeedOutput `json:"need_outputs,omitempty"`
+	RunsOn                  []string                `json:"runs_on"`
+	Queue                   string                  `json:"queue"`
+	Matrix                  map[string]any          `json:"matrix,omitempty"`
+	FailFast                *bool                   `json:"fail_fast,omitempty"`
+	MaxParallel             *int                    `json:"max_parallel,omitempty"`
+	Steps                   []workflow.Step         `json:"steps"`
+	Env                     map[string]string       `json:"env,omitempty"`
+	If                      string                  `json:"if,omitempty"`
+	TimeoutMinutes          float64                 `json:"timeout_minutes,omitempty"`
+	DefaultShell            string                  `json:"default_shell,omitempty"`
+	DefaultWorkingDirectory string                  `json:"default_working_directory,omitempty"`
+	Outputs                 map[string]string       `json:"outputs,omitempty"`
+	Container               *workflow.Container     `json:"container,omitempty"`
+	Services                []workflow.Service      `json:"services,omitempty"`
+	SourcePath              string                  `json:"source_path"`
+	SourceDigest            string                  `json:"source_digest"`
+	RepositoryRoot          string                  `json:"-"`
+	Source                  workflow.Span           `json:"source"`
+}
+
+// NeedOutput selects one caller-visible output from a concrete prerequisite.
+// An empty output list explicitly prevents an aggregate need from exposing its
+// producers' internal outputs.
+type NeedOutput struct {
+	Name    string `json:"name"`
+	StepKey string `json:"step_key"`
+	Output  string `json:"output"`
 }
 
 // Report summarizes successful workflow validation.
@@ -217,10 +227,6 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 	plans := make([]plan.Job, 0, len(ir.Jobs))
 	authorizations := make([]PlanAuthorization, 0, len(ir.Jobs))
 	planDigests := make(map[string]string, len(ir.Jobs))
-	logicalByKey := make(map[string]string, len(ir.Jobs))
-	for _, instance := range ir.Jobs {
-		logicalByKey[instance.Key] = instance.LogicalJobID
-	}
 	actionSource := newMemoizedActionSource(options.ActionSource)
 	for _, instance := range ir.Jobs {
 		steps := make([]plan.Step, len(instance.Steps))
@@ -304,7 +310,7 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 						span := instance.Steps[stepIndex].Span.Start
 						return nil, nil, fmt.Errorf("%s:%d:%d: bounded download-artifact adapter: %w", instance.SourcePath, span.Line, span.Column, err)
 					}
-					if len(instance.LogicalNeeds) == 0 {
+					if len(instance.NeedGroups) == 0 {
 						span := instance.Steps[stepIndex].Span.Start
 						return nil, nil, fmt.Errorf("%s:%d:%d: bounded download-artifact adapter requires at least one direct needs producer", instance.SourcePath, span.Line, span.Column)
 					}
@@ -339,18 +345,33 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 			}
 			sort.Strings(authorization.DockerCapabilitySources)
 		}
-		needSources := make(map[string][]plan.NeedSource, len(instance.LogicalNeeds))
-		for _, logicalNeed := range instance.LogicalNeeds {
-			for _, dependency := range instance.Needs {
-				if logicalByKey[dependency] != logicalNeed {
-					continue
-				}
+		needSources := make(map[string][]plan.NeedSource, len(instance.NeedGroups))
+		for _, logicalNeed := range sortedKeys(instance.NeedGroups) {
+			dependencies := instance.NeedGroups[logicalNeed]
+			if len(dependencies) > plan.MaxNeedProducers {
+				return nil, nil, fmt.Errorf("build plan for job %q: prerequisite %q has %d producers, maximum is %d", instance.LogicalJobID, logicalNeed, len(dependencies), plan.MaxNeedProducers)
+			}
+			for _, dependency := range dependencies {
 				digest, ok := planDigests[dependency]
 				if !ok {
 					return nil, nil, fmt.Errorf("build plan for job %q: prerequisite %q has no earlier plan digest", instance.LogicalJobID, dependency)
 				}
 				needSources[logicalNeed] = append(needSources[logicalNeed], plan.NeedSource{StepKey: dependency, PlanDigest: digest})
 			}
+		}
+		var needOutputs map[string][]plan.NeedOutput
+		if len(instance.NeedOutputs) != 0 {
+			needOutputs = make(map[string][]plan.NeedOutput, len(instance.NeedOutputs))
+			for _, logicalNeed := range sortedKeys(instance.NeedOutputs) {
+				outputs := instance.NeedOutputs[logicalNeed]
+				needOutputs[logicalNeed] = make([]plan.NeedOutput, len(outputs))
+				for i, output := range outputs {
+					needOutputs[logicalNeed][i] = plan.NeedOutput{Name: output.Name, StepKey: output.StepKey, Output: output.Output}
+				}
+			}
+		}
+		if len(needOutputs) != 0 {
+			jobSchema = plan.SchemaV5
 		}
 		secrets, err := requiredSecrets(instance)
 		if err != nil {
@@ -382,6 +403,7 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 			Vars:                    cloneMap(ir.Vars),
 			Dependencies:            append([]string(nil), instance.Needs...),
 			NeedSources:             needSources,
+			NeedOutputs:             needOutputs,
 			Env:                     instance.Env,
 			Condition:               instance.If,
 			TimeoutMinutes:          instance.TimeoutMinutes,
@@ -563,6 +585,7 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 	sourcePaths := make(map[string]string, len(resolved))
 	sourceDigests := make(map[string]string, len(resolved))
 	sourceRoots := make(map[string]string, len(resolved))
+	needBindings := make(map[string]map[string]needBinding, len(resolved))
 	for _, sourced := range resolved {
 		job := sourced.Job
 		if _, exists := jobs[job.ID]; exists {
@@ -572,6 +595,7 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 		sourcePaths[job.ID] = sourced.path
 		sourceDigests[job.ID] = sourced.digest
 		sourceRoots[job.ID] = sourced.root
+		needBindings[job.ID] = sourced.needBindings
 		if err := supported(sourced.path, job); err != nil {
 			return nil, err
 		}
@@ -613,7 +637,6 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 				Label:                   instanceLabel(job, matrix),
 				RunsOn:                  labels,
 				Queue:                   queue,
-				LogicalNeeds:            append([]string(nil), job.Needs...),
 				Matrix:                  matrix,
 				FailFast:                job.FailFast,
 				MaxParallel:             job.MaxParallel,
@@ -631,12 +654,32 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 				RepositoryRoot:          sourceRoots[id],
 				Source:                  job.Span,
 			}
-			for _, need := range job.Needs {
-				for _, prerequisite := range byLogicalID[need] {
-					instance.Needs = append(instance.Needs, prerequisite.Key)
+			for _, need := range sortedKeys(needBindings[id]) {
+				binding := needBindings[id][need]
+				var members []string
+				for _, member := range binding.members {
+					for _, prerequisite := range byLogicalID[member] {
+						members = append(members, prerequisite.Key)
+					}
+				}
+				sort.Strings(members)
+				if len(members) == 0 {
+					return nil, jobError(jobPath, job, fmt.Sprintf("prerequisite %q has no expanded instances", need))
+				}
+				if instance.NeedGroups == nil {
+					instance.NeedGroups = make(map[string][]string, len(needBindings[id]))
+				}
+				instance.NeedGroups[need] = members
+				instance.Needs = append(instance.Needs, members...)
+				if binding.projectOutputs {
+					if instance.NeedOutputs == nil {
+						instance.NeedOutputs = make(map[string][]NeedOutput)
+					}
+					instance.NeedOutputs[need] = []NeedOutput{}
 				}
 			}
 			sort.Strings(instance.Needs)
+			instance.Needs = slices.Compact(instance.Needs)
 			byLogicalID[id] = append(byLogicalID[id], instance)
 		}
 	}
@@ -677,6 +720,15 @@ func cloneMap(in map[string]string) map[string]string {
 		out[key] = value
 	}
 	return out
+}
+
+func sortedKeys[V any](values map[string]V) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func expandMatrix(path string, job workflow.Job, context expression.CompileContext) ([]map[string]any, error) {

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -312,9 +312,10 @@ jobs:
       enabled: true
   finish:
     needs: delegated
+    if: always() && needs.delegated.result == 'success'
     runs-on: ubuntu-latest
     steps:
-      - run: finish
+      - run: test "${{ needs.delegated.result }}" = success
 `)
 	calleePath := writeWorkflow(t, repository, "reusable.yml", `on:
   workflow_call:
@@ -355,11 +356,14 @@ jobs:
 	first := byID["delegated.first"]
 	second := byID["delegated.second"]
 	finish := byID["finish"]
-	if !reflect.DeepEqual(first.Needs, []string{prepare.Key}) || !reflect.DeepEqual(first.LogicalNeeds, []string{"prepare"}) {
-		t.Fatalf("callee root needs = %#v / %#v, want caller prerequisite", first.Needs, first.LogicalNeeds)
+	if !reflect.DeepEqual(first.Needs, []string{prepare.Key}) || !reflect.DeepEqual(first.NeedGroups, map[string][]string{"prepare": {prepare.Key}}) || !reflect.DeepEqual(first.NeedOutputs, map[string][]NeedOutput{"prepare": {}}) {
+		t.Fatalf("callee root needs = %#v / %#v / %#v, want status-only caller prerequisite", first.Needs, first.NeedGroups, first.NeedOutputs)
 	}
-	if !reflect.DeepEqual(second.Needs, []string{first.Key}) || !reflect.DeepEqual(finish.Needs, []string{second.Key}) {
-		t.Fatalf("callee/caller dependencies = %#v / %#v", second.Needs, finish.Needs)
+	if !reflect.DeepEqual(second.Needs, []string{first.Key}) || !reflect.DeepEqual(second.NeedGroups, map[string][]string{"first": {first.Key}}) {
+		t.Fatalf("callee dependency = %#v / %#v, want source-local need name", second.Needs, second.NeedGroups)
+	}
+	if !reflect.DeepEqual(finish.Needs, []string{first.Key, second.Key}) || !reflect.DeepEqual(finish.NeedGroups, map[string][]string{"delegated": {first.Key, second.Key}}) || !reflect.DeepEqual(finish.NeedOutputs, map[string][]NeedOutput{"delegated": {}}) {
+		t.Fatalf("caller dependency projection = %#v / %#v / %#v", finish.Needs, finish.NeedGroups, finish.NeedOutputs)
 	}
 	if first.Key != "gha-delegated-first" || first.Label != "delegated tests / first" {
 		t.Fatalf("callee identity = key %q label %q", first.Key, first.Label)
@@ -379,13 +383,29 @@ jobs:
 	if len(plans) != 4 {
 		t.Fatalf("plans = %d, want 4", len(plans))
 	}
+	firstPlan, err := plan.Encode(plans[1])
+	if err != nil {
+		t.Fatal(err)
+	}
 	secondPlan, err := plan.Encode(plans[2])
 	if err != nil {
 		t.Fatal(err)
 	}
+	if plans[3].Schema != plan.SchemaV5 {
+		t.Fatalf("downstream reusable-workflow plan schema = %q, want v5", plans[3].Schema)
+	}
+	if plans[1].Schema != plan.SchemaV5 || !reflect.DeepEqual(plans[1].NeedOutputs, map[string][]plan.NeedOutput{"prepare": {}}) {
+		t.Fatalf("callee root caller prerequisite projection = %q / %#v", plans[1].Schema, plans[1].NeedOutputs)
+	}
+	if plans[3].Condition != "always() && needs.delegated.result == 'success'" || plans[3].Steps[0].Command != `test "${{ needs.delegated.result }}" = success` {
+		t.Fatalf("downstream reusable-workflow result expressions = %q / %q", plans[3].Condition, plans[3].Steps[0].Command)
+	}
 	if !reflect.DeepEqual(plans[3].NeedSources, map[string][]plan.NeedSource{
-		"delegated.second": {{StepKey: second.Key, PlanDigest: transport.Digest(secondPlan)}},
-	}) {
+		"delegated": {
+			{StepKey: first.Key, PlanDigest: transport.Digest(firstPlan)},
+			{StepKey: second.Key, PlanDigest: transport.Digest(secondPlan)},
+		},
+	}) || !reflect.DeepEqual(plans[3].NeedOutputs, map[string][]plan.NeedOutput{"delegated": {}}) {
 		t.Fatalf("downstream reusable-workflow plan needs = %#v", plans[3].NeedSources)
 	}
 }
@@ -401,6 +421,11 @@ jobs:
     uses: ./.github/workflows/reusable.yml
     with:
       target: ${{ matrix.target }}
+  finish:
+    needs: delegated
+    runs-on: ubuntu-latest
+    steps:
+      - run: test "${{ needs.delegated.result }}" = success
 `)
 	writeWorkflow(t, repository, "reusable.yml", `on:
   workflow_call:
@@ -431,8 +456,11 @@ jobs:
 	if err := json.Unmarshal(first, &ir); err != nil {
 		t.Fatal(err)
 	}
-	if len(ir.Jobs) != 2 || ir.Jobs[0].LogicalJobID == ir.Jobs[1].LogicalJobID || ir.Jobs[0].Key == ir.Jobs[1].Key {
+	if len(ir.Jobs) != 3 || ir.Jobs[0].LogicalJobID == ir.Jobs[1].LogicalJobID || ir.Jobs[0].Key == ir.Jobs[1].Key {
 		t.Fatalf("matrix reusable jobs = %#v, want two namespaced identities", ir.Jobs)
+	}
+	if !reflect.DeepEqual(ir.Jobs[2].NeedGroups, map[string][]string{"delegated": {ir.Jobs[0].Key, ir.Jobs[1].Key}}) || !reflect.DeepEqual(ir.Jobs[2].NeedOutputs, map[string][]NeedOutput{"delegated": {}}) {
+		t.Fatalf("matrix reusable caller projection = %#v / %#v", ir.Jobs[2].NeedGroups, ir.Jobs[2].NeedOutputs)
 	}
 	runs := []string{ir.Jobs[0].Steps[0].Run, ir.Jobs[1].Steps[0].Run}
 	sort.Strings(runs)
@@ -448,8 +476,11 @@ jobs:
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(plans) != 2 || plans[0].Workflow.Path != "./.github/workflows/reusable.yml" || plans[0].Workflow.Digest != ir.Jobs[0].SourceDigest {
+	if len(plans) != 3 || plans[0].Workflow.Path != "./.github/workflows/reusable.yml" || plans[0].Workflow.Digest != ir.Jobs[0].SourceDigest {
 		t.Fatalf("callee plan provenance = %#v, want callee path and digest", plans)
+	}
+	if len(plans[2].NeedSources["delegated"]) != 2 || !reflect.DeepEqual(plans[2].NeedOutputs, map[string][]plan.NeedOutput{"delegated": {}}) {
+		t.Fatalf("matrix reusable plan projection = %#v / %#v", plans[2].NeedSources, plans[2].NeedOutputs)
 	}
 }
 
@@ -613,6 +644,16 @@ jobs:
 		}
 	})
 
+	t.Run("call condition", func(t *testing.T) {
+		repository := t.TempDir()
+		path := writeWorkflow(t, repository, "caller.yml", "on: push\njobs:\n  call:\n    if: github.ref == 'refs/heads/main'\n    uses: ./.github/workflows/reusable.yml\n")
+		writeWorkflow(t, repository, "reusable.yml", "on: workflow_call\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n")
+		_, err := Compile(path, readFile(t, path), readFile(t, smokePath("events", "push.json")))
+		if err == nil || !strings.Contains(err.Error(), "reusable-workflow call conditions are unsupported") {
+			t.Fatalf("Compile() error = %v, want explicit call-condition rejection", err)
+		}
+	})
+
 	t.Run("symlink escape", func(t *testing.T) {
 		repository := t.TempDir()
 		path := writeWorkflow(t, repository, "caller.yml", "on: push\njobs:\n  call:\n    uses: ./.github/workflows/escaped.yml\n")
@@ -666,6 +707,11 @@ jobs:
     uses: ./.github/workflows/middle.yml
     with:
       target: linux
+  finish:
+    needs: middle
+    runs-on: ubuntu-latest
+    steps:
+      - run: test "${{ needs.middle.result }}" = success
 `)
 	writeWorkflow(t, repository, "middle.yml", `on:
   workflow_call:
@@ -704,8 +750,8 @@ jobs:
 	if err := json.Unmarshal(result, &ir); err != nil {
 		t.Fatal(err)
 	}
-	if len(ir.Jobs) != 2 {
-		t.Fatalf("jobs = %d, want 2 nested matrix instances", len(ir.Jobs))
+	if len(ir.Jobs) != 3 {
+		t.Fatalf("jobs = %d, want 2 nested matrix instances and their caller", len(ir.Jobs))
 	}
 	runs := []string{ir.Jobs[0].Steps[0].Run, ir.Jobs[1].Steps[0].Run}
 	sort.Strings(runs)
@@ -713,9 +759,15 @@ jobs:
 		t.Fatalf("nested static inputs = %#v", runs)
 	}
 	for _, job := range ir.Jobs {
+		if job.LogicalJobID == "finish" {
+			continue
+		}
 		if !strings.HasPrefix(job.Label, "middle / leaf linux") {
 			t.Fatalf("nested label = %q, want substituted caller input", job.Label)
 		}
+	}
+	if !reflect.DeepEqual(ir.Jobs[2].NeedGroups, map[string][]string{"middle": {ir.Jobs[0].Key, ir.Jobs[1].Key}}) || !reflect.DeepEqual(ir.Jobs[2].NeedOutputs, map[string][]NeedOutput{"middle": {}}) {
+		t.Fatalf("nested reusable caller projection = %#v / %#v", ir.Jobs[2].NeedGroups, ir.Jobs[2].NeedOutputs)
 	}
 }
 

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -864,6 +864,52 @@ func TestCompileBoundsReusableWorkflowGraphExpansion(t *testing.T) {
 	}
 }
 
+func TestCompileReusableCallResultSupportsMaximumCalleeMatrixAndJoin(t *testing.T) {
+	repository := t.TempDir()
+	values := make([]string, maxMatrixInstances)
+	for i := range values {
+		values[i] = fmt.Sprint(i)
+	}
+	path := writeWorkflow(t, repository, "caller.yml", `on: push
+jobs:
+  delegated:
+    uses: ./.github/workflows/reusable.yml
+  finish:
+    needs: delegated
+    runs-on: ubuntu-latest
+    steps:
+      - run: test "${{ needs.delegated.result }}" = success
+`)
+	writeWorkflow(t, repository, "reusable.yml", fmt.Sprintf(`on: workflow_call
+jobs:
+  fanout:
+    strategy:
+      matrix:
+        value: [%s]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ matrix.value }}"
+  join:
+    needs: fanout
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+`, strings.Join(values, ", ")))
+
+	plans, err := CompilePlans(path, readFile(t, path), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), "gha-untrusted")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != maxMatrixInstances+2 {
+		t.Fatalf("plans = %d, want %d callee jobs and caller", len(plans), maxMatrixInstances+2)
+	}
+	caller := plans[len(plans)-1]
+	if got := len(caller.NeedSources["delegated"]); got != maxMatrixInstances+1 {
+		t.Fatalf("reusable-call result producers = %d, want matrix plus join (%d)", got, maxMatrixInstances+1)
+	}
+}
+
 func TestCompileRejectsRequiredReusableWorkflowSecrets(t *testing.T) {
 	repository := t.TempDir()
 	path := writeWorkflow(t, repository, "caller.yml", "on: push\njobs:\n  call:\n    uses: ./.github/workflows/reusable.yml\n")

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -25,9 +25,18 @@ var staticValueExpression = regexp.MustCompile(`^\s*\$\{\{\s*(inputs|matrix)\.([
 
 type sourcedJob struct {
 	workflow.Job
-	path   string
-	digest string
-	root   string
+	path         string
+	digest       string
+	root         string
+	needBindings map[string]needBinding
+}
+
+type needBinding struct {
+	// members are flattened logical job IDs owned by one source-level need.
+	// projectOutputs distinguishes reusable-call/status-only boundaries from
+	// ordinary job needs, whose outputs pass through unchanged.
+	members        []string
+	projectOutputs bool
 }
 
 type reusableResolver struct {
@@ -54,7 +63,11 @@ func resolveReusableWorkflows(path string, source []byte, parsed *workflow.Workf
 		}
 		jobs := make([]sourcedJob, len(parsed.Jobs))
 		for i, job := range parsed.Jobs {
-			jobs[i] = sourcedJob{Job: job, path: sourcePath, digest: digest, root: root}
+			bindings := make(map[string]needBinding, len(job.Needs))
+			for _, need := range job.Needs {
+				bindings[need] = needBinding{members: []string{need}}
+			}
+			jobs[i] = sourcedJob{Job: job, path: sourcePath, digest: digest, root: root, needBindings: bindings}
 		}
 		return jobs, nil
 	}
@@ -80,7 +93,7 @@ func hasReusableCall(parsed *workflow.Workflow) bool {
 	return false
 }
 
-func (resolver *reusableResolver) resolve(path, digest string, parsed *workflow.Workflow, namespace, labelPrefix string, inputs map[string]any, externalNeeds []string, depth int) ([]sourcedJob, error) {
+func (resolver *reusableResolver) resolve(path, digest string, parsed *workflow.Workflow, namespace, labelPrefix string, inputs map[string]any, externalNeeds map[string]needBinding, depth int) ([]sourcedJob, error) {
 	jobs := make(map[string]workflow.Job, len(parsed.Jobs))
 	for _, job := range parsed.Jobs {
 		jobs[job.ID] = job
@@ -90,7 +103,7 @@ func (resolver *reusableResolver) resolve(path, digest string, parsed *workflow.
 		return nil, err
 	}
 
-	replacements := make(map[string][]string, len(jobs))
+	replacements := make(map[string]needBinding, len(jobs))
 	var resolved []sourcedJob
 	for _, id := range order {
 		job := jobs[id]
@@ -104,12 +117,19 @@ func (resolver *reusableResolver) resolve(path, digest string, parsed *workflow.
 			if err := rejectCallMatrixExpressions(path, job); err != nil {
 				return nil, err
 			}
+			if strings.TrimSpace(job.If) != "" {
+				return nil, jobError(path, job, "reusable-workflow call conditions are unsupported")
+			}
 		}
-		needs := replacementNeeds(job.Needs, replacements)
+		needBindings := replacementNeeds(job.Needs, replacements)
 		if len(job.Needs) == 0 {
-			needs = append(needs, externalNeeds...)
-			sort.Strings(needs)
+			needBindings = cloneNeedBindings(externalNeeds)
+			for name, binding := range needBindings {
+				binding.projectOutputs = true
+				needBindings[name] = binding
+			}
 		}
+		needs := bindingMembers(needBindings)
 		if job.Reusable == nil {
 			job.ID = namespacedJobID(namespace, job.ID)
 			job.Needs = needs
@@ -124,8 +144,8 @@ func (resolver *reusableResolver) resolve(path, digest string, parsed *workflow.
 			if resolver.expanded > maxFlattenedJobs {
 				return nil, jobError(path, job, fmt.Sprintf("reusable-workflow graph expands beyond %d jobs", maxFlattenedJobs))
 			}
-			resolved = append(resolved, sourcedJob{Job: job, path: path, digest: digest, root: resolver.root})
-			replacements[id] = []string{job.ID}
+			resolved = append(resolved, sourcedJob{Job: job, path: path, digest: digest, root: resolver.root, needBindings: needBindings})
+			replacements[id] = needBinding{members: []string{job.ID}}
 			continue
 		}
 
@@ -168,7 +188,7 @@ func (resolver *reusableResolver) resolve(path, digest string, parsed *workflow.
 		if err != nil {
 			return nil, err
 		}
-		var terminals []string
+		var members []string
 		callNamespaces := make(map[string]struct{}, len(matrices))
 		for _, matrix := range matrices {
 			callInputs, err := resolveCallInputs(path, job, call, callee, inputs, matrix)
@@ -200,44 +220,59 @@ func (resolver *reusableResolver) resolve(path, digest string, parsed *workflow.
 			}
 
 			resolver.stack = append(resolver.stack, calleePath)
-			calleeJobs, err := resolver.resolve(calleeSourcePath, calleeDigest, callee, callNamespace, callLabel, callInputs, needs, depth+1)
+			calleeJobs, err := resolver.resolve(calleeSourcePath, calleeDigest, callee, callNamespace, callLabel, callInputs, needBindings, depth+1)
 			resolver.stack = resolver.stack[:len(resolver.stack)-1]
 			if err != nil {
 				return nil, err
 			}
 			resolved = append(resolved, calleeJobs...)
-			terminals = append(terminals, terminalJobIDs(calleeJobs)...)
+			for _, calleeJob := range calleeJobs {
+				members = append(members, calleeJob.ID)
+			}
 		}
-		sort.Strings(terminals)
-		replacements[id] = terminals
+		sort.Strings(members)
+		replacements[id] = needBinding{members: members, projectOutputs: true}
 	}
 	return resolved, nil
 }
 
-func replacementNeeds(needs []string, replacements map[string][]string) []string {
-	var out []string
+func replacementNeeds(needs []string, replacements map[string]needBinding) map[string]needBinding {
+	out := make(map[string]needBinding, len(needs))
 	for _, need := range needs {
-		out = append(out, replacements[need]...)
+		out[need] = cloneNeedBinding(replacements[need])
 	}
-	sort.Strings(out)
 	return out
 }
 
-func terminalJobIDs(jobs []sourcedJob) []string {
-	needed := make(map[string]struct{})
-	for _, job := range jobs {
-		for _, need := range job.Needs {
-			needed[need] = struct{}{}
+func bindingMembers(bindings map[string]needBinding) []string {
+	seen := make(map[string]struct{})
+	for _, binding := range bindings {
+		for _, member := range binding.members {
+			seen[member] = struct{}{}
 		}
 	}
-	var terminals []string
-	for _, job := range jobs {
-		if _, ok := needed[job.ID]; !ok {
-			terminals = append(terminals, job.ID)
-		}
+	members := make([]string, 0, len(seen))
+	for member := range seen {
+		members = append(members, member)
 	}
-	sort.Strings(terminals)
-	return terminals
+	sort.Strings(members)
+	return members
+}
+
+func cloneNeedBindings(bindings map[string]needBinding) map[string]needBinding {
+	if bindings == nil {
+		return nil
+	}
+	cloned := make(map[string]needBinding, len(bindings))
+	for name, binding := range bindings {
+		cloned[name] = cloneNeedBinding(binding)
+	}
+	return cloned
+}
+
+func cloneNeedBinding(binding needBinding) needBinding {
+	binding.members = append([]string(nil), binding.members...)
+	return binding
 }
 
 func namespacedJobID(namespace, id string) string {

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -24,7 +24,8 @@ const (
 	Schema   = SchemaV2
 )
 
-const MaxNeedProducers = 256
+const MaxNeedProducers = 1024
+const maxLegacyNeedProducers = 256
 const MaxNeedOutputs = 64
 const MaxStepTargets = 256
 
@@ -403,8 +404,12 @@ func (job Job) Validate() error {
 	}
 	needIDs := make(map[string]struct{}, len(job.NeedSources))
 	sourcedDependencies := make(map[string]struct{}, len(job.Dependencies))
+	maxNeedProducers := MaxNeedProducers
+	if job.Schema != SchemaV5 {
+		maxNeedProducers = maxLegacyNeedProducers
+	}
 	for name, sources := range job.NeedSources {
-		if len(name) > 255 || !logicalJobIDPattern.MatchString(name) || len(sources) == 0 || len(sources) > MaxNeedProducers {
+		if len(name) > 255 || !logicalJobIDPattern.MatchString(name) || len(sources) == 0 || len(sources) > maxNeedProducers {
 			return fmt.Errorf("job plan contains invalid prerequisite %q", name)
 		}
 		id := strings.ToLower(name)

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -20,10 +20,12 @@ const (
 	SchemaV2 = "https://buildkite.com/schemas/buildkite-gha/job-plan-v2.schema.json"
 	SchemaV3 = "https://buildkite.com/schemas/buildkite-gha/job-plan-v3.schema.json"
 	SchemaV4 = "https://buildkite.com/schemas/buildkite-gha/job-plan-v4.schema.json"
+	SchemaV5 = "https://buildkite.com/schemas/buildkite-gha/job-plan-v5.schema.json"
 	Schema   = SchemaV2
 )
 
 const MaxNeedProducers = 256
+const MaxNeedOutputs = 64
 const MaxStepTargets = 256
 
 var digestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
@@ -102,6 +104,14 @@ type NeedSource struct {
 	PlanDigest string `json:"plan_digest"`
 }
 
+// NeedOutput projects one named producer output into a logical prerequisite.
+// A NeedOutputs key with an empty list deliberately exposes no outputs.
+type NeedOutput struct {
+	Name    string `json:"name"`
+	StepKey string `json:"step_key"`
+	Output  string `json:"output"`
+}
+
 type Position struct {
 	Line   int `json:"line"`
 	Column int `json:"column"`
@@ -150,6 +160,7 @@ type Job struct {
 	Vars                 map[string]string       `json:"vars,omitempty"`
 	Dependencies         []string                `json:"dependencies,omitempty"`
 	NeedSources          map[string][]NeedSource `json:"need_sources,omitempty"`
+	NeedOutputs          map[string][]NeedOutput `json:"need_outputs,omitempty"`
 	// Needs is populated only from verified producer-attributed manifests at
 	// runtime. It is never accepted from or encoded into an immutable plan.
 	Needs                   map[string]Need      `json:"-"`
@@ -291,14 +302,17 @@ func Encode(job Job) ([]byte, error) {
 }
 
 func (job Job) Validate() error {
-	if job.Schema != SchemaV1 && job.Schema != SchemaV2 && job.Schema != SchemaV3 && job.Schema != SchemaV4 {
+	if job.Schema != SchemaV1 && job.Schema != SchemaV2 && job.Schema != SchemaV3 && job.Schema != SchemaV4 && job.Schema != SchemaV5 {
 		return fmt.Errorf("unsupported job plan schema %q", job.Schema)
 	}
-	if job.Schema != SchemaV3 && job.Schema != SchemaV4 && (len(job.Actions) != 0 || hasStepActions(job.Steps)) {
+	if job.Schema != SchemaV3 && job.Schema != SchemaV4 && job.Schema != SchemaV5 && (len(job.Actions) != 0 || hasStepActions(job.Steps)) {
 		return fmt.Errorf("job plan %s does not support action locks", job.Schema)
 	}
-	if job.Schema != SchemaV4 && (job.Container != nil || len(job.Services) != 0) {
+	if job.Schema != SchemaV4 && job.Schema != SchemaV5 && (job.Container != nil || len(job.Services) != 0) {
 		return fmt.Errorf("job plan %s does not support containers or services", job.Schema)
+	}
+	if job.Schema != SchemaV5 && job.NeedOutputs != nil {
+		return fmt.Errorf("job plan %s does not support prerequisite output projections", job.Schema)
 	}
 	if job.Compiler.Version == "" || !digestPattern.MatchString(job.Compiler.DistributionDigest) {
 		return fmt.Errorf("job plan compiler version and distribution digest are required")
@@ -418,6 +432,46 @@ func (job Job) Validate() error {
 	if len(sourcedDependencies) != len(dependencies) {
 		return fmt.Errorf("job plan dependencies and prerequisite producers differ")
 	}
+	needSourcesByName := make(map[string]map[string]struct{}, len(job.NeedSources))
+	for name, sources := range job.NeedSources {
+		steps := make(map[string]struct{}, len(sources))
+		for _, source := range sources {
+			steps[strings.ToLower(source.StepKey)] = struct{}{}
+		}
+		needSourcesByName[strings.ToLower(name)] = steps
+	}
+	projectedNeeds := make(map[string]struct{}, len(job.NeedOutputs))
+	for name, outputs := range job.NeedOutputs {
+		lowerName := strings.ToLower(name)
+		if _, exists := projectedNeeds[lowerName]; exists {
+			return fmt.Errorf("job plan contains duplicate prerequisite output projection %q", name)
+		}
+		projectedNeeds[lowerName] = struct{}{}
+		producers, exists := needSourcesByName[lowerName]
+		if !exists {
+			return fmt.Errorf("job plan prerequisite output projection %q has no matching prerequisite", name)
+		}
+		if len(outputs) > MaxNeedOutputs {
+			return fmt.Errorf("job plan prerequisite %q has more than %d projected outputs", name, MaxNeedOutputs)
+		}
+		seen := make(map[string]struct{}, len(outputs))
+		for i, output := range outputs {
+			if !targetPattern.MatchString(output.Name) || !targetPattern.MatchString(output.Output) || !targetPattern.MatchString(output.StepKey) {
+				return fmt.Errorf("job plan prerequisite %q has invalid output projection", name)
+			}
+			if _, exists := producers[strings.ToLower(output.StepKey)]; !exists {
+				return fmt.Errorf("job plan prerequisite %q output %q selects unknown producer %q", name, output.Name, output.StepKey)
+			}
+			if i > 0 && compareNeedOutput(outputs[i-1], output) >= 0 {
+				return fmt.Errorf("job plan prerequisite %q output projections must be unique and sorted", name)
+			}
+			key := strings.ToLower(output.Name) + "\x00" + strings.ToLower(output.StepKey)
+			if _, exists := seen[key]; exists {
+				return fmt.Errorf("job plan prerequisite %q repeats output projection %q from %q", name, output.Name, output.StepKey)
+			}
+			seen[key] = struct{}{}
+		}
+	}
 	if len(job.Steps) == 0 {
 		return fmt.Errorf("job plan contains no steps")
 	}
@@ -476,12 +530,22 @@ func (job Job) Validate() error {
 			return fmt.Errorf("step %q has unsupported kind %q", step.ID, step.Kind)
 		}
 	}
-	if job.Schema == SchemaV3 || job.Schema == SchemaV4 {
+	if job.Schema == SchemaV3 || job.Schema == SchemaV4 || (job.Schema == SchemaV5 && (len(job.Actions) != 0 || hasStepActions(job.Steps))) {
 		if err := validateActionLocks(job); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func compareNeedOutput(left, right NeedOutput) int {
+	if left.Name != right.Name {
+		return strings.Compare(left.Name, right.Name)
+	}
+	if left.StepKey != right.StepKey {
+		return strings.Compare(left.StepKey, right.StepKey)
+	}
+	return strings.Compare(left.Output, right.Output)
 }
 
 func validateContainer(image string, env map[string]string, ports []string) error {

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -546,6 +546,65 @@ func TestV4ContainerContractAndLegacyRejection(t *testing.T) {
 	}
 }
 
+func TestV5PrerequisiteOutputProjectionContractAndLegacyRejection(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("4", 64)
+	job := validJob()
+	job.Schema = SchemaV5
+	job.Dependencies = []string{"gha-delegated-first", "gha-delegated-second"}
+	job.NeedSources = map[string][]NeedSource{
+		"delegated": {
+			{StepKey: "gha-delegated-first", PlanDigest: digest},
+			{StepKey: "gha-delegated-second", PlanDigest: digest},
+		},
+	}
+	job.NeedOutputs = map[string][]NeedOutput{"delegated": {}}
+	job.Steps = []Step{{ID: "local", Kind: "uses", Uses: "./actions/build"}}
+	encoded, err := Encode(job)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Decode(encoded); err != nil {
+		t.Fatal(err)
+	}
+	schemaSource, err := os.ReadFile(filepath.Join("..", "..", "schemas", "job-plan-v5.schema.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var schemaDocument, planDocument any
+	if err := json.Unmarshal(schemaSource, &schemaDocument); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(encoded, &planDocument); err != nil {
+		t.Fatal(err)
+	}
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource(SchemaV5, schemaDocument); err != nil {
+		t.Fatal(err)
+	}
+	schema, err := compiler.Compile(SchemaV5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := schema.Validate(planDocument); err != nil {
+		t.Fatalf("v5 plan does not validate against schema: %v", err)
+	}
+
+	job.Steps = []Step{{ID: "step-1", Kind: "run", Command: "true"}}
+	job.NeedOutputs["delegated"] = []NeedOutput{{Name: "result", StepKey: "gha-delegated-first", Output: "internal"}}
+	if err := job.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	job.Schema = SchemaV4
+	if err := job.Validate(); err == nil || !strings.Contains(err.Error(), "does not support prerequisite output projections") {
+		t.Fatalf("Validate() error = %v, want legacy projection rejection", err)
+	}
+	job.Schema = SchemaV5
+	job.NeedOutputs["delegated"][0].StepKey = "gha-other"
+	if err := job.Validate(); err == nil || !strings.Contains(err.Error(), "selects unknown producer") {
+		t.Fatalf("Validate() error = %v, want producer binding rejection", err)
+	}
+}
+
 func TestContainerPortGrammarMatchesSchema(t *testing.T) {
 	schemaSource, err := os.ReadFile(filepath.Join("..", "..", "schemas", "job-plan-v4.schema.json"))
 	if err != nil {

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -305,7 +305,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 	var runErr error
 	prepared := remotePreparations{}
 	preStatus := remotePreparationStatus{}
-	if job.Schema == plan.SchemaV3 || job.Schema == plan.SchemaV4 {
+	if job.Schema == plan.SchemaV3 || job.Schema == plan.SchemaV4 || (job.Schema == plan.SchemaV5 && len(job.Actions) != 0) {
 		for stepIndex, step := range job.Steps {
 			if step.Kind != "uses" {
 				continue
@@ -978,7 +978,7 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 
 	var action metadata.Metadata
 	var actionLock *plan.ActionLock
-	if job.Schema == plan.SchemaV3 || job.Schema == plan.SchemaV4 {
+	if job.Schema == plan.SchemaV3 || job.Schema == plan.SchemaV4 || (job.Schema == plan.SchemaV5 && len(job.Actions) != 0) {
 		if step.Action == nil {
 			return result, fmt.Errorf("action %q has no immutable selector", step.Uses)
 		}

--- a/internal/runtime/needs.go
+++ b/internal/runtime/needs.go
@@ -17,7 +17,7 @@ const (
 
 // ResolveNeeds converts compiler-owned producer identities into the verified
 // logical results and outputs consumed by runtime expression contexts.
-func ResolveNeeds(ctx context.Context, agent transport.Agent, root, buildID string, sources map[string][]plan.NeedSource) (map[string]plan.Need, error) {
+func ResolveNeeds(ctx context.Context, agent transport.Agent, root, buildID string, sources map[string][]plan.NeedSource, outputs map[string][]plan.NeedOutput) (map[string]plan.Need, error) {
 	transportSources := make(map[string][]transport.ResultSource, len(sources))
 	for name, producers := range sources {
 		for _, producer := range producers {
@@ -26,7 +26,14 @@ func ResolveNeeds(ctx context.Context, agent transport.Agent, root, buildID stri
 			})
 		}
 	}
-	verified, err := transport.LoadNeeds(ctx, agent, root, buildID, transportSources)
+	projections := make(map[string][]transport.OutputProjection, len(outputs))
+	for name, selected := range outputs {
+		projections[name] = make([]transport.OutputProjection, len(selected))
+		for i, output := range selected {
+			projections[name][i] = transport.OutputProjection{Name: output.Name, StepKey: output.StepKey, Output: output.Output}
+		}
+	}
+	verified, err := transport.LoadNeeds(ctx, agent, root, buildID, transportSources, projections)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/transport/model.go
+++ b/internal/transport/model.go
@@ -21,7 +21,7 @@ const (
 	MaxResultOutputs       = 64
 	MaxResultOutputBytes   = 1024
 	MaxResultManifestBytes = 96 * 1024
-	MaxResultProducers     = 256
+	MaxResultProducers     = 1024
 
 	MaxResultArtifacts         = 64
 	MaxResultArtifactNameBytes = 255

--- a/internal/transport/results.go
+++ b/internal/transport/results.go
@@ -17,6 +17,15 @@ type ResultSource struct {
 	PlanDigest string
 }
 
+// OutputProjection selects one producer output for a caller-visible logical
+// need output. A present projection list, including an empty one, suppresses
+// passthrough of all other producer outputs.
+type OutputProjection struct {
+	Name    string
+	StepKey string
+	Output  string
+}
+
 // NeedResult is the verified runtime projection exposed to needs contexts.
 type NeedResult struct {
 	Result    string
@@ -165,7 +174,7 @@ func DownloadResult(ctx context.Context, agent Agent, root, buildID string, sour
 // LoadNeeds downloads every exact generated producer for each logical need and
 // returns only verified results and outputs. Conflicting matrix outputs fail
 // closed because Buildkite artifacts do not expose a trusted completion order.
-func LoadNeeds(ctx context.Context, agent Agent, root, buildID string, sources map[string][]ResultSource) (map[string]NeedResult, error) {
+func LoadNeeds(ctx context.Context, agent Agent, root, buildID string, sources map[string][]ResultSource, projections map[string][]OutputProjection) (map[string]NeedResult, error) {
 	if len(sources) > MaxResultProducers {
 		return nil, fmt.Errorf("result transport has %d logical needs, maximum is %d", len(sources), MaxResultProducers)
 	}
@@ -180,6 +189,20 @@ func LoadNeeds(ctx context.Context, agent Agent, root, buildID string, sources m
 		names = append(names, name)
 	}
 	sort.Strings(names)
+	projected := make(map[string][]OutputProjection, len(projections))
+	for name, outputs := range projections {
+		lower := strings.ToLower(name)
+		if _, exists := logicalNames[lower]; !exists {
+			return nil, fmt.Errorf("output projection %q has no logical need", name)
+		}
+		if _, exists := projected[lower]; exists {
+			return nil, fmt.Errorf("result transport repeats output projection %q", name)
+		}
+		if len(outputs) > MaxResultOutputs {
+			return nil, fmt.Errorf("logical need %q has more than %d output projections", name, MaxResultOutputs)
+		}
+		projected[lower] = append([]OutputProjection(nil), outputs...)
+	}
 	needs := make(map[string]NeedResult, len(sources))
 	for _, name := range names {
 		producers := append([]ResultSource(nil), sources[name]...)
@@ -189,6 +212,7 @@ func LoadNeeds(ctx context.Context, agent Agent, root, buildID string, sources m
 		sort.Slice(producers, func(i, j int) bool { return producers[i].StepKey < producers[j].StepKey })
 		need := NeedResult{Result: "skipped", Outputs: map[string]string{}}
 		outputNames := make(map[string]string)
+		manifests := make(map[string]ResultManifest, len(producers))
 		for i, producer := range producers {
 			if i > 0 && producers[i-1].StepKey == producer.StepKey {
 				return nil, fmt.Errorf("logical need %q repeats producer %q", name, producer.StepKey)
@@ -197,11 +221,15 @@ func LoadNeeds(ctx context.Context, agent Agent, root, buildID string, sources m
 			if err != nil {
 				return nil, fmt.Errorf("load logical need %q: %w", name, err)
 			}
+			manifests[strings.ToLower(producer.StepKey)] = manifest
 			need.Producers = append(need.Producers, manifest.Producer)
 			for _, artifact := range manifest.Artifacts {
 				need.Artifacts = append(need.Artifacts, NeedArtifact{Artifact: artifact, Producer: manifest.Producer})
 			}
 			need.Result = aggregateResult(need.Result, manifest.Result)
+			if _, isProjected := projected[strings.ToLower(name)]; isProjected {
+				continue
+			}
 			for _, output := range manifest.Outputs {
 				lower := strings.ToLower(output.Name)
 				if canonical, ok := outputNames[lower]; ok && need.Outputs[canonical] != output.Value {
@@ -217,9 +245,54 @@ func LoadNeeds(ctx context.Context, agent Agent, root, buildID string, sources m
 				need.Outputs[output.Name] = output.Value
 			}
 		}
+		if outputs, isProjected := projected[strings.ToLower(name)]; isProjected {
+			if err := projectNeedOutputs(name, outputs, manifests, need.Outputs); err != nil {
+				return nil, err
+			}
+		}
 		needs[name] = need
 	}
 	return needs, nil
+}
+
+func projectNeedOutputs(name string, projections []OutputProjection, manifests map[string]ResultManifest, outputs map[string]string) error {
+	projections = append([]OutputProjection(nil), projections...)
+	sort.Slice(projections, func(i, j int) bool {
+		if projections[i].Name != projections[j].Name {
+			return projections[i].Name < projections[j].Name
+		}
+		if projections[i].StepKey != projections[j].StepKey {
+			return projections[i].StepKey < projections[j].StepKey
+		}
+		return projections[i].Output < projections[j].Output
+	})
+	canonicalNames := make(map[string]string, len(projections))
+	for _, projection := range projections {
+		if !keyPattern.MatchString(projection.Name) || !keyPattern.MatchString(projection.StepKey) || !keyPattern.MatchString(projection.Output) {
+			return fmt.Errorf("logical need %q has invalid output projection", name)
+		}
+		manifest, exists := manifests[strings.ToLower(projection.StepKey)]
+		if !exists {
+			return fmt.Errorf("logical need %q output %q selects unknown producer %q", name, projection.Name, projection.StepKey)
+		}
+		value := ""
+		for _, output := range manifest.Outputs {
+			if strings.EqualFold(output.Name, projection.Output) {
+				value = output.Value
+				break
+			}
+		}
+		lower := strings.ToLower(projection.Name)
+		if canonical, exists := canonicalNames[lower]; exists {
+			if outputs[canonical] != value {
+				return fmt.Errorf("logical need %q has conflicting projected output %q without authoritative completion order", name, projection.Name)
+			}
+			continue
+		}
+		canonicalNames[lower] = projection.Name
+		outputs[projection.Name] = value
+	}
+	return nil
 }
 
 func aggregateResult(current, next string) string {

--- a/internal/transport/results_test.go
+++ b/internal/transport/results_test.go
@@ -132,7 +132,7 @@ func TestLoadNeedsMapsLogicalFanInToVerifiedProducers(t *testing.T) {
 			secondPath: mustManifest(t, resultManifest(testJobID2, second.StepKey, second.PlanDigest, "failure", Output{Name: "second", Value: "two"})),
 		},
 	}
-	needs, err := LoadNeeds(context.Background(), Agent{Runner: runner}, t.TempDir(), testBuildID, map[string][]ResultSource{"reusable.build": {second, first}})
+	needs, err := LoadNeeds(context.Background(), Agent{Runner: runner}, t.TempDir(), testBuildID, map[string][]ResultSource{"reusable.build": {second, first}}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -142,13 +142,29 @@ func TestLoadNeedsMapsLogicalFanInToVerifiedProducers(t *testing.T) {
 	if got := needs["reusable.build"].Artifacts[0]; got.Artifact != firstManifest.Artifacts[0] || got.Producer != firstManifest.Producer {
 		t.Fatalf("retained artifact authority = %#v", got)
 	}
+	projected, err := LoadNeeds(context.Background(), Agent{Runner: runner}, t.TempDir(), testBuildID, map[string][]ResultSource{"delegated": {second, first}}, map[string][]OutputProjection{"delegated": {}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if projected["delegated"].Result != "failure" || len(projected["delegated"].Outputs) != 0 || len(projected["delegated"].Producers) != 2 {
+		t.Fatalf("projected reusable need = %#v, want aggregate failure without internal outputs", projected["delegated"])
+	}
+	projected, err = LoadNeeds(context.Background(), Agent{Runner: runner}, t.TempDir(), testBuildID, map[string][]ResultSource{"delegated": {second, first}}, map[string][]OutputProjection{
+		"delegated": {{Name: "selected", StepKey: first.StepKey, Output: "first"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(projected["delegated"].Outputs, map[string]string{"selected": "one"}) {
+		t.Fatalf("selected reusable output = %#v", projected["delegated"].Outputs)
+	}
 
 	runner.dataByPath[secondPath] = mustManifest(t, resultManifest(testJobID2, second.StepKey, second.PlanDigest, "success", Output{Name: "first", Value: "different"}))
-	_, err = LoadNeeds(context.Background(), Agent{Runner: runner}, t.TempDir(), testBuildID, map[string][]ResultSource{"build": {first, second}})
+	_, err = LoadNeeds(context.Background(), Agent{Runner: runner}, t.TempDir(), testBuildID, map[string][]ResultSource{"build": {first, second}}, nil)
 	if err == nil || !strings.Contains(err.Error(), "conflicting matrix output") {
 		t.Fatalf("LoadNeeds() error = %v, want ambiguous matrix output rejection", err)
 	}
-	_, err = LoadNeeds(context.Background(), Agent{Runner: runner}, t.TempDir(), testBuildID, map[string][]ResultSource{"reusable/build": {first}})
+	_, err = LoadNeeds(context.Background(), Agent{Runner: runner}, t.TempDir(), testBuildID, map[string][]ResultSource{"reusable/build": {first}}, nil)
 	if err == nil || !strings.Contains(err.Error(), "has no valid producers") {
 		t.Fatalf("LoadNeeds() error = %v, want invalid logical need rejection", err)
 	}

--- a/schemas/job-plan-v5.schema.json
+++ b/schemas/job-plan-v5.schema.json
@@ -16,7 +16,7 @@
     "matrix": {"type": "object"},
     "vars": {"$ref": "#/$defs/stringMap"},
     "dependencies": {"type": "array", "items": {"$ref": "#/$defs/buildkiteName"}, "uniqueItems": true},
-    "need_sources": {"type": "object", "additionalProperties": {"type": "array", "minItems": 1, "maxItems": 256, "uniqueItems": true, "items": {"$ref": "#/$defs/needSource"}}},
+    "need_sources": {"type": "object", "additionalProperties": {"type": "array", "minItems": 1, "maxItems": 1024, "uniqueItems": true, "items": {"$ref": "#/$defs/needSource"}}},
     "need_outputs": {"type": "object", "additionalProperties": {"type": "array", "maxItems": 64, "items": {"$ref": "#/$defs/needOutput"}}},
     "env": {"$ref": "#/$defs/stringMap"},
     "condition": {"type": "string", "maxLength": 65536},

--- a/schemas/job-plan-v5.schema.json
+++ b/schemas/job-plan-v5.schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://buildkite.com/schemas/buildkite-gha/job-plan-v5.schema.json",
+  "title": "buildkite-gha job plan v5",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "compiler", "workflow", "event", "target", "required_capabilities", "steps"],
+  "properties": {
+    "schema": {"const": "https://buildkite.com/schemas/buildkite-gha/job-plan-v5.schema.json"},
+    "compiler": {"type": "object", "additionalProperties": false, "required": ["version", "distribution_digest"], "properties": {"version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$"}, "distribution_digest": {"$ref": "#/$defs/digest"}}},
+    "workflow": {"type": "object", "additionalProperties": false, "required": ["path", "digest", "logical_job_id"], "properties": {"path": {"type": "string", "minLength": 1, "maxLength": 1024}, "digest": {"$ref": "#/$defs/digest"}, "logical_job_id": {"type": "string", "minLength": 1, "maxLength": 255}}},
+    "event": {"type": "object", "additionalProperties": false, "required": ["provider", "name", "payload_digest"], "properties": {"provider": {"enum": ["github", "cursor-origin"]}, "name": {"type": "string", "pattern": "^[A-Za-z0-9_.-]+$", "maxLength": 128}, "payload_digest": {"$ref": "#/$defs/digest"}, "repository": {"type": "string", "maxLength": 512}, "ref": {"type": "string", "maxLength": 1024}, "sha": {"type": "string", "maxLength": 128}, "actor": {"type": "string", "maxLength": 256}}},
+    "target": {"type": "object", "additionalProperties": false, "required": ["step_key", "queue"], "properties": {"step_key": {"$ref": "#/$defs/buildkiteName"}, "queue": {"$ref": "#/$defs/buildkiteName"}}},
+    "required_capabilities": {"type": "array", "uniqueItems": true, "items": {"$ref": "#/$defs/capability"}, "maxItems": 16},
+    "required_secrets": {"type": "array", "items": {"type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"}, "uniqueItems": true, "maxItems": 128},
+    "matrix": {"type": "object"},
+    "vars": {"$ref": "#/$defs/stringMap"},
+    "dependencies": {"type": "array", "items": {"$ref": "#/$defs/buildkiteName"}, "uniqueItems": true},
+    "need_sources": {"type": "object", "additionalProperties": {"type": "array", "minItems": 1, "maxItems": 256, "uniqueItems": true, "items": {"$ref": "#/$defs/needSource"}}},
+    "need_outputs": {"type": "object", "additionalProperties": {"type": "array", "maxItems": 64, "items": {"$ref": "#/$defs/needOutput"}}},
+    "env": {"$ref": "#/$defs/stringMap"},
+    "condition": {"type": "string", "maxLength": 65536},
+    "timeout_minutes": {"type": "number", "exclusiveMinimum": 0, "maximum": 360},
+    "default_shell": {"type": "string"},
+    "default_working_directory": {"type": "string"},
+    "outputs": {"$ref": "#/$defs/stringMap"},
+    "steps": {"type": "array", "minItems": 1, "maxItems": 1000, "items": {"$ref": "#/$defs/step"}},
+    "actions": {"type": "array", "maxItems": 1024, "items": {"$ref": "#/$defs/actionLock"}},
+    "container": {"$ref": "#/$defs/container"},
+    "services": {"type": "object", "maxProperties": 32, "propertyNames": {"pattern": "^[a-z_][a-z0-9_-]{0,254}$"}, "additionalProperties": {"$ref": "#/$defs/container"}}
+  },
+  "$defs": {
+    "digest": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "buildkiteName": {"type": "string", "pattern": "^[A-Za-z0-9_-]+$", "minLength": 1, "maxLength": 255},
+    "capability": {"enum": ["network", "docker", "privileged-container", "secrets", "provider-token-read", "provider-token-write"]},
+    "stringMap": {"type": "object", "additionalProperties": {"type": "string"}},
+    "needSource": {"type": "object", "additionalProperties": false, "required": ["step_key", "plan_digest"], "properties": {"step_key": {"$ref": "#/$defs/buildkiteName"}, "plan_digest": {"$ref": "#/$defs/digest"}}},
+    "needOutput": {"type": "object", "additionalProperties": false, "required": ["name", "step_key", "output"], "properties": {"name": {"$ref": "#/$defs/buildkiteName"}, "step_key": {"$ref": "#/$defs/buildkiteName"}, "output": {"$ref": "#/$defs/buildkiteName"}}},
+    "position": {"type": "object", "additionalProperties": false, "required": ["line", "column"], "properties": {"line": {"type": "integer", "minimum": 0}, "column": {"type": "integer", "minimum": 0}}},
+    "span": {"type": "object", "additionalProperties": false, "required": ["start", "end"], "properties": {"start": {"$ref": "#/$defs/position"}, "end": {"$ref": "#/$defs/position"}}},
+    "selector": {"type": "object", "additionalProperties": false, "required": ["lock"], "properties": {"lock": {"type": "string", "pattern": "^a-[0-9a-f]{16}$"}}},
+    "path": {"type": "string", "minLength": 1, "maxLength": 1024, "pattern": "^[^/\\\\\\x00-\\x1f\\x7f]{1,255}(?:/[^/\\\\\\x00-\\x1f\\x7f]{1,255})*$", "not": {"pattern": "(^|/)\\.\\.?(/|$)"}},
+    "repository": {"type": "string", "maxLength": 140, "pattern": "^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?/[a-z0-9](?:[a-z0-9_.-]{0,98}[a-z0-9])?$"},
+    "actionLock": {
+      "type": "object", "additionalProperties": false,
+      "required": ["id", "source", "source_digest"],
+      "properties": {
+        "id": {"type": "string", "pattern": "^a-[0-9a-f]{16}$"}, "source": {"enum": ["workspace", "github"]},
+        "repository": {"$ref": "#/$defs/repository"}, "requested_ref": {"type": "string", "minLength": 1, "maxLength": 1024, "pattern": "^[^\\x00-\\x1f\\x7f]+$"},
+        "commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"}, "path": {"$ref": "#/$defs/path"}, "source_digest": {"$ref": "#/$defs/digest"},
+        "children": {"type": "object", "maxProperties": 1024, "propertyNames": {"minLength": 1, "maxLength": 2048, "pattern": "^[^\\x00-\\x1f\\x7f]+$"}, "additionalProperties": {"$ref": "#/$defs/selector"}}
+      },
+      "allOf": [
+        {"if": {"properties": {"source": {"const": "workspace"}}, "required": ["source"]}, "then": {"not": {"anyOf": [{"required": ["repository"]}, {"required": ["requested_ref"]}, {"required": ["commit"]}]}}},
+        {"if": {"properties": {"source": {"const": "github"}}, "required": ["source"]}, "then": {"required": ["repository", "requested_ref", "commit"]}}
+      ]
+    },
+    "container": {"type": "object", "additionalProperties": false, "required": ["image"], "properties": {"image": {"$ref": "#/$defs/image"}, "env": {"$ref": "#/$defs/containerEnv"}, "ports": {"type": "array", "maxItems": 128, "uniqueItems": true, "items": {"type": "string", "pattern": "^(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(?::(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]))?(?:/(?:tcp|udp))?$"}}}},
+    "containerEnv": {"type": "object", "maxProperties": 256, "propertyNames": {"pattern": "^[A-Za-z_][A-Za-z0-9_]{0,254}$"}, "additionalProperties": {"type": "string", "maxLength": 65536}},
+    "image": {"type": "string", "minLength": 1, "maxLength": 512, "pattern": "^[a-z0-9]+(?:[._-][a-z0-9]+)*(?:/[a-z0-9]+(?:[._-][a-z0-9]+)*)*(?::[A-Za-z0-9_][A-Za-z0-9_.-]{0,127})?(?:@sha256:[0-9a-f]{64})?$"},
+    "step": {
+      "type": "object", "additionalProperties": false, "required": ["id", "kind"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1, "maxLength": 255}, "name": {"type": "string"}, "kind": {"enum": ["run", "uses", "wait", "wait-all", "cancel"]}, "background": {"type": "boolean"},
+        "targets": {"type": "array", "minItems": 1, "maxItems": 256, "uniqueItems": true, "items": {"$ref": "#/$defs/buildkiteName"}},
+        "command": {"type": "string", "maxLength": 1048576}, "uses": {"type": "string", "maxLength": 1024}, "action": {"$ref": "#/$defs/selector"}, "shell": {"type": "string"}, "working_directory": {"type": "string"},
+        "env": {"$ref": "#/$defs/stringMap"}, "with": {"$ref": "#/$defs/stringMap"}, "condition": {"type": "string", "maxLength": 65536}, "continue_on_error": {"type": "boolean"}, "timeout_minutes": {"type": "number", "exclusiveMinimum": 0, "maximum": 360}, "source": {"$ref": "#/$defs/span"}
+      },
+      "allOf": [
+        {"if": {"properties": {"kind": {"const": "run"}}, "required": ["kind"]}, "then": {"required": ["command"], "not": {"anyOf": [{"required": ["uses"]}, {"required": ["targets"]}, {"required": ["action"]}]}}},
+        {"if": {"properties": {"kind": {"const": "uses"}}, "required": ["kind"]}, "then": {"required": ["uses"]}},
+        {"if": {"properties": {"kind": {"const": "wait"}}, "required": ["kind"]}, "then": {"required": ["targets"], "not": {"required": ["action"]}}},
+        {"if": {"properties": {"kind": {"const": "wait-all"}}, "required": ["kind"]}, "then": {"not": {"anyOf": [{"required": ["targets"]}, {"required": ["action"]}]}}},
+        {"if": {"properties": {"kind": {"const": "cancel"}}, "required": ["kind"]}, "then": {"required": ["targets"], "properties": {"targets": {"maxItems": 1}}, "not": {"required": ["action"]}}},
+        {"if": {"properties": {"kind": {"enum": ["wait", "wait-all", "cancel"]}}, "required": ["kind"]}, "then": {"not": {"anyOf": [{"required": ["background"]}, {"required": ["command"]}, {"required": ["uses"]}, {"required": ["shell"]}, {"required": ["working_directory"]}, {"required": ["env"]}, {"required": ["with"]}, {"required": ["condition"]}, {"required": ["continue_on_error"]}, {"required": ["timeout_minutes"]}, {"required": ["action"]}]}}}
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- preserve source-level local reusable-call names in downstream `needs` contexts
- aggregate `needs.<call>.result` from every exact, verified flattened callee job, including matrix and nested calls
- add a schema-v5 output-projection contract so call aliases and inherited caller prerequisites expose status without leaking internal outputs
- reject reusable-call `if:` conditions rather than silently discarding them

## Contract

This intentionally does **not** expose declared `on.workflow_call.outputs` yet. Reusable-call aliases carry an explicit empty output projection in this slice; parsing and projecting declared call outputs will follow separately.

Schema v5 composes with both compile-only unresolved action references and hosted immutable action locks. Ordinary non-reusable `needs` plans retain their existing schema and output passthrough behavior.

## Validation

- `mise run check`
