### PR TITLE
Add scoped private checkout support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ runtime. Buildkite remains the source of truth for scheduling, logs, retries,
 cancellation, and the build UI.
 
 > [!IMPORTANT]
-> This is an experimental v0.2 preview for **public, tokenless, Linux x86-64
-> workflows**. It deliberately rejects workflows that need private source,
-> secrets, provider tokens, or other protected capabilities.
+> This is an experimental v0.2 preview for **Linux x86-64 workflows**. The
+> default remains public and tokenless. Direct upload has an explicit,
+> fail-closed private-checkout preview for the pipeline's exact repository;
+> private actions and workflow-visible protected credentials remain rejected.
 
 ## Try an existing workflow
 
@@ -111,7 +112,8 @@ The plugin path currently supports:
 
 It does **not** currently support:
 
-- private repositories or private actions;
+- private actions or general private-source access; direct upload has only the
+  explicit pipeline-repository checkout described in the compatibility guide;
 - workflow secrets, `GITHUB_TOKEN`, GitHub-compatible OIDC, or protected queues;
 - `actions/cache` v4/v5 or unrecognized v6 commits, artifact
   merge/all/pattern/ID modes, or cross-run downloads;

--- a/docs/architecture/0003-protected-capability-control-plane.md
+++ b/docs/architecture/0003-protected-capability-control-plane.md
@@ -10,9 +10,9 @@ The service-free compatibility path can execute public, anonymous workflow code
 without giving it authority beyond its Buildkite job. Summaries, annotations,
 native artifact adapters, public exact-SHA checkout, and the audited
 `actions/cache` v6 client all use public Agent or explicitly configured
-cache-v2 interfaces. They do not establish authority for private source,
-secrets, provider tokens, environments, privileged queues, or compatible OIDC
-claims.
+cache-v2 interfaces. With one narrow exception described below, they do not
+establish authority for private source, secrets, provider tokens, environments,
+privileged queues, or compatible OIDC claims.
 
 A plan cannot authorize those protected values. Workflow and event files are
 compiler inputs, dynamic pipeline upload is ordinary pipeline authority, and
@@ -202,6 +202,59 @@ plan. Rotation overlaps old and new public keys for the maximum grant lifetime;
 emergency revocation takes precedence over a still-published key. Private keys
 remain in the platform signing boundary.
 
+### Narrow job-bound private-checkout exception
+
+Buildkite's Agent API can mint a GitHub installation token for the exact current
+job, exact pipeline repository, and caller-requested permission set. The server
+authenticates the request with the same job's Agent access token, independently
+requires the requested repository to equal the pipeline's configured GitHub
+repository, and validates permissions against its own allowlist. This supports
+one narrower integration without waiting for the general grant protocol:
+
+```http
+POST /v3/jobs/<current-job-id>/github_scoped_access_token
+Authorization: Token <current-job Agent access token>
+Content-Type: application/json
+```
+
+```json
+{
+  "repo_url": "https://github.com/<event owner>/<event repository>",
+  "permissions": {
+    "contents": "read"
+  }
+}
+```
+
+The uploader must opt in explicitly. The compiler adds
+`provider-token-read` only after resolving the exact `actions/checkout`
+adapter and validating its repository, ref, depth, path, submodule, and
+credential-persistence inputs. Fresh same-process compiler provenance permits
+that one capability through upload admission; the default `hosted-tokenless`
+profile continues to reject it.
+
+The runtime configures the endpoint only when the immutable plan contains that
+capability and a root checkout selector names the verified adapter. The event
+repository and exact SHA remain the only checkout targets, and the server's
+independent pipeline-repository comparison is the authoritative repository
+restriction. The client fixes `contents:read`; no workflow input can choose a
+repository, permission, or access level for minting.
+
+The returned token is masked before Agent redaction registration. Failure to
+register redaction aborts before Git fetch. A one-shot askpass helper reads the
+token from an inherited pipe and is present only for the fetch process. The
+token is not placed in arguments, the clone URL, Git config, plans, ordinary
+step environments, workflow contexts, results, outputs, state, summaries, or
+artifacts. Redirects, unknown response fields, trailing data, oversized bodies,
+invalid tokens, disabled service responses, and unavailable/rate-limited
+responses fail closed with bounded diagnostics.
+
+This exception does not establish authenticated provider event or fork
+provenance and therefore does not authorize writes, arbitrary workflow
+`permissions:`, private actions or reusable workflows, `GITHUB_TOKEN`,
+`github.token`, secrets, environments, or OIDC. Those features still require
+the general control-plane decision in this ADR.
+
 ### Runtime verification and capability use
 
 The runtime treats the response as inert bytes until all of these checks pass:
@@ -260,21 +313,29 @@ record; a successful job alone does not prove policy or audit behavior.
 
 ## Deferred decisions
 
-This ADR does not authorize or choose storage for private checkout, private
-actions, reusable workflow source, selected secrets, `GITHUB_TOKEN`, environment
-grants, or compatibility OIDC claims. It does not choose a secret manager,
-GitHub App permission set, customer policy language, administrative UI, or
-production service hostname. Those decisions require separate reviewed slices
-after the no-op boundary is proven.
+Apart from the fixed read-only pipeline-repository checkout exception, this ADR
+does not authorize or choose storage for private actions, reusable workflow
+source, selected secrets, `GITHUB_TOKEN`, environment grants, or compatibility
+OIDC claims. It does not choose a secret manager, general GitHub App permission
+set, customer policy language, administrative UI, or production service
+hostname. Those decisions require separate reviewed slices after the no-op
+boundary is proven.
 
 The existing cache-v2 GHAC token exchange remains separate. Cache tokens are
 minted through the current Buildkite job, scoped by the cache service, and
 exposed only to the audited cache action lifecycle. A capability grant neither
 contains nor replaces them.
 
+The job-bound private-checkout exchange is likewise separate. Its server-side
+pipeline-repository binding and client-fixed `contents:read` permission are not
+a substitute for the event, policy, signing, and audit contract required by a
+general capability grant.
+
 ## Consequences
 
 - Public tokenless workflows retain no new service dependency.
+- Explicit private checkout can use the pipeline's own repository without
+  exposing a reusable workflow credential or broadening the default profile.
 - The first protected-path milestone can prove the security boundary without
   risking a real credential.
 - Provider provenance and policy must exist in a Buildkite-owned service before

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -7,10 +7,13 @@ promises unless they appear here.
 
 ## The current execution profile
 
-The plugin and `upload` command use one fixed profile: `hosted-tokenless`.
-It is designed for public code that can run without protected credentials on a
-Linux x86-64 Buildkite Hosted Agent. Unsupported or privileged requests fail
-before the generated jobs are uploaded.
+The plugin and `upload` command default to one fixed profile:
+`hosted-tokenless`. It is designed for public code that can run without
+protected credentials on a Linux x86-64 Buildkite Hosted Agent. Unsupported or
+privileged requests fail before the generated jobs are uploaded. An explicit
+`upload --private-checkout` extension admits only the verified checkout adapter
+and only when the organization has enabled Buildkite's job-bound GitHub scoped
+access-token service.
 
 There are three different compatibility claims:
 
@@ -40,7 +43,7 @@ provide.
 | JavaScript actions | Supported | Managed, digest-verified Node 20 and 24 runtimes are used. |
 | Composite and local actions | Supported | Nested composites and global pre/main/post ordering are supported. |
 | Anonymous public actions | Supported | Sources are resolved to immutable commits and complete trees are verified. |
-| `actions/checkout` | Narrow support | Public `github.com` event repository, exact event SHA, workspace root, shallow credential-free fetch. |
+| `actions/checkout` | Narrow support | Public `github.com` event repository, exact event SHA, workspace root, and shallow credential-free fetch by default. Explicit private-checkout upload can authenticate that same fetch with fixed `contents:read` authority for the pipeline repository. |
 | Dockerfile actions | Supported subset | Only compiler-verified local or anonymous public Dockerfile actions are admitted. |
 | Step summaries | Supported | Published as job-scoped Buildkite annotations with a stable context. Requires Buildkite Agent v3.112 or newer. Oversized per-step summaries are skipped without failing the job; aggregate job summaries are bounded to 1 MiB. |
 | Workflow commands | Supported subset | `::add-mask`, `::stop-commands`, `::warning`, `::error`, `::group`, and `::endgroup` are supported. Groups become collapsed Buildkite log sections; because Buildkite sections are linear, nested or overlapping Actions groups flatten into successive sections. Warnings and errors retain title/file/range metadata and publish under separate, stable job-scoped contexts without changing step or job conclusions. Each aggregate is bounded to 1 MiB and requires Buildkite Agent v3.112 or newer for publication. Debug and matcher presentation commands are consumed without runner debug or matcher behavior. `::notice`, command echo control, and other legacy commands are not supported. |
@@ -50,8 +53,8 @@ provide.
 | Job and service containers | Not admitted | Implemented and runtime-proven, but still outside production `hosted-tokenless` policy. |
 | `docker://` actions | Not supported | Private images, credentials, arbitrary options, volumes, and privileged containers are also rejected. |
 | Other cache clients and broad artifact modes | Not supported | `actions/cache` v4/v5 and unrecognized v6 commits, artifact merge, IDs, patterns, all-artifact, cross-repository, and cross-run modes fail admission or input validation. |
-| Private repositories or actions | Not supported | The preview has no private-source capability broker. |
-| Secrets and provider tokens | Not supported | Includes `GITHUB_TOKEN`, GitHub App tokens, and protected environment grants. |
+| Private repositories or actions | Narrow checkout only | The direct uploader can opt into private checkout of the pipeline's exact GitHub repository. Private actions, alternate repositories, and reusable-workflow source remain unsupported. |
+| Secrets and provider tokens | Not exposed | `GITHUB_TOKEN`, `github.token`, GitHub App tokens for workflow use, protected secrets, and environment grants remain unsupported. The private-checkout credential is runtime-internal and available only to Git. |
 | OIDC | Not supported | GitHub-compatible and migration OIDC flows are deferred. |
 | Windows and macOS | Not supported | Unmapped runner labels fail validation. |
 
@@ -121,9 +124,24 @@ semantics when Buildkite has not supplied them.
 
 Generated jobs skip Buildkite's default checkout and allocate a fresh Actions
 workspace. A supported `actions/checkout` step performs a credential-free,
-shallow checkout of the public event repository at the exact event SHA. Private
-checkout, alternate repositories or refs, and credential persistence are not
-available in the preview.
+shallow checkout of the public event repository at the exact event SHA by
+default.
+
+With explicit installer configuration, direct upload may add
+`--private-checkout`. Compilation then adds `provider-token-read` only to a job
+containing the compiler-verified checkout adapter with its bounded inputs. At
+runtime, the CLI requests fixed `contents:read` authority from Buildkite's
+current-job Agent endpoint for `https://github.com/<event repository>`. The
+service independently requires that repository to be the pipeline's exact
+GitHub repository. The credential is registered with both runtime and Agent
+redaction before use, supplied to only the Git fetch through a one-shot askpass
+pipe, and never placed in the clone URL, arguments, Git config, plan, workflow
+environment, result, output, state, summary, or artifact.
+
+The option fails closed when scoped token minting is unavailable or disabled.
+It does not populate `GITHUB_TOKEN` or `github.token`, accept workflow-selected
+permissions, support write access, or enable private actions. Alternate
+repositories or refs and credential persistence remain unsupported.
 
 ### Artifact uploads use bounded native storage
 
