### PR TITLE
Accept stateless GitHub installation tokens

### DIFF
--- a/internal/runtime/github_token_service.go
+++ b/internal/runtime/github_token_service.go
@@ -16,7 +16,7 @@ import (
 
 const githubTokenResponseLimit = 64 << 10
 
-var githubInstallationTokenPattern = regexp.MustCompile(`^[A-Za-z0-9_]+$`)
+var githubInstallationTokenPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
 var retryAfterSecondsPattern = regexp.MustCompile(`^[0-9]{1,10}$`)
 
 // CheckoutTokenProvider mints one repository-scoped credential for the

--- a/internal/runtime/github_token_service_test.go
+++ b/internal/runtime/github_token_service_test.go
@@ -47,6 +47,7 @@ func TestAgentGitHubTokensMintsFixedReadOnlyRepositoryCredential(t *testing.T) {
 }
 
 func TestAgentGitHubTokensMintsExactWorkflowPermissions(t *testing.T) {
+	const statelessToken = "ghs_header.payload-with-hyphen.signature"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
@@ -55,7 +56,7 @@ func TestAgentGitHubTokensMintsExactWorkflowPermissions(t *testing.T) {
 		if string(body) != `{"repo_url":"https://github.com/buildkite/buildkite-gha","permissions":{"contents":"read","pull_requests":"write"}}` {
 			t.Errorf("request body = %s", body)
 		}
-		_, _ = io.WriteString(w, `{"token":"ghs_workflow_token"}`)
+		_, _ = io.WriteString(w, `{"token":"`+statelessToken+`"}`)
 	}))
 	defer server.Close()
 	provider, err := NewAgentGitHubTokens(AgentGitHubTokenConfig{Endpoint: server.URL, JobID: testCacheJobID, JobToken: "job-secret"})
@@ -63,7 +64,7 @@ func TestAgentGitHubTokensMintsExactWorkflowPermissions(t *testing.T) {
 		t.Fatal(err)
 	}
 	token, err := provider.WorkflowToken(context.Background(), "buildkite/buildkite-gha", map[string]string{"pull_requests": "write", "contents": "read"})
-	if err != nil || token != "ghs_workflow_token" {
+	if err != nil || token != statelessToken {
 		t.Fatalf("WorkflowToken() = %q, %v", token, err)
 	}
 	for _, permissions := range []map[string]string{nil, {}, {"contents": "admin"}, {"administration": "write"}, {"models": "write"}} {


### PR DESCRIPTION
## Summary

- accept `.` and `-` in GitHub installation tokens returned by the job-bound token service
- cover GitHub's new `ghs_`-prefixed stateless JWT token shape while continuing to reject whitespace and control characters

## Root cause

[`lox/notion-cli` build 5](https://buildkite.com/lox/notion-cli/builds/5#019fe0b5-6c9f-4c72-9969-96bd1ea9c753) used github-actions-buildkite-plugin v0.6.0 and buildkite-gha v0.6.0 to translate `.github/workflows/ci.yml` job `check` at `9e2dcfdacad890e63da77da2850452aeacb61e41`. The generated plan correctly requested `contents: read` because `jdx/mise-action@v2` defaults its `github_token` input to `${{ github.token }}`.

The runtime then failed before checkout with:

```text
buildkite-gha: run-job: GitHub workflow token response contains an invalid token
```

[Exact rebuild 6](https://buildkite.com/lox/notion-cli/builds/6#019fe0c3-62f5-4698-90b0-af849d7ce4b7) reproduced the same error.

GitHub is rolling out stateless GitHub App installation tokens as `ghs_`-prefixed JWTs. They contain two dots and may contain hyphens; GitHub's migration guidance explicitly warns against validators that reject those characters: https://github.blog/changelog/2026-05-15-github-app-installation-tokens-per-request-override-header

The existing `[A-Za-z0-9_]+` validator therefore rejected a valid token minted for this GitHub App installation. This change extends the safe token alphabet to the JWT/base64url punctuation without relaxing whitespace or control-character rejection.

## Validation

- `mise exec -- go test ./internal/runtime`
- `mise run check`
