### PR TITLE
Narrow unused internal API surface

### DIFF
--- a/internal/runtime/actions.go
+++ b/internal/runtime/actions.go
@@ -167,7 +167,7 @@ func (r *actionLockResolver) verifyWorkspace(lock plan.ActionLock) (metadata.Met
 	if r.workspace == "" {
 		return metadata.Metadata{}, fmt.Errorf("workspace is missing")
 	}
-	if err := VerifyWorkflow(r.job, r.workspace); err != nil {
+	if err := verifyWorkflow(r.job, r.workspace); err != nil {
 		return metadata.Metadata{}, fmt.Errorf("workspace action workflow verification failed: %w", err)
 	}
 	resolved, err := metadata.Load(r.workspace, lock.Path)

--- a/internal/runtime/cache_service_test.go
+++ b/internal/runtime/cache_service_test.go
@@ -512,7 +512,7 @@ fs.writeFileSync(process.env.MARKER, "executed");
 	runner := Runner{Cache: provider, Redactor: &testRedactor{}}
 	if err := runner.runJavaScriptPhase(
 		context.Background(), processor, actionRoot, node,
-		JavaScriptAction{Name: "ordinary", Path: actionRoot, Main: "main.js"}, "main.js", nil, nil, &result,
+		javaScriptAction{Name: "ordinary", Path: actionRoot, Main: "main.js"}, "main.js", nil, nil, &result,
 	); err != nil {
 		t.Fatalf("generic action cache fallback error = %v", err)
 	}
@@ -524,7 +524,7 @@ fs.writeFileSync(process.env.MARKER, "executed");
 	}
 	if err := runner.runJavaScriptPhase(
 		context.Background(), processor, actionRoot, node,
-		JavaScriptAction{Name: "cache", Path: actionRoot, Main: "main.js", Cache: true}, "main.js", nil, nil, &result,
+		javaScriptAction{Name: "cache", Path: actionRoot, Main: "main.js", Cache: true}, "main.js", nil, nil, &result,
 	); err == nil || !strings.Contains(err.Error(), "configure actions/cache v6 service: cache unavailable") {
 		t.Fatalf("explicit cache action error = %v", err)
 	}
@@ -542,7 +542,7 @@ func TestDockerActionReceivesCacheCredentialsWithoutTokenInArguments(t *testing.
 	action.Env["ACTIONS_RUNTIME_TOKEN"] = "workflow-token"
 	action.Env["ACTIONS_RESULTS_URL"] = "https://attacker.invalid"
 	action.Env["ACTIONS_CACHE_SERVICE_V2"] = "false"
-	if _, err := (Runner{Docker: fake.path, Cache: provider, Redactor: redactor}).RunDocker(context.Background(), action); err != nil {
+	if _, err := (Runner{Docker: fake.path, Cache: provider, Redactor: redactor}).runDockerAction(context.Background(), action); err != nil {
 		t.Fatal(err)
 	}
 	cacheRuntime, err := os.ReadFile(filepath.Join(fake.root, "cache-runtime"))
@@ -587,7 +587,7 @@ func TestCacheV6RedactorFailureAbortsBeforeExecutionAndScrubsToken(t *testing.T)
 	result := newResult()
 	result.Env["MARKER"] = marker
 	err := (Runner{Cache: provider, Redactor: failingCacheRedactor{token: token}}).runJavaScriptPhase(
-		context.Background(), processor, actionRoot, "node", JavaScriptAction{Name: "cache", Path: actionRoot, Main: "main.js", Cache: true}, "main.js", nil, nil, &result,
+		context.Background(), processor, actionRoot, "node", javaScriptAction{Name: "cache", Path: actionRoot, Main: "main.js", Cache: true}, "main.js", nil, nil, &result,
 	)
 	if err == nil || strings.Contains(err.Error(), token) || !strings.Contains(err.Error(), "***") {
 		t.Fatalf("runJavaScriptPhase() error = %v", err)
@@ -622,7 +622,7 @@ func TestActionRuntimeCacheTokenCommandFileEffectsAreDiscarded(t *testing.T) {
 			state := map[string]string{"kept": "action state"}
 			err := (Runner{Cache: provider, Redactor: &testRedactor{}}).runJavaScriptPhase(
 				context.Background(), newCommandProcessor(io.Discard, io.Discard), actionRoot, node,
-				JavaScriptAction{Name: "ordinary", Path: actionRoot, Main: "main.js"}, "main.js", nil, state, &result,
+				javaScriptAction{Name: "ordinary", Path: actionRoot, Main: "main.js"}, "main.js", nil, state, &result,
 			)
 			if err == nil || strings.Contains(err.Error(), token) || !strings.Contains(err.Error(), "phase effects were discarded") {
 				t.Fatalf("runJavaScriptPhase() error = %v", err)

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -1680,7 +1680,7 @@ func TestRunJobContainerSiblingDockerFailureCleansActionAndJobResources(t *testi
 
 func TestRunDockerRejectsMismatchedJobContainerPaths(t *testing.T) {
 	r := Runner{jobContainer: &jobContainerBackend{workspace: "/owned/workspace", temp: "/owned/temp"}}
-	_, err := r.runDocker(context.Background(), newCommandProcessor(nil, nil), DockerAction{Workspace: "/other/workspace", runnerTemp: "/owned/temp"})
+	_, err := r.runDocker(context.Background(), newCommandProcessor(nil, nil), dockerAction{Workspace: "/other/workspace", runnerTemp: "/owned/temp"})
 	if err == nil || !strings.Contains(err.Error(), "must match the job container's owned host paths") {
 		t.Fatalf("mismatched sibling paths error = %v", err)
 	}

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -40,7 +40,7 @@ type JobResult struct {
 const maxJobOutputBytes = 1024
 
 type registeredPost struct {
-	action     JavaScriptAction
+	action     javaScriptAction
 	state      map[string]string
 	node       string
 	condition  string
@@ -53,7 +53,7 @@ type postRegistry struct {
 }
 
 type preparedInvocation struct {
-	action         JavaScriptAction
+	action         javaScriptAction
 	state          map[string]string
 	node           string
 	postRegistered bool
@@ -124,8 +124,8 @@ func (r *postRegistry) snapshot() []registeredPost {
 	return append([]registeredPost(nil), r.posts...)
 }
 
-// VerifyWorkflow binds a plan to the workflow bytes in the supplied workspace.
-func VerifyWorkflow(job plan.Job, workspace string) error {
+// verifyWorkflow binds a plan to the workflow bytes in the supplied workspace.
+func verifyWorkflow(job plan.Job, workspace string) error {
 	path, err := workspacePath(workspace, job.Workflow.Path)
 	if err != nil {
 		return fmt.Errorf("verify workflow binding: %w", err)
@@ -1083,7 +1083,7 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 		if err != nil {
 			return result, err
 		}
-		javascript := JavaScriptAction{Name: actionName(action, step), Path: action.Path, Pre: action.Runs.Pre, Main: action.Runs.Main, Post: action.Runs.Post, Cache: usesCacheService(lock), nodeMajor: major, reference: step.Uses, jobStatusInputs: jobStatusInputs}
+		javascript := javaScriptAction{Name: actionName(action, step), Path: action.Path, Pre: action.Runs.Pre, Main: action.Runs.Main, Post: action.Runs.Post, Cache: usesCacheService(lock), nodeMajor: major, reference: step.Uses, jobStatusInputs: jobStatusInputs}
 		invocation := &preparedInvocation{action: javascript, state: map[string]string{}}
 		prepared[invocationID] = invocation
 		if javascript.Pre != "" && runPre {
@@ -1251,7 +1251,7 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 		if !strings.HasPrefix(step.Uses, "./") {
 			return result, fmt.Errorf("remote action %q is unsupported in the supported runtime subset", step.Uses)
 		}
-		if err := VerifyWorkflow(job, workspace); err != nil {
+		if err := verifyWorkflow(job, workspace); err != nil {
 			return result, err
 		}
 		var err error
@@ -1313,7 +1313,7 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 			return result, err
 		}
 		actionEnv := mergeStepEnvironment(jobEnv, stepEnv)
-		javascript := JavaScriptAction{Name: actionName(action, step), Path: actionPath, Pre: action.Runs.Pre, Main: action.Runs.Main, Post: action.Runs.Post, Inputs: inputs, Env: actionEnv, Cache: actionLock != nil && usesCacheService(*actionLock), nodeMajor: major, reference: step.Uses, jobStatusInputs: jobStatusInputs}
+		javascript := javaScriptAction{Name: actionName(action, step), Path: actionPath, Pre: action.Runs.Pre, Main: action.Runs.Main, Post: action.Runs.Post, Inputs: inputs, Env: actionEnv, Cache: actionLock != nil && usesCacheService(*actionLock), nodeMajor: major, reference: step.Uses, jobStatusInputs: jobStatusInputs}
 		state := map[string]string{}
 		wasPrepared := false
 		if invocation := prepared[invocationID]; invocation != nil {
@@ -1381,7 +1381,7 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 				invocationEnv[name] = value
 			}
 		}
-		result, err := r.runDocker(ctx, processor, DockerAction{Name: actionName(action, step), Path: actionPath, SourceRoot: sourceRoot, SourceDigest: sourceDigest, Workspace: workspace, Env: invocationEnv, explicitPATH: jobPATH || stepPATH || actionPATH})
+		result, err := r.runDocker(ctx, processor, dockerAction{Name: actionName(action, step), Path: actionPath, SourceRoot: sourceRoot, SourceDigest: sourceDigest, Workspace: workspace, Env: invocationEnv, explicitPATH: jobPATH || stepPATH || actionPATH})
 		return result, err
 	}
 	return result, fmt.Errorf("action %q uses unsupported runtime %q", step.Uses, actionRuntime)
@@ -1632,7 +1632,7 @@ func workspacePath(root, path string) (string, error) {
 	return resolved, nil
 }
 
-func postFor(action JavaScriptAction, state map[string]string, node, condition string) *registeredPost {
+func postFor(action javaScriptAction, state map[string]string, node, condition string) *registeredPost {
 	if action.Post == "" {
 		return nil
 	}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -134,8 +134,8 @@ func (r *Runner) setExplicitNode(major int, path string) {
 	}
 }
 
-// JavaScriptAction is an already-resolved local JavaScript action.
-type JavaScriptAction struct {
+// javaScriptAction is an already-resolved local JavaScript action.
+type javaScriptAction struct {
 	Name   string
 	Path   string
 	Pre    string
@@ -150,8 +150,8 @@ type JavaScriptAction struct {
 	jobStatusInputs []string
 }
 
-// DockerAction is an already-resolved local Docker action.
-type DockerAction struct {
+// dockerAction is an already-resolved local Docker action.
+type dockerAction struct {
 	Name         string
 	Path         string
 	SourceRoot   string
@@ -225,8 +225,9 @@ func boundJobSummary(summary string, truncated bool) (string, bool) {
 	return bounded, boundedTruncated
 }
 
-// RunDocker builds and executes an explicitly resolved local Docker action.
-func (r Runner) RunDocker(ctx context.Context, action DockerAction) (result Result, err error) {
+// runDockerAction builds and executes an explicitly resolved local Docker
+// action, creating an isolated workspace when the caller supplies none.
+func (r Runner) runDockerAction(ctx context.Context, action dockerAction) (result Result, err error) {
 	callerWorkspace := action.Workspace != ""
 	if !callerWorkspace {
 		action.Workspace, err = os.MkdirTemp("", "buildkite-gha-workspace-")
@@ -276,7 +277,7 @@ func (r Runner) RunDocker(ctx context.Context, action DockerAction) (result Resu
 	return r.runDocker(ctx, newCommandProcessor(r.stdout(), r.stderr()), action)
 }
 
-func (r Runner) runDocker(ctx context.Context, processor *commandProcessor, action DockerAction) (result Result, err error) {
+func (r Runner) runDocker(ctx context.Context, processor *commandProcessor, action dockerAction) (result Result, err error) {
 	result = newResult()
 	if action.runnerTemp == "" {
 		action.runnerTemp = r.runnerTemp
@@ -623,7 +624,7 @@ func (w *limitedWriter) Write(p []byte) (int, error) {
 	return w.writer.Write(p)
 }
 
-func (r Runner) runJavaScriptPhase(ctx context.Context, processor *commandProcessor, workspace, node string, action JavaScriptAction, entry string, stateEnv, stateOut map[string]string, result *Result) error {
+func (r Runner) runJavaScriptPhase(ctx context.Context, processor *commandProcessor, workspace, node string, action javaScriptAction, entry string, stateEnv, stateOut map[string]string, result *Result) error {
 	env := mergeStringMaps(result.Env, action.Env, actionInputEnv(action.Inputs))
 	if path, ok := result.Env["PATH"]; ok {
 		env["PATH"] = path
@@ -1174,13 +1175,9 @@ func verifyManagedNodeExecutable(ctx context.Context, major int, path, want stri
 	return nil
 }
 
-// DiscoverNode resolves an explicit Node binary or a binary in the managed
-// runtime root, and rejects binaries that do not report the requested major.
-// It deliberately does not fall back to PATH.
-func DiscoverNode(major int, explicit, managedRoot string) (string, error) {
-	return discoverNodeContext(context.Background(), major, explicit, managedRoot)
-}
-
+// discoverNodeContext resolves an explicit Node binary or a binary in the
+// managed runtime root, and rejects binaries that do not report the requested
+// major. It deliberately does not fall back to PATH.
 func discoverNodeContext(ctx context.Context, major int, explicit, managedRoot string) (string, error) {
 	var candidates []string
 	if explicit != "" {
@@ -1216,11 +1213,6 @@ func discoverNodeContext(ctx context.Context, major int, explicit, managedRoot s
 		failures = append(failures, fmt.Sprintf("%s: reported %q", candidate, version))
 	}
 	return "", fmt.Errorf("node %d discovery failed: %s", major, strings.Join(failures, "; "))
-}
-
-// DiscoverNode24 retains the original Node 24 discovery API.
-func DiscoverNode24(explicit, managedRoot string) (string, error) {
-	return DiscoverNode(24, explicit, managedRoot)
 }
 
 func newResult() Result {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -369,14 +369,14 @@ func (fake fakeDocker) calls(t *testing.T) []fakeDockerCall {
 	return calls
 }
 
-func fakeDockerAction(t *testing.T) DockerAction {
+func fakeDockerAction(t *testing.T) dockerAction {
 	t.Helper()
 	path := fixturePath(t, "actions", "docker")
 	digest, err := source.DigestTree(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	return DockerAction{
+	return dockerAction{
 		Name: "fake Docker", Path: path, SourceRoot: path, SourceDigest: digest,
 		Workspace: t.TempDir(), Env: map[string]string{"Z_LAST": "z", "A_FIRST": "a"},
 	}
@@ -414,7 +414,7 @@ func TestRunDockerFakeLifecycle(t *testing.T) {
 	t.Setenv("BUILDX_BUILDER", "ambient-builder")
 	t.Setenv("BUILDKIT_HOST", "tcp://ambient.invalid:1234")
 	var logs bytes.Buffer
-	result, err := (Runner{Docker: fake.path, Stdout: &logs, Stderr: &logs}).RunDocker(context.Background(), action)
+	result, err := (Runner{Docker: fake.path, Stdout: &logs, Stderr: &logs}).runDockerAction(context.Background(), action)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -648,7 +648,7 @@ func TestRunDockerRejectsUntrustedBuilderBeforeExecution(t *testing.T) {
 	for _, scenario := range []string{"remote", "multiline", "oversized", "inspect-fail"} {
 		t.Run(scenario, func(t *testing.T) {
 			fake := newFakeDocker(t, scenario)
-			if _, err := (Runner{Docker: fake.path}).RunDocker(context.Background(), fakeDockerAction(t)); err == nil {
+			if _, err := (Runner{Docker: fake.path}).runDockerAction(context.Background(), fakeDockerAction(t)); err == nil {
 				t.Fatal("untrusted builder was accepted")
 			}
 			calls := fake.calls(t)
@@ -665,7 +665,7 @@ func TestRunDockerFakeFailuresCleanOwnedResources(t *testing.T) {
 	for _, scenario := range []string{"build-fail", "run-fail", "leftover", "query-fail"} {
 		t.Run(scenario, func(t *testing.T) {
 			fake := newFakeDocker(t, scenario)
-			if _, err := (Runner{Docker: fake.path, CleanupTimeout: 2 * time.Second}).RunDocker(context.Background(), fakeDockerAction(t)); err == nil {
+			if _, err := (Runner{Docker: fake.path, CleanupTimeout: 2 * time.Second}).runDockerAction(context.Background(), fakeDockerAction(t)); err == nil {
 				t.Fatal("Docker failure returned success")
 			}
 			calls := fake.calls(t)
@@ -691,9 +691,9 @@ func TestRunDockerFakeFailuresCleanOwnedResources(t *testing.T) {
 
 func TestRunDockerProcessesFileCommandsAfterFailure(t *testing.T) {
 	fake := newFakeDocker(t, "run-fail")
-	result, err := (Runner{Docker: fake.path}).RunDocker(context.Background(), fakeDockerAction(t))
+	result, err := (Runner{Docker: fake.path}).runDockerAction(context.Background(), fakeDockerAction(t))
 	if err == nil || !strings.Contains(err.Error(), `run Docker action "fake Docker"`) {
-		t.Fatalf("RunDocker() error = %v", err)
+		t.Fatalf("runDockerAction() error = %v", err)
 	}
 	if result.Outputs["container"] != "ran" || result.Env["DOCKER_RUNTIME_SEEN"] != "true" || result.State["docker_state"] != "seen" || result.Summary != "docker action summary\n" || !slices.Equal(result.Paths, []string{"/fake/action/bin"}) {
 		t.Fatalf("Docker failure result = %#v", result)
@@ -702,9 +702,9 @@ func TestRunDockerProcessesFileCommandsAfterFailure(t *testing.T) {
 
 func TestRunDockerJoinsRunAndFileCommandFailures(t *testing.T) {
 	fake := newFakeDocker(t, "run-fail-invalid-files")
-	_, err := (Runner{Docker: fake.path}).RunDocker(context.Background(), fakeDockerAction(t))
+	_, err := (Runner{Docker: fake.path}).runDockerAction(context.Background(), fakeDockerAction(t))
 	if err == nil || !strings.Contains(err.Error(), `run Docker action "fake Docker"`) || !strings.Contains(err.Error(), `process Docker action "fake Docker" file commands`) || !strings.Contains(err.Error(), "invalid file command") {
-		t.Fatalf("RunDocker() error = %v", err)
+		t.Fatalf("runDockerAction() error = %v", err)
 	}
 }
 
@@ -712,7 +712,7 @@ func TestRunDockerReadsOnlyOriginalCommandFiles(t *testing.T) {
 	t.Parallel()
 
 	fake := newFakeDocker(t, "replace-files")
-	result, err := (Runner{Docker: fake.path}).RunDocker(context.Background(), fakeDockerAction(t))
+	result, err := (Runner{Docker: fake.path}).runDockerAction(context.Background(), fakeDockerAction(t))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -728,7 +728,7 @@ func TestRunDockerCancellationCleansOwnedResources(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		_, err := (Runner{Docker: fake.path, CleanupTimeout: 2 * time.Second, InterruptGrace: 50 * time.Millisecond, TerminateGrace: 50 * time.Millisecond}).RunDocker(ctx, fakeDockerAction(t))
+		_, err := (Runner{Docker: fake.path, CleanupTimeout: 2 * time.Second, InterruptGrace: 50 * time.Millisecond, TerminateGrace: 50 * time.Millisecond}).runDockerAction(ctx, fakeDockerAction(t))
 		done <- err
 	}()
 	deadline := time.Now().Add(3 * time.Second)
@@ -745,10 +745,10 @@ func TestRunDockerCancellationCleansOwnedResources(t *testing.T) {
 	select {
 	case err := <-done:
 		if !errors.Is(err, context.Canceled) {
-			t.Fatalf("RunDocker() error = %v, want context cancellation", err)
+			t.Fatalf("runDockerAction() error = %v, want context cancellation", err)
 		}
 	case <-time.After(3 * time.Second):
-		t.Fatal("RunDocker cancellation exceeded bound")
+		t.Fatal("runDockerAction cancellation exceeded bound")
 	}
 	calls := fake.calls(t)
 	for _, command := range [][]string{{"stop"}, {"rm", "--force"}, {"image", "rm", "--force"}, {"ps", "--all"}, {"image", "ls"}} {
@@ -3380,17 +3380,17 @@ func TestDiscoverNodeManagedAndWrongExplicitVersion(t *testing.T) {
 	if err := os.WriteFile(node, []byte("#!/bin/sh\necho v24.99.0\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	got, err := DiscoverNode24("", managed)
+	got, err := discoverNodeContext(context.Background(), 24, "", managed)
 	if err != nil || got != node {
-		t.Fatalf("DiscoverNode24() = %q, %v, want %q, nil", got, err, node)
+		t.Fatalf("discoverNodeContext(24) = %q, %v, want %q, nil", got, err, node)
 	}
 
 	wrong := filepath.Join(t.TempDir(), "node")
 	if err := os.WriteFile(wrong, []byte("#!/bin/sh\necho v23.1.0\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := DiscoverNode24(wrong, ""); err == nil || !strings.Contains(err.Error(), `reported "v23.1.0"`) {
-		t.Fatalf("DiscoverNode24() error = %v, want wrong-version detail", err)
+	if _, err := discoverNodeContext(context.Background(), 24, wrong, ""); err == nil || !strings.Contains(err.Error(), `reported "v23.1.0"`) {
+		t.Fatalf("discoverNodeContext(24) error = %v, want wrong-version detail", err)
 	}
 
 	node20 := filepath.Join(managed, "node", "20", "bin", "node")
@@ -3400,11 +3400,11 @@ func TestDiscoverNodeManagedAndWrongExplicitVersion(t *testing.T) {
 	if err := os.WriteFile(node20, []byte("#!/bin/sh\necho v20.99.0\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if got, err := DiscoverNode(20, "", managed); err != nil || got != node20 {
-		t.Fatalf("DiscoverNode(20) = %q, %v, want %q, nil", got, err, node20)
+	if got, err := discoverNodeContext(context.Background(), 20, "", managed); err != nil || got != node20 {
+		t.Fatalf("discoverNodeContext(20) = %q, %v, want %q, nil", got, err, node20)
 	}
-	if _, err := DiscoverNode(24, node20, ""); err == nil || !strings.Contains(err.Error(), `reported "v20.99.0"`) {
-		t.Fatalf("DiscoverNode(24) error = %v, want exact-major rejection", err)
+	if _, err := discoverNodeContext(context.Background(), 24, node20, ""); err == nil || !strings.Contains(err.Error(), `reported "v20.99.0"`) {
+		t.Fatalf("discoverNodeContext(24) error = %v, want exact-major rejection", err)
 	}
 }
 
@@ -3601,7 +3601,7 @@ func TestJavaScriptPhaseUsesVerifiedMiseNodeWithoutWorkflowRedirection(t *testin
 		t.Fatal(err)
 	}
 	result := newResult()
-	action := JavaScriptAction{Name: "mise", Path: root, Main: "main.js", Env: map[string]string{"MISE_DATA_DIR": "/workflow-controlled"}, nodeMajor: 24}
+	action := javaScriptAction{Name: "mise", Path: root, Main: "main.js", Env: map[string]string{"MISE_DATA_DIR": "/workflow-controlled"}, nodeMajor: 24}
 	if err := runner.runJavaScriptPhase(context.Background(), newCommandProcessor(io.Discard, io.Discard), root, resolvedNode, action, action.Main, nil, nil, &result); err != nil {
 		t.Fatal(err)
 	}
@@ -3650,12 +3650,13 @@ func TestDockerAction(t *testing.T) {
 	docker := requireDocker(t)
 	var logs bytes.Buffer
 	runner := Runner{Stdout: &logs, Stderr: &logs, Docker: docker}
-	result, err := runner.RunDocker(context.Background(), DockerAction{
+	result, err := runner.runDockerAction(context.Background(), dockerAction{
 		Name: "local Docker", Path: fixturePath(t, "actions", "docker"), Workspace: fixturePath(t),
 		Env: map[string]string{"INPUT_EXPECTED_FILE": "smoke/.github/workflows/ci.yml"},
 	})
+
 	if err != nil {
-		t.Fatalf("RunDocker() error = %v", err)
+		t.Fatalf("runDockerAction() error = %v", err)
 	}
 	if result.Outputs["container"] != "ran" || result.Env["DOCKER_RUNTIME_SEEN"] != "true" {
 		t.Errorf("Docker result = %#v", result)
@@ -3715,9 +3716,9 @@ func main() {
 	if err != nil {
 		t.Fatal(err)
 	}
-	result, err := (Runner{Docker: docker}).RunDocker(context.Background(), DockerAction{Name: "non-root Docker", Path: action, Workspace: workspace})
+	result, err := (Runner{Docker: docker}).runDockerAction(context.Background(), dockerAction{Name: "non-root Docker", Path: action, Workspace: workspace})
 	if err != nil {
-		t.Fatalf("RunDocker() error = %v", err)
+		t.Fatalf("runDockerAction() error = %v", err)
 	}
 	if result.Outputs["nonroot"] != "written" {
 		t.Fatalf("Docker result = %#v", result)
@@ -4773,7 +4774,7 @@ func canonicalTempDir(t *testing.T) string {
 func requireNode24(t *testing.T) string {
 	t.Helper()
 	if node := os.Getenv("BUILDKITE_GHA_TEST_NODE24"); node != "" {
-		if _, err := DiscoverNode24(node, ""); err != nil {
+		if _, err := discoverNodeContext(context.Background(), 24, node, ""); err != nil {
 			t.Fatalf("BUILDKITE_GHA_TEST_NODE24 is not Node 24: %v", err)
 		}
 		return node
@@ -4782,7 +4783,7 @@ func requireNode24(t *testing.T) string {
 		output, err := exec.Command(mise, "where", "node@24").CombinedOutput()
 		if err == nil {
 			node := filepath.Join(strings.TrimSpace(string(output)), "bin", "node")
-			if _, err := DiscoverNode24(node, ""); err == nil {
+			if _, err := discoverNodeContext(context.Background(), 24, node, ""); err == nil {
 				return node
 			}
 		}

--- a/internal/transport/boundary.go
+++ b/internal/transport/boundary.go
@@ -96,11 +96,6 @@ func (b *boundedBuffer) Bytes() []byte {
 	return b.buffer.Bytes()
 }
 
-func (a Agent) UploadArtifact(ctx context.Context, path string) error {
-	_, err := a.run(ctx, []string{"artifact", "upload", path}, nil)
-	return err
-}
-
 // UploadArtifactFrom uploads a workspace-relative path rooted at root.
 func (a Agent) UploadArtifactFrom(ctx context.Context, root, path string) error {
 	nativePath := filepath.FromSlash(path)


### PR DESCRIPTION
Pre-1.0 cleanup: removes dead entry points and makes internal-only runtime identifiers private, shrinking the exported surface we have to keep stable without changing behavior.

- Delete `transport.Agent.UploadArtifact` — zero callers; `UploadArtifactFrom` / `UploadArtifacts` are the live paths.
- Delete the exported `DiscoverNode` / `DiscoverNode24` wrappers — production uses the private `discoverNodeContext` path; tests now exercise it directly.
- Unexport `JavaScriptAction`, `DockerAction`, `Runner.RunDocker` (now `runDockerAction`), and `VerifyWorkflow` — all callers are inside `internal/runtime`.

Kept out of scope: the `compiler.CompilePlans*` wrappers have no production callers but are the entry point for ~60 test call sites across `internal/compiler` and `internal/runtime`, so removing them would be a large test rewrite for no behavior benefit.

Validation: `mise run check` passes (format, build, test, race, lint, vet, plan-fixtures, smoke:local, release:check).