### PR TITLE
docs: classify published plugin runtime evidence

### DIFF
--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -1346,9 +1346,11 @@ Cursor Origin public checkout remains a separate provider integration gate.
   restore an exact hit and verify the payload digest. Buildkite build 303 passed
   that lifecycle at exact merged commit
   `9d29bf26492be760016d29c7ba0d00033b4f9b39`. The minimal Phase 6 cache fixture
-  remains `compile-pass` conformance coverage. The stable cache extension now
-  awaits its exact-commit released-plugin run before receiving its own
-  `runtime-pass` classification.
+  remains `compile-pass` conformance coverage. The stable cache extension is
+  now `runtime-pass`: published-plugin build 337 proved its producer miss and
+  post-save, direct-dependent exact primary-key hit and restore, verified
+  payload, generated terminal, and default verified CLI distribution at source
+  commit `d5102df7e81c49f27a30fb2830d9608a56ee84de`.
   Together these results complete the GitHub/tokenless portion of delivery
   slice 1 and delivery slice 2. Cursor Origin public checkout still requires a
   provider context/source contract. Delivery slice 3—the OIDC-authenticated,
@@ -1429,9 +1431,10 @@ Cursor Origin public checkout remains a separate provider integration gate.
   Phase 2 shell/upload, Phase 3 concurrent, Phase 4 public-action, Phase 5
   hosted-Docker capability, Phase 5 Dockerfile-action, and Phase 5 complete
   container-runtime proofs, plus the Phase 6 job-summary, workflow-command,
-  upload-artifact, and artifact-roundtrip proofs. The next cache runtime claim
-  belongs to the optional released-plugin demo extension; its obsolete targeted
-  Phase 6 cache importer remains removed. The historical aggregate uploads
+  upload-artifact, and artifact-roundtrip proofs. The cache runtime claim is
+  recorded separately by the optional released-plugin demo extension in build
+  337; its obsolete targeted Phase 6 cache importer remains removed. The
+  historical aggregate uploads
   each included importer and continuation independently, then settles their
   generated and native terminal steps; it does not flatten the
   importer/continuation topology. Existing `PHASE2_PROBE`,
@@ -2067,9 +2070,9 @@ Start with `testdata/smoke` rather than an external workflow catalog:
   cache-v2 admission contract and the targeted build-unique miss, post-save,
   and dependent exact-hit shape as compile-only conformance coverage. The
   predecessor advanced migration POC retains hosted implementation evidence
-  from Buildkite build 303; the stable released-plugin cache extension awaits
-  its own exact-commit proof, and build 290 remains the original implementation
-  proof.
+  from Buildkite build 303; the stable released-plugin cache extension has
+  exact-commit runtime evidence from build 337, and build 290 remains the
+  original implementation proof.
 
 The fixture owns its event input, local actions, and expected observations. All
 external actions use immutable commits. Add narrow repository-owned regression

--- a/testdata/poc/README.md
+++ b/testdata/poc/README.md
@@ -45,8 +45,8 @@ calls `upload` directly.
 
 ## Released plugin demo
 
