### PR TITLE
Add hidden thin-plugin entrypoint

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -97,13 +97,18 @@ so piping its YAML directly to `buildkite-agent pipeline upload` is incomplete.
 
 ## Upload
 
-`upload` is the in-build command used by the plugin:
+`upload` is the public in-build command for custom importers:
 
 ```sh
 buildkite-gha upload .github/workflows/ci.yml
 ```
 
 It requires `BUILDKITE=true` and `BUILDKITE_STEP_KEY`.
+
+The GitHub Actions plugin instead invokes the hidden `buildkite-gha plugin`
+entrypoint and supplies the workflow through
+`BUILDKITE_PLUGIN_GITHUB_ACTIONS_WORKFLOW`. That integration command accepts no
+arguments and is intentionally absent from ordinary CLI help.
 
 Event source precedence is:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -105,10 +105,10 @@ buildkite-gha upload .github/workflows/ci.yml
 
 It requires `BUILDKITE=true` and `BUILDKITE_STEP_KEY`.
 
-The GitHub Actions plugin instead invokes the hidden `buildkite-gha plugin`
-entrypoint and supplies the workflow through
-`BUILDKITE_PLUGIN_GITHUB_ACTIONS_WORKFLOW`. That integration command accepts no
-arguments and is intentionally absent from ordinary CLI help.
+The hidden `buildkite-gha plugin` entrypoint provides the dedicated GitHub
+Actions plugin integration boundary. It reads the workflow from
+`BUILDKITE_PLUGIN_GITHUB_ACTIONS_WORKFLOW`, accepts no arguments, and is
+intentionally absent from ordinary CLI help.
 
 Event source precedence is:
 

--- a/internal/cli/buildkite_event.go
+++ b/internal/cli/buildkite_event.go
@@ -30,8 +30,7 @@ func buildkiteEventSource(getenv func(string) string) ([]byte, error) {
 		return nil, fmt.Errorf("BUILDKITE_REPO: %w", err)
 	}
 	sha := getenv("BUILDKITE_COMMIT")
