### PR TITLE
test: canonicalize Darwin temp paths

### DIFF
--- a/internal/action/metadata/metadata_test.go
+++ b/internal/action/metadata/metadata_test.go
@@ -182,9 +182,12 @@ func TestLoadIsStrictAndConfined(t *testing.T) {
 func TestLoadRejectsCompositeControlsWithLocation(t *testing.T) {
 	for _, control := range []string{"background", "wait", "wait-all", "cancel", "parallel"} {
 		t.Run(control, func(t *testing.T) {
-			root := t.TempDir()
+			root, err := filepath.EvalSymlinks(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
 			writeAction(t, root, "action.yml", "runs:\n  using: composite\n  steps:\n    - id: child\n      run: echo ok\n      "+control+": true\n")
-			_, err := Load(root, ".")
+			_, err = Load(root, ".")
 			want := fmt.Sprintf("parse action metadata %q:6:7: composite child 1 (id %q) declares unsupported control %q", filepath.Join(root, "action.yml"), "child", control)
 			if err == nil || err.Error() != want {
 				t.Fatalf("Load() error = %v, want %q", err, want)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -484,7 +484,11 @@ func TestRunUploadJavaScriptActionTransportsMiseWithoutNode(t *testing.T) {
 
 func TestPrepareMiseDataDirFallsBackWhenCacheIsUnavailable(t *testing.T) {
 	var stderr bytes.Buffer
-	dir := filepath.Join(t.TempDir(), "mise")
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(root, "mise")
 	if got := prepareMiseDataDir(dir, &stderr); got != dir || stderr.Len() != 0 {
 		t.Fatalf("prepareMiseDataDir() = %q, stderr = %q", got, stderr.String())
 	}
@@ -498,8 +502,14 @@ func TestPrepareMiseDataDirFallsBackWhenCacheIsUnavailable(t *testing.T) {
 		t.Fatalf("prepareMiseDataDir(file) = %q, stderr = %q", got, stderr.String())
 	}
 
-	parent := t.TempDir()
-	target := t.TempDir()
+	parent, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	target, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
 	link := filepath.Join(parent, "linked-cache")
 	if err := os.Symlink(target, link); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Why

`mise run release` correctly runs the full check gate before tagging, but two tests compare logical macOS `/var/...` temp paths with production paths canonicalized through `/private/var/...`. This makes a clean patch release fail locally on Darwin even though the production behavior is correct.

## What

- canonicalize the action metadata test root before asserting the exact source-located diagnostic
- canonicalize the mise cache test roots so the success case is a real directory and the symlink case tests the explicit fixture symlink rather than macOS's system `/var` alias
- leave production path and symlink checks unchanged

## Validation

- `mise exec -- go test -count=1 ./internal/action/metadata ./internal/cli`
- `mise run check`
- `git diff --check`