### PR TITLE
Validate released plugin v0.8.0

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -115,6 +115,7 @@ steps:
 
   - label: ":github: Exact-source plugin smoke"
     key: "plugin-source-smoke-importer"
+    if: build.env("DEMO_SUITE") != "plugin"
     env:
       BUILDKITE_GHA_TARGET_QUEUE: "hosted"
     timeout_in_minutes: 20

--- a/.buildkite/plugin-demo.yml
+++ b/.buildkite/plugin-demo.yml
@@ -8,7 +8,7 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#v0.2.2:
+      - github-actions#v0.8.0:
           workflow: .github/workflows/example-basic.yml
 
   - label: ":package: Artifact released-plugin demo"
@@ -17,7 +17,7 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#v0.2.2:
+      - github-actions#v0.8.0:
           workflow: .github/workflows/example-artifacts.yml
 
   - label: ":javascript: Actions released-plugin demo"
@@ -26,7 +26,7 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#v0.2.2:
+      - github-actions#v0.8.0:
           workflow: .github/workflows/local-actions-oracle.yml
 
   - label: ":rocket: Advanced released-plugin demo"
@@ -35,7 +35,7 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#v0.2.2:
+      - github-actions#v0.8.0:
           workflow: .github/workflows/example-advanced.yml
 
   - label: ":white_check_mark: Service-free plugin demo complete"
@@ -54,7 +54,7 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#v0.2.2:
+      - github-actions#v0.8.0:
           workflow: testdata/plugin-demo/.github/workflows/cache.yml
 
   - label: ":white_check_mark: Cache plugin demo complete"

--- a/docs/development.md
+++ b/docs/development.md
@@ -74,7 +74,7 @@ scripts/verify-artifact-roundtrip <build-number> <commit>
 
 ## Test released and native entry points
 
-Run the examples through the released plugin and its normal release installer:
+Run the examples through the released plugin and its default mise-based runtime resolution:
 
 ```sh
 commit=$(git rev-parse HEAD)
@@ -83,7 +83,7 @@ bk build create --pipeline buildkite/buildkite-gha \
   --env DEMO_SUITE=plugin --env DEMO_COMMIT="$commit" --yes
 ```
 
-Add `--env DEMO_CACHE=1` to include the optional cache producer and consumer workflow. The plugin must download and checksum-verify its public CLI release. The demo must not fall back to a local binary.
+Add `--env DEMO_CACHE=1` to include the optional cache producer and consumer workflow. Mise must download and verify the public CLI release. The demo must not fall back to a local binary.
 
 For a side-by-side GitHub Actions and Buildkite UX check, run:
 

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -485,6 +485,9 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 	if strings.Contains(pluginDemo.command, "BUILDKITE_GHA_CACHE_URL") {
 		t.Fatalf("released plugin demo loader still requires a cache Results URL:\n%s", pluginDemo.command)
 	}
+	if got := steps["plugin-source-smoke-importer"]; got.condition != `build.env("DEMO_SUITE") != "plugin"` {
+		t.Fatalf("exact-source plugin smoke = %#v", got)
+	}
 	if got := steps["publish-release"]; got.command != "mise exec -- scripts/ci-buildkite-release" || got.condition != "build.tag != null" {
 		t.Fatalf("release publisher = %#v", got)
 	}

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -846,7 +846,7 @@ func TestProductionPluginDemoContract(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	const plugin = "github-actions#v0.2.2"
+	const plugin = "github-actions#v0.8.0"
 	type pluginConfig struct {
 		Workflow string `yaml:"workflow"`
 		Version  string `yaml:"version"`


### PR DESCRIPTION
## Why

The released-plugin demo still exercised github-actions v0.2.2, while v0.8.0 now resolves the latest buildkite-gha release through mise by default.

## What

- Run every released-plugin demo importer against github-actions v0.8.0 without an exact buildkite-gha version pin.
- Keep the demo contract test and development guide aligned with mise-based runtime resolution.
- Run the exact-source smoke outside explicit released-plugin demo builds so their identical generated job keys cannot collide; normal builds retain the exact-source smoke.