### PR TITLE
Make hosted macOS action jobs portable

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -65,6 +65,7 @@ steps:
     steps:
       - label: ":go: Repository checks"
         key: "checks"
+        if: build.env("DEMO_SUITE") != "plugin"
         cache: ".buildkite/cache-volume"
         env:
           BUILDKITE_GHA_LIVE_REQUIRED: "1"

--- a/.buildkite/plugin-demo.yml
+++ b/.buildkite/plugin-demo.yml
@@ -59,7 +59,7 @@ steps:
       - "plugin-demo-actions-importer"
       - "plugin-demo-macos-importer"
       - "plugin-demo-advanced-importer"
-    command: "echo 'The released plugin and CLI completed all service-free workflows.'"
+    command: "echo 'The released plugin completed all service-free workflows. Linux used the released CLI; macOS used the CLI source from DEMO_COMMIT.'"
 
   - label: ":package: Cache released-plugin demo"
     key: "plugin-demo-cache-importer"

--- a/.buildkite/plugin-demo.yml
+++ b/.buildkite/plugin-demo.yml
@@ -40,7 +40,7 @@ steps:
           version: 0.10.3
           runners:
             - runs-on: macos-14
-              queue: mac-small
+              queue: macos
 
   - label: ":rocket: Advanced released-plugin demo"
     key: "plugin-demo-advanced-importer"

--- a/.buildkite/plugin-demo.yml
+++ b/.buildkite/plugin-demo.yml
@@ -37,7 +37,7 @@ steps:
     plugins:
       - github-actions#v0.9.3:
           workflow: .github/workflows/macos-actions-proof.yml
-          version: 0.10.3
+          source-ref: "$DEMO_COMMIT"
           runners:
             - runs-on: macos-14
               queue: mac-small

--- a/.buildkite/plugin-demo.yml
+++ b/.buildkite/plugin-demo.yml
@@ -8,7 +8,7 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#v0.8.0:
+      - github-actions#v0.9.3:
           workflow: .github/workflows/example-basic.yml
 
   - label: ":package: Artifact released-plugin demo"
@@ -17,7 +17,7 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#v0.8.0:
+      - github-actions#v0.9.3:
           workflow: .github/workflows/example-artifacts.yml
 
   - label: ":javascript: Actions released-plugin demo"
@@ -26,8 +26,21 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#v0.8.0:
+      - github-actions#v0.9.3:
           workflow: .github/workflows/local-actions-oracle.yml
+
+  - label: ":mac: Native macOS released-plugin proof"
+    key: "plugin-demo-macos-importer"
+    timeout_in_minutes: 15
+    retry:
+      automatic: false
+    plugins:
+      - github-actions#v0.9.3:
+          workflow: .github/workflows/macos-actions-proof.yml
+          version: 0.10.3
+          runners:
+            - runs-on: macos-14
+              queue: mac-small
 
   - label: ":rocket: Advanced released-plugin demo"
     key: "plugin-demo-advanced-importer"
@@ -35,7 +48,7 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#v0.8.0:
+      - github-actions#v0.9.3:
           workflow: .github/workflows/example-advanced.yml
 
   - label: ":white_check_mark: Service-free plugin demo complete"
@@ -44,6 +57,7 @@ steps:
       - "plugin-demo-basic-importer"
       - "plugin-demo-artifact-importer"
       - "plugin-demo-actions-importer"
+      - "plugin-demo-macos-importer"
       - "plugin-demo-advanced-importer"
     command: "echo 'The released plugin and CLI completed all service-free workflows.'"
 
@@ -54,7 +68,7 @@ steps:
     retry:
       automatic: false
     plugins:
-      - github-actions#v0.8.0:
+      - github-actions#v0.9.3:
           workflow: testdata/plugin-demo/.github/workflows/cache.yml
 
   - label: ":white_check_mark: Cache plugin demo complete"

--- a/.buildkite/plugin-demo.yml
+++ b/.buildkite/plugin-demo.yml
@@ -40,7 +40,7 @@ steps:
           version: 0.10.3
           runners:
             - runs-on: macos-14
-              queue: macos
+              queue: mac-small
 
   - label: ":rocket: Advanced released-plugin demo"
     key: "plugin-demo-advanced-importer"

