### PR TITLE
Install mise on action runtime cache miss

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ steps:
 The released plugin downloads and verifies `buildkite-gha` v0.2.3 by default,
 derives the event context from the Buildkite build, and uploads the generated
 jobs to the fixed `hosted` queue. Pin a released plugin version rather than a
-floating branch. For action jobs, the runtime reuses mise 2026.5.12 from
-`PATH` or the absolute path in `BUILDKITE_GHA_MISE`; when neither provides the
-exact version, it downloads and verifies a managed copy in the hosted cache.
-Shell-only jobs do not require or install mise.
+floating branch. For action jobs, the runtime reuses mise 2026.5.12 or newer
+from `PATH` or the absolute path in `BUILDKITE_GHA_MISE`; when neither provides
+a compatible version, it downloads and verifies a managed 2026.5.12 copy in
+the hosted cache. Shell-only jobs do not require or install mise.
 
 Configure branch, tag, and pull request triggers in Buildkite. The plugin
 derives a `pull_request` context for pull request builds and a `push` context

--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ steps:
 The released plugin downloads and verifies `buildkite-gha` v0.2.3 by default,
 derives the event context from the Buildkite build, and uploads the generated
 jobs to the fixed `hosted` queue. Pin a released plugin version rather than a
-floating branch. Runtime agents executing action jobs must provide mise
-2026.5.12 on `PATH` or at the absolute path in `BUILDKITE_GHA_MISE`; shell-only
-jobs do not require mise.
+floating branch. For action jobs, the runtime reuses mise 2026.5.12 from
+`PATH` or the absolute path in `BUILDKITE_GHA_MISE`; when neither provides the
+exact version, it downloads and verifies a managed copy in the hosted cache.
+Shell-only jobs do not require or install mise.
 
 Configure branch, tag, and pull request triggers in Buildkite. The plugin
 derives a `pull_request` context for pull request builds and a `push` context

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ steps:
 The released plugin downloads and verifies `buildkite-gha` v0.2.3 by default,
 derives the event context from the Buildkite build, and uploads the generated
 jobs to the fixed `hosted` queue. Pin a released plugin version rather than a
-floating branch.
+floating branch. Runtime agents executing action jobs must provide mise
+2026.5.12 on `PATH` or at the absolute path in `BUILDKITE_GHA_MISE`; shell-only
+jobs do not require mise.
 
 Configure branch, tag, and pull request triggers in Buildkite. The plugin
 derives a `pull_request` context for pull request builds and a `push` context

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -263,11 +263,13 @@ is the recommended installation. For direct use, download
 archive checksum, and extract it to a stable location. The archive contains
 `buildkite-gha` and `LICENSE`.
 
-Action workflows also require mise 2026.5.12 on the importer `PATH` when
-invoking `upload` directly. The runtime uses it with repository configuration
-disabled to install exact Node 20.20.2 or 24.18.0 releases. Those Node binaries
-require glibc 2.28 or newer; the static Go CLI does not. `validate` and
-`compile` do not install Node or require mise.
+Generated jobs that execute actions require mise 2026.5.12 on the runtime
+agent `PATH`, or at the absolute path supplied in `BUILDKITE_GHA_MISE`.
+`run-job` resolves and validates that executable before workflow code can
+modify `PATH`, then uses it with repository configuration disabled to install
+exact Node 20.20.2 or 24.18.0 releases. Those Node binaries require glibc 2.28
+or newer; the static Go CLI does not. Shell-only jobs, importers, `validate`,
+and `compile` do not require mise.
 
 ### Validate
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -267,13 +267,16 @@ Generated jobs that execute actions support mise 2026.5.12 or newer. `run-job`
 first checks `BUILDKITE_GHA_MISE` when set, then `PATH`; if neither supplies a
 compatible version, it downloads the pinned 2026.5.12 official archive into
 the automatically attached hosted cache. Both the archive and extracted
-executable are verified by embedded SHA-256 digests before use. An explicit
-`BUILDKITE_GHA_MISE` must be absolute and compatible rather than silently
-falling back. The runtime resolves and validates the executable before
-workflow code can modify `PATH`, then uses it with repository configuration
-disabled to install exact Node 20.20.2 or 24.18.0 releases. Those Node binaries
-require glibc 2.28 or newer; the static Go CLI does not. Shell-only jobs,
-importers, `validate`, and `compile` do not require or install mise.
+executable are verified by embedded SHA-256 digests before use. Verified cache
+bytes are copied into a job-private directory and reverified there before
+execution, so the shared cache remains an accelerator rather than executable
+authority. An explicit `BUILDKITE_GHA_MISE` must be absolute and compatible
+rather than silently falling back. The runtime resolves and validates the
+executable before workflow code can modify `PATH`, then uses it with repository
+configuration disabled to install exact Node 20.20.2 or 24.18.0 releases.
+Those Node binaries require glibc 2.28 or newer; the static Go CLI does not.
+Shell-only jobs, importers, `validate`, and `compile` do not require or install
+mise.
 
 ### Validate
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -263,13 +263,17 @@ is the recommended installation. For direct use, download
 archive checksum, and extract it to a stable location. The archive contains
 `buildkite-gha` and `LICENSE`.
 
-Generated jobs that execute actions require mise 2026.5.12 on the runtime
-agent `PATH`, or at the absolute path supplied in `BUILDKITE_GHA_MISE`.
-`run-job` resolves and validates that executable before workflow code can
-modify `PATH`, then uses it with repository configuration disabled to install
-exact Node 20.20.2 or 24.18.0 releases. Those Node binaries require glibc 2.28
-or newer; the static Go CLI does not. Shell-only jobs, importers, `validate`,
-and `compile` do not require mise.
+Generated jobs that execute actions use mise 2026.5.12. `run-job` first checks
+`BUILDKITE_GHA_MISE` when set, then `PATH`; if neither supplies the exact
+version, it downloads the pinned official archive into the automatically
+attached hosted cache. Both the archive and extracted executable are verified
+by embedded SHA-256 digests before use. An explicit `BUILDKITE_GHA_MISE` must
+be absolute and valid rather than silently falling back. The runtime resolves
+and validates the executable before workflow code can modify `PATH`, then uses
+it with repository configuration disabled to install exact Node 20.20.2 or
+24.18.0 releases. Those Node binaries require glibc 2.28 or newer; the static
+Go CLI does not. Shell-only jobs, importers, `validate`, and `compile` do not
+require or install mise.
 
 ### Validate
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -263,17 +263,17 @@ is the recommended installation. For direct use, download
 archive checksum, and extract it to a stable location. The archive contains
 `buildkite-gha` and `LICENSE`.
 
-Generated jobs that execute actions use mise 2026.5.12. `run-job` first checks
-`BUILDKITE_GHA_MISE` when set, then `PATH`; if neither supplies the exact
-version, it downloads the pinned official archive into the automatically
-attached hosted cache. Both the archive and extracted executable are verified
-by embedded SHA-256 digests before use. An explicit `BUILDKITE_GHA_MISE` must
-be absolute and valid rather than silently falling back. The runtime resolves
-and validates the executable before workflow code can modify `PATH`, then uses
-it with repository configuration disabled to install exact Node 20.20.2 or
-24.18.0 releases. Those Node binaries require glibc 2.28 or newer; the static
-Go CLI does not. Shell-only jobs, importers, `validate`, and `compile` do not
-require or install mise.
+Generated jobs that execute actions support mise 2026.5.12 or newer. `run-job`
+first checks `BUILDKITE_GHA_MISE` when set, then `PATH`; if neither supplies a
+compatible version, it downloads the pinned 2026.5.12 official archive into
+the automatically attached hosted cache. Both the archive and extracted
+executable are verified by embedded SHA-256 digests before use. An explicit
+`BUILDKITE_GHA_MISE` must be absolute and compatible rather than silently
+falling back. The runtime resolves and validates the executable before
+workflow code can modify `PATH`, then uses it with repository configuration
+disabled to install exact Node 20.20.2 or 24.18.0 releases. Those Node binaries
+require glibc 2.28 or newer; the static Go CLI does not. Shell-only jobs,
+importers, `validate`, and `compile` do not require or install mise.
 
 ### Validate
 

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -847,16 +847,16 @@ at barriers, and the cross-stream masking race.
   compatible.
 
 The release archive contains only the static Go CLI and LICENSE. Generated
-action jobs use mise 2026.5.12 without transporting an importer copy as an
-artifact. The runtime reuses an exact trusted executable from an explicit
-absolute path or `PATH`; otherwise the static CLI downloads the pinned official
-archive into the automatically attached hosted cache and verifies embedded
-archive and executable SHA-256 digests. It resolves and pins that executable
-before workflow code runs, then installs exactly `core:node@20.20.2` or
-`core:node@24.18.0` with mise configuration disabled, digest-verifies the
-resulting Node executable, and invokes that exact path directly. It never uses
-a fuzzy major, a data-dir plugin, repository mise configuration, or a
-workflow-modifiable tool-bin `PATH`.
+action jobs use mise 2026.5.12 or newer without transporting an importer copy
+as an artifact. The runtime reuses a compatible trusted executable from an
+explicit absolute path or `PATH`; otherwise the static CLI downloads the pinned
+2026.5.12 official archive into the automatically attached hosted cache and
+verifies embedded archive and executable SHA-256 digests. It resolves and pins
+that executable before workflow code runs, then installs exactly
+`core:node@20.20.2` or `core:node@24.18.0` with mise configuration disabled,
+digest-verifies the resulting Node executable, and invokes that exact path
+directly. It never uses a fuzzy Node major, a data-dir plugin, repository mise
+configuration, or a workflow-modifiable tool-bin `PATH`.
 `MISE_*` workflow environment overrides therefore cannot redirect compatibility
 Node; ordinary shell steps retain them.
 Generated action jobs declare a dedicated, pipeline-scoped Buildkite hosted
@@ -1054,22 +1054,23 @@ SBOMs in Phase 9. The initial supported distribution is Linux x86-64; Linux
 arm64 can follow once action/runtime compatibility is measured.
 
 Distributions provide the static bridge CLI and LICENSE. For action jobs, the
-bridge reuses an exact runtime mise or installs and verifies its pinned release
-in the integration-owned cache. It pins the absolute executable path before
-workflow code runs and uses it only to resolve digest-verified Node versions.
-Every generated job must execute the same bridge version that produced its
-plan unless the plan schema explicitly permits a compatible newer runtime.
+bridge reuses a compatible mise at or above its tested minimum or installs and
+verifies its pinned fallback release in the integration-owned cache. It pins
+the absolute executable path before workflow code runs and uses it only to
+resolve digest-verified Node versions. Every generated job must execute the
+same bridge version that produced its plan unless the plan schema explicitly
+permits a compatible newer runtime.
 
 The v0.1 preview bootstrap is implemented as one reproducible Linux x86-64
 archive containing only the static CLI and LICENSE, plus the
 `github-actions#v0.1.0` installer plugin. The plugin downloads an exact public
 release, verifies its checksum and fixed archive layout, caches the verified
 distribution, and invokes the fixed hosted-tokenless upload path. For action
-jobs, the static bridge reuses mise 2026.5.12 when available or downloads and
-digest-verifies its pinned official archive in the automatically attached,
-integration-owned hosted cache volume. Node 20.20.2 and 24.18.0 are installed
-by that pinned executable on demand into the same cache volume. Cached mise and
-Node executables are digest-verified before use, so
+jobs, the static bridge reuses mise 2026.5.12 or newer when available or
+downloads and digest-verifies its pinned 2026.5.12 official archive in the
+automatically attached, integration-owned hosted cache volume. Node 20.20.2
+and 24.18.0 are installed by that pinned executable on demand into the same
+cache volume. Cached mise and Node executables are digest-verified before use, so
 cache sharing across builds is an optimization rather than a trust boundary.
 Official mise-installed Node binaries require glibc 2.28 or newer.
 The source repository must be public before the initial tag because plugin

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -847,13 +847,16 @@ at barriers, and the cross-stream masking race.
   compatible.
 
 The release archive contains only the static Go CLI and LICENSE. Generated
-action jobs require mise 2026.5.12 as a runtime-agent capability rather than
-transporting an importer copy as an artifact. The runtime resolves and pins
-the trusted executable before workflow code runs, then installs exactly
-`core:node@20.20.2` or `core:node@24.18.0` with mise configuration disabled,
-digest-verifies the resulting Node executable, and invokes that exact path
-directly. It never uses a fuzzy major, a data-dir plugin, repository mise
-configuration, or a workflow-modifiable tool-bin `PATH`.
+action jobs use mise 2026.5.12 without transporting an importer copy as an
+artifact. The runtime reuses an exact trusted executable from an explicit
+absolute path or `PATH`; otherwise the static CLI downloads the pinned official
+archive into the automatically attached hosted cache and verifies embedded
+archive and executable SHA-256 digests. It resolves and pins that executable
+before workflow code runs, then installs exactly `core:node@20.20.2` or
+`core:node@24.18.0` with mise configuration disabled, digest-verifies the
+resulting Node executable, and invokes that exact path directly. It never uses
+a fuzzy major, a data-dir plugin, repository mise configuration, or a
+workflow-modifiable tool-bin `PATH`.
 `MISE_*` workflow environment overrides therefore cannot redirect compatibility
 Node; ordinary shell steps retain them.
 Generated action jobs declare a dedicated, pipeline-scoped Buildkite hosted
@@ -1050,22 +1053,23 @@ Publish checksummed releases. Add signatures, provenance attestations, and
 SBOMs in Phase 9. The initial supported distribution is Linux x86-64; Linux
 arm64 can follow once action/runtime compatibility is measured.
 
-Distributions provide the static bridge CLI and LICENSE. Runtime agents provide
-the required mise version for action jobs; the bridge pins its absolute path
-before workflow code runs and uses it only to resolve digest-verified Node
-versions. Every generated job must execute the same bridge version that
-produced its plan unless the plan schema explicitly permits a compatible newer
-runtime.
+Distributions provide the static bridge CLI and LICENSE. For action jobs, the
+bridge reuses an exact runtime mise or installs and verifies its pinned release
+in the integration-owned cache. It pins the absolute executable path before
+workflow code runs and uses it only to resolve digest-verified Node versions.
+Every generated job must execute the same bridge version that produced its
+plan unless the plan schema explicitly permits a compatible newer runtime.
 
 The v0.1 preview bootstrap is implemented as one reproducible Linux x86-64
 archive containing only the static CLI and LICENSE, plus the
 `github-actions#v0.1.0` installer plugin. The plugin downloads an exact public
 release, verifies its checksum and fixed archive layout, caches the verified
-distribution, and invokes the fixed hosted-tokenless upload path. Runtime
-agents provide mise 2026.5.12 for action jobs. Node 20.20.2 and 24.18.0 are
-installed by that pinned executable on demand into an automatically attached,
-integration-owned hosted cache volume. Cached Node executables are
-digest-verified before use, so
+distribution, and invokes the fixed hosted-tokenless upload path. For action
+jobs, the static bridge reuses mise 2026.5.12 when available or downloads and
+digest-verifies its pinned official archive in the automatically attached,
+integration-owned hosted cache volume. Node 20.20.2 and 24.18.0 are installed
+by that pinned executable on demand into the same cache volume. Cached mise and
+Node executables are digest-verified before use, so
 cache sharing across builds is an optimization rather than a trust boundary.
 Official mise-installed Node binaries require glibc 2.28 or newer.
 The source repository must be public before the initial tag because plugin
@@ -1266,9 +1270,9 @@ Cursor Origin public checkout remains a separate provider integration gate.
   on private sources or provider-dependent authentication. Action resolution is
   independent of event trust. Normal `upload` resolves local and anonymous
   public JavaScript/composite actions without transporting mise or Node
-  executable bytes; generated agents pin the required runtime mise capability
-  before workflow code and resolve compatibility versions through
-  `mise --no-config`.
+  executable bytes; generated agents reuse or install the pinned mise release
+  before workflow code and resolve compatibility versions through `mise
+  --no-config`.
   This path remains `EventUntrusted`, fixed to the
   ambient-clean, tokenless hosted queue, and accepts no capability, `network`,
   or the Phase 5 compiler-proven Dockerfile-action provenance.

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -851,8 +851,10 @@ action jobs use mise 2026.5.12 or newer without transporting an importer copy
 as an artifact. The runtime reuses a compatible trusted executable from an
 explicit absolute path or `PATH`; otherwise the static CLI downloads the pinned
 2026.5.12 official archive into the automatically attached hosted cache and
