### PR TITLE
feat: report workflow processing stages

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,10 @@ Schema: buildkite-gha/processing-report/v1
 Workflow: .github/workflows/ci.yml
 Result: compilable
 Status: passed
+Logical jobs: 2
+Instances: 3
+Compile: compilable
+Admission: not-evaluated
 ✓ 2 logical jobs and 3 static instances compile
 - Workflow parsing: passed
 - Event validation: not-evaluated

--- a/README.md
+++ b/README.md
@@ -213,6 +213,16 @@ reports:
 Workflow: .github/workflows/ci.yml
 Result: compilable
 ✓ 2 logical jobs and 3 static instances compile
+- Workflow parsing: passed
+- Event validation: not-evaluated
+- Static graph construction: passed
+- Matrix expansion: passed
+- Expression validation: passed
+- Local and public action discovery: passed
+- Immutable action resolution: passed
+- Job-plan construction: not-evaluated
+- Hosted-profile admission: not-evaluated
+- Pipeline generation: not-evaluated
 ```
 
 To also resolve public actions and apply the same policy as the plugin's
@@ -230,6 +240,13 @@ the workflow or prove that arbitrary action code is independent of GitHub-only
 services. Condition preflight validates the supported syntax, functions,
 contexts, and statically known operand types, but cannot prove value-dependent
 runtime behavior. JSON output is available with `--format json`.
+
+Every report includes all ten processing stages with `passed`, `failed`, or
+`not-evaluated`, plus source-located job, matrix-instance, action, and
+diagnostic records. Independent errors are aggregated deterministically.
+`compile` writes the same report to standard error before writing compiler
+output; the Buildkite importer writes it to its job log before upload or exit.
+Any failed required stage suppresses every plan and pipeline artifact.
 
 ## What gets translated?
 

--- a/README.md
+++ b/README.md
@@ -210,8 +210,10 @@ For example, a workflow with one producer and a two-entry consumer matrix
 reports:
 
 ```text
+Schema: buildkite-gha/processing-report/v1
 Workflow: .github/workflows/ci.yml
 Result: compilable
+Status: passed
 ✓ 2 logical jobs and 3 static instances compile
 - Workflow parsing: passed
 - Event validation: not-evaluated

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -758,6 +758,13 @@ error so standard output remains the requested IR or pipeline. Upload writes
 the report into the importer log before artifact or pipeline upload. A failure
 in any required stage is fail-closed: no partial plans or pipeline are emitted.
 
+Stage failures use stable, stage-specific codes such as
+`E_WORKFLOW_SYNTAX`, `E_EVENT_INVALID`, `E_GRAPH_INVALID`,
+`E_MATRIX_INVALID`, `E_EXPRESSION_INVALID`, `E_ACTION_RESOLUTION`,
+`E_PLAN_CONSTRUCTION`, and `E_PIPELINE_GENERATION`. Environment and hosted
+admission failures use `E_ENVIRONMENT` and `E_PROFILE`. Action diagnostics also
+identify the exact expanded instance and step when that invocation is known.
+
 ### Event snapshots
 
 `compile` and profile validation take an explicit, bounded event snapshot:

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -741,6 +741,23 @@ buildkite-gha validate --profile hosted-tokenless \
 Profile validation may access the public network to resolve actions. It does
 not call Buildkite, install Node, or execute workflow code.
 
+`validate`, `compile`, and `upload` use one versioned processing report. It
+always exposes workflow parsing, event validation, static graph construction,
+matrix expansion, expression validation, action discovery, immutable action
+resolution, job-plan construction, hosted-profile admission, and pipeline
+generation. Each stage is `passed`, `failed`, or `not-evaluated`; a downstream
+stage blocked by an earlier failure is never described as failed. Reports also
+retain every safely discovered logical job, expanded instance, and action
+invocation, with stable diagnostic codes, categories, and source locations.
+
+Text and `--format json` validation reports carry the same records. JSON uses
+the `buildkite-gha/processing-report/v1` schema. Reports never include secret
+values, tokens, event payload contents, generated plans, pipelines, or
+downloaded action contents. Compilation writes its text report to standard
+error so standard output remains the requested IR or pipeline. Upload writes
+the report into the importer log before artifact or pipeline upload. A failure
+in any required stage is fail-closed: no partial plans or pipeline are emitted.
+
 ### Event snapshots
 
 `compile` and profile validation take an explicit, bounded event snapshot:

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -891,6 +891,8 @@ func validate(args []string, stdout, stderr io.Writer, version string) int {
 	}
 	source, err := os.ReadFile(workflowPath)
 	if err != nil {
+		report := environmentProcessingReport(workflowPath, profile, "workflow input could not be read")
+		_ = compatibility.WriteProcessing(stdout, format, report)
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: %v\n", err)
 		return 1
 	}
