### PR TITLE
Support workflow and job concurrency groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ The plugin path currently supports:
 - static matrices, ordinary `needs` and outputs, and local reusable workflows
   with statically resolved inputs, caller-visible results, and directly mapped
   declared outputs;
+- statically resolvable workflow and job `concurrency` groups, translated to
+  repository-scoped Buildkite queues and whole-workflow concurrency gates;
 - the documented job and step condition subset, with unsupported functions and
   unavailable runtime contexts rejected before pipeline upload;
 - background, wait, cancellation, and parallel step controls;
@@ -129,6 +131,8 @@ It does **not** currently support:
 - job containers or service containers through the production plugin path;
 - compound or literal local reusable-workflow output mappings and reusable-call
   conditions;
+- `concurrency.cancel-in-progress`, runtime-dependent concurrency groups, or
+  workflow-level concurrency declared by a called reusable workflow;
 - privileged containers, arbitrary Docker options, or `docker://` actions; or
 - Windows or macOS jobs.
 
@@ -178,6 +182,7 @@ runtime behavior. JSON output is available with `--format json`.
 | Matrix entry | Command job with a stable key |
 | `needs` | `depends_on` plus verified result transport |
 | `runs-on` | Fail-closed queue policy |
+| `concurrency.group` | Repository-scoped Buildkite concurrency group or workflow gate |
 | Job output | Producer-attributed result artifact |
 | Step | Runs inside the job compatibility runtime |
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -36,7 +36,7 @@ provide.
 | Bash and `sh` steps | Supported | Includes environment and working-directory precedence. |
 | Static job graphs and `needs` | Supported | Dependencies and logical results are preserved. |
 | Static matrices | Supported | Includes typed values, `include`, `exclude`, and exact dependency fan-out. |
-| Workflow and job concurrency | Not supported | `concurrency.group` and `cancel-in-progress` fail compilation instead of being silently discarded. Configure equivalent behavior in Buildkite. `strategy.max-parallel` is translated separately for static matrix jobs. |
+| Workflow and job concurrency | Supported subset | Statically resolvable groups become repository-scoped, case-insensitive Buildkite concurrency groups. Workflow groups use an ordered opening/closing gate; job groups use `concurrency: 1`. Buildkite queues all waiting builds/jobs instead of replacing GitHub's previously pending entry. `cancel-in-progress` remains unsupported. |
 | Local reusable workflows | Supported subset | Statically resolvable local calls preserve source-level `needs` names and expose an aggregate `needs.<call>.result` from every callee job. Declared outputs mapped directly from `jobs.<job>.outputs.<name>` are exposed through `needs.<call>.outputs`; nested calls are supported and undeclared callee outputs remain hidden. Matrix-selected declarations verify every exact producer and fail closed when values conflict or exceed 64 concrete projections. Literal or compound output mappings, call-level conditions, and remote or runtime-dependent reusable workflows are deferred. Caller prerequisites inherited by callee roots are status-only. |
 | Job and step conditions | Supported subset | Validation accepts literals, logical operators, `==`, `!=`, and the zero-argument `always`, `success`, `failure`, and `cancelled` status functions. Job conditions can use `github` identity fields, `needs`, `vars`, and `matrix`; step conditions additionally support `steps`, `env`, and service ports. Unsupported functions, operators, reference shapes, and unavailable contexts fail before pipeline upload. |
 | Concurrent step controls | Supported | Includes `background`, `wait`, `wait-all`, `cancel`, and `parallel`. |
@@ -77,6 +77,50 @@ Buildkite annotations. Their publication is attempted after the authoritative
 logical result; an annotation API failure is reported as a warning but does not
 rewrite an otherwise successful job. Successfully parsed warning/error command
 lines are consumed and their decoded messages remain visible in the job log.
