### PR TITLE
Support bounded multi-prefix artifact selection

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -557,15 +557,15 @@ The adapter sets `artifact-id` and `artifact-digest`. The `artifact-url` output 
 | Input | Supported values |
 | --- | --- |
 | `name` | Exact name, mutually exclusive with `pattern`; runtime expressions are allowed. |
-| `pattern` | Bounded artifact-name glob or leading literal-prefix alternation; requires `merge-multiple: true`; runtime expressions are allowed. |
+| `pattern` | Bounded artifact-name glob; requires `merge-multiple: true`; runtime expressions are allowed. |
 | `path` | Optional literal workspace-relative path. |
 | `merge-multiple` | Omitted or `false` with `name`; required `true` with `pattern`. |
 | v8 `skip-decompress` | Omitted or `false`. |
 | v8 `digest-mismatch` | Omitted or `error`. |
 
-Artifacts must come from verified direct `needs` producers. Exact-name lookup must find one unique artifact. A bounded pattern may select and deterministically merge up to 64 distinct names. Patterns may use one leading group of 2 through 8 comma-separated literal prefixes, such as `{junit-results-backend,product-junit-results}-*`. Each expanded glob may be at most 255 bytes and must pass the same artifact-name glob validation as a single pattern. Empty alternatives, nesting, other brace positions, and glob characters inside alternatives are unsupported.
+Artifacts must come from verified direct `needs` producers. Exact-name lookup must find one unique artifact. A bounded pattern may select and deterministically merge up to 64 distinct names. The shipped pattern contract accepts `*`, `?`, character classes, and `**`. Brace alternation remains unsupported pending hosted proof.
 
-An artifact that matches multiple alternatives is selected once. When artifacts contain the same exact member path, the later artifact by name wins. All matched archives are validated and staged before the destination changes. Artifact ID, all-artifact, cross-run, cross-repository, raw, REST, and non-merged pattern modes are unsupported.
+When artifacts contain the same exact member path, the later artifact by name wins. All matched archives are validated and staged before the destination changes. Artifact ID, all-artifact, cross-run, cross-repository, raw, REST, and non-merged pattern modes are unsupported.
 
 Only ZIPs produced by the supported upload adapter are accepted. Digest or ZIP validation failure is fatal. The `download-path` output is supported.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -557,13 +557,15 @@ The adapter sets `artifact-id` and `artifact-digest`. The `artifact-url` output 
 | Input | Supported values |
 | --- | --- |
 | `name` | Exact name, mutually exclusive with `pattern`; runtime expressions are allowed. |
-| `pattern` | Bounded artifact-name glob; requires `merge-multiple: true`; runtime expressions are allowed. |
+| `pattern` | Bounded artifact-name glob or leading literal-prefix alternation; requires `merge-multiple: true`; runtime expressions are allowed. |
 | `path` | Optional literal workspace-relative path. |
 | `merge-multiple` | Omitted or `false` with `name`; required `true` with `pattern`. |
 | v8 `skip-decompress` | Omitted or `false`. |
 | v8 `digest-mismatch` | Omitted or `error`. |
 
-Artifacts must come from verified direct `needs` producers. Exact-name lookup must find one unique artifact. A bounded pattern may select and deterministically merge multiple distinct names. When artifacts contain the same exact member path, the later artifact by name wins. All matched archives are validated and staged before the destination changes. Artifact ID, all-artifact, cross-run, cross-repository, raw, REST, and non-merged pattern modes are unsupported.
+Artifacts must come from verified direct `needs` producers. Exact-name lookup must find one unique artifact. A bounded pattern may select and deterministically merge up to 64 distinct names. Patterns may use one leading group of 2 through 8 comma-separated literal prefixes, such as `{junit-results-backend,product-junit-results}-*`. Each expanded glob may be at most 255 bytes and must pass the same artifact-name glob validation as a single pattern. Empty alternatives, nesting, other brace positions, and glob characters inside alternatives are unsupported.
+
+An artifact that matches multiple alternatives is selected once. When artifacts contain the same exact member path, the later artifact by name wins. All matched archives are validated and staged before the destination changes. Artifact ID, all-artifact, cross-run, cross-repository, raw, REST, and non-merged pattern modes are unsupported.
 
 Only ZIPs produced by the supported upload adapter are accepted. Digest or ZIP validation failure is fatal. The `download-path` output is supported.
 

