### PR TITLE
Run node20 actions with Node 24

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -101,7 +101,7 @@ service.
 | Step summaries | Supported | Summaries publish as bounded job-scoped Buildkite annotations. Requires Buildkite Agent v3.112 or newer. Oversized per-step summaries are skipped; the aggregate job summary is limited to 1 MiB. |
 | Local actions | Supported subset | Workspace actions are digest-locked and reverified. JavaScript, composite, and compiler-verified Dockerfile runtimes are supported; other action runtimes are not. |
 | Anonymous public GitHub actions | Supported subset | Sources are anonymously resolved to exact commits, complete trees are digest-verified, and JavaScript/composite/Dockerfile runtime rules still apply. Private actions and actions that require unavailable GitHub services are not supported merely because source resolution succeeds. |
-| JavaScript actions | Supported | Managed, digest-verified Node 20 and 24 runtimes, pre/main/post lifecycle, inputs, outputs, state, LIFO post ordering, and the standard cache-v2 environment are supported. Other Node action runtime declarations are not. |
+| JavaScript actions | Supported | `node20` and `node24` declarations run on the managed, digest-verified Node 24 runtime, matching GitHub-hosted runners' current Node 20 deprecation behavior. The temporary `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` opt-out is not supported. Pre/main/post lifecycle, inputs, outputs, state, LIFO post ordering, and the standard cache-v2 environment are supported. Other Node action runtime declarations are not. |
 | Composite actions | Supported subset | Nested shell/action steps, outputs, and global pre/main/post ordering are supported. Composite `run` steps must select `bash` or `sh`. |
 | Dockerfile actions | Supported subset | Only compiler-verified local or anonymous public Dockerfile actions are admitted. The standard cache-v2 environment is available inside the action container. Lifecycle overrides, arbitrary Docker options, other credentials, volumes, private images, and privileged execution are not supported. |
 | `docker://` actions and action `entrypoint`/`args` overrides | Not supported | Validation rejects these forms. |
@@ -474,9 +474,9 @@ there before execution, so the shared cache remains an accelerator rather than
 executable authority. An explicit `BUILDKITE_GHA_MISE` must be absolute and
 compatible rather than silently falling back. The runtime resolves and
 validates the executable before workflow code can modify `PATH`, then uses it
-with repository configuration disabled to install exact Node 20.20.2 or
-24.18.0 releases. Those Node binaries require glibc 2.28 or newer; the static
-Go CLI does not. Shell-only jobs and action jobs whose resolved trees contain
+with repository configuration disabled to install the exact Node 24.18.0
+release. That Node binary requires glibc 2.28 or newer; the static Go CLI does
+not. Shell-only jobs and action jobs whose resolved trees contain
 only shell steps, native adapters, or Docker do not require or install mise.
 Importers, `validate`, and `compile` do not require or install mise either.
 

