### PR TITLE
feat: add GitHub workflow access tokens

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -149,9 +149,9 @@ permissions:
   pull-requests: write
 ```
 
-Supported values are `read`, `write`, and `none`. Supported names are `actions`, `artifact-metadata`, `attestations`, `checks`, `contents`, `deployments`, `discussions`, `issues`, `models`, `packages`, `pages`, `pull-requests`, `repository-projects`, `security-events`, and `statuses`. The `models` permission is read-only. The other names support `read` and `write`.
+Supported values are `read`, `write`, and `none`. Supported names are `actions`, `artifact-metadata`, `attestations`, `checks`, `contents`, `deployments`, `discussions`, `issues`, `packages`, `pages`, `pull-requests`, `security-events`, and `statuses`.
 
-An omitted map defaults to `contents: read` when a token is needed. A job map replaces the workflow map; it does not merge with it. A called workflow may only narrow its caller's permissions.
+An omitted map defaults to `contents: read` when a token is needed. A job map replaces the workflow map; it does not merge with it. A called workflow may only narrow its caller's permissions. These forms remain compilable when no job needs a token. Hosted token issuance requires one explicit, non-empty top-level map and rejects job-level maps and reusable-workflow jobs.
 
 The `read-all` and `write-all` values, the `id-token` permission, and noncanonical names are unsupported. An empty map, or a map containing only `none`, creates no token.
 
@@ -596,24 +596,28 @@ JavaScript and Docker actions with compatible bundled cache clients, such as `ac
 
 ### GitHub token
 
-**🟡 Supported subset.** A job requests one short-lived `GITHUB_TOKEN` for the exact event repository by statically referencing `secrets.GITHUB_TOKEN` or by using an action whose effective input default references `github.token`. Effective `permissions` determine the token scope. The Buildkite organization must enable the job-bound token service. The server-side Buildkite policy for repositories and permissions remains authoritative.
+**🟡 Supported subset.** A job requests one short-lived `GITHUB_TOKEN` for the exact event repository by statically referencing `secrets.GITHUB_TOKEN` or by using an action whose effective input default references `github.token`. Effective `permissions` determine the token scope. The Buildkite organization feature and the pipeline's workflow access token setting must be enabled. Both are disabled by default.
 
-A job can request a token for a pull request comment:
+Buildkite reads the workflow policy from the pipeline repository at the build's immutable commit. The workflow must be directly under `.github/workflows/`, use a simple `.yml` or `.yaml` filename, declare an explicit non-empty top-level permission map, and contain no job-level permission maps or reusable-workflow jobs.
+
+Pull-request builds and their triggered or rebuilt descendants may request only `contents: read`. Merge-queue builds and their descendants cannot request a token. The backend verifies this provenance and remains authoritative.
+
+A job can request read-only repository access:
 
 ```yaml
 permissions:
-  pull-requests: write
+  contents: read
 
 jobs:
-  comment:
+  inspect:
     runs-on: ubuntu-latest
     steps:
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr comment "$PR_NUMBER" --body "Checks passed"
+        run: gh api repos/{owner}/{repo}
 ```
 
-Job binding does not establish fork or actor trust. If untrusted sources can edit workflows, they can request write permissions. Restrict write tokens with Buildkite pipeline and organization policy.
+The server restricts pull requests, merge queues, and their descendants. For other builds, job binding does not establish that an arbitrary commit is trusted. Restrict who can create builds and enable write tokens only when branch builds run trusted code.
 
 The token is not added to the initial job environment. The `github.token` value is available only while evaluating an effective action metadata input default. Workflow-authored `github.token` and automatic ambient `GITHUB_TOKEN` are unsupported.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -27,14 +27,16 @@ Digests and immutable action locks detect changed code. They do not make code tr
 | Credential | Current boundary |
 | --- | --- |
 | Repository checkout | The verified adapter checks the event repository and exact commit. Buildkite authorizes managed private access; credentials are command-scoped and not persisted. |
-| `GITHUB_TOKEN` | Supported static uses receive one short-lived token for the event repository and compiler-resolved permissions. Buildkite verifies the repository and may deny the request. The token is not ambient. |
+| `GITHUB_TOKEN` | Supported static uses receive one short-lived token for the event repository and compiler-resolved permissions. Buildkite verifies the pipeline repository, immutable commit, workflow policy, and build provenance. Pull requests are limited to `contents: read`; merge queues are denied. The token is not ambient. |
 | Cache token | When caching is configured, every JavaScript or Docker action lifecycle receives a fresh job-bound token. This includes compatible clients such as `actions/setup-go`, not only `actions/cache`. Shell steps do not receive it. |
 | Ordinary workflow secrets | Rejected by production admission. |
 | GitHub-compatible OIDC | Unsupported. |
 
 An action that receives a credential can use or exfiltrate it. It can also export `GITHUB_TOKEN` to later steps through `GITHUB_ENV`. Log masking reduces accidental disclosure, but it is not access control and does not catch transformed values.
 
-If untrusted code can edit a workflow that requests write permissions, it can use a token that Buildkite allows. Restrict write permissions with organization and pipeline policy.
+Workflow token issuance requires an organization feature and a default-off pipeline setting. Buildkite reads the top-level permission policy from the workflow at the build's immutable commit. It denies incomplete or cyclic trigger and rebuild provenance. Pull-request ancestry retains a `contents: read` ceiling, and merge-queue ancestry is denied.
+
+For other builds, a user with permission to create a build at an arbitrary commit may select code that requests the workflow's allowed permissions. Enable write tokens only when those build-creation paths and branch builds are trusted.
 
 ### Checkout and submodules
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1445,7 +1445,7 @@ func hostedTokenlessError(kind hostedTokenlessFailureKind, err error) error {
 }
 
 type actionSourceAuthentication struct {
-	provider gharuntime.WorkflowTokenProvider
+	provider gharuntime.ScopedTokenProvider
 	redactor gharuntime.Redactor
 	warnings io.Writer
 }
