### PR TITLE
Align repository documentation with the Buildkite style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # buildkite-gha
 
-Run a GitHub Actions workflow as native Buildkite jobs—without creating a
+Run a GitHub Actions workflow as native Buildkite jobs without creating a
 GitHub Actions run.
 
 `buildkite-gha` translates each workflow job (and each static matrix entry)
 into a Buildkite job, then runs that job's Actions steps in a compatibility
-runtime. Buildkite remains the source of truth for scheduling, logs, retries,
-cancellation, and the build UI.
+runtime. Buildkite Pipelines is the source of truth for scheduling, logs,
+retries, cancellation, and the build interface.
 
 > [!IMPORTANT]
 > This is an experimental v0.1 preview for **public, tokenless, Linux x86-64
@@ -107,7 +107,7 @@ for the exact distinction and intentional behavior differences.
 
 Static validation does not contact Buildkite or execute the workflow:
 
-```sh
+```bash
 buildkite-gha validate .github/workflows/ci.yml
 ```
 
@@ -123,7 +123,7 @@ Result: compilable
 To also resolve public actions and apply the same policy as the plugin's
 `hosted-tokenless` upload, provide an event snapshot:
 
-```sh
+```bash
 buildkite-gha validate \
   --profile hosted-tokenless \
   --event-path .buildkite/events/current.json \
@@ -153,7 +153,7 @@ share a workspace, environment changes, action state, containers, and
 post-action lifecycle in GitHub Actions, so they must stay inside one job here
 too.
 
-```diagram
+```text
 ┌──────────────────────────┐
 │ Actions workflow + event │
 └────────────┬─────────────┘

--- a/docs/architecture/0001-upstream-actions-reuse.md
+++ b/docs/architecture/0001-upstream-actions-reuse.md
@@ -16,8 +16,8 @@ This spike inspected the current released source of `nektos/act`,
 `rhysd/actionlint`, and GitHub's open runner. It considered workflow and action
 models, matrix expansion, expression evaluation, resolution and execution,
 workflow commands and environment files, dependency licensing, and version
-pinning. The repositories were cloned and inspected locally as well as checked
-against their release pages and documentation.
+pinning. The review included local repository inspection and checks against
+the release pages and documentation.
 
 ## Decision
 
@@ -177,12 +177,12 @@ runtimes.
 
 1. Build one internal parser adapter around actionlint and convert syntax nodes
    into owned workflow/action types with source spans.
-2. Implement static matrix expansion and expression evaluation behind owned
+1. Implement static matrix expansion and expression evaluation behind owned
    interfaces, seeded by act tests and verified by GitHub differential fixtures.
-3. Define provider resolution, immutable archives, runtime state, workflow
+1. Define provider resolution, immutable archives, runtime state, workflow
    commands, and environment files independently of act's `RunContext` and
    container interfaces.
-4. Add dependency-update CI that runs parser golden tests, the smoke corpus,
+1. Add dependency-update CI that runs parser golden tests, the smoke corpus,
    license inventory, and SBOM generation before changing the actionlint pin.
-5. Keep an explicit oracle manifest containing the act and official-runner
+1. Keep an explicit oracle manifest containing the act and official-runner
    revisions so behavior changes are reviewed rather than absorbed implicitly.

--- a/docs/architecture/0002-plan-envelope-trust-boundary.md
+++ b/docs/architecture/0002-plan-envelope-trust-boundary.md
@@ -34,7 +34,7 @@ Protected capabilities will instead use a control-plane service that:
 Plans continue to use content digests and producer-attributed artifacts. The
 runtime continues to verify build, importer, job, step, queue, plan, and runtime
 bindings, but those checks do not authorize protected resources. Buildkite
-pipeline signing remains optional installation-specific defence in depth.
+pipeline signing remains optional installation-specific defense in depth.
 
 The original Phase 0 decision is retained below as an implementation and
 conformance record. Its statements that KMS-backed plan envelopes provide the
@@ -117,30 +117,30 @@ resolution:
 1. Apply artifact size and JSON depth limits, reject duplicate keys, parse the
    envelope, and validate its structural schema. The plan may be hashed at this
    stage but is otherwise inert.
-2. Decode and structurally validate the protected header. Reject an unsupported
+1. Decode and structurally validate the protected header. Reject an unsupported
    `alg` or `typ`, an unknown `kid`, or a locally revoked key.
-3. Recreate the JCS claims bytes and verify the JWS signature. Claims do not
+1. Recreate the JCS claims bytes and verify the JWS signature. Claims do not
    influence routing, diagnostics containing attacker-chosen identifiers, or
    authorization until this succeeds.
-4. Check `iat <= now < exp`, `exp > iat`, and `exp - iat <= 86400`. Phase 0 has
+1. Check `iat <= now < exp`, `exp > iat`, and `exp - iat <= 86400`. Phase 0 has
    no clock-skew allowance: compiler and runtime queues must have synchronized
    clocks. A retry cannot mint or extend an envelope; an expired build must be
    rebuilt. A longer supported queue or retry window requires a later contract
    revision rather than an installer override.
-5. Match the organization, pipeline, and build UUIDs to immutable Buildkite job
+1. Match the organization, pipeline, and build UUIDs to immutable Buildkite job
    context.
-6. Match the step key and actual agent queue exactly. Phase 0 reads
+1. Match the step key and actual agent queue exactly. Phase 0 reads
    `BUILDKITE_STEP_KEY` and `BUILDKITE_AGENT_META_DATA_QUEUE`; an absent value is
    a verification failure.
-7. Re-evaluate current local policy using the verified provenance and require
+1. Re-evaluate current local policy using the verified provenance and require
    the envelope capability ceiling to be a subset of that policy. In
    particular, `manual-unattested` and untrusted events cannot reach protected
    queues or capabilities unless an explicit local rule permits the exact
    combination.
-8. Hash the received canonical plan bytes, compare its digest to the envelope,
+1. Hash the received canonical plan bytes, compare its digest to the envelope,
    validate the plan schema, and require its compiler identity, workflow/event
    digests, target step, and target queue to equal the envelope claims.
-9. Require the plan's capability request to be a subset of both the signed
+1. Require the plan's capability request to be a subset of both the signed
    ceiling and current local ceiling, then begin execution.
 
 Every missing, malformed, mismatched, expired, revoked, unsupported, or
@@ -201,16 +201,16 @@ need live Buildkite builds before production support is claimed:
 1. Does a signed bootstrap job dynamically uploading with AWS KMS produce steps
    accepted by every intended self-hosted, Hosted, and Kubernetes verifier
    configuration, including mixed queues during rotation?
-2. Which immutable job context is available before hooks and plugins, and can a
+1. Which immutable job context is available before hooks and plugins, and can a
    custom bootstrap supply `BUILDKITE_BUILD_ID`, `BUILDKITE_STEP_KEY`, and the
    actual queue to the verifier without any plan-controlled override path?
-3. Does artifact download constrained by the compiler step always return the
+1. Does artifact download constrained by the compiler step always return the
    intended immutable plan under retries and duplicate artifact names, and
    what observable producer identity can the runtime verify?
-4. What diagnostic and job state does each pipeline-signature rejection path
+1. What diagnostic and job state does each pipeline-signature rejection path
    produce, and can an unsigned or wrongly signed generated upload ever reach a
    command hook before it is blocked?
-5. How do jobs queued across a plan-key or pipeline-key rotation behave, and
+1. How do jobs queued across a plan-key or pipeline-key rotation behave, and
    what operational delay is required before removing the old verification
    root?
 

--- a/docs/architecture/0003-protected-capability-control-plane.md
+++ b/docs/architecture/0003-protected-capability-control-plane.md
@@ -9,10 +9,10 @@
 The service-free compatibility path can execute public, anonymous workflow code
 without giving it authority beyond its Buildkite job. Summaries, annotations,
 native artifact adapters, public exact-SHA checkout, and the audited
-`actions/cache` v6 client all use public Agent or explicitly configured
-cache-v2 interfaces. They do not establish authority for private source,
-secrets, provider tokens, environments, privileged queues, or compatible OIDC
-claims.
+`actions/cache` v6 client all use public agent interfaces or explicitly
+configured cache-v2 interfaces. They do not establish authority for private
+source, secrets, provider tokens, environments, privileged queues, or compatible
+OIDC claims.
 
 A plan cannot authorize those protected values. Workflow and event files are
 compiler inputs, dynamic pipeline upload is ordinary pipeline authority, and
@@ -20,7 +20,7 @@ the Phase 0 runtime binding proves integrity rather than provider provenance.
 The runtime needs a separate authorization result tied to both the actual
 Buildkite job and independently established provider facts.
 
-Buildkite Job OIDC supplies the job half of that identity. A running Agent can
+Buildkite Job OIDC supplies the job half of that identity. A running agent can
 mint a short-lived token for an exact audience with immutable organization,
 pipeline, build, job, cluster, and queue identifiers. It does not prove the
 complete GitHub event, actor, fork relationship, workflow source, installation,
@@ -69,9 +69,10 @@ separate.
 
 ### Job authentication
 
-The client obtains a fresh token with the Agent command equivalent to:
+The client obtains a fresh token by running the equivalent of this
+`buildkite-agent` command:
 
-```sh
+```bash
 buildkite-agent oidc request-token \
   --audience "$BUILDKITE_GHA_CONTROL_PLANE_URL" \
   --claim organization_id,pipeline_id,build_id,cluster_id,queue_id,queue_key
@@ -84,7 +85,7 @@ paths, queries, fragments, and redirects are rejected. The setting cannot be
 overridden by plan-, workflow-, repository-, or ordinary build-supplied
 environment. The client captures the token without logging it, keeps it in
 memory for one exchange, and sends it only to that bound service as the
-control-plane bearer credential. It never reads or forwards the ambient Agent
+control-plane bearer credential. It never reads or forwards the ambient agent
 access token to that service or to action code.
 
 The control plane validates the token against the fixed Buildkite issuer
@@ -207,17 +208,17 @@ remain in the platform signing boundary.
 The runtime treats the response as inert bytes until all of these checks pass:
 
 1. Bound response size and structural depth.
-2. Validate the protected header and select a configured, non-revoked key.
-3. Verify the JWS signature before using any claim in routing or diagnostics.
-4. Validate schema, issuer, audience, ID, time window, and capability vocabulary.
-5. Match every Buildkite claim exposed through immutable current-job context,
+1. Validate the protected header and select a configured, non-revoked key.
+1. Verify the JWS signature before using any claim in routing or diagnostics.
+1. Validate schema, issuer, audience, ID, time window, and capability vocabulary.
+1. Match every Buildkite claim exposed through immutable current-job context,
    including build/job identity, step key, and queue key. IDs that are present
    only in verified Job OIDC are enforced by the control plane and retained in
    the signed grant for audit and later platform-supported runtime comparison.
-6. Match the plan and event digests to the exact decoded plan.
-7. Require the granted set to be a subset of the plan request and current local
+1. Match the plan and event digests to the exact decoded plan.
+1. Require the granted set to be a subset of the plan request and current local
    runtime policy.
-8. Resolve only the intersection of plan request, signed grant, and local
+1. Resolve only the intersection of plan request, signed grant, and local
    policy, at the point where a protected value is needed.
 
 For the no-op slice, the runtime verifies and discards the empty grant. It must
@@ -246,16 +247,16 @@ record; a successful job alone does not prove policy or audit behavior.
 ## Initial implementation sequence
 
 1. Finalize the request/grant schemas and platform endpoint ownership.
-2. Implement the platform verifier for Buildkite OIDC and authoritative GitHub
+1. Implement the platform verifier for Buildkite OIDC and authoritative GitHub
    event-to-build correlation.
-3. Implement empty-request policy, signed empty grants, JWKS publication, and
+1. Implement empty-request policy, signed empty grants, JWKS publication, and
    audit records without any credential backend.
-4. Add the `buildkite-gha` OIDC client and grant verifier behind explicit
+1. Add the `buildkite-gha` OIDC client and grant verifier behind explicit
    control-plane configuration.
-5. Add positive and negative conformance fixtures for signature, audience,
+1. Add positive and negative conformance fixtures for signature, audience,
    expiry, build/job/step/queue, plan/event digest, provider event, policy,
    capability broadening, key rotation, revocation, and service absence.
-6. Run one exact-commit hosted no-op proof and independently observe its audit
+1. Run one exact-commit hosted no-op proof and independently observe its audit
    binding before considering any credential-returning slice.
 
 ## Deferred decisions

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -9,15 +9,15 @@ promises unless they appear here.
 
 The plugin and `upload` command use one fixed profile: `hosted-tokenless`.
 It is designed for public code that can run without protected credentials on a
-Linux x86-64 Buildkite Hosted Agent. Unsupported or privileged requests fail
+Linux x86-64 Buildkite hosted agent. Unsupported or privileged requests fail
 before the generated jobs are uploaded.
 
 There are three different compatibility claims:
 
-1. **Compilable** — the workflow syntax and static job graph can be translated.
-2. **Admitted** — action sources resolve and the generated plans satisfy the
+1. **Compilable:** The workflow syntax and static job graph can be translated.
+1. **Admitted:** Action sources resolve and the generated plans satisfy the
    `hosted-tokenless` upload policy.
-3. **Runtime-proven** — the repository's conformance or hosted test suite has
+1. **Runtime-proven:** The repository's conformance or hosted test suite has
    executed that behavior successfully.
 
 Compilation alone is not admission, and admission does not execute arbitrary
@@ -41,8 +41,8 @@ provide.
 | Anonymous public actions | Supported | Sources are resolved to immutable commits and complete trees are verified. |
 | `actions/checkout` | Narrow support | Public `github.com` event repository, exact event SHA, workspace root, shallow credential-free fetch. |
 | Dockerfile actions | Supported subset | Only compiler-verified local or anonymous public Dockerfile actions are admitted. |
-| Step summaries | Supported | Published as job-scoped Buildkite annotations with a stable context. Requires Buildkite Agent v3.112 or newer. Oversized per-step summaries are skipped without failing the job; aggregate job summaries are bounded to 1 MiB. |
-| Workflow commands | Supported subset | `::add-mask`, `::stop-commands`, `::warning`, and `::error` are supported. Warnings and errors retain title/file/range metadata and publish under separate, stable job-scoped contexts without changing step or job conclusions. Each aggregate is bounded to 1 MiB and requires Buildkite Agent v3.112 or newer for publication. `::notice`, groups, command echo control, and legacy commands are not supported. |
+| Step summaries | Supported | Published as job-scoped Buildkite annotations with a stable context. Requires Buildkite agent v3.112 or newer. Oversized per-step summaries are skipped without failing the job; aggregate job summaries are bounded to 1 MiB. |
+| Workflow commands | Supported subset | `::add-mask`, `::stop-commands`, `::warning`, and `::error` are supported. Warnings and errors retain title/file/range metadata and publish under separate, stable job-scoped contexts without changing step or job conclusions. Each aggregate is bounded to 1 MiB and requires Buildkite agent v3.112 or newer for publication. `::notice`, groups, command echo control, and legacy commands are not supported. |
 | `actions/upload-artifact` | Narrow support | The audited v4 commit supports bounded literal files/directories, ZIP compression levels, hidden-file selection, exact no-file behavior, and native Buildkite publication. See the explicit limits below. |
 | `actions/download-artifact` | Narrow support | The audited v4.3.0 commit supports one exact literal name from verified direct `needs`, extracting directly to a clean workspace-relative path. |
 | `actions/cache` | Narrow v6 support | Only the audited v6.1.0 commit is admitted. It runs the stock ESM cache-v2 client with job-bound Buildkite credentials and requires an operator-configured compatible Results service. The predecessor fixture's exact miss/save/dependent-hit lifecycle passed in Buildkite build 303. |
@@ -59,8 +59,8 @@ provide.
 ### Buildkite owns the run
 
 No shadow GitHub Actions run is created. Workflow jobs and matrix entries are
-visible as Buildkite jobs, with Buildkite scheduling, logs, cancellation,
-retries, and status.
+visible as Buildkite jobs, with scheduling, logs, cancellation, retries, and
+status managed in Buildkite Pipelines.
 
 Actions steps remain inside one compatibility runtime because they share a
 workspace, environment-file updates, action state, and cleanup lifecycle.
@@ -101,9 +101,9 @@ one job workspace and lifecycle.
 ### Buildkite owns triggers
 
 Select the workflow explicitly in the plugin and configure pipeline triggers in
-Buildkite. `buildkite-gha` uses the event snapshot to populate Actions contexts;
-it does not subscribe to GitHub events or turn workflow `on:` entries into
-Buildkite triggers.
+Buildkite Pipelines. `buildkite-gha` uses the event snapshot to populate Actions
+contexts; it does not subscribe to GitHub events or turn workflow `on:` entries
+into Buildkite triggers.
 
 The plugin derives `pull_request` for Buildkite pull request builds and `push`
 for branch, tag, scheduled, and manual builds. It does not currently provide
@@ -118,19 +118,20 @@ semantics when Buildkite has not supplied them.
 
 ### Checkout starts clean
 
-Generated jobs skip Buildkite's default checkout and allocate a fresh Actions
-workspace. A supported `actions/checkout` step performs a credential-free,
-shallow checkout of the public event repository at the exact event SHA. Private
-checkout, alternate repositories or refs, and credential persistence are not
-available in the preview.
+Generated jobs skip the default checkout in Buildkite Pipelines and allocate a
+fresh Actions workspace. A supported `actions/checkout` step performs a
+credential-free, shallow checkout of the public event repository at the exact
+event SHA. Private checkout, alternate repositories or refs, and credential
+persistence are not available in the preview.
 
 ### Artifact uploads use bounded native storage
 
 The producer-side adapter recognizes only
 `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02`.
 It verifies that immutable action source and metadata, then replaces the whole
-upstream JavaScript lifecycle with a Buildkite Agent artifact upload. A mutable
-v4 reference is accepted only when resolution produces that audited commit.
+upstream JavaScript lifecycle with a native artifact upload through
+`buildkite-agent`. A mutable v4 reference is accepted only when resolution
+produces that audited commit.
 
 The supported inputs are `name`, `path`, `if-no-files-found`,
 `include-hidden-files`, `compression-level`, explicit `overwrite: false`, and
@@ -167,13 +168,13 @@ cache-v2 environment only to that verified action invocation.
 
 Before each pre, main, or post phase that runs, the runtime posts an empty body
 to the current job's
-`/v3/jobs/<BUILDKITE_JOB_ID>/ghac_tokens` Agent API endpoint using the ambient
+`/v3/jobs/<BUILDKITE_JOB_ID>/ghac_tokens` agent API endpoint using the ambient
 `BUILDKITE_AGENT_ACCESS_TOKEN`. The returned short-lived token is registered
 with both the local log scrubber and `buildkite-agent redactor add` before the
 action starts. A fresh token is minted for post-save rather than retaining a
 main-phase credential. The runtime exposes only `ACTIONS_CACHE_SERVICE_V2`,
 `ACTIONS_RESULTS_URL`, and `ACTIONS_RUNTIME_TOKEN` to the cache action; it does
-not forward the Agent job token, persist cache credentials into job state, or
+not forward the agent job token, persist cache credentials into job state, or
 expose them to ordinary actions. Credential-bearing phases also discard
 workflow-controlled legacy cache URLs, Node/process injection settings, TLS
 and OpenSSL configuration/module overrides, tar and dynamic-loader controls,
@@ -187,7 +188,7 @@ Operators must set `BUILDKITE_GHA_CACHE_URL` to the origin-only URL of the
 compatible Results service; a non-root path is rejected because the stock
 cache-v2 client uses root-relative Twirp endpoints. The Buildkite organization
 must also have GHAC token minting enabled, and jobs must be able to reach both
-that service and the Agent API.
+that service and the agent API.
 The service-issued token scopes cache access to the current organization and
 pipeline, grants writes only for an authorized ref, and limits cross-repository
 pull requests to the read-only default-branch scope. Missing configuration,
@@ -240,13 +241,13 @@ require glibc 2.28 or newer; the static Go CLI does not. `validate` and
 
 Validate the static workflow subset without an event:
 
-```sh
+```bash
 buildkite-gha validate .github/workflows/ci.yml
 ```
 
 Apply the production profile with human-readable or machine-readable output:
 
