### PR TITLE
Support Node 16 actions with a deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,9 @@ for limits and failure behavior.
 As a quick screen, the plugin path is a good fit for workflows built from:
 
 - Linux Bash and `sh` steps;
-- JavaScript, composite, local, and anonymous public actions;
+- JavaScript, composite, local, and anonymous public actions. `node16` actions
+  run on exact managed Node 16.20.2 and produce one end-of-job deprecation
+  warning naming the invoked actions;
 - supported local and public Dockerfile actions;
 - static matrices, ordinary `needs` and outputs, and local reusable workflows
   with statically resolved inputs, caller-visible results, and directly mapped

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -101,7 +101,7 @@ service.
 | Step summaries | Supported | Summaries publish as bounded job-scoped Buildkite annotations. Requires Buildkite Agent v3.112 or newer. Oversized per-step summaries are skipped; the aggregate job summary is limited to 1 MiB. |
 | Local actions | Supported subset | Workspace actions are digest-locked and reverified. JavaScript, composite, and compiler-verified Dockerfile runtimes are supported; other action runtimes are not. |
 | Public GitHub actions | Supported subset | Hosted importers use an available job-scoped Buildkite GitHub token only to resolve mutable tags and branches through the GitHub API; token-minting or redaction failure emits a sanitized warning before anonymous fallback, and local profile evaluation remains anonymous. Lowercase full commit SHAs require no REST resolution, and exact-commit archives are fetched anonymously and directly from codeload during import and runtime. Sources remain exact-commit locked, complete trees are digest-verified, and JavaScript/composite/Dockerfile runtime rules still apply. Private actions and actions that require unavailable GitHub services are not supported merely because source resolution succeeds. |
-| JavaScript actions | Supported | `node20` and `node24` declarations run on the managed, digest-verified Node 24 runtime, matching GitHub-hosted runners' current Node 20 deprecation behavior. The temporary `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` opt-out is not supported. Pre/main/post lifecycle, inputs, outputs, state, LIFO post ordering, and the standard cache-v2 environment are supported. Other Node action runtime declarations are not. |
+| JavaScript actions | Supported | `node16` declarations run on exact managed, digest-verified Node 16.20.2. Invoked Node 16 actions are named in one end-of-job warning, matching GitHub Actions' historical deprecation behavior. `node20` and `node24` declarations run on managed Node 24.18.0, matching GitHub-hosted runners' current Node 20 deprecation behavior. The temporary `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` opt-out is not supported. Pre/main/post lifecycle, inputs, outputs, state, LIFO post ordering, and the standard cache-v2 environment are supported. Other Node action runtime declarations are not. |
 | Composite actions | Supported subset | Nested shell/action steps, outputs, and global pre/main/post ordering are supported. Composite `run` steps must select `bash` or `sh`. |
 | Dockerfile actions | Supported subset | Only compiler-verified local or public Dockerfile actions are admitted. The standard cache-v2 environment is available inside the action container. Lifecycle overrides, arbitrary Docker options, other credentials, volumes, private images, and privileged execution are not supported. |
 | `docker://` actions and action `entrypoint`/`args` overrides | Not supported | Validation rejects these forms. |
@@ -475,10 +475,11 @@ there before execution, so the shared cache remains an accelerator rather than
 executable authority. An explicit `BUILDKITE_GHA_MISE` must be absolute and
 compatible rather than silently falling back. The runtime resolves and
 validates the executable before workflow code can modify `PATH`, then uses it
-with repository configuration disabled to install the exact Node 24.18.0
-release. That Node binary requires glibc 2.28 or newer; the static Go CLI does
-not. Shell-only jobs and action jobs whose resolved trees contain
-only shell steps, native adapters, or Docker do not require or install mise.
+with repository configuration disabled to install the exact Node 16.20.2 or
+24.18.0 release required by each action. Those Node binaries require glibc 2.28
+or newer; the static Go CLI does not. Shell-only jobs and action jobs whose
+resolved trees contain only shell steps, native adapters, or Docker do not
+require or install mise.
 Importers, `validate`, and `compile` do not require or install mise either.
 
 ### Validate

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -862,7 +862,7 @@ at barriers, and the cross-stream masking race.
 
 #### JavaScript actions
 
-- `node20` and `node24` action metadata;
+- `node16`, `node20`, and `node24` action metadata;
 - runner-compatible handling of deprecated Node versions;
 - action `pre`, `main`, and `post` entry points;
 - `INPUT_*`, `GITHUB_ACTION_PATH`, runtime files, and action state; and
@@ -878,10 +878,12 @@ verifies embedded archive and executable SHA-256 digests. Managed cache bytes
 are copied into a job-private directory and reverified before execution. The
 runtime resolves and pins that private executable before workflow code runs,
 then installs exactly
-`core:node@20.20.2` or `core:node@24.18.0` with mise configuration disabled,
+`core:node@16.20.2` or `core:node@24.18.0` with mise configuration disabled,
 digest-verifies the resulting Node executable, and invokes that exact path
