### PR TITLE
Name the policy rule that rejects a runs-on target

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -793,7 +793,7 @@ func TestRunValidateAndCompile(t *testing.T) {
 		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 			t.Fatal(err)
 		}
-		if report.Result != "incompatible" || report.Compile.Result != "incompatible" || len(report.Diagnostics) != 1 || report.Diagnostics[0].Message != "resolved runner target is not admitted by policy" {
+		if report.Result != "incompatible" || report.Compile.Result != "incompatible" || len(report.Diagnostics) != 1 || report.Diagnostics[0].Message != "resolved runner target is not admitted by policy: runner label is not mapped by policy" {
 			t.Fatalf("macOS profile report = %#v", report)
 		}
 	})
@@ -1667,7 +1667,7 @@ func TestProcessingReportRedactsEventDerivedRunnerValues(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 		t.Fatal(err)
 	}
-	if len(report.Diagnostics) != 1 || report.Diagnostics[0].Message != "resolved runner target is not admitted by policy" {
+	if len(report.Diagnostics) != 1 || report.Diagnostics[0].Message != "resolved runner target is not admitted by policy: runner label is not mapped by policy" {
 		t.Fatalf("diagnostics = %#v", report.Diagnostics)
 	}
 }

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -1010,7 +1010,7 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 					finding := &ProcessingFinding{
 						Stage: StageExpressions, Code: CodeExpressionInvalid, Category: "compatibility",
 						Path: jobPath, Line: runsOnPosition(job).Line, Column: runsOnPosition(job).Column,
-						Job: job.ID, Instance: key, Message: "resolved runner target is not admitted by policy",
+						Job: job.ID, Instance: key, Message: runnerRejectionMessage(err),
 						Err: locatedJobError(jobPath, job, runsOnPosition(job).Line, runsOnPosition(job).Column, err.Error()),
 					}
 					diagnostics = append(diagnostics, finding)

--- a/internal/compiler/config.go
+++ b/internal/compiler/config.go
@@ -1,6 +1,7 @@
 package compiler
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"sort"
@@ -242,9 +243,38 @@ func (sources VariableSources) snapshot() map[string]string {
 	return vars
 }
 
