### PR TITLE
Use released GitHub Actions plugin v0.2.2

### DIFF
--- a/.buildkite/examples.yml
+++ b/.buildkite/examples.yml
@@ -69,6 +69,6 @@ steps:
                 automatic: false
               cache: "/cache/bkcache/github-actions-buildkite-plugin"
               plugins:
-                - github-actions#v0.2.1:
+                - github-actions#v0.2.2:
                     workflow: "$$workflow"
       YAML

--- a/.buildkite/plugin-demo.yml
+++ b/.buildkite/plugin-demo.yml
@@ -8,7 +8,7 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#v0.2.1:
+      - github-actions#v0.2.2:
           workflow: .github/workflows/example-basic.yml
 
   - label: ":package: Artifact released-plugin demo"
@@ -17,7 +17,7 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#v0.2.1:
+      - github-actions#v0.2.2:
           workflow: .github/workflows/example-artifacts.yml
 
   - label: ":javascript: Actions released-plugin demo"
@@ -26,7 +26,7 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#v0.2.1:
+      - github-actions#v0.2.2:
           workflow: .github/workflows/phase-4-actions-oracle.yml
 
   - label: ":rocket: Advanced released-plugin demo"
@@ -35,7 +35,7 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#v0.2.1:
+      - github-actions#v0.2.2:
           workflow: .github/workflows/example-advanced.yml
 
   - label: ":white_check_mark: Service-free plugin demo complete"
@@ -54,7 +54,7 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#v0.2.1:
+      - github-actions#v0.2.2:
           workflow: testdata/poc/.github/workflows/cache.yml
 
   - label: ":white_check_mark: Cache plugin demo complete"

--- a/.buildkite/upload-examples.sh
+++ b/.buildkite/upload-examples.sh
@@ -103,6 +103,6 @@ steps:
           automatic: false
         cache: "/cache/bkcache/github-actions-buildkite-plugin"
         plugins:
-          - github-actions#v0.2.1:
+          - github-actions#v0.2.2:
               workflow: "$workflow"
 YAML

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ steps:
   - label: ":github: Test"
     key: "gha-ci"
     plugins:
-      - github-actions#v0.2.1:
+      - github-actions#v0.2.2:
           workflow: .github/workflows/ci.yml
 ```
 
-The released plugin downloads and verifies `buildkite-gha` v0.2.1 by default,
+The released plugin downloads and verifies `buildkite-gha` v0.2.3 by default,
 derives the event context from the Buildkite build, and uploads the generated
 jobs to the fixed `hosted` queue. Pin a released plugin version rather than a
 floating branch.
@@ -49,7 +49,7 @@ steps:
   - label: ":github: Test"
     key: "gha-ci"
     plugins:
-      - github-actions#v0.2.1:
+      - github-actions#v0.2.2:
           workflow: .github/workflows/ci.yml
 
   - label: ":rocket: Deploy"

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -532,7 +532,7 @@ func TestExamplesPipelineSelectsOneCanonicalWorkflow(t *testing.T) {
 		`group: ":github: Run workflow"`,
 		`label: "Prepare workflow"`,
 		`cache: "/cache/bkcache/github-actions-buildkite-plugin"`,
-		`github-actions#v0.2.1`,
+		`github-actions#v0.2.2`,
 	} {
 		if !strings.Contains(loader.Command, required) {
 			t.Fatalf("example loader lacks %q:\n%s", required, loader.Command)
@@ -660,7 +660,7 @@ func TestUploadExamplesScript(t *testing.T) {
 			`key: "example-basic-workflow"`,
 			`label: "Prepare workflow"`,
 			`key: "example-basic-importer"`,
-			`github-actions#v0.2.1`,
+			`github-actions#v0.2.2`,
 			`workflow: ".github/workflows/example-basic.yml"`,
 			`queue: "hosted"`,
 			`cache: "/cache/bkcache/github-actions-buildkite-plugin"`,
@@ -674,7 +674,7 @@ func TestUploadExamplesScript(t *testing.T) {
 				t.Fatalf("basic importer contains %q:\n%s", forbidden, pipeline)
 			}
 		}
-		if strings.Count(pipeline, "github-actions#v0.2.1") != 1 {
+		if strings.Count(pipeline, "github-actions#v0.2.2") != 1 {
 			t.Fatalf("basic importer does not contain exactly one plugin:\n%s", pipeline)
 		}
 	})
@@ -723,7 +723,7 @@ func TestProductionPluginDemoContract(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	const plugin = "github-actions#v0.2.1"
+	const plugin = "github-actions#v0.2.2"
 	type pluginConfig struct {
 		Workflow string `yaml:"workflow"`
 		Version  string `yaml:"version"`


### PR DESCRIPTION
## Summary

- update the examples and released-plugin demos to `github-actions#v0.2.2`
- document that this plugin release defaults to `buildkite-gha` v0.2.3
- update pipeline contract tests for the released version

This is the final version wiring after the CLI and plugin UX releases. The merged plugin commit was exercised in the examples pipeline before tagging:

- cold-cache run: https://buildkite.com/buildkite/buildkite-gha-examples/builds/10
- warm-cache run: https://buildkite.com/buildkite/buildkite-gha-examples/builds/11

## Validation

- `go test ./internal/buildkite`
- `shellcheck -x .buildkite/upload-examples.sh`
- `bash -n .buildkite/upload-examples.sh`
- `git diff --check`
