### PR TITLE
Move action lifecycle condition evaluation into expression

### DIFF
--- a/internal/expression/condition.go
+++ b/internal/expression/condition.go
@@ -321,6 +321,32 @@ func validateConditionReference(root string, path []string, scope ConditionScope
 	}
 }
 
+// EvaluateActionLifecycleCondition evaluates an action pre-if or post-if
+// condition against the supplied lifecycle state. The accepted grammar is
+// deliberately narrower than general conditions: exactly one bare status
+// function with optional ${{ }} delimiters. An empty condition is
+// unconditionally true (unlike general conditions, which apply the implicit
+// success guard), failure() means unsuccessful and not cancelled, and any
+// other expression fails closed with an error.
+func EvaluateActionLifecycleCondition(value string, unsuccessful, cancelled bool) (bool, error) {
+	value = strings.TrimSpace(value)
+	if strings.HasPrefix(value, "${{") && strings.HasSuffix(value, "}}") {
+		value = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(value, "${{"), "}}"))
+	}
+	switch strings.ToLower(value) {
+	case "", "always()":
+		return true, nil
+	case "success()":
+		return !unsuccessful && !cancelled, nil
+	case "failure()":
+		return unsuccessful && !cancelled, nil
+	case "cancelled()":
+		return cancelled, nil
+	default:
+		return false, fmt.Errorf("condition %q is unsupported", value)
+	}
+}
+
 // EvaluateCondition evaluates a job or step condition. Unsupported syntax and
 // unavailable values fail closed with an error.
 func EvaluateCondition(source string, context ConditionContext) (bool, error) {

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -490,6 +490,56 @@ func TestEvaluateFailsClosed(t *testing.T) {
 	}
 }
 