@@ -898,6 +900,8 @@ func validate(args []string, stdout, stderr io.Writer, version string) int {
 	if eventPath != "" {
 		event, err = os.ReadFile(eventPath)
 		if err != nil {
+			report := eventInputProcessingReport(workflowPath, profile, source, "event input could not be read")
+			_ = compatibility.WriteProcessing(stdout, format, report)
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: %v\n", err)
 			return 1
 		}
@@ -909,21 +913,20 @@ func validate(args []string, stdout, stderr io.Writer, version string) int {
 	} else {
 		report, err = compiler.ValidateEvent(workflowPath, source, event)
 	}
+	processingReport := initialProcessingReport(workflowPath, profile, eventPath != "", report, err)
 	if err != nil {
-		if profile == "" {
-			if writeErr := compatibility.Write(stdout, format, compatibility.Blocked(workflowPath, err)); writeErr != nil {
-				_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: write report: %v\n", writeErr)
-			}
-		} else if writeErr := compatibility.WriteProfile(stdout, format, compatibility.ProfileCompileBlocked(workflowPath, profile, err)); writeErr != nil {
-			_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: write profile report: %v\n", writeErr)
+		processingReport.Result = "incompatible"
+		if writeErr := compatibility.WriteProcessing(stdout, format, processingReport); writeErr != nil {
+			_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: write report: %v\n", writeErr)
 		}
 		return 1
 	}
 	if profile != "" {
 		_, _, distributionDigest, executableErr := executable()
 		if executableErr != nil {
-			profileReport := compatibility.ProfileNotEvaluated(workflowPath, profile, report.LogicalJobs, report.Instances, "E_ENVIRONMENT", executableErr)
-			if writeErr := compatibility.WriteProfile(stdout, format, withCompilerWarnings(profileReport, workflowPath, report.Warnings)); writeErr != nil {
+			addEnvironmentFailure(&processingReport, "compiler executable could not be inspected")
+			processingReport.Result = "indeterminate"
+			if writeErr := compatibility.WriteProcessing(stdout, format, processingReport); writeErr != nil {
 				_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: write profile report: %v\n", writeErr)
 			}
 			return 1
@@ -951,13 +954,11 @@ func validate(args []string, stdout, stderr io.Writer, version string) int {
 				}
 				return 1
 			}
-			code := compiler.CodeActionResolution
-			stage := stageResolution
-			category := "action-resolution"
 			if errors.As(profileErr, &failure) && failure.Kind == hostedTokenlessEnvironmentFailure {
-				code = "E_ENVIRONMENT"
+				addEnvironmentFailure(&processingReport, "hosted workflow-processing environment could not be initialized")
+			} else {
+				addProcessingFailure(&processingReport, workflowPath, stageResolution, compiler.CodeActionResolution, "action-resolution", profileErr)
 			}
-			addProcessingFailure(&processingReport, workflowPath, stage, code, category, profileErr)
 			processingReport.Result = "indeterminate"
 			if writeErr := compatibility.WriteProcessing(stdout, format, processingReport); writeErr != nil {
 				_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: write profile report: %v\n", writeErr)
@@ -979,30 +980,12 @@ func validate(args []string, stdout, stderr io.Writer, version string) int {
 		}
 		return 0
 	}
-	compatibilityReport := compatibility.Compilable(workflowPath, report.LogicalJobs, report.Instances)
-	compatibilityReport.Diagnostics = append(compatibilityReport.Diagnostics, compilerWarningDiagnostics(workflowPath, report.Warnings)...)
-	if err := compatibility.Write(stdout, format, compatibilityReport); err != nil {
+	processingReport.Result = "compilable"
+	if err := compatibility.WriteProcessing(stdout, format, processingReport); err != nil {
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: write report: %v\n", err)
 		return 1
 	}
 	return 0
-}
-
-func withCompilerWarnings(report compatibility.ProfileReport, path string, warnings []compiler.Warning) compatibility.ProfileReport {
-	report.Diagnostics = append(compilerWarningDiagnostics(path, warnings), report.Diagnostics...)
-	return report
-}
-
-func compilerWarningDiagnostics(path string, warnings []compiler.Warning) []compatibility.Diagnostic {
-	diagnostics := make([]compatibility.Diagnostic, len(warnings))
-	for i, warning := range warnings {
-		diagnostics[i] = compatibility.Diagnostic{
-			Level:   "warning",
-			Code:    warning.Code,
-			Message: fmt.Sprintf("%s:%d:%d: %s", path, warning.Line, warning.Column, warning.Message),
-		}
-	}
-	return diagnostics
 }
 
 func validateArgs(args []string) (workflowPath, eventPath, format, profile string, err error) {
@@ -1054,12 +1037,25 @@ func compile(args []string, stdout, stderr io.Writer, version string) int {
 	}
 	source, err := os.ReadFile(workflowPath)
 	if err != nil {
+		report := environmentProcessingReport(workflowPath, "", "workflow input could not be read")
+		_ = compatibility.WriteProcessing(stderr, "text", report)
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: compile: %v\n", err)
 		return 1
 	}
 	event, err := os.ReadFile(eventPath)
 	if err != nil {
+		report := eventInputProcessingReport(workflowPath, "", source, "event input could not be read")
+		_ = compatibility.WriteProcessing(stderr, "text", report)
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: compile: %v\n", err)
+		return 1
+	}
+	validation, validationErr := compiler.ValidateEvent(workflowPath, source, event)
+	processingReport := initialProcessingReport(workflowPath, "", true, validation, validationErr)
+	if validationErr != nil {
+		processingReport.Result = "incompatible"
+		if writeErr := compatibility.WriteProcessing(stderr, "text", processingReport); writeErr != nil {
+			_, _ = fmt.Fprintf(stderr, "buildkite-gha: compile: write report: %v\n", writeErr)
+		}
 		return 1
 	}
 	var result []byte
@@ -1077,7 +1073,9 @@ func compile(args []string, stdout, stderr io.Writer, version string) int {
 	} else {
 		digest, digestErr := executableDigest()
 		if digestErr != nil {
-			_, _ = fmt.Fprintf(stderr, "buildkite-gha: compile: %v\n", digestErr)
+			addEnvironmentFailure(&processingReport, "compiler executable could not be inspected")
+			processingReport.Result = "indeterminate"
+			_ = compatibility.WriteProcessing(stderr, "text", processingReport)
 			return 1
 		}
 		bundle, compileErr := compiler.CompileBundle(workflowPath, source, event, version, digest, "gha-importer")
@@ -1131,6 +1129,8 @@ func upload(args []string, stdout, stderr io.Writer, version string, agent trans
 	}
 	workflowSource, err := os.ReadFile(workflowPath)
 	if err != nil {
+		report := environmentProcessingReport(workflowPath, hostedTokenlessProfile, "workflow input could not be read")
+		_ = compatibility.WriteProcessing(stderr, "text", report)
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
 		return 1
 	}
@@ -1156,20 +1156,53 @@ func upload(args []string, stdout, stderr io.Writer, version string, agent trans
 		}
 	}
 	if err != nil {
+		report := eventInputProcessingReport(workflowPath, hostedTokenlessProfile, workflowSource, "event input could not be acquired")
+		_ = compatibility.WriteProcessing(stderr, "text", report)
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
+		return 1
+	}
+	validation, validationErr := compiler.ValidateEvent(workflowPath, workflowSource, eventSource)
+	processingReport := initialProcessingReport(workflowPath, hostedTokenlessProfile, true, validation, validationErr)
+	if validationErr != nil {
+		processingReport.Result = "incompatible"
+		_ = compatibility.WriteProcessing(stderr, "text", processingReport)
 		return 1
 	}
 	executablePath, executableContents, distributionDigest, err := executable()
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
+		addEnvironmentFailure(&processingReport, "compiler executable could not be inspected")
+		processingReport.Result = "indeterminate"
+		_ = compatibility.WriteProcessing(stderr, "text", processingReport)
 		return 1
 	}
 	preflight, err := compileHostedTokenless(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, os.Getenv("BUILDKITE_GROUP_LABEL"), targetQueue, runtimeImage, jobScopedActionSourceAuthentication(stderr))
+	applyProcessingEvidence(&processingReport, preflight.Bundle.Processing)
+	if preflight.Admitted {
+		processingReport.SetStage(stageAdmission, compatibility.Passed)
+		processingReport.Admission.Result = "admitted"
+	}
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
+		var failure *hostedTokenlessFailure
+		if errors.As(err, &failure) && failure.Kind == hostedTokenlessAdmissionFailure {
+			addProcessingFailure(&processingReport, workflowPath, stageAdmission, "E_PROFILE", "admission", err)
+			processingReport.Admission.Result = "not-admitted"
+			processingReport.Result = "not-admitted"
+		} else {
+			if errors.As(err, &failure) && failure.Kind == hostedTokenlessEnvironmentFailure {
+				addEnvironmentFailure(&processingReport, "hosted workflow-processing environment could not be initialized")
+			} else {
+				addProcessingFailure(&processingReport, workflowPath, stageResolution, compiler.CodeActionResolution, "action-resolution", err)
+			}
+			processingReport.Result = "indeterminate"
+		}
+		_ = compatibility.WriteProcessing(stderr, "text", processingReport)
 		return 1
 	}
 	bundle := preflight.Bundle
+	processingReport.SetStage(stageAdmission, compatibility.Passed)
+	processingReport.Admission.Result = "admitted"
+	processingReport.Result = "admitted"
+	_ = compatibility.WriteProcessing(stdout, "text", processingReport)
 	writeCompilerWarnings(stderr, "upload", workflowPath, bundle.IR.Warnings)
 	artifacts := make([]transport.Artifact, 0, 1+len(bundle.Plans))
 	distributionPath, err := buildkitepipeline.DistributionPath(distributionDigest)
@@ -1340,12 +1373,16 @@ func compileHostedTokenless(ctx context.Context, workflowPath string, workflowSo
 		options.ResolveActions = true
 		options.ActionSource = compiler.PublicActionSource{Resolver: resolver, Store: store}
 	}
-	bundle, err := compiler.CompileBundleContext(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, options)
+	bundle, err := compiler.CompileBundlePlansContext(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, options)
 	if err != nil {
 		return hostedTokenlessCompilation{Bundle: bundle, HasActions: hasActions}, hostedTokenlessError(hostedTokenlessEvaluationFailure, err)
 	}
 	if err := validateUnprivilegedBundle(bundle); err != nil {
 		return hostedTokenlessCompilation{Bundle: bundle, HasActions: hasActions}, hostedTokenlessError(hostedTokenlessAdmissionFailure, err)
+	}
+	bundle, err = compiler.GenerateBundlePipeline(bundle, distributionDigest, importerStep, options)
+	if err != nil {
+		return hostedTokenlessCompilation{Bundle: bundle, HasActions: hasActions, Admitted: true}, hostedTokenlessError(hostedTokenlessEvaluationFailure, err)
 	}
 	if !hasActions && bundleUsesActions(bundle) {
 		return hostedTokenlessCompilation{Bundle: bundle, HasActions: hasActions, Admitted: true}, hostedTokenlessError(hostedTokenlessEvaluationFailure, fmt.Errorf("final compilation introduced actions absent from preflight"))
@@ -1354,44 +1391,64 @@ func compileHostedTokenless(ctx context.Context, workflowPath string, workflowSo
 }
 
 func validateUnprivilegedBundle(bundle compiler.Bundle) error {
+	instances := make(map[string]compiler.JobInstance, len(bundle.IR.Jobs))
+	for _, instance := range bundle.IR.Jobs {
+		instances[instance.Key] = instance
+	}
+	var diagnostics []error
+	addFailure := func(artifact compiler.PlanArtifact, message string, err error) {
+		finding := &compiler.ProcessingFinding{
+			Stage: compiler.StageAdmission, Code: "E_PROFILE", Category: "admission",
+			Job: artifact.Job.Workflow.LogicalJobID, Instance: artifact.Job.Target.StepKey,
+			Message: message, Err: err,
+		}
+		if instance, ok := instances[artifact.Job.Target.StepKey]; ok {
+			finding.Path = instance.SourcePath
+			finding.Line = instance.Source.Start.Line
+			finding.Column = instance.Source.Start.Column
+		}
+		diagnostics = append(diagnostics, finding)
+	}
 	for _, artifact := range bundle.Plans {
 		for _, capability := range artifact.Job.RequiredCapabilities {
 			if capability == "docker" && !slices.Equal(artifact.Authorization.DockerCapabilitySources, []string{"dockerfile-actions"}) {
 				if slices.Contains(artifact.Authorization.DockerCapabilitySources, "job-containers") || slices.Contains(artifact.Authorization.DockerCapabilitySources, "service-containers") {
-					return fmt.Errorf("job %q uses job or service containers, which hosted-tokenless upload does not admit", artifact.Job.Workflow.LogicalJobID)
+					addFailure(artifact, "job or service containers are not admitted by the hosted profile", fmt.Errorf("job %q uses job or service containers, which hosted-tokenless upload does not admit", artifact.Job.Workflow.LogicalJobID))
+					continue
 				}
-				return fmt.Errorf("job %q requires docker without compiler-verified Dockerfile action provenance", artifact.Job.Workflow.LogicalJobID)
+				addFailure(artifact, "docker capability lacks compiler-verified action provenance", fmt.Errorf("job %q requires docker without compiler-verified Dockerfile action provenance", artifact.Job.Workflow.LogicalJobID))
+				continue
 			}
 			if capability == "provider-token-read" {
 				if !slices.Equal(artifact.Authorization.ProviderTokenReadCapabilitySources, []string{"checkout-adapter"}) {
-					return fmt.Errorf("job %q requires provider-token-read without compiler-verified checkout provenance", artifact.Job.Workflow.LogicalJobID)
+					addFailure(artifact, "provider token read capability lacks compiler-verified checkout provenance", fmt.Errorf("job %q requires provider-token-read without compiler-verified checkout provenance", artifact.Job.Workflow.LogicalJobID))
 				}
 				continue
 			}
 			if capability == "provider-token-write" {
 				if artifact.Job.GitHubToken == nil || !slices.Equal(artifact.Authorization.ProviderTokenWriteCapabilitySources, []string{"effective-permissions"}) {
-					return fmt.Errorf("job %q requires provider-token-write without compiler-verified workflow permission provenance", artifact.Job.Workflow.LogicalJobID)
+					addFailure(artifact, "provider token write capability lacks compiler-verified permission provenance", fmt.Errorf("job %q requires provider-token-write without compiler-verified workflow permission provenance", artifact.Job.Workflow.LogicalJobID))
 				}
 				continue
 			}
 			if capability != "network" && capability != "docker" {
-				return fmt.Errorf("job %q requires capability %q, unavailable to unprivileged upload", artifact.Job.Workflow.LogicalJobID, capability)
+				addFailure(artifact, fmt.Sprintf("capability %q is unavailable to the hosted profile", capability), fmt.Errorf("job %q requires capability %q, unavailable to unprivileged upload", artifact.Job.Workflow.LogicalJobID, capability))
 			}
 		}
 		for _, action := range artifact.Job.Actions {
 			descriptor, _ := actionintegration.Lookup(actionintegration.Identity{Source: action.Source, Repository: action.Repository, Path: action.Path})
 			if descriptor.Service == actionintegration.ServiceCache {
 				if err := actionintegration.ValidateCacheCommit(action.Commit); err != nil {
-					return fmt.Errorf("job %q uses unsupported cache action: %w", artifact.Job.Workflow.LogicalJobID, err)
+					addFailure(artifact, "cache action version is not admitted by the hosted profile", fmt.Errorf("job %q uses unsupported cache action: %w", artifact.Job.Workflow.LogicalJobID, err))
 				}
 				continue
 			}
 			if descriptor.Service != "" {
-				return fmt.Errorf("job %q uses action %q, which requires the unavailable GitHub Actions %s service; Phase 6 is required", artifact.Job.Workflow.LogicalJobID, action.Repository, descriptor.Service)
+				addFailure(artifact, "action requires a service unavailable to the hosted profile", fmt.Errorf("job %q uses action %q, which requires the unavailable GitHub Actions %s service; Phase 6 is required", artifact.Job.Workflow.LogicalJobID, action.Repository, descriptor.Service))
 			}
 		}
 	}
-	return nil
+	return errors.Join(diagnostics...)
 }
 
 func irUsesActions(ir compiler.IR) bool {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -931,6 +931,11 @@ func validate(args []string, stdout, stderr io.Writer, version string) int {
 		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 		defer stop()
 		preflight, profileErr := compileHostedTokenless(ctx, workflowPath, source, event, version, distributionDigest, "buildkite-gha-profile-importer", "", "", "", nil)
+		applyProcessingEvidence(&processingReport, preflight.Bundle.Processing)
+		if preflight.Admitted {
+			processingReport.SetStage(stageAdmission, compatibility.Passed)
+			processingReport.Admission.Result = "admitted"
+		}
 		if profileErr != nil {
 			if ctx.Err() != nil || errors.Is(profileErr, context.Canceled) {
 				_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: profile evaluation interrupted: %v\n", profileErr)
@@ -938,24 +943,37 @@ func validate(args []string, stdout, stderr io.Writer, version string) int {
 			}
 			var failure *hostedTokenlessFailure
 			if errors.As(profileErr, &failure) && failure.Kind == hostedTokenlessAdmissionFailure {
-				profileReport := compatibility.ProfileBlocked(workflowPath, profile, report.LogicalJobs, report.Instances, profileErr)
-				if writeErr := compatibility.WriteProfile(stdout, format, withCompilerWarnings(profileReport, workflowPath, report.Warnings)); writeErr != nil {
+				addProcessingFailure(&processingReport, workflowPath, stageAdmission, "E_PROFILE", "admission", profileErr)
+				processingReport.Admission.Result = "not-admitted"
+				processingReport.Result = "not-admitted"
+				if writeErr := compatibility.WriteProcessing(stdout, format, processingReport); writeErr != nil {
 					_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: write profile report: %v\n", writeErr)
 				}
 				return 1
 			}
-			code := "E_PROFILE_EVALUATION"
+			code := compiler.CodeActionResolution
+			stage := stageResolution
+			category := "action-resolution"
 			if errors.As(profileErr, &failure) && failure.Kind == hostedTokenlessEnvironmentFailure {
 				code = "E_ENVIRONMENT"
 			}
-			profileReport := compatibility.ProfileNotEvaluated(workflowPath, profile, report.LogicalJobs, report.Instances, code, profileErr)
-			if writeErr := compatibility.WriteProfile(stdout, format, withCompilerWarnings(profileReport, workflowPath, report.Warnings)); writeErr != nil {
+			addProcessingFailure(&processingReport, workflowPath, stage, code, category, profileErr)
+			processingReport.Result = "indeterminate"
+			if writeErr := compatibility.WriteProcessing(stdout, format, processingReport); writeErr != nil {
 				_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: write profile report: %v\n", writeErr)
 			}
 			return 1
 		}
-		profileReport := compatibility.Admitted(workflowPath, profile, report.LogicalJobs, report.Instances, preflight.HasActions)
-		if writeErr := compatibility.WriteProfile(stdout, format, withCompilerWarnings(profileReport, workflowPath, report.Warnings)); writeErr != nil {
+		processingReport.SetStage(stageAdmission, compatibility.Passed)
+		processingReport.Admission.Result = "admitted"
+		if preflight.HasActions {
+			processingReport.Diagnostics = append(processingReport.Diagnostics, compatibility.Diagnostic{
+				Level: "warning", Code: "W_ACTION_RUNTIME_UNKNOWN", Category: "compatibility", Stage: stageAdmission,
+				Message: "resolved action metadata cannot prove that arbitrary action code is independent of GitHub-only runtime services",
+			})
+		}
+		processingReport.Result = "admitted"
+		if writeErr := compatibility.WriteProcessing(stdout, format, processingReport); writeErr != nil {
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: write profile report: %v\n", writeErr)
 			return 1
 		}
@@ -1063,14 +1081,23 @@ func compile(args []string, stdout, stderr io.Writer, version string) int {
 			return 1
 		}
 		bundle, compileErr := compiler.CompileBundle(workflowPath, source, event, version, digest, "gha-importer")
+		applyProcessingEvidence(&processingReport, bundle.Processing)
 		err = compileErr
 		result = bundle.Pipeline
 		warnings = bundle.IR.Warnings
 	}
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "buildkite-gha: compile: %v\n", err)
+		addProcessingFailure(&processingReport, workflowPath, stagePlans, compiler.CodePlanConstruction, "compatibility", err)
+		processingReport.Result = "incompatible"
+		_ = compatibility.WriteProcessing(stderr, "text", processingReport)
 		return 1
 	}
+	if format == "ir-json" {
+		processingReport.Result = "compilable"
+	} else {
+		processingReport.Result = "compilable"
+	}
+	_ = compatibility.WriteProcessing(stderr, "text", processingReport)
 	writeCompilerWarnings(stderr, "compile", workflowPath, warnings)
 	if _, err := stdout.Write(result); err != nil {
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: compile: write output: %v\n", err)
@@ -1172,6 +1199,7 @@ func upload(args []string, stdout, stderr io.Writer, version string, agent trans
 type hostedTokenlessCompilation struct {
 	Bundle     compiler.Bundle
 	HasActions bool
+	Admitted   bool
 }
 
 type hostedTokenlessFailureKind string
@@ -1314,15 +1342,15 @@ func compileHostedTokenless(ctx context.Context, workflowPath string, workflowSo
 	}
 	bundle, err := compiler.CompileBundleContext(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, options)
 	if err != nil {
-		return hostedTokenlessCompilation{}, hostedTokenlessError(hostedTokenlessEvaluationFailure, err)
+		return hostedTokenlessCompilation{Bundle: bundle, HasActions: hasActions}, hostedTokenlessError(hostedTokenlessEvaluationFailure, err)
 	}
 	if err := validateUnprivilegedBundle(bundle); err != nil {
-		return hostedTokenlessCompilation{}, hostedTokenlessError(hostedTokenlessAdmissionFailure, err)
+		return hostedTokenlessCompilation{Bundle: bundle, HasActions: hasActions}, hostedTokenlessError(hostedTokenlessAdmissionFailure, err)
 	}
 	if !hasActions && bundleUsesActions(bundle) {
-		return hostedTokenlessCompilation{}, hostedTokenlessError(hostedTokenlessEvaluationFailure, fmt.Errorf("final compilation introduced actions absent from preflight"))
+		return hostedTokenlessCompilation{Bundle: bundle, HasActions: hasActions, Admitted: true}, hostedTokenlessError(hostedTokenlessEvaluationFailure, fmt.Errorf("final compilation introduced actions absent from preflight"))
 	}
-	return hostedTokenlessCompilation{Bundle: bundle, HasActions: hasActions}, nil
+	return hostedTokenlessCompilation{Bundle: bundle, HasActions: hasActions, Admitted: true}, nil
 }
 
 func validateUnprivilegedBundle(bundle compiler.Bundle) error {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -123,7 +123,7 @@ func TestRunValidateAndCompile(t *testing.T) {
 		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 			t.Fatal(err)
 		}
-		if report.Result != "incompatible" || len(report.Diagnostics) != 1 || report.Diagnostics[0].Code != "E_COMPILE" {
+		if report.Result != "incompatible" || len(report.Diagnostics) != 1 || report.Diagnostics[0].Code != compiler.CodeMatrixInvalid {
 			t.Fatalf("report = %#v", report)
 		}
 
@@ -136,7 +136,7 @@ func TestRunValidateAndCompile(t *testing.T) {
 		if err := json.Unmarshal(stdout.Bytes(), &profileReport); err != nil {
 			t.Fatal(err)
 		}
-		if profileReport.Result != "incompatible" || profileReport.Compile.Result != "incompatible" || profileReport.Admission.Result != "not-evaluated" || len(profileReport.Diagnostics) != 1 || profileReport.Diagnostics[0].Code != "E_COMPILE" {
+		if profileReport.Result != "incompatible" || profileReport.Compile.Result != "incompatible" || profileReport.Admission.Result != "not-evaluated" || len(profileReport.Diagnostics) != 1 || profileReport.Diagnostics[0].Code != compiler.CodeMatrixInvalid {
 			t.Fatalf("profile report = %#v", profileReport)
 		}
 	})
@@ -304,6 +304,146 @@ func TestCompileReportsActionResolutionFailureWithoutPipeline(t *testing.T) {
 	} {
 		if !strings.Contains(stderr.String(), want) {
 			t.Fatalf("stderr = %q, want %q", stderr.String(), want)
+		}
+	}
+}
+
+func TestProcessingReportStageAttributionDoesNotDependOnWorkflowPath(t *testing.T) {
+	for _, name := range []string{"matrix.yml", "workflow.yml"} {
+		t.Run(name, func(t *testing.T) {
+			workflowPath := filepath.Join(t.TempDir(), name)
+			workflow := []byte("on: push\njobs:\n  test:\n    runs-on: windows-latest\n    steps:\n      - run: true\n")
+			if err := os.WriteFile(workflowPath, workflow, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			var stdout, stderr bytes.Buffer
+			if code := Run([]string{"validate", "--format", "json", workflowPath}, &stdout, &stderr, "dev"); code != 1 {
+				t.Fatalf("Run() code = %d, want 1; stderr = %q", code, stderr.String())
+			}
+			var report compatibility.ProcessingReport
+			if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+				t.Fatal(err)
+			}
+			results := map[string]string{}
+			for _, stage := range report.Stages {
+				results[stage.ID] = stage.Result
+			}
+			if results[stageMatrix] != compatibility.Passed || results[stageExpressions] != compatibility.Failed || len(report.Diagnostics) != 1 || report.Diagnostics[0].Code != compiler.CodeExpressionInvalid {
+				t.Fatalf("report = %#v", report)
+			}
+		})
+	}
+}
+
+func TestCompileLeavesSkippedRemoteActionResolutionNotEvaluated(t *testing.T) {
+	workflowPath := filepath.Join(t.TempDir(), "remote.yml")
+	workflow := []byte(`on: push
+permissions: {}
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: owner/action@v1
+      - run: echo '${{ secrets.GITHUB_TOKEN }}'
+`)
+	if err := os.WriteFile(workflowPath, workflow, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"compile", "--event-path", eventPath, workflowPath}, &stdout, &stderr, "dev"); code != 1 {
+		t.Fatalf("Run() code = %d, want 1; stderr = %q", code, stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("compile emitted partial pipeline: %q", stdout.String())
+	}
+	for _, want := range []string{
+		"Immutable action resolution: not-evaluated",
+		"Job-plan construction: failed",
+		"action owner/action@v1 (job gha-test, step 1): not-evaluated",
+		"[E_PLAN_CONSTRUCTION]",
+	} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr = %q, want %q", stderr.String(), want)
+		}
+	}
+}
+
+func TestHostedReportRetainsIndependentActionInvocationResultsThroughWrapper(t *testing.T) {
+	root := t.TempDir()
+	workflowPath := filepath.Join(root, ".github", "workflows", "actions.yml")
+	actionPath := filepath.Join(root, ".github", "actions", "dynamic")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(actionPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	workflow := []byte(`on: push
+jobs:
+  duplicate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/dynamic
+        with:
+          value: supplied
+      - uses: ./.github/actions/dynamic
+  missing:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/missing-one
+      - uses: ./.github/actions/missing-two
+`)
+	if err := os.WriteFile(workflowPath, workflow, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	action := []byte(`name: dynamic
+inputs:
+  value:
+    default: ${{ github[env.NAME] }}
+runs:
+  using: node24
+  main: main.js
+`)
+	if err := os.WriteFile(filepath.Join(actionPath, "action.yml"), action, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(actionPath, "main.js"), []byte("console.log('unused')\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
+	var stdout, stderr bytes.Buffer
+	args := []string{"validate", "--profile", "hosted-tokenless", "--format", "json", "--event-path", eventPath, workflowPath}
+	if code := Run(args, &stdout, &stderr, "dev"); code != 1 {
+		t.Fatalf("Run() code = %d, want 1; stderr = %q", code, stderr.String())
+	}
+	var report compatibility.ProcessingReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Diagnostics) != 3 {
+		t.Fatalf("diagnostics = %#v, want three independent action failures", report.Diagnostics)
+	}
+	wantResults := map[int]string{1: compatibility.Passed, 2: compatibility.Failed}
+	missingFailures := 0
+	for _, result := range report.Actions {
+		switch result.Job {
+		case "gha-duplicate":
+			if result.Result != wantResults[result.Step] {
+				t.Fatalf("duplicate action result = %#v", result)
+			}
+		case "gha-missing":
+			if result.Result == compatibility.Failed {
+				missingFailures++
+			}
+		}
+	}
+	if missingFailures != 2 {
+		t.Fatalf("actions = %#v, want both missing invocations failed", report.Actions)
+	}
+	for _, diagnostic := range report.Diagnostics {
+		if diagnostic.Instance == "" || diagnostic.Step == 0 || diagnostic.Code != compiler.CodeActionResolution {
+			t.Fatalf("diagnostic lacks invocation identity: %#v", diagnostic)
 		}
 	}
 }
@@ -493,7 +633,7 @@ jobs:
 		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 			t.Fatal(err)
 		}
-		if report.Result != "incompatible" || len(report.Diagnostics) != 1 || report.Diagnostics[0].Code != "E_COMPILE" || !strings.Contains(report.Diagnostics[0].Message, want) {
+		if report.Result != "incompatible" || len(report.Diagnostics) != 1 || report.Diagnostics[0].Code != compiler.CodeExpressionInvalid || !strings.Contains(report.Diagnostics[0].Message, want) {
 			t.Fatalf("report = %#v", report)
 		}
 	})

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -654,6 +654,48 @@ jobs:
 	}
 }
 
+func TestProcessingReportFailsAllInstancesForJobScopedExpressionFailure(t *testing.T) {
+	workflowPath := filepath.Join(t.TempDir(), "matrix-concurrency.yml")
+	workflow := []byte(`on: push
+jobs:
+  test:
+    strategy:
+      max-parallel: 2
+      matrix:
+        target: [one, two]
+    runs-on: ubuntu-latest
+    concurrency: deploy-${{ matrix.target }}
+    steps:
+      - run: true
+`)
+	if err := os.WriteFile(workflowPath, workflow, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"validate", "--format", "json", workflowPath}, &stdout, &stderr, "dev"); code != 1 {
+		t.Fatalf("Run() code = %d, want 1; stderr = %q", code, stderr.String())
+	}
+	var report compatibility.ProcessingReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	instances := 0
+	for _, job := range report.Jobs {
+		if job.ID == "test" && job.Instance != "" {
+			instances++
+			if job.Result != compatibility.Failed {
+				t.Fatalf("matrix instance = %#v, want failed", job)
+			}
+		}
+	}
+	if instances != 2 {
+		t.Fatalf("matrix instances = %d, want 2; jobs = %#v", instances, report.Jobs)
+	}
+	if len(report.Diagnostics) != 1 || report.Diagnostics[0].Job != "test" || report.Diagnostics[0].Instance != "" {
+		t.Fatalf("diagnostics = %#v, want one job-scoped finding", report.Diagnostics)
+	}
+}
+
 func TestProcessingReportRedactsEventDerivedRunnerValues(t *testing.T) {
 	const sentinel = "raw-event-secret-8675309"
 	root := t.TempDir()
@@ -844,6 +886,47 @@ jobs:
 	}
 	if !logicalBad || !instanceBad {
 		t.Fatalf("callee job ledger = %#v", report.Jobs)
+	}
+}
+
+func TestProcessingReportFailsReusableCallerWhenResolutionFails(t *testing.T) {
+	root := t.TempDir()
+	workflowRoot := filepath.Join(root, ".github", "workflows")
+	if err := os.MkdirAll(workflowRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	workflowPath := filepath.Join(workflowRoot, "caller.yml")
+	calleePath := filepath.Join(workflowRoot, "reusable.yml")
+	if err := os.WriteFile(workflowPath, []byte("on: push\njobs:\n  delegated:\n    uses: ./.github/workflows/reusable.yml\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	callee := []byte(`on:
+  workflow_call:
+    outputs:
+      published:
+        value: literal
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+`)
+	if err := os.WriteFile(calleePath, callee, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"validate", "--format", "json", workflowPath}, &stdout, &stderr, "dev"); code != 1 {
+		t.Fatalf("Run() code = %d, want 1; stderr = %q", code, stderr.String())
+	}
+	var report compatibility.ProcessingReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Jobs) != 1 || report.Jobs[0].ID != "delegated" || report.Jobs[0].Result != compatibility.Failed {
+		t.Fatalf("caller job ledger = %#v", report.Jobs)
+	}
+	if len(report.Diagnostics) != 1 || report.Diagnostics[0].Job != "delegated" || report.Diagnostics[0].Stage != stageGraph {
+		t.Fatalf("diagnostics = %#v", report.Diagnostics)
 	}
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -214,6 +214,130 @@ func TestRunValidateAndCompile(t *testing.T) {
 	})
 }
 
+func TestProcessingReportAggregatesIndependentErrorsAndRetainsPartialSuccess(t *testing.T) {
+	workflowPath := filepath.Join(t.TempDir(), "incompatible.yml")
+	workflow := []byte(`on: push
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.value }}
+    steps:
+      - id: matrix
+        run: true
+  good:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./missing-action
+  bad-matrix:
+    needs: prepare
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+    steps:
+      - run: true
+  bad-condition:
+    runs-on: ubuntu-latest
+    steps:
+      - if: ${{ hashFiles('go.sum') }}
+        run: true
+  bad-runner:
+    runs-on: windows-latest
+    steps:
+      - run: true
+`)
+	if err := os.WriteFile(workflowPath, workflow, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"validate", "--format", "json", workflowPath}, &stdout, &stderr, "dev"); code != 1 {
+		t.Fatalf("Run() code = %d, want 1; stderr = %q", code, stderr.String())
+	}
+	var report compatibility.ProcessingReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if report.Status != compatibility.Failed || len(report.Stages) != 10 || len(report.Diagnostics) < 3 {
+		t.Fatalf("processing report = %#v", report)
+	}
+	stageResults := map[string]string{}
+	for _, stage := range report.Stages {
+		stageResults[stage.ID] = stage.Result
+	}
+	if stageResults[stageMatrix] != compatibility.Failed || stageResults[stageExpressions] != compatibility.Failed || stageResults[stageResolution] != compatibility.NotEvaluated {
+		t.Fatalf("stage results = %#v", stageResults)
+	}
+	foundGoodInstance := false
+	for _, job := range report.Jobs {
+		if job.ID == "good" && job.Instance != "" && job.Result == compatibility.Passed {
+			foundGoodInstance = true
+		}
+	}
+	if !foundGoodInstance || len(report.Actions) != 1 || report.Actions[0].Reference != "./missing-action" {
+		t.Fatalf("partial jobs/actions = %#v / %#v", report.Jobs, report.Actions)
+	}
+}
+
+func TestCompileReportsActionResolutionFailureWithoutPipeline(t *testing.T) {
+	workflowPath := filepath.Join(t.TempDir(), "action.yml")
+	workflow := []byte("on: push\njobs:\n  first:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: ./missing-one\n  second:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: ./missing-two\n")
+	if err := os.WriteFile(workflowPath, workflow, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"compile", "--event-path", eventPath, workflowPath}, &stdout, &stderr, "dev"); code != 1 {
+		t.Fatalf("Run() code = %d, want 1; stderr = %q", code, stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("compile emitted partial pipeline: %q", stdout.String())
+	}
+	for _, want := range []string{
+		"Immutable action resolution: failed",
+		"Job-plan construction: not-evaluated",
+		"Pipeline generation: not-evaluated",
+		"[E_ACTION_RESOLUTION]",
+		"job first/gha-first: passed",
+		"job second/gha-second: passed",
+		"action ./missing-one (job gha-first, step 1): failed",
+		"action ./missing-two (job gha-second, step 1): failed",
+	} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr = %q, want %q", stderr.String(), want)
+		}
+	}
+}
+
+func TestValidateReportsIndependentWorkflowAndEventSyntaxFailures(t *testing.T) {
+	root := t.TempDir()
+	workflowPath := filepath.Join(root, "invalid.yml")
+	eventPath := filepath.Join(root, "event.json")
+	if err := os.WriteFile(workflowPath, []byte("jobs: [\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(eventPath, []byte("{\"provider\":"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"validate", "--format", "json", "--event-path", eventPath, workflowPath}, &stdout, &stderr, "dev"); code != 1 {
+		t.Fatalf("Run() code = %d, want 1; stderr = %q", code, stderr.String())
+	}
+	var report compatibility.ProcessingReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	results := map[string]string{}
+	for _, stage := range report.Stages {
+		results[stage.ID] = stage.Result
+	}
+	if results[stageWorkflowParsing] != compatibility.Failed || results[stageEventValidation] != compatibility.Failed || results[stageGraph] != compatibility.NotEvaluated {
+		t.Fatalf("stage results = %#v", results)
+	}
+	if len(report.Diagnostics) != 2 || report.Diagnostics[0].Category != "syntax" || report.Diagnostics[1].Category != "environment" {
+		t.Fatalf("diagnostics = %#v", report.Diagnostics)
+	}
+}
+
 func TestWorkflowConcurrencyCancellationWarnsAndRetainsGate(t *testing.T) {
 	workflowPath := filepath.Join(t.TempDir(), "concurrency.yml")
 	workflow := []byte(`on: push

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -683,6 +683,35 @@ func TestProcessingReportRedactsEventDerivedRunnerValues(t *testing.T) {
 	}
 }
 
+func TestProcessingReportRedactsEventDerivedMatrixKeys(t *testing.T) {
+	const sentinel = "EVENT_SECRET_KEY_8675309"
+	root := t.TempDir()
+	workflowPath := filepath.Join(root, "event-matrix.yml")
+	eventPath := filepath.Join(root, "event.json")
+	workflow := []byte("on: push\njobs:\n  test:\n    strategy:\n      matrix: ${{ github.event.matrix }}\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n")
+	event := []byte(`{"provider":"github","event":"push","repository":{"owner":"owner","name":"repo"},"ref":"refs/heads/main","sha":"1111111111111111111111111111111111111111","actor":"actor","payload":{"matrix":{"` + sentinel + `":"invalid"}}}`)
+	if err := os.WriteFile(workflowPath, workflow, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(eventPath, event, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"validate", "--format", "json", "--event-path", eventPath, workflowPath}, &stdout, &stderr, "dev"); code != 1 {
+		t.Fatalf("Run() code = %d, want 1; stderr = %q", code, stderr.String())
+	}
+	if strings.Contains(stdout.String(), sentinel) || strings.Contains(stderr.String(), sentinel) {
+		t.Fatalf("report leaked event payload key: stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	var report compatibility.ProcessingReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Diagnostics) != 1 || report.Diagnostics[0].Code != compiler.CodeMatrixInvalid || report.Diagnostics[0].Message != "matrix could not be expanded or validated" {
+		t.Fatalf("diagnostics = %#v", report.Diagnostics)
+	}
+}
+
 func TestCompileAggregatesIndependentPlanFailuresWithoutPipeline(t *testing.T) {
 	workflowPath := filepath.Join(t.TempDir(), "plans.yml")
 	workflow := []byte(`on: push
@@ -1466,8 +1495,16 @@ func TestRunUploadRejectsInvalidTargetQueueEnvironment(t *testing.T) {
 			if code := run([]string{"upload", "--event-path", eventPath, workflowPath}, &stdout, &stderr, "dev", runner); code == 0 {
 				t.Fatalf("run() code = 0, want invalid target queue failure")
 			}
-			if len(runner.commands) != 0 || (!strings.Contains(stderr.String(), targetQueueEnvironment) && !strings.Contains(stderr.String(), "runner policy queue")) {
+			if len(runner.commands) != 0 {
 				t.Fatalf("commands = %#v, stderr = %q", runner.commands, stderr.String())
+			}
+			if test.name == "empty" && !strings.Contains(stderr.String(), targetQueueEnvironment) {
+				t.Fatalf("stderr = %q, want environment name", stderr.String())
+			}
+			if test.name == "malformed" {
+				if !strings.Contains(stderr.String(), "[E_ENVIRONMENT] workflow-processing configuration is invalid") || strings.Contains(stderr.String(), "[E_EXPRESSION_INVALID]") || strings.Contains(stderr.String(), test.queue) {
+					t.Fatalf("stderr = %q, want redacted environment diagnostic without expression failure", stderr.String())
+				}
 			}
 		})
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -476,6 +476,26 @@ func TestValidateReportsIndependentWorkflowAndEventSyntaxFailures(t *testing.T) 
 	if len(report.Diagnostics) != 2 || report.Diagnostics[0].Category != "syntax" || report.Diagnostics[1].Category != "environment" {
 		t.Fatalf("diagnostics = %#v", report.Diagnostics)
 	}
+
+	stdout.Reset()
+	stderr.Reset()
+	validEventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
+	if code := Run([]string{"validate", "--format", "json", "--event-path", validEventPath, workflowPath}, &stdout, &stderr, "dev"); code != 1 {
+		t.Fatalf("Run() with valid event code = %d, want 1; stderr = %q", code, stderr.String())
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	results = map[string]string{}
+	for _, stage := range report.Stages {
+		results[stage.ID] = stage.Result
+	}
+	if results[stageWorkflowParsing] != compatibility.Failed || results[stageEventValidation] != compatibility.Passed || results[stageGraph] != compatibility.NotEvaluated {
+		t.Fatalf("stage results with valid event = %#v", results)
+	}
+	if len(report.Diagnostics) != 1 || report.Diagnostics[0].Category != "syntax" {
+		t.Fatalf("diagnostics with valid event = %#v", report.Diagnostics)
+	}
 }
 
 func TestWorkflowConcurrencyCancellationWarnsAndRetainsGate(t *testing.T) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -442,7 +442,7 @@ runs:
 		t.Fatalf("actions = %#v, want both missing invocations failed", report.Actions)
 	}
 	for _, diagnostic := range report.Diagnostics {
-		if diagnostic.Instance == "" || diagnostic.Step == 0 || diagnostic.Code != compiler.CodeActionResolution {
+		if diagnostic.Instance == "" || diagnostic.Step == 0 || diagnostic.Code != compiler.CodeActionResolution || diagnostic.Message != "action could not be resolved or validated" {
 			t.Fatalf("diagnostic lacks invocation identity: %#v", diagnostic)
 		}
 	}
@@ -495,6 +495,295 @@ func TestValidateReportsIndependentWorkflowAndEventSyntaxFailures(t *testing.T) 
 	}
 	if len(report.Diagnostics) != 1 || report.Diagnostics[0].Category != "syntax" {
 		t.Fatalf("diagnostics with valid event = %#v", report.Diagnostics)
+	}
+}
+
+func TestCommandsEmitVersionedReportWhenEventInputCannotBeRead(t *testing.T) {
+	root := t.TempDir()
+	workflowPath := filepath.Join(root, "workflow.yml")
+	missingEventPath := filepath.Join(root, "missing-event.json")
+	if err := os.WriteFile(workflowPath, []byte("on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("validate JSON", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		args := []string{"validate", "--format", "json", "--event-path", missingEventPath, workflowPath}
+		if code := Run(args, &stdout, &stderr, "dev"); code != 1 {
+			t.Fatalf("Run() code = %d, stderr = %q", code, stderr.String())
+		}
+		var report compatibility.ProcessingReport
+		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+			t.Fatal(err)
+		}
+		stages := map[string]string{}
+		for _, stage := range report.Stages {
+			stages[stage.ID] = stage.Result
+		}
+		if report.Schema != compatibility.ProcessingSchema || report.Status != compatibility.Failed || stages[stageWorkflowParsing] != compatibility.Passed || stages[stageEventValidation] != compatibility.NotEvaluated || len(report.Diagnostics) != 1 || report.Diagnostics[0].Code != "E_ENVIRONMENT" || report.Diagnostics[0].Stage != "" {
+			t.Fatalf("report = %#v", report)
+		}
+	})
+
+	t.Run("compile text", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		args := []string{"compile", "--event-path", missingEventPath, workflowPath}
+		if code := Run(args, &stdout, &stderr, "dev"); code != 1 {
+			t.Fatalf("Run() code = %d, stderr = %q", code, stderr.String())
+		}
+		for _, want := range []string{"Schema: " + compatibility.ProcessingSchema, "Event validation: not-evaluated", "[E_ENVIRONMENT] event input could not be read"} {
+			if !strings.Contains(stderr.String(), want) {
+				t.Fatalf("stderr = %q, want %q", stderr.String(), want)
+			}
+		}
+	})
+}
+
+func TestProcessingReportRetainsEveryExpandedMatrixCandidate(t *testing.T) {
+	workflowPath := filepath.Join(t.TempDir(), "matrix.yml")
+	workflow := []byte(`on: push
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - run: true
+`)
+	if err := os.WriteFile(workflowPath, workflow, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"validate", "--format", "json", workflowPath}, &stdout, &stderr, "dev"); code != 1 {
+		t.Fatalf("Run() code = %d, want 1; stderr = %q", code, stderr.String())
+	}
+	var report compatibility.ProcessingReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	instances := map[string]string{}
+	for _, job := range report.Jobs {
+		if job.Instance != "" {
+			instances[job.Instance] = job.Result
+		}
+	}
+	if report.Instances != 2 || len(instances) != 2 {
+		t.Fatalf("instances = %d / %#v, want both matrix candidates", report.Instances, instances)
+	}
+	failedInstance := ""
+	for _, diagnostic := range report.Diagnostics {
+		if diagnostic.Code == compiler.CodeExpressionInvalid {
+			failedInstance = diagnostic.Instance
+		}
+	}
+	if failedInstance == "" || instances[failedInstance] != compatibility.Failed {
+		t.Fatalf("diagnostics/jobs = %#v / %#v", report.Diagnostics, report.Jobs)
+	}
+	passed := 0
+	for _, result := range instances {
+		if result == compatibility.Passed {
+			passed++
+		}
+	}
+	if passed != 1 {
+		t.Fatalf("instances = %#v, want one passed and one failed", instances)
+	}
+}
+
+func TestProcessingReportRedactsEventDerivedRunnerValues(t *testing.T) {
+	const sentinel = "raw-event-secret-8675309"
+	root := t.TempDir()
+	workflowPath := filepath.Join(root, "event-runner.yml")
+	eventPath := filepath.Join(root, "event.json")
+	workflow := []byte("on: push\njobs:\n  test:\n    runs-on: ${{ github.event.runner }}\n    steps:\n      - run: true\n")
+	event := []byte(`{"provider":"github","event":"push","repository":{"owner":"owner","name":"repo"},"ref":"refs/heads/main","sha":"1111111111111111111111111111111111111111","actor":"actor","payload":{"runner":"` + sentinel + `"}}`)
+	if err := os.WriteFile(workflowPath, workflow, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(eventPath, event, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"validate", "--format", "json", "--event-path", eventPath, workflowPath}, &stdout, &stderr, "dev"); code != 1 {
+		t.Fatalf("Run() code = %d, want 1; stderr = %q", code, stderr.String())
+	}
+	if strings.Contains(stdout.String(), sentinel) || strings.Contains(stderr.String(), sentinel) {
+		t.Fatalf("report leaked event payload value: stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	var report compatibility.ProcessingReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Diagnostics) != 1 || report.Diagnostics[0].Message != "resolved runner target is not admitted by policy" {
+		t.Fatalf("diagnostics = %#v", report.Diagnostics)
+	}
+}
+
+func TestCompileAggregatesIndependentPlanFailuresWithoutPipeline(t *testing.T) {
+	workflowPath := filepath.Join(t.TempDir(), "plans.yml")
+	workflow := []byte(`on: push
+permissions: {}
+jobs:
+  first:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo '${{ secrets.GITHUB_TOKEN }}'
+  second:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo '${{ secrets.GITHUB_TOKEN }}'
+  dependent:
+    needs: first
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+`)
+	if err := os.WriteFile(workflowPath, workflow, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"compile", "--event-path", eventPath, workflowPath}, &stdout, &stderr, "dev"); code != 1 {
+		t.Fatalf("Run() code = %d, want 1; stderr = %q", code, stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("compile emitted partial pipeline: %q", stdout.String())
+	}
+	if got := strings.Count(stderr.String(), "[E_PLAN_CONSTRUCTION]"); got != 2 {
+		t.Fatalf("plan diagnostics = %d, want 2; report = %q", got, stderr.String())
+	}
+	for _, want := range []string{"job first/gha-first: failed", "job second/gha-second: failed", "job dependent/gha-dependent: not-evaluated", "Pipeline generation: not-evaluated"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("report = %q, want %q", stderr.String(), want)
+		}
+	}
+}
+
+func TestHostedReportAggregatesIndependentAdmissionFailures(t *testing.T) {
+	workflowPath := filepath.Join(t.TempDir(), "containers.yml")
+	workflow := []byte(`on: push
+jobs:
+  first:
+    runs-on: ubuntu-latest
+    container: alpine:3.20
+    steps:
+      - run: true
+  second:
+    runs-on: ubuntu-latest
+    container: alpine:3.20
+    steps:
+      - run: true
+`)
+	if err := os.WriteFile(workflowPath, workflow, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
+	var stdout, stderr bytes.Buffer
+	args := []string{"validate", "--profile", "hosted-tokenless", "--format", "json", "--event-path", eventPath, workflowPath}
+	if code := Run(args, &stdout, &stderr, "dev"); code != 1 {
+		t.Fatalf("Run() code = %d, want 1; stderr = %q", code, stderr.String())
+	}
+	var report compatibility.ProcessingReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	profileFailures := 0
+	instances := map[string]string{}
+	for _, diagnostic := range report.Diagnostics {
+		if diagnostic.Code == "E_PROFILE" {
+			profileFailures++
+		}
+	}
+	for _, job := range report.Jobs {
+		if job.Instance != "" {
+			instances[job.Instance] = job.Result
+		}
+	}
+	if profileFailures != 2 || instances["gha-first"] != compatibility.Failed || instances["gha-second"] != compatibility.Failed {
+		t.Fatalf("report = %#v", report)
+	}
+}
+
+func TestProcessingReportRetainsReusableCalleeJobsAfterFailure(t *testing.T) {
+	root := t.TempDir()
+	workflowRoot := filepath.Join(root, ".github", "workflows")
+	if err := os.MkdirAll(workflowRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	workflowPath := filepath.Join(workflowRoot, "caller.yml")
+	calleePath := filepath.Join(workflowRoot, "reusable.yml")
+	if err := os.WriteFile(workflowPath, []byte("on: push\njobs:\n  call:\n    uses: ./.github/workflows/reusable.yml\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	callee := []byte(`on: workflow_call
+jobs:
+  good:
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+  bad:
+    runs-on: windows-latest
+    steps:
+      - run: true
+`)
+	if err := os.WriteFile(calleePath, callee, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"validate", "--format", "json", workflowPath}, &stdout, &stderr, "dev"); code != 1 {
+		t.Fatalf("Run() code = %d, want 1; stderr = %q", code, stderr.String())
+	}
+	var report compatibility.ProcessingReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	logicalBad, instanceBad := false, false
+	for _, job := range report.Jobs {
+		if job.ID != "call.bad" {
+			continue
+		}
+		if job.Instance == "" && job.Result == compatibility.Failed {
+			logicalBad = true
+		}
+		if job.Instance != "" && job.Result == compatibility.Failed {
+			instanceBad = true
+		}
+	}
+	if !logicalBad || !instanceBad {
+		t.Fatalf("callee job ledger = %#v", report.Jobs)
+	}
+}
+
+func TestProcessingReportAggregatesIndependentExpressionChecksPerInstance(t *testing.T) {
+	workflowPath := filepath.Join(t.TempDir(), "expressions.yml")
+	workflow := []byte(`on: push
+jobs:
+  test:
+    if: ${{ hashFiles('condition') }}
+    runs-on: windows-latest
+    concurrency: ${{ hashFiles('concurrency') }}
+    steps:
+      - run: true
+`)
+	if err := os.WriteFile(workflowPath, workflow, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"validate", "--format", "json", workflowPath}, &stdout, &stderr, "dev"); code != 1 {
+		t.Fatalf("Run() code = %d, want 1; stderr = %q", code, stderr.String())
+	}
+	var report compatibility.ProcessingReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Diagnostics) != 3 {
+		t.Fatalf("diagnostics = %#v, want condition, runner, and concurrency failures", report.Diagnostics)
+	}
+	for _, diagnostic := range report.Diagnostics {
+		if diagnostic.Code != compiler.CodeExpressionInvalid || diagnostic.Instance != "gha-test" {
+			t.Fatalf("diagnostic = %#v", diagnostic)
+		}
 	}
 }
 
@@ -1269,6 +1558,9 @@ func TestRunUploadRejectsInvalidWebhookMetadata(t *testing.T) {
 			var stdout, stderr bytes.Buffer
 			if code := run([]string{"upload", workflowPath}, &stdout, &stderr, "dev", runner); code != 1 || !strings.Contains(stderr.String(), test.want) {
 				t.Fatalf("run() code = %d, stderr = %q, want %q", code, stderr.String(), test.want)
+			}
+			if !strings.Contains(stderr.String(), "Schema: "+compatibility.ProcessingSchema) || !strings.Contains(stderr.String(), "[E_ENVIRONMENT] event input could not be acquired") {
+				t.Fatalf("stderr = %q, want versioned environment report", stderr.String())
 			}
 			if len(runner.commands) != 1 || !slices.Equal(runner.commands[0].args, []string{"meta-data", "get", "buildkite:webhook"}) {
 				t.Fatalf("commands = %#v, want only one metadata read", runner.commands)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -502,7 +502,7 @@ func TestCommandsEmitVersionedReportWhenEventInputCannotBeRead(t *testing.T) {
 	root := t.TempDir()
 	workflowPath := filepath.Join(root, "workflow.yml")
 	missingEventPath := filepath.Join(root, "missing-event.json")
-	if err := os.WriteFile(workflowPath, []byte("on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n"), 0o600); err != nil {
+	if err := os.WriteFile(workflowPath, []byte("on: push\njobs:\n  test:\n    runs-on: ${{ github.event.runner }}\n    steps:\n      - run: true\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -520,7 +520,7 @@ func TestCommandsEmitVersionedReportWhenEventInputCannotBeRead(t *testing.T) {
 		for _, stage := range report.Stages {
 			stages[stage.ID] = stage.Result
 		}
-		if report.Schema != compatibility.ProcessingSchema || report.Status != compatibility.Failed || stages[stageWorkflowParsing] != compatibility.Passed || stages[stageEventValidation] != compatibility.NotEvaluated || len(report.Diagnostics) != 1 || report.Diagnostics[0].Code != "E_ENVIRONMENT" || report.Diagnostics[0].Stage != "" {
+		if report.Schema != compatibility.ProcessingSchema || report.Result != "indeterminate" || report.Status != compatibility.Failed || stages[stageWorkflowParsing] != compatibility.Passed || stages[stageEventValidation] != compatibility.NotEvaluated || stages[stageExpressions] != compatibility.NotEvaluated || report.Instances != 0 || len(report.Jobs) != 1 || report.Jobs[0].Result != compatibility.NotEvaluated || len(report.Diagnostics) != 1 || report.Diagnostics[0].Code != "E_ENVIRONMENT" || report.Diagnostics[0].Stage != "" {
 			t.Fatalf("report = %#v", report)
 		}
 	})
@@ -537,6 +537,69 @@ func TestCommandsEmitVersionedReportWhenEventInputCannotBeRead(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestProcessingReportLeavesDependentsOfFailedMatrixNotEvaluated(t *testing.T) {
+	workflowPath := filepath.Join(t.TempDir(), "failed-prerequisite.yml")
+	workflow := []byte(`on: push
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.value }}
+    steps:
+      - id: matrix
+        run: true
+  upstream:
+    needs: prepare
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+    steps:
+      - run: true
+  downstream:
+    needs: upstream
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+`)
+	if err := os.WriteFile(workflowPath, workflow, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"validate", "--format", "json", workflowPath}, &stdout, &stderr, "dev"); code != 1 {
+		t.Fatalf("Run() code = %d, want 1; stderr = %q", code, stderr.String())
+	}
+	var report compatibility.ProcessingReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	stages := map[string]string{}
+	for _, stage := range report.Stages {
+		stages[stage.ID] = stage.Result
+	}
+	if stages[stageGraph] != compatibility.Passed || stages[stageMatrix] != compatibility.Failed {
+		t.Fatalf("stages = %#v", stages)
+	}
+	for _, diagnostic := range report.Diagnostics {
+		if diagnostic.Code == compiler.CodeGraphInvalid || diagnostic.Job == "downstream" {
+			t.Fatalf("cascading graph diagnostic = %#v", diagnostic)
+		}
+	}
+	logical, instance := "", ""
+	for _, job := range report.Jobs {
+		if job.ID != "downstream" {
+			continue
+		}
+		if job.Instance == "" {
+			logical = job.Result
+		} else {
+			instance = job.Result
+		}
+	}
+	if logical != compatibility.NotEvaluated || instance != compatibility.NotEvaluated {
+		t.Fatalf("downstream results = logical %q, instance %q; jobs = %#v", logical, instance, report.Jobs)
+	}
 }
 
 func TestProcessingReportRetainsEveryExpandedMatrixCandidate(t *testing.T) {

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -178,7 +178,10 @@ func markFailedJobs(report *compatibility.ProcessingReport) {
 			report.Jobs[i].Result = compatibility.Failed
 		}
 		for _, diagnostic := range report.Diagnostics {
-			if diagnostic.Level == "error" && diagnostic.Instance == report.Jobs[i].Instance && diagnostic.Instance != "" && diagnostic.Stage != stageResolution {
+			if diagnostic.Level != "error" || diagnostic.Stage == stageResolution || report.Jobs[i].Instance == "" {
+				continue
+			}
+			if diagnostic.Instance == report.Jobs[i].Instance || (diagnostic.Instance == "" && diagnostic.Job == report.Jobs[i].ID) {
 				report.Jobs[i].Result = compatibility.Failed
 			}
 		}

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -125,6 +125,32 @@ func addProcessingFailure(report *compatibility.ProcessingReport, path, stage, c
 	markFailedJobs(report)
 }
 
+func addEnvironmentFailure(report *compatibility.ProcessingReport, message string) {
+	report.Diagnostics = append(report.Diagnostics, compatibility.Diagnostic{
+		Level: "error", Code: "E_ENVIRONMENT", Category: "environment", Message: message,
+	})
+}
+
+func environmentProcessingReport(path, profile, message string) compatibility.ProcessingReport {
+	report := compatibility.NewProcessingReport(path, profile)
+	report.Result = "indeterminate"
+	addEnvironmentFailure(&report, message)
+	return report
+}
+
+func eventInputProcessingReport(path, profile string, source []byte, message string) compatibility.ProcessingReport {
+	validation, validationErr := compiler.Validate(path, source)
+	report := initialProcessingReport(path, profile, false, validation, validationErr)
+	if validationErr != nil {
+		report.Result = "incompatible"
+	} else {
+		report.Result = "indeterminate"
+		report.Compile.Result = compatibility.NotEvaluated
+	}
+	addEnvironmentFailure(&report, message)
+	return report
+}
+
 func markFailedJobs(report *compatibility.ProcessingReport) {
 	failed := map[string]bool{}
 	for _, diagnostic := range report.Diagnostics {
@@ -137,7 +163,7 @@ func markFailedJobs(report *compatibility.ProcessingReport) {
 			report.Jobs[i].Result = compatibility.Failed
 		}
 		for _, diagnostic := range report.Diagnostics {
-			if diagnostic.Level == "error" && diagnostic.Stage == stagePlans && diagnostic.Instance == report.Jobs[i].Instance && diagnostic.Instance != "" {
+			if diagnostic.Level == "error" && diagnostic.Instance == report.Jobs[i].Instance && diagnostic.Instance != "" && diagnostic.Stage != stageResolution {
 				report.Jobs[i].Result = compatibility.Failed
 			}
 		}
@@ -165,6 +191,21 @@ func applyProcessingEvidence(report *compatibility.ProcessingReport, evidence co
 		report.SetStage(stageResolution, compatibility.Failed)
 	} else if evidence.ActionResolutionComplete {
 		report.SetStage(stageResolution, compatibility.Passed)
+	}
+	for _, evaluation := range evidence.Plans {
+		for i := range report.Jobs {
+			if report.Jobs[i].Instance != evaluation.Instance || evaluation.Instance == "" {
+				continue
+			}
+			switch {
+			case !evaluation.Evaluated:
+				report.Jobs[i].Result = compatibility.NotEvaluated
+			case evaluation.Passed:
+				report.Jobs[i].Result = compatibility.Passed
+			default:
+				report.Jobs[i].Result = compatibility.Failed
+			}
+		}
 	}
 	if evidence.PlansConstructed {
 		report.SetStage(stagePlans, compatibility.Passed)
@@ -212,16 +253,21 @@ func diagnosticFromError(defaultPath, stage, code, category string, err error) c
 	var finding *compiler.ProcessingFinding
 	if structured, ok := err.(*compiler.ProcessingFinding); ok {
 		finding = structured
+		if finding.Message != "" {
+			message = finding.Message
+		}
 		if finding.Path != "" {
 			location = sourceLocation(finding.Path, finding.Line, finding.Column)
 		}
 	}
-	if match := locatedDiagnosticPattern.FindStringSubmatch(message); match != nil {
-		line, lineErr := strconv.Atoi(match[2])
-		column, columnErr := strconv.Atoi(match[3])
-		if lineErr == nil && columnErr == nil {
-			location = sourceLocation(match[1], line, column)
-			message = match[4]
+	if finding == nil || finding.Message == "" {
+		if match := locatedDiagnosticPattern.FindStringSubmatch(message); match != nil {
+			line, lineErr := strconv.Atoi(match[2])
+			column, columnErr := strconv.Atoi(match[3])
+			if lineErr == nil && columnErr == nil {
+				location = sourceLocation(match[1], line, column)
+				message = match[4]
+			}
 		}
 	}
 	diagnostic := compatibility.Diagnostic{

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -87,12 +87,23 @@ func initialProcessingReport(path, profile string, eventEvaluated bool, report c
 }
 
 func setInitialStageResults(report *compatibility.ProcessingReport, eventEvaluated bool, failed map[string]bool) {
-	order := []string{stageWorkflowParsing, stageEventValidation, stageGraph, stageMatrix, stageExpressions, stageDiscovery}
-	blocked := false
-	for _, stage := range order {
-		if stage == stageEventValidation && !eventEvaluated {
-			continue
+	workflowFailed := failed[stageWorkflowParsing]
+	if workflowFailed {
+		report.SetStage(stageWorkflowParsing, compatibility.Failed)
+	} else {
+		report.SetStage(stageWorkflowParsing, compatibility.Passed)
+	}
+	eventFailed := false
+	if eventEvaluated {
+		eventFailed = failed[stageEventValidation]
+		if eventFailed {
+			report.SetStage(stageEventValidation, compatibility.Failed)
+		} else {
+			report.SetStage(stageEventValidation, compatibility.Passed)
 		}
+	}
+	blocked := workflowFailed || eventFailed
+	for _, stage := range []string{stageGraph, stageMatrix, stageExpressions, stageDiscovery} {
 		if failed[stage] {
 			report.SetStage(stage, compatibility.Failed)
 			blocked = true

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -1,0 +1,272 @@
+package cli
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/buildkite/buildkite-gha/internal/compatibility"
+	"github.com/buildkite/buildkite-gha/internal/compiler"
+)
+
+const (
+	stageWorkflowParsing = "workflow-parsing"
+	stageEventValidation = "event-validation"
+	stageGraph           = "static-graph-construction"
+	stageMatrix          = "matrix-expansion"
+	stageExpressions     = "expression-validation"
+	stageDiscovery       = "action-discovery"
+	stageResolution      = "action-resolution"
+	stagePlans           = "job-plan-construction"
+	stageAdmission       = "hosted-profile-admission"
+	stagePipeline        = "pipeline-generation"
+)
+
+var locatedDiagnosticPattern = regexp.MustCompile(`^(.+):(\d+):(\d+): (.*)$`)
+
+func initialProcessingReport(path, profile string, eventEvaluated bool, report compiler.Report, processingErr error) compatibility.ProcessingReport {
+	out := compatibility.NewProcessingReport(path, profile)
+	out.LogicalJobs = report.LogicalJobs
+	out.Instances = report.Instances
+	out.Compile = compatibility.Stage{Result: "compilable", LogicalJobs: report.LogicalJobs, Instances: report.Instances}
+	out.Admission = compatibility.Stage{Result: compatibility.NotEvaluated}
+	for _, job := range report.ParsedJobs {
+		out.Jobs = append(out.Jobs, compatibility.JobResult{
+			ID: job.ID, Result: compatibility.Passed,
+			Location: sourceLocation(job.Path, job.Source.Start.Line, job.Source.Start.Column),
+		})
+	}
+	for _, instance := range report.Jobs {
+		out.Jobs = append(out.Jobs, compatibility.JobResult{
+			ID: instance.LogicalJobID, Instance: instance.Key, Result: compatibility.Passed,
+			Location: sourceLocation(instance.SourcePath, instance.Source.Start.Line, instance.Source.Start.Column),
+		})
+		for i, step := range instance.Steps {
+			if step.Uses == "" {
+				continue
+			}
+			out.Actions = append(out.Actions, compatibility.ActionResult{
+				Reference: step.Uses, Job: instance.Key, Step: i + 1,
+				Result:   compatibility.NotEvaluated,
+				Location: sourceLocation(instance.SourcePath, step.Span.Start.Line, step.Span.Start.Column),
+			})
+		}
+	}
+
+	if processingErr == nil {
+		out.SetStage(stageWorkflowParsing, compatibility.Passed)
+		if eventEvaluated {
+			out.SetStage(stageEventValidation, compatibility.Passed)
+		}
+		out.SetStage(stageGraph, compatibility.Passed)
+		out.SetStage(stageMatrix, compatibility.Passed)
+		out.SetStage(stageExpressions, compatibility.Passed)
+		out.SetStage(stageDiscovery, compatibility.Passed)
+		if len(out.Actions) == 0 {
+			out.SetStage(stageResolution, compatibility.Passed)
+		}
+	} else {
+		out.Compile.Result = "incompatible"
+		failed := map[string]bool{}
+		for _, err := range flattenErrors(processingErr) {
+			stage, code, category := classifyProcessingError(err)
+			if len(report.ParsedJobs) == 0 && stage != stageEventValidation {
+				stage, category = stageWorkflowParsing, "syntax"
+			}
+			failed[stage] = true
+			out.Diagnostics = append(out.Diagnostics, diagnosticFromError(path, stage, code, category, err))
+		}
+		markFailedJobs(&out)
+		setInitialStageResults(&out, eventEvaluated, failed)
+	}
+	for _, warning := range report.Warnings {
+		out.Diagnostics = append(out.Diagnostics, compatibility.Diagnostic{
+			Level: "warning", Code: warning.Code, Category: "compatibility", Stage: stageExpressions,
+			Message: fmt.Sprintf("%s:%d:%d: %s", path, warning.Line, warning.Column, warning.Message), Location: sourceLocation(path, warning.Line, warning.Column),
+		})
+	}
+	return out
+}
+
+func setInitialStageResults(report *compatibility.ProcessingReport, eventEvaluated bool, failed map[string]bool) {
+	order := []string{stageWorkflowParsing, stageEventValidation, stageGraph, stageMatrix, stageExpressions, stageDiscovery}
+	blocked := false
+	for _, stage := range order {
+		if stage == stageEventValidation && !eventEvaluated {
+			continue
+		}
+		if failed[stage] {
+			report.SetStage(stage, compatibility.Failed)
+			blocked = true
+			continue
+		}
+		if !blocked {
+			report.SetStage(stage, compatibility.Passed)
+		}
+	}
+}
+
+func addProcessingFailure(report *compatibility.ProcessingReport, path, stage, code, category string, err error) {
+	report.SetStage(stage, compatibility.Failed)
+	if stage == stageResolution && category == "action-resolution" {
+		markActions(report, compatibility.Passed)
+	}
+	for _, item := range flattenErrors(err) {
+		diagnostic := diagnosticFromError(path, stage, code, category, item)
+		report.Diagnostics = append(report.Diagnostics, diagnostic)
+	}
+	markFailedJobs(report)
+	for i := range report.Actions {
+		if stage != stageResolution {
+			continue
+		}
+		for _, diagnostic := range report.Diagnostics {
+			jobMatches := diagnostic.Job == "" || actionJobMatches(*report, report.Actions[i].Job, diagnostic.Job)
+			if jobMatches && ((diagnostic.Action != "" && diagnostic.Action == report.Actions[i].Reference) || (diagnostic.Action == "" && strings.Contains(diagnostic.Message, report.Actions[i].Reference))) {
+				report.Actions[i].Result = compatibility.Failed
+			}
+		}
+	}
+}
+
+func markFailedJobs(report *compatibility.ProcessingReport) {
+	failed := map[string]bool{}
+	for _, diagnostic := range report.Diagnostics {
+		if diagnostic.Level == "error" && diagnostic.Job != "" {
+			failed[diagnostic.Job] = true
+		}
+	}
+	for i := range report.Jobs {
+		if report.Jobs[i].Instance == "" && failed[report.Jobs[i].ID] {
+			report.Jobs[i].Result = compatibility.Failed
+		}
+	}
+}
+
+func actionJobMatches(report compatibility.ProcessingReport, instance, logical string) bool {
+	for _, job := range report.Jobs {
+		if job.Instance == instance {
+			return job.ID == logical
+		}
+	}
+	return false
+}
+
+func markActions(report *compatibility.ProcessingReport, result string) {
+	for i := range report.Actions {
+		report.Actions[i].Result = result
+	}
+}
+
+func allLocalActions(actions []compatibility.ActionResult) bool {
+	for _, action := range actions {
+		if !strings.HasPrefix(action.Reference, "./") {
+			return false
+		}
+	}
+	return true
+}
+
+func markLaterPrerequisites(report *compatibility.ProcessingReport, failedStage string, hosted bool) {
+	if failedStage == stagePlans || failedStage == stageAdmission || failedStage == stagePipeline {
+		report.SetStage(stageResolution, compatibility.Passed)
+		markActions(report, compatibility.Passed)
+	}
+	if failedStage == stageAdmission || failedStage == stagePipeline {
+		report.SetStage(stagePlans, compatibility.Passed)
+	}
+	if hosted && failedStage == stagePipeline {
+		report.SetStage(stageAdmission, compatibility.Passed)
+		report.Admission.Result = "admitted"
+	}
+}
+
+func laterProcessingFailure(err error) (stage, code, category string) {
+	message := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(message, "runner label"), strings.Contains(message, "untrusted event cannot"), strings.Contains(message, "runs-on"), strings.Contains(message, "condition"), strings.Contains(message, "expression"):
+		return stageExpressions, "E_COMPILE", "compatibility"
+	case strings.Contains(message, "emit buildkite pipeline"), strings.Contains(message, "pipeline requires"), strings.Contains(message, "invalid compiler step"):
+		return stagePipeline, "E_PIPELINE_GENERATION", "compatibility"
+	case strings.Contains(message, "action"), strings.Contains(message, "source store"), strings.Contains(message, "workflow path must identify a repository root"):
+		return stageResolution, "E_ACTION_RESOLUTION", "action-resolution"
+	default:
+		return stagePlans, "E_PLAN_CONSTRUCTION", "compatibility"
+	}
+}
+
+func flattenErrors(err error) []error {
+	if err == nil {
+		return nil
+	}
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		var out []error
+		for _, child := range joined.Unwrap() {
+			out = append(out, flattenErrors(child)...)
+		}
+		return out
+	}
+	return []error{err}
+}
+
+func classifyProcessingError(err error) (stage, code, category string) {
+	message := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(message, "parse workflow yaml"), strings.Contains(message, "actionlint"), strings.Contains(message, "could not parse as yaml"), strings.Contains(message, "yaml syntax"):
+		return stageWorkflowParsing, "E_COMPILE", "syntax"
+	case strings.Contains(message, "event snapshot"):
+		return stageEventValidation, "E_COMPILE", "environment"
+	case strings.Contains(message, "matrix"):
+		return stageMatrix, "E_COMPILE", "compatibility"
+	case strings.Contains(message, "condition"), strings.Contains(message, "expression"), strings.Contains(message, "concurrency group"), strings.Contains(message, "runs-on"):
+		return stageExpressions, "E_COMPILE", "compatibility"
+	case strings.Contains(message, "needs unknown"), strings.Contains(message, "job graph"), strings.Contains(message, "reusable workflow"), strings.Contains(message, "flattened job"):
+		return stageGraph, "E_COMPILE", "compatibility"
+	default:
+		return stageGraph, "E_COMPILE", "compatibility"
+	}
+}
+
+func diagnosticFromError(defaultPath, stage, code, category string, err error) compatibility.Diagnostic {
+	message := err.Error()
+	location := (*compatibility.SourceLocation)(nil)
+	if match := locatedDiagnosticPattern.FindStringSubmatch(message); match != nil {
+		line, lineErr := strconv.Atoi(match[2])
+		column, columnErr := strconv.Atoi(match[3])
+		if lineErr == nil && columnErr == nil {
+			location = sourceLocation(match[1], line, column)
+			message = match[4]
+		}
+	}
+	diagnostic := compatibility.Diagnostic{
+		Level: "error", Code: code, Category: category, Stage: stage,
+		Message: message, Location: location,
+	}
+	if diagnostic.Location == nil && defaultPath != "" && stage != stageEventValidation {
+		diagnostic.Location = sourceLocation(defaultPath, 1, 1)
+	}
+	if start := strings.Index(message, `job "`); start >= 0 {
+		rest := message[start+len(`job "`):]
+		if end := strings.Index(rest, `"`); end >= 0 {
+			diagnostic.Job = rest[:end]
+		}
+	}
+	if start := strings.Index(message, `action "`); start >= 0 {
+		rest := message[start+len(`action "`):]
+		if end := strings.Index(rest, `"`); end >= 0 {
+			diagnostic.Action = rest[:end]
+		}
+	}
+	return diagnostic
+}
+
+func sourceLocation(path string, line, column int) *compatibility.SourceLocation {
+	if line <= 0 {
+		line = 1
+	}
+	if column <= 0 {
+		column = 1
+	}
+	return &compatibility.SourceLocation{Path: path, Line: line, Column: column}
+}

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -110,7 +110,7 @@ func setInitialStageResults(report *compatibility.ProcessingReport, eventEvaluat
 			report.SetStage(stageEventValidation, compatibility.Passed)
 		}
 	}
-	blocked := workflowFailed || eventFailed
+	blocked := workflowFailed || eventFailed || failed[""]
 	for _, stage := range []string{stageGraph, stageMatrix, stageExpressions, stageDiscovery} {
 		if failed[stage] {
 			report.SetStage(stage, compatibility.Failed)
@@ -295,7 +295,7 @@ func diagnosticFromError(defaultPath, stage, code, category string, err error) c
 		diagnostic.Action = finding.Action
 		diagnostic.Step = finding.Step
 	}
-	if diagnostic.Location == nil && defaultPath != "" && stage != stageEventValidation {
+	if diagnostic.Location == nil && defaultPath != "" && stage != "" && stage != stageEventValidation {
 		diagnostic.Location = sourceLocation(defaultPath, 1, 1)
 	}
 	if diagnostic.Job == "" {

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -32,14 +32,22 @@ func initialProcessingReport(path, profile string, eventEvaluated bool, report c
 	out.Compile = compatibility.Stage{Result: "compilable", LogicalJobs: report.LogicalJobs, Instances: report.Instances}
 	out.Admission = compatibility.Stage{Result: compatibility.NotEvaluated}
 	for _, job := range report.ParsedJobs {
+		result := compatibility.Passed
+		if report.NotEvaluatedJobs[job.ID] {
+			result = compatibility.NotEvaluated
+		}
 		out.Jobs = append(out.Jobs, compatibility.JobResult{
-			ID: job.ID, Result: compatibility.Passed,
+			ID: job.ID, Result: result,
 			Location: sourceLocation(job.Path, job.Source.Start.Line, job.Source.Start.Column),
 		})
 	}
 	for _, instance := range report.Jobs {
+		result := compatibility.Passed
+		if report.NotEvaluatedInstances[instance.Key] {
+			result = compatibility.NotEvaluated
+		}
 		out.Jobs = append(out.Jobs, compatibility.JobResult{
-			ID: instance.LogicalJobID, Instance: instance.Key, Result: compatibility.Passed,
+			ID: instance.LogicalJobID, Instance: instance.Key, Result: result,
 			Location: sourceLocation(instance.SourcePath, instance.Source.Start.Line, instance.Source.Start.Column),
 		})
 		for i, step := range instance.Steps {
@@ -139,14 +147,21 @@ func environmentProcessingReport(path, profile, message string) compatibility.Pr
 }
 
 func eventInputProcessingReport(path, profile string, source []byte, message string) compatibility.ProcessingReport {
-	validation, validationErr := compiler.Validate(path, source)
-	report := initialProcessingReport(path, profile, false, validation, validationErr)
-	if validationErr != nil {
-		report.Result = "incompatible"
-	} else {
-		report.Result = "indeterminate"
-		report.Compile.Result = compatibility.NotEvaluated
+	parsed, parseErr := compiler.ParseWorkflow(path, source)
+	report := compatibility.NewProcessingReport(path, profile)
+	report.LogicalJobs = parsed.LogicalJobs
+	for _, job := range parsed.ParsedJobs {
+		report.Jobs = append(report.Jobs, compatibility.JobResult{
+			ID: job.ID, Result: compatibility.NotEvaluated,
+			Location: sourceLocation(job.Path, job.Source.Start.Line, job.Source.Start.Column),
+		})
 	}
+	if parseErr != nil {
+		addProcessingFailure(&report, path, stageWorkflowParsing, compiler.CodeWorkflowSyntax, "syntax", parseErr)
+	} else {
+		report.SetStage(stageWorkflowParsing, compatibility.Passed)
+	}
+	report.Result = "indeterminate"
 	addEnvironmentFailure(&report, message)
 	return report
 }

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -11,16 +11,16 @@ import (
 )
 
 const (
-	stageWorkflowParsing = "workflow-parsing"
-	stageEventValidation = "event-validation"
-	stageGraph           = "static-graph-construction"
-	stageMatrix          = "matrix-expansion"
-	stageExpressions     = "expression-validation"
-	stageDiscovery       = "action-discovery"
-	stageResolution      = "action-resolution"
-	stagePlans           = "job-plan-construction"
-	stageAdmission       = "hosted-profile-admission"
-	stagePipeline        = "pipeline-generation"
+	stageWorkflowParsing = string(compiler.StageWorkflowParsing)
+	stageEventValidation = string(compiler.StageEventValidation)
+	stageGraph           = string(compiler.StageGraph)
+	stageMatrix          = string(compiler.StageMatrix)
+	stageExpressions     = string(compiler.StageExpressions)
+	stageDiscovery       = string(compiler.StageDiscovery)
+	stageResolution      = string(compiler.StageResolution)
+	stagePlans           = string(compiler.StagePlans)
+	stageAdmission       = string(compiler.StageAdmission)
+	stagePipeline        = string(compiler.StagePipeline)
 )
 
 var locatedDiagnosticPattern = regexp.MustCompile(`^(.+):(\d+):(\d+): (.*)$`)
@@ -70,10 +70,7 @@ func initialProcessingReport(path, profile string, eventEvaluated bool, report c
 		out.Compile.Result = "incompatible"
 		failed := map[string]bool{}
 		for _, err := range flattenErrors(processingErr) {
-			stage, code, category := classifyProcessingError(err)
-			if len(report.ParsedJobs) == 0 && stage != stageEventValidation {
-				stage, category = stageWorkflowParsing, "syntax"
-			}
+			stage, code, category := processingErrorDetails(err, stageGraph, compiler.CodeGraphInvalid, "compatibility")
 			failed[stage] = true
 			out.Diagnostics = append(out.Diagnostics, diagnosticFromError(path, stage, code, category, err))
 		}
@@ -108,26 +105,13 @@ func setInitialStageResults(report *compatibility.ProcessingReport, eventEvaluat
 }
 
 func addProcessingFailure(report *compatibility.ProcessingReport, path, stage, code, category string, err error) {
-	report.SetStage(stage, compatibility.Failed)
-	if stage == stageResolution && category == "action-resolution" {
-		markActions(report, compatibility.Passed)
-	}
 	for _, item := range flattenErrors(err) {
-		diagnostic := diagnosticFromError(path, stage, code, category, item)
+		itemStage, itemCode, itemCategory := processingErrorDetails(item, stage, code, category)
+		report.SetStage(itemStage, compatibility.Failed)
+		diagnostic := diagnosticFromError(path, itemStage, itemCode, itemCategory, item)
 		report.Diagnostics = append(report.Diagnostics, diagnostic)
 	}
 	markFailedJobs(report)
-	for i := range report.Actions {
-		if stage != stageResolution {
-			continue
-		}
-		for _, diagnostic := range report.Diagnostics {
-			jobMatches := diagnostic.Job == "" || actionJobMatches(*report, report.Actions[i].Job, diagnostic.Job)
-			if jobMatches && ((diagnostic.Action != "" && diagnostic.Action == report.Actions[i].Reference) || (diagnostic.Action == "" && strings.Contains(diagnostic.Message, report.Actions[i].Reference))) {
-				report.Actions[i].Result = compatibility.Failed
-			}
-		}
-	}
 }
 
 func markFailedJobs(report *compatibility.ProcessingReport) {
@@ -141,64 +125,50 @@ func markFailedJobs(report *compatibility.ProcessingReport) {
 		if report.Jobs[i].Instance == "" && failed[report.Jobs[i].ID] {
 			report.Jobs[i].Result = compatibility.Failed
 		}
-	}
-}
-
-func actionJobMatches(report compatibility.ProcessingReport, instance, logical string) bool {
-	for _, job := range report.Jobs {
-		if job.Instance == instance {
-			return job.ID == logical
+		for _, diagnostic := range report.Diagnostics {
+			if diagnostic.Level == "error" && diagnostic.Stage == stagePlans && diagnostic.Instance == report.Jobs[i].Instance && diagnostic.Instance != "" {
+				report.Jobs[i].Result = compatibility.Failed
+			}
 		}
 	}
-	return false
 }
 
-func markActions(report *compatibility.ProcessingReport, result string) {
-	for i := range report.Actions {
-		report.Actions[i].Result = result
-	}
-}
-
-func allLocalActions(actions []compatibility.ActionResult) bool {
-	for _, action := range actions {
-		if !strings.HasPrefix(action.Reference, "./") {
-			return false
+func applyProcessingEvidence(report *compatibility.ProcessingReport, evidence compiler.ProcessingEvidence) {
+	resolutionFailed := false
+	for _, evaluation := range evidence.Actions {
+		if !evaluation.Passed {
+			resolutionFailed = true
+		}
+		for i := range report.Actions {
+			if report.Actions[i].Job != evaluation.Instance || report.Actions[i].Step != evaluation.Step || report.Actions[i].Reference != evaluation.Reference {
+				continue
+			}
+			if evaluation.Passed {
+				report.Actions[i].Result = compatibility.Passed
+			} else {
+				report.Actions[i].Result = compatibility.Failed
+			}
 		}
 	}
-	return true
-}
-
-func markLaterPrerequisites(report *compatibility.ProcessingReport, failedStage string, hosted bool) {
-	if failedStage == stagePlans || failedStage == stageAdmission || failedStage == stagePipeline {
+	if resolutionFailed {
+		report.SetStage(stageResolution, compatibility.Failed)
+	} else if evidence.ActionResolutionComplete {
 		report.SetStage(stageResolution, compatibility.Passed)
-		markActions(report, compatibility.Passed)
 	}
-	if failedStage == stageAdmission || failedStage == stagePipeline {
+	if evidence.PlansConstructed {
 		report.SetStage(stagePlans, compatibility.Passed)
 	}
-	if hosted && failedStage == stagePipeline {
-		report.SetStage(stageAdmission, compatibility.Passed)
-		report.Admission.Result = "admitted"
-	}
-}
-
-func laterProcessingFailure(err error) (stage, code, category string) {
-	message := strings.ToLower(err.Error())
-	switch {
-	case strings.Contains(message, "runner label"), strings.Contains(message, "untrusted event cannot"), strings.Contains(message, "runs-on"), strings.Contains(message, "condition"), strings.Contains(message, "expression"):
-		return stageExpressions, "E_COMPILE", "compatibility"
-	case strings.Contains(message, "emit buildkite pipeline"), strings.Contains(message, "pipeline requires"), strings.Contains(message, "invalid compiler step"):
-		return stagePipeline, "E_PIPELINE_GENERATION", "compatibility"
-	case strings.Contains(message, "action"), strings.Contains(message, "source store"), strings.Contains(message, "workflow path must identify a repository root"):
-		return stageResolution, "E_ACTION_RESOLUTION", "action-resolution"
-	default:
-		return stagePlans, "E_PLAN_CONSTRUCTION", "compatibility"
+	if evidence.PipelineGenerated {
+		report.SetStage(stagePipeline, compatibility.Passed)
 	}
 }
 
 func flattenErrors(err error) []error {
 	if err == nil {
 		return nil
+	}
+	if _, ok := err.(*compiler.ProcessingFinding); ok {
+		return []error{err}
 	}
 	if joined, ok := err.(interface{ Unwrap() []error }); ok {
 		var out []error
@@ -207,30 +177,34 @@ func flattenErrors(err error) []error {
 		}
 		return out
 	}
+	if wrapped, ok := err.(interface{ Unwrap() error }); ok {
+		nested := flattenErrors(wrapped.Unwrap())
+		for _, item := range nested {
+			if _, structured := item.(*compiler.ProcessingFinding); structured {
+				return nested
+			}
+		}
+	}
 	return []error{err}
 }
 
-func classifyProcessingError(err error) (stage, code, category string) {
-	message := strings.ToLower(err.Error())
-	switch {
-	case strings.Contains(message, "parse workflow yaml"), strings.Contains(message, "actionlint"), strings.Contains(message, "could not parse as yaml"), strings.Contains(message, "yaml syntax"):
-		return stageWorkflowParsing, "E_COMPILE", "syntax"
-	case strings.Contains(message, "event snapshot"):
-		return stageEventValidation, "E_COMPILE", "environment"
-	case strings.Contains(message, "matrix"):
-		return stageMatrix, "E_COMPILE", "compatibility"
-	case strings.Contains(message, "condition"), strings.Contains(message, "expression"), strings.Contains(message, "concurrency group"), strings.Contains(message, "runs-on"):
-		return stageExpressions, "E_COMPILE", "compatibility"
-	case strings.Contains(message, "needs unknown"), strings.Contains(message, "job graph"), strings.Contains(message, "reusable workflow"), strings.Contains(message, "flattened job"):
-		return stageGraph, "E_COMPILE", "compatibility"
-	default:
-		return stageGraph, "E_COMPILE", "compatibility"
+func processingErrorDetails(err error, fallbackStage, fallbackCode, fallbackCategory string) (stage, code, category string) {
+	if finding, ok := err.(*compiler.ProcessingFinding); ok {
+		return string(finding.Stage), finding.Code, finding.Category
 	}
+	return fallbackStage, fallbackCode, fallbackCategory
 }
 
 func diagnosticFromError(defaultPath, stage, code, category string, err error) compatibility.Diagnostic {
 	message := err.Error()
 	location := (*compatibility.SourceLocation)(nil)
+	var finding *compiler.ProcessingFinding
+	if structured, ok := err.(*compiler.ProcessingFinding); ok {
+		finding = structured
+		if finding.Path != "" {
+			location = sourceLocation(finding.Path, finding.Line, finding.Column)
+		}
+	}
 	if match := locatedDiagnosticPattern.FindStringSubmatch(message); match != nil {
 		line, lineErr := strconv.Atoi(match[2])
 		column, columnErr := strconv.Atoi(match[3])
@@ -243,19 +217,29 @@ func diagnosticFromError(defaultPath, stage, code, category string, err error) c
 		Level: "error", Code: code, Category: category, Stage: stage,
 		Message: message, Location: location,
 	}
+	if finding != nil {
+		diagnostic.Job = finding.Job
+		diagnostic.Instance = finding.Instance
+		diagnostic.Action = finding.Action
+		diagnostic.Step = finding.Step
+	}
 	if diagnostic.Location == nil && defaultPath != "" && stage != stageEventValidation {
 		diagnostic.Location = sourceLocation(defaultPath, 1, 1)
 	}
-	if start := strings.Index(message, `job "`); start >= 0 {
-		rest := message[start+len(`job "`):]
-		if end := strings.Index(rest, `"`); end >= 0 {
-			diagnostic.Job = rest[:end]
+	if diagnostic.Job == "" {
+		if start := strings.Index(message, `job "`); start >= 0 {
+			rest := message[start+len(`job "`):]
+			if end := strings.Index(rest, `"`); end >= 0 {
+				diagnostic.Job = rest[:end]
+			}
 		}
 	}
-	if start := strings.Index(message, `action "`); start >= 0 {
-		rest := message[start+len(`action "`):]
-		if end := strings.Index(rest, `"`); end >= 0 {
-			diagnostic.Action = rest[:end]
+	if diagnostic.Action == "" {
+		if start := strings.Index(message, `action "`); start >= 0 {
+			rest := message[start+len(`action "`):]
+			if end := strings.Index(rest, `"`); end >= 0 {
+				diagnostic.Action = rest[:end]
+			}
 		}
 	}
 	return diagnostic

--- a/internal/compatibility/report.go
+++ b/internal/compatibility/report.go
@@ -136,6 +136,12 @@ func (r *ProcessingReport) Finalize() {
 			r.Status = Passed
 		}
 	}
+	for _, diagnostic := range r.Diagnostics {
+		if diagnostic.Level == "error" {
+			r.Status = Failed
+			break
+		}
+	}
 	if r.Result == NotEvaluated {
 		r.Result = r.Status
 	}
@@ -214,7 +220,7 @@ func WriteProcessing(w io.Writer, format string, report ProcessingReport) error 
 	report.Finalize()
 	switch format {
 	case "text":
-		if _, err := fmt.Fprintf(w, "Schema: %s\nWorkflow: %s\nResult: %s\nStatus: %s\n", report.Schema, report.Workflow, report.Result, report.Status); err != nil {
+		if _, err := fmt.Fprintf(w, "Schema: %s\nWorkflow: %s\nResult: %s\nStatus: %s\nLogical jobs: %d\nInstances: %d\nCompile: %s\nAdmission: %s\n", report.Schema, report.Workflow, report.Result, report.Status, report.LogicalJobs, report.Instances, report.Compile.Result, report.Admission.Result); err != nil {
 			return err
 		}
 		if report.Profile != "" {

--- a/internal/compatibility/report.go
+++ b/internal/compatibility/report.go
@@ -40,7 +40,9 @@ type Diagnostic struct {
 	Message  string          `json:"message"`
 	Location *SourceLocation `json:"location,omitempty"`
 	Job      string          `json:"job,omitempty"`
+	Instance string          `json:"instance,omitempty"`
 	Action   string          `json:"action,omitempty"`
+	Step     int             `json:"step,omitempty"`
 }
 
 // ProcessingStage is one required workflow-processing boundary.
@@ -192,7 +194,7 @@ func compactDiagnostics(diagnostics []Diagnostic) []Diagnostic {
 	out := diagnostics[:1]
 	for _, diagnostic := range diagnostics[1:] {
 		previous := out[len(out)-1]
-		if previous.Level == diagnostic.Level && previous.Code == diagnostic.Code && previous.Category == diagnostic.Category && previous.Stage == diagnostic.Stage && previous.Message == diagnostic.Message && previous.Job == diagnostic.Job && previous.Action == diagnostic.Action && sameLocation(previous.Location, diagnostic.Location) {
+		if previous.Level == diagnostic.Level && previous.Code == diagnostic.Code && previous.Category == diagnostic.Category && previous.Stage == diagnostic.Stage && previous.Message == diagnostic.Message && previous.Job == diagnostic.Job && previous.Instance == diagnostic.Instance && previous.Action == diagnostic.Action && previous.Step == diagnostic.Step && sameLocation(previous.Location, diagnostic.Location) {
 			continue
 		}
 		out = append(out, diagnostic)
@@ -275,8 +277,14 @@ func textDiagnosticMetadata(diagnostic Diagnostic) string {
 	if diagnostic.Job != "" {
 		fields = append(fields, "job="+diagnostic.Job)
 	}
+	if diagnostic.Instance != "" {
+		fields = append(fields, "instance="+diagnostic.Instance)
+	}
 	if diagnostic.Action != "" {
 		fields = append(fields, "action="+diagnostic.Action)
+	}
+	if diagnostic.Step != 0 {
+		fields = append(fields, fmt.Sprintf("step=%d", diagnostic.Step))
 	}
 	if len(fields) == 0 {
 		return ""

--- a/internal/compatibility/report.go
+++ b/internal/compatibility/report.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
+	"strings"
 )
 
 const Schema = "buildkite-gha/compatibility-report/v1"
@@ -12,11 +14,281 @@ const Schema = "buildkite-gha/compatibility-report/v1"
 // ProfileSchema distinguishes static compilation from profile admission.
 const ProfileSchema = "buildkite-gha/compatibility-report/v2"
 
+// ProcessingSchema is the versioned, stage-oriented report shared by all
+// workflow-processing commands.
+const ProcessingSchema = "buildkite-gha/processing-report/v1"
+
+const (
+	Passed       = "passed"
+	Failed       = "failed"
+	NotEvaluated = "not-evaluated"
+)
+
+// SourceLocation identifies input without retaining any source or event data.
+type SourceLocation struct {
+	Path   string `json:"path"`
+	Line   int    `json:"line"`
+	Column int    `json:"column"`
+}
+
 // Diagnostic is one actionable compatibility finding.
 type Diagnostic struct {
-	Level   string `json:"level"`
-	Code    string `json:"code"`
-	Message string `json:"message"`
+	Level    string          `json:"level"`
+	Code     string          `json:"code"`
+	Category string          `json:"category,omitempty"`
+	Stage    string          `json:"stage,omitempty"`
+	Message  string          `json:"message"`
+	Location *SourceLocation `json:"location,omitempty"`
+	Job      string          `json:"job,omitempty"`
+	Action   string          `json:"action,omitempty"`
+}
+
+// ProcessingStage is one required workflow-processing boundary.
+type ProcessingStage struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Result string `json:"result"`
+}
+
+// JobResult retains successfully discovered logical jobs and matrix instances.
+type JobResult struct {
+	ID       string          `json:"id"`
+	Instance string          `json:"instance,omitempty"`
+	Result   string          `json:"result"`
+	Location *SourceLocation `json:"location,omitempty"`
+}
+
+// ActionResult retains action invocations without downloaded action contents.
+type ActionResult struct {
+	Reference string          `json:"reference"`
+	Job       string          `json:"job"`
+	Step      int             `json:"step"`
+	Result    string          `json:"result"`
+	Location  *SourceLocation `json:"location,omitempty"`
+}
+
+// ProcessingReport records all safely discoverable results. Artifacts are
+// deliberately excluded so reports cannot expose event or downloaded content.
+type ProcessingReport struct {
+	Schema      string            `json:"schema"`
+	Workflow    string            `json:"workflow"`
+	Profile     string            `json:"profile,omitempty"`
+	Result      string            `json:"result"`
+	Status      string            `json:"status"`
+	LogicalJobs int               `json:"logical_jobs"`
+	Instances   int               `json:"instances"`
+	Compile     Stage             `json:"compile,omitempty"`
+	Admission   Stage             `json:"admission,omitempty"`
+	Stages      []ProcessingStage `json:"stages"`
+	Jobs        []JobResult       `json:"jobs"`
+	Actions     []ActionResult    `json:"actions"`
+	Diagnostics []Diagnostic      `json:"diagnostics"`
+}
+
+var processingStages = []ProcessingStage{
+	{ID: "workflow-parsing", Name: "Workflow parsing"},
+	{ID: "event-validation", Name: "Event validation"},
+	{ID: "static-graph-construction", Name: "Static graph construction"},
+	{ID: "matrix-expansion", Name: "Matrix expansion"},
+	{ID: "expression-validation", Name: "Expression validation"},
+	{ID: "action-discovery", Name: "Local and public action discovery"},
+	{ID: "action-resolution", Name: "Immutable action resolution"},
+	{ID: "job-plan-construction", Name: "Job-plan construction"},
+	{ID: "hosted-profile-admission", Name: "Hosted-profile admission"},
+	{ID: "pipeline-generation", Name: "Pipeline generation"},
+}
+
+// NewProcessingReport returns a deterministic report with every stage present.
+func NewProcessingReport(workflow, profile string) ProcessingReport {
+	stages := append([]ProcessingStage(nil), processingStages...)
+	for i := range stages {
+		stages[i].Result = NotEvaluated
+	}
+	return ProcessingReport{
+		Schema: ProcessingSchema, Workflow: workflow, Profile: profile,
+		Result: NotEvaluated, Status: NotEvaluated, Stages: stages, Jobs: []JobResult{},
+		Actions: []ActionResult{}, Diagnostics: []Diagnostic{},
+		Compile: Stage{Result: NotEvaluated}, Admission: Stage{Result: NotEvaluated},
+	}
+}
+
+// SetStage records a stage outcome by stable ID.
+func (r *ProcessingReport) SetStage(id, result string) {
+	for i := range r.Stages {
+		if r.Stages[i].ID == id {
+			r.Stages[i].Result = result
+			return
+		}
+	}
+}
+
+// Finalize sorts entity results and derives the overall result.
+func (r *ProcessingReport) Finalize() {
+	r.Status = NotEvaluated
+	for _, stage := range r.Stages {
+		if stage.Result == Failed {
+			r.Status = Failed
+			break
+		}
+		if stage.Result == Passed {
+			r.Status = Passed
+		}
+	}
+	if r.Result == NotEvaluated {
+		r.Result = r.Status
+	}
+	sort.SliceStable(r.Jobs, func(i, j int) bool {
+		if r.Jobs[i].ID != r.Jobs[j].ID {
+			return r.Jobs[i].ID < r.Jobs[j].ID
+		}
+		return r.Jobs[i].Instance < r.Jobs[j].Instance
+	})
+	sort.SliceStable(r.Actions, func(i, j int) bool {
+		if r.Actions[i].Job != r.Actions[j].Job {
+			return r.Actions[i].Job < r.Actions[j].Job
+		}
+		if r.Actions[i].Step != r.Actions[j].Step {
+			return r.Actions[i].Step < r.Actions[j].Step
+		}
+		return r.Actions[i].Reference < r.Actions[j].Reference
+	})
+	stageOrder := make(map[string]int, len(processingStages))
+	for i, stage := range processingStages {
+		stageOrder[stage.ID] = i
+	}
+	sort.SliceStable(r.Diagnostics, func(i, j int) bool {
+		left, right := r.Diagnostics[i], r.Diagnostics[j]
+		if stageOrder[left.Stage] != stageOrder[right.Stage] {
+			return stageOrder[left.Stage] < stageOrder[right.Stage]
+		}
+		leftPath, rightPath, leftLine, rightLine, leftColumn, rightColumn := "", "", 0, 0, 0, 0
+		if left.Location != nil {
+			leftPath, leftLine, leftColumn = left.Location.Path, left.Location.Line, left.Location.Column
+		}
+		if right.Location != nil {
+			rightPath, rightLine, rightColumn = right.Location.Path, right.Location.Line, right.Location.Column
+		}
+		if leftPath != rightPath {
+			return leftPath < rightPath
+		}
+		if leftLine != rightLine {
+			return leftLine < rightLine
+		}
+		if leftColumn != rightColumn {
+			return leftColumn < rightColumn
+		}
+		if left.Code != right.Code {
+			return left.Code < right.Code
+		}
+		return left.Message < right.Message
+	})
+	r.Diagnostics = compactDiagnostics(r.Diagnostics)
+}
+
+func compactDiagnostics(diagnostics []Diagnostic) []Diagnostic {
+	if len(diagnostics) < 2 {
+		return diagnostics
+	}
+	out := diagnostics[:1]
+	for _, diagnostic := range diagnostics[1:] {
+		previous := out[len(out)-1]
+		if previous.Level == diagnostic.Level && previous.Code == diagnostic.Code && previous.Category == diagnostic.Category && previous.Stage == diagnostic.Stage && previous.Message == diagnostic.Message && previous.Job == diagnostic.Job && previous.Action == diagnostic.Action && sameLocation(previous.Location, diagnostic.Location) {
+			continue
+		}
+		out = append(out, diagnostic)
+	}
+	return out
+}
+
+func sameLocation(left, right *SourceLocation) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return *left == *right
+}
+
+// WriteProcessing renders the same fields in text or deterministic JSON.
+func WriteProcessing(w io.Writer, format string, report ProcessingReport) error {
+	report.Finalize()
+	switch format {
+	case "text":
+		if _, err := fmt.Fprintf(w, "Schema: %s\nWorkflow: %s\nResult: %s\nStatus: %s\n", report.Schema, report.Workflow, report.Result, report.Status); err != nil {
+			return err
+		}
+		if report.Profile != "" {
+			if _, err := fmt.Fprintf(w, "Profile: %s\n", report.Profile); err != nil {
+				return err
+			}
+		}
+		if report.Compile.Result == "compilable" {
+			if _, err := fmt.Fprintf(w, "✓ %d logical jobs and %d static instances compile\n", report.LogicalJobs, report.Instances); err != nil {
+				return err
+			}
+		}
+		for _, stage := range report.Stages {
+			if _, err := fmt.Fprintf(w, "- %s: %s\n", stage.Name, stage.Result); err != nil {
+				return err
+			}
+		}
+		for _, job := range report.Jobs {
+			name := job.ID
+			if job.Instance != "" {
+				name += "/" + job.Instance
+			}
+			if _, err := fmt.Fprintf(w, "  job %s: %s%s\n", name, job.Result, textLocation(job.Location)); err != nil {
+				return err
+			}
+		}
+		for _, action := range report.Actions {
+			if _, err := fmt.Fprintf(w, "  action %s (job %s, step %d): %s%s\n", action.Reference, action.Job, action.Step, action.Result, textLocation(action.Location)); err != nil {
+				return err
+			}
+		}
+		for _, diagnostic := range report.Diagnostics {
+			marker := "!"
+			if diagnostic.Level == "error" {
+				marker = "x"
+			}
+			if _, err := fmt.Fprintf(w, "%s [%s] %s%s%s\n", marker, diagnostic.Code, diagnostic.Message, textLocation(diagnostic.Location), textDiagnosticMetadata(diagnostic)); err != nil {
+				return err
+			}
+		}
+		return nil
+	case "json":
+		encoder := json.NewEncoder(w)
+		encoder.SetEscapeHTML(false)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(report)
+	default:
+		return fmt.Errorf("unsupported processing report format %q", format)
+	}
+}
+
+func textDiagnosticMetadata(diagnostic Diagnostic) string {
+	var fields []string
+	if diagnostic.Category != "" {
+		fields = append(fields, "category="+diagnostic.Category)
+	}
+	if diagnostic.Stage != "" {
+		fields = append(fields, "stage="+diagnostic.Stage)
+	}
+	if diagnostic.Job != "" {
+		fields = append(fields, "job="+diagnostic.Job)
+	}
+	if diagnostic.Action != "" {
+		fields = append(fields, "action="+diagnostic.Action)
+	}
+	if len(fields) == 0 {
+		return ""
+	}
+	return " {" + strings.Join(fields, ", ") + "}"
+}
+
+func textLocation(location *SourceLocation) string {
+	if location == nil {
+		return ""
+	}
+	return fmt.Sprintf(" (%s:%d:%d)", location.Path, location.Line, location.Column)
 }
 
 // Report describes whether a workflow can enter the static compiler.

--- a/internal/compatibility/report_test.go
+++ b/internal/compatibility/report_test.go
@@ -110,6 +110,9 @@ func TestWriteProfileReportsStagesWithoutOverclaimingRuntime(t *testing.T) {
 
 func TestProcessingReportContainsEveryStableStageInTextAndJSON(t *testing.T) {
 	report := NewProcessingReport("ci.yml", "hosted-tokenless")
+	report.LogicalJobs = 1
+	report.Instances = 1
+	report.Compile.Result = "incompatible"
 	for _, stage := range report.Stages[:6] {
 		report.SetStage(stage.ID, Passed)
 	}
@@ -168,6 +171,10 @@ func TestProcessingReportContainsEveryStableStageInTextAndJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, want := range []string{
+		"Logical jobs: 1",
+		"Instances: 1",
+		"Compile: incompatible",
+		"Admission: not-evaluated",
 		"Workflow parsing: passed",
 		"Immutable action resolution: failed",
 		"Job-plan construction: not-evaluated",

--- a/internal/compatibility/report_test.go
+++ b/internal/compatibility/report_test.go
@@ -4,8 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
 func TestWriteReports(t *testing.T) {
@@ -101,5 +105,80 @@ func TestWriteProfileReportsStagesWithoutOverclaimingRuntime(t *testing.T) {
 	}
 	if err := WriteProfile(&bytes.Buffer{}, "yaml", Admitted("ci.yml", "hosted-tokenless", 1, 1, false)); err == nil {
 		t.Fatal("WriteProfile() accepted unknown format")
+	}
+}
+
+func TestProcessingReportContainsEveryStableStageInTextAndJSON(t *testing.T) {
+	report := NewProcessingReport("ci.yml", "hosted-tokenless")
+	for _, stage := range report.Stages[:6] {
+		report.SetStage(stage.ID, Passed)
+	}
+	report.SetStage("action-resolution", Failed)
+	report.Result = "indeterminate"
+	report.Jobs = append(report.Jobs, JobResult{ID: "test", Instance: "gha-test", Result: Passed})
+	report.Actions = append(report.Actions, ActionResult{Reference: "./.github/actions/test", Job: "gha-test", Step: 1, Result: Failed})
+	report.Diagnostics = append(report.Diagnostics, Diagnostic{
+		Level: "error", Code: "E_ACTION_RESOLUTION", Category: "action-resolution",
+		Stage: "action-resolution", Message: "action metadata is invalid",
+		Location: &SourceLocation{Path: "ci.yml", Line: 8, Column: 9},
+	})
+
+	var encoded bytes.Buffer
+	if err := WriteProcessing(&encoded, "json", report); err != nil {
+		t.Fatal(err)
+	}
+	var decoded ProcessingReport
+	if err := json.Unmarshal(encoded.Bytes(), &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Schema != ProcessingSchema || len(decoded.Stages) != 10 || decoded.Status != Failed {
+		t.Fatalf("decoded report = %#v", decoded)
+	}
+	schemaSource, err := os.ReadFile(filepath.Join("..", "..", "schemas", "processing-report-v1.schema.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var schemaDocument any
+	if err := json.Unmarshal(schemaSource, &schemaDocument); err != nil {
+		t.Fatal(err)
+	}
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource("processing-report-v1.schema.json", schemaDocument); err != nil {
+		t.Fatal(err)
+	}
+	schema, err := compiler.Compile("processing-report-v1.schema.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document any
+	if err := json.Unmarshal(encoded.Bytes(), &document); err != nil {
+		t.Fatal(err)
+	}
+	if err := schema.Validate(document); err != nil {
+		t.Fatalf("processing report does not satisfy schema: %v", err)
+	}
+	for _, result := range []string{Passed, Failed, NotEvaluated} {
+		if !strings.Contains(encoded.String(), `"result": "`+result+`"`) {
+			t.Fatalf("JSON report does not contain stage result %q: %s", result, encoded.String())
+		}
+	}
+
+	var rendered bytes.Buffer
+	if err := WriteProcessing(&rendered, "text", report); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"Workflow parsing: passed",
+		"Immutable action resolution: failed",
+		"Job-plan construction: not-evaluated",
+		"action ./.github/actions/test (job gha-test, step 1): failed",
+		"[E_ACTION_RESOLUTION] action metadata is invalid",
+	} {
+		if !strings.Contains(rendered.String(), want) {
+			t.Fatalf("text report = %q, want %q", rendered.String(), want)
+		}
+	}
+	if err := WriteProcessing(&bytes.Buffer{}, "yaml", report); err == nil {
+		t.Fatal("WriteProcessing() accepted unknown format")
 	}
 }

--- a/internal/compatibility/report_test.go
+++ b/internal/compatibility/report_test.go
@@ -119,7 +119,7 @@ func TestProcessingReportContainsEveryStableStageInTextAndJSON(t *testing.T) {
 	report.Actions = append(report.Actions, ActionResult{Reference: "./.github/actions/test", Job: "gha-test", Step: 1, Result: Failed})
 	report.Diagnostics = append(report.Diagnostics, Diagnostic{
 		Level: "error", Code: "E_ACTION_RESOLUTION", Category: "action-resolution",
-		Stage: "action-resolution", Message: "action metadata is invalid",
+		Stage: "action-resolution", Message: "action metadata is invalid", Job: "test", Instance: "gha-test", Action: "./.github/actions/test", Step: 1,
 		Location: &SourceLocation{Path: "ci.yml", Line: 8, Column: 9},
 	})
 
@@ -173,6 +173,7 @@ func TestProcessingReportContainsEveryStableStageInTextAndJSON(t *testing.T) {
 		"Job-plan construction: not-evaluated",
 		"action ./.github/actions/test (job gha-test, step 1): failed",
 		"[E_ACTION_RESOLUTION] action metadata is invalid",
+		"instance=gha-test, action=./.github/actions/test, step=1",
 	} {
 		if !strings.Contains(rendered.String(), want) {
 			t.Fatalf("text report = %q, want %q", rendered.String(), want)

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path"
 	"path/filepath"
@@ -79,6 +80,28 @@ type actionCompilation struct {
 
 type actionRequirements struct {
 	githubToken bool
+}
+
+// validateActionResolutions resolves each independent root invocation before
+// plan construction. It deliberately aggregates failures while sharing one
+// immutable source snapshot; no plan can be emitted unless every root passes.
+func validateActionResolutions(ctx context.Context, ir IR, options Options) error {
+	actionSource := newMemoizedActionSource(options.ActionSource)
+	var diagnostics []error
+	for _, instance := range ir.Jobs {
+		for i, step := range instance.Steps {
+			if step.Kind != "uses" || (!options.ResolveActions && !strings.HasPrefix(step.Uses, "./")) {
+				continue
+			}
+			_, err := compileActionInvocations(ctx, instance.RepositoryRoot, actionSource, []string{step.Uses}, []map[string]string{step.With})
+			if err == nil {
+				continue
+			}
+			position := step.Span.Start
+			diagnostics = append(diagnostics, fmt.Errorf("%s:%d:%d: job %q action %q at step %d: %w", instance.SourcePath, position.Line, position.Column, instance.LogicalJobID, step.Uses, i+1, err))
+		}
+	}
+	return errors.Join(diagnostics...)
 }
 
 // compileActionLocks builds one shared action DAG for all roots. Selectors are

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -85,23 +85,35 @@ type actionRequirements struct {
 // validateActionResolutions resolves each independent root invocation before
 // plan construction. It deliberately aggregates failures while sharing one
 // immutable source snapshot; no plan can be emitted unless every root passes.
-func validateActionResolutions(ctx context.Context, ir IR, options Options) error {
+func validateActionResolutions(ctx context.Context, ir IR, options Options) (ProcessingEvidence, error) {
 	actionSource := newMemoizedActionSource(options.ActionSource)
+	evidence := ProcessingEvidence{ActionResolutionComplete: true}
 	var diagnostics []error
 	for _, instance := range ir.Jobs {
 		for i, step := range instance.Steps {
-			if step.Kind != "uses" || (!options.ResolveActions && !strings.HasPrefix(step.Uses, "./")) {
+			if step.Kind != "uses" {
+				continue
+			}
+			if !options.ResolveActions && !strings.HasPrefix(step.Uses, "./") {
+				evidence.ActionResolutionComplete = false
 				continue
 			}
 			_, err := compileActionInvocations(ctx, instance.RepositoryRoot, actionSource, []string{step.Uses}, []map[string]string{step.With})
+			evaluation := ActionEvaluation{Instance: instance.Key, Job: instance.LogicalJobID, Reference: step.Uses, Step: i + 1, Passed: err == nil}
+			evidence.Actions = append(evidence.Actions, evaluation)
 			if err == nil {
 				continue
 			}
 			position := step.Span.Start
-			diagnostics = append(diagnostics, fmt.Errorf("%s:%d:%d: job %q action %q at step %d: %w", instance.SourcePath, position.Line, position.Column, instance.LogicalJobID, step.Uses, i+1, err))
+			diagnostics = append(diagnostics, &ProcessingFinding{
+				Stage: StageResolution, Code: CodeActionResolution, Category: "action-resolution",
+				Path: instance.SourcePath, Line: position.Line, Column: position.Column,
+				Job: instance.LogicalJobID, Instance: instance.Key, Action: step.Uses, Step: i + 1,
+				Err: fmt.Errorf("%s:%d:%d: job %q action %q at step %d: %w", instance.SourcePath, position.Line, position.Column, instance.LogicalJobID, step.Uses, i+1, err),
+			})
 		}
 	}
-	return errors.Join(diagnostics...)
+	return evidence, errors.Join(diagnostics...)
 }
 
 // compileActionLocks builds one shared action DAG for all roots. Selectors are

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -109,7 +109,8 @@ func validateActionResolutions(ctx context.Context, ir IR, options Options) (Pro
 				Stage: StageResolution, Code: CodeActionResolution, Category: "action-resolution",
 				Path: instance.SourcePath, Line: position.Line, Column: position.Column,
 				Job: instance.LogicalJobID, Instance: instance.Key, Action: step.Uses, Step: i + 1,
-				Err: fmt.Errorf("%s:%d:%d: job %q action %q at step %d: %w", instance.SourcePath, position.Line, position.Column, instance.LogicalJobID, step.Uses, i+1, err),
+				Message: "action could not be resolved or validated",
+				Err:     fmt.Errorf("%s:%d:%d: job %q action %q at step %d: %w", instance.SourcePath, position.Line, position.Column, instance.LogicalJobID, step.Uses, i+1, err),
 			})
 		}
 	}

--- a/internal/compiler/bundle.go
+++ b/internal/compiler/bundle.go
@@ -32,9 +32,10 @@ type PlanAuthorization struct {
 
 // Bundle is the complete deterministic output of static compilation.
 type Bundle struct {
-	IR       IR
-	Plans    []PlanArtifact
-	Pipeline []byte
+	IR         IR
+	Plans      []PlanArtifact
+	Pipeline   []byte
+	Processing ProcessingEvidence
 }
 
 // CompileBundle compiles an unattested event snapshot with the fail-closed
@@ -73,34 +74,38 @@ func CompileBundlePlansContext(ctx context.Context, path string, source, eventSo
 		return Bundle{IR: ir}, err
 	}
 	options.ActionSource = newMemoizedActionSource(options.ActionSource)
-	if err := validateActionResolutions(ctx, ir, options); err != nil {
-		return Bundle{IR: ir}, err
+	evidence, err := validateActionResolutions(ctx, ir, options)
+	bundle := Bundle{IR: ir, Processing: evidence}
+	if err != nil {
+		return bundle, err
 	}
 	plans, authorizations, err := compilePlansWithAuthorization(ctx, ir, compilerVersion, compilerDistributionDigest, options)
 	if err != nil {
-		return Bundle{IR: ir}, err
+		return bundle, processingFinding(StagePlans, CodePlanConstruction, "compatibility", err)
 	}
 	if len(plans) != len(ir.Jobs) || len(authorizations) != len(plans) {
-		return Bundle{}, fmt.Errorf("compiler produced %d plans and %d authorizations for %d job instances", len(plans), len(authorizations), len(ir.Jobs))
+		return bundle, processingFinding(StagePlans, CodePlanConstruction, "compatibility", fmt.Errorf("compiler produced %d plans and %d authorizations for %d job instances", len(plans), len(authorizations), len(ir.Jobs)))
 	}
 
 	artifacts := make([]PlanArtifact, len(plans))
 	for i, job := range plans {
 		if job.Target.StepKey != ir.Jobs[i].Key || job.Target.Queue != ir.Jobs[i].Queue {
-			return Bundle{}, fmt.Errorf("plan %d target %q/%q does not match job instance %q/%q", i, job.Target.StepKey, job.Target.Queue, ir.Jobs[i].Key, ir.Jobs[i].Queue)
+			return bundle, processingFinding(StagePlans, CodePlanConstruction, "compatibility", fmt.Errorf("plan %d target %q/%q does not match job instance %q/%q", i, job.Target.StepKey, job.Target.Queue, ir.Jobs[i].Key, ir.Jobs[i].Queue))
 		}
 		contents, err := plan.Encode(job)
 		if err != nil {
-			return Bundle{}, fmt.Errorf("encode plan for job %q: %w", job.Workflow.LogicalJobID, err)
+			return bundle, &ProcessingFinding{Stage: StagePlans, Code: CodePlanConstruction, Category: "compatibility", Job: job.Workflow.LogicalJobID, Instance: ir.Jobs[i].Key, Err: fmt.Errorf("encode plan for job %q: %w", job.Workflow.LogicalJobID, err)}
 		}
 		digest := transport.Digest(contents)
 		planPath, err := buildkitepipeline.PlanPath(digest)
 		if err != nil {
-			return Bundle{}, fmt.Errorf("locate plan for job %q: %w", job.Workflow.LogicalJobID, err)
+			return bundle, &ProcessingFinding{Stage: StagePlans, Code: CodePlanConstruction, Category: "compatibility", Job: job.Workflow.LogicalJobID, Instance: ir.Jobs[i].Key, Err: fmt.Errorf("locate plan for job %q: %w", job.Workflow.LogicalJobID, err)}
 		}
 		artifacts[i] = PlanArtifact{Job: job, Digest: digest, Path: planPath, Contents: contents, Authorization: authorizations[i]}
 	}
-	return Bundle{IR: ir, Plans: artifacts}, nil
+	bundle.Plans = artifacts
+	bundle.Processing.PlansConstructed = true
+	return bundle, nil
 }
 
 // GenerateBundlePipeline emits pipeline bytes only after plan construction and
@@ -108,7 +113,7 @@ func CompileBundlePlansContext(ctx context.Context, path string, source, eventSo
 func GenerateBundlePipeline(bundle Bundle, compilerDistributionDigest, compilerStep string, options Options) (Bundle, error) {
 	ir, artifacts := bundle.IR, bundle.Plans
 	if len(artifacts) != len(ir.Jobs) {
-		return bundle, fmt.Errorf("compiler has %d plans for %d job instances", len(artifacts), len(ir.Jobs))
+		return bundle, processingFinding(StagePipeline, CodePipelineGeneration, "compatibility", fmt.Errorf("compiler has %d plans for %d job instances", len(artifacts), len(ir.Jobs)))
 	}
 	jobs := make([]buildkitepipeline.Job, len(artifacts))
 	for i, artifact := range artifacts {
@@ -145,9 +150,10 @@ func GenerateBundlePipeline(bundle Bundle, compilerDistributionDigest, compilerS
 		Jobs:               jobs,
 	})
 	if err != nil {
-		return bundle, fmt.Errorf("emit Buildkite pipeline: %w", err)
+		return bundle, processingFinding(StagePipeline, CodePipelineGeneration, "compatibility", fmt.Errorf("emit Buildkite pipeline: %w", err))
 	}
 	bundle.Pipeline = pipeline
+	bundle.Processing.PipelineGenerated = true
 	return bundle, nil
 }
 

--- a/internal/compiler/bundle.go
+++ b/internal/compiler/bundle.go
@@ -79,9 +79,10 @@ func CompileBundlePlansContext(ctx context.Context, path string, source, eventSo
 	if err != nil {
 		return bundle, err
 	}
-	plans, authorizations, err := compilePlansWithAuthorization(ctx, ir, compilerVersion, compilerDistributionDigest, options)
+	plans, authorizations, planEvaluations, err := compilePlansWithAuthorization(ctx, ir, compilerVersion, compilerDistributionDigest, options)
+	bundle.Processing.Plans = planEvaluations
 	if err != nil {
-		return bundle, processingFinding(StagePlans, CodePlanConstruction, "compatibility", err)
+		return bundle, err
 	}
 	if len(plans) != len(ir.Jobs) || len(authorizations) != len(plans) {
 		return bundle, processingFinding(StagePlans, CodePlanConstruction, "compatibility", fmt.Errorf("compiler produced %d plans and %d authorizations for %d job instances", len(plans), len(authorizations), len(ir.Jobs)))

--- a/internal/compiler/bundle.go
+++ b/internal/compiler/bundle.go
@@ -52,6 +52,16 @@ func CompileBundleWithOptions(path string, source, eventSource []byte, compilerV
 // CompileBundleContext produces a complete bundle and permits cancellation
 // while compilation resolves immutable public action source.
 func CompileBundleContext(ctx context.Context, path string, source, eventSource []byte, compilerVersion, compilerDistributionDigest, compilerStep string, options Options) (Bundle, error) {
+	bundle, err := CompileBundlePlansContext(ctx, path, source, eventSource, compilerVersion, compilerDistributionDigest, options)
+	if err != nil {
+		return bundle, err
+	}
+	return GenerateBundlePipeline(bundle, compilerDistributionDigest, compilerStep, options)
+}
+
+// CompileBundlePlansContext constructs every immutable plan but deliberately
+// stops before pipeline generation so callers can apply admission policy.
+func CompileBundlePlansContext(ctx context.Context, path string, source, eventSource []byte, compilerVersion, compilerDistributionDigest string, options Options) (Bundle, error) {
 	if compilerVersion == "" {
 		return Bundle{}, fmt.Errorf("compiler version is required")
 	}
@@ -60,18 +70,21 @@ func CompileBundleContext(ctx context.Context, path string, source, eventSource 
 	}
 	ir, err := compile(path, source, eventSource, options)
 	if err != nil {
-		return Bundle{}, err
+		return Bundle{IR: ir}, err
+	}
+	options.ActionSource = newMemoizedActionSource(options.ActionSource)
+	if err := validateActionResolutions(ctx, ir, options); err != nil {
+		return Bundle{IR: ir}, err
 	}
 	plans, authorizations, err := compilePlansWithAuthorization(ctx, ir, compilerVersion, compilerDistributionDigest, options)
 	if err != nil {
-		return Bundle{}, err
+		return Bundle{IR: ir}, err
 	}
 	if len(plans) != len(ir.Jobs) || len(authorizations) != len(plans) {
 		return Bundle{}, fmt.Errorf("compiler produced %d plans and %d authorizations for %d job instances", len(plans), len(authorizations), len(ir.Jobs))
 	}
 
 	artifacts := make([]PlanArtifact, len(plans))
-	jobs := make([]buildkitepipeline.Job, len(plans))
 	for i, job := range plans {
 		if job.Target.StepKey != ir.Jobs[i].Key || job.Target.Queue != ir.Jobs[i].Queue {
 			return Bundle{}, fmt.Errorf("plan %d target %q/%q does not match job instance %q/%q", i, job.Target.StepKey, job.Target.Queue, ir.Jobs[i].Key, ir.Jobs[i].Queue)
@@ -86,11 +99,25 @@ func CompileBundleContext(ctx context.Context, path string, source, eventSource 
 			return Bundle{}, fmt.Errorf("locate plan for job %q: %w", job.Workflow.LogicalJobID, err)
 		}
 		artifacts[i] = PlanArtifact{Job: job, Digest: digest, Path: planPath, Contents: contents, Authorization: authorizations[i]}
+	}
+	return Bundle{IR: ir, Plans: artifacts}, nil
+}
+
+// GenerateBundlePipeline emits pipeline bytes only after plan construction and
+// any caller-owned admission stage have succeeded.
+func GenerateBundlePipeline(bundle Bundle, compilerDistributionDigest, compilerStep string, options Options) (Bundle, error) {
+	ir, artifacts := bundle.IR, bundle.Plans
+	if len(artifacts) != len(ir.Jobs) {
+		return bundle, fmt.Errorf("compiler has %d plans for %d job instances", len(artifacts), len(ir.Jobs))
+	}
+	jobs := make([]buildkitepipeline.Job, len(artifacts))
+	for i, artifact := range artifacts {
+		job := artifact.Job
 		jobs[i] = buildkitepipeline.Job{
 			Key:          ir.Jobs[i].Key,
 			Label:        ir.Jobs[i].Label,
 			Queue:        ir.Jobs[i].Queue,
-			PlanDigest:   digest,
+			PlanDigest:   artifact.Digest,
 			Dependencies: append([]string(nil), ir.Jobs[i].Needs...),
 			RequiresMise: job.NeedsMise(),
 		}
@@ -118,9 +145,10 @@ func CompileBundleContext(ctx context.Context, path string, source, eventSource 
 		Jobs:               jobs,
 	})
 	if err != nil {
-		return Bundle{}, fmt.Errorf("emit Buildkite pipeline: %w", err)
+		return bundle, fmt.Errorf("emit Buildkite pipeline: %w", err)
 	}
-	return Bundle{IR: ir, Plans: artifacts, Pipeline: pipeline}, nil
+	bundle.Pipeline = pipeline
+	return bundle, nil
 }
 
 func buildkiteConcurrencyGroup(repository Repository, group string) string {

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -2,6 +2,7 @@ package compiler
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -52,6 +53,23 @@ func TestCompileBundleGoldenAndDeterministic(t *testing.T) {
 	wantPlans := readFile(t, filepath.Join("testdata", "shell.plans.golden.json"))
 	if !bytes.Equal(encodeGoldenPlans(t, first.Plans), wantPlans) {
 		t.Fatalf("plans changed; update shell.plans.golden.json intentionally")
+	}
+}
+
+func TestBundlePlansPermitAdmissionBeforePipelineGeneration(t *testing.T) {
+	path := smokePath(".github", "workflows", "shell.yml")
+	options := defaultOptions()
+	bundle, err := CompileBundlePlansContext(context.Background(), path, readFile(t, path), readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bundle.Plans) != 3 || len(bundle.Pipeline) != 0 {
+		t.Fatalf("plan-stage bundle has %d plans and %d pipeline bytes", len(bundle.Plans), len(bundle.Pipeline))
+	}
+	options.RuntimeImage = "mutable:latest"
+	failed, err := GenerateBundlePipeline(bundle, testDistributionDigest, "gha-importer", options)
+	if err == nil || len(failed.Pipeline) != 0 || len(failed.Plans) != 3 {
+		t.Fatalf("pipeline generation = %d bytes, %d plans, %v", len(failed.Pipeline), len(failed.Plans), err)
 	}
 }
 

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -152,7 +152,7 @@ func parsedJobs(path string, parsed *workflow.Workflow) []ParsedJob {
 func Validate(path string, source []byte) (Report, error) {
 	parsed, err := workflow.Parse(path, source)
 	if err != nil {
-		return Report{}, err
+		return Report{}, processingFinding(StageWorkflowParsing, CodeWorkflowSyntax, "syntax", err)
 	}
 	options := defaultOptions()
 	event := Event{
@@ -163,6 +163,7 @@ func Validate(path string, source []byte) (Report, error) {
 	}
 	context := compileContext(event, nil, path, parsed.Name)
 	_, concurrencyErr := resolveConcurrency(path, "", parsed.Concurrency, context, nil)
+	concurrencyErr = processingFinding(StageExpressions, CodeExpressionInvalid, "compatibility", concurrencyErr)
 	instances, expandErr := expand(path, source, parsed, context, options)
 	if err := errors.Join(concurrencyErr, expandErr); err != nil {
 		return Report{LogicalJobs: len(parsed.Jobs), Instances: len(instances), Jobs: instances, ParsedJobs: parsedJobs(path, parsed), Warnings: compilerWarnings(parsed.Concurrency)}, err
@@ -179,10 +180,12 @@ func ValidateEvent(path string, source, eventSource []byte) (Report, error) {
 // runner policy without producing compiler output.
 func ValidateEventWithOptions(path string, source, eventSource []byte, options Options) (Report, error) {
 	if err := options.validate(); err != nil {
-		return Report{}, err
+		return Report{}, processingFinding(StageExpressions, CodeExpressionInvalid, "environment", err)
 	}
 	parsed, parseErr := workflow.Parse(path, source)
+	parseErr = processingFinding(StageWorkflowParsing, CodeWorkflowSyntax, "syntax", parseErr)
 	event, eventErr := parseEvent(eventSource)
+	eventErr = processingFinding(StageEventValidation, CodeEventInvalid, "environment", eventErr)
 	if parseErr != nil || eventErr != nil {
 		if parsed == nil {
 			return Report{}, errors.Join(parseErr, eventErr)
@@ -192,6 +195,7 @@ func ValidateEventWithOptions(path string, source, eventSource []byte, options O
 	event.Trust = options.EventTrust
 	context := compileContext(event, options.Vars.snapshot(), path, parsed.Name)
 	_, concurrencyErr := resolveConcurrency(path, "", parsed.Concurrency, context, nil)
+	concurrencyErr = processingFinding(StageExpressions, CodeExpressionInvalid, "compatibility", concurrencyErr)
 	instances, expandErr := expand(path, source, parsed, context, options)
 	if err := errors.Join(concurrencyErr, expandErr); err != nil {
 		return Report{LogicalJobs: len(parsed.Jobs), Instances: len(instances), Jobs: instances, ParsedJobs: parsedJobs(path, parsed), Warnings: compilerWarnings(parsed.Concurrency)}, err
@@ -330,7 +334,7 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 		if lockActions && len(actionRefs) != 0 {
 			compiledActions, err := compileActionInvocations(ctx, instance.RepositoryRoot, actionSource, actionRefs, actionInputs)
 			if err != nil {
-				return nil, nil, fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err)
+				return nil, nil, planConstructionFinding(instance, fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err))
 			}
 			selectors := compiledActions.selectors
 			locks := compiledActions.locks
@@ -346,13 +350,13 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 				steps[stepIndex].Action = &plan.ActionSelector{Lock: selector.Lock}
 				lock, ok := locksByID[selector.Lock]
 				if !ok {
-					return nil, nil, fmt.Errorf("build plan for job %q: action lock %q is missing", instance.LogicalJobID, selector.Lock)
+					return nil, nil, planConstructionFinding(instance, fmt.Errorf("build plan for job %q: action lock %q is missing", instance.LogicalJobID, selector.Lock))
 				}
 				descriptor, _ := actionintegration.Lookup(actionintegration.Identity{Source: lock.Source, Repository: lock.Repository, Path: lock.Path})
 				if descriptor.Adapter == actionintegration.AdapterCheckoutExactEventSHA {
 					if err := actionintegration.ValidateCheckoutInputs(instance.Steps[stepIndex].With, ir.Event.Repository.Owner+"/"+ir.Event.Repository.Name, ir.Event.SHA); err != nil {
 						span := instance.Steps[stepIndex].Span.Start
-						return nil, nil, fmt.Errorf("%s:%d:%d: checkout adapter: %w", instance.SourcePath, span.Line, span.Column, err)
+						return nil, nil, planConstructionFinding(instance, fmt.Errorf("%s:%d:%d: checkout adapter: %w", instance.SourcePath, span.Line, span.Column, err))
 					}
 					capabilities = append(capabilities, "provider-token-read")
 					authorization.ProviderTokenReadCapabilitySources = append(authorization.ProviderTokenReadCapabilitySources, "checkout-adapter")
@@ -360,17 +364,17 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 				if descriptor.Adapter == actionintegration.AdapterUploadArtifactBuildkite {
 					if err := actionintegration.ValidateUploadArtifactInputs(lock.Commit, instance.Steps[stepIndex].With); err != nil {
 						span := instance.Steps[stepIndex].Span.Start
-						return nil, nil, fmt.Errorf("%s:%d:%d: bounded upload-artifact adapter: %w", instance.SourcePath, span.Line, span.Column, err)
+						return nil, nil, planConstructionFinding(instance, fmt.Errorf("%s:%d:%d: bounded upload-artifact adapter: %w", instance.SourcePath, span.Line, span.Column, err))
 					}
 				}
 				if descriptor.Adapter == actionintegration.AdapterDownloadArtifactBuildkite {
 					if err := actionintegration.ValidateDownloadArtifactInputs(lock.Commit, instance.Steps[stepIndex].With); err != nil {
 						span := instance.Steps[stepIndex].Span.Start
-						return nil, nil, fmt.Errorf("%s:%d:%d: bounded download-artifact adapter: %w", instance.SourcePath, span.Line, span.Column, err)
+						return nil, nil, planConstructionFinding(instance, fmt.Errorf("%s:%d:%d: bounded download-artifact adapter: %w", instance.SourcePath, span.Line, span.Column, err))
 					}
 					if len(instance.NeedGroups) == 0 {
 						span := instance.Steps[stepIndex].Span.Start
-						return nil, nil, fmt.Errorf("%s:%d:%d: bounded download-artifact adapter requires at least one direct needs producer", instance.SourcePath, span.Line, span.Column)
+						return nil, nil, planConstructionFinding(instance, fmt.Errorf("%s:%d:%d: bounded download-artifact adapter requires at least one direct needs producer", instance.SourcePath, span.Line, span.Column))
 					}
 				}
 			}
@@ -388,12 +392,12 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 			var err error
 			capabilities, err = requiredCapabilities(instance.RepositoryRoot, instance.SourcePath, instance.Steps)
 			if err != nil {
-				return nil, nil, fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err)
+				return nil, nil, planConstructionFinding(instance, fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err))
 			}
 		}
 		if instance.Container != nil || len(instance.Services) != 0 {
 			if len(actionRefs) != 0 && !lockActions {
-				return nil, nil, fmt.Errorf("build plan for job %q: containers with remote actions require action resolution through upload or profile validation", instance.LogicalJobID)
+				return nil, nil, planConstructionFinding(instance, fmt.Errorf("build plan for job %q: containers with remote actions require action resolution through upload or profile validation", instance.LogicalJobID))
 			}
 			if jobSchema != plan.SchemaV7 {
 				jobSchema = plan.SchemaV4
@@ -413,12 +417,12 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 		for _, logicalNeed := range sortedKeys(instance.NeedGroups) {
 			dependencies := instance.NeedGroups[logicalNeed]
 			if len(dependencies) > plan.MaxNeedProducers {
-				return nil, nil, fmt.Errorf("build plan for job %q: prerequisite %q has %d producers, maximum is %d", instance.LogicalJobID, logicalNeed, len(dependencies), plan.MaxNeedProducers)
+				return nil, nil, planConstructionFinding(instance, fmt.Errorf("build plan for job %q: prerequisite %q has %d producers, maximum is %d", instance.LogicalJobID, logicalNeed, len(dependencies), plan.MaxNeedProducers))
 			}
 			for _, dependency := range dependencies {
 				digest, ok := planDigests[dependency]
 				if !ok {
-					return nil, nil, fmt.Errorf("build plan for job %q: prerequisite %q has no earlier plan digest", instance.LogicalJobID, dependency)
+					return nil, nil, planConstructionFinding(instance, fmt.Errorf("build plan for job %q: prerequisite %q has no earlier plan digest", instance.LogicalJobID, dependency))
 				}
 				needSources[logicalNeed] = append(needSources[logicalNeed], plan.NeedSource{StepKey: dependency, PlanDigest: digest})
 			}
@@ -441,7 +445,7 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 		}
 		secrets, err := requiredSecrets(instance)
 		if err != nil {
-			return nil, nil, fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err)
+			return nil, nil, planConstructionFinding(instance, fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err))
 		}
 		var githubToken *plan.GitHubToken
 		referencesGitHubTokenSecret := slices.Contains(secrets, "GITHUB_TOKEN")
@@ -454,7 +458,7 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 				if referencesGitHubTokenSecret {
 					reference = "secrets.GITHUB_TOKEN"
 				}
-				return nil, nil, fmt.Errorf("%s:%d:%d: job %q references %s but has no effective permissions", instance.SourcePath, instance.Source.Start.Line, instance.Source.Start.Column, instance.LogicalJobID, reference)
+				return nil, nil, planConstructionFinding(instance, fmt.Errorf("%s:%d:%d: job %q references %s but has no effective permissions", instance.SourcePath, instance.Source.Start.Line, instance.Source.Start.Column, instance.LogicalJobID, reference))
 			}
 			permissions := make(map[string]string, len(instance.Permissions))
 			for name, access := range instance.Permissions {
@@ -521,11 +525,11 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 			job.Services[service.Name] = plan.Container{Image: service.Container.Image, Env: cloneMap(service.Container.Env), Ports: append([]string(nil), service.Container.Ports...)}
 		}
 		if err := job.Validate(); err != nil {
-			return nil, nil, fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err)
+			return nil, nil, planConstructionFinding(instance, fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err))
 		}
 		encoded, err := plan.Encode(job)
 		if err != nil {
-			return nil, nil, fmt.Errorf("encode plan for job %q: %w", instance.LogicalJobID, err)
+			return nil, nil, planConstructionFinding(instance, fmt.Errorf("encode plan for job %q: %w", instance.LogicalJobID, err))
 		}
 		digest := sha256.Sum256(encoded)
 		planDigests[instance.Key] = "sha256:" + hex.EncodeToString(digest[:])
@@ -533,6 +537,14 @@ func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, 
 		authorizations = append(authorizations, authorization)
 	}
 	return plans, authorizations, nil
+}
+
+func planConstructionFinding(instance JobInstance, err error) error {
+	return &ProcessingFinding{
+		Stage: StagePlans, Code: CodePlanConstruction, Category: "compatibility",
+		Path: instance.SourcePath, Line: instance.Source.Start.Line, Column: instance.Source.Start.Column,
+		Job: instance.LogicalJobID, Instance: instance.Key, Err: err,
+	}
 }
 
 func requiredSecrets(instance JobInstance) ([]string, error) {
@@ -590,20 +602,21 @@ func planSpan(span workflow.Span) plan.Span {
 
 func compile(path string, source, eventSource []byte, options Options) (IR, error) {
 	if err := options.validate(); err != nil {
-		return IR{}, err
+		return IR{}, processingFinding(StageExpressions, CodeExpressionInvalid, "environment", err)
 	}
 	parsed, err := workflow.Parse(path, source)
 	if err != nil {
-		return IR{}, err
+		return IR{}, processingFinding(StageWorkflowParsing, CodeWorkflowSyntax, "syntax", err)
 	}
 	event, err := parseEvent(eventSource)
 	if err != nil {
-		return IR{}, err
+		return IR{}, processingFinding(StageEventValidation, CodeEventInvalid, "environment", err)
 	}
 	event.Trust = options.EventTrust
 	vars := options.Vars.snapshot()
 	context := compileContext(event, vars, path, parsed.Name)
 	workflowConcurrencyGroup, concurrencyErr := resolveConcurrency(path, "", parsed.Concurrency, context, nil)
+	concurrencyErr = processingFinding(StageExpressions, CodeExpressionInvalid, "compatibility", concurrencyErr)
 	jobs, expandErr := expand(path, source, parsed, context, options)
 	digest := sha256.Sum256(source)
 	ir := IR{
@@ -707,7 +720,7 @@ func canonicalWorkflowName(path string) string {
 func expand(path string, source []byte, parsed *workflow.Workflow, context expression.CompileContext, options Options) ([]JobInstance, error) {
 	resolved, err := resolveReusableWorkflows(path, source, parsed)
 	if err != nil {
-		return nil, err
+		return nil, processingFinding(StageGraph, CodeGraphInvalid, "compatibility", err)
 	}
 	jobs := make(map[string]workflow.Job, len(resolved))
 	sourcePaths := make(map[string]string, len(resolved))
@@ -718,7 +731,7 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 	for _, sourced := range resolved {
 		job := sourced.Job
 		if _, exists := jobs[job.ID]; exists {
-			diagnostics = append(diagnostics, jobError(sourced.path, job, fmt.Sprintf("flattened job id %q collides with another job", job.ID)))
+			diagnostics = append(diagnostics, attributedProcessingFinding(StageGraph, CodeGraphInvalid, "compatibility", sourced.path, 0, 0, job.ID, "", "", 0, jobError(sourced.path, job, fmt.Sprintf("flattened job id %q collides with another job", job.ID))))
 			continue
 		}
 		jobs[job.ID] = job
@@ -732,7 +745,7 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 	}
 	order, err := topologicalOrder(path, jobs)
 	if err != nil {
-		diagnostics = append(diagnostics, err)
+		diagnostics = append(diagnostics, processingFinding(StageGraph, CodeGraphInvalid, "compatibility", err))
 		order = sortedKeys(jobs)
 	}
 
@@ -742,7 +755,7 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 		job := jobs[id]
 		matrices, matrixErr := expandMatrix(sourcePaths[id], job, context)
 		if matrixErr != nil {
-			diagnostics = append(diagnostics, matrixErr)
+			diagnostics = append(diagnostics, attributedProcessingFinding(StageMatrix, CodeMatrixInvalid, "compatibility", sourcePaths[id], 0, 0, job.ID, "", "", 0, matrixErr))
 			failedMatrices[id] = true
 			continue
 		}
@@ -761,22 +774,22 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 		concurrencyGroups := make(map[string]struct{}, len(matrices))
 		for _, matrix := range matrices {
 			if err := supportedConditions(jobPath, job, matrix, true); err != nil {
-				diagnostics = append(diagnostics, err)
+				diagnostics = append(diagnostics, attributedProcessingFinding(StageExpressions, CodeExpressionInvalid, "compatibility", jobPath, 0, 0, job.ID, "", "", 0, err))
 				continue
 			}
 			labels, err := resolveRunsOn(job, context, matrix)
 			if err != nil {
-				diagnostics = append(diagnostics, locatedJobError(jobPath, job, runsOnPosition(job).Line, runsOnPosition(job).Column, err.Error()))
+				diagnostics = append(diagnostics, attributedProcessingFinding(StageExpressions, CodeExpressionInvalid, "compatibility", jobPath, runsOnPosition(job).Line, runsOnPosition(job).Column, job.ID, "", "", 0, locatedJobError(jobPath, job, runsOnPosition(job).Line, runsOnPosition(job).Column, err.Error())))
 				continue
 			}
 			queue, err := options.Runners.resolve(labels, options.EventTrust)
 			if err != nil {
-				diagnostics = append(diagnostics, locatedJobError(jobPath, job, runsOnPosition(job).Line, runsOnPosition(job).Column, err.Error()))
+				diagnostics = append(diagnostics, attributedProcessingFinding(StageExpressions, CodeExpressionInvalid, "compatibility", jobPath, runsOnPosition(job).Line, runsOnPosition(job).Column, job.ID, "", "", 0, locatedJobError(jobPath, job, runsOnPosition(job).Line, runsOnPosition(job).Column, err.Error())))
 				continue
 			}
 			concurrencyGroup, err := resolveConcurrency(jobPath, job.ID, job.Concurrency, context, matrix)
 			if err != nil {
-				diagnostics = append(diagnostics, err)
+				diagnostics = append(diagnostics, attributedProcessingFinding(StageExpressions, CodeExpressionInvalid, "compatibility", jobPath, 0, 0, job.ID, "", "", 0, err))
 				continue
 			}
 			if concurrencyGroup != "" {
@@ -784,11 +797,11 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 			}
 			key, err := instanceKey(job.ID, matrix)
 			if err != nil {
-				diagnostics = append(diagnostics, jobError(jobPath, job, fmt.Sprintf("create deterministic instance key: %v", err)))
+				diagnostics = append(diagnostics, attributedProcessingFinding(StageMatrix, CodeMatrixInvalid, "compatibility", jobPath, 0, 0, job.ID, "", "", 0, jobError(jobPath, job, fmt.Sprintf("create deterministic instance key: %v", err))))
 				continue
 			}
 			if existingJob, exists := instanceKeys[key]; exists {
-				diagnostics = append(diagnostics, jobError(jobPath, job, fmt.Sprintf("deterministic instance key %q collides with another instance from job %q", key, existingJob)))
+				diagnostics = append(diagnostics, attributedProcessingFinding(StageMatrix, CodeMatrixInvalid, "compatibility", jobPath, 0, 0, job.ID, "", "", 0, jobError(jobPath, job, fmt.Sprintf("deterministic instance key %q collides with another instance from job %q", key, existingJob))))
 				continue
 			}
 			instanceKeys[key] = job.ID
@@ -827,7 +840,7 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 				}
 				sort.Strings(members)
 				if len(members) == 0 {
-					diagnostics = append(diagnostics, jobError(jobPath, job, fmt.Sprintf("prerequisite %q has no expanded instances", need)))
+					diagnostics = append(diagnostics, attributedProcessingFinding(StageGraph, CodeGraphInvalid, "compatibility", jobPath, 0, 0, job.ID, "", "", 0, jobError(jobPath, job, fmt.Sprintf("prerequisite %q has no expanded instances", need))))
 					continue
 				}
 				if instance.NeedGroups == nil {
@@ -843,11 +856,11 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 					for _, output := range binding.outputs {
 						producers := byLogicalID[output.member]
 						if len(producers) == 0 {
-							diagnostics = append(diagnostics, fmt.Errorf("%s:%d:%d: workflow_call output %q selects unexpanded job %q", output.path, output.span.Start.Line, output.span.Start.Column, output.name, output.member))
+							diagnostics = append(diagnostics, processingFinding(StageGraph, CodeGraphInvalid, "compatibility", fmt.Errorf("%s:%d:%d: workflow_call output %q selects unexpanded job %q", output.path, output.span.Start.Line, output.span.Start.Column, output.name, output.member)))
 							continue
 						}
 						if len(projected)+len(producers) > plan.MaxNeedOutputs {
-							diagnostics = append(diagnostics, fmt.Errorf("%s:%d:%d: workflow_call output %q expands call projections beyond the maximum of %d", output.path, output.span.Start.Line, output.span.Start.Column, output.name, plan.MaxNeedOutputs))
+							diagnostics = append(diagnostics, processingFinding(StageGraph, CodeGraphInvalid, "compatibility", fmt.Errorf("%s:%d:%d: workflow_call output %q expands call projections beyond the maximum of %d", output.path, output.span.Start.Line, output.span.Start.Column, output.name, plan.MaxNeedOutputs)))
 							continue
 						}
 						for _, producer := range producers {
@@ -872,7 +885,7 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 		}
 		if job.MaxParallel != nil && len(concurrencyGroups) > 1 {
 			position := job.Concurrency.Span.Start
-			diagnostics = append(diagnostics, locatedJobError(jobPath, job, position.Line, position.Column, "concurrency groups that vary by matrix cannot be combined with strategy.max-parallel"))
+			diagnostics = append(diagnostics, attributedProcessingFinding(StageExpressions, CodeExpressionInvalid, "compatibility", jobPath, position.Line, position.Column, job.ID, "", "", 0, locatedJobError(jobPath, job, position.Line, position.Column, "concurrency groups that vary by matrix cannot be combined with strategy.max-parallel")))
 		}
 	}
 
@@ -918,17 +931,17 @@ func permissionScopes(permissions *workflow.Permissions) map[string]string {
 
 func supported(path string, job workflow.Job) error {
 	if job.Reusable != nil {
-		return jobError(path, job, "internal error: unresolved reusable-workflow job")
+		return attributedProcessingFinding(StageGraph, CodeGraphInvalid, "compatibility", path, 0, 0, job.ID, "", "", 0, jobError(path, job, "internal error: unresolved reusable-workflow job"))
 	}
 	if len(job.RunsOn) == 0 && job.RunsOnExpr == nil {
-		return jobError(path, job, "runs-on must resolve statically")
+		return attributedProcessingFinding(StageExpressions, CodeExpressionInvalid, "compatibility", path, 0, 0, job.ID, "", "", 0, jobError(path, job, "runs-on must resolve statically"))
 	}
 	ids := make(map[string]struct{}, len(job.Steps))
 	for _, step := range job.Steps {
 		if step.ID != "" {
 			id := strings.ToLower(step.ID)
 			if _, exists := ids[id]; exists {
-				return locatedJobError(path, job, step.Span.Start.Line, step.Span.Start.Column, fmt.Sprintf("duplicate step id %q", step.ID))
+				return attributedProcessingFinding(StageGraph, CodeGraphInvalid, "compatibility", path, step.Span.Start.Line, step.Span.Start.Column, job.ID, "", "", 0, locatedJobError(path, job, step.Span.Start.Line, step.Span.Start.Column, fmt.Sprintf("duplicate step id %q", step.ID)))
 			}
 			ids[id] = struct{}{}
 		}

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -125,11 +125,13 @@ type NeedOutput struct {
 
 // Report summarizes successful workflow validation.
 type Report struct {
-	LogicalJobs int
-	Instances   int
-	Warnings    []Warning
-	Jobs        []JobInstance
-	ParsedJobs  []ParsedJob
+	LogicalJobs           int
+	Instances             int
+	Warnings              []Warning
+	Jobs                  []JobInstance
+	ParsedJobs            []ParsedJob
+	NotEvaluatedJobs      map[string]bool
+	NotEvaluatedInstances map[string]bool
 }
 
 // ParsedJob is the source identity retained before expansion succeeds.
@@ -140,9 +142,11 @@ type ParsedJob struct {
 }
 
 type expansionResult struct {
-	instances  []JobInstance
-	candidates []JobInstance
-	jobs       []ParsedJob
+	instances             []JobInstance
+	candidates            []JobInstance
+	jobs                  []ParsedJob
+	notEvaluatedJobs      map[string]bool
+	notEvaluatedInstances map[string]bool
 }
 
 func parsedJobs(path string, parsed *workflow.Workflow) []ParsedJob {
@@ -169,6 +173,24 @@ func processingJobs(path string, parsed *workflow.Workflow, resolved []sourcedJo
 	return jobs
 }
 
+// ParseWorkflow reports only event-independent workflow syntax and job
+// identities. Later stages deliberately remain unevaluated.
+func ParseWorkflow(path string, source []byte) (Report, error) {
+	parsed, err := workflow.Parse(path, source)
+	if err != nil {
+		return Report{}, processingFinding(StageWorkflowParsing, CodeWorkflowSyntax, "syntax", err)
+	}
+	return Report{LogicalJobs: len(parsed.Jobs), ParsedJobs: parsedJobs(path, parsed), Warnings: compilerWarnings(parsed.Concurrency)}, nil
+}
+
+func expansionReport(expanded expansionResult, warnings []Warning) Report {
+	return Report{
+		LogicalJobs: len(expanded.jobs), Instances: len(expanded.candidates),
+		Jobs: expanded.candidates, ParsedJobs: expanded.jobs, Warnings: warnings,
+		NotEvaluatedJobs: expanded.notEvaluatedJobs, NotEvaluatedInstances: expanded.notEvaluatedInstances,
+	}
+}
+
 // Validate parses and validates the supported static graph without requiring an
 // event snapshot.
 func Validate(path string, source []byte) (Report, error) {
@@ -188,9 +210,9 @@ func Validate(path string, source []byte) (Report, error) {
 	concurrencyErr = processingFinding(StageExpressions, CodeExpressionInvalid, "compatibility", concurrencyErr)
 	expanded, expandErr := expand(path, source, parsed, context, options)
 	if err := errors.Join(concurrencyErr, expandErr); err != nil {
-		return Report{LogicalJobs: len(expanded.jobs), Instances: len(expanded.candidates), Jobs: expanded.candidates, ParsedJobs: expanded.jobs, Warnings: compilerWarnings(parsed.Concurrency)}, err
+		return expansionReport(expanded, compilerWarnings(parsed.Concurrency)), err
 	}
-	return Report{LogicalJobs: len(expanded.jobs), Instances: len(expanded.candidates), Jobs: expanded.candidates, ParsedJobs: expanded.jobs, Warnings: compilerWarnings(parsed.Concurrency)}, nil
+	return expansionReport(expanded, compilerWarnings(parsed.Concurrency)), nil
 }
 
 // ValidateEvent validates both the supported static graph and its event input.
@@ -220,9 +242,9 @@ func ValidateEventWithOptions(path string, source, eventSource []byte, options O
 	concurrencyErr = processingFinding(StageExpressions, CodeExpressionInvalid, "compatibility", concurrencyErr)
 	expanded, expandErr := expand(path, source, parsed, context, options)
 	if err := errors.Join(concurrencyErr, expandErr); err != nil {
-		return Report{LogicalJobs: len(expanded.jobs), Instances: len(expanded.candidates), Jobs: expanded.candidates, ParsedJobs: expanded.jobs, Warnings: compilerWarnings(parsed.Concurrency)}, err
+		return expansionReport(expanded, compilerWarnings(parsed.Concurrency)), err
 	}
-	return Report{LogicalJobs: len(expanded.jobs), Instances: len(expanded.candidates), Jobs: expanded.candidates, ParsedJobs: expanded.jobs, Warnings: compilerWarnings(parsed.Concurrency)}, nil
+	return expansionReport(expanded, compilerWarnings(parsed.Concurrency)), nil
 }
 
 // Compile parses a workflow and event, expands its static graph, and returns
@@ -774,13 +796,17 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 	if err != nil {
 		return expansionResult{jobs: parsedJobs(path, parsed)}, processingFinding(StageGraph, CodeGraphInvalid, "compatibility", err)
 	}
-	result := expansionResult{jobs: processingJobs(path, parsed, resolved)}
+	result := expansionResult{
+		jobs:             processingJobs(path, parsed, resolved),
+		notEvaluatedJobs: make(map[string]bool), notEvaluatedInstances: make(map[string]bool),
+	}
 	jobs := make(map[string]workflow.Job, len(resolved))
 	sourcePaths := make(map[string]string, len(resolved))
 	sourceDigests := make(map[string]string, len(resolved))
 	sourceRoots := make(map[string]string, len(resolved))
 	needBindings := make(map[string]map[string]needBinding, len(resolved))
 	var diagnostics []error
+	failedJobs := make(map[string]bool, len(resolved))
 	for _, sourced := range resolved {
 		job := sourced.Job
 		if _, exists := jobs[job.ID]; exists {
@@ -794,6 +820,7 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 		needBindings[job.ID] = sourced.needBindings
 		if err := supported(sourced.path, job); err != nil {
 			diagnostics = append(diagnostics, err)
+			failedJobs[job.ID] = true
 		}
 	}
 	order, err := topologicalOrder(path, jobs)
@@ -810,6 +837,7 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 		if matrixErr != nil {
 			diagnostics = append(diagnostics, attributedProcessingFinding(StageMatrix, CodeMatrixInvalid, "compatibility", sourcePaths[id], 0, 0, job.ID, "", "", 0, matrixErr))
 			failedMatrices[id] = true
+			failedJobs[id] = true
 			continue
 		}
 		matricesByJob[id] = matrices
@@ -823,16 +851,27 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 		if failedMatrices[id] {
 			continue
 		}
+		jobBlocked := false
+		for _, binding := range needBindings[id] {
+			for _, member := range binding.members {
+				if failedJobs[member] {
+					jobBlocked = true
+				}
+			}
+		}
+		jobFailed := failedJobs[id]
 		matrices := matricesByJob[id]
 		concurrencyGroups := make(map[string]struct{}, len(matrices))
 		for _, matrix := range matrices {
 			key, err := instanceKey(job.ID, matrix)
 			if err != nil {
 				diagnostics = append(diagnostics, attributedProcessingFinding(StageMatrix, CodeMatrixInvalid, "compatibility", jobPath, 0, 0, job.ID, "", "", 0, jobError(jobPath, job, fmt.Sprintf("create deterministic instance key: %v", err))))
+				jobFailed = true
 				continue
 			}
 			if existingJob, exists := instanceKeys[key]; exists {
 				diagnostics = append(diagnostics, attributedProcessingFinding(StageMatrix, CodeMatrixInvalid, "compatibility", jobPath, 0, 0, job.ID, "", "", 0, jobError(jobPath, job, fmt.Sprintf("deterministic instance key %q collides with another instance from job %q", key, existingJob))))
+				jobFailed = true
 				continue
 			}
 			instanceKeys[key] = job.ID
@@ -892,6 +931,12 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 				concurrencyGroups[canonicalConcurrencyGroup(concurrencyGroup)] = struct{}{}
 			}
 			if !valid {
+				jobFailed = true
+				continue
+			}
+			if jobBlocked {
+				result.notEvaluatedJobs[id] = true
+				result.notEvaluatedInstances[key] = true
 				continue
 			}
 			instance := candidate
@@ -899,6 +944,7 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 			instance.RunsOn = labels
 			instance.Queue = queue
 			instance.ConcurrencyGroup = concurrencyGroup
+			dependencyFailed := false
 			for _, need := range sortedKeys(needBindings[id]) {
 				binding := needBindings[id][need]
 				var members []string
@@ -909,8 +955,9 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 				}
 				sort.Strings(members)
 				if len(members) == 0 {
-					diagnostics = append(diagnostics, attributedProcessingFinding(StageGraph, CodeGraphInvalid, "compatibility", jobPath, 0, 0, job.ID, "", "", 0, jobError(jobPath, job, fmt.Sprintf("prerequisite %q has no expanded instances", need))))
-					continue
+					diagnostics = append(diagnostics, attributedProcessingFinding(StageGraph, CodeGraphInvalid, "compatibility", jobPath, 0, 0, job.ID, key, "", 0, jobError(jobPath, job, fmt.Sprintf("prerequisite %q has no expanded instances", need))))
+					dependencyFailed = true
+					break
 				}
 				if instance.NeedGroups == nil {
 					instance.NeedGroups = make(map[string][]string, len(needBindings[id]))
@@ -948,6 +995,10 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 					instance.NeedOutputs[need] = projected
 				}
 			}
+			if dependencyFailed {
+				jobFailed = true
+				continue
+			}
 			sort.Strings(instance.Needs)
 			instance.Needs = slices.Compact(instance.Needs)
 			byLogicalID[id] = append(byLogicalID[id], instance)
@@ -955,7 +1006,9 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 		if job.MaxParallel != nil && len(concurrencyGroups) > 1 {
 			position := job.Concurrency.Span.Start
 			diagnostics = append(diagnostics, attributedProcessingFinding(StageExpressions, CodeExpressionInvalid, "compatibility", jobPath, position.Line, position.Column, job.ID, "", "", 0, locatedJobError(jobPath, job, position.Line, position.Column, "concurrency groups that vary by matrix cannot be combined with strategy.max-parallel")))
+			jobFailed = true
 		}
+		failedJobs[id] = jobFailed || jobBlocked
 	}
 
 	var instances []JobInstance

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -808,7 +808,11 @@ func canonicalWorkflowName(path string) string {
 func expand(path string, source []byte, parsed *workflow.Workflow, context expression.CompileContext, options Options) (expansionResult, error) {
 	resolved, err := resolveReusableWorkflows(path, source, parsed)
 	if err != nil {
-		return expansionResult{jobs: parsedJobs(path, parsed)}, processingFinding(StageGraph, CodeGraphInvalid, "compatibility", err)
+		notEvaluatedJobs := make(map[string]bool, len(parsed.Jobs))
+		for _, job := range parsed.Jobs {
+			notEvaluatedJobs[job.ID] = true
+		}
+		return expansionResult{jobs: parsedJobs(path, parsed), notEvaluatedJobs: notEvaluatedJobs}, processingFinding(StageGraph, CodeGraphInvalid, "compatibility", err)
 	}
 	result := expansionResult{
 		jobs:             processingJobs(path, parsed, resolved),

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -223,18 +223,29 @@ func ValidateEvent(path string, source, eventSource []byte) (Report, error) {
 // ValidateEventWithOptions validates the graph against explicit variables and
 // runner policy without producing compiler output.
 func ValidateEventWithOptions(path string, source, eventSource []byte, options Options) (Report, error) {
+	var optionsErr error
 	if err := options.validate(); err != nil {
-		return Report{}, processingFinding(StageExpressions, CodeExpressionInvalid, "environment", err)
+		optionsErr = &ProcessingFinding{
+			Code: CodeEnvironment, Category: "environment",
+			Message: "workflow-processing configuration is invalid", Err: err,
+		}
 	}
 	parsed, parseErr := workflow.Parse(path, source)
 	parseErr = processingFinding(StageWorkflowParsing, CodeWorkflowSyntax, "syntax", parseErr)
 	event, eventErr := parseEvent(eventSource)
 	eventErr = processingFinding(StageEventValidation, CodeEventInvalid, "environment", eventErr)
-	if parseErr != nil || eventErr != nil {
+	if parseErr != nil || eventErr != nil || optionsErr != nil {
 		if parsed == nil {
-			return Report{}, errors.Join(parseErr, eventErr)
+			return Report{}, errors.Join(parseErr, eventErr, optionsErr)
 		}
-		return Report{LogicalJobs: len(parsed.Jobs), ParsedJobs: parsedJobs(path, parsed), Warnings: compilerWarnings(parsed.Concurrency)}, errors.Join(parseErr, eventErr)
+		notEvaluatedJobs := make(map[string]bool, len(parsed.Jobs))
+		for _, job := range parsed.Jobs {
+			notEvaluatedJobs[job.ID] = true
+		}
+		return Report{
+			LogicalJobs: len(parsed.Jobs), ParsedJobs: parsedJobs(path, parsed),
+			Warnings: compilerWarnings(parsed.Concurrency), NotEvaluatedJobs: notEvaluatedJobs,
+		}, errors.Join(parseErr, eventErr, optionsErr)
 	}
 	event.Trust = options.EventTrust
 	context := compileContext(event, options.Vars.snapshot(), path, parsed.Name)
@@ -676,7 +687,10 @@ func planSpan(span workflow.Span) plan.Span {
 
 func compile(path string, source, eventSource []byte, options Options) (IR, error) {
 	if err := options.validate(); err != nil {
-		return IR{}, processingFinding(StageExpressions, CodeExpressionInvalid, "environment", err)
+		return IR{}, &ProcessingFinding{
+			Code: CodeEnvironment, Category: "environment",
+			Message: "workflow-processing configuration is invalid", Err: err,
+		}
 	}
 	parsed, err := workflow.Parse(path, source)
 	if err != nil {
@@ -835,7 +849,15 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 		job := jobs[id]
 		matrices, matrixErr := expandMatrix(sourcePaths[id], job, context)
 		if matrixErr != nil {
-			diagnostics = append(diagnostics, attributedProcessingFinding(StageMatrix, CodeMatrixInvalid, "compatibility", sourcePaths[id], 0, 0, job.ID, "", "", 0, matrixErr))
+			line, column := job.Span.Start.Line, job.Span.Start.Column
+			if job.Matrix != nil {
+				line, column = job.Matrix.Span.Start.Line, job.Matrix.Span.Start.Column
+			}
+			diagnostics = append(diagnostics, &ProcessingFinding{
+				Stage: StageMatrix, Code: CodeMatrixInvalid, Category: "compatibility",
+				Path: sourcePaths[id], Line: line, Column: column, Job: job.ID,
+				Message: "matrix could not be expanded or validated", Err: matrixErr,
+			})
 			failedMatrices[id] = true
 			failedJobs[id] = true
 			continue

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -127,6 +128,23 @@ type Report struct {
 	LogicalJobs int
 	Instances   int
 	Warnings    []Warning
+	Jobs        []JobInstance
+	ParsedJobs  []ParsedJob
+}
+
+// ParsedJob is the source identity retained before expansion succeeds.
+type ParsedJob struct {
+	ID     string
+	Path   string
+	Source workflow.Span
+}
+
+func parsedJobs(path string, parsed *workflow.Workflow) []ParsedJob {
+	jobs := make([]ParsedJob, len(parsed.Jobs))
+	for i, job := range parsed.Jobs {
+		jobs[i] = ParsedJob{ID: job.ID, Path: path, Source: job.Span}
+	}
+	return jobs
 }
 
 // Validate parses and validates the supported static graph without requiring an
@@ -144,14 +162,12 @@ func Validate(path string, source []byte) (Report, error) {
 		Payload: map[string]any{},
 	}
 	context := compileContext(event, nil, path, parsed.Name)
-	if _, err := resolveConcurrency(path, "", parsed.Concurrency, context, nil); err != nil {
-		return Report{}, err
+	_, concurrencyErr := resolveConcurrency(path, "", parsed.Concurrency, context, nil)
+	instances, expandErr := expand(path, source, parsed, context, options)
+	if err := errors.Join(concurrencyErr, expandErr); err != nil {
+		return Report{LogicalJobs: len(parsed.Jobs), Instances: len(instances), Jobs: instances, ParsedJobs: parsedJobs(path, parsed), Warnings: compilerWarnings(parsed.Concurrency)}, err
 	}
-	instances, err := expand(path, source, parsed, context, options)
-	if err != nil {
-		return Report{}, err
-	}
-	return Report{LogicalJobs: len(parsed.Jobs), Instances: len(instances), Warnings: compilerWarnings(parsed.Concurrency)}, nil
+	return Report{LogicalJobs: len(parsed.Jobs), Instances: len(instances), Jobs: instances, ParsedJobs: parsedJobs(path, parsed), Warnings: compilerWarnings(parsed.Concurrency)}, nil
 }
 
 // ValidateEvent validates both the supported static graph and its event input.
@@ -165,24 +181,22 @@ func ValidateEventWithOptions(path string, source, eventSource []byte, options O
 	if err := options.validate(); err != nil {
 		return Report{}, err
 	}
-	parsed, err := workflow.Parse(path, source)
-	if err != nil {
-		return Report{}, err
-	}
-	event, err := parseEvent(eventSource)
-	if err != nil {
-		return Report{}, err
+	parsed, parseErr := workflow.Parse(path, source)
+	event, eventErr := parseEvent(eventSource)
+	if parseErr != nil || eventErr != nil {
+		if parsed == nil {
+			return Report{}, errors.Join(parseErr, eventErr)
+		}
+		return Report{LogicalJobs: len(parsed.Jobs), ParsedJobs: parsedJobs(path, parsed), Warnings: compilerWarnings(parsed.Concurrency)}, errors.Join(parseErr, eventErr)
 	}
 	event.Trust = options.EventTrust
 	context := compileContext(event, options.Vars.snapshot(), path, parsed.Name)
-	if _, err := resolveConcurrency(path, "", parsed.Concurrency, context, nil); err != nil {
-		return Report{}, err
+	_, concurrencyErr := resolveConcurrency(path, "", parsed.Concurrency, context, nil)
+	instances, expandErr := expand(path, source, parsed, context, options)
+	if err := errors.Join(concurrencyErr, expandErr); err != nil {
+		return Report{LogicalJobs: len(parsed.Jobs), Instances: len(instances), Jobs: instances, ParsedJobs: parsedJobs(path, parsed), Warnings: compilerWarnings(parsed.Concurrency)}, err
 	}
-	instances, err := expand(path, source, parsed, context, options)
-	if err != nil {
-		return Report{}, err
-	}
-	return Report{LogicalJobs: len(parsed.Jobs), Instances: len(instances), Warnings: compilerWarnings(parsed.Concurrency)}, nil
+	return Report{LogicalJobs: len(parsed.Jobs), Instances: len(instances), Jobs: instances, ParsedJobs: parsedJobs(path, parsed), Warnings: compilerWarnings(parsed.Concurrency)}, nil
 }
 
 // Compile parses a workflow and event, expands its static graph, and returns
@@ -589,16 +603,10 @@ func compile(path string, source, eventSource []byte, options Options) (IR, erro
 	event.Trust = options.EventTrust
 	vars := options.Vars.snapshot()
 	context := compileContext(event, vars, path, parsed.Name)
-	workflowConcurrencyGroup, err := resolveConcurrency(path, "", parsed.Concurrency, context, nil)
-	if err != nil {
-		return IR{}, err
-	}
-	jobs, err := expand(path, source, parsed, context, options)
-	if err != nil {
-		return IR{}, err
-	}
+	workflowConcurrencyGroup, concurrencyErr := resolveConcurrency(path, "", parsed.Concurrency, context, nil)
+	jobs, expandErr := expand(path, source, parsed, context, options)
 	digest := sha256.Sum256(source)
-	return IR{
+	ir := IR{
 		Schema:   schema,
 		Workflow: WorkflowSource{Path: path, Name: parsed.Name, Digest: "sha256:" + hex.EncodeToString(digest[:]), ConcurrencyGroup: workflowConcurrencyGroup},
 		Event:    event,
@@ -609,7 +617,8 @@ func compile(path string, source, eventSource []byte, options Options) (IR, erro
 			Reason:    "run-job supports the fail-closed Phase 0 shell and local-action subset",
 		},
 		Jobs: jobs,
-	}, nil
+	}
+	return ir, errors.Join(concurrencyErr, expandErr)
 }
 
 func compilerWarnings(concurrency *workflow.Concurrency) []Warning {
@@ -705,10 +714,12 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 	sourceDigests := make(map[string]string, len(resolved))
 	sourceRoots := make(map[string]string, len(resolved))
 	needBindings := make(map[string]map[string]needBinding, len(resolved))
+	var diagnostics []error
 	for _, sourced := range resolved {
 		job := sourced.Job
 		if _, exists := jobs[job.ID]; exists {
-			return nil, jobError(sourced.path, job, fmt.Sprintf("flattened job id %q collides with another job", job.ID))
+			diagnostics = append(diagnostics, jobError(sourced.path, job, fmt.Sprintf("flattened job id %q collides with another job", job.ID)))
+			continue
 		}
 		jobs[job.ID] = job
 		sourcePaths[job.ID] = sourced.path
@@ -716,12 +727,26 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 		sourceRoots[job.ID] = sourced.root
 		needBindings[job.ID] = sourced.needBindings
 		if err := supported(sourced.path, job); err != nil {
-			return nil, err
+			diagnostics = append(diagnostics, err)
 		}
 	}
 	order, err := topologicalOrder(path, jobs)
 	if err != nil {
-		return nil, err
+		diagnostics = append(diagnostics, err)
+		order = sortedKeys(jobs)
+	}
+
+	matricesByJob := make(map[string][]map[string]any, len(jobs))
+	failedMatrices := make(map[string]bool)
+	for _, id := range order {
+		job := jobs[id]
+		matrices, matrixErr := expandMatrix(sourcePaths[id], job, context)
+		if matrixErr != nil {
+			diagnostics = append(diagnostics, matrixErr)
+			failedMatrices[id] = true
+			continue
+		}
+		matricesByJob[id] = matrices
 	}
 
 	byLogicalID := make(map[string][]JobInstance, len(jobs))
@@ -729,36 +754,42 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 	for _, id := range order {
 		job := jobs[id]
 		jobPath := sourcePaths[id]
-		matrices, err := expandMatrix(jobPath, job, context)
-		if err != nil {
-			return nil, err
+		if failedMatrices[id] {
+			continue
 		}
+		matrices := matricesByJob[id]
 		concurrencyGroups := make(map[string]struct{}, len(matrices))
 		for _, matrix := range matrices {
 			if err := supportedConditions(jobPath, job, matrix, true); err != nil {
-				return nil, err
+				diagnostics = append(diagnostics, err)
+				continue
 			}
 			labels, err := resolveRunsOn(job, context, matrix)
 			if err != nil {
-				return nil, locatedJobError(jobPath, job, runsOnPosition(job).Line, runsOnPosition(job).Column, err.Error())
+				diagnostics = append(diagnostics, locatedJobError(jobPath, job, runsOnPosition(job).Line, runsOnPosition(job).Column, err.Error()))
+				continue
 			}
 			queue, err := options.Runners.resolve(labels, options.EventTrust)
 			if err != nil {
-				return nil, locatedJobError(jobPath, job, runsOnPosition(job).Line, runsOnPosition(job).Column, err.Error())
+				diagnostics = append(diagnostics, locatedJobError(jobPath, job, runsOnPosition(job).Line, runsOnPosition(job).Column, err.Error()))
+				continue
 			}
 			concurrencyGroup, err := resolveConcurrency(jobPath, job.ID, job.Concurrency, context, matrix)
 			if err != nil {
-				return nil, err
+				diagnostics = append(diagnostics, err)
+				continue
 			}
 			if concurrencyGroup != "" {
 				concurrencyGroups[canonicalConcurrencyGroup(concurrencyGroup)] = struct{}{}
 			}
 			key, err := instanceKey(job.ID, matrix)
 			if err != nil {
-				return nil, jobError(jobPath, job, fmt.Sprintf("create deterministic instance key: %v", err))
+				diagnostics = append(diagnostics, jobError(jobPath, job, fmt.Sprintf("create deterministic instance key: %v", err)))
+				continue
 			}
 			if existingJob, exists := instanceKeys[key]; exists {
-				return nil, jobError(jobPath, job, fmt.Sprintf("deterministic instance key %q collides with another instance from job %q", key, existingJob))
+				diagnostics = append(diagnostics, jobError(jobPath, job, fmt.Sprintf("deterministic instance key %q collides with another instance from job %q", key, existingJob)))
+				continue
 			}
 			instanceKeys[key] = job.ID
 			instance := JobInstance{
@@ -796,7 +827,8 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 				}
 				sort.Strings(members)
 				if len(members) == 0 {
-					return nil, jobError(jobPath, job, fmt.Sprintf("prerequisite %q has no expanded instances", need))
+					diagnostics = append(diagnostics, jobError(jobPath, job, fmt.Sprintf("prerequisite %q has no expanded instances", need)))
+					continue
 				}
 				if instance.NeedGroups == nil {
 					instance.NeedGroups = make(map[string][]string, len(needBindings[id]))
@@ -811,10 +843,12 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 					for _, output := range binding.outputs {
 						producers := byLogicalID[output.member]
 						if len(producers) == 0 {
-							return nil, fmt.Errorf("%s:%d:%d: workflow_call output %q selects unexpanded job %q", output.path, output.span.Start.Line, output.span.Start.Column, output.name, output.member)
+							diagnostics = append(diagnostics, fmt.Errorf("%s:%d:%d: workflow_call output %q selects unexpanded job %q", output.path, output.span.Start.Line, output.span.Start.Column, output.name, output.member))
+							continue
 						}
 						if len(projected)+len(producers) > plan.MaxNeedOutputs {
-							return nil, fmt.Errorf("%s:%d:%d: workflow_call output %q expands call projections beyond the maximum of %d", output.path, output.span.Start.Line, output.span.Start.Column, output.name, plan.MaxNeedOutputs)
+							diagnostics = append(diagnostics, fmt.Errorf("%s:%d:%d: workflow_call output %q expands call projections beyond the maximum of %d", output.path, output.span.Start.Line, output.span.Start.Column, output.name, plan.MaxNeedOutputs))
+							continue
 						}
 						for _, producer := range producers {
 							projected = append(projected, NeedOutput{Name: output.name, StepKey: producer.Key, Output: output.output})
@@ -838,7 +872,7 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 		}
 		if job.MaxParallel != nil && len(concurrencyGroups) > 1 {
 			position := job.Concurrency.Span.Start
-			return nil, locatedJobError(jobPath, job, position.Line, position.Column, "concurrency groups that vary by matrix cannot be combined with strategy.max-parallel")
+			diagnostics = append(diagnostics, locatedJobError(jobPath, job, position.Line, position.Column, "concurrency groups that vary by matrix cannot be combined with strategy.max-parallel"))
 		}
 	}
 
@@ -846,7 +880,7 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 	for _, id := range order {
 		instances = append(instances, byLogicalID[id]...)
 	}
-	return instances, nil
+	return instances, errors.Join(diagnostics...)
 }
 
 func resolveConcurrency(path, jobID string, concurrency *workflow.Concurrency, context expression.CompileContext, matrix map[string]any) (string, error) {
@@ -889,9 +923,6 @@ func supported(path string, job workflow.Job) error {
 	if len(job.RunsOn) == 0 && job.RunsOnExpr == nil {
 		return jobError(path, job, "runs-on must resolve statically")
 	}
-	if err := supportedConditions(path, job, nil, false); err != nil {
-		return err
-	}
 	ids := make(map[string]struct{}, len(job.Steps))
 	for _, step := range job.Steps {
 		if step.ID != "" {
@@ -912,12 +943,13 @@ func supportedConditions(path string, job workflow.Job, matrix map[string]any, m
 			return expression.ValidateConditionWithMatrix(source, scope, matrix)
 		}
 	}
+	var diagnostics []error
 	if err := validate(job.If, expression.JobCondition); err != nil {
 		position := job.IfSpan.Start
 		if position.Line == 0 {
 			position = job.Span.Start
 		}
-		return locatedJobError(path, job, position.Line, position.Column, fmt.Sprintf("job condition: %v", err))
+		diagnostics = append(diagnostics, locatedJobError(path, job, position.Line, position.Column, fmt.Sprintf("job condition: %v", err)))
 	}
 	for i, step := range job.Steps {
 		if err := validate(step.If, expression.StepCondition); err != nil {
@@ -929,10 +961,10 @@ func supportedConditions(path string, job workflow.Job, matrix map[string]any, m
 			if step.ID != "" {
 				label = fmt.Sprintf("step %q", step.ID)
 			}
-			return locatedJobError(path, job, position.Line, position.Column, fmt.Sprintf("%s condition: %v", label, err))
+			diagnostics = append(diagnostics, locatedJobError(path, job, position.Line, position.Column, fmt.Sprintf("%s condition: %v", label, err)))
 		}
 	}
-	return nil
+	return errors.Join(diagnostics...)
 }
 
 func cloneMap(in map[string]string) map[string]string {

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -139,10 +139,32 @@ type ParsedJob struct {
 	Source workflow.Span
 }
 
+type expansionResult struct {
+	instances  []JobInstance
+	candidates []JobInstance
+	jobs       []ParsedJob
+}
+
 func parsedJobs(path string, parsed *workflow.Workflow) []ParsedJob {
 	jobs := make([]ParsedJob, len(parsed.Jobs))
 	for i, job := range parsed.Jobs {
 		jobs[i] = ParsedJob{ID: job.ID, Path: path, Source: job.Span}
+	}
+	return jobs
+}
+
+func processingJobs(path string, parsed *workflow.Workflow, resolved []sourcedJob) []ParsedJob {
+	jobs := parsedJobs(path, parsed)
+	seen := make(map[string]bool, len(jobs)+len(resolved))
+	for _, job := range jobs {
+		seen[job.ID] = true
+	}
+	for _, sourced := range resolved {
+		if seen[sourced.ID] {
+			continue
+		}
+		seen[sourced.ID] = true
+		jobs = append(jobs, ParsedJob{ID: sourced.ID, Path: sourced.path, Source: sourced.Span})
 	}
 	return jobs
 }
@@ -164,11 +186,11 @@ func Validate(path string, source []byte) (Report, error) {
 	context := compileContext(event, nil, path, parsed.Name)
 	_, concurrencyErr := resolveConcurrency(path, "", parsed.Concurrency, context, nil)
 	concurrencyErr = processingFinding(StageExpressions, CodeExpressionInvalid, "compatibility", concurrencyErr)
-	instances, expandErr := expand(path, source, parsed, context, options)
+	expanded, expandErr := expand(path, source, parsed, context, options)
 	if err := errors.Join(concurrencyErr, expandErr); err != nil {
-		return Report{LogicalJobs: len(parsed.Jobs), Instances: len(instances), Jobs: instances, ParsedJobs: parsedJobs(path, parsed), Warnings: compilerWarnings(parsed.Concurrency)}, err
+		return Report{LogicalJobs: len(expanded.jobs), Instances: len(expanded.candidates), Jobs: expanded.candidates, ParsedJobs: expanded.jobs, Warnings: compilerWarnings(parsed.Concurrency)}, err
 	}
-	return Report{LogicalJobs: len(parsed.Jobs), Instances: len(instances), Jobs: instances, ParsedJobs: parsedJobs(path, parsed), Warnings: compilerWarnings(parsed.Concurrency)}, nil
+	return Report{LogicalJobs: len(expanded.jobs), Instances: len(expanded.candidates), Jobs: expanded.candidates, ParsedJobs: expanded.jobs, Warnings: compilerWarnings(parsed.Concurrency)}, nil
 }
 
 // ValidateEvent validates both the supported static graph and its event input.
@@ -196,11 +218,11 @@ func ValidateEventWithOptions(path string, source, eventSource []byte, options O
 	context := compileContext(event, options.Vars.snapshot(), path, parsed.Name)
 	_, concurrencyErr := resolveConcurrency(path, "", parsed.Concurrency, context, nil)
 	concurrencyErr = processingFinding(StageExpressions, CodeExpressionInvalid, "compatibility", concurrencyErr)
-	instances, expandErr := expand(path, source, parsed, context, options)
+	expanded, expandErr := expand(path, source, parsed, context, options)
 	if err := errors.Join(concurrencyErr, expandErr); err != nil {
-		return Report{LogicalJobs: len(parsed.Jobs), Instances: len(instances), Jobs: instances, ParsedJobs: parsedJobs(path, parsed), Warnings: compilerWarnings(parsed.Concurrency)}, err
+		return Report{LogicalJobs: len(expanded.jobs), Instances: len(expanded.candidates), Jobs: expanded.candidates, ParsedJobs: expanded.jobs, Warnings: compilerWarnings(parsed.Concurrency)}, err
 	}
-	return Report{LogicalJobs: len(parsed.Jobs), Instances: len(instances), Jobs: instances, ParsedJobs: parsedJobs(path, parsed), Warnings: compilerWarnings(parsed.Concurrency)}, nil
+	return Report{LogicalJobs: len(expanded.jobs), Instances: len(expanded.candidates), Jobs: expanded.candidates, ParsedJobs: expanded.jobs, Warnings: compilerWarnings(parsed.Concurrency)}, nil
 }
 
 // Compile parses a workflow and event, expands its static graph, and returns
@@ -265,278 +287,308 @@ func CompilePlansContext(ctx context.Context, path string, source, eventSource [
 }
 
 func compilePlans(ctx context.Context, ir IR, compilerVersion, compilerDistributionDigest string, options Options) ([]plan.Job, error) {
-	plans, _, err := compilePlansWithAuthorization(ctx, ir, compilerVersion, compilerDistributionDigest, options)
+	plans, _, _, err := compilePlansWithAuthorization(ctx, ir, compilerVersion, compilerDistributionDigest, options)
+	if err != nil {
+		return nil, err
+	}
 	return plans, err
 }
 
-func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, compilerDistributionDigest string, options Options) ([]plan.Job, []PlanAuthorization, error) {
+func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, compilerDistributionDigest string, options Options) ([]plan.Job, []PlanAuthorization, []JobEvaluation, error) {
 	payload, err := json.Marshal(ir.Event.Payload)
 	if err != nil {
-		return nil, nil, fmt.Errorf("encode event payload: %w", err)
+		return nil, nil, nil, fmt.Errorf("encode event payload: %w", err)
 	}
 	eventDigest := sha256.Sum256(payload)
 	plans := make([]plan.Job, 0, len(ir.Jobs))
 	authorizations := make([]PlanAuthorization, 0, len(ir.Jobs))
+	evaluations := make([]JobEvaluation, 0, len(ir.Jobs))
+	failedInstances := make(map[string]bool, len(ir.Jobs))
+	var diagnostics []error
 	planDigests := make(map[string]string, len(ir.Jobs))
 	actionSource := newMemoizedActionSource(options.ActionSource)
+instances:
 	for _, instance := range ir.Jobs {
-		steps := make([]plan.Step, len(instance.Steps))
-		var actionIndexes []int
-		var actionRefs []string
-		var actionInputs []map[string]string
-		usedIDs := make(map[string]struct{}, len(instance.Steps))
-		for _, step := range instance.Steps {
-			if step.ID != "" {
-				usedIDs[strings.ToLower(step.ID)] = struct{}{}
+		for _, dependency := range instance.Needs {
+			if failedInstances[dependency] {
+				failedInstances[instance.Key] = true
+				evaluations = append(evaluations, JobEvaluation{Instance: instance.Key, Job: instance.LogicalJobID})
+				continue instances
 			}
 		}
-		for i, step := range instance.Steps {
-			id := step.ID
-			if id == "" {
-				id = fmt.Sprintf("step-%d", i+1)
-				for suffix := 2; ; suffix++ {
-					if _, exists := usedIDs[strings.ToLower(id)]; !exists {
+		var builtJob plan.Job
+		var builtAuthorization PlanAuthorization
+		var encoded []byte
+		planErr := func() error {
+			steps := make([]plan.Step, len(instance.Steps))
+			var actionIndexes []int
+			var actionRefs []string
+			var actionInputs []map[string]string
+			usedIDs := make(map[string]struct{}, len(instance.Steps))
+			for _, step := range instance.Steps {
+				if step.ID != "" {
+					usedIDs[strings.ToLower(step.ID)] = struct{}{}
+				}
+			}
+			for i, step := range instance.Steps {
+				id := step.ID
+				if id == "" {
+					id = fmt.Sprintf("step-%d", i+1)
+					for suffix := 2; ; suffix++ {
+						if _, exists := usedIDs[strings.ToLower(id)]; !exists {
+							break
+						}
+						id = fmt.Sprintf("step-%d-%d", i+1, suffix)
+					}
+					usedIDs[strings.ToLower(id)] = struct{}{}
+				}
+				span := planSpan(step.Span)
+				steps[i] = plan.Step{
+					ID: id, Name: step.Name, Kind: step.Kind, Background: step.Background, Targets: append([]string(nil), step.Targets...), Command: step.Run, Uses: step.Uses,
+					Shell: step.Shell, WorkingDirectory: step.WorkingDirectory,
+					Env: cloneMap(step.Env), With: cloneMap(step.With), Condition: step.If,
+					ContinueOnError: step.ContinueOnError, TimeoutMinutes: step.TimeoutMinutes, Source: &span,
+				}
+				if step.Kind == "uses" {
+					actionIndexes = append(actionIndexes, i)
+					actionRefs = append(actionRefs, step.Uses)
+					actionInputs = append(actionInputs, step.With)
+				}
+			}
+			jobSchema := plan.Schema
+			var actions []plan.ActionLock
+			requiresMise := len(actionRefs) != 0
+			var capabilities []string
+			var authorization PlanAuthorization
+			lockActions := options.ResolveActions
+			if len(actionRefs) != 0 && !lockActions {
+				lockActions = true
+				for _, ref := range actionRefs {
+					if !strings.HasPrefix(ref, "./") {
+						lockActions = false
 						break
 					}
-					id = fmt.Sprintf("step-%d-%d", i+1, suffix)
-				}
-				usedIDs[strings.ToLower(id)] = struct{}{}
-			}
-			span := planSpan(step.Span)
-			steps[i] = plan.Step{
-				ID: id, Name: step.Name, Kind: step.Kind, Background: step.Background, Targets: append([]string(nil), step.Targets...), Command: step.Run, Uses: step.Uses,
-				Shell: step.Shell, WorkingDirectory: step.WorkingDirectory,
-				Env: cloneMap(step.Env), With: cloneMap(step.With), Condition: step.If,
-				ContinueOnError: step.ContinueOnError, TimeoutMinutes: step.TimeoutMinutes, Source: &span,
-			}
-			if step.Kind == "uses" {
-				actionIndexes = append(actionIndexes, i)
-				actionRefs = append(actionRefs, step.Uses)
-				actionInputs = append(actionInputs, step.With)
-			}
-		}
-		jobSchema := plan.Schema
-		var actions []plan.ActionLock
-		requiresMise := len(actionRefs) != 0
-		var capabilities []string
-		var authorization PlanAuthorization
-		lockActions := options.ResolveActions
-		if len(actionRefs) != 0 && !lockActions {
-			lockActions = true
-			for _, ref := range actionRefs {
-				if !strings.HasPrefix(ref, "./") {
-					lockActions = false
-					break
 				}
 			}
-		}
-		actionRequiresGitHubToken := false
-		if lockActions && len(actionRefs) != 0 {
-			compiledActions, err := compileActionInvocations(ctx, instance.RepositoryRoot, actionSource, actionRefs, actionInputs)
+			actionRequiresGitHubToken := false
+			if lockActions && len(actionRefs) != 0 {
+				compiledActions, err := compileActionInvocations(ctx, instance.RepositoryRoot, actionSource, actionRefs, actionInputs)
+				if err != nil {
+					return fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err)
+				}
+				selectors := compiledActions.selectors
+				locks := compiledActions.locks
+				actionCapabilities := compiledActions.capabilities
+				requiresMise = compiledActions.requiresMise
+				actionRequiresGitHubToken = compiledActions.requiresGitHubToken
+				locksByID := make(map[string]plan.ActionLock, len(locks))
+				for _, lock := range locks {
+					locksByID[lock.ID] = lock
+				}
+				for i, selector := range selectors {
+					stepIndex := actionIndexes[i]
+					steps[stepIndex].Action = &plan.ActionSelector{Lock: selector.Lock}
+					lock, ok := locksByID[selector.Lock]
+					if !ok {
+						return fmt.Errorf("build plan for job %q: action lock %q is missing", instance.LogicalJobID, selector.Lock)
+					}
+					descriptor, _ := actionintegration.Lookup(actionintegration.Identity{Source: lock.Source, Repository: lock.Repository, Path: lock.Path})
+					if descriptor.Adapter == actionintegration.AdapterCheckoutExactEventSHA {
+						if err := actionintegration.ValidateCheckoutInputs(instance.Steps[stepIndex].With, ir.Event.Repository.Owner+"/"+ir.Event.Repository.Name, ir.Event.SHA); err != nil {
+							span := instance.Steps[stepIndex].Span.Start
+							return fmt.Errorf("%s:%d:%d: checkout adapter: %w", instance.SourcePath, span.Line, span.Column, err)
+						}
+						capabilities = append(capabilities, "provider-token-read")
+						authorization.ProviderTokenReadCapabilitySources = append(authorization.ProviderTokenReadCapabilitySources, "checkout-adapter")
+					}
+					if descriptor.Adapter == actionintegration.AdapterUploadArtifactBuildkite {
+						if err := actionintegration.ValidateUploadArtifactInputs(lock.Commit, instance.Steps[stepIndex].With); err != nil {
+							span := instance.Steps[stepIndex].Span.Start
+							return fmt.Errorf("%s:%d:%d: bounded upload-artifact adapter: %w", instance.SourcePath, span.Line, span.Column, err)
+						}
+					}
+					if descriptor.Adapter == actionintegration.AdapterDownloadArtifactBuildkite {
+						if err := actionintegration.ValidateDownloadArtifactInputs(lock.Commit, instance.Steps[stepIndex].With); err != nil {
+							span := instance.Steps[stepIndex].Span.Start
+							return fmt.Errorf("%s:%d:%d: bounded download-artifact adapter: %w", instance.SourcePath, span.Line, span.Column, err)
+						}
+						if len(instance.NeedGroups) == 0 {
+							span := instance.Steps[stepIndex].Span.Start
+							return fmt.Errorf("%s:%d:%d: bounded download-artifact adapter requires at least one direct needs producer", instance.SourcePath, span.Line, span.Column)
+						}
+					}
+				}
+				jobSchema = plan.SchemaV7
+				actions = locks
+				capabilities = append(append([]string{}, capabilities...), actionCapabilities...)
+				sort.Strings(capabilities)
+				capabilities = slices.Compact(capabilities)
+				sort.Strings(authorization.ProviderTokenReadCapabilitySources)
+				authorization.ProviderTokenReadCapabilitySources = slices.Compact(authorization.ProviderTokenReadCapabilitySources)
+				if slices.Contains(actionCapabilities, "docker") {
+					authorization.DockerCapabilitySources = append(authorization.DockerCapabilitySources, "dockerfile-actions")
+				}
+			} else {
+				var err error
+				capabilities, err = requiredCapabilities(instance.RepositoryRoot, instance.SourcePath, instance.Steps)
+				if err != nil {
+					return fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err)
+				}
+			}
+			if instance.Container != nil || len(instance.Services) != 0 {
+				if len(actionRefs) != 0 && !lockActions {
+					return fmt.Errorf("build plan for job %q: containers with remote actions require action resolution through upload or profile validation", instance.LogicalJobID)
+				}
+				if jobSchema != plan.SchemaV7 {
+					jobSchema = plan.SchemaV4
+				}
+				capabilities = append(capabilities, "docker", "network")
+				sort.Strings(capabilities)
+				capabilities = slices.Compact(capabilities)
+				if instance.Container != nil {
+					authorization.DockerCapabilitySources = append(authorization.DockerCapabilitySources, "job-containers")
+				}
+				if len(instance.Services) != 0 {
+					authorization.DockerCapabilitySources = append(authorization.DockerCapabilitySources, "service-containers")
+				}
+				sort.Strings(authorization.DockerCapabilitySources)
+			}
+			needSources := make(map[string][]plan.NeedSource, len(instance.NeedGroups))
+			for _, logicalNeed := range sortedKeys(instance.NeedGroups) {
+				dependencies := instance.NeedGroups[logicalNeed]
+				if len(dependencies) > plan.MaxNeedProducers {
+					return fmt.Errorf("build plan for job %q: prerequisite %q has %d producers, maximum is %d", instance.LogicalJobID, logicalNeed, len(dependencies), plan.MaxNeedProducers)
+				}
+				for _, dependency := range dependencies {
+					digest, ok := planDigests[dependency]
+					if !ok {
+						return fmt.Errorf("build plan for job %q: prerequisite %q has no earlier plan digest", instance.LogicalJobID, dependency)
+					}
+					needSources[logicalNeed] = append(needSources[logicalNeed], plan.NeedSource{StepKey: dependency, PlanDigest: digest})
+				}
+			}
+			var needOutputs map[string][]plan.NeedOutput
+			if len(instance.NeedOutputs) != 0 {
+				needOutputs = make(map[string][]plan.NeedOutput, len(instance.NeedOutputs))
+				for _, logicalNeed := range sortedKeys(instance.NeedOutputs) {
+					outputs := instance.NeedOutputs[logicalNeed]
+					needOutputs[logicalNeed] = make([]plan.NeedOutput, len(outputs))
+					for i, output := range outputs {
+						needOutputs[logicalNeed][i] = plan.NeedOutput{Name: output.Name, StepKey: output.StepKey, Output: output.Output}
+					}
+				}
+			}
+			if len(needOutputs) != 0 {
+				if jobSchema != plan.SchemaV7 {
+					jobSchema = plan.SchemaV5
+				}
+			}
+			secrets, err := requiredSecrets(instance)
 			if err != nil {
-				return nil, nil, planConstructionFinding(instance, fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err))
+				return fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err)
 			}
-			selectors := compiledActions.selectors
-			locks := compiledActions.locks
-			actionCapabilities := compiledActions.capabilities
-			requiresMise = compiledActions.requiresMise
-			actionRequiresGitHubToken = compiledActions.requiresGitHubToken
-			locksByID := make(map[string]plan.ActionLock, len(locks))
-			for _, lock := range locks {
-				locksByID[lock.ID] = lock
+			var githubToken *plan.GitHubToken
+			referencesGitHubTokenSecret := slices.Contains(secrets, "GITHUB_TOKEN")
+			if referencesGitHubTokenSecret {
+				secrets = slices.DeleteFunc(secrets, func(name string) bool { return name == "GITHUB_TOKEN" })
 			}
-			for i, selector := range selectors {
-				stepIndex := actionIndexes[i]
-				steps[stepIndex].Action = &plan.ActionSelector{Lock: selector.Lock}
-				lock, ok := locksByID[selector.Lock]
-				if !ok {
-					return nil, nil, planConstructionFinding(instance, fmt.Errorf("build plan for job %q: action lock %q is missing", instance.LogicalJobID, selector.Lock))
-				}
-				descriptor, _ := actionintegration.Lookup(actionintegration.Identity{Source: lock.Source, Repository: lock.Repository, Path: lock.Path})
-				if descriptor.Adapter == actionintegration.AdapterCheckoutExactEventSHA {
-					if err := actionintegration.ValidateCheckoutInputs(instance.Steps[stepIndex].With, ir.Event.Repository.Owner+"/"+ir.Event.Repository.Name, ir.Event.SHA); err != nil {
-						span := instance.Steps[stepIndex].Span.Start
-						return nil, nil, planConstructionFinding(instance, fmt.Errorf("%s:%d:%d: checkout adapter: %w", instance.SourcePath, span.Line, span.Column, err))
+			if referencesGitHubTokenSecret || actionRequiresGitHubToken {
+				if len(instance.Permissions) == 0 {
+					reference := "an action input default that references github.token"
+					if referencesGitHubTokenSecret {
+						reference = "secrets.GITHUB_TOKEN"
 					}
-					capabilities = append(capabilities, "provider-token-read")
-					authorization.ProviderTokenReadCapabilitySources = append(authorization.ProviderTokenReadCapabilitySources, "checkout-adapter")
+					return fmt.Errorf("%s:%d:%d: job %q references %s but has no effective permissions", instance.SourcePath, instance.Source.Start.Line, instance.Source.Start.Column, instance.LogicalJobID, reference)
 				}
-				if descriptor.Adapter == actionintegration.AdapterUploadArtifactBuildkite {
-					if err := actionintegration.ValidateUploadArtifactInputs(lock.Commit, instance.Steps[stepIndex].With); err != nil {
-						span := instance.Steps[stepIndex].Span.Start
-						return nil, nil, planConstructionFinding(instance, fmt.Errorf("%s:%d:%d: bounded upload-artifact adapter: %w", instance.SourcePath, span.Line, span.Column, err))
-					}
+				permissions := make(map[string]string, len(instance.Permissions))
+				for name, access := range instance.Permissions {
+					permissions[strings.ReplaceAll(name, "-", "_")] = access
 				}
-				if descriptor.Adapter == actionintegration.AdapterDownloadArtifactBuildkite {
-					if err := actionintegration.ValidateDownloadArtifactInputs(lock.Commit, instance.Steps[stepIndex].With); err != nil {
-						span := instance.Steps[stepIndex].Span.Start
-						return nil, nil, planConstructionFinding(instance, fmt.Errorf("%s:%d:%d: bounded download-artifact adapter: %w", instance.SourcePath, span.Line, span.Column, err))
-					}
-					if len(instance.NeedGroups) == 0 {
-						span := instance.Steps[stepIndex].Span.Start
-						return nil, nil, planConstructionFinding(instance, fmt.Errorf("%s:%d:%d: bounded download-artifact adapter requires at least one direct needs producer", instance.SourcePath, span.Line, span.Column))
-					}
+				githubToken = &plan.GitHubToken{Permissions: permissions}
+				if jobSchema != plan.SchemaV7 {
+					jobSchema = plan.SchemaV6
 				}
+				capabilities = append(capabilities, "provider-token-write")
+				authorization.ProviderTokenWriteCapabilitySources = []string{"effective-permissions"}
 			}
-			jobSchema = plan.SchemaV7
-			actions = locks
-			capabilities = append(append([]string{}, capabilities...), actionCapabilities...)
+			if instance.Queue == "" {
+				jobSchema = plan.SchemaV7
+			}
+			if len(secrets) != 0 {
+				capabilities = append(capabilities, "secrets")
+			}
 			sort.Strings(capabilities)
 			capabilities = slices.Compact(capabilities)
-			sort.Strings(authorization.ProviderTokenReadCapabilitySources)
-			authorization.ProviderTokenReadCapabilitySources = slices.Compact(authorization.ProviderTokenReadCapabilitySources)
-			if slices.Contains(actionCapabilities, "docker") {
-				authorization.DockerCapabilitySources = append(authorization.DockerCapabilitySources, "dockerfile-actions")
+			job := plan.Job{
+				Schema: jobSchema,
+				Compiler: plan.Compiler{
+					Version: compilerVersion, DistributionDigest: compilerDistributionDigest,
+				},
+				Workflow: plan.Workflow{
+					Path:         instance.SourcePath,
+					Digest:       instance.SourceDigest,
+					LogicalJobID: instance.LogicalJobID,
+				},
+				Event: plan.Event{
+					Provider: ir.Event.Provider, Name: ir.Event.Event, PayloadDigest: "sha256:" + hex.EncodeToString(eventDigest[:]),
+					Repository: ir.Event.Repository.Owner + "/" + ir.Event.Repository.Name,
+					Ref:        ir.Event.Ref, SHA: ir.Event.SHA, Actor: ir.Event.Actor,
+				},
+				Target:                  plan.Target{StepKey: instance.Key, Queue: instance.Queue},
+				RequiredCapabilities:    capabilities,
+				RequiredSecrets:         secrets,
+				GitHubToken:             githubToken,
+				Matrix:                  instance.Matrix,
+				Vars:                    cloneMap(ir.Vars),
+				Dependencies:            append([]string(nil), instance.Needs...),
+				NeedSources:             needSources,
+				NeedOutputs:             needOutputs,
+				Env:                     instance.Env,
+				Condition:               instance.If,
+				TimeoutMinutes:          instance.TimeoutMinutes,
+				DefaultShell:            instance.DefaultShell,
+				DefaultWorkingDirectory: instance.DefaultWorkingDirectory,
+				Outputs:                 instance.Outputs,
+				Steps:                   steps,
+				Actions:                 actions,
 			}
-		} else {
-			var err error
-			capabilities, err = requiredCapabilities(instance.RepositoryRoot, instance.SourcePath, instance.Steps)
-			if err != nil {
-				return nil, nil, planConstructionFinding(instance, fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err))
+			if jobSchema == plan.SchemaV7 {
+				job.RequiresMise = &requiresMise
 			}
-		}
-		if instance.Container != nil || len(instance.Services) != 0 {
-			if len(actionRefs) != 0 && !lockActions {
-				return nil, nil, planConstructionFinding(instance, fmt.Errorf("build plan for job %q: containers with remote actions require action resolution through upload or profile validation", instance.LogicalJobID))
-			}
-			if jobSchema != plan.SchemaV7 {
-				jobSchema = plan.SchemaV4
-			}
-			capabilities = append(capabilities, "docker", "network")
-			sort.Strings(capabilities)
-			capabilities = slices.Compact(capabilities)
 			if instance.Container != nil {
-				authorization.DockerCapabilitySources = append(authorization.DockerCapabilitySources, "job-containers")
+				job.Container = &plan.Container{Image: instance.Container.Image, Env: cloneMap(instance.Container.Env), Ports: append([]string(nil), instance.Container.Ports...)}
 			}
 			if len(instance.Services) != 0 {
-				authorization.DockerCapabilitySources = append(authorization.DockerCapabilitySources, "service-containers")
+				job.Services = make(map[string]plan.Container, len(instance.Services))
 			}
-			sort.Strings(authorization.DockerCapabilitySources)
-		}
-		needSources := make(map[string][]plan.NeedSource, len(instance.NeedGroups))
-		for _, logicalNeed := range sortedKeys(instance.NeedGroups) {
-			dependencies := instance.NeedGroups[logicalNeed]
-			if len(dependencies) > plan.MaxNeedProducers {
-				return nil, nil, planConstructionFinding(instance, fmt.Errorf("build plan for job %q: prerequisite %q has %d producers, maximum is %d", instance.LogicalJobID, logicalNeed, len(dependencies), plan.MaxNeedProducers))
+			for _, service := range instance.Services {
+				job.Services[service.Name] = plan.Container{Image: service.Container.Image, Env: cloneMap(service.Container.Env), Ports: append([]string(nil), service.Container.Ports...)}
 			}
-			for _, dependency := range dependencies {
-				digest, ok := planDigests[dependency]
-				if !ok {
-					return nil, nil, planConstructionFinding(instance, fmt.Errorf("build plan for job %q: prerequisite %q has no earlier plan digest", instance.LogicalJobID, dependency))
-				}
-				needSources[logicalNeed] = append(needSources[logicalNeed], plan.NeedSource{StepKey: dependency, PlanDigest: digest})
+			if err := job.Validate(); err != nil {
+				return fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err)
 			}
-		}
-		var needOutputs map[string][]plan.NeedOutput
-		if len(instance.NeedOutputs) != 0 {
-			needOutputs = make(map[string][]plan.NeedOutput, len(instance.NeedOutputs))
-			for _, logicalNeed := range sortedKeys(instance.NeedOutputs) {
-				outputs := instance.NeedOutputs[logicalNeed]
-				needOutputs[logicalNeed] = make([]plan.NeedOutput, len(outputs))
-				for i, output := range outputs {
-					needOutputs[logicalNeed][i] = plan.NeedOutput{Name: output.Name, StepKey: output.StepKey, Output: output.Output}
-				}
+			encodedJob, err := plan.Encode(job)
+			if err != nil {
+				return fmt.Errorf("encode plan for job %q: %w", instance.LogicalJobID, err)
 			}
-		}
-		if len(needOutputs) != 0 {
-			if jobSchema != plan.SchemaV7 {
-				jobSchema = plan.SchemaV5
-			}
-		}
-		secrets, err := requiredSecrets(instance)
-		if err != nil {
-			return nil, nil, planConstructionFinding(instance, fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err))
-		}
-		var githubToken *plan.GitHubToken
-		referencesGitHubTokenSecret := slices.Contains(secrets, "GITHUB_TOKEN")
-		if referencesGitHubTokenSecret {
-			secrets = slices.DeleteFunc(secrets, func(name string) bool { return name == "GITHUB_TOKEN" })
-		}
-		if referencesGitHubTokenSecret || actionRequiresGitHubToken {
-			if len(instance.Permissions) == 0 {
-				reference := "an action input default that references github.token"
-				if referencesGitHubTokenSecret {
-					reference = "secrets.GITHUB_TOKEN"
-				}
-				return nil, nil, planConstructionFinding(instance, fmt.Errorf("%s:%d:%d: job %q references %s but has no effective permissions", instance.SourcePath, instance.Source.Start.Line, instance.Source.Start.Column, instance.LogicalJobID, reference))
-			}
-			permissions := make(map[string]string, len(instance.Permissions))
-			for name, access := range instance.Permissions {
-				permissions[strings.ReplaceAll(name, "-", "_")] = access
-			}
-			githubToken = &plan.GitHubToken{Permissions: permissions}
-			if jobSchema != plan.SchemaV7 {
-				jobSchema = plan.SchemaV6
-			}
-			capabilities = append(capabilities, "provider-token-write")
-			authorization.ProviderTokenWriteCapabilitySources = []string{"effective-permissions"}
-		}
-		if instance.Queue == "" {
-			jobSchema = plan.SchemaV7
-		}
-		if len(secrets) != 0 {
-			capabilities = append(capabilities, "secrets")
-		}
-		sort.Strings(capabilities)
-		capabilities = slices.Compact(capabilities)
-		job := plan.Job{
-			Schema: jobSchema,
-			Compiler: plan.Compiler{
-				Version: compilerVersion, DistributionDigest: compilerDistributionDigest,
-			},
-			Workflow: plan.Workflow{
-				Path:         instance.SourcePath,
-				Digest:       instance.SourceDigest,
-				LogicalJobID: instance.LogicalJobID,
-			},
-			Event: plan.Event{
-				Provider: ir.Event.Provider, Name: ir.Event.Event, PayloadDigest: "sha256:" + hex.EncodeToString(eventDigest[:]),
-				Repository: ir.Event.Repository.Owner + "/" + ir.Event.Repository.Name,
-				Ref:        ir.Event.Ref, SHA: ir.Event.SHA, Actor: ir.Event.Actor,
-			},
-			Target:                  plan.Target{StepKey: instance.Key, Queue: instance.Queue},
-			RequiredCapabilities:    capabilities,
-			RequiredSecrets:         secrets,
-			GitHubToken:             githubToken,
-			Matrix:                  instance.Matrix,
-			Vars:                    cloneMap(ir.Vars),
-			Dependencies:            append([]string(nil), instance.Needs...),
-			NeedSources:             needSources,
-			NeedOutputs:             needOutputs,
-			Env:                     instance.Env,
-			Condition:               instance.If,
-			TimeoutMinutes:          instance.TimeoutMinutes,
-			DefaultShell:            instance.DefaultShell,
-			DefaultWorkingDirectory: instance.DefaultWorkingDirectory,
-			Outputs:                 instance.Outputs,
-			Steps:                   steps,
-			Actions:                 actions,
-		}
-		if jobSchema == plan.SchemaV7 {
-			job.RequiresMise = &requiresMise
-		}
-		if instance.Container != nil {
-			job.Container = &plan.Container{Image: instance.Container.Image, Env: cloneMap(instance.Container.Env), Ports: append([]string(nil), instance.Container.Ports...)}
-		}
-		if len(instance.Services) != 0 {
-			job.Services = make(map[string]plan.Container, len(instance.Services))
-		}
-		for _, service := range instance.Services {
-			job.Services[service.Name] = plan.Container{Image: service.Container.Image, Env: cloneMap(service.Container.Env), Ports: append([]string(nil), service.Container.Ports...)}
-		}
-		if err := job.Validate(); err != nil {
-			return nil, nil, planConstructionFinding(instance, fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err))
-		}
-		encoded, err := plan.Encode(job)
-		if err != nil {
-			return nil, nil, planConstructionFinding(instance, fmt.Errorf("encode plan for job %q: %w", instance.LogicalJobID, err))
+			builtJob = job
+			builtAuthorization = authorization
+			encoded = encodedJob
+			return nil
+		}()
+		if planErr != nil {
+			failedInstances[instance.Key] = true
+			evaluations = append(evaluations, JobEvaluation{Instance: instance.Key, Job: instance.LogicalJobID, Evaluated: true})
+			diagnostics = append(diagnostics, planConstructionFinding(instance, planErr))
+			continue
 		}
 		digest := sha256.Sum256(encoded)
 		planDigests[instance.Key] = "sha256:" + hex.EncodeToString(digest[:])
-		plans = append(plans, job)
-		authorizations = append(authorizations, authorization)
+		plans = append(plans, builtJob)
+		authorizations = append(authorizations, builtAuthorization)
+		evaluations = append(evaluations, JobEvaluation{Instance: instance.Key, Job: instance.LogicalJobID, Evaluated: true, Passed: true})
 	}
-	return plans, authorizations, nil
+	return plans, authorizations, evaluations, errors.Join(diagnostics...)
 }
 
 func planConstructionFinding(instance JobInstance, err error) error {
@@ -617,7 +669,7 @@ func compile(path string, source, eventSource []byte, options Options) (IR, erro
 	context := compileContext(event, vars, path, parsed.Name)
 	workflowConcurrencyGroup, concurrencyErr := resolveConcurrency(path, "", parsed.Concurrency, context, nil)
 	concurrencyErr = processingFinding(StageExpressions, CodeExpressionInvalid, "compatibility", concurrencyErr)
-	jobs, expandErr := expand(path, source, parsed, context, options)
+	expanded, expandErr := expand(path, source, parsed, context, options)
 	digest := sha256.Sum256(source)
 	ir := IR{
 		Schema:   schema,
@@ -629,7 +681,7 @@ func compile(path string, source, eventSource []byte, options Options) (IR, erro
 			Supported: true,
 			Reason:    "run-job supports the fail-closed Phase 0 shell and local-action subset",
 		},
-		Jobs: jobs,
+		Jobs: expanded.instances,
 	}
 	return ir, errors.Join(concurrencyErr, expandErr)
 }
@@ -717,11 +769,12 @@ func canonicalWorkflowName(path string) string {
 	return filepath.ToSlash(filepath.Clean(path))
 }
 
-func expand(path string, source []byte, parsed *workflow.Workflow, context expression.CompileContext, options Options) ([]JobInstance, error) {
+func expand(path string, source []byte, parsed *workflow.Workflow, context expression.CompileContext, options Options) (expansionResult, error) {
 	resolved, err := resolveReusableWorkflows(path, source, parsed)
 	if err != nil {
-		return nil, processingFinding(StageGraph, CodeGraphInvalid, "compatibility", err)
+		return expansionResult{jobs: parsedJobs(path, parsed)}, processingFinding(StageGraph, CodeGraphInvalid, "compatibility", err)
 	}
+	result := expansionResult{jobs: processingJobs(path, parsed, resolved)}
 	jobs := make(map[string]workflow.Job, len(resolved))
 	sourcePaths := make(map[string]string, len(resolved))
 	sourceDigests := make(map[string]string, len(resolved))
@@ -773,28 +826,6 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 		matrices := matricesByJob[id]
 		concurrencyGroups := make(map[string]struct{}, len(matrices))
 		for _, matrix := range matrices {
-			if err := supportedConditions(jobPath, job, matrix, true); err != nil {
-				diagnostics = append(diagnostics, attributedProcessingFinding(StageExpressions, CodeExpressionInvalid, "compatibility", jobPath, 0, 0, job.ID, "", "", 0, err))
-				continue
-			}
-			labels, err := resolveRunsOn(job, context, matrix)
-			if err != nil {
-				diagnostics = append(diagnostics, attributedProcessingFinding(StageExpressions, CodeExpressionInvalid, "compatibility", jobPath, runsOnPosition(job).Line, runsOnPosition(job).Column, job.ID, "", "", 0, locatedJobError(jobPath, job, runsOnPosition(job).Line, runsOnPosition(job).Column, err.Error())))
-				continue
-			}
-			queue, err := options.Runners.resolve(labels, options.EventTrust)
-			if err != nil {
-				diagnostics = append(diagnostics, attributedProcessingFinding(StageExpressions, CodeExpressionInvalid, "compatibility", jobPath, runsOnPosition(job).Line, runsOnPosition(job).Column, job.ID, "", "", 0, locatedJobError(jobPath, job, runsOnPosition(job).Line, runsOnPosition(job).Column, err.Error())))
-				continue
-			}
-			concurrencyGroup, err := resolveConcurrency(jobPath, job.ID, job.Concurrency, context, matrix)
-			if err != nil {
-				diagnostics = append(diagnostics, attributedProcessingFinding(StageExpressions, CodeExpressionInvalid, "compatibility", jobPath, 0, 0, job.ID, "", "", 0, err))
-				continue
-			}
-			if concurrencyGroup != "" {
-				concurrencyGroups[canonicalConcurrencyGroup(concurrencyGroup)] = struct{}{}
-			}
 			key, err := instanceKey(job.ID, matrix)
 			if err != nil {
 				diagnostics = append(diagnostics, attributedProcessingFinding(StageMatrix, CodeMatrixInvalid, "compatibility", jobPath, 0, 0, job.ID, "", "", 0, jobError(jobPath, job, fmt.Sprintf("create deterministic instance key: %v", err))))
@@ -805,16 +836,12 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 				continue
 			}
 			instanceKeys[key] = job.ID
-			instance := JobInstance{
+			candidate := JobInstance{
 				Key:                     key,
 				LogicalJobID:            job.ID,
-				Label:                   instanceLabel(job, matrix, context),
-				RunsOn:                  labels,
-				Queue:                   queue,
 				Matrix:                  matrix,
 				FailFast:                job.FailFast,
 				MaxParallel:             job.MaxParallel,
-				ConcurrencyGroup:        concurrencyGroup,
 				Steps:                   append([]workflow.Step(nil), job.Steps...),
 				Env:                     cloneMap(job.Env),
 				Permissions:             permissionScopes(job.Permissions),
@@ -830,6 +857,48 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 				RepositoryRoot:          sourceRoots[id],
 				Source:                  job.Span,
 			}
+			result.candidates = append(result.candidates, candidate)
+
+			valid := true
+			if err := supportedConditions(jobPath, job, matrix, true); err != nil {
+				diagnostics = append(diagnostics, attributedProcessingFinding(StageExpressions, CodeExpressionInvalid, "compatibility", jobPath, 0, 0, job.ID, key, "", 0, err))
+				valid = false
+			}
+			labels, runsOnErr := resolveRunsOn(job, context, matrix)
+			if runsOnErr != nil {
+				diagnostics = append(diagnostics, attributedProcessingFinding(StageExpressions, CodeExpressionInvalid, "compatibility", jobPath, runsOnPosition(job).Line, runsOnPosition(job).Column, job.ID, key, "", 0, locatedJobError(jobPath, job, runsOnPosition(job).Line, runsOnPosition(job).Column, runsOnErr.Error())))
+				valid = false
+			}
+			queue := ""
+			if runsOnErr == nil {
+				queue, err = options.Runners.resolve(labels, options.EventTrust)
+				if err != nil {
+					finding := &ProcessingFinding{
+						Stage: StageExpressions, Code: CodeExpressionInvalid, Category: "compatibility",
+						Path: jobPath, Line: runsOnPosition(job).Line, Column: runsOnPosition(job).Column,
+						Job: job.ID, Instance: key, Message: "resolved runner target is not admitted by policy",
+						Err: locatedJobError(jobPath, job, runsOnPosition(job).Line, runsOnPosition(job).Column, err.Error()),
+					}
+					diagnostics = append(diagnostics, finding)
+					valid = false
+				}
+			}
+			concurrencyGroup, concurrencyErr := resolveConcurrency(jobPath, job.ID, job.Concurrency, context, matrix)
+			if concurrencyErr != nil {
+				diagnostics = append(diagnostics, attributedProcessingFinding(StageExpressions, CodeExpressionInvalid, "compatibility", jobPath, 0, 0, job.ID, key, "", 0, concurrencyErr))
+				valid = false
+			}
+			if concurrencyGroup != "" {
+				concurrencyGroups[canonicalConcurrencyGroup(concurrencyGroup)] = struct{}{}
+			}
+			if !valid {
+				continue
+			}
+			instance := candidate
+			instance.Label = instanceLabel(job, matrix, context)
+			instance.RunsOn = labels
+			instance.Queue = queue
+			instance.ConcurrencyGroup = concurrencyGroup
 			for _, need := range sortedKeys(needBindings[id]) {
 				binding := needBindings[id][need]
 				var members []string
@@ -893,7 +962,8 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 	for _, id := range order {
 		instances = append(instances, byLogicalID[id]...)
 	}
-	return instances, errors.Join(diagnostics...)
+	result.instances = instances
+	return result, errors.Join(diagnostics...)
 }
 
 func resolveConcurrency(path, jobID string, concurrency *workflow.Concurrency, context expression.CompileContext, matrix map[string]any) (string, error) {

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -1540,6 +1540,52 @@ jobs:
 	}
 }
 
+func TestValidateRetainsDependentCandidateAsNotEvaluatedAfterMatrixFailure(t *testing.T) {
+	source := []byte(`on: push
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.value }}
+    steps:
+      - id: matrix
+        run: true
+  upstream:
+    needs: prepare
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+    steps:
+      - run: true
+  downstream:
+    needs: upstream
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+`)
+	report, err := Validate("failed-prerequisite.yml", source)
+	if err == nil || !strings.Contains(err.Error(), "runtime-dependent matrix") {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	if strings.Contains(err.Error(), "has no expanded instances") {
+		t.Fatalf("Validate() added cascading graph failure: %v", err)
+	}
+	if !report.NotEvaluatedJobs["downstream"] || !report.NotEvaluatedInstances["gha-downstream"] {
+		t.Fatalf("not-evaluated ledger = jobs %#v, instances %#v", report.NotEvaluatedJobs, report.NotEvaluatedInstances)
+	}
+}
+
+func TestParseWorkflowDoesNotEvaluateEventDependentJobs(t *testing.T) {
+	source := []byte("on: push\njobs:\n  test:\n    runs-on: ${{ github.event.runner }}\n    steps:\n      - run: true\n")
+	report, err := ParseWorkflow("event.yml", source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.LogicalJobs != 1 || len(report.ParsedJobs) != 1 || report.ParsedJobs[0].ID != "test" || report.Instances != 0 || len(report.Jobs) != 0 {
+		t.Fatalf("parse report = %#v", report)
+	}
+}
+
 func TestCompilePlansOwnsDeterministicRuntimeInputs(t *testing.T) {
 	path := smokePath(".github", "workflows", "plan-fixture.yml")
 	source := []byte(`name: plan fixture

--- a/internal/compiler/config_test.go
+++ b/internal/compiler/config_test.go
@@ -3,6 +3,7 @@ package compiler
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -109,6 +110,26 @@ func TestOptionsRejectActionConfigurationWithoutResolution(t *testing.T) {
 	options.ActionSource = &fakeActionSource{}
 	if err := options.validate(); err == nil || !strings.Contains(err.Error(), "requires ResolveActions") {
 		t.Fatalf("Options.validate() error = %v, want action-resolution configuration rejection", err)
+	}
+}
+
+func TestValidateEventReportsInvalidCompilerEnvironmentWithoutFailingWorkflowStage(t *testing.T) {
+	workflow := []byte("on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n")
+	options := defaultOptions()
+	options.Runners.Labels["ubuntu-latest"] = "not a queue"
+	report, err := ValidateEventWithOptions("environment.yml", workflow, pushEvent(t), options)
+	if err == nil {
+		t.Fatal("ValidateEventWithOptions() error = nil, want invalid environment")
+	}
+	var finding *ProcessingFinding
+	if !errors.As(err, &finding) {
+		t.Fatalf("ValidateEventWithOptions() error = %T, want ProcessingFinding", err)
+	}
+	if finding.Code != CodeEnvironment || finding.Stage != "" || finding.Category != "environment" || finding.Message != "workflow-processing configuration is invalid" {
+		t.Fatalf("finding = %#v", finding)
+	}
+	if report.LogicalJobs != 1 || len(report.ParsedJobs) != 1 || !report.NotEvaluatedJobs["test"] {
+		t.Fatalf("report = %#v", report)
 	}
 }
 

--- a/internal/compiler/processing.go
+++ b/internal/compiler/processing.go
@@ -44,6 +44,7 @@ type ProcessingFinding struct {
 	Instance string
 	Action   string
 	Step     int
+	Message  string
 	Err      error
 }
 
@@ -101,11 +102,20 @@ type ActionEvaluation struct {
 	Passed    bool
 }
 
+// JobEvaluation records whether plan construction ran for one instance.
+type JobEvaluation struct {
+	Instance  string
+	Job       string
+	Evaluated bool
+	Passed    bool
+}
+
 // ProcessingEvidence records facts learned before bundle construction stops.
 // It is returned on both success and failure.
 type ProcessingEvidence struct {
 	ActionResolutionComplete bool
 	Actions                  []ActionEvaluation
+	Plans                    []JobEvaluation
 	PlansConstructed         bool
 	PipelineGenerated        bool
 }

--- a/internal/compiler/processing.go
+++ b/internal/compiler/processing.go
@@ -29,6 +29,7 @@ const (
 	CodeActionResolution   = "E_ACTION_RESOLUTION"
 	CodePlanConstruction   = "E_PLAN_CONSTRUCTION"
 	CodePipelineGeneration = "E_PIPELINE_GENERATION"
+	CodeEnvironment        = "E_ENVIRONMENT"
 )
 
 // ProcessingFinding carries stable attribution independently of its rendered

--- a/internal/compiler/processing.go
+++ b/internal/compiler/processing.go
@@ -1,0 +1,111 @@
+package compiler
+
+import "errors"
+
+// ProcessingStage identifies one stable workflow-processing boundary without
+// coupling the compiler to the compatibility report wire format.
+type ProcessingStage string
+
+const (
+	StageWorkflowParsing ProcessingStage = "workflow-parsing"
+	StageEventValidation ProcessingStage = "event-validation"
+	StageGraph           ProcessingStage = "static-graph-construction"
+	StageMatrix          ProcessingStage = "matrix-expansion"
+	StageExpressions     ProcessingStage = "expression-validation"
+	StageDiscovery       ProcessingStage = "action-discovery"
+	StageResolution      ProcessingStage = "action-resolution"
+	StagePlans           ProcessingStage = "job-plan-construction"
+	StageAdmission       ProcessingStage = "hosted-profile-admission"
+	StagePipeline        ProcessingStage = "pipeline-generation"
+)
+
+const (
+	CodeWorkflowSyntax     = "E_WORKFLOW_SYNTAX"
+	CodeEventInvalid       = "E_EVENT_INVALID"
+	CodeGraphInvalid       = "E_GRAPH_INVALID"
+	CodeMatrixInvalid      = "E_MATRIX_INVALID"
+	CodeExpressionInvalid  = "E_EXPRESSION_INVALID"
+	CodeActionDiscovery    = "E_ACTION_DISCOVERY"
+	CodeActionResolution   = "E_ACTION_RESOLUTION"
+	CodePlanConstruction   = "E_PLAN_CONSTRUCTION"
+	CodePipelineGeneration = "E_PIPELINE_GENERATION"
+)
+
+// ProcessingFinding carries stable attribution independently of its rendered
+// error text. Err remains wrapped so errors.Is and errors.As keep working.
+type ProcessingFinding struct {
+	Stage    ProcessingStage
+	Code     string
+	Category string
+	Path     string
+	Line     int
+	Column   int
+	Job      string
+	Instance string
+	Action   string
+	Step     int
+	Err      error
+}
+
+func (e *ProcessingFinding) Error() string { return e.Err.Error() }
+func (e *ProcessingFinding) Unwrap() error { return e.Err }
+
+func processingFinding(stage ProcessingStage, code, category string, err error) error {
+	return attributedProcessingFinding(stage, code, category, "", 0, 0, "", "", "", 0, err)
+}
+
+func attributedProcessingFinding(stage ProcessingStage, code, category, path string, line, column int, job, instance, action string, step int, err error) error {
+	if err == nil {
+		return nil
+	}
+	if finding, ok := err.(*ProcessingFinding); ok {
+		if finding.Path == "" {
+			finding.Path, finding.Line, finding.Column = path, line, column
+		}
+		if finding.Job == "" {
+			finding.Job = job
+		}
+		if finding.Instance == "" {
+			finding.Instance = instance
+		}
+		if finding.Action == "" {
+			finding.Action = action
+		}
+		if finding.Step == 0 {
+			finding.Step = step
+		}
+		return err
+	}
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		children := joined.Unwrap()
+		wrapped := make([]error, 0, len(children))
+		for _, child := range children {
+			wrapped = append(wrapped, attributedProcessingFinding(stage, code, category, path, line, column, job, instance, action, step, child))
+		}
+		return errors.Join(wrapped...)
+	}
+	return &ProcessingFinding{
+		Stage: stage, Code: code, Category: category,
+		Path: path, Line: line, Column: column, Job: job, Instance: instance, Action: action, Step: step,
+		Err: err,
+	}
+}
+
+// ActionEvaluation records an attempted immutable resolution by invocation.
+// Skipped invocations are absent and remain not-evaluated in the report.
+type ActionEvaluation struct {
+	Instance  string
+	Job       string
+	Reference string
+	Step      int
+	Passed    bool
+}
+
+// ProcessingEvidence records facts learned before bundle construction stops.
+// It is returned on both success and failure.
+type ProcessingEvidence struct {
+	ActionResolutionComplete bool
+	Actions                  []ActionEvaluation
+	PlansConstructed         bool
+	PipelineGenerated        bool
+}

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -257,7 +257,13 @@ func (resolver *reusableResolver) resolve(path, digest string, parsed *workflow.
 			calleeResolution, err := resolver.resolve(calleeSourcePath, calleeDigest, callee, callNamespace, callLabel, callInputs, needBindings, calleePermissionCeiling, depth+1)
 			resolver.stack = resolver.stack[:len(resolver.stack)-1]
 			if err != nil {
-				return reusableResolution{}, err
+				return reusableResolution{}, &ProcessingFinding{
+					Stage: StageGraph, Code: CodeGraphInvalid, Category: "compatibility",
+					Path: path, Line: call.Span.Start.Line, Column: call.Span.Start.Column, Job: job.ID,
+					Message: "local reusable workflow could not be resolved",
+					Err: locatedJobError(path, job, call.Span.Start.Line, call.Span.Start.Column,
+						fmt.Sprintf("resolve local reusable workflow %q: %v", call.Uses, err)),
+				}
 			}
 			resolved = append(resolved, calleeResolution.jobs...)
 			callOutputs = append(callOutputs, calleeResolution.outputs...)

--- a/internal/workflow/parse.go
+++ b/internal/workflow/parse.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"sort"
@@ -1157,6 +1158,7 @@ func yamlStepSpan(step, execution *yaml.Node) Span {
 
 func filterActionlintDiagnostics(path string, errs []*actionlint.Error, expected []expectedActionlintDiagnostic) error {
 	matched := make([]bool, len(expected))
+	var diagnostics []error
 	for _, actionlintErr := range errs {
 		match := -1
 		for i, diagnostic := range expected {
@@ -1169,15 +1171,15 @@ func filterActionlintDiagnostics(path string, errs []*actionlint.Error, expected
 			matched[match] = true
 			continue
 		}
-		return fmt.Errorf("%s:%d:%d: %s", path, actionlintErr.Line, actionlintErr.Column, actionlintErr.Message)
+		diagnostics = append(diagnostics, fmt.Errorf("%s:%d:%d: %s", path, actionlintErr.Line, actionlintErr.Column, actionlintErr.Message))
 	}
 	for i, ok := range matched {
 		if !ok {
 			diagnostic := expected[i]
-			return fmt.Errorf("%s:%d:%d: actionlint concurrency diagnostic changed; pinned parser contract must be reviewed", path, diagnostic.Position.Line, diagnostic.Position.Column)
+			diagnostics = append(diagnostics, fmt.Errorf("%s:%d:%d: actionlint concurrency diagnostic changed; pinned parser contract must be reviewed", path, diagnostic.Position.Line, diagnostic.Position.Column))
 		}
 	}
-	return nil
+	return errors.Join(diagnostics...)
 }
 
 func validateStepConcurrency(path, jobID string, steps []Step) error {

--- a/schemas/processing-report-v1.schema.json
+++ b/schemas/processing-report-v1.schema.json
@@ -106,7 +106,9 @@
         "message": {"type": "string", "minLength": 1, "maxLength": 16384},
         "location": {"$ref": "#/$defs/location"},
         "job": {"type": "string", "minLength": 1, "maxLength": 255},
-        "action": {"type": "string", "minLength": 1, "maxLength": 1024}
+        "instance": {"type": "string", "minLength": 1, "maxLength": 255},
+        "action": {"type": "string", "minLength": 1, "maxLength": 1024},
+        "step": {"type": "integer", "minimum": 1}
       }
     }
   }

--- a/schemas/processing-report-v1.schema.json
+++ b/schemas/processing-report-v1.schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://buildkite.com/schemas/buildkite-gha/processing-report-v1.schema.json",
+  "title": "buildkite-gha processing report v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "workflow", "result", "status", "logical_jobs", "instances", "compile", "admission", "stages", "jobs", "actions", "diagnostics"],
+  "properties": {
+    "schema": {"const": "buildkite-gha/processing-report/v1"},
+    "workflow": {"type": "string", "minLength": 1, "maxLength": 4096},
+    "profile": {"type": "string", "maxLength": 128},
+    "result": {"type": "string", "minLength": 1, "maxLength": 128},
+    "status": {"$ref": "#/$defs/stageResult"},
+    "logical_jobs": {"type": "integer", "minimum": 0},
+    "instances": {"type": "integer", "minimum": 0},
+    "compile": {"$ref": "#/$defs/legacyStage"},
+    "admission": {"$ref": "#/$defs/legacyStage"},
+    "stages": {
+      "type": "array",
+      "minItems": 10,
+      "maxItems": 10,
+      "items": {"$ref": "#/$defs/stage"}
+    },
+    "jobs": {"type": "array", "items": {"$ref": "#/$defs/job"}},
+    "actions": {"type": "array", "items": {"$ref": "#/$defs/action"}},
+    "diagnostics": {"type": "array", "items": {"$ref": "#/$defs/diagnostic"}}
+  },
+  "$defs": {
+    "stageResult": {"enum": ["passed", "failed", "not-evaluated"]},
+    "stageID": {
+      "enum": [
+        "workflow-parsing",
+        "event-validation",
+        "static-graph-construction",
+        "matrix-expansion",
+        "expression-validation",
+        "action-discovery",
+        "action-resolution",
+        "job-plan-construction",
+        "hosted-profile-admission",
+        "pipeline-generation"
+      ]
+    },
+    "stage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name", "result"],
+      "properties": {
+        "id": {"$ref": "#/$defs/stageID"},
+        "name": {"type": "string", "minLength": 1, "maxLength": 128},
+        "result": {"$ref": "#/$defs/stageResult"}
+      }
+    },
+    "legacyStage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["result"],
+      "properties": {
+        "result": {"type": "string", "minLength": 1, "maxLength": 128},
+        "logical_jobs": {"type": "integer", "minimum": 0},
+        "instances": {"type": "integer", "minimum": 0}
+      }
+    },
+    "location": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "line", "column"],
+      "properties": {
+        "path": {"type": "string", "minLength": 1, "maxLength": 4096},
+        "line": {"type": "integer", "minimum": 1},
+        "column": {"type": "integer", "minimum": 1}
+      }
+    },
+    "job": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "result"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1, "maxLength": 255},
+        "instance": {"type": "string", "minLength": 1, "maxLength": 255},
+        "result": {"$ref": "#/$defs/stageResult"},
+        "location": {"$ref": "#/$defs/location"}
+      }
+    },
+    "action": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reference", "job", "step", "result"],
+      "properties": {
+        "reference": {"type": "string", "minLength": 1, "maxLength": 1024},
+        "job": {"type": "string", "minLength": 1, "maxLength": 255},
+        "step": {"type": "integer", "minimum": 1},
+        "result": {"$ref": "#/$defs/stageResult"},
+        "location": {"$ref": "#/$defs/location"}
+      }
+    },
+    "diagnostic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["level", "code", "message"],
+      "properties": {
+        "level": {"enum": ["error", "warning"]},
+        "code": {"type": "string", "pattern": "^[EW]_[A-Z0-9_]+$"},
+        "category": {"enum": ["syntax", "compatibility", "action-resolution", "environment", "admission"]},
+        "stage": {"$ref": "#/$defs/stageID"},
+        "message": {"type": "string", "minLength": 1, "maxLength": 16384},
+        "location": {"$ref": "#/$defs/location"},
+        "job": {"type": "string", "minLength": 1, "maxLength": 255},
+        "action": {"type": "string", "minLength": 1, "maxLength": 1024}
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Why

Workflow processing was fail-fast and surfaced only a single broad compiler error. That made migration failures harder to diagnose and hid successful work when a later stage failed. We need one deterministic report without weakening fail-closed pipeline generation.

## What

- Add a versioned text and JSON processing report covering all ten workflow stages.
- Include per-job, matrix-instance, and action results with stable diagnostic codes, categories, and source locations.
- Aggregate safely discoverable independent errors in one invocation.
- Use the same report for validate, compile, and upload, including Buildkite importer logs.
- Continue to suppress all plans and pipeline output when a required stage fails.

## How

- Retain safely constructed jobs, instances, and actions while aggregating parser, graph, matrix, expression, and action-resolution errors.
- Separate plan construction, hosted-profile admission, and pipeline generation into ordered boundaries.
- Render reports deterministically against the new processing-report-v1 JSON Schema.
- Add CLI, compiler, schema, determinism, aggregation, and fail-closed coverage, plus user documentation.