### PR TITLE
Accept action metadata used by starter workflows

### DIFF
--- a/internal/action/metadata/metadata.go
+++ b/internal/action/metadata/metadata.go
@@ -21,23 +21,28 @@ type Metadata struct {
 	// SourceRoot is the verified tree whose digest binds this action. For a
 	// workspace action it is Path; for a materialized GitHub action it is the
 	// repository root.
-	SourceRoot  string            `yaml:"-"`
-	Name        string            `yaml:"name"`
-	Description string            `yaml:"description"`
-	Author      string            `yaml:"author"`
-	Inputs      map[string]Input  `yaml:"inputs"`
-	Outputs     map[string]Output `yaml:"outputs"`
-	Runs        Runs              `yaml:"runs"`
-	Branding    Branding          `yaml:"branding"`
+	SourceRoot  string `yaml:"-"`
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+	// DeprecationMessage is inert metadata emitted by deprecated actions.
+	DeprecationMessage string            `yaml:"deprecationMessage"`
+	Author             string            `yaml:"author"`
+	Inputs             map[string]Input  `yaml:"inputs"`
+	Outputs            map[string]Output `yaml:"outputs"`
+	Runs               Runs              `yaml:"runs"`
+	Branding           Branding          `yaml:"branding"`
 }
 
 // Input declares one action input.
 type Input struct {
-	Description              string  `yaml:"description"`
-	DeprecationMessage       string  `yaml:"deprecation-message"`
-	LegacyDeprecationMessage string  `yaml:"deprecationMessage"`
-	Required                 bool    `yaml:"required"`
-	Default                  *string `yaml:"default"`
+	Description              string `yaml:"description"`
+	DeprecationMessage       string `yaml:"deprecation-message"`
+	LegacyDeprecationMessage string `yaml:"deprecationMessage"`
+	// Type is accepted as inert metadata because some GitHub-hosted actions
+	// declare it even though action inputs are exposed as strings.
+	Type     string  `yaml:"type"`
+	Required bool    `yaml:"required"`
+	Default  *string `yaml:"default"`
 }
 
 // Output declares one action output.

--- a/internal/action/metadata/metadata_test.go
+++ b/internal/action/metadata/metadata_test.go
@@ -112,7 +112,7 @@ func TestValidateDockerEntrypoints(t *testing.T) {
 func TestLoadIsStrictAndConfined(t *testing.T) {
 	t.Run("official declarative fields", func(t *testing.T) {
 		root := t.TempDir()
-		writeAction(t, root, "action.yml", "name: Setup tool\ndescription: Installs a tool\nauthor: GitHub\ninputs:\n  version:\n    deprecationMessage: Use version-file instead\nbranding:\n  icon: package\n  color: blue\nruns:\n  using: node24\n  main: dist/index.js\n")
+		writeAction(t, root, "action.yml", "name: Setup tool\ndescription: Installs a tool\ndeprecationMessage: Use setup-tool v2 instead\nauthor: GitHub\ninputs:\n  version:\n    deprecationMessage: Use version-file instead\n    type: string\nbranding:\n  icon: package\n  color: blue\nruns:\n  using: node24\n  main: dist/index.js\n")
 		action, err := Load(root, ".")
 		if err != nil {
 			t.Fatal(err)
@@ -120,8 +120,14 @@ func TestLoadIsStrictAndConfined(t *testing.T) {
 		if action.Author != "GitHub" {
 			t.Fatalf("Load() author = %q, want GitHub", action.Author)
 		}
+		if action.DeprecationMessage != "Use setup-tool v2 instead" {
+			t.Fatalf("Load() deprecation message = %q", action.DeprecationMessage)
+		}
 		if action.Inputs["version"].DeprecationMessage != "Use version-file instead" {
 			t.Fatalf("Load() deprecation message = %q", action.Inputs["version"].DeprecationMessage)
+		}
+		if action.Inputs["version"].Type != "string" {
+			t.Fatalf("Load() input type = %q", action.Inputs["version"].Type)
 		}
 		if action.Branding.Icon != "package" || action.Branding.Color != "blue" {
 			t.Fatalf("Load() branding = %#v", action.Branding)

--- a/scripts/starter-workflows-corpus
+++ b/scripts/starter-workflows-corpus
@@ -182,8 +182,7 @@ for id in "${case_ids[@]}"; do
   report="$work/$id.$mode.json"
   (
     cd "$case_root"
-    # The corpus publishes one aggregate annotation after every case completes.
-    BUILDKITE_JOB_ID='' clean_env "$work/buildkite-gha" validate "${validate_args[@]}" --format json \
+    clean_env "$work/buildkite-gha" validate "${validate_args[@]}" --format json \
       --event-path "$event_path" "$workflow"
   ) > "$report" || status=$?
   record_report "$id" "$status" "$report"

--- a/scripts/starter-workflows-corpus
+++ b/scripts/starter-workflows-corpus
@@ -182,7 +182,8 @@ for id in "${case_ids[@]}"; do
   report="$work/$id.$mode.json"
   (
     cd "$case_root"
-    clean_env "$work/buildkite-gha" validate "${validate_args[@]}" --format json \
+    # The corpus publishes one aggregate annotation after every case completes.
+    BUILDKITE_JOB_ID='' clean_env "$work/buildkite-gha" validate "${validate_args[@]}" --format json \
       --event-path "$event_path" "$workflow"
   ) > "$report" || status=$?
   record_report "$id" "$status" "$report"


### PR DESCRIPTION
## Why

The hosted compatibility profile rejects the Maven starter workflow because current public actions declare inert metadata fields that the strict action parser does not recognize.

## What

Accept top-level `deprecationMessage` and action input `type` metadata while retaining strict parsing for unknown fields. Cover both fields in the action metadata tests.