### PR TITLE
Run the full Go test suite on macOS arm64

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -104,7 +104,7 @@ steps:
           version: "2026.5.12"
     command: "mise run --jobs 1 check"
 
-  - label: ":go: macOS arm64"
+  - label: ":go: macOS arm64 build and portable tests"
     key: "macos-arm64"
     timeout_in_minutes: 20
     agents:
@@ -117,7 +117,17 @@ steps:
       test "$$(mise exec -- go env GOOS)" = "darwin"
       test "$$(mise exec -- go env GOARCH)" = "arm64"
       mise exec -- go build ./...
-      mise exec -- go test -count=1 ./...
+      mise exec -- go test -count=1 \
+        ./internal/action/integration \
+        ./internal/action/source \
+        ./internal/buildkite \
+        ./internal/compatibility \
+        ./internal/expression \
+        ./internal/plan \
+        ./internal/transport \
+        ./internal/workflow
+      mise exec -- go test -count=1 ./internal/runtime \
+        -run '^(TestCollectUploadFiles|TestUploadArtifact)'
 
   - label: ":github: OSS workflow compatibility"
     key: "oss-workflow-corpus"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -104,6 +104,21 @@ steps:
           version: "2026.5.12"
     command: "mise run --jobs 1 check"
 
+  - label: ":go: macOS arm64"
+    key: "macos-arm64"
+    timeout_in_minutes: 20
+    agents:
+      queue: "mac-small"
+    plugins:
+      - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
+          version: "2026.5.12"
+    command: |
+      set -euo pipefail
+      test "$$(mise exec -- go env GOOS)" = "darwin"
+      test "$$(mise exec -- go env GOARCH)" = "arm64"
+      mise exec -- go build ./...
+      mise exec -- go test -count=1 ./...
+
   - label: ":github: OSS workflow compatibility"
     key: "oss-workflow-corpus"
     soft_fail: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -104,7 +104,7 @@ steps:
           version: "2026.5.12"
     command: "mise run --jobs 1 check"
 
-  - label: ":go: macOS arm64 build and portable tests"
+  - label: ":go: macOS arm64 build and tests"
     key: "macos-arm64"
     timeout_in_minutes: 20
     agents:
@@ -117,17 +117,7 @@ steps:
       test "$$(mise exec -- go env GOOS)" = "darwin"
       test "$$(mise exec -- go env GOARCH)" = "arm64"
       mise exec -- go build ./...
-      mise exec -- go test -count=1 \
-        ./internal/action/integration \
-        ./internal/action/source \
-        ./internal/buildkite \
-        ./internal/compatibility \
-        ./internal/expression \
-        ./internal/plan \
-        ./internal/transport \
-        ./internal/workflow
-      mise exec -- go test -count=1 ./internal/runtime \
-        -run '^(TestCollectUploadFiles|TestUploadArtifact)'
+      mise exec -- go test -count=1 ./...
 
   - label: ":github: OSS workflow compatibility"
     key: "oss-workflow-corpus"

