### PR TITLE
Enable cache service for action runtimes

### DIFF
--- a/.github/workflows/example-basic.yml
+++ b/.github/workflows/example-basic.yml
@@ -22,7 +22,6 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: "1.26.5"
-          cache: "false"
           token: ""
 
       - name: Run focused tests

--- a/README.md
+++ b/README.md
@@ -145,7 +145,9 @@ workflows built from:
 - bounded native upload and exact-name download for the audited artifact v4
   commits; and
 - the audited `actions/cache` v6.1.0 commit through the official Buildkite
-  cache-v2 Results service, with an optional operator override.
+  cache-v2 Results service, plus compatible cache clients bundled into
+  JavaScript and Docker actions such as `actions/setup-go`, with an optional
+  operator override.
 
 It is not currently a fit for workflows that require:
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -100,16 +100,17 @@ service.
 | Step summaries | Supported | Summaries publish as bounded job-scoped Buildkite annotations. Requires Buildkite Agent v3.112 or newer. Oversized per-step summaries are skipped; the aggregate job summary is limited to 1 MiB. |
 | Local actions | Supported subset | Workspace actions are digest-locked and reverified. JavaScript, composite, and compiler-verified Dockerfile runtimes are supported; other action runtimes are not. |
 | Anonymous public GitHub actions | Supported subset | Sources are anonymously resolved to exact commits, complete trees are digest-verified, and JavaScript/composite/Dockerfile runtime rules still apply. Private actions and actions that require unavailable GitHub services are not supported merely because source resolution succeeds. |
-| JavaScript actions | Supported | Managed, digest-verified Node 20 and 24 runtimes, pre/main/post lifecycle, inputs, outputs, state, and LIFO post ordering are supported. Other Node action runtime declarations are not. |
+| JavaScript actions | Supported | Managed, digest-verified Node 20 and 24 runtimes, pre/main/post lifecycle, inputs, outputs, state, LIFO post ordering, and the standard cache-v2 environment are supported. Other Node action runtime declarations are not. |
 | Composite actions | Supported subset | Nested shell/action steps, outputs, and global pre/main/post ordering are supported. Composite `run` steps must select `bash` or `sh`. |
-| Dockerfile actions | Supported subset | Only compiler-verified local or anonymous public Dockerfile actions are admitted. Lifecycle overrides, arbitrary Docker options, credentials, volumes, private images, and privileged execution are not supported. |
+| Dockerfile actions | Supported subset | Only compiler-verified local or anonymous public Dockerfile actions are admitted. The standard cache-v2 environment is available inside the action container. Lifecycle overrides, arbitrary Docker options, other credentials, volumes, private images, and privileged execution are not supported. |
 | `docker://` actions and action `entrypoint`/`args` overrides | Not supported | Validation rejects these forms. |
 | Concurrent step controls | Supported | GitHub Actions `background`, `wait`, `wait-all`, `cancel`, and `parallel` controls run inside one job with at most ten active background steps. Effects and failures become visible at covering waits, remaining work is joined before cleanup, and cancellation targets the complete process group rather than only the direct process. |
 | `actions/checkout` | Supported subset | Public `github.com` event repository, exact event SHA, workspace root, and shallow credential-free fetch are supported by default. Explicit private-checkout upload can authenticate that same fetch with fixed `contents:read` authority for the pipeline repository. Alternate repositories/refs, submodules, LFS, persisted credentials, and arbitrary checkout inputs are not supported. |
 | `actions/upload-artifact` | Supported subset | Only the audited v4 commit is adapted. It supports bounded literal files/directories, ZIP compression 0–9, hidden-file selection, and exact no-file behavior. Globs, exclusions, symlinks, retention, overwrite, raw uploads, merge, and GitHub URLs are not supported. |
 | `actions/download-artifact` | Supported subset | Only the audited v4.3.0 commit is adapted. One exact literal name from verified direct `needs` can be extracted to a clean workspace-relative path. IDs, patterns, all-artifact, merge, cross-run, and cross-repository modes are not supported. |
 | `actions/cache` | Supported subset | Only the audited v6.1.0 commit, including its `restore` and `save` entry points, is admitted. It runs the stock Node 24 cache-v2 client with fresh job-bound credentials and the official Buildkite Results service by default. v4/v5 and unrecognized v6 commits are not supported. |
-| Other GitHub service-backed actions | Not supported | Except for the integrations listed above, no general GitHub artifact, cache, OIDC, Packages, Releases, Checks, or deployment service emulation is provided. An otherwise supported action runtime may still fail if its code requires one of those services. |
+| Cache clients bundled into actions | Supported subset | JavaScript and Docker action invocations receive fresh job-bound cache-v2 credentials when the service is available, matching the environment expected by setup actions such as `actions/setup-go`. The action remains responsible for its own key, version, paths, save/restore lifecycle, and cache-miss behavior. Ordinary `run` steps and native adapters do not receive cache credentials. |
+| Other GitHub service-backed actions | Not supported | Except for the integrations listed above, no general GitHub artifact, OIDC, Packages, Releases, Checks, or deployment service emulation is provided. An otherwise supported action runtime may still fail if its code requires one of those services. |
 
 ### Repositories, credentials, and platforms
 
