### PR TITLE
Use Buildkite default agent targeting

### DIFF
--- a/.buildkite/migration-poc.yml
+++ b/.buildkite/migration-poc.yml
@@ -4,6 +4,8 @@ agents:
 steps:
   - label: ":test_tube: Basic migration POC importer"
     key: "migration-poc-basic-importer"
+    env:
+      BUILDKITE_GHA_TARGET_QUEUE: "hosted"
     timeout_in_minutes: 15
     retry:
       automatic: false
@@ -14,6 +16,8 @@ steps:
 
   - label: ":package: Artifact migration POC importer"
     key: "migration-poc-artifact-importer"
+    env:
+      BUILDKITE_GHA_TARGET_QUEUE: "hosted"
     timeout_in_minutes: 15
     retry:
       automatic: false
@@ -24,6 +28,8 @@ steps:
 
   - label: ":rocket: Advanced migration POC importer"
     key: "migration-poc-advanced-importer"
+    env:
+      BUILDKITE_GHA_TARGET_QUEUE: "hosted"
     timeout_in_minutes: 15
     retry:
       automatic: false

--- a/.buildkite/phase-2-upload.yml
+++ b/.buildkite/phase-2-upload.yml
@@ -4,6 +4,8 @@ agents:
 steps:
   - label: ":pipeline: Phase 2 unprivileged importer"
     key: "phase-2-upload-importer"
+    env:
+      BUILDKITE_GHA_TARGET_QUEUE: "hosted"
     plugins:
       - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
           version: "2026.5.12"

--- a/.buildkite/phase-3-upload.yml
+++ b/.buildkite/phase-3-upload.yml
@@ -4,6 +4,8 @@ agents:
 steps:
   - label: ":pipeline: Phase 3 concurrent importer"
     key: "phase-3-upload-importer"
+    env:
+      BUILDKITE_GHA_TARGET_QUEUE: "hosted"
     plugins:
       - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
           version: "2026.5.12"

--- a/.buildkite/phase-4-upload.yml
+++ b/.buildkite/phase-4-upload.yml
@@ -4,6 +4,8 @@ agents:
 steps:
   - label: ":pipeline: Phase 4 actions importer"
     key: "phase-4-upload-importer"
+    env:
+      BUILDKITE_GHA_TARGET_QUEUE: "hosted"
     plugins:
       - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
           version: "2026.5.12"

--- a/.buildkite/phase-5-docker-action.yml
+++ b/.buildkite/phase-5-docker-action.yml
@@ -4,6 +4,8 @@ agents:
 steps:
   - label: ":pipeline: Phase 5 Dockerfile action importer"
     key: "phase-5-docker-action-importer"
+    env:
+      BUILDKITE_GHA_TARGET_QUEUE: "hosted"
     timeout_in_minutes: 15
     retry:
       automatic: false

--- a/.buildkite/phase-6-annotations.yml
+++ b/.buildkite/phase-6-annotations.yml
@@ -4,6 +4,8 @@ agents:
 steps:
   - label: ":warning: Phase 6 workflow command annotation importer"
     key: "phase-6-annotations-importer"
+    env:
+      BUILDKITE_GHA_TARGET_QUEUE: "hosted"
     timeout_in_minutes: 15
     retry:
       automatic: false

--- a/.buildkite/phase-6-artifact-roundtrip.yml
+++ b/.buildkite/phase-6-artifact-roundtrip.yml
@@ -4,6 +4,8 @@ agents:
 steps:
   - label: ":package: Phase 6 artifact roundtrip importer"
     key: "phase-6-artifact-roundtrip-importer"
+    env:
+      BUILDKITE_GHA_TARGET_QUEUE: "hosted"
     timeout_in_minutes: 15
     retry:
       automatic: false

--- a/.buildkite/phase-6-summary.yml
+++ b/.buildkite/phase-6-summary.yml
@@ -4,6 +4,8 @@ agents:
 steps:
   - label: ":memo: Phase 6 summary annotation importer"
     key: "phase-6-summary-importer"
+    env:
+      BUILDKITE_GHA_TARGET_QUEUE: "hosted"
     timeout_in_minutes: 15
     retry:
       automatic: false

--- a/.buildkite/phase-6-upload-artifact.yml
+++ b/.buildkite/phase-6-upload-artifact.yml
@@ -4,6 +4,8 @@ agents:
 steps:
   - label: ":package: Phase 6 upload-artifact importer"
     key: "phase-6-upload-artifact-importer"
+    env:
+      BUILDKITE_GHA_TARGET_QUEUE: "hosted"
     timeout_in_minutes: 15
     retry:
       automatic: false

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -127,6 +127,8 @@ steps:
 
   - label: ":github: Exact-source plugin smoke"
     key: "plugin-source-smoke-importer"
+    env:
+      BUILDKITE_GHA_TARGET_QUEUE: "hosted"
     timeout_in_minutes: 20
     retry:
       automatic: false

--- a/README.md
+++ b/README.md
@@ -31,11 +31,13 @@ steps:
 
 The released plugin downloads and verifies `buildkite-gha` v0.2.3 by default,
 derives the event context from the Buildkite build, and uploads the generated
-jobs to the fixed `hosted` queue. Pin a released plugin version rather than a
-floating branch. For action jobs, the runtime reuses mise 2026.5.12 or newer
-from `PATH` or the absolute path in `BUILDKITE_GHA_MISE`; when neither provides
-a compatible version, it downloads and verifies a managed 2026.5.12 copy in
-the hosted cache. Shell-only jobs do not require or install mise.
+jobs without agent selectors, so the pipeline's configured defaults decide
+where they run. Pin a released plugin version rather than a floating branch.
+For action jobs, the runtime reuses mise 2026.5.12 or newer from `PATH` or the
+absolute path in `BUILDKITE_GHA_MISE`; when neither provides a compatible
+version, it downloads and verifies a managed 2026.5.12 copy. Hosted Agents use
+their attached cache; other environments fall back to an ephemeral cache when
+that path is unavailable. Shell-only jobs do not require or install mise.
 
 Configure branch, tag, and pull request triggers in Buildkite. The plugin
 derives a `pull_request` context for pull request builds and a `push` context
@@ -184,7 +186,7 @@ runtime behavior. JSON output is available with `--format json`.
 | Job | Command job |
 | Matrix entry | Command job with a stable key |
 | `needs` | `depends_on` plus verified result transport |
-| `runs-on` | Fail-closed queue policy |
+| `runs-on` | Linux compatibility validation; Buildkite default agent targeting |
 | `concurrency.group` | Repository-scoped Buildkite concurrency group or workflow gate |
 | Job output | Producer-attributed result artifact |
 | Step | Runs inside the job compatibility runtime |

--- a/README.md
+++ b/README.md
@@ -29,15 +29,17 @@ steps:
           workflow: .github/workflows/ci.yml
 ```
 
-The released plugin downloads and verifies `buildkite-gha` v0.2.3 by default,
-derives the event context from the Buildkite build, and uploads the generated
-jobs without agent selectors, so the pipeline's configured defaults decide
-where they run. Pin a released plugin version rather than a floating branch.
-For action jobs, the runtime reuses mise 2026.5.12 or newer from `PATH` or the
-absolute path in `BUILDKITE_GHA_MISE`; when neither provides a compatible
-version, it downloads and verifies a managed 2026.5.12 copy. Hosted Agents use
-their attached cache; other environments fall back to an ephemeral cache when
-that path is unavailable. Shell-only jobs do not require or install mise.
+The pinned released plugin downloads and verifies `buildkite-gha` v0.2.3 by
+default, derives the event context from the Buildkite build, and uploads the
+generated jobs to the fixed `hosted` queue. Pin a released plugin version rather
+than a floating branch. Source builds containing the default-agent-targeting
+change omit agent selectors when invoked directly; the plugin path will inherit
+configured defaults only after a release bundles that CLI behavior. In those
+builds, action jobs reuse mise 2026.5.12 or newer from `PATH` or the absolute
+path in `BUILDKITE_GHA_MISE`; when neither provides a compatible version, the
+runtime downloads and verifies a managed 2026.5.12 copy. Hosted Agents use their
+attached cache; other environments fall back to an ephemeral cache when that
+path is unavailable. Shell-only jobs do not require or install mise.
 
 Configure branch, tag, and pull request triggers in Buildkite. The plugin
 derives a `pull_request` context for pull request builds and a `push` context

--- a/docs/architecture/0002-plan-envelope-trust-boundary.md
+++ b/docs/architecture/0002-plan-envelope-trust-boundary.md
@@ -17,8 +17,9 @@ transport, but do not recreate GitHub Actions' meaningful security boundary.
 GitHub controls event identity and protected capability issuance; it does not
 isolate `run` and `uses` steps inside a job. Buildkite dynamic pipeline upload is
 ordinary pipeline authority. Therefore public, anonymous, tokenless actions on
-an ambient-clean fixed hosted queue do not require a privileged compiler, plan
-signer, or this envelope.
+suitably isolated agents do not require a privileged compiler, plan signer, or
+this envelope. Generated jobs inherit Buildkite's configured agent targeting;
+operators own the whole-job isolation policy.
 
 Protected capabilities will instead use a control-plane service that:
 
@@ -32,9 +33,10 @@ Protected capabilities will instead use a control-plane service that:
   tokens, environment grants, or explicitly supported compatible OIDC claims.
 
 Plans continue to use content digests and producer-attributed artifacts. The
-runtime continues to verify build, importer, job, step, queue, plan, and runtime
-bindings, but those checks do not authorize protected resources. Buildkite
-pipeline signing remains optional installation-specific defence in depth.
+runtime continues to verify build, importer, job, step, plan, runtime, and any
+explicit queue bindings, but those checks do not authorize protected resources.
+Buildkite pipeline signing remains optional installation-specific defence in
+depth.
 
 The original Phase 0 decision is retained below as an implementation and
 conformance record. Its statements that KMS-backed plan envelopes provide the

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -7,11 +7,14 @@ promises unless they appear here.
 
 ## The current execution profile
 
-The plugin and `upload` command default to one fixed profile:
-`hosted-tokenless`. Despite the historical profile name, generated jobs do not
-select the `hosted` queue: they inherit Buildkite's configured agent defaults.
-It is designed for public code that can run without protected credentials on a
-compatible Linux x86-64 agent. Operators are responsible for configuring those
+The production plugin and its bundled `upload` command default to one fixed
+profile: `hosted-tokenless`. The currently pinned plugin bundles
+`buildkite-gha` v0.2.3, whose generated jobs select the `hosted` queue. Source
+builds containing the default-agent-targeting change instead omit agent
+selectors, and a plugin release that bundles that CLI behavior will inherit
+Buildkite's configured agent defaults. The profile is designed for public code
+that can run without protected credentials on a compatible Linux x86-64 agent.
+Operators using default targeting are responsible for configuring those
 defaults with suitable whole-job isolation. Unsupported or privileged requests
 fail before the generated jobs are uploaded. An explicit `upload
 --private-checkout` extension admits only the verified checkout adapter and only
@@ -35,7 +38,7 @@ provide.
 
 | Area | Production plugin | Notes |
 | --- | --- | --- |
-| Linux x86-64 host jobs | Supported | `ubuntu-latest`, `ubuntu-24.04`, and `ubuntu-22.04` are accepted. Generated jobs omit agent selectors and use Buildkite's configured defaults. |
+| Linux x86-64 host jobs | Supported | `ubuntu-latest`, `ubuntu-24.04`, and `ubuntu-22.04` are accepted. The currently pinned plugin targets the fixed `hosted` queue; a release containing the default-agent-targeting change will omit agent selectors and use Buildkite's configured defaults. |
 | Bash and `sh` steps | Supported | Includes environment and working-directory precedence. |
 | Static job graphs and `needs` | Supported | Dependencies and logical results are preserved. |
 | Static matrices | Supported | Includes typed values, `include`, `exclude`, and exact dependency fan-out. |
@@ -459,13 +462,13 @@ not a complete execution path.
 `upload` is the in-build command used by the plugin:
 
 ```sh
-buildkite-gha upload .github/workflows/ci.yml
+buildkite-gha upload --runtime-queue hosted .github/workflows/ci.yml
 ```
 
 An installer may explicitly enable pipeline-repository private checkout:
 
 ```sh
-buildkite-gha upload --private-checkout \
+buildkite-gha upload --private-checkout --runtime-queue hosted \
   .github/workflows/ci.yml
 ```
 
@@ -478,10 +481,12 @@ repository-bound by the Agent service.
 
 The command uploads the exact executable and content-addressed plans before
 calling `buildkite-agent pipeline upload --no-interpolation --reject-secrets`.
-Generated jobs do not set `agents`, so Buildkite's pipeline or organization
-defaults select the agents. The deprecated `--runtime-queue hosted` argument is
-still accepted for compatibility with older plugin releases, but it does not
-select a queue; other values are rejected rather than silently ignored.
+In source builds containing the default-agent-targeting change, generated jobs
+do not set `agents`, so Buildkite's pipeline or organization defaults select the
+agents. The deprecated `--runtime-queue hosted` argument remains accepted as a
+no-op for compatibility with plugin releases that still pass it; the current
+v0.2.3 release uses that argument to select `hosted`. Other values are rejected
+rather than silently ignored by the new implementation.
 
 `run-job` is an internal command emitted into generated jobs. Users should not
 need to invoke it directly.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -459,18 +459,23 @@ not a complete execution path.
 
 ### Upload
 
-`upload` is the in-build command used by the plugin:
+`upload` is the in-build command used by the plugin. Source builds containing
+the default-agent-targeting change use:
 
 ```sh
-buildkite-gha upload --runtime-queue hosted .github/workflows/ci.yml
+buildkite-gha upload .github/workflows/ci.yml
 ```
 
 An installer may explicitly enable pipeline-repository private checkout:
 
 ```sh
-buildkite-gha upload --private-checkout --runtime-queue hosted \
+buildkite-gha upload --private-checkout \
   .github/workflows/ci.yml
 ```
+
+When invoking the current v0.2.3 release directly, add
+`--runtime-queue hosted`; that release requires the argument and uses it to
+select the `hosted` queue.
 
 It requires `BUILDKITE=true` and `BUILDKITE_STEP_KEY`. Without `--event-path`,
 it derives a bounded compatibility snapshot from the current Buildkite build.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -488,5 +488,14 @@ no-op for compatibility with plugin releases that still pass it; the current
 v0.2.3 release uses that argument to select `hosted`. Other values are rejected
 rather than silently ignored by the new implementation.
 
+An importer that must select one queue can set `BUILDKITE_GHA_TARGET_QUEUE` on
+its step. The uploader maps every accepted Linux runner label to that queue,
+emits the corresponding `agents` selector, and binds the plan to the runtime
+queue. An empty, whitespace-containing, or otherwise invalid queue fails before
+pipeline upload. This setting is ordinary pipeline configuration, not an
+authenticated grant: it admits untrusted workflow code to the named queue, so
+that queue must provide suitable whole-job isolation and no ambient protected
+credentials.
+
 `run-job` is an internal command emitted into generated jobs. Users should not
 need to invoke it directly.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -8,11 +8,14 @@ promises unless they appear here.
 ## The current execution profile
 
 The plugin and `upload` command default to one fixed profile:
-`hosted-tokenless`. It is designed for public code that can run without
-protected credentials on a Linux x86-64 Buildkite Hosted Agent. Unsupported or
-privileged requests fail before the generated jobs are uploaded. An explicit
-`upload --private-checkout` extension admits only the verified checkout adapter
-and only when the organization has enabled Buildkite's job-bound GitHub scoped
+`hosted-tokenless`. Despite the historical profile name, generated jobs do not
+select the `hosted` queue: they inherit Buildkite's configured agent defaults.
+It is designed for public code that can run without protected credentials on a
+compatible Linux x86-64 agent. Operators are responsible for configuring those
+defaults with suitable whole-job isolation. Unsupported or privileged requests
+fail before the generated jobs are uploaded. An explicit `upload
+--private-checkout` extension admits only the verified checkout adapter and only
+when the organization has enabled Buildkite's job-bound GitHub scoped
 access-token service.
 
 There are three different compatibility claims:
@@ -32,7 +35,7 @@ provide.
 
 | Area | Production plugin | Notes |
 | --- | --- | --- |
-| Linux x86-64 host jobs | Supported | `ubuntu-latest`, `ubuntu-24.04`, and `ubuntu-22.04` map to the fixed `hosted` queue. |
+| Linux x86-64 host jobs | Supported | `ubuntu-latest`, `ubuntu-24.04`, and `ubuntu-22.04` are accepted. Generated jobs omit agent selectors and use Buildkite's configured defaults. |
 | Bash and `sh` steps | Supported | Includes environment and working-directory precedence. |
 | Static job graphs and `needs` | Supported | Dependencies and logical results are preserved. |
 | Static matrices | Supported | Includes typed values, `include`, `exclude`, and exact dependency fan-out. |
@@ -366,14 +369,16 @@ archive checksum, and extract it to a stable location. The archive contains
 Generated jobs that execute actions support mise 2026.5.12 or newer. `run-job`
 first checks `BUILDKITE_GHA_MISE` when set, then `PATH`; if neither supplies a
 compatible version, it downloads the pinned 2026.5.12 official archive into
-the automatically attached hosted cache. Both the archive and extracted
-executable are verified by embedded SHA-256 digests before use. Verified cache
-bytes are copied into a job-private directory and reverified there before
-execution, so the shared cache remains an accelerator rather than executable
-authority. An explicit `BUILDKITE_GHA_MISE` must be absolute and compatible
-rather than silently falling back. The runtime resolves and validates the
-executable before workflow code can modify `PATH`, then uses it with repository
-configuration disabled to install exact Node 20.20.2 or 24.18.0 releases.
+the managed cache path. Hosted Agents attach that cache automatically; other
+agent environments use it when available and otherwise fall back to an
+ephemeral cache. Both the archive and extracted executable are verified by
+embedded SHA-256 digests before use. Verified cache bytes are copied into a
+job-private directory and reverified there before execution, so the shared
+cache remains an accelerator rather than executable authority. An explicit
+`BUILDKITE_GHA_MISE` must be absolute and compatible rather than silently
+falling back. The runtime resolves and validates the executable before workflow
+code can modify `PATH`, then uses it with repository configuration disabled to
+install exact Node 20.20.2 or 24.18.0 releases.
 Those Node binaries require glibc 2.28 or newer; the static Go CLI does not.
 Shell-only jobs, importers, `validate`, and `compile` do not require or install
 mise.
@@ -454,13 +459,13 @@ not a complete execution path.
 `upload` is the in-build command used by the plugin:
 
 ```sh
