### PR TITLE
Fail unsupported conditions during validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ The plugin path currently supports:
 - static matrices, ordinary `needs` and outputs, and local reusable workflows
   with statically resolved inputs, caller-visible results, and directly mapped
   declared outputs;
-- the currently implemented job and step condition subset;
+- the documented job and step condition subset, with unsupported functions and
+  unavailable runtime contexts rejected before pipeline upload;
 - background, wait, cancellation, and parallel step controls;
 - timeouts, `continue-on-error`, masking, summaries, warning/error annotations,
   and pre/main/post actions;
@@ -123,8 +124,8 @@ It does **not** currently support:
   GitHub-compatible OIDC, or protected queues;
 - `actions/cache` v4/v5 or unrecognized v6 commits, artifact
   merge/all/pattern/ID modes, or cross-run downloads;
-- runtime condition access to the `github.event` payload;
-- exhaustive validation of condition functions before execution;
+- runtime condition access to the `github.event` payload, or condition
+  functions and contexts outside the documented subset;
 - job containers or service containers through the production plugin path;
 - compound or literal local reusable-workflow output mappings and reusable-call
   conditions;

--- a/README.md
+++ b/README.md
@@ -165,9 +165,9 @@ buildkite-gha validate \
 
 An `admitted` result means the plans satisfy upload policy. It does not execute
 the workflow or prove that arbitrary action code is independent of GitHub-only
-services. Condition validation is also not yet exhaustive: some unsupported
-functions or runtime contexts fail only when the job runs. JSON output is
-available with `--format json`.
+services. Condition preflight validates the supported syntax, functions,
+contexts, and statically known operand types, but cannot prove value-dependent
+runtime behavior. JSON output is available with `--format json`.
 
 ## What gets translated?
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -38,7 +38,7 @@ provide.
 | Static matrices | Supported | Includes typed values, `include`, `exclude`, and exact dependency fan-out. |
 | Workflow and job concurrency | Not supported | `concurrency.group` and `cancel-in-progress` fail compilation instead of being silently discarded. Configure equivalent behavior in Buildkite. `strategy.max-parallel` is translated separately for static matrix jobs. |
 | Local reusable workflows | Supported subset | Statically resolvable local calls preserve source-level `needs` names and expose an aggregate `needs.<call>.result` from every callee job. Declared outputs mapped directly from `jobs.<job>.outputs.<name>` are exposed through `needs.<call>.outputs`; nested calls are supported and undeclared callee outputs remain hidden. Matrix-selected declarations verify every exact producer and fail closed when values conflict or exceed 64 concrete projections. Literal or compound output mappings, call-level conditions, and remote or runtime-dependent reusable workflows are deferred. Caller prerequisites inherited by callee roots are status-only. |
-| Job and step conditions | Supported subset | Syntax is checked, but not every runtime function or context limitation is preflighted. Some unsupported expressions fail only when the job runs. |
+| Job and step conditions | Supported subset | Validation accepts literals, logical operators, `==`, `!=`, and the zero-argument `always`, `success`, `failure`, and `cancelled` status functions. Job conditions can use `github` identity fields, `needs`, `vars`, and `matrix`; step conditions additionally support `steps`, `env`, and service ports. Unsupported functions, operators, reference shapes, and unavailable contexts fail before pipeline upload. |
 | Concurrent step controls | Supported | Includes `background`, `wait`, `wait-all`, `cancel`, and `parallel`. |
 | JavaScript actions | Supported | Managed, digest-verified Node 20 and 24 runtimes are used. |
 | Composite and local actions | Supported | Nested composites and global pre/main/post ordering are supported. |
@@ -374,8 +374,8 @@ not call Buildkite, install Node, or execute workflow code.
 The snapshot supplies the compile-time Actions context. Generated plans retain
 the event name, repository, ref, SHA, actor, and a payload digest, but not the
 payload object itself. Runtime conditions can use those retained identity fields
-but cannot currently access `github.event`; an expression such as
-`github.event.action` may therefore pass validation and fail when the job runs.
+but cannot access `github.event`; validation rejects an expression such as
+`github.event.action` before pipeline upload.
 The snapshot is compatibility data, not proof that the event is trustworthy,
 and cannot authorize a protected capability.
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -205,14 +205,17 @@ func TestUnsupportedConditionPreflightAppliesToEveryCompilerEntryPoint(t *testin
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [12, "14"]
+    if: matrix.version == 12
     steps:
-      - if: vars.ENABLED == true
-        run: true
+      - run: true
 `), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
-	want := `step 1 condition: condition equality compares incompatible string and boolean operands`
+	want := `job condition: condition equality compares incompatible string and number operands`
 
 	t.Run("validate json", func(t *testing.T) {
 		var stdout, stderr bytes.Buffer

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -206,13 +206,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - if: github.event.pull_request.draft
+      - if: vars.ENABLED == true
         run: true
 `), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
-	want := `step 1 condition: condition reference "github.event.pull_request.draft" is unavailable at runtime`
+	want := `step 1 condition: condition equality compares incompatible string and boolean operands`
 
 	t.Run("validate json", func(t *testing.T) {
 		var stdout, stderr bytes.Buffer

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -199,6 +199,72 @@ func TestRunValidateAndCompile(t *testing.T) {
 	})
 }
 
