### PR TITLE
Skip mise for proven native action jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,12 @@ steps:
 The released plugin downloads and verifies `buildkite-gha` v0.2.3 by default,
 derives the event context from the Buildkite build, and uploads the generated
 jobs to the fixed `hosted` queue. Pin a released plugin version rather than a
-floating branch. For action jobs, the runtime reuses mise 2026.5.12 or newer
-from `PATH` or the absolute path in `BUILDKITE_GHA_MISE`; when neither provides
-a compatible version, it downloads and verifies a managed 2026.5.12 copy in
-the hosted cache. Shell-only jobs do not require or install mise.
+floating branch. For action jobs that can execute JavaScript, the runtime
+reuses mise 2026.5.12 or newer from `PATH` or the absolute path in
+`BUILDKITE_GHA_MISE`; when neither provides a compatible version, it downloads
+and verifies a managed 2026.5.12 copy in the hosted cache. Shell-only jobs and
+action jobs whose resolved trees contain only shell steps, native adapters, or
+Docker do not require or install mise.
 
 Configure branch, tag, and pull request triggers in Buildkite. The plugin
 derives a `pull_request` context for pull request builds and a `push` context

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -363,20 +363,21 @@ is the recommended installation. For direct use, download
 archive checksum, and extract it to a stable location. The archive contains
 `buildkite-gha` and `LICENSE`.
 
-Generated jobs that execute actions support mise 2026.5.12 or newer. `run-job`
-first checks `BUILDKITE_GHA_MISE` when set, then `PATH`; if neither supplies a
-compatible version, it downloads the pinned 2026.5.12 official archive into
-the automatically attached hosted cache. Both the archive and extracted
-executable are verified by embedded SHA-256 digests before use. Verified cache
-bytes are copied into a job-private directory and reverified there before
-execution, so the shared cache remains an accelerator rather than executable
-authority. An explicit `BUILDKITE_GHA_MISE` must be absolute and compatible
-rather than silently falling back. The runtime resolves and validates the
-executable before workflow code can modify `PATH`, then uses it with repository
-configuration disabled to install exact Node 20.20.2 or 24.18.0 releases.
-Those Node binaries require glibc 2.28 or newer; the static Go CLI does not.
-Shell-only jobs, importers, `validate`, and `compile` do not require or install
-mise.
+Generated jobs that can execute JavaScript actions support mise 2026.5.12 or
+newer. `run-job` first checks `BUILDKITE_GHA_MISE` when set, then `PATH`; if
+neither supplies a compatible version, it downloads the pinned 2026.5.12
+official archive into the automatically attached hosted cache. Both the archive
+and extracted executable are verified by embedded SHA-256 digests before use.
+Verified cache bytes are copied into a job-private directory and reverified
+there before execution, so the shared cache remains an accelerator rather than
+executable authority. An explicit `BUILDKITE_GHA_MISE` must be absolute and
+compatible rather than silently falling back. The runtime resolves and
+validates the executable before workflow code can modify `PATH`, then uses it
+with repository configuration disabled to install exact Node 20.20.2 or
+24.18.0 releases. Those Node binaries require glibc 2.28 or newer; the static
+Go CLI does not. Shell-only jobs and action jobs whose resolved trees contain
+only shell steps, native adapters, or Docker do not require or install mise.
+Importers, `validate`, and `compile` do not require or install mise either.
 
 ### Validate
 

--- a/internal/action/integration/integration.go
+++ b/internal/action/integration/integration.go
@@ -63,6 +63,13 @@ type Descriptor struct {
 	Service Service
 }
 
