### PR TITLE
Isolate fallback event tests from tag builds

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -3025,6 +3025,7 @@ func TestRunUploadAlignsBuildkiteFallbackWithEffectiveEvent(t *testing.T) {
 			t.Setenv("BUILDKITE_REPO", "https://github.com/buildkite/buildkite-gha")
 			t.Setenv("BUILDKITE_COMMIT", strings.Repeat("a", 40))
 			t.Setenv("BUILDKITE_BRANCH", "main")
+			t.Setenv("BUILDKITE_TAG", "")
 			if test.pullRequest {
 				t.Setenv("BUILDKITE_PULL_REQUEST", "42")
 				t.Setenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH", "main")


### PR DESCRIPTION
## Why

The v0.10.0 tag build inherited `BUILDKITE_TAG` while testing a synthetic pull request, producing contradictory event inputs. Main and local checks did not expose the tag-only environment leak.

## What

Clear the tag in the fallback-event test before constructing each synthetic Buildkite event.
