### PR TITLE
feat: default to official cache endpoint

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -77,9 +77,6 @@ steps:
       set -euo pipefail
       commit="$${DEMO_COMMIT:?DEMO_COMMIT is required}"
       [[ "$$commit" =~ ^[0-9a-f]{40}$$ ]]
-      if [[ "$${DEMO_CACHE:-}" == "1" ]]; then
-        : "$${BUILDKITE_GHA_CACHE_URL:?BUILDKITE_GHA_CACHE_URL is required when DEMO_CACHE=1}"
-      fi
       scripts/phase-0-shell-oracle-checkout "$$commit"
       test "$${BUILDKITE_COMMIT:?BUILDKITE_COMMIT is required}" = "$$commit"
       test -z "$$(git status --porcelain --untracked-files=all)"

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ The plugin path currently supports:
 - public, credential-free checkout of the event repository at its exact commit;
 - bounded native upload and exact-name download for the audited artifact v4
   commits; and
-- the audited `actions/cache` v6.1.0 commit through a configured compatible
-  cache-v2 Results service.
+- the audited `actions/cache` v6.1.0 commit through the official Buildkite
+  cache-v2 Results service, with an optional operator override.
 
 It does **not** currently support:
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -49,7 +49,7 @@ provide.
 | Workflow commands | Supported subset | `::add-mask`, `::stop-commands`, `::warning`, `::error`, `::group`, and `::endgroup` are supported. Groups become collapsed Buildkite log sections; because Buildkite sections are linear, nested or overlapping Actions groups flatten into successive sections. Warnings and errors retain title/file/range metadata and publish under separate, stable job-scoped contexts without changing step or job conclusions. Each aggregate is bounded to 1 MiB and requires Buildkite Agent v3.112 or newer for publication. Debug and matcher presentation commands are consumed without runner debug or matcher behavior. `::notice`, command echo control, and other legacy commands are not supported. |
 | `actions/upload-artifact` | Narrow support | The audited v4 commit supports bounded literal files/directories, ZIP compression levels, hidden-file selection, exact no-file behavior, and native Buildkite publication. See the explicit limits below. |
 | `actions/download-artifact` | Narrow support | The audited v4.3.0 commit supports one exact literal name from verified direct `needs`, extracting directly to a clean workspace-relative path. |
-| `actions/cache` | Narrow v6 support | Only the audited v6.1.0 commit is admitted. It runs the stock ESM cache-v2 client with job-bound Buildkite credentials and requires an operator-configured compatible Results service. The predecessor fixture's exact miss/save/dependent-hit lifecycle passed in Buildkite build 303. |
+| `actions/cache` | Narrow v6 support | Only the audited v6.1.0 commit is admitted. It runs the stock ESM cache-v2 client with job-bound Buildkite credentials and defaults to the official Buildkite Results service, with an optional operator override. The predecessor fixture's exact miss/save/dependent-hit lifecycle passed in Buildkite build 303. |
 | Job and service containers | Not admitted | Implemented and runtime-proven, but still outside production `hosted-tokenless` policy. |
 | `docker://` actions | Not supported | Private images, credentials, arbitrary options, volumes, and privileged containers are also rejected. |
 | Other cache clients and broad artifact modes | Not supported | `actions/cache` v4/v5 and unrecognized v6 commits, artifact merge, IDs, patterns, all-artifact, cross-repository, and cross-run modes fail admission or input validation. |
@@ -202,16 +202,17 @@ service values. Cache subprocesses use the fixed
 a credential appears in a phase's command-file effects, those effects are
 discarded and the phase fails.
 
-Operators must set `BUILDKITE_GHA_CACHE_URL` to the origin-only URL of the
-compatible Results service; a non-root path is rejected because the stock
+The runtime uses the official `https://ghacs.buildkite.com/` Results service by
+default. Operators can set `BUILDKITE_GHA_CACHE_URL` to override it with another
+compatible origin-only URL; a non-root path is rejected because the stock
 cache-v2 client uses root-relative Twirp endpoints. The Buildkite organization
-must also have GHAC token minting enabled, and jobs must be able to reach both
-that service and the Agent API.
+must have GHAC token minting enabled, and jobs must be able to reach both the
+Results service and the Agent API.
 The service-issued token scopes cache access to the current organization and
 pipeline, grants writes only for an authorized ref, and limits cross-repository
