### PR TITLE
Support toolchain images for generated jobs

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -111,7 +111,7 @@ service.
 | `actions/download-artifact` | Supported subset | Only the audited v4.3.0 commit is adapted. One exact literal name from verified direct `needs` can be extracted to a clean workspace-relative path. IDs, patterns, all-artifact, merge, cross-run, and cross-repository modes are not supported. |
 | `actions/cache` | Supported subset | Only the audited v6.1.0 commit, including its `restore` and `save` entry points, is admitted. It runs the stock Node 24 cache-v2 client with fresh job-bound credentials and the official Buildkite Results service by default. v4/v5 and unrecognized v6 commits are not supported. |
 | Cache clients bundled into actions | Supported subset | JavaScript and Docker action invocations receive fresh job-bound cache-v2 credentials when the service is available, matching the environment expected by setup actions such as `actions/setup-go`. The action remains responsible for its own key, version, paths, save/restore lifecycle, and cache-miss behavior. Ordinary `run` steps and native adapters do not receive cache credentials. |
-| Runner tool cache | Supported subset | For non-Docker processes, the runtime points `RUNNER_TOOL_CACHE` at a fresh job-private directory and does not expose an agent or Hosted shared cache as executable authority. Dockerfile actions do not receive `RUNNER_TOOL_CACHE`. Setup actions therefore download tools on a miss rather than trusting entries written by another job. The shared Hosted cache volume is not used for executable tools because stock action tool-cache clients trust a writable entry and completion marker without verifying its contents. |
+| Runner tool cache | Supported subset | By default, the runtime points `RUNNER_TOOL_CACHE` at a fresh job-private directory and does not expose an agent or Hosted shared cache as executable authority. When pipeline configuration selects an immutable runtime image with `BUILDKITE_GHA_RUNTIME_IMAGE`, generated jobs use that image's baked `/opt/hostedtoolcache` facade instead. Dockerfile actions do not receive `RUNNER_TOOL_CACHE`. The shared Hosted cache volume is never used for executable tools because stock action tool-cache clients trust a writable entry and completion marker without verifying its contents. |
 | Other GitHub service-backed actions | Not supported | Except for the integrations listed above, no general GitHub artifact, OIDC, Packages, Releases, Checks, or deployment service emulation is provided. An otherwise supported action runtime may still fail if its code requires one of those services. |
 
 ### Repositories, credentials, and platforms
@@ -612,6 +612,20 @@ pipeline upload. This setting is ordinary pipeline configuration, not an
 authenticated grant: it admits untrusted workflow code to the named queue, so
 that queue must provide suitable whole-job isolation and no ambient protected
 credentials.
+
+An importer can opt every generated workflow job into a toolchain-enabled
+Hosted image by setting `BUILDKITE_GHA_RUNTIME_IMAGE` to an immutable registry
+digest, for example:
+
+```yaml
+env:
+  BUILDKITE_GHA_RUNTIME_IMAGE: buildkite.namespace-images.com/agent-base@sha256:04a6656f92b90269b3259fffaba67e08a3d03d8dc79b40d45c9ac3d9000e9e03
+```
+
+The uploader emits this as each generated job's `image` and points the job's
+`RUNNER_TOOL_CACHE` at the image-baked `/opt/hostedtoolcache` inventory. Tags
+and other mutable references are rejected. Without this setting, generated
+jobs retain their current image selection and fresh job-private tool cache.
 
 `run-job` is an internal command emitted into generated jobs. Users should not
 need to invoke it directly.

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -2622,8 +2622,9 @@ them in the phase that first needs the capability:
    webhooks directly, and whether a small Buildkite platform API is missing.
 2. Phase 5 uses direct Hosted Agent execution. Exact-commit build 102 proved
    the local `default` Docker driver and queue prerequisites; build 136 proved
