### PR TITLE
Skip unsupported workflows in wildcard uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ steps:
 
 The plugin is a thin wrapper around the hidden `buildkite-gha plugin` entrypoint. It uses mise to install and verify the selected CLI release, and defaults to the latest stable release. During the preview, leaving `version` unset means there is no CLI version to update as new stable releases ship.
 
-Use `workflow: "*"` to select every tracked `.yml` and `.yaml` file directly under `.github/workflows`.
+Use `workflow: "*"` to select every tracked `.yml` and `.yaml` file directly under `.github/workflows`. This discovery mode reports and omits unsupported workflows.
 
 To hold the CLI at a specific release instead, set `version` to an exact stable release from `0.9.0` onward:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -116,7 +116,7 @@ Use `*` for every tracked `.yml` and `.yaml` file directly under `.github/workfl
 buildkite-gha upload '*'
 ```
 
-Quote `*` in shells and YAML. A single operand can also be a literal file, directory, or tracked glob. Matches are canonicalized, sorted, and deduplicated before workflow identities and job-key namespaces are assigned. Existing filenames containing `*`, `?`, or `[` remain literal.
+Quote `*` in shells and YAML. This exact selector reports and omits workflows that fail compatibility or hosted-profile admission. If none are supported, upload succeeds without adding steps. A single operand can also be a literal file, directory, or tracked glob. Matches are canonicalized, sorted, and deduplicated before workflow identities and job-key namespaces are assigned. Existing filenames containing `*`, `?`, or `[` remain literal.
 
 Two or more operands switch to explicit-list mode:
 
@@ -132,7 +132,7 @@ Every list entry must resolve to one regular, tracked `.yml` or `.yaml` file ins
 
 All selected directly runnable workflows are represented in one atomic pipeline upload. Each becomes an aggregate group whose label is `:github: <workflow-name>` or, for an unnamed workflow, its canonical path. The group depends on the importer; child jobs do not repeat that dependency. One group-level GitHub check is named `Buildkite / <workflow-name-or-path> (<effective-event>)`. A reusable-only `workflow_call` file may be selected so local callers can resolve it, but it does not create a group. An input set containing only reusable workflows is an error.
 
-Any input, trigger translation, event validation, compilation, admission, artifact, or upload failure aborts the aggregate transaction. No partially compiled pipeline is uploaded.
+Other selectors remain strict: any workflow failure aborts the aggregate transaction. Event-input, environment, action-resolution, artifact, and upload failures also abort `*` discovery. No partially compiled pipeline is uploaded.
 
 ### Select the effective event
 
@@ -150,7 +150,7 @@ The selected snapshot establishes one effective GitHub event for applicability, 
 
 Top-level workflows that do not declare the effective event are excluded before event-dependent validation and compilation, then emitted as skipped groups with an ignored placeholder and no plan artifacts. Reusable-only workflows remain available to local callers. If no directly runnable workflow applies, upload succeeds with an ignored-only pipeline. For applicable workflows, only the selected event contributes a group condition: push branch/tag filters, pull request base-branch/activity filters, or the corresponding manual/schedule Buildkite source predicate. Cross-event trigger conditions are never ORed into that group.
 
-Unsupported trigger events, path filters, inexact filters, malformed event data, and failures in any applicable workflow remain fatal. Buildkite still owns build creation and schedule identity; every workflow with `on.schedule` is eligible for a Buildkite scheduled build because Buildkite does not expose which schedule created it.
+With `*`, unsupported trigger events, path filters, inexact filters, and other workflow compatibility failures omit that workflow. They remain fatal for other selectors. Malformed event data remains fatal in every mode. Buildkite still owns build creation and schedule identity; every workflow with `on.schedule` is eligible for a Buildkite scheduled build because Buildkite does not expose which schedule created it.
 
 After all applicable workflows pass, the command uploads the exact executable and content-addressed plans before running one:
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -59,11 +59,11 @@ Steps remain inside one job because they share a workspace, environment files, a
 
 ### Aggregate workflow upload
 
