### PR TITLE
Isolate upload test from tag builds

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -893,6 +893,7 @@ func TestRunUploadUsesWebhookPayloadWithoutRetainingIt(t *testing.T) {
 	t.Setenv("BUILDKITE_REPO", "https://github.com/buildkite/buildkite-gha")
 	t.Setenv("BUILDKITE_COMMIT", sha)
 	t.Setenv("BUILDKITE_BRANCH", "executed")
+	t.Setenv("BUILDKITE_TAG", "")
 	t.Setenv("BUILDKITE_PULL_REQUEST", "false")
 	t.Setenv("BUILDKITE_BUILD_AUTHOR", "Build Author")
 	t.Setenv("BUILDKITE_GITHUB_EVENT", "pull_request")


### PR DESCRIPTION
A tag release build inherits `BUILDKITE_TAG`, which caused the upload webhook test to assert a tag ref instead of the branch ref configured by the test. Clear `BUILDKITE_TAG` in that test, matching the neighboring derived-event test, so repository checks are deterministic in both branch and tag builds.

This unblocks publishing a replacement `v0.7.1` release while leaving the failed `v0.7.0` tag immutable.