### PR TITLE
Make project docs easier to scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,83 +1,42 @@
 # buildkite-gha
 
-Run a GitHub Actions workflow as native Buildkite jobs—without creating a
+Run GitHub Actions workflows as native Buildkite jobs, without creating a
 GitHub Actions run.
 
-`buildkite-gha` translates each workflow job (and each static matrix entry)
-into a Buildkite job, then runs that job's Actions steps in a compatibility
-runtime. Buildkite remains the source of truth for scheduling, logs, retries,
-cancellation, and the build UI.
+`buildkite-gha` turns each supported workflow job and static matrix entry into
+a Buildkite job. Steps run in a compatibility runtime inside that job.
+Buildkite owns scheduling, logs, retries, cancellation, and the build UI.
 
 > [!IMPORTANT]
-> This is an experimental pre-1.0 preview for **Linux x86-64 workflows**. The
-> default remains limited to public actions and no general workflow secrets.
-> Verified checkout automatically uses Buildkite's repository-provider Git
-> credentials when the job is configured for them, and otherwise checks out
-> anonymously. Private actions and workflow secrets other than the explicitly
-> scoped `secrets.GITHUB_TOKEN` contract remain rejected.
+> This is an experimental pre-1.0 preview for Linux x86-64 workflows. The
+> production path supports local and public actions plus narrow, job-bound
+> checkout, `GITHUB_TOKEN`, artifact, and cache integrations. Private actions,
+> ordinary workflow secrets, and GitHub-compatible OIDC are not supported.
 
-## Buildkite controls the pipeline; the workflow describes the workload
+## How it works
 
-A GitHub Actions workflow combines two concerns: run triggers and event filters
-under `on:` control when GitHub creates a workflow run, while `jobs` and `steps`
-describe the work in that run. `buildkite-gha` imports only the supported
-workload portion into a Buildkite build that already exists. The supported
-local `on.workflow_call` interface is workload composition, not trigger setup.
+Buildkite creates the build. The plugin reads the workload from the workflow
+file and dynamically uploads the jobs it supports.
 
-Buildkite pipeline integrations, settings, schedules, and manual or API build
-requests decide when to create a build. The initial Buildkite pipeline
-definition then invokes the plugin, which dynamically uploads the supported
-workflow jobs into that build. The workflow's run triggers and event filters
-neither create nor filter Buildkite builds.
+| GitHub Actions | Buildkite |
+| --- | --- |
+| Triggers and filters under `on:` | Configure these in Buildkite |
+| Workflow run | Existing Buildkite build |
+| Job | Buildkite command job |
+| Matrix entry | Buildkite command job |
+| `needs` | `depends_on` plus verified result transport |
+| Step | Runs inside the job compatibility runtime |
+| `runs-on` | Linux compatibility check; Buildkite chooses the agent |
 
