### PR TITLE
Add native scoped GitHub workflow tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ The plugin path currently supports:
 - timeouts, `continue-on-error`, masking, summaries, warning/error annotations,
   and pre/main/post actions;
 - public, credential-free checkout of the event repository at its exact commit;
+- short-lived `secrets.GITHUB_TOKEN` values scoped to explicit workflow or job
+  `permissions` for the event repository;
 - bounded native upload and exact-name download for the audited artifact v4
   commits; and
 - the audited `actions/cache` v6.1.0 commit through a configured compatible
@@ -114,7 +116,8 @@ It does **not** currently support:
 
 - private actions or general private-source access; direct upload has only the
   explicit pipeline-repository checkout described in the compatibility guide;
-- workflow secrets, `GITHUB_TOKEN`, GitHub-compatible OIDC, or protected queues;
+- workflow secrets other than the scoped `GITHUB_TOKEN`, `github.token`,
+  GitHub-compatible OIDC, or protected queues;
 - `actions/cache` v4/v5 or unrecognized v6 commits, artifact
   merge/all/pattern/ID modes, or cross-run downloads;
 - runtime condition access to the `github.event` payload;

--- a/docs/architecture/0003-protected-capability-control-plane.md
+++ b/docs/architecture/0003-protected-capability-control-plane.md
@@ -202,7 +202,7 @@ plan. Rotation overlaps old and new public keys for the maximum grant lifetime;
 emergency revocation takes precedence over a still-published key. Private keys
 remain in the platform signing boundary.
 
-### Narrow job-bound private-checkout exception
+### Narrow job-bound GitHub token exceptions
 
 Buildkite's Agent API can mint a GitHub installation token for the exact current
 job, exact pipeline repository, and caller-requested permission set. The server
@@ -249,11 +249,30 @@ artifacts. Redirects, unknown response fields, trailing data, oversized bodies,
 invalid tokens, disabled service responses, and unavailable/rate-limited
 responses fail closed with bounded diagnostics.
 
-This exception does not establish authenticated provider event or fork
-provenance and therefore does not authorize writes, arbitrary workflow
-`permissions:`, private actions or reusable workflows, `GITHUB_TOKEN`,
-`github.token`, secrets, environments, or OIDC. Those features still require
-the general control-plane decision in this ADR.
+A second bounded integration uses the same endpoint for a synthetic
+`secrets.GITHUB_TOKEN`. A workflow must declare an explicit, non-empty
+permission mapping and statically reference that exact secret. The compiler
+emits the API-normalized permission map into a v6 plan, adds
+`provider-token-write`, and records same-process `workflow-permissions`
+provenance. Upload admission accepts only that exact compiler provenance. A
+serialized plan cannot self-authorize the capability.
+
+The runtime requests one token for the plan's exact event repository and exact
+permission map. It validates both independently, masks the returned token, and
+requires Agent redaction registration before making the synthetic secret
+available to expression evaluation. Job-level permissions replace workflow
+defaults; flattened local reusable workflows can only narrow caller authority.
+Permission aliases, implicit defaults, empty grants, and `id-token` fail
+closed. `github.token` and ambient `GITHUB_TOKEN` environment injection remain
+unsupported.
+
+These exceptions do not establish authenticated provider event, fork, or actor
+provenance. The server's independent pipeline-repository comparison,
+organization enablement, and permission allowlist are authoritative, but
+pipelines remain responsible for whether untrusted workflow changes may request
+an allowed write permission. Private actions, arbitrary reusable-workflow
+source, selected non-provider secrets, environments, and OIDC still require the
+general control-plane decision in this ADR.
 
 ### Runtime verification and capability use
 

--- a/docs/architecture/0003-protected-capability-control-plane.md
+++ b/docs/architecture/0003-protected-capability-control-plane.md
@@ -332,22 +332,24 @@ record; a successful job alone does not prove policy or audit behavior.
 
 ## Deferred decisions
 
-Apart from the fixed read-only pipeline-repository checkout exception, this ADR
-does not authorize or choose storage for private actions, reusable workflow
-source, selected secrets, `GITHUB_TOKEN`, environment grants, or compatibility
-OIDC claims. It does not choose a secret manager, general GitHub App permission
-set, customer policy language, administrative UI, or production service
-hostname. Those decisions require separate reviewed slices after the no-op
-boundary is proven.
+Apart from the fixed read-only pipeline-repository checkout and explicit scoped
+`secrets.GITHUB_TOKEN` exceptions above, this ADR does not authorize or choose
+storage for private actions, reusable workflow source, selected non-provider
+secrets, `github.token`, environment grants, or compatibility OIDC claims. It
+does not choose a secret manager, broader cross-repository GitHub App authority,
+customer policy language, administrative UI, or production service hostname.
+Those decisions require separate reviewed slices after the no-op boundary is
+proven.
 
 The existing cache-v2 GHAC token exchange remains separate. Cache tokens are
 minted through the current Buildkite job, scoped by the cache service, and
 exposed only to the audited cache action lifecycle. A capability grant neither
 contains nor replaces them.
 
-The job-bound private-checkout exchange is likewise separate. Its server-side
-pipeline-repository binding and client-fixed `contents:read` permission are not
-a substitute for the event, policy, signing, and audit contract required by a
+The job-bound GitHub token exchanges are likewise separate. Their server-side
+pipeline-repository binding and either client-fixed `contents:read` checkout
+permission or compiler-owned explicit workflow permission map are not a
+substitute for the event, policy, signing, and audit contract required by a
 general capability grant.
 
 ## Consequences

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -54,7 +54,7 @@ provide.
 | `docker://` actions | Not supported | Private images, credentials, arbitrary options, volumes, and privileged containers are also rejected. |
 | Other cache clients and broad artifact modes | Not supported | `actions/cache` v4/v5 and unrecognized v6 commits, artifact merge, IDs, patterns, all-artifact, cross-repository, and cross-run modes fail admission or input validation. |
 | Private repositories or actions | Narrow checkout only | The direct uploader can opt into private checkout of the pipeline's exact GitHub repository. Private actions, alternate repositories, and reusable-workflow source remain unsupported. |
-| Secrets and provider tokens | Not exposed | `GITHUB_TOKEN`, `github.token`, GitHub App tokens for workflow use, protected secrets, and environment grants remain unsupported. The private-checkout credential is runtime-internal and available only to Git. |
+| Secrets and provider tokens | Narrow `GITHUB_TOKEN` support | An explicit `secrets.GITHUB_TOKEN` reference can receive a short-lived token for the event repository and a non-empty explicit permission map. `github.token`, other workflow secrets, and environment grants remain unsupported. The separate private-checkout credential is runtime-internal and available only to Git. |
 | OIDC | Not supported | GitHub-compatible and migration OIDC flows are deferred. |
 | Windows and macOS | Not supported | Unmapped runner labels fail validation. |
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -143,6 +143,52 @@ It does not populate `GITHUB_TOKEN` or `github.token`, accept workflow-selected
 permissions, support write access, or enable private actions. Alternate
 repositories or refs and credential persistence remain unsupported.
 
+### Explicit permissions provide a scoped workflow token
+
+A job that statically references `${{ secrets.GITHUB_TOKEN }}` receives one
+short-lived GitHub installation token for the exact event repository when it
+also has a non-empty, explicit `permissions` mapping:
+
+```yaml
+permissions:
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr comment "$PR_NUMBER" --body "Checks passed"
+```
+
+Workflow permissions apply to jobs that omit job permissions. A job-level
+mapping replaces the workflow-level mapping rather than merging with it. Local
+reusable workflows inherit the caller's effective permissions and can only
+narrow them. `none` removes a permission. Omitted permissions, `{}`,
+`read-all`, `write-all`, and `id-token` do not produce a token; a static
+`GITHUB_TOKEN` reference without a non-empty effective mapping fails
+compilation.
+
+The compiler normalizes names such as `pull-requests` to the Agent API's
+`pull_requests`, emits the exact map into a v6 plan, and records same-process
+provenance for upload admission. The runtime requests the token once from the
+current-job Agent endpoint. The service independently requires the requested
+repository to match the pipeline's configured GitHub repository and applies
+its own permission allowlist and organization enablement. The token is
+registered with runtime and Agent redaction before expressions or steps can use
+it, and result values containing it are scrubbed.
+
+Only the explicit `secrets.GITHUB_TOKEN` context value is populated. The token
+is not an ambient `GITHUB_TOKEN` environment variable and `github.token`
+remains unsupported. Other secrets still use the existing explicit
+`BUILDKITE_GHA_SECRET_<NAME>` boundary and are not enabled by this feature.
+
+This job-bound service does not independently establish fork or actor trust.
+Pipelines that permit workflow changes from untrusted sources must apply the
+same care as GitHub Actions workflows granting write permissions, in addition
+to the service's repository and permission policy.
+
 ### Artifact uploads use bounded native storage
 
 The producer-side adapter recognizes only

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -1896,6 +1896,8 @@ the narrowest available boundary:
 - public checkout under GitHub and Cursor Origin provider adapters;
 - explicitly enabled private checkout of the pipeline's exact GitHub
   repository through the current job's scoped Agent token endpoint; and
+- compiler-authorized workflow `GITHUB_TOKEN` requests for the pipeline's exact
+  GitHub repository and explicit permission map through that same job endpoint;
 - step summaries and annotations.
 
 Prefer documented Buildkite storage and Agent interfaces. If an action toolkit
@@ -1931,7 +1933,9 @@ Delivery slices:
    interface. The first sub-slice is fixed `contents:read` checkout of the
    pipeline's exact repository through the current job's scoped Agent endpoint;
    private actions and private reusable-workflow source remain separate work.
-5. Add scoped GitHub tokens, selected secrets, and environment grants.
+5. Add scoped GitHub tokens, selected secrets, and environment grants. The
+   job-bound Agent endpoint now covers explicit workflow tokens; selected
+   secrets and general provenance-aware grants remain.
 6. Prefer direct Buildkite OIDC migration, then add only explicitly supported
    compatibility-issuer claims for providers that cannot consume it directly.
 
@@ -1941,6 +1945,10 @@ supports explicitly enabled, read-only checkout of the pipeline's exact GitHub
 repository. Its local request, admission, redaction, askpass, and leakage
 boundaries are tested; hosted proof remains pending endpoint deployment,
 organization enablement, installer wiring, and a private-repository canary.
+The job-bound portion of slice 5 now compiles explicit workflow and job
+permissions into a v6 plan and provides a synthetic `secrets.GITHUB_TOKEN`
+through the current-job endpoint, with independent runtime validation,
+redaction, and compiler-proven upload admission. Hosted proof remains pending.
 Private actions and reusable workflows remain deferred. Cursor Origin public
 checkout remains pending on its provider context/source contract. Slice 3's
 proposed

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -195,7 +195,7 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 		defer func() { _ = os.RemoveAll(artifactRoot) }()
 	}
 	var actionMaterializer gharuntime.ActionMaterializer
