### PR TITLE
Simplify repository checkout credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ cancellation, and the build UI.
 
 > [!IMPORTANT]
 > This is an experimental pre-1.0 preview for **Linux x86-64 workflows**. The
-> default remains public and tokenless. Direct upload has an explicit,
-> fail-closed private-checkout preview for the pipeline's exact repository;
-> private actions and workflow secrets other than the explicitly scoped
-> `secrets.GITHUB_TOKEN` contract remain rejected.
+> default remains limited to public actions and no general workflow secrets.
+> Verified checkout automatically uses Buildkite's repository-provider Git
+> credentials when the job is configured for them, and otherwise checks out
+> anonymously. Private actions and workflow secrets other than the explicitly
+> scoped `secrets.GITHUB_TOKEN` contract remain rejected.
 
 ## Buildkite controls the pipeline; the workflow describes the workload
 
@@ -138,7 +139,9 @@ workflows built from:
 - GitHub Actions background, wait, cancellation, and parallel step controls;
 - timeouts, `continue-on-error`, masking, summaries, warning/error annotations,
   and pre/main/post actions;
-- public, credential-free checkout of the event repository at its exact commit;
+- checkout of the event repository at its exact commit, using Buildkite's
+  repository-provider Git credentials when available and anonymous Git
+  otherwise;
 - short-lived GitHub tokens scoped to explicit workflow or job `permissions`
   for the event repository, consumed through `secrets.GITHUB_TOKEN` or an
   effective action metadata input default that references `github.token`;
@@ -149,8 +152,9 @@ workflows built from:
 
 It is not currently a fit for workflows that require:
 
-- private actions or general private-source access; direct upload has only the
-  explicit pipeline-repository checkout described in the compatibility guide;
+- private actions or general private-source access; checkout can use only the
+  job's native Buildkite repository-provider credentials as described in the
+  compatibility guide;
 - ordinary workflow secrets—the scoped `secrets.GITHUB_TOKEN` contract is the
   only workflow-visible secret exception;
 - workflow-authored `github.token`, ambient `GITHUB_TOKEN`, GitHub-compatible

--- a/README.md
+++ b/README.md
@@ -33,8 +33,11 @@ neither create nor filter Buildkite builds.
 Buildkite configuration also remains authoritative for agent targeting and
 protected capabilities. Workflow settings such as `runs-on`, `permissions`,
 environments, and concurrency are honored only within the explicitly supported
