### PR TITLE
Accept plural plugin workflow selections

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Run GitHub Actions workflows as native Buildkite jobs without creating a GitHub 
 `buildkite-gha` turns each supported workflow job and static matrix entry into a Buildkite job. Steps run in a compatibility runtime inside that job. Buildkite owns scheduling, logs, retries, cancellation, and the build UI.
 
 > [!IMPORTANT]
-> `buildkite-gha` is an experimental pre-1.0 preview. The released plugin path supports Linux x86-64. Runtime v0.9.0 also includes native macOS arm64 support, which requires the companion plugin release. The production path supports local and public actions and narrowly scoped, job-bound checkout, `GITHUB_TOKEN`, artifact, and cache integrations. Private actions, ordinary workflow secrets, and GitHub-compatible OIDC are unsupported.
+> `buildkite-gha` is an experimental pre-1.0 preview. The released plugin path supports Linux x86-64 and native macOS arm64. The production path supports local and public actions and narrowly scoped, job-bound checkout, `GITHUB_TOKEN`, artifact, and cache integrations. Private actions, ordinary workflow secrets, and GitHub-compatible OIDC are unsupported.
 
 ## How it works
 
@@ -32,8 +32,7 @@ steps:
   - label: ":github: Test"
     key: "gha-ci"
     plugins:
-      - github-actions#v0.8.0:
-          version: "0.9.0"
+      - github-actions#v0.9.3:
           workflow: .github/workflows/ci.yml
 
   - label: ":rocket: Deploy"
@@ -49,21 +48,18 @@ To hold the CLI at a specific release instead, set `version` to an exact stable 
 
 ```yaml
 plugins:
-  - github-actions#v0.8.0:
+  - github-actions#v0.9.3:
       workflow: .github/workflows/ci.yml
-      version: "0.9.0"
+      version: "0.10.1"
 ```
 
 Runtime v0.9.0 adds `runner.os` and `runner.arch`. They resolve to `Linux` and
-`X64` through the released plugin path. Native macOS runtime support is also in
-v0.9.0, but released plugin v0.8.0 does not declare or support `runners` and
-schema validation rejects that configuration. The companion plugin change must
-ship before using this macOS configuration in production:
+`X64` on Linux and `macOS` and `ARM64` on native macOS. Configure macOS runner
+labels with a native Darwin/arm64 queue:
 
 ```yaml
 plugins:
-  - github-actions#main:
-      version: "0.9.0"
+  - github-actions#v0.9.3:
       workflow: .github/workflows/ci.yml
       runners:
         - runs-on: ubuntu-latest
@@ -86,7 +82,7 @@ The [compatibility reference](docs/compatibility.md) is the source of truth. Use
 
 | Good fit | Not currently supported |
 | --- | --- |
-| Linux x86-64 jobs using `bash` or `sh` | Native macOS through a released plugin until the companion plugin release; Windows, Linux arm64, or macOS x86-64 |
+| Linux x86-64 and native macOS arm64 jobs using `bash` or `sh` | Windows, Linux arm64, or macOS x86-64 |
 | Local and public JavaScript and composite actions; verified Dockerfile actions on Linux | Private actions, Dockerfile actions on macOS, or arbitrary reusable-workflow source |
 | Static matrices, `needs`, outputs, and local reusable workflows | Dynamic matrices and expressions outside the documented subset |
 | Exact-commit checkout, including managed private repository access | Ordinary workflow secrets, GitHub-compatible OIDC, or protected queues |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The plugin is a thin wrapper around the hidden `buildkite-gha plugin` entrypoint
 
 Use `workflow: "*"` to select every tracked `.yml` and `.yaml` file directly under `.github/workflows`.
 
-To hold the CLI at a specific release instead, set `version` to an exact stable release from `0.8.0` onward:
+To hold the CLI at a specific release instead, set `version` to an exact stable release from `0.9.0` onward:
 
 ```yaml
 plugins:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -99,13 +99,14 @@ buildkite-gha upload .github/workflows/ci.yml
 
 The importer must run on Linux/amd64 with `BUILDKITE=true` and `BUILDKITE_STEP_KEY`.
 