@@ -1484,7 +1484,7 @@ func (a *actionSourceAuthentication) token(ctx context.Context, repository strin
 		a.warnAnonymousFallback("job-scoped GitHub source authentication is unavailable")
 		return "", nil
 	}
-	token, err := a.provider.WorkflowToken(ctx, repository, map[string]string{"contents": "read"})
+	token, err := a.provider.ScopedToken(ctx, repository, map[string]string{"contents": "read"})
 	if err != nil {
 		if ctx.Err() != nil {
 			return "", ctx.Err()
@@ -1626,8 +1626,13 @@ func validateUnprivilegedBundle(bundle compiler.Bundle) error {
 				continue
 			}
 			if capability == "provider-token-write" {
-				if artifact.Job.GitHubToken == nil || !slices.Equal(artifact.Authorization.ProviderTokenWriteCapabilitySources, []string{"effective-permissions"}) {
-					addFailure(artifact, "provider token write capability lacks compiler-verified permission provenance", fmt.Errorf("job %q requires provider-token-write without compiler-verified workflow permission provenance", artifact.Job.Workflow.LogicalJobID))
+				filename, filenameErr := plan.GitHubWorkflowPolicyFilename(artifact.Job.Workflow.Path)
+				if artifact.Job.GitHubToken == nil || !slices.Equal(artifact.Authorization.ProviderTokenWriteCapabilitySources, []string{"effective-permissions"}) || filenameErr != nil || artifact.Authorization.WorkflowTokenPolicyFilename == "" || artifact.Authorization.WorkflowTokenPolicyFilename != filename {
+					reason := bundle.IR.Workflow.WorkflowTokenPolicyDiagnostic
+					if reason == "" {
+						reason = "compiler-verified workflow policy evidence is missing or does not match the job plan"
+					}
+					addFailure(artifact, "provider token write capability lacks compiler-verified workflow policy", fmt.Errorf("job %q requires provider-token-write without a compiler-verified workflow policy: %s", artifact.Job.Workflow.LogicalJobID, reason))
 				}
 				continue
 			}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -3115,7 +3115,7 @@ func TestUnprivilegedUploadAdmitsOnlyCompilerVerifiedCheckoutCredentials(t *test
 
 func TestUnprivilegedUploadAdmitsOnlyCompilerVerifiedWorkflowToken(t *testing.T) {
 	job := plan.Job{
-		Workflow:             plan.Workflow{LogicalJobID: "comment"},
+		Workflow:             plan.Workflow{Path: ".github/workflows/comment.yml", LogicalJobID: "comment"},
 		RequiredCapabilities: []string{"provider-token-write"},
 		GitHubToken:          &plan.GitHubToken{Permissions: map[string]string{"pull_requests": "write"}},
 	}
@@ -3124,14 +3124,16 @@ func TestUnprivilegedUploadAdmitsOnlyCompilerVerifiedWorkflowToken(t *testing.T)
 		authorization compiler.PlanAuthorization
 		wantError     bool
 	}{
-		{name: "verified permissions", authorization: compiler.PlanAuthorization{ProviderTokenWriteCapabilitySources: []string{"effective-permissions"}}},
+		{name: "verified policy", authorization: compiler.PlanAuthorization{ProviderTokenWriteCapabilitySources: []string{"effective-permissions"}, WorkflowTokenPolicyFilename: "comment.yml"}},
 		{name: "missing provenance", wantError: true},
-		{name: "broadened provenance", authorization: compiler.PlanAuthorization{ProviderTokenWriteCapabilitySources: []string{"effective-permissions", "step-input"}}, wantError: true},
+		{name: "missing policy", authorization: compiler.PlanAuthorization{ProviderTokenWriteCapabilitySources: []string{"effective-permissions"}}, wantError: true},
+		{name: "mismatched policy", authorization: compiler.PlanAuthorization{ProviderTokenWriteCapabilitySources: []string{"effective-permissions"}, WorkflowTokenPolicyFilename: "other.yml"}, wantError: true},
+		{name: "broadened provenance", authorization: compiler.PlanAuthorization{ProviderTokenWriteCapabilitySources: []string{"effective-permissions", "step-input"}, WorkflowTokenPolicyFilename: "comment.yml"}, wantError: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: job, Authorization: test.authorization}}}
 			err := validateUnprivilegedBundle(bundle)
-			if test.wantError && (err == nil || !strings.Contains(err.Error(), "workflow permission provenance")) {
+			if test.wantError && (err == nil || !strings.Contains(err.Error(), "workflow policy")) {
 				t.Fatalf("validateUnprivilegedBundle() error = %v", err)
 			}
 			if !test.wantError && err != nil {
@@ -3344,7 +3346,7 @@ type cliWorkflowTokenProvider struct {
 	calls       int
 }
 
-func (p *cliWorkflowTokenProvider) WorkflowToken(_ context.Context, repository string, permissions map[string]string) (string, error) {
+func (p *cliWorkflowTokenProvider) ScopedToken(_ context.Context, repository string, permissions map[string]string) (string, error) {
 	p.calls++
 	p.repository = repository
 	p.permissions = permissions

--- a/internal/compiler/bundle.go
+++ b/internal/compiler/bundle.go
@@ -28,6 +28,7 @@ type PlanAuthorization struct {
 	DockerCapabilitySources             []string
 	ProviderTokenReadCapabilitySources  []string
 	ProviderTokenWriteCapabilitySources []string
+	WorkflowTokenPolicyFilename         string
 }
 
 // Bundle is the complete deterministic output of static compilation.

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -637,7 +637,7 @@ jobs:
     steps:
       - run: true
 `)
-	bundle, err := CompileBundle("workflow.yml", source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-importer")
+	bundle, err := CompileBundle(".github/workflows/token.yml", source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-importer")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -652,7 +652,7 @@ jobs:
 	if !reflect.DeepEqual(token.Job.RequiredSecrets, []string{"OTHER"}) || !reflect.DeepEqual(token.Job.RequiredCapabilities, []string{"provider-token-write", "secrets"}) {
 		t.Fatalf("token secret boundary = names %#v capabilities %#v", token.Job.RequiredSecrets, token.Job.RequiredCapabilities)
 	}
-	if !reflect.DeepEqual(token.Authorization.ProviderTokenWriteCapabilitySources, []string{"effective-permissions"}) {
+	if !reflect.DeepEqual(token.Authorization.ProviderTokenWriteCapabilitySources, []string{"effective-permissions"}) || token.Authorization.WorkflowTokenPolicyFilename != "token.yml" {
 		t.Fatalf("token authorization = %#v", token.Authorization)
 	}
 	if jobs["tokenless"].Job.GitHubToken != nil || jobs["tokenless"].Job.HasCapability("provider-token-write") {

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -78,10 +78,12 @@ type ExecutionBoundary struct {
 
 // WorkflowSource binds the IR to its input workflow bytes.
 type WorkflowSource struct {
-	Path             string `json:"path"`
-	Name             string `json:"name,omitempty"`
-	Digest           string `json:"digest"`
-	ConcurrencyGroup string `json:"concurrency_group,omitempty"`
+	Path                          string `json:"path"`
+	Name                          string `json:"name,omitempty"`
+	Digest                        string `json:"digest"`
+	ConcurrencyGroup              string `json:"concurrency_group,omitempty"`
+	WorkflowTokenPolicyFilename   string `json:"-"`
+	WorkflowTokenPolicyDiagnostic string `json:"-"`
 }
 
 // JobInstance is one statically expanded job in the owned IR.
@@ -513,6 +515,7 @@ instances:
 				githubToken = &plan.GitHubToken{Permissions: permissions}
 				capabilities = append(capabilities, "provider-token-write")
 				authorization.ProviderTokenWriteCapabilitySources = []string{"effective-permissions"}
+				authorization.WorkflowTokenPolicyFilename = ir.Workflow.WorkflowTokenPolicyFilename
 			}
 			if len(secrets) != 0 {
 				capabilities = append(capabilities, "secrets")
@@ -679,6 +682,7 @@ func compile(path string, source, eventSource []byte, options Options) (IR, erro
 	if err != nil {
 		return IR{}, processingFinding(StageWorkflowParsing, CodeWorkflowSyntax, "syntax", err)
 	}
+	workflowTokenPolicyFilename, workflowTokenPolicyDiagnostic := workflowTokenPolicyEvidence(path, parsed)
 	event, err := parseEvent(eventSource)
 	if err != nil {
 		return IR{}, processingFinding(StageEventValidation, CodeEventInvalid, "environment", err)
@@ -693,8 +697,11 @@ func compile(path string, source, eventSource []byte, options Options) (IR, erro
 	expanded, expandErr := expand(path, source, parsed, context, options)
 	digest := sha256.Sum256(source)
 	ir := IR{
-		Schema:   schema,
-		Workflow: WorkflowSource{Path: path, Name: parsed.Name, Digest: "sha256:" + hex.EncodeToString(digest[:]), ConcurrencyGroup: workflowConcurrencyGroup},
+		Schema: schema,
+		Workflow: WorkflowSource{
+			Path: path, Name: parsed.Name, Digest: "sha256:" + hex.EncodeToString(digest[:]), ConcurrencyGroup: workflowConcurrencyGroup,
+			WorkflowTokenPolicyFilename: workflowTokenPolicyFilename, WorkflowTokenPolicyDiagnostic: workflowTokenPolicyDiagnostic,
+		},
 		Event:    event,
 		Vars:     vars,
 		Warnings: compilerWarnings(parsed.Concurrency, cancelInProgress),
@@ -705,6 +712,32 @@ func compile(path string, source, eventSource []byte, options Options) (IR, erro
 		Jobs: expanded.instances,
 	}
 	return ir, errors.Join(concurrencyErr, cancellationErr, expandErr)
+}
+
+func workflowTokenPolicyEvidence(path string, parsed *workflow.Workflow) (string, string) {
+	filename, err := plan.GitHubWorkflowPolicyFilename(canonicalWorkflowName(path))
+	if err != nil {
+		return "", err.Error()
+	}
+	if parsed.Permissions == nil || len(parsed.Permissions.Scopes) == 0 {
+		return "", "GitHub workflow access tokens require explicit non-empty top-level permissions"
+	}
+	permissions := make(map[string]string, len(parsed.Permissions.Scopes))
+	for name, access := range parsed.Permissions.Scopes {
+		permissions[strings.ReplaceAll(name, "-", "_")] = access
+	}
+	if err := plan.ValidateGitHubWorkflowAccessTokenPermissions(permissions); err != nil {
+		return "", err.Error()
+	}
+	for _, job := range parsed.Jobs {
+		if job.Permissions != nil {
+			return "", "GitHub workflow access tokens do not support job-level permissions"
+		}
+		if job.Reusable != nil {
+			return "", "GitHub workflow access tokens do not support reusable-workflow jobs"
+		}
+	}
+	return filename, ""
 }
 
 func compilerWarnings(concurrency *workflow.Concurrency, cancelInProgress bool) []Warning {

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -41,6 +41,52 @@ func TestEffectiveReusablePermissionsOnlyNarrowCallerAuthority(t *testing.T) {
 	}
 }
 
+func TestWorkflowTokenPolicyEvidence(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		path       string
+		source     string
+		want       string
+		diagnostic string
+	}{
+		{
+			name: "eligible", path: ".github/workflows/ci.yml", want: "ci.yml",
+			source: "on: push\npermissions:\n  contents: read\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
+		},
+		{
+			name: "missing top-level permissions", path: ".github/workflows/ci.yml", diagnostic: "explicit non-empty",
+			source: "on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
+		},
+		{
+			name: "job permissions", path: ".github/workflows/ci.yml", diagnostic: "job-level",
+			source: "on: push\npermissions:\n  contents: read\njobs:\n  test:\n    permissions:\n      contents: read\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
+		},
+		{
+			name: "reusable workflow", path: ".github/workflows/ci.yml", diagnostic: "reusable-workflow",
+			source: "on: push\npermissions:\n  contents: read\njobs:\n  test:\n    uses: ./.github/workflows/reusable.yml\n",
+		},
+		{
+			name: "invalid path", path: "ci.yml", diagnostic: "directly under .github/workflows",
+			source: "on: push\npermissions:\n  contents: read\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
+		},
+		{
+			name: "endpoint permission mismatch", path: ".github/workflows/ci.yml", diagnostic: "unsupported permission",
+			source: "on: push\npermissions:\n  models: read\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			parsed, err := workflow.Parse(test.path, []byte(test.source))
+			if err != nil {
+				t.Fatal(err)
+			}
+			filename, diagnostic := workflowTokenPolicyEvidence(test.path, parsed)
+			if filename != test.want || !strings.Contains(diagnostic, test.diagnostic) {
+				t.Fatalf("workflowTokenPolicyEvidence() = %q, %q", filename, diagnostic)
+			}
+		})
+	}
+}
+
 func TestCompilePlansBoundsNestedReusableWorkflowDefaultPermissions(t *testing.T) {
 	repository := t.TempDir()
 	caller := writeWorkflow(t, repository, "caller.yml", `on: push

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -44,6 +44,7 @@ var containerEnvKeyPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 var containerPortPattern = regexp.MustCompile(`^(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(?::(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]))?(?:/(?:tcp|udp))?$`)
 var serviceNamePattern = regexp.MustCompile(`^[a-z_][a-z0-9_-]{0,254}$`)
 var githubRepositoryPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`)
+var githubWorkflowFilenamePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*\.ya?ml$`)
 
 var githubTokenPermissionAccess = map[string]map[string]bool{
 	"actions":             {"read": true, "write": true},
@@ -61,6 +62,22 @@ var githubTokenPermissionAccess = map[string]map[string]bool{
 	"repository_projects": {"read": true, "write": true},
 	"security_events":     {"read": true, "write": true},
 	"statuses":            {"read": true, "write": true},
+}
+
+var githubWorkflowAccessTokenPermissionAccess = map[string]map[string]bool{
+	"actions":           {"read": true, "write": true},
+	"artifact_metadata": {"read": true, "write": true},
+	"attestations":      {"read": true, "write": true},
+	"checks":            {"read": true, "write": true},
+	"contents":          {"read": true, "write": true},
+	"deployments":       {"read": true, "write": true},
+	"discussions":       {"read": true, "write": true},
+	"issues":            {"read": true, "write": true},
+	"packages":          {"read": true, "write": true},
+	"pages":             {"read": true, "write": true},
+	"pull_requests":     {"read": true, "write": true},
+	"security_events":   {"read": true, "write": true},
+	"statuses":          {"read": true, "write": true},
 }
 
 type ActionSelector struct {
@@ -655,6 +672,31 @@ func validGitHubRepository(repository string) bool {
 	return parts[0] != "." && parts[0] != ".." && parts[1] != "." && parts[1] != ".."
 }
 
+// GitHubWorkflowPolicyFilename derives the workflow-policy endpoint filename
+// from a compiler-owned repository workflow path.
+func GitHubWorkflowPolicyFilename(path string) (string, error) {
+	const prefix = ".github/workflows/"
+
+	relative := strings.TrimPrefix(path, "./")
+	if !strings.HasPrefix(relative, prefix) {
+		return "", fmt.Errorf("GitHub workflow token requires a workflow directly under .github/workflows")
+	}
+	filename := strings.TrimPrefix(relative, prefix)
+	if err := ValidateGitHubWorkflowPolicyFilename(filename); err != nil {
+		return "", err
+	}
+	return filename, nil
+}
+
+// ValidateGitHubWorkflowPolicyFilename applies the Agent API endpoint's
+// basename contract.
+func ValidateGitHubWorkflowPolicyFilename(filename string) error {
+	if len(filename) == 0 || len(filename) > 255 || strings.ContainsAny(filename, `/\\`) || !githubWorkflowFilenamePattern.MatchString(filename) {
+		return fmt.Errorf("GitHub workflow token requires a simple .yml or .yaml filename of at most 255 bytes")
+	}
+	return nil
+}
+
 func validateGitHubTokenPermissions(permissions map[string]string) error {
 	if len(permissions) == 0 || len(permissions) > len(githubTokenPermissionAccess) {
 		return fmt.Errorf("GitHub workflow token requires a non-empty bounded permission set")
@@ -663,6 +705,21 @@ func validateGitHubTokenPermissions(permissions map[string]string) error {
 		allowed, ok := githubTokenPermissionAccess[name]
 		if !ok || !allowed[access] {
 			return fmt.Errorf("GitHub workflow token contains unsupported permission %q with access %q", name, access)
+		}
+	}
+	return nil
+}
+
+// ValidateGitHubWorkflowAccessTokenPermissions applies the workflow-policy
+// endpoint's current server-maintained allowlist.
+func ValidateGitHubWorkflowAccessTokenPermissions(permissions map[string]string) error {
+	if len(permissions) == 0 || len(permissions) > len(githubWorkflowAccessTokenPermissionAccess) {
+		return fmt.Errorf("GitHub workflow access token requires a non-empty bounded permission set")
+	}
+	for name, access := range permissions {
+		allowed, ok := githubWorkflowAccessTokenPermissionAccess[name]
+		if !ok || !allowed[access] {
+			return fmt.Errorf("GitHub workflow access token contains unsupported permission %q with access %q", name, access)
 		}
 	}
 	return nil

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -766,6 +766,50 @@ func TestV5PrerequisiteOutputProjectionContractAndLegacyRejection(t *testing.T) 
 	}
 }
 
+func TestGitHubWorkflowPolicyFilename(t *testing.T) {
+	valid255 := strings.Repeat("a", 251) + ".yml"
+	for _, test := range []struct {
+		path string
+		want string
+	}{
+		{path: ".github/workflows/ci.yml", want: "ci.yml"},
+		{path: "./.github/workflows/release.yaml", want: "release.yaml"},
+		{path: ".github/workflows/Release_1.2-test.yml", want: "Release_1.2-test.yml"},
+		{path: ".github/workflows/" + valid255, want: valid255},
+	} {
+		got, err := GitHubWorkflowPolicyFilename(test.path)
+		if err != nil || got != test.want {
+			t.Errorf("GitHubWorkflowPolicyFilename(%q) = %q, %v; want %q", test.path, got, err, test.want)
+		}
+	}
+
+	for _, path := range []string{
+		"", "ci.yml", "/.github/workflows/ci.yml", ".github/workflows/nested/ci.yml",
+		".github/workflows/../ci.yml", ".github/workflows/.ci.yml", ".github/workflows/ci.json",
+		".github/workflows/ci yml", ".github/workflows/" + strings.Repeat("a", 252) + ".yml",
+	} {
+		if _, err := GitHubWorkflowPolicyFilename(path); err == nil {
+			t.Errorf("GitHubWorkflowPolicyFilename(%q) succeeded", path)
+		}
+	}
+}
+
+func TestValidateGitHubWorkflowAccessTokenPermissions(t *testing.T) {
+	if err := ValidateGitHubWorkflowAccessTokenPermissions(map[string]string{"contents": "read", "pull_requests": "write"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, permissions := range []map[string]string{
+		nil,
+		{"models": "read"},
+		{"repository_projects": "read"},
+		{"contents": "admin"},
+	} {
+		if err := ValidateGitHubWorkflowAccessTokenPermissions(permissions); err == nil {
+			t.Errorf("ValidateGitHubWorkflowAccessTokenPermissions(%#v) succeeded", permissions)
+		}
+	}
+}
+
 func TestV6GitHubWorkflowTokenContractAndSchema(t *testing.T) {
 	job := validJob()
 	job.Schema = SchemaV6

--- a/internal/runtime/github_token_service.go
+++ b/internal/runtime/github_token_service.go
@@ -12,6 +12,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/buildkite/buildkite-gha/internal/plan"
 )
 
 const githubTokenResponseLimit = 64 << 10
@@ -22,7 +24,13 @@ var retryAfterSecondsPattern = regexp.MustCompile(`^[0-9]{1,10}$`)
 // WorkflowTokenProvider mints one repository-scoped credential with the exact
 // plan-declared permissions accepted by the Buildkite backend.
 type WorkflowTokenProvider interface {
-	WorkflowToken(context.Context, string, map[string]string) (string, error)
+	WorkflowToken(context.Context, string, string, map[string]string) (string, error)
+}
+
+// ScopedTokenProvider mints a repository-scoped credential without selecting
+// the workflow-policy authority.
+type ScopedTokenProvider interface {
+	ScopedToken(context.Context, string, map[string]string) (string, error)
 }
 
 // AgentGitHubTokenConfig carries the current Buildkite job's Agent connection
@@ -38,13 +46,18 @@ type AgentGitHubTokenConfig struct {
 // AgentGitHubTokens mints repository-scoped tokens through Buildkite's
 // job-bound Agent API endpoint.
 type AgentGitHubTokens struct {
-	mintURL  string
-	jobToken string
-	client   *http.Client
+	scopedURL   string
+	workflowURL string
+	jobToken    string
+	client      *http.Client
 }
 
 func NewAgentGitHubTokens(config AgentGitHubTokenConfig) (*AgentGitHubTokens, error) {
-	mintURL, err := agentGitHubTokenURL(config.Endpoint, config.JobID)
+	scopedURL, err := agentGitHubTokenURL(config.Endpoint, config.JobID, "github_scoped_access_token")
+	if err != nil {
+		return nil, err
+	}
+	workflowURL, err := agentGitHubTokenURL(config.Endpoint, config.JobID, "github_workflow_access_token")
 	if err != nil {
 		return nil, err
 	}
@@ -61,17 +74,33 @@ func NewAgentGitHubTokens(config AgentGitHubTokenConfig) (*AgentGitHubTokens, er
 	if bounded.Timeout == 0 {
 		bounded.Timeout = 15 * time.Second
 	}
-	return &AgentGitHubTokens{mintURL: mintURL, jobToken: config.JobToken, client: &bounded}, nil
+	return &AgentGitHubTokens{scopedURL: scopedURL, workflowURL: workflowURL, jobToken: config.JobToken, client: &bounded}, nil
 }
 
-func (c *AgentGitHubTokens) WorkflowToken(ctx context.Context, repository string, permissions map[string]string) (string, error) {
-	if !validWorkflowTokenPermissions(permissions) {
-		return "", fmt.Errorf("GitHub workflow token requires valid effective permissions")
+func (c *AgentGitHubTokens) WorkflowToken(ctx context.Context, repository, workflow string, permissions map[string]string) (string, error) {
+	if c == nil {
+		return "", fmt.Errorf("GitHub workflow token provider is not configured")
 	}
-	return c.mint(ctx, repository, permissions, "workflow")
+	if err := plan.ValidateGitHubWorkflowPolicyFilename(workflow); err != nil {
+		return "", err
+	}
+	if err := plan.ValidateGitHubWorkflowAccessTokenPermissions(permissions); err != nil {
+		return "", err
+	}
+	return c.mint(ctx, c.workflowURL, repository, workflow, permissions, "workflow")
 }
 
-func (c *AgentGitHubTokens) mint(ctx context.Context, repository string, permissions map[string]string, purpose string) (string, error) {
+func (c *AgentGitHubTokens) ScopedToken(ctx context.Context, repository string, permissions map[string]string) (string, error) {
+	if c == nil {
+		return "", fmt.Errorf("GitHub scoped token provider is not configured")
+	}
+	if !validScopedTokenPermissions(permissions) {
+		return "", fmt.Errorf("GitHub scoped token requires valid permissions")
+	}
+	return c.mint(ctx, c.scopedURL, repository, "", permissions, "scoped")
+}
+
+func (c *AgentGitHubTokens) mint(ctx context.Context, mintURL, repository, workflow string, permissions map[string]string, purpose string) (string, error) {
 	if c == nil {
 		return "", fmt.Errorf("GitHub %s token provider is not configured", purpose)
 	}
@@ -80,15 +109,17 @@ func (c *AgentGitHubTokens) mint(ctx context.Context, repository string, permiss
 	}
 	body, err := json.Marshal(struct {
 		RepositoryURL string            `json:"repo_url"`
+		Workflow      string            `json:"workflow,omitempty"`
 		Permissions   map[string]string `json:"permissions"`
 	}{
 		RepositoryURL: "https://github.com/" + repository,
+		Workflow:      workflow,
 		Permissions:   permissions,
 	})
 	if err != nil {
 		return "", fmt.Errorf("encode GitHub %s token request: %w", purpose, err)
 	}
-	request, err := http.NewRequestWithContext(ctx, http.MethodPost, c.mintURL, bytes.NewReader(body))
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, mintURL, bytes.NewReader(body))
 	if err != nil {
 		return "", fmt.Errorf("create GitHub %s token request: %w", purpose, err)
 	}
@@ -102,7 +133,7 @@ func (c *AgentGitHubTokens) mint(ctx context.Context, repository string, permiss
 	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
 		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, githubTokenResponseLimit))
-		return "", githubTokenStatusError(response.StatusCode, response.Header.Get("Retry-After"))
+		return "", githubTokenStatusError(response.StatusCode, response.Header.Get("Retry-After"), purpose)
 	}
 	payload, err := io.ReadAll(io.LimitReader(response.Body, githubTokenResponseLimit+1))
 	if err != nil {
@@ -128,7 +159,7 @@ func (c *AgentGitHubTokens) mint(ctx context.Context, repository string, permiss
 	return decoded.Token, nil
 }
 
-func validWorkflowTokenPermissions(permissions map[string]string) bool {
+func validScopedTokenPermissions(permissions map[string]string) bool {
 	if len(permissions) == 0 || len(permissions) > 15 {
 		return false
 	}
@@ -149,7 +180,7 @@ func validWorkflowTokenPermissions(permissions map[string]string) bool {
 	return true
 }
 
-func agentGitHubTokenURL(endpoint, jobID string) (string, error) {
+func agentGitHubTokenURL(endpoint, jobID, endpointName string) (string, error) {
 	if !validBuildkiteJobID(jobID) {
 		return "", fmt.Errorf("GitHub token Agent job ID is required")
 	}
@@ -157,26 +188,30 @@ func agentGitHubTokenURL(endpoint, jobID string) (string, error) {
 	if err != nil || !validCredentialServiceURL(u) {
 		return "", fmt.Errorf("safe GitHub token Agent endpoint using HTTPS or loopback HTTP is required")
 	}
-	u.Path = strings.TrimRight(u.Path, "/") + "/jobs/" + jobID + "/github_scoped_access_token"
+	u.Path = strings.TrimRight(u.Path, "/") + "/jobs/" + jobID + "/" + endpointName
 	u.RawPath = ""
 	return u.String(), nil
 }
 
-func githubTokenStatusError(status int, retryAfter string) error {
+func githubTokenStatusError(status int, retryAfter, purpose string) error {
+	credential := "GitHub " + purpose + " token"
 	switch status {
 	case http.StatusBadRequest:
-		return fmt.Errorf("GitHub token request was rejected")
+		return fmt.Errorf("%s request was rejected", credential)
 	case http.StatusUnauthorized, http.StatusForbidden:
-		return fmt.Errorf("GitHub token request was denied")
+		return fmt.Errorf("%s request was denied", credential)
 	case http.StatusNotFound:
+		if purpose == "workflow" {
+			return fmt.Errorf("GitHub workflow access tokens are not enabled for this organization or pipeline")
+		}
 		return fmt.Errorf("GitHub scoped access tokens are not enabled for this organization")
 	case http.StatusServiceUnavailable:
 		retryAfter = strings.TrimSpace(retryAfter)
 		if retryAfterSecondsPattern.MatchString(retryAfter) {
-			return fmt.Errorf("GitHub token service is temporarily unavailable; retry after %s seconds", retryAfter)
+			return fmt.Errorf("%s service is temporarily unavailable; retry after %s seconds", credential, retryAfter)
 		}
-		return fmt.Errorf("GitHub token service is temporarily unavailable")
+		return fmt.Errorf("%s service is temporarily unavailable", credential)
 	default:
-		return fmt.Errorf("GitHub token service returned HTTP %d", status)
+		return fmt.Errorf("%s service returned HTTP %d", credential, status)
 	}
 }

--- a/internal/runtime/github_token_service_test.go
+++ b/internal/runtime/github_token_service_test.go
@@ -17,11 +17,17 @@ import (
 func TestAgentGitHubTokensMintsExactWorkflowPermissions(t *testing.T) {
 	const statelessToken = "ghs_header.payload-with-hyphen.signature"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/jobs/"+testCacheJobID+"/github_workflow_access_token" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if r.Method != http.MethodPost || r.Header.Get("Authorization") != "Token job-secret" || r.Header.Get("Accept") != "application/json" || r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("request = %s headers %#v", r.Method, r.Header)
+		}
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Error(err)
 		}
-		if string(body) != `{"repo_url":"https://github.com/buildkite/buildkite-gha","permissions":{"contents":"read","pull_requests":"write"}}` {
+		if string(body) != `{"repo_url":"https://github.com/buildkite/buildkite-gha","workflow":"ci.yml","permissions":{"contents":"read","pull_requests":"write"}}` {
 			t.Errorf("request body = %s", body)
 		}
 		_, _ = io.WriteString(w, `{"token":"`+statelessToken+`"}`)
@@ -31,14 +37,61 @@ func TestAgentGitHubTokensMintsExactWorkflowPermissions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	token, err := provider.WorkflowToken(context.Background(), "buildkite/buildkite-gha", map[string]string{"pull_requests": "write", "contents": "read"})
+	token, err := provider.WorkflowToken(context.Background(), "buildkite/buildkite-gha", "ci.yml", map[string]string{"pull_requests": "write", "contents": "read"})
 	if err != nil || token != statelessToken {
 		t.Fatalf("WorkflowToken() = %q, %v", token, err)
 	}
 	for _, permissions := range []map[string]string{nil, {}, {"contents": "admin"}, {"administration": "write"}, {"models": "write"}} {
-		if _, err := provider.WorkflowToken(context.Background(), "buildkite/buildkite-gha", permissions); err == nil {
+		if _, err := provider.WorkflowToken(context.Background(), "buildkite/buildkite-gha", "ci.yml", permissions); err == nil {
 			t.Fatalf("WorkflowToken(%#v) succeeded", permissions)
 		}
+	}
+	for _, permissions := range []map[string]string{{"models": "read"}, {"repository_projects": "read"}} {
+		if _, err := provider.WorkflowToken(context.Background(), "buildkite/buildkite-gha", "ci.yml", permissions); err == nil {
+			t.Fatalf("WorkflowToken(%#v) succeeded", permissions)
+		}
+	}
+}
+
+func TestAgentGitHubTokensMintsScopedSourceTokenWithoutWorkflow(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/jobs/"+testCacheJobID+"/github_scoped_access_token" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(body) != `{"repo_url":"https://github.com/actions/checkout","permissions":{"contents":"read"}}` {
+			t.Errorf("request body = %s", body)
+		}
+		_, _ = io.WriteString(w, `{"token":"ghs_scoped"}`)
+	}))
+	defer server.Close()
+	provider, err := NewAgentGitHubTokens(AgentGitHubTokenConfig{Endpoint: server.URL, JobID: testCacheJobID, JobToken: "job-secret"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token, err := provider.ScopedToken(context.Background(), "actions/checkout", map[string]string{"contents": "read"}); err != nil || token != "ghs_scoped" {
+		t.Fatalf("ScopedToken() = %q, %v", token, err)
+	}
+}
+
+func TestAgentGitHubTokensRejectsInvalidWorkflowBeforeNetwork(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { requests++ }))
+	defer server.Close()
+	provider, err := NewAgentGitHubTokens(AgentGitHubTokenConfig{Endpoint: server.URL, JobID: testCacheJobID, JobToken: "job-secret"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, workflow := range []string{"", "../ci.yml", "nested/ci.yml", ".ci.yml", "ci.json"} {
+		if _, err := provider.WorkflowToken(context.Background(), "buildkite/buildkite-gha", workflow, map[string]string{"contents": "read"}); err == nil {
+			t.Errorf("WorkflowToken(%q) succeeded", workflow)
+		}
+	}
+	if requests != 0 {
+		t.Fatalf("network requests = %d, want 0", requests)
 	}
 }
 
@@ -84,7 +137,7 @@ func TestAgentGitHubTokensRejectsUnsafeConfigurationAndRepository(t *testing.T) 
 		t.Fatal(err)
 	}
 	for _, repository := range []string{"", "other", "../other/repo", "owner/..", "owner/repo/extra", "owner/repo?permission=write"} {
-		if _, err := provider.WorkflowToken(context.Background(), repository, map[string]string{"contents": "read"}); err == nil {
+		if _, err := provider.WorkflowToken(context.Background(), repository, "ci.yml", map[string]string{"contents": "read"}); err == nil {
 			t.Fatalf("WorkflowToken(%q) succeeded", repository)
 		}
 	}
@@ -100,6 +153,7 @@ func TestAgentGitHubTokensRejectsRedirectsAndUntrustedResponses(t *testing.T) {
 		want       string
 	}{
 		{"rejected", http.StatusBadRequest, secret, "", "rejected"},
+		{"unauthorized", http.StatusUnauthorized, secret, "", "denied"},
 		{"denied", http.StatusForbidden, secret, "", "denied"},
 		{"disabled", http.StatusNotFound, secret, "", "not enabled"},
 		{"rate limited", http.StatusServiceUnavailable, secret, "60", "retry after 60 seconds"},
@@ -125,7 +179,7 @@ func TestAgentGitHubTokensRejectsRedirectsAndUntrustedResponses(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, err = provider.WorkflowToken(context.Background(), "buildkite/buildkite-gha", map[string]string{"contents": "read"})
+			_, err = provider.WorkflowToken(context.Background(), "buildkite/buildkite-gha", "ci.yml", map[string]string{"contents": "read"})
 			if err == nil || !strings.Contains(err.Error(), test.want) || strings.Contains(err.Error(), secret) {
 				t.Fatalf("WorkflowToken() error = %v, want %q without response data", err, test.want)
 			}
@@ -146,7 +200,7 @@ func TestAgentGitHubTokensRejectsRedirectsAndUntrustedResponses(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := provider.WorkflowToken(context.Background(), "buildkite/buildkite-gha", map[string]string{"contents": "read"}); err == nil || !strings.Contains(err.Error(), "HTTP 307") || redirected {
+	if _, err := provider.WorkflowToken(context.Background(), "buildkite/buildkite-gha", "ci.yml", map[string]string{"contents": "read"}); err == nil || !strings.Contains(err.Error(), "HTTP 307") || redirected {
 		t.Fatalf("redirect WorkflowToken() error/redirected = %v / %v", err, redirected)
 	}
 }
@@ -158,7 +212,7 @@ func TestAgentGitHubTokensHonorsCancellation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := provider.WorkflowToken(ctx, "buildkite/buildkite-gha", map[string]string{"contents": "read"}); !errors.Is(err, context.Canceled) {
+	if _, err := provider.WorkflowToken(ctx, "buildkite/buildkite-gha", "ci.yml", map[string]string{"contents": "read"}); !errors.Is(err, context.Canceled) {
 		t.Fatalf("WorkflowToken() error = %v, want cancellation", err)
 	}
 }
@@ -177,7 +231,7 @@ func TestAgentGitHubTokensAuthenticateUnrelatedPublicRepository(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	token, err := provider.WorkflowToken(ctx, "buildkite/buildkite-gha", map[string]string{"contents": "read"})
+	token, err := provider.ScopedToken(ctx, "buildkite/buildkite-gha", map[string]string{"contents": "read"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -283,7 +283,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		if secrets == nil {
 			secrets = map[string]string{}
 		}
-		secrets["GITHUB_TOKEN"], err = r.resolveWorkflowToken(runCtx, processor, job.Event.Repository, job.GitHubToken.Permissions)
+		secrets["GITHUB_TOKEN"], err = r.resolveWorkflowToken(runCtx, processor, job.Event.Repository, job.Workflow.Path, job.GitHubToken.Permissions)
 		if err != nil {
 			return jobResult, err
 		}
@@ -763,11 +763,15 @@ func (r Runner) resolveSecrets(ctx context.Context, processor *commandProcessor,
 	return values, nil
 }
 
-func (r Runner) resolveWorkflowToken(ctx context.Context, processor *commandProcessor, repository string, permissions map[string]string) (string, error) {
+func (r Runner) resolveWorkflowToken(ctx context.Context, processor *commandProcessor, repository, workflowPath string, permissions map[string]string) (string, error) {
 	if r.WorkflowToken == nil {
 		return "", fmt.Errorf("GitHub workflow token provider is not configured")
 	}
-	token, err := r.WorkflowToken.WorkflowToken(ctx, repository, permissions)
+	workflow, err := plan.GitHubWorkflowPolicyFilename(workflowPath)
+	if err != nil {
+		return "", err
+	}
+	token, err := r.WorkflowToken.WorkflowToken(ctx, repository, workflow, permissions)
 	if err != nil {
 		return "", err
 	}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -51,13 +51,15 @@ func (r *testRedactor) AddRedaction(_ context.Context, value string) error {
 type testWorkflowTokenProvider struct {
 	token       string
 	repository  string
+	workflow    string
 	permissions map[string]string
 	calls       int
 }
 
-func (p *testWorkflowTokenProvider) WorkflowToken(_ context.Context, repository string, permissions map[string]string) (string, error) {
+func (p *testWorkflowTokenProvider) WorkflowToken(_ context.Context, repository, workflow string, permissions map[string]string) (string, error) {
 	p.calls++
 	p.repository = repository
+	p.workflow = workflow
 	p.permissions = maps.Clone(permissions)
 	return p.token, nil
 }
@@ -2139,14 +2141,30 @@ func TestRunJobMintsAndRedactsScopedGitHubWorkflowToken(t *testing.T) {
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
-	if provider.calls != 1 || provider.repository != job.Event.Repository || !reflect.DeepEqual(provider.permissions, job.GitHubToken.Permissions) {
-		t.Fatalf("token request = calls %d, repository %q, permissions %#v", provider.calls, provider.repository, provider.permissions)
+	if provider.calls != 1 || provider.repository != job.Event.Repository || provider.workflow != "test.yml" || !reflect.DeepEqual(provider.permissions, job.GitHubToken.Permissions) {
+		t.Fatalf("token request = calls %d, repository %q, workflow %q, permissions %#v", provider.calls, provider.repository, provider.workflow, provider.permissions)
 	}
 	if !reflect.DeepEqual(redactor.values, []string{token}) {
 		t.Fatalf("redacted values = %#v", redactor.values)
 	}
 	if strings.Contains(logs.String(), token) || strings.Contains(fmt.Sprintf("%#v", result), token) || result.Env["GH_TOKEN"] != "***" || !strings.Contains(logs.String(), "***") {
 		t.Fatalf("workflow token leaked: result = %#v, logs = %q", result, logs.String())
+	}
+}
+
+func TestRunJobRejectsNestedWorkflowTokenPathBeforeMinting(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/nested/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: workflow token\n")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "run", Kind: "run", Command: "true"}})
+	job.Schema = plan.SchemaV6
+	job.Event.Repository = "buildkite/buildkite-gha"
+	job.RequiredCapabilities = []string{"provider-token-write"}
+	job.GitHubToken = &plan.GitHubToken{Permissions: map[string]string{"contents": "read"}}
+	provider := &testWorkflowTokenProvider{token: "must-not-be-minted"}
+	_, err := (Runner{WorkflowToken: provider, Redactor: &testRedactor{}}).RunJob(context.Background(), job, workspace)
+	if err == nil || !strings.Contains(err.Error(), "simple .yml or .yaml filename") || provider.calls != 0 {
+		t.Fatalf("RunJob() error/calls = %v / %d", err, provider.calls)
 	}
 }
 


### PR DESCRIPTION
## Why

GitHub Actions workflows can depend on `github.token` or `secrets.GITHUB_TOKEN`. `buildkite-gha` needs a secure way to provide that token without using ambient credentials or broadening access beyond the compiled workflow policy.

## What

- Mint short-lived, repository-scoped GitHub tokens for eligible workflow jobs.
- Keep action source authentication on the existing scoped-token path.
- Document the supported permission and workflow constraints.

## How

The compiler records verified policy evidence from the workflow path and explicit top-level permissions. Hosted admission rejects workflows with missing evidence, job-level permission overrides, reusable workflow jobs, invalid filenames, or unsupported permissions. At runtime, the CLI sends the repository, workflow filename, and effective permissions to the workflow-token endpoint, then registers the returned token for log redaction.