+// UsesNativeAdapter reports whether the resolved identity replaces the
+// upstream action lifecycle with Buildkite-native execution.
+func UsesNativeAdapter(identity Identity) bool {
+	descriptor, _ := Lookup(identity)
+	return descriptor.Adapter != ""
+}
+
 var catalog = map[Identity]Descriptor{
 	{Source: "github", Repository: "actions/checkout"}:                       {Adapter: AdapterCheckoutExactEventSHA},
 	{Source: "github", Repository: "actions/cache"}:                          {Service: ServiceCache},

--- a/internal/buildkite/pipeline.go
+++ b/internal/buildkite/pipeline.go
@@ -64,7 +64,7 @@ type Job struct {
 	Queue            string
 	PlanDigest       string
 	Dependencies     []string
-	UsesActions      bool
+	RequiresMise     bool
 	ConcurrencyGroup string
 	Concurrency      int
 }
@@ -135,7 +135,7 @@ func Emit(pipeline Pipeline) ([]byte, error) {
 		_, _ = fmt.Fprintf(&out, "%sagents:\n", attributeIndent)
 		_, _ = fmt.Fprintf(&out, "%s  queue: %s\n", attributeIndent, yamlScalar(job.Queue))
 		_, _ = fmt.Fprintf(&out, "%scheckout:\n%s  skip: true\n", attributeIndent, attributeIndent)
-		if job.UsesActions {
+		if job.RequiresMise {
 			_, _ = fmt.Fprintf(&out, "%scache:\n", attributeIndent)
 			_, _ = fmt.Fprintf(&out, "%s  paths:\n", attributeIndent)
 			_, _ = fmt.Fprintf(&out, "%s    - \".buildkite-gha/cache-volume\"\n", attributeIndent)
@@ -145,7 +145,7 @@ func Emit(pipeline Pipeline) ([]byte, error) {
 		_, _ = fmt.Fprintf(&out, "%s  BUILDKITE_GHA_PLAN_DIGEST: %s\n", attributeIndent, yamlScalar(job.PlanDigest))
 		_, _ = fmt.Fprintf(&out, "%s  BUILDKITE_GHA_PLAN_PATH: %s\n", attributeIndent, yamlScalar(planPath))
 		_, _ = fmt.Fprintf(&out, "%s  BUILDKITE_GHA_PLAN_PRODUCER: %s\n", attributeIndent, yamlScalar(pipeline.CompilerStep))
-		if job.UsesActions {
+		if job.RequiresMise {
 			_, _ = fmt.Fprintf(&out, "%s  BUILDKITE_GHA_MISE_DATA_DIR: %s\n", attributeIndent, yamlScalar(MiseDataDir()))
 		}
 		if job.Concurrency != 0 {

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -214,7 +214,7 @@ func TestEmitActionRuntimeRequirement(t *testing.T) {
 	pipeline := Pipeline{
 		CompilerStep:       "importer",
 		DistributionDigest: testDigest("distribution"),
-		Jobs:               []Job{{Key: "action", Label: "Action", Queue: "hosted", PlanDigest: testDigest("plan"), UsesActions: true}},
+		Jobs:               []Job{{Key: "action", Label: "Action", Queue: "hosted", PlanDigest: testDigest("plan"), RequiresMise: true}},
 	}
 	output, err := Emit(pipeline)
 	if err != nil {
@@ -260,7 +260,8 @@ func TestEmitMiseCacheOnlyForActionJobs(t *testing.T) {
 		CompilerStep:       "importer",
 		DistributionDigest: testDigest("distribution"),
 		Jobs: []Job{
-			{Key: "action", Label: "Action", Queue: "hosted", PlanDigest: testDigest("action-plan"), UsesActions: true},
+			{Key: "javascript", Label: "JavaScript", Queue: "hosted", PlanDigest: testDigest("javascript-plan"), RequiresMise: true},
+			{Key: "native", Label: "Native action", Queue: "hosted", PlanDigest: testDigest("native-plan")},
 			{Key: "shell", Label: "Shell", Queue: "hosted", PlanDigest: testDigest("shell-plan")},
 		},
 	})
@@ -279,11 +280,11 @@ func TestEmitMiseCacheOnlyForActionJobs(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, step := range document.Steps {
-		if step.Key == "action" && (step.Cache == nil || step.Env["BUILDKITE_GHA_MISE_DATA_DIR"] != MiseDataDir() || strings.Contains(step.Command, "/tools/mise/")) {
-			t.Fatalf("action job lacks runtime mise cache configuration: %#v", step)
+		if step.Key == "javascript" && (step.Cache == nil || step.Env["BUILDKITE_GHA_MISE_DATA_DIR"] != MiseDataDir() || strings.Contains(step.Command, "/tools/mise/")) {
+			t.Fatalf("JavaScript job lacks runtime mise cache configuration: %#v", step)
 		}
-		if step.Key == "shell" && (step.Cache != nil || step.Env["BUILDKITE_GHA_MISE_DATA_DIR"] != "" || strings.Contains(step.Command, "/tools/mise/")) {
-			t.Fatalf("shell job gained managed mise: %#v", step)
+		if (step.Key == "native" || step.Key == "shell") && (step.Cache != nil || step.Env["BUILDKITE_GHA_MISE_DATA_DIR"] != "" || strings.Contains(step.Command, "/tools/mise/")) {
+			t.Fatalf("no-mise job gained managed mise: %#v", step)
 		}
 	}
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -201,7 +201,7 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 		defer func() { _ = os.RemoveAll(artifactRoot) }()
 	}
 	var actionMaterializer gharuntime.ActionMaterializer
-	if (job.Schema == plan.SchemaV3 || job.Schema == plan.SchemaV4 || job.Schema == plan.SchemaV5 || job.Schema == plan.SchemaV6) && hasGitHubActionLocks(job.Actions) {
+	if (job.Schema == plan.SchemaV3 || job.Schema == plan.SchemaV4 || job.Schema == plan.SchemaV5 || job.Schema == plan.SchemaV6 || job.Schema == plan.SchemaV7) && hasGitHubActionLocks(job.Actions) {
 		actionCache, err := os.MkdirTemp("", "buildkite-gha-actions-")
 		if err != nil {
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: create action cache: %v\n", err)
@@ -272,7 +272,7 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 		return 1
 	}
 	var privateRuntime string
-	if jobUsesActions(job) {
+	if job.NeedsMise() {
 		runner.ResolveMise = func(ctx context.Context) (string, error) {
 			var err error
 			privateRuntime, err = os.MkdirTemp("", "buildkite-gha-runtime-")
@@ -334,18 +334,6 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 		return 1
 	}
 	return 0
-}
-
-func jobUsesActions(job plan.Job) bool {
-	if len(job.Actions) != 0 {
-		return true
-	}
-	for _, step := range job.Steps {
-		if step.Uses != "" || step.Action != nil || step.Kind == "uses" {
-			return true
-		}
-	}
-	return false
 }
 
 func resolveRuntimeMise(ctx context.Context, configured, dataDir, privateRuntime string, stderr io.Writer) (string, error) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1108,7 +1108,9 @@ func runtimeMiseTestArchive(t *testing.T, binary []byte) []byte {
 
 func TestRunJobPublishesFailureWhenExplicitRuntimeMiseIsInvalid(t *testing.T) {
 	job := cliRunJobPlan()
-	job.Schema = plan.SchemaV3
+	job.Schema = plan.SchemaV7
+	requiresMise := true
+	job.RequiresMise = &requiresMise
 	job.Actions = []plan.ActionLock{{
 		ID: "a-0000000000000001", Source: "workspace", Path: "actions/build",
 		SourceDigest: "sha256:" + strings.Repeat("a", 64),
@@ -1127,6 +1129,38 @@ func TestRunJobPublishesFailureWhenExplicitRuntimeMiseIsInvalid(t *testing.T) {
 	}
 	if manifest := publishedCLIManifest(t, runner, job, planDigest); manifest.Result != "failure" {
 		t.Fatalf("published result = %q, want failure", manifest.Result)
+	}
+}
+
+func TestRunJobMiseRequirementUsesCompilerDecisionAndFailsClosed(t *testing.T) {
+	no := false
+	yes := true
+	actionJob := func(requiresMise *bool) plan.Job {
+		return plan.Job{
+			Actions:      []plan.ActionLock{{ID: "a-0000000000000001"}},
+			Steps:        []plan.Step{{Kind: "uses", Action: &plan.ActionSelector{Lock: "a-0000000000000001"}}},
+			RequiresMise: requiresMise,
+		}
+	}
+	cacheJob := actionJob(&yes)
+	cacheJob.Actions[0].Source = "github"
+	cacheJob.Actions[0].Repository = "actions/cache"
+	for _, test := range []struct {
+		name string
+		job  plan.Job
+		want bool
+	}{
+		{name: "shell plan does not resolve mise", job: plan.Job{Steps: []plan.Step{{Kind: "run"}}}},
+		{name: "native plan does not resolve mise", job: actionJob(&no)},
+		{name: "JavaScript plan resolves mise", job: actionJob(&yes), want: true},
+		{name: "cache client plan resolves mise", job: cacheJob, want: true},
+		{name: "legacy or unknown action plan resolves mise", job: actionJob(nil), want: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.job.NeedsMise(); got != test.want {
+				t.Fatalf("NeedsMise() = %t, want %t", got, test.want)
+			}
+		})
 	}
 }
 

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -56,12 +56,7 @@ type actionNode struct {
 
 // compileActionLocks builds one shared action DAG for all roots. Selectors are
 // returned in the same order as refs.
-func compileActionLocks(ctx context.Context, workspace string, actionSource ActionSource, refs []string) ([]plan.ActionSelector, []plan.ActionLock, []string, error) {
-	selectors, locks, capabilities, _, err := compileActionLocksWithMise(ctx, workspace, actionSource, refs)
-	return selectors, locks, capabilities, err
-}
-
-func compileActionLocksWithMise(ctx context.Context, workspace string, actionSource ActionSource, refs []string) ([]plan.ActionSelector, []plan.ActionLock, []string, bool, error) {
+func compileActionLocks(ctx context.Context, workspace string, actionSource ActionSource, refs []string) ([]plan.ActionSelector, []plan.ActionLock, []string, bool, error) {
 	if workspace == "" {
 		return nil, nil, nil, true, fmt.Errorf("workflow path must identify a repository root")
 	}

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -41,12 +41,13 @@ func (s PublicActionSource) Fetch(ctx context.Context, ref source.Reference) (so
 }
 
 type actionLockBuilder struct {
-	workspace string
-	source    ActionSource
-	nodes     map[string]*actionNode
-	ids       map[string]string
-	active    map[string]bool
-	caps      map[string]bool
+	workspace    string
+	source       ActionSource
+	nodes        map[string]*actionNode
+	ids          map[string]string
+	active       map[string]bool
+	caps         map[string]bool
+	requiresMise bool
 }
 
 type actionNode struct {
@@ -56,19 +57,24 @@ type actionNode struct {
 // compileActionLocks builds one shared action DAG for all roots. Selectors are
 // returned in the same order as refs.
 func compileActionLocks(ctx context.Context, workspace string, actionSource ActionSource, refs []string) ([]plan.ActionSelector, []plan.ActionLock, []string, error) {
+	selectors, locks, capabilities, _, err := compileActionLocksWithMise(ctx, workspace, actionSource, refs)
+	return selectors, locks, capabilities, err
+}
+
+func compileActionLocksWithMise(ctx context.Context, workspace string, actionSource ActionSource, refs []string) ([]plan.ActionSelector, []plan.ActionLock, []string, bool, error) {
 	if workspace == "" {
-		return nil, nil, nil, fmt.Errorf("workflow path must identify a repository root")
+		return nil, nil, nil, true, fmt.Errorf("workflow path must identify a repository root")
 	}
 	abs, err := filepath.Abs(workspace)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("resolve workspace: %w", err)
+		return nil, nil, nil, true, fmt.Errorf("resolve workspace: %w", err)
 	}
 	b := &actionLockBuilder{workspace: abs, source: actionSource, nodes: map[string]*actionNode{}, ids: map[string]string{}, active: map[string]bool{}, caps: map[string]bool{}}
 	selectors := make([]plan.ActionSelector, 0, len(refs))
 	for _, ref := range refs {
 		n, err := b.add(ctx, ref, 1)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, nil, true, err
 		}
 		selectors = append(selectors, plan.ActionSelector{Lock: n.lock.ID})
 	}
@@ -82,7 +88,7 @@ func compileActionLocks(ctx context.Context, workspace string, actionSource Acti
 		caps = append(caps, c)
 	}
 	sort.Strings(caps)
-	return selectors, locks, caps, nil
+	return selectors, locks, caps, b.requiresMise, nil
 }
 
 func (b *actionLockBuilder) add(ctx context.Context, raw string, depth int) (*actionNode, error) {
@@ -122,6 +128,12 @@ func (b *actionLockBuilder) add(ctx context.Context, raw string, depth int) (*ac
 	}
 	if err := m.ValidateEntrypoints(runtime); err != nil {
 		return nil, err
+	}
+	if actionintegration.UsesNativeAdapter(actionintegration.Identity{Source: n.lock.Source, Repository: n.lock.Repository, Path: n.lock.Path}) {
+		return n, nil
+	}
+	if runtime == metadata.RuntimeNode20 || runtime == metadata.RuntimeNode24 {
+		b.requiresMise = true
 	}
 	for _, capability := range runtime.RequiredCapabilities() {
 		b.caps[capability] = true

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -134,7 +134,7 @@ func TestCompileActionLocksRequiresMiseOnlyForJavaScriptReachableGraphs(t *testi
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, _, _, got, err := compileActionLocksWithMise(context.Background(), workspace, source, test.refs)
+			_, _, _, got, err := compileActionLocks(context.Background(), workspace, source, test.refs)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -148,7 +148,7 @@ func TestCompileActionLocksRequiresMiseOnlyForJavaScriptReachableGraphs(t *testi
 func TestCompileActionLocksLocalAndDedup(t *testing.T) {
 	w := t.TempDir()
 	writeAction(t, w, "js", "name: js\nruns:\n  using: node20\n  main: index.js\n")
-	selectors, locks, caps, err := compileActionLocks(context.Background(), w, nil, []string{"./js", "./js"})
+	selectors, locks, caps, _, err := compileActionLocks(context.Background(), w, nil, []string{"./js", "./js"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -162,7 +162,7 @@ func TestCompileActionLocksRemoteCompositeUsesWorkspaceRoot(t *testing.T) {
 	writeAction(t, w, "child", "name: child\nruns:\n  using: docker\n  image: Dockerfile\n")
 	writeAction(t, remote, "", "name: parent\nruns:\n  using: composite\n  steps:\n    - uses: ./child\n")
 	f := &fakeActionSource{root: remote, calls: map[string]int{}}
-	_, locks, caps, err := compileActionLocks(context.Background(), w, f, []string{"Owner/Repo@v1", "Owner/Repo@v1"})
+	_, locks, caps, _, err := compileActionLocks(context.Background(), w, f, []string{"Owner/Repo@v1", "Owner/Repo@v1"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -183,14 +183,14 @@ func TestCompileActionLocksRemoteCompositeUsesWorkspaceRoot(t *testing.T) {
 func TestCompileActionLocksRecursion(t *testing.T) {
 	w := t.TempDir()
 	writeAction(t, w, "loop", "name: loop\nruns:\n  using: composite\n  steps:\n    - uses: ./loop\n")
-	_, _, _, err := compileActionLocks(context.Background(), w, nil, []string{"./loop"})
+	_, _, _, _, err := compileActionLocks(context.Background(), w, nil, []string{"./loop"})
 	if err == nil || !strings.Contains(err.Error(), "recursion") {
 		t.Fatalf("got %v", err)
 	}
 }
 
 func TestCompileActionLocksRequiresRepositoryRoot(t *testing.T) {
-	_, _, _, err := compileActionLocks(context.Background(), "", nil, []string{"./local"})
+	_, _, _, _, err := compileActionLocks(context.Background(), "", nil, []string{"./local"})
 	if err == nil || !strings.Contains(err.Error(), "workflow path must identify a repository root") {
 		t.Fatalf("compileActionLocks() error = %v, want repository-root rejection", err)
 	}
@@ -205,7 +205,7 @@ func TestCompileActionLocksRejectsExcessiveDepthBeforeResolvingLeaf(t *testing.T
 		}
 		writeAction(t, w, "depth-"+strconv.Itoa(i), "name: depth\nruns:\n  using: composite\n"+steps)
 	}
-	_, _, _, err := compileActionLocks(context.Background(), w, nil, []string{"./depth-0"})
+	_, _, _, _, err := compileActionLocks(context.Background(), w, nil, []string{"./depth-0"})
 	if err == nil || !strings.Contains(err.Error(), "exceeds maximum depth") {
 		t.Fatalf("compileActionLocks() error = %v, want depth rejection", err)
 	}
@@ -217,7 +217,7 @@ func TestCompileActionLocksRejectsEscapedJavaScriptEntrypoint(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(w, "outside.js"), []byte("// outside\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	_, _, _, err := compileActionLocks(context.Background(), w, nil, []string{"./js"})
+	_, _, _, _, err := compileActionLocks(context.Background(), w, nil, []string{"./js"})
 	if err == nil || !strings.Contains(err.Error(), "escapes action source") {
 		t.Fatalf("compileActionLocks() error = %v, want entry-point confinement rejection", err)
 	}
@@ -228,7 +228,7 @@ func TestCompileActionLocksExplicitRemoteAndDistinctRefs(t *testing.T) {
 	writeAction(t, remote, "", "name: parent\nruns:\n  using: composite\n  steps:\n    - uses: Other/Child/sub@v2\n")
 	writeAction(t, remote, "sub", "name: child\nruns:\n  using: node24\n  main: index.js\n")
 	f := &fakeActionSource{root: remote, calls: map[string]int{}}
-	selectors, locks, _, err := compileActionLocks(context.Background(), w, f, []string{"Owner/Repo@v1", "Owner/Repo@main"})
+	selectors, locks, _, _, err := compileActionLocks(context.Background(), w, f, []string{"Owner/Repo@v1", "Owner/Repo@main"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -246,11 +246,11 @@ func TestCompileActionLocksDeterministic(t *testing.T) {
 	w := t.TempDir()
 	writeAction(t, w, "parent", "name: parent\nruns:\n  using: composite\n  steps:\n    - uses: ./child\n")
 	writeAction(t, w, "child", "name: child\nruns:\n  using: node20\n  main: index.js\n")
-	aSelectors, aLocks, aCaps, err := compileActionLocks(context.Background(), w, nil, []string{"./parent"})
+	aSelectors, aLocks, aCaps, _, err := compileActionLocks(context.Background(), w, nil, []string{"./parent"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	bSelectors, bLocks, bCaps, err := compileActionLocks(context.Background(), w, nil, []string{"./parent"})
+	bSelectors, bLocks, bCaps, _, err := compileActionLocks(context.Background(), w, nil, []string{"./parent"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -275,7 +275,7 @@ func TestCompileActionLocksAllowsOnlyCacheV6Commit(t *testing.T) {
 				uses += "/" + path
 			}
 			uses += "@" + actionintegration.CacheCommit
-			_, locks, capabilities, err := compileActionLocks(context.Background(), workspace, &fakeActionSource{root: remote, calls: map[string]int{}}, []string{uses})
+			_, locks, capabilities, _, err := compileActionLocks(context.Background(), workspace, &fakeActionSource{root: remote, calls: map[string]int{}}, []string{uses})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -285,7 +285,7 @@ func TestCompileActionLocksAllowsOnlyCacheV6Commit(t *testing.T) {
 		})
 	}
 
-	_, locks, _, err := compileActionLocks(context.Background(), workspace, &fakeActionSource{root: remote, calls: map[string]int{}, commit: actionintegration.CacheCommit}, []string{"actions/cache@v6.1.0"})
+	_, locks, _, _, err := compileActionLocks(context.Background(), workspace, &fakeActionSource{root: remote, calls: map[string]int{}, commit: actionintegration.CacheCommit}, []string{"actions/cache@v6.1.0"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -294,7 +294,7 @@ func TestCompileActionLocksAllowsOnlyCacheV6Commit(t *testing.T) {
 	}
 
 	resolved := strings.Repeat("a", 40)
-	_, _, _, err = compileActionLocks(context.Background(), workspace, &fakeActionSource{root: remote, calls: map[string]int{}}, []string{"actions/cache@v6"})
+	_, _, _, _, err = compileActionLocks(context.Background(), workspace, &fakeActionSource{root: remote, calls: map[string]int{}}, []string{"actions/cache@v6"})
 	if err == nil || !strings.Contains(err.Error(), "actions/cache@v6 resolved to commit "+resolved) || !strings.Contains(err.Error(), "supported: actions/cache@v6.1.0 (commit "+actionintegration.CacheCommit+")") {
 		t.Fatalf("unsupported actions/cache commit error = %v", err)
 	}

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -32,6 +32,21 @@ func (contextActionSource) Fetch(ctx context.Context, _ source.Reference) (sourc
 	return source.Resolved{}, source.Materialized{}, ctx.Err()
 }
 
+type classifiedActionSource struct {
+	roots   map[string]string
+	commits map[string]string
+}
+
+func (s classifiedActionSource) Fetch(_ context.Context, ref source.Reference) (source.Resolved, source.Materialized, error) {
+	repository := strings.ToLower(ref.Owner + "/" + ref.Repository)
+	root := s.roots[repository]
+	return source.Resolved{Reference: ref, Commit: s.commits[repository]}, source.Materialized{
+		RepositoryRoot: root,
+		ActionRoot:     filepath.Join(root, ref.Path),
+		SourceDigest:   "sha256:" + strings.Repeat("a", 64),
+	}, nil
+}
+
 func (f *fakeActionSource) Fetch(_ context.Context, r source.Reference) (source.Resolved, source.Materialized, error) {
 	f.calls[r.Raw]++
 	d, err := source.DigestTree(filepath.Join(f.root, r.Path))
@@ -64,6 +79,69 @@ func writeAction(t *testing.T, root, name, body string) {
 				t.Fatal(err)
 			}
 		}
+	}
+}
+
+func TestCompileActionLocksRequiresMiseOnlyForJavaScriptReachableGraphs(t *testing.T) {
+	workspace := t.TempDir()
+	writeAction(t, workspace, "docker", "runs:\n  using: docker\n  image: Dockerfile\n")
+	writeAction(t, workspace, "native-docker-composite", "runs:\n  using: composite\n  steps:\n    - run: echo native\n      shell: sh\n    - uses: actions/checkout@v4\n    - uses: ./docker\n")
+	writeAction(t, workspace, "js", "runs:\n  using: node24\n  main: index.js\n")
+	writeAction(t, workspace, "js-composite", "runs:\n  using: composite\n  steps:\n    - uses: ./js\n")
+
+	remote := func(repository, using string) string {
+		root := t.TempDir()
+		writeAction(t, root, "", "runs:\n  using: "+using+"\n  main: index.js\n")
+		return root
+	}
+	remoteComposite := t.TempDir()
+	writeAction(t, remoteComposite, "", "runs:\n  using: composite\n  steps:\n    - uses: owner/javascript@v1\n")
+	source := classifiedActionSource{
+		roots: map[string]string{
+			"actions/checkout":          remote("actions/checkout", "node24"),
+			"actions/upload-artifact":   remote("actions/upload-artifact", "node24"),
+			"actions/download-artifact": remote("actions/download-artifact", "node24"),
+			"actions/cache":             remote("actions/cache", "node24"),
+			"owner/composite":           remoteComposite,
+			"owner/javascript":          remote("owner/javascript", "node24"),
+		},
+		commits: map[string]string{
+			"actions/checkout":          strings.Repeat("b", 40),
+			"actions/upload-artifact":   actionintegration.UploadArtifactCommit,
+			"actions/download-artifact": actionintegration.DownloadArtifactCommit,
+			"actions/cache":             actionintegration.CacheCommit,
+			"owner/composite":           strings.Repeat("c", 40),
+			"owner/javascript":          strings.Repeat("d", 40),
+		},
+	}
+
+	tests := []struct {
+		name string
+		refs []string
+		want bool
+	}{
+		{name: "shell only"},
+		{name: "native checkout only", refs: []string{"actions/checkout@v4"}},
+		{name: "native upload only", refs: []string{"actions/upload-artifact@v4"}},
+		{name: "native download only", refs: []string{"actions/download-artifact@v4"}},
+		{name: "Docker only", refs: []string{"./docker"}},
+		{name: "native and Docker composite", refs: []string{"./native-docker-composite"}},
+		{name: "JavaScript", refs: []string{"./js"}, want: true},
+		{name: "JavaScript through composite", refs: []string{"./js-composite"}, want: true},
+		{name: "JavaScript through remote composite", refs: []string{"owner/composite@v1"}, want: true},
+		{name: "cache v2 client", refs: []string{"actions/cache@v6.1.0"}, want: true},
+		{name: "mixed Docker and JavaScript", refs: []string{"./docker", "./js"}, want: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, _, got, err := compileActionLocksWithMise(context.Background(), workspace, source, test.refs)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != test.want {
+				t.Fatalf("requires mise = %t, want %t", got, test.want)
+			}
+		})
 	}
 }
 
@@ -276,8 +354,8 @@ jobs:
 	if !reflect.DeepEqual(first, second) {
 		t.Fatal("tokenless action plans are not deterministic")
 	}
-	if len(first) != 3 || first[0].Schema != plan.SchemaV3 || first[1].Schema != plan.SchemaV3 || first[2].Schema != plan.SchemaV2 {
-		t.Fatalf("plan schemas = %#v, want two action v3 plans and one shell v2 plan", []string{first[0].Schema, first[1].Schema, first[2].Schema})
+	if len(first) != 3 || first[0].Schema != plan.SchemaV7 || first[1].Schema != plan.SchemaV7 || first[2].Schema != plan.SchemaV2 {
+		t.Fatalf("plan schemas = %#v, want two action v7 plans and one shell v2 plan", []string{first[0].Schema, first[1].Schema, first[2].Schema})
 	}
 	actionJob := first[0]
 	if len(actionJob.Actions) != 3 || actionJob.Steps[0].Action == nil || actionJob.Steps[1].Action == nil || actionJob.Steps[2].Action == nil || *actionJob.Steps[1].Action != *actionJob.Steps[2].Action {
@@ -340,7 +418,7 @@ jobs:
 	if !reflect.DeepEqual(first, second) {
 		t.Fatal("workspace action plans are not deterministic")
 	}
-	if len(first) != 1 || first[0].Schema != plan.SchemaV4 || len(first[0].Actions) != 1 || first[0].Actions[0].Source != "workspace" || first[0].Steps[0].Action == nil {
+	if len(first) != 1 || first[0].Schema != plan.SchemaV7 || len(first[0].Actions) != 1 || first[0].Actions[0].Source != "workspace" || first[0].Steps[0].Action == nil {
 		t.Fatalf("workspace action plan = %#v", first)
 	}
 }
@@ -750,7 +828,7 @@ jobs:
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(plans) != 1 || plans[0].Schema != plan.SchemaV3 || len(plans[0].Actions) != 3 {
+	if len(plans) != 1 || plans[0].Schema != plan.SchemaV7 || len(plans[0].Actions) != 3 || plans[0].RequiresMise == nil || !*plans[0].RequiresMise {
 		t.Fatalf("public action plan = %#v", plans)
 	}
 	wantCommits := map[string]string{

--- a/internal/compiler/bundle.go
+++ b/internal/compiler/bundle.go
@@ -92,7 +92,7 @@ func CompileBundleContext(ctx context.Context, path string, source, eventSource 
 			Queue:        ir.Jobs[i].Queue,
 			PlanDigest:   digest,
 			Dependencies: append([]string(nil), ir.Jobs[i].Needs...),
-			UsesActions:  planUsesActions(job),
+			RequiresMise: job.NeedsMise(),
 		}
 		if ir.Jobs[i].ConcurrencyGroup != "" {
 			jobs[i].Concurrency = 1
@@ -126,13 +126,4 @@ func buildkiteConcurrencyGroup(repository Repository, group string) string {
 	scope := strings.ToLower(repository.Owner+"/"+repository.Name) + "\x00" + canonicalConcurrencyGroup(group)
 	digest := sha256.Sum256([]byte(scope))
 	return "buildkite-gha/concurrency/" + hex.EncodeToString(digest[:])
-}
-
-func planUsesActions(job plan.Job) bool {
-	for _, step := range job.Steps {
-		if step.Action != nil {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -3,6 +3,7 @@ package compiler
 import (
 	"bytes"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -77,6 +78,53 @@ func TestCompileBundleCompilesSmokeCorpus(t *testing.T) {
 				t.Fatalf("pipeline YAML: %v", err)
 			}
 		})
+	}
+}
+
+func TestCompileBundleCarriesResolvedMiseRequirementIntoPipeline(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := filepath.Join(workspace, ".github", "workflows", "actions.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeAction(t, workspace, "docker", "runs:\n  using: docker\n  image: Dockerfile\n")
+	writeAction(t, workspace, "javascript", "runs:\n  using: node24\n  main: index.js\n")
+	workflow := []byte("on: push\njobs:\n  native:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: ./docker\n  javascript:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: ./javascript\n")
+	bundle, err := CompileBundle(workflowPath, workflow, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "importer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bundle.Plans) != 2 {
+		t.Fatalf("plans = %d, want 2", len(bundle.Plans))
+	}
+	decisions := map[string]bool{}
+	for _, artifact := range bundle.Plans {
+		if artifact.Job.RequiresMise == nil {
+			t.Fatalf("job %q lacks requires_mise", artifact.Job.Target.StepKey)
+		}
+		decisions[artifact.Job.Workflow.LogicalJobID] = *artifact.Job.RequiresMise
+	}
+	if decisions["native"] || !decisions["javascript"] {
+		t.Fatalf("requires_mise decisions = %#v", decisions)
+	}
+	var document struct {
+		Steps []struct {
+			Key   string            `yaml:"key"`
+			Cache any               `yaml:"cache"`
+			Env   map[string]string `yaml:"env"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(bundle.Pipeline, &document); err != nil {
+		t.Fatal(err)
+	}
+	for _, step := range document.Steps {
+		wantMise := strings.Contains(step.Key, "javascript")
+		if hasCache := step.Cache != nil; hasCache != wantMise {
+			t.Fatalf("step %q managed cache = %t, want %t", step.Key, hasCache, wantMise)
+		}
+		if hasEnv := step.Env["BUILDKITE_GHA_MISE_DATA_DIR"] != ""; hasEnv != wantMise {
+			t.Fatalf("step %q managed mise env = %t, want %t", step.Key, hasEnv, wantMise)
+		}
 	}
 }
 

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -290,6 +290,7 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 		}
 		jobSchema := plan.Schema
 		var actions []plan.ActionLock
+		var requiresMise bool
 		var capabilities []string
 		var authorization PlanAuthorization
 		lockActions := options.ResolveActions
@@ -303,10 +304,11 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 			}
 		}
 		if lockActions && len(actionRefs) != 0 {
-			selectors, locks, actionCapabilities, err := compileActionLocks(ctx, instance.RepositoryRoot, actionSource, actionRefs)
+			selectors, locks, actionCapabilities, actionRequiresMise, err := compileActionLocksWithMise(ctx, instance.RepositoryRoot, actionSource, actionRefs)
 			if err != nil {
 				return nil, nil, fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err)
 			}
+			requiresMise = actionRequiresMise
 			locksByID := make(map[string]plan.ActionLock, len(locks))
 			for _, lock := range locks {
 				locksByID[lock.ID] = lock
@@ -346,7 +348,7 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 					}
 				}
 			}
-			jobSchema = plan.SchemaV3
+			jobSchema = plan.SchemaV7
 			actions = locks
 			capabilities = append(append([]string{}, capabilities...), actionCapabilities...)
 			sort.Strings(capabilities)
@@ -367,7 +369,9 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 			if len(actionRefs) != 0 && !lockActions {
 				return nil, nil, fmt.Errorf("build plan for job %q: containers with remote actions require action resolution through upload or profile validation", instance.LogicalJobID)
 			}
-			jobSchema = plan.SchemaV4
+			if jobSchema != plan.SchemaV7 {
+				jobSchema = plan.SchemaV4
+			}
 			capabilities = append(capabilities, "docker", "network")
 			sort.Strings(capabilities)
 			capabilities = slices.Compact(capabilities)
@@ -405,7 +409,9 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 			}
 		}
 		if len(needOutputs) != 0 {
-			jobSchema = plan.SchemaV5
+			if jobSchema != plan.SchemaV7 {
+				jobSchema = plan.SchemaV5
+			}
 		}
 		secrets, err := requiredSecrets(instance)
 		if err != nil {
@@ -422,7 +428,9 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 				permissions[strings.ReplaceAll(name, "-", "_")] = access
 			}
 			githubToken = &plan.GitHubToken{Permissions: permissions}
-			jobSchema = plan.SchemaV6
+			if jobSchema != plan.SchemaV7 {
+				jobSchema = plan.SchemaV6
+			}
 			capabilities = append(capabilities, "provider-token-write")
 			authorization.ProviderTokenWriteCapabilitySources = []string{"workflow-permissions"}
 		}
@@ -463,6 +471,9 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 			Outputs:                 instance.Outputs,
 			Steps:                   steps,
 			Actions:                 actions,
+		}
+		if len(actions) != 0 {
+			job.RequiresMise = &requiresMise
 		}
 		if instance.Container != nil {
 			job.Container = &plan.Container{Image: instance.Container.Image, Env: cloneMap(instance.Container.Env), Ports: append([]string(nil), instance.Container.Ports...)}

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -304,7 +304,7 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 			}
 		}
 		if lockActions && len(actionRefs) != 0 {
-			selectors, locks, actionCapabilities, actionRequiresMise, err := compileActionLocksWithMise(ctx, instance.RepositoryRoot, actionSource, actionRefs)
+			selectors, locks, actionCapabilities, actionRequiresMise, err := compileActionLocks(ctx, instance.RepositoryRoot, actionSource, actionRefs)
 			if err != nil {
 				return nil, nil, fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err)
 			}

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -22,6 +22,7 @@ const (
 	SchemaV4 = "https://buildkite.com/schemas/buildkite-gha/job-plan-v4.schema.json"
 	SchemaV5 = "https://buildkite.com/schemas/buildkite-gha/job-plan-v5.schema.json"
 	SchemaV6 = "https://buildkite.com/schemas/buildkite-gha/job-plan-v6.schema.json"
+	SchemaV7 = "https://buildkite.com/schemas/buildkite-gha/job-plan-v7.schema.json"
 	Schema   = SchemaV2
 )
 
@@ -191,17 +192,32 @@ type Job struct {
 	NeedOutputs          map[string][]NeedOutput `json:"need_outputs,omitempty"`
 	// Needs is populated only from verified producer-attributed manifests at
 	// runtime. It is never accepted from or encoded into an immutable plan.
-	Needs                   map[string]Need      `json:"-"`
-	Env                     map[string]string    `json:"env,omitempty"`
-	Condition               string               `json:"condition,omitempty"`
-	TimeoutMinutes          float64              `json:"timeout_minutes,omitempty"`
-	DefaultShell            string               `json:"default_shell,omitempty"`
-	DefaultWorkingDirectory string               `json:"default_working_directory,omitempty"`
-	Outputs                 map[string]string    `json:"outputs,omitempty"`
-	Steps                   []Step               `json:"steps"`
-	Actions                 []ActionLock         `json:"actions,omitempty"`
-	Container               *Container           `json:"container,omitempty"`
-	Services                map[string]Container `json:"services,omitempty"`
+	Needs                   map[string]Need   `json:"-"`
+	Env                     map[string]string `json:"env,omitempty"`
+	Condition               string            `json:"condition,omitempty"`
+	TimeoutMinutes          float64           `json:"timeout_minutes,omitempty"`
+	DefaultShell            string            `json:"default_shell,omitempty"`
+	DefaultWorkingDirectory string            `json:"default_working_directory,omitempty"`
+	Outputs                 map[string]string `json:"outputs,omitempty"`
+	Steps                   []Step            `json:"steps"`
+	Actions                 []ActionLock      `json:"actions,omitempty"`
+	// RequiresMise is compiler-resolved action runtime metadata. Nil preserves
+	// fail-closed behavior for older and unresolved action plans.
+	RequiresMise *bool                `json:"requires_mise,omitempty"`
+	Container    *Container           `json:"container,omitempty"`
+	Services     map[string]Container `json:"services,omitempty"`
+}
+
+// NeedsMise reports whether a generated job needs the managed action runtime.
+func (job Job) NeedsMise() bool {
+	usesActions := len(job.Actions) != 0
+	for _, step := range job.Steps {
+		usesActions = usesActions || step.Uses != "" || step.Action != nil || step.Kind == "uses"
+	}
+	if !usesActions {
+		return false
+	}
+	return job.RequiresMise == nil || *job.RequiresMise
 }
 
 // Decode rejects unknown fields and trailing JSON so schema drift fails closed.
@@ -330,20 +346,36 @@ func Encode(job Job) ([]byte, error) {
 }
 
 func (job Job) Validate() error {
-	if job.Schema != SchemaV1 && job.Schema != SchemaV2 && job.Schema != SchemaV3 && job.Schema != SchemaV4 && job.Schema != SchemaV5 && job.Schema != SchemaV6 {
+	if job.Schema != SchemaV1 && job.Schema != SchemaV2 && job.Schema != SchemaV3 && job.Schema != SchemaV4 && job.Schema != SchemaV5 && job.Schema != SchemaV6 && job.Schema != SchemaV7 {
 		return fmt.Errorf("unsupported job plan schema %q", job.Schema)
 	}
-	if job.Schema != SchemaV3 && job.Schema != SchemaV4 && job.Schema != SchemaV5 && job.Schema != SchemaV6 && (len(job.Actions) != 0 || hasStepActions(job.Steps)) {
+	if job.Schema != SchemaV3 && job.Schema != SchemaV4 && job.Schema != SchemaV5 && job.Schema != SchemaV6 && job.Schema != SchemaV7 && (len(job.Actions) != 0 || hasStepActions(job.Steps)) {
 		return fmt.Errorf("job plan %s does not support action locks", job.Schema)
 	}
-	if job.Schema != SchemaV4 && job.Schema != SchemaV5 && job.Schema != SchemaV6 && (job.Container != nil || len(job.Services) != 0) {
+	if job.Schema != SchemaV4 && job.Schema != SchemaV5 && job.Schema != SchemaV6 && job.Schema != SchemaV7 && (job.Container != nil || len(job.Services) != 0) {
 		return fmt.Errorf("job plan %s does not support containers or services", job.Schema)
 	}
-	if job.Schema != SchemaV5 && job.Schema != SchemaV6 && job.NeedOutputs != nil {
+	if job.Schema != SchemaV5 && job.Schema != SchemaV6 && job.Schema != SchemaV7 && job.NeedOutputs != nil {
 		return fmt.Errorf("job plan %s does not support prerequisite output projections", job.Schema)
 	}
-	if job.Schema != SchemaV6 && job.GitHubToken != nil {
+	if job.Schema != SchemaV6 && job.Schema != SchemaV7 && job.GitHubToken != nil {
 		return fmt.Errorf("job plan %s does not support GitHub workflow tokens", job.Schema)
+	}
+	if job.Schema == SchemaV7 && job.RequiresMise == nil {
+		return fmt.Errorf("job plan %s requires an explicit requires_mise decision", job.Schema)
+	}
+	if job.Schema != SchemaV7 && job.RequiresMise != nil {
+		return fmt.Errorf("job plan %s does not support requires_mise", job.Schema)
+	}
+	if job.RequiresMise != nil && !*job.RequiresMise {
+		if len(job.Actions) == 0 {
+			return fmt.Errorf("job plan requires_mise may be false only for a resolved action graph")
+		}
+		for _, step := range job.Steps {
+			if (step.Kind == "uses" || step.Uses != "") && step.Action == nil {
+				return fmt.Errorf("job plan requires_mise may be false only when every action has an immutable selector")
+			}
+		}
 	}
 	if job.Compiler.Version == "" || !digestPattern.MatchString(job.Compiler.DistributionDigest) {
 		return fmt.Errorf("job plan compiler version and distribution digest are required")
@@ -450,7 +482,7 @@ func (job Job) Validate() error {
 	needIDs := make(map[string]struct{}, len(job.NeedSources))
 	sourcedDependencies := make(map[string]struct{}, len(job.Dependencies))
 	maxNeedProducers := MaxNeedProducers
-	if job.Schema != SchemaV5 && job.Schema != SchemaV6 {
+	if job.Schema != SchemaV5 && job.Schema != SchemaV6 && job.Schema != SchemaV7 {
 		maxNeedProducers = maxLegacyNeedProducers
 	}
 	for name, sources := range job.NeedSources {
@@ -580,7 +612,7 @@ func (job Job) Validate() error {
 			return fmt.Errorf("step %q has unsupported kind %q", step.ID, step.Kind)
 		}
 	}
-	if job.Schema == SchemaV3 || job.Schema == SchemaV4 || ((job.Schema == SchemaV5 || job.Schema == SchemaV6) && (len(job.Actions) != 0 || hasStepActions(job.Steps))) {
+	if job.Schema == SchemaV3 || job.Schema == SchemaV4 || ((job.Schema == SchemaV5 || job.Schema == SchemaV6 || job.Schema == SchemaV7) && (len(job.Actions) != 0 || hasStepActions(job.Steps))) {
 		if err := validateActionLocks(job); err != nil {
 			return err
 		}

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -252,6 +252,58 @@ func TestV3ActionLocksRoundTripAndValidateAgainstSchema(t *testing.T) {
 	}
 }
 
+func TestV7RequiresMiseRoundTripAndSchema(t *testing.T) {
+	requiresMise := false
+	job := validJob()
+	job.Schema = SchemaV7
+	job.Steps = []Step{{ID: "native", Kind: "uses", Uses: "actions/checkout@v4", Action: &ActionSelector{Lock: "a-0000000000000001"}}}
+	job.Actions = []ActionLock{{
+		ID: "a-0000000000000001", Source: "github", Repository: "actions/checkout", RequestedRef: "v4",
+		Commit: strings.Repeat("a", 40), SourceDigest: "sha256:" + strings.Repeat("b", 64),
+	}}
+	job.RequiresMise = &requiresMise
+	encoded, err := Encode(job)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := Decode(encoded)
+	if err != nil || decoded.RequiresMise == nil || *decoded.RequiresMise {
+		t.Fatalf("Decode() requires_mise = %#v, error = %v", decoded.RequiresMise, err)
+	}
+	compiler := jsonschema.NewCompiler()
+	source, err := os.ReadFile(filepath.Join("..", "..", "schemas", "job-plan-v7.schema.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document any
+	if err := json.Unmarshal(source, &document); err != nil {
+		t.Fatal(err)
+	}
+	if err := compiler.AddResource(SchemaV7, document); err != nil {
+		t.Fatal(err)
+	}
+	schema, err := compiler.Compile(SchemaV7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var planDocument any
+	if err := json.Unmarshal(encoded, &planDocument); err != nil {
+		t.Fatal(err)
+	}
+	if err := schema.Validate(planDocument); err != nil {
+		t.Fatalf("v7 plan does not validate against schema: %v", err)
+	}
+	job.RequiresMise = nil
+	if err := job.Validate(); err == nil || !strings.Contains(err.Error(), "explicit requires_mise") {
+		t.Fatalf("Validate() missing requires_mise error = %v", err)
+	}
+	job.RequiresMise = &requiresMise
+	job.Steps[0].Action = nil
+	if err := job.Validate(); err == nil || !strings.Contains(err.Error(), "immutable selector") {
+		t.Fatalf("Validate() unresolved false error = %v", err)
+	}
+}
+
 func TestV3RemoteNestedActionLocks(t *testing.T) {
 	digest := "sha256:" + strings.Repeat("b", 64)
 	commit := strings.Repeat("c", 40)

--- a/internal/runtime/actions.go
+++ b/internal/runtime/actions.go
@@ -86,6 +86,10 @@ func usesDownloadArtifactAdapter(lock plan.ActionLock) bool {
 	return descriptor.Adapter == actionintegration.AdapterDownloadArtifactBuildkite
 }
 
+func usesNativeAdapter(lock plan.ActionLock) bool {
+	return actionintegration.UsesNativeAdapter(actionintegration.Identity{Source: lock.Source, Repository: lock.Repository, Path: lock.Path})
+}
+
 func usesCacheService(lock plan.ActionLock) bool {
 	descriptor, _ := actionintegration.Lookup(actionintegration.Identity{Source: lock.Source, Repository: lock.Repository, Path: lock.Path})
 	return descriptor.Service == actionintegration.ServiceCache

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -1094,6 +1094,39 @@ func TestRunJobContainerDoesNotProbeConfiguredNodeForCompositeOnlyActions(t *tes
 	}
 }
 
+func TestActionContainerMountsNativeAdapterDoesNotResolveMise(t *testing.T) {
+	workspace := t.TempDir()
+	remote := t.TempDir()
+	writeFixtureFile(t, remote, "action.yml", "name: checkout\nruns:\n  using: node24\n  main: index.js\n")
+	writeFixtureFile(t, remote, "index.js", "")
+	digest := digestTree(t, remote)
+	lockID := remoteLifecycleLockID(1)
+	job := jobContainerPlan(t, workspace, []plan.Step{{ID: "checkout", Kind: "uses", Uses: "actions/checkout@v4", Action: &plan.ActionSelector{Lock: lockID}}})
+	job.Actions = []plan.ActionLock{{
+		ID: lockID, Source: "github", Repository: "actions/checkout", RequestedRef: "v4",
+		Commit: strings.Repeat("a", 40), SourceDigest: digest,
+	}}
+	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, ActionRoot: remote, SourceDigest: digest}}
+	actions := newActionLockResolver(job, workspace, materializer)
+	miseCalls := 0
+	runner := Runner{ResolveMise: func(context.Context) (string, error) {
+		miseCalls++
+		return "", errors.New("unexpected mise resolution")
+	}}
+	mounts, err := runner.actionContainerMounts(context.Background(), actions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if miseCalls != 0 {
+		t.Fatalf("ResolveMise calls = %d, want 0", miseCalls)
+	}
+	for _, mount := range mounts {
+		if strings.Contains(mount.target, "node24") || strings.Contains(mount.target, "/nodes") {
+			t.Fatalf("native adapter gained Node mount: %#v", mount)
+		}
+	}
+}
+
 func TestRunJobContainerReadOnlyMountProbeFailureCleansOwnedResources(t *testing.T) {
 	f := newJobDocker(t, "fail-mount-probe")
 	w := t.TempDir()
@@ -1715,7 +1748,7 @@ func TestLivePhase5CompiledContainerRuntime(t *testing.T) {
 	}
 	for _, artifact := range bundle.Plans {
 		job := artifact.Job
-		if job.Schema != plan.SchemaV4 || !slices.Equal(job.RequiredCapabilities, []string{"docker", "network"}) {
+		if job.Schema != plan.SchemaV7 || !slices.Equal(job.RequiredCapabilities, []string{"docker", "network"}) {
 			t.Fatalf("compiled %s plan boundary = schema %q, capabilities %#v", job.Workflow.LogicalJobID, job.Schema, job.RequiredCapabilities)
 		}
 		wantSources := []string{"dockerfile-actions", "service-containers"}

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -3,7 +3,9 @@ package runtime
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1123,6 +1125,77 @@ func TestActionContainerMountsNativeAdapterDoesNotResolveMise(t *testing.T) {
 	for _, mount := range mounts {
 		if strings.Contains(mount.target, "node24") || strings.Contains(mount.target, "/nodes") {
 			t.Fatalf("native adapter gained Node mount: %#v", mount)
+		}
+	}
+}
+
+func TestRunJobContainerCheckoutPopulatesNoMiseWorkspaceAction(t *testing.T) {
+	f := newJobDocker(t, "")
+	workspace := t.TempDir()
+	workflowSource := []byte("name: container\n")
+	workflowDigest := sha256.Sum256(workflowSource)
+	localSource := []byte("name: local\nruns:\n  using: composite\n  steps:\n    - shell: sh\n      run: echo 'CHECKOUT_CHAIN=ok' >> \"$GITHUB_ENV\"\n")
+	localFixture := t.TempDir()
+	writeFixtureFile(t, localFixture, "action.yml", string(localSource))
+
+	remote := t.TempDir()
+	writeFixtureFile(t, remote, "action.yml", "name: checkout\nruns:\n  using: node24\n  main: index.js\n")
+	writeFixtureFile(t, remote, "index.js", "throw new Error('adapter must not execute checkout JavaScript')\n")
+	remoteDigest := digestTree(t, remote)
+
+	sha := strings.Repeat("a", 40)
+	git := filepath.Join(t.TempDir(), "git")
+	script := `#!/bin/sh
+set -eu
+operation=
+for argument in "$@"; do
+  case "$argument" in init|remote|fetch|checkout) operation="$argument"; break ;; esac
+done
+case "$operation" in
+  init) mkdir -p .git ;;
+  checkout)
+    printf '%s\n' ` + shellTestQuote(sha) + ` > .git/HEAD
+    mkdir -p .github/workflows .github/actions/local
+    printf '%s' ` + shellTestQuote(base64.StdEncoding.EncodeToString(workflowSource)) + ` | base64 -d > .github/workflows/container.yml
+    printf '%s' ` + shellTestQuote(base64.StdEncoding.EncodeToString(localSource)) + ` | base64 -d > .github/actions/local/action.yml
+    ;;
+esac
+`
+	if err := os.WriteFile(git, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	requiresMise := false
+	checkoutID, localID := remoteLifecycleLockID(1), remoteLifecycleLockID(2)
+	job := plan.Job{
+		Schema:   plan.SchemaV7,
+		Compiler: plan.Compiler{Version: "0.0.0-test", DistributionDigest: "sha256:" + strings.Repeat("1", 64)},
+		Workflow: plan.Workflow{Path: ".github/workflows/container.yml", Digest: "sha256:" + hex.EncodeToString(workflowDigest[:]), LogicalJobID: "container"},
+		Event: plan.Event{
+			Provider: "github", Name: "push", PayloadDigest: "sha256:" + strings.Repeat("3", 64),
+			Repository: "buildkite/buildkite-gha", Ref: "refs/heads/main", SHA: sha,
+		},
+		Target:               plan.Target{StepKey: "gha-container", Queue: "trusted"},
+		RequiredCapabilities: []string{"docker", "network"},
+		Steps: []plan.Step{
+			{ID: "checkout", Kind: "uses", Uses: "actions/checkout@v4", Action: &plan.ActionSelector{Lock: checkoutID}},
+			{ID: "local", Kind: "uses", Uses: "./.github/actions/local", Action: &plan.ActionSelector{Lock: localID}},
+		},
+		Actions: []plan.ActionLock{
+			{ID: checkoutID, Source: "github", Repository: "actions/checkout", RequestedRef: "v4", Commit: strings.Repeat("b", 40), SourceDigest: remoteDigest},
+			{ID: localID, Source: "workspace", Path: ".github/actions/local", SourceDigest: digestTree(t, localFixture)},
+		},
+		RequiresMise: &requiresMise,
+		Container:    &plan.Container{Image: "debian:bookworm-slim"},
+	}
+	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, ActionRoot: remote, SourceDigest: remoteDigest}}
+	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Git: git, Actions: materializer}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" || result.Env["CHECKOUT_CHAIN"] != "ok" {
+		t.Fatalf("container checkout chain result = %#v, error = %v", result, err)
+	}
+	for _, call := range f.calls(t) {
+		if slices.Contains(call.Args, "/__buildkite-gha/node20") || slices.Contains(call.Args, "/__buildkite-gha/node24") || slices.Contains(call.Args, "/__buildkite-gha/nodes") {
+			t.Fatalf("no-mise container checkout chain mounted or probed Node: %#v", call.Args)
 		}
 	}
 }

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -346,7 +346,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 	var runErr error
 	prepared := remotePreparations{}
 	preStatus := remotePreparationStatus{}
-	if job.Schema == plan.SchemaV3 || job.Schema == plan.SchemaV4 || ((job.Schema == plan.SchemaV5 || job.Schema == plan.SchemaV6) && len(job.Actions) != 0) {
+	if job.Schema == plan.SchemaV3 || job.Schema == plan.SchemaV4 || ((job.Schema == plan.SchemaV5 || job.Schema == plan.SchemaV6 || job.Schema == plan.SchemaV7) && len(job.Actions) != 0) {
 		for stepIndex, step := range job.Steps {
 			if step.Kind != "uses" {
 				continue
@@ -758,6 +758,9 @@ func (r Runner) verifyRemoteActionTree(ctx context.Context, actions *actionLockR
 	if err := action.ValidateEntrypoints(runtime); err != nil {
 		return err
 	}
+	if usesNativeAdapter(lock) {
+		return nil
+	}
 	if runtime != metadata.RuntimeComposite {
 		return nil
 	}
@@ -821,6 +824,9 @@ func (r *Runner) actionContainerMounts(ctx context.Context, actions *actionLockR
 				return nil, fmt.Errorf("conflicting verified action roots for %q", target)
 			}
 			byTarget[target] = m
+		}
+		if usesNativeAdapter(lock) {
+			continue
 		}
 		switch actionRuntime {
 		case metadata.RuntimeNode20:
@@ -1057,7 +1063,7 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 
 	var action metadata.Metadata
 	var actionLock *plan.ActionLock
-	if job.Schema == plan.SchemaV3 || job.Schema == plan.SchemaV4 || ((job.Schema == plan.SchemaV5 || job.Schema == plan.SchemaV6) && len(job.Actions) != 0) {
+	if job.Schema == plan.SchemaV3 || job.Schema == plan.SchemaV4 || ((job.Schema == plan.SchemaV5 || job.Schema == plan.SchemaV6 || job.Schema == plan.SchemaV7) && len(job.Actions) != 0) {
 		if step.Action == nil {
 			return result, fmt.Errorf("action %q has no immutable selector", step.Uses)
 		}

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -835,7 +835,7 @@ func (r *Runner) actionContainerMounts(ctx context.Context, actions *actionLockR
 			requiredNode[24] = true
 		}
 	}
-	if unknownWorkspaceRuntime {
+	if unknownWorkspaceRuntime && actions.job.NeedsMise() {
 		requiredNode[20], requiredNode[24] = true, true
 	}
 	for _, major := range []int{20, 24} {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -4135,7 +4135,7 @@ jobs:
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(plans) != 1 || plans[0].Schema != plan.SchemaV3 || len(plans[0].Actions) != 2 {
+	if len(plans) != 1 || plans[0].Schema != plan.SchemaV7 || len(plans[0].Actions) != 2 || plans[0].RequiresMise == nil || !*plans[0].RequiresMise {
 		t.Fatalf("portable setup plans = %#v", plans)
 	}
 	if got := plans[0].Steps[0].With["node-version"]; got != "24" {

--- a/schemas/job-plan-v7.schema.json
+++ b/schemas/job-plan-v7.schema.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://buildkite.com/schemas/buildkite-gha/job-plan-v7.schema.json",
+  "title": "buildkite-gha job plan v7",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "compiler", "workflow", "event", "target", "required_capabilities", "steps", "requires_mise"],
+  "properties": {
+    "schema": {"const": "https://buildkite.com/schemas/buildkite-gha/job-plan-v7.schema.json"},
+    "compiler": {"type": "object", "additionalProperties": false, "required": ["version", "distribution_digest"], "properties": {"version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$"}, "distribution_digest": {"$ref": "#/$defs/digest"}}},
+    "workflow": {"type": "object", "additionalProperties": false, "required": ["path", "digest", "logical_job_id"], "properties": {"path": {"type": "string", "minLength": 1, "maxLength": 1024}, "digest": {"$ref": "#/$defs/digest"}, "logical_job_id": {"type": "string", "minLength": 1, "maxLength": 255}}},
+    "event": {"type": "object", "additionalProperties": false, "required": ["provider", "name", "payload_digest"], "properties": {"provider": {"enum": ["github", "cursor-origin"]}, "name": {"type": "string", "pattern": "^[A-Za-z0-9_.-]+$", "maxLength": 128}, "payload_digest": {"$ref": "#/$defs/digest"}, "repository": {"type": "string", "maxLength": 512}, "ref": {"type": "string", "maxLength": 1024}, "sha": {"type": "string", "maxLength": 128}, "actor": {"type": "string", "maxLength": 256}}},
+    "target": {"type": "object", "additionalProperties": false, "required": ["step_key", "queue"], "properties": {"step_key": {"$ref": "#/$defs/buildkiteName"}, "queue": {"$ref": "#/$defs/buildkiteName"}}},
+    "required_capabilities": {"type": "array", "uniqueItems": true, "items": {"$ref": "#/$defs/capability"}, "maxItems": 16},
+    "required_secrets": {"type": "array", "items": {"type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_]*$", "not": {"const": "GITHUB_TOKEN"}}, "uniqueItems": true, "maxItems": 128},
+    "github_token": {"$ref": "#/$defs/githubToken"},
+    "matrix": {"type": "object"},
+    "vars": {"$ref": "#/$defs/stringMap"},
+    "dependencies": {"type": "array", "items": {"$ref": "#/$defs/buildkiteName"}, "uniqueItems": true},
+    "need_sources": {"type": "object", "additionalProperties": {"type": "array", "minItems": 1, "maxItems": 1024, "uniqueItems": true, "items": {"$ref": "#/$defs/needSource"}}},
+    "need_outputs": {"type": "object", "additionalProperties": {"type": "array", "maxItems": 64, "items": {"$ref": "#/$defs/needOutput"}}},
+    "env": {"$ref": "#/$defs/stringMap"},
+    "condition": {"type": "string", "maxLength": 65536},
+    "timeout_minutes": {"type": "number", "exclusiveMinimum": 0, "maximum": 360},
+    "default_shell": {"type": "string"},
+    "default_working_directory": {"type": "string"},
+    "outputs": {"$ref": "#/$defs/stringMap"},
+    "steps": {"type": "array", "minItems": 1, "maxItems": 1000, "items": {"$ref": "#/$defs/step"}},
+    "actions": {"type": "array", "maxItems": 1024, "items": {"$ref": "#/$defs/actionLock"}},
+    "requires_mise": {"type": "boolean"},
+    "container": {"$ref": "#/$defs/container"},
+    "services": {"type": "object", "maxProperties": 32, "propertyNames": {"pattern": "^[a-z_][a-z0-9_-]{0,254}$"}, "additionalProperties": {"$ref": "#/$defs/container"}}
+  },
+  "allOf": [
+    {
+      "if": {"required": ["github_token"]},
+      "then": {
+        "properties": {
+          "required_capabilities": {"contains": {"const": "provider-token-write"}},
+          "event": {"required": ["repository"], "properties": {"provider": {"const": "github"}, "repository": {"$ref": "#/$defs/githubEventRepository"}}}
+        }
+      }
+    },
+    {"if": {"properties": {"required_capabilities": {"contains": {"const": "provider-token-write"}}}}, "then": {"required": ["github_token"]}}
+  ],
+  "$defs": {
+    "digest": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "buildkiteName": {"type": "string", "pattern": "^[A-Za-z0-9_-]+$", "minLength": 1, "maxLength": 255},
+    "capability": {"enum": ["network", "docker", "privileged-container", "secrets", "provider-token-read", "provider-token-write"]},
+    "stringMap": {"type": "object", "additionalProperties": {"type": "string"}},
+    "githubEventRepository": {"type": "string", "maxLength": 140, "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$", "not": {"pattern": "^(?:\\.\\.?/|[A-Za-z0-9_.-]+/\\.\\.?)$"}},
+    "githubToken": {"type": "object", "additionalProperties": false, "required": ["permissions"], "properties": {"permissions": {"$ref": "#/$defs/githubPermissions"}}},
+    "githubPermissions": {
+      "type": "object", "additionalProperties": false, "minProperties": 1, "maxProperties": 15,
+      "properties": {
+        "actions": {"enum": ["read", "write"]},
+        "artifact_metadata": {"enum": ["read", "write"]},
+        "attestations": {"enum": ["read", "write"]},
+        "checks": {"enum": ["read", "write"]},
+        "contents": {"enum": ["read", "write"]},
+        "deployments": {"enum": ["read", "write"]},
+        "discussions": {"enum": ["read", "write"]},
+        "issues": {"enum": ["read", "write"]},
+        "models": {"const": "read"},
+        "packages": {"enum": ["read", "write"]},
+        "pages": {"enum": ["read", "write"]},
+        "pull_requests": {"enum": ["read", "write"]},
+        "repository_projects": {"enum": ["read", "write"]},
+        "security_events": {"enum": ["read", "write"]},
+        "statuses": {"enum": ["read", "write"]}
+      }
+    },
+    "needSource": {"type": "object", "additionalProperties": false, "required": ["step_key", "plan_digest"], "properties": {"step_key": {"$ref": "#/$defs/buildkiteName"}, "plan_digest": {"$ref": "#/$defs/digest"}}},
+    "needOutput": {"type": "object", "additionalProperties": false, "required": ["name", "step_key", "output"], "properties": {"name": {"$ref": "#/$defs/buildkiteName"}, "step_key": {"$ref": "#/$defs/buildkiteName"}, "output": {"$ref": "#/$defs/buildkiteName"}}},
+    "position": {"type": "object", "additionalProperties": false, "required": ["line", "column"], "properties": {"line": {"type": "integer", "minimum": 0}, "column": {"type": "integer", "minimum": 0}}},
+    "span": {"type": "object", "additionalProperties": false, "required": ["start", "end"], "properties": {"start": {"$ref": "#/$defs/position"}, "end": {"$ref": "#/$defs/position"}}},
+    "selector": {"type": "object", "additionalProperties": false, "required": ["lock"], "properties": {"lock": {"type": "string", "pattern": "^a-[0-9a-f]{16}$"}}},
+    "path": {"type": "string", "minLength": 1, "maxLength": 1024, "pattern": "^[^/\\\\\\x00-\\x1f\\x7f]{1,255}(?:/[^/\\\\\\x00-\\x1f\\x7f]{1,255})*$", "not": {"pattern": "(^|/)\\.\\.?(/|$)"}},
+    "repository": {"type": "string", "maxLength": 140, "pattern": "^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?/[a-z0-9](?:[a-z0-9_.-]{0,98}[a-z0-9])?$"},
+    "actionLock": {
+      "type": "object", "additionalProperties": false,
+      "required": ["id", "source", "source_digest"],
+      "properties": {
+        "id": {"type": "string", "pattern": "^a-[0-9a-f]{16}$"}, "source": {"enum": ["workspace", "github"]},
+        "repository": {"$ref": "#/$defs/repository"}, "requested_ref": {"type": "string", "minLength": 1, "maxLength": 1024, "pattern": "^[^\\x00-\\x1f\\x7f]+$"},
+        "commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"}, "path": {"$ref": "#/$defs/path"}, "source_digest": {"$ref": "#/$defs/digest"},
+        "children": {"type": "object", "maxProperties": 1024, "propertyNames": {"minLength": 1, "maxLength": 2048, "pattern": "^[^\\x00-\\x1f\\x7f]+$"}, "additionalProperties": {"$ref": "#/$defs/selector"}}
+      },
+      "allOf": [
+        {"if": {"properties": {"source": {"const": "workspace"}}, "required": ["source"]}, "then": {"not": {"anyOf": [{"required": ["repository"]}, {"required": ["requested_ref"]}, {"required": ["commit"]}]}}},
+        {"if": {"properties": {"source": {"const": "github"}}, "required": ["source"]}, "then": {"required": ["repository", "requested_ref", "commit"]}}
+      ]
+    },
+    "container": {"type": "object", "additionalProperties": false, "required": ["image"], "properties": {"image": {"$ref": "#/$defs/image"}, "env": {"$ref": "#/$defs/containerEnv"}, "ports": {"type": "array", "maxItems": 128, "uniqueItems": true, "items": {"type": "string", "pattern": "^(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(?::(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]))?(?:/(?:tcp|udp))?$"}}}},
+    "containerEnv": {"type": "object", "maxProperties": 256, "propertyNames": {"pattern": "^[A-Za-z_][A-Za-z0-9_]{0,254}$"}, "additionalProperties": {"type": "string", "maxLength": 65536}},
+    "image": {"type": "string", "minLength": 1, "maxLength": 512, "pattern": "^[a-z0-9]+(?:[._-][a-z0-9]+)*(?:/[a-z0-9]+(?:[._-][a-z0-9]+)*)*(?::[A-Za-z0-9_][A-Za-z0-9_.-]{0,127})?(?:@sha256:[0-9a-f]{64})?$"},
+    "step": {
+      "type": "object", "additionalProperties": false, "required": ["id", "kind"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1, "maxLength": 255}, "name": {"type": "string"}, "kind": {"enum": ["run", "uses", "wait", "wait-all", "cancel"]}, "background": {"type": "boolean"},
+        "targets": {"type": "array", "minItems": 1, "maxItems": 256, "uniqueItems": true, "items": {"$ref": "#/$defs/buildkiteName"}},
+        "command": {"type": "string", "maxLength": 1048576}, "uses": {"type": "string", "maxLength": 1024}, "action": {"$ref": "#/$defs/selector"}, "shell": {"type": "string"}, "working_directory": {"type": "string"},
+        "env": {"$ref": "#/$defs/stringMap"}, "with": {"$ref": "#/$defs/stringMap"}, "condition": {"type": "string", "maxLength": 65536}, "continue_on_error": {"type": "boolean"}, "timeout_minutes": {"type": "number", "exclusiveMinimum": 0, "maximum": 360}, "source": {"$ref": "#/$defs/span"}
+      },
+      "allOf": [
+        {"if": {"properties": {"kind": {"const": "run"}}, "required": ["kind"]}, "then": {"required": ["command"], "not": {"anyOf": [{"required": ["uses"]}, {"required": ["targets"]}, {"required": ["action"]}]}}},
+        {"if": {"properties": {"kind": {"const": "uses"}}, "required": ["kind"]}, "then": {"required": ["uses"]}},
+        {"if": {"properties": {"kind": {"const": "wait"}}, "required": ["kind"]}, "then": {"required": ["targets"], "not": {"required": ["action"]}}},
+        {"if": {"properties": {"kind": {"const": "wait-all"}}, "required": ["kind"]}, "then": {"not": {"anyOf": [{"required": ["targets"]}, {"required": ["action"]}]}}},
+        {"if": {"properties": {"kind": {"const": "cancel"}}, "required": ["kind"]}, "then": {"required": ["targets"], "properties": {"targets": {"maxItems": 1}}, "not": {"required": ["action"]}}},
+        {"if": {"properties": {"kind": {"enum": ["wait", "wait-all", "cancel"]}}, "required": ["kind"]}, "then": {"not": {"anyOf": [{"required": ["background"]}, {"required": ["command"]}, {"required": ["uses"]}, {"required": ["shell"]}, {"required": ["working_directory"]}, {"required": ["env"]}, {"required": ["with"]}, {"required": ["condition"]}, {"required": ["continue_on_error"]}, {"required": ["timeout_minutes"]}, {"required": ["action"]}]}}}
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- carry a compiler-resolved `requires_mise` decision in self-contained job-plan schema v7
- skip generated-job mise cache/env and runtime resolution only for action DAGs proven to contain shell, native adapters, and/or Docker execution
- preserve managed mise for JavaScript, cache-v2, mixed, legacy, unresolved, and otherwise uncertain action plans
- treat native adapters as execution leaves consistently during compilation, remote verification, and job-container Node mount preparation

## Behavior

| Resolved action tree | Managed mise |
| --- | --- |
| Shell only | No |
| Native checkout/upload/download only | No |
| Docker only | No |
| Composite containing only shell/native/Docker | No |
| JavaScript or JavaScript through composite | Yes |
| actions/cache v6 client | Yes |
| Mixed Docker + JavaScript | Yes |
| Legacy, unknown, or unresolved | Yes (fail closed) |

## Validation

- `mise exec -- go test ./internal/compiler ./internal/plan ./internal/cli ./internal/buildkite ./internal/runtime`
- `mise run check`
- `mise run smoke:profile`
- hosted artifacts proof: https://buildkite.com/buildkite/buildkite-gha-examples/builds/18
- hosted advanced proof: https://buildkite.com/buildkite/buildkite-gha-examples/builds/19

The hosted proofs ran at `b3062d8c38ce44012a9b6161fa73ec0ae964b5a7`. Artifact consumer, Docker/native exercise, both verifier matrix jobs, and fan-in had no mise section; JavaScript-capable producer and quality jobs retained mise. Artifact upload/download, Docker action/output, warnings/summaries, matrix fan-out, and fan-in all passed.

A subsequent review fix at `eb48e04679217f9e72af2f2cca6ebfd4c691def3` prevents pre-checkout job-container startup from conservatively requesting Node for a trusted v7 no-mise plan. Its checkout-to-local-composite container regression test and the full aggregate gate pass. The final follow-up only simplifies the internal compiler return path and aligns user-facing docs; it does not alter the hosted classification paths.