+func TestEvaluateActionLifecycleCondition(t *testing.T) {
+	tests := []struct {
+		name         string
+		condition    string
+		unsuccessful bool
+		cancelled    bool
+		want         bool
+		wantErr      bool
+	}{
+		{name: "empty means unconditional", condition: "", want: true},
+		{name: "empty stays true after failure", condition: "", unsuccessful: true, want: true},
+		{name: "empty stays true after cancellation", condition: "", cancelled: true, want: true},
+		{name: "whitespace only is empty", condition: "   ", unsuccessful: true, want: true},
+		{name: "always", condition: "always()", unsuccessful: true, cancelled: true, want: true},
+		{name: "success on success", condition: "success()", want: true},
+		{name: "success after failure", condition: "success()", unsuccessful: true, want: false},
+		{name: "success after cancellation", condition: "success()", cancelled: true, want: false},
+		{name: "failure after failure", condition: "failure()", unsuccessful: true, want: true},
+		{name: "cancellation dominates failure", condition: "failure()", unsuccessful: true, cancelled: true, want: false},
+		{name: "failure on success", condition: "failure()", want: false},
+		{name: "cancelled when cancelled", condition: "cancelled()", cancelled: true, want: true},
+		{name: "cancelled on success", condition: "cancelled()", want: false},
+		{name: "delimiters unwrap", condition: "${{ failure() }}", unsuccessful: true, want: true},
+		{name: "delimiters without spaces", condition: "${{always()}}", cancelled: true, want: true},
+		{name: "case is insensitive", condition: "ALWAYS()", want: true},
+		{name: "surrounding whitespace trims", condition: "  success()  ", want: true},
+		{name: "literals fail closed", condition: "true", wantErr: true},
+		{name: "references fail closed", condition: "github.event_name == 'push'", wantErr: true},
+		{name: "compound expressions fail closed", condition: "success() || failure()", wantErr: true},
+		{name: "arguments fail closed", condition: "success('build')", wantErr: true},
+		{name: "unknown functions fail closed", condition: "finished()", wantErr: true},
+		{name: "unopened delimiter fails closed", condition: "failure() }}", wantErr: true},
+		{name: "unclosed delimiter fails closed", condition: "${{ failure()", wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := EvaluateActionLifecycleCondition(test.condition, test.unsuccessful, test.cancelled)
+			if test.wantErr {
+				if err == nil || got {
+					t.Fatalf("EvaluateActionLifecycleCondition(%q) = %v, %v, want false with error", test.condition, got, err)
+				}
+				return
+			}
+			if err != nil || got != test.want {
+				t.Fatalf("EvaluateActionLifecycleCondition(%q, unsuccessful=%v, cancelled=%v) = %v, %v, want %v", test.condition, test.unsuccessful, test.cancelled, got, err, test.want)
+			}
+		})
+	}
+}
+
 func TestEvaluateConditionStatusOutputsAndTruthiness(t *testing.T) {
 	context := ConditionContext{
 		Inputs:      map[string]string{"enabled": "true"},

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -570,7 +570,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 			post.state = post.invocation.state
 			post.node = post.invocation.node
 		}
-		runPost, conditionErr := evaluateLifecycleCondition(post.condition, runErr != nil, ctx.Err() != nil || runCtx.Err() != nil)
+		runPost, conditionErr := expression.EvaluateActionLifecycleCondition(post.condition, runErr != nil, ctx.Err() != nil || runCtx.Err() != nil)
 		if conditionErr != nil {
 			runErr = errors.Join(runErr, fmt.Errorf("post action %q condition: %w", post.action.Name, conditionErr))
 			continue
@@ -1148,11 +1148,11 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 		if usesCheckoutAdapter(lock) || usesUploadArtifactAdapter(lock) || usesDownloadArtifactAdapter(lock) {
 			return result, nil
 		}
-		runPre, err := evaluateLifecycleCondition(action.Runs.PreIf, status.unsuccessful, ctx.Err() != nil)
+		runPre, err := expression.EvaluateActionLifecycleCondition(action.Runs.PreIf, status.unsuccessful, ctx.Err() != nil)
 		if err != nil {
 			return result, fmt.Errorf("JavaScript action %q pre-if: %w", step.Uses, err)
 		}
-		if _, err := evaluateLifecycleCondition(action.Runs.PostIf, false, false); err != nil {
+		if _, err := expression.EvaluateActionLifecycleCondition(action.Runs.PostIf, false, false); err != nil {
 			return result, fmt.Errorf("JavaScript action %q post-if: %w", step.Uses, err)
 		}
 		if action.Runs.Pre == "" && action.Runs.Post == "" {
@@ -1382,10 +1382,10 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 		if action.Runs.Main == "" {
 			return result, fmt.Errorf("JavaScript action %q has no main entry point", step.Uses)
 		}
-		if _, err := evaluateLifecycleCondition(action.Runs.PreIf, false, false); err != nil {
+		if _, err := expression.EvaluateActionLifecycleCondition(action.Runs.PreIf, false, false); err != nil {
 			return result, fmt.Errorf("JavaScript action %q pre-if: %w", step.Uses, err)
 		}
-		if _, err := evaluateLifecycleCondition(action.Runs.PostIf, false, false); err != nil {
+		if _, err := expression.EvaluateActionLifecycleCondition(action.Runs.PostIf, false, false); err != nil {
 			return result, fmt.Errorf("JavaScript action %q post-if: %w", step.Uses, err)
 		}
 		major, _ := actionNodeMajor(actionRuntime)
@@ -1418,7 +1418,7 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 			invocation.postRegistered = true
 		}
 		if javascript.Pre != "" && !wasPrepared {
-			runPre, _ := evaluateLifecycleCondition(action.Runs.PreIf, false, false)
+			runPre, _ := expression.EvaluateActionLifecycleCondition(action.Runs.PreIf, false, false)
 			if runPre {
 				if err := r.runJavaScriptPhase(ctx, processor, workspace, node, javascript, javascript.Pre, nil, state, &result); err != nil {
 					return result, err
@@ -1720,25 +1720,6 @@ func postForInvocation(invocation *preparedInvocation, condition string) *regist
 		return nil
 	}
 	return &registeredPost{condition: condition, invocation: invocation}
-}
-
-func evaluateLifecycleCondition(value string, unsuccessful, cancelled bool) (bool, error) {
-	value = strings.TrimSpace(value)
-	if strings.HasPrefix(value, "${{") && strings.HasSuffix(value, "}}") {
-		value = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(value, "${{"), "}}"))
-	}
-	switch strings.ToLower(value) {
-	case "", "always()":
-		return true, nil
-	case "success()":
-		return !unsuccessful && !cancelled, nil
-	case "failure()":
-		return unsuccessful && !cancelled, nil
-	case "cancelled()":
-		return cancelled, nil
-	default:
-		return false, fmt.Errorf("condition %q is unsupported", value)
-	}
 }
 
 func jobStatusValue(unsuccessful, cancelled bool) string {


### PR DESCRIPTION
Third of three expression-package cleanups (follows #151, #152), closing the one real encapsulation leak found in the review.

`evaluateLifecycleCondition` in `internal/runtime/job.go` hand-stripped `${{ }}` and reimplemented `success()`/`failure()`/`cancelled()`/`always()` with a switch — a second, private expression evaluator living outside the expression package.

## Changes

- The function moves **verbatim** to `expression.EvaluateActionLifecycleCondition` in `condition.go`. It deliberately does not delegate to `EvaluateCondition`: the lifecycle grammar is narrower and its semantics are exceptional — empty means unconditionally true (general conditions apply the implicit success guard), `failure()` means unsuccessful **and not cancelled** (cancellation dominates), and only a single bare status function with optional delimiters is accepted; anything else fails closed.
- The narrow name is intentional, so callers don't assume the broader condition grammar.
- Table tests pin the full truth table: empty/whitespace at success, failure, and cancellation; all four status functions with and without delimiters; case and whitespace handling; and fail-closed rejection of literals, references, compound expressions, arguments, unknown functions, and partial delimiters.
- All six runtime call sites adopt it unchanged — validation timing and error wrapping are preserved, including the deliberately ignored second evaluation error after prior validation.

## Validation

`mise run check` passes.