### PR TITLE
Support github.token action input defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,9 @@ workflows built from:
 - timeouts, `continue-on-error`, masking, summaries, warning/error annotations,
   and pre/main/post actions;
 - public, credential-free checkout of the event repository at its exact commit;
-- short-lived `secrets.GITHUB_TOKEN` values scoped to explicit workflow or job
-  `permissions` for the event repository;
+- short-lived GitHub tokens scoped to explicit workflow or job `permissions`
+  for the event repository, consumed through `secrets.GITHUB_TOKEN` or an
+  effective action metadata input default that references `github.token`;
 - bounded native upload and exact-name download for the audited artifact v4
   commits; and
 - the audited `actions/cache` v6.1.0 commit through the official Buildkite
@@ -152,8 +153,8 @@ It is not currently a fit for workflows that require:
   explicit pipeline-repository checkout described in the compatibility guide;
 - ordinary workflow secrets—the scoped `secrets.GITHUB_TOKEN` contract is the
   only workflow-visible secret exception;
-- `github.token`, ambient `GITHUB_TOKEN`, GitHub-compatible OIDC, or protected
-  queues;
+- workflow-authored `github.token`, ambient `GITHUB_TOKEN`, GitHub-compatible
+  OIDC, or protected queues;
 - `actions/cache` v4/v5 or unrecognized v6 commits, artifact
   merge/all/pattern/ID modes, or cross-run downloads;
 - runtime condition access to the `github.event` payload, or condition

--- a/docs/architecture/0003-protected-capability-control-plane.md
+++ b/docs/architecture/0003-protected-capability-control-plane.md
@@ -31,8 +31,8 @@ Phase 6 therefore starts the protected path with a signed **no-op grant**. It
 proves authentication, provenance, policy, signing, verification, expiry, and
 audit boundaries while carrying an empty capability set and returning no
 credential. General private source, non-provider secrets, GitHub authority
-beyond the fixed checkout and scoped `secrets.GITHUB_TOKEN` exceptions,
-environments, and compatibility OIDC remain deferred.
+beyond the fixed checkout and scoped workflow-token exceptions, environments,
+and compatibility OIDC remain deferred.
 
 ## Decision
 
@@ -251,12 +251,14 @@ invalid tokens, disabled service responses, and unavailable/rate-limited
 responses fail closed with bounded diagnostics.
 
 A second bounded integration uses the same endpoint for a synthetic
-`secrets.GITHUB_TOKEN`. A workflow must declare an explicit, non-empty
-permission mapping and statically reference that exact secret. The compiler
-emits the API-normalized permission map into a v6 plan, adds
-`provider-token-write`, and records same-process `workflow-permissions`
-provenance. Upload admission accepts only that exact compiler provenance. A
-serialized plan cannot self-authorize the capability.
+`secrets.GITHUB_TOKEN` or an action metadata input default that references
+`github.token`. A workflow must declare an explicit, non-empty permission
+mapping and either statically reference that exact secret or invoke an action
+whose effective default statically references the token. The compiler emits the
+API-normalized permission map into a v6 plan, adds `provider-token-write`, and
+records same-process `workflow-permissions` provenance. Upload admission accepts
+only that exact compiler provenance. A serialized plan cannot self-authorize
+the capability.
 
 The runtime requests one token for the plan's exact event repository and exact
 permission map. It validates both independently, masks the returned token, and
@@ -264,8 +266,9 @@ requires Agent redaction registration before making the synthetic secret
 available to expression evaluation. Job-level permissions replace workflow
 defaults; flattened local reusable workflows can only narrow caller authority.
 Permission aliases, implicit defaults, empty grants, and `id-token` fail
-closed. `github.token` and ambient `GITHUB_TOKEN` environment injection remain
-unsupported.
+closed. `github.token` is exposed only while evaluating effective action
+metadata input defaults; workflow-authored references and ambient
+`GITHUB_TOKEN` environment injection remain unsupported.
 
 These exceptions do not establish authenticated provider event, fork, or actor
 provenance. The server's independent pipeline-repository comparison,
@@ -333,14 +336,14 @@ record; a successful job alone does not prove policy or audit behavior.
 
 ## Deferred decisions
 
-Apart from the fixed read-only pipeline-repository checkout and explicit scoped
-`secrets.GITHUB_TOKEN` exceptions above, this ADR does not authorize or choose
-storage for private actions, reusable workflow source, selected non-provider
-secrets, `github.token`, environment grants, or compatibility OIDC claims. It
-does not choose a secret manager, broader cross-repository GitHub App authority,
-customer policy language, administrative UI, or production service hostname.
-Those decisions require separate reviewed slices after the no-op boundary is
-proven.
+Apart from the fixed read-only pipeline-repository checkout and scoped token
+exceptions above, this ADR does not authorize or choose storage for private
+actions, reusable workflow source, selected non-provider secrets, general
+workflow access to `github.token`, environment grants, or compatibility OIDC
+claims. It does not choose a secret manager, broader cross-repository GitHub
+App authority, customer policy language, administrative UI, or production
+service hostname. Those decisions require separate reviewed slices after the
+no-op boundary is proven.
 
 The existing cache-v2 GHAC token exchange remains separate. Cache tokens are
 minted through the current Buildkite job, scoped by the cache service, and

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -85,7 +85,7 @@ service.
 | Timeouts and `continue-on-error` | Supported subset | Literal step/job timeouts up to 360 minutes and step-level `continue-on-error` are supported. Expression-valued settings and job-level `continue-on-error` are not supported. |
 | Workflow and job concurrency | Supported subset | Statically resolvable groups become repository-scoped, case-insensitive Buildkite concurrency groups. Workflow groups use an ordered opening/closing gate; job groups use `concurrency: 1`. Buildkite queues all waiting entries instead of replacing GitHub's pending entry. Workflow-level literal `cancel-in-progress: true` emits a warning but does not cancel; job-level true and expression-valued cancellation are not supported. |
 | Local reusable workflows | Supported subset | Statically resolvable `./.github/workflows/...` calls, typed static inputs, nesting, caller-visible aggregate results, and declared outputs mapped directly from `jobs.<job>.outputs.<name>` are supported. Literal/compound output mappings, call-level conditions, call secrets, remote source, dynamic paths/inputs/matrices, and called-workflow top-level concurrency are not supported. |
