### PR TITLE
Reconcile v0.2.1 release and migration evidence

### DIFF
--- a/.buildkite/examples.yml
+++ b/.buildkite/examples.yml
@@ -65,6 +65,6 @@ steps:
           retry:
             automatic: false
           plugins:
-            - github-actions#v0.2.0:
+            - github-actions#v0.2.1:
                 workflow: "$$workflow"
       YAML

--- a/.buildkite/plugin-demo.yml
+++ b/.buildkite/plugin-demo.yml
@@ -8,7 +8,7 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#v0.2.0:
+      - github-actions#v0.2.1:
           workflow: .github/workflows/example-basic.yml
 
   - label: ":package: Artifact released-plugin demo"
@@ -17,7 +17,7 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#v0.2.0:
+      - github-actions#v0.2.1:
           workflow: .github/workflows/example-artifacts.yml
 
   - label: ":javascript: Actions released-plugin demo"
@@ -26,7 +26,7 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#v0.2.0:
+      - github-actions#v0.2.1:
           workflow: .github/workflows/phase-4-actions-oracle.yml
 
   - label: ":rocket: Advanced released-plugin demo"
@@ -35,7 +35,7 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#v0.2.0:
+      - github-actions#v0.2.1:
           workflow: .github/workflows/example-advanced.yml
 
   - label: ":white_check_mark: Service-free plugin demo complete"
@@ -54,7 +54,7 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#v0.2.0:
+      - github-actions#v0.2.1:
           workflow: testdata/poc/.github/workflows/cache.yml
 
   - label: ":white_check_mark: Cache plugin demo complete"

--- a/.buildkite/upload-examples.sh
+++ b/.buildkite/upload-examples.sh
@@ -99,6 +99,6 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#v0.2.0:
+      - github-actions#v0.2.1:
           workflow: "$workflow"
 YAML

--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ steps:
   - label: ":github: Test"
     key: "gha-ci"
     plugins:
