### PR TITLE
Remove legacy CompilePlans wrappers from the compiler

### DIFF
--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -421,7 +421,7 @@ runs:
 		if err := os.WriteFile(workflowPath, []byte(workflow), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		return CompilePlansWithOptions(workflowPath, []byte(workflow), pushEvent(t), "0.0.0-test", testDistributionDigest, defaultOptions())
+		return compilePlansForTest(context.Background(), workflowPath, []byte(workflow), pushEvent(t), "0.0.0-test", testDistributionDigest, defaultOptions())
 	}
 
 	effectiveWorkflow := `on: push
@@ -505,7 +505,7 @@ jobs:
       - uses: ./.github/actions/token
 `)
 	if err == nil || !strings.Contains(err.Error(), "action input default that references github.token") || !strings.Contains(err.Error(), "no effective permissions") {
-		t.Fatalf("CompilePlansWithOptions() error = %v, want empty permission rejection", err)
+		t.Fatalf("compilePlansForTest() error = %v, want empty permission rejection", err)
 	}
 }
 
@@ -695,11 +695,11 @@ jobs:
 		ResolveActions: true,
 		ActionSource:   fake,
 	}
-	first, err := CompilePlansWithOptions(workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, options)
+	first, err := compilePlansForTest(context.Background(), workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, options)
 	if err != nil {
 		t.Fatal(err)
 	}