-| `permissions` | Supported subset | Explicit canonical permission maps are carried only for a statically referenced `secrets.GITHUB_TOKEN`; job permissions replace workflow permissions and local reusable workflows may narrow them. Implicit defaults, `{}`, `read-all`, `write-all`, and `id-token` do not grant authority. |
+| `permissions` | Supported subset | Explicit canonical permission maps are carried only for a statically referenced `secrets.GITHUB_TOKEN` or an effective action metadata input default that statically references `github.token`; job permissions replace workflow permissions and local reusable workflows may narrow them. Implicit defaults, `{}`, `read-all`, `write-all`, and `id-token` do not grant authority. |
 | Job and service containers | Not admitted | Literal Linux container images, environment, ports, persistent job containers, and services are implemented and runtime-proven. Production `hosted-tokenless` upload rejects job/service-container provenance. Credentials, volumes, arbitrary options, private images, and privileged containers are not supported. |
 | Dynamic graph expansion | Not supported | Matrices or `needs` derived from runtime outputs and other runtime-created jobs are rejected. |
 | Deployment environments and approvals | Not supported | Environment secrets, protection rules, reviewers, and deployment approval/state parity are not implemented. |
@@ -119,7 +119,7 @@ service.
 | Private repositories | Supported subset | Direct upload can opt into read-only checkout of the pipeline's exact GitHub repository. Alternate repositories, private actions, and private reusable workflows are not supported. |
 | `secrets.GITHUB_TOKEN` | Supported subset | A static reference can receive one short-lived token for the exact event repository when the job has a non-empty explicit permission map and the organization enables the job-bound token service. It is not injected as an ambient environment variable. |
 | Other workflow secrets | Not admitted | The runtime has a plan-declared `BUILDKITE_GHA_SECRET_<NAME>` resolver boundary, but `hosted-tokenless` admission rejects its `secrets` capability. Reusable-workflow secret passing and environment secrets are also rejected. |
-| `github.token` and ambient `GITHUB_TOKEN` | Not supported | Only the explicit `secrets.GITHUB_TOKEN` contract above is populated. |
+| `github.token` and ambient `GITHUB_TOKEN` | Supported subset | `github.token` is populated only while evaluating an effective action metadata input default and uses the same scoped-token contract as `secrets.GITHUB_TOKEN`. Workflow-authored `github.token` and ambient `GITHUB_TOKEN` remain unavailable. An explicitly supplied action input, including an empty value, suppresses its metadata default. |
 | OIDC | Not supported | GitHub-compatible and migration OIDC flows, including `id-token`, are deferred. |
 | Windows and macOS | Not supported | Runner labels fail validation. Linux arm64 is also outside the current Linux x86-64 distribution/runtime contract. |
 | GitHub-hosted image parity | Not supported | Accepted Ubuntu labels do not promise GitHub's installed tools, image updates, filesystem layout, or service configuration. The selected Buildkite agents must provide the workflow's external tools. |
@@ -266,9 +266,11 @@ repositories or refs and credential persistence remain unsupported.
 
 ### Explicit permissions provide a scoped workflow token
 
