### PR TITLE
Add workspace-confined hashFiles support

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -419,11 +419,11 @@ Three expression modes intentionally support different syntax.
 | `!`, `&&`, `\|\|`, `==`, `!=` | ✅ Supported | ❌ Unsupported | 🟡 When the result resolves fully |
 | `always()`, `success()`, `failure()`, `cancelled()` | ✅ Without arguments | ❌ Unsupported | ❌ Unsupported |
 | `fromJSON()`, case-insensitive `startsWith()` | 🟡 Compile time only | ❌ Unsupported | 🟡 When the result resolves fully |
-| `hashFiles()` | ❌ Unsupported | ❌ Unsupported | ❌ Unsupported |
+| `hashFiles()` | 🟡 Step `if` only | 🟡 Workflow steps only | ❌ Unsupported |
 
 ### Conditions
 
-Job and step `if` conditions support literals and the syntax listed above. Ordered comparisons, other functions, and function arguments are unsupported.
+Job and step `if` conditions support literals and the syntax listed above. Ordered comparisons and other functions are unsupported. `hashFiles()` accepts 1–255 literal or direct-reference arguments in step conditions only.
 
 | Context | Job `if` | Step `if` |
 | --- | --- | --- |
@@ -442,7 +442,7 @@ An event-backed condition is evaluated from the immutable event snapshot before 
 
 ### Runtime interpolation
 
-Interpolated values support direct references only. Available contexts include `github`, `runner`, `inputs`, `matrix`, `vars`, `env`, `steps`, `needs`, `secrets`, and service ports where that value exists.
+Interpolated values support direct references only. Available contexts include `github`, `runner`, `inputs`, `matrix`, `vars`, `env`, `steps`, `needs`, `secrets`, and service ports where that value exists. Top-level workflow step `run`, `env`, `with`, explicit `shell`, and explicit `working-directory` fields also support `hashFiles()` with literal or direct-reference arguments. Job fields, job outputs, job defaults, step names, and action metadata keep the direct-reference-only rule.
 
 The only runner references are `runner.os` and `runner.arch`. They resolve to
 `Linux`/`X64` or `macOS`/`ARM64`. Runtime interpolation does not evaluate
@@ -457,6 +457,12 @@ run: echo "${{ needs.build.outputs.image }}"
 ```
 
 At runtime, only `github.actor`, `github.event_name`, `github.ref`, `github.repository`, and `github.sha` are retained. `github.event` is unavailable.
+
+`hashFiles()` evaluates when its step field is consumed. A step condition and normal step execution observe earlier steps such as checkout. A JavaScript action's `with` and `env` values can also be evaluated for its `pre` phase, then reevaluated for `main`. Patterns apply in argument order. `!` excludes matches, and a later positive pattern can include them again. Directory matches include descendants, hidden files match normally, overlapping patterns hash each path once, and matching is case-insensitive on Windows only. An empty match returns an empty string.
+
+For each matched file, `hashFiles()` calculates SHA-256 over its contents. It calculates the final lowercase digest over the concatenated binary file digests. Files use deterministic lexical path order; GitHub Runner's current glob traversal order is unspecified, so a multi-file digest can differ when that traversal is not lexical.
+
+Patterns cannot be absolute, contain a `..` path segment, or contain ASCII control characters. Hashing pins the workspace directory and confines file opens to it. It does not traverse symlinked directories. A matched symlink, including one targeting another workspace file, or matched non-regular file fails the step. GitHub Runner can hash a matched file symlink and supports an optional symlink-following mode; this runtime deliberately does neither.
 
 ### Compile-time expressions
 
@@ -676,6 +682,10 @@ immutable image with `/opt/hostedtoolcache`. macOS images are unsupported.
 | Files per uploaded artifact | 10,000 |
 | Uploaded source data or ZIP | 1 GiB |
 | Job summary | 1 MiB |
+| `hashFiles()` patterns | 255 per call; 1 KiB each; 64 KiB total |
+| `hashFiles()` workspace entries | 100,000 per call |
+| `hashFiles()` matched files | 10,000 per call |
+| `hashFiles()` selected bytes | 1 GiB per call |
 
 ## Validation
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -742,7 +742,7 @@ jobs:
   bad-condition:
     runs-on: ubuntu-latest
     steps:
-      - if: ${{ hashFiles('go.sum') }}
+      - if: ${{ contains('go.sum', 'sum') }}
         run: true
   bad-runner:
     runs-on: windows-latest

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -168,17 +168,16 @@ jobs:
 			want: `conditions.yml:5:9: job "test": job condition: condition reference "github.event.action" is unavailable at runtime`,
 		},
 		{
-			name: "named step function",
+			name: "job hash function",
 			source: `on: push
 jobs:
   test:
     runs-on: ubuntu-latest
+    if: hashFiles('go.sum') != ''
     steps:
