### PR TITLE
fix: reject unsupported workflow concurrency

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -33,6 +33,7 @@ provide.
 | Bash and `sh` steps | Supported | Includes environment and working-directory precedence. |
 | Static job graphs and `needs` | Supported | Dependencies and logical results are preserved. |
 | Static matrices | Supported | Includes typed values, `include`, `exclude`, and exact dependency fan-out. |
+| Workflow and job concurrency | Not supported | `concurrency.group` and `cancel-in-progress` fail compilation instead of being silently discarded. Configure equivalent behavior in Buildkite. `strategy.max-parallel` is translated separately for static matrix jobs. |
 | Local reusable workflows | Supported subset | Statically resolvable local calls preserve source-level `needs` names and expose an aggregate `needs.<call>.result` from every callee job. Declared outputs mapped directly from `jobs.<job>.outputs.<name>` are exposed through `needs.<call>.outputs`; nested calls are supported and undeclared callee outputs remain hidden. Matrix-selected declarations verify every exact producer and fail closed when values conflict or exceed 64 concrete projections. Literal or compound output mappings, call-level conditions, and remote or runtime-dependent reusable workflows are deferred. Caller prerequisites inherited by callee roots are status-only. |
 | Job and step conditions | Supported subset | Syntax is checked, but not every runtime function or context limitation is preflighted. Some unsupported expressions fail only when the job runs. |
 | Concurrent step controls | Supported | Includes `background`, `wait`, `wait-all`, `cancel`, and `parallel`. |

