### PR TITLE
Add nested GITHUB_TOKEN permissions oracle

### DIFF
--- a/.github/workflows/github-token-nesting-leaf.yml
+++ b/.github/workflows/github-token-nesting-leaf.yml
@@ -1,0 +1,30 @@
+name: Oracle - nested GITHUB_TOKEN leaf
+
+on:
+  workflow_call:
+    inputs:
+      label:
+        description: Branch label
+        required: true
+        type: string
+    outputs:
+      token-fingerprint:
+        description: SHA-256 fingerprint of this job's token
+        value: ${{ jobs.inspect.outputs.token-fingerprint }}
+
+jobs:
+  inspect:
+    name: ${{ inputs.label }} / inspect token
+    runs-on: ubuntu-latest
+    outputs:
+      token-fingerprint: ${{ steps.token.outputs.fingerprint }}
+    steps:
+      - name: Fingerprint token without exposing it
+        id: token
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          test -n "$GH_TOKEN"
+          fingerprint="$(printf '%s' "$GH_TOKEN" | sha256sum | cut -d ' ' -f 1)"
+          printf 'fingerprint=%s\n' "$fingerprint" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/github-token-nesting-middle.yml
+++ b/.github/workflows/github-token-nesting-middle.yml
@@ -1,0 +1,20 @@
+name: Oracle - nested GITHUB_TOKEN middle
+
+on:
+  workflow_call:
+    inputs:
+      label:
+        description: Branch label
+        required: true
+        type: string
+    outputs:
+      token-fingerprint:
+        description: SHA-256 fingerprint of the leaf job token
+        value: ${{ jobs.leaf.outputs.token-fingerprint }}
+
+jobs:
+  leaf:
+    name: ${{ inputs.label }} / nested call
+    uses: ./.github/workflows/github-token-nesting-leaf.yml
+    with:
+      label: ${{ inputs.label }}

--- a/.github/workflows/github-token-nesting-oracle.yml
+++ b/.github/workflows/github-token-nesting-oracle.yml
@@ -1,0 +1,51 @@
+name: Oracle - nested GITHUB_TOKEN scopes
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  contents:
+    name: Contents token
+    permissions:
+      contents: read
+    uses: ./.github/workflows/github-token-nesting-middle.yml
+    with:
+      label: contents
+
+  issues:
+    name: Issues token
+    permissions:
+      issues: read
+    uses: ./.github/workflows/github-token-nesting-middle.yml
+    with:
+      label: issues
+
+  verify:
+    name: Verify distinct job tokens
+    needs: [contents, issues]
+    permissions: {}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compare token fingerprints
+        shell: bash
+        env:
+          CONTENTS_FINGERPRINT: ${{ needs.contents.outputs.token-fingerprint }}
+          ISSUES_FINGERPRINT: ${{ needs.issues.outputs.token-fingerprint }}
+        run: |
+          test -n "$CONTENTS_FINGERPRINT"
+          test -n "$ISSUES_FINGERPRINT"
+          test "$CONTENTS_FINGERPRINT" != "$ISSUES_FINGERPRINT"
+          {
+            echo '## Nested `GITHUB_TOKEN` result'
+            echo
+            echo 'The nested jobs received distinct tokens.'
+            echo
+            echo '| Branch | Caller permission | Token fingerprint |'
+            echo '| --- | --- | --- |'
+            printf '| contents | `contents: read` | `%s…` |\n' "${CONTENTS_FINGERPRINT:0:12}"
+            printf '| issues | `issues: read` | `%s…` |\n' "${ISSUES_FINGERPRINT:0:12}"
+            echo
+            echo 'Open each nested job and inspect **Set up job → GITHUB_TOKEN Permissions** to see its effective scope.'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/github-token-nesting-oracle.yml
+++ b/.github/workflows/github-token-nesting-oracle.yml
@@ -1,6 +1,7 @@
 name: Oracle - nested GITHUB_TOKEN scopes
 
 on:
+  pull_request:
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
## Why

Clarify how GitHub scopes and issues `GITHUB_TOKEN` values for jobs expanded through nested reusable workflows, as discussed in #160.

## What

Add a manually dispatched oracle with two nested reusable-workflow chains. The caller grants each chain a different permission, and a final job compares SHA-256 token fingerprints without exposing either token. GitHub's job setup logs show the effective permissions for each leaf job.