-A job that statically references `${{ secrets.GITHUB_TOKEN }}` receives one
-short-lived GitHub installation token for the exact event repository when it
-also has a non-empty, explicit `permissions` mapping:
+A job that statically references `${{ secrets.GITHUB_TOKEN }}`, or uses an
+action with an effective metadata input default that statically references
+`${{ github.token }}`, receives one short-lived GitHub installation token for
+the exact event repository when it also has a non-empty, explicit `permissions`
+mapping:
 
 ```yaml
 permissions:
@@ -288,8 +290,7 @@ mapping replaces the workflow-level mapping rather than merging with it. Local
 reusable workflows inherit the caller's effective permissions and can only
 narrow them. `none` removes a permission. Omitted permissions, `{}`,
 `read-all`, `write-all`, and `id-token` do not produce a token; a static
-`GITHUB_TOKEN` reference without a non-empty effective mapping fails
-compilation.
+token reference without a non-empty effective mapping fails compilation.
 
 The compiler normalizes names such as `pull-requests` to the Agent API's
 `pull_requests`, emits the exact map into a v6 plan, and records same-process
@@ -300,10 +301,13 @@ its own permission allowlist and organization enablement. The token is
 registered with runtime and Agent redaction before expressions or steps can use
 it, and result values containing it are scrubbed.
 
-Only the explicit `secrets.GITHUB_TOKEN` context value is populated. The token
-is not an ambient `GITHUB_TOKEN` environment variable and `github.token`
-remains unsupported. Other secrets still use the existing explicit
-`BUILDKITE_GHA_SECRET_<NAME>` boundary and are not enabled by this feature.
+An explicit `secrets.GITHUB_TOKEN` reference continues to resolve through the
+scoped-token contract. For compatible actions, `github.token` is additionally
+populated only while evaluating an effective metadata input default; it remains
+unavailable to workflow-authored expressions. The token is not an ambient
+`GITHUB_TOKEN` environment variable. Other secrets still use the existing
+explicit `BUILDKITE_GHA_SECRET_<NAME>` boundary and are not enabled by this
+feature.
 
 This job-bound service does not independently establish fork or actor trust.
 Pipelines that permit workflow changes from untrusted sources must apply the
@@ -546,8 +550,8 @@ select the `hosted` queue.
 It requires `BUILDKITE=true` and `BUILDKITE_STEP_KEY`. Without `--event-path`,
 it derives a bounded compatibility snapshot from the current Buildkite build.
 With `--event-path`, it uses that explicit snapshot. Both paths remain
-unattested. Apart from the documented scoped `secrets.GITHUB_TOKEN` contract,
-they remain tokenless unless `--private-checkout` is explicitly selected; that
+unattested. Apart from the documented scoped workflow-token contract, they
+remain tokenless unless `--private-checkout` is explicitly selected; that
 checkout exception is confined to the adapter and independently
 repository-bound by the Agent service.
 

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -1076,15 +1076,17 @@ again at credential exchange. Runtime enforcement must never treat a plan's
 self-declared event, trust classification, signature, or capability list as
 sufficient authority.
 
-For the future general capability path, populate `github.token` or ambient
-`GITHUB_TOKEN` only from a repository- and permission-scoped GitHub App
-installation token brokered for the authenticated job. The current narrow
-exception populates only an explicit `secrets.GITHUB_TOKEN` reference; the other
-two forms remain unsupported. This approximates but does not duplicate native
-`GITHUB_TOKEN`: app identity, endpoint support, expiration, and event-recursion
-behavior can differ and must be documented. Do not invent a token or silently
-grant write access. Validation must identify actions and expressions requiring
-a provider token when no compatible grant can be issued.
+For the future general capability path, populate workflow-authored
+`github.token` or ambient `GITHUB_TOKEN` only from a repository- and
+permission-scoped GitHub App installation token brokered for the authenticated
+job. The current narrow exception populates an explicit
+`secrets.GITHUB_TOKEN` reference and effective action metadata input defaults
+that reference `github.token`; workflow-authored `github.token` and ambient
+environment injection remain unsupported. This approximates but does not
+duplicate native `GITHUB_TOKEN`: app identity, endpoint support, expiration,
+and event-recursion behavior can differ and must be documented. Do not invent a
+token or silently grant write access. Validation must identify actions and
+expressions requiring a provider token when no compatible grant can be issued.
 
 ### Installation and release model
 
@@ -1265,8 +1267,8 @@ Explicitly defer from beta unless implementation evidence changes the order:
 - remote private reusable workflows;
 - private checkout beyond the explicit read-only pipeline-repository exception,
   and all private actions;
-- protected secrets and GitHub authority beyond the scoped
-  `secrets.GITHUB_TOKEN` exception;
+- protected secrets and GitHub authority beyond the scoped token exception for
+  `secrets.GITHUB_TOKEN` and effective action metadata input defaults;
 - dynamic matrices and other runtime graph generation;
 - job-level replacement;
 - deployment environments and approval parity;
@@ -1964,8 +1966,8 @@ the narrowest available boundary:
 - public checkout under GitHub and Cursor Origin provider adapters;
 - explicitly enabled private checkout of the pipeline's exact GitHub
   repository through the current job's scoped Agent token endpoint; and
-- compiler-authorized workflow `GITHUB_TOKEN` requests for the pipeline's exact
-  GitHub repository and explicit permission map through that same job endpoint;
+- compiler-authorized workflow token requests for the pipeline's exact GitHub
+  repository and explicit permission map through that same job endpoint;
 - step summaries and annotations.
 
 Prefer documented Buildkite storage and Agent interfaces. If an action toolkit
@@ -2014,11 +2016,12 @@ repository. Its local request, admission, redaction, askpass, and leakage
 boundaries are tested; hosted proof remains pending endpoint deployment,
 organization enablement, installer wiring, and a private-repository canary.
 The job-bound portion of slice 5 now compiles explicit workflow and job
-permissions into a v6 plan and provides a synthetic `secrets.GITHUB_TOKEN`
-through the current-job endpoint, with independent runtime validation,
-redaction, and compiler-proven upload admission. Hosted proof remains pending.
-Private actions and reusable workflows remain deferred. Cursor Origin public
-checkout remains pending on its provider context/source contract. Slice 3's
+permissions into a v6 plan and provides a synthetic `secrets.GITHUB_TOKEN` or
+an action-default-only `github.token` value through the current-job endpoint,
+with independent runtime validation, redaction, and compiler-proven upload
+admission. Hosted proof remains pending. Private actions and reusable workflows
+remain deferred. Cursor Origin public checkout remains pending on its provider
+context/source contract. Slice 3's
 proposed
 [control-plane contract](../architecture/0003-protected-capability-control-plane.md)
 must establish ownership, exact OIDC audience, independent GitHub provenance,
@@ -2323,10 +2326,11 @@ The public, tokenless product path is substantial enough to harden and demo
 while the signed no-op grant proof waits for a named platform owner and the
 interfaces required by [ADR 0003](../architecture/0003-protected-capability-control-plane.md).
 Private actions and reusable workflows, workflow-visible provider tokens and
-secrets beyond the scoped `secrets.GITHUB_TOKEN` exception, environments, and
-compatible OIDC remain fail-closed during that work. The explicit
-private-checkout exception is limited to fixed read-only Git use for the
-pipeline repository. Neither narrow exception relaxes the other deferrals.
+secrets beyond the scoped `secrets.GITHUB_TOKEN` and action-metadata-default
+exceptions, environments, and compatible OIDC remain fail-closed during that
+work. The explicit private-checkout exception is limited to fixed read-only Git
+use for the pipeline repository. Neither narrow exception relaxes the other
+deferrals.
 
 The complete published installation experience is now proven. The initial CLI
 and companion plugin `v0.2.0` releases remain the subject of the repository's
@@ -2604,12 +2608,13 @@ them in the phase that first needs the capability:
    using Buildkite defaults must independently provide suitable whole-job
    isolation. Phases 6 and 9 still own authorization and queue policy for
    protected Docker capabilities and privileged workloads.
-6. The narrow workflow-visible token contract is now defined for explicit
-   `secrets.GITHUB_TOKEN` references with non-empty permission maps and exact
-   event-repository binding. `github.token`, ambient `GITHUB_TOKEN`, broader
-   provider authority, and event-provenance policy remain Phase 6 work. The
-   runtime-internal `contents:read` checkout credential remains separate;
-   tokenless workflows remain the default.
+6. The narrow token contract is now defined for explicit
+   `secrets.GITHUB_TOKEN` references and effective action metadata input
+   defaults that reference `github.token`, with non-empty permission maps and
+   exact event-repository binding. Workflow-authored `github.token`, ambient
+   `GITHUB_TOKEN`, broader provider authority, and event-provenance policy remain
+   Phase 6 work. The runtime-internal `contents:read` checkout credential
+   remains separate; tokenless workflows remain the default.
 
 ## Historical first product milestone (landed)
 

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -14,6 +14,7 @@ import (
 	actionintegration "github.com/buildkite/buildkite-gha/internal/action/integration"
 	"github.com/buildkite/buildkite-gha/internal/action/metadata"
 	"github.com/buildkite/buildkite-gha/internal/action/source"
+	"github.com/buildkite/buildkite-gha/internal/expression"
 	"github.com/buildkite/buildkite-gha/internal/plan"
 )
 
@@ -51,26 +52,51 @@ type actionLockBuilder struct {
 }
 
 type actionNode struct {
-	lock plan.ActionLock
+	lock     plan.ActionLock
+	metadata metadata.Metadata
+	children map[string]*actionNode
+	runtime  metadata.Runtime
+	native   bool
+}
+
+type actionCompilation struct {
+	selectors           []plan.ActionSelector
+	locks               []plan.ActionLock
+	capabilities        []string
+	requiresMise        bool
+	requiresGitHubToken bool
 }
 
 // compileActionLocks builds one shared action DAG for all roots. Selectors are
 // returned in the same order as refs.
 func compileActionLocks(ctx context.Context, workspace string, actionSource ActionSource, refs []string) ([]plan.ActionSelector, []plan.ActionLock, []string, bool, error) {
+	compiled, err := compileActionInvocations(ctx, workspace, actionSource, refs, nil)
+	if err != nil {
+		return nil, nil, nil, true, err
+	}
+	return compiled.selectors, compiled.locks, compiled.capabilities, compiled.requiresMise, nil
+}
+
+func compileActionInvocations(ctx context.Context, workspace string, actionSource ActionSource, refs []string, suppliedInputs []map[string]string) (actionCompilation, error) {
 	if workspace == "" {
-		return nil, nil, nil, true, fmt.Errorf("workflow path must identify a repository root")
+		return actionCompilation{}, fmt.Errorf("workflow path must identify a repository root")
+	}
+	if suppliedInputs != nil && len(suppliedInputs) != len(refs) {
+		return actionCompilation{}, fmt.Errorf("action references and supplied inputs have different lengths")
 	}
 	abs, err := filepath.Abs(workspace)
 	if err != nil {
-		return nil, nil, nil, true, fmt.Errorf("resolve workspace: %w", err)
+		return actionCompilation{}, fmt.Errorf("resolve workspace: %w", err)
 	}
 	b := &actionLockBuilder{workspace: abs, source: actionSource, nodes: map[string]*actionNode{}, ids: map[string]string{}, active: map[string]bool{}, caps: map[string]bool{}}
 	selectors := make([]plan.ActionSelector, 0, len(refs))
+	roots := make([]*actionNode, 0, len(refs))
 	for _, ref := range refs {
 		n, err := b.add(ctx, ref, 1)
 		if err != nil {
-			return nil, nil, nil, true, err
+			return actionCompilation{}, err
 		}
+		roots = append(roots, n)
 		selectors = append(selectors, plan.ActionSelector{Lock: n.lock.ID})
 	}
 	locks := make([]plan.ActionLock, 0, len(b.nodes))
@@ -83,7 +109,23 @@ func compileActionLocks(ctx context.Context, workspace string, actionSource Acti
 		caps = append(caps, c)
 	}
 	sort.Strings(caps)
-	return selectors, locks, caps, b.requiresMise, nil
+	requiresGitHubToken := false
+	if suppliedInputs != nil {
+		for i, root := range roots {
+			required, err := root.requiresGitHubToken(suppliedInputs[i])
+			if err != nil {
+				return actionCompilation{}, fmt.Errorf("compile action %q: %w", refs[i], err)
+			}
+			requiresGitHubToken = requiresGitHubToken || required
+		}
+	}
+	return actionCompilation{
+		selectors:           selectors,
+		locks:               locks,
+		capabilities:        caps,
+		requiresMise:        b.requiresMise,
+		requiresGitHubToken: requiresGitHubToken,
+	}, nil
 }
 
 func (b *actionLockBuilder) add(ctx context.Context, raw string, depth int) (*actionNode, error) {
@@ -117,14 +159,17 @@ func (b *actionLockBuilder) add(ctx context.Context, raw string, depth int) (*ac
 	if err != nil {
 		return nil, err
 	}
+	n.metadata = m
 	runtime, err := m.Runtime()
 	if err != nil {
 		return nil, err
 	}
+	n.runtime = runtime
 	if err := m.ValidateEntrypoints(runtime); err != nil {
 		return nil, err
 	}
 	if actionintegration.UsesNativeAdapter(actionintegration.Identity{Source: n.lock.Source, Repository: n.lock.Repository, Path: n.lock.Path}) {
+		n.native = true
 		return n, nil
 	}
 	if runtime == metadata.RuntimeNode20 || runtime == metadata.RuntimeNode24 {
@@ -144,11 +189,58 @@ func (b *actionLockBuilder) add(ctx context.Context, raw string, depth int) (*ac
 			}
 			if n.lock.Children == nil {
 				n.lock.Children = map[string]plan.ActionSelector{}
+				n.children = map[string]*actionNode{}
 			}
 			n.lock.Children[step.Uses] = plan.ActionSelector{Lock: child.lock.ID}
+			n.children[step.Uses] = child
 		}
 	}
 	return n, nil
+}
+
+func (n *actionNode) requiresGitHubToken(supplied map[string]string) (bool, error) {
+	if n.native {
+		return false, nil
+	}
+	required := false
+	for _, name := range sortedKeys(n.metadata.Inputs) {
+		input := n.metadata.Inputs[name]
+		if input.Default == nil || hasActionInput(supplied, name) {
+			continue
+		}
+		referencesToken, err := expression.ReferencesGitHubToken(*input.Default)
+		if err != nil {
+			return false, fmt.Errorf("action input %q default: %w", name, err)
+		}
+		required = required || referencesToken
+	}
+	if n.runtime != metadata.RuntimeComposite {
+		return required, nil
+	}
+	for i, step := range n.metadata.Runs.Steps {
+		if step.Uses == "" {
+			continue
+		}
+		child := n.children[step.Uses]
+		if child == nil {
+			return false, fmt.Errorf("composite action step %d child %q is missing", i+1, step.Uses)
+		}
+		childRequired, err := child.requiresGitHubToken(step.With)
+		if err != nil {
+			return false, fmt.Errorf("composite action step %d child %q: %w", i+1, step.Uses, err)
+		}
+		required = required || childRequired
+	}
+	return required, nil
+}
+
+func hasActionInput(inputs map[string]string, name string) bool {
+	for candidate := range inputs {
+		if strings.EqualFold(candidate, name) {
+			return true
+		}
+	}
+	return false
 }
 
 func (b *actionLockBuilder) describe(ctx context.Context, raw string) (string, plan.ActionLock, string, string, error) {

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -157,6 +157,208 @@ func TestCompileActionLocksLocalAndDedup(t *testing.T) {
 	}
 }
 
+func TestCompileActionInvocationsDetectsEffectiveGitHubTokenDefaults(t *testing.T) {
+	w := t.TempDir()
+	writeAction(t, w, "token", `name: token default
+inputs:
+  github_token:
+    default: ${{ github.token }}
+runs:
+  using: node24
+  main: index.js
+`)
+	writeAction(t, w, "actor", `name: actor default
+inputs:
+  actor:
+    default: ${{ github.actor }}
+runs:
+  using: node24
+  main: index.js
+`)
+	writeAction(t, w, "dynamic", `name: dynamic default
+inputs:
+  value:
+    default: ${{ github[env.NAME] }}
+runs:
+  using: node24
+  main: index.js
+`)
+	writeAction(t, w, "mixed", `name: mixed defaults
+inputs:
+  a_token:
+    default: ${{ github.token }}
+  z_dynamic:
+    default: ${{ github[env.NAME] }}
+runs:
+  using: node24
+  main: index.js
+`)
+
+	for _, test := range []struct {
+		name     string
+		ref      string
+		supplied map[string]string
+		want     bool
+		wantErr  string
+	}{
+		{name: "effective default", ref: "./token", want: true},
+		{name: "explicit empty input", ref: "./token", supplied: map[string]string{"github_token": ""}},
+		{name: "case-insensitive explicit input", ref: "./token", supplied: map[string]string{"GITHUB_TOKEN": "explicit"}},
+		{name: "unrelated GitHub default", ref: "./actor"},
+		{name: "dynamic GitHub index", ref: "./dynamic", wantErr: "index must be a string literal"},
+		{name: "token before dynamic GitHub index", ref: "./mixed", wantErr: "index must be a string literal"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			compiled, err := compileActionInvocations(context.Background(), w, nil, []string{test.ref}, []map[string]string{test.supplied})
+			if test.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+					t.Fatalf("compileActionInvocations() error = %v, want %q", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if compiled.requiresGitHubToken != test.want {
+				t.Fatalf("requires GitHub token = %t, want %t", compiled.requiresGitHubToken, test.want)
+			}
+		})
+	}
+}
+
+func TestCompileActionInvocationsDetectsOnlyEffectiveNestedGitHubTokenDefaults(t *testing.T) {
+	w := t.TempDir()
+	writeAction(t, w, "child", `name: child
+inputs:
+  github_token:
+    default: ${{ github.token }}
+runs:
+  using: node24
+  main: index.js
+`)
+	writeAction(t, w, "parent", `name: parent
+runs:
+  using: composite
+  steps:
+    - uses: ./child
+`)
+	writeAction(t, w, "overridden", `name: overridden parent
+runs:
+  using: composite
+  steps:
+    - uses: ./child
+      with:
+        github_token: ''
+`)
+	writeAction(t, w, "dynamic-child", `name: dynamic child
+inputs:
+  value:
+    default: ${{ github[env.NAME] }}
+runs:
+  using: node24
+  main: index.js
+`)
+	writeAction(t, w, "mixed-parent", `name: mixed parent
+runs:
+  using: composite
+  steps:
+    - uses: ./child
+    - uses: ./dynamic-child
+`)
+
+	for _, test := range []struct {
+		ref  string
+		want bool
+	}{
+		{ref: "./parent", want: true},
+		{ref: "./overridden"},
+	} {
+		compiled, err := compileActionInvocations(context.Background(), w, nil, []string{test.ref}, []map[string]string{nil})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if compiled.requiresGitHubToken != test.want {
+			t.Fatalf("%s requires GitHub token = %t, want %t", test.ref, compiled.requiresGitHubToken, test.want)
+		}
+	}
+	if _, err := compileActionInvocations(context.Background(), w, nil, []string{"./mixed-parent"}, []map[string]string{nil}); err == nil || !strings.Contains(err.Error(), "index must be a string literal") {
+		t.Fatalf("mixed child traversal error = %v, want dynamic index rejection", err)
+	}
+}
+
+func TestCompilePlansScopesGitHubTokenForEffectiveActionDefaults(t *testing.T) {
+	w := t.TempDir()
+	workflowPath := filepath.Join(w, ".github", "workflows", "token.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeAction(t, w, ".github/actions/token", `name: token default
+inputs:
+  github_token:
+    default: ${{ github.token }}
+runs:
+  using: node24
+  main: index.js
+`)
+	compile := func(workflow string) ([]plan.Job, error) {
+		if err := os.WriteFile(workflowPath, []byte(workflow), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return CompilePlansWithOptions(workflowPath, []byte(workflow), pushEvent(t), "0.0.0-test", testDistributionDigest, defaultOptions())
+	}
+
+	effectiveWorkflow := `on: push
+permissions:
+  contents: read
+jobs:
+  token:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/token
+`
+	plans, err := compile(effectiveWorkflow)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 1 || plans[0].GitHubToken == nil || !reflect.DeepEqual(plans[0].GitHubToken.Permissions, map[string]string{"contents": "read"}) || !plans[0].HasCapability("provider-token-write") {
+		t.Fatalf("effective action default token plan = %#v", plans)
+	}
+	bundle, err := CompileBundleWithOptions(workflowPath, []byte(effectiveWorkflow), pushEvent(t), "0.0.0-test", testDistributionDigest, "importer", defaultOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bundle.Plans) != 1 || !reflect.DeepEqual(bundle.Plans[0].Authorization.ProviderTokenWriteCapabilitySources, []string{"workflow-permissions"}) {
+		t.Fatalf("effective action default token authorization = %#v", bundle.Plans)
+	}
+
+	plans, err = compile(`on: push
+jobs:
+  token:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/token
+        with:
+          GITHUB_TOKEN: ''
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 1 || plans[0].GitHubToken != nil || plans[0].HasCapability("provider-token-write") {
+		t.Fatalf("overridden action default minted a token: %#v", plans)
+	}
+
+	_, err = compile(`on: push
+jobs:
+  token:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/token
+`)
+	if err == nil || !strings.Contains(err.Error(), "action input default that references github.token") || !strings.Contains(err.Error(), "no explicit effective permissions") {
+		t.Fatalf("CompilePlansWithOptions() error = %v, want explicit permission rejection", err)
+	}
+}
+
 func TestCompileActionLocksRemoteCompositeUsesWorkspaceRoot(t *testing.T) {
 	w, remote := t.TempDir(), t.TempDir()
 	writeAction(t, w, "child", "name: child\nruns:\n  using: docker\n  image: Dockerfile\n")

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -265,6 +265,7 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 		steps := make([]plan.Step, len(instance.Steps))
 		var actionIndexes []int
 		var actionRefs []string
+		var actionInputs []map[string]string
 		usedIDs := make(map[string]struct{}, len(instance.Steps))
 		for _, step := range instance.Steps {
 			if step.ID != "" {
@@ -293,6 +294,7 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 			if step.Kind == "uses" {
 				actionIndexes = append(actionIndexes, i)
 				actionRefs = append(actionRefs, step.Uses)
+				actionInputs = append(actionInputs, step.With)
 			}
 		}
 		jobSchema := plan.Schema
@@ -310,12 +312,17 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 				}
 			}
 		}