-   the complete container runtime. A compatibility image remains deferred until
-   tool-cache differences demonstrate a concrete need.
+   the complete container runtime. Importers can now opt generated jobs into an
+   immutable toolchain-enabled image; the default image and fresh job-private
+   tool cache remain unchanged when no image is selected.
 3. Phase 4 will set the customer-beta event and expression subset from the
    hosted differential corpus.
 4. Phase 6 will define Cursor Origin checkout, event, pull-request, Job OIDC,

--- a/internal/buildkite/pipeline.go
+++ b/internal/buildkite/pipeline.go
@@ -18,12 +18,17 @@ const maxConcurrencyGroupLength = 200
 const runtimeCacheName = "buildkite-gha"
 const runtimeCachePath = "/cache/bkcache/buildkite-gha"
 
+// HostedToolCachePath is the trusted, image-baked Actions tool-cache facade
+// used by explicitly selected runtime images.
+const HostedToolCachePath = "/opt/hostedtoolcache"
+
 // MinimumMiseVersion is the oldest supported mise release and the exact
 // release installed when no compatible runtime executable is available.
 const MinimumMiseVersion = "2026.5.12"
 
 var identifierPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,255}$`)
 var digestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+var runtimeImagePattern = regexp.MustCompile(`^[a-z0-9]+(?:[._-][a-z0-9]+)*(?:/[a-z0-9]+(?:[._-][a-z0-9]+)*)+@sha256:[0-9a-f]{64}$`)
 var uuidPattern = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 
 // Pipeline is the validated input required to emit generated compatibility jobs.
@@ -31,6 +36,7 @@ type Pipeline struct {
 	CompilerStep       string
 	DistributionDigest string
 	GroupLabel         string
+	RuntimeImage       string
 	ConcurrencyGate    *ConcurrencyGate
 	Jobs               []Job
 }
@@ -94,6 +100,9 @@ func Emit(pipeline Pipeline) ([]byte, error) {
 	if err := validateConcurrencyGate(pipeline.ConcurrencyGate); err != nil {
 		return nil, err
 	}
+	if pipeline.RuntimeImage != "" && !runtimeImagePattern.MatchString(pipeline.RuntimeImage) {
+		return nil, fmt.Errorf("runtime image %q must be an immutable registry sha256 reference", pipeline.RuntimeImage)
+	}
 	distributionPath, err := DistributionPath(pipeline.DistributionDigest)
 	if err != nil {
 		return nil, err
@@ -119,6 +128,9 @@ func Emit(pipeline Pipeline) ([]byte, error) {
 		}
 		_, _ = fmt.Fprintf(&out, "%s- label: %s\n", stepIndent, yamlScalar(job.Label))
 		_, _ = fmt.Fprintf(&out, "%skey: %s\n", attributeIndent, yamlScalar(job.Key))
+		if pipeline.RuntimeImage != "" {
+			_, _ = fmt.Fprintf(&out, "%simage: %s\n", attributeIndent, yamlScalar(pipeline.RuntimeImage))
+		}
 		commands := []string{
 			"set -euo pipefail",
 			`bootstrap_dir="$(mktemp -d "${TMPDIR:-/tmp}/buildkite-gha.XXXXXXXX")"`,
@@ -131,7 +143,11 @@ func Emit(pipeline Pipeline) ([]byte, error) {
 			"test \"$actual_distribution_digest\" = " + shellQuote(pipeline.DistributionDigest),
 			`chmod 0500 "$distribution"`,
 		}
-		commands = append(commands, `"$distribution" run-job --plan "$plan"`)
+		runJob := `"$distribution" run-job --plan "$plan"`
+		if pipeline.RuntimeImage != "" {
+			runJob += " --hosted-tool-cache"
+		}
+		commands = append(commands, runJob)
 		command := strings.Join(commands, "\n")
 		_, _ = fmt.Fprintf(&out, "%scommand: %s\n", attributeIndent, yamlScalar(command))
 		if job.Queue != "" {

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -264,6 +264,34 @@ func TestEmitActionRuntimeRequirement(t *testing.T) {
 	}
 }
 
+func TestEmitUsesImmutableRuntimeImageToolCache(t *testing.T) {
+	image := "buildkite.namespace-images.com/agent-base@sha256:" + strings.Repeat("0", 64)
+	output, err := Emit(Pipeline{
+		CompilerStep:       "importer",
+		DistributionDigest: testDigest("distribution"),
+		RuntimeImage:       image,
+		Jobs:               []Job{{Key: "job", Label: "Job", Queue: "hosted", PlanDigest: testDigest("plan")}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document struct {
+		Steps []struct {
+			Image   string `yaml:"image"`
+			Command string `yaml:"command"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(output, &document); err != nil {
+		t.Fatal(err)
+	}
+	if len(document.Steps) != 1 || document.Steps[0].Image != image {
+		t.Fatalf("runtime image = %#v, want %q", document.Steps, image)
+	}
+	if !strings.Contains(document.Steps[0].Command, "run-job --plan \"$plan\" --hosted-tool-cache") {
+		t.Fatalf("run-job command does not select hosted tool cache: %q", document.Steps[0].Command)
+	}
+}
+
 func TestMiseDataDirUsesManagedRuntimeVersion(t *testing.T) {
 	if got := MiseDataDir(); got != "/cache/bkcache/buildkite-gha/mise/"+MinimumMiseVersion {
 		t.Fatalf("MiseDataDir() = %q", got)
@@ -324,6 +352,7 @@ func TestEmitRejectsInvalidGraphsAndIdentifiers(t *testing.T) {
 		{name: "UUID compiler", in: Pipeline{CompilerStep: "123e4567-e89b-12d3-a456-426614174000", Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: digest}}}, want: "invalid compiler step key"},
 		{name: "UUID key", in: Pipeline{CompilerStep: "compiler", Jobs: []Job{{Key: "123e4567-e89b-12d3-a456-426614174000", Label: "One", Queue: "queue", PlanDigest: digest}}}, want: "invalid generated step key"},
 		{name: "bad digest", in: Pipeline{CompilerStep: "compiler", Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: "sha256:nope"}}}, want: "invalid plan digest"},
