### PR TITLE
docs: define Phase 6 capability grant boundary

### DIFF
--- a/docs/architecture/0003-protected-capability-control-plane.md
+++ b/docs/architecture/0003-protected-capability-control-plane.md
@@ -1,0 +1,298 @@
+# ADR 0003: Authenticate protected capability grants through a Buildkite control plane
+
+- Status: Proposed
+- Date: 2026-08-04
+- Decision owners: `buildkite-gha` and Buildkite platform maintainers
+
+## Context
+
+The service-free compatibility path can execute public, anonymous workflow code
+without giving it authority beyond its Buildkite job. Summaries, annotations,
+native artifact adapters, public exact-SHA checkout, and the audited
+`actions/cache` v6 client all use public Agent or explicitly configured
+cache-v2 interfaces. They do not establish authority for private source,
+secrets, provider tokens, environments, privileged queues, or compatible OIDC
+claims.
+
+A plan cannot authorize those protected values. Workflow and event files are
+compiler inputs, dynamic pipeline upload is ordinary pipeline authority, and
+the Phase 0 runtime binding proves integrity rather than provider provenance.
+The runtime needs a separate authorization result tied to both the actual
+Buildkite job and independently established provider facts.
+
+Buildkite Job OIDC supplies the job half of that identity. A running Agent can
+mint a short-lived token for an exact audience with immutable organization,
+pipeline, build, job, cluster, and queue identifiers. It does not prove the
+complete GitHub event, actor, fork relationship, workflow source, installation,
+or policy decision. A Buildkite-owned control plane must join those facts before
+issuing any grant.
+
+Phase 6 therefore starts the protected path with a signed **no-op grant**. It
+proves authentication, provenance, policy, signing, verification, expiry, and
+audit boundaries while carrying an empty capability set and returning no
+credential. Private source, secrets, GitHub tokens, environments, and
+compatibility OIDC remain deferred.
+
+## Decision
+
+### Ownership and trust domains
+
+The grant issuer is a Buildkite platform-owned control plane, not code running
+inside the requesting job and not the `buildkite-gha` compiler. The expected
+initial implementation belongs with the Buildkite service that owns build/job
+identity and GitHub provider events. A separately deployed service is acceptable
+only if it consumes equivalent authoritative interfaces and does not trust
+provider facts supplied by the CLI.
+
+This repository owns:
+
+- the versioned request and grant contracts;
+- the canonical event-snapshot serialization used to derive `event_digest`;
+- the client that obtains Job OIDC and requests a grant;
+- the runtime verifier and fail-closed capability intersection; and
+- conformance fixtures proving interoperability and rejection behavior.
+
+The control plane owns:
+
+- Buildkite OIDC verification and immutable job lookup;
+- provider-event provenance and event-to-build correlation;
+- organization, event, queue, environment, and permission policy;
+- grant signing, key rotation, revocation, and audit records; and
+- later credential brokering behind the same authorization decision.
+
+The control-plane signing key is a separate trust domain from Phase 0 probe
+keys, Buildkite pipeline-signing keys, cache tokens, and provider credentials.
+The concrete Phase 0 `RuntimeBinding` and its test key must not be treated as a
+grant or production trust root. Generic bounded JWS helpers may be extracted
+only if issuer, type, key configuration, and verification policy remain
+separate.
+
+### Job authentication
+
+The client obtains a fresh token with the Agent command equivalent to:
+
+```sh
+buildkite-agent oidc request-token \
+  --audience "$BUILDKITE_GHA_CONTROL_PLANE_URL" \
+  --claim organization_id,pipeline_id,build_id,cluster_id,queue_id,queue_key
+```
+
+`BUILDKITE_GHA_CONTROL_PLANE_URL` is one installer-owned, origin-only HTTPS
+service identifier. The client uses that same normalized origin as the OIDC
+audience and appends only the fixed request path. User information, non-root
+paths, queries, fragments, and redirects are rejected. The setting cannot be
+overridden by plan-, workflow-, repository-, or ordinary build-supplied
+environment. The client captures the token without logging it, keeps it in
+memory for one exchange, and sends it only to that bound service as the
+control-plane bearer credential. It never reads or forwards the ambient Agent
+access token to that service or to action code.
+
+The control plane validates the token against the fixed Buildkite issuer
+`https://agent.buildkite.com` and its configured discovery/JWKS endpoints. It
+requires the exact audience, signature, `nbf`, `iat`, `exp`, organization,
+pipeline, build, job, step, runner environment, cluster, and queue claims needed
+by policy. Missing required claims fail closed. Slugs and branch names are
+context only; immutable IDs are the authorization binding.
+
+### Grant request
+
+The initial endpoint accepts one bounded JSON request over HTTPS:
+
+```http
+POST /v1/capability-grants
+Authorization: Bearer <Buildkite Job OIDC token>
+Content-Type: application/json
+```
+
+```json
+{
+  "schema": "buildkite-gha/capability-request/v1",
+  "plan_digest": "sha256:<64 lowercase hex characters>",
+  "event_digest": "sha256:<64 lowercase hex characters>",
+  "requested_capabilities": []
+}
+```
+
+The request is size-bounded, rejects unknown fields and duplicate capability
+names, and requires a sorted capability list from the fixed plan vocabulary.
+It deliberately does not contain Buildkite IDs or provider identity claims as
+authoritative inputs. The service obtains Buildkite identity from verified
+OIDC and provider facts from its own event records or authenticated provider
+queries. Request fields only identify the inert plan and event snapshots to
+which the resulting decision must bind.
+
+The no-op proof requires `requested_capabilities` to be empty. Later revisions
+may request protected capabilities already declared by the exact plan, but
+cannot silently broaden this version's meaning.
+
+### Independent provider provenance
+
+For GitHub, the service joins the verified Buildkite build to an authenticated
+GitHub App webhook record or an equivalently authoritative provider record. At
+minimum, policy receives immutable installation, owner, repository, event or
+delivery, actor, ref, commit, and pull-request base/head/fork facts where they
+apply. Using this repository's versioned canonical event-snapshot contract, the
+service recomputes the digest from that authoritative record and requires it to
+match the inert request. The service treats `plan_digest` as an opaque binding;
+only the runtime has the plan bytes and verifies that binding against the
+decoded plan.
+
+Querying GitHub after the fact may supplement those records but cannot establish
+historical webhook facts that the API does not preserve. A provider event field
+copied from the plan, Buildkite environment, build message, or request body is
+never sufficient authorization evidence. If event-to-build correlation is
+absent or ambiguous, the service denies the request.
+
+Cursor Origin will implement the same provider contract with Origin-owned
+event and source identities. Its absence does not weaken or add fallbacks to
+the GitHub contract.
+
+### Policy decision
+
+The effective capability set is the intersection of:
+
+```text
+exact plan request
+∩ organization policy
+∩ authenticated provider-event policy
+∩ provider installation permissions
+∩ environment policy
+∩ Buildkite cluster and queue policy
+```
+
+The service records the policy version and a bounded decision reason. A no-op
+request still runs identity, provenance, and policy checks; an empty result is
+not permission to skip them. Unknown capabilities, an untrusted fork transition,
+a mismatched queue, an unattested event, or unavailable policy data is a denial.
+
+### Signed grant
+
+An allowed decision returns a standard three-part compact JWT signed with
+ES256. Its signature covers the exact transmitted protected-header and payload
+bytes; it has no detached payload and does not use Phase 0's JCS reconstruction
+or canonical-byte equality rule. Unknown top-level claims are rejected by this
+bounded versioned contract.
+
+The protected header fields are exactly `alg`, `kid`, and `typ`. `alg` is
+`ES256`; `typ` is
+`buildkite-gha-capability-grant+jwt`; and `kid` selects one immutable
+control-plane verification key. The token must not carry or honor `jku`, `x5u`,
+an embedded JWK, algorithm negotiation, or unrecognized critical headers.
+
+The signed claims contain:
+
+- schema, issuer, fixed runtime audience, unique grant ID, `iat`, `nbf`, and
+  `exp` with a bounded short lifetime;
+- immutable Buildkite organization, pipeline, build, job, cluster, and queue
+  IDs, plus the exact queue key, step key, and runner environment;
+- versioned provider provenance, including immutable repository/event identity,
+  ref, commit, actor and fork facts relevant to the event;
+- exact plan and canonical event digests;
+- the sorted, unique granted capability set; and
+- the policy version that produced the decision.
+
+The initial successful grant contains an empty capability set. It contains no
+secret, checkout credential, provider token, cache token, environment value, or
+credential URL.
+
+The issuer publishes an operator-configured JWKS over HTTPS. The same
+installer-owned control-plane configuration binds the request origin, Job OIDC
+audience, grant issuer, fixed runtime audience, and JWKS location outside the
+plan. Rotation overlaps old and new public keys for the maximum grant lifetime;
+emergency revocation takes precedence over a still-published key. Private keys
+remain in the platform signing boundary.
+
+### Runtime verification and capability use
+
+The runtime treats the response as inert bytes until all of these checks pass:
+
+1. Bound response size and structural depth.
+2. Validate the protected header and select a configured, non-revoked key.
+3. Verify the JWS signature before using any claim in routing or diagnostics.
+4. Validate schema, issuer, audience, ID, time window, and capability vocabulary.
+5. Match every Buildkite claim exposed through immutable current-job context,
+   including build/job identity, step key, and queue key. IDs that are present
+   only in verified Job OIDC are enforced by the control plane and retained in
+   the signed grant for audit and later platform-supported runtime comparison.
+6. Match the plan and event digests to the exact decoded plan.
+7. Require the granted set to be a subset of the plan request and current local
+   runtime policy.
+8. Resolve only the intersection of plan request, signed grant, and local
+   policy, at the point where a protected value is needed.
+
+For the no-op slice, the runtime verifies and discards the empty grant. It must
+not initialize a secret resolver, change queue admission, enable private action
+resolution, expose a token to child processes, or broaden the plan's capability
+ceiling. Public tokenless jobs do not contact the control plane unless running
+the explicit proof; service absence cannot regress their existing path.
+
+Every malformed, expired, mismatched, broadened, untrusted, unavailable, or
+ambiguous result fails before workflow execution obtains a protected value.
+There is no unsigned fallback and no fallback to plan-declared provenance.
+
+### Audit and observability
+
+The control plane writes one bounded audit record for every decision containing
+the authenticated Buildkite IDs, provider event ID, plan and event digests,
+requested and granted capability names, policy version, grant ID, outcome, and
+bounded reason code. It does not record bearer tokens or future returned
+credentials.
+
+The client emits bounded reason codes without response bodies or
+attacker-controlled identity strings. Hosted proof requires an independent
+read-only observation of both the generated job and its corresponding audit
+record; a successful job alone does not prove policy or audit behavior.
+
+## Initial implementation sequence
+
+1. Finalize the request/grant schemas and platform endpoint ownership.
+2. Implement the platform verifier for Buildkite OIDC and authoritative GitHub
+   event-to-build correlation.
+3. Implement empty-request policy, signed empty grants, JWKS publication, and
+   audit records without any credential backend.
+4. Add the `buildkite-gha` OIDC client and grant verifier behind explicit
+   control-plane configuration.
+5. Add positive and negative conformance fixtures for signature, audience,
+   expiry, build/job/step/queue, plan/event digest, provider event, policy,
+   capability broadening, key rotation, revocation, and service absence.
+6. Run one exact-commit hosted no-op proof and independently observe its audit
+   binding before considering any credential-returning slice.
+
+## Deferred decisions
+
+This ADR does not authorize or choose storage for private checkout, private
+actions, reusable workflow source, selected secrets, `GITHUB_TOKEN`, environment
+grants, or compatibility OIDC claims. It does not choose a secret manager,
+GitHub App permission set, customer policy language, administrative UI, or
+production service hostname. Those decisions require separate reviewed slices
+after the no-op boundary is proven.
+
+The existing cache-v2 GHAC token exchange remains separate. Cache tokens are
+minted through the current Buildkite job, scoped by the cache service, and
+exposed only to the audited cache action lifecycle. A capability grant neither
+contains nor replaces them.
+
+## Consequences
+
+- Public tokenless workflows retain no new service dependency.
+- The first protected-path milestone can prove the security boundary without
+  risking a real credential.
+- Provider provenance and policy must exist in a Buildkite-owned service before
+  private compatibility features can ship.
+- The CLI gains a small client and verifier, while signing keys, provider
+  records, and audit state remain outside workflow-controlled execution.
+- Phase 0 signing code may yield generic cryptographic helpers, but its concrete
+  keys, issuer, claims, and capability ceiling remain non-authorizing.
+- A full Phase 6 implementation now explicitly spans this repository and a
+  Buildkite platform service; repository-local code alone cannot satisfy it.
+
+## References checked
+
+- [Buildkite Agent OIDC](https://buildkite.com/docs/agent/cli/reference/oidc),
+  checked 2026-08-04
+- [Buildkite OIDC security guidance](https://buildkite.com/docs/pipelines/security/oidc),
+  checked 2026-08-04
+- [OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html)
+- [RFC 7515: JSON Web Signature](https://www.rfc-editor.org/rfc/rfc7515)
+- [RFC 7519: JSON Web Token](https://www.rfc-editor.org/rfc/rfc7519)
+- [ADR 0002: Phase 0 plan-envelope trust experiment](0002-plan-envelope-trust-boundary.md)

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -1917,8 +1917,9 @@ Delivery slices:
 
 Status: the GitHub/tokenless portion of slice 1 and all of slice 2 are
 implemented and hosted-proven. Cursor Origin public checkout remains pending on
-its provider context/source contract. Slice 3 is next and must establish the
-control-plane ownership, exact OIDC audience, independent GitHub provenance,
+its provider context/source contract. Slice 3 is next; its proposed
+[control-plane contract](../architecture/0003-protected-capability-control-plane.md)
+must establish ownership, exact OIDC audience, independent GitHub provenance,
 policy, signing, and audit boundaries before any protected value is returned.
 Slices 4–6 remain long-term Phase 6 scope but are explicitly deferred from the
 initial beta.


### PR DESCRIPTION
## Summary

- propose the cross-repository trust contract for Phase 6 protected capabilities
- keep the Buildkite-owned control plane responsible for Job OIDC verification, independent GitHub provenance, policy, signing, and audit
- define a signed empty-capability grant as the first proof, returning no credential
- bind the request endpoint and OIDC audience to one installer-owned HTTPS origin
- use standard compact ES256 JWTs, explicitly separate from Phase 0 signing and cache credentials
- keep public tokenless workflows independent of control-plane availability

The ADR deliberately stops before private checkout, secrets, GitHub tokens, environments, or compatibility OIDC. Those remain separate reviewed slices after the no-op boundary is proven.

## Platform confirmations needed

- which Buildkite service/repository owns the endpoint
- whether authoritative GitHub webhook records can be joined to builds with enough fidelity to reproduce the canonical event snapshot
- how the corresponding audit record will be queried for independent hosted proof
- which immutable cluster/queue IDs are observable inside the runtime versus enforceable only during control-plane OIDC verification

## Validation

- `git diff --cached --check`
- current Buildkite Agent OIDC command and optional claims checked against the official docs and `buildkite/agent` source
- independent security-boundary review applied before opening