-	second, err := CompilePlansWithOptions(workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, options)
+	second, err := compilePlansForTest(context.Background(), workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, options)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -759,11 +759,11 @@ jobs:
     steps:
       - uses: ./local
 `)
-	first, err := CompilePlans(workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, "gha-untrusted")
+	first, err := compileUntrustedPlans(workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, "gha-untrusted")
 	if err != nil {
 		t.Fatal(err)
 	}
-	second, err := CompilePlans(workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, "gha-untrusted")
+	second, err := compileUntrustedPlans(workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, "gha-untrusted")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -782,9 +782,9 @@ func TestCompilePlansContainersWithRemoteActionsRequireResolution(t *testing.T) 
 		t.Fatal(err)
 	}
 	workflow := []byte("on: push\njobs:\n  actions:\n    runs-on: ubuntu-latest\n    container: node:24\n    steps:\n      - uses: owner/action@v1\n")
-	_, err := CompilePlans(workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, "gha-untrusted")
+	_, err := compileUntrustedPlans(workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, "gha-untrusted")
 	if err == nil || !strings.Contains(err.Error(), "containers with remote actions require action resolution through upload or profile validation") {
-		t.Fatalf("CompilePlans() error = %v", err)
+		t.Fatalf("compileUntrustedPlans() error = %v", err)
 	}
 }
 
@@ -809,7 +809,7 @@ func TestCheckoutAdapterInputBoundary(t *testing.T) {
 		if err := os.WriteFile(workflowPath, workflow, 0o644); err != nil {
 			t.Fatal(err)
 		}
-		return CompilePlansWithOptions(workflowPath, workflow, pushEvent(t), "checkout-test", testDistributionDigest, options)
+		return compilePlansForTest(context.Background(), workflowPath, workflow, pushEvent(t), "checkout-test", testDistributionDigest, options)
 	}
 
 	accepted := []string{
@@ -846,7 +846,7 @@ func TestCheckoutAdapterInputBoundary(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			_, err := compile("        with:\n" + input)
 			if err == nil || !strings.Contains(err.Error(), "checkout.yml:") || !strings.Contains(err.Error(), "checkout adapter") {
-				t.Fatalf("CompilePlansWithOptions() error = %v", err)
+				t.Fatalf("compilePlansForTest() error = %v", err)
 			}
 		})
 	}
@@ -942,7 +942,7 @@ func TestUploadArtifactAdapterInputAndCommitBoundary(t *testing.T) {
 		if err := os.WriteFile(workflowPath, workflow, 0o644); err != nil {
 			t.Fatal(err)
 		}
-		return CompilePlansWithOptions(workflowPath, workflow, pushEvent(t), "artifact-test", testDistributionDigest, Options{
+		return compilePlansForTest(context.Background(), workflowPath, workflow, pushEvent(t), "artifact-test", testDistributionDigest, Options{
 			EventTrust: EventUntrusted,
 			Runners: RunnerPolicy{
 				Labels:          map[string]string{"ubuntu-latest": "hosted"},
@@ -1002,7 +1002,7 @@ func TestUploadArtifactAdapterInputAndCommitBoundary(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			_, err := compile(actionintegration.UploadArtifactCommit, "        with:\n"+input)
 			if err == nil || !strings.Contains(err.Error(), "artifact.yml:") || !strings.Contains(err.Error(), "bounded upload-artifact adapter") {
-				t.Fatalf("CompilePlansWithOptions() error = %v", err)
+				t.Fatalf("compilePlansForTest() error = %v", err)
 			}
 		})
 	}
@@ -1015,7 +1015,7 @@ func TestUploadArtifactAdapterInputAndCommitBoundary(t *testing.T) {
 	if err := os.WriteFile(workflowPath, matrixWorkflow, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	plans, err = CompilePlansWithOptions(workflowPath, matrixWorkflow, pushEvent(t), "artifact-test", testDistributionDigest, Options{
+	plans, err = compilePlansForTest(context.Background(), workflowPath, matrixWorkflow, pushEvent(t), "artifact-test", testDistributionDigest, Options{
 		EventTrust: EventUntrusted,
 		Runners: RunnerPolicy{
 			Labels:          map[string]string{"ubuntu-latest": "hosted"},
@@ -1049,7 +1049,7 @@ func TestDownloadArtifactAdapterInputCommitAndNeedsBoundary(t *testing.T) {
 		if err := os.WriteFile(workflowPath, workflow, 0o644); err != nil {
 			t.Fatal(err)
 		}
-		return CompilePlansWithOptions(workflowPath, workflow, pushEvent(t), "artifact-test", testDistributionDigest, Options{
+		return compilePlansForTest(context.Background(), workflowPath, workflow, pushEvent(t), "artifact-test", testDistributionDigest, Options{
 			EventTrust: EventUntrusted,
 			Runners: RunnerPolicy{
 				Labels:          map[string]string{"ubuntu-latest": "hosted"},
@@ -1092,7 +1092,7 @@ func TestDownloadArtifactAdapterInputCommitAndNeedsBoundary(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			_, err := compile(actionintegration.DownloadArtifactCommit, "    needs: producer\n", with)
 			if err == nil || !strings.Contains(err.Error(), "bounded download-artifact adapter") {
-				t.Fatalf("CompilePlansWithOptions() error = %v", err)
+				t.Fatalf("compilePlansForTest() error = %v", err)
 			}
 		})
 	}
@@ -1108,7 +1108,7 @@ func TestDownloadArtifactAdapterInputCommitAndNeedsBoundary(t *testing.T) {
 	} {
 		t.Run("v8 "+name, func(t *testing.T) {
 			if _, err := compile(actionintegration.DownloadArtifactV801Commit, "    needs: producer\n", with); err == nil || !strings.Contains(err.Error(), "bounded download-artifact adapter") {
-				t.Fatalf("CompilePlansWithOptions() error = %v", err)
+				t.Fatalf("compilePlansForTest() error = %v", err)
 			}
 		})
 	}
@@ -1149,7 +1149,7 @@ jobs:
 	if err := os.WriteFile(workflowPath, workflow, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	plans, err := CompilePlansWithOptions(workflowPath, workflow, pushEvent(t), "artifact-test", testDistributionDigest, Options{
+	plans, err := compilePlansForTest(context.Background(), workflowPath, workflow, pushEvent(t), "artifact-test", testDistributionDigest, Options{
 		EventTrust: EventUntrusted,
 		Runners: RunnerPolicy{
 			Labels:          map[string]string{"ubuntu-latest": "hosted"},
@@ -1202,7 +1202,7 @@ func TestPublicActionsContinuationDependsOnCompiledTerminal(t *testing.T) {
 	writeAction(t, remote, "", "name: remote\nruns:\n  using: node24\n  main: index.js\n")
 	workflowPath := filepath.Join("..", "..", "testdata", "public-actions", ".github", "workflows", "public-actions.yml")
 	eventPath := filepath.Join("..", "..", "testdata", "public-actions", "events", "public-checkout.json")
-	plans, err := CompilePlansWithOptions(workflowPath, readFile(t, workflowPath), readFile(t, eventPath), "public-actions-test", testDistributionDigest, Options{
+	plans, err := compilePlansForTest(context.Background(), workflowPath, readFile(t, workflowPath), readFile(t, eventPath), "public-actions-test", testDistributionDigest, Options{
 		EventTrust: EventUntrusted,
 		Runners: RunnerPolicy{
 			Labels:          map[string]string{"ubuntu-latest": "hosted"},
@@ -1247,7 +1247,7 @@ func TestDockerfileActionContinuationDependsOnCompiledTerminal(t *testing.T) {
 	writeAction(t, remote, "", "name: remote Docker\nruns:\n  using: docker\n  image: Dockerfile\n")
 	workflowPath := filepath.Join("..", "..", "testdata", "dockerfile-action", ".github", "workflows", "docker-action.yml")
 	templatePath := workflowPath + ".tmpl"
-	plans, err := CompilePlansWithOptions(workflowPath, readFile(t, templatePath), pushEvent(t), "dockerfile-action-test", testDistributionDigest, Options{
+	plans, err := compilePlansForTest(context.Background(), workflowPath, readFile(t, templatePath), pushEvent(t), "dockerfile-action-test", testDistributionDigest, Options{
 		EventTrust: EventUntrusted,
 		Runners: RunnerPolicy{
 			Labels:          map[string]string{"ubuntu-latest": "hosted"},
@@ -1285,7 +1285,7 @@ func TestCompilePlansRemoteActionRequiresSource(t *testing.T) {
 		t.Fatal(err)
 	}
 	workflow := []byte("on: push\njobs:\n  action:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: owner/repo@v1\n")
-	_, err := CompilePlansWithOptions(workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, Options{
+	_, err := compilePlansForTest(context.Background(), workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, Options{
 		EventTrust: EventUntrusted,
 		Runners: RunnerPolicy{
 			Labels:          map[string]string{"ubuntu-latest": "hosted"},
@@ -1294,7 +1294,7 @@ func TestCompilePlansRemoteActionRequiresSource(t *testing.T) {
 		ResolveActions: true,
 	})
 	if err == nil || !strings.Contains(err.Error(), "remote action source is not configured") {
-		t.Fatalf("CompilePlansWithOptions() error = %v, want source configuration rejection", err)
+		t.Fatalf("compilePlansForTest() error = %v, want source configuration rejection", err)
 	}
 }
 
@@ -1307,7 +1307,7 @@ func TestCompilePlansContextCancelsRemoteResolution(t *testing.T) {
 	workflow := []byte("on: push\njobs:\n  action:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: owner/repo@v1\n")
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	_, err := CompilePlansContext(ctx, workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, Options{
+	_, err := compilePlansForTest(ctx, workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, Options{
 		EventTrust: EventUntrusted,
 		Runners: RunnerPolicy{
 			Labels:          map[string]string{"ubuntu-latest": "hosted"},
@@ -1317,7 +1317,7 @@ func TestCompilePlansContextCancelsRemoteResolution(t *testing.T) {
 		ActionSource:   contextActionSource{},
 	})
 	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("CompilePlansContext() error = %v, want context cancellation", err)
+		t.Fatalf("compilePlansForTest() error = %v, want context cancellation", err)
 	}
 }
 
@@ -1356,7 +1356,7 @@ jobs:
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
-	plans, err := CompilePlansContext(ctx, workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, Options{
+	plans, err := compilePlansForTest(ctx, workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, Options{
 		EventTrust: EventUntrusted,
 		Runners: RunnerPolicy{
 			Labels:          map[string]string{"ubuntu-latest": "hosted"},

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -286,52 +286,6 @@ func CompileWithOptions(path string, source, eventSource []byte, options Options
 	return out.Bytes(), nil
 }
 
-// CompilePlans connects the owned compiler IR to one versioned plan per job instance.
-func CompilePlans(path string, source, eventSource []byte, compilerVersion, compilerDistributionDigest, targetQueue string) ([]plan.Job, error) {
-	if targetQueue != "" && targetQueue != "gha-untrusted" {
-		return nil, fmt.Errorf("unsupported target queue %q for unattested event snapshot; use CompilePlansWithOptions for explicit queue policy", targetQueue)
-	}
-	options := defaultOptions()
-	if targetQueue != "" {
-		for label := range options.Runners.Labels {
-			options.Runners.Labels[label] = targetQueue
-		}
-		options.Runners.UntrustedQueues = []string{targetQueue}
-		options.Runners.AllowUntrustedDefaultQueue = false
-	}
-	return CompilePlansWithOptions(path, source, eventSource, compilerVersion, compilerDistributionDigest, options)
-}
-
-// CompilePlansWithOptions creates one plan per job using compiler-selected
-// queues and the same snapshotted vars used for graph construction.
-func CompilePlansWithOptions(path string, source, eventSource []byte, compilerVersion, compilerDistributionDigest string, options Options) ([]plan.Job, error) {
-	return CompilePlansContext(context.Background(), path, source, eventSource, compilerVersion, compilerDistributionDigest, options)
-}
-
-// CompilePlansContext creates one plan per job and permits cancellation while
-// compilation resolves immutable public action source.
-func CompilePlansContext(ctx context.Context, path string, source, eventSource []byte, compilerVersion, compilerDistributionDigest string, options Options) ([]plan.Job, error) {
-	if compilerVersion == "" {
-		return nil, fmt.Errorf("compiler version is required")
-	}
-	if !strings.HasPrefix(compilerDistributionDigest, "sha256:") {
-		return nil, fmt.Errorf("compiler distribution digest is required")
-	}
-	ir, err := compile(path, source, eventSource, options)
-	if err != nil {
-		return nil, err
-	}
-	return compilePlans(ctx, ir, compilerVersion, compilerDistributionDigest, options)
-}
-
-func compilePlans(ctx context.Context, ir IR, compilerVersion, compilerDistributionDigest string, options Options) ([]plan.Job, error) {
-	plans, _, _, err := compilePlansWithAuthorization(ctx, ir, compilerVersion, compilerDistributionDigest, options)
-	if err != nil {
-		return nil, err
-	}
-	return plans, err
-}
-
 func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, compilerDistributionDigest string, options Options) ([]plan.Job, []PlanAuthorization, []JobEvaluation, error) {
 	payload, err := json.Marshal(ir.Event.Payload)
 	if err != nil {

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -65,7 +65,7 @@ jobs:
       - run: test -n '${{ secrets.GITHUB_TOKEN }}'
 `)
 