+		{name: "mutable runtime image", in: Pipeline{CompilerStep: "compiler", DistributionDigest: digest, RuntimeImage: "buildkite/agent-base:ubuntu-jammy-hosted-toolchains", Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: digest}}}, want: "immutable registry sha256 reference"},
 		{name: "partial concurrency", in: Pipeline{CompilerStep: "compiler", Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: digest, Concurrency: 2}}}, want: "concurrency and concurrency group together"},
 		{name: "empty workflow concurrency group", in: Pipeline{CompilerStep: "compiler", DistributionDigest: digest, ConcurrencyGate: &ConcurrencyGate{Queue: "queue"}, Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: digest}}}, want: "invalid workflow concurrency group"},
 		{name: "long job concurrency group", in: Pipeline{CompilerStep: "compiler", DistributionDigest: digest, Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: digest, Concurrency: 1, ConcurrencyGroup: strings.Repeat("x", maxConcurrencyGroupLength+1)}}}, want: "concurrency group exceeds"},

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -51,7 +51,7 @@ var commandUsage = map[string]string{
 	"validate": "Usage: buildkite-gha validate [--event-path <path>] [--profile hosted-tokenless] [--format text|json] <workflow>\n",
 	"compile":  "Usage: buildkite-gha compile --event-path <path> [--format pipeline|ir-json] <workflow>\n",
 	"upload":   "Usage: buildkite-gha upload [--event-path <path>] [--runtime-queue hosted] <workflow>\n",
-	"run-job":  "Usage: buildkite-gha run-job --plan <path> [--result <path>]\n",
+	"run-job":  "Usage: buildkite-gha run-job --plan <path> [--result <path>] [--hosted-tool-cache]\n",
 }
 
 func writeCommandHelp(stdout io.Writer, command string) {
@@ -62,7 +62,7 @@ func writeCommandHelp(stdout io.Writer, command string) {
 	case "compile":
 		_, _ = fmt.Fprint(stdout, "\nPipeline output references content-addressed plans; compile does not materialize or upload those artifacts.\n")
 	case "upload":
-		_, _ = fmt.Fprintf(stdout, "\nGenerated jobs use Buildkite's default agent targeting. An importer can explicitly target one queue with %s; that queue must be suitable for untrusted workflow code. The deprecated --runtime-queue hosted option is accepted for plugin compatibility but does not select a queue. Event precedence is an explicit event file, Buildkite's reserved webhook metadata, then reduced-fidelity Buildkite environment compatibility data; every source remains unsigned. Verified checkout jobs automatically use Buildkite repository-provider Git credentials when the job enables them; the deprecated --private-checkout option is accepted as a no-op.\n", targetQueueEnvironment)
+		_, _ = fmt.Fprintf(stdout, "\nGenerated jobs use Buildkite's default agent targeting. An importer can explicitly target one queue with %s; that queue must be suitable for untrusted workflow code. It can select an immutable image for generated jobs with %s. The deprecated --runtime-queue hosted option is accepted for plugin compatibility but does not select a queue. Event precedence is an explicit event file, Buildkite's reserved webhook metadata, then reduced-fidelity Buildkite environment compatibility data; every source remains unsigned. Verified checkout jobs automatically use Buildkite repository-provider Git credentials when the job enables them; the deprecated --private-checkout option is accepted as a no-op.\n", targetQueueEnvironment, runtimeImageEnvironment)
 	}
 }
 