+func TestUnsupportedConditionPreflightAppliesToEveryCompilerEntryPoint(t *testing.T) {
+	workflowPath := filepath.Join(t.TempDir(), "conditions.yml")
+	if err := os.WriteFile(workflowPath, []byte(`on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - if: github.event.pull_request.draft
+        run: true
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
+	want := `step 1 condition: condition reference "github.event.pull_request.draft" is unavailable at runtime`
+
+	t.Run("validate json", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		if code := Run([]string{"validate", "--format", "json", workflowPath}, &stdout, &stderr, "dev"); code != 1 {
+			t.Fatalf("Run() code = %d, stderr = %q", code, stderr.String())
+		}
+		var report compatibility.Report
+		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+			t.Fatal(err)
+		}
+		if report.Result != "incompatible" || len(report.Diagnostics) != 1 || report.Diagnostics[0].Code != "E_COMPILE" || !strings.Contains(report.Diagnostics[0].Message, want) {
+			t.Fatalf("report = %#v", report)
+		}
+	})
+
+	t.Run("profile", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		args := []string{"validate", "--profile", "hosted-tokenless", "--format", "json", "--event-path", eventPath, workflowPath}
+		if code := Run(args, &stdout, &stderr, "dev"); code != 1 {
+			t.Fatalf("Run() code = %d, stderr = %q", code, stderr.String())
+		}
+		var report compatibility.ProfileReport
+		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+			t.Fatal(err)
+		}
+		if report.Compile.Result != "incompatible" || report.Admission.Result != "not-evaluated" || len(report.Diagnostics) != 1 || !strings.Contains(report.Diagnostics[0].Message, want) {
+			t.Fatalf("profile report = %#v", report)
+		}
+	})
+
+	t.Run("compile", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		if code := Run([]string{"compile", "--event-path", eventPath, workflowPath}, &stdout, &stderr, "dev"); code != 1 || !strings.Contains(stderr.String(), want) {
+			t.Fatalf("Run() code = %d, stderr = %q", code, stderr.String())
+		}
+	})
+
+	t.Run("upload before Buildkite calls", func(t *testing.T) {
+		t.Setenv("BUILDKITE", "true")
+		t.Setenv("BUILDKITE_STEP_KEY", "condition-importer")
+		runner := &cliCaptureRunner{}
+		var stdout, stderr bytes.Buffer
+		args := []string{"upload", "--event-path", eventPath, "--runtime-queue", "hosted", workflowPath}
+		if code := run(args, &stdout, &stderr, "dev", runner); code != 1 || !strings.Contains(stderr.String(), want) {
+			t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+		}
+		if len(runner.commands) != 0 {
+			t.Fatalf("unsupported condition made Buildkite calls: %#v", runner.commands)
+		}
+	})
+}
+
 func TestValidateHostedTokenlessProfileResolvesActionsWithoutClaimingRuntime(t *testing.T) {
 	root := t.TempDir()
 	workflowPath := filepath.Join(root, ".github", "workflows", "action.yml")

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -641,6 +641,9 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 			return nil, err
 		}
 		for _, matrix := range matrices {
+			if err := supportedConditions(jobPath, job, matrix, true); err != nil {
+				return nil, err
+			}
 			labels, err := resolveRunsOn(job, context, matrix)
 			if err != nil {
 				return nil, locatedJobError(jobPath, job, runsOnPosition(job).Line, runsOnPosition(job).Column, err.Error())
@@ -754,16 +757,38 @@ func supported(path string, job workflow.Job) error {
 	if len(job.RunsOn) == 0 && job.RunsOnExpr == nil {
 		return jobError(path, job, "runs-on must resolve statically")
 	}
-	if err := expression.ValidateCondition(job.If, expression.JobCondition); err != nil {
+	if err := supportedConditions(path, job, nil, false); err != nil {
+		return err
+	}
+	ids := make(map[string]struct{}, len(job.Steps))
+	for _, step := range job.Steps {
+		if step.ID != "" {
+			id := strings.ToLower(step.ID)
+			if _, exists := ids[id]; exists {
+				return locatedJobError(path, job, step.Span.Start.Line, step.Span.Start.Column, fmt.Sprintf("duplicate step id %q", step.ID))
+			}
+			ids[id] = struct{}{}
+		}
+	}
+	return nil
+}
+
+func supportedConditions(path string, job workflow.Job, matrix map[string]any, matrixKnown bool) error {
+	validate := expression.ValidateCondition
+	if matrixKnown {
+		validate = func(source string, scope expression.ConditionScope) error {
+			return expression.ValidateConditionWithMatrix(source, scope, matrix)
+		}
+	}
+	if err := validate(job.If, expression.JobCondition); err != nil {
 		position := job.IfSpan.Start
 		if position.Line == 0 {
 			position = job.Span.Start
 		}
 		return locatedJobError(path, job, position.Line, position.Column, fmt.Sprintf("job condition: %v", err))
 	}
-	ids := make(map[string]struct{}, len(job.Steps))
 	for i, step := range job.Steps {
-		if err := expression.ValidateCondition(step.If, expression.StepCondition); err != nil {
+		if err := validate(step.If, expression.StepCondition); err != nil {
 			position := step.IfSpan.Start
 			if position.Line == 0 {
 				position = step.Span.Start
@@ -773,13 +798,6 @@ func supported(path string, job workflow.Job) error {
 				label = fmt.Sprintf("step %q", step.ID)
 			}
 			return locatedJobError(path, job, position.Line, position.Column, fmt.Sprintf("%s condition: %v", label, err))
-		}
-		if step.ID != "" {
-			id := strings.ToLower(step.ID)
-			if _, exists := ids[id]; exists {
-				return locatedJobError(path, job, step.Span.Start.Line, step.Span.Start.Column, fmt.Sprintf("duplicate step id %q", step.ID))
-			}
-			ids[id] = struct{}{}
 		}
 	}
 	return nil

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -754,8 +754,26 @@ func supported(path string, job workflow.Job) error {
 	if len(job.RunsOn) == 0 && job.RunsOnExpr == nil {
 		return jobError(path, job, "runs-on must resolve statically")
 	}
+	if err := expression.ValidateCondition(job.If, expression.JobCondition); err != nil {
+		position := job.IfSpan.Start
+		if position.Line == 0 {
+			position = job.Span.Start
+		}
+		return locatedJobError(path, job, position.Line, position.Column, fmt.Sprintf("job condition: %v", err))
+	}
 	ids := make(map[string]struct{}, len(job.Steps))
-	for _, step := range job.Steps {
+	for i, step := range job.Steps {
+		if err := expression.ValidateCondition(step.If, expression.StepCondition); err != nil {
+			position := step.IfSpan.Start
+			if position.Line == 0 {
+				position = step.Span.Start
+			}
+			label := fmt.Sprintf("step %d", i+1)
+			if step.ID != "" {
+				label = fmt.Sprintf("step %q", step.ID)
+			}
+			return locatedJobError(path, job, position.Line, position.Column, fmt.Sprintf("%s condition: %v", label, err))
+		}
 		if step.ID != "" {
 			id := strings.ToLower(step.ID)
 			if _, exists := ids[id]; exists {

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -413,6 +413,23 @@ jobs:
 	}
 }
 
+func TestCompileAllowsMaxUint64MatrixCondition(t *testing.T) {
+	source := []byte(`on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        value: [18446744073709551615]
+    if: matrix.value != 0
+    steps:
+      - run: true
+`)
+	if _, err := Compile("conditions.yml", source, readFile(t, smokePath("events", "push.json"))); err != nil {
+		t.Fatalf("Compile() error = %v", err)
+	}
+}
+
 func TestCompilePreservesStaticMatrixScalarTypes(t *testing.T) {
 	source := []byte(`on: push
 jobs:

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -93,6 +93,114 @@ func TestCompileIsByteIdenticalAndCoversSmokeCorpus(t *testing.T) {
 	}
 }
 
+func TestCompilePreflightsUnsupportedConditionsWithLocation(t *testing.T) {
+	eventSource := readFile(t, smokePath("events", "push.json"))
+	for _, test := range []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{
+			name: "job event payload",
+			source: `on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    if: github.event.action == 'opened'
+    steps:
+      - run: true
+`,
+			want: `conditions.yml:5:9: job "test": job condition: condition reference "github.event.action" is unavailable at runtime`,
+		},
+		{
+			name: "named step function",
+			source: `on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - id: inspect
+        if: hashFiles('go.sum') != ''
+        run: true
+`,
+			want: `conditions.yml:7:13: job "test": step "inspect" condition: condition function "hashFiles" is unsupported`,
+		},
+		{
+			name: "anonymous step context",
+			source: `on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - if: secrets.TOKEN
+        run: true
+`,
+			want: `conditions.yml:6:13: job "test": step 1 condition: condition context "secrets" is unsupported`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			for name, compile := range map[string]func() error{
+				"validate": func() error {
+					_, err := Validate("conditions.yml", []byte(test.source))
+					return err
+				},
+				"compile": func() error {
+					_, err := Compile("conditions.yml", []byte(test.source), eventSource)
+					return err
+				},
+				"plans": func() error {
+					_, err := CompilePlans("conditions.yml", []byte(test.source), eventSource, "0.0.0-test", testDistributionDigest, "gha-untrusted")
+					return err
+				},
+			} {
+				t.Run(name, func(t *testing.T) {
+					err := compile()
+					if err == nil || !strings.Contains(err.Error(), test.want) {
+						t.Fatalf("error = %v, want %q", err, test.want)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestCompileRetainsSupportedRuntimeDependentConditions(t *testing.T) {
+	source := []byte(`on: push
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      ready: ${{ steps.produce.outputs.ready }}
+    steps:
+      - id: produce
+        run: echo "ready=true" >> "$GITHUB_OUTPUT"
+  test:
+    needs: prepare
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7
+        ports: [6379]
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    if: always() && needs.prepare.result == 'success' && needs.prepare.outputs.ready && matrix.os && github.ref
+    steps:
+      - id: test
+        if: success() && env.ENABLED && vars.FLAG && needs.prepare.outputs.ready
+        run: true
+      - if: failure() && steps.test.outcome == 'failure' && steps.test.conclusion == 'success' && steps.test.outputs.ready && job.services.redis.ports[6379]
+        run: true
+`)
+	plans, err := CompilePlans("conditions.yml", source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-untrusted")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 2 || plans[1].Condition != "always() && needs.prepare.result == 'success' && needs.prepare.outputs.ready && matrix.os && github.ref" || plans[1].Steps[0].Condition != "success() && env.ENABLED && vars.FLAG && needs.prepare.outputs.ready" || plans[1].Steps[1].Condition != "failure() && steps.test.outcome == 'failure' && steps.test.conclusion == 'success' && steps.test.outputs.ready && job.services.redis.ports[6379]" {
+		t.Fatalf("runtime conditions were not retained: %#v", plans)
+	}
+}
+
 func TestCompileExpandsMatrixIncludeExcludeAndDependencies(t *testing.T) {
 	source := []byte(`name: matrix conformance
 on: push
@@ -814,6 +922,30 @@ jobs:
 	}
 	if got := conditions["disabled-call.string-gated"]; got != [2]string{"''", "''"} {
 		t.Fatalf("empty string conditions = %#v, want a falsy quoted expression literal", got)
+	}
+}
+
+func TestCompilePreflightsConditionsInReusableWorkflows(t *testing.T) {
+	repository := t.TempDir()
+	callerPath := writeWorkflow(t, repository, "caller.yml", `on: push
+jobs:
+  call:
+    uses: ./.github/workflows/reusable.yml
+`)
+	writeWorkflow(t, repository, "reusable.yml", `on: workflow_call
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - id: inspect
+        if: github.event.action == 'opened'
+        run: true
+`)
+
+	_, err := CompilePlans(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-untrusted")
+	want := `./.github/workflows/reusable.yml:7:13: job "call.test": step "inspect" condition: condition reference "github.event.action" is unavailable at runtime`
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("CompilePlans() error = %v, want callee condition diagnostic %q", err, want)
 	}
 }
 

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -162,6 +162,53 @@ jobs:
 `,
 			want: `conditions.yml:7:18: job "test": step "__parallel_6_9_1" condition: condition equality compares incompatible string and boolean operands`,
 		},
+		{
+			name: "concrete matrix type",
+			source: `on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [12, "14"]
+    if: matrix.version == 12
+    steps:
+      - run: true
+`,
+			want: `conditions.yml:8:9: job "test": job condition: condition equality compares incompatible string and number operands`,
+		},
+		{
+			name: "concrete matrix step type",
+			source: `on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [12, "14"]
+    steps:
+      - if: matrix.version == 12
+        run: true
+`,
+			want: `conditions.yml:9:13: job "test": step 1 condition: condition equality compares incompatible string and number operands`,
+		},
+		{
+			name: "missing concrete matrix value",
+			source: `on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - version: 12
+          - os: ubuntu-latest
+    if: matrix.version == 12
+    steps:
+      - run: true
+`,
+			want: `conditions.yml:10:9: job "test": job condition: condition reference "matrix.version" is unavailable in this matrix instance`,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			for name, compile := range map[string]func() error{
@@ -344,6 +391,25 @@ jobs:
 		if !reflect.DeepEqual(ir.Jobs[i].Matrix, want[i]) {
 			t.Fatalf("matrix instance %d = %#v, want %#v", i, ir.Jobs[i].Matrix, want[i])
 		}
+	}
+}
+
+func TestCompileAllowsCompatibleConcreteMatrixConditionTypes(t *testing.T) {
+	source := []byte(`on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [12, 14.0]
+        experimental: [true, false]
+    if: matrix.version == 12
+    steps:
+      - if: matrix.experimental == true
+        run: true
+`)
+	if _, err := Compile("conditions.yml", source, readFile(t, smokePath("events", "push.json"))); err != nil {
+		t.Fatalf("Compile() error = %v", err)
 	}
 }
 

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -137,6 +137,31 @@ jobs:
 `,
 			want: `conditions.yml:6:13: job "test": step 1 condition: condition context "secrets" is unsupported`,
 		},
+		{
+			name: "mixed equality",
+			source: `on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    if: vars.ENABLED == true
+    steps:
+      - run: true
+`,
+			want: `conditions.yml:5:9: job "test": job condition: condition equality compares incompatible string and boolean operands`,
+		},
+		{
+			name: "parallel member condition location",
+			source: `on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - parallel:
+          - if:  vars.ENABLED == true
+            run: true
+`,
+			want: `conditions.yml:7:18: job "test": step "__parallel_6_9_1" condition: condition equality compares incompatible string and boolean operands`,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			for name, compile := range map[string]func() error{

--- a/internal/expression/expression.go
+++ b/internal/expression/expression.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -389,13 +390,14 @@ func conditionMatrixValue(matrix map[string]any, target string) (any, bool) {
 }
 
 func conditionValueCategory(value any) string {
+	if _, ok := conditionNumber(value); ok {
+		return "number"
+	}
 	switch value.(type) {
 	case nil:
 		return "null"
 	case bool:
 		return "boolean"
-	case int, float64, json.Number:
-		return "number"
 	case string:
 		return "string"
 	default:
@@ -682,14 +684,20 @@ func conditionEqual(left, right any) (bool, error) {
 func conditionNumber(value any) (*big.Rat, bool) {
 	var source string
 	switch value := value.(type) {
-	case int:
-		return new(big.Rat).SetInt64(int64(value)), true
-	case float64:
-		source = strconv.FormatFloat(value, 'g', -1, 64)
 	case json.Number:
 		source = value.String()
 	default:
-		return nil, false
+		reflected := reflect.ValueOf(value)
+		switch reflected.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			source = strconv.FormatInt(reflected.Int(), 10)
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			source = strconv.FormatUint(reflected.Uint(), 10)
+		case reflect.Float32, reflect.Float64:
+			source = strconv.FormatFloat(reflected.Float(), 'g', -1, reflected.Type().Bits())
+		default:
+			return nil, false
+		}
 	}
 	number, ok := new(big.Rat).SetString(source)
 	return number, ok

--- a/internal/expression/expression.go
+++ b/internal/expression/expression.go
@@ -265,11 +265,21 @@ func ConditionUsesContext(source, contextName string) (bool, error) {
 // syntax, functions, and contexts implemented by the corresponding runtime
 // phase. Runtime-dependent values are not evaluated.
 func ValidateCondition(source string, scope ConditionScope) error {
+	return validateCondition(source, scope, nil, false)
+}
+
+// ValidateConditionWithMatrix additionally verifies references and operand
+// types against one concrete, statically expanded matrix instance.
+func ValidateConditionWithMatrix(source string, scope ConditionScope, matrix map[string]any) error {
+	return validateCondition(source, scope, matrix, true)
+}
+
+func validateCondition(source string, scope ConditionScope, matrix map[string]any, matrixKnown bool) error {
 	node, empty, err := parseCondition(source)
 	if err != nil || empty {
 		return err
 	}
-	return validateConditionNode(node, scope)
+	return validateConditionNode(node, scope, matrix, matrixKnown)
 }
 
 func parseCondition(source string) (actionlint.ExprNode, bool, error) {
@@ -287,7 +297,7 @@ func parseCondition(source string) (actionlint.ExprNode, bool, error) {
 	return node, false, nil
 }
 
-func validateConditionNode(node actionlint.ExprNode, scope ConditionScope) error {
+func validateConditionNode(node actionlint.ExprNode, scope ConditionScope, matrix map[string]any, matrixKnown bool) error {
 	switch node := node.(type) {
 	case *actionlint.NullNode, *actionlint.BoolNode, *actionlint.IntNode, *actionlint.FloatNode, *actionlint.StringNode:
 		return nil
@@ -296,25 +306,33 @@ func validateConditionNode(node actionlint.ExprNode, scope ConditionScope) error
 		if err != nil {
 			return err
 		}
+		if matrixKnown && strings.EqualFold(root, "matrix") && len(path) == 1 {
+			if _, ok := conditionMatrixValue(matrix, path[0]); !ok {
+				return fmt.Errorf("condition reference %q is unavailable in this matrix instance", root+"."+path[0])
+			}
+		}
 		return validateConditionReference(root, path, scope)
 	case *actionlint.NotOpNode:
-		return validateConditionNode(node.Operand, scope)
+		return validateConditionNode(node.Operand, scope, matrix, matrixKnown)
 	case *actionlint.LogicalOpNode:
-		if err := validateConditionNode(node.Left, scope); err != nil {
+		if err := validateConditionNode(node.Left, scope, matrix, matrixKnown); err != nil {
 			return err
 		}
-		return validateConditionNode(node.Right, scope)
+		return validateConditionNode(node.Right, scope, matrix, matrixKnown)
 	case *actionlint.CompareOpNode:
 		if !node.Kind.IsEqualityOp() {
 			return fmt.Errorf("condition comparison %s is unsupported", node.Kind)
 		}
-		if err := validateConditionNode(node.Left, scope); err != nil {
+		if err := validateConditionNode(node.Left, scope, matrix, matrixKnown); err != nil {
 			return err
 		}
-		if err := validateConditionNode(node.Right, scope); err != nil {
+		if err := validateConditionNode(node.Right, scope, matrix, matrixKnown); err != nil {
 			return err
 		}
-		left, right := conditionOperandCategory(node.Left), conditionOperandCategory(node.Right)
+		left, right := conditionOperandCategory(node.Left, matrix), conditionOperandCategory(node.Right, matrix)
+		if left == "unsupported" || right == "unsupported" {
+			return fmt.Errorf("condition equality uses an unsupported matrix value type")
+		}
 		if left != "unknown" && right != "unknown" && left != right {
 			return fmt.Errorf("condition equality compares incompatible %s and %s operands", left, right)
 		}
@@ -334,7 +352,7 @@ func validateConditionNode(node actionlint.ExprNode, scope ConditionScope) error
 	}
 }
 
-func conditionOperandCategory(node actionlint.ExprNode) string {
+func conditionOperandCategory(node actionlint.ExprNode, matrix map[string]any) string {
 	switch node := node.(type) {
 	case *actionlint.NullNode:
 		return "null"
@@ -345,12 +363,44 @@ func conditionOperandCategory(node actionlint.ExprNode) string {
 	case *actionlint.StringNode:
 		return "string"
 	case *actionlint.VariableNode, *actionlint.ObjectDerefNode, *actionlint.IndexAccessNode:
-		root, _, err := referencePath(node)
-		if err == nil && !strings.EqualFold(root, "matrix") {
+		root, path, err := referencePath(node)
+		if err != nil {
+			return "unknown"
+		}
+		if !strings.EqualFold(root, "matrix") {
 			return "string"
+		}
+		if len(path) == 1 {
+			if value, ok := conditionMatrixValue(matrix, path[0]); ok {
+				return conditionValueCategory(value)
+			}
 		}
 	}
 	return "unknown"
+}
+
+func conditionMatrixValue(matrix map[string]any, target string) (any, bool) {
+	for name, value := range matrix {
+		if strings.EqualFold(name, target) {
+			return value, true
+		}
+	}
+	return nil, false
+}
+
+func conditionValueCategory(value any) string {
+	switch value.(type) {
+	case nil:
+		return "null"
+	case bool:
+		return "boolean"
+	case int, float64, json.Number:
+		return "number"
+	case string:
+		return "string"
+	default:
+		return "unsupported"
+	}
 }
 
 func validateConditionReference(root string, path []string, scope ConditionScope) error {
@@ -609,7 +659,10 @@ func conditionEqual(left, right any) (bool, error) {
 	}
 	switch left := left.(type) {
 	case nil:
-		return right == nil, nil
+		if right != nil {
+			return false, fmt.Errorf("mixed-type condition equality is unsupported")
+		}
+		return true, nil
 	case string:
 		right, ok := right.(string)
 		if !ok {

--- a/internal/expression/expression.go
+++ b/internal/expression/expression.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/big"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/rhysd/actionlint"
@@ -309,7 +311,14 @@ func validateConditionNode(node actionlint.ExprNode, scope ConditionScope) error
 		if err := validateConditionNode(node.Left, scope); err != nil {
 			return err
 		}
-		return validateConditionNode(node.Right, scope)
+		if err := validateConditionNode(node.Right, scope); err != nil {
+			return err
+		}
+		left, right := conditionOperandCategory(node.Left), conditionOperandCategory(node.Right)
+		if left != "unknown" && right != "unknown" && left != right {
+			return fmt.Errorf("condition equality compares incompatible %s and %s operands", left, right)
+		}
+		return nil
 	case *actionlint.FuncCallNode:
 		switch strings.ToLower(node.Callee) {
 		case "always", "success", "failure", "cancelled":
@@ -323,6 +332,25 @@ func validateConditionNode(node actionlint.ExprNode, scope ConditionScope) error
 	default:
 		return fmt.Errorf("unsupported condition expression")
 	}
+}
+
+func conditionOperandCategory(node actionlint.ExprNode) string {
+	switch node := node.(type) {
+	case *actionlint.NullNode:
+		return "null"
+	case *actionlint.BoolNode, *actionlint.NotOpNode, *actionlint.LogicalOpNode, *actionlint.CompareOpNode, *actionlint.FuncCallNode:
+		return "boolean"
+	case *actionlint.IntNode, *actionlint.FloatNode:
+		return "number"
+	case *actionlint.StringNode:
+		return "string"
+	case *actionlint.VariableNode, *actionlint.ObjectDerefNode, *actionlint.IndexAccessNode:
+		root, _, err := referencePath(node)
+		if err == nil && !strings.EqualFold(root, "matrix") {
+			return "string"
+		}
+	}
+	return "unknown"
 }
 
 func validateConditionReference(root string, path []string, scope ConditionScope) error {
@@ -564,18 +592,21 @@ func conditionTruthy(value any) bool {
 		return false
 	case bool:
 		return value
-	case int:
-		return value != 0
-	case float64:
-		return value != 0
 	case string:
 		return value != ""
-	default:
-		return false
 	}
+	number, ok := conditionNumber(value)
+	return ok && number.Sign() != 0
 }
 
 func conditionEqual(left, right any) (bool, error) {
+	if leftNumber, ok := conditionNumber(left); ok {
+		rightNumber, ok := conditionNumber(right)
+		if !ok {
+			return false, fmt.Errorf("mixed-type condition equality is unsupported")
+		}
+		return leftNumber.Cmp(rightNumber) == 0, nil
+	}
 	switch left := left.(type) {
 	case nil:
 		return right == nil, nil
@@ -591,22 +622,24 @@ func conditionEqual(left, right any) (bool, error) {
 			return false, fmt.Errorf("mixed-type condition equality is unsupported")
 		}
 		return left == right, nil
-	case int:
-		switch right := right.(type) {
-		case int:
-			return left == right, nil
-		case float64:
-			return float64(left) == right, nil
-		}
-	case float64:
-		switch right := right.(type) {
-		case int:
-			return left == float64(right), nil
-		case float64:
-			return left == right, nil
-		}
 	}
 	return false, fmt.Errorf("mixed-type condition equality is unsupported")
+}
+
+func conditionNumber(value any) (*big.Rat, bool) {
+	var source string
+	switch value := value.(type) {
+	case int:
+		return new(big.Rat).SetInt64(int64(value)), true
+	case float64:
+		source = strconv.FormatFloat(value, 'g', -1, 64)
+	case json.Number:
+		source = value.String()
+	default:
+		return nil, false
+	}
+	number, ok := new(big.Rat).SetString(source)
+	return number, ok
 }
 
 func containsStatusFunction(node actionlint.ExprNode) bool {

--- a/internal/expression/expression.go
+++ b/internal/expression/expression.go
@@ -69,6 +69,17 @@ type ConditionContext struct {
 	Unsuccessful bool
 }
 
+// ConditionScope identifies the runtime phase in which a workflow condition
+// is evaluated.
+type ConditionScope uint8
+
+const (
+	// JobCondition is evaluated before a job starts.
+	JobCondition ConditionScope = iota
+	// StepCondition is evaluated while a job is running.
+	StepCondition
+)
+
 // CompileContext contains the non-secret values available while constructing
 // a workflow graph. Values are snapshots supplied by the compiler; evaluation
 // never reads the process environment or a secret provider.
@@ -225,16 +236,12 @@ func SecretReferences(template string) ([]string, error) {
 // ConditionUsesContext reports whether a condition references a named context.
 // Conditions may omit the normal ${{ ... }} delimiters.
 func ConditionUsesContext(source, contextName string) (bool, error) {
-	condition := strings.TrimSpace(source)
-	if condition == "" {
+	node, empty, err := parseCondition(source)
+	if err != nil {
+		return false, err
+	}
+	if empty {
 		return false, nil
-	}
-	if strings.HasPrefix(condition, "${{") && strings.HasSuffix(condition, "}}") {
-		condition = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(condition, "${{"), "}}"))
-	}
-	node, parseErr := actionlint.NewExprParser().Parse(actionlint.NewExprLexer(condition + "}}"))
-	if parseErr != nil {
-		return false, fmt.Errorf("parse condition: %w", parseErr)
 	}
 	found := false
 	actionlint.VisitExprNode(node, func(node, _ actionlint.ExprNode, entering bool) {
@@ -250,6 +257,125 @@ func ConditionUsesContext(source, contextName string) (bool, error) {
 		found = strings.EqualFold(root, contextName)
 	})
 	return found, nil
+}
+
+// ValidateCondition verifies that a job or step condition uses only expression
+// syntax, functions, and contexts implemented by the corresponding runtime
+// phase. Runtime-dependent values are not evaluated.
+func ValidateCondition(source string, scope ConditionScope) error {
+	node, empty, err := parseCondition(source)
+	if err != nil || empty {
+		return err
+	}
+	return validateConditionNode(node, scope)
+}
+
+func parseCondition(source string) (actionlint.ExprNode, bool, error) {
+	condition := strings.TrimSpace(source)
+	if condition == "" {
+		return nil, true, nil
+	}
+	if strings.HasPrefix(condition, "${{") && strings.HasSuffix(condition, "}}") {
+		condition = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(condition, "${{"), "}}"))
+	}
+	node, err := actionlint.NewExprParser().Parse(actionlint.NewExprLexer(condition + "}}"))
+	if err != nil {
+		return nil, false, fmt.Errorf("parse condition: %w", err)
+	}
+	return node, false, nil
+}
+
+func validateConditionNode(node actionlint.ExprNode, scope ConditionScope) error {
+	switch node := node.(type) {
+	case *actionlint.NullNode, *actionlint.BoolNode, *actionlint.IntNode, *actionlint.FloatNode, *actionlint.StringNode:
+		return nil
+	case *actionlint.VariableNode, *actionlint.ObjectDerefNode, *actionlint.IndexAccessNode:
+		root, path, err := referencePath(node)
+		if err != nil {
+			return err
+		}
+		return validateConditionReference(root, path, scope)
+	case *actionlint.NotOpNode:
+		return validateConditionNode(node.Operand, scope)
+	case *actionlint.LogicalOpNode:
+		if err := validateConditionNode(node.Left, scope); err != nil {
+			return err
+		}
+		return validateConditionNode(node.Right, scope)
+	case *actionlint.CompareOpNode:
+		if !node.Kind.IsEqualityOp() {
+			return fmt.Errorf("condition comparison %s is unsupported", node.Kind)
+		}
+		if err := validateConditionNode(node.Left, scope); err != nil {
+			return err
+		}
+		return validateConditionNode(node.Right, scope)
+	case *actionlint.FuncCallNode:
+		switch strings.ToLower(node.Callee) {
+		case "always", "success", "failure", "cancelled":
+			if len(node.Args) != 0 {
+				return fmt.Errorf("condition function %q arguments are unsupported", node.Callee)
+			}
+			return nil
+		default:
+			return fmt.Errorf("condition function %q is unsupported", node.Callee)
+		}
+	default:
+		return fmt.Errorf("unsupported condition expression")
+	}
+}
+
+func validateConditionReference(root string, path []string, scope ConditionScope) error {
+	reference := root
+	if len(path) != 0 {
+		reference += "." + strings.Join(path, ".")
+	}
+	switch strings.ToLower(root) {
+	case "github":
+		if len(path) == 1 {
+			switch strings.ToLower(path[0]) {
+			case "actor", "event_name", "ref", "repository", "sha":
+				return nil
+			}
+		}
+		return fmt.Errorf("condition reference %q is unavailable at runtime; supported github properties are actor, event_name, ref, repository, and sha", reference)
+	case "needs":
+		if len(path) == 2 && strings.EqualFold(path[1], "result") || len(path) == 3 && strings.EqualFold(path[1], "outputs") {
+			return nil
+		}
+		return fmt.Errorf("condition reference %q is unsupported; expected needs.<job>.result or needs.<job>.outputs.<name>", reference)
+	case "vars", "matrix":
+		if len(path) == 1 {
+			return nil
+		}
+		return fmt.Errorf("condition reference %q is unsupported; expected %s.<name>", reference, strings.ToLower(root))
+	case "steps":
+		if scope == JobCondition {
+			return fmt.Errorf("condition context %q is unavailable in job conditions", root)
+		}
+		if len(path) == 2 && (strings.EqualFold(path[1], "outcome") || strings.EqualFold(path[1], "conclusion")) || len(path) == 3 && strings.EqualFold(path[1], "outputs") {
+			return nil
+		}
+		return fmt.Errorf("condition reference %q is unsupported; expected steps.<step>.outcome, steps.<step>.conclusion, or steps.<step>.outputs.<name>", reference)
+	case "env":
+		if scope == JobCondition {
+			return fmt.Errorf("condition context %q is unavailable in job conditions", root)
+		}
+		if len(path) == 1 {
+			return nil
+		}
+		return fmt.Errorf("condition reference %q is unsupported; expected env.<name>", reference)
+	case "job":
+		if scope == JobCondition {
+			return fmt.Errorf("condition context %q is unavailable in job conditions", root)
+		}
+		if len(path) == 4 && strings.EqualFold(path[0], "services") && strings.EqualFold(path[2], "ports") {
+			return nil
+		}
+		return fmt.Errorf("condition reference %q is unsupported; expected job.services.<service>.ports[<port>]", reference)
+	default:
+		return fmt.Errorf("condition context %q is unsupported", root)
+	}
 }
 
 func visitTemplateExpressions(template string, visit func(actionlint.ExprNode) error) error {
@@ -279,16 +405,12 @@ func visitTemplateExpressions(template string, visit func(actionlint.ExprNode) e
 // EvaluateCondition evaluates a job or step condition. Unsupported syntax and
 // unavailable values fail closed with an error.
 func EvaluateCondition(source string, context ConditionContext) (bool, error) {
-	condition := strings.TrimSpace(source)
-	if condition == "" {
+	node, empty, err := parseCondition(source)
+	if err != nil {
+		return false, err
+	}
+	if empty {
 		return !context.Unsuccessful && !context.Cancelled, nil
-	}
-	if strings.HasPrefix(condition, "${{") && strings.HasSuffix(condition, "}}") {
-		condition = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(condition, "${{"), "}}"))
-	}
-	node, parseErr := actionlint.NewExprParser().Parse(actionlint.NewExprLexer(condition + "}}"))
-	if parseErr != nil {
-		return false, fmt.Errorf("parse condition: %w", parseErr)
 	}
 	value, err := evaluateConditionNode(node, context)
 	if err != nil {

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -254,6 +254,21 @@ func TestValidateConditionUsesConcreteMatrixTypes(t *testing.T) {
 	}
 }
 
+func TestValidateConditionAcceptsCompilerNumericKinds(t *testing.T) {
+	values := []any{
+		int(-1), int8(-1), int16(-1), int32(-1), int64(-1),
+		uint(1), uint8(1), uint16(1), uint32(1), uint64(1), ^uint64(0),
+		float32(1.5), float64(1.5), json.Number("1e3"),
+	}
+	for _, value := range values {
+		t.Run(reflect.TypeOf(value).String(), func(t *testing.T) {
+			if err := ValidateConditionWithMatrix("matrix.value != 0", JobCondition, map[string]any{"value": value}); err != nil {
+				t.Fatalf("ValidateConditionWithMatrix(%T) error = %v", value, err)
+			}
+		})
+	}
+}
+
 func TestEvaluateFailsClosed(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -165,6 +165,59 @@ func TestConditionUsesContextSupportsOptionalDelimiters(t *testing.T) {
 	}
 }
 
+func TestValidateConditionAllowsSupportedRuntimeExpressions(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		source string
+		scope  ConditionScope
+	}{
+		{
+			name:   "job dependencies and identity",
+			source: "always() && needs.build.result == 'success' && needs.build.outputs.ready && github.ref == 'refs/heads/main' && vars.ENABLED && matrix.os",
+			scope:  JobCondition,
+		},
+		{
+			name:   "step status environment and services",
+			source: "${{ failure() && steps.test.outcome == 'failure' && steps.test.conclusion == 'success' && steps.test.outputs.ready && env.LEVEL && job.services.redis.ports[6379] }}",
+			scope:  StepCondition,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := ValidateCondition(test.source, test.scope); err != nil {
+				t.Fatalf("ValidateCondition() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateConditionRejectsUnsupportedRuntimeExpressions(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		source string
+		scope  ConditionScope
+		want   string
+	}{
+		{name: "unsupported function", source: "hashFiles()", scope: StepCondition, want: `condition function "hashFiles" is unsupported`},
+		{name: "function arguments", source: "always(true)", scope: StepCondition, want: `condition function "always" arguments are unsupported`},
+		{name: "ordered comparison", source: "matrix.count > 1", scope: JobCondition, want: "condition comparison > is unsupported"},
+		{name: "runtime event payload", source: "github.event.pull_request.draft", scope: JobCondition, want: `condition reference "github.event.pull_request.draft" is unavailable at runtime`},
+		{name: "unsupported github property", source: "github.run_id", scope: StepCondition, want: `condition reference "github.run_id" is unavailable at runtime`},
+		{name: "step context in job", source: "steps.build.outcome", scope: JobCondition, want: `condition context "steps" is unavailable in job conditions`},
+		{name: "environment in job", source: "env.ENABLED", scope: JobCondition, want: `condition context "env" is unavailable in job conditions`},
+		{name: "unsupported context", source: "secrets.TOKEN", scope: StepCondition, want: `condition context "secrets" is unsupported`},
+		{name: "unsupported need shape", source: "needs.build.status", scope: JobCondition, want: `expected needs.<job>.result`},
+		{name: "dynamic index", source: "steps[env.STEP].outcome", scope: StepCondition, want: "expression index must be a string literal"},
+		{name: "malformed", source: "${{ github.ref == }}", scope: JobCondition, want: "parse condition"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := ValidateCondition(test.source, test.scope)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("ValidateCondition() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
 func TestEvaluateFailsClosed(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -225,6 +225,35 @@ func TestValidateConditionRejectsUnsupportedRuntimeExpressions(t *testing.T) {
 	}
 }
 
+func TestValidateConditionUsesConcreteMatrixTypes(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		source string
+		matrix map[string]any
+		want   string
+	}{
+		{name: "numeric value", source: "matrix.version == 12", matrix: map[string]any{"version": 14.0}},
+		{name: "json numeric value", source: "matrix.version == 12", matrix: map[string]any{"version": json.Number("14")}},
+		{name: "boolean value", source: "matrix.experimental == true", matrix: map[string]any{"experimental": false}},
+		{name: "string and number", source: "matrix.version == 12", matrix: map[string]any{"version": "14"}, want: "condition equality compares incompatible string and number operands"},
+		{name: "null and number", source: "matrix.version == 12", matrix: map[string]any{"version": nil}, want: "condition equality compares incompatible null and number operands"},
+		{name: "missing value", source: "matrix.version == 12", matrix: map[string]any{}, want: `condition reference "matrix.version" is unavailable in this matrix instance`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := ValidateConditionWithMatrix(test.source, JobCondition, test.matrix)
+			if test.want == "" && err != nil {
+				t.Fatalf("ValidateCondition() error = %v", err)
+			}
+			if test.want != "" && (err == nil || !strings.Contains(err.Error(), test.want)) {
+				t.Fatalf("ValidateCondition() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+	if err := ValidateCondition("matrix.version == 12", JobCondition); err != nil {
+		t.Fatalf("ValidateCondition() rejected unknown matrix type: %v", err)
+	}
+}
+
 func TestEvaluateFailsClosed(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -319,6 +348,9 @@ func TestEvaluateConditionFailsClosed(t *testing.T) {
 	}
 	if _, err := EvaluateCondition("true == 'true'", ConditionContext{}); err == nil {
 		t.Fatal("EvaluateCondition() silently coerced mixed equality operands")
+	}
+	if _, err := EvaluateCondition("null == true", ConditionContext{}); err == nil {
+		t.Fatal("EvaluateCondition() accepted mixed null equality operands")
 	}
 	if got, err := EvaluateCondition("", ConditionContext{Unsuccessful: true}); err != nil || got {
 		t.Fatalf("default condition after skipped prerequisite = %v, %v, want false", got, err)

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -1,6 +1,7 @@
 package expression
 
 import (
+	"encoding/json"
 	"reflect"
 	"strings"
 	"testing"
@@ -181,6 +182,10 @@ func TestValidateConditionAllowsSupportedRuntimeExpressions(t *testing.T) {
 			source: "${{ failure() && steps.test.outcome == 'failure' && steps.test.conclusion == 'success' && steps.test.outputs.ready && env.LEVEL && job.services.redis.ports[6379] }}",
 			scope:  StepCondition,
 		},
+		{name: "compatible booleans", source: "success() == true", scope: JobCondition},
+		{name: "compatible strings", source: "vars.ENABLED == 'true'", scope: JobCondition},
+		{name: "compatible integer and float", source: "1 == 1.0", scope: JobCondition},
+		{name: "runtime-dependent matrix value", source: "matrix.enabled == true", scope: JobCondition},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			if err := ValidateCondition(test.source, test.scope); err != nil {
@@ -207,6 +212,8 @@ func TestValidateConditionRejectsUnsupportedRuntimeExpressions(t *testing.T) {
 		{name: "unsupported context", source: "secrets.TOKEN", scope: StepCondition, want: `condition context "secrets" is unsupported`},
 		{name: "unsupported need shape", source: "needs.build.status", scope: JobCondition, want: `expected needs.<job>.result`},
 		{name: "dynamic index", source: "steps[env.STEP].outcome", scope: StepCondition, want: "expression index must be a string literal"},
+		{name: "string and boolean equality", source: "vars.ENABLED == true", scope: JobCondition, want: "condition equality compares incompatible string and boolean operands"},
+		{name: "boolean and number equality", source: "success() != 1", scope: JobCondition, want: "condition equality compares incompatible boolean and number operands"},
 		{name: "malformed", source: "${{ github.ref == }}", scope: JobCondition, want: "parse condition"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -280,6 +287,29 @@ func TestEvaluateConditionInputsMatchNormalExpressionSemantics(t *testing.T) {
 		if err != nil || got != want {
 			t.Errorf("EvaluateCondition(%q) = %v, %v, want %v", condition, got, err, want)
 		}
+	}
+}
+
+func TestEvaluateConditionSupportsJSONNumbers(t *testing.T) {
+	tests := []struct {
+		name      string
+		condition string
+		matrix    map[string]any
+		want      bool
+	}{
+		{name: "json number and int", condition: "matrix.value == 1", matrix: map[string]any{"value": json.Number("1")}, want: true},
+		{name: "json number and float", condition: "matrix.value == 1.5", matrix: map[string]any{"value": json.Number("1.5")}, want: true},
+		{name: "json numbers", condition: "matrix.left == matrix.right", matrix: map[string]any{"left": json.Number("1e3"), "right": json.Number("1000")}, want: true},
+		{name: "nonzero truthiness", condition: "matrix.value", matrix: map[string]any{"value": json.Number("0.25")}, want: true},
+		{name: "zero truthiness", condition: "matrix.value", matrix: map[string]any{"value": json.Number("0")}, want: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := EvaluateCondition(test.condition, ConditionContext{Matrix: test.matrix})
+			if err != nil || got != test.want {
+				t.Fatalf("EvaluateCondition(%q) = %v, %v, want %v", test.condition, got, err, test.want)
+			}
+		})
 	}
 }
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1894,13 +1894,15 @@ func TestDecodedPlanMatrixNumbersDriveRuntimeConditions(t *testing.T) {
 	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
 	nonzeroMarker := filepath.Join(workspace, "nonzero")
 	zeroMarker := filepath.Join(workspace, "zero")
+	maxUintMarker := filepath.Join(workspace, "max-uint")
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{
 		{ID: "nonzero", Kind: "run", Condition: "matrix.nonzero", Command: `touch "$NONZERO"`},
 		{ID: "zero", Kind: "run", Condition: "matrix.zero", Command: `touch "$ZERO"`},
+		{ID: "max-uint", Kind: "run", Condition: "matrix.max_uint != 0", Command: `touch "$MAX_UINT"`},
 	})
 	job.Condition = "matrix.count == 1"
-	job.Matrix = map[string]any{"count": 1, "nonzero": 2, "zero": 0}
-	job.Env = map[string]string{"NONZERO": nonzeroMarker, "ZERO": zeroMarker}
+	job.Matrix = map[string]any{"count": 1, "nonzero": 2, "zero": 0, "max_uint": ^uint64(0)}
+	job.Env = map[string]string{"NONZERO": nonzeroMarker, "ZERO": zeroMarker, "MAX_UINT": maxUintMarker}
 
 	encoded, err := plan.Encode(job)
 	if err != nil {
@@ -1919,6 +1921,9 @@ func TestDecodedPlanMatrixNumbersDriveRuntimeConditions(t *testing.T) {
 	}
 	if _, err := os.Stat(zeroMarker); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("zero matrix condition unexpectedly ran: %v", err)
+	}
+	if _, err := os.Stat(maxUintMarker); err != nil {
+		t.Fatalf("max uint64 matrix condition did not run: %v", err)
 	}
 }
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1888,6 +1888,40 @@ func TestJobConditionConsumesNeedResultAndOutput(t *testing.T) {
 	}
 }
 
+func TestDecodedPlanMatrixNumbersDriveRuntimeConditions(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	nonzeroMarker := filepath.Join(workspace, "nonzero")
+	zeroMarker := filepath.Join(workspace, "zero")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{
+		{ID: "nonzero", Kind: "run", Condition: "matrix.nonzero", Command: `touch "$NONZERO"`},
+		{ID: "zero", Kind: "run", Condition: "matrix.zero", Command: `touch "$ZERO"`},
+	})
+	job.Condition = "matrix.count == 1"
+	job.Matrix = map[string]any{"count": 1, "nonzero": 2, "zero": 0}
+	job.Env = map[string]string{"NONZERO": nonzeroMarker, "ZERO": zeroMarker}
+
+	encoded, err := plan.Encode(job)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := plan.Decode(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := (Runner{}).RunJob(context.Background(), decoded, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	if _, err := os.Stat(nonzeroMarker); err != nil {
+		t.Fatalf("nonzero matrix condition did not run: %v", err)
+	}
+	if _, err := os.Stat(zeroMarker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("zero matrix condition unexpectedly ran: %v", err)
+	}
+}
+
 func TestRunJobRejectsRegisteredSecretInOutput(t *testing.T) {
 	workspace := t.TempDir()
 	workflowPath := ".github/workflows/test.yml"

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -64,6 +64,7 @@ type Job struct {
 	Env                     map[string]string      `json:"env,omitempty"`
 	Permissions             *Permissions           `json:"permissions,omitempty"`
 	If                      string                 `json:"if,omitempty"`
+	IfSpan                  Span                   `json:"-"`
 	TimeoutMinutes          float64                `json:"timeout_minutes,omitempty"`
 	Outputs                 map[string]string      `json:"outputs,omitempty"`
 	Container               *Container             `json:"container,omitempty"`
@@ -141,6 +142,7 @@ type Step struct {
 	Env              map[string]string `json:"env,omitempty"`
 	With             map[string]string `json:"with,omitempty"`
 	If               string            `json:"if,omitempty"`
+	IfSpan           Span              `json:"-"`
 	ContinueOnError  bool              `json:"continue_on_error,omitempty"`
 	TimeoutMinutes   float64           `json:"timeout_minutes,omitempty"`
 	Span             Span              `json:"span"`

--- a/internal/workflow/parse.go
+++ b/internal/workflow/parse.go
@@ -943,6 +943,9 @@ func parseParallelStep(path string, node *yaml.Node) (Step, error) {
 	if step.If, err = optionalScalar(entries["if"]); err != nil {
 		return Step{}, yamlNodeError(path, entries["if"], "parallel member if must be a scalar")
 	}
+	if value := entries["if"]; value != nil {
+		step.IfSpan = yamlStepSpan(value, value)
+	}
 	if step.Env, err = scalarMap(entries["env"]); err != nil {
 		return Step{}, yamlNodeError(path, entries["env"], "parallel member env must be a scalar mapping")
 	}

--- a/internal/workflow/parse.go
+++ b/internal/workflow/parse.go
@@ -297,6 +297,7 @@ func adaptJob(path string, in *actionlint.Job, scalars map[Position]any, concurr
 	}
 	if in.If != nil {
 		out.If = in.If.Value
+		out.IfSpan = spanFrom(in.If.Pos, in.If.Value)
 	}
 	if in.Container != nil {
 		container, err := adaptContainer(path, in.ID.Value, in.Container)
@@ -434,6 +435,7 @@ func adaptJob(path string, in *actionlint.Job, scalars map[Position]any, concurr
 		}
 		if step.If != nil {
 			owned.If = step.If.Value
+			owned.IfSpan = spanFrom(step.If.Pos, step.If.Value)
 		}
 		if step.ContinueOnError != nil {
 			if step.ContinueOnError.Expression != nil {

--- a/internal/workflow/parse_test.go
+++ b/internal/workflow/parse_test.go
@@ -305,7 +305,7 @@ jobs:
       - id: prior
         run: echo "ready=true" >> "$GITHUB_OUTPUT"
       - parallel:
-          - if: steps.prior.outputs.ready == 'true'
+          - if:  steps.prior.outputs.ready == 'true'
             env:
               MATRIX_OS: ${{ matrix.os }}
               NEED_VALUE: ${{ needs.prepare.outputs.artifact }}
@@ -316,7 +316,7 @@ jobs:
 		t.Fatal(err)
 	}
 	steps := parsed.Jobs[1].Steps
-	if len(steps) != 3 || steps[1].If != "steps.prior.outputs.ready == 'true'" || steps[1].Env["MATRIX_OS"] != "${{ matrix.os }}" || steps[1].Env["NEED_VALUE"] != "${{ needs.prepare.outputs.artifact }}" {
+	if len(steps) != 3 || steps[1].If != "steps.prior.outputs.ready == 'true'" || steps[1].IfSpan.Start.Line != 20 || steps[1].IfSpan.Start.Column != 18 || steps[1].Env["MATRIX_OS"] != "${{ matrix.os }}" || steps[1].Env["NEED_VALUE"] != "${{ needs.prepare.outputs.artifact }}" {
 		t.Fatalf("parallel member context expressions = %#v", steps)
 	}
 }


### PR DESCRIPTION
## Summary

- statically validate workflow job and step `if` conditions against the expression forms and runtime contexts implemented by buildkite-gha
- reject unsupported functions, operators, reference shapes, dynamic indices, and unavailable contexts before generated jobs are uploaded
- report the workflow path, exact condition location, affected job, and affected step where applicable
- update the public compatibility documentation to describe the preflighted condition subset

## Supported behavior preserved

Runtime-dependent conditions using `needs`, `steps`, `matrix`, `vars`, step `env`, service ports, retained GitHub identity fields, and the zero-argument status functions continue to compile unchanged. Local reusable-workflow inputs are still statically substituted before condition validation.

The validation is shared by `validate`, profile validation, `compile`, and `upload`. The upload test verifies an incompatible condition fails before any Buildkite Agent command is invoked.

## Scope

This does not add expression functions, transport the event payload into job plans, or change workflow/job concurrency handling.

## Validation

- `mise run check`
- independent review for compiler/runtime phase mismatches and false positives