-	plans, err := CompilePlans(caller, readFile(t, caller), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), "gha-untrusted")
+	plans, err := compileUntrustedPlans(caller, readFile(t, caller), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), "gha-untrusted")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +87,7 @@ jobs:
     steps:
       - run: test -n '${{ secrets.GITHUB_TOKEN }}'
 `)
-	_, err = CompilePlans(emptyCaller, readFile(t, emptyCaller), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), "gha-untrusted")
+	_, err = compileUntrustedPlans(emptyCaller, readFile(t, emptyCaller), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), "gha-untrusted")
 	if err == nil || !strings.Contains(err.Error(), "no effective permissions") {
 		t.Fatalf("explicit empty reusable call permissions error = %v", err)
 	}
@@ -276,7 +276,7 @@ jobs:
 					return err
 				},
 				"plans": func() error {
-					_, err := CompilePlans("conditions.yml", []byte(test.source), eventSource, "0.0.0-test", testDistributionDigest, "gha-untrusted")
+					_, err := compileUntrustedPlans("conditions.yml", []byte(test.source), eventSource, "0.0.0-test", testDistributionDigest, "gha-untrusted")
 					return err
 				},
 			} {
@@ -319,7 +319,7 @@ jobs:
       - if: failure() && steps.test.outcome == 'failure' && steps.test.conclusion == 'success' && steps.test.outputs.ready && job.services.redis.ports[6379]
         run: true
 `)
