### PR TITLE
Use dedicated GitHub action source tokens

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -511,7 +511,7 @@ Matrices, runner labels, names, concurrency groups, and event-backed conditions 
 | Dockerfile action | 🟡 Supported subset | Verified local or public Dockerfile action on Linux. Rejected on macOS, including through a composite action. |
 | `docker://` action | ❌ Unsupported | Rejected during validation. |
 
-Mutable public refs are resolved during upload, then locked to a commit. Exact lowercase commit SHAs need no GitHub API lookup. Complete source trees are verified again at runtime.
+Mutable public refs are resolved during upload, then locked to a commit. The importer lazily requests one Buildkite action-source token and reuses it across all workflow roots and nested composite actions. This token authenticates only public metadata requests for repositories other than the credential repository; the credential repository and codeload requests remain anonymous. If token issuance is unavailable during rollout, resolution safely falls back to anonymous GitHub API access. Exact lowercase commit SHAs need no GitHub API lookup. Complete source trees are verified again at runtime.
 
 Nested calls from a repository-local composite must be local. Public composites may call local children or other public actions; every child is resolved and locked. Dockerfile actions cannot request credentials, volumes, arbitrary options, or privileged mode.
 

--- a/internal/action/source/source.go
+++ b/internal/action/source/source.go
@@ -110,7 +110,7 @@ type config struct {
 	api                                 *url.URL
 	codeload                            *url.URL
 	finalHosts                          map[string]bool
-	credential                          *scopedCredential
+	credential                          *actionSourceCredential
 	maxCompressed, maxExpanded, maxFile int64
 	maxEntries                          int
 	maxPath, maxSegment                 int
@@ -126,16 +126,16 @@ func defaults() config {
 // never be populated from workflow input.
 type Option func(*config) error
 
-// WithScopedGitHubTokenProvider authenticates mutable-ref API requests using a
+// WithGitHubActionSourceTokenProvider authenticates mutable-ref API requests using a
 // credential provisioned at the first such request and cached for this client.
 // Returning an empty token selects anonymous resolution. Full lowercase SHAs
 // never invoke the provider.
-func WithScopedGitHubTokenProvider(repository string, provider func(context.Context) (string, error)) Option {
+func WithGitHubActionSourceTokenProvider(repository string, provider func(context.Context) (string, error)) Option {
 	return func(c *config) error {
 		if provider == nil || !validRepository(repository) {
-			return fmt.Errorf("invalid scoped GitHub credential provider")
+			return fmt.Errorf("invalid GitHub action source credential provider")
 		}
-		c.credential = &scopedCredential{repository: strings.ToLower(repository), provider: provider}
+		c.credential = &actionSourceCredential{repository: strings.ToLower(repository), provider: provider}
 		return nil
 	}
 }
@@ -145,7 +145,7 @@ func validRepository(repository string) bool {
 	return len(parts) == 2 && ownerRE.MatchString(parts[0]) && repoRE.MatchString(parts[1]) && !strings.HasSuffix(parts[1], ".git")
 }
 
-type scopedCredential struct {
+type actionSourceCredential struct {
 	repository string
 	provider   func(context.Context) (string, error)
 	once       sync.Once
@@ -153,7 +153,7 @@ type scopedCredential struct {
 	err        error
 }
 
-func (c *scopedCredential) provision(ctx context.Context) error {
+func (c *actionSourceCredential) provision(ctx context.Context) error {
 	if c == nil || c.provider == nil {
 		return nil
 	}
@@ -323,7 +323,7 @@ func githubAPIGet(ctx context.Context, client *http.Client, cfg config, parts []
 	if err != nil {
 		return err
 	}
-	setAPIHeaders(req, scopedToken(cfg, parts))
+	setAPIHeaders(req, actionSourceToken(cfg, parts))
 	c := *client
 	c.Jar = nil
 	c.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
@@ -370,7 +370,7 @@ func ensurePublic(ctx context.Context, client *http.Client, cfg config, ref Refe
 	}
 	return nil
 }
-func scopedToken(cfg config, parts []string) string {
+func actionSourceToken(cfg config, parts []string) string {
 	if cfg.credential == nil {
 		return ""
 	}

--- a/internal/action/source/source_test.go
+++ b/internal/action/source/source_test.go
@@ -102,7 +102,7 @@ func TestResolverOptionalAuthenticationAndVisibility(t *testing.T) {
 			defer ts.Close()
 			opts := []Option{WithTestEndpoints(ts.URL)}
 			if tt.token != "" {
-				opts = append(opts, WithScopedGitHubTokenProvider(tt.tokenRepository, func(context.Context) (string, error) {
+				opts = append(opts, WithGitHubActionSourceTokenProvider(tt.tokenRepository, func(context.Context) (string, error) {
 					return tt.token, nil
 				}))
 			}
@@ -148,7 +148,7 @@ func TestResolverFullSHADirectAndRefEncoding(t *testing.T) {
 			defer ts.Close()
 			opts := []Option{WithTestEndpoints(ts.URL)}
 			if tt.authenticated {
-				opts = append(opts, WithScopedGitHubTokenProvider("pipeline/repo", func(context.Context) (string, error) {
+				opts = append(opts, WithGitHubActionSourceTokenProvider("pipeline/repo", func(context.Context) (string, error) {
 					provisions++
 					return "test-token", nil
 				}))
@@ -639,7 +639,7 @@ func TestStoreExactCommitDownloadsDirectlyFromCodeloadWithoutCredentials(t *test
 	defer apiServer.Close()
 	ref, _ := Parse("o/r@v1")
 	resolved := Resolved{Reference: ref, Commit: testSHA}
-	store, err := NewStore(t.TempDir(), apiServer.Client(), WithTestEndpoints(apiServer.URL, archiveServer.URL), WithScopedGitHubTokenProvider("pipeline/repo", func(context.Context) (string, error) {
+	store, err := NewStore(t.TempDir(), apiServer.Client(), WithTestEndpoints(apiServer.URL, archiveServer.URL), WithGitHubActionSourceTokenProvider("pipeline/repo", func(context.Context) (string, error) {
 		tokenProvisions++
 		return token, nil
 	}))
@@ -672,7 +672,7 @@ func TestStoreCodeloadRedirectPolicy(t *testing.T) {
 			_, _ = w.Write(archive)
 		}))
 		defer server.Close()
-		store, err := NewStore(t.TempDir(), server.Client(), WithTestEndpoints(server.URL, server.URL), WithScopedGitHubTokenProvider("pipeline/repo", func(context.Context) (string, error) {
+		store, err := NewStore(t.TempDir(), server.Client(), WithTestEndpoints(server.URL, server.URL), WithGitHubActionSourceTokenProvider("pipeline/repo", func(context.Context) (string, error) {
 			return "test-token", nil
 		}))
 		if err != nil {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -25,6 +25,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -1535,7 +1536,7 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 	for platform, runtimeDistribution := range runtimeDistributions {
 		runtimeDigests[platform] = runtimeDistribution.digest
 	}
-	authentication := jobScopedActionSourceAuthentication(stderr)
+	authentication := importerJobActionSourceAuthentication(stderr)
 	generatedWorkflows := make([]buildkitepipeline.Workflow, 0, len(workflows))
 	planArtifacts := make([]compiler.PlanArtifact, 0)
 	jobCount := 0
@@ -1935,12 +1936,15 @@ func hostedError(kind hostedFailureKind, err error) error {
 }
 
 type actionSourceAuthentication struct {
-	provider gharuntime.ScopedTokenProvider
-	redactor gharuntime.Redactor
-	warnings io.Writer
+	provider   gharuntime.ActionSourceTokenProvider
+	redactor   gharuntime.Redactor
+	warnings   io.Writer
+	once       sync.Once
+	credential string
+	err        error
 }
 
-func jobScopedActionSourceAuthentication(warnings io.Writer) *actionSourceAuthentication {
+func importerJobActionSourceAuthentication(warnings io.Writer) *actionSourceAuthentication {
 	authentication := &actionSourceAuthentication{
 		redactor: gharuntime.AgentRedactor{Executable: os.Getenv("BUILDKITE_GHA_AGENT")},
 		warnings: warnings,
@@ -1961,7 +1965,7 @@ func (a *actionSourceAuthentication) option(repository string) actionsource.Opti
 	if a == nil {
 		return nil
 	}
-	return actionsource.WithScopedGitHubTokenProvider(repository, func(ctx context.Context) (string, error) {
+	return actionsource.WithGitHubActionSourceTokenProvider(repository, func(ctx context.Context) (string, error) {
 		return a.token(ctx, repository)
 	})
 }
@@ -1970,11 +1974,18 @@ func (a *actionSourceAuthentication) token(ctx context.Context, repository strin
 	if err := ctx.Err(); err != nil {
 		return "", err
 	}
+	a.once.Do(func() {
+		a.credential, a.err = a.provision(ctx, repository)
+	})
+	return a.credential, a.err
+}
+
+func (a *actionSourceAuthentication) provision(ctx context.Context, repository string) (string, error) {
 	if a.provider == nil {
-		a.warnAnonymousFallback("job-scoped GitHub source authentication is unavailable")
+		a.warnAnonymousFallback("GitHub action source authentication is unavailable")
 		return "", nil
 	}
-	token, err := a.provider.ScopedToken(ctx, repository, map[string]string{"contents": "read"})
+	token, err := a.provider.ActionSourceToken(ctx, repository)
 	if err != nil {
 		if ctx.Err() != nil {
 			return "", ctx.Err()
@@ -1982,7 +1993,7 @@ func (a *actionSourceAuthentication) token(ctx context.Context, repository strin
 		if errors.Is(err, context.Canceled) {
 			return "", err
 		}
-		a.warnAnonymousFallback("could not mint a job-scoped GitHub source token")
+		a.warnAnonymousFallback("could not mint a GitHub action source token")
 		return "", nil
 	}
 	if err := a.redactor.AddRedaction(ctx, token); err != nil {
@@ -1992,7 +2003,7 @@ func (a *actionSourceAuthentication) token(ctx context.Context, repository strin
 		if errors.Is(err, context.Canceled) {
 			return "", err
 		}
-		a.warnAnonymousFallback("could not register the job-scoped GitHub source token with the Buildkite Agent redactor")
+		a.warnAnonymousFallback("could not register the GitHub action source token with the Buildkite Agent redactor")
 		return "", nil
 	}
 	return token, nil

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -20,6 +20,7 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"unicode/utf8"
 
@@ -3513,9 +3514,9 @@ func TestRunUploadRejectsAllReusableExplicitPaths(t *testing.T) {
 	}
 }
 
-func TestActionSourceAuthenticationUsesJobScopedTokenAndFallsBackAnonymously(t *testing.T) {
-	const token = "ghs_job_scoped"
-	provider := &cliWorkflowTokenProvider{token: token}
+func TestActionSourceAuthenticationUsesDedicatedTokenAndFallsBackAnonymously(t *testing.T) {
+	const token = "ghs_action_source"
+	provider := &cliActionSourceTokenProvider{token: token}
 	redactor := &cliRedactor{}
 	authentication := &actionSourceAuthentication{provider: provider, redactor: redactor}
 	option := authentication.option("buildkite/buildkite-gha")
@@ -3551,7 +3552,7 @@ func TestActionSourceAuthenticationUsesJobScopedTokenAndFallsBackAnonymously(t *
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := resolver.Resolve(context.Background(), ref); err != nil || requests != 2 || provider.calls != 1 || provider.repository != "buildkite/buildkite-gha" || !reflect.DeepEqual(provider.permissions, map[string]string{"contents": "read"}) || !slices.Equal(redactor.values, []string{token}) {
+	if _, err := resolver.Resolve(context.Background(), ref); err != nil || requests != 2 || provider.calls != 1 || provider.repository != "buildkite/buildkite-gha" || !slices.Equal(redactor.values, []string{token}) {
 		t.Fatalf("Resolve() error/requests = %v / %d", err, requests)
 	}
 	second, _ := actionsource.Parse("o/r@v2")
@@ -3561,19 +3562,19 @@ func TestActionSourceAuthenticationUsesJobScopedTokenAndFallsBackAnonymously(t *
 
 	for _, test := range []struct {
 		name          string
-		provider      *cliWorkflowTokenProvider
+		provider      *cliActionSourceTokenProvider
 		redactor      *cliRedactor
 		cancelContext bool
 		wantContext   bool
 	}{
 		{name: "unavailable", redactor: &cliRedactor{}},
-		{name: "mint failure", provider: &cliWorkflowTokenProvider{err: errors.New("secret backend details")}, redactor: &cliRedactor{}},
-		{name: "redaction failure", provider: &cliWorkflowTokenProvider{token: token}, redactor: &cliRedactor{err: errors.New("secret backend details")}},
-		{name: "mint client timeout", provider: &cliWorkflowTokenProvider{err: context.DeadlineExceeded}, redactor: &cliRedactor{}},
-		{name: "redaction client timeout", provider: &cliWorkflowTokenProvider{token: token}, redactor: &cliRedactor{err: context.DeadlineExceeded}},
+		{name: "mint failure", provider: &cliActionSourceTokenProvider{err: errors.New("secret backend details")}, redactor: &cliRedactor{}},
+		{name: "redaction failure", provider: &cliActionSourceTokenProvider{token: token}, redactor: &cliRedactor{err: errors.New("secret backend details")}},
+		{name: "mint client timeout", provider: &cliActionSourceTokenProvider{err: context.DeadlineExceeded}, redactor: &cliRedactor{}},
+		{name: "redaction client timeout", provider: &cliActionSourceTokenProvider{token: token}, redactor: &cliRedactor{err: context.DeadlineExceeded}},
 		{name: "pre-cancelled while unavailable", redactor: &cliRedactor{}, cancelContext: true, wantContext: true},
-		{name: "mint cancellation", provider: &cliWorkflowTokenProvider{err: context.Canceled}, redactor: &cliRedactor{}, wantContext: true},
-		{name: "redaction cancellation", provider: &cliWorkflowTokenProvider{token: token}, redactor: &cliRedactor{err: context.Canceled}, wantContext: true},
+		{name: "mint cancellation", provider: &cliActionSourceTokenProvider{err: context.Canceled}, redactor: &cliRedactor{}, wantContext: true},
+		{name: "redaction cancellation", provider: &cliActionSourceTokenProvider{token: token}, redactor: &cliRedactor{err: context.Canceled}, wantContext: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			var warnings bytes.Buffer
@@ -3601,6 +3602,56 @@ func TestActionSourceAuthenticationUsesJobScopedTokenAndFallsBackAnonymously(t *
 	}
 }
 
+func TestActionSourceAuthenticationReusesOneTokenAcrossConcurrentWorkflowResolvers(t *testing.T) {
+	const token = "ghs_action_source"
+	provider := &cliActionSourceTokenProvider{token: token}
+	redactor := &cliRedactor{}
+	authentication := &actionSourceAuthentication{provider: provider, redactor: redactor}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/o/r" {
+			_, _ = io.WriteString(w, `{"private":false,"visibility":"public"}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"object":{"type":"commit","sha":"0123456789abcdef0123456789abcdef01234567"}}`)
+	}))
+	defer server.Close()
+
+	const resolverCount = 11
+	resolvers := make([]*actionsource.Resolver, resolverCount)
+	for i := range resolvers {
+		resolver, err := actionsource.NewResolver(server.Client(), authentication.option("buildkite/buildkite-gha"), actionsource.WithTestEndpoints(server.URL))
+		if err != nil {
+			t.Fatal(err)
+		}
+		resolvers[i] = resolver
+	}
+	ref, err := actionsource.Parse("o/r@v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var wg sync.WaitGroup
+	errs := make(chan error, resolverCount)
+	for _, resolver := range resolvers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := resolver.Resolve(context.Background(), ref)
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if provider.calls != 1 || !slices.Equal(redactor.values, []string{token}) {
+		t.Fatalf("provider calls/redactions = %d / %#v, want one importer-job mint and redaction", provider.calls, redactor.values)
+	}
+}
+
 func TestHostedLocalActionDoesNotProvisionSourceToken(t *testing.T) {
 	root := t.TempDir()
 	workflowPath := filepath.Join(root, ".github", "workflows", "local.yml")
@@ -3622,7 +3673,7 @@ func TestHostedLocalActionDoesNotProvisionSourceToken(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	provider := &cliWorkflowTokenProvider{token: "must-not-be-minted"}
+	provider := &cliActionSourceTokenProvider{token: "must-not-be-minted"}
 	redactor := &cliRedactor{}
 	var warnings bytes.Buffer
 	authentication := &actionSourceAuthentication{provider: provider, redactor: redactor, warnings: &warnings}
@@ -3668,7 +3719,7 @@ func TestJobScopedActionSourceAuthenticationIgnoresAmbientGitHubTokens(t *testin
 	t.Setenv("BUILDKITE_JOB_ID", "")
 	t.Setenv("BUILDKITE_AGENT_ACCESS_TOKEN", "")
 	var warnings bytes.Buffer
-	authentication := jobScopedActionSourceAuthentication(&warnings)
+	authentication := importerJobActionSourceAuthentication(&warnings)
 	token, err := authentication.token(context.Background(), "buildkite/buildkite-gha")
 	if err != nil || token != "" || authentication.provider != nil || !strings.Contains(warnings.String(), "authentication is unavailable") {
 		t.Fatalf("ambient GitHub token authentication = provider %v, token %q, error %v, warnings %q", authentication.provider != nil, token, err, warnings.String())
@@ -3679,7 +3730,7 @@ func TestJobScopedActionSourceAuthenticationIgnoresAmbientGitHubTokens(t *testin
 	t.Setenv("BUILDKITE_AGENT_ENDPOINT", server.URL)
 	t.Setenv("BUILDKITE_JOB_ID", cliTestJobID)
 	t.Setenv("BUILDKITE_AGENT_ACCESS_TOKEN", "job-token")
-	if authentication := jobScopedActionSourceAuthentication(io.Discard); authentication.provider == nil {
+	if authentication := importerJobActionSourceAuthentication(io.Discard); authentication.provider == nil {
 		t.Fatal("job-scoped Agent configuration did not configure action-source authentication")
 	}
 }
@@ -4969,27 +5020,31 @@ type cliCaptureRunner struct {
 	contextErrors  []error
 }
 
-type cliWorkflowTokenProvider struct {
-	token       string
-	err         error
-	repository  string
-	permissions map[string]string
-	calls       int
+type cliActionSourceTokenProvider struct {
+	mu         sync.Mutex
+	token      string
+	err        error
+	repository string
+	calls      int
 }
 
-func (p *cliWorkflowTokenProvider) ScopedToken(_ context.Context, repository string, permissions map[string]string) (string, error) {
+func (p *cliActionSourceTokenProvider) ActionSourceToken(_ context.Context, repository string) (string, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.calls++
 	p.repository = repository
-	p.permissions = permissions
 	return p.token, p.err
 }
 
 type cliRedactor struct {
+	mu     sync.Mutex
 	values []string
 	err    error
 }
 
 func (r *cliRedactor) AddRedaction(_ context.Context, value string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.values = append(r.values, value)
 	return r.err
 }

--- a/internal/runtime/actions_test.go
+++ b/internal/runtime/actions_test.go
@@ -251,7 +251,7 @@ func TestActionLockResolverDownloadsExactCommitDirectlyFromCodeload(t *testing.T
 		_, _ = w.Write(archive)
 	}))
 	defer codeloadServer.Close()
-	store, err := source.NewStore(t.TempDir(), codeloadServer.Client(), source.WithTestEndpoints(apiServer.URL, codeloadServer.URL), source.WithScopedGitHubTokenProvider("pipeline/repo", func(context.Context) (string, error) {
+	store, err := source.NewStore(t.TempDir(), codeloadServer.Client(), source.WithTestEndpoints(apiServer.URL, codeloadServer.URL), source.WithGitHubActionSourceTokenProvider("pipeline/repo", func(context.Context) (string, error) {
 		tokenProvisions++
 		return token, nil
 	}))

--- a/internal/runtime/github_token_service.go
+++ b/internal/runtime/github_token_service.go
@@ -27,10 +27,10 @@ type WorkflowTokenProvider interface {
 	WorkflowToken(context.Context, string, string, map[string]string) (string, error)
 }
 
-// ScopedTokenProvider mints a repository-scoped credential without selecting
-// the workflow-policy authority.
-type ScopedTokenProvider interface {
-	ScopedToken(context.Context, string, map[string]string) (string, error)
+// ActionSourceTokenProvider mints a credential for resolving public GitHub
+// action sources.
+type ActionSourceTokenProvider interface {
+	ActionSourceToken(context.Context, string) (string, error)
 }
 
 // AgentGitHubTokenConfig carries the current Buildkite job's Agent connection
@@ -46,14 +46,14 @@ type AgentGitHubTokenConfig struct {
 // AgentGitHubTokens mints repository-scoped tokens through Buildkite's
 // job-bound Agent API endpoint.
 type AgentGitHubTokens struct {
-	scopedURL   string
-	workflowURL string
-	jobToken    string
-	client      *http.Client
+	actionSourceURL string
+	workflowURL     string
+	jobToken        string
+	client          *http.Client
 }
 
 func NewAgentGitHubTokens(config AgentGitHubTokenConfig) (*AgentGitHubTokens, error) {
-	scopedURL, err := agentGitHubTokenURL(config.Endpoint, config.JobID, "github_scoped_access_token")
+	actionSourceURL, err := agentGitHubTokenURL(config.Endpoint, config.JobID, "github_action_source_access_token")
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func NewAgentGitHubTokens(config AgentGitHubTokenConfig) (*AgentGitHubTokens, er
 	if bounded.Timeout == 0 {
 		bounded.Timeout = 15 * time.Second
 	}
-	return &AgentGitHubTokens{scopedURL: scopedURL, workflowURL: workflowURL, jobToken: config.JobToken, client: &bounded}, nil
+	return &AgentGitHubTokens{actionSourceURL: actionSourceURL, workflowURL: workflowURL, jobToken: config.JobToken, client: &bounded}, nil
 }
 
 func (c *AgentGitHubTokens) WorkflowToken(ctx context.Context, repository, workflow string, permissions map[string]string) (string, error) {
@@ -90,14 +90,11 @@ func (c *AgentGitHubTokens) WorkflowToken(ctx context.Context, repository, workf
 	return c.mint(ctx, c.workflowURL, repository, workflow, permissions, "workflow")
 }
 
-func (c *AgentGitHubTokens) ScopedToken(ctx context.Context, repository string, permissions map[string]string) (string, error) {
+func (c *AgentGitHubTokens) ActionSourceToken(ctx context.Context, repository string) (string, error) {
 	if c == nil {
-		return "", fmt.Errorf("GitHub scoped token provider is not configured")
+		return "", fmt.Errorf("GitHub action source token provider is not configured")
 	}
-	if !validScopedTokenPermissions(permissions) {
-		return "", fmt.Errorf("GitHub scoped token requires valid permissions")
-	}
-	return c.mint(ctx, c.scopedURL, repository, "", permissions, "scoped")
+	return c.mint(ctx, c.actionSourceURL, repository, "", nil, "action source")
 }
 
 func (c *AgentGitHubTokens) mint(ctx context.Context, mintURL, repository, workflow string, permissions map[string]string, purpose string) (string, error) {
@@ -110,7 +107,7 @@ func (c *AgentGitHubTokens) mint(ctx context.Context, mintURL, repository, workf
 	body, err := json.Marshal(struct {
 		RepositoryURL string            `json:"repo_url"`
 		Workflow      string            `json:"workflow,omitempty"`
-		Permissions   map[string]string `json:"permissions"`
+		Permissions   map[string]string `json:"permissions,omitempty"`
 	}{
 		RepositoryURL: "https://github.com/" + repository,
 		Workflow:      workflow,
@@ -159,27 +156,6 @@ func (c *AgentGitHubTokens) mint(ctx context.Context, mintURL, repository, workf
 	return decoded.Token, nil
 }
 
-func validScopedTokenPermissions(permissions map[string]string) bool {
-	if len(permissions) == 0 || len(permissions) > 15 {
-		return false
-	}
-	for name, access := range permissions {
-		switch name {
-		case "actions", "artifact_metadata", "attestations", "checks", "contents", "deployments", "discussions", "issues", "packages", "pages", "pull_requests", "repository_projects", "security_events", "statuses":
-			if access != "read" && access != "write" {
-				return false
-			}
-		case "models":
-			if access != "read" {
-				return false
-			}
-		default:
-			return false
-		}
-	}
-	return true
-}
-
 func agentGitHubTokenURL(endpoint, jobID, endpointName string) (string, error) {
 	if !validBuildkiteJobID(jobID) {
 		return "", fmt.Errorf("GitHub token Agent job ID is required")
@@ -204,7 +180,7 @@ func githubTokenStatusError(status int, retryAfter, purpose string) error {
 		if purpose == "workflow" {
 			return fmt.Errorf("GitHub workflow access tokens are not enabled for this organization or pipeline")
 		}
-		return fmt.Errorf("GitHub scoped access tokens are not enabled for this organization")
+		return fmt.Errorf("GitHub action source access tokens are not enabled for this organization")
 	case http.StatusServiceUnavailable:
 		retryAfter = strings.TrimSpace(retryAfter)
 		if retryAfterSecondsPattern.MatchString(retryAfter) {

--- a/internal/runtime/github_token_service_test.go
+++ b/internal/runtime/github_token_service_test.go
@@ -53,27 +53,30 @@ func TestAgentGitHubTokensMintsExactWorkflowPermissions(t *testing.T) {
 	}
 }
 
-func TestAgentGitHubTokensMintsScopedSourceTokenWithoutWorkflow(t *testing.T) {
+func TestAgentGitHubTokensMintsActionSourceTokenWithRepositoryOnly(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/jobs/"+testCacheJobID+"/github_scoped_access_token" {
+		if r.URL.Path != "/jobs/"+testCacheJobID+"/github_action_source_access_token" {
 			t.Errorf("path = %q", r.URL.Path)
+		}
+		if r.Method != http.MethodPost || r.Header.Get("Authorization") != "Token job-secret" || r.Header.Get("Accept") != "application/json" || r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("request = %s headers %#v", r.Method, r.Header)
 		}
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if string(body) != `{"repo_url":"https://github.com/actions/checkout","permissions":{"contents":"read"}}` {
+		if string(body) != `{"repo_url":"https://github.com/actions/checkout"}` {
 			t.Errorf("request body = %s", body)
 		}
-		_, _ = io.WriteString(w, `{"token":"ghs_scoped"}`)
+		_, _ = io.WriteString(w, `{"token":"ghs_action_source"}`)
 	}))
 	defer server.Close()
 	provider, err := NewAgentGitHubTokens(AgentGitHubTokenConfig{Endpoint: server.URL, JobID: testCacheJobID, JobToken: "job-secret"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if token, err := provider.ScopedToken(context.Background(), "actions/checkout", map[string]string{"contents": "read"}); err != nil || token != "ghs_scoped" {
-		t.Fatalf("ScopedToken() = %q, %v", token, err)
+	if token, err := provider.ActionSourceToken(context.Background(), "actions/checkout"); err != nil || token != "ghs_action_source" {
+		t.Fatalf("ActionSourceToken() = %q, %v", token, err)
 	}
 }
 
@@ -139,6 +142,9 @@ func TestAgentGitHubTokensRejectsUnsafeConfigurationAndRepository(t *testing.T) 
 	for _, repository := range []string{"", "other", "../other/repo", "owner/..", "owner/repo/extra", "owner/repo?permission=write"} {
 		if _, err := provider.WorkflowToken(context.Background(), repository, "ci.yml", map[string]string{"contents": "read"}); err == nil {
 			t.Fatalf("WorkflowToken(%q) succeeded", repository)
+		}
+		if _, err := provider.ActionSourceToken(context.Background(), repository); err == nil {
+			t.Fatalf("ActionSourceToken(%q) succeeded", repository)
 		}
 	}
 }
@@ -231,7 +237,7 @@ func TestAgentGitHubTokensAuthenticateUnrelatedPublicRepository(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	token, err := provider.ScopedToken(ctx, "buildkite/buildkite-gha", map[string]string{"contents": "read"})
+	token, err := provider.ActionSourceToken(ctx, "buildkite/buildkite-gha")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/runtime/github_token_service_test.go
+++ b/internal/runtime/github_token_service_test.go
@@ -239,6 +239,9 @@ func TestAgentGitHubTokensAuthenticateUnrelatedPublicRepository(t *testing.T) {
 	}
 	token, err := provider.ActionSourceToken(ctx, "buildkite/buildkite-gha")
 	if err != nil {
+		if strings.Contains(err.Error(), "not enabled") || strings.Contains(err.Error(), "temporarily unavailable") {
+			t.Skipf("GitHub action source token rollout is unavailable: %v", err)
+		}
 		t.Fatal(err)
 	}
 	if err := (AgentRedactor{Executable: os.Getenv("BUILDKITE_GHA_AGENT")}).AddRedaction(ctx, token); err != nil {


### PR DESCRIPTION
## Why

Buildkite's dedicated GitHub action-source token API replaces the generic scoped-token endpoint and limits issuance to 10 attempts per importer job per hour. Per-resolver minting can exceed that budget when one upload compiles many workflow roots.

## What

- Use the repository-only `github_action_source_access_token` endpoint without caller-supplied permissions or an old-endpoint fallback.
- Lazily mint and redact one token per importer job, then reuse it across workflow roots and nested composite action resolution.
- Keep disabled or unavailable rollout states on the safe anonymous path while preserving public-only visibility checks, anonymous codeload, digest verification, and exact-SHA bypasses.