-      - github-actions#v0.2.0:
+      - github-actions#v0.2.1:
           workflow: .github/workflows/ci.yml
 ```
 
-The released plugin downloads and verifies `buildkite-gha` v0.2.0 by default, derives the
-event context from the Buildkite build, and uploads the generated jobs to the
-fixed `hosted` queue. Pin a released plugin version rather than a floating
-branch.
+The released plugin downloads and verifies `buildkite-gha` v0.2.1 by default,
+derives the event context from the Buildkite build, and uploads the generated
+jobs to the fixed `hosted` queue. Pin a released plugin version rather than a
+floating branch.
 
 Configure branch, tag, and pull request triggers in Buildkite. The plugin
 derives a `pull_request` context for pull request builds and a `push` context
@@ -49,7 +49,7 @@ steps:
   - label: ":github: Test"
     key: "gha-ci"
     plugins:
-      - github-actions#v0.2.0:
+      - github-actions#v0.2.1:
           workflow: .github/workflows/ci.yml
 
   - label: ":rocket: Deploy"

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -198,10 +198,24 @@ cache action before its JavaScript executes.
 This implemented and admitted contract has hosted runtime evidence. The
 then-combined advanced migration POC in [Buildkite build 303](https://buildkite.com/buildkite/buildkite-gha/builds/303)
 demonstrated a build-unique miss, post-action save, and direct dependent exact
-hit at implementation commit
-`9d29bf26492be760016d29c7ba0d00033b4f9b39`. The minimal Phase 6 cache fixture
-remains compile-only conformance coverage. The stable released-plugin cache
-extension also remains compile/admission-only until its exact-commit hosted run.
+hit at implementation commit `9d29bf26492be760016d29c7ba0d00033b4f9b39`.
+The stable released-plugin extension subsequently proved the same producer
+miss, post-save, and direct-dependent exact primary-key hit in [Buildkite build
+337](https://buildkite.com/buildkite/buildkite-gha/builds/337). The minimal
+Phase 6 cache fixture remains compile-only conformance coverage; it is not the
+fixture that carries the runtime claim.
+
+An independent migrated-repository E2E adds customer-shaped evidence. At exact
+`mcncl/gotyper` commit
+[`8a74f88676a120e0bc6090b1aafc65edfd62ebbe`](https://github.com/mcncl/gotyper/commit/8a74f88676a120e0bc6090b1aafc65edfd62ebbe),
+[Buildkite build 11](https://buildkite.com/no-assembly/gotyper/builds/11)
+passed a public two-job workflow through plugin `v0.2.1`. The migrated workflow
+used exact audited checkout, setup-go, and cache commits, a shell-computed cache
+key, a direct `needs` edge, race tests, static analysis, and a final binary
+build. It explicitly disabled setup-go's token and built-in cache inputs, and
+its compatible Hosted image supplied the C compiler required by `go test
+-race`; this is evidence for the documented migrated subset, not a claim that
+unmodified workflows or every Hosted image are compatible.
 
 ### Failures stay explicit
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -180,8 +180,8 @@ publication and caller consumption, the build-unique cache miss, post-save,
 dependent exact hit, and subsequent artifact fan-out. The revised stable
 service-free and cache fixtures retain compile/admission coverage.
 
-The CLI and companion plugin `v0.2.0` releases exercised the complete customer
-installation path at source commit
+The initial CLI and companion plugin `v0.2.0` releases exercised the complete
+customer installation path at source commit
 `d5102df7e81c49f27a30fb2830d9608a56ee84de`. The service-free importer,
 generated jobs, native terminal, and repository checks passed in [Buildkite
 build 336](https://buildkite.com/buildkite/buildkite-gha/builds/336). The same
@@ -191,8 +191,26 @@ hit and restore, and cache terminal passed in [Buildkite build
 the public plugin tag resolved to the tested commit
 `d009da173158270a3921b2997ae8fd3d68526d00` and installed the same verified CLI
 distribution without an explicit CLI version override. These are the
-authoritative published installation proofs. Repeat the customer installation
-path with:
+authoritative initial published installation proofs.
+
+CLI `v0.2.1` was subsequently published at exact tag commit
+`a780787f049281290974292f00c29e92db717fb9` after [Buildkite release build
+351](https://buildkite.com/buildkite/buildkite-gha/builds/351) passed. Companion
+plugin `v0.2.1` resolves to exact commit
+`4910e56544e365bb545d3157c5aac058b6dabfaa` and defaults to that CLI release.
+At exact external repository commit
+[`8a74f88676a120e0bc6090b1aafc65edfd62ebbe`](https://github.com/mcncl/gotyper/commit/8a74f88676a120e0bc6090b1aafc65edfd62ebbe),
+[`mcncl/gotyper` build 11](https://buildkite.com/no-assembly/gotyper/builds/11)
+passed a two-job public workflow through the published plugin, including public
+checkout, setup-go, the audited cache v6 lifecycle, a direct dependency, race
+tests, static analysis, and a final binary build. This is the first external
+customer-shaped migration proof; several more migrations are still required by
+the public-beta gate.
+
+The generated example uploader and its `Run workflow` label landed on this
+repository's main branch after the CLI `v0.2.1` tag. They are current
+repository-demo UX rather than evidence about the released CLI runtime. Repeat
+the customer installation path with the current released-plugin demo:
 
 ```sh
 commit=$(git rev-parse HEAD)

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -1351,6 +1351,14 @@ Cursor Origin public checkout remains a separate provider integration gate.
   post-save, direct-dependent exact primary-key hit and restore, verified
   payload, generated terminal, and default verified CLI distribution at source
   commit `d5102df7e81c49f27a30fb2830d9608a56ee84de`.
+  The first independent migrated-repository E2E now adds customer-shaped
+  evidence for the released path. At exact `mcncl/gotyper` commit
+  `8a74f88676a120e0bc6090b1aafc65edfd62ebbe`, Buildkite build 11 passed a
+  public two-job workflow through plugin `v0.2.1`, including exact-commit
+  checkout and setup-go, the audited cache-v2 lifecycle, a direct dependency,
+  race tests, static analysis, and a final binary build on a compatible Hosted
+  image. This is one external migration, not yet the several required by the
+  public-beta gate.
   Together these results complete the GitHub/tokenless portion of delivery
   slice 1 and delivery slice 2. Cursor Origin public checkout still requires a
   provider context/source contract. Delivery slice 3—the OIDC-authenticated,
