### PR TITLE
Annotate workflow processing diagnostics in Buildkite

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -39,9 +39,11 @@ Use `--format json` for a `buildkite-gha/processing-report/v1` report.
 
 Reports cover workflow parsing, event validation, graph construction, matrix expansion, expressions, action discovery and resolution, plan construction, profile admission, and pipeline generation. A blocked downstream stage is `not-evaluated`, not `failed`.
 
+When `validate`, `compile`, or `upload` runs in a Buildkite job, it also publishes report warnings and errors as job-scoped Buildkite annotations. Annotation failures produce a warning but do not change the command result.
+
 Profile validation applies the upload trigger policy before compilation. A `not-applicable` result means the workflow does not declare the selected event and would become a skipped group during upload. Unsupported triggers and malformed data are incompatible.
 
-Validation may use the public network to resolve actions. It does not call Buildkite, install Node, or execute workflow code.
+Validation may use the public network to resolve actions. Apart from annotation publication when it runs in a Buildkite job, it does not call Buildkite, install Node, or execute workflow code.
 
 ## Provide an event snapshot
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -91,7 +91,7 @@ buildkite-gha compile \
   .github/workflows/ci.yml
 ```
 
-`compile` is read-only. It does not upload the executable, plans, or pipeline, so piping its YAML directly to `buildkite-agent pipeline upload` is incomplete.
+`compile` does not upload the executable, plans, or pipeline, so piping its YAML directly to `buildkite-agent pipeline upload` is incomplete.
 
 ## Upload from a custom importer
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -143,9 +143,9 @@ func run(args []string, stdout, stderr io.Writer, version string, agentRunner tr
 			}
 			switch args[0] {
 			case "validate":
-				return validate(args[1:], stdout, stderr, version)
+				return validate(args[1:], stdout, stderr, version, transport.Agent{Runner: agentRunner})
 			case "compile":
-				return compile(args[1:], stdout, stderr, version)
+				return compile(args[1:], stdout, stderr, version, transport.Agent{Runner: agentRunner})
 			case "upload":
 				return upload(args[1:], stdout, stderr, version, transport.Agent{Runner: agentRunner})
 			case "run-job":
@@ -1184,7 +1184,7 @@ func verifyBuildkiteTarget(job plan.Job) error {
 	return nil
 }
 
-func validate(args []string, stdout, stderr io.Writer, version string) int {
+func validate(args []string, stdout, stderr io.Writer, version string, agent transport.Agent) int {
 	workflowPath, eventPath, format, profile, err := validateArgs(args)
 	if err != nil {
 		return usageError(stderr, "validate: %v", err)
@@ -1192,7 +1192,7 @@ func validate(args []string, stdout, stderr io.Writer, version string) int {
 	if profile != "" && eventPath == "" {
 		return usageError(stderr, "validate: --event-path is required with --profile")
 	}
-	out := processingOutput{command: "validate", format: format, reports: stdout, stderr: stderr}
+	out := newProcessingOutput("validate", format, stdout, stderr, agent)
 	var loadEvent func() ([]byte, error)
 	if eventPath != "" {
 		loadEvent = func() ([]byte, error) { return os.ReadFile(eventPath) }
@@ -1308,7 +1308,7 @@ func validateArgs(args []string) (workflowPath, eventPath, format, profile strin
 	return workflowPath, eventPath, format, profile, err
 }
 
-func compile(args []string, stdout, stderr io.Writer, version string) int {
+func compile(args []string, stdout, stderr io.Writer, version string, agent transport.Agent) int {
 	workflowPath, eventPath, format, err := compileArgs(args)
 	if err != nil {
 		return usageError(stderr, "compile: %v", err)
@@ -1316,7 +1316,7 @@ func compile(args []string, stdout, stderr io.Writer, version string) int {
 	if eventPath == "" {
 		return usageError(stderr, "compile: --event-path is required")
 	}
-	out := processingOutput{command: "compile", format: "text", reports: stderr, stderr: stderr}
+	out := newProcessingOutput("compile", "text", stderr, stderr, agent)
 	source, event, ok := loadProcessingInputs(out, workflowPath, "", "event input could not be read", func() ([]byte, error) { return os.ReadFile(eventPath) })
 	if !ok {
 		return 1
@@ -1400,7 +1400,7 @@ func uploadParsed(uploadArguments parsedUploadArgs, stdout, stderr io.Writer, ve
 			return usageError(stderr, "upload: %s is no longer supported; configure runner profiles with --runner-queue and --runner-image, or with the plugin runners array", retired)
 		}
 	}
-	out := processingOutput{command: "upload", format: "text", reports: stderr, stderr: stderr}
+	out := newProcessingOutput("upload", "text", stderr, stderr, agent)
 	var workflows []workflowInput
 	var err error
 	if uploadArguments.explicitWorkflowPaths {
@@ -1605,6 +1605,7 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 	for i, input := range workflows {
 		if input.Applicable {
 			_ = compatibility.WriteProcessing(stdout, "text", processingReports[i])
+			out.annotate(processingReports[i])
 		}
 	}
 	artifacts := make([]transport.Artifact, 0, 1+len(runtimeDistributions)+len(planArtifacts))

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2066,7 +2066,7 @@ func TestValidatePublishesProcessingDiagnosticsInBuildkite(t *testing.T) {
 		if len(annotation.args) != 9 || annotation.args[0] != "annotate" || annotation.args[2] != "job" || annotation.args[4] != cliTestJobID || !strings.HasPrefix(annotation.args[6], processingAnnotationContext+"-") || annotation.args[8] != "error" {
 			t.Fatalf("annotation args = %#v", annotation.args)
 		}
-		for _, want := range []string{"GitHub Actions workflow diagnostics", "E\\_EXPRESSION\\_INVALID", "resolved runner target is not admitted by policy", "job: test"} {
+		for _, want := range []string{"GitHub Actions workflow diagnostics", "E\\_EXPRESSION\\_INVALID", "resolved runner target is not admitted by policy", "job: test", "instance: gha-test"} {
 			if !strings.Contains(string(annotation.stdin), want) {
 				t.Fatalf("annotation = %q, want %q", annotation.stdin, want)
 			}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2100,16 +2100,32 @@ func TestValidatePublishesProcessingDiagnosticsInBuildkite(t *testing.T) {
 func TestProcessingAnnotationIsBoundedAndEscapesMarkdown(t *testing.T) {
 	report := compatibility.NewProcessingReport("<workflow>|name", "")
 	report.Diagnostics = append(report.Diagnostics, compatibility.Diagnostic{
-		Level: "error", Code: "E_TEST", Message: "line one\n<script>*unsafe*</script> " + strings.Repeat("界", processingAnnotationBodyLimit),
+		Level: "error", Code: "E_TEST", Message: `line one
+<script>*unsafe*</script> "quoted" ` + strings.Repeat("界", processingAnnotationBodyLimit),
 	})
 	style, body := processingAnnotation(report)
 	if style != "error" || len(body) > processingAnnotationBodyLimit || !utf8.ValidString(body) {
 		t.Fatalf("style = %q, bytes = %d, valid UTF-8 = %v", style, len(body), utf8.ValidString(body))
 	}
-	for _, want := range []string{"&lt;workflow&gt;\\|name", "&lt;script&gt;\\*unsafe\\*&lt;/script&gt;", "Additional diagnostics omitted"} {
+	for _, want := range []string{"&lt;workflow&gt;\\|name", `&lt;script&gt;\*unsafe\*&lt;/script&gt; "quoted"`, "Additional diagnostics omitted"} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("annotation lacks %q", want)
 		}
+	}
+}
+
+func TestProcessingAnnotationDoesNotRepeatDiagnosticLocation(t *testing.T) {
+	report := compatibility.NewProcessingReport("ci.yml", "")
+	report.Diagnostics = append(report.Diagnostics, compatibility.Diagnostic{
+		Level: "warning", Code: "W_TEST", Message: "ci.yml:4:23: warning message",
+		Location: &compatibility.SourceLocation{Path: "ci.yml", Line: 4, Column: 23},
+	})
+	_, body := processingAnnotation(report)
+	if count := strings.Count(body, "ci.yml:4:23"); count != 1 {
+		t.Fatalf("annotation location count = %d, want 1: %q", count, body)
+	}
+	if !strings.Contains(body, "warning message") {
+		t.Fatalf("annotation = %q", body)
 	}
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -21,6 +21,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	actionintegration "github.com/buildkite/buildkite-gha/internal/action/integration"
 	actionsource "github.com/buildkite/buildkite-gha/internal/action/source"
@@ -38,6 +39,12 @@ const (
 	cliTestJobID         = "22222222-2222-4222-8222-222222222222"
 	cliTestProducerJobID = "33333333-3333-4333-8333-333333333333"
 )
+
+func TestMain(m *testing.M) {
+	_ = os.Unsetenv("BUILDKITE")
+	_ = os.Unsetenv("BUILDKITE_JOB_ID")
+	os.Exit(m.Run())
+}
 
 // Stable stage IDs asserted throughout the report expectations below.
 const (
@@ -2038,6 +2045,74 @@ jobs:
 	})
 }
 
+func TestValidatePublishesProcessingDiagnosticsInBuildkite(t *testing.T) {
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_JOB_ID", cliTestJobID)
+
+	t.Run("error", func(t *testing.T) {
+		workflowPath := filepath.Join(t.TempDir(), "unsupported.yml")
+		if err := os.WriteFile(workflowPath, []byte("on: push\njobs:\n  test:\n    runs-on: windows-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		runner := &cliCaptureRunner{}
+		var stdout, stderr bytes.Buffer
+		if code := run([]string{"validate", "--format", "json", workflowPath}, &stdout, &stderr, "dev", runner); code != 1 {
+			t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+		}
+		if len(runner.commands) != 1 {
+			t.Fatalf("commands = %#v, want one annotation", runner.commands)
+		}
+		annotation := runner.commands[0]
+		if len(annotation.args) != 9 || annotation.args[0] != "annotate" || annotation.args[2] != "job" || annotation.args[4] != cliTestJobID || !strings.HasPrefix(annotation.args[6], processingAnnotationContext+"-") || annotation.args[8] != "error" {
+			t.Fatalf("annotation args = %#v", annotation.args)
+		}
+		for _, want := range []string{"GitHub Actions workflow diagnostics", "E\\_EXPRESSION\\_INVALID", "resolved runner target is not admitted by policy", "job: test"} {
+			if !strings.Contains(string(annotation.stdin), want) {
+				t.Fatalf("annotation = %q, want %q", annotation.stdin, want)
+			}
+		}
+		var report compatibility.ProcessingReport
+		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil || report.Result != "incompatible" {
+			t.Fatalf("report = %#v, error = %v", report, err)
+		}
+	})
+
+	t.Run("warning publication failure is non-fatal", func(t *testing.T) {
+		workflowPath := filepath.Join(t.TempDir(), "warning.yml")
+		workflow := []byte("on: push\nconcurrency:\n  group: ci\n  cancel-in-progress: true\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n")
+		if err := os.WriteFile(workflowPath, workflow, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		runner := &cliCaptureRunner{failAnnotation: true}
+		var stdout, stderr bytes.Buffer
+		if code := run([]string{"validate", workflowPath}, &stdout, &stderr, "dev", runner); code != 0 {
+			t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+		}
+		if len(runner.commands) != 1 || runner.commands[0].args[8] != "warning" {
+			t.Fatalf("commands = %#v, want one warning annotation", runner.commands)
+		}
+		if !strings.Contains(stderr.String(), "warning: processing annotation: annotation unavailable") {
+			t.Fatalf("stderr = %q", stderr.String())
+		}
+	})
+}
+
+func TestProcessingAnnotationIsBoundedAndEscapesMarkdown(t *testing.T) {
+	report := compatibility.NewProcessingReport("<workflow>|name", "")
+	report.Diagnostics = append(report.Diagnostics, compatibility.Diagnostic{
+		Level: "error", Code: "E_TEST", Message: "line one\n<script>*unsafe*</script> " + strings.Repeat("界", processingAnnotationBodyLimit),
+	})
+	style, body := processingAnnotation(report)
+	if style != "error" || len(body) > processingAnnotationBodyLimit || !utf8.ValidString(body) {
+		t.Fatalf("style = %q, bytes = %d, valid UTF-8 = %v", style, len(body), utf8.ValidString(body))
+	}
+	for _, want := range []string{"&lt;workflow&gt;\\|name", "&lt;script&gt;\\*unsafe\\*&lt;/script&gt;", "Additional diagnostics omitted"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("annotation lacks %q", want)
+		}
+	}
+}
+
 func TestUnsupportedConditionPreflightAppliesToEveryCompilerEntryPoint(t *testing.T) {
 	workflowPath := filepath.Join(t.TempDir(), "conditions.yml")
 	if err := os.WriteFile(workflowPath, []byte(`on: push