-directly. It never uses a fuzzy Node major, a data-dir plugin, repository mise
-configuration, or a workflow-modifiable tool-bin `PATH`.
+directly. Node 20 and 24 declarations use Node 24, while Node 16 declarations
+retain exact Node 16 compatibility and produce an aggregate deprecation
+warning. The runtime never uses a fuzzy Node major, a data-dir plugin,
+repository mise configuration, or a workflow-modifiable tool-bin `PATH`.
 `MISE_*` workflow environment overrides therefore cannot redirect compatibility
 Node; ordinary shell steps retain them.
 Generated action jobs declare a dedicated, pipeline-scoped Buildkite hosted
@@ -1113,7 +1115,7 @@ jobs, the static bridge reuses mise 2026.5.12 or newer when available or
 downloads and digest-verifies its pinned 2026.5.12 official archive in the
 integration-owned managed cache path. Hosted Agents attach that cache
 automatically; other agent environments use it when available and otherwise
-fall back to ephemeral storage. Node 20.20.2 and 24.18.0 are installed by a
+fall back to ephemeral storage. Node 16.20.2 and 24.18.0 are installed by a
 reverified, job-private copy of that executable on demand into the same cache.
 Cached mise and Node executables are digest-verified before use, so cache
 sharing across builds is an optimization rather than a trust boundary.
@@ -1250,7 +1252,7 @@ The first externally useful beta should support:
   best-effort `fail-fast` that prevents undispatched siblings from starting;
 - shell `run` steps;
 - `background`, `wait`, `wait-all`, `cancel`, and `parallel` step controls;
-- JavaScript actions using managed Node 20/24;
+- JavaScript actions using managed Node 16/24;
 - composite actions;
 - Docker actions, job containers, and service containers;
 - environment files and workflow commands;
@@ -1330,9 +1332,9 @@ public checkout remains a separate provider integration gate.
 - Phase 4 is implemented within the tokenless public-action boundary.
   Action-resolved v3 plans carry immutable local and public action locks, verify
   complete source trees, execute nested composites and JavaScript pre/main/post