+
+### Concurrency groups queue instead of canceling
+
+Literal workflow and job `concurrency` shorthand is supported, as is the
+mapping form when `cancel-in-progress` is omitted or the literal `false`:
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    concurrency: deploy-${{ matrix.target }}
+```
+
+Groups must resolve during compilation. Direct substitutions can use `vars`,
+concrete `matrix` values for job groups, statically substituted `inputs` in jobs
+from local reusable workflows, and the available `github` fields: `actor`,
+`event`, `event_name`, `ref`, `repository`, `repository_owner`, `sha`, and
+`workflow`. Other fields and expression operators/functions fail closed; for
+example, `github.head_ref || github.run_id` is not available. Runtime
+`needs`/`strategy` values and workflow-level concurrency in a called reusable
+workflow also fail closed. A matrix job may combine
+`strategy.max-parallel` with concurrency only when every matrix entry resolves
+to the same case-insensitive group; the group limit of one then subsumes
+`max-parallel`.
+
+Generated group identities are hashed with the event repository. This keeps
+GitHub's repository scope and case-insensitive matching without exposing event
+values or exceeding Buildkite's 200-character concurrency-key limit. A
+workflow-level group emits Buildkite's ordered opening/closing gate steps, so
+jobs inside one admitted workflow run retain their normal parallelism.
+
+This is queue compatibility, not cancellation parity. Buildkite retains all
+waiting entries in FIFO order, while GitHub's default concurrency mode replaces
+an existing pending entry. The newer GitHub `queue` property is not yet accepted
+by the pinned syntax frontend; generated Buildkite groups always queue all
+entries. Literal `cancel-in-progress: true` and every expression-valued
+`cancel-in-progress` fail compilation because the bridge has no safely scoped
+cross-build cancellation mechanism. For a workflow-level gate, cancel the
+Buildkite build rather than one generated job: an individually canceled
+dependency does not execute the closing gate step, while whole-build
+cancellation removes that build's queued gate jobs.
 
 ### Concurrent steps stay inside the job
 

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -644,9 +644,14 @@ Pipeline upload is limited in size and job count. The emitter must detect the
 current limit, fail clearly or split large uploads without changing dependency
 semantics, and never depend on the visual ordering of multiple uploads.
 
-Buildkite concurrency groups can model queued access and `strategy.max-parallel`
-for expanded matrix jobs. They do not directly implement GHA
-`concurrency.cancel-in-progress`; report that as a compatibility gap until the
+Buildkite concurrency groups model queued job access and `strategy.max-parallel`
+for expanded matrix jobs. Ordered opening/closing concurrency gates serialize a
+whole imported workflow without serializing that workflow's internal jobs.
+User groups are case-normalized and hashed with the event repository so their
+Buildkite organization-wide identity preserves GitHub's repository scope and
+fits Buildkite's concurrency-key limit. These mechanisms queue every waiting
+entry; they do not implement GHA's pending-entry replacement or
+`concurrency.cancel-in-progress`. Report those as compatibility gaps until the
 bridge has an explicit, safely scoped cancellation mechanism.
 
 ### Graph and result semantics

--- a/internal/buildkite/pipeline.go
+++ b/internal/buildkite/pipeline.go
@@ -4,6 +4,7 @@ package buildkite
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"regexp"
@@ -13,6 +14,7 @@ import (
 
 const planDirectory = ".buildkite-gha/plans"
 const distributionDirectory = ".buildkite-gha/distributions"
+const maxConcurrencyGroupLength = 200
 
 // MinimumMiseVersion is the oldest supported mise release and the exact
 // release installed when no compatible runtime executable is available.
@@ -27,7 +29,15 @@ type Pipeline struct {
 	CompilerStep       string
 	DistributionDigest string
 	GroupLabel         string
+	ConcurrencyGate    *ConcurrencyGate
 	Jobs               []Job
+}
+
+// ConcurrencyGate serializes an entire generated workflow while allowing the
+// jobs between its opening and closing steps to run in parallel.
+type ConcurrencyGate struct {
+	Group string
+	Queue string
 }
 
 // DistributionPath returns the fixed local path for a content-addressed
@@ -79,6 +89,9 @@ func Emit(pipeline Pipeline) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := validateConcurrencyGate(pipeline.ConcurrencyGate); err != nil {
+		return nil, err
+	}
 	distributionPath, err := DistributionPath(pipeline.DistributionDigest)
 	if err != nil {
 		return nil, err
@@ -92,6 +105,11 @@ func Emit(pipeline Pipeline) ([]byte, error) {
 		stepIndent = "      "
 	}
 	attributeIndent := stepIndent + "  "
+	var gateOpenKey, gateCloseKey string
+	if pipeline.ConcurrencyGate != nil {
+		gateOpenKey, gateCloseKey = concurrencyGateKeys(pipeline.CompilerStep, pipeline.ConcurrencyGate.Group, jobs)
+		emitConcurrencyGateStep(&out, stepIndent, attributeIndent, ":github: Start workflow concurrency", gateOpenKey, pipeline.ConcurrencyGate, []dependency{{Step: pipeline.CompilerStep}})
+	}
 	for _, job := range jobs {
 		planPath, err := PlanPath(job.PlanDigest)
 		if err != nil {
@@ -136,11 +154,84 @@ func Emit(pipeline Pipeline) ([]byte, error) {
 		}
 		_, _ = fmt.Fprintf(&out, "%sdepends_on:\n", attributeIndent)
 		_, _ = fmt.Fprintf(&out, "%s  - step: %s\n%s    allow_failure: false\n", attributeIndent, yamlScalar(pipeline.CompilerStep), attributeIndent)
+		if gateOpenKey != "" {
+			_, _ = fmt.Fprintf(&out, "%s  - step: %s\n%s    allow_failure: false\n", attributeIndent, yamlScalar(gateOpenKey), attributeIndent)
+		}
 		for _, dependency := range job.Dependencies {
 			_, _ = fmt.Fprintf(&out, "%s  - step: %s\n%s    allow_failure: true\n", attributeIndent, yamlScalar(dependency), attributeIndent)
 		}
 	}
+	if pipeline.ConcurrencyGate != nil {
+		dependencies := make([]dependency, 0, len(jobs)+1)
+		dependencies = append(dependencies, dependency{Step: pipeline.CompilerStep})
+		for _, job := range jobs {
+			dependencies = append(dependencies, dependency{Step: job.Key, AllowFailure: true})
+		}
+		emitConcurrencyGateStep(&out, stepIndent, attributeIndent, ":github: Finish workflow concurrency", gateCloseKey, pipeline.ConcurrencyGate, dependencies)
+	}
 	return out.Bytes(), nil
+}
+
+type dependency struct {
+	Step         string
+	AllowFailure bool
+}
+
+func emitConcurrencyGateStep(out *bytes.Buffer, stepIndent, attributeIndent, label, key string, gate *ConcurrencyGate, dependencies []dependency) {
+	_, _ = fmt.Fprintf(out, "%s- label: %s\n", stepIndent, yamlScalar(label))
+	_, _ = fmt.Fprintf(out, "%skey: %s\n", attributeIndent, yamlScalar(key))
+	_, _ = fmt.Fprintf(out, "%scommand: %s\n", attributeIndent, yamlScalar("true"))
+	_, _ = fmt.Fprintf(out, "%sagents:\n", attributeIndent)
+	_, _ = fmt.Fprintf(out, "%s  queue: %s\n", attributeIndent, yamlScalar(gate.Queue))
+	_, _ = fmt.Fprintf(out, "%scheckout:\n%s  skip: true\n", attributeIndent, attributeIndent)
+	_, _ = fmt.Fprintf(out, "%sconcurrency: 1\n", attributeIndent)
+	_, _ = fmt.Fprintf(out, "%sconcurrency_group: %s\n", attributeIndent, yamlScalar(gate.Group))
+	_, _ = fmt.Fprintf(out, "%sdepends_on:\n", attributeIndent)
+	for _, dependency := range dependencies {
+		_, _ = fmt.Fprintf(out, "%s  - step: %s\n%s    allow_failure: %t\n", attributeIndent, yamlScalar(dependency.Step), attributeIndent, dependency.AllowFailure)
+	}
+}
+
+func validateConcurrencyGate(gate *ConcurrencyGate) error {
+	if gate == nil {
+		return nil
+	}
+	if gate.Group == "" || len(gate.Group) > maxConcurrencyGroupLength {
+		return fmt.Errorf("invalid workflow concurrency group")
+	}
+	if !identifierPattern.MatchString(gate.Queue) {
+		return fmt.Errorf("workflow concurrency gate has invalid queue %q", gate.Queue)
+	}
+	return nil
+}
+
+func concurrencyGateKeys(compilerStep, group string, jobs []Job) (string, string) {
+	digest := sha256Sum(group)
+	used := map[string]struct{}{compilerStep: {}}
+	for _, job := range jobs {
+		used[job.Key] = struct{}{}
+	}
+	open := uniqueStepKey("gha-concurrency-start-"+digest, used)
+	used[open] = struct{}{}
+	close := uniqueStepKey("gha-concurrency-finish-"+digest, used)
+	return open, close
+}
+
+func sha256Sum(value string) string {
+	digest := sha256.Sum256([]byte(value))
+	return fmt.Sprintf("%x", digest[:6])
+}
+
+func uniqueStepKey(base string, used map[string]struct{}) string {
+	if _, exists := used[base]; !exists {
+		return base
+	}
+	for suffix := 2; ; suffix++ {
+		candidate := fmt.Sprintf("%s-%d", base, suffix)
+		if _, exists := used[candidate]; !exists {
+			return candidate
+		}
+	}
 }
 
 func shellQuote(value string) string {
@@ -225,6 +316,9 @@ func validateJob(compilerStep string, job Job) error {
 	}
 	if job.Concurrency > 0 && job.ConcurrencyGroup == "" || job.Concurrency == 0 && job.ConcurrencyGroup != "" {
 		return fmt.Errorf("job %q requires concurrency and concurrency group together", job.Key)
+	}
+	if len(job.ConcurrencyGroup) > maxConcurrencyGroupLength {
+		return fmt.Errorf("job %q concurrency group exceeds %d characters", job.Key, maxConcurrencyGroupLength)
 	}
 	for _, dependency := range job.Dependencies {
 		if !validStepKey(dependency) || dependency == compilerStep || dependency == job.Key {

--- a/internal/buildkite/pipeline.go
+++ b/internal/buildkite/pipeline.go
@@ -206,7 +206,7 @@ func validateConcurrencyGate(gate *ConcurrencyGate) error {
 }
 
 func concurrencyGateKeys(compilerStep, group string, jobs []Job) (string, string) {
-	digest := sha256Sum(group)
+	digest := sha256Sum(compilerStep + "\x00" + group)
 	used := map[string]struct{}{compilerStep: {}}
 	for _, job := range jobs {
 		used[job.Key] = struct{}{}

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -201,6 +201,15 @@ func TestEmitWrapsJobsInWorkflowConcurrencyGate(t *testing.T) {
 	}
 }
 
+func TestConcurrencyGateKeysIncludeCompilerStep(t *testing.T) {
+	jobs := []Job{{Key: "job"}}
+	firstOpen, firstClose := concurrencyGateKeys("first-importer", "shared-group", jobs)
+	secondOpen, secondClose := concurrencyGateKeys("second-importer", "shared-group", jobs)
+	if firstOpen == secondOpen || firstClose == secondClose {
+		t.Fatalf("same-group imports have colliding gate keys: %q, %q and %q, %q", firstOpen, firstClose, secondOpen, secondClose)
+	}
+}
+
 func TestEmitActionRuntimeRequirement(t *testing.T) {
 	pipeline := Pipeline{
 		CompilerStep:       "importer",

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -134,6 +134,73 @@ func TestEmitMergesIntoContainingGroup(t *testing.T) {
 	}
 }
 
+func TestEmitWrapsJobsInWorkflowConcurrencyGate(t *testing.T) {
+	pipeline := Pipeline{
+		CompilerStep:       "importer",
+		DistributionDigest: testDigest("distribution"),
+		ConcurrencyGate:    &ConcurrencyGate{Group: "buildkite-gha/concurrency/group", Queue: "hosted"},
+		Jobs: []Job{
+			{Key: "producer", Label: "Producer", Queue: "hosted", PlanDigest: testDigest("producer")},
+			{Key: "consumer", Label: "Consumer", Queue: "hosted", PlanDigest: testDigest("consumer"), Dependencies: []string{"producer"}},
+		},
+	}
+	output, err := Emit(pipeline)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document struct {
+		Steps []struct {
+			Label            string `yaml:"label"`
+			Key              string `yaml:"key"`
+			Concurrency      int    `yaml:"concurrency"`
+			ConcurrencyGroup string `yaml:"concurrency_group"`
+			DependsOn        []struct {
+				Step         string `yaml:"step"`
+				AllowFailure bool   `yaml:"allow_failure"`
+			} `yaml:"depends_on"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(output, &document); err != nil {
+		t.Fatal(err)
+	}
+	if len(document.Steps) != 4 {
+		t.Fatalf("steps = %#v\n%s", document.Steps, output)
+	}
+	openKey, closeKey := concurrencyGateKeys(pipeline.CompilerStep, pipeline.ConcurrencyGate.Group, pipeline.Jobs)
+	open, producer, consumer, close := document.Steps[0], document.Steps[1], document.Steps[2], document.Steps[3]
+	if open.Key != openKey || open.Concurrency != 1 || open.ConcurrencyGroup != pipeline.ConcurrencyGate.Group || len(open.DependsOn) != 1 || open.DependsOn[0].Step != "importer" || open.DependsOn[0].AllowFailure {
+		t.Fatalf("opening gate = %#v", open)
+	}
+	for _, job := range []struct {
+		step struct {
+			Label            string `yaml:"label"`
+			Key              string `yaml:"key"`
+			Concurrency      int    `yaml:"concurrency"`
+			ConcurrencyGroup string `yaml:"concurrency_group"`
+			DependsOn        []struct {
+				Step         string `yaml:"step"`
+				AllowFailure bool   `yaml:"allow_failure"`
+			} `yaml:"depends_on"`
+		}
+		logicalDependency string
+	}{{producer, ""}, {consumer, "producer"}} {
+		if len(job.step.DependsOn) < 2 || job.step.DependsOn[1].Step != openKey || job.step.DependsOn[1].AllowFailure {
+			t.Fatalf("job %q does not strictly depend on opening gate: %#v", job.step.Key, job.step.DependsOn)
+		}
+		if job.logicalDependency != "" && (len(job.step.DependsOn) != 3 || job.step.DependsOn[2].Step != job.logicalDependency || !job.step.DependsOn[2].AllowFailure) {
+			t.Fatalf("job %q logical dependencies = %#v", job.step.Key, job.step.DependsOn)
+		}
+	}
+	if close.Key != closeKey || close.Concurrency != 1 || close.ConcurrencyGroup != pipeline.ConcurrencyGate.Group || len(close.DependsOn) != 3 {
+		t.Fatalf("closing gate = %#v", close)
+	}
+	for _, dependency := range close.DependsOn[1:] {
+		if !dependency.AllowFailure {
+			t.Fatalf("closing gate has strict generated dependency: %#v", close.DependsOn)
+		}
+	}
+}
+
 func TestEmitActionRuntimeRequirement(t *testing.T) {
 	pipeline := Pipeline{
 		CompilerStep:       "importer",
@@ -233,6 +300,8 @@ func TestEmitRejectsInvalidGraphsAndIdentifiers(t *testing.T) {
 		{name: "UUID key", in: Pipeline{CompilerStep: "compiler", Jobs: []Job{{Key: "123e4567-e89b-12d3-a456-426614174000", Label: "One", Queue: "queue", PlanDigest: digest}}}, want: "invalid generated step key"},
 		{name: "bad digest", in: Pipeline{CompilerStep: "compiler", Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: "sha256:nope"}}}, want: "invalid plan digest"},
 		{name: "partial concurrency", in: Pipeline{CompilerStep: "compiler", Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: digest, Concurrency: 2}}}, want: "concurrency and concurrency group together"},