-```sh
+```bash
 buildkite-gha validate --profile hosted-tokenless \
   --event-path .buildkite/events/current.json --format text \
   .github/workflows/ci.yml
@@ -294,7 +295,7 @@ and cannot authorize a protected capability.
 
 Render deterministic Buildkite pipeline YAML, or inspect the compiler IR:
 
-```sh
+```bash
 buildkite-gha compile --event-path .buildkite/events/current.json \
   .github/workflows/ci.yml
 
@@ -311,7 +312,7 @@ not a complete execution path.
 
 `upload` is the in-build command used by the plugin:
 
-```sh
+```bash
 buildkite-gha upload --runtime-queue hosted .github/workflows/ci.yml
 ```
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,14 +4,14 @@
 
 The repository pins Go and all lint and release tools with mise:
 
-```sh
+```bash
 mise trust mise.toml
 mise install
 ```
 
 Run the complete repository check with:
 
-```sh
+```bash
 mise run check
 ```
 
@@ -26,7 +26,7 @@ live prerequisites and fails rather than silently losing Phase 5 coverage.
 
 Focused tasks are also available:
 
-```sh
+```bash
 mise run format
 mise run build
 mise run test
@@ -43,7 +43,7 @@ The smoke inventory deliberately separates three kinds of evidence.
 
 ### Network-free compilation
 
-```sh
+```bash
 mise run smoke:local
 ```
 