-	plans, err := CompilePlans("conditions.yml", source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-untrusted")
+	plans, err := compileUntrustedPlans("conditions.yml", source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-untrusted")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -665,7 +665,7 @@ jobs:
 	if prepare.SourcePath != "./.github/workflows/caller.yml" || finish.SourcePath != "./.github/workflows/caller.yml" {
 		t.Fatalf("caller source provenance = %q / %q", prepare.SourcePath, finish.SourcePath)
 	}
-	plans, err := CompilePlans(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-untrusted")
+	plans, err := compileUntrustedPlans(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-untrusted")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -729,7 +729,7 @@ jobs:
           echo private=hidden >> "$GITHUB_OUTPUT"
 `)
 
-	plans, err := CompilePlans(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), "gha-untrusted")
+	plans, err := compileUntrustedPlans(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), "gha-untrusted")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -823,7 +823,7 @@ jobs:
         run: echo "release=${{ matrix.target }}" >> "$GITHUB_OUTPUT"
 `)
 
-		plans, err := CompilePlans(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), "gha-untrusted")
+		plans, err := compileUntrustedPlans(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), "gha-untrusted")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -869,7 +869,7 @@ jobs:
         run: echo result=nested >> "$GITHUB_OUTPUT"
 `)
 
-		plans, err := CompilePlans(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), "gha-untrusted")
+		plans, err := compileUntrustedPlans(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), "gha-untrusted")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1014,7 +1014,7 @@ jobs:
 	if !reflect.DeepEqual(runners, []string{"ubuntu-22.04", "ubuntu-24.04"}) {
 		t.Fatalf("statically resolved runs-on inputs = %#v", runners)
 	}
-	plans, err := CompilePlans(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
+	plans, err := compileUntrustedPlans(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1063,7 +1063,7 @@ jobs:
         run: echo non-empty
 `)
 
