### PR TITLE
Validate action input defaults during compilation

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -410,6 +410,51 @@ jobs:
 	})
 }
 
+func TestUploadRejectsUnsupportedEffectiveActionInputDefaultBeforeBuildkiteCalls(t *testing.T) {
+	root := t.TempDir()
+	workflowPath := filepath.Join(root, ".github", "workflows", "action.yml")
+	actionRoot := filepath.Join(root, ".github", "actions", "complex-default")
+	if err := os.MkdirAll(actionRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(workflowPath, []byte("on: push\njobs:\n  action:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: ./.github/actions/complex-default\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(actionRoot, "action.yml"), []byte(`name: complex default
+inputs:
+  token:
+    default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
+runs:
+  using: node24
+  main: main.js
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(actionRoot, "main.js"), []byte("console.log('must not run')\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_STEP_KEY", "action-default-importer")
+	runner := &cliCaptureRunner{}
+	var stdout, stderr bytes.Buffer
+	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
+	if code := run([]string{"upload", "--event-path", eventPath, workflowPath}, &stdout, &stderr, "dev", runner); code != 1 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	for _, want := range []string{`compile action "./.github/actions/complex-default"`, `action input "token" default`, "requires a direct context reference"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr = %q, want %q", stderr.String(), want)
+		}
+	}
+	if len(runner.commands) != 0 {
+		t.Fatalf("unsupported action default made Buildkite calls: %#v", runner.commands)
+	}
+}
+
 func TestValidateHostedTokenlessProfileResolvesActionsWithoutClaimingRuntime(t *testing.T) {
 	root := t.TempDir()
 	workflowPath := filepath.Join(root, ".github", "workflows", "action.yml")

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -67,6 +67,10 @@ type actionCompilation struct {
 	requiresGitHubToken bool
 }
 
+type actionRequirements struct {
+	githubToken bool
+}
+
 // compileActionLocks builds one shared action DAG for all roots. Selectors are
 // returned in the same order as refs.
 func compileActionLocks(ctx context.Context, workspace string, actionSource ActionSource, refs []string) ([]plan.ActionSelector, []plan.ActionLock, []string, bool, error) {
@@ -112,11 +116,11 @@ func compileActionInvocations(ctx context.Context, workspace string, actionSourc
 	requiresGitHubToken := false
 	if suppliedInputs != nil {
 		for i, root := range roots {
-			required, err := root.requiresGitHubToken(suppliedInputs[i])
+			requirements, err := root.inspectInvocation(suppliedInputs[i])
 			if err != nil {
 				return actionCompilation{}, fmt.Errorf("compile action %q: %w", refs[i], err)
 			}
-			requiresGitHubToken = requiresGitHubToken || required
+			requiresGitHubToken = requiresGitHubToken || requirements.githubToken
 		}
 	}
 	return actionCompilation{
@@ -198,24 +202,27 @@ func (b *actionLockBuilder) add(ctx context.Context, raw string, depth int) (*ac
 	return n, nil
 }
 
-func (n *actionNode) requiresGitHubToken(supplied map[string]string) (bool, error) {
+func (n *actionNode) inspectInvocation(supplied map[string]string) (actionRequirements, error) {
 	if n.native {
-		return false, nil
+		return actionRequirements{}, nil
 	}
-	required := false
+	var requirements actionRequirements
 	for _, name := range sortedKeys(n.metadata.Inputs) {
 		input := n.metadata.Inputs[name]
 		if input.Default == nil || hasActionInput(supplied, name) {
 			continue
 		}
+		if err := expression.ValidateRuntimeTemplate(*input.Default); err != nil {
+			return actionRequirements{}, fmt.Errorf("action input %q default: %w", name, err)
+		}
 		referencesToken, err := expression.ReferencesGitHubToken(*input.Default)
 		if err != nil {
-			return false, fmt.Errorf("action input %q default: %w", name, err)
+			return actionRequirements{}, fmt.Errorf("action input %q default: %w", name, err)
 		}
-		required = required || referencesToken
+		requirements.githubToken = requirements.githubToken || referencesToken
 	}
 	if n.runtime != metadata.RuntimeComposite {
-		return required, nil
+		return requirements, nil
 	}
 	for i, step := range n.metadata.Runs.Steps {
 		if step.Uses == "" {
@@ -223,15 +230,15 @@ func (n *actionNode) requiresGitHubToken(supplied map[string]string) (bool, erro
 		}
 		child := n.children[step.Uses]
 		if child == nil {
-			return false, fmt.Errorf("composite action step %d child %q is missing", i+1, step.Uses)
+			return actionRequirements{}, fmt.Errorf("composite action step %d child %q is missing", i+1, step.Uses)
 		}
-		childRequired, err := child.requiresGitHubToken(step.With)
+		childRequirements, err := child.inspectInvocation(step.With)
 		if err != nil {
-			return false, fmt.Errorf("composite action step %d child %q: %w", i+1, step.Uses, err)
+			return actionRequirements{}, fmt.Errorf("composite action step %d child %q: %w", i+1, step.Uses, err)
 		}
-		required = required || childRequired
+		requirements.githubToken = requirements.githubToken || childRequirements.githubToken
 	}
-	return required, nil
+	return requirements, nil
 }
 
 func hasActionInput(inputs map[string]string, name string) bool {

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -193,6 +193,14 @@ runs:
   using: node24
   main: index.js
 `)
+	writeAction(t, w, "complex", `name: complex default
+inputs:
+  token:
+    default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
+runs:
+  using: node24
+  main: index.js
+`)
 
 	for _, test := range []struct {
 		name     string
@@ -205,6 +213,8 @@ runs:
 		{name: "explicit empty input", ref: "./token", supplied: map[string]string{"github_token": ""}},
 		{name: "case-insensitive explicit input", ref: "./token", supplied: map[string]string{"GITHUB_TOKEN": "explicit"}},
 		{name: "unrelated GitHub default", ref: "./actor"},
+		{name: "unsupported complex default", ref: "./complex", wantErr: `compile action "./complex": action input "token" default: runtime interpolation requires a direct context reference`},
+		{name: "explicit input bypasses default", ref: "./complex", supplied: map[string]string{"token": ""}},
 		{name: "dynamic GitHub index", ref: "./dynamic", wantErr: "index must be a string literal"},
 		{name: "token before dynamic GitHub index", ref: "./mixed", wantErr: "index must be a string literal"},
 	} {
@@ -223,6 +233,26 @@ runs:
 				t.Fatalf("requires GitHub token = %t, want %t", compiled.requiresGitHubToken, test.want)
 			}
 		})
+	}
+}
+
+func TestCompileActionInvocationsValidatesResolvedRemoteDefaults(t *testing.T) {
+	workspace, remote := t.TempDir(), t.TempDir()
+	writeAction(t, remote, "", `name: complex remote default
+inputs:
+  token:
+    default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
+runs:
+  using: node24
+  main: index.js
+`)
+	actionSource := &fakeActionSource{root: remote, calls: map[string]int{}}
+	_, err := compileActionInvocations(context.Background(), workspace, actionSource, []string{"owner/action@v1"}, []map[string]string{nil})
+	if err == nil || !strings.Contains(err.Error(), `compile action "owner/action@v1": action input "token" default`) || !strings.Contains(err.Error(), "requires a direct context reference") {
+		t.Fatalf("compileActionInvocations() error = %v, want resolved remote default rejection", err)
+	}
+	if actionSource.calls["owner/action@v1"] != 1 {
+		t.Fatalf("remote action resolutions = %#v, want one", actionSource.calls)
 	}
 }
 

--- a/internal/expression/expression.go
+++ b/internal/expression/expression.go
@@ -83,6 +83,23 @@ const (
 	StepCondition
 )
 
+type runtimeReferenceKind uint8
+
+const (
+	runtimeReferenceUnsupported runtimeReferenceKind = iota
+	runtimeReferenceServicePort
+	runtimeReferenceGitHub
+	runtimeReferenceInput
+	runtimeReferenceMatrix
+	runtimeReferenceSecret
+	runtimeReferenceVar
+	runtimeReferenceEnv
+	runtimeReferenceStepOutput
+	runtimeReferenceStepStatus
+	runtimeReferenceNeedOutput
+	runtimeReferenceNeedResult
+)
+
 // CompileContext contains the non-secret values available while constructing
 // a workflow graph. Values are snapshots supplied by the compiler; evaluation
 // never reads the process environment or a secret provider.
@@ -127,6 +144,22 @@ func ReferencePath(text string) (string, []string, error) {
 		return "", nil, fmt.Errorf("invalid expression: %w", parseErr)
 	}
 	return referencePath(node)
+}
+
+// ValidateRuntimeTemplate verifies that every expression in a runtime template
+// has a reference shape supported by Evaluate. Runtime values are deliberately
+// not resolved because many contexts do not exist until a job or step runs.
+func ValidateRuntimeTemplate(template string) error {
+	return visitTemplateExpressions(template, func(node actionlint.ExprNode) error {
+		root, path, err := referencePath(node)
+		if err != nil {
+			return fmt.Errorf("runtime interpolation requires a direct context reference: %w", err)
+		}
+		if classifyRuntimeReference(root, path) == runtimeReferenceUnsupported {
+			return fmt.Errorf("unsupported runtime expression %q", referenceName(root, path))
+		}
+		return nil
+	})
 }
 
 // EvaluateCompile evaluates one complete graph-time expression. The supported
@@ -972,37 +1005,37 @@ func evaluateReference(reference string, context Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	switch {
-	case len(path) == 4 && strings.EqualFold(root, "job") && strings.EqualFold(path[0], "services") && strings.EqualFold(path[2], "ports"):
+	switch classifyRuntimeReference(root, path) {
+	case runtimeReferenceServicePort:
 		return resolveServicePort(context.Services, path[1], path[3], "expression")
-	case len(path) >= 1 && strings.EqualFold(root, "github"):
+	case runtimeReferenceGitHub:
 		value, ok := lookupRuntimeValue(context.GitHub, path)
 		if !ok {
 			return "", fmt.Errorf("expression references unavailable github value %q", strings.Join(path, "."))
 		}
 		return fmt.Sprint(value), nil
-	case len(path) == 1 && strings.EqualFold(root, "inputs"):
+	case runtimeReferenceInput:
 		return findString(context.Inputs, path[0]), nil
-	case len(path) == 1 && strings.EqualFold(root, "matrix"):
+	case runtimeReferenceMatrix:
 		for name, value := range context.Matrix {
 			if strings.EqualFold(name, path[0]) {
 				return fmt.Sprint(value), nil
 			}
 		}
 		return "", fmt.Errorf("expression references unavailable matrix value %q", path[0])
-	case len(path) == 1 && strings.EqualFold(root, "secrets"):
+	case runtimeReferenceSecret:
 		return findString(context.Secrets, path[0]), nil
-	case len(path) == 1 && strings.EqualFold(root, "vars"):
+	case runtimeReferenceVar:
 		return findString(context.Vars, path[0]), nil
-	case len(path) == 1 && strings.EqualFold(root, "env"):
+	case runtimeReferenceEnv:
 		return findString(context.Env, path[0]), nil
-	case len(path) == 3 && strings.EqualFold(root, "steps") && strings.EqualFold(path[1], "outputs"):
+	case runtimeReferenceStepOutput:
 		outputs, ok := findOutputs(context.Steps, path[0])
 		if !ok {
 			return "", fmt.Errorf("expression references unavailable step %q", path[0])
 		}
 		return findString(outputs, path[2]), nil
-	case len(path) == 2 && strings.EqualFold(root, "steps"):
+	case runtimeReferenceStepStatus:
 		for candidate, status := range context.StepStatuses {
 			if !strings.EqualFold(candidate, path[0]) {
 				continue
@@ -1015,13 +1048,13 @@ func evaluateReference(reference string, context Context) (string, error) {
 			}
 		}
 		return "", fmt.Errorf("expression references unavailable step %q", path[0])
-	case len(path) == 3 && strings.EqualFold(root, "needs") && strings.EqualFold(path[1], "outputs"):
+	case runtimeReferenceNeedOutput:
 		outputs, ok := findOutputs(context.Needs, path[0])
 		if !ok {
 			return "", fmt.Errorf("expression references unavailable need %q", path[0])
 		}
 		return findString(outputs, path[2]), nil
-	case len(path) == 2 && strings.EqualFold(root, "needs") && strings.EqualFold(path[1], "result"):
+	case runtimeReferenceNeedResult:
 		for candidate, result := range context.NeedResults {
 			if strings.EqualFold(candidate, path[0]) {
 				return result, nil
@@ -1031,6 +1064,42 @@ func evaluateReference(reference string, context Context) (string, error) {
 	default:
 		return "", fmt.Errorf("unsupported expression %q", reference)
 	}
+}
+
+func classifyRuntimeReference(root string, path []string) runtimeReferenceKind {
+	switch {
+	case len(path) == 4 && strings.EqualFold(root, "job") && strings.EqualFold(path[0], "services") && strings.EqualFold(path[2], "ports"):
+		return runtimeReferenceServicePort
+	case len(path) >= 1 && strings.EqualFold(root, "github"):
+		return runtimeReferenceGitHub
+	case len(path) == 1 && strings.EqualFold(root, "inputs"):
+		return runtimeReferenceInput
+	case len(path) == 1 && strings.EqualFold(root, "matrix"):
+		return runtimeReferenceMatrix
+	case len(path) == 1 && strings.EqualFold(root, "secrets"):
+		return runtimeReferenceSecret
+	case len(path) == 1 && strings.EqualFold(root, "vars"):
+		return runtimeReferenceVar
+	case len(path) == 1 && strings.EqualFold(root, "env"):
+		return runtimeReferenceEnv
+	case len(path) == 3 && strings.EqualFold(root, "steps") && strings.EqualFold(path[1], "outputs"):
+		return runtimeReferenceStepOutput
+	case len(path) == 2 && strings.EqualFold(root, "steps") && (strings.EqualFold(path[1], "outcome") || strings.EqualFold(path[1], "conclusion")):
+		return runtimeReferenceStepStatus
+	case len(path) == 3 && strings.EqualFold(root, "needs") && strings.EqualFold(path[1], "outputs"):
+		return runtimeReferenceNeedOutput
+	case len(path) == 2 && strings.EqualFold(root, "needs") && strings.EqualFold(path[1], "result"):
+		return runtimeReferenceNeedResult
+	default:
+		return runtimeReferenceUnsupported
+	}
+}
+
+func referenceName(root string, path []string) string {
+	if len(path) == 0 {
+		return root
+	}
+	return root + "." + strings.Join(path, ".")
 }
 
 func lookupRuntimeValue(value any, path []string) (any, bool) {

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -52,6 +52,50 @@ func TestReferencePathOwnsOnlyOneStaticReference(t *testing.T) {
 	}
 }
 
+func TestValidateRuntimeTemplateMatchesEvaluateReferenceGrammar(t *testing.T) {
+	for _, template := range []string{
+		"literal",
+		"${{ github.actor }}",
+		"${{ inputs.target }}",
+		"${{ matrix.version }}",
+		"${{ secrets.TOKEN }}",
+		"${{ vars.RELEASE }}",
+		"${{ env.PATH }}",
+		"${{ steps.build.outputs.release }}",
+		"${{ steps.build.outcome }}",
+		"${{ steps.build.conclusion }}",
+		"${{ needs.build.outputs.release }}",
+		"${{ needs.build.result }}",
+		"${{ job.services.redis.ports[6379] }}",
+		"prefix-${{ github.actor }}-${{ matrix.version }}",
+	} {
+		t.Run(template, func(t *testing.T) {
+			if err := ValidateRuntimeTemplate(template); err != nil {
+				t.Fatalf("ValidateRuntimeTemplate(%q) error = %v", template, err)
+			}
+		})
+	}
+
+	for _, test := range []struct {
+		template string
+		want     string
+	}{
+		{template: "${{ github.server_url == 'https://github.com' && github.token || '' }}", want: "requires a direct context reference"},
+		{template: "${{ hashFiles('go.sum') }}", want: "requires a direct context reference"},
+		{template: "${{ github }}", want: `unsupported runtime expression "github"`},
+		{template: "${{ steps.build.status }}", want: `unsupported runtime expression "steps.build.status"`},
+		{template: "${{ github[env.NAME] }}", want: "index must be a string literal"},
+		{template: "${{ true || }}", want: "invalid expression"},
+	} {
+		t.Run(test.template, func(t *testing.T) {
+			err := ValidateRuntimeTemplate(test.template)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("ValidateRuntimeTemplate(%q) error = %v, want %q", test.template, err, test.want)
+			}
+		})
+	}
+}
+
 func TestEvaluateIsSinglePass(t *testing.T) {
 	literal := "literal ${{ matrix.secret }} and ${{"
 	context := Context{


### PR DESCRIPTION
## Why

Resolved actions can currently pass compilation even when an effective input default uses expression syntax that the runtime cannot evaluate. This defers a compatibility failure until `run-job`, after the pipeline has been uploaded, and surfaces a confusing step-level error.

## What

Validate effective action input defaults during compilation and reject unsupported runtime interpolation before plans or pipeline YAML are emitted. Explicitly supplied inputs continue to bypass unused defaults.

## How

- Add a non-evaluating runtime-template validator backed by the same reference classifier used by runtime evaluation.
- Inspect resolved local, remote, and nested composite action invocations while building action requirements.
- Fail upload before any Buildkite calls when an effective default is unsupported.
- Add expression, compiler, remote-action, override, and CLI regression coverage.