### PR TITLE
Provide a default scoped GitHub token

### DIFF
--- a/docs/architecture/0003-protected-capability-control-plane.md
+++ b/docs/architecture/0003-protected-capability-control-plane.md
@@ -254,11 +254,13 @@ job's Agent credential is not placed in plans.
 
 A second bounded integration uses the scoped-token endpoint for a synthetic
 `secrets.GITHUB_TOKEN` or an action metadata input default that references
-`github.token`. A workflow must declare an explicit, non-empty permission
-mapping and either statically reference that exact secret or invoke an action
-whose effective default statically references the token. The compiler emits the
-API-normalized permission map into a v6 plan, adds `provider-token-write`, and
-records same-process `workflow-permissions` provenance. Upload admission accepts
+`github.token`. An omitted permission mapping receives the product's narrow
+`contents: read` default; an explicit mapping must remain non-empty after `none`
+entries are removed. The workflow must either statically reference that exact
+secret or invoke an action whose effective default statically references the
+token. The compiler emits the API-normalized permission map into a v6 plan,
+adds `provider-token-write`, and records same-process `effective-permissions`
+provenance. Upload admission accepts
 only that exact compiler provenance. A serialized plan cannot self-authorize
 the capability.
 
@@ -267,8 +269,8 @@ permission map. It validates both independently, masks the returned token, and
 requires Agent redaction registration before making the synthetic secret
 available to expression evaluation. Job-level permissions replace workflow
 defaults; flattened local reusable workflows can only narrow caller authority.
-Permission aliases, implicit defaults, empty grants, and `id-token` fail
-closed. `github.token` is exposed only while evaluating effective action
+Permission aliases, empty grants, and `id-token` fail closed. `github.token` is
+exposed only while evaluating effective action
 metadata input defaults; workflow-authored references and automatic ambient
 `GITHUB_TOKEN` environment injection remain unsupported. As on GitHub Runner,
 an action that receives the token may explicitly propagate it to later steps

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -86,7 +86,7 @@ service.
 | Timeouts and `continue-on-error` | Supported subset | Literal step/job timeouts up to 360 minutes and step-level `continue-on-error` are supported. Expression-valued settings and job-level `continue-on-error` are not supported. |
 | Workflow and job concurrency | Supported subset | Statically resolvable groups become repository-scoped, case-insensitive Buildkite concurrency groups. Workflow groups use an ordered opening/closing gate; job groups use `concurrency: 1`. Buildkite queues all waiting entries instead of replacing GitHub's pending entry. Workflow-level literal `cancel-in-progress: true` emits a warning but does not cancel; job-level true and expression-valued cancellation are not supported. |
 | Local reusable workflows | Supported subset | Statically resolvable `./.github/workflows/...` calls, typed static inputs, nesting, caller-visible aggregate results, and declared outputs mapped directly from `jobs.<job>.outputs.<name>` are supported. Literal/compound output mappings, call-level conditions, call secrets, remote source, dynamic paths/inputs/matrices, and called-workflow top-level concurrency are not supported. |
-| `permissions` | Supported subset | Explicit canonical permission maps are carried only for a statically referenced `secrets.GITHUB_TOKEN` or an effective action metadata input default that statically references `github.token`; job permissions replace workflow permissions and local reusable workflows may narrow them. Implicit defaults, `{}`, `read-all`, `write-all`, and `id-token` do not grant authority. |
+| `permissions` | Supported subset | Canonical permission maps are carried only for a statically referenced `secrets.GITHUB_TOKEN` or an effective action metadata input default that statically references `github.token`. Omitted permissions use the product's narrow `contents: read` default; explicit job permissions replace workflow permissions and local reusable workflows may only narrow them. `{}`, maps containing only `none`, `read-all`, `write-all`, and `id-token` do not grant authority. |
 | Job and service containers | Not admitted | Literal Linux container images, environment, ports, persistent job containers, and services are implemented and runtime-proven. Production `hosted-tokenless` upload rejects job/service-container provenance. Credentials, volumes, arbitrary options, private images, and privileged containers are not supported. |
 | Dynamic graph expansion | Not supported | Matrices or `needs` derived from runtime outputs and other runtime-created jobs are rejected. |
 | Deployment environments and approvals | Not supported | Environment secrets, protection rules, reviewers, and deployment approval/state parity are not implemented. |
