### PR TITLE
Add paired Actions and Buildkite examples

### DIFF
--- a/.buildkite/examples.yml
+++ b/.buildkite/examples.yml
@@ -1,0 +1,73 @@
+agents:
+  queue: "hosted"
+
+steps:
+  - block: ":github: Choose an example workflow"
+    key: "choose-example"
+    if: build.env("EXAMPLE") == null
+    prompt: "Choose the GitHub Actions workflow to run as native Buildkite jobs."
+    submit: "Run example"
+    fields:
+      - select: "Example"
+        key: "example"
+        required: true
+        default: "basic"
+        options:
+          - label: "Basic CI"
+            value: "basic"
+          - label: "Artifact build and handoff"
+            value: "artifacts"
+          - label: "Advanced delivery"
+            value: "advanced"
+
+  - label: ":pipeline: Load example workflow"
+    key: "example-loader"
+    timeout_in_minutes: 10
+    retry:
+      automatic: false
+    command: |
+      set -euo pipefail
+
+      example="$${EXAMPLE:-}"
+      if [[ -z "$$example" ]]; then
+        example="$$(buildkite-agent meta-data get example)"
+      fi
+
+      case "$$example" in
+        basic)
+          label="Basic CI"
+          workflow=".github/workflows/example-basic.yml"
+          ;;
+        artifacts)
+          label="Artifact build and handoff"
+          workflow=".github/workflows/example-artifacts.yml"
+          ;;
+        advanced)
+          label="Advanced delivery"
+          workflow=".github/workflows/example-advanced.yml"
+          ;;
+        *)
+          echo "unknown example: $$example" >&2
+          exit 2
+          ;;
+      esac
+
+      commit="$${EXAMPLE_COMMIT:-$${BUILDKITE_COMMIT:?BUILDKITE_COMMIT is required}}"
+      [[ "$$commit" =~ ^[0-9a-f]{40}$$ ]]
+      test "$${BUILDKITE_COMMIT:?BUILDKITE_COMMIT is required}" = "$$commit"
+      test -f "$$workflow"
+
+      cat <<YAML | buildkite-agent pipeline upload --no-interpolation --reject-secrets
+      agents:
+        queue: "hosted"
+
+      steps:
+        - label: ":github: $$label"
+          key: "example-$$example-importer"
+          timeout_in_minutes: 20
+          retry:
+            automatic: false
+          plugins:
+            - github-actions#v0.2.0:
+                workflow: "$$workflow"
+      YAML

--- a/.buildkite/migration-poc.yml
+++ b/.buildkite/migration-poc.yml
@@ -10,7 +10,7 @@ steps:
     plugins:
       - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
           version: "2026.5.12"
-    command: "scripts/migration-poc-import testdata/poc/.github/workflows/basic.yml"
+    command: "scripts/migration-poc-import .github/workflows/example-basic.yml"
 
   - label: ":package: Artifact migration POC importer"
     key: "migration-poc-artifact-importer"
@@ -20,7 +20,7 @@ steps:
     plugins:
       - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
           version: "2026.5.12"
-    command: "scripts/migration-poc-import testdata/poc/.github/workflows/artifacts.yml"
+    command: "scripts/migration-poc-import .github/workflows/example-artifacts.yml"
 
   - label: ":rocket: Advanced migration POC importer"
     key: "migration-poc-advanced-importer"
@@ -30,7 +30,7 @@ steps:
     plugins:
       - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
           version: "2026.5.12"
-    command: "scripts/migration-poc-import testdata/poc/.github/workflows/advanced.yml"
+    command: "scripts/migration-poc-import .github/workflows/example-advanced.yml"
 
   - label: ":pipeline: Migration POC continuation loader"
     key: "migration-poc-continuation-loader"

--- a/.buildkite/plugin-demo.yml
+++ b/.buildkite/plugin-demo.yml
@@ -9,7 +9,7 @@ steps:
       automatic: false
     plugins:
       - github-actions#v0.2.0:
-          workflow: testdata/poc/.github/workflows/basic.yml
+          workflow: .github/workflows/example-basic.yml
 
   - label: ":package: Artifact released-plugin demo"
     key: "plugin-demo-artifact-importer"
