### PR TITLE
Compact workflow command annotations

### DIFF
--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -1590,7 +1590,7 @@ func TestWorkflowCommandAnnotationProofContract(t *testing.T) {
 		t.Fatal(err)
 	}
 	fixtureText := string(fixture)
-	for _, fragment := range []string{"::warning title=Workflow warning", "::error title=Workflow error", "WORKFLOW_WARNING_OBSERVATION=stdout-with-location", "WORKFLOW_ERROR_OBSERVATION=stderr-outcome-neutral", "::add-mask::$canary", "workflow-command-secret"} {
+	for _, fragment := range []string{"::warning title=Deprecated command", "::error title=Invalid deployment target", "The save-state command is deprecated", "The deployment environment must be staging or production", "::warning title=Secret redaction", "Sensitive value redacted", "::add-mask::$canary", "workflow-command-secret"} {
 		if !strings.Contains(fixtureText, fragment) {
 			t.Fatalf("Workflow annotation fixture lacks %q: %s", fragment, fixture)
 		}

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -671,40 +671,17 @@ func scrubJobResult(result JobResult, sensitiveValues []string) JobResult {
 		result.Summary = trimSensitiveSuffix(result.Summary, sensitiveValues)
 	}
 	result.Summary = finalizeJobSummary(result.Summary, result.summaryTruncated)
-	result.WarningAnnotations, result.warningsTruncated = scrubWorkflowCommandAnnotations(result.WarningAnnotations, result.warningsTruncated, sensitiveValues)
-	result.ErrorAnnotations, result.errorsTruncated = scrubWorkflowCommandAnnotations(result.ErrorAnnotations, result.errorsTruncated, sensitiveValues)
+	result.WarningAnnotations, result.warningsTruncated = finalizeWorkflowCommandAnnotations(result.WarningAnnotations, result.warningsTruncated)
+	result.ErrorAnnotations, result.errorsTruncated = finalizeWorkflowCommandAnnotations(result.ErrorAnnotations, result.errorsTruncated)
 	return result
 }
 
-func scrubWorkflowCommandAnnotations(value string, truncated bool, sensitiveValues []string) (string, bool) {
-	annotationSensitiveValues := make([]string, 0, len(sensitiveValues))
-	for _, sensitive := range sensitiveValues {
-		if sensitive == "" {
-			continue
-		}
-		// User-controlled annotation content is rendered through commandHTML.
-		// Scrubbing that same valid UTF-8 representation prevents invalid raw
-		// mask bytes from splitting a rendered multibyte rune.
-		annotationSensitiveValues = append(annotationSensitiveValues, commandHTML(sensitive))
-	}
-	sort.Slice(annotationSensitiveValues, func(i, j int) bool {
-		if len(annotationSensitiveValues[i]) != len(annotationSensitiveValues[j]) {
-			return len(annotationSensitiveValues[i]) > len(annotationSensitiveValues[j])
-		}
-		return annotationSensitiveValues[i] < annotationSensitiveValues[j]
-	})
-	for _, sensitive := range annotationSensitiveValues {
-		value = strings.ReplaceAll(value, sensitive, "***")
-		var bounded string
-		var boundedTruncated bool
-		appendBoundedText(&bounded, &boundedTruncated, value, truncated, maxJobAnnotationBytes, workflowCommandTruncationNotice)
-		value, truncated = bounded, boundedTruncated
-	}
+func finalizeWorkflowCommandAnnotations(value string, truncated bool) (string, bool) {
 	var bounded string
 	var boundedTruncated bool
 	appendBoundedText(&bounded, &boundedTruncated, value, truncated, maxJobAnnotationBytes, workflowCommandTruncationNotice)
 	if boundedTruncated {
-		bounded = trimSensitiveSuffix(bounded, annotationSensitiveValues) + workflowCommandTruncationNotice
+		bounded += workflowCommandTruncationNotice
 	}
 	return bounded, boundedTruncated
 }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -42,7 +42,7 @@ const (
 	workflowCommandTruncationNotice  = "\n\n---\n_Workflow command annotations truncated at the 1 MiB limit._\n"
 	workflowWarningAnnotationHeading = "<h2 class=\"h3 mb2\">GitHub Actions warnings</h2>\n"
 	workflowErrorAnnotationHeading   = "<h2 class=\"h3 mb2\">GitHub Actions errors</h2>\n"
-	workflowCommandTableHeading      = "<table class=\"mb2\">\n<thead><tr><th class=\"col-4 align-middle\">Source</th><th class=\"col-2 align-middle\">Title</th><th class=\"col-6 align-middle\">Message</th></tr></thead>\n<tbody>\n"
+	workflowCommandTableHeading      = "<table class=\"col-12 mb2\">\n<thead><tr><th class=\"col-4 align-middle\">Source</th><th class=\"col-8 align-middle\">Message</th></tr></thead>\n<tbody>\n"
 	workflowCommandTableEnd          = "</tbody>\n</table>\n"
 )
 
@@ -1666,8 +1666,11 @@ func renderWorkflowCommandTableRow(command workflowCommandAnnotation) string {
 		}
 		source = "<code>" + commandHTML(location) + "</code>"
 	}
-	return "<tr><td>" + source + "</td><td>" + commandHTML(command.title) +
-		"</td><td>" + commandHTML(command.message) + "</td></tr>\n"
+	detail := commandHTML(command.message)
+	if command.title != "" {
+		detail = "<strong>" + commandHTML(command.title) + "</strong><br>\n" + detail
+	}
+	return "<tr><td>" + source + "</td><td>" + detail + "</td></tr>\n"
 }
 
 func workflowCommandLocationLabel(properties map[string]string) string {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -40,8 +40,10 @@ const (
 
 	jobSummaryTruncationNotice       = "\n\n---\n_Job summary truncated at the 1 MiB limit._\n"
 	workflowCommandTruncationNotice  = "\n\n---\n_Workflow command annotations truncated at the 1 MiB limit._\n"
-	workflowWarningAnnotationHeading = "## GitHub Actions warnings\n\n"
-	workflowErrorAnnotationHeading   = "## GitHub Actions errors\n\n"
+	workflowWarningAnnotationHeading = "<h2 class=\"h3 mb2\">GitHub Actions warnings</h2>\n"
+	workflowErrorAnnotationHeading   = "<h2 class=\"h3 mb2\">GitHub Actions errors</h2>\n"
+	workflowCommandTableHeading      = "<table class=\"mb2\">\n<thead><tr><th class=\"col-4 align-middle\">Source</th><th class=\"col-2 align-middle\">Title</th><th class=\"col-6 align-middle\">Message</th></tr></thead>\n<tbody>\n"
+	workflowCommandTableEnd          = "</tbody>\n</table>\n"
 )
 
 // Runner executes verified actions using explicitly configured host tools.
@@ -1298,19 +1300,22 @@ type commandProcessor struct {
 }
 
 type workflowCommandAnnotationBuffer struct {
-	body      string
+	commands  []workflowCommandAnnotation
+	rendered  int
 	truncated bool
+}
+
+type workflowCommandAnnotation struct {
+	file     string
+	title    string
+	location string
+	message  string
 }
 
 type parsedWorkflowCommand struct {
 	name       string
 	properties map[string]string
 	message    string
-}
-
-type workflowCommandMetadata struct {
-	label string
-	value string
 }
 
 func newCommandProcessor(stdout, stderr io.Writer) *commandProcessor {
@@ -1341,7 +1346,7 @@ func (p *commandProcessor) process(target io.Writer, line string) error {
 		case strings.EqualFold(command.name, "stop-commands"):
 			if !validWorkflowCommandStopToken(command.message) {
 				const message = "invalid ::stop-commands token: token is empty or collides with a workflow command"
-				p.appendWorkflowCommandLocked(&p.errors, workflowErrorAnnotationHeading, "Error", parsedWorkflowCommand{message: message})
+				p.appendWorkflowCommandLocked(&p.errors, workflowErrorAnnotationHeading, parsedWorkflowCommand{message: message})
 				p.writeWorkflowCommandMessageLocked(target, "error", message)
 				return errInvalidWorkflowCommandStopToken
 			}
@@ -1352,11 +1357,11 @@ func (p *commandProcessor) process(target io.Writer, line string) error {
 			p.writeMaskedLineLocked(target, line)
 			return nil
 		case strings.EqualFold(command.name, "warning"):
-			p.appendWorkflowCommandLocked(&p.warnings, workflowWarningAnnotationHeading, "Warning", command)
+			p.appendWorkflowCommandLocked(&p.warnings, workflowWarningAnnotationHeading, command)
 			p.writeWorkflowCommandMessageLocked(target, "warning", command.message)
 			return nil
 		case strings.EqualFold(command.name, "error"):
-			p.appendWorkflowCommandLocked(&p.errors, workflowErrorAnnotationHeading, "Error", command)
+			p.appendWorkflowCommandLocked(&p.errors, workflowErrorAnnotationHeading, command)
 			p.writeWorkflowCommandMessageLocked(target, "error", command.message)
 			return nil
 		case strings.EqualFold(command.name, "group"):
@@ -1443,7 +1448,7 @@ func (p *commandProcessor) writeWorkflowCommandMessageLocked(target io.Writer, s
 func (p *commandProcessor) trustedWarning(message string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.appendWorkflowCommandLocked(&p.trustedWarnings, workflowWarningAnnotationHeading, "Warning", parsedWorkflowCommand{message: message})
+	p.appendWorkflowCommandLocked(&p.trustedWarnings, workflowWarningAnnotationHeading, parsedWorkflowCommand{message: message})
 	p.writeWorkflowCommandMessageLocked(p.stderr, "warning", message)
 }
 
@@ -1458,12 +1463,30 @@ func (p *commandProcessor) maskTextLocked(text string) string {
 	return text
 }
 
-func (p *commandProcessor) appendWorkflowCommandLocked(buffer *workflowCommandAnnotationBuffer, heading, severity string, command parsedWorkflowCommand) {
-	fragment := renderWorkflowCommand(severity, command)
-	if buffer.body == "" {
-		fragment = heading + fragment
+func (p *commandProcessor) appendWorkflowCommandLocked(buffer *workflowCommandAnnotationBuffer, heading string, command parsedWorkflowCommand) {
+	annotation := workflowCommandAnnotation{
+		file:     strings.Clone(commandText(command.properties["file"])),
+		title:    strings.Clone(commandText(command.properties["title"])),
+		location: strings.Clone(workflowCommandLocationLabel(command.properties)),
+		message:  strings.Clone(commandText(command.message)),
 	}
-	appendBoundedText(&buffer.body, &buffer.truncated, fragment, false, maxJobAnnotationBytes, workflowCommandTruncationNotice)
+	p.appendWorkflowCommandAnnotationLocked(buffer, heading, annotation)
+}
+
+func (p *commandProcessor) appendWorkflowCommandAnnotationLocked(buffer *workflowCommandAnnotationBuffer, heading string, command workflowCommandAnnotation) {
+	if buffer.truncated {
+		return
+	}
+	additional := len(renderWorkflowCommandTableRow(command))
+	if len(buffer.commands) == 0 {
+		additional += len(heading) + len(workflowCommandTableHeading) + len(workflowCommandTableEnd)
+	}
+	if buffer.rendered+additional > maxJobAnnotationBytes-len(workflowCommandTruncationNotice) {
+		buffer.truncated = true
+		return
+	}
+	buffer.rendered += additional
+	buffer.commands = append(buffer.commands, command)
 }
 
 func (p *commandProcessor) suppress() {
@@ -1528,14 +1551,23 @@ func (p *commandProcessor) scrubError(err error) error {
 func (p *commandProcessor) workflowCommandAnnotations() (warnings string, warningsTruncated bool, errors string, errorsTruncated bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	warnings, warningsTruncated = p.warnings.body, p.warnings.truncated
-	if p.trustedWarnings.body != "" {
-		warnings, warningsTruncated = "", false
-		appendBoundedText(&warnings, &warningsTruncated, p.trustedWarnings.body, p.trustedWarnings.truncated, maxJobAnnotationBytes, workflowCommandTruncationNotice)
-		untrusted := strings.TrimPrefix(p.warnings.body, workflowWarningAnnotationHeading)
-		appendBoundedText(&warnings, &warningsTruncated, untrusted, p.warnings.truncated, maxJobAnnotationBytes, workflowCommandTruncationNotice)
+	masks := normalizedMasks(p.masks)
+	var combinedWarnings workflowCommandAnnotationBuffer
+	for _, command := range p.trustedWarnings.commands {
+		p.appendWorkflowCommandAnnotationLocked(&combinedWarnings, workflowWarningAnnotationHeading, maskWorkflowCommandAnnotation(command, masks))
 	}
-	return warnings, warningsTruncated, p.errors.body, p.errors.truncated
+	for _, command := range p.warnings.commands {
+		p.appendWorkflowCommandAnnotationLocked(&combinedWarnings, workflowWarningAnnotationHeading, maskWorkflowCommandAnnotation(command, masks))
+	}
+	combinedWarnings.truncated = combinedWarnings.truncated || p.trustedWarnings.truncated || p.warnings.truncated
+	warnings, warningsTruncated = renderWorkflowCommandAnnotation(workflowWarningAnnotationHeading, combinedWarnings.commands, combinedWarnings.truncated)
+	var maskedErrors workflowCommandAnnotationBuffer
+	for _, command := range p.errors.commands {
+		p.appendWorkflowCommandAnnotationLocked(&maskedErrors, workflowErrorAnnotationHeading, maskWorkflowCommandAnnotation(command, masks))
+	}
+	maskedErrors.truncated = maskedErrors.truncated || p.errors.truncated
+	errors, errorsTruncated = renderWorkflowCommandAnnotation(workflowErrorAnnotationHeading, maskedErrors.commands, maskedErrors.truncated)
+	return warnings, warningsTruncated, errors, errorsTruncated
 }
 
 func (p *commandProcessor) addMaskLocked(value string) {
@@ -1588,52 +1620,115 @@ func decodeCommandProperty(value string) string {
 	return replacer.Replace(value)
 }
 
-func renderWorkflowCommand(severity string, command parsedWorkflowCommand) string {
-	var body strings.Builder
-	body.WriteString("### ")
-	body.WriteString(severity)
-	body.WriteString("\n\n")
-	metadata := []workflowCommandMetadata{
-		{label: "Title", value: command.properties["title"]},
-		{label: "File", value: command.properties["file"]},
+func renderWorkflowCommandAnnotation(heading string, commands []workflowCommandAnnotation, truncated bool) (string, bool) {
+	if len(commands) == 0 {
+		return "", truncated
 	}
-	line, endLine, column, endColumn := workflowCommandLocation(command.properties)
-	metadata = append(metadata,
-		workflowCommandMetadata{label: "Line", value: line},
-		workflowCommandMetadata{label: "End line", value: endLine},
-		workflowCommandMetadata{label: "Column", value: column},
-		workflowCommandMetadata{label: "End column", value: endColumn},
-	)
-	hasMetadata := false
-	for _, item := range metadata {
-		if item.value == "" {
-			continue
+	type commandGroup struct {
+		file     string
+		commands []workflowCommandAnnotation
+	}
+	groups := make([]commandGroup, 0)
+	groupIndexes := make(map[string]int)
+	for _, command := range commands {
+		file := command.file
+		index, ok := groupIndexes[file]
+		if !ok {
+			index = len(groups)
+			groupIndexes[file] = index
+			groups = append(groups, commandGroup{file: file})
 		}
-		if !hasMetadata {
-			body.WriteString("<p>")
-			hasMetadata = true
-		} else {
-			body.WriteString("<br>\n")
+		groups[index].commands = append(groups[index].commands, command)
+	}
+
+	var rendered strings.Builder
+	rendered.WriteString(heading)
+	rendered.WriteString(workflowCommandTableHeading)
+	for _, group := range groups {
+		for _, command := range group.commands {
+			rendered.WriteString(renderWorkflowCommandTableRow(command))
 		}
-		body.WriteString("<strong>")
-		body.WriteString(item.label)
-		body.WriteString(":</strong> <code>")
-		body.WriteString(commandHTML(item.value))
-		body.WriteString("</code>")
 	}
-	if hasMetadata {
-		body.WriteString("</p>\n\n")
+	rendered.WriteString(workflowCommandTableEnd)
+
+	var body string
+	var bodyTruncated bool
+	appendBoundedText(&body, &bodyTruncated, rendered.String(), truncated, maxJobAnnotationBytes, workflowCommandTruncationNotice)
+	return body, bodyTruncated
+}
+
+func renderWorkflowCommandTableRow(command workflowCommandAnnotation) string {
+	source := "General"
+	if command.file != "" {
+		location := command.file
+		if command.location != "" {
+			location += ":" + command.location
+		}
+		source = "<code>" + commandHTML(location) + "</code>"
 	}
-	body.WriteString("<p>")
-	body.WriteString(commandHTML(command.message))
-	body.WriteString("</p>\n\n")
-	return body.String()
+	return "<tr><td>" + source + "</td><td>" + commandHTML(command.title) +
+		"</td><td>" + commandHTML(command.message) + "</td></tr>\n"
+}
+
+func workflowCommandLocationLabel(properties map[string]string) string {
+	line, endLine, column, endColumn := workflowCommandLocation(properties)
+	if line == "" {
+		return ""
+	}
+	if endLine == "" {
+		endLine = line
+	}
+	if endColumn == "" {
+		endColumn = column
+	}
+	start := line
+	if column != "" {
+		start += ":" + column
+	}
+	end := endLine
+	if endColumn != "" {
+		end += ":" + endColumn
+	}
+	if end == "" || end == start || endLine == line && endColumn == column {
+		return start
+	}
+	return start + "–" + end
+}
+
+func normalizedMasks(masks []string) []string {
+	normalized := make([]string, 0, len(masks))
+	for _, mask := range masks {
+		if mask = commandText(mask); mask != "" {
+			normalized = append(normalized, mask)
+		}
+	}
+	sort.Slice(normalized, func(i, j int) bool {
+		if len(normalized[i]) != len(normalized[j]) {
+			return len(normalized[i]) > len(normalized[j])
+		}
+		return normalized[i] < normalized[j]
+	})
+	return normalized
+}
+
+func maskWorkflowCommandAnnotation(command workflowCommandAnnotation, masks []string) workflowCommandAnnotation {
+	values := []*string{&command.file, &command.title, &command.location, &command.message}
+	for _, mask := range masks {
+		for _, value := range values {
+			*value = strings.ReplaceAll(*value, mask, "***")
+		}
+	}
+	return command
+}
+
+func commandText(value string) string {
+	value = strings.ToValidUTF8(value, "\uFFFD")
+	value = strings.ReplaceAll(value, "\r\n", "\n")
+	return strings.ReplaceAll(value, "\r", "\n")
 }
 
 func commandHTML(value string) string {
-	value = strings.ToValidUTF8(value, "\uFFFD")
-	value = strings.ReplaceAll(value, "\r\n", "\n")
-	value = strings.ReplaceAll(value, "\r", "\n")
+	value = commandText(value)
 	return strings.ReplaceAll(html.EscapeString(value), "\n", "<br>\n")
 }
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1670,7 +1670,7 @@ func renderWorkflowCommandListItem(command workflowCommandAnnotation) string {
 	if command.title != "" {
 		detail = "<strong>" + commandHTML(command.title) + ":</strong> " + detail
 	}
-	return "<div class=\"border-top py2\"><div>" + detail +
+	return "<div class=\"border-top border-silver py2\"><div>" + detail +
 		"</div><div class=\"mt1\">" + source + "</div></div>\n"
 }
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -42,8 +42,8 @@ const (
 	workflowCommandTruncationNotice  = "\n\n---\n_Workflow command annotations truncated at the 1 MiB limit._\n"
 	workflowWarningAnnotationHeading = "<h2 class=\"h4 mb2\">GitHub Actions warnings</h2>\n"
 	workflowErrorAnnotationHeading   = "<h2 class=\"h4 mb2\">GitHub Actions errors</h2>\n"
-	workflowCommandTableHeading      = "<table class=\"col-12 mb2\">\n<thead><tr><th class=\"col-4 align-middle\">Source</th><th class=\"col-8 align-middle\">Message</th></tr></thead>\n<tbody>\n"
-	workflowCommandTableEnd          = "</tbody>\n</table>\n"
+	workflowCommandTableHeading      = "<div class=\"flex\"><table class=\"flex-auto mb2\">\n<thead><tr><th class=\"col-4 align-middle\">Source</th><th class=\"col-8 align-middle\">Message</th></tr></thead>\n<tbody>\n"
+	workflowCommandTableEnd          = "</tbody>\n</table></div>\n"
 )
 
 // Runner executes verified actions using explicitly configured host tools.
@@ -1660,7 +1660,7 @@ func renderWorkflowCommandAnnotation(heading string, commands []workflowCommandA
 func renderWorkflowCommandTableRow(command workflowCommandAnnotation) string {
 	source := "General"
 	if command.file != "" {
-		location := command.file
+		location := filepath.Base(strings.ReplaceAll(command.file, "\\", "/"))
 		if command.location != "" {
 			location += ":" + command.location
 		}
@@ -1668,7 +1668,7 @@ func renderWorkflowCommandTableRow(command workflowCommandAnnotation) string {
 	}
 	detail := commandHTML(command.message)
 	if command.title != "" {
-		detail = "<strong>" + commandHTML(command.title) + "</strong><br>\n" + detail
+		detail = "<strong>" + commandHTML(command.title) + ":</strong> " + detail
 	}
 	return "<tr><td>" + source + "</td><td>" + detail + "</td></tr>\n"
 }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -42,8 +42,8 @@ const (
 	workflowCommandTruncationNotice  = "\n\n---\n_Workflow command annotations truncated at the 1 MiB limit._\n"
 	workflowWarningAnnotationHeading = "<h2 class=\"h4 mb2\">GitHub Actions warnings</h2>\n"
 	workflowErrorAnnotationHeading   = "<h2 class=\"h4 mb2\">GitHub Actions errors</h2>\n"
-	workflowCommandTableHeading      = "<div class=\"flex\"><table class=\"flex-auto mb2\">\n<thead><tr><th class=\"col-4 align-middle\">Source</th><th class=\"col-8 align-middle\">Message</th></tr></thead>\n<tbody>\n"
-	workflowCommandTableEnd          = "</tbody>\n</table></div>\n"
+	workflowCommandListHeading       = "<div class=\"mb2\">\n"
+	workflowCommandListEnd           = "</div>\n"
 )
 
 // Runner executes verified actions using explicitly configured host tools.
@@ -1477,9 +1477,9 @@ func (p *commandProcessor) appendWorkflowCommandAnnotationLocked(buffer *workflo
 	if buffer.truncated {
 		return
 	}
-	additional := len(renderWorkflowCommandTableRow(command))
+	additional := len(renderWorkflowCommandListItem(command))
 	if len(buffer.commands) == 0 {
-		additional += len(heading) + len(workflowCommandTableHeading) + len(workflowCommandTableEnd)
+		additional += len(heading) + len(workflowCommandListHeading) + len(workflowCommandListEnd)
 	}
 	if buffer.rendered+additional > maxJobAnnotationBytes-len(workflowCommandTruncationNotice) {
 		buffer.truncated = true
@@ -1643,13 +1643,13 @@ func renderWorkflowCommandAnnotation(heading string, commands []workflowCommandA
 
 	var rendered strings.Builder
 	rendered.WriteString(heading)
-	rendered.WriteString(workflowCommandTableHeading)
+	rendered.WriteString(workflowCommandListHeading)
 	for _, group := range groups {
 		for _, command := range group.commands {
-			rendered.WriteString(renderWorkflowCommandTableRow(command))
+			rendered.WriteString(renderWorkflowCommandListItem(command))
 		}
 	}
-	rendered.WriteString(workflowCommandTableEnd)
+	rendered.WriteString(workflowCommandListEnd)
 
 	var body string
 	var bodyTruncated bool
@@ -1657,7 +1657,7 @@ func renderWorkflowCommandAnnotation(heading string, commands []workflowCommandA
 	return body, bodyTruncated
 }
 
-func renderWorkflowCommandTableRow(command workflowCommandAnnotation) string {
+func renderWorkflowCommandListItem(command workflowCommandAnnotation) string {
 	source := "General"
 	if command.file != "" {
 		location := filepath.Base(strings.ReplaceAll(command.file, "\\", "/"))
@@ -1670,7 +1670,8 @@ func renderWorkflowCommandTableRow(command workflowCommandAnnotation) string {
 	if command.title != "" {
 		detail = "<strong>" + commandHTML(command.title) + ":</strong> " + detail
 	}
-	return "<tr><td>" + source + "</td><td>" + detail + "</td></tr>\n"
+	return "<div class=\"border-top py2\"><div>" + detail +
+		"</div><div class=\"mt1 muted\">" + source + "</div></div>\n"
 }
 
 func workflowCommandLocationLabel(properties map[string]string) string {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -40,8 +40,8 @@ const (
 
 	jobSummaryTruncationNotice       = "\n\n---\n_Job summary truncated at the 1 MiB limit._\n"
 	workflowCommandTruncationNotice  = "\n\n---\n_Workflow command annotations truncated at the 1 MiB limit._\n"
-	workflowWarningAnnotationHeading = "<h2 class=\"h3 mb2\">GitHub Actions warnings</h2>\n"
-	workflowErrorAnnotationHeading   = "<h2 class=\"h3 mb2\">GitHub Actions errors</h2>\n"
+	workflowWarningAnnotationHeading = "<h2 class=\"h4 mb2\">GitHub Actions warnings</h2>\n"
+	workflowErrorAnnotationHeading   = "<h2 class=\"h4 mb2\">GitHub Actions errors</h2>\n"
 	workflowCommandTableHeading      = "<table class=\"col-12 mb2\">\n<thead><tr><th class=\"col-4 align-middle\">Source</th><th class=\"col-8 align-middle\">Message</th></tr></thead>\n<tbody>\n"
 	workflowCommandTableEnd          = "</tbody>\n</table>\n"
 )

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1670,8 +1670,8 @@ func renderWorkflowCommandListItem(command workflowCommandAnnotation) string {
 	if command.title != "" {
 		detail = "<strong>" + commandHTML(command.title) + ":</strong> " + detail
 	}
-	return "<div class=\"border-top silver py2\"><div class=\"black\">" + detail +
-		"</div><div class=\"mt1 black\">" + source + "</div></div>\n"
+	return "<div class=\"border-top py2\"><div>" + detail +
+		"</div><div class=\"mt1\">" + source + "</div></div>\n"
 }
 
 func workflowCommandLocationLabel(properties map[string]string) string {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1670,8 +1670,8 @@ func renderWorkflowCommandListItem(command workflowCommandAnnotation) string {
 	if command.title != "" {
 		detail = "<strong>" + commandHTML(command.title) + ":</strong> " + detail
 	}
-	return "<div class=\"border-top py2\"><div>" + detail +
-		"</div><div class=\"mt1 muted\">" + source + "</div></div>\n"
+	return "<div class=\"border-top silver py2\"><div class=\"black\">" + detail +
+		"</div><div class=\"mt1 black\">" + source + "</div></div>\n"
 }
 
 func workflowCommandLocationLabel(properties map[string]string) string {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -3085,14 +3085,14 @@ func TestWorkflowCommandsProduceBoundedMaskedJobAnnotations(t *testing.T) {
 		}
 	}
 	for _, fragment := range []string{
-		"<h2 class=\"h4 mb2\">GitHub Actions warnings</h2>\n<div class=\"flex\"><table class=\"flex-auto mb2\">", `<th class="col-4 align-middle">Source</th><th class="col-8 align-middle">Message</th>`, "<td><code>cmd,main.go:12:3–12:5</code></td>", "<strong>Unsafe &lt;title&gt;:</strong> *** *** &lt;warning&gt;",
+		"<h2 class=\"h4 mb2\">GitHub Actions warnings</h2>\n<div class=\"mb2\">", `<div class="border-top py2"><div><strong>Unsafe &lt;title&gt;:</strong> *** *** &lt;warning&gt;</div>`, `<div class="mt1 muted"><code>cmd,main.go:12:3–12:5</code></div>`,
 	} {
 		if !strings.Contains(result.WarningAnnotations, fragment) {
 			t.Errorf("warning annotation lacks %q: %q", fragment, result.WarningAnnotations)
 		}
 	}
 	for _, fragment := range []string{
-		"<h2 class=\"h4 mb2\">GitHub Actions errors</h2>\n<div class=\"flex\"><table class=\"flex-auto mb2\">", "<td><code>main.go:9:2–9:4</code></td>", "*** &lt;error&gt;",
+		"<h2 class=\"h4 mb2\">GitHub Actions errors</h2>\n<div class=\"mb2\">", `<div class="mt1 muted"><code>main.go:9:2–9:4</code></div>`, "*** &lt;error&gt;",
 	} {
 		if !strings.Contains(result.ErrorAnnotations, fragment) {
 			t.Errorf("error annotation lacks %q: %q", fragment, result.ErrorAnnotations)
@@ -3121,17 +3121,17 @@ func TestWorkflowCommandAnnotationsGroupRowsByFile(t *testing.T) {
 	if truncated {
 		t.Fatal("small grouped annotation was truncated")
 	}
-	if first, second := strings.LastIndex(warnings, "first.go"), strings.Index(warnings, "second.go"); first < 0 || second < first || strings.Count(warnings, "<tr><td>") != 4 {
+	if first, second := strings.LastIndex(warnings, "first.go"), strings.Index(warnings, "second.go"); first < 0 || second < first || strings.Count(warnings, `class="border-top py2"`) != 4 {
 		t.Fatalf("annotation did not retain row order within first-seen file groups: %q", warnings)
 	}
-	for _, row := range []string{
-		"<td><code>first.go:2</code></td><td><strong>First:</strong> first message</td>",
-		"<td><code>first.go:9</code></td><td>another first message</td>",
-		"<td><code>second.go:7:3</code></td><td>second message</td>",
-		"<td>General</td><td><strong>General:</strong> general message</td>",
+	for _, item := range []string{
+		"<div><strong>First:</strong> first message</div><div class=\"mt1 muted\"><code>first.go:2</code></div>",
+		"<div>another first message</div><div class=\"mt1 muted\"><code>first.go:9</code></div>",
+		"<div>second message</div><div class=\"mt1 muted\"><code>second.go:7:3</code></div>",
+		"<div><strong>General:</strong> general message</div><div class=\"mt1 muted\">General</div>",
 	} {
-		if !strings.Contains(warnings, row) {
-			t.Errorf("annotation lacks row %q: %q", row, warnings)
+		if !strings.Contains(warnings, item) {
+			t.Errorf("annotation lacks item %q: %q", item, warnings)
 		}
 	}
 }
@@ -3373,8 +3373,8 @@ func TestWorkflowCommandAnnotationsAreConcurrentAndUTF8Bounded(t *testing.T) {
 	}
 	group.Wait()
 	warnings, truncated, _, _ := processor.workflowCommandAnnotations()
-	if truncated || strings.Count(warnings, "<tr><td>") != 100 {
-		t.Fatalf("concurrent warning annotation count = %d, truncated = %v", strings.Count(warnings, "<tr><td>"), truncated)
+	if truncated || strings.Count(warnings, `class="border-top py2"`) != 100 {
+		t.Fatalf("concurrent warning annotation count = %d, truncated = %v", strings.Count(warnings, `class="border-top py2"`), truncated)
 	}
 
 	processor = newCommandProcessor(io.Discard, io.Discard)
@@ -3397,7 +3397,7 @@ func TestWorkflowCommandAnnotationsNormalizeInvalidUTF8(t *testing.T) {
 	if truncated || !utf8.ValidString(warnings) || strings.Count(warnings, "\uFFFD") != 3 {
 		t.Fatalf("warning annotation = %q, truncated = %v, valid UTF-8 = %v", warnings, truncated, utf8.ValidString(warnings))
 	}
-	for _, fragment := range []string{"<td><code>bad\uFFFD.go</code></td>", "<td><strong>bad\uFFFD:</strong> bad\uFFFD</td>"} {
+	for _, fragment := range []string{`<div class="mt1 muted"><code>bad�.go</code></div>`, "<div><strong>bad\uFFFD:</strong> bad\uFFFD</div>"} {
 		if !strings.Contains(warnings, fragment) {
 			t.Fatalf("warning annotation lacks %q: %q", fragment, warnings)
 		}
@@ -3424,10 +3424,10 @@ func TestWorkflowCommandMasksCannotCorruptAnnotationMarkup(t *testing.T) {
 	_ = processor.process(io.Discard, "::add-mask::table")
 
 	warnings, truncated, _, _ := processor.workflowCommandAnnotations()
-	if truncated || !strings.Contains(warnings, `<td><code>***.go</code></td>`) || !strings.Contains(warnings, "<td><strong>***:</strong> s***uctured *** text</td>") {
+	if truncated || !strings.Contains(warnings, `<div class="mt1 muted"><code>***.go</code></div>`) || !strings.Contains(warnings, "<div><strong>***:</strong> s***uctured *** text</div>") {
 		t.Fatalf("masked warning annotation = %q, truncated = %v", warnings, truncated)
 	}
-	if strings.Count(warnings, "<table") != 1 || strings.Count(warnings, "</table>") != 1 || strings.Count(warnings, "<tr>") != strings.Count(warnings, "</tr>") {
+	if strings.Count(warnings, `class="border-top py2"`) != 1 || strings.Count(warnings, "<div") != strings.Count(warnings, "</div>") {
 		t.Fatalf("masks corrupted annotation markup: %q", warnings)
 	}
 }
@@ -3440,8 +3440,8 @@ func TestWorkflowCommandAnnotationsRemainBoundedAfterMaskExpansion(t *testing.T)
 	_ = processor.process(io.Discard, "::add-mask::x")
 
 	warnings, truncated, _, _ := processor.workflowCommandAnnotations()
-	if !truncated || strings.Contains(warnings, strings.Repeat("x", 100)) || !strings.HasSuffix(warnings, workflowCommandTableEnd) || strings.Count(warnings, "<tr><td>") != strings.Count(warnings, "</td></tr>") {
-		t.Fatalf("expanded warning annotation bytes = %d, rows = %d/%d, truncated = %v", len(warnings), strings.Count(warnings, "<tr><td>"), strings.Count(warnings, "</td></tr>"), truncated)
+	if !truncated || strings.Contains(warnings, strings.Repeat("x", 100)) || !strings.HasSuffix(warnings, workflowCommandListEnd) || strings.Count(warnings, `class="border-top py2"`)*3+1 != strings.Count(warnings, "</div>") {
+		t.Fatalf("expanded warning annotation bytes = %d, items = %d, closing divs = %d, truncated = %v", len(warnings), strings.Count(warnings, `class="border-top py2"`), strings.Count(warnings, "</div>"), truncated)
 	}
 	result := scrubJobResult(JobResult{WarningAnnotations: warnings, warningsTruncated: truncated}, processor.maskValues())
 	if len(result.WarningAnnotations) > maxJobAnnotationBytes || !utf8.ValidString(result.WarningAnnotations) || !strings.HasSuffix(result.WarningAnnotations, workflowCommandTruncationNotice) {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -3085,14 +3085,14 @@ func TestWorkflowCommandsProduceBoundedMaskedJobAnnotations(t *testing.T) {
 		}
 	}
 	for _, fragment := range []string{
-		"## GitHub Actions warnings", "### Warning", "Unsafe &lt;title&gt;", "cmd,main.go", "<strong>Line:</strong> <code>12</code>", "*** &lt;warning&gt;",
+		"<h2 class=\"h3 mb2\">GitHub Actions warnings</h2>\n<table class=\"mb2\">", `<th class="col-4 align-middle">Source</th><th class="col-2 align-middle">Title</th><th class="col-6 align-middle">Message</th>`, "<td><code>cmd,main.go:12:3–12:5</code></td>", "Unsafe &lt;title&gt;", "*** &lt;warning&gt;",
 	} {
 		if !strings.Contains(result.WarningAnnotations, fragment) {
 			t.Errorf("warning annotation lacks %q: %q", fragment, result.WarningAnnotations)
 		}
 	}
 	for _, fragment := range []string{
-		"## GitHub Actions errors", "### Error", "<strong>Line:</strong> <code>9</code>", "<strong>Column:</strong> <code>2</code>", "*** &lt;error&gt;",
+		"<h2 class=\"h3 mb2\">GitHub Actions errors</h2>\n<table class=\"mb2\">", "<td><code>main.go:9:2–9:4</code></td>", "*** &lt;error&gt;",
 	} {
 		if !strings.Contains(result.ErrorAnnotations, fragment) {
 			t.Errorf("error annotation lacks %q: %q", fragment, result.ErrorAnnotations)
@@ -3103,6 +3103,81 @@ func TestWorkflowCommandsProduceBoundedMaskedJobAnnotations(t *testing.T) {
 	}
 	if strings.Contains(stderr.String(), "::error") || !strings.Contains(stderr.String(), "error: *** <error>") {
 		t.Fatalf("stderr = %q, want masked rendered error", stderr.String())
+	}
+}
+
+func TestWorkflowCommandAnnotationsGroupRowsByFile(t *testing.T) {
+	processor := newCommandProcessor(io.Discard, io.Discard)
+	for _, command := range []string{
+		"::warning file=first.go,line=2,title=First::first message",
+		"::warning file=second.go,line=7,col=3::second message",
+		"::warning file=first.go,line=9::another first message",
+		"::warning title=General::general message",
+	} {
+		_ = processor.process(io.Discard, command)
+	}
+
+	warnings, truncated, _, _ := processor.workflowCommandAnnotations()
+	if truncated {
+		t.Fatal("small grouped annotation was truncated")
+	}
+	if first, second := strings.LastIndex(warnings, "first.go"), strings.Index(warnings, "second.go"); first < 0 || second < first || strings.Count(warnings, "<tr><td>") != 4 {
+		t.Fatalf("annotation did not retain row order within first-seen file groups: %q", warnings)
+	}
+	for _, row := range []string{
+		"<td><code>first.go:2</code></td><td>First</td><td>first message</td>",
+		"<td><code>first.go:9</code></td><td></td><td>another first message</td>",
+		"<td><code>second.go:7:3</code></td><td></td><td>second message</td>",
+		"<td>General</td><td>General</td><td>general message</td>",
+	} {
+		if !strings.Contains(warnings, row) {
+			t.Errorf("annotation lacks row %q: %q", row, warnings)
+		}
+	}
+}
+
+func TestWorkflowCommandAnnotationRetainsOnlyOwnedRenderedFields(t *testing.T) {
+	processor := newCommandProcessor(io.Discard, io.Discard)
+	properties := map[string]string{
+		"file": "main.go", "title": "Lint", "line": "7", "unknown": strings.Repeat("unused", 100_000),
+	}
+	processor.mu.Lock()
+	processor.appendWorkflowCommandLocked(&processor.warnings, workflowWarningAnnotationHeading, parsedWorkflowCommand{properties: properties, message: "message"})
+	processor.mu.Unlock()
+	properties["file"] = "changed.go"
+	properties["title"] = "Changed"
+
+	if len(processor.warnings.commands) != 1 {
+		t.Fatalf("retained commands = %d, want 1", len(processor.warnings.commands))
+	}
+	got := processor.warnings.commands[0]
+	if got.file != "main.go" || got.title != "Lint" || got.location != "7" || got.message != "message" {
+		t.Fatalf("retained annotation = %#v", got)
+	}
+	if processor.warnings.rendered >= len(properties["unknown"]) {
+		t.Fatalf("rendered size %d retained unknown property bytes", processor.warnings.rendered)
+	}
+}
+
+func TestWorkflowCommandLocationLabels(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		properties map[string]string
+		want       string
+	}{
+		{name: "line", properties: map[string]string{"line": "5"}, want: "5"},
+		{name: "point", properties: map[string]string{"line": "5", "col": "3"}, want: "5:3"},
+		{name: "same-line range", properties: map[string]string{"line": "5", "col": "3", "endcolumn": "8"}, want: "5:3–5:8"},
+		{name: "explicit same point", properties: map[string]string{"line": "5", "endline": "5", "col": "3"}, want: "5:3"},
+		{name: "multiline range", properties: map[string]string{"line": "5", "endline": "6", "col": "3", "endcolumn": "8"}, want: "5–6"},
+		{name: "end line supplies start", properties: map[string]string{"endline": "5"}, want: "5"},
+		{name: "reversed range", properties: map[string]string{"line": "5", "endline": "4"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := workflowCommandLocationLabel(test.properties); got != test.want {
+				t.Fatalf("workflowCommandLocationLabel() = %q, want %q", got, test.want)
+			}
+		})
 	}
 }
 
@@ -3298,8 +3373,8 @@ func TestWorkflowCommandAnnotationsAreConcurrentAndUTF8Bounded(t *testing.T) {
 	}
 	group.Wait()
 	warnings, truncated, _, _ := processor.workflowCommandAnnotations()
-	if truncated || strings.Count(warnings, "### Warning") != 100 {
-		t.Fatalf("concurrent warning annotation count = %d, truncated = %v", strings.Count(warnings, "### Warning"), truncated)
+	if truncated || strings.Count(warnings, "<tr><td>") != 100 {
+		t.Fatalf("concurrent warning annotation count = %d, truncated = %v", strings.Count(warnings, "<tr><td>"), truncated)
 	}
 
 	processor = newCommandProcessor(io.Discard, io.Discard)
@@ -3322,7 +3397,7 @@ func TestWorkflowCommandAnnotationsNormalizeInvalidUTF8(t *testing.T) {
 	if truncated || !utf8.ValidString(warnings) || strings.Count(warnings, "\uFFFD") != 3 {
 		t.Fatalf("warning annotation = %q, truncated = %v, valid UTF-8 = %v", warnings, truncated, utf8.ValidString(warnings))
 	}
-	for _, fragment := range []string{"<strong>Title:</strong> <code>bad\uFFFD</code>", "<strong>File:</strong> <code>bad\uFFFD.go</code>", "<p>bad\uFFFD</p>"} {
+	for _, fragment := range []string{"<td><code>bad\uFFFD.go</code></td>", "<td>bad\uFFFD</td><td>bad\uFFFD</td>"} {
 		if !strings.Contains(warnings, fragment) {
 			t.Fatalf("warning annotation lacks %q: %q", fragment, warnings)
 		}
@@ -3342,12 +3417,35 @@ func TestWorkflowCommandAnnotationScrubbingPreservesUTF8(t *testing.T) {
 	}
 }
 
-func TestWorkflowCommandAnnotationsRemainBoundedAfterSecretScrubbing(t *testing.T) {
-	secret := "x"
-	result := JobResult{WarningAnnotations: strings.Repeat(secret, maxJobAnnotationBytes)}
-	result = scrubJobResult(result, []string{secret})
-	if len(result.WarningAnnotations) > maxJobAnnotationBytes || !utf8.ValidString(result.WarningAnnotations) || strings.Contains(result.WarningAnnotations, secret) || !strings.HasSuffix(result.WarningAnnotations, workflowCommandTruncationNotice) {
-		t.Fatalf("scrubbed warnings bytes = %d, valid UTF-8 = %v", len(result.WarningAnnotations), utf8.ValidString(result.WarningAnnotations))
+func TestWorkflowCommandMasksCannotCorruptAnnotationMarkup(t *testing.T) {
+	processor := newCommandProcessor(io.Discard, io.Discard)
+	_ = processor.process(io.Discard, "::warning file=table.go,title=tr::structured table text")
+	_ = processor.process(io.Discard, "::add-mask::tr")
+	_ = processor.process(io.Discard, "::add-mask::table")
+
+	warnings, truncated, _, _ := processor.workflowCommandAnnotations()
+	if truncated || !strings.Contains(warnings, `<td><code>***.go</code></td>`) || !strings.Contains(warnings, "<td>***</td><td>s***uctured *** text</td>") {
+		t.Fatalf("masked warning annotation = %q, truncated = %v", warnings, truncated)
+	}
+	if strings.Count(warnings, "<table") != 1 || strings.Count(warnings, "</table>") != 1 || strings.Count(warnings, "<tr>") != strings.Count(warnings, "</tr>") {
+		t.Fatalf("masks corrupted annotation markup: %q", warnings)
+	}
+}
+
+func TestWorkflowCommandAnnotationsRemainBoundedAfterMaskExpansion(t *testing.T) {
+	processor := newCommandProcessor(io.Discard, io.Discard)
+	for range 5000 {
+		_ = processor.process(io.Discard, "::warning file=main.go::"+strings.Repeat("x", 100))
+	}
+	_ = processor.process(io.Discard, "::add-mask::x")
+
+	warnings, truncated, _, _ := processor.workflowCommandAnnotations()
+	if !truncated || strings.Contains(warnings, "x") || !strings.HasSuffix(warnings, workflowCommandTableEnd) || strings.Count(warnings, "<tr><td>") != strings.Count(warnings, "</td></tr>") {
+		t.Fatalf("expanded warning annotation bytes = %d, rows = %d/%d, truncated = %v", len(warnings), strings.Count(warnings, "<tr><td>"), strings.Count(warnings, "</td></tr>"), truncated)
+	}
+	result := scrubJobResult(JobResult{WarningAnnotations: warnings, warningsTruncated: truncated}, processor.maskValues())
+	if len(result.WarningAnnotations) > maxJobAnnotationBytes || !utf8.ValidString(result.WarningAnnotations) || !strings.HasSuffix(result.WarningAnnotations, workflowCommandTruncationNotice) {
+		t.Fatalf("final warning annotation bytes = %d, valid UTF-8 = %v", len(result.WarningAnnotations), utf8.ValidString(result.WarningAnnotations))
 	}
 }
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -3085,7 +3085,7 @@ func TestWorkflowCommandsProduceBoundedMaskedJobAnnotations(t *testing.T) {
 		}
 	}
 	for _, fragment := range []string{
-		"<h2 class=\"h4 mb2\">GitHub Actions warnings</h2>\n<div class=\"mb2\">", `<div class="border-top py2"><div><strong>Unsafe &lt;title&gt;:</strong> *** *** &lt;warning&gt;</div>`, `<div class="mt1"><code>cmd,main.go:12:3–12:5</code></div>`,
+		"<h2 class=\"h4 mb2\">GitHub Actions warnings</h2>\n<div class=\"mb2\">", `<div class="border-top border-silver py2"><div><strong>Unsafe &lt;title&gt;:</strong> *** *** &lt;warning&gt;</div>`, `<div class="mt1"><code>cmd,main.go:12:3–12:5</code></div>`,
 	} {
 		if !strings.Contains(result.WarningAnnotations, fragment) {
 			t.Errorf("warning annotation lacks %q: %q", fragment, result.WarningAnnotations)
@@ -3121,7 +3121,7 @@ func TestWorkflowCommandAnnotationsGroupRowsByFile(t *testing.T) {
 	if truncated {
 		t.Fatal("small grouped annotation was truncated")
 	}
-	if first, second := strings.LastIndex(warnings, "first.go"), strings.Index(warnings, "second.go"); first < 0 || second < first || strings.Count(warnings, `class="border-top py2"`) != 4 {
+	if first, second := strings.LastIndex(warnings, "first.go"), strings.Index(warnings, "second.go"); first < 0 || second < first || strings.Count(warnings, `class="border-top border-silver py2"`) != 4 {
 		t.Fatalf("annotation did not retain row order within first-seen file groups: %q", warnings)
 	}
 	for _, item := range []string{
@@ -3373,8 +3373,8 @@ func TestWorkflowCommandAnnotationsAreConcurrentAndUTF8Bounded(t *testing.T) {
 	}
 	group.Wait()
 	warnings, truncated, _, _ := processor.workflowCommandAnnotations()
-	if truncated || strings.Count(warnings, `class="border-top py2"`) != 100 {
-		t.Fatalf("concurrent warning annotation count = %d, truncated = %v", strings.Count(warnings, `class="border-top py2"`), truncated)
+	if truncated || strings.Count(warnings, `class="border-top border-silver py2"`) != 100 {
+		t.Fatalf("concurrent warning annotation count = %d, truncated = %v", strings.Count(warnings, `class="border-top border-silver py2"`), truncated)
 	}
 
 	processor = newCommandProcessor(io.Discard, io.Discard)
@@ -3427,7 +3427,7 @@ func TestWorkflowCommandMasksCannotCorruptAnnotationMarkup(t *testing.T) {
 	if truncated || !strings.Contains(warnings, `<div class="mt1"><code>***.go</code></div>`) || !strings.Contains(warnings, "<div><strong>***:</strong> s***uctured *** text</div>") {
 		t.Fatalf("masked warning annotation = %q, truncated = %v", warnings, truncated)
 	}
-	if strings.Count(warnings, `class="border-top py2"`) != 1 || strings.Count(warnings, "<div") != strings.Count(warnings, "</div>") {
+	if strings.Count(warnings, `class="border-top border-silver py2"`) != 1 || strings.Count(warnings, "<div") != strings.Count(warnings, "</div>") {
 		t.Fatalf("masks corrupted annotation markup: %q", warnings)
 	}
 }
@@ -3440,8 +3440,8 @@ func TestWorkflowCommandAnnotationsRemainBoundedAfterMaskExpansion(t *testing.T)
 	_ = processor.process(io.Discard, "::add-mask::x")
 
 	warnings, truncated, _, _ := processor.workflowCommandAnnotations()
-	if !truncated || strings.Contains(warnings, strings.Repeat("x", 100)) || !strings.HasSuffix(warnings, workflowCommandListEnd) || strings.Count(warnings, `class="border-top py2"`)*3+1 != strings.Count(warnings, "</div>") {
-		t.Fatalf("expanded warning annotation bytes = %d, items = %d, closing divs = %d, truncated = %v", len(warnings), strings.Count(warnings, `class="border-top py2"`), strings.Count(warnings, "</div>"), truncated)
+	if !truncated || strings.Contains(warnings, strings.Repeat("x", 100)) || !strings.HasSuffix(warnings, workflowCommandListEnd) || strings.Count(warnings, `class="border-top border-silver py2"`)*3+1 != strings.Count(warnings, "</div>") {
+		t.Fatalf("expanded warning annotation bytes = %d, items = %d, closing divs = %d, truncated = %v", len(warnings), strings.Count(warnings, `class="border-top border-silver py2"`), strings.Count(warnings, "</div>"), truncated)
 	}
 	result := scrubJobResult(JobResult{WarningAnnotations: warnings, warningsTruncated: truncated}, processor.maskValues())
 	if len(result.WarningAnnotations) > maxJobAnnotationBytes || !utf8.ValidString(result.WarningAnnotations) || !strings.HasSuffix(result.WarningAnnotations, workflowCommandTruncationNotice) {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -3085,14 +3085,14 @@ func TestWorkflowCommandsProduceBoundedMaskedJobAnnotations(t *testing.T) {
 		}
 	}
 	for _, fragment := range []string{
-		"<h2 class=\"h4 mb2\">GitHub Actions warnings</h2>\n<table class=\"col-12 mb2\">", `<th class="col-4 align-middle">Source</th><th class="col-8 align-middle">Message</th>`, "<td><code>cmd,main.go:12:3–12:5</code></td>", "<strong>Unsafe &lt;title&gt;</strong><br>", "*** &lt;warning&gt;",
+		"<h2 class=\"h4 mb2\">GitHub Actions warnings</h2>\n<div class=\"flex\"><table class=\"flex-auto mb2\">", `<th class="col-4 align-middle">Source</th><th class="col-8 align-middle">Message</th>`, "<td><code>cmd,main.go:12:3–12:5</code></td>", "<strong>Unsafe &lt;title&gt;:</strong> *** *** &lt;warning&gt;",
 	} {
 		if !strings.Contains(result.WarningAnnotations, fragment) {
 			t.Errorf("warning annotation lacks %q: %q", fragment, result.WarningAnnotations)
 		}
 	}
 	for _, fragment := range []string{
-		"<h2 class=\"h4 mb2\">GitHub Actions errors</h2>\n<table class=\"col-12 mb2\">", "<td><code>main.go:9:2–9:4</code></td>", "*** &lt;error&gt;",
+		"<h2 class=\"h4 mb2\">GitHub Actions errors</h2>\n<div class=\"flex\"><table class=\"flex-auto mb2\">", "<td><code>main.go:9:2–9:4</code></td>", "*** &lt;error&gt;",
 	} {
 		if !strings.Contains(result.ErrorAnnotations, fragment) {
 			t.Errorf("error annotation lacks %q: %q", fragment, result.ErrorAnnotations)
@@ -3109,9 +3109,9 @@ func TestWorkflowCommandsProduceBoundedMaskedJobAnnotations(t *testing.T) {
 func TestWorkflowCommandAnnotationsGroupRowsByFile(t *testing.T) {
 	processor := newCommandProcessor(io.Discard, io.Discard)
 	for _, command := range []string{
-		"::warning file=first.go,line=2,title=First::first message",
+		"::warning file=path/to/first.go,line=2,title=First::first message",
 		"::warning file=second.go,line=7,col=3::second message",
-		"::warning file=first.go,line=9::another first message",
+		"::warning file=path/to/first.go,line=9::another first message",
 		"::warning title=General::general message",
 	} {
 		_ = processor.process(io.Discard, command)
@@ -3125,10 +3125,10 @@ func TestWorkflowCommandAnnotationsGroupRowsByFile(t *testing.T) {
 		t.Fatalf("annotation did not retain row order within first-seen file groups: %q", warnings)
 	}
 	for _, row := range []string{
-		"<td><code>first.go:2</code></td><td><strong>First</strong><br>\nfirst message</td>",
+		"<td><code>first.go:2</code></td><td><strong>First:</strong> first message</td>",
 		"<td><code>first.go:9</code></td><td>another first message</td>",
 		"<td><code>second.go:7:3</code></td><td>second message</td>",
-		"<td>General</td><td><strong>General</strong><br>\ngeneral message</td>",
+		"<td>General</td><td><strong>General:</strong> general message</td>",
 	} {
 		if !strings.Contains(warnings, row) {
 			t.Errorf("annotation lacks row %q: %q", row, warnings)
@@ -3397,7 +3397,7 @@ func TestWorkflowCommandAnnotationsNormalizeInvalidUTF8(t *testing.T) {
 	if truncated || !utf8.ValidString(warnings) || strings.Count(warnings, "\uFFFD") != 3 {
 		t.Fatalf("warning annotation = %q, truncated = %v, valid UTF-8 = %v", warnings, truncated, utf8.ValidString(warnings))
 	}
-	for _, fragment := range []string{"<td><code>bad\uFFFD.go</code></td>", "<td><strong>bad\uFFFD</strong><br>\nbad\uFFFD</td>"} {
+	for _, fragment := range []string{"<td><code>bad\uFFFD.go</code></td>", "<td><strong>bad\uFFFD:</strong> bad\uFFFD</td>"} {
 		if !strings.Contains(warnings, fragment) {
 			t.Fatalf("warning annotation lacks %q: %q", fragment, warnings)
 		}
@@ -3424,7 +3424,7 @@ func TestWorkflowCommandMasksCannotCorruptAnnotationMarkup(t *testing.T) {
 	_ = processor.process(io.Discard, "::add-mask::table")
 
 	warnings, truncated, _, _ := processor.workflowCommandAnnotations()
-	if truncated || !strings.Contains(warnings, `<td><code>***.go</code></td>`) || !strings.Contains(warnings, "<td><strong>***</strong><br>\ns***uctured *** text</td>") {
+	if truncated || !strings.Contains(warnings, `<td><code>***.go</code></td>`) || !strings.Contains(warnings, "<td><strong>***:</strong> s***uctured *** text</td>") {
 		t.Fatalf("masked warning annotation = %q, truncated = %v", warnings, truncated)
 	}
 	if strings.Count(warnings, "<table") != 1 || strings.Count(warnings, "</table>") != 1 || strings.Count(warnings, "<tr>") != strings.Count(warnings, "</tr>") {
@@ -3440,7 +3440,7 @@ func TestWorkflowCommandAnnotationsRemainBoundedAfterMaskExpansion(t *testing.T)
 	_ = processor.process(io.Discard, "::add-mask::x")
 
 	warnings, truncated, _, _ := processor.workflowCommandAnnotations()
-	if !truncated || strings.Contains(warnings, "x") || !strings.HasSuffix(warnings, workflowCommandTableEnd) || strings.Count(warnings, "<tr><td>") != strings.Count(warnings, "</td></tr>") {
+	if !truncated || strings.Contains(warnings, strings.Repeat("x", 100)) || !strings.HasSuffix(warnings, workflowCommandTableEnd) || strings.Count(warnings, "<tr><td>") != strings.Count(warnings, "</td></tr>") {
 		t.Fatalf("expanded warning annotation bytes = %d, rows = %d/%d, truncated = %v", len(warnings), strings.Count(warnings, "<tr><td>"), strings.Count(warnings, "</td></tr>"), truncated)
 	}
 	result := scrubJobResult(JobResult{WarningAnnotations: warnings, warningsTruncated: truncated}, processor.maskValues())

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -3085,14 +3085,14 @@ func TestWorkflowCommandsProduceBoundedMaskedJobAnnotations(t *testing.T) {
 		}
 	}
 	for _, fragment := range []string{
-		"<h2 class=\"h3 mb2\">GitHub Actions warnings</h2>\n<table class=\"col-12 mb2\">", `<th class="col-4 align-middle">Source</th><th class="col-8 align-middle">Message</th>`, "<td><code>cmd,main.go:12:3–12:5</code></td>", "<strong>Unsafe &lt;title&gt;</strong><br>", "*** &lt;warning&gt;",
+		"<h2 class=\"h4 mb2\">GitHub Actions warnings</h2>\n<table class=\"col-12 mb2\">", `<th class="col-4 align-middle">Source</th><th class="col-8 align-middle">Message</th>`, "<td><code>cmd,main.go:12:3–12:5</code></td>", "<strong>Unsafe &lt;title&gt;</strong><br>", "*** &lt;warning&gt;",
 	} {
 		if !strings.Contains(result.WarningAnnotations, fragment) {
 			t.Errorf("warning annotation lacks %q: %q", fragment, result.WarningAnnotations)
 		}
 	}
 	for _, fragment := range []string{
-		"<h2 class=\"h3 mb2\">GitHub Actions errors</h2>\n<table class=\"col-12 mb2\">", "<td><code>main.go:9:2–9:4</code></td>", "*** &lt;error&gt;",
+		"<h2 class=\"h4 mb2\">GitHub Actions errors</h2>\n<table class=\"col-12 mb2\">", "<td><code>main.go:9:2–9:4</code></td>", "*** &lt;error&gt;",
 	} {
 		if !strings.Contains(result.ErrorAnnotations, fragment) {
 			t.Errorf("error annotation lacks %q: %q", fragment, result.ErrorAnnotations)

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -3085,14 +3085,14 @@ func TestWorkflowCommandsProduceBoundedMaskedJobAnnotations(t *testing.T) {
 		}
 	}
 	for _, fragment := range []string{
-		"<h2 class=\"h4 mb2\">GitHub Actions warnings</h2>\n<div class=\"mb2\">", `<div class="border-top py2"><div><strong>Unsafe &lt;title&gt;:</strong> *** *** &lt;warning&gt;</div>`, `<div class="mt1 muted"><code>cmd,main.go:12:3–12:5</code></div>`,
+		"<h2 class=\"h4 mb2\">GitHub Actions warnings</h2>\n<div class=\"mb2\">", `<div class="border-top silver py2"><div class="black"><strong>Unsafe &lt;title&gt;:</strong> *** *** &lt;warning&gt;</div>`, `<div class="mt1 black"><code>cmd,main.go:12:3–12:5</code></div>`,
 	} {
 		if !strings.Contains(result.WarningAnnotations, fragment) {
 			t.Errorf("warning annotation lacks %q: %q", fragment, result.WarningAnnotations)
 		}
 	}
 	for _, fragment := range []string{
-		"<h2 class=\"h4 mb2\">GitHub Actions errors</h2>\n<div class=\"mb2\">", `<div class="mt1 muted"><code>main.go:9:2–9:4</code></div>`, "*** &lt;error&gt;",
+		"<h2 class=\"h4 mb2\">GitHub Actions errors</h2>\n<div class=\"mb2\">", `<div class="mt1 black"><code>main.go:9:2–9:4</code></div>`, "*** &lt;error&gt;",
 	} {
 		if !strings.Contains(result.ErrorAnnotations, fragment) {
 			t.Errorf("error annotation lacks %q: %q", fragment, result.ErrorAnnotations)
@@ -3121,14 +3121,14 @@ func TestWorkflowCommandAnnotationsGroupRowsByFile(t *testing.T) {
 	if truncated {
 		t.Fatal("small grouped annotation was truncated")
 	}
-	if first, second := strings.LastIndex(warnings, "first.go"), strings.Index(warnings, "second.go"); first < 0 || second < first || strings.Count(warnings, `class="border-top py2"`) != 4 {
+	if first, second := strings.LastIndex(warnings, "first.go"), strings.Index(warnings, "second.go"); first < 0 || second < first || strings.Count(warnings, `class="border-top silver py2"`) != 4 {
 		t.Fatalf("annotation did not retain row order within first-seen file groups: %q", warnings)
 	}
 	for _, item := range []string{
-		"<div><strong>First:</strong> first message</div><div class=\"mt1 muted\"><code>first.go:2</code></div>",
-		"<div>another first message</div><div class=\"mt1 muted\"><code>first.go:9</code></div>",
-		"<div>second message</div><div class=\"mt1 muted\"><code>second.go:7:3</code></div>",
-		"<div><strong>General:</strong> general message</div><div class=\"mt1 muted\">General</div>",
+		"<div class=\"black\"><strong>First:</strong> first message</div><div class=\"mt1 black\"><code>first.go:2</code></div>",
+		"<div class=\"black\">another first message</div><div class=\"mt1 black\"><code>first.go:9</code></div>",
+		"<div class=\"black\">second message</div><div class=\"mt1 black\"><code>second.go:7:3</code></div>",
+		"<div class=\"black\"><strong>General:</strong> general message</div><div class=\"mt1 black\">General</div>",
 	} {
 		if !strings.Contains(warnings, item) {
 			t.Errorf("annotation lacks item %q: %q", item, warnings)
@@ -3373,8 +3373,8 @@ func TestWorkflowCommandAnnotationsAreConcurrentAndUTF8Bounded(t *testing.T) {
 	}
 	group.Wait()
 	warnings, truncated, _, _ := processor.workflowCommandAnnotations()
-	if truncated || strings.Count(warnings, `class="border-top py2"`) != 100 {
-		t.Fatalf("concurrent warning annotation count = %d, truncated = %v", strings.Count(warnings, `class="border-top py2"`), truncated)
+	if truncated || strings.Count(warnings, `class="border-top silver py2"`) != 100 {
+		t.Fatalf("concurrent warning annotation count = %d, truncated = %v", strings.Count(warnings, `class="border-top silver py2"`), truncated)
 	}
 
 	processor = newCommandProcessor(io.Discard, io.Discard)
@@ -3397,7 +3397,7 @@ func TestWorkflowCommandAnnotationsNormalizeInvalidUTF8(t *testing.T) {
 	if truncated || !utf8.ValidString(warnings) || strings.Count(warnings, "\uFFFD") != 3 {
 		t.Fatalf("warning annotation = %q, truncated = %v, valid UTF-8 = %v", warnings, truncated, utf8.ValidString(warnings))
 	}
-	for _, fragment := range []string{`<div class="mt1 muted"><code>bad�.go</code></div>`, "<div><strong>bad\uFFFD:</strong> bad\uFFFD</div>"} {
+	for _, fragment := range []string{`<div class="mt1 black"><code>bad�.go</code></div>`, "<div class=\"black\"><strong>bad\uFFFD:</strong> bad\uFFFD</div>"} {
 		if !strings.Contains(warnings, fragment) {
 			t.Fatalf("warning annotation lacks %q: %q", fragment, warnings)
 		}
@@ -3424,10 +3424,10 @@ func TestWorkflowCommandMasksCannotCorruptAnnotationMarkup(t *testing.T) {
 	_ = processor.process(io.Discard, "::add-mask::table")
 
 	warnings, truncated, _, _ := processor.workflowCommandAnnotations()
-	if truncated || !strings.Contains(warnings, `<div class="mt1 muted"><code>***.go</code></div>`) || !strings.Contains(warnings, "<div><strong>***:</strong> s***uctured *** text</div>") {
+	if truncated || !strings.Contains(warnings, `<div class="mt1 black"><code>***.go</code></div>`) || !strings.Contains(warnings, "<div class=\"black\"><strong>***:</strong> s***uctured *** text</div>") {
 		t.Fatalf("masked warning annotation = %q, truncated = %v", warnings, truncated)
 	}
-	if strings.Count(warnings, `class="border-top py2"`) != 1 || strings.Count(warnings, "<div") != strings.Count(warnings, "</div>") {
+	if strings.Count(warnings, `class="border-top silver py2"`) != 1 || strings.Count(warnings, "<div") != strings.Count(warnings, "</div>") {
 		t.Fatalf("masks corrupted annotation markup: %q", warnings)
 	}
 }
@@ -3440,8 +3440,8 @@ func TestWorkflowCommandAnnotationsRemainBoundedAfterMaskExpansion(t *testing.T)
 	_ = processor.process(io.Discard, "::add-mask::x")
 
 	warnings, truncated, _, _ := processor.workflowCommandAnnotations()
-	if !truncated || strings.Contains(warnings, strings.Repeat("x", 100)) || !strings.HasSuffix(warnings, workflowCommandListEnd) || strings.Count(warnings, `class="border-top py2"`)*3+1 != strings.Count(warnings, "</div>") {
-		t.Fatalf("expanded warning annotation bytes = %d, items = %d, closing divs = %d, truncated = %v", len(warnings), strings.Count(warnings, `class="border-top py2"`), strings.Count(warnings, "</div>"), truncated)
+	if !truncated || strings.Contains(warnings, strings.Repeat("x", 100)) || !strings.HasSuffix(warnings, workflowCommandListEnd) || strings.Count(warnings, `class="border-top silver py2"`)*3+1 != strings.Count(warnings, "</div>") {
+		t.Fatalf("expanded warning annotation bytes = %d, items = %d, closing divs = %d, truncated = %v", len(warnings), strings.Count(warnings, `class="border-top silver py2"`), strings.Count(warnings, "</div>"), truncated)
 	}
 	result := scrubJobResult(JobResult{WarningAnnotations: warnings, warningsTruncated: truncated}, processor.maskValues())
 	if len(result.WarningAnnotations) > maxJobAnnotationBytes || !utf8.ValidString(result.WarningAnnotations) || !strings.HasSuffix(result.WarningAnnotations, workflowCommandTruncationNotice) {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -3085,14 +3085,14 @@ func TestWorkflowCommandsProduceBoundedMaskedJobAnnotations(t *testing.T) {
 		}
 	}
 	for _, fragment := range []string{
-		"<h2 class=\"h3 mb2\">GitHub Actions warnings</h2>\n<table class=\"mb2\">", `<th class="col-4 align-middle">Source</th><th class="col-2 align-middle">Title</th><th class="col-6 align-middle">Message</th>`, "<td><code>cmd,main.go:12:3–12:5</code></td>", "Unsafe &lt;title&gt;", "*** &lt;warning&gt;",
+		"<h2 class=\"h3 mb2\">GitHub Actions warnings</h2>\n<table class=\"col-12 mb2\">", `<th class="col-4 align-middle">Source</th><th class="col-8 align-middle">Message</th>`, "<td><code>cmd,main.go:12:3–12:5</code></td>", "<strong>Unsafe &lt;title&gt;</strong><br>", "*** &lt;warning&gt;",
 	} {
 		if !strings.Contains(result.WarningAnnotations, fragment) {
 			t.Errorf("warning annotation lacks %q: %q", fragment, result.WarningAnnotations)
 		}
 	}
 	for _, fragment := range []string{
-		"<h2 class=\"h3 mb2\">GitHub Actions errors</h2>\n<table class=\"mb2\">", "<td><code>main.go:9:2–9:4</code></td>", "*** &lt;error&gt;",
+		"<h2 class=\"h3 mb2\">GitHub Actions errors</h2>\n<table class=\"col-12 mb2\">", "<td><code>main.go:9:2–9:4</code></td>", "*** &lt;error&gt;",
 	} {
 		if !strings.Contains(result.ErrorAnnotations, fragment) {
 			t.Errorf("error annotation lacks %q: %q", fragment, result.ErrorAnnotations)
@@ -3125,10 +3125,10 @@ func TestWorkflowCommandAnnotationsGroupRowsByFile(t *testing.T) {
 		t.Fatalf("annotation did not retain row order within first-seen file groups: %q", warnings)
 	}
 	for _, row := range []string{
-		"<td><code>first.go:2</code></td><td>First</td><td>first message</td>",
-		"<td><code>first.go:9</code></td><td></td><td>another first message</td>",
-		"<td><code>second.go:7:3</code></td><td></td><td>second message</td>",
-		"<td>General</td><td>General</td><td>general message</td>",
+		"<td><code>first.go:2</code></td><td><strong>First</strong><br>\nfirst message</td>",
+		"<td><code>first.go:9</code></td><td>another first message</td>",
+		"<td><code>second.go:7:3</code></td><td>second message</td>",
+		"<td>General</td><td><strong>General</strong><br>\ngeneral message</td>",
 	} {
 		if !strings.Contains(warnings, row) {
 			t.Errorf("annotation lacks row %q: %q", row, warnings)
@@ -3397,7 +3397,7 @@ func TestWorkflowCommandAnnotationsNormalizeInvalidUTF8(t *testing.T) {
 	if truncated || !utf8.ValidString(warnings) || strings.Count(warnings, "\uFFFD") != 3 {
 		t.Fatalf("warning annotation = %q, truncated = %v, valid UTF-8 = %v", warnings, truncated, utf8.ValidString(warnings))
 	}
-	for _, fragment := range []string{"<td><code>bad\uFFFD.go</code></td>", "<td>bad\uFFFD</td><td>bad\uFFFD</td>"} {
+	for _, fragment := range []string{"<td><code>bad\uFFFD.go</code></td>", "<td><strong>bad\uFFFD</strong><br>\nbad\uFFFD</td>"} {
 		if !strings.Contains(warnings, fragment) {
 			t.Fatalf("warning annotation lacks %q: %q", fragment, warnings)
 		}
@@ -3424,7 +3424,7 @@ func TestWorkflowCommandMasksCannotCorruptAnnotationMarkup(t *testing.T) {
 	_ = processor.process(io.Discard, "::add-mask::table")
 
 	warnings, truncated, _, _ := processor.workflowCommandAnnotations()
-	if truncated || !strings.Contains(warnings, `<td><code>***.go</code></td>`) || !strings.Contains(warnings, "<td>***</td><td>s***uctured *** text</td>") {
+	if truncated || !strings.Contains(warnings, `<td><code>***.go</code></td>`) || !strings.Contains(warnings, "<td><strong>***</strong><br>\ns***uctured *** text</td>") {
 		t.Fatalf("masked warning annotation = %q, truncated = %v", warnings, truncated)
 	}
 	if strings.Count(warnings, "<table") != 1 || strings.Count(warnings, "</table>") != 1 || strings.Count(warnings, "<tr>") != strings.Count(warnings, "</tr>") {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -3085,14 +3085,14 @@ func TestWorkflowCommandsProduceBoundedMaskedJobAnnotations(t *testing.T) {
 		}
 	}
 	for _, fragment := range []string{
-		"<h2 class=\"h4 mb2\">GitHub Actions warnings</h2>\n<div class=\"mb2\">", `<div class="border-top silver py2"><div class="black"><strong>Unsafe &lt;title&gt;:</strong> *** *** &lt;warning&gt;</div>`, `<div class="mt1 black"><code>cmd,main.go:12:3–12:5</code></div>`,
+		"<h2 class=\"h4 mb2\">GitHub Actions warnings</h2>\n<div class=\"mb2\">", `<div class="border-top py2"><div><strong>Unsafe &lt;title&gt;:</strong> *** *** &lt;warning&gt;</div>`, `<div class="mt1"><code>cmd,main.go:12:3–12:5</code></div>`,
 	} {
 		if !strings.Contains(result.WarningAnnotations, fragment) {
 			t.Errorf("warning annotation lacks %q: %q", fragment, result.WarningAnnotations)
 		}
 	}
 	for _, fragment := range []string{
-		"<h2 class=\"h4 mb2\">GitHub Actions errors</h2>\n<div class=\"mb2\">", `<div class="mt1 black"><code>main.go:9:2–9:4</code></div>`, "*** &lt;error&gt;",
+		"<h2 class=\"h4 mb2\">GitHub Actions errors</h2>\n<div class=\"mb2\">", `<div class="mt1"><code>main.go:9:2–9:4</code></div>`, "*** &lt;error&gt;",
 	} {
 		if !strings.Contains(result.ErrorAnnotations, fragment) {
 			t.Errorf("error annotation lacks %q: %q", fragment, result.ErrorAnnotations)
@@ -3121,14 +3121,14 @@ func TestWorkflowCommandAnnotationsGroupRowsByFile(t *testing.T) {
 	if truncated {
 		t.Fatal("small grouped annotation was truncated")
 	}
-	if first, second := strings.LastIndex(warnings, "first.go"), strings.Index(warnings, "second.go"); first < 0 || second < first || strings.Count(warnings, `class="border-top silver py2"`) != 4 {
+	if first, second := strings.LastIndex(warnings, "first.go"), strings.Index(warnings, "second.go"); first < 0 || second < first || strings.Count(warnings, `class="border-top py2"`) != 4 {
 		t.Fatalf("annotation did not retain row order within first-seen file groups: %q", warnings)
 	}
 	for _, item := range []string{
-		"<div class=\"black\"><strong>First:</strong> first message</div><div class=\"mt1 black\"><code>first.go:2</code></div>",
-		"<div class=\"black\">another first message</div><div class=\"mt1 black\"><code>first.go:9</code></div>",
-		"<div class=\"black\">second message</div><div class=\"mt1 black\"><code>second.go:7:3</code></div>",
-		"<div class=\"black\"><strong>General:</strong> general message</div><div class=\"mt1 black\">General</div>",
+		"<div><strong>First:</strong> first message</div><div class=\"mt1\"><code>first.go:2</code></div>",
+		"<div>another first message</div><div class=\"mt1\"><code>first.go:9</code></div>",
+		"<div>second message</div><div class=\"mt1\"><code>second.go:7:3</code></div>",
+		"<div><strong>General:</strong> general message</div><div class=\"mt1\">General</div>",
 	} {
 		if !strings.Contains(warnings, item) {
 			t.Errorf("annotation lacks item %q: %q", item, warnings)
@@ -3373,8 +3373,8 @@ func TestWorkflowCommandAnnotationsAreConcurrentAndUTF8Bounded(t *testing.T) {
 	}
 	group.Wait()
 	warnings, truncated, _, _ := processor.workflowCommandAnnotations()
-	if truncated || strings.Count(warnings, `class="border-top silver py2"`) != 100 {
-		t.Fatalf("concurrent warning annotation count = %d, truncated = %v", strings.Count(warnings, `class="border-top silver py2"`), truncated)
+	if truncated || strings.Count(warnings, `class="border-top py2"`) != 100 {
+		t.Fatalf("concurrent warning annotation count = %d, truncated = %v", strings.Count(warnings, `class="border-top py2"`), truncated)
 	}
 
 	processor = newCommandProcessor(io.Discard, io.Discard)
@@ -3397,7 +3397,7 @@ func TestWorkflowCommandAnnotationsNormalizeInvalidUTF8(t *testing.T) {
 	if truncated || !utf8.ValidString(warnings) || strings.Count(warnings, "\uFFFD") != 3 {
 		t.Fatalf("warning annotation = %q, truncated = %v, valid UTF-8 = %v", warnings, truncated, utf8.ValidString(warnings))
 	}
-	for _, fragment := range []string{`<div class="mt1 black"><code>bad�.go</code></div>`, "<div class=\"black\"><strong>bad\uFFFD:</strong> bad\uFFFD</div>"} {
+	for _, fragment := range []string{`<div class="mt1"><code>bad�.go</code></div>`, "<div><strong>bad\uFFFD:</strong> bad\uFFFD</div>"} {
 		if !strings.Contains(warnings, fragment) {
 			t.Fatalf("warning annotation lacks %q: %q", fragment, warnings)
 		}
@@ -3424,10 +3424,10 @@ func TestWorkflowCommandMasksCannotCorruptAnnotationMarkup(t *testing.T) {
 	_ = processor.process(io.Discard, "::add-mask::table")
 
 	warnings, truncated, _, _ := processor.workflowCommandAnnotations()
-	if truncated || !strings.Contains(warnings, `<div class="mt1 black"><code>***.go</code></div>`) || !strings.Contains(warnings, "<div class=\"black\"><strong>***:</strong> s***uctured *** text</div>") {
+	if truncated || !strings.Contains(warnings, `<div class="mt1"><code>***.go</code></div>`) || !strings.Contains(warnings, "<div><strong>***:</strong> s***uctured *** text</div>") {
 		t.Fatalf("masked warning annotation = %q, truncated = %v", warnings, truncated)
 	}
-	if strings.Count(warnings, `class="border-top silver py2"`) != 1 || strings.Count(warnings, "<div") != strings.Count(warnings, "</div>") {
+	if strings.Count(warnings, `class="border-top py2"`) != 1 || strings.Count(warnings, "<div") != strings.Count(warnings, "</div>") {
 		t.Fatalf("masks corrupted annotation markup: %q", warnings)
 	}
 }
@@ -3440,8 +3440,8 @@ func TestWorkflowCommandAnnotationsRemainBoundedAfterMaskExpansion(t *testing.T)
 	_ = processor.process(io.Discard, "::add-mask::x")
 
 	warnings, truncated, _, _ := processor.workflowCommandAnnotations()
-	if !truncated || strings.Contains(warnings, strings.Repeat("x", 100)) || !strings.HasSuffix(warnings, workflowCommandListEnd) || strings.Count(warnings, `class="border-top silver py2"`)*3+1 != strings.Count(warnings, "</div>") {
-		t.Fatalf("expanded warning annotation bytes = %d, items = %d, closing divs = %d, truncated = %v", len(warnings), strings.Count(warnings, `class="border-top silver py2"`), strings.Count(warnings, "</div>"), truncated)
+	if !truncated || strings.Contains(warnings, strings.Repeat("x", 100)) || !strings.HasSuffix(warnings, workflowCommandListEnd) || strings.Count(warnings, `class="border-top py2"`)*3+1 != strings.Count(warnings, "</div>") {
+		t.Fatalf("expanded warning annotation bytes = %d, items = %d, closing divs = %d, truncated = %v", len(warnings), strings.Count(warnings, `class="border-top py2"`), strings.Count(warnings, "</div>"), truncated)
 	}
 	result := scrubJobResult(JobResult{WarningAnnotations: warnings, warningsTruncated: truncated}, processor.maskValues())
 	if len(result.WarningAnnotations) > maxJobAnnotationBytes || !utf8.ValidString(result.WarningAnnotations) || !strings.HasSuffix(result.WarningAnnotations, workflowCommandTruncationNotice) {

--- a/scripts/verify-workflow-annotations
+++ b/scripts/verify-workflow-annotations
@@ -56,7 +56,7 @@ if ! jq -e \
     $warnings[0].job_id == $job_id and
     $warnings[0].style == "warning" and
     ($warnings[0].body_html | contains("Deprecated command")) and
-    ($warnings[0].body_html | contains("border-top silver py2")) and
+    ($warnings[0].body_html | contains("border-top py2")) and
     ($warnings[0].body_html | contains("workflow-command-annotations.yml:13:3–13:8")) and
     ($warnings[0].body_html | contains("The save-state command is deprecated; use environment files instead.")) and
     ($warnings[0].body_html | contains("Secret redaction")) and

--- a/scripts/verify-workflow-annotations
+++ b/scripts/verify-workflow-annotations
@@ -55,19 +55,19 @@ if ! jq -e \
     $warnings[0].scope == "job" and
     $warnings[0].job_id == $job_id and
     $warnings[0].style == "warning" and
-    ($warnings[0].body_html | contains("Workflow warning")) and
+    ($warnings[0].body_html | contains("Deprecated command")) and
     ($warnings[0].body_html | contains(">Source</th>")) and
-    ($warnings[0].body_html | contains("workflow-command-annotations.yml")) and
     ($warnings[0].body_html | contains("workflow-command-annotations.yml:13:3–13:8")) and
-    ($warnings[0].body_html | contains("WORKFLOW_WARNING_OBSERVATION=stdout-with-location")) and
-    ($warnings[0].body_html | contains("masked diagnostic")) and
+    ($warnings[0].body_html | contains("The save-state command is deprecated; use environment files instead.")) and
+    ($warnings[0].body_html | contains("Secret redaction")) and
+    ($warnings[0].body_html | contains("Sensitive value redacted: ***")) and
     ($warnings[0].body_html | contains($masked_canary) | not) and
     $errors[0].scope == "job" and
     $errors[0].job_id == $job_id and
     $errors[0].style == "error" and
-    ($errors[0].body_html | contains("Workflow error")) and
+    ($errors[0].body_html | contains("Invalid deployment target")) and
     ($errors[0].body_html | contains("workflow-command-annotations.yml:18")) and
-    ($errors[0].body_html | contains("WORKFLOW_ERROR_OBSERVATION=stderr-outcome-neutral"))
+    ($errors[0].body_html | contains("The deployment environment must be staging or production."))
   ' <<<"$annotations" >/dev/null
 then
   echo "job $job_id does not have the exact workflow command annotation contract" >&2

--- a/scripts/verify-workflow-annotations
+++ b/scripts/verify-workflow-annotations
@@ -56,10 +56,9 @@ if ! jq -e \
     $warnings[0].job_id == $job_id and
     $warnings[0].style == "warning" and
     ($warnings[0].body_html | contains("Workflow warning")) and
+    ($warnings[0].body_html | contains(">Source</th>")) and
     ($warnings[0].body_html | contains("workflow-command-annotations.yml")) and
-    ($warnings[0].body_html | contains("Line:")) and
-    ($warnings[0].body_html | contains("13")) and
-    ($warnings[0].body_html | contains("Column:")) and
+    ($warnings[0].body_html | contains("workflow-command-annotations.yml:13:3–13:8")) and
     ($warnings[0].body_html | contains("WORKFLOW_WARNING_OBSERVATION=stdout-with-location")) and
     ($warnings[0].body_html | contains("masked diagnostic")) and
     ($warnings[0].body_html | contains($masked_canary) | not) and
@@ -67,7 +66,7 @@ if ! jq -e \
     $errors[0].job_id == $job_id and
     $errors[0].style == "error" and
     ($errors[0].body_html | contains("Workflow error")) and
-    ($errors[0].body_html | contains("18")) and
+    ($errors[0].body_html | contains("workflow-command-annotations.yml:18")) and
     ($errors[0].body_html | contains("WORKFLOW_ERROR_OBSERVATION=stderr-outcome-neutral"))
   ' <<<"$annotations" >/dev/null
 then

--- a/scripts/verify-workflow-annotations
+++ b/scripts/verify-workflow-annotations
@@ -56,7 +56,7 @@ if ! jq -e \
     $warnings[0].job_id == $job_id and
     $warnings[0].style == "warning" and
     ($warnings[0].body_html | contains("Deprecated command")) and
-    ($warnings[0].body_html | contains(">Source</th>")) and
+    ($warnings[0].body_html | contains("border-top py2")) and
     ($warnings[0].body_html | contains("workflow-command-annotations.yml:13:3–13:8")) and
     ($warnings[0].body_html | contains("The save-state command is deprecated; use environment files instead.")) and
     ($warnings[0].body_html | contains("Secret redaction")) and

--- a/scripts/verify-workflow-annotations
+++ b/scripts/verify-workflow-annotations
@@ -56,7 +56,7 @@ if ! jq -e \
     $warnings[0].job_id == $job_id and
     $warnings[0].style == "warning" and
     ($warnings[0].body_html | contains("Deprecated command")) and
-    ($warnings[0].body_html | contains("border-top py2")) and
+    ($warnings[0].body_html | contains("border-top silver py2")) and
     ($warnings[0].body_html | contains("workflow-command-annotations.yml:13:3–13:8")) and
     ($warnings[0].body_html | contains("The save-state command is deprecated; use environment files instead.")) and
     ($warnings[0].body_html | contains("Secret redaction")) and

--- a/scripts/verify-workflow-annotations
+++ b/scripts/verify-workflow-annotations
@@ -56,7 +56,7 @@ if ! jq -e \
     $warnings[0].job_id == $job_id and
     $warnings[0].style == "warning" and
     ($warnings[0].body_html | contains("Deprecated command")) and
-    ($warnings[0].body_html | contains("border-top py2")) and
+    ($warnings[0].body_html | contains("border-top border-silver py2")) and
     ($warnings[0].body_html | contains("workflow-command-annotations.yml:13:3–13:8")) and
     ($warnings[0].body_html | contains("The save-state command is deprecated; use environment files instead.")) and
     ($warnings[0].body_html | contains("Secret redaction")) and

--- a/testdata/smoke/.github/workflows/workflow-command-annotations.yml
+++ b/testdata/smoke/.github/workflows/workflow-command-annotations.yml
@@ -10,16 +10,16 @@ jobs:
       - name: Emit a warning from stdout
         shell: bash
         run: |
-          printf '%s\n' '::warning title=Workflow warning,file=.github/workflows/workflow-command-annotations.yml,line=13,endLine=13,col=3,endColumn=8::WORKFLOW_WARNING_OBSERVATION=stdout-with-location'
+          printf '%s\n' '::warning title=Deprecated command,file=.github/workflows/workflow-command-annotations.yml,line=13,endLine=13,col=3,endColumn=8::The save-state command is deprecated; use environment files instead.'
 
       - name: Emit an error from stderr without failing the job
         shell: bash
         run: |
-          printf '%s\n' '::error title=Workflow error,file=.github/workflows/workflow-command-annotations.yml,line=18::WORKFLOW_ERROR_OBSERVATION=stderr-outcome-neutral' >&2
+          printf '%s\n' '::error title=Invalid deployment target,file=.github/workflows/workflow-command-annotations.yml,line=18::The deployment environment must be staging or production.' >&2
 
       - name: Prove late annotation masking
         shell: bash
         run: |
           canary='workflow-command-secret'
-          printf '%s\n' "::warning title=Masked warning::masked diagnostic $canary"
+          printf '%s\n' "::warning title=Secret redaction::Sensitive value redacted: $canary"
           printf '%s\n' "::add-mask::$canary"


### PR DESCRIPTION
## Why

Workflow command diagnostics currently render as a full-size heading per warning or error. Several diagnostics can dominate the pipeline view and make its structure harder to scan.

## What

Render diagnostics under one `h4`-sized heading as a compact bordered list. Each item leads with **Title:** and its message, then shows the basename location at normal opacity, such as `file.yml:12`. Light-grey `border-silver` separators distinguish diagnostics without table headers or column chrome. This relies on [buildkite/buildkite#32377](https://github.com/buildkite/buildkite/pull/32377). Items retain first-seen file grouping, and the markup remains safe under secret masking and the 1 MiB annotation limit.

Hosted [workflow annotation proof build #716](https://buildkite.com/buildkite/buildkite-gha/builds/716) passed for the branch. The current production sanitizer still strips `border-silver`, so the light-grey separator will appear after buildkite/buildkite#32377 is merged and deployed. An authenticated Buildkite UI screenshot is still needed; API access cannot capture the private pipeline UI.

## Screenshots

**Before**

<img width="1762" height="512" alt="image" src="https://github.com/user-attachments/assets/47574cad-3371-451e-a6c1-6a975f6a651a" />

**After**

<img width="3616" height="2452" alt="CleanShot 2026-08-12 at 16 07 14@2x" src="https://github.com/user-attachments/assets/1867fcd7-c6c5-4e8b-9620-bc9478ce9a6b" />