### PR TITLE
test: add released plugin demo

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -70,6 +70,21 @@ steps:
     if: build.env("POC_SUITE") == "migration"
     command: "buildkite-agent pipeline upload .buildkite/migration-poc.yml"
 
+  - label: ":github: Load released plugin demo"
+    key: "plugin-demo-loader"
+    if: build.env("DEMO_SUITE") == "plugin"
+    command: |
+      set -euo pipefail
+      commit="$${DEMO_COMMIT:?DEMO_COMMIT is required}"
+      [[ "$$commit" =~ ^[0-9a-f]{40}$$ ]]
+      if [[ "$${DEMO_CACHE:-}" == "1" ]]; then
+        : "$${BUILDKITE_GHA_CACHE_URL:?BUILDKITE_GHA_CACHE_URL is required when DEMO_CACHE=1}"
+      fi
+      scripts/phase-0-shell-oracle-checkout "$$commit"
+      test "$${BUILDKITE_COMMIT:?BUILDKITE_COMMIT is required}" = "$$commit"
+      test -z "$$(git status --porcelain --untracked-files=all)"
+      buildkite-agent pipeline upload .buildkite/plugin-demo.yml
+
   - label: ":pipeline: Load consolidated hosted smoke proof"
     key: "hosted-smoke-loader"
     if: build.env("SMOKE_PROBE") == "hosted"

--- a/.buildkite/plugin-demo.yml
+++ b/.buildkite/plugin-demo.yml
@@ -1,0 +1,70 @@
+agents:
+  queue: "hosted"
+
+steps:
+  - label: ":test_tube: Basic released-plugin demo"
+    key: "plugin-demo-basic-importer"
+    timeout_in_minutes: 15
+    retry:
+      automatic: false
+    plugins:
+      - github-actions#aca805f6eb2965201d4edaa57f3eec8ef9ea7ccb:
+          workflow: testdata/poc/.github/workflows/basic.yml
+          version: "0.2.0"
+
+  - label: ":package: Artifact released-plugin demo"
+    key: "plugin-demo-artifact-importer"
+    timeout_in_minutes: 15
+    retry:
+      automatic: false
+    plugins:
+      - github-actions#aca805f6eb2965201d4edaa57f3eec8ef9ea7ccb:
+          workflow: testdata/poc/.github/workflows/artifacts.yml
+          version: "0.2.0"
+
+  - label: ":javascript: Actions released-plugin demo"
+    key: "plugin-demo-actions-importer"
+    timeout_in_minutes: 15
+    retry:
+      automatic: false
+    plugins:
+      - github-actions#aca805f6eb2965201d4edaa57f3eec8ef9ea7ccb:
+          workflow: .github/workflows/phase-4-actions-oracle.yml
+          version: "0.2.0"
+
+  - label: ":rocket: Advanced released-plugin demo"
+    key: "plugin-demo-advanced-importer"
+    timeout_in_minutes: 15
+    retry:
+      automatic: false
+    plugins:
+      - github-actions#aca805f6eb2965201d4edaa57f3eec8ef9ea7ccb:
+          workflow: testdata/poc/.github/workflows/advanced.yml
+          version: "0.2.0"
+
+  - label: ":white_check_mark: Service-free plugin demo complete"
+    key: "plugin-demo-service-free-terminal"
+    depends_on:
+      - "plugin-demo-basic-importer"
+      - "plugin-demo-artifact-importer"
+      - "plugin-demo-actions-importer"
+      - "plugin-demo-advanced-importer"
+    command: "echo 'The released plugin and CLI completed all service-free workflows.'"
+
+  - label: ":package: Cache released-plugin demo"
+    key: "plugin-demo-cache-importer"
+    if: build.env("DEMO_CACHE") == "1"
+    timeout_in_minutes: 15
+    retry:
+      automatic: false
+    plugins:
+      - github-actions#aca805f6eb2965201d4edaa57f3eec8ef9ea7ccb:
+          workflow: testdata/poc/.github/workflows/cache.yml
+          version: "0.2.0"
+
+  - label: ":white_check_mark: Cache plugin demo complete"
+    key: "plugin-demo-cache-terminal"
+    if: build.env("DEMO_CACHE") == "1"
+    depends_on:
+      - "plugin-demo-cache-importer"
+    command: "echo 'The released plugin and CLI completed the cache extension.'"

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -45,7 +45,7 @@ provide.
 | Workflow commands | Supported subset | `::add-mask`, `::stop-commands`, `::warning`, and `::error` are supported. Warnings and errors retain title/file/range metadata and publish under separate, stable job-scoped contexts without changing step or job conclusions. Each aggregate is bounded to 1 MiB and requires Buildkite Agent v3.112 or newer for publication. `::notice`, groups, command echo control, and legacy commands are not supported. |
 | `actions/upload-artifact` | Narrow support | The audited v4 commit supports bounded literal files/directories, ZIP compression levels, hidden-file selection, exact no-file behavior, and native Buildkite publication. See the explicit limits below. |
 | `actions/download-artifact` | Narrow support | The audited v4.3.0 commit supports one exact literal name from verified direct `needs`, extracting directly to a clean workspace-relative path. |