@@ -18,7 +18,7 @@ steps:
       automatic: false
     plugins:
       - github-actions#v0.2.0:
-          workflow: testdata/poc/.github/workflows/artifacts.yml
+          workflow: .github/workflows/example-artifacts.yml
 
   - label: ":javascript: Actions released-plugin demo"
     key: "plugin-demo-actions-importer"
@@ -36,7 +36,7 @@ steps:
       automatic: false
     plugins:
       - github-actions#v0.2.0:
-          workflow: testdata/poc/.github/workflows/advanced.yml
+          workflow: .github/workflows/example-advanced.yml
 
   - label: ":white_check_mark: Service-free plugin demo complete"
     key: "plugin-demo-service-free-terminal"

--- a/.github/workflows/example-advanced.yml
+++ b/.github/workflows/example-advanced.yml
@@ -1,7 +1,6 @@
-name: Migration POC - advanced delivery
+name: Example - advanced delivery
 
 on:
-  push:
   workflow_dispatch:
 
 permissions:
@@ -12,7 +11,7 @@ env:
 
 jobs:
   quality:
-    uses: ./.github/workflows/reusable-quality.yml
+    uses: ./.github/workflows/example-reusable-quality.yml
     with:
       package: ./internal/action/integration
 

--- a/.github/workflows/example-artifacts.yml
+++ b/.github/workflows/example-artifacts.yml
@@ -1,7 +1,6 @@
-name: Migration POC - build artifact
+name: Example - build artifact
 
 on:
-  push:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/example-basic.yml
+++ b/.github/workflows/example-basic.yml
@@ -1,7 +1,6 @@
-name: Migration POC - basic CI
+name: Example - basic CI
 
 on:
-  push:
   workflow_dispatch:
 
 permissions:
@@ -13,7 +12,6 @@ env:
 jobs:
   poc-basic:
     name: Basic Go CI
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/example-reusable-quality.yml
+++ b/.github/workflows/example-reusable-quality.yml
@@ -1,4 +1,4 @@
-name: Migration POC - reusable quality check
+name: Example - reusable quality check
 
 on:
   workflow_call:

--- a/README.md
+++ b/README.md
@@ -62,6 +62,33 @@ This gives teams a migration path: start with the existing Actions workflow,
 then move work into native Buildkite jobs over time. Automatic replacement of
 a named imported job is planned, but is not part of this preview.
 
+## Compare example runs
+
+The basic CI, artifact handoff, and advanced delivery examples are manual
+GitHub Actions workflows under `.github/workflows`. The dedicated
+`buildkite-gha-examples` pipeline imports those exact files one at a time and
+offers the same three choices through a Buildkite block step.
+
+To launch both providers at the current branch's exact remote commit and print
+their run URLs together:
+
+```sh
+scripts/compare-example basic
+scripts/compare-example artifacts
+scripts/compare-example advanced
+```
+
+The helper requires authenticated `gh` and `bk` CLIs. The current commit must
+be the head of the corresponding `origin` branch, and GitHub must already know
+the workflow from the repository's default branch. Pass `--github-only` or
+`--buildkite-only` to launch just one side.
+
+For the native manual experience, choose one of the `Example - ...` workflows
+in GitHub's Actions tab. In Buildkite, create a build on the
+`buildkite-gha-examples` pipeline and select the example when the build blocks.
+Compare the job graph, matrix presentation, logs, summaries, annotations,
+artifacts, retries, and cancellation behavior.
+
 ## Is my workflow a fit?
 
 The plugin path currently supports:

--- a/docs/development.md
+++ b/docs/development.md
@@ -74,6 +74,24 @@ download modes, and unsupported artifact commits still fail admission. Job and
 service container fixtures have separate hosted runtime evidence but remain
 outside production admission.
 
+### Paired native UX runs
+
+After the example workflows exist on the default branch, launch the same
+workflow at the current branch's exact remote commit in both products:
+
+```sh
+scripts/compare-example basic
+scripts/compare-example artifacts
+scripts/compare-example advanced
+```
+
+This uses GitHub's native `workflow_dispatch` path and the dedicated
+`buildkite-gha-examples` pipeline. It prints both URLs for a side-by-side review
+of the graph, logs, summaries, annotations, artifacts, retries, and cancellation
+experience. Use `--github-only` or `--buildkite-only` to exercise one native
+manual trigger at a time. These runs are qualitative UX comparisons; they do
+not replace the normalized smoke evidence below.
+
 ### Hosted runtime proofs
 
 Run all implemented hosted proofs against one exact commit:

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -433,6 +433,108 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 	}
 }
 
