### PR TITLE
Harden credential service boundaries

### DIFF
--- a/internal/runtime/cache_service.go
+++ b/internal/runtime/cache_service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -129,8 +130,8 @@ func agentCacheMintURL(endpoint, jobID string) (string, error) {
 		return "", fmt.Errorf("cache Agent job ID is required")
 	}
 	u, err := url.Parse(endpoint)
-	if err != nil || u.Scheme != "http" && u.Scheme != "https" || u.Host == "" || u.User != nil || u.RawQuery != "" || u.Fragment != "" {
-		return "", fmt.Errorf("safe cache Agent endpoint is required")
+	if err != nil || !validCredentialServiceURL(u) {
+		return "", fmt.Errorf("safe cache Agent endpoint using HTTPS or loopback HTTP is required")
 	}
 	u.Path = strings.TrimRight(u.Path, "/") + "/jobs/" + jobID + "/ghac_tokens"
 	u.RawPath = ""
@@ -139,12 +140,26 @@ func agentCacheMintURL(endpoint, jobID string) (string, error) {
 
 func normalizeCacheResultsURL(value string) (string, error) {
 	u, err := url.Parse(value)
-	if err != nil || u.Scheme != "http" && u.Scheme != "https" || u.Host == "" || u.User != nil || u.RawQuery != "" || u.Fragment != "" || u.Path != "" && u.Path != "/" {
-		return "", fmt.Errorf("safe cache Results service URL is required")
+	if err != nil || !validCredentialServiceURL(u) || u.Path != "" && u.Path != "/" {
+		return "", fmt.Errorf("safe cache Results service URL using HTTPS or loopback HTTP is required")
 	}
 	u.Path = "/"
 	u.RawPath = ""
 	return u.String(), nil
+}
+
+func validCredentialServiceURL(u *url.URL) bool {
+	if u == nil || u.Host == "" || u.Hostname() == "" || u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+		return false
+	}
+	if u.Scheme == "https" {
+		return true
+	}
+	if u.Scheme != "http" {
+		return false
+	}
+	ip := net.ParseIP(u.Hostname())
+	return ip != nil && ip.IsLoopback()
 }
 
 func validBuildkiteJobID(value string) bool {

--- a/internal/runtime/cache_service_test.go
+++ b/internal/runtime/cache_service_test.go
@@ -74,21 +74,43 @@ func TestAgentCacheCredentialsDefaultsOfficialResultsService(t *testing.T) {
 	}
 }
 
+func TestAgentCacheCredentialsAcceptsHTTPSAndLoopbackHTTP(t *testing.T) {
+	for _, endpoint := range []string{
+		"https://service.example",
+		"http://127.0.0.1:1234",
+		"http://[::1]:1234",
+	} {
+		t.Run(endpoint, func(t *testing.T) {
+			if _, err := NewAgentCacheCredentials(AgentCacheConfig{
+				Endpoint: endpoint + "/v3", JobID: testCacheJobID, JobToken: "job-token", ResultsURL: endpoint,
+			}); err != nil {
+				t.Fatalf("NewAgentCacheCredentials(%q): %v", endpoint, err)
+			}
+		})
+	}
+}
+
 func TestAgentCacheCredentialsRejectsUnsafeConfiguration(t *testing.T) {
 	valid := AgentCacheConfig{
 		Endpoint: "https://agent.example/v3", JobID: testCacheJobID,
 		JobToken: "job-token", ResultsURL: "https://cache.example",
 	}
 	for name, mutate := range map[string]func(*AgentCacheConfig){
-		"missing endpoint":       func(c *AgentCacheConfig) { c.Endpoint = "" },
-		"endpoint credentials":   func(c *AgentCacheConfig) { c.Endpoint = "https://user@agent.example/v3" },
-		"endpoint query":         func(c *AgentCacheConfig) { c.Endpoint += "?redirect=other" },
-		"invalid job ID":         func(c *AgentCacheConfig) { c.JobID = "../other" },
-		"missing job token":      func(c *AgentCacheConfig) { c.JobToken = "" },
-		"job token header split": func(c *AgentCacheConfig) { c.JobToken = "secret\r\nOther: value" },
-		"results credentials":    func(c *AgentCacheConfig) { c.ResultsURL = "https://user@cache.example/v2" },
-		"results path":           func(c *AgentCacheConfig) { c.ResultsURL += "/v2" },
-		"results query":          func(c *AgentCacheConfig) { c.ResultsURL += "?token=value" },
+		"missing endpoint":              func(c *AgentCacheConfig) { c.Endpoint = "" },
+		"endpoint credentials":          func(c *AgentCacheConfig) { c.Endpoint = "https://user@agent.example/v3" },
+		"endpoint query":                func(c *AgentCacheConfig) { c.Endpoint += "?redirect=other" },
+		"endpoint plaintext hostname":   func(c *AgentCacheConfig) { c.Endpoint = "http://localhost/v3" },
+		"endpoint plaintext private IP": func(c *AgentCacheConfig) { c.Endpoint = "http://10.0.0.1/v3" },
+		"endpoint plaintext public IP":  func(c *AgentCacheConfig) { c.Endpoint = "http://203.0.113.1/v3" },
+		"invalid job ID":                func(c *AgentCacheConfig) { c.JobID = "../other" },
+		"missing job token":             func(c *AgentCacheConfig) { c.JobToken = "" },
+		"job token header split":        func(c *AgentCacheConfig) { c.JobToken = "secret\r\nOther: value" },
+		"results credentials":           func(c *AgentCacheConfig) { c.ResultsURL = "https://user@cache.example/v2" },
+		"results path":                  func(c *AgentCacheConfig) { c.ResultsURL += "/v2" },
+		"results query":                 func(c *AgentCacheConfig) { c.ResultsURL += "?token=value" },
+		"results plaintext hostname":    func(c *AgentCacheConfig) { c.ResultsURL = "http://localhost" },
+		"results plaintext private IP":  func(c *AgentCacheConfig) { c.ResultsURL = "http://10.0.0.1" },
+		"results plaintext public IP":   func(c *AgentCacheConfig) { c.ResultsURL = "http://203.0.113.1" },
 	} {
 		t.Run(name, func(t *testing.T) {
 			config := valid

--- a/internal/runtime/github_token_service.go
+++ b/internal/runtime/github_token_service.go
@@ -165,8 +165,8 @@ func agentGitHubTokenURL(endpoint, jobID string) (string, error) {
 		return "", fmt.Errorf("GitHub token Agent job ID is required")
 	}
 	u, err := url.Parse(endpoint)
-	if err != nil || u.Scheme != "http" && u.Scheme != "https" || u.Host == "" || u.User != nil || u.RawQuery != "" || u.Fragment != "" {
-		return "", fmt.Errorf("safe GitHub token Agent endpoint is required")
+	if err != nil || !validCredentialServiceURL(u) {
+		return "", fmt.Errorf("safe GitHub token Agent endpoint using HTTPS or loopback HTTP is required")
 	}
 	u.Path = strings.TrimRight(u.Path, "/") + "/jobs/" + jobID + "/github_scoped_access_token"
 	u.RawPath = ""

--- a/internal/runtime/github_token_service_test.go
+++ b/internal/runtime/github_token_service_test.go
@@ -73,15 +73,34 @@ func TestAgentGitHubTokensMintsExactWorkflowPermissions(t *testing.T) {
 	}
 }
 
+func TestAgentGitHubTokensAcceptsHTTPSAndLoopbackHTTP(t *testing.T) {
+	for _, endpoint := range []string{
+		"https://agent.example/v3",
+		"http://127.0.0.1:1234/v3",
+		"http://[::1]:1234/v3",
+	} {
+		t.Run(endpoint, func(t *testing.T) {
+			if _, err := NewAgentGitHubTokens(AgentGitHubTokenConfig{
+				Endpoint: endpoint, JobID: testCacheJobID, JobToken: "job-token",
+			}); err != nil {
+				t.Fatalf("NewAgentGitHubTokens(%q): %v", endpoint, err)
+			}
+		})
+	}
+}
+
 func TestAgentGitHubTokensRejectsUnsafeConfigurationAndRepository(t *testing.T) {
 	valid := AgentGitHubTokenConfig{Endpoint: "https://agent.example/v3", JobID: testCacheJobID, JobToken: "job-token"}
 	for name, mutate := range map[string]func(*AgentGitHubTokenConfig){
-		"missing endpoint":       func(c *AgentGitHubTokenConfig) { c.Endpoint = "" },
-		"endpoint credentials":   func(c *AgentGitHubTokenConfig) { c.Endpoint = "https://user@agent.example/v3" },
-		"endpoint query":         func(c *AgentGitHubTokenConfig) { c.Endpoint += "?redirect=other" },
-		"invalid job ID":         func(c *AgentGitHubTokenConfig) { c.JobID = "../other" },
-		"missing job token":      func(c *AgentGitHubTokenConfig) { c.JobToken = "" },
-		"job token header split": func(c *AgentGitHubTokenConfig) { c.JobToken = "secret\r\nOther: value" },
+		"missing endpoint":              func(c *AgentGitHubTokenConfig) { c.Endpoint = "" },
+		"endpoint credentials":          func(c *AgentGitHubTokenConfig) { c.Endpoint = "https://user@agent.example/v3" },
+		"endpoint query":                func(c *AgentGitHubTokenConfig) { c.Endpoint += "?redirect=other" },
+		"endpoint plaintext hostname":   func(c *AgentGitHubTokenConfig) { c.Endpoint = "http://localhost/v3" },
+		"endpoint plaintext private IP": func(c *AgentGitHubTokenConfig) { c.Endpoint = "http://10.0.0.1/v3" },
+		"endpoint plaintext public IP":  func(c *AgentGitHubTokenConfig) { c.Endpoint = "http://203.0.113.1/v3" },
+		"invalid job ID":                func(c *AgentGitHubTokenConfig) { c.JobID = "../other" },
+		"missing job token":             func(c *AgentGitHubTokenConfig) { c.JobToken = "" },
+		"job token header split":        func(c *AgentGitHubTokenConfig) { c.JobToken = "secret\r\nOther: value" },
 	} {
 		t.Run(name, func(t *testing.T) {
 			config := valid

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -959,9 +959,13 @@ func TestResolveAgentRedactorBeforeWorkflowPinsPointerWithoutMutatingCaller(t *t
 	}
 }
 
-func TestAgentRedactorOnlyExposesJobAPIEnvironment(t *testing.T) {
+func TestAgentRedactorSatisfiesCLIValidationWithoutExposingAgentCredential(t *testing.T) {
 	agent := filepath.Join(t.TempDir(), "buildkite-agent")
 	writeFixtureFile(t, filepath.Dir(agent), filepath.Base(agent), `#!/bin/sh
+test "$#" -eq 3 || { echo 'Missing agent-access-token. See: buildkite-agent redactor add --help' >&2; exit 10; }
+test "$1" = "redactor" || exit 11
+test "$2" = "add" || exit 12
+test "$3" = "--agent-access-token=unused" || { echo 'Missing agent-access-token. See: buildkite-agent redactor add --help' >&2; exit 13; }
 test "${BUILDKITE_AGENT_JOB_API_SOCKET-}" = "/tmp/job-api.sock" || exit 11
 test "${BUILDKITE_AGENT_JOB_API_TOKEN-}" = "job-api-token" || exit 12
 test -z "${BUILDKITE_AGENT_ACCESS_TOKEN+x}" || exit 13

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -959,6 +959,29 @@ func TestResolveAgentRedactorBeforeWorkflowPinsPointerWithoutMutatingCaller(t *t
 	}
 }
 
+func TestAgentRedactorOnlyExposesJobAPIEnvironment(t *testing.T) {
+	agent := filepath.Join(t.TempDir(), "buildkite-agent")
+	writeFixtureFile(t, filepath.Dir(agent), filepath.Base(agent), `#!/bin/sh
+test "${BUILDKITE_AGENT_JOB_API_SOCKET-}" = "/tmp/job-api.sock" || exit 11
+test "${BUILDKITE_AGENT_JOB_API_TOKEN-}" = "job-api-token" || exit 12
+test -z "${BUILDKITE_AGENT_ACCESS_TOKEN+x}" || exit 13
+test -z "${BUILDKITE_AGENT_ENDPOINT+x}" || exit 14
+test -z "${AMBIENT_SECRET+x}" || exit 15
+`)
+	if err := os.Chmod(agent, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BUILDKITE_AGENT_JOB_API_SOCKET", "/tmp/job-api.sock")
+	t.Setenv("BUILDKITE_AGENT_JOB_API_TOKEN", "job-api-token")
+	t.Setenv("BUILDKITE_AGENT_ACCESS_TOKEN", "agent-access-token")
+	t.Setenv("BUILDKITE_AGENT_ENDPOINT", "https://agent.example/v3")
+	t.Setenv("AMBIENT_SECRET", "must-not-be-inherited")
+
+	if err := (AgentRedactor{Executable: agent}).AddRedaction(context.Background(), "redact-me"); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestFailureConditionsAndCancellation(t *testing.T) {
 	workspace := t.TempDir()
 	workflowPath := ".github/workflows/test.yml"

--- a/internal/runtime/secrets.go
+++ b/internal/runtime/secrets.go
@@ -65,7 +65,9 @@ func (r AgentRedactor) AddRedaction(ctx context.Context, value string) error {
 	if executable == "" {
 		executable = "buildkite-agent"
 	}
-	command := exec.CommandContext(ctx, executable, "redactor", "add")
+	// redactor add uses only the Job API, but its embedded Agent API config
+	// still requires an access-token value during CLI validation.
+	command := exec.CommandContext(ctx, executable, "redactor", "add", "--agent-access-token=unused")
 	command.Env = []string{
 		"BUILDKITE_AGENT_JOB_API_SOCKET=" + os.Getenv("BUILDKITE_AGENT_JOB_API_SOCKET"),
 		"BUILDKITE_AGENT_JOB_API_TOKEN=" + os.Getenv("BUILDKITE_AGENT_JOB_API_TOKEN"),

--- a/internal/runtime/secrets.go
+++ b/internal/runtime/secrets.go
@@ -66,7 +66,10 @@ func (r AgentRedactor) AddRedaction(ctx context.Context, value string) error {
 		executable = "buildkite-agent"
 	}
 	command := exec.CommandContext(ctx, executable, "redactor", "add")
-	command.Env = os.Environ()
+	command.Env = []string{
+		"BUILDKITE_AGENT_JOB_API_SOCKET=" + os.Getenv("BUILDKITE_AGENT_JOB_API_SOCKET"),
+		"BUILDKITE_AGENT_JOB_API_TOKEN=" + os.Getenv("BUILDKITE_AGENT_JOB_API_TOKEN"),
+	}
 	command.Stdin = strings.NewReader(value)
 	if output, err := command.CombinedOutput(); err != nil {
 		return fmt.Errorf("register secret with Buildkite Agent redactor: %w: %s", err, output)


### PR DESCRIPTION
## Summary

- restrict `buildkite-agent redactor add` to the Job API socket and token instead of inheriting the complete job environment
- require HTTPS for GitHub-token, cache-token, and cache Results service endpoints, while retaining literal loopback HTTP for local testing
- add regression coverage for allowed IPv4/IPv6 loopback endpoints and rejected hostname, private-IP, and public-IP plaintext endpoints

## Security impact

This reduces the credentials available to the redactor subprocess and prevents bearer credentials from being sent to non-loopback services over plaintext HTTP. Existing URL protections for userinfo, queries, fragments, and cache Results paths remain enforced.

## Testing

- `mise run check`