@@ -330,10 +348,19 @@ not a complete execution path.
 buildkite-gha upload --runtime-queue hosted .github/workflows/ci.yml
 ```
 
+An installer may explicitly enable pipeline-repository private checkout:
+
+```sh
+buildkite-gha upload --private-checkout --runtime-queue hosted \
+  .github/workflows/ci.yml
+```
+
 It requires `BUILDKITE=true` and `BUILDKITE_STEP_KEY`. Without `--event-path`,
 it derives a bounded compatibility snapshot from the current Buildkite build.
 With `--event-path`, it uses that explicit snapshot. Both paths remain
-unattested and tokenless.
+unattested. They remain tokenless unless `--private-checkout` is explicitly
+selected; that exception is confined to the checkout adapter and independently
+repository-bound by the Agent service.
 
 The command uploads the exact executable and content-addressed plans before
 calling `buildkite-agent pipeline upload --no-interpolation --reject-secrets`.

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -1893,7 +1893,9 @@ the narrowest available boundary:
 - cache restore/save through the stock audited cache-v2 client, a compatible
   Results service, and short-lived job-bound GHAC credentials;
 - artifact upload/download through bounded native adapters;
-- public checkout under GitHub and Cursor Origin provider adapters; and
+- public checkout under GitHub and Cursor Origin provider adapters;
+- explicitly enabled private checkout of the pipeline's exact GitHub
+  repository through the current job's scoped Agent token endpoint; and
 - step summaries and annotations.
 
 Prefer documented Buildkite storage and Agent interfaces. If an action toolkit
@@ -1925,20 +1927,27 @@ Delivery slices:
    all Agent authority outside action code.
 3. Prove Job OIDC authentication, build/job binding, GitHub provenance checks,
    policy evaluation, and signed no-op grants before returning credentials.
-4. Add private checkout, private actions, and private reusable-workflow source
-   access through the narrowest practical credential or download interface.
+4. Add private source through the narrowest practical credential or download
+   interface. The first sub-slice is fixed `contents:read` checkout of the
+   pipeline's exact repository through the current job's scoped Agent endpoint;
+   private actions and private reusable-workflow source remain separate work.
 5. Add scoped GitHub tokens, selected secrets, and environment grants.
 6. Prefer direct Buildkite OIDC migration, then add only explicitly supported
    compatibility-issuer claims for providers that cannot consume it directly.
 
 Status: the GitHub/tokenless portion of slice 1 and all of slice 2 are
-implemented and hosted-proven. Cursor Origin public checkout remains pending on
-its provider context/source contract. Slice 3 is next; its proposed
+implemented and hosted-proven. The narrow CLI/runtime portion of slice 4 now
+supports explicitly enabled, read-only checkout of the pipeline's exact GitHub
+repository. Its local request, admission, redaction, askpass, and leakage
+boundaries are tested; hosted proof remains pending endpoint deployment,
+organization enablement, installer wiring, and a private-repository canary.
+Private actions and reusable workflows remain deferred. Cursor Origin public
+checkout remains pending on its provider context/source contract. Slice 3's
+proposed
 [control-plane contract](../architecture/0003-protected-capability-control-plane.md)
 must establish ownership, exact OIDC audience, independent GitHub provenance,
 policy, signing, and audit boundaries before any protected value is returned.
-Slices 4–6 remain long-term Phase 6 scope but are explicitly deferred from the
-initial beta.
+The remainder of slices 4–6 remains long-term Phase 6 scope.
 
 Definition of done:
 
@@ -2236,8 +2245,10 @@ The project is not globally blocked on the protected-capability control plane.
 The public, tokenless product path is substantial enough to harden and demo
 while the signed no-op grant proof waits for a named platform owner and the
 interfaces required by [ADR 0003](../architecture/0003-protected-capability-control-plane.md).
-Private source, secrets, provider tokens, environments, and compatible OIDC
-remain fail-closed during that work.
+Private actions and reusable workflows, workflow-visible provider tokens,
+secrets, environments, and compatible OIDC remain fail-closed during that work.
+The explicit private-checkout exception is limited to fixed read-only Git use
+for the pipeline repository and does not relax those deferrals.
 
 The complete published installation experience is now proven. The initial CLI
 and companion plugin `v0.2.0` releases remain the subject of the repository's
@@ -2505,8 +2516,9 @@ them in the phase that first needs the capability:
    queue policy for protected Docker capabilities and privileged workloads.
 6. Phase 6 will define the GitHub App installation-token compatibility contract
    for `github.token` and `GITHUB_TOKEN`, including repository/permission
-   narrowing and documented differences from native Actions tokens. Tokenless
-   workflows remain the default until then.
+   narrowing and documented differences from native Actions tokens. The
+   runtime-internal `contents:read` checkout credential does not define that
+   workflow-visible contract; tokenless workflows remain the default.
 
 ## Recommended first product milestone
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -47,7 +47,7 @@ const managedMiseVersion = "2026.5.12"
 var commandUsage = map[string]string{
 	"validate": "Usage: buildkite-gha validate [--event-path <path>] [--profile hosted-tokenless] [--format text|json] <workflow>\n",
 	"compile":  "Usage: buildkite-gha compile --event-path <path> [--format pipeline|ir-json] <workflow>\n",
-	"upload":   "Usage: buildkite-gha upload [--event-path <path>] --runtime-queue hosted <workflow>\n",
+	"upload":   "Usage: buildkite-gha upload [--event-path <path>] [--private-checkout] --runtime-queue hosted <workflow>\n",
 	"run-job":  "Usage: buildkite-gha run-job --plan <path> [--result <path>]\n",
 }
 
@@ -94,7 +94,7 @@ func run(args []string, stdout, stderr io.Writer, version string, agentRunner tr
 					_, _ = fmt.Fprint(stdout, "\nThe hosted-tokenless profile resolves actions and applies production upload policy without executing jobs or proving arbitrary action runtime compatibility.\n")
 				}
 				if args[0] == "upload" {
-					_, _ = fmt.Fprint(stdout, "\nThis unsigned, unprivileged path accepts an explicit event file or derives compatibility data from Buildkite; neither grants protected authority.\n")
+					_, _ = fmt.Fprint(stdout, "\nThe default path accepts an explicit event file or derives compatibility data from Buildkite and remains unsigned and unprivileged. --private-checkout opts only verified checkout jobs into current-job, read-only pipeline-repository authority.\n")
 				}
 				return 0
 			}
@@ -139,7 +139,7 @@ func help(args []string, stdout, stderr io.Writer) int {
 		_, _ = fmt.Fprint(stdout, "\nPipeline output references content-addressed plans; compile does not materialize or upload those artifacts.\n")
 	}
 	if args[0] == "upload" {
-		_, _ = fmt.Fprint(stdout, "\nThis unsigned, unprivileged path accepts an explicit event file or derives compatibility data from Buildkite; neither grants protected authority.\n")
+		_, _ = fmt.Fprint(stdout, "\nThe default path accepts an explicit event file or derives compatibility data from Buildkite and remains unsigned and unprivileged. --private-checkout opts only verified checkout jobs into current-job, read-only pipeline-repository authority.\n")
 	}
 	return 0
 }
@@ -227,6 +227,18 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 			return 1
 		}
 	}
+	var checkoutTokens gharuntime.CheckoutTokenProvider
+	if job.HasCapability("provider-token-read") {
+		checkoutTokens, err = gharuntime.NewAgentGitHubTokens(gharuntime.AgentGitHubTokenConfig{
+			Endpoint: os.Getenv("BUILDKITE_AGENT_ENDPOINT"),
+			JobID:    os.Getenv("BUILDKITE_JOB_ID"),
+			JobToken: os.Getenv("BUILDKITE_AGENT_ACCESS_TOKEN"),
+		})
+		if err != nil {
+			_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: configure private checkout token service: %v\n", err)
+			return 1
+		}
+	}
 	runner := gharuntime.Runner{
 		Stdout:      stdout,
 		Stderr:      stderr,
@@ -238,6 +250,7 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 		Actions:     actionMaterializer,
 		Artifacts:   agent,
 		Cache:       cacheCredentials,
+		Checkout:    checkoutTokens,
 	}
 	runner.RuntimeExecutable, err = os.Executable()
 	if err != nil {
@@ -480,7 +493,7 @@ func validate(args []string, stdout, stderr io.Writer, version string) int {
 		}
 		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 		defer stop()
-		preflight, profileErr := compileHostedTokenless(ctx, workflowPath, source, event, version, distributionDigest, "buildkite-gha-profile-importer", "", false)
+		preflight, profileErr := compileHostedTokenless(ctx, workflowPath, source, event, version, distributionDigest, "buildkite-gha-profile-importer", "", false, false)
 		if profileErr != nil {
 			if ctx.Err() != nil || errors.Is(profileErr, context.Canceled) {
 				_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: profile evaluation interrupted: %v\n", profileErr)
@@ -597,7 +610,7 @@ func compile(args []string, stdout, stderr io.Writer, version string) int {
 }
 
 func upload(args []string, stdout, stderr io.Writer, version string, agent transport.Agent) int {
-	workflowPath, eventPath, _, err := uploadArgs(args)
+	workflowPath, eventPath, _, privateCheckout, err := uploadArgs(args)
 	if err != nil {
 		return usageError(stderr, "upload: %v", err)
 	}
@@ -627,7 +640,7 @@ func upload(args []string, stdout, stderr io.Writer, version string, agent trans
 	}
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
-	preflight, err := compileHostedTokenless(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, os.Getenv("BUILDKITE_GROUP_LABEL"), true)
+	preflight, err := compileHostedTokenless(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, os.Getenv("BUILDKITE_GROUP_LABEL"), true, privateCheckout)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
 		return 1
@@ -687,7 +700,7 @@ func hostedTokenlessError(kind hostedTokenlessFailureKind, err error) error {
 	return &hostedTokenlessFailure{Kind: kind, Err: err}
 }
 
-func compileHostedTokenless(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, transportMise bool) (hostedTokenlessCompilation, error) {
+func compileHostedTokenless(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, transportMise, privateCheckout bool) (hostedTokenlessCompilation, error) {
 	preflight, err := compiler.Compile(workflowPath, workflowSource, eventSource)
 	if err != nil {
 		return hostedTokenlessCompilation{}, hostedTokenlessError(hostedTokenlessEvaluationFailure, err)
@@ -698,8 +711,9 @@ func compileHostedTokenless(ctx context.Context, workflowPath string, workflowSo
 	}
 	hasActions := irUsesActions(ir)
 	options := compiler.Options{
-		EventTrust: compiler.EventUntrusted,
-		GroupLabel: groupLabel,
+		EventTrust:     compiler.EventUntrusted,
+		GroupLabel:     groupLabel,
+		ResolveActions: privateCheckout,
 		Runners: compiler.RunnerPolicy{
 			Labels: map[string]string{
 				"ubuntu-latest": unprivilegedRuntimeQueue,
@@ -708,6 +722,7 @@ func compileHostedTokenless(ctx context.Context, workflowPath string, workflowSo
 			},
 			UntrustedQueues: []string{unprivilegedRuntimeQueue},
 		},
+		PrivateCheckout: privateCheckout,
 	}
 	if hasActions {
 		actionRoot, err := os.MkdirTemp("", "buildkite-gha-action-source-")
@@ -740,7 +755,7 @@ func compileHostedTokenless(ctx context.Context, workflowPath string, workflowSo
 	if err != nil {
 		return hostedTokenlessCompilation{}, hostedTokenlessError(hostedTokenlessEvaluationFailure, err)
 	}
-	if err := validateUnprivilegedBundle(bundle); err != nil {
+	if err := validateUnprivilegedBundleWithPrivateCheckout(bundle, privateCheckout); err != nil {
 		return hostedTokenlessCompilation{}, hostedTokenlessError(hostedTokenlessAdmissionFailure, err)
 	}
 	if !hasActions && bundleUsesActions(bundle) {
@@ -750,6 +765,10 @@ func compileHostedTokenless(ctx context.Context, workflowPath string, workflowSo
 }
 
 func validateUnprivilegedBundle(bundle compiler.Bundle) error {
+	return validateUnprivilegedBundleWithPrivateCheckout(bundle, false)
+}
+
+func validateUnprivilegedBundleWithPrivateCheckout(bundle compiler.Bundle, privateCheckout bool) error {
 	for _, artifact := range bundle.Plans {
 		for _, capability := range artifact.Job.RequiredCapabilities {
 			if capability == "docker" && !slices.Equal(artifact.Authorization.DockerCapabilitySources, []string{"dockerfile-actions"}) {
@@ -757,6 +776,12 @@ func validateUnprivilegedBundle(bundle compiler.Bundle) error {
 					return fmt.Errorf("job %q uses job or service containers, which hosted-tokenless upload does not admit", artifact.Job.Workflow.LogicalJobID)
 				}
 				return fmt.Errorf("job %q requires docker without compiler-verified Dockerfile action provenance", artifact.Job.Workflow.LogicalJobID)
+			}
+			if capability == "provider-token-read" {
+				if !privateCheckout || !slices.Equal(artifact.Authorization.ProviderTokenReadCapabilitySources, []string{"checkout-adapter"}) {
+					return fmt.Errorf("job %q requires provider-token-read without compiler-verified private checkout provenance", artifact.Job.Workflow.LogicalJobID)
+				}
+				continue
 			}
 			if capability != "network" && capability != "docker" {
 				return fmt.Errorf("job %q requires capability %q, unavailable to unprivileged upload", artifact.Job.Workflow.LogicalJobID, capability)
@@ -873,35 +898,44 @@ func deterministicGzip(source []byte) ([]byte, error) {
 	return out.Bytes(), nil
 }
 
-func uploadArgs(args []string) (workflowPath, eventPath, runtimeQueue string, err error) {
+func uploadArgs(args []string) (workflowPath, eventPath, runtimeQueue string, privateCheckout bool, err error) {
 	filtered := make([]string, 0, len(args))
 	runtimeQueueSeen := false
+	privateCheckoutSeen := false
 	for i := 0; i < len(args); i++ {
+		if args[i] == "--private-checkout" {
+			if privateCheckoutSeen {
+				return "", "", "", false, fmt.Errorf("--private-checkout may only be specified once")
+			}
+			privateCheckoutSeen = true
+			privateCheckout = true
+			continue
+		}
 		if args[i] != "--runtime-queue" {
 			filtered = append(filtered, args[i])
 			continue
 		}
 		if runtimeQueueSeen {
-			return "", "", "", fmt.Errorf("--runtime-queue may only be specified once")
+			return "", "", "", false, fmt.Errorf("--runtime-queue may only be specified once")
 		}
 		runtimeQueueSeen = true
 		i++
 		if i == len(args) {
-			return "", "", "", fmt.Errorf("--runtime-queue requires a queue")
+			return "", "", "", false, fmt.Errorf("--runtime-queue requires a queue")
 		}
 		runtimeQueue = args[i]
 	}
 	workflowPath, eventPath, err = workflowArgs(filtered)
 	if err != nil {
-		return "", "", "", err
+		return "", "", "", false, err
 	}
 	if !runtimeQueueSeen {
-		return "", "", "", fmt.Errorf("--runtime-queue %s is required for unprivileged upload", unprivilegedRuntimeQueue)
+		return "", "", "", false, fmt.Errorf("--runtime-queue %s is required for unprivileged upload", unprivilegedRuntimeQueue)
 	}
 	if runtimeQueue != unprivilegedRuntimeQueue {
-		return "", "", "", fmt.Errorf("--runtime-queue must be %q for unprivileged upload", unprivilegedRuntimeQueue)
+		return "", "", "", false, fmt.Errorf("--runtime-queue must be %q for unprivileged upload", unprivilegedRuntimeQueue)
 	}
-	return workflowPath, eventPath, runtimeQueue, err
+	return workflowPath, eventPath, runtimeQueue, privateCheckout, err
 }
 
 func compileArgs(args []string) (workflowPath, eventPath, format string, err error) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -679,6 +679,35 @@ func TestUnprivilegedUploadRejectsCapabilities(t *testing.T) {
 	}
 }
 
+func TestUnprivilegedUploadAdmitsOnlyCompilerVerifiedPrivateCheckout(t *testing.T) {
+	job := plan.Job{
+		Workflow:             plan.Workflow{LogicalJobID: "private-checkout"},
+		RequiredCapabilities: []string{"network", "provider-token-read"},
+	}
+	for _, test := range []struct {
+		name          string
+		enabled       bool
+		authorization compiler.PlanAuthorization
+		wantError     bool
+	}{
+		{name: "explicit verified adapter", enabled: true, authorization: compiler.PlanAuthorization{ProviderTokenReadCapabilitySources: []string{"checkout-adapter"}}},
+		{name: "default profile", authorization: compiler.PlanAuthorization{ProviderTokenReadCapabilitySources: []string{"checkout-adapter"}}, wantError: true},
+		{name: "missing provenance", enabled: true, wantError: true},
+		{name: "broadened provenance", enabled: true, authorization: compiler.PlanAuthorization{ProviderTokenReadCapabilitySources: []string{"checkout-adapter", "javascript-action"}}, wantError: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: job, Authorization: test.authorization}}}
+			err := validateUnprivilegedBundleWithPrivateCheckout(bundle, test.enabled)
+			if test.wantError && (err == nil || !strings.Contains(err.Error(), "private checkout provenance")) {
+				t.Fatalf("validateUnprivilegedBundle() error = %v", err)
+			}
+			if !test.wantError && err != nil {
+				t.Fatalf("validateUnprivilegedBundle() error = %v", err)
+			}
+		})
+	}
+}
+
 func TestUnprivilegedUploadAllowsPublicAndDockerfileActionCapabilities(t *testing.T) {
 	for _, capabilities := range [][]string{nil, {"network"}, {"docker"}, {"docker", "network"}} {
 		bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: plan.Job{
@@ -1427,14 +1456,21 @@ func TestArgumentParsersRejectRepeatedOptions(t *testing.T) {
 	if _, _, _, err := compileArgs([]string{"--format", "pipeline", "--format", "ir-json", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
 		t.Fatalf("compileArgs() error = %v, want duplicate format error", err)
 	}
-	if _, _, _, err := uploadArgs([]string{"--runtime-queue", "one", "--runtime-queue", "two", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
+	if _, _, _, _, err := uploadArgs([]string{"--runtime-queue", "one", "--runtime-queue", "two", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
 		t.Fatalf("uploadArgs() error = %v, want duplicate runtime queue error", err)
 	}
-	if _, _, _, err := uploadArgs([]string{"workflow.yml"}); err == nil || !strings.Contains(err.Error(), "is required") {
+	if _, _, _, _, err := uploadArgs([]string{"workflow.yml"}); err == nil || !strings.Contains(err.Error(), "is required") {
 		t.Fatalf("uploadArgs() error = %v, want required runtime queue error", err)
 	}
-	if _, _, _, err := uploadArgs([]string{"--runtime-queue", "custom-runners", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), `must be "hosted"`) {
+	if _, _, _, _, err := uploadArgs([]string{"--runtime-queue", "custom-runners", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), `must be "hosted"`) {
 		t.Fatalf("uploadArgs() error = %v, want fixed runtime queue error", err)
+	}
+	if _, _, _, _, err := uploadArgs([]string{"--private-checkout", "--private-checkout", "--runtime-queue", "hosted", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
+		t.Fatalf("uploadArgs() error = %v, want duplicate private checkout error", err)
+	}
+	workflow, event, queue, privateCheckout, err := uploadArgs([]string{"--private-checkout", "--runtime-queue", "hosted", "--event-path", "event.json", "workflow.yml"})
+	if err != nil || workflow != "workflow.yml" || event != "event.json" || queue != "hosted" || !privateCheckout {
+		t.Fatalf("uploadArgs() = %q, %q, %q, %v, %v", workflow, event, queue, privateCheckout, err)
 	}
 }
 

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -416,6 +416,61 @@ func TestTokenlessCheckoutAdapterInputBoundary(t *testing.T) {
 	}
 }
 
+func TestPrivateCheckoutCapabilityRequiresVerifiedRootAdapter(t *testing.T) {
+	workspace, remote := t.TempDir(), t.TempDir()
+	workflowPath := filepath.Join(workspace, ".github", "workflows", "checkout.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeAction(t, remote, "", "name: checkout\nruns:\n  using: node24\n  main: index.js\n")
+	compile := func(uses, with string, private bool) (Bundle, error) {
+		workflow := []byte("on: push\njobs:\n  checkout:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: " + uses + "\n" + with)
+		if err := os.WriteFile(workflowPath, workflow, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return CompileBundleWithOptions(workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, "importer", Options{
+			EventTrust: EventUntrusted,
+			Runners: RunnerPolicy{
+				Labels:          map[string]string{"ubuntu-latest": "hosted"},
+				UntrustedQueues: []string{"hosted"},
+			},
+			ResolveActions:  true,
+			ActionSource:    &fakeActionSource{root: remote, calls: map[string]int{}},
+			PrivateCheckout: private,
+		})
+	}
+
+	bundle, err := compile("actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1", "", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bundle.Plans) != 1 || !reflect.DeepEqual(bundle.Plans[0].Job.RequiredCapabilities, []string{"network", "provider-token-read"}) ||
+		!reflect.DeepEqual(bundle.Plans[0].Authorization.ProviderTokenReadCapabilitySources, []string{"checkout-adapter"}) {
+		t.Fatalf("private checkout plan = %#v", bundle.Plans)
+	}
+
+	bundle, err = compile("actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1", "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(bundle.Plans[0].Job.RequiredCapabilities, []string{"network"}) || len(bundle.Plans[0].Authorization.ProviderTokenReadCapabilitySources) != 0 {
+		t.Fatalf("default checkout authority changed = %#v", bundle.Plans[0])
+	}
+
+	bundle, err = compile("owner/action@v1", "", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(bundle.Plans[0].Job.RequiredCapabilities, []string{"network"}) || len(bundle.Plans[0].Authorization.ProviderTokenReadCapabilitySources) != 0 {
+		t.Fatalf("ordinary action received checkout authority = %#v", bundle.Plans[0])
+	}
+
+	_, err = compile("actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1", "        with:\n          token: '${{ github.token }}'\n", true)
+	if err == nil || !strings.Contains(err.Error(), "tokenless checkout adapter") || !strings.Contains(err.Error(), "Phase 6") {
+		t.Fatalf("workflow token input error = %v", err)
+	}
+}
+
 func TestUploadArtifactAdapterInputAndCommitBoundary(t *testing.T) {
 	workspace, remote := t.TempDir(), t.TempDir()
 	workflowPath := filepath.Join(workspace, ".github", "workflows", "artifact.yml")

--- a/internal/compiler/bundle.go
+++ b/internal/compiler/bundle.go
@@ -23,7 +23,8 @@ type PlanArtifact struct {
 // It is deliberately not part of the encoded plan: runtimes independently
 // enforce capabilities, while upload policy relies only on fresh compilation.
 type PlanAuthorization struct {
-	DockerCapabilitySources []string
+	DockerCapabilitySources            []string
+	ProviderTokenReadCapabilitySources []string
 }
 
 // Bundle is the complete deterministic output of static compilation.

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -298,6 +298,10 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 						span := instance.Steps[stepIndex].Span.Start
 						return nil, nil, fmt.Errorf("%s:%d:%d: tokenless checkout adapter: %w", instance.SourcePath, span.Line, span.Column, err)
 					}
+					if options.PrivateCheckout {
+						capabilities = append(capabilities, "provider-token-read")
+						authorization.ProviderTokenReadCapabilitySources = append(authorization.ProviderTokenReadCapabilitySources, "checkout-adapter")
+					}
 				}
 				if descriptor.Adapter == actionintegration.AdapterUploadArtifactBuildkite {
 					if err := actionintegration.ValidateUploadArtifactInputs(instance.Steps[stepIndex].With); err != nil {
@@ -318,7 +322,11 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 			}
 			jobSchema = plan.SchemaV3
 			actions = locks
-			capabilities = actionCapabilities
+			capabilities = append(append([]string{}, capabilities...), actionCapabilities...)
+			sort.Strings(capabilities)
+			capabilities = slices.Compact(capabilities)
+			sort.Strings(authorization.ProviderTokenReadCapabilitySources)
+			authorization.ProviderTokenReadCapabilitySources = slices.Compact(authorization.ProviderTokenReadCapabilitySources)
 			if slices.Contains(actionCapabilities, "docker") {
 				authorization.DockerCapabilitySources = append(authorization.DockerCapabilitySources, "dockerfile-actions")
 			}

--- a/internal/compiler/config.go
+++ b/internal/compiler/config.go
@@ -45,6 +45,10 @@ type Options struct {
 	// access. ActionSource is required only when a workflow uses remote actions.
 	ResolveActions bool
 	ActionSource   ActionSource
+	// PrivateCheckout adds provider-token-read only to compiler-verified
+	// actions/checkout adapter steps. It does not expose a workflow token or
+	// alter the permissions fixed by the runtime credential provider.
+	PrivateCheckout bool
 	// MiseDigest is runtime transport policy only. It is emitted into generated
 	// pipeline bootstrap commands and never changes compiler IR or plans.
 	MiseDigest  string
@@ -73,6 +77,9 @@ func (options Options) validate() error {
 	}
 	if !options.ResolveActions && options.ActionSource != nil {
 		return fmt.Errorf("action source configuration requires ResolveActions")
+	}
+	if options.PrivateCheckout && !options.ResolveActions {
+		return fmt.Errorf("private checkout requires ResolveActions")
 	}
 	if len(options.Runners.Labels) == 0 {
 		return fmt.Errorf("runner policy requires at least one label mapping")

--- a/internal/compiler/config_test.go
+++ b/internal/compiler/config_test.go
@@ -102,6 +102,14 @@ func TestUntrustedOptionsPermitAnonymousPublicActionSource(t *testing.T) {
 	}
 }
 
+func TestPrivateCheckoutRequiresActionResolution(t *testing.T) {
+	options := defaultOptions()
+	options.PrivateCheckout = true
+	if err := options.validate(); err == nil || !strings.Contains(err.Error(), "requires ResolveActions") {
+		t.Fatalf("Options.validate() error = %v", err)
+	}
+}
+
 func TestOptionsRejectActionConfigurationWithoutResolution(t *testing.T) {
 	options := defaultOptions()
 	options.ActionSource = &fakeActionSource{}

--- a/internal/runtime/actions.go
+++ b/internal/runtime/actions.go
@@ -60,6 +60,22 @@ func usesCheckoutAdapter(lock plan.ActionLock) bool {
 	return descriptor.Adapter == actionintegration.AdapterCheckoutExactEventSHA
 }
 
+func jobUsesCheckoutAdapter(job plan.Job) bool {
+	locks := make(map[string]plan.ActionLock, len(job.Actions))
+	for _, lock := range job.Actions {
+		locks[lock.ID] = lock
+	}
+	for _, step := range job.Steps {
+		if step.Action == nil {
+			continue
+		}
+		if lock, ok := locks[step.Action.Lock]; ok && usesCheckoutAdapter(lock) {
+			return true
+		}
+	}
+	return false
+}
+
 func usesUploadArtifactAdapter(lock plan.ActionLock) bool {
 	descriptor, _ := actionintegration.Lookup(actionintegration.Identity{Source: lock.Source, Repository: lock.Repository, Path: lock.Path})
 	return descriptor.Adapter == actionintegration.AdapterUploadArtifactBuildkite

--- a/internal/runtime/checkout.go
+++ b/internal/runtime/checkout.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -16,13 +17,26 @@ import (
 var checkoutRepositoryPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`)
 var checkoutSHAPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
 
