### PR TITLE
Document the strict and loose expression evaluator families

### DIFF
--- a/internal/expression/expression.go
+++ b/internal/expression/expression.go
@@ -1087,6 +1087,12 @@ func resolveConditionReference(root string, path []string, context ConditionCont
 	return nil, fmt.Errorf("condition references unavailable value %s.%s", root, strings.Join(path, "."))
 }
 
+// The condition* helpers are the strict evaluation family used by runtime
+// conditions: mixed-type equality is an error rather than a coercion, so
+// unsupported comparisons fail closed instead of silently converting. The
+// actionInputDefault* family implements GitHub's loose coercion for action
+// input defaults; the two families are deliberately separate and must not
+// be unified.
 func conditionTruthy(value any) bool {
 	switch value := value.(type) {
 	case nil:
@@ -1130,6 +1136,10 @@ func conditionEqual(left, right any) (bool, error) {
 	return false, fmt.Errorf("mixed-type condition equality is unsupported")
 }
 
+// conditionNumber converts native numeric representations to a rational.
+// It is shared infrastructure for both the strict condition family and the
+// loose actionInputDefault family and does not by itself imply coercion:
+// callers decide whether non-numeric values become numbers.
 func conditionNumber(value any) (*big.Rat, bool) {
 	var source string
 	switch value := value.(type) {
@@ -1533,6 +1543,11 @@ func evaluateActionInputDefaultNode(node actionlint.ExprNode, context Context) (
 	}
 }
 
+// The actionInputDefault* helpers are the loose coercion family that mirrors
+// GitHub's expression semantics for action input defaults: nil and empty
+// strings coerce to zero, booleans coerce to numbers, and same-typed
+// aggregates compare by identity. Runtime conditions deliberately use the
+// strict condition* family instead; keep the two separate.
 func actionInputDefaultTruthy(value any) bool {
 	switch value := value.(type) {
 	case nil:

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -648,6 +648,42 @@ func TestEvaluateCompileConditionUsesEventSnapshot(t *testing.T) {
 	}
 }
 
+func TestCompileInputLiteralRepresentations(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   any
+		want    string
+		wantErr string
+	}{
+		{name: "nil is the null literal", value: nil, want: "null"},
+		{name: "true", value: true, want: "true"},
+		{name: "false", value: false, want: "false"},
+		{name: "plain string is quoted", value: "ready", want: "'ready'"},
+		{name: "apostrophes escape by doubling", value: "it's ready", want: "'it''s ready'"},
+		{name: "empty string stays a literal", value: "", want: "''"},
+		{name: "json number preserves source text", value: json.Number("0.30"), want: "0.30"},
+		{name: "int", value: 42, want: "42"},
+		{name: "float64 uses shortest form", value: 2.5, want: "2.5"},
+		{name: "aggregate values cannot be literals", value: []any{"x"}, wantErr: "cannot be represented"},
+		{name: "maps cannot be literals", value: map[string]any{"x": "y"}, wantErr: "cannot be represented"},
+		{name: "typed numerics outside the YAML model fail closed", value: int32(7), wantErr: "cannot be represented"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := compileInputLiteral(test.value)
+			if test.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+					t.Fatalf("compileInputLiteral(%#v) error = %v, want %q", test.value, err, test.wantErr)
+				}
+				return
+			}
+			if err != nil || got != test.want {
+				t.Fatalf("compileInputLiteral(%#v) = %q, %v, want %q", test.value, got, err, test.want)
+			}
+		})
+	}
+}
+
 func TestSubstituteCompileInputsPreservesExpressionSyntax(t *testing.T) {
 	template := "${{ !inputs.enabled && matrix.run-new && 'inputs.enabled' || inputs.label }}"
 	got, err := SubstituteCompileInputs(template, map[string]any{"enabled": false, "label": "it''s ready"})


### PR DESCRIPTION
First of three expression-package cleanups reviewed in the pre-1.0 architecture thread (follows #135–#140). No behavior change.

The package has two deliberately different value-semantics families: `condition*` (strict — mixed-type equality fails closed, used by runtime conditions) and `actionInputDefault*` (GitHub's loose coercion for action input defaults). Nothing recorded that the split is intentional, which invites an accidental "deduplication" into a bug.

## Changes

- Doc comments on both families stating the boundary and that they must not be unified; `conditionNumber` marked as shared conversion infrastructure that does not itself imply coercion.
- Characterization tests for `compileInputLiteral`, the least-covered function in the package (37.5%): null/bool/string/number representations, apostrophe doubling, and fail-closed rejection of aggregates and non-YAML numeric types.

## Validation

`mise run check` passes.