+		actionRequiresGitHubToken := false
 		if lockActions && len(actionRefs) != 0 {
-			selectors, locks, actionCapabilities, actionRequiresMise, err := compileActionLocks(ctx, instance.RepositoryRoot, actionSource, actionRefs)
+			compiledActions, err := compileActionInvocations(ctx, instance.RepositoryRoot, actionSource, actionRefs, actionInputs)
 			if err != nil {
 				return nil, nil, fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err)
 			}
-			requiresMise = actionRequiresMise
+			selectors := compiledActions.selectors
+			locks := compiledActions.locks
+			actionCapabilities := compiledActions.capabilities
+			requiresMise = compiledActions.requiresMise
+			actionRequiresGitHubToken = compiledActions.requiresGitHubToken
 			locksByID := make(map[string]plan.ActionLock, len(locks))
 			for _, lock := range locks {
 				locksByID[lock.ID] = lock
@@ -425,10 +432,17 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 			return nil, nil, fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err)
 		}
 		var githubToken *plan.GitHubToken
-		if slices.Contains(secrets, "GITHUB_TOKEN") {
+		referencesGitHubTokenSecret := slices.Contains(secrets, "GITHUB_TOKEN")
+		if referencesGitHubTokenSecret {
 			secrets = slices.DeleteFunc(secrets, func(name string) bool { return name == "GITHUB_TOKEN" })
+		}
+		if referencesGitHubTokenSecret || actionRequiresGitHubToken {
 			if len(instance.Permissions) == 0 {
-				return nil, nil, fmt.Errorf("%s:%d:%d: job %q references secrets.GITHUB_TOKEN but has no explicit effective permissions", instance.SourcePath, instance.Source.Start.Line, instance.Source.Start.Column, instance.LogicalJobID)
+				reference := "an action input default that references github.token"
+				if referencesGitHubTokenSecret {
+					reference = "secrets.GITHUB_TOKEN"
+				}
+				return nil, nil, fmt.Errorf("%s:%d:%d: job %q references %s but has no explicit effective permissions", instance.SourcePath, instance.Source.Start.Line, instance.Source.Start.Column, instance.LogicalJobID, reference)
 			}
 			permissions := make(map[string]string, len(instance.Permissions))
 			for name, access := range instance.Permissions {

--- a/internal/expression/expression.go
+++ b/internal/expression/expression.go
@@ -236,6 +236,54 @@ func SecretReferences(template string) ([]string, error) {
 	return names, nil
 }
 
+// ReferencesGitHubToken reports whether a template statically references
+// github.token. Dynamic GitHub indexes fail closed so compiler-owned token
+// authority cannot depend on a runtime-selected property.
+func ReferencesGitHubToken(template string) (bool, error) {
+	found := false
+	err := visitTemplateExpressions(template, func(expression actionlint.ExprNode) error {
+		var referenceErr error
+		actionlint.VisitExprNode(expression, func(node, parent actionlint.ExprNode, entering bool) {
+			if !entering || referenceErr != nil {
+				return
+			}
+			switch node.(type) {
+			case *actionlint.VariableNode, *actionlint.ObjectDerefNode, *actionlint.IndexAccessNode:
+			default:
+				return
+			}
+			root, path, err := referencePath(node)
+			if !strings.EqualFold(root, "github") {
+				return
+			}
+			if err != nil {
+				referenceErr = fmt.Errorf("github reference: %w", err)
+				return
+			}
+			if len(path) == 0 || !strings.EqualFold(path[0], "token") {
+				return
+			}
+			if len(path) != 1 {
+				referenceErr = fmt.Errorf("github.token reference must name exactly github.token")
+				return
+			}
+			switch parent := parent.(type) {
+			case *actionlint.ObjectDerefNode:
+				if parent.Receiver == node {
+					return
+				}
+			case *actionlint.IndexAccessNode:
+				if parent.Operand == node {
+					return
+				}
+			}
+			found = true
+		})
+		return referenceErr
+	})
+	return found, err
+}
+
 // ConditionUsesContext reports whether a condition references a named context.
 // Conditions may omit the normal ${{ ... }} delimiters.
 func ConditionUsesContext(source, contextName string) (bool, error) {

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -153,6 +153,33 @@ func TestSecretReferencesUsesExpressionAST(t *testing.T) {
 	}
 }
 
+func TestReferencesGitHubTokenUsesExpressionAST(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		template string
+		want     bool
+	}{
+		{name: "dot", template: "${{ github.token }}", want: true},
+		{name: "bracket", template: "prefix-${{ github['TOKEN'] }}", want: true},
+		{name: "compound", template: "${{ github.token || '' }}", want: true},
+		{name: "other GitHub value", template: "${{ github.actor }}"},
+		{name: "plain", template: "github.token"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := ReferencesGitHubToken(test.template)
+			if err != nil || got != test.want {
+				t.Fatalf("ReferencesGitHubToken(%q) = %v, %v, want %v", test.template, got, err, test.want)
+			}
+		})
+	}
+	if _, err := ReferencesGitHubToken("${{ github[env.NAME] }}"); err == nil || !strings.Contains(err.Error(), "index must be a string literal") {
+		t.Fatalf("ReferencesGitHubToken() dynamic index error = %v", err)
+	}
+	if _, err := ReferencesGitHubToken("${{ github.token.extra }}"); err == nil || !strings.Contains(err.Error(), "must name exactly github.token") {
+		t.Fatalf("ReferencesGitHubToken() token dereference error = %v", err)
+	}
+}
+
 func TestConditionUsesContextSupportsOptionalDelimiters(t *testing.T) {
 	for _, condition := range []string{"inputs.enabled", "${{ inputs.enabled }}", "inputs.enabled && github.ref"} {
 		usesInputs, err := ConditionUsesContext(condition, "inputs")

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -1359,14 +1359,19 @@ func resolveActionInputs(action metadata.Metadata, supplied map[string]string, c
 		names = append(names, name)
 	}
 	sort.Strings(names)
+	defaultContext := context
+	if token, ok := context.Secrets["GITHUB_TOKEN"]; ok {
+		defaultContext.GitHub = cloneAnyMap(context.GitHub)
+		defaultContext.GitHub["token"] = token
+	}
 	for _, name := range names {
 		definition := action.Inputs[name]
 		if _, ok := inputs[name]; ok {
 			continue
 		}
 		if definition.Default != nil {
-			context.Inputs = inputs
-			value, err := expression.Evaluate(*definition.Default, context)
+			defaultContext.Inputs = inputs
+			value, err := expression.Evaluate(*definition.Default, defaultContext)
 			if err != nil {
 				return nil, fmt.Errorf("action input %q default: %w", name, err)
 			}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1972,6 +1972,100 @@ func TestRunJobMintsAndRedactsScopedGitHubWorkflowToken(t *testing.T) {
 	}
 }
 
+func TestResolveActionInputsExposesScopedTokenOnlyToMetadataDefaults(t *testing.T) {
+	tokenDefault := "${{ github.token }}"
+	actorDefault := "${{ github.actor }}"
+	action := metadata.Metadata{Inputs: map[string]metadata.Input{
+		"github_token": {Default: &tokenDefault},
+		"actor":        {Default: &actorDefault},
+	}}
+	eval := expression.Context{
+		GitHub:  map[string]any{"actor": "octocat"},
+		Secrets: map[string]string{"GITHUB_TOKEN": "ghs_scoped_action_default"},
+	}
+
+	inputs, err := resolveActionInputs(action, nil, eval)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(inputs, map[string]string{"github_token": "ghs_scoped_action_default", "actor": "octocat"}) {
+		t.Fatalf("resolved action inputs = %#v", inputs)
+	}
+	if _, leaked := eval.GitHub["token"]; leaked {
+		t.Fatalf("metadata default evaluation mutated the shared GitHub context: %#v", eval.GitHub)
+	}
+	if _, err := expression.Evaluate("${{ github.token }}", eval); err == nil || !strings.Contains(err.Error(), `unavailable github value "token"`) {
+		t.Fatalf("workflow github.token evaluation error = %v, want unavailable value", err)
+	}
+
+	inputs, err = resolveActionInputs(action, map[string]string{"GITHUB_TOKEN": ""}, eval)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inputs["github_token"] != "" {
+		t.Fatalf("explicit empty input did not suppress metadata default: %#v", inputs)
+	}
+
+	withoutToken := eval
+	withoutToken.Secrets = nil
+	if _, err := resolveActionInputs(action, nil, withoutToken); err == nil || !strings.Contains(err.Error(), `unavailable github value "token"`) {
+		t.Fatalf("unplanned metadata github.token evaluation error = %v, want unavailable value", err)
+	}
+}
+
+func TestRunJobSuppliesScopedGitHubTokenToEffectiveActionDefault(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := filepath.Join(workspace, ".github", "workflows", "test.yml")
+	workflow := []byte(`on: push
+permissions:
+  contents: read
+jobs:
+  token:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/token
+`)
+	writeFixtureFile(t, workspace, ".github/actions/token/action.yml", `name: token default
+inputs:
+  github_token:
+    default: ${{ github.token }}
+runs:
+  using: composite
+  steps:
+    - shell: sh
+      run: |
+        test "${{ inputs.github_token }}" = "ghs_scoped_action_default"
+        test "${GITHUB_TOKEN+x}" = ""
+`)
+	writeFixtureFile(t, workspace, ".github/workflows/test.yml", string(workflow))
+	event, err := os.ReadFile(fixturePath(t, "smoke", "events", "push.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	plans, err := compiler.CompilePlansWithOptions(workflowPath, workflow, event, "0.0.0-test", "sha256:"+strings.Repeat("2", 64), compiler.Options{
+		EventTrust: compiler.EventUntrusted,
+		Runners: compiler.RunnerPolicy{
+			Labels:                     map[string]string{"ubuntu-latest": ""},
+			AllowUntrustedDefaultQueue: true,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 1 || plans[0].GitHubToken == nil {
+		t.Fatalf("compiled scoped token plan = %#v", plans)
+	}
+	provider := &testWorkflowTokenProvider{token: "ghs_scoped_action_default"}
+	redactor := &testRedactor{}
+	result, err := (Runner{WorkflowToken: provider, Redactor: redactor}).RunJob(context.Background(), plans[0], workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	if provider.calls != 1 || !reflect.DeepEqual(redactor.values, []string{"ghs_scoped_action_default"}) {
+		t.Fatalf("token handling = provider calls %d, redactions %#v", provider.calls, redactor.values)
+	}
+}
+
 func TestRunJobAbortsAndScrubsWorkflowTokenWhenRedactionFails(t *testing.T) {
 	workspace := t.TempDir()
 	workflowPath := ".github/workflows/test.yml"


### PR DESCRIPTION
## Summary

- detect effective action metadata input defaults that statically reference `github.token`
- reuse the existing repository-scoped, explicit-permissions workflow token plan and authorization path
- expose `github.token` only while evaluating action metadata defaults, without adding ambient `GITHUB_TOKEN` or enabling workflow-authored `github.token`
- honor explicit input overrides, including empty and case-insensitive values, and traverse nested composite actions
- update the compatibility, architecture, and product-plan documentation

## Problem

[`jdx/mise-action@v2`](https://github.com/jdx/mise-action/blob/v2/action.yml) defaults its `github_token` input to `${{ github.token }}`. A workflow can correctly declare scoped permissions, but `buildkite-gha` previously detected token demand only from workflow-authored `secrets.GITHUB_TOKEN` references. The resolved action default therefore failed at runtime with:

```text
action input "github_token" default: expression references unavailable github value "token"
```

This was observed in [lox/notion-cli build 3](https://buildkite.com/lox/notion-cli/builds/3).

## Security boundary

Token planning still requires a non-empty explicit effective permission map and uses the existing exact-repository workflow token provider plus `workflow-permissions` admission provenance. Dynamic or malformed GitHub references fail closed. Native adapters are excluded because they do not evaluate upstream metadata defaults.

The runtime adds `github.token` to a copied context only for action metadata default evaluation. Workflow-authored `${{ github.token }}` remains unavailable, and action processes receive no ambient `GITHUB_TOKEN` environment variable.

## Verification

- `mise run check`
  - build and all tests
  - race suite
  - `golangci-lint` (0 issues)
  - ShellCheck and `go vet`
  - plan fixtures and local smoke inventory
  - GoReleaser validation
- end-to-end compile/runtime regression proves scoped token minting, redaction, action-default delivery, and absence of ambient `GITHUB_TOKEN`
- compiler regressions cover explicit overrides, nested composites, dynamic references, permission rejection, and authorization provenance
