### PR TITLE
Test unreleased CLI through released plugin

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -125,6 +125,18 @@ steps:
           version: "2026.5.12"
     command: "mise run --jobs 1 check"
 
+  - label: ":github: Exact-source plugin smoke"
+    key: "plugin-source-smoke-importer"
+    timeout_in_minutes: 20
+    retry:
+      automatic: false
+    plugins:
+      - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
+          version: "2026.5.12"
+      - github-actions#v0.4.4:
+          workflow: .github/workflows/example-basic.yml
+          buildkite-gha-source-ref: "${BUILDKITE_COMMIT}"
+
   - wait: ~
 
   - label: ":rocket: Publish release"

--- a/docs/development.md
+++ b/docs/development.md
@@ -74,6 +74,15 @@ download modes, and unsupported artifact commits still fail admission. Job and
 service container fixtures have separate hosted runtime evidence but remain
 outside production admission.
 
+### Exact-source plugin smoke
+
+Every Buildkite build runs `.github/workflows/example-basic.yml` through the
+released plugin with `buildkite-gha-source-ref` set to the build's exact commit.
+This proves a pull request's unreleased CLI source through the public plugin
+before a CLI release exists. The released-plugin demos remain separate because
+they verify release archives, checksums, and the normal default installation
+path rather than source execution.
+
 ### Paired native UX runs
 
 After the example workflows exist on the default branch, launch the same


### PR DESCRIPTION
## Why

CLI changes currently need a release before the companion plugin can exercise them end to end. Plugin v0.4.4 now supports running an exact canonical `buildkite-gha` commit from source, so CLI pull requests can prove the cross-repository path before release.

## What changed

- Add an always-on Buildkite importer using released `github-actions#v0.4.4`.
- Pass the build's exact `BUILDKITE_COMMIT` as `buildkite-gha-source-ref`, rather than following floating `latest`.
- Run the basic example workflow through that exact unreleased CLI source.
- Document how this source proof differs from released archive/checksum demos.

## Validation

- `mise run check`
- Focused `go test ./internal/expression ./internal/workflow`
- `git diff --check`

The branch Buildkite build is the end-to-end proof: the source commit must be publicly fetchable before the released plugin can compile and upload the generated workflow jobs.