--- a/internal/action/metadata/metadata.go
+++ b/internal/action/metadata/metadata.go
@@ -87,7 +87,8 @@ type Runtime string
 const (
 	// MaxNestedActionDepth bounds local action expansion in both compilation and execution.
 	MaxNestedActionDepth = 10
-	// RuntimeNode20 executes a JavaScript action with managed Node 20.
+	// RuntimeNode20 identifies the accepted node20 action declaration. Matching
+	// GitHub-hosted runners, Runtime maps it to the managed Node 24 runtime.
 	RuntimeNode20 Runtime = "node20"
 	// RuntimeNode24 executes a JavaScript action with managed Node 24.
 	RuntimeNode24 Runtime = "node24"
@@ -279,7 +280,7 @@ func mappingKeyNode(node *yaml.Node, name string) *yaml.Node {
 func (metadata Metadata) Runtime() (Runtime, error) {
 	switch metadata.Runs.Using {
 	case string(RuntimeNode20):
-		return RuntimeNode20, nil
+		return RuntimeNode24, nil
 	case string(RuntimeNode24):
 		return RuntimeNode24, nil
 	case string(RuntimeComposite):

--- a/internal/action/metadata/metadata_test.go
+++ b/internal/action/metadata/metadata_test.go
@@ -16,7 +16,7 @@ func TestLoadAndClassify(t *testing.T) {
 		wantCapacity string
 		wantError    string
 	}{
-		{name: "Node 20", using: "node20", wantRuntime: RuntimeNode20},
+		{name: "Node 20 declaration", using: "node20", wantRuntime: RuntimeNode24},
 		{name: "Node 24", using: "node24", wantRuntime: RuntimeNode24},
 		{name: "composite", using: "composite", wantRuntime: RuntimeComposite},
 		{name: "Docker", using: "docker", wantRuntime: RuntimeDocker, wantCapacity: "docker,network"},

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -1504,7 +1504,7 @@ func TestRunJobContainerWorkspaceActionRemainsLazy(t *testing.T) {
 	workspace := t.TempDir()
 	writeFixtureFile(t, workspace, ".github/workflows/container.yml", "name: lazy container action\n")
 	actionSource := t.TempDir()
-	actionYAML := "name: lazy\nruns:\n  using: node24\n  main: main.js\n"
+	actionYAML := "name: lazy\nruns:\n  using: node20\n  main: main.js\n"
 	mainJS := `require("node:fs").appendFileSync(process.env.GITHUB_OUTPUT, "lazy=ready\n")
 `
 	writeFixtureFile(t, actionSource, "action.yml", actionYAML)
@@ -1525,9 +1525,33 @@ func TestRunJobContainerWorkspaceActionRemainsLazy(t *testing.T) {
 	job.Outputs = map[string]string{"lazy": "${{ steps.lazy.outputs.lazy }}"}
 	node20 := filepath.Join(t.TempDir(), "node20")
 	writeNodeExecutable(t, node20, 20)
-	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node20: node20, Node24: requireNode24(t)}).RunJob(context.Background(), job, workspace)
+	node24 := requireNode24(t)
+	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node20: node20, Node24: node24}).RunJob(context.Background(), job, workspace)
 	if err != nil || result.Outputs["lazy"] != "ready" {
 		t.Fatalf("lazy container action result = %#v, error = %v", result, err)
+	}
+	calls := f.calls(t)
+	createIndex := jobDockerCallIndex(calls, "create")
+	if createIndex < 0 {
+		t.Fatalf("Docker create absent: %#v", calls)
+	}
+	createArgs := calls[createIndex].Args
+	if !slices.Contains(createArgs, "type=bind,source="+node24+",target=/__buildkite-gha/node24,readonly") || slices.Contains(createArgs, "type=bind,source="+node20+",target=/__buildkite-gha/node20,readonly") {
+		t.Fatalf("lazy node20 declaration mounts = %#v", createArgs)
+	}
+	seenLifecycleExec := false
+	for _, call := range calls {
+		joined := strings.Join(call.Args, "\x00")
+		if !strings.Contains(joined, ContainerProcessHelperCommand+"\x00run") || !strings.Contains(joined, "/.github/actions/lazy/") {
+			continue
+		}
+		seenLifecycleExec = true
+		if !strings.Contains(joined, "/__buildkite-gha/node24") {
+			t.Fatalf("lazy node20 declaration did not execute with Node 24: %#v", call.Args)
+		}
+	}
+	if !seenLifecycleExec {
+		t.Fatalf("lazy node20 lifecycle exec absent: %#v", calls)
 	}
 }
 

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -916,7 +916,7 @@ func (r *Runner) actionContainerMounts(ctx context.Context, actions *actionLockR
 		}
 	}
 	if unknownWorkspaceRuntime && actions.job.NeedsMise() {
-		requiredNode[20], requiredNode[24] = true, true
+		requiredNode[24] = true
 	}
 	for _, major := range []int{20, 24} {
 		if !requiredNode[major] {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1318,7 +1318,7 @@ runs:
 	}
 }
 
-func TestJavaScriptMainSeesPrePathEffects(t *testing.T) {
+func TestNode20DeclarationUsesNode24ForJavaScriptLifecycle(t *testing.T) {
 	workspace := t.TempDir()
 	workflowPath := ".github/workflows/test.yml"
 	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
@@ -1332,17 +1332,17 @@ runs:
 	writeFixtureFile(t, workspace, ".github/actions/path/pre.js", "")
 	writeFixtureFile(t, workspace, ".github/actions/path/main.js", "")
 	writeFixtureFile(t, workspace, ".github/actions/path/post.js", "")
-	fakeNode := filepath.Join(workspace, "node20")
-	writeFixtureFile(t, workspace, "node20", `#!/bin/sh
+	fakeNode := filepath.Join(workspace, "node24")
+	writeFixtureFile(t, workspace, "node24", `#!/bin/sh
 set -eu
 if [ "${1:-}" = --version ]; then
-  echo v20.0.0
+  echo v24.0.0
   exit 0
 fi
 case "${1##*/}" in
   pre.js) printf '%s\n' "$PATH_ENTRY" >> "$GITHUB_PATH" ;;
   main.js) case ":$PATH:" in *":$PATH_ENTRY:"*) ;; *) exit 9 ;; esac ;;
