### PR TITLE
test: prove plugin v0.2 candidate default

### DIFF
--- a/.buildkite/plugin-demo.yml
+++ b/.buildkite/plugin-demo.yml
@@ -8,9 +8,8 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#aca805f6eb2965201d4edaa57f3eec8ef9ea7ccb:
+      - github-actions#984ee8cabfa69a1413edf38c281da9dbccfb62bf:
           workflow: testdata/poc/.github/workflows/basic.yml
-          version: "0.2.0"
 
   - label: ":package: Artifact released-plugin demo"
     key: "plugin-demo-artifact-importer"
@@ -18,9 +17,8 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#aca805f6eb2965201d4edaa57f3eec8ef9ea7ccb:
+      - github-actions#984ee8cabfa69a1413edf38c281da9dbccfb62bf:
           workflow: testdata/poc/.github/workflows/artifacts.yml
-          version: "0.2.0"
 
   - label: ":javascript: Actions released-plugin demo"
     key: "plugin-demo-actions-importer"
@@ -28,9 +26,8 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#aca805f6eb2965201d4edaa57f3eec8ef9ea7ccb:
+      - github-actions#984ee8cabfa69a1413edf38c281da9dbccfb62bf:
           workflow: .github/workflows/phase-4-actions-oracle.yml
-          version: "0.2.0"
 
   - label: ":rocket: Advanced released-plugin demo"
     key: "plugin-demo-advanced-importer"
@@ -38,9 +35,8 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#aca805f6eb2965201d4edaa57f3eec8ef9ea7ccb:
+      - github-actions#984ee8cabfa69a1413edf38c281da9dbccfb62bf:
           workflow: testdata/poc/.github/workflows/advanced.yml
-          version: "0.2.0"
 
   - label: ":white_check_mark: Service-free plugin demo complete"
     key: "plugin-demo-service-free-terminal"
@@ -58,9 +54,8 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#aca805f6eb2965201d4edaa57f3eec8ef9ea7ccb:
+      - github-actions#984ee8cabfa69a1413edf38c281da9dbccfb62bf:
           workflow: testdata/poc/.github/workflows/cache.yml
-          version: "0.2.0"
 
   - label: ":white_check_mark: Cache plugin demo complete"
     key: "plugin-demo-cache-terminal"

--- a/.buildkite/plugin-demo.yml
+++ b/.buildkite/plugin-demo.yml
@@ -8,7 +8,7 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#d009da173158270a3921b2997ae8fd3d68526d00:
+      - github-actions#v0.2.0:
           workflow: testdata/poc/.github/workflows/basic.yml
 
   - label: ":package: Artifact released-plugin demo"
@@ -17,7 +17,7 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#d009da173158270a3921b2997ae8fd3d68526d00:
+      - github-actions#v0.2.0:
           workflow: testdata/poc/.github/workflows/artifacts.yml
 
   - label: ":javascript: Actions released-plugin demo"
@@ -26,7 +26,7 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#d009da173158270a3921b2997ae8fd3d68526d00:
+      - github-actions#v0.2.0:
           workflow: .github/workflows/phase-4-actions-oracle.yml
 
   - label: ":rocket: Advanced released-plugin demo"
@@ -35,7 +35,7 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#d009da173158270a3921b2997ae8fd3d68526d00:
+      - github-actions#v0.2.0:
           workflow: testdata/poc/.github/workflows/advanced.yml
 
   - label: ":white_check_mark: Service-free plugin demo complete"
@@ -54,7 +54,7 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#d009da173158270a3921b2997ae8fd3d68526d00:
+      - github-actions#v0.2.0:
           workflow: testdata/poc/.github/workflows/cache.yml
 
   - label: ":white_check_mark: Cache plugin demo complete"

--- a/.buildkite/plugin-demo.yml
+++ b/.buildkite/plugin-demo.yml
@@ -8,7 +8,7 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#984ee8cabfa69a1413edf38c281da9dbccfb62bf:
+      - github-actions#d009da173158270a3921b2997ae8fd3d68526d00:
           workflow: testdata/poc/.github/workflows/basic.yml
 
   - label: ":package: Artifact released-plugin demo"
@@ -17,7 +17,7 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#984ee8cabfa69a1413edf38c281da9dbccfb62bf:
+      - github-actions#d009da173158270a3921b2997ae8fd3d68526d00:
           workflow: testdata/poc/.github/workflows/artifacts.yml
 
   - label: ":javascript: Actions released-plugin demo"
