### PR TITLE
Keep the hosted toolchain image current with Renovate

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -128,7 +128,8 @@ Set an image by digest:
 
 ```yaml
 env:
-  BUILDKITE_GHA_RUNTIME_IMAGE: buildkite.namespace-images.com/agent-base@sha256:04a6656f92b90269b3259fffaba67e08a3d03d8dc79b40d45c9ac3d9000e9e03
+  # renovate: datasource=docker depName=buildkite/agent-base tag=ubuntu-noble-hosted-toolchains
+  BUILDKITE_GHA_RUNTIME_IMAGE: buildkite.namespace-images.com/agent-base@sha256:62a45683afffaae9edfd669c16d2fee23b5a571679f31715e1063dada667ea24
 ```
 
 Tags and other mutable references are rejected. The image may provide a baked `/opt/hostedtoolcache` inventory.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -128,6 +128,7 @@ Set an image by digest:
 
 ```yaml
 env:
+  # Renovate resolves this Docker Hub tag; Namespace must preserve its manifest digest.
   # renovate: datasource=docker depName=buildkite/agent-base tag=ubuntu-noble-hosted-toolchains
   BUILDKITE_GHA_RUNTIME_IMAGE: buildkite.namespace-images.com/agent-base@sha256:62a45683afffaae9edfd669c16d2fee23b5a571679f31715e1063dada667ea24
 ```

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>buildkite/renovate-config"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^docs\\/cli\\.md$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+) tag=(?<currentValue>\\S+)\\s+BUILDKITE_GHA_RUNTIME_IMAGE: buildkite\\.namespace-images\\.com/agent-base@(?<currentDigest>sha256:[a-f0-9]{64})"
+      ],
+      "versioningTemplate": "docker"
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>buildkite/renovate-config"],
+  "extends": ["config:recommended"],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
## Why

The hosted toolchain runtime image is digest-pinned, but the digest-only Namespace reference does not tell Renovate which agent-base variant to follow.

## What

Add a focused Renovate regex manager that tracks the `ubuntu-noble-hosted-toolchains` Docker tag and updates the immutable Namespace digest. Refresh the documented reference to the digest published by the latest agent-base-images build.
