### PR TITLE
Rename hosted-tokenless profile to hosted

### DIFF
--- a/.deepsec/data/buildkite-gha/INFO.md
+++ b/.deepsec/data/buildkite-gha/INFO.md
@@ -13,7 +13,7 @@ cache, and narrowly supported Docker action behaviour.
 
 ## Auth shape
 
-- `hosted-tokenless` admission is the production authority boundary. Fresh
+- `hosted` admission is the production authority boundary. Fresh
   compiler `PlanAuthorization` evidence decides whether requested Docker or
   provider-token capabilities may enter an uploaded plan.
 - `plan.Job.Validate`, `verifyWorkflow`, and runtime capability checks bind a
@@ -49,7 +49,7 @@ the same VM.
 ## Project-specific patterns to flag
 
 - Any path from workflow/event/plan fields to queue selection or
-  `RequiredCapabilities` that bypasses `hosted-tokenless` admission or relies
+  `RequiredCapabilities` that bypasses `hosted` admission or relies
   on encoded-plan claims instead of same-process compiler evidence.
 - Any Buildkite Agent access token, repository credential, GitHub token,
   workflow secret, or cache token persisted in plans, pipeline YAML, logs,

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ To resolve public actions and apply the production upload policy, provide an eve
 
 ```sh
 buildkite-gha validate \
-  --profile hosted-tokenless \
+  --profile hosted \
   --event-path .buildkite/events/current.json \
   .github/workflows/ci.yml
 ```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -28,10 +28,12 @@ Resolve actions and apply production policy:
 
 ```sh
 buildkite-gha validate \
-  --profile hosted-tokenless \
+  --profile hosted \
   --event-path .buildkite/events/current.json \
   .github/workflows/ci.yml
 ```
+
+The deprecated `hosted-tokenless` profile name remains an alias for `hosted`.
 
 Use `--format json` for a `buildkite-gha/processing-report/v1` report.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,6 +1,6 @@
 # GitHub Actions compatibility
 
-This page defines the initial production contract for `buildkite-gha`. It applies to the `hosted-tokenless` profile used by `upload` and the Buildkite plugin.
+This page defines the initial production contract for `buildkite-gha`. It applies to the `hosted` profile used by `upload` and the Buildkite plugin.
 
 The released plugin path supports Linux x86-64 and native macOS arm64, including
 the matching `runner.os` and `runner.arch` values. Platform labels do not provide
@@ -339,7 +339,7 @@ A job may expand to at most 256 instances. Matrices derived from `needs` or `ste
 
 ### Containers and services
 
-**🚧 Not available in production.** The compiler and runtime support a bounded Linux subset for job `container` and `services`, but the `hosted-tokenless` profile rejects it before upload.
+**🚧 Not available in production.** The compiler and runtime support a bounded Linux subset for job `container` and `services`, but the `hosted` profile rejects it before upload.
 
 The underlying subset accepts literal public image names, environment maps, and ports. Credentials, volumes, options, private images, dynamic values, and privileged containers are unsupported.
 
@@ -732,7 +732,7 @@ Apply the same profile as production upload:
 
 ```sh
 buildkite-gha validate \
-  --profile hosted-tokenless \
+  --profile hosted \
   --event-path .buildkite/events/current.json \
   .github/workflows/ci.yml
 ```

--- a/docs/development.md
+++ b/docs/development.md
@@ -45,7 +45,7 @@ mise run release:check
 mise run smoke:profile
 ```
 
