### PR TITLE
Harden native download-artifact compatibility

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -560,7 +560,10 @@ and SHA-256 digest before parsing the same descriptor; mismatch is always
 fatal. A bounded central-directory scan enforces the entry limit before Go's
 ZIP reader allocates its entry table and rejects multi-disk, ZIP64, malformed,
 ambiguous-end-record, forged-count, undeclared-entry, and out-of-bounds
-directories. ZIP admission then allows only
+directories. It validates matching central and local names, requires disk zero,
+rejects member comments, and bounds each central/local extra area to 64 bytes;
+both central and local ZIP64 sentinels and extra fields fail closed. ZIP
+admission then allows only
 regular stored/deflated members, at most 10,000 entries, 1 GiB archive and
 aggregate expanded size, 4,096-byte member paths, and 256 path components.
 Empty names,

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -516,7 +516,7 @@ bundled client.
 | `name` omitted or explicitly empty | Rejected. Upstream selects all artifacts; run-wide listing is outside the producer-bound bridge. |
 | `name: <exact value>` | Required. Leading/trailing whitespace is trimmed like `@actions/core`; the resulting UTF-8 name must satisfy the bounded upload name rules. Lookup is case-sensitive and must find exactly one artifact across all direct-needs manifests. Duplicate names, including matrix producers, are ambiguous and rejected. |
 | `path` omitted or explicitly empty | Workspace root, matching upstream fallback. The `download-path` output is its absolute logical path. |
-| `path: <value>` | Trimmed, clean, literal, workspace-relative slash path only. Absolute, drive, UNC, backslash, traversal, unclean, oversized, and expression-authored paths are rejected rather than reproducing upstream tilde/absolute-path expansion. |
+| `path: <value>` | Trimmed, literal, workspace-relative slash path only. A leading `./` and trailing slash are normalized (`./` means the workspace root and `./out/` means `out`). Absolute, drive, UNC, backslash, traversal, other unclean spellings, oversized values, and expression-authored paths are rejected rather than reproducing upstream tilde/absolute-path expansion. |
 | `merge-multiple` omitted | `false`, matching every admitted release. |
 | `merge-multiple: false` | Accepted with the toolkit's `false`, `False`, or `FALSE` spellings after trimming. Empty or true values are rejected. Since exactly one artifact is allowed, this is only explicit-default compatibility. |
 | `artifact-ids`, `pattern` | Rejected, including empty values. ID, pattern, one-result pattern/ID layout, all-artifact selection, and partial missing-ID behavior are not implemented. |
@@ -524,7 +524,7 @@ bundled client.
 | v8 `skip-decompress` omitted or `false` | ZIP extraction. Explicit false accepts the toolkit's three case spellings. `true` and empty are rejected; raw archive download and direct non-ZIP artifacts are unsupported. The input itself is rejected for v4–v7 because it is not in those releases' metadata. |
 | v8 `digest-mismatch` omitted or `error` | Digest mismatch is fatal. `ignore`, `info`, and `warn` are rejected. The input itself is rejected for v4–v7; their upstream warning-only mismatch behavior is deliberately tightened by the bridge. |
 | Any other or future input | Rejected. Input names that collide case-insensitively are also rejected. |
-| Expressions in supported inputs | Workflow-authored expressions are rejected by compiler admission. Runtime validation is repeated after evaluation as defense in depth, but it does not broaden the admitted source syntax. |
+| Expressions in supported inputs | `name` may contain workflow expressions and must evaluate at runtime to one valid exact artifact name; for example, `${{ github.sha }}` is supported. Expressions remain rejected in `path` and mode-selecting inputs. Runtime validation is repeated after evaluation and rejects unresolved or invalid names. |
 
 The only upstream output is `download-path`. The adapter sets it after a
 successful install, exposes it through normal step-output and environment-file
@@ -542,6 +542,16 @@ cancelled producers expose only a terminal manifest they actually published;
 a producer cancellation that prevents publication makes hydration fail rather
 than silently widening the search. Retrying one producer can make producer
 selection ambiguous, so retry the whole build.