@@ -120,7 +120,7 @@ service.
 | --- | --- | --- |
 | Public GitHub repositories | Supported subset | Public event-repository checkout and public GitHub actions are supported within the source-authentication boundary above. GitHub Enterprise Server and non-GitHub repository providers are not current production sources. |
 | Private repositories | Supported subset | The event repository can be checked out when Buildkite supplies repository-provider Git credentials to the job and its backend authorizes the concrete repository URL. Alternate repositories, private actions, and private reusable workflows are not supported. |
-| `secrets.GITHUB_TOKEN` | Supported subset | A static reference can receive one short-lived token for the exact event repository when the job has a non-empty explicit permission map and the organization enables the job-bound token service. The runtime does not inject it into the initial job environment; an action may explicitly export it through `GITHUB_ENV`, as on GitHub Runner. |
+| `secrets.GITHUB_TOKEN` | Supported subset | A static reference can receive one short-lived token for the exact event repository when the job has non-empty effective permissions and the organization enables the job-bound token service. Omitted permissions use the product's narrow `contents: read` default. The runtime does not inject the token into the initial job environment; an action may explicitly export it through `GITHUB_ENV`, as on GitHub Runner. |
 | Other workflow secrets | Not admitted | The runtime has a plan-declared `BUILDKITE_GHA_SECRET_<NAME>` resolver boundary, but `hosted-tokenless` admission rejects its `secrets` capability. Reusable-workflow secret passing and environment secrets are also rejected. |
 | `github.token` and ambient `GITHUB_TOKEN` | Supported subset | `github.token` is populated only while evaluating an effective action metadata input default and uses the same scoped-token contract as `secrets.GITHUB_TOKEN`. Workflow-authored `github.token` and automatic ambient `GITHUB_TOKEN` remain unavailable. An action may explicitly export its input as `GITHUB_TOKEN` for later steps through `GITHUB_ENV`; an explicitly supplied action input, including an empty value, suppresses its metadata default. |
 | OIDC | Not supported | GitHub-compatible and migration OIDC flows, including `id-token`, are deferred. |
@@ -274,13 +274,13 @@ This checkout path does not populate
 actions, or add support for alternate repositories or refs. The deprecated
 `--private-checkout` option is temporarily accepted as a no-op for compatibility.
 
-### Explicit permissions provide a scoped workflow token
+### Effective permissions provide a scoped workflow token
 
 A job that statically references `${{ secrets.GITHUB_TOKEN }}`, or uses an
 action with an effective metadata input default that statically references
 `${{ github.token }}`, receives one short-lived GitHub installation token for
