### PR TITLE
Improve OSS action compatibility

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -107,7 +107,7 @@ service.
 | `docker://` actions and action `entrypoint`/`args` overrides | Not supported | Validation rejects these forms. |
 | Concurrent step controls | Supported | GitHub Actions `background`, `wait`, `wait-all`, `cancel`, and `parallel` controls run inside one job with at most ten active background steps. Effects and failures become visible at covering waits, remaining work is joined before cleanup, and cancellation targets the complete process group rather than only the direct process. |
 | `actions/checkout` | Supported subset | The `github.com` event repository, exact event SHA, workspace root, and shallow fetch are supported. The fetch automatically uses Buildkite's repository-provider Git credential helper when the job has those credentials enabled and is anonymous otherwise. Alternate repositories/refs, submodules, LFS, persisted credentials, and arbitrary checkout inputs are not supported. |
-| `actions/upload-artifact` | Supported subset | Only the audited v4 commit is adapted. It supports bounded literal files/directories, ZIP compression 0–9, hidden-file selection, and exact no-file behavior. Globs, exclusions, symlinks, retention, overwrite, raw uploads, merge, and GitHub URLs are not supported. |
+| `actions/upload-artifact` | Supported subset | The audited v4 and v7 commits are adapted in ZIP mode. They support bounded literal files/directories, ZIP compression 0–9, hidden-file selection, and exact no-file behavior. Globs, exclusions, symlinks, retention, overwrite, v7 raw uploads, merge, and GitHub URLs are not supported. |
 | `actions/download-artifact` | Supported subset | Only the audited v4.3.0 commit is adapted. One exact literal name from verified direct `needs` can be extracted to a clean workspace-relative path. IDs, patterns, all-artifact, merge, cross-run, and cross-repository modes are not supported. |
 | `actions/cache` | Supported subset | Only the audited v6.1.0 commit, including its `restore` and `save` entry points, is admitted. It runs the stock Node 24 cache-v2 client with fresh job-bound credentials and the official Buildkite Results service by default. v4/v5 and unrecognized v6 commits are not supported. |
 | Cache clients bundled into actions | Supported subset | JavaScript and Docker action invocations receive fresh job-bound cache-v2 credentials when the service is available, matching the environment expected by setup actions such as `actions/setup-go`. The action remains responsible for its own key, version, paths, save/restore lifecycle, and cache-miss behavior. Ordinary `run` steps and native adapters do not receive cache credentials. |
@@ -330,11 +330,14 @@ to the service's repository and permission policy.
 
 ### Artifact uploads use bounded native storage
 
-The producer-side adapter recognizes only
-`actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02`.
-It verifies that immutable action source and metadata, then replaces the whole
-upstream JavaScript lifecycle with a Buildkite Agent artifact upload. A mutable
-v4 reference is accepted only when resolution produces that audited commit.
+The producer-side adapter recognizes only the audited commits
+`actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02`
+(v4) and
+`actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`
+(v7). It verifies the immutable action source and metadata, then replaces the
+whole upstream JavaScript lifecycle with a Buildkite Agent artifact upload. A
+mutable v4 or v7 reference is accepted only when resolution produces one of
+those audited commits.
 
 The supported inputs are `name`, `path`, `if-no-files-found`,
 `include-hidden-files`, `compression-level`, explicit `overwrite: false`, and

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -106,7 +106,7 @@ service.
 | Dockerfile actions | Supported subset | Only compiler-verified local or public Dockerfile actions are admitted. The standard cache-v2 environment is available inside the action container. Lifecycle overrides, arbitrary Docker options, other credentials, volumes, private images, and privileged execution are not supported. |
 | `docker://` actions and action `entrypoint`/`args` overrides | Not supported | Validation rejects these forms. |
 | Concurrent step controls | Supported | GitHub Actions `background`, `wait`, `wait-all`, `cancel`, and `parallel` controls run inside one job with at most ten active background steps. Effects and failures become visible at covering waits, remaining work is joined before cleanup, and cancellation targets the complete process group rather than only the direct process. |