+		{name: "empty workflow concurrency group", in: Pipeline{CompilerStep: "compiler", DistributionDigest: digest, ConcurrencyGate: &ConcurrencyGate{Queue: "queue"}, Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: digest}}}, want: "invalid workflow concurrency group"},
+		{name: "long job concurrency group", in: Pipeline{CompilerStep: "compiler", DistributionDigest: digest, Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: digest, Concurrency: 1, ConcurrencyGroup: strings.Repeat("x", maxConcurrencyGroupLength+1)}}}, want: "concurrency group exceeds"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/compiler/bundle.go
+++ b/internal/compiler/bundle.go
@@ -2,6 +2,8 @@ package compiler
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"strings"
 
@@ -92,21 +94,38 @@ func CompileBundleContext(ctx context.Context, path string, source, eventSource 
 			Dependencies: append([]string(nil), ir.Jobs[i].Needs...),
 			UsesActions:  planUsesActions(job),
 		}
-		if ir.Jobs[i].MaxParallel != nil {
+		if ir.Jobs[i].ConcurrencyGroup != "" {
+			jobs[i].Concurrency = 1
+			jobs[i].ConcurrencyGroup = buildkiteConcurrencyGroup(ir.Event.Repository, ir.Jobs[i].ConcurrencyGroup)
+		} else if ir.Jobs[i].MaxParallel != nil {
 			jobs[i].Concurrency = *ir.Jobs[i].MaxParallel
 			jobs[i].ConcurrencyGroup = "buildkite-gha/" + strings.TrimPrefix(ir.Workflow.Digest, "sha256:") + "/" + ir.Jobs[i].LogicalJobID
+		}
+	}
+	var concurrencyGate *buildkitepipeline.ConcurrencyGate
+	if ir.Workflow.ConcurrencyGroup != "" {
+		concurrencyGate = &buildkitepipeline.ConcurrencyGate{
+			Group: buildkiteConcurrencyGroup(ir.Event.Repository, ir.Workflow.ConcurrencyGroup),
+			Queue: jobs[0].Queue,
 		}
 	}
 	pipeline, err := buildkitepipeline.Emit(buildkitepipeline.Pipeline{
 		CompilerStep:       compilerStep,
 		DistributionDigest: compilerDistributionDigest,
 		GroupLabel:         options.GroupLabel,
+		ConcurrencyGate:    concurrencyGate,
 		Jobs:               jobs,
 	})
 	if err != nil {
 		return Bundle{}, fmt.Errorf("emit Buildkite pipeline: %w", err)
 	}
 	return Bundle{IR: ir, Plans: artifacts, Pipeline: pipeline}, nil
