### PR TITLE
Introduce invocationEnvironment for step env overlay and PATH precedence

### DIFF
--- a/internal/runtime/invocation_env_test.go
+++ b/internal/runtime/invocation_env_test.go
@@ -1,0 +1,102 @@
+package runtime
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestInvocationEnvironmentProcessOverlayOrder(t *testing.T) {
+	var r Runner
+	environment := r.invocationEnvironment(
+		map[string]string{"SHARED": "job", "JOB_ONLY": "job", "GITHUB_REPOSITORY": "owner/repo"},
+		map[string]string{"SHARED": "step", "STEP_ONLY": "step", "GITHUB_REPOSITORY": "spoofed"},
+	)
+	got := environment.process()
+	want := map[string]string{
+		"SHARED":    "step",
+		"JOB_ONLY":  "job",
+		"STEP_ONLY": "step",
+		// Runtime context names stay job-owned even when a step overlays them.
+		"GITHUB_REPOSITORY": "owner/repo",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("process() = %#v, want %#v", got, want)
+	}
+}
+
+func TestInvocationEnvironmentDockerPATHPrecedence(t *testing.T) {
+	tests := []struct {
+		name             string
+		runner           Runner
+		jobEnv           map[string]string
+		stepEnv          map[string]string
+		actionEnv        map[string]string
+		wantPATH         string
+		wantExplicitPATH bool
+	}{
+		{
+			name:             "action PATH replaces implicit job PATH",
+			runner:           Runner{implicitJobPATH: "/usr/bin"},
+			jobEnv:           map[string]string{"PATH": "/usr/bin"},
+			actionEnv:        map[string]string{"PATH": "/action/bin"},
+			wantPATH:         "/action/bin",
+			wantExplicitPATH: true,
+		},
+		{
+			name:             "explicit job PATH wins over action PATH",
+			runner:           Runner{explicitJobPATH: true, implicitJobPATH: "/usr/bin"},
+			jobEnv:           map[string]string{"PATH": "/job/bin"},
+			actionEnv:        map[string]string{"PATH": "/action/bin"},
+			wantPATH:         "/job/bin",
+			wantExplicitPATH: true,
+		},
+		{
+			name:             "step PATH wins over action PATH",
+			runner:           Runner{implicitJobPATH: "/usr/bin"},
+			jobEnv:           map[string]string{"PATH": "/usr/bin"},
+			stepEnv:          map[string]string{"PATH": "/step/bin"},
+			actionEnv:        map[string]string{"PATH": "/action/bin"},
+			wantPATH:         "/step/bin",
+			wantExplicitPATH: true,
+		},
+		{
+			name:             "implicit PATH everywhere keeps image PATH authority",
+			runner:           Runner{implicitJobPATH: "/usr/bin"},
+			jobEnv:           map[string]string{"PATH": "/usr/bin"},
+			actionEnv:        map[string]string{"OTHER": "value"},
+			wantPATH:         "/usr/bin",
+			wantExplicitPATH: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			environment := test.runner.invocationEnvironment(test.jobEnv, test.stepEnv)
+			env, explicitPATH := environment.docker(test.actionEnv, nil)
+			if env["PATH"] != test.wantPATH || explicitPATH != test.wantExplicitPATH {
+				t.Fatalf("docker() PATH = %q explicit = %v, want %q explicit = %v", env["PATH"], explicitPATH, test.wantPATH, test.wantExplicitPATH)
+			}
+		})
+	}
+}
+
+func TestInvocationEnvironmentDockerOverlaysActionAndInputs(t *testing.T) {
+	runner := Runner{implicitJobPATH: "/usr/bin"}
+	environment := runner.invocationEnvironment(
+		map[string]string{"PATH": "/usr/bin", "SHARED": "job"},
+		map[string]string{"STEP_ONLY": "step"},
+	)
+	env, _ := environment.docker(
+		map[string]string{"SHARED": "action", "ACTION_ONLY": "action"},
+		map[string]string{"my input": "value"},
+	)
+	want := map[string]string{
+		"PATH":           "/usr/bin",
+		"SHARED":         "job", // action env fills only unset names
+		"STEP_ONLY":      "step",
+		"ACTION_ONLY":    "action",
+		"INPUT_MY_INPUT": "value",
+	}
+	if !reflect.DeepEqual(env, want) {
+		t.Fatalf("docker() env = %#v, want %#v", env, want)
+	}
+}

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -852,6 +852,43 @@ func ubuntuImageOS(osRelease []byte) string {
 	}
 }
 