-buildkite-gha upload --runtime-queue hosted .github/workflows/ci.yml
+buildkite-gha upload .github/workflows/ci.yml
 ```
 
 An installer may explicitly enable pipeline-repository private checkout:
 
 ```sh
-buildkite-gha upload --private-checkout --runtime-queue hosted \
+buildkite-gha upload --private-checkout \
   .github/workflows/ci.yml
 ```
 
@@ -473,8 +478,10 @@ repository-bound by the Agent service.
 
 The command uploads the exact executable and content-addressed plans before
 calling `buildkite-agent pipeline upload --no-interpolation --reject-secrets`.
-The queue argument is intentionally fixed to `hosted`; it cannot be used to
-select a more privileged queue.
+Generated jobs do not set `agents`, so Buildkite's pipeline or organization
+defaults select the agents. The deprecated `--runtime-queue hosted` argument is
+still accepted for compatibility with older plugin releases, but it does not
+select a queue; other values are rejected rather than silently ignored.
 
 `run-job` is an internal command emitted into generated jobs. Users should not
 need to invoke it directly.

--- a/docs/development.md
+++ b/docs/development.md
@@ -79,9 +79,12 @@ outside production admission.
 Every Buildkite build runs `.github/workflows/example-basic.yml` through the
 released plugin with `buildkite-gha-source-ref` set to the build's exact commit.
 This proves a pull request's unreleased CLI source through the public plugin
-before a CLI release exists. The released-plugin demos remain separate because
-they verify release archives, checksums, and the normal default installation
-path rather than source execution.
+before a CLI release exists. The importer explicitly sets
+`BUILDKITE_GHA_TARGET_QUEUE=hosted`, so this repository's smoke continues to
+exercise its intended queue while default uploads omit agent targeting. The
+released-plugin demos remain separate because they verify release archives,
+checksums, and the normal default installation path rather than source
+execution.
 
 ### Paired native UX runs
 
@@ -114,7 +117,9 @@ bk build create --pipeline buildkite/buildkite-gha \
 ```
 
 The aggregate retains each phase's importer and continuation topology. Use a
-phase selector only for targeted diagnosis:
+phase selector only for targeted diagnosis. Importer steps that generate jobs
+set `BUILDKITE_GHA_TARGET_QUEUE=hosted`; this keeps these hosted-specific proofs
+explicit rather than relying on deployment defaults.
 
 | Coverage | Build environment |
 | --- | --- |

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -1258,6 +1258,10 @@ Cursor Origin public checkout remains a separate provider integration gate.
 - Generated workflow jobs and concurrency gates now omit Buildkite `agents` by
   default, leaving scheduling to the pipeline or organization defaults. An
   explicit `RunnerPolicy` queue remains supported for embedding API callers.
+  Upload importers can opt into that policy through
+  `BUILDKITE_GHA_TARGET_QUEUE`; the value is ordinary pipeline configuration and
+  must name a queue suitable for untrusted workflow code. Repository-owned
+  hosted proof importers set it to `hosted` explicitly.
   Job-plan schema v7 makes `target.queue` optional, and runtime queue binding is
   checked only when a plan explicitly selects one. The deprecated
   `--runtime-queue hosted` spelling remains a no-op compatibility path for

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -2,7 +2,7 @@
 
 Status: **Active**
 Date: 2026-07-22
-Last reviewed: 2026-07-27
+Last reviewed: 2026-08-07
 Target repository: `buildkite/buildkite-gha`
 
 > This is the active product and implementation plan. It records future UX,
@@ -46,7 +46,7 @@ The unit of translation is the Actions job:
 | Workflow run | Buildkite build |
 | Workflow job or matrix entry | Buildkite command job |
 | `needs` | `depends_on` plus producer-attributed result manifests |
-| `runs-on` | Buildkite queue/agent selectors |
+| `runs-on` | Linux compatibility validation and optional policy-selected agent selectors |
 | Static matrix | Expanded keyed Buildkite jobs |
 | Dynamic matrix | Deferred dynamic pipeline upload |
 | Job output | Namespaced Buildkite build metadata |
@@ -105,9 +105,11 @@ or Docker daemon across trust domains is outside this tokenless threat model.
 
 Buildkite dynamic pipeline upload is likewise ordinary pipeline authority, not
 a weaker class of job merely because the pipeline was generated. Public,
-anonymous, tokenless actions may run on an ambient-clean fixed hosted queue
-without a privileged compiler, plan signer, or supporting service. They have no
-more authority than a shell step that downloads and executes public code.
+anonymous, tokenless actions do not require a privileged compiler, plan signer,
+or supporting service. Generated jobs inherit Buildkite's configured agent
+targeting by default; operators remain responsible for ensuring those agents
+provide suitable job-level isolation. The actions have no more authority than a
+shell step that downloads and executes public code.
 
 Protected capabilities are different. A plan may request a GitHub token,
 private source, secret, environment grant, privileged queue, or compatible OIDC
@@ -228,8 +230,8 @@ buildkite-gha run-job --plan .buildkite-gha/plans/<digest>.json
 `--provider <name>` switches positional workflow paths to repository-relative
 provider paths resolved at the attested event SHA. Without `--provider`, paths
 are local files and the supplied event is unattested. An unattested event can
-drive tokenless execution on an allowed queue, but cannot authorize a protected
-capability.
+drive tokenless execution using deployment-configured agent defaults or an
+explicitly admitted runner policy, but cannot authorize a protected capability.
 
 `compile` must not mutate the current build. It is suitable for local review,
 golden tests, and:
@@ -253,21 +255,18 @@ inert local inputs:
 steps:
   - label: ":github: Load existing CI workflow"
     key: "gha-ci"
-    agents:
-      queue: "hosted"
     command: >-
       buildkite-gha upload
       --event-path .buildkite/events/current.json
-      --runtime-queue hosted
       .github/workflows/ci.yml
 ```
 
 This importer is authoritative in the same sense as any other Buildkite dynamic
-pipeline generator. It should use a pinned distribution, fixed queue policy,
-bounded inert inputs, and generated jobs without ambient protected credentials.
-It does not need a signer merely to upload tokenless jobs. If the workflow asks
-for a protected capability, `upload` fails unless the installation has a valid
-control-plane grant for that exact build and plan.
+pipeline generator. It should use a pinned distribution, deployment-configured
+agent defaults, bounded inert inputs, and generated jobs without ambient
+protected credentials. It does not need a signer merely to upload tokenless
+jobs. If the workflow asks for a protected capability, `upload` fails unless the
+installation has a valid control-plane grant for that exact build and plan.
 
 A future provider-backed mode may skip checkout and read the workflow through a
 data-only provider adapter at an authenticated event SHA. Private reads in that
@@ -280,12 +279,9 @@ An existing native step can depend on the importer:
 steps:
   - label: ":github: Load existing CI workflow"
     key: "gha-ci"
-    agents:
-      queue: "hosted"
     command: >-
       buildkite-gha upload
       --event-path .buildkite/events/current.json
-      --runtime-queue hosted
       .github/workflows/ci.yml
 
   - label: ":rocket: Native deployment"
@@ -550,7 +546,7 @@ contains no secret values and includes:
 - matrix values and strategy settings;
 - dependency IDs;
 - job condition, environment, defaults, timeout, and permissions;
-- requested runner labels and resolved Buildkite target;
+- requested runner labels and optional policy-selected Buildkite target;
 - job and service container definitions;
 - ordered action steps, including source locations;
 - action references and immutable resolved SHAs where available;
@@ -561,10 +557,10 @@ contains no secret values and includes:
 Plans are canonical JSON with content digests. The upload job publishes them as
 namespaced, producer-attributed Buildkite artifacts before generated jobs become
 eligible. Each generated job downloads its plan from the exact importer,
-verifies the digest, schema, build, job, step, queue, and compiler/runtime
-binding, then invokes `run-job`. These checks protect transport and prevent a
-job from accidentally consuming another job's plan; they do not grant protected
-authority.
+verifies the digest, schema, build, job, step, optional explicit queue, and
+compiler/runtime binding, then invokes `run-job`. These checks protect transport
+and prevent a job from accidentally consuming another job's plan; they do not
+grant protected authority.
 
 A plan lists requested capabilities. Before resolving any protected capability,
 the runtime must additionally present its own Buildkite Job OIDC identity and a
@@ -589,11 +585,12 @@ bootstrap contract is:
 - obtain workflow and action metadata as bounded inert input without executing
   repository hooks, plugins, generated scripts, or repository-provided
   binaries during data-only provider reads;
-- provide no ambient protected credentials to tokenless importer or runtime
-  queues;
-- emit fixed `run-job` commands whose queue, plugins, containers, and requested
-  capabilities are selected through fail-closed policy rather than copied
-  directly from workflow text;
+- provide no ambient protected credentials to the tokenless importer or
+  runtime jobs;
+- emit fixed `run-job` commands whose agent targeting is omitted by default or
+  selected by explicit embedding policy, and whose plugins, containers, and
+  requested capabilities are selected through fail-closed policy rather than
+  copied directly from workflow text;
 - bind every content-addressed plan to the generated job and exact importer;
   and
 - reject protected capability requests unless a matching control-plane grant
@@ -622,7 +619,7 @@ The emitter maps every expanded GHA job to an ordinary command step with:
 - logical GHA dependency edges expressed with per-dependency
   `allow_failure: true` so failed prerequisites still dispatch the compatibility
   runtime;
-- a queue mapping derived from `runs-on` and policy;
+- no agent selector by default, or a queue selected by explicit runner policy;
 - timeout and concurrency properties where semantics align;
 - `checkout.skip: true` so the agent does not populate the job workspace before
   the compatibility runtime starts;
@@ -1027,8 +1024,10 @@ authority.
 - The runtime verifies that the grant matches its own job, plan digest, queue,
   requested capability, audience, and expiry before resolving a value.
 - Fork pull requests receive no privileged secrets by default.
-- An untrusted event can target only queues explicitly configured for untrusted
-  code; workflow-controlled `runs-on` values cannot select a privileged queue.
+- Workflow-controlled `runs-on` values cannot name an arbitrary Buildkite queue.
+  The default upload path inherits deployment-configured agent targeting;
+  explicit embedding policies may map accepted labels only to separately
+  admitted queues for untrusted code.
 - Provider API tokens are short-lived and least-privilege.
 - Reusable workflows can only narrow inherited permissions.
 - Every secret is registered with the Agent redactor before use.
@@ -1072,14 +1071,15 @@ The v0.1 preview bootstrap is implemented as one reproducible Linux x86-64
 archive containing only the static CLI and LICENSE, plus the
 `github-actions#v0.1.0` installer plugin. The plugin downloads an exact public
 release, verifies its checksum and fixed archive layout, caches the verified
-distribution, and invokes the fixed hosted-tokenless upload path. For action
+distribution, and invokes the tokenless upload path. For action
 jobs, the static bridge reuses mise 2026.5.12 or newer when available or
 downloads and digest-verifies its pinned 2026.5.12 official archive in the
-automatically attached, integration-owned hosted cache volume. Node 20.20.2
-and 24.18.0 are installed by a reverified, job-private copy of that executable
-on demand into the same cache volume. Cached mise and Node executables are
-digest-verified before use, so cache sharing across builds is an optimization
-rather than a trust boundary.
+integration-owned managed cache path. Hosted Agents attach that cache
+automatically; other agent environments use it when available and otherwise
+fall back to ephemeral storage. Node 20.20.2 and 24.18.0 are installed by a
+reverified, job-private copy of that executable on demand into the same cache.
+Cached mise and Node executables are digest-verified before use, so cache
+sharing across builds is an optimization rather than a trust boundary.
 Official mise-installed Node binaries require glibc 2.28 or newer.
 The source repository must be public before the initial tag because plugin
 installation intentionally uses anonymous release downloads. Release
@@ -1255,6 +1255,13 @@ Cursor Origin public checkout remains a separate provider integration gate.
   plans, Buildkite pipeline YAML, and text/JSON compatibility reports.
   `compile` remains a read-only rendering command; `upload` materializes the
   executable and content-addressed plans used by generated jobs.
+- Generated workflow jobs and concurrency gates now omit Buildkite `agents` by
+  default, leaving scheduling to the pipeline or organization defaults. An
+  explicit `RunnerPolicy` queue remains supported for embedding API callers.
+  Job-plan schema v7 makes `target.queue` optional, and runtime queue binding is
+  checked only when a plan explicitly selects one. The deprecated
+  `--runtime-queue hosted` spelling remains a no-op compatibility path for
+  released plugin hooks; other values are rejected.
 - Phase 2 is complete. Its sequential shell runtime, producer-attributed result
   transport, and unprivileged `upload` bootstrap are implemented and proven on
   Buildkite. Generated plans
@@ -1282,9 +1289,10 @@ Cursor Origin public checkout remains a separate provider integration gate.
   executable bytes; generated agents reuse or install the pinned mise release
   before workflow code and resolve compatibility versions through `mise
   --no-config`.
-  This path remains `EventUntrusted`, fixed to the
-  ambient-clean, tokenless hosted queue, and accepts no capability, `network`,
-  or the Phase 5 compiler-proven Dockerfile-action provenance.
+  This path remains `EventUntrusted`, uses Buildkite's configured default agent
+  targeting, and accepts no capability, `network`, or the Phase 5
+  compiler-proven Dockerfile-action provenance. Operators remain responsible
+  for selecting suitably isolated agents for untrusted workflow code.
   Private remote action or repository source, provider tokens, secrets, job- or
   service-container provenance, privileged queues, and other protected
   capabilities fail closed.
@@ -1860,10 +1868,11 @@ Implemented order and fixed boundaries:
    fixed structured mounts and bridge-owned labels, and stop/remove containers
    and images under an independent bounded cleanup context.
 2. Admit only local and anonymously resolved public Dockerfile actions on the