-	decoded, err := hex.DecodeString(sha)
-	if err != nil || len(decoded) != 20 || sha != strings.ToLower(sha) {
+	if !validBuildkiteCommit(sha) {
 		return nil, fmt.Errorf("BUILDKITE_COMMIT must be a full lowercase 40-hex commit, not a symbolic ref")
 	}
 	branch, tag, pullRequest := getenv("BUILDKITE_BRANCH"), getenv("BUILDKITE_TAG"), getenv("BUILDKITE_PULL_REQUEST")
@@ -110,6 +109,11 @@ func buildkiteEventSource(getenv func(string) string) ([]byte, error) {
 		return nil, fmt.Errorf("encode Buildkite compatibility snapshot: %w", err)
 	}
 	return result, nil
+}
+
+func validBuildkiteCommit(commit string) bool {
+	decoded, err := hex.DecodeString(commit)
+	return err == nil && len(decoded) == 20 && commit == strings.ToLower(commit)
 }
 
 // buildkiteWebhookEventSource overlays untrusted trigger data onto the

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -69,6 +69,7 @@ func writeCommandHelp(stdout io.Writer, command string) {
 const (
 	resultPublicationTimeout                    = 10 * time.Second
 	legacyRuntimeQueue                          = "hosted"
+	pluginWorkflowEnvironment                   = "BUILDKITE_PLUGIN_GITHUB_ACTIONS_WORKFLOW"
 	targetQueueEnvironment                      = "BUILDKITE_GHA_TARGET_QUEUE"
 	runtimeImageEnvironment                     = "BUILDKITE_GHA_RUNTIME_IMAGE"
 	repositoryProviderGitCredentialsEnvironment = "BUILDKITE_USE_REPOSITORY_PROVIDER_GIT_CREDENTIALS"
@@ -111,6 +112,8 @@ func run(args []string, stdout, stderr io.Writer, version string, agentRunner tr
 		}
 		_, _ = fmt.Fprintf(stdout, "buildkite-gha %s\n", version)
 		return 0
+	case "plugin":
+		return plugin(args[1:], stdout, stderr, version, agentRunner)
 	default:
 		if _, ok := commandUsage[args[0]]; ok {
 			if len(args) == 2 && (args[1] == "-h" || args[1] == "--help") {
@@ -134,6 +137,39 @@ func run(args []string, stdout, stderr io.Writer, version string, agentRunner tr
 
 		return usageError(stderr, "unknown command %q", args[0])
 	}
+}
+
+func plugin(args []string, stdout, stderr io.Writer, version string, runner transport.Runner) int {
+	if len(args) != 0 {
+		return usageError(stderr, "plugin does not accept arguments")
+	}
+	workflowPath := os.Getenv(pluginWorkflowEnvironment)
+	if strings.TrimSpace(workflowPath) == "" {
+		return usageError(stderr, "plugin: %s is required", pluginWorkflowEnvironment)
+	}
+	if err := normalizePluginCommit(context.Background(), os.Getenv, os.Setenv, runner); err != nil {
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: plugin: %v\n", err)
+		return 1
+	}
+	return upload([]string{workflowPath}, stdout, stderr, version, transport.Agent{Runner: runner})
+}
+
+func normalizePluginCommit(ctx context.Context, getenv func(string) string, setenv func(string, string) error, runner transport.Runner) error {
+	if validBuildkiteCommit(getenv("BUILDKITE_COMMIT")) {
+		return nil
+	}
+	output, err := runner.Run(ctx, "", "git", []string{"rev-parse", "HEAD"}, nil)
+	if err != nil {
+		return fmt.Errorf("resolve BUILDKITE_COMMIT from checked-out HEAD: %w", err)
+	}
+	commit := strings.TrimSpace(string(output))
+	if !validBuildkiteCommit(commit) {
+		return fmt.Errorf("resolve BUILDKITE_COMMIT from checked-out HEAD: git returned an invalid commit")
+	}
+	if err := setenv("BUILDKITE_COMMIT", commit); err != nil {
+		return fmt.Errorf("set resolved BUILDKITE_COMMIT: %w", err)
+	}
+	return nil
 }
 
 func help(args []string, stdout, stderr io.Writer) int {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -82,6 +82,116 @@ func TestUploadHelpFormsMatch(t *testing.T) {
 	}
 }
 
+func TestPluginIsHiddenFromHelp(t *testing.T) {
+	for _, args := range [][]string{{"--help"}, {"help"}} {
+		var stdout, stderr bytes.Buffer
+		if code := Run(args, &stdout, &stderr, "test-version"); code != 0 {
+			t.Fatalf("Run(%q) code = %d, stderr = %q", args, code, stderr.String())
+		}
+		if strings.Contains(stdout.String(), "plugin") {
+			t.Fatalf("Run(%q) exposed plugin command: %q", args, stdout.String())
+		}
+	}
+
+	for _, args := range [][]string{{"help", "plugin"}, {"plugin", "--help"}} {
+		var stdout, stderr bytes.Buffer
+		if code := Run(args, &stdout, &stderr, "test-version"); code != 2 {
+			t.Fatalf("Run(%q) code = %d, want 2", args, code)
+		}
+		if stdout.Len() != 0 || strings.Contains(stderr.String(), "buildkite-gha plugin") {
+			t.Fatalf("Run(%q) exposed plugin help: stdout=%q stderr=%q", args, stdout.String(), stderr.String())
+		}
+	}
+}
+
+func TestPluginRequiresCanonicalWorkflowWithoutSideEffects(t *testing.T) {
+	t.Setenv(pluginWorkflowEnvironment, "")
+	t.Setenv("WORKFLOW", "legacy.yml")
+	runner := &cliCaptureRunner{}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"plugin"}, &stdout, &stderr, "dev", runner); code != 2 {
+		t.Fatalf("run() code = %d, want 2; stderr = %q", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), pluginWorkflowEnvironment+" is required") || len(runner.commands) != 0 {
+		t.Fatalf("stderr = %q, commands = %#v", stderr.String(), runner.commands)
+	}
+}
+
+func TestPluginDelegatesCanonicalWorkflowToUpload(t *testing.T) {
+	workflowPath := filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "shell.yml")
+	t.Setenv(pluginWorkflowEnvironment, workflowPath)
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_STEP_KEY", "plugin-importer")
+	t.Setenv("BUILDKITE_REPO", "https://github.com/buildkite/buildkite-gha")
+	t.Setenv("BUILDKITE_COMMIT", "0123456789abcdef0123456789abcdef01234567")
+	t.Setenv("BUILDKITE_BRANCH", "main")
+	t.Setenv("BUILDKITE_TAG", "")
+	t.Setenv("BUILDKITE_PULL_REQUEST", "false")
+
+	t.Run("uploads through the existing implementation", func(t *testing.T) {
+		runner := &cliCaptureRunner{}
+		var stdout, stderr bytes.Buffer
+		if code := run([]string{"plugin"}, &stdout, &stderr, "dev", runner); code != 0 {
+			t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+		}
+		if len(runner.commands) == 0 || runner.commands[0].name != "buildkite-agent" || !slices.Equal(runner.commands[0].args, []string{"meta-data", "get", "buildkite:webhook"}) {
+			t.Fatalf("commands = %#v, want upload event acquisition first", runner.commands)
+		}
+		if len(runner.uploaded) != 4 || !strings.Contains(stdout.String(), "Uploaded 3 jobs") {
+			t.Fatalf("uploads = %d, stdout = %q", len(runner.uploaded), stdout.String())
+		}
+	})
+
+	t.Run("propagates upload failure", func(t *testing.T) {
+		runner := &cliCaptureRunner{failAt: 1}
+		var stdout, stderr bytes.Buffer
+		if code := run([]string{"plugin"}, &stdout, &stderr, "dev", runner); code != 1 {
+			t.Fatalf("run() code = %d, want 1; stderr = %q", code, stderr.String())
+		}
+		if !strings.Contains(stderr.String(), "injected failure") || len(runner.uploaded) != 0 {
+			t.Fatalf("stderr = %q, uploads = %#v", stderr.String(), runner.uploaded)
+		}
+	})
+}
+
+func TestNormalizePluginCommit(t *testing.T) {
+	const fullCommit = "0123456789abcdef0123456789abcdef01234567"
+	t.Run("preserves valid full commit", func(t *testing.T) {
+		runner := &cliCaptureRunner{}
+		setCalls := 0
+		err := normalizePluginCommit(context.Background(), func(string) string { return fullCommit }, func(string, string) error {
+			setCalls++
+			return nil
+		}, runner)
+		if err != nil || setCalls != 0 || len(runner.commands) != 0 {
+			t.Fatalf("normalizePluginCommit() error = %v, set calls = %d, commands = %#v", err, setCalls, runner.commands)
+		}
+	})
+
+	t.Run("resolves symbolic commit from HEAD", func(t *testing.T) {
+		runner := &cliCaptureRunner{gitOutput: []byte(fullCommit + "\n")}
+		name, value := "", ""
+		err := normalizePluginCommit(context.Background(), func(string) string { return "HEAD" }, func(gotName, gotValue string) error {
+			name, value = gotName, gotValue
+			return nil
+		}, runner)
+		if err != nil || name != "BUILDKITE_COMMIT" || value != fullCommit {
+			t.Fatalf("normalizePluginCommit() = %q, %q, %v", name, value, err)
+		}
+		if len(runner.commands) != 1 || runner.commands[0].name != "git" || !slices.Equal(runner.commands[0].args, []string{"rev-parse", "HEAD"}) {
+			t.Fatalf("commands = %#v, want exact git rev-parse HEAD invocation", runner.commands)
+		}
+	})
+
+	t.Run("propagates resolution failure", func(t *testing.T) {
+		runner := &cliCaptureRunner{gitErr: errors.New("no checkout")}
+		err := normalizePluginCommit(context.Background(), func(string) string { return "HEAD" }, os.Setenv, runner)
+		if err == nil || !strings.Contains(err.Error(), "resolve BUILDKITE_COMMIT from checked-out HEAD: no checkout") {
+			t.Fatalf("normalizePluginCommit() error = %v", err)
+		}
+	})
+}
+
 func TestRunValidateAndCompile(t *testing.T) {
 	workflowPath := filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "shell.yml")
 	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