-and admitted boundaries in the [support matrix](docs/compatibility.md#support-matrix);
-they cannot change Buildkite pipeline settings or grant themselves authority.
+and admitted boundaries in the [support matrix](docs/compatibility.md#support-matrix).
+They are requests constrained by Buildkite configuration, admission policy, and
+the supported runtime. Repository credential and token requests are additionally
+bounded by Buildkite's server-side repository and permission policy; none can
+change Buildkite pipeline settings.
 
 ## Try an existing workflow
 
@@ -142,9 +145,10 @@ workflows built from:
 - checkout of the event repository at its exact commit, using Buildkite's
   repository-provider Git credentials when available and anonymous Git
   otherwise;
-- short-lived GitHub tokens scoped to explicit workflow or job `permissions`
-  for the event repository, consumed through `secrets.GITHUB_TOKEN` or an
-  effective action metadata input default that references `github.token`;
+- short-lived GitHub tokens requested with explicit workflow or job
+  `permissions` for the event repository and bounded by Buildkite's server-side
+  policy, consumed through `secrets.GITHUB_TOKEN` or an effective action
+  metadata input default that references `github.token`;
 - bounded native upload and exact-name download for the audited artifact v4
   commits; and
 - the audited `actions/cache` v6.1.0 commit through the official Buildkite

--- a/docs/architecture/0003-protected-capability-control-plane.md
+++ b/docs/architecture/0003-protected-capability-control-plane.md
@@ -243,10 +243,14 @@ are enabled. Otherwise it performs the same checkout anonymously.
 The event repository and exact SHA remain the only checkout targets. The
 credential helper is configured as a command-scoped Git option only for the
 fetch, uses HTTP-path matching, receives the current job's Agent API identity,
-and is not persisted. The Buildkite backend independently authorizes the
-concrete repository URL received through Git's credential protocol. No workflow
-input can select another credential target or access level, and the job's Agent
-credential is not placed in plans or workflow environments.
+and is not persisted. The runtime forwards proxy variables captured from the job
+process before workflow execution to that credentialed fetch but does not add
+the job credential to ordinary workflow subprocess environments. This is
+inheritance control, not OS-level isolation between hostile processes in the
+same job. The Buildkite backend independently authorizes the concrete repository
+URL received through Git's credential protocol. Through the supported adapter
+no workflow input can select another credential target or access level, and the
+job's Agent credential is not placed in plans.
 
 A second bounded integration uses the scoped-token endpoint for a synthetic
 `secrets.GITHUB_TOKEN` or an action metadata input default that references
@@ -272,9 +276,12 @@ These exceptions do not establish authenticated provider event, fork, or actor
 provenance. The server's independent pipeline-repository comparison,
 organization enablement, and permission allowlist are authoritative, but
 pipelines remain responsible for whether untrusted workflow changes may request
-an allowed write permission. Private actions, arbitrary reusable-workflow
-source, selected non-provider secrets, environments, and OIDC still require the
-general control-plane decision in this ADR.
+an allowed write permission. The compiled permission map constrains the supported
+client path; it is not an independent authorization ceiling against same-job
+code that obtains the Agent access token and calls the endpoint directly.
+Private actions, arbitrary reusable-workflow source, selected non-provider
+secrets, environments, and OIDC still require the general control-plane decision
+in this ADR.
 
 ### Runtime verification and capability use
 
@@ -349,8 +356,9 @@ exposed only to the audited cache action lifecycle. A capability grant neither
 contains nor replaces them.
 
 The job-bound provider credential exchanges are likewise separate. Their
-server-side repository authorization and either a Git-selected checkout URL or
-compiler-owned explicit workflow permission map are not a substitute for the
+server-side repository authorization and permission allowlists are the
+authoritative ceilings. A Git-selected checkout URL and the explicit workflow
+permission map carried by the supported client path are not substitutes for the
 event, policy, signing, and audit contract required by a general capability
 grant.
 

--- a/docs/architecture/0003-protected-capability-control-plane.md
+++ b/docs/architecture/0003-protected-capability-control-plane.md
@@ -203,14 +203,18 @@ plan. Rotation overlaps old and new public keys for the maximum grant lifetime;
 emergency revocation takes precedence over a still-published key. Private keys
 remain in the platform signing boundary.
 
-### Narrow job-bound GitHub token exceptions
+### Narrow job-bound provider credential exceptions
 
-Buildkite's Agent API can mint a GitHub installation token for the exact current
-job, exact pipeline repository, and caller-requested permission set. The server
-authenticates the request with the same job's Agent access token, independently
-requires the requested repository to equal the pipeline's configured GitHub
-repository, and validates permissions against its own allowlist. This supports
-one narrower integration without waiting for the general grant protocol:
+Buildkite has two native, job-bound credential paths that support narrower
+integrations without waiting for the general grant protocol. Repository
+checkout uses the Agent's Git credential helper and delegates authorization for
+the concrete URL supplied by Git to Buildkite's repository-provider backend.
+Workflow `GITHUB_TOKEN` support uses the Agent API below to mint a GitHub
+installation token for the exact current job, exact pipeline repository, and
+caller-requested permission set. The server authenticates the request with the
+same job's Agent access token, independently requires the requested repository
+to equal the pipeline's configured GitHub repository, and validates permissions
+against its own allowlist:
 
 ```http
 POST /v3/jobs/<current-job-id>/github_scoped_access_token
@@ -227,30 +231,24 @@ Content-Type: application/json
 }
 ```
 
-The uploader must opt in explicitly. The compiler adds
-`provider-token-read` only after resolving the exact `actions/checkout`
-adapter and validating its repository, ref, depth, path, submodule, and
-credential-persistence inputs. Fresh same-process compiler provenance permits
-that one capability through upload admission; the default `hosted-tokenless`
-profile continues to reject it.
+The compiler adds `provider-token-read` after resolving the exact
+`actions/checkout` adapter and validating its repository, ref, depth, path,
+submodule, and credential-persistence inputs. Fresh same-process compiler
+provenance permits that one capability through upload admission. The runtime
+uses `buildkite-agent git-credentials-helper` only when the immutable plan has
+that capability, a root checkout selector names the verified adapter, and the
+server-provided job environment indicates repository-provider Git credentials
+are enabled. Otherwise it performs the same checkout anonymously.
 
-The runtime configures the endpoint only when the immutable plan contains that
-capability and a root checkout selector names the verified adapter. The event
-repository and exact SHA remain the only checkout targets, and the server's
-independent pipeline-repository comparison is the authoritative repository
-restriction. The client fixes `contents:read`; no workflow input can choose a
-repository, permission, or access level for minting.
+The event repository and exact SHA remain the only checkout targets. The
+credential helper is configured as a command-scoped Git option only for the
+fetch, uses HTTP-path matching, receives the current job's Agent API identity,
+and is not persisted. The Buildkite backend independently authorizes the
+concrete repository URL received through Git's credential protocol. No workflow
+input can select another credential target or access level, and the job's Agent
+credential is not placed in plans or workflow environments.
 
-The returned token is masked before Agent redaction registration. Failure to
-register redaction aborts before Git fetch. A one-shot askpass helper reads the
-token from an inherited pipe and is present only for the fetch process. The
-token is not placed in arguments, the clone URL, Git config, plans, ordinary
-step environments, workflow contexts, results, outputs, state, summaries, or
-artifacts. Redirects, unknown response fields, trailing data, oversized bodies,
-invalid tokens, disabled service responses, and unavailable/rate-limited
-responses fail closed with bounded diagnostics.
-
-A second bounded integration uses the same endpoint for a synthetic
+A second bounded integration uses the scoped-token endpoint for a synthetic
 `secrets.GITHUB_TOKEN` or an action metadata input default that references
 `github.token`. A workflow must declare an explicit, non-empty permission
 mapping and either statically reference that exact secret or invoke an action
@@ -336,31 +334,32 @@ record; a successful job alone does not prove policy or audit behavior.
 
 ## Deferred decisions
 
-Apart from the fixed read-only pipeline-repository checkout and scoped token
-exceptions above, this ADR does not authorize or choose storage for private
-actions, reusable workflow source, selected non-provider secrets, general
-workflow access to `github.token`, environment grants, or compatibility OIDC
-claims. It does not choose a secret manager, broader cross-repository GitHub
-App authority, customer policy language, administrative UI, or production
-service hostname. Those decisions require separate reviewed slices after the
-no-op boundary is proven.
+Apart from native repository-provider checkout and scoped token exceptions
+above, this ADR does not authorize or choose storage for private actions,
+reusable workflow source, selected non-provider secrets, general workflow
+access to `github.token`, environment grants, or compatibility OIDC claims. It
+does not choose a secret manager, broader cross-repository GitHub App authority,
+customer policy language, administrative UI, or production service hostname.
+Those decisions require separate reviewed slices after the no-op boundary is
+proven.
 
 The existing cache-v2 GHAC token exchange remains separate. Cache tokens are
 minted through the current Buildkite job, scoped by the cache service, and
 exposed only to the audited cache action lifecycle. A capability grant neither
 contains nor replaces them.
 
-The job-bound GitHub token exchanges are likewise separate. Their server-side
-pipeline-repository binding and either client-fixed `contents:read` checkout
-permission or compiler-owned explicit workflow permission map are not a
-substitute for the event, policy, signing, and audit contract required by a
-general capability grant.
+The job-bound provider credential exchanges are likewise separate. Their
+server-side repository authorization and either a Git-selected checkout URL or
+compiler-owned explicit workflow permission map are not a substitute for the
+event, policy, signing, and audit contract required by a general capability
+grant.
 
 ## Consequences
 
-- Public tokenless workflows retain no new service dependency.
-- Explicit private checkout can use the pipeline's own repository without
-  exposing a reusable workflow credential or broadening the default profile.
+- Public checkout retains no new service dependency when repository-provider
+  credentials are not enabled for the job.
+- Private checkout uses Buildkite's existing repository-provider policy without
+  exposing a reusable workflow credential or requiring a separate user option.
 - The first protected-path milestone can prove the security boundary without
   risking a real credential.
 - Provider provenance and policy must exist in a Buildkite-owned service before

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -260,8 +260,14 @@ requested by Git. If neither signal is enabled, checkout is anonymous; the CLI
 does not try to infer repository visibility.
 
 The helper is configured only on the verified fetch command, with HTTP-path
-matching enabled. It is not persisted in Git config, and its job credential is
-not exposed to workflow steps. This checkout path does not populate
+matching enabled. It is not persisted in Git config. The runtime passes the
+upper- and lower-case HTTP proxy variables captured from the job process before
+workflow execution to that credentialed fetch, but does not add its job
+credential to ordinary workflow subprocess environments. This command scoping
+limits accidental inheritance; it is not an OS-level isolation boundary between
+hostile processes in the same job. The Buildkite repository-provider backend
+remains authoritative for whether it issues credentials for the concrete URL.
+This checkout path does not populate
 `GITHUB_TOKEN` or `github.token`, use workflow `permissions`, enable private
 actions, or add support for alternate repositories or refs. The deprecated
 `--private-checkout` option is temporarily accepted as a no-op for compatibility.
@@ -299,9 +305,12 @@ The compiler normalizes names such as `pull-requests` to the Agent API's
 provenance for upload admission. The runtime requests the token once from the
 current-job Agent endpoint. The service independently requires the requested
 repository to match the pipeline's configured GitHub repository and applies
-its own permission allowlist and organization enablement. The token is
-registered with runtime and Agent redaction before expressions or steps can use
-it, and result values containing it are scrubbed.
+its own permission allowlist and organization enablement. Those server-side
+checks are the authorization ceiling; the compiled map constrains the supported
+client path but is not a separate security boundary against code that obtains
+the current job's Agent access token. The token is registered with runtime and
+Agent redaction before expressions or steps can use it, and result values
+containing it are scrubbed.
 
 An explicit `secrets.GITHUB_TOKEN` reference continues to resolve through the
 scoped-token contract. For compatible actions, `github.token` is additionally

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -35,9 +35,10 @@ one queue. Operators using default or explicit targeting are responsible for
 providing suitable whole-job isolation. The profile is designed for public code
 that can run without general protected credentials on a compatible Linux
 x86-64 agent. Unsupported or privileged requests fail before the generated jobs
-are uploaded. An explicit `upload --private-checkout` extension admits only the
-verified checkout adapter and only when the organization has enabled
-Buildkite's job-bound GitHub scoped access-token service.
+are uploaded. A compiler-verified checkout automatically declares bounded
+repository-provider read capability. At runtime it uses Buildkite's native Git
+credential helper only when the job environment indicates repository-provider
+credentials are available; otherwise the same checkout runs anonymously.
 
 There are three different compatibility claims:
 
@@ -105,7 +106,7 @@ service.
 | Dockerfile actions | Supported subset | Only compiler-verified local or anonymous public Dockerfile actions are admitted. Lifecycle overrides, arbitrary Docker options, credentials, volumes, private images, and privileged execution are not supported. |
 | `docker://` actions and action `entrypoint`/`args` overrides | Not supported | Validation rejects these forms. |
 | Concurrent step controls | Supported | GitHub Actions `background`, `wait`, `wait-all`, `cancel`, and `parallel` controls run inside one job with at most ten active background steps. Effects and failures become visible at covering waits, remaining work is joined before cleanup, and cancellation targets the complete process group rather than only the direct process. |
-| `actions/checkout` | Supported subset | Public `github.com` event repository, exact event SHA, workspace root, and shallow credential-free fetch are supported by default. Explicit private-checkout upload can authenticate that same fetch with fixed `contents:read` authority for the pipeline repository. Alternate repositories/refs, submodules, LFS, persisted credentials, and arbitrary checkout inputs are not supported. |
+| `actions/checkout` | Supported subset | The `github.com` event repository, exact event SHA, workspace root, and shallow fetch are supported. The fetch automatically uses Buildkite's repository-provider Git credential helper when the job has those credentials enabled and is anonymous otherwise. Alternate repositories/refs, submodules, LFS, persisted credentials, and arbitrary checkout inputs are not supported. |
 | `actions/upload-artifact` | Supported subset | Only the audited v4 commit is adapted. It supports bounded literal files/directories, ZIP compression 0–9, hidden-file selection, and exact no-file behavior. Globs, exclusions, symlinks, retention, overwrite, raw uploads, merge, and GitHub URLs are not supported. |
 | `actions/download-artifact` | Supported subset | Only the audited v4.3.0 commit is adapted. One exact literal name from verified direct `needs` can be extracted to a clean workspace-relative path. IDs, patterns, all-artifact, merge, cross-run, and cross-repository modes are not supported. |
 | `actions/cache` | Supported subset | Only the audited v6.1.0 commit, including its `restore` and `save` entry points, is admitted. It runs the stock Node 24 cache-v2 client with fresh job-bound credentials and the official Buildkite Results service by default. v4/v5 and unrecognized v6 commits are not supported. |
@@ -116,7 +117,7 @@ service.
 | GitHub Actions area | Status | Current boundary |
 | --- | --- | --- |
 | Public GitHub repositories | Supported subset | Public event-repository checkout and anonymous public GitHub actions are supported. GitHub Enterprise Server and non-GitHub repository providers are not current production sources. |
-| Private repositories | Supported subset | Direct upload can opt into read-only checkout of the pipeline's exact GitHub repository. Alternate repositories, private actions, and private reusable workflows are not supported. |
+| Private repositories | Supported subset | The event repository can be checked out when Buildkite supplies repository-provider Git credentials to the job and its backend authorizes the concrete repository URL. Alternate repositories, private actions, and private reusable workflows are not supported. |
 | `secrets.GITHUB_TOKEN` | Supported subset | A static reference can receive one short-lived token for the exact event repository when the job has a non-empty explicit permission map and the organization enables the job-bound token service. It is not injected as an ambient environment variable. |
 | Other workflow secrets | Not admitted | The runtime has a plan-declared `BUILDKITE_GHA_SECRET_<NAME>` resolver boundary, but `hosted-tokenless` admission rejects its `secrets` capability. Reusable-workflow secret passing and environment secrets are also rejected. |
 | `github.token` and ambient `GITHUB_TOKEN` | Supported subset | `github.token` is populated only while evaluating an effective action metadata input default and uses the same scoped-token contract as `secrets.GITHUB_TOKEN`. Workflow-authored `github.token` and ambient `GITHUB_TOKEN` remain unavailable. An explicitly supplied action input, including an empty value, suppresses its metadata default. |
@@ -244,25 +245,26 @@ semantics when Buildkite has not supplied them.
 ### Checkout starts clean
 
 Generated jobs skip Buildkite's default checkout and allocate a fresh Actions
-workspace. A supported `actions/checkout` step performs a credential-free,
-shallow checkout of the public event repository at the exact event SHA by
-default.
+workspace. A supported `actions/checkout` step performs a shallow checkout of
+the event repository at the exact event SHA. Compilation automatically adds
+`provider-token-read` only to a job containing the compiler-verified checkout
+adapter with its bounded inputs.
 
-With explicit installer configuration, direct upload may add
-`--private-checkout`. Compilation then adds `provider-token-read` only to a job
-containing the compiler-verified checkout adapter with its bounded inputs. At
-runtime, the CLI requests fixed `contents:read` authority from Buildkite's
-current-job Agent endpoint for `https://github.com/<event repository>`. The
-service independently requires that repository to be the pipeline's exact
-GitHub repository. The credential is registered with both runtime and Agent
-redaction before use, supplied to only the Git fetch through a one-shot askpass
-pipe, and never placed in the clone URL, arguments, Git config, plan, workflow
-environment, result, output, state, summary, or artifact.
+At runtime, the fetch uses Buildkite's native
+`buildkite-agent git-credentials-helper` when
+`BUILDKITE_USE_REPOSITORY_PROVIDER_GIT_CREDENTIALS=true`, or when the legacy
+`BUILDKITE_USE_GITHUB_APP_GIT_CREDENTIALS=true` signal is present. The helper
+receives the current job identity and Agent access token, and the Buildkite
+backend decides whether to issue credentials for the concrete repository URL
+requested by Git. If neither signal is enabled, checkout is anonymous; the CLI
+does not try to infer repository visibility.
 
-The option fails closed when scoped token minting is unavailable or disabled.
-It does not populate `GITHUB_TOKEN` or `github.token`, accept workflow-selected
-permissions, support write access, or enable private actions. Alternate
-repositories or refs and credential persistence remain unsupported.
+The helper is configured only on the verified fetch command, with HTTP-path
+matching enabled. It is not persisted in Git config, and its job credential is
+not exposed to workflow steps. This checkout path does not populate
+`GITHUB_TOKEN` or `github.token`, use workflow `permissions`, enable private
+actions, or add support for alternate repositories or refs. The deprecated
+`--private-checkout` option is temporarily accepted as a no-op for compatibility.
 
 ### Explicit permissions provide a scoped workflow token
 
@@ -536,13 +538,6 @@ uses:
 buildkite-gha upload .github/workflows/ci.yml
 ```
 
-An installer may explicitly enable pipeline-repository private checkout:
-
-```sh
-buildkite-gha upload --private-checkout \
-  .github/workflows/ci.yml
-```
-
 When invoking the v0.4.2 release directly, add `--runtime-queue hosted`; that
 release requires the argument and uses it to
 select the `hosted` queue.
@@ -550,10 +545,9 @@ select the `hosted` queue.
 It requires `BUILDKITE=true` and `BUILDKITE_STEP_KEY`. Without `--event-path`,
 it derives a bounded compatibility snapshot from the current Buildkite build.
 With `--event-path`, it uses that explicit snapshot. Both paths remain
-unattested. Apart from the documented scoped workflow-token contract, they
-remain tokenless unless `--private-checkout` is explicitly selected; that
-checkout exception is confined to the adapter and independently
-repository-bound by the Agent service.
+unattested. Apart from the documented scoped workflow-token contract and
+Buildkite's native, job-bound repository-provider credentials for verified
+checkout, they remain free of provider credentials.
 
 The command uploads the exact executable and content-addressed plans before
 calling `buildkite-agent pipeline upload --no-interpolation --reject-secrets`.
@@ -561,7 +555,8 @@ In the current source CLI, generated jobs do not set `agents`, so Buildkite's
 pipeline or organization defaults select the agents. The deprecated
 `--runtime-queue hosted` argument remains accepted as a no-op for compatibility
 with plugin releases that pass it to v0.4.2; other values are rejected rather
-than silently ignored.
+than silently ignored. The deprecated `--private-checkout` argument is also
+accepted as a no-op for one-release migration compatibility.
 
 An importer that must select one queue can set `BUILDKITE_GHA_TARGET_QUEUE` on
 its step. The uploader maps every accepted Linux runner label to that queue,

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -1967,9 +1967,9 @@ the narrowest available boundary:
 - exact event-repository checkout under GitHub, using Buildkite's native
   repository-provider Git helper when the job enables it and anonymous Git
   otherwise, plus future Cursor Origin provider adapters;
-- compiler-authorized workflow token requests for the pipeline's exact GitHub
-  repository and explicit permission map through the current-job scoped token
-  endpoint;
+- compiler-admitted workflow token requests for the pipeline's exact GitHub
+  repository and explicit permission map, authorized and bounded by the
+  current-job endpoint's server-side repository and permission policy;
 - step summaries and annotations.
 
 Prefer documented Buildkite storage and Agent interfaces. If an action toolkit
@@ -1977,6 +1977,14 @@ requires an HTTP protocol, use the official compatible service by default with
 an explicit operator override, or provide a well-defined adapter rather than
 proxying GitHub's private service. Cache credentials authorize storage access
 only; they are distinct from the provider-feature grants below.
+
+For the native repository and scoped-token exceptions, the Buildkite backend's
+repository checks and permission allowlists are the authorization ceiling. The
+runtime omits the Agent access token from ordinary workflow subprocess
+environments, but that inheritance control is not OS-level isolation between
+hostile processes in one job. Exact checkout inputs and compiled workflow
+permissions constrain the supported client path rather than replacing the
+backend policy.
 
 Protected provider features use the supporting control-plane service:
 

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -1265,8 +1265,8 @@ Explicitly defer from beta unless implementation evidence changes the order:
 - GitHub Enterprise Server;
 - all repository event types;
 - remote private reusable workflows;
-- private checkout beyond the explicit read-only pipeline-repository exception,
-  and all private actions;
+- private checkout beyond the event repository authorized by Buildkite's
+  native repository-provider credentials, and all private actions;
 - protected secrets and GitHub authority beyond the scoped token exception for
   `secrets.GITHUB_TOKEN` and effective action metadata input defaults;
 - dynamic matrices and other runtime graph generation;
@@ -1337,12 +1337,13 @@ public checkout remains a separate provider integration gate.
   --no-config`.
   This path remains `EventUntrusted`, uses Buildkite's configured default agent
   targeting, and admits only `network`, compiler-proven Dockerfile-action
-  provenance, the scoped workflow-token contract, and the explicitly enabled
-  private-checkout exception. Operators remain responsible for selecting
-  suitably isolated agents for untrusted workflow code. Private remote action
-  source, alternate repository source, ordinary secrets, job- or
-  service-container provenance, privileged queues, and other protected
-  capabilities fail closed.
+  provenance, the scoped workflow-token contract, and compiler-verified
+  checkout. Verified checkout uses Buildkite's native repository-provider Git
+  credentials when enabled for the job and otherwise runs anonymously.
+  Operators remain responsible for selecting suitably isolated agents for
+  untrusted workflow code. Private remote action source, alternate repository
+  source, ordinary secrets, job- or service-container provenance, privileged
+  queues, and other protected capabilities fail closed.
   Because this repository is private, the historical live evidence is split:
   the former proof importer used a synthetic public event to prove anonymous
   checkout and portable setup actions on Buildkite, while the GitHub-hosted
@@ -1963,11 +1964,12 @@ the narrowest available boundary:
 - cache restore/save through the stock audited cache-v2 client, a compatible
   Results service, and short-lived job-bound GHAC credentials;
 - artifact upload/download through bounded native adapters;
-- public checkout under GitHub and Cursor Origin provider adapters;
-- explicitly enabled private checkout of the pipeline's exact GitHub
-  repository through the current job's scoped Agent token endpoint; and
+- exact event-repository checkout under GitHub, using Buildkite's native
+  repository-provider Git helper when the job enables it and anonymous Git
+  otherwise, plus future Cursor Origin provider adapters;
 - compiler-authorized workflow token requests for the pipeline's exact GitHub
-  repository and explicit permission map through that same job endpoint;
+  repository and explicit permission map through the current-job scoped token
+  endpoint;
 - step summaries and annotations.
 
 Prefer documented Buildkite storage and Agent interfaces. If an action toolkit
@@ -1985,7 +1987,7 @@ Protected provider features use the supporting control-plane service:
 - evaluate organization, event, environment, queue, and requested-permission
   policy;
 - issue signed, expiring grants bound to exact plan digests and jobs;
-- broker private checkout and action access, selected secrets, and scoped
+- broker broader private source and action access, selected secrets, and scoped
   GitHub App installation tokens; and
 - maintain audit records, expiry, revocation, key rotation, and fail-closed
   behavior.
@@ -2000,9 +2002,9 @@ Delivery slices:
 3. Prove Job OIDC authentication, build/job binding, GitHub provenance checks,
    policy evaluation, and signed no-op grants before returning credentials.
 4. Add private source through the narrowest practical credential or download
-   interface. The first sub-slice is fixed `contents:read` checkout of the
-   pipeline's exact repository through the current job's scoped Agent endpoint;
-   private actions and private reusable-workflow source remain separate work.
+   interface. Exact event-repository checkout uses the existing Buildkite Agent
+   Git credential helper; private actions and private reusable-workflow source
+   remain separate work.
 5. Add scoped GitHub tokens, selected secrets, and environment grants. The
    job-bound Agent endpoint now covers explicit workflow tokens; selected
    secrets and general provenance-aware grants remain.
@@ -2042,7 +2044,8 @@ Definition of done:
 - A forged event, wrong build/job/queue, expired grant, broadened permission,
   and fork-to-privileged transition all fail before a protected value is
   returned.
-- Public tokenless workflows still run when the control-plane service is absent.
+- Public checkout still runs anonymously when repository-provider credentials
+  and the control-plane service are absent.
 - The validator distinguishes portable and provider-dependent actions and names
   any unavailable protected capability.
 
@@ -2328,9 +2331,10 @@ interfaces required by [ADR 0003](../architecture/0003-protected-capability-cont
 Private actions and reusable workflows, workflow-visible provider tokens and
 secrets beyond the scoped `secrets.GITHUB_TOKEN` and action-metadata-default
 exceptions, environments, and compatible OIDC remain fail-closed during that
-work. The explicit private-checkout exception is limited to fixed read-only Git
-use for the pipeline repository. Neither narrow exception relaxes the other
-deferrals.
+work. Compiler-verified checkout can use only Buildkite's native
+repository-provider credentials for the exact event repository and is
+anonymous when those credentials are unavailable.
+Neither narrow exception relaxes the other deferrals.
 
 The complete published installation experience is now proven. The initial CLI
 and companion plugin `v0.2.0` releases remain the subject of the repository's

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -49,7 +49,7 @@ Run "buildkite-gha help <command>" for command help.
 var commandUsage = map[string]string{
 	"validate": "Usage: buildkite-gha validate [--event-path <path>] [--profile hosted-tokenless] [--format text|json] <workflow>\n",
 	"compile":  "Usage: buildkite-gha compile --event-path <path> [--format pipeline|ir-json] <workflow>\n",
-	"upload":   "Usage: buildkite-gha upload [--event-path <path>] [--private-checkout] [--runtime-queue hosted] <workflow>\n",
+	"upload":   "Usage: buildkite-gha upload [--event-path <path>] [--runtime-queue hosted] <workflow>\n",
 	"run-job":  "Usage: buildkite-gha run-job --plan <path> [--result <path>]\n",
 }
 
@@ -61,20 +61,26 @@ func writeCommandHelp(stdout io.Writer, command string) {
 	case "compile":
 		_, _ = fmt.Fprint(stdout, "\nPipeline output references content-addressed plans; compile does not materialize or upload those artifacts.\n")
 	case "upload":
-		_, _ = fmt.Fprintf(stdout, "\nGenerated jobs use Buildkite's default agent targeting. An importer can explicitly target one queue with %s; that queue must be suitable for untrusted workflow code. The deprecated --runtime-queue hosted option is accepted for plugin compatibility but does not select a queue. The default path accepts an explicit event file or derives compatibility data from Buildkite and remains unsigned. --private-checkout opts only verified checkout jobs into current-job, read-only pipeline-repository authority.\n", targetQueueEnvironment)
+		_, _ = fmt.Fprintf(stdout, "\nGenerated jobs use Buildkite's default agent targeting. An importer can explicitly target one queue with %s; that queue must be suitable for untrusted workflow code. The deprecated --runtime-queue hosted option is accepted for plugin compatibility but does not select a queue. The default path accepts an explicit event file or derives compatibility data from Buildkite and remains unsigned. Verified checkout jobs automatically use Buildkite repository-provider Git credentials when the job enables them; the deprecated --private-checkout option is accepted as a no-op.\n", targetQueueEnvironment)
 	}
 }
 
 const (
-	resultPublicationTimeout = 10 * time.Second
-	legacyRuntimeQueue       = "hosted"
-	targetQueueEnvironment   = "BUILDKITE_GHA_TARGET_QUEUE"
-	hostedTokenlessProfile   = "hosted-tokenless"
-	runtimeMiseArchiveDigest = "bd0930c0b619f51ddb60e32e5cce18a5533567b2f1ba9fc4875b9f39a2bb3ed8"
-	runtimeMiseBinaryDigest  = "a238972a3162d710b85b28c324372e96ca4e4b486c81fe78695000d9fbc77c48"
-	runtimeMiseArchiveLimit  = 64 << 20
-	runtimeMiseBinaryLimit   = 128 << 20
+	resultPublicationTimeout                    = 10 * time.Second
+	legacyRuntimeQueue                          = "hosted"
+	targetQueueEnvironment                      = "BUILDKITE_GHA_TARGET_QUEUE"
+	repositoryProviderGitCredentialsEnvironment = "BUILDKITE_USE_REPOSITORY_PROVIDER_GIT_CREDENTIALS"
+	legacyGitHubAppGitCredentialsEnvironment    = "BUILDKITE_USE_GITHUB_APP_GIT_CREDENTIALS"
+	hostedTokenlessProfile                      = "hosted-tokenless"
+	runtimeMiseArchiveDigest                    = "bd0930c0b619f51ddb60e32e5cce18a5533567b2f1ba9fc4875b9f39a2bb3ed8"
+	runtimeMiseBinaryDigest                     = "a238972a3162d710b85b28c324372e96ca4e4b486c81fe78695000d9fbc77c48"
+	runtimeMiseArchiveLimit                     = 64 << 20
+	runtimeMiseBinaryLimit                      = 128 << 20
 )
+
+func repositoryProviderGitCredentialsEnabled(getenv func(string) string) bool {
+	return getenv(repositoryProviderGitCredentialsEnvironment) == "true" || getenv(legacyGitHubAppGitCredentialsEnvironment) == "true"
+}
 
 // Run executes the command and returns its process exit code.
 func Run(args []string, stdout, stderr io.Writer, version string) int {
@@ -227,9 +233,8 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 			return 1
 		}
 	}
-	var checkoutTokens gharuntime.CheckoutTokenProvider
 	var workflowTokens gharuntime.WorkflowTokenProvider
-	if job.HasCapability("provider-token-read") || job.HasCapability("provider-token-write") {
+	if job.HasCapability("provider-token-write") {
 		githubTokens, tokenErr := gharuntime.NewAgentGitHubTokens(gharuntime.AgentGitHubTokenConfig{
 			Endpoint: os.Getenv("BUILDKITE_AGENT_ENDPOINT"),
 			JobID:    os.Getenv("BUILDKITE_JOB_ID"),
@@ -239,26 +244,31 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: configure GitHub token service: %v\n", tokenErr)
 			return 1
 		}
-		if job.HasCapability("provider-token-read") {
-			checkoutTokens = githubTokens
-		}
-		if job.HasCapability("provider-token-write") {
-			workflowTokens = githubTokens
+		workflowTokens = githubTokens
+	}
+	var repositoryCredentials *gharuntime.AgentRepositoryCredentials
+	if repositoryProviderGitCredentialsEnabled(os.Getenv) {
+		repositoryCredentials = &gharuntime.AgentRepositoryCredentials{
+			Agent:    os.Getenv("BUILDKITE_GHA_AGENT"),
+			Endpoint: os.Getenv("BUILDKITE_AGENT_ENDPOINT"),
+			JobID:    os.Getenv("BUILDKITE_JOB_ID"),
+			JobToken: os.Getenv("BUILDKITE_AGENT_ACCESS_TOKEN"),
+			NoHTTP2:  os.Getenv("BUILDKITE_NO_HTTP2"),
 		}
 	}
 	runner := gharuntime.Runner{
-		Stdout:        stdout,
-		Stderr:        stderr,
-		MiseDataDir:   prepareMiseDataDir(os.Getenv("BUILDKITE_GHA_MISE_DATA_DIR"), stderr),
-		Docker:        os.Getenv("BUILDKITE_GHA_DOCKER"),
-		Git:           os.Getenv("BUILDKITE_GHA_GIT"),
-		Secrets:       gharuntime.EnvironmentSecrets{},
-		Redactor:      gharuntime.AgentRedactor{Executable: os.Getenv("BUILDKITE_GHA_AGENT")},
-		Actions:       actionMaterializer,
-		Artifacts:     agent,
-		Cache:         cacheCredentials,
-		Checkout:      checkoutTokens,
-		WorkflowToken: workflowTokens,
+		Stdout:                stdout,
+		Stderr:                stderr,
+		MiseDataDir:           prepareMiseDataDir(os.Getenv("BUILDKITE_GHA_MISE_DATA_DIR"), stderr),
+		Docker:                os.Getenv("BUILDKITE_GHA_DOCKER"),
+		Git:                   os.Getenv("BUILDKITE_GHA_GIT"),
+		Secrets:               gharuntime.EnvironmentSecrets{},
+		Redactor:              gharuntime.AgentRedactor{Executable: os.Getenv("BUILDKITE_GHA_AGENT")},
+		Actions:               actionMaterializer,
+		Artifacts:             agent,
+		Cache:                 cacheCredentials,
+		RepositoryCredentials: repositoryCredentials,
+		WorkflowToken:         workflowTokens,
 	}
 	runner.RuntimeExecutable, err = os.Executable()
 	if err != nil {
@@ -903,7 +913,7 @@ func validate(args []string, stdout, stderr io.Writer, version string) int {
 		}
 		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 		defer stop()
-		preflight, profileErr := compileHostedTokenless(ctx, workflowPath, source, event, version, distributionDigest, "buildkite-gha-profile-importer", "", "", false)
+		preflight, profileErr := compileHostedTokenless(ctx, workflowPath, source, event, version, distributionDigest, "buildkite-gha-profile-importer", "", "")
 		if profileErr != nil {
 			if ctx.Err() != nil || errors.Is(profileErr, context.Canceled) {
 				_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: profile evaluation interrupted: %v\n", profileErr)
@@ -1059,7 +1069,7 @@ func writeCompilerWarnings(stderr io.Writer, command, path string, warnings []co
 }
 
 func upload(args []string, stdout, stderr io.Writer, version string, agent transport.Agent) int {
-	workflowPath, eventPath, privateCheckout, err := uploadArgs(args)
+	workflowPath, eventPath, err := uploadArgs(args)
 	if err != nil {
 		return usageError(stderr, "upload: %v", err)
 	}
@@ -1093,7 +1103,7 @@ func upload(args []string, stdout, stderr io.Writer, version string, agent trans
 	}
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
-	preflight, err := compileHostedTokenless(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, os.Getenv("BUILDKITE_GROUP_LABEL"), targetQueue, privateCheckout)
+	preflight, err := compileHostedTokenless(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, os.Getenv("BUILDKITE_GROUP_LABEL"), targetQueue)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
 		return 1
@@ -1150,7 +1160,7 @@ func hostedTokenlessError(kind hostedTokenlessFailureKind, err error) error {
 	return &hostedTokenlessFailure{Kind: kind, Err: err}
 }
 
-func compileHostedTokenless(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel, targetQueue string, privateCheckout bool) (hostedTokenlessCompilation, error) {
+func compileHostedTokenless(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel, targetQueue string) (hostedTokenlessCompilation, error) {
 	preflight, err := compiler.Compile(workflowPath, workflowSource, eventSource)
 	if err != nil {
 		return hostedTokenlessCompilation{}, hostedTokenlessError(hostedTokenlessEvaluationFailure, err)
@@ -1161,9 +1171,8 @@ func compileHostedTokenless(ctx context.Context, workflowPath string, workflowSo
 	}
 	hasActions := irUsesActions(ir)
 	options := compiler.Options{
-		EventTrust:     compiler.EventUntrusted,
-		GroupLabel:     groupLabel,
-		ResolveActions: privateCheckout,
+		EventTrust: compiler.EventUntrusted,
+		GroupLabel: groupLabel,
 		Runners: compiler.RunnerPolicy{
 			Labels: map[string]string{
 				"ubuntu-latest": targetQueue,
@@ -1172,7 +1181,6 @@ func compileHostedTokenless(ctx context.Context, workflowPath string, workflowSo
 			},
 			AllowUntrustedDefaultQueue: targetQueue == "",
 		},
-		PrivateCheckout: privateCheckout,
 	}
 	if targetQueue != "" {
 		options.Runners.UntrustedQueues = []string{targetQueue}
@@ -1198,7 +1206,7 @@ func compileHostedTokenless(ctx context.Context, workflowPath string, workflowSo
 	if err != nil {
 		return hostedTokenlessCompilation{}, hostedTokenlessError(hostedTokenlessEvaluationFailure, err)
 	}
-	if err := validateUnprivilegedBundleWithPrivateCheckout(bundle, privateCheckout); err != nil {
+	if err := validateUnprivilegedBundle(bundle); err != nil {
 		return hostedTokenlessCompilation{}, hostedTokenlessError(hostedTokenlessAdmissionFailure, err)
 	}
 	if !hasActions && bundleUsesActions(bundle) {
@@ -1208,10 +1216,6 @@ func compileHostedTokenless(ctx context.Context, workflowPath string, workflowSo
 }
 
 func validateUnprivilegedBundle(bundle compiler.Bundle) error {
-	return validateUnprivilegedBundleWithPrivateCheckout(bundle, false)
-}
-
-func validateUnprivilegedBundleWithPrivateCheckout(bundle compiler.Bundle, privateCheckout bool) error {
 	for _, artifact := range bundle.Plans {
 		for _, capability := range artifact.Job.RequiredCapabilities {
 			if capability == "docker" && !slices.Equal(artifact.Authorization.DockerCapabilitySources, []string{"dockerfile-actions"}) {
@@ -1221,8 +1225,8 @@ func validateUnprivilegedBundleWithPrivateCheckout(bundle compiler.Bundle, priva
 				return fmt.Errorf("job %q requires docker without compiler-verified Dockerfile action provenance", artifact.Job.Workflow.LogicalJobID)
 			}
 			if capability == "provider-token-read" {
-				if !privateCheckout || !slices.Equal(artifact.Authorization.ProviderTokenReadCapabilitySources, []string{"checkout-adapter"}) {
-					return fmt.Errorf("job %q requires provider-token-read without compiler-verified private checkout provenance", artifact.Job.Workflow.LogicalJobID)
+				if !slices.Equal(artifact.Authorization.ProviderTokenReadCapabilitySources, []string{"checkout-adapter"}) {
+					return fmt.Errorf("job %q requires provider-token-read without compiler-verified checkout provenance", artifact.Job.Workflow.LogicalJobID)
 				}
 				continue
 			}
@@ -1277,18 +1281,17 @@ func bundleUsesActions(bundle compiler.Bundle) bool {
 	return false
 }
 
-func uploadArgs(args []string) (workflowPath, eventPath string, privateCheckout bool, err error) {
+func uploadArgs(args []string) (workflowPath, eventPath string, err error) {
 	filtered := make([]string, 0, len(args))
 	runtimeQueue := ""
 	runtimeQueueSeen := false
-	privateCheckoutSeen := false
+	deprecatedPrivateCheckoutSeen := false
 	for i := 0; i < len(args); i++ {
 		if args[i] == "--private-checkout" {
-			if privateCheckoutSeen {
-				return "", "", false, fmt.Errorf("--private-checkout may only be specified once")
+			if deprecatedPrivateCheckoutSeen {
+				return "", "", fmt.Errorf("--private-checkout may only be specified once")
 			}
-			privateCheckoutSeen = true
-			privateCheckout = true
+			deprecatedPrivateCheckoutSeen = true
 			continue
 		}
 		if args[i] != "--runtime-queue" {
@@ -1296,23 +1299,23 @@ func uploadArgs(args []string) (workflowPath, eventPath string, privateCheckout 
 			continue
 		}
 		if runtimeQueueSeen {
-			return "", "", false, fmt.Errorf("--runtime-queue may only be specified once")
+			return "", "", fmt.Errorf("--runtime-queue may only be specified once")
 		}
 		runtimeQueueSeen = true
 		i++
 		if i == len(args) {
-			return "", "", false, fmt.Errorf("--runtime-queue requires a queue")
+			return "", "", fmt.Errorf("--runtime-queue requires a queue")
 		}
 		runtimeQueue = args[i]
 	}
 	workflowPath, eventPath, err = workflowArgs(filtered)
 	if err != nil {
-		return "", "", false, err
+		return "", "", err
 	}
 	if runtimeQueueSeen && runtimeQueue != legacyRuntimeQueue {
-		return "", "", false, fmt.Errorf("deprecated --runtime-queue must be %q", legacyRuntimeQueue)
+		return "", "", fmt.Errorf("deprecated --runtime-queue must be %q", legacyRuntimeQueue)
 	}
-	return workflowPath, eventPath, privateCheckout, err
+	return workflowPath, eventPath, err
 }
 
 func compileArgs(args []string) (workflowPath, eventPath, format string, err error) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1298,7 +1298,7 @@ func TestRunUploadFailsClosedBeforePipeline(t *testing.T) {
 }
 
 func TestUnprivilegedUploadRejectsCapabilities(t *testing.T) {
-	for _, capability := range []string{"secrets", "provider-token-read", "provider-token-write", "privileged-container", "future-capability"} {
+	for _, capability := range []string{"secrets", "provider-token-write", "privileged-container", "future-capability"} {
 		bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: plan.Job{
 			Workflow:             plan.Workflow{LogicalJobID: "protected"},
 			RequiredCapabilities: []string{capability},
@@ -1309,26 +1309,24 @@ func TestUnprivilegedUploadRejectsCapabilities(t *testing.T) {
 	}
 }
 
-func TestUnprivilegedUploadAdmitsOnlyCompilerVerifiedPrivateCheckout(t *testing.T) {
+func TestUnprivilegedUploadAdmitsOnlyCompilerVerifiedCheckoutCredentials(t *testing.T) {
 	job := plan.Job{
-		Workflow:             plan.Workflow{LogicalJobID: "private-checkout"},
+		Workflow:             plan.Workflow{LogicalJobID: "checkout"},
 		RequiredCapabilities: []string{"network", "provider-token-read"},
 	}
 	for _, test := range []struct {
 		name          string
-		enabled       bool
 		authorization compiler.PlanAuthorization
 		wantError     bool
 	}{
-		{name: "explicit verified adapter", enabled: true, authorization: compiler.PlanAuthorization{ProviderTokenReadCapabilitySources: []string{"checkout-adapter"}}},
-		{name: "default profile", authorization: compiler.PlanAuthorization{ProviderTokenReadCapabilitySources: []string{"checkout-adapter"}}, wantError: true},
-		{name: "missing provenance", enabled: true, wantError: true},
-		{name: "broadened provenance", enabled: true, authorization: compiler.PlanAuthorization{ProviderTokenReadCapabilitySources: []string{"checkout-adapter", "javascript-action"}}, wantError: true},
+		{name: "verified adapter", authorization: compiler.PlanAuthorization{ProviderTokenReadCapabilitySources: []string{"checkout-adapter"}}},
+		{name: "missing provenance", wantError: true},
+		{name: "broadened provenance", authorization: compiler.PlanAuthorization{ProviderTokenReadCapabilitySources: []string{"checkout-adapter", "javascript-action"}}, wantError: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: job, Authorization: test.authorization}}}
-			err := validateUnprivilegedBundleWithPrivateCheckout(bundle, test.enabled)
-			if test.wantError && (err == nil || !strings.Contains(err.Error(), "private checkout provenance")) {
+			err := validateUnprivilegedBundle(bundle)
+			if test.wantError && (err == nil || !strings.Contains(err.Error(), "checkout provenance")) {
 				t.Fatalf("validateUnprivilegedBundle() error = %v", err)
 			}
 			if !test.wantError && err != nil {
@@ -2128,22 +2126,43 @@ func TestArgumentParsersRejectRepeatedOptions(t *testing.T) {
 	if _, _, _, err := compileArgs([]string{"--format", "pipeline", "--format", "ir-json", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
 		t.Fatalf("compileArgs() error = %v, want duplicate format error", err)
 	}
-	if _, _, _, err := uploadArgs([]string{"--runtime-queue", "one", "--runtime-queue", "two", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
+	if _, _, err := uploadArgs([]string{"--runtime-queue", "one", "--runtime-queue", "two", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
 		t.Fatalf("uploadArgs() error = %v, want duplicate runtime queue error", err)
 	}
-	workflow, event, privateCheckout, err := uploadArgs([]string{"workflow.yml"})
-	if err != nil || workflow != "workflow.yml" || event != "" || privateCheckout {
-		t.Fatalf("uploadArgs() default = %q, %q, %v, %v", workflow, event, privateCheckout, err)
+	workflow, event, err := uploadArgs([]string{"workflow.yml"})
+	if err != nil || workflow != "workflow.yml" || event != "" {
+		t.Fatalf("uploadArgs() default = %q, %q, %v", workflow, event, err)
 	}
-	if _, _, _, err := uploadArgs([]string{"--runtime-queue", "custom-runners", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), `must be "hosted"`) {
+	if _, _, err := uploadArgs([]string{"--runtime-queue", "custom-runners", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), `must be "hosted"`) {
 		t.Fatalf("uploadArgs() error = %v, want legacy runtime queue error", err)
 	}
-	if _, _, _, err := uploadArgs([]string{"--private-checkout", "--private-checkout", "--runtime-queue", "hosted", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
+	if _, _, err := uploadArgs([]string{"--private-checkout", "--private-checkout", "--runtime-queue", "hosted", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
 		t.Fatalf("uploadArgs() error = %v, want duplicate private checkout error", err)
 	}
-	workflow, event, privateCheckout, err = uploadArgs([]string{"--private-checkout", "--runtime-queue", "hosted", "--event-path", "event.json", "workflow.yml"})
-	if err != nil || workflow != "workflow.yml" || event != "event.json" || !privateCheckout {
-		t.Fatalf("uploadArgs() = %q, %q, %v, %v", workflow, event, privateCheckout, err)
+	workflow, event, err = uploadArgs([]string{"--private-checkout", "--runtime-queue", "hosted", "--event-path", "event.json", "workflow.yml"})
+	if err != nil || workflow != "workflow.yml" || event != "event.json" {
+		t.Fatalf("uploadArgs() deprecated private checkout = %q, %q, %v", workflow, event, err)
+	}
+}
+
+func TestRepositoryProviderGitCredentialsUseServerEnvironment(t *testing.T) {
+	values := map[string]string{}
+	getenv := func(name string) string { return values[name] }
+	if repositoryProviderGitCredentialsEnabled(getenv) {
+		t.Fatal("repository provider credentials enabled without a server setting")
+	}
+	values[repositoryProviderGitCredentialsEnvironment] = "true"
+	if !repositoryProviderGitCredentialsEnabled(getenv) {
+		t.Fatal("repository provider credentials setting was ignored")
+	}
+	delete(values, repositoryProviderGitCredentialsEnvironment)
+	values[legacyGitHubAppGitCredentialsEnvironment] = "true"
+	if !repositoryProviderGitCredentialsEnabled(getenv) {
+		t.Fatal("legacy GitHub App credentials setting was ignored")
+	}
+	values[legacyGitHubAppGitCredentialsEnvironment] = "TRUE"
+	if repositoryProviderGitCredentialsEnabled(getenv) {
+		t.Fatal("non-canonical server setting enabled repository credentials")
 	}
 }
 

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -638,7 +638,7 @@ func TestCompilePlansContainersWithRemoteActionsRequireResolution(t *testing.T) 
 	}
 }
 
-func TestTokenlessCheckoutAdapterInputBoundary(t *testing.T) {
+func TestCheckoutAdapterInputBoundary(t *testing.T) {
 	workspace, remote := t.TempDir(), t.TempDir()
 	workflowPath := filepath.Join(workspace, ".github", "workflows", "checkout.yml")
 	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
@@ -669,10 +669,10 @@ func TestTokenlessCheckoutAdapterInputBoundary(t *testing.T) {
 	for _, with := range accepted {
 		plans, err := compile(with)
 		if err != nil {
-			t.Fatalf("tokenless checkout with %q: %v", with, err)
+			t.Fatalf("checkout with %q: %v", with, err)
 		}
-		if len(plans) != 1 || !reflect.DeepEqual(plans[0].RequiredCapabilities, []string{"network"}) {
-			t.Fatalf("tokenless checkout plans = %#v", plans)
+		if len(plans) != 1 || !reflect.DeepEqual(plans[0].RequiredCapabilities, []string{"network", "provider-token-read"}) {
+			t.Fatalf("checkout plans = %#v", plans)
 		}
 	}
 
@@ -689,21 +689,21 @@ func TestTokenlessCheckoutAdapterInputBoundary(t *testing.T) {
 	for name, input := range rejected {
 		t.Run(name, func(t *testing.T) {
 			_, err := compile("        with:\n" + input)
-			if err == nil || !strings.Contains(err.Error(), "checkout.yml:") || !strings.Contains(err.Error(), "tokenless checkout adapter") || !strings.Contains(err.Error(), "Phase 6") {
+			if err == nil || !strings.Contains(err.Error(), "checkout.yml:") || !strings.Contains(err.Error(), "checkout adapter") || !strings.Contains(err.Error(), "Phase 6") {
 				t.Fatalf("CompilePlansWithOptions() error = %v", err)
 			}
 		})
 	}
 }
 
-func TestPrivateCheckoutCapabilityRequiresVerifiedRootAdapter(t *testing.T) {
+func TestCheckoutCapabilityRequiresVerifiedRootAdapter(t *testing.T) {
 	workspace, remote := t.TempDir(), t.TempDir()
 	workflowPath := filepath.Join(workspace, ".github", "workflows", "checkout.yml")
 	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	writeAction(t, remote, "", "name: checkout\nruns:\n  using: node24\n  main: index.js\n")
-	compile := func(uses, with string, private bool) (Bundle, error) {
+	compile := func(uses, with string) (Bundle, error) {
 		workflow := []byte("on: push\njobs:\n  checkout:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: " + uses + "\n" + with)
 		if err := os.WriteFile(workflowPath, workflow, 0o644); err != nil {
 			t.Fatal(err)
@@ -714,30 +714,21 @@ func TestPrivateCheckoutCapabilityRequiresVerifiedRootAdapter(t *testing.T) {
 				Labels:          map[string]string{"ubuntu-latest": "hosted"},
 				UntrustedQueues: []string{"hosted"},
 			},
-			ResolveActions:  true,
-			ActionSource:    &fakeActionSource{root: remote, calls: map[string]int{}},
-			PrivateCheckout: private,
+			ResolveActions: true,
+			ActionSource:   &fakeActionSource{root: remote, calls: map[string]int{}},
 		})
 	}
 
-	bundle, err := compile("actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1", "", true)
+	bundle, err := compile("actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(bundle.Plans) != 1 || !reflect.DeepEqual(bundle.Plans[0].Job.RequiredCapabilities, []string{"network", "provider-token-read"}) ||
 		!reflect.DeepEqual(bundle.Plans[0].Authorization.ProviderTokenReadCapabilitySources, []string{"checkout-adapter"}) {
-		t.Fatalf("private checkout plan = %#v", bundle.Plans)
+		t.Fatalf("checkout plan = %#v", bundle.Plans)
 	}
 
-	bundle, err = compile("actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1", "", false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(bundle.Plans[0].Job.RequiredCapabilities, []string{"network"}) || len(bundle.Plans[0].Authorization.ProviderTokenReadCapabilitySources) != 0 {
-		t.Fatalf("default checkout authority changed = %#v", bundle.Plans[0])
-	}
-
-	bundle, err = compile("owner/action@v1", "", true)
+	bundle, err = compile("owner/action@v1", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -745,8 +736,8 @@ func TestPrivateCheckoutCapabilityRequiresVerifiedRootAdapter(t *testing.T) {
 		t.Fatalf("ordinary action received checkout authority = %#v", bundle.Plans[0])
 	}
 
-	_, err = compile("actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1", "        with:\n          token: '${{ github.token }}'\n", true)
-	if err == nil || !strings.Contains(err.Error(), "tokenless checkout adapter") || !strings.Contains(err.Error(), "Phase 6") {
+	_, err = compile("actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1", "        with:\n          token: '${{ github.token }}'\n")
+	if err == nil || !strings.Contains(err.Error(), "checkout adapter") || !strings.Contains(err.Error(), "Phase 6") {
 		t.Fatalf("workflow token input error = %v", err)
 	}
 }

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -338,12 +338,10 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 				if descriptor.Adapter == actionintegration.AdapterCheckoutExactEventSHA {
 					if err := actionintegration.ValidateCheckoutInputs(instance.Steps[stepIndex].With, ir.Event.Repository.Owner+"/"+ir.Event.Repository.Name, ir.Event.SHA); err != nil {
 						span := instance.Steps[stepIndex].Span.Start
-						return nil, nil, fmt.Errorf("%s:%d:%d: tokenless checkout adapter: %w", instance.SourcePath, span.Line, span.Column, err)
+						return nil, nil, fmt.Errorf("%s:%d:%d: checkout adapter: %w", instance.SourcePath, span.Line, span.Column, err)
 					}
-					if options.PrivateCheckout {
-						capabilities = append(capabilities, "provider-token-read")
-						authorization.ProviderTokenReadCapabilitySources = append(authorization.ProviderTokenReadCapabilitySources, "checkout-adapter")
-					}
+					capabilities = append(capabilities, "provider-token-read")
+					authorization.ProviderTokenReadCapabilitySources = append(authorization.ProviderTokenReadCapabilitySources, "checkout-adapter")
 				}
 				if descriptor.Adapter == actionintegration.AdapterUploadArtifactBuildkite {
 					if err := actionintegration.ValidateUploadArtifactInputs(instance.Steps[stepIndex].With); err != nil {

--- a/internal/compiler/config.go
+++ b/internal/compiler/config.go
@@ -48,10 +48,6 @@ type Options struct {
 	// access. ActionSource is required only when a workflow uses remote actions.
 	ResolveActions bool
 	ActionSource   ActionSource
-	// PrivateCheckout adds provider-token-read only to compiler-verified
-	// actions/checkout adapter steps. It does not expose a workflow token or
-	// alter the permissions fixed by the runtime credential provider.
-	PrivateCheckout bool
 	// GroupLabel merges generated jobs into the Buildkite group containing the
 	// importer. It affects pipeline presentation only, not compiler IR or plans.
 	GroupLabel string
@@ -77,9 +73,6 @@ func (options Options) validate() error {
 	}
 	if !options.ResolveActions && options.ActionSource != nil {
 		return fmt.Errorf("action source configuration requires ResolveActions")
-	}
-	if options.PrivateCheckout && !options.ResolveActions {
-		return fmt.Errorf("private checkout requires ResolveActions")
 	}
 	if len(options.Runners.Labels) == 0 {
 		return fmt.Errorf("runner policy requires at least one label mapping")

--- a/internal/compiler/config_test.go
+++ b/internal/compiler/config_test.go
@@ -104,14 +104,6 @@ func TestUntrustedOptionsPermitAnonymousPublicActionSource(t *testing.T) {
 	}
 }
 
-func TestPrivateCheckoutRequiresActionResolution(t *testing.T) {
-	options := defaultOptions()
-	options.PrivateCheckout = true
-	if err := options.validate(); err == nil || !strings.Contains(err.Error(), "requires ResolveActions") {
-		t.Fatalf("Options.validate() error = %v", err)
-	}
-}
-
 func TestOptionsRejectActionConfigurationWithoutResolution(t *testing.T) {
 	options := defaultOptions()
 	options.ActionSource = &fakeActionSource{}

--- a/internal/runtime/cache_service.go
+++ b/internal/runtime/cache_service.go
@@ -35,8 +35,8 @@ type CacheCredentialProvider interface {
 }
 
 // AgentCacheConfig identifies the exact current Buildkite job and cache-v2
-// service. Endpoint and JobToken are runtime authority and are never forwarded
-// to action code.
+// service. Endpoint and JobToken are runtime connection and authentication
+// material; this provider does not add them to action subprocess environments.
 type AgentCacheConfig struct {
 	Endpoint   string
 	JobID      string

--- a/internal/runtime/checkout.go
+++ b/internal/runtime/checkout.go
@@ -15,15 +15,20 @@ import (
 
 var checkoutRepositoryPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`)
 var checkoutSHAPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
+var agentProxyEnvironmentNames = [...]string{
+	"HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY",
+	"http_proxy", "https_proxy", "all_proxy", "no_proxy",
+}
 
 // AgentRepositoryCredentials configure Buildkite's native, job-bound Git
 // credential helper for one verified checkout fetch.
 type AgentRepositoryCredentials struct {
-	Agent    string
-	Endpoint string
-	JobID    string
-	JobToken string
-	NoHTTP2  string
+	Agent            string
+	Endpoint         string
+	JobID            string
+	JobToken         string
+	NoHTTP2          string
+	proxyEnvironment map[string]string
 }
 
 func resolveAgentRepositoryCredentialsBeforeWorkflow(credentials *AgentRepositoryCredentials) (*AgentRepositoryCredentials, error) {
@@ -42,6 +47,12 @@ func resolveAgentRepositoryCredentialsBeforeWorkflow(credentials *AgentRepositor
 	}
 	resolved := *credentials
 	resolved.Agent = agent
+	resolved.proxyEnvironment = make(map[string]string, len(agentProxyEnvironmentNames))
+	for _, name := range agentProxyEnvironmentNames {
+		if value, ok := os.LookupEnv(name); ok {
+			resolved.proxyEnvironment[name] = value
+		}
+	}
 	return &resolved, nil
 }
 
@@ -141,6 +152,9 @@ func (r Runner) runRepositoryProviderCheckoutFetch(ctx context.Context, processo
 	}
 	if credentials.NoHTTP2 != "" {
 		credentialEnv["BUILDKITE_NO_HTTP2"] = credentials.NoHTTP2
+	}
+	for name, value := range credentials.proxyEnvironment {
+		credentialEnv[name] = value
 	}
 	credentialArgs := append(append([]string(nil), base...),
 		"-c", "credential.useHttpPath=true",

--- a/internal/runtime/checkout.go
+++ b/internal/runtime/checkout.go
@@ -3,7 +3,6 @@ package runtime
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,6 +16,39 @@ import (
 var checkoutRepositoryPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`)
 var checkoutSHAPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
 
+// AgentRepositoryCredentials configure Buildkite's native, job-bound Git
+// credential helper for one verified checkout fetch.
+type AgentRepositoryCredentials struct {
+	Agent    string
+	Endpoint string
+	JobID    string
+	JobToken string
+	NoHTTP2  string
+}
+
+func resolveAgentRepositoryCredentialsBeforeWorkflow(credentials *AgentRepositoryCredentials) (*AgentRepositoryCredentials, error) {
+	if credentials == nil {
+		return nil, nil
+	}
+	if !validBuildkiteJobID(credentials.JobID) {
+		return nil, fmt.Errorf("repository-provider credentials require the current Buildkite job ID")
+	}
+	if credentials.JobToken == "" || strings.ContainsAny(credentials.JobToken, "\r\n") {
+		return nil, fmt.Errorf("repository-provider credentials require the current Buildkite Agent access token")
+	}
+	agent, err := resolveHostExecutableBeforeWorkflow(credentials.Agent, "buildkite-agent", "Buildkite Agent Git credential helper")
+	if err != nil {
+		return nil, err
+	}
+	resolved := *credentials
+	resolved.Agent = agent
+	return &resolved, nil
+}
+
+func agentGitCredentialHelperCommand(agent string) string {
+	return "!'" + strings.ReplaceAll(agent, "'", `'\''`) + "' git-credentials-helper"
+}
+
 func validCheckoutRepository(repository string) bool {
 	if len(repository) > 140 || !checkoutRepositoryPattern.MatchString(repository) {
 		return false
@@ -27,16 +59,9 @@ func validCheckoutRepository(repository string) bool {
 
 func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, inputs map[string]string) (Result, error) {
 	result := newResult()
-	private := job.HasCapability("provider-token-read")
-	adapter := "tokenless checkout adapter"
-	if private {
-		adapter = "private checkout adapter"
-	}
-	validRepository := checkoutRepositoryPattern.MatchString(job.Event.Repository)
-	if private {
-		validRepository = validCheckoutRepository(job.Event.Repository)
-	}
-	if job.Event.Provider != "github" || !validRepository || !checkoutSHAPattern.MatchString(job.Event.SHA) {
+	const adapter = "checkout adapter"
+	credentialed := job.HasCapability("provider-token-read") && r.RepositoryCredentials != nil
+	if job.Event.Provider != "github" || !validCheckoutRepository(job.Event.Repository) || !checkoutSHAPattern.MatchString(job.Event.SHA) {
 		return result, fmt.Errorf("%s requires a valid github.com event repository and exact SHA; Phase 6 is required for other events", adapter)
 	}
 	if err := actionintegration.ValidateCheckoutInputs(inputs, job.Event.Repository, job.Event.SHA); err != nil {
@@ -44,20 +69,20 @@ func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, wo
 	}
 	entries, err := os.ReadDir(workspace)
 	if err != nil {
-		return result, fmt.Errorf("tokenless checkout adapter inspect workspace: %w", err)
+		return result, fmt.Errorf("%s inspect workspace: %w", adapter, err)
 	}
 	if len(entries) != 0 {
-		return result, fmt.Errorf("tokenless checkout adapter requires an empty workspace; Phase 6 is required for clean behavior")
+		return result, fmt.Errorf("%s requires an empty workspace; Phase 6 is required for clean behavior", adapter)
 	}
 	git := r.Git
-	if private && (git == "" || !filepath.IsAbs(git)) {
-		return result, fmt.Errorf("private checkout adapter requires Git to be resolved before workflow execution")
+	if credentialed && (git == "" || !filepath.IsAbs(git)) {
+		return result, fmt.Errorf("repository-provider checkout requires Git to be resolved before workflow execution")
 	}
-	if !private && git == "" {
+	if !credentialed && git == "" {
 		git, err = exec.LookPath("git")
 	}
 	if err != nil {
-		return result, fmt.Errorf("tokenless checkout adapter discover Git: %w", err)
+		return result, fmt.Errorf("%s discover Git: %w", adapter, err)
 	}
 	env := map[string]string{
 		"HOME":                filepath.Join(workspace, ".no-home"),
@@ -83,8 +108,8 @@ func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, wo
 		return result, err
 	}
 	fetchArgs := []string{"fetch", "--no-tags", "--no-recurse-submodules", "--depth=1", "origin", job.Event.SHA}
-	if private {
-		if err := r.runPrivateCheckoutFetch(ctx, processor, workspace, env, git, base, job.Event.Repository, fetchArgs); err != nil {
+	if credentialed {
+		if err := r.runRepositoryProviderCheckoutFetch(ctx, processor, workspace, env, git, base, fetchArgs); err != nil {
 			return result, fmt.Errorf("%s git fetch: %w", adapter, err)
 		}
 	} else if err := run(env, fetchArgs...); err != nil {
@@ -95,69 +120,34 @@ func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, wo
 	}
 	head, err := os.ReadFile(filepath.Join(workspace, ".git", "HEAD"))
 	if err != nil || strings.TrimSpace(string(head)) != job.Event.SHA {
-		return result, fmt.Errorf("tokenless checkout adapter did not produce exact detached SHA %s", job.Event.SHA)
+		return result, fmt.Errorf("%s did not produce exact detached SHA %s", adapter, job.Event.SHA)
 	}
 	result.Outputs["ref"] = job.Event.Ref
 	result.Outputs["commit"] = job.Event.SHA
 	return result, nil
 }
 
-func (r Runner) runPrivateCheckoutFetch(ctx context.Context, processor *commandProcessor, workspace string, env map[string]string, git string, base []string, repository string, fetchArgs []string) error {
-	if r.Checkout == nil {
-		return fmt.Errorf("private checkout token provider is not configured")
+func (r Runner) runRepositoryProviderCheckoutFetch(ctx context.Context, processor *commandProcessor, workspace string, env map[string]string, git string, base, fetchArgs []string) error {
+	credentials := r.RepositoryCredentials
+	if credentials == nil || credentials.Agent == "" || !filepath.IsAbs(credentials.Agent) {
+		return fmt.Errorf("repository-provider credentials were not resolved before workflow execution")
 	}
-	token, err := r.Checkout.Token(ctx, repository)
-	if err != nil {
-		return err
+	processor.addMask(credentials.JobToken)
+	credentialEnv := cloneStrings(env)
+	credentialEnv["BUILDKITE_AGENT_ACCESS_TOKEN"] = credentials.JobToken
+	credentialEnv["BUILDKITE_JOB_ID"] = credentials.JobID
+	if credentials.Endpoint != "" {
+		credentialEnv["BUILDKITE_AGENT_ENDPOINT"] = credentials.Endpoint
 	}
-	if len(token) > 16<<10 || !githubInstallationTokenPattern.MatchString(token) {
-		return fmt.Errorf("private checkout token provider returned an invalid token")
+	if credentials.NoHTTP2 != "" {
+		credentialEnv["BUILDKITE_NO_HTTP2"] = credentials.NoHTTP2
 	}
-	if r.Redactor == nil {
-		return fmt.Errorf("private checkout token provider requires a redactor")
-	}
-	processor.addMask(token)
-	if err := r.Redactor.AddRedaction(ctx, token); err != nil {
-		return processor.scrubError(err)
-	}
-
-	helperDir, err := os.MkdirTemp("", "buildkite-gha-askpass-")
-	if err != nil {
-		return fmt.Errorf("create private checkout askpass directory: %w", err)
-	}
-	defer func() { _ = os.RemoveAll(helperDir) }()
-	helper := filepath.Join(helperDir, "askpass")
-	const script = `#!/bin/sh
-case "$1" in
-  *sername*) printf '%s\n' x-access-token ;;
-  *assword*) IFS= read -r token <&3 || exit 1; printf '%s\n' "$token" ;;
-  *) exit 1 ;;
-esac
-`
-	if err := os.WriteFile(helper, []byte(script), 0o700); err != nil {
-		return fmt.Errorf("create private checkout askpass helper: %w", err)
-	}
-	reader, writer, err := os.Pipe()
-	if err != nil {
-		return fmt.Errorf("create private checkout credential pipe: %w", err)
-	}
-	if _, err := io.WriteString(writer, token+"\n"); err != nil {
-		_ = reader.Close()
-		_ = writer.Close()
-		return fmt.Errorf("write private checkout credential pipe: %w", err)
-	}
-	if err := writer.Close(); err != nil {
-		_ = reader.Close()
-		return fmt.Errorf("close private checkout credential pipe: %w", err)
-	}
-	defer func() { _ = reader.Close() }()
-
-	privateEnv := cloneStrings(env)
-	privateEnv["GIT_ASKPASS"] = helper
-	privateEnv["LC_ALL"] = "C"
-	cmd := exec.Command(git, append(base, fetchArgs...)...)
+	credentialArgs := append(append([]string(nil), base...),
+		"-c", "credential.useHttpPath=true",
+		"-c", "credential.helper="+agentGitCredentialHelperCommand(credentials.Agent),
+	)
+	cmd := exec.Command(git, append(credentialArgs, fetchArgs...)...)
 	cmd.Dir = workspace
-	cmd.Env = processEnv(privateEnv)
-	cmd.ExtraFiles = []*os.File{reader}
+	cmd.Env = processEnv(credentialEnv)
 	return processor.scrubError(r.runStreamingCommand(ctx, processor, cmd))
 }

--- a/internal/runtime/checkout_test.go
+++ b/internal/runtime/checkout_test.go
@@ -179,6 +179,15 @@ func TestCheckoutUsesCommandScopedAgentCredentialHelper(t *testing.T) {
 	workspace := t.TempDir()
 	sha := strings.Repeat("a", 40)
 	repositoryToken := "ghs_repository_token"
+	proxyEnvironment := map[string]string{
+		"HTTP_PROXY": "http://upper-http.example:8080", "HTTPS_PROXY": "http://upper-https.example:8080",
+		"ALL_PROXY": "socks5://upper-all.example:1080", "NO_PROXY": "upper-no-proxy.example",
+		"http_proxy": "http://lower-http.example:8080", "https_proxy": "http://lower-https.example:8080",
+		"all_proxy": "socks5://lower-all.example:1080", "no_proxy": "lower-no-proxy.example",
+	}
+	for name, value := range proxyEnvironment {
+		t.Setenv(name, value)
+	}
 	gitLog := filepath.Join(t.TempDir(), "git.log")
 	agentLog := filepath.Join(t.TempDir(), "agent.log")
 	agent := filepath.Join(t.TempDir(), "buildkite-agent")
@@ -190,6 +199,14 @@ test "$BUILDKITE_AGENT_ENDPOINT" = https://agent.example/v3
 test "$BUILDKITE_AGENT_ACCESS_TOKEN" = job-secret
 test "$BUILDKITE_JOB_ID" = 11111111-1111-4111-8111-111111111111
 test "$BUILDKITE_NO_HTTP2" = true
+test "$HTTP_PROXY" = http://upper-http.example:8080
+test "$HTTPS_PROXY" = http://upper-https.example:8080
+test "$ALL_PROXY" = socks5://upper-all.example:1080
+test "$NO_PROXY" = upper-no-proxy.example
+test "$http_proxy" = http://lower-http.example:8080
+test "$https_proxy" = http://lower-https.example:8080
+test "$all_proxy" = socks5://lower-all.example:1080
+test "$no_proxy" = lower-no-proxy.example
 input="$(cat)"
 case "$input" in
   *"protocol=https"*"host=github.com"*"path=buildkite/buildkite-gha.git"*) ;;
@@ -204,6 +221,16 @@ printf 'username=token\npassword=%s\n' ` + shellTestQuote(repositoryToken) + `
 	git := filepath.Join(t.TempDir(), "git")
 	script := `#!/bin/sh
 set -eu
+assert_no_proxy_environment() {
+  test -z "${HTTP_PROXY+x}"
+  test -z "${HTTPS_PROXY+x}"
+  test -z "${ALL_PROXY+x}"
+  test -z "${NO_PROXY+x}"
+  test -z "${http_proxy+x}"
+  test -z "${https_proxy+x}"
+  test -z "${all_proxy+x}"
+  test -z "${no_proxy+x}"
+}
 operation=
 for argument in "$@"; do
   case "$argument" in init|remote|fetch|checkout) operation="$argument"; break ;; esac
@@ -214,6 +241,7 @@ case "$operation" in
     test -z "${BUILDKITE_AGENT_ACCESS_TOKEN+x}"
     test -z "${BUILDKITE_JOB_ID+x}"
     test -z "${BUILDKITE_NO_HTTP2+x}"
+    assert_no_proxy_environment
     mkdir -p .git
     ;;
   remote)
@@ -221,12 +249,21 @@ case "$operation" in
     test -z "${BUILDKITE_AGENT_ACCESS_TOKEN+x}"
     test -z "${BUILDKITE_JOB_ID+x}"
     test -z "${BUILDKITE_NO_HTTP2+x}"
+    assert_no_proxy_environment
     ;;
   fetch)
     test -z "$GIT_ASKPASS"
     test "$BUILDKITE_AGENT_ENDPOINT" = https://agent.example/v3
     test "$BUILDKITE_AGENT_ACCESS_TOKEN" = job-secret
     test "$BUILDKITE_JOB_ID" = 11111111-1111-4111-8111-111111111111
+    test "$HTTP_PROXY" = http://upper-http.example:8080
+    test "$HTTPS_PROXY" = http://upper-https.example:8080
+    test "$ALL_PROXY" = socks5://upper-all.example:1080
+    test "$NO_PROXY" = upper-no-proxy.example
+    test "$http_proxy" = http://lower-http.example:8080
+    test "$https_proxy" = http://lower-https.example:8080
+    test "$all_proxy" = socks5://lower-all.example:1080
+    test "$no_proxy" = lower-no-proxy.example
     helper=
     use_http_path=
     for argument in "$@"; do
@@ -248,6 +285,7 @@ case "$operation" in
     test -z "${BUILDKITE_AGENT_ACCESS_TOKEN+x}"
     test -z "${BUILDKITE_JOB_ID+x}"
     test -z "${BUILDKITE_NO_HTTP2+x}"
+    assert_no_proxy_environment
     printf '%s\n' ` + shellTestQuote(sha) + ` > .git/HEAD
     ;;
 esac
@@ -264,6 +302,13 @@ printf '%s\n' "$*" >> ` + shellTestQuote(gitLog) + `
 	}
 	credentials := &AgentRepositoryCredentials{
 		Agent: agent, Endpoint: "https://agent.example/v3", JobID: testCacheJobID, JobToken: "job-secret", NoHTTP2: "true",
+	}
+	credentials, err := resolveAgentRepositoryCredentialsBeforeWorkflow(credentials)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name := range proxyEnvironment {
+		t.Setenv(name, "http://late-workflow-value.invalid")
 	}
 	result, err := (Runner{Git: git, RepositoryCredentials: credentials, Stdout: &logs, Stderr: &logs}).runCheckout(context.Background(), processor, workspace, job, nil)
 	if err != nil {

--- a/internal/runtime/checkout_test.go
+++ b/internal/runtime/checkout_test.go
@@ -16,13 +16,7 @@ import (
 	"github.com/buildkite/buildkite-gha/internal/plan"
 )
 
-type checkoutTokenProviderFunc func(context.Context, string) (string, error)
-
-func (f checkoutTokenProviderFunc) Token(ctx context.Context, repository string) (string, error) {
-	return f(ctx, repository)
-}
-
-func TestTokenlessCheckoutAdapterPopulatesVerifiedWorkspace(t *testing.T) {
+func TestAnonymousCheckoutAdapterPopulatesVerifiedWorkspace(t *testing.T) {
 	workspace := t.TempDir()
 	workflowSource := []byte("name: checked out\n")
 	localSource := []byte("name: local\nruns:\n  using: composite\n  steps:\n    - shell: sh\n      run: echo 'CHECKOUT_CHAIN=ok' >> \"$GITHUB_ENV\"\n")
@@ -95,7 +89,7 @@ esac
 			Provider: "github", Name: "push", PayloadDigest: "sha256:" + strings.Repeat("3", 64), Repository: "buildkite/buildkite-gha", Ref: "refs/heads/main", SHA: sha,
 		},
 		Target:               plan.Target{StepKey: "gha-checkout", Queue: "trusted"},
-		RequiredCapabilities: []string{"network"},
+		RequiredCapabilities: []string{"network", "provider-token-read"},
 		Steps: []plan.Step{
 			{ID: "checkout", Kind: "uses", Uses: "actions/checkout@v7", Action: &plan.ActionSelector{Lock: checkoutID}},
 			{ID: "local", Kind: "uses", Uses: "./.github/actions/local", Action: &plan.ActionSelector{Lock: localID}},
@@ -128,7 +122,7 @@ esac
 			t.Fatalf("Git log lacks %q:\n%s", required, log)
 		}
 	}
-	if strings.Contains(strings.ToLower(log), "authorization") || strings.Contains(strings.ToLower(log), "token") {
+	if strings.Contains(strings.ToLower(log), "authorization") || strings.Contains(strings.ToLower(log), "token") || strings.Contains(log, "git-credentials-helper") {
 		t.Fatalf("Git log contains credential material: %s", log)
 	}
 	if got, err := os.ReadFile(filepath.Join(workspace, ".git", "HEAD")); err != nil || strings.TrimSpace(string(got)) != sha {
@@ -149,7 +143,7 @@ esac
 	}
 }
 
-func TestTokenlessCheckoutAdapterRejectsUnsupportedInputsAndState(t *testing.T) {
+func TestCheckoutAdapterRejectsUnsupportedInputsAndState(t *testing.T) {
 	repository, sha := "buildkite/buildkite-gha", strings.Repeat("a", 40)
 	processor := newCommandProcessor(io.Discard, io.Discard)
 	job := plan.Job{Event: plan.Event{Provider: "github", Repository: repository, SHA: sha}}
@@ -169,32 +163,47 @@ func TestTokenlessCheckoutAdapterRejectsUnsupportedInputsAndState(t *testing.T) 
 	}
 }
 
-func TestTokenlessCheckoutPreservesPublicRepositoryValidation(t *testing.T) {
+func TestCheckoutRejectsInvalidRepositoryBeforeInspectingWorkspace(t *testing.T) {
 	workspace := t.TempDir()
 	if err := os.WriteFile(filepath.Join(workspace, "occupied"), []byte("x"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	job := plan.Job{Event: plan.Event{Provider: "github", Repository: "owner/..", SHA: strings.Repeat("a", 40)}}
 	processor := newCommandProcessor(io.Discard, io.Discard)
-	if _, err := (Runner{}).runCheckout(context.Background(), processor, workspace, job, nil); err == nil || !strings.Contains(err.Error(), "empty workspace") {
-		t.Fatalf("tokenless checkout repository validation error = %v", err)
-	}
-	job.RequiredCapabilities = []string{"provider-token-read"}
 	if _, err := (Runner{}).runCheckout(context.Background(), processor, workspace, job, nil); err == nil || !strings.Contains(err.Error(), "valid github.com event repository") {
-		t.Fatalf("private checkout repository validation error = %v", err)
+		t.Fatalf("checkout repository validation error = %v", err)
 	}
 }
 
-func TestPrivateCheckoutAdapterUsesOneShotAskpassCredential(t *testing.T) {
+func TestCheckoutUsesCommandScopedAgentCredentialHelper(t *testing.T) {
 	workspace := t.TempDir()
 	sha := strings.Repeat("a", 40)
-	token := "ghs_private_checkout_secret"
+	repositoryToken := "ghs_repository_token"
 	gitLog := filepath.Join(t.TempDir(), "git.log")
-	askpassLog := filepath.Join(t.TempDir(), "askpass.log")
+	agentLog := filepath.Join(t.TempDir(), "agent.log")
+	agent := filepath.Join(t.TempDir(), "buildkite-agent")
+	agentScript := `#!/bin/sh
+set -eu
+test "$1" = git-credentials-helper
+test "$2" = get
+test "$BUILDKITE_AGENT_ENDPOINT" = https://agent.example/v3
+test "$BUILDKITE_AGENT_ACCESS_TOKEN" = job-secret
+test "$BUILDKITE_JOB_ID" = 11111111-1111-4111-8111-111111111111
+test "$BUILDKITE_NO_HTTP2" = true
+input="$(cat)"
+case "$input" in
+  *"protocol=https"*"host=github.com"*"path=buildkite/buildkite-gha.git"*) ;;
+  *) exit 40 ;;
+esac
+printf '%s\n' "$*" > ` + shellTestQuote(agentLog) + `
+printf 'username=token\npassword=%s\n' ` + shellTestQuote(repositoryToken) + `
+`
+	if err := os.WriteFile(agent, []byte(agentScript), 0o700); err != nil {
+		t.Fatal(err)
+	}
 	git := filepath.Join(t.TempDir(), "git")
 	script := `#!/bin/sh
 set -eu
-case "$*" in *` + token + `*) exit 30 ;; esac
 operation=
 for argument in "$@"; do
   case "$argument" in init|remote|fetch|checkout) operation="$argument"; break ;; esac
@@ -202,21 +211,43 @@ done
 case "$operation" in
   init)
     test -z "$GIT_ASKPASS"
+    test -z "${BUILDKITE_AGENT_ACCESS_TOKEN+x}"
+    test -z "${BUILDKITE_JOB_ID+x}"
+    test -z "${BUILDKITE_NO_HTTP2+x}"
     mkdir -p .git
     ;;
   remote)
     test -z "$GIT_ASKPASS"
+    test -z "${BUILDKITE_AGENT_ACCESS_TOKEN+x}"
+    test -z "${BUILDKITE_JOB_ID+x}"
+    test -z "${BUILDKITE_NO_HTTP2+x}"
     ;;
   fetch)
-    test -n "$GIT_ASKPASS"
-    if env | grep -F ` + shellTestQuote(token) + ` >/dev/null; then exit 31; fi
-    printf '%s' "$GIT_ASKPASS" > ` + shellTestQuote(askpassLog) + `
-    test "$("$GIT_ASKPASS" 'Username for https://github.com')" = x-access-token
-    test "$("$GIT_ASKPASS" 'Password for https://github.com')" = ` + shellTestQuote(token) + `
-    test -z "$("$GIT_ASKPASS" 'Password for https://github.com')"
+    test -z "$GIT_ASKPASS"
+    test "$BUILDKITE_AGENT_ENDPOINT" = https://agent.example/v3
+    test "$BUILDKITE_AGENT_ACCESS_TOKEN" = job-secret
+    test "$BUILDKITE_JOB_ID" = 11111111-1111-4111-8111-111111111111
+    helper=
+    use_http_path=
+    for argument in "$@"; do
+      case "$argument" in
+        credential.helper=!*) helper="${argument#credential.helper=!}" ;;
+        credential.useHttpPath=true) use_http_path=true ;;
+      esac
+    done
+    test -n "$helper"
+    test "$use_http_path" = true
+    credentials="$(printf 'protocol=https\nhost=github.com\npath=buildkite/buildkite-gha.git\n\n' | sh -c "$helper get")"
+    case "$credentials" in
+      *"username=token"*"password=` + repositoryToken + `"*) ;;
+      *) exit 41 ;;
+    esac
     ;;
   checkout)
     test -z "$GIT_ASKPASS"
+    test -z "${BUILDKITE_AGENT_ACCESS_TOKEN+x}"
+    test -z "${BUILDKITE_JOB_ID+x}"
+    test -z "${BUILDKITE_NO_HTTP2+x}"
     printf '%s\n' ` + shellTestQuote(sha) + ` > .git/HEAD
     ;;
 esac
@@ -225,53 +256,98 @@ printf '%s\n' "$*" >> ` + shellTestQuote(gitLog) + `
 	if err := os.WriteFile(git, []byte(script), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	var repositories []string
-	provider := checkoutTokenProviderFunc(func(_ context.Context, repository string) (string, error) {
-		repositories = append(repositories, repository)
-		return token, nil
-	})
-	redactor := &testRedactor{}
 	var logs bytes.Buffer
 	processor := newCommandProcessor(&logs, &logs)
 	job := plan.Job{
 		Event:                plan.Event{Provider: "github", Repository: "buildkite/buildkite-gha", Ref: "refs/heads/main", SHA: sha},
 		RequiredCapabilities: []string{"network", "provider-token-read"},
 	}
-	result, err := (Runner{Git: git, Checkout: provider, Redactor: redactor, Stdout: &logs, Stderr: &logs}).runCheckout(context.Background(), processor, workspace, job, nil)
+	credentials := &AgentRepositoryCredentials{
+		Agent: agent, Endpoint: "https://agent.example/v3", JobID: testCacheJobID, JobToken: "job-secret", NoHTTP2: "true",
+	}
+	result, err := (Runner{Git: git, RepositoryCredentials: credentials, Stdout: &logs, Stderr: &logs}).runCheckout(context.Background(), processor, workspace, job, nil)
 	if err != nil {
 		t.Fatalf("runCheckout() error = %v, logs = %q", err, logs.String())
 	}
 	if result.Outputs["commit"] != sha || result.Outputs["ref"] != job.Event.Ref {
 		t.Fatalf("checkout outputs = %#v", result.Outputs)
 	}
-	if len(repositories) != 1 || repositories[0] != job.Event.Repository || len(redactor.values) != 1 || redactor.values[0] != token {
-		t.Fatalf("repositories/redactions = %#v / %#v", repositories, redactor.values)
+	if _, err := os.Stat(agentLog); err != nil {
+		t.Fatalf("Buildkite Agent credential helper did not run: %v", err)
 	}
 	gitBytes, err := os.ReadFile(gitLog)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(string(gitBytes), token) || strings.Contains(logs.String(), token) {
-		t.Fatalf("checkout exposed token in Git arguments or logs: %q / %q", gitBytes, logs.String())
+	if strings.Contains(string(gitBytes), repositoryToken) || strings.Contains(logs.String(), repositoryToken) {
+		t.Fatalf("checkout exposed repository token in Git arguments or logs: %q / %q", gitBytes, logs.String())
 	}
-	helperBytes, err := os.ReadFile(askpassLog)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := os.Stat(string(helperBytes)); !os.IsNotExist(err) {
-		t.Fatalf("askpass helper survived checkout: %v", err)
-	}
-	configBytes, err := os.ReadFile(filepath.Join(workspace, ".git", "config"))
-	if err == nil && strings.Contains(string(configBytes), token) {
-		t.Fatalf("Git config contains checkout token: %q", configBytes)
+	if strings.Count(string(gitBytes), "git-credentials-helper") != 1 {
+		t.Fatalf("credential helper was not confined to one Git command: %q", gitBytes)
 	}
 }
 
-func TestPrivateCheckoutPinsGitBeforeActionPreHooks(t *testing.T) {
+func TestAgentGitCredentialHelperCommandQuotesExecutable(t *testing.T) {
+	got := agentGitCredentialHelperCommand("/tmp/agent's path")
+	want := `!'/tmp/agent'\''s path' git-credentials-helper`
+	if got != want {
+		t.Fatalf("agentGitCredentialHelperCommand() = %q, want %q", got, want)
+	}
+}
+
+func TestRepositoryProviderCheckoutFailsClosedWhenHelperDeniesAccess(t *testing.T) {
 	workspace := t.TempDir()
-	workflowSource := []byte("name: private checkout executable confinement\n")
+	checkoutMarker := filepath.Join(t.TempDir(), "checkout-ran")
+	agent := filepath.Join(t.TempDir(), "buildkite-agent")
+	if err := os.WriteFile(agent, []byte("#!/bin/sh\necho job-secret >&2\nexit 37\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	git := filepath.Join(t.TempDir(), "git")
+	gitScript := `#!/bin/sh
+set -eu
+operation=
+helper=
+for argument in "$@"; do
+  case "$argument" in
+    init|remote|fetch|checkout) operation="$argument" ;;
+    credential.helper=!*) helper="${argument#credential.helper=!}" ;;
+  esac
+done
+case "$operation" in
+  init) mkdir -p .git ;;
+  fetch)
+    test -n "$helper"
+    printf 'protocol=https\nhost=github.com\npath=buildkite/buildkite-gha.git\n\n' | sh -c "$helper get"
+    ;;
+  checkout) : > ` + shellTestQuote(checkoutMarker) + ` ;;
+esac
+`
+	if err := os.WriteFile(git, []byte(gitScript), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	job := plan.Job{
+		Event:                plan.Event{Provider: "github", Repository: "buildkite/buildkite-gha", SHA: strings.Repeat("a", 40)},
+		RequiredCapabilities: []string{"network", "provider-token-read"},
+	}
+	credentials := &AgentRepositoryCredentials{Agent: agent, JobID: testCacheJobID, JobToken: "job-secret"}
+	var logs bytes.Buffer
+	processor := newCommandProcessor(&logs, &logs)
+	if _, err := (Runner{Git: git, RepositoryCredentials: credentials, Stdout: &logs, Stderr: &logs}).runCheckout(context.Background(), processor, workspace, job, nil); err == nil {
+		t.Fatal("runCheckout() succeeded after repository-provider helper denial")
+	}
+	if strings.Contains(logs.String(), "job-secret") || !strings.Contains(logs.String(), "***") {
+		t.Fatalf("helper denial logs did not scrub the job credential: %q", logs.String())
+	}
+	if _, err := os.Stat(checkoutMarker); !os.IsNotExist(err) {
+		t.Fatalf("checkout ran after credential helper denial: %v", err)
+	}
+}
+
+func TestRepositoryProviderCheckoutPinsGitAndAgentBeforeActionPreHooks(t *testing.T) {
+	workspace := t.TempDir()
+	workflowSource := []byte("name: repository provider checkout executable confinement\n")
 	sha := strings.Repeat("a", 40)
-	token := "ghs_private_checkout_secret"
+	repositoryToken := "ghs_repository_token"
 
 	trustedLog := filepath.Join(t.TempDir(), "trusted-git.log")
 	trustedDir := t.TempDir()
@@ -285,8 +361,13 @@ done
 case "$operation" in
   init) mkdir -p .git ;;
   fetch)
-    test "$("$GIT_ASKPASS" 'Username for https://github.com')" = x-access-token
-    test "$("$GIT_ASKPASS" 'Password for https://github.com')" = ` + shellTestQuote(token) + `
+    helper=
+    for argument in "$@"; do
+      case "$argument" in credential.helper=!*) helper="${argument#credential.helper=!}" ;; esac
+    done
+    test -n "$helper"
+    credentials="$(printf 'protocol=https\nhost=github.com\npath=buildkite/buildkite-gha.git\n\n' | sh -c "$helper get")"
+    case "$credentials" in *"password=` + repositoryToken + `"*) ;; *) exit 41 ;; esac
     ;;
   checkout)
     printf '%s\n' ` + shellTestQuote(sha) + ` > .git/HEAD
@@ -301,7 +382,17 @@ printf '%s\n' "$*" >> ` + shellTestQuote(trustedLog) + `
 	}
 	trustedAgentMarker := filepath.Join(t.TempDir(), "trusted-agent-ran")
 	trustedAgent := filepath.Join(trustedDir, "buildkite-agent")
-	trustedAgentScript := "#!/bin/sh\nIFS= read -r value\ntest \"$value\" = " + shellTestQuote(token) + "\n: > " + shellTestQuote(trustedAgentMarker) + "\n"
+	trustedAgentScript := `#!/bin/sh
+set -eu
+test "$1" = git-credentials-helper
+test "$2" = get
+test "$BUILDKITE_AGENT_ACCESS_TOKEN" = job-secret
+test "$BUILDKITE_JOB_ID" = 11111111-1111-4111-8111-111111111111
+input="$(cat)"
+case "$input" in *"path=buildkite/buildkite-gha.git"*) ;; *) exit 42 ;; esac
+: > ` + shellTestQuote(trustedAgentMarker) + `
+printf 'username=token\npassword=%s\n' ` + shellTestQuote(repositoryToken) + `
+`
 	if err := os.WriteFile(trustedAgent, []byte(trustedAgentScript), 0o700); err != nil {
 		t.Fatal(err)
 	}
@@ -319,11 +410,6 @@ printf '%s\n' "$*" >> ` + shellTestQuote(trustedLog) + `
 	poisonGitMarker := filepath.Join(t.TempDir(), "poison-git-ran")
 	poisonGit := filepath.Join(poisonDir, "git")
 	if err := os.WriteFile(poisonGit, []byte("#!/bin/sh\ntouch "+shellTestQuote(poisonGitMarker)+"\nexit 97\n"), 0o700); err != nil {
-		t.Fatal(err)
-	}
-	poisonCatMarker := filepath.Join(t.TempDir(), "poison-cat-ran")
-	poisonCat := filepath.Join(poisonDir, "cat")
-	if err := os.WriteFile(poisonCat, []byte("#!/bin/sh\ntouch "+shellTestQuote(poisonCatMarker)+"\nexit 98\n"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 	poisonAgentMarker := filepath.Join(t.TempDir(), "poison-agent-ran")
@@ -351,9 +437,8 @@ fi
 if [ "${1##*/}" = pre.js ]; then
   rm -f "$LOOKUP_GIT"
   ln -s "$POISON_GIT" "$LOOKUP_GIT"
-  ln -s "$POISON_CAT" "$LOOKUP_CAT"
-	  rm -f "$LOOKUP_AGENT"
-	  ln -s "$POISON_AGENT" "$LOOKUP_AGENT"
+  rm -f "$LOOKUP_AGENT"
+  ln -s "$POISON_AGENT" "$LOOKUP_AGENT"
 fi
 `
 	if err := os.WriteFile(node, []byte(nodeScript), 0o700); err != nil {
@@ -379,8 +464,6 @@ fi
 			"LOOKUP_AGENT": lookupAgent,
 			"LOOKUP_GIT":   lookupGit,
 			"POISON_AGENT": poisonAgent,
-			"LOOKUP_CAT":   filepath.Join(lookupDir, "cat"),
-			"POISON_CAT":   poisonCat,
 			"POISON_GIT":   poisonGit,
 		},
 		Steps: []plan.Step{
@@ -392,10 +475,10 @@ fi
 			{ID: checkoutID, Source: "github", Repository: "actions/checkout", RequestedRef: "v7", Commit: strings.Repeat("c", 40), SourceDigest: remoteDigest},
 		},
 	}
-	provider := checkoutTokenProviderFunc(func(context.Context, string) (string, error) { return token, nil })
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: remoteDigest}}
 	var logs bytes.Buffer
-	result, err := (Runner{Node24: node, Checkout: provider, Redactor: AgentRedactor{}, Actions: materializer, Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	credentials := &AgentRepositoryCredentials{JobID: testCacheJobID, JobToken: "job-secret"}
+	result, err := (Runner{Node24: node, RepositoryCredentials: credentials, Actions: materializer, Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v, logs = %q", result, err, logs.String())
 	}
@@ -405,55 +488,44 @@ fi
 	if target, err := filepath.EvalSymlinks(lookupGit); err != nil || target != poisonGit {
 		t.Fatalf("pre-hook Git replacement = %q, %v; want %q", target, err, poisonGit)
 	}
-	if target, err := filepath.EvalSymlinks(filepath.Join(lookupDir, "cat")); err != nil || target != poisonCat {
-		t.Fatalf("pre-hook cat replacement = %q, %v; want %q", target, err, poisonCat)
-	}
 	if target, err := filepath.EvalSymlinks(lookupAgent); err != nil || target != poisonAgent {
 		t.Fatalf("pre-hook Agent replacement = %q, %v; want %q", target, err, poisonAgent)
 	}
 	if _, err := os.Stat(trustedAgentMarker); err != nil {
-		t.Fatalf("trusted Agent redactor did not run: %v", err)
+		t.Fatalf("trusted Agent credential helper did not run: %v", err)
 	}
-	for name, marker := range map[string]string{"Git selected through poisoned PATH": poisonGitMarker, "askpass reader selected through poisoned PATH": poisonCatMarker, "Agent redactor selected through poisoned PATH": poisonAgentMarker} {
+	for name, marker := range map[string]string{"Git selected through poisoned PATH": poisonGitMarker, "Agent helper selected through poisoned PATH": poisonAgentMarker} {
 		if _, err := os.Stat(marker); !os.IsNotExist(err) {
 			t.Fatalf("%s: %v", name, err)
 		}
 	}
-	if strings.Contains(logs.String(), token) {
-		t.Fatalf("checkout exposed token in logs: %q", logs.String())
+	if strings.Contains(logs.String(), repositoryToken) {
+		t.Fatalf("checkout exposed repository token in logs: %q", logs.String())
 	}
 }
 
-func TestPrivateCheckoutRequiresPreResolvedGit(t *testing.T) {
+func TestRepositoryProviderCheckoutRequiresPreResolvedGit(t *testing.T) {
 	job := plan.Job{
 		Event:                plan.Event{Provider: "github", Repository: "buildkite/buildkite-gha", SHA: strings.Repeat("a", 40)},
 		RequiredCapabilities: []string{"provider-token-read"},
 	}
-	if _, err := (Runner{Git: "git"}).runCheckout(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), job, nil); err == nil || !strings.Contains(err.Error(), "resolved before workflow execution") {
+	credentials := &AgentRepositoryCredentials{Agent: "/usr/bin/buildkite-agent", JobID: testCacheJobID, JobToken: "job-secret"}
+	if _, err := (Runner{Git: "git", RepositoryCredentials: credentials}).runCheckout(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), job, nil); err == nil || !strings.Contains(err.Error(), "resolved before workflow execution") {
 		t.Fatalf("runCheckout() unresolved Git error = %v", err)
 	}
 }
 
-func TestPrivateCheckoutRedactorFailureAbortsBeforeFetchAndScrubsToken(t *testing.T) {
-	token := "ghs_private_checkout_secret"
-	marker := filepath.Join(t.TempDir(), "fetch-ran")
-	git := filepath.Join(t.TempDir(), "git")
-	script := "#!/bin/sh\ncase \"$*\" in *fetch*) touch " + shellTestQuote(marker) + " ;; init*) mkdir -p .git ;; esac\n"
-	if err := os.WriteFile(git, []byte(script), 0o700); err != nil {
-		t.Fatal(err)
-	}
-	job := plan.Job{
-		Event:                plan.Event{Provider: "github", Repository: "buildkite/buildkite-gha", SHA: strings.Repeat("a", 40)},
-		RequiredCapabilities: []string{"network", "provider-token-read"},
-	}
-	provider := checkoutTokenProviderFunc(func(context.Context, string) (string, error) { return token, nil })
-	err := error(nil)
-	_, err = (Runner{Git: git, Checkout: provider, Redactor: failingCacheRedactor{token: token}}).runCheckout(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), job, nil)
-	if err == nil || strings.Contains(err.Error(), token) || !strings.Contains(err.Error(), "***") {
-		t.Fatalf("runCheckout() error = %v", err)
-	}
-	if _, err := os.Stat(marker); !os.IsNotExist(err) {
-		t.Fatalf("Git fetch ran before redactor registration succeeded: %v", err)
+func TestRepositoryProviderCredentialsRejectInvalidJobIdentity(t *testing.T) {
+	for name, credentials := range map[string]*AgentRepositoryCredentials{
+		"missing job ID": {JobToken: "job-secret"},
+		"missing token":  {JobID: testCacheJobID},
+		"unsafe token":   {JobID: testCacheJobID, JobToken: "secret\nheader"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := resolveAgentRepositoryCredentialsBeforeWorkflow(credentials); err == nil {
+				t.Fatalf("resolveAgentRepositoryCredentialsBeforeWorkflow(%#v) succeeded", credentials)
+			}
+		})
 	}
 }
 
@@ -463,11 +535,7 @@ func TestProviderTokenReadRuntimeAuthorityIsCheckoutOnly(t *testing.T) {
 	writeFixtureFile(t, workspace, workflowPath, "name: authority\n")
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "ordinary", Kind: "run", Command: "true"}})
 	job.RequiredCapabilities = []string{"provider-token-read"}
-	if _, err := (Runner{}).RunJob(context.Background(), job, workspace); err == nil || !strings.Contains(err.Error(), "requires the private checkout token provider") {
-		t.Fatalf("missing provider error = %v", err)
-	}
-	provider := checkoutTokenProviderFunc(func(context.Context, string) (string, error) { return "ghs_unused", nil })
-	if _, err := (Runner{Checkout: provider}).RunJob(context.Background(), job, workspace); err == nil || !strings.Contains(err.Error(), "restricted to the verified checkout adapter") {
+	if _, err := (Runner{}).RunJob(context.Background(), job, workspace); err == nil || !strings.Contains(err.Error(), "restricted to the verified checkout adapter") {
 		t.Fatalf("ordinary provider-token-read error = %v", err)
 	}
 }

--- a/internal/runtime/github_token_service.go
+++ b/internal/runtime/github_token_service.go
@@ -20,14 +20,14 @@ var githubInstallationTokenPattern = regexp.MustCompile(`^[A-Za-z0-9_]+$`)
 var retryAfterSecondsPattern = regexp.MustCompile(`^[0-9]{1,10}$`)
 
 // WorkflowTokenProvider mints one repository-scoped credential with the exact
-// compiler-owned permissions carried by a verified job plan.
+// plan-declared permissions accepted by the Buildkite backend.
 type WorkflowTokenProvider interface {
 	WorkflowToken(context.Context, string, map[string]string) (string, error)
 }
 
-// AgentGitHubTokenConfig identifies the exact current Buildkite job. Endpoint
-// and JobToken are runtime authority and are never forwarded to Git or action
-// code.
+// AgentGitHubTokenConfig carries the current Buildkite job's Agent connection
+// and authentication material. This client does not add it to Git or action
+// subprocess environments.
 type AgentGitHubTokenConfig struct {
 	Endpoint string
 	JobID    string

--- a/internal/runtime/github_token_service.go
+++ b/internal/runtime/github_token_service.go
@@ -19,13 +19,6 @@ const githubTokenResponseLimit = 64 << 10
 var githubInstallationTokenPattern = regexp.MustCompile(`^[A-Za-z0-9_]+$`)
 var retryAfterSecondsPattern = regexp.MustCompile(`^[0-9]{1,10}$`)
 
-// CheckoutTokenProvider mints one repository-scoped credential for the
-// verified checkout adapter. The provider fixes permissions independently of
-// workflow inputs.
-type CheckoutTokenProvider interface {
-	Token(context.Context, string) (string, error)
-}
-
 // WorkflowTokenProvider mints one repository-scoped credential with the exact
 // compiler-owned permissions carried by a verified job plan.
 type WorkflowTokenProvider interface {
@@ -69,10 +62,6 @@ func NewAgentGitHubTokens(config AgentGitHubTokenConfig) (*AgentGitHubTokens, er
 		bounded.Timeout = 15 * time.Second
 	}
 	return &AgentGitHubTokens{mintURL: mintURL, jobToken: config.JobToken, client: &bounded}, nil
-}
-
-func (c *AgentGitHubTokens) Token(ctx context.Context, repository string) (string, error) {
-	return c.mint(ctx, repository, map[string]string{"contents": "read"}, "checkout")
 }
 
 func (c *AgentGitHubTokens) WorkflowToken(ctx context.Context, repository string, permissions map[string]string) (string, error) {

--- a/internal/runtime/github_token_service_test.go
+++ b/internal/runtime/github_token_service_test.go
@@ -10,42 +10,6 @@ import (
 	"testing"
 )
 
-func TestAgentGitHubTokensMintsFixedReadOnlyRepositoryCredential(t *testing.T) {
-	var calls int
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		calls++
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Error(err)
-		}
-		if r.Method != http.MethodPost || r.URL.EscapedPath() != "/v3/jobs/"+testCacheJobID+"/github_scoped_access_token" || r.URL.RawQuery != "" {
-			t.Errorf("request = %s %s", r.Method, r.URL.String())
-		}
-		if r.Header.Get("Authorization") != "Token job-secret" || r.Header.Get("Accept") != "application/json" || r.Header.Get("Content-Type") != "application/json" {
-			t.Errorf("request headers = %#v", r.Header)
-		}
-		if string(body) != `{"repo_url":"https://github.com/buildkite/buildkite-gha","permissions":{"contents":"read"}}` {
-			t.Errorf("request body = %s", body)
-		}
-		_, _ = io.WriteString(w, `{"token":"ghs_scoped_token"}`)
-	}))
-	defer server.Close()
-
-	provider, err := NewAgentGitHubTokens(AgentGitHubTokenConfig{
-		Endpoint: server.URL + "/v3/", JobID: testCacheJobID, JobToken: "job-secret",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	token, err := provider.Token(context.Background(), "buildkite/buildkite-gha")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if calls != 1 || token != "ghs_scoped_token" {
-		t.Fatalf("calls/token = %d / %q", calls, token)
-	}
-}
-
 func TestAgentGitHubTokensMintsExactWorkflowPermissions(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
@@ -115,8 +79,8 @@ func TestAgentGitHubTokensRejectsUnsafeConfigurationAndRepository(t *testing.T) 
 		t.Fatal(err)
 	}
 	for _, repository := range []string{"", "other", "../other/repo", "owner/..", "owner/repo/extra", "owner/repo?permission=write"} {
-		if _, err := provider.Token(context.Background(), repository); err == nil {
-			t.Fatalf("Token(%q) succeeded", repository)
+		if _, err := provider.WorkflowToken(context.Background(), repository, map[string]string{"contents": "read"}); err == nil {
+			t.Fatalf("WorkflowToken(%q) succeeded", repository)
 		}
 	}
 }
@@ -156,9 +120,9 @@ func TestAgentGitHubTokensRejectsRedirectsAndUntrustedResponses(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, err = provider.Token(context.Background(), "buildkite/buildkite-gha")
+			_, err = provider.WorkflowToken(context.Background(), "buildkite/buildkite-gha", map[string]string{"contents": "read"})
 			if err == nil || !strings.Contains(err.Error(), test.want) || strings.Contains(err.Error(), secret) {
-				t.Fatalf("Token() error = %v, want %q without response data", err, test.want)
+				t.Fatalf("WorkflowToken() error = %v, want %q without response data", err, test.want)
 			}
 		})
 	}
@@ -177,8 +141,8 @@ func TestAgentGitHubTokensRejectsRedirectsAndUntrustedResponses(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := provider.Token(context.Background(), "buildkite/buildkite-gha"); err == nil || !strings.Contains(err.Error(), "HTTP 307") || redirected {
-		t.Fatalf("redirect Token() error/redirected = %v / %v", err, redirected)
+	if _, err := provider.WorkflowToken(context.Background(), "buildkite/buildkite-gha", map[string]string{"contents": "read"}); err == nil || !strings.Contains(err.Error(), "HTTP 307") || redirected {
+		t.Fatalf("redirect WorkflowToken() error/redirected = %v / %v", err, redirected)
 	}
 }
 
@@ -189,7 +153,7 @@ func TestAgentGitHubTokensHonorsCancellation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := provider.Token(ctx, "buildkite/buildkite-gha"); !errors.Is(err, context.Canceled) {
-		t.Fatalf("Token() error = %v, want cancellation", err)
+	if _, err := provider.WorkflowToken(ctx, "buildkite/buildkite-gha", map[string]string{"contents": "read"}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("WorkflowToken() error = %v, want cancellation", err)
 	}
 }

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -116,22 +116,26 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		}
 	}
 	if job.HasCapability("provider-token-read") {
-		if r.Checkout == nil {
-			return JobResult{}, fmt.Errorf("provider-token-read capability requires the private checkout token provider")
-		}
 		if !jobUsesCheckoutAdapter(job) {
 			return JobResult{}, fmt.Errorf("provider-token-read capability is restricted to the verified checkout adapter")
 		}
-		git, err := resolveHostExecutableBeforeWorkflow(r.Git, "git", "private checkout Git")
-		if err != nil {
-			return JobResult{}, err
+		if r.RepositoryCredentials != nil {
+			credentials, err := resolveAgentRepositoryCredentialsBeforeWorkflow(r.RepositoryCredentials)
+			if err != nil {
+				return JobResult{}, err
+			}
+			r.RepositoryCredentials = credentials
+			git, err := resolveHostExecutableBeforeWorkflow(r.Git, "git", "repository-provider checkout Git")
+			if err != nil {
+				return JobResult{}, err
+			}
+			r.Git = git
 		}
-		r.Git = git
 	}
 	if job.HasCapability("provider-token-write") && r.WorkflowToken == nil {
 		return JobResult{}, fmt.Errorf("provider-token-write capability requires the GitHub workflow token provider")
 	}
-	if job.HasCapability("provider-token-read") || job.HasCapability("provider-token-write") {
+	if job.HasCapability("provider-token-write") {
 		if r.Redactor == nil {
 			return JobResult{}, fmt.Errorf("provider token capability requires the Buildkite Agent redactor")
 		}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -46,36 +46,36 @@ const (
 
 // Runner executes verified actions using explicitly configured host tools.
 type Runner struct {
-	Stdout            io.Writer
-	Stderr            io.Writer
-	Node20            string
-	Node24            string
-	ManagedNodeRoot   string
-	Mise              string
-	ResolveMise       func(context.Context) (string, error)
-	MiseDataDir       string
-	Docker            string
-	RuntimeExecutable string
-	Git               string
-	CleanupTimeout    time.Duration
-	PostActionTimeout time.Duration
-	InterruptGrace    time.Duration
-	TerminateGrace    time.Duration
-	Secrets           SecretResolver
-	Redactor          Redactor
-	Actions           ActionMaterializer
-	Artifacts         ArtifactStore
-	Cache             CacheCredentialProvider
-	Checkout          CheckoutTokenProvider
-	WorkflowToken     WorkflowTokenProvider
-	runnerTemp        string
-	implicitJobPATH   string
-	explicitJobPATH   bool
-	jobContainer      *jobContainerBackend
-	jobDocker         *jobContainerBackend
-	nodeVerification  *managedNodeVerification
-	nodeDigests       map[int]string
-	artifactRegistry  *artifactRegistry
+	Stdout                io.Writer
+	Stderr                io.Writer
+	Node20                string
+	Node24                string
+	ManagedNodeRoot       string
+	Mise                  string
+	ResolveMise           func(context.Context) (string, error)
+	MiseDataDir           string
+	Docker                string
+	RuntimeExecutable     string
+	Git                   string
+	CleanupTimeout        time.Duration
+	PostActionTimeout     time.Duration
+	InterruptGrace        time.Duration
+	TerminateGrace        time.Duration
+	Secrets               SecretResolver
+	Redactor              Redactor
+	Actions               ActionMaterializer
+	Artifacts             ArtifactStore
+	Cache                 CacheCredentialProvider
+	RepositoryCredentials *AgentRepositoryCredentials
+	WorkflowToken         WorkflowTokenProvider
+	runnerTemp            string
+	implicitJobPATH       string
+	explicitJobPATH       bool
+	jobContainer          *jobContainerBackend
+	jobDocker             *jobContainerBackend
+	nodeVerification      *managedNodeVerification
+	nodeDigests           map[int]string
+	artifactRegistry      *artifactRegistry
 }
 
 func resolveHostExecutableBeforeWorkflow(configured, fallback, label string) (string, error) {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -2721,9 +2721,19 @@ func TestLongLineChildProcess(t *testing.T) {
 
 func TestProcessEnvironmentIsExplicitAndUsable(t *testing.T) {
 	t.Setenv("BUILDKITE_AGENT_ACCESS_TOKEN", "must-not-leak")
+	for _, name := range agentProxyEnvironmentNames {
+		t.Setenv(name, "http://must-not-leak.invalid")
+	}
 	var logs bytes.Buffer
 	processor := newCommandProcessor(&logs, &logs)
-	command := `test -n "$PATH" && test -n "$HOME" && test -n "$TMPDIR" && test "$DECLARED" = visible && test -z "${BUILDKITE_AGENT_ACCESS_TOKEN:-}" && printf '%s\n' environment-ok`
+	command := `
+test -n "$PATH" && test -n "$HOME" && test -n "$TMPDIR"
+test "$DECLARED" = visible
+test -z "${BUILDKITE_AGENT_ACCESS_TOKEN+x}"
+test -z "${HTTP_PROXY+x}" && test -z "${HTTPS_PROXY+x}" && test -z "${ALL_PROXY+x}" && test -z "${NO_PROXY+x}"
+test -z "${http_proxy+x}" && test -z "${https_proxy+x}" && test -z "${all_proxy+x}" && test -z "${no_proxy+x}"
+printf '%s\n' environment-ok
+`
 	if err := (Runner{}).runStreaming(context.Background(), processor, "", map[string]string{"DECLARED": "visible"}, "sh", "-c", command); err != nil {
 		t.Fatalf("runStreaming() error = %v", err)
 	}


### PR DESCRIPTION
## Problem

Private event-repository checkout currently requires users to opt into `--private-checkout`, even though Buildkite already decides whether a job has repository-provider credentials. That duplicates platform policy in workflow-import configuration and makes public/private repository visibility something the uploader appears to choose.

The checkout credential path also mints and handles a separate scoped token instead of using the Buildkite Agent's native repository credential helper.

## Fix

- Make a compiler-verified `actions/checkout` adapter always declare `provider-token-read` with checkout provenance.
- At runtime, use `buildkite-agent git-credentials-helper` only when Buildkite enables repository-provider credentials through `BUILDKITE_USE_REPOSITORY_PROVIDER_GIT_CREDENTIALS=true` or its legacy GitHub App signal.
- Otherwise perform the same exact-SHA checkout anonymously; do not infer repository visibility.
- Scope the helper and Agent job credential to the verified `git fetch` command, enable HTTP-path matching, clear inherited helpers and headers, and never persist credentials.
- Pin Git and the Agent executable before workflow code, forward the Agent endpoint, HTTP/2 configuration, and job-process proxy variables to the credentialed fetch, scrub the Agent token from diagnostics, and fail closed on helper denial.
- Keep workflow `permissions`, `secrets.GITHUB_TOKEN`, and action metadata `github.token` defaults on their existing separate scoped-token path.

The repository-provider backend remains authoritative for whether credentials are issued for the concrete URL. Omitting the Agent credential from ordinary workflow subprocess environments limits inheritance; it is not an OS-level isolation boundary within the job. Likewise, compiled workflow permissions constrain the supported scoped-token client path while Buildkite's server-side repository and permission policy remains the authorization ceiling.

`upload --private-checkout` remains accepted as a deprecated no-op for one-release compatibility, but is no longer advertised. The companion plugin retains a version-safe bridge while its default remains on an older CLI.

## Test coverage

Tests cover:

- automatic compiler capability and same-process checkout provenance;
- admission rejection for missing or broadened provenance;
- anonymous checkout when Buildkite does not advertise credentials;
- command-scoped Agent helper configuration and executable quoting;
- preservation of upper- and lower-case proxy variables captured before workflow execution, with later ambient changes ignored;
- helper denial and token scrubbing;
- Agent/Git executable confinement before action pre-hooks;
- Agent job and proxy variables being absent from non-fetch commands and ordinary workflow subprocesses;
- current and legacy Buildkite credential signals; and
- deprecated CLI flag parsing as a no-op.

Full validation after merging current `main`:

```text
mise run check
Finished in 22.79s
```

## Companion change

- buildkite-plugins/github-actions-buildkite-plugin#21 updates plugin configuration and preserves a version-safe bridge for released CLIs. Its credential signals indicate availability only; the repository-provider backend remains authoritative.