### PR TITLE
Fix Darwin canonical path assertions

### DIFF
--- a/internal/runtime/checkout_test.go
+++ b/internal/runtime/checkout_test.go
@@ -315,7 +315,7 @@ printf '%s\n' "$*" >> ` + shellTestQuote(trustedLog) + `
 	if err := os.Symlink(trustedAgent, lookupAgent); err != nil {
 		t.Fatal(err)
 	}
-	poisonDir := t.TempDir()
+	poisonDir := canonicalTempDir(t)
 	poisonGitMarker := filepath.Join(t.TempDir(), "poison-git-ran")
 	poisonGit := filepath.Join(poisonDir, "git")
 	if err := os.WriteFile(poisonGit, []byte("#!/bin/sh\ntouch "+shellTestQuote(poisonGitMarker)+"\nexit 97\n"), 0o700); err != nil {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -911,7 +911,7 @@ func TestEnvironmentSecretsCannotReadAmbientAgentVariables(t *testing.T) {
 }
 
 func TestResolveAgentRedactorBeforeWorkflowPinsPointerWithoutMutatingCaller(t *testing.T) {
-	realDir := t.TempDir()
+	realDir := canonicalTempDir(t)
 	realAgent := filepath.Join(realDir, "buildkite-agent")
 	writeFixtureFile(t, realDir, "buildkite-agent", "#!/bin/sh\nexit 0\n")
 	if err := os.Chmod(realAgent, 0o700); err != nil {


### PR DESCRIPTION
## Summary

- canonicalize temporary fixture directories used as expected executable targets
- preserve the executable-pinning assertions across macOS `/var` → `/private/var` resolution

## Testing

- `mise exec -- go test ./internal/runtime -run 'TestPrivateCheckoutPinsGitBeforeActionPreHooks|TestResolveAgentRedactorBeforeWorkflowPinsPointerWithoutMutatingCaller' -count=1`\n- `mise exec -- go test ./internal/runtime -count=1`