### PR TITLE
Align push webhook refs for PR-associated builds

### DIFF
--- a/internal/cli/buildkite_event.go
+++ b/internal/cli/buildkite_event.go
@@ -145,6 +145,16 @@ func buildkiteWebhookEventSource(getenv func(string) string, webhook []byte) ([]
 	snapshot["payload"] = payload
 	if event := strings.TrimSpace(getenv("BUILDKITE_GITHUB_EVENT")); githubEventNamePattern.MatchString(event) {
 		snapshot["event"] = event
+		// Buildkite can associate a push-created build with an open pull
+		// request. Keep the authoritative execution ref consistent with the
+		// linked webhook event rather than retaining refs/pull/<n>/head.
+		if event == "push" {
+			if tag := strings.TrimSpace(getenv("BUILDKITE_TAG")); tag != "" {
+				snapshot["ref"] = "refs/tags/" + tag
+			} else if branch := strings.TrimSpace(getenv("BUILDKITE_BRANCH")); branch != "" {
+				snapshot["ref"] = "refs/heads/" + branch
+			}
+		}
 	}
 	if sender, ok := payload["sender"].(map[string]any); ok {
 		if login, ok := sender["login"].(string); ok && safeGitHubLogin(login) {

--- a/internal/cli/buildkite_event_test.go
+++ b/internal/cli/buildkite_event_test.go
@@ -148,6 +148,28 @@ func TestBuildkiteWebhookEventSourceUsesPayloadButPreservesExecutionIdentity(t *
 	}
 }
 
+func TestBuildkiteWebhookPushUsesBranchRefForPullRequestAssociatedBuild(t *testing.T) {
+	env := map[string]string{
+		"BUILDKITE": "true", "BUILDKITE_STEP_KEY": "step",
+		"BUILDKITE_REPO":         "https://github.com/buildkite/buildkite-gha",
+		"BUILDKITE_COMMIT":       strings.Repeat("a", 40),
+		"BUILDKITE_BRANCH":       "feature",
+		"BUILDKITE_PULL_REQUEST": "42",
+		"BUILDKITE_GITHUB_EVENT": "push",
+	}
+	source, err := buildkiteWebhookEventSource(func(key string) string { return env[key] }, []byte(`{"ref":"refs/heads/feature"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var snapshot map[string]any
+	if err := json.Unmarshal(source, &snapshot); err != nil {
+		t.Fatal(err)
+	}
+	if snapshot["event"] != "push" || snapshot["ref"] != "refs/heads/feature" {
+		t.Fatalf("snapshot event/ref = %q / %q", snapshot["event"], snapshot["ref"])
+	}
+}
+
 func TestBuildkiteWebhookEventSourceEventAndActorFallbacks(t *testing.T) {
 	env := map[string]string{
 		"BUILDKITE": "true", "BUILDKITE_STEP_KEY": "step",


### PR DESCRIPTION
## Why

Buildkite can associate a webhook-created push build with an open pull request. The webhook then selected `push` while the compatibility snapshot retained `refs/pull/<n>/head`, causing trigger translation to reject otherwise valid plugin uploads.

## What

When linked webhook metadata selects `push`, derive the authoritative ref from the Buildkite tag or branch. Keep the existing pull-request ref behavior for pull-request events and cover the mixed push/PR-association case with a regression test.