-`*` selects every tracked `.yml` and `.yaml` file directly under `.github/workflows`. Upload also accepts one literal, directory, or tracked glob, or two or more explicit workflow paths. Lists require regular, tracked `.yml` or `.yaml` files inside the repository; directories, missing or untracked files, outside paths, symlinks, and globs fail. Inputs are canonicalized, sorted, and deduplicated before workflow identities and job-key namespaces are assigned.
+`*` selects every tracked `.yml` and `.yaml` file directly under `.github/workflows`. It reports and omits workflows that fail compatibility or hosted-profile admission. If none are supported, upload succeeds without adding steps. Upload also accepts one literal, directory, or tracked glob, or two or more explicit workflow paths. Lists require regular, tracked `.yml` or `.yaml` files inside the repository; directories, missing or untracked files, outside paths, symlinks, and globs fail. Inputs are canonicalized, sorted, and deduplicated before workflow identities and job-key namespaces are assigned.
 
 All directly runnable workflows are represented in one artifact and pipeline transaction. Each becomes one aggregate group labeled `:github: <workflow-name>`, with its canonical path as the fallback for an unnamed workflow. A workflow that declares the effective event compiles into child jobs. A workflow that does not declare it becomes a skipped group with an ignored placeholder and no plan artifacts. The label is static across events. The group-level GitHub check is named `Buildkite / <workflow-name-or-path> (<effective-event>)`. Each group depends on the importer, while its child jobs omit that redundant dependency and their own check notifications.
 
-Reusable-only `workflow_call` files remain available to local callers but do not create groups. Selecting only reusable workflows is an error. A parse, trigger, event, compilation, admission, artifact, or upload failure aborts the whole transaction; no partial pipeline is uploaded.
+Reusable-only `workflow_call` files remain available to local callers but do not create groups. Selecting only reusable workflows is an error. Other selectors fail atomically for any workflow error. Event-input, environment, action-resolution, artifact, and upload failures remain fatal in `*` discovery; no partial pipeline is uploaded.
 
 ## Workflow syntax
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -67,7 +67,7 @@ func writeCommandHelp(stdout io.Writer, command string) {
 	case "compile":
 		_, _ = fmt.Fprint(stdout, "\nPipeline output references content-addressed plans; compile does not materialize or upload those artifacts.\n")
 	case "upload":
-		_, _ = fmt.Fprint(stdout, "\nThe * shorthand selects tracked .yml and .yaml files directly under .github/workflows. One workflow operand preserves literal, directory, and tracked glob expansion. Two or more operands are explicit tracked .yml/.yaml paths; use -- before paths that begin with a dash. Inputs are uploaded as one aggregate pipeline with one group per directly runnable workflow; reusable-only workflow_call files are imported through callers but do not become groups. Scheduled groups select only build.source == schedule: Buildkite schedules retain cron ownership, so every scheduled workflow group is eligible on any Buildkite scheduled build. Each repeatable --runner-queue argument maps one supported runs-on label to a Buildkite queue. Configured Linux profiles default to the matching immutable hosted-toolchains image; --runner-image overrides it. Duplicate or unsupported mappings fail, unmapped supported Linux labels retain their default targeting, and every macOS label requires an explicit queue. Each repeatable --runtime-distribution argument binds linux/amd64 or darwin/arm64 to a verified executable. Upload importers must run on linux/amd64; the Linux runtime defaults to the importer executable when omitted, and macOS has no default. The deprecated --runtime-queue hosted option is accepted for plugin compatibility but does not select a queue. Event precedence is an explicit event file, Buildkite's reserved webhook metadata, then reduced-fidelity Buildkite environment compatibility data; every source remains unsigned. Verified checkout jobs automatically use Buildkite repository-provider Git credentials when the job enables them; the deprecated --private-checkout option is accepted as a no-op.\n")
+		_, _ = fmt.Fprint(stdout, "\nThe * shorthand selects tracked .yml and .yaml files directly under .github/workflows, reports unsupported workflows, and omits them. One workflow operand preserves literal, directory, and tracked glob expansion. Two or more operands are explicit tracked .yml/.yaml paths; use -- before paths that begin with a dash. Inputs are uploaded as one aggregate pipeline with one group per directly runnable workflow; reusable-only workflow_call files are imported through callers but do not become groups. Scheduled groups select only build.source == schedule: Buildkite schedules retain cron ownership, so every scheduled workflow group is eligible on any Buildkite scheduled build. Each repeatable --runner-queue argument maps one supported runs-on label to a Buildkite queue. Configured Linux profiles default to the matching immutable hosted-toolchains image; --runner-image overrides it. Duplicate or unsupported mappings fail, unmapped supported Linux labels retain their default targeting, and every macOS label requires an explicit queue. Each repeatable --runtime-distribution argument binds linux/amd64 or darwin/arm64 to a verified executable. Upload importers must run on linux/amd64; the Linux runtime defaults to the importer executable when omitted, and macOS has no default. The deprecated --runtime-queue hosted option is accepted for plugin compatibility but does not select a queue. Event precedence is an explicit event file, Buildkite's reserved webhook metadata, then reduced-fidelity Buildkite environment compatibility data; every source remains unsigned. Verified checkout jobs automatically use Buildkite repository-provider Git credentials when the job enables them; the deprecated --private-checkout option is accepted as a no-op.\n")
 	}
 }
 
