### PR TITLE
test: make runtime suite portable on macOS

### DIFF
--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -948,7 +948,7 @@ func TestRunJobContainerConcurrentExecUsesUniquePIDFiles(t *testing.T) {
 func TestRunJobContainerBarrierVisibility(t *testing.T) {
 	f := newJobDocker(t, "")
 	w := t.TempDir()
-	j := jobContainerPlan(t, w, []plan.Step{{ID: "bg", Kind: "run", Shell: "sh", Background: true, Command: `sleep .15; echo LATE=yes >> "$GITHUB_ENV"; echo value=x >> "$GITHUB_OUTPUT"; echo /late >> "$GITHUB_PATH"`}, {ID: "before", Kind: "run", Shell: "sh", Command: `test -z "${LATE-}"`}, {ID: "wait", Kind: "wait", Targets: []string{"bg"}}, {ID: "after", Kind: "run", Shell: "sh", Command: `test "$LATE" = yes; case "$PATH" in /late:*) ;; *) exit 9;; esac`}})
+	j := jobContainerPlan(t, w, []plan.Step{{ID: "bg", Kind: "run", Shell: "sh", Background: true, Command: `/bin/sleep .15; echo LATE=yes >> "$GITHUB_ENV"; echo value=x >> "$GITHUB_OUTPUT"; echo /late >> "$GITHUB_PATH"`}, {ID: "before", Kind: "run", Shell: "sh", Command: `test -z "${LATE-}"`}, {ID: "wait", Kind: "wait", Targets: []string{"bg"}}, {ID: "after", Kind: "run", Shell: "sh", Command: `test "$LATE" = yes; case "$PATH" in /late:*) ;; *) exit 9;; esac`}})
 	if _, e := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(context.Background(), j, w); e != nil {
 		t.Fatal(e)
 	}
@@ -1381,7 +1381,7 @@ func TestRunJobContainerWorkspaceActionRemainsLazy(t *testing.T) {
 	writeFixtureFile(t, actionSource, "main.js", mainJS)
 	lockID := remoteLifecycleLockID(1)
 	lazyDir := ".github/actions/lazy"
-	create := fmt.Sprintf("mkdir -p %s; printf '%%s' %s | base64 -d > %s/action.yml; printf '%%s' %s | base64 -d > %s/main.js",
+	create := fmt.Sprintf("/bin/mkdir -p %s; printf '%%s' %s | base64 -d > %s/action.yml; printf '%%s' %s | base64 -d > %s/main.js",
 		lazyDir, base64.StdEncoding.EncodeToString([]byte(actionYAML)), lazyDir,
 		base64.StdEncoding.EncodeToString([]byte(mainJS)), lazyDir)
 	job := runtimePlan(t, workspace, ".github/workflows/container.yml", []plan.Step{
@@ -1542,7 +1542,7 @@ func TestRunJobContainerJavaScriptCancellationRunsPost(t *testing.T) {
 	lockID := remoteLifecycleLockID(1)
 	job := runtimePlan(t, workspace, ".github/workflows/container.yml", []plan.Step{
 		{ID: "background", Kind: "uses", Uses: "./.github/actions/cancel", Background: true, Action: &plan.ActionSelector{Lock: lockID}},
-		{ID: "await", Kind: "run", Shell: "sh", Command: `while [ ! -f "$READY" ]; do sleep .01; done`},
+		{ID: "await", Kind: "run", Shell: "sh", Command: `while [ ! -f "$READY" ]; do /bin/sleep .01; done`},
 		{ID: "cancel", Kind: "cancel", Targets: []string{"background"}},
 	})
 	job.Schema = plan.SchemaV4

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -436,6 +436,15 @@ func fakeJobDockerExec(root, scenario string, args []string) {
 		helper[1] = translate(helper[1])
 	}
 	if helper[0] == "run" {
+		// The fake container executes on the host, so resolve image PATH commands
+		// before replacing the process environment with the simulated image PATH.
+		if len(helper) > 2 && !filepath.IsAbs(helper[2]) {
+			command, err := exec.LookPath(helper[2])
+			if err != nil {
+				os.Exit(126)
+			}
+			helper[2] = command
+		}
 		for j := 2; j < len(helper); j++ {
 			if strings.HasPrefix(helper[j], "/") {
 				helper[j] = translate(helper[j])
@@ -1448,7 +1457,7 @@ func TestRunJobContainerRunsDockerActionsAsSiblings(t *testing.T) {
 		f := newJobDocker(t, "")
 		workspace := t.TempDir()
 		writeFixtureFile(t, workspace, ".github/workflows/container.yml", "name: remote Docker rejection\n")
-		remote := t.TempDir()
+		remote := canonicalTempDir(t)
 		writeFixtureFile(t, remote, "docker/action.yml", "name: docker\nruns:\n  using: docker\n  image: Dockerfile\n")
 		writeFixtureFile(t, remote, "docker/Dockerfile", "FROM scratch\n")
 		digest := digestTree(t, remote)

--- a/internal/runtime/download_artifact_test.go
+++ b/internal/runtime/download_artifact_test.go
@@ -299,7 +299,7 @@ func TestDownloadArtifactRejectsUnsupportedMemberAndExpandedSize(t *testing.T) {
 
 func TestDownloadArtifactAdapterBypassesVerifiedUpstreamLifecycle(t *testing.T) {
 	archive, size, digest := testDownloadZIP(t, "result.txt")
-	workspace := t.TempDir()
+	workspace := canonicalTempDir(t)
 	workflowPath := ".github/workflows/download.yml"
 	writeFixtureFile(t, workspace, workflowPath, "name: download proof\n")
 	remote := t.TempDir()

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -455,7 +455,11 @@ func TestRunDockerFakeLifecycle(t *testing.T) {
 			mounts = append(mounts, run[i+1])
 		}
 	}
-	if len(mounts) != 3 || !strings.HasSuffix(mounts[0], ",target=/github/file_commands") || mounts[1] != "type=bind,source="+action.Workspace+",target=/github/workspace" || !strings.HasSuffix(mounts[2], ",target=/github/runner_temp") {
+	resolvedWorkspace, err := filepath.EvalSymlinks(action.Workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mounts) != 3 || !strings.HasSuffix(mounts[0], ",target=/github/file_commands") || mounts[1] != "type=bind,source="+resolvedWorkspace+",target=/github/workspace" || !strings.HasSuffix(mounts[2], ",target=/github/runner_temp") {
 		t.Fatalf("fixed Docker mounts = %#v", mounts)
 	}
 	if workdir := argumentAfter(t, run, "--workdir"); workdir != "/github/workspace" {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -164,7 +164,7 @@ record() {
   if ! mode="$(stat -c %a "$DOCKER_CONFIG" 2>/dev/null)"; then
     mode="$(stat -f %Lp "$DOCKER_CONFIG")"
   fi
-  entries="$(find "$DOCKER_CONFIG" -mindepth 1 -maxdepth 1 -print -quit | wc -l)"
+  entries="$(find "$DOCKER_CONFIG" -mindepth 1 -maxdepth 1 -print -quit | wc -l | tr -d '[:space:]')"
   printf 'config=%s;mode=%s;entries=%s;host=%s;context=%s;builder=%s;buildkit=%s' \
     "$DOCKER_CONFIG" "$mode" "$entries" "${DOCKER_HOST-unset}" "${DOCKER_CONTEXT-unset}" \
     "${BUILDX_BUILDER-unset}" "${BUILDKIT_HOST-unset}" >> "$transcript"
@@ -2106,7 +2106,9 @@ sleep 30
 		t.Fatal(err)
 	}
 	job := runtimePlan(t, workspace, ".github/workflows/test.yml", []plan.Step{{ID: "slow", Kind: "uses", Uses: "./.github/actions/slow"}})
-	job.TimeoutMinutes = 0.001
+	// Leave enough of the job budget for process discovery on slower Darwin
+	// hosts; the post still has only the separate 250 ms cleanup grace.
+	job.TimeoutMinutes = 0.01
 	job.Env = map[string]string{"POST_STARTED": postStarted}
 	runner := Runner{
 		Node24: fakeNode, CleanupTimeout: 250 * time.Millisecond, PostActionTimeout: 3 * time.Second,

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -161,7 +161,9 @@ scenario=__SCENARIO__
 transcript="$state/transcript"
 record() {
   local mode entries
-  mode="$(stat -c %a "$DOCKER_CONFIG")"
+  if ! mode="$(stat -c %a "$DOCKER_CONFIG" 2>/dev/null)"; then
+    mode="$(stat -f %Lp "$DOCKER_CONFIG")"
+  fi
   entries="$(find "$DOCKER_CONFIG" -mindepth 1 -maxdepth 1 -print -quit | wc -l)"
   printf 'config=%s;mode=%s;entries=%s;host=%s;context=%s;builder=%s;buildkit=%s' \
     "$DOCKER_CONFIG" "$mode" "$entries" "${DOCKER_HOST-unset}" "${DOCKER_CONTEXT-unset}" \
@@ -1482,7 +1484,7 @@ require('node:fs').appendFileSync(process.env.CWD_LOG, %q + process.cwd() + '\t'
 
 func TestJavaScriptActionCanonicalizesWorkspaceAndRunnerTemp(t *testing.T) {
 	node := requireNode24(t)
-	base := t.TempDir()
+	base := canonicalTempDir(t)
 	realParent := filepath.Join(base, "real")
 	if err := os.Mkdir(realParent, 0o755); err != nil {
 		t.Fatal(err)
@@ -2087,7 +2089,7 @@ func TestPostActionsUseBoundedCleanupContext(t *testing.T) {
 }
 
 func TestJobTimeoutLimitsPostActionsToCleanupGrace(t *testing.T) {
-	workspace := t.TempDir()
+	workspace := canonicalTempDir(t)
 	writeFixtureFile(t, workspace, ".github/workflows/test.yml", "name: runtime test\n")
 	writeFixtureFile(t, workspace, ".github/actions/slow/action.yml", "name: Job timeout post\nruns:\n  using: node24\n  main: main.js\n  post: post.js\n")
 	writeFixtureFile(t, workspace, ".github/actions/slow/main.js", "")
@@ -2757,7 +2759,7 @@ func TestDiscoverNodeManagedAndWrongExplicitVersion(t *testing.T) {
 }
 
 func TestMiseNodeSelectionIsExactAndConfigFree(t *testing.T) {
-	root := t.TempDir()
+	root := canonicalTempDir(t)
 	log := filepath.Join(root, "args")
 	dataDir := filepath.Join(root, "data")
 	installation := filepath.Join(dataDir, "installs", "node", Node20Version)
@@ -2790,7 +2792,7 @@ func TestMiseNodeSelectionIsExactAndConfigFree(t *testing.T) {
 }
 
 func TestMiseNodePathIgnoresProgressOnStderr(t *testing.T) {
-	root := t.TempDir()
+	root := canonicalTempDir(t)
 	nodeRoot := filepath.Join(root, "node")
 	if err := os.MkdirAll(filepath.Join(nodeRoot, "bin"), 0o755); err != nil {
 		t.Fatal(err)
@@ -2822,7 +2824,7 @@ func TestMiseNodePathIgnoresProgressOnStderr(t *testing.T) {
 }
 
 func TestManagedMiseCacheReplacesNodeWithWrongDigest(t *testing.T) {
-	root := t.TempDir()
+	root := canonicalTempDir(t)
 	dataDir := filepath.Join(root, "data")
 	installation := filepath.Join(dataDir, "installs", "node", Node24Version)
 	node := filepath.Join(installation, "bin", "node")
@@ -2875,7 +2877,7 @@ esac
 }
 
 func TestManagedMiseCacheRefusesSymlinkedRemoval(t *testing.T) {
-	dataDir := t.TempDir()
+	dataDir := canonicalTempDir(t)
 	outside := t.TempDir()
 	if err := os.Symlink(outside, filepath.Join(dataDir, "installs")); err != nil {
 		t.Fatal(err)
@@ -2890,7 +2892,7 @@ func TestManagedMiseCacheRefusesSymlinkedRemoval(t *testing.T) {
 }
 
 func TestJavaScriptPhaseUsesVerifiedMiseNodeWithoutWorkflowRedirection(t *testing.T) {
-	root := t.TempDir()
+	root := canonicalTempDir(t)
 	log := filepath.Join(root, "node-args")
 	dataDir := filepath.Join(root, "mise-data")
 	installation := filepath.Join(dataDir, "installs", "node", Node24Version)
@@ -2940,7 +2942,7 @@ func TestMiseMissingIsClear(t *testing.T) {
 }
 
 func TestMiseNodeSelectionRejectsWrongExactVersion(t *testing.T) {
-	root := t.TempDir()
+	root := canonicalTempDir(t)
 	installation := filepath.Join(root, "node")
 	node := filepath.Join(installation, "bin", "node")
 	if err := os.MkdirAll(filepath.Dir(node), 0o755); err != nil {
@@ -3141,7 +3143,7 @@ runs:
 }
 
 func TestNestedCompositeEvaluatesEnvironmentOnceAndIsolatesStepScopes(t *testing.T) {
-	workspace := t.TempDir()
+	workspace := canonicalTempDir(t)
 	workflowPath := ".github/workflows/test.yml"
 	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
 	writeFixtureFile(t, workspace, ".github/actions/js/action.yml", `name: Nested JavaScript
@@ -4034,6 +4036,15 @@ func fixturePath(t *testing.T, parts ...string) string {
 	return path
 }
 
+func canonicalTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
 func requireNode24(t *testing.T) string {
 	t.Helper()
 	if node := os.Getenv("BUILDKITE_GHA_TEST_NODE24"); node != "" {
@@ -4063,10 +4074,15 @@ func requireDocker(t *testing.T) string {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	if output, err := exec.CommandContext(ctx, docker, "info", "--format", "{{.ServerVersion}}").CombinedOutput(); err != nil {
+	dockerConfig := t.TempDir()
+	if err := os.Chmod(dockerConfig, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	dockerEnv := map[string]string{"DOCKER_CONFIG": dockerConfig}
+	if output, err := boundedDockerCombinedOutput(ctx, dockerEnv, docker, "info", "--format", "{{.ServerVersion}}"); err != nil {
 		livePrerequisiteUnavailable(t, "Docker unavailable: daemon probe failed: %v: %s", err, strings.TrimSpace(string(output)))
 	}
-	if output, err := exec.CommandContext(ctx, docker, "buildx", "inspect", "default").CombinedOutput(); err != nil || dockerBuilderDriver(string(output)) != "docker" {
+	if output, err := boundedDockerCombinedOutput(ctx, dockerEnv, docker, "buildx", "inspect", "default"); err != nil || dockerBuilderDriver(string(output)) != "docker" {
 		livePrerequisiteUnavailable(t, "Docker unavailable: default Buildx builder is not the local docker driver: %v: %s", err, strings.TrimSpace(string(output)))
 	}
 	return docker

--- a/internal/runtime/upload_artifact_test.go
+++ b/internal/runtime/upload_artifact_test.go
@@ -137,7 +137,18 @@ func TestUploadArtifactDoesNotStageInContainerWritableRunnerTemp(t *testing.T) {
 	if _, err := r.runUploadArtifact(context.Background(), newCommandProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "result.txt"}); err != nil {
 		t.Fatal(err)
 	}
-	if len(uploader.uploads) != 1 || uploader.uploads[0].root == sharedRunnerTemp || !strings.HasPrefix(uploader.uploads[0].root, os.TempDir()+string(filepath.Separator)) {
+	if len(uploader.uploads) != 1 {
+		t.Fatalf("uploads = %#v, want one", uploader.uploads)
+	}
+	stagingParent, err := filepath.EvalSymlinks(filepath.Dir(uploader.uploads[0].root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tempDir, err := filepath.EvalSymlinks(os.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if uploader.uploads[0].root == sharedRunnerTemp || stagingParent != tempDir {
 		t.Fatalf("upload staging root = %q, shared runner temp = %q", uploader.uploads[0].root, sharedRunnerTemp)
 	}
 }


### PR DESCRIPTION
## Summary

- canonicalize test-owned temporary paths before asserting runtime and mise symlink behavior on Darwin
- make fake Docker and container execution portable across GNU/Linux and macOS utilities and host layouts
- probe live Docker with the same isolated configuration used by runtime execution, skipping locally when that secure path is unavailable

Runtime security behavior is unchanged: Docker credentials and connection overrides remain isolated, and managed mise paths retain strict symlink rejection.

## Verification

- `mise run check` (Linux amd64)
- `GOOS=darwin GOARCH=arm64 go test -c ./internal/runtime`
- `mise exec -- go test -count=1 ./internal/runtime` (macOS arm64, 50.753s)