### PR TITLE
Label example importer as Run workflow

### DIFF
--- a/.buildkite/examples.yml
+++ b/.buildkite/examples.yml
@@ -35,15 +35,12 @@ steps:
 
       case "$$example" in
         basic)
-          label="Basic CI"
           workflow=".github/workflows/example-basic.yml"
           ;;
         artifacts)
-          label="Artifact build and handoff"
           workflow=".github/workflows/example-artifacts.yml"
           ;;
         advanced)
-          label="Advanced delivery"
           workflow=".github/workflows/example-advanced.yml"
           ;;
         *)
@@ -62,7 +59,7 @@ steps:
         queue: "hosted"
 
       steps:
-        - label: ":github: $$label"
+        - label: ":github: Run workflow"
           key: "example-$$example-importer"
           timeout_in_minutes: 20
           retry:

--- a/.buildkite/upload-examples.sh
+++ b/.buildkite/upload-examples.sh
@@ -56,15 +56,12 @@ fi
 
 case "$example" in
   basic)
-    label="Basic CI"
     workflow=".github/workflows/example-basic.yml"
     ;;
   artifacts)
-    label="Artifact build and handoff"
     workflow=".github/workflows/example-artifacts.yml"
     ;;
   advanced)
-    label="Advanced delivery"
     workflow=".github/workflows/example-advanced.yml"
     ;;
   *)
@@ -96,7 +93,7 @@ agents:
   queue: "hosted"
 
 steps:
-  - label: ":github: $label"
+  - label: ":github: Run workflow"
     key: "example-$example-importer"
     timeout_in_minutes: 20
     retry:

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -618,7 +618,7 @@ func TestUploadExamplesScript(t *testing.T) {
 			t.Fatalf("upload importer: %v\n%s", err, output)
 		}
 		for _, required := range []string{
-			`:github: Basic CI`,
+			`:github: Run workflow`,
 			`key: "example-basic-importer"`,
 			`github-actions#v0.2.0`,
 			`workflow: ".github/workflows/example-basic.yml"`,


### PR DESCRIPTION
## Summary

- label the example importer as `:github: Run workflow` in the active uploader
- keep the retained fallback pipeline consistent
- preserve internal importer keys used for dependencies and artifact binding

## Testing

- `mise exec -- go test ./internal/buildkite`
- `mise exec -- shellcheck -x .buildkite/upload-examples.sh`
- `bash -n .buildkite/upload-examples.sh`