--- a/internal/action/integration/integration.go
+++ b/internal/action/integration/integration.go
@@ -71,6 +71,9 @@ const (
 	MaxUploadArtifactNameBytes = 255
 	MaxUploadArtifactRoots     = 32
 	MaxUploadArtifactPathBytes = 4096
+
+	MaxDownloadArtifactPatternAlternatives = 8
+	MaxDownloadArtifactPatternBytes        = MaxUploadArtifactNameBytes
 )
 
 // Service identifies an Actions runtime service used by a known action.
@@ -229,8 +232,13 @@ func validateDownloadArtifactInputs(commit string, inputs map[string]string, all
 	if hasName && !hasNameExpression && ValidateUploadArtifactName(name) != nil {
 		return fmt.Errorf("required input %q must be an exact literal artifact name", "name")
 	}
-	if hasPattern && (strings.Contains(pattern, "${{") && !allowNameExpression || !strings.Contains(pattern, "${{") && !validDownloadArtifactPattern(pattern)) {
+	if hasPattern && strings.Contains(pattern, "${{") && !allowNameExpression {
 		return fmt.Errorf("input %q must be a bounded literal artifact-name glob", "pattern")
+	}
+	if hasPattern && !strings.Contains(pattern, "${{") {
+		if _, err := DownloadArtifactPatterns(pattern); err != nil {
+			return fmt.Errorf("input %q must be a bounded literal artifact-name glob: %w", "pattern", err)
+		}
 	}
 	if value, ok := inputFold(inputs, "path"); ok {
 		if _, err := NormalizeDownloadArtifactPath(value); err != nil {
@@ -366,8 +374,48 @@ func validateUploadArtifactInputs(commit string, inputs map[string]string, evalu
 	return nil
 }
 
+// DownloadArtifactPatterns expands an optional leading group of literal
+// artifact-name prefixes into independently validated bounded globs.
+func DownloadArtifactPatterns(pattern string) ([]string, error) {
+	if !strings.ContainsAny(pattern, "{}") {
+		if !validDownloadArtifactPattern(pattern) {
+			return nil, fmt.Errorf("invalid artifact-name glob")
+		}
+		return []string{pattern}, nil
+	}
+	if !strings.HasPrefix(pattern, "{") || strings.Count(pattern, "{") != 1 || strings.Count(pattern, "}") != 1 {
+		return nil, fmt.Errorf("alternation must be one leading, non-nested prefix group")
+	}
+	close := strings.IndexByte(pattern, '}')
+	if close < 0 || close == len(pattern)-1 {
+		return nil, fmt.Errorf("alternation must be followed by an artifact-name glob suffix")
+	}
+	alternatives := strings.Split(pattern[1:close], ",")
+	if len(alternatives) < 2 || len(alternatives) > MaxDownloadArtifactPatternAlternatives {
+		return nil, fmt.Errorf("alternation has %d alternatives, require 2 through %d", len(alternatives), MaxDownloadArtifactPatternAlternatives)
+	}
+	suffix := pattern[close+1:]
+	expanded := make([]string, 0, len(alternatives))
+	seen := make(map[string]struct{}, len(alternatives))
+	for _, alternative := range alternatives {
+		if alternative == "" || strings.ContainsAny(alternative, "*?[]{}") {
+			return nil, fmt.Errorf("alternation alternatives must be non-empty literal prefixes")
+		}
+		candidate := alternative + suffix
+		if !validDownloadArtifactPattern(candidate) {
+			return nil, fmt.Errorf("expanded alternative is not a valid artifact-name glob")
+		}
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		expanded = append(expanded, candidate)
+	}
+	return expanded, nil
+}
+
 func validDownloadArtifactPattern(pattern string) bool {
-	if pattern == "" || len(pattern) > MaxUploadArtifactNameBytes || !utf8.ValidString(pattern) || strings.HasPrefix(pattern, "!") || strings.ContainsAny(pattern, "\\/:<>|{}\r\n") || !strings.ContainsAny(pattern, "*?[") {
+	if pattern == "" || len(pattern) > MaxDownloadArtifactPatternBytes || !utf8.ValidString(pattern) || strings.HasPrefix(pattern, "!") || strings.ContainsAny(pattern, "\\/:<>|{}\r\n") || !strings.ContainsAny(pattern, "*?[") {
 		return false
 	}
 	for _, r := range pattern {

--- a/internal/action/integration/integration_test.go
+++ b/internal/action/integration/integration_test.go
@@ -82,6 +82,49 @@ func TestDownloadArtifactExactContract(t *testing.T) {
 	}
 }
 
+func TestDownloadArtifactPatterns(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		pattern string
+		want    []string
+	}{
+		{name: "single glob", pattern: "junit-results-backend-*", want: []string{"junit-results-backend-*"}},
+		{name: "PostHog prefixes", pattern: "{junit-results-backend,product-junit-results}-*", want: []string{"junit-results-backend-*", "product-junit-results-*"}},
+		{name: "duplicate prefix", pattern: "{junit,junit}-*", want: []string{"junit-*"}},
+		{name: "maximum alternatives", pattern: "{a,b,c,d,e,f,g,h}-*", want: []string{"a-*", "b-*", "c-*", "d-*", "e-*", "f-*", "g-*", "h-*"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := DownloadArtifactPatterns(test.pattern)
+			if err != nil || strings.Join(got, "|") != strings.Join(test.want, "|") {
+				t.Fatalf("DownloadArtifactPatterns(%q) = %#v, %v, want %#v", test.pattern, got, err, test.want)
+			}
+		})
+	}
+
+	rejected := map[string]string{
+		"empty alternative":        "{a,}-*",
+		"one alternative":          "{a}-*",
+		"too many alternatives":    "{a,b,c,d,e,f,g,h,i}-*",
+		"nested":                   "{a,{b,c}}-*",
+		"trailing brace":           "{a,b}-*}",
+		"missing close":            "{a,b-*",
+		"missing suffix":           "{a,b}",
+		"non-leading group":        "prefix-{a,b}-*",
+		"glob alternative":         "{a*,b}-*",
+		"traversal":                "{../a,b}-*",
+		"control character":        "{a,b\x1f}-*",
+		"unsupported second group": "{a,b}-{c,d}*",
+		"oversized expansion":      "{" + strings.Repeat("a", MaxDownloadArtifactPatternBytes) + ",b}-*",
+	}
+	for name, pattern := range rejected {
+		t.Run(name, func(t *testing.T) {
+			if _, err := DownloadArtifactPatterns(pattern); err == nil {
+				t.Fatalf("DownloadArtifactPatterns(%q) succeeded", pattern)
+			}
+		})
+	}
+}
+
 func TestNormalizeDownloadArtifactPath(t *testing.T) {
 	for input, want := range map[string]string{"": ".", ".": ".", "./": ".", "././": ".", "out": "out", "out/": "out", "./out/": "out", "././out/": "out", "./nested/out///": "nested/out"} {
 		t.Run("accept "+input, func(t *testing.T) {

--- a/internal/action/integration/integration_test.go
+++ b/internal/action/integration/integration_test.go
@@ -58,8 +58,9 @@ func TestDownloadArtifactExactContract(t *testing.T) {
 	}
 	for name, inputs := range map[string]map[string]string{
 		"all": nil, "absolute": {"name": "x", "path": "/tmp"},
-		"name and pattern": {"name": "x", "pattern": "x-*", "merge-multiple": "true"},
-		"merge":            {"name": "x", "merge-multiple": "true"}, "ids": {"name": "x", "artifact-ids": "1"},
+		"name and pattern":              {"name": "x", "pattern": "x-*", "merge-multiple": "true"},
+		"PostHog pattern without merge": {"pattern": "{junit-results-backend,product-junit-results}-*"},
+		"merge":                         {"name": "x", "merge-multiple": "true"}, "ids": {"name": "x", "artifact-ids": "1"},
 		"duplicate": {"name": "x", "Name": "y"}, "token": {"name": "x", "github-token": ""},
 		"drive path": {"name": "x", "path": "C:/out"},
 	} {

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -1077,6 +1077,10 @@ func TestDownloadArtifactAdapterInputCommitAndNeedsBoundary(t *testing.T) {
 	if err != nil || len(plans) != 2 || plans[1].Actions[0].Commit != actionintegration.DownloadArtifactV5Commit {
 		t.Fatalf("download-artifact v5 pattern plans = %#v, %v", plans, err)
 	}
+	plans, err = compile(actionintegration.DownloadArtifactV5Commit, "    needs: producer\n", "        with:\n          pattern: '{junit-results-backend,product-junit-results}-*'\n          path: out\n          merge-multiple: true\n")
+	if err != nil || len(plans) != 2 || plans[1].Steps[0].With["pattern"] != "{junit-results-backend,product-junit-results}-*" {
+		t.Fatalf("download-artifact PostHog pattern plans = %#v, %v", plans, err)
+	}
 
 	for name, with := range map[string]string{
 		"missing name":  "        with:\n          path: out\n",

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -121,8 +121,8 @@ func TestCompileBundleCompilesSmokeCorpus(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(workflows) != 8 {
-		t.Fatalf("smoke workflows = %d, want 8", len(workflows))
+	if len(workflows) != 9 {
+		t.Fatalf("smoke workflows = %d, want 9", len(workflows))
 	}
 	event := readFile(t, smokePath("events", "push.json"))
 	for _, path := range workflows {

--- a/internal/compiler/smoke_manifest_test.go
+++ b/internal/compiler/smoke_manifest_test.go
@@ -45,7 +45,7 @@ func TestSmokeManifestInventory(t *testing.T) {
 		t.Fatalf("schema = %q", manifest.Schema)
 	}
 
-	wantOrder := []string{"smoke-shell", "smoke-concurrent", "smoke-ci", "smoke-artifact", "example-basic", "example-artifacts", "example-advanced", "plugin-demo-cache", "public-actions", "dockerfile-action", "container-runtime", "summary-annotation", "workflow-command-annotations", "upload-artifact", "cache-v6", "unsupported-job-container", "unsupported-service-container"}
+	wantOrder := []string{"smoke-shell", "smoke-concurrent", "smoke-ci", "smoke-artifact", "smoke-artifact-multi-prefix", "example-basic", "example-artifacts", "example-advanced", "plugin-demo-cache", "public-actions", "dockerfile-action", "container-runtime", "summary-annotation", "workflow-command-annotations", "upload-artifact", "cache-v6", "unsupported-job-container", "unsupported-service-container"}
 	if len(manifest.Fixtures) != len(wantOrder) {
 		t.Fatalf("fixtures = %d, want %d", len(manifest.Fixtures), len(wantOrder))
 	}

--- a/internal/runtime/download_artifact.go
+++ b/internal/runtime/download_artifact.go
@@ -51,6 +51,14 @@ func (r Runner) runDownloadArtifact(ctx context.Context, processor *commandProce
 		values[strings.ToLower(k)] = strings.TrimSpace(v)
 	}
 	name, pattern := values["name"], values["pattern"]
+	var patterns []string
+	var err error
+	if pattern != "" {
+		patterns, err = actionintegration.DownloadArtifactPatterns(pattern)
+		if err != nil {
+			return result, fmt.Errorf("bounded download-artifact adapter: %w", err)
+		}
+	}
 	destinationSlash, err := actionintegration.NormalizeDownloadArtifactPath(values["path"])
 	if err != nil {
 		return result, fmt.Errorf("bounded download-artifact adapter: %w", err)
@@ -78,10 +86,13 @@ func (r Runner) runDownloadArtifact(ctx context.Context, processor *commandProce
 	for _, need := range needs {
 		for _, artifact := range need.Artifacts {
 			matched := artifact.Name == name
-			if pattern != "" {
-				matched, err = doublestar.Match(pattern, artifact.Name)
+			for _, candidate := range patterns {
+				matched, err = doublestar.Match(candidate, artifact.Name)
 				if err != nil {
 					return result, fmt.Errorf("match artifact pattern: %w", err)
+				}
+				if matched {
+					break
 				}
 			}
 			if matched {

--- a/internal/runtime/download_artifact_test.go
+++ b/internal/runtime/download_artifact_test.go
@@ -274,15 +274,63 @@ func TestDownloadArtifactPatternMergesVerifiedDirectNeeds(t *testing.T) {
 	}
 }
 
+func TestDownloadArtifactMultiPrefixDeduplicatesAndOrdersVerifiedProducers(t *testing.T) {
+	backendArchive, backendSize, backendDigest := testDownloadZIP(t, "backend.xml")
+	productArchive, productSize, productDigest := testDownloadZIP(t, "product.xml")
+	backendPath := "buildkite-gha/v1/artifacts/" + strings.Repeat("6", 64) + ".zip"
+	productPath := "buildkite-gha/v1/artifacts/" + strings.Repeat("7", 64) + ".zip"
+	backend := plan.NeedArtifact{Name: "junit-results-backend-2", Path: backendPath, Digest: backendDigest, Size: backendSize, FileCount: 1, Producer: plan.NeedProducer{JobID: "11111111-1111-4111-8111-111111111111"}}
+	product := plan.NeedArtifact{Name: "product-junit-results-1", Path: productPath, Digest: productDigest, Size: productSize, FileCount: 1, Producer: plan.NeedProducer{JobID: "22222222-2222-4222-8222-222222222222"}}
+	store := &downloadStore{archives: map[string]string{backendPath: backendArchive, productPath: productArchive}}
+	workspace := t.TempDir()
+
+	_, err := (Runner{Artifacts: store}).runDownloadArtifact(
+		context.Background(), newCommandProcessor(io.Discard, io.Discard), workspace,
+		map[string]plan.Need{"backend": {Artifacts: []plan.NeedArtifact{product}}, "products": {Artifacts: []plan.NeedArtifact{backend}}},
+		actionintegration.DownloadArtifactV5Commit,
+		map[string]string{"pattern": "{junit-results,junit-results-backend,product-junit-results}-*", "path": "junit", "merge-multiple": "true"},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(store.paths, []string{backendPath, productPath}) {
+		t.Fatalf("deduplicated download order = %#v, want artifact-name order", store.paths)
+	}
+	for _, file := range []string{"backend.xml", "product.xml"} {
+		if _, err := os.Stat(filepath.Join(workspace, "junit", file)); err != nil {
+			t.Fatalf("merged file %q: %v", file, err)
+		}
+	}
+}
+
+func TestDownloadArtifactPatternRejectsTooManyMatchesBeforeDownload(t *testing.T) {
+	artifacts := make([]plan.NeedArtifact, transport.MaxResultArtifacts+1)
+	for i := range artifacts {
+		artifacts[i].Name = fmt.Sprintf("backend-%03d", i)
+	}
+	store := &downloadStore{}
+	_, err := (Runner{Artifacts: store}).runDownloadArtifact(
+		context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(),
+		map[string]plan.Need{"producer": {Artifacts: artifacts}}, actionintegration.DownloadArtifactV5Commit,
+		map[string]string{"pattern": "{backend,product}-*", "merge-multiple": "true"},
+	)
+	if err == nil || !strings.Contains(err.Error(), "maximum is 64") {
+		t.Fatalf("match limit error = %v", err)
+	}
+	if len(store.paths) != 0 {
+		t.Fatalf("over-limit selection downloaded artifacts: %#v", store.paths)
+	}
+}
+
 func TestDownloadArtifactPatternStagesCompleteMergeBeforeDestinationMutation(t *testing.T) {
 	firstArchive, firstSize, firstDigest := testDownloadZIPPayload(t, "first", "result.xml")
 	secondArchive, secondSize, secondDigest := testDownloadZIPPayload(t, "second", "result.xml")
 	firstPath := "buildkite-gha/v1/artifacts/" + strings.Repeat("4", 64) + ".zip"
 	secondPath := "buildkite-gha/v1/artifacts/" + strings.Repeat("5", 64) + ".zip"
-	first := plan.NeedArtifact{Name: "results-a", Path: firstPath, Digest: firstDigest, Size: firstSize, FileCount: 1, Producer: plan.NeedProducer{JobID: "11111111-1111-4111-8111-111111111111"}}
-	second := plan.NeedArtifact{Name: "results-b", Path: secondPath, Digest: secondDigest, Size: secondSize, FileCount: 1, Producer: plan.NeedProducer{JobID: "22222222-2222-4222-8222-222222222222"}}
+	first := plan.NeedArtifact{Name: "backend-results-a", Path: firstPath, Digest: firstDigest, Size: firstSize, FileCount: 1, Producer: plan.NeedProducer{JobID: "11111111-1111-4111-8111-111111111111"}}
+	second := plan.NeedArtifact{Name: "product-results-b", Path: secondPath, Digest: secondDigest, Size: secondSize, FileCount: 1, Producer: plan.NeedProducer{JobID: "22222222-2222-4222-8222-222222222222"}}
 	needs := map[string]plan.Need{"test": {Artifacts: []plan.NeedArtifact{second, first}}}
-	inputs := map[string]string{"pattern": "results-*", "path": "merged", "merge-multiple": "true"}
+	inputs := map[string]string{"pattern": "{backend-results,product-results}-*", "path": "merged", "merge-multiple": "true"}
 
 	t.Run("later artifact name wins overlapping member", func(t *testing.T) {
 		workspace := t.TempDir()

--- a/testdata/smoke/.github/workflows/artifact-multi-prefix.yml
+++ b/testdata/smoke/.github/workflows/artifact-multi-prefix.yml
@@ -1,0 +1,37 @@
+name: bounded multi-prefix artifact selection
+
+on: push
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          mkdir -p junit
+          printf 'backend\n' > junit/backend.xml
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: junit-results-backend-1
+          path: junit/backend.xml
+
+  product:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          mkdir -p junit
+          printf 'product\n' > junit/product.xml
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: product-junit-results-1
+          path: junit/product.xml
+
+  report:
+    needs: [backend, product]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          pattern: '{junit-results-backend,product-junit-results}-*'
+          path: junit-artifacts
+          merge-multiple: true
+      - run: test -f junit-artifacts/backend.xml && test -f junit-artifacts/product.xml

--- a/testdata/smoke/manifest.json
+++ b/testdata/smoke/manifest.json
@@ -38,6 +38,15 @@
       "action_preflight": "hosted-tokenless"
     },
     {
+      "id": "smoke-artifact-multi-prefix",
+      "workflow": "testdata/smoke/.github/workflows/artifact-multi-prefix.yml",
+      "event": "testdata/smoke/events/push.json",
+      "expectation": "compile-pass",
+      "evidence": "Parser, compiler, and runtime tests cover bounded expansion, direct-needs matching, deterministic deduplication, merge order, and atomic staging.",
+      "note": "This PostHog-shaped two-prefix fixture is compile-only; hosted producer-to-consumer execution remains unproven.",
+      "action_preflight": "hosted-tokenless"
+    },
+    {
       "id": "example-basic",
       "workflow": ".github/workflows/example-basic.yml",
       "event": "testdata/smoke/events/push.json",


### PR DESCRIPTION
## Why

Some workflows select artifacts from a small fixed set of producer prefixes, but the native download adapter currently accepts only one bounded glob.

PostHog uses the same two-prefix pattern in its [`django_tests` failure gate](https://github.com/buildkite/posthog/blob/b9a0729f733e6dd170017677bb339608489ec3d2/.github/workflows/ci-backend.yml#L3463-L3471) and [`report-test-timings`](https://github.com/buildkite/posthog/blob/b9a0729f733e6dd170017677bb339608489ec3d2/.github/workflows/ci-backend.yml#L3809-L3815):

```yaml
- name: Download junit artifacts
  uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
  with:
    path: ./junit-artifacts
    pattern: '{junit-results-backend,product-junit-results}-*'
```

Previously the braces caused admission to reject the pattern. This PR expands that exact bounded form into:

```text
junit-results-backend-*
product-junit-results-*
```

and evaluates both against the same verified artifact inventory.

## What

- Accept one optional leading group of 2–8 comma-separated literal prefixes.
- Reject empty alternatives, nesting, braces elsewhere, and glob metacharacters inside alternatives.
- Validate every expanded glob against the existing 255-byte artifact-name pattern contract.
- Preserve verified direct-`needs` provenance, the 64-match limit, deterministic artifact-name ordering, and overlap deduplication.
- Add PostHog-shaped compiler coverage plus runtime order, deduplication, collision, match-limit, staging, and failure-path tests.

This fixes bounded multi-prefix parsing and matching only. The unchanged PostHog uses still have independent blockers—most notably omitted `merge-multiple: true`, plus destination/provenance constraints in their respective jobs—so brace alternation remains outside the advertised public compatibility contract until hosted multi-producer proof exists.

Related: [PB-2796](https://linear.app/buildkite/issue/PB-2796/support-bounded-multi-prefix-artifact-selection)