-| `actions/checkout` | Supported subset | The `github.com` event repository, exact event SHA, workspace root, and shallow fetch are supported. The fetch automatically uses Buildkite's repository-provider Git credential helper when the job has those credentials enabled and is anonymous otherwise. Alternate repositories/refs, submodules, LFS, persisted credentials, and arbitrary checkout inputs are not supported. |
+| `actions/checkout` | Supported subset | The `github.com` event repository, exact event SHA, workspace root, and fetch depth 1 or 0 are supported. Depth 0 fetches all branch and tag history while retaining the exact event SHA. The fetch automatically uses Buildkite's repository-provider Git credential helper when the job has those credentials enabled and is anonymous otherwise. Alternate repositories/refs, submodules, LFS, persisted credentials, and arbitrary checkout inputs are not supported. |
 | `actions/upload-artifact` | Supported subset | The audited v4 and v7 commits are adapted in ZIP mode. They support bounded literal files/directories, ZIP compression 0–9, hidden-file selection, and exact no-file behavior. Globs, exclusions, symlinks, retention, overwrite, v7 raw uploads, merge, and GitHub URLs are not supported. |
 | `actions/download-artifact` | Supported subset | Only the audited v4.3.0 commit is adapted. One exact literal name from verified direct `needs` can be extracted to a clean workspace-relative path. IDs, patterns, all-artifact, merge, cross-run, and cross-repository modes are not supported. |
 | `actions/cache` | Supported subset | Only the audited v6.1.0 commit, including its `restore` and `save` entry points, is admitted. It runs the stock Node 24 cache-v2 client with fresh job-bound credentials and the official Buildkite Results service by default. v4/v5 and unrecognized v6 commits are not supported. |
@@ -247,8 +247,9 @@ semantics when Buildkite has not supplied them.
 ### Checkout starts clean
 
 Generated jobs skip Buildkite's default checkout and allocate a fresh Actions
-workspace. A supported `actions/checkout` step performs a shallow checkout of
-the event repository at the exact event SHA. Compilation automatically adds
+workspace. A supported `actions/checkout` step checks out the event repository
+at the exact event SHA, using GitHub's default depth 1 or explicit
+`fetch-depth: 0` for all branch and tag history. Compilation automatically adds
 `provider-token-read` only to a job containing the compiler-verified checkout
 adapter with its bounded inputs.
 

--- a/internal/action/integration/integration.go
+++ b/internal/action/integration/integration.go
@@ -284,7 +284,7 @@ func ValidateCheckoutInputs(inputs map[string]string, repository, sha string) er
 				continue
 			}
 		case "fetch-depth":