--- a/internal/workflow/parse.go
+++ b/internal/workflow/parse.go
@@ -202,7 +202,7 @@ func validateRawConcurrency(path string, document *yaml.Node) error {
 		return nil
 	}
 	for i := 0; i+1 < len(jobs.Content); i += 2 {
-		name, job := jobs.Content[i], jobs.Content[i+1]
+		name, job := resolveAlias(jobs.Content[i]), jobs.Content[i+1]
 		if key := mappingKey(job, "concurrency"); key != nil {
 			return rawError(path, key, fmt.Sprintf("job %q concurrency is unsupported; only strategy.max-parallel is translated", name.Value))
 		}

--- a/internal/workflow/parse.go
+++ b/internal/workflow/parse.go
@@ -1098,7 +1098,7 @@ func mappingValue(node *yaml.Node, name string) *yaml.Node {
 		return nil
 	}
 	for i := 0; i+1 < len(node.Content); i += 2 {
-		if node.Content[i].Value == name {
+		if mappingKeyMatches(node.Content[i], name) {
 			return node.Content[i+1]
 		}
 	}
@@ -1110,11 +1110,18 @@ func mappingKey(node *yaml.Node, name string) *yaml.Node {
 		return nil
 	}
 	for i := 0; i+1 < len(node.Content); i += 2 {
-		if node.Content[i].Value == name {
+		if mappingKeyMatches(node.Content[i], name) {
 			return node.Content[i]
 		}
 	}
 	return nil
+}
+
+func mappingKeyMatches(node *yaml.Node, name string) bool {
+	if node != nil && node.Kind == yaml.AliasNode {
+		node = node.Alias
+	}
+	return node != nil && node.Kind == yaml.ScalarNode && node.Value == name
 }
 
 func stringList(node *yaml.Node) ([]string, error) {

--- a/internal/workflow/parse.go
+++ b/internal/workflow/parse.go
@@ -1094,18 +1094,20 @@ func mappingEntries(node *yaml.Node) map[string]*yaml.Node {
 }
 
 func mappingValue(node *yaml.Node, name string) *yaml.Node {
+	node = resolveAlias(node)
 	if node == nil || node.Kind != yaml.MappingNode {
 		return nil
 	}
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		if mappingKeyMatches(node.Content[i], name) {
-			return node.Content[i+1]
+			return resolveAlias(node.Content[i+1])
 		}
 	}
 	return nil
 }
 
 func mappingKey(node *yaml.Node, name string) *yaml.Node {
+	node = resolveAlias(node)
 	if node == nil || node.Kind != yaml.MappingNode {
 		return nil
 	}
@@ -1118,10 +1120,15 @@ func mappingKey(node *yaml.Node, name string) *yaml.Node {
 }
 
 func mappingKeyMatches(node *yaml.Node, name string) bool {
+	node = resolveAlias(node)
+	return node != nil && node.Kind == yaml.ScalarNode && node.Value == name
+}
+
+func resolveAlias(node *yaml.Node) *yaml.Node {
 	if node != nil && node.Kind == yaml.AliasNode {
 		node = node.Alias
 	}
-	return node != nil && node.Kind == yaml.ScalarNode && node.Value == name
+	return node
 }
 
 func stringList(node *yaml.Node) ([]string, error) {

--- a/internal/workflow/parse.go
+++ b/internal/workflow/parse.go
@@ -41,6 +41,9 @@ func Parse(path string, source []byte) (*Workflow, error) {
 	if err := validateRawContainers(path, &document); err != nil {
 		return nil, err
 	}
+	if err := validateRawConcurrency(path, &document); err != nil {
+		return nil, err
+	}
 	concurrency, err := parseConcurrencySyntax(path, &document)
 	if err != nil {
 		return nil, err
@@ -181,6 +184,27 @@ func validateRawContainers(path string, document *yaml.Node) error {
 			if err := validateRawContainer(path, container); err != nil {
 				return err
 			}
+		}
+	}
+	return nil
+}
+
+func validateRawConcurrency(path string, document *yaml.Node) error {
+	root := document
+	if root.Kind == yaml.DocumentNode && len(root.Content) != 0 {
+		root = root.Content[0]
+	}
+	if key := mappingKey(root, "concurrency"); key != nil {
+		return rawError(path, key, "workflow concurrency is unsupported; configure equivalent concurrency behavior in Buildkite")
+	}
+	jobs := mappingValue(root, "jobs")
+	if jobs == nil || jobs.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(jobs.Content); i += 2 {
+		name, job := jobs.Content[i], jobs.Content[i+1]
+		if key := mappingKey(job, "concurrency"); key != nil {
+			return rawError(path, key, fmt.Sprintf("job %q concurrency is unsupported; only strategy.max-parallel is translated", name.Value))
 		}
 	}
 	return nil

--- a/internal/workflow/parse_test.go
+++ b/internal/workflow/parse_test.go
@@ -119,6 +119,16 @@ func TestParseRejectsWorkflowAndJobConcurrencyWithLocation(t *testing.T) {
 			source: "on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    concurrency: deploy\n    steps: [{run: true}]\n",
 			want:   "concurrency.yml:5:5: job \"test\" concurrency is unsupported; only strategy.max-parallel is translated",
 		},
+		{
+			name:   "workflow-alias",
+			source: "on: push\nenv:\n  FIELD: &field concurrency\n*field: deploy\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
+			want:   "concurrency.yml:4:1: workflow concurrency is unsupported; configure equivalent concurrency behavior in Buildkite",
+		},
+		{
+			name:   "jobs-and-job-aliases",
+			source: "on: push\nenv:\n  JOBS: &jobs jobs\n  FIELD: &field concurrency\n*jobs:\n  test:\n    runs-on: ubuntu-latest\n    *field: deploy\n    steps: [{run: true}]\n",
+			want:   "concurrency.yml:8:5: job \"test\" concurrency is unsupported; only strategy.max-parallel is translated",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := Parse("concurrency.yml", []byte(test.source))

--- a/internal/workflow/parse_test.go
+++ b/internal/workflow/parse_test.go
@@ -129,6 +129,11 @@ func TestParseRejectsWorkflowAndJobConcurrencyWithLocation(t *testing.T) {
 			source: "on: push\nenv:\n  JOBS: &jobs jobs\n  FIELD: &field concurrency\n*jobs:\n  test:\n    runs-on: ubuntu-latest\n    *field: deploy\n    steps: [{run: true}]\n",
 			want:   "concurrency.yml:8:5: job \"test\" concurrency is unsupported; only strategy.max-parallel is translated",
 		},
+		{
+			name:   "aliased-job",
+			source: "on: push\njobs:\n  anchor-holder:\n    runs-on: ubuntu-latest\n    strategy:\n      matrix:\n        include:\n          - &shared-job\n            runs-on: ubuntu-latest\n            concurrency: deploy\n            steps:\n              - run: echo ok\n    steps:\n      - run: echo holder\n  test: *shared-job\n",
+			want:   "concurrency.yml:10:13: job \"test\" concurrency is unsupported; only strategy.max-parallel is translated",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := Parse("concurrency.yml", []byte(test.source))

--- a/internal/workflow/parse_test.go
+++ b/internal/workflow/parse_test.go
@@ -105,6 +105,30 @@ func TestContainerValidationIsScopedAndSourceLocated(t *testing.T) {
 	}
 }
 
+func TestParseRejectsWorkflowAndJobConcurrencyWithLocation(t *testing.T) {
+	for _, test := range []struct {
+		name, source, want string
+	}{
+		{
+			name:   "workflow",
+			source: "on: push\nconcurrency:\n  group: build-${{ github.ref }}\n  cancel-in-progress: true\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
+			want:   "concurrency.yml:2:1: workflow concurrency is unsupported; configure equivalent concurrency behavior in Buildkite",
+		},
+		{
+			name:   "job",
+			source: "on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    concurrency: deploy\n    steps: [{run: true}]\n",
+			want:   "concurrency.yml:5:5: job \"test\" concurrency is unsupported; only strategy.max-parallel is translated",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := Parse("concurrency.yml", []byte(test.source))
+			if err == nil || err.Error() != test.want {
+				t.Fatalf("Parse() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
 func TestParseContainerShortForms(t *testing.T) {
 	source := []byte("on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    container: node:24\n    services:\n      redis: redis:7\n      postgres: {image: postgres:16, ports: ['5432:5432/udp']}\n    steps: [{run: true}]\n")
 	parsed, err := Parse("short.yml", source)

--- a/internal/workflow/parse_test.go
+++ b/internal/workflow/parse_test.go
@@ -134,6 +134,11 @@ func TestParseRejectsWorkflowAndJobConcurrencyWithLocation(t *testing.T) {
 			source: "on: push\njobs:\n  anchor-holder:\n    runs-on: ubuntu-latest\n    strategy:\n      matrix:\n        include:\n          - &shared-job\n            runs-on: ubuntu-latest\n            concurrency: deploy\n            steps:\n              - run: echo ok\n    steps:\n      - run: echo holder\n  test: *shared-job\n",
 			want:   "concurrency.yml:10:13: job \"test\" concurrency is unsupported; only strategy.max-parallel is translated",
 		},
+		{
+			name:   "aliased-job-id",
+			source: "on: push\nenv:\n  ID: &job-id test\njobs:\n  *job-id:\n    runs-on: ubuntu-latest\n    concurrency: deploy\n    steps: [{run: true}]\n",
+			want:   "concurrency.yml:7:5: job \"test\" concurrency is unsupported; only strategy.max-parallel is translated",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := Parse("concurrency.yml", []byte(test.source))


### PR DESCRIPTION
## Summary

- reject workflow- and job-level GitHub Actions `concurrency` with source-located diagnostics instead of silently discarding it
- distinguish unsupported concurrency groups/cancellation from supported static-matrix `strategy.max-parallel`
- document the production compatibility boundary

This was found by validating the current `wolfeidau/s3iofs` workflow as the first real post-release migration candidate. Before this change it was reported as admitted even though its workflow-level `cancel-in-progress` behavior was dropped; it now fails clearly at the `concurrency` declaration and points users to native Buildkite configuration.

## Validation

- `mise run check`
- `mise exec -- go test ./internal/workflow`
- live validation of the current s3iofs workflow and exact public commit, confirming the new `E_COMPILE` diagnostic at line 9
- `git diff --check`