+func validCheckoutRepository(repository string) bool {
+	if len(repository) > 140 || !checkoutRepositoryPattern.MatchString(repository) {
+		return false
+	}
+	parts := strings.Split(repository, "/")
+	return parts[0] != "." && parts[0] != ".." && parts[1] != "." && parts[1] != ".."
+}
+
 func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, inputs map[string]string) (Result, error) {
 	result := newResult()
-	if job.Event.Provider != "github" || !checkoutRepositoryPattern.MatchString(job.Event.Repository) || !checkoutSHAPattern.MatchString(job.Event.SHA) {
-		return result, fmt.Errorf("tokenless checkout adapter requires a valid github.com event repository and exact SHA; Phase 6 is required for other events")
+	private := job.HasCapability("provider-token-read")
+	adapter := "tokenless checkout adapter"
+	if private {
+		adapter = "private checkout adapter"
+	}
+	if job.Event.Provider != "github" || !validCheckoutRepository(job.Event.Repository) || !checkoutSHAPattern.MatchString(job.Event.SHA) {
+		return result, fmt.Errorf("%s requires a valid github.com event repository and exact SHA; Phase 6 is required for other events", adapter)
 	}
 	if err := actionintegration.ValidateCheckoutInputs(inputs, job.Event.Repository, job.Event.SHA); err != nil {
-		return result, fmt.Errorf("tokenless checkout adapter: %w", err)
+		return result, fmt.Errorf("%s: %w", adapter, err)
 	}
 	entries, err := os.ReadDir(workspace)
 	if err != nil {
@@ -47,24 +61,29 @@ func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, wo
 		"SSH_ASKPASS":         "",
 		"GIT_SSH_COMMAND":     "ssh -oBatchMode=yes",
 	}
-	run := func(args ...string) error {
-		base := []string{"-c", "credential.helper=", "-c", "http.extraheader=", "-c", "core.hooksPath=/dev/null"}
-		if err := r.runStreaming(ctx, processor, workspace, env, git, append(base, args...)...); err != nil {
-			return fmt.Errorf("tokenless checkout adapter git %s: %w", args[0], err)
+	base := []string{"-c", "credential.helper=", "-c", "http.extraheader=", "-c", "core.hooksPath=/dev/null"}
+	run := func(runEnv map[string]string, args ...string) error {
+		if err := r.runStreaming(ctx, processor, workspace, runEnv, git, append(base, args...)...); err != nil {
+			return fmt.Errorf("%s git %s: %w", adapter, args[0], err)
 		}
 		return nil
 	}
-	if err := run("init", "--template=", "."); err != nil {
+	if err := run(env, "init", "--template=", "."); err != nil {
 		return result, err
 	}
 	url := "https://github.com/" + job.Event.Repository + ".git"
-	if err := run("remote", "add", "origin", url); err != nil {
+	if err := run(env, "remote", "add", "origin", url); err != nil {
 		return result, err
 	}
-	if err := run("fetch", "--no-tags", "--no-recurse-submodules", "--depth=1", "origin", job.Event.SHA); err != nil {
+	fetchArgs := []string{"fetch", "--no-tags", "--no-recurse-submodules", "--depth=1", "origin", job.Event.SHA}
+	if private {
+		if err := r.runPrivateCheckoutFetch(ctx, processor, workspace, env, git, base, job.Event.Repository, fetchArgs); err != nil {
+			return result, fmt.Errorf("%s git fetch: %w", adapter, err)
+		}
+	} else if err := run(env, fetchArgs...); err != nil {
 		return result, err
 	}
-	if err := run("checkout", "--detach", job.Event.SHA); err != nil {
+	if err := run(env, "checkout", "--detach", job.Event.SHA); err != nil {
 		return result, err
 	}
 	head, err := os.ReadFile(filepath.Join(workspace, ".git", "HEAD"))
@@ -74,4 +93,64 @@ func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, wo
 	result.Outputs["ref"] = job.Event.Ref
 	result.Outputs["commit"] = job.Event.SHA
 	return result, nil
+}
+
+func (r Runner) runPrivateCheckoutFetch(ctx context.Context, processor *commandProcessor, workspace string, env map[string]string, git string, base []string, repository string, fetchArgs []string) error {
+	if r.Checkout == nil {
+		return fmt.Errorf("private checkout token provider is not configured")
+	}
+	token, err := r.Checkout.Token(ctx, repository)
+	if err != nil {
+		return err
+	}
+	if len(token) > 16<<10 || !githubInstallationTokenPattern.MatchString(token) {
+		return fmt.Errorf("private checkout token provider returned an invalid token")
+	}
+	if r.Redactor == nil {
+		return fmt.Errorf("private checkout token provider requires a redactor")
+	}
+	processor.addMask(token)
+	if err := r.Redactor.AddRedaction(ctx, token); err != nil {
+		return processor.scrubError(err)
+	}
+
+	helperDir, err := os.MkdirTemp("", "buildkite-gha-askpass-")
+	if err != nil {
+		return fmt.Errorf("create private checkout askpass directory: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(helperDir) }()
+	helper := filepath.Join(helperDir, "askpass")
+	const script = `#!/bin/sh
+case "$1" in
+  *sername*) printf '%s\n' x-access-token ;;
+  *assword*) cat <&3 ;;
+  *) exit 1 ;;
+esac
+`
+	if err := os.WriteFile(helper, []byte(script), 0o700); err != nil {
+		return fmt.Errorf("create private checkout askpass helper: %w", err)
+	}
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		return fmt.Errorf("create private checkout credential pipe: %w", err)
+	}
+	if _, err := io.WriteString(writer, token); err != nil {
+		_ = reader.Close()
+		_ = writer.Close()
+		return fmt.Errorf("write private checkout credential pipe: %w", err)
+	}
+	if err := writer.Close(); err != nil {
+		_ = reader.Close()
+		return fmt.Errorf("close private checkout credential pipe: %w", err)
+	}
+	defer func() { _ = reader.Close() }()
+
+	privateEnv := cloneStrings(env)
+	privateEnv["GIT_ASKPASS"] = helper
+	privateEnv["LC_ALL"] = "C"
+	cmd := exec.Command(git, append(base, fetchArgs...)...)
+	cmd.Dir = workspace
+	cmd.Env = processEnv(privateEnv)
+	cmd.ExtraFiles = []*os.File{reader}
+	return processor.scrubError(r.runStreamingCommand(ctx, processor, cmd))
 }

--- a/internal/runtime/checkout.go
+++ b/internal/runtime/checkout.go
@@ -25,6 +25,30 @@ func validCheckoutRepository(repository string) bool {
 	return parts[0] != "." && parts[0] != ".." && parts[1] != "." && parts[1] != ".."
 }
 
+func resolvePrivateCheckoutGit(configured string) (string, error) {
+	candidate := configured
+	if candidate == "" {
+		candidate = "git"
+	}
+	resolved, err := exec.LookPath(candidate)
+	if err != nil {
+		return "", fmt.Errorf("resolve private checkout Git before workflow execution: %w", err)
+	}
+	resolved, err = filepath.Abs(resolved)
+	if err != nil {
+		return "", fmt.Errorf("resolve private checkout Git absolute path before workflow execution: %w", err)
+	}
+	resolved, err = filepath.EvalSymlinks(resolved)
+	if err != nil {
+		return "", fmt.Errorf("canonicalize private checkout Git before workflow execution: %w", err)
+	}
+	info, err := os.Stat(resolved)
+	if err != nil || !info.Mode().IsRegular() || info.Mode().Perm()&0o111 == 0 {
+		return "", fmt.Errorf("private checkout requires a real executable Git resolved before workflow execution")
+	}
+	return resolved, nil
+}
+
 func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, inputs map[string]string) (Result, error) {
 	result := newResult()
 	private := job.HasCapability("provider-token-read")
@@ -46,7 +70,10 @@ func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, wo
 		return result, fmt.Errorf("tokenless checkout adapter requires an empty workspace; Phase 6 is required for clean behavior")
 	}
 	git := r.Git
-	if git == "" {
+	if private && (git == "" || !filepath.IsAbs(git)) {
+		return result, fmt.Errorf("private checkout adapter requires Git to be resolved before workflow execution")
+	}
+	if !private && git == "" {
 		git, err = exec.LookPath("git")
 	}
 	if err != nil {
@@ -123,7 +150,7 @@ func (r Runner) runPrivateCheckoutFetch(ctx context.Context, processor *commandP
 	const script = `#!/bin/sh
 case "$1" in
   *sername*) printf '%s\n' x-access-token ;;
-  *assword*) cat <&3 ;;
+  *assword*) IFS= read -r token <&3 || exit 1; printf '%s\n' "$token" ;;
   *) exit 1 ;;
 esac
 `
@@ -134,7 +161,7 @@ esac
 	if err != nil {
 		return fmt.Errorf("create private checkout credential pipe: %w", err)
 	}
-	if _, err := io.WriteString(writer, token); err != nil {
+	if _, err := io.WriteString(writer, token+"\n"); err != nil {
 		_ = reader.Close()
 		_ = writer.Close()
 		return fmt.Errorf("write private checkout credential pipe: %w", err)

--- a/internal/runtime/checkout.go
+++ b/internal/runtime/checkout.go
@@ -25,30 +25,6 @@ func validCheckoutRepository(repository string) bool {
 	return parts[0] != "." && parts[0] != ".." && parts[1] != "." && parts[1] != ".."
 }
 
-func resolvePrivateCheckoutGit(configured string) (string, error) {
-	candidate := configured
-	if candidate == "" {
-		candidate = "git"
-	}
-	resolved, err := exec.LookPath(candidate)
-	if err != nil {
-		return "", fmt.Errorf("resolve private checkout Git before workflow execution: %w", err)
-	}
-	resolved, err = filepath.Abs(resolved)
-	if err != nil {
-		return "", fmt.Errorf("resolve private checkout Git absolute path before workflow execution: %w", err)
-	}
-	resolved, err = filepath.EvalSymlinks(resolved)
-	if err != nil {
-		return "", fmt.Errorf("canonicalize private checkout Git before workflow execution: %w", err)
-	}
-	info, err := os.Stat(resolved)
-	if err != nil || !info.Mode().IsRegular() || info.Mode().Perm()&0o111 == 0 {
-		return "", fmt.Errorf("private checkout requires a real executable Git resolved before workflow execution")
-	}
-	return resolved, nil
-}
-
 func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, inputs map[string]string) (Result, error) {
 	result := newResult()
 	private := job.HasCapability("provider-token-read")
@@ -56,7 +32,11 @@ func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, wo
 	if private {
 		adapter = "private checkout adapter"
 	}
-	if job.Event.Provider != "github" || !validCheckoutRepository(job.Event.Repository) || !checkoutSHAPattern.MatchString(job.Event.SHA) {
+	validRepository := checkoutRepositoryPattern.MatchString(job.Event.Repository)
+	if private {
+		validRepository = validCheckoutRepository(job.Event.Repository)
+	}
+	if job.Event.Provider != "github" || !validRepository || !checkoutSHAPattern.MatchString(job.Event.SHA) {
 		return result, fmt.Errorf("%s requires a valid github.com event repository and exact SHA; Phase 6 is required for other events", adapter)
 	}
 	if err := actionintegration.ValidateCheckoutInputs(inputs, job.Event.Repository, job.Event.SHA); err != nil {

--- a/internal/runtime/checkout_test.go
+++ b/internal/runtime/checkout_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
@@ -14,6 +15,12 @@ import (
 	"github.com/buildkite/buildkite-gha/internal/action/source"
 	"github.com/buildkite/buildkite-gha/internal/plan"
 )
+
+type checkoutTokenProviderFunc func(context.Context, string) (string, error)
+
+func (f checkoutTokenProviderFunc) Token(ctx context.Context, repository string) (string, error) {
+	return f(ctx, repository)
+}
 
 func TestTokenlessCheckoutAdapterPopulatesVerifiedWorkspace(t *testing.T) {
 	workspace := t.TempDir()
@@ -159,6 +166,126 @@ func TestTokenlessCheckoutAdapterRejectsUnsupportedInputsAndState(t *testing.T) 
 	job.Event.Provider = "other"
 	if _, err := (Runner{}).runCheckout(context.Background(), processor, t.TempDir(), job, nil); err == nil || !strings.Contains(err.Error(), "valid github.com event") {
 		t.Fatalf("invalid event error = %v", err)
+	}
+}
+
+func TestPrivateCheckoutAdapterUsesOneShotAskpassCredential(t *testing.T) {
+	workspace := t.TempDir()
+	sha := strings.Repeat("a", 40)
+	token := "ghs_private_checkout_secret"
+	gitLog := filepath.Join(t.TempDir(), "git.log")
+	askpassLog := filepath.Join(t.TempDir(), "askpass.log")
+	git := filepath.Join(t.TempDir(), "git")
+	script := `#!/bin/sh
+set -eu
+case "$*" in *` + token + `*) exit 30 ;; esac
+operation=
+for argument in "$@"; do
+  case "$argument" in init|remote|fetch|checkout) operation="$argument"; break ;; esac
+done
+case "$operation" in
+  init)
+    test -z "$GIT_ASKPASS"
+    mkdir -p .git
+    ;;
+  remote)
+    test -z "$GIT_ASKPASS"
+    ;;
+  fetch)
+    test -n "$GIT_ASKPASS"
+    if env | grep -F ` + shellTestQuote(token) + ` >/dev/null; then exit 31; fi
+    printf '%s' "$GIT_ASKPASS" > ` + shellTestQuote(askpassLog) + `
+    test "$("$GIT_ASKPASS" 'Username for https://github.com')" = x-access-token
+    test "$("$GIT_ASKPASS" 'Password for https://github.com')" = ` + shellTestQuote(token) + `
+    test -z "$("$GIT_ASKPASS" 'Password for https://github.com')"
+    ;;
+  checkout)
+    test -z "$GIT_ASKPASS"
+    printf '%s\n' ` + shellTestQuote(sha) + ` > .git/HEAD
+    ;;
+esac
+printf '%s\n' "$*" >> ` + shellTestQuote(gitLog) + `
+`
+	if err := os.WriteFile(git, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	var repositories []string
+	provider := checkoutTokenProviderFunc(func(_ context.Context, repository string) (string, error) {
+		repositories = append(repositories, repository)
+		return token, nil
+	})
+	redactor := &testRedactor{}
+	var logs bytes.Buffer
+	processor := newCommandProcessor(&logs, &logs)
+	job := plan.Job{
+		Event:                plan.Event{Provider: "github", Repository: "buildkite/buildkite-gha", Ref: "refs/heads/main", SHA: sha},
+		RequiredCapabilities: []string{"network", "provider-token-read"},
+	}
+	result, err := (Runner{Git: git, Checkout: provider, Redactor: redactor, Stdout: &logs, Stderr: &logs}).runCheckout(context.Background(), processor, workspace, job, nil)
+	if err != nil {
+		t.Fatalf("runCheckout() error = %v, logs = %q", err, logs.String())
+	}
+	if result.Outputs["commit"] != sha || result.Outputs["ref"] != job.Event.Ref {
+		t.Fatalf("checkout outputs = %#v", result.Outputs)
+	}
+	if len(repositories) != 1 || repositories[0] != job.Event.Repository || len(redactor.values) != 1 || redactor.values[0] != token {
+		t.Fatalf("repositories/redactions = %#v / %#v", repositories, redactor.values)
+	}
+	gitBytes, err := os.ReadFile(gitLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(gitBytes), token) || strings.Contains(logs.String(), token) {
+		t.Fatalf("checkout exposed token in Git arguments or logs: %q / %q", gitBytes, logs.String())
+	}
+	helperBytes, err := os.ReadFile(askpassLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(string(helperBytes)); !os.IsNotExist(err) {
+		t.Fatalf("askpass helper survived checkout: %v", err)
+	}
+	configBytes, err := os.ReadFile(filepath.Join(workspace, ".git", "config"))
+	if err == nil && strings.Contains(string(configBytes), token) {
+		t.Fatalf("Git config contains checkout token: %q", configBytes)
+	}
+}
+
+func TestPrivateCheckoutRedactorFailureAbortsBeforeFetchAndScrubsToken(t *testing.T) {
+	token := "ghs_private_checkout_secret"
+	marker := filepath.Join(t.TempDir(), "fetch-ran")
+	git := filepath.Join(t.TempDir(), "git")
+	script := "#!/bin/sh\ncase \"$*\" in *fetch*) touch " + shellTestQuote(marker) + " ;; init*) mkdir -p .git ;; esac\n"
+	if err := os.WriteFile(git, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	job := plan.Job{
+		Event:                plan.Event{Provider: "github", Repository: "buildkite/buildkite-gha", SHA: strings.Repeat("a", 40)},
+		RequiredCapabilities: []string{"network", "provider-token-read"},
+	}
+	provider := checkoutTokenProviderFunc(func(context.Context, string) (string, error) { return token, nil })
+	err := error(nil)
+	_, err = (Runner{Git: git, Checkout: provider, Redactor: failingCacheRedactor{token: token}}).runCheckout(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), job, nil)
+	if err == nil || strings.Contains(err.Error(), token) || !strings.Contains(err.Error(), "***") {
+		t.Fatalf("runCheckout() error = %v", err)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("Git fetch ran before redactor registration succeeded: %v", err)
+	}
+}
+
+func TestProviderTokenReadRuntimeAuthorityIsCheckoutOnly(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/authority.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: authority\n")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "ordinary", Kind: "run", Command: "true"}})
+	job.RequiredCapabilities = []string{"provider-token-read"}
+	if _, err := (Runner{}).RunJob(context.Background(), job, workspace); err == nil || !strings.Contains(err.Error(), "requires the private checkout token provider") {
+		t.Fatalf("missing provider error = %v", err)
+	}
+	provider := checkoutTokenProviderFunc(func(context.Context, string) (string, error) { return "ghs_unused", nil })
+	if _, err := (Runner{Checkout: provider}).RunJob(context.Background(), job, workspace); err == nil || !strings.Contains(err.Error(), "restricted to the verified checkout adapter") {
+		t.Fatalf("ordinary provider-token-read error = %v", err)
 	}
 }
 

--- a/internal/runtime/checkout_test.go
+++ b/internal/runtime/checkout_test.go
@@ -251,6 +251,149 @@ printf '%s\n' "$*" >> ` + shellTestQuote(gitLog) + `
 	}
 }
 
+func TestPrivateCheckoutPinsGitBeforeActionPreHooks(t *testing.T) {
+	workspace := t.TempDir()
+	workflowSource := []byte("name: private checkout executable confinement\n")
+	sha := strings.Repeat("a", 40)
+	token := "ghs_private_checkout_secret"
+
+	trustedLog := filepath.Join(t.TempDir(), "trusted-git.log")
+	trustedDir := t.TempDir()
+	trustedGit := filepath.Join(trustedDir, "git")
+	trustedScript := `#!/bin/sh
+set -eu
+operation=
+for argument in "$@"; do
+  case "$argument" in init|remote|fetch|checkout) operation="$argument"; break ;; esac
+done
+case "$operation" in
+  init) mkdir -p .git ;;
+  fetch)
+    test "$("$GIT_ASKPASS" 'Username for https://github.com')" = x-access-token
+    test "$("$GIT_ASKPASS" 'Password for https://github.com')" = ` + shellTestQuote(token) + `
+    ;;
+  checkout)
+    printf '%s\n' ` + shellTestQuote(sha) + ` > .git/HEAD
+    mkdir -p .github/workflows
+    printf '%s' ` + shellTestQuote(base64.StdEncoding.EncodeToString(workflowSource)) + ` | base64 -d > .github/workflows/test.yml
+    ;;
+esac
+printf '%s\n' "$*" >> ` + shellTestQuote(trustedLog) + `
+`
+	if err := os.WriteFile(trustedGit, []byte(trustedScript), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	lookupDir := t.TempDir()
+	lookupGit := filepath.Join(lookupDir, "git")
+	if err := os.Symlink(trustedGit, lookupGit); err != nil {
+		t.Fatal(err)
+	}
+	poisonDir := t.TempDir()
+	poisonGitMarker := filepath.Join(t.TempDir(), "poison-git-ran")
+	poisonGit := filepath.Join(poisonDir, "git")
+	if err := os.WriteFile(poisonGit, []byte("#!/bin/sh\ntouch "+shellTestQuote(poisonGitMarker)+"\nexit 97\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	poisonCatMarker := filepath.Join(t.TempDir(), "poison-cat-ran")
+	poisonCat := filepath.Join(poisonDir, "cat")
+	if err := os.WriteFile(poisonCat, []byte("#!/bin/sh\ntouch "+shellTestQuote(poisonCatMarker)+"\nexit 98\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", lookupDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	remote := t.TempDir()
+	writeFixtureFile(t, remote, "action.yml", "name: checkout\nruns:\n  using: node24\n  main: dist/index.js\n")
+	writeFixtureFile(t, remote, "dist/index.js", "")
+	writeFixtureFile(t, remote, "poison/action.yml", "name: poison PATH\nruns:\n  using: node24\n  pre: pre.js\n  main: main.js\n")
+	writeFixtureFile(t, remote, "poison/pre.js", "")
+	writeFixtureFile(t, remote, "poison/main.js", "")
+	remoteDigest := digestTree(t, remote)
+
+	node := filepath.Join(t.TempDir(), "node24")
+	nodeScript := `#!/bin/sh
+set -eu
+if [ "${1:-}" = --version ]; then
+  echo v24.0.0
+  exit 0
+fi
+if [ "${1##*/}" = pre.js ]; then
+  rm -f "$LOOKUP_GIT"
+  ln -s "$POISON_GIT" "$LOOKUP_GIT"
+  ln -s "$POISON_CAT" "$LOOKUP_CAT"
+fi
+`
+	if err := os.WriteFile(node, []byte(nodeScript), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	workflowDigest := sha256.Sum256(workflowSource)
+	poisonID, checkoutID := "a-0000000000000001", "a-0000000000000002"
+	job := plan.Job{
+		Schema: plan.SchemaV3,
+		Compiler: plan.Compiler{
+			Version: "phase4-test", DistributionDigest: "sha256:" + strings.Repeat("2", 64),
+		},
+		Workflow: plan.Workflow{
+			Path: ".github/workflows/test.yml", Digest: "sha256:" + hex.EncodeToString(workflowDigest[:]), LogicalJobID: "checkout",
+		},
+		Event: plan.Event{
+			Provider: "github", Name: "push", PayloadDigest: "sha256:" + strings.Repeat("3", 64), Repository: "buildkite/buildkite-gha", Ref: "refs/heads/main", SHA: sha,
+		},
+		Target:               plan.Target{StepKey: "gha-checkout", Queue: "trusted"},
+		RequiredCapabilities: []string{"network", "provider-token-read"},
+		Env: map[string]string{
+			"LOOKUP_GIT": lookupGit,
+			"LOOKUP_CAT": filepath.Join(lookupDir, "cat"),
+			"POISON_CAT": poisonCat,
+			"POISON_GIT": poisonGit,
+		},
+		Steps: []plan.Step{
+			{ID: "poison", Kind: "uses", Uses: "owner/repo/poison@v1", Action: &plan.ActionSelector{Lock: poisonID}},
+			{ID: "checkout", Kind: "uses", Uses: "actions/checkout@v7", Action: &plan.ActionSelector{Lock: checkoutID}},
+		},
+		Actions: []plan.ActionLock{
+			{ID: poisonID, Source: "github", Repository: "owner/repo", RequestedRef: "v1", Commit: strings.Repeat("b", 40), Path: "poison", SourceDigest: remoteDigest},
+			{ID: checkoutID, Source: "github", Repository: "actions/checkout", RequestedRef: "v7", Commit: strings.Repeat("c", 40), SourceDigest: remoteDigest},
+		},
+	}
+	provider := checkoutTokenProviderFunc(func(context.Context, string) (string, error) { return token, nil })
+	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: remoteDigest}}
+	redactor := &testRedactor{}
+	var logs bytes.Buffer
+	result, err := (Runner{Node24: node, Checkout: provider, Redactor: redactor, Actions: materializer, Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v, logs = %q", result, err, logs.String())
+	}
+	if _, err := os.Stat(trustedLog); err != nil {
+		t.Fatalf("trusted Git did not run: %v", err)
+	}
+	if target, err := filepath.EvalSymlinks(lookupGit); err != nil || target != poisonGit {
+		t.Fatalf("pre-hook Git replacement = %q, %v; want %q", target, err, poisonGit)
+	}
+	if target, err := filepath.EvalSymlinks(filepath.Join(lookupDir, "cat")); err != nil || target != poisonCat {
+		t.Fatalf("pre-hook cat replacement = %q, %v; want %q", target, err, poisonCat)
+	}
+	for name, marker := range map[string]string{"Git selected through poisoned PATH": poisonGitMarker, "askpass reader selected through poisoned PATH": poisonCatMarker} {
+		if _, err := os.Stat(marker); !os.IsNotExist(err) {
+			t.Fatalf("%s: %v", name, err)
+		}
+	}
+	if strings.Contains(logs.String(), token) {
+		t.Fatalf("checkout exposed token in logs: %q", logs.String())
+	}
+}
+
+func TestPrivateCheckoutRequiresPreResolvedGit(t *testing.T) {
+	job := plan.Job{
+		Event:                plan.Event{Provider: "github", Repository: "buildkite/buildkite-gha", SHA: strings.Repeat("a", 40)},
+		RequiredCapabilities: []string{"provider-token-read"},
+	}
+	if _, err := (Runner{Git: "git"}).runCheckout(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), job, nil); err == nil || !strings.Contains(err.Error(), "resolved before workflow execution") {
+		t.Fatalf("runCheckout() unresolved Git error = %v", err)
+	}
+}
+
 func TestPrivateCheckoutRedactorFailureAbortsBeforeFetchAndScrubsToken(t *testing.T) {
 	token := "ghs_private_checkout_secret"
 	marker := filepath.Join(t.TempDir(), "fetch-ran")

--- a/internal/runtime/checkout_test.go
+++ b/internal/runtime/checkout_test.go
@@ -169,6 +169,22 @@ func TestTokenlessCheckoutAdapterRejectsUnsupportedInputsAndState(t *testing.T) 
 	}
 }
 
+func TestTokenlessCheckoutPreservesPublicRepositoryValidation(t *testing.T) {
+	workspace := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workspace, "occupied"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	job := plan.Job{Event: plan.Event{Provider: "github", Repository: "owner/..", SHA: strings.Repeat("a", 40)}}
+	processor := newCommandProcessor(io.Discard, io.Discard)
+	if _, err := (Runner{}).runCheckout(context.Background(), processor, workspace, job, nil); err == nil || !strings.Contains(err.Error(), "empty workspace") {
+		t.Fatalf("tokenless checkout repository validation error = %v", err)
+	}
+	job.RequiredCapabilities = []string{"provider-token-read"}
+	if _, err := (Runner{}).runCheckout(context.Background(), processor, workspace, job, nil); err == nil || !strings.Contains(err.Error(), "valid github.com event repository") {
+		t.Fatalf("private checkout repository validation error = %v", err)
+	}
+}
+
 func TestPrivateCheckoutAdapterUsesOneShotAskpassCredential(t *testing.T) {
 	workspace := t.TempDir()
 	sha := strings.Repeat("a", 40)
@@ -283,10 +299,20 @@ printf '%s\n' "$*" >> ` + shellTestQuote(trustedLog) + `
 	if err := os.WriteFile(trustedGit, []byte(trustedScript), 0o700); err != nil {
 		t.Fatal(err)
 	}
+	trustedAgentMarker := filepath.Join(t.TempDir(), "trusted-agent-ran")
+	trustedAgent := filepath.Join(trustedDir, "buildkite-agent")
+	trustedAgentScript := "#!/bin/sh\nIFS= read -r value\ntest \"$value\" = " + shellTestQuote(token) + "\n: > " + shellTestQuote(trustedAgentMarker) + "\n"
+	if err := os.WriteFile(trustedAgent, []byte(trustedAgentScript), 0o700); err != nil {
+		t.Fatal(err)
+	}
 
 	lookupDir := t.TempDir()
 	lookupGit := filepath.Join(lookupDir, "git")
 	if err := os.Symlink(trustedGit, lookupGit); err != nil {
+		t.Fatal(err)
+	}
+	lookupAgent := filepath.Join(lookupDir, "buildkite-agent")
+	if err := os.Symlink(trustedAgent, lookupAgent); err != nil {
 		t.Fatal(err)
 	}
 	poisonDir := t.TempDir()
@@ -298,6 +324,11 @@ printf '%s\n' "$*" >> ` + shellTestQuote(trustedLog) + `
 	poisonCatMarker := filepath.Join(t.TempDir(), "poison-cat-ran")
 	poisonCat := filepath.Join(poisonDir, "cat")
 	if err := os.WriteFile(poisonCat, []byte("#!/bin/sh\ntouch "+shellTestQuote(poisonCatMarker)+"\nexit 98\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	poisonAgentMarker := filepath.Join(t.TempDir(), "poison-agent-ran")
+	poisonAgent := filepath.Join(poisonDir, "buildkite-agent")
+	if err := os.WriteFile(poisonAgent, []byte("#!/bin/sh\n: > "+shellTestQuote(poisonAgentMarker)+"\nexit 99\n"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", lookupDir+string(os.PathListSeparator)+os.Getenv("PATH"))
@@ -321,6 +352,8 @@ if [ "${1##*/}" = pre.js ]; then
   rm -f "$LOOKUP_GIT"
   ln -s "$POISON_GIT" "$LOOKUP_GIT"
   ln -s "$POISON_CAT" "$LOOKUP_CAT"
+	  rm -f "$LOOKUP_AGENT"
+	  ln -s "$POISON_AGENT" "$LOOKUP_AGENT"
 fi
 `
 	if err := os.WriteFile(node, []byte(nodeScript), 0o700); err != nil {
@@ -343,10 +376,12 @@ fi
 		Target:               plan.Target{StepKey: "gha-checkout", Queue: "trusted"},
 		RequiredCapabilities: []string{"network", "provider-token-read"},
 		Env: map[string]string{
-			"LOOKUP_GIT": lookupGit,
-			"LOOKUP_CAT": filepath.Join(lookupDir, "cat"),
-			"POISON_CAT": poisonCat,
-			"POISON_GIT": poisonGit,
+			"LOOKUP_AGENT": lookupAgent,
+			"LOOKUP_GIT":   lookupGit,
+			"POISON_AGENT": poisonAgent,
+			"LOOKUP_CAT":   filepath.Join(lookupDir, "cat"),
+			"POISON_CAT":   poisonCat,
+			"POISON_GIT":   poisonGit,
 		},
 		Steps: []plan.Step{
 			{ID: "poison", Kind: "uses", Uses: "owner/repo/poison@v1", Action: &plan.ActionSelector{Lock: poisonID}},
@@ -359,9 +394,8 @@ fi
 	}
 	provider := checkoutTokenProviderFunc(func(context.Context, string) (string, error) { return token, nil })
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: remoteDigest}}
-	redactor := &testRedactor{}
 	var logs bytes.Buffer
-	result, err := (Runner{Node24: node, Checkout: provider, Redactor: redactor, Actions: materializer, Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node24: node, Checkout: provider, Redactor: AgentRedactor{}, Actions: materializer, Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v, logs = %q", result, err, logs.String())
 	}
@@ -374,7 +408,13 @@ fi
 	if target, err := filepath.EvalSymlinks(filepath.Join(lookupDir, "cat")); err != nil || target != poisonCat {
 		t.Fatalf("pre-hook cat replacement = %q, %v; want %q", target, err, poisonCat)
 	}
-	for name, marker := range map[string]string{"Git selected through poisoned PATH": poisonGitMarker, "askpass reader selected through poisoned PATH": poisonCatMarker} {
+	if target, err := filepath.EvalSymlinks(lookupAgent); err != nil || target != poisonAgent {
+		t.Fatalf("pre-hook Agent replacement = %q, %v; want %q", target, err, poisonAgent)
+	}
+	if _, err := os.Stat(trustedAgentMarker); err != nil {
+		t.Fatalf("trusted Agent redactor did not run: %v", err)
+	}
+	for name, marker := range map[string]string{"Git selected through poisoned PATH": poisonGitMarker, "askpass reader selected through poisoned PATH": poisonCatMarker, "Agent redactor selected through poisoned PATH": poisonAgentMarker} {
 		if _, err := os.Stat(marker); !os.IsNotExist(err) {
 			t.Fatalf("%s: %v", name, err)
 		}

--- a/internal/runtime/github_token_service.go
+++ b/internal/runtime/github_token_service.go
@@ -1,0 +1,155 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const githubTokenResponseLimit = 64 << 10
+
+var githubInstallationTokenPattern = regexp.MustCompile(`^[A-Za-z0-9_]+$`)
+var retryAfterSecondsPattern = regexp.MustCompile(`^[0-9]{1,10}$`)
+
+// CheckoutTokenProvider mints one repository-scoped credential for the
+// verified checkout adapter. The provider fixes permissions independently of
+// workflow inputs.
+type CheckoutTokenProvider interface {
+	Token(context.Context, string) (string, error)
+}
+
+// AgentGitHubTokenConfig identifies the exact current Buildkite job. Endpoint
+// and JobToken are runtime authority and are never forwarded to Git or action
+// code.
+type AgentGitHubTokenConfig struct {
+	Endpoint string
+	JobID    string
+	JobToken string
+	Client   *http.Client
+}
+
+// AgentGitHubTokens mints a read-only token for the pipeline's exact GitHub
+// repository through Buildkite's job-bound Agent API endpoint.
+type AgentGitHubTokens struct {
+	mintURL  string
+	jobToken string
+	client   *http.Client
+}
+
+func NewAgentGitHubTokens(config AgentGitHubTokenConfig) (*AgentGitHubTokens, error) {
+	mintURL, err := agentGitHubTokenURL(config.Endpoint, config.JobID)
+	if err != nil {
+		return nil, err
+	}
+	if config.JobToken == "" || strings.ContainsAny(config.JobToken, "\r\n") {
+		return nil, fmt.Errorf("GitHub token Agent job token is required")
+	}
+	client := config.Client
+	if client == nil {
+		client = &http.Client{Timeout: 15 * time.Second}
+	}
+	bounded := *client
+	bounded.Jar = nil
+	bounded.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	if bounded.Timeout == 0 {
+		bounded.Timeout = 15 * time.Second
+	}
+	return &AgentGitHubTokens{mintURL: mintURL, jobToken: config.JobToken, client: &bounded}, nil
+}
+
+func (c *AgentGitHubTokens) Token(ctx context.Context, repository string) (string, error) {
+	if c == nil {
+		return "", fmt.Errorf("GitHub checkout token provider is not configured")
+	}
+	if !validCheckoutRepository(repository) {
+		return "", fmt.Errorf("GitHub checkout token requires a valid event repository")
+	}
+	body, err := json.Marshal(struct {
+		RepositoryURL string            `json:"repo_url"`
+		Permissions   map[string]string `json:"permissions"`
+	}{
+		RepositoryURL: "https://github.com/" + repository,
+		Permissions:   map[string]string{"contents": "read"},
+	})
+	if err != nil {
+		return "", fmt.Errorf("encode GitHub checkout token request: %w", err)
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, c.mintURL, bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("create GitHub checkout token request: %w", err)
+	}
+	request.Header.Set("Authorization", "Token "+c.jobToken)
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Content-Type", "application/json")
+	response, err := c.client.Do(request)
+	if err != nil {
+		return "", fmt.Errorf("request GitHub checkout token: %w", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, githubTokenResponseLimit))
+		return "", githubTokenStatusError(response.StatusCode, response.Header.Get("Retry-After"))
+	}
+	payload, err := io.ReadAll(io.LimitReader(response.Body, githubTokenResponseLimit+1))
+	if err != nil {
+		return "", fmt.Errorf("read GitHub checkout token response: %w", err)
+	}
+	if len(payload) > githubTokenResponseLimit {
+		return "", fmt.Errorf("GitHub checkout token response exceeds the %d-byte limit", githubTokenResponseLimit)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	var decoded struct {
+		Token string `json:"token"`
+	}
+	if err := decoder.Decode(&decoded); err != nil {
+		return "", fmt.Errorf("decode GitHub checkout token response: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return "", fmt.Errorf("GitHub checkout token response has trailing data")
+	}
+	if len(decoded.Token) > 16<<10 || !githubInstallationTokenPattern.MatchString(decoded.Token) {
+		return "", fmt.Errorf("GitHub checkout token response contains an invalid token")
+	}
+	return decoded.Token, nil
+}
+
+func agentGitHubTokenURL(endpoint, jobID string) (string, error) {
+	if !validBuildkiteJobID(jobID) {
+		return "", fmt.Errorf("GitHub token Agent job ID is required")
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil || u.Scheme != "http" && u.Scheme != "https" || u.Host == "" || u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+		return "", fmt.Errorf("safe GitHub token Agent endpoint is required")
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + "/jobs/" + jobID + "/github_scoped_access_token"
+	u.RawPath = ""
+	return u.String(), nil
+}
+
+func githubTokenStatusError(status int, retryAfter string) error {
+	switch status {
+	case http.StatusBadRequest:
+		return fmt.Errorf("GitHub checkout token request was rejected")
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return fmt.Errorf("GitHub checkout token request was denied")
+	case http.StatusNotFound:
+		return fmt.Errorf("GitHub scoped access tokens are not enabled for this organization")
+	case http.StatusServiceUnavailable:
+		retryAfter = strings.TrimSpace(retryAfter)
+		if retryAfterSecondsPattern.MatchString(retryAfter) {
+			return fmt.Errorf("GitHub checkout token service is temporarily unavailable; retry after %s seconds", retryAfter)
+		}
+		return fmt.Errorf("GitHub checkout token service is temporarily unavailable")
+	default:
+		return fmt.Errorf("GitHub checkout token service returned HTTP %d", status)
+	}
+}

--- a/internal/runtime/github_token_service_test.go
+++ b/internal/runtime/github_token_service_test.go
@@ -1,0 +1,149 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAgentGitHubTokensMintsFixedReadOnlyRepositoryCredential(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Error(err)
+		}
+		if r.Method != http.MethodPost || r.URL.EscapedPath() != "/v3/jobs/"+testCacheJobID+"/github_scoped_access_token" || r.URL.RawQuery != "" {
+			t.Errorf("request = %s %s", r.Method, r.URL.String())
+		}
+		if r.Header.Get("Authorization") != "Token job-secret" || r.Header.Get("Accept") != "application/json" || r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("request headers = %#v", r.Header)
+		}
+		if string(body) != `{"repo_url":"https://github.com/buildkite/buildkite-gha","permissions":{"contents":"read"}}` {
+			t.Errorf("request body = %s", body)
+		}
+		_, _ = io.WriteString(w, `{"token":"ghs_scoped_token"}`)
+	}))
+	defer server.Close()
+
+	provider, err := NewAgentGitHubTokens(AgentGitHubTokenConfig{
+		Endpoint: server.URL + "/v3/", JobID: testCacheJobID, JobToken: "job-secret",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	token, err := provider.Token(context.Background(), "buildkite/buildkite-gha")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 || token != "ghs_scoped_token" {
+		t.Fatalf("calls/token = %d / %q", calls, token)
+	}
+}
+
+func TestAgentGitHubTokensRejectsUnsafeConfigurationAndRepository(t *testing.T) {
+	valid := AgentGitHubTokenConfig{Endpoint: "https://agent.example/v3", JobID: testCacheJobID, JobToken: "job-token"}
+	for name, mutate := range map[string]func(*AgentGitHubTokenConfig){
+		"missing endpoint":       func(c *AgentGitHubTokenConfig) { c.Endpoint = "" },
+		"endpoint credentials":   func(c *AgentGitHubTokenConfig) { c.Endpoint = "https://user@agent.example/v3" },
+		"endpoint query":         func(c *AgentGitHubTokenConfig) { c.Endpoint += "?redirect=other" },
+		"invalid job ID":         func(c *AgentGitHubTokenConfig) { c.JobID = "../other" },
+		"missing job token":      func(c *AgentGitHubTokenConfig) { c.JobToken = "" },
+		"job token header split": func(c *AgentGitHubTokenConfig) { c.JobToken = "secret\r\nOther: value" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := valid
+			mutate(&config)
+			if _, err := NewAgentGitHubTokens(config); err == nil {
+				t.Fatalf("NewAgentGitHubTokens(%#v) succeeded", config)
+			}
+		})
+	}
+	provider, err := NewAgentGitHubTokens(valid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, repository := range []string{"", "other", "../other/repo", "owner/..", "owner/repo/extra", "owner/repo?permission=write"} {
+		if _, err := provider.Token(context.Background(), repository); err == nil {
+			t.Fatalf("Token(%q) succeeded", repository)
+		}
+	}
+}
+
+func TestAgentGitHubTokensRejectsRedirectsAndUntrustedResponses(t *testing.T) {
+	secret := "ghs_must_not_leak"
+	for _, test := range []struct {
+		name       string
+		status     int
+		body       string
+		retryAfter string
+		want       string
+	}{
+		{"rejected", http.StatusBadRequest, secret, "", "rejected"},
+		{"denied", http.StatusForbidden, secret, "", "denied"},
+		{"disabled", http.StatusNotFound, secret, "", "not enabled"},
+		{"rate limited", http.StatusServiceUnavailable, secret, "60", "retry after 60 seconds"},
+		{"unsafe retry header", http.StatusServiceUnavailable, secret, secret, "temporarily unavailable"},
+		{"unexpected status", http.StatusBadGateway, secret, "", "HTTP 502"},
+		{"malformed JSON", http.StatusOK, `{"token":`, "", "decode"},
+		{"unknown field", http.StatusOK, `{"token":"ghs_valid","other":true}`, "", "unknown field"},
+		{"trailing JSON", http.StatusOK, `{"token":"ghs_valid"}{}`, "", "trailing data"},
+		{"empty token", http.StatusOK, `{"token":""}`, "", "invalid token"},
+		{"invalid token", http.StatusOK, `{"token":"secret with spaces"}`, "", "invalid token"},
+		{"oversized", http.StatusOK, `{"token":"ghs_valid"}` + strings.Repeat(" ", githubTokenResponseLimit), "", "exceeds"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if test.retryAfter != "" {
+					w.Header().Set("Retry-After", test.retryAfter)
+				}
+				w.WriteHeader(test.status)
+				_, _ = io.WriteString(w, test.body)
+			}))
+			defer server.Close()
+			provider, err := NewAgentGitHubTokens(AgentGitHubTokenConfig{Endpoint: server.URL, JobID: testCacheJobID, JobToken: "job-token"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = provider.Token(context.Background(), "buildkite/buildkite-gha")
+			if err == nil || !strings.Contains(err.Error(), test.want) || strings.Contains(err.Error(), secret) {
+				t.Fatalf("Token() error = %v, want %q without response data", err, test.want)
+			}
+		})
+	}
+
+	var redirected bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/elsewhere" {
+			redirected = true
+			_, _ = io.WriteString(w, `{"token":"ghs_valid"}`)
+			return
+		}
+		http.Redirect(w, r, "/elsewhere", http.StatusTemporaryRedirect)
+	}))
+	defer server.Close()
+	provider, err := NewAgentGitHubTokens(AgentGitHubTokenConfig{Endpoint: server.URL, JobID: testCacheJobID, JobToken: "job-token"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := provider.Token(context.Background(), "buildkite/buildkite-gha"); err == nil || !strings.Contains(err.Error(), "HTTP 307") || redirected {
+		t.Fatalf("redirect Token() error/redirected = %v / %v", err, redirected)
+	}
+}
+
+func TestAgentGitHubTokensHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	provider, err := NewAgentGitHubTokens(AgentGitHubTokenConfig{Endpoint: "https://agent.invalid/v3", JobID: testCacheJobID, JobToken: "job-token"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := provider.Token(ctx, "buildkite/buildkite-gha"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Token() error = %v, want cancellation", err)
+	}
+}

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -111,8 +111,16 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		return JobResult{}, err
 	}
 	for _, capability := range job.RequiredCapabilities {
-		if capability != "docker" && capability != "secrets" && capability != "network" {
+		if capability != "docker" && capability != "secrets" && capability != "network" && capability != "provider-token-read" {
 			return JobResult{}, fmt.Errorf("capability %q is unsupported in the job runtime", capability)
+		}
+	}
+	if job.HasCapability("provider-token-read") {
+		if r.Checkout == nil {
+			return JobResult{}, fmt.Errorf("provider-token-read capability requires the private checkout token provider")
+		}
+		if !jobUsesCheckoutAdapter(job) {
+			return JobResult{}, fmt.Errorf("provider-token-read capability is restricted to the verified checkout adapter")
 		}
 	}
 	if len(job.Dependencies) != 0 && len(job.Needs) == 0 {

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -122,6 +122,11 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		if !jobUsesCheckoutAdapter(job) {
 			return JobResult{}, fmt.Errorf("provider-token-read capability is restricted to the verified checkout adapter")
 		}
+		git, err := resolvePrivateCheckoutGit(r.Git)
+		if err != nil {
+			return JobResult{}, err
+		}
+		r.Git = git
 	}
 	if len(job.Dependencies) != 0 && len(job.Needs) == 0 {
 		return JobResult{}, fmt.Errorf("job has %d static dependencies but no hydrated prerequisite results", len(job.Dependencies))

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -122,11 +122,18 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		if !jobUsesCheckoutAdapter(job) {
 			return JobResult{}, fmt.Errorf("provider-token-read capability is restricted to the verified checkout adapter")
 		}
-		git, err := resolvePrivateCheckoutGit(r.Git)
+		git, err := resolveHostExecutableBeforeWorkflow(r.Git, "git", "private checkout Git")
 		if err != nil {
 			return JobResult{}, err
 		}
 		r.Git = git
+		if r.Redactor == nil {
+			return JobResult{}, fmt.Errorf("provider-token-read capability requires the Buildkite Agent redactor")
+		}
+		r.Redactor, err = resolveAgentRedactorBeforeWorkflow(r.Redactor)
+		if err != nil {
+			return JobResult{}, err
+		}
 	}
 	if len(job.Dependencies) != 0 && len(job.Needs) == 0 {
 		return JobResult{}, fmt.Errorf("job has %d static dependencies but no hydrated prerequisite results", len(job.Dependencies))

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -76,6 +76,30 @@ type Runner struct {
 	artifactRegistry  *artifactRegistry
 }
 
+func resolveHostExecutableBeforeWorkflow(configured, fallback, label string) (string, error) {
+	candidate := configured
+	if candidate == "" {
+		candidate = fallback
+	}
+	resolved, err := exec.LookPath(candidate)
+	if err != nil {
+		return "", fmt.Errorf("resolve %s before workflow execution: %w", label, err)
+	}
+	resolved, err = filepath.Abs(resolved)
+	if err != nil {
+		return "", fmt.Errorf("resolve %s absolute path before workflow execution: %w", label, err)
+	}
+	resolved, err = filepath.EvalSymlinks(resolved)
+	if err != nil {
+		return "", fmt.Errorf("canonicalize %s before workflow execution: %w", label, err)
+	}
+	info, err := os.Stat(resolved)
+	if err != nil || !info.Mode().IsRegular() || info.Mode().Perm()&0o111 == 0 {
+		return "", fmt.Errorf("%s must be a real executable resolved before workflow execution", label)
+	}
+	return resolved, nil
+}
+
 type managedNodeVerification struct {
 	mu    sync.Mutex
 	paths map[int]string

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -65,6 +65,7 @@ type Runner struct {
 	Actions           ActionMaterializer
 	Artifacts         ArtifactStore
 	Cache             CacheCredentialProvider
+	Checkout          CheckoutTokenProvider
 	runnerTemp        string
 	implicitJobPATH   string
 	explicitJobPATH   bool
@@ -697,6 +698,10 @@ func (r Runner) runStreaming(ctx context.Context, processor *commandProcessor, d
 	cmd := exec.Command(name, args...)
 	cmd.Dir = dir
 	cmd.Env = processEnv(env)
+	return r.runStreamingCommand(ctx, processor, cmd)
+}
+
+func (r Runner) runStreamingCommand(ctx context.Context, processor *commandProcessor, cmd *exec.Cmd) error {
 	configureProcessGroup(cmd)
 	stdout, stdoutWriter, err := os.Pipe()
 	if err != nil {
@@ -764,7 +769,7 @@ func (r Runner) runStreaming(ctx context.Context, processor *commandProcessor, d
 		waitErr = ctx.Err()
 	}
 	if waitErr != nil {
-		waitErr = fmt.Errorf("process %s: %w", name, waitErr)
+		waitErr = fmt.Errorf("process %s: %w", cmd.Path, waitErr)
 	}
 	return errors.Join(waitErr, streamErrs[0], streamErrs[1])
 }

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -910,6 +910,34 @@ func TestEnvironmentSecretsCannotReadAmbientAgentVariables(t *testing.T) {
 	}
 }
 
+func TestResolveAgentRedactorBeforeWorkflowPinsPointerWithoutMutatingCaller(t *testing.T) {
+	realDir := t.TempDir()
+	realAgent := filepath.Join(realDir, "buildkite-agent")
+	writeFixtureFile(t, realDir, "buildkite-agent", "#!/bin/sh\nexit 0\n")
+	if err := os.Chmod(realAgent, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	lookupDir := t.TempDir()
+	lookupAgent := filepath.Join(lookupDir, "buildkite-agent")
+	if err := os.Symlink(realAgent, lookupAgent); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", lookupDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	configured := &AgentRedactor{}
+	resolved, err := resolveAgentRedactorBeforeWorkflow(configured)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pinned, ok := resolved.(*AgentRedactor)
+	if !ok || pinned == configured || pinned.Executable != realAgent {
+		t.Fatalf("resolved redactor = %#v, want independent pointer pinned to %q", resolved, realAgent)
+	}
+	if configured.Executable != "" {
+		t.Fatalf("configured redactor mutated to %q", configured.Executable)
+	}
+}
+
 func TestFailureConditionsAndCancellation(t *testing.T) {
 	workspace := t.TempDir()
 	workflowPath := ".github/workflows/test.yml"

--- a/internal/runtime/secrets.go
+++ b/internal/runtime/secrets.go
@@ -34,6 +34,32 @@ type AgentRedactor struct {
 	Executable string
 }
 
+func resolveAgentRedactorBeforeWorkflow(redactor Redactor) (Redactor, error) {
+	resolve := func(redactor AgentRedactor) (AgentRedactor, error) {
+		executable, err := resolveHostExecutableBeforeWorkflow(redactor.Executable, "buildkite-agent", "Buildkite Agent redactor")
+		if err != nil {
+			return AgentRedactor{}, err
+		}
+		redactor.Executable = executable
+		return redactor, nil
+	}
+	switch redactor := redactor.(type) {
+	case AgentRedactor:
+		return resolve(redactor)
+	case *AgentRedactor:
+		if redactor == nil {
+			return nil, fmt.Errorf("buildkite Agent redactor is nil")
+		}
+		resolved, err := resolve(*redactor)
+		if err != nil {
+			return nil, err
+		}
+		return &resolved, nil
+	default:
+		return redactor, nil
+	}
+}
+
 func (r AgentRedactor) AddRedaction(ctx context.Context, value string) error {
 	executable := r.Executable
 	if executable == "" {


### PR DESCRIPTION
## Summary

- add an explicit `upload --private-checkout` mode for the pipeline's exact GitHub repository
- mint fixed `contents:read` credentials through the current job's Agent API and expose them only to the verified checkout adapter
- preserve the default public, tokenless checkout path and continue rejecting workflow-visible tokens, writes, private actions, and arbitrary repositories or permissions

## Security boundary

Fresh compiler provenance admits `provider-token-read` only for a validated root `actions/checkout` adapter. The runtime independently requires that adapter, registers both runtime and Agent redaction before fetch, and passes the credential through a one-shot askpass pipe rather than argv, URLs, Git config, plans, workflow environments, or result data. HTTP responses are bounded and strict; redirects and unavailable/disabled minting fail closed.

## Rollout

Hosted proof requires the scoped Agent endpoint to be deployed, the organization feature to be enabled, installer wiring for the opt-in, and a private-repository canary. The default path has no new service dependency.

## Verification

- `mise run check`
- focused private-checkout, credential-provider, compiler-admission, and default-tokenless tests