-  lifecycle through exact mise-managed Node 20.20.2 or 24.18.0, and fail closed
-  on private sources or provider-dependent authentication. Action resolution is
-  independent of event trust. Normal `upload` resolves local and anonymous
+  lifecycle through exact mise-managed Node 16.20.2 or 24.18.0, and fail closed
+  on private sources or provider-dependent authentication. Action resolution
+  is independent of event trust. Normal `upload` resolves local and anonymous
   public JavaScript/composite actions without transporting mise or Node
   executable bytes; generated agents reuse or install the pinned mise release
   before workflow code and resolve compatibility versions through `mise

--- a/internal/action/metadata/metadata.go
+++ b/internal/action/metadata/metadata.go
@@ -87,6 +87,8 @@ type Runtime string
 const (
 	// MaxNestedActionDepth bounds local action expansion in both compilation and execution.
 	MaxNestedActionDepth = 10
+	// RuntimeNode16 executes a JavaScript action with managed Node 16.
+	RuntimeNode16 Runtime = "node16"
 	// RuntimeNode20 identifies the accepted node20 action declaration. Matching
 	// GitHub-hosted runners, Runtime maps it to the managed Node 24 runtime.
 	RuntimeNode20 Runtime = "node20"
@@ -279,6 +281,8 @@ func mappingKeyNode(node *yaml.Node, name string) *yaml.Node {
 // so compilation and execution share one support boundary.
 func (metadata Metadata) Runtime() (Runtime, error) {
 	switch metadata.Runs.Using {
+	case string(RuntimeNode16):
+		return RuntimeNode16, nil
 	case string(RuntimeNode20):
 		return RuntimeNode24, nil
 	case string(RuntimeNode24):
@@ -315,7 +319,7 @@ func (metadata Metadata) ValidateEntrypoints(runtime Runtime) error {
 		}
 		return nil
 	}
-	if runtime != RuntimeNode20 && runtime != RuntimeNode24 {
+	if runtime != RuntimeNode16 && runtime != RuntimeNode20 && runtime != RuntimeNode24 {
 		return nil
 	}
 	if metadata.Runs.Main == "" {

--- a/internal/action/metadata/metadata_test.go
+++ b/internal/action/metadata/metadata_test.go
@@ -16,6 +16,7 @@ func TestLoadAndClassify(t *testing.T) {
 		wantCapacity string
 		wantError    string
 	}{
+		{name: "Node 16", using: "node16", wantRuntime: RuntimeNode16},
 		{name: "Node 20 declaration", using: "node20", wantRuntime: RuntimeNode24},
 		{name: "Node 24", using: "node24", wantRuntime: RuntimeNode24},
 		{name: "composite", using: "composite", wantRuntime: RuntimeComposite},

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -176,7 +176,7 @@ func (b *actionLockBuilder) add(ctx context.Context, raw string, depth int) (*ac
 		n.native = true
 		return n, nil
 	}
-	if runtime == metadata.RuntimeNode20 || runtime == metadata.RuntimeNode24 {
+	if runtime == metadata.RuntimeNode16 || runtime == metadata.RuntimeNode20 || runtime == metadata.RuntimeNode24 {
 		b.requiresMise = true
 	}
 	for _, capability := range runtime.RequiredCapabilities() {

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -1794,22 +1794,30 @@ func TestCollectNestedActionCapabilities(t *testing.T) {
 	}
 }
 
-func TestCompilePlansAcceptsNode20LocalAction(t *testing.T) {
-	repository := t.TempDir()
-	workflowPath := filepath.Join(repository, ".github", "workflows", "node20.yml")
-	actionDir := filepath.Join(repository, ".github", "actions", "node20")
-	if err := os.MkdirAll(actionDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(actionDir, "action.yml"), []byte("runs:\n  using: node20\n  main: index.js\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(actionDir, "index.js"), []byte("// fixture\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	source := []byte("on: push\njobs:\n  node20:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: ./.github/actions/node20\n")
-	if _, err := CompilePlans(workflowPath, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted"); err != nil {
-		t.Fatalf("CompilePlans() error = %v, want node20 support", err)
+func TestCompilePlansAcceptsSupportedJavaScriptLocalActions(t *testing.T) {
+	for _, runtime := range []string{"node16", "node20", "node24"} {
+		t.Run(runtime, func(t *testing.T) {
+			repository := t.TempDir()
+			workflowPath := filepath.Join(repository, ".github", "workflows", runtime+".yml")
+			actionDir := filepath.Join(repository, ".github", "actions", runtime)
+			if err := os.MkdirAll(actionDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(actionDir, "action.yml"), []byte("runs:\n  using: "+runtime+"\n  main: index.js\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(actionDir, "index.js"), []byte("// fixture\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			source := []byte("on: push\njobs:\n  javascript:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: ./.github/actions/" + runtime + "\n")
+			plans, err := CompilePlans(workflowPath, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
+			if err != nil {
+				t.Fatalf("CompilePlans() error = %v, want %s support", err, runtime)
+			}
+			if len(plans) != 1 || !plans[0].NeedsMise() {
+				t.Fatalf("CompilePlans() plans = %#v, want one %s job requiring mise", plans, runtime)
+			}
+		})
 	}
 }
 

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -1212,7 +1212,7 @@ esac
 		t.Fatalf("container checkout chain result = %#v, error = %v", result, err)
 	}
 	for _, call := range f.calls(t) {
-		if slices.Contains(call.Args, "/__buildkite-gha/node20") || slices.Contains(call.Args, "/__buildkite-gha/node24") || slices.Contains(call.Args, "/__buildkite-gha/nodes") {
+		if slices.Contains(call.Args, "/__buildkite-gha/node16") || slices.Contains(call.Args, "/__buildkite-gha/node20") || slices.Contains(call.Args, "/__buildkite-gha/node24") || slices.Contains(call.Args, "/__buildkite-gha/nodes") {
 			t.Fatalf("no-mise container checkout chain mounted or probed Node: %#v", call.Args)
 		}
 	}
@@ -1523,10 +1523,12 @@ func TestRunJobContainerWorkspaceActionRemainsLazy(t *testing.T) {
 	job.Container = &plan.Container{Image: "debian:bookworm-slim"}
 	job.Actions = []plan.ActionLock{{ID: lockID, Source: "workspace", Path: lazyDir, SourceDigest: digestTree(t, actionSource)}}
 	job.Outputs = map[string]string{"lazy": "${{ steps.lazy.outputs.lazy }}"}
+	node16 := filepath.Join(t.TempDir(), "node16")
+	writeNodeExecutable(t, node16, 16)
 	node20 := filepath.Join(t.TempDir(), "node20")
 	writeNodeExecutable(t, node20, 20)
 	node24 := requireNode24(t)
-	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node20: node20, Node24: node24}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node16: node16, Node20: node20, Node24: node24}).RunJob(context.Background(), job, workspace)
 	if err != nil || result.Outputs["lazy"] != "ready" {
 		t.Fatalf("lazy container action result = %#v, error = %v", result, err)
 	}
@@ -1536,7 +1538,7 @@ func TestRunJobContainerWorkspaceActionRemainsLazy(t *testing.T) {
 		t.Fatalf("Docker create absent: %#v", calls)
 	}
 	createArgs := calls[createIndex].Args
-	if !slices.Contains(createArgs, "type=bind,source="+node24+",target=/__buildkite-gha/node24,readonly") || slices.Contains(createArgs, "type=bind,source="+node20+",target=/__buildkite-gha/node20,readonly") {
+	if !slices.Contains(createArgs, "type=bind,source="+node16+",target=/__buildkite-gha/node16,readonly") || !slices.Contains(createArgs, "type=bind,source="+node24+",target=/__buildkite-gha/node24,readonly") || slices.Contains(createArgs, "type=bind,source="+node20+",target=/__buildkite-gha/node20,readonly") {
 		t.Fatalf("lazy node20 declaration mounts = %#v", createArgs)
 	}
 	seenLifecycleExec := false

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -65,6 +65,50 @@ type remotePreparationStatus struct {
 	unsuccessful bool
 }
 
+const node16DeprecationMessage = "Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: %s. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/."
+
+type node16DeprecationWarnings struct {
+	mu      sync.Mutex
+	actions map[string]struct{}
+}
+
+func (w *node16DeprecationWarnings) record(reference string) {
+	if w == nil || reference == "" {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.actions == nil {
+		w.actions = make(map[string]struct{})
+	}
+	w.actions[reference] = struct{}{}
+}
+
+func (w *node16DeprecationWarnings) emit(processor *commandProcessor) {
+	if w == nil || processor == nil {
+		return
+	}
+	w.mu.Lock()
+	actions := sortedKeys(w.actions)
+	w.mu.Unlock()
+	if len(actions) != 0 {
+		processor.trustedWarning(fmt.Sprintf(node16DeprecationMessage, strings.Join(actions, ", ")))
+	}
+}
+
+func actionNodeMajor(runtime metadata.Runtime) (int, bool) {
+	switch runtime {
+	case metadata.RuntimeNode16:
+		return 16, true
+	case metadata.RuntimeNode20:
+		return 20, true
+	case metadata.RuntimeNode24:
+		return 24, true
+	default:
+		return 0, false
+	}
+}
+
 func (r *postRegistry) register(post *registeredPost) {
 	if post == nil {
 		return
@@ -168,6 +212,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		return JobResult{}, fmt.Errorf("job has %d static dependencies but no hydrated prerequisite results", len(job.Dependencies))
 	}
 	processor := newCommandProcessor(r.stdout(), r.stderr())
+	r.node16Warnings = &node16DeprecationWarnings{}
 	eval := expression.Context{
 		Matrix:       job.Matrix,
 		Steps:        make(map[string]map[string]string, len(job.Steps)),
@@ -528,6 +573,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		}
 	}
 
+	r.node16Warnings.emit(processor)
 	jobResult.WarningAnnotations, jobResult.warningsTruncated, jobResult.ErrorAnnotations, jobResult.errorsTruncated = processor.workflowCommandAnnotations()
 	sensitiveValues := processor.maskValues()
 	for _, artifact := range jobResult.Artifacts {
@@ -925,24 +971,18 @@ func (r *Runner) actionContainerMounts(ctx context.Context, actions *actionLockR
 		if usesNativeAdapter(lock) {
 			continue
 		}
-		switch actionRuntime {
-		case metadata.RuntimeNode20:
-			requiredNode[20] = true
-		case metadata.RuntimeNode24:
-			requiredNode[24] = true
+		if major, ok := actionNodeMajor(actionRuntime); ok {
+			requiredNode[major] = true
 		}
 	}
 	if unknownWorkspaceRuntime && actions.job.NeedsMise() {
-		requiredNode[24] = true
+		requiredNode[16], requiredNode[24] = true, true
 	}
-	for _, major := range []int{20, 24} {
+	for _, major := range []int{16, 20, 24} {
 		if !requiredNode[major] {
 			continue
 		}
-		explicit := r.Node24
-		if major == 20 {
-			explicit = r.Node20
-		}
+		explicit := r.explicitNode(major)
 		if explicit != "" {
 			abs, err := filepath.Abs(explicit)
 			if err != nil {
@@ -971,11 +1011,7 @@ func (r *Runner) actionContainerMounts(ctx context.Context, actions *actionLockR
 			if err != nil {
 				return nil, err
 			}
-			if major == 20 {
-				r.Node20 = explicit
-			} else {
-				r.Node24 = explicit
-			}
+			r.setExplicitNode(major, explicit)
 		}
 		byTarget[fmt.Sprintf("/__buildkite-gha/node%d", major)] = containerMount{host: explicit, target: fmt.Sprintf("/__buildkite-gha/node%d", major), readonly: true}
 	}
@@ -1009,7 +1045,7 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 	}
 
 	switch runtime {
-	case metadata.RuntimeNode20, metadata.RuntimeNode24:
+	case metadata.RuntimeNode16, metadata.RuntimeNode20, metadata.RuntimeNode24:
 		// The checkout adapter replaces the verified action's JavaScript
 		// lifecycle as one indivisible operation. Do not register upstream
 		// checkout cleanup for a main phase that this runtime never executes.
@@ -1026,11 +1062,9 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 		if action.Runs.Pre == "" && action.Runs.Post == "" {
 			return result, nil
 		}
-		major, explicit := 24, r.Node24
-		if runtime == metadata.RuntimeNode20 {
-			major, explicit = 20, r.Node20
-		}
-		javascript := JavaScriptAction{Name: actionName(action, step), Path: action.Path, Pre: action.Runs.Pre, Main: action.Runs.Main, Post: action.Runs.Post, Cache: usesCacheService(lock), nodeMajor: major}
+		major, _ := actionNodeMajor(runtime)
+		explicit := r.explicitNode(major)
+		javascript := JavaScriptAction{Name: actionName(action, step), Path: action.Path, Pre: action.Runs.Pre, Main: action.Runs.Main, Post: action.Runs.Post, Cache: usesCacheService(lock), nodeMajor: major, reference: step.Uses}
 		invocation := &preparedInvocation{action: javascript, state: map[string]string{}}
 		prepared[invocationID] = invocation
 		if javascript.Pre != "" && runPre {
@@ -1236,7 +1270,7 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 	actionEval := eval
 	actionEval.Inputs = inputs
 	switch actionRuntime {
-	case metadata.RuntimeNode20, metadata.RuntimeNode24:
+	case metadata.RuntimeNode16, metadata.RuntimeNode20, metadata.RuntimeNode24:
 		if action.Runs.Main == "" {
 			return result, fmt.Errorf("JavaScript action %q has no main entry point", step.Uses)
 		}
@@ -1246,16 +1280,14 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 		if _, err := evaluateLifecycleCondition(action.Runs.PostIf, false, false); err != nil {
 			return result, fmt.Errorf("JavaScript action %q post-if: %w", step.Uses, err)
 		}
-		major, explicit := 24, r.Node24
-		if actionRuntime == metadata.RuntimeNode20 {
-			major, explicit = 20, r.Node20
-		}
+		major, _ := actionNodeMajor(actionRuntime)
+		explicit := r.explicitNode(major)
 		node, err := r.discoverNode(ctx, major, explicit)
 		if err != nil {
 			return result, err
 		}
 		actionEnv := mergeStepEnvironment(jobEnv, stepEnv)
-		javascript := JavaScriptAction{Name: actionName(action, step), Path: actionPath, Pre: action.Runs.Pre, Main: action.Runs.Main, Post: action.Runs.Post, Inputs: inputs, Env: actionEnv, Cache: actionLock != nil && usesCacheService(*actionLock), nodeMajor: major}
+		javascript := JavaScriptAction{Name: actionName(action, step), Path: actionPath, Pre: action.Runs.Pre, Main: action.Runs.Main, Post: action.Runs.Post, Inputs: inputs, Env: actionEnv, Cache: actionLock != nil && usesCacheService(*actionLock), nodeMajor: major, reference: step.Uses}
 		state := map[string]string{}
 		wasPrepared := false
 		if invocation := prepared[invocationID]; invocation != nil {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -48,6 +48,7 @@ const (
 type Runner struct {
 	Stdout                io.Writer
 	Stderr                io.Writer
+	Node16                string
 	Node20                string
 	Node24                string
 	ManagedNodeRoot       string
@@ -77,6 +78,7 @@ type Runner struct {
 	nodeVerification      *managedNodeVerification
 	nodeDigests           map[int]string
 	artifactRegistry      *artifactRegistry
+	node16Warnings        *node16DeprecationWarnings
 }
 
 func resolveHostExecutableBeforeWorkflow(configured, fallback, label string) (string, error) {
@@ -108,6 +110,30 @@ type managedNodeVerification struct {
 	paths map[int]string
 }
 
+func (r Runner) explicitNode(major int) string {
+	switch major {
+	case 16:
+		return r.Node16
+	case 20:
+		return r.Node20
+	case 24:
+		return r.Node24
+	default:
+		return ""
+	}
+}
+
+func (r *Runner) setExplicitNode(major int, path string) {
+	switch major {
+	case 16:
+		r.Node16 = path
+	case 20:
+		r.Node20 = path
+	case 24:
+		r.Node24 = path
+	}
+}
+
 // JavaScriptAction is an already-resolved local JavaScript action.
 type JavaScriptAction struct {
 	Name   string
@@ -120,6 +146,7 @@ type JavaScriptAction struct {
 	Cache  bool
 
 	nodeMajor int
+	reference string
 }
 
 // DockerAction is an already-resolved local Docker action.
@@ -633,6 +660,9 @@ func (r Runner) runJavaScriptPhase(ctx context.Context, processor *commandProces
 		entrypoint = r.jobContainer.containerPath(entrypoint)
 	}
 	name, args := node, []string{entrypoint}
+	if r.node16Warnings != nil && action.nodeMajor == 16 {
+		r.node16Warnings.record(action.reference)
+	}
 	var beforeResult Result
 	var beforeState map[string]string
 	if cacheToken != "" {
@@ -904,15 +934,19 @@ func trimStreamLineEnding(line string) string {
 }
 
 const (
+	Node16Version = "16.20.2"
 	Node20Version = "20.20.2"
 	Node24Version = "24.18.0"
 	// Digests are for bin/node in the official Linux x86-64 release archives.
+	node16Digest = "8440cffda5a21bf7cfda43d2c396f79777585a4c5e03ed2801fe226953a7aa11"
 	node20Digest = "6295488653f0d93b0a157841746fef7e72cc4328cfb60c4bbe0ca2668a836ffd"
 	node24Digest = "41a74efb34cbde5c7632cdac0cf8bd1a14d0b8d73dc1e82755014d9a9ce70f5c"
 )
 
 func nodeTool(major int) string {
 	switch major {
+	case 16:
+		return "core:node@" + Node16Version
 	case 20:
 		return "core:node@" + Node20Version
 	case 24:
@@ -1007,6 +1041,8 @@ func (r Runner) nodeDigest(major int) string {
 		return digest
 	}
 	switch major {
+	case 16:
+		return node16Digest
 	case 20:
 		return node20Digest
 	case 24:
@@ -1122,6 +1158,8 @@ func verifyManagedNodeExecutable(ctx context.Context, major int, path, want stri
 	}
 	var wantVersion string
 	switch major {
+	case 16:
+		wantVersion = "v" + Node16Version
 	case 20:
 		wantVersion = "v" + Node20Version
 	case 24:
@@ -1255,14 +1293,15 @@ func sortedKeys[V any](values map[string]V) []string {
 }
 
 type commandProcessor struct {
-	mu        sync.Mutex
-	stdout    io.Writer
-	stderr    io.Writer
-	masks     []string
-	warnings  workflowCommandAnnotationBuffer
-	errors    workflowCommandAnnotationBuffer
-	stopToken string
-	discard   bool
+	mu              sync.Mutex
+	stdout          io.Writer
+	stderr          io.Writer
+	masks           []string
+	trustedWarnings workflowCommandAnnotationBuffer
+	warnings        workflowCommandAnnotationBuffer
+	errors          workflowCommandAnnotationBuffer
+	stopToken       string
+	discard         bool
 }
 
 type workflowCommandAnnotationBuffer struct {
@@ -1406,6 +1445,15 @@ func (p *commandProcessor) writeWorkflowCommandMessageLocked(target io.Writer, s
 	p.writeMaskedLineLocked(target, severity+": "+message)
 }
 
+// trustedWarning records a runner-owned warning even after untrusted action
+// output has been suppressed, while preserving the job's registered masks.
+func (p *commandProcessor) trustedWarning(message string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.appendWorkflowCommandLocked(&p.trustedWarnings, workflowWarningAnnotationHeading, "Warning", parsedWorkflowCommand{message: message})
+	p.writeWorkflowCommandMessageLocked(p.stderr, "warning", message)
+}
+
 func (p *commandProcessor) writeMaskedLineLocked(target io.Writer, line string) {
 	_, _ = fmt.Fprintln(target, p.maskTextLocked(line))
 }
@@ -1487,7 +1535,14 @@ func (p *commandProcessor) scrubError(err error) error {
 func (p *commandProcessor) workflowCommandAnnotations() (warnings string, warningsTruncated bool, errors string, errorsTruncated bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	return p.warnings.body, p.warnings.truncated, p.errors.body, p.errors.truncated
+	warnings, warningsTruncated = p.warnings.body, p.warnings.truncated
+	if p.trustedWarnings.body != "" {
+		warnings, warningsTruncated = "", false
+		appendBoundedText(&warnings, &warningsTruncated, p.trustedWarnings.body, p.trustedWarnings.truncated, maxJobAnnotationBytes, workflowCommandTruncationNotice)
+		untrusted := strings.TrimPrefix(p.warnings.body, workflowWarningAnnotationHeading)
+		appendBoundedText(&warnings, &warningsTruncated, untrusted, p.warnings.truncated, maxJobAnnotationBytes, workflowCommandTruncationNotice)
+	}
+	return warnings, warningsTruncated, p.errors.body, p.errors.truncated
 }
 
 func (p *commandProcessor) addMaskLocked(value string) {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1362,6 +1362,159 @@ esac
 	if result.Env["NODE24_POST"] != "true" {
 		t.Fatalf("RunJob() environment = %#v, want Node 24 post lifecycle effect", result.Env)
 	}
+	if result.WarningAnnotations != "" {
+		t.Fatalf("RunJob() warnings = %q, want no Node 20 deprecation warning", result.WarningAnnotations)
+	}
+}
+
+func TestNode16DeclarationUsesExactLifecycleAndWarns(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	writeFixtureFile(t, workspace, ".github/actions/node16/action.yml", `name: Node 16 lifecycle
+runs:
+  using: node16
+  pre: pre.js
+  main: main.js
+  post: post.js
+`)
+	for _, entry := range []string{"pre.js", "main.js", "post.js"} {
+		writeFixtureFile(t, workspace, ".github/actions/node16/"+entry, "")
+	}
+	fakeNode := filepath.Join(workspace, "node16")
+	writeFixtureFile(t, workspace, "node16", `#!/bin/sh
+set -eu
+if [ "${1:-}" = --version ]; then
+  echo v16.20.2
+  exit 0
+fi
+printf 'NODE16_%s=true\n' "$(basename "$1" .js | tr '[:lower:]' '[:upper:]')" >> "$GITHUB_ENV"
+`)
+	if err := os.Chmod(fakeNode, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "javascript", Kind: "uses", Uses: "./.github/actions/node16"}})
+	var logs bytes.Buffer
+	result, err := (Runner{Node16: fakeNode, Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	for _, phase := range []string{"PRE", "MAIN", "POST"} {
+		if result.Env["NODE16_"+phase] != "true" {
+			t.Fatalf("RunJob() environment = %#v, want Node 16 %s lifecycle effect", result.Env, phase)
+		}
+	}
+	warning := fmt.Sprintf(node16DeprecationMessage, "./.github/actions/node16")
+	if strings.Count(logs.String(), warning) != 1 || strings.Count(result.WarningAnnotations, warning) != 1 {
+		t.Fatalf("RunJob() logs = %q, warnings = %q, want one Node 16 lifecycle warning %q", logs.String(), result.WarningAnnotations, warning)
+	}
+}
+
+func TestNode16WarningAggregatesInvokedActions(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	for _, name := range []string{"alpha", "beta", "skipped"} {
+		writeFixtureFile(t, workspace, ".github/actions/"+name+"/action.yml", "name: "+name+"\nruns:\n  using: node16\n  main: main.js\n")
+		writeFixtureFile(t, workspace, ".github/actions/"+name+"/main.js", "")
+	}
+	writeFixtureFile(t, workspace, ".github/actions/modern/action.yml", "name: modern\nruns:\n  using: node20\n  main: main.js\n")
+	writeFixtureFile(t, workspace, ".github/actions/modern/main.js", "")
+	node16 := filepath.Join(workspace, "node16")
+	node24 := filepath.Join(workspace, "node24")
+	writeNodeExecutable(t, node16, 16)
+	writeNodeExecutable(t, node24, 24)
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{
+		{ID: "beta", Kind: "uses", Uses: "./.github/actions/beta"},
+		{ID: "alpha", Kind: "uses", Uses: "./.github/actions/alpha"},
+		{ID: "alpha-again", Kind: "uses", Uses: "./.github/actions/alpha"},
+		{ID: "skipped", Kind: "uses", Uses: "./.github/actions/skipped", Condition: "false"},
+		{ID: "modern", Kind: "uses", Uses: "./.github/actions/modern"},
+	})
+	var logs bytes.Buffer
+	result, err := (Runner{Node16: node16, Node24: node24, Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	warning := fmt.Sprintf(node16DeprecationMessage, "./.github/actions/alpha, ./.github/actions/beta")
+	if strings.Count(logs.String(), warning) != 1 || strings.Count(result.WarningAnnotations, warning) != 1 {
+		t.Fatalf("RunJob() logs = %q, warnings = %q, want one aggregate warning %q", logs.String(), result.WarningAnnotations, warning)
+	}
+	for _, absent := range []string{"./.github/actions/skipped", "./.github/actions/modern"} {
+		if strings.Contains(result.WarningAnnotations, absent) {
+			t.Fatalf("RunJob() warnings = %q, unexpectedly named %q", result.WarningAnnotations, absent)
+		}
+	}
+}
+
+func TestNode16WarningSurvivesSuppressionAndMasksReferences(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	writeFixtureFile(t, workspace, ".github/actions/sensitive/action.yml", "name: sensitive\nruns:\n  using: node16\n  main: main.js\n")
+	writeFixtureFile(t, workspace, ".github/actions/sensitive/main.js", "")
+	fakeNode := filepath.Join(workspace, "node16")
+	writeFixtureFile(t, workspace, "node16", `#!/bin/sh
+set -eu
+if [ "${1:-}" = --version ]; then echo v16.20.2; exit 0; fi
+printf '%s\n' '::add-mask::sensitive'
+head -c 1048577 /dev/zero | tr '\000' x
+printf '\n'
+`)
+	if err := os.Chmod(fakeNode, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "node16", Kind: "uses", Uses: "./.github/actions/sensitive"}})
+	var logs bytes.Buffer
+	result, err := (Runner{Node16: fakeNode, Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	if err == nil || !strings.Contains(err.Error(), "line exceeds 1048576-byte limit") || result.Conclusion != "failure" {
+		t.Fatalf("RunJob() result = %#v, error = %v, want oversized-line failure", result, err)
+	}
+	warningLog := logs.String()
+	if warningIndex := strings.LastIndex(warningLog, "warning: Node.js 16 actions are deprecated"); warningIndex >= 0 {
+		warningLog = warningLog[warningIndex:]
+	}
+	for _, output := range []string{warningLog, result.WarningAnnotations} {
+		if !strings.Contains(output, "Node.js 16 actions are deprecated") || !strings.Contains(output, "./.github/actions/***") || strings.Contains(output, "sensitive") {
+			t.Fatalf("RunJob() warning = %q, want masked Node 16 warning after stream suppression", output)
+		}
+	}
+}
+
+func TestNode16WarningHasPriorityOverUntrustedAnnotationLimit(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	writeFixtureFile(t, workspace, ".github/actions/node16/action.yml", "name: node16\nruns:\n  using: node16\n  main: main.js\n")
+	writeFixtureFile(t, workspace, ".github/actions/node16/main.js", "")
+	fakeNode := filepath.Join(workspace, "node16")
+	writeFixtureFile(t, workspace, "node16", `#!/bin/sh
+set -eu
+if [ "${1:-}" = --version ]; then echo v16.20.2; exit 0; fi
+i=0
+while [ "$i" -lt 17 ]; do
+  printf '%s' '::warning::'
+  head -c 65536 /dev/zero | tr '\000' x
+  printf '\n'
+  i=$((i + 1))
+done
+`)
+	if err := os.Chmod(fakeNode, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "node16", Kind: "uses", Uses: "./.github/actions/node16"}})
+	var logs bytes.Buffer
+	result, err := (Runner{Node16: fakeNode, Stdout: io.Discard, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	warning := fmt.Sprintf(node16DeprecationMessage, "./.github/actions/node16")
+	if strings.Count(logs.String(), warning) != 1 || strings.Count(result.WarningAnnotations, warning) != 1 {
+		t.Fatalf("RunJob() logs = %q, warnings contain Node 16 message %d times, want one priority warning", logs.String(), strings.Count(result.WarningAnnotations, warning))
+	}
+	if len(result.WarningAnnotations) > maxJobAnnotationBytes || !utf8.ValidString(result.WarningAnnotations) || !strings.HasSuffix(result.WarningAnnotations, workflowCommandTruncationNotice) {
+		t.Fatalf("RunJob() warning annotation bytes = %d, valid UTF-8 = %v, suffix present = %v", len(result.WarningAnnotations), utf8.ValidString(result.WarningAnnotations), strings.HasSuffix(result.WarningAnnotations, workflowCommandTruncationNotice))
+	}
 }
 
 func TestBackgroundFailureSurfacesAtWait(t *testing.T) {
@@ -3277,6 +3430,38 @@ func TestMiseNodeSelectionIsExactAndConfigFree(t *testing.T) {
 		t.Fatal(err)
 	}
 	if string(data) != "--no-config install core:node@20.20.2\n--no-config where core:node@20.20.2\n" {
+		t.Fatalf("mise arguments = %q", data)
+	}
+}
+
+func TestMiseNode16SelectionIsExactAndConfigFree(t *testing.T) {
+	root := canonicalTempDir(t)
+	log := filepath.Join(root, "args")
+	dataDir := filepath.Join(root, "data")
+	installation := filepath.Join(dataDir, "installs", "node", Node16Version)
+	node := filepath.Join(installation, "bin", "node")
+	nodeBytes := []byte("#!/bin/sh\nprintf 'v16.20.2\\n'\n")
+	if err := os.MkdirAll(filepath.Dir(node), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(node, nodeBytes, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mise := filepath.Join(root, "mise")
+	writeFixtureFile(t, root, "mise", fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$*\" >> %q\ncase \"$2\" in install) :;; where) printf '%%s\\n' %q;; *) exit 9;; esac\n", log, installation))
+	if err := os.Chmod(mise, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	digest := sha256.Sum256(nodeBytes)
+	got, err := (Runner{Mise: mise, MiseDataDir: dataDir, nodeDigests: map[int]string{16: hex.EncodeToString(digest[:])}}).discoverNode(context.Background(), 16, "")
+	if err != nil || got != node {
+		t.Fatalf("discoverNode() = %q, %v", got, err)
+	}
+	data, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "--no-config install core:node@16.20.2\n--no-config where core:node@16.20.2\n" {
 		t.Fatalf("mise arguments = %q", data)
 	}
 }


### PR DESCRIPTION
## Summary

- accept `runs.using: node16` and execute it with digest-verified managed Node 16.20.2
- emit GitHub Actions’ historical aggregate Node 16 deprecation warning as both a masked log warning and a Buildkite annotation
- name only invoked Node 16 actions, deduplicate repeated/pre/main/post invocations, and retain the warning across action failures, oversized-output suppression, and a saturated untrusted annotation budget
- preserve current GitHub-compatible `node20`/`node24` execution on managed Node 24.18.0
- document the compatibility boundary and cover host/container runtime selection

## Validation

- `DOCKER_CONTEXT=default mise run --jobs 1 check`
- focused Node 16 runtime tests under `go test -race`
- Oracle review; applied its annotation-priority finding before the full check