### PR TITLE
Use webhook metadata for upload event payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,20 @@ artifacts, retries, and cancellation behavior.
 
 The [support matrix](docs/compatibility.md#support-matrix) is the authoritative
 list of supported, partially supported, not-admitted, and unsupported GitHub
-Actions behavior. As a quick screen, the plugin path is a good fit for
-workflows built from:
+Actions behavior.
+
+During `upload`, an explicit `--event-path` has highest precedence. Otherwise
+the CLI reads Buildkite's reserved `buildkite:webhook` metadata once for the
+compile-time `github.event` object, falling back to a reduced-fidelity
+`BUILDKITE_*` snapshot only when Buildkite reports no available webhook
+association. Buildkite environment values always define the exact top-level
+repository, SHA, and ref being executed. Every source remains untrusted; raw
+webhook data cannot grant protected capabilities and is not retained in plans
+or pipeline YAML. Stored webhook data has no delivery headers, and GitHub push
+payloads may omit `commits`. See [Event snapshots](docs/compatibility.md#event-snapshots)
+for limits and failure behavior.
+
+As a quick screen, the plugin path is a good fit for workflows built from:
 
 - Linux Bash and `sh` steps;
 - JavaScript, composite, local, and anonymous public actions;

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -564,12 +564,36 @@ When invoking the v0.4.2 release directly, add `--runtime-queue hosted`; that
 release requires the argument and uses it to
 select the `hosted` queue.
 
-It requires `BUILDKITE=true` and `BUILDKITE_STEP_KEY`. Without `--event-path`,
-it derives a bounded compatibility snapshot from the current Buildkite build.
-With `--event-path`, it uses that explicit snapshot. Both paths remain
-unattested. Apart from the documented scoped workflow-token contract and
-Buildkite's native, job-bound repository-provider credentials for verified
-checkout, they remain free of provider credentials.
+It requires `BUILDKITE=true` and `BUILDKITE_STEP_KEY`. Event source precedence
+is:
+
+1. An explicit `--event-path`. This never reads Buildkite metadata.
+2. Buildkite's reserved `buildkite:webhook` metadata for webhook-linked builds.
+3. A reduced-fidelity snapshot derived from `BUILDKITE_*` variables when
+   Buildkite reports that the build is not webhook-triggered or its linked
+   webhook is unavailable.
+
+The webhook metadata is fetched once and must be one valid JSON object no larger
+than 25 MiB. Malformed, duplicate-key, non-object, oversized, transport,
+authorization, and rate-limit failures stop upload; they do not silently select
+the fallback. `BUILDKITE_GITHUB_EVENT`, when valid, supplies `github.event_name`,
+and a valid webhook `sender.login` improves `github.actor` compatibility.
+Buildkite's validated repository mapping and exact `BUILDKITE_COMMIT` and
+branch/tag/PR ref always supply top-level `github.repository`, `github.sha`, and
+`github.ref`. These values intentionally need not equal trigger payload fields:
+pull requests and rebuilds can legitimately execute different identities.
+
+All three paths remain untrusted compatibility data. Webhook fields cannot
+authorize queues, secrets, tokens, or protected capabilities. Generated plans
+and pipeline YAML retain only the existing payload digest and values deliberately
+selected by compile-time expressions, never the raw payload object. The metadata
+is Buildkite's stored parsed webhook document rather than the original HTTP
+delivery: delivery headers are unavailable, and GitHub push payloads may omit
+`commits`.
+
+Apart from the documented scoped workflow-token contract and Buildkite's native,
+job-bound repository-provider credentials for verified checkout, upload remains
+free of provider credentials.
 
 The command uploads the exact executable and content-addressed plans before
 calling `buildkite-agent pipeline upload --no-interpolation --reject-secrets`.

--- a/internal/cli/buildkite_event.go
+++ b/internal/cli/buildkite_event.go
@@ -1,13 +1,20 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 )
+
+var githubEventNamePattern = regexp.MustCompile(`^[a-z][a-z0-9_]{0,99}$`)
 
 // buildkiteEventSource creates compatibility data only. Buildkite environment
 // variables can be changed by hooks and this snapshot is not an attestation.
@@ -103,6 +110,125 @@ func buildkiteEventSource(getenv func(string) string) ([]byte, error) {
 		return nil, fmt.Errorf("encode Buildkite compatibility snapshot: %w", err)
 	}
 	return result, nil
+}
+
+// buildkiteWebhookEventSource overlays untrusted trigger data onto the
+// execution identity derived and validated by buildkiteEventSource.
+func buildkiteWebhookEventSource(getenv func(string) string, webhook []byte) ([]byte, error) {
+	base, err := buildkiteEventSource(getenv)
+	if err != nil {
+		return nil, err
+	}
+	payload, err := parseWebhookPayload(webhook)
+	if err != nil {
+		return nil, err
+	}
+	var snapshot map[string]any
+	decoder := json.NewDecoder(bytes.NewReader(base))
+	decoder.UseNumber()
+	if err := decoder.Decode(&snapshot); err != nil {
+		return nil, fmt.Errorf("decode Buildkite compatibility snapshot: %w", err)
+	}
+	snapshot["payload"] = payload
+	if event := strings.TrimSpace(getenv("BUILDKITE_GITHUB_EVENT")); githubEventNamePattern.MatchString(event) {
+		snapshot["event"] = event
+	}
+	if sender, ok := payload["sender"].(map[string]any); ok {
+		if login, ok := sender["login"].(string); ok && safeGitHubLogin(login) {
+			snapshot["actor"] = login
+		}
+	}
+	result, err := json.Marshal(snapshot)
+	if err != nil {
+		return nil, fmt.Errorf("encode Buildkite webhook snapshot: %w", err)
+	}
+	return result, nil
+}
+
+func parseWebhookPayload(source []byte) (map[string]any, error) {
+	if len(bytes.TrimSpace(source)) == 0 || !utf8.Valid(source) {
+		return nil, fmt.Errorf("buildkite:webhook must contain one valid UTF-8 JSON object")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(source))
+	decoder.UseNumber()
+	value, err := decodeWebhookValue(decoder)
+	if err != nil {
+		return nil, fmt.Errorf("parse buildkite:webhook: %w", err)
+	}
+	if _, err := decoder.Token(); err != io.EOF {
+		if err == nil {
+			return nil, fmt.Errorf("parse buildkite:webhook: multiple JSON values")
+		}
+		return nil, fmt.Errorf("parse buildkite:webhook: %w", err)
+	}
+	payload, ok := value.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("buildkite:webhook must be a JSON object")
+	}
+	return payload, nil
+}
+
+func decodeWebhookValue(decoder *json.Decoder) (any, error) {
+	token, err := decoder.Token()
+	if err != nil {
+		return nil, err
+	}
+	delimiter, ok := token.(json.Delim)
+	if !ok {
+		return token, nil
+	}
+	switch delimiter {
+	case '{':
+		object := map[string]any{}
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return nil, err
+			}
+			key, ok := keyToken.(string)
+			if !ok {
+				return nil, fmt.Errorf("object key is not a string")
+			}
+			if _, exists := object[key]; exists {
+				return nil, fmt.Errorf("conflicting duplicate object key %q", key)
+			}
+			object[key], err = decodeWebhookValue(decoder)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if _, err := decoder.Token(); err != nil {
+			return nil, err
+		}
+		return object, nil
+	case '[':
+		var array []any
+		for decoder.More() {
+			value, err := decodeWebhookValue(decoder)
+			if err != nil {
+				return nil, err
+			}
+			array = append(array, value)
+		}
+		if _, err := decoder.Token(); err != nil {
+			return nil, err
+		}
+		return array, nil
+	default:
+		return nil, fmt.Errorf("unexpected JSON delimiter %q", delimiter)
+	}
+}
+
+func safeGitHubLogin(login string) bool {
+	if strings.TrimSpace(login) != login || login == "" || len(login) > 255 {
+		return false
+	}
+	for _, r := range login {
+		if unicode.IsControl(r) {
+			return false
+		}
+	}
+	return true
 }
 
 func parsePublicGitHubRepository(raw string) (owner, name, cloneURL string, err error) {

--- a/internal/cli/buildkite_event.go
+++ b/internal/cli/buildkite_event.go
@@ -202,7 +202,7 @@ func decodeWebhookValue(decoder *json.Decoder) (any, error) {
 		}
 		return object, nil
 	case '[':
-		var array []any
+		array := []any{}
 		for decoder.More() {
 			value, err := decodeWebhookValue(decoder)
 			if err != nil {

--- a/internal/cli/buildkite_event_test.go
+++ b/internal/cli/buildkite_event_test.go
@@ -108,3 +108,68 @@ func TestBuildkiteEventSourceFailsClosed(t *testing.T) {
 		t.Fatalf("error = %v", err)
 	}
 }
+
+func TestBuildkiteWebhookEventSourceUsesPayloadButPreservesExecutionIdentity(t *testing.T) {
+	env := map[string]string{
+		"BUILDKITE": "true", "BUILDKITE_STEP_KEY": "step",
+		"BUILDKITE_REPO":         "https://github.com/buildkite/buildkite-gha",
+		"BUILDKITE_COMMIT":       strings.Repeat("a", 40),
+		"BUILDKITE_BRANCH":       "executed-branch",
+		"BUILDKITE_BUILD_AUTHOR": "Build Author",
+		"BUILDKITE_GITHUB_EVENT": "pull_request_target",
+	}
+	webhook := []byte("{\"ref\":\"refs/heads/trigger-branch\",\"after\":\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"repository\":{\"full_name\":\"other/trigger\"},\"sender\":{\"login\":\"octocat\"},\"nested\":{\"complete\":true}}")
+	source, err := buildkiteWebhookEventSource(func(key string) string { return env[key] }, webhook)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var snapshot map[string]any
+	if err := json.Unmarshal(source, &snapshot); err != nil {
+		t.Fatal(err)
+	}
+	payload := snapshot["payload"].(map[string]any)
+	repository := snapshot["repository"].(map[string]any)
+	if snapshot["event"] != "pull_request_target" || snapshot["actor"] != "octocat" ||
+		snapshot["sha"] != strings.Repeat("a", 40) || snapshot["ref"] != "refs/heads/executed-branch" ||
+		repository["owner"] != "buildkite" || repository["name"] != "buildkite-gha" ||
+		payload["after"] != strings.Repeat("b", 40) || payload["nested"].(map[string]any)["complete"] != true {
+		t.Fatalf("webhook snapshot = %#v", snapshot)
+	}
+}
+
+func TestBuildkiteWebhookEventSourceEventAndActorFallbacks(t *testing.T) {
+	env := map[string]string{
+		"BUILDKITE": "true", "BUILDKITE_STEP_KEY": "step",
+		"BUILDKITE_REPO": "https://github.com/a/b", "BUILDKITE_COMMIT": strings.Repeat("a", 40),
+		"BUILDKITE_BRANCH": "main", "BUILDKITE_BUILD_AUTHOR": "Build Author",
+		"BUILDKITE_GITHUB_EVENT": "not valid",
+	}
+	source, err := buildkiteWebhookEventSource(func(key string) string { return env[key] }, []byte("{\"sender\":{\"login\":\" bad \"}}"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var snapshot map[string]any
+	if err := json.Unmarshal(source, &snapshot); err != nil {
+		t.Fatal(err)
+	}
+	if snapshot["event"] != "push" || snapshot["actor"] != "Build Author" {
+		t.Fatalf("fallback snapshot = %#v", snapshot)
+	}
+}
+
+func TestParseWebhookPayloadRejectsInvalidDocuments(t *testing.T) {
+	for _, test := range []struct {
+		name, source, want string
+	}{
+		{name: "malformed", source: "{\"sender\":", want: "parse buildkite:webhook"},
+		{name: "non-object", source: `[1,2]`, want: "must be a JSON object"},
+		{name: "multiple", source: `{} {}`, want: "multiple JSON values"},
+		{name: "conflicting duplicate", source: "{\"ref\":\"one\",\"ref\":\"two\"}", want: "conflicting duplicate object key"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := parseWebhookPayload([]byte(test.source)); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("parseWebhookPayload() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}

--- a/internal/cli/buildkite_event_test.go
+++ b/internal/cli/buildkite_event_test.go
@@ -173,3 +173,17 @@ func TestParseWebhookPayloadRejectsInvalidDocuments(t *testing.T) {
 		})
 	}
 }
+
+func TestParseWebhookPayloadPreservesEmptyArrays(t *testing.T) {
+	payload, err := parseWebhookPayload([]byte("{\"commits\":[],\"nested\":{\"requested_reviewers\":[]}}"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(encoded) != "{\"commits\":[],\"nested\":{\"requested_reviewers\":[]}}" {
+		t.Fatalf("encoded payload = %s", encoded)
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -3,6 +3,7 @@ package cli
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
 	"context"
 	"crypto/sha256"
@@ -61,7 +62,7 @@ func writeCommandHelp(stdout io.Writer, command string) {
 	case "compile":
 		_, _ = fmt.Fprint(stdout, "\nPipeline output references content-addressed plans; compile does not materialize or upload those artifacts.\n")
 	case "upload":
-		_, _ = fmt.Fprintf(stdout, "\nGenerated jobs use Buildkite's default agent targeting. An importer can explicitly target one queue with %s; that queue must be suitable for untrusted workflow code. The deprecated --runtime-queue hosted option is accepted for plugin compatibility but does not select a queue. The default path accepts an explicit event file or derives compatibility data from Buildkite and remains unsigned. Verified checkout jobs automatically use Buildkite repository-provider Git credentials when the job enables them; the deprecated --private-checkout option is accepted as a no-op.\n", targetQueueEnvironment)
+		_, _ = fmt.Fprintf(stdout, "\nGenerated jobs use Buildkite's default agent targeting. An importer can explicitly target one queue with %s; that queue must be suitable for untrusted workflow code. The deprecated --runtime-queue hosted option is accepted for plugin compatibility but does not select a queue. Event precedence is an explicit event file, Buildkite's reserved webhook metadata, then reduced-fidelity Buildkite environment compatibility data; every source remains unsigned. Verified checkout jobs automatically use Buildkite repository-provider Git credentials when the job enables them; the deprecated --private-checkout option is accepted as a no-op.\n", targetQueueEnvironment)
 	}
 }
 
@@ -76,6 +77,7 @@ const (
 	runtimeMiseBinaryDigest                     = "a238972a3162d710b85b28c324372e96ca4e4b486c81fe78695000d9fbc77c48"
 	runtimeMiseArchiveLimit                     = 64 << 20
 	runtimeMiseBinaryLimit                      = 128 << 20
+	maxWebhookMetadataBytes                     = 25 << 20
 )
 
 func repositoryProviderGitCredentialsEnabled(getenv func(string) string) bool {
@@ -1089,11 +1091,26 @@ func upload(args []string, stdout, stderr io.Writer, version string, agent trans
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
 		return 1
 	}
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 	var eventSource []byte
 	if eventPath != "" {
 		eventSource, err = os.ReadFile(eventPath)
 	} else {
-		eventSource, err = buildkiteEventSource(os.Getenv)
+		webhook, metadataErr := agent.GetMetadataBounded(ctx, "buildkite:webhook", maxWebhookMetadataBytes+1)
+		switch {
+		case metadataErr == nil:
+			webhook = bytes.TrimSuffix(webhook, []byte("\n"))
+			if len(webhook) > maxWebhookMetadataBytes {
+				err = fmt.Errorf("buildkite:webhook exceeds %d bytes", maxWebhookMetadataBytes)
+			} else {
+				eventSource, err = buildkiteWebhookEventSource(os.Getenv, webhook)
+			}
+		case errors.Is(metadataErr, transport.ErrMetadataUnavailable):
+			eventSource, err = buildkiteEventSource(os.Getenv)
+		default:
+			err = metadataErr
+		}
 	}
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
@@ -1104,8 +1121,6 @@ func upload(args []string, stdout, stderr io.Writer, version string, agent trans
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
 		return 1
 	}
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
 	preflight, err := compileHostedTokenless(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, os.Getenv("BUILDKITE_GROUP_LABEL"), targetQueue)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -483,7 +483,7 @@ func TestRunUploadCompilesArtifactsAndUploadsSelfContainedPipeline(t *testing.T)
 	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
 	t.Setenv("BUILDKITE", "true")
 	t.Setenv("BUILDKITE_STEP_KEY", "phase-2-importer")
-	runner := &cliCaptureRunner{}
+	runner := &cliCaptureRunner{webhookErr: errors.New("metadata must not be read with --event-path")}
 	var stdout, stderr bytes.Buffer
 	if code := run([]string{"upload", "--event-path", eventPath, workflowPath}, &stdout, &stderr, "dev", runner); code != 0 {
 		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
@@ -680,6 +680,98 @@ func TestRunUploadDerivesUnattestedBuildkiteEvent(t *testing.T) {
 	}
 	if planCount != 3 {
 		t.Fatalf("derived-event plan count = %d, want 3", planCount)
+	}
+	if len(runner.commands) == 0 || !slices.Equal(runner.commands[0].args, []string{"meta-data", "get", "buildkite:webhook"}) {
+		t.Fatalf("first command = %#v, want one webhook metadata read", runner.commands)
+	}
+	for _, command := range runner.commands[1:] {
+		if slices.Equal(command.args, []string{"meta-data", "get", "buildkite:webhook"}) {
+			t.Fatalf("webhook metadata read more than once: %#v", runner.commands)
+		}
+	}
+}
+
+func TestRunUploadUsesWebhookPayloadWithoutRetainingIt(t *testing.T) {
+	workflowPath := filepath.Join(t.TempDir(), "webhook.yml")
+	if err := os.WriteFile(workflowPath, []byte("on: pull_request\njobs:\n  test:\n    runs-on: ubuntu-${{ github.event.marker }}\n    steps:\n      - run: echo selected\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sha := strings.Repeat("a", 40)
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_STEP_KEY", "webhook-importer")
+	t.Setenv("BUILDKITE_REPO", "https://github.com/buildkite/buildkite-gha")
+	t.Setenv("BUILDKITE_COMMIT", sha)
+	t.Setenv("BUILDKITE_BRANCH", "executed")
+	t.Setenv("BUILDKITE_PULL_REQUEST", "false")
+	t.Setenv("BUILDKITE_BUILD_AUTHOR", "Build Author")
+	t.Setenv("BUILDKITE_GITHUB_EVENT", "pull_request")
+	rawSecret := "raw-webhook-value-must-not-be-retained"
+	runner := &cliCaptureRunner{webhook: []byte(fmt.Sprintf("{\"marker\":\"latest\",\"private\":\"%s\",\"ref\":\"refs/heads/trigger\",\"after\":\"%s\",\"repository\":{\"full_name\":\"other/trigger\"},\"sender\":{\"login\":\"octocat\"}}", rawSecret, strings.Repeat("b", 40)))}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"upload", workflowPath}, &stdout, &stderr, "dev", runner); code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	if len(runner.commands) == 0 || !slices.Equal(runner.commands[0].args, []string{"meta-data", "get", "buildkite:webhook"}) {
+		t.Fatalf("commands = %#v, want metadata read first", runner.commands)
+	}
+	metadataReads, planCount := 0, 0
+	for _, command := range runner.commands {
+		if slices.Equal(command.args, []string{"meta-data", "get", "buildkite:webhook"}) {
+			metadataReads++
+		}
+		if bytes.Contains(command.stdin, []byte(rawSecret)) {
+			t.Fatalf("command retained raw webhook payload: %#v", command.args)
+		}
+	}
+	for path, contents := range runner.uploaded {
+		if !strings.HasSuffix(path, ".json") {
+			continue
+		}
+		if bytes.Contains(contents, []byte(rawSecret)) {
+			t.Fatalf("plan %q retained raw webhook payload", path)
+		}
+		job, err := plan.Decode(contents)
+		if err != nil {
+			t.Fatal(err)
+		}
+		planCount++
+		if job.Event.Name != "pull_request" || job.Event.Repository != "buildkite/buildkite-gha" || job.Event.Ref != "refs/heads/executed" || job.Event.SHA != sha || job.Event.Actor != "octocat" {
+			t.Fatalf("webhook plan = %#v", job)
+		}
+	}
+	if metadataReads != 1 || planCount != 1 {
+		t.Fatalf("metadata reads = %d, plans = %d", metadataReads, planCount)
+	}
+}
+
+func TestRunUploadRejectsInvalidWebhookMetadata(t *testing.T) {
+	workflowPath := filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "shell.yml")
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_STEP_KEY", "webhook-importer")
+	t.Setenv("BUILDKITE_REPO", "https://github.com/buildkite/buildkite-gha")
+	t.Setenv("BUILDKITE_COMMIT", strings.Repeat("a", 40))
+	t.Setenv("BUILDKITE_BRANCH", "main")
+	for _, test := range []struct {
+		name    string
+		webhook []byte
+		err     error
+		want    string
+	}{
+		{name: "malformed", webhook: []byte("{\"incomplete\":"), want: "parse buildkite:webhook"},
+		{name: "non-object", webhook: []byte(`[1]`), want: "must be a JSON object"},
+		{name: "oversized", webhook: bytes.Repeat([]byte("x"), maxWebhookMetadataBytes+1), want: "exceeds"},
+		{name: "operational failure", err: errors.New("agent authorization failed"), want: "agent authorization failed"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			runner := &cliCaptureRunner{webhook: test.webhook, webhookErr: test.err}
+			var stdout, stderr bytes.Buffer
+			if code := run([]string{"upload", workflowPath}, &stdout, &stderr, "dev", runner); code != 1 || !strings.Contains(stderr.String(), test.want) {
+				t.Fatalf("run() code = %d, stderr = %q, want %q", code, stderr.String(), test.want)
+			}
+			if len(runner.commands) != 1 || !slices.Equal(runner.commands[0].args, []string{"meta-data", "get", "buildkite:webhook"}) {
+				t.Fatalf("commands = %#v, want only one metadata read", runner.commands)
+			}
+		})
 	}
 }
 
@@ -1549,6 +1641,8 @@ type cliCaptureRunner struct {
 	failAt         int
 	failMetadata   bool
 	failAnnotation bool
+	webhook        []byte
+	webhookErr     error
 	jobByStep      map[string]string
 	dataByPath     map[string][]byte
 	uploaded       map[string][]byte
@@ -1560,6 +1654,15 @@ func (r *cliCaptureRunner) Run(ctx context.Context, dir, name string, args []str
 	r.contextErrors = append(r.contextErrors, ctx.Err())
 	if r.failAt != 0 && len(r.commands) == r.failAt {
 		return nil, errors.New("injected failure")
+	}
+	if slices.Equal(args, []string{"meta-data", "get", "buildkite:webhook"}) {
+		if r.webhookErr != nil {
+			return nil, r.webhookErr
+		}
+		if r.webhook == nil {
+			return nil, transport.ErrMetadataUnavailable
+		}
+		return bytes.Clone(r.webhook), nil
 	}
 	if len(args) >= 2 && args[0] == "artifact" && args[1] == "search" {
 		return []byte(r.jobByStep[args[4]] + "\n"), nil

--- a/internal/transport/boundary.go
+++ b/internal/transport/boundary.go
@@ -3,6 +3,7 @@ package transport
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -10,13 +11,19 @@ import (
 	"path/filepath"
 	"slices"
 	"sort"
+	"strings"
 	"unicode/utf8"
 )
 
 const (
 	maxAnnotationBodyBytes         = 1024 * 1024
 	maxAnnotationContextCharacters = 100
+	maxAgentErrorBytes             = 64 * 1024
 )
+
+// ErrMetadataUnavailable means Buildkite confirmed that reserved webhook
+// metadata does not apply to the build or its linked webhook is unavailable.
+var ErrMetadataUnavailable = errors.New("buildkite webhook metadata is unavailable")
 
 // Runner is the only process boundary used by the Buildkite adapter.
 type Runner interface {
@@ -44,6 +51,50 @@ func (r CommandRunner) Run(ctx context.Context, dir, name string, args []string,
 		return stdout.Bytes(), err
 	}
 	return stdout.Bytes(), nil
+}
+
+// RunBounded executes a command while bounding captured stdout and stderr.
+func (r CommandRunner) RunBounded(ctx context.Context, dir, name string, args []string, stdin []byte, limit int) ([]byte, []byte, error) {
+	command := exec.CommandContext(ctx, name, args...)
+	command.Dir = dir
+	command.Stdin = bytes.NewReader(stdin)
+	stdout := newBoundedBuffer(limit)
+	stderr := newBoundedBuffer(maxAgentErrorBytes)
+	command.Stdout = stdout
+	command.Stderr = stderr
+	err := command.Run()
+	if stdout.overflow {
+		return nil, stderr.Bytes(), fmt.Errorf("command output exceeds %d bytes", limit)
+	}
+	if stderr.overflow {
+		return stdout.Bytes(), nil, fmt.Errorf("command error output exceeds %d bytes", maxAgentErrorBytes)
+	}
+	return stdout.Bytes(), stderr.Bytes(), err
+}
+
+type boundedBuffer struct {
+	buffer    bytes.Buffer
+	remaining int
+	overflow  bool
+}
+
+func newBoundedBuffer(limit int) *boundedBuffer {
+	return &boundedBuffer{remaining: limit}
+}
+
+func (b *boundedBuffer) Write(p []byte) (int, error) {
+	if len(p) > b.remaining {
+		_, _ = b.buffer.Write(p[:b.remaining])
+		b.remaining = 0
+		b.overflow = true
+		return len(p), nil
+	}
+	b.remaining -= len(p)
+	return b.buffer.Write(p)
+}
+
+func (b *boundedBuffer) Bytes() []byte {
+	return b.buffer.Bytes()
 }
 
 func (a Agent) UploadArtifact(ctx context.Context, path string) error {
@@ -80,6 +131,44 @@ func (a Agent) SetMetadata(ctx context.Context, key, value string) error {
 
 func (a Agent) GetMetadata(ctx context.Context, key string) ([]byte, error) {
 	return a.run(ctx, []string{"meta-data", "get", key}, nil)
+}
+
+// GetMetadataBounded retrieves metadata once without allowing agent stdout to
+// grow beyond limit. CommandRunner also captures bounded stderr so the two
+// documented reserved-webhook absence responses can be distinguished from
+// authorization, transport, and rate-limit failures.
+func (a Agent) GetMetadataBounded(ctx context.Context, key string, limit int) ([]byte, error) {
+	if limit < 1 {
+		return nil, fmt.Errorf("metadata output limit must be positive")
+	}
+	runner, ok := a.Runner.(interface {
+		RunBounded(context.Context, string, string, []string, []byte, int) ([]byte, []byte, error)
+	})
+	if !ok {
+		result, err := a.GetMetadata(ctx, key)
+		if err != nil {
+			return nil, err
+		}
+		if len(result) > limit {
+			return nil, fmt.Errorf("command output exceeds %d bytes", limit)
+		}
+		return result, nil
+	}
+	stdout, stderr, err := runner.RunBounded(ctx, "", "buildkite-agent", []string{"meta-data", "get", key}, nil, limit)
+	if err == nil {
+		return stdout, nil
+	}
+	message := strings.TrimSpace(string(stderr))
+	var exitError *exec.ExitError
+	if key == "buildkite:webhook" && len(stdout) == 0 && errors.As(err, &exitError) && exitError.ExitCode() == 1 &&
+		(strings.Contains(message, "400 Bad Request: Build was not triggered by a webhook") ||
+			strings.Contains(message, "404 Not Found: Build webhook is not available")) {
+		return nil, ErrMetadataUnavailable
+	}
+	if message != "" {
+		return nil, fmt.Errorf("get Buildkite metadata %q: %v: %s", key, err, message)
+	}
+	return nil, fmt.Errorf("get Buildkite metadata %q: %w", key, err)
 }
 
 func (a Agent) UploadPipeline(ctx context.Context, pipeline []byte) error {

--- a/internal/transport/model_test.go
+++ b/internal/transport/model_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -474,6 +475,44 @@ func TestUploadRejectsTamperedMaterializedBindingBeforeAgentReadsIt(t *testing.T
 	err = Upload(context.Background(), Agent{Runner: runner}, root, []PlanArtifact{producer, consumer}, pipeline, expected, completed)
 	if err == nil || !strings.Contains(err.Error(), "on-disk bytes differ") || len(runner.commands) != 1 {
 		t.Fatalf("Upload() error = %v, commands = %d", err, len(runner.commands))
+	}
+}
+
+func TestCommandRunnerBoundsOutputWhileReading(t *testing.T) {
+	stdout, _, err := (CommandRunner{}).RunBounded(context.Background(), "", "sh", []string{"-c", "printf 123456789"}, nil, 8)
+	if err == nil || !strings.Contains(err.Error(), "exceeds 8 bytes") || len(stdout) != 0 {
+		t.Fatalf("runBounded() stdout = %q, error = %v", stdout, err)
+	}
+}
+
+func TestGetMetadataBoundedClassifiesOnlyExpectedWebhookAbsence(t *testing.T) {
+	for _, test := range []struct {
+		name, message, stdout string
+		exit                  int
+		wantAbsent            bool
+	}{
+		{name: "non-webhook", message: "400 Bad Request: Build was not triggered by a webhook", exit: 1, wantAbsent: true},
+		{name: "missing linked webhook", message: "404 Not Found: Build webhook is not available", exit: 1, wantAbsent: true},
+		{name: "rate limited", message: "429 Too Many Requests: rate limit exceeded", exit: 1},
+		{name: "unexpected exit", message: "400 Bad Request: Build was not triggered by a webhook", exit: 2},
+		{name: "oversized output", message: "400 Bad Request: Build was not triggered by a webhook", stdout: strings.Repeat("x", 1025), exit: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			agentPath := filepath.Join(dir, "buildkite-agent")
+			script := "#!/bin/sh\nprintf '%s' '" + test.stdout + "'\nprintf '%s\\n' '" + test.message + "' >&2\nexit " + strconv.Itoa(test.exit) + "\n"
+			if err := os.WriteFile(agentPath, []byte(script), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PATH", dir)
+			_, err := (Agent{Runner: CommandRunner{}}).GetMetadataBounded(context.Background(), "buildkite:webhook", 1024)
+			if got := errors.Is(err, ErrMetadataUnavailable); got != test.wantAbsent {
+				t.Fatalf("GetMetadataBounded() error = %v, absent = %t, want %t", err, got, test.wantAbsent)
+			}
+			if !test.wantAbsent && err == nil {
+				t.Fatalf("operational error = %v", err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Why

`buildkite-gha upload` currently reconstructs `github.event` entirely from `BUILDKITE_*` variables, losing webhook fields needed by compile-time expressions. Webhook-linked builds already expose Buildkite's stored parsed payload through the reserved `buildkite:webhook` metadata key.

## What

Prefer one bounded read of `buildkite:webhook` when no explicit `--event-path` is supplied, while continuing to derive the exact repository, SHA, and ref being executed from validated Buildkite environment values. Confirmed non-webhook or unavailable-webhook responses use the existing reduced-fidelity fallback; malformed, oversized, rate-limited, unauthorized, and transport failures stop upload.

The webhook remains untrusted compatibility data and cannot grant protected capabilities. Raw payload data is not retained in plans or pipeline YAML beyond the existing digest and values deliberately selected during compilation. The compatibility guide documents source precedence, the 25 MiB limit, fallback behavior, and stored-payload limitations.