-verifies embedded archive and executable SHA-256 digests. It resolves and pins
-that executable before workflow code runs, then installs exactly
+verifies embedded archive and executable SHA-256 digests. Managed cache bytes
+are copied into a job-private directory and reverified before execution. The
+runtime resolves and pins that private executable before workflow code runs,
+then installs exactly
 `core:node@20.20.2` or `core:node@24.18.0` with mise configuration disabled,
 digest-verifies the resulting Node executable, and invokes that exact path
 directly. It never uses a fuzzy Node major, a data-dir plugin, repository mise
@@ -1069,9 +1071,10 @@ distribution, and invokes the fixed hosted-tokenless upload path. For action
 jobs, the static bridge reuses mise 2026.5.12 or newer when available or
 downloads and digest-verifies its pinned 2026.5.12 official archive in the
 automatically attached, integration-owned hosted cache volume. Node 20.20.2
-and 24.18.0 are installed by that pinned executable on demand into the same
-cache volume. Cached mise and Node executables are digest-verified before use, so
-cache sharing across builds is an optimization rather than a trust boundary.
+and 24.18.0 are installed by a reverified, job-private copy of that executable
+on demand into the same cache volume. Cached mise and Node executables are
+digest-verified before use, so cache sharing across builds is an optimization
+rather than a trust boundary.
 Official mise-installed Node binaries require glibc 2.28 or newer.
 The source repository must be public before the initial tag because plugin
 installation intentionally uses anonymous release downloads. Release

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -846,23 +846,21 @@ at barriers, and the cross-stream masking race.
 - managed Node distributions rather than assuming the host's `node` is
   compatible.
 
-The release archive contains only the static Go CLI and LICENSE. The installer
-plugin bootstraps mise 2026.5.12, verifies its pinned release archive and exact
-cached executable tree by SHA-256, and follows the shared Buildkite hosted-cache
-and agent-cache conventions. For action workflows, upload deterministically
-archives that pinned importer mise executable, transports it as a
-content-addressed artifact, and re-verifies it in every generated action job.
-The runtime installs exactly `core:node@20.20.2` or `core:node@24.18.0` with
-mise configuration disabled, digest-verifies the resulting Node executable,
-and invokes that exact path directly. It never uses a fuzzy major, a data-dir
-plugin, repository mise configuration, or an unverified tool-bin `PATH`.
+The release archive contains only the static Go CLI and LICENSE. Generated
+action jobs require mise 2026.5.12 as a runtime-agent capability rather than
+transporting an importer copy as an artifact. The runtime resolves and pins
+the trusted executable before workflow code runs, then installs exactly
+`core:node@20.20.2` or `core:node@24.18.0` with mise configuration disabled,
+digest-verifies the resulting Node executable, and invokes that exact path
+directly. It never uses a fuzzy major, a data-dir plugin, repository mise
+configuration, or a workflow-modifiable tool-bin `PATH`.
 `MISE_*` workflow environment overrides therefore cannot redirect compatibility
 Node; ordinary shell steps retain them.
 Generated action jobs declare a dedicated, pipeline-scoped Buildkite hosted
 cache volume and use a runtime-owned `MISE_DATA_DIR`; the cache is a best-effort
 accelerator, not an authority. The runtime checks cached Node executable bytes
 against the official Linux x86-64 release digest, removes and reinstalls a
-mismatch through the transported mise executable, and fails closed if the
+mismatch through the pinned runtime mise executable, and fails closed if the
 replacement still differs. Shell-only jobs do not attach this cache. For job
 containers, the host resolves that verified Node installation and mounts the
 Node executable; mise is not required in the image. Node runtime bytes are not
@@ -1052,21 +1050,22 @@ Publish checksummed releases. Add signatures, provenance attestations, and
 SBOMs in Phase 9. The initial supported distribution is Linux x86-64; Linux
 arm64 can follow once action/runtime compatibility is measured.
 
-Distributions provide the static bridge CLI and LICENSE. The installer plugin
-provides the pinned, verified mise executable, and action workflows transport
-it as a content-addressed artifact so generated hosted jobs can resolve exact
-Node versions without preinstalled mise. Every generated job must execute the
-same bridge version that produced its plan unless the plan schema explicitly
-permits a compatible newer runtime.
+Distributions provide the static bridge CLI and LICENSE. Runtime agents provide
+the required mise version for action jobs; the bridge pins its absolute path
+before workflow code runs and uses it only to resolve digest-verified Node
+versions. Every generated job must execute the same bridge version that
+produced its plan unless the plan schema explicitly permits a compatible newer
+runtime.
 
 The v0.1 preview bootstrap is implemented as one reproducible Linux x86-64
 archive containing only the static CLI and LICENSE, plus the
 `github-actions#v0.1.0` installer plugin. The plugin downloads an exact public
 release, verifies its checksum and fixed archive layout, caches the verified
-distribution, installs and digest-verifies the pinned mise executable, and
-invokes the fixed hosted-tokenless upload path. Node 20.20.2 and 24.18.0 are
-installed by mise on demand into an automatically attached, integration-owned
-hosted cache volume. Cached Node executables are digest-verified before use, so
+distribution, and invokes the fixed hosted-tokenless upload path. Runtime
+agents provide mise 2026.5.12 for action jobs. Node 20.20.2 and 24.18.0 are
+installed by that pinned executable on demand into an automatically attached,
+integration-owned hosted cache volume. Cached Node executables are
+digest-verified before use, so
 cache sharing across builds is an optimization rather than a trust boundary.
 Official mise-installed Node binaries require glibc 2.28 or newer.
 The source repository must be public before the initial tag because plugin
@@ -1266,9 +1265,10 @@ Cursor Origin public checkout remains a separate provider integration gate.
   lifecycle through exact mise-managed Node 20.20.2 or 24.18.0, and fail closed
   on private sources or provider-dependent authentication. Action resolution is
   independent of event trust. Normal `upload` resolves local and anonymous
-  public JavaScript/composite actions without transporting Node executable
-  bytes; generated agents use the exact content-addressed importer mise
-  executable to resolve compatibility versions through `mise --no-config`.
+  public JavaScript/composite actions without transporting mise or Node
+  executable bytes; generated agents pin the required runtime mise capability
+  before workflow code and resolve compatibility versions through
+  `mise --no-config`.
   This path remains `EventUntrusted`, fixed to the
   ambient-clean, tokenless hosted queue, and accepts no capability, `network`,
   or the Phase 5 compiler-proven Dockerfile-action provenance.

--- a/internal/buildkite/pipeline.go
+++ b/internal/buildkite/pipeline.go
@@ -13,19 +13,19 @@ import (
 
 const planDirectory = ".buildkite-gha/plans"
 const distributionDirectory = ".buildkite-gha/distributions"
-const toolDirectory = ".buildkite-gha/tools"
+
+// RequiredMiseVersion is the runtime-agent capability required by generated
+// jobs that execute actions. The runtime pins mise before workflow code runs.
+const RequiredMiseVersion = "2026.5.12"
 
 var identifierPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,255}$`)
 var digestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
-var toolVersionPattern = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+$`)
 var uuidPattern = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 
 // Pipeline is the validated input required to emit generated compatibility jobs.
 type Pipeline struct {
 	CompilerStep       string
 	DistributionDigest string
-	MiseDigest         string
-	MiseVersion        string
 	GroupLabel         string
 	Jobs               []Job
 }
@@ -39,24 +39,12 @@ func DistributionPath(digest string) (string, error) {
 	return distributionDirectory + "/" + strings.TrimPrefix(digest, "sha256:") + "/buildkite-gha", nil
 }
 
-// MisePath returns the fixed artifact path for a content-addressed mise
-// executable archive.
-func MisePath(digest string) (string, error) {
-	if !digestPattern.MatchString(digest) {
-		return "", fmt.Errorf("invalid mise digest %q", digest)
-	}
-	return toolDirectory + "/mise/" + strings.TrimPrefix(digest, "sha256:") + "/mise.gz", nil
-}
-
-// MiseDataDir returns the runtime-owned hosted cache path for one exact mise
-// version. The generated cache path triggers Buildkite's documented
+// MiseDataDir returns the runtime-owned hosted cache path for the required
+// mise version. The generated cache path triggers Buildkite's documented
 // /cache/bkcache volume mount; cache contents are an accelerator, never an
 // authority.
