### PR TITLE
Support resilient aggregate workflow glob uploads

### DIFF
--- a/internal/buildkite/pipeline.go
+++ b/internal/buildkite/pipeline.go
@@ -39,6 +39,29 @@ type Pipeline struct {
 	RuntimeImage       string
 	ConcurrencyGate    *ConcurrencyGate
 	Jobs               []Job
+	Workflows          []Workflow
+}
+
+// Workflow is one ordered aggregate pipeline entry. It contains either a
+// conditioned group of generated jobs or one top-level direct command step.
+type Workflow struct {
+	GroupLabel      string
+	GroupKey        string
+	CheckName       string
+	Condition       string
+	ConcurrencyGate *ConcurrencyGate
+	Jobs            []Job
+	CommandSteps    []CommandStep
+}
+
+// CommandStep is an aggregate-only top-level command which runs without
+// generated plan or distribution bootstrap state.
+type CommandStep struct {
+	Key       string
+	Label     string
+	CheckName string
+	Command   string
+	Queue     string
 }
 
 // ConcurrencyGate serializes an entire generated workflow while allowing the
@@ -90,15 +113,107 @@ func Emit(pipeline Pipeline) ([]byte, error) {
 	if !validStepKey(pipeline.CompilerStep) {
 		return nil, fmt.Errorf("invalid compiler step key %q", pipeline.CompilerStep)
 	}
-	if len(pipeline.Jobs) == 0 {
-		return nil, fmt.Errorf("pipeline requires at least one generated job")
+	aggregate := len(pipeline.Workflows) != 0
+	workflows := pipeline.Workflows
+	if aggregate {
+		if len(pipeline.Jobs) != 0 || pipeline.GroupLabel != "" || pipeline.ConcurrencyGate != nil {
+			return nil, fmt.Errorf("aggregate pipeline cannot mix legacy workflow fields")
+		}
+	} else {
+		workflows = []Workflow{{
+			GroupLabel:      pipeline.GroupLabel,
+			ConcurrencyGate: pipeline.ConcurrencyGate,
+			Jobs:            pipeline.Jobs,
+		}}
 	}
-	jobs, err := orderJobs(pipeline.CompilerStep, pipeline.Jobs)
-	if err != nil {
-		return nil, err
-	}
-	if err := validateConcurrencyGate(pipeline.ConcurrencyGate); err != nil {
-		return nil, err
+
+	prepared := make([]preparedWorkflow, len(workflows))
+	usedKeys := map[string]string{pipeline.CompilerStep: "compiler step"}
+	usedDigests := make(map[string]string)
+	for i, workflow := range workflows {
+		hasJobs, hasCommandSteps := len(workflow.Jobs) != 0, len(workflow.CommandSteps) != 0
+		if !hasJobs && !hasCommandSteps {
+			if aggregate {
+				return nil, fmt.Errorf("workflow %d requires exactly one of generated jobs or direct command steps", i+1)
+			}
+			return nil, fmt.Errorf("workflow %d requires at least one generated job", i+1)
+		}
+		if hasJobs && hasCommandSteps {
+			return nil, fmt.Errorf("workflow %d cannot mix generated jobs and direct command steps", i+1)
+		}
+		if hasCommandSteps && !aggregate {
+			return nil, fmt.Errorf("workflow %d direct command steps require aggregate emission", i+1)
+		}
+		if hasCommandSteps {
+			if len(workflow.CommandSteps) != 1 {
+				return nil, fmt.Errorf("workflow %d direct mode requires exactly one command step", i+1)
+			}
+			if workflow.GroupLabel != "" || workflow.GroupKey != "" || workflow.CheckName != "" || workflow.Condition != "" || workflow.ConcurrencyGate != nil {
+				return nil, fmt.Errorf("workflow %d direct mode cannot set group metadata or a concurrency gate", i+1)
+			}
+		}
+		if aggregate && !hasCommandSteps {
+			if workflow.GroupLabel == "" {
+				return nil, fmt.Errorf("workflow %d requires a group label", i+1)
+			}
+			if !validStepKey(workflow.GroupKey) {
+				return nil, fmt.Errorf("workflow %d has invalid group key %q", i+1, workflow.GroupKey)
+			}
+			if workflow.CheckName == "" {
+				return nil, fmt.Errorf("workflow %q requires a GitHub Check name", workflow.GroupKey)
+			}
+			if workflow.Condition == "" {
+				return nil, fmt.Errorf("workflow %q requires a trigger condition", workflow.GroupKey)
+			}
+			if owner, exists := usedKeys[workflow.GroupKey]; exists {
+				return nil, fmt.Errorf("workflow group key %q collides with %s", workflow.GroupKey, owner)
+			}
+			usedKeys[workflow.GroupKey] = "workflow group"
+		}
+		var jobs []Job
+		if hasJobs {
+			var err error
+			jobs, err = orderJobs(pipeline.CompilerStep, workflow.Jobs)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if err := validateConcurrencyGate(workflow.ConcurrencyGate); err != nil {
+			return nil, err
+		}
+		for _, job := range jobs {
+			if owner, exists := usedKeys[job.Key]; exists {
+				return nil, fmt.Errorf("generated step key %q collides with %s", job.Key, owner)
+			}
+			usedKeys[job.Key] = "generated job"
+			if owner, exists := usedDigests[job.PlanDigest]; exists {
+				return nil, fmt.Errorf("jobs %q and %q share plan digest %s", owner, job.Key, job.PlanDigest)
+			}
+			usedDigests[job.PlanDigest] = job.Key
+		}
+		for _, step := range workflow.CommandSteps {
+			if err := validateCommandStep(step); err != nil {
+				return nil, err
+			}
+			if owner, exists := usedKeys[step.Key]; exists {
+				return nil, fmt.Errorf("direct command step key %q collides with %s", step.Key, owner)
+			}
+			usedKeys[step.Key] = "direct command step"
+		}
+		prepared[i] = preparedWorkflow{Workflow: workflow, Jobs: jobs, Grouped: aggregate || workflow.GroupLabel != "", Aggregate: aggregate}
+		if workflow.ConcurrencyGate != nil {
+			gateNamespace := pipeline.CompilerStep
+			if aggregate {
+				gateNamespace += "\x00" + workflow.GroupKey
+			}
+			prepared[i].GateOpenKey, prepared[i].GateCloseKey = concurrencyGateKeys(gateNamespace, workflow.ConcurrencyGate.Group, jobs)
+			for _, gateKey := range []string{prepared[i].GateOpenKey, prepared[i].GateCloseKey} {
+				if owner, exists := usedKeys[gateKey]; exists {
+					return nil, fmt.Errorf("workflow concurrency key %q collides with %s", gateKey, owner)
+				}
+				usedKeys[gateKey] = "workflow concurrency gate"
+			}
+		}
 	}
 	if pipeline.RuntimeImage != "" && !runtimeImagePattern.MatchString(pipeline.RuntimeImage) {
 		return nil, fmt.Errorf("runtime image %q must be an immutable registry sha256 reference", pipeline.RuntimeImage)
@@ -107,40 +222,80 @@ func Emit(pipeline Pipeline) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	var out bytes.Buffer
 	out.WriteString("steps:\n")
+	for _, workflow := range prepared {
+		emitWorkflow(&out, pipeline, distributionPath, workflow)
+	}
+	return out.Bytes(), nil
+}
+
+type preparedWorkflow struct {
+	Workflow
+	Jobs                      []Job
+	Grouped                   bool
+	Aggregate                 bool
+	GateOpenKey, GateCloseKey string
+}
+
+func emitWorkflow(out *bytes.Buffer, pipeline Pipeline, distributionPath string, workflow preparedWorkflow) {
+	if len(workflow.CommandSteps) != 0 {
+		emitDirectCommandStep(out, pipeline.CompilerStep, workflow.CommandSteps[0])
+		return
+	}
 	stepIndent := "  "
-	if pipeline.GroupLabel != "" {
-		_, _ = fmt.Fprintf(&out, "  - group: %s\n", yamlScalar(pipeline.GroupLabel))
+	if workflow.Grouped {
+		groupLabel := workflow.GroupLabel
+		if workflow.Aggregate {
+			groupLabel = ":github: " + groupLabel
+		}
+		_, _ = fmt.Fprintf(out, "  - group: %s\n", yamlScalar(groupLabel))
+		if workflow.GroupKey != "" {
+			_, _ = fmt.Fprintf(out, "    key: %s\n", yamlScalar(workflow.GroupKey))
+		}
+		if workflow.Condition != "" {
+			_, _ = fmt.Fprintf(out, "    if: %s\n", yamlScalar(workflow.Condition))
+		}
+		if workflow.CheckName != "" {
+			out.WriteString("    notify:\n")
+			out.WriteString("      - github_check:\n")
+			_, _ = fmt.Fprintf(out, "          name: %s\n", yamlScalar(workflow.CheckName))
+		}
+		if workflow.Aggregate {
+			_, _ = fmt.Fprintf(out, "    depends_on: %s\n", yamlScalar(pipeline.CompilerStep))
+		}
 		out.WriteString("    steps:\n")
 		stepIndent = "      "
 	}
 	attributeIndent := stepIndent + "  "
-	var gateOpenKey, gateCloseKey string
-	if pipeline.ConcurrencyGate != nil {
-		gateOpenKey, gateCloseKey = concurrencyGateKeys(pipeline.CompilerStep, pipeline.ConcurrencyGate.Group, jobs)
-		emitConcurrencyGateStep(&out, stepIndent, attributeIndent, ":github: Start workflow concurrency", gateOpenKey, pipeline.ConcurrencyGate, []dependency{{Step: pipeline.CompilerStep}})
+	if workflow.ConcurrencyGate != nil {
+		dependencies := []dependency{{Step: pipeline.CompilerStep}}
+		if workflow.Aggregate {
+			dependencies = nil
+		}
+		emitConcurrencyGateStep(out, stepIndent, attributeIndent, ":github: Start workflow concurrency", workflow.GateOpenKey, workflow.ConcurrencyGate, dependencies)
 	}
-	for _, job := range jobs {
+	for _, job := range workflow.Jobs {
 		planPath, err := PlanPath(job.PlanDigest)
 		if err != nil {
-			return nil, fmt.Errorf("job %q: %w", job.Key, err)
+			panic(fmt.Sprintf("validated job %q has invalid plan path: %v", job.Key, err))
 		}
-		_, _ = fmt.Fprintf(&out, "%s- label: %s\n", stepIndent, yamlScalar(job.Label))
-		_, _ = fmt.Fprintf(&out, "%skey: %s\n", attributeIndent, yamlScalar(job.Key))
+		_, _ = fmt.Fprintf(out, "%s- label: %s\n", stepIndent, yamlScalar(job.Label))
+		_, _ = fmt.Fprintf(out, "%skey: %s\n", attributeIndent, yamlScalar(job.Key))
 		if pipeline.RuntimeImage != "" {
-			_, _ = fmt.Fprintf(&out, "%simage: %s\n", attributeIndent, yamlScalar(pipeline.RuntimeImage))
+			_, _ = fmt.Fprintf(out, "%simage: %s\n", attributeIndent, yamlScalar(pipeline.RuntimeImage))
 		}
 		commands := []string{
 			"set -euo pipefail",
 			`bootstrap_dir="$(mktemp -d "${TMPDIR:-/tmp}/buildkite-gha.XXXXXXXX")"`,
 			`trap 'rm -rf -- "$bootstrap_dir"' EXIT`,
-			"buildkite-agent artifact download " + shellQuote(distributionPath) + ` "$bootstrap_dir" --step ` + shellQuote(pipeline.CompilerStep),
-			"buildkite-agent artifact download " + shellQuote(planPath) + ` "$bootstrap_dir" --step ` + shellQuote(pipeline.CompilerStep),
+			"buildkite-agent artifact download " + ShellQuote(distributionPath) + ` "$bootstrap_dir" --step ` + ShellQuote(pipeline.CompilerStep),
+			"buildkite-agent artifact download " + ShellQuote(planPath) + ` "$bootstrap_dir" --step ` + ShellQuote(pipeline.CompilerStep),
 			"distribution=\"$bootstrap_dir/" + distributionPath + `"`,
 			"plan=\"$bootstrap_dir/" + planPath + `"`,
 			`actual_distribution_digest="$(sha256sum "$distribution" | awk '{print "sha256:" $1}')"`,
-			"test \"$actual_distribution_digest\" = " + shellQuote(pipeline.DistributionDigest),
+			"test \"$actual_distribution_digest\" = " + ShellQuote(pipeline.DistributionDigest),
 			`chmod 0500 "$distribution"`,
 		}
 		runJob := `"$distribution" run-job --plan "$plan"`
@@ -149,47 +304,68 @@ func Emit(pipeline Pipeline) ([]byte, error) {
 		}
 		commands = append(commands, runJob)
 		command := strings.Join(commands, "\n")
-		_, _ = fmt.Fprintf(&out, "%scommand: %s\n", attributeIndent, yamlScalar(command))
+		_, _ = fmt.Fprintf(out, "%scommand: %s\n", attributeIndent, yamlScalar(command))
 		if job.Queue != "" {
-			_, _ = fmt.Fprintf(&out, "%sagents:\n", attributeIndent)
-			_, _ = fmt.Fprintf(&out, "%s  queue: %s\n", attributeIndent, yamlScalar(job.Queue))
+			_, _ = fmt.Fprintf(out, "%sagents:\n", attributeIndent)
+			_, _ = fmt.Fprintf(out, "%s  queue: %s\n", attributeIndent, yamlScalar(job.Queue))
 		}
-		_, _ = fmt.Fprintf(&out, "%scheckout:\n%s  skip: true\n", attributeIndent, attributeIndent)
+		_, _ = fmt.Fprintf(out, "%scheckout:\n%s  skip: true\n", attributeIndent, attributeIndent)
 		if job.RequiresMise {
-			_, _ = fmt.Fprintf(&out, "%scache:\n", attributeIndent)
-			_, _ = fmt.Fprintf(&out, "%s  paths:\n", attributeIndent)
-			_, _ = fmt.Fprintf(&out, "%s    - %s\n", attributeIndent, yamlScalar(runtimeCachePath))
-			_, _ = fmt.Fprintf(&out, "%s  name: %s\n", attributeIndent, yamlScalar(runtimeCacheName))
+			_, _ = fmt.Fprintf(out, "%scache:\n", attributeIndent)
+			_, _ = fmt.Fprintf(out, "%s  paths:\n", attributeIndent)
+			_, _ = fmt.Fprintf(out, "%s    - %s\n", attributeIndent, yamlScalar(runtimeCachePath))
+			_, _ = fmt.Fprintf(out, "%s  name: %s\n", attributeIndent, yamlScalar(runtimeCacheName))
 		}
-		_, _ = fmt.Fprintf(&out, "%senv:\n", attributeIndent)
-		_, _ = fmt.Fprintf(&out, "%s  BUILDKITE_GHA_PLAN_DIGEST: %s\n", attributeIndent, yamlScalar(job.PlanDigest))
-		_, _ = fmt.Fprintf(&out, "%s  BUILDKITE_GHA_PLAN_PATH: %s\n", attributeIndent, yamlScalar(planPath))
-		_, _ = fmt.Fprintf(&out, "%s  BUILDKITE_GHA_PLAN_PRODUCER: %s\n", attributeIndent, yamlScalar(pipeline.CompilerStep))
+		_, _ = fmt.Fprintf(out, "%senv:\n", attributeIndent)
+		_, _ = fmt.Fprintf(out, "%s  BUILDKITE_GHA_PLAN_DIGEST: %s\n", attributeIndent, yamlScalar(job.PlanDigest))
+		_, _ = fmt.Fprintf(out, "%s  BUILDKITE_GHA_PLAN_PATH: %s\n", attributeIndent, yamlScalar(planPath))
+		_, _ = fmt.Fprintf(out, "%s  BUILDKITE_GHA_PLAN_PRODUCER: %s\n", attributeIndent, yamlScalar(pipeline.CompilerStep))
 		if job.RequiresMise {
-			_, _ = fmt.Fprintf(&out, "%s  BUILDKITE_GHA_MISE_DATA_DIR: %s\n", attributeIndent, yamlScalar(MiseDataDir()))
+			_, _ = fmt.Fprintf(out, "%s  BUILDKITE_GHA_MISE_DATA_DIR: %s\n", attributeIndent, yamlScalar(MiseDataDir()))
 		}
 		if job.Concurrency != 0 {
-			_, _ = fmt.Fprintf(&out, "%sconcurrency: %d\n", attributeIndent, job.Concurrency)
-			_, _ = fmt.Fprintf(&out, "%sconcurrency_group: %s\n", attributeIndent, yamlScalar(job.ConcurrencyGroup))
+			_, _ = fmt.Fprintf(out, "%sconcurrency: %d\n", attributeIndent, job.Concurrency)
+			_, _ = fmt.Fprintf(out, "%sconcurrency_group: %s\n", attributeIndent, yamlScalar(job.ConcurrencyGroup))
 		}
-		_, _ = fmt.Fprintf(&out, "%sdepends_on:\n", attributeIndent)
-		_, _ = fmt.Fprintf(&out, "%s  - step: %s\n%s    allow_failure: false\n", attributeIndent, yamlScalar(pipeline.CompilerStep), attributeIndent)
-		if gateOpenKey != "" {
-			_, _ = fmt.Fprintf(&out, "%s  - step: %s\n%s    allow_failure: false\n", attributeIndent, yamlScalar(gateOpenKey), attributeIndent)
+		if !workflow.Aggregate {
+			_, _ = fmt.Fprintf(out, "%sdepends_on:\n", attributeIndent)
+			_, _ = fmt.Fprintf(out, "%s  - step: %s\n%s    allow_failure: false\n", attributeIndent, yamlScalar(pipeline.CompilerStep), attributeIndent)
+		} else if workflow.GateOpenKey != "" || len(job.Dependencies) != 0 {
+			_, _ = fmt.Fprintf(out, "%sdepends_on:\n", attributeIndent)
+		}
+		if workflow.GateOpenKey != "" {
+			_, _ = fmt.Fprintf(out, "%s  - step: %s\n%s    allow_failure: false\n", attributeIndent, yamlScalar(workflow.GateOpenKey), attributeIndent)
 		}
 		for _, dependency := range job.Dependencies {
-			_, _ = fmt.Fprintf(&out, "%s  - step: %s\n%s    allow_failure: true\n", attributeIndent, yamlScalar(dependency), attributeIndent)
+			_, _ = fmt.Fprintf(out, "%s  - step: %s\n%s    allow_failure: true\n", attributeIndent, yamlScalar(dependency), attributeIndent)
 		}
 	}
-	if pipeline.ConcurrencyGate != nil {
-		dependencies := make([]dependency, 0, len(jobs)+1)
-		dependencies = append(dependencies, dependency{Step: pipeline.CompilerStep})
-		for _, job := range jobs {
+	if workflow.ConcurrencyGate != nil {
+		dependencies := make([]dependency, 0, len(workflow.Jobs)+1)
+		if !workflow.Aggregate {
+			dependencies = append(dependencies, dependency{Step: pipeline.CompilerStep})
+		}
+		for _, job := range workflow.Jobs {
 			dependencies = append(dependencies, dependency{Step: job.Key, AllowFailure: true})
 		}
-		emitConcurrencyGateStep(&out, stepIndent, attributeIndent, ":github: Finish workflow concurrency", gateCloseKey, pipeline.ConcurrencyGate, dependencies)
+		emitConcurrencyGateStep(out, stepIndent, attributeIndent, ":github: Finish workflow concurrency", workflow.GateCloseKey, workflow.ConcurrencyGate, dependencies)
 	}
-	return out.Bytes(), nil
+}
+
+func emitDirectCommandStep(out *bytes.Buffer, compilerStep string, step CommandStep) {
+	_, _ = fmt.Fprintf(out, "  - label: %s\n", yamlScalar(step.Label))
+	_, _ = fmt.Fprintf(out, "    key: %s\n", yamlScalar(step.Key))
+	_, _ = fmt.Fprintf(out, "    depends_on: %s\n", yamlScalar(compilerStep))
+	out.WriteString("    notify:\n")
+	out.WriteString("      - github_check:\n")
+	_, _ = fmt.Fprintf(out, "          name: %s\n", yamlScalar(step.CheckName))
+	_, _ = fmt.Fprintf(out, "    command: %s\n", yamlScalar(step.Command))
+	if step.Queue != "" {
+		out.WriteString("    agents:\n")
+		_, _ = fmt.Fprintf(out, "      queue: %s\n", yamlScalar(step.Queue))
+	}
+	out.WriteString("    checkout:\n")
+	out.WriteString("      skip: true\n")
 }
 
 type dependency struct {
@@ -208,6 +384,9 @@ func emitConcurrencyGateStep(out *bytes.Buffer, stepIndent, attributeIndent, lab
 	_, _ = fmt.Fprintf(out, "%scheckout:\n%s  skip: true\n", attributeIndent, attributeIndent)
 	_, _ = fmt.Fprintf(out, "%sconcurrency: 1\n", attributeIndent)
 	_, _ = fmt.Fprintf(out, "%sconcurrency_group: %s\n", attributeIndent, yamlScalar(gate.Group))
+	if len(dependencies) == 0 {
+		return
+	}
 	_, _ = fmt.Fprintf(out, "%sdepends_on:\n", attributeIndent)
 	for _, dependency := range dependencies {
 		_, _ = fmt.Fprintf(out, "%s  - step: %s\n%s    allow_failure: %t\n", attributeIndent, yamlScalar(dependency.Step), attributeIndent, dependency.AllowFailure)
@@ -256,8 +435,28 @@ func uniqueStepKey(base string, used map[string]struct{}) string {
 	}
 }
 
-func shellQuote(value string) string {
+// ShellQuote returns one POSIX shell word which expands to value literally.
+func ShellQuote(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}
+
+func validateCommandStep(step CommandStep) error {
+	if !validStepKey(step.Key) {
+		return fmt.Errorf("invalid direct command step key %q", step.Key)
+	}
+	if step.Label == "" {
+		return fmt.Errorf("direct command step %q requires a label", step.Key)
+	}
+	if step.CheckName == "" {
+		return fmt.Errorf("direct command step %q requires a GitHub Check name", step.Key)
+	}
+	if step.Command == "" {
+		return fmt.Errorf("direct command step %q requires a command", step.Key)
+	}
+	if step.Queue != "" && !identifierPattern.MatchString(step.Queue) {
+		return fmt.Errorf("direct command step %q has invalid queue %q", step.Key, step.Queue)
+	}
+	return nil
 }
 
 func orderJobs(compilerStep string, input []Job) ([]Job, error) {

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -79,7 +79,7 @@ func TestEmitGolden(t *testing.T) {
 		}
 		if !strings.Contains(step.Command, `bootstrap_dir="$(mktemp -d "${TMPDIR:-/tmp}/buildkite-gha.XXXXXXXX")"`) ||
 			!strings.Contains(step.Command, `sha256sum "$distribution"`) ||
-			!strings.Contains(step.Command, `test "$actual_distribution_digest" = `+shellQuote(pipeline.DistributionDigest)) ||
+			!strings.Contains(step.Command, `test "$actual_distribution_digest" = `+ShellQuote(pipeline.DistributionDigest)) ||
 			!strings.Contains(step.Command, `"$distribution" run-job --plan "$plan"`) {
 			t.Fatalf("step %q does not bootstrap and verify its exact distribution:\n%s", step.Key, step.Command)
 		}
@@ -131,6 +131,322 @@ func TestEmitMergesIntoContainingGroup(t *testing.T) {
 	job := document.Steps[0].Steps[0]
 	if job.Key != "job" || len(job.DependsOn) != 1 || job.DependsOn[0].Step != "importer" || job.DependsOn[0].AllowFailure {
 		t.Fatalf("grouped job = %#v", job)
+	}
+}
+
+func TestEmitAggregateWorkflowGroups(t *testing.T) {
+	output, err := Emit(Pipeline{
+		CompilerStep:       "importer",
+		DistributionDigest: testDigest("distribution"),
+		Workflows: []Workflow{
+			{
+				GroupLabel: "CI", GroupKey: "gha-workflow-1111111111111111", CheckName: "Buildkite / CI (push)", Condition: `build.source_event == "push"`,
+				Jobs: []Job{{Key: "gha-1111111111111111-test", Label: "Test", PlanDigest: testDigest("first plan")}},
+			},
+			{
+				GroupLabel: ".github/workflows/release.yml", GroupKey: "gha-workflow-2222222222222222", CheckName: "Buildkite / .github/workflows/release \"quoted\".yml\nnext (workflow_dispatch)", Condition: `build.source == "ui"`,
+				Jobs: []Job{{Key: "gha-2222222222222222-test", Label: "Test", PlanDigest: testDigest("second plan")}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document struct {
+		Steps []struct {
+			Group     string `yaml:"group"`
+			Key       string `yaml:"key"`
+			Condition string `yaml:"if"`
+			DependsOn string `yaml:"depends_on"`
+			Notify    []struct {
+				GitHubCheck struct {
+					Name string `yaml:"name"`
+				} `yaml:"github_check"`
+			} `yaml:"notify"`
+			Steps []struct {
+				Key       string            `yaml:"key"`
+				Command   string            `yaml:"command"`
+				Env       map[string]string `yaml:"env"`
+				Notify    any               `yaml:"notify"`
+				DependsOn *yaml.Node        `yaml:"depends_on"`
+			} `yaml:"steps"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(output, &document); err != nil {
+		t.Fatal(err)
+	}
+	if len(document.Steps) != 2 || document.Steps[0].Group != ":github: CI" || document.Steps[0].Key != "gha-workflow-1111111111111111" || document.Steps[0].Condition != `build.source_event == "push"` || document.Steps[0].DependsOn != "importer" || len(document.Steps[0].Notify) != 1 || document.Steps[0].Notify[0].GitHubCheck.Name != "Buildkite / CI (push)" || len(document.Steps[0].Steps) != 1 || document.Steps[0].Steps[0].Key != "gha-1111111111111111-test" || document.Steps[0].Steps[0].Notify != nil {
+		t.Fatalf("first aggregate group = %#v\n%s", document.Steps, output)
+	}
+	if document.Steps[1].Group != ":github: .github/workflows/release.yml" || document.Steps[1].Key != "gha-workflow-2222222222222222" || document.Steps[1].DependsOn != "importer" || len(document.Steps[1].Notify) != 1 || document.Steps[1].Notify[0].GitHubCheck.Name != "Buildkite / .github/workflows/release \"quoted\".yml\nnext (workflow_dispatch)" || len(document.Steps[1].Steps) != 1 || document.Steps[1].Steps[0].Key != "gha-2222222222222222-test" || document.Steps[1].Steps[0].Notify != nil {
+		t.Fatalf("second aggregate group = %#v\n%s", document.Steps[1], output)
+	}
+	for _, group := range document.Steps {
+		for _, step := range group.Steps {
+			if step.DependsOn != nil {
+				t.Fatalf("dependency-free aggregate child %q emitted depends_on: %#v", step.Key, step.DependsOn)
+			}
+			if step.Env["BUILDKITE_GHA_PLAN_PRODUCER"] != "importer" || strings.Count(step.Command, `--step 'importer'`) != 2 {
+				t.Fatalf("aggregate child %q does not fetch artifacts from importer: env %#v, command %q", step.Key, step.Env, step.Command)
+			}
+		}
+	}
+	if !strings.Contains(string(output), `name: "Buildkite / .github/workflows/release \"quoted\".yml\nnext (workflow_dispatch)"`) {
+		t.Fatalf("GitHub Check name did not use YAML scalar escaping:\n%s", output)
+	}
+}
+
+func TestEmitAggregateDirectCommandStepsAreIsolatedAndShellSafe(t *testing.T) {
+	temporary := t.TempDir()
+	commandSubstitutionMarker := filepath.Join(temporary, "command-substitution-ran")
+	backtickMarker := filepath.Join(temporary, "backtick-ran")
+	message := "parse 'single' and \"double\"; $(touch " + commandSubstitutionMarker + ") `touch " + backtickMarker + "` $HOME\n---\n-leading: [yaml] # punctuation & * ? | > < = ! % @"
+	command := "printf '%s\\n' " + ShellQuote(message) + " >&2\nexit 1"
+	image := "buildkite.namespace-images.com/agent-base@sha256:" + strings.Repeat("0", 64)
+	output, err := Emit(Pipeline{
+		CompilerStep:       "importer",
+		DistributionDigest: testDigest("distribution"),
+		RuntimeImage:       image,
+		Workflows: []Workflow{
+			{CommandSteps: []CommandStep{{Key: "parse-error-queued", Label: ":github: Broken queued (push)", CheckName: "Buildkite / Broken queued (push)", Command: command, Queue: "hosted"}}},
+			{CommandSteps: []CommandStep{{Key: "parse-error-default", Label: ":github: Broken default (push)", CheckName: "Buildkite / Broken default (push)", Command: command}}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	type emittedCommandStep struct {
+		Group     string `yaml:"group"`
+		Label     string `yaml:"label"`
+		Key       string `yaml:"key"`
+		Condition string `yaml:"if"`
+		DependsOn string `yaml:"depends_on"`
+		Notify    []struct {
+			GitHubCheck struct {
+				Name string `yaml:"name"`
+			} `yaml:"github_check"`
+		} `yaml:"notify"`
+		Command  string            `yaml:"command"`
+		Image    string            `yaml:"image"`
+		Agents   map[string]string `yaml:"agents"`
+		Env      *yaml.Node        `yaml:"env"`
+		Cache    *yaml.Node        `yaml:"cache"`
+		Steps    *yaml.Node        `yaml:"steps"`
+		Checkout struct {
+			Skip bool `yaml:"skip"`
+		} `yaml:"checkout"`
+	}
+	var document struct {
+		Steps []emittedCommandStep `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(output, &document); err != nil {
+		t.Fatalf("parse direct command pipeline: %v\n%s", err, output)
+	}
+	if len(document.Steps) != 2 {
+		t.Fatalf("direct command steps = %#v", document.Steps)
+	}
+	for i, step := range document.Steps {
+		wantLabel := []string{":github: Broken queued (push)", ":github: Broken default (push)"}[i]
+		wantCheck := []string{"Buildkite / Broken queued (push)", "Buildkite / Broken default (push)"}[i]
+		if step.Group != "" || step.Label != wantLabel || step.Condition != "" || step.DependsOn != "importer" || len(step.Notify) != 1 || step.Notify[0].GitHubCheck.Name != wantCheck || step.Command != command || !step.Checkout.Skip || step.Image != "" || step.Env != nil || step.Cache != nil || step.Steps != nil {
+			t.Fatalf("direct command step %d gained generated-job state: %#v", i, step)
+		}
+	}
+	if document.Steps[0].Agents["queue"] != "hosted" || document.Steps[1].Agents != nil {
+		t.Fatalf("direct command queues = %#v / %#v", document.Steps[0].Agents, document.Steps[1].Agents)
+	}
+
+	var stdout, stderr bytes.Buffer
+	commandProcess := exec.Command("sh", "-c", document.Steps[1].Command)
+	commandProcess.Dir = temporary
+	commandProcess.Stdout = &stdout
+	commandProcess.Stderr = &stderr
+	err = commandProcess.Run()
+	var exitError *exec.ExitError
+	if !errors.As(err, &exitError) || exitError.ExitCode() != 1 {
+		t.Fatalf("direct command exit = %v, want 1", err)
+	}
+	if stdout.Len() != 0 || stderr.String() != message+"\n" {
+		t.Fatalf("direct command stdout/stderr = %q / %q, want exact stderr %q", stdout.String(), stderr.String(), message+"\n")
+	}
+	for _, marker := range []string{commandSubstitutionMarker, backtickMarker} {
+		if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("shell injection marker %q exists or cannot be checked: %v", marker, err)
+		}
+	}
+}
+
+func TestEmitAggregateRejectsInvalidDirectCommandContent(t *testing.T) {
+	digest := testDigest("distribution")
+	metadata := Workflow{GroupLabel: "Broken", GroupKey: "workflow-broken", CheckName: "Buildkite / Broken", Condition: "true"}
+	direct := func(key string) CommandStep {
+		return CommandStep{Key: key, Label: ":github: Broken (push)", CheckName: "Buildkite / Broken (push)", Command: "false"}
+	}
+	tests := []struct {
+		name      string
+		workflows []Workflow
+		want      string
+	}{
+		{name: "empty", workflows: []Workflow{metadata}, want: "requires exactly one of generated jobs or direct command steps"},
+		{
+			name: "mixed",
+			workflows: []Workflow{{
+				GroupLabel: "Mixed", GroupKey: "workflow-mixed", CheckName: "Buildkite / Mixed", Condition: "true",
+				Jobs: []Job{{Key: "job", Label: "Job", PlanDigest: testDigest("plan")}}, CommandSteps: []CommandStep{direct("command")},
+			}},
+			want: "cannot mix generated jobs and direct command steps",
+		},
+		{name: "multiple direct steps", workflows: []Workflow{{CommandSteps: []CommandStep{direct("one"), direct("two")}}}, want: "requires exactly one command step"},
+		{name: "direct group key", workflows: []Workflow{{GroupKey: "workflow-broken", CommandSteps: []CommandStep{direct("command")}}}, want: "cannot set group metadata"},
+		{name: "direct condition", workflows: []Workflow{{Condition: "true", CommandSteps: []CommandStep{direct("command")}}}, want: "cannot set group metadata"},
+		{name: "direct concurrency gate", workflows: []Workflow{{ConcurrencyGate: &ConcurrencyGate{Group: "group"}, CommandSteps: []CommandStep{direct("command")}}}, want: "cannot set group metadata"},
+		{
+			name: "missing direct check",
+			workflows: func() []Workflow {
+				step := direct("command")
+				step.CheckName = ""
+				return []Workflow{{CommandSteps: []CommandStep{step}}}
+			}(),
+			want: "requires a GitHub Check name",
+		},
+		{
+			name:      "importer collision",
+			workflows: []Workflow{{CommandSteps: []CommandStep{direct("importer")}}},
+			want:      `direct command step key "importer" collides with compiler step`,
+		},
+		{
+			name: "generated job collision",
+			workflows: []Workflow{
+				{CommandSteps: []CommandStep{direct("shared")}},
+				{GroupLabel: "Generated", GroupKey: "workflow-generated", CheckName: "Buildkite / Generated", Condition: "true", Jobs: []Job{{Key: "shared", Label: "Job", PlanDigest: testDigest("plan")}}},
+			},
+			want: `generated step key "shared" collides with direct command step`,
+		},
+		{
+			name: "workflow group collision",
+			workflows: []Workflow{
+				{CommandSteps: []CommandStep{direct("workflow-generated")}},
+				{GroupLabel: "Generated", GroupKey: "workflow-generated", CheckName: "Buildkite / Generated", Condition: "true", Jobs: []Job{{Key: "job", Label: "Job", PlanDigest: testDigest("plan")}}},
+			},
+			want: `workflow group key "workflow-generated" collides with direct command step`,
+		},
+		{
+			name: "concurrency gate collision",
+			workflows: func() []Workflow {
+				gate := &ConcurrencyGate{Group: "buildkite-gha/concurrency/generated"}
+				jobs := []Job{{Key: "job", Label: "Job", PlanDigest: testDigest("plan")}}
+				open, _ := concurrencyGateKeys("importer\x00workflow-generated", gate.Group, jobs)
+				return []Workflow{
+					{GroupLabel: "Generated", GroupKey: "workflow-generated", CheckName: "Buildkite / Generated", Condition: "true", ConcurrencyGate: gate, Jobs: jobs},
+					{CommandSteps: []CommandStep{direct(open)}},
+				}
+			}(),
+			want: "collides with workflow concurrency gate",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := Emit(Pipeline{CompilerStep: "importer", DistributionDigest: digest, Workflows: test.workflows})
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Emit() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestEmitAggregateWorkflowConcurrencyDependencies(t *testing.T) {
+	pipeline := Pipeline{
+		CompilerStep:       "importer",
+		DistributionDigest: testDigest("distribution"),
+		Workflows: []Workflow{{
+			GroupLabel:      "CI",
+			GroupKey:        "workflow-ci",
+			CheckName:       "Buildkite / CI",
+			Condition:       "true",
+			ConcurrencyGate: &ConcurrencyGate{Group: "buildkite-gha/concurrency/ci"},
+			Jobs: []Job{
+				{Key: "producer", Label: "Producer", PlanDigest: testDigest("producer")},
+				{Key: "consumer", Label: "Consumer", PlanDigest: testDigest("consumer"), Dependencies: []string{"producer"}},
+			},
+		}},
+	}
+	output, err := Emit(pipeline)
+	if err != nil {
+		t.Fatal(err)
+	}
+	type emittedDependency struct {
+		Step         string `yaml:"step"`
+		AllowFailure bool   `yaml:"allow_failure"`
+	}
+	type emittedStep struct {
+		Key       string              `yaml:"key"`
+		DependsOn []emittedDependency `yaml:"depends_on"`
+	}
+	var document struct {
+		Steps []struct {
+			DependsOn string        `yaml:"depends_on"`
+			Steps     []emittedStep `yaml:"steps"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(output, &document); err != nil {
+		t.Fatalf("parse aggregate concurrency pipeline: %v\n%s", err, output)
+	}
+	if len(document.Steps) != 1 || document.Steps[0].DependsOn != "importer" || len(document.Steps[0].Steps) != 4 {
+		t.Fatalf("aggregate concurrency group = %#v\n%s", document.Steps, output)
+	}
+	openKey, closeKey := concurrencyGateKeys("importer\x00workflow-ci", pipeline.Workflows[0].ConcurrencyGate.Group, pipeline.Workflows[0].Jobs)
+	open, producer, consumer, close := document.Steps[0].Steps[0], document.Steps[0].Steps[1], document.Steps[0].Steps[2], document.Steps[0].Steps[3]
+	if open.Key != openKey || len(open.DependsOn) != 0 {
+		t.Fatalf("aggregate opening gate = %#v", open)
+	}
+	if producer.Key != "producer" || len(producer.DependsOn) != 1 || producer.DependsOn[0].Step != openKey || producer.DependsOn[0].AllowFailure {
+		t.Fatalf("aggregate producer dependencies = %#v", producer)
+	}
+	if consumer.Key != "consumer" || len(consumer.DependsOn) != 2 || consumer.DependsOn[0].Step != openKey || consumer.DependsOn[0].AllowFailure || consumer.DependsOn[1].Step != "producer" || !consumer.DependsOn[1].AllowFailure {
+		t.Fatalf("aggregate consumer dependencies = %#v", consumer)
+	}
+	if close.Key != closeKey || len(close.DependsOn) != 2 || close.DependsOn[0].Step != "producer" || !close.DependsOn[0].AllowFailure || close.DependsOn[1].Step != "consumer" || !close.DependsOn[1].AllowFailure {
+		t.Fatalf("aggregate closing gate dependencies = %#v", close)
+	}
+	for _, step := range document.Steps[0].Steps {
+		for _, dependency := range step.DependsOn {
+			if dependency.Step == pipeline.CompilerStep {
+				t.Fatalf("aggregate child %q retains importer dependency: %#v", step.Key, step.DependsOn)
+			}
+		}
+	}
+}
+
+func TestEmitAggregateRequiresGitHubCheckName(t *testing.T) {
+	_, err := Emit(Pipeline{
+		CompilerStep:       "importer",
+		DistributionDigest: testDigest("distribution"),
+		Workflows: []Workflow{{
+			GroupLabel: "CI", GroupKey: "workflow-ci", Condition: "true",
+			Jobs: []Job{{Key: "test", Label: "Test", PlanDigest: testDigest("plan")}},
+		}},
+	})
+	if err == nil || !strings.Contains(err.Error(), `workflow "workflow-ci" requires a GitHub Check name`) {
+		t.Fatalf("missing GitHub Check name error = %v", err)
+	}
+}
+
+func TestEmitAggregateRejectsCrossWorkflowCollisions(t *testing.T) {
+	base := Pipeline{
+		CompilerStep:       "importer",
+		DistributionDigest: testDigest("distribution"),
+		Workflows: []Workflow{
+			{GroupLabel: "One", GroupKey: "workflow-one", CheckName: "Buildkite / One", Condition: "true", Jobs: []Job{{Key: "shared", Label: "One", PlanDigest: testDigest("one")}}},
+			{GroupLabel: "Two", GroupKey: "workflow-two", CheckName: "Buildkite / Two", Condition: "true", Jobs: []Job{{Key: "shared", Label: "Two", PlanDigest: testDigest("two")}}},
+		},
+	}
+	if _, err := Emit(base); err == nil || !strings.Contains(err.Error(), `generated step key "shared" collides`) {
+		t.Fatalf("duplicate aggregate key error = %v", err)
+	}
+	base.Workflows[1].Jobs[0].Key = "other"
+	base.Workflows[1].Jobs[0].PlanDigest = base.Workflows[0].Jobs[0].PlanDigest
+	if _, err := Emit(base); err == nil || !strings.Contains(err.Error(), "share plan digest") {
+		t.Fatalf("duplicate aggregate plan error = %v", err)
 	}
 }
 

--- a/internal/buildkite/triggers.go
+++ b/internal/buildkite/triggers.go
@@ -1,0 +1,240 @@
+package buildkite
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/buildkite/buildkite-gha/internal/workflow"
+)
+
+// TranslateTriggerCondition converts GitHub's trigger selection into a
+// deterministic Buildkite conditional. It deliberately does not approximate
+// path filtering: Buildkite if_changed has materially different semantics.
+func TranslateTriggerCondition(triggers []workflow.Trigger) (string, error) {
+	var terms []string
+	for _, t := range triggers {
+		term, contributes, err := translateTrigger(t)
+		if err != nil {
+			return "", err
+		}
+		if contributes {
+			terms = append(terms, "("+term+")")
+		}
+	}
+	if len(terms) == 0 {
+		return "", fmt.Errorf("workflow has no supported build source trigger")
+	}
+	return strings.Join(terms, " || "), nil
+}
+
+func translateTrigger(t workflow.Trigger) (string, bool, error) {
+	if t.Paths != nil || t.PathsIgnore != nil {
+		return "", false, fmt.Errorf("%s path filters are unsupported: Buildkite if_changed is not equivalent", t.Event)
+	}
+	switch t.Event {
+	case "workflow_call":
+		return "", false, nil
+	case "workflow_dispatch":
+		if hasWebhookFilters(t) {
+			return "", false, fmt.Errorf("workflow_dispatch has unsupported webhook filters")
+		}
+		return `(build.source == "ui" || build.source == "api")`, true, nil
+	case "schedule":
+		if hasWebhookFilters(t) {
+			return "", false, fmt.Errorf("schedule has unsupported webhook filters")
+		}
+		// Buildkite does not expose the identity of the schedule that created a
+		// build. Cron ownership therefore stays in Buildkite, and every scheduled
+		// workflow group is eligible on any Buildkite scheduled build.
+		return `build.source == "schedule"`, true, nil
+	case "push":
+		if t.Types != nil || t.Workflows != nil {
+			return "", false, fmt.Errorf("push has unsupported filters")
+		}
+		parts := []string{`build.source_event == "push"`}
+		branch, hasBranchFilter, err := refFilters("build.branch", t.Branches, t.BranchesIgnore)
+		if err != nil {
+			return "", false, fmt.Errorf("push branches: %w", err)
+		}
+		tag, hasTagFilter, err := refFilters("build.tag", t.Tags, t.TagsIgnore)
+		if err != nil {
+			return "", false, fmt.Errorf("push tags: %w", err)
+		}
+		if hasBranchFilter && hasTagFilter {
+			parts = append(parts, "((build.tag == null && ("+branch+")) || (build.tag != null && ("+tag+")))")
+		} else if hasBranchFilter {
+			parts = append(parts, `build.tag == null`, branch)
+		} else if hasTagFilter {
+			parts = append(parts, `build.tag != null`, tag)
+		}
+		return strings.Join(parts, " && "), true, nil
+	case "pull_request":
+		if t.Tags != nil || t.TagsIgnore != nil || t.Workflows != nil {
+			return "", false, fmt.Errorf("pull_request tag filters are unsupported")
+		}
+		parts := []string{`build.source_event == "pull_request"`}
+		b, hasBranchFilter, err := refFilters("build.pull_request.base_branch", t.Branches, t.BranchesIgnore)
+		if err != nil {
+			return "", false, fmt.Errorf("pull_request branches: %w", err)
+		}
+		if hasBranchFilter {
+			parts = append(parts, b)
+		}
+		types := t.Types
+		if types == nil {
+			types = []string{"opened", "synchronize", "reopened"}
+		}
+		if len(types) == 0 {
+			return "", false, fmt.Errorf("pull_request types is explicitly empty")
+		}
+		var actions []string
+		for _, a := range types {
+			if !supportedPullRequestAction[a] {
+				return "", false, fmt.Errorf("pull_request activity type %q cannot be mapped exactly", a)
+			}
+			actions = append(actions, `build.source_action == `+yamlScalar(a))
+		}
+		parts = append(parts, "("+strings.Join(actions, " || ")+")")
+		return strings.Join(parts, " && "), true, nil
+	default:
+		return "", false, fmt.Errorf("unsupported GitHub trigger event %q", t.Event)
+	}
+}
+
+var supportedPullRequestAction = map[string]bool{
+	"assigned": true, "unassigned": true, "labeled": true, "unlabeled": true,
+	"opened": true, "edited": true, "closed": true, "reopened": true,
+	"synchronize": true, "converted_to_draft": true, "locked": true, "unlocked": true,
+	"enqueued": true, "dequeued": true, "milestoned": true, "demilestoned": true,
+	"ready_for_review": true, "review_requested": true, "review_request_removed": true,
+	"auto_merge_enabled": true, "auto_merge_disabled": true,
+}
+
+func hasWebhookFilters(t workflow.Trigger) bool {
+	return t.Types != nil || t.Branches != nil || t.BranchesIgnore != nil || t.Tags != nil || t.TagsIgnore != nil || t.Workflows != nil
+}
+
+func refFilters(field string, include, exclude []string) (string, bool, error) {
+	if include != nil && exclude != nil {
+		return "", false, fmt.Errorf("include and ignore filters cannot be combined")
+	}
+	configured := include != nil || exclude != nil
+	if !configured {
+		return "", false, nil
+	}
+	state := ""
+	apply := func(pattern string, positive bool) error {
+		r, err := githubRefGlob(pattern)
+		if err != nil {
+			return err
+		}
+		match := field + " =~ /" + r + "/"
+		if positive {
+			if state == "" {
+				state = match
+			} else {
+				state = "(" + state + " || " + match + ")"
+			}
+		} else if state == "" {
+			state = "!(" + match + ")"
+		} else {
+			state = "(" + state + " && !(" + match + "))"
+		}
+		return nil
+	}
+	positiveSeen := false
+	for _, p := range include {
+		positive := true
+		if strings.HasPrefix(p, "!") {
+			positive = false
+			p = p[1:]
+		}
+		if p == "" {
+			return "", false, fmt.Errorf("empty ref glob")
+		}
+		if !positive && !positiveSeen {
+			return "", false, fmt.Errorf("negative pattern %q must follow a positive pattern", "!"+p)
+		}
+		if err := apply(p, positive); err != nil {
+			return "", false, err
+		}
+		if positive {
+			positiveSeen = true
+		}
+	}
+	if include != nil && len(include) == 0 {
+		return "false", true, nil
+	}
+	if exclude != nil {
+		state = "true"
+	}
+	for _, p := range exclude {
+		if strings.HasPrefix(p, "!") {
+			return "", false, fmt.Errorf("ignore filter pattern %q cannot be negated", p)
+		}
+		if err := apply(p, false); err != nil {
+			return "", false, err
+		}
+	}
+	return state, true, nil
+}
+
+func githubRefGlob(glob string) (string, error) {
+	regexLiteral := func(value string) string {
+		return strings.ReplaceAll(regexp.QuoteMeta(value), "/", `\/`)
+	}
+	type atom struct {
+		value      string
+		modifiable bool
+	}
+	runes := []rune(glob)
+	var atoms []atom
+	for i := 0; i < len(runes); i++ {
+		c := runes[i]
+		switch c {
+		case '\\':
+			if i+1 >= len(runes) {
+				return "", fmt.Errorf("trailing escape in glob %q", glob)
+			}
+			i++
+			atoms = append(atoms, atom{value: regexLiteral(string(runes[i])), modifiable: true})
+		case '*':
+			if i+1 < len(runes) && runes[i+1] == '*' {
+				i++
+				atoms = append(atoms, atom{value: ".*"})
+			} else {
+				atoms = append(atoms, atom{value: `[^\/]*`})
+			}
+		case '[':
+			j := i + 1
+			for j < len(runes) && runes[j] != ']' {
+				j++
+			}
+			if j == len(runes) {
+				return "", fmt.Errorf("unterminated character class in glob %q", glob)
+			}
+			class := string(runes[i : j+1])
+			if _, err := regexp.Compile(class); err != nil {
+				return "", fmt.Errorf("invalid character class in glob %q", glob)
+			}
+			atoms = append(atoms, atom{value: strings.ReplaceAll(class, "/", `\/`), modifiable: true})
+			i = j
+		case '?', '+':
+			if len(atoms) == 0 || !atoms[len(atoms)-1].modifiable {
+				return "", fmt.Errorf("glob %q has invalid %q modifier", glob, c)
+			}
+			atoms[len(atoms)-1].value += string(c)
+			atoms[len(atoms)-1].modifiable = false
+		default:
+			atoms = append(atoms, atom{value: regexLiteral(string(c)), modifiable: true})
+		}
+	}
+	var regex strings.Builder
+	regex.WriteByte('^')
+	for _, atom := range atoms {
+		regex.WriteString(atom.value)
+	}
+	regex.WriteByte('$')
+	return regex.String(), nil
+}

--- a/internal/buildkite/triggers_test.go
+++ b/internal/buildkite/triggers_test.go
@@ -1,0 +1,111 @@
+package buildkite
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/buildkite/buildkite-gha/internal/workflow"
+)
+
+func TestTranslateTriggerCondition(t *testing.T) {
+	got, err := TranslateTriggerCondition([]workflow.Trigger{
+		{Event: "push", Branches: []string{"main", "releases/**", "!releases/**-alpha", "releases/v[0-9]+"}},
+		{Event: "pull_request"}, {Event: "workflow_dispatch"}, {Event: "schedule"}, {Event: "workflow_call"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`build.source_event == "push"`, `build.branch =~ /^main$/`, `releases\/.*`, `build.source_event == "pull_request"`, `build.source_action == "opened"`, `build.source_action == "synchronize"`, `build.source == "ui"`, `build.source == "schedule"`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("condition missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestTranslateTriggerConditionRejectsUnsafeTriggers(t *testing.T) {
+	tests := []struct {
+		name     string
+		triggers []workflow.Trigger
+		want     string
+	}{
+		{name: "paths", triggers: []workflow.Trigger{{Event: "push", Paths: []string{"src/**"}}}, want: "path filters are unsupported"},
+		{name: "event", triggers: []workflow.Trigger{{Event: "issues"}}, want: "unsupported GitHub trigger"},
+		{name: "mixed include ignore", triggers: []workflow.Trigger{{Event: "push", Branches: []string{"main"}, BranchesIgnore: []string{"release"}}}, want: "cannot be combined"},
+		{name: "leading negative", triggers: []workflow.Trigger{{Event: "push", Branches: []string{"!release/**"}}}, want: "must follow a positive"},
+		{name: "unsupported PR type", triggers: []workflow.Trigger{{Event: "pull_request", Types: []string{"not-real"}}}, want: "cannot be mapped exactly"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := TranslateTriggerCondition(test.triggers)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Errorf("TranslateTriggerCondition(%v) error = %v, want %q", test.triggers, err, test.want)
+			}
+		})
+	}
+}
+
+func TestTranslateTriggerConditionRequiresDirectBuildSource(t *testing.T) {
+	_, err := TranslateTriggerCondition([]workflow.Trigger{{Event: "workflow_call"}})
+	if err == nil || !strings.Contains(err.Error(), "no supported build source") {
+		t.Fatalf("TranslateTriggerCondition(workflow_call) error = %v", err)
+	}
+}
+
+func TestTranslatePushSeparatesBranchAndTagFilters(t *testing.T) {
+	condition, err := TranslateTriggerCondition([]workflow.Trigger{{
+		Event:    "push",
+		Branches: []string{"release/**", "!release/**-alpha", "release/special-alpha"},
+		Tags:     []string{"v[0-9]+", "!v0"},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		`build.tag == null &&`, `build.branch =~ /^release\/.*$/`, `&& !(build.branch =~ /^release\/.*-alpha$/)`, `|| build.branch =~ /^release\/special-alpha$/`,
+		`build.tag != null &&`, `build.tag =~ /^v[0-9]+$/`, `&& !(build.tag =~ /^v0$/)`,
+	} {
+		if !strings.Contains(condition, want) {
+			t.Errorf("push condition missing %q:\n%s", want, condition)
+		}
+	}
+}
+
+func TestGitHubRefGlobPreservesEscapedSpecialCharacterModifiers(t *testing.T) {
+	got, err := githubRefGlob(`release/\*?/v[0-9]+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := `^release\/\*?\/v[0-9]+$`; got != want {
+		t.Fatalf("githubRefGlob() = %q, want %q", got, want)
+	}
+	for _, glob := range []string{"?main", "main**+", "main?+"} {
+		if _, err := githubRefGlob(glob); err == nil {
+			t.Errorf("githubRefGlob(%q) succeeded, want invalid modifier", glob)
+		}
+	}
+}
+
+func TestGitHubRefGlobEscapesSlashInsideWildcardClass(t *testing.T) {
+	got, err := githubRefGlob("release/*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := `^release\/[^\/]*$`; got != want {
+		t.Fatalf("githubRefGlob() = %q, want %q", got, want)
+	}
+}
+
+func TestTranslatePullRequestUsesBaseBranchAndExplicitTypes(t *testing.T) {
+	condition, err := TranslateTriggerCondition([]workflow.Trigger{{Event: "pull_request", BranchesIgnore: []string{"docs/**"}, Types: []string{"labeled", "ready_for_review"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`build.pull_request.base_branch`, `!(build.pull_request.base_branch =~ /^docs\/.*$/)`, `build.source_action == "labeled"`, `build.source_action == "ready_for_review"`} {
+		if !strings.Contains(condition, want) {
+			t.Errorf("pull request condition missing %q:\n%s", want, condition)
+		}
+	}
+	if strings.Contains(condition, `source_action == "opened"`) {
+		t.Fatalf("explicit types gained default action:\n%s", condition)
+	}
+}

--- a/internal/cli/buildkite_event.go
+++ b/internal/cli/buildkite_event.go
@@ -44,6 +44,12 @@ func buildkiteEventSource(getenv func(string) string) ([]byte, error) {
 	}
 
 	event, ref := "push", ""
+	switch getenv("BUILDKITE_SOURCE") {
+	case "schedule":
+		event = "schedule"
+	case "ui", "api":
+		event = "workflow_dispatch"
+	}
 	payload := map[string]any{}
 	if pullRequest != "" && pullRequest != "false" {
 		number, parseErr := strconv.Atoi(pullRequest)

--- a/internal/cli/buildkite_event_test.go
+++ b/internal/cli/buildkite_event_test.go
@@ -41,6 +41,13 @@ func TestBuildkiteEventSourceMappings(t *testing.T) {
 		check            func(t *testing.T, snapshot map[string]any)
 	}{
 		{name: "branch", event: "push", ref: "refs/heads/main", env: map[string]string{"BUILDKITE_BRANCH": "main"}},
+		{name: "UI", event: "workflow_dispatch", ref: "refs/heads/main", env: map[string]string{"BUILDKITE_BRANCH": "main", "BUILDKITE_SOURCE": "ui"}},
+		{name: "API", event: "workflow_dispatch", ref: "refs/heads/main", env: map[string]string{"BUILDKITE_BRANCH": "main", "BUILDKITE_SOURCE": "api"}},
+		{name: "schedule", event: "schedule", ref: "refs/heads/main", env: map[string]string{"BUILDKITE_BRANCH": "main", "BUILDKITE_SOURCE": "schedule"}},
+		{name: "empty source fallback", event: "push", ref: "refs/heads/main", env: map[string]string{"BUILDKITE_BRANCH": "main", "BUILDKITE_SOURCE": ""}},
+		{name: "unknown source fallback", event: "push", ref: "refs/heads/main", env: map[string]string{"BUILDKITE_BRANCH": "main", "BUILDKITE_SOURCE": "unknown"}},
+		{name: "webhook source fallback", event: "push", ref: "refs/heads/main", env: map[string]string{"BUILDKITE_BRANCH": "main", "BUILDKITE_SOURCE": "webhook"}},
+		{name: "trigger job source fallback", event: "push", ref: "refs/heads/main", env: map[string]string{"BUILDKITE_BRANCH": "main", "BUILDKITE_SOURCE": "trigger_job"}},
 		{name: "tag", event: "push", ref: "refs/tags/v1.2.3", env: map[string]string{"BUILDKITE_TAG": "v1.2.3"}},
 		{name: "pull request head compatibility ref", event: "pull_request", ref: "refs/pull/42/head", env: map[string]string{"BUILDKITE_PULL_REQUEST": "42", "BUILDKITE_BRANCH": "contributor:feature", "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "main", "BUILDKITE_PULL_REQUEST_REPO": "https://github.com/contributor/widgets.git"}, check: func(t *testing.T, snapshot map[string]any) {
 			payload := snapshot["payload"].(map[string]any)
@@ -52,6 +59,10 @@ func TestBuildkiteEventSourceMappings(t *testing.T) {
 				t.Fatalf("pull request payload = %#v", payload)
 			}
 		}},
+		{name: "pull request overrides UI", event: "pull_request", ref: "refs/pull/42/head", env: map[string]string{"BUILDKITE_PULL_REQUEST": "42", "BUILDKITE_BRANCH": "feature", "BUILDKITE_SOURCE": "ui"}},
+		{name: "pull request overrides API", event: "pull_request", ref: "refs/pull/42/head", env: map[string]string{"BUILDKITE_PULL_REQUEST": "42", "BUILDKITE_BRANCH": "feature", "BUILDKITE_SOURCE": "api"}},
+		{name: "pull request overrides schedule", event: "pull_request", ref: "refs/pull/42/head", env: map[string]string{"BUILDKITE_PULL_REQUEST": "42", "BUILDKITE_BRANCH": "feature", "BUILDKITE_SOURCE": "schedule"}},
+		{name: "pull request overrides fallback source", event: "pull_request", ref: "refs/pull/42/head", env: map[string]string{"BUILDKITE_PULL_REQUEST": "42", "BUILDKITE_BRANCH": "feature", "BUILDKITE_SOURCE": "webhook"}},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -32,6 +33,7 @@ import (
 	"github.com/buildkite/buildkite-gha/internal/plan"
 	gharuntime "github.com/buildkite/buildkite-gha/internal/runtime"
 	"github.com/buildkite/buildkite-gha/internal/transport"
+	"github.com/buildkite/buildkite-gha/internal/workflow"
 )
 
 const usage = `Usage:
@@ -50,7 +52,7 @@ Run "buildkite-gha help <command>" for command help.
 var commandUsage = map[string]string{
 	"validate": "Usage: buildkite-gha validate [--event-path <path>] [--profile hosted-tokenless] [--format text|json] <workflow>\n",
 	"compile":  "Usage: buildkite-gha compile --event-path <path> [--format pipeline|ir-json] <workflow>\n",
-	"upload":   "Usage: buildkite-gha upload [--event-path <path>] [--runtime-queue hosted] <workflow>\n",
+	"upload":   "Usage: buildkite-gha upload [--event-path <path>] [--runtime-queue hosted] <workflow-pattern>\n",
 	"run-job":  "Usage: buildkite-gha run-job --plan <path> [--result <path>] [--hosted-tool-cache]\n",
 }
 
@@ -62,7 +64,7 @@ func writeCommandHelp(stdout io.Writer, command string) {
 	case "compile":
 		_, _ = fmt.Fprint(stdout, "\nPipeline output references content-addressed plans; compile does not materialize or upload those artifacts.\n")
 	case "upload":
-		_, _ = fmt.Fprintf(stdout, "\nGenerated jobs use Buildkite's default agent targeting. An importer can explicitly target one queue with %s; that queue must be suitable for untrusted workflow code. It can select an immutable image for generated jobs with %s. The deprecated --runtime-queue hosted option is accepted for plugin compatibility but does not select a queue. Event precedence is an explicit event file, Buildkite's reserved webhook metadata, then reduced-fidelity Buildkite environment compatibility data; every source remains unsigned. Verified checkout jobs automatically use Buildkite repository-provider Git credentials when the job enables them; the deprecated --private-checkout option is accepted as a no-op.\n", targetQueueEnvironment, runtimeImageEnvironment)
+		_, _ = fmt.Fprintf(stdout, "\nThe workflow pattern is expanded against tracked files and uploaded as one aggregate pipeline with one group per directly runnable workflow; reusable-only workflow_call files are imported through callers but do not become groups. Scheduled groups select only build.source == schedule: Buildkite schedules retain cron ownership, so every scheduled workflow group is eligible on any Buildkite scheduled build. Generated jobs use Buildkite's default agent targeting. An importer can explicitly target one queue with %s; that queue must be suitable for untrusted workflow code. It can select an immutable image for generated jobs with %s. The deprecated --runtime-queue hosted option is accepted for plugin compatibility but does not select a queue. Event precedence is an explicit event file, Buildkite's reserved webhook metadata, then reduced-fidelity Buildkite environment compatibility data; every source remains unsigned. Verified checkout jobs automatically use Buildkite repository-provider Git credentials when the job enables them; the deprecated --private-checkout option is accepted as a no-op.\n", targetQueueEnvironment, runtimeImageEnvironment)
 	}
 }
 
@@ -1086,7 +1088,7 @@ func writeCompilerWarnings(stderr io.Writer, command, path string, warnings []co
 }
 
 func upload(args []string, stdout, stderr io.Writer, version string, agent transport.Agent) int {
-	workflowPath, eventPath, err := uploadArgs(args)
+	workflowPattern, eventPath, err := uploadArgs(args)
 	if err != nil {
 		return usageError(stderr, "upload: %v", err)
 	}
@@ -1102,9 +1104,31 @@ func upload(args []string, stdout, stderr io.Writer, version string, agent trans
 	if os.Getenv("BUILDKITE") != "true" || strings.TrimSpace(importerStep) == "" {
 		return usageError(stderr, "upload: BUILDKITE=true and BUILDKITE_STEP_KEY are required")
 	}
-	workflowSource, err := os.ReadFile(workflowPath)
+	workflows, err := expandWorkflowPattern(workflowPattern)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
+		return 1
+	}
+	uploadableWorkflowCount := 0
+	for i := range workflows {
+		workflows[i].Source, err = os.ReadFile(workflows[i].Path)
+		if err != nil {
+			_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: read workflow %s: %v\n", workflows[i].CanonicalPath, err)
+			return 1
+		}
+		parsed, parseErr := workflow.Parse(workflows[i].Path, workflows[i].Source)
+		if parseErr != nil {
+			workflows[i].ParseErr = parseErr
+			uploadableWorkflowCount++
+			continue
+		}
+		workflows[i].ReusableOnly = parsed.ReusableOnly()
+		if !workflows[i].ReusableOnly {
+			uploadableWorkflowCount++
+		}
+	}
+	if uploadableWorkflowCount == 0 {
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: workflow pattern %q matched only reusable workflow_call workflows; there is nothing to upload\n", workflowPattern)
 		return 1
 	}
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -1132,26 +1156,92 @@ func upload(args []string, stdout, stderr io.Writer, version string, agent trans
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
 		return 1
 	}
+	activeEvent, err := compiler.EventName(eventSource)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
+		return 1
+	}
 	executablePath, executableContents, distributionDigest, err := executable()
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
 		return 1
 	}
-	preflight, err := compileHostedTokenless(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, os.Getenv("BUILDKITE_GROUP_LABEL"), targetQueue, runtimeImage, jobScopedActionSourceAuthentication(stderr))
+	authentication := jobScopedActionSourceAuthentication(stderr)
+	generatedWorkflows := make([]buildkitepipeline.Workflow, 0, len(workflows))
+	planArtifacts := make([]compiler.PlanArtifact, 0)
+	jobCount := 0
+	for _, input := range workflows {
+		if input.ReusableOnly {
+			continue
+		}
+		if input.ParseErr != nil {
+			displayLabel := input.CanonicalPath + " (" + activeEvent + ")"
+			generatedWorkflows = append(generatedWorkflows, buildkitepipeline.Workflow{
+				CommandSteps: []buildkitepipeline.CommandStep{{
+					Key:       "gha-" + input.Identity + "-parse-error",
+					Label:     ":github: " + displayLabel,
+					CheckName: "Buildkite / " + displayLabel,
+					Command:   "printf '%s\\n' " + buildkitepipeline.ShellQuote(input.ParseErr.Error()) + " >&2\nexit 1",
+					Queue:     targetQueue,
+				}},
+			})
+			jobCount++
+			continue
+		}
+		preflight, err := compileHostedTokenlessNamespaced(ctx, input.Path, input.Source, eventSource, version, distributionDigest, importerStep, "", targetQueue, runtimeImage, input.StepKeyNamespace, authentication)
+		if err != nil {
+			_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %s: %v\n", input.CanonicalPath, err)
+			return 1
+		}
+		bundle := preflight.Bundle
+		if bundle.IR.Event.Event != activeEvent {
+			_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %s: compiler event %q does not match active event %q\n", input.CanonicalPath, bundle.IR.Event.Event, activeEvent)
+			return 1
+		}
+		condition, err := buildkitepipeline.TranslateTriggerCondition(bundle.IR.Workflow.Triggers)
+		if err != nil {
+			_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %s: translate workflow triggers: %v\n", input.CanonicalPath, err)
+			return 1
+		}
+		label := bundle.IR.Workflow.Name
+		if label == "" {
+			label = input.CanonicalPath
+		}
+		displayLabel := label + " (" + bundle.IR.Event.Event + ")"
+		generated := bundle.GeneratedWorkflow
+		generated.GroupLabel = displayLabel
+		generated.GroupKey = "gha-workflow-" + input.Identity
+		generated.CheckName = "Buildkite / " + displayLabel
+		generated.Condition = condition
+		generatedWorkflows = append(generatedWorkflows, generated)
+		planArtifacts = append(planArtifacts, bundle.Plans...)
+		jobCount += len(bundle.Plans)
+		writeCompilerWarnings(stderr, "upload", input.CanonicalPath, bundle.IR.Warnings)
+	}
+	aggregatePipeline, err := buildkitepipeline.Emit(buildkitepipeline.Pipeline{
+		CompilerStep:       importerStep,
+		DistributionDigest: distributionDigest,
+		RuntimeImage:       runtimeImage,
+		Workflows:          generatedWorkflows,
+	})
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: emit aggregate Buildkite pipeline: %v\n", err)
 		return 1
 	}
-	bundle := preflight.Bundle
-	writeCompilerWarnings(stderr, "upload", workflowPath, bundle.IR.Warnings)
-	artifacts := make([]transport.Artifact, 0, 1+len(bundle.Plans))
+	artifacts := make([]transport.Artifact, 0, 1+len(planArtifacts))
 	distributionPath, err := buildkitepipeline.DistributionPath(distributionDigest)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
 		return 1
 	}
 	artifacts = append(artifacts, transport.Artifact{Path: distributionPath, Digest: distributionDigest, Contents: executableContents})
-	for _, jobPlan := range bundle.Plans {
+	artifactPaths := map[string]struct{}{distributionPath: {}}
+	for _, jobPlan := range planArtifacts {
+		if _, exists := artifactPaths[jobPlan.Path]; exists {
+			_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: duplicate aggregate artifact path %q\n", jobPlan.Path)
+			return 1
+		}
+		artifactPaths[jobPlan.Path] = struct{}{}
 		artifacts = append(artifacts, transport.Artifact{Path: jobPlan.Path, Digest: jobPlan.Digest, Contents: jobPlan.Contents})
 	}
 	root, err := os.MkdirTemp("", "buildkite-gha-upload-")
@@ -1161,12 +1251,99 @@ func upload(args []string, stdout, stderr io.Writer, version string, agent trans
 	}
 	defer func() { _ = os.RemoveAll(root) }()
 
-	if err := transport.UploadArtifacts(ctx, agent, root, artifacts, bundle.Pipeline); err != nil {
+	if err := transport.UploadArtifacts(ctx, agent, root, artifacts, aggregatePipeline); err != nil {
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
 		return 1
 	}
-	_, _ = fmt.Fprintf(stdout, "Uploaded %d jobs from %s with importer %s.\n", len(bundle.Plans), executablePath, importerStep)
+	_, _ = fmt.Fprintf(stdout, "Uploaded %d jobs from %d workflows using %s with importer %s.\n", jobCount, len(generatedWorkflows), executablePath, importerStep)
 	return 0
+}
+
+type workflowInput struct {
+	Path, CanonicalPath, Identity, StepKeyNamespace string
+	Source                                          []byte
+	ReusableOnly                                    bool
+	ParseErr                                        error
+}
+
+func expandWorkflowPattern(pattern string) ([]workflowInput, error) {
+	patternHasMeta := strings.ContainsAny(pattern, "*?[")
+	if info, err := os.Stat(pattern); err == nil && !info.IsDir() {
+		// An existing path is always literal, even when its filename contains
+		// glob metacharacters. This preserves the pre-pattern CLI contract.
+		patternHasMeta = false
+	}
+	rootBytes, rootErr := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if rootErr != nil {
+		if !patternHasMeta {
+			if info, err := os.Stat(pattern); err == nil && !info.IsDir() {
+				return workflowInputs([]workflowInput{{Path: pattern, CanonicalPath: filepath.ToSlash(filepath.Clean(pattern))}}, false)
+			}
+		}
+		return nil, fmt.Errorf("locate checked-out git repository: %w", rootErr)
+	}
+	root := strings.TrimSpace(string(rootBytes))
+	absolutePattern, err := filepath.Abs(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("resolve workflow pattern %q: %w", pattern, err)
+	}
+	relativePattern, err := filepath.Rel(root, absolutePattern)
+	if err != nil || relativePattern == ".." || strings.HasPrefix(relativePattern, ".."+string(filepath.Separator)) {
+		if !patternHasMeta {
+			if info, statErr := os.Stat(pattern); statErr == nil && !info.IsDir() {
+				return workflowInputs([]workflowInput{{Path: pattern, CanonicalPath: filepath.ToSlash(filepath.Clean(pattern))}}, false)
+			}
+		}
+		return nil, fmt.Errorf("workflow pattern %q is outside the checked-out git repository", pattern)
+	}
+	pathspecMagic := ":(literal)"
+	if patternHasMeta {
+		pathspecMagic = ":(glob)"
+	}
+	command := exec.Command("git", "-C", root, "ls-files", "-z", "--", pathspecMagic+filepath.ToSlash(relativePattern))
+	output, err := command.Output()
+	if err != nil {
+		return nil, fmt.Errorf("expand workflow pattern %q against tracked files: %w", pattern, err)
+	}
+	var matches []workflowInput
+	for _, entry := range bytes.Split(output, []byte{0}) {
+		if len(entry) == 0 {
+			continue
+		}
+		canonical := string(entry)
+		matches = append(matches, workflowInput{Path: filepath.Join(root, filepath.FromSlash(canonical)), CanonicalPath: canonical})
+	}
+	if len(matches) == 0 && !patternHasMeta {
+		if info, statErr := os.Stat(pattern); statErr == nil && !info.IsDir() {
+			return workflowInputs([]workflowInput{{Path: pattern, CanonicalPath: filepath.ToSlash(filepath.Clean(pattern))}}, false)
+		}
+	}
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("workflow pattern %q matched no tracked files", pattern)
+	}
+	return workflowInputs(matches, patternHasMeta || len(matches) > 1)
+}
+
+func workflowInputs(matches []workflowInput, namespaceKeys bool) ([]workflowInput, error) {
+	sort.Slice(matches, func(i, j int) bool { return matches[i].CanonicalPath < matches[j].CanonicalPath })
+	out := matches[:0]
+	identities := make(map[string]string, len(matches))
+	for _, match := range matches {
+		if len(out) != 0 && out[len(out)-1].CanonicalPath == match.CanonicalPath {
+			continue
+		}
+		digest := sha256.Sum256([]byte(match.CanonicalPath))
+		match.Identity = hex.EncodeToString(digest[:8])
+		if other, exists := identities[match.Identity]; exists {
+			return nil, fmt.Errorf("workflow identity collision between %q and %q", other, match.CanonicalPath)
+		}
+		identities[match.Identity] = match.CanonicalPath
+		if namespaceKeys {
+			match.StepKeyNamespace = match.Identity
+		}
+		out = append(out, match)
+	}
+	return out, nil
 }
 
 type hostedTokenlessCompilation struct {
@@ -1265,6 +1442,10 @@ func (a *actionSourceAuthentication) warnAnonymousFallback(reason string) {
 }
 
 func compileHostedTokenless(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel, targetQueue, runtimeImage string, actionAuthentication *actionSourceAuthentication) (hostedTokenlessCompilation, error) {
+	return compileHostedTokenlessNamespaced(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, groupLabel, targetQueue, runtimeImage, "", actionAuthentication)
+}
+
+func compileHostedTokenlessNamespaced(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel, targetQueue, runtimeImage, stepKeyNamespace string, actionAuthentication *actionSourceAuthentication) (hostedTokenlessCompilation, error) {
 	preflight, err := compiler.Compile(workflowPath, workflowSource, eventSource)
 	if err != nil {
 		return hostedTokenlessCompilation{}, hostedTokenlessError(hostedTokenlessEvaluationFailure, err)
@@ -1275,9 +1456,10 @@ func compileHostedTokenless(ctx context.Context, workflowPath string, workflowSo
 	}
 	hasActions := irUsesActions(ir)
 	options := compiler.Options{
-		EventTrust:   compiler.EventUntrusted,
-		GroupLabel:   groupLabel,
-		RuntimeImage: runtimeImage,
+		EventTrust:       compiler.EventUntrusted,
+		GroupLabel:       groupLabel,
+		RuntimeImage:     runtimeImage,
+		StepKeyNamespace: stepKeyNamespace,
 		Runners: compiler.RunnerPolicy{
 			Labels: map[string]string{
 				"ubuntu-latest": targetQueue,

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"slices"
@@ -28,6 +29,7 @@ import (
 	"github.com/buildkite/buildkite-gha/internal/plan"
 	gharuntime "github.com/buildkite/buildkite-gha/internal/runtime"
 	"github.com/buildkite/buildkite-gha/internal/transport"
+	"github.com/buildkite/buildkite-gha/internal/workflow"
 	"go.yaml.in/yaml/v4"
 )
 
@@ -77,7 +79,7 @@ func TestUploadHelpFormsMatch(t *testing.T) {
 		}
 		outputs = append(outputs, stdout.String())
 	}
-	if outputs[0] != outputs[1] || !strings.Contains(outputs[0], targetQueueEnvironment) {
+	if outputs[0] != outputs[1] || !strings.Contains(outputs[0], targetQueueEnvironment) || !strings.Contains(outputs[0], "every scheduled workflow group is eligible") {
 		t.Fatalf("upload help outputs differ or omit target queue environment:\nhelp command: %q\nhelp flag: %q", outputs[0], outputs[1])
 	}
 }
@@ -551,31 +553,46 @@ func TestRunUploadCompilesArtifactsAndUploadsSelfContainedPipeline(t *testing.T)
 	}
 	var pipeline struct {
 		Steps []struct {
-			Key      string `yaml:"key"`
-			Command  string `yaml:"command"`
-			Cache    any    `yaml:"cache"`
-			Agents   any    `yaml:"agents"`
-			Checkout struct {
-				Skip bool `yaml:"skip"`
-			} `yaml:"checkout"`
-			DependsOn []struct {
-				Step         string `yaml:"step"`
-				AllowFailure bool   `yaml:"allow_failure"`
-			} `yaml:"depends_on"`
+			Group     string `yaml:"group"`
+			Key       string `yaml:"key"`
+			Condition string `yaml:"if"`
+			DependsOn string `yaml:"depends_on"`
+			Steps     []struct {
+				Key      string `yaml:"key"`
+				Command  string `yaml:"command"`
+				Cache    any    `yaml:"cache"`
+				Agents   any    `yaml:"agents"`
+				Checkout struct {
+					Skip bool `yaml:"skip"`
+				} `yaml:"checkout"`
+				DependsOn []struct {
+					Step         string `yaml:"step"`
+					AllowFailure bool   `yaml:"allow_failure"`
+				} `yaml:"depends_on"`
+			} `yaml:"steps"`
 		} `yaml:"steps"`
 	}
 	if err := yaml.Unmarshal(pipelineCommand.stdin, &pipeline); err != nil {
 		t.Fatalf("uploaded pipeline YAML: %v", err)
 	}
-	if len(pipeline.Steps) != 3 {
+	if len(pipeline.Steps) != 1 || pipeline.Steps[0].Group != ":github: buildkite-gha shell smoke (push)" || pipeline.Steps[0].Key == "" || !strings.Contains(pipeline.Steps[0].Condition, `build.source_event == "push"`) || pipeline.Steps[0].DependsOn != "phase-2-importer" || len(pipeline.Steps[0].Steps) != 3 {
 		t.Fatalf("uploaded steps = %#v", pipeline.Steps)
 	}
-	for _, step := range pipeline.Steps {
+	wantLegacyKeys := map[string]bool{"gha-producer": true, "gha-consumer-5ebbc197d87b": true, "gha-consumer-91934b28b00f": true}
+	for _, step := range pipeline.Steps[0].Steps {
+		if !wantLegacyKeys[step.Key] {
+			t.Fatalf("literal single-workflow upload changed generated key %q", step.Key)
+		}
 		if step.Cache != nil {
 			t.Fatalf("shell-only step %q unexpectedly configures a runtime cache: %#v", step.Key, step.Cache)
 		}
-		if !step.Checkout.Skip || step.Agents != nil || len(step.DependsOn) == 0 || step.DependsOn[0].Step != "phase-2-importer" || step.DependsOn[0].AllowFailure {
-			t.Fatalf("step %q lacks isolated checkout or exact importer dependency: %#v", step.Key, step)
+		if !step.Checkout.Skip || step.Agents != nil {
+			t.Fatalf("step %q lacks isolated checkout or default agent targeting: %#v", step.Key, step)
+		}
+		for _, dependency := range step.DependsOn {
+			if dependency.Step == "phase-2-importer" {
+				t.Fatalf("step %q retains importer dependency: %#v", step.Key, step.DependsOn)
+			}
 		}
 		if !strings.Contains(step.Command, `bootstrap_dir="$(mktemp -d `) ||
 			!strings.Contains(step.Command, `--step 'phase-2-importer'`) ||
@@ -583,6 +600,686 @@ func TestRunUploadCompilesArtifactsAndUploadsSelfContainedPipeline(t *testing.T)
 			!strings.Contains(step.Command, `"$distribution" run-job --plan "$plan"`) {
 			t.Fatalf("step %q command is not self-contained:\n%s", step.Key, step.Command)
 		}
+	}
+}
+
+func TestExpandWorkflowPatternSortsDeduplicatesAndRejectsNoMatch(t *testing.T) {
+	pattern := filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "*e*.yml")
+	first, err := expandWorkflowPattern(pattern)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := expandWorkflowPattern(pattern)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(first, second) || len(first) != 2 || !strings.HasSuffix(first[0].CanonicalPath, "/concurrent.yml") || !strings.HasSuffix(first[1].CanonicalPath, "/shell.yml") {
+		t.Fatalf("expanded workflows = %#v and %#v", first, second)
+	}
+	for _, workflow := range first {
+		if workflow.Identity == "" || workflow.StepKeyNamespace != workflow.Identity {
+			t.Fatalf("glob workflow identity = %#v", workflow)
+		}
+	}
+	duplicated, err := workflowInputs([]workflowInput{first[1], first[0], first[1]}, true)
+	if err != nil || len(duplicated) != 2 || duplicated[0].CanonicalPath != first[0].CanonicalPath || duplicated[1].CanonicalPath != first[1].CanonicalPath {
+		t.Fatalf("deduplicated workflows/error = %#v / %v", duplicated, err)
+	}
+	if _, err := expandWorkflowPattern(filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "missing-*.yml")); err == nil || !strings.Contains(err.Error(), "matched no tracked files") {
+		t.Fatalf("no-match error = %v", err)
+	}
+}
+
+func TestExpandWorkflowPatternPreservesLiteralMetacharacterPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "workflow[1].yml")
+	if err := os.WriteFile(path, []byte("on: push\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	inputs, err := expandWorkflowPattern(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inputs) != 1 || inputs[0].Path != path || inputs[0].StepKeyNamespace != "" {
+		t.Fatalf("literal metacharacter input = %#v", inputs)
+	}
+}
+
+func TestExpandWorkflowPatternNamespacesLiteralDirectoryMatches(t *testing.T) {
+	directory := filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows")
+	inputs, err := expandWorkflowPattern(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inputs) != 4 {
+		t.Fatalf("literal directory matched %d workflows, want 4", len(inputs))
+	}
+	for _, input := range inputs {
+		if input.StepKeyNamespace == "" || input.StepKeyNamespace != input.Identity {
+			t.Fatalf("literal directory workflow is not namespaced: %#v", input)
+		}
+	}
+}
+
+func TestRunUploadAggregatesGlobAtomicallyWithNamespacedJobs(t *testing.T) {
+	pattern := filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "*e*.yml")
+	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
+	inputs, err := expandWorkflowPattern(pattern)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_STEP_KEY", "aggregate-importer")
+	runner := &cliCaptureRunner{}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"upload", "--event-path", eventPath, pattern}, &stdout, &stderr, "dev", runner); code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Uploaded 5 jobs from 2 workflows") || stderr.Len() != 0 || len(runner.commands) != 7 {
+		t.Fatalf("stdout/stderr/commands = %q / %q / %d", stdout.String(), stderr.String(), len(runner.commands))
+	}
+	pipelineCommand := runner.commands[len(runner.commands)-1]
+	if !slices.Equal(pipelineCommand.args, []string{"pipeline", "upload", "--no-interpolation", "--reject-secrets"}) {
+		t.Fatalf("aggregate pipeline command = %#v", pipelineCommand)
+	}
+	var pipeline struct {
+		Steps []struct {
+			Group     string `yaml:"group"`
+			Key       string `yaml:"key"`
+			Condition string `yaml:"if"`
+			DependsOn string `yaml:"depends_on"`
+			Notify    []struct {
+				GitHubCheck struct {
+					Name string `yaml:"name"`
+				} `yaml:"github_check"`
+			} `yaml:"notify"`
+			Steps []struct {
+				Key       string `yaml:"key"`
+				Notify    any    `yaml:"notify"`
+				DependsOn []struct {
+					Step string `yaml:"step"`
+				} `yaml:"depends_on"`
+			} `yaml:"steps"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(pipelineCommand.stdin, &pipeline); err != nil {
+		t.Fatal(err)
+	}
+	wantLabels := []string{"buildkite-gha concurrent smoke", "buildkite-gha shell smoke"}
+	seenKeys := make(map[string]bool)
+	for i, group := range pipeline.Steps {
+		if i >= len(inputs) {
+			t.Fatalf("unexpected aggregate group %d = %#v", i, group)
+		}
+		wantCheckName := "Buildkite / " + wantLabels[i] + " (push)"
+		if group.Group != ":github: "+wantLabels[i]+" (push)" || group.Key != "gha-workflow-"+inputs[i].Identity || !strings.Contains(group.Condition, `build.source_event == "push"`) || !strings.Contains(group.Condition, `build.source == "ui"`) || group.DependsOn != "aggregate-importer" || len(group.Notify) != 1 || group.Notify[0].GitHubCheck.Name != wantCheckName {
+			t.Fatalf("aggregate group %d = %#v", i, group)
+		}
+		prefix := "gha-" + inputs[i].Identity + "-"
+		for _, step := range group.Steps {
+			if !strings.HasPrefix(step.Key, prefix) || seenKeys[step.Key] || step.Notify != nil {
+				t.Fatalf("aggregate step key %q, prefix %q, seen %t", step.Key, prefix, seenKeys[step.Key])
+			}
+			seenKeys[step.Key] = true
+			for _, dependency := range step.DependsOn {
+				if dependency.Step == "aggregate-importer" || !strings.HasPrefix(dependency.Step, prefix) {
+					t.Fatalf("step %q has cross-workflow or unnamespaced dependency %q", step.Key, dependency.Step)
+				}
+			}
+		}
+	}
+	if len(pipeline.Steps) != 2 || len(seenKeys) != 5 {
+		t.Fatalf("aggregate groups/keys = %d/%d", len(pipeline.Steps), len(seenKeys))
+	}
+	planCount := 0
+	for path, contents := range runner.uploaded {
+		if !strings.HasSuffix(path, ".json") {
+			continue
+		}
+		job, err := plan.Decode(contents)
+		if err != nil {
+			t.Fatal(err)
+		}
+		planCount++
+		if !seenKeys[job.Target.StepKey] {
+			t.Fatalf("plan targets unknown aggregate key %q", job.Target.StepKey)
+		}
+	}
+	if planCount != 5 {
+		t.Fatalf("aggregate uploaded plans = %d", planCount)
+	}
+}
+
+func TestRunUploadRecoversTopLevelWorkflowParseFailure(t *testing.T) {
+	eventPath, err := filepath.Abs(filepath.Join("..", "..", "testdata", "smoke", "events", "push.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	validSource := "name: Valid workflow\non: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo ok\n"
+	invalidSource := "name: Do not trust this name\non: push\njobs:\n  broken:\n    runs-on: ubuntu-latest\n    concurrency:\n      group: shared\n      cancel-in-progress: true\n    steps:\n      - run: echo no\n"
+	pattern := initializeTrackedWorkflowRepository(t, map[string]string{
+		"a-invalid.yml": invalidSource,
+		"b-valid.yml":   validSource,
+	})
+	inputs, err := expandWorkflowPattern(pattern)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inputs) != 2 {
+		t.Fatalf("workflow inputs = %#v", inputs)
+	}
+	_, expectedParseError := workflow.Parse(inputs[0].Path, []byte(invalidSource))
+	if expectedParseError == nil || !strings.Contains(expectedParseError.Error(), "concurrency cancel-in-progress is unsupported") {
+		t.Fatalf("invalid fixture parse error = %v", expectedParseError)
+	}
+
+	image := "buildkite.namespace-images.com/agent-base@sha256:" + strings.Repeat("0", 64)
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_STEP_KEY", "parse-recovery-importer")
+	t.Setenv(targetQueueEnvironment, "hosted")
+	t.Setenv(runtimeImageEnvironment, image)
+	runner := &cliCaptureRunner{}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"upload", "--event-path", eventPath, pattern}, &stdout, &stderr, "dev", runner); code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Uploaded 2 jobs from 2 workflows") || stderr.Len() != 0 || len(runner.commands) != 3 {
+		t.Fatalf("stdout/stderr/commands = %q / %q / %d", stdout.String(), stderr.String(), len(runner.commands))
+	}
+
+	type emittedChildStep struct {
+		Label     string            `yaml:"label"`
+		Key       string            `yaml:"key"`
+		Command   string            `yaml:"command"`
+		Image     string            `yaml:"image"`
+		Agents    map[string]string `yaml:"agents"`
+		Env       *yaml.Node        `yaml:"env"`
+		Cache     *yaml.Node        `yaml:"cache"`
+		DependsOn *yaml.Node        `yaml:"depends_on"`
+		Checkout  struct {
+			Skip bool `yaml:"skip"`
+		} `yaml:"checkout"`
+	}
+	var pipeline struct {
+		Steps []struct {
+			Group     string `yaml:"group"`
+			Label     string `yaml:"label"`
+			Key       string `yaml:"key"`
+			Condition string `yaml:"if"`
+			DependsOn string `yaml:"depends_on"`
+			Notify    []struct {
+				GitHubCheck struct {
+					Name string `yaml:"name"`
+				} `yaml:"github_check"`
+			} `yaml:"notify"`
+			Command  string             `yaml:"command"`
+			Image    string             `yaml:"image"`
+			Agents   map[string]string  `yaml:"agents"`
+			Env      *yaml.Node         `yaml:"env"`
+			Cache    *yaml.Node         `yaml:"cache"`
+			Steps    []emittedChildStep `yaml:"steps"`
+			Checkout struct {
+				Skip bool `yaml:"skip"`
+			} `yaml:"checkout"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(runner.commands[len(runner.commands)-1].stdin, &pipeline); err != nil {
+		t.Fatalf("uploaded pipeline YAML: %v", err)
+	}
+	if len(pipeline.Steps) != 2 {
+		t.Fatalf("uploaded workflow groups = %#v", pipeline.Steps)
+	}
+	invalid := pipeline.Steps[0]
+	wantLabel := inputs[0].CanonicalPath + " (push)"
+	if invalid.Group != "" || invalid.Label != ":github: "+wantLabel || invalid.Key != "gha-"+inputs[0].Identity+"-parse-error" || invalid.Condition != "" || invalid.DependsOn != "parse-recovery-importer" || len(invalid.Notify) != 1 || invalid.Notify[0].GitHubCheck.Name != "Buildkite / "+wantLabel || len(invalid.Steps) != 0 || invalid.Agents["queue"] != "hosted" || !invalid.Checkout.Skip || invalid.Image != "" || invalid.Env != nil || invalid.Cache != nil || strings.Contains(invalid.Command, "artifact download") || strings.Contains(invalid.Command, "BUILDKITE_GHA_PLAN") {
+		t.Fatalf("parse-failure command step = %#v", invalid)
+	}
+	valid := pipeline.Steps[1]
+	if valid.Group != ":github: Valid workflow (push)" || valid.Label != "" || valid.Key != "gha-workflow-"+inputs[1].Identity || valid.Condition == "true" || valid.DependsOn != "parse-recovery-importer" || len(valid.Steps) != 1 || valid.Steps[0].Image != image || valid.Steps[0].Agents["queue"] != "hosted" {
+		t.Fatalf("valid workflow group changed = %#v", valid)
+	}
+	var commandStdout, commandStderr bytes.Buffer
+	command := exec.Command("sh", "-c", invalid.Command)
+	command.Stdout = &commandStdout
+	command.Stderr = &commandStderr
+	err = command.Run()
+	var exitError *exec.ExitError
+	if !errors.As(err, &exitError) || exitError.ExitCode() != 1 || commandStdout.Len() != 0 || commandStderr.String() != expectedParseError.Error()+"\n" {
+		t.Fatalf("parse-failure command exit/stdout/stderr = %v / %q / %q, want exit 1 and %q", err, commandStdout.String(), commandStderr.String(), expectedParseError.Error()+"\n")
+	}
+
+	planCount := 0
+	for path, contents := range runner.uploaded {
+		if !strings.HasSuffix(path, ".json") {
+			continue
+		}
+		job, err := plan.Decode(contents)
+		if err != nil {
+			t.Fatal(err)
+		}
+		planCount++
+		if !strings.Contains(job.Workflow.Path, "b-valid.yml") {
+			t.Fatalf("unexpected parse-failure plan = %#v", job.Workflow)
+		}
+	}
+	if planCount != 1 {
+		t.Fatalf("uploaded plan count = %d, want only valid workflow plan", planCount)
+	}
+}
+
+func TestRunUploadAllParseFailuresUseActiveEventWithoutBundle(t *testing.T) {
+	pushEvent, err := os.ReadFile(filepath.Join("..", "..", "testdata", "smoke", "events", "push.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name, event string
+	}{
+		{name: "push", event: "push"},
+		{name: "pull request", event: "pull_request"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			eventSource := bytes.Replace(pushEvent, []byte(`"event": "push"`), []byte(`"event": "`+test.event+`"`), 1)
+			eventPath := filepath.Join(t.TempDir(), "event.json")
+			if err := os.WriteFile(eventPath, eventSource, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			pattern := initializeTrackedWorkflowRepository(t, map[string]string{
+				"a-invalid.yml": "on: push\njobs:\n  one:\n    runs-on: ubuntu-latest\n    concurrency: {group: one, cancel-in-progress: true}\n    steps: [{run: true}]\n",
+				"b-invalid.yml": "on: push\njobs:\n  two:\n    runs-on: ubuntu-latest\n    concurrency: {group: two, cancel-in-progress: true}\n    steps: [{run: true}]\n",
+			})
+			inputs, err := expandWorkflowPattern(pattern)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("BUILDKITE", "true")
+			t.Setenv("BUILDKITE_STEP_KEY", "all-invalid-importer")
+			runner := &cliCaptureRunner{}
+			var stdout, stderr bytes.Buffer
+			if code := run([]string{"upload", "--event-path", eventPath, pattern}, &stdout, &stderr, "dev", runner); code != 0 {
+				t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+			}
+			if !strings.Contains(stdout.String(), "Uploaded 2 jobs from 2 workflows") || stderr.Len() != 0 || len(runner.commands) != 2 {
+				t.Fatalf("stdout/stderr/commands = %q / %q / %d", stdout.String(), stderr.String(), len(runner.commands))
+			}
+			var pipeline struct {
+				Steps []struct {
+					Group     string `yaml:"group"`
+					Label     string `yaml:"label"`
+					Key       string `yaml:"key"`
+					Condition string `yaml:"if"`
+					DependsOn string `yaml:"depends_on"`
+					Notify    []struct {
+						GitHubCheck struct {
+							Name string `yaml:"name"`
+						} `yaml:"github_check"`
+					} `yaml:"notify"`
+					Command  string            `yaml:"command"`
+					Agents   map[string]string `yaml:"agents"`
+					Env      *yaml.Node        `yaml:"env"`
+					Cache    *yaml.Node        `yaml:"cache"`
+					Image    string            `yaml:"image"`
+					Steps    *yaml.Node        `yaml:"steps"`
+					Checkout struct {
+						Skip bool `yaml:"skip"`
+					} `yaml:"checkout"`
+				} `yaml:"steps"`
+			}
+			if err := yaml.Unmarshal(runner.commands[len(runner.commands)-1].stdin, &pipeline); err != nil {
+				t.Fatal(err)
+			}
+			if len(pipeline.Steps) != 2 {
+				t.Fatalf("parse-failure steps = %#v", pipeline.Steps)
+			}
+			for i, step := range pipeline.Steps {
+				displayLabel := inputs[i].CanonicalPath + " (" + test.event + ")"
+				if step.Group != "" || step.Label != ":github: "+displayLabel || step.Key != "gha-"+inputs[i].Identity+"-parse-error" || step.Condition != "" || step.DependsOn != "all-invalid-importer" || len(step.Notify) != 1 || step.Notify[0].GitHubCheck.Name != "Buildkite / "+displayLabel || step.Command == "" || step.Agents != nil || step.Env != nil || step.Cache != nil || step.Image != "" || step.Steps != nil || !step.Checkout.Skip {
+					t.Fatalf("active-event parse-failure step = %#v", step)
+				}
+			}
+			for path := range runner.uploaded {
+				if strings.HasSuffix(path, ".json") {
+					t.Fatalf("all-invalid upload contains plan %q", path)
+				}
+			}
+		})
+	}
+}
+
+func TestRunUploadOmitsReusableOnlyAndKeepsParseFailureVisible(t *testing.T) {
+	eventPath, err := filepath.Abs(filepath.Join("..", "..", "testdata", "smoke", "events", "push.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pattern := initializeTrackedWorkflowRepository(t, map[string]string{
+		"a-reusable.yml": "name: Reusable\non: workflow_call\njobs:\n  shared:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
+		"b-invalid.yml":  "on: push\njobs:\n  bad:\n    runs-on: ubuntu-latest\n    concurrency: {group: bad, cancel-in-progress: true}\n    steps: [{run: true}]\n",
+	})
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_STEP_KEY", "reusable-parse-importer")
+	runner := &cliCaptureRunner{}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"upload", "--event-path", eventPath, pattern}, &stdout, &stderr, "dev", runner); code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Uploaded 1 jobs from 1 workflows") || stderr.Len() != 0 || len(runner.commands) != 2 {
+		t.Fatalf("stdout/stderr/commands = %q / %q / %d", stdout.String(), stderr.String(), len(runner.commands))
+	}
+	var pipeline struct {
+		Steps []struct {
+			Group     string     `yaml:"group"`
+			Label     string     `yaml:"label"`
+			DependsOn string     `yaml:"depends_on"`
+			Steps     *yaml.Node `yaml:"steps"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(runner.commands[len(runner.commands)-1].stdin, &pipeline); err != nil {
+		t.Fatal(err)
+	}
+	if len(pipeline.Steps) != 1 || pipeline.Steps[0].Group != "" || pipeline.Steps[0].Label != ":github: .github/workflows/b-invalid.yml (push)" || pipeline.Steps[0].DependsOn != "reusable-parse-importer" || pipeline.Steps[0].Steps != nil {
+		t.Fatalf("reusable/parse-failure steps = %#v", pipeline.Steps)
+	}
+	for path := range runner.uploaded {
+		if strings.HasSuffix(path, ".json") {
+			t.Fatalf("reusable/parse-failure upload contains plan %q", path)
+		}
+	}
+}
+
+func TestRunUploadMalformedReusableReachedThroughCallerRemainsFatal(t *testing.T) {
+	eventPath, err := filepath.Abs(filepath.Join("..", "..", "testdata", "smoke", "events", "push.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pattern := initializeTrackedWorkflowRepository(t, map[string]string{
+		"a-caller.yml":   "on: push\njobs:\n  imported:\n    uses: ./.github/workflows/b-reusable.yml\n",
+		"b-reusable.yml": "on: workflow_call\njobs:\n  bad:\n    runs-on: ubuntu-latest\n    concurrency: {group: bad, cancel-in-progress: true}\n    steps: [{run: true}]\n",
+	})
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_STEP_KEY", "reusable-boundary-importer")
+	runner := &cliCaptureRunner{}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"upload", "--event-path", eventPath, pattern}, &stdout, &stderr, "dev", runner); code != 1 || !strings.Contains(stderr.String(), "b-reusable.yml") || !strings.Contains(stderr.String(), "concurrency cancel-in-progress is unsupported") {
+		t.Fatalf("run() code/stderr = %d / %q", code, stderr.String())
+	}
+	if stdout.Len() != 0 || len(runner.commands) != 0 || len(runner.uploaded) != 0 {
+		t.Fatalf("malformed called workflow reached upload: stdout %q, commands %#v, uploads %#v", stdout.String(), runner.commands, runner.uploaded)
+	}
+}
+
+func TestRunUploadParseFailureDoesNotMaskCompilerFailure(t *testing.T) {
+	eventPath, err := filepath.Abs(filepath.Join("..", "..", "testdata", "smoke", "events", "push.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	compilerFailure := "on: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    strategy:\n      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}\n    steps:\n      - run: true\n"
+	pattern := initializeTrackedWorkflowRepository(t, map[string]string{
+		"a-invalid.yml": "on: push\njobs:\n  bad:\n    runs-on: ubuntu-latest\n    concurrency: {group: bad, cancel-in-progress: true}\n    steps: [{run: true}]\n",
+		"b-compile.yml": compilerFailure,
+	})
+	inputs, err := expandWorkflowPattern(pattern)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := workflow.Parse(inputs[1].Path, []byte(compilerFailure)); err != nil {
+		t.Fatalf("compiler-failure fixture failed top-level parsing: %v", err)
+	}
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_STEP_KEY", "compile-boundary-importer")
+	runner := &cliCaptureRunner{}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"upload", "--event-path", eventPath, pattern}, &stdout, &stderr, "dev", runner); code != 1 || !strings.Contains(stderr.String(), "b-compile.yml") || !strings.Contains(stderr.String(), "matrix") {
+		t.Fatalf("run() code/stderr = %d / %q", code, stderr.String())
+	}
+	if stdout.Len() != 0 || len(runner.commands) != 0 || len(runner.uploaded) != 0 {
+		t.Fatalf("compiler failure reached upload: stdout %q, commands %#v, uploads %#v", stdout.String(), runner.commands, runner.uploaded)
+	}
+}
+
+func TestRunUploadNamesAggregateGitHubChecksFromWorkflowLabels(t *testing.T) {
+	repository := t.TempDir()
+	workflowDirectory := filepath.Join(repository, ".github", "workflows")
+	if err := os.MkdirAll(workflowDirectory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runnable := func(name string) string {
+		return name + "on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo ok\n"
+	}
+	sources := map[string]string{
+		"a.yml":        runnable("name: 'Shared \"checks\"'\n"),
+		"b.yml":        runnable("name: 'Shared \"checks\"'\n"),
+		"unnamed.yml":  runnable(""),
+		"reusable.yml": "name: Shared\non: workflow_call\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo ok\n",
+	}
+	for name, source := range sources {
+		if err := os.WriteFile(filepath.Join(workflowDirectory, name), []byte(source), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, args := range [][]string{{"init", "-q", repository}, {"-C", repository, "add", ".github/workflows"}} {
+		if output, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, output)
+		}
+	}
+	eventPath, err := filepath.Abs(filepath.Join("..", "..", "testdata", "smoke", "events", "push.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repository)
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_STEP_KEY", "checks-importer")
+	runner := &cliCaptureRunner{}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"upload", "--event-path", eventPath, ".github/workflows/*.yml"}, &stdout, &stderr, "dev", runner); code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	var pipeline struct {
+		Steps []struct {
+			Group     string `yaml:"group"`
+			DependsOn string `yaml:"depends_on"`
+			Notify    []struct {
+				GitHubCheck struct {
+					Name string `yaml:"name"`
+				} `yaml:"github_check"`
+			} `yaml:"notify"`
+			Steps []struct {
+				Notify    any        `yaml:"notify"`
+				DependsOn *yaml.Node `yaml:"depends_on"`
+			} `yaml:"steps"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(runner.commands[len(runner.commands)-1].stdin, &pipeline); err != nil {
+		t.Fatal(err)
+	}
+	want := []struct {
+		group, checkName string
+	}{
+		{group: `:github: Shared "checks" (push)`, checkName: `Buildkite / Shared "checks" (push)`},
+		{group: `:github: Shared "checks" (push)`, checkName: `Buildkite / Shared "checks" (push)`},
+		{group: ":github: .github/workflows/unnamed.yml (push)", checkName: "Buildkite / .github/workflows/unnamed.yml (push)"},
+	}
+	if len(pipeline.Steps) != len(want) {
+		t.Fatalf("aggregate groups = %#v, want %d directly runnable workflows", pipeline.Steps, len(want))
+	}
+	for i, group := range pipeline.Steps {
+		if group.Group != want[i].group || group.DependsOn != "checks-importer" || len(group.Notify) != 1 || group.Notify[0].GitHubCheck.Name != want[i].checkName {
+			t.Fatalf("aggregate group %d = %#v, want %#v", i, group, want[i])
+		}
+		for _, step := range group.Steps {
+			if step.Notify != nil || step.DependsOn != nil {
+				t.Fatalf("aggregate group %d child emitted notification or dependency: %#v / %#v", i, step.Notify, step.DependsOn)
+			}
+		}
+	}
+}
+
+func TestRunUploadNamesGitHubCheckForActiveEvent(t *testing.T) {
+	workflowPath := filepath.Join(t.TempDir(), "multi-trigger.yml")
+	workflowSource := "name: Active event\non:\n  push:\n  pull_request:\n  workflow_dispatch:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo ok\n"
+	if err := os.WriteFile(workflowPath, []byte(workflowSource), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	eventPath, err := filepath.Abs(filepath.Join("..", "..", "testdata", "smoke", "events", "push.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name, source, githubEvent, wantEvent string
+		eventPath                            string
+		webhook                              []byte
+	}{
+		{name: "push fallback", source: "webhook", wantEvent: "push"},
+		{name: "pull request webhook metadata", source: "webhook", githubEvent: "pull_request", webhook: []byte(`{}`), wantEvent: "pull_request"},
+		{name: "UI fallback", source: "ui", wantEvent: "workflow_dispatch"},
+		{name: "API fallback", source: "api", wantEvent: "workflow_dispatch"},
+		{name: "schedule fallback", source: "schedule", wantEvent: "schedule"},
+		{name: "explicit event path precedence", source: "schedule", githubEvent: "pull_request", eventPath: eventPath, wantEvent: "push"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("BUILDKITE", "true")
+			t.Setenv("BUILDKITE_STEP_KEY", "event-name-importer")
+			t.Setenv("BUILDKITE_REPO", "https://github.com/buildkite/buildkite-gha")
+			t.Setenv("BUILDKITE_COMMIT", strings.Repeat("a", 40))
+			t.Setenv("BUILDKITE_BRANCH", "main")
+			t.Setenv("BUILDKITE_PULL_REQUEST", "false")
+			t.Setenv("BUILDKITE_SOURCE", test.source)
+			t.Setenv("BUILDKITE_GITHUB_EVENT", test.githubEvent)
+			runner := &cliCaptureRunner{webhook: test.webhook}
+			args := []string{"upload"}
+			if test.eventPath != "" {
+				args = append(args, "--event-path", test.eventPath)
+				runner.webhookErr = errors.New("metadata must not be read with --event-path")
+			}
+			args = append(args, workflowPath)
+			var stdout, stderr bytes.Buffer
+			if code := run(args, &stdout, &stderr, "dev", runner); code != 0 {
+				t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+			}
+			var pipeline struct {
+				Steps []struct {
+					Group  string `yaml:"group"`
+					Notify []struct {
+						GitHubCheck struct {
+							Name string `yaml:"name"`
+						} `yaml:"github_check"`
+					} `yaml:"notify"`
+				} `yaml:"steps"`
+			}
+			if err := yaml.Unmarshal(runner.commands[len(runner.commands)-1].stdin, &pipeline); err != nil {
+				t.Fatal(err)
+			}
+			wantCheckName := "Buildkite / Active event (" + test.wantEvent + ")"
+			wantGroup := ":github: Active event (" + test.wantEvent + ")"
+			if len(pipeline.Steps) != 1 || pipeline.Steps[0].Group != wantGroup || len(pipeline.Steps[0].Notify) != 1 || pipeline.Steps[0].Notify[0].GitHubCheck.Name != wantCheckName {
+				t.Fatalf("aggregate event group = %#v, want group %q and check %q", pipeline.Steps, wantGroup, wantCheckName)
+			}
+		})
+	}
+}
+
+func TestRunUploadRejectsUnsupportedTriggerBeforeAnyUpload(t *testing.T) {
+	workflowPath := filepath.Join(t.TempDir(), "issues.yml")
+	if err := os.WriteFile(workflowPath, []byte("on: issues\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_STEP_KEY", "unsupported-trigger-importer")
+	runner := &cliCaptureRunner{}
+	var stdout, stderr bytes.Buffer
+	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
+	if code := run([]string{"upload", "--event-path", eventPath, workflowPath}, &stdout, &stderr, "dev", runner); code != 1 || !strings.Contains(stderr.String(), `unsupported GitHub trigger event "issues"`) {
+		t.Fatalf("run() code/stderr = %d / %q", code, stderr.String())
+	}
+	if len(runner.commands) != 0 || len(runner.uploaded) != 0 {
+		t.Fatalf("unsupported trigger reached Buildkite: commands %#v, uploads %#v", runner.commands, runner.uploaded)
+	}
+}
+
+func TestRunUploadSkipsReusableOnlyMatchButCompilesItThroughCaller(t *testing.T) {
+	repository := t.TempDir()
+	workflowDirectory := filepath.Join(repository, ".github", "workflows")
+	if err := os.MkdirAll(workflowDirectory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	caller := "name: Caller\non: push\njobs:\n  imported:\n    uses: ./.github/workflows/reusable.yml\n"
+	reusable := "name: Reusable\non: workflow_call\njobs:\n  shared:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"
+	for name, source := range map[string]string{"caller.yml": caller, "reusable.yml": reusable} {
+		if err := os.WriteFile(filepath.Join(workflowDirectory, name), []byte(source), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, args := range [][]string{{"init", "-q", repository}, {"-C", repository, "add", ".github/workflows"}} {
+		if output, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, output)
+		}
+	}
+	eventPath, err := filepath.Abs(filepath.Join("..", "..", "testdata", "smoke", "events", "push.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repository)
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_STEP_KEY", "reusable-importer")
+	runner := &cliCaptureRunner{}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"upload", "--event-path", eventPath, ".github/workflows/*.yml"}, &stdout, &stderr, "dev", runner); code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Uploaded 1 jobs from 1 workflows") || len(runner.commands) != 3 {
+		t.Fatalf("stdout/commands = %q / %d", stdout.String(), len(runner.commands))
+	}
+	var pipeline struct {
+		Steps []struct {
+			Group     string `yaml:"group"`
+			DependsOn string `yaml:"depends_on"`
+			Notify    []struct {
+				GitHubCheck struct {
+					Name string `yaml:"name"`
+				} `yaml:"github_check"`
+			} `yaml:"notify"`
+			Steps []struct {
+				Key    string `yaml:"key"`
+				Notify any    `yaml:"notify"`
+			} `yaml:"steps"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(runner.commands[len(runner.commands)-1].stdin, &pipeline); err != nil {
+		t.Fatal(err)
+	}
+	if len(pipeline.Steps) != 1 || pipeline.Steps[0].Group != ":github: Caller (push)" || pipeline.Steps[0].DependsOn != "reusable-importer" || len(pipeline.Steps[0].Notify) != 1 || pipeline.Steps[0].Notify[0].GitHubCheck.Name != "Buildkite / Caller (push)" || len(pipeline.Steps[0].Steps) != 1 || !strings.HasPrefix(pipeline.Steps[0].Steps[0].Key, "gha-") || pipeline.Steps[0].Steps[0].Notify != nil {
+		t.Fatalf("aggregate reusable pipeline = %#v", pipeline)
+	}
+	compiledReusable := false
+	for path, contents := range runner.uploaded {
+		if !strings.HasSuffix(path, ".json") {
+			continue
+		}
+		job, err := plan.Decode(contents)
+		if err != nil {
+			t.Fatal(err)
+		}
+		compiledReusable = job.Workflow.Path == "./.github/workflows/reusable.yml"
+	}
+	if !compiledReusable {
+		t.Fatal("caller did not compile the reusable-only workflow into its plan")
+	}
+}
+
+func TestRunUploadRejectsAllReusableOnlyMatches(t *testing.T) {
+	workflowPath := filepath.Join(t.TempDir(), "reusable.yml")
+	source := "on: workflow_call\njobs:\n  shared:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"
+	if err := os.WriteFile(workflowPath, []byte(source), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_STEP_KEY", "reusable-only-importer")
+	runner := &cliCaptureRunner{}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"upload", workflowPath}, &stdout, &stderr, "dev", runner); code != 1 || !strings.Contains(stderr.String(), "matched only reusable workflow_call workflows") {
+		t.Fatalf("run() code/stderr = %d / %q", code, stderr.String())
+	}
+	if len(runner.commands) != 0 || len(runner.uploaded) != 0 {
+		t.Fatalf("reusable-only upload reached Buildkite: commands %#v, uploads %#v", runner.commands, runner.uploaded)
 	}
 }
 
@@ -745,17 +1442,19 @@ func TestRunUploadUsesExplicitTargetQueue(t *testing.T) {
 
 	var pipeline struct {
 		Steps []struct {
-			Key    string            `yaml:"key"`
-			Agents map[string]string `yaml:"agents"`
+			Steps []struct {
+				Key    string            `yaml:"key"`
+				Agents map[string]string `yaml:"agents"`
+			} `yaml:"steps"`
 		} `yaml:"steps"`
 	}
 	if err := yaml.Unmarshal(runner.commands[len(runner.commands)-1].stdin, &pipeline); err != nil {
 		t.Fatalf("uploaded pipeline YAML: %v", err)
 	}
-	if len(pipeline.Steps) != 3 {
+	if len(pipeline.Steps) != 1 || len(pipeline.Steps[0].Steps) != 3 {
 		t.Fatalf("uploaded steps = %#v", pipeline.Steps)
 	}
-	for _, step := range pipeline.Steps {
+	for _, step := range pipeline.Steps[0].Steps {
 		if step.Agents["queue"] != "hosted" {
 			t.Fatalf("step %q agents = %#v, want hosted queue", step.Key, step.Agents)
 		}
@@ -794,17 +1493,19 @@ func TestRunUploadUsesExplicitRuntimeImage(t *testing.T) {
 	}
 	var pipeline struct {
 		Steps []struct {
-			Image   string `yaml:"image"`
-			Command string `yaml:"command"`
+			Steps []struct {
+				Image   string `yaml:"image"`
+				Command string `yaml:"command"`
+			} `yaml:"steps"`
 		} `yaml:"steps"`
 	}
 	if err := yaml.Unmarshal(runner.commands[len(runner.commands)-1].stdin, &pipeline); err != nil {
 		t.Fatalf("uploaded pipeline YAML: %v", err)
 	}
-	if len(pipeline.Steps) != 3 {
+	if len(pipeline.Steps) != 1 || len(pipeline.Steps[0].Steps) != 3 {
 		t.Fatalf("uploaded steps = %#v", pipeline.Steps)
 	}
-	for _, step := range pipeline.Steps {
+	for _, step := range pipeline.Steps[0].Steps {
 		if step.Image != image || !strings.Contains(step.Command, "--hosted-tool-cache") {
 			t.Fatalf("runtime image step = %#v", step)
 		}
@@ -837,7 +1538,7 @@ func TestRunUploadRejectsInvalidTargetQueueEnvironment(t *testing.T) {
 	}
 }
 
-func TestRunUploadMergesGeneratedJobsIntoContainingGroup(t *testing.T) {
+func TestRunUploadUsesWorkflowGroupInsteadOfContainingGroup(t *testing.T) {
 	workflowPath := filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "shell.yml")
 	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
 	t.Setenv("BUILDKITE", "true")
@@ -850,9 +1551,11 @@ func TestRunUploadMergesGeneratedJobsIntoContainingGroup(t *testing.T) {
 	}
 	var pipeline struct {
 		Steps []struct {
-			Group string `yaml:"group"`
-			Key   string `yaml:"key"`
-			Steps []struct {
+			Group     string `yaml:"group"`
+			Key       string `yaml:"key"`
+			Condition string `yaml:"if"`
+			DependsOn string `yaml:"depends_on"`
+			Steps     []struct {
 				Key string `yaml:"key"`
 			} `yaml:"steps"`
 		} `yaml:"steps"`
@@ -860,7 +1563,7 @@ func TestRunUploadMergesGeneratedJobsIntoContainingGroup(t *testing.T) {
 	if err := yaml.Unmarshal(runner.commands[len(runner.commands)-1].stdin, &pipeline); err != nil {
 		t.Fatalf("uploaded pipeline YAML: %v", err)
 	}
-	if len(pipeline.Steps) != 1 || pipeline.Steps[0].Group != ":github: Run workflow" || pipeline.Steps[0].Key != "" || len(pipeline.Steps[0].Steps) != 3 {
+	if len(pipeline.Steps) != 1 || pipeline.Steps[0].Group != ":github: buildkite-gha shell smoke (push)" || pipeline.Steps[0].Key == "" || pipeline.Steps[0].Condition == "" || pipeline.Steps[0].DependsOn != "grouped-importer" || len(pipeline.Steps[0].Steps) != 3 {
 		t.Fatalf("grouped upload = %#v", pipeline.Steps)
 	}
 }
@@ -1012,25 +1715,29 @@ func TestRunUploadCompilesConcurrentSmokePipeline(t *testing.T) {
 
 	var pipeline struct {
 		Steps []struct {
-			Key       string `yaml:"key"`
-			Agents    any    `yaml:"agents"`
-			DependsOn []struct {
-				Step         string `yaml:"step"`
-				AllowFailure bool   `yaml:"allow_failure"`
-			} `yaml:"depends_on"`
+			DependsOn string `yaml:"depends_on"`
+			Steps     []struct {
+				Key       string `yaml:"key"`
+				Agents    any    `yaml:"agents"`
+				DependsOn []struct {
+					Step         string `yaml:"step"`
+					AllowFailure bool   `yaml:"allow_failure"`
+				} `yaml:"depends_on"`
+			} `yaml:"steps"`
 		} `yaml:"steps"`
 	}
 	if err := yaml.Unmarshal(runner.commands[3].stdin, &pipeline); err != nil {
 		t.Fatalf("uploaded pipeline YAML: %v", err)
 	}
-	if len(pipeline.Steps) != 2 {
+	if len(pipeline.Steps) != 1 || pipeline.Steps[0].DependsOn != "phase-3-upload-importer" || len(pipeline.Steps[0].Steps) != 2 {
 		t.Fatalf("uploaded steps = %#v", pipeline.Steps)
 	}
-	if pipeline.Steps[0].Key != "gha-concurrent" || pipeline.Steps[0].Agents != nil || len(pipeline.Steps[0].DependsOn) != 1 || pipeline.Steps[0].DependsOn[0].Step != "phase-3-upload-importer" || pipeline.Steps[0].DependsOn[0].AllowFailure {
-		t.Fatalf("concurrent step = %#v", pipeline.Steps[0])
+	steps := pipeline.Steps[0].Steps
+	if steps[0].Key != "gha-concurrent" || steps[0].Agents != nil || len(steps[0].DependsOn) != 0 {
+		t.Fatalf("concurrent step = %#v", steps[0])
 	}
-	observer := pipeline.Steps[1]
-	if observer.Key != "gha-observe" || observer.Agents != nil || len(observer.DependsOn) != 2 || observer.DependsOn[0].Step != "phase-3-upload-importer" || observer.DependsOn[0].AllowFailure || observer.DependsOn[1].Step != "gha-concurrent" || !observer.DependsOn[1].AllowFailure {
+	observer := steps[1]
+	if observer.Key != "gha-observe" || observer.Agents != nil || len(observer.DependsOn) != 1 || observer.DependsOn[0].Step != "gha-concurrent" || !observer.DependsOn[0].AllowFailure {
 		t.Fatalf("observer step = %#v", observer)
 	}
 }
@@ -1072,25 +1779,27 @@ func TestRunUploadJavaScriptActionRequiresRuntimeMiseWithoutTransport(t *testing
 	}
 	var pipeline struct {
 		Steps []struct {
-			Command string `yaml:"command"`
-			Cache   struct {
-				Paths []string `yaml:"paths"`
-				Name  string   `yaml:"name"`
-			} `yaml:"cache"`
-			Env map[string]string `yaml:"env"`
+			Steps []struct {
+				Command string `yaml:"command"`
+				Cache   struct {
+					Paths []string `yaml:"paths"`
+					Name  string   `yaml:"name"`
+				} `yaml:"cache"`
+				Env map[string]string `yaml:"env"`
+			} `yaml:"steps"`
 		} `yaml:"steps"`
 	}
 	if err := yaml.Unmarshal(runner.commands[2].stdin, &pipeline); err != nil {
 		t.Fatalf("parse uploaded pipeline: %v", err)
 	}
-	if len(pipeline.Steps) != 1 {
+	if len(pipeline.Steps) != 1 || len(pipeline.Steps[0].Steps) != 1 {
 		t.Fatalf("uploaded pipeline steps = %#v", pipeline.Steps)
 	}
-	command := pipeline.Steps[0].Command
+	command := pipeline.Steps[0].Steps[0].Command
 	if strings.Contains(command, ".buildkite-gha/tools/mise/") || strings.Contains(command, `export PATH="$bootstrap_dir:$PATH"`) || strings.Contains(command, "BUILDKITE_GHA_NODE") || strings.Contains(command, ".buildkite-gha/runtimes") {
 		t.Fatalf("generated pipeline still transports runtime tools:\n%s", command)
 	}
-	step := pipeline.Steps[0]
+	step := pipeline.Steps[0].Steps[0]
 	if step.Cache.Name != "buildkite-gha" || len(step.Cache.Paths) != 1 || step.Cache.Paths[0] != "/cache/bkcache/buildkite-gha" {
 		t.Fatalf("generated action cache = %#v", step.Cache)
 	}
@@ -1852,6 +2561,27 @@ type cliCommand struct {
 	name  string
 	args  []string
 	stdin []byte
+}
+
+func initializeTrackedWorkflowRepository(t *testing.T, sources map[string]string) string {
+	t.Helper()
+	repository := t.TempDir()
+	directory := filepath.Join(repository, ".github", "workflows")
+	if err := os.MkdirAll(directory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, source := range sources {
+		if err := os.WriteFile(filepath.Join(directory, name), []byte(source), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, args := range [][]string{{"init", "-q", repository}, {"-C", repository, "add", ".github/workflows"}} {
+		if output, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, output)
+		}
+	}
+	t.Chdir(repository)
+	return ".github/workflows/*.yml"
 }
 
 type cliCaptureRunner struct {

--- a/internal/compiler/bundle.go
+++ b/internal/compiler/bundle.go
@@ -32,9 +32,10 @@ type PlanAuthorization struct {
 
 // Bundle is the complete deterministic output of static compilation.
 type Bundle struct {
-	IR       IR
-	Plans    []PlanArtifact
-	Pipeline []byte
+	IR                IR
+	Plans             []PlanArtifact
+	Pipeline          []byte
+	GeneratedWorkflow buildkitepipeline.Workflow
 }
 
 // CompileBundle compiles an unattested event snapshot with the fail-closed
@@ -99,7 +100,11 @@ func CompileBundleContext(ctx context.Context, path string, source, eventSource 
 			jobs[i].ConcurrencyGroup = buildkiteConcurrencyGroup(ir.Event.Repository, ir.Jobs[i].ConcurrencyGroup)
 		} else if ir.Jobs[i].MaxParallel != nil {
 			jobs[i].Concurrency = *ir.Jobs[i].MaxParallel
-			jobs[i].ConcurrencyGroup = "buildkite-gha/" + strings.TrimPrefix(ir.Workflow.Digest, "sha256:") + "/" + ir.Jobs[i].LogicalJobID
+			workflowScope := strings.TrimPrefix(ir.Workflow.Digest, "sha256:")
+			if options.StepKeyNamespace != "" {
+				workflowScope += "/" + options.StepKeyNamespace
+			}
+			jobs[i].ConcurrencyGroup = "buildkite-gha/" + workflowScope + "/" + ir.Jobs[i].LogicalJobID
 		}
 	}
 	var concurrencyGate *buildkitepipeline.ConcurrencyGate
@@ -109,18 +114,22 @@ func CompileBundleContext(ctx context.Context, path string, source, eventSource 
 			Queue: jobs[0].Queue,
 		}
 	}
+	generatedWorkflow := buildkitepipeline.Workflow{
+		ConcurrencyGate: concurrencyGate,
+		Jobs:            jobs,
+	}
 	pipeline, err := buildkitepipeline.Emit(buildkitepipeline.Pipeline{
 		CompilerStep:       compilerStep,
 		DistributionDigest: compilerDistributionDigest,
 		GroupLabel:         options.GroupLabel,
 		RuntimeImage:       options.RuntimeImage,
-		ConcurrencyGate:    concurrencyGate,
-		Jobs:               jobs,
+		ConcurrencyGate:    generatedWorkflow.ConcurrencyGate,
+		Jobs:               generatedWorkflow.Jobs,
 	})
 	if err != nil {
 		return Bundle{}, fmt.Errorf("emit Buildkite pipeline: %w", err)
 	}
-	return Bundle{IR: ir, Plans: artifacts, Pipeline: pipeline}, nil
+	return Bundle{IR: ir, Plans: artifacts, Pipeline: pipeline, GeneratedWorkflow: generatedWorkflow}, nil
 }
 
 func buildkiteConcurrencyGroup(repository Repository, group string) string {

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -98,6 +98,43 @@ func TestCompileBundlePreservesRuntimeImagePolicy(t *testing.T) {
 	}
 }
 
+func TestCompileBundleNamespacesTargetsAndDependencies(t *testing.T) {
+	path := smokePath(".github", "workflows", "shell.yml")
+	options := defaultOptions()
+	options.StepKeyNamespace = "0123456789abcdef"
+	bundle, err := CompileBundleWithOptions(path, readFile(t, path), readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-importer", options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bundle.IR.Jobs) != 3 || len(bundle.Plans) != 3 || len(bundle.GeneratedWorkflow.Jobs) != 3 {
+		t.Fatalf("namespaced bundle size = IR %d, plans %d, jobs %d", len(bundle.IR.Jobs), len(bundle.Plans), len(bundle.GeneratedWorkflow.Jobs))
+	}
+	producer := "gha-0123456789abcdef-producer"
+	if bundle.IR.Jobs[0].Key != producer || bundle.Plans[0].Job.Target.StepKey != producer || bundle.GeneratedWorkflow.Jobs[0].Key != producer {
+		t.Fatalf("namespaced producer = IR %q, plan %q, pipeline %q", bundle.IR.Jobs[0].Key, bundle.Plans[0].Job.Target.StepKey, bundle.GeneratedWorkflow.Jobs[0].Key)
+	}
+	for i := 1; i < len(bundle.Plans); i++ {
+		if !strings.HasPrefix(bundle.Plans[i].Job.Target.StepKey, "gha-0123456789abcdef-consumer-") || !reflect.DeepEqual(bundle.Plans[i].Job.Dependencies, []string{producer}) || !reflect.DeepEqual(bundle.GeneratedWorkflow.Jobs[i].Dependencies, []string{producer}) {
+			t.Fatalf("namespaced consumer %d = target %q, plan needs %#v, pipeline needs %#v", i, bundle.Plans[i].Job.Target.StepKey, bundle.Plans[i].Job.Dependencies, bundle.GeneratedWorkflow.Jobs[i].Dependencies)
+		}
+	}
+}
+
+func TestCompileBundleNamespacesMaxParallelConcurrency(t *testing.T) {
+	source := []byte("on: push\njobs:\n  test:\n    strategy:\n      max-parallel: 1\n      matrix:\n        target: [one, two]\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n")
+	options := defaultOptions()
+	options.StepKeyNamespace = "0123456789abcdef"
+	bundle, err := CompileBundleWithOptions("workflow.yml", source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-importer", options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, job := range bundle.GeneratedWorkflow.Jobs {
+		if !strings.Contains(job.ConcurrencyGroup, "/0123456789abcdef/test") {
+			t.Fatalf("matrix concurrency group = %q, want workflow namespace", job.ConcurrencyGroup)
+		}
+	}
+}
+
 func TestCompileBundleCompilesSmokeCorpus(t *testing.T) {
 	workflows, err := filepath.Glob(smokePath(".github", "workflows", "*.yml"))
 	if err != nil {

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -77,10 +77,11 @@ type ExecutionBoundary struct {
 
 // WorkflowSource binds the IR to its input workflow bytes.
 type WorkflowSource struct {
-	Path             string `json:"path"`
-	Name             string `json:"name,omitempty"`
-	Digest           string `json:"digest"`
-	ConcurrencyGroup string `json:"concurrency_group,omitempty"`
+	Path             string             `json:"path"`
+	Name             string             `json:"name,omitempty"`
+	Digest           string             `json:"digest"`
+	ConcurrencyGroup string             `json:"concurrency_group,omitempty"`
+	Triggers         []workflow.Trigger `json:"-"`
 }
 
 // JobInstance is one statically expanded job in the owned IR.
@@ -600,7 +601,7 @@ func compile(path string, source, eventSource []byte, options Options) (IR, erro
 	digest := sha256.Sum256(source)
 	return IR{
 		Schema:   schema,
-		Workflow: WorkflowSource{Path: path, Name: parsed.Name, Digest: "sha256:" + hex.EncodeToString(digest[:]), ConcurrencyGroup: workflowConcurrencyGroup},
+		Workflow: WorkflowSource{Path: path, Name: parsed.Name, Digest: "sha256:" + hex.EncodeToString(digest[:]), ConcurrencyGroup: workflowConcurrencyGroup, Triggers: parsed.Triggers},
 		Event:    event,
 		Vars:     vars,
 		Warnings: compilerWarnings(parsed.Concurrency),
@@ -660,6 +661,16 @@ func parseEvent(source []byte) (Event, error) {
 		Provider: input.Provider, Event: input.Event, Repository: input.Repository,
 		Ref: input.Ref, SHA: input.SHA, Actor: input.Actor, Payload: input.Payload,
 	}, nil
+}
+
+// EventName validates an event snapshot with the compiler's canonical parser
+// and returns its active provider event name.
+func EventName(source []byte) (string, error) {
+	event, err := parseEvent(source)
+	if err != nil {
+		return "", err
+	}
+	return event.Event, nil
 }
 
 func compileContext(event Event, vars map[string]string, workflowPath, workflowName string) expression.CompileContext {
@@ -753,7 +764,7 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 			if concurrencyGroup != "" {
 				concurrencyGroups[canonicalConcurrencyGroup(concurrencyGroup)] = struct{}{}
 			}
-			key, err := instanceKey(job.ID, matrix)
+			key, err := namespacedInstanceKey(options.StepKeyNamespace, job.ID, matrix)
 			if err != nil {
 				return nil, jobError(jobPath, job, fmt.Sprintf("create deterministic instance key: %v", err))
 			}
@@ -1329,7 +1340,15 @@ func topologicalOrder(path string, jobs map[string]workflow.Job) ([]string, erro
 }
 
 func instanceKey(jobID string, matrix map[string]any) (string, error) {
-	prefix := "gha-" + sanitize(jobID)
+	return namespacedInstanceKey("", jobID, matrix)
+}
+
+func namespacedInstanceKey(namespace, jobID string, matrix map[string]any) (string, error) {
+	prefix := "gha-"
+	if namespace != "" {
+		prefix += namespace + "-"
+	}
+	prefix += sanitize(jobID)
 	if len(matrix) == 0 {
 		return prefix, nil
 	}

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -1965,6 +1965,18 @@ func TestCompileRejectsInvalidEventSnapshots(t *testing.T) {
 	}
 }
 
+func TestEventNameUsesCanonicalEventParser(t *testing.T) {
+	source := readFile(t, smokePath("events", "push.json"))
+	name, err := EventName(source)
+	if err != nil || name != "push" {
+		t.Fatalf("EventName() = %q, %v, want push", name, err)
+	}
+	invalid := bytes.Replace(source, []byte(`"actor":`), []byte(`"unexpected":true,"actor":`), 1)
+	if _, err := EventName(invalid); err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("EventName() invalid snapshot error = %v", err)
+	}
+}
+
 func smokePath(parts ...string) string {
 	return filepath.Join(append([]string{"..", "..", "testdata", "smoke"}, parts...)...)
 }

--- a/internal/compiler/config.go
+++ b/internal/compiler/config.go
@@ -8,6 +8,7 @@ import (
 )
 
 var queuePattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,255}$`)
+var stepKeyNamespacePattern = regexp.MustCompile(`^[0-9a-f]{16}$`)
 
 // EventTrust is the compiler's authenticated classification of an event.
 type EventTrust string
@@ -54,6 +55,10 @@ type Options struct {
 	// RuntimeImage selects one immutable image for generated workflow jobs. It
 	// affects pipeline placement only, not compiler IR or plans.
 	RuntimeImage string
+	// StepKeyNamespace deterministically separates generated keys when several
+	// workflows are compiled into one Buildkite pipeline. Empty preserves the
+	// legacy single-workflow keys.
+	StepKeyNamespace string
 }
 
 func defaultOptions() Options {
@@ -76,6 +81,9 @@ func (options Options) validate() error {
 	}
 	if !options.ResolveActions && options.ActionSource != nil {
 		return fmt.Errorf("action source configuration requires ResolveActions")
+	}
+	if options.StepKeyNamespace != "" && !stepKeyNamespacePattern.MatchString(options.StepKeyNamespace) {
+		return fmt.Errorf("step key namespace %q must be 16 lowercase hexadecimal characters", options.StepKeyNamespace)
 	}
 	if len(options.Runners.Labels) == 0 {
 		return fmt.Errorf("runner policy requires at least one label mapping")

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -18,6 +18,7 @@ type Span struct {
 // Workflow is the actionlint-independent syntax needed by the Phase 0 compiler.
 type Workflow struct {
 	Name                    string                `json:"name,omitempty"`
+	Triggers                []Trigger             `json:"triggers,omitempty"`
 	Env                     map[string]string     `json:"env,omitempty"`
 	Permissions             *Permissions          `json:"permissions,omitempty"`
 	Concurrency             *Concurrency          `json:"concurrency,omitempty"`
@@ -28,6 +29,53 @@ type Workflow struct {
 	RequiredCallSecrets     []string              `json:"required_call_secrets,omitempty"`
 	Callable                bool                  `json:"callable,omitempty"`
 	Jobs                    []Job                 `json:"jobs"`
+}
+
+// ReusableOnly reports whether the workflow can only be invoked through
+// workflow_call and must not become a directly runnable aggregate group.
+func (w Workflow) ReusableOnly() bool {
+	if len(w.Triggers) == 0 {
+		return false
+	}
+	for _, trigger := range w.Triggers {
+		if trigger.Event != "workflow_call" {
+			return false
+		}
+	}
+	return true
+}
+
+// Trigger is one configured entry in the workflow's on section. Slice fields
+// are nil when omitted and non-nil when explicitly configured (including an
+// empty list), which is significant for GitHub's defaults.
+type Trigger struct {
+	Event          string           `json:"event"`
+	Types          []string         `json:"types,omitempty"`
+	Branches       []string         `json:"branches,omitempty"`
+	BranchesIgnore []string         `json:"branches_ignore,omitempty"`
+	Tags           []string         `json:"tags,omitempty"`
+	TagsIgnore     []string         `json:"tags_ignore,omitempty"`
+	Paths          []string         `json:"paths,omitempty"`
+	PathsIgnore    []string         `json:"paths_ignore,omitempty"`
+	Workflows      []string         `json:"workflows,omitempty"`
+	Schedules      []Schedule       `json:"schedules,omitempty"`
+	Dispatch       *DispatchTrigger `json:"dispatch,omitempty"`
+}
+
+type Schedule struct{ Cron, Timezone string }
+
+// DispatchTrigger retains workflow_dispatch configuration for later adapters.
+type DispatchTrigger struct {
+	Inputs []DispatchInput `json:"inputs,omitempty"`
+}
+
+type DispatchInput struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description,omitempty"`
+	Required    bool     `json:"required,omitempty"`
+	Default     string   `json:"default,omitempty"`
+	Type        string   `json:"type,omitempty"`
+	Options     []string `json:"options,omitempty"`
 }
 
 // Concurrency is the supported subset of a GitHub Actions concurrency group.

--- a/internal/workflow/parse.go
+++ b/internal/workflow/parse.go
@@ -59,6 +59,7 @@ func Parse(path string, source []byte) (*Workflow, error) {
 	}
 
 	owned := &Workflow{}
+	owned.Triggers = adaptTriggers(parsed.On)
 	if parsed.Name != nil {
 		owned.Name = parsed.Name.Value
 	}
@@ -160,6 +161,85 @@ func Parse(path string, source []byte) (*Workflow, error) {
 		return nil, fmt.Errorf("%s:%d:%d: concurrent step did not match the pinned actionlint syntax tree", path, position.Line, position.Column)
 	}
 	return owned, nil
+}
+
+func adaptTriggers(events []actionlint.Event) []Trigger {
+	out := make([]Trigger, 0, len(events))
+	values := func(f *actionlint.WebhookEventFilter) []string {
+		if f == nil {
+			return nil
+		}
+		v := make([]string, len(f.Values))
+		for i, s := range f.Values {
+			v[i] = s.Value
+		}
+		return v
+	}
+	stringsOf := func(in []*actionlint.String) []string {
+		if in == nil {
+			return nil
+		}
+		out := make([]string, len(in))
+		for i, s := range in {
+			out[i] = s.Value
+		}
+		return out
+	}
+	for _, event := range events {
+		t := Trigger{Event: event.EventName()}
+		switch e := event.(type) {
+		case *actionlint.WebhookEvent:
+			t.Types, t.Branches, t.BranchesIgnore = stringsOf(e.Types), values(e.Branches), values(e.BranchesIgnore)
+			t.Tags, t.TagsIgnore, t.Paths, t.PathsIgnore = values(e.Tags), values(e.TagsIgnore), values(e.Paths), values(e.PathsIgnore)
+			t.Workflows = stringsOf(e.Workflows)
+		case *actionlint.ScheduledEvent:
+			for _, s := range e.Schedules {
+				x := Schedule{}
+				if s.Cron != nil {
+					x.Cron = s.Cron.Value
+				}
+				if s.Timezone != nil {
+					x.Timezone = s.Timezone.Value
+				}
+				t.Schedules = append(t.Schedules, x)
+			}
+		case *actionlint.WorkflowDispatchEvent:
+			names := make([]string, 0, len(e.Inputs))
+			for name := range e.Inputs {
+				names = append(names, name)
+			}
+			sort.Strings(names)
+			t.Dispatch = &DispatchTrigger{}
+			for _, name := range names {
+				input := e.Inputs[name]
+				owned := DispatchInput{Name: name, Options: stringsOf(input.Options)}
+				if input.Description != nil {
+					owned.Description = input.Description.Value
+				}
+				if input.Required != nil {
+					owned.Required = input.Required.Value
+				}
+				if input.Default != nil {
+					owned.Default = input.Default.Value
+				}
+				switch input.Type {
+				case actionlint.WorkflowDispatchEventInputTypeString:
+					owned.Type = "string"
+				case actionlint.WorkflowDispatchEventInputTypeNumber:
+					owned.Type = "number"
+				case actionlint.WorkflowDispatchEventInputTypeBoolean:
+					owned.Type = "boolean"
+				case actionlint.WorkflowDispatchEventInputTypeChoice:
+					owned.Type = "choice"
+				case actionlint.WorkflowDispatchEventInputTypeEnvironment:
+					owned.Type = "environment"
+				}
+				t.Dispatch.Inputs = append(t.Dispatch.Inputs, owned)
+			}
+		}
+		out = append(out, t)
+	}
+	return out
 }
 
 var containerImagePattern = regexp.MustCompile(`^[a-z0-9]+(?:[._-][a-z0-9]+)*(?:/[a-z0-9]+(?:[._-][a-z0-9]+)*)*(?::[A-Za-z0-9_][A-Za-z0-9_.-]{0,127})?(?:@sha256:[0-9a-f]{64})?$`)

--- a/internal/workflow/triggers_test.go
+++ b/internal/workflow/triggers_test.go
@@ -1,0 +1,74 @@
+package workflow
+
+import "testing"
+
+func TestParseRetainsShorthandTriggerForms(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		on     string
+		events []string
+	}{
+		{name: "scalar", on: "push", events: []string{"push"}},
+		{name: "list", on: "[push, pull_request, workflow_dispatch]", events: []string{"push", "pull_request", "workflow_dispatch"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			workflow, err := Parse("workflow.yml", []byte("on: "+test.on+"\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(workflow.Triggers) != len(test.events) {
+				t.Fatalf("triggers = %#v", workflow.Triggers)
+			}
+			for i, event := range test.events {
+				if workflow.Triggers[i].Event != event {
+					t.Fatalf("trigger %d = %#v, want %q", i, workflow.Triggers[i], event)
+				}
+			}
+			if workflow.Triggers[0].Types != nil || workflow.Triggers[0].Branches != nil {
+				t.Fatalf("omitted shorthand filters were not retained as nil: %#v", workflow.Triggers[0])
+			}
+		})
+	}
+}
+
+func TestParseRetainsTriggerConfiguration(t *testing.T) {
+	source := []byte("on:\n  push:\n    branches: [main, '!release/**', 'release/**']\n  pull_request:\n    types: [opened]\n  workflow_dispatch:\n    inputs:\n      target:\n        type: string\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n")
+	w, err := Parse("workflow.yml", source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(w.Triggers) != 4 {
+		t.Fatalf("got %d triggers: %#v", len(w.Triggers), w.Triggers)
+	}
+	if got := w.Triggers[0].Branches; len(got) != 3 || got[1] != "!release/**" || got[2] != "release/**" {
+		t.Fatalf("branch order lost: %#v", got)
+	}
+	if w.Triggers[1].Types == nil || len(w.Triggers[1].Types) != 1 {
+		t.Fatalf("types not retained: %#v", w.Triggers[1])
+	}
+	if w.Triggers[2].Dispatch == nil || len(w.Triggers[2].Dispatch.Inputs) != 1 || w.Triggers[2].Dispatch.Inputs[0].Name != "target" {
+		t.Fatalf("dispatch not retained: %#v", w.Triggers[2])
+	}
+	if len(w.Triggers[3].Schedules) != 1 || w.Triggers[3].Schedules[0].Cron != "0 0 * * *" {
+		t.Fatalf("schedule not retained: %#v", w.Triggers[3])
+	}
+}
+
+func TestWorkflowReusableOnly(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		triggers []Trigger
+		want     bool
+	}{
+		{name: "call only", triggers: []Trigger{{Event: "workflow_call"}}, want: true},
+		{name: "duplicate call only", triggers: []Trigger{{Event: "workflow_call"}, {Event: "workflow_call"}}, want: true},
+		{name: "call and push", triggers: []Trigger{{Event: "workflow_call"}, {Event: "push"}}},
+		{name: "empty"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := (Workflow{Triggers: test.triggers}).ReusableOnly(); got != test.want {
+				t.Fatalf("ReusableOnly() = %t, want %t", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- upload glob-matched workflows as ordered aggregate entries
- emit top-level failing command steps for top-level workflow parse errors
- preserve active-event labels, GitHub checks, strict importer dependencies, and fatal scope boundaries

## Validation
- mise run check