@@ -345,33 +346,42 @@ mismatch is fatal (stricter than upstream). GitHub URLs and metadata are not
 fabricated. Exact-commit Buildkite build 270 and its independent artifact
 observation prove the producer-to-two-consumer roundtrip contract.
 
-### Cache v6 uses the standard cache-v2 protocol
+### Actions use the standard cache-v2 protocol
 
-The cache integration recognizes only
+The explicit cache-action integration recognizes only
 `actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9` (v6.1.0), including
 the `restore` and `save` entry points from that same immutable source tree.
 Older majors and every other commit fail closed. Unlike the artifact actions,
 the runtime does not replace the upstream implementation: it executes the
 audited action's stock Node 24 ESM lifecycle and supplies the standard
-cache-v2 environment only to that verified action invocation.
+cache-v2 environment to the action.
 
-Before each pre, main, or post phase that runs, the runtime posts an empty body
-to the current job's
+Before each JavaScript pre, main, or post phase and each Docker action that
+runs, the runtime attempts to post an empty body to the current job's
 `/v3/jobs/<BUILDKITE_JOB_ID>/ghac_tokens` Agent API endpoint using the ambient
 `BUILDKITE_AGENT_ACCESS_TOKEN`. The returned short-lived token is registered
 with both the local log scrubber and `buildkite-agent redactor add` before the
-action starts. A fresh token is minted for post-save rather than retaining a
-main-phase credential. The runtime exposes only `ACTIONS_CACHE_SERVICE_V2`,
-`ACTIONS_RESULTS_URL`, and `ACTIONS_RUNTIME_TOKEN` to the cache action; it does
-not forward the Agent job token, persist cache credentials into job state, or
-expose them to ordinary actions. Credential-bearing phases also discard
-workflow-controlled legacy cache URLs, Node/process injection settings, TLS
-and OpenSSL configuration/module overrides, tar and dynamic-loader controls,
-and upper- or lower-case proxy settings before overlaying the runtime-owned
-service values. Cache subprocesses use the fixed
+action starts. A fresh token is minted for each invocation rather than
+retaining a broad job credential. The runtime exposes only
+`ACTIONS_CACHE_SERVICE_V2`, `ACTIONS_RESULTS_URL`, and
+`ACTIONS_RUNTIME_TOKEN`; it does not forward the Agent job token, persist cache
+credentials into job state, or expose them to ordinary `run` steps or native
+adapters. Workflow-controlled cache service variables are discarded before
+the runtime-owned values are overlaid.
+
+The audited `actions/cache` integration remains stricter than a general action
+invocation: credential or redaction failure stops it before its JavaScript
+executes. It additionally discards Node/process injection settings, TLS and
+OpenSSL configuration/module overrides, tar and dynamic-loader controls, and
+upper- or lower-case proxy settings. Its subprocesses use the fixed
 `/usr/local/bin:/usr/bin:/bin` tool path rather than workflow `PATH` changes. If
-a credential appears in a phase's command-file effects, those effects are
-discarded and the phase fails.
+a credential appears in any action's command-file effects, those effects are
+discarded and the action fails. Other JavaScript and Docker actions receive the
+same cache-v2 environment when credentials can be minted, allowing embedded
+clients such as `actions/setup-go` to use their normal cache lifecycle. If the
+cache service is unavailable, those general actions continue without the
+cache environment so an incidental cache does not make unrelated action
+execution fail.
 
 The runtime uses the official `https://ghacs.buildkite.com/` Results service by
 default. Operators can set `BUILDKITE_GHA_CACHE_URL` to override it with another
@@ -381,9 +391,10 @@ must have GHAC token minting enabled, and jobs must be able to reach both the
 Results service and the Agent API.
 The service-issued token scopes cache access to the current organization and
 pipeline, grants writes only for an authorized ref, and limits cross-repository
-pull requests to the read-only default-branch scope. Disabled minting, malformed
-responses, redirects, unsafe override configuration, or failed redaction stop
-the cache action before its JavaScript executes.
+pull requests to the read-only default-branch scope. For the explicit audited
+cache action, disabled minting, malformed responses, redirects, unsafe override
+configuration, or failed redaction stop the action before its JavaScript
+executes.
 
 This implemented and admitted contract has hosted runtime evidence. The
 then-combined advanced migration POC in [Buildkite build 303](https://buildkite.com/buildkite/buildkite-gha/builds/303)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -215,16 +215,19 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: %v\n", err)
 		return 1
 	}