-   fixed tokenless `hosted` queue. Continue rejecting `docker://` images,
-   Docker pre/post entrypoints, arbitrary Docker options, private registries,
-   credentials, provider tokens, host namespaces, devices, socket mounts, and
-   privileged capabilities.
+   tokenless path. Generated jobs use Buildkite's configured agent defaults;
+   operators must provide suitable whole-job Docker isolation. Continue
+   rejecting `docker://` images, Docker pre/post entrypoints, arbitrary Docker
+   options, private registries, credentials, provider tokens, host namespaces,
+   devices, socket mounts, and privileged capabilities.
 3. Persistent job containers and path translation landed after Docker action
    lifecycle, command-file processing, masking, cancellation, and cleanup
    passed conformance coverage.
@@ -2514,6 +2523,12 @@ unknown plan.
     imported job exits successfully after publishing its logical `skipped`
     result and emits a clear annotation. Downstream compatibility semantics use
     the logical result rather than the Buildkite job state.
+12. Generated jobs omit Buildkite agent targeting by default. Empty runner
+    policy mappings mean "use Buildkite defaults"; explicit queue mappings
+    remain available to embedding API callers. Schema v7 makes
+    `target.queue` optional, and only explicit targets are runtime-verified.
+    The deprecated `--runtime-queue hosted` CLI spelling is accepted but does
+    not alter scheduling.
 
 ## Decisions deferred after Phase 0
 
@@ -2531,10 +2546,11 @@ them in the phase that first needs the capability:
    hosted differential corpus.
 4. Phase 6 will define Cursor Origin checkout, event, pull-request, Job OIDC,
    and short-lived capability contracts alongside the GitHub provider adapter.
-5. The fixed Buildkite `hosted` queue's documented per-job disposable isolation
-   and the Phase 5 probe are sufficient for tokenless, non-privileged Dockerfile
-   actions built on the local driver. Phases 6 and 9 still own authorization and
-   queue policy for protected Docker capabilities and privileged workloads.
+5. The Phase 5 probe on Buildkite's `hosted` queue proves this repository's
+   Dockerfile-action evidence, not a product scheduling requirement. Deployments
+   using Buildkite defaults must independently provide suitable whole-job
+   isolation. Phases 6 and 9 still own authorization and queue policy for
+   protected Docker capabilities and privileged workloads.
 6. Phase 6 will define the GitHub App installation-token compatibility contract
    for `github.token` and `GITHUB_TOKEN`, including repository/permission
    narrowing and documented differences from native Actions tokens. The

--- a/internal/buildkite/pipeline.go
+++ b/internal/buildkite/pipeline.go
@@ -49,10 +49,10 @@ func DistributionPath(digest string) (string, error) {
 	return distributionDirectory + "/" + strings.TrimPrefix(digest, "sha256:") + "/buildkite-gha", nil
 }
 
-// MiseDataDir returns the runtime-owned hosted cache path for the required
-// mise version. The generated cache path triggers Buildkite's documented
-// /cache/bkcache volume mount; cache contents are an accelerator, never an
-// authority.
+// MiseDataDir returns the runtime-owned managed cache path for the required
+// mise version. Hosted Agents mount this path automatically; other agent
+// environments fall back to an ephemeral cache when it is unavailable. Cache
+// contents are an accelerator, never an authority.
 func MiseDataDir() string {
 	return "/cache/bkcache/buildkite-gha/mise/" + MinimumMiseVersion
 }
