### PR TITLE
Resolve matrix expressions in job labels

### DIFF
--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -634,7 +634,7 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 			instance := JobInstance{
 				Key:                     key,
 				LogicalJobID:            job.ID,
-				Label:                   instanceLabel(job, matrix),
+				Label:                   instanceLabel(job, matrix, context),
 				RunsOn:                  labels,
 				Queue:                   queue,
 				Matrix:                  matrix,
@@ -1202,10 +1202,20 @@ func loadLocalAction(repositoryRoot, uses string) (metadata.Metadata, error) {
 	return metadata.Load(repositoryRoot, relativeActionPath)
 }
 
-func instanceLabel(job workflow.Job, matrix map[string]any) string {
+func instanceLabel(job workflow.Job, matrix map[string]any, context expression.CompileContext) string {
 	label := job.Name
 	if label == "" {
 		label = job.ID
+	} else {
+		context.Matrix = matrix
+		if resolved, err := expression.EvaluateCompileTemplate(label, context); err == nil {
+			label = resolved
+			withoutMatrix := context
+			withoutMatrix.Matrix = nil
+			if _, err := expression.EvaluateCompileTemplate(job.Name, withoutMatrix); err != nil {
+				return label
+			}
+		}
 	}
 	if len(matrix) == 0 {
 		return label

--- a/internal/compiler/config_test.go
+++ b/internal/compiler/config_test.go
@@ -114,6 +114,7 @@ func TestCompileEvaluatesGitHubEventVarsAndMatrixForRunsOn(t *testing.T) {
 	workflow := []byte(`on: push
 jobs:
   test:
+    name: test-${{ matrix.os }}
     strategy:
       matrix: ${{ fromJSON(vars.MATRIX) }}
     runs-on: ${{ matrix.os }}
@@ -144,6 +145,9 @@ jobs:
 	}
 	if len(ir.Jobs) != 3 || ir.Jobs[0].Queue != "event-linux" || ir.Jobs[1].Queue != "linux" || ir.Jobs[2].Queue != "linux" {
 		t.Fatalf("context-selected queues = %#v", ir.Jobs)
+	}
+	if ir.Jobs[1].Label != "test-ubuntu-22.04" || ir.Jobs[2].Label != "test-ubuntu-24.04" {
+		t.Fatalf("matrix-resolved labels = %q and %q", ir.Jobs[1].Label, ir.Jobs[2].Label)
 	}
 }
 

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -238,7 +238,7 @@ func (resolver *reusableResolver) resolve(path, digest string, parsed *workflow.
 				callLabel = job.ID
 			}
 			if len(matrix) != 0 {
-				callLabel = instanceLabel(job, matrix)
+				callLabel = instanceLabel(job, matrix, expression.CompileContext{})
 			}
 			if labelPrefix != "" {
 				callLabel = labelPrefix + " / " + callLabel


### PR DESCRIPTION
## Summary

- evaluate explicit workflow job names against each concrete matrix row before emitting Buildkite labels
- avoid appending redundant matrix metadata when the explicit name already depends on matrix values
- preserve the existing matrix suffix for static or non-matrix-dependent names

This was found by running the merged workflow UX from source in the examples pipeline: the advanced jobs appeared as `Verify payload (${{ matrix.variant }}) (variant=primary)`. They now appear as `Verify payload (primary)` and `Verify payload (secondary)`.

## Validation

- `mise run check`
- source-built advanced example: https://buildkite.com/buildkite/buildkite-gha-examples/builds/9
