### PR TITLE
Add a stable launcher for plugin-selected CLI releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,6 +13,18 @@ builds:
       - -trimpath
     ldflags:
       - -s -w -X main.version={{.Version}}
+  - id: buildkite-gha-launcher-linux
+    main: ./cmd/buildkite-gha-launcher
+    binary: buildkite-gha-launcher
+    env:
+      - CGO_ENABLED=0
+    goos: [linux]
+    goarch: [amd64]
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
 
 archives:
   - id: buildkite-gha
@@ -30,6 +42,10 @@ archives:
           mode: 0644
           owner: root
           group: root
+  - id: buildkite-gha-launcher
+    ids: [buildkite-gha-launcher-linux]
+    formats: [binary]
+    name_template: buildkite-gha-launcher_Linux_x86_64
 
 checksum:
   name_template: checksums.txt

--- a/cmd/buildkite-gha-launcher/main.go
+++ b/cmd/buildkite-gha-launcher/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"os"
+
+	"github.com/buildkite/buildkite-gha/internal/launcher"
+)
+
+func main() { os.Exit(launcher.Run(os.Args[1:])) }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -6,6 +6,11 @@ The [GitHub Actions Buildkite plugin](https://github.com/buildkite-plugins/githu
 
 Download `buildkite-gha_Linux_x86_64.tar.gz` and `checksums.txt` from the matching GitHub [release](https://github.com/buildkite/buildkite-gha/releases). Verify the checksum, then extract `buildkite-gha` to a stable path.
 
+Releases also include the raw Linux amd64 `buildkite-gha-launcher_Linux_x86_64`
+artifact for plugin hooks to pin. The launcher reads
+`BUILDKITE_PLUGIN_GITHUB_ACTIONS_VERSION`, defaulting to `latest`, or accepts an
+exact stable version from `0.8.0` onward.
+
 Jobs with JavaScript actions require `mise` 2026.5.12 or newer. `run-job` checks `BUILDKITE_GHA_MISE`, then `PATH`, and then downloads a verified managed copy. Shell-only, native-adapter, and Docker-only jobs do not require `mise`.
 
 Managed Node binaries require glibc 2.28 or newer. The Go CLI has no glibc requirement.

--- a/docs/development.md
+++ b/docs/development.md
@@ -37,6 +37,11 @@ mise run smoke:local
 mise run release:check
 ```
 
+GoReleaser publishes the raw Linux amd64
+`buildkite-gha-launcher_Linux_x86_64` asset in `checksums.txt` while preserving
+the existing `buildkite-gha_Linux_x86_64.tar.gz` contents (`LICENSE` and
+`buildkite-gha`).
+
 ### Understand smoke results
 
 `mise run smoke:local` is network-free. It validates the smoke inventory and compiles each workflow twice. A pass proves deterministic compilation, not runtime behavior.

--- a/internal/launcher/cache.go
+++ b/internal/launcher/cache.go
@@ -1,0 +1,259 @@
+package launcher
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+func (c config) cacheRoot() (string, bool) {
+	if root := c.getenv("BUILDKITE_GITHUB_ACTIONS_PLUGIN_CACHE_ROOT"); root != "" {
+		return root, true
+	}
+	if c.getenv("BUILDKITE_COMPUTE_TYPE") == "hosted" {
+		base := c.getenv("MISE_HOSTED_CACHE_VOLUME_ROOT")
+		if base == "" {
+			base = "/cache/bkcache"
+		}
+		if st, err := os.Stat(base); err == nil && st.IsDir() {
+			return filepath.Join(base, "github-actions-buildkite-plugin"), true
+		}
+	}
+	if v := c.getenv("BUILDKITE_AGENT_DATA_PATH"); v != "" {
+		return filepath.Join(v, "cache/github-actions-buildkite-plugin"), true
+	}
+	if v := c.getenv("XDG_CACHE_HOME"); v != "" {
+		return filepath.Join(v, "buildkite/github-actions-buildkite-plugin"), true
+	}
+	if v := c.getenv("HOME"); v != "" {
+		return filepath.Join(v, ".cache/buildkite/github-actions-buildkite-plugin"), true
+	}
+	return "", false
+}
+
+func openCacheRoot(root string) (*os.Root, error) {
+	for p := root; ; p = filepath.Dir(p) {
+		st, err := os.Lstat(p)
+		if err == nil && st.Mode()&os.ModeSymlink != 0 {
+			return nil, fmt.Errorf("cache path contains symlink %s", p)
+		}
+		if err != nil && !os.IsNotExist(err) {
+			return nil, err
+		}
+		if filepath.Dir(p) == p {
+			break
+		}
+	}
+	if err := os.MkdirAll(root, 0700); err != nil {
+		return nil, err
+	}
+	before, err := os.Stat(root)
+	if err != nil {
+		return nil, err
+	}
+	cache, err := os.OpenRoot(root)
+	if err != nil {
+		return nil, err
+	}
+	after, err := cache.Stat(".")
+	if err != nil || !os.SameFile(before, after) {
+		_ = cache.Close()
+		return nil, fmt.Errorf("cache root changed while opening")
+	}
+	probeName, err := randomCacheName(".write-")
+	if err != nil {
+		_ = cache.Close()
+		return nil, err
+	}
+	probe, err := cache.OpenFile(probeName, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+	if err != nil {
+		_ = cache.Close()
+		return nil, err
+	}
+	closeErr := probe.Close()
+	removeErr := cache.Remove(probeName)
+	if closeErr != nil || removeErr != nil {
+		_ = cache.Close()
+		return nil, fmt.Errorf("verify cache writes: %v", errors.Join(closeErr, removeErr))
+	}
+	return cache, nil
+}
+
+func (c config) privateArchive(cache *os.Root, tag, want, entry string) (string, bool, error) {
+	private, err := os.CreateTemp(c.tempDir, "buildkite-gha-archive-")
+	if err != nil {
+		return "", false, err
+	}
+	name := private.Name()
+	defer func() {
+		if private != nil {
+			_ = private.Close()
+		}
+	}()
+	cacheHit := false
+	if src, openErr := cache.OpenFile(entry, os.O_RDONLY|syscall.O_NONBLOCK|syscall.O_NOFOLLOW, 0); openErr == nil {
+		info, statErr := src.Stat()
+		if statErr == nil && info.Mode().IsRegular() {
+			err = copyAndVerify(private, src, want)
+			cacheHit = err == nil
+		}
+		_ = src.Close()
+	}
+	if cacheHit {
+		if closeErr := private.Close(); closeErr != nil {
+			_ = os.Remove(name)
+			return "", false, closeErr
+		}
+		private = nil
+		_ = os.Chmod(name, 0600)
+		return name, false, nil
+	}
+	if err := private.Truncate(0); err != nil {
+		_ = os.Remove(name)
+		return "", false, err
+	}
+	if _, err := private.Seek(0, 0); err != nil {
+		_ = os.Remove(name)
+		return "", false, err
+	}
+	b, fetchErr := c.fetch(tag, archiveName, maxArchive)
+	if fetchErr != nil {
+		_ = os.Remove(name)
+		return "", false, fmt.Errorf("download archive: %w", fetchErr)
+	}
+	if _, err = private.Write(b); err != nil {
+		_ = os.Remove(name)
+		return "", false, err
+	}
+	if fmt.Sprintf("%x", sha256.Sum256(b)) != want {
+		_ = os.Remove(name)
+		return "", false, fmt.Errorf("archive checksum mismatch")
+	}
+	if err := private.Close(); err != nil {
+		_ = os.Remove(name)
+		return "", false, err
+	}
+	private = nil
+	_ = os.Chmod(name, 0600)
+	return name, true, nil
+}
+
+func copyAndVerify(destination *os.File, source io.Reader, want string) error {
+	hash := sha256.New()
+	written, err := io.Copy(io.MultiWriter(destination, hash), io.LimitReader(source, maxArchive+1))
+	if err != nil {
+		return err
+	}
+	if written > maxArchive || hex.EncodeToString(hash.Sum(nil)) != want {
+		return fmt.Errorf("cache checksum verification failed")
+	}
+	return nil
+}
+
+func publish(cache *os.Root, source, entry string) error {
+	if err := cache.MkdirAll(filepath.ToSlash(filepath.Dir(entry)), 0700); err != nil {
+		return err
+	}
+	stageName, err := randomCacheName(".stage-")
+	if err != nil {
+		return err
+	}
+	stage, err := cache.OpenFile(stageName, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = cache.Remove(stageName) }()
+	src, err := os.Open(source)
+	if err != nil {
+		_ = stage.Close()
+		return err
+	}
+	_, copyErr := io.Copy(stage, io.LimitReader(src, maxArchive+1))
+	_ = src.Close()
+	closeErr := stage.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	return cache.Rename(stageName, entry)
+}
+
+func randomCacheName(prefix string) (string, error) {
+	random := make([]byte, 16)
+	if _, err := rand.Read(random); err != nil {
+		return "", err
+	}
+	return prefix + hex.EncodeToString(random), nil
+}
+
+func extract(archive, dir string) error {
+	f, err := os.Open(archive)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = gz.Close() }()
+	limited := &io.LimitedReader{R: gz, N: maxArchive + 1}
+	tr := tar.NewReader(limited)
+	seen := map[string]bool{}
+	for {
+		h, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if h.Name != "LICENSE" && h.Name != "buildkite-gha" {
+			return fmt.Errorf("unexpected archive entry %q", h.Name)
+		}
+		if seen[h.Name] || h.Typeflag != tar.TypeReg || h.Size < 0 || h.Size > maxArchive {
+			return fmt.Errorf("invalid archive entry %q", h.Name)
+		}
+		seen[h.Name] = true
+		mode := os.FileMode(0644)
+		if h.Name == "buildkite-gha" {
+			mode = 0700
+		}
+		out, err := os.OpenFile(filepath.Join(dir, h.Name), os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode)
+		if err != nil {
+			return err
+		}
+		_, copyErr := io.CopyN(out, tr, h.Size)
+		closeErr := out.Close()
+		if copyErr != nil {
+			return copyErr
+		}
+		if closeErr != nil {
+			return closeErr
+		}
+		if err := os.Chmod(filepath.Join(dir, h.Name), mode); err != nil {
+			return err
+		}
+	}
+	if !seen["LICENSE"] || !seen["buildkite-gha"] {
+		return fmt.Errorf("archive must contain LICENSE and buildkite-gha exactly once")
+	}
+	trailing, err := io.Copy(io.Discard, limited)
+	if err != nil {
+		return fmt.Errorf("finish archive decompression: %w", err)
+	}
+	if trailing != 0 || limited.N == 0 {
+		return fmt.Errorf("archive contains trailing data or exceeds extraction limit")
+	}
+	return nil
+}

--- a/internal/launcher/integration_test.go
+++ b/internal/launcher/integration_test.go
@@ -1,0 +1,390 @@
+package launcher
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"testing"
+)
+
+const testTarget = `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  printf 'buildkite-gha %s\n' "${TEST_TARGET_VERSION:-0.8.0}"
+  exit 0
+fi
+printf 'argv=%s argc=%s\n' "$*" "$#"
+printf 'executable=%s\n' "$0"
+printf 'env=%s\n' "$TEST_INHERITED"
+printf 'cwd=%s\n' "$PWD"
+IFS= read -r input || true
+printf 'stdin=%s\n' "$input"
+printf 'target-stderr\n' >&2
+exit "${TEST_EXIT:-0}"
+`
+
+type releaseFixture struct {
+	archive          []byte
+	checksum         string
+	latestLocation   string
+	latestRequests   atomic.Int32
+	checksumRequests atomic.Int32
+	archiveRequests  atomic.Int32
+	server           *httptest.Server
+}
+
+func newReleaseFixture(t *testing.T, archive []byte) *releaseFixture {
+	t.Helper()
+	digest := sha256.Sum256(archive)
+	f := &releaseFixture{archive: archive, checksum: fmt.Sprintf("%x", digest)}
+	f.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/releases/latest":
+			f.latestRequests.Add(1)
+			location := f.latestLocation
+			if location == "" {
+				location = f.server.URL + "/releases/tag/v0.8.0"
+			}
+			http.Redirect(w, r, location, http.StatusFound)
+		case "/releases/tag/v0.8.0":
+			_, _ = io.WriteString(w, "release")
+		case "/releases/download/v0.8.0/checksums.txt":
+			f.checksumRequests.Add(1)
+			_, _ = fmt.Fprintf(w, "%s  %s\n", f.checksum, archiveName)
+		case "/releases/download/v0.8.0/" + archiveName:
+			f.archiveRequests.Add(1)
+			_, _ = w.Write(f.archive)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(f.server.Close)
+	return f
+}
+
+func targetArchive(t *testing.T, target string, extra ...tar.Header) []byte {
+	t.Helper()
+	var compressed bytes.Buffer
+	gz := gzip.NewWriter(&compressed)
+	tw := tar.NewWriter(gz)
+	writeTarEntry(t, tw, tar.Header{Name: "LICENSE", Mode: 0644, Size: 7, Typeflag: tar.TypeReg}, []byte("license"))
+	writeTarEntry(t, tw, tar.Header{Name: "buildkite-gha", Mode: 0755, Size: int64(len(target)), Typeflag: tar.TypeReg}, []byte(target))
+	for _, header := range extra {
+		writeTarEntry(t, tw, header, bytes.Repeat([]byte("x"), int(header.Size)))
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return compressed.Bytes()
+}
+
+func archiveWithEntries(t *testing.T, entries ...tar.Header) []byte {
+	t.Helper()
+	var compressed bytes.Buffer
+	gz := gzip.NewWriter(&compressed)
+	tw := tar.NewWriter(gz)
+	for _, header := range entries {
+		writeTarEntry(t, tw, header, bytes.Repeat([]byte("x"), int(header.Size)))
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return compressed.Bytes()
+}
+
+func writeTarEntry(t *testing.T, tw *tar.Writer, header tar.Header, contents []byte) {
+	t.Helper()
+	if err := tw.WriteHeader(&header); err != nil {
+		t.Fatal(err)
+	}
+	if len(contents) > 0 {
+		if _, err := tw.Write(contents); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func testConfig(t *testing.T, fixture *releaseFixture, selector string) (config, *bytes.Buffer, *bytes.Buffer, string) {
+	t.Helper()
+	cache := filepath.Join(t.TempDir(), "cache")
+	values := map[string]string{
+		"BUILDKITE_PLUGIN_GITHUB_ACTIONS_VERSION":    selector,
+		"BUILDKITE_GITHUB_ACTIONS_PLUGIN_CACHE_ROOT": cache,
+	}
+	stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
+	c := config{
+		env:           []string{"PATH=" + os.Getenv("PATH"), "TEST_INHERITED=kept"},
+		getenv:        func(name string) string { return values[name] },
+		stdout:        stdout,
+		stderr:        stderr,
+		stdin:         strings.NewReader("input-data\n"),
+		client:        fixture.server.Client(),
+		repositoryURL: fixture.server.URL,
+		goos:          "linux",
+		goarch:        "amd64",
+		tempDir:       t.TempDir(),
+	}
+	return c, stdout, stderr, cache
+}
+
+func TestLauncherExactExecutionContract(t *testing.T) {
+	fixture := newReleaseFixture(t, targetArchive(t, testTarget))
+	c, stdout, stderr, _ := testConfig(t, fixture, "v0.8.0")
+	working := t.TempDir()
+	t.Chdir(working)
+	c.env = append(c.env, "TEST_EXIT=37")
+	err := c.run()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 37 {
+		t.Fatalf("run error = %v, want exit 37", err)
+	}
+	for _, want := range []string{"~~~ :github: Prepare workflow", "argv=plugin argc=1", "env=kept", "cwd=" + working, "stdin=input-data"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Errorf("stdout %q does not contain %q", stdout.String(), want)
+		}
+	}
+	if !strings.Contains(stdout.String(), "executable="+c.tempDir+"/buildkite-gha-run-") {
+		t.Errorf("target did not execute from a private run directory: %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "target-stderr") {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+	if fixture.latestRequests.Load() != 0 || fixture.checksumRequests.Load() != 1 || fixture.archiveRequests.Load() != 1 {
+		t.Fatalf("requests latest/checksum/archive = %d/%d/%d", fixture.latestRequests.Load(), fixture.checksumRequests.Load(), fixture.archiveRequests.Load())
+	}
+}
+
+func TestLauncherLatestResolvesOnceAndIgnoresLegacySelector(t *testing.T) {
+	fixture := newReleaseFixture(t, targetArchive(t, testTarget))
+	c, _, stderr, _ := testConfig(t, fixture, "")
+	original := c.getenv
+	c.getenv = func(name string) string {
+		if name == "BUILDKITE_PLUGIN__VERSION" {
+			return "0.7.0"
+		}
+		return original(name)
+	}
+	if err := c.run(); err != nil {
+		t.Fatal(err)
+	}
+	if fixture.latestRequests.Load() != 1 || !strings.Contains(stderr.String(), "resolved latest to v0.8.0") {
+		t.Fatalf("latest requests = %d, stderr = %q", fixture.latestRequests.Load(), stderr.String())
+	}
+}
+
+func TestLauncherRejectsUncanonicalLatestRedirect(t *testing.T) {
+	fixture := newReleaseFixture(t, targetArchive(t, testTarget))
+	fixture.latestLocation = fixture.server.URL + "/releases/download/v0.8.0/checksums.txt"
+	c, _, _, _ := testConfig(t, fixture, "latest")
+	if err := c.run(); err == nil || !strings.Contains(err.Error(), "outside canonical release tags") {
+		t.Fatalf("run error = %v", err)
+	}
+	if fixture.archiveRequests.Load() != 0 {
+		t.Fatal("downloaded archive after invalid latest redirect")
+	}
+
+	fixture.latestLocation = "https://example.com/buildkite/buildkite-gha/releases/tag/v0.8.0"
+	if err := c.run(); err == nil || !strings.Contains(err.Error(), "untrusted URL") {
+		t.Fatalf("cross-host redirect error = %v", err)
+	}
+}
+
+func TestLauncherCacheHitAndTamperRepair(t *testing.T) {
+	fixture := newReleaseFixture(t, targetArchive(t, testTarget))
+	c, _, _, cache := testConfig(t, fixture, "0.8.0")
+	if err := c.run(); err != nil {
+		t.Fatal(err)
+	}
+	c.stdout, c.stderr, c.stdin = io.Discard, io.Discard, strings.NewReader("")
+	if err := c.run(); err != nil {
+		t.Fatal(err)
+	}
+	if fixture.archiveRequests.Load() != 1 || fixture.checksumRequests.Load() != 2 {
+		t.Fatalf("cache-hit requests archive/checksum = %d/%d", fixture.archiveRequests.Load(), fixture.checksumRequests.Load())
+	}
+	entry := filepath.Join(cache, "v0.8.0", "Linux_x86_64", fixture.checksum, archiveName)
+	if err := os.WriteFile(entry, []byte("tampered"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.run(); err != nil {
+		t.Fatal(err)
+	}
+	if fixture.archiveRequests.Load() != 2 || !fileDigestMatches(t, entry, fixture.checksum) {
+		t.Fatalf("tampered cache was not repaired; downloads = %d", fixture.archiveRequests.Load())
+	}
+}
+
+func TestLauncherUnusableSelectedCacheFallsBackToTemporary(t *testing.T) {
+	fixture := newReleaseFixture(t, targetArchive(t, testTarget))
+	c, _, stderr, cache := testConfig(t, fixture, "0.8.0")
+	if err := os.WriteFile(cache, []byte("not a directory"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.run(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stderr.String(), "using temporary cache") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+	if info, err := os.Stat(cache); err != nil || !info.Mode().IsRegular() {
+		t.Fatalf("selected cache was replaced instead of bypassed: %v, %v", info, err)
+	}
+}
+
+func TestLauncherTreatsCachedFIFOAsMiss(t *testing.T) {
+	fixture := newReleaseFixture(t, targetArchive(t, testTarget))
+	c, _, _, cache := testConfig(t, fixture, "0.8.0")
+	entry := filepath.Join(cache, "v0.8.0", "Linux_x86_64", fixture.checksum, archiveName)
+	if err := os.MkdirAll(filepath.Dir(entry), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Mkfifo(entry, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.run(); err != nil {
+		t.Fatal(err)
+	}
+	if fixture.archiveRequests.Load() != 1 || !fileDigestMatches(t, entry, fixture.checksum) {
+		t.Fatalf("cached FIFO did not become a verified archive; downloads = %d", fixture.archiveRequests.Load())
+	}
+}
+
+func TestLauncherConcurrentCacheConvergence(t *testing.T) {
+	fixture := newReleaseFixture(t, targetArchive(t, testTarget))
+	base, _, _, cache := testConfig(t, fixture, "0.8.0")
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c := base
+			c.stdout, c.stderr, c.stdin = io.Discard, io.Discard, strings.NewReader("")
+			errs <- c.run()
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	entry := filepath.Join(cache, "v0.8.0", "Linux_x86_64", fixture.checksum, archiveName)
+	if !fileDigestMatches(t, entry, fixture.checksum) {
+		t.Fatal("concurrent cache did not converge on verified archive")
+	}
+}
+
+func TestLauncherFailuresDoNotPublishOrExecute(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*releaseFixture)
+		archive []byte
+		want    string
+	}{
+		{name: "checksum mismatch", archive: targetArchive(t, testTarget), mutate: func(f *releaseFixture) { f.checksum = strings.Repeat("0", 64) }, want: "checksum mismatch"},
+		{name: "hostile archive", archive: archiveWithEntries(t, tar.Header{Name: "../buildkite-gha", Size: 1, Typeflag: tar.TypeReg}), want: "unexpected archive entry"},
+		{name: "version mismatch", archive: targetArchive(t, strings.Replace(testTarget, "0.8.0", "0.9.0", 1)), want: "version verification"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newReleaseFixture(t, test.archive)
+			if test.mutate != nil {
+				test.mutate(fixture)
+			}
+			c, stdout, _, cache := testConfig(t, fixture, "0.8.0")
+			if err := c.run(); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("run error = %v, want %q", err, test.want)
+			}
+			if strings.Contains(stdout.String(), "Prepare workflow") {
+				t.Fatal("plugin execution began after validation failure")
+			}
+			entry := filepath.Join(cache, "v0.8.0", "Linux_x86_64", fixture.checksum, archiveName)
+			if _, err := os.Stat(entry); !os.IsNotExist(err) {
+				t.Fatalf("invalid distribution was cached: %v", err)
+			}
+		})
+	}
+}
+
+func TestExtractRejectsHostileEntries(t *testing.T) {
+	tests := []struct {
+		name   string
+		header tar.Header
+	}{
+		{name: "parent path", header: tar.Header{Name: "../buildkite-gha", Size: 1, Typeflag: tar.TypeReg}},
+		{name: "absolute path", header: tar.Header{Name: "/buildkite-gha", Size: 1, Typeflag: tar.TypeReg}},
+		{name: "symlink", header: tar.Header{Name: "buildkite-gha", Linkname: "target", Typeflag: tar.TypeSymlink}},
+		{name: "hardlink", header: tar.Header{Name: "buildkite-gha", Linkname: "target", Typeflag: tar.TypeLink}},
+		{name: "directory", header: tar.Header{Name: "buildkite-gha", Typeflag: tar.TypeDir}},
+		{name: "extra", header: tar.Header{Name: "extra", Size: 1, Typeflag: tar.TypeReg}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			archive := filepath.Join(t.TempDir(), "archive.tar.gz")
+			if err := os.WriteFile(archive, archiveWithEntries(t, test.header), 0600); err != nil {
+				t.Fatal(err)
+			}
+			if err := extract(archive, t.TempDir()); err == nil {
+				t.Fatal("hostile entry was accepted")
+			}
+		})
+	}
+
+	t.Run("duplicate", func(t *testing.T) {
+		archive := filepath.Join(t.TempDir(), "archive.tar.gz")
+		duplicate := targetArchive(t, testTarget, tar.Header{Name: "buildkite-gha", Size: 1, Typeflag: tar.TypeReg})
+		if err := os.WriteFile(archive, duplicate, 0600); err != nil {
+			t.Fatal(err)
+		}
+		if err := extract(archive, t.TempDir()); err == nil || !strings.Contains(err.Error(), "invalid archive entry") {
+			t.Fatalf("duplicate entry error = %v", err)
+		}
+	})
+
+	t.Run("trailing gzip member", func(t *testing.T) {
+		contents := targetArchive(t, testTarget)
+		var trailing bytes.Buffer
+		gz := gzip.NewWriter(&trailing)
+		_, _ = gz.Write([]byte("trailing"))
+		if err := gz.Close(); err != nil {
+			t.Fatal(err)
+		}
+		archive := filepath.Join(t.TempDir(), "archive.tar.gz")
+		if err := os.WriteFile(archive, append(contents, trailing.Bytes()...), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if err := extract(archive, t.TempDir()); err == nil || !strings.Contains(err.Error(), "trailing data") {
+			t.Fatalf("trailing member error = %v", err)
+		}
+	})
+}
+
+func fileDigestMatches(t *testing.T, path, want string) bool {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	digest := sha256.Sum256(b)
+	return fmt.Sprintf("%x", digest) == want
+}

--- a/internal/launcher/integration_test.go
+++ b/internal/launcher/integration_test.go
@@ -172,6 +172,29 @@ func TestLauncherExactExecutionContract(t *testing.T) {
 	}
 }
 
+func TestLauncherRetriesTextBusyExec(t *testing.T) {
+	fixture := newReleaseFixture(t, targetArchive(t, testTarget))
+	c, stdout, _, _ := testConfig(t, fixture, "0.8.0")
+	attempts := map[string]int{}
+	c.startCommand = func(cmd *exec.Cmd) error {
+		argument := cmd.Args[1]
+		attempts[argument]++
+		if (argument == "--version" && attempts[argument] <= 2) || (argument == "plugin" && attempts[argument] == 1) {
+			return syscall.ETXTBSY
+		}
+		return cmd.Start()
+	}
+	if err := c.run(); err != nil {
+		t.Fatal(err)
+	}
+	if attempts["--version"] != 3 || attempts["plugin"] != 2 {
+		t.Fatalf("start attempts = %#v, want 3 version and 2 plugin attempts", attempts)
+	}
+	if !strings.Contains(stdout.String(), "argv=plugin argc=1") {
+		t.Fatalf("plugin did not execute after ETXTBSY retries: %q", stdout.String())
+	}
+}
+
 func TestLauncherLatestResolvesOnceAndIgnoresLegacySelector(t *testing.T) {
 	fixture := newReleaseFixture(t, targetArchive(t, testTarget))
 	c, _, stderr, _ := testConfig(t, fixture, "")

--- a/internal/launcher/launcher.go
+++ b/internal/launcher/launcher.go
@@ -1,0 +1,297 @@
+// Package launcher installs and runs a verified buildkite-gha release.
+package launcher
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const (
+	repositoryURL = "https://github.com/buildkite/buildkite-gha"
+	archiveName   = "buildkite-gha_Linux_x86_64.tar.gz"
+	maxChecksums  = 2 << 20
+	maxArchive    = 128 << 20
+	maxVersionOut = 1 << 10
+)
+
+var versionRE = regexp.MustCompile(`^(?:v)?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$`)
+
+type config struct {
+	env           []string
+	getenv        func(string) string
+	stderr        io.Writer
+	stdout        io.Writer
+	stdin         io.Reader
+	client        *http.Client
+	repositoryURL string
+	goos, goarch  string
+	tempDir       string
+}
+
+// Run executes the zero-argument stable launcher and returns the process exit code.
+func Run(args []string) int {
+	c := defaultConfig()
+	if len(args) != 0 {
+		_, _ = fmt.Fprintln(c.stderr, "buildkite-gha-launcher: arguments are not accepted")
+		return 2
+	}
+	if err := c.run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok && status.Signaled() {
+				return 128 + int(status.Signal())
+			}
+			return exitErr.ExitCode()
+		}
+		_, _ = fmt.Fprintf(c.stderr, "buildkite-gha-launcher: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func defaultConfig() config {
+	return config{env: os.Environ(), getenv: os.Getenv, stderr: os.Stderr, stdout: os.Stdout, stdin: os.Stdin,
+		client: &http.Client{Timeout: 45 * time.Second}, repositoryURL: repositoryURL,
+		goos: runtime.GOOS, goarch: runtime.GOARCH, tempDir: os.TempDir()}
+}
+
+func parseSelector(s string) (string, error) {
+	if s == "" || s == "latest" {
+		return s, nil
+	}
+	if !versionRE.MatchString(s) {
+		return "", fmt.Errorf("version must be latest or an exact stable semantic version")
+	}
+	var major, minor, patch int
+	if _, err := fmt.Sscanf(strings.TrimPrefix(s, "v"), "%d.%d.%d", &major, &minor, &patch); err != nil || major == 0 && minor < 8 {
+		return "", fmt.Errorf("version must be at least 0.8.0")
+	}
+	return fmt.Sprintf("v%d.%d.%d", major, minor, patch), nil
+}
+
+func (c config) run() error {
+	if c.goos != "linux" || c.goarch != "amd64" {
+		return fmt.Errorf("unsupported platform %s/%s (requires linux/amd64)", c.goos, c.goarch)
+	}
+	selector, err := parseSelector(c.getenv("BUILDKITE_PLUGIN_GITHUB_ACTIONS_VERSION"))
+	if err != nil {
+		return err
+	}
+	if selector == "" || selector == "latest" {
+		selector, err = c.resolveLatest()
+		if err != nil {
+			return err
+		}
+		_, _ = fmt.Fprintf(c.stderr, "buildkite-gha-launcher: resolved latest to %s\n", selector)
+	}
+	version := strings.TrimPrefix(selector, "v")
+	checksums, err := c.fetch(selector, "checksums.txt", maxChecksums)
+	if err != nil {
+		return fmt.Errorf("download checksums: %w", err)
+	}
+	want, err := parseChecksum(checksums, archiveName)
+	if err != nil {
+		return err
+	}
+	root, persistent := c.cacheRoot()
+	if root == "" {
+		root, err = os.MkdirTemp(c.tempDir, "buildkite-gha-cache-")
+		if err != nil {
+			return fmt.Errorf("create temporary cache: %w", err)
+		}
+		defer func() { _ = os.RemoveAll(root) }()
+	}
+	cache, err := openCacheRoot(root)
+	if err != nil {
+		if persistent {
+			_, _ = fmt.Fprintf(c.stderr, "buildkite-gha-launcher: warning: cache unavailable: %v; using temporary cache\n", err)
+		}
+		root, err = os.MkdirTemp(c.tempDir, "buildkite-gha-cache-")
+		if err != nil {
+			return fmt.Errorf("create temporary cache: %w", err)
+		}
+		defer func() { _ = os.RemoveAll(root) }()
+		cache, err = openCacheRoot(root)
+		if err != nil {
+			return fmt.Errorf("open temporary cache: %w", err)
+		}
+	}
+	defer func() { _ = cache.Close() }()
+	entry := filepath.ToSlash(filepath.Join(selector, "Linux_x86_64", want, archiveName))
+	archive, downloaded, err := c.privateArchive(cache, selector, want, entry)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.Remove(archive) }()
+	runDir, err := os.MkdirTemp(c.tempDir, "buildkite-gha-run-")
+	if err != nil {
+		return fmt.Errorf("create run directory: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(runDir) }()
+	if err := extract(archive, runDir); err != nil {
+		return fmt.Errorf("extract archive: %w", err)
+	}
+	binary := filepath.Join(runDir, "buildkite-gha")
+	cmd := exec.Command(binary, "--version")
+	cmd.Env = c.env
+	var versionOutput boundedBuffer
+	cmd.Stdout = &versionOutput
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil || versionOutput.overflow || versionOutput.String() != "buildkite-gha "+version+"\n" {
+		return fmt.Errorf("installed binary version verification failed")
+	}
+	if downloaded {
+		if err := publish(cache, archive, entry); err != nil {
+			_, _ = fmt.Fprintf(c.stderr, "buildkite-gha-launcher: warning: cache publication failed: %v\n", err)
+		}
+	}
+	_, _ = fmt.Fprintln(c.stdout, "~~~ :github: Prepare workflow")
+	cmd = exec.Command(binary, "plugin")
+	cmd.Env, cmd.Stdin, cmd.Stdout, cmd.Stderr = c.env, c.stdin, c.stdout, c.stderr
+	return runForwarding(cmd)
+}
+
+type boundedBuffer struct {
+	bytes.Buffer
+	overflow bool
+}
+
+func (b *boundedBuffer) Write(p []byte) (int, error) {
+	written := len(p)
+	if b.Len()+len(p) > maxVersionOut {
+		p = p[:max(0, maxVersionOut-b.Len())]
+		b.overflow = true
+	}
+	_, _ = b.Buffer.Write(p)
+	return written, nil
+}
+
+func runForwarding(cmd *exec.Cmd) error {
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	sigs := make(chan os.Signal, 2)
+	signal.Notify(sigs, os.Interrupt, syscall.SIGTERM)
+	done := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case s := <-sigs:
+				_ = cmd.Process.Signal(s)
+			case <-done:
+				return
+			}
+		}
+	}()
+	err := cmd.Wait()
+	close(done)
+	signal.Stop(sigs)
+	return err
+}
+
+func (c config) resolveLatest() (string, error) {
+	u := c.repositoryURL + "/releases/latest"
+	client := *c.client
+	hosts, scheme := c.redirectHosts(map[string]bool{"github.com": true})
+	client.CheckRedirect = redirectPolicy(hosts, scheme, 5)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, u, nil)
+	if err != nil {
+		return "", fmt.Errorf("create latest request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("latest returned %s", resp.Status)
+	}
+	prefix := c.repositoryURL + "/releases/tag/"
+	if !strings.HasPrefix(resp.Request.URL.String(), prefix) {
+		return "", fmt.Errorf("latest resolved outside canonical release tags")
+	}
+	tag, err := parseSelector(strings.TrimPrefix(resp.Request.URL.String(), prefix))
+	if err != nil || !strings.HasPrefix(strings.TrimPrefix(resp.Request.URL.String(), prefix), "v") {
+		return "", fmt.Errorf("latest resolved to invalid tag")
+	}
+	return tag, nil
+}
+
+func (c config) redirectHosts(production map[string]bool) (map[string]bool, string) {
+	u, err := url.Parse(c.repositoryURL)
+	if err == nil && c.repositoryURL != repositoryURL {
+		return map[string]bool{strings.ToLower(u.Hostname()): true}, u.Scheme
+	}
+	return production, "https"
+}
+
+func redirectPolicy(hosts map[string]bool, scheme string, max int) func(*http.Request, []*http.Request) error {
+	return func(req *http.Request, via []*http.Request) error {
+		if len(via) >= max {
+			return fmt.Errorf("too many redirects")
+		}
+		port := req.URL.Port()
+		if req.URL.Scheme != scheme || req.URL.User != nil || scheme == "https" && port != "" && port != "443" || !hosts[strings.ToLower(req.URL.Hostname())] {
+			return fmt.Errorf("redirect to untrusted URL")
+		}
+		return nil
+	}
+}
+
+func (c config) fetch(tag, name string, limit int64) ([]byte, error) {
+	u := c.repositoryURL + "/releases/download/" + url.PathEscape(tag) + "/" + name
+	client := *c.client
+	hosts, scheme := c.redirectHosts(map[string]bool{"github.com": true, "objects.githubusercontent.com": true, "github-releases.githubusercontent.com": true, "release-assets.githubusercontent.com": true})
+	client.CheckRedirect = redirectPolicy(hosts, scheme, 8)
+	resp, err := client.Get(u)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s returned %s", name, resp.Status)
+	}
+	b, err := io.ReadAll(io.LimitReader(resp.Body, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(b)) > limit {
+		return nil, fmt.Errorf("%s exceeds size limit", name)
+	}
+	return b, nil
+}
+
+func parseChecksum(data []byte, name string) (string, error) {
+	var found []string
+	for _, line := range strings.Split(string(data), "\n") {
+		f := strings.Fields(line)
+		if len(f) == 2 && f[1] == name {
+			if len(f[0]) != 64 {
+				return "", fmt.Errorf("invalid checksum for %s", name)
+			}
+			if _, err := hex.DecodeString(f[0]); err != nil {
+				return "", fmt.Errorf("invalid checksum for %s", name)
+			}
+			found = append(found, strings.ToLower(f[0]))
+		}
+	}
+	if len(found) != 1 {
+		return "", fmt.Errorf("checksums must contain exactly one entry for %s", name)
+	}
+	return found[0], nil
+}

--- a/internal/launcher/launcher.go
+++ b/internal/launcher/launcher.go
@@ -27,6 +27,8 @@ const (
 	maxChecksums  = 2 << 20
 	maxArchive    = 128 << 20
 	maxVersionOut = 1 << 10
+	textBusyTries = 5
+	textBusyDelay = 10 * time.Millisecond
 )
 
 var versionRE = regexp.MustCompile(`^(?:v)?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$`)
@@ -41,6 +43,7 @@ type config struct {
 	repositoryURL string
 	goos, goarch  string
 	tempDir       string
+	startCommand  func(*exec.Cmd) error
 }
 
 // Run executes the zero-argument stable launcher and returns the process exit code.
@@ -147,12 +150,19 @@ func (c config) run() error {
 		return fmt.Errorf("extract archive: %w", err)
 	}
 	binary := filepath.Join(runDir, "buildkite-gha")
-	cmd := exec.Command(binary, "--version")
-	cmd.Env = c.env
-	var versionOutput boundedBuffer
-	cmd.Stdout = &versionOutput
-	cmd.Stderr = io.Discard
-	if err := cmd.Run(); err != nil || versionOutput.overflow || versionOutput.String() != "buildkite-gha "+version+"\n" {
+	var versionOutput *boundedBuffer
+	cmd, err := startWithTextBusyRetry(func() *exec.Cmd {
+		versionOutput = new(boundedBuffer)
+		cmd := exec.Command(binary, "--version")
+		cmd.Env = c.env
+		cmd.Stdout = versionOutput
+		cmd.Stderr = io.Discard
+		return cmd
+	}, c.startCommand)
+	if err != nil {
+		return fmt.Errorf("installed binary version verification failed: %w", err)
+	}
+	if err := cmd.Wait(); err != nil || versionOutput.overflow || versionOutput.String() != "buildkite-gha "+version+"\n" {
 		return fmt.Errorf("installed binary version verification failed")
 	}
 	if downloaded {
@@ -161,9 +171,11 @@ func (c config) run() error {
 		}
 	}
 	_, _ = fmt.Fprintln(c.stdout, "~~~ :github: Prepare workflow")
-	cmd = exec.Command(binary, "plugin")
-	cmd.Env, cmd.Stdin, cmd.Stdout, cmd.Stderr = c.env, c.stdin, c.stdout, c.stderr
-	return runForwarding(cmd)
+	return runForwarding(func() *exec.Cmd {
+		cmd := exec.Command(binary, "plugin")
+		cmd.Env, cmd.Stdin, cmd.Stdout, cmd.Stderr = c.env, c.stdin, c.stdout, c.stderr
+		return cmd
+	}, c.startCommand)
 }
 
 type boundedBuffer struct {
@@ -181,8 +193,25 @@ func (b *boundedBuffer) Write(p []byte) (int, error) {
 	return written, nil
 }
 
-func runForwarding(cmd *exec.Cmd) error {
-	if err := cmd.Start(); err != nil {
+func startWithTextBusyRetry(newCommand func() *exec.Cmd, start func(*exec.Cmd) error) (*exec.Cmd, error) {
+	if start == nil {
+		start = func(cmd *exec.Cmd) error { return cmd.Start() }
+	}
+	for attempt := range textBusyTries {
+		cmd := newCommand()
+		if err := start(cmd); err == nil {
+			return cmd, nil
+		} else if !errors.Is(err, syscall.ETXTBSY) || attempt == textBusyTries-1 {
+			return nil, err
+		}
+		time.Sleep(textBusyDelay)
+	}
+	panic("unreachable")
+}
+
+func runForwarding(newCommand func() *exec.Cmd, start func(*exec.Cmd) error) error {
+	cmd, err := startWithTextBusyRetry(newCommand, start)
+	if err != nil {
 		return err
 	}
 	sigs := make(chan os.Signal, 2)
@@ -198,7 +227,7 @@ func runForwarding(cmd *exec.Cmd) error {
 			}
 		}
 	}()
-	err := cmd.Wait()
+	err = cmd.Wait()
 	close(done)
 	signal.Stop(sigs)
 	return err

--- a/internal/launcher/launcher_test.go
+++ b/internal/launcher/launcher_test.go
@@ -1,0 +1,106 @@
+package launcher
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseSelector(t *testing.T) {
+	t.Parallel()
+	tests := map[string]string{"": "", "latest": "latest", "0.8.0": "v0.8.0", "v1.2.3": "v1.2.3"}
+	for input, want := range tests {
+		got, err := parseSelector(input)
+		if err != nil || got != want {
+			t.Errorf("parseSelector(%q) = %q, %v; want %q", input, got, err, want)
+		}
+	}
+	for _, input := range []string{"0.7.9", "v1.2.3-rc.1", "1.2", "1.2.3+meta", "../1.2.3", "01.2.3", "LATEST"} {
+		if _, err := parseSelector(input); err == nil {
+			t.Errorf("parseSelector(%q) unexpectedly succeeded", input)
+		}
+	}
+}
+
+func TestParseChecksumRequiresOneEntry(t *testing.T) {
+	t.Parallel()
+	h := strings.Repeat("a", 64)
+	if got, err := parseChecksum([]byte(h+"  "+archiveName+"\n"), archiveName); err != nil || got != h {
+		t.Fatalf("got %q, %v", got, err)
+	}
+	for _, data := range []string{"", "bad  " + archiveName, h + "  " + archiveName + "\n" + h + "  " + archiveName} {
+		if _, err := parseChecksum([]byte(data), archiveName); err == nil {
+			t.Errorf("accepted %q", data)
+		}
+	}
+}
+
+func TestCacheRootPrecedence(t *testing.T) {
+	t.Parallel()
+	d := t.TempDir()
+	env := map[string]string{"BUILDKITE_COMPUTE_TYPE": "hosted", "MISE_HOSTED_CACHE_VOLUME_ROOT": d, "BUILDKITE_AGENT_DATA_PATH": "/agent", "XDG_CACHE_HOME": "/xdg", "HOME": "/home"}
+	c := config{getenv: func(k string) string { return env[k] }}
+	got, _ := c.cacheRoot()
+	if want := filepath.Join(d, "github-actions-buildkite-plugin"); got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+	env["BUILDKITE_GITHUB_ACTIONS_PLUGIN_CACHE_ROOT"] = "/test-only"
+	if got, _ := c.cacheRoot(); got != "/test-only" {
+		t.Fatalf("override got %q", got)
+	}
+	delete(env, "BUILDKITE_GITHUB_ACTIONS_PLUGIN_CACHE_ROOT")
+	delete(env, "BUILDKITE_COMPUTE_TYPE")
+	if got, _ := c.cacheRoot(); got != "/agent/cache/github-actions-buildkite-plugin" {
+		t.Fatalf("agent cache got %q", got)
+	}
+	delete(env, "BUILDKITE_AGENT_DATA_PATH")
+	if got, _ := c.cacheRoot(); got != "/xdg/buildkite/github-actions-buildkite-plugin" {
+		t.Fatalf("XDG cache got %q", got)
+	}
+	delete(env, "XDG_CACHE_HOME")
+	if got, _ := c.cacheRoot(); got != "/home/.cache/buildkite/github-actions-buildkite-plugin" {
+		t.Fatalf("home cache got %q", got)
+	}
+}
+
+func TestOpenCacheRootRejectsSymlinkAncestor(t *testing.T) {
+	t.Parallel()
+	d := t.TempDir()
+	link := filepath.Join(d, "link")
+	target := t.TempDir()
+	if err := os.Mkdir(filepath.Join(target, "cache"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	if root, err := openCacheRoot(filepath.Join(link, "cache")); err == nil {
+		_ = root.Close()
+		t.Fatal("accepted symlink root")
+	}
+}
+
+func TestRedirectPolicyRestrictsSchemeHostAndPort(t *testing.T) {
+	t.Parallel()
+	policy := redirectPolicy(map[string]bool{"github.com": true, "release-assets.githubusercontent.com": true}, "https", 3)
+	for _, raw := range []string{"https://github.com/release", "https://release-assets.githubusercontent.com/asset", "https://github.com:443/release"} {
+		req, err := http.NewRequest(http.MethodGet, raw, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := policy(req, []*http.Request{{}}); err != nil {
+			t.Errorf("policy rejected %q: %v", raw, err)
+		}
+	}
+	for _, raw := range []string{"http://github.com/release", "https://example.com/release", "https://github.com:8443/release", "https://user@github.com/release"} {
+		req, err := http.NewRequest(http.MethodGet, raw, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if policy(req, []*http.Request{{}}) == nil {
+			t.Errorf("policy accepted %q", raw)
+		}
+	}
+}

--- a/internal/launcher/launcher_test.go
+++ b/internal/launcher/launcher_test.go
@@ -1,10 +1,13 @@
 package launcher
 
 import (
+	"errors"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -102,5 +105,29 @@ func TestRedirectPolicyRestrictsSchemeHostAndPort(t *testing.T) {
 		if policy(req, []*http.Request{{}}) == nil {
 			t.Errorf("policy accepted %q", raw)
 		}
+	}
+}
+
+func TestTextBusyRetryIsBoundedAndErrorSpecific(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		err          error
+		wantAttempts int
+	}{
+		{name: "text busy", err: syscall.ETXTBSY, wantAttempts: textBusyTries},
+		{name: "other error", err: syscall.EACCES, wantAttempts: 1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			attempts := 0
+			_, err := startWithTextBusyRetry(func() *exec.Cmd { return exec.Command("unused") }, func(*exec.Cmd) error {
+				attempts++
+				return test.err
+			})
+			if !errors.Is(err, test.err) || attempts != test.wantAttempts {
+				t.Fatalf("retry = %v after %d attempts, want %v after %d", err, attempts, test.err, test.wantAttempts)
+			}
+		})
 	}
 }

--- a/internal/launcher/release_test.go
+++ b/internal/launcher/release_test.go
@@ -1,0 +1,21 @@
+package launcher
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestReleaseConfigPreservesArchiveAndAddsRawLauncher(t *testing.T) {
+	t.Parallel()
+	b, err := os.ReadFile("../../.goreleaser.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	for _, required := range []string{"name_template: buildkite-gha_Linux_x86_64", "src: LICENSE", "main: ./cmd/buildkite-gha-launcher", "formats: [binary]", "name_template: buildkite-gha-launcher_Linux_x86_64"} {
+		if strings.Count(s, required) != 1 {
+			t.Errorf("release config must contain exactly one %q", required)
+		}
+	}
+}


### PR DESCRIPTION
## Why

The GitHub Actions plugin needs a small, stable artifact it can pin instead of owning release selection, installer, cache, and archive-validation logic in Bash. The selected `buildkite-gha` release must still remain the authority for plugin workflow parsing and exact self-distribution into generated jobs.

## What

- publish a separate raw `buildkite-gha-launcher_Linux_x86_64` asset without changing the existing CLI archive
- resolve `latest` once or accept an exact stable release from v0.8.0, then securely download, validate, cache, and privately extract that target
- execute only the selected target's hidden `buildkite-gha plugin` command with inherited process semantics and bounded retries for transient text-busy starts
- cover redirect, checksum, archive, cache-tamper/concurrency, and process-boundary behavior, and document the co-published-checksum trust limit