### PR TITLE
Prove macOS support with the released runtime

### DIFF
--- a/.buildkite/plugin-demo.yml
+++ b/.buildkite/plugin-demo.yml
@@ -37,7 +37,7 @@ steps:
     plugins:
       - github-actions#v0.9.3:
           workflow: .github/workflows/macos-actions-proof.yml
-          source-ref: "$DEMO_COMMIT"
+          version: "0.11.1"
           runners:
             - runs-on: macos-14
               queue: mac-small
@@ -59,7 +59,7 @@ steps:
       - "plugin-demo-actions-importer"
       - "plugin-demo-macos-importer"
       - "plugin-demo-advanced-importer"
-    command: "echo 'The released plugin completed all service-free workflows. Linux used the released CLI; macOS used the CLI source from DEMO_COMMIT.'"
+    command: "echo 'The released plugin and CLI completed all service-free workflows.'"
 
   - label: ":package: Cache released-plugin demo"
     key: "plugin-demo-cache-importer"

--- a/docs/development.md
+++ b/docs/development.md
@@ -74,7 +74,7 @@ scripts/verify-artifact-roundtrip <build-number> <commit>
 
 ## Test released and native entry points
 
-Run the examples through the released plugin. Linux uses its default mise-based public release resolution. The native macOS proof temporarily builds the CLI runtime from `DEMO_COMMIT` through the plugin's `source-ref` option until the Darwin cache fix is released:
+Run the examples through the released plugin. Linux uses its default mise-based public release resolution. The native macOS proof pins the released Darwin runtime:
 
 ```sh
 commit=$(git rev-parse HEAD)
@@ -83,7 +83,7 @@ bk build create --pipeline buildkite/buildkite-gha \
   --env DEMO_SUITE=plugin --env DEMO_COMMIT="$commit" --yes
 ```
 
-Add `--env DEMO_CACHE=1` to include the optional cache producer and consumer workflow. For Linux workflows, mise must download and verify the public CLI release; they must not fall back to a local binary.
+Add `--env DEMO_CACHE=1` to include the optional cache producer and consumer workflow. Every workflow must use a public CLI release; the demo must not fall back to a source build or local binary.
 
 For a side-by-side GitHub Actions and Buildkite UX check, run:
 

--- a/testdata/plugin-demo/README.md
+++ b/testdata/plugin-demo/README.md
@@ -2,7 +2,6 @@
 
 `.buildkite/plugin-demo.yml` runs the repository's example workflows through
 the released `github-actions` plugin. The service-free examples run by default
-and normally resolve the released CLI. The native macOS arm64 proof runs the
-selected source commit until its runtime changes ship in a release. It covers
-shell, JavaScript, and composite steps. Set `DEMO_CACHE=1` to include the
-optional cache extension in `.github/workflows/cache.yml`.
+and resolve the released CLI. The native macOS arm64 proof pins its released
+runtime and covers shell, JavaScript, and composite steps. Set `DEMO_CACHE=1`
+to include the optional cache extension in `.github/workflows/cache.yml`.


### PR DESCRIPTION
## Why

`v0.11.1` includes the portable Darwin runtime cache from #172, but the macOS plugin demo still builds the runtime from branch source. That does not prove the released path users receive.

## What

Pin the native macOS proof to the released `v0.11.1` runtime, remove the `source-ref` override, and update the demo documentation to describe the released path.

Closes #129.