@@ -1386,6 +1386,7 @@ func uploadFromPlatform(goos, goarch string, args []string, stdout, stderr io.Wr
 
 func uploadParsed(uploadArguments parsedUploadArgs, stdout, stderr io.Writer, version string, agent transport.Agent) int {
 	workflowOperands, eventPath := uploadArguments.workflowOperands, uploadArguments.eventPath
+	excludeUnsupported := !uploadArguments.explicitWorkflowPaths && len(workflowOperands) == 1 && workflowOperands[0] == "*"
 	importerStep := os.Getenv("BUILDKITE_STEP_KEY")
 	if os.Getenv("BUILDKITE") != "true" || strings.TrimSpace(importerStep) == "" {
 		return usageError(stderr, "upload: BUILDKITE=true and BUILDKITE_STEP_KEY are required")
@@ -1417,6 +1418,10 @@ func uploadParsed(uploadArguments parsedUploadArgs, stdout, stderr io.Writer, ve
 		parsed, parseErr := workflow.Parse(workflows[i].Path, workflows[i].Source)
 		if parseErr != nil {
 			_, _ = validatedProcessingReport(out, workflows[i].Path, hostedTokenlessProfile, workflows[i].Source, nil, false)
+			if excludeUnsupported {
+				excludeUnsupportedWorkflow(stderr, &workflows[i], parseErr)
+				continue
+			}
 			return 1
 		}
 		workflows[i].ReusableOnly = parsed.ReusableOnly()
@@ -1427,6 +1432,9 @@ func uploadParsed(uploadArguments parsedUploadArgs, stdout, stderr io.Writer, ve
 		}
 	}
 	if runnableWorkflowCount == 0 {
+		if excludeUnsupported && excludedWorkflowCount(workflows) != 0 {
+			return finishExcludedWorkflowSelection(stdout, workflows)
+		}
 		if len(workflowOperands) == 1 {
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: workflow pattern %q matched only reusable workflow_call workflows; there is nothing to upload\n", workflowOperands[0])
 		} else {
@@ -1436,15 +1444,19 @@ func uploadParsed(uploadArguments parsedUploadArgs, stdout, stderr io.Writer, ve
 	}
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
-	for _, input := range workflows {
-		if input.ReusableOnly {
+	for i := range workflows {
+		if workflows[i].ReusableOnly || workflows[i].Excluded {
 			continue
 		}
-		validation, validationErr := compiler.Validate(input.Path, input.Source)
+		validation, validationErr := compiler.Validate(workflows[i].Path, workflows[i].Source)
 		if validation.RuntimeMatrixBoundary {
-			report := compatibility.InitialProcessingReport(input.Path, hostedTokenlessProfile, false, validation, validationErr)
+			report := compatibility.InitialProcessingReport(workflows[i].Path, hostedTokenlessProfile, false, validation, validationErr)
 			report.Result = "incompatible"
 			_ = out.write(report)
+			if excludeUnsupported {
+				excludeUnsupportedWorkflow(stderr, &workflows[i], validationErr)
+				continue
+			}
 			return 1
 		}
 	}
@@ -1468,13 +1480,19 @@ func uploadParsed(uploadArguments parsedUploadArgs, stdout, stderr io.Writer, ve
 		return 1
 	}
 	for i := range workflows {
-		if workflows[i].ReusableOnly {
+		if workflows[i].ReusableOnly || workflows[i].Excluded {
 			continue
 		}
 		selection, triggerErr := selectWorkflowTrigger(workflows[i].Triggers, effectiveEvent)
 		if triggerErr != nil {
 			triggerErr = fmt.Errorf("%s: translate workflow triggers: %w", workflows[i].CanonicalPath, triggerErr)
 			_ = out.write(triggerFailureProcessingReport(workflows[i], triggerErr))
+			if excludeUnsupported {
+				if _, staticErr := buildkitepipeline.TranslateTriggerCondition(workflows[i].Triggers); staticErr != nil {
+					excludeUnsupportedWorkflow(stderr, &workflows[i], triggerErr)
+					continue
+				}
+			}
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", triggerErr)
 			return 1
 		}
@@ -1482,23 +1500,33 @@ func uploadParsed(uploadArguments parsedUploadArgs, stdout, stderr io.Writer, ve
 		workflows[i].TriggerCondition = selection.Condition
 		workflows[i].SkipReason = selection.SkipReason
 	}
+	if excludeUnsupported && supportedWorkflowCount(workflows) == 0 {
+		return finishExcludedWorkflowSelection(stdout, workflows)
+	}
 	processingReports := make([]compatibility.ProcessingReport, len(workflows))
 	for i, input := range workflows {
-		if !input.Applicable {
+		if !input.Applicable || input.Excluded {
 			continue
 		}
 		validationOptions := hostedTokenlessOptions("", uploadArguments.runnerTargets, nil)
 		validationOptions.StepKeyNamespace = input.StepKeyNamespace
 		processingReport, ok := validatedProcessingReportWithOptions(out, input.Path, hostedTokenlessProfile, input.Source, effectiveEvent.Source, true, &validationOptions)
 		if !ok {
+			if excludeUnsupported && unsupportedProcessingReport(processingReport) {
+				excludeUnsupportedWorkflow(stderr, &workflows[i], nil)
+				continue
+			}
 			return 1
 		}
 		processingReports[i] = processingReport
 	}
+	if excludeUnsupported && supportedWorkflowCount(workflows) == 0 {
+		return finishExcludedWorkflowSelection(stdout, workflows)
+	}
 	executablePath, executableContents, distributionDigest, err := executable()
 	if err != nil {
 		for i, input := range workflows {
-			if !input.Applicable {
+			if !input.Applicable || input.Excluded {
 				continue
 			}
 			processingReports[i].AddEnvironmentFailure("compiler executable could not be inspected")
@@ -1511,7 +1539,7 @@ func uploadParsed(uploadArguments parsedUploadArgs, stdout, stderr io.Writer, ve
 	if uploadArguments.pluginAcquisition != nil {
 		requiredPlatforms := make(map[compiler.Platform]bool, 2)
 		for _, input := range workflows {
-			if !input.Applicable {
+			if !input.Applicable || input.Excluded {
 				continue
 			}
 			platforms, platformErr := requiredRuntimePlatforms(input.Path, input.Source, effectiveEvent.Source, "", uploadArguments.runnerTargets)
@@ -1539,6 +1567,7 @@ func uploadParsed(uploadArguments parsedUploadArgs, stdout, stderr io.Writer, ve
 }
 
 func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout, stderr io.Writer, version string, agent transport.Agent, workflows []workflowInput, effectiveEvent effectiveEventSelection, executablePath string, executableContents []byte, distributionDigest, importerStep string, processingReports []compatibility.ProcessingReport, out processingOutput, runtimeDistributions map[compiler.Platform]runtimeDistribution) int {
+	excludeUnsupported := !uploadArguments.explicitWorkflowPaths && len(uploadArguments.workflowOperands) == 1 && uploadArguments.workflowOperands[0] == "*"
 	runtimeDigests := map[compiler.Platform]string{compiler.PlatformLinuxAMD64: distributionDigest}
 	for platform, runtimeDistribution := range runtimeDistributions {
 		runtimeDigests[platform] = runtimeDistribution.digest
@@ -1548,7 +1577,7 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 	planArtifacts := make([]compiler.PlanArtifact, 0)
 	jobCount := 0
 	for i, input := range workflows {
-		if input.ReusableOnly {
+		if input.ReusableOnly || input.Excluded {
 			continue
 		}
 		if !input.Applicable {
@@ -1569,6 +1598,10 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 		if err != nil {
 			processingReports[i].Result = classifyHostedTokenlessFailure(&processingReports[i], input.Path, err)
 			_ = out.write(processingReports[i])
+			if excludeUnsupported && processingReports[i].Result == "not-admitted" {
+				excludeUnsupportedWorkflow(stderr, &workflows[i], err)
+				continue
+			}
 			return 1
 		}
 		bundle := preflight.Bundle
@@ -1589,6 +1622,9 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 		processingReports[i].Result = "admitted"
 		writeCompilerWarnings(stderr, "upload", input.CanonicalPath, bundle.IR.Warnings)
 	}
+	if excludeUnsupported && len(generatedWorkflows) == 0 {
+		return finishExcludedWorkflowSelection(stdout, workflows)
+	}
 	aggregatePipeline, err := buildkitepipeline.Emit(buildkitepipeline.Pipeline{
 		CompilerStep: importerStep,
 		Workflows:    generatedWorkflows,
@@ -1598,7 +1634,7 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 		return 1
 	}
 	for i, input := range workflows {
-		if input.Applicable {
+		if input.Applicable && !input.Excluded {
 			_ = compatibility.WriteProcessing(stdout, "text", processingReports[i])
 		}
 	}
@@ -1814,7 +1850,62 @@ type workflowInput struct {
 	Source                                                []byte
 	Triggers                                              []workflow.Trigger
 	TriggerCondition, SkipReason                          string
-	ReusableOnly, Applicable                              bool
+	ReusableOnly, Applicable, Excluded                    bool
+}
+
+func excludeUnsupportedWorkflow(stderr io.Writer, input *workflowInput, err error) {
+	input.Excluded = true
+	path := input.CanonicalPath
+	if path == "" {
+		path = input.Path
+	}
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: warning: excluding unsupported workflow %s: %v\n", path, err)
+		return
+	}
+	_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: warning: excluding unsupported workflow %s\n", path)
+}
+
+func unsupportedProcessingReport(report compatibility.ProcessingReport) bool {
+	if report.Result != "incompatible" {
+		return false
+	}
+	for _, diagnostic := range report.Diagnostics {
+		if diagnostic.Level == "error" && diagnostic.Category == "environment" {
+			return false
+		}
+	}
+	return true
+}
+
+func supportedWorkflowCount(workflows []workflowInput) int {
+	count := 0
+	for _, input := range workflows {
+		if !input.ReusableOnly && !input.Excluded {
+			count++
+		}
+	}
+	return count
+}
+
+func excludedWorkflowCount(workflows []workflowInput) int {
+	count := 0
+	for _, input := range workflows {
+		if input.Excluded {
+			count++
+		}
+	}
+	return count
+}
+
+func finishExcludedWorkflowSelection(stdout io.Writer, workflows []workflowInput) int {
+	count := excludedWorkflowCount(workflows)
+	noun := "workflows"
+	if count == 1 {
+		noun = "workflow"
+	}
+	_, _ = fmt.Fprintf(stdout, "Excluded %d unsupported %s; no supported workflows to upload.\n", count, noun)
+	return 0
 }
 
 func expandWorkflowOperands(operands []string) ([]workflowInput, error) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -3269,17 +3269,89 @@ func TestRunUploadRejectsUnsupportedTriggerBeforeAnyUpload(t *testing.T) {
 	}
 }
 
+func TestPluginStarExcludesUnsupportedWorkflows(t *testing.T) {
+	requireImporterHost(t)
+	repository := writeUploadWorkflowRepository(t, map[string]string{
+		"invalid.yml": "on: [push\njobs: {}\n",
+		"issues.yml":  "name: Issues\non: issues\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
+		"push.yml":    "name: Push\non: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
+		"secret.yml":  "name: Secret\non: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    env:\n      TOKEN: ${{ secrets.TOKEN }}\n    steps: [{run: true}]\n",
+		"windows.yml": "name: Windows\non: push\njobs:\n  test:\n    runs-on: windows-latest\n    steps: [{run: true}]\n",
+	})
+	t.Chdir(repository)
+	t.Setenv(pluginConfigurationEnvironment, `{"workflows":"*"}`)
+	setCLIPluginBuildkiteEnvironment(t, "star-importer")
+	runner := &cliCaptureRunner{}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"plugin"}, &stdout, &stderr, "dev", runner); code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Uploaded 1 jobs from 1 workflows") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+	for _, want := range []string{
+		`unsupported GitHub trigger event "issues"`,
+		"warning: excluding unsupported workflow .github/workflows/invalid.yml",
+		"warning: excluding unsupported workflow .github/workflows/issues.yml",
+		"warning: excluding unsupported workflow .github/workflows/secret.yml",
+		"warning: excluding unsupported workflow .github/workflows/windows.yml",
+	} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr = %q, want %q", stderr.String(), want)
+		}
+	}
+	var pipeline struct {
+		Steps []struct {
+			Group string `yaml:"group"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(runner.commands[len(runner.commands)-1].stdin, &pipeline); err != nil {
+		t.Fatal(err)
+	}
+	if len(pipeline.Steps) != 1 || pipeline.Steps[0].Group != ":github: Push" {
+		t.Fatalf("wildcard pipeline groups = %#v", pipeline.Steps)
+	}
+}
+
+func TestPluginStarSucceedsWhenAllWorkflowsAreUnsupported(t *testing.T) {
+	requireImporterHost(t)
+	repository := writeUploadWorkflowRepository(t, map[string]string{
+		"issues.yml": "on: issues\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
+	})
+	t.Chdir(repository)
+	t.Setenv(pluginConfigurationEnvironment, `{"workflows":"*"}`)
+	setCLIPluginBuildkiteEnvironment(t, "unsupported-star-importer")
+	runner := &cliCaptureRunner{}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"plugin"}, &stdout, &stderr, "dev", runner); code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Excluded 1 unsupported workflow; no supported workflows to upload") || !strings.Contains(stderr.String(), "warning: excluding unsupported workflow .github/workflows/issues.yml") {
+		t.Fatalf("stdout/stderr = %q / %q", stdout.String(), stderr.String())
+	}
+	if len(runner.uploaded) != 0 {
+		t.Fatalf("unsupported wildcard selection uploaded artifacts: %#v", runner.uploaded)
+	}
+	for _, command := range runner.commands {
+		if len(command.args) >= 2 && command.args[0] == "pipeline" && command.args[1] == "upload" {
+			t.Fatalf("unsupported wildcard selection uploaded a pipeline: %#v", command)
+		}
+	}
+}
+
 func TestRunUploadRejectsIncompletePullRequestSnapshots(t *testing.T) {
 	requireImporterHost(t)
 	for _, test := range []struct {
 		name, workflow, want string
 		payload              map[string]any
+		wildcard             bool
 	}{
 		{
 			name:     "missing action",
 			workflow: "on: pull_request\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
 			payload:  map[string]any{"pull_request": map[string]any{"base": map[string]any{"ref": "main"}}},
 			want:     "payload.action",
+			wildcard: true,
 		},
 		{
 			name:     "missing filtered base branch",
@@ -3296,7 +3368,11 @@ func TestRunUploadRejectsIncompletePullRequestSnapshots(t *testing.T) {
 			t.Setenv("BUILDKITE_STEP_KEY", "incomplete-pull-request-importer")
 			runner := &cliCaptureRunner{webhookErr: errors.New("metadata must not be read with --event-path")}
 			var stdout, stderr bytes.Buffer
-			if code := run([]string{"upload", "--event-path", eventPath, ".github/workflows/pull-request.yml"}, &stdout, &stderr, "dev", runner); code != 1 || !strings.Contains(stderr.String(), test.want) {
+			workflowOperand := ".github/workflows/pull-request.yml"
+			if test.wildcard {
+				workflowOperand = "*"
+			}
+			if code := run([]string{"upload", "--event-path", eventPath, workflowOperand}, &stdout, &stderr, "dev", runner); code != 1 || !strings.Contains(stderr.String(), test.want) {
 				t.Fatalf("run() code/stderr = %d / %q, want %q", code, stderr.String(), test.want)
 			}
 			if len(runner.commands) != 0 || len(runner.uploaded) != 0 {


### PR DESCRIPTION
## Summary

- treat the exact `workflows: *` selector as discovery mode
- report and omit incompatible or non-admitted workflows while uploading supported workflows
- keep explicit selectors and shared event, environment, action-resolution, artifact, and upload failures strict
- succeed without adding steps when every discovered workflow is unsupported

## Testing

- `mise run check`