-The hidden zero-argument `buildkite-gha plugin` entry point reads `workflow` and
-`runners` from `BUILDKITE_PLUGIN_CONFIGURATION`; it also accepts the plugin-owned
-`version`, `source-ref`, and `minimum-release-age` fields. The Linux/amd64 importer
-fetches the same release's Darwin runtime only when the workflow requires it.
-Released plugin v0.8.0 does not declare or support `runners`; schema validation
-rejects that configuration. Native macOS therefore requires the companion
-plugin release. Custom importers can use the public flags below.
+The hidden zero-argument `buildkite-gha plugin` entry point reads `workflows` and
+`runners` from `BUILDKITE_PLUGIN_CONFIGURATION`; `workflows` accepts one selector
+string or an array of explicit paths. It also accepts the plugin-owned `version`,
+`source-ref`, and `minimum-release-age` fields. The legacy singular `workflow`
+field remains supported for released plugin compatibility but cannot be combined
+with `workflows`. The Linux/amd64 importer fetches the same release's Darwin
+runtime only when a workflow requires it. Custom importers can use the public
+flags below.
 
 ### Select workflows
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -2,11 +2,9 @@
 
 This page defines the initial production contract for `buildkite-gha`. It applies to the `hosted-tokenless` profile used by `upload` and the Buildkite plugin.
 
-Runtime v0.9.0 supports native macOS arm64, but released plugin v0.8.0 does not
-declare or support `runners`; schema validation rejects its runner mapping.
-Linux support, including `runner.os` and `runner.arch`, is available through the
-released plugin path. Native macOS becomes production-supported only after the
-companion plugin release.
+The released plugin path supports Linux x86-64 and native macOS arm64, including
+the matching `runner.os` and `runner.arch` values. Platform labels do not provide
+GitHub image or toolchain parity.
 
 GitHub Actions syntax changes over time. If a feature is not listed here, treat it as unsupported. GitHub's [workflow syntax reference](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax) describes the original syntax; this page describes the subset that runs on Buildkite.
 