-	if (job.Schema == plan.SchemaV3 || job.Schema == plan.SchemaV4 || job.Schema == plan.SchemaV5) && hasGitHubActionLocks(job.Actions) {
+	if (job.Schema == plan.SchemaV3 || job.Schema == plan.SchemaV4 || job.Schema == plan.SchemaV5 || job.Schema == plan.SchemaV6) && hasGitHubActionLocks(job.Actions) {
 		actionCache, err := os.MkdirTemp("", "buildkite-gha-actions-")
 		if err != nil {
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: create action cache: %v\n", err)
@@ -228,29 +228,37 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 		}
 	}
 	var checkoutTokens gharuntime.CheckoutTokenProvider
-	if job.HasCapability("provider-token-read") {
-		checkoutTokens, err = gharuntime.NewAgentGitHubTokens(gharuntime.AgentGitHubTokenConfig{
+	var workflowTokens gharuntime.WorkflowTokenProvider
+	if job.HasCapability("provider-token-read") || job.HasCapability("provider-token-write") {
+		githubTokens, tokenErr := gharuntime.NewAgentGitHubTokens(gharuntime.AgentGitHubTokenConfig{
 			Endpoint: os.Getenv("BUILDKITE_AGENT_ENDPOINT"),
 			JobID:    os.Getenv("BUILDKITE_JOB_ID"),
 			JobToken: os.Getenv("BUILDKITE_AGENT_ACCESS_TOKEN"),
 		})
-		if err != nil {
-			_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: configure private checkout token service: %v\n", err)
+		if tokenErr != nil {
+			_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: configure GitHub token service: %v\n", tokenErr)
 			return 1
+		}
+		if job.HasCapability("provider-token-read") {
+			checkoutTokens = githubTokens
+		}
+		if job.HasCapability("provider-token-write") {
+			workflowTokens = githubTokens
 		}
 	}
 	runner := gharuntime.Runner{
-		Stdout:      stdout,
-		Stderr:      stderr,
-		MiseDataDir: prepareMiseDataDir(os.Getenv("BUILDKITE_GHA_MISE_DATA_DIR"), stderr),
-		Docker:      os.Getenv("BUILDKITE_GHA_DOCKER"),
-		Git:         os.Getenv("BUILDKITE_GHA_GIT"),
-		Secrets:     gharuntime.EnvironmentSecrets{},
-		Redactor:    gharuntime.AgentRedactor{Executable: os.Getenv("BUILDKITE_GHA_AGENT")},
-		Actions:     actionMaterializer,
-		Artifacts:   agent,
-		Cache:       cacheCredentials,
-		Checkout:    checkoutTokens,
+		Stdout:        stdout,
+		Stderr:        stderr,
+		MiseDataDir:   prepareMiseDataDir(os.Getenv("BUILDKITE_GHA_MISE_DATA_DIR"), stderr),
+		Docker:        os.Getenv("BUILDKITE_GHA_DOCKER"),
+		Git:           os.Getenv("BUILDKITE_GHA_GIT"),
+		Secrets:       gharuntime.EnvironmentSecrets{},
+		Redactor:      gharuntime.AgentRedactor{Executable: os.Getenv("BUILDKITE_GHA_AGENT")},
+		Actions:       actionMaterializer,
+		Artifacts:     agent,
+		Cache:         cacheCredentials,
+		Checkout:      checkoutTokens,
+		WorkflowToken: workflowTokens,
 	}
 	runner.RuntimeExecutable, err = os.Executable()
 	if err != nil {
@@ -780,6 +788,12 @@ func validateUnprivilegedBundleWithPrivateCheckout(bundle compiler.Bundle, priva
 			if capability == "provider-token-read" {
 				if !privateCheckout || !slices.Equal(artifact.Authorization.ProviderTokenReadCapabilitySources, []string{"checkout-adapter"}) {
 					return fmt.Errorf("job %q requires provider-token-read without compiler-verified private checkout provenance", artifact.Job.Workflow.LogicalJobID)
+				}
+				continue
+			}
+			if capability == "provider-token-write" {
+				if artifact.Job.GitHubToken == nil || !slices.Equal(artifact.Authorization.ProviderTokenWriteCapabilitySources, []string{"workflow-permissions"}) {
+					return fmt.Errorf("job %q requires provider-token-write without compiler-verified workflow permission provenance", artifact.Job.Workflow.LogicalJobID)
 				}
 				continue
 			}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -708,6 +708,34 @@ func TestUnprivilegedUploadAdmitsOnlyCompilerVerifiedPrivateCheckout(t *testing.
 	}
 }
 
+func TestUnprivilegedUploadAdmitsOnlyCompilerVerifiedWorkflowToken(t *testing.T) {
+	job := plan.Job{
+		Workflow:             plan.Workflow{LogicalJobID: "comment"},
+		RequiredCapabilities: []string{"provider-token-write"},
+		GitHubToken:          &plan.GitHubToken{Permissions: map[string]string{"pull_requests": "write"}},
+	}
+	for _, test := range []struct {
+		name          string
+		authorization compiler.PlanAuthorization
+		wantError     bool
+	}{
+		{name: "verified permissions", authorization: compiler.PlanAuthorization{ProviderTokenWriteCapabilitySources: []string{"workflow-permissions"}}},
+		{name: "missing provenance", wantError: true},
+		{name: "broadened provenance", authorization: compiler.PlanAuthorization{ProviderTokenWriteCapabilitySources: []string{"workflow-permissions", "step-input"}}, wantError: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: job, Authorization: test.authorization}}}
+			err := validateUnprivilegedBundle(bundle)
+			if test.wantError && (err == nil || !strings.Contains(err.Error(), "workflow permission provenance")) {
+				t.Fatalf("validateUnprivilegedBundle() error = %v", err)
+			}
+			if !test.wantError && err != nil {
+				t.Fatalf("validateUnprivilegedBundle() error = %v", err)
+			}
+		})
+	}
+}
+
 func TestUnprivilegedUploadAllowsPublicAndDockerfileActionCapabilities(t *testing.T) {
 	for _, capabilities := range [][]string{nil, {"network"}, {"docker"}, {"docker", "network"}} {
 		bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: plan.Job{

--- a/internal/compiler/bundle.go
+++ b/internal/compiler/bundle.go
@@ -23,8 +23,9 @@ type PlanArtifact struct {
 // It is deliberately not part of the encoded plan: runtimes independently
 // enforce capabilities, while upload policy relies only on fresh compilation.
 type PlanAuthorization struct {
-	DockerCapabilitySources            []string
-	ProviderTokenReadCapabilitySources []string
+	DockerCapabilitySources             []string
+	ProviderTokenReadCapabilitySources  []string
+	ProviderTokenWriteCapabilitySources []string
 }
 
 // Bundle is the complete deterministic output of static compilation.

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/buildkite/buildkite-gha/internal/plan"
 	"go.yaml.in/yaml/v4"
 )
 
@@ -114,6 +115,80 @@ func TestCompileBundleDeclaresSecretCapabilityAndNames(t *testing.T) {
 	job := bundle.Plans[0].Job
 	if !reflect.DeepEqual(job.RequiredSecrets, []string{"CANARY", "DEPLOY_TOKEN"}) || !reflect.DeepEqual(job.RequiredCapabilities, []string{"secrets"}) {
 		t.Fatalf("secret boundary = names %#v capabilities %#v", job.RequiredSecrets, job.RequiredCapabilities)
+	}
+}
+
+func TestCompileBundleDeclaresScopedGitHubWorkflowToken(t *testing.T) {
+	source := []byte(`name: token
+on: push
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  token:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      OTHER: ${{ secrets.OTHER }}
+    steps:
+      - run: test -n "$GH_TOKEN"
+  tokenless:
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+`)
+	bundle, err := CompileBundle("workflow.yml", source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	jobs := map[string]PlanArtifact{}
+	for _, artifact := range bundle.Plans {
+		jobs[artifact.Job.Workflow.LogicalJobID] = artifact
+	}
+	token := jobs["token"]
+	if token.Job.Schema != plan.SchemaV6 || token.Job.GitHubToken == nil || !reflect.DeepEqual(token.Job.GitHubToken.Permissions, map[string]string{"contents": "read", "pull_requests": "write"}) {
+		t.Fatalf("GitHub workflow token plan = %#v", token.Job)
+	}
+	if !reflect.DeepEqual(token.Job.RequiredSecrets, []string{"OTHER"}) || !reflect.DeepEqual(token.Job.RequiredCapabilities, []string{"provider-token-write", "secrets"}) {
+		t.Fatalf("token secret boundary = names %#v capabilities %#v", token.Job.RequiredSecrets, token.Job.RequiredCapabilities)
+	}
+	if !reflect.DeepEqual(token.Authorization.ProviderTokenWriteCapabilitySources, []string{"workflow-permissions"}) {
+		t.Fatalf("token authorization = %#v", token.Authorization)
+	}
+	if jobs["tokenless"].Job.GitHubToken != nil || jobs["tokenless"].Job.HasCapability("provider-token-write") {
+		t.Fatalf("unreferenced permissions minted a token: %#v", jobs["tokenless"].Job)
+	}
+}
+
+func TestCompileBundleGitHubTokenRequiresExplicitEffectivePermissions(t *testing.T) {
+	for _, permissions := range []string{"", "permissions: {}\n", "permissions:\n  contents: none\n"} {
+		source := []byte("on: push\n" + permissions + "jobs:\n  token:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo '${{ secrets.GITHUB_TOKEN }}'\n")
+		_, err := CompileBundle("workflow.yml", source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-importer")
+		if err == nil || !strings.Contains(err.Error(), "references secrets.GITHUB_TOKEN but has no explicit effective permissions") {
+			t.Fatalf("CompileBundle() error = %v, want explicit permission rejection", err)
+		}
+	}
+}
+
+func TestCompileBundleJobPermissionsReplaceWorkflowPermissions(t *testing.T) {
+	source := []byte(`on: push
+permissions:
+  contents: read
+jobs:
+  token:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps: [{run: true}]
+`)
+	bundle, err := CompileBundle("workflow.yml", source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := bundle.Plans[0].Job.GitHubToken.Permissions; !reflect.DeepEqual(got, map[string]string{"pull_requests": "write"}) {
+		t.Fatalf("effective job permissions = %#v", got)
 	}
 }
 

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -192,6 +192,24 @@ jobs:
 	}
 }
 
+func TestCompileBundleRejectsPermissionNormalizationCollision(t *testing.T) {
+	source := []byte(`on: push
+permissions:
+  pull-requests: read
+  pull_requests: write
+jobs:
+  token:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps: [{run: true}]
+`)
+	_, err := CompileBundle("workflow.yml", source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err == nil || !strings.Contains(err.Error(), `unsupported permission "pull_requests"`) {
+		t.Fatalf("CompileBundle() error = %v, want non-canonical permission rejection", err)
+	}
+}
+
 func TestCompileBundleRejectsDynamicSecretIndex(t *testing.T) {
 	source := []byte("name: secrets\non: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    env:\n      SECRET_NAME: TOKEN\n      TOKEN: ${{ secrets[env.SECRET_NAME] }}\n    steps:\n      - run: true\n")
 	_, err := CompileBundle("workflow.yml", source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-importer")

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -88,6 +88,7 @@ type JobInstance struct {
 	MaxParallel             *int                    `json:"max_parallel,omitempty"`
 	Steps                   []workflow.Step         `json:"steps"`
 	Env                     map[string]string       `json:"env,omitempty"`
+	Permissions             map[string]string       `json:"permissions,omitempty"`
 	If                      string                  `json:"if,omitempty"`
 	TimeoutMinutes          float64                 `json:"timeout_minutes,omitempty"`
 	DefaultShell            string                  `json:"default_shell,omitempty"`
@@ -385,10 +386,26 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 		if err != nil {
 			return nil, nil, fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err)
 		}
+		var githubToken *plan.GitHubToken
+		if slices.Contains(secrets, "GITHUB_TOKEN") {
+			secrets = slices.DeleteFunc(secrets, func(name string) bool { return name == "GITHUB_TOKEN" })
+			if len(instance.Permissions) == 0 {
+				return nil, nil, fmt.Errorf("%s:%d:%d: job %q references secrets.GITHUB_TOKEN but has no explicit effective permissions", instance.SourcePath, instance.Source.Start.Line, instance.Source.Start.Column, instance.LogicalJobID)
+			}
+			permissions := make(map[string]string, len(instance.Permissions))
+			for name, access := range instance.Permissions {
+				permissions[strings.ReplaceAll(name, "-", "_")] = access
+			}
+			githubToken = &plan.GitHubToken{Permissions: permissions}
+			jobSchema = plan.SchemaV6
+			capabilities = append(capabilities, "provider-token-write")
+			authorization.ProviderTokenWriteCapabilitySources = []string{"workflow-permissions"}
+		}
 		if len(secrets) != 0 {
 			capabilities = append(capabilities, "secrets")
-			sort.Strings(capabilities)
 		}
+		sort.Strings(capabilities)
+		capabilities = slices.Compact(capabilities)
 		job := plan.Job{
 			Schema: jobSchema,
 			Compiler: plan.Compiler{
@@ -407,6 +424,7 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 			Target:                  plan.Target{StepKey: instance.Key, Queue: instance.Queue},
 			RequiredCapabilities:    capabilities,
 			RequiredSecrets:         secrets,
+			GitHubToken:             githubToken,
 			Matrix:                  instance.Matrix,
 			Vars:                    cloneMap(ir.Vars),
 			Dependencies:            append([]string(nil), instance.Needs...),
@@ -650,6 +668,7 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 				MaxParallel:             job.MaxParallel,
 				Steps:                   append([]workflow.Step(nil), job.Steps...),
 				Env:                     cloneMap(job.Env),
+				Permissions:             permissionScopes(job.Permissions),
 				If:                      job.If,
 				TimeoutMinutes:          job.TimeoutMinutes,
 				DefaultShell:            job.DefaultShell,
@@ -719,6 +738,13 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 		instances = append(instances, byLogicalID[id]...)
 	}
 	return instances, nil
+}
+
+func permissionScopes(permissions *workflow.Permissions) map[string]string {
+	if permissions == nil {
+		return nil
+	}
+	return cloneMap(permissions.Scopes)
 }
 
 func supported(path string, job workflow.Job) error {

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -17,8 +17,26 @@ import (
 	"github.com/buildkite/buildkite-gha/internal/action/metadata"
 	"github.com/buildkite/buildkite-gha/internal/plan"
 	"github.com/buildkite/buildkite-gha/internal/transport"
+	"github.com/buildkite/buildkite-gha/internal/workflow"
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )
+
+func TestEffectiveReusablePermissionsOnlyNarrowCallerAuthority(t *testing.T) {
+	span := workflow.Span{Start: workflow.Position{Line: 2, Column: 1}}
+	caller := &workflow.Permissions{Scopes: map[string]string{"contents": "read", "pull-requests": "write"}, Span: span}
+	callee := &workflow.Permissions{Scopes: map[string]string{"contents": "write", "issues": "write", "pull-requests": "read"}, Span: span}
+	effective := effectivePermissions(callee, nil, caller, true)
+	want := map[string]string{"contents": "read", "pull-requests": "read"}
+	if !reflect.DeepEqual(effective.Scopes, want) {
+		t.Fatalf("effective permissions = %#v, want %#v", effective.Scopes, want)
+	}
+	if inherited := effectivePermissions(nil, nil, caller, true); !reflect.DeepEqual(inherited.Scopes, caller.Scopes) || inherited == caller {
+		t.Fatalf("inherited permissions = %#v, want independent copy of %#v", inherited, caller)
+	}
+	if unbounded := effectivePermissions(callee, caller, nil, false); !reflect.DeepEqual(unbounded.Scopes, callee.Scopes) {
+		t.Fatalf("root job permissions = %#v, want job replacement %#v", unbounded, callee)
+	}
+}
 
 func TestCompileShellGoldenGraph(t *testing.T) {
 	workflowPath := smokePath(".github", "workflows", "shell.yml")

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -80,6 +80,7 @@ func resolveReusableWorkflows(path string, source []byte, parsed *workflow.Workf
 		workflowJobs := make(map[string]workflow.Job, len(parsed.Jobs))
 		replacements := make(map[string]needBinding, len(parsed.Jobs))
 		for i, job := range parsed.Jobs {
+			job.Permissions = effectivePermissions(job.Permissions, parsed.Permissions, nil, false)
 			bindings := make(map[string]needBinding, len(job.Needs))
 			for _, need := range job.Needs {
 				bindings[need] = needBinding{members: []string{need}}
@@ -103,7 +104,7 @@ func resolveReusableWorkflows(path string, source []byte, parsed *workflow.Workf
 		return nil, err
 	}
 	resolver := reusableResolver{root: root, stack: []string{canonicalPath}}
-	resolution, err := resolver.resolve(sourcePath, digest, parsed, "", "", nil, nil, 0)
+	resolution, err := resolver.resolve(sourcePath, digest, parsed, "", "", nil, nil, nil, 0)
 	return resolution.jobs, err
 }
 
@@ -116,7 +117,7 @@ func hasReusableCall(parsed *workflow.Workflow) bool {
 	return false
 }
 
-func (resolver *reusableResolver) resolve(path, digest string, parsed *workflow.Workflow, namespace, labelPrefix string, inputs map[string]any, externalNeeds map[string]needBinding, depth int) (reusableResolution, error) {
+func (resolver *reusableResolver) resolve(path, digest string, parsed *workflow.Workflow, namespace, labelPrefix string, inputs map[string]any, externalNeeds map[string]needBinding, permissionCeiling *workflow.Permissions, depth int) (reusableResolution, error) {
 	jobs := make(map[string]workflow.Job, len(parsed.Jobs))
 	for _, job := range parsed.Jobs {
 		jobs[job.ID] = job
@@ -130,6 +131,7 @@ func (resolver *reusableResolver) resolve(path, digest string, parsed *workflow.
 	var resolved []sourcedJob
 	for _, id := range order {
 		job := jobs[id]
+		job.Permissions = effectivePermissions(job.Permissions, parsed.Permissions, permissionCeiling, depth != 0)
 		job = applyStaticInputs(job, inputs)
 		if parsed.Callable {
 			if err := rejectUnresolvedInputExpressions(path, job); err != nil {
@@ -244,8 +246,12 @@ func (resolver *reusableResolver) resolve(path, digest string, parsed *workflow.
 				callLabel = labelPrefix + " / " + callLabel
 			}
 
+			calleePermissionCeiling := job.Permissions
+			if calleePermissionCeiling == nil {
+				calleePermissionCeiling = &workflow.Permissions{Scopes: map[string]string{}, Span: call.Span}
+			}
 			resolver.stack = append(resolver.stack, calleePath)
-			calleeResolution, err := resolver.resolve(calleeSourcePath, calleeDigest, callee, callNamespace, callLabel, callInputs, needBindings, depth+1)
+			calleeResolution, err := resolver.resolve(calleeSourcePath, calleeDigest, callee, callNamespace, callLabel, callInputs, needBindings, calleePermissionCeiling, depth+1)
 			resolver.stack = resolver.stack[:len(resolver.stack)-1]
 			if err != nil {
 				return reusableResolution{}, err
@@ -265,6 +271,45 @@ func (resolver *reusableResolver) resolve(path, digest string, parsed *workflow.
 		return reusableResolution{}, err
 	}
 	return reusableResolution{jobs: resolved, outputs: outputs}, nil
+}
+
+func effectivePermissions(job, workflowDefault, ceiling *workflow.Permissions, bounded bool) *workflow.Permissions {
+	declared := job
+	if declared == nil {
+		declared = workflowDefault
+	}
+	if !bounded {
+		return clonePermissions(declared)
+	}
+	if declared == nil {
+		return clonePermissions(ceiling)
+	}
+	effective := &workflow.Permissions{Scopes: map[string]string{}, Span: declared.Span}
+	if ceiling == nil {
+		return effective
+	}
+	for name, access := range declared.Scopes {
+		ceilingAccess, ok := ceiling.Scopes[name]
+		if !ok {
+			continue
+		}
+		if access == "write" && ceilingAccess == "read" {
+			access = "read"
+		}
+		effective.Scopes[name] = access
+	}
+	return effective
+}
+
+func clonePermissions(in *workflow.Permissions) *workflow.Permissions {
+	if in == nil {
+		return nil
+	}
+	out := &workflow.Permissions{Scopes: make(map[string]string, len(in.Scopes)), Span: in.Span}
+	for name, access := range in.Scopes {
+		out.Scopes[name] = access
+	}
+	return out
 }
 
 func replacementNeeds(needs []string, replacements map[string]needBinding) map[string]needBinding {

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -21,6 +21,7 @@ const (
 	SchemaV3 = "https://buildkite.com/schemas/buildkite-gha/job-plan-v3.schema.json"
 	SchemaV4 = "https://buildkite.com/schemas/buildkite-gha/job-plan-v4.schema.json"
 	SchemaV5 = "https://buildkite.com/schemas/buildkite-gha/job-plan-v5.schema.json"
+	SchemaV6 = "https://buildkite.com/schemas/buildkite-gha/job-plan-v6.schema.json"
 	Schema   = SchemaV2
 )
 
@@ -39,6 +40,25 @@ var containerImagePattern = regexp.MustCompile(`^[a-z0-9]+(?:[._-][a-z0-9]+)*(?:
 var containerEnvKeyPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 var containerPortPattern = regexp.MustCompile(`^(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(?::(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]))?(?:/(?:tcp|udp))?$`)
 var serviceNamePattern = regexp.MustCompile(`^[a-z_][a-z0-9_-]{0,254}$`)
+var githubRepositoryPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`)
+
+var githubTokenPermissionAccess = map[string]map[string]bool{
+	"actions":             {"read": true, "write": true},
+	"artifact_metadata":   {"read": true, "write": true},
+	"attestations":        {"read": true, "write": true},
+	"checks":              {"read": true, "write": true},
+	"contents":            {"read": true, "write": true},
+	"deployments":         {"read": true, "write": true},
+	"discussions":         {"read": true, "write": true},
+	"issues":              {"read": true, "write": true},
+	"models":              {"read": true},
+	"packages":            {"read": true, "write": true},
+	"pages":               {"read": true, "write": true},
+	"pull_requests":       {"read": true, "write": true},
+	"repository_projects": {"read": true, "write": true},
+	"security_events":     {"read": true, "write": true},
+	"statuses":            {"read": true, "write": true},
+}
 
 type ActionSelector struct {
 	Lock string `json:"lock"`
@@ -148,6 +168,12 @@ type Container struct {
 	Ports []string          `json:"ports,omitempty"`
 }
 
+// GitHubToken describes one synthetic secrets.GITHUB_TOKEN value. Permissions
+// are API-normalized and compiler-owned; the repository always comes from Event.
+type GitHubToken struct {
+	Permissions map[string]string `json:"permissions"`
+}
+
 // Job is one immutable, compiler-selected workflow job instance.
 type Job struct {
 	Schema               string                  `json:"schema"`
@@ -157,6 +183,7 @@ type Job struct {
 	Target               Target                  `json:"target"`
 	RequiredCapabilities []string                `json:"required_capabilities"`
 	RequiredSecrets      []string                `json:"required_secrets,omitempty"`
+	GitHubToken          *GitHubToken            `json:"github_token,omitempty"`
 	Matrix               map[string]any          `json:"matrix,omitempty"`
 	Vars                 map[string]string       `json:"vars,omitempty"`
 	Dependencies         []string                `json:"dependencies,omitempty"`
@@ -303,17 +330,20 @@ func Encode(job Job) ([]byte, error) {
 }
 
 func (job Job) Validate() error {
-	if job.Schema != SchemaV1 && job.Schema != SchemaV2 && job.Schema != SchemaV3 && job.Schema != SchemaV4 && job.Schema != SchemaV5 {
+	if job.Schema != SchemaV1 && job.Schema != SchemaV2 && job.Schema != SchemaV3 && job.Schema != SchemaV4 && job.Schema != SchemaV5 && job.Schema != SchemaV6 {
 		return fmt.Errorf("unsupported job plan schema %q", job.Schema)
 	}
-	if job.Schema != SchemaV3 && job.Schema != SchemaV4 && job.Schema != SchemaV5 && (len(job.Actions) != 0 || hasStepActions(job.Steps)) {
+	if job.Schema != SchemaV3 && job.Schema != SchemaV4 && job.Schema != SchemaV5 && job.Schema != SchemaV6 && (len(job.Actions) != 0 || hasStepActions(job.Steps)) {
 		return fmt.Errorf("job plan %s does not support action locks", job.Schema)
 	}
-	if job.Schema != SchemaV4 && job.Schema != SchemaV5 && (job.Container != nil || len(job.Services) != 0) {
+	if job.Schema != SchemaV4 && job.Schema != SchemaV5 && job.Schema != SchemaV6 && (job.Container != nil || len(job.Services) != 0) {
 		return fmt.Errorf("job plan %s does not support containers or services", job.Schema)
 	}
-	if job.Schema != SchemaV5 && job.NeedOutputs != nil {
+	if job.Schema != SchemaV5 && job.Schema != SchemaV6 && job.NeedOutputs != nil {
 		return fmt.Errorf("job plan %s does not support prerequisite output projections", job.Schema)
+	}
+	if job.Schema != SchemaV6 && job.GitHubToken != nil {
+		return fmt.Errorf("job plan %s does not support GitHub workflow tokens", job.Schema)
 	}
 	if job.Compiler.Version == "" || !digestPattern.MatchString(job.Compiler.DistributionDigest) {
 		return fmt.Errorf("job plan compiler version and distribution digest are required")
@@ -382,10 +412,25 @@ func (job Job) Validate() error {
 		if !secretNamePattern.MatchString(name) || i > 0 && job.RequiredSecrets[i-1] == name {
 			return fmt.Errorf("job plan contains invalid or repeated required secret %q", name)
 		}
+		if name == "GITHUB_TOKEN" {
+			return fmt.Errorf("job plan must provide GITHUB_TOKEN through the scoped workflow token contract")
+		}
 	}
 	if len(job.RequiredSecrets) != 0 {
 		if _, ok := capabilities["secrets"]; !ok {
 			return fmt.Errorf("job plan required secrets need the secrets capability")
+		}
+	}
+	_, workflowTokenCapability := capabilities["provider-token-write"]
+	if (job.GitHubToken != nil) != workflowTokenCapability {
+		return fmt.Errorf("job plan GitHub workflow token and provider-token-write capability must be declared together")
+	}
+	if job.GitHubToken != nil {
+		if job.Event.Provider != "github" || !validGitHubRepository(job.Event.Repository) {
+			return fmt.Errorf("GitHub workflow token requires a valid github.com event repository")
+		}
+		if err := validateGitHubTokenPermissions(job.GitHubToken.Permissions); err != nil {
+			return err
 		}
 	}
 	if !sort.StringsAreSorted(job.Dependencies) {
@@ -405,7 +450,7 @@ func (job Job) Validate() error {
 	needIDs := make(map[string]struct{}, len(job.NeedSources))
 	sourcedDependencies := make(map[string]struct{}, len(job.Dependencies))
 	maxNeedProducers := MaxNeedProducers
-	if job.Schema != SchemaV5 {
+	if job.Schema != SchemaV5 && job.Schema != SchemaV6 {
 		maxNeedProducers = maxLegacyNeedProducers
 	}
 	for name, sources := range job.NeedSources {
@@ -535,9 +580,30 @@ func (job Job) Validate() error {
 			return fmt.Errorf("step %q has unsupported kind %q", step.ID, step.Kind)
 		}
 	}
-	if job.Schema == SchemaV3 || job.Schema == SchemaV4 || (job.Schema == SchemaV5 && (len(job.Actions) != 0 || hasStepActions(job.Steps))) {
+	if job.Schema == SchemaV3 || job.Schema == SchemaV4 || ((job.Schema == SchemaV5 || job.Schema == SchemaV6) && (len(job.Actions) != 0 || hasStepActions(job.Steps))) {
 		if err := validateActionLocks(job); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+func validGitHubRepository(repository string) bool {
+	if len(repository) > 140 || !githubRepositoryPattern.MatchString(repository) {
+		return false
+	}
+	parts := strings.Split(repository, "/")
+	return parts[0] != "." && parts[0] != ".." && parts[1] != "." && parts[1] != ".."
+}
+
+func validateGitHubTokenPermissions(permissions map[string]string) error {
+	if len(permissions) == 0 || len(permissions) > len(githubTokenPermissionAccess) {
+		return fmt.Errorf("GitHub workflow token requires a non-empty bounded permission set")
+	}
+	for name, access := range permissions {
+		allowed, ok := githubTokenPermissionAccess[name]
+		if !ok || !allowed[access] {
+			return fmt.Errorf("GitHub workflow token contains unsupported permission %q with access %q", name, access)
 		}
 	}
 	return nil

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -605,6 +605,104 @@ func TestV5PrerequisiteOutputProjectionContractAndLegacyRejection(t *testing.T) 
 	}
 }
 
+func TestV6GitHubWorkflowTokenContractAndSchema(t *testing.T) {
+	job := validJob()
+	job.Schema = SchemaV6
+	job.Event.Repository = "buildkite/buildkite-gha"
+	job.RequiredCapabilities = []string{"provider-token-write"}
+	job.GitHubToken = &GitHubToken{Permissions: map[string]string{"contents": "read", "pull_requests": "write"}}
+	encoded, err := Encode(job)
+	if err != nil {
+		t.Fatal(err)
+	}
+	schemaSource, err := os.ReadFile(filepath.Join("..", "..", "schemas", "job-plan-v6.schema.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var schemaDocument, planDocument any
+	if err := json.Unmarshal(schemaSource, &schemaDocument); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(encoded, &planDocument); err != nil {
+		t.Fatal(err)
+	}
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource(SchemaV6, schemaDocument); err != nil {
+		t.Fatal(err)
+	}
+	schema, err := compiler.Compile(SchemaV6)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := schema.Validate(planDocument); err != nil {
+		t.Fatalf("v6 plan does not validate against schema: %v", err)
+	}
+	for _, test := range []struct {
+		name string
+		edit func(map[string]any)
+	}{
+		{name: "other provider", edit: func(document map[string]any) {
+			document["event"].(map[string]any)["provider"] = "cursor-origin"
+		}},
+		{name: "missing repository", edit: func(document map[string]any) {
+			delete(document["event"].(map[string]any), "repository")
+		}},
+		{name: "malformed repository", edit: func(document map[string]any) {
+			document["event"].(map[string]any)["repository"] = "buildkite"
+		}},
+		{name: "dot repository component", edit: func(document map[string]any) {
+			document["event"].(map[string]any)["repository"] = "buildkite/.."
+		}},
+	} {
+		t.Run("schema rejects "+test.name, func(t *testing.T) {
+			encodedDocument, err := json.Marshal(planDocument)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var changed map[string]any
+			if err := json.Unmarshal(encodedDocument, &changed); err != nil {
+				t.Fatal(err)
+			}
+			test.edit(changed)
+			if err := schema.Validate(changed); err == nil {
+				t.Fatalf("v6 schema accepted token plan with %s", test.name)
+			}
+		})
+	}
+
+	for _, test := range []struct {
+		name string
+		edit func(*Job)
+		want string
+	}{
+		{name: "missing capability", edit: func(j *Job) { j.RequiredCapabilities = []string{} }, want: "declared together"},
+		{name: "missing token", edit: func(j *Job) { j.GitHubToken = nil }, want: "declared together"},
+		{name: "legacy schema", edit: func(j *Job) { j.Schema = SchemaV5 }, want: "does not support GitHub workflow tokens"},
+		{name: "unknown permission", edit: func(j *Job) { j.GitHubToken.Permissions = map[string]string{"administration": "write"} }, want: "unsupported permission"},
+		{name: "invalid access", edit: func(j *Job) { j.GitHubToken.Permissions = map[string]string{"contents": "admin"} }, want: "unsupported permission"},
+		{name: "reserved ambient secret", edit: func(j *Job) {
+			j.RequiredCapabilities = []string{"provider-token-write", "secrets"}
+			j.RequiredSecrets = []string{"GITHUB_TOKEN"}
+		}, want: "scoped workflow token contract"},
+		{name: "other provider", edit: func(j *Job) { j.Event.Provider = "cursor-origin" }, want: "valid github.com event repository"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			changed := job
+			changed.RequiredCapabilities = append([]string(nil), job.RequiredCapabilities...)
+			changed.RequiredSecrets = append([]string(nil), job.RequiredSecrets...)
+			permissions := map[string]string{}
+			for name, access := range job.GitHubToken.Permissions {
+				permissions[name] = access
+			}
+			changed.GitHubToken = &GitHubToken{Permissions: permissions}
+			test.edit(&changed)
+			if err := changed.Validate(); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Validate() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
 func TestContainerPortGrammarMatchesSchema(t *testing.T) {
 	schemaSource, err := os.ReadFile(filepath.Join("..", "..", "schemas", "job-plan-v4.schema.json"))
 	if err != nil {

--- a/internal/runtime/github_token_service.go
+++ b/internal/runtime/github_token_service.go
@@ -26,6 +26,12 @@ type CheckoutTokenProvider interface {
 	Token(context.Context, string) (string, error)
 }
 
+// WorkflowTokenProvider mints one repository-scoped credential with the exact
+// compiler-owned permissions carried by a verified job plan.
+type WorkflowTokenProvider interface {
+	WorkflowToken(context.Context, string, map[string]string) (string, error)
+}
+
 // AgentGitHubTokenConfig identifies the exact current Buildkite job. Endpoint
 // and JobToken are runtime authority and are never forwarded to Git or action
 // code.
@@ -36,8 +42,8 @@ type AgentGitHubTokenConfig struct {
 	Client   *http.Client
 }
 
-// AgentGitHubTokens mints a read-only token for the pipeline's exact GitHub
-// repository through Buildkite's job-bound Agent API endpoint.
+// AgentGitHubTokens mints repository-scoped tokens through Buildkite's
+// job-bound Agent API endpoint.
 type AgentGitHubTokens struct {
 	mintURL  string
 	jobToken string
@@ -66,32 +72,43 @@ func NewAgentGitHubTokens(config AgentGitHubTokenConfig) (*AgentGitHubTokens, er
 }
 
 func (c *AgentGitHubTokens) Token(ctx context.Context, repository string) (string, error) {
+	return c.mint(ctx, repository, map[string]string{"contents": "read"}, "checkout")
+}
+
+func (c *AgentGitHubTokens) WorkflowToken(ctx context.Context, repository string, permissions map[string]string) (string, error) {
+	if !validWorkflowTokenPermissions(permissions) {
+		return "", fmt.Errorf("GitHub workflow token requires valid explicit permissions")
+	}
+	return c.mint(ctx, repository, permissions, "workflow")
+}
+
+func (c *AgentGitHubTokens) mint(ctx context.Context, repository string, permissions map[string]string, purpose string) (string, error) {
 	if c == nil {
-		return "", fmt.Errorf("GitHub checkout token provider is not configured")
+		return "", fmt.Errorf("GitHub %s token provider is not configured", purpose)
 	}
 	if !validCheckoutRepository(repository) {
-		return "", fmt.Errorf("GitHub checkout token requires a valid event repository")
+		return "", fmt.Errorf("GitHub %s token requires a valid event repository", purpose)
 	}
 	body, err := json.Marshal(struct {
 		RepositoryURL string            `json:"repo_url"`
 		Permissions   map[string]string `json:"permissions"`
 	}{
 		RepositoryURL: "https://github.com/" + repository,
-		Permissions:   map[string]string{"contents": "read"},
+		Permissions:   permissions,
 	})
 	if err != nil {
-		return "", fmt.Errorf("encode GitHub checkout token request: %w", err)
+		return "", fmt.Errorf("encode GitHub %s token request: %w", purpose, err)
 	}
 	request, err := http.NewRequestWithContext(ctx, http.MethodPost, c.mintURL, bytes.NewReader(body))
 	if err != nil {
-		return "", fmt.Errorf("create GitHub checkout token request: %w", err)
+		return "", fmt.Errorf("create GitHub %s token request: %w", purpose, err)
 	}
 	request.Header.Set("Authorization", "Token "+c.jobToken)
 	request.Header.Set("Accept", "application/json")
 	request.Header.Set("Content-Type", "application/json")
 	response, err := c.client.Do(request)
 	if err != nil {
-		return "", fmt.Errorf("request GitHub checkout token: %w", err)
+		return "", fmt.Errorf("request GitHub %s token: %w", purpose, err)
 	}
 	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
@@ -100,10 +117,10 @@ func (c *AgentGitHubTokens) Token(ctx context.Context, repository string) (strin
 	}
 	payload, err := io.ReadAll(io.LimitReader(response.Body, githubTokenResponseLimit+1))
 	if err != nil {
-		return "", fmt.Errorf("read GitHub checkout token response: %w", err)
+		return "", fmt.Errorf("read GitHub %s token response: %w", purpose, err)
 	}
 	if len(payload) > githubTokenResponseLimit {
-		return "", fmt.Errorf("GitHub checkout token response exceeds the %d-byte limit", githubTokenResponseLimit)
+		return "", fmt.Errorf("GitHub %s token response exceeds the %d-byte limit", purpose, githubTokenResponseLimit)
 	}
 	decoder := json.NewDecoder(bytes.NewReader(payload))
 	decoder.DisallowUnknownFields()
@@ -111,15 +128,36 @@ func (c *AgentGitHubTokens) Token(ctx context.Context, repository string) (strin
 		Token string `json:"token"`
 	}
 	if err := decoder.Decode(&decoded); err != nil {
-		return "", fmt.Errorf("decode GitHub checkout token response: %w", err)
+		return "", fmt.Errorf("decode GitHub %s token response: %w", purpose, err)
 	}
 	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
-		return "", fmt.Errorf("GitHub checkout token response has trailing data")
+		return "", fmt.Errorf("GitHub %s token response has trailing data", purpose)
 	}
 	if len(decoded.Token) > 16<<10 || !githubInstallationTokenPattern.MatchString(decoded.Token) {
-		return "", fmt.Errorf("GitHub checkout token response contains an invalid token")
+		return "", fmt.Errorf("GitHub %s token response contains an invalid token", purpose)
 	}
 	return decoded.Token, nil
+}
+
+func validWorkflowTokenPermissions(permissions map[string]string) bool {
+	if len(permissions) == 0 || len(permissions) > 15 {
+		return false
+	}
+	for name, access := range permissions {
+		switch name {
+		case "actions", "artifact_metadata", "attestations", "checks", "contents", "deployments", "discussions", "issues", "packages", "pages", "pull_requests", "repository_projects", "security_events", "statuses":
+			if access != "read" && access != "write" {
+				return false
+			}
+		case "models":
+			if access != "read" {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func agentGitHubTokenURL(endpoint, jobID string) (string, error) {
@@ -138,18 +176,18 @@ func agentGitHubTokenURL(endpoint, jobID string) (string, error) {
 func githubTokenStatusError(status int, retryAfter string) error {
 	switch status {
 	case http.StatusBadRequest:
-		return fmt.Errorf("GitHub checkout token request was rejected")
+		return fmt.Errorf("GitHub token request was rejected")
 	case http.StatusUnauthorized, http.StatusForbidden:
-		return fmt.Errorf("GitHub checkout token request was denied")
+		return fmt.Errorf("GitHub token request was denied")
 	case http.StatusNotFound:
 		return fmt.Errorf("GitHub scoped access tokens are not enabled for this organization")
 	case http.StatusServiceUnavailable:
 		retryAfter = strings.TrimSpace(retryAfter)
 		if retryAfterSecondsPattern.MatchString(retryAfter) {
-			return fmt.Errorf("GitHub checkout token service is temporarily unavailable; retry after %s seconds", retryAfter)
+			return fmt.Errorf("GitHub token service is temporarily unavailable; retry after %s seconds", retryAfter)
 		}
-		return fmt.Errorf("GitHub checkout token service is temporarily unavailable")
+		return fmt.Errorf("GitHub token service is temporarily unavailable")
 	default:
-		return fmt.Errorf("GitHub checkout token service returned HTTP %d", status)
+		return fmt.Errorf("GitHub token service returned HTTP %d", status)
 	}
 }

--- a/internal/runtime/github_token_service_test.go
+++ b/internal/runtime/github_token_service_test.go
@@ -46,6 +46,33 @@ func TestAgentGitHubTokensMintsFixedReadOnlyRepositoryCredential(t *testing.T) {
 	}
 }
 
+func TestAgentGitHubTokensMintsExactWorkflowPermissions(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Error(err)
+		}
+		if string(body) != `{"repo_url":"https://github.com/buildkite/buildkite-gha","permissions":{"contents":"read","pull_requests":"write"}}` {
+			t.Errorf("request body = %s", body)
+		}
+		_, _ = io.WriteString(w, `{"token":"ghs_workflow_token"}`)
+	}))
+	defer server.Close()
+	provider, err := NewAgentGitHubTokens(AgentGitHubTokenConfig{Endpoint: server.URL, JobID: testCacheJobID, JobToken: "job-secret"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	token, err := provider.WorkflowToken(context.Background(), "buildkite/buildkite-gha", map[string]string{"pull_requests": "write", "contents": "read"})
+	if err != nil || token != "ghs_workflow_token" {
+		t.Fatalf("WorkflowToken() = %q, %v", token, err)
+	}
+	for _, permissions := range []map[string]string{nil, {}, {"contents": "admin"}, {"administration": "write"}, {"models": "write"}} {
+		if _, err := provider.WorkflowToken(context.Background(), "buildkite/buildkite-gha", permissions); err == nil {
+			t.Fatalf("WorkflowToken(%#v) succeeded", permissions)
+		}
+	}
+}
+
 func TestAgentGitHubTokensRejectsUnsafeConfigurationAndRepository(t *testing.T) {
 	valid := AgentGitHubTokenConfig{Endpoint: "https://agent.example/v3", JobID: testCacheJobID, JobToken: "job-token"}
 	for name, mutate := range map[string]func(*AgentGitHubTokenConfig){

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -111,7 +111,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		return JobResult{}, err
 	}
 	for _, capability := range job.RequiredCapabilities {
-		if capability != "docker" && capability != "secrets" && capability != "network" && capability != "provider-token-read" {
+		if capability != "docker" && capability != "secrets" && capability != "network" && capability != "provider-token-read" && capability != "provider-token-write" {
 			return JobResult{}, fmt.Errorf("capability %q is unsupported in the job runtime", capability)
 		}
 	}
@@ -127,9 +127,15 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 			return JobResult{}, err
 		}
 		r.Git = git
+	}
+	if job.HasCapability("provider-token-write") && r.WorkflowToken == nil {
+		return JobResult{}, fmt.Errorf("provider-token-write capability requires the GitHub workflow token provider")
+	}
+	if job.HasCapability("provider-token-read") || job.HasCapability("provider-token-write") {
 		if r.Redactor == nil {
-			return JobResult{}, fmt.Errorf("provider-token-read capability requires the Buildkite Agent redactor")
+			return JobResult{}, fmt.Errorf("provider token capability requires the Buildkite Agent redactor")
 		}
+		var err error
 		r.Redactor, err = resolveAgentRedactorBeforeWorkflow(r.Redactor)
 		if err != nil {
 			return JobResult{}, err
@@ -184,6 +190,15 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 	secrets, err := r.resolveSecrets(runCtx, processor, job.RequiredSecrets)
 	if err != nil {
 		return jobResult, err
+	}
+	if job.GitHubToken != nil {
+		if secrets == nil {
+			secrets = map[string]string{}
+		}
+		secrets["GITHUB_TOKEN"], err = r.resolveWorkflowToken(runCtx, processor, job.Event.Repository, job.GitHubToken.Permissions)
+		if err != nil {
+			return jobResult, err
+		}
 	}
 	eval.Secrets = secrets
 	if workspace == "" {
@@ -325,7 +340,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 	var runErr error
 	prepared := remotePreparations{}
 	preStatus := remotePreparationStatus{}
-	if job.Schema == plan.SchemaV3 || job.Schema == plan.SchemaV4 || (job.Schema == plan.SchemaV5 && len(job.Actions) != 0) {
+	if job.Schema == plan.SchemaV3 || job.Schema == plan.SchemaV4 || ((job.Schema == plan.SchemaV5 || job.Schema == plan.SchemaV6) && len(job.Actions) != 0) {
 		for stepIndex, step := range job.Steps {
 			if step.Kind != "uses" {
 				continue
@@ -630,6 +645,27 @@ func (r Runner) resolveSecrets(ctx context.Context, processor *commandProcessor,
 		values[name] = value
 	}
 	return values, nil
+}
+
+func (r Runner) resolveWorkflowToken(ctx context.Context, processor *commandProcessor, repository string, permissions map[string]string) (string, error) {
+	if r.WorkflowToken == nil {
+		return "", fmt.Errorf("GitHub workflow token provider is not configured")
+	}
+	token, err := r.WorkflowToken.WorkflowToken(ctx, repository, permissions)
+	if err != nil {
+		return "", err
+	}
+	if len(token) > 16<<10 || !githubInstallationTokenPattern.MatchString(token) {
+		return "", fmt.Errorf("GitHub workflow token provider returned an invalid token")
+	}
+	if r.Redactor == nil {
+		return "", fmt.Errorf("GitHub workflow token provider requires a redactor")
+	}
+	processor.addMask(token)
+	if err := r.Redactor.AddRedaction(ctx, token); err != nil {
+		return "", processor.scrubError(err)
+	}
+	return token, nil
 }
 
 func durationMinutes(minutes float64) time.Duration {
@@ -1015,7 +1051,7 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 
 	var action metadata.Metadata
 	var actionLock *plan.ActionLock
-	if job.Schema == plan.SchemaV3 || job.Schema == plan.SchemaV4 || (job.Schema == plan.SchemaV5 && len(job.Actions) != 0) {
+	if job.Schema == plan.SchemaV3 || job.Schema == plan.SchemaV4 || ((job.Schema == plan.SchemaV5 || job.Schema == plan.SchemaV6) && len(job.Actions) != 0) {
 		if step.Action == nil {
 			return result, fmt.Errorf("action %q has no immutable selector", step.Uses)
 		}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -66,6 +66,7 @@ type Runner struct {
 	Artifacts         ArtifactStore
 	Cache             CacheCredentialProvider
 	Checkout          CheckoutTokenProvider
+	WorkflowToken     WorkflowTokenProvider
 	runnerTemp        string
 	implicitJobPATH   string
 	explicitJobPATH   bool

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"slices"
 	"strconv"
@@ -45,6 +46,26 @@ type testRedactor struct{ values []string }
 func (r *testRedactor) AddRedaction(_ context.Context, value string) error {
 	r.values = append(r.values, value)
 	return nil
+}
+
+type testWorkflowTokenProvider struct {
+	token       string
+	repository  string
+	permissions map[string]string
+	calls       int
+}
+
+func (p *testWorkflowTokenProvider) WorkflowToken(_ context.Context, repository string, permissions map[string]string) (string, error) {
+	p.calls++
+	p.repository = repository
+	p.permissions = maps.Clone(permissions)
+	return p.token, nil
+}
+
+type failingTokenRedactor struct{ token string }
+
+func (r failingTokenRedactor) AddRedaction(context.Context, string) error {
+	return fmt.Errorf("failed to redact %s", r.token)
 }
 
 func TestValidateDockerMountPath(t *testing.T) {
@@ -1851,6 +1872,53 @@ func TestRunJobRejectsRegisteredSecretInOutput(t *testing.T) {
 	_, err := (Runner{Secrets: testSecretResolver{"CANARY": "do-not-publish"}, Redactor: &testRedactor{}}).RunJob(context.Background(), job, workspace)
 	if err == nil || !strings.Contains(err.Error(), "contains a registered secret") || strings.Contains(err.Error(), "do-not-publish") {
 		t.Fatalf("RunJob() error = %v, want non-disclosing secret-output rejection", err)
+	}
+}
+
+func TestRunJobMintsAndRedactsScopedGitHubWorkflowToken(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: workflow token\n")
+	const token = "ghs_scoped_workflow_token"
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{
+		ID: "use-token", Kind: "run", Shell: "sh", Command: `test "$GH_TOKEN" = "ghs_scoped_workflow_token" && printf '%s\n' "$GH_TOKEN"`,
+	}})
+	job.Schema = plan.SchemaV6
+	job.Event.Repository = "buildkite/buildkite-gha"
+	job.RequiredCapabilities = []string{"provider-token-write"}
+	job.GitHubToken = &plan.GitHubToken{Permissions: map[string]string{"contents": "read", "pull_requests": "write"}}
+	job.Env = map[string]string{"GH_TOKEN": "${{ secrets.GITHUB_TOKEN }}"}
+	provider := &testWorkflowTokenProvider{token: token}
+	redactor := &testRedactor{}
+	var logs bytes.Buffer
+	result, err := (Runner{Stdout: &logs, Stderr: &logs, WorkflowToken: provider, Redactor: redactor}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	if provider.calls != 1 || provider.repository != job.Event.Repository || !reflect.DeepEqual(provider.permissions, job.GitHubToken.Permissions) {
+		t.Fatalf("token request = calls %d, repository %q, permissions %#v", provider.calls, provider.repository, provider.permissions)
+	}
+	if !reflect.DeepEqual(redactor.values, []string{token}) {
+		t.Fatalf("redacted values = %#v", redactor.values)
+	}
+	if strings.Contains(logs.String(), token) || strings.Contains(fmt.Sprintf("%#v", result), token) || result.Env["GH_TOKEN"] != "***" || !strings.Contains(logs.String(), "***") {
+		t.Fatalf("workflow token leaked: result = %#v, logs = %q", result, logs.String())
+	}
+}
+
+func TestRunJobAbortsAndScrubsWorkflowTokenWhenRedactionFails(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: workflow token\n")
+	const token = "ghs_redaction_failure_token"
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "never", Kind: "run", Command: "false"}})
+	job.Schema = plan.SchemaV6
+	job.Event.Repository = "buildkite/buildkite-gha"
+	job.RequiredCapabilities = []string{"provider-token-write"}
+	job.GitHubToken = &plan.GitHubToken{Permissions: map[string]string{"pull_requests": "write"}}
+	_, err := (Runner{WorkflowToken: &testWorkflowTokenProvider{token: token}, Redactor: failingTokenRedactor{token: token}}).RunJob(context.Background(), job, workspace)
+	if err == nil || strings.Contains(err.Error(), token) || !strings.Contains(err.Error(), "***") {
+		t.Fatalf("RunJob() error = %v, want redaction failure without token disclosure", err)
 	}
 }
 

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -19,6 +19,7 @@ type Span struct {
 type Workflow struct {
 	Name                    string                `json:"name,omitempty"`
 	Env                     map[string]string     `json:"env,omitempty"`
+	Permissions             *Permissions          `json:"permissions,omitempty"`
 	DefaultShell            string                `json:"default_shell,omitempty"`
 	DefaultWorkingDirectory string                `json:"default_working_directory,omitempty"`
 	CallInputs              map[string]CallInput  `json:"call_inputs,omitempty"`
@@ -26,6 +27,13 @@ type Workflow struct {
 	RequiredCallSecrets     []string              `json:"required_call_secrets,omitempty"`
 	Callable                bool                  `json:"callable,omitempty"`
 	Jobs                    []Job                 `json:"jobs"`
+}
+
+// Permissions is an explicitly declared GitHub token permission set. Omitted
+// permissions remain nil so compilation never invents default authority.
+type Permissions struct {
+	Scopes map[string]string `json:"scopes"`
+	Span   Span              `json:"span"`
 }
 
 // CallInput declares one statically resolvable workflow_call input.
@@ -54,6 +62,7 @@ type Job struct {
 	MaxParallel             *int                   `json:"max_parallel,omitempty"`
 	Reusable                *ReusableWorkflowCall  `json:"reusable_workflow,omitempty"`
 	Env                     map[string]string      `json:"env,omitempty"`
+	Permissions             *Permissions           `json:"permissions,omitempty"`
 	If                      string                 `json:"if,omitempty"`
 	TimeoutMinutes          float64                `json:"timeout_minutes,omitempty"`
 	Outputs                 map[string]string      `json:"outputs,omitempty"`

--- a/internal/workflow/parse.go
+++ b/internal/workflow/parse.go
@@ -61,6 +61,10 @@ func Parse(path string, source []byte) (*Workflow, error) {
 	if parsed.Name != nil {
 		owned.Name = parsed.Name.Value
 	}
+	owned.Permissions, err = adaptPermissions(path, parsed.Permissions)
+	if err != nil {
+		return nil, err
+	}
 	if parsed.Env != nil && parsed.Env.Expression != nil {
 		return nil, locatedError(path, parsed.Env.Expression.Pos, "workflow", "expression-valued workflow env is unsupported")
 	}
@@ -268,6 +272,11 @@ func validateRawContainer(path string, node *yaml.Node) error {
 
 func adaptJob(path string, in *actionlint.Job, scalars map[Position]any, concurrency map[Position]stepConcurrency) (Job, error) {
 	out := Job{ID: in.ID.Value, Span: pointSpan(in.Pos)}
+	permissions, err := adaptPermissions(path, in.Permissions)
+	if err != nil {
+		return Job{}, err
+	}
+	out.Permissions = permissions
 	if in.WorkflowCall != nil {
 		call := in.WorkflowCall
 		out.Reusable = &ReusableWorkflowCall{
@@ -481,6 +490,38 @@ func adaptJob(path string, in *actionlint.Job, scalars map[Position]any, concurr
 		return Job{}, err
 	}
 	return out, nil
+}
+
+func adaptPermissions(path string, in *actionlint.Permissions) (*Permissions, error) {
+	if in == nil {
+		return nil, nil
+	}
+	if in.All != nil {
+		return nil, locatedError(path, in.All.Pos, "permissions", "permission aliases are unsupported; declare each required permission explicitly")
+	}
+	scopes := make(map[string]string, len(in.Scopes))
+	names := make([]string, 0, len(in.Scopes))
+	for name := range in.Scopes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		scope := in.Scopes[name]
+		if scope == nil || scope.Name == nil || scope.Value == nil {
+			return nil, locatedError(path, in.Pos, "permissions", "invalid permission declaration")
+		}
+		if name == "id-token" {
+			return nil, locatedError(path, scope.Name.Pos, "permissions", "id-token permission requires GitHub-compatible OIDC and is unsupported")
+		}
+		switch scope.Value.Value {
+		case "read", "write":
+			scopes[name] = scope.Value.Value
+		case "none":
+		default:
+			return nil, locatedError(path, scope.Value.Pos, "permissions", fmt.Sprintf("invalid access %q for permission %q", scope.Value.Value, name))
+		}
+	}
+	return &Permissions{Scopes: scopes, Span: pointSpan(in.Pos)}, nil
 }
 
 func workflowCallInputType(inputType actionlint.WorkflowCallEventInputType) string {

--- a/internal/workflow/parse.go
+++ b/internal/workflow/parse.go
@@ -513,6 +513,9 @@ func adaptPermissions(path string, in *actionlint.Permissions) (*Permissions, er
 		if name == "id-token" {
 			return nil, locatedError(path, scope.Name.Pos, "permissions", "id-token permission requires GitHub-compatible OIDC and is unsupported")
 		}
+		if !supportedGitHubTokenPermission(name) {
+			return nil, locatedError(path, scope.Name.Pos, "permissions", fmt.Sprintf("unsupported permission %q; use canonical GitHub permission names", name))
+		}
 		switch scope.Value.Value {
 		case "read", "write":
 			scopes[name] = scope.Value.Value
@@ -522,6 +525,15 @@ func adaptPermissions(path string, in *actionlint.Permissions) (*Permissions, er
 		}
 	}
 	return &Permissions{Scopes: scopes, Span: pointSpan(in.Pos)}, nil
+}
+
+func supportedGitHubTokenPermission(name string) bool {
+	switch name {
+	case "actions", "artifact-metadata", "attestations", "checks", "contents", "deployments", "discussions", "issues", "models", "packages", "pages", "pull-requests", "repository-projects", "security-events", "statuses":
+		return true
+	default:
+		return false
+	}
 }
 
 func workflowCallInputType(inputType actionlint.WorkflowCallEventInputType) string {

--- a/internal/workflow/parse_test.go
+++ b/internal/workflow/parse_test.go
@@ -56,6 +56,55 @@ func TestParsePreservesEnvironmentVariableCase(t *testing.T) {
 	}
 }
 
+func TestParseOwnsExplicitWorkflowAndJobPermissions(t *testing.T) {
+	source := []byte(`on: push
+permissions:
+  contents: read
+  pull-requests: write
+  issues: none
+jobs:
+  inherited:
+    runs-on: ubuntu-latest
+    steps: [{run: true}]
+  overridden:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps: [{run: true}]
+`)
+	parsed, err := Parse("permissions.yml", source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Permissions == nil || parsed.Permissions.Span.Start.Line != 2 || parsed.Permissions.Scopes["contents"] != "read" || parsed.Permissions.Scopes["pull-requests"] != "write" {
+		t.Fatalf("workflow permissions = %#v", parsed.Permissions)
+	}
+	if _, exists := parsed.Permissions.Scopes["issues"]; exists {
+		t.Fatalf("none permission was retained: %#v", parsed.Permissions.Scopes)
+	}
+	if parsed.Jobs[0].Permissions != nil || parsed.Jobs[1].Permissions == nil || parsed.Jobs[1].Permissions.Scopes["issues"] != "write" || parsed.Jobs[1].Permissions.Span.Start.Line != 12 {
+		t.Fatalf("job permissions = %#v / %#v", parsed.Jobs[0].Permissions, parsed.Jobs[1].Permissions)
+	}
+}
+
+func TestParseRejectsUnsupportedPermissionFormsWithLocation(t *testing.T) {
+	for _, test := range []struct {
+		name, declaration, want string
+	}{
+		{name: "read all", declaration: "permissions: read-all\n", want: "permissions.yml:2:14: job \"permissions\": permission aliases are unsupported"},
+		{name: "write all", declaration: "permissions: write-all\n", want: "permissions.yml:2:14: job \"permissions\": permission aliases are unsupported"},
+		{name: "OIDC", declaration: "permissions:\n  id-token: write\n", want: "permissions.yml:3:3: job \"permissions\": id-token permission requires GitHub-compatible OIDC"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			source := []byte("on: push\n" + test.declaration + "jobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n")
+			_, err := Parse("permissions.yml", source)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Parse() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
 func TestParseOwnsLiteralContainersAndSortsServices(t *testing.T) {
 	source := []byte("on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    container:\n      image: node:24\n      env: {NODE_ENV: test}\n      ports: [8080]\n    services:\n      zed: {image: redis:7}\n      alpha: {image: postgres:16, ports: ['5432:5432']}\n    steps:\n      - run: true\n")
 	parsed, err := Parse("containers.yml", source)

--- a/internal/workflow/parse_test.go
+++ b/internal/workflow/parse_test.go
@@ -94,6 +94,7 @@ func TestParseRejectsUnsupportedPermissionFormsWithLocation(t *testing.T) {
 		{name: "read all", declaration: "permissions: read-all\n", want: "permissions.yml:2:14: job \"permissions\": permission aliases are unsupported"},
 		{name: "write all", declaration: "permissions: write-all\n", want: "permissions.yml:2:14: job \"permissions\": permission aliases are unsupported"},
 		{name: "OIDC", declaration: "permissions:\n  id-token: write\n", want: "permissions.yml:3:3: job \"permissions\": id-token permission requires GitHub-compatible OIDC"},
+		{name: "non-canonical name", declaration: "permissions:\n  pull_requests: write\n", want: "permissions.yml:3:3: job \"permissions\": unsupported permission \"pull_requests\""},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			source := []byte("on: push\n" + test.declaration + "jobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n")

--- a/schemas/job-plan-v6.schema.json
+++ b/schemas/job-plan-v6.schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://buildkite.com/schemas/buildkite-gha/job-plan-v6.schema.json",
+  "title": "buildkite-gha job plan v6",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "compiler", "workflow", "event", "target", "required_capabilities", "steps"],
+  "properties": {
+    "schema": {"const": "https://buildkite.com/schemas/buildkite-gha/job-plan-v6.schema.json"},
+    "compiler": {"type": "object", "additionalProperties": false, "required": ["version", "distribution_digest"], "properties": {"version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$"}, "distribution_digest": {"$ref": "#/$defs/digest"}}},
+    "workflow": {"type": "object", "additionalProperties": false, "required": ["path", "digest", "logical_job_id"], "properties": {"path": {"type": "string", "minLength": 1, "maxLength": 1024}, "digest": {"$ref": "#/$defs/digest"}, "logical_job_id": {"type": "string", "minLength": 1, "maxLength": 255}}},
+    "event": {"type": "object", "additionalProperties": false, "required": ["provider", "name", "payload_digest"], "properties": {"provider": {"enum": ["github", "cursor-origin"]}, "name": {"type": "string", "pattern": "^[A-Za-z0-9_.-]+$", "maxLength": 128}, "payload_digest": {"$ref": "#/$defs/digest"}, "repository": {"type": "string", "maxLength": 512}, "ref": {"type": "string", "maxLength": 1024}, "sha": {"type": "string", "maxLength": 128}, "actor": {"type": "string", "maxLength": 256}}},
+    "target": {"type": "object", "additionalProperties": false, "required": ["step_key", "queue"], "properties": {"step_key": {"$ref": "#/$defs/buildkiteName"}, "queue": {"$ref": "#/$defs/buildkiteName"}}},
+    "required_capabilities": {"type": "array", "uniqueItems": true, "items": {"$ref": "#/$defs/capability"}, "maxItems": 16},
+    "required_secrets": {"type": "array", "items": {"type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_]*$", "not": {"const": "GITHUB_TOKEN"}}, "uniqueItems": true, "maxItems": 128},
+    "github_token": {"$ref": "#/$defs/githubToken"},
+    "matrix": {"type": "object"},
+    "vars": {"$ref": "#/$defs/stringMap"},
+    "dependencies": {"type": "array", "items": {"$ref": "#/$defs/buildkiteName"}, "uniqueItems": true},
+    "need_sources": {"type": "object", "additionalProperties": {"type": "array", "minItems": 1, "maxItems": 1024, "uniqueItems": true, "items": {"$ref": "#/$defs/needSource"}}},
+    "need_outputs": {"type": "object", "additionalProperties": {"type": "array", "maxItems": 64, "items": {"$ref": "#/$defs/needOutput"}}},
+    "env": {"$ref": "#/$defs/stringMap"},
+    "condition": {"type": "string", "maxLength": 65536},
+    "timeout_minutes": {"type": "number", "exclusiveMinimum": 0, "maximum": 360},
+    "default_shell": {"type": "string"},
+    "default_working_directory": {"type": "string"},
+    "outputs": {"$ref": "#/$defs/stringMap"},
+    "steps": {"type": "array", "minItems": 1, "maxItems": 1000, "items": {"$ref": "#/$defs/step"}},
+    "actions": {"type": "array", "maxItems": 1024, "items": {"$ref": "#/$defs/actionLock"}},
+    "container": {"$ref": "#/$defs/container"},
+    "services": {"type": "object", "maxProperties": 32, "propertyNames": {"pattern": "^[a-z_][a-z0-9_-]{0,254}$"}, "additionalProperties": {"$ref": "#/$defs/container"}}
+  },
+  "allOf": [
+    {
+      "if": {"required": ["github_token"]},
+      "then": {
+        "properties": {
+          "required_capabilities": {"contains": {"const": "provider-token-write"}},
+          "event": {"required": ["repository"], "properties": {"provider": {"const": "github"}, "repository": {"$ref": "#/$defs/githubEventRepository"}}}
+        }
+      }
+    },
+    {"if": {"properties": {"required_capabilities": {"contains": {"const": "provider-token-write"}}}}, "then": {"required": ["github_token"]}}
+  ],
+  "$defs": {
+    "digest": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "buildkiteName": {"type": "string", "pattern": "^[A-Za-z0-9_-]+$", "minLength": 1, "maxLength": 255},
+    "capability": {"enum": ["network", "docker", "privileged-container", "secrets", "provider-token-read", "provider-token-write"]},
+    "stringMap": {"type": "object", "additionalProperties": {"type": "string"}},
+    "githubEventRepository": {"type": "string", "maxLength": 140, "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$", "not": {"pattern": "^(?:\\.\\.?/|[A-Za-z0-9_.-]+/\\.\\.?)$"}},
+    "githubToken": {"type": "object", "additionalProperties": false, "required": ["permissions"], "properties": {"permissions": {"$ref": "#/$defs/githubPermissions"}}},
+    "githubPermissions": {
+      "type": "object", "additionalProperties": false, "minProperties": 1, "maxProperties": 15,
+      "properties": {
+        "actions": {"enum": ["read", "write"]},
+        "artifact_metadata": {"enum": ["read", "write"]},
+        "attestations": {"enum": ["read", "write"]},
+        "checks": {"enum": ["read", "write"]},
+        "contents": {"enum": ["read", "write"]},
+        "deployments": {"enum": ["read", "write"]},
+        "discussions": {"enum": ["read", "write"]},
+        "issues": {"enum": ["read", "write"]},
+        "models": {"const": "read"},
+        "packages": {"enum": ["read", "write"]},
+        "pages": {"enum": ["read", "write"]},
+        "pull_requests": {"enum": ["read", "write"]},
+        "repository_projects": {"enum": ["read", "write"]},
+        "security_events": {"enum": ["read", "write"]},
+        "statuses": {"enum": ["read", "write"]}
+      }
+    },
+    "needSource": {"type": "object", "additionalProperties": false, "required": ["step_key", "plan_digest"], "properties": {"step_key": {"$ref": "#/$defs/buildkiteName"}, "plan_digest": {"$ref": "#/$defs/digest"}}},
+    "needOutput": {"type": "object", "additionalProperties": false, "required": ["name", "step_key", "output"], "properties": {"name": {"$ref": "#/$defs/buildkiteName"}, "step_key": {"$ref": "#/$defs/buildkiteName"}, "output": {"$ref": "#/$defs/buildkiteName"}}},
+    "position": {"type": "object", "additionalProperties": false, "required": ["line", "column"], "properties": {"line": {"type": "integer", "minimum": 0}, "column": {"type": "integer", "minimum": 0}}},
+    "span": {"type": "object", "additionalProperties": false, "required": ["start", "end"], "properties": {"start": {"$ref": "#/$defs/position"}, "end": {"$ref": "#/$defs/position"}}},
+    "selector": {"type": "object", "additionalProperties": false, "required": ["lock"], "properties": {"lock": {"type": "string", "pattern": "^a-[0-9a-f]{16}$"}}},
+    "path": {"type": "string", "minLength": 1, "maxLength": 1024, "pattern": "^[^/\\\\\\x00-\\x1f\\x7f]{1,255}(?:/[^/\\\\\\x00-\\x1f\\x7f]{1,255})*$", "not": {"pattern": "(^|/)\\.\\.?(/|$)"}},
+    "repository": {"type": "string", "maxLength": 140, "pattern": "^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?/[a-z0-9](?:[a-z0-9_.-]{0,98}[a-z0-9])?$"},
+    "actionLock": {
+      "type": "object", "additionalProperties": false,
+      "required": ["id", "source", "source_digest"],
+      "properties": {
+        "id": {"type": "string", "pattern": "^a-[0-9a-f]{16}$"}, "source": {"enum": ["workspace", "github"]},
+        "repository": {"$ref": "#/$defs/repository"}, "requested_ref": {"type": "string", "minLength": 1, "maxLength": 1024, "pattern": "^[^\\x00-\\x1f\\x7f]+$"},
+        "commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"}, "path": {"$ref": "#/$defs/path"}, "source_digest": {"$ref": "#/$defs/digest"},
+        "children": {"type": "object", "maxProperties": 1024, "propertyNames": {"minLength": 1, "maxLength": 2048, "pattern": "^[^\\x00-\\x1f\\x7f]+$"}, "additionalProperties": {"$ref": "#/$defs/selector"}}
+      },
+      "allOf": [
+        {"if": {"properties": {"source": {"const": "workspace"}}, "required": ["source"]}, "then": {"not": {"anyOf": [{"required": ["repository"]}, {"required": ["requested_ref"]}, {"required": ["commit"]}]}}},
+        {"if": {"properties": {"source": {"const": "github"}}, "required": ["source"]}, "then": {"required": ["repository", "requested_ref", "commit"]}}
+      ]
+    },
+    "container": {"type": "object", "additionalProperties": false, "required": ["image"], "properties": {"image": {"$ref": "#/$defs/image"}, "env": {"$ref": "#/$defs/containerEnv"}, "ports": {"type": "array", "maxItems": 128, "uniqueItems": true, "items": {"type": "string", "pattern": "^(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(?::(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]))?(?:/(?:tcp|udp))?$"}}}},
+    "containerEnv": {"type": "object", "maxProperties": 256, "propertyNames": {"pattern": "^[A-Za-z_][A-Za-z0-9_]{0,254}$"}, "additionalProperties": {"type": "string", "maxLength": 65536}},
+    "image": {"type": "string", "minLength": 1, "maxLength": 512, "pattern": "^[a-z0-9]+(?:[._-][a-z0-9]+)*(?:/[a-z0-9]+(?:[._-][a-z0-9]+)*)*(?::[A-Za-z0-9_][A-Za-z0-9_.-]{0,127})?(?:@sha256:[0-9a-f]{64})?$"},
+    "step": {
+      "type": "object", "additionalProperties": false, "required": ["id", "kind"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1, "maxLength": 255}, "name": {"type": "string"}, "kind": {"enum": ["run", "uses", "wait", "wait-all", "cancel"]}, "background": {"type": "boolean"},
+        "targets": {"type": "array", "minItems": 1, "maxItems": 256, "uniqueItems": true, "items": {"$ref": "#/$defs/buildkiteName"}},
+        "command": {"type": "string", "maxLength": 1048576}, "uses": {"type": "string", "maxLength": 1024}, "action": {"$ref": "#/$defs/selector"}, "shell": {"type": "string"}, "working_directory": {"type": "string"},
+        "env": {"$ref": "#/$defs/stringMap"}, "with": {"$ref": "#/$defs/stringMap"}, "condition": {"type": "string", "maxLength": 65536}, "continue_on_error": {"type": "boolean"}, "timeout_minutes": {"type": "number", "exclusiveMinimum": 0, "maximum": 360}, "source": {"$ref": "#/$defs/span"}
+      },
+      "allOf": [
+        {"if": {"properties": {"kind": {"const": "run"}}, "required": ["kind"]}, "then": {"required": ["command"], "not": {"anyOf": [{"required": ["uses"]}, {"required": ["targets"]}, {"required": ["action"]}]}}},
+        {"if": {"properties": {"kind": {"const": "uses"}}, "required": ["kind"]}, "then": {"required": ["uses"]}},
+        {"if": {"properties": {"kind": {"const": "wait"}}, "required": ["kind"]}, "then": {"required": ["targets"], "not": {"required": ["action"]}}},
+        {"if": {"properties": {"kind": {"const": "wait-all"}}, "required": ["kind"]}, "then": {"not": {"anyOf": [{"required": ["targets"]}, {"required": ["action"]}]}}},
+        {"if": {"properties": {"kind": {"const": "cancel"}}, "required": ["kind"]}, "then": {"required": ["targets"], "properties": {"targets": {"maxItems": 1}}, "not": {"required": ["action"]}}},
+        {"if": {"properties": {"kind": {"enum": ["wait", "wait-all", "cancel"]}}, "required": ["kind"]}, "then": {"not": {"anyOf": [{"required": ["background"]}, {"required": ["command"]}, {"required": ["uses"]}, {"required": ["shell"]}, {"required": ["working_directory"]}, {"required": ["env"]}, {"required": ["with"]}, {"required": ["condition"]}, {"required": ["continue_on_error"]}, {"required": ["timeout_minutes"]}, {"required": ["action"]}]}}}
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- parse explicit workflow- and job-level GitHub `permissions`, including permission narrowing across local reusable workflows
- compile static `secrets.GITHUB_TOKEN` references into a v6 job plan with the exact API-normalized permission set and compiler-owned upload provenance
- mint one short-lived token for the event repository through the current Buildkite Agent job endpoint, then register runtime and Agent redaction before exposing it to expressions or steps
- keep ordinary workflow secrets and the fixed `contents: read` private-checkout token on their existing separate boundaries

Token requests fail closed when permissions are omitted or empty. Permission aliases and `id-token` remain unsupported, as do `github.token` and ambient `GITHUB_TOKEN` injection.

## How to use

Once scoped GitHub token vending is enabled for the Buildkite organization, declare the minimum permissions the job needs and statically reference `${{ secrets.GITHUB_TOKEN }}`:

```yaml
name: Comment on pull request
on:
  pull_request:
    types: [opened, synchronize, reopened]

permissions:
  pull-requests: write

jobs:
  comment:
    runs-on: ubuntu-latest
    steps:
      - name: Comment on the pull request
        env:
          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        run: |
          set -euo pipefail
          pr_number="$(
            gh api \
              "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
              --jq '.[0].number'
          )"
          test -n "$pr_number"
          gh pr comment "$pr_number" \
            --repo "$GITHUB_REPOSITORY" \
            --body "👋 Automated checks have completed successfully."
```

A job-level `permissions` map replaces the workflow-level map. Jobs that do not reference `secrets.GITHUB_TOKEN` do not request a token. No empty `token:` input or `BUILDKITE_GHA_SECRET_GITHUB_TOKEN` variable is required.

## Security boundary

The plan binds the request to the event repository and exact explicit permission map. Upload admission requires fresh same-process compiler provenance; serialized plans cannot self-authorize the protected capability. Plan validation, the runtime client, and the Agent service independently validate the repository and permissions. Returned credentials are masked locally and registered with the Buildkite Agent redactor before use.

The service's organization enablement, pipeline-repository match, and permission policy remain authoritative. Pipelines that execute workflow changes from untrusted sources must still control whether those changes can request write permissions.

## Verification

- `mise run check`
- focused workflow, compiler, plan, runtime, and CLI tests
- independent security/correctness review