@@ -26,7 +26,7 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#984ee8cabfa69a1413edf38c281da9dbccfb62bf:
+      - github-actions#d009da173158270a3921b2997ae8fd3d68526d00:
           workflow: .github/workflows/phase-4-actions-oracle.yml
 
   - label: ":rocket: Advanced released-plugin demo"
@@ -35,7 +35,7 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#984ee8cabfa69a1413edf38c281da9dbccfb62bf:
+      - github-actions#d009da173158270a3921b2997ae8fd3d68526d00:
           workflow: testdata/poc/.github/workflows/advanced.yml
 
   - label: ":white_check_mark: Service-free plugin demo complete"
@@ -54,7 +54,7 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#984ee8cabfa69a1413edf38c281da9dbccfb62bf:
+      - github-actions#d009da173158270a3921b2997ae8fd3d68526d00:
           workflow: testdata/poc/.github/workflows/cache.yml
 
   - label: ":white_check_mark: Cache plugin demo complete"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ runtime. Buildkite remains the source of truth for scheduling, logs, retries,
 cancellation, and the build UI.
 
 > [!IMPORTANT]
-> This is an experimental v0.1 preview for **public, tokenless, Linux x86-64
+> This is an experimental v0.2 preview for **public, tokenless, Linux x86-64
 > workflows**. It deliberately rejects workflows that need private source,
 > secrets, provider tokens, or other protected capabilities.
 
@@ -24,17 +24,14 @@ steps:
   - label: ":github: Test"
     key: "gha-ci"
     plugins:
-      - github-actions#aca805f6eb2965201d4edaa57f3eec8ef9ea7ccb:
+      - github-actions#v0.2.0:
           workflow: .github/workflows/ci.yml
 ```
 
-The companion plugin has not published a `v0.1.0` tag yet, so this preview
-example pins its reviewed initial commit. Use `github-actions#v0.1.0` after that
-tag is published; do not replace the pin with a floating branch.
-
-The plugin downloads and verifies `buildkite-gha` v0.1.0 by default, derives the
+The released plugin downloads and verifies `buildkite-gha` v0.2.0 by default, derives the
 event context from the Buildkite build, and uploads the generated jobs to the
-fixed `hosted` queue.
+fixed `hosted` queue. Pin a released plugin version rather than a floating
+branch.
 
 Configure branch, tag, and pull request triggers in Buildkite. The plugin
 derives a `pull_request` context for pull request builds and a `push` context
@@ -52,7 +49,7 @@ steps:
   - label: ":github: Test"
     key: "gha-ci"
     plugins:
-      - github-actions#aca805f6eb2965201d4edaa57f3eec8ef9ea7ccb:
+      - github-actions#v0.2.0:
           workflow: .github/workflows/ci.yml
 
   - label: ":rocket: Deploy"

--- a/docs/development.md
+++ b/docs/development.md
@@ -162,15 +162,19 @@ publication and caller consumption, the build-unique cache miss, post-save,
 dependent exact hit, and subsequent artifact fan-out. The revised stable
 service-free and cache fixtures retain compile/admission coverage.
 
-The CLI `v0.2.0` release and companion plugin candidate at exact commit
-`d009da173158270a3921b2997ae8fd3d68526d00` exercised the complete customer
+The CLI and companion plugin `v0.2.0` releases exercised the complete customer
 installation path at source commit