@@ -26,13 +24,13 @@ Looking for something else? [Browse open compatibility issues](https://github.co
 | --- | --- | --- |
 | [Workflow and job names](#workflow-syntax) | 🟡 Supported subset | `name` and job names are retained. `run-name` has no effect. |
 | [Triggers and filters under `on`](#names-and-triggers) | 🟡 Supported subset | Buildkite creates builds; upload selects aggregate workflow groups for one effective event. Local `workflow_call` is supported for composition. |
-| [Platforms](#job-configuration) | 🟡 Supported subset | Linux x86-64 with `ubuntu-latest`, `ubuntu-24.04`, or `ubuntu-22.04`. Runtime v0.9.0 supports native macOS arm64, but the released plugin cannot configure it yet. Labels do not provide GitHub image or Xcode parity. |
+| [Platforms](#job-configuration) | 🟡 Supported subset | Linux x86-64 with `ubuntu-latest`, `ubuntu-24.04`, or `ubuntu-22.04`; native macOS arm64 with `macos-latest`, `macos-14`, or `macos-15`. Labels do not provide GitHub image, toolchain, or Xcode parity. |
 | [Jobs and dependencies](#job-configuration) | ✅ Supported | Static dependencies, matrix fan-out and fan-in, results, and bounded outputs. |
 | [Matrix strategies](#matrix-strategies) | 🟡 Supported subset | Static matrices, `include`, `exclude`, and literal `max-parallel`. Maximum 256 instances per job. `fail-fast` has no effect. |
-| [Shell steps](#commands-and-actions) | 🟡 Supported subset | Linux `bash` and `sh`; runtime-only macOS support has the same shell boundary. |
+| [Shell steps](#commands-and-actions) | 🟡 Supported subset | Linux and macOS `bash` and `sh`. |
 | [Conditions and expressions](#expressions-and-contexts) | 🟡 Supported subset | Boolean and equality conditions and direct references to selected contexts. |
 | [Reusable workflows](#reusable-workflows) | 🟡 Supported subset | Local workflows with static inputs, `secrets: inherit`, and direct job-output mappings. |
-| [Actions](#actions) | 🟡 Supported subset | Local and public JavaScript and composite actions on Linux and the runtime-only macOS path; verified Dockerfile actions on Linux only. |
+| [Actions](#actions) | 🟡 Supported subset | Local and public JavaScript and composite actions on Linux and macOS; verified Dockerfile actions on Linux only. |
 | [Checkout, artifacts, and cache](#actions) | 🟡 Supported subset | Only the audited versions and modes listed below. |
 | [`GITHUB_TOKEN`](#github-token) | 🟡 Supported subset | One job-bound token for the event repository. Workflows containing reusable-workflow jobs cannot receive one. |
 | [Other workflow secrets](#other-secrets-and-oidc) | 🚧 Not available in production | Production upload rejects ordinary secret requirements. |

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -176,7 +176,7 @@ func plugin(args []string, stdout, stderr io.Writer, version string, runner tran
 		return 1
 	}
 	return uploadParsed(parsedUploadArgs{
-		workflowOperands:  []string{configuration.Workflow},
+		workflowOperands:  configuration.Workflows,
 		runnerTargets:     configuration.runnerTargets,
 		pluginAcquisition: &pluginRuntimeAcquisition{version: version},
 	}, stdout, stderr, version, transport.Agent{Runner: runner})
@@ -190,7 +190,7 @@ func validateImporterPlatform(goos, goarch string) error {
 }
 
 type pluginConfiguration struct {
-	Workflow      string
+	Workflows     []string
 	runnerTargets map[string]compiler.RunnerTarget
 }
 
@@ -215,14 +215,44 @@ func parsePluginConfiguration(source string) (pluginConfiguration, error) {
 	}
 	for key := range encoded {
 		switch key {
-		case "workflow", "runners", "version", "source-ref", "minimum-release-age":
+		case "workflow", "workflows", "runners", "version", "source-ref", "minimum-release-age":
 		default:
 			return pluginConfiguration{}, fmt.Errorf("%s contains unknown field %q", pluginConfigurationEnvironment, key)
 		}
 	}
-	workflow, ok := encoded["workflow"].(string)
-	if !ok || strings.TrimSpace(workflow) == "" {
-		return pluginConfiguration{}, fmt.Errorf("%s workflow is required", pluginConfigurationEnvironment)
+	legacyWorkflow, hasLegacyWorkflow := encoded["workflow"]
+	workflowsValue, hasWorkflows := encoded["workflows"]
+	if hasLegacyWorkflow && hasWorkflows {
+		return pluginConfiguration{}, fmt.Errorf("%s workflow and workflows are mutually exclusive", pluginConfigurationEnvironment)
+	}
+	var workflows []string
+	if hasLegacyWorkflow {
+		workflow, ok := legacyWorkflow.(string)
+		if !ok || strings.TrimSpace(workflow) == "" {
+			return pluginConfiguration{}, fmt.Errorf("%s workflow must be a non-empty string", pluginConfigurationEnvironment)
+		}
+		workflows = []string{workflow}
+	} else {
+		switch value := workflowsValue.(type) {
+		case string:
+			if strings.TrimSpace(value) != "" {
+				workflows = []string{value}
+			}
+		case []any:
+			if len(value) != 0 {
+				workflows = make([]string, len(value))
+				for index, entry := range value {
+					workflow, ok := entry.(string)
+					if !ok || strings.TrimSpace(workflow) == "" {
+						return pluginConfiguration{}, fmt.Errorf("%s workflows entry %d must be a non-empty string", pluginConfigurationEnvironment, index)
+					}
+					workflows[index] = workflow
+				}
+			}
+		}
+		if len(workflows) == 0 {
+			return pluginConfiguration{}, fmt.Errorf("%s workflows is required and must be a non-empty string or array of non-empty strings", pluginConfigurationEnvironment)
+		}
 	}
 	targets := make(map[string]compiler.RunnerTarget)
 	if runnersValue, configured := encoded["runners"]; configured {
@@ -268,7 +298,7 @@ func parsePluginConfiguration(source string) (pluginConfiguration, error) {
 			targets[label] = target
 		}
 	}
-	return pluginConfiguration{Workflow: workflow, runnerTargets: targets}, nil
+	return pluginConfiguration{Workflows: workflows, runnerTargets: targets}, nil
 }
 
 func normalizePluginCommit(ctx context.Context, getenv func(string) string, setenv func(string, string) error, runner transport.Runner) error {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -176,9 +176,10 @@ func plugin(args []string, stdout, stderr io.Writer, version string, runner tran
 		return 1
 	}
 	return uploadParsed(parsedUploadArgs{
-		workflowOperands:  configuration.Workflows,
-		runnerTargets:     configuration.runnerTargets,
-		pluginAcquisition: &pluginRuntimeAcquisition{version: version},
+		workflowOperands:      configuration.Workflows,
+		explicitWorkflowPaths: configuration.explicitWorkflowPaths,
+		runnerTargets:         configuration.runnerTargets,
+		pluginAcquisition:     &pluginRuntimeAcquisition{version: version},
 	}, stdout, stderr, version, transport.Agent{Runner: runner})
 }
 
@@ -190,8 +191,9 @@ func validateImporterPlatform(goos, goarch string) error {
 }
 
 type pluginConfiguration struct {
-	Workflows     []string
-	runnerTargets map[string]compiler.RunnerTarget
+	Workflows             []string
+	explicitWorkflowPaths bool
+	runnerTargets         map[string]compiler.RunnerTarget
 }
 
 func parsePluginConfiguration(source string) (pluginConfiguration, error) {
@@ -226,6 +228,7 @@ func parsePluginConfiguration(source string) (pluginConfiguration, error) {
 		return pluginConfiguration{}, fmt.Errorf("%s workflow and workflows are mutually exclusive", pluginConfigurationEnvironment)
 	}
 	var workflows []string
+	explicitWorkflowPaths := false
 	if hasLegacyWorkflow {
 		workflow, ok := legacyWorkflow.(string)
 		if !ok || strings.TrimSpace(workflow) == "" {
@@ -240,6 +243,7 @@ func parsePluginConfiguration(source string) (pluginConfiguration, error) {
 			}
 		case []any:
 			if len(value) != 0 {
+				explicitWorkflowPaths = true
 				workflows = make([]string, len(value))
 				for index, entry := range value {
 					workflow, ok := entry.(string)
@@ -298,7 +302,7 @@ func parsePluginConfiguration(source string) (pluginConfiguration, error) {
 			targets[label] = target
 		}
 	}
-	return pluginConfiguration{Workflows: workflows, runnerTargets: targets}, nil
+	return pluginConfiguration{Workflows: workflows, explicitWorkflowPaths: explicitWorkflowPaths, runnerTargets: targets}, nil
 }
 
 func normalizePluginCommit(ctx context.Context, getenv func(string) string, setenv func(string, string) error, runner transport.Runner) error {
@@ -1392,7 +1396,13 @@ func uploadParsed(uploadArguments parsedUploadArgs, stdout, stderr io.Writer, ve
 		}
 	}
 	out := processingOutput{command: "upload", format: "text", reports: stderr, stderr: stderr}
-	workflows, err := expandWorkflowOperands(workflowOperands)
+	var workflows []workflowInput
+	var err error
+	if uploadArguments.explicitWorkflowPaths {
+		workflows, err = expandExplicitWorkflowPaths(workflowOperands)
+	} else {
+		workflows, err = expandWorkflowOperands(workflowOperands)
+	}
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
 		return 1
@@ -1814,6 +1824,10 @@ func expandWorkflowOperands(operands []string) ([]workflowInput, error) {
 	if len(operands) == 1 {
 		return expandWorkflowPattern(operands[0])
 	}
+	return expandExplicitWorkflowPaths(operands)
+}
+
+func expandExplicitWorkflowPaths(operands []string) ([]workflowInput, error) {
 	rootBytes, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
 	if err != nil {
 		return nil, fmt.Errorf("locate checked-out git repository: %w", err)
@@ -1832,7 +1846,7 @@ func expandWorkflowOperands(operands []string) ([]workflowInput, error) {
 		canonical := filepath.ToSlash(filepath.Clean(relative))
 		if err := requireRegularWorkflowFile(absolute, operand); err != nil {
 			if strings.ContainsAny(operand, "*?[") {
-				return nil, fmt.Errorf("multiple workflow operands must be explicit paths; glob pattern %q is not allowed", operand)
+				return nil, fmt.Errorf("workflow list entries must be explicit paths; glob pattern %q is not allowed", operand)
 			}
 			return nil, err
 		}
@@ -1844,7 +1858,7 @@ func expandWorkflowOperands(operands []string) ([]workflowInput, error) {
 		entries := bytes.Split(output, []byte{0})
 		if err != nil || len(entries) != 2 || string(entries[0]) != canonical || len(entries[1]) != 0 {
 			if strings.ContainsAny(operand, "*?[") {
-				return nil, fmt.Errorf("multiple workflow operands must be explicit paths; glob pattern %q is not allowed", operand)
+				return nil, fmt.Errorf("workflow list entries must be explicit paths; glob pattern %q is not allowed", operand)
 			}
 			return nil, fmt.Errorf("workflow path %q is not tracked by git", operand)
 		}
@@ -2224,6 +2238,7 @@ func bundleUsesActions(bundle compiler.Bundle) bool {
 
 type parsedUploadArgs struct {
 	workflowOperands         []string
+	explicitWorkflowPaths    bool
 	eventPath                string
 	runtimeDistributionPaths map[compiler.Platform]string
 	runnerTargets            map[string]compiler.RunnerTarget

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -148,7 +148,7 @@ func TestPluginRequiresConfigurationWithoutSideEffects(t *testing.T) {
 func TestParsePluginConfiguration(t *testing.T) {
 	image := "buildkite.namespace-images.com/agent-base@sha256:" + strings.Repeat("0", 64)
 	configuration, err := parsePluginConfiguration(`{
-  "workflow": ".github/workflows/ci.yml",
+  "workflows": [".github/workflows/ci.yml", ".github/workflows/release.yml"],
   "version": "0.8.0",
   "source-ref": "0123456789abcdef0123456789abcdef01234567",
   "minimum-release-age": "24h",
@@ -160,7 +160,7 @@ func TestParsePluginConfiguration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if configuration.Workflow != ".github/workflows/ci.yml" || len(configuration.runnerTargets) != 2 {
+	if !slices.Equal(configuration.Workflows, []string{".github/workflows/ci.yml", ".github/workflows/release.yml"}) || len(configuration.runnerTargets) != 2 {
 		t.Fatalf("configuration = %#v", configuration)
 	}
 	if got := configuration.runnerTargets["ubuntu-latest"]; got != (compiler.RunnerTarget{Queue: "hosted", Platform: compiler.PlatformLinuxAMD64, Image: image}) {
@@ -169,9 +169,13 @@ func TestParsePluginConfiguration(t *testing.T) {
 	if got := configuration.runnerTargets["macos-14"]; got != (compiler.RunnerTarget{Queue: "macos-sonoma-arm64", Platform: compiler.PlatformDarwinARM64}) {
 		t.Fatalf("Darwin target = %#v", got)
 	}
-	minimal, err := parsePluginConfiguration(`{"workflow":"workflow.yml"}`)
-	if err != nil || minimal.Workflow != "workflow.yml" || len(minimal.runnerTargets) != 0 {
+	minimal, err := parsePluginConfiguration(`{"workflows":"workflow.yml"}`)
+	if err != nil || !slices.Equal(minimal.Workflows, []string{"workflow.yml"}) || len(minimal.runnerTargets) != 0 {
 		t.Fatalf("minimal configuration = %#v, %v", minimal, err)
+	}
+	legacy, err := parsePluginConfiguration(`{"workflow":"legacy.yml"}`)
+	if err != nil || !slices.Equal(legacy.Workflows, []string{"legacy.yml"}) {
+		t.Fatalf("legacy configuration = %#v, %v", legacy, err)
 	}
 
 	for _, test := range []struct {
@@ -180,8 +184,14 @@ func TestParsePluginConfiguration(t *testing.T) {
 		want   string
 	}{
 		{name: "malformed", source: `{`, want: "decode"},
-		{name: "missing workflow", source: `{}`, want: "workflow is required"},
+		{name: "missing workflows", source: `{}`, want: "workflows is required"},
 		{name: "duplicate workflow", source: `{"workflow":"one.yml","workflow":"two.yml"}`, want: "duplicate object key"},
+		{name: "both workflow fields", source: `{"workflow":"one.yml","workflows":"two.yml"}`, want: "mutually exclusive"},
+		{name: "empty workflow", source: `{"workflow":""}`, want: "workflow must be a non-empty string"},
+		{name: "empty workflows string", source: `{"workflows":""}`, want: "non-empty string or array"},
+		{name: "empty workflows array", source: `{"workflows":[]}`, want: "non-empty string or array"},
+		{name: "non-string workflow entry", source: `{"workflows":["one.yml",null]}`, want: "workflows entry 1 must be a non-empty string"},
+		{name: "empty workflow entry", source: `{"workflows":["one.yml",""]}`, want: "workflows entry 1 must be a non-empty string"},
 		{name: "unknown top-level field", source: `{"workflow":"ci.yml","runnerss":[]}`, want: "unknown field"},
 		{name: "retired source acquisition field", source: `{"workflow":"ci.yml","buildkite-gha-source-ref":"latest"}`, want: "unknown field"},
 		{name: "null runners", source: `{"workflow":"ci.yml","runners":null}`, want: "non-empty array"},
@@ -276,8 +286,8 @@ func TestPluginUsesJSONConfigurationAndOnlyRequiredRuntime(t *testing.T) {
 		t.Fatal(err)
 	}
 	configuration, err := json.Marshal(map[string]any{
-		"workflow": workflowPath,
-		"version":  "0.8.0",
+		"workflows": workflowPath,
+		"version":   "0.8.0",
 		"runners": []map[string]string{
 			{"runs-on": "ubuntu-latest", "queue": "hosted"},
 		},
@@ -316,6 +326,40 @@ func TestPluginUsesJSONConfigurationAndOnlyRequiredRuntime(t *testing.T) {
 		if step.Agents["queue"] != "hosted" || step.Image != defaultNobleRunnerImage || !strings.Contains(step.Command, "--hosted-tool-cache") {
 			t.Fatalf("plugin profile was not applied: %#v", step)
 		}
+	}
+}
+
+func TestPluginUploadsPluralWorkflowList(t *testing.T) {
+	requireImporterHost(t)
+	configuration, err := json.Marshal(map[string]any{
+		"workflows": []string{
+			filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "shell.yml"),
+			filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "concurrent.yml"),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(pluginConfigurationEnvironment, string(configuration))
+	setCLIPluginBuildkiteEnvironment(t, "plugin-workflows")
+	runner := &cliCaptureRunner{}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"plugin"}, &stdout, &stderr, "dev", runner); code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Uploaded 5 jobs from 2 workflows") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+	var pipeline struct {
+		Steps []struct {
+			Group string `yaml:"group"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(runner.commands[len(runner.commands)-1].stdin, &pipeline); err != nil {
+		t.Fatal(err)
+	}
+	if len(pipeline.Steps) != 2 {
+		t.Fatalf("workflow groups = %#v", pipeline.Steps)
 	}
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -163,6 +163,9 @@ func TestParsePluginConfiguration(t *testing.T) {
 	if !slices.Equal(configuration.Workflows, []string{".github/workflows/ci.yml", ".github/workflows/release.yml"}) || len(configuration.runnerTargets) != 2 {
 		t.Fatalf("configuration = %#v", configuration)
 	}
+	if !configuration.explicitWorkflowPaths {
+		t.Fatal("workflows array did not retain explicit path semantics")
+	}
 	if got := configuration.runnerTargets["ubuntu-latest"]; got != (compiler.RunnerTarget{Queue: "hosted", Platform: compiler.PlatformLinuxAMD64, Image: image}) {
 		t.Fatalf("Linux target = %#v", got)
 	}
@@ -170,7 +173,7 @@ func TestParsePluginConfiguration(t *testing.T) {
 		t.Fatalf("Darwin target = %#v", got)
 	}
 	minimal, err := parsePluginConfiguration(`{"workflows":"workflow.yml"}`)
-	if err != nil || !slices.Equal(minimal.Workflows, []string{"workflow.yml"}) || len(minimal.runnerTargets) != 0 {
+	if err != nil || !slices.Equal(minimal.Workflows, []string{"workflow.yml"}) || minimal.explicitWorkflowPaths || len(minimal.runnerTargets) != 0 {
 		t.Fatalf("minimal configuration = %#v, %v", minimal, err)
 	}
 	legacy, err := parsePluginConfiguration(`{"workflow":"legacy.yml"}`)
@@ -360,6 +363,26 @@ func TestPluginUploadsPluralWorkflowList(t *testing.T) {
 	}
 	if len(pipeline.Steps) != 2 {
 		t.Fatalf("workflow groups = %#v", pipeline.Steps)
+	}
+}
+
+func TestPluginRejectsGlobInSingleEntryWorkflowList(t *testing.T) {
+	requireImporterHost(t)
+	configuration, err := json.Marshal(map[string]any{
+		"workflows": []string{filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "*.yml")},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(pluginConfigurationEnvironment, string(configuration))
+	setCLIPluginBuildkiteEnvironment(t, "plugin-workflows-glob")
+	runner := &cliCaptureRunner{}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"plugin"}, &stdout, &stderr, "dev", runner); code != 1 || !strings.Contains(stderr.String(), "explicit paths") {
+		t.Fatalf("run() code/stderr = %d / %q", code, stderr.String())
+	}
+	if stdout.Len() != 0 || len(runner.commands) != 0 || len(runner.uploaded) != 0 {
+		t.Fatalf("invalid workflow list reached Buildkite: stdout %q, commands %#v, uploads %#v", stdout.String(), runner.commands, runner.uploaded)
 	}
 }
 


### PR DESCRIPTION
## Why

The companion plugin now sends `workflows`, but the released runtime accepts only the legacy singular `workflow` field. Live release smoke therefore fails before upload.

## What

Accept `workflows` as either one selector or an explicit path list, while retaining singular `workflow` compatibility for existing plugin releases. Reject ambiguous or malformed configuration before upload. Update the CLI and compatibility docs to match the released plugin and macOS support.