+func TestExamplesPipelineSelectsOneCanonicalWorkflow(t *testing.T) {
+	root := filepath.Join("..", "..")
+	source, err := os.ReadFile(filepath.Join(root, ".buildkite", "examples.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	type option struct {
+		Label string `yaml:"label"`
+		Value string `yaml:"value"`
+	}
+	var document struct {
+		Agents struct {
+			Queue string `yaml:"queue"`
+		} `yaml:"agents"`
+		Steps []struct {
+			Block            string `yaml:"block"`
+			Label            string `yaml:"label"`
+			Key              string `yaml:"key"`
+			If               string `yaml:"if"`
+			Command          string `yaml:"command"`
+			TimeoutInMinutes int    `yaml:"timeout_in_minutes"`
+			Fields           []struct {
+				Select   string   `yaml:"select"`
+				Key      string   `yaml:"key"`
+				Required bool     `yaml:"required"`
+				Default  string   `yaml:"default"`
+				Options  []option `yaml:"options"`
+			} `yaml:"fields"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(source, &document); err != nil {
+		t.Fatalf("parse examples pipeline: %v", err)
+	}
+	if document.Agents.Queue != "hosted" || len(document.Steps) != 2 {
+		t.Fatalf("examples pipeline structure = queue %q, steps %#v", document.Agents.Queue, document.Steps)
+	}
+	picker := document.Steps[0]
+	if picker.Key != "choose-example" || picker.Block == "" || picker.If != `build.env("EXAMPLE") == null` || len(picker.Fields) != 1 {
+		t.Fatalf("example picker = %#v", picker)
+	}
+	field := picker.Fields[0]
+	wantOptions := []option{{"Basic CI", "basic"}, {"Artifact build and handoff", "artifacts"}, {"Advanced delivery", "advanced"}}
+	if field.Select != "Example" || field.Key != "example" || !field.Required || field.Default != "basic" || fmt.Sprint(field.Options) != fmt.Sprint(wantOptions) {
+		t.Fatalf("example picker field = %#v", field)
+	}
+	loader := document.Steps[1]
+	if loader.Key != "example-loader" || loader.Label == "" || loader.TimeoutInMinutes != 10 {
+		t.Fatalf("example loader = %#v", loader)
+	}
+	for _, required := range []string{
+		`example="$${EXAMPLE:-}"`,
+		`buildkite-agent meta-data get example`,
+		`.github/workflows/example-basic.yml`,
+		`.github/workflows/example-artifacts.yml`,
+		`.github/workflows/example-advanced.yml`,
+		`EXAMPLE_COMMIT`,
+		`test "$${BUILDKITE_COMMIT:?BUILDKITE_COMMIT is required}" = "$$commit"`,
+		`pipeline upload --no-interpolation --reject-secrets`,
+		`queue: "hosted"`,
+		`github-actions#v0.2.0`,
+	} {
+		if !strings.Contains(loader.Command, required) {
+			t.Fatalf("example loader lacks %q:\n%s", required, loader.Command)
+		}
+	}
+	for _, forbidden := range []string{"mise run", "plugin-demo.yml", "cache.yml", "phase-4-actions-oracle.yml"} {
+		if strings.Contains(loader.Command, forbidden) {
+			t.Fatalf("example loader contains %q:\n%s", forbidden, loader.Command)
+		}
+	}
+
+	workflows := map[string]string{
+		"example-basic.yml":     "Example - basic CI",
+		"example-artifacts.yml": "Example - build artifact",
+		"example-advanced.yml":  "Example - advanced delivery",
+	}
+	for path, wantName := range workflows {
+		workflowSource, err := os.ReadFile(filepath.Join(root, ".github", "workflows", path))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var workflowDocument struct {
+			Name string         `yaml:"name"`
+			On   map[string]any `yaml:"on"`
+		}
+		if err := yaml.Unmarshal(workflowSource, &workflowDocument); err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		if workflowDocument.Name != wantName || len(workflowDocument.On) != 1 {
+			t.Fatalf("%s trigger contract = name %q, on %#v", path, workflowDocument.Name, workflowDocument.On)
+		}
+		if _, exists := workflowDocument.On["workflow_dispatch"]; !exists {
+			t.Fatalf("%s is not manually dispatchable: %#v", path, workflowDocument.On)
+		}
+	}
+	if basic, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "example-basic.yml")); err != nil {
+		t.Fatal(err)
+	} else if strings.Contains(string(basic), "github.event_name") {
+		t.Fatalf("manual basic example retains event-specific behavior:\n%s", basic)
+	}
+}
+
 func TestProductionPluginDemoContract(t *testing.T) {
 	root := filepath.Join("..", "..")
 	source, err := os.ReadFile(filepath.Join(root, ".buildkite", "plugin-demo.yml"))
@@ -483,10 +585,10 @@ func TestProductionPluginDemoContract(t *testing.T) {
 		}{step.If, step.Command, step.TimeoutInMinutes, step.DependsOn, step.Plugins}
 	}
 	importers := map[string]string{
-		"plugin-demo-basic-importer":    "testdata/poc/.github/workflows/basic.yml",
-		"plugin-demo-artifact-importer": "testdata/poc/.github/workflows/artifacts.yml",
+		"plugin-demo-basic-importer":    ".github/workflows/example-basic.yml",
+		"plugin-demo-artifact-importer": ".github/workflows/example-artifacts.yml",
 		"plugin-demo-actions-importer":  ".github/workflows/phase-4-actions-oracle.yml",
-		"plugin-demo-advanced-importer": "testdata/poc/.github/workflows/advanced.yml",
+		"plugin-demo-advanced-importer": ".github/workflows/example-advanced.yml",
 		"plugin-demo-cache-importer":    "testdata/poc/.github/workflows/cache.yml",
 	}
 	for key, workflow := range importers {
@@ -532,7 +634,7 @@ func TestProductionPluginDemoContract(t *testing.T) {
 		}
 	}
 