-The profile task uses the network to resolve selected public actions and apply the production `hosted-tokenless` policy. Admission still does not execute action code. See [`testdata/smoke/README.md`](../testdata/smoke/README.md) for the inventory and result meanings.
+The profile task uses the network to resolve selected public actions and apply the production `hosted` policy. Admission still does not execute action code. See [`testdata/smoke/README.md`](../testdata/smoke/README.md) for the inventory and result meanings.
 
 ## Verify runtime behavior
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -57,7 +57,7 @@ Command scoping limits accidental spread. It does not stop a hostile concurrent 
 
     ```sh
     buildkite-gha validate \
-      --profile hosted-tokenless \
+      --profile hosted \
       --event-path event.json \
       .github/workflows/ci.yml
     ```

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -53,7 +53,7 @@ Run "buildkite-gha help <command>" for command help.
 `
 
 var commandUsage = map[string]string{
-	"validate": "Usage: buildkite-gha validate [--event-path <path>] [--profile hosted-tokenless] [--format text|json] <workflow>\n",
+	"validate": "Usage: buildkite-gha validate [--event-path <path>] [--profile hosted] [--format text|json] <workflow>\n",
 	"compile":  "Usage: buildkite-gha compile --event-path <path> [--format pipeline|ir-json] <workflow>\n",
 	"upload":   "Usage: buildkite-gha upload [--event-path <path>] [--runner-queue <runs-on>=<queue>]... [--runner-image <runs-on>=<immutable-image>]... [--runtime-distribution <platform>=<absolute-path>]... [--runtime-queue hosted] [--] <workflow-pattern | workflow-path> [<workflow-path>...]\n",
 	"run-job":  "Usage: buildkite-gha run-job (--plan <path> | --plan-digest <digest> --plan-producer <step>) [--result <path>] [--hosted-tool-cache]\n",
@@ -63,7 +63,7 @@ func writeCommandHelp(stdout io.Writer, command string) {
 	_, _ = fmt.Fprint(stdout, commandUsage[command])
 	switch command {
 	case "validate":
-		_, _ = fmt.Fprint(stdout, "\nThe hosted-tokenless profile resolves actions and applies production upload policy without executing jobs or proving arbitrary action runtime compatibility.\n")
+		_, _ = fmt.Fprint(stdout, "\nThe hosted profile resolves actions and applies production upload policy without executing jobs or proving arbitrary action runtime compatibility.\n")
 	case "compile":
 		_, _ = fmt.Fprint(stdout, "\nPipeline output references content-addressed plans; compile does not materialize or upload those artifacts.\n")
 	case "upload":
@@ -80,7 +80,8 @@ const (
 	legacyRuntimeImageEnvironment               = "BUILDKITE_GHA_RUNTIME_IMAGE"
 	repositoryProviderGitCredentialsEnvironment = "BUILDKITE_USE_REPOSITORY_PROVIDER_GIT_CREDENTIALS"
 	legacyGitHubAppGitCredentialsEnvironment    = "BUILDKITE_USE_GITHUB_APP_GIT_CREDENTIALS"
-	hostedTokenlessProfile                      = "hosted-tokenless"
+	hostedProfile                               = "hosted"
+	legacyHostedTokenlessProfile                = "hosted-tokenless"
 	runtimeMiseArchiveDigest                    = "bd0930c0b619f51ddb60e32e5cce18a5533567b2f1ba9fc4875b9f39a2bb3ed8"
 	runtimeMiseBinaryDigest                     = "a238972a3162d710b85b28c324372e96ca4e4b486c81fe78695000d9fbc77c48"
 	runtimeMiseDarwinARM64ArchiveDigest         = "5b883c868a0748dd0c595d30fd000ec5138dfabdeef2c30222866ebf34af1ae3"
@@ -1232,14 +1233,14 @@ func validate(args []string, stdout, stderr io.Writer, version string) int {
 		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 		defer stop()
 		runtimeDistributions := map[compiler.Platform]string{compiler.PlatformLinuxAMD64: distributionDigest}
-		preflight, profileErr := compileHostedTokenless(ctx, workflowPath, source, event, version, distributionDigest, "buildkite-gha-profile-importer", "", nil, runtimeDistributions, nil)
+		preflight, profileErr := compileHosted(ctx, workflowPath, source, event, version, distributionDigest, "buildkite-gha-profile-importer", "", nil, runtimeDistributions, nil)
 		applyHostedPreflight(&processingReport, preflight)
 		if profileErr != nil {
 			if ctx.Err() != nil || errors.Is(profileErr, context.Canceled) {
 				_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: profile evaluation interrupted: %v\n", profileErr)
 				return 1
 			}
-			processingReport.Result = classifyHostedTokenlessFailure(&processingReport, workflowPath, profileErr)
+			processingReport.Result = classifyHostedFailure(&processingReport, workflowPath, profileErr)
 			_ = out.write(processingReport)
 			return 1
 		}
@@ -1294,9 +1295,10 @@ func validateArgs(args []string) (workflowPath, eventPath, format, profile strin
 		} else {
 			profileSeen = true
 			profile = args[i]
-			if profile != hostedTokenlessProfile {
-				return "", "", "", "", fmt.Errorf("--profile must be %q", hostedTokenlessProfile)
+			if profile != hostedProfile && profile != legacyHostedTokenlessProfile {
+				return "", "", "", "", fmt.Errorf("--profile must be %q", hostedProfile)
 			}
+			profile = hostedProfile
 		}
 	}
 	workflowPath, eventPath, err = workflowArgs(filtered)
@@ -1411,12 +1413,12 @@ func uploadParsed(uploadArguments parsedUploadArgs, stdout, stderr io.Writer, ve
 	for i := range workflows {
 		workflows[i].Source, err = os.ReadFile(workflows[i].Path)
 		if err != nil {
-			report := compatibility.EnvironmentProcessingReport(workflows[i].Path, hostedTokenlessProfile, "workflow input could not be read")
+			report := compatibility.EnvironmentProcessingReport(workflows[i].Path, hostedProfile, "workflow input could not be read")
 			return out.fail(report, fmt.Errorf("read workflow %s: %w", workflows[i].CanonicalPath, err))
 		}
 		parsed, parseErr := workflow.Parse(workflows[i].Path, workflows[i].Source)
 		if parseErr != nil {
-			_, _ = validatedProcessingReport(out, workflows[i].Path, hostedTokenlessProfile, workflows[i].Source, nil, false)
+			_, _ = validatedProcessingReport(out, workflows[i].Path, hostedProfile, workflows[i].Source, nil, false)
 			return 1
 		}
 		workflows[i].ReusableOnly = parsed.ReusableOnly()
@@ -1442,7 +1444,7 @@ func uploadParsed(uploadArguments parsedUploadArgs, stdout, stderr io.Writer, ve
 		}
 		validation, validationErr := compiler.Validate(input.Path, input.Source)
 		if validation.RuntimeMatrixBoundary {
-			report := compatibility.InitialProcessingReport(input.Path, hostedTokenlessProfile, false, validation, validationErr)
+			report := compatibility.InitialProcessingReport(input.Path, hostedProfile, false, validation, validationErr)
 			report.Result = "incompatible"
 			_ = out.write(report)
 			return 1
@@ -1452,7 +1454,7 @@ func uploadParsed(uploadArguments parsedUploadArgs, stdout, stderr io.Writer, ve
 	if err != nil {
 		for _, input := range workflows {
 			if !input.ReusableOnly {
-				return out.fail(compatibility.EventInputProcessingReport(input.Path, hostedTokenlessProfile, input.Source, "event input could not be acquired"), err)
+				return out.fail(compatibility.EventInputProcessingReport(input.Path, hostedProfile, input.Source, "event input could not be acquired"), err)
 			}
 		}
 		return 1
@@ -1461,7 +1463,7 @@ func uploadParsed(uploadArguments parsedUploadArgs, stdout, stderr io.Writer, ve
 	if err != nil {
 		for _, input := range workflows {
 			if !input.ReusableOnly {
-				_, _ = validatedProcessingReport(out, input.Path, hostedTokenlessProfile, input.Source, eventSource, true)
+				_, _ = validatedProcessingReport(out, input.Path, hostedProfile, input.Source, eventSource, true)
 				return 1
 			}
 		}
@@ -1487,9 +1489,9 @@ func uploadParsed(uploadArguments parsedUploadArgs, stdout, stderr io.Writer, ve
 		if !input.Applicable {
 			continue
 		}
-		validationOptions := hostedTokenlessOptions("", uploadArguments.runnerTargets, nil)
+		validationOptions := hostedOptions("", uploadArguments.runnerTargets, nil)
 		validationOptions.StepKeyNamespace = input.StepKeyNamespace
-		processingReport, ok := validatedProcessingReportWithOptions(out, input.Path, hostedTokenlessProfile, input.Source, effectiveEvent.Source, true, &validationOptions)
+		processingReport, ok := validatedProcessingReportWithOptions(out, input.Path, hostedProfile, input.Source, effectiveEvent.Source, true, &validationOptions)
 		if !ok {
 			return 1
 		}
@@ -1564,10 +1566,10 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 			})
 			continue
 		}
-		preflight, err := compileHostedTokenlessNamespaced(ctx, input.Path, input.Source, effectiveEvent.Source, version, distributionDigest, importerStep, "", uploadArguments.runnerTargets, runtimeDigests, input.StepKeyNamespace, authentication)
+		preflight, err := compileHostedNamespaced(ctx, input.Path, input.Source, effectiveEvent.Source, version, distributionDigest, importerStep, "", uploadArguments.runnerTargets, runtimeDigests, input.StepKeyNamespace, authentication)
 		applyHostedPreflight(&processingReports[i], preflight)
 		if err != nil {
-			processingReports[i].Result = classifyHostedTokenlessFailure(&processingReports[i], input.Path, err)
+			processingReports[i].Result = classifyHostedFailure(&processingReports[i], input.Path, err)
 			_ = out.write(processingReports[i])
 			return 1
 		}
@@ -1650,7 +1652,7 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 }
 
 func requiredRuntimePlatforms(workflowPath string, workflowSource, eventSource []byte, groupLabel string, configuredTargets map[string]compiler.RunnerTarget) (map[compiler.Platform]bool, error) {
-	preflight, err := compiler.CompileWithOptions(workflowPath, workflowSource, eventSource, hostedTokenlessOptions(groupLabel, configuredTargets, nil))
+	preflight, err := compiler.CompileWithOptions(workflowPath, workflowSource, eventSource, hostedOptions(groupLabel, configuredTargets, nil))
 	if err != nil {
 		return nil, err
 	}
@@ -1796,7 +1798,7 @@ func triggerFailureProcessingReport(input workflowInput, err error) compatibilit
 
 func triggerProcessingReport(path string, source []byte) compatibility.ProcessingReport {
 	parsed, _ := compiler.ParseWorkflow(path, source)
-	report := compatibility.NewProcessingReport(path, hostedTokenlessProfile)
+	report := compatibility.NewProcessingReport(path, hostedProfile)
 	report.LogicalJobs = parsed.LogicalJobs
 	report.SetStage(string(compiler.StageWorkflowParsing), compatibility.Passed)
 	report.SetStage(string(compiler.StageEventValidation), compatibility.Passed)
@@ -1968,30 +1970,30 @@ func workflowInputs(matches []workflowInput, namespaceKeys bool) ([]workflowInpu
 	return out, nil
 }
 
-type hostedTokenlessCompilation struct {
+type hostedCompilation struct {
 	Bundle     compiler.Bundle
 	HasActions bool
 	Admitted   bool
 }
 
-type hostedTokenlessFailureKind string
+type hostedFailureKind string
 
 const (
-	hostedTokenlessEnvironmentFailure hostedTokenlessFailureKind = "environment"
-	hostedTokenlessEvaluationFailure  hostedTokenlessFailureKind = "evaluation"
-	hostedTokenlessAdmissionFailure   hostedTokenlessFailureKind = "admission"
+	hostedEnvironmentFailure hostedFailureKind = "environment"
+	hostedEvaluationFailure  hostedFailureKind = "evaluation"
+	hostedAdmissionFailure   hostedFailureKind = "admission"
 )
 
-type hostedTokenlessFailure struct {
-	Kind hostedTokenlessFailureKind
+type hostedFailure struct {
+	Kind hostedFailureKind
 	Err  error
 }
 
-func (e *hostedTokenlessFailure) Error() string { return e.Err.Error() }
-func (e *hostedTokenlessFailure) Unwrap() error { return e.Err }
+func (e *hostedFailure) Error() string { return e.Err.Error() }
+func (e *hostedFailure) Unwrap() error { return e.Err }
 
-func hostedTokenlessError(kind hostedTokenlessFailureKind, err error) error {
-	return &hostedTokenlessFailure{Kind: kind, Err: err}
+func hostedError(kind hostedFailureKind, err error) error {
+	return &hostedFailure{Kind: kind, Err: err}
 }
 
 type actionSourceAuthentication struct {
@@ -2064,7 +2066,7 @@ func (a *actionSourceAuthentication) warnAnonymousFallback(reason string) {
 	}
 }
 
-func hostedTokenlessOptions(groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runtimeDistributions map[compiler.Platform]string) compiler.Options {
+func hostedOptions(groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runtimeDistributions map[compiler.Platform]string) compiler.Options {
 	targets := map[string]compiler.RunnerTarget{
 		"ubuntu-latest": {Platform: compiler.PlatformLinuxAMD64},
 		"ubuntu-24.04":  {Platform: compiler.PlatformLinuxAMD64},
@@ -2090,26 +2092,26 @@ func hostedTokenlessOptions(groupLabel string, configuredTargets map[string]comp
 	return options
 }
 
-func compileHostedTokenless(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runtimeDistributions map[compiler.Platform]string, actionAuthentication *actionSourceAuthentication) (hostedTokenlessCompilation, error) {
-	return compileHostedTokenlessNamespaced(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, groupLabel, configuredTargets, runtimeDistributions, "", actionAuthentication)
+func compileHosted(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runtimeDistributions map[compiler.Platform]string, actionAuthentication *actionSourceAuthentication) (hostedCompilation, error) {
+	return compileHostedNamespaced(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, groupLabel, configuredTargets, runtimeDistributions, "", actionAuthentication)
 }
 
-func compileHostedTokenlessNamespaced(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runtimeDistributions map[compiler.Platform]string, stepKeyNamespace string, actionAuthentication *actionSourceAuthentication) (hostedTokenlessCompilation, error) {
-	options := hostedTokenlessOptions(groupLabel, configuredTargets, runtimeDistributions)
+func compileHostedNamespaced(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runtimeDistributions map[compiler.Platform]string, stepKeyNamespace string, actionAuthentication *actionSourceAuthentication) (hostedCompilation, error) {
+	options := hostedOptions(groupLabel, configuredTargets, runtimeDistributions)
 	options.StepKeyNamespace = stepKeyNamespace
 	preflight, err := compiler.CompileWithOptions(workflowPath, workflowSource, eventSource, options)
 	if err != nil {
-		return hostedTokenlessCompilation{}, hostedTokenlessError(hostedTokenlessEvaluationFailure, err)
+		return hostedCompilation{}, hostedError(hostedEvaluationFailure, err)
 	}
 	var ir compiler.IR
 	if err := json.Unmarshal(preflight, &ir); err != nil {
-		return hostedTokenlessCompilation{}, hostedTokenlessError(hostedTokenlessEvaluationFailure, fmt.Errorf("decode compiler preflight: %w", err))
+		return hostedCompilation{}, hostedError(hostedEvaluationFailure, fmt.Errorf("decode compiler preflight: %w", err))
 	}
 	hasActions := irUsesActions(ir)
 	if hasActions {
 		actionRoot, err := os.MkdirTemp("", "buildkite-gha-action-source-")
 		if err != nil {
-			return hostedTokenlessCompilation{}, hostedTokenlessError(hostedTokenlessEnvironmentFailure, fmt.Errorf("create action source store: %w", err))
+			return hostedCompilation{}, hostedError(hostedEnvironmentFailure, fmt.Errorf("create action source store: %w", err))
 		}
 		defer func() { _ = os.RemoveAll(actionRoot) }()
 		var sourceOptions []actionsource.Option
@@ -2119,30 +2121,30 @@ func compileHostedTokenlessNamespaced(ctx context.Context, workflowPath string, 
 		}
 		resolver, err := actionsource.NewResolver(nil, sourceOptions...)
 		if err != nil {
-			return hostedTokenlessCompilation{}, hostedTokenlessError(hostedTokenlessEnvironmentFailure, fmt.Errorf("configure public action resolver: %w", err))
+			return hostedCompilation{}, hostedError(hostedEnvironmentFailure, fmt.Errorf("configure public action resolver: %w", err))
 		}
 		store, err := actionsource.NewStore(actionRoot, nil)
 		if err != nil {
-			return hostedTokenlessCompilation{}, hostedTokenlessError(hostedTokenlessEnvironmentFailure, fmt.Errorf("configure public action source store: %w", err))
+			return hostedCompilation{}, hostedError(hostedEnvironmentFailure, fmt.Errorf("configure public action source store: %w", err))
 		}
 		options.ResolveActions = true
 		options.ActionSource = compiler.PublicActionSource{Resolver: resolver, Store: store}
 	}
 	bundle, err := compiler.CompileBundlePlansContext(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, options)
 	if err != nil {
-		return hostedTokenlessCompilation{Bundle: bundle, HasActions: hasActions}, hostedTokenlessError(hostedTokenlessEvaluationFailure, err)
+		return hostedCompilation{Bundle: bundle, HasActions: hasActions}, hostedError(hostedEvaluationFailure, err)
 	}
 	if err := validateUnprivilegedBundle(bundle); err != nil {
-		return hostedTokenlessCompilation{Bundle: bundle, HasActions: hasActions}, hostedTokenlessError(hostedTokenlessAdmissionFailure, err)
+		return hostedCompilation{Bundle: bundle, HasActions: hasActions}, hostedError(hostedAdmissionFailure, err)
 	}
 	bundle, err = compiler.GenerateBundlePipeline(bundle, distributionDigest, importerStep, options)
 	if err != nil {
-		return hostedTokenlessCompilation{Bundle: bundle, HasActions: hasActions, Admitted: true}, hostedTokenlessError(hostedTokenlessEvaluationFailure, err)
+		return hostedCompilation{Bundle: bundle, HasActions: hasActions, Admitted: true}, hostedError(hostedEvaluationFailure, err)
 	}
 	if !hasActions && bundleUsesActions(bundle) {
-		return hostedTokenlessCompilation{Bundle: bundle, HasActions: hasActions, Admitted: true}, hostedTokenlessError(hostedTokenlessEvaluationFailure, fmt.Errorf("final compilation introduced actions absent from preflight"))
+		return hostedCompilation{Bundle: bundle, HasActions: hasActions, Admitted: true}, hostedError(hostedEvaluationFailure, fmt.Errorf("final compilation introduced actions absent from preflight"))
 	}
-	return hostedTokenlessCompilation{Bundle: bundle, HasActions: hasActions, Admitted: true}, nil
+	return hostedCompilation{Bundle: bundle, HasActions: hasActions, Admitted: true}, nil
 }
 
 func validateUnprivilegedBundle(bundle compiler.Bundle) error {
@@ -2168,7 +2170,7 @@ func validateUnprivilegedBundle(bundle compiler.Bundle) error {
 		for _, capability := range artifact.Job.RequiredCapabilities {
 			if capability == "docker" && !slices.Equal(artifact.Authorization.DockerCapabilitySources, []string{"dockerfile-actions"}) {
 				if slices.Contains(artifact.Authorization.DockerCapabilitySources, "job-containers") || slices.Contains(artifact.Authorization.DockerCapabilitySources, "service-containers") {
-					addFailure(artifact, "job or service containers are not admitted by the hosted profile", fmt.Errorf("job %q uses job or service containers, which hosted-tokenless upload does not admit", artifact.Job.Workflow.LogicalJobID))
+					addFailure(artifact, "job or service containers are not admitted by the hosted profile", fmt.Errorf("job %q uses job or service containers, which hosted upload does not admit", artifact.Job.Workflow.LogicalJobID))
 					continue
 				}
 				addFailure(artifact, "docker capability lacks compiler-verified action provenance", fmt.Errorf("job %q requires docker without compiler-verified Dockerfile action provenance", artifact.Job.Workflow.LogicalJobID))

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -710,7 +710,7 @@ func TestRunValidateAndCompile(t *testing.T) {
 
 		stdout.Reset()
 		stderr.Reset()
-		if code := Run([]string{"validate", "--profile", "hosted-tokenless", "--format", "json", "--event-path", eventPath, workflow}, &stdout, &stderr, "dev"); code != 1 {
+		if code := Run([]string{"validate", "--profile", "hosted", "--format", "json", "--event-path", eventPath, workflow}, &stdout, &stderr, "dev"); code != 1 {
 			t.Fatalf("profile Run() code = %d, want 1; stderr = %q", code, stderr.String())
 		}
 		var profileReport compatibility.ProcessingReport
@@ -722,9 +722,9 @@ func TestRunValidateAndCompile(t *testing.T) {
 		}
 	})
 
-	t.Run("validate hosted tokenless profile", func(t *testing.T) {
+	t.Run("validate hosted profile", func(t *testing.T) {
 		var stdout, stderr bytes.Buffer
-		args := []string{"validate", "--profile", "hosted-tokenless", "--format", "json", "--event-path", eventPath, workflowPath}
+		args := []string{"validate", "--profile", "hosted", "--format", "json", "--event-path", eventPath, workflowPath}
 		runner := &cliCaptureRunner{}
 		if code := run(args, &stdout, &stderr, "dev", runner); code != 0 {
 			t.Fatalf("Run() code = %d, stderr = %q", code, stderr.String())
@@ -736,18 +736,18 @@ func TestRunValidateAndCompile(t *testing.T) {
 		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 			t.Fatal(err)
 		}
-		if report.Result != "admitted" || report.Profile != "hosted-tokenless" || report.Compile.Instances != 3 || report.Admission.Result != "admitted" || len(report.Diagnostics) != 0 {
+		if report.Result != "admitted" || report.Profile != "hosted" || report.Compile.Instances != 3 || report.Admission.Result != "admitted" || len(report.Diagnostics) != 0 {
 			t.Fatalf("profile report = %#v", report)
 		}
 	})
 
-	t.Run("validate hosted tokenless profile applies upload trigger policy", func(t *testing.T) {
+	t.Run("validate hosted profile applies upload trigger policy", func(t *testing.T) {
 		workflow := filepath.Join(t.TempDir(), "issues.yml")
 		if err := os.WriteFile(workflow, []byte("on: issues\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
 			t.Fatal(err)
 		}
 		var stdout, stderr bytes.Buffer
-		args := []string{"validate", "--profile", "hosted-tokenless", "--format", "json", "--event-path", eventPath, workflow}
+		args := []string{"validate", "--profile", "hosted", "--format", "json", "--event-path", eventPath, workflow}
 		if code := Run(args, &stdout, &stderr, "dev"); code != 1 {
 			t.Fatalf("Run() code = %d, want 1; stderr = %q", code, stderr.String())
 		}
@@ -760,13 +760,13 @@ func TestRunValidateAndCompile(t *testing.T) {
 		}
 	})
 
-	t.Run("validate hosted tokenless profile does not compile a cross-event workflow", func(t *testing.T) {
+	t.Run("validate hosted profile does not compile a cross-event workflow", func(t *testing.T) {
 		workflow := filepath.Join(t.TempDir(), "pull-request.yml")
 		if err := os.WriteFile(workflow, []byte("on: pull_request\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
 			t.Fatal(err)
 		}
 		var stdout, stderr bytes.Buffer
-		args := []string{"validate", "--profile", "hosted-tokenless", "--format", "json", "--event-path", eventPath, workflow}
+		args := []string{"validate", "--profile", "hosted", "--format", "json", "--event-path", eventPath, workflow}
 		if code := Run(args, &stdout, &stderr, "dev"); code != 0 {
 			t.Fatalf("Run() code = %d, stderr = %q", code, stderr.String())
 		}
@@ -779,13 +779,13 @@ func TestRunValidateAndCompile(t *testing.T) {
 		}
 	})
 
-	t.Run("validate hosted tokenless macOS profile requires upload mapping", func(t *testing.T) {
+	t.Run("validate hosted macOS profile requires upload mapping", func(t *testing.T) {
 		workflow := filepath.Join(t.TempDir(), "macos.yml")
 		if err := os.WriteFile(workflow, []byte("on: push\njobs:\n  macos:\n    runs-on: macos-15\n    steps:\n      - run: echo macos\n"), 0o600); err != nil {
 			t.Fatal(err)
 		}
 		var stdout, stderr bytes.Buffer
-		args := []string{"validate", "--profile", "hosted-tokenless", "--format", "json", "--event-path", eventPath, workflow}
+		args := []string{"validate", "--profile", "hosted", "--format", "json", "--event-path", eventPath, workflow}
 		if code := Run(args, &stdout, &stderr, "dev"); code != 1 {
 			t.Fatalf("Run() code = %d, want 1; stderr = %q", code, stderr.String())
 		}
@@ -800,7 +800,7 @@ func TestRunValidateAndCompile(t *testing.T) {
 
 	t.Run("validate profile requires event", func(t *testing.T) {
 		var stdout, stderr bytes.Buffer
-		if code := Run([]string{"validate", "--profile", "hosted-tokenless", workflowPath}, &stdout, &stderr, "dev"); code != 2 || !strings.Contains(stderr.String(), "--event-path is required with --profile") {
+		if code := Run([]string{"validate", "--profile", "hosted", workflowPath}, &stdout, &stderr, "dev"); code != 2 || !strings.Contains(stderr.String(), "--event-path is required with --profile") {
 			t.Fatalf("Run() code = %d, stderr = %q", code, stderr.String())
 		}
 	})
@@ -811,7 +811,7 @@ func TestRunValidateAndCompile(t *testing.T) {
 			t.Fatal(err)
 		}
 		var stdout, stderr bytes.Buffer
-		if code := Run([]string{"validate", "--profile", "hosted-tokenless", "--format", "json", "--event-path", eventPath, workflow}, &stdout, &stderr, "dev"); code != 0 {
+		if code := Run([]string{"validate", "--profile", "hosted", "--format", "json", "--event-path", eventPath, workflow}, &stdout, &stderr, "dev"); code != 0 {
 			t.Fatalf("Run() code = %d, stderr = %q", code, stderr.String())
 		}
 		var report compatibility.ProcessingReport
@@ -2151,7 +2151,7 @@ runs:
 	}
 }
 
-func TestValidateHostedTokenlessProfileResolvesActionsWithoutClaimingRuntime(t *testing.T) {
+func TestValidateHostedProfileResolvesActionsWithoutClaimingRuntime(t *testing.T) {
 	root := t.TempDir()
 	workflowPath := filepath.Join(root, ".github", "workflows", "action.yml")
 	actionPath := filepath.Join(root, ".github", "actions", "local")
@@ -2200,7 +2200,7 @@ func TestValidateHostedTokenlessProfileResolvesActionsWithoutClaimingRuntime(t *
 	}
 }
 
-func TestValidateHostedTokenlessProfileRejectsProtectedCapabilityAfterCompile(t *testing.T) {
+func TestValidateHostedProfileRejectsProtectedCapabilityAfterCompile(t *testing.T) {
 	workflowPath := filepath.Join(t.TempDir(), "secret.yml")
 	if err := os.WriteFile(workflowPath, []byte("on: push\njobs:\n  secret:\n    runs-on: ubuntu-latest\n    env:\n      TOKEN: ${{ secrets.TOKEN }}\n    steps:\n      - run: true\n"), 0o600); err != nil {
 		t.Fatal(err)
@@ -3584,7 +3584,7 @@ func TestHostedLocalActionDoesNotProvisionSourceToken(t *testing.T) {
 	redactor := &cliRedactor{}
 	var warnings bytes.Buffer
 	authentication := &actionSourceAuthentication{provider: provider, redactor: redactor, warnings: &warnings}
-	if _, err := compileHostedTokenless(context.Background(), workflowPath, workflowSource, eventSource, "dev", "sha256:"+strings.Repeat("0", 64), "importer", "", nil, nil, authentication); err != nil {
+	if _, err := compileHosted(context.Background(), workflowPath, workflowSource, eventSource, "dev", "sha256:"+strings.Repeat("0", 64), "importer", "", nil, nil, authentication); err != nil {
 		t.Fatal(err)
 	}
 	if provider.calls != 0 || len(redactor.values) != 0 || warnings.Len() != 0 {
@@ -3592,7 +3592,7 @@ func TestHostedLocalActionDoesNotProvisionSourceToken(t *testing.T) {
 	}
 }
 
-func TestCompileHostedTokenlessRequiresExplicitMacOSQueueAndRuntime(t *testing.T) {
+func TestCompileHostedRequiresExplicitMacOSQueueAndRuntime(t *testing.T) {
 	workflow := []byte("on: push\njobs:\n  macos:\n    runs-on: macos-15\n    steps:\n      - run: echo macos\n")
 	event, err := os.ReadFile(filepath.Join("..", "..", "testdata", "smoke", "events", "push.json"))
 	if err != nil {
@@ -3600,16 +3600,16 @@ func TestCompileHostedTokenlessRequiresExplicitMacOSQueueAndRuntime(t *testing.T
 	}
 	compilerDigest := "sha256:" + strings.Repeat("0", 64)
 	darwinDigest := "sha256:" + strings.Repeat("1", 64)
-	_, err = compileHostedTokenless(context.Background(), "macos.yml", workflow, event, "0.0.0-test", compilerDigest, "importer", "", nil, nil, nil)
+	_, err = compileHosted(context.Background(), "macos.yml", workflow, event, "0.0.0-test", compilerDigest, "importer", "", nil, nil, nil)
 	if err == nil || !strings.Contains(err.Error(), `runner label "macos-15" is not mapped by policy`) {
 		t.Fatalf("missing macOS queue error = %v", err)
 	}
 	macOSTarget := map[string]compiler.RunnerTarget{"macos-15": {Queue: "macos", Platform: compiler.PlatformDarwinARM64}}
-	_, err = compileHostedTokenless(context.Background(), "macos.yml", workflow, event, "0.0.0-test", compilerDigest, "importer", "", macOSTarget, nil, nil)
+	_, err = compileHosted(context.Background(), "macos.yml", workflow, event, "0.0.0-test", compilerDigest, "importer", "", macOSTarget, nil, nil)
 	if err == nil || !strings.Contains(err.Error(), "no runtime distribution configured for darwin/arm64") {
 		t.Fatalf("missing macOS runtime error = %v", err)
 	}
-	compiled, err := compileHostedTokenless(context.Background(), "macos.yml", workflow, event, "0.0.0-test", compilerDigest, "importer", "", macOSTarget, map[compiler.Platform]string{compiler.PlatformDarwinARM64: darwinDigest}, nil)
+	compiled, err := compileHosted(context.Background(), "macos.yml", workflow, event, "0.0.0-test", compilerDigest, "importer", "", macOSTarget, map[compiler.Platform]string{compiler.PlatformDarwinARM64: darwinDigest}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3751,7 +3751,7 @@ jobs:
 	targets := map[string]compiler.RunnerTarget{
 		"ubuntu-latest": {Queue: "hosted", Platform: compiler.PlatformLinuxAMD64, Image: image},
 	}
-	compiled, err := compileHostedTokenless(context.Background(), "profiles.yml", workflow, event, "dev", "sha256:"+strings.Repeat("1", 64), "importer", "", targets, nil, nil)
+	compiled, err := compileHosted(context.Background(), "profiles.yml", workflow, event, "dev", "sha256:"+strings.Repeat("1", 64), "importer", "", targets, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4762,7 +4762,7 @@ func TestUnprivilegedUploadRejectsContainerProvenance(t *testing.T) {
 		bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: plan.Job{
 			Workflow: plan.Workflow{LogicalJobID: "container-job"}, RequiredCapabilities: []string{"docker", "network"},
 		}, Authorization: compiler.PlanAuthorization{DockerCapabilitySources: sources}}}}
-		if err := validateUnprivilegedBundle(bundle); err == nil || !strings.Contains(err.Error(), "hosted-tokenless upload does not admit") {
+		if err := validateUnprivilegedBundle(bundle); err == nil || !strings.Contains(err.Error(), "hosted upload does not admit") {
 			t.Fatalf("validateUnprivilegedBundle(%v) error = %v", sources, err)
 		}
 	}
@@ -5596,10 +5596,13 @@ func TestArgumentParsersRejectRepeatedOptions(t *testing.T) {
 	if _, _, _, _, err := validateArgs([]string{"--format", "json", "--format", "text", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
 		t.Fatalf("validateArgs() error = %v, want duplicate format error", err)
 	}
-	if _, _, _, _, err := validateArgs([]string{"--profile", "hosted-tokenless", "--profile", "hosted-tokenless", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
+	if _, _, _, _, err := validateArgs([]string{"--profile", "hosted", "--profile", "hosted", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
 		t.Fatalf("validateArgs() error = %v, want duplicate profile error", err)
 	}
-	if _, _, _, _, err := validateArgs([]string{"--profile", "unknown", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), `must be "hosted-tokenless"`) {
+	if _, _, _, profile, err := validateArgs([]string{"--profile", "hosted-tokenless", "workflow.yml"}); err != nil || profile != "hosted" {
+		t.Fatalf("validateArgs() legacy profile = %q, %v", profile, err)
+	}
+	if _, _, _, _, err := validateArgs([]string{"--profile", "unknown", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), `must be "hosted"`) {
 		t.Fatalf("validateArgs() error = %v, want unknown profile error", err)
 	}
 	if _, _, _, err := compileArgs([]string{"--format", "pipeline", "--format", "ir-json", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -83,7 +83,7 @@ func validatedProcessingReportWithOptions(out processingOutput, workflowPath, pr
 
 // applyHostedPreflight folds hosted preflight evidence and any admission
 // grant into the report.
-func applyHostedPreflight(report *compatibility.ProcessingReport, preflight hostedTokenlessCompilation) {
+func applyHostedPreflight(report *compatibility.ProcessingReport, preflight hostedCompilation) {
 	report.ApplyEvidence(preflight.Bundle.Processing)
 	if preflight.Admitted {
 		report.SetStage(string(compiler.StageAdmission), compatibility.Passed)
@@ -91,16 +91,16 @@ func applyHostedPreflight(report *compatibility.ProcessingReport, preflight host
 	}
 }
 
-// classifyHostedTokenlessFailure records a failed hosted preflight in the
+// classifyHostedFailure records a failed hosted preflight in the
 // report and returns the report result it implies.
-func classifyHostedTokenlessFailure(report *compatibility.ProcessingReport, workflowPath string, err error) string {
-	var failure *hostedTokenlessFailure
-	if errors.As(err, &failure) && failure.Kind == hostedTokenlessAdmissionFailure {
+func classifyHostedFailure(report *compatibility.ProcessingReport, workflowPath string, err error) string {
+	var failure *hostedFailure
+	if errors.As(err, &failure) && failure.Kind == hostedAdmissionFailure {
 		report.AddFailure(workflowPath, string(compiler.StageAdmission), "E_PROFILE", "admission", err)
 		report.Admission.Result = "not-admitted"
 		return "not-admitted"
 	}
-	if errors.As(err, &failure) && failure.Kind == hostedTokenlessEnvironmentFailure {
+	if errors.As(err, &failure) && failure.Kind == hostedEnvironmentFailure {
 		report.AddEnvironmentFailure("hosted workflow-processing environment could not be initialized")
 	} else {
 		report.AddFailure(workflowPath, string(compiler.StageResolution), compiler.CodeActionResolution, "action-resolution", err)

--- a/internal/compatibility/report_test.go
+++ b/internal/compatibility/report_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestProcessingReportContainsEveryStableStageInTextAndJSON(t *testing.T) {
-	report := NewProcessingReport("ci.yml", "hosted-tokenless")
+	report := NewProcessingReport("ci.yml", "hosted")
 	report.LogicalJobs = 1
 	report.Instances = 1
 	report.Compile.Result = "incompatible"

--- a/internal/compiler/smoke_manifest_test.go
+++ b/internal/compiler/smoke_manifest_test.go
@@ -62,7 +62,7 @@ func TestSmokeManifestInventory(t *testing.T) {
 		if fixture.Expectation != "compile-pass" && fixture.Expectation != "compile-unsupported" && fixture.Expectation != "runtime-pass" && fixture.Expectation != "runtime-unsupported" && fixture.Expectation != "future" {
 			t.Fatalf("%s: invalid expectation %q", fixture.ID, fixture.Expectation)
 		}
-		if fixture.ActionPreflight != "none" && fixture.ActionPreflight != "hosted-tokenless" {
+		if fixture.ActionPreflight != "none" && fixture.ActionPreflight != "hosted" {
 			t.Fatalf("%s: invalid action preflight %q", fixture.ID, fixture.ActionPreflight)
 		}
 		if strings.TrimSpace(fixture.Evidence) == "" || strings.TrimSpace(fixture.Note) == "" {

--- a/mise.toml
+++ b/mise.toml
@@ -62,15 +62,15 @@ description = "Validate and deterministically compile the local smoke inventory"
 run = "./scripts/smoke-local"
 
 [tasks."smoke:profile"]
-description = "Resolve actions and apply the hosted-tokenless profile to smoke fixtures"
-run = "./scripts/smoke-local --profile hosted-tokenless"
+description = "Resolve actions and apply the hosted profile to smoke fixtures"
+run = "./scripts/smoke-local --profile hosted"
 
 [tasks."corpus:starter"]
 description = "Report compile compatibility for the pinned GitHub starter workflow corpus"
 run = "./scripts/starter-workflows-corpus"
 
 [tasks."corpus:starter-profile"]
-description = "Report hosted-tokenless admission for the pinned GitHub starter workflow corpus"
+description = "Report hosted admission for the pinned GitHub starter workflow corpus"
 run = "./scripts/starter-workflows-corpus --profile"
 
 [tasks.check]

--- a/scripts/smoke-local
+++ b/scripts/smoke-local
@@ -6,8 +6,8 @@ readonly root
 readonly manifest="$root/testdata/smoke/manifest.json"
 profile=""
 if (( $# != 0 )); then
-  [[ $# == 2 && "$1" == --profile && "$2" == hosted-tokenless ]] || {
-    echo 'usage: scripts/smoke-local [--profile hosted-tokenless]' >&2
+  [[ $# == 2 && "$1" == --profile && "$2" == hosted ]] || {
+    echo 'usage: scripts/smoke-local [--profile hosted]' >&2
     exit 2
   }
   profile="$2"
@@ -29,7 +29,7 @@ jq -e '
     (.workflow | type == "string" and length > 0 and (startswith("testdata/") or IN(".github/workflows/example-basic.yml", ".github/workflows/example-artifacts.yml", ".github/workflows/example-advanced.yml")) and (contains("..") | not)) and
     (.event | type == "string" and length > 0 and startswith("testdata/") and (contains("..") | not)) and
     (.expectation | IN("compile-pass", "compile-unsupported", "runtime-pass", "runtime-unsupported", "future")) and
-    (.action_preflight | IN("none", "hosted-tokenless")) and
+    (.action_preflight | IN("none", "hosted")) and
     (.evidence | type == "string" and length > 0) and
     (.note | type == "string" and length > 0)) and
   ([.fixtures[].id] | length == (unique | length)) and

--- a/scripts/starter-workflows-corpus
+++ b/scripts/starter-workflows-corpus
@@ -66,7 +66,7 @@ validate_args=()
 if $profile; then
   mode=profile
   desired=admitted
-  validate_args=(--profile hosted-tokenless)
+  validate_args=(--profile hosted)
 fi
 summary="$work/summary.md"
 printf '### Starter workflow compatibility — %s\n\n' "$mode" > "$summary"

--- a/testdata/smoke/README.md
+++ b/testdata/smoke/README.md
@@ -40,7 +40,7 @@ The default harness does not parse emitted YAML, fetch actions, or execute
 workflows; successful compilation is not runtime evidence.
 
 Run `mise run smoke:profile` for the opt-in networked preflight of entries marked
-`hosted-tokenless`. It anonymously resolves actions, compiles plans, and applies
+`hosted`. It anonymously resolves actions, compiles plans, and applies
 the same admission policy as production upload without installing or executing
 Node. Admission does not execute action code or prove that a generic action is
 independent of GitHub-only artifact, cache, token, or OIDC services.
@@ -54,7 +54,7 @@ and unsupported artifact commits remain rejected. The profile leaves unknown
 generic service dependencies as an explicit warning rather than guessing from
 arbitrary action source. Runtime-pass job and service container fixtures are
 deliberately not marked for this profile: their execution is proven separately,
-while production hosted-tokenless admission continues to reject their container
+while production hosted admission continues to reject their container
 provenance.
 
 `events/push.json` is deterministic and its repository SHA is intentionally

--- a/testdata/smoke/manifest.json
+++ b/testdata/smoke/manifest.json
@@ -26,7 +26,7 @@
       "expectation": "compile-pass",
       "evidence": "Local JavaScript and composite action components have runtime tests; the complete hosted fixture does not.",
       "note": "Component runtime evidence must not be read as full workflow runtime evidence.",
-      "action_preflight": "hosted-tokenless"
+      "action_preflight": "hosted"
     },
     {
       "id": "smoke-artifact",
@@ -35,7 +35,7 @@
       "expectation": "runtime-pass",
       "evidence": "Exact-commit Buildkite build 270 and an independent read-only artifact observation proved the producer-to-two-consumer native roundtrip.",
       "note": "The verifier bound merged commit 1b69b2fa1a9d488d0f349b3267b484db9aeea57d, one producer, both matrix consumers, their terminal manifests, the exact native archive, and the build-unique payload.",
-      "action_preflight": "hosted-tokenless"
+      "action_preflight": "hosted"
     },
     {
       "id": "smoke-artifact-multi-prefix",
@@ -44,7 +44,7 @@
       "expectation": "compile-pass",
       "evidence": "Parser, compiler, and runtime tests cover bounded expansion, direct-needs matching, deterministic deduplication, merge order, and atomic staging.",
       "note": "This PostHog-shaped two-prefix fixture is compile-only; hosted producer-to-consumer execution remains unproven.",
-      "action_preflight": "hosted-tokenless"
+      "action_preflight": "hosted"
     },
     {
       "id": "example-basic",
@@ -53,7 +53,7 @@
       "expectation": "runtime-pass",
       "evidence": "Exact-commit Buildkite build 290 passed the complete example suite.",
       "note": "At commit 379344599c0653990687d017bd195d416c7bc29c, checkout, setup-go, shell tests, conditions, outputs, and the summary-producing workflow all completed on the hosted runtime; the dedicated summary-annotation fixture owns independent persistence evidence.",
-      "action_preflight": "hosted-tokenless"
+      "action_preflight": "hosted"
     },
     {
       "id": "example-artifacts",
@@ -62,7 +62,7 @@
       "expectation": "runtime-pass",
       "evidence": "Exact-commit Buildkite build 290 passed the complete example suite.",
       "note": "At commit 379344599c0653990687d017bd195d416c7bc29c, build, job outputs, exact-name direct-needs artifact transfer, and downloaded binary execution all passed on the hosted runtime.",
-      "action_preflight": "hosted-tokenless"
+      "action_preflight": "hosted"
     },
     {
       "id": "example-advanced",
@@ -71,7 +71,7 @@
       "expectation": "runtime-pass",
       "evidence": "Published-plugin Buildkite build 336 passed the revised service-free advanced fixture and all generated jobs.",
       "note": "At source commit d5102df7e81c49f27a30fb2830d9608a56ee84de, plugin v0.2.0 resolved to d009da173158270a3921b2997ae8fd3d68526d00 and proved the reusable output, public Dockerfile action, artifact, matrix, summary, and annotation path.",
-      "action_preflight": "hosted-tokenless"
+      "action_preflight": "hosted"
     },
     {
       "id": "plugin-demo-cache",
@@ -80,7 +80,7 @@
       "expectation": "runtime-pass",
       "evidence": "Published-plugin Buildkite build 337 passed the stable cache-v2 fixture and all generated jobs.",
       "note": "At source commit d5102df7e81c49f27a30fb2830d9608a56ee84de, plugin v0.2.0 resolved to d009da173158270a3921b2997ae8fd3d68526d00; the producer observed a miss and post-save before its direct dependent restored an exact primary-key hit and verified the payload.",
-      "action_preflight": "hosted-tokenless"
+      "action_preflight": "hosted"
     },
     {
       "id": "public-actions",
@@ -89,7 +89,7 @@
       "expectation": "runtime-pass",
       "evidence": "The pinned public checkout and setup action proof has runtime coverage.",
       "note": "The local harness compiles only and never fetches these actions.",
-      "action_preflight": "hosted-tokenless"
+      "action_preflight": "hosted"
     },
     {
       "id": "dockerfile-action",
@@ -98,7 +98,7 @@
       "expectation": "runtime-pass",
       "evidence": "The pinned public Dockerfile action proof has hosted runtime coverage.",
       "note": "The deterministic smoke event matches the production Dockerfile-action proof input.",
-      "action_preflight": "hosted-tokenless"
+      "action_preflight": "hosted"
     },
     {
       "id": "container-runtime",
@@ -106,7 +106,7 @@
       "event": "testdata/smoke/events/push.json",
       "expectation": "runtime-pass",
       "evidence": "The complete compiler-to-Runner container fixture passed in exact-commit Buildkite build 136.",
-      "note": "Hosted-tokenless admission still rejects its job- and service-container provenance.",
+      "note": "Hosted admission still rejects its job- and service-container provenance.",
       "action_preflight": "none"
     },
     {
@@ -134,7 +134,7 @@
       "expectation": "runtime-pass",
       "evidence": "Exact-commit Buildkite build 259 and an independent read-only artifact observation proved native archive publication and its bounded producer contract.",
       "note": "The verifier bound build 259, merged implementation commit 12e72d3298e919f33caba70d39265ef2da387f83, and generated job 019fb686-0167-4da1-9bfc-550166d6a1a4.",
-      "action_preflight": "hosted-tokenless"
+      "action_preflight": "hosted"
     },
     {
       "id": "cache-v6",
@@ -143,7 +143,7 @@
       "expectation": "compile-pass",
       "evidence": "Compiler and runtime conformance tests admit the audited actions/cache v6.1.0 commit and execute the cache lifecycle with isolated per-phase cache-v2 credentials.",
       "note": "This minimal fixture remains compile-only conformance coverage. The stable plugin-demo-cache fixture has published-plugin runtime evidence from Buildkite build 337.",
-      "action_preflight": "hosted-tokenless"
+      "action_preflight": "hosted"
     },
     {
       "id": "cache-v5",
@@ -152,7 +152,7 @@
       "expectation": "compile-pass",
       "evidence": "Compiler, upload, run-job, and runtime resolver tests admit only the audited actions/cache v5 commits; shared tests cover the unchanged isolated cache-v2 credential boundary.",
       "note": "This minimal roundtrip remains compile-only conformance coverage until an exact v5 commit passes the hosted cache-v2 runtime proof.",
-      "action_preflight": "hosted-tokenless"
+      "action_preflight": "hosted"
     },
     {
       "id": "unsupported-job-container",
@@ -160,7 +160,7 @@
       "event": "testdata/smoke/events/push.json",
       "expectation": "runtime-pass",
       "evidence": "The plan-v4 job-container fixture passed in exact-commit Buildkite build 136.",
-      "note": "Hosted-tokenless admission still rejects job-container provenance.",
+      "note": "Hosted admission still rejects job-container provenance.",
       "action_preflight": "none"
     },
     {
@@ -169,7 +169,7 @@
       "event": "testdata/smoke/events/push.json",
       "expectation": "runtime-pass",
       "evidence": "The plan-v4 service-container fixture passed in exact-commit Buildkite build 136.",
-      "note": "Hosted-tokenless admission still rejects service-container provenance.",
+      "note": "Hosted admission still rejects service-container provenance.",
       "action_preflight": "none"
     }
   ]

--- a/testdata/starter-workflows/README.md
+++ b/testdata/starter-workflows/README.md
@@ -40,7 +40,7 @@ mise run corpus:starter-profile -- go cmake-multi-platform swift
 
 Each command prints every result, reports a passing/blocked summary, and exits
 non-zero while any template misses its target state. The profile scan resolves
-public actions and applies the `hosted-tokenless` admission policy, but neither
+public actions and applies the `hosted` admission policy, but neither
 mode executes action or project code. Mutable action tags remain as declared by
 the official template, so profile results are observational and runtime proof
 must retain immutable resolved action locks.


### PR DESCRIPTION
## Why

`hosted-tokenless` no longer accurately describes the production profile now that narrowly scoped, policy-approved tokens are supported.

## What

Make `hosted` the canonical CLI, report, documentation, smoke, and starter-corpus profile name. Keep `hosted-tokenless` as a deprecated alias that normalizes reports to `hosted`.