-the exact event repository when it also has a non-empty, explicit `permissions`
-mapping:
+the exact event repository. An omitted `permissions` block uses the product's
+narrow `contents: read` default; an explicit non-empty map replaces that default:
 
 ```yaml
 permissions:
@@ -298,9 +298,10 @@ jobs:
 Workflow permissions apply to jobs that omit job permissions. A job-level
 mapping replaces the workflow-level mapping rather than merging with it. Local
 reusable workflows inherit the caller's effective permissions and can only
-narrow them. `none` removes a permission. Omitted permissions, `{}`,
-`read-all`, `write-all`, and `id-token` do not produce a token; a static
-token reference without a non-empty effective mapping fails compilation.
+narrow them. `none` removes a permission. Explicit `{}` and maps containing
+only `none` do not produce a token; `read-all`, `write-all`, and `id-token` are
+unsupported. A static token reference without a non-empty effective mapping
+fails compilation.
 
 The compiler normalizes names such as `pull-requests` to the Agent API's
 `pull_requests`, emits the exact map into a v6 plan, and records same-process

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -1970,7 +1970,7 @@ the narrowest available boundary:
   repository-provider Git helper when the job enables it and anonymous Git
   otherwise, plus future Cursor Origin provider adapters;
 - compiler-admitted workflow token requests for the pipeline's exact GitHub
-  repository and explicit permission map, authorized and bounded by the
+  repository and effective permission map, authorized and bounded by the
   current-job endpoint's server-side repository and permission policy;
 - step summaries and annotations.
 
@@ -2633,13 +2633,15 @@ them in the phase that first needs the capability:
    using Buildkite defaults must independently provide suitable whole-job
    isolation. Phases 6 and 9 still own authorization and queue policy for
    protected Docker capabilities and privileged workloads.
-6. The narrow token contract is now defined for explicit
+6. The narrow token contract is now defined for static
    `secrets.GITHUB_TOKEN` references and effective action metadata input
-   defaults that reference `github.token`, with non-empty permission maps and
-   exact event-repository binding. Workflow-authored `github.token`, ambient
+   defaults that reference `github.token`, with a narrow `contents:read` product
+   default when permissions are omitted, non-empty effective permission maps,
+   and exact event-repository binding. Workflow-authored `github.token`, ambient
    `GITHUB_TOKEN`, broader provider authority, and event-provenance policy remain
    Phase 6 work. The runtime-internal `contents:read` checkout credential
-   remains separate; tokenless workflows remain the default.
+   remains separate; jobs that do not effectively consume the workflow token
+   remain tokenless.
 
 ## Historical first product milestone (landed)
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1324,7 +1324,7 @@ func validateUnprivilegedBundle(bundle compiler.Bundle) error {
 				continue
 			}
 			if capability == "provider-token-write" {
-				if artifact.Job.GitHubToken == nil || !slices.Equal(artifact.Authorization.ProviderTokenWriteCapabilitySources, []string{"workflow-permissions"}) {
+				if artifact.Job.GitHubToken == nil || !slices.Equal(artifact.Authorization.ProviderTokenWriteCapabilitySources, []string{"effective-permissions"}) {
 					return fmt.Errorf("job %q requires provider-token-write without compiler-verified workflow permission provenance", artifact.Job.Workflow.LogicalJobID)
 				}
 				continue

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1631,9 +1631,9 @@ func TestUnprivilegedUploadAdmitsOnlyCompilerVerifiedWorkflowToken(t *testing.T)
 		authorization compiler.PlanAuthorization
 		wantError     bool
 	}{
-		{name: "verified permissions", authorization: compiler.PlanAuthorization{ProviderTokenWriteCapabilitySources: []string{"workflow-permissions"}}},
+		{name: "verified permissions", authorization: compiler.PlanAuthorization{ProviderTokenWriteCapabilitySources: []string{"effective-permissions"}}},
 		{name: "missing provenance", wantError: true},
-		{name: "broadened provenance", authorization: compiler.PlanAuthorization{ProviderTokenWriteCapabilitySources: []string{"workflow-permissions", "step-input"}}, wantError: true},
+		{name: "broadened provenance", authorization: compiler.PlanAuthorization{ProviderTokenWriteCapabilitySources: []string{"effective-permissions", "step-input"}}, wantError: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: job, Authorization: test.authorization}}}

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -357,7 +357,7 @@ jobs:
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(bundle.Plans) != 1 || !reflect.DeepEqual(bundle.Plans[0].Authorization.ProviderTokenWriteCapabilitySources, []string{"workflow-permissions"}) {
+	if len(bundle.Plans) != 1 || !reflect.DeepEqual(bundle.Plans[0].Authorization.ProviderTokenWriteCapabilitySources, []string{"effective-permissions"}) {
 		t.Fatalf("effective action default token authorization = %#v", bundle.Plans)
 	}
 
@@ -377,15 +377,30 @@ jobs:
 		t.Fatalf("overridden action default minted a token: %#v", plans)
 	}
 
-	_, err = compile(`on: push
+	plans, err = compile(`on: push
 jobs:
   token:
     runs-on: ubuntu-latest
     steps:
       - uses: ./.github/actions/token
 `)
