### PR TITLE
Add generated example pipeline uploader

### DIFF
--- a/.buildkite/upload-examples.sh
+++ b/.buildkite/upload-examples.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if (( $# > 1 )); then
+  echo 'usage: .buildkite/upload-examples.sh [basic|artifacts|advanced]' >&2
+  exit 2
+fi
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+upload_pipeline() {
+  buildkite-agent pipeline upload --no-interpolation --reject-secrets
+}
+
+if (( $# == 1 )); then
+  example="$1"
+elif [[ -v EXAMPLE ]]; then
+  example="$EXAMPLE"
+else
+  cat <<'YAML' | upload_pipeline
+agents:
+  queue: "hosted"
+
+steps:
+  - block: ":github: Choose an example workflow"
+    key: "choose-example"
+    prompt: "Choose the GitHub Actions workflow to run as native Buildkite jobs."
+    submit: "Run example"
+    fields:
+      - select: "Example"
+        key: "example"
+        required: true
+        default: "basic"
+        options:
+          - label: "Basic CI"
+            value: "basic"
+          - label: "Artifact build and handoff"
+            value: "artifacts"
+          - label: "Advanced delivery"
+            value: "advanced"
+
+  - label: ":pipeline: Load example workflow"
+    key: "example-loader"
+    timeout_in_minutes: 10
+    retry:
+      automatic: false
+    command: |
+      set -euo pipefail
+      example="$(buildkite-agent meta-data get example)"
+      .buildkite/upload-examples.sh "$example"
+YAML
+  exit
+fi
+
+case "$example" in
+  basic)
+    label="Basic CI"
+    workflow=".github/workflows/example-basic.yml"
+    ;;
+  artifacts)
+    label="Artifact build and handoff"
+    workflow=".github/workflows/example-artifacts.yml"
+    ;;
+  advanced)
+    label="Advanced delivery"
+    workflow=".github/workflows/example-advanced.yml"
+    ;;
+  *)
+    echo "unknown example: $example" >&2
+    exit 2
+    ;;
+esac
+
+if [[ -v EXAMPLE_COMMIT ]]; then
+  commit="$EXAMPLE_COMMIT"
+else
+  commit="${BUILDKITE_COMMIT:-}"
+fi
+if [[ ! "$commit" =~ ^[0-9a-f]{40}$ ]]; then
+  echo 'example commit must be a full lowercase 40-character SHA' >&2
+  exit 2
+fi
+if [[ "${BUILDKITE_COMMIT:-}" != "$commit" ]]; then
+  echo 'EXAMPLE_COMMIT must match BUILDKITE_COMMIT' >&2
+  exit 2
+fi
+if [[ ! -f "$workflow" ]]; then
+  echo "example workflow does not exist: $workflow" >&2
+  exit 2
+fi
+
+cat <<YAML | upload_pipeline
+agents:
+  queue: "hosted"
+
+steps:
+  - label: ":github: $label"
+    key: "example-$example-importer"
+    timeout_in_minutes: 20
+    retry:
+      automatic: false
+    plugins:
+      - github-actions#v0.2.0:
+          workflow: "$workflow"
+YAML

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -3,8 +3,10 @@ package buildkite
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -532,6 +534,145 @@ func TestExamplesPipelineSelectsOneCanonicalWorkflow(t *testing.T) {
 		t.Fatal(err)
 	} else if strings.Contains(string(basic), "github.event_name") {
 		t.Fatalf("manual basic example retains event-specific behavior:\n%s", basic)
+	}
+}
+
+func TestUploadExamplesScript(t *testing.T) {
+	root := filepath.Join("..", "..")
+	script, err := filepath.Abs(filepath.Join(root, ".buildkite", "upload-examples.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	const commit = "0123456789abcdef0123456789abcdef01234567"
+
+	run := func(t *testing.T, environment map[string]string, arguments ...string) (string, string, error) {
+		t.Helper()
+		fakeBin := t.TempDir()
+		capture := filepath.Join(fakeBin, "pipeline.yml")
+		capturedArguments := filepath.Join(fakeBin, "arguments")
+		fakeAgent := filepath.Join(fakeBin, "buildkite-agent")
+		if err := os.WriteFile(fakeAgent, []byte("#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$CAPTURED_ARGUMENTS\"\ncat > \"$CAPTURE\"\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		command := exec.Command(script, arguments...)
+		command.Dir = root
+		command.Env = []string{
+			"PATH=" + fakeBin + string(os.PathListSeparator) + os.Getenv("PATH"),
+			"CAPTURE=" + capture,
+			"CAPTURED_ARGUMENTS=" + capturedArguments,
+		}
+		for key, value := range environment {
+			command.Env = append(command.Env, key+"="+value)
+		}
+		output, runErr := command.CombinedOutput()
+		pipeline, readErr := os.ReadFile(capture)
+		if readErr != nil && !os.IsNotExist(readErr) {
+			t.Fatal(readErr)
+		}
+		uploadArguments, readErr := os.ReadFile(capturedArguments)
+		if readErr != nil && !os.IsNotExist(readErr) {
+			t.Fatal(readErr)
+		}
+		if runErr == nil {
+			var document any
+			if err := yaml.Unmarshal(pipeline, &document); err != nil {
+				t.Fatalf("generated invalid YAML: %v\n%s", err, pipeline)
+			}
+		}
+		return string(pipeline), string(uploadArguments) + string(output), runErr
+	}
+
+	t.Run("interactive picker", func(t *testing.T) {
+		pipeline, output, err := run(t, nil)
+		if err != nil {
+			t.Fatalf("upload picker: %v\n%s", err, output)
+		}
+		for _, required := range []string{
+			`key: "choose-example"`,
+			`value: "basic"`,
+			`value: "artifacts"`,
+			`value: "advanced"`,
+			`example="$(buildkite-agent meta-data get example)"`,
+			`.buildkite/upload-examples.sh "$example"`,
+			`queue: "hosted"`,
+		} {
+			if !strings.Contains(pipeline, required) {
+				t.Fatalf("picker lacks %q:\n%s", required, pipeline)
+			}
+		}
+		if strings.Contains(pipeline, "github-actions#") {
+			t.Fatalf("picker unexpectedly contains importer:\n%s", pipeline)
+		}
+		if output != "pipeline\nupload\n--no-interpolation\n--reject-secrets\n" {
+			t.Fatalf("upload arguments = %q", output)
+		}
+	})
+
+	t.Run("environment selection", func(t *testing.T) {
+		pipeline, output, err := run(t, map[string]string{
+			"EXAMPLE":          "basic",
+			"EXAMPLE_COMMIT":   commit,
+			"BUILDKITE_COMMIT": commit,
+		})
+		if err != nil {
+			t.Fatalf("upload importer: %v\n%s", err, output)
+		}
+		for _, required := range []string{
+			`:github: Basic CI`,
+			`key: "example-basic-importer"`,
+			`github-actions#v0.2.0`,
+			`workflow: ".github/workflows/example-basic.yml"`,
+			`queue: "hosted"`,
+		} {
+			if !strings.Contains(pipeline, required) {
+				t.Fatalf("basic importer lacks %q:\n%s", required, pipeline)
+			}
+		}
+		for _, forbidden := range []string{"choose-example", "example-loader"} {
+			if strings.Contains(pipeline, forbidden) {
+				t.Fatalf("basic importer contains %q:\n%s", forbidden, pipeline)
+			}
+		}
+		if strings.Count(pipeline, "github-actions#v0.2.0") != 1 {
+			t.Fatalf("basic importer does not contain exactly one plugin:\n%s", pipeline)
+		}
+	})
+
+	t.Run("positional selection", func(t *testing.T) {
+		pipeline, output, err := run(t, map[string]string{"BUILDKITE_COMMIT": commit}, "artifacts")
+		if err != nil {
+			t.Fatalf("upload importer: %v\n%s", err, output)
+		}
+		if !strings.Contains(pipeline, `workflow: ".github/workflows/example-artifacts.yml"`) {
+			t.Fatalf("artifact importer has wrong workflow:\n%s", pipeline)
+		}
+	})
+
+	for _, test := range []struct {
+		name        string
+		environment map[string]string
+		arguments   []string
+	}{
+		{name: "unknown example", environment: map[string]string{"EXAMPLE": "other"}},
+		{name: "empty example", environment: map[string]string{"EXAMPLE": ""}},
+		{name: "malformed build commit", environment: map[string]string{"EXAMPLE": "basic", "BUILDKITE_COMMIT": "abc"}},
+		{name: "malformed comparison commit", environment: map[string]string{"EXAMPLE": "basic", "EXAMPLE_COMMIT": "abc", "BUILDKITE_COMMIT": commit}},
+		{name: "mismatched commit", environment: map[string]string{"EXAMPLE": "basic", "EXAMPLE_COMMIT": commit, "BUILDKITE_COMMIT": "1123456789abcdef0123456789abcdef01234567"}},
+		{name: "too many arguments", arguments: []string{"basic", "advanced"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			pipeline, output, err := run(t, test.environment, test.arguments...)
+			if err == nil {
+				t.Fatalf("invalid invocation succeeded:\n%s", output)
+			}
+			var exitError *exec.ExitError
+			if !errors.As(err, &exitError) || exitError.ExitCode() != 2 {
+				t.Fatalf("invalid invocation error = %v, output:\n%s", err, output)
+			}
+			if pipeline != "" {
+				t.Fatalf("invalid invocation uploaded pipeline:\n%s", pipeline)
+			}
+		})
 	}
 }
 

--- a/mise.toml
+++ b/mise.toml
@@ -31,7 +31,7 @@ run = "golangci-lint run"
 
 [tasks."lint:shell"]
 description = "Lint shell scripts"
-run = "shellcheck -x .buildkite/phase-0-transport-probe/probe.sh scripts/ci-buildkite-release scripts/compare-example scripts/migration-poc-import scripts/phase-0-shell-oracle-checkout scripts/phase-0-sign-json scripts/phase-0-verify-json scripts/phase-5-hosted-docker-probe scripts/phase-5-hosted-runtime-probe scripts/phase-6-artifact-roundtrip-verify scripts/phase-6-summary-annotation-verify scripts/phase-6-upload-artifact-verify scripts/phase-6-workflow-annotations-verify scripts/release scripts/smoke-local testdata/actions/docker/entrypoint.sh testdata/phase5/runtime/.github/actions/docker/entrypoint.sh"
+run = "shellcheck -x .buildkite/phase-0-transport-probe/probe.sh .buildkite/upload-examples.sh scripts/ci-buildkite-release scripts/compare-example scripts/migration-poc-import scripts/phase-0-shell-oracle-checkout scripts/phase-0-sign-json scripts/phase-0-verify-json scripts/phase-5-hosted-docker-probe scripts/phase-5-hosted-runtime-probe scripts/phase-6-artifact-roundtrip-verify scripts/phase-6-summary-annotation-verify scripts/phase-6-upload-artifact-verify scripts/phase-6-workflow-annotations-verify scripts/release scripts/smoke-local testdata/actions/docker/entrypoint.sh testdata/phase5/runtime/.github/actions/docker/entrypoint.sh"
 
 [tasks.vet]
 description = "Run go vet"


### PR DESCRIPTION
## Summary

- add an executable Buildkite bootstrap that uploads the selected example importer directly when `EXAMPLE` is set
- generate the interactive picker only for manual builds without a selection
- validate the fixed example allowlist and exact Buildkite commit before uploading
- retain `.buildkite/examples.yml` during the pipeline-settings rollout

## Testing

- `mise run check`