--- a/internal/action/metadata/metadata_test.go
+++ b/internal/action/metadata/metadata_test.go
@@ -277,7 +277,7 @@ runs:
 }
 
 func TestValidateEntrypointsRejectsNestedGitMetadata(t *testing.T) {
-	root := t.TempDir()
+	root := canonicalTempDir(t)
 	if err := os.Mkdir(filepath.Join(root, ".git"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -334,7 +334,7 @@ func TestValidateEntrypointsRejectsNestedGitMetadata(t *testing.T) {
 }
 
 func TestValidateEntrypointsAllowsRemoteActionRepositoryBuildOutput(t *testing.T) {
-	repository := t.TempDir()
+	repository := canonicalTempDir(t)
 	action := filepath.Join(repository, "setup-gradle")
 	entrypoint := filepath.Join(repository, "dist", "setup-gradle", "main", "index.js")
 	if err := os.MkdirAll(action, 0o755); err != nil {
@@ -364,4 +364,13 @@ func writeAction(t *testing.T, root, name, contents string) {
 	if err := os.WriteFile(filepath.Join(root, name), []byte(contents), 0o600); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func canonicalTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dir
 }

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -744,7 +744,17 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 		`test "$$(mise exec -- go env GOOS)" = "darwin"`,
 		`test "$$(mise exec -- go env GOARCH)" = "arm64"`,
 		`mise exec -- go build ./...`,
-		`mise exec -- go test -count=1 ./...`,
+		`mise exec -- go test -count=1 \`,
+		`./internal/action/integration \`,
+		`./internal/action/source \`,
+		`./internal/buildkite \`,
+		`./internal/compatibility \`,
+		`./internal/expression \`,
+		`./internal/plan \`,
+		`./internal/transport \`,
+		`./internal/workflow`,
+		`mise exec -- go test -count=1 ./internal/runtime \`,
+		`-run '^(TestCollectUploadFiles|TestUploadArtifact)'`,
 	} {
 		if !strings.Contains(macOS.command, required) {
 			t.Fatalf("macOS arm64 checks lack %q:\n%s", required, macOS.command)

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -622,7 +622,7 @@ func TestEmitRejectsInvalidGraphsAndIdentifiers(t *testing.T) {
 	}
 }
 
-func TestCheckedInPipelinesTargetHostedQueue(t *testing.T) {
+func TestCheckedInPipelinesTargetApprovedQueues(t *testing.T) {
 	root := filepath.Join("..", "..", ".buildkite")
 	count := 0
 	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
@@ -641,6 +641,7 @@ func TestCheckedInPipelinesTargetHostedQueue(t *testing.T) {
 				Queue string `yaml:"queue"`
 			} `yaml:"agents"`
 			Steps []struct {
+				Key    string `yaml:"key"`
 				Agents struct {
 					Queue string `yaml:"queue"`
 				} `yaml:"agents"`
@@ -657,6 +658,12 @@ func TestCheckedInPipelinesTargetHostedQueue(t *testing.T) {
 			t.Errorf("%s has no steps", path)
 		}
 		for index, step := range document.Steps {
+			if path == filepath.Join(root, "pipeline.yml") && step.Key == "macos-arm64" {
+				if step.Agents.Queue != "mac-small" {
+					t.Errorf("%s step %d queue = %q, want mac-small", path, index, step.Agents.Queue)
+				}
+				continue
+			}
 			if step.Agents.Queue != "" && step.Agents.Queue != "hosted" {
 				t.Errorf("%s step %d overrides queue with %q, want hosted", path, index, step.Agents.Queue)
 			}
@@ -683,10 +690,14 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 			Queue string `yaml:"queue"`
 		} `yaml:"agents"`
 		Steps []struct {
-			Key     string            `yaml:"key"`
-			Command string            `yaml:"command"`
-			If      string            `yaml:"if"`
-			Env     map[string]string `yaml:"env"`
+			Key              string            `yaml:"key"`
+			Command          string            `yaml:"command"`
+			If               string            `yaml:"if"`
+			Env              map[string]string `yaml:"env"`
+			TimeoutInMinutes int               `yaml:"timeout_in_minutes"`
+			Agents           struct {
+				Queue string `yaml:"queue"`
+			} `yaml:"agents"`
 		} `yaml:"steps"`
 	}
 	if err := yaml.Unmarshal(source, &document); err != nil {
@@ -699,9 +710,11 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 		t.Fatalf("default pipeline queue = %q, want hosted", document.Agents.Queue)
 	}
 	steps := make(map[string]struct {
-		command     string
-		condition   string
-		environment map[string]string
+		command          string
+		condition        string
+		environment      map[string]string
+		timeoutInMinutes int
+		queue            string
 	}, len(document.Steps))
 	for _, step := range document.Steps {
 		if step.Key != "" {
@@ -710,16 +723,32 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 			}
 		}
 		steps[step.Key] = struct {
-			command     string
-			condition   string
-			environment map[string]string
-		}{command: step.Command, condition: step.If, environment: step.Env}
+			command          string
+			condition        string
+			environment      map[string]string
+			timeoutInMinutes int
+			queue            string
+		}{command: step.Command, condition: step.If, environment: step.Env, timeoutInMinutes: step.TimeoutInMinutes, queue: step.Agents.Queue}
 	}
 	if got := steps["checks"]; got.command != "mise run --jobs 1 check" || got.condition != "" {
 		t.Fatalf("repository checks = %#v", got)
 	}
 	if got := steps["checks"].environment["BUILDKITE_GHA_LIVE_REQUIRED"]; got != "1" {
 		t.Fatalf("repository checks BUILDKITE_GHA_LIVE_REQUIRED = %q, want required live prerequisites", got)
+	}
+	macOS := steps["macos-arm64"]
+	if macOS.condition != "" || macOS.queue != "mac-small" || macOS.timeoutInMinutes != 20 {
+		t.Fatalf("macOS arm64 checks = %#v", macOS)
+	}
+	for _, required := range []string{
+		`test "$$(mise exec -- go env GOOS)" = "darwin"`,
+		`test "$$(mise exec -- go env GOARCH)" = "arm64"`,
+		`mise exec -- go build ./...`,
+		`mise exec -- go test -count=1 ./...`,
+	} {
+		if !strings.Contains(macOS.command, required) {
+			t.Fatalf("macOS arm64 checks lack %q:\n%s", required, macOS.command)
+		}
 	}
 	pluginDemo := steps["plugin-demo-loader"]
 	if pluginDemo.condition != `build.env("DEMO_SUITE") == "plugin"` {

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -744,21 +744,14 @@ func TestDefaultPipelineRunsRepositoryChecks(t *testing.T) {
 		`test "$$(mise exec -- go env GOOS)" = "darwin"`,
 		`test "$$(mise exec -- go env GOARCH)" = "arm64"`,
 		`mise exec -- go build ./...`,
-		`mise exec -- go test -count=1 \`,
-		`./internal/action/integration \`,
-		`./internal/action/source \`,
-		`./internal/buildkite \`,
-		`./internal/compatibility \`,
-		`./internal/expression \`,
-		`./internal/plan \`,
-		`./internal/transport \`,
-		`./internal/workflow`,
-		`mise exec -- go test -count=1 ./internal/runtime \`,
-		`-run '^(TestCollectUploadFiles|TestUploadArtifact)'`,
+		`mise exec -- go test -count=1 ./...`,
 	} {
 		if !strings.Contains(macOS.command, required) {
 			t.Fatalf("macOS arm64 checks lack %q:\n%s", required, macOS.command)
 		}
+	}
+	if strings.Contains(macOS.command, "-run") {
+		t.Fatalf("macOS arm64 checks filter tests:\n%s", macOS.command)
 	}
 	pluginDemo := steps["plugin-demo-loader"]
 	if pluginDemo.condition != `build.env("DEMO_SUITE") == "plugin"` {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -3137,7 +3137,7 @@ func TestRunUploadExplainsWhenNoWorkflowsApply(t *testing.T) {
 
 func writeUploadWorkflowRepository(t *testing.T, sources map[string]string) string {
 	t.Helper()
-	repository := t.TempDir()
+	repository := canonicalTempDir(t)
 	workflowDirectory := filepath.Join(repository, ".github", "workflows")
 	if err := os.MkdirAll(workflowDirectory, 0o755); err != nil {
 		t.Fatal(err)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -821,6 +821,9 @@ jobs:
 		{name: "upload before event metadata", args: []string{"upload", workflow}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			if test.args[0] == "upload" {
+				requireImporterHost(t)
+			}
 			var stdout, stderr bytes.Buffer
 			runner := &cliCaptureRunner{}
 			if code := run(test.args, &stdout, &stderr, "dev", runner); code != 1 {
@@ -858,6 +861,7 @@ jobs:
 		t.Fatal(err)
 	}
 	t.Run("invalid boundary before event metadata", func(t *testing.T) {
+		requireImporterHost(t)
 		var stdout, stderr bytes.Buffer
 		runner := &cliCaptureRunner{}
 		if code := run([]string{"upload", invalidWorkflow}, &stdout, &stderr, "dev", runner); code != 1 {
@@ -900,6 +904,7 @@ jobs:
 		t.Fatal(err)
 	}
 	t.Run("exact boundary survives an earlier graph failure", func(t *testing.T) {
+		requireImporterHost(t)
 		var stdout, stderr bytes.Buffer
 		runner := &cliCaptureRunner{}
 		if code := run([]string{"upload", graphFailureWorkflow}, &stdout, &stderr, "dev", runner); code != 1 {
@@ -953,6 +958,7 @@ jobs:
 		t.Fatal(err)
 	}
 	t.Run("reusable boundary discovery does not depend on fail-fast order", func(t *testing.T) {
+		requireImporterHost(t)
 		var stdout, stderr bytes.Buffer
 		runner := &cliCaptureRunner{}
 		if code := run([]string{"upload", reusableBoundaryWorkflow}, &stdout, &stderr, "dev", runner); code != 1 {
@@ -994,6 +1000,7 @@ jobs:
 		t.Fatal(err)
 	}
 	t.Run("shared boundary is rescanned when reached at a shallower depth", func(t *testing.T) {
+		requireImporterHost(t)
 		var stdout, stderr bytes.Buffer
 		runner := &cliCaptureRunner{}
 		if code := run([]string{"upload", sharedBoundaryWorkflow}, &stdout, &stderr, "dev", runner); code != 1 {
@@ -1028,6 +1035,7 @@ jobs:
 		}
 	}
 	t.Run("depth-limited reusable discovery fails closed before event metadata", func(t *testing.T) {
+		requireImporterHost(t)
 		var stdout, stderr bytes.Buffer
 		runner := &cliCaptureRunner{}
 		if code := run([]string{"upload", depthBoundaryWorkflow}, &stdout, &stderr, "dev", runner); code != 1 {
@@ -1071,6 +1079,7 @@ jobs:
 		t.Fatal(err)
 	}
 	t.Run("incomplete reusable discovery fails closed before event metadata", func(t *testing.T) {
+		requireImporterHost(t)
 		var stdout, stderr bytes.Buffer
 		runner := &cliCaptureRunner{}
 		if code := run([]string{"upload", malformedBoundaryWorkflow}, &stdout, &stderr, "dev", runner); code != 1 {
@@ -2447,6 +2456,7 @@ func TestExpandWorkflowPatternStarSelectsTopLevelYAMLWorkflows(t *testing.T) {
 }
 
 func TestRunUploadRejectsTrackedSymlinksMatchedByGlob(t *testing.T) {
+	requireImporterHost(t)
 	workflowSource := "on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"
 	for _, test := range []struct {
 		name   string
@@ -2584,6 +2594,7 @@ func TestExpandWorkflowOperandsCanonicalizesExplicitTrackedPaths(t *testing.T) {
 }
 
 func TestRunUploadExplicitPathsAreAtomicAndOrderIndependent(t *testing.T) {
+	requireImporterHost(t)
 	workflow := func(name string) string {
 		return "name: " + name + "\non: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"
 	}
@@ -2633,6 +2644,7 @@ func TestRunUploadExplicitPathsAreAtomicAndOrderIndependent(t *testing.T) {
 }
 
 func TestRunUploadRejectsMultipleOperandGlobBeforeBuildkite(t *testing.T) {
+	requireImporterHost(t)
 	workflowSource := "on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"
 	repository := writeUploadWorkflowRepository(t, map[string]string{"a.yml": workflowSource})
 	t.Chdir(repository)
@@ -2649,6 +2661,7 @@ func TestRunUploadRejectsMultipleOperandGlobBeforeBuildkite(t *testing.T) {
 }
 
 func TestRunUploadAggregatesGlobAtomicallyWithNamespacedJobs(t *testing.T) {
+	requireImporterHost(t)
 	pattern := filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "*e*.yml")
 	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
 	inputs, err := expandWorkflowPattern(pattern)
@@ -2738,6 +2751,7 @@ func TestRunUploadAggregatesGlobAtomicallyWithNamespacedJobs(t *testing.T) {
 }
 
 func TestRunUploadNamesAggregateGitHubChecksFromWorkflowLabels(t *testing.T) {
+	requireImporterHost(t)
 	repository := t.TempDir()
 	workflowDirectory := filepath.Join(repository, ".github", "workflows")
 	if err := os.MkdirAll(workflowDirectory, 0o755); err != nil {
@@ -2830,6 +2844,7 @@ func TestRunUploadNamesAggregateGitHubChecksFromWorkflowLabels(t *testing.T) {
 }
 
 func TestRunUploadNamesGitHubCheckForActiveEvent(t *testing.T) {
+	requireImporterHost(t)
 	workflowPath := filepath.Join(t.TempDir(), "multi-trigger.yml")
 	workflowSource := "name: Active event\non:\n  push:\n  pull_request:\n  workflow_dispatch:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo ok\n"
 	if err := os.WriteFile(workflowPath, []byte(workflowSource), 0o600); err != nil {
@@ -2896,6 +2911,7 @@ func TestRunUploadNamesGitHubCheckForActiveEvent(t *testing.T) {
 }
 
 func TestRunUploadIsolatesExplicitEffectiveEventsBeforeCompilation(t *testing.T) {
+	requireImporterHost(t)
 	repository := writeUploadWorkflowRepository(t, map[string]string{
 		"dispatch.yml":     "name: Dispatch\non: workflow_dispatch\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
 		"pull-request.yml": "name: Pull request\non: pull_request\njobs:\n  test:\n    runs-on: ${{ github.event.pull_request.runner }}\n    steps: [{run: true}]\n",
@@ -2985,6 +3001,7 @@ func TestRunUploadIsolatesExplicitEffectiveEventsBeforeCompilation(t *testing.T)
 }
 
 func TestRunUploadAlignsBuildkiteFallbackWithEffectiveEvent(t *testing.T) {
+	requireImporterHost(t)
 	repository := writeUploadWorkflowRepository(t, map[string]string{
 		"dispatch.yml":     "name: Dispatch\non: workflow_dispatch\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
 		"pull-request.yml": "name: Pull request\non:\n  pull_request:\n    branches: [main]\n    types: [synchronize]\njobs:\n  test:\n    runs-on: ${{ github.event.pull_request.base.ref == 'main' && 'ubuntu-latest' || 'ubuntu-22.04' }}\n    steps: [{run: true}]\n",
@@ -3058,6 +3075,7 @@ func TestRunUploadAlignsBuildkiteFallbackWithEffectiveEvent(t *testing.T) {
 }
 
 func TestRunUploadKeepsApplicableCompilationFailuresFatal(t *testing.T) {
+	requireImporterHost(t)
 	workflowPath := filepath.Join(t.TempDir(), "invalid-push.yml")
 	if err := os.WriteFile(workflowPath, []byte("on: push\njobs:\n  test:\n    runs-on: ${{ github.event.missing_runner }}\n    steps: [{run: true}]\n"), 0o600); err != nil {
 		t.Fatal(err)
@@ -3081,6 +3099,7 @@ func TestRunUploadKeepsApplicableCompilationFailuresFatal(t *testing.T) {
 }
 
 func TestRunUploadExplainsWhenNoWorkflowsApply(t *testing.T) {
+	requireImporterHost(t)
 	workflowPath := filepath.Join(t.TempDir(), "pull-request.yml")
 	if err := os.WriteFile(workflowPath, []byte("on: pull_request\njobs:\n  test:\n    runs-on: ${{ github.event.pull_request.runner }}\n    steps: [{run: true}]\n"), 0o600); err != nil {
 		t.Fatal(err)
@@ -3161,6 +3180,7 @@ func writeUploadEvent(t *testing.T, directory, event, ref string, payload map[st
 }
 
 func TestRunUploadRejectsUnsupportedTriggerBeforeAnyUpload(t *testing.T) {
+	requireImporterHost(t)
 	workflowPath := filepath.Join(t.TempDir(), "issues.yml")
 	if err := os.WriteFile(workflowPath, []byte("on: issues\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
 		t.Fatal(err)
@@ -3182,6 +3202,7 @@ func TestRunUploadRejectsUnsupportedTriggerBeforeAnyUpload(t *testing.T) {
 }
 
 func TestRunUploadRejectsIncompletePullRequestSnapshots(t *testing.T) {
+	requireImporterHost(t)
 	for _, test := range []struct {
 		name, workflow, want string
 		payload              map[string]any
@@ -3218,6 +3239,7 @@ func TestRunUploadRejectsIncompletePullRequestSnapshots(t *testing.T) {
 }
 
 func TestRunRejectsUnclassifiablePushSnapshot(t *testing.T) {
+	requireImporterHost(t)
 	workflow := "on:\n  push:\n    branches: [main]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"
 	repository := writeUploadWorkflowRepository(t, map[string]string{"push.yml": workflow})
 	eventPath := writeUploadEvent(t, repository, "push", "refs/pull/42/head", map[string]any{})
@@ -3250,6 +3272,7 @@ func TestRunRejectsUnclassifiablePushSnapshot(t *testing.T) {
 }
 
 func TestRunUploadSkipsReusableOnlyMatchButCompilesItThroughCaller(t *testing.T) {
+	requireImporterHost(t)
 	repository := t.TempDir()
 	workflowDirectory := filepath.Join(repository, ".github", "workflows")
 	if err := os.MkdirAll(workflowDirectory, 0o755); err != nil {
@@ -3342,6 +3365,7 @@ func TestRunUploadSkipsReusableOnlyMatchButCompilesItThroughCaller(t *testing.T)
 }
 
 func TestRunUploadRejectsAllReusableOnlyMatches(t *testing.T) {
+	requireImporterHost(t)
 	workflowPath := filepath.Join(t.TempDir(), "reusable.yml")
 	source := "on: workflow_call\njobs:\n  shared:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"
 	if err := os.WriteFile(workflowPath, []byte(source), 0o600); err != nil {
@@ -3360,6 +3384,7 @@ func TestRunUploadRejectsAllReusableOnlyMatches(t *testing.T) {
 }
 
 func TestRunUploadRejectsAllReusableExplicitPaths(t *testing.T) {
+	requireImporterHost(t)
 	reusable := "on: workflow_call\njobs:\n  shared:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"
 	repository := writeUploadWorkflowRepository(t, map[string]string{
 		"first.yml":  reusable,

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -49,6 +49,22 @@ const (
 	stageResolution      = string(compiler.StageResolution)
 )
 
+func requireImporterHost(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS != "linux" || runtime.GOARCH != "amd64" {
+		t.Skip("the importer requires linux/amd64")
+	}
+}
+
+func canonicalTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
 func TestRunHelpAndVersion(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -116,6 +132,7 @@ func TestPluginIsHiddenAndZeroArgument(t *testing.T) {
 }
 
 func TestPluginRequiresConfigurationWithoutSideEffects(t *testing.T) {
+	requireImporterHost(t)
 	t.Setenv(pluginConfigurationEnvironment, "")
 	t.Setenv("BUILDKITE_PLUGIN_GITHUB_ACTIONS_WORKFLOW", "legacy.yml")
 	runner := &cliCaptureRunner{}
@@ -252,6 +269,7 @@ func TestUploadRejectsDarwinImporterBeforeProcessing(t *testing.T) {
 }
 
 func TestPluginUsesJSONConfigurationAndOnlyRequiredRuntime(t *testing.T) {
+	requireImporterHost(t)
 	workflowPath := filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "shell.yml")
 	executable, err := os.Executable()
 	if err != nil {
@@ -302,6 +320,7 @@ func TestPluginUsesJSONConfigurationAndOnlyRequiredRuntime(t *testing.T) {
 }
 
 func TestPluginPublishesMixedRuntimeDistributions(t *testing.T) {
+	requireImporterHost(t)
 	const fullCommit = "0123456789abcdef0123456789abcdef01234567"
 	root := t.TempDir()
 	workflowPath := filepath.Join(root, "mixed.yml")
@@ -446,7 +465,7 @@ func TestPluginAcquisitionIsLazyAndBindsVerifiedDarwinContents(t *testing.T) {
 		}
 	}))
 	defer server.Close()
-	cache := filepath.Join(t.TempDir(), pluginDarwinAsset)
+	cache := filepath.Join(canonicalTempDir(t), pluginDarwinAsset)
 	distribution, err := acquirePluginDarwin(context.Background(), "1.2.3", server.Client(), server.URL, cache)
 	if err != nil {
 		t.Fatal(err)
@@ -1924,6 +1943,7 @@ jobs:
 	})
 
 	t.Run("upload", func(t *testing.T) {
+		requireImporterHost(t)
 		t.Setenv("BUILDKITE", "true")
 		t.Setenv("BUILDKITE_STEP_KEY", "concurrency-importer")
 		runner := &cliCaptureRunner{}
@@ -1997,6 +2017,7 @@ jobs:
 	})
 
 	t.Run("upload before Buildkite calls", func(t *testing.T) {
+		requireImporterHost(t)
 		t.Setenv("BUILDKITE", "true")
 		t.Setenv("BUILDKITE_STEP_KEY", "condition-importer")
 		runner := &cliCaptureRunner{}
@@ -2012,6 +2033,7 @@ jobs:
 }
 
 func TestUploadAcceptsConditionalActionInputDefault(t *testing.T) {
+	requireImporterHost(t)
 	root := t.TempDir()
 	workflowPath := filepath.Join(root, ".github", "workflows", "action.yml")
 	actionRoot := filepath.Join(root, ".github", "actions", "complex-default")
@@ -2122,6 +2144,7 @@ func TestValidateHostedTokenlessProfileRejectsProtectedCapabilityAfterCompile(t 
 }
 
 func TestRunUploadCompilesArtifactsAndUploadsSelfContainedPipeline(t *testing.T) {
+	requireImporterHost(t)
 	workflowPath := filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "shell.yml")
 	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
 	t.Setenv("BUILDKITE", "true")
@@ -2206,6 +2229,7 @@ func TestRunUploadCompilesArtifactsAndUploadsSelfContainedPipeline(t *testing.T)
 }
 
 func TestRunUploadPublishesMixedRuntimeDistributions(t *testing.T) {
+	requireImporterHost(t)
 	root := t.TempDir()
 	workflowPath := filepath.Join(root, "mixed.yml")
 	workflow := []byte("on: push\njobs:\n  linux:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo linux\n  macos:\n    needs: linux\n    runs-on: macos-15\n    steps:\n      - run: echo macos\n")
@@ -3526,6 +3550,7 @@ func TestJobScopedActionSourceAuthenticationIgnoresAmbientGitHubTokens(t *testin
 }
 
 func TestRunUploadUsesExplicitTargetQueue(t *testing.T) {
+	requireImporterHost(t)
 	workflowPath := filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "shell.yml")
 	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
 	t.Setenv("BUILDKITE", "true")
@@ -3581,6 +3606,7 @@ func TestRunUploadUsesExplicitTargetQueue(t *testing.T) {
 }
 
 func TestRunUploadUsesExplicitRuntimeImage(t *testing.T) {
+	requireImporterHost(t)
 	workflowPath := filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "shell.yml")
 	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
 	image := "buildkite.namespace-images.com/agent-base@sha256:" + strings.Repeat("0", 64)
@@ -3669,6 +3695,7 @@ jobs:
 }
 
 func TestRunUploadRejectsLegacyTargetingEnvironment(t *testing.T) {
+	requireImporterHost(t)
 	workflowPath := filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "shell.yml")
 	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
 	for _, environment := range []string{legacyTargetQueueEnvironment, legacyRuntimeImageEnvironment} {
@@ -3689,6 +3716,7 @@ func TestRunUploadRejectsLegacyTargetingEnvironment(t *testing.T) {
 }
 
 func TestRunUploadUsesWorkflowGroupInsteadOfContainingGroup(t *testing.T) {
+	requireImporterHost(t)
 	workflowPath := filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "shell.yml")
 	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
 	t.Setenv("BUILDKITE", "true")
@@ -3719,6 +3747,7 @@ func TestRunUploadUsesWorkflowGroupInsteadOfContainingGroup(t *testing.T) {
 }
 
 func TestRunUploadDerivesUnattestedBuildkiteEvent(t *testing.T) {
+	requireImporterHost(t)
 	workflowPath := filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "shell.yml")
 	sha := "0123456789abcdef0123456789abcdef01234567"
 	t.Setenv("BUILDKITE", "true")
@@ -3762,6 +3791,7 @@ func TestRunUploadDerivesUnattestedBuildkiteEvent(t *testing.T) {
 }
 
 func TestRunUploadUsesWebhookPayloadWithoutRetainingIt(t *testing.T) {
+	requireImporterHost(t)
 	workflowPath := filepath.Join(t.TempDir(), "webhook.yml")
 	if err := os.WriteFile(workflowPath, []byte("on: pull_request\njobs:\n  test:\n    runs-on: ubuntu-${{ github.event.marker }}\n    steps:\n      - run: echo selected\n"), 0o600); err != nil {
 		t.Fatal(err)
@@ -3816,6 +3846,7 @@ func TestRunUploadUsesWebhookPayloadWithoutRetainingIt(t *testing.T) {
 }
 
 func TestRunUploadRejectsInvalidWebhookMetadata(t *testing.T) {
+	requireImporterHost(t)
 	workflowPath := filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "shell.yml")
 	t.Setenv("BUILDKITE", "true")
 	t.Setenv("BUILDKITE_STEP_KEY", "webhook-importer")
@@ -3850,6 +3881,7 @@ func TestRunUploadRejectsInvalidWebhookMetadata(t *testing.T) {
 }
 
 func TestRunUploadCompilesConcurrentSmokePipeline(t *testing.T) {
+	requireImporterHost(t)
 	workflowPath := filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "concurrent.yml")
 	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
 	t.Setenv("BUILDKITE", "true")
@@ -3896,6 +3928,7 @@ func TestRunUploadCompilesConcurrentSmokePipeline(t *testing.T) {
 }
 
 func TestRunUploadJavaScriptActionRequiresRuntimeMiseWithoutTransport(t *testing.T) {
+	requireImporterHost(t)
 	root := t.TempDir()
 	workflowPath := filepath.Join(root, ".github", "workflows", "action.yml")
 	actionRoot := filepath.Join(root, ".github", "actions", "local")
@@ -4006,6 +4039,7 @@ func TestPrepareMiseDataDirFallsBackWhenCacheIsUnavailable(t *testing.T) {
 }
 
 func TestRunUploadAllowsCompilerVerifiedLocalDockerfileAction(t *testing.T) {
+	requireImporterHost(t)
 	root := t.TempDir()
 	workflowPath := filepath.Join(root, ".github", "workflows", "docker.yml")
 	actionRoot := filepath.Join(root, ".github", "actions", "docker")
@@ -4061,7 +4095,7 @@ func writeFakeNode(t *testing.T, root string, major int) string {
 
 func setFakeMise(t *testing.T, version string) string {
 	t.Helper()
-	root := t.TempDir()
+	root := canonicalTempDir(t)
 	mise := filepath.Join(root, "mise")
 	script := "#!/bin/sh\nif [ -n \"${MISE_TEST_POISON:-}\" ]; then printf 'poisoned\\n'; else printf '" + version + " linux-x64 (test)\\n'; fi\n"
 	if err := os.WriteFile(mise, []byte(script), 0o700); err != nil {
@@ -4104,7 +4138,7 @@ func TestResolveRuntimeMiseAcceptsNewerVersion(t *testing.T) {
 }
 
 func TestResolveRuntimeMiseAcceptsPrefixedVersionOutput(t *testing.T) {
-	root := t.TempDir()
+	root := canonicalTempDir(t)
 	mise := filepath.Join(root, "mise")
 	if err := os.WriteFile(mise, []byte("#!/bin/sh\nprintf 'mise v2026.8.1 linux-x64 (test)\\n'\n"), 0o700); err != nil {
 		t.Fatal(err)
@@ -4269,7 +4303,7 @@ func TestValidateRuntimeMiseRejectsOversizedCacheEntry(t *testing.T) {
 }
 
 func TestManagedMiseCacheIsNotExecutedBeforePrivateCopy(t *testing.T) {
-	root := t.TempDir()
+	root := canonicalTempDir(t)
 	marker := filepath.Join(t.TempDir(), "executed")
 	binary := []byte("#!/bin/sh\nprintf ran > '" + marker + "'\nprintf '" + buildkitepipeline.MinimumMiseVersion + " linux-x64 (test)\\n'\n")
 	digest := sha256.Sum256(binary)
@@ -4519,6 +4553,7 @@ func TestRunJobSkipsActionJobBeforePreparingRuntimeMise(t *testing.T) {
 }
 
 func TestRunUploadFailsClosedBeforePipeline(t *testing.T) {
+	requireImporterHost(t)
 	workflowPath := filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "shell.yml")
 	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
 	t.Setenv("BUILDKITE", "true")
@@ -4892,6 +4927,9 @@ func TestRunUsageErrors(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			if len(test.args) != 0 && test.args[0] == "upload" {
+				requireImporterHost(t)
+			}
 			t.Setenv("BUILDKITE", "")
 			t.Setenv("BUILDKITE_STEP_KEY", "")
 			var stdout, stderr bytes.Buffer
@@ -5568,21 +5606,31 @@ func TestLoadRuntimeDistributionsValidatesPlatformBinaryAndSymlink(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	distributions, err := loadRuntimeDistributions(map[compiler.Platform]string{compiler.PlatformLinuxAMD64: executable})
+	platform, err := compiler.ParsePlatform(runtime.GOOS + "/" + runtime.GOARCH)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := distributions[compiler.PlatformLinuxAMD64].digest; got != cliTestRuntimeDigest() {
+	distributions, err := loadRuntimeDistributions(map[compiler.Platform]string{platform: executable})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := distributions[platform].digest; got != cliTestRuntimeDigest() {
 		t.Fatalf("runtime digest = %q, want %q", got, cliTestRuntimeDigest())
 	}
-	if _, err := loadRuntimeDistributions(map[compiler.Platform]string{compiler.PlatformDarwinARM64: executable}); err == nil || !strings.Contains(err.Error(), "Mach-O") {
-		t.Fatalf("Darwin runtime accepted Linux executable: %v", err)
+	other := compiler.PlatformDarwinARM64
+	wantFormat := "Mach-O"
+	if platform == compiler.PlatformDarwinARM64 {
+		other = compiler.PlatformLinuxAMD64
+		wantFormat = "ELF"
+	}
+	if _, err := loadRuntimeDistributions(map[compiler.Platform]string{other: executable}); err == nil || !strings.Contains(err.Error(), wantFormat) {
+		t.Fatalf("%s runtime accepted %s executable: %v", other, platform, err)
 	}
 	symlink := filepath.Join(t.TempDir(), "runtime")
 	if err := os.Symlink(executable, symlink); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := loadRuntimeDistributions(map[compiler.Platform]string{compiler.PlatformLinuxAMD64: symlink}); err == nil || !strings.Contains(err.Error(), "non-symlink") {
+	if _, err := loadRuntimeDistributions(map[compiler.Platform]string{platform: symlink}); err == nil || !strings.Contains(err.Error(), "non-symlink") {
 		t.Fatalf("runtime symlink error = %v", err)
 	}
 }

--- a/internal/runtime/checkout_test.go
+++ b/internal/runtime/checkout_test.go
@@ -686,7 +686,7 @@ func TestCheckoutRejectsInvalidRepositoryBeforeInspectingWorkspace(t *testing.T)
 }
 
 func TestCheckoutUsesCommandScopedAgentCredentialHelper(t *testing.T) {
-	workspace := t.TempDir()
+	workspace := canonicalTempDir(t)
 	checkoutDirectory := filepath.Join(workspace, "test-catalog")
 	poisonedGlobalConfig := []byte("[url \"https://attacker.invalid/\"]\n\tinsteadOf = https://github.com/\n")
 	if err := os.WriteFile(filepath.Join(workspace, ".no-global-gitconfig"), poisonedGlobalConfig, 0o600); err != nil {

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -1,3 +1,5 @@
+//go:build linux && amd64
+
 package runtime
 
 import (

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -537,6 +537,7 @@ func TestRunDockerFakeLifecycle(t *testing.T) {
 }
 
 func TestRunDockerPreservesExplicitPath(t *testing.T) {
+	requireLinuxAMD64(t)
 	t.Parallel()
 
 	for _, test := range []struct {
@@ -587,6 +588,7 @@ func TestRunDockerPreservesExplicitPath(t *testing.T) {
 }
 
 func TestRunDockerPreservesPathWrittenThroughGitHubEnv(t *testing.T) {
+	requireLinuxAMD64(t)
 	fake := newFakeDocker(t, "success")
 	workspace := t.TempDir()
 	writeFixtureFile(t, workspace, ".github/workflows/test.yml", "name: Docker dynamic PATH test\n")
@@ -608,6 +610,7 @@ func TestRunDockerPreservesPathWrittenThroughGitHubEnv(t *testing.T) {
 }
 
 func TestRunDockerActionEnvironmentUsesInvocationBeforeActionDefaults(t *testing.T) {
+	requireLinuxAMD64(t)
 	fake := newFakeDocker(t, "success")
 	workspace := t.TempDir()
 	writeFixtureFile(t, workspace, ".github/workflows/test.yml", "name: Docker environment precedence test\n")
@@ -760,6 +763,7 @@ func TestRunDockerCancellationCleansOwnedResources(t *testing.T) {
 }
 
 func TestRunJobLegacyDockerPlanUsesFakeBackend(t *testing.T) {
+	requireLinuxAMD64(t)
 	fake := newFakeDocker(t, "success")
 	workspace := fixturePath(t)
 	job := runtimePlan(t, workspace, "smoke/.github/workflows/ci.yml", []plan.Step{{ID: "docker", Kind: "uses", Uses: "./actions/docker"}})
@@ -4987,6 +4991,13 @@ func canonicalTempDir(t *testing.T) string {
 		t.Fatal(err)
 	}
 	return dir
+}
+
+func requireLinuxAMD64(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS != "linux" || runtime.GOARCH != "amd64" {
+		t.Skip("requires a linux/amd64 runtime host")
+	}
 }
 
 func requireNode24(t *testing.T) string {

--- a/internal/runtime/upload_artifact_test.go
+++ b/internal/runtime/upload_artifact_test.go
@@ -629,10 +629,7 @@ func TestUploadArtifactAdapterBypassesVerifiedUpstreamLifecycle(t *testing.T) {
 	workflowPath := ".github/workflows/upload.yml"
 	writeFixtureFile(t, workspace, workflowPath, "name: upload proof\n")
 	writeFixtureFile(t, workspace, "payload/result.txt", "payload")
-	remote, err := filepath.EvalSymlinks(t.TempDir())
-	if err != nil {
-		t.Fatal(err)
-	}
+	remote := canonicalTempDir(t)
 	writeFixtureFile(t, remote, "action.yml", "name: upload artifact\nruns:\n  using: node24\n  pre: dist/pre.js\n  main: dist/main.js\n  post: dist/post.js\n")
 	for _, phase := range []string{"pre", "main", "post"} {
 		writeFixtureFile(t, remote, "dist/"+phase+".js", "throw new Error('adapter must not execute upstream JavaScript')\n")
@@ -688,10 +685,7 @@ func TestUploadArtifactV6ConditionalMatrixAndExpressionName(t *testing.T) {
 	workflowPath := ".github/workflows/upload.yml"
 	writeFixtureFile(t, workspace, workflowPath, "name: conditional upload proof\n")
 	writeFixtureFile(t, workspace, "artifacts.tar.gz", "archive")
-	remote, err := filepath.EvalSymlinks(t.TempDir())
-	if err != nil {
-		t.Fatal(err)
-	}
+	remote := canonicalTempDir(t)
 	writeFixtureFile(t, remote, "action.yml", "name: upload artifact\nruns:\n  using: node24\n  main: dist/upload/index.js\n")
 	writeFixtureFile(t, remote, "dist/upload/index.js", "throw new Error('adapter must not execute upstream JavaScript')\n")
 	digest, err := source.DigestTree(remote)

--- a/internal/runtime/upload_artifact_test.go
+++ b/internal/runtime/upload_artifact_test.go
@@ -629,7 +629,10 @@ func TestUploadArtifactAdapterBypassesVerifiedUpstreamLifecycle(t *testing.T) {
 	workflowPath := ".github/workflows/upload.yml"
 	writeFixtureFile(t, workspace, workflowPath, "name: upload proof\n")
 	writeFixtureFile(t, workspace, "payload/result.txt", "payload")
-	remote := t.TempDir()
+	remote, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
 	writeFixtureFile(t, remote, "action.yml", "name: upload artifact\nruns:\n  using: node24\n  pre: dist/pre.js\n  main: dist/main.js\n  post: dist/post.js\n")
 	for _, phase := range []string{"pre", "main", "post"} {
 		writeFixtureFile(t, remote, "dist/"+phase+".js", "throw new Error('adapter must not execute upstream JavaScript')\n")
@@ -685,7 +688,10 @@ func TestUploadArtifactV6ConditionalMatrixAndExpressionName(t *testing.T) {
 	workflowPath := ".github/workflows/upload.yml"
 	writeFixtureFile(t, workspace, workflowPath, "name: conditional upload proof\n")
 	writeFixtureFile(t, workspace, "artifacts.tar.gz", "archive")
-	remote := t.TempDir()
+	remote, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
 	writeFixtureFile(t, remote, "action.yml", "name: upload artifact\nruns:\n  using: node24\n  main: dist/upload/index.js\n")
 	writeFixtureFile(t, remote, "dist/upload/index.js", "throw new Error('adapter must not execute upstream JavaScript')\n")
 	digest, err := source.DigestTree(remote)


### PR DESCRIPTION
## Why

The Darwin cross-build catches compilation errors but cannot execute macOS binaries or verify Darwin filesystem and process behavior. Native macOS support needs a runtime regression guard.

## What

Add a required Buildkite step on the `mac-small` queue that verifies the agent is Darwin/arm64, builds every Go package, and runs the ordinary uncached `go test ./...` suite.

Mark Linux/amd64 importer and Docker tests with Go build constraints or focused `t.Skip` guards. Portable tests still run on both platforms. Canonicalize temporary paths in alias-sensitive fixtures so macOS's `/tmp` alias does not produce false path-escape failures.

Keep every other checked-in pipeline step pinned to the hosted queue.