@@ -132,8 +132,10 @@ func Emit(pipeline Pipeline) ([]byte, error) {
 		commands = append(commands, `"$distribution" run-job --plan "$plan"`)
 		command := strings.Join(commands, "\n")
 		_, _ = fmt.Fprintf(&out, "%scommand: %s\n", attributeIndent, yamlScalar(command))
-		_, _ = fmt.Fprintf(&out, "%sagents:\n", attributeIndent)
-		_, _ = fmt.Fprintf(&out, "%s  queue: %s\n", attributeIndent, yamlScalar(job.Queue))
+		if job.Queue != "" {
+			_, _ = fmt.Fprintf(&out, "%sagents:\n", attributeIndent)
+			_, _ = fmt.Fprintf(&out, "%s  queue: %s\n", attributeIndent, yamlScalar(job.Queue))
+		}
 		_, _ = fmt.Fprintf(&out, "%scheckout:\n%s  skip: true\n", attributeIndent, attributeIndent)
 		if job.UsesActions {
 			_, _ = fmt.Fprintf(&out, "%scache:\n", attributeIndent)
@@ -181,8 +183,10 @@ func emitConcurrencyGateStep(out *bytes.Buffer, stepIndent, attributeIndent, lab
 	_, _ = fmt.Fprintf(out, "%s- label: %s\n", stepIndent, yamlScalar(label))
 	_, _ = fmt.Fprintf(out, "%skey: %s\n", attributeIndent, yamlScalar(key))
 	_, _ = fmt.Fprintf(out, "%scommand: %s\n", attributeIndent, yamlScalar("true"))
-	_, _ = fmt.Fprintf(out, "%sagents:\n", attributeIndent)
-	_, _ = fmt.Fprintf(out, "%s  queue: %s\n", attributeIndent, yamlScalar(gate.Queue))
+	if gate.Queue != "" {
+		_, _ = fmt.Fprintf(out, "%sagents:\n", attributeIndent)
+		_, _ = fmt.Fprintf(out, "%s  queue: %s\n", attributeIndent, yamlScalar(gate.Queue))
+	}
 	_, _ = fmt.Fprintf(out, "%scheckout:\n%s  skip: true\n", attributeIndent, attributeIndent)
 	_, _ = fmt.Fprintf(out, "%sconcurrency: 1\n", attributeIndent)
 	_, _ = fmt.Fprintf(out, "%sconcurrency_group: %s\n", attributeIndent, yamlScalar(gate.Group))
@@ -199,7 +203,7 @@ func validateConcurrencyGate(gate *ConcurrencyGate) error {
 	if gate.Group == "" || len(gate.Group) > maxConcurrencyGroupLength {
 		return fmt.Errorf("invalid workflow concurrency group")
 	}
-	if !identifierPattern.MatchString(gate.Queue) {
+	if gate.Queue != "" && !identifierPattern.MatchString(gate.Queue) {
 		return fmt.Errorf("workflow concurrency gate has invalid queue %q", gate.Queue)
 	}
 	return nil
@@ -305,7 +309,7 @@ func validateJob(compilerStep string, job Job) error {
 	if job.Label == "" {
 		return fmt.Errorf("job %q requires a label", job.Key)
 	}
-	if !identifierPattern.MatchString(job.Queue) {
+	if job.Queue != "" && !identifierPattern.MatchString(job.Queue) {
 		return fmt.Errorf("job %q has invalid queue %q", job.Key, job.Queue)
 	}
 	if _, err := PlanPath(job.PlanDigest); err != nil {

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -201,6 +201,21 @@ func TestEmitWrapsJobsInWorkflowConcurrencyGate(t *testing.T) {
 	}
 }
 
+func TestEmitUsesDefaultAgentTargetingWhenQueueIsEmpty(t *testing.T) {
+	output, err := Emit(Pipeline{
+		CompilerStep:       "importer",
+		DistributionDigest: testDigest("distribution"),
+		ConcurrencyGate:    &ConcurrencyGate{Group: "buildkite-gha/concurrency/group"},
+		Jobs:               []Job{{Key: "job", Label: "Job", PlanDigest: testDigest("plan")}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(output), "agents:") || strings.Contains(string(output), "queue:") {
+		t.Fatalf("default-targeted pipeline contains agent selectors:\n%s", output)
+	}
+}
+
 func TestConcurrencyGateKeysIncludeCompilerStep(t *testing.T) {
 	jobs := []Job{{Key: "job"}}
 	firstOpen, firstClose := concurrencyGateKeys("first-importer", "shared-group", jobs)

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -532,6 +532,51 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 	}
 }
 
+func TestRepositoryHostedImportersSelectExplicitTargetQueue(t *testing.T) {
+	tests := map[string][]string{
+		"pipeline.yml":                   {"plugin-source-smoke-importer"},
+		"phase-2-upload.yml":             {"phase-2-upload-importer"},
+		"phase-3-upload.yml":             {"phase-3-upload-importer"},
+		"phase-4-upload.yml":             {"phase-4-upload-importer"},
+		"phase-5-docker-action.yml":      {"phase-5-docker-action-importer"},
+		"phase-6-summary.yml":            {"phase-6-summary-importer"},
+		"phase-6-annotations.yml":        {"phase-6-annotations-importer"},
+		"phase-6-upload-artifact.yml":    {"phase-6-upload-artifact-importer"},
+		"phase-6-artifact-roundtrip.yml": {"phase-6-artifact-roundtrip-importer"},
+		"migration-poc.yml": {
+			"migration-poc-basic-importer",
+			"migration-poc-artifact-importer",
+			"migration-poc-advanced-importer",
+		},
+	}
+	for path, importerKeys := range tests {
+		t.Run(path, func(t *testing.T) {
+			source, err := os.ReadFile(filepath.Join("..", "..", ".buildkite", path))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var document struct {
+				Steps []struct {
+					Key string            `yaml:"key"`
+					Env map[string]string `yaml:"env"`
+				} `yaml:"steps"`
+			}
+			if err := yaml.Unmarshal(source, &document); err != nil {
+				t.Fatal(err)
+			}
+			steps := make(map[string]map[string]string, len(document.Steps))
+			for _, step := range document.Steps {
+				steps[step.Key] = step.Env
+			}
+			for _, key := range importerKeys {
+				if got := steps[key]["BUILDKITE_GHA_TARGET_QUEUE"]; got != "hosted" {
+					t.Fatalf("importer %q target queue = %q, want hosted", key, got)
+				}
+			}
+		})
+	}
+}
+
 func TestExamplesPipelineSelectsOneCanonicalWorkflow(t *testing.T) {
 	root := filepath.Join("..", "..")
 	source, err := os.ReadFile(filepath.Join(root, ".buildkite", "examples.yml"))

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -53,6 +53,18 @@ var commandUsage = map[string]string{
 	"run-job":  "Usage: buildkite-gha run-job --plan <path> [--result <path>]\n",
 }
 
+func writeCommandHelp(stdout io.Writer, command string) {
+	_, _ = fmt.Fprint(stdout, commandUsage[command])
+	switch command {
+	case "validate":
+		_, _ = fmt.Fprint(stdout, "\nThe hosted-tokenless profile resolves actions and applies production upload policy without executing jobs or proving arbitrary action runtime compatibility.\n")
+	case "compile":
+		_, _ = fmt.Fprint(stdout, "\nPipeline output references content-addressed plans; compile does not materialize or upload those artifacts.\n")
+	case "upload":
+		_, _ = fmt.Fprintf(stdout, "\nGenerated jobs use Buildkite's default agent targeting. An importer can explicitly target one queue with %s; that queue must be suitable for untrusted workflow code. The deprecated --runtime-queue hosted option is accepted for plugin compatibility but does not select a queue. The default path accepts an explicit event file or derives compatibility data from Buildkite and remains unsigned. --private-checkout opts only verified checkout jobs into current-job, read-only pipeline-repository authority.\n", targetQueueEnvironment)
+	}
+}
+
 const (
 	resultPublicationTimeout = 10 * time.Second
 	legacyRuntimeQueue       = "hosted"
@@ -91,18 +103,9 @@ func run(args []string, stdout, stderr io.Writer, version string, agentRunner tr
 		_, _ = fmt.Fprintf(stdout, "buildkite-gha %s\n", version)
 		return 0
 	default:
-		if commandHelp, ok := commandUsage[args[0]]; ok {
+		if _, ok := commandUsage[args[0]]; ok {
 			if len(args) == 2 && (args[1] == "-h" || args[1] == "--help") {
-				_, _ = fmt.Fprint(stdout, commandHelp)
-				if args[0] == "compile" {
-					_, _ = fmt.Fprint(stdout, "\nPipeline output references content-addressed plans; compile does not materialize or upload those artifacts.\n")
-				}
-				if args[0] == "validate" {
-					_, _ = fmt.Fprint(stdout, "\nThe hosted-tokenless profile resolves actions and applies production upload policy without executing jobs or proving arbitrary action runtime compatibility.\n")
-				}
-				if args[0] == "upload" {
-					_, _ = fmt.Fprintf(stdout, "\nGenerated jobs use Buildkite's default agent targeting. An importer can explicitly target one queue with %s; that queue must be suitable for untrusted workflow code. The deprecated --runtime-queue hosted option is accepted for plugin compatibility but does not select a queue. The default path accepts an explicit event file or derives compatibility data from Buildkite and remains unsigned. --private-checkout opts only verified checkout jobs into current-job, read-only pipeline-repository authority.\n", targetQueueEnvironment)
-				}
+				writeCommandHelp(stdout, args[0])
 				return 0
 			}
 			switch args[0] {
@@ -133,21 +136,11 @@ func help(args []string, stdout, stderr io.Writer) int {
 		return usageError(stderr, "help accepts at most one command")
 	}
 
-	commandHelp, ok := commandUsage[args[0]]
-	if !ok {
+	if _, ok := commandUsage[args[0]]; !ok {
 		return usageError(stderr, "unknown command %q", args[0])
 	}
 
-	_, _ = fmt.Fprint(stdout, commandHelp)
-	if args[0] == "validate" {
-		_, _ = fmt.Fprint(stdout, "\nThe hosted-tokenless profile resolves actions and applies production upload policy without executing jobs or proving arbitrary action runtime compatibility.\n")
-	}
-	if args[0] == "compile" {
-		_, _ = fmt.Fprint(stdout, "\nPipeline output references content-addressed plans; compile does not materialize or upload those artifacts.\n")
-	}
-	if args[0] == "upload" {
-		_, _ = fmt.Fprint(stdout, "\nGenerated jobs use Buildkite's default agent targeting. The deprecated --runtime-queue hosted option is accepted for plugin compatibility but does not select a queue. The default path accepts an explicit event file or derives compatibility data from Buildkite and remains unsigned. --private-checkout opts only verified checkout jobs into current-job, read-only pipeline-repository authority.\n")
-	}
+	writeCommandHelp(stdout, args[0])
 	return 0
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -49,13 +49,13 @@ Run "buildkite-gha help <command>" for command help.
 var commandUsage = map[string]string{
 	"validate": "Usage: buildkite-gha validate [--event-path <path>] [--profile hosted-tokenless] [--format text|json] <workflow>\n",
 	"compile":  "Usage: buildkite-gha compile --event-path <path> [--format pipeline|ir-json] <workflow>\n",
-	"upload":   "Usage: buildkite-gha upload [--event-path <path>] [--private-checkout] --runtime-queue hosted <workflow>\n",
+	"upload":   "Usage: buildkite-gha upload [--event-path <path>] [--private-checkout] [--runtime-queue hosted] <workflow>\n",
 	"run-job":  "Usage: buildkite-gha run-job --plan <path> [--result <path>]\n",
 }
 
 const (
 	resultPublicationTimeout = 10 * time.Second
-	unprivilegedRuntimeQueue = "hosted"
+	legacyRuntimeQueue       = "hosted"
 	hostedTokenlessProfile   = "hosted-tokenless"
 	runtimeMiseArchiveDigest = "bd0930c0b619f51ddb60e32e5cce18a5533567b2f1ba9fc4875b9f39a2bb3ed8"
 	runtimeMiseBinaryDigest  = "a238972a3162d710b85b28c324372e96ca4e4b486c81fe78695000d9fbc77c48"
@@ -100,7 +100,7 @@ func run(args []string, stdout, stderr io.Writer, version string, agentRunner tr
 					_, _ = fmt.Fprint(stdout, "\nThe hosted-tokenless profile resolves actions and applies production upload policy without executing jobs or proving arbitrary action runtime compatibility.\n")
 				}
 				if args[0] == "upload" {
-					_, _ = fmt.Fprint(stdout, "\nThe default path accepts an explicit event file or derives compatibility data from Buildkite and remains unsigned and unprivileged. --private-checkout opts only verified checkout jobs into current-job, read-only pipeline-repository authority.\n")
+					_, _ = fmt.Fprint(stdout, "\nGenerated jobs use Buildkite's default agent targeting. The deprecated --runtime-queue hosted option is accepted for plugin compatibility but does not select a queue. The default path accepts an explicit event file or derives compatibility data from Buildkite and remains unsigned. --private-checkout opts only verified checkout jobs into current-job, read-only pipeline-repository authority.\n")
 				}
 				return 0
 			}
@@ -145,7 +145,7 @@ func help(args []string, stdout, stderr io.Writer) int {
 		_, _ = fmt.Fprint(stdout, "\nPipeline output references content-addressed plans; compile does not materialize or upload those artifacts.\n")
 	}
 	if args[0] == "upload" {
-		_, _ = fmt.Fprint(stdout, "\nThe default path accepts an explicit event file or derives compatibility data from Buildkite and remains unsigned and unprivileged. --private-checkout opts only verified checkout jobs into current-job, read-only pipeline-repository authority.\n")
+		_, _ = fmt.Fprint(stdout, "\nGenerated jobs use Buildkite's default agent targeting. The deprecated --runtime-queue hosted option is accepted for plugin compatibility but does not select a queue. The default path accepts an explicit event file or derives compatibility data from Buildkite and remains unsigned. --private-checkout opts only verified checkout jobs into current-job, read-only pipeline-repository authority.\n")
 	}
 	return 0
 }
@@ -201,7 +201,7 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 		defer func() { _ = os.RemoveAll(artifactRoot) }()
 	}
 	var actionMaterializer gharuntime.ActionMaterializer
-	if (job.Schema == plan.SchemaV3 || job.Schema == plan.SchemaV4 || job.Schema == plan.SchemaV5 || job.Schema == plan.SchemaV6) && hasGitHubActionLocks(job.Actions) {
+	if (job.Schema == plan.SchemaV3 || job.Schema == plan.SchemaV4 || job.Schema == plan.SchemaV5 || job.Schema == plan.SchemaV6 || job.Schema == plan.SchemaV7) && hasGitHubActionLocks(job.Actions) {
 		actionCache, err := os.MkdirTemp("", "buildkite-gha-actions-")
 		if err != nil {
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: create action cache: %v\n", err)
@@ -857,13 +857,16 @@ func runJobArgs(args []string) (planPath, resultPath string, err error) {
 func verifyBuildkiteTarget(job plan.Job) error {
 	stepKey := os.Getenv("BUILDKITE_STEP_KEY")
 	queue := os.Getenv("BUILDKITE_AGENT_META_DATA_QUEUE")
-	if os.Getenv("BUILDKITE") != "" && (stepKey == "" || queue == "") {
-		return fmt.Errorf("buildkite execution requires BUILDKITE_STEP_KEY and BUILDKITE_AGENT_META_DATA_QUEUE")
+	if os.Getenv("BUILDKITE") != "" && stepKey == "" {
+		return fmt.Errorf("buildkite execution requires BUILDKITE_STEP_KEY")
+	}
+	if os.Getenv("BUILDKITE") != "" && job.Target.Queue != "" && queue == "" {
+		return fmt.Errorf("buildkite execution with an explicit target queue requires BUILDKITE_AGENT_META_DATA_QUEUE")
 	}
 	if stepKey != "" && stepKey != job.Target.StepKey {
 		return fmt.Errorf("plan targets step %q, executing step is %q", job.Target.StepKey, stepKey)
 	}
-	if queue != "" && queue != job.Target.Queue {
+	if job.Target.Queue != "" && queue != "" && queue != job.Target.Queue {
 		return fmt.Errorf("plan targets queue %q, executing queue is %q", job.Target.Queue, queue)
 	}
 	return nil
@@ -1177,11 +1180,11 @@ func compileHostedTokenless(ctx context.Context, workflowPath string, workflowSo
 		ResolveActions: privateCheckout,
 		Runners: compiler.RunnerPolicy{
 			Labels: map[string]string{
-				"ubuntu-latest": unprivilegedRuntimeQueue,
-				"ubuntu-24.04":  unprivilegedRuntimeQueue,
-				"ubuntu-22.04":  unprivilegedRuntimeQueue,
+				"ubuntu-latest": "",
+				"ubuntu-24.04":  "",
+				"ubuntu-22.04":  "",
 			},
-			UntrustedQueues: []string{unprivilegedRuntimeQueue},
+			AllowUntrustedDefaultQueue: true,
 		},
 		PrivateCheckout: privateCheckout,
 	}
@@ -1316,11 +1319,8 @@ func uploadArgs(args []string) (workflowPath, eventPath, runtimeQueue string, pr
 	if err != nil {
 		return "", "", "", false, err
 	}
-	if !runtimeQueueSeen {
-		return "", "", "", false, fmt.Errorf("--runtime-queue %s is required for unprivileged upload", unprivilegedRuntimeQueue)
-	}
-	if runtimeQueue != unprivilegedRuntimeQueue {
-		return "", "", "", false, fmt.Errorf("--runtime-queue must be %q for unprivileged upload", unprivilegedRuntimeQueue)
+	if runtimeQueueSeen && runtimeQueue != legacyRuntimeQueue {
+		return "", "", "", false, fmt.Errorf("deprecated --runtime-queue must be %q", legacyRuntimeQueue)
 	}
 	return workflowPath, eventPath, runtimeQueue, privateCheckout, err
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1077,7 +1077,7 @@ func writeCompilerWarnings(stderr io.Writer, command, path string, warnings []co
 }
 
 func upload(args []string, stdout, stderr io.Writer, version string, agent transport.Agent) int {
-	workflowPath, eventPath, _, privateCheckout, err := uploadArgs(args)
+	workflowPath, eventPath, privateCheckout, err := uploadArgs(args)
 	if err != nil {
 		return usageError(stderr, "upload: %v", err)
 	}
@@ -1288,14 +1288,15 @@ func bundleUsesActions(bundle compiler.Bundle) bool {
 	return false
 }
 
-func uploadArgs(args []string) (workflowPath, eventPath, runtimeQueue string, privateCheckout bool, err error) {
+func uploadArgs(args []string) (workflowPath, eventPath string, privateCheckout bool, err error) {
 	filtered := make([]string, 0, len(args))
+	runtimeQueue := ""
 	runtimeQueueSeen := false
 	privateCheckoutSeen := false
 	for i := 0; i < len(args); i++ {
 		if args[i] == "--private-checkout" {
 			if privateCheckoutSeen {
-				return "", "", "", false, fmt.Errorf("--private-checkout may only be specified once")
+				return "", "", false, fmt.Errorf("--private-checkout may only be specified once")
 			}
 			privateCheckoutSeen = true
 			privateCheckout = true
@@ -1306,23 +1307,23 @@ func uploadArgs(args []string) (workflowPath, eventPath, runtimeQueue string, pr
 			continue
 		}
 		if runtimeQueueSeen {
-			return "", "", "", false, fmt.Errorf("--runtime-queue may only be specified once")
+			return "", "", false, fmt.Errorf("--runtime-queue may only be specified once")
 		}
 		runtimeQueueSeen = true
 		i++
 		if i == len(args) {
-			return "", "", "", false, fmt.Errorf("--runtime-queue requires a queue")
+			return "", "", false, fmt.Errorf("--runtime-queue requires a queue")
 		}
 		runtimeQueue = args[i]
 	}
 	workflowPath, eventPath, err = workflowArgs(filtered)
 	if err != nil {
-		return "", "", "", false, err
+		return "", "", false, err
 	}
 	if runtimeQueueSeen && runtimeQueue != legacyRuntimeQueue {
-		return "", "", "", false, fmt.Errorf("deprecated --runtime-queue must be %q", legacyRuntimeQueue)
+		return "", "", false, fmt.Errorf("deprecated --runtime-queue must be %q", legacyRuntimeQueue)
 	}
-	return workflowPath, eventPath, runtimeQueue, privateCheckout, err
+	return workflowPath, eventPath, privateCheckout, err
 }
 
 func compileArgs(args []string) (workflowPath, eventPath, format string, err error) {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -56,6 +56,7 @@ var commandUsage = map[string]string{
 const (
 	resultPublicationTimeout = 10 * time.Second
 	legacyRuntimeQueue       = "hosted"
+	targetQueueEnvironment   = "BUILDKITE_GHA_TARGET_QUEUE"
 	hostedTokenlessProfile   = "hosted-tokenless"
 	runtimeMiseArchiveDigest = "bd0930c0b619f51ddb60e32e5cce18a5533567b2f1ba9fc4875b9f39a2bb3ed8"
 	runtimeMiseBinaryDigest  = "a238972a3162d710b85b28c324372e96ca4e4b486c81fe78695000d9fbc77c48"
@@ -100,7 +101,7 @@ func run(args []string, stdout, stderr io.Writer, version string, agentRunner tr
 					_, _ = fmt.Fprint(stdout, "\nThe hosted-tokenless profile resolves actions and applies production upload policy without executing jobs or proving arbitrary action runtime compatibility.\n")
 				}
 				if args[0] == "upload" {
-					_, _ = fmt.Fprint(stdout, "\nGenerated jobs use Buildkite's default agent targeting. The deprecated --runtime-queue hosted option is accepted for plugin compatibility but does not select a queue. The default path accepts an explicit event file or derives compatibility data from Buildkite and remains unsigned. --private-checkout opts only verified checkout jobs into current-job, read-only pipeline-repository authority.\n")
+					_, _ = fmt.Fprintf(stdout, "\nGenerated jobs use Buildkite's default agent targeting. An importer can explicitly target one queue with %s; that queue must be suitable for untrusted workflow code. The deprecated --runtime-queue hosted option is accepted for plugin compatibility but does not select a queue. The default path accepts an explicit event file or derives compatibility data from Buildkite and remains unsigned. --private-checkout opts only verified checkout jobs into current-job, read-only pipeline-repository authority.\n", targetQueueEnvironment)
 				}
 				return 0
 			}
@@ -921,7 +922,7 @@ func validate(args []string, stdout, stderr io.Writer, version string) int {
 		}
 		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 		defer stop()
-		preflight, profileErr := compileHostedTokenless(ctx, workflowPath, source, event, version, distributionDigest, "buildkite-gha-profile-importer", "", false)
+		preflight, profileErr := compileHostedTokenless(ctx, workflowPath, source, event, version, distributionDigest, "buildkite-gha-profile-importer", "", "", false)
 		if profileErr != nil {
 			if ctx.Err() != nil || errors.Is(profileErr, context.Canceled) {
 				_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: profile evaluation interrupted: %v\n", profileErr)
@@ -1081,6 +1082,10 @@ func upload(args []string, stdout, stderr io.Writer, version string, agent trans
 	if err != nil {
 		return usageError(stderr, "upload: %v", err)
 	}
+	targetQueue, targetQueueConfigured := os.LookupEnv(targetQueueEnvironment)
+	if targetQueueConfigured && targetQueue == "" {
+		return usageError(stderr, "upload: %s must name a non-empty queue when set", targetQueueEnvironment)
+	}
 	importerStep := os.Getenv("BUILDKITE_STEP_KEY")
 	if os.Getenv("BUILDKITE") != "true" || strings.TrimSpace(importerStep) == "" {
 		return usageError(stderr, "upload: BUILDKITE=true and BUILDKITE_STEP_KEY are required")
@@ -1107,7 +1112,7 @@ func upload(args []string, stdout, stderr io.Writer, version string, agent trans
 	}
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
-	preflight, err := compileHostedTokenless(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, os.Getenv("BUILDKITE_GROUP_LABEL"), privateCheckout)
+	preflight, err := compileHostedTokenless(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, os.Getenv("BUILDKITE_GROUP_LABEL"), targetQueue, privateCheckout)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
 		return 1
@@ -1164,7 +1169,7 @@ func hostedTokenlessError(kind hostedTokenlessFailureKind, err error) error {
 	return &hostedTokenlessFailure{Kind: kind, Err: err}
 }
 
-func compileHostedTokenless(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, privateCheckout bool) (hostedTokenlessCompilation, error) {
+func compileHostedTokenless(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel, targetQueue string, privateCheckout bool) (hostedTokenlessCompilation, error) {
 	preflight, err := compiler.Compile(workflowPath, workflowSource, eventSource)
 	if err != nil {
 		return hostedTokenlessCompilation{}, hostedTokenlessError(hostedTokenlessEvaluationFailure, err)
@@ -1180,13 +1185,16 @@ func compileHostedTokenless(ctx context.Context, workflowPath string, workflowSo
 		ResolveActions: privateCheckout,
 		Runners: compiler.RunnerPolicy{
 			Labels: map[string]string{
-				"ubuntu-latest": "",
-				"ubuntu-24.04":  "",
-				"ubuntu-22.04":  "",
+				"ubuntu-latest": targetQueue,
+				"ubuntu-24.04":  targetQueue,
+				"ubuntu-22.04":  targetQueue,
 			},
-			AllowUntrustedDefaultQueue: true,
+			AllowUntrustedDefaultQueue: targetQueue == "",
 		},
 		PrivateCheckout: privateCheckout,
+	}
+	if targetQueue != "" {
+		options.Runners.UntrustedQueues = []string{targetQueue}
 	}
 	if hasActions {
 		actionRoot, err := os.MkdirTemp("", "buildkite-gha-action-source-")

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -45,8 +45,8 @@ func TestRunHelpAndVersion(t *testing.T) {
 		{name: "help flag", args: []string{"--help"}, wantOutput: "validate"},
 		{name: "help command", args: []string{"help"}, wantOutput: "run-job"},
 		{name: "command help", args: []string{"help", "compile"}, wantOutput: "buildkite-gha compile --event-path"},
-		{name: "upload help", args: []string{"help", "upload"}, wantOutput: "derives compatibility data from Buildkite"},
-		{name: "upload help flag", args: []string{"upload", "--help"}, wantOutput: "derives compatibility data from Buildkite"},
+		{name: "upload help", args: []string{"help", "upload"}, wantOutput: "default agent targeting"},
+		{name: "upload help flag", args: []string{"upload", "--help"}, wantOutput: "default agent targeting"},
 		{name: "command help flag", args: []string{"run-job", "--help"}, wantOutput: "--plan <path>"},
 		{name: "version flag", args: []string{"--version"}, wantOutput: "buildkite-gha test-version\n"},
 	}
@@ -317,7 +317,11 @@ jobs:
 			t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
 		}
 		assertWarning(t, "upload", stderr.String())
-		if len(runner.commands) == 0 || strings.Count(string(runner.commands[len(runner.commands)-1].stdin), "concurrency_group:") != 2 {
+		if len(runner.commands) == 0 {
+			t.Fatalf("uploaded commands = %#v", runner.commands)
+		}
+		pipeline := string(runner.commands[len(runner.commands)-1].stdin)
+		if strings.Count(pipeline, "concurrency_group:") != 2 || strings.Contains(pipeline, "agents:") {
 			t.Fatalf("uploaded commands = %#v", runner.commands)
 		}
 	})
@@ -466,7 +470,7 @@ func TestRunUploadCompilesArtifactsAndUploadsSelfContainedPipeline(t *testing.T)
 	t.Setenv("BUILDKITE_STEP_KEY", "phase-2-importer")
 	runner := &cliCaptureRunner{}
 	var stdout, stderr bytes.Buffer
-	if code := run([]string{"upload", "--event-path", eventPath, "--runtime-queue", "hosted", workflowPath}, &stdout, &stderr, "dev", runner); code != 0 {
+	if code := run([]string{"upload", "--event-path", eventPath, workflowPath}, &stdout, &stderr, "dev", runner); code != 0 {
 		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
 	}
 	if !strings.Contains(stdout.String(), "Uploaded 3 jobs") || stderr.Len() != 0 {
@@ -491,12 +495,10 @@ func TestRunUploadCompilesArtifactsAndUploadsSelfContainedPipeline(t *testing.T)
 	}
 	var pipeline struct {
 		Steps []struct {
-			Key     string `yaml:"key"`
-			Command string `yaml:"command"`
-			Cache   any    `yaml:"cache"`
-			Agents  struct {
-				Queue string `yaml:"queue"`
-			} `yaml:"agents"`
+			Key      string `yaml:"key"`
+			Command  string `yaml:"command"`
+			Cache    any    `yaml:"cache"`
+			Agents   any    `yaml:"agents"`
 			Checkout struct {
 				Skip bool `yaml:"skip"`
 			} `yaml:"checkout"`
@@ -516,7 +518,7 @@ func TestRunUploadCompilesArtifactsAndUploadsSelfContainedPipeline(t *testing.T)
 		if step.Cache != nil {
 			t.Fatalf("shell-only step %q unexpectedly configures a runtime cache: %#v", step.Key, step.Cache)
 		}
-		if !step.Checkout.Skip || step.Agents.Queue != "hosted" || len(step.DependsOn) == 0 || step.DependsOn[0].Step != "phase-2-importer" || step.DependsOn[0].AllowFailure {
+		if !step.Checkout.Skip || step.Agents != nil || len(step.DependsOn) == 0 || step.DependsOn[0].Step != "phase-2-importer" || step.DependsOn[0].AllowFailure {
 			t.Fatalf("step %q lacks isolated checkout or exact importer dependency: %#v", step.Key, step)
 		}
 		if !strings.Contains(step.Command, `bootstrap_dir="$(mktemp -d `) ||
@@ -610,10 +612,8 @@ func TestRunUploadCompilesConcurrentSmokePipeline(t *testing.T) {
 
 	var pipeline struct {
 		Steps []struct {
-			Key    string `yaml:"key"`
-			Agents struct {
-				Queue string `yaml:"queue"`
-			} `yaml:"agents"`
+			Key       string `yaml:"key"`
+			Agents    any    `yaml:"agents"`
 			DependsOn []struct {
 				Step         string `yaml:"step"`
 				AllowFailure bool   `yaml:"allow_failure"`
@@ -626,11 +626,11 @@ func TestRunUploadCompilesConcurrentSmokePipeline(t *testing.T) {
 	if len(pipeline.Steps) != 2 {
 		t.Fatalf("uploaded steps = %#v", pipeline.Steps)
 	}
-	if pipeline.Steps[0].Key != "gha-concurrent" || pipeline.Steps[0].Agents.Queue != "hosted" || len(pipeline.Steps[0].DependsOn) != 1 || pipeline.Steps[0].DependsOn[0].Step != "phase-3-upload-importer" || pipeline.Steps[0].DependsOn[0].AllowFailure {
+	if pipeline.Steps[0].Key != "gha-concurrent" || pipeline.Steps[0].Agents != nil || len(pipeline.Steps[0].DependsOn) != 1 || pipeline.Steps[0].DependsOn[0].Step != "phase-3-upload-importer" || pipeline.Steps[0].DependsOn[0].AllowFailure {
 		t.Fatalf("concurrent step = %#v", pipeline.Steps[0])
 	}
 	observer := pipeline.Steps[1]
-	if observer.Key != "gha-observe" || observer.Agents.Queue != "hosted" || len(observer.DependsOn) != 2 || observer.DependsOn[0].Step != "phase-3-upload-importer" || observer.DependsOn[0].AllowFailure || observer.DependsOn[1].Step != "gha-concurrent" || !observer.DependsOn[1].AllowFailure {
+	if observer.Key != "gha-observe" || observer.Agents != nil || len(observer.DependsOn) != 2 || observer.DependsOn[0].Step != "phase-3-upload-importer" || observer.DependsOn[0].AllowFailure || observer.DependsOn[1].Step != "gha-concurrent" || !observer.DependsOn[1].AllowFailure {
 		t.Fatalf("observer step = %#v", observer)
 	}
 }
@@ -1969,6 +1969,20 @@ func TestVerifyBuildkiteTargetFailsClosed(t *testing.T) {
 	if err := verifyBuildkiteTarget(job); err == nil || !strings.Contains(err.Error(), "requires BUILDKITE_STEP_KEY") {
 		t.Fatalf("verifyBuildkiteTarget() error = %v, want missing binding", err)
 	}
+	t.Setenv("BUILDKITE_STEP_KEY", "gha-expected")
+	t.Setenv("BUILDKITE_AGENT_META_DATA_QUEUE", "gha-other")
+	if err := verifyBuildkiteTarget(job); err == nil || !strings.Contains(err.Error(), "executing queue") {
+		t.Fatalf("verifyBuildkiteTarget() error = %v, want explicit queue mismatch", err)
+	}
+	t.Setenv("BUILDKITE_AGENT_META_DATA_QUEUE", "")
+	if err := verifyBuildkiteTarget(job); err == nil || !strings.Contains(err.Error(), "requires BUILDKITE_AGENT_META_DATA_QUEUE") {
+		t.Fatalf("verifyBuildkiteTarget() error = %v, want missing explicit queue binding", err)
+	}
+	job.Target.Queue = ""
+	t.Setenv("BUILDKITE_AGENT_META_DATA_QUEUE", "customer-default")
+	if err := verifyBuildkiteTarget(job); err != nil {
+		t.Fatalf("verifyBuildkiteTarget() default targeting error = %v", err)
+	}
 }
 
 func TestArgumentParsersRejectRepeatedOptions(t *testing.T) {
@@ -1993,16 +2007,17 @@ func TestArgumentParsersRejectRepeatedOptions(t *testing.T) {
 	if _, _, _, _, err := uploadArgs([]string{"--runtime-queue", "one", "--runtime-queue", "two", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
 		t.Fatalf("uploadArgs() error = %v, want duplicate runtime queue error", err)
 	}
-	if _, _, _, _, err := uploadArgs([]string{"workflow.yml"}); err == nil || !strings.Contains(err.Error(), "is required") {
-		t.Fatalf("uploadArgs() error = %v, want required runtime queue error", err)
+	workflow, event, queue, privateCheckout, err := uploadArgs([]string{"workflow.yml"})
+	if err != nil || workflow != "workflow.yml" || event != "" || queue != "" || privateCheckout {
+		t.Fatalf("uploadArgs() default = %q, %q, %q, %v, %v", workflow, event, queue, privateCheckout, err)
 	}
 	if _, _, _, _, err := uploadArgs([]string{"--runtime-queue", "custom-runners", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), `must be "hosted"`) {
-		t.Fatalf("uploadArgs() error = %v, want fixed runtime queue error", err)
+		t.Fatalf("uploadArgs() error = %v, want legacy runtime queue error", err)
 	}
 	if _, _, _, _, err := uploadArgs([]string{"--private-checkout", "--private-checkout", "--runtime-queue", "hosted", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
 		t.Fatalf("uploadArgs() error = %v, want duplicate private checkout error", err)
 	}
-	workflow, event, queue, privateCheckout, err := uploadArgs([]string{"--private-checkout", "--runtime-queue", "hosted", "--event-path", "event.json", "workflow.yml"})
+	workflow, event, queue, privateCheckout, err = uploadArgs([]string{"--private-checkout", "--runtime-queue", "hosted", "--event-path", "event.json", "workflow.yml"})
 	if err != nil || workflow != "workflow.yml" || event != "event.json" || queue != "hosted" || !privateCheckout {
 		t.Fatalf("uploadArgs() = %q, %q, %q, %v, %v", workflow, event, queue, privateCheckout, err)
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -431,6 +431,7 @@ func TestValidateHostedTokenlessProfileResolvesActionsWithoutClaimingRuntime(t *
 	}
 
 	t.Setenv("BUILDKITE_GHA_NODE20", filepath.Join(root, "missing-node20"))
+	t.Setenv(targetQueueEnvironment, "not a queue")
 	stdout.Reset()
 	stderr.Reset()
 	if code := Run([]string{"validate", "--profile", "hosted-tokenless", "--format", "json", "--event-path", eventPath, workflowPath}, &stdout, &stderr, "dev"); code != 0 {
@@ -527,6 +528,81 @@ func TestRunUploadCompilesArtifactsAndUploadsSelfContainedPipeline(t *testing.T)
 			!strings.Contains(step.Command, `"$distribution" run-job --plan "$plan"`) {
 			t.Fatalf("step %q command is not self-contained:\n%s", step.Key, step.Command)
 		}
+	}
+}
+
+func TestRunUploadUsesExplicitTargetQueue(t *testing.T) {
+	workflowPath := filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "shell.yml")
+	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_STEP_KEY", "explicit-queue-importer")
+	t.Setenv(targetQueueEnvironment, "hosted")
+	runner := &cliCaptureRunner{}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"upload", "--event-path", eventPath, "--runtime-queue", "hosted", workflowPath}, &stdout, &stderr, "dev", runner); code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+
+	var pipeline struct {
+		Steps []struct {
+			Key    string            `yaml:"key"`
+			Agents map[string]string `yaml:"agents"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(runner.commands[len(runner.commands)-1].stdin, &pipeline); err != nil {
+		t.Fatalf("uploaded pipeline YAML: %v", err)
+	}
+	if len(pipeline.Steps) != 3 {
+		t.Fatalf("uploaded steps = %#v", pipeline.Steps)
+	}
+	for _, step := range pipeline.Steps {
+		if step.Agents["queue"] != "hosted" {
+			t.Fatalf("step %q agents = %#v, want hosted queue", step.Key, step.Agents)
+		}
+	}
+
+	planCount := 0
+	for path, contents := range runner.uploaded {
+		if !strings.HasSuffix(path, ".json") {
+			continue
+		}
+		job, err := plan.Decode(contents)
+		if err != nil {
+			t.Fatalf("decode plan %q: %v", path, err)
+		}
+		planCount++
+		if job.Schema == plan.SchemaV7 || job.Target.Queue != "hosted" {
+			t.Fatalf("explicitly targeted plan = schema %q, target %#v", job.Schema, job.Target)
+		}
+	}
+	if planCount != 3 {
+		t.Fatalf("uploaded plan count = %d, want 3", planCount)
+	}
+}
+
+func TestRunUploadRejectsInvalidTargetQueueEnvironment(t *testing.T) {
+	workflowPath := filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "shell.yml")
+	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
+	for _, test := range []struct {
+		name  string
+		queue string
+	}{
+		{name: "empty", queue: ""},
+		{name: "malformed", queue: "not a queue"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("BUILDKITE", "true")
+			t.Setenv("BUILDKITE_STEP_KEY", "invalid-queue-importer")
+			t.Setenv(targetQueueEnvironment, test.queue)
+			runner := &cliCaptureRunner{}
+			var stdout, stderr bytes.Buffer
+			if code := run([]string{"upload", "--event-path", eventPath, workflowPath}, &stdout, &stderr, "dev", runner); code == 0 {
+				t.Fatalf("run() code = 0, want invalid target queue failure")
+			}
+			if len(runner.commands) != 0 || (!strings.Contains(stderr.String(), targetQueueEnvironment) && !strings.Contains(stderr.String(), "runner policy queue")) {
+				t.Fatalf("commands = %#v, stderr = %q", runner.commands, stderr.String())
+			}
+		})
 	}
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -67,6 +67,20 @@ func TestRunHelpAndVersion(t *testing.T) {
 	}
 }
 
+func TestUploadHelpFormsMatch(t *testing.T) {
+	outputs := make([]string, 0, 2)
+	for _, args := range [][]string{{"help", "upload"}, {"upload", "--help"}} {
+		var stdout, stderr bytes.Buffer
+		if code := Run(args, &stdout, &stderr, "test-version"); code != 0 {
+			t.Fatalf("Run(%q) code = %d, stderr = %q", args, code, stderr.String())
+		}
+		outputs = append(outputs, stdout.String())
+	}
+	if outputs[0] != outputs[1] || !strings.Contains(outputs[0], targetQueueEnvironment) {
+		t.Fatalf("upload help outputs differ or omit target queue environment:\nhelp command: %q\nhelp flag: %q", outputs[0], outputs[1])
+	}
+}
+
 func TestRunValidateAndCompile(t *testing.T) {
 	workflowPath := filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "shell.yml")
 	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2004,22 +2004,22 @@ func TestArgumentParsersRejectRepeatedOptions(t *testing.T) {
 	if _, _, _, err := compileArgs([]string{"--format", "pipeline", "--format", "ir-json", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
 		t.Fatalf("compileArgs() error = %v, want duplicate format error", err)
 	}
-	if _, _, _, _, err := uploadArgs([]string{"--runtime-queue", "one", "--runtime-queue", "two", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
+	if _, _, _, err := uploadArgs([]string{"--runtime-queue", "one", "--runtime-queue", "two", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
 		t.Fatalf("uploadArgs() error = %v, want duplicate runtime queue error", err)
 	}
-	workflow, event, queue, privateCheckout, err := uploadArgs([]string{"workflow.yml"})
-	if err != nil || workflow != "workflow.yml" || event != "" || queue != "" || privateCheckout {
-		t.Fatalf("uploadArgs() default = %q, %q, %q, %v, %v", workflow, event, queue, privateCheckout, err)
+	workflow, event, privateCheckout, err := uploadArgs([]string{"workflow.yml"})
+	if err != nil || workflow != "workflow.yml" || event != "" || privateCheckout {
+		t.Fatalf("uploadArgs() default = %q, %q, %v, %v", workflow, event, privateCheckout, err)
 	}
-	if _, _, _, _, err := uploadArgs([]string{"--runtime-queue", "custom-runners", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), `must be "hosted"`) {
+	if _, _, _, err := uploadArgs([]string{"--runtime-queue", "custom-runners", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), `must be "hosted"`) {
 		t.Fatalf("uploadArgs() error = %v, want legacy runtime queue error", err)
 	}
-	if _, _, _, _, err := uploadArgs([]string{"--private-checkout", "--private-checkout", "--runtime-queue", "hosted", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
+	if _, _, _, err := uploadArgs([]string{"--private-checkout", "--private-checkout", "--runtime-queue", "hosted", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
 		t.Fatalf("uploadArgs() error = %v, want duplicate private checkout error", err)
 	}
-	workflow, event, queue, privateCheckout, err = uploadArgs([]string{"--private-checkout", "--runtime-queue", "hosted", "--event-path", "event.json", "workflow.yml"})
-	if err != nil || workflow != "workflow.yml" || event != "event.json" || queue != "hosted" || !privateCheckout {
-		t.Fatalf("uploadArgs() = %q, %q, %q, %v, %v", workflow, event, queue, privateCheckout, err)
+	workflow, event, privateCheckout, err = uploadArgs([]string{"--private-checkout", "--runtime-queue", "hosted", "--event-path", "event.json", "workflow.yml"})
+	if err != nil || workflow != "workflow.yml" || event != "event.json" || !privateCheckout {
+		t.Fatalf("uploadArgs() = %q, %q, %v, %v", workflow, event, privateCheckout, err)
 	}
 }
 

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -54,6 +54,26 @@ func TestCompileBundleGoldenAndDeterministic(t *testing.T) {
 	}
 }
 
+func TestCompileBundlePreservesExplicitQueuePolicy(t *testing.T) {
+	workflow := []byte("on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n")
+	bundle, err := CompileBundleWithOptions("workflow.yml", workflow, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-importer", Options{
+		EventTrust: EventUntrusted,
+		Runners: RunnerPolicy{
+			Labels:          map[string]string{"ubuntu-latest": "customer-untrusted"},
+			UntrustedQueues: []string{"customer-untrusted"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bundle.Plans) != 1 || bundle.Plans[0].Job.Target.Queue != "customer-untrusted" || bundle.Plans[0].Job.Schema != plan.SchemaV2 {
+		t.Fatalf("explicitly targeted plan = %#v", bundle.Plans)
+	}
+	if !bytes.Contains(bundle.Pipeline, []byte("agents:\n      queue: \"customer-untrusted\"")) {
+		t.Fatalf("explicit queue absent from pipeline:\n%s", bundle.Pipeline)
+	}
+}
+
 func TestCompileBundleCompilesSmokeCorpus(t *testing.T) {
 	workflows, err := filepath.Glob(smokePath(".github", "workflows", "*.yml"))
 	if err != nil {
@@ -358,7 +378,7 @@ jobs:
 		jobs[artifact.Job.Workflow.LogicalJobID] = artifact
 	}
 	token := jobs["token"]
-	if token.Job.Schema != plan.SchemaV6 || token.Job.GitHubToken == nil || !reflect.DeepEqual(token.Job.GitHubToken.Permissions, map[string]string{"contents": "read", "pull_requests": "write"}) {
+	if token.Job.Schema != plan.SchemaV7 || token.Job.GitHubToken == nil || !reflect.DeepEqual(token.Job.GitHubToken.Permissions, map[string]string{"contents": "read", "pull_requests": "write"}) {
 		t.Fatalf("GitHub workflow token plan = %#v", token.Job)
 	}
 	if !reflect.DeepEqual(token.Job.RequiredSecrets, []string{"OTHER"}) || !reflect.DeepEqual(token.Job.RequiredCapabilities, []string{"provider-token-write", "secrets"}) {

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -210,10 +210,17 @@ func CompileWithOptions(path string, source, eventSource []byte, options Options
 
 // CompilePlans connects the owned compiler IR to one versioned plan per job instance.
 func CompilePlans(path string, source, eventSource []byte, compilerVersion, compilerDistributionDigest, targetQueue string) ([]plan.Job, error) {
-	if targetQueue != "gha-untrusted" {
-		return nil, fmt.Errorf("unattested event snapshots may only target queue %q; use CompilePlansWithOptions for authenticated events", "gha-untrusted")
+	if targetQueue != "" && targetQueue != "gha-untrusted" {
+		return nil, fmt.Errorf("unsupported target queue %q for unattested event snapshot; use CompilePlansWithOptions for explicit queue policy", targetQueue)
 	}
 	options := defaultOptions()
+	if targetQueue != "" {
+		for label := range options.Runners.Labels {
+			options.Runners.Labels[label] = targetQueue
+		}
+		options.Runners.UntrustedQueues = []string{targetQueue}
+		options.Runners.AllowUntrustedDefaultQueue = false
+	}
 	return CompilePlansWithOptions(path, source, eventSource, compilerVersion, compilerDistributionDigest, options)
 }
 
@@ -425,6 +432,9 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 			jobSchema = plan.SchemaV6
 			capabilities = append(capabilities, "provider-token-write")
 			authorization.ProviderTokenWriteCapabilitySources = []string{"workflow-permissions"}
+		}
+		if instance.Queue == "" {
+			jobSchema = plan.SchemaV7
 		}
 		if len(secrets) != 0 {
 			capabilities = append(capabilities, "secrets")

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -1830,21 +1830,21 @@ func TestWorkflowRepositoryNormalizesInMemoryWorkflowPath(t *testing.T) {
 func TestCompiledPlansValidateAgainstVersionedSchema(t *testing.T) {
 	path := smokePath(".github", "workflows", "shell.yml")
 	source := readFile(t, path)
-	plans, err := CompilePlans(path, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
+	plans, err := CompilePlans(path, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	schemaSource := readFile(t, filepath.Join("..", "..", "schemas", "job-plan-v2.schema.json"))
+	schemaSource := readFile(t, filepath.Join("..", "..", "schemas", "job-plan-v7.schema.json"))
 	var schemaDocument any
 	if err := json.Unmarshal(schemaSource, &schemaDocument); err != nil {
 		t.Fatal(err)
 	}
 	compiler := jsonschema.NewCompiler()
-	if err := compiler.AddResource(plan.Schema, schemaDocument); err != nil {
+	if err := compiler.AddResource(plan.SchemaV7, schemaDocument); err != nil {
 		t.Fatal(err)
 	}
-	jobSchema, err := compiler.Compile(plan.Schema)
+	jobSchema, err := compiler.Compile(plan.SchemaV7)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1858,7 +1858,7 @@ func TestCompiledPlansValidateAgainstVersionedSchema(t *testing.T) {
 			t.Fatal(err)
 		}
 		if err := jobSchema.Validate(document); err != nil {
-			t.Fatalf("compiled plan does not validate against %s: %v\n%s", plan.Schema, err, encoded)
+			t.Fatalf("compiled plan does not validate against %s: %v\n%s", plan.SchemaV7, err, encoded)
 		}
 	}
 }

--- a/internal/compiler/config.go
+++ b/internal/compiler/config.go
@@ -27,11 +27,14 @@ type VariableSources struct {
 }
 
 // RunnerPolicy maps every accepted Linux runner label to a Buildkite queue.
-// Multi-label targets are accepted only when every label maps to the same
-// queue. Untrusted events are additionally restricted to UntrustedQueues.
+// An empty queue uses Buildkite's default agent targeting. Multi-label targets
+// are accepted only when every label maps to the same queue. Untrusted events
+// are additionally restricted to UntrustedQueues unless the default is
+// explicitly allowed.
 type RunnerPolicy struct {
-	Labels          map[string]string
-	UntrustedQueues []string
+	Labels                     map[string]string
+	UntrustedQueues            []string
+	AllowUntrustedDefaultQueue bool
 }
 
 // Options are the complete non-secret graph-construction inputs beyond the
@@ -57,13 +60,14 @@ type Options struct {
 func defaultOptions() Options {
 	return Options{
 		// The convenience wrappers accept a local event path with no attestation,
-		// so their fixed policy is tokenless and untrusted by construction.
+		// so their policy is tokenless and untrusted by construction. Agent
+		// targeting remains owned by the Buildkite pipeline configuration.
 		EventTrust: EventUntrusted,
 		Runners: RunnerPolicy{Labels: map[string]string{
-			"ubuntu-latest": "gha-untrusted",
-			"ubuntu-24.04":  "gha-untrusted",
-			"ubuntu-22.04":  "gha-untrusted",
-		}, UntrustedQueues: []string{"gha-untrusted"}},
+			"ubuntu-latest": "",
+			"ubuntu-24.04":  "",
+			"ubuntu-22.04":  "",
+		}, AllowUntrustedDefaultQueue: true},
 	}
 }
 
@@ -82,10 +86,10 @@ func (options Options) validate() error {
 	}
 	labels := make(map[string]string, len(options.Runners.Labels))
 	for label, queue := range options.Runners.Labels {
-		if strings.TrimSpace(label) == "" || strings.TrimSpace(queue) == "" {
-			return fmt.Errorf("runner policy labels and queues must be non-empty")
+		if strings.TrimSpace(label) == "" {
+			return fmt.Errorf("runner policy labels must be non-empty")
 		}
-		if !queuePattern.MatchString(queue) {
+		if queue != "" && !queuePattern.MatchString(queue) {
 			return fmt.Errorf("runner policy queue %q is invalid", queue)
 		}
 		normalized := strings.ToLower(strings.TrimSpace(label))
@@ -141,6 +145,7 @@ func (policy RunnerPolicy) resolve(labels []string, trust EventTrust) (string, e
 		return "", fmt.Errorf("runs-on must resolve to at least one label")
 	}
 	var queue string
+	resolved := false
 	for _, label := range labels {
 		normalized := strings.ToLower(strings.TrimSpace(label))
 		if unsupportedOS(normalized) {
@@ -158,12 +163,16 @@ func (policy RunnerPolicy) resolve(labels []string, trust EventTrust) (string, e
 		if !ok {
 			return "", fmt.Errorf("runner label %q is not mapped by policy", label)
 		}
-		if queue != "" && queue != mapped {
+		if resolved && queue != mapped {
 			return "", fmt.Errorf("runner labels resolve to conflicting queues %q and %q", queue, mapped)
 		}
 		queue = mapped
+		resolved = true
 	}
-	if trust == EventUntrusted && !contains(policy.UntrustedQueues, queue) {
+	if trust == EventUntrusted && queue == "" && !policy.AllowUntrustedDefaultQueue {
+		return "", fmt.Errorf("untrusted event cannot use Buildkite default agent targeting")
+	}
+	if trust == EventUntrusted && queue != "" && !contains(policy.UntrustedQueues, queue) {
 		allowlist := append([]string(nil), policy.UntrustedQueues...)
 		sort.Strings(allowlist)
 		return "", fmt.Errorf("untrusted event cannot target queue %q; allowed queues: %s", queue, strings.Join(allowlist, ", "))

--- a/internal/compiler/config_test.go
+++ b/internal/compiler/config_test.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/buildkite/buildkite-gha/internal/plan"
 )
 
 func TestCompileOptionsSnapshotVarsWithDeterministicPrecedence(t *testing.T) {
@@ -187,7 +189,7 @@ func TestRunsOnPolicyFailsClosedWithLocatedDiagnostics(t *testing.T) {
 	}
 }
 
-func TestDefaultCompilePolicyIsUntrustedAndFixedToTokenlessQueue(t *testing.T) {
+func TestDefaultCompilePolicyIsUntrustedAndUsesBuildkiteDefault(t *testing.T) {
 	workflow := []byte("on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n")
 	compiled, err := Compile("default.yml", workflow, pushEvent(t))
 	if err != nil {
@@ -197,12 +199,42 @@ func TestDefaultCompilePolicyIsUntrustedAndFixedToTokenlessQueue(t *testing.T) {
 	if err := json.Unmarshal(compiled, &ir); err != nil {
 		t.Fatal(err)
 	}
-	if ir.Event.Trust != EventUntrusted || ir.Jobs[0].Queue != "gha-untrusted" {
+	if ir.Event.Trust != EventUntrusted || ir.Jobs[0].Queue != "" {
 		t.Fatalf("default compiler trust boundary = event %q, queue %q", ir.Event.Trust, ir.Jobs[0].Queue)
 	}
 	_, err = CompilePlans("default.yml", workflow, pushEvent(t), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "privileged")
-	if err == nil || !strings.Contains(err.Error(), `unattested event snapshots may only target queue "gha-untrusted"`) {
+	if err == nil || !strings.Contains(err.Error(), "use CompilePlansWithOptions for explicit queue policy") {
 		t.Fatalf("CompilePlans() privileged default error = %v", err)
+	}
+	plans, err := CompilePlans("default.yml", workflow, pushEvent(t), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 1 || plans[0].Target.Queue != "gha-untrusted" || plans[0].Schema != plan.SchemaV2 {
+		t.Fatalf("CompilePlans() explicit legacy target = %#v", plans)
+	}
+}
+
+func TestUntrustedDefaultQueueRequiresExplicitPolicy(t *testing.T) {
+	workflow := []byte("on: push\njobs:\n  test:\n    runs-on: [ubuntu-latest, linux]\n    steps:\n      - run: true\n")
+	options := Options{
+		EventTrust: EventUntrusted,
+		Runners: RunnerPolicy{Labels: map[string]string{
+			"ubuntu-latest": "",
+			"linux":         "",
+		}},
+	}
+	if _, err := CompileWithOptions("default.yml", workflow, pushEvent(t), options); err == nil || !strings.Contains(err.Error(), "cannot use Buildkite default agent targeting") {
+		t.Fatalf("CompileWithOptions() error = %v, want default-targeting policy rejection", err)
+	}
+	options.Runners.AllowUntrustedDefaultQueue = true
+	if _, err := CompileWithOptions("default.yml", workflow, pushEvent(t), options); err != nil {
+		t.Fatalf("CompileWithOptions() explicit default policy error = %v", err)
+	}
+	options.EventTrust = EventTrusted
+	options.Runners.Labels["linux"] = "explicit"
+	if _, err := CompileWithOptions("default.yml", workflow, pushEvent(t), options); err == nil || !strings.Contains(err.Error(), "conflicting queues") {
+		t.Fatalf("CompileWithOptions() mixed default/explicit error = %v", err)
 	}
 }
 

--- a/internal/compiler/testdata/shell.pipeline.golden.yml
+++ b/internal/compiler/testdata/shell.pipeline.golden.yml
@@ -1,28 +1,24 @@
 steps:
   - label: "producer"
     key: "gha-producer"
-    command: "set -euo pipefail\nbootstrap_dir=\"$(mktemp -d \"${TMPDIR:-/tmp}/buildkite-gha.XXXXXXXX\")\"\ntrap 'rm -rf -- \"$bootstrap_dir\"' EXIT\nbuildkite-agent artifact download '.buildkite-gha/distributions/2222222222222222222222222222222222222222222222222222222222222222/buildkite-gha' \"$bootstrap_dir\" --step 'gha-importer'\nbuildkite-agent artifact download '.buildkite-gha/plans/d7286589fecd60e590f1e59cd975f7ad104fd0752cecd8a89ff025ce89c4eca2.json' \"$bootstrap_dir\" --step 'gha-importer'\ndistribution=\"$bootstrap_dir/.buildkite-gha/distributions/2222222222222222222222222222222222222222222222222222222222222222/buildkite-gha\"\nplan=\"$bootstrap_dir/.buildkite-gha/plans/d7286589fecd60e590f1e59cd975f7ad104fd0752cecd8a89ff025ce89c4eca2.json\"\nactual_distribution_digest=\"$(sha256sum \"$distribution\" | awk '{print \"sha256:\" $1}')\"\ntest \"$actual_distribution_digest\" = 'sha256:2222222222222222222222222222222222222222222222222222222222222222'\nchmod 0500 \"$distribution\"\n\"$distribution\" run-job --plan \"$plan\""
-    agents:
-      queue: "gha-untrusted"
+    command: "set -euo pipefail\nbootstrap_dir=\"$(mktemp -d \"${TMPDIR:-/tmp}/buildkite-gha.XXXXXXXX\")\"\ntrap 'rm -rf -- \"$bootstrap_dir\"' EXIT\nbuildkite-agent artifact download '.buildkite-gha/distributions/2222222222222222222222222222222222222222222222222222222222222222/buildkite-gha' \"$bootstrap_dir\" --step 'gha-importer'\nbuildkite-agent artifact download '.buildkite-gha/plans/cdd9d2cb1dcbca4f46c643f89eec3134156dc7fccd3665c846a1d9a0a88428b7.json' \"$bootstrap_dir\" --step 'gha-importer'\ndistribution=\"$bootstrap_dir/.buildkite-gha/distributions/2222222222222222222222222222222222222222222222222222222222222222/buildkite-gha\"\nplan=\"$bootstrap_dir/.buildkite-gha/plans/cdd9d2cb1dcbca4f46c643f89eec3134156dc7fccd3665c846a1d9a0a88428b7.json\"\nactual_distribution_digest=\"$(sha256sum \"$distribution\" | awk '{print \"sha256:\" $1}')\"\ntest \"$actual_distribution_digest\" = 'sha256:2222222222222222222222222222222222222222222222222222222222222222'\nchmod 0500 \"$distribution\"\n\"$distribution\" run-job --plan \"$plan\""
     checkout:
       skip: true
     env:
-      BUILDKITE_GHA_PLAN_DIGEST: "sha256:d7286589fecd60e590f1e59cd975f7ad104fd0752cecd8a89ff025ce89c4eca2"
-      BUILDKITE_GHA_PLAN_PATH: ".buildkite-gha/plans/d7286589fecd60e590f1e59cd975f7ad104fd0752cecd8a89ff025ce89c4eca2.json"
+      BUILDKITE_GHA_PLAN_DIGEST: "sha256:cdd9d2cb1dcbca4f46c643f89eec3134156dc7fccd3665c846a1d9a0a88428b7"
+      BUILDKITE_GHA_PLAN_PATH: ".buildkite-gha/plans/cdd9d2cb1dcbca4f46c643f89eec3134156dc7fccd3665c846a1d9a0a88428b7.json"
       BUILDKITE_GHA_PLAN_PRODUCER: "gha-importer"
     depends_on:
       - step: "gha-importer"
         allow_failure: false
   - label: "consumer (variant=one)"
     key: "gha-consumer-5ebbc197d87b"
-    command: "set -euo pipefail\nbootstrap_dir=\"$(mktemp -d \"${TMPDIR:-/tmp}/buildkite-gha.XXXXXXXX\")\"\ntrap 'rm -rf -- \"$bootstrap_dir\"' EXIT\nbuildkite-agent artifact download '.buildkite-gha/distributions/2222222222222222222222222222222222222222222222222222222222222222/buildkite-gha' \"$bootstrap_dir\" --step 'gha-importer'\nbuildkite-agent artifact download '.buildkite-gha/plans/87f9d57de2a880a092696d9a734220313c5719bc9c6f80f34beb87ddae3f5f07.json' \"$bootstrap_dir\" --step 'gha-importer'\ndistribution=\"$bootstrap_dir/.buildkite-gha/distributions/2222222222222222222222222222222222222222222222222222222222222222/buildkite-gha\"\nplan=\"$bootstrap_dir/.buildkite-gha/plans/87f9d57de2a880a092696d9a734220313c5719bc9c6f80f34beb87ddae3f5f07.json\"\nactual_distribution_digest=\"$(sha256sum \"$distribution\" | awk '{print \"sha256:\" $1}')\"\ntest \"$actual_distribution_digest\" = 'sha256:2222222222222222222222222222222222222222222222222222222222222222'\nchmod 0500 \"$distribution\"\n\"$distribution\" run-job --plan \"$plan\""
-    agents:
-      queue: "gha-untrusted"
+    command: "set -euo pipefail\nbootstrap_dir=\"$(mktemp -d \"${TMPDIR:-/tmp}/buildkite-gha.XXXXXXXX\")\"\ntrap 'rm -rf -- \"$bootstrap_dir\"' EXIT\nbuildkite-agent artifact download '.buildkite-gha/distributions/2222222222222222222222222222222222222222222222222222222222222222/buildkite-gha' \"$bootstrap_dir\" --step 'gha-importer'\nbuildkite-agent artifact download '.buildkite-gha/plans/9021df6985c50b996f1561ada934d02d91d1586b313bb3b1a47712fe9769ed11.json' \"$bootstrap_dir\" --step 'gha-importer'\ndistribution=\"$bootstrap_dir/.buildkite-gha/distributions/2222222222222222222222222222222222222222222222222222222222222222/buildkite-gha\"\nplan=\"$bootstrap_dir/.buildkite-gha/plans/9021df6985c50b996f1561ada934d02d91d1586b313bb3b1a47712fe9769ed11.json\"\nactual_distribution_digest=\"$(sha256sum \"$distribution\" | awk '{print \"sha256:\" $1}')\"\ntest \"$actual_distribution_digest\" = 'sha256:2222222222222222222222222222222222222222222222222222222222222222'\nchmod 0500 \"$distribution\"\n\"$distribution\" run-job --plan \"$plan\""
     checkout:
       skip: true
     env:
-      BUILDKITE_GHA_PLAN_DIGEST: "sha256:87f9d57de2a880a092696d9a734220313c5719bc9c6f80f34beb87ddae3f5f07"
-      BUILDKITE_GHA_PLAN_PATH: ".buildkite-gha/plans/87f9d57de2a880a092696d9a734220313c5719bc9c6f80f34beb87ddae3f5f07.json"
+      BUILDKITE_GHA_PLAN_DIGEST: "sha256:9021df6985c50b996f1561ada934d02d91d1586b313bb3b1a47712fe9769ed11"
+      BUILDKITE_GHA_PLAN_PATH: ".buildkite-gha/plans/9021df6985c50b996f1561ada934d02d91d1586b313bb3b1a47712fe9769ed11.json"
       BUILDKITE_GHA_PLAN_PRODUCER: "gha-importer"
     depends_on:
       - step: "gha-importer"
@@ -31,14 +27,12 @@ steps:
         allow_failure: true
   - label: "consumer (variant=two)"
     key: "gha-consumer-91934b28b00f"
-    command: "set -euo pipefail\nbootstrap_dir=\"$(mktemp -d \"${TMPDIR:-/tmp}/buildkite-gha.XXXXXXXX\")\"\ntrap 'rm -rf -- \"$bootstrap_dir\"' EXIT\nbuildkite-agent artifact download '.buildkite-gha/distributions/2222222222222222222222222222222222222222222222222222222222222222/buildkite-gha' \"$bootstrap_dir\" --step 'gha-importer'\nbuildkite-agent artifact download '.buildkite-gha/plans/f4c7b6ef3aeb2ccd2b3a0f31d2c9d7c41a54b90864f42fe6fd06cb2d3dddcda9.json' \"$bootstrap_dir\" --step 'gha-importer'\ndistribution=\"$bootstrap_dir/.buildkite-gha/distributions/2222222222222222222222222222222222222222222222222222222222222222/buildkite-gha\"\nplan=\"$bootstrap_dir/.buildkite-gha/plans/f4c7b6ef3aeb2ccd2b3a0f31d2c9d7c41a54b90864f42fe6fd06cb2d3dddcda9.json\"\nactual_distribution_digest=\"$(sha256sum \"$distribution\" | awk '{print \"sha256:\" $1}')\"\ntest \"$actual_distribution_digest\" = 'sha256:2222222222222222222222222222222222222222222222222222222222222222'\nchmod 0500 \"$distribution\"\n\"$distribution\" run-job --plan \"$plan\""
-    agents:
-      queue: "gha-untrusted"
+    command: "set -euo pipefail\nbootstrap_dir=\"$(mktemp -d \"${TMPDIR:-/tmp}/buildkite-gha.XXXXXXXX\")\"\ntrap 'rm -rf -- \"$bootstrap_dir\"' EXIT\nbuildkite-agent artifact download '.buildkite-gha/distributions/2222222222222222222222222222222222222222222222222222222222222222/buildkite-gha' \"$bootstrap_dir\" --step 'gha-importer'\nbuildkite-agent artifact download '.buildkite-gha/plans/f3c8108ae8af7403acf9e5d0e22b6ab52b9c1ca1761cbdc43f0db4ea00bd2c10.json' \"$bootstrap_dir\" --step 'gha-importer'\ndistribution=\"$bootstrap_dir/.buildkite-gha/distributions/2222222222222222222222222222222222222222222222222222222222222222/buildkite-gha\"\nplan=\"$bootstrap_dir/.buildkite-gha/plans/f3c8108ae8af7403acf9e5d0e22b6ab52b9c1ca1761cbdc43f0db4ea00bd2c10.json\"\nactual_distribution_digest=\"$(sha256sum \"$distribution\" | awk '{print \"sha256:\" $1}')\"\ntest \"$actual_distribution_digest\" = 'sha256:2222222222222222222222222222222222222222222222222222222222222222'\nchmod 0500 \"$distribution\"\n\"$distribution\" run-job --plan \"$plan\""
     checkout:
       skip: true
     env:
-      BUILDKITE_GHA_PLAN_DIGEST: "sha256:f4c7b6ef3aeb2ccd2b3a0f31d2c9d7c41a54b90864f42fe6fd06cb2d3dddcda9"
-      BUILDKITE_GHA_PLAN_PATH: ".buildkite-gha/plans/f4c7b6ef3aeb2ccd2b3a0f31d2c9d7c41a54b90864f42fe6fd06cb2d3dddcda9.json"
+      BUILDKITE_GHA_PLAN_DIGEST: "sha256:f3c8108ae8af7403acf9e5d0e22b6ab52b9c1ca1761cbdc43f0db4ea00bd2c10"
+      BUILDKITE_GHA_PLAN_PATH: ".buildkite-gha/plans/f3c8108ae8af7403acf9e5d0e22b6ab52b9c1ca1761cbdc43f0db4ea00bd2c10.json"
       BUILDKITE_GHA_PLAN_PRODUCER: "gha-importer"
     depends_on:
       - step: "gha-importer"

--- a/internal/compiler/testdata/shell.plans.golden.json
+++ b/internal/compiler/testdata/shell.plans.golden.json
@@ -1,6 +1,6 @@
 [
   {
-    "schema": "https://buildkite.com/schemas/buildkite-gha/job-plan-v2.schema.json",
+    "schema": "https://buildkite.com/schemas/buildkite-gha/job-plan-v7.schema.json",
     "compiler": {
       "version": "0.0.0-test",
       "distribution_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
@@ -20,8 +20,7 @@
       "actor": "buildkite-gha-smoke"
     },
     "target": {
-      "step_key": "gha-producer",
-      "queue": "gha-untrusted"
+      "step_key": "gha-producer"
     },
     "required_capabilities": [],
     "outputs": {
@@ -68,7 +67,7 @@
     ]
   },
   {
-    "schema": "https://buildkite.com/schemas/buildkite-gha/job-plan-v2.schema.json",
+    "schema": "https://buildkite.com/schemas/buildkite-gha/job-plan-v7.schema.json",
     "compiler": {
       "version": "0.0.0-test",
       "distribution_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
@@ -88,8 +87,7 @@
       "actor": "buildkite-gha-smoke"
     },
     "target": {
-      "step_key": "gha-consumer-5ebbc197d87b",
-      "queue": "gha-untrusted"
+      "step_key": "gha-consumer-5ebbc197d87b"
     },
     "required_capabilities": [],
     "matrix": {
@@ -102,7 +100,7 @@
       "producer": [
         {
           "step_key": "gha-producer",
-          "plan_digest": "sha256:d7286589fecd60e590f1e59cd975f7ad104fd0752cecd8a89ff025ce89c4eca2"
+          "plan_digest": "sha256:cdd9d2cb1dcbca4f46c643f89eec3134156dc7fccd3665c846a1d9a0a88428b7"
         }
       ]
     },
@@ -131,7 +129,7 @@
     ]
   },
   {
-    "schema": "https://buildkite.com/schemas/buildkite-gha/job-plan-v2.schema.json",
+    "schema": "https://buildkite.com/schemas/buildkite-gha/job-plan-v7.schema.json",
     "compiler": {
       "version": "0.0.0-test",
       "distribution_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
@@ -151,8 +149,7 @@
       "actor": "buildkite-gha-smoke"
     },
     "target": {
-      "step_key": "gha-consumer-91934b28b00f",
-      "queue": "gha-untrusted"
+      "step_key": "gha-consumer-91934b28b00f"
     },
     "required_capabilities": [],
     "matrix": {
@@ -165,7 +162,7 @@
       "producer": [
         {
           "step_key": "gha-producer",
-          "plan_digest": "sha256:d7286589fecd60e590f1e59cd975f7ad104fd0752cecd8a89ff025ce89c4eca2"
+          "plan_digest": "sha256:cdd9d2cb1dcbca4f46c643f89eec3134156dc7fccd3665c846a1d9a0a88428b7"
         }
       ]
     },

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -22,6 +22,7 @@ const (
 	SchemaV4 = "https://buildkite.com/schemas/buildkite-gha/job-plan-v4.schema.json"
 	SchemaV5 = "https://buildkite.com/schemas/buildkite-gha/job-plan-v5.schema.json"
 	SchemaV6 = "https://buildkite.com/schemas/buildkite-gha/job-plan-v6.schema.json"
+	SchemaV7 = "https://buildkite.com/schemas/buildkite-gha/job-plan-v7.schema.json"
 	Schema   = SchemaV2
 )
 
@@ -98,7 +99,7 @@ type Workflow struct {
 
 type Target struct {
 	StepKey string `json:"step_key"`
-	Queue   string `json:"queue"`
+	Queue   string `json:"queue,omitempty"`
 }
 
 type Need struct {
@@ -330,19 +331,19 @@ func Encode(job Job) ([]byte, error) {
 }
 
 func (job Job) Validate() error {
-	if job.Schema != SchemaV1 && job.Schema != SchemaV2 && job.Schema != SchemaV3 && job.Schema != SchemaV4 && job.Schema != SchemaV5 && job.Schema != SchemaV6 {
+	if job.Schema != SchemaV1 && job.Schema != SchemaV2 && job.Schema != SchemaV3 && job.Schema != SchemaV4 && job.Schema != SchemaV5 && job.Schema != SchemaV6 && job.Schema != SchemaV7 {
 		return fmt.Errorf("unsupported job plan schema %q", job.Schema)
 	}
-	if job.Schema != SchemaV3 && job.Schema != SchemaV4 && job.Schema != SchemaV5 && job.Schema != SchemaV6 && (len(job.Actions) != 0 || hasStepActions(job.Steps)) {
+	if job.Schema != SchemaV3 && job.Schema != SchemaV4 && job.Schema != SchemaV5 && job.Schema != SchemaV6 && job.Schema != SchemaV7 && (len(job.Actions) != 0 || hasStepActions(job.Steps)) {
 		return fmt.Errorf("job plan %s does not support action locks", job.Schema)
 	}
-	if job.Schema != SchemaV4 && job.Schema != SchemaV5 && job.Schema != SchemaV6 && (job.Container != nil || len(job.Services) != 0) {
+	if job.Schema != SchemaV4 && job.Schema != SchemaV5 && job.Schema != SchemaV6 && job.Schema != SchemaV7 && (job.Container != nil || len(job.Services) != 0) {
 		return fmt.Errorf("job plan %s does not support containers or services", job.Schema)
 	}
-	if job.Schema != SchemaV5 && job.Schema != SchemaV6 && job.NeedOutputs != nil {
+	if job.Schema != SchemaV5 && job.Schema != SchemaV6 && job.Schema != SchemaV7 && job.NeedOutputs != nil {
 		return fmt.Errorf("job plan %s does not support prerequisite output projections", job.Schema)
 	}
-	if job.Schema != SchemaV6 && job.GitHubToken != nil {
+	if job.Schema != SchemaV6 && job.Schema != SchemaV7 && job.GitHubToken != nil {
 		return fmt.Errorf("job plan %s does not support GitHub workflow tokens", job.Schema)
 	}
 	if job.Compiler.Version == "" || !digestPattern.MatchString(job.Compiler.DistributionDigest) {
@@ -357,8 +358,14 @@ func (job Job) Validate() error {
 	if job.Workflow.Path == "" || !digestPattern.MatchString(job.Workflow.Digest) || job.Workflow.LogicalJobID == "" {
 		return fmt.Errorf("job plan requires a workflow path, sha256 digest, and logical job id")
 	}
-	if !targetPattern.MatchString(job.Target.StepKey) || !targetPattern.MatchString(job.Target.Queue) {
-		return fmt.Errorf("job plan requires a target step key and queue")
+	if !targetPattern.MatchString(job.Target.StepKey) {
+		return fmt.Errorf("job plan requires a target step key")
+	}
+	if job.Schema != SchemaV7 && !targetPattern.MatchString(job.Target.Queue) {
+		return fmt.Errorf("job plan %s requires a target queue", job.Schema)
+	}
+	if job.Target.Queue != "" && !targetPattern.MatchString(job.Target.Queue) {
+		return fmt.Errorf("job plan has invalid target queue %q", job.Target.Queue)
 	}
 	if job.TimeoutMinutes < 0 || job.TimeoutMinutes > 360 {
 		return fmt.Errorf("job timeout_minutes must be between 0 and 360")
@@ -450,7 +457,7 @@ func (job Job) Validate() error {
 	needIDs := make(map[string]struct{}, len(job.NeedSources))
 	sourcedDependencies := make(map[string]struct{}, len(job.Dependencies))
 	maxNeedProducers := MaxNeedProducers
-	if job.Schema != SchemaV5 && job.Schema != SchemaV6 {
+	if job.Schema != SchemaV5 && job.Schema != SchemaV6 && job.Schema != SchemaV7 {
 		maxNeedProducers = maxLegacyNeedProducers
 	}
 	for name, sources := range job.NeedSources {
@@ -580,7 +587,7 @@ func (job Job) Validate() error {
 			return fmt.Errorf("step %q has unsupported kind %q", step.ID, step.Kind)
 		}
 	}
-	if job.Schema == SchemaV3 || job.Schema == SchemaV4 || ((job.Schema == SchemaV5 || job.Schema == SchemaV6) && (len(job.Actions) != 0 || hasStepActions(job.Steps))) {
+	if job.Schema == SchemaV3 || job.Schema == SchemaV4 || ((job.Schema == SchemaV5 || job.Schema == SchemaV6 || job.Schema == SchemaV7) && (len(job.Actions) != 0 || hasStepActions(job.Steps))) {
 		if err := validateActionLocks(job); err != nil {
 			return err
 		}

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -703,6 +703,59 @@ func TestV6GitHubWorkflowTokenContractAndSchema(t *testing.T) {
 	}
 }
 
+func TestV7DefaultQueueContractAndSchema(t *testing.T) {
+	job := validJob()
+	job.Schema = SchemaV7
+	job.Target.Queue = ""
+	encoded, err := Encode(job)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), `"queue"`) {
+		t.Fatalf("default-targeted plan contains a queue:\n%s", encoded)
+	}
+
+	schemaSource, err := os.ReadFile(filepath.Join("..", "..", "schemas", "job-plan-v7.schema.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var schemaDocument, planDocument any
+	if err := json.Unmarshal(schemaSource, &schemaDocument); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(encoded, &planDocument); err != nil {
+		t.Fatal(err)
+	}
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource(SchemaV7, schemaDocument); err != nil {
+		t.Fatal(err)
+	}
+	schema, err := compiler.Compile(SchemaV7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := schema.Validate(planDocument); err != nil {
+		t.Fatalf("v7 default-targeted plan does not validate against schema: %v", err)
+	}
+
+	job.Target.Queue = "explicit"
+	if err := job.Validate(); err != nil {
+		t.Fatalf("v7 explicit queue validation error = %v", err)
+	}
+	job.Target.Queue = "invalid queue"
+	if err := job.Validate(); err == nil || !strings.Contains(err.Error(), "invalid target queue") {
+		t.Fatalf("v7 malformed queue error = %v", err)
+	}
+	for _, legacy := range []string{SchemaV1, SchemaV2, SchemaV3, SchemaV4, SchemaV5, SchemaV6} {
+		job := validJob()
+		job.Schema = legacy
+		job.Target.Queue = ""
+		if err := job.Validate(); err == nil || !strings.Contains(err.Error(), "requires a target queue") {
+			t.Fatalf("legacy schema %q empty queue error = %v", legacy, err)
+		}
+	}
+}
+
 func TestContainerPortGrammarMatchesSchema(t *testing.T) {
 	schemaSource, err := os.ReadFile(filepath.Join("..", "..", "schemas", "job-plan-v4.schema.json"))
 	if err != nil {

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -1796,7 +1796,7 @@ func TestLivePhase5ManifestContainerFixtures(t *testing.T) {
 		if compileErr != nil {
 			t.Fatalf("compile %s: %v", test.name, compileErr)
 		}
-		if len(bundle.Plans) != 1 || bundle.Plans[0].Job.Schema != plan.SchemaV4 || bundle.Plans[0].Job.Workflow.LogicalJobID != test.logicalJob || !slices.Equal(bundle.Plans[0].Authorization.DockerCapabilitySources, []string{test.provenance}) {
+		if len(bundle.Plans) != 1 || bundle.Plans[0].Job.Schema != plan.SchemaV7 || bundle.Plans[0].Job.Workflow.LogicalJobID != test.logicalJob || !slices.Equal(bundle.Plans[0].Authorization.DockerCapabilitySources, []string{test.provenance}) {
 			t.Fatalf("compiled %s boundary = %#v", test.name, bundle.Plans)
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -346,7 +346,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 	var runErr error
 	prepared := remotePreparations{}
 	preStatus := remotePreparationStatus{}
-	if job.Schema == plan.SchemaV3 || job.Schema == plan.SchemaV4 || ((job.Schema == plan.SchemaV5 || job.Schema == plan.SchemaV6) && len(job.Actions) != 0) {
+	if job.Schema == plan.SchemaV3 || job.Schema == plan.SchemaV4 || ((job.Schema == plan.SchemaV5 || job.Schema == plan.SchemaV6 || job.Schema == plan.SchemaV7) && len(job.Actions) != 0) {
 		for stepIndex, step := range job.Steps {
 			if step.Kind != "uses" {
 				continue
@@ -1057,7 +1057,7 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 
 	var action metadata.Metadata
 	var actionLock *plan.ActionLock
-	if job.Schema == plan.SchemaV3 || job.Schema == plan.SchemaV4 || ((job.Schema == plan.SchemaV5 || job.Schema == plan.SchemaV6) && len(job.Actions) != 0) {
+	if job.Schema == plan.SchemaV3 || job.Schema == plan.SchemaV4 || ((job.Schema == plan.SchemaV5 || job.Schema == plan.SchemaV6 || job.Schema == plan.SchemaV7) && len(job.Actions) != 0) {
 		if step.Action == nil {
 			return result, fmt.Errorf("action %q has no immutable selector", step.Uses)
 		}

--- a/schemas/job-plan-v7.schema.json
+++ b/schemas/job-plan-v7.schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://buildkite.com/schemas/buildkite-gha/job-plan-v7.schema.json",
+  "title": "buildkite-gha job plan v7",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "compiler", "workflow", "event", "target", "required_capabilities", "steps"],
+  "properties": {
+    "schema": {"const": "https://buildkite.com/schemas/buildkite-gha/job-plan-v7.schema.json"},
+    "compiler": {"type": "object", "additionalProperties": false, "required": ["version", "distribution_digest"], "properties": {"version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$"}, "distribution_digest": {"$ref": "#/$defs/digest"}}},
+    "workflow": {"type": "object", "additionalProperties": false, "required": ["path", "digest", "logical_job_id"], "properties": {"path": {"type": "string", "minLength": 1, "maxLength": 1024}, "digest": {"$ref": "#/$defs/digest"}, "logical_job_id": {"type": "string", "minLength": 1, "maxLength": 255}}},
+    "event": {"type": "object", "additionalProperties": false, "required": ["provider", "name", "payload_digest"], "properties": {"provider": {"enum": ["github", "cursor-origin"]}, "name": {"type": "string", "pattern": "^[A-Za-z0-9_.-]+$", "maxLength": 128}, "payload_digest": {"$ref": "#/$defs/digest"}, "repository": {"type": "string", "maxLength": 512}, "ref": {"type": "string", "maxLength": 1024}, "sha": {"type": "string", "maxLength": 128}, "actor": {"type": "string", "maxLength": 256}}},
+    "target": {"type": "object", "additionalProperties": false, "required": ["step_key"], "properties": {"step_key": {"$ref": "#/$defs/buildkiteName"}, "queue": {"$ref": "#/$defs/buildkiteName"}}},
+    "required_capabilities": {"type": "array", "uniqueItems": true, "items": {"$ref": "#/$defs/capability"}, "maxItems": 16},
+    "required_secrets": {"type": "array", "items": {"type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_]*$", "not": {"const": "GITHUB_TOKEN"}}, "uniqueItems": true, "maxItems": 128},
+    "github_token": {"$ref": "#/$defs/githubToken"},
+    "matrix": {"type": "object"},
+    "vars": {"$ref": "#/$defs/stringMap"},
+    "dependencies": {"type": "array", "items": {"$ref": "#/$defs/buildkiteName"}, "uniqueItems": true},
+    "need_sources": {"type": "object", "additionalProperties": {"type": "array", "minItems": 1, "maxItems": 1024, "uniqueItems": true, "items": {"$ref": "#/$defs/needSource"}}},
+    "need_outputs": {"type": "object", "additionalProperties": {"type": "array", "maxItems": 64, "items": {"$ref": "#/$defs/needOutput"}}},
+    "env": {"$ref": "#/$defs/stringMap"},
+    "condition": {"type": "string", "maxLength": 65536},
+    "timeout_minutes": {"type": "number", "exclusiveMinimum": 0, "maximum": 360},
+    "default_shell": {"type": "string"},
+    "default_working_directory": {"type": "string"},
+    "outputs": {"$ref": "#/$defs/stringMap"},
+    "steps": {"type": "array", "minItems": 1, "maxItems": 1000, "items": {"$ref": "#/$defs/step"}},
+    "actions": {"type": "array", "maxItems": 1024, "items": {"$ref": "#/$defs/actionLock"}},
+    "container": {"$ref": "#/$defs/container"},
+    "services": {"type": "object", "maxProperties": 32, "propertyNames": {"pattern": "^[a-z_][a-z0-9_-]{0,254}$"}, "additionalProperties": {"$ref": "#/$defs/container"}}
+  },
+  "allOf": [
+    {
+      "if": {"required": ["github_token"]},
+      "then": {
+        "properties": {
+          "required_capabilities": {"contains": {"const": "provider-token-write"}},
+          "event": {"required": ["repository"], "properties": {"provider": {"const": "github"}, "repository": {"$ref": "#/$defs/githubEventRepository"}}}
+        }
+      }
+    },
+    {"if": {"properties": {"required_capabilities": {"contains": {"const": "provider-token-write"}}}}, "then": {"required": ["github_token"]}}
+  ],
+  "$defs": {
+    "digest": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "buildkiteName": {"type": "string", "pattern": "^[A-Za-z0-9_-]+$", "minLength": 1, "maxLength": 255},
+    "capability": {"enum": ["network", "docker", "privileged-container", "secrets", "provider-token-read", "provider-token-write"]},
+    "stringMap": {"type": "object", "additionalProperties": {"type": "string"}},
+    "githubEventRepository": {"type": "string", "maxLength": 140, "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$", "not": {"pattern": "^(?:\\.\\.?/|[A-Za-z0-9_.-]+/\\.\\.?)$"}},
+    "githubToken": {"type": "object", "additionalProperties": false, "required": ["permissions"], "properties": {"permissions": {"$ref": "#/$defs/githubPermissions"}}},
+    "githubPermissions": {
+      "type": "object", "additionalProperties": false, "minProperties": 1, "maxProperties": 15,
+      "properties": {
+        "actions": {"enum": ["read", "write"]},
+        "artifact_metadata": {"enum": ["read", "write"]},
+        "attestations": {"enum": ["read", "write"]},
+        "checks": {"enum": ["read", "write"]},
+        "contents": {"enum": ["read", "write"]},
+        "deployments": {"enum": ["read", "write"]},
+        "discussions": {"enum": ["read", "write"]},
+        "issues": {"enum": ["read", "write"]},
+        "models": {"const": "read"},
+        "packages": {"enum": ["read", "write"]},
+        "pages": {"enum": ["read", "write"]},
+        "pull_requests": {"enum": ["read", "write"]},
+        "repository_projects": {"enum": ["read", "write"]},
+        "security_events": {"enum": ["read", "write"]},
+        "statuses": {"enum": ["read", "write"]}
+      }
+    },
+    "needSource": {"type": "object", "additionalProperties": false, "required": ["step_key", "plan_digest"], "properties": {"step_key": {"$ref": "#/$defs/buildkiteName"}, "plan_digest": {"$ref": "#/$defs/digest"}}},
+    "needOutput": {"type": "object", "additionalProperties": false, "required": ["name", "step_key", "output"], "properties": {"name": {"$ref": "#/$defs/buildkiteName"}, "step_key": {"$ref": "#/$defs/buildkiteName"}, "output": {"$ref": "#/$defs/buildkiteName"}}},
+    "position": {"type": "object", "additionalProperties": false, "required": ["line", "column"], "properties": {"line": {"type": "integer", "minimum": 0}, "column": {"type": "integer", "minimum": 0}}},
+    "span": {"type": "object", "additionalProperties": false, "required": ["start", "end"], "properties": {"start": {"$ref": "#/$defs/position"}, "end": {"$ref": "#/$defs/position"}}},
+    "selector": {"type": "object", "additionalProperties": false, "required": ["lock"], "properties": {"lock": {"type": "string", "pattern": "^a-[0-9a-f]{16}$"}}},
+    "path": {"type": "string", "minLength": 1, "maxLength": 1024, "pattern": "^[^/\\\\\\x00-\\x1f\\x7f]{1,255}(?:/[^/\\\\\\x00-\\x1f\\x7f]{1,255})*$", "not": {"pattern": "(^|/)\\.\\.?(/|$)"}},
+    "repository": {"type": "string", "maxLength": 140, "pattern": "^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?/[a-z0-9](?:[a-z0-9_.-]{0,98}[a-z0-9])?$"},
+    "actionLock": {
+      "type": "object", "additionalProperties": false,
+      "required": ["id", "source", "source_digest"],
+      "properties": {
+        "id": {"type": "string", "pattern": "^a-[0-9a-f]{16}$"}, "source": {"enum": ["workspace", "github"]},
+        "repository": {"$ref": "#/$defs/repository"}, "requested_ref": {"type": "string", "minLength": 1, "maxLength": 1024, "pattern": "^[^\\x00-\\x1f\\x7f]+$"},
+        "commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"}, "path": {"$ref": "#/$defs/path"}, "source_digest": {"$ref": "#/$defs/digest"},
+        "children": {"type": "object", "maxProperties": 1024, "propertyNames": {"minLength": 1, "maxLength": 2048, "pattern": "^[^\\x00-\\x1f\\x7f]+$"}, "additionalProperties": {"$ref": "#/$defs/selector"}}
+      },
+      "allOf": [
+        {"if": {"properties": {"source": {"const": "workspace"}}, "required": ["source"]}, "then": {"not": {"anyOf": [{"required": ["repository"]}, {"required": ["requested_ref"]}, {"required": ["commit"]}]}}},
+        {"if": {"properties": {"source": {"const": "github"}}, "required": ["source"]}, "then": {"required": ["repository", "requested_ref", "commit"]}}
+      ]
+    },
+    "container": {"type": "object", "additionalProperties": false, "required": ["image"], "properties": {"image": {"$ref": "#/$defs/image"}, "env": {"$ref": "#/$defs/containerEnv"}, "ports": {"type": "array", "maxItems": 128, "uniqueItems": true, "items": {"type": "string", "pattern": "^(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(?::(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]))?(?:/(?:tcp|udp))?$"}}}},
+    "containerEnv": {"type": "object", "maxProperties": 256, "propertyNames": {"pattern": "^[A-Za-z_][A-Za-z0-9_]{0,254}$"}, "additionalProperties": {"type": "string", "maxLength": 65536}},
+    "image": {"type": "string", "minLength": 1, "maxLength": 512, "pattern": "^[a-z0-9]+(?:[._-][a-z0-9]+)*(?:/[a-z0-9]+(?:[._-][a-z0-9]+)*)*(?::[A-Za-z0-9_][A-Za-z0-9_.-]{0,127})?(?:@sha256:[0-9a-f]{64})?$"},
+    "step": {
+      "type": "object", "additionalProperties": false, "required": ["id", "kind"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1, "maxLength": 255}, "name": {"type": "string"}, "kind": {"enum": ["run", "uses", "wait", "wait-all", "cancel"]}, "background": {"type": "boolean"},
+        "targets": {"type": "array", "minItems": 1, "maxItems": 256, "uniqueItems": true, "items": {"$ref": "#/$defs/buildkiteName"}},
+        "command": {"type": "string", "maxLength": 1048576}, "uses": {"type": "string", "maxLength": 1024}, "action": {"$ref": "#/$defs/selector"}, "shell": {"type": "string"}, "working_directory": {"type": "string"},
+        "env": {"$ref": "#/$defs/stringMap"}, "with": {"$ref": "#/$defs/stringMap"}, "condition": {"type": "string", "maxLength": 65536}, "continue_on_error": {"type": "boolean"}, "timeout_minutes": {"type": "number", "exclusiveMinimum": 0, "maximum": 360}, "source": {"$ref": "#/$defs/span"}
+      },
+      "allOf": [
+        {"if": {"properties": {"kind": {"const": "run"}}, "required": ["kind"]}, "then": {"required": ["command"], "not": {"anyOf": [{"required": ["uses"]}, {"required": ["targets"]}, {"required": ["action"]}]}}},
+        {"if": {"properties": {"kind": {"const": "uses"}}, "required": ["kind"]}, "then": {"required": ["uses"]}},
+        {"if": {"properties": {"kind": {"const": "wait"}}, "required": ["kind"]}, "then": {"required": ["targets"], "not": {"required": ["action"]}}},
+        {"if": {"properties": {"kind": {"const": "wait-all"}}, "required": ["kind"]}, "then": {"not": {"anyOf": [{"required": ["targets"]}, {"required": ["action"]}]}}},
+        {"if": {"properties": {"kind": {"const": "cancel"}}, "required": ["kind"]}, "then": {"required": ["targets"], "properties": {"targets": {"maxItems": 1}}, "not": {"required": ["action"]}}},
+        {"if": {"properties": {"kind": {"enum": ["wait", "wait-all", "cancel"]}}, "required": ["kind"]}, "then": {"not": {"anyOf": [{"required": ["background"]}, {"required": ["command"]}, {"required": ["uses"]}, {"required": ["shell"]}, {"required": ["working_directory"]}, {"required": ["env"]}, {"required": ["with"]}, {"required": ["condition"]}, {"required": ["continue_on_error"]}, {"required": ["timeout_minutes"]}, {"required": ["action"]}]}}}
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Stop assigning generated workflow jobs and concurrency gates to a hard-coded `hosted` queue; omit `agents` so Buildkite pipeline or organization defaults apply.
- Add job-plan schema v7 with an optional `target.queue`, and verify the runtime queue only when an explicit runner policy selected one.
- Preserve explicit `RunnerPolicy` queue mappings, let importer steps opt into one queue with `BUILDKITE_GHA_TARGET_QUEUE`, and accept the deprecated `--runtime-queue hosted` spelling as a no-op for existing plugin compatibility.
- Keep this repository's generated smoke jobs explicitly targeted to `hosted`, and document that any explicit or default target must provide suitable isolation for untrusted workflow code.
- Distinguish the current pinned plugin/CLI release, which still selects `hosted`, from source builds and future releases containing default targeting.

## Testing

- `mise run check`
- `mise exec -- go test ./internal/compiler ./internal/cli ./internal/buildkite ./internal/plan`
- `git diff --check`