-	plans, err := CompilePlans(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-untrusted")
+	plans, err := compileUntrustedPlans(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-untrusted")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1109,10 +1109,10 @@ jobs:
         run: true
 `)
 
-	_, err := CompilePlans(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-untrusted")
+	_, err := compileUntrustedPlans(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-untrusted")
 	want := `./.github/workflows/reusable.yml:7:13: job "call.test": step "inspect" condition: condition reference "github.event.action" is unavailable at runtime`
 	if err == nil || !strings.Contains(err.Error(), want) {
-		t.Fatalf("CompilePlans() error = %v, want callee condition diagnostic %q", err, want)
+		t.Fatalf("compileUntrustedPlans() error = %v, want callee condition diagnostic %q", err, want)
 	}
 }
 
@@ -1139,7 +1139,7 @@ jobs:
       - run: echo ${{ inputs.enabled }} ${{ github.ref }}
 `)
 
-	plans, err := CompilePlans(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-untrusted")
+	plans, err := compileUntrustedPlans(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-untrusted")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1162,7 +1162,7 @@ func TestCompilePlansResolveReusableLocalActionsFromRepositoryRoot(t *testing.T)
 	if err := os.WriteFile(filepath.Join(actionDir, "Dockerfile"), []byte("FROM scratch\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	plans, err := CompilePlans(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-untrusted")
+	plans, err := compileUntrustedPlans(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-untrusted")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1477,7 +1477,7 @@ jobs:
       - run: true
 `, strings.Join(values, ", ")))
 
-	plans, err := CompilePlans(path, readFile(t, path), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), "gha-untrusted")
+	plans, err := compileUntrustedPlans(path, readFile(t, path), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), "gha-untrusted")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1527,7 +1527,7 @@ jobs:
         env:
           OPTIONAL_TOKEN: ${{ secrets.OPTIONAL_TOKEN }}
 `)
-	plans, err := CompilePlans(path, readFile(t, path), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), "gha-untrusted")
+	plans, err := compileUntrustedPlans(path, readFile(t, path), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), "gha-untrusted")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1552,7 +1552,7 @@ jobs:
         env:
           OPTIONAL_TOKEN: ${{ secrets.OPTIONAL_TOKEN }}
 `)
-	plans, err := CompilePlans(path, readFile(t, path), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), "gha-untrusted")
+	plans, err := compileUntrustedPlans(path, readFile(t, path), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), "gha-untrusted")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1593,7 +1593,7 @@ jobs:
       - run: echo "${{ secrets.NESTED_TOKEN }}"
 `)
 
-			plans, err := CompilePlans(path, readFile(t, path), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), "gha-untrusted")
+			plans, err := compileUntrustedPlans(path, readFile(t, path), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), "gha-untrusted")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1897,7 +1897,7 @@ jobs:
         with:
           message: ${{ steps.javascript.outputs.result }}
 `)
-	plans, err := CompilePlans(path, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
+	plans, err := compileUntrustedPlans(path, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1920,7 +1920,7 @@ jobs:
 	if producer.RequiredCapabilities == nil || len(producer.RequiredCapabilities) != 0 {
 		t.Fatalf("required capabilities = %#v, want concrete empty array", producer.RequiredCapabilities)
 	}
-	second, err := CompilePlans(path, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
+	second, err := compileUntrustedPlans(path, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1962,7 +1962,7 @@ jobs:
           - id: named-parallel
             run: echo named
 `)