@@ -2228,18 +2236,32 @@ interfaces required by [ADR 0003](../architecture/0003-protected-capability-cont
 Private source, secrets, provider tokens, environments, and compatible OIDC
 remain fail-closed during that work.
 
-The complete published installation experience is now proven. CLI `v0.2.0` is
-public, and companion plugin `v0.2.0` resolves to the exact tested merge commit
-`d009da173158270a3921b2997ae8fd3d68526d00`, which defaults to that CLI release.
-At source commit `d5102df7e81c49f27a30fb2830d9608a56ee84de`, Buildkite build 336 passed the
+The complete published installation experience is now proven. The initial CLI
+and companion plugin `v0.2.0` releases remain the subject of the repository's
+full released-plugin demo proofs: at source commit
+`d5102df7e81c49f27a30fb2830d9608a56ee84de`, Buildkite build 336 passed the
 service-free terminal after the basic, artifact, JavaScript/composite, and
 advanced importers and generated jobs succeeded. Buildkite build 337 passed the
 same service-free lane plus the cache producer miss and post-save,
 direct-dependent primary-key hit and restore, cache terminal, and repository
-checks. Both runs used only the public plugin tag and its default verified CLI
-distribution. They are the authoritative published quick-start evidence.
+checks. Both runs used only plugin `v0.2.0` at exact commit
+`d009da173158270a3921b2997ae8fd3d68526d00` and its default verified CLI
+`v0.2.0` distribution. They remain the authoritative full installation and
+cache-demo evidence.
 
-Treat a fully reproducible demo as the next product milestone, distinct from a
+CLI `v0.2.1` is public at exact tag commit
+`a780787f049281290974292f00c29e92db717fb9`; Buildkite release build 351 passed
+for that commit. Companion plugin `v0.2.1` resolves to exact commit
+`4910e56544e365bb545d3157c5aac058b6dabfaa` and defaults to CLI `v0.2.1`.
+At exact external repository commit
+`8a74f88676a120e0bc6090b1aafc65edfd62ebbe`, `mcncl/gotyper` Buildkite build 11
+passed a public two-job workflow through those published versions. This is the
+first independent customer-shaped installation proof. The generated example
+uploader and `Run workflow` label landed on main after the CLI `v0.2.1` tag;
+they are repository-demo UX rather than evidence about the released CLI
+runtime.
+
+The fully reproducible demo milestone is complete and remains distinct from a
 public-beta declaration. It has two explicit lanes:
 
 1. The service-free baseline installs an immutable plugin revision, downloads
@@ -2286,10 +2308,11 @@ The demo gap closed in this order, using small cross-repository changes:
    from the temporary commit pin to that tag, and rerun both demo lanes using
    only the published configuration. Record those exact runs as the
    authoritative installation and demo evidence.
-5. Ongoing: use failures and diagnostics from those runs, followed by several
-   real customer workflow migrations, to drive small compatibility or UX
-   changes. Do not add workflow-specific runtime branches to make a demo
-   fixture pass.
+5. Ongoing: use failures and diagnostics from those runs and real customer
+   workflow migrations to drive small compatibility or UX changes. The first
+   external migration passed at `mcncl/gotyper` commit
+   `8a74f88676a120e0bc6090b1aafc65edfd62ebbe`; several more remain. Do not add
+   workflow-specific runtime branches to make a demo fixture pass.
 
 This milestone does not by itself satisfy every public-beta gate. The initial
 support target still names manual-input event envelopes plus job and service
@@ -2299,9 +2322,10 @@ installation even though the implemented preview is checksummed and fixed to a
 Hosted runtime queue. Those are explicit scope decisions: either implement and
 prove them or deliberately revise the beta contract before claiming the
 initial support target is complete. A production cache endpoint and several
-customer migrations are also still outstanding. The signed no-op capability
-grant remains a parallel security-foundation item, not permission to block or
-weaken the service-free demo.
+customer migrations beyond the first `mcncl/gotyper` proof are also still
+outstanding. The signed no-op capability grant remains a parallel
+security-foundation item, not permission to block or weaken the service-free
+demo.
 
 ## Release gates
 

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -494,7 +494,7 @@ func TestExamplesPipelineSelectsOneCanonicalWorkflow(t *testing.T) {
 		`test "$${BUILDKITE_COMMIT:?BUILDKITE_COMMIT is required}" = "$$commit"`,
 		`pipeline upload --no-interpolation --reject-secrets`,
 		`queue: "hosted"`,
-		`github-actions#v0.2.0`,
+		`github-actions#v0.2.1`,
 	} {
 		if !strings.Contains(loader.Command, required) {
 			t.Fatalf("example loader lacks %q:\n%s", required, loader.Command)
@@ -620,7 +620,7 @@ func TestUploadExamplesScript(t *testing.T) {
 		for _, required := range []string{
 			`:github: Run workflow`,
 			`key: "example-basic-importer"`,
-			`github-actions#v0.2.0`,
+			`github-actions#v0.2.1`,
 			`workflow: ".github/workflows/example-basic.yml"`,
 			`queue: "hosted"`,
 		} {
@@ -633,7 +633,7 @@ func TestUploadExamplesScript(t *testing.T) {
 				t.Fatalf("basic importer contains %q:\n%s", forbidden, pipeline)
 			}
 		}
-		if strings.Count(pipeline, "github-actions#v0.2.0") != 1 {
+		if strings.Count(pipeline, "github-actions#v0.2.1") != 1 {
 			t.Fatalf("basic importer does not contain exactly one plugin:\n%s", pipeline)
 		}
 	})
@@ -682,7 +682,7 @@ func TestProductionPluginDemoContract(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	const plugin = "github-actions#v0.2.0"
+	const plugin = "github-actions#v0.2.1"
 	type pluginConfig struct {
 		Workflow string `yaml:"workflow"`
 		Version  string `yaml:"version"`

--- a/testdata/poc/README.md
+++ b/testdata/poc/README.md
@@ -107,6 +107,19 @@ CLI `v0.2.0` distribution without an explicit CLI version override. Build 337
 observed the required producer miss and post-save followed by the direct
 dependent's exact primary-key hit and restore.
 
+CLI `v0.2.1` was published at exact tag commit
+`a780787f049281290974292f00c29e92db717fb9` after [Buildkite release build
+351](https://buildkite.com/buildkite/buildkite-gha/builds/351) passed. Companion
+plugin `v0.2.1` resolves to exact commit
+`4910e56544e365bb545d3157c5aac058b6dabfaa` and installs CLI `v0.2.1` by default.
+The first independent migrated-repository proof used those published versions:
+at exact `mcncl/gotyper` commit
+[`8a74f88676a120e0bc6090b1aafc65edfd62ebbe`](https://github.com/mcncl/gotyper/commit/8a74f88676a120e0bc6090b1aafc65edfd62ebbe),
+[Buildkite build 11](https://buildkite.com/no-assembly/gotyper/builds/11)
+passed public checkout, setup-go, the audited cache v6 lifecycle, a direct
+two-job dependency, race tests, static analysis, and a final binary build on a
+compatible Hosted image.
+
 The historical phase fixtures and their recorded observations remain the
 conformance ledger. The now-superseded targeted cache importer, continuation,
 and verifier were removed after build 290 passed. The remaining phase-specific


### PR DESCRIPTION
## Summary

- move live README, example, and released-plugin demo pins to plugin v0.2.1
- record CLI release build 351, the plugin v0.2.1 commit/default, and the external gotyper build 11 E2E
- preserve v0.2.0 builds 336/337 as historical installation proofs while fixing the contradictory cache runtime classification
- distinguish post-tag repository demo UX from evidence about the released CLI runtime
- keep the remaining public-beta migration and cache-service gaps explicit

## Verification

- `mise run check`