+
+Matrix jobs do not broaden that boundary. Every downstream matrix instance
+that directly `needs` a producer matrix receives the verified manifests for
+that producer group. If only one producer conditionally publishes the requested
+exact name, every consumer may select it; if two producers publish that name,
+every consumer rejects the ambiguous match. This covers the download-side
+invocation used by
+[`mastodon/mastodon`'s pinned v7 consumers](https://github.com/mastodon/mastodon/blob/7d9b24bba24eb46a23a207882718feb61138fada/.github/workflows/test-ruby.yml),
+which use `${{ github.sha }}` and `path: './'`, without granting run-wide
+artifact visibility. That workflow's upload side remains outside this profile.
 
 Only ZIP artifacts published by the bounded native upload adapters are
 accepted. The consumer opens the manifest path without following a final

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -552,8 +552,8 @@ ZIP reader allocates its entry table and rejects multi-disk, ZIP64, malformed,
 ambiguous-end-record, forged-count, undeclared-entry, and out-of-bounds
 directories. ZIP admission then allows only
 regular stored/deflated members, at most 10,000 entries, 1 GiB archive and
-aggregate expanded size, a 1,000:1 per-member compression ratio, 4,096-byte
-member paths, and 256 path components. Empty names,
+aggregate expanded size, 4,096-byte member paths, and 256 path components.
+Empty names,
 duplicates (including case-folded and file/child path collisions), traversal,
 absolute/drive/UNC paths, control characters, invalid UTF-8, directory entries, symlinks,
 recognized special-file encodings, and unsupported compression methods fail

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -108,7 +108,7 @@ service.
 | Concurrent step controls | Supported | GitHub Actions `background`, `wait`, `wait-all`, `cancel`, and `parallel` controls run inside one job with at most ten active background steps. Effects and failures become visible at covering waits, remaining work is joined before cleanup, and cancellation targets the complete process group rather than only the direct process. |
 | `actions/checkout` | Supported subset | Only the [audited commits](#actionscheckout-native-adapter) from current v4-v7 are admitted. The adapter checks out the `github.com` event repository's exact SHA at the workspace root with depth 1 or 0, optional shallow tags, and command-scoped Buildkite repository-provider credentials. Unknown commits and unsupported inputs fail closed. |
 | `actions/upload-artifact` | Supported subset | Exactly v4.6.2, v5.0.0, v6.0.0, and v7.0.1 are adapted at the immutable commits listed below, root entrypoint only and ZIP mode only. Bounded literal paths and final-component file globs, ZIP compression 0–9, hidden-file selection, no-file behavior, and advisory `retention-days` are supported. Recursive globs, exclusions, symlinks, effective retention control, overwrite, v7 raw uploads, merge, and GitHub URLs are not supported. |
-| `actions/download-artifact` | Supported subset | Only the audited v4.3.0 commit is adapted. One exact literal name from verified direct `needs` can be extracted to a clean workspace-relative path. IDs, patterns, all-artifact, merge, cross-run, and cross-repository modes are not supported. |
+| `actions/download-artifact` | Supported subset | Six exact audited release commits from v4.3.0 through v8.0.1 are adapted in one common exact-name ZIP mode. Selection is limited to one uniquely named artifact from verified direct `needs`; broader selection, raw, REST, and cross-run/repository modes fail closed. See the exact matrix below. |
 | `actions/cache` | Supported subset | Only the audited v6.1.0 commit, including its `restore` and `save` entry points, is admitted. It runs the stock Node 24 cache-v2 client with fresh job-bound credentials and the official Buildkite Results service by default. v4/v5 and unrecognized v6 commits are not supported. |
 | Cache clients bundled into actions | Supported subset | JavaScript and Docker action invocations receive fresh job-bound cache-v2 credentials when the service is available, matching the environment expected by setup actions such as `actions/setup-go`. The action remains responsible for its own key, version, paths, save/restore lifecycle, and cache-miss behavior. Ordinary `run` steps and native adapters do not receive cache credentials. |
 | Runner tool cache | Supported subset | By default, the runtime points `RUNNER_TOOL_CACHE` at a fresh job-private directory and does not expose an agent or Hosted shared cache as executable authority. When pipeline configuration selects an immutable runtime image with `BUILDKITE_GHA_RUNTIME_IMAGE`, generated jobs use that image's baked `/opt/hostedtoolcache` facade instead. Dockerfile actions do not receive `RUNNER_TOOL_CACHE`. The shared Hosted cache volume is never used for executable tools because stock action tool-cache clients trust a writable entry and completion marker without verifying its contents. |
@@ -485,18 +485,103 @@ all three outputs depend on the GitHub Artifact service. It therefore remains
 outside the native bridge and fails production admission rather than being
 silently approximated. The v7 merge entrypoint has no raw mode.
 
-The consumer recognizes only
-`actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093`.
-It scans only verified manifests from direct `needs`, requires one
-exact-name match, downloads by the bound producer job UUID,
-and verifies size and SHA-256 before preflighting and extracting the bounded
-ZIP. Omitted `path` means workspace root; `download-path` is absolute. Digest
-mismatch is fatal (stricter than upstream). GitHub URLs and metadata are not
-fabricated. This native handling is an interim, bounded bridge; the parallel
-Results ArtifactService work is intended to let stock upstream JavaScript use
-its protocol rather than expanding this adapter into a protocol emulator.
-Exact-commit Buildkite build 270 and its independent artifact observation prove
-the producer-to-two-consumer roundtrip contract.
+### Download-artifact uses one audited, fail-closed ZIP profile
+
+The native adapter replaces the complete upstream JavaScript lifecycle. It
+therefore admits release **commits**, not version ranges: a mutable tag such as
+`v8` is usable only when source resolution locks it to an exact commit in this
+table. Any other commit, including a future release under an existing major
+tag, is rejected at compile time and again at runtime.
+
+| Upstream release | Exact admitted commit and metadata | Action runtime | Bundled `@actions/artifact` |
+| --- | --- | --- | --- |
+| v4.3.0 | [`d3f86a106a0bac45b974a628896c90dbdf5c8093`](https://github.com/actions/download-artifact/blob/d3f86a106a0bac45b974a628896c90dbdf5c8093/action.yml) | Node 20 | [`2.3.2`](https://github.com/actions/download-artifact/blob/d3f86a106a0bac45b974a628896c90dbdf5c8093/package-lock.json#L41-L44) |
+| v5.0.0 | [`634f93cb2916e3fdff6788551b99b062d0335ce0`](https://github.com/actions/download-artifact/blob/634f93cb2916e3fdff6788551b99b062d0335ce0/action.yml) | Node 20 | [`2.3.2`](https://github.com/actions/download-artifact/blob/634f93cb2916e3fdff6788551b99b062d0335ce0/package-lock.json#L41-L44) |
+| v6.0.0 | [`018cc2cf5baa6db3ef3c5f8a56943fffe632ef53`](https://github.com/actions/download-artifact/blob/018cc2cf5baa6db3ef3c5f8a56943fffe632ef53/action.yml) | Node 20 | [`4.0.0`](https://github.com/actions/download-artifact/blob/018cc2cf5baa6db3ef3c5f8a56943fffe632ef53/package-lock.json#L41-L44) |
+| v7.0.0 | [`37930b1c2abaa49bbe596cd826c3c89aef350131`](https://github.com/actions/download-artifact/blob/37930b1c2abaa49bbe596cd826c3c89aef350131/action.yml) | Node 24 | [`5.0.1`](https://github.com/actions/download-artifact/blob/37930b1c2abaa49bbe596cd826c3c89aef350131/package-lock.json#L41-L44) |
+| v8.0.0 | [`70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3`](https://github.com/actions/download-artifact/blob/70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3/action.yml) | Node 24 ESM | [`6.1.0`](https://github.com/actions/download-artifact/blob/70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3/package-lock.json#L38-L41) |
+| v8.0.1 | [`3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c`](https://github.com/actions/download-artifact/blob/3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c/action.yml) | Node 24 ESM | [`6.2.1`](https://github.com/actions/download-artifact/blob/3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c/package-lock.json#L38-L41) |
+
+This audit was current through v8.0.1 on 2026-08-10. v4.3 added ID selection; v5 changed
+single-result ID/pattern destination layout; v6 and v7 changed the artifact
+client and Node runtime; v8 added raw/direct downloads, content-type-sensitive
+ZIP handling, `skip-decompress`, and configurable digest mismatch behavior;
+v8.0.1 fixed CJK filename/content-disposition handling. None of those changes
+altered the exact-name, one-ZIP, direct-to-`path` profile below. The adapter's
+own UTF-8 path handling is covered independently and does not depend on the
+bundled client.
+
+| Upstream input or default | Native decision |
+| --- | --- |
+| `name` omitted or explicitly empty | Rejected. Upstream selects all artifacts; run-wide listing is outside the producer-bound bridge. |
+| `name: <exact value>` | Required. Leading/trailing whitespace is trimmed like `@actions/core`; the resulting UTF-8 name must satisfy the bounded upload name rules. Lookup is case-sensitive and must find exactly one artifact across all direct-needs manifests. Duplicate names, including matrix producers, are ambiguous and rejected. |
+| `path` omitted or explicitly empty | Workspace root, matching upstream fallback. The `download-path` output is its absolute logical path. |
+| `path: <value>` | Trimmed, clean, literal, workspace-relative slash path only. Absolute, drive, UNC, backslash, traversal, unclean, oversized, and expression-authored paths are rejected rather than reproducing upstream tilde/absolute-path expansion. |
+| `merge-multiple` omitted | `false`, matching every admitted release. |
+| `merge-multiple: false` | Accepted with the toolkit's `false`, `False`, or `FALSE` spellings after trimming. Empty or true values are rejected. Since exactly one artifact is allowed, this is only explicit-default compatibility. |
+| `artifact-ids`, `pattern` | Rejected, including empty values. ID, pattern, one-result pattern/ID layout, all-artifact selection, and partial missing-ID behavior are not implemented. |
+| `github-token`, `repository`, `run-id` | Rejected, including explicit empty/default-shaped values. The GitHub REST cross-run/cross-repository path is not emulated. |
+| v8 `skip-decompress` omitted or `false` | ZIP extraction. Explicit false accepts the toolkit's three case spellings. `true` and empty are rejected; raw archive download and direct non-ZIP artifacts are unsupported. The input itself is rejected for v4–v7 because it is not in those releases' metadata. |
+| v8 `digest-mismatch` omitted or `error` | Digest mismatch is fatal. `ignore`, `info`, and `warn` are rejected. The input itself is rejected for v4–v7; their upstream warning-only mismatch behavior is deliberately tightened by the bridge. |
+| Any other or future input | Rejected. Input names that collide case-insensitively are also rejected. |
+| Expressions in supported inputs | Workflow-authored expressions are rejected by compiler admission. Runtime validation is repeated after evaluation as defense in depth, but it does not broaden the admitted source syntax. |
+
+The only upstream output is `download-path`. The adapter sets it after a
+successful install, exposes it through normal step-output and environment-file
+machinery, and does not set it on failure. It is the absolute logical workspace
+destination, including for an omitted or empty `path`.
+
+The producer visibility boundary is narrower than GitHub's current-run artifact
+service. The consumer scans only canonical result manifests hydrated from its
+compiler-selected direct `needs`. Each artifact remains bound to its plan,
+build, generated producer step, and unique producer job UUID. The runtime asks
+Buildkite Agent for that exact native artifact path under the bound UUID; it
+does not search by user-controlled artifact name or trust metadata mirrors.
+Zero matches and every duplicate exact-name match fail. Failed, skipped, or
+cancelled producers expose only a terminal manifest they actually published;
+a producer cancellation that prevents publication makes hydration fail rather
+than silently widening the search. Retrying one producer can make producer
+selection ambiguous, so retry the whole build.
+
+Only ZIP artifacts published by the bounded native upload adapters are
+accepted. The consumer opens the manifest path without following a final
+symlink, pins that descriptor, and verifies its regular-file type, byte size,
+and SHA-256 digest before parsing the same descriptor; mismatch is always
+fatal. A bounded central-directory scan enforces the entry limit before Go's
+ZIP reader allocates its entry table and rejects multi-disk, ZIP64, malformed,
+ambiguous-end-record, forged-count, undeclared-entry, and out-of-bounds
+directories. ZIP admission then allows only
+regular stored/deflated members, at most 10,000 entries, 1 GiB archive and
+aggregate expanded size, a 1,000:1 per-member compression ratio, 4,096-byte
+member paths, and 256 path components. Empty names,
+duplicates (including case-folded and file/child path collisions), traversal,
+absolute/drive/UNC paths, control characters, invalid UTF-8, directory entries, symlinks,
+recognized special-file encodings, and unsupported compression methods fail
+closed. ZIP has no portable hardlink entry type; regular entries that originated
+from hardlinks are extracted as independent regular files. Raw content and
+malformed ZIPs are never reclassified as files.
+
+Digest and archive validation complete before extraction. Members are then
+fully decompressed into a private workspace staging directory with cancellation
+and declared-size checks before final destination members are changed. When the
+destination is the workspace root, the transient hidden staging directory is
+inside that destination, but it is removed on every return. Successful
+installation walks and opens workspace/destination directories without
+following symlinks, pins their descriptors, and renames relative to those
+descriptors. It creates directories as `0755`, writes files as `0644`, and may
+replace existing regular files. It does not preserve ZIP permissions or
+timestamps. Destination components and collisions may not be symlinks or
+special files. Validation, decompression, or cancellation before installation
+leaves final destination members unchanged and cleans temporary
+downloads/staging. Installation is atomic per file, not a multi-file
+transaction; a failure can leave already installed members, but a concurrent
+pathname or symlink swap cannot redirect installation away from the pinned
+destination tree.
+
+This bounded bridge is intentionally not a local implementation of GitHub's
+artifact protocol. The future direction is the parallel Results ArtifactService
+design, while preserving exact compiler-owned producer/dependency attribution;
+it is not a reason to broaden the current direct-needs semantics.
 
 ### Actions use the standard cache-v2 protocol
 

--- a/internal/action/integration/integration.go
+++ b/internal/action/integration/integration.go
@@ -180,9 +180,20 @@ func ValidateCacheCommit(commit string) error {
 	return nil
 }
 
-// ValidateDownloadArtifactInputs implements the common exact-name ZIP subset
-// for the audited commit. The runtime applies it again after evaluation.
+// ValidateDownloadArtifactInputs implements source-time admission for the
+// common exact-name ZIP subset. Exact names are validated after evaluation by
+// ValidateDownloadArtifactRuntimeInputs.
 func ValidateDownloadArtifactInputs(commit string, inputs map[string]string) error {
+	return validateDownloadArtifactInputs(commit, inputs, true)
+}
+
+// ValidateDownloadArtifactRuntimeInputs validates evaluated inputs at the
+// runtime boundary.
+func ValidateDownloadArtifactRuntimeInputs(commit string, inputs map[string]string) error {
+	return validateDownloadArtifactInputs(commit, inputs, false)
+}
+
+func validateDownloadArtifactInputs(commit string, inputs map[string]string, allowNameExpression bool) error {
 	if err := ValidateDownloadArtifactCommit(commit); err != nil {
 		return err
 	}
@@ -204,13 +215,16 @@ func ValidateDownloadArtifactInputs(commit string, inputs map[string]string) err
 	}
 	name, ok := inputFold(inputs, "name")
 	name = strings.TrimSpace(name)
-	if !ok || strings.Contains(name, "${{") || ValidateUploadArtifactName(name) != nil {
+	hasNameExpression := strings.Contains(name, "${{")
+	if !ok || name == "" || hasNameExpression && !allowNameExpression {
+		return fmt.Errorf("required input %q must be an exact literal artifact name", "name")
+	}
+	if !hasNameExpression && ValidateUploadArtifactName(name) != nil {
 		return fmt.Errorf("required input %q must be an exact literal artifact name", "name")
 	}
 	if value, ok := inputFold(inputs, "path"); ok {
-		value = strings.TrimSpace(value)
-		if value != "" && (strings.Contains(value, "${{") || len(value) > MaxUploadArtifactPathBytes || strings.Contains(value, "\\") || windowsDrivePath(value) || !filepath.IsLocal(value) || path.Clean(value) != value) {
-			return fmt.Errorf("input %q must be a clean workspace-relative literal", "path")
+		if _, err := NormalizeDownloadArtifactPath(value); err != nil {
+			return err
 		}
 	}
 	if value, ok := inputFold(inputs, "merge-multiple"); ok && !uploadArtifactFalse(strings.TrimSpace(value)) {
@@ -223,6 +237,34 @@ func ValidateDownloadArtifactInputs(commit string, inputs map[string]string) err
 		return fmt.Errorf("input %q may only be omitted or error; digest mismatch is always fatal", "digest-mismatch")
 	}
 	return nil
+}
+
+// NormalizeDownloadArtifactPath accepts the safe relative spellings used by
+// upstream and returns their clean slash form. It intentionally normalizes
+// only leading ./ components and trailing slashes.
+func NormalizeDownloadArtifactPath(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" || value == "." {
+		return ".", nil
+	}
+	if strings.Contains(value, "${{") || len(value) > MaxUploadArtifactPathBytes || strings.Contains(value, "\\") {
+		return "", fmt.Errorf("input %q must be a safe workspace-relative literal", "path")
+	}
+	normalized := value
+	for strings.HasPrefix(normalized, "./") {
+		normalized = strings.TrimPrefix(normalized, "./")
+	}
+	if strings.HasPrefix(normalized, "/") {
+		return "", fmt.Errorf("input %q must be a safe workspace-relative literal", "path")
+	}
+	normalized = strings.TrimRight(normalized, "/")
+	if normalized == "" {
+		return ".", nil
+	}
+	if windowsDrivePath(normalized) || !filepath.IsLocal(normalized) || path.Clean(normalized) != normalized {
+		return "", fmt.Errorf("input %q must be a safe workspace-relative literal", "path")
+	}
+	return normalized, nil
 }
 
 func windowsDrivePath(value string) bool {

--- a/internal/action/integration/integration.go
+++ b/internal/action/integration/integration.go
@@ -51,7 +51,17 @@ const (
 	UploadArtifactV5Commit = "330a01c490aca151604b8cf639adc76d48f6c5d4"
 	UploadArtifactV6Commit = "b7c566a772e6b6bfb58ed0dc250532a479d7789f"
 	UploadArtifactV7Commit = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
-	DownloadArtifactCommit = "d3f86a106a0bac45b974a628896c90dbdf5c8093"
+	// DownloadArtifact commits are the exact audited upstream releases whose
+	// exact-name ZIP mode is implemented by the native adapter. Other selection,
+	// raw-download, and digest-policy modes remain unsupported.
+	DownloadArtifactV4Commit   = "d3f86a106a0bac45b974a628896c90dbdf5c8093"
+	DownloadArtifactV5Commit   = "634f93cb2916e3fdff6788551b99b062d0335ce0"
+	DownloadArtifactV6Commit   = "018cc2cf5baa6db3ef3c5f8a56943fffe632ef53"
+	DownloadArtifactV7Commit   = "37930b1c2abaa49bbe596cd826c3c89aef350131"
+	DownloadArtifactV8Commit   = "70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3"
+	DownloadArtifactV801Commit = "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c"
+	// DownloadArtifactCommit is retained as the original v4.3.0 spelling.
+	DownloadArtifactCommit = DownloadArtifactV4Commit
 	// CacheCommit is the only actions/cache implementation admitted to the
 	// Buildkite-backed cache-v2 service.
 	CacheCommit = "55cc8345863c7cc4c66a329aec7e433d2d1c52a9"
@@ -142,10 +152,24 @@ func ValidateUploadArtifactCommit(commit string) error {
 }
 
 func ValidateDownloadArtifactCommit(commit string) error {
-	if commit != DownloadArtifactCommit {
-		return fmt.Errorf("actions/download-artifact native adapter supports only commit %s, resolved %q; Phase 6 is required", DownloadArtifactCommit, commit)
+	for _, supported := range DownloadArtifactCommits() {
+		if commit == supported {
+			return nil
+		}
 	}
-	return nil
+	return fmt.Errorf("actions/download-artifact native adapter does not support resolved commit %q; supported commits are %s; Phase 6 is required", commit, strings.Join(DownloadArtifactCommits(), ", "))
+}
+
+// DownloadArtifactCommits returns the complete immutable admission set.
+func DownloadArtifactCommits() []string {
+	return []string{
+		DownloadArtifactV4Commit,
+		DownloadArtifactV5Commit,
+		DownloadArtifactV6Commit,
+		DownloadArtifactV7Commit,
+		DownloadArtifactV8Commit,
+		DownloadArtifactV801Commit,
+	}
 }
 
 // ValidateCacheCommit rejects cache client and protocol drift from v6.1.0.
@@ -156,9 +180,17 @@ func ValidateCacheCommit(commit string) error {
 	return nil
 }
 
-// ValidateDownloadArtifactInputs implements only v4.3.0 exact-name mode.
-func ValidateDownloadArtifactInputs(inputs map[string]string) error {
+// ValidateDownloadArtifactInputs implements the common exact-name ZIP subset
+// for the audited commit. The runtime applies it again after evaluation.
+func ValidateDownloadArtifactInputs(commit string, inputs map[string]string) error {
+	if err := ValidateDownloadArtifactCommit(commit); err != nil {
+		return err
+	}
 	allowed := map[string]bool{"name": true, "path": true, "merge-multiple": true}
+	if commit == DownloadArtifactV8Commit || commit == DownloadArtifactV801Commit {
+		allowed["skip-decompress"] = true
+		allowed["digest-mismatch"] = true
+	}
 	seen := map[string]bool{}
 	for _, name := range sortedNames(inputs) {
 		lower := strings.ToLower(name)
@@ -171,18 +203,30 @@ func ValidateDownloadArtifactInputs(inputs map[string]string) error {
 		}
 	}
 	name, ok := inputFold(inputs, "name")
+	name = strings.TrimSpace(name)
 	if !ok || strings.Contains(name, "${{") || ValidateUploadArtifactName(name) != nil {
 		return fmt.Errorf("required input %q must be an exact literal artifact name", "name")
 	}
 	if value, ok := inputFold(inputs, "path"); ok {
-		if value == "" || strings.Contains(value, "${{") || len(value) > MaxUploadArtifactPathBytes || strings.Contains(value, "\\") || !filepath.IsLocal(value) || path.Clean(value) != value {
+		value = strings.TrimSpace(value)
+		if value != "" && (strings.Contains(value, "${{") || len(value) > MaxUploadArtifactPathBytes || strings.Contains(value, "\\") || windowsDrivePath(value) || !filepath.IsLocal(value) || path.Clean(value) != value) {
 			return fmt.Errorf("input %q must be a clean workspace-relative literal", "path")
 		}
 	}
-	if value, ok := inputFold(inputs, "merge-multiple"); ok && !uploadArtifactFalse(value) {
+	if value, ok := inputFold(inputs, "merge-multiple"); ok && !uploadArtifactFalse(strings.TrimSpace(value)) {
 		return fmt.Errorf("input %q may only be omitted or false; Phase 6 is required", "merge-multiple")
 	}
+	if value, ok := inputFold(inputs, "skip-decompress"); ok && !uploadArtifactFalse(strings.TrimSpace(value)) {
+		return fmt.Errorf("input %q may only be omitted or false; raw downloads are unsupported", "skip-decompress")
+	}
+	if value, ok := inputFold(inputs, "digest-mismatch"); ok && strings.TrimSpace(value) != "error" {
+		return fmt.Errorf("input %q may only be omitted or error; digest mismatch is always fatal", "digest-mismatch")
+	}
 	return nil
+}
+
+func windowsDrivePath(value string) bool {
+	return len(value) >= 2 && ((value[0] >= 'a' && value[0] <= 'z') || (value[0] >= 'A' && value[0] <= 'Z')) && value[1] == ':'
 }
 
 // ValidateUploadArtifactInputs validates the bounded adapter's static input

--- a/internal/action/integration/integration_test.go
+++ b/internal/action/integration/integration_test.go
@@ -117,6 +117,7 @@ func TestValidateUploadArtifactInputs(t *testing.T) {
 		inputs map[string]string
 	}{
 		{UploadArtifactCommit, map[string]string{"path": "payload/result.txt"}},
+		{UploadArtifactCommit, map[string]string{"name": " payload ", "path": "payload/result.txt"}},
 		{UploadArtifactV5Commit, map[string]string{"path": "./payload/result.txt"}},
 		{UploadArtifactV6Commit, map[string]string{"path": "payload/", "name": "${{ github.sha }}", "retention-days": "0"}},
 		{UploadArtifactCommit, map[string]string{

--- a/internal/action/integration/integration_test.go
+++ b/internal/action/integration/integration_test.go
@@ -33,25 +33,46 @@ func TestLookupMatchesKnownCanonicalActions(t *testing.T) {
 }
 
 func TestDownloadArtifactExactContract(t *testing.T) {
-	if err := ValidateDownloadArtifactCommit(DownloadArtifactCommit); err != nil {
-		t.Fatal(err)
+	for _, commit := range DownloadArtifactCommits() {
+		if err := ValidateDownloadArtifactCommit(commit); err != nil {
+			t.Fatalf("audited commit %s rejected: %v", commit, err)
+		}
 	}
 	if err := ValidateDownloadArtifactCommit(strings.Repeat("0", 40)); err == nil {
 		t.Fatal("unrecognized commit accepted")
 	}
-	for _, inputs := range []map[string]string{{"name": "payload"}, {"Name": "payload", "path": "out", "merge-multiple": "False"}} {
-		if err := ValidateDownloadArtifactInputs(inputs); err != nil {
-			t.Fatalf("valid inputs rejected: %v", err)
+	for _, commit := range DownloadArtifactCommits() {
+		for _, inputs := range []map[string]string{{"name": "payload"}, {"Name": " payload ", "path": "", "merge-multiple": " False "}} {
+			if err := ValidateDownloadArtifactInputs(commit, inputs); err != nil {
+				t.Fatalf("commit %s valid inputs rejected: %v", commit, err)
+			}
+		}
+	}
+	for _, commit := range []string{DownloadArtifactV8Commit, DownloadArtifactV801Commit} {
+		if err := ValidateDownloadArtifactInputs(commit, map[string]string{"name": "payload", "skip-decompress": "false", "digest-mismatch": "error"}); err != nil {
+			t.Fatalf("v8 default inputs rejected: %v", err)
 		}
 	}
 	for name, inputs := range map[string]map[string]string{
 		"all": nil, "expression": {"name": "${{ x }}"}, "absolute": {"name": "x", "path": "/tmp"},
 		"merge": {"name": "x", "merge-multiple": "true"}, "ids": {"name": "x", "artifact-ids": "1"},
-		"duplicate": {"name": "x", "Name": "y"},
+		"duplicate": {"name": "x", "Name": "y"}, "token": {"name": "x", "github-token": ""},
+		"drive path": {"name": "x", "path": "C:/out"},
 	} {
 		t.Run(name, func(t *testing.T) {
-			if ValidateDownloadArtifactInputs(inputs) == nil {
+			if ValidateDownloadArtifactInputs(DownloadArtifactV4Commit, inputs) == nil {
 				t.Fatal("unsupported inputs accepted")
+			}
+		})
+	}
+	for name, inputs := range map[string]map[string]string{
+		"raw":                    {"name": "x", "skip-decompress": "true"},
+		"digest warning":         {"name": "x", "digest-mismatch": "warn"},
+		"explicit empty boolean": {"name": "x", "skip-decompress": ""},
+	} {
+		t.Run("v8 "+name, func(t *testing.T) {
+			if ValidateDownloadArtifactInputs(DownloadArtifactV801Commit, inputs) == nil {
+				t.Fatal("unsupported v8 mode accepted")
 			}
 		})
 	}

--- a/internal/action/integration/integration_test.go
+++ b/internal/action/integration/integration_test.go
@@ -42,11 +42,14 @@ func TestDownloadArtifactExactContract(t *testing.T) {
 		t.Fatal("unrecognized commit accepted")
 	}
 	for _, commit := range DownloadArtifactCommits() {
-		for _, inputs := range []map[string]string{{"name": "payload"}, {"Name": " payload ", "path": "", "merge-multiple": " False "}} {
+		for _, inputs := range []map[string]string{{"name": "payload"}, {"Name": " payload ", "path": "", "merge-multiple": " False "}, {"name": "${{ github.sha }}", "path": "./out/"}} {
 			if err := ValidateDownloadArtifactInputs(commit, inputs); err != nil {
 				t.Fatalf("commit %s valid inputs rejected: %v", commit, err)
 			}
 		}
+	}
+	if err := ValidateDownloadArtifactRuntimeInputs(DownloadArtifactV7Commit, map[string]string{"name": "${{ github.sha }}", "path": "./"}); err == nil {
+		t.Fatal("unevaluated runtime name accepted")
 	}
 	for _, commit := range []string{DownloadArtifactV8Commit, DownloadArtifactV801Commit} {
 		if err := ValidateDownloadArtifactInputs(commit, map[string]string{"name": "payload", "skip-decompress": "false", "digest-mismatch": "error"}); err != nil {
@@ -54,7 +57,7 @@ func TestDownloadArtifactExactContract(t *testing.T) {
 		}
 	}
 	for name, inputs := range map[string]map[string]string{
-		"all": nil, "expression": {"name": "${{ x }}"}, "absolute": {"name": "x", "path": "/tmp"},
+		"all": nil, "absolute": {"name": "x", "path": "/tmp"},
 		"merge": {"name": "x", "merge-multiple": "true"}, "ids": {"name": "x", "artifact-ids": "1"},
 		"duplicate": {"name": "x", "Name": "y"}, "token": {"name": "x", "github-token": ""},
 		"drive path": {"name": "x", "path": "C:/out"},
@@ -73,6 +76,24 @@ func TestDownloadArtifactExactContract(t *testing.T) {
 		t.Run("v8 "+name, func(t *testing.T) {
 			if ValidateDownloadArtifactInputs(DownloadArtifactV801Commit, inputs) == nil {
 				t.Fatal("unsupported v8 mode accepted")
+			}
+		})
+	}
+}
+
+func TestNormalizeDownloadArtifactPath(t *testing.T) {
+	for input, want := range map[string]string{"": ".", ".": ".", "./": ".", "././": ".", "out": "out", "out/": "out", "./out/": "out", "././out/": "out", "./nested/out///": "nested/out"} {
+		t.Run("accept "+input, func(t *testing.T) {
+			got, err := NormalizeDownloadArtifactPath(input)
+			if err != nil || got != want {
+				t.Fatalf("NormalizeDownloadArtifactPath(%q) = %q, %v, want %q", input, got, err, want)
+			}
+		})
+	}
+	for _, input := range []string{"/", "//", "/tmp", "C:/out", "./C:/out", "././C:/out", `\\server\share`, "../out", "./../out", ".//", ".//out", `out\child`, "out/./child", "out//child", "${{ matrix.path }}"} {
+		t.Run("reject "+input, func(t *testing.T) {
+			if _, err := NormalizeDownloadArtifactPath(input); err == nil {
+				t.Fatalf("NormalizeDownloadArtifactPath(%q) succeeded", input)
 			}
 		})
 	}

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -1020,6 +1020,71 @@ func TestDownloadArtifactAdapterInputCommitAndNeedsBoundary(t *testing.T) {
 	}
 }
 
+func TestDownloadArtifactCompilesConditionalProducerAndConsumerMatrixFanout(t *testing.T) {
+	workspace, remote := t.TempDir(), t.TempDir()
+	workflowPath := filepath.Join(workspace, ".github", "workflows", "artifacts.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeAction(t, remote, "", "name: artifact action\nruns:\n  using: node24\n  main: index.js\n")
+	workflow := []byte(`on: push
+jobs:
+  producer:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        publish: [true, false]
+    steps:
+      - if: matrix.publish
+        uses: actions/upload-artifact@` + actionintegration.UploadArtifactCommit + `
+        with:
+          name: ${{ github.sha }}
+          path: payload
+  consumer:
+    needs: producer
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [one, two]
+    steps:
+      - uses: actions/download-artifact@` + actionintegration.DownloadArtifactV7Commit + `
+        with:
+          name: ${{ github.sha }}
+          path: './'
+`)
+	if err := os.WriteFile(workflowPath, workflow, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	plans, err := CompilePlansWithOptions(workflowPath, workflow, pushEvent(t), "phase6-test", testDistributionDigest, Options{
+		EventTrust: EventUntrusted,
+		Runners: RunnerPolicy{
+			Labels:          map[string]string{"ubuntu-latest": "hosted"},
+			UntrustedQueues: []string{"hosted"},
+		},
+		ResolveActions: true,
+		ActionSource:   &fakeActionSource{root: remote, calls: map[string]int{}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 4 {
+		t.Fatalf("plans = %d, want two producers and two consumers", len(plans))
+	}
+	for i, producer := range plans[:2] {
+		if producer.Workflow.LogicalJobID != "producer" || len(producer.Steps) != 1 || producer.Steps[0].Condition != "matrix.publish" || producer.Matrix["publish"] != (i == 0) {
+			t.Fatalf("producer %d = %#v", i, producer)
+		}
+	}
+	for i, consumer := range plans[2:] {
+		if consumer.Workflow.LogicalJobID != "consumer" || consumer.Matrix["shard"] != []string{"one", "two"}[i] || len(consumer.NeedSources["producer"]) != 2 {
+			t.Fatalf("consumer %d fan-in = %#v", i, consumer)
+		}
+		if len(consumer.Steps) != 1 || consumer.Steps[0].With["name"] != "${{ github.sha }}" || consumer.Steps[0].With["path"] != "./" || len(consumer.Actions) != 1 || consumer.Actions[0].Commit != actionintegration.DownloadArtifactV7Commit {
+			t.Fatalf("consumer %d download = %#v", i, consumer)
+		}
+	}
+}
+
 func TestDownloadArtifactMutableTagMustResolveToAuditedExactLock(t *testing.T) {
 	remote := t.TempDir()
 	writeAction(t, remote, "", "name: artifact action\nruns:\n  using: node24\n  main: index.js\n")

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -970,19 +970,30 @@ func TestDownloadArtifactAdapterInputCommitAndNeedsBoundary(t *testing.T) {
 		})
 	}
 
-	plans, err := compile(actionintegration.DownloadArtifactCommit, "    needs: producer\n", "        with:\n          name: payload\n          path: out\n          merge-multiple: false\n")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(plans) != 2 || len(plans[1].NeedSources["producer"]) != 1 || plans[1].Actions[0].Commit != actionintegration.DownloadArtifactCommit {
-		t.Fatalf("download-artifact plans = %#v", plans)
+	for _, commit := range actionintegration.DownloadArtifactCommits() {
+		with := "        with:\n          name: payload\n          path: out\n          merge-multiple: false\n"
+		if commit == actionintegration.DownloadArtifactV8Commit || commit == actionintegration.DownloadArtifactV801Commit {
+			with += "          skip-decompress: false\n          digest-mismatch: error\n"
+		}
+		plans, err := compile(commit, "    needs: producer\n", with)
+		if err != nil {
+			t.Fatalf("audited download-artifact commit %s: %v", commit, err)
+		}
+		if len(plans) != 2 || len(plans[1].NeedSources["producer"]) != 1 || plans[1].Actions[0].Commit != commit {
+			t.Fatalf("download-artifact plans for %s = %#v", commit, plans)
+		}
 	}
 
 	for name, with := range map[string]string{
 		"missing name":  "        with:\n          path: out\n",
 		"pattern":       "        with:\n          name: payload\n          pattern: 'payload-*'\n",
+		"artifact IDs":  "        with:\n          name: payload\n          artifact-ids: '1'\n",
 		"merge":         "        with:\n          name: payload\n          merge-multiple: true\n",
 		"absolute path": "        with:\n          name: payload\n          path: /tmp/out\n",
+		"drive path":    "        with:\n          name: payload\n          path: C:/out\n",
+		"cross run":     "        with:\n          name: payload\n          run-id: '1'\n",
+		"cross repo":    "        with:\n          name: payload\n          repository: owner/repo\n",
+		"REST token":    "        with:\n          name: payload\n          github-token: token\n",
 	} {
 		t.Run(name, func(t *testing.T) {
 			_, err := compile(actionintegration.DownloadArtifactCommit, "    needs: producer\n", with)
@@ -996,6 +1007,34 @@ func TestDownloadArtifactAdapterInputCommitAndNeedsBoundary(t *testing.T) {
 	}
 	if _, err := compile(strings.Repeat("b", 40), "    needs: producer\n", "        with:\n          name: payload\n"); err == nil || !strings.Contains(err.Error(), actionintegration.DownloadArtifactCommit) {
 		t.Fatalf("unsupported download-artifact commit error = %v", err)
+	}
+	for name, with := range map[string]string{
+		"raw":             "        with:\n          name: payload\n          skip-decompress: true\n",
+		"digest override": "        with:\n          name: payload\n          digest-mismatch: warn\n",
+	} {
+		t.Run("v8 "+name, func(t *testing.T) {
+			if _, err := compile(actionintegration.DownloadArtifactV801Commit, "    needs: producer\n", with); err == nil || !strings.Contains(err.Error(), "bounded download-artifact adapter") {
+				t.Fatalf("CompilePlansWithOptions() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestDownloadArtifactMutableTagMustResolveToAuditedExactLock(t *testing.T) {
+	remote := t.TempDir()
+	writeAction(t, remote, "", "name: artifact action\nruns:\n  using: node24\n  main: index.js\n")
+	resolved := &fakeActionSource{root: remote, calls: map[string]int{}, commit: actionintegration.DownloadArtifactV801Commit}
+	_, locks, _, _, err := compileActionLocks(context.Background(), t.TempDir(), resolved, []string{"actions/download-artifact@v8"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(locks) != 1 || locks[0].RequestedRef != "v8" || locks[0].Commit != actionintegration.DownloadArtifactV801Commit {
+		t.Fatalf("mutable v8 lock = %#v", locks)
+	}
+
+	resolved.commit = strings.Repeat("b", 40)
+	if _, _, _, _, err := compileActionLocks(context.Background(), t.TempDir(), resolved, []string{"actions/download-artifact@v8"}); err == nil {
+		t.Fatal("mutable v8 tag resolving to an unaudited commit was accepted")
 	}
 }
 

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -350,7 +350,7 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 					}
 				}
 				if descriptor.Adapter == actionintegration.AdapterDownloadArtifactBuildkite {
-					if err := actionintegration.ValidateDownloadArtifactInputs(instance.Steps[stepIndex].With); err != nil {
+					if err := actionintegration.ValidateDownloadArtifactInputs(lock.Commit, instance.Steps[stepIndex].With); err != nil {
 						span := instance.Steps[stepIndex].Span.Start
 						return nil, nil, fmt.Errorf("%s:%d:%d: bounded download-artifact adapter: %w", instance.SourcePath, span.Line, span.Column, err)
 					}

--- a/internal/runtime/download_artifact.go
+++ b/internal/runtime/download_artifact.go
@@ -257,10 +257,12 @@ func preflightZIPDirectory(reader io.ReaderAt, size int64) error {
 	const (
 		eocdSize      = 22
 		maxZIPComment = 1<<16 - 1
-		maxZIPExtra   = 1<<16 - 1
+		maxZIPExtra   = 64
 		centralHeader = 46
+		localHeader   = 30
 		eocdSignature = 0x06054b50
 		centralSig    = 0x02014b50
+		localSig      = 0x04034b50
 		zip16Sentinel = 1<<16 - 1
 		zip32Sentinel = 1<<32 - 1
 	)
@@ -300,7 +302,7 @@ func preflightZIPDirectory(reader io.ReaderAt, size int64) error {
 	entries := binary.LittleEndian.Uint16(record[10:])
 	centralSize := binary.LittleEndian.Uint32(record[12:])
 	centralOffset := binary.LittleEndian.Uint32(record[16:])
-	if binary.LittleEndian.Uint16(record[4:]) != 0 || binary.LittleEndian.Uint16(record[6:]) != 0 || entriesDisk != entries || entries == zip16Sentinel || centralSize == zip16Sentinel || centralSize == zip32Sentinel || centralOffset == zip32Sentinel {
+	if binary.LittleEndian.Uint16(record[4:]) != 0 || binary.LittleEndian.Uint16(record[6:]) != 0 || entriesDisk != entries || entries == zip16Sentinel || centralSize == zip32Sentinel || centralOffset == zip32Sentinel {
 		return fmt.Errorf("multi-disk or ZIP64 artifact is unsupported")
 	}
 	if entries == 0 || int(entries) > transport.MaxResultArtifactFileCount {
@@ -308,11 +310,23 @@ func preflightZIPDirectory(reader io.ReaderAt, size int64) error {
 	}
 	position, end := int64(centralOffset), int64(centralOffset)+int64(centralSize)
 	eocdOffset := size - tailSize + int64(eocd)
+	if centralSize == zip16Sentinel {
+		if eocdOffset < 20 {
+			return fmt.Errorf("artifact ZIP end record is malformed")
+		}
+		var locator [20]byte
+		if _, err := reader.ReadAt(locator[:], eocdOffset-20); err != nil {
+			return err
+		}
+		if binary.LittleEndian.Uint32(locator[:]) == 0x07064b50 && binary.LittleEndian.Uint32(locator[4:]) == 0 && binary.LittleEndian.Uint32(locator[16:]) == 1 {
+			return fmt.Errorf("ZIP64 artifact is unsupported")
+		}
+	}
 	if position < 0 || end < position || end != eocdOffset {
 		return fmt.Errorf("artifact ZIP central directory is out of bounds")
 	}
 	count := 0
-	extra := make([]byte, maxZIPExtra)
+	metadata := make([]byte, actionintegration.MaxUploadArtifactPathBytes+maxZIPExtra)
 	for position < end {
 		if end-position < centralHeader {
 			return fmt.Errorf("artifact ZIP central directory is malformed")
@@ -324,34 +338,60 @@ func preflightZIPDirectory(reader io.ReaderAt, size int64) error {
 		if binary.LittleEndian.Uint32(header[:]) != centralSig {
 			return fmt.Errorf("artifact ZIP central directory is malformed")
 		}
-		if binary.LittleEndian.Uint32(header[20:]) == zip32Sentinel || binary.LittleEndian.Uint32(header[24:]) == zip32Sentinel || binary.LittleEndian.Uint16(header[34:]) == zip16Sentinel || binary.LittleEndian.Uint32(header[42:]) == zip32Sentinel {
+		if binary.LittleEndian.Uint32(header[20:]) == zip32Sentinel || binary.LittleEndian.Uint32(header[24:]) == zip32Sentinel || binary.LittleEndian.Uint16(header[34:]) != 0 || binary.LittleEndian.Uint32(header[42:]) == zip32Sentinel {
 			return fmt.Errorf("ZIP64 artifact member is unsupported")
 		}
 		nameSize := int64(binary.LittleEndian.Uint16(header[28:]))
 		extraSize := int64(binary.LittleEndian.Uint16(header[30:]))
 		commentSize := int64(binary.LittleEndian.Uint16(header[32:]))
-		extraPosition, extraEnd := position+centralHeader+nameSize, position+centralHeader+nameSize+extraSize
-		if extraPosition < position || extraEnd < extraPosition || extraEnd > end {
+		if nameSize > actionintegration.MaxUploadArtifactPathBytes || extraSize > maxZIPExtra || commentSize != 0 {
+			return fmt.Errorf("artifact ZIP central directory metadata exceeds bounds")
+		}
+		metadataPosition, metadataEnd := position+centralHeader, position+centralHeader+nameSize+extraSize
+		if metadataPosition < position || metadataEnd < metadataPosition || metadataEnd > end {
 			return fmt.Errorf("artifact ZIP central directory exceeds bounds")
 		}
-		fields := extra[:extraSize]
-		if extraSize > 0 {
-			if _, err := reader.ReadAt(fields, extraPosition); err != nil {
+		entryMetadata := metadata[:nameSize+extraSize]
+		if len(entryMetadata) > 0 {
+			if _, err := reader.ReadAt(entryMetadata, metadataPosition); err != nil {
 				return err
 			}
 		}
-		for len(fields) > 0 {
-			if len(fields) < 4 {
-				return fmt.Errorf("artifact ZIP central directory extra field is malformed")
+		memberName := string(entryMetadata[:nameSize])
+		if !validArtifactMember(memberName) {
+			return fmt.Errorf("artifact ZIP member name is unsafe")
+		}
+		if err := preflightZIPExtraFields(entryMetadata[nameSize:]); err != nil {
+			return err
+		}
+
+		localOffset := int64(binary.LittleEndian.Uint32(header[42:]))
+		if localOffset < 0 || int64(centralOffset)-localOffset < localHeader {
+			return fmt.Errorf("artifact ZIP local header is out of bounds")
+		}
+		var local [localHeader]byte
+		if _, err := reader.ReadAt(local[:], localOffset); err != nil {
+			return err
+		}
+		if binary.LittleEndian.Uint32(local[:]) != localSig || binary.LittleEndian.Uint32(local[18:]) == zip32Sentinel || binary.LittleEndian.Uint32(local[22:]) == zip32Sentinel {
+			return fmt.Errorf("ZIP64 or malformed artifact local header is unsupported")
+		}
+		localNameSize := int64(binary.LittleEndian.Uint16(local[26:]))
+		localExtraSize := int64(binary.LittleEndian.Uint16(local[28:]))
+		if localNameSize > actionintegration.MaxUploadArtifactPathBytes || localExtraSize > maxZIPExtra || int64(centralOffset)-localOffset-localHeader < localNameSize+localExtraSize {
+			return fmt.Errorf("artifact ZIP local header metadata exceeds bounds")
+		}
+		localMetadata := metadata[:localNameSize+localExtraSize]
+		if len(localMetadata) > 0 {
+			if _, err := reader.ReadAt(localMetadata, localOffset+localHeader); err != nil {
+				return err
 			}
-			fieldSize := int(binary.LittleEndian.Uint16(fields[2:]))
-			if fieldSize > len(fields)-4 {
-				return fmt.Errorf("artifact ZIP central directory extra field is malformed")
-			}
-			if binary.LittleEndian.Uint16(fields[:]) == 0x0001 {
-				return fmt.Errorf("ZIP64 artifact member is unsupported")
-			}
-			fields = fields[4+fieldSize:]
+		}
+		if string(localMetadata[:localNameSize]) != memberName {
+			return fmt.Errorf("artifact ZIP local and central names differ")
+		}
+		if err := preflightZIPExtraFields(localMetadata[localNameSize:]); err != nil {
+			return err
 		}
 		position += centralHeader + nameSize + extraSize + commentSize
 		count++
@@ -361,6 +401,23 @@ func preflightZIPDirectory(reader io.ReaderAt, size int64) error {
 	}
 	if position != end || count != int(entries) {
 		return fmt.Errorf("artifact ZIP central directory count mismatch")
+	}
+	return nil
+}
+
+func preflightZIPExtraFields(fields []byte) error {
+	for len(fields) > 0 {
+		if len(fields) < 4 {
+			return fmt.Errorf("artifact ZIP extra field is malformed")
+		}
+		fieldSize := int(binary.LittleEndian.Uint16(fields[2:]))
+		if fieldSize > len(fields)-4 {
+			return fmt.Errorf("artifact ZIP extra field is malformed")
+		}
+		if binary.LittleEndian.Uint16(fields[:]) == 0x0001 {
+			return fmt.Errorf("ZIP64 artifact member is unsupported")
+		}
+		fields = fields[4+fieldSize:]
 	}
 	return nil
 }

--- a/internal/runtime/download_artifact.go
+++ b/internal/runtime/download_artifact.go
@@ -176,7 +176,7 @@ func extractDownloadZIPFile(ctx context.Context, f *os.File, size int64, workspa
 		foldedNames = append(foldedNames, strings.ToLower(name))
 		members = append(members, downloadMember{file: f, name: name, size: int64(f.UncompressedSize64)})
 	}
-	sort.Strings(foldedNames)
+	sort.Slice(foldedNames, func(i, j int) bool { return downloadPathLess(foldedNames[i], foldedNames[j]) })
 	for i := 1; i < len(foldedNames); i++ {
 		previous, current := foldedNames[i-1], foldedNames[i]
 		if current == previous || strings.HasPrefix(current, previous+"/") {
@@ -233,6 +233,22 @@ func extractDownloadZIPFile(ctx context.Context, f *os.File, size int64, workspa
 		return err
 	}
 	return installDownloadMembers(ctx, workspace, staging, destination, members)
+}
+
+func downloadPathLess(left, right string) bool {
+	for i := 0; i < min(len(left), len(right)); i++ {
+		if left[i] == right[i] {
+			continue
+		}
+		if left[i] == '/' {
+			return true
+		}
+		if right[i] == '/' {
+			return false
+		}
+		return left[i] < right[i]
+	}
+	return len(left) < len(right)
 }
 
 func preflightZIPDirectory(reader io.ReaderAt, size int64) error {

--- a/internal/runtime/download_artifact.go
+++ b/internal/runtime/download_artifact.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"context"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -18,6 +19,7 @@ import (
 	actionintegration "github.com/buildkite/buildkite-gha/internal/action/integration"
 	"github.com/buildkite/buildkite-gha/internal/plan"
 	"github.com/buildkite/buildkite-gha/internal/transport"
+	"golang.org/x/sys/unix"
 )
 
 type downloadMember struct {
@@ -26,18 +28,20 @@ type downloadMember struct {
 	size int64
 }
 
-func (r Runner) runDownloadArtifact(ctx context.Context, processor *commandProcessor, workspace string, needs map[string]plan.Need, inputs map[string]string) (result Result, returnErr error) {
+const maxDownloadCompressionRatio = 1_000
+
+func (r Runner) runDownloadArtifact(ctx context.Context, processor *commandProcessor, workspace string, needs map[string]plan.Need, commit string, inputs map[string]string) (result Result, returnErr error) {
 	result = newResult()
 	defer func() { returnErr = processor.scrubError(returnErr) }()
 	if err := ctx.Err(); err != nil {
 		return result, err
 	}
-	if err := actionintegration.ValidateDownloadArtifactInputs(inputs); err != nil {
+	if err := actionintegration.ValidateDownloadArtifactInputs(commit, inputs); err != nil {
 		return result, fmt.Errorf("bounded download-artifact adapter: %w", err)
 	}
 	values := map[string]string{}
 	for k, v := range inputs {
-		values[strings.ToLower(k)] = v
+		values[strings.ToLower(k)] = strings.TrimSpace(v)
 	}
 	name, destinationRelative := values["name"], "."
 	for _, mask := range processor.maskValues() {
@@ -101,17 +105,22 @@ func (r Runner) runDownloadArtifact(ctx context.Context, processor *commandProce
 	if regular != 1 {
 		return result, fmt.Errorf("download contained %d regular files, want exactly the expected archive", regular)
 	}
-	info, err := os.Lstat(archivePath)
+	archive, err := os.OpenFile(archivePath, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		return result, fmt.Errorf("downloaded archive is not the expected regular file")
+	}
+	defer func() { _ = archive.Close() }()
+	info, err := archive.Stat()
 	if err != nil || !info.Mode().IsRegular() {
 		return result, fmt.Errorf("downloaded archive is not the expected regular file")
 	}
 	if info.Size() != artifact.Size {
 		return result, fmt.Errorf("downloaded archive size mismatch")
 	}
-	if err := verifyDownloadDigest(ctx, archivePath, artifact.Digest, artifact.Size); err != nil {
+	if err := verifyDownloadDigestFile(ctx, archive, artifact.Digest, artifact.Size); err != nil {
 		return result, err
 	}
-	if err := extractDownloadZIP(ctx, archivePath, resolvedWorkspace, destinationRelative, artifact.FileCount); err != nil {
+	if err := extractDownloadZIPFile(ctx, archive, artifact.Size, resolvedWorkspace, destinationRelative, artifact.FileCount); err != nil {
 		return result, err
 	}
 	result.Outputs["download-path"] = absDestination
@@ -123,28 +132,55 @@ func verifyDownloadDigest(ctx context.Context, filename, digest string, size int
 	if err != nil {
 		return err
 	}
+	err = verifyDownloadDigestFile(ctx, f, digest, size)
+	return errors.Join(err, f.Close())
+}
+
+func verifyDownloadDigestFile(ctx context.Context, f *os.File, digest string, size int64) error {
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
 	h := sha256.New()
-	n, copyErr := io.Copy(h, io.LimitReader(contextReader{ctx: ctx, reader: f}, transport.MaxResultArtifactSizeBytes+1))
-	closeErr := f.Close()
-	if err := errors.Join(copyErr, closeErr); err != nil {
+	n, err := io.Copy(h, io.LimitReader(contextReader{ctx: ctx, reader: f}, transport.MaxResultArtifactSizeBytes+1))
+	if err != nil {
 		return err
 	}
 	if n != size || "sha256:"+hex.EncodeToString(h.Sum(nil)) != digest {
 		return fmt.Errorf("downloaded archive digest mismatch")
 	}
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
 	return ctx.Err()
 }
 
 func extractDownloadZIP(ctx context.Context, filename, workspace, destination string, expectedCount int) error {
-	z, err := zip.OpenReader(filename)
+	f, err := os.Open(filename)
 	if err != nil {
 		return fmt.Errorf("open artifact ZIP: %w", err)
 	}
-	defer func() { _ = z.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return fmt.Errorf("stat artifact ZIP: %w", err)
+	}
+	err = extractDownloadZIPFile(ctx, f, info.Size(), workspace, destination, expectedCount)
+	return errors.Join(err, f.Close())
+}
+
+func extractDownloadZIPFile(ctx context.Context, f *os.File, size int64, workspace, destination string, expectedCount int) error {
+	if err := preflightZIPDirectory(f, size); err != nil {
+		return fmt.Errorf("preflight artifact ZIP: %w", err)
+	}
+	z, err := zip.NewReader(f, size)
+	if err != nil {
+		return fmt.Errorf("open artifact ZIP: %w", err)
+	}
 	if len(z.File) != expectedCount || len(z.File) > transport.MaxResultArtifactFileCount {
 		return fmt.Errorf("artifact ZIP file count mismatch")
 	}
 	seen, folded := map[string]bool{}, map[string]bool{}
+	parents, foldedParents := map[string]bool{}, map[string]bool{}
 	members := make([]downloadMember, 0, len(z.File))
 	var expanded int64
 	for _, f := range z.File {
@@ -155,14 +191,27 @@ func extractDownloadZIP(ctx context.Context, filename, workspace, destination st
 		if !validArtifactMember(name) || seen[name] || folded[strings.ToLower(name)] {
 			return fmt.Errorf("unsafe or duplicate artifact ZIP member %q", name)
 		}
+		foldedName := strings.ToLower(name)
+		if parents[name] || foldedParents[foldedName] {
+			return fmt.Errorf("artifact ZIP member %q collides with another member path", name)
+		}
+		for parent := path.Dir(name); parent != "."; parent = path.Dir(parent) {
+			if seen[parent] || folded[strings.ToLower(parent)] {
+				return fmt.Errorf("artifact ZIP member %q collides with another member path", name)
+			}
+			parents[parent], foldedParents[strings.ToLower(parent)] = true, true
+		}
 		if f.Method != zip.Store && f.Method != zip.Deflate || !f.Mode().IsRegular() || f.FileInfo().IsDir() {
 			return fmt.Errorf("artifact ZIP member %q is not a supported regular file", name)
 		}
 		if f.UncompressedSize64 > uint64(transport.MaxResultArtifactSizeBytes) || expanded > transport.MaxResultArtifactSizeBytes-int64(f.UncompressedSize64) {
 			return fmt.Errorf("artifact expanded bytes exceed 1 GiB")
 		}
+		if f.UncompressedSize64 > 0 && (f.CompressedSize64 == 0 || f.UncompressedSize64 > f.CompressedSize64*maxDownloadCompressionRatio) {
+			return fmt.Errorf("artifact ZIP member %q exceeds compression ratio limit", name)
+		}
 		expanded += int64(f.UncompressedSize64)
-		seen[name], folded[strings.ToLower(name)] = true, true
+		seen[name], folded[foldedName] = true, true
 		members = append(members, downloadMember{file: f, name: name, size: int64(f.UncompressedSize64)})
 	}
 	workspaceRoot, err := os.OpenRoot(workspace)
@@ -170,32 +219,23 @@ func extractDownloadZIP(ctx context.Context, filename, workspace, destination st
 		return fmt.Errorf("open download workspace: %w", err)
 	}
 	defer func() { _ = workspaceRoot.Close() }()
-	if err := validateDownloadDirectory(workspaceRoot, destination); err != nil {
-		return err
-	}
-	if err := workspaceRoot.MkdirAll(destination, 0o755); err != nil {
-		return err
-	}
-	if err := validateDownloadDirectory(workspaceRoot, destination); err != nil {
-		return err
-	}
-	root, err := workspaceRoot.OpenRoot(destination)
+	staging, err := os.MkdirTemp(workspace, ".buildkite-gha-extract-")
 	if err != nil {
-		return err
+		return fmt.Errorf("create artifact staging directory: %w", err)
 	}
-	defer func() { _ = root.Close() }()
-	if err := preflightDestination(root, members); err != nil {
-		return err
+	defer func() { _ = os.RemoveAll(staging) }()
+	stagingName := filepath.Base(staging)
+	stagingRoot, err := workspaceRoot.OpenRoot(stagingName)
+	if err != nil {
+		return fmt.Errorf("open artifact staging directory: %w", err)
 	}
+	defer func() { _ = stagingRoot.Close() }()
 	for _, member := range members {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
 		if dir := path.Dir(member.name); dir != "." {
-			if err := root.MkdirAll(filepath.FromSlash(dir), 0o755); err != nil {
-				return err
-			}
-			if err := validateDownloadDirectory(root, filepath.FromSlash(dir)); err != nil {
+			if err := stagingRoot.MkdirAll(filepath.FromSlash(dir), 0o755); err != nil {
 				return err
 			}
 		}
@@ -203,14 +243,10 @@ func extractDownloadZIP(ctx context.Context, filename, workspace, destination st
 		if err != nil {
 			return err
 		}
-		out, err := root.OpenFile(filepath.FromSlash(member.name), os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW|syscall.O_NONBLOCK, 0o644)
+		out, err := stagingRoot.OpenFile(filepath.FromSlash(member.name), os.O_WRONLY|os.O_CREATE|os.O_EXCL|syscall.O_NOFOLLOW|syscall.O_NONBLOCK, 0o644)
 		if err != nil {
 			_ = in.Close()
-			return fmt.Errorf("open artifact destination %q: %w", member.name, err)
-		}
-		info, statErr := out.Stat()
-		if statErr != nil || !info.Mode().IsRegular() {
-			return errors.Join(fmt.Errorf("artifact destination %q is not a regular file", member.name), statErr, out.Close(), in.Close())
+			return fmt.Errorf("open staged artifact member %q: %w", member.name, err)
 		}
 		if err := out.Chmod(0o644); err != nil {
 			return errors.Join(err, out.Close(), in.Close())
@@ -224,11 +260,207 @@ func extractDownloadZIP(ctx context.Context, filename, workspace, destination st
 			return fmt.Errorf("artifact ZIP member %q size mismatch", member.name)
 		}
 	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return installDownloadMembers(ctx, workspace, staging, destination, members)
+}
+
+func preflightZIPDirectory(reader io.ReaderAt, size int64) error {
+	const (
+		eocdSize      = 22
+		maxZIPComment = 1<<16 - 1
+		centralHeader = 46
+		eocdSignature = 0x06054b50
+		centralSig    = 0x02014b50
+		zip16Sentinel = 1<<16 - 1
+		zip32Sentinel = 1<<32 - 1
+	)
+	if size < eocdSize || size > transport.MaxResultArtifactSizeBytes {
+		return fmt.Errorf("artifact ZIP size is out of bounds")
+	}
+	tailSize := min(size, int64(eocdSize+maxZIPComment))
+	tail := make([]byte, tailSize)
+	if _, err := reader.ReadAt(tail, size-tailSize); err != nil {
+		return err
+	}
+	eocd := -1
+	for i := len(tail) - eocdSize; i >= 0; i-- {
+		if binary.LittleEndian.Uint32(tail[i:]) != eocdSignature {
+			continue
+		}
+		comment := int(binary.LittleEndian.Uint16(tail[i+20:]))
+		if i+eocdSize+comment == len(tail) {
+			eocd = i
+			break
+		}
+	}
+	if eocd < 0 {
+		return fmt.Errorf("artifact ZIP end record is missing")
+	}
+	for i := eocd + 1; i <= len(tail)-eocdSize; i++ {
+		if binary.LittleEndian.Uint32(tail[i:]) != eocdSignature {
+			continue
+		}
+		comment := int(binary.LittleEndian.Uint16(tail[i+20:]))
+		if i+eocdSize+comment <= len(tail) {
+			return fmt.Errorf("artifact ZIP has an ambiguous end record")
+		}
+	}
+	record := tail[eocd:]
+	entriesDisk := binary.LittleEndian.Uint16(record[8:])
+	entries := binary.LittleEndian.Uint16(record[10:])
+	centralSize := binary.LittleEndian.Uint32(record[12:])
+	centralOffset := binary.LittleEndian.Uint32(record[16:])
+	if binary.LittleEndian.Uint16(record[4:]) != 0 || binary.LittleEndian.Uint16(record[6:]) != 0 || entriesDisk != entries || entries == zip16Sentinel || centralSize == zip32Sentinel || centralOffset == zip32Sentinel {
+		return fmt.Errorf("multi-disk or ZIP64 artifact is unsupported")
+	}
+	if entries == 0 || int(entries) > transport.MaxResultArtifactFileCount {
+		return fmt.Errorf("artifact ZIP file count is out of bounds")
+	}
+	position, end := int64(centralOffset), int64(centralOffset)+int64(centralSize)
+	eocdOffset := size - tailSize + int64(eocd)
+	if position < 0 || end < position || end != eocdOffset {
+		return fmt.Errorf("artifact ZIP central directory is out of bounds")
+	}
+	count := 0
+	for position < end {
+		var header [centralHeader]byte
+		if _, err := reader.ReadAt(header[:], position); err != nil {
+			return err
+		}
+		if binary.LittleEndian.Uint32(header[:]) != centralSig {
+			return fmt.Errorf("artifact ZIP central directory is malformed")
+		}
+		nameSize := int64(binary.LittleEndian.Uint16(header[28:]))
+		extraSize := int64(binary.LittleEndian.Uint16(header[30:]))
+		commentSize := int64(binary.LittleEndian.Uint16(header[32:]))
+		position += centralHeader + nameSize + extraSize + commentSize
+		count++
+		if count > transport.MaxResultArtifactFileCount || position > end {
+			return fmt.Errorf("artifact ZIP central directory exceeds bounds")
+		}
+	}
+	if position != end || count != int(entries) {
+		return fmt.Errorf("artifact ZIP central directory count mismatch")
+	}
+	return nil
+}
+
+func installDownloadMembers(ctx context.Context, workspace, staging, destination string, members []downloadMember) error {
+	workspaceFD, err := unix.Open(workspace, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return fmt.Errorf("open pinned download workspace: %w", err)
+	}
+	defer func() { _ = unix.Close(workspaceFD) }()
+	stagingFD, err := unix.Open(staging, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return fmt.Errorf("open pinned artifact staging directory: %w", err)
+	}
+	defer func() { _ = unix.Close(stagingFD) }()
+	destinationFD, err := openDownloadDirectoryAt(workspaceFD, filepath.ToSlash(destination), true)
+	if err != nil {
+		return fmt.Errorf("open pinned artifact destination %q: %w", destination, err)
+	}
+	defer func() { _ = unix.Close(destinationFD) }()
+	return installDownloadMembersAt(ctx, stagingFD, destinationFD, members)
+}
+
+func installDownloadMembersAt(ctx context.Context, stagingFD, destinationFD int, members []downloadMember) error {
+	for _, member := range members {
+		if err := preflightDownloadMemberAt(destinationFD, member.name, false); err != nil {
+			return err
+		}
+	}
+	for _, member := range members {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		directory, base := path.Split(member.name)
+		sourceParent, err := openDownloadDirectoryAt(stagingFD, strings.TrimSuffix(directory, "/"), false)
+		if err != nil {
+			return err
+		}
+		destinationParent, err := openDownloadDirectoryAt(destinationFD, strings.TrimSuffix(directory, "/"), true)
+		if err != nil {
+			_ = unix.Close(sourceParent)
+			return err
+		}
+		installErr := preflightDownloadBaseAt(destinationParent, base)
+		if installErr == nil {
+			installErr = unix.Renameat(sourceParent, base, destinationParent, base)
+		}
+		closeErr := errors.Join(unix.Close(sourceParent), unix.Close(destinationParent))
+		if err := errors.Join(installErr, closeErr); err != nil {
+			return fmt.Errorf("install artifact destination %q: %w", member.name, err)
+		}
+	}
 	return ctx.Err()
+}
+
+func preflightDownloadMemberAt(root int, name string, createParents bool) error {
+	directory, base := path.Split(name)
+	parent, err := openDownloadDirectoryAt(root, strings.TrimSuffix(directory, "/"), createParents)
+	if err != nil {
+		if !createParents && errors.Is(err, unix.ENOENT) {
+			return nil
+		}
+		return err
+	}
+	defer func() { _ = unix.Close(parent) }()
+	return preflightDownloadBaseAt(parent, base)
+}
+
+func preflightDownloadBaseAt(parent int, base string) error {
+	var stat unix.Stat_t
+	err := unix.Fstatat(parent, base, &stat, unix.AT_SYMLINK_NOFOLLOW)
+	if errors.Is(err, unix.ENOENT) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if stat.Mode&unix.S_IFMT != unix.S_IFREG {
+		return fmt.Errorf("artifact destination collision %q is not a regular file", base)
+	}
+	return nil
+}
+
+func openDownloadDirectoryAt(root int, directory string, create bool) (int, error) {
+	current, err := unix.Dup(root)
+	if err != nil {
+		return -1, err
+	}
+	if directory == "" || directory == "." {
+		return current, nil
+	}
+	for _, component := range strings.Split(directory, "/") {
+		if component == "" || component == "." || component == ".." {
+			_ = unix.Close(current)
+			return -1, fmt.Errorf("invalid artifact directory component")
+		}
+		next, openErr := unix.Openat(current, component, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+		if errors.Is(openErr, unix.ENOENT) && create {
+			if err := unix.Mkdirat(current, component, 0o755); err != nil && !errors.Is(err, unix.EEXIST) {
+				_ = unix.Close(current)
+				return -1, err
+			}
+			next, openErr = unix.Openat(current, component, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+		}
+		_ = unix.Close(current)
+		if openErr != nil {
+			return -1, openErr
+		}
+		current = next
+	}
+	return current, nil
 }
 
 func validArtifactMember(name string) bool {
 	if name == "" || name == "." || name == ".." || strings.HasPrefix(name, "../") || len(name) > actionintegration.MaxUploadArtifactPathBytes || !utf8.ValidString(name) || strings.ContainsAny(name, "\\\x00") || path.Clean(name) != name || strings.HasPrefix(name, "/") {
+		return false
+	}
+	if len(name) >= 2 && ((name[0] >= 'a' && name[0] <= 'z') || (name[0] >= 'A' && name[0] <= 'Z')) && name[1] == ':' {
 		return false
 	}
 	if len(strings.Split(name, "/")) > 256 {
@@ -240,50 +472,4 @@ func validArtifactMember(name string) bool {
 		}
 	}
 	return true
-}
-
-func validateDownloadDirectory(root *os.Root, directory string) error {
-	if directory == "." {
-		return nil
-	}
-	current := ""
-	for _, component := range strings.Split(filepath.ToSlash(directory), "/") {
-		current = path.Join(current, component)
-		info, err := root.Lstat(filepath.FromSlash(current))
-		if os.IsNotExist(err) {
-			return nil
-		}
-		if err != nil {
-			return err
-		}
-		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
-			return fmt.Errorf("artifact path component %q is not a real directory", current)
-		}
-	}
-	return nil
-}
-
-func preflightDestination(root *os.Root, members []downloadMember) error {
-	for _, member := range members {
-		current := ""
-		parts := strings.Split(member.name, "/")
-		for i, part := range parts {
-			current = path.Join(current, part)
-			info, err := root.Lstat(filepath.FromSlash(current))
-			if os.IsNotExist(err) {
-				continue
-			}
-			if err != nil {
-				return err
-			}
-			if i < len(parts)-1 {
-				if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
-					return fmt.Errorf("artifact path component %q is not a directory", current)
-				}
-			} else if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
-				return fmt.Errorf("artifact destination collision %q is not a regular file", current)
-			}
-		}
-	}
-	return nil
 }

--- a/internal/runtime/download_artifact.go
+++ b/internal/runtime/download_artifact.go
@@ -257,6 +257,7 @@ func preflightZIPDirectory(reader io.ReaderAt, size int64) error {
 	const (
 		eocdSize      = 22
 		maxZIPComment = 1<<16 - 1
+		maxZIPExtra   = 1<<16 - 1
 		centralHeader = 46
 		eocdSignature = 0x06054b50
 		centralSig    = 0x02014b50
@@ -299,7 +300,7 @@ func preflightZIPDirectory(reader io.ReaderAt, size int64) error {
 	entries := binary.LittleEndian.Uint16(record[10:])
 	centralSize := binary.LittleEndian.Uint32(record[12:])
 	centralOffset := binary.LittleEndian.Uint32(record[16:])
-	if binary.LittleEndian.Uint16(record[4:]) != 0 || binary.LittleEndian.Uint16(record[6:]) != 0 || entriesDisk != entries || entries == zip16Sentinel || centralSize == zip32Sentinel || centralOffset == zip32Sentinel {
+	if binary.LittleEndian.Uint16(record[4:]) != 0 || binary.LittleEndian.Uint16(record[6:]) != 0 || entriesDisk != entries || entries == zip16Sentinel || centralSize == zip16Sentinel || centralSize == zip32Sentinel || centralOffset == zip32Sentinel {
 		return fmt.Errorf("multi-disk or ZIP64 artifact is unsupported")
 	}
 	if entries == 0 || int(entries) > transport.MaxResultArtifactFileCount {
@@ -311,7 +312,11 @@ func preflightZIPDirectory(reader io.ReaderAt, size int64) error {
 		return fmt.Errorf("artifact ZIP central directory is out of bounds")
 	}
 	count := 0
+	extra := make([]byte, maxZIPExtra)
 	for position < end {
+		if end-position < centralHeader {
+			return fmt.Errorf("artifact ZIP central directory is malformed")
+		}
 		var header [centralHeader]byte
 		if _, err := reader.ReadAt(header[:], position); err != nil {
 			return err
@@ -329,22 +334,24 @@ func preflightZIPDirectory(reader io.ReaderAt, size int64) error {
 		if extraPosition < position || extraEnd < extraPosition || extraEnd > end {
 			return fmt.Errorf("artifact ZIP central directory exceeds bounds")
 		}
-		for extraPosition < extraEnd {
-			if extraEnd-extraPosition < 4 {
-				return fmt.Errorf("artifact ZIP central directory extra field is malformed")
-			}
-			var extraHeader [4]byte
-			if _, err := reader.ReadAt(extraHeader[:], extraPosition); err != nil {
+		fields := extra[:extraSize]
+		if extraSize > 0 {
+			if _, err := reader.ReadAt(fields, extraPosition); err != nil {
 				return err
 			}
-			fieldSize := int64(binary.LittleEndian.Uint16(extraHeader[2:]))
-			if binary.LittleEndian.Uint16(extraHeader[:]) == 0x0001 {
-				return fmt.Errorf("ZIP64 artifact member is unsupported")
-			}
-			extraPosition += 4 + fieldSize
-			if extraPosition > extraEnd {
+		}
+		for len(fields) > 0 {
+			if len(fields) < 4 {
 				return fmt.Errorf("artifact ZIP central directory extra field is malformed")
 			}
+			fieldSize := int(binary.LittleEndian.Uint16(fields[2:]))
+			if fieldSize > len(fields)-4 {
+				return fmt.Errorf("artifact ZIP central directory extra field is malformed")
+			}
+			if binary.LittleEndian.Uint16(fields[:]) == 0x0001 {
+				return fmt.Errorf("ZIP64 artifact member is unsupported")
+			}
+			fields = fields[4+fieldSize:]
 		}
 		position += centralHeader + nameSize + extraSize + commentSize
 		count++

--- a/internal/runtime/download_artifact.go
+++ b/internal/runtime/download_artifact.go
@@ -28,8 +28,6 @@ type downloadMember struct {
 	size int64
 }
 
-const maxDownloadCompressionRatio = 1_000
-
 func (r Runner) runDownloadArtifact(ctx context.Context, processor *commandProcessor, workspace string, needs map[string]plan.Need, commit string, inputs map[string]string) (result Result, returnErr error) {
 	result = newResult()
 	defer func() { returnErr = processor.scrubError(returnErr) }()
@@ -127,15 +125,6 @@ func (r Runner) runDownloadArtifact(ctx context.Context, processor *commandProce
 	return result, nil
 }
 
-func verifyDownloadDigest(ctx context.Context, filename, digest string, size int64) error {
-	f, err := os.Open(filename)
-	if err != nil {
-		return err
-	}
-	err = verifyDownloadDigestFile(ctx, f, digest, size)
-	return errors.Join(err, f.Close())
-}
-
 func verifyDownloadDigestFile(ctx context.Context, f *os.File, digest string, size int64) error {
 	if _, err := f.Seek(0, io.SeekStart); err != nil {
 		return err
@@ -152,20 +141,6 @@ func verifyDownloadDigestFile(ctx context.Context, f *os.File, digest string, si
 		return err
 	}
 	return ctx.Err()
-}
-
-func extractDownloadZIP(ctx context.Context, filename, workspace, destination string, expectedCount int) error {
-	f, err := os.Open(filename)
-	if err != nil {
-		return fmt.Errorf("open artifact ZIP: %w", err)
-	}
-	info, err := f.Stat()
-	if err != nil {
-		_ = f.Close()
-		return fmt.Errorf("stat artifact ZIP: %w", err)
-	}
-	err = extractDownloadZIPFile(ctx, f, info.Size(), workspace, destination, expectedCount)
-	return errors.Join(err, f.Close())
 }
 
 func extractDownloadZIPFile(ctx context.Context, f *os.File, size int64, workspace, destination string, expectedCount int) error {
@@ -206,9 +181,6 @@ func extractDownloadZIPFile(ctx context.Context, f *os.File, size int64, workspa
 		}
 		if f.UncompressedSize64 > uint64(transport.MaxResultArtifactSizeBytes) || expanded > transport.MaxResultArtifactSizeBytes-int64(f.UncompressedSize64) {
 			return fmt.Errorf("artifact expanded bytes exceed 1 GiB")
-		}
-		if f.UncompressedSize64 > 0 && (f.CompressedSize64 == 0 || f.UncompressedSize64 > f.CompressedSize64*maxDownloadCompressionRatio) {
-			return fmt.Errorf("artifact ZIP member %q exceeds compression ratio limit", name)
 		}
 		expanded += int64(f.UncompressedSize64)
 		seen[name], folded[foldedName] = true, true
@@ -368,7 +340,7 @@ func installDownloadMembers(ctx context.Context, workspace, staging, destination
 
 func installDownloadMembersAt(ctx context.Context, stagingFD, destinationFD int, members []downloadMember) error {
 	for _, member := range members {
-		if err := preflightDownloadMemberAt(destinationFD, member.name, false); err != nil {
+		if err := preflightDownloadMemberAt(destinationFD, member.name); err != nil {
 			return err
 		}
 	}
@@ -398,11 +370,11 @@ func installDownloadMembersAt(ctx context.Context, stagingFD, destinationFD int,
 	return ctx.Err()
 }
 
-func preflightDownloadMemberAt(root int, name string, createParents bool) error {
+func preflightDownloadMemberAt(root int, name string) error {
 	directory, base := path.Split(name)
-	parent, err := openDownloadDirectoryAt(root, strings.TrimSuffix(directory, "/"), createParents)
+	parent, err := openDownloadDirectoryAt(root, strings.TrimSuffix(directory, "/"), false)
 	if err != nil {
-		if !createParents && errors.Is(err, unix.ENOENT) {
+		if errors.Is(err, unix.ENOENT) {
 			return nil
 		}
 		return err

--- a/internal/runtime/download_artifact.go
+++ b/internal/runtime/download_artifact.go
@@ -319,9 +319,33 @@ func preflightZIPDirectory(reader io.ReaderAt, size int64) error {
 		if binary.LittleEndian.Uint32(header[:]) != centralSig {
 			return fmt.Errorf("artifact ZIP central directory is malformed")
 		}
+		if binary.LittleEndian.Uint32(header[20:]) == zip32Sentinel || binary.LittleEndian.Uint32(header[24:]) == zip32Sentinel || binary.LittleEndian.Uint16(header[34:]) == zip16Sentinel || binary.LittleEndian.Uint32(header[42:]) == zip32Sentinel {
+			return fmt.Errorf("ZIP64 artifact member is unsupported")
+		}
 		nameSize := int64(binary.LittleEndian.Uint16(header[28:]))
 		extraSize := int64(binary.LittleEndian.Uint16(header[30:]))
 		commentSize := int64(binary.LittleEndian.Uint16(header[32:]))
+		extraPosition, extraEnd := position+centralHeader+nameSize, position+centralHeader+nameSize+extraSize
+		if extraPosition < position || extraEnd < extraPosition || extraEnd > end {
+			return fmt.Errorf("artifact ZIP central directory exceeds bounds")
+		}
+		for extraPosition < extraEnd {
+			if extraEnd-extraPosition < 4 {
+				return fmt.Errorf("artifact ZIP central directory extra field is malformed")
+			}
+			var extraHeader [4]byte
+			if _, err := reader.ReadAt(extraHeader[:], extraPosition); err != nil {
+				return err
+			}
+			fieldSize := int64(binary.LittleEndian.Uint16(extraHeader[2:]))
+			if binary.LittleEndian.Uint16(extraHeader[:]) == 0x0001 {
+				return fmt.Errorf("ZIP64 artifact member is unsupported")
+			}
+			extraPosition += 4 + fieldSize
+			if extraPosition > extraEnd {
+				return fmt.Errorf("artifact ZIP central directory extra field is malformed")
+			}
+		}
 		position += centralHeader + nameSize + extraSize + commentSize
 		count++
 		if count > transport.MaxResultArtifactFileCount || position > end {

--- a/internal/runtime/download_artifact.go
+++ b/internal/runtime/download_artifact.go
@@ -35,21 +35,23 @@ func (r Runner) runDownloadArtifact(ctx context.Context, processor *commandProce
 	if err := ctx.Err(); err != nil {
 		return result, err
 	}
-	if err := actionintegration.ValidateDownloadArtifactInputs(commit, inputs); err != nil {
+	if err := actionintegration.ValidateDownloadArtifactRuntimeInputs(commit, inputs); err != nil {
 		return result, fmt.Errorf("bounded download-artifact adapter: %w", err)
 	}
 	values := map[string]string{}
 	for k, v := range inputs {
 		values[strings.ToLower(k)] = strings.TrimSpace(v)
 	}
-	name, destinationRelative := values["name"], "."
+	name := values["name"]
+	destinationSlash, err := actionintegration.NormalizeDownloadArtifactPath(values["path"])
+	if err != nil {
+		return result, fmt.Errorf("bounded download-artifact adapter: %w", err)
+	}
+	destinationRelative := filepath.FromSlash(destinationSlash)
 	for _, mask := range processor.maskValues() {
 		if mask != "" && strings.Contains(name, mask) {
 			return result, errors.New("artifact name contains a registered mask and cannot be downloaded")
 		}
-	}
-	if p := values["path"]; p != "" {
-		destinationRelative = filepath.FromSlash(p)
 	}
 	logicalWorkspace, err := filepath.Abs(workspace)
 	if err != nil {

--- a/internal/runtime/download_artifact.go
+++ b/internal/runtime/download_artifact.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 	"syscall"
 	"unicode/utf8"
@@ -154,27 +155,16 @@ func extractDownloadZIPFile(ctx context.Context, f *os.File, size int64, workspa
 	if len(z.File) != expectedCount || len(z.File) > transport.MaxResultArtifactFileCount {
 		return fmt.Errorf("artifact ZIP file count mismatch")
 	}
-	seen, folded := map[string]bool{}, map[string]bool{}
-	parents, foldedParents := map[string]bool{}, map[string]bool{}
 	members := make([]downloadMember, 0, len(z.File))
+	foldedNames := make([]string, 0, len(z.File))
 	var expanded int64
 	for _, f := range z.File {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
 		name := f.Name
-		if !validArtifactMember(name) || seen[name] || folded[strings.ToLower(name)] {
-			return fmt.Errorf("unsafe or duplicate artifact ZIP member %q", name)
-		}
-		foldedName := strings.ToLower(name)
-		if parents[name] || foldedParents[foldedName] {
-			return fmt.Errorf("artifact ZIP member %q collides with another member path", name)
-		}
-		for parent := path.Dir(name); parent != "."; parent = path.Dir(parent) {
-			if seen[parent] || folded[strings.ToLower(parent)] {
-				return fmt.Errorf("artifact ZIP member %q collides with another member path", name)
-			}
-			parents[parent], foldedParents[strings.ToLower(parent)] = true, true
+		if !validArtifactMember(name) {
+			return fmt.Errorf("unsafe artifact ZIP member %q", name)
 		}
 		if f.Method != zip.Store && f.Method != zip.Deflate || !f.Mode().IsRegular() || f.FileInfo().IsDir() {
 			return fmt.Errorf("artifact ZIP member %q is not a supported regular file", name)
@@ -183,8 +173,15 @@ func extractDownloadZIPFile(ctx context.Context, f *os.File, size int64, workspa
 			return fmt.Errorf("artifact expanded bytes exceed 1 GiB")
 		}
 		expanded += int64(f.UncompressedSize64)
-		seen[name], folded[foldedName] = true, true
+		foldedNames = append(foldedNames, strings.ToLower(name))
 		members = append(members, downloadMember{file: f, name: name, size: int64(f.UncompressedSize64)})
+	}
+	sort.Strings(foldedNames)
+	for i := 1; i < len(foldedNames); i++ {
+		previous, current := foldedNames[i-1], foldedNames[i]
+		if current == previous || strings.HasPrefix(current, previous+"/") {
+			return fmt.Errorf("duplicate or colliding artifact ZIP member paths")
+		}
 	}
 	workspaceRoot, err := os.OpenRoot(workspace)
 	if err != nil {

--- a/internal/runtime/download_artifact_test.go
+++ b/internal/runtime/download_artifact_test.go
@@ -31,6 +31,21 @@ type downloadStore struct {
 	download    func(context.Context, string) error
 }
 
+type countingReaderAt struct {
+	reader io.ReaderAt
+	reads  []readAtCall
+}
+
+type readAtCall struct {
+	offset int64
+	size   int
+}
+
+func (r *countingReaderAt) ReadAt(p []byte, off int64) (int, error) {
+	r.reads = append(r.reads, readAtCall{offset: off, size: len(p)})
+	return r.reader.ReadAt(p, off)
+}
+
 func (s *downloadStore) UploadArtifactFrom(context.Context, string, string) error { return nil }
 func (s *downloadStore) DownloadArtifact(ctx context.Context, path, destination, jobID string) error {
 	s.path = path
@@ -436,66 +451,181 @@ func TestDownloadArtifactPreflightsCentralDirectoryBeforeZIPAllocation(t *testin
 }
 
 func TestDownloadArtifactPreflightRejectsPerEntryZIP64(t *testing.T) {
-	t.Run("sentinel offset", func(t *testing.T) {
-		name, _, _ := testDownloadZIP(t, "result.txt")
-		contents, err := os.ReadFile(name)
-		if err != nil {
-			t.Fatal(err)
-		}
-		eocd := len(contents) - 22
-		central := int(binary.LittleEndian.Uint32(contents[eocd+16:]))
-		if central < 0 || central+46 > eocd || binary.LittleEndian.Uint32(contents[central:]) != 0x02014b50 {
-			t.Fatal("test ZIP central directory is malformed")
-		}
-		binary.LittleEndian.PutUint32(contents[central+42:], 1<<32-1)
-		if err := os.WriteFile(name, contents, 0o644); err != nil {
-			t.Fatal(err)
-		}
-		f, err := os.Open(name)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := preflightZIPDirectory(f, int64(len(contents))); err == nil || !strings.Contains(err.Error(), "ZIP64") {
-			t.Fatalf("per-entry ZIP64 sentinel error = %v", err)
-		}
-		if err := f.Close(); err != nil {
-			t.Fatal(err)
-		}
-	})
+	for _, test := range []struct {
+		name   string
+		offset int
+		width  int
+	}{
+		{name: "compressed size", offset: 20, width: 4},
+		{name: "uncompressed size", offset: 24, width: 4},
+		{name: "disk start", offset: 34, width: 2},
+		{name: "local header offset", offset: 42, width: 4},
+	} {
+		t.Run(test.name+" sentinel", func(t *testing.T) {
+			name, _, _ := testDownloadZIP(t, "result.txt")
+			contents, err := os.ReadFile(name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			eocd := len(contents) - 22
+			central := int(binary.LittleEndian.Uint32(contents[eocd+16:]))
+			if central < 0 || central+46 > eocd || binary.LittleEndian.Uint32(contents[central:]) != 0x02014b50 {
+				t.Fatal("test ZIP central directory is malformed")
+			}
+			if test.width == 2 {
+				binary.LittleEndian.PutUint16(contents[central+test.offset:], 1<<16-1)
+			} else {
+				binary.LittleEndian.PutUint32(contents[central+test.offset:], 1<<32-1)
+			}
+			if err := os.WriteFile(name, contents, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			f, err := os.Open(name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := preflightZIPDirectory(f, int64(len(contents))); err == nil || !strings.Contains(err.Error(), "ZIP64") {
+				t.Fatalf("per-entry ZIP64 sentinel error = %v", err)
+			}
+			if err := f.Close(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
 
-	t.Run("extra field", func(t *testing.T) {
-		name := filepath.Join(t.TempDir(), "zip64-extra.zip")
-		out, err := os.Create(name)
-		if err != nil {
-			t.Fatal(err)
+	for _, test := range []struct {
+		name  string
+		extra []byte
+		want  string
+	}{
+		{name: "chained ZIP64 extra", extra: []byte{0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00}, want: "ZIP64"},
+		{name: "truncated extra header", extra: []byte{0x02, 0x00, 0x00}, want: "malformed"},
+		{name: "extra size overrun", extra: []byte{0x02, 0x00, 0x04, 0x00, 0x00}, want: "malformed"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			name := filepath.Join(t.TempDir(), "zip64-extra.zip")
+			out, err := os.Create(name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			zw := zip.NewWriter(out)
+			header := &zip.FileHeader{Name: "result.txt", Method: zip.Store, Extra: test.extra}
+			member, err := zw.CreateHeader(header)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := member.Write([]byte("payload")); err != nil {
+				t.Fatal(err)
+			}
+			if err := errors.Join(zw.Close(), out.Close()); err != nil {
+				t.Fatal(err)
+			}
+			f, err := os.Open(name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			info, err := f.Stat()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := preflightZIPDirectory(f, info.Size()); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("per-entry extra error = %v, want %q", err, test.want)
+			}
+			if err := f.Close(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestDownloadArtifactPreflightRejectsEOCDZIP64Forms(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		offset int
+		width  int
+		value  uint32
+	}{
+		{name: "entry count sentinel", offset: 10, width: 2, value: 1<<16 - 1},
+		{name: "directory size Go locator sentinel", offset: 12, width: 4, value: 1<<16 - 1},
+		{name: "directory size ZIP64 sentinel", offset: 12, width: 4, value: 1<<32 - 1},
+		{name: "directory offset sentinel", offset: 16, width: 4, value: 1<<32 - 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			name, _, _ := testDownloadZIP(t, "result.txt")
+			contents, err := os.ReadFile(name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			eocd := len(contents) - 22
+			if test.width == 2 {
+				binary.LittleEndian.PutUint16(contents[eocd+test.offset:], uint16(test.value))
+			} else {
+				binary.LittleEndian.PutUint32(contents[eocd+test.offset:], test.value)
+			}
+			if test.name == "directory size Go locator sentinel" {
+				binary.LittleEndian.PutUint32(contents[eocd-20:], 0x07064b50)
+			}
+			if err := preflightZIPDirectory(bytes.NewReader(contents), int64(len(contents))); err == nil || !strings.Contains(err.Error(), "ZIP64") {
+				t.Fatalf("EOCD ZIP64 error = %v", err)
+			}
+		})
+	}
+}
+
+func TestDownloadArtifactPreflightRejectsShortCentralDirectoryResidue(t *testing.T) {
+	name, _, _ := testDownloadZIP(t, "result.txt")
+	contents, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	eocd := len(contents) - 22
+	binary.LittleEndian.PutUint32(contents[eocd+12:], 1)
+	binary.LittleEndian.PutUint32(contents[eocd+16:], uint32(eocd-1))
+	reader := &countingReaderAt{reader: bytes.NewReader(contents)}
+	if err := preflightZIPDirectory(reader, int64(len(contents))); err == nil || !strings.Contains(err.Error(), "malformed") {
+		t.Fatalf("short central directory error = %v", err)
+	}
+	if len(reader.reads) != 1 {
+		t.Fatalf("ReaderAt calls = %#v, want only the EOCD tail read", reader.reads)
+	}
+}
+
+func TestDownloadArtifactPreflightReadsEachExtraAreaOnce(t *testing.T) {
+	name := filepath.Join(t.TempDir(), "many-extras.zip")
+	out, err := os.Create(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zw := zip.NewWriter(out)
+	extra := bytes.Repeat([]byte{0x02, 0x00, 0x00, 0x00}, 100)
+	member, err := zw.CreateHeader(&zip.FileHeader{Name: "result.txt", Method: zip.Store, Extra: extra})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := member.Write([]byte("payload")); err != nil {
+		t.Fatal(err)
+	}
+	if err := errors.Join(zw.Close(), out.Close()); err != nil {
+		t.Fatal(err)
+	}
+	contents, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader := &countingReaderAt{reader: bytes.NewReader(contents)}
+	if err := preflightZIPDirectory(reader, int64(len(contents))); err != nil {
+		t.Fatal(err)
+	}
+	if len(reader.reads) != 3 {
+		t.Fatalf("ReaderAt calls = %#v, want tail, central header, and one complete extra-area read", reader.reads)
+	}
+	eocd := len(contents) - 22
+	central := int64(binary.LittleEndian.Uint32(contents[eocd+16:]))
+	for _, call := range reader.reads[1:] {
+		if call.offset < central || call.offset+int64(call.size) > int64(eocd) {
+			t.Fatalf("central-directory read %#v is outside [%d, %d)", call, central, eocd)
 		}
-		zw := zip.NewWriter(out)
-		header := &zip.FileHeader{Name: "result.txt", Method: zip.Store, Extra: []byte{0x01, 0x00, 0x00, 0x00}}
-		member, err := zw.CreateHeader(header)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if _, err := member.Write([]byte("payload")); err != nil {
-			t.Fatal(err)
-		}
-		if err := errors.Join(zw.Close(), out.Close()); err != nil {
-			t.Fatal(err)
-		}
-		f, err := os.Open(name)
-		if err != nil {
-			t.Fatal(err)
-		}
-		info, err := f.Stat()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := preflightZIPDirectory(f, info.Size()); err == nil || !strings.Contains(err.Error(), "ZIP64") {
-			t.Fatalf("per-entry ZIP64 extra error = %v", err)
-		}
-		if err := f.Close(); err != nil {
-			t.Fatal(err)
-		}
-	})
+	}
 }
 
 func TestDownloadArtifactExtractionUsesVerifiedArchiveDescriptor(t *testing.T) {

--- a/internal/runtime/download_artifact_test.go
+++ b/internal/runtime/download_artifact_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"context"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"io"
@@ -17,19 +18,26 @@ import (
 	"github.com/buildkite/buildkite-gha/internal/action/source"
 	"github.com/buildkite/buildkite-gha/internal/plan"
 	"github.com/buildkite/buildkite-gha/internal/transport"
+	"golang.org/x/sys/unix"
 )
 
 type downloadStore struct {
-	archive string
-	path    string
-	jobID   string
-	extra   bool
+	archive     string
+	path        string
+	jobID       string
+	destination string
+	extra       bool
+	download    func(context.Context, string) error
 }
 
 func (s *downloadStore) UploadArtifactFrom(context.Context, string, string) error { return nil }
-func (s *downloadStore) DownloadArtifact(_ context.Context, path, destination, jobID string) error {
+func (s *downloadStore) DownloadArtifact(ctx context.Context, path, destination, jobID string) error {
 	s.path = path
 	s.jobID = jobID
+	s.destination = destination
+	if s.download != nil {
+		return s.download(ctx, destination)
+	}
 	target := filepath.Join(destination, filepath.FromSlash(path))
 	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 		return err
@@ -84,7 +92,7 @@ func TestDownloadArtifactExactNeedAndDirectExtraction(t *testing.T) {
 	workspace := t.TempDir()
 	processor := newCommandProcessor(io.Discard, io.Discard)
 	need := plan.NeedArtifact{Name: "payload", ID: "42", Path: "buildkite-gha/v1/artifacts/" + strings.Repeat("a", 64) + ".zip", Digest: digest, Size: size, FileCount: 1, Producer: plan.NeedProducer{JobID: "11111111-1111-4111-8111-111111111111"}}
-	result, err := (Runner{Artifacts: store}).runDownloadArtifact(context.Background(), processor, workspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{need}}}, map[string]string{"name": "payload", "path": "out"})
+	result, err := (Runner{Artifacts: store}).runDownloadArtifact(context.Background(), processor, workspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{need}}}, actionintegration.DownloadArtifactCommit, map[string]string{"name": "payload", "path": "out"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,14 +106,47 @@ func TestDownloadArtifactExactNeedAndDirectExtraction(t *testing.T) {
 	if result.Outputs["download-path"] != want {
 		t.Fatalf("download-path = %q", result.Outputs["download-path"])
 	}
-	if _, err := (Runner{Artifacts: store}).runDownloadArtifact(context.Background(), processor, workspace, map[string]plan.Need{}, map[string]string{"name": "payload"}); err == nil || strings.Contains(err.Error(), "payload") {
+	if _, err := (Runner{Artifacts: store}).runDownloadArtifact(context.Background(), processor, workspace, map[string]plan.Need{}, actionintegration.DownloadArtifactCommit, map[string]string{"name": "payload"}); err == nil || strings.Contains(err.Error(), "payload") {
 		t.Fatal("missing artifact accepted")
 	}
-	if _, err := (Runner{Artifacts: store}).runDownloadArtifact(context.Background(), processor, workspace, map[string]plan.Need{"a": {Artifacts: []plan.NeedArtifact{need}}, "b": {Artifacts: []plan.NeedArtifact{need}}}, map[string]string{"name": "payload"}); err == nil || strings.Contains(err.Error(), "payload") {
+	if _, err := (Runner{Artifacts: store}).runDownloadArtifact(context.Background(), processor, workspace, map[string]plan.Need{"a": {Artifacts: []plan.NeedArtifact{need}}, "b": {Artifacts: []plan.NeedArtifact{need}}}, actionintegration.DownloadArtifactCommit, map[string]string{"name": "payload"}); err == nil || strings.Contains(err.Error(), "payload") {
 		t.Fatal("ambiguous artifact accepted")
 	}
-	if _, err := (Runner{Artifacts: store}).runDownloadArtifact(context.Background(), processor, workspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{need}}}, map[string]string{"name": "Payload"}); err == nil || strings.Contains(err.Error(), "Payload") {
+	if _, err := (Runner{Artifacts: store}).runDownloadArtifact(context.Background(), processor, workspace, map[string]plan.Need{"matrix": {Artifacts: []plan.NeedArtifact{need, need}}}, actionintegration.DownloadArtifactCommit, map[string]string{"name": "payload"}); err == nil {
+		t.Fatal("duplicate matrix artifact name accepted")
+	}
+	if _, err := (Runner{Artifacts: store}).runDownloadArtifact(context.Background(), processor, workspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{need}}}, actionintegration.DownloadArtifactCommit, map[string]string{"name": "Payload"}); err == nil || strings.Contains(err.Error(), "Payload") {
 		t.Fatal("non-exact artifact name accepted")
+	}
+}
+
+func TestDownloadArtifactSupportsAuditedCommitsAndNonASCIIExactName(t *testing.T) {
+	archive, size, digest := testDownloadZIP(t, "結果.txt")
+	artifact := plan.NeedArtifact{
+		Name: "成果物", ID: "42", Path: "buildkite-gha/v1/artifacts/" + strings.Repeat("f", 64) + ".zip",
+		Digest: digest, Size: size, FileCount: 1,
+		Producer: plan.NeedProducer{JobID: "11111111-1111-4111-8111-111111111111"},
+	}
+	for _, commit := range actionintegration.DownloadArtifactCommits() {
+		t.Run(commit[:7], func(t *testing.T) {
+			workspace := t.TempDir()
+			inputs := map[string]string{"name": " 成果物 ", "path": ""}
+			if commit == actionintegration.DownloadArtifactV8Commit || commit == actionintegration.DownloadArtifactV801Commit {
+				inputs["skip-decompress"] = "False"
+				inputs["digest-mismatch"] = "error"
+			}
+			result, err := (Runner{Artifacts: &downloadStore{archive: archive}}).runDownloadArtifact(context.Background(), newCommandProcessor(io.Discard, io.Discard), workspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{artifact}}}, commit, inputs)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got, err := os.ReadFile(filepath.Join(workspace, "結果.txt")); err != nil || string(got) != "payload" {
+				t.Fatalf("non-ASCII output = %q, %v", got, err)
+			}
+			want, _ := filepath.Abs(workspace)
+			if result.Outputs["download-path"] != want {
+				t.Fatalf("default download-path = %q, want %q", result.Outputs["download-path"], want)
+			}
+		})
 	}
 }
 
@@ -113,7 +154,7 @@ func TestDownloadArtifactRejectsMaskedNameWithoutDisclosure(t *testing.T) {
 	const maskedName = "runtime-secret-artifact"
 	processor := newCommandProcessor(io.Discard, io.Discard)
 	processor.addMask(maskedName)
-	_, err := (Runner{}).runDownloadArtifact(context.Background(), processor, t.TempDir(), nil, map[string]string{"name": maskedName})
+	_, err := (Runner{}).runDownloadArtifact(context.Background(), processor, t.TempDir(), nil, actionintegration.DownloadArtifactCommit, map[string]string{"name": maskedName})
 	if err == nil || strings.Contains(err.Error(), maskedName) || !strings.Contains(err.Error(), "registered mask") {
 		t.Fatalf("masked artifact lookup error = %v", err)
 	}
@@ -133,7 +174,7 @@ func TestDownloadArtifactScrubsMaskedMemberFromDestinationErrors(t *testing.T) {
 		Digest: digest, Size: size, FileCount: 1,
 		Producer: plan.NeedProducer{JobID: "11111111-1111-4111-8111-111111111111"},
 	}
-	_, err := (Runner{Artifacts: &downloadStore{archive: archive}}).runDownloadArtifact(context.Background(), processor, workspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{artifact}}}, map[string]string{"name": "payload"})
+	_, err := (Runner{Artifacts: &downloadStore{archive: archive}}).runDownloadArtifact(context.Background(), processor, workspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{artifact}}}, actionintegration.DownloadArtifactCommit, map[string]string{"name": "payload"})
 	if err == nil || strings.Contains(err.Error(), maskedMember) || !strings.Contains(err.Error(), "***") {
 		t.Fatalf("masked destination error = %v", err)
 	}
@@ -153,14 +194,14 @@ func TestDownloadArtifactScrubsQuotedMaskedDestinationFromErrors(t *testing.T) {
 		Digest: digest, Size: size, FileCount: 1,
 		Producer: plan.NeedProducer{JobID: "11111111-1111-4111-8111-111111111111"},
 	}
-	_, err := (Runner{Artifacts: &downloadStore{archive: archive}}).runDownloadArtifact(context.Background(), processor, workspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{artifact}}}, map[string]string{"name": "payload", "path": maskedDestination})
+	_, err := (Runner{Artifacts: &downloadStore{archive: archive}}).runDownloadArtifact(context.Background(), processor, workspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{artifact}}}, actionintegration.DownloadArtifactCommit, map[string]string{"name": "payload", "path": maskedDestination})
 	if err == nil || strings.Contains(err.Error(), maskedDestination) || strings.Contains(err.Error(), `runtime\"secret`) || !strings.Contains(err.Error(), "***") {
 		t.Fatalf("quoted masked destination error = %v", err)
 	}
 }
 
 func TestDownloadArtifactRejectsUnsafeZIPAndDigest(t *testing.T) {
-	for _, name := range []string{"../escape", "/absolute", "dir/../escape", "a\\b"} {
+	for _, name := range []string{"../escape", "/absolute", "dir/../escape", "a\\b", "C:/drive", `\\server\share`} {
 		t.Run(name, func(t *testing.T) {
 			archive, _, _ := testDownloadZIP(t, name)
 			if err := extractDownloadZIP(context.Background(), archive, t.TempDir(), ".", 1); err == nil {
@@ -186,6 +227,259 @@ func TestDownloadArtifactRejectsUnsafeZIPAndDigest(t *testing.T) {
 	}
 }
 
+func TestDownloadArtifactRejectsRawCorruptDuplicateAndHighRatioArchivesWithoutDestinationMutation(t *testing.T) {
+	workspace := t.TempDir()
+	for _, test := range []struct {
+		name      string
+		archive   func(*testing.T) string
+		fileCount int
+	}{
+		{name: "raw", archive: func(t *testing.T) string {
+			name := filepath.Join(t.TempDir(), "raw")
+			if err := os.WriteFile(name, []byte("not a ZIP"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			return name
+		}, fileCount: 1},
+		{name: "duplicate", archive: func(t *testing.T) string {
+			name, _, _ := testDownloadZIP(t, "same", "same")
+			return name
+		}, fileCount: 2},
+		{name: "file before child", archive: func(t *testing.T) string {
+			name, _, _ := testDownloadZIP(t, "same", "same/child")
+			return name
+		}, fileCount: 2},
+		{name: "child before file", archive: func(t *testing.T) string {
+			name, _, _ := testDownloadZIP(t, "same/child", "same")
+			return name
+		}, fileCount: 2},
+		{name: "corrupt member", archive: func(t *testing.T) string {
+			name, _, _ := testDownloadZIP(t, "first", "second")
+			zr, err := zip.OpenReader(name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			offset, err := zr.File[0].DataOffset()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := zr.Close(); err != nil {
+				t.Fatal(err)
+			}
+			contents, err := os.ReadFile(name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if offset < 0 || offset >= int64(len(contents)) {
+				t.Fatal("ZIP member offset is out of bounds")
+			}
+			contents[offset] ^= 0xff
+			if err := os.WriteFile(name, contents, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			return name
+		}, fileCount: 2},
+		{name: "compression ratio", archive: func(t *testing.T) string {
+			name := filepath.Join(t.TempDir(), "ratio.zip")
+			out, err := os.Create(name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			zw := zip.NewWriter(out)
+			member, err := zw.Create("zeros")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := member.Write(make([]byte, 2<<20)); err != nil {
+				t.Fatal(err)
+			}
+			if err := errors.Join(zw.Close(), out.Close()); err != nil {
+				t.Fatal(err)
+			}
+			return name
+		}, fileCount: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			destination := filepath.Join(workspace, strings.ReplaceAll(test.name, " ", "-"))
+			if err := extractDownloadZIP(context.Background(), test.archive(t), workspace, filepath.Base(destination), test.fileCount); err == nil {
+				t.Fatal("unsafe archive accepted")
+			}
+			if _, err := os.Lstat(destination); !os.IsNotExist(err) {
+				t.Fatalf("failed extraction mutated destination: %v", err)
+			}
+		})
+	}
+}
+
+func TestDownloadArtifactPreflightsCentralDirectoryBeforeZIPAllocation(t *testing.T) {
+	name := filepath.Join(t.TempDir(), "many.zip")
+	out, err := os.Create(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zw := zip.NewWriter(out)
+	for i := 0; i <= transport.MaxResultArtifactFileCount; i++ {
+		if _, err := zw.CreateHeader(&zip.FileHeader{Name: strings.Repeat("x", i%8+1) + string(rune(0x1000+i)), Method: zip.Store}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := errors.Join(zw.Close(), out.Close()); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := f.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := preflightZIPDirectory(f, info.Size()); err == nil {
+		t.Fatal("oversized central directory accepted")
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	contents, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	eocd := len(contents) - 22
+	if eocd < 0 || binary.LittleEndian.Uint32(contents[eocd:]) != 0x06054b50 {
+		t.Fatal("test ZIP has no terminal EOCD")
+	}
+	binary.LittleEndian.PutUint16(contents[eocd+8:], 1)
+	binary.LittleEndian.PutUint16(contents[eocd+10:], 1)
+	if err := os.WriteFile(name, contents, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	f, err = os.Open(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := preflightZIPDirectory(f, int64(len(contents))); err == nil {
+		t.Fatal("forged central-directory count accepted")
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	valid, _, _ := testDownloadZIP(t, "result.txt")
+	contents, err = os.ReadFile(valid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	eocd = len(contents) - 22
+	binary.LittleEndian.PutUint16(contents[eocd+20:], 22)
+	forgedEnd := make([]byte, 22)
+	binary.LittleEndian.PutUint32(forgedEnd, 0x06054b50)
+	contents = append(contents, forgedEnd...)
+	if err := os.WriteFile(valid, contents, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	f, err = os.Open(valid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := preflightZIPDirectory(f, int64(len(contents))); err == nil {
+		t.Fatal("ambiguous terminal EOCD accepted")
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDownloadArtifactExtractionUsesVerifiedArchiveDescriptor(t *testing.T) {
+	name, size, digest := testDownloadZIP(t, "result.txt")
+	f, err := os.Open(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	if err := verifyDownloadDigestFile(context.Background(), f, digest, size); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(name, name+".verified"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(name, []byte("replacement"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	workspace := t.TempDir()
+	if err := extractDownloadZIPFile(context.Background(), f, size, workspace, ".", 1); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.ReadFile(filepath.Join(workspace, "result.txt")); err != nil || string(got) != "payload" {
+		t.Fatalf("descriptor-pinned extraction = %q, %v", got, err)
+	}
+}
+
+func TestDownloadArtifactInstallUsesPinnedDestinationDescriptor(t *testing.T) {
+	workspace := t.TempDir()
+	destination := filepath.Join(workspace, "destination")
+	staging := filepath.Join(workspace, "staging")
+	alternate := filepath.Join(workspace, "alternate")
+	for _, directory := range []string{destination, staging, alternate} {
+		if err := os.Mkdir(directory, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(staging, "result.txt"), []byte("payload"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	destinationFD, err := unix.Open(destination, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = unix.Close(destinationFD) }()
+	stagingFD, err := unix.Open(staging, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = unix.Close(stagingFD) }()
+	moved := destination + "-moved"
+	if err := os.Rename(destination, moved); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(alternate, destination); err != nil {
+		t.Fatal(err)
+	}
+	if err := installDownloadMembersAt(context.Background(), stagingFD, destinationFD, []downloadMember{{name: "result.txt", size: 7}}); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.ReadFile(filepath.Join(moved, "result.txt")); err != nil || string(got) != "payload" {
+		t.Fatalf("pinned destination contents = %q, %v", got, err)
+	}
+	if _, err := os.Lstat(filepath.Join(alternate, "result.txt")); !os.IsNotExist(err) {
+		t.Fatalf("replacement destination target was mutated: %v", err)
+	}
+}
+
+func TestDownloadArtifactCancellationCleansPartialAgentDownload(t *testing.T) {
+	archive, size, digest := testDownloadZIP(t, "result.txt")
+	artifact := plan.NeedArtifact{
+		Name: "payload", Path: "buildkite-gha/v1/artifacts/" + strings.Repeat("9", 64) + ".zip",
+		Digest: digest, Size: size, FileCount: 1,
+		Producer: plan.NeedProducer{JobID: "11111111-1111-4111-8111-111111111111"},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	store := &downloadStore{archive: archive, download: func(ctx context.Context, destination string) error {
+		if err := os.WriteFile(filepath.Join(destination, "partial"), []byte("partial"), 0o644); err != nil {
+			return err
+		}
+		cancel()
+		return ctx.Err()
+	}}
+	_, err := (Runner{Artifacts: store}).runDownloadArtifact(ctx, newCommandProcessor(io.Discard, io.Discard), t.TempDir(), map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{artifact}}}, actionintegration.DownloadArtifactCommit, map[string]string{"name": "payload"})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancellation error = %v", err)
+	}
+	if _, err := os.Lstat(store.destination); !os.IsNotExist(err) {
+		t.Fatalf("partial agent download was not cleaned: %v", err)
+	}
+}
+
 func TestDownloadArtifactRejectsManifestAndDownloadMismatch(t *testing.T) {
 	archive, size, digest := testDownloadZIP(t, "result.txt")
 	base := plan.NeedArtifact{Name: "payload", Path: "buildkite-gha/v1/artifacts/" + strings.Repeat("b", 64) + ".zip", Digest: digest, Size: size, FileCount: 1, Producer: plan.NeedProducer{JobID: "11111111-1111-4111-8111-111111111111"}}
@@ -201,7 +495,7 @@ func TestDownloadArtifactRejectsManifestAndDownloadMismatch(t *testing.T) {
 			artifact := base
 			store := &downloadStore{archive: archive}
 			test.alter(&artifact, store)
-			_, err := (Runner{Artifacts: store}).runDownloadArtifact(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{artifact}}}, map[string]string{"name": "payload"})
+			_, err := (Runner{Artifacts: store}).runDownloadArtifact(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{artifact}}}, actionintegration.DownloadArtifactCommit, map[string]string{"name": "payload"})
 			if err == nil {
 				t.Fatal("mismatched download accepted")
 			}

--- a/internal/runtime/download_artifact_test.go
+++ b/internal/runtime/download_artifact_test.go
@@ -8,12 +8,14 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 
 	actionintegration "github.com/buildkite/buildkite-gha/internal/action/integration"
 	"github.com/buildkite/buildkite-gha/internal/action/source"
@@ -493,6 +495,20 @@ func TestDownloadArtifactPreflightRejectsPerEntryZIP64(t *testing.T) {
 		})
 	}
 
+	t.Run("nonzero disk start", func(t *testing.T) {
+		name, _, _ := testDownloadZIP(t, "result.txt")
+		contents, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		eocd := len(contents) - 22
+		central := int(binary.LittleEndian.Uint32(contents[eocd+16:]))
+		binary.LittleEndian.PutUint16(contents[central+34:], 1)
+		if err := preflightZIPDirectory(bytes.NewReader(contents), int64(len(contents))); err == nil {
+			t.Fatal("nonzero per-entry disk accepted")
+		}
+	})
+
 	for _, test := range []struct {
 		name  string
 		extra []byte
@@ -538,6 +554,99 @@ func TestDownloadArtifactPreflightRejectsPerEntryZIP64(t *testing.T) {
 	}
 }
 
+func TestDownloadArtifactPreflightRejectsLocalZIP64(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		offset int
+	}{
+		{name: "compressed size", offset: 18},
+		{name: "uncompressed size", offset: 22},
+	} {
+		t.Run(test.name+" sentinel", func(t *testing.T) {
+			name, _, _ := testDownloadZIP(t, "result.txt")
+			contents, err := os.ReadFile(name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			eocd := len(contents) - 22
+			central := int(binary.LittleEndian.Uint32(contents[eocd+16:]))
+			local := int(binary.LittleEndian.Uint32(contents[central+42:]))
+			binary.LittleEndian.PutUint32(contents[local+test.offset:], 1<<32-1)
+			if err := preflightZIPDirectory(bytes.NewReader(contents), int64(len(contents))); err == nil || !strings.Contains(err.Error(), "ZIP64") {
+				t.Fatalf("local ZIP64 sentinel error = %v", err)
+			}
+		})
+	}
+
+	t.Run("extra field", func(t *testing.T) {
+		name := filepath.Join(t.TempDir(), "local-zip64-extra.zip")
+		out, err := os.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		zw := zip.NewWriter(out)
+		member, err := zw.CreateHeader(&zip.FileHeader{Name: "result.txt", Method: zip.Store, Extra: []byte{0x01, 0x00, 0x00, 0x00}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := member.Write([]byte("payload")); err != nil {
+			t.Fatal(err)
+		}
+		if err := errors.Join(zw.Close(), out.Close()); err != nil {
+			t.Fatal(err)
+		}
+		contents, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		eocd := len(contents) - 22
+		central := int(binary.LittleEndian.Uint32(contents[eocd+16:]))
+		centralExtra := central + 46 + int(binary.LittleEndian.Uint16(contents[central+28:]))
+		binary.LittleEndian.PutUint16(contents[centralExtra:], 2)
+		if err := preflightZIPDirectory(bytes.NewReader(contents), int64(len(contents))); err == nil || !strings.Contains(err.Error(), "ZIP64") {
+			t.Fatalf("local ZIP64 extra error = %v", err)
+		}
+	})
+}
+
+func TestDownloadArtifactPreflightBoundsCentralMetadata(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		header  zip.FileHeader
+		wantErr string
+	}{
+		{name: "oversized member name", header: zip.FileHeader{Name: strings.Repeat("x", actionintegration.MaxUploadArtifactPathBytes+1), Method: zip.Store}, wantErr: "metadata"},
+		{name: "member comment", header: zip.FileHeader{Name: "result.txt", Method: zip.Store, Comment: "comment"}, wantErr: "metadata"},
+		{name: "oversized extra", header: zip.FileHeader{Name: "result.txt", Method: zip.Store, Extra: append([]byte{0x02, 0x00, 61, 0x00}, make([]byte, 61)...)}, wantErr: "metadata"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			name := filepath.Join(t.TempDir(), "metadata.zip")
+			out, err := os.Create(name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			zw := zip.NewWriter(out)
+			member, err := zw.CreateHeader(&test.header)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := member.Write([]byte("payload")); err != nil {
+				t.Fatal(err)
+			}
+			if err := errors.Join(zw.Close(), out.Close()); err != nil {
+				t.Fatal(err)
+			}
+			contents, err := os.ReadFile(name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := preflightZIPDirectory(bytes.NewReader(contents), int64(len(contents))); err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("central metadata error = %v, want %q", err, test.wantErr)
+			}
+		})
+	}
+}
+
 func TestDownloadArtifactPreflightRejectsEOCDZIP64Forms(t *testing.T) {
 	for _, test := range []struct {
 		name   string
@@ -546,7 +655,7 @@ func TestDownloadArtifactPreflightRejectsEOCDZIP64Forms(t *testing.T) {
 		value  uint32
 	}{
 		{name: "entry count sentinel", offset: 10, width: 2, value: 1<<16 - 1},
-		{name: "directory size Go locator sentinel", offset: 12, width: 4, value: 1<<16 - 1},
+		{name: "directory size with ZIP64 locator", offset: 12, width: 4, value: 1<<16 - 1},
 		{name: "directory size ZIP64 sentinel", offset: 12, width: 4, value: 1<<32 - 1},
 		{name: "directory offset sentinel", offset: 16, width: 4, value: 1<<32 - 1},
 	} {
@@ -562,13 +671,57 @@ func TestDownloadArtifactPreflightRejectsEOCDZIP64Forms(t *testing.T) {
 			} else {
 				binary.LittleEndian.PutUint32(contents[eocd+test.offset:], test.value)
 			}
-			if test.name == "directory size Go locator sentinel" {
-				binary.LittleEndian.PutUint32(contents[eocd-20:], 0x07064b50)
+			if test.name == "directory size with ZIP64 locator" {
+				locator := contents[eocd-20 : eocd]
+				clear(locator)
+				binary.LittleEndian.PutUint32(locator, 0x07064b50)
+				binary.LittleEndian.PutUint32(locator[16:], 1)
 			}
 			if err := preflightZIPDirectory(bytes.NewReader(contents), int64(len(contents))); err == nil || !strings.Contains(err.Error(), "ZIP64") {
 				t.Fatalf("EOCD ZIP64 error = %v", err)
 			}
 		})
+	}
+}
+
+func TestDownloadArtifactPreflightAcceptsOrdinary65535ByteCentralDirectory(t *testing.T) {
+	name := filepath.Join(t.TempDir(), "ordinary-65535.zip")
+	out, err := os.Create(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zw := zip.NewWriter(out)
+	for i := range 100 {
+		length := 600
+		if i == 99 {
+			length = 635
+		}
+		prefix := fmt.Sprintf("%03d-", i)
+		header := &zip.FileHeader{
+			Name: prefix + strings.Repeat("x", length-len(prefix)), Method: zip.Store,
+			Modified: time.Date(1980, time.January, 1, 0, 0, 0, 0, time.UTC),
+		}
+		member, err := zw.CreateHeader(header)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := member.Write([]byte("payload")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := errors.Join(zw.Close(), out.Close()); err != nil {
+		t.Fatal(err)
+	}
+	contents, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	eocd := len(contents) - 22
+	if got := binary.LittleEndian.Uint32(contents[eocd+12:]); got != 1<<16-1 {
+		t.Fatalf("central directory size = %d, want 65535", got)
+	}
+	if err := preflightZIPDirectory(bytes.NewReader(contents), int64(len(contents))); err != nil {
+		t.Fatalf("ordinary 65,535-byte central directory rejected: %v", err)
 	}
 }
 
@@ -590,14 +743,14 @@ func TestDownloadArtifactPreflightRejectsShortCentralDirectoryResidue(t *testing
 	}
 }
 
-func TestDownloadArtifactPreflightReadsEachExtraAreaOnce(t *testing.T) {
+func TestDownloadArtifactPreflightUsesBoundedMetadataReads(t *testing.T) {
 	name := filepath.Join(t.TempDir(), "many-extras.zip")
 	out, err := os.Create(name)
 	if err != nil {
 		t.Fatal(err)
 	}
 	zw := zip.NewWriter(out)
-	extra := bytes.Repeat([]byte{0x02, 0x00, 0x00, 0x00}, 100)
+	extra := bytes.Repeat([]byte{0x02, 0x00, 0x00, 0x00}, 10)
 	member, err := zw.CreateHeader(&zip.FileHeader{Name: "result.txt", Method: zip.Store, Extra: extra})
 	if err != nil {
 		t.Fatal(err)
@@ -616,14 +769,19 @@ func TestDownloadArtifactPreflightReadsEachExtraAreaOnce(t *testing.T) {
 	if err := preflightZIPDirectory(reader, int64(len(contents))); err != nil {
 		t.Fatal(err)
 	}
-	if len(reader.reads) != 3 {
-		t.Fatalf("ReaderAt calls = %#v, want tail, central header, and one complete extra-area read", reader.reads)
+	if len(reader.reads) != 5 {
+		t.Fatalf("ReaderAt calls = %#v, want tail plus bounded central and local header/metadata reads", reader.reads)
 	}
 	eocd := len(contents) - 22
 	central := int64(binary.LittleEndian.Uint32(contents[eocd+16:]))
-	for _, call := range reader.reads[1:] {
+	for _, call := range reader.reads[1:3] {
 		if call.offset < central || call.offset+int64(call.size) > int64(eocd) {
 			t.Fatalf("central-directory read %#v is outside [%d, %d)", call, central, eocd)
+		}
+	}
+	for _, call := range reader.reads[3:] {
+		if call.offset < 0 || call.offset+int64(call.size) > central {
+			t.Fatalf("local-header read %#v is outside [0, %d)", call, central)
 		}
 	}
 }

--- a/internal/runtime/download_artifact_test.go
+++ b/internal/runtime/download_artifact_test.go
@@ -435,6 +435,69 @@ func TestDownloadArtifactPreflightsCentralDirectoryBeforeZIPAllocation(t *testin
 	}
 }
 
+func TestDownloadArtifactPreflightRejectsPerEntryZIP64(t *testing.T) {
+	t.Run("sentinel offset", func(t *testing.T) {
+		name, _, _ := testDownloadZIP(t, "result.txt")
+		contents, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		eocd := len(contents) - 22
+		central := int(binary.LittleEndian.Uint32(contents[eocd+16:]))
+		if central < 0 || central+46 > eocd || binary.LittleEndian.Uint32(contents[central:]) != 0x02014b50 {
+			t.Fatal("test ZIP central directory is malformed")
+		}
+		binary.LittleEndian.PutUint32(contents[central+42:], 1<<32-1)
+		if err := os.WriteFile(name, contents, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		f, err := os.Open(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := preflightZIPDirectory(f, int64(len(contents))); err == nil || !strings.Contains(err.Error(), "ZIP64") {
+			t.Fatalf("per-entry ZIP64 sentinel error = %v", err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("extra field", func(t *testing.T) {
+		name := filepath.Join(t.TempDir(), "zip64-extra.zip")
+		out, err := os.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		zw := zip.NewWriter(out)
+		header := &zip.FileHeader{Name: "result.txt", Method: zip.Store, Extra: []byte{0x01, 0x00, 0x00, 0x00}}
+		member, err := zw.CreateHeader(header)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := member.Write([]byte("payload")); err != nil {
+			t.Fatal(err)
+		}
+		if err := errors.Join(zw.Close(), out.Close()); err != nil {
+			t.Fatal(err)
+		}
+		f, err := os.Open(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		info, err := f.Stat()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := preflightZIPDirectory(f, info.Size()); err == nil || !strings.Contains(err.Error(), "ZIP64") {
+			t.Fatalf("per-entry ZIP64 extra error = %v", err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
 func TestDownloadArtifactExtractionUsesVerifiedArchiveDescriptor(t *testing.T) {
 	name, size, digest := testDownloadZIP(t, "result.txt")
 	f, err := os.Open(name)

--- a/internal/runtime/download_artifact_test.go
+++ b/internal/runtime/download_artifact_test.go
@@ -687,3 +687,59 @@ func TestDownloadArtifactAdapterBypassesVerifiedUpstreamLifecycle(t *testing.T) 
 		t.Fatalf("unsupported runtime commit error = %v", err)
 	}
 }
+
+func TestDownloadArtifactMatrixConsumersEvaluateNameAndNormalizeRootPath(t *testing.T) {
+	archive, size, digest := testDownloadZIP(t, "result.txt")
+	remote := t.TempDir()
+	writeFixtureFile(t, remote, "action.yml", "name: download artifact\nruns:\n  using: node24\n  main: dist/main.js\n")
+	writeFixtureFile(t, remote, "dist/main.js", "throw new Error('adapter must not execute upstream JavaScript')\n")
+	sourceDigest, err := source.DigestTree(remote)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const eventSHA = "7d9b24bba24eb46a23a207882718feb61138fada"
+	artifact := plan.NeedArtifact{
+		Name: eventSHA, ID: "42", Path: "buildkite-gha/v1/artifacts/" + strings.Repeat("c", 64) + ".zip",
+		Digest: digest, Size: size, FileCount: 1,
+		Producer: plan.NeedProducer{BuildID: "11111111-1111-4111-8111-111111111111", JobID: "22222222-2222-4222-8222-222222222222", StepKey: "gha-producer-one"},
+	}
+	store := &downloadStore{archive: archive}
+	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, ActionRoot: remote, SourceDigest: sourceDigest}}
+	for _, shard := range []string{"one", "two"} {
+		t.Run(shard, func(t *testing.T) {
+			workspace := canonicalTempDir(t)
+			workflowPath := ".github/workflows/download.yml"
+			writeFixtureFile(t, workspace, workflowPath, "name: matrix download proof\n")
+			lockID := "a-0000000000000002"
+			job := runtimePlan(t, workspace, workflowPath, []plan.Step{{
+				ID: "download", Kind: "uses", Uses: "actions/download-artifact@" + actionintegration.DownloadArtifactV7Commit,
+				With: map[string]string{"name": "${{ github.sha }}", "path": "./"}, Action: &plan.ActionSelector{Lock: lockID},
+			}})
+			job.Schema = plan.SchemaV3
+			job.RequiredCapabilities = []string{"network"}
+			job.Event.SHA = eventSHA
+			job.Matrix = map[string]any{"shard": shard}
+			job.Outputs = map[string]string{"download_path": "${{ steps.download.outputs.download-path }}"}
+			job.Actions = []plan.ActionLock{{
+				ID: lockID, Source: "github", Repository: "actions/download-artifact", RequestedRef: actionintegration.DownloadArtifactV7Commit,
+				Commit: actionintegration.DownloadArtifactV7Commit, SourceDigest: sourceDigest,
+			}}
+			job.Needs = map[string]plan.Need{"producer": {Result: "success", Artifacts: []plan.NeedArtifact{artifact}}}
+
+			result, err := (Runner{Actions: materializer, Artifacts: store}).RunJob(context.Background(), job, workspace)
+			wantPath, absErr := filepath.Abs(workspace)
+			if absErr != nil {
+				t.Fatal(absErr)
+			}
+			if err != nil || result.Conclusion != "success" || result.Outputs["download_path"] != wantPath || !filepath.IsAbs(result.Outputs["download_path"]) {
+				t.Fatalf("RunJob() result = %#v, error = %v, want download path %q", result, err, wantPath)
+			}
+			if got, err := os.ReadFile(filepath.Join(workspace, "result.txt")); err != nil || string(got) != "payload" {
+				t.Fatalf("workspace-root contents = %q, %v", got, err)
+			}
+		})
+	}
+	if materializer.calls != 2 || store.path != artifact.Path || store.jobID != artifact.Producer.JobID {
+		t.Fatalf("materializations/download = %d / %q / %q", materializer.calls, store.path, store.jobID)
+	}
+}

--- a/internal/runtime/download_artifact_test.go
+++ b/internal/runtime/download_artifact_test.go
@@ -313,6 +313,10 @@ func TestDownloadArtifactRejectsRawCorruptAndDuplicateArchivesWithoutDestination
 			name, _, _ := testDownloadZIP(t, "same/child", "same")
 			return name
 		}, fileCount: 2},
+		{name: "lexically separated file and child", archive: func(t *testing.T) string {
+			name, _, _ := testDownloadZIP(t, "same", "same.", "same/child")
+			return name
+		}, fileCount: 3},
 		{name: "corrupt member", archive: func(t *testing.T) string {
 			name, _, _ := testDownloadZIP(t, "first", "second")
 			zr, err := zip.OpenReader(name)

--- a/internal/runtime/download_artifact_test.go
+++ b/internal/runtime/download_artifact_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"archive/zip"
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/binary"
@@ -86,6 +87,29 @@ func testDownloadZIP(t *testing.T, names ...string) (string, int64, string) {
 	return filename, int64(len(b)), "sha256:" + hex.EncodeToString(sum[:])
 }
 
+func verifyDownloadDigest(ctx context.Context, filename, digest string, size int64) error {
+	f, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	err = verifyDownloadDigestFile(ctx, f, digest, size)
+	return errors.Join(err, f.Close())
+}
+
+func extractDownloadZIP(ctx context.Context, filename, workspace, destination string, expectedCount int) error {
+	f, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return err
+	}
+	err = extractDownloadZIPFile(ctx, f, info.Size(), workspace, destination, expectedCount)
+	return errors.Join(err, f.Close())
+}
+
 func TestDownloadArtifactExactNeedAndDirectExtraction(t *testing.T) {
 	archive, size, digest := testDownloadZIP(t, "nested/result.txt")
 	store := &downloadStore{archive: archive}
@@ -147,6 +171,42 @@ func TestDownloadArtifactSupportsAuditedCommitsAndNonASCIIExactName(t *testing.T
 				t.Fatalf("default download-path = %q, want %q", result.Outputs["download-path"], want)
 			}
 		})
+	}
+}
+
+func TestNativeArtifactRoundTripTrimsNameAndAcceptsHighCompression(t *testing.T) {
+	uploadWorkspace := t.TempDir()
+	contents := make([]byte, 2<<20)
+	if err := os.WriteFile(filepath.Join(uploadWorkspace, "zeros.bin"), contents, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	uploader := &captureArtifactUploader{}
+	uploadRunner := Runner{Artifacts: uploader, artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
+	upload, err := uploadRunner.runUploadArtifact(context.Background(), newCommandProcessor(io.Discard, io.Discard), uploadWorkspace, map[string]string{"name": " payload ", "path": "zeros.bin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(upload.Artifacts) != 1 || upload.Artifacts[0].Name != "payload" || len(uploader.uploads) != 1 {
+		t.Fatalf("normalized upload = %#v, captures = %#v", upload, uploader.uploads)
+	}
+	archive := filepath.Join(t.TempDir(), "artifact.zip")
+	if err := os.WriteFile(archive, uploader.uploads[0].data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	record := upload.Artifacts[0]
+	artifact := plan.NeedArtifact{
+		Name: record.Name, ID: record.ID, Path: record.Path, Digest: record.Digest,
+		Size: record.Size, FileCount: record.FileCount,
+		Producer: plan.NeedProducer{JobID: "11111111-1111-4111-8111-111111111111"},
+	}
+	downloadWorkspace := t.TempDir()
+	_, err = (Runner{Artifacts: &downloadStore{archive: archive}}).runDownloadArtifact(context.Background(), newCommandProcessor(io.Discard, io.Discard), downloadWorkspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{artifact}}}, actionintegration.DownloadArtifactV801Commit, map[string]string{"name": " payload "})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(downloadWorkspace, "zeros.bin"))
+	if err != nil || !bytes.Equal(got, contents) {
+		t.Fatalf("high-compression roundtrip bytes = %d, error = %v", len(got), err)
 	}
 }
 
@@ -227,7 +287,7 @@ func TestDownloadArtifactRejectsUnsafeZIPAndDigest(t *testing.T) {
 	}
 }
 
-func TestDownloadArtifactRejectsRawCorruptDuplicateAndHighRatioArchivesWithoutDestinationMutation(t *testing.T) {
+func TestDownloadArtifactRejectsRawCorruptAndDuplicateArchivesWithoutDestinationMutation(t *testing.T) {
 	workspace := t.TempDir()
 	for _, test := range []struct {
 		name      string
@@ -279,25 +339,6 @@ func TestDownloadArtifactRejectsRawCorruptDuplicateAndHighRatioArchivesWithoutDe
 			}
 			return name
 		}, fileCount: 2},
-		{name: "compression ratio", archive: func(t *testing.T) string {
-			name := filepath.Join(t.TempDir(), "ratio.zip")
-			out, err := os.Create(name)
-			if err != nil {
-				t.Fatal(err)
-			}
-			zw := zip.NewWriter(out)
-			member, err := zw.Create("zeros")
-			if err != nil {
-				t.Fatal(err)
-			}
-			if _, err := member.Write(make([]byte, 2<<20)); err != nil {
-				t.Fatal(err)
-			}
-			if err := errors.Join(zw.Close(), out.Close()); err != nil {
-				t.Fatal(err)
-			}
-			return name
-		}, fileCount: 1},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			destination := filepath.Join(workspace, strings.ReplaceAll(test.name, " ", "-"))

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -1227,7 +1227,7 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 			if err != nil {
 				return result, err
 			}
-			return r.runDownloadArtifact(ctx, processor, workspace, job.Needs, inputs)
+			return r.runDownloadArtifact(ctx, processor, workspace, job.Needs, lock.Commit, inputs)
 		}
 	} else {
 		if !strings.HasPrefix(step.Uses, "./") {

--- a/internal/runtime/upload_artifact.go
+++ b/internal/runtime/upload_artifact.go
@@ -72,7 +72,7 @@ func parseUploadOptions(commit string, inputs map[string]string) (uploadOptions,
 	}
 	o := uploadOptions{name: "artifact", noFiles: "warn", level: 6}
 	if v, ok := values["name"]; ok {
-		o.name = v
+		o.name = strings.TrimSpace(v)
 	}
 	if err := actionintegration.ValidateUploadArtifactName(o.name); err != nil {
 		return o, err

--- a/internal/transport/results_test.go
+++ b/internal/transport/results_test.go
@@ -179,6 +179,28 @@ func TestLoadNeedsMapsLogicalFanInToVerifiedProducers(t *testing.T) {
 	}
 }
 
+func TestLoadNeedsRetainsOneConditionalMatrixArtifact(t *testing.T) {
+	first := ResultSource{StepKey: "gha-build-one", PlanDigest: Digest([]byte("one-plan"))}
+	second := ResultSource{StepKey: "gha-build-two", PlanDigest: Digest([]byte("two-plan"))}
+	firstManifest := resultManifest(testJobID, first.StepKey, first.PlanDigest, "success")
+	firstManifest.Artifacts = []ResultArtifact{resultArtifact("payload", "1", strings.Repeat("a", 64))}
+	runner := &resultRunner{
+		jobByStep: map[string]string{first.StepKey: testJobID, second.StepKey: testJobID2},
+		dataByPath: map[string][]byte{
+			ResultPath(first.StepKey, first.PlanDigest):   mustManifest(t, firstManifest),
+			ResultPath(second.StepKey, second.PlanDigest): mustManifest(t, resultManifest(testJobID2, second.StepKey, second.PlanDigest, "success")),
+		},
+	}
+	needs, err := LoadNeeds(context.Background(), Agent{Runner: runner}, t.TempDir(), testBuildID, map[string][]ResultSource{"build": {first, second}}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	need := needs["build"]
+	if need.Result != "success" || len(need.Producers) != 2 || len(need.Artifacts) != 1 || need.Artifacts[0].Artifact.Name != "payload" || need.Artifacts[0].Producer.StepKey != first.StepKey {
+		t.Fatalf("conditional matrix fan-in = %#v", need)
+	}
+}
+
 func TestAggregateResultTreatsMixedSuccessAndSkippedAsSuccess(t *testing.T) {
 	if got := aggregateResult("skipped", "success"); got != "success" {
 		t.Fatalf("aggregateResult() = %q, want success", got)


### PR DESCRIPTION
## Why

The native `actions/download-artifact` bridge admitted only v4.3.0 without a complete, source-backed contract for newer releases, explicit defaults, outputs, producer visibility, or hostile archives. A concrete audit of [`mastodon/mastodon@7d9b24b`](https://github.com/mastodon/mastodon/blob/7d9b24bba24eb46a23a207882718feb61138fada/.github/workflows/test-ruby.yml) also found that valid pinned-v7 consumers using `${{ github.sha }}` and `path: './'` were rejected.

## What

- Admit only the audited exact release commits for [v4.3.0](https://github.com/actions/download-artifact/tree/d3f86a106a0bac45b974a628896c90dbdf5c8093), [v5.0.0](https://github.com/actions/download-artifact/tree/634f93cb2916e3fdff6788551b99b062d0335ce0), [v6.0.0](https://github.com/actions/download-artifact/tree/018cc2cf5baa6db3ef3c5f8a56943fffe632ef53), [v7.0.0](https://github.com/actions/download-artifact/tree/37930b1c2abaa49bbe596cd826c3c89aef350131), [v8.0.0](https://github.com/actions/download-artifact/tree/70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3), and [v8.0.1](https://github.com/actions/download-artifact/tree/3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c) in their shared exact-name ZIP profile. Unknown future commits and broader selection, REST, raw, merge, and digest-override modes remain fail-closed.
- Separate source-time expression admission from evaluated runtime validation, normalize safe leading `./` and trailing `/` destination spellings, preserve absolute `download-path`, exact direct-needs matching, and producer-job UUID attribution, and cover conditional producer matrices feeding multiple downstream matrix consumers. Duplicate publishers remain ambiguous and rejected.
- Pin the verified archive descriptor through parsing, preflight the central directory before ZIP allocation, reject EOCD, central-entry, and local-header ZIP64 metadata, bound archive and expanded bytes, reject path/type/collision attacks, stage decompression, and install through pinned directory descriptors without rejecting valid highly compressible native uploads.
- Document the complete version/input/output matrix, upstream runtime and artifact-client evidence, direct-needs visibility boundary, extraction caveats, the bounded Mastodon download-side shape, and future Results-backed direction.

`mise --locked run check` passed in 44.85s, including build, all tests, race tests, Go/shell lint, vet, 8/8 plan fixtures, the full local smoke inventory, and GoReleaser configuration validation.