-	plans, err := CompilePlans(path, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
+	plans, err := compileUntrustedPlans(path, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1992,7 +1992,7 @@ jobs:
 
 func TestConcurrentSmokeTerminalKeyMatchesNativeContinuation(t *testing.T) {
 	path := smokePath(".github", "workflows", "concurrent.yml")
-	plans, err := CompilePlans(path, readFile(t, path), readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
+	plans, err := compileUntrustedPlans(path, readFile(t, path), readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2006,7 +2006,7 @@ func TestConcurrentSmokeTerminalKeyMatchesNativeContinuation(t *testing.T) {
 
 func TestCompilePlansRecordsStaticDependenciesWithVerifiedNeedSources(t *testing.T) {
 	path := smokePath(".github", "workflows", "shell.yml")
-	plans, err := CompilePlans(path, readFile(t, path), readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
+	plans, err := compileUntrustedPlans(path, readFile(t, path), readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2041,7 +2041,7 @@ jobs:
     steps:
       - run: echo done
 `)
-	plans, err := CompilePlans("matrix.yml", source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-untrusted")
+	plans, err := compileUntrustedPlans("matrix.yml", source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-untrusted")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2076,7 +2076,7 @@ func TestCompilePlansDerivesDockerCapability(t *testing.T) {
 		t.Fatal(err)
 	}
 	source := []byte("on: push\njobs:\n  docker:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: ./.github/actions/docker\n")
-	plans, err := CompilePlans(workflowPath, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
+	plans, err := compileUntrustedPlans(workflowPath, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2145,12 +2145,12 @@ func TestCompilePlansAcceptsSupportedJavaScriptLocalActions(t *testing.T) {
 				t.Fatal(err)
 			}
 			source := []byte("on: push\njobs:\n  javascript:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: ./.github/actions/" + runtime + "\n")
-			plans, err := CompilePlans(workflowPath, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
+			plans, err := compileUntrustedPlans(workflowPath, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
 			if err != nil {
-				t.Fatalf("CompilePlans() error = %v, want %s support", err, runtime)
+				t.Fatalf("compileUntrustedPlans() error = %v, want %s support", err, runtime)
 			}
 			if len(plans) != 1 || !plans[0].NeedsMise() {
-				t.Fatalf("CompilePlans() plans = %#v, want one %s job requiring mise", plans, runtime)
+				t.Fatalf("compileUntrustedPlans() plans = %#v, want one %s job requiring mise", plans, runtime)
 			}
 		})
 	}
@@ -2167,9 +2167,9 @@ func TestCompilePlansRejectsRuntimeInvalidActionMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 	source := []byte("on: push\njobs:\n  invalid:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: ./.github/actions/invalid\n")
-	_, err := CompilePlans(workflowPath, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
+	_, err := compileUntrustedPlans(workflowPath, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
 	if err == nil || !strings.Contains(err.Error(), "field unexpected not found") {
-		t.Fatalf("CompilePlans() error = %v, want strict action metadata rejection", err)
+		t.Fatalf("compileUntrustedPlans() error = %v, want strict action metadata rejection", err)
 	}
 }
 
@@ -2228,7 +2228,7 @@ func TestWorkflowRepositoryNormalizesInMemoryWorkflowPath(t *testing.T) {
 func TestCompiledPlansValidateAgainstVersionedSchema(t *testing.T) {
 	path := smokePath(".github", "workflows", "shell.yml")
 	source := readFile(t, path)
-	plans, err := CompilePlans(path, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "")
+	plans, err := compileUntrustedPlans(path, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2315,7 +2315,7 @@ func readFile(t *testing.T, path string) []byte {
 
 func TestCompilePlansEmitV4ForContainers(t *testing.T) {
 	workflowSource := []byte("on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    container: node:24\n    services:\n      redis: {image: redis:7}\n    steps:\n      - run: true\n")
-	plans, err := CompilePlans("containers.yml", workflowSource, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("1", 64), "gha-untrusted")
+	plans, err := compileUntrustedPlans("containers.yml", workflowSource, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("1", 64), "gha-untrusted")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/compiler/config_test.go
+++ b/internal/compiler/config_test.go
@@ -2,6 +2,7 @@ package compiler
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"reflect"
@@ -215,16 +216,12 @@ func TestDefaultCompilePolicyIsUntrustedAndUsesBuildkiteDefault(t *testing.T) {
 	if ir.Event.Trust != EventUntrusted || ir.Jobs[0].Queue != "" {
 		t.Fatalf("default compiler trust boundary = event %q, queue %q", ir.Event.Trust, ir.Jobs[0].Queue)
 	}
-	_, err = CompilePlans("default.yml", workflow, pushEvent(t), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "privileged")
-	if err == nil || !strings.Contains(err.Error(), "use CompilePlansWithOptions for explicit queue policy") {
-		t.Fatalf("CompilePlans() privileged default error = %v", err)
-	}
-	plans, err := CompilePlans("default.yml", workflow, pushEvent(t), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
+	plans, err := compileUntrustedPlans("default.yml", workflow, pushEvent(t), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(plans) != 1 || plans[0].Target.Queue != "gha-untrusted" || plans[0].Schema != plan.SchemaV2 {
-		t.Fatalf("CompilePlans() explicit legacy target = %#v", plans)
+		t.Fatalf("compileUntrustedPlans() explicit legacy target = %#v", plans)
 	}
 }
 
@@ -259,7 +256,7 @@ func TestCompilePlansUsePolicyQueueAndContainOnlyNonSecretVars(t *testing.T) {
 		Vars:       VariableSources{Bridge: map[string]string{"PUBLIC": "snapshotted"}},
 		Runners:    RunnerPolicy{Labels: map[string]string{"ubuntu-24.04": "linux"}},
 	}
-	plans, err := CompilePlansWithOptions("plan.yml", workflow, pushEvent(t), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), options)
+	plans, err := compilePlansForTest(context.Background(), "plan.yml", workflow, pushEvent(t), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), options)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/compiler/plans_test.go
+++ b/internal/compiler/plans_test.go
@@ -1,0 +1,37 @@
+package compiler
+
+import (
+	"context"
+
+	"github.com/buildkite/buildkite-gha/internal/plan"
+)
+
+// compilePlansForTest compiles plans through the production
+// CompileBundlePlansContext path and unwraps the plan jobs, so tests exercise
+// the interface that ships rather than a test-only wrapper.
+func compilePlansForTest(ctx context.Context, path string, source, eventSource []byte, compilerVersion, compilerDistributionDigest string, options Options) ([]plan.Job, error) {
+	bundle, err := CompileBundlePlansContext(ctx, path, source, eventSource, compilerVersion, compilerDistributionDigest, options)
+	if err != nil {
+		return nil, err
+	}
+	jobs := make([]plan.Job, len(bundle.Plans))
+	for i, artifact := range bundle.Plans {
+		jobs[i] = artifact.Job
+	}
+	return jobs, nil
+}
+
+// compileUntrustedPlans applies the tokenless untrusted convenience policy:
+// every default runner label pinned to targetQueue, which is also the only
+// queue admitted for untrusted events.
+func compileUntrustedPlans(path string, source, eventSource []byte, compilerVersion, compilerDistributionDigest, targetQueue string) ([]plan.Job, error) {
+	options := defaultOptions()
+	if targetQueue != "" {
+		for label := range options.Runners.Labels {
+			options.Runners.Labels[label] = targetQueue
+		}
+		options.Runners.UntrustedQueues = []string{targetQueue}
+		options.Runners.AllowUntrustedDefaultQueue = false
+	}
+	return compilePlansForTest(context.Background(), path, source, eventSource, compilerVersion, compilerDistributionDigest, options)
+}

--- a/internal/runtime/compileplans_test.go
+++ b/internal/runtime/compileplans_test.go
@@ -1,0 +1,41 @@
+package runtime
+
+import (
+	"context"
+
+	"github.com/buildkite/buildkite-gha/internal/compiler"
+	"github.com/buildkite/buildkite-gha/internal/plan"
+)
+
+// compilePlansForTest compiles plans through the production
+// compiler.CompileBundlePlansContext path and unwraps the plan jobs, so tests
+// exercise the interface that ships rather than a test-only wrapper.
+func compilePlansForTest(ctx context.Context, path string, source, eventSource []byte, compilerVersion, compilerDistributionDigest string, options compiler.Options) ([]plan.Job, error) {
+	bundle, err := compiler.CompileBundlePlansContext(ctx, path, source, eventSource, compilerVersion, compilerDistributionDigest, options)
+	if err != nil {
+		return nil, err
+	}
+	jobs := make([]plan.Job, len(bundle.Plans))
+	for i, artifact := range bundle.Plans {
+		jobs[i] = artifact.Job
+	}
+	return jobs, nil
+}
+
+// compileUntrustedPlans applies the tokenless untrusted convenience policy:
+// every default runner label pinned to targetQueue, which is also the only
+// queue admitted for untrusted events.
+func compileUntrustedPlans(path string, source, eventSource []byte, compilerVersion, compilerDistributionDigest, targetQueue string) ([]plan.Job, error) {
+	options := compiler.Options{
+		EventTrust: compiler.EventUntrusted,
+		Runners: compiler.RunnerPolicy{
+			Labels: map[string]string{
+				"ubuntu-latest": targetQueue,
+				"ubuntu-24.04":  targetQueue,
+				"ubuntu-22.04":  targetQueue,
+			},
+			UntrustedQueues: []string{targetQueue},
+		},
+	}
+	return compilePlansForTest(context.Background(), path, source, eventSource, compilerVersion, compilerDistributionDigest, options)
+}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -868,7 +868,7 @@ jobs:
 	if err != nil {
 		t.Fatal(err)
 	}
-	plans, err := compiler.CompilePlansWithOptions(
+	plans, err := compilePlansForTest(context.Background(),
 		filepath.Join(workspace, workflowPath),
 		[]byte(source),
 		event,
@@ -910,7 +910,7 @@ func TestCompiledBracketSecretResolvesAndMasks(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	plans, err := compiler.CompilePlans(filepath.Join(workspace, workflowPath), []byte(source), event, "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
+	plans, err := compileUntrustedPlans(filepath.Join(workspace, workflowPath), []byte(source), event, "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1810,7 +1810,7 @@ func TestConcurrentSmokeWorkflowEndToEnd(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	plans, err := compiler.CompilePlans(workflowPath, source, event, "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
+	plans, err := compileUntrustedPlans(workflowPath, source, event, "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2285,7 +2285,7 @@ runs:
 	if err != nil {
 		t.Fatal(err)
 	}
-	plans, err := compiler.CompilePlansWithOptions(workflowPath, workflow, event, "0.0.0-test", "sha256:"+strings.Repeat("2", 64), compiler.Options{
+	plans, err := compilePlansForTest(context.Background(), workflowPath, workflow, event, "0.0.0-test", "sha256:"+strings.Repeat("2", 64), compiler.Options{
 		EventTrust: compiler.EventUntrusted,
 		Runners: compiler.RunnerPolicy{
 			Labels:                     map[string]string{"ubuntu-latest": ""},
@@ -4622,7 +4622,7 @@ jobs:
 	if err != nil {
 		t.Fatal(err)
 	}
-	plans, err := compiler.CompilePlansContext(ctx, workflowPath, workflow, event, "0.0.0-test", "sha256:"+strings.Repeat("2", 64), compiler.Options{
+	plans, err := compilePlansForTest(ctx, workflowPath, workflow, event, "0.0.0-test", "sha256:"+strings.Repeat("2", 64), compiler.Options{
 		EventTrust: compiler.EventUntrusted,
 		Runners: compiler.RunnerPolicy{
 			Labels:          map[string]string{"ubuntu-latest": "hosted"},


### PR DESCRIPTION
Part of the pre-1.0 architecture cleanup (follows #135, #136, #137).

`CompilePlans`, `CompilePlansWithOptions`, and `CompilePlansContext` had zero production callers — the CLI compiles through `CompileBundlePlansContext`. They survived only because ~66 test call sites used them, so tests exercised an interface that never ships, including a legacy `gha-untrusted` queue restriction users cannot reach.

## Changes

- Delete the three wrappers and the now-unused private `compilePlans` from `internal/compiler/compiler.go` (net −50 lines of production API).
- Migrate compiler and runtime tests to package-private helpers (`compilePlansForTest`, `compileUntrustedPlans`) that call the production `CompileBundlePlansContext` path and unwrap `plan.Job` from bundle artifacts. Tests now also run action-resolution validation, matching shipping behavior.
- Remove the wrapper-only "unsupported target queue" assertion from `TestDefaultCompilePolicyIsUntrustedAndUsesBuildkiteDefault`; it validated input checking on the deleted convenience wrapper, not compiler queue policy. Queue admission remains covered by the options-based policy tests.

## Validation

`mise run check` passes (format, build, test, race, lint, vet, local smoke, release check).