@@ -2092,9 +2167,10 @@ jobs:
 		}
 	})
 
-	t.Run("upload before Buildkite calls", func(t *testing.T) {
+	t.Run("upload annotates before artifact or pipeline calls", func(t *testing.T) {
 		requireImporterHost(t)
 		t.Setenv("BUILDKITE", "true")
+		t.Setenv("BUILDKITE_JOB_ID", cliTestJobID)
 		t.Setenv("BUILDKITE_STEP_KEY", "condition-importer")
 		runner := &cliCaptureRunner{}
 		var stdout, stderr bytes.Buffer
@@ -2102,8 +2178,8 @@ jobs:
 		if code := run(args, &stdout, &stderr, "dev", runner); code != 1 || !strings.Contains(stderr.String(), want) {
 			t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
 		}
-		if len(runner.commands) != 0 {
-			t.Fatalf("unsupported condition made Buildkite calls: %#v", runner.commands)
+		if len(runner.commands) != 1 || runner.commands[0].args[0] != "annotate" || runner.commands[0].args[8] != "error" {
+			t.Fatalf("unsupported condition commands = %#v, want one error annotation", runner.commands)
 		}
 	})
 }

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
-	"html"
 	"io"
 	"os"
 	"strings"
@@ -98,7 +97,7 @@ func processingAnnotation(report compatibility.ProcessingReport) (style, body st
 			out.WriteString(markdownText(fmt.Sprintf("%s:%d:%d", diagnostic.Location.Path, diagnostic.Location.Line, diagnostic.Location.Column)))
 		}
 		out.WriteString("\n  ")
-		out.WriteString(markdownText(diagnostic.Message))
+		out.WriteString(markdownText(annotationDiagnosticMessage(diagnostic)))
 		if diagnostic.Stage != "" {
 			out.WriteString(" · stage: ")
 			out.WriteString(markdownText(diagnostic.Stage))
@@ -135,9 +134,17 @@ func truncateProcessingAnnotation(body string) string {
 	return body[:end] + notice
 }
 
+func annotationDiagnosticMessage(diagnostic compatibility.Diagnostic) string {
+	if diagnostic.Location == nil {
+		return diagnostic.Message
+	}
+	prefix := fmt.Sprintf("%s:%d:%d: ", diagnostic.Location.Path, diagnostic.Location.Line, diagnostic.Location.Column)
+	return strings.TrimPrefix(diagnostic.Message, prefix)
+}
+
 func markdownText(value string) string {
 	value = strings.Join(strings.Fields(value), " ")
-	value = html.EscapeString(value)
+	value = strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;").Replace(value)
 	replacer := strings.NewReplacer(
 		"\\", "\\\\", "`", "\\`", "*", "\\*", "_", "\\_", "[", "\\[", "]", "\\]",
 		"<", "\\<", ">", "\\>", "#", "\\#", "|", "\\|",

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -1,22 +1,44 @@
 package cli
 
 import (
+	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
+	"html"
 	"io"
 	"os"
+	"strings"
+	"unicode/utf8"
 
 	"github.com/buildkite/buildkite-gha/internal/compatibility"
 	"github.com/buildkite/buildkite-gha/internal/compiler"
+	"github.com/buildkite/buildkite-gha/internal/transport"
+)
+
+const (
+	processingAnnotationContext   = "buildkite-gha-processing"
+	processingAnnotationBodyLimit = 1024 * 1024
 )
 
 // processingOutput owns where one command writes processing reports and
 // command diagnostics.
 type processingOutput struct {
-	command string
-	format  string
-	reports io.Writer
-	stderr  io.Writer
+	command       string
+	format        string
+	reports       io.Writer
+	stderr        io.Writer
+	annotationJob string
+	agent         transport.Agent
+}
+
+func newProcessingOutput(command, format string, reports, stderr io.Writer, agent transport.Agent) processingOutput {
+	out := processingOutput{command: command, format: format, reports: reports, stderr: stderr}
+	if os.Getenv("BUILDKITE") == "true" && os.Getenv("BUILDKITE_JOB_ID") != "" {
+		out.annotationJob = os.Getenv("BUILDKITE_JOB_ID")
+		out.agent = agent
+	}
+	return out
 }
 
 // write emits the report, reporting write failures on stderr.
@@ -25,7 +47,98 @@ func (o processingOutput) write(report compatibility.ProcessingReport) error {
 		_, _ = fmt.Fprintf(o.stderr, "buildkite-gha: %s: write report: %v\n", o.command, err)
 		return err
 	}
+	o.annotate(report)
 	return nil
+}
+
+func (o processingOutput) annotate(report compatibility.ProcessingReport) {
+	if o.annotationJob == "" {
+		return
+	}
+	style, body := processingAnnotation(report)
+	if body == "" {
+		return
+	}
+	digest := sha256.Sum256([]byte(report.Workflow))
+	annotationContext := fmt.Sprintf("%s-%x", processingAnnotationContext, digest[:6])
+	if err := o.agent.AnnotateJob(context.Background(), o.annotationJob, annotationContext, style, body); err != nil {
+		_, _ = fmt.Fprintf(o.stderr, "buildkite-gha: %s: warning: processing annotation: %v\n", o.command, err)
+	}
+}
+
+func processingAnnotation(report compatibility.ProcessingReport) (style, body string) {
+	style = "warning"
+	diagnostics := make([]compatibility.Diagnostic, 0, len(report.Diagnostics))
+	for _, diagnostic := range report.Diagnostics {
+		if diagnostic.Level != "warning" && diagnostic.Level != "error" {
+			continue
+		}
+		if diagnostic.Level == "error" {
+			style = "error"
+		}
+		diagnostics = append(diagnostics, diagnostic)
+	}
+	if len(diagnostics) == 0 {
+		return "", ""
+	}
+
+	var out strings.Builder
+	out.WriteString("### GitHub Actions workflow diagnostics\n\n")
+	out.WriteString("**Workflow:** ")
+	out.WriteString(markdownText(report.Workflow))
+	out.WriteString("\n")
+	for _, diagnostic := range diagnostics {
+		out.WriteString("\n- **")
+		out.WriteString(strings.ToUpper(diagnostic.Level))
+		out.WriteString(" ")
+		out.WriteString(markdownText(diagnostic.Code))
+		out.WriteString("**")
+		if diagnostic.Location != nil {
+			out.WriteString(" · ")
+			out.WriteString(markdownText(fmt.Sprintf("%s:%d:%d", diagnostic.Location.Path, diagnostic.Location.Line, diagnostic.Location.Column)))
+		}
+		out.WriteString("\n  ")
+		out.WriteString(markdownText(diagnostic.Message))
+		if diagnostic.Stage != "" {
+			out.WriteString(" · stage: ")
+			out.WriteString(markdownText(diagnostic.Stage))
+		}
+		if diagnostic.Job != "" {
+			out.WriteString(" · job: ")
+			out.WriteString(markdownText(diagnostic.Job))
+		}
+		if diagnostic.Action != "" {
+			out.WriteString(" · action: ")
+			out.WriteString(markdownText(diagnostic.Action))
+		}
+		if diagnostic.Step != 0 {
+			_, _ = fmt.Fprintf(&out, " · step: %d", diagnostic.Step)
+		}
+		out.WriteString("\n")
+	}
+	return style, truncateProcessingAnnotation(out.String())
+}
+
+func truncateProcessingAnnotation(body string) string {
+	if len(body) <= processingAnnotationBodyLimit {
+		return body
+	}
+	const notice = "\n\n_Additional diagnostics omitted at the Buildkite annotation size limit._\n"
+	end := processingAnnotationBodyLimit - len(notice)
+	for !utf8.ValidString(body[:end]) {
+		end--
+	}
+	return body[:end] + notice
+}
+
+func markdownText(value string) string {
+	value = strings.Join(strings.Fields(value), " ")
+	value = html.EscapeString(value)
+	replacer := strings.NewReplacer(
+		"\\", "\\\\", "`", "\\`", "*", "\\*", "_", "\\_", "[", "\\[", "]", "\\]",
+		"<", "\\<", ">", "\\>", "#", "\\#", "|", "\\|",
+	)
+	return replacer.Replace(value)
 }
 
 // fail emits the report and the failure that ended the command.

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -107,6 +107,10 @@ func processingAnnotation(report compatibility.ProcessingReport) (style, body st
 			out.WriteString(" · job: ")
 			out.WriteString(markdownText(diagnostic.Job))
 		}
+		if diagnostic.Instance != "" {
+			out.WriteString(" · instance: ")
+			out.WriteString(markdownText(diagnostic.Instance))
+		}
 		if diagnostic.Action != "" {
 			out.WriteString(" · action: ")
 			out.WriteString(markdownText(diagnostic.Action))


### PR DESCRIPTION
## Why

Unsupported workflow features currently fail the importer with diagnostics only in the job log, making the reason difficult to find from the Buildkite build view.

## What

Publish processing-report warnings and errors as job-scoped Buildkite annotations when `validate`, `compile`, or `upload` runs in Buildkite. Annotations use stable per-workflow contexts, escape workflow-controlled Markdown, respect Buildkite's size limit, and remain visibility-only when publication fails.

## Examples

An unsupported runner produces an error annotation:

> ### GitHub Actions workflow diagnostics
>
> **Workflow:** .github/workflows/ci.yml
>
> - **ERROR E_EXPRESSION_INVALID** · .github/workflows/ci.yml:3:3  
>   resolved runner target is not admitted by policy · stage: expression-validation · job: test · instance: gha-test

A compatibility warning does not fail the command:

> ### GitHub Actions workflow diagnostics
>
> **Workflow:** .github/workflows/ci.yml
>
> - **WARNING W_WORKFLOW_CONCURRENCY_CANCEL_IN_PROGRESS_IGNORED** · .github/workflows/ci.yml:4:23  
>   workflow concurrency cancel-in-progress is not enforced; Buildkite pipeline settings can approximate it for same-branch builds · stage: expression-validation

