### PR TITLE
test: prove reusable workflow outputs end to end

### DIFF
--- a/testdata/poc/.github/workflows/advanced.yml
+++ b/testdata/poc/.github/workflows/advanced.yml
@@ -34,8 +34,10 @@ jobs:
         shell: bash
         env:
           CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
+          TESTED_PACKAGE: ${{ needs.quality.outputs.tested-package }}
         run: |
           test "$CACHE_HIT" != true
+          test "$TESTED_PACKAGE" = './internal/action/integration'
           mkdir -p migration-cache
           printf '%s\n' "$POC_CACHE_PAYLOAD" > migration-cache/payload.txt
 
@@ -104,7 +106,7 @@ jobs:
           {
             echo "## Advanced migration POC: $VARIANT"
             echo
-            echo 'Reusable workflow, cache, artifact, matrix, and annotation checks passed.'
+            echo 'Reusable workflow output, cache, artifact, matrix, and annotation checks passed.'
           } >> "$GITHUB_STEP_SUMMARY"
 
   poc-advanced:

--- a/testdata/poc/.github/workflows/reusable-quality.yml
+++ b/testdata/poc/.github/workflows/reusable-quality.yml
@@ -7,6 +7,10 @@ on:
         description: Go package to test
         required: true
         type: string
+    outputs:
+      tested-package:
+        description: Exact package covered by the reusable quality check
+        value: ${{ jobs.check.outputs.tested-package }}
 
 permissions:
   contents: read
@@ -16,6 +20,8 @@ jobs:
     name: Reusable package check
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    outputs:
+      tested-package: ${{ steps.package-test.outputs.tested-package }}
     steps:
       - name: Checkout the event commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -28,7 +34,10 @@ jobs:
           token: ""
 
       - name: Test requested package
+        id: package-test
         shell: bash
         env:
           PACKAGE: ${{ inputs.package }}
-        run: go test "$PACKAGE"
+        run: |
+          go test "$PACKAGE"
+          printf 'tested-package=%s\n' "$PACKAGE" >> "$GITHUB_OUTPUT"

--- a/testdata/poc/README.md
+++ b/testdata/poc/README.md
@@ -7,9 +7,9 @@ exact-commit Buildkite proof, rather than adding more phase-numbered probes:
   summary.
 - `artifacts.yml`: build, job outputs, a direct producer-to-consumer artifact
   handoff, and execution of the downloaded binary.
-- `advanced.yml`: a local reusable workflow, cache v6 miss/save/hit lifecycle,
-  `continue-on-error`, artifact handoff, matrix fan-out/fan-in, summaries, and
-  workflow-command annotations.
+- `advanced.yml`: a local reusable workflow with a caller-consumed declared
+  output, cache v6 miss/save/hit lifecycle, `continue-on-error`, artifact
+  handoff, matrix fan-out/fan-in, summaries, and workflow-command annotations.
 
 The suite stays within the `hosted-tokenless` admission profile. It does not
 imply support for secrets, job or service containers, remote reusable
@@ -46,6 +46,10 @@ the restored payload through the bounded artifact adapters to both matrix
 consumers. The successful workflow proves the summary and warning emission
 paths ran, while the dedicated Phase 6 fixtures retain the independent
 annotation-persistence observations.
+
+The declared reusable-workflow output assertion was added after build 290 and
+must receive a fresh exact-commit hosted run before it is recorded as runtime
+evidence for the current advanced fixture.
 
 The historical phase fixtures and their recorded observations remain the
 conformance ledger. The now-superseded targeted cache importer, continuation,

--- a/testdata/smoke/manifest.json
+++ b/testdata/smoke/manifest.json
@@ -59,9 +59,9 @@
       "id": "migration-poc-advanced",
       "workflow": "testdata/poc/.github/workflows/advanced.yml",
       "event": "testdata/smoke/events/push.json",
-      "expectation": "runtime-pass",
-      "evidence": "Exact-commit Buildkite build 290 passed the complete migration POC suite.",
-      "note": "At commit 379344599c0653990687d017bd195d416c7bc29c, the local reusable workflow, build-unique cache v6 miss/save/hit lifecycle, continue-on-error status interpolation, artifact transfer, and matrix fan-out and fan-in passed while the jobs emitted summaries and annotations; dedicated Phase 6 fixtures own independent annotation-persistence evidence.",
+      "expectation": "compile-pass",
+      "evidence": "Exact-commit Buildkite build 290 proved the prior advanced flow; the added declared reusable-workflow output assertion awaits a refreshed hosted run.",
+      "note": "The current fixture compiles the reusable quality job's declared tested-package output into the caller and requires the dependent cache producer to observe its exact value before continuing. Build 290 remains evidence for the cache, artifact, matrix, summary, and annotation paths at commit 379344599c0653990687d017bd195d416c7bc29c, but not for this additive output assertion.",
       "action_preflight": "hosted-tokenless"
     },
     {


### PR DESCRIPTION
## Summary

- publish an exact declared output from the reusable quality workflow
- consume and assert that output in the dependent advanced migration POC job
- mark the changed advanced fixture compile-pass until a fresh exact-commit hosted run succeeds

This extends the existing full migration demo rather than adding an isolated proof or a hard-coded job count. The flow now fails if reusable workflow output projection or hydration regresses.

## Validation

- `mise run check`