--- a/.github/workflows/macos-actions-proof.yml
+++ b/.github/workflows/macos-actions-proof.yml
@@ -12,7 +12,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Verify native runner identity
-        if: runner.os == 'macOS' && runner.arch == 'ARM64'
         shell: bash
         env:
           RUNNER_CONTEXT: ${{ runner.os }}/${{ runner.arch }}

--- a/.github/workflows/macos-actions-proof.yml
+++ b/.github/workflows/macos-actions-proof.yml
@@ -1,0 +1,62 @@
+name: Native macOS actions proof
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  macos:
+    runs-on: macos-14
+    timeout-minutes: 10
+    steps:
+      - name: Verify native runner identity
+        if: runner.os == 'macOS' && runner.arch == 'ARM64'
+        shell: bash
+        env:
+          RUNNER_CONTEXT: ${{ runner.os }}/${{ runner.arch }}
+        run: |
+          test "$RUNNER_CONTEXT" = macOS/ARM64
+          test "$RUNNER_OS/$RUNNER_ARCH" = macOS/ARM64
+          test "$(uname -s)/$(uname -m)" = Darwin/arm64
+
+      - name: Verify image and tool boundaries
+        shell: bash
+        run: |
+          test -z "${ImageOS:-}"
+          test "${RUNNER_TOOL_CACHE:-}" != /opt/hostedtoolcache
+          if buildkite-gha-intentionally-missing-tool; then
+            echo "unexpectedly found the missing-tool probe" >&2
+            exit 1
+          else
+            test "$?" = 127
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Produce shell output
+        id: shell
+        shell: bash
+        run: echo "result=macos" >> "$GITHUB_OUTPUT"
+
+      - name: Run local JavaScript action
+        id: javascript
+        uses: ./.github/actions/oracle-javascript
+        with:
+          message: ${{ steps.shell.outputs.result }}
+
+      - name: Run local composite action
+        id: composite
+        uses: ./.github/actions/oracle-composite
+        with:
+          message: ${{ steps.javascript.outputs.result }}
+
+      - name: Verify action results
+        shell: bash
+        env:
+          RESULT: ${{ steps.composite.outputs.result }}
+        run: |
+          test "$RESULT" = macos-javascript-composite
+          test "$SMOKE_COMPOSITE_SEEN" = true

--- a/docs/development.md
+++ b/docs/development.md
@@ -74,7 +74,7 @@ scripts/verify-artifact-roundtrip <build-number> <commit>
 
 ## Test released and native entry points
 
-Run the examples through the released plugin and its default mise-based runtime resolution:
+Run the examples through the released plugin. Linux uses its default mise-based public release resolution. The native macOS proof temporarily builds the CLI runtime from `DEMO_COMMIT` through the plugin's `source-ref` option until the Darwin cache fix is released:
 
 ```sh
 commit=$(git rev-parse HEAD)
@@ -83,7 +83,7 @@ bk build create --pipeline buildkite/buildkite-gha \
   --env DEMO_SUITE=plugin --env DEMO_COMMIT="$commit" --yes
 ```
 
-Add `--env DEMO_CACHE=1` to include the optional cache producer and consumer workflow. Mise must download and verify the public CLI release. The demo must not fall back to a local binary.
+Add `--env DEMO_CACHE=1` to include the optional cache producer and consumer workflow. For Linux workflows, mise must download and verify the public CLI release; they must not fall back to a local binary.
 
 For a side-by-side GitHub Actions and Buildkite UX check, run:
 

--- a/internal/buildkite/pipeline.go
+++ b/internal/buildkite/pipeline.go
@@ -18,6 +18,7 @@ const distributionDirectory = ".buildkite-gha/distributions"
 const maxConcurrencyGroupLength = 200
 const runtimeCacheName = "buildkite-gha"
 const runtimeCacheRoot = "/cache/bkcache/buildkite-gha"
+const darwinRuntimeCacheRoot = "/tmp/bkcache/buildkite-gha"
 
 // ContinueOnErrorExitStatus is reserved for a workflow failure that the job's
 // immutable plan explicitly allows Buildkite to soft-fail.
@@ -85,7 +86,7 @@ func MiseDataDir(platforms ...string) string {
 	if len(platforms) != 0 {
 		platform = platforms[0]
 	}
-	return runtimeCacheRoot + "/mise/" + platformCacheKey(platform) + "/" + MinimumMiseVersion
+	return platformMiseCachePath(platform) + "/" + MinimumMiseVersion
 }
 
 // Job describes one expanded workflow job after queue policy has been applied.