-After CLI `v0.2.0` exists at the exact commit, run the same workflows through
-the pinned companion plugin and its real anonymous release installer:
+Run the same workflows through the released companion plugin and its real
+anonymous release installer:
 
 ```sh
 commit=$(git rev-parse HEAD)
@@ -87,10 +87,17 @@ dynamic pipeline dependency extension makes them wait for all generated jobs.
 passed the predecessor three-workflow suite at exact commit
 `9d29bf26492be760016d29c7ba0d00033b4f9b39`. Its then-combined advanced workflow
 proved the declared reusable output, build-unique cache miss/post-save/hit,
-artifact fan-out, summary, and warning paths. The revised service-free and
-cache fixtures deliberately surrender that whole-fixture classification until
-the released-plugin demo runs against their exact commit. Component and
-dedicated Phase 6 evidence remains valid.
+artifact fan-out, summary, and warning paths.
+
+[Buildkite build 336](https://buildkite.com/buildkite/buildkite-gha/builds/336)
+is the authoritative released-plugin service-free proof, and [Buildkite build
+337](https://buildkite.com/buildkite/buildkite-gha/builds/337) is the
+authoritative cache-extension proof. Both ran source commit
+`d5102df7e81c49f27a30fb2830d9608a56ee84de` through plugin `v0.2.0`, which
+resolved to `d009da173158270a3921b2997ae8fd3d68526d00` and installed the verified
+CLI `v0.2.0` distribution without an explicit CLI version override. Build 337
+observed the required producer miss and post-save followed by the direct
+dependent's exact primary-key hit and restore.
 
 The historical phase fixtures and their recorded observations remain the
 conformance ledger. The now-superseded targeted cache importer, continuation,

--- a/testdata/smoke/manifest.json
+++ b/testdata/smoke/manifest.json
@@ -59,18 +59,18 @@
       "id": "migration-poc-advanced",
       "workflow": "testdata/poc/.github/workflows/advanced.yml",
       "event": "testdata/smoke/events/push.json",
-      "expectation": "compile-pass",
-      "evidence": "The component behaviors have exact-commit hosted evidence, but the service-free Dockerfile-action revision awaits its released-plugin run.",
-      "note": "Build 303 proved the predecessor fixture's reusable output, artifact, matrix, summary, and annotation path. The revised fixture deliberately separates cache and adds public Dockerfile-action coverage.",
+      "expectation": "runtime-pass",
+      "evidence": "Published-plugin Buildkite build 336 passed the revised service-free advanced fixture and all generated jobs.",
+      "note": "At source commit d5102df7e81c49f27a30fb2830d9608a56ee84de, plugin v0.2.0 resolved to d009da173158270a3921b2997ae8fd3d68526d00 and proved the reusable output, public Dockerfile action, artifact, matrix, summary, and annotation path.",
       "action_preflight": "hosted-tokenless"
     },
     {
       "id": "migration-poc-cache",
       "workflow": "testdata/poc/.github/workflows/cache.yml",
       "event": "testdata/smoke/events/push.json",
-      "expectation": "compile-pass",
-      "evidence": "Build 303 proved the cache-v2 implementation lifecycle; this stable released-plugin fixture awaits an exact-commit hosted run.",
-      "note": "The first run of a release commit must observe a producer miss and post-save before the direct dependent requires an exact hit; warm reruns verify the same immutable payload.",
+      "expectation": "runtime-pass",
+      "evidence": "Published-plugin Buildkite build 337 passed the stable cache-v2 fixture and all generated jobs.",
+      "note": "At source commit d5102df7e81c49f27a30fb2830d9608a56ee84de, plugin v0.2.0 resolved to d009da173158270a3921b2997ae8fd3d68526d00; the producer observed a miss and post-save before its direct dependent restored an exact primary-key hit and verified the payload.",
       "action_preflight": "hosted-tokenless"
     },
     {
@@ -133,7 +133,7 @@
       "event": "testdata/smoke/events/push.json",
       "expectation": "compile-pass",
       "evidence": "Compiler and runtime conformance tests admit only the audited actions/cache v6.1.0 commit and execute its ESM pre/main/post lifecycle with isolated per-phase cache-v2 credentials.",
-      "note": "This minimal fixture remains compile-only conformance coverage. The predecessor combined advanced fixture proved the hosted roundtrip in Buildkite build 303; migration-poc-cache awaits released-plugin evidence.",
+      "note": "This minimal fixture remains compile-only conformance coverage. The stable migration-poc-cache fixture has published-plugin runtime evidence from Buildkite build 337.",
       "action_preflight": "hosted-tokenless"
     },
     {


### PR DESCRIPTION
## Summary

- classify the revised advanced and cache migration fixtures as runtime-proven by published-plugin builds 336 and 337
- keep the minimal Phase 6 cache fixture compile-only while linking its stable runtime counterpart
- remove the remaining stale plan and POC statements that said released-plugin evidence was pending

## Validation

- `mise exec -- go test ./internal/compiler`
- `mise run smoke:local`
- `mise exec -- jq empty testdata/smoke/manifest.json`
- `git diff --check`

Authoritative evidence: [build 336](https://buildkite.com/buildkite/buildkite-gha/builds/336) and [build 337](https://buildkite.com/buildkite/buildkite-gha/builds/337).