@@ -2618,6 +2728,8 @@ type cliCaptureRunner struct {
 	failAt         int
 	failMetadata   bool
 	failAnnotation bool
+	gitOutput      []byte
+	gitErr         error
 	webhook        []byte
 	webhookErr     error
 	jobByStep      map[string]string
@@ -2656,6 +2768,9 @@ func (r *cliCaptureRunner) Run(ctx context.Context, dir, name string, args []str
 	r.contextErrors = append(r.contextErrors, ctx.Err())
 	if r.failAt != 0 && len(r.commands) == r.failAt {
 		return nil, errors.New("injected failure")
+	}
+	if name == "git" && slices.Equal(args, []string{"rev-parse", "HEAD"}) {
+		return bytes.Clone(r.gitOutput), r.gitErr
 	}
 	if slices.Equal(args, []string{"meta-data", "get", "buildkite:webhook"}) {
 		if r.webhookErr != nil {


### PR DESCRIPTION
## Why

The GitHub Actions Buildkite plugin needs a deliberately narrow integration boundary instead of invoking the public `upload` command and translating plugin configuration into CLI arguments.

## What

Add a hidden, zero-argument `buildkite-gha plugin` entrypoint that reads the canonical workflow environment, normalizes symbolic Buildkite commits from checked-out `HEAD`, and delegates to the existing upload implementation. Keep the public command surface and direct `upload` behavior unchanged.
