### PR TITLE
Align repository documentation with current plugin and runtime behavior

### DIFF
--- a/.buildkite/phase-0-transport-probe/README.md
+++ b/.buildkite/phase-0-transport-probe/README.md
@@ -10,7 +10,9 @@ This probe is intentionally dormant: local tests capture commands and never call
 
 Buildkite signed pipelines are outside this initial transport probe. Run the probe on the existing `hosted` queue without secrets, provider tokens, privileged containers, or other production capabilities. The signed, build-bound plan envelope remains mandatory and is a separate trust mechanism: `PHASE0_SIGN_JSON` signs plan bindings and markers, and `PHASE0_VERIFY_JSON` verifies them before runtime use.
 
-Signed-pipeline compatibility is deferred to the hardening phase as optional defence in depth for installations that already require it. It must use keys separate from the plan-envelope signer when implemented.
+Signed-pipeline compatibility is deferred to the hardening phase as optional
+defense in depth for installations that already require it. It must use keys
+separate from the plan-envelope signer when implemented.
 
 The live probe also requires:
 
@@ -62,7 +64,7 @@ Also run a negative build with `PHASE0_TAMPER_BINDING=1`; the producer must reje
 ## Recorded evidence
 
 - [Buildkite build 27](https://buildkite.com/buildkite/buildkite-gha/builds/27)
-  passed the complete transport and Agent-redaction path at commit
+  passed the complete transport and agent redaction path at commit
   `787b3adfe306a17fbf073c70b24f8b747b5882a8`.
 - [Buildkite build 15](https://buildkite.com/buildkite/buildkite-gha/builds/15)
   failed its producer while the failure-settling consumer passed.

--- a/README.md
+++ b/README.md
@@ -1,22 +1,25 @@
 # buildkite-gha
 
-Run a GitHub Actions workflow as native Buildkite jobs—without creating a
+Run a GitHub Actions workflow as native Buildkite jobs without creating a
 GitHub Actions run.
 
 `buildkite-gha` translates each workflow job (and each static matrix entry)
 into a Buildkite job, then runs that job's Actions steps in a compatibility
-runtime. Buildkite remains the source of truth for scheduling, logs, retries,
-cancellation, and the build UI.
+runtime. Buildkite Pipelines is the source of truth for scheduling, logs,
+retries, cancellation, and the build interface.
 
 > [!IMPORTANT]
-> This is an experimental pre-1.0 preview for **Linux x86-64 workflows**. The
+> This is a research preview for **Linux x86-64 workflows**. The
 > default remains limited to public actions and no general workflow secrets.
 > Verified checkout automatically uses Buildkite's repository-provider Git
 > credentials when the job is configured for them, and otherwise checks out
 > anonymously. Private actions and workflow secrets other than the explicitly
 > scoped `secrets.GITHUB_TOKEN` contract remain rejected.
+>
+> To provide feedback or report issues, contact the [Buildkite Support
+> team](mailto:support@buildkite.com).
 
-## Buildkite controls the pipeline; the workflow describes the workload
+## Buildkite Pipelines controls the pipeline; the workflow describes the workload
 
 A GitHub Actions workflow combines two concerns: run triggers and event filters
 under `on:` control when GitHub creates a workflow run, while `jobs` and `steps`
@@ -50,21 +53,22 @@ steps:
   - label: ":github: Test"
     key: "gha-ci"
     plugins:
-      - github-actions#v0.4.4:
+      - github-actions#v0.7.1:
           workflow: .github/workflows/ci.yml
+          version: "0.7.2"
 ```
 
-The pinned released plugin downloads and verifies `buildkite-gha` v0.4.2 by
-default, derives the event context from the Buildkite build, and explicitly
-targets the fixed `hosted` queue. Pin a released plugin version rather than a
-floating branch. The current source CLI instead omits agent selectors by
-default, so direct uploads inherit Buildkite's configured agent targeting unless
-`BUILDKITE_GHA_TARGET_QUEUE` selects one queue explicitly. Jobs that can execute
+Every importer step must have a unique `key`. Pin a released plugin version
+rather than a floating branch. Plugin and binary releases are independent. The
+v0.7.1 plugin defaults to `buildkite-gha` v0.7.1, while this example explicitly
+selects `buildkite-gha` v0.7.2. Generated jobs inherit the pipeline or
+organization default agent targeting unless the importer sets
+`BUILDKITE_GHA_TARGET_QUEUE` to select one queue. Jobs that can execute
 JavaScript reuse mise 2026.5.12 or newer from `PATH` or the absolute path in
 `BUILDKITE_GHA_MISE`; when neither provides a compatible version, the runtime
-downloads and verifies a managed 2026.5.12 copy. Hosted Agents use their
-attached cache; other environments fall back to an ephemeral cache when that
-path is unavailable. Shell-only jobs and action jobs whose resolved trees
+downloads and verifies a managed 2026.5.12 copy. Buildkite hosted agents use
+their attached cache; other environments fall back to an ephemeral cache when
+that path is unavailable. Shell-only jobs and action jobs whose resolved trees
 contain only shell steps, native adapters, or Docker do not require or install
 mise.
 
@@ -84,8 +88,9 @@ steps:
   - label: ":github: Test"
     key: "gha-ci"
     plugins:
-      - github-actions#v0.4.4:
+      - github-actions#v0.7.1:
           workflow: .github/workflows/ci.yml
+          version: "0.7.2"
 
   - label: ":rocket: Deploy"
     key: "deploy"
@@ -107,7 +112,7 @@ offers the same three choices through a Buildkite block step.
 To launch both providers at the current branch's exact remote commit and print
 their run URLs together:
 
-```sh
+```bash
 scripts/compare-example basic
 scripts/compare-example artifacts
 scripts/compare-example advanced
@@ -200,7 +205,7 @@ for the exact distinction and intentional behavior differences.
 
 Static validation does not contact Buildkite or execute the workflow:
 
-```sh
+```bash
 buildkite-gha validate .github/workflows/ci.yml
 ```
 
@@ -216,7 +221,7 @@ Result: compilable
 To also resolve public actions and apply the same policy as the plugin's
 `hosted-tokenless` upload, provide an event snapshot:
 
-```sh
+```bash
 buildkite-gha validate \
   --profile hosted-tokenless \
   --event-path .buildkite/events/current.json \
@@ -248,7 +253,7 @@ share a workspace, environment changes, action state, containers, and
 post-action lifecycle in GitHub Actions, so they must stay inside one job here
 too.
 
-```diagram
+```text
 ┌──────────────────────────┐
 │ Buildkite configuration  │
 │ creates the build        │

--- a/docs/architecture/0001-upstream-actions-reuse.md
+++ b/docs/architecture/0001-upstream-actions-reuse.md
@@ -16,8 +16,8 @@ This spike inspected the current released source of `nektos/act`,
 `rhysd/actionlint`, and GitHub's open runner. It considered workflow and action
 models, matrix expansion, expression evaluation, resolution and execution,
 workflow commands and environment files, dependency licensing, and version
-pinning. The repositories were cloned and inspected locally as well as checked
-against their release pages and documentation.
+pinning. The review included local repository inspection and checks against
+the release pages and documentation.
 
 ## Decision
 
@@ -177,12 +177,12 @@ runtimes.
 
 1. Build one internal parser adapter around actionlint and convert syntax nodes
    into owned workflow/action types with source spans.
-2. Implement static matrix expansion and expression evaluation behind owned
+1. Implement static matrix expansion and expression evaluation behind owned
    interfaces, seeded by act tests and verified by GitHub differential fixtures.
-3. Define provider resolution, immutable archives, runtime state, workflow
+1. Define provider resolution, immutable archives, runtime state, workflow
    commands, and environment files independently of act's `RunContext` and
    container interfaces.
-4. Add dependency-update CI that runs parser golden tests, the smoke corpus,
+1. Add dependency-update CI that runs parser golden tests, the smoke corpus,
    license inventory, and SBOM generation before changing the actionlint pin.
-5. Keep an explicit oracle manifest containing the act and official-runner
+1. Keep an explicit oracle manifest containing the act and official-runner
    revisions so behavior changes are reviewed rather than absorbed implicitly.

--- a/docs/architecture/0002-plan-envelope-trust-boundary.md
+++ b/docs/architecture/0002-plan-envelope-trust-boundary.md
@@ -35,7 +35,7 @@ Protected capabilities will instead use a control-plane service that:
 Plans continue to use content digests and producer-attributed artifacts. The
 runtime continues to verify build, importer, job, step, plan, runtime, and any
 explicit queue bindings, but those checks do not authorize protected resources.
-Buildkite pipeline signing remains optional installation-specific defence in
+Buildkite pipeline signing remains optional installation-specific defense in
 depth.
 
 The original Phase 0 decision is retained below as an implementation and
@@ -119,30 +119,30 @@ resolution:
 1. Apply artifact size and JSON depth limits, reject duplicate keys, parse the
    envelope, and validate its structural schema. The plan may be hashed at this
    stage but is otherwise inert.
-2. Decode and structurally validate the protected header. Reject an unsupported
+1. Decode and structurally validate the protected header. Reject an unsupported
    `alg` or `typ`, an unknown `kid`, or a locally revoked key.
-3. Recreate the JCS claims bytes and verify the JWS signature. Claims do not
+1. Recreate the JCS claims bytes and verify the JWS signature. Claims do not
    influence routing, diagnostics containing attacker-chosen identifiers, or
    authorization until this succeeds.
-4. Check `iat <= now < exp`, `exp > iat`, and `exp - iat <= 86400`. Phase 0 has
+1. Check `iat <= now < exp`, `exp > iat`, and `exp - iat <= 86400`. Phase 0 has
    no clock-skew allowance: compiler and runtime queues must have synchronized
    clocks. A retry cannot mint or extend an envelope; an expired build must be
    rebuilt. A longer supported queue or retry window requires a later contract
    revision rather than an installer override.
-5. Match the organization, pipeline, and build UUIDs to immutable Buildkite job
+1. Match the organization, pipeline, and build UUIDs to immutable Buildkite job
    context.
-6. Match the step key and actual agent queue exactly. Phase 0 reads
+1. Match the step key and actual agent queue exactly. Phase 0 reads
    `BUILDKITE_STEP_KEY` and `BUILDKITE_AGENT_META_DATA_QUEUE`; an absent value is
    a verification failure.
-7. Re-evaluate current local policy using the verified provenance and require
+1. Re-evaluate current local policy using the verified provenance and require
    the envelope capability ceiling to be a subset of that policy. In
    particular, `manual-unattested` and untrusted events cannot reach protected
    queues or capabilities unless an explicit local rule permits the exact
    combination.
-8. Hash the received canonical plan bytes, compare its digest to the envelope,
+1. Hash the received canonical plan bytes, compare its digest to the envelope,
    validate the plan schema, and require its compiler identity, workflow/event
    digests, target step, and target queue to equal the envelope claims.
-9. Require the plan's capability request to be a subset of both the signed
+1. Require the plan's capability request to be a subset of both the signed
    ceiling and current local ceiling, then begin execution.
 
 Every missing, malformed, mismatched, expired, revoked, unsupported, or
@@ -190,7 +190,8 @@ Primary references checked on 2026-07-22:
 
 - [Buildkite signed pipelines](https://buildkite.com/docs/agent/self-hosted/security/signed-pipelines)
 - [Buildkite dynamic pipelines](https://buildkite.com/docs/pipelines/configure/dynamic-pipelines)
-- [Buildkite Agent pipeline upload](https://buildkite.com/docs/agent/cli/reference/pipeline)
+- [Buildkite agent pipeline
+  upload](https://buildkite.com/docs/agent/cli/reference/pipeline)
 - [Buildkite environment variables](https://buildkite.com/docs/pipelines/configure/environment-variables)
 - [RFC 7515: JSON Web Signature](https://www.rfc-editor.org/rfc/rfc7515)
 - [RFC 8785: JSON Canonicalization Scheme](https://www.rfc-editor.org/rfc/rfc8785)
@@ -203,16 +204,16 @@ need live Buildkite builds before production support is claimed:
 1. Does a signed bootstrap job dynamically uploading with AWS KMS produce steps
    accepted by every intended self-hosted, Hosted, and Kubernetes verifier
    configuration, including mixed queues during rotation?
-2. Which immutable job context is available before hooks and plugins, and can a
+1. Which immutable job context is available before hooks and plugins, and can a
    custom bootstrap supply `BUILDKITE_BUILD_ID`, `BUILDKITE_STEP_KEY`, and the
    actual queue to the verifier without any plan-controlled override path?
-3. Does artifact download constrained by the compiler step always return the
+1. Does artifact download constrained by the compiler step always return the
    intended immutable plan under retries and duplicate artifact names, and
    what observable producer identity can the runtime verify?
-4. What diagnostic and job state does each pipeline-signature rejection path
+1. What diagnostic and job state does each pipeline-signature rejection path
    produce, and can an unsigned or wrongly signed generated upload ever reach a
    command hook before it is blocked?
-5. How do jobs queued across a plan-key or pipeline-key rotation behave, and
+1. How do jobs queued across a plan-key or pipeline-key rotation behave, and
    what operational delay is required before removing the old verification
    root?
 

--- a/docs/architecture/0003-protected-capability-control-plane.md
+++ b/docs/architecture/0003-protected-capability-control-plane.md
@@ -9,7 +9,7 @@
 The service-free compatibility path can execute public, anonymous workflow code
 without giving it authority beyond its Buildkite job. Summaries, annotations,
 native artifact adapters, public exact-SHA checkout, and the audited
-`actions/cache` v6 client all use public Agent or explicitly configured
+`actions/cache` v6 client all use public agent or explicitly configured
 cache-v2 interfaces. With two narrow exceptions described below, they do not
 establish general authority for private source, secrets, provider tokens,
 environments, privileged queues, or compatible OIDC claims.
@@ -20,7 +20,7 @@ the Phase 0 runtime binding proves integrity rather than provider provenance.
 The runtime needs a separate authorization result tied to both the actual
 Buildkite job and independently established provider facts.
 
-Buildkite Job OIDC supplies the job half of that identity. A running Agent can
+Buildkite Job OIDC supplies the job half of that identity. A running agent can
 mint a short-lived token for an exact audience with immutable organization,
 pipeline, build, job, cluster, and queue identifiers. It does not prove the
 complete GitHub event, actor, fork relationship, workflow source, installation,
@@ -70,9 +70,10 @@ separate.
 
 ### Job authentication
 
-The client obtains a fresh token with the Agent command equivalent to:
+The client obtains a fresh token by running the equivalent of this
+`buildkite-agent` command:
 
-```sh
+```bash
 buildkite-agent oidc request-token \
   --audience "$BUILDKITE_GHA_CONTROL_PLANE_URL" \
   --claim organization_id,pipeline_id,build_id,cluster_id,queue_id,queue_key
@@ -85,7 +86,7 @@ paths, queries, fragments, and redirects are rejected. The setting cannot be
 overridden by plan-, workflow-, repository-, or ordinary build-supplied
 environment. The client captures the token without logging it, keeps it in
 memory for one exchange, and sends it only to that bound service as the
-control-plane bearer credential. It never reads or forwards the ambient Agent
+control-plane bearer credential. It never reads or forwards the ambient agent
 access token to that service or to action code.
 
 The control plane validates the token against the fixed Buildkite issuer
@@ -207,18 +208,18 @@ remain in the platform signing boundary.
 
 Buildkite has two native, job-bound credential paths that support narrower
 integrations without waiting for the general grant protocol. Repository
-checkout uses the Agent's Git credential helper and delegates authorization for
+checkout uses the agent's Git credential helper and delegates authorization for
 the concrete URL supplied by Git to Buildkite's repository-provider backend.
-Workflow `GITHUB_TOKEN` support uses the Agent API below to mint a GitHub
+Workflow `GITHUB_TOKEN` support uses the agent API below to mint a GitHub
 installation token for the exact current job, exact pipeline repository, and
 caller-requested permission set. The server authenticates the request with the
-same job's Agent access token, independently requires the requested repository
+same job's agent access token, independently requires the requested repository
 to equal the pipeline's configured GitHub repository, and validates permissions
 against its own allowlist:
 
 ```http
 POST /v3/jobs/<current-job-id>/github_scoped_access_token
-Authorization: Token <current-job Agent access token>
+Authorization: Token <current-job agent access token>
 Content-Type: application/json
 ```
 
@@ -242,7 +243,7 @@ are enabled. Otherwise it performs the same checkout anonymously.
 
 The event repository and exact SHA remain the only checkout targets. The
 credential helper is configured as a command-scoped Git option only for the
-fetch, uses HTTP-path matching, receives the current job's Agent API identity,
+fetch, uses HTTP-path matching, receives the current job's agent API identity,
 and is not persisted. The runtime forwards proxy variables captured from the job
 process before workflow execution to that credentialed fetch but does not add
 the job credential to ordinary workflow subprocess environments. This is
@@ -250,7 +251,7 @@ inheritance control, not OS-level isolation between hostile processes in the
 same job. The Buildkite backend independently authorizes the concrete repository
 URL received through Git's credential protocol. Through the supported adapter
 no workflow input can select another credential target or access level, and the
-job's Agent credential is not placed in plans.
+job's agent credential is not placed in plans.
 
 A second bounded integration uses the scoped-token endpoint for a synthetic
 `secrets.GITHUB_TOKEN` or an action metadata input default that references
@@ -266,7 +267,7 @@ the capability.
 
 The runtime requests one token for the plan's exact event repository and exact
 permission map. It validates both independently, masks the returned token, and
-requires Agent redaction registration before making the synthetic secret
+requires agent redaction registration before making the synthetic secret
 available to expression evaluation. Job-level permissions replace workflow
 defaults; flattened local reusable workflows can only narrow caller authority.
 Permission aliases, empty grants, and `id-token` fail closed. `github.token` is
@@ -282,7 +283,7 @@ organization enablement, and permission allowlist are authoritative, but
 pipelines remain responsible for whether untrusted workflow changes may request
 an allowed write permission. The compiled permission map constrains the supported
 client path; it is not an independent authorization ceiling against same-job
-code that obtains the Agent access token and calls the endpoint directly.
+code that obtains the agent access token and calls the endpoint directly.
 Private actions, arbitrary reusable-workflow source, selected non-provider
 secrets, environments, and OIDC still require the general control-plane decision
 in this ADR.
@@ -292,17 +293,18 @@ in this ADR.
 The runtime treats the response as inert bytes until all of these checks pass:
 
 1. Bound response size and structural depth.
-2. Validate the protected header and select a configured, non-revoked key.
-3. Verify the JWS signature before using any claim in routing or diagnostics.
-4. Validate schema, issuer, audience, ID, time window, and capability vocabulary.
-5. Match every Buildkite claim exposed through immutable current-job context,
+1. Validate the protected header and select a configured, non-revoked key.
+1. Verify the JWS signature before using any claim in routing or diagnostics.
+1. Validate schema, issuer, audience, ID, time window, and capability
+   vocabulary.
+1. Match every Buildkite claim exposed through immutable current-job context,
    including build/job identity, step key, and queue key. IDs that are present
    only in verified Job OIDC are enforced by the control plane and retained in
    the signed grant for audit and later platform-supported runtime comparison.
-6. Match the plan and event digests to the exact decoded plan.
-7. Require the granted set to be a subset of the plan request and current local
+1. Match the plan and event digests to the exact decoded plan.
+1. Require the granted set to be a subset of the plan request and current local
    runtime policy.
-8. Resolve only the intersection of plan request, signed grant, and local
+1. Resolve only the intersection of plan request, signed grant, and local
    policy, at the point where a protected value is needed.
 
 For the no-op slice, the runtime verifies and discards the empty grant. It must
@@ -331,16 +333,16 @@ record; a successful job alone does not prove policy or audit behavior.
 ## Initial implementation sequence
 
 1. Finalize the request/grant schemas and platform endpoint ownership.
-2. Implement the platform verifier for Buildkite OIDC and authoritative GitHub
+1. Implement the platform verifier for Buildkite OIDC and authoritative GitHub
    event-to-build correlation.
-3. Implement empty-request policy, signed empty grants, JWKS publication, and
+1. Implement empty-request policy, signed empty grants, JWKS publication, and
    audit records without any credential backend.
-4. Add the `buildkite-gha` OIDC client and grant verifier behind explicit
+1. Add the `buildkite-gha` OIDC client and grant verifier behind explicit
    control-plane configuration.
-5. Add positive and negative conformance fixtures for signature, audience,
+1. Add positive and negative conformance fixtures for signature, audience,
    expiry, build/job/step/queue, plan/event digest, provider event, policy,
    capability broadening, key rotation, revocation, and service absence.
-6. Run one exact-commit hosted no-op proof and independently observe its audit
+1. Run one exact-commit hosted no-op proof and independently observe its audit
    binding before considering any credential-returning slice.
 
 ## Deferred decisions
@@ -385,7 +387,7 @@ grant.
 
 ## References checked
 
-- [Buildkite Agent OIDC](https://buildkite.com/docs/agent/cli/reference/oidc),
+- [Buildkite agent OIDC](https://buildkite.com/docs/agent/cli/reference/oidc),
   checked 2026-08-04
 - [Buildkite OIDC security guidance](https://buildkite.com/docs/pipelines/security/oidc),
   checked 2026-08-04

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -15,7 +15,7 @@ Buildkite separates them, and `buildkite-gha` preserves that boundary:
 | Build creation, repository events, branch/tag/PR filters, schedules, and manual builds | Buildkite pipeline integrations, settings, schedules, or manual/API build requests. Workflow run triggers and event filters are not imported. |
 | Steps in an existing build | The initial Buildkite pipeline definition plus dynamic pipeline uploads. The plugin adds admitted workflow jobs here. |
 | Job graph and step behavior | The supported `jobs`, matrices, `needs`, conditions, and `steps` subset in the selected Actions workflow. |
-| Agents and protected capabilities | Buildkite pipeline/organization configuration and admission policy. Workflow runner, permission, environment, and credential declarations are requests, not grants. |
+| Buildkite agent targeting and protected capabilities | Buildkite pipeline or organization configuration and admission policy. Workflow runner, permission, environment, and credential declarations are requests, not grants. |
 
 The imported workflow therefore cannot create, suppress, or reconfigure a
 Buildkite build. Some workflow-level execution controls, such as the documented
@@ -26,26 +26,27 @@ documented separately in the support matrix; it is not Buildkite trigger setup.
 
 ## The current execution profile
 
-The production plugin and its bundled `upload` command default to one fixed
-profile: `hosted-tokenless`. The README's pinned plugin v0.4.4 installs
-`buildkite-gha` v0.4.2 and explicitly selects the `hosted` queue. The current
-source CLI instead omits agent selectors by default and inherits Buildkite's
-configured agent targeting; `BUILDKITE_GHA_TARGET_QUEUE` can explicitly select
-one queue. Operators using default or explicit targeting are responsible for
-providing suitable whole-job isolation. The profile is designed for public code
-that can run without general protected credentials on a compatible Linux
-x86-64 agent. Unsupported or privileged requests fail before the generated jobs
-are uploaded. A compiler-verified checkout automatically declares bounded
-repository-provider read capability. At runtime it uses Buildkite's native Git
-credential helper only when the job environment indicates repository-provider
-credentials are available; otherwise the same checkout runs anonymously.
+The plugin and its `upload` command use the `hosted-tokenless` profile. Plugin
+and binary versions are independent. Plugin v0.7.1 defaults to `buildkite-gha`
+v0.7.1, while the README examples explicitly select `buildkite-gha` v0.7.2.
+Generated jobs omit agent selectors by default and inherit the pipeline or
+organization's configured agent targeting. An importer can set
+`BUILDKITE_GHA_TARGET_QUEUE` to select one queue. Operators using default or
+explicit targeting are responsible for providing suitable whole-job isolation.
+The profile is designed for public code that can run without general protected
+credentials on a compatible Linux x86-64 agent. Unsupported or privileged
+requests fail before the generated jobs are uploaded. A compiler-verified
+checkout automatically declares bounded repository-provider read capability.
+At runtime it uses Buildkite's native Git credential helper only when the job
+environment indicates repository-provider credentials are available; otherwise
+the same checkout runs anonymously.
 
 There are three different compatibility claims:
 
-1. **Compilable** — the workflow syntax and static job graph can be translated.
-2. **Admitted** — action sources resolve and the generated plans satisfy the
+1. **Compilable**: The workflow syntax and static job graph can be translated.
+1. **Admitted**: Action sources resolve and the generated plans satisfy the
    `hosted-tokenless` upload policy.
-3. **Runtime-proven** — the repository's conformance or hosted test suite has
+1. **Runtime-proven**: The repository's conformance or hosted test suite has
    executed that behavior successfully.
 
 Compilation alone is not admission, and admission does not execute arbitrary
@@ -76,7 +77,7 @@ service.
 | GitHub Actions area | Status | Current boundary |
 | --- | --- | --- |
 | Run triggers and event filters under `on:` | Not supported | Buildkite owns build creation and triggers. The plugin derives `pull_request` for pull-request builds and `push` for every other build; it does not create `schedule` or `workflow_dispatch` events or inputs. Direct CLI event snapshots can provide another event name, but workflow trigger entries are not matched and cannot create or suppress a Buildkite build. `on.workflow_call` is covered by the local reusable-workflows row below. |
-| Linux x86-64 host jobs and `runs-on` | Supported subset | `ubuntu-latest`, `ubuntu-24.04`, and `ubuntu-22.04` are accepted. The released plugin configuration targets `hosted`; the current source CLI uses Buildkite defaults unless `BUILDKITE_GHA_TARGET_QUEUE` selects a queue. This is label validation, not Ubuntu image parity. On Ubuntu hosts the runtime derives GitHub's `ImageOS` family (for example, `ubuntu24`) from the actual host `/etc/os-release`; other distributions leave it unset. |
+| Linux x86-64 host jobs and `runs-on` | Supported subset | `ubuntu-latest`, `ubuntu-24.04`, and `ubuntu-22.04` are accepted. Generated jobs use Buildkite defaults unless `BUILDKITE_GHA_TARGET_QUEUE` selects a queue. This is label validation, not Ubuntu image parity. On Ubuntu hosts the runtime derives GitHub's `ImageOS` family (for example, `ubuntu24`) from the actual host `/etc/os-release`; other distributions leave it unset. |
 | Static job graphs and `needs` | Supported | Dependencies, matrix fan-out/fan-in, logical results, and bounded outputs are transported between generated jobs. Retrying one producer can make result selection ambiguous; retry the whole build. |
 | Static matrices | Supported subset | Typed rows, `include`, `exclude`, compile-time `github`/event/`vars` values and `fromJSON`, exact dependency fan-out, and literal `max-parallel` are supported, with at most 256 expanded instances per job. Runtime matrices from `needs` or `steps` are not supported. `strategy.fail-fast` is accepted but not enforced: every expanded Buildkite job is uploaded and siblings are not canceled after a failure. |
 | `env` and `defaults.run` | Supported subset | Workflow/job/step environment precedence, shell, and workspace-confined working directories are supported. A whole environment map cannot be expression-valued. Only `bash` and `sh` shells are supported; the host default is `bash` and a job-container default is `sh`. |
@@ -98,7 +99,7 @@ service.
 | `run` steps | Supported subset | Linux `bash` and `sh`, environment/working-directory precedence, process-tree cancellation, and workspace confinement are supported. PowerShell, Python-as-shell, Windows command shells, and custom shell templates are not supported. |
 | Environment files | Supported | `GITHUB_OUTPUT`, `GITHUB_ENV`, `GITHUB_PATH`, `GITHUB_STATE`, and `GITHUB_STEP_SUMMARY`, including multiline values, are supported with bounded files and entries. `NODE_OPTIONS` remains blocked. Matching GitHub Runner behavior, actions may propagate `GITHUB_*` and `RUNNER_*` values to later `env` expressions; runtime-owned context values are overlaid with their canonical values when each step process launches. |
 | Workflow commands | Supported subset | `::add-mask`, `::stop-commands`, `::warning`, `::error`, `::group`, and `::endgroup` are supported. Groups flatten to linear Buildkite log sections. Debug and matcher commands are consumed without presentation behavior. `::notice`, command echo control, and other legacy commands are not supported. |
-| Step summaries | Supported | Summaries publish as bounded job-scoped Buildkite annotations. Requires Buildkite Agent v3.112 or newer. Oversized per-step summaries are skipped; the aggregate job summary is limited to 1 MiB. |
+| Step summaries | Supported | Summaries publish as bounded job-scoped Buildkite annotations. Requires Buildkite agent v3.112 or newer. Oversized per-step summaries are skipped; the aggregate job summary is limited to 1 MiB. |
 | Local actions | Supported subset | Workspace actions are digest-locked and reverified. JavaScript, composite, and compiler-verified Dockerfile runtimes are supported; other action runtimes are not. |
 | Public GitHub actions | Supported subset | Hosted importers use an available job-scoped Buildkite GitHub token only to resolve mutable tags and branches through the GitHub API; token-minting or redaction failure emits a sanitized warning before anonymous fallback, and local profile evaluation remains anonymous. Lowercase full commit SHAs require no REST resolution, and exact-commit archives are fetched anonymously and directly from codeload during import and runtime. Sources remain exact-commit locked, complete trees are digest-verified, and JavaScript/composite/Dockerfile runtime rules still apply. Private actions and actions that require unavailable GitHub services are not supported merely because source resolution succeeds. |
 | JavaScript actions | Supported | `node20` and `node24` declarations run on the managed, digest-verified Node 24 runtime, matching GitHub-hosted runners' current Node 20 deprecation behavior. The temporary `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` opt-out is not supported. Pre/main/post lifecycle, inputs, outputs, state, LIFO post ordering, and the standard cache-v2 environment are supported. Other Node action runtime declarations are not. |
@@ -132,12 +133,12 @@ service.
 ### Buildkite owns the run
 
 No shadow GitHub Actions run is created. Workflow jobs and matrix entries are
-visible as Buildkite jobs, with Buildkite scheduling, logs, cancellation,
-retries, and status.
+visible as Buildkite jobs, with scheduling, logs, cancellation, retries, and
+status managed in Buildkite Pipelines.
 
 Actions steps remain inside one compatibility runtime because they share a
 workspace, environment-file updates, action state, and cleanup lifecycle.
-Docker is another execution backend within that job—not a security boundary
+Docker is another execution backend within that job, not a security boundary
 between mutually untrusted steps. Use a disposable job VM when workflow code
 must be isolated from other jobs or the agent host.
 
@@ -227,11 +228,11 @@ one job workspace and lifecycle.
 ### Buildkite owns build creation and triggers
 
 Select the workflow explicitly in the plugin and configure pipeline triggers in
-Buildkite. `buildkite-gha` uses the event snapshot to populate Actions contexts;
-it does not subscribe to GitHub events or turn workflow `on:` entries into
-Buildkite triggers. The initial Buildkite pipeline invokes the importer after a
-build exists, and the importer can only add steps to that build through dynamic
-pipeline upload.
+Buildkite Pipelines. `buildkite-gha` uses the event snapshot to populate Actions
+contexts; it does not subscribe to GitHub events or turn workflow `on:` entries
+into Buildkite triggers. The initial Buildkite pipeline invokes the importer
+after a build exists, and the importer can only add steps to that build through
+dynamic pipeline upload.
 
 The plugin derives `pull_request` for Buildkite pull request builds and `push`
 for branch, tag, scheduled, and manual builds. It does not currently provide
@@ -246,18 +247,18 @@ semantics when Buildkite has not supplied them.
 
 ### Checkout starts clean
 
-Generated jobs skip Buildkite's default checkout and allocate a fresh Actions
-workspace. A supported `actions/checkout` step checks out the event repository
-at the exact event SHA, using GitHub's default depth 1 or explicit
-`fetch-depth: 0` for all branch and tag history. Compilation automatically adds
-`provider-token-read` only to a job containing the compiler-verified checkout
-adapter with its bounded inputs.
+Generated jobs skip the default checkout in Buildkite Pipelines and allocate a
+fresh Actions workspace. A supported `actions/checkout` step checks out the
+event repository at the exact event SHA, using GitHub's default depth 1 or
+explicit `fetch-depth: 0` for all branch and tag history. Compilation
+automatically adds `provider-token-read` only to a job containing the
+compiler-verified checkout adapter with its bounded inputs.
 
 At runtime, the fetch uses Buildkite's native
 `buildkite-agent git-credentials-helper` when
 `BUILDKITE_USE_REPOSITORY_PROVIDER_GIT_CREDENTIALS=true`, or when the legacy
 `BUILDKITE_USE_GITHUB_APP_GIT_CREDENTIALS=true` signal is present. The helper
-receives the current job identity and Agent access token, and the Buildkite
+receives the current job identity and agent access token, and the Buildkite
 backend decides whether to issue credentials for the concrete repository URL
 requested by Git. If neither signal is enabled, checkout is anonymous; the CLI
 does not try to infer repository visibility.
@@ -304,16 +305,16 @@ only `none` do not produce a token; `read-all`, `write-all`, and `id-token` are
 unsupported. A static token reference without a non-empty effective mapping
 fails compilation.
 
-The compiler normalizes names such as `pull-requests` to the Agent API's
+The compiler normalizes names such as `pull-requests` to the agent API's
 `pull_requests`, emits the exact map into a v6 plan, and records same-process
 provenance for upload admission. The runtime requests the token once from the
-current-job Agent endpoint. The service independently requires the requested
+current-job agent endpoint. The service independently requires the requested
 repository to match the pipeline's configured GitHub repository and applies
 its own permission allowlist and organization enablement. Those server-side
 checks are the authorization ceiling; the compiled map constrains the supported
 client path but is not a separate security boundary against code that obtains
-the current job's Agent access token. The token is registered with runtime and
-Agent redaction before expressions or steps can use it, and result values
+the current job's agent access token. The token is registered with runtime and
+agent redaction before expressions or steps can use it, and result values
 containing it are scrubbed.
 
 An explicit `secrets.GITHUB_TOKEN` reference continues to resolve through the
@@ -337,9 +338,9 @@ The producer-side adapter recognizes only the audited commits
 (v4) and
 `actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`
 (v7). It verifies the immutable action source and metadata, then replaces the
-whole upstream JavaScript lifecycle with a Buildkite Agent artifact upload. A
-mutable v4 or v7 reference is accepted only when resolution produces one of
-those audited commits.
+whole upstream JavaScript lifecycle with a native artifact upload through
+`buildkite-agent`. A mutable v4 or v7 reference is accepted only when resolution
+produces one of those audited commits.
 
 The supported inputs are `name`, `path`, `if-no-files-found`,
 `include-hidden-files`, `compression-level`, explicit `overwrite: false`, and
@@ -376,13 +377,13 @@ cache-v2 environment to the action.
 
 Before each JavaScript pre, main, or post phase and each Docker action that
 runs, the runtime attempts to post an empty body to the current job's
-`/v3/jobs/<BUILDKITE_JOB_ID>/ghac_tokens` Agent API endpoint using the ambient
+`/v3/jobs/<BUILDKITE_JOB_ID>/ghac_tokens` agent API endpoint using the ambient
 `BUILDKITE_AGENT_ACCESS_TOKEN`. The returned short-lived token is registered
 with both the local log scrubber and `buildkite-agent redactor add` before the
 action starts. A fresh token is minted for each invocation rather than
 retaining a broad job credential. The runtime exposes only
 `ACTIONS_CACHE_SERVICE_V2`, `ACTIONS_RESULTS_URL`, and
-`ACTIONS_RUNTIME_TOKEN`; it does not forward the Agent job token, persist cache
+`ACTIONS_RUNTIME_TOKEN`; it does not forward the agent job token, persist cache
 credentials into job state, or expose them to ordinary `run` steps or native
 adapters. Workflow-controlled cache service variables are discarded before
 the runtime-owned values are overlaid.
@@ -406,7 +407,7 @@ default. Operators can set `BUILDKITE_GHA_CACHE_URL` to override it with another
 compatible origin-only URL; a non-root path is rejected because the stock
 cache-v2 client uses root-relative Twirp endpoints. The Buildkite organization
 must have GHAC token minting enabled, and jobs must be able to reach both the
-Results service and the Agent API.
+Results service and the agent API.
 The service-issued token scopes cache access to the current organization and
 pipeline, grants writes only for an authorized ref, and limits cross-repository
 pull requests to the read-only default-branch scope. For the explicit audited
@@ -470,10 +471,10 @@ archive checksum, and extract it to a stable location. The archive contains
 Generated jobs that can execute JavaScript actions support mise 2026.5.12 or
 newer. `run-job` first checks `BUILDKITE_GHA_MISE` when set, then `PATH`; if
 neither supplies a compatible version, it downloads the pinned 2026.5.12
-official archive into the managed cache path. Hosted Agents attach that cache
-automatically; other agent environments use it when available and otherwise
-fall back to an ephemeral cache. Both the archive and extracted executable are
-verified by embedded SHA-256 digests before use.
+official archive into the managed cache path. Buildkite hosted agents attach
+that cache automatically; other agent environments use it when available and
+otherwise fall back to an ephemeral cache. Both the archive and extracted
+executable are verified by embedded SHA-256 digests before use.
 Verified cache bytes are copied into a job-private directory and reverified
 there before execution, so the shared cache remains an accelerator rather than
 executable authority. An explicit `BUILDKITE_GHA_MISE` must be absolute and
@@ -489,13 +490,13 @@ Importers, `validate`, and `compile` do not require or install mise either.
 
 Validate the static workflow subset without an event:
 
-```sh
+```bash
 buildkite-gha validate .github/workflows/ci.yml
 ```
 
 Apply the production profile with human-readable or machine-readable output:
 
-```sh
+```bash
 buildkite-gha validate --profile hosted-tokenless \
   --event-path .buildkite/events/current.json --format text \
   .github/workflows/ci.yml
@@ -543,7 +544,7 @@ and cannot authorize a protected capability.
 
 Render deterministic Buildkite pipeline YAML, or inspect the compiler IR:
 
-```sh
+```bash
 buildkite-gha compile --event-path .buildkite/events/current.json \
   .github/workflows/ci.yml
 
@@ -558,23 +559,21 @@ not a complete execution path.
 
 ### Upload
 
-`upload` is the in-build command used by the plugin. The current source CLI
-uses:
+`upload` is the in-build command used by the plugin. Plugin v0.7.1 invokes:
 
-```sh
+```bash
 buildkite-gha upload .github/workflows/ci.yml
 ```
 
-When invoking the v0.4.2 release directly, add `--runtime-queue hosted`; that
-release requires the argument and uses it to
-select the `hosted` queue.
+It does not pass `--runtime-queue`. The deprecated `--runtime-queue hosted` form
+remains an accepted no-op only for compatibility with legacy plugins.
 
 It requires `BUILDKITE=true` and `BUILDKITE_STEP_KEY`. Event source precedence
 is:
 
 1. An explicit `--event-path`. This never reads Buildkite metadata.
-2. Buildkite's reserved `buildkite:webhook` metadata for webhook-linked builds.
-3. A reduced-fidelity snapshot derived from `BUILDKITE_*` variables when
+1. Buildkite's reserved `buildkite:webhook` metadata for webhook-linked builds.
+1. A reduced-fidelity snapshot derived from `BUILDKITE_*` variables when
    Buildkite reports that the build is not webhook-triggered or its linked
    webhook is unavailable.
 
@@ -602,12 +601,12 @@ free of provider credentials.
 
 The command uploads the exact executable and content-addressed plans before
 calling `buildkite-agent pipeline upload --no-interpolation --reject-secrets`.
-In the current source CLI, generated jobs do not set `agents`, so Buildkite's
-pipeline or organization defaults select the agents. The deprecated
-`--runtime-queue hosted` argument remains accepted as a no-op for compatibility
-with plugin releases that pass it to v0.4.2; other values are rejected rather
-than silently ignored. The deprecated `--private-checkout` argument is also
-accepted as a no-op for one-release migration compatibility.
+Generated jobs do not set `agents`, so Buildkite's pipeline or organization
+defaults select the agents. The deprecated
+`--runtime-queue hosted` argument remains accepted as a deprecated no-op for
+legacy plugin compatibility; other values are rejected rather than silently
+ignored. The deprecated `--private-checkout` argument is also accepted as a
+no-op for one-release migration compatibility.
 
 An importer that must select one queue can set `BUILDKITE_GHA_TARGET_QUEUE` on
 its step. The uploader maps every accepted Linux runner label to that queue,

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,14 +4,14 @@
 
 The repository pins Go and all lint and release tools with mise:
 
-```sh
+```bash
 mise trust mise.toml
 mise install
 ```
 
 Run the complete repository check with:
 
-```sh
+```bash
 mise run check
 ```
 
@@ -26,7 +26,7 @@ live prerequisites and fails rather than silently losing Phase 5 coverage.
 
 Focused tasks are also available:
 
-```sh
+```bash
 mise run format
 mise run build
 mise run test
@@ -43,7 +43,7 @@ The smoke inventory deliberately separates three kinds of evidence.
 
 ### Network-free compilation
 
-```sh
+```bash
 mise run smoke:local
 ```
 
@@ -57,7 +57,7 @@ and the precise meaning of each expectation.
 
 ### Production-policy preflight
 
-```sh
+```bash
 mise run smoke:profile
 ```
 
@@ -91,7 +91,7 @@ execution.
 After the example workflows exist on the default branch, launch the same
 workflow at the current branch's exact remote commit in both products:
 
-```sh
+```bash
 scripts/compare-example basic
 scripts/compare-example artifacts
 scripts/compare-example advanced
@@ -110,7 +110,7 @@ not replace the normalized smoke evidence below.
 
 Run all implemented hosted proofs against one exact commit:
 
-```sh
+```bash
 commit=$(git rev-parse HEAD)
 test ${#commit} -eq 40
 bk build create --pipeline buildkite/buildkite-gha \
@@ -141,7 +141,7 @@ outcome does not by itself prove that Buildkite persisted the annotation. After
 the targeted or aggregate build settles, use an authenticated `bk` CLI with
 `read_builds` access to verify the job-scoped annotation independently:
 
-```sh
+```bash
 scripts/phase-6-summary-annotation-verify <build-number> <commit>
 ```
 
@@ -153,7 +153,7 @@ fragments.
 Workflow-command annotation publication is also advisory. Verify its distinct
 warning and error contexts independently after the annotations proof settles:
 
-```sh
+```bash
 scripts/phase-6-workflow-annotations-verify <build-number> <commit>
 ```
 
@@ -165,7 +165,7 @@ absence of the registered masking canary.
 Artifact publication and consumption require independent native-storage
 observations after their targeted or aggregate builds settle:
 
-```sh
+```bash
 scripts/phase-6-upload-artifact-verify <build-number> <commit>
 scripts/phase-6-artifact-roundtrip-verify <build-number> <commit>
 ```
@@ -181,7 +181,7 @@ advanced service-free workflow without adding another phase-specific proof. It
 builds the exact checked-out source locally, so it is runtime evidence rather
 than installation evidence:
 
-```sh
+```bash
 commit=$(git rev-parse HEAD)
 test ${#commit} -eq 40
 bk build create --pipeline buildkite/buildkite-gha \
@@ -228,7 +228,7 @@ repository's main branch after the CLI `v0.2.1` tag. They are current
 repository-demo UX rather than evidence about the released CLI runtime. Repeat
 the customer installation path with the current released-plugin demo:
 
-```sh
+```bash
 commit=$(git rev-parse HEAD)
 test ${#commit} -eq 40
 bk build create --pipeline buildkite/buildkite-gha \
@@ -241,7 +241,7 @@ action, and advanced workflows, then a native terminal step. Add the cache
 extension only for an organization with GHAC token minting enabled; the runtime
 uses the official Buildkite Results service by default:
 
-```sh
+```bash
 bk build create --pipeline buildkite/buildkite-gha \
   --branch "$(git branch --show-current)" --commit "$commit" \
   --env DEMO_SUITE=plugin --env DEMO_COMMIT="$commit" \
@@ -273,7 +273,7 @@ coverage, differential oracles, commits, and historical Buildkite evidence.
 
 From a clean, up-to-date `main`, run:
 
-```sh
+```bash
 mise run release
 ```
 

--- a/docs/plans/2026-07-22-buildkite-gha.md
+++ b/docs/plans/2026-07-22-buildkite-gha.md
@@ -1,8 +1,8 @@
-# `buildkite-gha`: GitHub Actions compatibility for Buildkite
+# buildkite-gha: GitHub Actions compatibility for Buildkite
 
 Status: **Active**
 Date: 2026-07-22
-Last reviewed: 2026-08-08
+Last reviewed: 2026-08-10
 Target repository: `buildkite/buildkite-gha`
 
 > This is the active product and implementation plan. It records future UX,
@@ -19,7 +19,7 @@ GitHub Actions workflow to run as a native Buildkite build. The project has two
 responsibilities:
 
 1. Compile a GitHub Actions workflow into ordinary Buildkite pipeline jobs.
-2. Execute the GitHub Actions steps inside each generated Buildkite job through
+1. Execute the GitHub Actions steps inside each generated Buildkite job through
    an Actions-compatible runtime.
 
 The intended entry point is conceptually:
@@ -28,7 +28,7 @@ The intended entry point is conceptually:
 buildkite-gha upload .github/workflows/ci.yml
 ```
 
-with a possible future Buildkite Agent integration:
+with a possible future Buildkite agent integration:
 
 ```bash
 buildkite-agent pipeline load-gha-workflow .github/workflows/ci.yml
@@ -74,15 +74,15 @@ parallel and background steps.
 A team should be able to:
 
 1. Create a Buildkite pipeline for an existing repository.
-2. Point it at an existing `.github/workflows/*.yml` file.
-3. Run the workflow on Buildkite with useful compatibility diagnostics and no
+1. Point it at an existing `.github/workflows/*.yml` file.
+1. Run the workflow on Buildkite with useful compatibility diagnostics and no
    GitHub Actions control-plane dependency.
-4. View progress and logs in Buildkite.
-5. Add native Buildkite jobs before or after the imported workflow.
-6. Replace individual imported jobs with native Buildkite jobs over time.
-7. Move the repository from GitHub to Cursor Origin while retaining the same
+1. View progress and logs in Buildkite.
+1. Add native Buildkite jobs before or after the imported workflow.
+1. Replace individual imported jobs with native Buildkite jobs over time.
+1. Move the repository from GitHub to Cursor Origin while retaining the same
    Buildkite pipeline and most portable actions.
-8. Remove the compatibility layer when the migration is complete.
+1. Remove the compatibility layer when the migration is complete.
 
 GitHub Actions becomes an accepted pipeline and action format, not the system
 of record.
@@ -175,7 +175,7 @@ runtime capabilities, and security-sensitive behavior before execution.
 
 The compiler records secret names and permission requirements, never values.
 The runtime resolves secrets inside the destination job, registers them with
-the Buildkite Agent redactor before action output can be emitted, and keeps
+the Buildkite agent redactor before action output can be emitted, and keeps
 them out of metadata, artifacts, generated YAML, and debug diagnostics.
 
 ## Goals
@@ -191,7 +191,7 @@ them out of metadata, artifacts, generated YAML, and debug diagnostics.
   uploads.
 - Provide deterministic compilation and a versioned intermediate
   representation.
-- Work through stable public Buildkite pipeline and Agent interfaces rather
+- Work through stable public Buildkite pipeline and agent interfaces rather
   than private Rails APIs.
 - Support GitHub and Cursor Origin as repository/event providers through a
   provider-neutral event and source interface.
@@ -263,7 +263,7 @@ buildkite-gha compile .github/workflows/ci.yml |
 ```
 
 `upload` is the ergonomic in-build command. It creates per-job plan artifacts,
-uploads the generated pipeline through the Buildkite Agent, and fails the
+uploads the generated pipeline through the Buildkite agent, and fails the
 bootstrap job if either operation fails.
 
 ### Initial Buildkite pipeline
@@ -319,7 +319,7 @@ visual insertion order is not an execution contract.
 ### Future first-class syntax
 
 Once the project is proven, Buildkite could recognize an import in its pipeline
-schema or expose it through the Agent:
+schema or expose it through the agent:
 
 ```yaml
 steps:
@@ -339,7 +339,7 @@ it.
 
 ## Architecture
 
-```diagram
+```text
 ┌──────────────────────────┐
 │ Workflow + event payload │
 └────────────┬─────────────┘
@@ -617,7 +617,7 @@ bootstrap contract is:
 - reject protected capability requests unless a matching control-plane grant
   can be established by the execution job.
 
-Buildkite signed pipelines are an optional Buildkite-specific defence-in-depth
+Buildkite signed pipelines are an optional Buildkite-specific defense-in-depth
 layer for installations that require uploaded step provenance. They are not a
 GitHub Actions compatibility requirement, and neither pipeline signatures nor
 plan signatures replace the protected capability service.
@@ -648,7 +648,7 @@ The emitter maps every expanded GHA job to an ordinary command step with:
 - the installation mechanism for the same pinned `buildkite-gha` version that
   performed compilation.
 
-Native checkout suppression requires Buildkite Agent v3.130.0 or later. The
+Native checkout suppression requires Buildkite agent v3.130.0 or later. The
 runtime must still allocate and verify a fresh empty directory for
 `GITHUB_WORKSPACE`; it must not assume that the agent command directory is empty
 or suitable merely because checkout was skipped. The generated command and
@@ -755,11 +755,11 @@ strategy:
 Represent these as deferred graph continuations:
 
 1. Compile and upload the known prerequisite graph.
-2. The prerequisite publishes a bounded, producer-attributed result manifest.
-3. A generated continuation command downloads that manifest from the exact
+1. The prerequisite publishes a bounded, producer-attributed result manifest.
+1. A generated continuation command downloads that manifest from the exact
    prerequisite step and verifies its plan identity.
-4. The compiler expands only the newly available portion of the graph.
-5. It publishes immutable plans and uploads the downstream Buildkite jobs with
+1. The compiler expands only the newly available portion of the graph.
+1. It publishes immutable plans and uploads the downstream Buildkite jobs with
    stable keys.
 
 Continuations are ordinary authoritative dynamic uploads within the same
@@ -798,22 +798,22 @@ protocol against a real partially retried build.
 job. Its state machine is:
 
 1. Verify the job plan and runtime version.
-2. Load producer-attributed prerequisite results and outputs, evaluate the job
+1. Load producer-attributed prerequisite results and outputs, evaluate the job
    condition, and, when false, record `skipped` and exit successfully without
    resolving secrets or starting containers.
-3. Resolve non-secret variables and required secrets.
-4. Register every resolved secret with the Buildkite Agent redactor.
-5. Create an empty GHA workspace and temporary directories.
-6. Start the job container and service containers, if configured.
-7. Resolve and prepare local and remote actions.
-8. Execute pre-actions in required order.
-9. Execute main steps, evaluating each condition at step start.
-10. Process workflow commands and environment files after every step.
-11. Execute post-actions in LIFO order, including after failure or cancellation
+1. Resolve non-secret variables and required secrets.
+1. Register every resolved secret with the Buildkite agent redactor.
+1. Create an empty GHA workspace and temporary directories.
+1. Start the job container and service containers, if configured.
+1. Resolve and prepare local and remote actions.
+1. Execute pre-actions in required order.
+1. Execute main steps, evaluating each condition at step start.
+1. Process workflow commands and environment files after every step.
+1. Execute post-actions in LIFO order, including after failure or cancellation
     within a bounded cleanup period.
-12. Evaluate and record job outputs and the logical job result.
-13. Publish step summaries and perform container/process cleanup.
-14. Exit with the Buildkite result corresponding to the logical GHA result.
+1. Evaluate and record job outputs and the logical job result.
+1. Publish step summaries and perform container/process cleanup.
+1. Exit with the Buildkite result corresponding to the logical GHA result.
 
 Generated GHA jobs should begin with an empty workspace rather than Buildkite's
 automatic repository checkout. This preserves Actions behavior for workflows
@@ -825,7 +825,7 @@ populated the workspace, as they do in GitHub Actions.
 
 Support these step/action types:
 
-#### `run` steps
+#### Run steps
 
 - GHA default-shell selection and shell flags;
 - `defaults.run.shell` and `working-directory`;
@@ -984,10 +984,10 @@ Actions fall into three product categories:
 1. **Portable actions** operate on the workspace, execute tools, or call an
    independent external API. Run their JavaScript, container, or composite
    implementation directly.
-2. **Actions-runtime integrations** depend on GitHub's cache, artifact, OIDC,
+1. **Actions-runtime integrations** depend on GitHub's cache, artifact, OIDC,
    or token services. Provide Buildkite-backed protocol services or explicit
    compatibility adapters.
-3. **Provider-dependent actions** modify GitHub repositories, pull requests,
+1. **Provider-dependent actions** modify GitHub repositories, pull requests,
    checks, issues, or releases. They can use a scoped GitHub token while GitHub
    is the repository provider. Under Cursor Origin they require an Origin
    equivalent or must be migrated.
@@ -1008,7 +1008,7 @@ repository metadata while preserving the action's documented inputs and
 outputs. Cache and artifact support should use Buildkite storage semantics
 without exposing GitHub's private service credentials.
 
-### Triggers and workflow `on`
+### Triggers and workflow event configuration
 
 `buildkite-gha` does not itself listen for repository events. A Buildkite
 pipeline integration, schedule, manual or API build request, or future Origin
@@ -1062,7 +1062,7 @@ authority.
   admitted queues for untrusted code.
 - Provider API tokens are short-lived and least-privilege.
 - Reusable workflows can only narrow inherited permissions.
-- Every secret is registered with the Agent redactor before use.
+- Every secret is registered with the agent redactor before use.
 - Job outputs containing registered secret literals or explicitly supported
   standard encodings are rejected rather than published; general secret taint
   tracking is out of scope.
@@ -1111,7 +1111,7 @@ release, verifies its checksum and fixed archive layout, caches the verified
 distribution, and invokes the tokenless upload path. For action
 jobs, the static bridge reuses mise 2026.5.12 or newer when available or
 downloads and digest-verifies its pinned 2026.5.12 official archive in the
-integration-owned managed cache path. Hosted Agents attach that cache
+integration-owned managed cache path. Buildkite hosted agents attach that cache
 automatically; other agent environments use it when available and otherwise
 fall back to ephemeral storage. Node 20.20.2 and 24.18.0 are installed by a
 reverified, job-private copy of that executable on demand into the same cache.
@@ -1243,7 +1243,7 @@ implemented and admitted surface today.
 
 The first externally useful beta should support:
 
-- Linux x86-64 on a compatible Hosted Agent image;
+- Linux x86-64 on a compatible Buildkite hosted agent image;
 - `push`, `pull_request`, and manual-input event envelopes;
 - `env`, `defaults`, `needs`, job and step `if`, timeouts, and bounded outputs;
 - static matrices with `include`, `exclude`, and `max-parallel`, plus
@@ -1385,10 +1385,11 @@ public checkout remains a separate provider integration gate.
   masking, so the distinct checked-in hosted fixture is now `runtime-pass`.
   The producer-side artifact slice now recognizes only the audited
   `actions/upload-artifact` v4 commit and replaces its lifecycle with a bounded
-  Buildkite Agent upload. Literal workspace files and directories become an
-  immutable, digest-addressed ZIP; compatible artifact ID and digest outputs
-  and the native path, size, and file count are bound into the authoritative
-  terminal result manifest. Globs, symlinks, overwrite, retention, raw upload,
+  native artifact upload through `buildkite-agent`. Literal workspace files and
+  directories become an immutable, digest-addressed ZIP; compatible artifact ID
+  and digest outputs and the native path, size, and file count are bound into
+  the authoritative terminal result manifest. Globs, symlinks, overwrite,
+  retention, raw upload,
   and unrecognized upstream commits fail explicitly. Build 259 and its
   exact-commit artifact observation prove publication, attribution, manifest
   binding, archive integrity and contents, hidden-file exclusion, and compatible
@@ -1411,7 +1412,7 @@ public checkout remains a separate provider integration gate.
   The runtime mints a fresh, job-bound GHAC token for each action lifecycle
   phase, registers it with both redaction layers before execution, and exposes
   the three cache-v2 variables only to the verified cache action. The ambient
-  Agent job token never enters action code or plan/result state. Older majors,
+  agent job token never enters action code or plan/result state. Older majors,
   other commits, unsafe mint responses, redirects, missing service
   configuration, and redaction failure all fail closed. The then-combined
   advanced migration POC forms the exact-commit implementation proof: it
@@ -1490,7 +1491,7 @@ public checkout remains a separate provider integration gate.
 - All local tests, race tests, vet, schema fixtures, shell checks, and offline
   pipeline validation pass. A default `.buildkite/pipeline.yml` now runs the
   repository checks, and all compilable smoke-manifest outputs pass the current
-  Buildkite Agent's `pipeline upload --dry-run --no-interpolation` parser.
+  `buildkite-agent pipeline upload --dry-run --no-interpolation` parser.
 - The smoke inventory now separates compilation, production-policy admission,
   and runtime evidence. `mise run smoke:local` is network-free: it validates
   the manifest and workflows and checks deterministic compilation, but is not
@@ -1654,8 +1655,9 @@ Phase 2 live evidence:
 - [Buildkite build 40](https://buildkite.com/buildkite/buildkite-gha/builds/40)
   ran exact implementation commit
   `e93298085ffef96e1cb0982e7a0b88f3558b11da`. The producer and both consumer
-  matrix jobs passed on ephemeral hosted Agent `4.0.0-beta.6`, followed by the
-  native Buildkite continuation and the full repository check.
+  matrix jobs passed on an ephemeral hosted agent running Buildkite agent
+  `4.0.0-beta.6`, followed by the native Buildkite continuation and the full
+  repository check.
 - The consumer logs emitted the normalized observations
   `{"result":"smoke-shell","variant":"one"}` and
   `{"result":"smoke-shell","variant":"two"}`, matching the checked-in
@@ -1682,7 +1684,7 @@ Phase 0 live evidence:
   passed the complete transport at commit
   `787b3adfe306a17fbf073c70b24f8b747b5882a8`: immutable plan artifacts,
   producer-constrained result download, generated dependency execution, native
-  dependency extension, metadata visibility, and Agent redaction all passed.
+  dependency extension, metadata visibility, and agent redaction all passed.
 - [Buildkite build 15](https://buildkite.com/buildkite/buildkite-gha/builds/15)
   proved that the consumer runs and verifies a failure manifest after its
   producer fails. [Buildkite build 19](https://buildkite.com/buildkite/buildkite-gha/builds/19)
@@ -1699,7 +1701,7 @@ Phase 0 spike support snapshot:
 | Compile | Actionlint-backed owned model, deterministic compile-time context and vars evaluation, bounded local reusable-workflow flattening, source-ordered matrix `include`/`exclude`, exact dependency fan-out, policy-selected queues, schema-valid versioned plans, and Buildkite pipeline YAML | Runtime-dependent graph expressions, remote reusable workflows, unsupported operating systems, and unmapped runner labels fail closed |
 | Execute | Bash/sh steps; ten-active-step concurrency with barrier-scoped effects; JavaScript, composite, and Dockerfile actions; persistent job containers; services for container and host jobs; fresh workspaces; bounded prerequisite, step, and job outputs; file commands; conditions; masking; timeouts; process-tree cancellation; `continue-on-error`; bounded LIFO post-actions; and exact container cleanup | Producer result hydration enters through the transport boundary; private actions, `docker://` actions, protected credentials, arbitrary container options, unsupported operating systems, and unsupported expression/coercion forms fail closed |
 | Differential | Isolated committed fixture, canonical capture/comparison, offline validation, and matching hosted GitHub Actions and Buildkite observations | Broader runtime behavior remains phase-specific differential work |
-| Transport | Confined materialization of verified content-addressed plan and binding bytes, deterministic two-job live upload, strict compiler edges, failure-settling logical edges, producer-bound manifests, metadata, Agent redaction, signed markers, and native dependency extension | The probe deliberately avoids assuming upload atomicity |
+| Transport | Confined materialization of verified content-addressed plan and binding bytes, deterministic two-job live upload, strict compiler edges, failure-settling logical edges, producer-bound manifests, metadata, agent redaction, signed markers, and native dependency extension | The probe deliberately avoids assuming upload atomicity |
 | Authorization | Eight signed-envelope conformance cases plus live rejection of a corrupted signature prove bounded signing and verification mechanics only | Protected capabilities require Buildkite Job OIDC authentication, provider provenance and policy verification, narrow signed grants, runtime exchange checks, and auditability; Buildkite signed-pipeline integration remains optional Phase 9 work |
 | Recovery | Ambiguous, partial, conflicting, or unattested interrupted uploads fail closed; a live interrupted upload and retry returned exit 75 | Operator cancel/rebuild is the supported recovery until Buildkite exposes an authoritative completed-upload query |
 
@@ -1719,11 +1721,11 @@ Build four spikes before committing to the runtime implementation:
 
 1. Parse and compile representative workflows using selected `act` and
    `actionlint` components into an owned intermediate representation.
-2. Run one JavaScript, one composite, and one Docker action inside a Buildkite
+1. Run one JavaScript, one composite, and one Docker action inside a Buildkite
    job while preserving outputs, masks, environment changes, and post-actions.
-3. Run equivalent fixture workflows on GitHub Actions and Buildkite and compare
+1. Run equivalent fixture workflows on GitHub Actions and Buildkite and compare
    normalized observations.
-4. Exercise the complete transport on a real Buildkite build: upload immutable
+1. Exercise the complete transport on a real Buildkite build: upload immutable
    plan artifacts, dynamically upload two dependent jobs, download and verify
    plans by compiler step, publish and consume producer-attributed result
    manifests, verify per-dependency failure handling keeps the compiler edge
@@ -1750,7 +1752,7 @@ Definition of done:
 - Compiler and runtime boundaries are proven without a GitHub runner service.
 - The action runtime can stream already-masked output into a Buildkite job.
 - Plan artifact ordering, dynamic dependency extension, metadata visibility,
-  producer attribution, and Agent redaction are proven in a real build.
+  producer attribution, and agent redaction are proven in a real build.
 - Interrupted-upload recovery is proven in a real build when a documented
   verification query exists; otherwise the fail-closed path and explicit
   operator recovery are proven and recorded as the supported behavior.
@@ -1829,14 +1831,14 @@ Delivery slices:
    conditions and status functions, environment precedence, supported shells
    and working directories, file commands, timeouts, cancellation,
    `continue-on-error`, and bounded cleanup.
-2. Promote the Phase 0 result probe into production transport contracts:
+1. Promote the Phase 0 result probe into production transport contracts:
    canonical producer-attributed manifests, exact-step artifact download,
    bounded metadata mirrors, and verified `needs` injection.
-3. Implement `buildkite-gha upload` for the explicit unprivileged local-event
+1. Implement `buildkite-gha upload` for the explicit unprivileged local-event
    mode, materializing immutable plans before dynamically uploading the
    generated pipeline. Protected capabilities remain unavailable until the
    control plane for that capability exists.
-4. Run `testdata/smoke/.github/workflows/shell.yml` on Buildkite, compare its
+1. Run `testdata/smoke/.github/workflows/shell.yml` on Buildkite, compare its
    normalized observation with the GitHub Actions oracle, exercise failure and
    cancellation cleanup, and inspect raw logs for the secret fixture.
 
@@ -1918,16 +1920,16 @@ Implemented order and fixed boundaries:
    the verified action tree, select `buildx build --builder default --load`, use
    fixed structured mounts and bridge-owned labels, and stop/remove containers
    and images under an independent bounded cleanup context.
-2. Admit only local and anonymously resolved public Dockerfile actions on the
+1. Admit only local and anonymously resolved public Dockerfile actions on the
    tokenless path. Generated jobs use Buildkite's configured agent defaults;
    operators must provide suitable whole-job Docker isolation. Continue
    rejecting `docker://` images, Docker pre/post entrypoints, arbitrary Docker
    options, private registries, credentials, provider tokens, host namespaces,
    devices, socket mounts, and privileged capabilities.
-3. Persistent job containers and path translation landed after Docker action
+1. Persistent job containers and path translation landed after Docker action
    lifecycle, command-file processing, masking, cancellation, and cleanup
    passed conformance coverage.
-4. Services, aliases, port context, health diagnostics, and startup/orphan
+1. Services, aliases, port context, health diagnostics, and startup/orphan
    cleanup use the same runtime-owned backend. Imported container definitions
    are not translated into workflow-controlled Buildkite plugins.
 
@@ -1974,7 +1976,7 @@ the narrowest available boundary:
   current-job endpoint's server-side repository and permission policy;
 - step summaries and annotations.
 
-Prefer documented Buildkite storage and Agent interfaces. If an action toolkit
+Prefer documented Buildkite storage and agent interfaces. If an action toolkit
 requires an HTTP protocol, use the official compatible service by default with
 an explicit operator override, or provide a well-defined adapter rather than
 proxying GitHub's private service. Cache credentials authorize storage access
@@ -1982,7 +1984,7 @@ only; they are distinct from the provider-feature grants below.
 
 For the native repository and scoped-token exceptions, the Buildkite backend's
 repository checks and permission allowlists are the authorization ceiling. The
-runtime omits the Agent access token from ordinary workflow subprocess
+runtime omits the agent access token from ordinary workflow subprocess
 environments, but that inheritance control is not OS-level isolation between
 hostile processes in one job. Exact checkout inputs and compiled workflow
 permissions constrain the supported client path rather than replacing the
@@ -2006,19 +2008,19 @@ Delivery slices:
 
 1. Ship artifact, summary, and public-checkout adapters without a service
    dependency.
-2. Run only the audited `actions/cache` v6.1.0 client against cache-v2, minting
+1. Run only the audited `actions/cache` v6.1.0 client against cache-v2, minting
    short-lived credentials through the exact current Buildkite job and keeping
-   all Agent authority outside action code.
-3. Prove Job OIDC authentication, build/job binding, GitHub provenance checks,
+   all agent authority outside action code.
+1. Prove Job OIDC authentication, build/job binding, GitHub provenance checks,
    policy evaluation, and signed no-op grants before returning credentials.
-4. Add private source through the narrowest practical credential or download
-   interface. Exact event-repository checkout uses the existing Buildkite Agent
+1. Add private source through the narrowest practical credential or download
+   interface. Exact event-repository checkout uses the existing Buildkite agent
    Git credential helper; private actions and private reusable-workflow source
    remain separate work.
-5. Add scoped GitHub tokens, selected secrets, and environment grants. The
-   job-bound Agent endpoint now covers explicit workflow tokens; selected
+1. Add scoped GitHub tokens, selected secrets, and environment grants. The
+   job-bound agent endpoint now covers explicit workflow tokens; selected
    secrets and general provenance-aware grants remain.
-6. Prefer direct Buildkite OIDC migration, then add only explicitly supported
+1. Prefer direct Buildkite OIDC migration, then add only explicitly supported
    compatibility-issuer claims for providers that cannot consume it directly.
 
 Status: the GitHub/tokenless portion of slice 1 and all of slice 2 are
@@ -2107,7 +2109,7 @@ Complete:
 - protected capability service availability, abuse controls, audit retention,
   key rotation, revocation, and external security review;
 - signed releases, checksums, provenance, and SBOMs;
-- Hosted Agent image integration;
+- Buildkite hosted agent image integration;
 - the installer Buildkite plugin;
 - metrics for compile time, runtime overhead, action compatibility, and failures;
 - user-facing compatibility documentation; and
@@ -2263,7 +2265,7 @@ Run real builds that exercise:
 - untrusted pull-request policy.
 
 The full Buildkite path must be tested; a local Docker harness cannot prove
-dynamic pipeline, Agent redaction, artifact, metadata, or cancellation behavior.
+dynamic pipeline, agent redaction, artifact, metadata, or cancellation behavior.
 
 ### Fuzzing and security tests
 
@@ -2340,7 +2342,7 @@ compatibility may justify Buildkite additions:
 - UI treatment for generated/imported pipelines and compatibility findings.
 
 Each addition should be proposed only after the standalone implementation
-proves that a public Agent or pipeline contract cannot provide the required
+proves that a public agent or pipeline contract cannot provide the required
 behavior safely.
 
 ## Beta readiness reconciliation
@@ -2394,7 +2396,7 @@ public-beta declaration. It has two explicit lanes:
    artifact transfer, summaries, warning/error annotations, and a native
    continuation without depending on the capability service or a cache
    service.
-2. The cache extension uses the same released plugin and CLI with an explicitly
+1. The cache extension uses the same released plugin and CLI with an explicitly
    configured origin-only Results URL. It additionally proves the audited
    `actions/cache` v6.1.0 miss, post-save, and direct-dependent hit using
    short-lived credentials minted for the exact Buildkite job. The development
@@ -2404,11 +2406,11 @@ public-beta declaration. It has two explicit lanes:
 Both lanes must start from ordinary documented plugin configuration rather
 than a repository-only importer. A recorded run must name the exact Git commit,
 plugin revision, CLI release, Buildkite build, and any cache prerequisite. A
-clean Hosted Agent must be able to repeat the run without an unpublished local
-binary or retained workspace state. The visible result should contain the
-importer, generated jobs at basic through advanced complexity, native logs and
-dependencies, artifact and cache observations, and the final native
-continuation.
+clean Buildkite hosted agent must be able to repeat the run without an
+unpublished local binary or retained workspace state. The visible result should
+contain the importer, generated jobs at basic through advanced complexity,
+native logs and dependencies, artifact and cache observations, and the final
+native continuation.
 
 The demo gap closed in this order, using small cross-repository changes:
 
@@ -2416,20 +2418,20 @@ The demo gap closed in this order, using small cross-repository changes:
    stable representative fixtures. Keep the service-free baseline independent
    of the cache extension, remove development-only source rewriting from the
    plugin path, and preserve deterministic compile/admission coverage locally.
-2. Completed: run the full local gate and existing exact-commit hosted proofs,
+1. Completed: run the full local gate and existing exact-commit hosted proofs,
    then publish the resulting CLI as `v0.2.0` with its current checksummed
    archive contract. The plugin cannot prove the current runtime before that
    runtime has a public immutable release; failures found by the plugin proof
    are fixed in a patch release rather than by replacing release assets.
-3. Completed: in the companion plugin repository, default to the proven CLI
+1. Completed: in the companion plugin repository, default to the proven CLI
    release, add a live installer/plugin smoke lane alongside the existing
    isolated tests, and document the exact prerequisites. Prove the candidate
    plugin commit against both demo lanes before tagging the plugin.
-4. Completed: tag the companion plugin, update this repository's quick start
+1. Completed: tag the companion plugin, update this repository's quick start
    from the temporary commit pin to that tag, and rerun both demo lanes using
    only the published configuration. Record those exact runs as the
    authoritative installation and demo evidence.
-5. Ongoing: use failures and diagnostics from those runs and real customer
+1. Ongoing: use failures and diagnostics from those runs and real customer
    workflow migrations to drive small compatibility or UX changes. The first
    external migration passed at `mcncl/gotyper` commit
    `8a74f88676a120e0bc6090b1aafc65edfd62ebbe`; several more remain. Do not add
@@ -2438,22 +2440,22 @@ The demo gap closed in this order, using small cross-repository changes:
 This milestone does not by itself satisfy every public-beta gate. The initial
 support target still names manual-input event envelopes plus job and service
 containers that the production plugin does not expose or admit. The release
-gate also currently requires signed, repeatable Hosted and self-hosted
-installation even though the released production plugin is checksummed and
-explicitly targets the Hosted queue. The current source CLI instead inherits
-Buildkite's configured agent targeting by default. Those are explicit scope
-decisions: either implement and prove them or deliberately revise the beta
-contract before claiming the initial support target is complete. A production
-cache endpoint and several customer migrations beyond the first
-`mcncl/gotyper` proof are also still outstanding. The signed no-op capability
-grant remains a parallel security-foundation item, not permission to block or
-weaken the service-free demo.
+gate also currently requires signed, repeatable hosted and self-hosted
+installation even though the released plugin is checksummed and, like the
+current CLI, inherits the pipeline or organization default agent targeting.
+Those are explicit scope decisions: either implement and prove them or
+deliberately revise the beta contract before claiming the initial support target
+is complete. A production cache endpoint and several customer migrations beyond
+the first `mcncl/gotyper` proof are also still outstanding. The signed no-op
+capability grant remains a parallel security-foundation item, not permission to
+block or weaken the service-free demo.
 
 ## Release gates
 
 ### Private alpha
 
-- Shell, JavaScript, and composite fixtures pass on Linux Hosted Agents.
+- Shell, JavaScript, and composite fixtures pass on Linux Buildkite hosted
+  agents.
 - The validator catches unsupported containers, platforms, and event fields.
 - Logs and outputs are native Buildkite data.
 - No GitHub Actions run or private runner protocol is involved.
@@ -2490,7 +2492,7 @@ runtime, hosted images, service protocols, and repository APIs. Manage scope
 through explicit compatibility levels, differential fixtures, and a Linux-first
 support contract rather than claiming universal compatibility.
 
-### Reusing `act` creates upstream coupling
+### Reusing act creates upstream coupling
 
 `act` provides the fastest Go starting point but is optimized for local
 container execution, not Buildkite compilation and hosted-agent fidelity. Own
@@ -2557,7 +2559,7 @@ unknown plan.
   build/job/queue binding in Phase 0. It is retained as an integrity mechanism,
   not as production capability authorization.
 - Buildkite pipeline signing protects uploaded command provenance and remains
-  optional installation-specific defence in depth; it is not required for
+  optional installation-specific defense in depth; it is not required for
   tokenless Actions compatibility.
 - Concurrent Actions steps require their own supervisor and conformance surface;
   they are now an explicit delivery phase rather than an unowned beta promise.
@@ -2573,39 +2575,39 @@ unknown plan.
    producer-attributed artifacts bound to the build, importer, target job, step,
    queue, compiler, and workflow. These bindings protect transport but do not
    authorize protected resources.
-2. The bootstrap is an ordinary Buildkite dynamic pipeline generator. It runs a
+1. The bootstrap is an ordinary Buildkite dynamic pipeline generator. It runs a
    pinned verified distribution, treats provider-fetched workflow text as inert
    data, exposes no ambient protected credential in tokenless mode, and emits
    fixed fail-closed job definitions.
-3. Buildkite signed pipelines are not required for the initial implementation.
-   Buildkite step signing is optional defence in depth and is deferred to Phase
-   9. Protected capabilities are separately authorized by the Phase 6 control
-   plane after Buildkite Job OIDC authentication.
-4. Generated compatibility jobs set `checkout.skip: true`, require Buildkite
-   Agent v3.130.0 or later, and allocate a fresh `GITHUB_WORKSPACE` themselves.
-5. Parallel and background steps remain in the beta target and are implemented
+1. Buildkite signed pipelines are not required for the initial implementation.
+   Buildkite step signing is optional defense in depth and is deferred to
+   Phase 9. Protected capabilities are separately authorized by the Phase 6
+   control plane after Buildkite Job OIDC authentication.
+1. Generated compatibility jobs set `checkout.skip: true`, require Buildkite
+   agent v3.130.0 or later, and allocate a fresh `GITHUB_WORKSPACE` themselves.
+1. Parallel and background steps remain in the beta target and are implemented
    in a dedicated phase after the sequential shell runtime.
-6. Static local reusable workflows are compiled in Phase 1. Phase 7 adds dynamic
+1. Static local reusable workflows are compiled in Phase 1. Phase 7 adds dynamic
    matrices and remote reusable workflows without reimplementing the local
    compiler path.
-7. Import actionlint v1.7.12 unchanged as the syntax frontend and immediately
+1. Import actionlint v1.7.12 unchanged as the syntax frontend and immediately
    adapt it into owned models. Keep act v0.2.89 and Actions runner v2.336.0 as
    pinned behavioral oracles; do not import or fork act for production.
-8. The Phase 0 envelope experiment uses detached ES256 JWS over bounded RFC 8785
+1. The Phase 0 envelope experiment uses detached ES256 JWS over bounded RFC 8785
    canonical claims and remains separate from Buildkite pipeline signing. It
    proves signing mechanics only. The production capability-grant profile, key
    custody, rotation, revocation, and audit contract are Phase 6 decisions.
-9. Explicit bridge, provider, and Buildkite variable maps use
+1. Explicit bridge, provider, and Buildkite variable maps use
    `Bridge < Provider < Buildkite` precedence and are snapshotted into every
    compiled plan.
-10. No current Buildkite query authoritatively verifies a completed dynamic
+1. No current Buildkite query authoritatively verifies a completed dynamic
     upload after interruption. Recovery fails closed with exit 75 and requires
     the operator to cancel and rebuild.
-11. Until Buildkite has a scheduler-visible skipped result, a runtime-skipped
+1. Until Buildkite has a scheduler-visible skipped result, a runtime-skipped
     imported job exits successfully after publishing its logical `skipped`
     result and emits a clear annotation. Downstream compatibility semantics use
     the logical result rather than the Buildkite job state.
-12. Generated jobs omit Buildkite agent targeting by default. Empty runner
+1. Generated jobs omit Buildkite agent targeting by default. Empty runner
     policy mappings mean "use Buildkite defaults"; explicit queue mappings
     remain available to embedding API callers. Schema v7 makes
     `target.queue` optional, and only explicit targets are runtime-verified.
@@ -2620,21 +2622,21 @@ them in the phase that first needs the capability:
 1. Phase 6 control-plane work will determine which authenticated GitHub event
    payload Buildkite exposes, whether the service must receive GitHub App
    webhooks directly, and whether a small Buildkite platform API is missing.
-2. Phase 5 uses direct Hosted Agent execution. Exact-commit build 102 proved
-   the local `default` Docker driver and queue prerequisites; build 136 proved
-   the complete container runtime. Importers can now opt generated jobs into an
-   immutable toolchain-enabled image; the default image and fresh job-private
-   tool cache remain unchanged when no image is selected.
-3. Phase 4 will set the customer-beta event and expression subset from the
+1. Phase 5 uses direct Buildkite hosted agent execution. Exact-commit build 102
+   proved the local `default` Docker driver and queue prerequisites; build 136
+   proved the complete container runtime. Importers can now opt generated jobs
+   into an immutable toolchain-enabled image; the default image and fresh
+   job-private tool cache remain unchanged when no image is selected.
+1. Phase 4 will set the customer-beta event and expression subset from the
    hosted differential corpus.
-4. Phase 6 will define Cursor Origin checkout, event, pull-request, Job OIDC,
+1. Phase 6 will define Cursor Origin checkout, event, pull-request, Job OIDC,
    and short-lived capability contracts alongside the GitHub provider adapter.
-5. The Phase 5 probe on Buildkite's `hosted` queue proves this repository's
+1. The Phase 5 probe on Buildkite's `hosted` queue proves this repository's
    Dockerfile-action evidence, not a product scheduling requirement. Deployments
    using Buildkite defaults must independently provide suitable whole-job
    isolation. Phases 6 and 9 still own authorization and queue policy for
    protected Docker capabilities and privileged workloads.
-6. The narrow token contract is now defined for static
+1. The narrow token contract is now defined for static
    `secrets.GITHUB_TOKEN` references and effective action metadata input
    defaults that reference `github.token`, with a narrow `contents:read` product
    default when permissions are omitted, non-empty effective permission maps,
@@ -2653,22 +2655,22 @@ matrix](../compatibility.md#support-matrix).
 1. A Buildkite bootstrap job runs `buildkite-gha upload` on
    `testdata/smoke/.github/workflows/ci.yml` materialized as the fixture
    repository.
-2. The compiler emits two native Buildkite jobs with a dependency between them.
-3. The first job runs a shell step, a JavaScript action, and a composite action.
-4. It publishes a bounded output, which the second job consumes through its
+1. The compiler emits two native Buildkite jobs with a dependency between them.
+1. The first job runs a shell step, a JavaScript action, and a composite action.
+1. It publishes a bounded output, which the second job consumes through its
    producer-attributed result manifest.
-5. The runtime separately uploads and downloads a Buildkite-native diagnostic
+1. The runtime separately uploads and downloads a Buildkite-native diagnostic
    artifact to prove job transport. The later Phase 6 slices added the bounded
    `actions/upload-artifact` and exact-name `actions/download-artifact`
    adapters now listed in the support matrix.
-6. Both jobs stream masked logs and display action warnings and summaries in
+1. Both jobs stream masked logs and display action warnings and summaries in
    Buildkite.
-7. A native Buildkite job depends on the imported workflow and succeeds.
-8. The same `ci.yml` fixture runs on GitHub Actions and produces the checked-in
+1. A native Buildkite job depends on the imported workflow and succeeds.
+1. The same `ci.yml` fixture runs on GitHub Actions and produces the checked-in
    output observation plus equivalent normalized log and action-lifecycle
    events; the Buildkite-native transport artifact is excluded from differential
    comparison.
-9. Generated jobs skip checkout, create fresh workspaces, and reject a plan
+1. Generated jobs skip checkout, create fresh workspaces, and reject a plan
    whose digest or build, importer, job, step, queue, or runtime binding does not
    match. The tokenless queue exposes no ambient protected credential.
 

--- a/testdata/oss/README.md
+++ b/testdata/oss/README.md
@@ -28,7 +28,7 @@ The initial ten cases deliberately mix outcomes:
 
 Run the networked compile corpus with:
 
-```sh
+```bash
 mise run corpus:oss
 ```
 
@@ -40,7 +40,7 @@ Compiler determinism remains covered by the repository-owned smoke fixtures.
 The profile scan resolves public actions and treats only admitted workflows as
 passing:
 
-```sh
+```bash
 mise run corpus:oss-profile
 mise run corpus:oss-profile -- bat-changelog jq-valgrind
 ```

--- a/testdata/poc/README.md
+++ b/testdata/poc/README.md
@@ -37,7 +37,7 @@ than the audited actions/cache v6.1.0 commit.
 The repository-only importer builds the exact checked-out source and runs the
 three service-free workflows before a CLI release exists:
 
-```sh
+```bash
 commit=$(git rev-parse HEAD)
 bk build create \
   --pipeline buildkite/buildkite-gha \
@@ -57,7 +57,7 @@ calls `upload` directly.
 Run the same workflows through the released companion plugin and its real
 anonymous release installer:
 
-```sh
+```bash
 commit=$(git rev-parse HEAD)
 bk build create \
   --pipeline buildkite/buildkite-gha \
@@ -71,7 +71,7 @@ bk build create \
 Add the optional cache extension only when the organization can mint GHAC
 tokens and the exact origin is configured:
 
-```sh
+```bash
 commit=$(git rev-parse HEAD)
 bk build create \
   --pipeline buildkite/buildkite-gha \

--- a/testdata/smoke/README.md
+++ b/testdata/smoke/README.md
@@ -10,12 +10,12 @@ workflow is executable:
 
 1. `shell.yml` is the first runtime target. It has two logical jobs, a static
    consumer matrix, shell steps, and a bounded `needs` output.
-2. `concurrent.yml` adds background, targeted and full waits, cancellation,
+1. `concurrent.yml` adds background, targeted and full waits, cancellation,
    bounded queueing, parallel lowering, implicit cleanup, and concurrent
    masking probes.
-3. `ci.yml` adds checkout plus local JavaScript and composite actions, including
+1. `ci.yml` adds checkout plus local JavaScript and composite actions, including
    output, environment-file, masking, summary, and post-action events.
-4. `artifact.yml` adds GitHub artifact-action compatibility and verifies one
+1. `artifact.yml` adds GitHub artifact-action compatibility and verifies one
    payload in both consumer matrix instances.
 
 `manifest.json` is the authoritative, ordered compatibility inventory for


### PR DESCRIPTION
This PR superseded the documentation update in #56 by applying the same Buildkite Documentation style conventions to the current codebase and feature set.

- Updated the README to describe the project as a research preview and added the Buildkite Support contact.
- Updated the quick-start examples to use GitHub Actions Buildkite plugin v0.7.1 with buildkite-gha v0.7.2.
- Documented that plugin and binary versions are independent and that importer steps require a unique key.
- Corrected generated-job targeting guidance. Jobs now inherit the pipeline or organization defaults unless BUILDKITE_GHA_TARGET_QUEUE selects a queue.
- Updated direct CLI guidance to reflect that current integrations no longer pass --runtime-queue. The deprecated --runtime-queue hosted form remains a no-op for legacy compatibility.
- Updated the compatibility guide, development guide, architecture decisions, active implementation plan, and fixture documentation.
- Standardized Buildkite terminology, US English spelling, sentence-case headings, code-fence languages, and ordered-list markers.
- Preserved historical release evidence and intentionally pinned internal smoke-test configuration.