+// invocationEnvironment owns the environment overlay order for one step
+// invocation: job environment first, step environment second, with runtime
+// context names protected. It also captures whether the job or step pinned
+// PATH explicitly, which decides Docker action PATH precedence.
+type invocationEnvironment struct {
+	jobEnv       map[string]string
+	stepEnv      map[string]string
+	explicitPATH bool
+}
+
+func (r Runner) invocationEnvironment(jobEnv, stepEnv map[string]string) invocationEnvironment {
+	_, stepPATH := stepEnv["PATH"]
+	jobPATH := r.explicitJobPATH || jobEnv["PATH"] != r.implicitJobPATH
+	return invocationEnvironment{jobEnv: jobEnv, stepEnv: stepEnv, explicitPATH: jobPATH || stepPATH}
+}
+
+// process is the environment for shell and JavaScript step processes.
+func (e invocationEnvironment) process() map[string]string {
+	return mergeStepEnvironment(e.jobEnv, e.stepEnv)
+}
+
+// docker overlays action-declared environment beneath the invocation
+// environment: action values fill only unset names, except that the action
+// may replace PATH when neither the job nor the step pinned one. It returns
+// the container environment and whether any layer set PATH explicitly, which
+// makes the Docker image PATH yield.
+func (e invocationEnvironment) docker(actionEnv, inputs map[string]string) (map[string]string, bool) {
+	env := mergeStepEnvironment(e.jobEnv, e.stepEnv, actionInputEnv(inputs))
+	for name, value := range actionEnv {
+		if _, exists := env[name]; !exists || (name == "PATH" && !e.explicitPATH) {
+			env[name] = value
+		}
+	}
+	_, actionPATH := actionEnv["PATH"]
+	return env, e.explicitPATH || actionPATH
+}
+
 func mergeStepEnvironment(base map[string]string, overlays ...map[string]string) map[string]string {
 	out := mergeStringMaps(append([]map[string]string{base}, overlays...)...)
 	for name, value := range base {
@@ -1170,6 +1207,7 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 	if err != nil {
 		return newResult(), err
 	}
+	environment := r.invocationEnvironment(jobEnv, stepEnv)
 	result := newResult()
 	if step.Kind == "run" {
 		script, err := expression.Evaluate(step.Command, eval)
@@ -1207,7 +1245,7 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 		if err != nil {
 			return result, err
 		}
-		runEnv := mergeStepEnvironment(jobEnv, stepEnv)
+		runEnv := environment.process()
 		err = r.runProcess(ctx, processor, dir, runEnv, &result, nil, args[0], args[1:]...)
 		return result, err
 	}
@@ -1312,7 +1350,7 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 		if err != nil {
 			return result, err
 		}
-		actionEnv := mergeStepEnvironment(jobEnv, stepEnv)
+		actionEnv := environment.process()
 		javascript := javaScriptAction{Name: actionName(action, step), Path: actionPath, Pre: action.Runs.Pre, Main: action.Runs.Main, Post: action.Runs.Post, Inputs: inputs, Env: actionEnv, Cache: actionLock != nil && usesCacheService(*actionLock), nodeMajor: major, reference: step.Uses, jobStatusInputs: jobStatusInputs}
 		state := map[string]string{}
 		wasPrepared := false
@@ -1326,7 +1364,7 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 			// Preserve invocation state while evaluating inputs and environment
 			// again with every main-visible effect committed.
 			javascript.Inputs = inputs
-			javascript.Env = mergeStepEnvironment(jobEnv, stepEnv)
+			javascript.Env = environment.process()
 			invocation.action = javascript
 		}
 		if !wasPrepared {
@@ -1371,17 +1409,8 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 		if actionLock != nil {
 			sourceDigest = actionLock.SourceDigest
 		}
-		_, stepPATH := stepEnv["PATH"]
-		_, actionPATH := dockerEnv["PATH"]
-		jobPATH := r.explicitJobPATH || jobEnv["PATH"] != r.implicitJobPATH
-		invocationEnv := mergeStepEnvironment(jobEnv, stepEnv, actionInputEnv(inputs))
-		for name, value := range dockerEnv {
-			_, exists := invocationEnv[name]
-			if !exists || (name == "PATH" && !jobPATH && !stepPATH) {
-				invocationEnv[name] = value
-			}
-		}
-		result, err := r.runDocker(ctx, processor, dockerAction{Name: actionName(action, step), Path: actionPath, SourceRoot: sourceRoot, SourceDigest: sourceDigest, Workspace: workspace, Env: invocationEnv, explicitPATH: jobPATH || stepPATH || actionPATH})
+		invocationEnv, explicitPATH := environment.docker(dockerEnv, inputs)
+		result, err := r.runDocker(ctx, processor, dockerAction{Name: actionName(action, step), Path: actionPath, SourceRoot: sourceRoot, SourceDigest: sourceDigest, Workspace: workspace, Env: invocationEnv, explicitPATH: explicitPATH})
 		return result, err
 	}
 	return result, fmt.Errorf("action %q uses unsupported runtime %q", step.Uses, actionRuntime)


### PR DESCRIPTION
Part of the pre-1.0 architecture cleanup (follows #135, #136, #137, #139). First bounded slice of the runtime environment work — no package split, no `Runner` rewrite.

`runActionStep` computed `mergeStepEnvironment(jobEnv, stepEnv)` four times and inlined a dense Docker PATH-precedence block reading three booleans from two maps and two `Runner` fields. The overlay order and PATH rules were order-sensitive and unnamed.

## Changes

- New `invocationEnvironment` value, constructed once at the top of `runActionStep`, owns:
  - `process()` — the environment for shell and JavaScript step processes (job env, then step env, runtime context names protected).
  - `docker()` — overlays action-declared env beneath the invocation env; the action may replace `PATH` only when neither the job nor the step pinned one, and it reports whether the Docker image `PATH` must yield.
- The Docker branch's inline PATH block is a direct transcription into `docker()`; behavior is unchanged.
- New focused unit tests cover overlay order, runtime-context protection, action/input overlay semantics, and every PATH precedence combination (implicit job PATH, explicit job PATH, step PATH, action PATH).

Composite and remote-preparation paths are deliberately untouched; they can adopt the same value in a later slice if it pays for itself.

## Validation

`mise run check` passes (format, build, test, race, lint, vet, local smoke, release check).