### PR TITLE
docs: record reusable output runtime proof

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -155,12 +155,13 @@ bk build create --pipeline buildkite/buildkite-gha \
   --env BUILDKITE_GHA_CACHE_URL=<cache-v2-results-origin> --yes
 ```
 
-[Buildkite build 290](https://buildkite.com/buildkite/buildkite-gha/builds/290)
+[Buildkite build 303](https://buildkite.com/buildkite/buildkite-gha/builds/303)
 passed all three workflows at exact commit
-`379344599c0653990687d017bd195d416c7bc29c`, including the build-unique cache
-miss, post-save, dependent exact hit, and subsequent artifact fan-out. The
-minimal `testdata/phase6` cache fixture remains compile-only conformance
-coverage; the migration POC owns the hosted runtime claim.
+`9d29bf26492be760016d29c7ba0d00033b4f9b39`, including declared reusable-output
+publication and caller consumption, the build-unique cache miss, post-save,
+dependent exact hit, and subsequent artifact fan-out. The minimal
+`testdata/phase6` cache fixture remains compile-only conformance coverage; the
+migration POC owns the hosted runtime claim.
 
 The phase definitions under `.buildkite/` and the [active
 plan](plans/2026-07-22-buildkite-gha.md#current-progress) document the exact

--- a/testdata/poc/README.md
+++ b/testdata/poc/README.md
@@ -38,18 +38,15 @@ repeatable.
 
 ## Recorded evidence
 
-[Buildkite build 290](https://buildkite.com/buildkite/buildkite-gha/builds/290)
+[Buildkite build 303](https://buildkite.com/buildkite/buildkite-gha/builds/303)
 passed all three POCs at exact commit
-`379344599c0653990687d017bd195d416c7bc29c`. The advanced workflow proved a
-build-unique cache miss, post-save, and dependent exact hit, then transferred
-the restored payload through the bounded artifact adapters to both matrix
-consumers. The successful workflow proves the summary and warning emission
-paths ran, while the dedicated Phase 6 fixtures retain the independent
-annotation-persistence observations.
-
-The declared reusable-workflow output assertion was added after build 290 and
-must receive a fresh exact-commit hosted run before it is recorded as runtime
-evidence for the current advanced fixture.
+`9d29bf26492be760016d29c7ba0d00033b4f9b39`. The advanced workflow proved its
+declared reusable-workflow output reached the caller with the exact expected
+value, followed by a build-unique cache miss, post-save, and dependent exact
+hit. It then transferred the restored payload through the bounded artifact
+adapters to both matrix consumers. The successful workflow proves the summary
+and warning emission paths ran, while the dedicated Phase 6 fixtures retain
+the independent annotation-persistence observations.
 
 The historical phase fixtures and their recorded observations remain the
 conformance ledger. The now-superseded targeted cache importer, continuation,

--- a/testdata/smoke/manifest.json
+++ b/testdata/smoke/manifest.json
@@ -59,9 +59,9 @@
       "id": "migration-poc-advanced",
       "workflow": "testdata/poc/.github/workflows/advanced.yml",
       "event": "testdata/smoke/events/push.json",
-      "expectation": "compile-pass",
-      "evidence": "Exact-commit Buildkite build 290 proved the prior advanced flow; the added declared reusable-workflow output assertion awaits a refreshed hosted run.",
-      "note": "The current fixture compiles the reusable quality job's declared tested-package output into the caller and requires the dependent cache producer to observe its exact value before continuing. Build 290 remains evidence for the cache, artifact, matrix, summary, and annotation paths at commit 379344599c0653990687d017bd195d416c7bc29c, but not for this additive output assertion.",
+      "expectation": "runtime-pass",
+      "evidence": "Exact-commit Buildkite build 303 passed the current advanced migration POC, including its caller-consumed declared reusable-workflow output.",
+      "note": "At commit 9d29bf26492be760016d29c7ba0d00033b4f9b39, the reusable quality job published tested-package through its workflow_call declaration and the dependent cache producer observed the exact expected value before the cache, artifact, matrix, summary, and annotation paths completed.",
       "action_preflight": "hosted-tokenless"
     },
     {
@@ -124,7 +124,7 @@
       "event": "testdata/smoke/events/push.json",
       "expectation": "compile-pass",
       "evidence": "Compiler and runtime conformance tests admit only the audited actions/cache v6.1.0 commit and execute its ESM pre/main/post lifecycle with isolated per-phase cache-v2 credentials.",
-      "note": "This minimal fixture remains compile-only conformance coverage. The migration-poc-advanced fixture owns the exact-commit hosted cache roundtrip evidence from Buildkite build 290.",
+      "note": "This minimal fixture remains compile-only conformance coverage. The migration-poc-advanced fixture owns the current exact-commit hosted cache roundtrip evidence from Buildkite build 303.",
       "action_preflight": "hosted-tokenless"
     },
     {


### PR DESCRIPTION
## Summary

- record exact-commit Buildkite build 303 as the current full migration POC proof
- promote the advanced fixture back to `runtime-pass`
- document that the reusable workflow's declared output reached the direct caller with the exact expected value before the cache/artifact flow completed

The `gha-cache-producer` log downloaded the `gha-quality-check` result manifest, passed the exact `needs.quality.outputs.tested-package` assertion, completed the build-unique cache miss/save lifecycle, and published its successful terminal manifest.

Proof: https://buildkite.com/buildkite/buildkite-gha/builds/303

## Validation

- `mise run smoke:local`
- `python3 -m json.tool testdata/smoke/manifest.json`
- `git diff --check`