@@ -57,7 +57,7 @@ and the precise meaning of each expectation.
 
 ### Production-policy preflight
 
-```sh
+```bash
 mise run smoke:profile
 ```
 
@@ -78,7 +78,7 @@ outside production admission.
 
 Run all implemented hosted proofs against one exact commit:
 
-```sh
+```bash
 commit=$(git rev-parse HEAD)
 test ${#commit} -eq 40
 bk build create --pipeline buildkite/buildkite-gha \
@@ -107,7 +107,7 @@ outcome does not by itself prove that Buildkite persisted the annotation. After
 the targeted or aggregate build settles, use an authenticated `bk` CLI with
 `read_builds` access to verify the job-scoped annotation independently:
 
-```sh
+```bash
 scripts/phase-6-summary-annotation-verify <build-number> <commit>
 ```
 
@@ -119,7 +119,7 @@ fragments.
 Workflow-command annotation publication is also advisory. Verify its distinct
 warning and error contexts independently after the annotations proof settles:
 
-```sh
+```bash
 scripts/phase-6-workflow-annotations-verify <build-number> <commit>
 ```
 
@@ -131,7 +131,7 @@ absence of the registered masking canary.
 Artifact publication and consumption require independent native-storage
 observations after their targeted or aggregate builds settle:
 
-```sh
+```bash
 scripts/phase-6-upload-artifact-verify <build-number> <commit>
 scripts/phase-6-artifact-roundtrip-verify <build-number> <commit>
 ```
@@ -147,7 +147,7 @@ advanced service-free workflow without adding another phase-specific proof. It
 builds the exact checked-out source locally, so it is runtime evidence rather
 than installation evidence:
 
