### PR TITLE
Run example comparisons with current CLI source

### DIFF
--- a/.buildkite/examples.yml
+++ b/.buildkite/examples.yml
@@ -69,6 +69,9 @@ steps:
                 automatic: false
               cache: "/cache/bkcache/github-actions-buildkite-plugin"
               plugins:
-                - github-actions#v0.2.2:
+                - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
+                    version: "2026.5.12"
+                - github-actions#v0.4.4:
                     workflow: "$$workflow"
+                    buildkite-gha-source-ref: "$$commit"
       YAML

--- a/.buildkite/upload-examples.sh
+++ b/.buildkite/upload-examples.sh
@@ -103,6 +103,9 @@ steps:
           automatic: false
         cache: "/cache/bkcache/github-actions-buildkite-plugin"
         plugins:
-          - github-actions#v0.2.2:
+          - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
+              version: "2026.5.12"
+          - github-actions#v0.4.4:
               workflow: "$workflow"
+              buildkite-gha-source-ref: "$commit"
 YAML

--- a/docs/development.md
+++ b/docs/development.md
@@ -95,7 +95,9 @@ scripts/compare-example advanced
 ```
 
 This uses GitHub's native `workflow_dispatch` path and the dedicated
-`buildkite-gha-examples` pipeline. It prints both URLs for a side-by-side review
+`buildkite-gha-examples` pipeline. The Buildkite importer uses released plugin
+v0.4.4 to run the branch's exact unreleased CLI commit, so both providers
+exercise the same source. The script prints both URLs for a side-by-side review
 of the graph, logs, summaries, annotations, artifacts, retries, and cancellation
 experience. Use `--github-only` or `--buildkite-only` to exercise one native
 manual trigger at a time. These runs are qualitative UX comparisons; they do

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -579,7 +579,9 @@ func TestExamplesPipelineSelectsOneCanonicalWorkflow(t *testing.T) {
 		`group: ":github: Run workflow"`,
 		`label: "Prepare workflow"`,
 		`cache: "/cache/bkcache/github-actions-buildkite-plugin"`,
-		`github-actions#v0.2.2`,
+		`mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2`,
+		`github-actions#v0.4.4`,
+		`buildkite-gha-source-ref: "$$commit"`,
 	} {
 		if !strings.Contains(loader.Command, required) {
 			t.Fatalf("example loader lacks %q:\n%s", required, loader.Command)
@@ -707,8 +709,10 @@ func TestUploadExamplesScript(t *testing.T) {
 			`key: "example-basic-workflow"`,
 			`label: "Prepare workflow"`,
 			`key: "example-basic-importer"`,
-			`github-actions#v0.2.2`,
+			`mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2`,
+			`github-actions#v0.4.4`,
 			`workflow: ".github/workflows/example-basic.yml"`,
+			`buildkite-gha-source-ref: "` + commit + `"`,
 			`queue: "hosted"`,
 			`cache: "/cache/bkcache/github-actions-buildkite-plugin"`,
 		} {
@@ -721,8 +725,8 @@ func TestUploadExamplesScript(t *testing.T) {
 				t.Fatalf("basic importer contains %q:\n%s", forbidden, pipeline)
 			}
 		}
-		if strings.Count(pipeline, "github-actions#v0.2.2") != 1 {
-			t.Fatalf("basic importer does not contain exactly one plugin:\n%s", pipeline)
+		if strings.Count(pipeline, "github-actions#v0.4.4") != 1 || strings.Count(pipeline, "mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2") != 1 {
+			t.Fatalf("basic importer does not contain exactly one of each plugin:\n%s", pipeline)
 		}
 	})
 


### PR DESCRIPTION
## Why

The dedicated example-comparison pipeline still uses plugin v0.2.2 and its old released CLI default. That makes new GitHub-versus-Buildkite UX comparisons measure stale code, even though plugin v0.4.4 can now run an exact unreleased CLI commit.

## What changed

- Use released plugin v0.4.4 for the basic, artifacts, and advanced Buildkite example imports.
- Provide mise 2026.5.12 to the importer.
- Set `buildkite-gha-source-ref` to the exact comparison commit already checked by the loader.
- Update both checked-in example loaders, their behavior tests, and development guidance.

## Validation

- `go test ./internal/buildkite`
- `shellcheck -x .buildkite/upload-examples.sh`
- `bash -n .buildkite/upload-examples.sh`
- `git diff --check`

Live exact-commit comparison builds at `5720e6176e22e593d77575f47bb9af1c7c58ffe2`:

- [Basic](https://buildkite.com/buildkite/buildkite-gha-examples/builds/17)
- [Artifacts](https://buildkite.com/buildkite/buildkite-gha-examples/builds/16)
- [Advanced](https://buildkite.com/buildkite/buildkite-gha-examples/builds/15)