-  post.js) printf 'NODE20_POST=true\n' >> "$GITHUB_ENV" ;;
+  post.js) printf 'NODE24_POST=true\n' >> "$GITHUB_ENV" ;;
 esac
 `)
 	if err := os.Chmod(fakeNode, 0o700); err != nil {
@@ -1352,15 +1352,15 @@ esac
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "javascript", Kind: "uses", Uses: "./.github/actions/path"}})
 	job.Env = map[string]string{"PATH_ENTRY": pathEntry}
 
-	result, err := (Runner{Node20: fakeNode}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node24: fakeNode}).RunJob(context.Background(), job, workspace)
 	if err != nil {
 		t.Fatalf("RunJob() error = %v", err)
 	}
 	if result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v", result)
 	}
-	if result.Env["NODE20_POST"] != "true" {
-		t.Fatalf("RunJob() environment = %#v, want node20 post lifecycle effect", result.Env)
+	if result.Env["NODE24_POST"] != "true" {
+		t.Fatalf("RunJob() environment = %#v, want Node 24 post lifecycle effect", result.Env)
 	}
 }
 
@@ -3614,7 +3614,7 @@ inputs:
   message:
     required: true
 runs:
-  using: node24
+  using: node20
   main: main.js
 `)
 	writeFixtureFile(t, workspace, ".github/actions/js/main.js", "")
@@ -3765,8 +3765,12 @@ func TestRemoteActionPreHooksRunBeforeJobMainInDepthFirstOrder(t *testing.T) {
 	workflowPath := ".github/workflows/test.yml"
 	writeFixtureFile(t, workspace, workflowPath, "name: remote lifecycle ordering\n")
 	remote := t.TempDir()
-	for _, name := range []string{"first", "skipped", "second"} {
-		writeFixtureFile(t, remote, name+"/action.yml", "name: "+name+"\nruns:\n  using: node24\n  pre: pre.js\n  main: main.js\n  post: post.js\n")
+	for i, name := range []string{"first", "skipped", "second"} {
+		using := "node24"
+		if i == 0 {
+			using = "node20"
+		}
+		writeFixtureFile(t, remote, name+"/action.yml", "name: "+name+"\nruns:\n  using: "+using+"\n  pre: pre.js\n  main: main.js\n  post: post.js\n")
 		for _, phase := range []string{"pre", "main", "post"} {
 			writeFixtureFile(t, remote, name+"/"+phase+".js", "")
 		}


### PR DESCRIPTION
## Why

GitHub-hosted runners now execute actions declaring `runs.using: node20` with their bundled Node 24 runtime by default. buildkite-gha still selected its exact Node 20 runtime, creating a compatibility mismatch.

## What

Map `node20` declarations to buildkite-gha's existing digest-verified Node 24 runtime at the shared metadata classification boundary, including composite, remote lifecycle, and lazy job-container paths. Explicit `node24` declarations remain unchanged, and unresolved workspace actions no longer cause Node 20 to be mounted speculatively.

The temporary `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` escape hatch is intentionally unsupported: buildkite-gha has no server-controlled removal phase, so exposing it would make the insecure fallback indefinite rather than matching GitHub's bounded transition.