@@ -70,6 +70,7 @@ const (
 	resultPublicationTimeout                    = 10 * time.Second
 	legacyRuntimeQueue                          = "hosted"
 	targetQueueEnvironment                      = "BUILDKITE_GHA_TARGET_QUEUE"
+	runtimeImageEnvironment                     = "BUILDKITE_GHA_RUNTIME_IMAGE"
 	repositoryProviderGitCredentialsEnvironment = "BUILDKITE_USE_REPOSITORY_PROVIDER_GIT_CREDENTIALS"
 	legacyGitHubAppGitCredentialsEnvironment    = "BUILDKITE_USE_GITHUB_APP_GIT_CREDENTIALS"
 	hostedTokenlessProfile                      = "hosted-tokenless"
@@ -159,7 +160,7 @@ func runJob(args []string, stdout, stderr io.Writer, version string, agent trans
 }
 
 func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer, version string, agent transport.Agent) int {
-	planPath, resultPath, err := runJobArgs(args)
+	planPath, resultPath, hostedToolCache, err := runJobArgs(args)
 	if err != nil {
 		return usageError(stderr, "run-job: %v", err)
 	}
@@ -261,10 +262,15 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 			NoHTTP2:  os.Getenv("BUILDKITE_NO_HTTP2"),
 		}
 	}