-pull requests to the read-only default-branch scope. Missing configuration,
-disabled minting, malformed responses, redirects, or failed redaction stop the
-cache action before its JavaScript executes.
+pull requests to the read-only default-branch scope. Disabled minting, malformed
+responses, redirects, unsafe override configuration, or failed redaction stop
+the cache action before its JavaScript executes.
 
 This implemented and admitted contract has hosted runtime evidence. The
 then-combined advanced migration POC in [Buildkite build 303](https://buildkite.com/buildkite/buildkite-gha/builds/303)

--- a/docs/development.md
+++ b/docs/development.md
@@ -222,15 +222,14 @@ bk build create --pipeline buildkite/buildkite-gha \
 
 This service-free lane runs the basic, artifact, root-level JavaScript/composite
 action, and advanced workflows, then a native terminal step. Add the cache
-extension only for an organization with GHAC token minting enabled and an
-explicitly configured compatible origin:
+extension only for an organization with GHAC token minting enabled; the runtime
+uses the official Buildkite Results service by default:
 
 ```sh
 bk build create --pipeline buildkite/buildkite-gha \
   --branch "$(git branch --show-current)" --commit "$commit" \
   --env DEMO_SUITE=plugin --env DEMO_COMMIT="$commit" \
-  --env DEMO_CACHE=1 \
-  --env BUILDKITE_GHA_CACHE_URL=<cache-v2-results-origin> --yes
+  --env DEMO_CACHE=1 --yes
 ```
 
 The first cache run for the release commit must show a producer miss,

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -1899,10 +1899,10 @@ the narrowest available boundary:
 - step summaries and annotations.
 
 Prefer documented Buildkite storage and Agent interfaces. If an action toolkit
-requires an HTTP protocol, use an explicitly configured compatible service or
-provide a well-defined adapter rather than proxying GitHub's private service.
-Cache credentials authorize storage access only; they are distinct from the
-provider-feature grants below.
+requires an HTTP protocol, use the official compatible service by default with
+an explicit operator override, or provide a well-defined adapter rather than
+proxying GitHub's private service. Cache credentials authorize storage access
+only; they are distinct from the provider-feature grants below.
 
 Protected provider features use the supporting control-plane service:
 

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -385,8 +385,6 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 	for _, required := range []string{
 		`commit="$${DEMO_COMMIT:?DEMO_COMMIT is required}"`,
 		`[[ "$$commit" =~ ^[0-9a-f]{40}$$ ]]`,
-		`[[ "$${DEMO_CACHE:-}" == "1" ]]`,
-		`$${BUILDKITE_GHA_CACHE_URL:?BUILDKITE_GHA_CACHE_URL is required when DEMO_CACHE=1}`,
 		`scripts/phase-0-shell-oracle-checkout "$$commit"`,
 		`test "$${BUILDKITE_COMMIT:?BUILDKITE_COMMIT is required}" = "$$commit"`,
 		`git status --porcelain --untracked-files=all`,
@@ -395,6 +393,9 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 		if !strings.Contains(pluginDemo.command, required) {
 			t.Fatalf("released plugin demo loader lacks %q:\n%s", required, pluginDemo.command)
 		}
+	}
+	if strings.Contains(pluginDemo.command, "BUILDKITE_GHA_CACHE_URL") {
+		t.Fatalf("released plugin demo loader still requires a cache Results URL:\n%s", pluginDemo.command)
 	}
 	if got := steps["publish-release"]; got.command != "mise exec -- scripts/ci-buildkite-release" || got.condition != "build.tag != null" {
 		t.Fatalf("release publisher = %#v", got)

--- a/internal/runtime/cache_service.go
+++ b/internal/runtime/cache_service.go
@@ -16,6 +16,7 @@ import (
 const (
 	cacheCredentialResponseLimit = 64 << 10
 	cacheActionToolPath          = "/usr/local/bin:/usr/bin:/bin"
+	defaultCacheResultsURL       = "https://ghacs.buildkite.com/"
 )
 
 var cacheRuntimeTokenPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$`)
@@ -59,6 +60,9 @@ func NewAgentCacheCredentials(config AgentCacheConfig) (*AgentCacheCredentials, 
 	}
 	if config.JobToken == "" || strings.ContainsAny(config.JobToken, "\r\n") {
 		return nil, fmt.Errorf("cache Agent job token is required")
+	}
+	if config.ResultsURL == "" {
+		config.ResultsURL = defaultCacheResultsURL
 	}
 	resultsURL, err := normalizeCacheResultsURL(config.ResultsURL)
 	if err != nil {

--- a/internal/runtime/cache_service_test.go
+++ b/internal/runtime/cache_service_test.go
@@ -62,6 +62,18 @@ func TestAgentCacheCredentialsMintsBoundedJobCredential(t *testing.T) {
 	}
 }
 
+func TestAgentCacheCredentialsDefaultsOfficialResultsService(t *testing.T) {
+	provider, err := NewAgentCacheCredentials(AgentCacheConfig{
+		Endpoint: "https://agent.example/v3", JobID: testCacheJobID, JobToken: "job-token",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if provider.resultsURL != defaultCacheResultsURL {
+		t.Fatalf("default Results URL = %q, want %q", provider.resultsURL, defaultCacheResultsURL)
+	}
+}
+
 func TestAgentCacheCredentialsRejectsUnsafeConfiguration(t *testing.T) {
 	valid := AgentCacheConfig{
 		Endpoint: "https://agent.example/v3", JobID: testCacheJobID,
@@ -74,7 +86,6 @@ func TestAgentCacheCredentialsRejectsUnsafeConfiguration(t *testing.T) {
 		"invalid job ID":         func(c *AgentCacheConfig) { c.JobID = "../other" },
 		"missing job token":      func(c *AgentCacheConfig) { c.JobToken = "" },
 		"job token header split": func(c *AgentCacheConfig) { c.JobToken = "secret\r\nOther: value" },
-		"missing results URL":    func(c *AgentCacheConfig) { c.ResultsURL = "" },
 		"results credentials":    func(c *AgentCacheConfig) { c.ResultsURL = "https://user@cache.example/v2" },
 		"results path":           func(c *AgentCacheConfig) { c.ResultsURL += "/v2" },
 		"results query":          func(c *AgentCacheConfig) { c.ResultsURL += "?token=value" },


### PR DESCRIPTION
## Summary

- default cache-v2 Results traffic to `https://ghacs.buildkite.com/`
- retain `BUILDKITE_GHA_CACHE_URL` as an explicit validated operator override
- remove the cache endpoint requirement from the released-plugin demo and update user-facing documentation

## Testing

- `mise run check`