### PR TITLE
Harden native checkout compatibility boundaries

### DIFF
--- a/docs/architecture/0003-protected-capability-control-plane.md
+++ b/docs/architecture/0003-protected-capability-control-plane.md
@@ -231,14 +231,17 @@ Content-Type: application/json
 }
 ```
 
-The compiler adds `provider-token-read` after resolving the exact
-`actions/checkout` adapter and validating its repository, ref, depth, path,
-submodule, and credential-persistence inputs. Fresh same-process compiler
-provenance permits that one capability through upload admission. The runtime
-uses `buildkite-agent git-credentials-helper` only when the immutable plan has
-that capability, a root checkout selector names the verified adapter, and the
-server-provided job environment indicates repository-provider Git credentials
-are enabled. Otherwise it performs the same checkout anonymously.
+The compiler adds `provider-token-read` only after the resolved
+`actions/checkout` commit is in the audited native-adapter allowlist and its
+repository, ref, depth, path, submodule, and credential-persistence inputs pass
+validation. Fresh same-process compiler provenance permits that one capability
+through upload admission. Before resolving Git or repository credentials, the
+runtime revalidates every checkout lock in the plan and requires a root checkout
+selector to name the verified adapter. It invokes
+`buildkite-agent git-credentials-helper` only when the immutable plan has that
+capability and the server-provided job environment indicates
+repository-provider Git credentials are enabled. Otherwise it performs the same
+checkout anonymously.
 
 The event repository and exact SHA remain the only checkout targets. The
 credential helper is configured as a command-scoped Git option only for the

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -262,6 +262,17 @@ commit is in this audited allowlist (snapshot 2026-08-10):
 | v7 | [`3d3c42e5aac5ba805825da76410c181273ba90b1`](https://github.com/actions/checkout/blob/3d3c42e5aac5ba805825da76410c181273ba90b1/action.yml) | **Supported subset.** Node 24 ESM implementation with the same public inputs, main/post entrypoint, and outputs as current v6. |
 | v7 corpus pin | [`9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0`](https://github.com/actions/checkout/blob/9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0/action.yml) | **Supported subset.** The v7.0.0-era pin used by the OSS corpus. v7.0.1's default-self-checkout guard bypass, explicit-ref parsing, and cleanup hardening do not alter this bounded native result. |
 
+The upstream metadata surface evolved as follows. “Unset” means the manifest has
+no default; it is not the same as a declared empty string.
+
+| Majors | Input/default and lifecycle changes |
+| --- | --- |
+| v1 | Declares `repository`, `ref`, `token`, `clean: true`, `submodules`, `lfs`, `fetch-depth`, and `path`; all except `clean` are unset (the depth description says unlimited). Uses the runner `checkout` plugin and has no outputs or action lifecycle entrypoints. |
+| v2 | Changes the default depth to `1`; defaults `repository` to `${{ github.repository }}`, `token` to `${{ github.token }}`, `ssh-strict`, `persist-credentials`, `clean`, and `set-safe-directory` to true, and `lfs`, `submodules`, and `allow-unsafe-pr-checkout` to false. Adds unset `ssh-key` and `ssh-known-hosts`. Uses Node 12 main/post with no pre or outputs. |
+| v3 | Retains v2 and adds `sparse-checkout: null`, `sparse-checkout-cone-mode: true`, `fetch-tags: false`, and unset `github-server-url`. Uses Node 16 main/post with no pre or outputs. |
+| v4 | Adds `ssh-user: git`, `filter: null`, and `show-progress: true`; adds `ref` and `commit` outputs and moves to Node 20. |
+| v5-v7 | Retain the current v4 public inputs, defaults, outputs, and main/post shape with no pre. v5-v7 use Node 24; v6 isolates persisted credentials under runner temp, and v7 migrates the implementation to ESM. |
+
 Major tags are mutable. A tag such as `actions/checkout@v7` works only while it
 resolves to an allowlisted commit; a moved tag or arbitrary future commit is
 rejected until its exact source and metadata are audited. v1-v3 are explicitly

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -106,7 +106,7 @@ service.
 | Dockerfile actions | Supported subset | Only compiler-verified local or public Dockerfile actions are admitted. The standard cache-v2 environment is available inside the action container. Lifecycle overrides, arbitrary Docker options, other credentials, volumes, private images, and privileged execution are not supported. |
 | `docker://` actions and action `entrypoint`/`args` overrides | Not supported | Validation rejects these forms. |
 | Concurrent step controls | Supported | GitHub Actions `background`, `wait`, `wait-all`, `cancel`, and `parallel` controls run inside one job with at most ten active background steps. Effects and failures become visible at covering waits, remaining work is joined before cleanup, and cancellation targets the complete process group rather than only the direct process. |
