### PR TITLE
Fix OSS corpus event fidelity

### DIFF
--- a/scripts/oss-corpus
+++ b/scripts/oss-corpus
@@ -35,7 +35,7 @@ trap 'rm -rf -- "$work"' EXIT
 
 cd "$root"
 jq -e '
-  .schema == "buildkite-gha/oss-corpus/v3" and
+  .schema == "buildkite-gha/oss-corpus/v4" and
   (.cases | type == "array" and length > 0) and
   all(.cases[];
     (.id | test("^[a-z0-9]+(?:-[a-z0-9]+)*$")) and
@@ -45,6 +45,13 @@ jq -e '
     (.workflow_sha256 | test("^[0-9a-f]{64}$")) and
     (.default_branch | test("^[A-Za-z0-9][A-Za-z0-9._/-]*$") and (contains("..") | not)) and
     (.event | IN("push", "pull_request")) and
+    (if .event == "push" then
+      ((.event_action // "") == "") and
+      ((.event_branch // .default_branch) | test("^[A-Za-z0-9][A-Za-z0-9._/-]*$") and (contains("..") | not))
+    else
+      ((.event_branch // "") == "") and
+      (.event_action | type == "string" and test("^[a-z][a-z_]*$"))
+    end) and
     ((.github_run == null) or (.github_run | test("^https://github.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/actions/runs/[1-9][0-9]*$")))) and
   ([.cases[].id] | length == (unique | length))
 ' "$manifest" >/dev/null
@@ -70,6 +77,8 @@ if $profile; then
   desired=admitted
   validate_args=(--profile hosted-tokenless)
 fi
+success_label=compilable
+$profile && success_label=admitted
 summary="$work/summary.md"
 printf '### OSS workflow compatibility — %s\n\n' "$mode" > "$summary"
 passed=0
@@ -85,11 +94,12 @@ clean_env() {
 }
 
 make_event() {
-  local repository=$1 commit=$2 branch=$3 event=$4 destination=$5
+  local repository=$1 commit=$2 branch=$3 event=$4 event_branch=$5 event_action=$6 destination=$7
   local owner=${repository%%/*} name=${repository#*/}
   jq -n \
     --arg owner "$owner" --arg name "$name" --arg sha "$commit" \
-    --arg branch "$branch" --arg event "$event" '
+    --arg branch "$branch" --arg event "$event" --arg event_branch "$event_branch" \
+    --arg event_action "$event_action" '
     def clone_url: "https://github.com/" + $owner + "/" + $name + ".git";
     def payload_repo: {
       clone_url: clone_url,
@@ -105,17 +115,18 @@ make_event() {
       provider: "github",
       event: $event,
       repository: repository,
-      ref: (if $event == "pull_request" then "refs/pull/1/head" else "refs/heads/" + $branch end),
+      ref: (if $event == "pull_request" then "refs/pull/1/head" else "refs/heads/" + $event_branch end),
       sha: $sha,
       actor: "buildkite-gha-corpus",
       payload: (if $event == "pull_request" then {
+        action: $event_action,
         number: 1,
         pull_request: {
           number: 1,
           head: {sha: $sha, ref: "corpus", repo: payload_repo},
           base: {ref: $branch, repo: payload_repo}
         }
-      } else {ref: ("refs/heads/" + $branch)} end)
+      } else {ref: ("refs/heads/" + $event_branch)} end)
     }
   ' > "$destination"
 }
@@ -156,6 +167,8 @@ for id in "${case_ids[@]}"; do
   workflow_sha256="$(jq -r '.workflow_sha256' <<<"$entry")"
   branch="$(jq -r '.default_branch' <<<"$entry")"
   event="$(jq -r '.event' <<<"$entry")"
+  event_branch="$(jq -r '.event_branch // .default_branch' <<<"$entry")"
+  event_action="$(jq -r '.event_action // ""' <<<"$entry")"
 
   case_root="$work/cases/$id"
   workflow_path="$case_root/$workflow"
@@ -169,7 +182,7 @@ for id in "${case_ids[@]}"; do
     echo "$id: workflow digest=$actual_sha256, want $workflow_sha256" >&2
     exit 1
   }
-  make_event "$repository" "$commit" "$branch" "$event" "$event_path"
+  make_event "$repository" "$commit" "$branch" "$event" "$event_branch" "$event_action" "$event_path"
 
   status=0
   report="$work/$id.$mode.json"
@@ -181,7 +194,7 @@ for id in "${case_ids[@]}"; do
   record_report "$id" "$status" "$report"
 done
 
-printf '\n**%d passing; %d blocked.**\n' "$passed" "$blocked" >> "$summary"
+printf '\n**%d %s; %d blocked.**\n' "$passed" "$success_label" "$blocked" >> "$summary"
 cat "$summary"
 if [[ "${BUILDKITE:-}" == true ]] && command -v buildkite-agent >/dev/null; then
   style=success

--- a/testdata/oss/README.md
+++ b/testdata/oss/README.md
@@ -11,18 +11,21 @@ It does not clone the repository or execute third-party code. This deliberately
 limits the corpus to workflows that do not need repository-local actions or
 reusable workflows during compilation.
 
+Push cases can set `event_branch`; otherwise they use `default_branch`.
+Pull-request cases set `event_action` so the synthetic event is complete.
+
 The initial ten cases deliberately mix outcomes:
 
 | Case | Ecosystem/shape | Exact GitHub run | Current boundary |
 | --- | --- | --- | --- |
 | `urfave-cli-lint` | Go setup and third-party lint action | [Success](https://github.com/urfave/cli/actions/runs/29794452917) | Admitted by profile evaluation; runtime remains unproven. |
-| `fastify-markdown-lint` | Small Node lint job with pinned actions | — | Admitted by profile evaluation; runtime remains unproven. |
+| `fastify-markdown-lint` | Small Node lint job with pinned actions | — | Push path filters are unsupported. The corpus uses a non-default push branch that passes the workflow's branch filter. |
 | `prettier-lint` | Larger Yarn, cache, condition, and concurrency workflow | [Success](https://github.com/prettier/prettier/actions/runs/31316608109) | Admitted with ignored concurrency-cancellation behavior; runtime remains unproven. |
-| `bat-changelog` | Pull-request shell and output workflow | — | Admitted; runtime needs a faithful real PR event. |
-| `p-map-main` | Two-entry Node matrix | [Success](https://github.com/sindresorhus/p-map/actions/runs/29779845179) | Admitted by profile evaluation; runtime remains unproven. |
+| `bat-changelog` | Pull-request shell and output workflow | — | Compiles with the synthetic `synchronize` event but is not admitted because implicit checkout credentials require unverified token-write access. |
+| `p-map-main` | Two-entry Node matrix | [Success](https://github.com/sindresorhus/p-map/actions/runs/29779845179) | Not admitted because implicit checkout credentials require unverified token-write access. |
 | `fzf-linux` | Go, Ruby, multiple shells, and host package setup | [Success](https://github.com/junegunn/fzf/actions/runs/31253573599) | Admitted; checkout's requested full history is supported. Runtime remains unproven. |
-| `jq-valgrind` | C/autotools/Valgrind plus failure artifact | [Success](https://github.com/jqlang/jq/actions/runs/30182447884) | Profile-admitted with bounded direct submodules; emits `W_ACTION_RUNTIME_UNKNOWN` because static action metadata cannot prove independence from every GitHub-only runtime service. The profile does not execute the checkout or build. |
-| `go-task-ci` | Five-job Go matrix | [Success](https://github.com/go-task/task/actions/runs/31330279154) | Compound concurrency expression is unsupported. |
+| `jq-valgrind` | C/autotools/Valgrind plus failure artifact | [Success](https://github.com/jqlang/jq/actions/runs/30182447884) | Not admitted because implicit checkout credentials require unverified token-write access. |
+| `go-task-ci` | Five-job Go matrix | [Success](https://github.com/go-task/task/actions/runs/31330279154) | The `github.head_ref` concurrency expression and non-Linux matrix rows are unsupported. |
 | `gum-build` | Remote reusable workflow | — | Remote reuse and runtime secret forwarding are unsupported. |
 | `just-ci` | Rust and a mixed-OS matrix | [Success](https://github.com/casey/just/actions/runs/31140381397) | Non-Linux runner rows are unsupported. |
 
@@ -32,13 +35,13 @@ Run the networked compile corpus with:
 mise run corpus:oss
 ```
 
-This prints every result, reports a passing/blocked summary, and exits non-zero
+This prints every result, reports a compilable/blocked summary, and exits non-zero
 while any workflow is not compilable. Seven cases also retain a successful
 upstream GitHub run at the exact source SHA as a future comparison reference.
 Compiler determinism remains covered by the repository-owned smoke fixtures.
 
-The profile scan resolves public actions and treats only admitted workflows as
-passing:
+The profile scan resolves public actions and counts only admitted workflows in
+its admitted total:
 
 ```sh
 mise run corpus:oss-profile

--- a/testdata/oss/manifest.json
+++ b/testdata/oss/manifest.json
@@ -1,5 +1,5 @@
 {
-  "schema": "buildkite-gha/oss-corpus/v3",
+  "schema": "buildkite-gha/oss-corpus/v4",
   "cases": [
     {
       "id": "urfave-cli-lint",
@@ -19,6 +19,7 @@
       "workflow_sha256": "1df71d89b1ce8a22025539d35760db833c4c7a182d0e0eac417d95d8420f2cee",
       "default_branch": "main",
       "event": "push",
+      "event_branch": "corpus-markdown-change",
       "github_run": null
     },
     {
@@ -39,6 +40,7 @@
       "workflow_sha256": "31f33b596fbced2e8b1291bcda024ffc2300b3c1c27cc66df19dbce37c3acbb5",
       "default_branch": "master",
       "event": "pull_request",
+      "event_action": "synchronize",
       "github_run": null
     },
     {


### PR DESCRIPTION
## Why

The OSS compatibility profile used an incomplete pull-request event for `bat-changelog` and a non-matching default-branch push for `fastify-markdown-lint`. Its annotation also described profile admission as “passing,” and the documented case boundaries no longer matched current results.

## What

Add explicit event branches and pull-request actions to corpus v4, then use them when building synthetic snapshots. Report compile and profile totals as “compilable” and “admitted,” and update the compatibility table to describe the current boundaries without weakening hosted-tokenless admission.
