### PR TITLE
Fix unused testFileLock and testExec lint findings

### DIFF
--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -17,6 +17,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -94,6 +95,18 @@ func envPointer(name string) *string {
 		return &v
 	}
 	return nil
+}
+
+func testFileLock(file *os.File, lock bool) error {
+	operation := syscall.LOCK_UN
+	if lock {
+		operation = syscall.LOCK_EX
+	}
+	return syscall.Flock(int(file.Fd()), operation)
+}
+
+func testExec(path string, args, env []string) error {
+	return syscall.Exec(path, args, env)
 }
 
 func TestJobContainerFakeDockerProcess(t *testing.T) {

--- a/internal/runtime/test_platform_unix_test.go
+++ b/internal/runtime/test_platform_unix_test.go
@@ -4,21 +4,8 @@ package runtime
 
 import (
 	"errors"
-	"os"
 	"syscall"
 )
-
-func testFileLock(file *os.File, lock bool) error {
-	operation := syscall.LOCK_UN
-	if lock {
-		operation = syscall.LOCK_EX
-	}
-	return syscall.Flock(int(file.Fd()), operation)
-}
-
-func testExec(path string, args, env []string) error {
-	return syscall.Exec(path, args, env)
-}
 
 func testProcessExists(pid int) bool {
 	return !errors.Is(syscall.Kill(pid, 0), syscall.ESRCH)


### PR DESCRIPTION
## Summary

`make lint` failed on darwin with two `unused` findings in
`test_platform_unix_test.go`: `testFileLock` and `testExec`.

## Root cause

Both helpers are called only from `containers_test.go`, which is
build-tagged `linux && amd64`. `test_platform_unix_test.go` tags them
`linux || darwin`, a broader set. On darwin (and linux/arm64), the
caller is excluded from the build, so the two symbols become dead
code and `unused` flags them.

## Fix

This is the "used only under another build tag" case. Moved
`testFileLock` and `testExec` into `containers_test.go`, whose build
tag already matches where they're actually used. No deletion, no
`nolint`, no config changes.

## Verified

- `make lint` — 0 issues (was 2 unused findings)
- `go build ./...` — passes
- `go test ./internal/runtime/...` — passes
- `GOOS=linux GOARCH=amd64 go vet ./internal/runtime/...` — passes (compile-checks the moved code under its real target tag)
- `GOOS=windows go build ./...` — passes
- `GOOS=darwin go build ./...` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)