### PR TITLE
fix: support conditional action input defaults

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -411,7 +411,7 @@ jobs:
 	})
 }
 
-func TestUploadRejectsUnsupportedEffectiveActionInputDefaultBeforeBuildkiteCalls(t *testing.T) {
+func TestUploadAcceptsConditionalActionInputDefault(t *testing.T) {
 	root := t.TempDir()
 	workflowPath := filepath.Join(root, ".github", "workflows", "action.yml")
 	actionRoot := filepath.Join(root, ".github", "actions", "complex-default")
@@ -421,7 +421,7 @@ func TestUploadRejectsUnsupportedEffectiveActionInputDefaultBeforeBuildkiteCalls
 	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(workflowPath, []byte("on: push\njobs:\n  action:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: ./.github/actions/complex-default\n"), 0o600); err != nil {
+	if err := os.WriteFile(workflowPath, []byte("on: push\npermissions:\n  contents: read\njobs:\n  action:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: ./.github/actions/complex-default\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(actionRoot, "action.yml"), []byte(`name: complex default
@@ -443,16 +443,11 @@ runs:
 	runner := &cliCaptureRunner{}
 	var stdout, stderr bytes.Buffer
 	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
-	if code := run([]string{"upload", "--event-path", eventPath, workflowPath}, &stdout, &stderr, "dev", runner); code != 1 {
+	if code := run([]string{"upload", "--event-path", eventPath, workflowPath}, &stdout, &stderr, "dev", runner); code != 0 {
 		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
 	}
-	for _, want := range []string{`compile action "./.github/actions/complex-default"`, `action input "token" default`, "requires a direct context reference"} {
-		if !strings.Contains(stderr.String(), want) {
-			t.Fatalf("stderr = %q, want %q", stderr.String(), want)
-		}
-	}
-	if len(runner.commands) != 0 {
-		t.Fatalf("unsupported action default made Buildkite calls: %#v", runner.commands)
+	if len(runner.commands) == 0 {
+		t.Fatal("conditional action default did not upload a pipeline")
 	}
 }
 

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -212,7 +212,7 @@ func (n *actionNode) inspectInvocation(supplied map[string]string) (actionRequir
 		if input.Default == nil || hasActionInput(supplied, name) {
 			continue
 		}
-		if err := expression.ValidateRuntimeTemplate(*input.Default); err != nil {
+		if err := expression.ValidateActionInputDefault(*input.Default); err != nil {
 			return actionRequirements{}, fmt.Errorf("action input %q default: %w", name, err)
 		}
 		referencesToken, err := expression.ReferencesGitHubToken(*input.Default)

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -213,7 +213,7 @@ runs:
 		{name: "explicit empty input", ref: "./token", supplied: map[string]string{"github_token": ""}},
 		{name: "case-insensitive explicit input", ref: "./token", supplied: map[string]string{"GITHUB_TOKEN": "explicit"}},
 		{name: "unrelated GitHub default", ref: "./actor"},
-		{name: "unsupported complex default", ref: "./complex", wantErr: `compile action "./complex": action input "token" default: runtime interpolation requires a direct context reference`},
+		{name: "conditional token default", ref: "./complex", want: true},
 		{name: "explicit input bypasses default", ref: "./complex", supplied: map[string]string{"token": ""}},
 		{name: "dynamic GitHub index", ref: "./dynamic", wantErr: "index must be a string literal"},
 		{name: "token before dynamic GitHub index", ref: "./mixed", wantErr: "index must be a string literal"},
@@ -236,7 +236,7 @@ runs:
 	}
 }
 
-func TestCompileActionInvocationsValidatesResolvedRemoteDefaults(t *testing.T) {
+func TestCompileActionInvocationsAcceptsResolvedRemoteConditionalDefaults(t *testing.T) {
 	workspace, remote := t.TempDir(), t.TempDir()
 	writeAction(t, remote, "", `name: complex remote default
 inputs:
@@ -247,9 +247,12 @@ runs:
   main: index.js
 `)
 	actionSource := &fakeActionSource{root: remote, calls: map[string]int{}}
-	_, err := compileActionInvocations(context.Background(), workspace, actionSource, []string{"owner/action@v1"}, []map[string]string{nil})
-	if err == nil || !strings.Contains(err.Error(), `compile action "owner/action@v1": action input "token" default`) || !strings.Contains(err.Error(), "requires a direct context reference") {
-		t.Fatalf("compileActionInvocations() error = %v, want resolved remote default rejection", err)
+	compiled, err := compileActionInvocations(context.Background(), workspace, actionSource, []string{"owner/action@v1"}, []map[string]string{nil})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !compiled.requiresGitHubToken {
+		t.Fatal("conditional remote action default did not require a GitHub token")
 	}
 	if actionSource.calls["owner/action@v1"] != 1 {
 		t.Fatalf("remote action resolutions = %#v, want one", actionSource.calls)

--- a/internal/expression/expression.go
+++ b/internal/expression/expression.go
@@ -147,10 +147,17 @@ func ReferencePath(text string) (string, []string, error) {
 }
 
 // ValidateRuntimeTemplate verifies that every expression in a runtime template
-// has a reference shape supported by Evaluate. Runtime values are deliberately
-// not resolved because many contexts do not exist until a job or step runs.
+// has a shape supported by Evaluate. Runtime values are deliberately not
+// resolved because many contexts do not exist until a job or step runs.
 func ValidateRuntimeTemplate(template string) error {
-	return visitTemplateExpressions(template, func(node actionlint.ExprNode) error {
+	return visitTemplateExpressions(template, validateRuntimeNode)
+}
+
+func validateRuntimeNode(node actionlint.ExprNode) error {
+	switch node := node.(type) {
+	case *actionlint.NullNode, *actionlint.BoolNode, *actionlint.IntNode, *actionlint.FloatNode, *actionlint.StringNode:
+		return nil
+	case *actionlint.VariableNode, *actionlint.ObjectDerefNode, *actionlint.IndexAccessNode:
 		root, path, err := referencePath(node)
 		if err != nil {
 			return fmt.Errorf("runtime interpolation requires a direct context reference: %w", err)
@@ -159,7 +166,22 @@ func ValidateRuntimeTemplate(template string) error {
 			return fmt.Errorf("unsupported runtime expression %q", referenceName(root, path))
 		}
 		return nil
-	})
+	case *actionlint.LogicalOpNode:
+		if err := validateRuntimeNode(node.Left); err != nil {
+			return err
+		}
+		return validateRuntimeNode(node.Right)
+	case *actionlint.CompareOpNode:
+		if !node.Kind.IsEqualityOp() {
+			return fmt.Errorf("runtime interpolation comparison %s is unsupported", node.Kind)
+		}
+		if err := validateRuntimeNode(node.Left); err != nil {
+			return err
+		}
+		return validateRuntimeNode(node.Right)
+	default:
+		return fmt.Errorf("runtime interpolation expression is unsupported")
+	}
 }
 
 // EvaluateCompile evaluates one complete graph-time expression. The supported
@@ -987,7 +1009,7 @@ func Evaluate(template string, context Context) (string, error) {
 			return "", fmt.Errorf("unterminated expression in %q", template)
 		}
 		end += start + len(open)
-		replacement, err := evaluateReference(strings.TrimSpace(remaining[start+len(open):end]), context)
+		replacement, err := evaluateRuntimeExpression(strings.TrimSpace(remaining[start+len(open):end]), context)
 		if err != nil {
 			return "", err
 		}
@@ -996,15 +1018,85 @@ func Evaluate(template string, context Context) (string, error) {
 	}
 }
 
-func evaluateReference(reference string, context Context) (string, error) {
-	node, parseErr := actionlint.NewExprParser().Parse(actionlint.NewExprLexer(reference + "}}"))
+func evaluateRuntimeExpression(source string, context Context) (string, error) {
+	node, parseErr := actionlint.NewExprParser().Parse(actionlint.NewExprLexer(source + "}}"))
 	if parseErr != nil {
 		return "", fmt.Errorf("invalid expression: %w", parseErr)
 	}
-	root, path, err := referencePath(node)
+	value, err := evaluateRuntimeNode(node, context)
 	if err != nil {
 		return "", err
 	}
+	switch value := value.(type) {
+	case nil:
+		return "", nil
+	case string:
+		return value, nil
+	default:
+		return fmt.Sprint(value), nil
+	}
+}
+
+func evaluateRuntimeNode(node actionlint.ExprNode, context Context) (any, error) {
+	switch node := node.(type) {
+	case *actionlint.NullNode:
+		return nil, nil
+	case *actionlint.BoolNode:
+		return node.Value, nil
+	case *actionlint.IntNode:
+		return node.Value, nil
+	case *actionlint.FloatNode:
+		return node.Value, nil
+	case *actionlint.StringNode:
+		return node.Value, nil
+	case *actionlint.VariableNode, *actionlint.ObjectDerefNode, *actionlint.IndexAccessNode:
+		root, path, err := referencePath(node)
+		if err != nil {
+			return nil, err
+		}
+		return resolveRuntimeReference(root, path, context)
+	case *actionlint.LogicalOpNode:
+		left, err := evaluateRuntimeNode(node.Left, context)
+		if err != nil {
+			return nil, err
+		}
+		if node.Kind == actionlint.LogicalOpNodeKindAnd {
+			if !conditionTruthy(left) {
+				return left, nil
+			}
+			return evaluateRuntimeNode(node.Right, context)
+		}
+		if conditionTruthy(left) {
+			return left, nil
+		}
+		return evaluateRuntimeNode(node.Right, context)
+	case *actionlint.CompareOpNode:
+		left, err := evaluateRuntimeNode(node.Left, context)
+		if err != nil {
+			return nil, err
+		}
+		right, err := evaluateRuntimeNode(node.Right, context)
+		if err != nil {
+			return nil, err
+		}
+		equal, err := conditionEqual(left, right)
+		if err != nil {
+			return nil, err
+		}
+		switch node.Kind {
+		case actionlint.CompareOpNodeKindEq:
+			return equal, nil
+		case actionlint.CompareOpNodeKindNotEq:
+			return !equal, nil
+		default:
+			return nil, fmt.Errorf("runtime interpolation comparison %s is unsupported", node.Kind)
+		}
+	default:
+		return nil, fmt.Errorf("runtime interpolation expression is unsupported")
+	}
+}
+
+func resolveRuntimeReference(root string, path []string, context Context) (any, error) {
 	switch classifyRuntimeReference(root, path) {
 	case runtimeReferenceServicePort:
 		return resolveServicePort(context.Services, path[1], path[3], "expression")
@@ -1013,13 +1105,13 @@ func evaluateReference(reference string, context Context) (string, error) {
 		if !ok {
 			return "", fmt.Errorf("expression references unavailable github value %q", strings.Join(path, "."))
 		}
-		return fmt.Sprint(value), nil
+		return value, nil
 	case runtimeReferenceInput:
 		return findString(context.Inputs, path[0]), nil
 	case runtimeReferenceMatrix:
 		for name, value := range context.Matrix {
 			if strings.EqualFold(name, path[0]) {
-				return fmt.Sprint(value), nil
+				return value, nil
 			}
 		}
 		return "", fmt.Errorf("expression references unavailable matrix value %q", path[0])
@@ -1062,7 +1154,7 @@ func evaluateReference(reference string, context Context) (string, error) {
 		}
 		return "", fmt.Errorf("expression references unavailable need %q", path[0])
 	default:
-		return "", fmt.Errorf("unsupported expression %q", reference)
+		return nil, fmt.Errorf("unsupported expression %q", referenceName(root, path))
 	}
 }
 

--- a/internal/expression/expression.go
+++ b/internal/expression/expression.go
@@ -147,13 +147,29 @@ func ReferencePath(text string) (string, []string, error) {
 }
 
 // ValidateRuntimeTemplate verifies that every expression in a runtime template
-// has a shape supported by Evaluate. Runtime values are deliberately not
-// resolved because many contexts do not exist until a job or step runs.
+// is one direct reference supported by Evaluate. Runtime values are
+// deliberately not resolved because many contexts do not exist until a job or
+// step runs.
 func ValidateRuntimeTemplate(template string) error {
-	return visitTemplateExpressions(template, validateRuntimeNode)
+	return visitTemplateExpressions(template, func(node actionlint.ExprNode) error {
+		root, path, err := referencePath(node)
+		if err != nil {
+			return fmt.Errorf("runtime interpolation requires a direct context reference: %w", err)
+		}
+		if classifyRuntimeReference(root, path) == runtimeReferenceUnsupported {
+			return fmt.Errorf("unsupported runtime expression %q", referenceName(root, path))
+		}
+		return nil
+	})
 }
 
-func validateRuntimeNode(node actionlint.ExprNode) error {
+// ValidateActionInputDefault verifies the restricted compound expression
+// surface supported only while evaluating action metadata input defaults.
+func ValidateActionInputDefault(template string) error {
+	return visitTemplateExpressions(template, validateActionInputDefaultNode)
+}
+
+func validateActionInputDefaultNode(node actionlint.ExprNode) error {
 	switch node := node.(type) {
 	case *actionlint.NullNode, *actionlint.BoolNode, *actionlint.IntNode, *actionlint.FloatNode, *actionlint.StringNode:
 		return nil
@@ -167,20 +183,20 @@ func validateRuntimeNode(node actionlint.ExprNode) error {
 		}
 		return nil
 	case *actionlint.LogicalOpNode:
-		if err := validateRuntimeNode(node.Left); err != nil {
+		if err := validateActionInputDefaultNode(node.Left); err != nil {
 			return err
 		}
-		return validateRuntimeNode(node.Right)
+		return validateActionInputDefaultNode(node.Right)
 	case *actionlint.CompareOpNode:
 		if !node.Kind.IsEqualityOp() {
-			return fmt.Errorf("runtime interpolation comparison %s is unsupported", node.Kind)
+			return fmt.Errorf("action input default comparison %s is unsupported", node.Kind)
 		}
-		if err := validateRuntimeNode(node.Left); err != nil {
+		if err := validateActionInputDefaultNode(node.Left); err != nil {
 			return err
 		}
-		return validateRuntimeNode(node.Right)
+		return validateActionInputDefaultNode(node.Right)
 	default:
-		return fmt.Errorf("runtime interpolation expression is unsupported")
+		return fmt.Errorf("action input default expression is unsupported")
 	}
 }
 
@@ -992,9 +1008,19 @@ func decodeJSONValue(source string) (any, error) {
 	return value, nil
 }
 
-// Evaluate substitutes the supported Phase 0 expressions in a template once.
+// Evaluate substitutes direct runtime references in a template once.
 func Evaluate(template string, context Context) (string, error) {
-	const open, close = "${{", "}}"
+	return evaluateRuntimeTemplate(template, context, evaluateDirectRuntimeNode)
+}
+
+// EvaluateActionInputDefault substitutes the restricted compound expressions
+// supported only in action metadata input defaults.
+func EvaluateActionInputDefault(template string, context Context) (string, error) {
+	return evaluateRuntimeTemplate(template, context, evaluateActionInputDefaultNode)
+}
+
+func evaluateRuntimeTemplate(template string, context Context, evaluate func(actionlint.ExprNode, Context) (any, error)) (string, error) {
+	const open = "${{"
 	var evaluated strings.Builder
 	remaining := template
 	for {
@@ -1004,40 +1030,42 @@ func Evaluate(template string, context Context) (string, error) {
 			return evaluated.String(), nil
 		}
 		evaluated.WriteString(remaining[:start])
-		end := strings.Index(remaining[start+len(open):], close)
-		if end < 0 {
-			return "", fmt.Errorf("unterminated expression in %q", template)
+		source := remaining[start+len(open):]
+		_, consumed, lexErr := actionlint.LexExpression(source)
+		if lexErr != nil {
+			if !strings.Contains(source, "}}") {
+				return "", fmt.Errorf("unterminated expression in %q", template)
+			}
+			return "", fmt.Errorf("invalid expression: %w", lexErr)
 		}
-		end += start + len(open)
-		replacement, err := evaluateRuntimeExpression(strings.TrimSpace(remaining[start+len(open):end]), context)
+		node, parseErr := actionlint.NewExprParser().Parse(actionlint.NewExprLexer(source[:consumed]))
+		if parseErr != nil {
+			return "", fmt.Errorf("invalid expression: %w", parseErr)
+		}
+		value, err := evaluate(node, context)
 		if err != nil {
 			return "", err
 		}
-		evaluated.WriteString(replacement)
-		remaining = remaining[end+len(close):]
+		switch value := value.(type) {
+		case nil:
+		case string:
+			evaluated.WriteString(value)
+		default:
+			_, _ = fmt.Fprint(&evaluated, value)
+		}
+		remaining = source[consumed:]
 	}
 }
 
-func evaluateRuntimeExpression(source string, context Context) (string, error) {
-	node, parseErr := actionlint.NewExprParser().Parse(actionlint.NewExprLexer(source + "}}"))
-	if parseErr != nil {
-		return "", fmt.Errorf("invalid expression: %w", parseErr)
-	}
-	value, err := evaluateRuntimeNode(node, context)
+func evaluateDirectRuntimeNode(node actionlint.ExprNode, context Context) (any, error) {
+	root, path, err := referencePath(node)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	switch value := value.(type) {
-	case nil:
-		return "", nil
-	case string:
-		return value, nil
-	default:
-		return fmt.Sprint(value), nil
-	}
+	return resolveRuntimeReference(root, path, context)
 }
 
-func evaluateRuntimeNode(node actionlint.ExprNode, context Context) (any, error) {
+func evaluateActionInputDefaultNode(node actionlint.ExprNode, context Context) (any, error) {
 	switch node := node.(type) {
 	case *actionlint.NullNode:
 		return nil, nil
@@ -1050,49 +1078,119 @@ func evaluateRuntimeNode(node actionlint.ExprNode, context Context) (any, error)
 	case *actionlint.StringNode:
 		return node.Value, nil
 	case *actionlint.VariableNode, *actionlint.ObjectDerefNode, *actionlint.IndexAccessNode:
-		root, path, err := referencePath(node)
-		if err != nil {
-			return nil, err
-		}
-		return resolveRuntimeReference(root, path, context)
+		return evaluateDirectRuntimeNode(node, context)
 	case *actionlint.LogicalOpNode:
-		left, err := evaluateRuntimeNode(node.Left, context)
+		left, err := evaluateActionInputDefaultNode(node.Left, context)
 		if err != nil {
 			return nil, err
 		}
-		if node.Kind == actionlint.LogicalOpNodeKindAnd {
-			if !conditionTruthy(left) {
+		switch node.Kind {
+		case actionlint.LogicalOpNodeKindAnd:
+			if !actionInputDefaultTruthy(left) {
 				return left, nil
 			}
-			return evaluateRuntimeNode(node.Right, context)
+			return evaluateActionInputDefaultNode(node.Right, context)
+		case actionlint.LogicalOpNodeKindOr:
+			if actionInputDefaultTruthy(left) {
+				return left, nil
+			}
+			return evaluateActionInputDefaultNode(node.Right, context)
+		default:
+			return nil, fmt.Errorf("action input default logical operator %s is unsupported", node.Kind)
 		}
-		if conditionTruthy(left) {
-			return left, nil
-		}
-		return evaluateRuntimeNode(node.Right, context)
 	case *actionlint.CompareOpNode:
-		left, err := evaluateRuntimeNode(node.Left, context)
+		left, err := evaluateActionInputDefaultNode(node.Left, context)
 		if err != nil {
 			return nil, err
 		}
-		right, err := evaluateRuntimeNode(node.Right, context)
+		right, err := evaluateActionInputDefaultNode(node.Right, context)
 		if err != nil {
 			return nil, err
 		}
-		equal, err := conditionEqual(left, right)
-		if err != nil {
-			return nil, err
-		}
+		equal := actionInputDefaultEqual(left, right)
 		switch node.Kind {
 		case actionlint.CompareOpNodeKindEq:
 			return equal, nil
 		case actionlint.CompareOpNodeKindNotEq:
 			return !equal, nil
 		default:
-			return nil, fmt.Errorf("runtime interpolation comparison %s is unsupported", node.Kind)
+			return nil, fmt.Errorf("action input default comparison %s is unsupported", node.Kind)
 		}
 	default:
-		return nil, fmt.Errorf("runtime interpolation expression is unsupported")
+		return nil, fmt.Errorf("action input default expression is unsupported")
+	}
+}
+
+func actionInputDefaultTruthy(value any) bool {
+	switch value := value.(type) {
+	case nil:
+		return false
+	case bool:
+		return value
+	case string:
+		return value != ""
+	}
+	if number, ok := conditionNumber(value); ok {
+		return number.Sign() != 0
+	}
+	return true
+}
+
+func actionInputDefaultEqual(left, right any) bool {
+	if left == nil && right == nil {
+		return true
+	}
+	if leftNumber, leftOK := conditionNumber(left); leftOK {
+		if rightNumber, rightOK := conditionNumber(right); rightOK {
+			return leftNumber.Cmp(rightNumber) == 0
+		}
+	}
+	switch left := left.(type) {
+	case string:
+		if right, ok := right.(string); ok {
+			return strings.EqualFold(left, right)
+		}
+	case bool:
+		if right, ok := right.(bool); ok {
+			return left == right
+		}
+	}
+	if left != nil && right != nil && reflect.TypeOf(left) == reflect.TypeOf(right) {
+		leftValue, rightValue := reflect.ValueOf(left), reflect.ValueOf(right)
+		switch leftValue.Kind() {
+		case reflect.Map, reflect.Pointer, reflect.Slice:
+			return leftValue.Pointer() == rightValue.Pointer()
+		}
+	}
+	leftNumber, leftOK := actionInputDefaultNumber(left)
+	rightNumber, rightOK := actionInputDefaultNumber(right)
+	return leftOK && rightOK && leftNumber.Cmp(rightNumber) == 0
+}
+
+func actionInputDefaultNumber(value any) (*big.Rat, bool) {
+	switch value := value.(type) {
+	case nil:
+		return new(big.Rat), true
+	case bool:
+		if value {
+			return big.NewRat(1, 1), true
+		}
+		return new(big.Rat), true
+	case string:
+		if strings.TrimSpace(value) == "" {
+			return new(big.Rat), true
+		}
+		decoded, err := decodeJSONValue(value)
+		if err != nil {
+			return nil, false
+		}
+		number, ok := decoded.(json.Number)
+		if !ok {
+			return nil, false
+		}
+		return conditionNumber(number)
+	default:
+		return conditionNumber(value)
 	}
 }
 

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -67,7 +67,6 @@ func TestValidateRuntimeTemplateMatchesEvaluateReferenceGrammar(t *testing.T) {
 		"${{ needs.build.outputs.release }}",
 		"${{ needs.build.result }}",
 		"${{ job.services.redis.ports[6379] }}",
-		"${{ github.server_url == 'https://github.com' && github.token || '' }}",
 		"prefix-${{ github.actor }}-${{ matrix.version }}",
 	} {
 		t.Run(template, func(t *testing.T) {
@@ -81,7 +80,8 @@ func TestValidateRuntimeTemplateMatchesEvaluateReferenceGrammar(t *testing.T) {
 		template string
 		want     string
 	}{
-		{template: "${{ hashFiles('go.sum') }}", want: "expression is unsupported"},
+		{template: "${{ github.server_url == 'https://github.com' && github.token || '' }}", want: "requires a direct context reference"},
+		{template: "${{ hashFiles('go.sum') }}", want: "requires a direct context reference"},
 		{template: "${{ github }}", want: `unsupported runtime expression "github"`},
 		{template: "${{ steps.build.status }}", want: `unsupported runtime expression "steps.build.status"`},
 		{template: "${{ github[env.NAME] }}", want: "index must be a string literal"},
@@ -96,7 +96,23 @@ func TestValidateRuntimeTemplateMatchesEvaluateReferenceGrammar(t *testing.T) {
 	}
 }
 
-func TestEvaluateSupportsConditionalValueExpressions(t *testing.T) {
+func TestValidateActionInputDefaultSupportsRestrictedCompoundExpressions(t *testing.T) {
+	for _, template := range []string{
+		"${{ github.server_url == 'https://github.com' && github.token || '' }}",
+		"${{ true && 'quoted }} braces' || '' }}",
+	} {
+		if err := ValidateActionInputDefault(template); err != nil {
+			t.Errorf("ValidateActionInputDefault(%q) error = %v", template, err)
+		}
+	}
+	for _, template := range []string{"${{ hashFiles('go.sum') }}", "${{ 1 > 0 }}", "${{ github[env.NAME] }}"} {
+		if err := ValidateActionInputDefault(template); err == nil {
+			t.Errorf("ValidateActionInputDefault(%q) unexpectedly succeeded", template)
+		}
+	}
+}
+
+func TestEvaluateActionInputDefaultSupportsConditionalValueExpressions(t *testing.T) {
 	template := "${{ github.server_url == 'https://github.com' && github.token || '' }}"
 	for _, test := range []struct {
 		name    string
@@ -110,7 +126,7 @@ func TestEvaluateSupportsConditionalValueExpressions(t *testing.T) {
 		{name: "GitHub.com missing token", github: map[string]any{"server_url": "https://github.com"}, wantErr: `unavailable github value "token"`},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := Evaluate(template, Context{GitHub: test.github})
+			got, err := EvaluateActionInputDefault(template, Context{GitHub: test.github})
 			if test.wantErr != "" {
 				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
 					t.Fatalf("Evaluate() error = %v, want %q", err, test.wantErr)
@@ -119,6 +135,34 @@ func TestEvaluateSupportsConditionalValueExpressions(t *testing.T) {
 			}
 			if err != nil || got != test.want {
 				t.Fatalf("Evaluate() = %q, %v, want %q", got, err, test.want)
+			}
+		})
+	}
+	if _, err := Evaluate(template, Context{}); err == nil {
+		t.Fatal("Evaluate() accepted action-default compound expression outside action metadata")
+	}
+}
+
+func TestEvaluateActionInputDefaultMatchesGitHubEqualityAndTemplateBoundaries(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		template string
+		context  Context
+		want     string
+	}{
+		{name: "quoted closing delimiter", template: "${{ true && 'quoted }} braces' || '' }}", want: "quoted }} braces"},
+		{name: "numeric string", template: "${{ matrix.version == '20' && 'yes' || 'no' }}", context: Context{Matrix: map[string]any{"version": 20}}, want: "yes"},
+		{name: "null and zero", template: "${{ null == 0 && 'yes' || 'no' }}", want: "yes"},
+		{name: "false and zero", template: "${{ false == 0 && 'yes' || 'no' }}", want: "yes"},
+		{name: "empty string and zero", template: "${{ '' == 0 && 'yes' || 'no' }}", want: "yes"},
+		{name: "not equal", template: "${{ 'not-a-number' != 0 && 'yes' || 'no' }}", want: "yes"},
+		{name: "falsy zero", template: "${{ 0 && 'yes' || 'no' }}", want: "no"},
+		{name: "truthy short circuit", template: "${{ 'fallback' || github.missing }}", want: "fallback"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := EvaluateActionInputDefault(test.template, test.context)
+			if err != nil || got != test.want {
+				t.Fatalf("EvaluateActionInputDefault() = %q, %v, want %q", got, err, test.want)
 			}
 		})
 	}

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -67,6 +67,7 @@ func TestValidateRuntimeTemplateMatchesEvaluateReferenceGrammar(t *testing.T) {
 		"${{ needs.build.outputs.release }}",
 		"${{ needs.build.result }}",
 		"${{ job.services.redis.ports[6379] }}",
+		"${{ github.server_url == 'https://github.com' && github.token || '' }}",
 		"prefix-${{ github.actor }}-${{ matrix.version }}",
 	} {
 		t.Run(template, func(t *testing.T) {
@@ -80,8 +81,7 @@ func TestValidateRuntimeTemplateMatchesEvaluateReferenceGrammar(t *testing.T) {
 		template string
 		want     string
 	}{
-		{template: "${{ github.server_url == 'https://github.com' && github.token || '' }}", want: "requires a direct context reference"},
-		{template: "${{ hashFiles('go.sum') }}", want: "requires a direct context reference"},
+		{template: "${{ hashFiles('go.sum') }}", want: "expression is unsupported"},
 		{template: "${{ github }}", want: `unsupported runtime expression "github"`},
 		{template: "${{ steps.build.status }}", want: `unsupported runtime expression "steps.build.status"`},
 		{template: "${{ github[env.NAME] }}", want: "index must be a string literal"},
@@ -96,11 +96,39 @@ func TestValidateRuntimeTemplateMatchesEvaluateReferenceGrammar(t *testing.T) {
 	}
 }
 
+func TestEvaluateSupportsConditionalValueExpressions(t *testing.T) {
+	template := "${{ github.server_url == 'https://github.com' && github.token || '' }}"
+	for _, test := range []struct {
+		name    string
+		github  map[string]any
+		want    string
+		wantErr string
+	}{
+		{name: "GitHub.com token", github: map[string]any{"server_url": "https://github.com", "token": "ghs_scoped"}, want: "ghs_scoped"},
+		{name: "case insensitive URL", github: map[string]any{"server_url": "HTTPS://GITHUB.COM", "token": "ghs_scoped"}, want: "ghs_scoped"},
+		{name: "GHES empty token", github: map[string]any{"server_url": "https://github.example.com"}},
+		{name: "GitHub.com missing token", github: map[string]any{"server_url": "https://github.com"}, wantErr: `unavailable github value "token"`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := Evaluate(template, Context{GitHub: test.github})
+			if test.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+					t.Fatalf("Evaluate() error = %v, want %q", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil || got != test.want {
+				t.Fatalf("Evaluate() = %q, %v, want %q", got, err, test.want)
+			}
+		})
+	}
+}
+
 func TestEvaluateIsSinglePass(t *testing.T) {
 	literal := "literal ${{ matrix.secret }} and ${{"
 	context := Context{
 		Inputs:       map[string]string{"value": literal},
-		Matrix:       map[string]any{"value": literal, "secret": "reevaluated"},
+		Matrix:       map[string]any{"value": literal, "secret": "reevaluated", "number": json.Number("1e3")},
 		Steps:        map[string]map[string]string{"producer": {"value": literal}},
 		StepStatuses: map[string]StepStatus{"producer": {Outcome: "failure", Conclusion: "success"}},
 		Needs:        map[string]map[string]string{"producer": {"value": literal}},
@@ -114,6 +142,7 @@ func TestEvaluateIsSinglePass(t *testing.T) {
 		"${{ steps.Producer.conclusion }}":    "success",
 		"${{ needs.Producer.outputs.value }}": literal,
 		"${{ needs.Producer.result }}":        "success",
+		"${{ matrix.number }}":                "1e3",
 		"before ${{ inputs.value }} after":    "before " + literal + " after",
 	}
 	for template, want := range tests {

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -1454,7 +1454,7 @@ func resolveActionInputs(action metadata.Metadata, supplied map[string]string, c
 		}
 		if definition.Default != nil {
 			defaultContext.Inputs = inputs
-			value, err := expression.Evaluate(*definition.Default, defaultContext)
+			value, err := expression.EvaluateActionInputDefault(*definition.Default, defaultContext)
 			if err != nil {
 				return nil, fmt.Errorf("action input %q default: %w", name, err)
 			}

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -720,6 +720,7 @@ func githubContext(job plan.Job) map[string]any {
 		"sha":        job.Event.SHA,
 		"actor":      job.Event.Actor,
 		"event_name": job.Event.Name,
+		"server_url": "https://github.com",
 	}
 }
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1999,13 +1999,15 @@ func TestRunJobMintsAndRedactsScopedGitHubWorkflowToken(t *testing.T) {
 
 func TestResolveActionInputsExposesScopedTokenOnlyToMetadataDefaults(t *testing.T) {
 	tokenDefault := "${{ github.token }}"
+	conditionalTokenDefault := "${{ github.server_url == 'https://github.com' && github.token || '' }}"
 	actorDefault := "${{ github.actor }}"
 	action := metadata.Metadata{Inputs: map[string]metadata.Input{
-		"github_token": {Default: &tokenDefault},
-		"actor":        {Default: &actorDefault},
+		"github_token":      {Default: &tokenDefault},
+		"conditional_token": {Default: &conditionalTokenDefault},
+		"actor":             {Default: &actorDefault},
 	}}
 	eval := expression.Context{
-		GitHub:  map[string]any{"actor": "octocat"},
+		GitHub:  map[string]any{"actor": "octocat", "server_url": "https://github.com"},
 		Secrets: map[string]string{"GITHUB_TOKEN": "ghs_scoped_action_default"},
 	}
 
@@ -2013,7 +2015,7 @@ func TestResolveActionInputsExposesScopedTokenOnlyToMetadataDefaults(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(inputs, map[string]string{"github_token": "ghs_scoped_action_default", "actor": "octocat"}) {
+	if !reflect.DeepEqual(inputs, map[string]string{"github_token": "ghs_scoped_action_default", "conditional_token": "ghs_scoped_action_default", "actor": "octocat"}) {
 		t.Fatalf("resolved action inputs = %#v", inputs)
 	}
 	if _, leaked := eval.GitHub["token"]; leaked {
@@ -2035,6 +2037,14 @@ func TestResolveActionInputsExposesScopedTokenOnlyToMetadataDefaults(t *testing.
 	withoutToken.Secrets = nil
 	if _, err := resolveActionInputs(action, nil, withoutToken); err == nil || !strings.Contains(err.Error(), `unavailable github value "token"`) {
 		t.Fatalf("unplanned metadata github.token evaluation error = %v, want unavailable value", err)
+	}
+	ghesAction := metadata.Metadata{Inputs: map[string]metadata.Input{"token": {Default: &conditionalTokenDefault}}}
+	ghes := eval
+	ghes.GitHub = map[string]any{"server_url": "https://github.example.com"}
+	ghes.Secrets = nil
+	inputs, err = resolveActionInputs(ghesAction, nil, ghes)
+	if err != nil || inputs["token"] != "" {
+		t.Fatalf("GHES conditional token input = %#v, %v, want empty token", inputs, err)
 	}
 }
 
@@ -2085,7 +2095,7 @@ jobs:
 	writeFixtureFile(t, workspace, ".github/actions/token/action.yml", `name: token default
 inputs:
   github_token:
-    default: ${{ github.token }}
+    default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
 runs:
   using: node24
   main: dist/index.js


### PR DESCRIPTION
## Why

Pinned `actions/setup-node` metadata uses a conditional token default. The importer only accepted direct context references, so it rejected valid workflows using this action.

## What

- Support literals, equality comparisons, and value-preserving short-circuit `&&` / `||` expressions specifically in action metadata input defaults.
- Expose `github.server_url` in the runtime GitHub context.
- Keep workflow-authored runtime interpolation limited to direct references.
- Continue detecting `github.token` references so permission planning remains explicit and fail-closed.

## How

Action defaults use a dedicated validator and evaluator with lexer-aware expression boundaries, GitHub-compatible loose equality, and short-circuit behavior. Regression coverage verifies remote action import, quoted delimiters, mixed-type equality, GitHub.com token resolution, GHES empty-token behavior, CLI upload, and end-to-end action execution.