-	if cacheRequired {
+	if cacheRequired || len(job.Actions) > 0 {
 		cacheCredentials, err = gharuntime.NewAgentCacheCredentials(gharuntime.AgentCacheConfig{
 			Endpoint:   os.Getenv("BUILDKITE_AGENT_ENDPOINT"),
 			JobID:      os.Getenv("BUILDKITE_JOB_ID"),
 			JobToken:   os.Getenv("BUILDKITE_AGENT_ACCESS_TOKEN"),
 			ResultsURL: os.Getenv("BUILDKITE_GHA_CACHE_URL"),
 		})
-		if err != nil {
+		if err != nil && cacheRequired {
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: configure actions/cache v6 service: %v\n", err)
 			return 1
+		}
+		if err != nil {
+			cacheCredentials = nil
 		}
 	}
 	var checkoutTokens gharuntime.CheckoutTokenProvider

--- a/internal/runtime/cache_service.go
+++ b/internal/runtime/cache_service.go
@@ -22,8 +22,8 @@ const (
 
 var cacheRuntimeTokenPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$`)
 
-// CacheCredentials are the short-lived values exposed only to one verified
-// actions/cache lifecycle phase.
+// CacheCredentials are the short-lived values exposed only to one action
+// lifecycle invocation.
 type CacheCredentials struct {
 	ResultsURL string
 	Token      string
@@ -195,10 +195,28 @@ func cacheCredentialStatusError(status int) error {
 	}
 }
 
+func isCacheServiceEnvironment(name string) bool {
+	switch name {
+	case "ACTIONS_RESULTS_URL", "ACTIONS_RUNTIME_TOKEN", "ACTIONS_CACHE_SERVICE_V2", "ACTIONS_CACHE_URL", "ACTIONS_RUNTIME_URL":
+		return true
+	default:
+		return false
+	}
+}
+
+func removeCacheServiceEnvironment(env map[string]string) map[string]string {
+	clean := cloneStrings(env)
+	for name := range clean {
+		if isCacheServiceEnvironment(name) {
+			delete(clean, name)
+		}
+	}
+	return clean
+}
+
 func isolateCacheActionEnvironment(env map[string]string) map[string]string {
-	isolated := cloneStrings(env)
+	isolated := removeCacheServiceEnvironment(env)
 	for _, name := range []string{
-		"ACTIONS_RESULTS_URL", "ACTIONS_RUNTIME_TOKEN", "ACTIONS_CACHE_SERVICE_V2", "ACTIONS_CACHE_URL", "ACTIONS_RUNTIME_URL",
 		"NODE_OPTIONS", "NODE_PATH", "NODE_EXTRA_CA_CERTS", "NODE_TLS_REJECT_UNAUTHORIZED", "SSLKEYLOGFILE", "LD_AUDIT", "LD_PRELOAD", "LD_LIBRARY_PATH",
 		"OPENSSL_CONF", "OPENSSL_CONF_INCLUDE", "OPENSSL_ENGINES", "OPENSSL_MODULES",
 		"TAR_OPTIONS",

--- a/internal/runtime/cache_service_test.go
+++ b/internal/runtime/cache_service_test.go
@@ -242,13 +242,18 @@ console.log("credential=" + process.env.ACTIONS_RUNTIME_TOKEN);
 `, cacheActionToolPath, phase)
 		writeFixtureFile(t, remote, phase+".js", program)
 	}
-	writeFixtureFile(t, remote, "ordinary/action.yml", "name: ordinary\nruns:\n  using: node24\n  main: index.js\n")
-	writeFixtureFile(t, remote, "ordinary/index.js", `import fs from "node:fs";
-for (const name of ["ACTIONS_CACHE_SERVICE_V2", "ACTIONS_RESULTS_URL", "ACTIONS_RUNTIME_TOKEN", "BUILDKITE_AGENT_ACCESS_TOKEN"])
+	writeFixtureFile(t, remote, "ordinary/action.yml", "name: ordinary\nruns:\n  using: node24\n  pre: pre.js\n  main: main.js\n  post: post.js\n")
+	for _, phase := range []string{"pre", "main", "post"} {
+		writeFixtureFile(t, remote, "ordinary/"+phase+".js", fmt.Sprintf(`import fs from "node:fs";
+for (const name of ["ACTIONS_CACHE_SERVICE_V2", "ACTIONS_RESULTS_URL", "ACTIONS_RUNTIME_TOKEN"])
+  if (!process.env[name]) throw new Error("missing " + name);
+for (const name of ["ACTIONS_CACHE_URL", "ACTIONS_RUNTIME_URL", "BUILDKITE_AGENT_ACCESS_TOKEN"])
   if (process.env[name]) throw new Error(name + " leaked");
-if (!process.env.PATH.startsWith(process.env.ATTACKER_BIN + ":")) throw new Error("ordinary action PATH was isolated");
-fs.appendFileSync(process.env.LIFECYCLE_LOG, "ordinary\n");
-`)
+if (process.env.PATH === %q) throw new Error("ordinary action PATH was isolated");
+fs.appendFileSync(process.env.LIFECYCLE_LOG, "ordinary-%s|" + process.env.ACTIONS_RUNTIME_TOKEN + "|" + process.env.ACTIONS_RESULTS_URL + "|" + process.env.ACTIONS_CACHE_SERVICE_V2 + "\n");
+console.log("ordinary-credential=" + process.env.ACTIONS_RUNTIME_TOKEN);
+`, cacheActionToolPath, phase))
+	}
 	digest, err := source.DigestTree(remote)
 	if err != nil {
 		t.Fatal(err)
@@ -276,9 +281,14 @@ fs.appendFileSync(process.env.LIFECYCLE_LOG, "ordinary\n");
 		"BUILDKITE_AGENT_ACCESS_TOKEN": "workflow-agent-token", "BUILDKITE_JOB_ID": testCacheJobID, "FAKE_TAR_MARKER": fakeTarMarker,
 	}
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{
+		{ID: "shell-before", Kind: "run", Command: `test -z "${ACTIONS_RUNTIME_TOKEN:-}" && test -z "${ACTIONS_RESULTS_URL:-}" && test -z "${ACTIONS_CACHE_SERVICE_V2:-}"`},
 		{ID: "poison-path", Kind: "run", Command: `printf '%s\n' "$ATTACKER_BIN" >> "$GITHUB_PATH"`},
-		{ID: "ordinary", Kind: "uses", Uses: "owner/repo/ordinary@v1", Action: &plan.ActionSelector{Lock: ordinaryID}},
+		{ID: "ordinary", Kind: "uses", Uses: "owner/repo/ordinary@v1", Env: map[string]string{
+			"ACTIONS_RESULTS_URL": "https://attacker.invalid", "ACTIONS_RUNTIME_TOKEN": "workflow-token", "ACTIONS_CACHE_SERVICE_V2": "false",
+			"ACTIONS_CACHE_URL": "https://legacy.invalid", "ACTIONS_RUNTIME_URL": "https://legacy.invalid",
+		}, Action: &plan.ActionSelector{Lock: ordinaryID}},
 		{ID: "cache", Kind: "uses", Uses: "actions/cache@" + actionintegration.CacheCommit, Env: cacheEnv, Action: &plan.ActionSelector{Lock: cacheID}},
+		{ID: "shell-after", Kind: "run", Command: `test -z "${ACTIONS_RUNTIME_TOKEN:-}" && test -z "${ACTIONS_RESULTS_URL:-}" && test -z "${ACTIONS_CACHE_SERVICE_V2:-}"`},
 	})
 	job.Schema = plan.SchemaV3
 	job.RequiredCapabilities = []string{"network"}