-| `actions/cache` | Narrow v6 support | Only the audited v6.1.0 commit is admitted. It runs the stock ESM cache-v2 client with job-bound Buildkite credentials and requires an operator-configured compatible Results service. The current exact miss/save/dependent-hit lifecycle passed in Buildkite build 303. |
+| `actions/cache` | Narrow v6 support | Only the audited v6.1.0 commit is admitted. It runs the stock ESM cache-v2 client with job-bound Buildkite credentials and requires an operator-configured compatible Results service. The predecessor fixture's exact miss/save/dependent-hit lifecycle passed in Buildkite build 303. |
 | Job and service containers | Not admitted | Implemented and runtime-proven, but still outside production `hosted-tokenless` policy. |
 | `docker://` actions | Not supported | Private images, credentials, arbitrary options, volumes, and privileged containers are also rejected. |
 | Other cache clients and broad artifact modes | Not supported | `actions/cache` v4/v5 and unrecognized v6 commits, artifact merge, IDs, patterns, all-artifact, cross-repository, and cross-run modes fail admission or input validation. |
@@ -195,12 +195,12 @@ disabled minting, malformed responses, redirects, or failed redaction stop the
 cache action before its JavaScript executes.
 
 This implemented and admitted contract has hosted runtime evidence. The
-advanced migration POC in [Buildkite build 303](https://buildkite.com/buildkite/buildkite-gha/builds/303)
+then-combined advanced migration POC in [Buildkite build 303](https://buildkite.com/buildkite/buildkite-gha/builds/303)
 demonstrated a build-unique miss, post-action save, and direct dependent exact
 hit at implementation commit
 `9d29bf26492be760016d29c7ba0d00033b4f9b39`. The minimal Phase 6 cache fixture
-remains compile-only conformance coverage; the migration POC owns the runtime
-claim.
+remains compile-only conformance coverage. The stable released-plugin cache
+extension also remains compile/admission-only until its exact-commit hosted run.
 
 ### Failures stay explicit
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -142,26 +142,55 @@ producer and both consumer matrix jobs to pass, checks all three terminal
 manifests, and confirms both consumers observed the exact payload and compatible
 absolute `download-path` output.
 
-The migration POC suite covers basic CI, artifact transfer, and the cache v6
-roundtrip without adding another phase-specific proof. Run it with an exact
-commit and the operator-configured cache-v2 Results origin:
+The pre-release migration POC covers basic CI, artifact transfer, and the
+advanced service-free workflow without adding another phase-specific proof. It
+builds the exact checked-out source locally, so it is runtime evidence rather
+than installation evidence:
 
 ```sh
 commit=$(git rev-parse HEAD)
 test ${#commit} -eq 40
 bk build create --pipeline buildkite/buildkite-gha \
   --branch "$(git branch --show-current)" --commit "$commit" \
-  --env POC_SUITE=migration --env POC_COMMIT="$commit" \
-  --env BUILDKITE_GHA_CACHE_URL=<cache-v2-results-origin> --yes
+  --env POC_SUITE=migration --env POC_COMMIT="$commit" --yes
 ```
 
 [Buildkite build 303](https://buildkite.com/buildkite/buildkite-gha/builds/303)
-passed all three workflows at exact commit
+passed the predecessor three-workflow suite at exact commit
 `9d29bf26492be760016d29c7ba0d00033b4f9b39`, including declared reusable-output
 publication and caller consumption, the build-unique cache miss, post-save,
-dependent exact hit, and subsequent artifact fan-out. The minimal
-`testdata/phase6` cache fixture remains compile-only conformance coverage; the
-migration POC owns the hosted runtime claim.
+dependent exact hit, and subsequent artifact fan-out. The revised stable
+service-free and cache fixtures retain compile/admission coverage but await
+exact-commit hosted evidence through the released plugin.
+
+After CLI `v0.2.0` is published from the exact commit, exercise the complete
+customer installation path through the pinned companion plugin:
+
+```sh
+commit=$(git rev-parse HEAD)
+test ${#commit} -eq 40
+bk build create --pipeline buildkite/buildkite-gha \
+  --branch "$(git branch --show-current)" --commit "$commit" \
+  --env DEMO_SUITE=plugin --env DEMO_COMMIT="$commit" --yes
+```
+
+This service-free lane runs the basic, artifact, root-level JavaScript/composite
+action, and advanced workflows, then a native terminal step. Add the cache
+extension only for an organization with GHAC token minting enabled and an
+explicitly configured compatible origin:
+
+```sh
+bk build create --pipeline buildkite/buildkite-gha \
+  --branch "$(git branch --show-current)" --commit "$commit" \
+  --env DEMO_SUITE=plugin --env DEMO_COMMIT="$commit" \
+  --env DEMO_CACHE=1 \
+  --env BUILDKITE_GHA_CACHE_URL=<cache-v2-results-origin> --yes
+```
+
+The first cache run for the release commit must show a producer miss,
+post-save, and direct-dependent exact hit. The plugin demo is intentionally
+dormant before `v0.2.0` exists: it downloads and checksum-verifies the public
+release rather than falling back to a local binary.
 
 The phase definitions under `.buildkite/` and the [active
 plan](plans/2026-07-22-buildkite-gha.md#current-progress) document the exact

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -1339,14 +1339,16 @@ Cursor Origin public checkout remains a separate provider integration gate.
   the three cache-v2 variables only to the verified cache action. The ambient
   Agent job token never enters action code or plan/result state. Older majors,
   other commits, unsafe mint responses, redirects, missing service
-  configuration, and redaction failure all fail closed. The advanced migration
-  POC forms the exact-commit hosted proof: it requires a build-unique exact-key
-  miss, creates a deterministic payload, saves through the registered post
-  action, and requires a direct dependent to restore an exact hit and verify
-  the payload digest. Buildkite build 303 passed the current lifecycle at exact
-  merged commit `9d29bf26492be760016d29c7ba0d00033b4f9b39`. The
-  minimal Phase 6 cache fixture remains `compile-pass` conformance coverage;
-  the separately dispatched migration POC owns the hosted runtime claim.
+  configuration, and redaction failure all fail closed. The then-combined
+  advanced migration POC forms the exact-commit implementation proof: it
+  required a build-unique exact-key miss, created a deterministic payload,
+  saved through the registered post action, and required a direct dependent to
+  restore an exact hit and verify the payload digest. Buildkite build 303 passed
+  that lifecycle at exact merged commit
+  `9d29bf26492be760016d29c7ba0d00033b4f9b39`. The minimal Phase 6 cache fixture
+  remains `compile-pass` conformance coverage. The stable cache extension now
+  awaits its exact-commit released-plugin run before receiving its own
+  `runtime-pass` classification.
   Together these results complete the GitHub/tokenless portion of delivery
   slice 1 and delivery slice 2. Cursor Origin public checkout still requires a
   provider context/source contract. Delivery slice 3—the OIDC-authenticated,
@@ -1417,19 +1419,19 @@ Cursor Origin public checkout remains a separate provider integration gate.
   --format text|json <workflow>`. Expected-negative fixtures preserve current
   boundaries: unsupported cache commits, artifact merge and broad download
   modes, and unsupported artifact commits are denied admission or input
-  validation. The exact cache v6.1.0 fixture is admitted, and the advanced
-  migration POC passed its hosted miss, post-save, and dependent exact-hit
-  lifecycle in Buildkite build 303. Job and service containers compile to
-  schema-v4 plans and have hosted runtime evidence, while production admission
-  rejects their container provenance.
+  validation. The exact cache v6.1.0 fixture is admitted, and the predecessor
+  advanced migration POC passed its hosted miss, post-save, and dependent
+  exact-hit lifecycle in Buildkite build 303. Job and service containers
+  compile to schema-v4 plans and have hosted runtime evidence, while production
+  admission rejects their container provenance.
 - A consolidated exact-commit hosted dispatcher is available with
   `SMOKE_PROBE=hosted` and `SMOKE_COMMIT=<full commit>`. It aggregates the
   Phase 2 shell/upload, Phase 3 concurrent, Phase 4 public-action, Phase 5
   hosted-Docker capability, Phase 5 Dockerfile-action, and Phase 5 complete
   container-runtime proofs, plus the Phase 6 job-summary, workflow-command,
-  upload-artifact, and artifact-roundtrip proofs. Cache runtime coverage now
-  belongs to the separately dispatched migration POC suite, and its obsolete
-  targeted Phase 6 cache importer was removed. The historical aggregate uploads
+  upload-artifact, and artifact-roundtrip proofs. The next cache runtime claim
+  belongs to the optional released-plugin demo extension; its obsolete targeted
+  Phase 6 cache importer remains removed. The historical aggregate uploads
   each included importer and continuation independently, then settles their
   generated and native terminal steps; it does not flatten the
   importer/continuation topology. Existing `PHASE2_PROBE`,
@@ -1554,12 +1556,12 @@ Phase 6 evidence:
   fixture remains as compile-only conformance coverage.
 - [Buildkite build 303](https://buildkite.com/buildkite/buildkite-gha/builds/303)
   ran exact merged commit `9d29bf26492be760016d29c7ba0d00033b4f9b39`
-  and passed the current three-workflow migration POC suite. The advanced cache
-  producer hydrated the reusable quality job's verified result manifest,
+  and passed the then-current three-workflow migration POC suite. The advanced
+  cache producer hydrated the reusable quality job's verified result manifest,
   required the exact declared `tested-package` output before creating its
   payload, then completed the build-unique cache miss, post-save, dependent hit,
-  and artifact fan-out. This is the current hosted runtime claim; build 290
-  remains the original cache implementation proof.
+  and artifact fan-out. This remains hosted implementation evidence for the
+  cache lifecycle; build 290 remains the original cache implementation proof.
 
 Phase 2 live evidence:
 
@@ -2064,8 +2066,10 @@ Start with `testdata/smoke` rather than an external workflow catalog:
 - `testdata/phase6/.github/workflows/cache-v6.yml` preserves the exact audited
   cache-v2 admission contract and the targeted build-unique miss, post-save,
   and dependent exact-hit shape as compile-only conformance coverage. The
-  advanced migration POC owns current hosted runtime evidence from Buildkite
-  build 303; build 290 remains the original implementation proof.
+  predecessor advanced migration POC retains hosted implementation evidence
+  from Buildkite build 303; the stable released-plugin cache extension awaits
+  its own exact-commit proof, and build 290 remains the original implementation
+  proof.
 
 The fixture owns its event input, local actions, and expected observations. All
 external actions use immutable commits. Add narrow repository-owned regression

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -341,6 +341,24 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 	if got := steps["migration-poc-loader"]; got.command != "buildkite-agent pipeline upload .buildkite/migration-poc.yml" || got.condition != `build.env("POC_SUITE") == "migration"` {
 		t.Fatalf("migration POC loader = %#v", got)
 	}
+	pluginDemo := steps["plugin-demo-loader"]
+	if pluginDemo.condition != `build.env("DEMO_SUITE") == "plugin"` {
+		t.Fatalf("released plugin demo loader = %#v", pluginDemo)
+	}
+	for _, required := range []string{
+		`commit="$${DEMO_COMMIT:?DEMO_COMMIT is required}"`,
+		`[[ "$$commit" =~ ^[0-9a-f]{40}$$ ]]`,
+		`[[ "$${DEMO_CACHE:-}" == "1" ]]`,
+		`$${BUILDKITE_GHA_CACHE_URL:?BUILDKITE_GHA_CACHE_URL is required when DEMO_CACHE=1}`,
+		`scripts/phase-0-shell-oracle-checkout "$$commit"`,
+		`test "$${BUILDKITE_COMMIT:?BUILDKITE_COMMIT is required}" = "$$commit"`,
+		`git status --porcelain --untracked-files=all`,
+		`buildkite-agent pipeline upload .buildkite/plugin-demo.yml`,
+	} {
+		if !strings.Contains(pluginDemo.command, required) {
+			t.Fatalf("released plugin demo loader lacks %q:\n%s", required, pluginDemo.command)
+		}
+	}
 	if got := steps["publish-release"]; got.command != "mise exec -- scripts/ci-buildkite-release" || got.condition != "build.tag != null" {
 		t.Fatalf("release publisher = %#v", got)
 	}
@@ -412,6 +430,139 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 	}
 	if strings.Contains(hosted.command, "--replace") {
 		t.Fatalf("hosted smoke loader uses replacement upload:\n%s", hosted.command)
+	}
+}
+
+func TestProductionPluginDemoContract(t *testing.T) {
+	root := filepath.Join("..", "..")
+	source, err := os.ReadFile(filepath.Join(root, ".buildkite", "plugin-demo.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	const plugin = "github-actions#aca805f6eb2965201d4edaa57f3eec8ef9ea7ccb"
+	type pluginConfig struct {
+		Workflow string `yaml:"workflow"`
+		Version  string `yaml:"version"`
+	}
+	var document struct {
+		Agents struct {
+			Queue string `yaml:"queue"`
+		} `yaml:"agents"`
+		Steps []struct {
+			Key              string                    `yaml:"key"`
+			If               string                    `yaml:"if"`
+			Command          string                    `yaml:"command"`
+			TimeoutInMinutes int                       `yaml:"timeout_in_minutes"`
+			DependsOn        []string                  `yaml:"depends_on"`
+			Plugins          []map[string]pluginConfig `yaml:"plugins"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(source, &document); err != nil {
+		t.Fatalf("parse released plugin demo: %v", err)
+	}
+	if document.Agents.Queue != "hosted" || len(document.Steps) != 7 {
+		t.Fatalf("released plugin demo structure = queue %q, steps %#v", document.Agents.Queue, document.Steps)
+	}
+	steps := make(map[string]struct {
+		condition    string
+		command      string
+		timeout      int
+		dependencies []string
+		plugins      []map[string]pluginConfig
+	}, len(document.Steps))
+	for _, step := range document.Steps {
+		if _, exists := steps[step.Key]; step.Key == "" || exists {
+			t.Fatalf("invalid or duplicate released plugin demo key %q", step.Key)
+		}
+		steps[step.Key] = struct {
+			condition    string
+			command      string
+			timeout      int
+			dependencies []string
+			plugins      []map[string]pluginConfig
+		}{step.If, step.Command, step.TimeoutInMinutes, step.DependsOn, step.Plugins}
+	}
+	importers := map[string]string{
+		"plugin-demo-basic-importer":    "testdata/poc/.github/workflows/basic.yml",
+		"plugin-demo-artifact-importer": "testdata/poc/.github/workflows/artifacts.yml",
+		"plugin-demo-actions-importer":  ".github/workflows/phase-4-actions-oracle.yml",
+		"plugin-demo-advanced-importer": "testdata/poc/.github/workflows/advanced.yml",
+		"plugin-demo-cache-importer":    "testdata/poc/.github/workflows/cache.yml",
+	}
+	for key, workflow := range importers {
+		step := steps[key]
+		if step.command != "" || step.timeout != 15 || len(step.plugins) != 1 || len(step.plugins[0]) != 1 {
+			t.Fatalf("released plugin importer %q = %#v", key, step)
+		}
+		config, exists := step.plugins[0][plugin]
+		if !exists || config.Workflow != workflow || config.Version != "0.2.0" {
+			t.Fatalf("released plugin importer %q config = %#v", key, step.plugins)
+		}
+		wantCondition := ""
+		if key == "plugin-demo-cache-importer" {
+			wantCondition = `build.env("DEMO_CACHE") == "1"`
+		}
+		if step.condition != wantCondition {
+			t.Fatalf("released plugin importer %q condition = %q, want %q", key, step.condition, wantCondition)
+		}
+	}
+	serviceTerminal := steps["plugin-demo-service-free-terminal"]
+	wantServiceDependencies := map[string]bool{
+		"plugin-demo-basic-importer":    true,
+		"plugin-demo-artifact-importer": true,
+		"plugin-demo-actions-importer":  true,
+		"plugin-demo-advanced-importer": true,
+	}
+	if len(serviceTerminal.dependencies) != len(wantServiceDependencies) {
+		t.Fatalf("released plugin service-free terminal dependencies = %v", serviceTerminal.dependencies)
+	}
+	for _, dependency := range serviceTerminal.dependencies {
+		if !wantServiceDependencies[dependency] {
+			t.Fatalf("released plugin service-free terminal has unexpected dependency %q", dependency)
+		}
+	}
+	cacheTerminal := steps["plugin-demo-cache-terminal"]
+	if cacheTerminal.condition != `build.env("DEMO_CACHE") == "1"` || len(cacheTerminal.dependencies) != 1 || cacheTerminal.dependencies[0] != "plugin-demo-cache-importer" {
+		t.Fatalf("released plugin cache terminal = %#v", cacheTerminal)
+	}
+	text := string(source)
+	for _, forbidden := range []string{"scripts/migration-poc-import", "github-actions#main", "github-actions#master", "__POC_NONCE__"} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("released plugin demo contains %q", forbidden)
+		}
+	}
+
+	advanced, err := os.ReadFile(filepath.Join(root, "testdata", "poc", ".github", "workflows", "advanced.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	advancedText := string(advanced)
+	for _, required := range []string{
+		"actions/hello-world-docker-action@66e612e94eca3366d470e868d0c2d86bd25e693d",
+		"actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02",
+		"actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093",
+		"continue-on-error: true",
+	} {
+		if !strings.Contains(advancedText, required) {
+			t.Fatalf("advanced released-plugin fixture lacks %q", required)
+		}
+	}
+	if strings.Contains(advancedText, "actions/cache@") || strings.Contains(advancedText, "__POC_") {
+		t.Fatalf("service-free released-plugin fixture retains cache or source rewriting:\n%s", advanced)
+	}
+
+	cache, err := os.ReadFile(filepath.Join(root, "testdata", "poc", ".github", "workflows", "cache.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cacheText := string(cache)
+	if count := strings.Count(cacheText, "actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9"); count != 2 {
+		t.Fatalf("released-plugin cache fixture has %d audited cache invocations, want two", count)
+	}
+	for _, forbidden := range []string{"restore-keys:", "__POC_", "BUILDKITE_"} {
+		if strings.Contains(cacheText, forbidden) {
+			t.Fatalf("released-plugin cache fixture contains %q", forbidden)
+		}
 	}
 }
 

--- a/internal/compiler/smoke_manifest_test.go
+++ b/internal/compiler/smoke_manifest_test.go
@@ -45,7 +45,7 @@ func TestSmokeManifestInventory(t *testing.T) {
 		t.Fatalf("schema = %q", manifest.Schema)
 	}
 
-	wantOrder := []string{"smoke-shell", "smoke-concurrent", "smoke-ci", "smoke-artifact", "migration-poc-basic", "migration-poc-artifacts", "migration-poc-advanced", "phase4-public-actions", "phase5-docker-action", "phase5-container-runtime", "phase6-summary-annotation", "phase6-workflow-command-annotations", "phase6-upload-artifact", "phase6-cache-v6", "unsupported-job-container", "unsupported-service-container"}
+	wantOrder := []string{"smoke-shell", "smoke-concurrent", "smoke-ci", "smoke-artifact", "migration-poc-basic", "migration-poc-artifacts", "migration-poc-advanced", "migration-poc-cache", "phase4-public-actions", "phase5-docker-action", "phase5-container-runtime", "phase6-summary-annotation", "phase6-workflow-command-annotations", "phase6-upload-artifact", "phase6-cache-v6", "unsupported-job-container", "unsupported-service-container"}
 	if len(manifest.Fixtures) != len(wantOrder) {
 		t.Fatalf("fixtures = %d, want %d", len(manifest.Fixtures), len(wantOrder))
 	}
@@ -86,7 +86,7 @@ func TestSmokeManifestInventory(t *testing.T) {
 	}
 
 	var checkedIn []string
-	for _, pattern := range []string{"testdata/smoke/.github/workflows/*.yml", "testdata/poc/.github/workflows/basic.yml", "testdata/poc/.github/workflows/artifacts.yml", "testdata/poc/.github/workflows/advanced.yml", "testdata/phase4/.github/workflows/*.yml", "testdata/phase5/.github/workflows/*.yml.tmpl", "testdata/phase5/runtime/.github/workflows/*.yml", "testdata/phase6/.github/workflows/*.yml", "testdata/unsupported/.github/workflows/*.yml"} {
+	for _, pattern := range []string{"testdata/smoke/.github/workflows/*.yml", "testdata/poc/.github/workflows/basic.yml", "testdata/poc/.github/workflows/artifacts.yml", "testdata/poc/.github/workflows/advanced.yml", "testdata/poc/.github/workflows/cache.yml", "testdata/phase4/.github/workflows/*.yml", "testdata/phase5/.github/workflows/*.yml.tmpl", "testdata/phase5/runtime/.github/workflows/*.yml", "testdata/phase6/.github/workflows/*.yml", "testdata/unsupported/.github/workflows/*.yml"} {
 		matches, err := filepath.Glob(filepath.Join(root, filepath.FromSlash(pattern)))
 		if err != nil {
 			t.Fatal(err)
@@ -100,6 +100,30 @@ func TestSmokeManifestInventory(t *testing.T) {
 	sort.Strings(sortedInventory)
 	if fmt.Sprint(sortedInventory) != fmt.Sprint(checkedIn) {
 		t.Fatalf("inventory = %v, checked-in workflows = %v", sortedInventory, checkedIn)
+	}
+}
+
+func TestProductionPluginActionWorkflowCompilesDeterministically(t *testing.T) {
+	root := filepath.Join("..", "..")
+	workflowPath := filepath.Join(root, ".github", "workflows", "phase-4-actions-oracle.yml")
+	workflow, err := os.ReadFile(workflowPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	event, err := os.ReadFile(filepath.Join(root, "testdata", "smoke", "events", "push.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := Compile(workflowPath, workflow, event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := Compile(workflowPath, workflow, event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) == 0 || !bytes.Equal(first, second) {
+		t.Fatal("production plugin action workflow compilation is empty or nondeterministic")
 	}
 }
 

--- a/scripts/migration-poc-import
+++ b/scripts/migration-poc-import
@@ -22,21 +22,9 @@ scripts/phase-0-shell-oracle-checkout "$commit"
 test "${BUILDKITE_COMMIT:?BUILDKITE_COMMIT is required}" = "$commit"
 test -z "$(git status --porcelain --untracked-files=all)"
 
-if grep -q 'actions/cache@' "$workflow"; then
-  : "${BUILDKITE_GHA_CACHE_URL:?BUILDKITE_GHA_CACHE_URL is required by the advanced POC}"
-fi
-
 distribution_root=$(mktemp -d "${TMPDIR:-/tmp}/buildkite-gha-migration-poc.XXXXXXXX")
 event_path=$(mktemp "${TMPDIR:-/tmp}/buildkite-gha-migration-event.XXXXXXXX.json")
-compiled_workflow=$(mktemp "$(dirname "$workflow")/.migration-poc.XXXXXXXX.yml")
-trap 'rm -rf -- "$distribution_root"; rm -f -- "$event_path" "$compiled_workflow"' EXIT
-
-nonce=${BUILDKITE_BUILD_NUMBER:?BUILDKITE_BUILD_NUMBER is required}
-sed "s/__POC_NONCE__/$nonce/g" "$workflow" > "$compiled_workflow"
-if grep -q '__POC_NONCE__' "$compiled_workflow"; then
-  echo "failed to substitute migration POC nonce in $workflow" >&2
-  exit 1
-fi
+trap 'rm -rf -- "$distribution_root"; rm -f -- "$event_path"' EXIT
 
 branch=${BUILDKITE_BRANCH:?BUILDKITE_BRANCH is required}
 jq -n \
@@ -65,4 +53,4 @@ CGO_ENABLED=0 mise exec -- go build -trimpath -buildvcs=false \
 "$distribution_root/buildkite-gha" upload \
   --event-path "$event_path" \
   --runtime-queue hosted \
-  "$compiled_workflow"
+  "$workflow"

--- a/testdata/poc/.github/workflows/advanced.yml
+++ b/testdata/poc/.github/workflows/advanced.yml
@@ -8,8 +8,7 @@ permissions:
   contents: read
 
 env:
-  POC_CACHE_KEY: migration-poc-v1-__POC_NONCE__
-  POC_CACHE_PAYLOAD: migration-poc-payload:__POC_NONCE__
+  POC_ADVANCED_PAYLOAD: migration-poc-advanced:${{ github.sha }}
 
 jobs:
   quality:
@@ -17,50 +16,32 @@ jobs:
     with:
       package: ./internal/action/integration
 
-  cache-producer:
-    name: Populate dependency cache
+  advanced-package:
+    name: Exercise actions and package payload
     needs: quality
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Restore build-unique cache
-        id: cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: migration-cache
-          key: ${{ env.POC_CACHE_KEY }}
-
-      - name: Require miss and create payload
+      - name: Require reusable workflow output and create payload
         shell: bash
         env:
-          CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
           TESTED_PACKAGE: ${{ needs.quality.outputs.tested-package }}
         run: |
-          test "$CACHE_HIT" != true
           test "$TESTED_PACKAGE" = './internal/action/integration'
-          mkdir -p migration-cache
-          printf '%s\n' "$POC_CACHE_PAYLOAD" > migration-cache/payload.txt
+          mkdir -p migration-payload
+          printf '%s\n' "$POC_ADVANCED_PAYLOAD" > migration-payload/payload.txt
 
-  advanced-package:
-    name: Restore cache and package payload
-    needs: cache-producer
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Restore producer cache
-        id: cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Run public Dockerfile action
+        id: docker
+        uses: actions/hello-world-docker-action@66e612e94eca3366d470e868d0c2d86bd25e693d
         with:
-          path: migration-cache
-          key: ${{ env.POC_CACHE_KEY }}
+          who-to-greet: Migration POC
 
-      - name: Require cache hit
+      - name: Verify Dockerfile action output
         shell: bash
         env:
-          CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
-        run: |
-          test "$CACHE_HIT" = true
-          test "$(cat migration-cache/payload.txt)" = "$POC_CACHE_PAYLOAD"
+          ACTION_TIME: ${{ steps.docker.outputs.time }}
+        run: test -n "$ACTION_TIME"
 
       - name: Exercise continue-on-error
         id: expected-failure
@@ -76,8 +57,8 @@ jobs:
       - name: Upload restored payload
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: migration-poc-payload
-          path: migration-cache/payload.txt
+          name: migration-poc-advanced
+          path: migration-payload/payload.txt
           if-no-files-found: error
 
   advanced-verify:
@@ -93,7 +74,7 @@ jobs:
       - name: Download payload
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          name: migration-poc-payload
+          name: migration-poc-advanced
           path: payload
 
       - name: Verify payload
@@ -101,12 +82,12 @@ jobs:
         env:
           VARIANT: ${{ matrix.variant }}
         run: |
-          test "$(cat payload/payload.txt)" = "$POC_CACHE_PAYLOAD"
-          echo "::warning title=Migration POC::$VARIANT verified the cached artifact"
+          test "$(cat payload/payload.txt)" = "$POC_ADVANCED_PAYLOAD"
+          echo "::warning title=Migration POC::$VARIANT verified the advanced artifact"
           {
             echo "## Advanced migration POC: $VARIANT"
             echo
-            echo 'Reusable workflow output, cache, artifact, matrix, and annotation checks passed.'
+            echo 'Reusable output, Dockerfile action, artifact, matrix, and annotation checks passed.'
           } >> "$GITHUB_STEP_SUMMARY"
 
   poc-advanced:

--- a/testdata/poc/.github/workflows/cache.yml
+++ b/testdata/poc/.github/workflows/cache.yml
@@ -1,0 +1,76 @@
+name: Migration POC - cache extension
+
+on:
+  push:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  POC_CACHE_KEY: migration-plugin-v1-${{ github.sha }}
+  POC_CACHE_PAYLOAD: migration-plugin-cache:${{ github.sha }}
+
+jobs:
+  cache-producer:
+    name: Populate dependency cache
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Restore release-commit cache
+        id: cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: migration-cache
+          key: ${{ env.POC_CACHE_KEY }}
+
+      - name: Create or verify payload
+        shell: bash
+        env:
+          CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
+        run: |
+          if [[ "$CACHE_HIT" == true ]]; then
+            test "$(cat migration-cache/payload.txt)" = "$POC_CACHE_PAYLOAD"
+          else
+            mkdir -p migration-cache
+            printf '%s\n' "$POC_CACHE_PAYLOAD" > migration-cache/payload.txt
+          fi
+
+  cache-consumer:
+    name: Restore dependency cache
+    needs: cache-producer
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Restore producer cache
+        id: cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: migration-cache
+          key: ${{ env.POC_CACHE_KEY }}
+
+      - name: Require exact cache hit
+        shell: bash
+        env:
+          CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
+        run: |
+          test "$CACHE_HIT" = true
+          test "$(cat migration-cache/payload.txt)" = "$POC_CACHE_PAYLOAD"
+
+      - name: Publish cache summary
+        shell: bash
+        run: |
+          {
+            echo '## Cache migration POC'
+            echo
+            echo 'The dependent job restored the exact actions/cache v6 entry.'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  poc-cache:
+    name: Cache POC complete
+    needs: cache-consumer
+    runs-on: ubuntu-latest
+    steps:
+      - name: Confirm cache roundtrip
+        shell: bash
+        run: echo 'Cache producer and consumer completed.'

--- a/testdata/poc/README.md
+++ b/testdata/poc/README.md
@@ -1,24 +1,32 @@
 # Migration POC suite
 
 These workflows exercise common GitHub Actions migration shapes as one
-exact-commit Buildkite proof, rather than adding more phase-numbered probes:
+customer-shaped suite, rather than adding more phase-numbered probes:
 
 - `basic.yml`: checkout, tool setup, shell tests, conditions, outputs, and a job
   summary.
 - `artifacts.yml`: build, job outputs, a direct producer-to-consumer artifact
   handoff, and execution of the downloaded binary.
 - `advanced.yml`: a local reusable workflow with a caller-consumed declared
-  output, cache v6 miss/save/hit lifecycle, `continue-on-error`, artifact
-  handoff, matrix fan-out/fan-in, summaries, and workflow-command annotations.
+  output, a public Dockerfile action, `continue-on-error`, artifact handoff,
+  matrix fan-out/fan-in, summaries, and workflow-command annotations.
+- `cache.yml`: the optional `actions/cache` v6 miss/save/direct-dependent-hit
+  extension.
+
+The released-plugin service-free lane also imports the repository's root-level
+Phase 4 workflow to prove checked-out local JavaScript and composite actions.
+Keeping those actions under the actual event repository root allows the runtime
+to rehash the same workspace source that the compiler locked.
 
 The suite stays within the `hosted-tokenless` admission profile. It does not
 imply support for secrets, job or service containers, remote reusable
 workflows, moving action refs, broad artifact modes, or cache versions other
 than the audited actions/cache v6.1.0 commit.
 
-## Hosted run
+## Pre-release runtime run
 
-Run the suite against one exact commit:
+The repository-only importer builds the exact checked-out source and runs the
+three service-free workflows before a CLI release exists:
 
 ```sh
 commit=$(git rev-parse HEAD)
@@ -28,25 +36,61 @@ bk build create \
   --commit "$commit" \
   -e POC_SUITE=migration \
   -e POC_COMMIT="$commit" \
-  -e BUILDKITE_GHA_CACHE_URL=https://isaacsu-ghacs.buildkite.dev
+  --yes
 ```
 
-`POC_COMMIT` must be a full lowercase Git object ID. The importer generates an
-event bound to that same commit and substitutes the Buildkite build number into
-the cache key, making the expected producer miss and dependent consumer hit
-repeatable.
+`POC_COMMIT` must be a full lowercase Git object ID. This is runtime evidence,
+not installation evidence: the importer compiles a development binary and
+calls `upload` directly.
+
+## Released plugin demo
+
+After CLI `v0.2.0` exists at the exact commit, run the same workflows through
+the pinned companion plugin and its real anonymous release installer:
+
+```sh
+commit=$(git rev-parse HEAD)
+bk build create \
+  --pipeline buildkite/buildkite-gha \
+  --branch "$(git branch --show-current)" \
+  --commit "$commit" \
+  -e DEMO_SUITE=plugin \
+  -e DEMO_COMMIT="$commit" \
+  --yes
+```
+
+Add the optional cache extension only when the organization can mint GHAC
+tokens and the exact origin is configured:
+
+```sh
+commit=$(git rev-parse HEAD)
+bk build create \
+  --pipeline buildkite/buildkite-gha \
+  --branch "$(git branch --show-current)" \
+  --commit "$commit" \
+  -e DEMO_SUITE=plugin \
+  -e DEMO_COMMIT="$commit" \
+  -e DEMO_CACHE=1 \
+  -e BUILDKITE_GHA_CACHE_URL=<cache-v2-results-origin> \
+  --yes
+```
+
+The first cache run for a release commit must show a producer miss, post-save,
+and direct-dependent hit. Warm reruns accept and verify the immutable producer
+entry before requiring the same dependent hit. The service-free terminal and,
+when selected, cache terminal depend on their plugin importers; Buildkite's
+dynamic pipeline dependency extension makes them wait for all generated jobs.
 
 ## Recorded evidence
 
 [Buildkite build 303](https://buildkite.com/buildkite/buildkite-gha/builds/303)
-passed all three POCs at exact commit
-`9d29bf26492be760016d29c7ba0d00033b4f9b39`. The advanced workflow proved its
-declared reusable-workflow output reached the caller with the exact expected
-value, followed by a build-unique cache miss, post-save, and dependent exact
-hit. It then transferred the restored payload through the bounded artifact
-adapters to both matrix consumers. The successful workflow proves the summary
-and warning emission paths ran, while the dedicated Phase 6 fixtures retain
-the independent annotation-persistence observations.
+passed the predecessor three-workflow suite at exact commit
+`9d29bf26492be760016d29c7ba0d00033b4f9b39`. Its then-combined advanced workflow
+proved the declared reusable output, build-unique cache miss/post-save/hit,
+artifact fan-out, summary, and warning paths. The revised service-free and
+cache fixtures deliberately surrender that whole-fixture classification until
+the released-plugin demo runs against their exact commit. Component and
+dedicated Phase 6 evidence remains valid.
 
 The historical phase fixtures and their recorded observations remain the
 conformance ledger. The now-superseded targeted cache importer, continuation,

--- a/testdata/smoke/README.md
+++ b/testdata/smoke/README.md
@@ -46,8 +46,9 @@ Node. Admission does not execute action code or prove that a generic action is
 independent of GitHub-only artifact, cache, token, or OIDC services.
 The exact audited `actions/upload-artifact` and exact-name
 `actions/download-artifact` commits are admitted through bounded native
-adapters. Cache actions, artifact merge and broad download modes, and
-unsupported commits remain rejected; the profile leaves unknown generic
+adapters. The exact audited `actions/cache` v6.1.0 commit is also admitted;
+other cache commits, artifact merge and broad download modes, and unsupported
+artifact commits remain rejected. The profile leaves unknown generic
 service dependencies as an explicit warning rather than guessing from
 arbitrary action source. Runtime-pass job and service container fixtures are
 deliberately not marked for this profile: their execution is proven separately,

--- a/testdata/smoke/manifest.json
+++ b/testdata/smoke/manifest.json
@@ -59,9 +59,18 @@
       "id": "migration-poc-advanced",
       "workflow": "testdata/poc/.github/workflows/advanced.yml",
       "event": "testdata/smoke/events/push.json",
-      "expectation": "runtime-pass",
-      "evidence": "Exact-commit Buildkite build 303 passed the current advanced migration POC, including its caller-consumed declared reusable-workflow output.",
-      "note": "At commit 9d29bf26492be760016d29c7ba0d00033b4f9b39, the reusable quality job published tested-package through its workflow_call declaration and the dependent cache producer observed the exact expected value before the cache, artifact, matrix, summary, and annotation paths completed.",
+      "expectation": "compile-pass",
+      "evidence": "The component behaviors have exact-commit hosted evidence, but the service-free Dockerfile-action revision awaits its released-plugin run.",
+      "note": "Build 303 proved the predecessor fixture's reusable output, artifact, matrix, summary, and annotation path. The revised fixture deliberately separates cache and adds public Dockerfile-action coverage.",
+      "action_preflight": "hosted-tokenless"
+    },
+    {
+      "id": "migration-poc-cache",
+      "workflow": "testdata/poc/.github/workflows/cache.yml",
+      "event": "testdata/smoke/events/push.json",
+      "expectation": "compile-pass",
+      "evidence": "Build 303 proved the cache-v2 implementation lifecycle; this stable released-plugin fixture awaits an exact-commit hosted run.",
+      "note": "The first run of a release commit must observe a producer miss and post-save before the direct dependent requires an exact hit; warm reruns verify the same immutable payload.",
       "action_preflight": "hosted-tokenless"
     },
     {
@@ -124,7 +133,7 @@
       "event": "testdata/smoke/events/push.json",
       "expectation": "compile-pass",
       "evidence": "Compiler and runtime conformance tests admit only the audited actions/cache v6.1.0 commit and execute its ESM pre/main/post lifecycle with isolated per-phase cache-v2 credentials.",
-      "note": "This minimal fixture remains compile-only conformance coverage. The migration-poc-advanced fixture owns the current exact-commit hosted cache roundtrip evidence from Buildkite build 303.",
+      "note": "This minimal fixture remains compile-only conformance coverage. The predecessor combined advanced fixture proved the hosted roundtrip in Buildkite build 303; migration-poc-cache awaits released-plugin evidence.",
       "action_preflight": "hosted-tokenless"
     },
     {


### PR DESCRIPTION
## Summary

- add an opt-in end-to-end lane that invokes the pinned companion plugin and installs the future CLI v0.2.0 release
- run basic, artifact, root-level JavaScript/composite action, and advanced service-free workflows before an optional cache v6 extension
- separate cache from the advanced POC and remove development-time workflow rewriting from the pre-release importer
- keep revised fixtures compile-only until fresh exact-commit hosted evidence exists, while preserving build 303 as historical implementation evidence

## Verification

- `mise run check`
- focused `hosted-tokenless` admission for:
  - `testdata/poc/.github/workflows/advanced.yml`
  - `testdata/poc/.github/workflows/cache.yml`
  - `.github/workflows/phase-4-actions-oracle.yml`
- `mise exec -- svu next` → `v0.2.0`

## Hosted proof sequence

This PR intentionally does not run the plugin lane before the release exists.

1. Merge this PR.
2. Run the pre-release exact-commit migration POC against merged `main`.
3. Publish CLI `v0.2.0` from that same commit.
4. Run `DEMO_SUITE=plugin`, first service-free and then with `DEMO_CACHE=1` plus the configured origin.

The plugin is pinned to reviewed commit `aca805f6eb2965201d4edaa57f3eec8ef9ea7ccb`; no moving plugin reference or local CLI fallback is used.
