### PR TITLE
Accept plugin source-ref acquisition field

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -99,8 +99,8 @@ The importer must run on Linux/amd64 with `BUILDKITE=true` and `BUILDKITE_STEP_K
 
 The hidden zero-argument `buildkite-gha plugin` entry point reads `workflow` and
 `runners` from `BUILDKITE_PLUGIN_CONFIGURATION`; it also accepts the plugin-owned
-`version` and `minimum-release-age` fields. The Linux/amd64 importer fetches the
-same release's Darwin runtime only when the workflow requires it.
+`version`, `source-ref`, and `minimum-release-age` fields. The Linux/amd64 importer
+fetches the same release's Darwin runtime only when the workflow requires it.
 
 Event source precedence is:
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -213,7 +213,7 @@ func parsePluginConfiguration(source string) (pluginConfiguration, error) {
 	}
 	for key := range encoded {
 		switch key {
-		case "workflow", "runners", "version", "minimum-release-age":
+		case "workflow", "runners", "version", "source-ref", "minimum-release-age":
 		default:
 			return pluginConfiguration{}, fmt.Errorf("%s contains unknown field %q", pluginConfigurationEnvironment, key)
 		}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -132,6 +132,7 @@ func TestParsePluginConfiguration(t *testing.T) {
 	configuration, err := parsePluginConfiguration(`{
   "workflow": ".github/workflows/ci.yml",
   "version": "0.8.0",
+  "source-ref": "0123456789abcdef0123456789abcdef01234567",
   "minimum-release-age": "24h",
   "runners": [
     {"runs-on":"ubuntu-latest","queue":"hosted","image":"` + image + `"},


### PR DESCRIPTION
## Why

The companion plugin now supports an exact `source-ref` for testing an unreleased runtime. It passes the original plugin configuration to the hidden Go command, whose strict decoder otherwise rejects that plugin-owned acquisition field before testing can begin.

## What

Accept and ignore top-level `source-ref` alongside `version` and `minimum-release-age`. Behavioral fields and runner-item fields remain strictly validated, and the retired `buildkite-gha-source-ref` alias remains unsupported.