-func MiseDataDir(version string) (string, error) {
-	if !toolVersionPattern.MatchString(version) {
-		return "", fmt.Errorf("invalid mise version %q", version)
-	}
-	return "/cache/bkcache/buildkite-gha/mise/" + version, nil
+func MiseDataDir() string {
+	return "/cache/bkcache/buildkite-gha/mise/" + RequiredMiseVersion
 }
 
 // Job describes one expanded workflow job after queue policy has been applied.
@@ -95,20 +83,6 @@ func Emit(pipeline Pipeline) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	var misePath string
-	var miseDataDir string
-	if pipeline.MiseDigest != "" {
-		misePath, err = MisePath(pipeline.MiseDigest)
-		if err != nil {
-			return nil, err
-		}
-		miseDataDir, err = MiseDataDir(pipeline.MiseVersion)
-		if err != nil {
-			return nil, err
-		}
-	} else if pipeline.MiseVersion != "" {
-		return nil, fmt.Errorf("mise version requires a mise digest")
-	}
 	var out bytes.Buffer
 	out.WriteString("steps:\n")
 	stepIndent := "  "
@@ -125,7 +99,6 @@ func Emit(pipeline Pipeline) ([]byte, error) {
 		}
 		_, _ = fmt.Fprintf(&out, "%s- label: %s\n", stepIndent, yamlScalar(job.Label))
 		_, _ = fmt.Fprintf(&out, "%skey: %s\n", attributeIndent, yamlScalar(job.Key))
-		usesMise := misePath != "" && job.UsesActions
 		commands := []string{
 			"set -euo pipefail",
 			`bootstrap_dir="$(mktemp -d "${TMPDIR:-/tmp}/buildkite-gha.XXXXXXXX")"`,
@@ -138,25 +111,13 @@ func Emit(pipeline Pipeline) ([]byte, error) {
 			"test \"$actual_distribution_digest\" = " + shellQuote(pipeline.DistributionDigest),
 			`chmod 0500 "$distribution"`,
 		}
-		if usesMise {
-			commands = append(commands,
-				"buildkite-agent artifact download "+shellQuote(misePath)+` "$bootstrap_dir" --step `+shellQuote(pipeline.CompilerStep),
-				"mise_archive=\"$bootstrap_dir/"+misePath+`"`,
-				`mise="$bootstrap_dir/mise"`,
-				`actual_mise_digest="$(sha256sum "$mise_archive" | awk '{print "sha256:" $1}')"`,
-				`test "$actual_mise_digest" = `+shellQuote(pipeline.MiseDigest),
-				`gzip -dc "$mise_archive" > "$mise"`,
-				`chmod 0500 "$mise"`,
-				`export PATH="$bootstrap_dir:$PATH"`,
-			)
-		}
 		commands = append(commands, `"$distribution" run-job --plan "$plan"`)
 		command := strings.Join(commands, "\n")
 		_, _ = fmt.Fprintf(&out, "%scommand: %s\n", attributeIndent, yamlScalar(command))
 		_, _ = fmt.Fprintf(&out, "%sagents:\n", attributeIndent)
 		_, _ = fmt.Fprintf(&out, "%s  queue: %s\n", attributeIndent, yamlScalar(job.Queue))
 		_, _ = fmt.Fprintf(&out, "%scheckout:\n%s  skip: true\n", attributeIndent, attributeIndent)
-		if usesMise {
+		if job.UsesActions {
 			_, _ = fmt.Fprintf(&out, "%scache:\n", attributeIndent)
 			_, _ = fmt.Fprintf(&out, "%s  paths:\n", attributeIndent)
 			_, _ = fmt.Fprintf(&out, "%s    - \".buildkite-gha/cache-volume\"\n", attributeIndent)
@@ -166,8 +127,8 @@ func Emit(pipeline Pipeline) ([]byte, error) {
 		_, _ = fmt.Fprintf(&out, "%s  BUILDKITE_GHA_PLAN_DIGEST: %s\n", attributeIndent, yamlScalar(job.PlanDigest))
 		_, _ = fmt.Fprintf(&out, "%s  BUILDKITE_GHA_PLAN_PATH: %s\n", attributeIndent, yamlScalar(planPath))
 		_, _ = fmt.Fprintf(&out, "%s  BUILDKITE_GHA_PLAN_PRODUCER: %s\n", attributeIndent, yamlScalar(pipeline.CompilerStep))
-		if usesMise {
-			_, _ = fmt.Fprintf(&out, "%s  BUILDKITE_GHA_MISE_DATA_DIR: %s\n", attributeIndent, yamlScalar(miseDataDir))
+		if job.UsesActions {
+			_, _ = fmt.Fprintf(&out, "%s  BUILDKITE_GHA_MISE_DATA_DIR: %s\n", attributeIndent, yamlScalar(MiseDataDir()))
 		}
 		if job.Concurrency != 0 {
 			_, _ = fmt.Fprintf(&out, "%sconcurrency: %d\n", attributeIndent, job.Concurrency)

--- a/internal/buildkite/pipeline.go
+++ b/internal/buildkite/pipeline.go
@@ -14,8 +14,9 @@ import (
 const planDirectory = ".buildkite-gha/plans"
 const distributionDirectory = ".buildkite-gha/distributions"
 
-// MiseVersion is the exact mise release used to provision action runtimes.
-const MiseVersion = "2026.5.12"
+// MinimumMiseVersion is the oldest supported mise release and the exact
+// release installed when no compatible runtime executable is available.
+const MinimumMiseVersion = "2026.5.12"
 
 var identifierPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,255}$`)
 var digestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
@@ -43,7 +44,7 @@ func DistributionPath(digest string) (string, error) {
 // /cache/bkcache volume mount; cache contents are an accelerator, never an
 // authority.
 func MiseDataDir() string {
-	return "/cache/bkcache/buildkite-gha/mise/" + MiseVersion
+	return "/cache/bkcache/buildkite-gha/mise/" + MinimumMiseVersion
 }
 
 // Job describes one expanded workflow job after queue policy has been applied.

--- a/internal/buildkite/pipeline.go
+++ b/internal/buildkite/pipeline.go
@@ -14,9 +14,8 @@ import (
 const planDirectory = ".buildkite-gha/plans"
 const distributionDirectory = ".buildkite-gha/distributions"
 
-// RequiredMiseVersion is the runtime-agent capability required by generated
-// jobs that execute actions. The runtime pins mise before workflow code runs.
-const RequiredMiseVersion = "2026.5.12"
+// MiseVersion is the exact mise release used to provision action runtimes.
+const MiseVersion = "2026.5.12"
 
 var identifierPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,255}$`)
 var digestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
@@ -44,7 +43,7 @@ func DistributionPath(digest string) (string, error) {
 // /cache/bkcache volume mount; cache contents are an accelerator, never an
 // authority.
 func MiseDataDir() string {
-	return "/cache/bkcache/buildkite-gha/mise/" + RequiredMiseVersion
+	return "/cache/bkcache/buildkite-gha/mise/" + MiseVersion
 }
 
 // Job describes one expanded workflow job after queue policy has been applied.

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -173,8 +173,8 @@ func TestEmitActionRuntimeRequirement(t *testing.T) {
 	}
 }
 
-func TestMiseDataDirUsesRequiredRuntimeVersion(t *testing.T) {
-	if got := MiseDataDir(); got != "/cache/bkcache/buildkite-gha/mise/"+RequiredMiseVersion {
+func TestMiseDataDirUsesManagedRuntimeVersion(t *testing.T) {
+	if got := MiseDataDir(); got != "/cache/bkcache/buildkite-gha/mise/"+MiseVersion {
 		t.Fatalf("MiseDataDir() = %q", got)
 	}
 }

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -174,7 +174,7 @@ func TestEmitActionRuntimeRequirement(t *testing.T) {
 }
 
 func TestMiseDataDirUsesManagedRuntimeVersion(t *testing.T) {
-	if got := MiseDataDir(); got != "/cache/bkcache/buildkite-gha/mise/"+MiseVersion {
+	if got := MiseDataDir(); got != "/cache/bkcache/buildkite-gha/mise/"+MinimumMiseVersion {
 		t.Fatalf("MiseDataDir() = %q", got)
 	}
 }

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -134,20 +134,13 @@ func TestEmitMergesIntoContainingGroup(t *testing.T) {
 	}
 }
 
-func TestEmitMiseBootstrap(t *testing.T) {
-	digest := testDigest("mise")
+func TestEmitActionRuntimeRequirement(t *testing.T) {
 	pipeline := Pipeline{
 		CompilerStep:       "importer",
 		DistributionDigest: testDigest("distribution"),
-		MiseDigest:         digest,
-		MiseVersion:        "2026.5.12",
 		Jobs:               []Job{{Key: "action", Label: "Action", Queue: "hosted", PlanDigest: testDigest("plan"), UsesActions: true}},
 	}
 	output, err := Emit(pipeline)
-	if err != nil {
-		t.Fatal(err)
-	}
-	path, err := MisePath(digest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,42 +161,21 @@ func TestEmitMiseBootstrap(t *testing.T) {
 		t.Fatalf("emitted steps = %#v", document.Steps)
 	}
 	command := document.Steps[0].Command
-	for _, want := range []string{
-		"artifact download '" + path + `' "$bootstrap_dir" --step 'importer'`,
-		`sha256sum "$mise_archive"`,
-		`test "$actual_mise_digest" = '` + digest + `'`,
-		`gzip -dc "$mise_archive" > "$mise"`,
-		`chmod 0500 "$mise"`,
-		`export PATH="$bootstrap_dir:$PATH"`,
-	} {
-		if !strings.Contains(command, want) {
-			t.Fatalf("mise bootstrap missing %q:\n%s", want, command)
-		}
+	if strings.Contains(command, "/tools/mise/") || strings.Contains(command, "mise_archive") || strings.Contains(command, `export PATH="$bootstrap_dir:$PATH"`) {
+		t.Fatalf("generated action job still transports mise:\n%s", command)
 	}
 	step := document.Steps[0]
 	if step.Cache.Name != "buildkite-gha" || len(step.Cache.Paths) != 1 || step.Cache.Paths[0] != ".buildkite-gha/cache-volume" {
 		t.Fatalf("mise cache volume = %#v", step.Cache)
 	}
-	if step.Env["BUILDKITE_GHA_MISE_DATA_DIR"] != "/cache/bkcache/buildkite-gha/mise/2026.5.12" {
+	if step.Env["BUILDKITE_GHA_MISE_DATA_DIR"] != MiseDataDir() {
 		t.Fatalf("mise data directory = %q", step.Env["BUILDKITE_GHA_MISE_DATA_DIR"])
 	}
 }
 
-func TestMisePathValidation(t *testing.T) {
-	digest := testDigest("mise")
-	path, err := MisePath(digest)
-	if err != nil || path != ".buildkite-gha/tools/mise/"+strings.TrimPrefix(digest, "sha256:")+"/mise.gz" {
-		t.Fatalf("MisePath() = %q, %v", path, err)
-	}
-	if _, err := MisePath("sha256:nope"); err == nil {
-		t.Fatal("MisePath() accepted an invalid digest")
-	}
-	dataDir, err := MiseDataDir("2026.5.12")
-	if err != nil || dataDir != "/cache/bkcache/buildkite-gha/mise/2026.5.12" {
-		t.Fatalf("MiseDataDir() = %q, %v", dataDir, err)
-	}
-	if _, err := MiseDataDir("latest"); err == nil {
-		t.Fatal("MiseDataDir() accepted an unpinned version")
+func TestMiseDataDirUsesRequiredRuntimeVersion(t *testing.T) {
+	if got := MiseDataDir(); got != "/cache/bkcache/buildkite-gha/mise/"+RequiredMiseVersion {
+		t.Fatalf("MiseDataDir() = %q", got)
 	}
 }
 
@@ -211,8 +183,6 @@ func TestEmitMiseCacheOnlyForActionJobs(t *testing.T) {
 	output, err := Emit(Pipeline{
 		CompilerStep:       "importer",
 		DistributionDigest: testDigest("distribution"),
-		MiseDigest:         testDigest("mise"),
-		MiseVersion:        "2026.5.12",
 		Jobs: []Job{
 			{Key: "action", Label: "Action", Queue: "hosted", PlanDigest: testDigest("action-plan"), UsesActions: true},
 			{Key: "shell", Label: "Shell", Queue: "hosted", PlanDigest: testDigest("shell-plan")},
@@ -233,8 +203,8 @@ func TestEmitMiseCacheOnlyForActionJobs(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, step := range document.Steps {
-		if step.Key == "action" && (step.Cache == nil || step.Env["BUILDKITE_GHA_MISE_DATA_DIR"] == "" || !strings.Contains(step.Command, "/tools/mise/")) {
-			t.Fatalf("action job lacks managed mise: %#v", step)
+		if step.Key == "action" && (step.Cache == nil || step.Env["BUILDKITE_GHA_MISE_DATA_DIR"] != MiseDataDir() || strings.Contains(step.Command, "/tools/mise/")) {
+			t.Fatalf("action job lacks runtime mise cache configuration: %#v", step)
 		}
 		if step.Key == "shell" && (step.Cache != nil || step.Env["BUILDKITE_GHA_MISE_DATA_DIR"] != "" || strings.Contains(step.Command, "/tools/mise/")) {
 			t.Fatalf("shell job gained managed mise: %#v", step)
@@ -251,8 +221,6 @@ func TestEmitRejectsInvalidGraphsAndIdentifiers(t *testing.T) {
 	}{
 		{name: "empty", in: Pipeline{CompilerStep: "compiler", DistributionDigest: digest}, want: "at least one generated job"},
 		{name: "bad distribution digest", in: Pipeline{CompilerStep: "compiler", DistributionDigest: "sha256:nope", Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: digest}}}, want: "invalid distribution digest"},
-		{name: "mise digest without version", in: Pipeline{CompilerStep: "compiler", DistributionDigest: digest, MiseDigest: digest, Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: testDigest("mise-plan")}}}, want: "invalid mise version"},
-		{name: "mise version without digest", in: Pipeline{CompilerStep: "compiler", DistributionDigest: digest, MiseVersion: "2026.5.12", Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: testDigest("mise-version-plan")}}}, want: "mise version requires a mise digest"},
 		{name: "unknown dependency", in: Pipeline{CompilerStep: "compiler", Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: digest, Dependencies: []string{"missing"}}}}, want: "unknown dependency"},
 		{name: "cycle", in: Pipeline{CompilerStep: "compiler", Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: testDigest("one"), Dependencies: []string{"two"}}, {Key: "two", Label: "Two", Queue: "queue", PlanDigest: testDigest("two"), Dependencies: []string{"one"}}}}, want: "contains a cycle"},
 		{name: "duplicate key", in: Pipeline{CompilerStep: "compiler", Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: testDigest("one")}, {Key: "one", Label: "Other", Queue: "queue", PlanDigest: testDigest("other")}}}, want: "duplicate generated step key"},

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -263,26 +263,32 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: resolve runtime executable: %v\n", err)
 		return 1
 	}
+	var privateRuntime string
+	if jobUsesActions(job) {
+		runner.ResolveMise = func(ctx context.Context) (string, error) {
+			var err error
+			privateRuntime, err = os.MkdirTemp("", "buildkite-gha-runtime-")
+			if err != nil {
+				return "", fmt.Errorf("prepare action runtime: create private action runtime: %w", err)
+			}
+			mise, err := resolveRuntimeMise(ctx, os.Getenv("BUILDKITE_GHA_MISE"), runner.MiseDataDir, privateRuntime, stderr)
+			if err != nil {
+				return "", fmt.Errorf("prepare action runtime: %w", err)
+			}
+			return mise, nil
+		}
+		defer func() {
+			if privateRuntime != "" {
+				_ = os.RemoveAll(privateRuntime)
+			}
+		}()
+	}
 	var result gharuntime.JobResult
 	var runErr error
-	if jobUsesActions(job) {
-		privateRuntime, err := os.MkdirTemp("", "buildkite-gha-runtime-")
-		if err != nil {
-			runErr = fmt.Errorf("create private action runtime: %w", err)
-		} else {
-			defer func() { _ = os.RemoveAll(privateRuntime) }()
-			runner.Mise, runErr = resolveRuntimeMise(ctx, os.Getenv("BUILDKITE_GHA_MISE"), runner.MiseDataDir, privateRuntime, stderr)
-		}
-		if runErr != nil {
-			runErr = fmt.Errorf("prepare action runtime: %w", runErr)
-		}
-	}
 	if len(job.NeedSources) != 0 {
-		if runErr == nil {
-			job.Needs, runErr = gharuntime.ResolveNeeds(ctx, agent, artifactRoot, producer.BuildID, job.NeedSources, job.NeedOutputs)
-			if runErr != nil {
-				runErr = fmt.Errorf("hydrate prerequisite results: %w", runErr)
-			}
+		job.Needs, runErr = gharuntime.ResolveNeeds(ctx, agent, artifactRoot, producer.BuildID, job.NeedSources, job.NeedOutputs)
+		if runErr != nil {
+			runErr = fmt.Errorf("hydrate prerequisite results: %w", runErr)
 		}
 	}
 	if runErr == nil {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -361,7 +361,7 @@ func resolveRuntimeMiseWithInstaller(ctx context.Context, configured, dataDir, p
 }
 
 func validateRuntimeMise(ctx context.Context, candidate, expectedDigest string) (string, error) {
-	resolved, err := validateRuntimeMiseFile(candidate, expectedDigest)
+	resolved, err := validateRuntimeMiseFile(ctx, candidate, expectedDigest)
 	if err != nil {
 		return "", err
 	}
@@ -390,7 +390,7 @@ func validateRuntimeMise(ctx context.Context, candidate, expectedDigest string) 
 	return resolved, nil
 }
 
-func validateRuntimeMiseFile(candidate, expectedDigest string) (string, error) {
+func validateRuntimeMiseFile(ctx context.Context, candidate, expectedDigest string) (string, error) {
 	if !filepath.IsAbs(candidate) {
 		absolute, err := filepath.Abs(candidate)
 		if err != nil {
@@ -410,7 +410,10 @@ func validateRuntimeMiseFile(candidate, expectedDigest string) (string, error) {
 		return "", fmt.Errorf("runtime mise executable %q is not an executable regular file", resolved)
 	}
 	if expectedDigest != "" {
-		actual, err := fileSHA256(resolved)
+		if info.Size() > runtimeMiseBinaryLimit {
+			return "", fmt.Errorf("runtime mise executable exceeds %d-byte limit", runtimeMiseBinaryLimit)
+		}
+		actual, err := fileSHA256(ctx, resolved, runtimeMiseBinaryLimit)
 		if err != nil {
 			return "", fmt.Errorf("hash runtime mise executable: %w", err)
 		}
@@ -469,7 +472,7 @@ func installRuntimeMise(ctx context.Context, dataDir, privateRuntime string, std
 		root = filepath.Join(filepath.Dir(root), "runtime", buildkitepipeline.MinimumMiseVersion)
 	}
 	destination := filepath.Join(root, "linux-x64", "mise")
-	if resolved, err := validateRuntimeMiseFile(destination, runtimeMiseBinaryDigest); err == nil {
+	if resolved, err := validateRuntimeMiseFile(ctx, destination, runtimeMiseBinaryDigest); err == nil {
 		return pinRuntimeMise(ctx, resolved, privateRuntime, runtimeMiseBinaryDigest)
 	}
 	_, _ = fmt.Fprintf(stderr, "~~~ :mise: Install mise %s\n", buildkitepipeline.MinimumMiseVersion)
@@ -536,7 +539,7 @@ func pinRuntimeMise(ctx context.Context, cached, privateRuntime, expectedDigest 
 func installRuntimeMiseFrom(ctx context.Context, root string, client *http.Client, sourceURL, archiveDigest, binaryDigest string) (string, error) {
 	destinationDir := filepath.Join(root, "linux-x64")
 	destination := filepath.Join(destinationDir, "mise")
-	if resolved, err := validateRuntimeMiseFile(destination, binaryDigest); err == nil {
+	if resolved, err := validateRuntimeMiseFile(ctx, destination, binaryDigest); err == nil {
 		return resolved, nil
 	}
 	parent := filepath.Dir(destinationDir)
@@ -567,7 +570,7 @@ func installRuntimeMiseFrom(ctx context.Context, root string, client *http.Clien
 		return "", fmt.Errorf("remove staged mise archive: %w", err)
 	}
 	if _, err := os.Lstat(destinationDir); err == nil {
-		if resolved, validationErr := validateRuntimeMiseFile(destination, binaryDigest); validationErr == nil {
+		if resolved, validationErr := validateRuntimeMiseFile(ctx, destination, binaryDigest); validationErr == nil {
 			return resolved, nil
 		}
 		invalid := destinationDir + fmt.Sprintf(".invalid-%d", time.Now().UnixNano())
@@ -578,13 +581,13 @@ func installRuntimeMiseFrom(ctx context.Context, root string, client *http.Clien
 		return "", fmt.Errorf("inspect mise runtime cache: %w", err)
 	}
 	if err := os.Rename(staging, destinationDir); err != nil {
-		if resolved, validationErr := validateRuntimeMiseFile(destination, binaryDigest); validationErr == nil {
+		if resolved, validationErr := validateRuntimeMiseFile(ctx, destination, binaryDigest); validationErr == nil {
 			return resolved, nil
 		}
 		return "", fmt.Errorf("publish mise runtime cache: %w", err)
 	}
 	staging = ""
-	resolved, err := validateRuntimeMiseFile(destination, binaryDigest)
+	resolved, err := validateRuntimeMiseFile(ctx, destination, binaryDigest)
 	if err != nil {
 		return "", fmt.Errorf("validate installed mise cache: %w", err)
 	}
@@ -680,15 +683,37 @@ func extractRuntimeMise(archive, destination, expectedDigest string) error {
 	return nil
 }
 
-func fileSHA256(path string) (string, error) {
+func fileSHA256(ctx context.Context, path string, limit int64) (string, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return "", err
 	}
 	defer func() { _ = file.Close() }()
 	hash := sha256.New()
-	if _, err := io.Copy(hash, file); err != nil {
-		return "", err
+	buffer := make([]byte, 32*1024)
+	var read int64
+	for read <= limit {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		chunk := buffer
+		if remaining := limit + 1 - read; remaining < int64(len(chunk)) {
+			chunk = chunk[:remaining]
+		}
+		n, readErr := file.Read(chunk)
+		if n > 0 {
+			_, _ = hash.Write(chunk[:n])
+			read += int64(n)
+		}
+		if errors.Is(readErr, io.EOF) {
+			break
+		}
+		if readErr != nil {
+			return "", readErr
+		}
+	}
+	if read > limit {
+		return "", fmt.Errorf("exceeds %d-byte limit", limit)
 	}
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -563,7 +563,7 @@ func installRuntimeMiseFrom(ctx context.Context, root string, client *http.Clien
 	if err := extractRuntimeMise(archive, stagedExecutable, binaryDigest); err != nil {
 		return "", err
 	}
-	if _, err := validateRuntimeMise(ctx, stagedExecutable, binaryDigest); err != nil {
+	if _, err := validateRuntimeMiseFile(ctx, stagedExecutable, binaryDigest); err != nil {
 		return "", fmt.Errorf("validate downloaded mise executable: %w", err)
 	}
 	if err := os.Remove(archive); err != nil {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -266,7 +266,13 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 	var result gharuntime.JobResult
 	var runErr error
 	if jobUsesActions(job) {
-		runner.Mise, runErr = resolveRuntimeMise(ctx, os.Getenv("BUILDKITE_GHA_MISE"), runner.MiseDataDir, stderr)
+		privateRuntime, err := os.MkdirTemp("", "buildkite-gha-runtime-")
+		if err != nil {
+			runErr = fmt.Errorf("create private action runtime: %w", err)
+		} else {
+			defer func() { _ = os.RemoveAll(privateRuntime) }()
+			runner.Mise, runErr = resolveRuntimeMise(ctx, os.Getenv("BUILDKITE_GHA_MISE"), runner.MiseDataDir, privateRuntime, stderr)
+		}
 		if runErr != nil {
 			runErr = fmt.Errorf("prepare action runtime: %w", runErr)
 		}
@@ -328,11 +334,11 @@ func jobUsesActions(job plan.Job) bool {
 	return false
 }
 
-func resolveRuntimeMise(ctx context.Context, configured, dataDir string, stderr io.Writer) (string, error) {
-	return resolveRuntimeMiseWithInstaller(ctx, configured, dataDir, stderr, installRuntimeMise)
+func resolveRuntimeMise(ctx context.Context, configured, dataDir, privateRuntime string, stderr io.Writer) (string, error) {
+	return resolveRuntimeMiseWithInstaller(ctx, configured, dataDir, privateRuntime, stderr, installRuntimeMise)
 }
 
-func resolveRuntimeMiseWithInstaller(ctx context.Context, configured, dataDir string, stderr io.Writer, install func(context.Context, string, io.Writer) (string, error)) (string, error) {
+func resolveRuntimeMiseWithInstaller(ctx context.Context, configured, dataDir, privateRuntime string, stderr io.Writer, install func(context.Context, string, string, io.Writer) (string, error)) (string, error) {
 	if configured != "" {
 		if !filepath.IsAbs(configured) {
 			return "", fmt.Errorf("BUILDKITE_GHA_MISE must be an absolute path")
@@ -345,10 +351,40 @@ func resolveRuntimeMiseWithInstaller(ctx context.Context, configured, dataDir st
 		}
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: warning: mise on PATH is incompatible with minimum version %s; using the managed runtime copy\n", buildkitepipeline.MinimumMiseVersion)
 	}
-	return install(ctx, dataDir, stderr)
+	return install(ctx, dataDir, privateRuntime, stderr)
 }
 
 func validateRuntimeMise(ctx context.Context, candidate, expectedDigest string) (string, error) {
+	resolved, err := validateRuntimeMiseFile(candidate, expectedDigest)
+	if err != nil {
+		return "", err
+	}
+	command := exec.CommandContext(ctx, resolved, "--version")
+	for _, value := range os.Environ() {
+		name, _, _ := strings.Cut(value, "=")
+		if !strings.HasPrefix(name, "MISE_") {
+			command.Env = append(command.Env, value)
+		}
+	}
+	output, err := command.Output()
+	if err != nil {
+		return "", fmt.Errorf("validate runtime mise executable: %w", err)
+	}
+	fields := strings.Fields(string(output))
+	if len(fields) == 0 {
+		return "", fmt.Errorf("validate runtime mise executable: empty version")
+	}
+	reported := fields[0]
+	if reported == "mise" && len(fields) > 1 {
+		reported = fields[1]
+	}
+	if !miseVersionAtLeast(reported, buildkitepipeline.MinimumMiseVersion) {
+		return "", fmt.Errorf("runtime mise executable reported version %q, want %q or newer", reported, buildkitepipeline.MinimumMiseVersion)
+	}
+	return resolved, nil
+}
+
+func validateRuntimeMiseFile(candidate, expectedDigest string) (string, error) {
 	if !filepath.IsAbs(candidate) {
 		absolute, err := filepath.Abs(candidate)
 		if err != nil {
@@ -375,28 +411,6 @@ func validateRuntimeMise(ctx context.Context, candidate, expectedDigest string) 
 		if actual != expectedDigest {
 			return "", fmt.Errorf("runtime mise executable checksum mismatch")
 		}
-	}
-	command := exec.CommandContext(ctx, resolved, "--version")
-	for _, value := range os.Environ() {
-		name, _, _ := strings.Cut(value, "=")
-		if !strings.HasPrefix(name, "MISE_") {
-			command.Env = append(command.Env, value)
-		}
-	}
-	output, err := command.Output()
-	if err != nil {
-		return "", fmt.Errorf("validate runtime mise executable: %w", err)
-	}
-	fields := strings.Fields(string(output))
-	if len(fields) == 0 {
-		return "", fmt.Errorf("validate runtime mise executable: empty version")
-	}
-	reported := fields[0]
-	if reported == "mise" && len(fields) > 1 {
-		reported = fields[1]
-	}
-	if !miseVersionAtLeast(reported, buildkitepipeline.MinimumMiseVersion) {
-		return "", fmt.Errorf("runtime mise executable reported version %q, want %q or newer", reported, buildkitepipeline.MinimumMiseVersion)
 	}
 	return resolved, nil
 }
@@ -433,7 +447,7 @@ func miseVersionAtLeast(actual, minimum string) bool {
 	return true
 }
 
-func installRuntimeMise(ctx context.Context, dataDir string, stderr io.Writer) (string, error) {
+func installRuntimeMise(ctx context.Context, dataDir, privateRuntime string, stderr io.Writer) (string, error) {
 	if runtime.GOOS != "linux" || runtime.GOARCH != "amd64" {
 		return "", fmt.Errorf("managed mise is unavailable on %s/%s; set BUILDKITE_GHA_MISE to a compatible absolute path", runtime.GOOS, runtime.GOARCH)
 	}
@@ -449,8 +463,8 @@ func installRuntimeMise(ctx context.Context, dataDir string, stderr io.Writer) (
 		root = filepath.Join(filepath.Dir(root), "runtime", buildkitepipeline.MinimumMiseVersion)
 	}
 	destination := filepath.Join(root, "linux-x64", "mise")
-	if resolved, err := validateRuntimeMise(ctx, destination, runtimeMiseBinaryDigest); err == nil {
-		return resolved, nil
+	if resolved, err := validateRuntimeMiseFile(destination, runtimeMiseBinaryDigest); err == nil {
+		return pinRuntimeMise(ctx, resolved, privateRuntime, runtimeMiseBinaryDigest)
 	}
 	_, _ = fmt.Fprintf(stderr, "~~~ :mise: Install mise %s\n", buildkitepipeline.MinimumMiseVersion)
 	url := fmt.Sprintf("https://github.com/jdx/mise/releases/download/v%s/mise-v%s-linux-x64.tar.gz", buildkitepipeline.MinimumMiseVersion, buildkitepipeline.MinimumMiseVersion)
@@ -466,13 +480,57 @@ func installRuntimeMise(ctx context.Context, dataDir string, stderr io.Writer) (
 			return nil
 		},
 	}
-	return installRuntimeMiseFrom(ctx, root, client, url, runtimeMiseArchiveDigest, runtimeMiseBinaryDigest)
+	cached, err := installRuntimeMiseFrom(ctx, root, client, url, runtimeMiseArchiveDigest, runtimeMiseBinaryDigest)
+	if err != nil {
+		return "", err
+	}
+	return pinRuntimeMise(ctx, cached, privateRuntime, runtimeMiseBinaryDigest)
+}
+
+func pinRuntimeMise(ctx context.Context, cached, privateRuntime, expectedDigest string) (string, error) {
+	if privateRuntime == "" {
+		return "", fmt.Errorf("private action runtime directory is required")
+	}
+	resolvedRoot, err := filepath.EvalSymlinks(privateRuntime)
+	if err != nil || resolvedRoot != privateRuntime {
+		return "", fmt.Errorf("private action runtime directory contains a symlink")
+	}
+	source, err := os.Open(cached)
+	if err != nil {
+		return "", fmt.Errorf("open cached mise executable: %w", err)
+	}
+	defer func() { _ = source.Close() }()
+	destination := filepath.Join(privateRuntime, "mise")
+	output, err := os.OpenFile(destination, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o500)
+	if err != nil {
+		return "", fmt.Errorf("create private mise executable: %w", err)
+	}
+	hash := sha256.New()
+	written, copyErr := io.Copy(io.MultiWriter(output, hash), io.LimitReader(source, runtimeMiseBinaryLimit+1))
+	closeErr := output.Close()
+	if copyErr != nil {
+		return "", fmt.Errorf("copy private mise executable: %w", copyErr)
+	}
+	if closeErr != nil {
+		return "", fmt.Errorf("write private mise executable: %w", closeErr)
+	}
+	if written > runtimeMiseBinaryLimit {
+		return "", fmt.Errorf("cached mise executable exceeds %d-byte limit", runtimeMiseBinaryLimit)
+	}
+	if hex.EncodeToString(hash.Sum(nil)) != expectedDigest {
+		return "", fmt.Errorf("cached mise executable checksum verification failed")
+	}
+	resolved, err := validateRuntimeMise(ctx, destination, expectedDigest)
+	if err != nil {
+		return "", fmt.Errorf("validate private mise executable: %w", err)
+	}
+	return resolved, nil
 }
 
 func installRuntimeMiseFrom(ctx context.Context, root string, client *http.Client, sourceURL, archiveDigest, binaryDigest string) (string, error) {
 	destinationDir := filepath.Join(root, "linux-x64")
 	destination := filepath.Join(destinationDir, "mise")
-	if resolved, err := validateRuntimeMise(ctx, destination, binaryDigest); err == nil {
+	if resolved, err := validateRuntimeMiseFile(destination, binaryDigest); err == nil {
 		return resolved, nil
 	}
 	parent := filepath.Dir(destinationDir)
@@ -503,7 +561,7 @@ func installRuntimeMiseFrom(ctx context.Context, root string, client *http.Clien
 		return "", fmt.Errorf("remove staged mise archive: %w", err)
 	}
 	if _, err := os.Lstat(destinationDir); err == nil {
-		if resolved, validationErr := validateRuntimeMise(ctx, destination, binaryDigest); validationErr == nil {
+		if resolved, validationErr := validateRuntimeMiseFile(destination, binaryDigest); validationErr == nil {
 			return resolved, nil
 		}
 		invalid := destinationDir + fmt.Sprintf(".invalid-%d", time.Now().UnixNano())
@@ -514,15 +572,15 @@ func installRuntimeMiseFrom(ctx context.Context, root string, client *http.Clien
 		return "", fmt.Errorf("inspect mise runtime cache: %w", err)
 	}
 	if err := os.Rename(staging, destinationDir); err != nil {
-		if resolved, validationErr := validateRuntimeMise(ctx, destination, binaryDigest); validationErr == nil {
+		if resolved, validationErr := validateRuntimeMiseFile(destination, binaryDigest); validationErr == nil {
 			return resolved, nil
 		}
 		return "", fmt.Errorf("publish mise runtime cache: %w", err)
 	}
 	staging = ""
-	resolved, err := validateRuntimeMise(ctx, destination, binaryDigest)
+	resolved, err := validateRuntimeMiseFile(destination, binaryDigest)
 	if err != nil {
-		return "", fmt.Errorf("validate installed mise executable: %w", err)
+		return "", fmt.Errorf("validate installed mise cache: %w", err)
 	}
 	return resolved, nil
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -2,8 +2,6 @@
 package cli
 
 import (
-	"bytes"
-	"compress/gzip"
 	"context"
 	"crypto/sha256"
 	"encoding/json"
@@ -41,8 +39,6 @@ Commands:
 
 Run "buildkite-gha help <command>" for command help.
 `
-
-const managedMiseVersion = "2026.5.12"
 
 var commandUsage = map[string]string{
 	"validate": "Usage: buildkite-gha validate [--event-path <path>] [--profile hosted-tokenless] [--format text|json] <workflow>\n",
@@ -259,10 +255,18 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 	}
 	var result gharuntime.JobResult
 	var runErr error
-	if len(job.NeedSources) != 0 {
-		job.Needs, runErr = gharuntime.ResolveNeeds(ctx, agent, artifactRoot, producer.BuildID, job.NeedSources, job.NeedOutputs)
+	if jobUsesActions(job) {
+		runner.Mise, runErr = resolveRuntimeMise(ctx, os.Getenv("BUILDKITE_GHA_MISE"))
 		if runErr != nil {
-			runErr = fmt.Errorf("hydrate prerequisite results: %w", runErr)
+			runErr = fmt.Errorf("prepare action runtime: %w", runErr)
+		}
+	}
+	if len(job.NeedSources) != 0 {
+		if runErr == nil {
+			job.Needs, runErr = gharuntime.ResolveNeeds(ctx, agent, artifactRoot, producer.BuildID, job.NeedSources, job.NeedOutputs)
+			if runErr != nil {
+				runErr = fmt.Errorf("hydrate prerequisite results: %w", runErr)
+			}
 		}
 	}
 	if runErr == nil {
@@ -300,6 +304,65 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 		return 1
 	}
 	return 0
+}
+
+func jobUsesActions(job plan.Job) bool {
+	if len(job.Actions) != 0 {
+		return true
+	}
+	for _, step := range job.Steps {
+		if step.Uses != "" || step.Action != nil || step.Kind == "uses" {
+			return true
+		}
+	}
+	return false
+}
+
+func resolveRuntimeMise(ctx context.Context, configured string) (string, error) {
+	candidate := configured
+	if candidate == "" {
+		var err error
+		candidate, err = exec.LookPath("mise")
+		if err != nil {
+			return "", fmt.Errorf("mise %s is required on the runtime agent: %w", buildkitepipeline.RequiredMiseVersion, err)
+		}
+	} else if !filepath.IsAbs(candidate) {
+		return "", fmt.Errorf("BUILDKITE_GHA_MISE must be an absolute path")
+	}
+	absolute, err := filepath.Abs(candidate)
+	if err != nil {
+		return "", fmt.Errorf("resolve runtime mise path: %w", err)
+	}
+	resolved, err := filepath.EvalSymlinks(absolute)
+	if err != nil {
+		return "", fmt.Errorf("resolve runtime mise executable: %w", err)
+	}
+	info, err := os.Lstat(resolved)
+	if err != nil {
+		return "", fmt.Errorf("inspect runtime mise executable: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Mode().Perm()&0o111 == 0 {
+		return "", fmt.Errorf("runtime mise executable %q is not an executable regular file", resolved)
+	}
+	command := exec.CommandContext(ctx, resolved, "--version")
+	for _, value := range os.Environ() {
+		name, _, _ := strings.Cut(value, "=")
+		if !strings.HasPrefix(name, "MISE_") {
+			command.Env = append(command.Env, value)
+		}
+	}
+	output, err := command.Output()
+	if err != nil {
+		return "", fmt.Errorf("validate runtime mise executable: %w", err)
+	}
+	fields := strings.Fields(string(output))
+	if len(fields) == 0 {
+		return "", fmt.Errorf("validate runtime mise executable: empty version")
+	}
+	if fields[0] != buildkitepipeline.RequiredMiseVersion {
+		return "", fmt.Errorf("runtime mise executable reported version %q, want %q", fields[0], buildkitepipeline.RequiredMiseVersion)
+	}
+	return resolved, nil
 }
 
 func prepareMiseDataDir(path string, stderr io.Writer) string {
@@ -493,7 +556,7 @@ func validate(args []string, stdout, stderr io.Writer, version string) int {
 		}
 		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 		defer stop()
-		preflight, profileErr := compileHostedTokenless(ctx, workflowPath, source, event, version, distributionDigest, "buildkite-gha-profile-importer", "", false, false)
+		preflight, profileErr := compileHostedTokenless(ctx, workflowPath, source, event, version, distributionDigest, "buildkite-gha-profile-importer", "", false)
 		if profileErr != nil {
 			if ctx.Err() != nil || errors.Is(profileErr, context.Canceled) {
 				_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: profile evaluation interrupted: %v\n", profileErr)
@@ -640,22 +703,19 @@ func upload(args []string, stdout, stderr io.Writer, version string, agent trans
 	}
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
-	preflight, err := compileHostedTokenless(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, os.Getenv("BUILDKITE_GROUP_LABEL"), true, privateCheckout)
+	preflight, err := compileHostedTokenless(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, os.Getenv("BUILDKITE_GROUP_LABEL"), privateCheckout)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
 		return 1
 	}
 	bundle := preflight.Bundle
-	artifacts := make([]transport.Artifact, 0, 2+len(bundle.Plans))
+	artifacts := make([]transport.Artifact, 0, 1+len(bundle.Plans))
 	distributionPath, err := buildkitepipeline.DistributionPath(distributionDigest)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
 		return 1
 	}
 	artifacts = append(artifacts, transport.Artifact{Path: distributionPath, Digest: distributionDigest, Contents: executableContents})
-	if preflight.MiseArtifact != nil {
-		artifacts = append(artifacts, *preflight.MiseArtifact)
-	}
 	for _, jobPlan := range bundle.Plans {
 		artifacts = append(artifacts, transport.Artifact{Path: jobPlan.Path, Digest: jobPlan.Digest, Contents: jobPlan.Contents})
 	}
@@ -675,9 +735,8 @@ func upload(args []string, stdout, stderr io.Writer, version string, agent trans
 }
 
 type hostedTokenlessCompilation struct {
-	Bundle       compiler.Bundle
-	MiseArtifact *transport.Artifact
-	HasActions   bool
+	Bundle     compiler.Bundle
+	HasActions bool
 }
 
 type hostedTokenlessFailureKind string
@@ -700,7 +759,7 @@ func hostedTokenlessError(kind hostedTokenlessFailureKind, err error) error {
 	return &hostedTokenlessFailure{Kind: kind, Err: err}
 }
 
-func compileHostedTokenless(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, transportMise, privateCheckout bool) (hostedTokenlessCompilation, error) {
+func compileHostedTokenless(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, privateCheckout bool) (hostedTokenlessCompilation, error) {
 	preflight, err := compiler.Compile(workflowPath, workflowSource, eventSource)
 	if err != nil {
 		return hostedTokenlessCompilation{}, hostedTokenlessError(hostedTokenlessEvaluationFailure, err)
@@ -741,16 +800,6 @@ func compileHostedTokenless(ctx context.Context, workflowPath string, workflowSo
 		options.ResolveActions = true
 		options.ActionSource = compiler.PublicActionSource{Resolver: resolver, Store: store}
 	}
-	var miseArtifact *transport.Artifact
-	if hasActions && transportMise {
-		artifact, err := managedMiseArtifact(ctx)
-		if err != nil {
-			return hostedTokenlessCompilation{}, hostedTokenlessError(hostedTokenlessEnvironmentFailure, err)
-		}
-		miseArtifact = &artifact
-		options.MiseDigest = artifact.Digest
-		options.MiseVersion = managedMiseVersion
-	}
 	bundle, err := compiler.CompileBundleContext(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, options)
 	if err != nil {
 		return hostedTokenlessCompilation{}, hostedTokenlessError(hostedTokenlessEvaluationFailure, err)
@@ -761,7 +810,7 @@ func compileHostedTokenless(ctx context.Context, workflowPath string, workflowSo
 	if !hasActions && bundleUsesActions(bundle) {
 		return hostedTokenlessCompilation{}, hostedTokenlessError(hostedTokenlessEvaluationFailure, fmt.Errorf("final compilation introduced actions absent from preflight"))
 	}
-	return hostedTokenlessCompilation{Bundle: bundle, MiseArtifact: miseArtifact, HasActions: hasActions}, nil
+	return hostedTokenlessCompilation{Bundle: bundle, HasActions: hasActions}, nil
 }
 
 func validateUnprivilegedBundle(bundle compiler.Bundle) error {
@@ -826,76 +875,6 @@ func bundleUsesActions(bundle compiler.Bundle) bool {
 		}
 	}
 	return false
-}
-
-func managedMiseArtifact(ctx context.Context) (transport.Artifact, error) {
-	mise, err := exec.LookPath("mise")
-	if err != nil {
-		return transport.Artifact{}, fmt.Errorf("mise is required on the importer for action workflows: %w", err)
-	}
-	realMise, err := filepath.EvalSymlinks(mise)
-	if err != nil {
-		return transport.Artifact{}, fmt.Errorf("resolve importer mise executable: %w", err)
-	}
-	contents, err := os.ReadFile(realMise)
-	if err != nil {
-		return transport.Artifact{}, fmt.Errorf("read importer mise executable: %w", err)
-	}
-	if err := validateMiseBytes(ctx, contents); err != nil {
-		return transport.Artifact{}, err
-	}
-	archive, err := deterministicGzip(contents)
-	if err != nil {
-		return transport.Artifact{}, fmt.Errorf("archive importer mise executable: %w", err)
-	}
-	digest := transport.Digest(archive)
-	path, err := buildkitepipeline.MisePath(digest)
-	if err != nil {
-		return transport.Artifact{}, err
-	}
-	return transport.Artifact{Path: path, Digest: digest, Contents: archive}, nil
-}
-
-func validateMiseBytes(ctx context.Context, contents []byte) error {
-	dir, err := os.MkdirTemp("", "buildkite-gha-mise-validation-")
-	if err != nil {
-		return fmt.Errorf("create mise validation directory: %w", err)
-	}
-	defer func() { _ = os.RemoveAll(dir) }()
-	copyPath := filepath.Join(dir, "mise")
-	if err := os.WriteFile(copyPath, contents, 0o700); err != nil {
-		return fmt.Errorf("materialize importer mise executable for validation: %w", err)
-	}
-	command := exec.CommandContext(ctx, copyPath, "--version")
-	command.Env = []string{"HOME=" + dir, "PATH=/usr/local/bin:/usr/bin:/bin"}
-	output, err := command.Output()
-	if err != nil {
-		return fmt.Errorf("validate exact importer mise executable bytes: %w", err)
-	}
-	if strings.TrimSpace(string(output)) == "" {
-		return fmt.Errorf("validate exact importer mise executable bytes: empty version")
-	}
-	fields := strings.Fields(string(output))
-	if fields[0] != managedMiseVersion {
-		return fmt.Errorf("validate exact importer mise executable bytes: reported version %q, want %q", fields[0], managedMiseVersion)
-	}
-	return nil
-}
-
-func deterministicGzip(source []byte) ([]byte, error) {
-	var out bytes.Buffer
-	w, err := gzip.NewWriterLevel(&out, gzip.BestCompression)
-	if err != nil {
-		return nil, err
-	}
-	w.OS = 255
-	if _, err := w.Write(source); err != nil {
-		return nil, err
-	}
-	if err := w.Close(); err != nil {
-		return nil, err
-	}
-	return out.Bytes(), nil
 }
 
 func uploadArgs(args []string) (workflowPath, eventPath, runtimeQueue string, privateCheckout bool, err error) {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -342,7 +343,7 @@ func resolveRuntimeMiseWithInstaller(ctx context.Context, configured, dataDir st
 		if resolved, validationErr := validateRuntimeMise(ctx, candidate, ""); validationErr == nil {
 			return resolved, nil
 		}
-		_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: warning: mise on PATH does not match required version %s; using the managed runtime copy\n", buildkitepipeline.MiseVersion)
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: warning: mise on PATH is incompatible with minimum version %s; using the managed runtime copy\n", buildkitepipeline.MinimumMiseVersion)
 	}
 	return install(ctx, dataDir, stderr)
 }
@@ -390,10 +391,46 @@ func validateRuntimeMise(ctx context.Context, candidate, expectedDigest string) 
 	if len(fields) == 0 {
 		return "", fmt.Errorf("validate runtime mise executable: empty version")
 	}
-	if fields[0] != buildkitepipeline.MiseVersion {
-		return "", fmt.Errorf("runtime mise executable reported version %q, want %q", fields[0], buildkitepipeline.MiseVersion)
+	reported := fields[0]
+	if reported == "mise" && len(fields) > 1 {
+		reported = fields[1]
+	}
+	if !miseVersionAtLeast(reported, buildkitepipeline.MinimumMiseVersion) {
+		return "", fmt.Errorf("runtime mise executable reported version %q, want %q or newer", reported, buildkitepipeline.MinimumMiseVersion)
 	}
 	return resolved, nil
+}
+
+func miseVersionAtLeast(actual, minimum string) bool {
+	parse := func(value string) ([3]int, bool) {
+		var parsed [3]int
+		parts := strings.Split(strings.TrimPrefix(value, "v"), ".")
+		if len(parts) != len(parsed) {
+			return parsed, false
+		}
+		for index, part := range parts {
+			number, err := strconv.Atoi(part)
+			if err != nil || number < 0 {
+				return parsed, false
+			}
+			parsed[index] = number
+		}
+		return parsed, true
+	}
+	got, ok := parse(actual)
+	if !ok {
+		return false
+	}
+	want, ok := parse(minimum)
+	if !ok {
+		return false
+	}
+	for index := range got {
+		if got[index] != want[index] {
+			return got[index] > want[index]
+		}
+	}
+	return true
 }
 
 func installRuntimeMise(ctx context.Context, dataDir string, stderr io.Writer) (string, error) {
@@ -407,16 +444,16 @@ func installRuntimeMise(ctx context.Context, dataDir string, stderr io.Writer) (
 		if err != nil {
 			return "", fmt.Errorf("resolve mise runtime cache: %w", err)
 		}
-		root = filepath.Join(root, "buildkite-gha", "mise", buildkitepipeline.MiseVersion)
+		root = filepath.Join(root, "buildkite-gha", "mise", buildkitepipeline.MinimumMiseVersion)
 	} else {
-		root = filepath.Join(filepath.Dir(root), "runtime", buildkitepipeline.MiseVersion)
+		root = filepath.Join(filepath.Dir(root), "runtime", buildkitepipeline.MinimumMiseVersion)
 	}
 	destination := filepath.Join(root, "linux-x64", "mise")
 	if resolved, err := validateRuntimeMise(ctx, destination, runtimeMiseBinaryDigest); err == nil {
 		return resolved, nil
 	}
-	_, _ = fmt.Fprintf(stderr, "~~~ :mise: Install mise %s\n", buildkitepipeline.MiseVersion)
-	url := fmt.Sprintf("https://github.com/jdx/mise/releases/download/v%s/mise-v%s-linux-x64.tar.gz", buildkitepipeline.MiseVersion, buildkitepipeline.MiseVersion)
+	_, _ = fmt.Fprintf(stderr, "~~~ :mise: Install mise %s\n", buildkitepipeline.MinimumMiseVersion)
+	url := fmt.Sprintf("https://github.com/jdx/mise/releases/download/v%s/mise-v%s-linux-x64.tar.gz", buildkitepipeline.MinimumMiseVersion, buildkitepipeline.MinimumMiseVersion)
 	client := &http.Client{
 		Timeout: 2 * time.Minute,
 		CheckRedirect: func(request *http.Request, via []*http.Request) error {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -2,16 +2,21 @@
 package cli
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"syscall"
@@ -51,6 +56,10 @@ const (
 	resultPublicationTimeout = 10 * time.Second
 	unprivilegedRuntimeQueue = "hosted"
 	hostedTokenlessProfile   = "hosted-tokenless"
+	runtimeMiseArchiveDigest = "bd0930c0b619f51ddb60e32e5cce18a5533567b2f1ba9fc4875b9f39a2bb3ed8"
+	runtimeMiseBinaryDigest  = "a238972a3162d710b85b28c324372e96ca4e4b486c81fe78695000d9fbc77c48"
+	runtimeMiseArchiveLimit  = 64 << 20
+	runtimeMiseBinaryLimit   = 128 << 20
 )
 
 // Run executes the command and returns its process exit code.
@@ -256,7 +265,7 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 	var result gharuntime.JobResult
 	var runErr error
 	if jobUsesActions(job) {
-		runner.Mise, runErr = resolveRuntimeMise(ctx, os.Getenv("BUILDKITE_GHA_MISE"))
+		runner.Mise, runErr = resolveRuntimeMise(ctx, os.Getenv("BUILDKITE_GHA_MISE"), runner.MiseDataDir, stderr)
 		if runErr != nil {
 			runErr = fmt.Errorf("prepare action runtime: %w", runErr)
 		}
@@ -318,22 +327,35 @@ func jobUsesActions(job plan.Job) bool {
 	return false
 }
 
-func resolveRuntimeMise(ctx context.Context, configured string) (string, error) {
-	candidate := configured
-	if candidate == "" {
-		var err error
-		candidate, err = exec.LookPath("mise")
-		if err != nil {
-			return "", fmt.Errorf("mise %s is required on the runtime agent: %w", buildkitepipeline.RequiredMiseVersion, err)
+func resolveRuntimeMise(ctx context.Context, configured, dataDir string, stderr io.Writer) (string, error) {
+	return resolveRuntimeMiseWithInstaller(ctx, configured, dataDir, stderr, installRuntimeMise)
+}
+
+func resolveRuntimeMiseWithInstaller(ctx context.Context, configured, dataDir string, stderr io.Writer, install func(context.Context, string, io.Writer) (string, error)) (string, error) {
+	if configured != "" {
+		if !filepath.IsAbs(configured) {
+			return "", fmt.Errorf("BUILDKITE_GHA_MISE must be an absolute path")
 		}
-	} else if !filepath.IsAbs(candidate) {
-		return "", fmt.Errorf("BUILDKITE_GHA_MISE must be an absolute path")
+		return validateRuntimeMise(ctx, configured, "")
 	}
-	absolute, err := filepath.Abs(candidate)
-	if err != nil {
-		return "", fmt.Errorf("resolve runtime mise path: %w", err)
+	if candidate, err := exec.LookPath("mise"); err == nil {
+		if resolved, validationErr := validateRuntimeMise(ctx, candidate, ""); validationErr == nil {
+			return resolved, nil
+		}
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: warning: mise on PATH does not match required version %s; using the managed runtime copy\n", buildkitepipeline.MiseVersion)
 	}
-	resolved, err := filepath.EvalSymlinks(absolute)
+	return install(ctx, dataDir, stderr)
+}
+
+func validateRuntimeMise(ctx context.Context, candidate, expectedDigest string) (string, error) {
+	if !filepath.IsAbs(candidate) {
+		absolute, err := filepath.Abs(candidate)
+		if err != nil {
+			return "", fmt.Errorf("resolve runtime mise path: %w", err)
+		}
+		candidate = absolute
+	}
+	resolved, err := filepath.EvalSymlinks(candidate)
 	if err != nil {
 		return "", fmt.Errorf("resolve runtime mise executable: %w", err)
 	}
@@ -343,6 +365,15 @@ func resolveRuntimeMise(ctx context.Context, configured string) (string, error) 
 	}
 	if !info.Mode().IsRegular() || info.Mode().Perm()&0o111 == 0 {
 		return "", fmt.Errorf("runtime mise executable %q is not an executable regular file", resolved)
+	}
+	if expectedDigest != "" {
+		actual, err := fileSHA256(resolved)
+		if err != nil {
+			return "", fmt.Errorf("hash runtime mise executable: %w", err)
+		}
+		if actual != expectedDigest {
+			return "", fmt.Errorf("runtime mise executable checksum mismatch")
+		}
 	}
 	command := exec.CommandContext(ctx, resolved, "--version")
 	for _, value := range os.Environ() {
@@ -359,10 +390,206 @@ func resolveRuntimeMise(ctx context.Context, configured string) (string, error) 
 	if len(fields) == 0 {
 		return "", fmt.Errorf("validate runtime mise executable: empty version")
 	}
-	if fields[0] != buildkitepipeline.RequiredMiseVersion {
-		return "", fmt.Errorf("runtime mise executable reported version %q, want %q", fields[0], buildkitepipeline.RequiredMiseVersion)
+	if fields[0] != buildkitepipeline.MiseVersion {
+		return "", fmt.Errorf("runtime mise executable reported version %q, want %q", fields[0], buildkitepipeline.MiseVersion)
 	}
 	return resolved, nil
+}
+
+func installRuntimeMise(ctx context.Context, dataDir string, stderr io.Writer) (string, error) {
+	if runtime.GOOS != "linux" || runtime.GOARCH != "amd64" {
+		return "", fmt.Errorf("managed mise is unavailable on %s/%s; set BUILDKITE_GHA_MISE to a compatible absolute path", runtime.GOOS, runtime.GOARCH)
+	}
+	root := dataDir
+	if root == "" {
+		var err error
+		root, err = os.UserCacheDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve mise runtime cache: %w", err)
+		}
+		root = filepath.Join(root, "buildkite-gha", "mise", buildkitepipeline.MiseVersion)
+	} else {
+		root = filepath.Join(filepath.Dir(root), "runtime", buildkitepipeline.MiseVersion)
+	}
+	destination := filepath.Join(root, "linux-x64", "mise")
+	if resolved, err := validateRuntimeMise(ctx, destination, runtimeMiseBinaryDigest); err == nil {
+		return resolved, nil
+	}
+	_, _ = fmt.Fprintf(stderr, "~~~ :mise: Install mise %s\n", buildkitepipeline.MiseVersion)
+	url := fmt.Sprintf("https://github.com/jdx/mise/releases/download/v%s/mise-v%s-linux-x64.tar.gz", buildkitepipeline.MiseVersion, buildkitepipeline.MiseVersion)
+	client := &http.Client{
+		Timeout: 2 * time.Minute,
+		CheckRedirect: func(request *http.Request, via []*http.Request) error {
+			if request.URL.Scheme != "https" {
+				return errors.New("mise download redirected away from HTTPS")
+			}
+			if len(via) >= 10 {
+				return errors.New("too many mise download redirects")
+			}
+			return nil
+		},
+	}
+	return installRuntimeMiseFrom(ctx, root, client, url, runtimeMiseArchiveDigest, runtimeMiseBinaryDigest)
+}
+
+func installRuntimeMiseFrom(ctx context.Context, root string, client *http.Client, sourceURL, archiveDigest, binaryDigest string) (string, error) {
+	destinationDir := filepath.Join(root, "linux-x64")
+	destination := filepath.Join(destinationDir, "mise")
+	if resolved, err := validateRuntimeMise(ctx, destination, binaryDigest); err == nil {
+		return resolved, nil
+	}
+	parent := filepath.Dir(destinationDir)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return "", fmt.Errorf("create mise runtime cache: %w", err)
+	}
+	resolvedParent, err := filepath.EvalSymlinks(parent)
+	if err != nil || resolvedParent != parent {
+		return "", fmt.Errorf("mise runtime cache contains a symlink")
+	}
+	staging, err := os.MkdirTemp(parent, ".linux-x64.")
+	if err != nil {
+		return "", fmt.Errorf("stage mise runtime: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(staging) }()
+	archive := filepath.Join(staging, "mise.tar.gz")
+	if err := downloadRuntimeMise(ctx, client, sourceURL, archive, archiveDigest); err != nil {
+		return "", err
+	}
+	stagedExecutable := filepath.Join(staging, "mise")
+	if err := extractRuntimeMise(archive, stagedExecutable, binaryDigest); err != nil {
+		return "", err
+	}
+	if _, err := validateRuntimeMise(ctx, stagedExecutable, binaryDigest); err != nil {
+		return "", fmt.Errorf("validate downloaded mise executable: %w", err)
+	}
+	if err := os.Remove(archive); err != nil {
+		return "", fmt.Errorf("remove staged mise archive: %w", err)
+	}
+	if _, err := os.Lstat(destinationDir); err == nil {
+		if resolved, validationErr := validateRuntimeMise(ctx, destination, binaryDigest); validationErr == nil {
+			return resolved, nil
+		}
+		invalid := destinationDir + fmt.Sprintf(".invalid-%d", time.Now().UnixNano())
+		if err := os.Rename(destinationDir, invalid); err == nil {
+			_ = os.RemoveAll(invalid)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("inspect mise runtime cache: %w", err)
+	}
+	if err := os.Rename(staging, destinationDir); err != nil {
+		if resolved, validationErr := validateRuntimeMise(ctx, destination, binaryDigest); validationErr == nil {
+			return resolved, nil
+		}
+		return "", fmt.Errorf("publish mise runtime cache: %w", err)
+	}
+	staging = ""
+	resolved, err := validateRuntimeMise(ctx, destination, binaryDigest)
+	if err != nil {
+		return "", fmt.Errorf("validate installed mise executable: %w", err)
+	}
+	return resolved, nil
+}
+
+func downloadRuntimeMise(ctx context.Context, client *http.Client, sourceURL, destination, expectedDigest string) error {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, sourceURL, nil)
+	if err != nil {
+		return fmt.Errorf("create mise download request: %w", err)
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return fmt.Errorf("download mise: %w", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("download mise: unexpected HTTP status %s", response.Status)
+	}
+	file, err := os.OpenFile(destination, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("create mise archive: %w", err)
+	}
+	hash := sha256.New()
+	written, copyErr := io.Copy(io.MultiWriter(file, hash), io.LimitReader(response.Body, runtimeMiseArchiveLimit+1))
+	closeErr := file.Close()
+	if copyErr != nil {
+		return fmt.Errorf("download mise archive: %w", copyErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("write mise archive: %w", closeErr)
+	}
+	if written > runtimeMiseArchiveLimit {
+		return fmt.Errorf("download mise archive: exceeds %d-byte limit", runtimeMiseArchiveLimit)
+	}
+	if hex.EncodeToString(hash.Sum(nil)) != expectedDigest {
+		return fmt.Errorf("mise archive checksum verification failed")
+	}
+	return nil
+}
+
+func extractRuntimeMise(archive, destination, expectedDigest string) error {
+	file, err := os.Open(archive)
+	if err != nil {
+		return fmt.Errorf("open mise archive: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	gzipReader, err := gzip.NewReader(file)
+	if err != nil {
+		return fmt.Errorf("open mise gzip archive: %w", err)
+	}
+	defer func() { _ = gzipReader.Close() }()
+	tarReader := tar.NewReader(gzipReader)
+	found := false
+	for {
+		header, err := tarReader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("read mise archive: %w", err)
+		}
+		if strings.TrimPrefix(filepath.ToSlash(header.Name), "./") != "mise/bin/mise" {
+			continue
+		}
+		if found {
+			return fmt.Errorf("mise archive contains duplicate executable")
+		}
+		if header.Typeflag != tar.TypeReg || header.Size <= 0 || header.Size > runtimeMiseBinaryLimit {
+			return fmt.Errorf("mise archive executable is not a bounded regular file")
+		}
+		output, err := os.OpenFile(destination, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o500)
+		if err != nil {
+			return fmt.Errorf("create mise executable: %w", err)
+		}
+		hash := sha256.New()
+		written, copyErr := io.Copy(io.MultiWriter(output, hash), tarReader)
+		closeErr := output.Close()
+		if copyErr != nil {
+			return fmt.Errorf("extract mise executable: %w", copyErr)
+		}
+		if closeErr != nil {
+			return fmt.Errorf("write mise executable: %w", closeErr)
+		}
+		if written != header.Size || hex.EncodeToString(hash.Sum(nil)) != expectedDigest {
+			return fmt.Errorf("mise executable checksum verification failed")
+		}
+		found = true
+	}
+	if !found {
+		return fmt.Errorf("mise archive does not contain mise/bin/mise")
+	}
+	return nil
+}
+
+func fileSHA256(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = file.Close() }()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
 func prepareMiseDataDir(path string, stderr io.Writer) string {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,13 +1,18 @@
 package cli
 
 import (
+	"archive/tar"
 	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -606,7 +611,7 @@ func setFakeMise(t *testing.T, version string) string {
 }
 
 func TestResolveRuntimeMisePinsRequiredExecutable(t *testing.T) {
-	realMise := setFakeMise(t, buildkitepipeline.RequiredMiseVersion)
+	realMise := setFakeMise(t, buildkitepipeline.MiseVersion)
 	linkRoot := t.TempDir()
 	link := filepath.Join(linkRoot, "mise")
 	if err := os.Symlink(realMise, link); err != nil {
@@ -614,7 +619,7 @@ func TestResolveRuntimeMisePinsRequiredExecutable(t *testing.T) {
 	}
 	t.Setenv("PATH", linkRoot)
 	t.Setenv("MISE_TEST_POISON", "must-not-reach-version-check")
-	got, err := resolveRuntimeMise(context.Background(), "")
+	got, err := resolveRuntimeMise(context.Background(), "", t.TempDir(), io.Discard)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -627,21 +632,50 @@ func TestResolveRuntimeMisePinsRequiredExecutable(t *testing.T) {
 	}
 }
 
-func TestResolveRuntimeMiseRejectsInvalidRuntimeCapability(t *testing.T) {
-	t.Run("missing", func(t *testing.T) {
-		t.Setenv("PATH", t.TempDir())
-		if _, err := resolveRuntimeMise(context.Background(), ""); err == nil || !strings.Contains(err.Error(), "is required on the runtime agent") {
-			t.Fatalf("resolveRuntimeMise() error = %v", err)
-		}
-	})
+func TestResolveRuntimeMiseInstallsManagedCopyWhenNeeded(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		version string
+	}{
+		{name: "missing"},
+		{name: "wrong PATH version", version: "2026.5.13"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			pathRoot := t.TempDir()
+			if test.version != "" {
+				mise := filepath.Join(pathRoot, "mise")
+				if err := os.WriteFile(mise, []byte("#!/bin/sh\nprintf '"+test.version+" linux-x64 (test)\\n'\n"), 0o700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			t.Setenv("PATH", pathRoot)
+			dataDir := t.TempDir()
+			managed := filepath.Join(t.TempDir(), "mise")
+			called := 0
+			installer := func(_ context.Context, gotDataDir string, _ io.Writer) (string, error) {
+				called++
+				if gotDataDir != dataDir {
+					t.Fatalf("installer data dir = %q, want %q", gotDataDir, dataDir)
+				}
+				return managed, nil
+			}
+			got, err := resolveRuntimeMiseWithInstaller(context.Background(), "", dataDir, io.Discard, installer)
+			if err != nil || got != managed || called != 1 {
+				t.Fatalf("resolveRuntimeMiseWithInstaller() = %q, %v; calls = %d", got, err, called)
+			}
+		})
+	}
+}
+
+func TestResolveRuntimeMiseRejectsInvalidExplicitOverride(t *testing.T) {
 	t.Run("configured path must be absolute", func(t *testing.T) {
-		if _, err := resolveRuntimeMise(context.Background(), "mise"); err == nil || !strings.Contains(err.Error(), "must be an absolute path") {
+		if _, err := resolveRuntimeMise(context.Background(), "mise", t.TempDir(), io.Discard); err == nil || !strings.Contains(err.Error(), "must be an absolute path") {
 			t.Fatalf("resolveRuntimeMise() error = %v", err)
 		}
 	})
 	t.Run("wrong version", func(t *testing.T) {
 		mise := setFakeMise(t, "2026.5.13")
-		if _, err := resolveRuntimeMise(context.Background(), mise); err == nil || !strings.Contains(err.Error(), `reported version "2026.5.13", want "2026.5.12"`) {
+		if _, err := resolveRuntimeMise(context.Background(), mise, t.TempDir(), io.Discard); err == nil || !strings.Contains(err.Error(), `reported version "2026.5.13", want "2026.5.12"`) {
 			t.Fatalf("resolveRuntimeMise() error = %v", err)
 		}
 	})
@@ -650,13 +684,86 @@ func TestResolveRuntimeMiseRejectsInvalidRuntimeCapability(t *testing.T) {
 		if err := os.WriteFile(mise, []byte("mise"), 0o600); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := resolveRuntimeMise(context.Background(), mise); err == nil || !strings.Contains(err.Error(), "not an executable regular file") {
+		if _, err := resolveRuntimeMise(context.Background(), mise, t.TempDir(), io.Discard); err == nil || !strings.Contains(err.Error(), "not an executable regular file") {
 			t.Fatalf("resolveRuntimeMise() error = %v", err)
 		}
 	})
 }
 
-func TestRunJobPublishesFailureWhenActionRuntimeMiseIsMissing(t *testing.T) {
+func TestInstallRuntimeMiseDownloadsVerifiesAndReusesCache(t *testing.T) {
+	binary := []byte("#!/bin/sh\nprintf '" + buildkitepipeline.MiseVersion + " linux-x64 (test)\\n'\n")
+	archive := runtimeMiseTestArchive(t, binary)
+	archiveHash := sha256.Sum256(archive)
+	binaryHash := sha256.Sum256(binary)
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		requests++
+		_, _ = response.Write(archive)
+	}))
+	defer server.Close()
+	root := t.TempDir()
+	want := filepath.Join(root, "linux-x64", "mise")
+	for i := 0; i < 2; i++ {
+		got, err := installRuntimeMiseFrom(context.Background(), root, server.Client(), server.URL, hex.EncodeToString(archiveHash[:]), hex.EncodeToString(binaryHash[:]))
+		if err != nil || got != want {
+			t.Fatalf("installRuntimeMiseFrom() = %q, %v", got, err)
+		}
+	}
+	if requests != 1 {
+		t.Fatalf("mise archive requests = %d, want one cache miss", requests)
+	}
+	if got, err := os.ReadFile(want); err != nil || !bytes.Equal(got, binary) {
+		t.Fatalf("installed mise = %q, %v", got, err)
+	}
+}
+
+func TestInstallRuntimeMiseRejectsInvalidArchive(t *testing.T) {
+	binary := []byte("#!/bin/sh\nprintf '" + buildkitepipeline.MiseVersion + " linux-x64 (test)\\n'\n")
+	archive := runtimeMiseTestArchive(t, binary)
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		_, _ = response.Write(archive)
+	}))
+	defer server.Close()
+	binaryHash := sha256.Sum256(binary)
+	if _, err := installRuntimeMiseFrom(context.Background(), t.TempDir(), server.Client(), server.URL, strings.Repeat("0", 64), hex.EncodeToString(binaryHash[:])); err == nil || !strings.Contains(err.Error(), "archive checksum") {
+		t.Fatalf("installRuntimeMiseFrom() error = %v", err)
+	}
+}
+
+func TestInstallRuntimeMiseLiveRelease(t *testing.T) {
+	if os.Getenv("BUILDKITE_GHA_LIVE_REQUIRED") != "1" {
+		t.Skip("set BUILDKITE_GHA_LIVE_REQUIRED=1 to verify the pinned mise release")
+	}
+	got, err := installRuntimeMise(context.Background(), t.TempDir(), io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := validateRuntimeMise(context.Background(), got, runtimeMiseBinaryDigest); err != nil {
+		t.Fatalf("validate installed mise release: %v", err)
+	}
+}
+
+func runtimeMiseTestArchive(t *testing.T, binary []byte) []byte {
+	t.Helper()
+	var out bytes.Buffer
+	gzipWriter := gzip.NewWriter(&out)
+	tarWriter := tar.NewWriter(gzipWriter)
+	if err := tarWriter.WriteHeader(&tar.Header{Name: "mise/bin/mise", Mode: 0o755, Size: int64(len(binary)), Typeflag: tar.TypeReg}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tarWriter.Write(binary); err != nil {
+		t.Fatal(err)
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return out.Bytes()
+}
+
+func TestRunJobPublishesFailureWhenExplicitRuntimeMiseIsInvalid(t *testing.T) {
 	job := cliRunJobPlan()
 	job.Schema = plan.SchemaV3
 	job.Actions = []plan.ActionLock{{
@@ -669,10 +776,10 @@ func TestRunJobPublishesFailureWhenActionRuntimeMiseIsMissing(t *testing.T) {
 	}}
 	planPath, planDigest := writeCLIJobPlan(t, job)
 	setCLIJobIdentity(t, job, planDigest)
-	t.Setenv("PATH", t.TempDir())
+	t.Setenv("BUILDKITE_GHA_MISE", filepath.Join(t.TempDir(), "missing-mise"))
 	runner := &cliCaptureRunner{}
 	var stdout, stderr bytes.Buffer
-	if code := run([]string{"run-job", "--plan", planPath}, &stdout, &stderr, "dev", runner); code != 1 || !strings.Contains(stderr.String(), "prepare action runtime: mise 2026.5.12 is required on the runtime agent") {
+	if code := run([]string{"run-job", "--plan", planPath}, &stdout, &stderr, "dev", runner); code != 1 || !strings.Contains(stderr.String(), "prepare action runtime: resolve runtime mise executable") {
 		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
 	}
 	if manifest := publishedCLIManifest(t, runner, job, planDigest); manifest.Result != "failure" {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -619,7 +619,7 @@ func TestResolveRuntimeMisePinsRequiredExecutable(t *testing.T) {
 	}
 	t.Setenv("PATH", linkRoot)
 	t.Setenv("MISE_TEST_POISON", "must-not-reach-version-check")
-	got, err := resolveRuntimeMise(context.Background(), "", t.TempDir(), io.Discard)
+	got, err := resolveRuntimeMise(context.Background(), "", t.TempDir(), t.TempDir(), io.Discard)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -634,7 +634,7 @@ func TestResolveRuntimeMisePinsRequiredExecutable(t *testing.T) {
 
 func TestResolveRuntimeMiseAcceptsNewerVersion(t *testing.T) {
 	realMise := setFakeMise(t, "2026.8.1")
-	got, err := resolveRuntimeMiseWithInstaller(context.Background(), "", t.TempDir(), io.Discard, func(context.Context, string, io.Writer) (string, error) {
+	got, err := resolveRuntimeMiseWithInstaller(context.Background(), "", t.TempDir(), t.TempDir(), io.Discard, func(context.Context, string, string, io.Writer) (string, error) {
 		return "", errors.New("unexpected managed mise install")
 	})
 	if err != nil || got != realMise {
@@ -648,7 +648,7 @@ func TestResolveRuntimeMiseAcceptsPrefixedVersionOutput(t *testing.T) {
 	if err := os.WriteFile(mise, []byte("#!/bin/sh\nprintf 'mise v2026.8.1 linux-x64 (test)\\n'\n"), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	got, err := resolveRuntimeMise(context.Background(), mise, t.TempDir(), io.Discard)
+	got, err := resolveRuntimeMise(context.Background(), mise, t.TempDir(), t.TempDir(), io.Discard)
 	if err != nil || got != mise {
 		t.Fatalf("resolveRuntimeMise() = %q, %v; want %q", got, err, mise)
 	}
@@ -695,14 +695,18 @@ func TestResolveRuntimeMiseInstallsManagedCopyWhenNeeded(t *testing.T) {
 			dataDir := t.TempDir()
 			managed := filepath.Join(t.TempDir(), "mise")
 			called := 0
-			installer := func(_ context.Context, gotDataDir string, _ io.Writer) (string, error) {
+			privateRuntime := t.TempDir()
+			installer := func(_ context.Context, gotDataDir, gotPrivateRuntime string, _ io.Writer) (string, error) {
 				called++
 				if gotDataDir != dataDir {
 					t.Fatalf("installer data dir = %q, want %q", gotDataDir, dataDir)
 				}
+				if gotPrivateRuntime != privateRuntime {
+					t.Fatalf("installer private runtime = %q, want %q", gotPrivateRuntime, privateRuntime)
+				}
 				return managed, nil
 			}
-			got, err := resolveRuntimeMiseWithInstaller(context.Background(), "", dataDir, io.Discard, installer)
+			got, err := resolveRuntimeMiseWithInstaller(context.Background(), "", dataDir, privateRuntime, io.Discard, installer)
 			if err != nil || got != managed || called != 1 {
 				t.Fatalf("resolveRuntimeMiseWithInstaller() = %q, %v; calls = %d", got, err, called)
 			}
@@ -712,13 +716,13 @@ func TestResolveRuntimeMiseInstallsManagedCopyWhenNeeded(t *testing.T) {
 
 func TestResolveRuntimeMiseRejectsInvalidExplicitOverride(t *testing.T) {
 	t.Run("configured path must be absolute", func(t *testing.T) {
-		if _, err := resolveRuntimeMise(context.Background(), "mise", t.TempDir(), io.Discard); err == nil || !strings.Contains(err.Error(), "must be an absolute path") {
+		if _, err := resolveRuntimeMise(context.Background(), "mise", t.TempDir(), t.TempDir(), io.Discard); err == nil || !strings.Contains(err.Error(), "must be an absolute path") {
 			t.Fatalf("resolveRuntimeMise() error = %v", err)
 		}
 	})
 	t.Run("old version", func(t *testing.T) {
 		mise := setFakeMise(t, "2026.5.11")
-		if _, err := resolveRuntimeMise(context.Background(), mise, t.TempDir(), io.Discard); err == nil || !strings.Contains(err.Error(), `reported version "2026.5.11", want "2026.5.12" or newer`) {
+		if _, err := resolveRuntimeMise(context.Background(), mise, t.TempDir(), t.TempDir(), io.Discard); err == nil || !strings.Contains(err.Error(), `reported version "2026.5.11", want "2026.5.12" or newer`) {
 			t.Fatalf("resolveRuntimeMise() error = %v", err)
 		}
 	})
@@ -727,7 +731,7 @@ func TestResolveRuntimeMiseRejectsInvalidExplicitOverride(t *testing.T) {
 		if err := os.WriteFile(mise, []byte("mise"), 0o600); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := resolveRuntimeMise(context.Background(), mise, t.TempDir(), io.Discard); err == nil || !strings.Contains(err.Error(), "not an executable regular file") {
+		if _, err := resolveRuntimeMise(context.Background(), mise, t.TempDir(), t.TempDir(), io.Discard); err == nil || !strings.Contains(err.Error(), "not an executable regular file") {
 			t.Fatalf("resolveRuntimeMise() error = %v", err)
 		}
 	})
@@ -773,13 +777,73 @@ func TestInstallRuntimeMiseRejectsInvalidArchive(t *testing.T) {
 	}
 }
 
+func TestManagedMiseCacheIsNotExecutedBeforePrivateCopy(t *testing.T) {
+	root := t.TempDir()
+	marker := filepath.Join(t.TempDir(), "executed")
+	binary := []byte("#!/bin/sh\nprintf ran > '" + marker + "'\nprintf '" + buildkitepipeline.MinimumMiseVersion + " linux-x64 (test)\\n'\n")
+	digest := sha256.Sum256(binary)
+	cached := filepath.Join(root, "linux-x64", "mise")
+	if err := os.MkdirAll(filepath.Dir(cached), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cached, binary, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	got, err := installRuntimeMiseFrom(context.Background(), root, nil, "", "", hex.EncodeToString(digest[:]))
+	if err != nil || got != cached {
+		t.Fatalf("installRuntimeMiseFrom() = %q, %v; want cache hit %q", got, err, cached)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("shared cache executable ran during validation: %v", err)
+	}
+	if _, err := pinRuntimeMise(context.Background(), cached, t.TempDir(), hex.EncodeToString(digest[:])); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("private executable did not run during version validation: %v", err)
+	}
+}
+
+func TestPinRuntimeMiseCopiesVerifiedBytesPrivately(t *testing.T) {
+	binary := []byte("#!/bin/sh\nprintf '" + buildkitepipeline.MinimumMiseVersion + " linux-x64 (test)\\n'\n")
+	digest := sha256.Sum256(binary)
+	cached := filepath.Join(t.TempDir(), "mise")
+	if err := os.WriteFile(cached, binary, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	privateRuntime := t.TempDir()
+	got, err := pinRuntimeMise(context.Background(), cached, privateRuntime, hex.EncodeToString(digest[:]))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != filepath.Join(privateRuntime, "mise") {
+		t.Fatalf("pinRuntimeMise() = %q, want private executable", got)
+	}
+	if err := os.Chmod(cached, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cached, []byte("tampered"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if copied, err := os.ReadFile(got); err != nil || !bytes.Equal(copied, binary) {
+		t.Fatalf("private mise changed with cache: %q, %v", copied, err)
+	}
+	if _, err := pinRuntimeMise(context.Background(), cached, t.TempDir(), hex.EncodeToString(digest[:])); err == nil || !strings.Contains(err.Error(), "checksum") {
+		t.Fatalf("pinRuntimeMise() accepted tampered cache: %v", err)
+	}
+}
+
 func TestInstallRuntimeMiseLiveRelease(t *testing.T) {
 	if os.Getenv("BUILDKITE_GHA_LIVE_REQUIRED") != "1" {
 		t.Skip("set BUILDKITE_GHA_LIVE_REQUIRED=1 to verify the pinned mise release")
 	}
-	got, err := installRuntimeMise(context.Background(), t.TempDir(), io.Discard)
+	privateRuntime := t.TempDir()
+	got, err := installRuntimeMise(context.Background(), t.TempDir(), privateRuntime, io.Discard)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if filepath.Dir(got) != privateRuntime {
+		t.Fatalf("installed mise path = %q, want job-private root %q", got, privateRuntime)
 	}
 	if _, err := validateRuntimeMise(context.Background(), got, runtimeMiseBinaryDigest); err != nil {
 		t.Fatalf("validate installed mise release: %v", err)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -822,6 +822,31 @@ func TestManagedMiseCacheIsNotExecutedBeforePrivateCopy(t *testing.T) {
 	}
 }
 
+func TestManagedMiseColdCacheIsNotExecutedBeforePrivateCopy(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "executed")
+	binary := []byte("#!/bin/sh\nprintf ran > '" + marker + "'\nprintf '" + buildkitepipeline.MinimumMiseVersion + " linux-x64 (test)\\n'\n")
+	archive := runtimeMiseTestArchive(t, binary)
+	archiveDigest := sha256.Sum256(archive)
+	binaryDigest := sha256.Sum256(binary)
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		_, _ = response.Write(archive)
+	}))
+	defer server.Close()
+	cached, err := installRuntimeMiseFrom(context.Background(), t.TempDir(), server.Client(), server.URL, hex.EncodeToString(archiveDigest[:]), hex.EncodeToString(binaryDigest[:]))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("shared staging executable ran during validation: %v", err)
+	}
+	if _, err := pinRuntimeMise(context.Background(), cached, t.TempDir(), hex.EncodeToString(binaryDigest[:])); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("private executable did not run during version validation: %v", err)
+	}
+}
+
 func TestPinRuntimeMiseCopiesVerifiedBytesPrivately(t *testing.T) {
 	binary := []byte("#!/bin/sh\nprintf '" + buildkitepipeline.MinimumMiseVersion + " linux-x64 (test)\\n'\n")
 	digest := sha256.Sum256(binary)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2,14 +2,12 @@ package cli
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -18,6 +16,7 @@ import (
 	"testing"
 
 	actionintegration "github.com/buildkite/buildkite-gha/internal/action/integration"
+	buildkitepipeline "github.com/buildkite/buildkite-gha/internal/buildkite"
 	"github.com/buildkite/buildkite-gha/internal/compatibility"
 	"github.com/buildkite/buildkite-gha/internal/compiler"
 	"github.com/buildkite/buildkite-gha/internal/plan"
@@ -438,7 +437,7 @@ func TestRunUploadCompilesConcurrentSmokePipeline(t *testing.T) {
 	}
 }
 
-func TestRunUploadJavaScriptActionTransportsMiseWithoutNode(t *testing.T) {
+func TestRunUploadJavaScriptActionRequiresRuntimeMiseWithoutTransport(t *testing.T) {
 	root := t.TempDir()
 	workflowPath := filepath.Join(root, ".github", "workflows", "action.yml")
 	actionRoot := filepath.Join(root, ".github", "actions", "local")
@@ -459,27 +458,19 @@ func TestRunUploadJavaScriptActionTransportsMiseWithoutNode(t *testing.T) {
 	}
 	t.Setenv("BUILDKITE", "true")
 	t.Setenv("BUILDKITE_STEP_KEY", "action-importer")
-	setFakeMise(t)
 	runner := &cliCaptureRunner{}
 	var stdout, stderr bytes.Buffer
 	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
 	if code := run([]string{"upload", "--event-path", eventPath, "--runtime-queue", "hosted", workflowPath}, &stdout, &stderr, "dev", runner); code != 0 {
 		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
 	}
-	if len(runner.commands) != 4 {
-		t.Fatalf("commands = %d, want distribution, mise, plan, and pipeline", len(runner.commands))
+	if len(runner.commands) != 3 {
+		t.Fatalf("commands = %d, want distribution, plan, and pipeline", len(runner.commands))
 	}
-	miseArtifacts := 0
 	for path := range runner.uploaded {
-		if strings.Contains(path, "/runtimes/") {
-			t.Fatalf("upload contains a Node runtime artifact %q", path)
+		if strings.Contains(path, "/runtimes/") || strings.Contains(path, "/tools/mise/") {
+			t.Fatalf("upload contains a runtime tool artifact %q", path)
 		}
-		if strings.Contains(path, "/tools/mise/") && strings.HasSuffix(path, "/mise.gz") {
-			miseArtifacts++
-		}
-	}
-	if miseArtifacts != 1 {
-		t.Fatalf("uploaded mise artifacts = %d, want 1: %#v", miseArtifacts, runner.uploaded)
 	}
 	var pipeline struct {
 		Steps []struct {
@@ -491,21 +482,21 @@ func TestRunUploadJavaScriptActionTransportsMiseWithoutNode(t *testing.T) {
 			Env map[string]string `yaml:"env"`
 		} `yaml:"steps"`
 	}
-	if err := yaml.Unmarshal(runner.commands[3].stdin, &pipeline); err != nil {
+	if err := yaml.Unmarshal(runner.commands[2].stdin, &pipeline); err != nil {
 		t.Fatalf("parse uploaded pipeline: %v", err)
 	}
 	if len(pipeline.Steps) != 1 {
 		t.Fatalf("uploaded pipeline steps = %#v", pipeline.Steps)
 	}
 	command := pipeline.Steps[0].Command
-	if !strings.Contains(command, ".buildkite-gha/tools/mise/") || !strings.Contains(command, `export PATH="$bootstrap_dir:$PATH"`) || strings.Contains(command, "BUILDKITE_GHA_NODE") || strings.Contains(command, ".buildkite-gha/runtimes") {
-		t.Fatalf("generated pipeline does not use the mise runtime boundary:\n%s", command)
+	if strings.Contains(command, ".buildkite-gha/tools/mise/") || strings.Contains(command, `export PATH="$bootstrap_dir:$PATH"`) || strings.Contains(command, "BUILDKITE_GHA_NODE") || strings.Contains(command, ".buildkite-gha/runtimes") {
+		t.Fatalf("generated pipeline still transports runtime tools:\n%s", command)
 	}
 	step := pipeline.Steps[0]
 	if step.Cache.Name != "buildkite-gha" || len(step.Cache.Paths) != 1 || step.Cache.Paths[0] != ".buildkite-gha/cache-volume" {
 		t.Fatalf("generated action cache = %#v", step.Cache)
 	}
-	if step.Env["BUILDKITE_GHA_MISE_DATA_DIR"] != "/cache/bkcache/buildkite-gha/mise/2026.5.12" {
+	if step.Env["BUILDKITE_GHA_MISE_DATA_DIR"] != buildkitepipeline.MiseDataDir() {
 		t.Fatalf("generated mise data directory = %q", step.Env["BUILDKITE_GHA_MISE_DATA_DIR"])
 	}
 }
@@ -570,7 +561,6 @@ func TestRunUploadAllowsCompilerVerifiedLocalDockerfileAction(t *testing.T) {
 	}
 	t.Setenv("BUILDKITE", "true")
 	t.Setenv("BUILDKITE_STEP_KEY", "docker-importer")
-	setFakeMise(t)
 	runner := &cliCaptureRunner{}
 	var stdout, stderr bytes.Buffer
 	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
@@ -603,52 +593,90 @@ func writeFakeNode(t *testing.T, root string, major int) string {
 	return path
 }
 
-func setFakeMise(t *testing.T) {
+func setFakeMise(t *testing.T, version string) string {
 	t.Helper()
 	root := t.TempDir()
 	mise := filepath.Join(root, "mise")
-	if err := os.WriteFile(mise, []byte("#!/bin/sh\nprintf '2026.5.12 linux-x64 (test)\\n'\n"), 0o700); err != nil {
+	script := "#!/bin/sh\nif [ -n \"${MISE_TEST_POISON:-}\" ]; then printf 'poisoned\\n'; else printf '" + version + " linux-x64 (test)\\n'; fi\n"
+	if err := os.WriteFile(mise, []byte(script), 0o700); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", root+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return mise
 }
 
-func TestManagedMiseArtifactRequiresPinnedVersionAndIsDeterministic(t *testing.T) {
-	setFakeMise(t)
-	first, err := managedMiseArtifact(context.Background())
+func TestResolveRuntimeMisePinsRequiredExecutable(t *testing.T) {
+	realMise := setFakeMise(t, buildkitepipeline.RequiredMiseVersion)
+	linkRoot := t.TempDir()
+	link := filepath.Join(linkRoot, "mise")
+	if err := os.Symlink(realMise, link); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", linkRoot)
+	t.Setenv("MISE_TEST_POISON", "must-not-reach-version-check")
+	got, err := resolveRuntimeMise(context.Background(), "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	second, err := managedMiseArtifact(context.Background())
+	want, err := filepath.EvalSymlinks(realMise)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if first.Path != second.Path || first.Digest != second.Digest || !bytes.Equal(first.Contents, second.Contents) {
-		t.Fatalf("mise artifacts differ: first = %#v, second = %#v", first, second)
+	if got != want || !filepath.IsAbs(got) {
+		t.Fatalf("resolveRuntimeMise() = %q, want pinned %q", got, want)
 	}
-	reader, err := gzip.NewReader(bytes.NewReader(first.Contents))
-	if err != nil {
-		t.Fatal(err)
-	}
-	uncompressed, err := io.ReadAll(reader)
-	if closeErr := reader.Close(); err == nil {
-		err = closeErr
-	}
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Contains(uncompressed, []byte(managedMiseVersion)) {
-		t.Fatalf("mise artifact does not contain pinned executable: %q", uncompressed)
-	}
+}
 
-	root := t.TempDir()
-	wrong := filepath.Join(root, "mise")
-	if err := os.WriteFile(wrong, []byte("#!/bin/sh\nprintf '2026.5.13 linux-x64 (test)\\n'\n"), 0o700); err != nil {
-		t.Fatal(err)
+func TestResolveRuntimeMiseRejectsInvalidRuntimeCapability(t *testing.T) {
+	t.Run("missing", func(t *testing.T) {
+		t.Setenv("PATH", t.TempDir())
+		if _, err := resolveRuntimeMise(context.Background(), ""); err == nil || !strings.Contains(err.Error(), "is required on the runtime agent") {
+			t.Fatalf("resolveRuntimeMise() error = %v", err)
+		}
+	})
+	t.Run("configured path must be absolute", func(t *testing.T) {
+		if _, err := resolveRuntimeMise(context.Background(), "mise"); err == nil || !strings.Contains(err.Error(), "must be an absolute path") {
+			t.Fatalf("resolveRuntimeMise() error = %v", err)
+		}
+	})
+	t.Run("wrong version", func(t *testing.T) {
+		mise := setFakeMise(t, "2026.5.13")
+		if _, err := resolveRuntimeMise(context.Background(), mise); err == nil || !strings.Contains(err.Error(), `reported version "2026.5.13", want "2026.5.12"`) {
+			t.Fatalf("resolveRuntimeMise() error = %v", err)
+		}
+	})
+	t.Run("not executable", func(t *testing.T) {
+		mise := filepath.Join(t.TempDir(), "mise")
+		if err := os.WriteFile(mise, []byte("mise"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := resolveRuntimeMise(context.Background(), mise); err == nil || !strings.Contains(err.Error(), "not an executable regular file") {
+			t.Fatalf("resolveRuntimeMise() error = %v", err)
+		}
+	})
+}
+
+func TestRunJobPublishesFailureWhenActionRuntimeMiseIsMissing(t *testing.T) {
+	job := cliRunJobPlan()
+	job.Schema = plan.SchemaV3
+	job.Actions = []plan.ActionLock{{
+		ID: "a-0000000000000001", Source: "workspace", Path: "actions/build",
+		SourceDigest: "sha256:" + strings.Repeat("a", 64),
+	}}
+	job.Steps = []plan.Step{{
+		ID: "local", Kind: "uses", Uses: "./actions/build",
+		Action: &plan.ActionSelector{Lock: "a-0000000000000001"},
+	}}
+	planPath, planDigest := writeCLIJobPlan(t, job)
+	setCLIJobIdentity(t, job, planDigest)
+	t.Setenv("PATH", t.TempDir())
+	runner := &cliCaptureRunner{}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"run-job", "--plan", planPath}, &stdout, &stderr, "dev", runner); code != 1 || !strings.Contains(stderr.String(), "prepare action runtime: mise 2026.5.12 is required on the runtime agent") {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
 	}
-	t.Setenv("PATH", root+string(os.PathListSeparator)+os.Getenv("PATH"))
-	if _, err := managedMiseArtifact(context.Background()); err == nil || !strings.Contains(err.Error(), `reported version "2026.5.13", want "2026.5.12"`) {
-		t.Fatalf("managedMiseArtifact() error = %v", err)
+	if manifest := publishedCLIManifest(t, runner, job, planDigest); manifest.Result != "failure" {
+		t.Fatalf("published result = %q, want failure", manifest.Result)
 	}
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -777,6 +777,24 @@ func TestInstallRuntimeMiseRejectsInvalidArchive(t *testing.T) {
 	}
 }
 
+func TestValidateRuntimeMiseRejectsOversizedCacheEntry(t *testing.T) {
+	cached := filepath.Join(t.TempDir(), "mise")
+	file, err := os.OpenFile(cached, os.O_CREATE|os.O_WRONLY, 0o500)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Truncate(runtimeMiseBinaryLimit + 1); err != nil {
+		_ = file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := validateRuntimeMiseFile(context.Background(), cached, strings.Repeat("0", 64)); err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("validateRuntimeMiseFile() error = %v, want size rejection", err)
+	}
+}
+
 func TestManagedMiseCacheIsNotExecutedBeforePrivateCopy(t *testing.T) {
 	root := t.TempDir()
 	marker := filepath.Join(t.TempDir(), "executed")

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -894,6 +894,34 @@ func TestRunJobPublishesFailureWhenExplicitRuntimeMiseIsInvalid(t *testing.T) {
 	}
 }
 
+func TestRunJobSkipsActionJobBeforePreparingRuntimeMise(t *testing.T) {
+	job := cliRunJobPlan()
+	job.Schema = plan.SchemaV3
+	job.Condition = "${{ false }}"
+	job.Actions = []plan.ActionLock{{
+		ID: "a-0000000000000001", Source: "workspace", Path: "actions/build",
+		SourceDigest: "sha256:" + strings.Repeat("a", 64),
+	}}
+	job.Steps = []plan.Step{{
+		ID: "local", Kind: "uses", Uses: "./actions/build",
+		Action: &plan.ActionSelector{Lock: "a-0000000000000001"},
+	}}
+	planPath, planDigest := writeCLIJobPlan(t, job)
+	setCLIJobIdentity(t, job, planDigest)
+	t.Setenv("BUILDKITE_GHA_MISE", filepath.Join(t.TempDir(), "missing-mise"))
+	runner := &cliCaptureRunner{}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"run-job", "--plan", planPath}, &stdout, &stderr, "dev", runner); code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	if strings.Contains(stderr.String(), "prepare action runtime") {
+		t.Fatalf("skipped job prepared action runtime: %q", stderr.String())
+	}
+	if manifest := publishedCLIManifest(t, runner, job, planDigest); manifest.Result != "skipped" {
+		t.Fatalf("published result = %q, want skipped", manifest.Result)
+	}
+}
+
 func TestRunUploadFailsClosedBeforePipeline(t *testing.T) {
 	workflowPath := filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "shell.yml")
 	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -611,7 +611,7 @@ func setFakeMise(t *testing.T, version string) string {
 }
 
 func TestResolveRuntimeMisePinsRequiredExecutable(t *testing.T) {
-	realMise := setFakeMise(t, buildkitepipeline.MiseVersion)
+	realMise := setFakeMise(t, buildkitepipeline.MinimumMiseVersion)
 	linkRoot := t.TempDir()
 	link := filepath.Join(linkRoot, "mise")
 	if err := os.Symlink(realMise, link); err != nil {
@@ -632,13 +632,56 @@ func TestResolveRuntimeMisePinsRequiredExecutable(t *testing.T) {
 	}
 }
 
+func TestResolveRuntimeMiseAcceptsNewerVersion(t *testing.T) {
+	realMise := setFakeMise(t, "2026.8.1")
+	got, err := resolveRuntimeMiseWithInstaller(context.Background(), "", t.TempDir(), io.Discard, func(context.Context, string, io.Writer) (string, error) {
+		return "", errors.New("unexpected managed mise install")
+	})
+	if err != nil || got != realMise {
+		t.Fatalf("resolveRuntimeMiseWithInstaller() = %q, %v; want %q", got, err, realMise)
+	}
+}
+
+func TestResolveRuntimeMiseAcceptsPrefixedVersionOutput(t *testing.T) {
+	root := t.TempDir()
+	mise := filepath.Join(root, "mise")
+	if err := os.WriteFile(mise, []byte("#!/bin/sh\nprintf 'mise v2026.8.1 linux-x64 (test)\\n'\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	got, err := resolveRuntimeMise(context.Background(), mise, t.TempDir(), io.Discard)
+	if err != nil || got != mise {
+		t.Fatalf("resolveRuntimeMise() = %q, %v; want %q", got, err, mise)
+	}
+}
+
+func TestMiseVersionAtLeast(t *testing.T) {
+	for _, test := range []struct {
+		actual string
+		want   bool
+	}{
+		{actual: "2026.5.12", want: true},
+		{actual: "v2026.5.12", want: true},
+		{actual: "2026.5.13", want: true},
+		{actual: "2026.8.1", want: true},
+		{actual: "2027.1.1", want: true},
+		{actual: "2026.5.11"},
+		{actual: "2025.12.31"},
+		{actual: "2026.5"},
+		{actual: "latest"},
+	} {
+		if got := miseVersionAtLeast(test.actual, buildkitepipeline.MinimumMiseVersion); got != test.want {
+			t.Errorf("miseVersionAtLeast(%q, %q) = %t, want %t", test.actual, buildkitepipeline.MinimumMiseVersion, got, test.want)
+		}
+	}
+}
+
 func TestResolveRuntimeMiseInstallsManagedCopyWhenNeeded(t *testing.T) {
 	for _, test := range []struct {
 		name    string
 		version string
 	}{
 		{name: "missing"},
-		{name: "wrong PATH version", version: "2026.5.13"},
+		{name: "old PATH version", version: "2026.5.11"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			pathRoot := t.TempDir()
@@ -673,9 +716,9 @@ func TestResolveRuntimeMiseRejectsInvalidExplicitOverride(t *testing.T) {
 			t.Fatalf("resolveRuntimeMise() error = %v", err)
 		}
 	})
-	t.Run("wrong version", func(t *testing.T) {
-		mise := setFakeMise(t, "2026.5.13")
-		if _, err := resolveRuntimeMise(context.Background(), mise, t.TempDir(), io.Discard); err == nil || !strings.Contains(err.Error(), `reported version "2026.5.13", want "2026.5.12"`) {
+	t.Run("old version", func(t *testing.T) {
+		mise := setFakeMise(t, "2026.5.11")
+		if _, err := resolveRuntimeMise(context.Background(), mise, t.TempDir(), io.Discard); err == nil || !strings.Contains(err.Error(), `reported version "2026.5.11", want "2026.5.12" or newer`) {
 			t.Fatalf("resolveRuntimeMise() error = %v", err)
 		}
 	})
@@ -691,7 +734,7 @@ func TestResolveRuntimeMiseRejectsInvalidExplicitOverride(t *testing.T) {
 }
 
 func TestInstallRuntimeMiseDownloadsVerifiesAndReusesCache(t *testing.T) {
-	binary := []byte("#!/bin/sh\nprintf '" + buildkitepipeline.MiseVersion + " linux-x64 (test)\\n'\n")
+	binary := []byte("#!/bin/sh\nprintf '" + buildkitepipeline.MinimumMiseVersion + " linux-x64 (test)\\n'\n")
 	archive := runtimeMiseTestArchive(t, binary)
 	archiveHash := sha256.Sum256(archive)
 	binaryHash := sha256.Sum256(binary)
@@ -718,7 +761,7 @@ func TestInstallRuntimeMiseDownloadsVerifiesAndReusesCache(t *testing.T) {
 }
 
 func TestInstallRuntimeMiseRejectsInvalidArchive(t *testing.T) {
-	binary := []byte("#!/bin/sh\nprintf '" + buildkitepipeline.MiseVersion + " linux-x64 (test)\\n'\n")
+	binary := []byte("#!/bin/sh\nprintf '" + buildkitepipeline.MinimumMiseVersion + " linux-x64 (test)\\n'\n")
 	archive := runtimeMiseTestArchive(t, binary)
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
 		_, _ = response.Write(archive)

--- a/internal/compiler/bundle.go
+++ b/internal/compiler/bundle.go
@@ -99,8 +99,6 @@ func CompileBundleContext(ctx context.Context, path string, source, eventSource 
 	pipeline, err := buildkitepipeline.Emit(buildkitepipeline.Pipeline{
 		CompilerStep:       compilerStep,
 		DistributionDigest: compilerDistributionDigest,
-		MiseDigest:         options.MiseDigest,
-		MiseVersion:        options.MiseVersion,
 		GroupLabel:         options.GroupLabel,
 		Jobs:               jobs,
 	})

--- a/internal/compiler/config.go
+++ b/internal/compiler/config.go
@@ -49,10 +49,6 @@ type Options struct {
 	// actions/checkout adapter steps. It does not expose a workflow token or
 	// alter the permissions fixed by the runtime credential provider.
 	PrivateCheckout bool
-	// MiseDigest is runtime transport policy only. It is emitted into generated
-	// pipeline bootstrap commands and never changes compiler IR or plans.
-	MiseDigest  string
-	MiseVersion string
 	// GroupLabel merges generated jobs into the Buildkite group containing the
 	// importer. It affects pipeline presentation only, not compiler IR or plans.
 	GroupLabel string

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -180,6 +180,12 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		runCtx, cancelJob = context.WithTimeout(ctx, durationMinutes(job.TimeoutMinutes))
 	}
 	defer cancelJob()
+	if r.Mise == "" && r.ResolveMise != nil {
+		r.Mise, err = r.ResolveMise(runCtx)
+		if err != nil {
+			return jobResult, err
+		}
+	}
 
 	secrets, err := r.resolveSecrets(runCtx, processor, job.RequiredSecrets)
 	if err != nil {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -898,15 +898,10 @@ func (r Runner) discoverNode(ctx context.Context, major int, explicit string) (s
 	if tool == "" {
 		return "", fmt.Errorf("unsupported Node runtime major %d", major)
 	}
-	mise := r.Mise
-	var err error
-	if mise == "" {
-		mise, err = exec.LookPath("mise")
-		if err != nil {
-			return "", fmt.Errorf("mise is required to run JavaScript actions: %w", err)
-		}
+	if r.Mise == "" {
+		return "", fmt.Errorf("mise is required to run JavaScript actions; no pinned runtime path was configured")
 	}
-	return r.installAndVerifyMiseNode(ctx, major, mise)
+	return r.installAndVerifyMiseNode(ctx, major, r.Mise)
 }
 
 func (r Runner) resolveMiseNodePath(ctx context.Context, major int) (string, error) {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -52,6 +52,7 @@ type Runner struct {
 	Node24            string
 	ManagedNodeRoot   string
 	Mise              string
+	ResolveMise       func(context.Context) (string, error)
 	MiseDataDir       string
 	Docker            string
 	RuntimeExecutable string


### PR DESCRIPTION
## Summary

- stop uploading and downloading the importer-side `mise.gz` artifact
- for action jobs, reuse compatible mise 2026.5.12 or newer from an explicit absolute `BUILDKITE_GHA_MISE` or trusted `PATH`
- when no compatible ambient copy exists, download pinned mise 2026.5.12 into the automatically attached hosted cache and verify embedded archive and executable SHA-256 digests
- preserve exact Node digest verification and keep shell-only jobs independent of mise

## Why

The example builds currently transport a roughly 31.6 MB mise artifact before any workflow job can run. mise is runtime tooling, not build data, so carrying it through Buildkite artifact transport adds latency and internal UI noise.

The static CLI now owns the cold-cache fallback inside the generated action job. Unlike the earlier implementation, it does not require exact equality with the fallback release: newer compatible mise installations are reused. We retain a pinned, tested fallback rather than the mise plugin's mutable `latest` endpoint so a given buildkite-gha release remains reproducible.

Cache hits perform no network work. Managed cache bytes are copied into a job-private directory and reverified there before execution, so a shared writable cache never becomes executable authority. Generated jobs still download the exact content-addressed `buildkite-gha` distribution and plan; expected digests remain embedded in generated job definitions rather than mutable Buildkite metadata.

## Runtime behavior

Before workflow code runs, an action-bearing job:

1. validates an explicit absolute `BUILDKITE_GHA_MISE`, requiring version 2026.5.12 or newer and failing rather than silently overriding operator intent;
2. otherwise reuses compatible mise from trusted `PATH`;
3. otherwise downloads pinned mise 2026.5.12 over HTTPS into a private staging directory, verifies the archive and executable SHA-256 digests, and atomically publishes it to the hosted runtime cache.

Concurrent cold-cache jobs converge on verified cache bytes; each job executes only its reverified private copy. `MISE_*` variables are stripped during version validation. Shell-only jobs do not attach the runtime cache or perform mise setup.

## Validation

- `mise run check`
- `go test -race ./internal/cli ./internal/runtime ./internal/buildkite ./internal/compiler`
- live download, extraction, digest, and version proof against the real mise 2026.5.12 release: pass
- focused tests for newer and prefixed versions, old-version fallback, cache reuse, checksum rejection, strict explicit overrides, symlink pinning, action-only gating, no artifact transport, and terminal failure-result publication
- `git diff --check`

## Rollout

Release this compatible CLI first, then update the default CLI version and complete the companion plugin change: https://github.com/buildkite-plugins/github-actions-buildkite-plugin/pull/9

The examples do not require a hosted-image or `saas-iac` change: buildkite-gha handles the verified cache-miss install itself.