-	advanced, err := os.ReadFile(filepath.Join(root, "testdata", "poc", ".github", "workflows", "advanced.yml"))
+	advanced, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "example-advanced.yml"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/compiler/smoke_manifest_test.go
+++ b/internal/compiler/smoke_manifest_test.go
@@ -68,9 +68,10 @@ func TestSmokeManifestInventory(t *testing.T) {
 		if strings.TrimSpace(fixture.Evidence) == "" || strings.TrimSpace(fixture.Note) == "" {
 			t.Fatalf("%s: evidence and note are required", fixture.ID)
 		}
-		for _, path := range []string{fixture.Workflow, fixture.Event} {
+		for index, path := range []string{fixture.Workflow, fixture.Event} {
 			clean := filepath.ToSlash(filepath.Clean(filepath.FromSlash(path)))
-			if !strings.HasPrefix(path, "testdata/") || filepath.IsAbs(path) || clean != path || slicesContain(strings.Split(path, "/"), "..") {
+			allowedRootWorkflow := index == 0 && (path == ".github/workflows/example-basic.yml" || path == ".github/workflows/example-artifacts.yml" || path == ".github/workflows/example-advanced.yml")
+			if (!strings.HasPrefix(path, "testdata/") && !allowedRootWorkflow) || filepath.IsAbs(path) || clean != path || slicesContain(strings.Split(path, "/"), "..") {
 				t.Fatalf("%s: unsafe path %q", fixture.ID, path)
 			}
 			if info, err := os.Stat(filepath.Join(root, filepath.FromSlash(path))); err != nil || !info.Mode().IsRegular() {
@@ -86,7 +87,7 @@ func TestSmokeManifestInventory(t *testing.T) {
 	}
 
 	var checkedIn []string
-	for _, pattern := range []string{"testdata/smoke/.github/workflows/*.yml", "testdata/poc/.github/workflows/basic.yml", "testdata/poc/.github/workflows/artifacts.yml", "testdata/poc/.github/workflows/advanced.yml", "testdata/poc/.github/workflows/cache.yml", "testdata/phase4/.github/workflows/*.yml", "testdata/phase5/.github/workflows/*.yml.tmpl", "testdata/phase5/runtime/.github/workflows/*.yml", "testdata/phase6/.github/workflows/*.yml", "testdata/unsupported/.github/workflows/*.yml"} {
+	for _, pattern := range []string{".github/workflows/example-basic.yml", ".github/workflows/example-artifacts.yml", ".github/workflows/example-advanced.yml", "testdata/smoke/.github/workflows/*.yml", "testdata/poc/.github/workflows/cache.yml", "testdata/phase4/.github/workflows/*.yml", "testdata/phase5/.github/workflows/*.yml.tmpl", "testdata/phase5/runtime/.github/workflows/*.yml", "testdata/phase6/.github/workflows/*.yml", "testdata/unsupported/.github/workflows/*.yml"} {
 		matches, err := filepath.Glob(filepath.Join(root, filepath.FromSlash(pattern)))
 		if err != nil {
 			t.Fatal(err)

--- a/mise.toml
+++ b/mise.toml
@@ -31,7 +31,7 @@ run = "golangci-lint run"
 
 [tasks."lint:shell"]
 description = "Lint shell scripts"
-run = "shellcheck -x .buildkite/phase-0-transport-probe/probe.sh scripts/ci-buildkite-release scripts/migration-poc-import scripts/phase-0-shell-oracle-checkout scripts/phase-0-sign-json scripts/phase-0-verify-json scripts/phase-5-hosted-docker-probe scripts/phase-5-hosted-runtime-probe scripts/phase-6-artifact-roundtrip-verify scripts/phase-6-summary-annotation-verify scripts/phase-6-upload-artifact-verify scripts/phase-6-workflow-annotations-verify scripts/release scripts/smoke-local testdata/actions/docker/entrypoint.sh testdata/phase5/runtime/.github/actions/docker/entrypoint.sh"
+run = "shellcheck -x .buildkite/phase-0-transport-probe/probe.sh scripts/ci-buildkite-release scripts/compare-example scripts/migration-poc-import scripts/phase-0-shell-oracle-checkout scripts/phase-0-sign-json scripts/phase-0-verify-json scripts/phase-5-hosted-docker-probe scripts/phase-5-hosted-runtime-probe scripts/phase-6-artifact-roundtrip-verify scripts/phase-6-summary-annotation-verify scripts/phase-6-upload-artifact-verify scripts/phase-6-workflow-annotations-verify scripts/release scripts/smoke-local testdata/actions/docker/entrypoint.sh testdata/phase5/runtime/.github/actions/docker/entrypoint.sh"
 
 [tasks.vet]
 description = "Run go vet"

--- a/scripts/compare-example
+++ b/scripts/compare-example
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo 'usage: scripts/compare-example [--github-only|--buildkite-only] <basic|artifacts|advanced>' >&2
+}
+
+mode=both
+example=""
+while (( $# > 0 )); do
+  case "$1" in
+    --github-only)
+      [[ "$mode" == both ]] || { usage; exit 2; }
+      mode=github
+      ;;
+    --buildkite-only)
+      [[ "$mode" == both ]] || { usage; exit 2; }
+      mode=buildkite
+      ;;
+    -*)
+      usage
+      exit 2
+      ;;
+    *)
+      [[ -z "$example" ]] || { usage; exit 2; }
+      example=$1
+      ;;
+  esac
+  shift
+done
+
+case "$example" in
+  basic)
+    label="Basic CI"
+    workflow="example-basic.yml"
+    ;;
+  artifacts)
+    label="Artifact build and handoff"
+    workflow="example-artifacts.yml"
+    ;;
+  advanced)
+    label="Advanced delivery"
+    workflow="example-advanced.yml"
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly root
+cd "$root"
+
+branch="$(git branch --show-current)"
+[[ -n "$branch" ]] || { echo 'compare-example requires a checked-out branch' >&2; exit 1; }
+commit="$(git rev-parse HEAD)"
+[[ "$commit" =~ ^[0-9a-f]{40}$ ]]
+
+remote_line="$(git ls-remote --exit-code origin "refs/heads/$branch")" || {
+  echo "origin has no branch named $branch; push the branch before comparing it" >&2
+  exit 1
+}
+remote_commit=${remote_line%%[[:space:]]*}
+[[ "$remote_commit" == "$commit" ]] || {
+  echo "origin/$branch is at $remote_commit, not $commit; push the exact commit before comparing it" >&2
+  exit 1
+}
+
+github_url=""
+if [[ "$mode" == both || "$mode" == github ]]; then
+  command -v gh >/dev/null || { echo 'compare-example requires gh' >&2; exit 1; }
+  before_run_id="$(gh run list \
+    --repo buildkite/buildkite-gha \
+    --workflow "$workflow" \
+    --branch "$branch" \
+    --limit 100 \
+    --json databaseId \
+    --jq 'map(.databaseId) | max // 0')"
+
+  gh workflow run "$workflow" \
+    --repo buildkite/buildkite-gha \
+    --ref "$branch"
+
+  for _ in {1..30}; do
+    github_url="$(gh run list \
+      --repo buildkite/buildkite-gha \
+      --workflow "$workflow" \
+      --branch "$branch" \
+      --limit 100 \
+      --json databaseId,event,headSha,url \
+      --jq "[.[] | select(.databaseId > $before_run_id and .event == \"workflow_dispatch\" and .headSha == \"$commit\")] | sort_by(.databaseId) | last | .url // empty")"
+    [[ -z "$github_url" ]] || break
+    sleep 2
+  done
+fi
+
+buildkite_url=""
+if [[ "$mode" == both || "$mode" == buildkite ]]; then
+  command -v bk >/dev/null || { echo 'compare-example requires bk' >&2; exit 1; }
+  buildkite_url="$(bk build create \
+    --pipeline buildkite/buildkite-gha-examples \
+    --branch "$branch" \
+    --commit "$commit" \
+    --message "Compare $label with GitHub Actions at ${commit:0:12}" \
+    --env "EXAMPLE=$example" \
+    --env "EXAMPLE_COMMIT=$commit" \
+    --yes)"
+fi
+
+printf 'Example:   %s\n' "$example"
+printf 'Commit:    %s\n' "$commit"
+if [[ "$mode" == both || "$mode" == github ]]; then
+  if [[ -n "$github_url" ]]; then
+    printf 'Actions:   %s\n' "$github_url"
+  else
+    echo 'Actions:   dispatched, but its URL was not discoverable within 60 seconds' >&2
+  fi
+fi
+if [[ "$mode" == both || "$mode" == buildkite ]]; then
+  printf 'Buildkite: %s\n' "$buildkite_url"
+fi
+
+[[ "$mode" == buildkite || -n "$github_url" ]]

--- a/scripts/migration-poc-import
+++ b/scripts/migration-poc-import
@@ -8,9 +8,9 @@ fi
 
 workflow=$1
 case "$workflow" in
-  testdata/poc/.github/workflows/basic.yml | \
-    testdata/poc/.github/workflows/artifacts.yml | \
-    testdata/poc/.github/workflows/advanced.yml) ;;
+  .github/workflows/example-basic.yml | \
+    .github/workflows/example-artifacts.yml | \
+    .github/workflows/example-advanced.yml) ;;
   *)
     echo "unsupported migration POC workflow: $workflow" >&2
     exit 2

