### PR TITLE
docs: clarify pipeline and workload ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,17 @@ cancellation, and the build UI.
 
 ## Buildkite controls the pipeline; the workflow describes the workload
 
-A GitHub Actions workflow combines two concerns: `on:` and related settings
-control when GitHub creates a workflow run, while `jobs` and `steps` describe
-the work in that run. `buildkite-gha` imports only the supported workload
-portion into a Buildkite build that already exists.
+A GitHub Actions workflow combines two concerns: run triggers and event filters
+under `on:` control when GitHub creates a workflow run, while `jobs` and `steps`
+describe the work in that run. `buildkite-gha` imports only the supported
+workload portion into a Buildkite build that already exists. The supported
+local `on.workflow_call` interface is workload composition, not trigger setup.
 
 Buildkite pipeline integrations, settings, schedules, and manual or API build
 requests decide when to create a build. The initial Buildkite pipeline
 definition then invokes the plugin, which dynamically uploads the supported
-workflow jobs into that build. The workflow's `on:` block neither creates nor
-filters Buildkite builds.
+workflow jobs into that build. The workflow's run triggers and event filters
+neither create nor filter Buildkite builds.
 
 Buildkite configuration also remains authoritative for agent targeting and
 protected capabilities. Workflow settings such as `runs-on`, `permissions`,
@@ -209,7 +210,7 @@ runtime behavior. JSON output is available with `--format json`.
 
 | GitHub Actions | Buildkite |
 | --- | --- |
-| `on:` and event filters | Not translated; Buildkite configuration creates the build |
+| Run triggers and event filters under `on:` | Not translated; Buildkite configuration creates the build |
 | Workflow run | Existing Buildkite build |
 | Job | Command job |
 | Matrix entry | Command job with a stable key |

--- a/README.md
+++ b/README.md
@@ -15,6 +15,25 @@ cancellation, and the build UI.
 > private actions and workflow secrets other than the explicitly scoped
 > `secrets.GITHUB_TOKEN` contract remain rejected.
 
