### PR TITLE
docs: Update thin plugin guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ steps:
   - label: ":github: Test"
     key: "gha-ci"
     plugins:
-      - github-actions#v0.4.4:
+      - github-actions#main:
           workflow: .github/workflows/ci.yml
 
   - label: ":rocket: Deploy"
@@ -40,7 +40,16 @@ steps:
     command: .buildkite/deploy.sh
 ```
 
-The plugin downloads and verifies the released CLI. Pin a plugin version rather than a floating branch.
+The plugin is a thin wrapper around the hidden `buildkite-gha plugin` entrypoint. It uses mise to install and verify the selected CLI release, and defaults to the latest stable release. During the preview, leaving `version` unset means there is no CLI version to update as new stable releases ship.
+
+To hold the CLI at a specific release instead, set `version` to an exact stable release from `0.8.0` onward:
+
+```yaml
+plugins:
+  - github-actions#main:
+      workflow: .github/workflows/ci.yml
+      version: "0.8.0"
+```
 
 The imported workflow is a dynamic part of the Buildkite pipeline. The native deploy job waits for the importer and every job it uploads. This approach lets you keep an existing workflow while moving jobs to native Buildkite steps over time.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -46,7 +46,7 @@ Command scoping limits accidental spread. It does not stop a hostile concurrent 
 
 ## Operator checklist
 
-1. Pin a released plugin version.
+1. Leave the plugin's CLI `version` unset to follow the latest stable `buildkite-gha` release, or set an exact stable release from `0.8.0` onward when a controlled rollout requires a pin.
 1. Run imported jobs on an isolated queue with no ambient credentials.
 1. Treat public actions as third-party code and prefer immutable commit pins.
 1. Restrict managed repository access and write tokens with Buildkite policy.


### PR DESCRIPTION
## Summary

- replace the stale plugin/runtime version example with the current preview configuration
- document that the plugin delegates to the hidden `buildkite-gha plugin` entrypoint
- make the latest stable CLI the default and exact releases from 0.8.0 onward an optional pin
- align the security checklist with the same release-selection guidance

This documents the behavior introduced by buildkite-plugins/github-actions-buildkite-plugin#28 and should land with or after that plugin change.

## Validation

- `git diff --check`
- confirmed no `v0.4.4`, `v0.4.2`, or old released-plugin pin guidance remains in `README.md` or `docs/`