+// Every runs-on rejection reason a processing report may render. Resolved
+// labels can interpolate event payload data, so a reason must stay a literal
+// and never interpolate a resolved value.
+const (
+	reasonNoLabels          = "runs-on must resolve to at least one label"
+	reasonDuplicateLabel    = "duplicate runner label"
+	reasonUnsupportedOS     = "unsupported operating system"
+	reasonUnmappedLabel     = "runner label is not mapped by policy"
+	reasonConflictingQueues = "labels resolve to conflicting queues"
+	reasonConflictingTarget = "labels resolve to conflicting targets"
+	reasonUntrustedDefault  = "untrusted event cannot use Buildkite default agent targeting"
+	reasonUntrustedQueue    = "untrusted event cannot target the resolved queue"
+)
+
+// runnerPolicyRejection pairs a rejected runs-on resolution with its reason.
+// Reports may render reason but never the detailed error, which quotes the
+// resolved label.
+type runnerPolicyRejection struct {
+	reason string
+	err    error
+}
+
+func (e *runnerPolicyRejection) Error() string { return e.err.Error() }
+func (e *runnerPolicyRejection) Unwrap() error { return e.err }
+
+func rejectRunner(reason, format string, args ...any) error {
+	return &runnerPolicyRejection{reason: reason, err: fmt.Errorf(format, args...)}
+}
+
 func (policy RunnerPolicy) resolve(labels []string, trust EventTrust) (RunnerTarget, error) {
 	if len(labels) == 0 {
-		return RunnerTarget{}, fmt.Errorf("runs-on must resolve to at least one label")
+		return RunnerTarget{}, rejectRunner(reasonNoLabels, reasonNoLabels)
 	}
 	var target RunnerTarget
 	resolved := false
@@ -252,11 +282,11 @@ func (policy RunnerPolicy) resolve(labels []string, trust EventTrust) (RunnerTar
 	for _, label := range labels {
 		normalized := strings.ToLower(strings.TrimSpace(label))
 		if _, duplicate := seen[normalized]; duplicate {
-			return RunnerTarget{}, fmt.Errorf("runs-on contains duplicate runner label %q", label)
+			return RunnerTarget{}, rejectRunner(reasonDuplicateLabel, "runs-on contains duplicate runner label %q", label)
 		}
 		seen[normalized] = struct{}{}
 		if unsupportedOS(normalized) {
-			return RunnerTarget{}, fmt.Errorf("unsupported operating system runner label %q", label)
+			return RunnerTarget{}, rejectRunner(reasonUnsupportedOS, "unsupported operating system runner label %q", label)
 		}
 		mapped, ok := policy.Targets[normalized]
 		if !ok {
@@ -280,26 +310,38 @@ func (policy RunnerPolicy) resolve(labels []string, trust EventTrust) (RunnerTar
 			}
 		}
 		if !ok {
-			return RunnerTarget{}, fmt.Errorf("runner label %q is not mapped by policy", label)
+			return RunnerTarget{}, rejectRunner(reasonUnmappedLabel, "runner label %q is not mapped by policy", label)
 		}
 		if resolved && target != mapped {
 			if target.Platform == mapped.Platform && target.Image == mapped.Image {
-				return RunnerTarget{}, fmt.Errorf("runner labels resolve to conflicting queues %q and %q", target.Queue, mapped.Queue)
+				return RunnerTarget{}, rejectRunner(reasonConflictingQueues, "runner labels resolve to conflicting queues %q and %q", target.Queue, mapped.Queue)
 			}
-			return RunnerTarget{}, fmt.Errorf("runner labels resolve to conflicting targets %q and %q", targetDescription(target), targetDescription(mapped))
+			return RunnerTarget{}, rejectRunner(reasonConflictingTarget, "runner labels resolve to conflicting targets %q and %q", targetDescription(target), targetDescription(mapped))
 		}
 		target = mapped
 		resolved = true
 	}
 	if trust == EventUntrusted && target.Queue == "" && !policy.AllowUntrustedDefaultQueue {
-		return RunnerTarget{}, fmt.Errorf("untrusted event cannot use Buildkite default agent targeting")
+		return RunnerTarget{}, rejectRunner(reasonUntrustedDefault, reasonUntrustedDefault)
 	}
 	if trust == EventUntrusted && target.Queue != "" && !contains(policy.UntrustedQueues, target.Queue) {
 		allowlist := append([]string(nil), policy.UntrustedQueues...)
 		sort.Strings(allowlist)
-		return RunnerTarget{}, fmt.Errorf("untrusted event cannot target queue %q; allowed queues: %s", target.Queue, strings.Join(allowlist, ", "))
+		return RunnerTarget{}, rejectRunner(reasonUntrustedQueue, "untrusted event cannot target queue %q; allowed queues: %s", target.Queue, strings.Join(allowlist, ", "))
 	}
 	return target, nil
+}
+
+// runnerRejectionMessage renders a rejected runs-on resolution for a processing
+// report. It appends only the fixed rejection reason, so a resolved label built
+// from event payload data never reaches the report.
+func runnerRejectionMessage(err error) string {
+	const message = "resolved runner target is not admitted by policy"
+	var rejection *runnerPolicyRejection
+	if errors.As(err, &rejection) {
+		return message + ": " + rejection.reason
+	}
+	return message
 }
 
 func unsupportedOS(label string) bool {

--- a/internal/compiler/config_test.go
+++ b/internal/compiler/config_test.go
@@ -228,6 +228,46 @@ func TestRunsOnPolicyFailsClosedWithLocatedDiagnostics(t *testing.T) {
 	}
 }
 
+func TestRunnerRejectionMessageNamesReasonWithoutResolvedLabel(t *testing.T) {
+	policy := RunnerPolicy{
+		Labels:          map[string]string{"ubuntu-24.04": "linux", "self-hosted": "one", "linux": "two", "default": ""},
+		Targets:         map[string]RunnerTarget{"macos": {Queue: "macos", Platform: PlatformDarwinARM64}},
+		UntrustedQueues: []string{"isolated"},
+	}
+	tests := []struct {
+		name   string
+		labels []string
+		trust  EventTrust
+		want   string
+	}{
+		{name: "no labels", trust: EventTrusted, want: reasonNoLabels},
+		{name: "duplicate label", labels: []string{"ubuntu-24.04", "ubuntu-24.04"}, trust: EventTrusted, want: reasonDuplicateLabel},
+		{name: "unsupported operating system", labels: []string{"windows-latest"}, trust: EventTrusted, want: reasonUnsupportedOS},
+		{name: "unmapped label", labels: []string{"macos-15"}, trust: EventTrusted, want: reasonUnmappedLabel},
+		{name: "conflicting queues", labels: []string{"self-hosted", "linux"}, trust: EventTrusted, want: reasonConflictingQueues},
+		{name: "conflicting targets", labels: []string{"ubuntu-24.04", "macos"}, trust: EventTrusted, want: reasonConflictingTarget},
+		{name: "untrusted default targeting", labels: []string{"default"}, trust: EventUntrusted, want: reasonUntrustedDefault},
+		{name: "untrusted queue", labels: []string{"ubuntu-24.04"}, trust: EventUntrusted, want: reasonUntrustedQueue},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := policy.resolve(test.labels, test.trust)
+			if err == nil {
+				t.Fatal("resolve() error = nil, want rejection")
+			}
+			if message := runnerRejectionMessage(err); message != "resolved runner target is not admitted by policy: "+test.want {
+				t.Fatalf("runnerRejectionMessage() = %q, want reason %q", message, test.want)
+			}
+		})
+	}
+}
+
+func TestRunnerRejectionMessageFallsBackWhenUnclassified(t *testing.T) {
+	if message := runnerRejectionMessage(errors.New("boom")); message != "resolved runner target is not admitted by policy" {
+		t.Fatalf("runnerRejectionMessage() = %q, want the bare policy message", message)
+	}
+}
+
 func TestDefaultCompilePolicyIsUntrustedAndUsesBuildkiteDefault(t *testing.T) {
 	workflow := []byte("on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n")
 	compiled, err := Compile("default.yml", workflow, pushEvent(t))

--- a/internal/compiler/processing.go
+++ b/internal/compiler/processing.go
@@ -45,8 +45,10 @@ type ProcessingFinding struct {
 	Instance string
 	Action   string
 	Step     int
-	Message  string
-	Err      error
+	// Message replaces Err's text in the rendered report. Set it whenever Err
+	// can quote event-derived data, so that data cannot reach the report.
+	Message string
+	Err     error
 }
 
 func (e *ProcessingFinding) Error() string { return e.Err.Error() }


### PR DESCRIPTION
Every rejected `runs-on` produced the same sentence, so a Windows row and an
unmapped macOS row looked identical. Only the first is a real boundary. The
second just needs a queue in the plugin's `runners:` config.

`ProcessingFinding.Message` hides the detailed error on purpose: `runs-on` can
interpolate `${{ github.event.* }}`, so a resolved label is untrusted. The
message now appends the rejection reason only. Reasons are literals from a
fixed set, so no resolved value can reach a report.

Before:

    resolved runner target is not admitted by policy
    resolved runner target is not admitted by policy

After:

    resolved runner target is not admitted by policy: unsupported operating system
    resolved runner target is not admitted by policy: runner label is not mapped by policy

Detailed error text is unchanged, so the Go API and its existing tests see
exactly what they saw before.

<details>
<summary>How we found this improvement</summary>

Not by reading the code. By running `validate` against unmodified workflows from
eight public repos — bubbletea, execa, commander.js, ripgrep, black, cli/cli,
ruff, and p-queue — and comparing what each diagnostic actually told us.

Most were already actionable: `condition function "startsWith" is unsupported`,
`reusable workflow "…@main" is remote or runtime-dependent`. The runner
rejection was the outlier — the most frequent diagnostic in the sample, and the
only one that named nothing. On ripgrep it printed four identical lines,
separable only by an instance hash. `RunnerPolicy.resolve` had known the exact
cause all along.

The first attempt was to drop the `Message` override and let the detailed error
through. That was wrong, and the test name caught it:
`TestProcessingReportRedactsEventDerivedRunnerValues`. `runs-on` can be
`${{ github.event.runner }}`, so a resolved label may carry event payload data.
The override is a redaction control — that test plants a sentinel in the payload
and fails if it reaches stdout or stderr.

That reframed the change from "show the error" to **report why, never what**,
which is what this PR does.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