-`71f23edfba88e18b57f58150c2b71d31141fbf03`. The service-free terminal passed
-in [Buildkite build 331](https://buildkite.com/buildkite/buildkite-gha/builds/331),
-and the cache miss, post-save, dependent exact hit, and cache terminal passed
-in [Buildkite build 332](https://buildkite.com/buildkite/buildkite-gha/builds/332).
-The plugin `v0.2.0` tag resolves to that proven plugin commit. Exercise the
-published customer installation path with:
+`d5102df7e81c49f27a30fb2830d9608a56ee84de`. The service-free importer,
+generated jobs, native terminal, and repository checks passed in [Buildkite
+build 336](https://buildkite.com/buildkite/buildkite-gha/builds/336). The same
+checks plus the cache producer miss and post-save, direct-dependent primary-key
+hit and restore, and cache terminal passed in [Buildkite build
+337](https://buildkite.com/buildkite/buildkite-gha/builds/337). In both builds,
+the public plugin tag resolved to the tested commit
+`d009da173158270a3921b2997ae8fd3d68526d00` and installed the same verified CLI
+distribution without an explicit CLI version override. These are the
+authoritative published installation proofs. Repeat the customer installation
+path with:
 
 ```sh
 commit=$(git rev-parse HEAD)

--- a/docs/development.md
+++ b/docs/development.md
@@ -160,11 +160,17 @@ passed the predecessor three-workflow suite at exact commit
 `9d29bf26492be760016d29c7ba0d00033b4f9b39`, including declared reusable-output
 publication and caller consumption, the build-unique cache miss, post-save,
 dependent exact hit, and subsequent artifact fan-out. The revised stable
-service-free and cache fixtures retain compile/admission coverage but await
-exact-commit hosted evidence through the released plugin.
+service-free and cache fixtures retain compile/admission coverage.
 
-After CLI `v0.2.0` is published from the exact commit, exercise the complete
-customer installation path through the pinned companion plugin:
+The CLI `v0.2.0` release and companion plugin candidate at exact commit
+`d009da173158270a3921b2997ae8fd3d68526d00` exercised the complete customer
+installation path at source commit
+`71f23edfba88e18b57f58150c2b71d31141fbf03`. The service-free terminal passed
+in [Buildkite build 331](https://buildkite.com/buildkite/buildkite-gha/builds/331),
+and the cache miss, post-save, dependent exact hit, and cache terminal passed
+in [Buildkite build 332](https://buildkite.com/buildkite/buildkite-gha/builds/332).
+The plugin `v0.2.0` tag resolves to that proven plugin commit. Exercise the
+published customer installation path with:
 
 ```sh
 commit=$(git rev-parse HEAD)
@@ -188,9 +194,9 @@ bk build create --pipeline buildkite/buildkite-gha \
 ```
 
 The first cache run for the release commit must show a producer miss,
-post-save, and direct-dependent exact hit. The plugin demo is intentionally
-dormant before `v0.2.0` exists: it downloads and checksum-verifies the public
-release rather than falling back to a local binary.
+post-save, and direct-dependent exact hit. The plugin downloads and
+checksum-verifies the public release rather than falling back to a local
+binary.
 
 The phase definitions under `.buildkite/` and the [active
 plan](plans/2026-07-22-buildkite-gha.md#current-progress) document the exact

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -2225,15 +2225,16 @@ interfaces required by [ADR 0003](../architecture/0003-protected-capability-cont
 Private source, secrets, provider tokens, environments, and compatible OIDC
 remain fail-closed during that work.
 
-The current hosted evidence proves the runtime, but not yet the complete
-installation experience. Buildkite build 303 compiled a local development
-binary and invoked `upload` through `scripts/migration-poc-import`; it did not
-install a published binary through the companion plugin. The public CLI
-`v0.1.0` predates the current artifact, cache, annotation, and reusable-output
-work, while the current source advances the next release to `v0.2.0`. The
-companion plugin has no `v0.1.0` tag, its reviewed source commit still defaults
-to CLI `v0.1.0`, and its installer has only mock-backed tests rather than a
-hosted plugin-to-runtime proof.
+The complete candidate installation experience is now proven. CLI `v0.2.0` is
+public, and companion plugin `v0.2.0` resolves to the exact tested merge commit
+`d009da173158270a3921b2997ae8fd3d68526d00`, which defaults to that CLI release.
+At source commit `71f23edfba88e18b57f58150c2b71d31141fbf03`, Buildkite build 331 passed the
+service-free terminal after the basic, artifact, JavaScript/composite, and
+advanced importers and generated jobs succeeded. Buildkite build 332 passed the
+cache producer miss and post-save, direct-dependent exact hit, cache terminal,
+and their generated jobs. Those runs pinned the exact plugin commit and omitted
+the CLI version override. A final rerun through the public plugin tag remains
+the authoritative published quick-start proof.
 
 Treat a fully reproducible demo as the next product milestone, distinct from a
 public-beta declaration. It has two explicit lanes:
@@ -2263,26 +2264,26 @@ importer, generated jobs at basic through advanced complexity, native logs and
 dependencies, artifact and cache observations, and the final native
 continuation.
 
-Close the demo gap in this order, using small cross-repository changes:
+The demo gap is closing in this order, using small cross-repository changes:
 
-1. In this repository, add a production-plugin demo dispatcher and stable
+1. Completed: in this repository, add a production-plugin demo dispatcher and stable
    representative fixtures. Keep the service-free baseline independent of the
    cache extension, remove development-only source rewriting from the plugin
    path, and preserve deterministic compile/admission coverage locally.
-2. Run the full local gate and existing exact-commit hosted proofs, then publish
+2. Completed: run the full local gate and existing exact-commit hosted proofs, then publish
    the resulting CLI as `v0.2.0` with its current checksummed archive contract.
    The plugin cannot prove the current runtime before that runtime has a public
    immutable release; failures found by the plugin proof are fixed in a patch
    release rather than by replacing release assets.
-3. In the companion plugin repository, default to the proven CLI release, add
+3. Completed: in the companion plugin repository, default to the proven CLI release, add
    a live installer/plugin smoke lane alongside the existing isolated tests,
    and document the exact prerequisites. Prove the candidate plugin commit
    against both demo lanes before tagging the plugin.
-4. Tag the companion plugin, update this repository's quick start from the
-   temporary commit pin to that tag, and rerun the service-free lane using only
-   the published quick-start configuration. Record that exact run as the
-   authoritative installation and demo evidence.
-5. Use failures and diagnostics from those runs, followed by several real
+4. In progress: tag the companion plugin, update this repository's quick start from
+   the temporary commit pin to that tag, and rerun both demo lanes using only
+   the published configuration. Record those exact runs as the authoritative
+   installation and demo evidence.
+5. Ongoing: use failures and diagnostics from those runs, followed by several real
    customer workflow migrations, to drive small compatibility or UX changes.
    Do not add workflow-specific runtime branches to make a demo fixture pass.
 

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -2225,16 +2225,16 @@ interfaces required by [ADR 0003](../architecture/0003-protected-capability-cont
 Private source, secrets, provider tokens, environments, and compatible OIDC
 remain fail-closed during that work.
 
-The complete candidate installation experience is now proven. CLI `v0.2.0` is
+The complete published installation experience is now proven. CLI `v0.2.0` is
 public, and companion plugin `v0.2.0` resolves to the exact tested merge commit
 `d009da173158270a3921b2997ae8fd3d68526d00`, which defaults to that CLI release.
-At source commit `71f23edfba88e18b57f58150c2b71d31141fbf03`, Buildkite build 331 passed the
+At source commit `d5102df7e81c49f27a30fb2830d9608a56ee84de`, Buildkite build 336 passed the
 service-free terminal after the basic, artifact, JavaScript/composite, and
-advanced importers and generated jobs succeeded. Buildkite build 332 passed the
-cache producer miss and post-save, direct-dependent exact hit, cache terminal,
-and their generated jobs. Those runs pinned the exact plugin commit and omitted
-the CLI version override. A final rerun through the public plugin tag remains
-the authoritative published quick-start proof.
+advanced importers and generated jobs succeeded. Buildkite build 337 passed the
+same service-free lane plus the cache producer miss and post-save,
+direct-dependent primary-key hit and restore, cache terminal, and repository
+checks. Both runs used only the public plugin tag and its default verified CLI
+distribution. They are the authoritative published quick-start evidence.
 
 Treat a fully reproducible demo as the next product milestone, distinct from a
 public-beta declaration. It has two explicit lanes:
@@ -2264,28 +2264,29 @@ importer, generated jobs at basic through advanced complexity, native logs and
 dependencies, artifact and cache observations, and the final native
 continuation.
 
-The demo gap is closing in this order, using small cross-repository changes:
+The demo gap closed in this order, using small cross-repository changes:
 
-1. Completed: in this repository, add a production-plugin demo dispatcher and stable
-   representative fixtures. Keep the service-free baseline independent of the
-   cache extension, remove development-only source rewriting from the plugin
-   path, and preserve deterministic compile/admission coverage locally.
-2. Completed: run the full local gate and existing exact-commit hosted proofs, then publish
-   the resulting CLI as `v0.2.0` with its current checksummed archive contract.
-   The plugin cannot prove the current runtime before that runtime has a public
-   immutable release; failures found by the plugin proof are fixed in a patch
-   release rather than by replacing release assets.
-3. Completed: in the companion plugin repository, default to the proven CLI release, add
-   a live installer/plugin smoke lane alongside the existing isolated tests,
-   and document the exact prerequisites. Prove the candidate plugin commit
-   against both demo lanes before tagging the plugin.
-4. In progress: tag the companion plugin, update this repository's quick start from
-   the temporary commit pin to that tag, and rerun both demo lanes using only
-   the published configuration. Record those exact runs as the authoritative
-   installation and demo evidence.
-5. Ongoing: use failures and diagnostics from those runs, followed by several real
-   customer workflow migrations, to drive small compatibility or UX changes.
-   Do not add workflow-specific runtime branches to make a demo fixture pass.
+1. Completed: in this repository, add a production-plugin demo dispatcher and
+   stable representative fixtures. Keep the service-free baseline independent
+   of the cache extension, remove development-only source rewriting from the
+   plugin path, and preserve deterministic compile/admission coverage locally.
+2. Completed: run the full local gate and existing exact-commit hosted proofs,
+   then publish the resulting CLI as `v0.2.0` with its current checksummed
+   archive contract. The plugin cannot prove the current runtime before that
+   runtime has a public immutable release; failures found by the plugin proof
+   are fixed in a patch release rather than by replacing release assets.
+3. Completed: in the companion plugin repository, default to the proven CLI
+   release, add a live installer/plugin smoke lane alongside the existing
+   isolated tests, and document the exact prerequisites. Prove the candidate
+   plugin commit against both demo lanes before tagging the plugin.
+4. Completed: tag the companion plugin, update this repository's quick start
+   from the temporary commit pin to that tag, and rerun both demo lanes using
+   only the published configuration. Record those exact runs as the
+   authoritative installation and demo evidence.
+5. Ongoing: use failures and diagnostics from those runs, followed by several
+   real customer workflow migrations, to drive small compatibility or UX
+   changes. Do not add workflow-specific runtime branches to make a demo
+   fixture pass.
 
 This milestone does not by itself satisfy every public-beta gate. The initial
 support target still names manual-input event envelopes plus job and service

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -439,7 +439,7 @@ func TestProductionPluginDemoContract(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	const plugin = "github-actions#d009da173158270a3921b2997ae8fd3d68526d00"
+	const plugin = "github-actions#v0.2.0"
 	type pluginConfig struct {
 		Workflow string `yaml:"workflow"`
 		Version  string `yaml:"version"`

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -439,7 +439,7 @@ func TestProductionPluginDemoContract(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	const plugin = "github-actions#aca805f6eb2965201d4edaa57f3eec8ef9ea7ccb"
+	const plugin = "github-actions#984ee8cabfa69a1413edf38c281da9dbccfb62bf"
 	type pluginConfig struct {
 		Workflow string `yaml:"workflow"`
 		Version  string `yaml:"version"`
@@ -495,7 +495,7 @@ func TestProductionPluginDemoContract(t *testing.T) {
 			t.Fatalf("released plugin importer %q = %#v", key, step)
 		}
 		config, exists := step.plugins[0][plugin]
-		if !exists || config.Workflow != workflow || config.Version != "0.2.0" {
+		if !exists || config.Workflow != workflow || config.Version != "" {
 			t.Fatalf("released plugin importer %q config = %#v", key, step.plugins)
 		}
 		wantCondition := ""

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -439,7 +439,7 @@ func TestProductionPluginDemoContract(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	const plugin = "github-actions#984ee8cabfa69a1413edf38c281da9dbccfb62bf"
+	const plugin = "github-actions#d009da173158270a3921b2997ae8fd3d68526d00"
 	type pluginConfig struct {
 		Workflow string `yaml:"workflow"`
 		Version  string `yaml:"version"`


### PR DESCRIPTION
## Summary
- pin the released-plugin demo to companion candidate commit 984ee8cabfa69a1413edf38c281da9dbccfb62bf
- omit all explicit CLI version overrides so both demo lanes exercise the candidate's v0.2.0 default
- preserve the exact plugin/default contract in the pipeline test

## Validation
- mise exec -- go test ./internal/buildkite
- bk pipeline validate --file .buildkite/plugin-demo.yml --no-input

## Hosted proof required before merge/tag
Run the service-free and cache-extension demo selectors against this exact branch commit. The candidate plugin itself is buildkite-plugins/github-actions-buildkite-plugin#2.