-	if err == nil || !strings.Contains(err.Error(), "action input default that references github.token") || !strings.Contains(err.Error(), "no explicit effective permissions") {
-		t.Fatalf("CompilePlansWithOptions() error = %v, want explicit permission rejection", err)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 1 || plans[0].GitHubToken == nil || !reflect.DeepEqual(plans[0].GitHubToken.Permissions, map[string]string{"contents": "read"}) {
+		t.Fatalf("default action token plan = %#v", plans)
+	}
+
+	_, err = compile(`on: push
+permissions: {}
+jobs:
+  token:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/token
+`)
+	if err == nil || !strings.Contains(err.Error(), "action input default that references github.token") || !strings.Contains(err.Error(), "no effective permissions") {
+		t.Fatalf("CompilePlansWithOptions() error = %v, want empty permission rejection", err)
 	}
 }
 

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -432,7 +432,7 @@ jobs:
 	if !reflect.DeepEqual(token.Job.RequiredSecrets, []string{"OTHER"}) || !reflect.DeepEqual(token.Job.RequiredCapabilities, []string{"provider-token-write", "secrets"}) {
 		t.Fatalf("token secret boundary = names %#v capabilities %#v", token.Job.RequiredSecrets, token.Job.RequiredCapabilities)
 	}
-	if !reflect.DeepEqual(token.Authorization.ProviderTokenWriteCapabilitySources, []string{"workflow-permissions"}) {
+	if !reflect.DeepEqual(token.Authorization.ProviderTokenWriteCapabilitySources, []string{"effective-permissions"}) {
 		t.Fatalf("token authorization = %#v", token.Authorization)
 	}
 	if jobs["tokenless"].Job.GitHubToken != nil || jobs["tokenless"].Job.HasCapability("provider-token-write") {
@@ -440,12 +440,27 @@ jobs:
 	}
 }
 