-			if value == "1" {
+			if value == "0" || value == "1" {
 				continue
 			}
 		case "clean", "set-safe-directory":

--- a/internal/action/integration/integration.go
+++ b/internal/action/integration/integration.go
@@ -34,9 +34,11 @@ const (
 	// AdapterDownloadArtifactBuildkite extracts one producer-attributed native
 	// archive without using the GitHub Actions artifact service.
 	AdapterDownloadArtifactBuildkite Adapter = "download-artifact-buildkite-v1"
-	// UploadArtifactCommit is the only upstream implementation whose input and
-	// archive semantics this adapter implements.
+	// UploadArtifactCommit and UploadArtifactV7Commit are the audited upstream
+	// implementations whose ZIP-mode semantics this adapter implements. Raw v7
+	// uploads remain explicitly unsupported by ValidateUploadArtifactInputs.
 	UploadArtifactCommit   = "ea165f8d65b6e75b540449e92b4886f43607fa02"
+	UploadArtifactV7Commit = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
 	DownloadArtifactCommit = "d3f86a106a0bac45b974a628896c90dbdf5c8093"
 	// CacheCommit is the only actions/cache implementation admitted to the
 	// Buildkite-backed cache-v2 service.
@@ -82,8 +84,8 @@ var catalog = map[Identity]Descriptor{
 
 // ValidateUploadArtifactCommit rejects semantic drift from the audited action.
 func ValidateUploadArtifactCommit(commit string) error {
-	if commit != UploadArtifactCommit {
-		return fmt.Errorf("actions/upload-artifact native adapter supports only commit %s, resolved %q; Phase 6 is required", UploadArtifactCommit, commit)
+	if commit != UploadArtifactCommit && commit != UploadArtifactV7Commit {
+		return fmt.Errorf("actions/upload-artifact native adapter supports only commits %s and %s, resolved %q; Phase 6 is required", UploadArtifactCommit, UploadArtifactV7Commit, commit)
 	}
 	return nil
 }

--- a/internal/action/integration/integration_test.go
+++ b/internal/action/integration/integration_test.go
@@ -137,6 +137,7 @@ func TestValidateCheckoutInputs(t *testing.T) {
 	for _, inputs := range []map[string]string{
 		nil,
 		{"repository": "BUILDKITE/BUILDKITE-GHA", "ref": sha, "fetch-depth": "1", "persist-credentials": "false", "clean": "true", "set-safe-directory": "true"},
+		{"fetch-depth": "0"},
 	} {
 		if err := ValidateCheckoutInputs(inputs, repository, sha); err != nil {
 			t.Fatalf("ValidateCheckoutInputs(%#v) = %v", inputs, err)

--- a/internal/action/integration/integration_test.go
+++ b/internal/action/integration/integration_test.go
@@ -57,12 +57,14 @@ func TestDownloadArtifactExactContract(t *testing.T) {
 	}
 }
 
-func TestUploadArtifactCommitIsExact(t *testing.T) {
-	if err := ValidateUploadArtifactCommit(UploadArtifactCommit); err != nil {
-		t.Fatal(err)
+func TestUploadArtifactCommitsAreExact(t *testing.T) {
+	for _, commit := range []string{UploadArtifactCommit, UploadArtifactV7Commit} {
+		if err := ValidateUploadArtifactCommit(commit); err != nil {
+			t.Fatalf("audited commit %s rejected: %v", commit, err)
+		}
 	}
-	if err := ValidateUploadArtifactCommit(strings.Repeat("0", 40)); err == nil {
-		t.Fatal("unrecognized commit accepted")
+	if err := ValidateUploadArtifactCommit(strings.Repeat("0", 40)); err == nil || !strings.Contains(err.Error(), UploadArtifactCommit) || !strings.Contains(err.Error(), UploadArtifactV7Commit) {
+		t.Fatalf("unrecognized commit error = %v, want both audited commits", err)
 	}
 }
 

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -808,6 +808,16 @@ func TestUploadArtifactAdapterInputAndCommitBoundary(t *testing.T) {
 	if len(plans) != 1 || !reflect.DeepEqual(plans[0].RequiredCapabilities, []string{"network"}) {
 		t.Fatalf("upload-artifact plans = %#v", plans)
 	}
+	plans, err = compile(actionintegration.UploadArtifactV7Commit, "        with:\n          name: payload\n          path: payload/result.txt\n          archive: true\n")
+	if err != nil {
+		t.Fatalf("audited v7 ZIP upload rejected: %v", err)
+	}
+	if len(plans) != 1 || !reflect.DeepEqual(plans[0].RequiredCapabilities, []string{"network"}) {
+		t.Fatalf("upload-artifact v7 plans = %#v", plans)
+	}
+	if _, err := compile(actionintegration.UploadArtifactV7Commit, "        with:\n          path: payload/result.txt\n          archive: false\n"); err == nil || !strings.Contains(err.Error(), `input "archive" may only be omitted or true`) {
+		t.Fatalf("upload-artifact v7 raw mode error = %v", err)
+	}
 
 	for name, input := range map[string]string{
 		"missing path": "          name: payload\n",
@@ -823,7 +833,7 @@ func TestUploadArtifactAdapterInputAndCommitBoundary(t *testing.T) {
 		})
 	}
 
-	if _, err := compile(strings.Repeat("b", 40), "        with:\n          path: payload\n"); err == nil || !strings.Contains(err.Error(), actionintegration.UploadArtifactCommit) {
+	if _, err := compile(strings.Repeat("b", 40), "        with:\n          path: payload\n"); err == nil || !strings.Contains(err.Error(), actionintegration.UploadArtifactCommit) || !strings.Contains(err.Error(), actionintegration.UploadArtifactV7Commit) {
 		t.Fatalf("unsupported upload-artifact commit error = %v", err)
 	}
 }

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -695,6 +695,7 @@ func TestCheckoutAdapterInputBoundary(t *testing.T) {
 	accepted := []string{
 		"",
 		"        with:\n          repository: buildkite/buildkite-gha\n          ref: 1111111111111111111111111111111111111111\n          fetch-depth: '1'\n          persist-credentials: false\n          clean: true\n          set-safe-directory: true\n",
+		"        with:\n          fetch-depth: '0'\n",
 	}
 	for _, with := range accepted {
 		plans, err := compile(with)
@@ -713,7 +714,7 @@ func TestCheckoutAdapterInputBoundary(t *testing.T) {
 		"ssh-key":     "          ssh-key: key\n",
 		"submodules":  "          submodules: true\n",
 		"path":        "          path: nested\n",
-		"fetch-depth": "          fetch-depth: '0'\n",
+		"fetch-depth": "          fetch-depth: '2'\n",
 		"credentials": "          persist-credentials: true\n",
 	}
 	for name, input := range rejected {

--- a/internal/runtime/checkout.go
+++ b/internal/runtime/checkout.go
@@ -118,7 +118,7 @@ func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, wo
 	if err := run(env, "remote", "add", "origin", url); err != nil {
 		return result, err
 	}
-	fetchArgs := []string{"fetch", "--no-tags", "--no-recurse-submodules", "--depth=1", "origin", job.Event.SHA}
+	fetchArgs := checkoutFetchArgs(inputs, job.Event.SHA)
 	if credentialed {
 		if err := r.runRepositoryProviderCheckoutFetch(ctx, processor, workspace, env, git, base, fetchArgs); err != nil {
 			return result, fmt.Errorf("%s git fetch: %w", adapter, err)
@@ -136,6 +136,20 @@ func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, wo
 	result.Outputs["ref"] = job.Event.Ref
 	result.Outputs["commit"] = job.Event.SHA
 	return result, nil
+}
+
+func checkoutFetchArgs(inputs map[string]string, sha string) []string {
+	for name, value := range inputs {
+		if strings.EqualFold(name, "fetch-depth") && value == "0" {
+			return []string{
+				"fetch", "--no-tags", "--prune", "--no-recurse-submodules", "origin",
+				"+refs/heads/*:refs/remotes/origin/*",
+				"+refs/tags/*:refs/tags/*",
+				"+" + sha + ":refs/buildkite-gha/event",
+			}
+		}
+	}
+	return []string{"fetch", "--no-tags", "--no-recurse-submodules", "--depth=1", "origin", sha}
 }
 
 func (r Runner) runRepositoryProviderCheckoutFetch(ctx context.Context, processor *commandProcessor, workspace string, env map[string]string, git string, base, fetchArgs []string) error {

--- a/internal/runtime/checkout_test.go
+++ b/internal/runtime/checkout_test.go
@@ -163,6 +163,28 @@ func TestCheckoutAdapterRejectsUnsupportedInputsAndState(t *testing.T) {
 	}
 }
 
+func TestCheckoutFetchDepth(t *testing.T) {
+	sha := strings.Repeat("a", 40)
+	for _, test := range []struct {
+		name   string
+		inputs map[string]string
+		want   string
+	}{
+		{name: "default shallow", want: "fetch --no-tags --no-recurse-submodules --depth=1 origin " + sha},
+		{name: "explicit shallow", inputs: map[string]string{"fetch-depth": "1"}, want: "fetch --no-tags --no-recurse-submodules --depth=1 origin " + sha},
+		{
+			name: "all branches and tags", inputs: map[string]string{"Fetch-Depth": "0"},
+			want: "fetch --no-tags --prune --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/* +" + sha + ":refs/buildkite-gha/event",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := strings.Join(checkoutFetchArgs(test.inputs, sha), " "); got != test.want {
+				t.Fatalf("checkoutFetchArgs() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
 func TestCheckoutRejectsInvalidRepositoryBeforeInspectingWorkspace(t *testing.T) {
 	workspace := t.TempDir()
 	if err := os.WriteFile(filepath.Join(workspace, "occupied"), []byte("x"), 0o600); err != nil {


### PR DESCRIPTION
## Why

The OSS compatibility canary exposed two bounded action-adapter gaps that can be fixed without changing workflow meaning:

- `actions/upload-artifact@v7` resolves to `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`, while the native adapter admitted only its audited v4 commit
- `actions/checkout` rejected `fetch-depth: 0`, used by the pinned fzf workflow

## What

- admit the audited upload-artifact v7 commit alongside the existing v4 commit
- retain the existing bounded ZIP-only artifact contract and continue rejecting `archive: false` explicitly
- support checkout depth 0 by fetching all branch and tag refspecs plus a private ref pinned to the exact event SHA
- retain depth 1 as the default and continue rejecting arbitrary positive depths
- test both audited artifact pins, unknown-pin rejection, v7 ZIP/raw boundaries, checkout input classification, and exact full-history Git arguments
- document both boundaries

This removes both failures without pretending that a SHA-only fetch is GitHub-compatible full history and without silently treating v7 raw uploads as ZIP uploads.

## Corpus impact

With the separately-owned compound action-default expression fix simulated by explicit empty token inputs, the unchanged fzf workflow reaches `admitted` with its real `fetch-depth: 0` setting.

The `jq-valgrind` case advances beyond the v7 commit check but remains correctly blocked on independent choices: checkout submodules, artifact glob paths, and per-artifact retention.

## Validation

- `mise exec -- go test ./internal/action/integration ./internal/compiler ./internal/runtime -run 'Test(UploadArtifact|Checkout)' -count=1`
- `mise run check`
- real Git fetch against `junegunn/fzf@715d26f`: 11 remote branches, 177 tags, and exact event ref verified
- exact fzf profile probe: `admitted` after bypassing only the separately-owned compound token-default parser issue