@@ -355,7 +356,11 @@ func platformCacheKey(platform string) string {
 }
 
 func platformMiseCachePath(platform string) string {
-	return runtimeCacheRoot + "/mise/" + platformCacheKey(platform)
+	root := runtimeCacheRoot
+	if platform == "darwin/arm64" {
+		root = darwinRuntimeCacheRoot
+	}
+	return root + "/mise/" + platformCacheKey(platform)
 }
 
 type dependency struct {

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -525,7 +525,7 @@ func TestEmitDarwinActionRuntimeUsesNativePlatformCache(t *testing.T) {
 		t.Fatalf("steps = %#v", document.Steps)
 	}
 	step := document.Steps[0]
-	if step.Image != "" || step.Cache.Name != "buildkite-gha-darwin-arm64" || !slices.Equal(step.Cache.Paths, []string{"/cache/bkcache/buildkite-gha/mise/darwin-arm64"}) {
+	if step.Image != "" || step.Cache.Name != "buildkite-gha-darwin-arm64" || !slices.Equal(step.Cache.Paths, []string{"/tmp/bkcache/buildkite-gha/mise/darwin-arm64"}) {
 		t.Fatalf("Darwin runtime placement = %#v", step)
 	}
 	if step.Env["BUILDKITE_GHA_MISE_DATA_DIR"] != MiseDataDir("darwin/arm64") {
@@ -568,7 +568,7 @@ func TestMiseDataDirUsesManagedRuntimeVersion(t *testing.T) {
 	if got := MiseDataDir(); got != "/cache/bkcache/buildkite-gha/mise/linux-amd64/"+MinimumMiseVersion {
 		t.Fatalf("MiseDataDir() = %q", got)
 	}
-	if got := MiseDataDir("darwin/arm64"); got != "/cache/bkcache/buildkite-gha/mise/darwin-arm64/"+MinimumMiseVersion {
+	if got := MiseDataDir("darwin/arm64"); got != "/tmp/bkcache/buildkite-gha/mise/darwin-arm64/"+MinimumMiseVersion {
 		t.Fatalf("MiseDataDir(darwin/arm64) = %q", got)
 	}
 }

--- a/testdata/plugin-demo/README.md
+++ b/testdata/plugin-demo/README.md
@@ -1,7 +1,8 @@
 # Released-plugin demo fixtures
 
 `.buildkite/plugin-demo.yml` runs the repository's example workflows through
-the released `github-actions` plugin and CLI. The service-free examples run by
-default. They include a native macOS arm64 proof for shell, JavaScript, and
-composite steps. Set `DEMO_CACHE=1` to include the optional cache extension in
-`.github/workflows/cache.yml`.
+the released `github-actions` plugin. The service-free examples run by default
+and normally resolve the released CLI. The native macOS arm64 proof runs the
+selected source commit until its runtime changes ship in a release. It covers
+shell, JavaScript, and composite steps. Set `DEMO_CACHE=1` to include the
+optional cache extension in `.github/workflows/cache.yml`.

--- a/testdata/plugin-demo/README.md
+++ b/testdata/plugin-demo/README.md
@@ -2,5 +2,6 @@
 
 `.buildkite/plugin-demo.yml` runs the repository's example workflows through
 the released `github-actions` plugin and CLI. The service-free examples run by
-default. Set `DEMO_CACHE=1` to include the optional cache extension in
+default. They include a native macOS arm64 proof for shell, JavaScript, and
+composite steps. Set `DEMO_CACHE=1` to include the optional cache extension in
 `.github/workflows/cache.yml`.


### PR DESCRIPTION
## Why

Native macOS support still lacks a hosted runtime proof for JavaScript and composite actions, runner context expressions, and the documented image and tool boundaries. The initial proof exposed that generated Darwin action jobs reuse Linux's read-only `/cache` root on this repository's hosted macOS queue.

## What

Use a writable, platform-isolated Darwin runtime cache while preserving the existing Linux path. Add a native Darwin arm64 workflow to the released-plugin demo that runs shell, checkout, local JavaScript, and composite steps on `mac-small`. The proof checks runner identity, absent GitHub image metadata, and normal missing-tool failure. It runs the selected source commit until this cache fix ships in a runtime release. Keep dedicated plugin-demo builds focused on that suite; normal builds retain the repository check lane.

Related to #129.