-func TestCompileBundleGitHubTokenRequiresExplicitEffectivePermissions(t *testing.T) {
-	for _, permissions := range []string{"", "permissions: {}\n", "permissions:\n  contents: none\n"} {
+func TestCompileBundleGitHubTokenUsesRestrictedDefaultPermissions(t *testing.T) {
+	source := []byte("on: push\njobs:\n  token:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo '${{ secrets.GITHUB_TOKEN }}'\n")
+	bundle, err := CompileBundle("workflow.yml", source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	job := bundle.Plans[0]
+	if job.Job.GitHubToken == nil || !reflect.DeepEqual(job.Job.GitHubToken.Permissions, map[string]string{"contents": "read"}) {
+		t.Fatalf("default GitHub workflow token plan = %#v", job.Job)
+	}
+	if !reflect.DeepEqual(job.Authorization.ProviderTokenWriteCapabilitySources, []string{"effective-permissions"}) {
+		t.Fatalf("default token authorization = %#v", job.Authorization)
+	}
+}
+
+func TestCompileBundleGitHubTokenRejectsExplicitEmptyPermissions(t *testing.T) {
+	for _, permissions := range []string{"permissions: {}\n", "permissions:\n  contents: none\n"} {
 		source := []byte("on: push\n" + permissions + "jobs:\n  token:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo '${{ secrets.GITHUB_TOKEN }}'\n")
 		_, err := CompileBundle("workflow.yml", source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-importer")
-		if err == nil || !strings.Contains(err.Error(), "references secrets.GITHUB_TOKEN but has no explicit effective permissions") {
-			t.Fatalf("CompileBundle() error = %v, want explicit permission rejection", err)
+		if err == nil || !strings.Contains(err.Error(), "references secrets.GITHUB_TOKEN but has no effective permissions") {
+			t.Fatalf("CompileBundle() error = %v, want empty permission rejection", err)
 		}
 	}
 }

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -440,7 +440,7 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 				if referencesGitHubTokenSecret {
 					reference = "secrets.GITHUB_TOKEN"
 				}
-				return nil, nil, fmt.Errorf("%s:%d:%d: job %q references %s but has no explicit effective permissions", instance.SourcePath, instance.Source.Start.Line, instance.Source.Start.Column, instance.LogicalJobID, reference)
+				return nil, nil, fmt.Errorf("%s:%d:%d: job %q references %s but has no effective permissions", instance.SourcePath, instance.Source.Start.Line, instance.Source.Start.Column, instance.LogicalJobID, reference)
 			}
 			permissions := make(map[string]string, len(instance.Permissions))
 			for name, access := range instance.Permissions {
@@ -451,7 +451,7 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 				jobSchema = plan.SchemaV6
 			}
 			capabilities = append(capabilities, "provider-token-write")
-			authorization.ProviderTokenWriteCapabilitySources = []string{"workflow-permissions"}
+			authorization.ProviderTokenWriteCapabilitySources = []string{"effective-permissions"}
 		}
 		if instance.Queue == "" {
 			jobSchema = plan.SchemaV7

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -25,6 +25,9 @@ func TestEffectiveReusablePermissionsOnlyNarrowCallerAuthority(t *testing.T) {
 	span := workflow.Span{Start: workflow.Position{Line: 2, Column: 1}}
 	caller := &workflow.Permissions{Scopes: map[string]string{"contents": "read", "pull-requests": "write"}, Span: span}
 	callee := &workflow.Permissions{Scopes: map[string]string{"contents": "write", "issues": "write", "pull-requests": "read"}, Span: span}
+	if inherited := effectivePermissions(nil, nil, nil, false); !reflect.DeepEqual(inherited.Scopes, map[string]string{"contents": "read"}) {
+		t.Fatalf("root default permissions = %#v", inherited)
+	}
 	effective := effectivePermissions(callee, nil, caller, true)
 	want := map[string]string{"contents": "read", "pull-requests": "read"}
 	if !reflect.DeepEqual(effective.Scopes, want) {
@@ -35,6 +38,58 @@ func TestEffectiveReusablePermissionsOnlyNarrowCallerAuthority(t *testing.T) {
 	}
 	if unbounded := effectivePermissions(callee, caller, nil, false); !reflect.DeepEqual(unbounded.Scopes, callee.Scopes) {
 		t.Fatalf("root job permissions = %#v, want job replacement %#v", unbounded, callee)
+	}
+}
+
+func TestCompilePlansBoundsNestedReusableWorkflowDefaultPermissions(t *testing.T) {
+	repository := t.TempDir()
+	caller := writeWorkflow(t, repository, "caller.yml", `on: push
+jobs:
+  delegated:
+    uses: ./.github/workflows/middle.yml
+`)
+	writeWorkflow(t, repository, "middle.yml", `on: workflow_call
+permissions:
+  contents: write
+  issues: write
+  packages: read
+jobs:
+  delegated:
+    uses: ./.github/workflows/leaf.yml
+`)
+	writeWorkflow(t, repository, "leaf.yml", `on: workflow_call
+jobs:
+  token:
+    runs-on: ubuntu-latest
+    steps:
+      - run: test -n '${{ secrets.GITHUB_TOKEN }}'
+`)
+
+	plans, err := CompilePlans(caller, readFile(t, caller), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), "gha-untrusted")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 1 || plans[0].GitHubToken == nil || !reflect.DeepEqual(plans[0].GitHubToken.Permissions, map[string]string{"contents": "read"}) {
+		t.Fatalf("nested reusable token plan = %#v", plans)
+	}
+
+	emptyRepository := t.TempDir()
+	emptyCaller := writeWorkflow(t, emptyRepository, "caller.yml", `on: push
+jobs:
+  delegated:
+    permissions: {}
+    uses: ./.github/workflows/leaf.yml
+`)
+	writeWorkflow(t, emptyRepository, "leaf.yml", `on: workflow_call
+jobs:
+  token:
+    runs-on: ubuntu-latest
+    steps:
+      - run: test -n '${{ secrets.GITHUB_TOKEN }}'
+`)
+	_, err = CompilePlans(emptyCaller, readFile(t, emptyCaller), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), "gha-untrusted")
+	if err == nil || !strings.Contains(err.Error(), "no effective permissions") {
+		t.Fatalf("explicit empty reusable call permissions error = %v", err)
 	}
 }
 

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -282,6 +282,9 @@ func effectivePermissions(job, workflowDefault, ceiling *workflow.Permissions, b
 		declared = workflowDefault
 	}
 	if !bounded {
+		if declared == nil {
+			return defaultGitHubTokenPermissions()
+		}
 		return clonePermissions(declared)
 	}
 	if declared == nil {
@@ -302,6 +305,12 @@ func effectivePermissions(job, workflowDefault, ceiling *workflow.Permissions, b
 		effective.Scopes[name] = access
 	}
 	return effective
+}
+
+func defaultGitHubTokenPermissions() *workflow.Permissions {
+	// Provide the narrow permission needed by setup actions without inheriting
+	// unobservable organization or repository settings that may grant writes.
+	return &workflow.Permissions{Scopes: map[string]string{"contents": "read"}}
 }
 
 func clonePermissions(in *workflow.Permissions) *workflow.Permissions {

--- a/internal/runtime/github_token_service.go
+++ b/internal/runtime/github_token_service.go
@@ -66,7 +66,7 @@ func NewAgentGitHubTokens(config AgentGitHubTokenConfig) (*AgentGitHubTokens, er
 
 func (c *AgentGitHubTokens) WorkflowToken(ctx context.Context, repository string, permissions map[string]string) (string, error) {
 	if !validWorkflowTokenPermissions(permissions) {
-		return "", fmt.Errorf("GitHub workflow token requires valid explicit permissions")
+		return "", fmt.Errorf("GitHub workflow token requires valid effective permissions")
 	}
 	return c.mint(ctx, repository, permissions, "workflow")
 }

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -2043,8 +2043,6 @@ func TestRunJobSuppliesScopedGitHubTokenToEffectiveActionDefault(t *testing.T) {
 	workspace := t.TempDir()
 	workflowPath := filepath.Join(workspace, ".github", "workflows", "test.yml")
 	workflow := []byte(`on: push
-permissions:
-  contents: read
 jobs:
   token:
     runs-on: ubuntu-latest
@@ -2144,8 +2142,8 @@ runs:
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
-	if provider.calls != 1 || !reflect.DeepEqual(redactor.values, []string{"ghs_scoped_action_default"}) {
-		t.Fatalf("token handling = provider calls %d, redactions %#v", provider.calls, redactor.values)
+	if provider.calls != 1 || !reflect.DeepEqual(provider.permissions, map[string]string{"contents": "read"}) || !reflect.DeepEqual(redactor.values, []string{"ghs_scoped_action_default"}) {
+		t.Fatalf("token handling = provider calls %d, permissions %#v, redactions %#v", provider.calls, provider.permissions, redactor.values)
 	}
 	if result.Env["GITHUB_TOKEN"] != "***" || result.Env["GITHUB_SHA"] != "action-sha" || result.Env["RUNNER_TEMP"] != "/action-temp" || strings.Contains(logs.String(), "ghs_scoped_action_default") || !strings.Contains(logs.String(), "exported token: ***") {
 		t.Fatalf("exported workflow token leaked: result = %#v, logs = %q", result, logs.String())

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -41,7 +41,8 @@ type Concurrency struct {
 }
 
 // Permissions is an explicitly declared GitHub token permission set. Omitted
-// permissions remain nil so compilation never invents default authority.
+// permissions remain nil so the compiler can distinguish them from an explicit
+// empty permission map when applying its narrow product default.
 type Permissions struct {
 	Scopes map[string]string `json:"scopes"`
 	Span   Span              `json:"span"`


### PR DESCRIPTION
## Why

Imported workflows currently receive a GitHub token only when they declare an explicit `permissions:` block. That differs from GitHub Actions and leaves actions that rely on an effective `github.token` default without credentials.

## What

Apply a narrow `contents: read` product default when permissions are omitted, while preserving explicit empty permissions as tokenless and limiting reusable workflows to the caller's effective authority. Token provisioning remains lazy, event-repository scoped, and redacted before use.