+	runnerToolCache := ""
+	if hostedToolCache {
+		runnerToolCache = buildkitepipeline.HostedToolCachePath
+	}
 	runner := gharuntime.Runner{
 		Stdout:                stdout,
 		Stderr:                stderr,
 		MiseDataDir:           prepareMiseDataDir(os.Getenv("BUILDKITE_GHA_MISE_DATA_DIR"), stderr),
+		ToolCache:             runnerToolCache,
 		Docker:                os.Getenv("BUILDKITE_GHA_DOCKER"),
 		Git:                   os.Getenv("BUILDKITE_GHA_GIT"),
 		Secrets:               gharuntime.EnvironmentSecrets{},
@@ -822,19 +828,25 @@ func publishTerminalResult(agent transport.Agent, root string, job plan.Job, pla
 	return gharuntime.PublishJobResult(ctx, agent, root, workflow, job.Target.StepKey, planDigest, producer, result)
 }
 
-func runJobArgs(args []string) (planPath, resultPath string, err error) {
+func runJobArgs(args []string) (planPath, resultPath string, hostedToolCache bool, err error) {
 	seen := map[string]bool{}
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
+		case "--hosted-tool-cache":
+			if seen[args[i]] {
+				return "", "", false, fmt.Errorf("%s may only be specified once", args[i])
+			}
+			seen[args[i]] = true
+			hostedToolCache = true
 		case "--plan", "--result":
 			option := args[i]
 			if seen[option] {
-				return "", "", fmt.Errorf("%s may only be specified once", option)
+				return "", "", false, fmt.Errorf("%s may only be specified once", option)
 			}
 			seen[option] = true
 			i++
 			if i == len(args) {
-				return "", "", fmt.Errorf("%s requires a path", option)
+				return "", "", false, fmt.Errorf("%s requires a path", option)
 			}
 			if option == "--plan" {
 				planPath = args[i]
@@ -842,13 +854,13 @@ func runJobArgs(args []string) (planPath, resultPath string, err error) {
 				resultPath = args[i]
 			}
 		default:
-			return "", "", fmt.Errorf("unknown option %q", args[i])
+			return "", "", false, fmt.Errorf("unknown option %q", args[i])
 		}
 	}
 	if planPath == "" {
-		return "", "", fmt.Errorf("--plan is required")
+		return "", "", false, fmt.Errorf("--plan is required")
 	}
-	return planPath, resultPath, nil
+	return planPath, resultPath, hostedToolCache, nil
 }
 
 func verifyBuildkiteTarget(job plan.Job) error {
@@ -918,7 +930,7 @@ func validate(args []string, stdout, stderr io.Writer, version string) int {
 		}
 		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 		defer stop()
-		preflight, profileErr := compileHostedTokenless(ctx, workflowPath, source, event, version, distributionDigest, "buildkite-gha-profile-importer", "", "", nil)
+		preflight, profileErr := compileHostedTokenless(ctx, workflowPath, source, event, version, distributionDigest, "buildkite-gha-profile-importer", "", "", "", nil)
 		if profileErr != nil {
 			if ctx.Err() != nil || errors.Is(profileErr, context.Canceled) {
 				_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: profile evaluation interrupted: %v\n", profileErr)
@@ -1082,6 +1094,10 @@ func upload(args []string, stdout, stderr io.Writer, version string, agent trans
 	if targetQueueConfigured && targetQueue == "" {
 		return usageError(stderr, "upload: %s must name a non-empty queue when set", targetQueueEnvironment)
 	}
+	runtimeImage, runtimeImageConfigured := os.LookupEnv(runtimeImageEnvironment)
+	if runtimeImageConfigured && runtimeImage == "" {
+		return usageError(stderr, "upload: %s must name a non-empty image when set", runtimeImageEnvironment)
+	}
 	importerStep := os.Getenv("BUILDKITE_STEP_KEY")
 	if os.Getenv("BUILDKITE") != "true" || strings.TrimSpace(importerStep) == "" {
 		return usageError(stderr, "upload: BUILDKITE=true and BUILDKITE_STEP_KEY are required")
@@ -1121,7 +1137,7 @@ func upload(args []string, stdout, stderr io.Writer, version string, agent trans
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
 		return 1
 	}
-	preflight, err := compileHostedTokenless(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, os.Getenv("BUILDKITE_GROUP_LABEL"), targetQueue, jobScopedActionSourceAuthentication(stderr))
+	preflight, err := compileHostedTokenless(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, os.Getenv("BUILDKITE_GROUP_LABEL"), targetQueue, runtimeImage, jobScopedActionSourceAuthentication(stderr))
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
 		return 1
@@ -1248,7 +1264,7 @@ func (a *actionSourceAuthentication) warnAnonymousFallback(reason string) {
 	}
 }
 
-func compileHostedTokenless(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel, targetQueue string, actionAuthentication *actionSourceAuthentication) (hostedTokenlessCompilation, error) {
+func compileHostedTokenless(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel, targetQueue, runtimeImage string, actionAuthentication *actionSourceAuthentication) (hostedTokenlessCompilation, error) {
 	preflight, err := compiler.Compile(workflowPath, workflowSource, eventSource)
 	if err != nil {
 		return hostedTokenlessCompilation{}, hostedTokenlessError(hostedTokenlessEvaluationFailure, err)
@@ -1259,8 +1275,9 @@ func compileHostedTokenless(ctx context.Context, workflowPath string, workflowSo
 	}
 	hasActions := irUsesActions(ir)
 	options := compiler.Options{
-		EventTrust: compiler.EventUntrusted,
-		GroupLabel: groupLabel,
+		EventTrust:   compiler.EventUntrusted,
+		GroupLabel:   groupLabel,
+		RuntimeImage: runtimeImage,
 		Runners: compiler.RunnerPolicy{
 			Labels: map[string]string{
 				"ubuntu-latest": targetQueue,

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -704,7 +704,7 @@ func TestHostedLocalActionDoesNotProvisionSourceToken(t *testing.T) {
 	redactor := &cliRedactor{}
 	var warnings bytes.Buffer
 	authentication := &actionSourceAuthentication{provider: provider, redactor: redactor, warnings: &warnings}
-	if _, err := compileHostedTokenless(context.Background(), workflowPath, workflowSource, eventSource, "dev", "sha256:"+strings.Repeat("0", 64), "importer", "", "", authentication); err != nil {
+	if _, err := compileHostedTokenless(context.Background(), workflowPath, workflowSource, eventSource, "dev", "sha256:"+strings.Repeat("0", 64), "importer", "", "", "", authentication); err != nil {
 		t.Fatal(err)
 	}
 	if provider.calls != 0 || len(redactor.values) != 0 || warnings.Len() != 0 {
@@ -782,6 +782,37 @@ func TestRunUploadUsesExplicitTargetQueue(t *testing.T) {
 	}
 	if planCount != 3 {
 		t.Fatalf("uploaded plan count = %d, want 3", planCount)
+	}
+}
+
+func TestRunUploadUsesExplicitRuntimeImage(t *testing.T) {
+	workflowPath := filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "shell.yml")
+	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
+	image := "buildkite.namespace-images.com/agent-base@sha256:" + strings.Repeat("0", 64)
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_STEP_KEY", "runtime-image-importer")
+	t.Setenv(runtimeImageEnvironment, image)
+	runner := &cliCaptureRunner{}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"upload", "--event-path", eventPath, workflowPath}, &stdout, &stderr, "dev", runner); code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	var pipeline struct {
+		Steps []struct {
+			Image   string `yaml:"image"`
+			Command string `yaml:"command"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(runner.commands[len(runner.commands)-1].stdin, &pipeline); err != nil {
+		t.Fatalf("uploaded pipeline YAML: %v", err)
+	}
+	if len(pipeline.Steps) != 3 {
+		t.Fatalf("uploaded steps = %#v", pipeline.Steps)
+	}
+	for _, step := range pipeline.Steps {
+		if step.Image != image || !strings.Contains(step.Command, "--hosted-tool-cache") {
+			t.Fatalf("runtime image step = %#v", step)
+		}
 	}
 }
 
@@ -2428,8 +2459,14 @@ func TestVerifyBuildkiteTargetFailsClosed(t *testing.T) {
 }
 
 func TestArgumentParsersRejectRepeatedOptions(t *testing.T) {
-	if _, _, err := runJobArgs([]string{"--plan", "one", "--plan", "two"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
+	if _, _, _, err := runJobArgs([]string{"--plan", "one", "--plan", "two"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
 		t.Fatalf("runJobArgs() error = %v, want duplicate option error", err)
+	}
+	if _, _, _, err := runJobArgs([]string{"--plan", "one", "--hosted-tool-cache", "--hosted-tool-cache"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
+		t.Fatalf("runJobArgs() error = %v, want duplicate hosted tool cache error", err)
+	}
+	if planPath, resultPath, hostedToolCache, err := runJobArgs([]string{"--hosted-tool-cache", "--result", "result.json", "--plan", "plan.json"}); err != nil || planPath != "plan.json" || resultPath != "result.json" || !hostedToolCache {
+		t.Fatalf("runJobArgs() = %q, %q, %t, %v", planPath, resultPath, hostedToolCache, err)
 	}
 	if _, _, err := workflowArgs([]string{"--event-path", "one", "--event-path", "two", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
 		t.Fatalf("workflowArgs() error = %v, want duplicate option error", err)

--- a/internal/compiler/bundle.go
+++ b/internal/compiler/bundle.go
@@ -113,6 +113,7 @@ func CompileBundleContext(ctx context.Context, path string, source, eventSource 
 		CompilerStep:       compilerStep,
 		DistributionDigest: compilerDistributionDigest,
 		GroupLabel:         options.GroupLabel,
+		RuntimeImage:       options.RuntimeImage,
 		ConcurrencyGate:    concurrencyGate,
 		Jobs:               jobs,
 	})

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -75,6 +75,29 @@ func TestCompileBundlePreservesExplicitQueuePolicy(t *testing.T) {
 	}
 }
 
+func TestCompileBundlePreservesRuntimeImagePolicy(t *testing.T) {
+	workflow := []byte("on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n")
+	image := "buildkite.namespace-images.com/agent-base@sha256:" + strings.Repeat("0", 64)
+	options := defaultOptions()
+	options.RuntimeImage = image
+	bundle, err := CompileBundleWithOptions("workflow.yml", workflow, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-importer", options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document struct {
+		Steps []struct {
+			Image   string `yaml:"image"`
+			Command string `yaml:"command"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(bundle.Pipeline, &document); err != nil {
+		t.Fatal(err)
+	}
+	if len(document.Steps) != 1 || document.Steps[0].Image != image || !strings.Contains(document.Steps[0].Command, "--hosted-tool-cache") {
+		t.Fatalf("runtime image pipeline = %#v", document.Steps)
+	}
+}
+
 func TestCompileBundleCompilesSmokeCorpus(t *testing.T) {
 	workflows, err := filepath.Glob(smokePath(".github", "workflows", "*.yml"))
 	if err != nil {

--- a/internal/compiler/config.go
+++ b/internal/compiler/config.go
@@ -51,6 +51,9 @@ type Options struct {
 	// GroupLabel merges generated jobs into the Buildkite group containing the
 	// importer. It affects pipeline presentation only, not compiler IR or plans.
 	GroupLabel string
+	// RuntimeImage selects one immutable image for generated workflow jobs. It
+	// affects pipeline placement only, not compiler IR or plans.
+	RuntimeImage string
 }
 
 func defaultOptions() Options {

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -281,8 +281,24 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 			return jobResult, fmt.Errorf("make Docker runner temp writable: %w", err)
 		}
 	}
-	if err := os.Mkdir(filepath.Join(runnerTemp, "tool-cache"), 0o755); err != nil {
-		return jobResult, fmt.Errorf("create runner tool cache: %w", err)
+	toolCache := r.ToolCache
+	if toolCache == "" {
+		toolCache = filepath.Join(runnerTemp, "tool-cache")
+		if err := os.Mkdir(toolCache, 0o755); err != nil {
+			return jobResult, fmt.Errorf("create runner tool cache: %w", err)
+		}
+	} else {
+		if !filepath.IsAbs(toolCache) || filepath.Clean(toolCache) != toolCache {
+			return jobResult, fmt.Errorf("configured runner tool cache must be an absolute canonical path")
+		}
+		resolved, err := filepath.EvalSymlinks(toolCache)
+		if err != nil || resolved != toolCache {
+			return jobResult, fmt.Errorf("configured runner tool cache is unavailable or contains a symlink")
+		}
+		info, err := os.Stat(toolCache)
+		if err != nil || !info.IsDir() {
+			return jobResult, fmt.Errorf("configured runner tool cache is not a directory")
+		}
 	}
 	if job.HasCapability("docker") {
 		r.runnerTemp = runnerTemp
@@ -346,7 +362,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		eval.Services = backend.servicePorts
 		defer func() { runJobErr = errors.Join(runJobErr, backend.cleanup()) }()
 	}
-	runtimeEnv := standardEnvironment(job, workspace, runnerTemp)
+	runtimeEnv := standardEnvironment(job, workspace, runnerTemp, toolCache)
 	jobResult.Env = mergeStepEnvironment(runtimeEnv, jobEnv)
 	if r.jobContainer != nil && !explicitJobPATH {
 		jobResult.Env["PATH"] = r.jobContainer.imagePATH
@@ -723,7 +739,7 @@ func githubContext(job plan.Job) map[string]any {
 	}
 }
 
-func standardEnvironment(job plan.Job, workspace, runnerTemp string) map[string]string {
+func standardEnvironment(job plan.Job, workspace, runnerTemp, toolCache string) map[string]string {
 	env := map[string]string{
 		"CI":                "true",
 		"GITHUB_ACTIONS":    "true",
@@ -737,7 +753,7 @@ func standardEnvironment(job plan.Job, workspace, runnerTemp string) map[string]
 		"GITHUB_WORKSPACE":  workspace,
 		"RUNNER_OS":         "Linux",
 		"RUNNER_TEMP":       runnerTemp,
-		"RUNNER_TOOL_CACHE": filepath.Join(runnerTemp, "tool-cache"),
+		"RUNNER_TOOL_CACHE": toolCache,
 	}
 	if imageOS := runnerImageOS(); imageOS != "" {
 		env["ImageOS"] = imageOS

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -54,6 +54,7 @@ type Runner struct {
 	Mise                  string
 	ResolveMise           func(context.Context) (string, error)
 	MiseDataDir           string
+	ToolCache             string
 	Docker                string
 	RuntimeExecutable     string
 	Git                   string

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -2375,6 +2375,25 @@ func TestRunnerToolCacheIsPerJobAndReserved(t *testing.T) {
 	}
 }
 
+func TestRunnerUsesConfiguredToolCache(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	toolCache, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{
+		ID:      "tool-cache",
+		Kind:    "run",
+		Command: `test "$RUNNER_TOOL_CACHE" = "$EXPECTED_TOOL_CACHE"`,
+	}})
+	job.Env = map[string]string{"EXPECTED_TOOL_CACHE": toolCache}
+	if result, err := (Runner{ToolCache: toolCache}).RunJob(context.Background(), job, workspace); err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+}
+
 func TestUbuntuImageOS(t *testing.T) {
 	for _, test := range []struct {
 		name   string


### PR DESCRIPTION
## Why

The new opt-in Hosted toolchain images provide an image-baked `/opt/hostedtoolcache`, but generated `run-job` steps cannot currently select those images or expose their trusted tool inventory to setup actions. Falling back to a persistent writable tool cache would weaken the executable-cache boundary because setup actions trust entries and completion markers without verifying their contents.

## What

- let importers select one runtime image with `BUILDKITE_GHA_RUNTIME_IMAGE`
- require an immutable registry digest and emit it as the `image` for every generated workflow job
- point `RUNNER_TOOL_CACHE` at `/opt/hostedtoolcache` only through the compiler-emitted `--hosted-tool-cache` runtime mode
- validate the selected cache root while preserving the existing fresh job-private cache when no image is configured
- document the opt-in contract and the Jammy toolchain image example

## Validation

- `mise run check`