@@ -287,7 +297,10 @@ fs.appendFileSync(process.env.LIFECYCLE_LOG, "ordinary\n");
 		{ID: cacheID, Source: "github", Repository: "actions/cache", RequestedRef: actionintegration.CacheCommit, Commit: actionintegration.CacheCommit, SourceDigest: digest},
 		{ID: ordinaryID, Source: "github", Repository: "owner/repo", RequestedRef: "v1", Commit: strings.Repeat("a", 40), Path: "ordinary", SourceDigest: digest},
 	}
-	provider := &sequenceCacheCredentials{tokens: []string{"header.pre.signature", "header.main.signature", "header.post.signature"}}
+	provider := &sequenceCacheCredentials{tokens: []string{
+		"header.first.signature", "header.second.signature", "header.third.signature",
+		"header.fourth.signature", "header.fifth.signature", "header.sixth.signature",
+	}}
 	redactor := &testRedactor{}
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}
 	var logs bytes.Buffer
@@ -303,11 +316,36 @@ fs.appendFileSync(process.env.LIFECYCLE_LOG, "ordinary\n");
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "pre|header.pre.signature|https://cache.example/|true\nordinary\nmain|header.main.signature|https://cache.example/|true\npost|header.post.signature|https://cache.example/|true\n"
-	if string(contents) != want {
-		t.Fatalf("lifecycle = %q, want %q", contents, want)
+	wantPhases := map[string]bool{
+		"pre": false, "main": false, "post": false,
+		"ordinary-pre": false, "ordinary-main": false, "ordinary-post": false,
 	}
-	if provider.calls != 3 || fmt.Sprint(redactor.values) != fmt.Sprint(provider.tokens) {
+	seenTokens := map[string]bool{}
+	for _, line := range strings.Split(strings.TrimSpace(string(contents)), "\n") {
+		fields := strings.Split(line, "|")
+		if len(fields) != 4 || fields[2] != "https://cache.example/" || fields[3] != "true" {
+			t.Fatalf("invalid lifecycle record %q in %q", line, contents)
+		}
+		if _, ok := wantPhases[fields[0]]; !ok || wantPhases[fields[0]] {
+			t.Fatalf("unexpected or duplicate lifecycle phase %q in %q", fields[0], contents)
+		}
+		wantPhases[fields[0]] = true
+		if seenTokens[fields[1]] {
+			t.Fatalf("cache credential %q was reused in %q", fields[1], contents)
+		}
+		seenTokens[fields[1]] = true
+	}
+	for phase, seen := range wantPhases {
+		if !seen {
+			t.Fatalf("lifecycle phase %q missing from %q", phase, contents)
+		}
+	}
+	for _, token := range provider.tokens {
+		if !seenTokens[token] {
+			t.Fatalf("cache credential %q missing from %q", token, contents)
+		}
+	}
+	if provider.calls != 6 || fmt.Sprint(redactor.values) != fmt.Sprint(provider.tokens) {
 		t.Fatalf("credential calls/redactions = %d / %#v", provider.calls, redactor.values)
 	}
 	for _, token := range provider.tokens {
@@ -330,6 +368,203 @@ fs.appendFileSync(process.env.LIFECYCLE_LOG, "ordinary\n");
 	job.Actions[0].Commit = strings.Repeat("b", 40)
 	if _, err := (Runner{Node24: node, Actions: materializer, Cache: provider, Redactor: redactor}).RunJob(context.Background(), job, workspace); err == nil || !strings.Contains(err.Error(), actionintegration.CacheCommit) {
 		t.Fatalf("unsupported runtime cache commit error = %v", err)
+	}
+}
+
+func TestActionCacheRedactorIsPinnedBeforeWorkflowExecution(t *testing.T) {
+	node := requireNode24(t)
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/cache-redactor.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: cache redactor\n")
+	actionPath := ".github/actions/generic"
+	writeFixtureFile(t, workspace, actionPath+"/action.yml", "name: generic\nruns:\n  using: node24\n  main: main.js\n")
+	writeFixtureFile(t, workspace, actionPath+"/main.js", "")
+
+	token := "header.pinned.signature"
+	trustedDir := canonicalTempDir(t)
+	trustedMarker := filepath.Join(t.TempDir(), "trusted-agent-ran")
+	trustedAgent := filepath.Join(trustedDir, "buildkite-agent")
+	writeFixtureFile(t, trustedDir, "buildkite-agent", "#!/bin/sh\nIFS= read -r value\ntest \"$value\" = "+shellTestQuote(token)+"\n: > "+shellTestQuote(trustedMarker)+"\n")
+	if err := os.Chmod(trustedAgent, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	lookupDir := t.TempDir()
+	lookupAgent := filepath.Join(lookupDir, "buildkite-agent")
+	if err := os.Symlink(trustedAgent, lookupAgent); err != nil {
+		t.Fatal(err)
+	}
+	poisonDir := canonicalTempDir(t)
+	poisonMarker := filepath.Join(t.TempDir(), "poison-agent-ran")
+	poisonAgent := filepath.Join(poisonDir, "buildkite-agent")
+	writeFixtureFile(t, poisonDir, "buildkite-agent", "#!/bin/sh\n: > "+shellTestQuote(poisonMarker)+"\nexit 99\n")
+	if err := os.Chmod(poisonAgent, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", lookupDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	lockID := remoteLifecycleLockID(1)
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{
+		{ID: "poison", Kind: "run", Command: `rm -f "$LOOKUP_AGENT" && ln -s "$POISON_AGENT" "$LOOKUP_AGENT"`},
+		{ID: "generic", Kind: "uses", Uses: "./" + actionPath, Action: &plan.ActionSelector{Lock: lockID}},
+	})
+	job.Schema = plan.SchemaV3
+	job.Env = map[string]string{"LOOKUP_AGENT": lookupAgent, "POISON_AGENT": poisonAgent}
+	job.Actions = []plan.ActionLock{{
+		ID: lockID, Source: "workspace", Path: actionPath,
+		SourceDigest: digestTree(t, filepath.Join(workspace, filepath.FromSlash(actionPath))),
+	}}
+	provider := &sequenceCacheCredentials{tokens: []string{token}}
+	result, err := (Runner{Node24: node, Cache: provider, Redactor: AgentRedactor{}}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	if target, err := filepath.EvalSymlinks(lookupAgent); err != nil || target != poisonAgent {
+		t.Fatalf("workflow Agent replacement = %q, %v; want %q", target, err, poisonAgent)
+	}
+	if _, err := os.Stat(trustedMarker); err != nil {
+		t.Fatalf("trusted Agent redactor did not run: %v", err)
+	}
+	if _, err := os.Stat(poisonMarker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("workflow-selected Agent received cache credential or marker stat failed: %v", err)
+	}
+}
+
+func TestGenericActionCacheDisablesWhenRedactorCannotBePinned(t *testing.T) {
+	node := requireNode24(t)
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/cache-fallback.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: cache fallback\n")
+	actionPath := ".github/actions/generic"
+	writeFixtureFile(t, workspace, actionPath+"/action.yml", "name: generic\nruns:\n  using: node24\n  main: main.js\n")
+	writeFixtureFile(t, workspace, actionPath+"/main.js", `for (const name of ["ACTIONS_CACHE_SERVICE_V2", "ACTIONS_RESULTS_URL", "ACTIONS_RUNTIME_TOKEN"]) if (process.env[name]) throw new Error(name + " leaked");`)
+	lockID := remoteLifecycleLockID(1)
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "generic", Kind: "uses", Uses: "./" + actionPath, Action: &plan.ActionSelector{Lock: lockID}}})
+	job.Schema = plan.SchemaV3
+	job.Actions = []plan.ActionLock{{
+		ID: lockID, Source: "workspace", Path: actionPath,
+		SourceDigest: digestTree(t, filepath.Join(workspace, filepath.FromSlash(actionPath))),
+	}}
+	provider := &sequenceCacheCredentials{tokens: []string{"header.unused.signature"}}
+	result, err := (Runner{
+		Node24: node, Cache: provider,
+		Redactor: AgentRedactor{Executable: filepath.Join(t.TempDir(), "missing-agent")},
+	}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	if provider.calls != 0 {
+		t.Fatalf("cache credential provider called %d times after redactor fallback", provider.calls)
+	}
+}
+
+func TestExplicitCacheRequiresPinnedRedactorBeforeWorkflowExecution(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/cache-strict.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: strict cache\n")
+	marker := filepath.Join(workspace, "workflow-ran")
+	remote := t.TempDir()
+	writeFixtureFile(t, remote, "action.yml", "name: cache\nruns:\n  using: node24\n  main: main.js\n")
+	writeFixtureFile(t, remote, "main.js", "")
+	lockID := remoteLifecycleLockID(1)
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{
+		{ID: "run", Kind: "run", Command: `: > "$MARKER"`},
+		{ID: "cache", Kind: "uses", Uses: "actions/cache@" + actionintegration.CacheCommit, Action: &plan.ActionSelector{Lock: lockID}},
+	})
+	job.Schema = plan.SchemaV3
+	job.Env = map[string]string{"MARKER": marker}
+	job.Actions = []plan.ActionLock{{
+		ID: lockID, Source: "github", Repository: "actions/cache",
+		RequestedRef: actionintegration.CacheCommit, Commit: actionintegration.CacheCommit,
+		SourceDigest: digestTree(t, remote),
+	}}
+	provider := &sequenceCacheCredentials{tokens: []string{"header.unused.signature"}}
+	_, err := (Runner{
+		Cache:    provider,
+		Redactor: AgentRedactor{Executable: filepath.Join(t.TempDir(), "missing-agent")},
+	}).RunJob(context.Background(), job, workspace)
+	if err == nil || !strings.Contains(err.Error(), "resolve Buildkite Agent redactor before workflow execution") {
+		t.Fatalf("RunJob() error = %v", err)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("workflow executed before strict cache redactor failure: %v", err)
+	}
+	if provider.calls != 0 {
+		t.Fatalf("cache credential provider called %d times before redactor failure", provider.calls)
+	}
+}
+
+func TestGenericJavaScriptCacheCredentialFailureFallsBackUncached(t *testing.T) {
+	node := requireNode24(t)
+	actionRoot := t.TempDir()
+	marker := filepath.Join(actionRoot, "executed")
+	writeFixtureFile(t, actionRoot, "main.js", `const fs = require("node:fs");
+for (const name of ["ACTIONS_CACHE_SERVICE_V2", "ACTIONS_RESULTS_URL", "ACTIONS_RUNTIME_TOKEN"])
+  if (process.env[name]) throw new Error(name + " leaked");
+fs.writeFileSync(process.env.MARKER, "executed");
+`)
+	provider := cacheCredentialProviderFunc(func(context.Context) (CacheCredentials, error) {
+		return CacheCredentials{}, fmt.Errorf("cache unavailable")
+	})
+	result := newResult()
+	result.Env["MARKER"] = marker
+	result.Env["ACTIONS_RUNTIME_TOKEN"] = "workflow-token"
+	processor := newCommandProcessor(io.Discard, io.Discard)
+	runner := Runner{Cache: provider, Redactor: &testRedactor{}}
+	if err := runner.runJavaScriptPhase(
+		context.Background(), processor, actionRoot, node,
+		JavaScriptAction{Name: "ordinary", Path: actionRoot, Main: "main.js"}, "main.js", nil, nil, &result,
+	); err != nil {
+		t.Fatalf("generic action cache fallback error = %v", err)
+	}
+	if contents, err := os.ReadFile(marker); err != nil || string(contents) != "executed" {
+		t.Fatalf("generic action marker = %q, %v", contents, err)
+	}
+	if err := os.Remove(marker); err != nil {
+		t.Fatal(err)
+	}
+	if err := runner.runJavaScriptPhase(
+		context.Background(), processor, actionRoot, node,
+		JavaScriptAction{Name: "cache", Path: actionRoot, Main: "main.js", Cache: true}, "main.js", nil, nil, &result,
+	); err == nil || !strings.Contains(err.Error(), "configure actions/cache v6 service: cache unavailable") {
+		t.Fatalf("explicit cache action error = %v", err)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("strict cache action executed or marker stat failed: %v", err)
+	}
+}
+
+func TestDockerActionReceivesCacheCredentialsWithoutTokenInArguments(t *testing.T) {
+	token := "header.docker.signature"
+	provider := &sequenceCacheCredentials{tokens: []string{token}}
+	redactor := &testRedactor{}
+	fake := newFakeDocker(t, "success")
+	action := fakeDockerAction(t)
+	action.Env["ACTIONS_RUNTIME_TOKEN"] = "workflow-token"
+	action.Env["ACTIONS_RESULTS_URL"] = "https://attacker.invalid"
+	action.Env["ACTIONS_CACHE_SERVICE_V2"] = "false"
+	if _, err := (Runner{Docker: fake.path, Cache: provider, Redactor: redactor}).RunDocker(context.Background(), action); err != nil {
+		t.Fatal(err)
+	}
+	cacheRuntime, err := os.ReadFile(filepath.Join(fake.root, "cache-runtime"))
+	if err != nil || string(cacheRuntime) != token+"|https://cache.example/|true" {
+		t.Fatalf("Docker cache environment = %q, %v", cacheRuntime, err)
+	}
+	calls := fake.calls(t)
+	runIndex := callIndex(calls, "run")
+	if runIndex < 0 {
+		t.Fatalf("Docker run absent: %#v", calls)
+	}
+	arguments := strings.Join(calls[runIndex].args, "\x00")
+	if strings.Contains(arguments, token) {
+		t.Fatalf("Docker arguments contain cache credential: %#v", calls[runIndex].args)
+	}
+	for _, name := range []string{"ACTIONS_CACHE_SERVICE_V2", "ACTIONS_RESULTS_URL", "ACTIONS_RUNTIME_TOKEN"} {
+		if !strings.Contains(arguments, "\x00--env\x00"+name+"\x00") {
+			t.Fatalf("Docker arguments omit inherited %s: %#v", name, calls[runIndex].args)
+		}
+	}
+	if provider.calls != 1 || fmt.Sprint(redactor.values) != fmt.Sprint([]string{token}) {
+		t.Fatalf("credential calls/redactions = %d / %#v", provider.calls, redactor.values)
 	}
 }
 
@@ -362,7 +597,7 @@ func TestCacheV6RedactorFailureAbortsBeforeExecutionAndScrubsToken(t *testing.T)
 	}
 }
 