-Buildkite configuration also remains authoritative for agent targeting and
-protected capabilities. Workflow settings such as `runs-on`, `permissions`,
-environments, and concurrency are honored only within the explicitly supported
-and admitted boundaries in the [support matrix](docs/compatibility.md#support-matrix).
-They are requests constrained by Buildkite configuration, admission policy, and
-the supported runtime. Repository credential and token requests are additionally
-bounded by Buildkite's server-side repository and permission policy; none can
-change Buildkite pipeline settings.
+Steps stay together because they share a workspace, environment changes,
+action state, and post-action cleanup. Local `workflow_call` remains useful for
+workflow composition, but `on:` never creates or filters a Buildkite build.
 
 ## Try an existing workflow
 
 Add the [GitHub Actions Buildkite
 plugin](https://github.com/buildkite-plugins/github-actions-buildkite-plugin)
-to your Buildkite `pipeline.yml`:
-
-```yaml
-steps:
-  - label: ":github: Test"
-    key: "gha-ci"
-    plugins:
-      - github-actions#v0.4.4:
-          workflow: .github/workflows/ci.yml
-```
-
-The pinned released plugin downloads and verifies `buildkite-gha` v0.4.2 by
-default, derives the event context from the Buildkite build, and explicitly
-targets the fixed `hosted` queue. Pin a released plugin version rather than a
-floating branch. The current source CLI instead omits agent selectors by
-default, so direct uploads inherit Buildkite's configured agent targeting unless
-`BUILDKITE_GHA_TARGET_QUEUE` selects one queue explicitly. Jobs that can execute
-JavaScript reuse mise 2026.5.12 or newer from `PATH` or the absolute path in
-`BUILDKITE_GHA_MISE`; when neither provides a compatible version, the runtime
-downloads and verifies a managed 2026.5.12 copy. Hosted Agents use their
-attached cache; other environments fall back to an ephemeral cache when that
-path is unavailable. Shell-only jobs and action jobs whose resolved trees
-contain only shell steps, native adapters, or Docker do not require or install
-mise.
-
-Configure branch, tag, and pull request triggers in Buildkite. The plugin
-derives a `pull_request` context for pull request builds and a `push` context
-for every other build. Scheduled and manual Buildkite builds therefore do not
-receive `schedule` or `workflow_dispatch` contexts or dispatch inputs. The
-workflow's `on:` block does not create or change Buildkite triggers.
-
-### Mix imported and native jobs
-
-The imported workflow is an ordinary dynamic part of the Buildkite pipeline.
-A native job can depend on the importer and will wait for the jobs it uploads:
+to your pipeline:
 
 ```yaml
 steps:
@@ -88,151 +47,52 @@ steps:
           workflow: .github/workflows/ci.yml
 
   - label: ":rocket: Deploy"
-    key: "deploy"
     depends_on: "gha-ci"
     command: .buildkite/deploy.sh
 ```
 
-This gives teams a migration path: start with the existing Actions workflow,
-then move work into native Buildkite jobs over time. Automatic replacement of
-a named imported job is planned, but is not part of this preview.
+The plugin downloads and verifies the released CLI. Pin a plugin version rather
+than a floating branch.
 
-## Compare example runs
+The imported workflow is an ordinary dynamic part of the pipeline. The native
+deploy job above waits for the importer and every job it uploads. This lets you
+keep an existing workflow while moving jobs to native Buildkite steps over
+time.
 
-The basic CI, artifact handoff, and advanced delivery examples are manual
-GitHub Actions workflows under `.github/workflows`. The dedicated
-`buildkite-gha-examples` pipeline imports those exact files one at a time and
-offers the same three choices through a Buildkite block step.
-
-To launch both providers at the current branch's exact remote commit and print
-their run URLs together:
-
-```sh
-scripts/compare-example basic
-scripts/compare-example artifacts
-scripts/compare-example advanced
-```
-
-The helper requires authenticated `gh` and `bk` CLIs. The current commit must
-be the head of the corresponding `origin` branch, and GitHub must already know
-the workflow from the repository's default branch. Pass `--github-only` or
-`--buildkite-only` to launch just one side.
-
-For the native manual experience, choose one of the `Example - ...` workflows
-in GitHub's Actions tab. In Buildkite, create a build on the
-`buildkite-gha-examples` pipeline and select the example when the build blocks.
-Compare the job graph, matrix presentation, logs, summaries, annotations,
-artifacts, retries, and cancellation behavior.
+Configure branch, tag, pull request, schedule, and manual triggers in Buildkite.
+The plugin uses `pull_request` context for pull request builds and `push` context
+for other builds. The workflow's `on:` filters do not create or filter
+Buildkite builds.
 
 ## Is my workflow a fit?
 
-The [support matrix](docs/compatibility.md#support-matrix) is the authoritative
-list of supported, partially supported, not-admitted, and unsupported GitHub
-Actions behavior.
+The [compatibility reference](docs/compatibility.md) is the source of truth.
+For a quick screen:
 
-During `upload`, an explicit `--event-path` has highest precedence. Otherwise
-the CLI reads Buildkite's reserved `buildkite:webhook` metadata once for the
-compile-time `github.event` object, falling back to a reduced-fidelity
-`BUILDKITE_*` snapshot only when Buildkite reports no available webhook
-association. Buildkite environment values always define the exact top-level
-repository, SHA, and ref being executed. Every source remains untrusted; raw
-webhook data cannot grant protected capabilities and is not retained in plans
-or pipeline YAML. Stored webhook data has no delivery headers, and GitHub push
-payloads may omit `commits`. See [Event snapshots](docs/cli.md#event-snapshots)
-for limits and failure behavior.
+| Good fit | Not currently supported |
+| --- | --- |
+| Linux x86-64 jobs using Bash or `sh` | Windows, macOS, or Linux arm64 |
+| Local and public JavaScript, composite, and verified Dockerfile actions | Private actions or arbitrary reusable-workflow source |
+| Static matrices, `needs`, outputs, and local reusable workflows | Dynamic matrices and expressions outside the documented subset |
+| Exact-commit checkout, including managed private repository access | Ordinary workflow secrets, GitHub-compatible OIDC, or protected queues |
+| Scoped `GITHUB_TOKEN` use allowed by Buildkite policy | Ambient or workflow-authored `github.token` use |
+| Audited artifact v4 and cache v6 integrations | Other artifact/cache modes and general GitHub service emulation |
+| Background, wait, cancellation, and parallel step controls | Job and service containers through the production plugin path |
 
-As a quick screen, the plugin path is a good fit for workflows built from:
+Some features have a supported subset or an intentional Buildkite-specific
+behavior. Check the matrix before migrating a workflow.
 
-- Linux Bash and `sh` steps;
-- JavaScript, composite, local, and anonymous public actions. `node16` actions
-  run on exact managed Node 16.20.2 and produce one end-of-job deprecation
-  warning naming the invoked actions;
-- supported local and public Dockerfile actions;
-- static matrices, ordinary `needs` and outputs, and local reusable workflows
-  with statically resolved inputs, caller-visible results, and directly mapped
-  declared outputs;
-- the documented job and step condition subset, with unsupported functions and
-  unavailable runtime contexts rejected before pipeline upload;
-- GitHub Actions background, wait, cancellation, and parallel step controls;
-- timeouts, `continue-on-error`, masking, summaries, warning/error annotations,
-  and pre/main/post actions;
-- checkout of the event repository at its exact commit, using Buildkite's
-  repository-provider Git credentials when available and anonymous Git
-  otherwise;
-- short-lived GitHub tokens requested with explicit workflow or job
-  `permissions` for the event repository and bounded by Buildkite's server-side
-  policy, consumed through `secrets.GITHUB_TOKEN` or an effective action
-  metadata input default that references `github.token`;
-- bounded native upload and exact-name download for the audited artifact v4
-  commits; and
-- the audited `actions/cache` v6.1.0 commit through the official Buildkite
-  cache-v2 Results service, plus compatible cache clients bundled into
-  JavaScript and Docker actions such as `actions/setup-go`, with an optional
-  operator override.
+## Validate before running
 
-It is not currently a fit for workflows that require:
-
-- private actions or general private-source access; checkout can use only the
-  job's native Buildkite repository-provider credentials as described in the
-  compatibility guide;
-- ordinary workflow secrets—the scoped `secrets.GITHUB_TOKEN` contract is the
-  only workflow-visible secret exception;
-- workflow-authored `github.token`, automatic ambient `GITHUB_TOKEN` injection,
-  GitHub-compatible OIDC, or protected queues;
-- `actions/cache` v4/v5 or unrecognized v6 commits, artifact
-  merge/all/pattern/ID modes, or cross-run downloads;
-- runtime condition access to the `github.event` payload, or condition
-  functions and contexts outside the documented subset;
-- job containers or service containers through the production plugin path;
-- GitHub matrix fail-fast semantics—the complete static matrix is uploaded and
-  sibling jobs are not canceled after one entry fails;
-- compound or literal local reusable-workflow output mappings and reusable-call
-  conditions;
-- job-level or expression-valued `concurrency.cancel-in-progress`,
-  runtime-dependent concurrency groups, or workflow-level concurrency declared
-  by a called reusable workflow;
-- privileged containers, arbitrary Docker options, or `docker://` actions; or
-- Windows or macOS jobs.
-
-The underlying runtime has broader container coverage than the production
-plugin currently exposes. See the [compatibility reference](docs/compatibility.md)
-for the exact distinction and intentional behavior differences.
-
-## Check before running
-
-Static validation does not contact Buildkite or execute the workflow:
+Check syntax and the static job graph without contacting Buildkite or executing
+workflow code:
 
 ```sh
 buildkite-gha validate .github/workflows/ci.yml
 ```
 
-For example, a workflow with one producer and a two-entry consumer matrix
-reports:
-
-```text
-Schema: buildkite-gha/processing-report/v1
-Workflow: .github/workflows/ci.yml
-Result: compilable
-Status: passed
-Logical jobs: 2
-Instances: 3
-Compile: compilable
-Admission: not-evaluated
-✓ 2 logical jobs and 3 static instances compile
-- Workflow parsing: passed
-- Event validation: not-evaluated
-- Static graph construction: passed
-- Matrix expansion: passed
-- Expression validation: passed
-- Local and public action discovery: passed
-- Immutable action resolution: passed
-- Job-plan construction: not-evaluated
-- Hosted-profile admission: not-evaluated
-- Pipeline generation: not-evaluated
-```
-
-To also resolve public actions and apply the same policy as the plugin's
-`hosted-tokenless` upload, provide an event snapshot:
+To resolve public actions and apply the production upload policy, provide an
+event snapshot:
 
 ```sh
 buildkite-gha validate \
@@ -241,74 +101,32 @@ buildkite-gha validate \
   .github/workflows/ci.yml
 ```
 
-An `admitted` result means the plans satisfy upload policy. It does not execute
-the workflow or prove that arbitrary action code is independent of GitHub-only
-services. Condition preflight validates the supported syntax, functions,
-contexts, and statically known operand types, but cannot prove value-dependent
-runtime behavior. JSON output is available with `--format json`.
+An `admitted` result means the workflow satisfies upload policy. It does not
+execute the workflow or prove that arbitrary action code works without GitHub
+services. Use `--format json` for machine-readable output.
 
-Every report includes all ten processing stages with `passed`, `failed`, or
-`not-evaluated`, plus source-located job, matrix-instance, action, and
-diagnostic records. Independent errors are aggregated deterministically.
-`compile` writes the same report to standard error before writing compiler
-output; the Buildkite importer writes it to its job log before upload or exit.
-Any failed required stage suppresses every plan and pipeline artifact.
+See the [CLI guide](docs/cli.md) for event snapshots, compilation, direct
+upload, and agent targeting.
 
-## What gets translated?
+## Run untrusted jobs safely
 
-| GitHub Actions | Buildkite |
-| --- | --- |
-| Run triggers and event filters under `on:` | Not translated; Buildkite configuration creates the build |
-| Workflow run | Existing Buildkite build |
-| Job | Command job |
-| Matrix entry | Command job with a stable key |
-| `needs` | `depends_on` plus verified result transport |
-| `runs-on` | Linux compatibility validation; Buildkite default agent targeting |
-| `concurrency.group` | Repository-scoped Buildkite concurrency group or workflow gate |
-| Job output | Producer-attributed result artifact |
-| Step | Runs inside the job compatibility runtime |
+Workflow steps and third-party actions are repository code. Run imported jobs
+on a disposable, whole-job-isolated queue with no ambient protected
+credentials. Action containers do not replace that boundary.
 
-Steps are intentionally **not** translated into separate Buildkite jobs. They
-share a workspace, environment changes, action state, containers, and
-post-action lifecycle in GitHub Actions, so they must stay inside one job here
-too.
-
-```diagram
-┌──────────────────────────┐
-│ Buildkite configuration  │
-│ creates the build        │
-└────────────┬─────────────┘
-             ▼
-┌──────────────────────────┐    ┌──────────────────────────┐
-│ Existing Buildkite build │◀───│ Actions workflow + event │
-│ invokes the importer     │    │ snapshot (workload input)│
-└────────────┬─────────────┘    └──────────────────────────┘
-             ▼
-┌──────────────────────────┐
-│ Validate, compile, and   │
-│ dynamically upload jobs │
-└────────────┬─────────────┘
-             ▼
-┌──────────────────────────┐
-│ Native Buildkite jobs    │
-│ one runtime per GHA job  │
-└────────────┬─────────────┘
-             ▼
-┌──────────────────────────┐
-│ Buildkite logs + results │
-└──────────────────────────┘
-```
+See the [security model](docs/security.md) before enabling managed repository
+access, scoped write tokens, or caching.
 
 ## Documentation
 
-- [GitHub Actions compatibility and behavior differences](docs/compatibility.md)
-- [Direct CLI use](docs/cli.md)
-- [Security model and operator responsibilities](docs/security.md)
-- [Development, smoke tests, and releases](docs/development.md)
+- [Compatibility reference](docs/compatibility.md)
+- [CLI guide](docs/cli.md)
+- [Security model](docs/security.md)
+- [Development and releases](docs/development.md)
 - [Architecture decisions](docs/architecture/)
 
 Use `buildkite-gha help`, `buildkite-gha help <command>`, or
-`buildkite-gha --version` for the exact installed command surface.
+`buildkite-gha --version` for the installed command surface.
 
 ## License
 

--- a/docs/architecture/0001-upstream-actions-reuse.md
+++ b/docs/architecture/0001-upstream-actions-reuse.md
@@ -1,4 +1,4 @@
-# ADR 0001: Reuse actionlint as a parser and keep act as an oracle
+# ADR 0001: Use actionlint as the parser; keep runners as references
 
 - Status: Accepted
 - Date: 2026-07-22
@@ -6,183 +6,36 @@
 
 ## Context
 
-`buildkite-gha` needs a GitHub Actions syntax frontend and a compatible job
-runtime, but its durable interfaces are a provider-neutral workflow model and a
-versioned Buildkite job plan. Reusing an upstream execution model across that
-boundary would couple compilation, policy, action resolution, and execution to
-the assumptions of a local Actions runner.
+`buildkite-gha` needs to understand GitHub Actions syntax without inheriting a
+GitHub Actions runner. Its durable interfaces are its own workflow model and
+versioned Buildkite job plan.
 
-This spike inspected the current released source of `nektos/act`,
-`rhysd/actionlint`, and GitHub's open runner. It considered workflow and action
-models, matrix expansion, expression evaluation, resolution and execution,
-workflow commands and environment files, dependency licensing, and version
-pinning. The repositories were cloned and inspected locally as well as checked
-against their release pages and documentation.
+Using a runner's execution model inside the compiler would couple parsing,
+policy, action resolution, and execution to assumptions that do not fit
+Buildkite.
 
 ## Decision
 
-Import `github.com/rhysd/actionlint` unchanged as a pinned parser frontend. Use
-its workflow AST, source positions, expression lexer/parser/AST, availability
-metadata, and, where useful, its static semantic checks. Immediately adapt the
-parsed result into owned internal workflow and expression interfaces; neither
-the actionlint AST nor any act type may appear in the versioned job plan.
+- Use the pinned [`actionlint`](https://github.com/rhysd/actionlint) module for
+  workflow and expression parsing, source positions, and useful static checks.
+- Convert parsed values immediately into types owned by this repository.
+  Actionlint types must not enter compiler IR or job plans.
+- Implement matrix expansion, expression evaluation, action resolution,
+  workflow commands, environment files, and execution in owned packages.
+- Use [`nektos/act`](https://github.com/nektos/act) and the
+  [GitHub Actions runner](https://github.com/actions/runner) as behavioral
+  references and sources of test cases, not production dependencies.
+- Do not maintain an upstream fork. A release-blocking incompatibility that
+  cannot be handled by an adapter or upstream contribution requires a new ADR.
 
-Do not import an act package into production in the first implementation wave.
-Use act's model, matrix, expression, action resolution, lifecycle, command, and
-environment-file code as behavioral reference and as a source of differential
-test cases. Implement those product boundaries in owned packages against the
-official runner's observable behavior.
+## Consequences
 
-Maintain no forks. A fork is justified only after a differential fixture proves
-a release-blocking gap, an upstream contribution is not viable on the required
-timeline, and a small adapter or owned implementation would create more
-maintenance risk. Record such a change in a new ADR with the upstream issue,
-patch delta, merge cadence, and exit condition.
+- Parser upgrades require the parser-adapter tests and workflow corpus to pass.
+- Compatibility is judged by observable behavior, not by sharing runner code.
+- The production dependency graph stays smaller and avoids act's runner,
+  Docker, Git, and mutable execution model.
+- Actionlint and its transitive dependencies remain part of the shipped Go
+  module graph and must be included in licensing review.
 
-## Component decisions
-
-### Workflow and action models
-
-Use actionlint's position-bearing workflow AST as the syntax frontend and adapt
-it immediately into an owned model. `actionlint.Parse` is a documented library
-API and its nodes retain one-based line and column positions, which supports
-source-located compatibility diagnostics.
-
-Do not use `act/pkg/model` as the canonical model. Its structs mix decoded
-values with mutable execution results, some fields retain `yaml.Node` while
-others discard source locations, and helpers mutate model state or terminate
-through act's logging conventions. Importing the package also pulls schema,
-Git, logging, and roughly thirty third-party modules into the compiler. Act's
-`ReadAction` and action types remain useful references for `action.yml`
-coverage, but action metadata must also be adapted into owned types.
-
-### Matrix expansion
-
-Implement matrix expansion in the owned compiler. Use
-`act/pkg/model.Job.GetMatrixes` as a test-input source, not as a dependency: the
-method combines decoding, mutation, Cartesian expansion, include/exclude
-policy, and act-specific error behavior. It also turns a zero-result product
-into one empty matrix entry, so the required empty-matrix behavior cannot be
-accepted without a GitHub differential fixture.
-
-The implementation must separately represent an unevaluated matrix expression,
-a statically evaluated matrix value, and expanded instances. This preserves the
-compiler/runtime phase boundary needed for deferred matrices and allows explicit
-size and cardinality limits before expansion.
-
-### Expression parsing and evaluation
-
-Import actionlint's lexer, parser, expression AST, and static type checker
-unchanged behind an internal adapter. Implement evaluation, coercion, context
-availability, status functions, and resource limits in an owned evaluator.
-
-Do not import `act/pkg/exprparser`. It gives useful reference behavior for
-coercion, wildcard access, functions, and truthiness, but its public environment
-contains act model types and its status functions walk an act `Run`, workflow,
-and mutable job results. `hashFiles` also embeds local-filesystem behavior. That
-boundary cannot represent the plan's distinct compile-time, job-start,
-step-start, and job-output phases without carrying act runtime state inward.
-
-### Action resolution and execution
-
-Implement provider-neutral action resolution and an immutable source cache in
-owned packages. Act's `runner.ActionCache` demonstrates a useful split between
-resolving a ref and reading an archive, but it lives in `pkg/runner`; importing
-that package compiles the Docker, go-git, container, logging, and execution
-stack. Its default resolver is GitHub-shaped and its action lifecycle shares a
-mutable `RunContext`, while `buildkite-gha` must bind resolution to provider
-provenance, signed plans, archive limits, and queue policy.
-
-Use act's pre/main/post, JavaScript, composite, Docker, service, and cleanup
-paths as scenario references. Use the official runner as the compatibility
-oracle for lifecycle ordering and observable semantics. Do not use the official
-runner listener, server job-message model, or C# worker assemblies as runtime
-dependencies.
-
-### Workflow commands and environment files
-
-Implement an owned streaming command processor and per-step environment-file
-processor. Act's command parser is tied to `RunContext`, logrus, and its output
-pipeline, while its environment-file readers retrieve files through a job
-container abstraction and include limits such as a 1 GB scanner buffer that do
-not match this project's bounded-input policy.
-
-Match the official runner instead: it serializes command handling, uses a
-case-insensitive command registry, gives each step fresh file-command paths,
-blocks `NODE_OPTIONS` through `GITHUB_ENV`, and processes state, outputs, paths,
-and summaries after the step. Differential fixtures must cover LF and CRLF,
-heredocs, malformed delimiters, stop-command tokens, annotation escaping,
-masking order, and the concurrent-stream masking race.
-
-## Evidence
-
-| Upstream | Package or source inspected | Revision inspected | Disposition |
-| --- | --- | --- | --- |
-| [rhysd/actionlint](https://github.com/rhysd/actionlint/releases/tag/v1.7.12) | [`github.com/rhysd/actionlint`](https://github.com/rhysd/actionlint/blob/v1.7.12/docs/api.md) workflow AST, `Parse`, expression lexer/parser/checker, action metadata | `v1.7.12`, `914e7df21a07ef503a81201c76d2b11c789d3fca` | Import unchanged behind adapters |
-| [nektos/act](https://github.com/nektos/act/releases/tag/v0.2.89) | [`pkg/model`](https://github.com/nektos/act/blob/v0.2.89/pkg/model/workflow.go), including `ReadWorkflow`, `ReadAction`, and `GetMatrixes` | `v0.2.89`, `4f411281417e88660bea1c1a1749aa71ae0bd60f` | Behavioral reference only |
-| nektos/act | [`pkg/exprparser`](https://github.com/nektos/act/blob/v0.2.89/pkg/exprparser/interpreter.go) | `v0.2.89`, `4f411281417e88660bea1c1a1749aa71ae0bd60f` | Behavioral reference and fixture source only |
-| nektos/act | `pkg/runner` action cache, remote resolution, and pre/main/post execution | `v0.2.89`, `4f411281417e88660bea1c1a1749aa71ae0bd60f` | Pattern and fixture reference only |
-| nektos/act | [`pkg/runner/command.go`](https://github.com/nektos/act/blob/v0.2.89/pkg/runner/command.go) and environment-file handling | `v0.2.89`, `4f411281417e88660bea1c1a1749aa71ae0bd60f` | Behavioral reference only |
-| [actions/runner](https://github.com/actions/runner/releases/tag/v2.336.0) | [`ActionCommandManager.cs`](https://github.com/actions/runner/blob/v2.336.0/src/Runner.Worker/ActionCommandManager.cs) and [`FileCommandManager.cs`](https://github.com/actions/runner/blob/v2.336.0/src/Runner.Worker/FileCommandManager.cs) | `v2.336.0`, `98aabcd429c4e8402406c56ce2d26387fed3b9ce` | Primary behavioral oracle; no dependency |
-
-At these revisions, `go test ./pkg/model ./pkg/exprparser` passes in act.
-Actionlint's core package and command tests pass; its repository-wide test run
-has one failure in the network-sensitive `scripts/generate-popular-actions`
-bad-request test, outside the imported package. `go list -deps` confirms that
-actionlint's single root package compiles its linter dependencies, while
-`act/pkg/model` reaches go-git and related modules and `act/pkg/runner` adds the
-Docker/Moby stack.
-
-## Licensing and dependency consequences
-
-Act, actionlint, and the official runner are MIT licensed. Importing or copying
-substantial source requires retaining their copyright and license notices.
-Actionlint's compiled dependency set at v1.7.12 is permissively licensed but
-includes Apache-2.0 and BSD-family notices in addition to MIT; release builds
-must generate and review a third-party notice and SBOM from the resolved module
-graph.
-
-Avoiding act as a module keeps its much wider transitive graph out of the
-product. The inspected act graph includes Docker/Moby Apache-2.0 components and
-`github.com/cyphar/filepath-securejoin` under MPL-2.0. MPL-2.0 is compatible
-with this use but adds file-level source obligations if modified and
-distributed, which is another reason not to inherit the runner stack without a
-product need. Any future copied act code must carry act's MIT notice adjacent
-to the derived source and be included in release notices.
-
-This is an engineering license inventory, not legal approval. The release gate
-remains an automated license scan over the exact shipped source and bundled
-runtimes.
-
-## Version policy
-
-- Pin actionlint to the exact `v1.7.12` module version and commit through
-  `go.mod` and `go.sum`; do not use `latest` or a floating branch. Its own API
-  documentation says library consumers do not receive semantic-versioning
-  guarantees, so every update requires parser-adapter golden tests and the
-  workflow corpus.
-- Accept actionlint's Go 1.25 minimum as an explicit foundation constraint for
-  this revision. Reconsider the pin if the project chooses an older Go support
-  floor rather than silently raising the toolchain.
-- Record exact act and official-runner tags and commits with every imported
-  differential fixture. They are test provenance, not Go dependencies. The
-  latest runner release may be progressively deployed, so GitHub differential
-  evidence must also capture the runner version observed in each run.
-- Do not combine act's pinned actionlint v1.7.7 dependency with a direct current
-  actionlint dependency. Keeping act out of `go.mod` avoids Go minimal-version
-  selection silently testing act against a newer, non-semver library API than
-  act declares.
-
-## Consequences for the next implementation wave
-
-1. Build one internal parser adapter around actionlint and convert syntax nodes
-   into owned workflow/action types with source spans.
-2. Implement static matrix expansion and expression evaluation behind owned
-   interfaces, seeded by act tests and verified by GitHub differential fixtures.
-3. Define provider resolution, immutable archives, runtime state, workflow
-   commands, and environment files independently of act's `RunContext` and
-   container interfaces.
-4. Add dependency-update CI that runs parser golden tests, the smoke corpus,
-   license inventory, and SBOM generation before changing the actionlint pin.
-5. Keep an explicit oracle manifest containing the act and official-runner
-   revisions so behavior changes are reviewed rather than absorbed implicitly.
+The [compatibility reference](../compatibility.md) remains the source of truth
+for supported syntax and behavior.

--- a/docs/architecture/0003-protected-capability-control-plane.md
+++ b/docs/architecture/0003-protected-capability-control-plane.md
@@ -1,402 +1,74 @@
-# ADR 0003: Authenticate protected capability grants through a Buildkite control plane
+# ADR 0003: Keep protected capabilities behind Buildkite-owned policy
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-08-04
 - Decision owners: `buildkite-gha` and Buildkite platform maintainers
 
 ## Context
 
-The service-free compatibility path can execute public, anonymous workflow code
-without giving it authority beyond its Buildkite job. Summaries, annotations,
-native artifact adapters, public exact-SHA checkout, and the audited
-`actions/cache` v6 client all use public Agent or explicitly configured
-cache-v2 interfaces. With two narrow exceptions described below, they do not
-establish general authority for private source, secrets, provider tokens,
-environments, privileged queues, or compatible OIDC claims.
+Workflow files, action metadata, event snapshots, and generated job plans are
+inputs controlled by repository code. They can describe required capabilities,
+but cannot authorize credentials, protected queues, environments, or provider
+identity.
 
-A plan cannot authorize those protected values. Workflow and event files are
-compiler inputs, and dynamic pipeline upload is ordinary pipeline authority.
-The runtime needs a separate authorization result tied to both the
-actual Buildkite job and independently established provider facts.
-
-Buildkite Job OIDC supplies the job half of that identity. A running Agent can
-mint a short-lived token for an exact audience with immutable organization,
-pipeline, build, job, cluster, and queue identifiers. It does not prove the
-complete GitHub event, actor, fork relationship, workflow source, installation,
-or policy decision. A Buildkite-owned control plane must join those facts before
-issuing any grant.
-
-The protected-capability implementation therefore starts with a signed **no-op grant**. It
-proves authentication, provenance, policy, signing, verification, expiry, and
-audit boundaries while carrying an empty capability set and returning no
-credential. General private source, non-provider secrets, GitHub authority
-beyond the fixed checkout and scoped workflow-token exceptions, environments,
-and compatibility OIDC remain deferred.
+Buildkite Job OIDC can identify the running job. It does not prove the GitHub
+event, actor, fork relationship, workflow source, installation, or policy
+decision. Broader protected capabilities need both sides of that identity.
 
 ## Decision
 
-### Ownership and trust domains
+General protected capabilities require a Buildkite-owned control plane outside
+the workflow job and compiler.
 
-The grant issuer is a Buildkite platform-owned control plane, not code running
-inside the requesting job and not the `buildkite-gha` compiler. The expected
-initial implementation belongs with the Buildkite service that owns build/job
-identity and GitHub provider events. A separately deployed service is acceptable
-only if it consumes equivalent authoritative interfaces and does not trust
-provider facts supplied by the CLI.
+The control plane must:
 
-This repository owns:
+1. authenticate the requesting job with Buildkite Job OIDC;
+2. join it to authoritative provider-event data;
+3. apply organization, pipeline, event, environment, cluster, and queue policy;
+4. issue a short-lived signed grant bound to the job, provider event, plan,
+   queue, and allowed capabilities; and
+5. record the decision without logging credentials.
 
-- the versioned request and grant contracts;
-- the canonical event-snapshot serialization used to derive `event_digest`;
-- the client that obtains Job OIDC and requests a grant;
-- the runtime verifier and fail-closed capability intersection; and
-- conformance fixtures proving interoperability and rejection behavior.
+The runtime must verify the signature and every binding before using a protected
+value. Effective authority is the intersection of the plan request, signed
+grant, and local runtime policy. Missing, expired, mismatched, broadened, or
+unavailable grants fail closed. There is no unsigned fallback and no fallback
+to repository-supplied provenance.
 
-The control plane owns:
+### Ownership
 
-- Buildkite OIDC verification and immutable job lookup;
-- provider-event provenance and event-to-build correlation;
-- organization, event, queue, environment, and permission policy;
-- grant signing, key rotation, revocation, and audit records; and
-- later credential brokering behind the same authorization decision.
+A future implementation splits responsibility this way:
 
-The control-plane signing key is a separate trust domain from Buildkite
-pipeline-signing keys, cache tokens, and provider credentials.
+| This repository | Buildkite control plane |
+| --- | --- |
+| Versioned request and grant contracts | Job OIDC verification |
+| Event and plan digests | Authoritative provider-event correlation |
+| Client and runtime verifier | Organization and queue policy |
+| Fail-closed capability intersection | Signing, rotation, revocation, and audit |
+| Conformance tests | Credential brokering |
 
-### Job authentication
+### Existing narrow integrations
 
-The client obtains a fresh token with the Agent command equivalent to:
+These job-bound integrations remain separate from a general grant protocol:
 
-```sh
-buildkite-agent oidc request-token \
-  --audience "$BUILDKITE_GHA_CONTROL_PLANE_URL" \
-  --claim organization_id,pipeline_id,build_id,cluster_id,queue_id,queue_key
-```
+- verified checkout may use Buildkite's Git credential helper;
+- supported `GITHUB_TOKEN` uses may request a repository-scoped token with a
+  compiler-resolved permission set; and
+- the audited cache action may receive cache-service credentials for its own
+  lifecycle.
 
-`BUILDKITE_GHA_CONTROL_PLANE_URL` is one installer-owned, origin-only HTTPS
-service identifier. The client uses that same normalized origin as the OIDC
-audience and appends only the fixed request path. User information, non-root
-paths, queries, fragments, and redirects are rejected. The setting cannot be
-overridden by plan-, workflow-, repository-, or ordinary build-supplied
-environment. The client captures the token without logging it, keeps it in
-memory for one exchange, and sends it only to that bound service as the
-control-plane bearer credential. It never reads or forwards the ambient Agent
-access token to that service or to action code.
-
-The control plane validates the token against the fixed Buildkite issuer
-`https://agent.buildkite.com` and its configured discovery/JWKS endpoints. It
-requires the exact audience, signature, `nbf`, `iat`, `exp`, organization,
-pipeline, build, job, step, runner environment, cluster, and queue claims needed
-by policy. Missing required claims fail closed. Slugs and branch names are
-context only; immutable IDs are the authorization binding.
-
-### Grant request
-
-The initial endpoint accepts one bounded JSON request over HTTPS:
-
-```http
-POST /v1/capability-grants
-Authorization: Bearer <Buildkite Job OIDC token>
-Content-Type: application/json
-```
-
-```json
-{
-  "schema": "buildkite-gha/capability-request/v1",
-  "plan_digest": "sha256:<64 lowercase hex characters>",
-  "event_digest": "sha256:<64 lowercase hex characters>",
-  "requested_capabilities": []
-}
-```
-
-The request is size-bounded, rejects unknown fields and duplicate capability
-names, and requires a sorted capability list from the fixed plan vocabulary.
-It deliberately does not contain Buildkite IDs or provider identity claims as
-authoritative inputs. The service obtains Buildkite identity from verified
-OIDC and provider facts from its own event records or authenticated provider
-queries. Request fields only identify the inert plan and event snapshots to
-which the resulting decision must bind.
-
-The no-op proof requires `requested_capabilities` to be empty. Later revisions
-may request protected capabilities already declared by the exact plan, but
-cannot silently broaden this version's meaning.
-
-### Independent provider provenance
-
-For GitHub, the service joins the verified Buildkite build to an authenticated
-GitHub App webhook record or an equivalently authoritative provider record. At
-minimum, policy receives immutable installation, owner, repository, event or
-delivery, actor, ref, commit, and pull-request base/head/fork facts where they
-apply. Using this repository's versioned canonical event-snapshot contract, the
-service recomputes the digest from that authoritative record and requires it to
-match the inert request. The service treats `plan_digest` as an opaque binding;
-only the runtime has the plan bytes and verifies that binding against the
-decoded plan.
-
-Querying GitHub after the fact may supplement those records but cannot establish
-historical webhook facts that the API does not preserve. A provider event field
-copied from the plan, Buildkite environment, build message, or request body is
-never sufficient authorization evidence. If event-to-build correlation is
-absent or ambiguous, the service denies the request.
-
-Cursor Origin will implement the same provider contract with Origin-owned
-event and source identities. Its absence does not weaken or add fallbacks to
-the GitHub contract.
-
-### Policy decision
-
-The effective capability set is the intersection of:
-
-```text
-exact plan request
-∩ organization policy
-∩ authenticated provider-event policy
-∩ provider installation permissions
-∩ environment policy
-∩ Buildkite cluster and queue policy
-```
-
-The service records the policy version and a bounded decision reason. A no-op
-request still runs identity, provenance, and policy checks; an empty result is
-not permission to skip them. Unknown capabilities, an untrusted fork transition,
-a mismatched queue, an unattested event, or unavailable policy data is a denial.
-
-### Signed grant
-
-An allowed decision returns a standard three-part compact JWT signed with
-ES256. Its signature covers the exact transmitted protected-header and payload
-bytes; it has no detached payload and does not use the prototype's JCS reconstruction
-or canonical-byte equality rule. Unknown top-level claims are rejected by this
-bounded versioned contract.
-
-The protected header fields are exactly `alg`, `kid`, and `typ`. `alg` is
-`ES256`; `typ` is
-`buildkite-gha-capability-grant+jwt`; and `kid` selects one immutable
-control-plane verification key. The token must not carry or honor `jku`, `x5u`,
-an embedded JWK, algorithm negotiation, or unrecognized critical headers.
-
-The signed claims contain:
-
-- schema, issuer, fixed runtime audience, unique grant ID, `iat`, `nbf`, and
-  `exp` with a bounded short lifetime;
-- immutable Buildkite organization, pipeline, build, job, cluster, and queue
-  IDs, plus the exact queue key, step key, and runner environment;
-- versioned provider provenance, including immutable repository/event identity,
-  ref, commit, actor and fork facts relevant to the event;
-- exact plan and canonical event digests;
-- the sorted, unique granted capability set; and
-- the policy version that produced the decision.
-
-The initial successful grant contains an empty capability set. It contains no
-secret, checkout credential, provider token, cache token, environment value, or
-credential URL.
-
-The issuer publishes an operator-configured JWKS over HTTPS. The same
-installer-owned control-plane configuration binds the request origin, Job OIDC
-audience, grant issuer, fixed runtime audience, and JWKS location outside the
-plan. Rotation overlaps old and new public keys for the maximum grant lifetime;
-emergency revocation takes precedence over a still-published key. Private keys
-remain in the platform signing boundary.
-
-### Narrow job-bound provider credential exceptions
-
-Buildkite has two native, job-bound credential paths that support narrower
-integrations without waiting for the general grant protocol. Repository
-checkout uses the Agent's Git credential helper and delegates authorization for
-the concrete URL supplied by Git to Buildkite's repository-provider backend.
-Workflow `GITHUB_TOKEN` support uses the Agent API below to mint a GitHub
-installation token for the exact current job, exact pipeline repository, and
-caller-requested permission set. The server authenticates the request with the
-same job's Agent access token, independently requires the requested repository
-to equal the pipeline's configured GitHub repository, and validates permissions
-against its own allowlist:
-
-```http
-POST /v3/jobs/<current-job-id>/github_scoped_access_token
-Authorization: Token <current-job Agent access token>
-Content-Type: application/json
-```
-
-```json
-{
-  "repo_url": "https://github.com/<event owner>/<event repository>",
-  "permissions": {
-    "contents": "read"
-  }
-}
-```
-
-The compiler adds `provider-token-read` only after the resolved
-`actions/checkout` commit is in the audited native-adapter allowlist and its
-repository, ref, depth, path, submodule, and credential-persistence inputs pass
-validation. Fresh same-process compiler provenance permits that one capability
-through upload admission. Before resolving Git or repository credentials, the
-runtime revalidates every checkout lock in the plan and requires a root checkout
-selector to name the verified adapter. It invokes
-`buildkite-agent git-credentials-helper` only when the immutable plan has that
-capability and the server-provided job environment indicates
-repository-provider Git credentials are enabled. Otherwise it performs the same
-checkout anonymously.
-
-The superproject target remains the event repository at its exact SHA. When the
-admitted checkout requests submodules, native Git may additionally request the
-repositories selected by the checked-in `.gitmodules` graph. The credential
-helper is configured as a command-scoped, `github.com`-specific Git option only
-for the fetch or submodule update, uses HTTP-path matching, receives the current
-job's Agent API identity, and is not persisted. External HTTPS submodules do not
-receive this helper. The Buildkite backend independently authorizes every
-concrete GitHub repository URL received through Git's credential protocol. For
-managed GitHub code access, the requested owner must match the pipeline's GitHub
-account and the connected App installation must include the repository; the
-resulting token is restricted to that repository with `contents: read`. This is
-an intentional same-account sibling-repository authority, not a
-pipeline-repository-only allowlist.
-
-The runtime forwards proxy variables captured from the job process before
-workflow execution to a credentialed Git command but does not add the job
-credential to ordinary workflow subprocess environments. This is inheritance
-control, not OS-level isolation between hostile processes in the same job.
-Action pre-hooks and ordered workflow steps share that job trust boundary, so
-whole-job isolation remains mandatory. The job's Agent credential is not placed
-in plans; protecting it from concurrent same-UID processes would require a
-separate credential broker or checkout sandbox rather than additional manifest
-validation.
-
-A second bounded integration uses the scoped-token endpoint for a synthetic
-`secrets.GITHUB_TOKEN` or an action metadata input default that references
-`github.token`. An omitted permission mapping receives the product's narrow
-`contents: read` default; an explicit mapping must remain non-empty after `none`
-entries are removed. The workflow must either statically reference that exact
-secret or invoke an action whose effective default statically references the
-token. The compiler emits the API-normalized permission map into a v6 plan,
-adds `provider-token-write`, and records same-process `effective-permissions`
-provenance. Upload admission accepts
-only that exact compiler provenance. A serialized plan cannot self-authorize
-the capability.
-
-The runtime requests one token for the plan's exact event repository and exact
-permission map. It validates both independently, masks the returned token, and
-requires Agent redaction registration before making the synthetic secret
-available to expression evaluation. Job-level permissions replace workflow
-defaults; flattened local reusable workflows can only narrow caller authority.
-Permission aliases, empty grants, and `id-token` fail closed. `github.token` is
-exposed only while evaluating effective action
-metadata input defaults; workflow-authored references and automatic ambient
-`GITHUB_TOKEN` environment injection remain unsupported. As on GitHub Runner,
-an action that receives the token may explicitly propagate it to later steps
-through `GITHUB_ENV`; redaction remains registered for the job lifetime.
-
-These exceptions do not establish authenticated provider event, fork, or actor
-provenance. The server's independent pipeline-repository comparison,
-organization enablement, and permission allowlist are authoritative, but
-pipelines remain responsible for whether untrusted workflow changes may request
-an allowed write permission. The compiled permission map constrains the supported
-client path; it is not an independent authorization ceiling against same-job
-code that obtains the Agent access token and calls the endpoint directly.
-Private actions, arbitrary reusable-workflow source, selected non-provider
-secrets, environments, and OIDC still require the general control-plane decision
-in this ADR.
-
-### Runtime verification and capability use
-
-The runtime treats the response as inert bytes until all of these checks pass:
-
-1. Bound response size and structural depth.
-2. Validate the protected header and select a configured, non-revoked key.
-3. Verify the JWS signature before using any claim in routing or diagnostics.
-4. Validate schema, issuer, audience, ID, time window, and capability vocabulary.
-5. Match every Buildkite claim exposed through immutable current-job context,
-   including build/job identity, step key, and queue key. IDs that are present
-   only in verified Job OIDC are enforced by the control plane and retained in
-   the signed grant for audit and later platform-supported runtime comparison.
-6. Match the plan and event digests to the exact decoded plan.
-7. Require the granted set to be a subset of the plan request and current local
-   runtime policy.
-8. Resolve only the intersection of plan request, signed grant, and local
-   policy, at the point where a protected value is needed.
-
-For the no-op slice, the runtime verifies and discards the empty grant. It must
-not initialize a secret resolver, change queue admission, enable private action
-resolution, expose a token to child processes, or broaden the plan's capability
-ceiling. Public tokenless jobs do not contact the control plane unless running
-the explicit proof; service absence cannot regress their existing path.
-
-Every malformed, expired, mismatched, broadened, untrusted, unavailable, or
-ambiguous result fails before workflow execution obtains a protected value.
-There is no unsigned fallback and no fallback to plan-declared provenance.
-
-### Audit and observability
-
-The control plane writes one bounded audit record for every decision containing
-the authenticated Buildkite IDs, provider event ID, plan and event digests,
-requested and granted capability names, policy version, grant ID, outcome, and
-bounded reason code. It does not record bearer tokens or future returned
-credentials.
-
-The client emits bounded reason codes without response bodies or
-attacker-controlled identity strings. Hosted proof requires an independent
-read-only observation of both the generated job and its corresponding audit
-record; a successful job alone does not prove policy or audit behavior.
-
-## Initial implementation sequence
-
-1. Finalize the request/grant schemas and platform endpoint ownership.
-2. Implement the platform verifier for Buildkite OIDC and authoritative GitHub
-   event-to-build correlation.
-3. Implement empty-request policy, signed empty grants, JWKS publication, and
-   audit records without any credential backend.
-4. Add the `buildkite-gha` OIDC client and grant verifier behind explicit
-   control-plane configuration.
-5. Add positive and negative conformance fixtures for signature, audience,
-   expiry, build/job/step/queue, plan/event digest, provider event, policy,
-   capability broadening, key rotation, revocation, and service absence.
-6. Run one exact-commit hosted no-op proof and independently observe its audit
-   binding before considering any credential-returning slice.
-
-## Deferred decisions
-
-Apart from native repository-provider checkout and scoped token exceptions
-above, this ADR does not authorize or choose storage for private actions,
-reusable workflow source, selected non-provider secrets, general workflow
-access to `github.token`, environment grants, or compatibility OIDC claims. It
-does not choose a secret manager, broader cross-repository GitHub App authority,
-customer policy language, administrative UI, or production service hostname.
-Those decisions require separate reviewed slices after the no-op boundary is
-proven.
-
-The existing cache-v2 GHAC token exchange remains separate. Cache tokens are
-minted through the current Buildkite job, scoped by the cache service, and
-exposed only to the audited cache action lifecycle. A capability grant neither
-contains nor replaces them.
-
-The job-bound provider credential exchanges are likewise separate. Their
-server-side repository authorization and permission allowlists are the
-authoritative ceilings. A Git-selected checkout URL and the explicit workflow
-permission map carried by the supported client path are not substitutes for the
-event, policy, signing, and audit contract required by a general capability
-grant.
+Their server-side repository and permission checks are authoritative. They do
+not prove the full provider event or authorize ordinary workflow secrets,
+private actions, environments, or compatible OIDC claims.
 
 ## Consequences
 
-- Public checkout retains no new service dependency when repository-provider
-  credentials are not enabled for the job.
-- Private checkout uses Buildkite's existing repository-provider policy without
-  exposing a reusable workflow credential or requiring a separate user option.
-- The first protected-path milestone can prove the security boundary without
-  risking a real credential.
-- Provider provenance and policy must exist in a Buildkite-owned service before
-  private compatibility features can ship.
-- The CLI gains a small client and verifier, while signing keys, provider
-  records, and audit state remain outside workflow-controlled execution.
-- A full protected-capability implementation explicitly spans this repository and a
-  Buildkite platform service; repository-local code alone cannot satisfy it.
+- Repository-local code alone cannot add general protected capabilities.
+- Public tokenless jobs must not depend on the control plane.
+- Private actions, ordinary secrets, environments, and compatible OIDC stay
+  unsupported until the platform boundary exists.
+- Protocol, rollout, and credential-specific implementation work belongs in
+  tracked Linear issues rather than this ADR.
 
-## References checked
-
-- [Buildkite Agent OIDC](https://buildkite.com/docs/agent/cli/reference/oidc),
-  checked 2026-08-04
-- [Buildkite OIDC security guidance](https://buildkite.com/docs/pipelines/security/oidc),
-  checked 2026-08-04
-- [OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html)
-- [RFC 7515: JSON Web Signature](https://www.rfc-editor.org/rfc/rfc7515)
-- [RFC 7519: JSON Web Token](https://www.rfc-editor.org/rfc/rfc7519)
+See the [security model](../security.md) for the boundaries operators need to
+apply today.

--- a/docs/architecture/0003-protected-capability-control-plane.md
+++ b/docs/architecture/0003-protected-capability-control-plane.md
@@ -54,8 +54,9 @@ These job-bound integrations remain separate from a general grant protocol:
 - verified checkout may use Buildkite's Git credential helper;
 - supported `GITHUB_TOKEN` uses may request a repository-scoped token with a
   compiler-resolved permission set; and
-- the audited cache action may receive cache-service credentials for its own
-  lifecycle.
+- when caching is configured, every JavaScript or Docker action lifecycle
+  receives a fresh cache token. This includes compatible clients such as
+  `actions/setup-go`, not only `actions/cache`.
 
 Their server-side repository and permission checks are authoritative. They do
 not prove the full provider event or authorize ordinary workflow secrets,

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,122 +2,66 @@
 
 ## Set up the toolchain
 
-The repository pins Go and all lint and release tools with mise:
+The repository pins Go, Node, lint, and release tools with mise:
 
 ```sh
 mise trust mise.toml
 mise install
 ```
 
-`mise.lock` pins platform-specific download URLs and checksums so cold CI jobs
-do not need GitHub release API discovery. Buildkite sets `MISE_LOCKED=1`, making
-missing lock entries fail closed instead of falling back to provider APIs.
-Regenerate the lock with mise 2026.5.12, the oldest version supported by CI,
-and commit it whenever tool versions change:
+`mise.lock` lets locked CI jobs install tools without release API discovery.
+When tool versions change, regenerate it with mise 2026.5.12 or newer:
 
 ```sh
 mise lock --platform linux-x64,linux-x64-musl,linux-arm64,linux-arm64-musl,macos-x64,macos-arm64,windows-x64
 ```
 
-Run the complete repository check with:
+## Run local checks
+
+Run the same aggregate gate as CI:
 
 ```sh
 mise run check
 ```
 
-`check` verifies formatting, builds the commands, runs standard and
-race-enabled tests, runs `go vet`, golangci-lint, and shellcheck, checks
-deterministic smoke compilation, and validates the release configuration.
-`make check` is a convenience alias.
-The standard and race-enabled suites run serially because their live container
-tests inspect daemon-wide Docker resources. Local runs may skip those tests when
-Docker or managed Node is unavailable; the hosted repository check requires the
-live prerequisites and fails rather than silently losing container coverage.
+`make check` is an alias. The gate checks formatting, builds, standard and race
+tests, Go and shell linting, vet, deterministic smoke compilation, and release
+configuration. Container tests may skip locally when Docker or managed Node is
+unavailable; Buildkite requires those prerequisites.
 
-Focused tasks are also available:
+Useful focused tasks are:
 
 ```sh
-mise run format
 mise run build
 mise run test
 mise run test:race
 mise run lint:go
 mise run lint:shell
-mise run vet
-```
-
-## Understand the smoke lanes
-
-The smoke inventory deliberately separates three kinds of evidence.
-
-### Network-free compilation
-
-```sh
 mise run smoke:local
+mise run release:check
 ```
 
-This validates the manifest and workflow syntax, then compiles each supported
-fixture twice to check deterministic output. Expected-negative fixtures are
-also checked. A pass is compile-time evidence only; it does not prove that a
-workflow executes successfully.
+### Understand smoke results
 
-See [`testdata/smoke/README.md`](../testdata/smoke/README.md) for the inventory
-and the precise meaning of each expectation.
-
-### Production-policy preflight
+`mise run smoke:local` is network-free. It validates the smoke inventory and
+compiles each workflow twice. A pass proves deterministic compilation, not
+runtime behavior.
 
 ```sh
 mise run smoke:profile
 ```
 
-This opt-in networked lane anonymously resolves selected public actions and
-applies the same `hosted-tokenless` admission policy as production `upload`.
-It does not install Node or run action code. An `admitted` result is policy
-evidence, not runtime evidence.
+The profile task uses the network to resolve selected public actions and apply
+the production `hosted-tokenless` policy. Admission still does not execute
+action code. See [`testdata/smoke/README.md`](../testdata/smoke/README.md) for
+the inventory and result meanings.
 
-The exact audited `actions/upload-artifact` and exact-name
-`actions/download-artifact` commits pass admission through bounded native
-adapters. The exact audited `actions/cache` v6.1.0 commit also passes through
-its cache-v2 credential boundary. Other cache commits, artifact merge/broad
-download modes, and unsupported artifact commits still fail admission. Job and
-service container fixtures have separate hosted runtime evidence but remain
-outside production admission.
+## Verify runtime behavior
 
-### Exact-source plugin smoke
+Every normal Buildkite build runs repository checks and executes the basic
+example through a released plugin against the build's exact CLI source.
 
-Every Buildkite build runs `.github/workflows/example-basic.yml` through the
-released plugin with `buildkite-gha-source-ref` set to the build's exact commit.
-This proves a pull request's unreleased CLI source through the public plugin
-before a CLI release exists. The importer explicitly sets
-`BUILDKITE_GHA_TARGET_QUEUE=hosted`, so this repository's smoke continues to
-exercise its intended queue while default uploads omit agent targeting. The
-released-plugin demos remain separate because they verify release archives,
-checksums, and the normal default installation path rather than source
-execution.
-
-### Paired native UX runs
-
-After the example workflows exist on the default branch, launch the same
-workflow at the current branch's exact remote commit in both products:
-
-```sh
-scripts/compare-example basic
-scripts/compare-example artifacts
-scripts/compare-example advanced
-```
-
-This uses GitHub's native `workflow_dispatch` path and the dedicated
-`buildkite-gha-examples` pipeline. The Buildkite importer uses released plugin
-v0.4.4 to run the branch's exact unreleased CLI commit, so both providers
-exercise the same source. The script prints both URLs for a side-by-side review
-of the graph, logs, summaries, annotations, artifacts, retries, and cancellation
-experience. Use `--github-only` or `--buildkite-only` to exercise one native
-manual trigger at a time. These runs are qualitative UX comparisons; they do
-not replace the normalized smoke evidence below.
-
-### Hosted runtime proofs
-
-Run all implemented hosted proofs against one exact commit:
+Run the complete hosted smoke suite for a pushed commit with:
 
 ```sh
 commit=$(git rev-parse HEAD)
@@ -127,133 +71,47 @@ bk build create --pipeline buildkite/buildkite-gha \
   --env SMOKE_PROBE=hosted --env SMOKE_COMMIT="$commit" --yes
 ```
 
-The proof suite retains each behavior's importer and continuation topology. Use
-the proof selector only for targeted diagnosis. Importer steps that generate jobs
-set `BUILDKITE_GHA_TARGET_QUEUE=hosted`; this keeps these hosted-specific proofs
-explicit rather than relying on deployment defaults.
+This covers shell jobs, concurrent steps, public and Dockerfile actions,
+container runtime behavior, summaries, annotations, and artifact upload and
+roundtrip. Use `COMPATIBILITY_PROOF=<target>` with
+`COMPATIBILITY_PROOF_COMMIT=<commit>` only when diagnosing one target; the
+available target names live in [`.buildkite/pipeline.yml`](../.buildkite/pipeline.yml).
 
-| Coverage | Build environment |
-| --- | --- |
-| Sequential shell and upload | `COMPATIBILITY_PROOF=shell-upload`, `COMPATIBILITY_PROOF_COMMIT=<commit>` |
-| Concurrent step controls | `COMPATIBILITY_PROOF=concurrent-steps`, `COMPATIBILITY_PROOF_COMMIT=<commit>` |
-| Public JavaScript/composite actions | `COMPATIBILITY_PROOF=public-actions`, `COMPATIBILITY_PROOF_COMMIT=<commit>` |
-| Hosted Docker prerequisites | `COMPATIBILITY_PROOF=hosted-docker`, `COMPATIBILITY_PROOF_COMMIT=<commit>` |
-| Dockerfile action path | `COMPATIBILITY_PROOF=dockerfile-action`, `COMPATIBILITY_PROOF_COMMIT=<commit>` |
-| Complete container runtime | `COMPATIBILITY_PROOF=container-runtime`, `COMPATIBILITY_PROOF_COMMIT=<commit>` |
-| Job summary annotation | `COMPATIBILITY_PROOF=summary-annotation`, `COMPATIBILITY_PROOF_COMMIT=<commit>` |
-| Workflow warning/error annotations | `COMPATIBILITY_PROOF=workflow-annotations`, `COMPATIBILITY_PROOF_COMMIT=<commit>` |
-| Upload-artifact publication | `COMPATIBILITY_PROOF=upload-artifact`, `COMPATIBILITY_PROOF_COMMIT=<commit>` |
-| Artifact producer/consumer roundtrip | `COMPATIBILITY_PROOF=artifact-roundtrip`, `COMPATIBILITY_PROOF_COMMIT=<commit>` |
-
-Summary annotation publication is advisory, so the generated job's successful
-outcome does not by itself prove that Buildkite persisted the annotation. After
-the targeted proof build settles, use an authenticated `bk` CLI with
-`read_builds` access to verify the job-scoped annotation independently:
+Some Buildkite APIs are advisory, so a passing job is not enough evidence that
+the result was persisted. Check those results independently after the build:
 
 ```sh
 scripts/verify-summary-annotation <build-number> <commit>
-```
-
-The verifier reads only the generated job and its annotations. It requires
-the build to match the expected exact commit and exactly one `info` annotation
-with context `buildkite-gha-job-summary`, job scope, and both checked-in summary
-fragments.
-
-Workflow-command annotation publication is also advisory. Verify its distinct
-warning and error contexts independently after the annotations proof settles:
-
-```sh
 scripts/verify-workflow-annotations <build-number> <commit>
-```
-
-This verifier requires the generated job to pass even though it emitted an
-`::error` command, then checks exactly one job-scoped `warning` annotation and
-one job-scoped `error` annotation, their checked-in body fragments, and the
-absence of the registered masking canary.
-
-Artifact publication and consumption require independent native-storage
-observations after their targeted proof builds settle:
-
-```sh
 scripts/verify-upload-artifact <build-number> <commit>
 scripts/verify-artifact-roundtrip <build-number> <commit>
 ```
 
-The upload verifier binds the archive, terminal manifest, producer, digest,
-contents, and action outputs. The roundtrip verifier additionally requires the
-producer and both consumer matrix jobs to pass, checks all three terminal
-manifests, and confirms both consumers observed the exact payload and compatible
-absolute `download-path` output.
+## Test released and native entry points
 
-The initial CLI and companion plugin `v0.2.0` releases exercised the complete
-customer installation path at source commit
-`d5102df7e81c49f27a30fb2830d9608a56ee84de`. The service-free importer,
-generated jobs, native terminal, and repository checks passed in [Buildkite
-build 336](https://buildkite.com/buildkite/buildkite-gha/builds/336). The same
-checks plus the cache producer miss and post-save, direct-dependent primary-key
-hit and restore, and cache terminal passed in [Buildkite build
-337](https://buildkite.com/buildkite/buildkite-gha/builds/337). In both builds,
-the public plugin tag resolved to the tested commit
-`d009da173158270a3921b2997ae8fd3d68526d00` and installed the same verified CLI
-distribution without an explicit CLI version override. These are the
-authoritative initial published installation proofs.
-
-CLI `v0.2.1` was subsequently published at exact tag commit
-`a780787f049281290974292f00c29e92db717fb9` after [Buildkite release build
-351](https://buildkite.com/buildkite/buildkite-gha/builds/351) passed. Companion
-plugin `v0.2.1` resolves to exact commit
-`4910e56544e365bb545d3157c5aac058b6dabfaa` and defaults to that CLI release.
-At exact external repository commit
-[`8a74f88676a120e0bc6090b1aafc65edfd62ebbe`](https://github.com/mcncl/gotyper/commit/8a74f88676a120e0bc6090b1aafc65edfd62ebbe),
-[`mcncl/gotyper` build 11](https://buildkite.com/no-assembly/gotyper/builds/11)
-passed a two-job public workflow through the published plugin, including public
-checkout, setup-go, the audited cache v6 lifecycle, a direct dependency, race
-tests, static analysis, and a final binary build. This is the first external
-customer-shaped migration proof; several more migrations are still required by
-the public-beta gate.
-
-The generated example uploader and its `Run workflow` label landed on this
-repository's main branch after the CLI `v0.2.1` tag. They are current
-repository-demo UX rather than evidence about the released CLI runtime. Repeat
-the customer installation path with the current released-plugin demo:
+Run the examples through the released plugin and its normal release installer:
 
 ```sh
 commit=$(git rev-parse HEAD)
-test ${#commit} -eq 40
 bk build create --pipeline buildkite/buildkite-gha \
   --branch "$(git branch --show-current)" --commit "$commit" \
   --env DEMO_SUITE=plugin --env DEMO_COMMIT="$commit" --yes
 ```
 
-This service-free lane runs the basic, artifact, root-level JavaScript/composite
-action, and advanced workflows, then a native terminal step. Add the cache
-extension only for an organization with GHAC token minting enabled; the runtime
-uses the official Buildkite Results service by default:
+Add `--env DEMO_CACHE=1` to include the optional cache producer/consumer
+workflow. The plugin must download and checksum-verify its public CLI release;
+the demo must not fall back to a local binary.
+
+For a side-by-side GitHub Actions and Buildkite UX check, run:
 
 ```sh
-bk build create --pipeline buildkite/buildkite-gha \
-  --branch "$(git branch --show-current)" --commit "$commit" \
-  --env DEMO_SUITE=plugin --env DEMO_COMMIT="$commit" \
-  --env DEMO_CACHE=1 --yes
+scripts/compare-example basic
+scripts/compare-example artifacts
+scripts/compare-example advanced
 ```
 
-The first cache run for the release commit must show a producer miss,
-post-save, and direct-dependent exact hit. The plugin downloads and
-checksum-verifies the public release rather than falling back to a local
-binary.
-
-The smoke manifest and proof definitions under `.buildkite/` record current
-coverage. Git, pull requests, and Buildkite retain the historical evidence.
-
-## Architecture and security
-
-- The [security model](security.md) explains the operator-facing trust
-  boundaries.
-- [ADR 0001](architecture/0001-upstream-actions-reuse.md) explains why the
-  compiler uses actionlint while act and the official runner remain behavioral
-  references.
-- [ADR 0003](architecture/0003-protected-capability-control-plane.md) proposes
-  the control plane required for broader protected capabilities.
+The branch must be pushed, and its remote commit must match `HEAD`. Use
+`--github-only` or `--buildkite-only` to launch one side.
 
 ## Publish a release
 
@@ -263,30 +121,19 @@ From a clean, up-to-date `main`, run:
 mise run release
 ```
 
-The script runs `check`, chooses the next conventional-commit-derived v0 tag,
-and pushes it. The tag webhook build reruns repository checks, creates the
-GitHub release, and uploads the Linux x86-64 archive and checksum. Publication
-can be retried from the same tag build; existing draft assets are replaced.
+The task runs `check`, chooses the next conventional-commit-derived v0 tag, and
+pushes it. The tag build reruns checks and publishes the GitHub release, archive,
+and checksum. Publication can be retried from the same tag build.
 
-The source repository must be public before the first tag is pushed because the
-companion plugin intentionally downloads release assets without a GitHub token.
+`GHA_GITHUB_RELEASE_TOKEN` must be a fine-grained, repository-scoped token with
+Contents read/write access. Store it as a Buildkite Secret restricted to this
+release pipeline, webhook-created `v*` tag builds, and no ordinary branch or
+pull request builds. The publisher verifies the remote tag, checkout, and
+Buildkite commit before requesting the secret.
 
-### Release credential policy
+## Related documents
 
-The pipeline tag condition prevents accidental publication, but it is not a
-secret boundary: pull request code can upload arbitrary Buildkite steps. Store
-a fine-grained GitHub token with repository-scoped Contents read/write access as
-the `GHA_GITHUB_RELEASE_TOKEN` Buildkite Secret, restricted to webhook-created
-`v*` tag builds in the release pipeline:
-
-```yaml
-- pipeline_id: "019f8835-5873-4a64-850e-ba117a339d87"
-  build_source: "webhook"
-  build_branch: "v*"
-```
-
-Buildkite records a tag webhook's tag name as the build branch, so these claims
-exclude ordinary branch and pull request webhook builds. The publisher also
-verifies that the upstream tag, checked-out commit, and Buildkite commit agree
-before retrieving the token. Never expose this token through a shared agent
-environment hook.
+- [Compatibility reference](compatibility.md)
+- [Security model](security.md)
+- [Parser and runner dependency decision](architecture/0001-upstream-actions-reuse.md)
+- [Protected-capability boundary](architecture/0003-protected-capability-control-plane.md)

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,90 +1,78 @@
 # Security model
 
 `buildkite-gha` runs workflow steps and third-party actions as native Buildkite
-jobs. Treat that code like any other repository script: it is not made safe by
-using Actions syntax.
+jobs. Actions syntax does not make that code trusted.
 
-The [compatibility reference](compatibility.md) is the source of truth for
-supported features. This page explains the trust boundaries around them.
+The [compatibility reference](compatibility.md) lists supported features. This
+page explains the boundaries operators must provide around them.
 
 ## Isolate the whole job
 
-The runtime does not isolate steps from each other. They share a workspace,
-environment changes, processes, and action lifecycle. A shell step can affect a
-later action, and an action can affect a later shell step.
+Steps share a workspace, environment changes, processes, action state, and the
+job's Buildkite identity. A shell step can affect a later action, and an action
+can affect a later shell step.
 
-Dockerfile actions add packaging, not a security boundary. When a queue uses a
-disposable job VM, that VM—not the action container—is the boundary around the
-Docker daemon and workflow code.
+Dockerfile actions add packaging, not a security boundary. Use a queue with:
 
-Run imported jobs on a queue that provides:
-
-- whole-job isolation;
+- a disposable machine or equivalent whole-job isolation;
 - no ambient protected credentials; and
-- a clean machine for each untrusted job.
+- a clean environment for every untrusted job.
 
-On a persistent self-hosted agent, workflow code can use whatever host resources
-the agent process exposes. Files or processes it leaves behind may affect later
-jobs.
+On a persistent self-hosted agent, workflow code can access exposed host
+resources and leave state that affects later jobs.
 
-## Inputs do not grant authority
+## Repository data is not authority
 
-Workflow files, action metadata, event snapshots, and webhook payloads are
-untrusted inputs. They can request work, queues, and permissions, but are not
-sufficient authority for them. Buildkite configuration and server-side policy
-decide what is allowed.
+Workflow files, action metadata, event snapshots, and job plans are untrusted
+inputs. They may describe work and request permissions. Buildkite configuration
+and server-side policy choose the queue and decide what authority is available.
 
-Content digests and immutable action locks detect changed code. A digest alone
-does not make that code trusted or grant it authority.
+Digests and immutable action locks detect changed code. They do not make code
+trusted or grant credentials.
 
 ## Credential boundaries
 
-| Credential | Supported boundary |
+| Credential | Current boundary |
 | --- | --- |
-| Repository checkout | The verified adapter checks the plan's event repository and exact commit. Buildkite authorizes private repository access. Credentials are not persisted. |
-| `GITHUB_TOKEN` | One short-lived token is requested for the plan's event repository and compiler-resolved permissions. Buildkite independently requires the pipeline repository to match and may deny the request. The token is not initially ambient. |
-| Cache token | Fresh job-bound credentials are minted for each JavaScript or Docker action lifecycle when the cache service is configured. Ordinary shell steps do not receive them. |
+| Repository checkout | The verified adapter checks the event repository and exact commit. Buildkite authorizes managed private access; credentials are command-scoped and not persisted. |
+| `GITHUB_TOKEN` | Supported static uses receive one short-lived token for the event repository and compiler-resolved permissions. Buildkite verifies the repository and may deny the request. The token is not ambient. |
+| Cache token | A fresh job-bound token is exposed only to the audited cache action lifecycle when the cache service is configured. |
 | Ordinary workflow secrets | Rejected by production admission. |
 | GitHub-compatible OIDC | Unsupported. |
 
+An action that receives a credential can use or exfiltrate it. It can also
+export `GITHUB_TOKEN` to later steps through `GITHUB_ENV`. Log masking reduces
+accidental disclosure; it is not access control and does not catch transformed
+values.
+
+If untrusted code can edit a workflow that requests write permissions, it can
+use a token that Buildkite allows. Restrict write permissions with organization
+and pipeline policy.
+
 ### Checkout and submodules
 
-Checked-in `.gitmodules` files may select repositories covered by the job's
-Buildkite managed code access. For GitHub, that can include another repository
-in the same account when the connected GitHub App installation includes it.
-Buildkite authorizes each repository and returns a repository-specific,
-read-only token. The helper is offered only to `github.com`, is scoped by HTTP
-path, and is not persisted. External HTTPS submodules are fetched anonymously;
-SSH and non-HTTPS transports are disabled.
+Buildkite authorizes every managed GitHub repository requested through Git's
+credential protocol. Checked-in `.gitmodules` may select another repository in
+the same GitHub account when the connected App installation includes it. Those
+tokens are repository-specific and read-only. External HTTPS submodules are
+anonymous; SSH and non-HTTPS transports are disabled.
 
-The installed Git executable owns submodule manifest parsing, paths, relative
-URLs, and recursion. Use a current, vendor-supported Git distribution,
-preferably pinned in an immutable job image.
+The credential helper is offered only to `github.com`, uses HTTP-path matching,
+and is not persisted. The installed Git executable owns submodule parsing and
+recursion, so keep it current and preferably pin it in the job image.
 
-Job binding does not prove that a branch, actor, or fork is trusted. If an
-untrusted change can edit a workflow that requests write permissions, that code
-can use the resulting token. Restrict write permissions with Buildkite
-organization and pipeline policy.
-
-An action that receives a credential has the same ability to use or exfiltrate
-it as a shell command in that job. It can also export `GITHUB_TOKEN` to later
-steps through `GITHUB_ENV`. Log masking hides registered literal values; it is
-not access control and cannot detect every encoded or transformed value.
-
-Checkout's command-scoped environment and Git configuration reduce accidental
-credential spread; they do not isolate the helper or Agent identity from a
-hostile concurrent process under the same job identity. Protecting checkout
-credentials from hostile same-job code would require a separate UID, sandbox,
-or pre-job credential broker rather than more `.gitmodules` parsing.
+Command scoping limits accidental spread. It does not stop a hostile concurrent
+process under the same job identity from reaching the Agent or helper. That
+requires a separate UID, sandbox, or pre-job credential broker.
 
 ## Operator checklist
 
 1. Pin a released plugin version.
-2. Use an isolated queue with no ambient credentials.
-3. Treat public actions as third-party code; prefer immutable commit pins.
-4. Restrict repository credentials and write tokens with Buildkite policy.
-5. Keep the queue's Git distribution current and patched.
-6. Validate the production profile before upload:
+2. Run imported jobs on an isolated queue with no ambient credentials.
+3. Treat public actions as third-party code and prefer immutable commit pins.
+4. Restrict managed repository access and write tokens with Buildkite policy.
+5. Keep Git and the job image patched.
+6. Validate before upload:
 
    ```sh
    buildkite-gha validate \
@@ -96,5 +84,6 @@ or pre-job credential broker rather than more `.gitmodules` parsing.
 7. Keep unsupported secrets, private actions, OIDC, and protected queues out of
    imported workflows.
 
-For implementation detail, see the proposed
-[protected-capability control-plane ADR](architecture/0003-protected-capability-control-plane.md).
+Broader protected capabilities require the Buildkite-owned policy boundary in
+[ADR 0003](architecture/0003-protected-capability-control-plane.md); repository
+configuration alone cannot authorize them.

--- a/docs/security.md
+++ b/docs/security.md
@@ -36,7 +36,7 @@ trusted or grant credentials.
 | --- | --- |
 | Repository checkout | The verified adapter checks the event repository and exact commit. Buildkite authorizes managed private access; credentials are command-scoped and not persisted. |
 | `GITHUB_TOKEN` | Supported static uses receive one short-lived token for the event repository and compiler-resolved permissions. Buildkite verifies the repository and may deny the request. The token is not ambient. |
-| Cache token | A fresh job-bound token is exposed only to the audited cache action lifecycle when the cache service is configured. |
+| Cache token | When caching is configured, every JavaScript or Docker action lifecycle receives a fresh job-bound token. This includes compatible clients such as `actions/setup-go`, not only `actions/cache`. Shell steps do not receive it. |
 | Ordinary workflow secrets | Rejected by production admission. |
 | GitHub-compatible OIDC | Unsupported. |
 


### PR DESCRIPTION
Depends on #121. Review this PR after the compatibility experiment cleanup.

## Why

The README and supporting docs had grown into research notes and implementation plans. That made current behavior, useful commands, and durable decisions hard to find.

## What

- Rework the README around how the compatibility layer works, who it suits, a quick start, validation, and safe operation.
- Reduce ADRs to durable decisions; keep future implementation work in Linear.
- Rewrite the development guide around current checks, hosted smoke, plugin validation, and releases.
- Tighten the security guide around whole-job isolation and the exact checkout, GitHub token, and cache credential boundaries.