+}
+
+func buildkiteConcurrencyGroup(repository Repository, group string) string {
+	scope := strings.ToLower(repository.Owner+"/"+repository.Name) + "\x00" + canonicalConcurrencyGroup(group)
+	digest := sha256.Sum256([]byte(scope))
+	return "buildkite-gha/concurrency/" + hex.EncodeToString(digest[:])
 }
 
 func planUsesActions(job plan.Job) bool {

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -105,6 +105,215 @@ func TestCompileBundleDoesNotExposeEventValues(t *testing.T) {
 	}
 }
 
+func TestCompileBundleTranslatesWorkflowAndJobConcurrency(t *testing.T) {
+	source := []byte(`name: Deployment
+on: push
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+jobs:
+  static:
+    strategy:
+      max-parallel: 2
+      matrix:
+        target: [one, two]
+    runs-on: ubuntu-latest
+    concurrency: Deploy
+    steps: [{run: true}]
+  dynamic:
+    strategy:
+      matrix:
+        target: [alpha, beta]
+    runs-on: ubuntu-latest
+    concurrency: deploy-${{ matrix.target }}
+    steps: [{run: true}]
+`)
+	bundle, err := CompileBundle("concurrency.yml", source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bundle.IR.Workflow.ConcurrencyGroup != "Deployment-refs/heads/main" || len(bundle.IR.Jobs) != 4 {
+		t.Fatalf("concurrency IR = workflow %q jobs %#v", bundle.IR.Workflow.ConcurrencyGroup, bundle.IR.Jobs)
+	}
+	repository := bundle.IR.Event.Repository
+	wantJobGroups := make(map[string]string, len(bundle.IR.Jobs))
+	for _, job := range bundle.IR.Jobs {
+		want := "Deploy"
+		if job.LogicalJobID == "dynamic" {
+			want = "deploy-" + job.Matrix["target"].(string)
+		}
+		if job.ConcurrencyGroup != want {
+			t.Fatalf("job %q concurrency group = %q, want %q", job.Key, job.ConcurrencyGroup, want)
+		}
+		wantJobGroups[job.Key] = buildkiteConcurrencyGroup(repository, want)
+	}
+	if buildkiteConcurrencyGroup(repository, "Deploy") != buildkiteConcurrencyGroup(repository, "deploy") {
+		t.Fatal("Buildkite concurrency group did not preserve GitHub's case-insensitive grouping")
+	}
+
+	var document struct {
+		Steps []struct {
+			Key              string `yaml:"key"`
+			Concurrency      int    `yaml:"concurrency"`
+			ConcurrencyGroup string `yaml:"concurrency_group"`
+			DependsOn        []struct {
+				Step         string `yaml:"step"`
+				AllowFailure bool   `yaml:"allow_failure"`
+			} `yaml:"depends_on"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(bundle.Pipeline, &document); err != nil {
+		t.Fatal(err)
+	}
+	if len(document.Steps) != 6 {
+		t.Fatalf("pipeline steps = %#v\n%s", document.Steps, bundle.Pipeline)
+	}
+	wantWorkflowGroup := buildkiteConcurrencyGroup(repository, bundle.IR.Workflow.ConcurrencyGroup)
+	if document.Steps[0].Concurrency != 1 || document.Steps[0].ConcurrencyGroup != wantWorkflowGroup || document.Steps[5].Concurrency != 1 || document.Steps[5].ConcurrencyGroup != wantWorkflowGroup {
+		t.Fatalf("workflow gate groups = %#v / %#v, want %q", document.Steps[0], document.Steps[5], wantWorkflowGroup)
+	}
+	openKey := document.Steps[0].Key
+	for _, step := range document.Steps[1:5] {
+		if step.Concurrency != 1 || step.ConcurrencyGroup != wantJobGroups[step.Key] {
+			t.Fatalf("generated job concurrency = %#v, want %q", step, wantJobGroups[step.Key])
+		}
+		if len(step.DependsOn) < 2 || step.DependsOn[1].Step != openKey || step.DependsOn[1].AllowFailure {
+			t.Fatalf("generated job gate dependency = %#v", step.DependsOn)
+		}
+	}
+	if len(document.Steps[5].DependsOn) != 5 {
+		t.Fatalf("closing gate dependencies = %#v", document.Steps[5].DependsOn)
+	}
+	for _, dependency := range document.Steps[5].DependsOn[1:] {
+		if !dependency.AllowFailure {
+			t.Fatalf("closing gate dependency is strict: %#v", document.Steps[5].DependsOn)
+		}
+	}
+}
+
+func TestCompileRejectsMatrixVaryingConcurrencyWithMaxParallel(t *testing.T) {
+	source := []byte(`on: push
+jobs:
+  test:
+    strategy:
+      max-parallel: 2
+      matrix:
+        target: [one, two]
+    runs-on: ubuntu-latest
+    concurrency: deploy-${{ matrix.target }}
+    steps: [{run: true}]
+`)
+	_, err := CompileBundle("concurrency.yml", source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err == nil || !strings.Contains(err.Error(), "concurrency groups that vary by matrix cannot be combined with strategy.max-parallel") {
+		t.Fatalf("CompileBundle() error = %v, want matrix concurrency conflict", err)
+	}
+}
+
+func TestCompileAllowsCaseEquivalentMatrixConcurrencyWithMaxParallel(t *testing.T) {
+	source := []byte(`on: push
+jobs:
+  test:
+    strategy:
+      max-parallel: 2
+      matrix:
+        target: [Prod, prod]
+    runs-on: ubuntu-latest
+    concurrency: deploy-${{ matrix.target }}
+    steps: [{run: true}]
+`)
+	bundle, err := CompileBundle("concurrency.yml", source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bundle.IR.Jobs) != 2 || bundle.IR.Jobs[0].ConcurrencyGroup == bundle.IR.Jobs[1].ConcurrencyGroup {
+		t.Fatalf("resolved concurrency groups = %#v", bundle.IR.Jobs)
+	}
+	for _, group := range []string{bundle.IR.Jobs[0].ConcurrencyGroup, bundle.IR.Jobs[1].ConcurrencyGroup} {
+		if buildkiteConcurrencyGroup(bundle.IR.Event.Repository, group) != buildkiteConcurrencyGroup(bundle.IR.Event.Repository, "deploy-prod") {
+			t.Fatalf("group %q did not canonicalize case-insensitively", group)
+		}
+	}
+}
+
+func TestValidateDefersRequiredGitHubConcurrencyValues(t *testing.T) {
+	source := []byte(`on: push
+concurrency: validate-${{ github.ref }}
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    concurrency: test-${{ github.sha }}
+    steps: [{run: true}]
+`)
+	if _, err := Validate("concurrency.yml", source); err != nil {
+		t.Fatalf("Validate() rejected event-backed concurrency: %v", err)
+	}
+}
+
+func TestCanonicalWorkflowNameIsRepositoryRelative(t *testing.T) {
+	relative := smokePath(".github", "workflows", "shell.yml")
+	absolute, err := filepath.Abs(relative)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := ".github/workflows/shell.yml"
+	if got := canonicalWorkflowName(relative); got != want {
+		t.Fatalf("canonicalWorkflowName(relative) = %q, want %q", got, want)
+	}
+	if got := canonicalWorkflowName(absolute); got != want {
+		t.Fatalf("canonicalWorkflowName(absolute) = %q, want %q", got, want)
+	}
+}
+
+func TestCompileResolvesReusableJobConcurrencyInputs(t *testing.T) {
+	repository := t.TempDir()
+	writeWorkflow(t, repository, "reusable.yml", `on:
+  workflow_call:
+    inputs:
+      target:
+        type: string
+        required: true
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    concurrency: deploy-${{ inputs.target }}
+    steps: [{run: true}]
+`)
+	caller := writeWorkflow(t, repository, "caller.yml", `on: push
+jobs:
+  call:
+    uses: ./.github/workflows/reusable.yml
+    with:
+      target: production
+`)
+	bundle, err := CompileBundle(caller, readFile(t, caller), pushEvent(t), "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bundle.IR.Jobs) != 1 || bundle.IR.Jobs[0].ConcurrencyGroup != "deploy-production" {
+		t.Fatalf("reusable job concurrency = %#v", bundle.IR.Jobs)
+	}
+}
+
+func TestCompileRejectsCalledWorkflowConcurrency(t *testing.T) {
+	repository := t.TempDir()
+	writeWorkflow(t, repository, "reusable.yml", `on: workflow_call
+concurrency: reusable
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps: [{run: true}]
+`)
+	caller := writeWorkflow(t, repository, "caller.yml", `on: push
+jobs:
+  call:
+    uses: ./.github/workflows/reusable.yml
+`)
+	_, err := CompileBundle(caller, readFile(t, caller), pushEvent(t), "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err == nil || !strings.Contains(err.Error(), "workflow concurrency in a called reusable workflow is unsupported") {
+		t.Fatalf("CompileBundle() error = %v, want called workflow concurrency rejection", err)
+	}
+}
+
 func TestCompileBundleDeclaresSecretCapabilityAndNames(t *testing.T) {
 	source := []byte("name: secrets\non: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    env:\n      TOKEN: ${{ secrets['deploy_token'] }}\n    steps:\n      - run: echo \\\"${{ secrets.CANARY }}\\\"\n")
 	event := readFile(t, smokePath("events", "push.json"))

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -68,9 +68,10 @@ type ExecutionBoundary struct {
 
 // WorkflowSource binds the IR to its input workflow bytes.
 type WorkflowSource struct {
-	Path   string `json:"path"`
-	Name   string `json:"name,omitempty"`
-	Digest string `json:"digest"`
+	Path             string `json:"path"`
+	Name             string `json:"name,omitempty"`
+	Digest           string `json:"digest"`
+	ConcurrencyGroup string `json:"concurrency_group,omitempty"`
 }
 
 // JobInstance is one statically expanded job in the owned IR.
@@ -86,6 +87,7 @@ type JobInstance struct {
 	Matrix                  map[string]any          `json:"matrix,omitempty"`
 	FailFast                *bool                   `json:"fail_fast,omitempty"`
 	MaxParallel             *int                    `json:"max_parallel,omitempty"`
+	ConcurrencyGroup        string                  `json:"concurrency_group,omitempty"`
 	Steps                   []workflow.Step         `json:"steps"`
 	Env                     map[string]string       `json:"env,omitempty"`
 	Permissions             map[string]string       `json:"permissions,omitempty"`
@@ -125,8 +127,17 @@ func Validate(path string, source []byte) (Report, error) {
 		return Report{}, err
 	}
 	options := defaultOptions()
-	event := Event{Trust: options.EventTrust, Payload: map[string]any{}}
-	instances, err := expand(path, source, parsed, compileContext(event, nil), options)
+	event := Event{
+		Event: "validation", Trust: options.EventTrust,
+		Repository: Repository{Owner: "validation", Name: "validation"},
+		Ref:        "refs/heads/validation", SHA: strings.Repeat("0", 40), Actor: "validation",
+		Payload: map[string]any{},
+	}
+	context := compileContext(event, nil, path, parsed.Name)
+	if _, err := resolveConcurrency(path, "", parsed.Concurrency, context, nil); err != nil {
+		return Report{}, err
+	}
+	instances, err := expand(path, source, parsed, context, options)
 	if err != nil {
 		return Report{}, err
 	}
@@ -153,7 +164,11 @@ func ValidateEventWithOptions(path string, source, eventSource []byte, options O
 		return Report{}, err
 	}
 	event.Trust = options.EventTrust
-	instances, err := expand(path, source, parsed, compileContext(event, options.Vars.snapshot()), options)
+	context := compileContext(event, options.Vars.snapshot(), path, parsed.Name)
+	if _, err := resolveConcurrency(path, "", parsed.Concurrency, context, nil); err != nil {
+		return Report{}, err
+	}
+	instances, err := expand(path, source, parsed, context, options)
 	if err != nil {
 		return Report{}, err
 	}
@@ -530,14 +545,19 @@ func compile(path string, source, eventSource []byte, options Options) (IR, erro
 	}
 	event.Trust = options.EventTrust
 	vars := options.Vars.snapshot()
-	jobs, err := expand(path, source, parsed, compileContext(event, vars), options)
+	context := compileContext(event, vars, path, parsed.Name)
+	workflowConcurrencyGroup, err := resolveConcurrency(path, "", parsed.Concurrency, context, nil)
+	if err != nil {
+		return IR{}, err
+	}
+	jobs, err := expand(path, source, parsed, context, options)
 	if err != nil {
 		return IR{}, err
 	}
 	digest := sha256.Sum256(source)
 	return IR{
 		Schema:   schema,
-		Workflow: WorkflowSource{Path: path, Name: parsed.Name, Digest: "sha256:" + hex.EncodeToString(digest[:])},
+		Workflow: WorkflowSource{Path: path, Name: parsed.Name, Digest: "sha256:" + hex.EncodeToString(digest[:]), ConcurrencyGroup: workflowConcurrencyGroup},
 		Event:    event,
 		Vars:     vars,
 		Execution: ExecutionBoundary{
@@ -585,8 +605,11 @@ func parseEvent(source []byte) (Event, error) {
 	}, nil
 }
 
-func compileContext(event Event, vars map[string]string) expression.CompileContext {
+func compileContext(event Event, vars map[string]string, workflowPath, workflowName string) expression.CompileContext {
 	repository := event.Repository.Owner + "/" + event.Repository.Name
+	if workflowName == "" {
+		workflowName = canonicalWorkflowName(workflowPath)
+	}
 	return expression.CompileContext{
 		GitHub: map[string]any{
 			"event_name":       event.Event,
@@ -596,10 +619,23 @@ func compileContext(event Event, vars map[string]string) expression.CompileConte
 			"ref":              event.Ref,
 			"sha":              event.SHA,
 			"actor":            event.Actor,
+			"workflow":         workflowName,
 		},
 		Event: event.Payload,
 		Vars:  vars,
 	}
+}
+
+func canonicalWorkflowName(path string) string {
+	if isRepositoryWorkflowPath(path) {
+		root, canonicalPath, err := workflowRepository(path)
+		if err == nil {
+			if relative, err := repositoryWorkflowPath(root, canonicalPath); err == nil {
+				return strings.TrimPrefix(relative, "./")
+			}
+		}
+	}
+	return filepath.ToSlash(filepath.Clean(path))
 }
 
 func expand(path string, source []byte, parsed *workflow.Workflow, context expression.CompileContext, options Options) ([]JobInstance, error) {
@@ -640,6 +676,7 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 		if err != nil {
 			return nil, err
 		}
+		concurrencyGroups := make(map[string]struct{}, len(matrices))
 		for _, matrix := range matrices {
 			if err := supportedConditions(jobPath, job, matrix, true); err != nil {
 				return nil, err
@@ -651,6 +688,13 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 			queue, err := options.Runners.resolve(labels, options.EventTrust)
 			if err != nil {
 				return nil, locatedJobError(jobPath, job, runsOnPosition(job).Line, runsOnPosition(job).Column, err.Error())
+			}
+			concurrencyGroup, err := resolveConcurrency(jobPath, job.ID, job.Concurrency, context, matrix)
+			if err != nil {
+				return nil, err
+			}
+			if concurrencyGroup != "" {
+				concurrencyGroups[canonicalConcurrencyGroup(concurrencyGroup)] = struct{}{}
 			}
 			key, err := instanceKey(job.ID, matrix)
 			if err != nil {
@@ -669,6 +713,7 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 				Matrix:                  matrix,
 				FailFast:                job.FailFast,
 				MaxParallel:             job.MaxParallel,
+				ConcurrencyGroup:        concurrencyGroup,
 				Steps:                   append([]workflow.Step(nil), job.Steps...),
 				Env:                     cloneMap(job.Env),
 				Permissions:             permissionScopes(job.Permissions),
@@ -734,6 +779,10 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 			instance.Needs = slices.Compact(instance.Needs)
 			byLogicalID[id] = append(byLogicalID[id], instance)
 		}
+		if job.MaxParallel != nil && len(concurrencyGroups) > 1 {
+			position := job.Concurrency.Span.Start
+			return nil, locatedJobError(jobPath, job, position.Line, position.Column, "concurrency groups that vary by matrix cannot be combined with strategy.max-parallel")
+		}
 	}
 
 	var instances []JobInstance
@@ -741,6 +790,32 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 		instances = append(instances, byLogicalID[id]...)
 	}
 	return instances, nil
+}
+
+func resolveConcurrency(path, jobID string, concurrency *workflow.Concurrency, context expression.CompileContext, matrix map[string]any) (string, error) {
+	if concurrency == nil {
+		return "", nil
+	}
+	context.Matrix = matrix
+	group, err := expression.EvaluateCompileTemplate(concurrency.Group, context)
+	if err != nil {
+		message := fmt.Sprintf("concurrency group cannot be resolved at compile time: %v", err)
+		if jobID == "" {
+			return "", fmt.Errorf("%s:%d:%d: workflow %s", path, concurrency.Span.Start.Line, concurrency.Span.Start.Column, message)
+		}
+		return "", locatedJobError(path, workflow.Job{ID: jobID}, concurrency.Span.Start.Line, concurrency.Span.Start.Column, message)
+	}
+	if strings.TrimSpace(group) == "" {
+		if jobID == "" {
+			return "", fmt.Errorf("%s:%d:%d: workflow concurrency group resolved to an empty string", path, concurrency.Span.Start.Line, concurrency.Span.Start.Column)
+		}
+		return "", locatedJobError(path, workflow.Job{ID: jobID}, concurrency.Span.Start.Line, concurrency.Span.Start.Column, "concurrency group resolved to an empty string")
+	}
+	return group, nil
+}
+
+func canonicalConcurrencyGroup(group string) string {
+	return strings.ToLower(group)
 }
 
 func permissionScopes(permissions *workflow.Permissions) map[string]string {

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -208,6 +208,9 @@ func (resolver *reusableResolver) resolve(path, digest string, parsed *workflow.
 			return reusableResolution{}, locatedJobError(path, job, call.Span.Start.Line, call.Span.Start.Column, fmt.Sprintf("locate local reusable workflow %q: %v", call.Uses, err))
 		}
 		calleeSourcePath = "./" + filepath.ToSlash(calleeSourcePath)
+		if callee.Concurrency != nil {
+			return reusableResolution{}, fmt.Errorf("%s:%d:%d: workflow concurrency in a called reusable workflow is unsupported", calleeSourcePath, callee.Concurrency.Span.Start.Line, callee.Concurrency.Span.Start.Column)
+		}
 		calleeDigest := "sha256:" + sha256Sum(source)
 
 		matrices, err := expandMatrix(path, job, expression.CompileContext{})
@@ -586,6 +589,11 @@ func applyStaticInputs(job workflow.Job, inputs map[string]any) workflow.Job {
 	job.If = replaceStaticInputCondition(job.If, inputs)
 	job.DefaultShell = replaceStaticInputs(job.DefaultShell, inputs)
 	job.DefaultWorkingDirectory = replaceStaticInputs(job.DefaultWorkingDirectory, inputs)
+	if job.Concurrency != nil {
+		concurrency := *job.Concurrency
+		concurrency.Group = replaceStaticInputs(concurrency.Group, inputs)
+		job.Concurrency = &concurrency
+	}
 	job.Env = replaceMapInputs(job.Env, inputs)
 	job.Outputs = replaceMapInputs(job.Outputs, inputs)
 	job.RunsOn = append([]string(nil), job.RunsOn...)
@@ -628,6 +636,9 @@ func rejectUnresolvedInputExpressions(path string, job workflow.Job) error {
 		return jobError(path, job, "reusable-workflow input expression is not statically resolvable")
 	}
 	jobValues := []string{job.Name, job.DefaultShell, job.DefaultWorkingDirectory}
+	if job.Concurrency != nil {
+		jobValues = append(jobValues, job.Concurrency.Group)
+	}
 	jobValues = append(jobValues, job.RunsOn...)
 	jobValues = appendMapValues(jobValues, job.Env)
 	jobValues = appendMapValues(jobValues, job.Outputs)

--- a/internal/expression/expression.go
+++ b/internal/expression/expression.go
@@ -173,7 +173,7 @@ func EvaluateCompileTemplate(template string, context CompileContext) (string, e
 		case bool, json.Number, float64, int:
 			_, _ = fmt.Fprint(&evaluated, value)
 		default:
-			return "", fmt.Errorf("expression in runner label resolved to %T, want a scalar", value)
+			return "", fmt.Errorf("template expression resolved to %T, want a scalar", value)
 		}
 		remaining = remaining[end+len(close):]
 	}

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -20,6 +20,7 @@ type Workflow struct {
 	Name                    string                `json:"name,omitempty"`
 	Env                     map[string]string     `json:"env,omitempty"`
 	Permissions             *Permissions          `json:"permissions,omitempty"`
+	Concurrency             *Concurrency          `json:"concurrency,omitempty"`
 	DefaultShell            string                `json:"default_shell,omitempty"`
 	DefaultWorkingDirectory string                `json:"default_working_directory,omitempty"`
 	CallInputs              map[string]CallInput  `json:"call_inputs,omitempty"`
@@ -27,6 +28,14 @@ type Workflow struct {
 	RequiredCallSecrets     []string              `json:"required_call_secrets,omitempty"`
 	Callable                bool                  `json:"callable,omitempty"`
 	Jobs                    []Job                 `json:"jobs"`
+}
+
+// Concurrency is the queue-only subset of a GitHub Actions concurrency group.
+// Cancellation is rejected while parsing because Buildkite concurrency groups
+// cannot cancel an already running job or workflow.
+type Concurrency struct {
+	Group string `json:"group"`
+	Span  Span   `json:"span"`
 }
 
 // Permissions is an explicitly declared GitHub token permission set. Omitted
@@ -60,6 +69,7 @@ type Job struct {
 	Matrix                  *Matrix                `json:"matrix,omitempty"`
 	FailFast                *bool                  `json:"fail_fast,omitempty"`
 	MaxParallel             *int                   `json:"max_parallel,omitempty"`
+	Concurrency             *Concurrency           `json:"concurrency,omitempty"`
 	Reusable                *ReusableWorkflowCall  `json:"reusable_workflow,omitempty"`
 	Env                     map[string]string      `json:"env,omitempty"`
 	Permissions             *Permissions           `json:"permissions,omitempty"`

--- a/internal/workflow/parse.go
+++ b/internal/workflow/parse.go
@@ -41,7 +41,7 @@ func Parse(path string, source []byte) (*Workflow, error) {
 	if err := validateRawContainers(path, &document); err != nil {
 		return nil, err
 	}
-	if err := validateRawConcurrency(path, &document); err != nil {
+	if err := validateRawConcurrencyCancellation(path, &document); err != nil {
 		return nil, err
 	}
 	concurrency, err := parseConcurrencySyntax(path, &document)
@@ -60,6 +60,10 @@ func Parse(path string, source []byte) (*Workflow, error) {
 	owned := &Workflow{}
 	if parsed.Name != nil {
 		owned.Name = parsed.Name.Value
+	}
+	owned.Concurrency, err = adaptConcurrency(path, "", parsed.Concurrency)
+	if err != nil {
+		return nil, err
 	}
 	owned.Permissions, err = adaptPermissions(path, parsed.Permissions)
 	if err != nil {
@@ -193,13 +197,20 @@ func validateRawContainers(path string, document *yaml.Node) error {
 	return nil
 }
 
-func validateRawConcurrency(path string, document *yaml.Node) error {
+func rawError(path string, node *yaml.Node, message string) error {
+	return fmt.Errorf("%s:%d:%d: %s", path, node.Line, node.Column, message)
+}
+
+// actionlint v1.7.12 compares YAML boolean text case-sensitively, even though
+// YAML accepts True and TRUE. Decode cancellation booleans from the raw tree so
+// no true spelling can be silently adapted as false.
+func validateRawConcurrencyCancellation(path string, document *yaml.Node) error {
 	root := document
 	if root.Kind == yaml.DocumentNode && len(root.Content) != 0 {
 		root = root.Content[0]
 	}
-	if key := mappingKey(root, "concurrency"); key != nil {
-		return rawError(path, key, "workflow concurrency is unsupported; configure equivalent concurrency behavior in Buildkite")
+	if err := validateRawConcurrencyCancellationValue(path, "", mappingValue(root, "concurrency")); err != nil {
+		return err
 	}
 	jobs := mappingValue(root, "jobs")
 	if jobs == nil || jobs.Kind != yaml.MappingNode {
@@ -207,15 +218,29 @@ func validateRawConcurrency(path string, document *yaml.Node) error {
 	}
 	for i := 0; i+1 < len(jobs.Content); i += 2 {
 		name, job := resolveAlias(jobs.Content[i]), jobs.Content[i+1]
-		if key := mappingKey(job, "concurrency"); key != nil {
-			return rawError(path, key, fmt.Sprintf("job %q concurrency is unsupported; only strategy.max-parallel is translated", name.Value))
+		if err := validateRawConcurrencyCancellationValue(path, name.Value, mappingValue(job, "concurrency")); err != nil {
+			return err
 		}
 	}
 	return nil
 }
 
-func rawError(path string, node *yaml.Node, message string) error {
-	return fmt.Errorf("%s:%d:%d: %s", path, node.Line, node.Column, message)
+func validateRawConcurrencyCancellationValue(path, jobID string, concurrency *yaml.Node) error {
+	if concurrency == nil || concurrency.Kind != yaml.MappingNode {
+		return nil
+	}
+	cancel := mappingValue(concurrency, "cancel-in-progress")
+	if cancel == nil || cancel.Kind != yaml.ScalarNode || cancel.ShortTag() != "!!bool" {
+		return nil
+	}
+	var enabled bool
+	if err := cancel.Decode(&enabled); err != nil || !enabled {
+		return nil
+	}
+	if jobID == "" {
+		return rawError(path, cancel, "workflow concurrency cancel-in-progress is unsupported")
+	}
+	return rawError(path, cancel, fmt.Sprintf("job %q: concurrency cancel-in-progress is unsupported", jobID))
 }
 
 func validateRawContainer(path string, node *yaml.Node) error {
@@ -272,6 +297,11 @@ func validateRawContainer(path string, node *yaml.Node) error {
 
 func adaptJob(path string, in *actionlint.Job, scalars map[Position]any, concurrency map[Position]stepConcurrency) (Job, error) {
 	out := Job{ID: in.ID.Value, Span: pointSpan(in.Pos)}
+	ownedConcurrency, err := adaptConcurrency(path, in.ID.Value, in.Concurrency)
+	if err != nil {
+		return Job{}, err
+	}
+	out.Concurrency = ownedConcurrency
 	permissions, err := adaptPermissions(path, in.Permissions)
 	if err != nil {
 		return Job{}, err
@@ -492,6 +522,30 @@ func adaptJob(path string, in *actionlint.Job, scalars map[Position]any, concurr
 		return Job{}, err
 	}
 	return out, nil
+}
+
+func adaptConcurrency(path, jobID string, in *actionlint.Concurrency) (*Concurrency, error) {
+	if in == nil {
+		return nil, nil
+	}
+	if in.CancelInProgress != nil && (in.CancelInProgress.Expression != nil || in.CancelInProgress.Value) {
+		position := in.CancelInProgress.Pos
+		if in.CancelInProgress.Expression != nil {
+			position = in.CancelInProgress.Expression.Pos
+		}
+		if jobID == "" {
+			return nil, fmt.Errorf("%s:%d:%d: workflow concurrency cancel-in-progress is unsupported", path, position.Line, position.Col)
+		}
+		return nil, locatedError(path, position, jobID, "concurrency cancel-in-progress is unsupported")
+	}
+	if in.Group == nil || strings.TrimSpace(in.Group.Value) == "" {
+		position := in.Pos
+		if jobID == "" {
+			return nil, fmt.Errorf("%s:%d:%d: workflow concurrency group must not be empty", path, position.Line, position.Col)
+		}
+		return nil, locatedError(path, position, jobID, "concurrency group must not be empty")
+	}
+	return &Concurrency{Group: in.Group.Value, Span: spanFrom(in.Group.Pos, in.Group.Value)}, nil
 }
 
 func adaptPermissions(path string, in *actionlint.Permissions) (*Permissions, error) {

--- a/internal/workflow/parse_test.go
+++ b/internal/workflow/parse_test.go
@@ -155,44 +155,115 @@ func TestContainerValidationIsScopedAndSourceLocated(t *testing.T) {
 	}
 }
 
-func TestParseRejectsWorkflowAndJobConcurrencyWithLocation(t *testing.T) {
+func TestParseOwnsWorkflowAndJobConcurrency(t *testing.T) {
+	source := []byte(`name: concurrency
+on: push
+concurrency:
+  group: workflow-${{ github.ref }}
+  cancel-in-progress: false
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    concurrency: deploy
+    steps: [{run: true}]
+`)
+	parsed, err := Parse("concurrency.yml", source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Concurrency == nil || parsed.Concurrency.Group != "workflow-${{ github.ref }}" || parsed.Concurrency.Span.Start.Line != 4 {
+		t.Fatalf("workflow concurrency = %#v", parsed.Concurrency)
+	}
+	if len(parsed.Jobs) != 1 || parsed.Jobs[0].Concurrency == nil || parsed.Jobs[0].Concurrency.Group != "deploy" || parsed.Jobs[0].Concurrency.Span.Start.Line != 9 {
+		t.Fatalf("job concurrency = %#v", parsed.Jobs)
+	}
+}
+
+func TestParseOwnsAliasedConcurrency(t *testing.T) {
+	for _, test := range []struct {
+		name, source string
+		workflow     bool
+	}{
+		{
+			name:     "workflow-key",
+			source:   "on: push\nenv:\n  FIELD: &field concurrency\n*field: deploy\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
+			workflow: true,
+		},
+		{
+			name:   "jobs-and-job-keys",
+			source: "on: push\nenv:\n  JOBS: &jobs jobs\n  FIELD: &field concurrency\n*jobs:\n  test:\n    runs-on: ubuntu-latest\n    *field: deploy\n    steps: [{run: true}]\n",
+		},
+		{
+			name:   "whole-job",
+			source: "on: push\njobs:\n  anchor-holder:\n    runs-on: ubuntu-latest\n    strategy:\n      matrix:\n        include:\n          - &shared-job\n            runs-on: ubuntu-latest\n            concurrency: deploy\n            steps:\n              - run: echo ok\n    steps:\n      - run: echo holder\n  test: *shared-job\n",
+		},
+		{
+			name:   "job-id",
+			source: "on: push\nenv:\n  ID: &job-id test\njobs:\n  *job-id:\n    runs-on: ubuntu-latest\n    concurrency: deploy\n    steps: [{run: true}]\n",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			parsed, err := Parse("concurrency.yml", []byte(test.source))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if test.workflow {
+				if parsed.Concurrency == nil || parsed.Concurrency.Group != "deploy" {
+					t.Fatalf("workflow concurrency = %#v", parsed.Concurrency)
+				}
+				return
+			}
+			found := false
+			for _, job := range parsed.Jobs {
+				if job.ID == "test" && job.Concurrency != nil && job.Concurrency.Group == "deploy" {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("jobs = %#v, want test concurrency group", parsed.Jobs)
+			}
+		})
+	}
+}
+
+func TestParseRejectsConcurrencyCancellationWithLocation(t *testing.T) {
 	for _, test := range []struct {
 		name, source, want string
 	}{
 		{
 			name:   "workflow",
-			source: "on: push\nconcurrency:\n  group: build-${{ github.ref }}\n  cancel-in-progress: true\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
-			want:   "concurrency.yml:2:1: workflow concurrency is unsupported; configure equivalent concurrency behavior in Buildkite",
+			source: "on: push\nconcurrency:\n  group: deploy\n  cancel-in-progress: true\njobs:\n  test: {runs-on: ubuntu-latest, steps: [{run: true}]}\n",
+			want:   "concurrency.yml:4:23: workflow concurrency cancel-in-progress is unsupported",
+		},
+		{
+			name:   "workflow-uppercase",
+			source: "on: push\nconcurrency:\n  group: deploy\n  cancel-in-progress: TRUE\njobs:\n  test: {runs-on: ubuntu-latest, steps: [{run: true}]}\n",
+			want:   "concurrency.yml:4:23: workflow concurrency cancel-in-progress is unsupported",
 		},
 		{
 			name:   "job",
-			source: "on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    concurrency: deploy\n    steps: [{run: true}]\n",
-			want:   "concurrency.yml:5:5: job \"test\" concurrency is unsupported; only strategy.max-parallel is translated",
+			source: "on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    concurrency: {group: deploy, cancel-in-progress: true}\n    steps: [{run: true}]\n",
+			want:   "job \"test\": concurrency cancel-in-progress is unsupported",
 		},
 		{
-			name:   "workflow-alias",
-			source: "on: push\nenv:\n  FIELD: &field concurrency\n*field: deploy\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
-			want:   "concurrency.yml:4:1: workflow concurrency is unsupported; configure equivalent concurrency behavior in Buildkite",
+			name:   "job-title-case",
+			source: "on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    concurrency: {group: deploy, cancel-in-progress: True}\n    steps: [{run: true}]\n",
+			want:   "job \"test\": concurrency cancel-in-progress is unsupported",
 		},
 		{
-			name:   "jobs-and-job-aliases",
-			source: "on: push\nenv:\n  JOBS: &jobs jobs\n  FIELD: &field concurrency\n*jobs:\n  test:\n    runs-on: ubuntu-latest\n    *field: deploy\n    steps: [{run: true}]\n",
-			want:   "concurrency.yml:8:5: job \"test\" concurrency is unsupported; only strategy.max-parallel is translated",
+			name:   "aliased-true",
+			source: "on: push\nenv:\n  CANCEL: &cancel TRUE\nconcurrency:\n  group: deploy\n  cancel-in-progress: *cancel\njobs:\n  test: {runs-on: ubuntu-latest, steps: [{run: true}]}\n",
+			want:   "workflow concurrency cancel-in-progress is unsupported",
 		},
 		{
-			name:   "aliased-job",
-			source: "on: push\njobs:\n  anchor-holder:\n    runs-on: ubuntu-latest\n    strategy:\n      matrix:\n        include:\n          - &shared-job\n            runs-on: ubuntu-latest\n            concurrency: deploy\n            steps:\n              - run: echo ok\n    steps:\n      - run: echo holder\n  test: *shared-job\n",
-			want:   "concurrency.yml:10:13: job \"test\" concurrency is unsupported; only strategy.max-parallel is translated",
-		},
-		{
-			name:   "aliased-job-id",
-			source: "on: push\nenv:\n  ID: &job-id test\njobs:\n  *job-id:\n    runs-on: ubuntu-latest\n    concurrency: deploy\n    steps: [{run: true}]\n",
-			want:   "concurrency.yml:7:5: job \"test\" concurrency is unsupported; only strategy.max-parallel is translated",
+			name:   "expression",
+			source: "on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    concurrency:\n      group: deploy\n      cancel-in-progress: ${{ github.ref == 'refs/heads/main' }}\n    steps: [{run: true}]\n",
+			want:   "job \"test\": concurrency cancel-in-progress is unsupported",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := Parse("concurrency.yml", []byte(test.source))
-			if err == nil || err.Error() != test.want {
+			if err == nil || !strings.Contains(err.Error(), test.want) {
 				t.Fatalf("Parse() error = %v, want %q", err, test.want)
 			}
 		})


### PR DESCRIPTION
## Summary

- parse scalar and mapping-form workflow/job `concurrency` declarations
- translate job groups to repository-scoped Buildkite concurrency groups
- serialize workflow runs with ordered opening/closing gate steps while preserving within-run job parallelism
- resolve groups from supported static `github`, `vars`, matrix, and reusable-workflow input contexts
- document the queue-only compatibility boundary and reject cancellation/runtime-dependent behavior

## Compatibility notes

This intentionally provides queue compatibility rather than full GitHub cancellation parity. `cancel-in-progress: true` and expression-valued cancellation fail closed. Buildkite also retains all waiting entries FIFO instead of replacing GitHub's existing pending entry.

No hosted Buildkite gate/cancellation proof was run; pipeline generation is covered by unit tests and the local smoke gate.

## Test plan

- [x] `mise run check`