-| `actions/checkout` | Supported subset | The `github.com` event repository, exact event SHA, workspace root, and fetch depth 1 or 0 are supported. Depth 0 fetches all branch and tag history while retaining the exact event SHA. The fetch automatically uses Buildkite's repository-provider Git credential helper when the job has those credentials enabled and is anonymous otherwise. Alternate repositories/refs, submodules, LFS, persisted credentials, and arbitrary checkout inputs are not supported. |
+| `actions/checkout` | Supported subset | Only the [audited commits](#actionscheckout-native-adapter) from current v4-v7 are admitted. The adapter checks out the `github.com` event repository's exact SHA at the workspace root with depth 1 or 0, optional shallow tags, and command-scoped Buildkite repository-provider credentials. Unknown commits and unsupported inputs fail closed. |
 | `actions/upload-artifact` | Supported subset | The audited v4 and v7 commits are adapted in ZIP mode. They support bounded literal files/directories, ZIP compression 0–9, hidden-file selection, and exact no-file behavior. Globs, exclusions, symlinks, retention, overwrite, v7 raw uploads, merge, and GitHub URLs are not supported. |
 | `actions/download-artifact` | Supported subset | Only the audited v4.3.0 commit is adapted. One exact literal name from verified direct `needs` can be extracted to a clean workspace-relative path. IDs, patterns, all-artifact, merge, cross-run, and cross-repository modes are not supported. |
 | `actions/cache` | Supported subset | Only the audited v6.1.0 commit, including its `restore` and `save` entry points, is admitted. It runs the stock Node 24 cache-v2 client with fresh job-bound credentials and the official Buildkite Results service by default. v4/v5 and unrecognized v6 commits are not supported. |
@@ -244,14 +244,76 @@ For pull requests, the plugin uses the exact Buildkite commit and a
 `refs/pull/<number>/head` compatibility ref. It does not claim GitHub's merge-ref
 semantics when Buildkite has not supplied them.
 
-### Checkout starts clean
+### `actions/checkout` native adapter
+
+The compiler resolves mutable action references before selection and records the
+exact commit and source-tree digest in the plan. Repository identity selects the
+checkout integration, but the native adapter is admitted only when the resolved
+commit is in this audited allowlist (snapshot 2026-08-10):
+
+| Upstream major | Audited major-tag commit | Metadata and native decision |
+| --- | --- | --- |
+| v1 | [`50fbc622fc4ef5163becd7fab6573eac35f8462e`](https://github.com/actions/checkout/blob/50fbc622fc4ef5163becd7fab6573eac35f8462e/action.yml) | **Not supported.** Legacy `runs.plugin: checkout`, no JavaScript lifecycle or outputs, and an unlimited-history default do not match this adapter. |
+| v2 | [`0717577d45739eb3c851188b29f50ed6c0b2194e`](https://github.com/actions/checkout/blob/0717577d45739eb3c851188b29f50ed6c0b2194e/action.yml) | **Not supported.** Node 12 main/post action, no outputs, and an older input surface. |
+| v3 | [`a37ce9120846195fa4ece8f58b268e6043cb2f26`](https://github.com/actions/checkout/blob/a37ce9120846195fa4ece8f58b268e6043cb2f26/action.yml) | **Not supported.** Node 16 main/post action and no `ref`/`commit` outputs. |
+| v4 | [`11d5960a326750d5838078e36cf38b85af677262`](https://github.com/actions/checkout/blob/11d5960a326750d5838078e36cf38b85af677262/action.yml) | **Supported subset.** Node 20, `dist/index.js` main/post, no pre, `ref` and `commit` outputs. |
+| v5 | [`fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09`](https://github.com/actions/checkout/blob/fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09/action.yml) | **Supported subset.** Same public contract as v4 with Node 24. |
+| v6 | [`d23441a48e516b6c34aea4fa41551a30e30af803`](https://github.com/actions/checkout/blob/d23441a48e516b6c34aea4fa41551a30e30af803/action.yml) | **Supported subset.** Node 24; upstream moved persisted credentials to a temporary file and conditional includes, but persistence is not implemented here. |
+| v7 | [`3d3c42e5aac5ba805825da76410c181273ba90b1`](https://github.com/actions/checkout/blob/3d3c42e5aac5ba805825da76410c181273ba90b1/action.yml) | **Supported subset.** Node 24 ESM implementation with the same public inputs, main/post entrypoint, and outputs as current v6. |
+| v7 corpus pin | [`9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0`](https://github.com/actions/checkout/blob/9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0/action.yml) | **Supported subset.** The v7.0.0-era pin used by the OSS corpus. v7.0.1's default-self-checkout guard bypass, explicit-ref parsing, and cleanup hardening do not alter this bounded native result. |
+
+Major tags are mutable. A tag such as `actions/checkout@v7` works only while it
+resolves to an allowlisted commit; a moved tag or arbitrary future commit is
+rejected until its exact source and metadata are audited. v1-v3 are explicitly
+unsupported rather than silently replaced with different native semantics.
+
+All supported commits declare the following current v4-v7 inputs. Input names
+are case-insensitive and case-colliding duplicates are rejected. GitHub Actions
+boolean spellings (`true`, `True`, `TRUE` and corresponding false forms) are
+accepted where shown. The compiler validates admitted static values, and the
+runtime repeats validation after expression evaluation. A dynamic value cannot
+widen the event repository, SHA, or credential boundary. Checkout input
+expressions must currently resolve during compilation to an admitted literal;
+otherwise compilation fails closed.
+
+| Input | Admitted values | Native decision |
+| --- | --- | --- |
+| `repository` | omitted, or the event `owner/repo` (case-insensitive) | Alternate repositories and an explicit empty value are rejected. |
+| `ref` | omitted, empty, or the exact lowercase 40-hex event SHA | Branches, tags, other SHAs, and SHA-256 object IDs are rejected. Checkout is always detached at the event SHA. |
+| `token` | omitted only | Explicit values, including empty, are rejected. The upstream `${{ github.token }}` default is not used. |
+| `ssh-key`, `ssh-known-hosts` | omitted or empty | Non-empty SSH configuration is rejected; no SSH transport is attempted. |
+| `ssh-strict` | omitted or true | Default-equivalent only. |
+| `ssh-user` | omitted or `git` | Default-equivalent only. |
+| `persist-credentials` | omitted or false | Credentials are never persisted. This intentionally differs from upstream's `true` default. |
+| `path` | omitted or empty | Only the workspace root is supported. |
+| `clean` | omitted or true | The workspace must already be empty. Existing files are rejected, not reset or deleted. |
+| `filter`, `sparse-checkout` | omitted or empty | Partial and sparse clones are rejected. |
+| `sparse-checkout-cone-mode` | omitted or true | Accepted only as an inert default while sparse checkout is absent. |
+| `fetch-depth` | omitted, `1`, or `0` | Default/`1` fetches only the exact SHA with depth 1. `0` fetches all heads, tags, and an explicit exact-event refspec before detached checkout. Other values are rejected rather than normalized. |
+| `fetch-tags` | omitted, true, or false | Default false suppresses tags for depth 1. True adds an explicit tag refspec. Depth 0 always includes tags. |
+| `show-progress` | omitted, true, or false | Defaults to true and controls `git fetch --progress`. |
+| `lfs` | omitted or false | LFS is not installed or fetched. |
+| `submodules` | omitted or false | `true` and `recursive` are rejected. See the product decision below. |
+| `set-safe-directory` | omitted or true | Accepted as default-equivalent; the adapter uses isolated Git config and does not mutate the user's global `safe.directory`. |
+| `github-server-url` | omitted, empty, or `https://github.com` | GitHub Enterprise Server and alternate hosts are rejected. |
+| `allow-unsafe-pr-checkout` | omitted or false | Alternate fork repository/ref selection is already impossible; true is rejected. |
+
+The adapter does not execute upstream's Node main/post lifecycle. It initializes
+an isolated Git repository, disables system/global Git config and hooks for its
+commands, fetches over public HTTPS, and verifies `.git/HEAD` is the exact event
+SHA. It emits the upstream v4+ `ref` and `commit` step outputs from the immutable
+event. An omitted or empty `ref` outputs the event ref; an explicitly supplied
+event SHA outputs an empty `ref`, matching upstream's commit classification. It
+does not emit matcher commands or post state, configure credentials
+for later steps, clean an existing checkout, choose a local branch, fall back to
+the REST archive API, or modify global safe-directory configuration.
 
 Generated jobs skip Buildkite's default checkout and allocate a fresh Actions
-workspace. A supported `actions/checkout` step checks out the event repository
-at the exact event SHA, using GitHub's default depth 1 or explicit
-`fetch-depth: 0` for all branch and tag history. Compilation automatically adds
-`provider-token-read` only to a job containing the compiler-verified checkout
-adapter with its bounded inputs.
+workspace. Compilation adds `provider-token-read` only after the root checkout
+lock passes the commit and input boundaries. At runtime the same commit and
+evaluated-input checks run again before Git or credentials are used.
+
+#### Credentials and submodules remain narrow by design
 
 At runtime, the fetch uses Buildkite's native
 `buildkite-agent git-credentials-helper` when
@@ -274,6 +336,16 @@ This checkout path does not populate
 `GITHUB_TOKEN` or `github.token`, use workflow `permissions`, enable private
 actions, or add support for alternate repositories or refs. The deprecated
 `--private-checkout` option is temporarily accepted as a no-op for compatibility.
+
+Public-HTTPS submodules are deliberately **not** implemented. An honest bounded
+implementation would need to validate every `.gitmodules` URL and path before
+Git follows it, distinguish direct from recursive updates, revalidate nested
+manifests, prevent symlink/path escapes, preserve depth 1/0 semantics, and ensure
+the event-repository helper is never offered to submodule hosts or paths. Git's
+ordinary recursive update performs network access before that complete policy
+can be established. Rather than broaden credential authority or special-case
+the jq corpus, both `submodules: true` and `submodules: recursive` fail closed;
+public, private, relative, and SSH submodules are all unsupported.
 
 ### Effective permissions provide a scoped workflow token
 

--- a/internal/action/integration/integration.go
+++ b/internal/action/integration/integration.go
@@ -34,6 +34,15 @@ const (
 	// AdapterDownloadArtifactBuildkite extracts one producer-attributed native
 	// archive without using the GitHub Actions artifact service.
 	AdapterDownloadArtifactBuildkite Adapter = "download-artifact-buildkite-v1"
+	// CheckoutV4Commit through CheckoutV7Commit are the current audited major
+	// release implementations. CheckoutV7InitialCommit is retained because it
+	// is pinned by the OSS compatibility corpus; its later v7.0.1 changes do
+	// not affect the adapter's bounded exact-event-SHA operation.
+	CheckoutV4Commit        = "11d5960a326750d5838078e36cf38b85af677262"
+	CheckoutV5Commit        = "fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09"
+	CheckoutV6Commit        = "d23441a48e516b6c34aea4fa41551a30e30af803"
+	CheckoutV7InitialCommit = "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+	CheckoutV7Commit        = "3d3c42e5aac5ba805825da76410c181273ba90b1"
 	// UploadArtifactCommit and UploadArtifactV7Commit are the audited upstream
 	// implementations whose ZIP-mode semantics this adapter implements. Raw v7
 	// uploads remain explicitly unsupported by ValidateUploadArtifactInputs.
@@ -80,6 +89,33 @@ var catalog = map[Identity]Descriptor{
 	{Source: "github", Repository: "actions/upload-artifact"}:                {Adapter: AdapterUploadArtifactBuildkite},
 	{Source: "github", Repository: "actions/upload-artifact", Path: "merge"}: {Service: ServiceArtifact},
 	{Source: "github", Repository: "actions/download-artifact"}:              {Adapter: AdapterDownloadArtifactBuildkite},
+}
+
+var checkoutCommits = map[string]string{
+	CheckoutV4Commit:        "v4",
+	CheckoutV5Commit:        "v5",
+	CheckoutV6Commit:        "v6",
+	CheckoutV7InitialCommit: "v7.0.0",
+	CheckoutV7Commit:        "v7.0.1",
+}
+
+// ValidateCheckoutCommit rejects semantic drift from the audited upstream
+// manifests and implementations. Mutable references are resolved before this
+// check, so a moved major tag must be deliberately audited and added here.
+func ValidateCheckoutCommit(commit string) error {
+	if _, ok := checkoutCommits[commit]; !ok {
+		return fmt.Errorf("actions/checkout native adapter does not admit resolved commit %q; supported commits are %s", commit, strings.Join(sortedCheckoutCommits(), ", "))
+	}
+	return nil
+}
+
+func sortedCheckoutCommits() []string {
+	commits := make([]string, 0, len(checkoutCommits))
+	for commit, version := range checkoutCommits {
+		commits = append(commits, version+" ("+commit+")")
+	}
+	sort.Strings(commits)
+	return commits
 }
 
 // ValidateUploadArtifactCommit rejects semantic drift from the audited action.
@@ -276,11 +312,11 @@ func ValidateCheckoutInputs(inputs map[string]string, repository, sha string) er
 				continue
 			}
 		case "ref":
-			if value == sha {
+			if value == "" || value == sha {
 				continue
 			}
 		case "persist-credentials":
-			if value == "false" {
+			if uploadArtifactFalse(value) {
 				continue
 			}
 		case "fetch-depth":
@@ -288,11 +324,35 @@ func ValidateCheckoutInputs(inputs map[string]string, repository, sha string) er
 				continue
 			}
 		case "clean", "set-safe-directory":
-			if value == "true" {
+			if uploadArtifactTrue(value) {
+				continue
+			}
+		case "lfs", "submodules", "allow-unsafe-pr-checkout":
+			if uploadArtifactFalse(value) {
+				continue
+			}
+		case "fetch-tags", "show-progress":
+			if uploadArtifactBoolean(value) {
+				continue
+			}
+		case "ssh-key", "ssh-known-hosts", "path", "filter", "sparse-checkout":
+			if value == "" {
+				continue
+			}
+		case "ssh-strict", "sparse-checkout-cone-mode":
+			if uploadArtifactTrue(value) {
+				continue
+			}
+		case "ssh-user":
+			if value == "git" {
+				continue
+			}
+		case "github-server-url":
+			if value == "" || value == "https://github.com" {
 				continue
 			}
 		}
-		return fmt.Errorf("explicit input %q is unsupported (including empty values); Phase 6 is required", name)
+		return fmt.Errorf("explicit input %q value is unsupported; Phase 6 is required", name)
 	}
 	return nil
 }

--- a/internal/action/integration/integration_test.go
+++ b/internal/action/integration/integration_test.go
@@ -68,6 +68,17 @@ func TestUploadArtifactCommitsAreExact(t *testing.T) {
 	}
 }
 
+func TestCheckoutCommitsAreExact(t *testing.T) {
+	for _, commit := range []string{CheckoutV4Commit, CheckoutV5Commit, CheckoutV6Commit, CheckoutV7InitialCommit, CheckoutV7Commit} {
+		if err := ValidateCheckoutCommit(commit); err != nil {
+			t.Fatalf("audited commit %s rejected: %v", commit, err)
+		}
+	}
+	if err := ValidateCheckoutCommit(strings.Repeat("0", 40)); err == nil || !strings.Contains(err.Error(), "does not admit") || !strings.Contains(err.Error(), CheckoutV7Commit) {
+		t.Fatalf("unrecognized checkout commit error = %v", err)
+	}
+}
+
 func TestCacheCommitIsExactV6(t *testing.T) {
 	if err := ValidateCacheCommit(CacheCommit); err != nil {
 		t.Fatal(err)
@@ -136,7 +147,15 @@ func TestValidateCheckoutInputs(t *testing.T) {
 	repository, sha := "buildkite/buildkite-gha", strings.Repeat("a", 40)
 	for _, inputs := range []map[string]string{
 		nil,
-		{"repository": "BUILDKITE/BUILDKITE-GHA", "ref": sha, "fetch-depth": "1", "persist-credentials": "false", "clean": "true", "set-safe-directory": "true"},
+		{
+			"repository": "BUILDKITE/BUILDKITE-GHA", "ref": sha, "fetch-depth": "1",
+			"persist-credentials": "FALSE", "clean": "True", "set-safe-directory": "TRUE",
+			"ssh-key": "", "ssh-known-hosts": "", "ssh-strict": "true", "ssh-user": "git",
+			"path": "", "filter": "", "sparse-checkout": "", "sparse-checkout-cone-mode": "true",
+			"fetch-tags": "true", "show-progress": "False", "lfs": "false", "submodules": "FALSE",
+			"github-server-url": "https://github.com", "allow-unsafe-pr-checkout": "false",
+		},
+		{"ref": "", "github-server-url": ""},
 		{"fetch-depth": "0"},
 	} {
 		if err := ValidateCheckoutInputs(inputs, repository, sha); err != nil {
@@ -149,7 +168,15 @@ func TestValidateCheckoutInputs(t *testing.T) {
 		"foreign repository":   {"repository": "other/repository"},
 		"foreign ref":          {"ref": strings.Repeat("b", 40)},
 		"submodules":           {"submodules": "true"},
+		"recursive submodules": {"submodules": "recursive"},
 		"path":                 {"path": "nested"},
+		"filter":               {"filter": "blob:none"},
+		"sparse checkout":      {"sparse-checkout": "src"},
+		"lfs":                  {"lfs": "true"},
+		"fetch depth":          {"fetch-depth": "2"},
+		"ssh key":              {"ssh-key": "key"},
+		"GHES":                 {"github-server-url": "https://github.example"},
+		"unknown":              {"future-input": "value"},
 		"persist credentials":  {"persist-credentials": "true"},
 		"case-colliding names": {"Repository": repository, "repository": repository},
 	} {

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -37,6 +37,16 @@ func (s PublicActionSource) Fetch(ctx context.Context, ref source.Reference) (so
 	if err != nil {
 		return source.Resolved{}, source.Materialized{}, err
 	}
+	identity := actionintegration.Identity{
+		Source:     "github",
+		Repository: strings.ToLower(ref.Owner + "/" + ref.Repository),
+		Path:       ref.Path,
+	}
+	if descriptor, _ := actionintegration.Lookup(identity); descriptor.Adapter == actionintegration.AdapterCheckoutExactEventSHA {
+		if err := actionintegration.ValidateCheckoutCommit(strings.ToLower(r.Commit)); err != nil {
+			return source.Resolved{}, source.Materialized{}, err
+		}
+	}
 	m, err := s.Store.Materialize(ctx, r)
 	return r, m, err
 }
@@ -282,6 +292,11 @@ func (b *actionLockBuilder) describe(ctx context.Context, raw string) (string, p
 	commit := strings.ToLower(resolved.Commit)
 	lock := plan.ActionLock{Source: "github", Repository: canonical, RequestedRef: ref.Ref, Commit: commit, Path: ref.Path, SourceDigest: materialized.SourceDigest}
 	descriptor, _ := actionintegration.Lookup(actionintegration.Identity{Source: lock.Source, Repository: lock.Repository, Path: lock.Path})
+	if descriptor.Adapter == actionintegration.AdapterCheckoutExactEventSHA {
+		if err := actionintegration.ValidateCheckoutCommit(lock.Commit); err != nil {
+			return "", plan.ActionLock{}, "", "", err
+		}
+	}
 	if descriptor.Adapter == actionintegration.AdapterUploadArtifactBuildkite {
 		if err := actionintegration.ValidateUploadArtifactCommit(lock.Commit); err != nil {
 			return "", plan.ActionLock{}, "", "", err

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -106,7 +106,7 @@ func TestCompileActionLocksRequiresMiseOnlyForJavaScriptReachableGraphs(t *testi
 			"owner/javascript":          remote("owner/javascript", "node24"),
 		},
 		commits: map[string]string{
-			"actions/checkout":          strings.Repeat("b", 40),
+			"actions/checkout":          actionintegration.CheckoutV4Commit,
 			"actions/upload-artifact":   actionintegration.UploadArtifactCommit,
 			"actions/download-artifact": actionintegration.DownloadArtifactCommit,
 			"actions/cache":             actionintegration.CacheCommit,
@@ -693,19 +693,19 @@ func TestCheckoutAdapterInputBoundary(t *testing.T) {
 		t.Fatal(err)
 	}
 	writeAction(t, remote, "", "name: checkout\nruns:\n  using: node24\n  main: index.js\n")
+	options := Options{
+		EventTrust: EventUntrusted,
+		Runners: RunnerPolicy{
+			Labels:          map[string]string{"ubuntu-latest": "hosted"},
+			UntrustedQueues: []string{"hosted"},
+		},
+		ResolveActions: true,
+		ActionSource:   &fakeActionSource{root: remote, calls: map[string]int{}},
+	}
 	compile := func(with string) ([]plan.Job, error) {
 		workflow := []byte("on: push\njobs:\n  checkout:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1\n" + with)
 		if err := os.WriteFile(workflowPath, workflow, 0o644); err != nil {
 			t.Fatal(err)
-		}
-		options := Options{
-			EventTrust: EventUntrusted,
-			Runners: RunnerPolicy{
-				Labels:          map[string]string{"ubuntu-latest": "hosted"},
-				UntrustedQueues: []string{"hosted"},
-			},
-			ResolveActions: true,
-			ActionSource:   &fakeActionSource{root: remote, calls: map[string]int{}},
 		}
 		return CompilePlansWithOptions(workflowPath, workflow, pushEvent(t), "phase4-test", testDistributionDigest, options)
 	}
@@ -742,6 +742,32 @@ func TestCheckoutAdapterInputBoundary(t *testing.T) {
 				t.Fatalf("CompilePlansWithOptions() error = %v", err)
 			}
 		})
+	}
+}
+
+func TestCheckoutAdapterCommitBoundary(t *testing.T) {
+	workspace, remote := t.TempDir(), t.TempDir()
+	writeAction(t, remote, "", "name: checkout\nruns:\n  using: node24\n  main: index.js\n")
+	for version, commit := range map[string]string{
+		"v4":     actionintegration.CheckoutV4Commit,
+		"v5":     actionintegration.CheckoutV5Commit,
+		"v6":     actionintegration.CheckoutV6Commit,
+		"v7.0.0": actionintegration.CheckoutV7InitialCommit,
+		"v7.0.1": actionintegration.CheckoutV7Commit,
+	} {
+		t.Run(version, func(t *testing.T) {
+			actionSource := &fakeActionSource{root: remote, commit: commit, calls: map[string]int{}}
+			_, locks, _, _, err := compileActionLocks(context.Background(), workspace, actionSource, []string{"actions/checkout@" + version})
+			if err != nil || len(locks) != 1 || locks[0].Commit != commit {
+				t.Fatalf("compileActionLocks() locks = %#v, error = %v", locks, err)
+			}
+		})
+	}
+
+	unknown := strings.Repeat("0", 40)
+	actionSource := &fakeActionSource{root: remote, commit: unknown, calls: map[string]int{}}
+	if _, _, _, _, err := compileActionLocks(context.Background(), workspace, actionSource, []string{"actions/checkout@v8"}); err == nil || !strings.Contains(err.Error(), "does not admit") {
+		t.Fatalf("unknown checkout commit error = %v", err)
 	}
 }
 

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -766,7 +766,7 @@ func TestCheckoutAdapterCommitBoundary(t *testing.T) {
 
 	unknown := strings.Repeat("0", 40)
 	actionSource := &fakeActionSource{root: remote, commit: unknown, calls: map[string]int{}}
-	if _, _, _, _, err := compileActionLocks(context.Background(), workspace, actionSource, []string{"actions/checkout@v8"}); err == nil || !strings.Contains(err.Error(), "does not admit") {
+	if _, _, _, _, err := compileActionLocks(context.Background(), workspace, actionSource, []string{"actions/checkout@v7"}); err == nil || !strings.Contains(err.Error(), "does not admit") {
 		t.Fatalf("unknown checkout commit error = %v", err)
 	}
 }

--- a/internal/runtime/actions.go
+++ b/internal/runtime/actions.go
@@ -63,6 +63,11 @@ func usesCheckoutAdapter(lock plan.ActionLock) bool {
 func validateJobCheckoutAdapters(job plan.Job) (bool, error) {
 	locks := make(map[string]plan.ActionLock, len(job.Actions))
 	for _, lock := range job.Actions {
+		if usesCheckoutAdapter(lock) {
+			if err := actionintegration.ValidateCheckoutCommit(lock.Commit); err != nil {
+				return false, err
+			}
+		}
 		locks[lock.ID] = lock
 	}
 	found := false
@@ -72,9 +77,6 @@ func validateJobCheckoutAdapters(job plan.Job) (bool, error) {
 		}
 		if lock, ok := locks[step.Action.Lock]; ok && usesCheckoutAdapter(lock) {
 			found = true
-			if err := actionintegration.ValidateCheckoutCommit(lock.Commit); err != nil {
-				return false, err
-			}
 		}
 	}
 	return found, nil

--- a/internal/runtime/actions.go
+++ b/internal/runtime/actions.go
@@ -60,20 +60,24 @@ func usesCheckoutAdapter(lock plan.ActionLock) bool {
 	return descriptor.Adapter == actionintegration.AdapterCheckoutExactEventSHA
 }
 
-func jobUsesCheckoutAdapter(job plan.Job) bool {
+func validateJobCheckoutAdapters(job plan.Job) (bool, error) {
 	locks := make(map[string]plan.ActionLock, len(job.Actions))
 	for _, lock := range job.Actions {
 		locks[lock.ID] = lock
 	}
+	found := false
 	for _, step := range job.Steps {
 		if step.Action == nil {
 			continue
 		}
 		if lock, ok := locks[step.Action.Lock]; ok && usesCheckoutAdapter(lock) {
-			return true
+			found = true
+			if err := actionintegration.ValidateCheckoutCommit(lock.Commit); err != nil {
+				return false, err
+			}
 		}
 	}
-	return false
+	return found, nil
 }
 
 func usesUploadArtifactAdapter(lock plan.ActionLock) bool {
@@ -119,6 +123,11 @@ func (r *actionLockResolver) resolve(ctx context.Context, selector plan.ActionSe
 	}
 	if entry.duplicate || entry.lock.ID != selector.Lock {
 		return metadata.Metadata{}, plan.ActionLock{}, fmt.Errorf("resolve action lock %q: lock identity is ambiguous", selector.Lock)
+	}
+	if usesCheckoutAdapter(entry.lock) {
+		if err := actionintegration.ValidateCheckoutCommit(entry.lock.Commit); err != nil {
+			return metadata.Metadata{}, plan.ActionLock{}, err
+		}
 	}
 	if usesUploadArtifactAdapter(entry.lock) {
 		if err := actionintegration.ValidateUploadArtifactCommit(entry.lock.Commit); err != nil {

--- a/internal/runtime/checkout.go
+++ b/internal/runtime/checkout.go
@@ -133,23 +133,55 @@ func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, wo
 	if err != nil || strings.TrimSpace(string(head)) != job.Event.SHA {
 		return result, fmt.Errorf("%s did not produce exact detached SHA %s", adapter, job.Event.SHA)
 	}
-	result.Outputs["ref"] = job.Event.Ref
+	result.Outputs["ref"] = checkoutRefOutput(inputs, job.Event.Ref)
 	result.Outputs["commit"] = job.Event.SHA
 	return result, nil
 }
 
-func checkoutFetchArgs(inputs map[string]string, sha string) []string {
+func checkoutRefOutput(inputs map[string]string, eventRef string) string {
 	for name, value := range inputs {
-		if strings.EqualFold(name, "fetch-depth") && value == "0" {
-			return []string{
-				"fetch", "--no-tags", "--prune", "--no-recurse-submodules", "origin",
-				"+refs/heads/*:refs/remotes/origin/*",
-				"+refs/tags/*:refs/tags/*",
-				"+" + sha + ":refs/buildkite-gha/event",
-			}
+		if strings.EqualFold(name, "ref") && value != "" {
+			return ""
 		}
 	}
-	return []string{"fetch", "--no-tags", "--no-recurse-submodules", "--depth=1", "origin", sha}
+	return eventRef
+}
+
+func checkoutFetchArgs(inputs map[string]string, sha string) []string {
+	progress := true
+	fetchTags := false
+	depth := "1"
+	for name, value := range inputs {
+		switch {
+		case strings.EqualFold(name, "fetch-depth"):
+			depth = value
+		case strings.EqualFold(name, "fetch-tags"):
+			fetchTags = checkoutInputTrue(value)
+		case strings.EqualFold(name, "show-progress"):
+			progress = checkoutInputTrue(value)
+		}
+	}
+	args := []string{"fetch", "--no-tags", "--no-recurse-submodules"}
+	if progress {
+		args = append(args, "--progress")
+	}
+	if depth == "0" {
+		return append(args,
+			"--prune", "origin",
+			"+refs/heads/*:refs/remotes/origin/*",
+			"+refs/tags/*:refs/tags/*",
+			"+"+sha+":refs/buildkite-gha/event",
+		)
+	}
+	args = append(args, "--depth=1", "origin", sha)
+	if fetchTags {
+		args = append(args, "+refs/tags/*:refs/tags/*")
+	}
+	return args
+}
+
+func checkoutInputTrue(value string) bool {
+	return value == "true" || value == "True" || value == "TRUE"
 }
 
 func (r Runner) runRepositoryProviderCheckoutFetch(ctx context.Context, processor *commandProcessor, workspace string, env map[string]string, git string, base, fetchArgs []string) error {

--- a/internal/runtime/checkout_test.go
+++ b/internal/runtime/checkout_test.go
@@ -6,12 +6,15 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	actionintegration "github.com/buildkite/buildkite-gha/internal/action/integration"
 	"github.com/buildkite/buildkite-gha/internal/action/source"
 	"github.com/buildkite/buildkite-gha/internal/plan"
 )
@@ -95,7 +98,7 @@ esac
 			{ID: "local", Kind: "uses", Uses: "./.github/actions/local", Action: &plan.ActionSelector{Lock: localID}},
 		},
 		Actions: []plan.ActionLock{
-			{ID: checkoutID, Source: "github", Repository: "actions/checkout", RequestedRef: "v7", Commit: strings.Repeat("b", 40), SourceDigest: remoteDigest},
+			{ID: checkoutID, Source: "github", Repository: "actions/checkout", RequestedRef: "v7", Commit: actionintegration.CheckoutV7Commit, SourceDigest: remoteDigest},
 			{ID: localID, Source: "workspace", Path: ".github/actions/local", SourceDigest: localDigest},
 		},
 	}
@@ -115,7 +118,7 @@ esac
 	for _, required := range []string{
 		"init --template= .",
 		"remote add origin https://github.com/buildkite/buildkite-gha.git",
-		"fetch --no-tags --no-recurse-submodules --depth=1 origin " + sha,
+		"fetch --no-tags --no-recurse-submodules --progress --depth=1 origin " + sha,
 		"checkout --detach " + sha,
 	} {
 		if !strings.Contains(log, required) {
@@ -129,12 +132,22 @@ esac
 		t.Fatalf("checkout HEAD = %q, %v", got, err)
 	}
 
-	job.Actions[0].SourceDigest = "sha256:" + strings.Repeat("0", 64)
-	secondWorkspace := t.TempDir()
-	secondLog := filepath.Join(filepath.Dir(gitLog), "tampered.log")
-	if err := os.Rename(gitLog, secondLog); err != nil {
+	job.Actions[0].Commit = strings.Repeat("0", 40)
+	unknownWorkspace := t.TempDir()
+	previousLog := filepath.Join(filepath.Dir(gitLog), "successful.log")
+	if err := os.Rename(gitLog, previousLog); err != nil {
 		t.Fatal(err)
 	}
+	if _, err := (Runner{Git: git, Actions: materializer}).RunJob(context.Background(), job, unknownWorkspace); err == nil || !strings.Contains(err.Error(), "does not admit") {
+		t.Fatalf("unknown checkout commit error = %v", err)
+	}
+	if _, err := os.Stat(gitLog); !os.IsNotExist(err) {
+		t.Fatalf("Git ran before unknown checkout commit rejection: %v", err)
+	}
+
+	job.Actions[0].Commit = actionintegration.CheckoutV7Commit
+	job.Actions[0].SourceDigest = "sha256:" + strings.Repeat("0", 64)
+	secondWorkspace := t.TempDir()
 	if _, err := (Runner{Git: git, Actions: materializer}).RunJob(context.Background(), job, secondWorkspace); err == nil || !strings.Contains(err.Error(), "digest mismatch") {
 		t.Fatalf("tampered checkout lock error = %v", err)
 	}
@@ -170,11 +183,13 @@ func TestCheckoutFetchDepth(t *testing.T) {
 		inputs map[string]string
 		want   string
 	}{
-		{name: "default shallow", want: "fetch --no-tags --no-recurse-submodules --depth=1 origin " + sha},
-		{name: "explicit shallow", inputs: map[string]string{"fetch-depth": "1"}, want: "fetch --no-tags --no-recurse-submodules --depth=1 origin " + sha},
+		{name: "default shallow with progress", want: "fetch --no-tags --no-recurse-submodules --progress --depth=1 origin " + sha},
+		{name: "explicit shallow", inputs: map[string]string{"fetch-depth": "1"}, want: "fetch --no-tags --no-recurse-submodules --progress --depth=1 origin " + sha},
+		{name: "shallow tags", inputs: map[string]string{"fetch-tags": "TRUE"}, want: "fetch --no-tags --no-recurse-submodules --progress --depth=1 origin " + sha + " +refs/tags/*:refs/tags/*"},
+		{name: "progress disabled", inputs: map[string]string{"show-progress": "false"}, want: "fetch --no-tags --no-recurse-submodules --depth=1 origin " + sha},
 		{
 			name: "all branches and tags", inputs: map[string]string{"Fetch-Depth": "0"},
-			want: "fetch --no-tags --prune --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/* +" + sha + ":refs/buildkite-gha/event",
+			want: "fetch --no-tags --no-recurse-submodules --progress --prune origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/* +" + sha + ":refs/buildkite-gha/event",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -183,6 +198,87 @@ func TestCheckoutFetchDepth(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCheckoutRefOutput(t *testing.T) {
+	eventRef := "refs/heads/main"
+	sha := strings.Repeat("a", 40)
+	for _, test := range []struct {
+		name   string
+		inputs map[string]string
+		want   string
+	}{
+		{name: "omitted", want: eventRef},
+		{name: "explicit empty", inputs: map[string]string{"REF": ""}, want: eventRef},
+		{name: "explicit SHA", inputs: map[string]string{"ref": sha}, want: ""},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := checkoutRefOutput(test.inputs, eventRef); got != test.want {
+				t.Fatalf("checkoutRefOutput() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestCheckoutFetchArgsAgainstRealRepository(t *testing.T) {
+	sourceRoot := t.TempDir()
+	runTestGit(t, sourceRoot, "init", "--initial-branch=main")
+	runTestGit(t, sourceRoot, "config", "user.name", "buildkite-gha test")
+	runTestGit(t, sourceRoot, "config", "user.email", "test@example.invalid")
+	var commits []string
+	for i, contents := range []string{"first\n", "second\n", "third\n"} {
+		if err := os.WriteFile(filepath.Join(sourceRoot, "payload.txt"), []byte(contents), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		runTestGit(t, sourceRoot, "add", "payload.txt")
+		runTestGit(t, sourceRoot, "commit", "-m", fmt.Sprintf("commit %d", i+1))
+		commits = append(commits, strings.TrimSpace(runTestGit(t, sourceRoot, "rev-parse", "HEAD")))
+	}
+	runTestGit(t, sourceRoot, "tag", "old", commits[0])
+	runTestGit(t, sourceRoot, "tag", "tip", commits[2])
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runTestGit(t, "", "clone", "--bare", sourceRoot, remote)
+
+	for _, test := range []struct {
+		name       string
+		inputs     map[string]string
+		wantCount  string
+		wantTagTip bool
+	}{
+		{name: "depth one exact detached SHA", wantCount: "1"},
+		{name: "depth zero history and tags", inputs: map[string]string{"fetch-depth": "0", "show-progress": "false"}, wantCount: "2", wantTagTip: true},
+		{name: "shallow explicit tags", inputs: map[string]string{"fetch-tags": "true", "show-progress": "false"}, wantCount: "1", wantTagTip: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			workspace := t.TempDir()
+			runTestGit(t, workspace, "init", "--initial-branch=main")
+			runTestGit(t, workspace, "remote", "add", "origin", remote)
+			runTestGit(t, workspace, checkoutFetchArgs(test.inputs, commits[1])...)
+			runTestGit(t, workspace, "checkout", "--detach", commits[1])
+			if got := strings.TrimSpace(runTestGit(t, workspace, "rev-parse", "HEAD")); got != commits[1] {
+				t.Fatalf("HEAD = %s, want exact event SHA %s", got, commits[1])
+			}
+			if got := strings.TrimSpace(runTestGit(t, workspace, "rev-list", "--count", "HEAD")); got != test.wantCount {
+				t.Fatalf("reachable commit count = %s, want %s", got, test.wantCount)
+			}
+			_, err := exec.Command("git", "-C", workspace, "show-ref", "--verify", "--quiet", "refs/tags/tip").CombinedOutput()
+			if (err == nil) != test.wantTagTip {
+				t.Fatalf("tip tag present = %t, want %t (error %v)", err == nil, test.wantTagTip, err)
+			}
+		})
+	}
+}
+
+func runTestGit(t *testing.T, directory string, args ...string) string {
+	t.Helper()
+	if directory != "" {
+		args = append([]string{"-C", directory}, args...)
+	}
+	output, err := exec.Command("git", args...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)
+	}
+	return string(output)
 }
 
 func TestCheckoutRejectsInvalidRepositoryBeforeInspectingWorkspace(t *testing.T) {
@@ -539,7 +635,7 @@ fi
 		},
 		Actions: []plan.ActionLock{
 			{ID: poisonID, Source: "github", Repository: "owner/repo", RequestedRef: "v1", Commit: strings.Repeat("b", 40), Path: "poison", SourceDigest: remoteDigest},
-			{ID: checkoutID, Source: "github", Repository: "actions/checkout", RequestedRef: "v7", Commit: strings.Repeat("c", 40), SourceDigest: remoteDigest},
+			{ID: checkoutID, Source: "github", Repository: "actions/checkout", RequestedRef: "v7", Commit: actionintegration.CheckoutV7Commit, SourceDigest: remoteDigest},
 		},
 	}
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: remoteDigest}}
@@ -604,6 +700,23 @@ func TestProviderTokenReadRuntimeAuthorityIsCheckoutOnly(t *testing.T) {
 	job.RequiredCapabilities = []string{"provider-token-read"}
 	if _, err := (Runner{}).RunJob(context.Background(), job, workspace); err == nil || !strings.Contains(err.Error(), "restricted to the verified checkout adapter") {
 		t.Fatalf("ordinary provider-token-read error = %v", err)
+	}
+}
+
+func TestProviderTokenReadPreflightRejectsAnyUnknownCheckoutCommit(t *testing.T) {
+	validID, unknownID := "a-0000000000000001", "a-0000000000000002"
+	job := plan.Job{
+		Steps: []plan.Step{
+			{Kind: "uses", Action: &plan.ActionSelector{Lock: validID}},
+			{Kind: "uses", Action: &plan.ActionSelector{Lock: unknownID}},
+		},
+		Actions: []plan.ActionLock{
+			{ID: validID, Source: "github", Repository: "actions/checkout", Commit: actionintegration.CheckoutV7Commit},
+			{ID: unknownID, Source: "github", Repository: "actions/checkout", Commit: strings.Repeat("0", 40)},
+		},
+	}
+	if found, err := validateJobCheckoutAdapters(job); err == nil || found || !strings.Contains(err.Error(), "does not admit") {
+		t.Fatalf("validateJobCheckoutAdapters() = %t, %v, want fail-closed rejection", found, err)
 	}
 }
 

--- a/internal/runtime/checkout_test.go
+++ b/internal/runtime/checkout_test.go
@@ -704,14 +704,15 @@ func TestProviderTokenReadRuntimeAuthorityIsCheckoutOnly(t *testing.T) {
 }
 
 func TestProviderTokenReadPreflightRejectsAnyUnknownCheckoutCommit(t *testing.T) {
-	validID, unknownID := "a-0000000000000001", "a-0000000000000002"
+	validID, parentID, unknownID := "a-0000000000000001", "a-0000000000000002", "a-0000000000000003"
 	job := plan.Job{
 		Steps: []plan.Step{
 			{Kind: "uses", Action: &plan.ActionSelector{Lock: validID}},
-			{Kind: "uses", Action: &plan.ActionSelector{Lock: unknownID}},
+			{Kind: "uses", Action: &plan.ActionSelector{Lock: parentID}},
 		},
 		Actions: []plan.ActionLock{
 			{ID: validID, Source: "github", Repository: "actions/checkout", Commit: actionintegration.CheckoutV7Commit},
+			{ID: parentID, Source: "github", Repository: "owner/composite", Commit: strings.Repeat("b", 40), Children: map[string]plan.ActionSelector{"actions/checkout@future": {Lock: unknownID}}},
 			{ID: unknownID, Source: "github", Repository: "actions/checkout", Commit: strings.Repeat("0", 40)},
 		},
 	}

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	actionintegration "github.com/buildkite/buildkite-gha/internal/action/integration"
 	"github.com/buildkite/buildkite-gha/internal/action/source"
 	"github.com/buildkite/buildkite-gha/internal/compiler"
 	"github.com/buildkite/buildkite-gha/internal/plan"
@@ -1124,7 +1125,7 @@ func TestActionContainerMountsNativeAdapterDoesNotResolveMise(t *testing.T) {
 	job := jobContainerPlan(t, workspace, []plan.Step{{ID: "checkout", Kind: "uses", Uses: "actions/checkout@v4", Action: &plan.ActionSelector{Lock: lockID}}})
 	job.Actions = []plan.ActionLock{{
 		ID: lockID, Source: "github", Repository: "actions/checkout", RequestedRef: "v4",
-		Commit: strings.Repeat("a", 40), SourceDigest: digest,
+		Commit: actionintegration.CheckoutV4Commit, SourceDigest: digest,
 	}}
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, ActionRoot: remote, SourceDigest: digest}}
 	actions := newActionLockResolver(job, workspace, materializer)
@@ -1200,7 +1201,7 @@ esac
 			{ID: "local", Kind: "uses", Uses: "./.github/actions/local", Action: &plan.ActionSelector{Lock: localID}},
 		},
 		Actions: []plan.ActionLock{
-			{ID: checkoutID, Source: "github", Repository: "actions/checkout", RequestedRef: "v4", Commit: strings.Repeat("b", 40), SourceDigest: remoteDigest},
+			{ID: checkoutID, Source: "github", Repository: "actions/checkout", RequestedRef: "v4", Commit: actionintegration.CheckoutV4Commit, SourceDigest: remoteDigest},
 			{ID: localID, Source: "workspace", Path: ".github/actions/local", SourceDigest: digestTree(t, localFixture)},
 		},
 		RequiresMise: &requiresMise,

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -160,7 +160,11 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		}
 	}
 	if job.HasCapability("provider-token-read") {
-		if !jobUsesCheckoutAdapter(job) {
+		usesCheckout, err := validateJobCheckoutAdapters(job)
+		if err != nil {
+			return JobResult{}, fmt.Errorf("provider-token-read checkout preflight: %w", err)
+		}
+		if !usesCheckout {
 			return JobResult{}, fmt.Errorf("provider-token-read capability is restricted to the verified checkout adapter")
 		}
 		if r.RepositoryCredentials != nil {

--- a/testdata/oss/README.md
+++ b/testdata/oss/README.md
@@ -15,13 +15,13 @@ The initial ten cases deliberately mix outcomes:
 
 | Case | Ecosystem/shape | Exact GitHub run | Current boundary |
 | --- | --- | --- | --- |
-| `urfave-cli-lint` | Go setup and third-party lint action | [Success](https://github.com/urfave/cli/actions/runs/29794452917) | Setup action's compound token default blocks profile evaluation. |
-| `fastify-markdown-lint` | Small Node lint job with pinned actions | — | Setup action's compound token default blocks profile evaluation. |
-| `prettier-lint` | Larger Yarn, cache, condition, and concurrency workflow | [Success](https://github.com/prettier/prettier/actions/runs/31316608109) | Setup action's compound token default blocks profile evaluation. |
+| `urfave-cli-lint` | Go setup and third-party lint action | [Success](https://github.com/urfave/cli/actions/runs/29794452917) | Admitted by profile evaluation; runtime remains unproven. |
+| `fastify-markdown-lint` | Small Node lint job with pinned actions | — | Admitted by profile evaluation; runtime remains unproven. |
+| `prettier-lint` | Larger Yarn, cache, condition, and concurrency workflow | [Success](https://github.com/prettier/prettier/actions/runs/31316608109) | Admitted with ignored concurrency-cancellation behavior; runtime remains unproven. |
 | `bat-changelog` | Pull-request shell and output workflow | — | Admitted; runtime needs a faithful real PR event. |
-| `p-map-main` | Two-entry Node matrix | [Success](https://github.com/sindresorhus/p-map/actions/runs/29779845179) | Setup action's compound token default blocks profile evaluation. |
-| `fzf-linux` | Go, Ruby, multiple shells, and host package setup | [Success](https://github.com/junegunn/fzf/actions/runs/31253573599) | Setup action's compound token default blocks profile evaluation; checkout also requests full history. |
-| `jq-valgrind` | C/autotools/Valgrind plus failure artifact | [Success](https://github.com/jqlang/jq/actions/runs/30182447884) | Artifact action commit is outside the audited adapter. |
+| `p-map-main` | Two-entry Node matrix | [Success](https://github.com/sindresorhus/p-map/actions/runs/29779845179) | Admitted by profile evaluation; runtime remains unproven. |
+| `fzf-linux` | Go, Ruby, multiple shells, and host package setup | [Success](https://github.com/junegunn/fzf/actions/runs/31253573599) | Admitted; checkout's requested full history is supported. Runtime remains unproven. |
+| `jq-valgrind` | C/autotools/Valgrind plus failure artifact | [Success](https://github.com/jqlang/jq/actions/runs/30182447884) | Checkout requests unsupported submodules and fails closed. |
 | `go-task-ci` | Five-job Go matrix | [Success](https://github.com/go-task/task/actions/runs/31330279154) | Compound concurrency expression is unsupported. |
 | `gum-build` | Remote reusable workflow | — | Remote reuse and runtime secret forwarding are unsupported. |
 | `just-ci` | Rust and a mixed-OS matrix | [Success](https://github.com/casey/just/actions/runs/31140381397) | Non-Linux runner rows are unsupported. |


### PR DESCRIPTION
## Why

The native `actions/checkout` adapter was selected by repository identity alone, so a moved major tag or arbitrary future commit could silently receive provider checkout authority without an exact-source compatibility decision. Its documented input/default and lifecycle differences were also too implicit.

## What

- admit only audited exact implementations for current [v4](https://github.com/actions/checkout/blob/11d5960a326750d5838078e36cf38b85af677262/action.yml), [v5](https://github.com/actions/checkout/blob/fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09/action.yml), [v6](https://github.com/actions/checkout/blob/d23441a48e516b6c34aea4fa41551a30e30af803/action.yml), [v7](https://github.com/actions/checkout/blob/3d3c42e5aac5ba805825da76410c181273ba90b1/action.yml), and the corpus's [v7.0.0-era pin](https://github.com/actions/checkout/blob/9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0/action.yml); unknown resolutions fail before source materialization where possible and again at compiler, credential preflight, and runtime boundaries
- make the bounded input contract explicit and tested, including empty/default values, boolean case variants, case-colliding names, exact event SHA output behavior, depth 0/1, tags, progress, anonymous and provider-credential paths, empty-workspace enforcement, and real temporary Git repositories
- document the full [v1](https://github.com/actions/checkout/blob/50fbc622fc4ef5163becd7fab6573eac35f8462e/action.yml) through [v7](https://github.com/actions/checkout/blob/3d3c42e5aac5ba805825da76410c181273ba90b1/action.yml) metadata/default/lifecycle evolution, native semantic differences, outputs, and credential boundary

Public-HTTPS submodules remain deliberately unsupported. A safe implementation would need complete direct/recursive `.gitmodules` URL and path validation, nested-manifest and symlink confinement, depth semantics, and proof that event-repository credentials cannot reach submodule hosts or paths. `true`, `recursive`, private, relative, and SSH submodules therefore all fail closed rather than receiving a corpus-specific implementation.

## Validation

- `git ls-remote https://github.com/actions/checkout.git 'refs/tags/v[1-7]' 'refs/tags/v[1-7]^{}'` — confirmed the documented exact v1-v7 targets (including peeled v1)
- `mise run check` — passed format, build, tests, race tests, Go/shell lint, vet, all 8 plan fixtures, all local smoke classifications, and GoReleaser config validation; `golangci-lint`: `0 issues`
- `mise run corpus:oss-profile` — expected non-zero mixed result without executing third-party code: **6 admitted, 4 blocked**; `jq-valgrind` now fails closed specifically on `submodules: true`

Tracking: [PB-2730](https://linear.app/buildkite/issue/PB-2730/compatibility-gap-expand-actionscheckout-input-and-repository). This PR is the bounded hardening slice; submodule, LFS, and alternate-repository compatibility remain open there.