-      - id: inspect
-        if: hashFiles('go.sum') != ''
-        run: true
+      - run: true
 `,
-			want: `conditions.yml:7:13: job "test": step "inspect" condition: condition function "hashFiles" is unsupported`,
+			want: `conditions.yml:5:9: job "test": job condition: condition function "hashFiles" is unavailable in job conditions`,
 		},
 		{
 			name: "anonymous step context",

--- a/internal/expression/condition.go
+++ b/internal/expression/condition.go
@@ -25,6 +25,7 @@ type ConditionContext struct {
 	Failure      bool
 	Cancelled    bool
 	Unsuccessful bool
+	HashFiles    func([]string) (string, error)
 }
 
 // ConditionScope identifies the runtime phase in which a workflow condition
@@ -119,6 +120,19 @@ func validateConditionNode(node actionlint.ExprNode, scope ConditionScope, matri
 				return fmt.Errorf("condition function %q arguments are unsupported", node.Callee)
 			}
 			return nil
+		case "hashfiles":
+			if scope != StepCondition {
+				return fmt.Errorf("condition function %q is unavailable in job conditions", node.Callee)
+			}
+			if len(node.Args) == 0 || len(node.Args) > 255 {
+				return fmt.Errorf("condition function %q requires 1 to 255 arguments", node.Callee)
+			}
+			for _, argument := range node.Args {
+				if err := validateHashFilesArgument(argument, scope, matrix, matrixKnown); err != nil {
+					return err
+				}
+			}
+			return nil
 		default:
 			return fmt.Errorf("condition function %q is unsupported", node.Callee)
 		}
@@ -192,6 +206,16 @@ func validateCompileConditionNode(node actionlint.ExprNode, scope ConditionScope
 			}
 			_, err := evaluateCompileNode(node, context)
 			return err
+		case strings.EqualFold(node.Callee, "hashFiles") && scope == StepCondition:
+			if len(node.Args) == 0 || len(node.Args) > 255 {
+				return fmt.Errorf("condition function %q requires 1 to 255 arguments", node.Callee)
+			}
+			for _, argument := range node.Args {
+				if err := validateHashFilesArgument(argument, scope, matrix, true); err != nil {
+					return err
+				}
+			}
+			return nil
 		default:
 			return fmt.Errorf("condition function %q is unsupported", node.Callee)
 		}
@@ -215,7 +239,12 @@ func conditionOperandCategory(node actionlint.ExprNode, matrix map[string]any) s
 	switch node := node.(type) {
 	case *actionlint.NullNode:
 		return "null"
-	case *actionlint.BoolNode, *actionlint.NotOpNode, *actionlint.LogicalOpNode, *actionlint.CompareOpNode, *actionlint.FuncCallNode:
+	case *actionlint.BoolNode, *actionlint.NotOpNode, *actionlint.LogicalOpNode, *actionlint.CompareOpNode:
+		return "boolean"
+	case *actionlint.FuncCallNode:
+		if strings.EqualFold(node.Callee, "hashFiles") {
+			return "string"
+		}
 		return "boolean"
 	case *actionlint.IntNode, *actionlint.FloatNode:
 		return "number"
@@ -431,23 +460,77 @@ func evaluateConditionNode(node actionlint.ExprNode, context ConditionContext) (
 			return nil, fmt.Errorf("condition comparison %s is unsupported", node.Kind)
 		}
 	case *actionlint.FuncCallNode:
-		if len(node.Args) != 0 {
-			return nil, fmt.Errorf("condition function %q arguments are unsupported", node.Callee)
-		}
 		switch strings.ToLower(node.Callee) {
 		case "always":
+			if len(node.Args) != 0 {
+				return nil, fmt.Errorf("condition function %q arguments are unsupported", node.Callee)
+			}
 			return true, nil
 		case "success":
+			if len(node.Args) != 0 {
+				return nil, fmt.Errorf("condition function %q arguments are unsupported", node.Callee)
+			}
 			return !context.Unsuccessful && !context.Cancelled, nil
 		case "failure":
+			if len(node.Args) != 0 {
+				return nil, fmt.Errorf("condition function %q arguments are unsupported", node.Callee)
+			}
 			return context.Failure, nil
 		case "cancelled":
+			if len(node.Args) != 0 {
+				return nil, fmt.Errorf("condition function %q arguments are unsupported", node.Callee)
+			}
 			return context.Cancelled, nil
+		case "hashfiles":
+			if context.HashFiles == nil {
+				return nil, fmt.Errorf("condition function %q is unavailable", node.Callee)
+			}
+			patterns, err := evaluateHashFilesArguments(node.Args, func(argument actionlint.ExprNode) (any, error) {
+				return evaluateConditionHashFilesArgument(argument, context)
+			})
+			if err != nil {
+				return nil, err
+			}
+			return context.HashFiles(patterns)
 		default:
 			return nil, fmt.Errorf("condition function %q is unsupported", node.Callee)
 		}
 	default:
 		return nil, fmt.Errorf("unsupported condition expression")
+	}
+}
+
+func validateHashFilesArgument(node actionlint.ExprNode, scope ConditionScope, matrix map[string]any, matrixKnown bool) error {
+	switch node.(type) {
+	case *actionlint.NullNode, *actionlint.BoolNode, *actionlint.IntNode, *actionlint.FloatNode, *actionlint.StringNode:
+		return nil
+	case *actionlint.VariableNode, *actionlint.ObjectDerefNode, *actionlint.IndexAccessNode:
+		return validateConditionNode(node, scope, matrix, matrixKnown)
+	default:
+		return fmt.Errorf("condition function %q arguments must be literals or direct context references", "hashFiles")
+	}
+}
+
+func evaluateConditionHashFilesArgument(node actionlint.ExprNode, context ConditionContext) (any, error) {
+	switch node := node.(type) {
+	case *actionlint.NullNode:
+		return nil, nil
+	case *actionlint.BoolNode:
+		return node.Value, nil
+	case *actionlint.IntNode:
+		return node.Value, nil
+	case *actionlint.FloatNode:
+		return node.Value, nil
+	case *actionlint.StringNode:
+		return node.Value, nil
+	case *actionlint.VariableNode, *actionlint.ObjectDerefNode, *actionlint.IndexAccessNode:
+		root, path, err := referencePath(node)
+		if err != nil {
+			return nil, err
+		}
+		return resolveConditionReference(root, path, context)
+	default:
+		return nil, fmt.Errorf("arguments must be literals or direct context references")
 	}
 }
 

--- a/internal/expression/condition.go
+++ b/internal/expression/condition.go
@@ -386,14 +386,14 @@ func EvaluateCondition(source string, context ConditionContext) (bool, error) {
 	if empty {
 		return !context.Unsuccessful && !context.Cancelled, nil
 	}
+	if !containsStatusFunction(node) && (context.Unsuccessful || context.Cancelled) {
+		return false, nil
+	}
 	value, err := evaluateConditionNode(node, context)
 	if err != nil {
 		return false, err
 	}
 	result := conditionTruthy(value)
-	if !containsStatusFunction(node) && (context.Unsuccessful || context.Cancelled) {
-		return false, nil
-	}
 	return result, nil
 }
 

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -399,7 +399,9 @@ func TestValidateConditionRejectsUnsupportedRuntimeExpressions(t *testing.T) {
 		scope  ConditionScope
 		want   string
 	}{
-		{name: "unsupported function", source: "hashFiles()", scope: StepCondition, want: `condition function "hashFiles" is unsupported`},
+		{name: "hashFiles needs a pattern", source: "hashFiles()", scope: StepCondition, want: `condition function "hashFiles" requires 1 to 255 arguments`},
+		{name: "hashFiles unavailable in jobs", source: "hashFiles('go.sum')", scope: JobCondition, want: `condition function "hashFiles" is unavailable in job conditions`},
+		{name: "unsupported function", source: "contains('a', 'b')", scope: StepCondition, want: `condition function "contains" is unsupported`},
 		{name: "function arguments", source: "always(true)", scope: StepCondition, want: `condition function "always" arguments are unsupported`},
 		{name: "ordered comparison", source: "matrix.count > 1", scope: JobCondition, want: "condition comparison > is unsupported"},
 		{name: "runtime event payload", source: "github.event.pull_request.draft", scope: JobCondition, want: `condition reference "github.event.pull_request.draft" is unavailable at runtime`},
@@ -419,6 +421,48 @@ func TestValidateConditionRejectsUnsupportedRuntimeExpressions(t *testing.T) {
 				t.Fatalf("ValidateCondition() error = %v, want %q", err, test.want)
 			}
 		})
+	}
+}
+
+func TestHashFilesIsLimitedToStepRuntimeExpressions(t *testing.T) {
+	hash := func(patterns []string) (string, error) {
+		if !reflect.DeepEqual(patterns, []string{"*.go", "!generated/**"}) {
+			t.Fatalf("hashFiles patterns = %#v", patterns)
+		}
+		return "digest", nil
+	}
+	context := Context{HashFiles: hash}
+	if got, err := EvaluateStep("key-${{ hashFiles('*.go', '!generated/**') }}", context); err != nil || got != "key-digest" {
+		t.Fatalf("EvaluateStep() = %q, %v", got, err)
+	}
+	if _, err := Evaluate("${{ hashFiles('*.go') }}", context); err == nil || !strings.Contains(err.Error(), "unsupported expression reference") {
+		t.Fatalf("Evaluate() hashFiles error = %v", err)
+	}
+	if _, err := EvaluateStep("${{ contains('a', 'b') }}", context); err == nil || !strings.Contains(err.Error(), "unsupported expression reference") {
+		t.Fatalf("EvaluateStep() contains error = %v", err)
+	}
+
+	condition := ConditionContext{HashFiles: hash}
+	if got, err := EvaluateCondition("hashFiles('*.go', '!generated/**') != ''", condition); err != nil || !got {
+		t.Fatalf("EvaluateCondition() = %v, %v", got, err)
+	}
+	if err := ValidateCondition("hashFiles('*.go') != ''", StepCondition); err != nil {
+		t.Fatalf("ValidateCondition() = %v", err)
+	}
+}
+
+func TestCompileConditionValidationAdmitsRuntimeHashFilesWithoutFilesystemAccess(t *testing.T) {
+	context := CompileContext{GitHub: map[string]any{"event": map[string]any{"pull_request": map[string]any{"draft": false}}}}
+	source := "github.event.pull_request.draft && hashFiles('go.sum') != ''"
+	if err := ValidateCompileConditionWithMatrix(source, StepCondition, context, nil); err != nil {
+		t.Fatalf("ValidateCompileConditionWithMatrix() = %v", err)
+	}
+	resolved, err := EvaluateCompileCondition(source, context)
+	if err != nil || resolved {
+		t.Fatalf("EvaluateCompileCondition() = %v, %v", resolved, err)
+	}
+	if _, err := EvaluateCompile(Expression{Text: "${{ hashFiles('go.sum') }}"}, context); err == nil || !strings.Contains(err.Error(), `unsupported compile-time function "hashFiles"`) {
+		t.Fatalf("EvaluateCompile() hashFiles error = %v", err)
 	}
 }
 

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -698,6 +698,13 @@ func TestEvaluateConditionFailsClosed(t *testing.T) {
 	if got, err := EvaluateCondition("", ConditionContext{Unsuccessful: true}); err != nil || got {
 		t.Fatalf("default condition after skipped prerequisite = %v, %v, want false", got, err)
 	}
+	hashCalled := false
+	if got, err := EvaluateCondition("hashFiles('**') != ''", ConditionContext{Unsuccessful: true, HashFiles: func([]string) (string, error) {
+		hashCalled = true
+		return "digest", nil
+	}}); err != nil || got || hashCalled {
+		t.Fatalf("implicit success guard = %v, %v, hash called %v; want false, nil, false", got, err, hashCalled)
+	}
 	if _, err := EvaluateCondition("needs.missing.result", ConditionContext{}); err == nil {
 		t.Fatal("EvaluateCondition() accepted an unavailable need result")
 	}

--- a/internal/expression/runtime.go
+++ b/internal/expression/runtime.go
@@ -2,7 +2,9 @@
 package expression
 
 import (
+	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/rhysd/actionlint"
@@ -10,19 +12,21 @@ import (
 
 // Context contains the compile-time values available while evaluating a template.
 type Context struct {
-	Inputs       map[string]string
-	Matrix       map[string]any
-	Steps        map[string]map[string]string
-	StepStatuses map[string]StepStatus
-	Needs        map[string]map[string]string
-	NeedResults  map[string]string
-	Secrets      map[string]string
-	Vars         map[string]string
-	Env          map[string]string
-	GitHub       map[string]any
-	Runner       map[string]string
-	Services     map[string]map[string]string
-	JobStatus    string
+	Inputs           map[string]string
+	Matrix           map[string]any
+	Steps            map[string]map[string]string
+	StepStatuses     map[string]StepStatus
+	Needs            map[string]map[string]string
+	NeedResults      map[string]string
+	Secrets          map[string]string
+	Vars             map[string]string
+	Env              map[string]string
+	GitHub           map[string]any
+	Runner           map[string]string
+	Services         map[string]map[string]string
+	JobStatus        string
+	HashFiles        func([]string) (string, error)
+	HashFilesContext func(context.Context, []string) (string, error)
 }
 
 type runtimeReferenceKind uint8
@@ -63,6 +67,12 @@ func validateRuntimeTemplate(template string) error {
 // Evaluate substitutes direct runtime references in a template once.
 func Evaluate(template string, context Context) (string, error) {
 	return evaluateRuntimeTemplate(template, context, evaluateDirectRuntimeNode)
+}
+
+// EvaluateStep substitutes direct runtime references and hashFiles calls in a
+// workflow step template. Other runtime surfaces remain direct-reference only.
+func EvaluateStep(template string, context Context) (string, error) {
+	return evaluateRuntimeTemplate(template, context, evaluateStepRuntimeNode)
 }
 
 func evaluateRuntimeTemplate(template string, context Context, evaluate func(actionlint.ExprNode, Context) (any, error)) (string, error) {
@@ -109,6 +119,70 @@ func evaluateDirectRuntimeNode(node actionlint.ExprNode, context Context) (any, 
 		return nil, err
 	}
 	return resolveRuntimeReference(root, path, context)
+}
+
+func evaluateStepRuntimeNode(node actionlint.ExprNode, context Context) (any, error) {
+	call, ok := node.(*actionlint.FuncCallNode)
+	if !ok || !strings.EqualFold(call.Callee, "hashFiles") {
+		return evaluateDirectRuntimeNode(node, context)
+	}
+	if context.HashFiles == nil {
+		return nil, fmt.Errorf("runtime function %q is unavailable", call.Callee)
+	}
+	patterns, err := evaluateHashFilesArguments(call.Args, func(argument actionlint.ExprNode) (any, error) {
+		return evaluateRuntimeHashFilesArgument(argument, context)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return context.HashFiles(patterns)
+}
+
+func evaluateHashFilesArguments(nodes []actionlint.ExprNode, evaluate func(actionlint.ExprNode) (any, error)) ([]string, error) {
+	if len(nodes) == 0 || len(nodes) > 255 {
+		return nil, fmt.Errorf("function %q requires 1 to 255 arguments", "hashFiles")
+	}
+	patterns := make([]string, len(nodes))
+	for i, node := range nodes {
+		value, err := evaluate(node)
+		if err != nil {
+			return nil, fmt.Errorf("hashFiles argument %d: %w", i+1, err)
+		}
+		patterns[i] = runtimeString(value)
+	}
+	return patterns, nil
+}
+
+func evaluateRuntimeHashFilesArgument(node actionlint.ExprNode, context Context) (any, error) {
+	switch node := node.(type) {
+	case *actionlint.NullNode:
+		return nil, nil
+	case *actionlint.BoolNode:
+		return node.Value, nil
+	case *actionlint.IntNode:
+		return node.Value, nil
+	case *actionlint.FloatNode:
+		return node.Value, nil
+	case *actionlint.StringNode:
+		return node.Value, nil
+	case *actionlint.VariableNode, *actionlint.ObjectDerefNode, *actionlint.IndexAccessNode:
+		return evaluateDirectRuntimeNode(node, context)
+	default:
+		return nil, fmt.Errorf("arguments must be literals or direct context references")
+	}
+}
+
+func runtimeString(value any) string {
+	switch value := value.(type) {
+	case nil:
+		return ""
+	case bool:
+		return strconv.FormatBool(value)
+	case string:
+		return value
+	default:
+		return fmt.Sprint(value)
+	}
 }
 
 func resolveRuntimeReference(root string, path []string, context Context) (any, error) {

--- a/internal/runtime/checkout_test.go
+++ b/internal/runtime/checkout_test.go
@@ -83,6 +83,7 @@ esac
 	}
 
 	workflowDigest := sha256.Sum256(workflowSource)
+	headDigest := githubHash(sha + "\n")
 	checkoutID, localID := "a-0000000000000001", "a-0000000000000002"
 	job := plan.Job{
 		Schema: plan.SchemaV3,
@@ -99,6 +100,7 @@ esac
 		RequiredCapabilities: []string{"network", "provider-token-read"},
 		Steps: []plan.Step{
 			{ID: "checkout", Kind: "uses", Uses: "actions/checkout@v7", Action: &plan.ActionSelector{Lock: checkoutID}},
+			{ID: "hash", Kind: "run", Shell: "sh", Condition: "hashFiles('.git/HEAD') != ''", Env: map[string]string{"HEAD_HASH": "${{ hashFiles('.git/HEAD') }}"}, Command: "test \"$HEAD_HASH\" = " + headDigest},
 			{ID: "local", Kind: "uses", Uses: "./.github/actions/local", Action: &plan.ActionSelector{Lock: localID}},
 		},
 		Actions: []plan.ActionLock{

--- a/internal/runtime/concurrent.go
+++ b/internal/runtime/concurrent.go
@@ -155,7 +155,7 @@ func (s *backgroundSupervisor) commitCompleted(tasks []*backgroundTask) []stepEx
 	return executions
 }
 
-func (r Runner) executePlanStep(jobCtx, runCtx context.Context, processor *commandProcessor, workspace string, job plan.Job, step plan.Step, invocationID string, jobEnv map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations) stepExecution {
+func (r Runner) executePlanStep(jobCtx, runCtx context.Context, processor *commandProcessor, workspace string, job plan.Job, step plan.Step, invocationID string, jobEnv, stepEnv map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations) stepExecution {
 	stepCtx := runCtx
 	cancelStep := func() {}
 	if step.TimeoutMinutes > 0 {
@@ -166,7 +166,7 @@ func (r Runner) executePlanStep(jobCtx, runCtx context.Context, processor *comma
 			return eval.HashFilesContext(stepCtx, patterns)
 		}
 	}
-	result, err := r.runJobStep(stepCtx, processor, workspace, job, step, invocationID, jobEnv, eval, posts, actions, prepared)
+	result, err := r.runJobStep(stepCtx, processor, workspace, job, step, invocationID, jobEnv, stepEnv, eval, posts, actions, prepared)
 	cancelStep()
 	return classifyStepExecution(jobCtx, runCtx, step, result, err)
 }

--- a/internal/runtime/concurrent.go
+++ b/internal/runtime/concurrent.go
@@ -161,6 +161,11 @@ func (r Runner) executePlanStep(jobCtx, runCtx context.Context, processor *comma
 	if step.TimeoutMinutes > 0 {
 		stepCtx, cancelStep = context.WithTimeout(runCtx, durationMinutes(step.TimeoutMinutes))
 	}
+	if eval.HashFilesContext != nil {
+		eval.HashFiles = func(patterns []string) (string, error) {
+			return eval.HashFilesContext(stepCtx, patterns)
+		}
+	}
 	result, err := r.runJobStep(stepCtx, processor, workspace, job, step, invocationID, jobEnv, eval, posts, actions, prepared)
 	cancelStep()
 	return classifyStepExecution(jobCtx, runCtx, step, result, err)
@@ -226,19 +231,21 @@ func commitResultEnvironment(env map[string]string, result Result) {
 
 func cloneExpressionContext(in expression.Context) expression.Context {
 	return expression.Context{
-		Inputs:       cloneStrings(in.Inputs),
-		Matrix:       cloneAnyMap(in.Matrix),
-		Steps:        cloneNestedStrings(in.Steps),
-		StepStatuses: cloneStepStatuses(in.StepStatuses),
-		Needs:        cloneNestedStrings(in.Needs),
-		NeedResults:  cloneStrings(in.NeedResults),
-		Secrets:      cloneStrings(in.Secrets),
-		Vars:         cloneStrings(in.Vars),
-		Env:          cloneStrings(in.Env),
-		GitHub:       cloneAnyMap(in.GitHub),
-		Runner:       cloneStrings(in.Runner),
-		Services:     cloneNestedStrings(in.Services),
-		JobStatus:    in.JobStatus,
+		Inputs:           cloneStrings(in.Inputs),
+		Matrix:           cloneAnyMap(in.Matrix),
+		Steps:            cloneNestedStrings(in.Steps),
+		StepStatuses:     cloneStepStatuses(in.StepStatuses),
+		Needs:            cloneNestedStrings(in.Needs),
+		NeedResults:      cloneStrings(in.NeedResults),
+		Secrets:          cloneStrings(in.Secrets),
+		Vars:             cloneStrings(in.Vars),
+		Env:              cloneStrings(in.Env),
+		GitHub:           cloneAnyMap(in.GitHub),
+		Runner:           cloneStrings(in.Runner),
+		Services:         cloneNestedStrings(in.Services),
+		JobStatus:        in.JobStatus,
+		HashFiles:        in.HashFiles,
+		HashFilesContext: in.HashFilesContext,
 	}
 }
 

--- a/internal/runtime/concurrent.go
+++ b/internal/runtime/concurrent.go
@@ -162,6 +162,14 @@ func stepContext(parent context.Context, timeoutMinutes float64) (context.Contex
 	return context.WithCancel(parent)
 }
 
+func bindHashFilesContext(ctx context.Context, eval *expression.Context) {
+	if eval.HashFilesContext != nil {
+		eval.HashFiles = func(patterns []string) (string, error) {
+			return eval.HashFilesContext(ctx, patterns)
+		}
+	}
+}
+
 func (r Runner) executePlanStep(jobCtx, runCtx context.Context, processor *commandProcessor, workspace string, job plan.Job, step plan.Step, invocationID string, jobEnv, stepEnv map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations) stepExecution {
 	result, err := r.runJobStep(runCtx, processor, workspace, job, step, invocationID, jobEnv, stepEnv, eval, posts, actions, prepared)
 	return classifyStepExecution(jobCtx, runCtx, step, result, err)

--- a/internal/runtime/concurrent.go
+++ b/internal/runtime/concurrent.go
@@ -155,19 +155,15 @@ func (s *backgroundSupervisor) commitCompleted(tasks []*backgroundTask) []stepEx
 	return executions
 }
 
+func stepContext(parent context.Context, timeoutMinutes float64) (context.Context, context.CancelFunc) {
+	if timeoutMinutes > 0 {
+		return context.WithTimeout(parent, durationMinutes(timeoutMinutes))
+	}
+	return context.WithCancel(parent)
+}
+
 func (r Runner) executePlanStep(jobCtx, runCtx context.Context, processor *commandProcessor, workspace string, job plan.Job, step plan.Step, invocationID string, jobEnv, stepEnv map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations) stepExecution {
-	stepCtx := runCtx
-	cancelStep := func() {}
-	if step.TimeoutMinutes > 0 {
-		stepCtx, cancelStep = context.WithTimeout(runCtx, durationMinutes(step.TimeoutMinutes))
-	}
-	if eval.HashFilesContext != nil {
-		eval.HashFiles = func(patterns []string) (string, error) {
-			return eval.HashFilesContext(stepCtx, patterns)
-		}
-	}
-	result, err := r.runJobStep(stepCtx, processor, workspace, job, step, invocationID, jobEnv, stepEnv, eval, posts, actions, prepared)
-	cancelStep()
+	result, err := r.runJobStep(runCtx, processor, workspace, job, step, invocationID, jobEnv, stepEnv, eval, posts, actions, prepared)
 	return classifyStepExecution(jobCtx, runCtx, step, result, err)
 }
 

--- a/internal/runtime/hash_files.go
+++ b/internal/runtime/hash_files.go
@@ -28,13 +28,14 @@ const (
 )
 
 type hashFilesLimits struct {
-	patterns          int
-	patternBytes      int
-	totalPatternBytes int
-	matches           int
-	bytes             int64
-	entries           int
-	beforeOpen        func(string)
+	patterns            int
+	patternBytes        int
+	totalPatternBytes   int
+	matches             int
+	bytes               int64
+	entries             int
+	beforeOpen          func(string)
+	beforeDirectoryOpen func(string)
 }
 
 var defaultHashFilesLimits = hashFilesLimits{
@@ -74,7 +75,8 @@ func hashWorkspaceRootFilesWithLimits(ctx context.Context, root *os.Root, source
 		return "", err
 	}
 	var selected []string
-	err = walkHashFilesRoot(ctx, root, limits.entries, func(name string, entry fs.DirEntry) error {
+	directories := make(map[string]fs.FileInfo)
+	err = walkHashFilesRoot(ctx, root, limits.entries, limits.beforeDirectoryOpen, directories, func(name string, entry fs.DirEntry) error {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
@@ -125,6 +127,9 @@ func hashWorkspaceRootFilesWithLimits(ctx context.Context, root *os.Root, source
 		if err := ctx.Err(); err != nil {
 			return "", err
 		}
+		if err := verifyHashFileDirectories(root, directories, name); err != nil {
+			return "", err
+		}
 		before, err := root.Lstat(name)
 		if err != nil {
 			return "", fmt.Errorf("inspect hashFiles match %q: %w", name, err)
@@ -169,10 +174,13 @@ func hashWorkspaceRootFilesWithLimits(ctx context.Context, root *os.Root, source
 		total += read
 		_, _ = combined.Write(fileHash.Sum(nil))
 	}
+	if err := verifyHashFileDirectories(root, directories, ""); err != nil {
+		return "", err
+	}
 	return hex.EncodeToString(combined.Sum(nil)), nil
 }
 
-func walkHashFilesRoot(ctx context.Context, root *os.Root, limit int, visit func(string, fs.DirEntry) error) error {
+func walkHashFilesRoot(ctx context.Context, root *os.Root, limit int, beforeOpen func(string), directories map[string]fs.FileInfo, visit func(string, fs.DirEntry) error) error {
 	const readBatch = 256
 	entriesRead := 0
 	var walk func(string) error
@@ -180,9 +188,24 @@ func walkHashFilesRoot(ctx context.Context, root *os.Root, limit int, visit func
 		if err := ctx.Err(); err != nil {
 			return err
 		}
+		before, err := root.Lstat(directory)
+		if err != nil {
+			return fmt.Errorf("inspect hashFiles directory %q: %w", directory, err)
+		}
+		if before.Mode()&os.ModeSymlink != 0 || !before.IsDir() {
+			return fmt.Errorf("hashFiles directory %q changed before traversal", directory)
+		}
+		if beforeOpen != nil {
+			beforeOpen(directory)
+		}
 		handle, err := root.Open(directory)
 		if err != nil {
 			return fmt.Errorf("open hashFiles directory %q: %w", directory, err)
+		}
+		opened, err := handle.Stat()
+		if err != nil || !opened.IsDir() || !os.SameFile(before, opened) {
+			_ = handle.Close()
+			return fmt.Errorf("hashFiles directory %q changed before traversal", directory)
 		}
 		var entries []fs.DirEntry
 		for {
@@ -207,6 +230,11 @@ func walkHashFilesRoot(ctx context.Context, root *os.Root, limit int, visit func
 		if err := handle.Close(); err != nil {
 			return fmt.Errorf("close hashFiles directory %q: %w", directory, err)
 		}
+		after, err := root.Lstat(directory)
+		if err != nil || !sameHashFileInfo(before, after) {
+			return fmt.Errorf("hashFiles directory %q changed during traversal", directory)
+		}
+		directories[directory] = before
 		sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
 		for _, entry := range entries {
 			name := path.Join(directory, entry.Name())
@@ -222,6 +250,35 @@ func walkHashFilesRoot(ctx context.Context, root *os.Root, limit int, visit func
 		return nil
 	}
 	return walk(".")
+}
+
+func verifyHashFileDirectories(root *os.Root, directories map[string]fs.FileInfo, name string) error {
+	if name == "" {
+		for directory, before := range directories {
+			after, err := root.Lstat(directory)
+			if err != nil || !sameHashFileInfo(before, after) {
+				return fmt.Errorf("hashFiles directory %q changed after traversal", directory)
+			}
+		}
+		return nil
+	}
+	for directory := path.Dir(name); ; directory = path.Dir(directory) {
+		before, ok := directories[directory]
+		if !ok {
+			return fmt.Errorf("hashFiles directory %q was not traversed", directory)
+		}
+		after, err := root.Lstat(directory)
+		if err != nil || !sameHashFileInfo(before, after) {
+			return fmt.Errorf("hashFiles directory %q changed after traversal", directory)
+		}
+		if directory == "." {
+			return nil
+		}
+	}
+}
+
+func sameHashFileInfo(before, after fs.FileInfo) bool {
+	return after != nil && os.SameFile(before, after) && before.Mode() == after.Mode() && before.Size() == after.Size() && before.ModTime().Equal(after.ModTime())
 }
 
 func copyHashFile(ctx context.Context, destination io.Writer, source io.Reader) (int64, error) {

--- a/internal/runtime/hash_files.go
+++ b/internal/runtime/hash_files.go
@@ -128,7 +128,7 @@ func hashWorkspaceRootFilesWithLimits(ctx context.Context, root *os.Root, source
 		if err := ctx.Err(); err != nil {
 			return "", err
 		}
-		if err := verifyHashFileDirectories(root, directories, name); err != nil {
+		if err := verifyHashFileDirectories(ctx, root, directories, name); err != nil {
 			return "", err
 		}
 		fileDigest, read, err := hashWorkspaceFile(ctx, root, directories[path.Dir(name)], name, limits, total)
@@ -141,7 +141,7 @@ func hashWorkspaceRootFilesWithLimits(ctx context.Context, root *os.Root, source
 			limits.afterFileHash(name)
 		}
 	}
-	if err := verifyHashFileDirectories(root, directories, ""); err != nil {
+	if err := verifyHashFileDirectories(ctx, root, directories, ""); err != nil {
 		return "", err
 	}
 	return hex.EncodeToString(combined.Sum(nil)), nil
@@ -288,9 +288,12 @@ func walkHashFilesRoot(ctx context.Context, root *os.Root, limit int, beforeOpen
 	return walk(".", root, rootInfo)
 }
 
-func verifyHashFileDirectories(root *os.Root, directories map[string]fs.FileInfo, name string) error {
+func verifyHashFileDirectories(ctx context.Context, root *os.Root, directories map[string]fs.FileInfo, name string) error {
 	if name == "" {
 		for directory, before := range directories {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
 			after, err := root.Lstat(directory)
 			if err != nil || !sameHashFileInfo(before, after) {
 				return fmt.Errorf("hashFiles directory %q changed after traversal", directory)
@@ -299,6 +302,9 @@ func verifyHashFileDirectories(root *os.Root, directories map[string]fs.FileInfo
 		return nil
 	}
 	for directory := path.Dir(name); ; directory = path.Dir(directory) {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		before, ok := directories[directory]
 		if !ok {
 			return fmt.Errorf("hashFiles directory %q was not traversed", directory)

--- a/internal/runtime/hash_files.go
+++ b/internal/runtime/hash_files.go
@@ -1,0 +1,321 @@
+package runtime
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
+)
+
+const (
+	maxHashFilePatterns          = 255
+	maxHashFilePatternBytes      = 1024
+	maxHashFilePatternBytesTotal = 64 << 10
+	maxHashFileMatches           = 10_000
+	maxHashFileBytes             = 1 << 30
+	maxHashFileEntries           = 100_000
+)
+
+type hashFilesLimits struct {
+	patterns          int
+	patternBytes      int
+	totalPatternBytes int
+	matches           int
+	bytes             int64
+	entries           int
+	beforeOpen        func(string)
+}
+
+var defaultHashFilesLimits = hashFilesLimits{
+	patterns: maxHashFilePatterns, patternBytes: maxHashFilePatternBytes,
+	totalPatternBytes: maxHashFilePatternBytesTotal, matches: maxHashFileMatches,
+	bytes: maxHashFileBytes, entries: maxHashFileEntries,
+}
+
+type hashFilePattern struct {
+	pattern       string
+	directory     string
+	negative      bool
+	directoryOnly bool
+}
+
+func hashWorkspaceFiles(ctx context.Context, workspace string, patterns []string) (digest string, retErr error) {
+	root, err := os.OpenRoot(workspace)
+	if err != nil {
+		return "", fmt.Errorf("open hashFiles workspace: %w", err)
+	}
+	defer func() { retErr = errors.Join(retErr, root.Close()) }()
+	return hashWorkspaceRootFilesWithLimits(ctx, root, patterns, defaultHashFilesLimits, runtime.GOOS == "windows")
+}
+
+func hashWorkspaceFilesWithLimits(ctx context.Context, workspace string, sources []string, limits hashFilesLimits, caseInsensitive bool) (digest string, retErr error) {
+	root, err := os.OpenRoot(workspace)
+	if err != nil {
+		return "", fmt.Errorf("open hashFiles workspace: %w", err)
+	}
+	defer func() { retErr = errors.Join(retErr, root.Close()) }()
+	return hashWorkspaceRootFilesWithLimits(ctx, root, sources, limits, caseInsensitive)
+}
+
+func hashWorkspaceRootFilesWithLimits(ctx context.Context, root *os.Root, sources []string, limits hashFilesLimits, caseInsensitive bool) (string, error) {
+	patterns, err := parseHashFilePatterns(sources, limits)
+	if err != nil {
+		return "", err
+	}
+	var selected []string
+	entries := 0
+	err = fs.WalkDir(root.FS(), ".", func(name string, entry fs.DirEntry, walkErr error) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if walkErr != nil {
+			return fmt.Errorf("walk hashFiles workspace at %q: %w", name, walkErr)
+		}
+		if name == "." {
+			return nil
+		}
+		entries++
+		if entries > limits.entries {
+			return fmt.Errorf("hashFiles workspace has more than %d entries", limits.entries)
+		}
+		matched, err := hashFilePatternMatch(patterns, name, caseInsensitive)
+		if err != nil {
+			return err
+		}
+		if !matched || entry.IsDir() {
+			return nil
+		}
+		if entry.Type()&fs.ModeSymlink != 0 {
+			return fmt.Errorf("hashFiles matched symlink %q; symlinks are unsupported", name)
+		}
+		if !entry.Type().IsRegular() {
+			info, err := entry.Info()
+			if err != nil {
+				return fmt.Errorf("inspect hashFiles match %q: %w", name, err)
+			}
+			if !info.Mode().IsRegular() {
+				return fmt.Errorf("hashFiles matched non-regular file %q", name)
+			}
+		}
+		selected = append(selected, name)
+		if len(selected) > limits.matches {
+			return fmt.Errorf("hashFiles matched more than %d files", limits.matches)
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	if len(selected) == 0 {
+		return "", nil
+	}
+	sort.Slice(selected, func(i, j int) bool {
+		if caseInsensitive {
+			left, right := strings.ToLower(selected[i]), strings.ToLower(selected[j])
+			if left != right {
+				return left < right
+			}
+		}
+		return selected[i] < selected[j]
+	})
+
+	combined := sha256.New()
+	var total int64
+	for _, name := range selected {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		before, err := root.Lstat(name)
+		if err != nil {
+			return "", fmt.Errorf("inspect hashFiles match %q: %w", name, err)
+		}
+		if before.Mode()&os.ModeSymlink != 0 {
+			return "", fmt.Errorf("hashFiles matched symlink %q; symlinks are unsupported", name)
+		}
+		if !before.Mode().IsRegular() {
+			return "", fmt.Errorf("hashFiles matched non-regular file %q", name)
+		}
+		if before.Size() < 0 || before.Size() > limits.bytes-total {
+			return "", fmt.Errorf("hashFiles selected bytes exceed %d", limits.bytes)
+		}
+		if limits.beforeOpen != nil {
+			limits.beforeOpen(name)
+		}
+		file, err := root.Open(name)
+		if err != nil {
+			return "", fmt.Errorf("open hashFiles match %q: %w", name, err)
+		}
+		opened, err := file.Stat()
+		if err != nil || !opened.Mode().IsRegular() || !os.SameFile(before, opened) {
+			_ = file.Close()
+			return "", fmt.Errorf("hashFiles match %q changed before hashing", name)
+		}
+		fileHash := sha256.New()
+		read, copyErr := copyHashFile(ctx, fileHash, io.LimitReader(file, limits.bytes-total+1))
+		closeErr := file.Close()
+		if copyErr != nil {
+			return "", fmt.Errorf("hash hashFiles match %q: %w", name, copyErr)
+		}
+		if closeErr != nil {
+			return "", fmt.Errorf("close hashFiles match %q: %w", name, closeErr)
+		}
+		if read > limits.bytes-total {
+			return "", fmt.Errorf("hashFiles selected bytes exceed %d", limits.bytes)
+		}
+		after, err := root.Lstat(name)
+		if err != nil || !os.SameFile(before, after) || read != before.Size() || after.Size() != before.Size() || !after.ModTime().Equal(before.ModTime()) {
+			return "", fmt.Errorf("hashFiles match %q changed while hashing", name)
+		}
+		total += read
+		_, _ = combined.Write(fileHash.Sum(nil))
+	}
+	return hex.EncodeToString(combined.Sum(nil)), nil
+}
+
+func copyHashFile(ctx context.Context, destination io.Writer, source io.Reader) (int64, error) {
+	buffer := make([]byte, 64<<10)
+	var written int64
+	for {
+		if err := ctx.Err(); err != nil {
+			return written, err
+		}
+		read, readErr := source.Read(buffer)
+		if read > 0 {
+			count, writeErr := destination.Write(buffer[:read])
+			written += int64(count)
+			if writeErr != nil {
+				return written, writeErr
+			}
+			if count != read {
+				return written, io.ErrShortWrite
+			}
+		}
+		if readErr == io.EOF {
+			return written, ctx.Err()
+		}
+		if readErr != nil {
+			return written, readErr
+		}
+	}
+}
+
+func parseHashFilePatterns(sources []string, limits hashFilesLimits) ([]hashFilePattern, error) {
+	if len(sources) == 0 || len(sources) > limits.patterns {
+		return nil, fmt.Errorf("hashFiles requires 1 to %d patterns", limits.patterns)
+	}
+	patterns := make([]hashFilePattern, 0, len(sources))
+	total := 0
+	for i, source := range sources {
+		if len(source) > limits.patternBytes {
+			return nil, fmt.Errorf("hashFiles pattern %d exceeds %d bytes", i+1, limits.patternBytes)
+		}
+		total += len(source)
+		if total > limits.totalPatternBytes {
+			return nil, fmt.Errorf("hashFiles patterns exceed %d total bytes", limits.totalPatternBytes)
+		}
+		for _, value := range []byte(source) {
+			if value < 0x20 || value == 0x7f {
+				return nil, fmt.Errorf("hashFiles pattern %d contains a forbidden control character", i+1)
+			}
+		}
+		pattern := strings.TrimSpace(source)
+		if pattern == "" || strings.HasPrefix(pattern, "#") {
+			continue
+		}
+		negative := false
+		for strings.HasPrefix(pattern, "!") {
+			negative = !negative
+			pattern = strings.TrimSpace(pattern[1:])
+		}
+		if runtime.GOOS == "windows" {
+			pattern = filepath.ToSlash(pattern)
+		}
+		if pattern == "" || path.IsAbs(pattern) || filepath.IsAbs(pattern) || filepath.VolumeName(pattern) != "" || strings.HasPrefix(pattern, "//") || windowsVolumePattern(pattern) {
+			return nil, fmt.Errorf("hashFiles pattern %d must be relative to the workspace", i+1)
+		}
+		segments := strings.Split(pattern, "/")
+		for j, segment := range segments {
+			if segment == ".." || segment == "." && j != 0 {
+				return nil, fmt.Errorf("hashFiles pattern %d may not contain %q", i+1, segment)
+			}
+		}
+		if pattern == "." || pattern == "./" {
+			pattern = "**"
+		}
+		directoryOnly := strings.HasSuffix(pattern, "/")
+		pattern = strings.TrimPrefix(pattern, "./")
+		pattern = strings.TrimSuffix(pattern, "/")
+		if pattern == "" {
+			pattern = "**"
+			directoryOnly = false
+		}
+		pattern = escapeHashFileBraces(pattern)
+		if !doublestar.ValidatePattern(pattern) {
+			return nil, fmt.Errorf("hashFiles pattern %d is invalid", i+1)
+		}
+		directory := pattern
+		if directoryOnly {
+			pattern += "/**"
+		}
+		patterns = append(patterns, hashFilePattern{pattern: pattern, directory: directory, negative: negative, directoryOnly: directoryOnly})
+	}
+	return patterns, nil
+}
+
+func windowsVolumePattern(pattern string) bool {
+	return len(pattern) >= 2 && ((pattern[0] >= 'a' && pattern[0] <= 'z') || (pattern[0] >= 'A' && pattern[0] <= 'Z')) && pattern[1] == ':'
+}
+
+func hashFilePatternMatch(patterns []hashFilePattern, name string, caseInsensitive bool) (bool, error) {
+	matched := false
+	for _, pattern := range patterns {
+		candidatePattern, candidateName := pattern.pattern, name
+		if caseInsensitive {
+			candidatePattern, candidateName = strings.ToLower(candidatePattern), strings.ToLower(candidateName)
+		}
+		patternMatched := false
+		for candidate := candidateName; candidate != "."; candidate = path.Dir(candidate) {
+			patternMatched, _ = doublestar.Match(candidatePattern, candidate)
+			if patternMatched && pattern.directoryOnly {
+				directory := pattern.directory
+				if caseInsensitive {
+					directory = strings.ToLower(directory)
+				}
+				patternMatched, _ = doublestar.Match(directory, candidate)
+				patternMatched = !patternMatched
+			}
+			if patternMatched {
+				break
+			}
+			if pattern.directoryOnly {
+				break
+			}
+		}
+		if patternMatched {
+			matched = !pattern.negative
+		}
+	}
+	return matched, nil
+}
+
+func escapeHashFileBraces(pattern string) string {
+	var escaped strings.Builder
+	for i, r := range pattern {
+		if (r == '{' || r == '}') && (i == 0 || pattern[i-1] != '\\') {
+			escaped.WriteByte('\\')
+		}
+		escaped.WriteRune(r)
+	}
+	return escaped.String()
+}

--- a/internal/runtime/hash_files.go
+++ b/internal/runtime/hash_files.go
@@ -176,7 +176,7 @@ func hashWorkspaceFile(ctx context.Context, root *os.Root, directoryInfo fs.File
 	if limits.beforeOpen != nil {
 		limits.beforeOpen(name)
 	}
-	file, err := directory.Open(base)
+	file, err := openHashFile(directory, base)
 	if err != nil {
 		return nil, 0, fmt.Errorf("open hashFiles match %q: %w", name, err)
 	}

--- a/internal/runtime/hash_files.go
+++ b/internal/runtime/hash_files.go
@@ -74,20 +74,9 @@ func hashWorkspaceRootFilesWithLimits(ctx context.Context, root *os.Root, source
 		return "", err
 	}
 	var selected []string
-	entries := 0
-	err = fs.WalkDir(root.FS(), ".", func(name string, entry fs.DirEntry, walkErr error) error {
+	err = walkHashFilesRoot(ctx, root, limits.entries, func(name string, entry fs.DirEntry) error {
 		if err := ctx.Err(); err != nil {
 			return err
-		}
-		if walkErr != nil {
-			return fmt.Errorf("walk hashFiles workspace at %q: %w", name, walkErr)
-		}
-		if name == "." {
-			return nil
-		}
-		entries++
-		if entries > limits.entries {
-			return fmt.Errorf("hashFiles workspace has more than %d entries", limits.entries)
 		}
 		matched, err := hashFilePatternMatch(patterns, name, caseInsensitive)
 		if err != nil {
@@ -181,6 +170,58 @@ func hashWorkspaceRootFilesWithLimits(ctx context.Context, root *os.Root, source
 		_, _ = combined.Write(fileHash.Sum(nil))
 	}
 	return hex.EncodeToString(combined.Sum(nil)), nil
+}
+
+func walkHashFilesRoot(ctx context.Context, root *os.Root, limit int, visit func(string, fs.DirEntry) error) error {
+	const readBatch = 256
+	entriesRead := 0
+	var walk func(string) error
+	walk = func(directory string) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		handle, err := root.Open(directory)
+		if err != nil {
+			return fmt.Errorf("open hashFiles directory %q: %w", directory, err)
+		}
+		var entries []fs.DirEntry
+		for {
+			batch, readErr := handle.ReadDir(readBatch)
+			for _, entry := range batch {
+				entriesRead++
+				if entriesRead > limit {
+					return errors.Join(fmt.Errorf("hashFiles workspace has more than %d entries", limit), handle.Close())
+				}
+				entries = append(entries, entry)
+			}
+			if readErr == io.EOF {
+				break
+			}
+			if readErr != nil {
+				return errors.Join(fmt.Errorf("read hashFiles directory %q: %w", directory, readErr), handle.Close())
+			}
+			if err := ctx.Err(); err != nil {
+				return errors.Join(err, handle.Close())
+			}
+		}
+		if err := handle.Close(); err != nil {
+			return fmt.Errorf("close hashFiles directory %q: %w", directory, err)
+		}
+		sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+		for _, entry := range entries {
+			name := path.Join(directory, entry.Name())
+			if err := visit(name, entry); err != nil {
+				return err
+			}
+			if entry.IsDir() {
+				if err := walk(name); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+	return walk(".")
 }
 
 func copyHashFile(ctx context.Context, destination io.Writer, source io.Reader) (int64, error) {

--- a/internal/runtime/hash_files.go
+++ b/internal/runtime/hash_files.go
@@ -36,6 +36,7 @@ type hashFilesLimits struct {
 	entries             int
 	beforeOpen          func(string)
 	beforeDirectoryOpen func(string)
+	afterFileHash       func(string)
 }
 
 var defaultHashFilesLimits = hashFilesLimits{
@@ -130,49 +131,15 @@ func hashWorkspaceRootFilesWithLimits(ctx context.Context, root *os.Root, source
 		if err := verifyHashFileDirectories(root, directories, name); err != nil {
 			return "", err
 		}
-		before, err := root.Lstat(name)
+		fileDigest, read, err := hashWorkspaceFile(ctx, root, directories[path.Dir(name)], name, limits, total)
 		if err != nil {
-			return "", fmt.Errorf("inspect hashFiles match %q: %w", name, err)
-		}
-		if before.Mode()&os.ModeSymlink != 0 {
-			return "", fmt.Errorf("hashFiles matched symlink %q; symlinks are unsupported", name)
-		}
-		if !before.Mode().IsRegular() {
-			return "", fmt.Errorf("hashFiles matched non-regular file %q", name)
-		}
-		if before.Size() < 0 || before.Size() > limits.bytes-total {
-			return "", fmt.Errorf("hashFiles selected bytes exceed %d", limits.bytes)
-		}
-		if limits.beforeOpen != nil {
-			limits.beforeOpen(name)
-		}
-		file, err := root.Open(name)
-		if err != nil {
-			return "", fmt.Errorf("open hashFiles match %q: %w", name, err)
-		}
-		opened, err := file.Stat()
-		if err != nil || !opened.Mode().IsRegular() || !os.SameFile(before, opened) {
-			_ = file.Close()
-			return "", fmt.Errorf("hashFiles match %q changed before hashing", name)
-		}
-		fileHash := sha256.New()
-		read, copyErr := copyHashFile(ctx, fileHash, io.LimitReader(file, limits.bytes-total+1))
-		closeErr := file.Close()
-		if copyErr != nil {
-			return "", fmt.Errorf("hash hashFiles match %q: %w", name, copyErr)
-		}
-		if closeErr != nil {
-			return "", fmt.Errorf("close hashFiles match %q: %w", name, closeErr)
-		}
-		if read > limits.bytes-total {
-			return "", fmt.Errorf("hashFiles selected bytes exceed %d", limits.bytes)
-		}
-		after, err := root.Lstat(name)
-		if err != nil || !os.SameFile(before, after) || read != before.Size() || after.Size() != before.Size() || !after.ModTime().Equal(before.ModTime()) {
-			return "", fmt.Errorf("hashFiles match %q changed while hashing", name)
+			return "", err
 		}
 		total += read
-		_, _ = combined.Write(fileHash.Sum(nil))
+		_, _ = combined.Write(fileDigest)
+		if limits.afterFileHash != nil {
+			limits.afterFileHash(name)
+		}
 	}
 	if err := verifyHashFileDirectories(root, directories, ""); err != nil {
 		return "", err
@@ -180,30 +147,82 @@ func hashWorkspaceRootFilesWithLimits(ctx context.Context, root *os.Root, source
 	return hex.EncodeToString(combined.Sum(nil)), nil
 }
 
+func hashWorkspaceFile(ctx context.Context, root *os.Root, directoryInfo fs.FileInfo, name string, limits hashFilesLimits, total int64) (digest []byte, read int64, retErr error) {
+	directoryName := path.Dir(name)
+	directory, err := root.OpenRoot(directoryName)
+	if err != nil {
+		return nil, 0, fmt.Errorf("open hashFiles directory %q: %w", directoryName, err)
+	}
+	defer func() { retErr = errors.Join(retErr, directory.Close()) }()
+	openedDirectory, err := directory.Lstat(".")
+	if err != nil || !sameHashFileInfo(directoryInfo, openedDirectory) {
+		return nil, 0, fmt.Errorf("hashFiles directory %q changed before hashing", directoryName)
+	}
+
+	base := path.Base(name)
+	before, err := directory.Lstat(base)
+	if err != nil {
+		return nil, 0, fmt.Errorf("inspect hashFiles match %q: %w", name, err)
+	}
+	if before.Mode()&os.ModeSymlink != 0 {
+		return nil, 0, fmt.Errorf("hashFiles matched symlink %q; symlinks are unsupported", name)
+	}
+	if !before.Mode().IsRegular() {
+		return nil, 0, fmt.Errorf("hashFiles matched non-regular file %q", name)
+	}
+	if before.Size() < 0 || before.Size() > limits.bytes-total {
+		return nil, 0, fmt.Errorf("hashFiles selected bytes exceed %d", limits.bytes)
+	}
+	if limits.beforeOpen != nil {
+		limits.beforeOpen(name)
+	}
+	file, err := directory.Open(base)
+	if err != nil {
+		return nil, 0, fmt.Errorf("open hashFiles match %q: %w", name, err)
+	}
+	opened, err := file.Stat()
+	if err != nil || !opened.Mode().IsRegular() || !os.SameFile(before, opened) {
+		_ = file.Close()
+		return nil, 0, fmt.Errorf("hashFiles match %q changed before hashing", name)
+	}
+	fileHash := sha256.New()
+	read, copyErr := copyHashFile(ctx, fileHash, io.LimitReader(file, limits.bytes-total+1))
+	closeErr := file.Close()
+	if copyErr != nil {
+		return nil, 0, fmt.Errorf("hash hashFiles match %q: %w", name, copyErr)
+	}
+	if closeErr != nil {
+		return nil, 0, fmt.Errorf("close hashFiles match %q: %w", name, closeErr)
+	}
+	if read > limits.bytes-total {
+		return nil, 0, fmt.Errorf("hashFiles selected bytes exceed %d", limits.bytes)
+	}
+	after, err := directory.Lstat(base)
+	if err != nil || !os.SameFile(before, after) || read != before.Size() || after.Size() != before.Size() || !after.ModTime().Equal(before.ModTime()) {
+		return nil, 0, fmt.Errorf("hashFiles match %q changed while hashing", name)
+	}
+	return fileHash.Sum(nil), read, nil
+}
+
 func walkHashFilesRoot(ctx context.Context, root *os.Root, limit int, beforeOpen func(string), directories map[string]fs.FileInfo, visit func(string, fs.DirEntry) error) error {
 	const readBatch = 256
 	entriesRead := 0
-	var walk func(string) error
-	walk = func(directory string) error {
+	rootInfo, err := root.Lstat(".")
+	if err != nil {
+		return fmt.Errorf("inspect hashFiles workspace: %w", err)
+	}
+	directories["."] = rootInfo
+	var walk func(string, *os.Root, fs.FileInfo) error
+	walk = func(directory string, current *os.Root, currentInfo fs.FileInfo) error {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		before, err := root.Lstat(directory)
-		if err != nil {
-			return fmt.Errorf("inspect hashFiles directory %q: %w", directory, err)
-		}
-		if before.Mode()&os.ModeSymlink != 0 || !before.IsDir() {
-			return fmt.Errorf("hashFiles directory %q changed before traversal", directory)
-		}
-		if beforeOpen != nil {
-			beforeOpen(directory)
-		}
-		handle, err := root.Open(directory)
+		handle, err := current.Open(".")
 		if err != nil {
 			return fmt.Errorf("open hashFiles directory %q: %w", directory, err)
 		}
 		opened, err := handle.Stat()
-		if err != nil || !opened.IsDir() || !os.SameFile(before, opened) {
+		if err != nil || !opened.IsDir() || !os.SameFile(currentInfo, opened) {
 			_ = handle.Close()
 			return fmt.Errorf("hashFiles directory %q changed before traversal", directory)
 		}
@@ -230,11 +249,10 @@ func walkHashFilesRoot(ctx context.Context, root *os.Root, limit int, beforeOpen
 		if err := handle.Close(); err != nil {
 			return fmt.Errorf("close hashFiles directory %q: %w", directory, err)
 		}
-		after, err := root.Lstat(directory)
-		if err != nil || !sameHashFileInfo(before, after) {
+		after, err := current.Lstat(".")
+		if err != nil || !sameHashFileInfo(currentInfo, after) {
 			return fmt.Errorf("hashFiles directory %q changed during traversal", directory)
 		}
-		directories[directory] = before
 		sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
 		for _, entry := range entries {
 			name := path.Join(directory, entry.Name())
@@ -242,14 +260,32 @@ func walkHashFilesRoot(ctx context.Context, root *os.Root, limit int, beforeOpen
 				return err
 			}
 			if entry.IsDir() {
-				if err := walk(name); err != nil {
-					return err
+				before, err := current.Lstat(entry.Name())
+				if err != nil || before.Mode()&os.ModeSymlink != 0 || !before.IsDir() {
+					return fmt.Errorf("hashFiles directory %q changed before traversal", name)
+				}
+				if beforeOpen != nil {
+					beforeOpen(name)
+				}
+				childRoot, err := current.OpenRoot(entry.Name())
+				if err != nil {
+					return fmt.Errorf("open hashFiles directory %q: %w", name, err)
+				}
+				opened, err := childRoot.Lstat(".")
+				if err != nil || !opened.IsDir() || !os.SameFile(before, opened) {
+					_ = childRoot.Close()
+					return fmt.Errorf("hashFiles directory %q changed before traversal", name)
+				}
+				directories[name] = before
+				walkErr := walk(name, childRoot, before)
+				if closeErr := childRoot.Close(); walkErr != nil || closeErr != nil {
+					return errors.Join(walkErr, closeErr)
 				}
 			}
 		}
 		return nil
 	}
-	return walk(".")
+	return walk(".", root, rootInfo)
 }
 
 func verifyHashFileDirectories(root *os.Root, directories map[string]fs.FileInfo, name string) error {

--- a/internal/runtime/hash_files.go
+++ b/internal/runtime/hash_files.go
@@ -314,7 +314,7 @@ func verifyHashFileDirectories(root *os.Root, directories map[string]fs.FileInfo
 }
 
 func sameHashFileInfo(before, after fs.FileInfo) bool {
-	return after != nil && os.SameFile(before, after) && before.Mode() == after.Mode() && before.Size() == after.Size() && before.ModTime().Equal(after.ModTime())
+	return after != nil && after.IsDir() && os.SameFile(before, after) && before.Mode() == after.Mode()
 }
 
 func copyHashFile(ctx context.Context, destination io.Writer, source io.Reader) (int64, error) {

--- a/internal/runtime/hash_files_open_other.go
+++ b/internal/runtime/hash_files_open_other.go
@@ -1,0 +1,9 @@
+//go:build !linux && !darwin
+
+package runtime
+
+import "os"
+
+func openHashFile(directory *os.Root, name string) (*os.File, error) {
+	return directory.Open(name)
+}

--- a/internal/runtime/hash_files_open_unix.go
+++ b/internal/runtime/hash_files_open_unix.go
@@ -1,0 +1,13 @@
+//go:build linux || darwin
+
+package runtime
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func openHashFile(directory *os.Root, name string) (*os.File, error) {
+	return directory.OpenFile(name, os.O_RDONLY|unix.O_NONBLOCK, 0)
+}

--- a/internal/runtime/hash_files_test.go
+++ b/internal/runtime/hash_files_test.go
@@ -437,6 +437,38 @@ func TestHashFilesStepConditionFailureRunsFailureCleanup(t *testing.T) {
 	}
 }
 
+func TestHashFilesRemotePreFailureUsesStepConclusion(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: hashFiles remote pre failure\n")
+	writeFixtureFile(t, workspace, "target", "value")
+	if err := os.Symlink("target", filepath.Join(workspace, "link")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	remote := t.TempDir()
+	writeFixtureFile(t, remote, "action/action.yml", "name: pre failure\nruns:\n  using: node24\n  pre: pre.js\n  main: main.js\n")
+	writeFixtureFile(t, remote, "action/pre.js", "")
+	writeFixtureFile(t, remote, "action/main.js", "")
+	digest := digestTree(t, remote)
+	lockID := remoteLifecycleLockID(1)
+	marker := filepath.Join(workspace, "continued")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{
+		{ID: "invalid", Kind: "uses", Uses: remoteLifecycleUses("action"), Action: &plan.ActionSelector{Lock: lockID}, ContinueOnError: true, Env: map[string]string{"HASH": "${{ hashFiles('link') }}"}},
+		{ID: "after", Kind: "run", Shell: "sh", Condition: "steps.invalid.outcome == 'failure' && steps.invalid.conclusion == 'success'", Command: "touch " + marker},
+	})
+	job.Schema = plan.SchemaV3
+	job.RequiredCapabilities = []string{"network"}
+	job.Actions = []plan.ActionLock{remoteLifecycleLock(lockID, "action", digest, nil)}
+	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}
+	result, err := (Runner{Actions: materializer}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("later step did not run: %v", err)
+	}
+}
+
 func TestHashFilesInterpolationUsesStepTimeoutContext(t *testing.T) {
 	for _, test := range []struct {
 		name      string

--- a/internal/runtime/hash_files_test.go
+++ b/internal/runtime/hash_files_test.go
@@ -372,6 +372,29 @@ func TestHashWorkspaceFilesFinalVerificationObservesCancellation(t *testing.T) {
 	}
 }
 
+func TestHashWorkspaceFilesRejectsFIFORacedIntoMatch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("FIFOs are unavailable on Windows")
+	}
+	workspace := t.TempDir()
+	writeFixtureFile(t, workspace, "value", "value")
+	limits := defaultHashFilesLimits
+	limits.beforeOpen = func(name string) {
+		file := filepath.Join(workspace, name)
+		if err := os.Remove(file); err != nil {
+			t.Fatal(err)
+		}
+		if err := unix.Mkfifo(file, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if _, err := hashWorkspaceFilesWithLimits(ctx, workspace, []string{"value"}, limits, false); err == nil || !strings.Contains(err.Error(), "changed before hashing") {
+		t.Fatalf("FIFO race error = %v", err)
+	}
+}
+
 func TestHashFilesInterpolationUsesStepTimeoutContext(t *testing.T) {
 	for _, test := range []struct {
 		name      string

--- a/internal/runtime/hash_files_test.go
+++ b/internal/runtime/hash_files_test.go
@@ -361,6 +361,17 @@ func TestHashWorkspaceFilesOpensMatchesThroughPinnedDirectories(t *testing.T) {
 	}
 }
 
+func TestHashWorkspaceFilesFinalVerificationObservesCancellation(t *testing.T) {
+	workspace := t.TempDir()
+	writeFixtureFile(t, workspace, "nested/value", "value")
+	ctx, cancel := context.WithCancel(context.Background())
+	limits := defaultHashFilesLimits
+	limits.afterFileHash = func(string) { cancel() }
+	if _, err := hashWorkspaceFilesWithLimits(ctx, workspace, []string{"nested/value"}, limits, false); !errors.Is(err, context.Canceled) {
+		t.Fatalf("hashWorkspaceFilesWithLimits() error = %v, want context cancellation", err)
+	}
+}
+
 func TestHashFilesInterpolationUsesStepTimeoutContext(t *testing.T) {
 	for _, test := range []struct {
 		name      string

--- a/internal/runtime/hash_files_test.go
+++ b/internal/runtime/hash_files_test.go
@@ -189,6 +189,25 @@ func TestRunJobPinsHashWorkspaceBeforePathReplacement(t *testing.T) {
 	}
 }
 
+func TestRunJobHashFilesArgumentsUseStepEnvironment(t *testing.T) {
+	workspace := t.TempDir()
+	writeFixtureFile(t, workspace, ".github/workflows/test.yml", "name: hashFiles step environment\n")
+	writeFixtureFile(t, workspace, "value", "contents")
+	digest := githubHash("contents")
+	job := runtimePlan(t, workspace, ".github/workflows/test.yml", []plan.Step{{
+		ID:        "hash",
+		Kind:      "run",
+		Shell:     "sh",
+		Env:       map[string]string{"PATTERN": "value"},
+		Condition: "hashFiles(env.PATTERN) != ''",
+		Command:   `test "${{ hashFiles(env.PATTERN) }}" = "` + digest + `"`,
+	}})
+	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() step environment hashFiles result = %#v, %v", result, err)
+	}
+}
+
 func TestHashFilesRemainsUnavailableOutsideWorkflowStepFields(t *testing.T) {
 	workspace := t.TempDir()
 	writeFixtureFile(t, workspace, ".github/workflows/test.yml", "name: hashFiles surfaces\n")
@@ -278,7 +297,7 @@ func TestHashFilesInterpolationUsesStepTimeoutContext(t *testing.T) {
 	execution := (Runner{}).executePlanStep(
 		context.Background(), context.Background(), nil, "", plan.Job{},
 		plan.Step{ID: "hash", Kind: "run", TimeoutMinutes: 0.001, Env: map[string]string{"HASH": "${{ hashFiles('value') }}"}},
-		"0", nil, eval, nil, nil, nil,
+		"0", nil, nil, eval, nil, nil, nil,
 	)
 	if !called || !errors.Is(execution.err, context.DeadlineExceeded) {
 		t.Fatalf("step timeout hashFiles execution = %#v", execution)

--- a/internal/runtime/hash_files_test.go
+++ b/internal/runtime/hash_files_test.go
@@ -301,6 +301,29 @@ func TestHashWorkspaceFilesDetectsMutationAndCancellation(t *testing.T) {
 	}
 }
 
+func TestHashWorkspaceFilesDetectsDirectoryReplacementBeforeTraversal(t *testing.T) {
+	workspace := t.TempDir()
+	writeFixtureFile(t, workspace, "nested/value", "original")
+	writeFixtureFile(t, workspace, "target/value", "replacement")
+	limits := defaultHashFilesLimits
+	replaced := false
+	limits.beforeDirectoryOpen = func(name string) {
+		if name != "nested" || replaced {
+			return
+		}
+		replaced = true
+		if err := os.Rename(filepath.Join(workspace, "nested"), filepath.Join(workspace, "moved")); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink("target", filepath.Join(workspace, "nested")); err != nil {
+			t.Skipf("symlinks unavailable: %v", err)
+		}
+	}
+	if _, err := hashWorkspaceFilesWithLimits(context.Background(), workspace, []string{"nested/**"}, limits, false); err == nil || !strings.Contains(err.Error(), "changed before traversal") {
+		t.Fatalf("directory replacement error = %v", err)
+	}
+}
+
 func TestHashFilesInterpolationUsesStepTimeoutContext(t *testing.T) {
 	for _, test := range []struct {
 		name      string

--- a/internal/runtime/hash_files_test.go
+++ b/internal/runtime/hash_files_test.go
@@ -437,6 +437,36 @@ func TestHashFilesStepConditionFailureRunsFailureCleanup(t *testing.T) {
 	}
 }
 
+func TestHashFilesSkippedStepsDoNotAccessWorkspace(t *testing.T) {
+	workspace := t.TempDir()
+	writeFixtureFile(t, workspace, ".github/workflows/test.yml", "name: skipped hashFiles\n")
+	writeFixtureFile(t, workspace, "target", "value")
+	if err := os.Symlink("target", filepath.Join(workspace, "link")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	envMarker := filepath.Join(workspace, "env-ran")
+	conditionMarker := filepath.Join(workspace, "condition-ran")
+	cleanupMarker := filepath.Join(workspace, "cleaned")
+	job := runtimePlan(t, workspace, ".github/workflows/test.yml", []plan.Step{
+		{ID: "fails", Kind: "run", Shell: "sh", Command: "exit 1"},
+		{ID: "env", Kind: "run", Shell: "sh", Env: map[string]string{"HASH": "${{ hashFiles('link') }}"}, Command: "touch " + envMarker},
+		{ID: "condition", Kind: "run", Shell: "sh", Condition: "hashFiles('link') != ''", Command: "touch " + conditionMarker},
+		{ID: "cleanup", Kind: "run", Shell: "sh", Condition: "always()", Command: "touch " + cleanupMarker},
+	})
+	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	if err == nil || result.Conclusion != "failure" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	for _, marker := range []string{envMarker, conditionMarker} {
+		if _, statErr := os.Stat(marker); !errors.Is(statErr, os.ErrNotExist) {
+			t.Fatalf("skipped step marker %q stat error = %v", marker, statErr)
+		}
+	}
+	if _, err := os.Stat(cleanupMarker); err != nil {
+		t.Fatalf("cleanup did not run: %v", err)
+	}
+}
+
 func TestHashFilesRemotePreFailureUsesStepConclusion(t *testing.T) {
 	workspace := t.TempDir()
 	workflowPath := ".github/workflows/test.yml"

--- a/internal/runtime/hash_files_test.go
+++ b/internal/runtime/hash_files_test.go
@@ -1,0 +1,316 @@
+package runtime
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/buildkite-gha/internal/expression"
+	"github.com/buildkite/buildkite-gha/internal/plan"
+	"golang.org/x/sys/unix"
+)
+
+func TestHashWorkspaceFilesConformance(t *testing.T) {
+	workspace := t.TempDir()
+	writeFixtureFile(t, workspace, "a.txt", "alpha")
+	writeFixtureFile(t, workspace, "b.txt", "bravo")
+	writeFixtureFile(t, workspace, "nested/c.txt", "charlie")
+	writeFixtureFile(t, workspace, "nested/skip.txt", "skip")
+	writeFixtureFile(t, workspace, ".hidden", "hidden")
+	writeFixtureFile(t, workspace, ".config/value", "dot-directory")
+	writeFixtureFile(t, workspace, "literal/{name}.txt", "braces")
+
+	for _, test := range []struct {
+		name     string
+		patterns []string
+		contents []string
+	}{
+		{name: "known digest and stable order", patterns: []string{"*.txt"}, contents: []string{"alpha", "bravo"}},
+		{name: "multiple patterns", patterns: []string{"a.txt", "nested/*.txt"}, contents: []string{"alpha", "charlie", "skip"}},
+		{name: "ordered negation", patterns: []string{"**", "!nested/**"}, contents: []string{"dot-directory", "hidden", "alpha", "bravo", "braces"}},
+		{name: "ordered re-inclusion", patterns: []string{"**", "!nested/**", "nested/c.txt"}, contents: []string{"dot-directory", "hidden", "alpha", "bravo", "braces", "charlie"}},
+		{name: "later exclusion", patterns: []string{"nested/c.txt", "!nested/**"}},
+		{name: "duplicate overlap", patterns: []string{"a.txt", "*.txt", "a.txt"}, contents: []string{"alpha", "bravo"}},
+		{name: "empty matches", patterns: []string{"missing/**"}},
+		{name: "hidden files and nested paths", patterns: []string{"**/.hidden", ".config"}, contents: []string{"dot-directory", "hidden"}},
+		{name: "directory implies descendants", patterns: []string{"nested"}, contents: []string{"charlie", "skip"}},
+		{name: "trailing slash directory", patterns: []string{"nested/"}, contents: []string{"charlie", "skip"}},
+		{name: "braces are literal", patterns: []string{"literal/{name}.txt"}, contents: []string{"braces"}},
+		{name: "comments and blank patterns", patterns: []string{" # ignored", "", "a.txt"}, contents: []string{"alpha"}},
+		{name: "workspace root", patterns: []string{"."}, contents: []string{"dot-directory", "hidden", "alpha", "bravo", "braces", "charlie", "skip"}},
+		{name: "spaced negation", patterns: []string{"**", "! nested/**"}, contents: []string{"dot-directory", "hidden", "alpha", "bravo", "braces"}},
+		{name: "spaced double negation", patterns: []string{"!! nested/c.txt"}, contents: []string{"charlie"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := hashWorkspaceFiles(context.Background(), workspace, test.patterns)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := githubHash(test.contents...)
+			if test.name == "known digest and stable order" {
+				want = "90d39555bb3c223e12f5a375c3011d2462fe2e1e36b8416a0b623d5831a9b4f3"
+			}
+			if got != want {
+				t.Fatalf("hashWorkspaceFiles(%#v) = %q, want %q", test.patterns, got, want)
+			}
+		})
+	}
+
+	first, err := hashWorkspaceFiles(context.Background(), workspace, []string{"**"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range 5 {
+		got, err := hashWorkspaceFiles(context.Background(), workspace, []string{"**"})
+		if err != nil || got != first {
+			t.Fatalf("repeated hash = %q, %v; want %q", got, err, first)
+		}
+	}
+}
+
+func TestHashWorkspaceFilesDirectoryPatternDoesNotMatchRegularFile(t *testing.T) {
+	workspace := t.TempDir()
+	writeFixtureFile(t, workspace, "plain", "regular")
+	if got, err := hashWorkspaceFiles(context.Background(), workspace, []string{"plain/"}); err != nil || got != "" {
+		t.Fatalf("directory-only regular file hash = %q, %v", got, err)
+	}
+}
+
+func TestHashFilePatternPlatformCaseSensitivity(t *testing.T) {
+	patterns, err := parseHashFilePatterns([]string{"SRC/*.GO"}, defaultHashFilesLimits)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if matched, _ := hashFilePatternMatch(patterns, "src/main.go", false); matched {
+		t.Fatal("case-sensitive platform matched different case")
+	}
+	if matched, _ := hashFilePatternMatch(patterns, "src/main.go", true); !matched {
+		t.Fatal("case-insensitive platform did not match different case")
+	}
+}
+
+func TestHashWorkspaceFilesRejectsEscapesAndUnsafeFiles(t *testing.T) {
+	workspace := t.TempDir()
+	outside := t.TempDir()
+	writeFixtureFile(t, workspace, "safe.txt", "safe")
+	writeFixtureFile(t, outside, "outside.txt", "outside")
+	for _, pattern := range []string{"/etc/passwd", "../outside", "safe/../../outside", `C:\outside`, "./safe/../outside"} {
+		t.Run(pattern, func(t *testing.T) {
+			if _, err := hashWorkspaceFiles(context.Background(), workspace, []string{pattern}); err == nil || !strings.Contains(err.Error(), "hashFiles pattern") {
+				t.Fatalf("escape pattern error = %v", err)
+			}
+		})
+	}
+	for _, pattern := range []string{"safe\n", "safe\t", "safe\x1b", "safe\x7f"} {
+		if _, err := hashWorkspaceFiles(context.Background(), workspace, []string{pattern}); err == nil || !strings.Contains(err.Error(), "control character") {
+			t.Fatalf("control pattern error = %v", err)
+		}
+	}
+
+	for name, target := range map[string]string{
+		"inside-link": filepath.Join(workspace, "safe.txt"),
+		"escape-link": filepath.Join(outside, "outside.txt"),
+		"loop":        "loop",
+	} {
+		if err := os.Symlink(target, filepath.Join(workspace, name)); err != nil {
+			t.Skipf("symlinks unavailable: %v", err)
+		}
+		if _, err := hashWorkspaceFiles(context.Background(), workspace, []string{name}); err == nil || !strings.Contains(err.Error(), "symlink") {
+			t.Fatalf("%s error = %v", name, err)
+		}
+	}
+
+	if runtime.GOOS != "windows" {
+		fifo := filepath.Join(workspace, "pipe")
+		if err := unix.Mkfifo(fifo, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := hashWorkspaceFiles(context.Background(), workspace, []string{"pipe"}); err == nil || !strings.Contains(err.Error(), "non-regular") {
+			t.Fatalf("special file error = %v", err)
+		}
+	}
+}
+
+func TestHashWorkspaceRootRemainsPinnedAfterPathReplacement(t *testing.T) {
+	parent := t.TempDir()
+	workspace := filepath.Join(parent, "workspace")
+	outside := filepath.Join(parent, "outside")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFixtureFile(t, workspace, "value", "inside")
+	writeFixtureFile(t, outside, "value", "outside")
+	root, err := os.OpenRoot(workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := root.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	moved := filepath.Join(parent, "moved")
+	if err := os.Rename(workspace, moved); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, workspace); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	got, err := hashWorkspaceRootFilesWithLimits(context.Background(), root, []string{"value"}, defaultHashFilesLimits, false)
+	if err != nil || got != githubHash("inside") {
+		t.Fatalf("pinned workspace hash = %q, %v", got, err)
+	}
+}
+
+func TestRunJobPinsHashWorkspaceBeforePathReplacement(t *testing.T) {
+	parent := t.TempDir()
+	workspace := filepath.Join(parent, "workspace")
+	outside := filepath.Join(parent, "outside")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFixtureFile(t, workspace, ".github/workflows/test.yml", "name: pinned hash workspace\n")
+	writeFixtureFile(t, workspace, "value", "inside")
+	writeFixtureFile(t, outside, "value", "outside")
+	job := runtimePlan(t, workspace, ".github/workflows/test.yml", []plan.Step{
+		{ID: "replace", Kind: "run", Shell: "sh", Env: map[string]string{"OUTSIDE": outside}, Command: `mv "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE-moved" && ln -s "$OUTSIDE" "$GITHUB_WORKSPACE"`},
+		{ID: "hash", Kind: "run", Shell: "sh", Env: map[string]string{"VALUE_HASH": "${{ hashFiles('value') }}"}, Command: "test \"$VALUE_HASH\" = " + githubHash("inside")},
+	})
+	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() pinned workspace result = %#v, %v", result, err)
+	}
+}
+
+func TestHashFilesRemainsUnavailableOutsideWorkflowStepFields(t *testing.T) {
+	workspace := t.TempDir()
+	writeFixtureFile(t, workspace, ".github/workflows/test.yml", "name: hashFiles surfaces\n")
+	writeFixtureFile(t, workspace, "value", "contents")
+	for _, test := range []struct {
+		name   string
+		change func(*plan.Job)
+	}{
+		{name: "job default shell", change: func(job *plan.Job) { job.DefaultShell = "${{ hashFiles('value') }}" }},
+		{name: "job default working directory", change: func(job *plan.Job) { job.DefaultWorkingDirectory = "${{ hashFiles('value') }}" }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			job := runtimePlan(t, workspace, ".github/workflows/test.yml", []plan.Step{{ID: "run", Kind: "run", Command: "true"}})
+			test.change(&job)
+			if _, err := (Runner{}).RunJob(context.Background(), job, workspace); err == nil || !strings.Contains(err.Error(), "unsupported expression reference") {
+				t.Fatalf("RunJob() default hashFiles error = %v", err)
+			}
+		})
+	}
+
+	job := runtimePlan(t, workspace, ".github/workflows/test.yml", []plan.Step{{ID: "name", Name: "${{ hashFiles('value') }}", Kind: "run", Shell: "sh", Command: "true"}})
+	if result, err := (Runner{}).RunJob(context.Background(), job, workspace); err != nil || result.Conclusion != "success" {
+		t.Fatalf("step name unexpectedly evaluated hashFiles: %#v, %v", result, err)
+	}
+
+	writeFixtureFile(t, workspace, ".github/actions/composite/action.yml", "runs:\n  using: composite\n  steps:\n    - shell: sh\n      run: echo \"${{ hashFiles('value') }}\"\n")
+	job = runtimePlan(t, workspace, ".github/workflows/test.yml", []plan.Step{{ID: "composite", Kind: "uses", Uses: "./.github/actions/composite"}})
+	if _, err := (Runner{}).RunJob(context.Background(), job, workspace); err == nil || !strings.Contains(err.Error(), "unsupported expression reference") {
+		t.Fatalf("composite metadata hashFiles error = %v", err)
+	}
+}
+
+func TestHashWorkspaceFilesEnforcesEveryBound(t *testing.T) {
+	workspace := t.TempDir()
+	writeFixtureFile(t, workspace, "one", "1")
+	writeFixtureFile(t, workspace, "two", "22")
+	base := hashFilesLimits{patterns: 10, patternBytes: 20, totalPatternBytes: 40, matches: 10, bytes: 10, entries: 10}
+	for _, test := range []struct {
+		name     string
+		patterns []string
+		limits   hashFilesLimits
+		want     string
+	}{
+		{name: "pattern count", patterns: []string{"one", "two"}, limits: withHashLimits(base, func(l *hashFilesLimits) { l.patterns = 1 }), want: "1 to 1 patterns"},
+		{name: "pattern length", patterns: []string{"one"}, limits: withHashLimits(base, func(l *hashFilesLimits) { l.patternBytes = 2 }), want: "exceeds 2 bytes"},
+		{name: "total pattern length", patterns: []string{"one", "two"}, limits: withHashLimits(base, func(l *hashFilesLimits) { l.totalPatternBytes = 5 }), want: "exceed 5 total bytes"},
+		{name: "matched files", patterns: []string{"*"}, limits: withHashLimits(base, func(l *hashFilesLimits) { l.matches = 1 }), want: "more than 1 files"},
+		{name: "hashed bytes", patterns: []string{"*"}, limits: withHashLimits(base, func(l *hashFilesLimits) { l.bytes = 2 }), want: "selected bytes exceed 2"},
+		{name: "workspace entries", patterns: []string{"missing"}, limits: withHashLimits(base, func(l *hashFilesLimits) { l.entries = 1 }), want: "more than 1 entries"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := hashWorkspaceFilesWithLimits(context.Background(), workspace, test.patterns, test.limits, false)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("bound error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestHashWorkspaceFilesDetectsMutationAndCancellation(t *testing.T) {
+	workspace := t.TempDir()
+	writeFixtureFile(t, workspace, "mutable", "before")
+	limits := defaultHashFilesLimits
+	limits.beforeOpen = func(string) {
+		if err := os.WriteFile(filepath.Join(workspace, "mutable"), []byte("after mutation"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := hashWorkspaceFilesWithLimits(context.Background(), workspace, []string{"mutable"}, limits, false); err == nil || !strings.Contains(err.Error(), "changed") {
+		t.Fatalf("mutation error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := hashWorkspaceFiles(ctx, workspace, []string{"mutable"}); err == nil {
+		t.Fatal("cancelled hashFiles succeeded")
+	}
+}
+
+func TestHashFilesInterpolationUsesStepTimeoutContext(t *testing.T) {
+	called := false
+	eval := expression.Context{HashFilesContext: func(ctx context.Context, _ []string) (string, error) {
+		called = true
+		<-ctx.Done()
+		return "", ctx.Err()
+	}}
+	execution := (Runner{}).executePlanStep(
+		context.Background(), context.Background(), nil, "", plan.Job{},
+		plan.Step{ID: "hash", Kind: "run", TimeoutMinutes: 0.001, Env: map[string]string{"HASH": "${{ hashFiles('value') }}"}},
+		"0", nil, eval, nil, nil, nil,
+	)
+	if !called || !errors.Is(execution.err, context.DeadlineExceeded) {
+		t.Fatalf("step timeout hashFiles execution = %#v", execution)
+	}
+}
+
+func githubHash(contents ...string) string {
+	if len(contents) == 0 {
+		return ""
+	}
+	combined := sha256.New()
+	for _, content := range contents {
+		digest := sha256.Sum256([]byte(content))
+		_, _ = combined.Write(digest[:])
+	}
+	return hex.EncodeToString(combined.Sum(nil))
+}
+
+func withHashLimits(base hashFilesLimits, update func(*hashFilesLimits)) hashFilesLimits {
+	copy := base
+	update(&copy)
+	return copy
+}
+
+func TestGitHubHashTestHelperUsesBinaryDigests(t *testing.T) {
+	first, second := sha256.Sum256([]byte("a")), sha256.Sum256([]byte("b"))
+	joined := append(append([]byte(nil), first[:]...), second[:]...)
+	want := sha256.Sum256(joined)
+	if got := githubHash("a", "b"); got != hex.EncodeToString(want[:]) {
+		t.Fatalf("githubHash() = %q", got)
+	}
+	if reflect.DeepEqual(first[:], []byte(hex.EncodeToString(first[:]))) {
+		t.Fatal("test helper unexpectedly hashes hexadecimal digests")
+	}
+}

--- a/internal/runtime/hash_files_test.go
+++ b/internal/runtime/hash_files_test.go
@@ -395,6 +395,27 @@ func TestHashWorkspaceFilesRejectsFIFORacedIntoMatch(t *testing.T) {
 	}
 }
 
+func TestHashFilesStepEnvironmentFailureUsesStepConclusion(t *testing.T) {
+	workspace := t.TempDir()
+	writeFixtureFile(t, workspace, ".github/workflows/test.yml", "name: hashFiles environment failure\n")
+	writeFixtureFile(t, workspace, "target", "value")
+	if err := os.Symlink("target", filepath.Join(workspace, "link")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	marker := filepath.Join(workspace, "continued")
+	job := runtimePlan(t, workspace, ".github/workflows/test.yml", []plan.Step{
+		{ID: "invalid", Kind: "run", Shell: "sh", ContinueOnError: true, Env: map[string]string{"HASH": "${{ hashFiles('link') }}"}, Command: "exit 99"},
+		{ID: "after", Kind: "run", Shell: "sh", Condition: "steps.invalid.outcome == 'failure' && steps.invalid.conclusion == 'success'", Command: "touch " + marker},
+	})
+	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("later step did not run: %v", err)
+	}
+}
+
 func TestHashFilesInterpolationUsesStepTimeoutContext(t *testing.T) {
 	for _, test := range []struct {
 		name      string

--- a/internal/runtime/hash_files_test.go
+++ b/internal/runtime/hash_files_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -13,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/buildkite/buildkite-gha/internal/action/source"
 	"github.com/buildkite/buildkite-gha/internal/plan"
 	"golang.org/x/sys/unix"
 )
@@ -267,6 +269,18 @@ func TestHashWorkspaceFilesEnforcesEveryBound(t *testing.T) {
 	}
 }
 
+func TestHashWorkspaceFilesBoundsSingleDirectoryEnumeration(t *testing.T) {
+	workspace := t.TempDir()
+	for i := range 300 {
+		writeFixtureFile(t, workspace, fmt.Sprintf("entry-%03d", i), "")
+	}
+	limits := defaultHashFilesLimits
+	limits.entries = 10
+	if _, err := hashWorkspaceFilesWithLimits(context.Background(), workspace, []string{"missing"}, limits, false); err == nil || !strings.Contains(err.Error(), "more than 10 entries") {
+		t.Fatalf("single-directory entry bound error = %v", err)
+	}
+}
+
 func TestHashWorkspaceFilesDetectsMutationAndCancellation(t *testing.T) {
 	workspace := t.TempDir()
 	writeFixtureFile(t, workspace, "mutable", "before")
@@ -329,6 +343,49 @@ func TestHashFilesInterpolationUsesStepTimeoutContext(t *testing.T) {
 				t.Fatalf("RunJob() took %s after step timeout", elapsed)
 			}
 		})
+	}
+}
+
+func TestHashFilesPrePhaseUsesStepTimeoutContext(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: hashFiles pre timeout\n")
+	file, err := os.Create(filepath.Join(workspace, "large"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Truncate(256 << 20); err != nil {
+		_ = file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	remote := t.TempDir()
+	writeFixtureFile(t, remote, "action/action.yml", "name: timeout\nruns:\n  using: node24\n  pre: pre.js\n  main: main.js\n")
+	writeFixtureFile(t, remote, "action/pre.js", "")
+	writeFixtureFile(t, remote, "action/main.js", "")
+	digest := digestTree(t, remote)
+	lockID := remoteLifecycleLockID(1)
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{
+		ID:             "hash",
+		Kind:           "uses",
+		Uses:           remoteLifecycleUses("action"),
+		Action:         &plan.ActionSelector{Lock: lockID},
+		TimeoutMinutes: 0.001,
+		Env:            map[string]string{"HASH": "${{ hashFiles('large') }}"},
+	}})
+	job.Schema = plan.SchemaV3
+	job.RequiredCapabilities = []string{"network"}
+	job.Actions = []plan.ActionLock{remoteLifecycleLock(lockID, "action", digest, nil)}
+	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}
+	started := time.Now()
+	_, err = (Runner{Actions: materializer}).RunJob(context.Background(), job, workspace)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("RunJob() pre timeout error = %v", err)
+	}
+	if elapsed := time.Since(started); elapsed > 2*time.Second {
+		t.Fatalf("RunJob() pre took %s after step timeout", elapsed)
 	}
 }
 

--- a/internal/runtime/hash_files_test.go
+++ b/internal/runtime/hash_files_test.go
@@ -11,8 +11,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
-	"github.com/buildkite/buildkite-gha/internal/expression"
 	"github.com/buildkite/buildkite-gha/internal/plan"
 	"golang.org/x/sys/unix"
 )
@@ -288,19 +288,47 @@ func TestHashWorkspaceFilesDetectsMutationAndCancellation(t *testing.T) {
 }
 
 func TestHashFilesInterpolationUsesStepTimeoutContext(t *testing.T) {
-	called := false
-	eval := expression.Context{HashFilesContext: func(ctx context.Context, _ []string) (string, error) {
-		called = true
-		<-ctx.Done()
-		return "", ctx.Err()
-	}}
-	execution := (Runner{}).executePlanStep(
-		context.Background(), context.Background(), nil, "", plan.Job{},
-		plan.Step{ID: "hash", Kind: "run", TimeoutMinutes: 0.001, Env: map[string]string{"HASH": "${{ hashFiles('value') }}"}},
-		"0", nil, nil, eval, nil, nil, nil,
-	)
-	if !called || !errors.Is(execution.err, context.DeadlineExceeded) {
-		t.Fatalf("step timeout hashFiles execution = %#v", execution)
+	for _, test := range []struct {
+		name      string
+		env       map[string]string
+		condition string
+	}{
+		{name: "environment", env: map[string]string{"HASH": "${{ hashFiles('large') }}"}},
+		{name: "condition", condition: "hashFiles('large') != ''"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			workspace := t.TempDir()
+			writeFixtureFile(t, workspace, ".github/workflows/test.yml", "name: hashFiles timeout\n")
+			large := filepath.Join(workspace, "large")
+			file, err := os.Create(large)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := file.Truncate(256 << 20); err != nil {
+				_ = file.Close()
+				t.Fatal(err)
+			}
+			if err := file.Close(); err != nil {
+				t.Fatal(err)
+			}
+			job := runtimePlan(t, workspace, ".github/workflows/test.yml", []plan.Step{{
+				ID:             "hash",
+				Kind:           "run",
+				Shell:          "sh",
+				TimeoutMinutes: 0.001,
+				Env:            test.env,
+				Condition:      test.condition,
+				Command:        "true",
+			}})
+			started := time.Now()
+			_, err = (Runner{}).RunJob(context.Background(), job, workspace)
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("RunJob() timeout error = %v", err)
+			}
+			if elapsed := time.Since(started); elapsed > 2*time.Second {
+				t.Fatalf("RunJob() took %s after step timeout", elapsed)
+			}
+		})
 	}
 }
 

--- a/internal/runtime/hash_files_test.go
+++ b/internal/runtime/hash_files_test.go
@@ -324,6 +324,43 @@ func TestHashWorkspaceFilesDetectsDirectoryReplacementBeforeTraversal(t *testing
 	}
 }
 
+func TestHashWorkspaceFilesOpensMatchesThroughPinnedDirectories(t *testing.T) {
+	workspace := t.TempDir()
+	writeFixtureFile(t, workspace, "nested/value", "original")
+	writeFixtureFile(t, workspace, "replacement/value", "replacement")
+	limits := defaultHashFilesLimits
+	limits.beforeOpen = func(name string) {
+		if name != "nested/value" {
+			return
+		}
+		if err := os.Rename(filepath.Join(workspace, "nested"), filepath.Join(workspace, "original")); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Rename(filepath.Join(workspace, "replacement"), filepath.Join(workspace, "nested")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	limits.afterFileHash = func(name string) {
+		if name != "nested/value" {
+			return
+		}
+		if err := os.Rename(filepath.Join(workspace, "nested"), filepath.Join(workspace, "replacement")); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Rename(filepath.Join(workspace, "original"), filepath.Join(workspace, "nested")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	digest, err := hashWorkspaceFilesWithLimits(context.Background(), workspace, []string{"nested/value"}, limits, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := githubHash("original")
+	if digest != want {
+		t.Fatalf("digest = %q, want original file digest %q", digest, want)
+	}
+}
+
 func TestHashFilesInterpolationUsesStepTimeoutContext(t *testing.T) {
 	for _, test := range []struct {
 		name      string

--- a/internal/runtime/hash_files_test.go
+++ b/internal/runtime/hash_files_test.go
@@ -416,6 +416,27 @@ func TestHashFilesStepEnvironmentFailureUsesStepConclusion(t *testing.T) {
 	}
 }
 
+func TestHashFilesStepConditionFailureRunsFailureCleanup(t *testing.T) {
+	workspace := t.TempDir()
+	writeFixtureFile(t, workspace, ".github/workflows/test.yml", "name: hashFiles condition failure\n")
+	writeFixtureFile(t, workspace, "target", "value")
+	if err := os.Symlink("target", filepath.Join(workspace, "link")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	marker := filepath.Join(workspace, "cleaned")
+	job := runtimePlan(t, workspace, ".github/workflows/test.yml", []plan.Step{
+		{ID: "invalid", Kind: "run", Shell: "sh", Condition: "hashFiles('link') != ''", Command: "exit 99"},
+		{ID: "cleanup", Kind: "run", Shell: "sh", Condition: "failure()", Command: "touch " + marker},
+	})
+	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	if err == nil || result.Conclusion != "failure" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("failure cleanup did not run: %v", err)
+	}
+}
+
 func TestHashFilesInterpolationUsesStepTimeoutContext(t *testing.T) {
 	for _, test := range []struct {
 		name      string

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -482,7 +482,11 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 				continue
 			}
 			preEnv := mergeStepEnvironment(runtimeEnv, jobResult.Env)
-			preResult, preErr := r.prepareRemoteAction(runCtx, processor, workspace, step, strconv.Itoa(stepIndex), preEnv, eval, &posts, actions, prepared, &preStatus, true, nil)
+			preCtx, cancelPre := stepContext(runCtx, step.TimeoutMinutes)
+			preEval := cloneExpressionContext(eval)
+			bindHashFilesContext(preCtx, &preEval)
+			preResult, preErr := r.prepareRemoteAction(preCtx, processor, workspace, step, strconv.Itoa(stepIndex), preEnv, preEval, &posts, actions, prepared, &preStatus, true, nil)
+			cancelPre()
 			commitResultEnvironment(jobResult.Env, preResult)
 			mergeInto(jobResult.State, preResult.State)
 			appendJobSummary(&jobResult.Summary, &jobResult.summaryTruncated, preResult.Summary, preResult.summaryTruncated)
@@ -533,11 +537,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 
 		stepCtx, cancelStep := stepContext(runCtx, step.TimeoutMinutes)
 		stepEval := cloneExpressionContext(eval)
-		if stepEval.HashFilesContext != nil {
-			stepEval.HashFiles = func(patterns []string) (string, error) {
-				return stepEval.HashFilesContext(stepCtx, patterns)
-			}
-		}
+		bindHashFilesContext(stepCtx, &stepEval)
 		stepEnv, err := evaluateStepMap(step.Env, stepEval)
 		if err != nil {
 			cancelStep()

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -562,14 +562,17 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		jobEnv := mergeStepEnvironment(runtimeEnv, jobResult.Env)
 		evalSnapshot := stepEval
 		if step.Background {
+			cancelStep()
 			step := step
-			supervisor.start(stepCtx, step.ID,
-				func(stepCtx context.Context) stepExecution {
-					defer cancelStep()
-					return r.executePlanStep(ctx, stepCtx, processor, workspace, job, step, strconv.Itoa(stepIndex), jobEnv, stepEnv, evalSnapshot, &posts, actions, prepared)
+			supervisor.start(runCtx, step.ID,
+				func(taskCtx context.Context) stepExecution {
+					stepCtx, cancelExecution := stepContext(taskCtx, step.TimeoutMinutes)
+					defer cancelExecution()
+					executionEval := cloneExpressionContext(evalSnapshot)
+					bindHashFilesContext(stepCtx, &executionEval)
+					return r.executePlanStep(ctx, stepCtx, processor, workspace, job, step, strconv.Itoa(stepIndex), jobEnv, stepEnv, executionEval, &posts, actions, prepared)
 				},
 				func(stepCtx context.Context) stepExecution {
-					cancelStep()
 					return cancelledStepExecution(ctx, stepCtx, step)
 				},
 			)

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -487,8 +487,12 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 			preEval := cloneExpressionContext(eval)
 			bindHashFilesContext(preCtx, &preEval)
 			preResult, preErr := r.prepareRemoteAction(preCtx, processor, workspace, step, strconv.Itoa(stepIndex), preEnv, preEval, &posts, actions, prepared, &preStatus, true, nil)
+			commitResultEnvironment(jobResult.Env, preResult)
+			mergeInto(jobResult.State, preResult.State)
+			appendJobSummary(&jobResult.Summary, &jobResult.summaryTruncated, preResult.Summary, preResult.summaryTruncated)
+			eval.Env = jobResult.Env
 			if preErr != nil {
-				execution := classifyStepExecution(ctx, preCtx, step, preResult, fmt.Errorf("action %q pre: %w", step.Uses, preErr))
+				execution := classifyStepExecution(ctx, preCtx, step, newResult(), fmt.Errorf("action %q pre: %w", step.Uses, preErr))
 				preFailures[stepIndex] = execution
 				if execution.conclusion != "success" {
 					preStatus.unsuccessful = true
@@ -497,10 +501,6 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 				continue
 			}
 			cancelPre()
-			commitResultEnvironment(jobResult.Env, preResult)
-			mergeInto(jobResult.State, preResult.State)
-			appendJobSummary(&jobResult.Summary, &jobResult.summaryTruncated, preResult.Summary, preResult.summaryTruncated)
-			eval.Env = jobResult.Env
 		}
 	}
 	for stepIndex, step := range job.Steps {

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -486,6 +486,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 			preCtx, cancelPre := stepContext(runCtx, step.TimeoutMinutes)
 			preEval := cloneExpressionContext(eval)
 			bindHashFilesContext(preCtx, &preEval)
+			wasUnsuccessful := preStatus.unsuccessful
 			preResult, preErr := r.prepareRemoteAction(preCtx, processor, workspace, step, strconv.Itoa(stepIndex), preEnv, preEval, &posts, actions, prepared, &preStatus, true, nil)
 			commitResultEnvironment(jobResult.Env, preResult)
 			mergeInto(jobResult.State, preResult.State)
@@ -496,6 +497,8 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 				preFailures[stepIndex] = execution
 				if execution.conclusion != "success" {
 					preStatus.unsuccessful = true
+				} else {
+					preStatus.unsuccessful = wasUnsuccessful
 				}
 				cancelPre()
 				continue
@@ -542,6 +545,17 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		}
 		if execution, ok := preFailures[stepIndex]; ok {
 			runErr = errors.Join(runErr, commitStepExecution(execution, &jobResult, &eval, statuses))
+			continue
+		}
+		referencesStatus, err := expression.ReferencesStatusFunction(step.Condition)
+		if err != nil {
+			execution := classifyStepExecution(ctx, runCtx, step, newResult(), fmt.Errorf("condition: %w", err))
+			runErr = errors.Join(runErr, commitStepExecution(execution, &jobResult, &eval, statuses))
+			continue
+		}
+		if !referencesStatus && (runErr != nil || runCtx.Err() != nil) {
+			statuses[strings.ToLower(step.ID)] = expression.StepStatus{Outcome: "skipped", Conclusion: "skipped", Outputs: map[string]string{}}
+			eval.Steps[strings.ToLower(step.ID)] = map[string]string{}
 			continue
 		}
 

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -456,6 +456,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 	var runErr error
 	prepared := remotePreparations{}
 	preStatus := remotePreparationStatus{}
+	preFailures := make(map[int]stepExecution)
 	if job.Schema == plan.SchemaV3 || job.Schema == plan.SchemaV4 || ((job.Schema == plan.SchemaV5 || job.Schema == plan.SchemaV6 || job.Schema == plan.SchemaV7 || job.Schema == plan.SchemaV8) && len(job.Actions) != 0) {
 		for stepIndex, step := range job.Steps {
 			eval.JobStatus = jobStatusValue(runErr != nil, runCtx.Err() != nil)
@@ -486,15 +487,20 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 			preEval := cloneExpressionContext(eval)
 			bindHashFilesContext(preCtx, &preEval)
 			preResult, preErr := r.prepareRemoteAction(preCtx, processor, workspace, step, strconv.Itoa(stepIndex), preEnv, preEval, &posts, actions, prepared, &preStatus, true, nil)
+			if preErr != nil {
+				execution := classifyStepExecution(ctx, preCtx, step, preResult, fmt.Errorf("action %q pre: %w", step.Uses, preErr))
+				preFailures[stepIndex] = execution
+				if execution.conclusion != "success" {
+					preStatus.unsuccessful = true
+				}
+				cancelPre()
+				continue
+			}
 			cancelPre()
 			commitResultEnvironment(jobResult.Env, preResult)
 			mergeInto(jobResult.State, preResult.State)
 			appendJobSummary(&jobResult.Summary, &jobResult.summaryTruncated, preResult.Summary, preResult.summaryTruncated)
 			eval.Env = jobResult.Env
-			if preErr != nil {
-				preStatus.unsuccessful = true
-				runErr = errors.Join(runErr, fmt.Errorf("action %q pre: %w", step.Uses, preErr))
-			}
 		}
 	}
 	for stepIndex, step := range job.Steps {
@@ -532,6 +538,10 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 			}
 			statuses[strings.ToLower(step.ID)] = expression.StepStatus{Outcome: outcome, Conclusion: conclusion, Outputs: map[string]string{}}
 			eval.Steps[strings.ToLower(step.ID)] = map[string]string{}
+			continue
+		}
+		if execution, ok := preFailures[stepIndex]; ok {
+			runErr = errors.Join(runErr, commitStepExecution(execution, &jobResult, &eval, statuses))
 			continue
 		}
 

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -304,6 +304,17 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 	if err != nil {
 		return jobResult, fmt.Errorf("canonicalize workspace: %w", err)
 	}
+	hashRoot, err := os.OpenRoot(workspace)
+	if err != nil {
+		return jobResult, fmt.Errorf("open hashFiles workspace: %w", err)
+	}
+	defer func() { runJobErr = errors.Join(runJobErr, hashRoot.Close()) }()
+	eval.HashFilesContext = func(ctx context.Context, patterns []string) (string, error) {
+		return hashWorkspaceRootFilesWithLimits(ctx, hashRoot, patterns, defaultHashFilesLimits, goruntime.GOOS == "windows")
+	}
+	eval.HashFiles = func(patterns []string) (string, error) {
+		return eval.HashFilesContext(runCtx, patterns)
+	}
 	if job.HasCapability("docker") {
 		workspaceDir, err := os.Open(workspace)
 		if err != nil {
@@ -471,7 +482,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 				continue
 			}
 			preEnv := mergeStepEnvironment(runtimeEnv, jobResult.Env)
-			preResult, preErr := r.prepareRemoteAction(runCtx, processor, workspace, step, strconv.Itoa(stepIndex), preEnv, eval, &posts, actions, prepared, &preStatus, nil)
+			preResult, preErr := r.prepareRemoteAction(runCtx, processor, workspace, step, strconv.Itoa(stepIndex), preEnv, eval, &posts, actions, prepared, &preStatus, true, nil)
 			commitResultEnvironment(jobResult.Env, preResult)
 			mergeInto(jobResult.State, preResult.State)
 			appendJobSummary(&jobResult.Summary, &jobResult.summaryTruncated, preResult.Summary, preResult.summaryTruncated)
@@ -520,7 +531,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 			continue
 		}
 
-		condition := expression.ConditionContext{Needs: eval.Needs, NeedResults: eval.NeedResults, Steps: statuses, Env: jobResult.Env, Vars: job.Vars, Matrix: job.Matrix, GitHub: eval.GitHub, Runner: eval.Runner, Services: eval.Services, Failure: runErr != nil, Unsuccessful: runErr != nil, Cancelled: runCtx.Err() != nil}
+		condition := expression.ConditionContext{Needs: eval.Needs, NeedResults: eval.NeedResults, Steps: statuses, Env: jobResult.Env, Vars: job.Vars, Matrix: job.Matrix, GitHub: eval.GitHub, Runner: eval.Runner, Services: eval.Services, Failure: runErr != nil, Unsuccessful: runErr != nil, Cancelled: runCtx.Err() != nil, HashFiles: eval.HashFiles}
 		run, err := expression.EvaluateCondition(step.Condition, condition)
 		if err != nil {
 			runErr = errors.Join(runErr, fmt.Errorf("step %q condition: %w", step.ID, err))
@@ -1118,9 +1129,15 @@ func (r *Runner) actionContainerMounts(ctx context.Context, actions *actionLockR
 	return out, nil
 }
 
-func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProcessor, workspace string, step plan.Step, invocationID string, jobEnv map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations, status *remotePreparationStatus, inheritedEvalErr error) (Result, error) {
+func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProcessor, workspace string, step plan.Step, invocationID string, jobEnv map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations, status *remotePreparationStatus, workflowStep bool, inheritedEvalErr error) (Result, error) {
 	result := newResult()
 	eval.JobStatus = jobStatusValue(status.unsuccessful, ctx.Err() != nil)
+	evaluate := evaluateMap
+	if workflowStep {
+		evaluate = evaluateStepMap
+	} else {
+		eval.HashFiles = nil
+	}
 	source, err := actions.source(*step.Action)
 	if err != nil {
 		return result, err
@@ -1171,7 +1188,7 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 			if inheritedEvalErr != nil {
 				return result, inheritedEvalErr
 			}
-			inputs, err := evaluateMap(step.With, eval)
+			inputs, err := evaluate(step.With, eval)
 			if err != nil {
 				return result, err
 			}
@@ -1179,7 +1196,7 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 			if err != nil {
 				return result, err
 			}
-			stepEnv, err := evaluateMap(step.Env, eval)
+			stepEnv, err := evaluate(step.Env, eval)
 			if err != nil {
 				return result, err
 			}
@@ -1203,13 +1220,13 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 		stepEnv := map[string]string{}
 		compositeEvalErr := inheritedEvalErr
 		if compositeEvalErr == nil {
-			inputs, compositeEvalErr = evaluateMap(step.With, eval)
+			inputs, compositeEvalErr = evaluate(step.With, eval)
 		}
 		if compositeEvalErr == nil {
 			inputs, compositeEvalErr = resolveActionInputs(action, inputs, eval)
 		}
 		if compositeEvalErr == nil {
-			stepEnv, compositeEvalErr = evaluateMap(step.Env, eval)
+			stepEnv, compositeEvalErr = evaluate(step.Env, eval)
 		}
 		eval.Inputs = inputs
 		compositeProcessEnv := mergeStepEnvironment(jobEnv, stepEnv)
@@ -1225,7 +1242,7 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 			child := plan.Step{ID: childStep.ID, Name: childStep.Name, Kind: "uses", Uses: childStep.Uses, With: childStep.With, Env: childStep.Env, Action: &plan.ActionSelector{Lock: selector.Lock}}
 			childProcessEnv := mergeStepEnvironment(compositeProcessEnv, result.Env)
 			eval.Env = mergeStringMaps(compositeExpressionEnv, result.Env)
-			childResult, childErr := r.prepareRemoteAction(ctx, processor, workspace, child, fmt.Sprintf("%s/%d", invocationID, i), childProcessEnv, eval, posts, actions, prepared, status, compositeEvalErr)
+			childResult, childErr := r.prepareRemoteAction(ctx, processor, workspace, child, fmt.Sprintf("%s/%d", invocationID, i), childProcessEnv, eval, posts, actions, prepared, status, false, compositeEvalErr)
 			mergeInto(result.Env, childResult.Env)
 			if childResult.pathBaseSet {
 				result.pathBase = childResult.pathBase
@@ -1247,22 +1264,24 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 }
 
 func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, step plan.Step, invocationID string, jobEnv map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations, actionStack []string) (Result, error) {
-	stepEnv, err := evaluateMap(step.Env, eval)
+	stepEnv, err := evaluateStepMap(step.Env, eval)
 	if err != nil {
 		return newResult(), err
 	}
 	environment := r.invocationEnvironment(jobEnv, stepEnv)
 	result := newResult()
 	if step.Kind == "run" {
-		script, err := expression.Evaluate(step.Command, eval)
+		script, err := expression.EvaluateStep(step.Command, eval)
 		if err != nil {
 			return result, err
 		}
 		shell := step.Shell
 		if shell == "" {
 			shell = job.DefaultShell
+			shell, err = expression.Evaluate(shell, eval)
+		} else {
+			shell, err = expression.EvaluateStep(shell, eval)
 		}
-		shell, err = expression.Evaluate(shell, eval)
 		if err != nil {
 			return result, err
 		}
@@ -1276,8 +1295,10 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 		workingDirectory := step.WorkingDirectory
 		if workingDirectory == "" {
 			workingDirectory = job.DefaultWorkingDirectory
+			workingDirectory, err = expression.Evaluate(workingDirectory, eval)
+		} else {
+			workingDirectory, err = expression.EvaluateStep(workingDirectory, eval)
 		}
-		workingDirectory, err = expression.Evaluate(workingDirectory, eval)
 		if err != nil {
 			return result, err
 		}
@@ -1306,7 +1327,7 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 		}
 		action, actionLock = resolvedAction, &lock
 		if usesCheckoutAdapter(lock) {
-			inputs, err := evaluateMap(step.With, eval)
+			inputs, err := evaluateStepMap(step.With, eval)
 			if err != nil {
 				return result, err
 			}
@@ -1316,14 +1337,14 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 			return r.runCheckout(ctx, processor, workspace, job, inputs)
 		}
 		if usesUploadArtifactAdapter(lock) {
-			inputs, err := evaluateMap(step.With, eval)
+			inputs, err := evaluateStepMap(step.With, eval)
 			if err != nil {
 				return result, err
 			}
 			return r.runUploadArtifactCommit(ctx, processor, workspace, lock.Commit, inputs)
 		}
 		if usesDownloadArtifactAdapter(lock) {
-			inputs, err := evaluateMap(step.With, eval)
+			inputs, err := evaluateStepMap(step.With, eval)
 			if err != nil {
 				return result, err
 			}
@@ -1363,7 +1384,7 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 		return result, fmt.Errorf("local action nesting exceeds maximum depth %d at %q", metadata.MaxNestedActionDepth, actionPath)
 	}
 	actionStack = append(append([]string(nil), actionStack...), actionIdentity)
-	inputs, err := evaluateMap(step.With, eval)
+	inputs, err := evaluateStepMap(step.With, eval)
 	if err != nil {
 		return result, err
 	}
@@ -1465,6 +1486,10 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 
 func (r Runner) runCompositeMetadata(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, actionPath string, action metadata.Metadata, inputs map[string]string, invocationID string, jobEnv, stepEnv map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations, actionLock *plan.ActionLock, actionStack []string) (Result, error) {
 	result := newResult()
+	// hashFiles is a workflow-step surface. Do not extend it into action
+	// metadata expressions while executing a composite action.
+	eval.HashFiles = nil
+	eval.HashFilesContext = nil
 	eval.Inputs = inputs
 	eval.Steps = make(map[string]map[string]string)
 	eval.StepStatuses = make(map[string]expression.StepStatus)
@@ -1577,6 +1602,18 @@ func evaluateMap(values map[string]string, context expression.Context) (map[stri
 	for _, name := range sortedKeys(values) {
 		value := values[name]
 		resolved, err := expression.Evaluate(value, context)
+		if err != nil {
+			return nil, fmt.Errorf("evaluate %q: %w", name, err)
+		}
+		out[name] = resolved
+	}
+	return out, nil
+}
+
+func evaluateStepMap(values map[string]string, context expression.Context) (map[string]string, error) {
+	out := make(map[string]string, len(values))
+	for _, name := range sortedKeys(values) {
+		resolved, err := expression.EvaluateStep(values[name], context)
 		if err != nil {
 			return nil, fmt.Errorf("evaluate %q: %w", name, err)
 		}

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -540,9 +540,10 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		bindHashFilesContext(stepCtx, &stepEval)
 		stepEnv, err := evaluateStepMap(step.Env, stepEval)
 		if err != nil {
+			execution := classifyStepExecution(ctx, stepCtx, step, newResult(), fmt.Errorf("environment: %w", err))
 			cancelStep()
-			runErr = errors.Join(runErr, fmt.Errorf("step %q environment: %w", step.ID, err))
-			break
+			runErr = errors.Join(runErr, commitStepExecution(execution, &jobResult, &eval, statuses))
+			continue
 		}
 		stepEval.Env = mergeStringMaps(stepEval.Env, stepEnv)
 		condition := expression.ConditionContext{Needs: eval.Needs, NeedResults: eval.NeedResults, Steps: statuses, Env: stepEval.Env, Vars: job.Vars, Matrix: job.Matrix, GitHub: eval.GitHub, Runner: eval.Runner, Services: eval.Services, Failure: runErr != nil, Unsuccessful: runErr != nil, Cancelled: stepCtx.Err() != nil, HashFiles: stepEval.HashFiles}

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -531,7 +531,14 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 			continue
 		}
 
-		condition := expression.ConditionContext{Needs: eval.Needs, NeedResults: eval.NeedResults, Steps: statuses, Env: jobResult.Env, Vars: job.Vars, Matrix: job.Matrix, GitHub: eval.GitHub, Runner: eval.Runner, Services: eval.Services, Failure: runErr != nil, Unsuccessful: runErr != nil, Cancelled: runCtx.Err() != nil, HashFiles: eval.HashFiles}
+		stepEnv, err := evaluateStepMap(step.Env, eval)
+		if err != nil {
+			runErr = errors.Join(runErr, fmt.Errorf("step %q environment: %w", step.ID, err))
+			break
+		}
+		stepEval := cloneExpressionContext(eval)
+		stepEval.Env = mergeStringMaps(stepEval.Env, stepEnv)
+		condition := expression.ConditionContext{Needs: eval.Needs, NeedResults: eval.NeedResults, Steps: statuses, Env: stepEval.Env, Vars: job.Vars, Matrix: job.Matrix, GitHub: eval.GitHub, Runner: eval.Runner, Services: eval.Services, Failure: runErr != nil, Unsuccessful: runErr != nil, Cancelled: runCtx.Err() != nil, HashFiles: eval.HashFiles}
 		run, err := expression.EvaluateCondition(step.Condition, condition)
 		if err != nil {
 			runErr = errors.Join(runErr, fmt.Errorf("step %q condition: %w", step.ID, err))
@@ -544,12 +551,12 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		}
 
 		jobEnv := mergeStepEnvironment(runtimeEnv, jobResult.Env)
-		evalSnapshot := cloneExpressionContext(eval)
+		evalSnapshot := stepEval
 		if step.Background {
 			step := step
 			supervisor.start(runCtx, step.ID,
 				func(stepCtx context.Context) stepExecution {
-					return r.executePlanStep(ctx, stepCtx, processor, workspace, job, step, strconv.Itoa(stepIndex), jobEnv, evalSnapshot, &posts, actions, prepared)
+					return r.executePlanStep(ctx, stepCtx, processor, workspace, job, step, strconv.Itoa(stepIndex), jobEnv, stepEnv, evalSnapshot, &posts, actions, prepared)
 				},
 				func(stepCtx context.Context) stepExecution {
 					return cancelledStepExecution(ctx, stepCtx, step)
@@ -558,7 +565,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 			continue
 		}
 		processor.logSection(stepDisplayName(step, evalSnapshot))
-		execution := r.executePlanStep(ctx, runCtx, processor, workspace, job, step, strconv.Itoa(stepIndex), jobEnv, evalSnapshot, &posts, actions, prepared)
+		execution := r.executePlanStep(ctx, runCtx, processor, workspace, job, step, strconv.Itoa(stepIndex), jobEnv, stepEnv, evalSnapshot, &posts, actions, prepared)
 		if execution.outcome == "failure" {
 			processor.expandCurrentSection()
 		}
@@ -976,8 +983,8 @@ func isRuntimeContextEnvironment(name string) bool {
 	}
 }
 
-func (r Runner) runJobStep(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, step plan.Step, invocationID string, jobEnv map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations) (Result, error) {
-	return r.runActionStep(ctx, processor, workspace, job, step, invocationID, jobEnv, eval, posts, actions, prepared, nil)
+func (r Runner) runJobStep(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, step plan.Step, invocationID string, jobEnv, stepEnv map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations) (Result, error) {
+	return r.runActionStep(ctx, processor, workspace, job, step, invocationID, jobEnv, stepEnv, eval, posts, actions, prepared, nil)
 }
 
 // verifyRemoteActionTree materializes and verifies every remote subtree before
@@ -1188,15 +1195,16 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 			if inheritedEvalErr != nil {
 				return result, inheritedEvalErr
 			}
+			stepEnv, err := evaluate(step.Env, eval)
+			if err != nil {
+				return result, err
+			}
+			eval.Env = mergeStringMaps(eval.Env, stepEnv)
 			inputs, err := evaluate(step.With, eval)
 			if err != nil {
 				return result, err
 			}
 			inputs, err = resolveActionInputs(action, inputs, eval)
-			if err != nil {
-				return result, err
-			}
-			stepEnv, err := evaluate(step.Env, eval)
 			if err != nil {
 				return result, err
 			}
@@ -1220,13 +1228,14 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 		stepEnv := map[string]string{}
 		compositeEvalErr := inheritedEvalErr
 		if compositeEvalErr == nil {
+			stepEnv, compositeEvalErr = evaluate(step.Env, eval)
+		}
+		if compositeEvalErr == nil {
+			eval.Env = mergeStringMaps(eval.Env, stepEnv)
 			inputs, compositeEvalErr = evaluate(step.With, eval)
 		}
 		if compositeEvalErr == nil {
 			inputs, compositeEvalErr = resolveActionInputs(action, inputs, eval)
-		}
-		if compositeEvalErr == nil {
-			stepEnv, compositeEvalErr = evaluate(step.Env, eval)
 		}
 		eval.Inputs = inputs
 		compositeProcessEnv := mergeStepEnvironment(jobEnv, stepEnv)
@@ -1263,10 +1272,13 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 	}
 }
 
-func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, step plan.Step, invocationID string, jobEnv map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations, actionStack []string) (Result, error) {
-	stepEnv, err := evaluateStepMap(step.Env, eval)
-	if err != nil {
-		return newResult(), err
+func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, step plan.Step, invocationID string, jobEnv, stepEnv map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations, actionStack []string) (Result, error) {
+	if stepEnv == nil {
+		var err error
+		stepEnv, err = evaluateStepMap(step.Env, eval)
+		if err != nil {
+			return newResult(), err
+		}
 	}
 	environment := r.invocationEnvironment(jobEnv, stepEnv)
 	result := newResult()
@@ -1541,7 +1553,7 @@ func (r Runner) runCompositeMetadata(ctx context.Context, processor *commandProc
 				}
 			}
 			if childErr == nil {
-				stepResult, childErr = r.runActionStep(ctx, processor, workspace, job, child, fmt.Sprintf("%s/%d", invocationID, i), childJobEnv, eval, posts, actions, prepared, actionStack)
+				stepResult, childErr = r.runActionStep(ctx, processor, workspace, job, child, fmt.Sprintf("%s/%d", invocationID, i), childJobEnv, nil, eval, posts, actions, prepared, actionStack)
 			}
 		} else if strings.TrimSpace(step.Run) == "" {
 			childErr = fmt.Errorf("composite action step %d has no run command", i+1)

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -531,20 +531,29 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 			continue
 		}
 
-		stepEnv, err := evaluateStepMap(step.Env, eval)
+		stepCtx, cancelStep := stepContext(runCtx, step.TimeoutMinutes)
+		stepEval := cloneExpressionContext(eval)
+		if stepEval.HashFilesContext != nil {
+			stepEval.HashFiles = func(patterns []string) (string, error) {
+				return stepEval.HashFilesContext(stepCtx, patterns)
+			}
+		}
+		stepEnv, err := evaluateStepMap(step.Env, stepEval)
 		if err != nil {
+			cancelStep()
 			runErr = errors.Join(runErr, fmt.Errorf("step %q environment: %w", step.ID, err))
 			break
 		}
-		stepEval := cloneExpressionContext(eval)
 		stepEval.Env = mergeStringMaps(stepEval.Env, stepEnv)
-		condition := expression.ConditionContext{Needs: eval.Needs, NeedResults: eval.NeedResults, Steps: statuses, Env: stepEval.Env, Vars: job.Vars, Matrix: job.Matrix, GitHub: eval.GitHub, Runner: eval.Runner, Services: eval.Services, Failure: runErr != nil, Unsuccessful: runErr != nil, Cancelled: runCtx.Err() != nil, HashFiles: eval.HashFiles}
+		condition := expression.ConditionContext{Needs: eval.Needs, NeedResults: eval.NeedResults, Steps: statuses, Env: stepEval.Env, Vars: job.Vars, Matrix: job.Matrix, GitHub: eval.GitHub, Runner: eval.Runner, Services: eval.Services, Failure: runErr != nil, Unsuccessful: runErr != nil, Cancelled: stepCtx.Err() != nil, HashFiles: stepEval.HashFiles}
 		run, err := expression.EvaluateCondition(step.Condition, condition)
 		if err != nil {
+			cancelStep()
 			runErr = errors.Join(runErr, fmt.Errorf("step %q condition: %w", step.ID, err))
 			break
 		}
 		if !run {
+			cancelStep()
 			statuses[strings.ToLower(step.ID)] = expression.StepStatus{Outcome: "skipped", Conclusion: "skipped", Outputs: map[string]string{}}
 			eval.Steps[strings.ToLower(step.ID)] = map[string]string{}
 			continue
@@ -554,18 +563,21 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		evalSnapshot := stepEval
 		if step.Background {
 			step := step
-			supervisor.start(runCtx, step.ID,
+			supervisor.start(stepCtx, step.ID,
 				func(stepCtx context.Context) stepExecution {
+					defer cancelStep()
 					return r.executePlanStep(ctx, stepCtx, processor, workspace, job, step, strconv.Itoa(stepIndex), jobEnv, stepEnv, evalSnapshot, &posts, actions, prepared)
 				},
 				func(stepCtx context.Context) stepExecution {
+					cancelStep()
 					return cancelledStepExecution(ctx, stepCtx, step)
 				},
 			)
 			continue
 		}
 		processor.logSection(stepDisplayName(step, evalSnapshot))
-		execution := r.executePlanStep(ctx, runCtx, processor, workspace, job, step, strconv.Itoa(stepIndex), jobEnv, stepEnv, evalSnapshot, &posts, actions, prepared)
+		execution := r.executePlanStep(ctx, stepCtx, processor, workspace, job, step, strconv.Itoa(stepIndex), jobEnv, stepEnv, evalSnapshot, &posts, actions, prepared)
+		cancelStep()
 		if execution.outcome == "failure" {
 			processor.expandCurrentSection()
 		}

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -549,9 +549,10 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		condition := expression.ConditionContext{Needs: eval.Needs, NeedResults: eval.NeedResults, Steps: statuses, Env: stepEval.Env, Vars: job.Vars, Matrix: job.Matrix, GitHub: eval.GitHub, Runner: eval.Runner, Services: eval.Services, Failure: runErr != nil, Unsuccessful: runErr != nil, Cancelled: stepCtx.Err() != nil, HashFiles: stepEval.HashFiles}
 		run, err := expression.EvaluateCondition(step.Condition, condition)
 		if err != nil {
+			execution := classifyStepExecution(ctx, stepCtx, step, newResult(), fmt.Errorf("condition: %w", err))
 			cancelStep()
-			runErr = errors.Join(runErr, fmt.Errorf("step %q condition: %w", step.ID, err))
-			break
+			runErr = errors.Join(runErr, commitStepExecution(execution, &jobResult, &eval, statuses))
+			continue
 		}
 		if !run {
 			cancelStep()

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -4483,6 +4483,55 @@ fi
 	}
 }
 
+func TestRemoteCompositeSoftPreFailurePreservesSuccessForLaterPre(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: softened composite pre failure\n")
+	remote := t.TempDir()
+	writeFixtureFile(t, remote, "parent/action.yml", "name: parent\nruns:\n  using: composite\n  steps:\n    - uses: owner/repo/child@v1\n")
+	writeFixtureFile(t, remote, "child/action.yml", "name: child\nruns:\n  using: node24\n  pre: pre.js\n  main: main.js\n")
+	writeFixtureFile(t, remote, "child/pre.js", "")
+	writeFixtureFile(t, remote, "child/main.js", "")
+	writeFixtureFile(t, remote, "after/action.yml", "name: after\nruns:\n  using: node24\n  pre: pre.js\n  pre-if: success()\n  main: main.js\n")
+	writeFixtureFile(t, remote, "after/pre.js", "")
+	writeFixtureFile(t, remote, "after/main.js", "")
+	marker := filepath.Join(workspace, "observed")
+	fakeNode := filepath.Join(workspace, "node24")
+	writeFixtureFile(t, workspace, "node24", `#!/bin/sh
+set -eu
+if [ "${1:-}" = --version ]; then echo v24.0.0; exit 0; fi
+action=$(basename "$(dirname "$1")")
+phase=$(basename "$1" .js)
+if [ "$action:$phase" = child:pre ]; then exit 7; fi
+if [ "$action:$phase" = after:pre ]; then touch "$MARKER"; fi
+`)
+	if err := os.Chmod(fakeNode, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	digest := digestTree(t, remote)
+	parentID, childID, afterID := remoteLifecycleLockID(1), remoteLifecycleLockID(2), remoteLifecycleLockID(3)
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{
+		{ID: "parent", Kind: "uses", Uses: remoteLifecycleUses("parent"), Action: &plan.ActionSelector{Lock: parentID}, ContinueOnError: true},
+		{ID: "after", Kind: "uses", Uses: remoteLifecycleUses("after"), Action: &plan.ActionSelector{Lock: afterID}},
+	})
+	job.Schema = plan.SchemaV3
+	job.RequiredCapabilities = []string{"network"}
+	job.Env = map[string]string{"MARKER": marker}
+	job.Actions = []plan.ActionLock{
+		remoteLifecycleLock(parentID, "parent", digest, map[string]plan.ActionSelector{remoteLifecycleUses("child"): {Lock: childID}}),
+		remoteLifecycleLock(childID, "child", digest, nil),
+		remoteLifecycleLock(afterID, "after", digest, nil),
+	}
+	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}
+	result, err := (Runner{Node24: fakeNode, Actions: materializer}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("later success pre did not run: %v", err)
+	}
+}
+
 func TestRemotePreparationErrorStillDrainsRegisteredPosts(t *testing.T) {
 	workspace := t.TempDir()
 	workflowPath := ".github/workflows/test.yml"

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -4703,6 +4703,35 @@ jobs:
 	}
 }
 
+func TestCompiledWorkflowUsesHashFilesAfterWorkspacePreparation(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := filepath.Join(workspace, ".github", "workflows", "hash-files.yml")
+	workflow := []byte(`on: push
+jobs:
+  hash:
+    runs-on: ubuntu-latest
+    steps:
+      - run: printf 'runtime contents' > payload
+      - if: hashFiles('payload') != ''
+        env:
+          PAYLOAD_HASH: ${{ hashFiles('payload') }}
+        run: test "$PAYLOAD_HASH" = "93f7a1af9e76c89675b5bc8c5f5c6aa62f1c78bc0c95693f0296b25274843527"
+`)
+	writeFixtureFile(t, workspace, ".github/workflows/hash-files.yml", string(workflow))
+	event, err := os.ReadFile(fixturePath(t, "smoke", "events", "push.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	plans, err := compileUntrustedPlans(workflowPath, workflow, event, "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "hosted")
+	if err != nil || len(plans) != 1 {
+		t.Fatalf("compile hashFiles workflow = %#v, %v", plans, err)
+	}
+	result, err := (Runner{}).RunJob(context.Background(), plans[0], workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+}
+
 func TestRunJobDockerUsesSharedMasking(t *testing.T) {
 	docker := requireDocker(t)
 	workspace := fixturePath(t)

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -4431,6 +4431,58 @@ if [ "$action:$phase" = fails:pre ]; then exit 7; fi
 	}
 }
 
+func TestRemoteActionPreFailurePropagatesEnvironmentToLaterPre(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: failed remote pre effects\n")
+	remote := t.TempDir()
+	for _, name := range []string{"fails", "after"} {
+		writeFixtureFile(t, remote, name+"/action.yml", "name: "+name+"\nruns:\n  using: node24\n  pre: pre.js\n  main: main.js\n")
+		writeFixtureFile(t, remote, name+"/pre.js", "")
+		writeFixtureFile(t, remote, name+"/main.js", "")
+	}
+	marker := filepath.Join(workspace, "observed")
+	fakeNode := filepath.Join(workspace, "node24")
+	writeFixtureFile(t, workspace, "node24", `#!/bin/sh
+set -eu
+if [ "${1:-}" = --version ]; then echo v24.0.0; exit 0; fi
+action=$(basename "$(dirname "$1")")
+phase=$(basename "$1" .js)
+if [ "$action:$phase" = fails:pre ]; then
+  printf '%s\n' 'PRE_EFFECT=available' >> "$GITHUB_ENV"
+  exit 7
+fi
+if [ "$action:$phase" = after:pre ]; then
+  test "$PRE_EFFECT" = available
+  touch "$MARKER"
+fi
+`)
+	if err := os.Chmod(fakeNode, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	digest := digestTree(t, remote)
+	failsID, afterID := remoteLifecycleLockID(1), remoteLifecycleLockID(2)
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{
+		{ID: "fails", Kind: "uses", Uses: remoteLifecycleUses("fails"), Action: &plan.ActionSelector{Lock: failsID}, ContinueOnError: true},
+		{ID: "after", Kind: "uses", Uses: remoteLifecycleUses("after"), Action: &plan.ActionSelector{Lock: afterID}},
+	})
+	job.Schema = plan.SchemaV3
+	job.RequiredCapabilities = []string{"network"}
+	job.Env = map[string]string{"MARKER": marker}
+	job.Actions = []plan.ActionLock{
+		remoteLifecycleLock(failsID, "fails", digest, nil),
+		remoteLifecycleLock(afterID, "after", digest, nil),
+	}
+	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}
+	result, err := (Runner{Node24: fakeNode, Actions: materializer}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("later pre did not observe failed pre environment: %v", err)
+	}
+}
+
 func TestRemotePreparationErrorStillDrainsRegisteredPosts(t *testing.T) {
 	workspace := t.TempDir()
 	workflowPath := ".github/workflows/test.yml"

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1092,6 +1092,33 @@ func TestCancelQueuedBackgroundNeverStartsIt(t *testing.T) {
 	}
 }
 
+func TestQueuedBackgroundTimeoutStartsAtDispatch(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: background timeout dispatch\n")
+	release := filepath.Join(workspace, "release")
+	queuedMarker := filepath.Join(workspace, "queued-started")
+	steps := make([]plan.Step, 0, maxActiveBackgroundSteps+3)
+	for i := 0; i < maxActiveBackgroundSteps; i++ {
+		steps = append(steps, plan.Step{ID: fmt.Sprintf("blocker-%d", i), Kind: "run", Background: true, Command: `while [ ! -f "$RELEASE" ]; do sleep 0.01; done`})
+	}
+	steps = append(steps,
+		plan.Step{ID: "queued", Kind: "run", Background: true, TimeoutMinutes: 0.001, Command: `touch "$QUEUED_MARKER"`},
+		plan.Step{ID: "release", Kind: "run", Command: `sleep 0.2; touch "$RELEASE"`},
+		plan.Step{ID: "wait", Kind: "wait-all"},
+	)
+	job := runtimePlan(t, workspace, workflowPath, steps)
+	job.Env = map[string]string{"RELEASE": release, "QUEUED_MARKER": queuedMarker}
+
+	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	if _, err := os.Stat(queuedMarker); err != nil {
+		t.Fatalf("queued timed step did not run: %v", err)
+	}
+}
+
 func TestCancelQueuedBackgroundNeverRegistersPostAction(t *testing.T) {
 	node := requireNode24(t)
 	workspace := t.TempDir()


### PR DESCRIPTION
## Why

Imported workflows can use GitHub Actions' `hashFiles()` to derive cache keys and gate steps from checked-out files. The runtime currently rejects the function, so compatible workflows need manual hashing or cannot compile.

## What

Add runtime-only `hashFiles()` support to top-level workflow step conditions, commands, environments, inputs, explicit shells, and explicit working directories. Match GitHub's ordered glob selection and SHA-256 digest construction while preserving direct-reference-only interpolation everywhere else.

Confine traversal and file opens to a pinned workspace root, reject symlinks and special files, detect mutation, and enforce explicit pattern, traversal, match, and byte limits. Multi-file hashing uses deterministic lexical path order; this is intentionally stricter than GitHub Runner's unspecified filesystem enumeration order.