### PR TITLE
Improve compatibility diagnostics

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1243,7 +1243,7 @@ func validate(args []string, stdout, stderr io.Writer, version string, agent tra
 		if preflight.HasActions {
 			processingReport.Diagnostics = append(processingReport.Diagnostics, compatibility.Diagnostic{
 				Level: "warning", Code: "W_ACTION_RUNTIME_UNKNOWN", Category: "compatibility", Stage: string(compiler.StageAdmission),
-				Message: "resolved action metadata cannot prove that arbitrary action code is independent of GitHub-only runtime services",
+				Message: "Third-party action runtime behavior was not validated. The action source, metadata, declared runtime, entrypoints, inputs, and nested actions were validated, but the action code was not executed and may depend on GitHub-only services. No action is required for admission; test the action on Buildkite if runtime compatibility is important.",
 			})
 		}
 		processingReport.Result = "admitted"
@@ -2108,15 +2108,18 @@ func validateUnprivilegedBundle(bundle compiler.Bundle) error {
 		for _, capability := range artifact.Job.RequiredCapabilities {
 			if capability == "docker" && !slices.Equal(artifact.Authorization.DockerCapabilitySources, []string{"dockerfile-actions"}) {
 				if slices.Contains(artifact.Authorization.DockerCapabilitySources, "job-containers") || slices.Contains(artifact.Authorization.DockerCapabilitySources, "service-containers") {
-					addFailure(artifact, "job or service containers are not admitted by the hosted profile", fmt.Errorf("job %q uses job or service containers, which hosted upload does not admit", artifact.Job.Workflow.LogicalJobID))
+					message := hostedContainerDiagnostic(artifact.Job)
+					addFailure(artifact, message, errors.New("hosted container unsupported"))
 					continue
 				}
-				addFailure(artifact, "docker capability lacks compiler-verified action provenance", fmt.Errorf("job %q requires docker without compiler-verified Dockerfile action provenance", artifact.Job.Workflow.LogicalJobID))
+				message := "Docker is unsupported for this job; hosted production allows Docker only for resolved Dockerfile actions"
+				addFailure(artifact, message, errors.New("unsupported Docker access"))
 				continue
 			}
 			if capability == "provider-token-read" {
 				if !slices.Equal(artifact.Authorization.ProviderTokenReadCapabilitySources, []string{"checkout-adapter"}) {
-					addFailure(artifact, "provider token read capability lacks compiler-verified checkout provenance", fmt.Errorf("job %q requires provider-token-read without compiler-verified checkout provenance", artifact.Job.Workflow.LogicalJobID))
+					message := "GitHub checkout credentials are unsupported for this job; use the managed actions/checkout integration"
+					addFailure(artifact, message, errors.New("unsupported GitHub checkout credentials"))
 				}
 				continue
 			}
@@ -2125,14 +2128,19 @@ func validateUnprivilegedBundle(bundle compiler.Bundle) error {
 				if artifact.Job.GitHubToken == nil || !slices.Equal(artifact.Authorization.ProviderTokenWriteCapabilitySources, []string{"effective-permissions"}) || filenameErr != nil || artifact.Authorization.WorkflowTokenPolicyFilename == "" || artifact.Authorization.WorkflowTokenPolicyFilename != filename {
 					reason := bundle.IR.Workflow.WorkflowTokenPolicyDiagnostic
 					if reason == "" {
-						reason = "compiler-verified workflow policy evidence is missing or does not match the job plan"
+						reason = "the workflow token request does not match the compiled job"
 					}
-					addFailure(artifact, "provider token write capability lacks compiler-verified workflow policy", fmt.Errorf("job %q requires provider-token-write without a compiler-verified workflow policy: %s", artifact.Job.Workflow.LogicalJobID, reason))
+					message := githubTokenAdmissionDiagnostic(artifact, reason)
+					addFailure(artifact, message, errors.New("hosted GITHUB_TOKEN unsupported"))
 				}
 				continue
 			}
 			if capability != "network" && capability != "docker" {
-				addFailure(artifact, fmt.Sprintf("capability %q is unavailable to the hosted profile", capability), fmt.Errorf("job %q requires capability %q, unavailable to unprivileged upload", artifact.Job.Workflow.LogicalJobID, capability))
+				message := fmt.Sprintf("Job %q uses unsupported hosted runtime requirement %q", artifact.Job.Workflow.LogicalJobID, capability)
+				if capability == "secrets" {
+					message = fmt.Sprintf("Job %q uses GitHub Actions secrets, which hosted production does not provide", artifact.Job.Workflow.LogicalJobID)
+				}
+				addFailure(artifact, message, errors.New(message))
 			}
 		}
 		for _, action := range artifact.Job.Actions {
@@ -2149,6 +2157,80 @@ func validateUnprivilegedBundle(bundle compiler.Bundle) error {
 		}
 	}
 	return errors.Join(diagnostics...)
+}
+
+func githubTokenAdmissionDiagnostic(artifact compiler.PlanArtifact, reason string) string {
+	limitation := reason
+	fix := "Use a supported workflow-level permissions map or remove the GITHUB_TOKEN dependency."
+	switch {
+	case strings.Contains(reason, "job-level permissions"):
+		limitation = "job-level permissions are unsupported for hosted GITHUB_TOKEN issuance"
+		fix = "Move the permissions map to the workflow top level."
+	case strings.Contains(reason, "reusable-workflow jobs"):
+		limitation = "workflows containing reusable-workflow jobs cannot receive a hosted GITHUB_TOKEN"
+		fix = "Inline the reusable job or remove the GITHUB_TOKEN dependency; runner configuration cannot enable this shape."
+	case strings.Contains(reason, "directly under .github/workflows"):
+		limitation = "hosted GITHUB_TOKEN issuance requires the workflow directly under .github/workflows"
+		fix = "Move the workflow directly under .github/workflows."
+	case strings.Contains(reason, "unsupported permission"):
+		limitation = reason
+		fix = "Remove the unsupported permission or avoid requiring GITHUB_TOKEN."
+	case strings.Contains(reason, "explicit non-empty"):
+		limitation = "an explicit empty or all-none top-level permissions map cannot issue GITHUB_TOKEN"
+		fix = "Declare the required permissions at the workflow top level."
+	}
+
+	var causes []string
+	if artifact.Authorization.GitHubTokenSecretReference {
+		causes = append(causes, "the workflow references secrets.GITHUB_TOKEN")
+	}
+	if len(artifact.Authorization.GitHubTokenActions) != 0 {
+		quoted := make([]string, len(artifact.Authorization.GitHubTokenActions))
+		for i, action := range artifact.Authorization.GitHubTokenActions {
+			quoted[i] = fmt.Sprintf("%q", action)
+		}
+		actionLabel := "action"
+		if len(quoted) > 1 {
+			actionLabel = "actions"
+		}
+		causes = append(causes, actionLabel+" "+strings.Join(quoted, ", ")+" defaults an input to github.token")
+	}
+	if len(causes) == 0 {
+		causes = append(causes, "the compiled job requests a workflow token")
+	}
+	permissions := "none"
+	if artifact.Job.GitHubToken != nil && len(artifact.Job.GitHubToken.Permissions) != 0 {
+		names := make([]string, 0, len(artifact.Job.GitHubToken.Permissions))
+		for name := range artifact.Job.GitHubToken.Permissions {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		values := make([]string, 0, len(names))
+		for _, name := range names {
+			values = append(values, strings.ReplaceAll(name, "_", "-")+": "+artifact.Job.GitHubToken.Permissions[name])
+		}
+		permissions = strings.Join(values, ", ")
+	}
+	return fmt.Sprintf("Job %q needs GITHUB_TOKEN, but %s. Cause: %s. Effective permissions: %s. %s", artifact.Job.Workflow.LogicalJobID, limitation, strings.Join(causes, "; "), permissions, fix)
+}
+
+func hostedContainerDiagnostic(job plan.Job) string {
+	var constructs []string
+	if job.Container != nil {
+		constructs = append(constructs, fmt.Sprintf("job container %q", job.Container.Image))
+	}
+	serviceNames := make([]string, 0, len(job.Services))
+	for name := range job.Services {
+		serviceNames = append(serviceNames, name)
+	}
+	sort.Strings(serviceNames)
+	for _, name := range serviceNames {
+		constructs = append(constructs, fmt.Sprintf("service container %q (image %q)", name, job.Services[name].Image))
+	}
+	if len(constructs) == 0 {
+		constructs = append(constructs, "a job or service container")
+	}
+	return fmt.Sprintf("Job %q uses %s. The compiler supports this construct, but hosted production does not run job or service containers. Replace the container with ordinary steps or an externally reachable service; runner configuration cannot enable containers in the hosted profile.", job.Workflow.LogicalJobID, strings.Join(constructs, " and "))
 }
 
 func irUsesActions(ir compiler.IR) bool {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -818,7 +818,7 @@ func TestRunValidateAndCompile(t *testing.T) {
 		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 			t.Fatal(err)
 		}
-		if report.Result != "incompatible" || report.Compile.Result != "incompatible" || len(report.Diagnostics) != 1 || report.Diagnostics[0].Message != "resolved runner target is not admitted by policy: runner label is not mapped by policy" {
+		if report.Result != "incompatible" || report.Compile.Result != "incompatible" || len(report.Diagnostics) != 1 || !strings.Contains(report.Diagnostics[0].Message, `Runner label "macos-15" is not mapped`) {
 			t.Fatalf("macOS profile report = %#v", report)
 		}
 	})
@@ -1414,7 +1414,7 @@ runs:
 		t.Fatalf("actions = %#v, want both missing invocations failed", report.Actions)
 	}
 	for _, diagnostic := range report.Diagnostics {
-		if diagnostic.Instance == "" || diagnostic.Step == 0 || diagnostic.Code != compiler.CodeActionResolution || diagnostic.Message != "action could not be resolved or validated" {
+		if diagnostic.Instance == "" || diagnostic.Step == 0 || diagnostic.Code != compiler.CodeActionResolution || !strings.Contains(diagnostic.Message, `Action "`) || !strings.Contains(diagnostic.Message, "unsupported") {
 			t.Fatalf("diagnostic lacks invocation identity: %#v", diagnostic)
 		}
 	}
@@ -1692,7 +1692,7 @@ func TestProcessingReportRedactsEventDerivedRunnerValues(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 		t.Fatal(err)
 	}
-	if len(report.Diagnostics) != 1 || report.Diagnostics[0].Message != "resolved runner target is not admitted by policy: runner label is not mapped by policy" {
+	if len(report.Diagnostics) != 1 || strings.Contains(report.Diagnostics[0].Message, sentinel) || report.Diagnostics[0].Message != "Runner label is not mapped to a runner target; configure a runner-target mapping for this label or use ubuntu-22.04, ubuntu-24.04, ubuntu-latest" {
 		t.Fatalf("diagnostics = %#v", report.Diagnostics)
 	}
 }
@@ -2084,7 +2084,7 @@ func TestValidatePublishesProcessingDiagnosticsInBuildkite(t *testing.T) {
 		if len(annotation.args) != 9 || annotation.args[0] != "annotate" || annotation.args[2] != "job" || annotation.args[4] != cliTestJobID || !strings.HasPrefix(annotation.args[6], processingAnnotationContext+"-") || annotation.args[8] != "error" {
 			t.Fatalf("annotation args = %#v", annotation.args)
 		}
-		for _, want := range []string{"GitHub Actions workflow diagnostics", "E\\_EXPRESSION\\_INVALID", "resolved runner target is not admitted by policy", "job: test", "instance: gha-test"} {
+		for _, want := range []string{"GitHub Actions workflow diagnostics", "E\\_EXPRESSION\\_INVALID", `Runner label "windows-latest" uses an unsupported operating system`, "job: test", "instance: gha-test"} {
 			if !strings.Contains(string(annotation.stdin), want) {
 				t.Fatalf("annotation = %q, want %q", annotation.stdin, want)
 			}
@@ -2144,6 +2144,38 @@ func TestProcessingAnnotationDoesNotRepeatDiagnosticLocation(t *testing.T) {
 	}
 	if !strings.Contains(body, "warning message") {
 		t.Fatalf("annotation = %q", body)
+	}
+}
+
+func TestProcessingDiagnosticRenderingsUseTheSameMessageAndAggregation(t *testing.T) {
+	const message = `Job "test" needs GITHUB_TOKEN, but job-level permissions are unsupported. Effective permissions: contents: read.`
+	report := compatibility.NewProcessingReport("ci.yml", "hosted")
+	for _, instance := range []string{"gha-test-a", "gha-test-b"} {
+		report.Diagnostics = append(report.Diagnostics, compatibility.Diagnostic{
+			Level: "error", Code: "E_PROFILE", Stage: string(compiler.StageAdmission),
+			Message: message, Job: "test", Instance: instance,
+		})
+	}
+
+	var jsonOutput bytes.Buffer
+	if err := compatibility.WriteProcessing(&jsonOutput, "json", report); err != nil {
+		t.Fatal(err)
+	}
+	var decoded compatibility.ProcessingReport
+	if err := json.Unmarshal(jsonOutput.Bytes(), &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded.Diagnostics) != 1 || decoded.Diagnostics[0].Message != message || decoded.Diagnostics[0].Instance != "" {
+		t.Fatalf("JSON diagnostics = %#v", decoded.Diagnostics)
+	}
+
+	var textOutput bytes.Buffer
+	if err := compatibility.WriteProcessing(&textOutput, "text", report); err != nil {
+		t.Fatal(err)
+	}
+	_, annotation := processingAnnotation(report)
+	if strings.Count(textOutput.String(), message) != 1 || strings.Count(annotation, markdownText(message)) != 1 {
+		t.Fatalf("text = %q; annotation = %q", textOutput.String(), annotation)
 	}
 }
 
@@ -2324,7 +2356,7 @@ func TestValidateHostedProfileRejectsProtectedCapabilityAfterCompile(t *testing.
 	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 		t.Fatal(err)
 	}
-	if report.Result != "not-admitted" || report.Compile.Result != "compilable" || report.Admission.Result != "not-admitted" || len(report.Diagnostics) != 1 || report.Diagnostics[0].Code != "E_PROFILE" || !strings.Contains(report.Diagnostics[0].Message, `capability "secrets"`) {
+	if report.Result != "not-admitted" || report.Compile.Result != "compilable" || report.Admission.Result != "not-admitted" || len(report.Diagnostics) != 1 || report.Diagnostics[0].Code != "E_PROFILE" || !strings.Contains(report.Diagnostics[0].Message, "uses GitHub Actions secrets") {
 		t.Fatalf("profile report = %#v", report)
 	}
 }
@@ -4733,7 +4765,12 @@ func TestUnprivilegedUploadRejectsCapabilities(t *testing.T) {
 			Workflow:             plan.Workflow{LogicalJobID: "protected"},
 			RequiredCapabilities: []string{capability},
 		}}}}
-		if err := validateUnprivilegedBundle(bundle); err == nil || !strings.Contains(err.Error(), capability) {
+		err := validateUnprivilegedBundle(bundle)
+		want := capability
+		if capability == "provider-token-write" {
+			want = "GITHUB_TOKEN"
+		}
+		if err == nil || !strings.Contains(err.Error(), want) {
 			t.Fatalf("validateUnprivilegedBundle(%q) error = %v, want capability rejection", capability, err)
 		}
 	}
@@ -4756,7 +4793,7 @@ func TestUnprivilegedUploadAdmitsOnlyCompilerVerifiedCheckoutCredentials(t *test
 		t.Run(test.name, func(t *testing.T) {
 			bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: job, Authorization: test.authorization}}}
 			err := validateUnprivilegedBundle(bundle)
-			if test.wantError && (err == nil || !strings.Contains(err.Error(), "checkout provenance")) {
+			if test.wantError && (err == nil || !strings.Contains(err.Error(), "unsupported GitHub checkout credentials")) {
 				t.Fatalf("validateUnprivilegedBundle() error = %v", err)
 			}
 			if !test.wantError && err != nil {
@@ -4786,13 +4823,38 @@ func TestUnprivilegedUploadAdmitsOnlyCompilerVerifiedWorkflowToken(t *testing.T)
 		t.Run(test.name, func(t *testing.T) {
 			bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: job, Authorization: test.authorization}}}
 			err := validateUnprivilegedBundle(bundle)
-			if test.wantError && (err == nil || !strings.Contains(err.Error(), "workflow policy")) {
+			if test.wantError && (err == nil || !strings.Contains(err.Error(), "GITHUB_TOKEN")) {
 				t.Fatalf("validateUnprivilegedBundle() error = %v", err)
 			}
 			if !test.wantError && err != nil {
 				t.Fatalf("validateUnprivilegedBundle() error = %v", err)
 			}
 		})
+	}
+}
+
+func TestGitHubTokenAdmissionDiagnosticExplainsCausePermissionsAndFix(t *testing.T) {
+	artifact := compiler.PlanArtifact{
+		Job: plan.Job{
+			Workflow:    plan.Workflow{LogicalJobID: "build"},
+			GitHubToken: &plan.GitHubToken{Permissions: map[string]string{"contents": "read", "pull_requests": "write"}},
+		},
+		Authorization: compiler.PlanAuthorization{GitHubTokenActions: []string{"owner/action@v1"}},
+	}
+	want := `Job "build" needs GITHUB_TOKEN, but job-level permissions are unsupported for hosted GITHUB_TOKEN issuance. Cause: action "owner/action@v1" defaults an input to github.token. Effective permissions: contents: read, pull-requests: write. Move the permissions map to the workflow top level.`
+	if got := githubTokenAdmissionDiagnostic(artifact, "GitHub workflow access tokens do not support job-level permissions"); got != want {
+		t.Fatalf("githubTokenAdmissionDiagnostic() = %q, want %q", got, want)
+	}
+}
+
+func TestHostedContainerDiagnosticNamesServiceAndBoundary(t *testing.T) {
+	job := plan.Job{
+		Workflow: plan.Workflow{LogicalJobID: "test"},
+		Services: map[string]plan.Container{"postgres": {Image: "postgres:11-alpine"}},
+	}
+	want := `Job "test" uses service container "postgres" (image "postgres:11-alpine"). The compiler supports this construct, but hosted production does not run job or service containers. Replace the container with ordinary steps or an externally reachable service; runner configuration cannot enable containers in the hosted profile.`
+	if got := hostedContainerDiagnostic(job); got != want {
+		t.Fatalf("hostedContainerDiagnostic() = %q, want %q", got, want)
 	}
 }
 