--- a/scripts/smoke-local
+++ b/scripts/smoke-local
@@ -26,7 +26,7 @@ jq -e '
   all(.fixtures[];
     keys == ["action_preflight", "event", "evidence", "expectation", "id", "note", "workflow"] and
     (.id | test("^[a-z0-9]+(?:-[a-z0-9]+)*$")) and
-    (.workflow | type == "string" and length > 0 and startswith("testdata/") and (contains("..") | not)) and
+    (.workflow | type == "string" and length > 0 and (startswith("testdata/") or IN(".github/workflows/example-basic.yml", ".github/workflows/example-artifacts.yml", ".github/workflows/example-advanced.yml")) and (contains("..") | not)) and
     (.event | type == "string" and length > 0 and startswith("testdata/") and (contains("..") | not)) and
     (.expectation | IN("compile-pass", "compile-unsupported", "runtime-pass", "runtime-unsupported", "future")) and
     (.action_preflight | IN("none", "hosted-tokenless")) and

--- a/testdata/poc/README.md
+++ b/testdata/poc/README.md
@@ -1,17 +1,25 @@
 # Migration POC suite
 
-These workflows exercise common GitHub Actions migration shapes as one
-customer-shaped suite, rather than adding more phase-numbered probes:
+The canonical service-free example workflows at the repository root and the
+optional cache fixture in this directory exercise common GitHub Actions
+migration shapes as one customer-shaped suite:
 
-- `basic.yml`: checkout, tool setup, shell tests, conditions, outputs, and a job
-  summary.
-- `artifacts.yml`: build, job outputs, a direct producer-to-consumer artifact
-  handoff, and execution of the downloaded binary.
-- `advanced.yml`: a local reusable workflow with a caller-consumed declared
-  output, a public Dockerfile action, `continue-on-error`, artifact handoff,
-  matrix fan-out/fan-in, summaries, and workflow-command annotations.
+- `.github/workflows/example-basic.yml`: checkout, tool setup, shell tests,
+  conditions, outputs, and a job summary.
+- `.github/workflows/example-artifacts.yml`: build, job outputs, a direct
+  producer-to-consumer artifact handoff, and execution of the downloaded
+  binary.
+- `.github/workflows/example-advanced.yml`: a local reusable workflow with a
+  caller-consumed declared output, a public Dockerfile action,
+  `continue-on-error`, artifact handoff, matrix fan-out/fan-in, summaries, and
+  workflow-command annotations.
 - `cache.yml`: the optional `actions/cache` v6 miss/save/direct-dependent-hit
   extension.
+
+Keeping the service-free examples under the root `.github/workflows` directory
+makes each file both a native `workflow_dispatch` workflow and the exact source
+imported by the Buildkite comparison pipeline. The workflows are manual-only in
+this repository so they do not create extra Actions runs on every push.
 
 The released-plugin service-free lane also imports the repository's root-level
 Phase 4 workflow to prove checked-out local JavaScript and composite actions.

--- a/testdata/smoke/manifest.json
+++ b/testdata/smoke/manifest.json
@@ -39,7 +39,7 @@
     },
     {
       "id": "migration-poc-basic",
-      "workflow": "testdata/poc/.github/workflows/basic.yml",
+      "workflow": ".github/workflows/example-basic.yml",
       "event": "testdata/smoke/events/push.json",
       "expectation": "runtime-pass",
       "evidence": "Exact-commit Buildkite build 290 passed the complete migration POC suite.",
@@ -48,7 +48,7 @@
     },
     {
       "id": "migration-poc-artifacts",
-      "workflow": "testdata/poc/.github/workflows/artifacts.yml",
+      "workflow": ".github/workflows/example-artifacts.yml",
       "event": "testdata/smoke/events/push.json",
       "expectation": "runtime-pass",
       "evidence": "Exact-commit Buildkite build 290 passed the complete migration POC suite.",
@@ -57,7 +57,7 @@
     },
     {
       "id": "migration-poc-advanced",
-      "workflow": "testdata/poc/.github/workflows/advanced.yml",
+      "workflow": ".github/workflows/example-advanced.yml",
       "event": "testdata/smoke/events/push.json",
       "expectation": "runtime-pass",
       "evidence": "Published-plugin Buildkite build 336 passed the revised service-free advanced fixture and all generated jobs.",


### PR DESCRIPTION
## Summary

- promote the basic, artifact, and advanced migration POCs into manually dispatchable root workflows shared by both providers
- add a dedicated Buildkite picker pipeline that imports exactly one allowlisted workflow through the released github-actions plugin
- add an exact-commit launcher that starts matching GitHub Actions and Buildkite runs and prints both URLs
- keep the existing smoke inventory, migration importers, plugin demo, tests, and documentation aligned with the canonical workflow paths

## Validation

- `mise run check`

## Rollout

The manual [buildkite-gha Examples](https://buildkite.com/buildkite/buildkite-gha-examples) pipeline is already provisioned and points at `.buildkite/examples.yml`. GitHub only accepts `workflow_dispatch` for a new workflow after that workflow exists on the default branch, so the first paired run should be launched after this PR merges.