### PR TITLE
Escape annotation text with one scheme

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2100,13 +2100,13 @@ func TestValidatePublishesProcessingDiagnosticsInBuildkite(t *testing.T) {
 func TestProcessingAnnotationIsBoundedAndEscapesMarkdown(t *testing.T) {
 	report := compatibility.NewProcessingReport("<workflow>|name", "")
 	report.Diagnostics = append(report.Diagnostics, compatibility.Diagnostic{
-		Level: "error", Code: "E_TEST", Message: "line one\n<script>*unsafe*</script> " + strings.Repeat("界", processingAnnotationBodyLimit),
+		Level: "error", Code: "E_TEST", Message: "line one\n<script>*unsafe*</script> runs-on target \"windows-latest\" for job's step " + strings.Repeat("界", processingAnnotationBodyLimit),
 	})
 	style, body := processingAnnotation(report)
 	if style != "error" || len(body) > processingAnnotationBodyLimit || !utf8.ValidString(body) {
 		t.Fatalf("style = %q, bytes = %d, valid UTF-8 = %v", style, len(body), utf8.ValidString(body))
 	}
-	for _, want := range []string{"&lt;workflow&gt;\\|name", "&lt;script&gt;\\*unsafe\\*&lt;/script&gt;", "Additional diagnostics omitted"} {
+	for _, want := range []string{"\\<workflow\\>\\|name", "\\<script\\>\\*unsafe\\*\\</script\\>", "Additional diagnostics omitted", "runs-on target \"windows-latest\" for job's step"} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("annotation lacks %q", want)
 		}

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
-	"html"
 	"io"
 	"os"
 	"strings"
@@ -137,10 +136,9 @@ func truncateProcessingAnnotation(body string) string {
 
 func markdownText(value string) string {
 	value = strings.Join(strings.Fields(value), " ")
-	value = html.EscapeString(value)
 	replacer := strings.NewReplacer(
 		"\\", "\\\\", "`", "\\`", "*", "\\*", "_", "\\_", "[", "\\[", "]", "\\]",
-		"<", "\\<", ">", "\\>", "#", "\\#", "|", "\\|",
+		"<", "\\<", ">", "\\>", "#", "\\#", "|", "\\|", "&", "\\&",
 	)
 	return replacer.Replace(value)
 }


### PR DESCRIPTION
Follow-up to #173.

`markdownText` applies two escaping schemes: `html.EscapeString`, then a markdown escaper that also escapes `#`. The `#` escape breaks the numeric entities `html.EscapeString` emits for `"` and `'`:

    in : runs-on target "windows-latest" is not admitted by policy
    out: runs-on target &\#34;windows-latest&\#34; is not admitted by policy

Rendered, the reader sees `&#34;windows-latest&#34;`. Compiler diagnostics quote values with `%q` throughout, so this affects most real annotations rather than an edge case.

This escapes markdown punctuation only, adding `&` so entity injection is still blocked. `<` and `>` were already in the replacer but unreachable while `html.EscapeString` ran first, so HTML tags stay neutralized.

The existing test asserted the double-escaped output and never covered `"` or `'`; it now covers both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)