@@ -4814,7 +4876,7 @@ func TestUnprivilegedUploadRejectsDockerWithoutCompilerProvenance(t *testing.T) 
 		Workflow:             plan.Workflow{LogicalJobID: "unproven-docker"},
 		RequiredCapabilities: []string{"docker"},
 	}}}}
-	if err := validateUnprivilegedBundle(bundle); err == nil || !strings.Contains(err.Error(), "without compiler-verified Dockerfile action provenance") {
+	if err := validateUnprivilegedBundle(bundle); err == nil || !strings.Contains(err.Error(), "unsupported Docker access") {
 		t.Fatalf("validateUnprivilegedBundle() error = %v, want Docker provenance rejection", err)
 	}
 }
@@ -4828,7 +4890,7 @@ func TestUnprivilegedUploadRejectsContainerProvenance(t *testing.T) {
 		bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: plan.Job{
 			Workflow: plan.Workflow{LogicalJobID: "container-job"}, RequiredCapabilities: []string{"docker", "network"},
 		}, Authorization: compiler.PlanAuthorization{DockerCapabilitySources: sources}}}}
-		if err := validateUnprivilegedBundle(bundle); err == nil || !strings.Contains(err.Error(), "hosted upload does not admit") {
+		if err := validateUnprivilegedBundle(bundle); err == nil || !strings.Contains(err.Error(), "hosted container unsupported") {
 			t.Fatalf("validateUnprivilegedBundle(%v) error = %v", sources, err)
 		}
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2084,9 +2084,14 @@ func TestValidatePublishesProcessingDiagnosticsInBuildkite(t *testing.T) {
 		if len(annotation.args) != 9 || annotation.args[0] != "annotate" || annotation.args[2] != "job" || annotation.args[4] != cliTestJobID || !strings.HasPrefix(annotation.args[6], processingAnnotationContext+"-") || annotation.args[8] != "error" {
 			t.Fatalf("annotation args = %#v", annotation.args)
 		}
-		for _, want := range []string{"GitHub Actions workflow diagnostics", "E\\_EXPRESSION\\_INVALID", `Runner label "windows-latest" uses an unsupported operating system`, "job: test", "instance: gha-test"} {
+		for _, want := range []string{"GitHub Actions workflow diagnostics", "#### Unsupported runner", "`E_EXPRESSION_INVALID`", `Runner label "windows-latest" uses an unsupported operating system`, "Job `test`"} {
 			if !strings.Contains(string(annotation.stdin), want) {
 				t.Fatalf("annotation = %q, want %q", annotation.stdin, want)
+			}
+		}
+		for _, unwanted := range []string{"stage:", "instance:", "gha-test"} {
+			if strings.Contains(string(annotation.stdin), unwanted) {
+				t.Fatalf("annotation = %q, does not want %q", annotation.stdin, unwanted)
 			}
 		}
 		var report compatibility.ProcessingReport
@@ -2147,6 +2152,75 @@ func TestProcessingAnnotationDoesNotRepeatDiagnosticLocation(t *testing.T) {
 	}
 }
 
+func TestProcessingAnnotationPresentsActionFailureAsAConciseCard(t *testing.T) {
+	report := compatibility.NewProcessingReport("ci.yml", "hosted")
+	report.Diagnostics = append(report.Diagnostics, compatibility.Diagnostic{
+		Level: "error", Code: "E_ACTION_UNSUPPORTED", Stage: string(compiler.StageResolution),
+		Message: `Action "actions/setup-java@v4" is unsupported: action metadata uses unsupported field "deprecationMessage"`,
+		Job:     "test", Instance: "gha-test-a1b2", Action: "actions/setup-java@v4", Step: 2,
+	})
+
+	_, body := processingAnnotation(report)
+	for _, want := range []string{
+		"#### Unsupported action: **actions/setup-java@v4**",
+		"`E_ACTION_UNSUPPORTED` · Job `test` · Step 2",
+		`Action metadata uses unsupported field "deprecationMessage"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("annotation = %q, want %q", body, want)
+		}
+	}
+	if count := strings.Count(body, "actions/setup-java@v4"); count != 1 {
+		t.Fatalf("action count = %d, want 1: %q", count, body)
+	}
+	for _, unwanted := range []string{"stage:", "instance:", "gha-test-a1b2"} {
+		if strings.Contains(body, unwanted) {
+			t.Fatalf("annotation = %q, does not want %q", body, unwanted)
+		}
+	}
+}
+
+func TestProcessingAnnotationUsesUserFacingDiagnosticHeadings(t *testing.T) {
+	tests := []struct {
+		name       string
+		diagnostic compatibility.Diagnostic
+		want       string
+	}{
+		{
+			name: "action resolution",
+			diagnostic: compatibility.Diagnostic{Action: "owner/action@v1",
+				Message: `Action "owner/action@v1" could not be resolved: tag v1 was not found`},
+			want: "Action could not be resolved: **owner/action@v1**",
+		},
+		{
+			name: "token configuration",
+			diagnostic: compatibility.Diagnostic{Code: "E_PROFILE",
+				Message: `Job "test" needs GITHUB_TOKEN, but job-level permissions are unsupported.`},
+			want: "Unsupported GITHUB_TOKEN configuration",
+		},
+		{
+			name: "hosted container",
+			diagnostic: compatibility.Diagnostic{Code: "E_PROFILE",
+				Message: `Job "test" uses service container "postgres". The compiler supports this construct, but hosted production does not run job or service containers.`},
+			want: "Unsupported hosted container",
+		},
+		{
+			name: "third-party runtime warning",
+			diagnostic: compatibility.Diagnostic{Level: "warning", Code: "W_ACTION_RUNTIME_UNKNOWN",
+				Message: "Third-party action runtime behavior was not validated."},
+			want: "Third-party action runtime compatibility",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			heading, _ := annotationDiagnosticPresentation(test.diagnostic)
+			if heading != test.want {
+				t.Fatalf("heading = %q, want %q", heading, test.want)
+			}
+		})
+	}
+}
+
 func TestProcessingDiagnosticRenderingsUseTheSameMessageAndAggregation(t *testing.T) {
 	const message = `Job "test" needs GITHUB_TOKEN, but job-level permissions are unsupported. Effective permissions: contents: read.`
 	report := compatibility.NewProcessingReport("ci.yml", "hosted")
@@ -2174,8 +2248,13 @@ func TestProcessingDiagnosticRenderingsUseTheSameMessageAndAggregation(t *testin
 		t.Fatal(err)
 	}
 	_, annotation := processingAnnotation(report)
-	if strings.Count(textOutput.String(), message) != 1 || strings.Count(annotation, markdownText(message)) != 1 {
+	if strings.Count(textOutput.String(), message) != 1 ||
+		strings.Count(annotation, `Job "test" needs GITHUB\_TOKEN, but job-level permissions are unsupported.`) != 1 ||
+		strings.Count(annotation, `Effective permissions: contents: read.`) != 1 {
 		t.Fatalf("text = %q; annotation = %q", textOutput.String(), annotation)
+	}
+	if strings.Contains(annotation, "gha-test-") {
+		t.Fatalf("annotation exposes matrix instance IDs: %q", annotation)
 	}
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2152,6 +2152,12 @@ func TestProcessingAnnotationDoesNotRepeatDiagnosticLocation(t *testing.T) {
 	}
 }
 
+func TestMarkdownCodeContainsWorkflowBackticks(t *testing.T) {
+	if got, want := markdownCode("action` **not bold** ``tail"), "``` action` **not bold** ``tail ```"; got != want {
+		t.Fatalf("markdownCode() = %q, want %q", got, want)
+	}
+}
+
 func TestProcessingAnnotationPresentsActionFailureAsAConciseCard(t *testing.T) {
 	report := compatibility.NewProcessingReport("ci.yml", "hosted")
 	report.Diagnostics = append(report.Diagnostics, compatibility.Diagnostic{

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2084,12 +2084,12 @@ func TestValidatePublishesProcessingDiagnosticsInBuildkite(t *testing.T) {
 		if len(annotation.args) != 9 || annotation.args[0] != "annotate" || annotation.args[2] != "job" || annotation.args[4] != cliTestJobID || !strings.HasPrefix(annotation.args[6], processingAnnotationContext+"-") || annotation.args[8] != "error" {
 			t.Fatalf("annotation args = %#v", annotation.args)
 		}
-		for _, want := range []string{"GitHub Actions workflow diagnostics", "#### Unsupported runner", "`E_EXPRESSION_INVALID`", `Runner label "windows-latest" uses an unsupported operating system`, "Job `test`"} {
+		for _, want := range []string{"GitHub Actions workflow diagnostics", `#### Runner label "windows-latest" uses an unsupported operating system`, "Job `test`"} {
 			if !strings.Contains(string(annotation.stdin), want) {
 				t.Fatalf("annotation = %q, want %q", annotation.stdin, want)
 			}
 		}
-		for _, unwanted := range []string{"stage:", "instance:", "gha-test"} {
+		for _, unwanted := range []string{"E_EXPRESSION_INVALID", "stage:", "instance:", "gha-test"} {
 			if strings.Contains(string(annotation.stdin), unwanted) {
 				t.Fatalf("annotation = %q, does not want %q", annotation.stdin, unwanted)
 			}
@@ -2162,9 +2162,8 @@ func TestProcessingAnnotationPresentsActionFailureAsAConciseCard(t *testing.T) {
 
 	_, body := processingAnnotation(report)
 	for _, want := range []string{
-		"#### Unsupported action: **actions/setup-java@v4**",
-		"`E_ACTION_UNSUPPORTED` · Job `test` · Step 2",
-		`Action metadata uses unsupported field "deprecationMessage"`,
+		`#### Action metadata uses unsupported field "deprecationMessage"`,
+		"Action `actions/setup-java@v4` · Job `test` · Step 2",
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("annotation = %q, want %q", body, want)
@@ -2173,14 +2172,14 @@ func TestProcessingAnnotationPresentsActionFailureAsAConciseCard(t *testing.T) {
 	if count := strings.Count(body, "actions/setup-java@v4"); count != 1 {
 		t.Fatalf("action count = %d, want 1: %q", count, body)
 	}
-	for _, unwanted := range []string{"stage:", "instance:", "gha-test-a1b2"} {
+	for _, unwanted := range []string{"E_ACTION_UNSUPPORTED", "stage:", "instance:", "gha-test-a1b2"} {
 		if strings.Contains(body, unwanted) {
 			t.Fatalf("annotation = %q, does not want %q", body, unwanted)
 		}
 	}
 }
 
-func TestProcessingAnnotationUsesUserFacingDiagnosticHeadings(t *testing.T) {
+func TestProcessingAnnotationLeadsWithTheActionableDiagnostic(t *testing.T) {
 	tests := []struct {
 		name       string
 		diagnostic compatibility.Diagnostic
@@ -2190,25 +2189,25 @@ func TestProcessingAnnotationUsesUserFacingDiagnosticHeadings(t *testing.T) {
 			name: "action resolution",
 			diagnostic: compatibility.Diagnostic{Action: "owner/action@v1",
 				Message: `Action "owner/action@v1" could not be resolved: tag v1 was not found`},
-			want: "Action could not be resolved: **owner/action@v1**",
+			want: "Tag v1 was not found",
 		},
 		{
 			name: "token configuration",
 			diagnostic: compatibility.Diagnostic{Code: "E_PROFILE",
 				Message: `Job "test" needs GITHUB_TOKEN, but job-level permissions are unsupported.`},
-			want: "Unsupported GITHUB_TOKEN configuration",
+			want: `Job "test" needs GITHUB\_TOKEN, but job-level permissions are unsupported.`,
 		},
 		{
 			name: "hosted container",
 			diagnostic: compatibility.Diagnostic{Code: "E_PROFILE",
 				Message: `Job "test" uses service container "postgres". The compiler supports this construct, but hosted production does not run job or service containers.`},
-			want: "Unsupported hosted container",
+			want: `Job "test" uses service container "postgres".`,
 		},
 		{
 			name: "third-party runtime warning",
 			diagnostic: compatibility.Diagnostic{Level: "warning", Code: "W_ACTION_RUNTIME_UNKNOWN",
 				Message: "Third-party action runtime behavior was not validated."},
-			want: "Third-party action runtime compatibility",
+			want: "Third-party action runtime behavior was not validated.",
 		},
 	}
 	for _, test := range tests {

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -66,6 +66,7 @@ func (o processingOutput) annotate(report compatibility.ProcessingReport) {
 }
 
 func processingAnnotation(report compatibility.ProcessingReport) (style, body string) {
+	report.Finalize()
 	style = "warning"
 	diagnostics := make([]compatibility.Diagnostic, 0, len(report.Diagnostics))
 	for _, diagnostic := range report.Diagnostics {

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -181,7 +181,20 @@ func upperFirst(value string) string {
 
 func markdownCode(value string) string {
 	value = strings.Join(strings.Fields(value), " ")
-	value = strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;", "`", "\\`").Replace(value)
+	value = strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;").Replace(value)
+	if strings.Contains(value, "`") {
+		longest, current := 0, 0
+		for _, r := range value {
+			if r == '`' {
+				current++
+				longest = max(longest, current)
+			} else {
+				current = 0
+			}
+		}
+		delimiter := strings.Repeat("`", longest+1)
+		return delimiter + " " + value + " " + delimiter
+	}
 	return "`" + value + "`"
 }
 

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -89,24 +89,30 @@ func processingAnnotation(report compatibility.ProcessingReport) (style, body st
 	out.WriteString(markdownText(report.Workflow))
 	out.WriteString("\n")
 	for _, diagnostic := range diagnostics {
-		heading, message := annotationDiagnosticPresentation(diagnostic)
+		heading, details := annotationDiagnosticPresentation(diagnostic)
 		out.WriteString("\n#### ")
 		out.WriteString(heading)
-		out.WriteString("\n\n")
-		out.WriteString(markdownCode(diagnostic.Code))
+		context := make([]string, 0, 4)
+		if diagnostic.Action != "" {
+			context = append(context, "Action "+markdownCode(diagnostic.Action))
+		}
 		if diagnostic.Location != nil {
-			out.WriteString(" · ")
-			out.WriteString(markdownCode(fmt.Sprintf("%s:%d:%d", diagnostic.Location.Path, diagnostic.Location.Line, diagnostic.Location.Column)))
+			context = append(context, markdownCode(fmt.Sprintf("%s:%d:%d", diagnostic.Location.Path, diagnostic.Location.Line, diagnostic.Location.Column)))
 		}
 		if diagnostic.Job != "" {
-			out.WriteString(" · Job ")
-			out.WriteString(markdownCode(diagnostic.Job))
+			context = append(context, "Job "+markdownCode(diagnostic.Job))
 		}
 		if diagnostic.Step != 0 {
-			_, _ = fmt.Fprintf(&out, " · Step %d", diagnostic.Step)
+			context = append(context, fmt.Sprintf("Step %d", diagnostic.Step))
 		}
-		out.WriteString("\n\n")
-		for i, sentence := range annotationSentences(message) {
+		if len(context) != 0 {
+			out.WriteString("\n\n")
+			out.WriteString(strings.Join(context, " · "))
+		}
+		if len(details) != 0 {
+			out.WriteString("\n\n")
+		}
+		for i, sentence := range details {
 			if i != 0 {
 				out.WriteString("  \n")
 			}
@@ -137,39 +143,24 @@ func annotationDiagnosticMessage(diagnostic compatibility.Diagnostic) string {
 	return strings.TrimPrefix(diagnostic.Message, prefix)
 }
 
-func annotationDiagnosticPresentation(diagnostic compatibility.Diagnostic) (heading, message string) {
-	message = annotationDiagnosticMessage(diagnostic)
+func annotationDiagnosticPresentation(diagnostic compatibility.Diagnostic) (heading string, details []string) {
+	message := annotationDiagnosticMessage(diagnostic)
 	if diagnostic.Action != "" {
-		for _, presentation := range []struct {
-			prefix  string
-			heading string
-		}{
-			{fmt.Sprintf("Action %q is unsupported: ", diagnostic.Action), "Unsupported action"},
-			{fmt.Sprintf("Action %q could not be resolved: ", diagnostic.Action), "Action could not be resolved"},
+		for _, prefix := range []string{
+			fmt.Sprintf("Action %q is unsupported: ", diagnostic.Action),
+			fmt.Sprintf("Action %q could not be resolved: ", diagnostic.Action),
 		} {
-			if strings.HasPrefix(message, presentation.prefix) {
-				return presentation.heading + ": **" + markdownText(diagnostic.Action) + "**", upperFirst(strings.TrimPrefix(message, presentation.prefix))
+			if strings.HasPrefix(message, prefix) {
+				message = upperFirst(strings.TrimPrefix(message, prefix))
+				break
 			}
 		}
-		return "Action compatibility: **" + markdownText(diagnostic.Action) + "**", message
 	}
-	switch {
-	case strings.HasPrefix(message, "Runner label"):
-		heading = "Unsupported runner"
-	case strings.Contains(message, "job or service containers"):
-		heading = "Unsupported hosted container"
-	case strings.Contains(message, "needs GITHUB_TOKEN"):
-		heading = "Unsupported GITHUB_TOKEN configuration"
-	case diagnostic.Code == "W_ACTION_RUNTIME_UNKNOWN":
-		heading = "Third-party action runtime compatibility"
-	case diagnostic.Stage == string(compiler.StageAdmission):
-		heading = "Hosted profile incompatibility"
-	case diagnostic.Level == "warning":
-		heading = "Compatibility warning"
-	default:
-		heading = "Workflow incompatibility"
+	sentences := annotationSentences(message)
+	if len(sentences) == 0 {
+		return "Compatibility diagnostic", nil
 	}
-	return heading, message
+	return markdownText(sentences[0]), sentences[1:]
 }
 
 func annotationSentences(message string) []string {

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/buildkite/buildkite-gha/internal/compatibility"
@@ -88,35 +89,28 @@ func processingAnnotation(report compatibility.ProcessingReport) (style, body st
 	out.WriteString(markdownText(report.Workflow))
 	out.WriteString("\n")
 	for _, diagnostic := range diagnostics {
-		out.WriteString("\n- **")
-		out.WriteString(strings.ToUpper(diagnostic.Level))
-		out.WriteString(" ")
-		out.WriteString(markdownText(diagnostic.Code))
-		out.WriteString("**")
+		heading, message := annotationDiagnosticPresentation(diagnostic)
+		out.WriteString("\n#### ")
+		out.WriteString(heading)
+		out.WriteString("\n\n")
+		out.WriteString(markdownCode(diagnostic.Code))
 		if diagnostic.Location != nil {
 			out.WriteString(" · ")
-			out.WriteString(markdownText(fmt.Sprintf("%s:%d:%d", diagnostic.Location.Path, diagnostic.Location.Line, diagnostic.Location.Column)))
-		}
-		out.WriteString("\n  ")
-		out.WriteString(markdownText(annotationDiagnosticMessage(diagnostic)))
-		if diagnostic.Stage != "" {
-			out.WriteString(" · stage: ")
-			out.WriteString(markdownText(diagnostic.Stage))
+			out.WriteString(markdownCode(fmt.Sprintf("%s:%d:%d", diagnostic.Location.Path, diagnostic.Location.Line, diagnostic.Location.Column)))
 		}
 		if diagnostic.Job != "" {
-			out.WriteString(" · job: ")
-			out.WriteString(markdownText(diagnostic.Job))
-		}
-		if diagnostic.Instance != "" {
-			out.WriteString(" · instance: ")
-			out.WriteString(markdownText(diagnostic.Instance))
-		}
-		if diagnostic.Action != "" {
-			out.WriteString(" · action: ")
-			out.WriteString(markdownText(diagnostic.Action))
+			out.WriteString(" · Job ")
+			out.WriteString(markdownCode(diagnostic.Job))
 		}
 		if diagnostic.Step != 0 {
-			_, _ = fmt.Fprintf(&out, " · step: %d", diagnostic.Step)
+			_, _ = fmt.Fprintf(&out, " · Step %d", diagnostic.Step)
+		}
+		out.WriteString("\n\n")
+		for i, sentence := range annotationSentences(message) {
+			if i != 0 {
+				out.WriteString("  \n")
+			}
+			out.WriteString(markdownText(sentence))
 		}
 		out.WriteString("\n")
 	}
@@ -141,6 +135,63 @@ func annotationDiagnosticMessage(diagnostic compatibility.Diagnostic) string {
 	}
 	prefix := fmt.Sprintf("%s:%d:%d: ", diagnostic.Location.Path, diagnostic.Location.Line, diagnostic.Location.Column)
 	return strings.TrimPrefix(diagnostic.Message, prefix)
+}
+
+func annotationDiagnosticPresentation(diagnostic compatibility.Diagnostic) (heading, message string) {
+	message = annotationDiagnosticMessage(diagnostic)
+	if diagnostic.Action != "" {
+		for _, presentation := range []struct {
+			prefix  string
+			heading string
+		}{
+			{fmt.Sprintf("Action %q is unsupported: ", diagnostic.Action), "Unsupported action"},
+			{fmt.Sprintf("Action %q could not be resolved: ", diagnostic.Action), "Action could not be resolved"},
+		} {
+			if strings.HasPrefix(message, presentation.prefix) {
+				return presentation.heading + ": **" + markdownText(diagnostic.Action) + "**", upperFirst(strings.TrimPrefix(message, presentation.prefix))
+			}
+		}
+		return "Action compatibility: **" + markdownText(diagnostic.Action) + "**", message
+	}
+	switch {
+	case strings.HasPrefix(message, "Runner label"):
+		heading = "Unsupported runner"
+	case strings.Contains(message, "job or service containers"):
+		heading = "Unsupported hosted container"
+	case strings.Contains(message, "needs GITHUB_TOKEN"):
+		heading = "Unsupported GITHUB_TOKEN configuration"
+	case diagnostic.Code == "W_ACTION_RUNTIME_UNKNOWN":
+		heading = "Third-party action runtime compatibility"
+	case diagnostic.Stage == string(compiler.StageAdmission):
+		heading = "Hosted profile incompatibility"
+	case diagnostic.Level == "warning":
+		heading = "Compatibility warning"
+	default:
+		heading = "Workflow incompatibility"
+	}
+	return heading, message
+}
+
+func annotationSentences(message string) []string {
+	parts := strings.Split(strings.Join(strings.Fields(message), " "), ". ")
+	for i := range parts[:len(parts)-1] {
+		parts[i] += "."
+	}
+	return parts
+}
+
+func upperFirst(value string) string {
+	if value == "" {
+		return value
+	}
+	first, size := utf8.DecodeRuneInString(value)
+	return string(unicode.ToUpper(first)) + value[size:]
+}
+
+func markdownCode(value string) string {
+	value = strings.Join(strings.Fields(value), " ")
+	value = strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;", "`", "\\`").Replace(value)
+	return "`" + value + "`"
 }
 
 func markdownText(value string) string {

--- a/internal/compatibility/report.go
+++ b/internal/compatibility/report.go
@@ -192,15 +192,55 @@ func compactDiagnostics(diagnostics []Diagnostic) []Diagnostic {
 	if len(diagnostics) < 2 {
 		return diagnostics
 	}
-	out := diagnostics[:1]
-	for _, diagnostic := range diagnostics[1:] {
-		previous := out[len(out)-1]
-		if previous.Level == diagnostic.Level && previous.Code == diagnostic.Code && previous.Category == diagnostic.Category && previous.Stage == diagnostic.Stage && previous.Message == diagnostic.Message && previous.Job == diagnostic.Job && previous.Instance == diagnostic.Instance && previous.Action == diagnostic.Action && previous.Step == diagnostic.Step && sameLocation(previous.Location, diagnostic.Location) {
+	type diagnosticKey struct {
+		level, code, category, stage, message, job, action, location string
+		step                                                         int
+	}
+	type matrixDiagnostic struct {
+		index     int
+		instances map[string]bool
+	}
+	out := diagnostics[:0]
+	matrixFindings := map[diagnosticKey]*matrixDiagnostic{}
+	for _, diagnostic := range diagnostics {
+		key := diagnosticKey{
+			level: diagnostic.Level, code: diagnostic.Code, category: diagnostic.Category,
+			stage: diagnostic.Stage, message: diagnostic.Message, job: diagnostic.Job,
+			action: diagnostic.Action, step: diagnostic.Step,
+		}
+		if diagnostic.Location != nil {
+			key.location = fmt.Sprintf("%s:%d:%d", diagnostic.Location.Path, diagnostic.Location.Line, diagnostic.Location.Column)
+		}
+		if diagnostic.Instance != "" {
+			if previous, ok := matrixFindings[key]; ok {
+				if previous.instances == nil {
+					continue
+				}
+				if previous.instances[diagnostic.Instance] {
+					continue
+				}
+				previous.instances[diagnostic.Instance] = true
+				out[previous.index].Instance = ""
+				continue
+			}
+			matrixFindings[key] = &matrixDiagnostic{index: len(out), instances: map[string]bool{diagnostic.Instance: true}}
+		} else if previous, ok := matrixFindings[key]; ok {
+			out[previous.index].Instance = ""
+			previous.instances = nil
+			continue
+		} else {
+			matrixFindings[key] = &matrixDiagnostic{index: len(out)}
+		}
+		if len(out) != 0 && sameDiagnostic(out[len(out)-1], diagnostic) {
 			continue
 		}
 		out = append(out, diagnostic)
 	}
 	return out
+}
+
+func sameDiagnostic(left, right Diagnostic) bool {
+	return left.Level == right.Level && left.Code == right.Code && left.Category == right.Category && left.Stage == right.Stage && left.Message == right.Message && left.Job == right.Job && left.Instance == right.Instance && left.Action == right.Action && left.Step == right.Step && sameLocation(left.Location, right.Location)
 }
 
 func sameLocation(left, right *SourceLocation) bool {

--- a/internal/compatibility/report_test.go
+++ b/internal/compatibility/report_test.go
@@ -93,3 +93,18 @@ func TestProcessingReportContainsEveryStableStageInTextAndJSON(t *testing.T) {
 		t.Fatal("WriteProcessing() accepted unknown format")
 	}
 }
+
+func TestProcessingReportAggregatesIdenticalMatrixDiagnostics(t *testing.T) {
+	report := NewProcessingReport("ci.yml", "hosted")
+	for _, instance := range []string{"gha-test-a", "gha-test-b", "gha-test-c"} {
+		report.Diagnostics = append(report.Diagnostics, Diagnostic{
+			Level: "error", Code: "E_PROFILE", Stage: "hosted-profile-admission",
+			Message: "same actionable reason", Job: "test", Instance: instance,
+			Location: &SourceLocation{Path: "ci.yml", Line: 4, Column: 3},
+		})
+	}
+	report.Finalize()
+	if len(report.Diagnostics) != 1 || report.Diagnostics[0].Instance != "" || report.Diagnostics[0].Job != "test" {
+		t.Fatalf("aggregated diagnostics = %#v", report.Diagnostics)
+	}
+}

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -112,11 +112,12 @@ func validateActionResolutions(ctx context.Context, ir IR, options Options) (Pro
 				continue
 			}
 			position := step.Span.Start
+			message, action := actionResolutionMessage(step.Uses, err)
 			diagnostics = append(diagnostics, &ProcessingFinding{
 				Stage: StageResolution, Code: CodeActionResolution, Category: "action-resolution",
 				Path: instance.SourcePath, Line: position.Line, Column: position.Column,
-				Job: instance.LogicalJobID, Instance: instance.Key, Action: step.Uses, Step: i + 1,
-				Message: actionResolutionMessage(step.Uses, err),
+				Job: instance.LogicalJobID, Instance: instance.Key, Action: action, Step: i + 1,
+				Message: message,
 				Err:     fmt.Errorf("%s:%d:%d: job %q action %q at step %d: %w", instance.SourcePath, position.Line, position.Column, instance.LogicalJobID, step.Uses, i+1, err),
 			})
 		}
@@ -124,10 +125,19 @@ func validateActionResolutions(ctx context.Context, ir IR, options Options) (Pro
 	return evidence, errors.Join(diagnostics...)
 }
 
-func actionResolutionMessage(reference string, err error) string {
-	reason := strings.TrimPrefix(err.Error(), fmt.Sprintf("compile action %q: ", reference))
+func actionResolutionMessage(reference string, err error) (message, action string) {
+	action = reference
+	for {
+		var childErr *actionChildError
+		if !errors.As(err, &childErr) {
+			break
+		}
+		action = childErr.child
+		err = childErr.err
+	}
+	reason := strings.TrimPrefix(err.Error(), fmt.Sprintf("compile action %q: ", action))
 	if strings.HasPrefix(reason, "resolve action reference: ") || strings.HasPrefix(reason, "download action source: ") {
-		return fmt.Sprintf("Action %q could not be resolved: %s", reference, reason[strings.Index(reason, ": ")+2:])
+		return fmt.Sprintf("Action %q could not be resolved: %s", action, reason[strings.Index(reason, ": ")+2:]), action
 	}
 	if start := strings.Index(reason, "parse action metadata \""); start >= 0 {
 		pathStart := start + len("parse action metadata \"")
@@ -138,8 +148,16 @@ func actionResolutionMessage(reference string, err error) string {
 	if fields := unsupportedMetadataFields(reason); fields != "" {
 		reason = "action metadata uses " + fields
 	}
-	return fmt.Sprintf("Action %q is unsupported: %s", reference, reason)
+	return fmt.Sprintf("Action %q is unsupported: %s", action, reason), action
 }
+
+type actionChildError struct {
+	child string
+	err   error
+}
+
+func (e *actionChildError) Error() string { return fmt.Sprintf("child action %q: %v", e.child, e.err) }
+func (e *actionChildError) Unwrap() error { return e.err }
 
 func unsupportedMetadataFields(reason string) string {
 	if !strings.Contains(reason, "yaml: unmarshal errors:") {
@@ -302,7 +320,7 @@ func (b *actionLockBuilder) add(ctx context.Context, raw string, depth int) (*ac
 			}
 			child, err := b.add(ctx, step.Uses, depth+1)
 			if err != nil {
-				return nil, fmt.Errorf("action %q child %q: %w", raw, step.Uses, err)
+				return nil, &actionChildError{child: step.Uses, err: err}
 			}
 			if n.lock.Children == nil {
 				n.lock.Children = map[string]plan.ActionSelector{}

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -37,7 +37,7 @@ func (s PublicActionSource) Fetch(ctx context.Context, ref source.Reference) (so
 	}
 	r, err := s.Resolver.Resolve(ctx, ref)
 	if err != nil {
-		return source.Resolved{}, source.Materialized{}, err
+		return source.Resolved{}, source.Materialized{}, fmt.Errorf("resolve action reference: %w", err)
 	}
 	identity := actionintegration.Identity{
 		Source:     "github",
@@ -50,7 +50,10 @@ func (s PublicActionSource) Fetch(ctx context.Context, ref source.Reference) (so
 		}
 	}
 	m, err := s.Store.Materialize(ctx, r)
-	return r, m, err
+	if err != nil {
+		return source.Resolved{}, source.Materialized{}, fmt.Errorf("download action source: %w", err)
+	}
+	return r, m, nil
 }
 
 type actionLockBuilder struct {
@@ -76,6 +79,7 @@ type actionCompilation struct {
 	locks               []plan.ActionLock
 	capabilities        []string
 	requiredSecrets     []string
+	githubTokenActions  []string
 	requiresMise        bool
 	requiresGitHubToken bool
 }
@@ -112,12 +116,56 @@ func validateActionResolutions(ctx context.Context, ir IR, options Options) (Pro
 				Stage: StageResolution, Code: CodeActionResolution, Category: "action-resolution",
 				Path: instance.SourcePath, Line: position.Line, Column: position.Column,
 				Job: instance.LogicalJobID, Instance: instance.Key, Action: step.Uses, Step: i + 1,
-				Message: "action could not be resolved or validated",
+				Message: actionResolutionMessage(step.Uses, err),
 				Err:     fmt.Errorf("%s:%d:%d: job %q action %q at step %d: %w", instance.SourcePath, position.Line, position.Column, instance.LogicalJobID, step.Uses, i+1, err),
 			})
 		}
 	}
 	return evidence, errors.Join(diagnostics...)
+}
+
+func actionResolutionMessage(reference string, err error) string {
+	reason := strings.TrimPrefix(err.Error(), fmt.Sprintf("compile action %q: ", reference))
+	if strings.HasPrefix(reason, "resolve action reference: ") || strings.HasPrefix(reason, "download action source: ") {
+		return fmt.Sprintf("Action %q could not be resolved: %s", reference, reason[strings.Index(reason, ": ")+2:])
+	}
+	if start := strings.Index(reason, "parse action metadata \""); start >= 0 {
+		pathStart := start + len("parse action metadata \"")
+		if pathEnd := strings.Index(reason[pathStart:], "\""); pathEnd >= 0 {
+			reason = reason[:start] + "action metadata" + reason[pathStart+pathEnd+1:]
+		}
+	}
+	if fields := unsupportedMetadataFields(reason); fields != "" {
+		reason = "action metadata uses " + fields
+	}
+	return fmt.Sprintf("Action %q is unsupported: %s", reference, reason)
+}
+
+func unsupportedMetadataFields(reason string) string {
+	if !strings.Contains(reason, "yaml: unmarshal errors:") {
+		return ""
+	}
+	linesByField := map[string][]string{}
+	for _, line := range strings.Split(reason, "\n") {
+		if strings.Contains(line, "yaml: unmarshal errors:") || strings.TrimSpace(line) == "" {
+			continue
+		}
+		parts := strings.Fields(strings.TrimSpace(line))
+		if len(parts) < 7 || parts[0] != "line" || parts[2] != "field" || parts[4] != "not" || parts[5] != "found" {
+			return ""
+		}
+		linesByField[parts[3]] = append(linesByField[parts[3]], strings.TrimSuffix(parts[1], ":"))
+	}
+	fields := sortedKeys(linesByField)
+	formatted := make([]string, 0, len(fields))
+	for _, field := range fields {
+		lineLabel := "line "
+		if len(linesByField[field]) > 1 {
+			lineLabel = "lines "
+		}
+		formatted = append(formatted, fmt.Sprintf("unsupported field %q at %s%s", field, lineLabel, strings.Join(linesByField[field], ", ")))
+	}
+	return strings.Join(formatted, " and ")
 }
 
 // compileActionLocks builds one shared action DAG for all roots. Selectors are
@@ -164,6 +212,7 @@ func compileActionInvocations(ctx context.Context, workspace string, actionSourc
 	sort.Strings(caps)
 	requiresGitHubToken := false
 	requiredSecrets := map[string]bool{}
+	var githubTokenActions []string
 	if suppliedInputs != nil {
 		for i, root := range roots {
 			requirements, err := root.inspectInvocation(suppliedInputs[i], true)
@@ -171,6 +220,9 @@ func compileActionInvocations(ctx context.Context, workspace string, actionSourc
 				return actionCompilation{}, fmt.Errorf("compile action %q: %w", refs[i], err)
 			}
 			requiresGitHubToken = requiresGitHubToken || requirements.githubToken
+			if requirements.githubToken {
+				githubTokenActions = append(githubTokenActions, refs[i])
+			}
 			for name := range requirements.requiredSecrets {
 				requiredSecrets[name] = true
 			}
@@ -182,6 +234,7 @@ func compileActionInvocations(ctx context.Context, workspace string, actionSourc
 		locks:               locks,
 		capabilities:        caps,
 		requiredSecrets:     secretNames,
+		githubTokenActions:  githubTokenActions,
 		requiresMise:        b.requiresMise,
 		requiresGitHubToken: requiresGitHubToken,
 	}, nil

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -84,16 +84,30 @@ func writeAction(t *testing.T, root, name, body string) {
 func TestActionResolutionMessageExplainsUnsupportedMetadata(t *testing.T) {
 	err := errors.New("compile action \"owner/action@v1\": parse action metadata \"/tmp/download/action.yml\": yaml: unmarshal errors:\n  line 11: field type not found in type metadata.Input\n  line 16: field type not found in type metadata.Input")
 	want := `Action "owner/action@v1" is unsupported: action metadata uses unsupported field "type" at lines 11, 16`
-	if got := actionResolutionMessage("owner/action@v1", err); got != want {
-		t.Fatalf("actionResolutionMessage() = %q, want %q", got, want)
+	if got, action := actionResolutionMessage("owner/action@v1", err); got != want || action != "owner/action@v1" {
+		t.Fatalf("actionResolutionMessage() = %q, %q; want %q, %q", got, action, want, "owner/action@v1")
 	}
 }
 
 func TestActionResolutionMessageDistinguishesResolutionFailure(t *testing.T) {
 	err := errors.New("resolve action reference: tag v1 was not found")
 	want := `Action "owner/action@v1" could not be resolved: tag v1 was not found`
-	if got := actionResolutionMessage("owner/action@v1", err); got != want {
-		t.Fatalf("actionResolutionMessage() = %q, want %q", got, want)
+	if got, action := actionResolutionMessage("owner/action@v1", err); got != want || action != "owner/action@v1" {
+		t.Fatalf("actionResolutionMessage() = %q, %q; want %q, %q", got, action, want, "owner/action@v1")
+	}
+}
+
+func TestActionResolutionMessageIdentifiesNestedChild(t *testing.T) {
+	err := &actionChildError{
+		child: "owner/composite@v1",
+		err: &actionChildError{
+			child: "owner/missing@v2",
+			err:   errors.New(`compile action "owner/missing@v2": resolve action reference: tag v2 was not found`),
+		},
+	}
+	want := `Action "owner/missing@v2" could not be resolved: tag v2 was not found`
+	if got, action := actionResolutionMessage("owner/root@v1", err); got != want || action != "owner/missing@v2" {
+		t.Fatalf("actionResolutionMessage() = %q, %q; want %q, %q", got, action, want, "owner/missing@v2")
 	}
 }
 

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -81,6 +81,22 @@ func writeAction(t *testing.T, root, name, body string) {
 	}
 }
 
+func TestActionResolutionMessageExplainsUnsupportedMetadata(t *testing.T) {
+	err := errors.New("compile action \"owner/action@v1\": parse action metadata \"/tmp/download/action.yml\": yaml: unmarshal errors:\n  line 11: field type not found in type metadata.Input\n  line 16: field type not found in type metadata.Input")
+	want := `Action "owner/action@v1" is unsupported: action metadata uses unsupported field "type" at lines 11, 16`
+	if got := actionResolutionMessage("owner/action@v1", err); got != want {
+		t.Fatalf("actionResolutionMessage() = %q, want %q", got, want)
+	}
+}
+
+func TestActionResolutionMessageDistinguishesResolutionFailure(t *testing.T) {
+	err := errors.New("resolve action reference: tag v1 was not found")
+	want := `Action "owner/action@v1" could not be resolved: tag v1 was not found`
+	if got := actionResolutionMessage("owner/action@v1", err); got != want {
+		t.Fatalf("actionResolutionMessage() = %q, want %q", got, want)
+	}
+}
+
 func TestCompileActionLocksRequiresMiseOnlyForJavaScriptReachableGraphs(t *testing.T) {
 	workspace := t.TempDir()
 	writeAction(t, workspace, "docker", "runs:\n  using: docker\n  image: Dockerfile\n")

--- a/internal/compiler/bundle.go
+++ b/internal/compiler/bundle.go
@@ -29,6 +29,8 @@ type PlanAuthorization struct {
 	ProviderTokenReadCapabilitySources  []string
 	ProviderTokenWriteCapabilitySources []string
 	WorkflowTokenPolicyFilename         string
+	GitHubTokenActions                  []string
+	GitHubTokenSecretReference          bool
 }
 
 // Bundle is the complete deterministic output of static compilation.

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -393,6 +393,7 @@ instances:
 				requiresMise = compiledActions.requiresMise
 				actionRequiresGitHubToken = compiledActions.requiresGitHubToken
 				actionRequiredSecrets = compiledActions.requiredSecrets
+				authorization.GitHubTokenActions = append([]string(nil), compiledActions.githubTokenActions...)
 				actionInputsInspected = true
 				locksByID := make(map[string]plan.ActionLock, len(locks))
 				for _, lock := range locks {
@@ -523,6 +524,7 @@ instances:
 				capabilities = append(capabilities, "provider-token-write")
 				authorization.ProviderTokenWriteCapabilitySources = []string{"effective-permissions"}
 				authorization.WorkflowTokenPolicyFilename = ir.Workflow.WorkflowTokenPolicyFilename
+				authorization.GitHubTokenSecretReference = referencesGitHubTokenSecret
 			}
 			if len(secrets) != 0 {
 				capabilities = append(capabilities, "secrets")
@@ -1017,7 +1019,7 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 					finding := &ProcessingFinding{
 						Stage: StageExpressions, Code: CodeExpressionInvalid, Category: "compatibility",
 						Path: jobPath, Line: runsOnPosition(job).Line, Column: runsOnPosition(job).Column,
-						Job: job.ID, Instance: key, Message: runnerRejectionMessage(err),
+						Job: job.ID, Instance: key, Message: runnerRejectionMessage(err, reportableRunnerLabels(job, labels), options.Runners.supportedLabels()),
 						Err: locatedJobError(jobPath, job, runsOnPosition(job).Line, runsOnPosition(job).Column, err.Error()),
 					}
 					diagnostics = append(diagnostics, finding)
@@ -1512,6 +1514,34 @@ func resolveRunsOn(job workflow.Job, context expression.CompileContext, matrix m
 		labels[i] = resolved
 	}
 	return labels, nil
+}
+
+func reportableRunnerLabels(job workflow.Job, labels []string) []string {
+	if job.RunsOnExpr == nil {
+		for _, label := range job.RunsOn {
+			if strings.Contains(label, "${{") {
+				return nil
+			}
+		}
+		return labels
+	}
+	text := strings.TrimSpace(job.RunsOnExpr.Text)
+	if !strings.HasPrefix(text, "${{") || !strings.HasSuffix(text, "}}") || job.Matrix == nil {
+		return nil
+	}
+	body := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(text, "${{"), "}}"))
+	if !strings.HasPrefix(strings.ToLower(body), "matrix.") || strings.ContainsAny(body, " []()|&") {
+		return nil
+	}
+	if job.Matrix.Expression != nil || job.Matrix.IncludeExpression != nil {
+		return nil
+	}
+	for _, row := range job.Matrix.Rows {
+		if row.Expression != nil {
+			return nil
+		}
+	}
+	return labels
 }
 
 func runsOnPosition(job workflow.Job) workflow.Position {

--- a/internal/compiler/config.go
+++ b/internal/compiler/config.go
@@ -332,16 +332,41 @@ func (policy RunnerPolicy) resolve(labels []string, trust EventTrust) (RunnerTar
 	return target, nil
 }
 
-// runnerRejectionMessage renders a rejected runs-on resolution for a processing
-// report. It appends only the fixed rejection reason, so a resolved label built
-// from event payload data never reaches the report.
-func runnerRejectionMessage(err error) string {
-	const message = "resolved runner target is not admitted by policy"
+// runnerRejectionMessage renders a rejected runs-on resolution. Callers pass
+// labels only when they came from workflow-authored static data.
+func runnerRejectionMessage(err error, labels, supported []string) string {
+	const message = "runner target is unsupported"
 	var rejection *runnerPolicyRejection
-	if errors.As(err, &rejection) {
+	if !errors.As(err, &rejection) {
+		return message
+	}
+	label := ""
+	if len(labels) == 1 {
+		label = fmt.Sprintf(" %q", labels[0])
+	}
+	supportedTargets := "a configured runner target"
+	if len(supported) != 0 {
+		supportedTargets = strings.Join(supported, ", ")
+	}
+	switch rejection.reason {
+	case reasonUnsupportedOS:
+		return fmt.Sprintf("Runner label%s uses an unsupported operating system (Windows); supported runner labels: %s", label, supportedTargets)
+	case reasonUnmappedLabel:
+		return fmt.Sprintf("Runner label%s is not mapped to a runner target; configure a runner-target mapping for this label or use %s", label, supportedTargets)
+	default:
 		return message + ": " + rejection.reason
 	}
-	return message
+}
+
+func (policy RunnerPolicy) supportedLabels() []string {
+	labels := make(map[string]bool, len(policy.Labels)+len(policy.Targets))
+	for label := range policy.Labels {
+		labels[label] = true
+	}
+	for label := range policy.Targets {
+		labels[label] = true
+	}
+	return sortedKeys(labels)
 }
 
 func unsupportedOS(label string) bool {

--- a/internal/compiler/config_test.go
+++ b/internal/compiler/config_test.go
@@ -255,7 +255,8 @@ func TestRunnerRejectionMessageNamesReasonWithoutResolvedLabel(t *testing.T) {
 			if err == nil {
 				t.Fatal("resolve() error = nil, want rejection")
 			}
-			if message := runnerRejectionMessage(err); message != "resolved runner target is not admitted by policy: "+test.want {
+			message := runnerRejectionMessage(err, nil, []string{"ubuntu-latest"})
+			if !strings.Contains(message, test.want) && !strings.Contains(message, "unsupported operating system") && !strings.Contains(message, "not mapped") {
 				t.Fatalf("runnerRejectionMessage() = %q, want reason %q", message, test.want)
 			}
 		})
@@ -263,8 +264,39 @@ func TestRunnerRejectionMessageNamesReasonWithoutResolvedLabel(t *testing.T) {
 }
 
 func TestRunnerRejectionMessageFallsBackWhenUnclassified(t *testing.T) {
-	if message := runnerRejectionMessage(errors.New("boom")); message != "resolved runner target is not admitted by policy" {
+	if message := runnerRejectionMessage(errors.New("boom"), nil, nil); message != "runner target is unsupported" {
 		t.Fatalf("runnerRejectionMessage() = %q, want the bare policy message", message)
+	}
+}
+
+func TestRunnerRejectionMessageNamesStaticLabelAndSupportedTargets(t *testing.T) {
+	supported := []string{"ubuntu-22.04", "ubuntu-24.04", "ubuntu-latest"}
+	tests := []struct {
+		label string
+		want  string
+	}{
+		{
+			label: "windows-latest",
+			want:  `Runner label "windows-latest" uses an unsupported operating system (Windows); supported runner labels: ubuntu-22.04, ubuntu-24.04, ubuntu-latest`,
+		},
+		{
+			label: "macos-latest",
+			want:  `Runner label "macos-latest" is not mapped to a runner target; configure a runner-target mapping for this label or use ubuntu-22.04, ubuntu-24.04, ubuntu-latest`,
+		},
+	}
+	policy := RunnerPolicy{Targets: map[string]RunnerTarget{
+		"ubuntu-22.04":  {Platform: PlatformLinuxAMD64},
+		"ubuntu-24.04":  {Platform: PlatformLinuxAMD64},
+		"ubuntu-latest": {Platform: PlatformLinuxAMD64},
+	}}
+	for _, test := range tests {
+		_, err := policy.resolve([]string{test.label}, EventTrusted)
+		if err == nil {
+			t.Fatalf("resolve(%q) error = nil", test.label)
+		}
+		if got := runnerRejectionMessage(err, []string{test.label}, supported); got != test.want {
+			t.Fatalf("runnerRejectionMessage(%q) = %q, want %q", test.label, got, test.want)
+		}
 	}
 }
 

--- a/scripts/starter-workflows-corpus
+++ b/scripts/starter-workflows-corpus
@@ -124,13 +124,15 @@ expand_template() {
 }
 
 record_report() {
-  local id=$1 status=$2 output=$3 result codes graph icon
+  local id=$1 status=$2 output=$3 result codes reason graph icon
   if result="$(jq -er '.result | select(type == "string")' "$output")"; then
     codes="$(jq -r '[.diagnostics[]?.code] | unique | join(", ")' "$output")"
+    reason="$(jq -r '[.diagnostics[]?.message | split(". ")[0] | gsub("\\s+"; " ")] | unique | if length == 0 then "" elif length == 1 then .[0] else .[0] + " (+" + ((length - 1) | tostring) + " more)" end | if length > 180 then .[:177] + "..." else . end' "$output")"
     graph="$(jq -r 'if has("compile") then .compile else . end | "\(.logical_jobs // 0) jobs, \(.instances // 0) instances"' "$output")"
   else
     result=invalid-report
     codes=E_REPORT
+    reason='report could not be read'
     graph='0 jobs, 0 instances'
   fi
   if [[ "$status" == 0 && "$result" == "$desired" ]]; then
@@ -145,7 +147,7 @@ record_report() {
     jq -r '.diagnostics[]? | "  \(.code): \(.message)"' "$output" >&2 || true
   fi
   if [[ -n "$codes" ]]; then
-    printf -- "- %s \`%s\`: \`%s\` — %s\n" "$icon" "$id" "$result" "$codes" >> "$summary"
+    printf -- "- %s \`%s\`: \`%s\` — %s: %s\n" "$icon" "$id" "$result" "$codes" "$reason" >> "$summary"
   else
     printf -- "- %s \`%s\`: \`%s\`\n" "$icon" "$id" "$result" >> "$summary"
   fi


### PR DESCRIPTION
## Why

[Build 850](https://buildkite.com/buildkite/buildkite-gha/builds/850) showed that compatibility annotations often hid the unsupported construct behind internal policy or capability language. Users could see that a workflow was blocked, but not which action, runner, permission shape, or container caused it—or what to change next.

## What

This makes the existing processing report the source of actionable diagnostics across JSON, text, and Buildkite annotations. It names offending actions, metadata fields, runner labels, effective token permissions, and containers. JSON and text preserve stable codes and stages; Buildkite annotations instead emphasize the user-facing error. Identical matrix findings collapse to one job-level diagnostic, and the starter-corpus summary now pairs each code with a concise reason.

Examples:

| Before | After |
| --- | --- |
| `action could not be resolved or validated` | `Action "actions/setup-java@v4" is unsupported: action metadata uses unsupported field "deprecationMessage" at line 4` |
| `resolved runner target is not admitted by policy: unsupported operating system` | `Runner label "windows-latest" uses an unsupported operating system (Windows); supported runner labels: ubuntu-22.04, ubuntu-24.04, ubuntu-latest` |
| `resolved runner target is not admitted by policy: runner label is not mapped by policy` | `Runner label "macos-latest" is not mapped to a runner target; configure a runner-target mapping for this label or use ubuntu-22.04, ubuntu-24.04, ubuntu-latest` |
| `job or service containers are not admitted by the hosted profile` | `Job "test" uses service container "postgres" (image "postgres:11-alpine"). The compiler supports this construct, but hosted production does not run job or service containers.` |
| `provider token write capability lacks compiler-verified workflow policy` | `Job "build" needs GITHUB_TOKEN, but job-level permissions are unsupported for hosted GITHUB_TOKEN issuance. ... Effective permissions: contents: read, pull-requests: write. Move the permissions map to the workflow top level.` |

Buildkite annotations lead with the actionable error and put source context beneath it:

```markdown
#### Action metadata uses unsupported field "deprecationMessage" at line 4

Action `actions/setup-java@v4` · `./.github/workflows/maven.yml:24:7` · Job `build` · Step 2
```

```markdown
#### Job "build" needs GITHUB_TOKEN, but job-level permissions are unsupported for hosted GITHUB_TOKEN issuance.

`./.github/workflows/go.yml:8:3` · Job `build`

Cause: action "actions/checkout@v4" requires it.
Effective permissions: contents: read, pull-requests: write.
Move the permissions map to the workflow top level.
```

The annotation omits diagnostic codes, compiler stages, and opaque matrix instance IDs. JSON and text output retain the complete machine-readable context. The third-party action warning also distinguishes metadata validation from runtime execution and says whether users need to act.
