### PR TITLE
Move processing-report semantics into compatibility

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -941,7 +941,7 @@ func validate(args []string, stdout, stderr io.Writer, version string) int {
 	if profile != "" {
 		_, _, distributionDigest, executableErr := executable()
 		if executableErr != nil {
-			addEnvironmentFailure(&processingReport, "compiler executable could not be inspected")
+			processingReport.AddEnvironmentFailure("compiler executable could not be inspected")
 			processingReport.Result = "indeterminate"
 			_ = out.write(processingReport)
 			return 1
@@ -959,11 +959,11 @@ func validate(args []string, stdout, stderr io.Writer, version string) int {
 			_ = out.write(processingReport)
 			return 1
 		}
-		processingReport.SetStage(stageAdmission, compatibility.Passed)
+		processingReport.SetStage(string(compiler.StageAdmission), compatibility.Passed)
 		processingReport.Admission.Result = "admitted"
 		if preflight.HasActions {
 			processingReport.Diagnostics = append(processingReport.Diagnostics, compatibility.Diagnostic{
-				Level: "warning", Code: "W_ACTION_RUNTIME_UNKNOWN", Category: "compatibility", Stage: stageAdmission,
+				Level: "warning", Code: "W_ACTION_RUNTIME_UNKNOWN", Category: "compatibility", Stage: string(compiler.StageAdmission),
 				Message: "resolved action metadata cannot prove that arbitrary action code is independent of GitHub-only runtime services",
 			})
 		}
@@ -1051,19 +1051,19 @@ func compile(args []string, stdout, stderr io.Writer, version string) int {
 	} else {
 		digest, digestErr := executableDigest()
 		if digestErr != nil {
-			addEnvironmentFailure(&processingReport, "compiler executable could not be inspected")
+			processingReport.AddEnvironmentFailure("compiler executable could not be inspected")
 			processingReport.Result = "indeterminate"
 			_ = out.write(processingReport)
 			return 1
 		}
 		bundle, compileErr := compiler.CompileBundle(workflowPath, source, event, version, digest, "gha-importer")
-		applyProcessingEvidence(&processingReport, bundle.Processing)
+		processingReport.ApplyEvidence(bundle.Processing)
 		err = compileErr
 		result = bundle.Pipeline
 		warnings = bundle.IR.Warnings
 	}
 	if err != nil {
-		addProcessingFailure(&processingReport, workflowPath, stagePlans, compiler.CodePlanConstruction, "compatibility", err)
+		processingReport.AddFailure(workflowPath, string(compiler.StagePlans), compiler.CodePlanConstruction, "compatibility", err)
 		processingReport.Result = "incompatible"
 		_ = out.write(processingReport)
 		return 1
@@ -1132,7 +1132,7 @@ func upload(args []string, stdout, stderr io.Writer, version string, agent trans
 	}
 	executablePath, executableContents, distributionDigest, err := executable()
 	if err != nil {
-		addEnvironmentFailure(&processingReport, "compiler executable could not be inspected")
+		processingReport.AddEnvironmentFailure("compiler executable could not be inspected")
 		processingReport.Result = "indeterminate"
 		_ = out.write(processingReport)
 		return 1
@@ -1145,7 +1145,7 @@ func upload(args []string, stdout, stderr io.Writer, version string, agent trans
 		return 1
 	}
 	bundle := preflight.Bundle
-	processingReport.SetStage(stageAdmission, compatibility.Passed)
+	processingReport.SetStage(string(compiler.StageAdmission), compatibility.Passed)
 	processingReport.Admission.Result = "admitted"
 	processingReport.Result = "admitted"
 	_ = compatibility.WriteProcessing(stdout, "text", processingReport)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -37,6 +37,16 @@ const (
 	cliTestProducerJobID = "33333333-3333-4333-8333-333333333333"
 )
 
+// Stable stage IDs asserted throughout the report expectations below.
+const (
+	stageWorkflowParsing = string(compiler.StageWorkflowParsing)
+	stageEventValidation = string(compiler.StageEventValidation)
+	stageGraph           = string(compiler.StageGraph)
+	stageMatrix          = string(compiler.StageMatrix)
+	stageExpressions     = string(compiler.StageExpressions)
+	stageResolution      = string(compiler.StageResolution)
+)
+
 func TestRunHelpAndVersion(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -5,9 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"regexp"
-	"strconv"
-	"strings"
 
 	"github.com/buildkite/buildkite-gha/internal/compatibility"
 	"github.com/buildkite/buildkite-gha/internal/compiler"
@@ -44,7 +41,7 @@ func (o processingOutput) fail(report compatibility.ProcessingReport, err error)
 func loadProcessingInputs(out processingOutput, workflowPath, profile, eventFailureMessage string, loadEvent func() ([]byte, error)) (source, event []byte, ok bool) {
 	source, err := os.ReadFile(workflowPath)
 	if err != nil {
-		out.fail(environmentProcessingReport(workflowPath, profile, "workflow input could not be read"), err)
+		out.fail(compatibility.EnvironmentProcessingReport(workflowPath, profile, "workflow input could not be read"), err)
 		return nil, nil, false
 	}
 	if loadEvent == nil {
@@ -52,7 +49,7 @@ func loadProcessingInputs(out processingOutput, workflowPath, profile, eventFail
 	}
 	event, err = loadEvent()
 	if err != nil {
-		out.fail(eventInputProcessingReport(workflowPath, profile, source, eventFailureMessage), err)
+		out.fail(compatibility.EventInputProcessingReport(workflowPath, profile, source, eventFailureMessage), err)
 		return nil, nil, false
 	}
 	return source, event, true
@@ -69,7 +66,7 @@ func validatedProcessingReport(out processingOutput, workflowPath, profile strin
 	} else {
 		validation, err = compiler.Validate(workflowPath, source)
 	}
-	report := initialProcessingReport(workflowPath, profile, eventEvaluated, validation, err)
+	report := compatibility.InitialProcessingReport(workflowPath, profile, eventEvaluated, validation, err)
 	if err != nil {
 		report.Result = "incompatible"
 		_ = out.write(report)
@@ -81,9 +78,9 @@ func validatedProcessingReport(out processingOutput, workflowPath, profile strin
 // applyHostedPreflight folds hosted preflight evidence and any admission
 // grant into the report.
 func applyHostedPreflight(report *compatibility.ProcessingReport, preflight hostedTokenlessCompilation) {
-	applyProcessingEvidence(report, preflight.Bundle.Processing)
+	report.ApplyEvidence(preflight.Bundle.Processing)
 	if preflight.Admitted {
-		report.SetStage(stageAdmission, compatibility.Passed)
+		report.SetStage(string(compiler.StageAdmission), compatibility.Passed)
 		report.Admission.Result = "admitted"
 	}
 }
@@ -93,334 +90,14 @@ func applyHostedPreflight(report *compatibility.ProcessingReport, preflight host
 func classifyHostedTokenlessFailure(report *compatibility.ProcessingReport, workflowPath string, err error) string {
 	var failure *hostedTokenlessFailure
 	if errors.As(err, &failure) && failure.Kind == hostedTokenlessAdmissionFailure {
-		addProcessingFailure(report, workflowPath, stageAdmission, "E_PROFILE", "admission", err)
+		report.AddFailure(workflowPath, string(compiler.StageAdmission), "E_PROFILE", "admission", err)
 		report.Admission.Result = "not-admitted"
 		return "not-admitted"
 	}
 	if errors.As(err, &failure) && failure.Kind == hostedTokenlessEnvironmentFailure {
-		addEnvironmentFailure(report, "hosted workflow-processing environment could not be initialized")
+		report.AddEnvironmentFailure("hosted workflow-processing environment could not be initialized")
 	} else {
-		addProcessingFailure(report, workflowPath, stageResolution, compiler.CodeActionResolution, "action-resolution", err)
+		report.AddFailure(workflowPath, string(compiler.StageResolution), compiler.CodeActionResolution, "action-resolution", err)
 	}
 	return "indeterminate"
-}
-
-const (
-	stageWorkflowParsing = string(compiler.StageWorkflowParsing)
-	stageEventValidation = string(compiler.StageEventValidation)
-	stageGraph           = string(compiler.StageGraph)
-	stageMatrix          = string(compiler.StageMatrix)
-	stageExpressions     = string(compiler.StageExpressions)
-	stageDiscovery       = string(compiler.StageDiscovery)
-	stageResolution      = string(compiler.StageResolution)
-	stagePlans           = string(compiler.StagePlans)
-	stageAdmission       = string(compiler.StageAdmission)
-	stagePipeline        = string(compiler.StagePipeline)
-)
-
-var locatedDiagnosticPattern = regexp.MustCompile(`^(.+):(\d+):(\d+): (.*)$`)
-
-func initialProcessingReport(path, profile string, eventEvaluated bool, report compiler.Report, processingErr error) compatibility.ProcessingReport {
-	out := compatibility.NewProcessingReport(path, profile)
-	out.LogicalJobs = report.LogicalJobs
-	out.Instances = report.Instances
-	out.Compile = compatibility.Stage{Result: "compilable", LogicalJobs: report.LogicalJobs, Instances: report.Instances}
-	out.Admission = compatibility.Stage{Result: compatibility.NotEvaluated}
-	for _, job := range report.ParsedJobs {
-		result := compatibility.Passed
-		if report.NotEvaluatedJobs[job.ID] {
-			result = compatibility.NotEvaluated
-		}
-		out.Jobs = append(out.Jobs, compatibility.JobResult{
-			ID: job.ID, Result: result,
-			Location: sourceLocation(job.Path, job.Source.Start.Line, job.Source.Start.Column),
-		})
-	}
-	for _, instance := range report.Jobs {
-		result := compatibility.Passed
-		if report.NotEvaluatedInstances[instance.Key] {
-			result = compatibility.NotEvaluated
-		}
-		out.Jobs = append(out.Jobs, compatibility.JobResult{
-			ID: instance.LogicalJobID, Instance: instance.Key, Result: result,
-			Location: sourceLocation(instance.SourcePath, instance.Source.Start.Line, instance.Source.Start.Column),
-		})
-		for i, step := range instance.Steps {
-			if step.Uses == "" {
-				continue
-			}
-			out.Actions = append(out.Actions, compatibility.ActionResult{
-				Reference: step.Uses, Job: instance.Key, Step: i + 1,
-				Result:   compatibility.NotEvaluated,
-				Location: sourceLocation(instance.SourcePath, step.Span.Start.Line, step.Span.Start.Column),
-			})
-		}
-	}
-
-	if processingErr == nil {
-		out.SetStage(stageWorkflowParsing, compatibility.Passed)
-		if eventEvaluated {
-			out.SetStage(stageEventValidation, compatibility.Passed)
-		}
-		out.SetStage(stageGraph, compatibility.Passed)
-		out.SetStage(stageMatrix, compatibility.Passed)
-		out.SetStage(stageExpressions, compatibility.Passed)
-		out.SetStage(stageDiscovery, compatibility.Passed)
-		if len(out.Actions) == 0 {
-			out.SetStage(stageResolution, compatibility.Passed)
-		}
-	} else {
-		out.Compile.Result = "incompatible"
-		failed := map[string]bool{}
-		for _, err := range flattenErrors(processingErr) {
-			stage, code, category := processingErrorDetails(err, stageGraph, compiler.CodeGraphInvalid, "compatibility")
-			failed[stage] = true
-			out.Diagnostics = append(out.Diagnostics, diagnosticFromError(path, stage, code, category, err))
-		}
-		markFailedJobs(&out)
-		setInitialStageResults(&out, eventEvaluated, failed)
-	}
-	for _, warning := range report.Warnings {
-		out.Diagnostics = append(out.Diagnostics, compatibility.Diagnostic{
-			Level: "warning", Code: warning.Code, Category: "compatibility", Stage: stageExpressions,
-			Message: fmt.Sprintf("%s:%d:%d: %s", path, warning.Line, warning.Column, warning.Message), Location: sourceLocation(path, warning.Line, warning.Column),
-		})
-	}
-	return out
-}
-
-func setInitialStageResults(report *compatibility.ProcessingReport, eventEvaluated bool, failed map[string]bool) {
-	workflowFailed := failed[stageWorkflowParsing]
-	if workflowFailed {
-		report.SetStage(stageWorkflowParsing, compatibility.Failed)
-	} else {
-		report.SetStage(stageWorkflowParsing, compatibility.Passed)
-	}
-	eventFailed := false
-	if eventEvaluated {
-		eventFailed = failed[stageEventValidation]
-		if eventFailed {
-			report.SetStage(stageEventValidation, compatibility.Failed)
-		} else {
-			report.SetStage(stageEventValidation, compatibility.Passed)
-		}
-	}
-	blocked := workflowFailed || eventFailed || failed[""]
-	for _, stage := range []string{stageGraph, stageMatrix, stageExpressions, stageDiscovery} {
-		if failed[stage] {
-			report.SetStage(stage, compatibility.Failed)
-			blocked = true
-			continue
-		}
-		if !blocked {
-			report.SetStage(stage, compatibility.Passed)
-		}
-	}
-}
-
-func addProcessingFailure(report *compatibility.ProcessingReport, path, stage, code, category string, err error) {
-	for _, item := range flattenErrors(err) {
-		itemStage, itemCode, itemCategory := processingErrorDetails(item, stage, code, category)
-		report.SetStage(itemStage, compatibility.Failed)
-		diagnostic := diagnosticFromError(path, itemStage, itemCode, itemCategory, item)
-		report.Diagnostics = append(report.Diagnostics, diagnostic)
-	}
-	markFailedJobs(report)
-}
-
-func addEnvironmentFailure(report *compatibility.ProcessingReport, message string) {
-	report.Diagnostics = append(report.Diagnostics, compatibility.Diagnostic{
-		Level: "error", Code: "E_ENVIRONMENT", Category: "environment", Message: message,
-	})
-}
-
-func environmentProcessingReport(path, profile, message string) compatibility.ProcessingReport {
-	report := compatibility.NewProcessingReport(path, profile)
-	report.Result = "indeterminate"
-	addEnvironmentFailure(&report, message)
-	return report
-}
-
-func eventInputProcessingReport(path, profile string, source []byte, message string) compatibility.ProcessingReport {
-	parsed, parseErr := compiler.ParseWorkflow(path, source)
-	report := compatibility.NewProcessingReport(path, profile)
-	report.LogicalJobs = parsed.LogicalJobs
-	for _, job := range parsed.ParsedJobs {
-		report.Jobs = append(report.Jobs, compatibility.JobResult{
-			ID: job.ID, Result: compatibility.NotEvaluated,
-			Location: sourceLocation(job.Path, job.Source.Start.Line, job.Source.Start.Column),
-		})
-	}
-	if parseErr != nil {
-		addProcessingFailure(&report, path, stageWorkflowParsing, compiler.CodeWorkflowSyntax, "syntax", parseErr)
-	} else {
-		report.SetStage(stageWorkflowParsing, compatibility.Passed)
-	}
-	report.Result = "indeterminate"
-	addEnvironmentFailure(&report, message)
-	return report
-}
-
-func markFailedJobs(report *compatibility.ProcessingReport) {
-	failed := map[string]bool{}
-	for _, diagnostic := range report.Diagnostics {
-		if diagnostic.Level == "error" && diagnostic.Job != "" {
-			failed[diagnostic.Job] = true
-		}
-	}
-	for i := range report.Jobs {
-		if report.Jobs[i].Instance == "" && failed[report.Jobs[i].ID] {
-			report.Jobs[i].Result = compatibility.Failed
-		}
-		for _, diagnostic := range report.Diagnostics {
-			if diagnostic.Level != "error" || diagnostic.Stage == stageResolution || report.Jobs[i].Instance == "" {
-				continue
-			}
-			if diagnostic.Instance == report.Jobs[i].Instance || (diagnostic.Instance == "" && diagnostic.Job == report.Jobs[i].ID) {
-				report.Jobs[i].Result = compatibility.Failed
-			}
-		}
-	}
-}
-
-func applyProcessingEvidence(report *compatibility.ProcessingReport, evidence compiler.ProcessingEvidence) {
-	resolutionFailed := false
-	for _, evaluation := range evidence.Actions {
-		if !evaluation.Passed {
-			resolutionFailed = true
-		}
-		for i := range report.Actions {
-			if report.Actions[i].Job != evaluation.Instance || report.Actions[i].Step != evaluation.Step || report.Actions[i].Reference != evaluation.Reference {
-				continue
-			}
-			if evaluation.Passed {
-				report.Actions[i].Result = compatibility.Passed
-			} else {
-				report.Actions[i].Result = compatibility.Failed
-			}
-		}
-	}
-	if resolutionFailed {
-		report.SetStage(stageResolution, compatibility.Failed)
-	} else if evidence.ActionResolutionComplete {
-		report.SetStage(stageResolution, compatibility.Passed)
-	}
-	for _, evaluation := range evidence.Plans {
-		for i := range report.Jobs {
-			if report.Jobs[i].Instance != evaluation.Instance || evaluation.Instance == "" {
-				continue
-			}
-			switch {
-			case !evaluation.Evaluated:
-				report.Jobs[i].Result = compatibility.NotEvaluated
-			case evaluation.Passed:
-				report.Jobs[i].Result = compatibility.Passed
-			default:
-				report.Jobs[i].Result = compatibility.Failed
-			}
-		}
-	}
-	if evidence.PlansConstructed {
-		report.SetStage(stagePlans, compatibility.Passed)
-	}
-	if evidence.PipelineGenerated {
-		report.SetStage(stagePipeline, compatibility.Passed)
-	}
-}
-
-func flattenErrors(err error) []error {
-	if err == nil {
-		return nil
-	}
-	if _, ok := err.(*compiler.ProcessingFinding); ok {
-		return []error{err}
-	}
-	if joined, ok := err.(interface{ Unwrap() []error }); ok {
-		var out []error
-		for _, child := range joined.Unwrap() {
-			out = append(out, flattenErrors(child)...)
-		}
-		return out
-	}
-	if wrapped, ok := err.(interface{ Unwrap() error }); ok {
-		nested := flattenErrors(wrapped.Unwrap())
-		for _, item := range nested {
-			if _, structured := item.(*compiler.ProcessingFinding); structured {
-				return nested
-			}
-		}
-	}
-	return []error{err}
-}
-
-func processingErrorDetails(err error, fallbackStage, fallbackCode, fallbackCategory string) (stage, code, category string) {
-	if finding, ok := err.(*compiler.ProcessingFinding); ok {
-		return string(finding.Stage), finding.Code, finding.Category
-	}
-	return fallbackStage, fallbackCode, fallbackCategory
-}
-
-func diagnosticFromError(defaultPath, stage, code, category string, err error) compatibility.Diagnostic {
-	message := err.Error()
-	location := (*compatibility.SourceLocation)(nil)
-	var finding *compiler.ProcessingFinding
-	if structured, ok := err.(*compiler.ProcessingFinding); ok {
-		finding = structured
-		if finding.Message != "" {
-			message = finding.Message
-		}
-		if finding.Path != "" {
-			location = sourceLocation(finding.Path, finding.Line, finding.Column)
-		}
-	}
-	if finding == nil || finding.Message == "" {
-		if match := locatedDiagnosticPattern.FindStringSubmatch(message); match != nil {
-			line, lineErr := strconv.Atoi(match[2])
-			column, columnErr := strconv.Atoi(match[3])
-			if lineErr == nil && columnErr == nil {
-				location = sourceLocation(match[1], line, column)
-				message = match[4]
-			}
-		}
-	}
-	diagnostic := compatibility.Diagnostic{
-		Level: "error", Code: code, Category: category, Stage: stage,
-		Message: message, Location: location,
-	}
-	if finding != nil {
-		diagnostic.Job = finding.Job
-		diagnostic.Instance = finding.Instance
-		diagnostic.Action = finding.Action
-		diagnostic.Step = finding.Step
-	}
-	if diagnostic.Location == nil && defaultPath != "" && stage != "" && stage != stageEventValidation {
-		diagnostic.Location = sourceLocation(defaultPath, 1, 1)
-	}
-	if diagnostic.Job == "" {
-		if start := strings.Index(message, `job "`); start >= 0 {
-			rest := message[start+len(`job "`):]
-			if end := strings.Index(rest, `"`); end >= 0 {
-				diagnostic.Job = rest[:end]
-			}
-		}
-	}
-	if diagnostic.Action == "" {
-		if start := strings.Index(message, `action "`); start >= 0 {
-			rest := message[start+len(`action "`):]
-			if end := strings.Index(rest, `"`); end >= 0 {
-				diagnostic.Action = rest[:end]
-			}
-		}
-	}
-	return diagnostic
-}
-
-func sourceLocation(path string, line, column int) *compatibility.SourceLocation {
-	if line <= 0 {
-		line = 1
-	}
-	if column <= 0 {
-		column = 1
-	}
-	return &compatibility.SourceLocation{Path: path, Line: line, Column: column}
 }

--- a/internal/compatibility/processing_compiler.go
+++ b/internal/compatibility/processing_compiler.go
@@ -1,0 +1,342 @@
+package compatibility
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/buildkite/buildkite-gha/internal/compiler"
+)
+
+const (
+	stageWorkflowParsing = string(compiler.StageWorkflowParsing)
+	stageEventValidation = string(compiler.StageEventValidation)
+	stageGraph           = string(compiler.StageGraph)
+	stageMatrix          = string(compiler.StageMatrix)
+	stageExpressions     = string(compiler.StageExpressions)
+	stageDiscovery       = string(compiler.StageDiscovery)
+	stageResolution      = string(compiler.StageResolution)
+	stagePlans           = string(compiler.StagePlans)
+	stagePipeline        = string(compiler.StagePipeline)
+)
+
+var locatedDiagnosticPattern = regexp.MustCompile(`^(.+):(\d+):(\d+): (.*)$`)
+
+// InitialProcessingReport starts a processing report from a compiler
+// validation outcome, recording stage results, discovered jobs and actions,
+// diagnostics, and warnings.
+func InitialProcessingReport(path, profile string, eventEvaluated bool, report compiler.Report, processingErr error) ProcessingReport {
+	out := NewProcessingReport(path, profile)
+	out.LogicalJobs = report.LogicalJobs
+	out.Instances = report.Instances
+	out.Compile = Stage{Result: "compilable", LogicalJobs: report.LogicalJobs, Instances: report.Instances}
+	out.Admission = Stage{Result: NotEvaluated}
+	for _, job := range report.ParsedJobs {
+		result := Passed
+		if report.NotEvaluatedJobs[job.ID] {
+			result = NotEvaluated
+		}
+		out.Jobs = append(out.Jobs, JobResult{
+			ID: job.ID, Result: result,
+			Location: sourceLocation(job.Path, job.Source.Start.Line, job.Source.Start.Column),
+		})
+	}
+	for _, instance := range report.Jobs {
+		result := Passed
+		if report.NotEvaluatedInstances[instance.Key] {
+			result = NotEvaluated
+		}
+		out.Jobs = append(out.Jobs, JobResult{
+			ID: instance.LogicalJobID, Instance: instance.Key, Result: result,
+			Location: sourceLocation(instance.SourcePath, instance.Source.Start.Line, instance.Source.Start.Column),
+		})
+		for i, step := range instance.Steps {
+			if step.Uses == "" {
+				continue
+			}
+			out.Actions = append(out.Actions, ActionResult{
+				Reference: step.Uses, Job: instance.Key, Step: i + 1,
+				Result:   NotEvaluated,
+				Location: sourceLocation(instance.SourcePath, step.Span.Start.Line, step.Span.Start.Column),
+			})
+		}
+	}
+
+	if processingErr == nil {
+		out.SetStage(stageWorkflowParsing, Passed)
+		if eventEvaluated {
+			out.SetStage(stageEventValidation, Passed)
+		}
+		out.SetStage(stageGraph, Passed)
+		out.SetStage(stageMatrix, Passed)
+		out.SetStage(stageExpressions, Passed)
+		out.SetStage(stageDiscovery, Passed)
+		if len(out.Actions) == 0 {
+			out.SetStage(stageResolution, Passed)
+		}
+	} else {
+		out.Compile.Result = "incompatible"
+		failed := map[string]bool{}
+		for _, err := range flattenErrors(processingErr) {
+			stage, code, category := processingErrorDetails(err, stageGraph, compiler.CodeGraphInvalid, "compatibility")
+			failed[stage] = true
+			out.Diagnostics = append(out.Diagnostics, diagnosticFromError(path, stage, code, category, err))
+		}
+		markFailedJobs(&out)
+		setInitialStageResults(&out, eventEvaluated, failed)
+	}
+	for _, warning := range report.Warnings {
+		out.Diagnostics = append(out.Diagnostics, Diagnostic{
+			Level: "warning", Code: warning.Code, Category: "compatibility", Stage: stageExpressions,
+			Message: fmt.Sprintf("%s:%d:%d: %s", path, warning.Line, warning.Column, warning.Message), Location: sourceLocation(path, warning.Line, warning.Column),
+		})
+	}
+	return out
+}
+
+func setInitialStageResults(report *ProcessingReport, eventEvaluated bool, failed map[string]bool) {
+	workflowFailed := failed[stageWorkflowParsing]
+	if workflowFailed {
+		report.SetStage(stageWorkflowParsing, Failed)
+	} else {
+		report.SetStage(stageWorkflowParsing, Passed)
+	}
+	eventFailed := false
+	if eventEvaluated {
+		eventFailed = failed[stageEventValidation]
+		if eventFailed {
+			report.SetStage(stageEventValidation, Failed)
+		} else {
+			report.SetStage(stageEventValidation, Passed)
+		}
+	}
+	blocked := workflowFailed || eventFailed || failed[""]
+	for _, stage := range []string{stageGraph, stageMatrix, stageExpressions, stageDiscovery} {
+		if failed[stage] {
+			report.SetStage(stage, Failed)
+			blocked = true
+			continue
+		}
+		if !blocked {
+			report.SetStage(stage, Passed)
+		}
+	}
+}
+
+// AddFailure records every finding in err as a failed-stage diagnostic and
+// marks the jobs those findings implicate.
+func (r *ProcessingReport) AddFailure(path, stage, code, category string, err error) {
+	for _, item := range flattenErrors(err) {
+		itemStage, itemCode, itemCategory := processingErrorDetails(item, stage, code, category)
+		r.SetStage(itemStage, Failed)
+		diagnostic := diagnosticFromError(path, itemStage, itemCode, itemCategory, item)
+		r.Diagnostics = append(r.Diagnostics, diagnostic)
+	}
+	markFailedJobs(r)
+}
+
+// AddEnvironmentFailure records a failure of the processing environment
+// rather than of the workflow under evaluation.
+func (r *ProcessingReport) AddEnvironmentFailure(message string) {
+	r.Diagnostics = append(r.Diagnostics, Diagnostic{
+		Level: "error", Code: "E_ENVIRONMENT", Category: "environment", Message: message,
+	})
+}
+
+// EnvironmentProcessingReport reports that processing could not start because
+// the environment failed before the workflow was read.
+func EnvironmentProcessingReport(path, profile, message string) ProcessingReport {
+	report := NewProcessingReport(path, profile)
+	report.Result = "indeterminate"
+	report.AddEnvironmentFailure(message)
+	return report
+}
+
+// EventInputProcessingReport reports that the event input could not be
+// acquired, retaining whatever the workflow source alone can prove.
+func EventInputProcessingReport(path, profile string, source []byte, message string) ProcessingReport {
+	parsed, parseErr := compiler.ParseWorkflow(path, source)
+	report := NewProcessingReport(path, profile)
+	report.LogicalJobs = parsed.LogicalJobs
+	for _, job := range parsed.ParsedJobs {
+		report.Jobs = append(report.Jobs, JobResult{
+			ID: job.ID, Result: NotEvaluated,
+			Location: sourceLocation(job.Path, job.Source.Start.Line, job.Source.Start.Column),
+		})
+	}
+	if parseErr != nil {
+		report.AddFailure(path, stageWorkflowParsing, compiler.CodeWorkflowSyntax, "syntax", parseErr)
+	} else {
+		report.SetStage(stageWorkflowParsing, Passed)
+	}
+	report.Result = "indeterminate"
+	report.AddEnvironmentFailure(message)
+	return report
+}
+
+func markFailedJobs(report *ProcessingReport) {
+	failed := map[string]bool{}
+	for _, diagnostic := range report.Diagnostics {
+		if diagnostic.Level == "error" && diagnostic.Job != "" {
+			failed[diagnostic.Job] = true
+		}
+	}
+	for i := range report.Jobs {
+		if report.Jobs[i].Instance == "" && failed[report.Jobs[i].ID] {
+			report.Jobs[i].Result = Failed
+		}
+		for _, diagnostic := range report.Diagnostics {
+			if diagnostic.Level != "error" || diagnostic.Stage == stageResolution || report.Jobs[i].Instance == "" {
+				continue
+			}
+			if diagnostic.Instance == report.Jobs[i].Instance || (diagnostic.Instance == "" && diagnostic.Job == report.Jobs[i].ID) {
+				report.Jobs[i].Result = Failed
+			}
+		}
+	}
+}
+
+// ApplyEvidence folds compiler processing evidence into action, job, and
+// stage results.
+func (r *ProcessingReport) ApplyEvidence(evidence compiler.ProcessingEvidence) {
+	resolutionFailed := false
+	for _, evaluation := range evidence.Actions {
+		if !evaluation.Passed {
+			resolutionFailed = true
+		}
+		for i := range r.Actions {
+			if r.Actions[i].Job != evaluation.Instance || r.Actions[i].Step != evaluation.Step || r.Actions[i].Reference != evaluation.Reference {
+				continue
+			}
+			if evaluation.Passed {
+				r.Actions[i].Result = Passed
+			} else {
+				r.Actions[i].Result = Failed
+			}
+		}
+	}
+	if resolutionFailed {
+		r.SetStage(stageResolution, Failed)
+	} else if evidence.ActionResolutionComplete {
+		r.SetStage(stageResolution, Passed)
+	}
+	for _, evaluation := range evidence.Plans {
+		for i := range r.Jobs {
+			if r.Jobs[i].Instance != evaluation.Instance || evaluation.Instance == "" {
+				continue
+			}
+			switch {
+			case !evaluation.Evaluated:
+				r.Jobs[i].Result = NotEvaluated
+			case evaluation.Passed:
+				r.Jobs[i].Result = Passed
+			default:
+				r.Jobs[i].Result = Failed
+			}
+		}
+	}
+	if evidence.PlansConstructed {
+		r.SetStage(stagePlans, Passed)
+	}
+	if evidence.PipelineGenerated {
+		r.SetStage(stagePipeline, Passed)
+	}
+}
+
+func flattenErrors(err error) []error {
+	if err == nil {
+		return nil
+	}
+	if _, ok := err.(*compiler.ProcessingFinding); ok {
+		return []error{err}
+	}
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		var out []error
+		for _, child := range joined.Unwrap() {
+			out = append(out, flattenErrors(child)...)
+		}
+		return out
+	}
+	if wrapped, ok := err.(interface{ Unwrap() error }); ok {
+		nested := flattenErrors(wrapped.Unwrap())
+		for _, item := range nested {
+			if _, structured := item.(*compiler.ProcessingFinding); structured {
+				return nested
+			}
+		}
+	}
+	return []error{err}
+}
+
+func processingErrorDetails(err error, fallbackStage, fallbackCode, fallbackCategory string) (stage, code, category string) {
+	if finding, ok := err.(*compiler.ProcessingFinding); ok {
+		return string(finding.Stage), finding.Code, finding.Category
+	}
+	return fallbackStage, fallbackCode, fallbackCategory
+}
+
+func diagnosticFromError(defaultPath, stage, code, category string, err error) Diagnostic {
+	message := err.Error()
+	location := (*SourceLocation)(nil)
+	var finding *compiler.ProcessingFinding
+	if structured, ok := err.(*compiler.ProcessingFinding); ok {
+		finding = structured
+		if finding.Message != "" {
+			message = finding.Message
+		}
+		if finding.Path != "" {
+			location = sourceLocation(finding.Path, finding.Line, finding.Column)
+		}
+	}
+	if finding == nil || finding.Message == "" {
+		if match := locatedDiagnosticPattern.FindStringSubmatch(message); match != nil {
+			line, lineErr := strconv.Atoi(match[2])
+			column, columnErr := strconv.Atoi(match[3])
+			if lineErr == nil && columnErr == nil {
+				location = sourceLocation(match[1], line, column)
+				message = match[4]
+			}
+		}
+	}
+	diagnostic := Diagnostic{
+		Level: "error", Code: code, Category: category, Stage: stage,
+		Message: message, Location: location,
+	}
+	if finding != nil {
+		diagnostic.Job = finding.Job
+		diagnostic.Instance = finding.Instance
+		diagnostic.Action = finding.Action
+		diagnostic.Step = finding.Step
+	}
+	if diagnostic.Location == nil && defaultPath != "" && stage != "" && stage != stageEventValidation {
+		diagnostic.Location = sourceLocation(defaultPath, 1, 1)
+	}
+	if diagnostic.Job == "" {
+		if start := strings.Index(message, `job "`); start >= 0 {
+			rest := message[start+len(`job "`):]
+			if end := strings.Index(rest, `"`); end >= 0 {
+				diagnostic.Job = rest[:end]
+			}
+		}
+	}
+	if diagnostic.Action == "" {
+		if start := strings.Index(message, `action "`); start >= 0 {
+			rest := message[start+len(`action "`):]
+			if end := strings.Index(rest, `"`); end >= 0 {
+				diagnostic.Action = rest[:end]
+			}
+		}
+	}
+	return diagnostic
+}
+
+func sourceLocation(path string, line, column int) *SourceLocation {
+	if line <= 0 {
+		line = 1
+	}
+	if column <= 0 {
+		column = 1
+	}
+	return &SourceLocation{Path: path, Line: line, Column: column}
+}


### PR DESCRIPTION
Second slice of concentrating processing-report construction (follows #136).

The processing-report schema lives in `internal/compatibility` (checked against `schemas/processing-report-v1.schema.json`), but the semantics that populate it — stage transitions, diagnostic extraction from compiler findings, job/action result marking, evidence folding — lived in `internal/cli`. Report bugs therefore straddled two packages; the feature needed seven consecutive fix commits.

This moves that construction logic into `internal/compatibility/processing_compiler.go` (`compatibility` now imports `compiler`; no cycle, `compiler` does not import `compatibility`):

- `InitialProcessingReport`, `EnvironmentProcessingReport`, `EventInputProcessingReport` constructors
- `AddFailure`, `AddEnvironmentFailure`, `ApplyEvidence` methods on `ProcessingReport`
- private helpers (error flattening, diagnostic extraction, stage bookkeeping) move along and stay private

`internal/cli/processing_report.go` shrinks from 426 to 105 lines and now contains only command-facing IO adapters. The CLI-side stage-alias constants are gone; `cli.go` uses `string(compiler.Stage…)` at its three remaining sites and the test file keeps a local alias block for its report assertions.

Pure code motion plus renames; no behavior change. Validation: `mise run check` passes.