### PR TITLE
Speed up runtime tests with safe parallelism

### DIFF
--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -48,13 +48,13 @@ func newJobDocker(t *testing.T, scenario string) fakeJobDocker {
 		t.Fatal(err)
 	}
 	wrapper := filepath.Join(root, "docker")
-	// Avoid the race runtime's one-second exit sleep on every fake Docker call.
+	// Scope fake state to this subprocess rather than the parent test process so
+	// independent container tests can run in parallel. Avoid the race runtime's
+	// one-second exit sleep on every fake Docker call.
 	text := "#!/bin/sh\nGORACE=atexit_sleep_ms=0 JOB_DOCKER_ROOT=" + strconv.Quote(root) + " JOB_DOCKER_SCENARIO=" + strconv.Quote(scenario) + " exec " + strconv.Quote(exe) + " -test.run=^TestJobContainerFakeDockerProcess$ -- \"$@\"\n"
 	if err := os.WriteFile(wrapper, []byte(text), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("JOB_DOCKER_ROOT", root)
-	t.Setenv("JOB_DOCKER_SCENARIO", scenario)
 	return fakeJobDocker{wrapper, root}
 }
 
@@ -553,6 +553,8 @@ func TestRunJobContainerDefaultsRunStepsToSh(t *testing.T) {
 }
 
 func TestRunJobContainerServicesLifecycleAndArguments(t *testing.T) {
+	t.Parallel()
+
 	f := newJobDocker(t, "")
 	w := t.TempDir()
 	j := jobContainerPlan(t, w, nil)
@@ -654,6 +656,8 @@ func TestRunJobContainerMalformedServicePortsIncludeMaskedDiagnostics(t *testing
 }
 
 func TestRunJobContainerLaterServiceCreateFailureCleansExactServices(t *testing.T) {
+	t.Parallel()
+
 	f := newJobDocker(t, "fail-later-service-create")
 	w, tmp := t.TempDir(), t.TempDir()
 	_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).startJobContainer(context.Background(), newCommandProcessor(os.Stdout, os.Stderr), w, tmp, plan.Container{Image: "alpine"}, map[string]plan.Container{"a": {Image: "one"}, "b": {Image: "two"}})
@@ -676,6 +680,8 @@ func TestRunJobContainerLaterServiceCreateFailureCleansExactServices(t *testing.
 }
 
 func TestRunJobContainerServiceReadinessCancellationCleansEverything(t *testing.T) {
+	t.Parallel()
+
 	f := newJobDocker(t, "service-starting")
 	w, tmp := t.TempDir(), t.TempDir()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -797,6 +803,8 @@ func TestRunJobHostServicePortProtocolCollisionIsDeterministic(t *testing.T) {
 }
 
 func TestRunJobContainerSetupFailuresCleanOwnedResources(t *testing.T) {
+	t.Parallel()
+
 	for _, stage := range []string{"pull", "network-create", "create", "start", "probe", "step"} {
 		t.Run(stage, func(t *testing.T) {
 			f := newJobDocker(t, "fail-"+stage)
@@ -851,6 +859,8 @@ func TestRunJobContainerCleanupQueryFailureStillRemovesExactResources(t *testing
 }
 
 func TestRunJobContainerReportsLeftoverAndVerificationFailure(t *testing.T) {
+	t.Parallel()
+
 	for _, s := range []string{"leftover", "verify-fail"} {
 		t.Run(s, func(t *testing.T) {
 			f := newJobDocker(t, s)
@@ -875,6 +885,8 @@ func startTestBackend(t *testing.T, f fakeJobDocker) (*jobContainerBackend, stri
 }
 
 func TestRunJobContainerCancellationTargetsProcessTree(t *testing.T) {
+	t.Parallel()
+
 	f := newJobDocker(t, "")
 	b, w := startTestBackend(t, f)
 	marker := filepath.Join(w, "alive")
@@ -911,6 +923,8 @@ func TestRunJobContainerCancellationTargetsProcessTree(t *testing.T) {
 }
 
 func TestRunJobContainerConcurrentExecUsesUniquePIDFiles(t *testing.T) {
+	t.Parallel()
+
 	f := newJobDocker(t, "")
 	b, w := startTestBackend(t, f)
 	c1, x := context.WithCancel(context.Background())
@@ -948,6 +962,8 @@ func TestRunJobContainerConcurrentExecUsesUniquePIDFiles(t *testing.T) {
 }
 
 func TestRunJobContainerBarrierVisibility(t *testing.T) {
+	t.Parallel()
+
 	f := newJobDocker(t, "")
 	w := t.TempDir()
 	j := jobContainerPlan(t, w, []plan.Step{{ID: "bg", Kind: "run", Shell: "sh", Background: true, Command: `/bin/sleep .15; echo LATE=yes >> "$GITHUB_ENV"; echo value=x >> "$GITHUB_OUTPUT"; echo /late >> "$GITHUB_PATH"`}, {ID: "before", Kind: "run", Shell: "sh", Command: `test -z "${LATE-}"`}, {ID: "wait", Kind: "wait", Targets: []string{"bg"}}, {ID: "after", Kind: "run", Shell: "sh", Command: `test "$LATE" = yes; case "$PATH" in /late:*) ;; *) exit 9;; esac`}})
@@ -1027,6 +1043,8 @@ func TestContainerPathUsesLongestReadOnlyMount(t *testing.T) {
 }
 
 func TestRunJobContainerNodeProbeFailureCleansOwnedResources(t *testing.T) {
+	t.Parallel()
+
 	for _, scenario := range []string{"wrong-node-major", "incompatible-node"} {
 		t.Run(scenario, func(t *testing.T) {
 			f := newJobDocker(t, scenario)
@@ -1317,6 +1335,8 @@ func TestRunJobContainerJavaScriptLifecycle(t *testing.T) {
 }
 
 func TestRunJobContainerCompositeAndNestedJavaScript(t *testing.T) {
+	t.Parallel()
+
 	f := newJobDocker(t, "")
 	workspace := t.TempDir()
 	writeFixtureFile(t, workspace, ".github/workflows/container.yml", "name: nested container actions\n")
@@ -1375,6 +1395,8 @@ printf '%s:%s\n' "$action" "$phase" >> "$LIFECYCLE_LOG"
 }
 
 func TestRunJobContainerRemoteActionsMountedReadOnly(t *testing.T) {
+	t.Parallel()
+
 	f := newJobDocker(t, "")
 	workspace := t.TempDir()
 	writeFixtureFile(t, workspace, ".github/workflows/container.yml", "name: remote container action\n")
@@ -1476,6 +1498,8 @@ echo NESTED_REMOTE=seen >> "$GITHUB_ENV"
 }
 
 func TestRunJobContainerWorkspaceActionRemainsLazy(t *testing.T) {
+	t.Parallel()
+
 	f := newJobDocker(t, "")
 	workspace := t.TempDir()
 	writeFixtureFile(t, workspace, ".github/workflows/container.yml", "name: lazy container action\n")
@@ -1636,6 +1660,8 @@ func TestRunDockerRejectsMismatchedJobContainerPaths(t *testing.T) {
 }
 
 func TestRunJobContainerJavaScriptCancellationRunsPost(t *testing.T) {
+	t.Parallel()
+
 	f := newJobDocker(t, "")
 	workspace := t.TempDir()
 	writeFixtureFile(t, workspace, ".github/workflows/container.yml", "name: cancelled container action\n")

--- a/internal/runtime/process_helper_test.go
+++ b/internal/runtime/process_helper_test.go
@@ -64,6 +64,8 @@ func TestContainerProcessHelperTerminatesProcessGroup(t *testing.T) {
 }
 
 func TestContainerProcessHelperTerminateToleratesMissingPIDFile(t *testing.T) {
+	t.Parallel()
+
 	start := time.Now()
 	if got := RunContainerProcessHelper([]string{"terminate", filepath.Join(t.TempDir(), "missing"), "1ms", "1ms"}); got != 0 {
 		t.Fatalf("status = %d", got)
@@ -74,6 +76,8 @@ func TestContainerProcessHelperTerminateToleratesMissingPIDFile(t *testing.T) {
 }
 
 func TestContainerProcessHelperCancelBeforePIDPreventsLateCommandStart(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	pidfile := filepath.Join(dir, "late.pid")
 	started := filepath.Join(dir, "started")

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -533,6 +533,8 @@ func TestRunDockerFakeLifecycle(t *testing.T) {
 }
 
 func TestRunDockerPreservesExplicitPath(t *testing.T) {
+	t.Parallel()
+
 	for _, test := range []struct {
 		name       string
 		jobPATH    string
@@ -655,6 +657,8 @@ func TestRunDockerRejectsUntrustedBuilderBeforeExecution(t *testing.T) {
 }
 
 func TestRunDockerFakeFailuresCleanOwnedResources(t *testing.T) {
+	t.Parallel()
+
 	for _, scenario := range []string{"build-fail", "run-fail", "leftover", "query-fail"} {
 		t.Run(scenario, func(t *testing.T) {
 			fake := newFakeDocker(t, scenario)
@@ -702,6 +706,8 @@ func TestRunDockerJoinsRunAndFileCommandFailures(t *testing.T) {
 }
 
 func TestRunDockerReadsOnlyOriginalCommandFiles(t *testing.T) {
+	t.Parallel()
+
 	fake := newFakeDocker(t, "replace-files")
 	result, err := (Runner{Docker: fake.path}).RunDocker(context.Background(), fakeDockerAction(t))
 	if err != nil {
@@ -713,6 +719,8 @@ func TestRunDockerReadsOnlyOriginalCommandFiles(t *testing.T) {
 }
 
 func TestRunDockerCancellationCleansOwnedResources(t *testing.T) {
+	t.Parallel()
+
 	fake := newFakeDocker(t, "cancel")
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
@@ -1018,6 +1026,8 @@ func TestFailureConditionsAndCancellation(t *testing.T) {
 }
 
 func TestExplicitCancelCommitsEffectsWithoutFailingJob(t *testing.T) {
+	t.Parallel()
+
 	for range 20 {
 		testExplicitCancelCommitsEffectsWithoutFailingJob(t)
 	}
@@ -1492,6 +1502,8 @@ func TestBackgroundSupervisorBoundsActiveWorkAndQueuesFIFO(t *testing.T) {
 }
 
 func TestImplicitWaitAllPrecedesPostCleanup(t *testing.T) {
+	t.Parallel()
+
 	node := requireNode24(t)
 	workspace := t.TempDir()
 	workflowPath := ".github/workflows/test.yml"
@@ -1670,6 +1682,8 @@ func TestConcurrentSmokeWorkflowEndToEnd(t *testing.T) {
 }
 
 func TestCancellationTerminatesChildProcessGroup(t *testing.T) {
+	t.Parallel()
+
 	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
 		t.Skip("process groups are implemented for the initial Linux runtime and Darwin development hosts")
 	}
@@ -1699,6 +1713,8 @@ func TestCancellationTerminatesChildProcessGroup(t *testing.T) {
 }
 
 func TestCancellationEscalatesFromInterruptToTermination(t *testing.T) {
+	t.Parallel()
+
 	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
 		t.Skip("process groups are implemented for the initial Linux runtime and Darwin development hosts")
 	}
@@ -1740,6 +1756,8 @@ while :; do sleep 1; done`)
 }
 
 func TestCancellationPreservesInterruptGraceForDescendants(t *testing.T) {
+	t.Parallel()
+
 	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
 		t.Skip("process groups are implemented for the initial Linux runtime and Darwin development hosts")
 	}
@@ -1780,6 +1798,8 @@ wait`)
 }
 
 func TestCancellationWaitsForProcessGroupCleanupAfterOutputCloses(t *testing.T) {
+	t.Parallel()
+
 	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
 		t.Skip("process groups are implemented for the initial Linux runtime and Darwin development hosts")
 	}
@@ -1832,6 +1852,8 @@ while :; do sleep 1; done`)
 }
 
 func TestExplicitCancelTerminatesBackgroundProcessGroup(t *testing.T) {
+	t.Parallel()
+
 	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
 		t.Skip("process groups are implemented for the initial Linux runtime and Darwin development hosts")
 	}
@@ -2203,6 +2225,8 @@ printf 'retained summary\n' >> "$GITHUB_STEP_SUMMARY"`},
 }
 
 func TestPostActionsRunLIFOAfterMainFailure(t *testing.T) {
+	t.Parallel()
+
 	node := requireNode24(t)
 	var logs bytes.Buffer
 	workspace := fixturePath(t)
@@ -2298,6 +2322,8 @@ func TestJavaScriptInputEnvironmentMatchesToolkitNames(t *testing.T) {
 }
 
 func TestConcurrentPostActionsRunLIFOByRegistration(t *testing.T) {
+	t.Parallel()
+
 	node := requireNode24(t)
 	workspace := t.TempDir()
 	workflowPath := ".github/workflows/test.yml"
@@ -2330,6 +2356,8 @@ func TestConcurrentPostActionsRunLIFOByRegistration(t *testing.T) {
 }
 
 func TestPostActionsUseBoundedCleanupContext(t *testing.T) {
+	t.Parallel()
+
 	node := requireNode24(t)
 	workspace := t.TempDir()
 	writeFixtureFile(t, workspace, ".github/workflows/test.yml", "name: runtime test\n")
@@ -2349,6 +2377,8 @@ func TestPostActionsUseBoundedCleanupContext(t *testing.T) {
 }
 
 func TestJobTimeoutLimitsPostActionsToCleanupGrace(t *testing.T) {
+	t.Parallel()
+
 	workspace := canonicalTempDir(t)
 	writeFixtureFile(t, workspace, ".github/workflows/test.yml", "name: runtime test\n")
 	writeFixtureFile(t, workspace, ".github/actions/slow/action.yml", "name: Job timeout post\nruns:\n  using: node24\n  main: main.js\n  post: post.js\n")
@@ -2388,6 +2418,8 @@ sleep 30
 }
 
 func TestCancellationStillRunsRegisteredPostAction(t *testing.T) {
+	t.Parallel()
+
 	node := requireNode24(t)
 	workspace := t.TempDir()
 	writeFixtureFile(t, workspace, ".github/workflows/test.yml", "name: runtime test\n")
@@ -2405,6 +2437,8 @@ func TestCancellationStillRunsRegisteredPostAction(t *testing.T) {
 }
 
 func TestExplicitBackgroundCancelStillRunsRegisteredPostAction(t *testing.T) {
+	t.Parallel()
+
 	node := requireNode24(t)
 	workspace := t.TempDir()
 	writeFixtureFile(t, workspace, ".github/workflows/test.yml", "name: runtime test\n")


### PR DESCRIPTION
## Problem

The test suite is dominated by `internal/runtime`, where process-heavy runtime and fake-Docker tests all ran serially. A warm uncached run took about 16 seconds normally and 32 seconds under the race detector.

## Change

- run 32 independent runtime, container, cancellation, and process-helper tests in parallel
- keep tests that mutate process-wide environment variables serial
- scope fake-Docker root and scenario state to each subprocess instead of the parent test process, removing the shared state that prevented safe parallel execution

This changes only the test harness. Production behavior and coverage are unchanged.

## Results

Measured in the same 16-core Amp orb with test-result caching disabled:

| Suite | Before | After |
| --- | ---: | ---: |
| `go test ./...` | 16.33s | 8.05s |
| `go test -race ./...` | 31.95s | 18.46s |

That makes the normal suite 51% faster and the race suite 42% faster.

## Validation

- `go test -count=10 ./internal/runtime`
- `go test -race -shuffle=on -count=3 ./internal/runtime`
- `mise run check` after rebasing onto current `main` (39.60s, 0 lint issues)