+## Buildkite controls the pipeline; the workflow describes the workload
+
+A GitHub Actions workflow combines two concerns: `on:` and related settings
+control when GitHub creates a workflow run, while `jobs` and `steps` describe
+the work in that run. `buildkite-gha` imports only the supported workload
+portion into a Buildkite build that already exists.
+
+Buildkite pipeline integrations, settings, schedules, and manual or API build
+requests decide when to create a build. The initial Buildkite pipeline
+definition then invokes the plugin, which dynamically uploads the supported
+workflow jobs into that build. The workflow's `on:` block neither creates nor
+filters Buildkite builds.
+
+Buildkite configuration also remains authoritative for agent targeting and
+protected capabilities. Workflow settings such as `runs-on`, `permissions`,
+environments, and concurrency are honored only within the explicitly supported
+and admitted boundaries in the [support matrix](docs/compatibility.md#support-matrix);
+they cannot change Buildkite pipeline settings or grant themselves authority.
+
 ## Try an existing workflow
 
 Add the [GitHub Actions Buildkite
@@ -190,7 +209,8 @@ runtime behavior. JSON output is available with `--format json`.
 
 | GitHub Actions | Buildkite |
 | --- | --- |
-| Workflow run | Build |
+| `on:` and event filters | Not translated; Buildkite configuration creates the build |
+| Workflow run | Existing Buildkite build |
 | Job | Command job |
 | Matrix entry | Command job with a stable key |
 | `needs` | `depends_on` plus verified result transport |
@@ -206,12 +226,18 @@ too.
 
 ```diagram
 ┌──────────────────────────┐
-│ Actions workflow + event │
+│ Buildkite configuration  │
+│ creates the build        │
 └────────────┬─────────────┘
              ▼
+┌──────────────────────────┐    ┌──────────────────────────┐
+│ Existing Buildkite build │◀───│ Actions workflow + event │
+│ invokes the importer     │    │ snapshot (workload input)│
+└────────────┬─────────────┘    └──────────────────────────┘
+             ▼
 ┌──────────────────────────┐
-│ Validate and compile     │
-│ jobs, matrices, policy   │
+│ Validate, compile, and   │
+│ dynamically upload jobs │
 └────────────┬─────────────┘
              ▼
 ┌──────────────────────────┐

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -12,7 +12,7 @@ Buildkite separates them, and `buildkite-gha` preserves that boundary:
 
 | Concern | Authoritative configuration |
 | --- | --- |
-| Build creation, repository events, branch/tag/PR filters, schedules, and manual builds | Buildkite pipeline integrations, settings, schedules, or manual/API build requests. Workflow `on:` is not imported. |
+| Build creation, repository events, branch/tag/PR filters, schedules, and manual builds | Buildkite pipeline integrations, settings, schedules, or manual/API build requests. Workflow run triggers and event filters are not imported. |
 | Steps in an existing build | The initial Buildkite pipeline definition plus dynamic pipeline uploads. The plugin adds admitted workflow jobs here. |
 | Job graph and step behavior | The supported `jobs`, matrices, `needs`, conditions, and `steps` subset in the selected Actions workflow. |
 | Agents and protected capabilities | Buildkite pipeline/organization configuration and admission policy. Workflow runner, permission, environment, and credential declarations are requests, not grants. |
@@ -20,7 +20,9 @@ Buildkite separates them, and `buildkite-gha` preserves that boundary:
 The imported workflow therefore cannot create, suppress, or reconfigure a
 Buildkite build. Some workflow-level execution controls, such as the documented
 concurrency subset, are translated into steps within the existing build; that
-does not make the workflow a source of Buildkite pipeline settings.
+does not make the workflow a source of Buildkite pipeline settings. The
+supported local `on.workflow_call` interface composes imported workloads and is
+documented separately in the support matrix; it is not Buildkite trigger setup.
 
 ## The current execution profile
 
@@ -72,7 +74,7 @@ service.
 
 | GitHub Actions area | Status | Current boundary |
 | --- | --- | --- |
-| `on:` and event filters | Not supported | Buildkite owns build creation and triggers. The plugin derives `pull_request` for pull-request builds and `push` for every other build; it does not create `schedule` or `workflow_dispatch` events or inputs. Direct CLI event snapshots can provide another event name, but the workflow's `on:` block is not matched and cannot create or suppress a Buildkite build. |
+| Run triggers and event filters under `on:` | Not supported | Buildkite owns build creation and triggers. The plugin derives `pull_request` for pull-request builds and `push` for every other build; it does not create `schedule` or `workflow_dispatch` events or inputs. Direct CLI event snapshots can provide another event name, but workflow trigger entries are not matched and cannot create or suppress a Buildkite build. `on.workflow_call` is covered by the local reusable-workflows row below. |
 | Linux x86-64 host jobs and `runs-on` | Supported subset | `ubuntu-latest`, `ubuntu-24.04`, and `ubuntu-22.04` are accepted. The released plugin configuration targets `hosted`; the current source CLI uses Buildkite defaults unless `BUILDKITE_GHA_TARGET_QUEUE` selects a queue. This is label validation, not Ubuntu image parity. |
 | Static job graphs and `needs` | Supported | Dependencies, matrix fan-out/fan-in, logical results, and bounded outputs are transported between generated jobs. Retrying one producer can make result selection ambiguous; retry the whole build. |
 | Static matrices | Supported subset | Typed rows, `include`, `exclude`, compile-time `github`/event/`vars` values and `fromJSON`, exact dependency fan-out, and literal `max-parallel` are supported, with at most 256 expanded instances per job. Runtime matrices from `needs` or `steps` are not supported. `strategy.fail-fast` is accepted but not enforced: every expanded Buildkite job is uploaded and siblings are not canceled after a failure. |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -5,6 +5,23 @@ This guide describes the behavior available to users today. The
 internals, future product ideas, and deferred decisions; those are not support
 promises unless they appear here.
 
+## Pipeline configuration and workload are separate
+
+GitHub Actions puts run creation and workload definition in one workflow file.
+Buildkite separates them, and `buildkite-gha` preserves that boundary:
+
+| Concern | Authoritative configuration |
+| --- | --- |
+| Build creation, repository events, branch/tag/PR filters, schedules, and manual builds | Buildkite pipeline integrations, settings, schedules, or manual/API build requests. Workflow `on:` is not imported. |
+| Steps in an existing build | The initial Buildkite pipeline definition plus dynamic pipeline uploads. The plugin adds admitted workflow jobs here. |
+| Job graph and step behavior | The supported `jobs`, matrices, `needs`, conditions, and `steps` subset in the selected Actions workflow. |
+| Agents and protected capabilities | Buildkite pipeline/organization configuration and admission policy. Workflow runner, permission, environment, and credential declarations are requests, not grants. |
+
+The imported workflow therefore cannot create, suppress, or reconfigure a
+Buildkite build. Some workflow-level execution controls, such as the documented
+concurrency subset, are translated into steps within the existing build; that
+does not make the workflow a source of Buildkite pipeline settings.
+
 ## The current execution profile
 
 The production plugin and its bundled `upload` command default to one fixed
@@ -55,7 +72,7 @@ service.
 
 | GitHub Actions area | Status | Current boundary |
 | --- | --- | --- |
-| `on:` and event filters | Not supported | Buildkite owns triggers. The plugin derives `pull_request` for pull-request builds and `push` for every other build; it does not create `schedule` or `workflow_dispatch` events or inputs. Direct CLI event snapshots can provide another event name, but the workflow's `on:` block is not matched. |
+| `on:` and event filters | Not supported | Buildkite owns build creation and triggers. The plugin derives `pull_request` for pull-request builds and `push` for every other build; it does not create `schedule` or `workflow_dispatch` events or inputs. Direct CLI event snapshots can provide another event name, but the workflow's `on:` block is not matched and cannot create or suppress a Buildkite build. |
 | Linux x86-64 host jobs and `runs-on` | Supported subset | `ubuntu-latest`, `ubuntu-24.04`, and `ubuntu-22.04` are accepted. The released plugin configuration targets `hosted`; the current source CLI uses Buildkite defaults unless `BUILDKITE_GHA_TARGET_QUEUE` selects a queue. This is label validation, not Ubuntu image parity. |
 | Static job graphs and `needs` | Supported | Dependencies, matrix fan-out/fan-in, logical results, and bounded outputs are transported between generated jobs. Retrying one producer can make result selection ambiguous; retry the whole build. |
 | Static matrices | Supported subset | Typed rows, `include`, `exclude`, compile-time `github`/event/`vars` values and `fromJSON`, exact dependency fan-out, and literal `max-parallel` are supported, with at most 256 expanded instances per job. Runtime matrices from `needs` or `steps` are not supported. `strategy.fail-fast` is accepted but not enforced: every expanded Buildkite job is uploaded and siblings are not canceled after a failure. |
@@ -202,12 +219,14 @@ final `wait-all` before post-action cleanup. Use `cancel: <step-id>` for targete
 cancellation or `parallel:` for a fixed inline group. These controls preserve
 one job workspace and lifecycle.
 
-### Buildkite owns triggers
+### Buildkite owns build creation and triggers
 
 Select the workflow explicitly in the plugin and configure pipeline triggers in
 Buildkite. `buildkite-gha` uses the event snapshot to populate Actions contexts;
 it does not subscribe to GitHub events or turn workflow `on:` entries into
-Buildkite triggers.
+Buildkite triggers. The initial Buildkite pipeline invokes the importer after a
+build exists, and the importer can only add steps to that build through dynamic
+pipeline upload.
 
 The plugin derives `pull_request` for Buildkite pull request builds and `push`
 for branch, tag, scheduled, and manual builds. It does not currently provide

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -45,14 +45,14 @@ one workflow file. This project deliberately imports only the workload side.
 Buildkite pipeline integrations, settings, schedules, and manual or API build
 requests create the build and establish build-level policy. The initial
 Buildkite pipeline definition invokes `buildkite-gha`; dynamic upload then adds
-admitted workflow jobs to that existing build. Workflow `on:` configuration is
-not a source of Buildkite trigger or pipeline configuration.
+admitted workflow jobs to that existing build. Workflow run triggers and event
+filters are not a source of Buildkite trigger or pipeline configuration.
 
 The unit of translation is the Actions job:
 
 | GitHub Actions concept | Buildkite representation |
 | --- | --- |
-| `on:` and event filters | Not translated; Buildkite configuration creates the build |
+| Run triggers and event filters under `on:` | Not translated; Buildkite configuration creates the build |
 | Workflow run | Existing Buildkite build |
 | Workflow job or matrix entry | Buildkite command job |
 | `needs` | `depends_on` plus producer-attributed result manifests |
@@ -95,7 +95,7 @@ Every imported workflow runs inside a Buildkite build that already exists.
 Buildkite owns build creation, trigger policy, build-level cancellation and
 skip policy, agent targeting, the job graph, and the live job logs. The initial
 pipeline definition and subsequent dynamic uploads add steps to that build;
-workflow `on:` configuration does not create or reconfigure the pipeline.
+workflow run-trigger configuration does not create or reconfigure the pipeline.
 
 The selected workflow controls only its admitted workload: generated jobs,
 dependencies, matrices, and runtime steps. Runner labels, permissions,
@@ -1016,11 +1016,14 @@ integration creates the build according to Buildkite configuration. The
 initial pipeline definition then invokes the importer; `upload` only adds steps
 within that existing build.
 
-Workflow `on:` is parsed as source syntax but is not matched during compilation
-and must not be treated as Buildkite trigger policy. In particular, `compile`
-and `upload` do not create or update webhooks, branch/path filters, schedules,
-manual-build forms, or other pipeline settings, and `on:` cannot suppress a
-Buildkite build that has already started.
+Run-trigger entries and event filters under workflow `on:` are parsed as source
+syntax but are not matched during compilation and must not be treated as
+Buildkite trigger policy. In particular, `compile` and `upload` do not create or
+update webhooks, branch/path filters, schedules, manual-build forms, or other
+pipeline settings, and workflow triggers cannot suppress a Buildkite build that
+has already started. The supported local `on.workflow_call` interface is
+different: it composes imported workloads and does not configure Buildkite
+triggers.
 
 An event adapter may provide a bounded Actions-compatible context for an
 already-created build. The current plugin maps pull-request builds to
@@ -1030,10 +1033,11 @@ fields from incomplete environment variables. If required context is
 unavailable, the affected compatibility feature fails with the missing adapter
 capability rather than claiming provider parity.
 
-A future migration tool may inspect `on:` and propose equivalent Buildkite
-pipeline settings, schedules, or manual inputs. That must be an explicit,
-reviewable setup operation applied outside workflow compilation, not a hidden
-side effect of importing workload into a running build.
+A future migration tool may inspect run-trigger entries under `on:` and propose
+equivalent Buildkite pipeline settings, schedules, or manual inputs. That must
+be an explicit, reviewable setup operation applied outside workflow
+compilation, not a hidden side effect of importing workload into a running
+build.
 
 ### Secrets, permissions, tokens, and untrusted changes
 
@@ -2499,9 +2503,9 @@ unknown plan.
 ## Key learnings from pressure-testing
 
 - GitHub Actions combines run-trigger configuration and workload in one file;
-  Buildkite does not. Importing `jobs` must not make workflow `on:` a hidden
-  source of Buildkite pipeline settings. Any future trigger migration belongs
-  in explicit, reviewable setup tooling outside `compile` and `upload`.
+  Buildkite does not. Importing `jobs` must not make workflow trigger entries a
+  hidden source of Buildkite pipeline settings. Any future trigger migration
+  belongs in explicit, reviewable setup tooling outside `compile` and `upload`.
 - A content digest establishes plan integrity, not authority. Protected
   capabilities require authenticated Buildkite job identity, independently
   verified provider provenance, and a narrow control-plane grant.

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -2,7 +2,7 @@
 
 Status: **Active**
 Date: 2026-07-22
-Last reviewed: 2026-08-07
+Last reviewed: 2026-08-08
 Target repository: `buildkite/buildkite-gha`
 
 > This is the active product and implementation plan. It records future UX,
@@ -40,11 +40,20 @@ migration, but it is not part of the workflow execution control plane. This
 also permits a repository to move to Cursor Origin without replacing the
 execution architecture.
 
+GitHub Actions normally combines pipeline control and workload declaration in
+one workflow file. This project deliberately imports only the workload side.
+Buildkite pipeline integrations, settings, schedules, and manual or API build
+requests create the build and establish build-level policy. The initial
+Buildkite pipeline definition invokes `buildkite-gha`; dynamic upload then adds
+admitted workflow jobs to that existing build. Workflow `on:` configuration is
+not a source of Buildkite trigger or pipeline configuration.
+
 The unit of translation is the Actions job:
 
 | GitHub Actions concept | Buildkite representation |
 | --- | --- |
-| Workflow run | Buildkite build |
+| `on:` and event filters | Not translated; Buildkite configuration creates the build |
+| Workflow run | Existing Buildkite build |
 | Workflow job or matrix entry | Buildkite command job |
 | `needs` | `depends_on` plus producer-attributed result manifests |
 | `runs-on` | Linux compatibility validation and optional policy-selected agent selectors |
@@ -80,11 +89,22 @@ of record.
 
 ## Product principles
 
-### Buildkite is authoritative
+### Buildkite controls the pipeline; the workflow describes the workload
 
-Every imported workflow is a normal Buildkite build. Buildkite owns the job
-graph and displays the live job logs. There is no shadow GitHub workflow run to
-reconcile and no requirement to visit GitHub to understand progress.
+Every imported workflow runs inside a Buildkite build that already exists.
+Buildkite owns build creation, trigger policy, build-level cancellation and
+skip policy, agent targeting, the job graph, and the live job logs. The initial
+pipeline definition and subsequent dynamic uploads add steps to that build;
+workflow `on:` configuration does not create or reconfigure the pipeline.
+
+The selected workflow controls only its admitted workload: generated jobs,
+dependencies, matrices, and runtime steps. Runner labels, permissions,
+environments, credentials, and other protected capabilities are untrusted
+requests checked against Buildkite configuration and admission policy, not
+authority granted by the workflow. Supported workflow concurrency may affect
+generated jobs, but cross-build policy remains a Buildkite pipeline concern.
+There is no shadow GitHub workflow run to reconcile and no requirement to visit
+GitHub to understand progress.
 
 ### Event identity and capability issuance are the security boundary
 
@@ -991,22 +1011,29 @@ without exposing GitHub's private service credentials.
 ### Triggers and workflow `on`
 
 `buildkite-gha` does not itself listen for repository events. A Buildkite
-pipeline, API caller, or future Origin integration creates the build.
+pipeline integration, schedule, manual or API build request, or future Origin
+integration creates the build according to Buildkite configuration. The
+initial pipeline definition then invokes the importer; `upload` only adds steps
+within that existing build.
 
-The compiler uses `on` to validate that the supplied event should run the
-workflow and to reproduce branch/path/input filtering. Event adapters must
-cover, in phases:
+Workflow `on:` is parsed as source syntax but is not matched during compilation
+and must not be treated as Buildkite trigger policy. In particular, `compile`
+and `upload` do not create or update webhooks, branch/path filters, schedules,
+manual-build forms, or other pipeline settings, and `on:` cannot suppress a
+Buildkite build that has already started.
 
-- `push`;
-- `pull_request`;
-- `workflow_dispatch`-style manual input;
-- `schedule` mapped to a Buildkite schedule;
-- `workflow_call`; and
-- additional repository events as provider integrations mature.
+An event adapter may provide a bounded Actions-compatible context for an
+already-created build. The current plugin maps pull-request builds to
+`pull_request` and all other builds to `push`; richer schedule, manual-input,
+or provider event contexts remain future work. The plan must not invent event
+fields from incomplete environment variables. If required context is
+unavailable, the affected compatibility feature fails with the missing adapter
+capability rather than claiming provider parity.
 
-The plan must not invent a GitHub event payload from incomplete environment
-variables. If required event fields are unavailable, validation fails with the
-missing fields and the required adapter capability.
+A future migration tool may inspect `on:` and propose equivalent Buildkite
+pipeline settings, schedules, or manual inputs. That must be an explicit,
+reviewable setup operation applied outside workflow compilation, not a hidden
+side effect of importing workload into a running build.
 
 ### Secrets, permissions, tokens, and untrusted changes
 
@@ -2471,6 +2498,10 @@ unknown plan.
 
 ## Key learnings from pressure-testing
 
+- GitHub Actions combines run-trigger configuration and workload in one file;
+  Buildkite does not. Importing `jobs` must not make workflow `on:` a hidden
+  source of Buildkite pipeline settings. Any future trigger migration belongs
+  in explicit, reviewable setup tooling outside `compile` and `upload`.
 - A content digest establishes plan integrity, not authority. Protected
   capabilities require authenticated Buildkite job identity, independently
   verified provider provenance, and a narrow control-plane grant.


### PR DESCRIPTION
## Summary

- explain that Buildkite configuration creates the build and owns trigger and build-level policy, while `buildkite-gha` imports only the admitted workflow workload
- show how the initial Buildkite pipeline invokes the importer and dynamic pipeline upload adds generated jobs to the existing build
- clarify that run triggers and event filters under workflow `on:` are not translated, while supported local `on.workflow_call` declarations compose imported workloads
- document runner, permission, environment, and credential declarations as requests rather than grants
- correct the active design plan so any future trigger migration is explicit setup tooling, not a side effect of `compile` or `upload`

## Validation

- `mise run smoke:local`
- internal Markdown link and anchor validation (25 links across 7 README/docs files)
- support-matrix status validation (39 rows)
- `git diff --check`