-func TestCacheV6TokenCommandFileEffectsAreDiscarded(t *testing.T) {
+func TestActionRuntimeCacheTokenCommandFileEffectsAreDiscarded(t *testing.T) {
 	node := requireNode24(t)
 	token := "header.secret.signature"
 	for name, command := range map[string]string{
@@ -387,7 +622,7 @@ func TestCacheV6TokenCommandFileEffectsAreDiscarded(t *testing.T) {
 			state := map[string]string{"kept": "action state"}
 			err := (Runner{Cache: provider, Redactor: &testRedactor{}}).runJavaScriptPhase(
 				context.Background(), newCommandProcessor(io.Discard, io.Discard), actionRoot, node,
-				JavaScriptAction{Name: "cache", Path: actionRoot, Main: "main.js", Cache: true}, "main.js", nil, state, &result,
+				JavaScriptAction{Name: "ordinary", Path: actionRoot, Main: "main.js"}, "main.js", nil, state, &result,
 			)
 			if err == nil || strings.Contains(err.Error(), token) || !strings.Contains(err.Error(), "phase effects were discarded") {
 				t.Fatalf("runJavaScriptPhase() error = %v", err)

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -131,14 +131,33 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 	if job.HasCapability("provider-token-write") && r.WorkflowToken == nil {
 		return JobResult{}, fmt.Errorf("provider-token-write capability requires the GitHub workflow token provider")
 	}
-	if job.HasCapability("provider-token-read") || job.HasCapability("provider-token-write") {
-		if r.Redactor == nil {
-			return JobResult{}, fmt.Errorf("provider token capability requires the Buildkite Agent redactor")
+	providerTokenRequired := job.HasCapability("provider-token-read") || job.HasCapability("provider-token-write")
+	cacheRequired := false
+	for _, lock := range job.Actions {
+		if usesCacheService(lock) {
+			cacheRequired = true
+			break
 		}
-		var err error
-		r.Redactor, err = resolveAgentRedactorBeforeWorkflow(r.Redactor)
-		if err != nil {
-			return JobResult{}, err
+	}
+	if providerTokenRequired || r.Cache != nil {
+		if r.Redactor == nil {
+			if providerTokenRequired {
+				return JobResult{}, fmt.Errorf("provider token capability requires the Buildkite Agent redactor")
+			}
+			if cacheRequired {
+				return JobResult{}, fmt.Errorf("actions/cache requires the Buildkite Agent redactor")
+			}
+			r.Cache = nil
+		} else {
+			resolved, err := resolveAgentRedactorBeforeWorkflow(r.Redactor)
+			if err != nil {
+				if providerTokenRequired || cacheRequired {
+					return JobResult{}, err
+				}
+				r.Cache = nil
+			} else {
+				r.Redactor = resolved
+			}
 		}
 	}
 	if len(job.Dependencies) != 0 && len(job.Needs) == 0 {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -382,6 +382,14 @@ func (r Runner) runDocker(ctx context.Context, processor *commandProcessor, acti
 			return result, err
 		}
 	}
+	cacheEnv, cacheErr := r.cacheActionEnvironment(ctx, processor)
+	if cacheErr != nil && ctx.Err() != nil {
+		return result, ctx.Err()
+	}
+	cacheToken := ""
+	if cacheErr == nil {
+		cacheToken = cacheEnv["ACTIONS_RUNTIME_TOKEN"]
+	}
 	args := []string{"run", "--name", container, "--label", owner, "--mount", "type=bind,source=" + files.dir + ",target=/github/file_commands"}
 	if r.jobDocker != nil {
 		args = append(args, "--network", r.jobDocker.network)
@@ -397,7 +405,7 @@ func (r Runner) runDocker(ctx context.Context, processor *commandProcessor, acti
 		}}
 	}
 	for _, name := range sortedKeys(action.Env) {
-		if name == "RUNNER_TOOL_CACHE" || (name == "PATH" && !action.explicitPATH) || name == "GITHUB_WORKSPACE" || name == "RUNNER_TEMP" {
+		if isCacheServiceEnvironment(name) || name == "RUNNER_TOOL_CACHE" || (name == "PATH" && !action.explicitPATH) || name == "GITHUB_WORKSPACE" || name == "RUNNER_TEMP" {
 			continue
 		}
 		value := action.Env[name]
@@ -420,10 +428,17 @@ func (r Runner) runDocker(ctx context.Context, processor *commandProcessor, acti
 		"--env", "GITHUB_PATH=/github/file_commands/path",
 		"--env", "GITHUB_STATE=/github/file_commands/state",
 		"--env", "GITHUB_STEP_SUMMARY=/github/file_commands/summary",
-		image,
 	)
+	dockerRunEnv := dockerEnv
+	for _, name := range sortedKeys(cacheEnv) {
+		args = append(args, "--env", name)
+	}
+	if len(cacheEnv) > 0 {
+		dockerRunEnv = mergeStringMaps(dockerEnv, cacheEnv)
+	}
+	args = append(args, image)
 	ran = true
-	runErr := r.runStreaming(ctx, processor, "", dockerEnv, docker, args...)
+	runErr := r.runStreaming(ctx, processor, "", dockerRunEnv, docker, args...)
 	if runErr != nil {
 		runErr = fmt.Errorf("run Docker action %q: %w", action.Name, runErr)
 	}
@@ -431,6 +446,14 @@ func (r Runner) runDocker(ctx context.Context, processor *commandProcessor, acti
 	effects.reportSummaryUploadFailure(processor)
 	if fileErr != nil {
 		fileErr = fmt.Errorf("process Docker action %q file commands: %w", action.Name, fileErr)
+	}
+	if cacheToken != "" {
+		runErr = processor.scrubError(runErr)
+		fileErr = processor.scrubError(fileErr)
+		if resultContains(result, cacheToken) {
+			result = newResult()
+			return result, errors.Join(runErr, fileErr, errors.New("action runtime cache token leakage detected; action effects were discarded"))
+		}
 	}
 	return result, errors.Join(runErr, fileErr)
 }
@@ -580,13 +603,19 @@ func (r Runner) runJavaScriptPhase(ctx context.Context, processor *commandProces
 	for name, value := range stateEnv {
 		env["STATE_"+name] = value
 	}
-	cacheToken := ""
+	env = removeCacheServiceEnvironment(env)
 	if action.Cache {
 		env = isolateCacheActionEnvironment(env)
-		cacheEnv, err := r.cacheActionEnvironment(ctx, processor)
-		if err != nil {
-			return fmt.Errorf("configure actions/cache v6 service: %w", err)
-		}
+	}
+	cacheEnv, cacheErr := r.cacheActionEnvironment(ctx, processor)
+	if cacheErr != nil && ctx.Err() != nil {
+		return ctx.Err()
+	}
+	if cacheErr != nil && action.Cache {
+		return fmt.Errorf("configure actions/cache v6 service: %w", cacheErr)
+	}
+	cacheToken := ""
+	if cacheErr == nil {
 		env = mergeStringMaps(env, cacheEnv)
 		cacheToken = cacheEnv["ACTIONS_RUNTIME_TOKEN"]
 	}
@@ -616,7 +645,7 @@ func (r Runner) runJavaScriptPhase(ctx context.Context, processor *commandProces
 		if leaked {
 			*result = beforeResult
 			restoreStringMap(stateOut, beforeState)
-			leakErr := errors.New("actions/cache runtime token leakage detected; phase effects were discarded")
+			leakErr := errors.New("action runtime cache token leakage detected; phase effects were discarded")
 			if err != nil {
 				leakErr = errors.Join(err, leakErr)
 			}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -230,6 +230,9 @@ if [[ "$1" == buildx && "$2" == build ]]; then
 fi
 
 if [[ "$1" == run ]]; then
+	if [[ -n "${ACTIONS_RUNTIME_TOKEN:-}" ]]; then
+		printf '%s|%s|%s' "$ACTIONS_RUNTIME_TOKEN" "${ACTIONS_RESULTS_URL:-}" "${ACTIONS_CACHE_SERVICE_V2:-}" > "$state/cache-runtime"
+	fi
   files=''
   workspace=''
   runner_temp=''


### PR DESCRIPTION
## Summary

- expose fresh job-bound cache-v2 credentials to JavaScript pre/main/post phases and Docker action invocations, matching the GitHub runner boundary
- let embedded cache clients such as `actions/setup-go` use the existing Buildkite Results service without action-specific handling
- keep ordinary `run:` steps and native adapters credential-free, preserve strict fail-closed handling for audited `actions/cache@v6.1.0`, and let other actions continue uncached when the service is unavailable
- pin the Buildkite Agent redactor before workflow code can mutate `PATH`, and discard command-file effects that contain a cache credential
- enable setup-go's default cache in the exact-source basic smoke

## Validation

- `mise exec -- go test ./internal/runtime ./internal/cli ./internal/compiler ./internal/plan`
- `mise run check`

## Hosted proof

Both runs used exact head `8762dd1db0ad4559474200e17c07aafaea852120` in the same pipeline and branch scope:

1. [Build 473](https://buildkite.com/buildkite/buildkite-gha/builds/473) and its [generated Basic Go CI job](https://buildkite.com/buildkite/buildkite-gha/builds/473#019fe094-864c-443c-b005-fc9571e52f76) passed. Unchanged `actions/setup-go@v6` reported `Cache is not found`, then its post phase saved 27,764,627 bytes under the setup-go primary key.
2. [Build 474](https://buildkite.com/buildkite/buildkite-gha/builds/474) and its [generated Basic Go CI job](https://buildkite.com/buildkite/buildkite-gha/builds/474#019fe097-34a9-4aec-89f4-d0a2886c1bd4) passed. setup-go reported the same primary-key hit, restored all 27,764,627 bytes successfully, and correctly skipped the post save.

The generated job duration fell from 20.431s on the miss/save run to 11.611s on the restore-hit run. This is functional proof, not a provider benchmark.