-```sh
+```bash
 commit=$(git rev-parse HEAD)
 test ${#commit} -eq 40
 bk build create --pipeline buildkite/buildkite-gha \
@@ -166,7 +166,7 @@ exact-commit hosted evidence through the released plugin.
 After CLI `v0.2.0` is published from the exact commit, exercise the complete
 customer installation path through the pinned companion plugin:
 
-```sh
+```bash
 commit=$(git rev-parse HEAD)
 test ${#commit} -eq 40
 bk build create --pipeline buildkite/buildkite-gha \
@@ -179,7 +179,7 @@ action, and advanced workflows, then a native terminal step. Add the cache
 extension only for an organization with GHAC token minting enabled and an
 explicitly configured compatible origin:
 
-```sh
+```bash
 bk build create --pipeline buildkite/buildkite-gha \
   --branch "$(git branch --show-current)" --commit "$commit" \
   --env DEMO_SUITE=plugin --env DEMO_COMMIT="$commit" \
@@ -212,7 +212,7 @@ coverage, differential oracles, commits, and historical Buildkite evidence.
 
 From a clean, up-to-date `main`, run:
 
-```sh
+```bash
 mise run release
 ```
 
@@ -238,8 +238,8 @@ the `GHA_GITHUB_RELEASE_TOKEN` Buildkite Secret, restricted to webhook-created
   build_branch: "v*"
 ```
 
-Buildkite records a tag webhook's tag name as the build branch, so these claims
-exclude ordinary branch and pull request webhook builds. The publisher also
-verifies that the upstream tag, checked-out commit, and Buildkite commit agree
-before retrieving the token. Never expose this token through a shared agent
-environment hook.
+Buildkite Pipelines records a tag webhook's tag name as the build branch, so
+these claims exclude ordinary branch and pull request webhook builds. The
+publisher also verifies that the upstream tag, checked-out commit, and Buildkite
+commit agree before retrieving the token. Never expose this token through a
+shared agent environment hook.

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -1,4 +1,4 @@
-# `buildkite-gha`: GitHub Actions compatibility for Buildkite
+# buildkite-gha: GitHub Actions compatibility for Buildkite
 
 Status: **Active**
 Date: 2026-07-22
@@ -18,7 +18,7 @@ GitHub Actions workflow to run as a native Buildkite build. The project has two
 responsibilities:
 
 1. Compile a GitHub Actions workflow into ordinary Buildkite pipeline jobs.
-2. Execute the GitHub Actions steps inside each generated Buildkite job through
+1. Execute the GitHub Actions steps inside each generated Buildkite job through
    an Actions-compatible runtime.
 
 The intended entry point is conceptually:
@@ -27,16 +27,16 @@ The intended entry point is conceptually:
 buildkite-gha upload .github/workflows/ci.yml
 ```
 
-with a possible future Buildkite Agent integration:
+with a possible future `buildkite-agent` integration:
 
 ```bash
 buildkite-agent pipeline load-gha-workflow .github/workflows/ci.yml
 ```
 
-Buildkite, not GitHub, owns scheduling, logs, job state, cancellation, retries,
-artifacts, and the build UI. GitHub may remain the source-code host during
-migration, but it is not part of the workflow execution control plane. This
-also permits a repository to move to Cursor Origin without replacing the
+Buildkite Pipelines, not GitHub, owns scheduling, logs, job state, cancellation,
+retries, artifacts, and the build UI. GitHub may remain the source-code host
+during migration, but it is not part of the workflow execution control plane.
+This also permits a repository to move to Cursor Origin without replacing the
 execution architecture.
 
 The unit of translation is the Actions job:
@@ -64,15 +64,15 @@ parallel and background steps.
 A team should be able to:
 
 1. Create a Buildkite pipeline for an existing repository.
-2. Point it at an existing `.github/workflows/*.yml` file.
-3. Run the workflow on Buildkite with useful compatibility diagnostics and no
+1. Point it at an existing `.github/workflows/*.yml` file.
+1. Run the workflow on Buildkite with useful compatibility diagnostics and no
    GitHub Actions control-plane dependency.
-4. View progress and logs in Buildkite.
-5. Add native Buildkite jobs before or after the imported workflow.
-6. Replace individual imported jobs with native Buildkite jobs over time.
-7. Move the repository from GitHub to Cursor Origin while retaining the same
+1. View progress and logs in Buildkite.
+1. Add native Buildkite jobs before or after the imported workflow.
+1. Replace individual imported jobs with native Buildkite jobs over time.
+1. Move the repository from GitHub to Cursor Origin while retaining the same
    Buildkite pipeline and most portable actions.
-8. Remove the compatibility layer when the migration is complete.
+1. Remove the compatibility layer when the migration is complete.
 
 GitHub Actions becomes an accepted pipeline and action format, not the system
 of record.
@@ -81,9 +81,9 @@ of record.
 
 ### Buildkite is authoritative
 
-Every imported workflow is a normal Buildkite build. Buildkite owns the job
-graph and displays the live job logs. There is no shadow GitHub workflow run to
-reconcile and no requirement to visit GitHub to understand progress.
+Every imported workflow is a normal Buildkite build. Buildkite Pipelines owns
+the job graph and displays the live job logs. There is no shadow GitHub workflow
+run to reconcile and no requirement to visit GitHub to understand progress.
 
 ### Event identity and capability issuance are the security boundary
 
@@ -152,7 +152,7 @@ runtime capabilities, and security-sensitive behavior before execution.
 
 The compiler records secret names and permission requirements, never values.
 The runtime resolves secrets inside the destination job, registers them with
-the Buildkite Agent redactor before action output can be emitted, and keeps
+the Buildkite agent redactor before action output can be emitted, and keeps
 them out of metadata, artifacts, generated YAML, and debug diagnostics.
 
 ## Goals
@@ -168,7 +168,7 @@ them out of metadata, artifacts, generated YAML, and debug diagnostics.
   uploads.
 - Provide deterministic compilation and a versioned intermediate
   representation.
-- Work through stable public Buildkite pipeline and Agent interfaces rather
+- Work through stable public Buildkite pipeline and agent interfaces rather
   than private Rails APIs.
 - Support GitHub and Cursor Origin as repository/event providers through a
   provider-neutral event and source interface.
@@ -240,7 +240,7 @@ buildkite-gha compile .github/workflows/ci.yml |
 ```
 
 `upload` is the ergonomic in-build command. It creates per-job plan artifacts,
-uploads the generated pipeline through the Buildkite Agent, and fails the
+uploads the generated pipeline through `buildkite-agent`, and fails the
 bootstrap job if either operation fails.
 
 ### Initial Buildkite pipeline
@@ -294,15 +294,15 @@ steps:
     command: ".buildkite/deploy.sh"
 ```
 
-Buildkite's dynamic pipeline dependency rule causes a step depending on the
-upload job to also wait for jobs subsequently uploaded by it. The compiler must
-still emit explicit keys and `depends_on` relationships for the imported DAG;
-visual insertion order is not an execution contract.
+The dynamic pipeline dependency rule in Buildkite Pipelines causes a step that
+depends on the upload job to also wait for jobs subsequently uploaded by it. The
+compiler must still emit explicit keys and `depends_on` relationships for the
+imported DAG; visual insertion order is not an execution contract.
 
 ### Future first-class syntax
 
 Once the project is proven, Buildkite could recognize an import in its pipeline
-schema or expose it through the Agent:
+schema or expose it through `buildkite-agent`:
 
 ```yaml
 steps:
@@ -322,7 +322,7 @@ it.
 
 ## Architecture
 
-```diagram
+```text
 ┌──────────────────────────┐
 │ Workflow + event payload │
 └────────────┬─────────────┘
@@ -599,7 +599,7 @@ bootstrap contract is:
 - reject protected capability requests unless a matching control-plane grant
   can be established by the execution job.
 
-Buildkite signed pipelines are an optional Buildkite-specific defence-in-depth
+Buildkite signed pipelines are an optional Buildkite-specific defense-in-depth
 layer for installations that require uploaded step provenance. They are not a
 GitHub Actions compatibility requirement, and neither pipeline signatures nor
 plan signatures replace the protected capability service.
@@ -630,7 +630,7 @@ The emitter maps every expanded GHA job to an ordinary command step with:
 - the installation mechanism for the same pinned `buildkite-gha` version that
   performed compilation.
 
-Native checkout suppression requires Buildkite Agent v3.130.0 or later. The
+Native checkout suppression requires Buildkite agent v3.130.0 or later. The
 runtime must still allocate and verify a fresh empty directory for
 `GITHUB_WORKSPACE`; it must not assume that the agent command directory is empty
 or suitable merely because checkout was skipped. The generated command and
@@ -732,11 +732,11 @@ strategy:
 Represent these as deferred graph continuations:
 
 1. Compile and upload the known prerequisite graph.
-2. The prerequisite publishes a bounded, producer-attributed result manifest.
-3. A generated continuation command downloads that manifest from the exact
+1. The prerequisite publishes a bounded, producer-attributed result manifest.
+1. A generated continuation command downloads that manifest from the exact
    prerequisite step and verifies its plan identity.
-4. The compiler expands only the newly available portion of the graph.
-5. It publishes immutable plans and uploads the downstream Buildkite jobs with
+1. The compiler expands only the newly available portion of the graph.
+1. It publishes immutable plans and uploads the downstream Buildkite jobs with
    stable keys.
 
 Continuations are ordinary authoritative dynamic uploads within the same
@@ -747,8 +747,9 @@ capability grant. Each newly generated job that needs protected authority must
 be covered by a matching grant bound to its plan and authenticated job identity.
 
 Continuations and the initial upload must use an explicit retry protocol.
-Buildkite rejects an upload when a step key already exists; deterministic keys
-prevent duplication but do not make a retry succeed automatically.
+Buildkite Pipelines rejects an upload when a step key already exists;
+deterministic keys prevent duplication but do not make a retry succeed
+automatically.
 
 Before uploading, record a signed expected pipeline digest and key manifest
 under a namespaced metadata marker. After the upload command returns success,
@@ -775,34 +776,35 @@ protocol against a real partially retried build.
 job. Its state machine is:
 
 1. Verify the job plan and runtime version.
-2. Load producer-attributed prerequisite results and outputs, evaluate the job
+1. Load producer-attributed prerequisite results and outputs, evaluate the job
    condition, and, when false, record `skipped` and exit successfully without
    resolving secrets or starting containers.
-3. Resolve non-secret variables and required secrets.
-4. Register every resolved secret with the Buildkite Agent redactor.
-5. Create an empty GHA workspace and temporary directories.
-6. Start the job container and service containers, if configured.
-7. Resolve and prepare local and remote actions.
-8. Execute pre-actions in required order.
-9. Execute main steps, evaluating each condition at step start.
-10. Process workflow commands and environment files after every step.
-11. Execute post-actions in LIFO order, including after failure or cancellation
-    within a bounded cleanup period.
-12. Evaluate and record job outputs and the logical job result.
-13. Publish step summaries and perform container/process cleanup.
-14. Exit with the Buildkite result corresponding to the logical GHA result.
+1. Resolve non-secret variables and required secrets.
+1. Register every resolved secret with the Buildkite agent redactor.
+1. Create an empty GHA workspace and temporary directories.
+1. Start the job container and service containers, if configured.
+1. Resolve and prepare local and remote actions.
+1. Execute pre-actions in required order.
+1. Execute main steps, evaluating each condition at step start.
+1. Process workflow commands and environment files after every step.
+1. Execute post-actions in LIFO order, including after failure or cancellation
+   within a bounded cleanup period.
+1. Evaluate and record job outputs and the logical job result.
+1. Publish step summaries and perform container/process cleanup.
+1. Exit with the Buildkite result corresponding to the logical GHA result.
 
-Generated GHA jobs should begin with an empty workspace rather than Buildkite's
-automatic repository checkout. This preserves Actions behavior for workflows
-that do or do not invoke `actions/checkout`. The plan artifact is sufficient to
-start the runtime. Local actions become available only after the workflow has
-populated the workspace, as they do in GitHub Actions.
+Generated GHA jobs should begin with an empty workspace rather than the
+automatic repository checkout in Buildkite Pipelines. This preserves Actions
+behavior for workflows that do or do not invoke `actions/checkout`. The plan
+artifact is sufficient to start the runtime. Local actions become available
+only after the workflow has populated the workspace, as they do in GitHub
+Actions.
 
 ### Step execution
 
 Support these step/action types:
 
-#### `run` steps
+#### run steps
 
 - GHA default-shell selection and shell flags;
 - `defaults.run.shell` and `working-directory`;
@@ -924,7 +926,7 @@ protected.
 Step summaries become job-scoped Buildkite annotations when supported, with a
 stable context. Oversized per-step summaries are rejected without failing the
 job, matching GitHub Actions, while the aggregate annotation is truncated to
-Buildkite's 1 MiB body limit.
+the 1 MiB annotation body limit in Buildkite Pipelines.
 
 Parallel step logs need explicit step identity. Prefer live prefixed output and
 per-step completion summaries over buffering all output until completion.
@@ -955,10 +957,10 @@ Actions fall into three product categories:
 1. **Portable actions** operate on the workspace, execute tools, or call an
    independent external API. Run their JavaScript, container, or composite
    implementation directly.
-2. **Actions-runtime integrations** depend on GitHub's cache, artifact, OIDC,
+1. **Actions-runtime integrations** depend on GitHub's cache, artifact, OIDC,
    or token services. Provide Buildkite-backed protocol services or explicit
    compatibility adapters.
-3. **Provider-dependent actions** modify GitHub repositories, pull requests,
+1. **Provider-dependent actions** modify GitHub repositories, pull requests,
    checks, issues, or releases. They can use a scoped GitHub token while GitHub
    is the repository provider. Under Cursor Origin they require an Origin
    equivalent or must be migrated.
@@ -979,7 +981,7 @@ repository metadata while preserving the action's documented inputs and
 outputs. Cache and artifact support should use Buildkite storage semantics
 without exposing GitHub's private service credentials.
 
-### Triggers and workflow `on`
+### Triggers and workflow on
 
 `buildkite-gha` does not itself listen for repository events. A Buildkite
 pipeline, API caller, or future Origin integration creates the build.
@@ -1020,7 +1022,7 @@ authority.
   code; workflow-controlled `runs-on` values cannot select a privileged queue.
 - Provider API tokens are short-lived and least-privilege.
 - Reusable workflows can only narrow inherited permissions.
-- Every secret is registered with the Agent redactor before use.
+- Every secret is registered with the agent redactor before use.
 - Job outputs containing registered secret literals or explicitly supported
   standard encodings are rejected rather than published; general secret taint
   tracking is out of scope.
@@ -1187,7 +1189,7 @@ findings are machine-readable through `--format json`.
 
 The first externally useful beta should support:
 
-- Linux x86-64 on a compatible Hosted Agent image;
+- Linux x86-64 on a compatible hosted agent image;
 - `push`, `pull_request`, and manual-input event envelopes;
 - `env`, `defaults`, `needs`, job and step `if`, timeouts, and bounded outputs;
 - static matrices with `include`, `exclude`, and `max-parallel`, plus
@@ -1311,11 +1313,12 @@ Cursor Origin public checkout remains a separate provider integration gate.
   masking, so the distinct checked-in hosted fixture is now `runtime-pass`.
   The producer-side artifact slice now recognizes only the audited
   `actions/upload-artifact` v4 commit and replaces its lifecycle with a bounded
-  Buildkite Agent upload. Literal workspace files and directories become an
-  immutable, digest-addressed ZIP; compatible artifact ID and digest outputs
-  and the native path, size, and file count are bound into the authoritative
-  terminal result manifest. Globs, symlinks, overwrite, retention, raw upload,
-  and unrecognized upstream commits fail explicitly. Build 259 and its
+  native artifact upload through `buildkite-agent`. Literal workspace files
+  and directories become an immutable, digest-addressed ZIP; compatible
+  artifact ID and digest outputs and the native path, size, and file count are
+  bound into the authoritative terminal result manifest. Globs, symlinks,
+  overwrite, retention, raw upload, and unrecognized upstream commits fail
+  explicitly. Build 259 and its
   exact-commit artifact observation prove publication, attribution, manifest
   binding, archive integrity and contents, hidden-file exclusion, and compatible
   action outputs, so the separate upload-only fixture is now `runtime-pass`.
@@ -1337,7 +1340,7 @@ Cursor Origin public checkout remains a separate provider integration gate.
   The runtime mints a fresh, job-bound GHAC token for each action lifecycle
   phase, registers it with both redaction layers before execution, and exposes
   the three cache-v2 variables only to the verified cache action. The ambient
-  Agent job token never enters action code or plan/result state. Older majors,
+  agent job token never enters action code or plan/result state. Older majors,
   other commits, unsafe mint responses, redirects, missing service
   configuration, and redaction failure all fail closed. The then-combined
   advanced migration POC forms the exact-commit implementation proof: it
@@ -1405,7 +1408,7 @@ Cursor Origin public checkout remains a separate provider integration gate.
 - All local tests, race tests, vet, schema fixtures, shell checks, and offline
   pipeline validation pass. A default `.buildkite/pipeline.yml` now runs the
   repository checks, and all compilable smoke-manifest outputs pass the current
-  Buildkite Agent's `pipeline upload --dry-run --no-interpolation` parser.
+  Buildkite agent's `pipeline upload --dry-run --no-interpolation` parser.
 - The smoke inventory now separates compilation, production-policy admission,
   and runtime evidence. `mise run smoke:local` is network-free: it validates
   the manifest and workflows and checks deterministic compilation, but is not
@@ -1568,7 +1571,7 @@ Phase 2 live evidence:
 - [Buildkite build 40](https://buildkite.com/buildkite/buildkite-gha/builds/40)
   ran exact implementation commit
   `e93298085ffef96e1cb0982e7a0b88f3558b11da`. The producer and both consumer
-  matrix jobs passed on ephemeral hosted Agent `4.0.0-beta.6`, followed by the
+  matrix jobs passed on ephemeral hosted agent `4.0.0-beta.6`, followed by the
   native Buildkite continuation and the full repository check.
 - The consumer logs emitted the normalized observations
   `{"result":"smoke-shell","variant":"one"}` and
@@ -1596,7 +1599,7 @@ Phase 0 live evidence:
   passed the complete transport at commit
   `787b3adfe306a17fbf073c70b24f8b747b5882a8`: immutable plan artifacts,
   producer-constrained result download, generated dependency execution, native
-  dependency extension, metadata visibility, and Agent redaction all passed.
+  dependency extension, metadata visibility, and agent redaction all passed.
 - [Buildkite build 15](https://buildkite.com/buildkite/buildkite-gha/builds/15)
   proved that the consumer runs and verifies a failure manifest after its
   producer fails. [Buildkite build 19](https://buildkite.com/buildkite/buildkite-gha/builds/19)
@@ -1613,7 +1616,7 @@ Phase 0 spike support snapshot:
 | Compile | Actionlint-backed owned model, deterministic compile-time context and vars evaluation, bounded local reusable-workflow flattening, source-ordered matrix `include`/`exclude`, exact dependency fan-out, policy-selected queues, schema-valid versioned plans, and Buildkite pipeline YAML | Runtime-dependent graph expressions, remote reusable workflows, unsupported operating systems, and unmapped runner labels fail closed |
 | Execute | Bash/sh steps; ten-active-step concurrency with barrier-scoped effects; JavaScript, composite, and Dockerfile actions; persistent job containers; services for container and host jobs; fresh workspaces; bounded prerequisite, step, and job outputs; file commands; conditions; masking; timeouts; process-tree cancellation; `continue-on-error`; bounded LIFO post-actions; and exact container cleanup | Producer result hydration enters through the transport boundary; private actions, `docker://` actions, protected credentials, arbitrary container options, unsupported operating systems, and unsupported expression/coercion forms fail closed |
 | Differential | Isolated committed fixture, canonical capture/comparison, offline validation, and matching hosted GitHub Actions and Buildkite observations | Broader runtime behavior remains phase-specific differential work |
-| Transport | Confined materialization of verified content-addressed plan and binding bytes, deterministic two-job live upload, strict compiler edges, failure-settling logical edges, producer-bound manifests, metadata, Agent redaction, signed markers, and native dependency extension | The probe deliberately avoids assuming upload atomicity |
+| Transport | Confined materialization of verified content-addressed plan and binding bytes, deterministic two-job live upload, strict compiler edges, failure-settling logical edges, producer-bound manifests, metadata, agent redaction, signed markers, and native dependency extension | The probe deliberately avoids assuming upload atomicity |
 | Authorization | Eight signed-envelope conformance cases plus live rejection of a corrupted signature prove bounded signing and verification mechanics only | Protected capabilities require Buildkite Job OIDC authentication, provider provenance and policy verification, narrow signed grants, runtime exchange checks, and auditability; Buildkite signed-pipeline integration remains optional Phase 9 work |
 | Recovery | Ambiguous, partial, conflicting, or unattested interrupted uploads fail closed; a live interrupted upload and retry returned exit 75 | Operator cancel/rebuild is the supported recovery until Buildkite exposes an authoritative completed-upload query |
 
@@ -1633,11 +1636,11 @@ Build four spikes before committing to the runtime implementation:
 
 1. Parse and compile representative workflows using selected `act` and
    `actionlint` components into an owned intermediate representation.
-2. Run one JavaScript, one composite, and one Docker action inside a Buildkite
+1. Run one JavaScript, one composite, and one Docker action inside a Buildkite
    job while preserving outputs, masks, environment changes, and post-actions.
-3. Run equivalent fixture workflows on GitHub Actions and Buildkite and compare
+1. Run equivalent fixture workflows on GitHub Actions and Buildkite and compare
    normalized observations.
-4. Exercise the complete transport on a real Buildkite build: upload immutable
+1. Exercise the complete transport on a real Buildkite build: upload immutable
    plan artifacts, dynamically upload two dependent jobs, download and verify
    plans by compiler step, publish and consume producer-attributed result
    manifests, verify per-dependency failure handling keeps the compiler edge
@@ -1664,7 +1667,7 @@ Definition of done:
 - Compiler and runtime boundaries are proven without a GitHub runner service.
 - The action runtime can stream already-masked output into a Buildkite job.
 - Plan artifact ordering, dynamic dependency extension, metadata visibility,
-  producer attribution, and Agent redaction are proven in a real build.
+  producer attribution, and agent redaction are proven in a real build.
 - Interrupted-upload recovery is proven in a real build when a documented
   verification query exists; otherwise the fail-closed path and explicit
   operator recovery are proven and recorded as the supported behavior.
@@ -1743,14 +1746,14 @@ Delivery slices:
    conditions and status functions, environment precedence, supported shells
    and working directories, file commands, timeouts, cancellation,
    `continue-on-error`, and bounded cleanup.
-2. Promote the Phase 0 result probe into production transport contracts:
+1. Promote the Phase 0 result probe into production transport contracts:
    canonical producer-attributed manifests, exact-step artifact download,
    bounded metadata mirrors, and verified `needs` injection.
-3. Implement `buildkite-gha upload` for the explicit unprivileged local-event
+1. Implement `buildkite-gha upload` for the explicit unprivileged local-event
    mode, materializing immutable plans before dynamically uploading the
    generated pipeline. Protected capabilities remain unavailable until the
    control plane for that capability exists.
-4. Run `testdata/smoke/.github/workflows/shell.yml` on Buildkite, compare its
+1. Run `testdata/smoke/.github/workflows/shell.yml` on Buildkite, compare its
    normalized observation with the GitHub Actions oracle, exercise failure and
    cancellation cleanup, and inspect raw logs for the secret fixture.
 
@@ -1832,15 +1835,15 @@ Implemented order and fixed boundaries:
    the verified action tree, select `buildx build --builder default --load`, use
    fixed structured mounts and bridge-owned labels, and stop/remove containers
    and images under an independent bounded cleanup context.
-2. Admit only local and anonymously resolved public Dockerfile actions on the
+1. Admit only local and anonymously resolved public Dockerfile actions on the
    fixed tokenless `hosted` queue. Continue rejecting `docker://` images,
    Docker pre/post entrypoints, arbitrary Docker options, private registries,
    credentials, provider tokens, host namespaces, devices, socket mounts, and
    privileged capabilities.
-3. Persistent job containers and path translation landed after Docker action
+1. Persistent job containers and path translation landed after Docker action
    lifecycle, command-file processing, masking, cancellation, and cleanup
    passed conformance coverage.
-4. Services, aliases, port context, health diagnostics, and startup/orphan
+1. Services, aliases, port context, health diagnostics, and startup/orphan
    cleanup use the same runtime-owned backend. Imported container definitions
    are not translated into workflow-controlled Buildkite plugins.
 
@@ -1882,7 +1885,7 @@ the narrowest available boundary:
 - public checkout under GitHub and Cursor Origin provider adapters; and
 - step summaries and annotations.
 
-Prefer documented Buildkite storage and Agent interfaces. If an action toolkit
+Prefer documented Buildkite storage and agent interfaces. If an action toolkit
 requires an HTTP protocol, use an explicitly configured compatible service or
 provide a well-defined adapter rather than proxying GitHub's private service.
 Cache credentials authorize storage access only; they are distinct from the
@@ -1906,15 +1909,15 @@ Delivery slices:
 
 1. Ship artifact, summary, and public-checkout adapters without a service
    dependency.
-2. Run only the audited `actions/cache` v6.1.0 client against cache-v2, minting
+1. Run only the audited `actions/cache` v6.1.0 client against cache-v2, minting
    short-lived credentials through the exact current Buildkite job and keeping
-   all Agent authority outside action code.
-3. Prove Job OIDC authentication, build/job binding, GitHub provenance checks,
+   all agent authority outside action code.
+1. Prove Job OIDC authentication, build/job binding, GitHub provenance checks,
    policy evaluation, and signed no-op grants before returning credentials.
-4. Add private checkout, private actions, and private reusable-workflow source
+1. Add private checkout, private actions, and private reusable-workflow source
    access through the narrowest practical credential or download interface.
-5. Add scoped GitHub tokens, selected secrets, and environment grants.
-6. Prefer direct Buildkite OIDC migration, then add only explicitly supported
+1. Add scoped GitHub tokens, selected secrets, and environment grants.
+1. Prefer direct Buildkite OIDC migration, then add only explicitly supported
    compatibility-issuer claims for providers that cannot consume it directly.
 
 Status: the GitHub/tokenless portion of slice 1 and all of slice 2 are
@@ -1992,7 +1995,7 @@ Complete:
 - protected capability service availability, abuse controls, audit retention,
   key rotation, revocation, and external security review;
 - signed releases, checksums, provenance, and SBOMs;
-- Hosted Agent image integration;
+- Hosted agent image integration;
 - the installer Buildkite plugin;
 - metrics for compile time, runtime overhead, action compatibility, and failures;
 - user-facing compatibility documentation; and
@@ -2136,7 +2139,7 @@ Run real builds that exercise:
 - untrusted pull-request policy.
 
 The full Buildkite path must be tested; a local Docker harness cannot prove
-dynamic pipeline, Agent redaction, artifact, metadata, or cancellation behavior.
+dynamic pipeline, agent redaction, artifact, metadata, or cancellation behavior.
 
 ### Fuzzing and security tests
 
@@ -2213,7 +2216,7 @@ compatibility may justify Buildkite additions:
 - UI treatment for generated/imported pipelines and compatibility findings.
 
 Each addition should be proposed only after the standalone implementation
-proves that a public Agent or pipeline contract cannot provide the required
+proves that a public agent or pipeline interface cannot provide the required
 behavior safely.
 
 ## Beta readiness reconciliation
@@ -2247,7 +2250,7 @@ public-beta declaration. It has two explicit lanes:
    artifact transfer, summaries, warning/error annotations, and a native
    continuation without depending on the capability service or a cache
    service.
-2. The cache extension uses the same released plugin and CLI with an explicitly
+1. The cache extension uses the same released plugin and CLI with an explicitly
    configured origin-only Results URL. It additionally proves the audited
    `actions/cache` v6.1.0 miss, post-save, and direct-dependent hit using
    short-lived credentials minted for the exact Buildkite job. The development
@@ -2257,7 +2260,7 @@ public-beta declaration. It has two explicit lanes:
 Both lanes must start from ordinary documented plugin configuration rather
 than a repository-only importer. A recorded run must name the exact Git commit,
 plugin revision, CLI release, Buildkite build, and any cache prerequisite. A
-clean Hosted Agent must be able to repeat the run without an unpublished local
+clean hosted agent must be able to repeat the run without an unpublished local
 binary or retained workspace state. The visible result should contain the
 importer, generated jobs at basic through advanced complexity, native logs and
 dependencies, artifact and cache observations, and the final native
@@ -2269,20 +2272,20 @@ Close the demo gap in this order, using small cross-repository changes:
    representative fixtures. Keep the service-free baseline independent of the
    cache extension, remove development-only source rewriting from the plugin
    path, and preserve deterministic compile/admission coverage locally.
-2. Run the full local gate and existing exact-commit hosted proofs, then publish
+1. Run the full local gate and existing exact-commit hosted proofs, then publish
    the resulting CLI as `v0.2.0` with its current checksummed archive contract.
    The plugin cannot prove the current runtime before that runtime has a public
    immutable release; failures found by the plugin proof are fixed in a patch
    release rather than by replacing release assets.
-3. In the companion plugin repository, default to the proven CLI release, add
+1. In the companion plugin repository, default to the proven CLI release, add
    a live installer/plugin smoke lane alongside the existing isolated tests,
    and document the exact prerequisites. Prove the candidate plugin commit
    against both demo lanes before tagging the plugin.
-4. Tag the companion plugin, update this repository's quick start from the
+1. Tag the companion plugin, update this repository's quick start from the
    temporary commit pin to that tag, and rerun the service-free lane using only
    the published quick-start configuration. Record that exact run as the
    authoritative installation and demo evidence.
-5. Use failures and diagnostics from those runs, followed by several real
+1. Use failures and diagnostics from those runs, followed by several real
    customer workflow migrations, to drive small compatibility or UX changes.
    Do not add workflow-specific runtime branches to make a demo fixture pass.
 
@@ -2339,7 +2342,7 @@ runtime, hosted images, service protocols, and repository APIs. Manage scope
 through explicit compatibility levels, differential fixtures, and a Linux-first
 support contract rather than claiming universal compatibility.
 
-### Reusing `act` creates upstream coupling
+### Reusing act creates upstream coupling
 
 `act` provides the fastest Go starting point but is optimized for local
 container execution, not Buildkite compilation and hosted-agent fidelity. Own
@@ -2402,7 +2405,7 @@ unknown plan.
   build/job/queue binding in Phase 0. It is retained as an integrity mechanism,
   not as production capability authorization.
 - Buildkite pipeline signing protects uploaded command provenance and remains
-  optional installation-specific defence in depth; it is not required for
+  optional installation-specific defense in depth; it is not required for
   tokenless Actions compatibility.
 - Concurrent Actions steps require their own supervisor and conformance surface;
   they are now an explicit delivery phase rather than an unowned beta promise.
@@ -2418,38 +2421,38 @@ unknown plan.
    producer-attributed artifacts bound to the build, importer, target job, step,
    queue, compiler, and workflow. These bindings protect transport but do not
    authorize protected resources.
-2. The bootstrap is an ordinary Buildkite dynamic pipeline generator. It runs a
+1. The bootstrap is an ordinary Buildkite dynamic pipeline generator. It runs a
    pinned verified distribution, treats provider-fetched workflow text as inert
    data, exposes no ambient protected credential in tokenless mode, and emits
    fixed fail-closed job definitions.
-3. Buildkite signed pipelines are not required for the initial implementation.
-   Buildkite step signing is optional defence in depth and is deferred to Phase
-   9. Protected capabilities are separately authorized by the Phase 6 control
-   plane after Buildkite Job OIDC authentication.
-4. Generated compatibility jobs set `checkout.skip: true`, require Buildkite
-   Agent v3.130.0 or later, and allocate a fresh `GITHUB_WORKSPACE` themselves.
-5. Parallel and background steps remain in the beta target and are implemented
+1. Buildkite signed pipelines are not required for the initial implementation.
+   Buildkite step signing is optional defense in depth and is deferred to
+   Phase 9. The Phase 6 control plane separately authorizes protected
+   capabilities after Buildkite Job OIDC authentication.
+1. Generated compatibility jobs set `checkout.skip: true`, require Buildkite
+   agent v3.130.0 or later, and allocate a fresh `GITHUB_WORKSPACE` themselves.
+1. Parallel and background steps remain in the beta target and are implemented
    in a dedicated phase after the sequential shell runtime.
-6. Static local reusable workflows are compiled in Phase 1. Phase 7 adds dynamic
+1. Static local reusable workflows are compiled in Phase 1. Phase 7 adds dynamic
    matrices and remote reusable workflows without reimplementing the local
    compiler path.
-7. Import actionlint v1.7.12 unchanged as the syntax frontend and immediately
+1. Import actionlint v1.7.12 unchanged as the syntax frontend and immediately
    adapt it into owned models. Keep act v0.2.89 and Actions runner v2.336.0 as
    pinned behavioral oracles; do not import or fork act for production.
-8. The Phase 0 envelope experiment uses detached ES256 JWS over bounded RFC 8785
+1. The Phase 0 envelope experiment uses detached ES256 JWS over bounded RFC 8785
    canonical claims and remains separate from Buildkite pipeline signing. It
    proves signing mechanics only. The production capability-grant profile, key
    custody, rotation, revocation, and audit contract are Phase 6 decisions.
-9. Explicit bridge, provider, and Buildkite variable maps use
+1. Explicit bridge, provider, and Buildkite variable maps use
    `Bridge < Provider < Buildkite` precedence and are snapshotted into every
    compiled plan.
-10. No current Buildkite query authoritatively verifies a completed dynamic
-    upload after interruption. Recovery fails closed with exit 75 and requires
-    the operator to cancel and rebuild.
-11. Until Buildkite has a scheduler-visible skipped result, a runtime-skipped
-    imported job exits successfully after publishing its logical `skipped`
-    result and emits a clear annotation. Downstream compatibility semantics use
-    the logical result rather than the Buildkite job state.
+1. No current Buildkite query authoritatively verifies a completed dynamic
+   upload after interruption. Recovery fails closed with exit 75 and requires
+   the operator to cancel and rebuild.
+1. Until Buildkite has a scheduler-visible skipped result, a runtime-skipped
+   imported job exits successfully after publishing its logical `skipped`
+   result and emits a clear annotation. Downstream compatibility semantics use
+   the logical result rather than the Buildkite job state.
 
 ## Decisions deferred after Phase 0
 
@@ -2459,19 +2462,19 @@ them in the phase that first needs the capability:
 1. Phase 6 control-plane work will determine which authenticated GitHub event
    payload Buildkite exposes, whether the service must receive GitHub App
    webhooks directly, and whether a small Buildkite platform API is missing.
-2. Phase 5 uses direct Hosted Agent execution. Exact-commit build 102 proved
+1. Phase 5 uses direct hosted agent execution. Exact-commit build 102 proved
    the local `default` Docker driver and queue prerequisites; build 136 proved
    the complete container runtime. A compatibility image remains deferred until
    tool-cache differences demonstrate a concrete need.
-3. Phase 4 will set the customer-beta event and expression subset from the
+1. Phase 4 will set the customer-beta event and expression subset from the
    hosted differential corpus.
-4. Phase 6 will define Cursor Origin checkout, event, pull-request, Job OIDC,
+1. Phase 6 will define Cursor Origin checkout, event, pull-request, Job OIDC,
    and short-lived capability contracts alongside the GitHub provider adapter.
-5. The fixed Buildkite `hosted` queue's documented per-job disposable isolation
+1. The fixed Buildkite `hosted` queue's documented per-job disposable isolation
    and the Phase 5 probe are sufficient for tokenless, non-privileged Dockerfile
    actions built on the local driver. Phases 6 and 9 still own authorization and
    queue policy for protected Docker capabilities and privileged workloads.
-6. Phase 6 will define the GitHub App installation-token compatibility contract
+1. Phase 6 will define the GitHub App installation-token compatibility contract
    for `github.token` and `GITHUB_TOKEN`, including repository/permission
    narrowing and documented differences from native Actions tokens. Tokenless
    workflows remain the default until then.
@@ -2484,21 +2487,21 @@ that proves the product boundary:
 1. A Buildkite bootstrap job runs `buildkite-gha upload` on
    `testdata/smoke/.github/workflows/ci.yml` materialized as the fixture
    repository.
-2. The compiler emits two native Buildkite jobs with a dependency between them.
-3. The first job runs a shell step, a JavaScript action, and a composite action.
-4. It publishes a bounded output, which the second job consumes through its
+1. The compiler emits two native Buildkite jobs with a dependency between them.
+1. The first job runs a shell step, a JavaScript action, and a composite action.
+1. It publishes a bounded output, which the second job consumes through its
    producer-attributed result manifest.
-5. The runtime separately uploads and downloads a Buildkite-native diagnostic
+1. The runtime separately uploads and downloads a Buildkite-native diagnostic
    artifact to prove job transport; GHA artifact-action compatibility remains a
    Phase 6 deliverable.
-6. Both jobs stream masked logs and display action warnings and summaries in
+1. Both jobs stream masked logs and display action warnings and summaries in
    Buildkite.
-7. A native Buildkite job depends on the imported workflow and succeeds.
-8. The same `ci.yml` fixture runs on GitHub Actions and produces the checked-in
+1. A native Buildkite job depends on the imported workflow and succeeds.
+1. The same `ci.yml` fixture runs on GitHub Actions and produces the checked-in
    output observation plus equivalent normalized log and action-lifecycle
    events; the Buildkite-native transport artifact is excluded from differential
    comparison.
-9. Generated jobs skip checkout, create fresh workspaces, and reject a plan
+1. Generated jobs skip checkout, create fresh workspaces, and reject a plan
    whose digest or build, importer, job, step, queue, or runtime binding does not
    match. The tokenless queue exposes no ambient protected credential.
 


### PR DESCRIPTION
This PR updates the repository documentation to follow the writing and Markdown conventions used in the Buildkite documentation.

I applied these changes to the root README and all six Markdown files under `docs/`, including the compatibility guide, development guide, architecture decisions, and active implementation plan.

## What changed

- Standardized Buildkite terminology, including:
  - **Buildkite Pipelines** for product-specific behavior.
  - **Buildkite agent** for the running software.
  - `buildkite-agent` for the CLI executable.
- Updated headings to use sentence case and removed inline formatting from headings.
- Changed shell code fences from `sh` to `bash`.
- Changed diagram fences to `text` for portable syntax highlighting.
- Standardized ordered-list source markers to `1.`.
- Applied US English spelling and punctuation.
- Reworked a small number of sentences for clearer, more direct prose.
- Removed unnecessary em dashes and possessive product-name constructions.
- Preserved repository-relative links and GitHub-compatible Markdown rather than introducing Buildkite docs-site-specific syntax.

## Compatibility

These edits do not change documented behavior, commands, configuration examples, compatibility claims, versions, commits, or architecture decisions.

Code-block contents, link destinations, and generated heading anchors remain unchanged.