### PR TITLE
Add reusable job authorization manifests

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -32,7 +32,7 @@ Looking for something else? [Browse open compatibility issues](https://github.co
 | [Reusable workflows](#reusable-workflows) | 🟡 Supported subset | Local workflows with static inputs, `secrets: inherit`, and direct job-output mappings. |
 | [Actions](#actions) | 🟡 Supported subset | Local and public JavaScript and composite actions on Linux and macOS; verified Dockerfile actions on Linux only. |
 | [Checkout, artifacts, and cache](#actions) | 🟡 Supported subset | Only the audited versions and modes listed below. |
-| [`GITHUB_TOKEN`](#github-token) | 🟡 Supported subset | One job-bound token for the event repository. Workflows containing reusable-workflow jobs cannot receive one. |
+| [`GITHUB_TOKEN`](#github-token) | 🟡 Supported subset | One job-bound token for the event repository, including compiler-verified local reusable workflows. |
 | [Other workflow secrets](#other-secrets-and-oidc) | 🚧 Not available in production | Production upload rejects ordinary secret requirements. |
 | [Job and service containers](#containers-and-services) | 🚧 Not available in production | A bounded container subset exists, but production upload rejects it. |
 | [Environments and snapshots](#job-configuration) | ➖ Accepted, no effect | No approvals, environment secrets, deployment state, or custom-image creation. |
@@ -122,6 +122,7 @@ A top-level workflow that does not declare the effective event is excluded befor
 - Static input values and defaults.
 - `secrets: inherit` when the called workflow declares no required secrets. Nested workflows must inherit again at every call edge.
 - Nested calls up to four levels.
+- Job-bound `GITHUB_TOKEN` requests with compiler-verified caller chains and effective permissions.
 - Caller-visible aggregate results.
 - Outputs mapped directly from `jobs.<job>.outputs.<name>`.
 
@@ -129,7 +130,6 @@ A top-level workflow that does not declare the effective event is excluded befor
 
 - Remote or dynamic workflow paths.
 - Call-level `if`.
-- Token requests from any direct or expanded job in a workflow containing a reusable-workflow call.
 - Explicit secret mappings or required called-workflow secrets.
 - Dynamic inputs or matrices.
 - Literal or compound output expressions.
@@ -184,7 +184,7 @@ permissions:
 
 Supported values are `read`, `write`, and `none`. Supported names are `actions`, `artifact-metadata`, `attestations`, `checks`, `contents`, `deployments`, `discussions`, `issues`, `packages`, `pages`, `pull-requests`, `security-events`, and `statuses`.
 
-An omitted map defaults to exactly `contents: read` when a token is needed. This deterministic default does not inherit GitHub repository or organization settings. A job map replaces the workflow map; it does not merge with it. A called workflow may only narrow its caller's permissions. These forms remain compilable when no job needs a token. Hosted token issuance accepts the omitted default or an explicit, non-empty top-level map. It rejects job-level maps and reusable-workflow jobs. Write access therefore requires an explicit top-level map.
+An omitted map defaults to exactly `contents: read` when a token is needed. This deterministic default does not inherit GitHub repository or organization settings. A job map replaces the workflow map; it does not merge with it. Called workflows inherit the caller's permissions when they omit a declaration. An explicit called-workflow or job map cannot exceed the inherited caller ceiling. A called job map may increase from its workflow default when it remains within that ceiling. Permission inheritance and elevation checks run during compilation even when no job needs a token. Hosted token issuance requires one explicit, non-empty map at the top level of the root workflow.
 
 The `read-all` and `write-all` values, the `id-token` permission, and noncanonical names are unsupported. An empty map, or a map containing only `none`, creates no token.
 
@@ -647,9 +647,9 @@ JavaScript and Docker actions with compatible bundled cache clients, such as `ac
 
 **🟡 Supported subset.** A job requests one short-lived `GITHUB_TOKEN` for the exact event repository by statically referencing `secrets.GITHUB_TOKEN` or by using an action whose effective input default references `github.token`. Effective `permissions` determine the token scope. The Buildkite organization feature and the pipeline's workflow access token setting must be enabled. Both are disabled by default.
 
-Buildkite reads the workflow policy from the pipeline repository at the build's immutable commit. The workflow must be directly under `.github/workflows/`, use a simple `.yml` or `.yaml` filename, and contain no job-level permission maps or reusable-workflow jobs. The workflow-token endpoint must interpret omitted top-level permissions as exactly `contents: read`, without consulting GitHub repository or organization defaults. Write access requires an explicit, non-empty top-level map. An explicit empty map or scopes resolving only to `none` produce no token.
+Buildkite reads the workflow policy from the pipeline repository at the build's immutable commit. The root workflow must be directly under `.github/workflows/`, use a simple `.yml` or `.yaml` filename, and declare an explicit non-empty top-level permission map. Local reusable workflows may request a token. Buildkite verifies every caller workflow/job edge, the final concrete workflow/job, its effective permissions, and the exact content-addressed job plan.
 
-If the selected workflow contains a reusable-workflow job, no direct or expanded job can receive a token. This includes `actions/checkout` in a called workflow when its effective `token` input defaults to `${{ github.token }}`. Tokenless local reusable workflows remain supported.
+The compiler adds this authorization only to generated Buildkite command steps whose plan statically requires `GITHUB_TOKEN`, including recursive composite-action input defaults. Buildkite removes the authorization from the runtime environment during trusted plugin upload. Tokenless jobs do not receive it.
 
 Pull-request builds and their triggered or rebuilt descendants may request only `contents: read`. Merge-queue builds and their descendants cannot request a token. The endpoint does not support GitHub Enterprise Server. The backend verifies this provenance and remains authoritative.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -27,14 +27,14 @@ Digests and immutable action locks detect changed code. They do not make code tr
 | Credential | Current boundary |
 | --- | --- |
 | Repository checkout | The verified adapter checks the event repository and exact commit. Buildkite authorizes managed private access; credentials are command-scoped and not persisted. |
-| `GITHUB_TOKEN` | Supported static uses receive one short-lived token for the event repository and compiler-resolved permissions. Omitted workflow permissions mean exactly `contents: read`; GitHub repository and organization settings are not inherited. Buildkite verifies the pipeline repository, immutable commit, workflow policy, and build provenance. Pull requests are limited to `contents: read`; merge queues are denied. The token is not ambient. |
+| `GITHUB_TOKEN` | Supported static uses receive one short-lived token for the event repository and compiler-resolved permissions when the root workflow declares an explicit non-empty permission map. Buildkite verifies the pipeline repository, immutable commit, workflow policy, and build provenance. Pull requests are limited to `contents: read`; merge queues are denied. The token is not ambient. |
 | Cache token | When caching is configured, every JavaScript or Docker action lifecycle receives a fresh job-bound token. This includes compatible clients such as `actions/setup-go`, not only `actions/cache`. Shell steps do not receive it. |
 | Ordinary workflow secrets | Rejected by production admission. |
 | GitHub-compatible OIDC | Unsupported. |
 
 An action that receives a credential can use or exfiltrate it. It can also export `GITHUB_TOKEN` to later steps through `GITHUB_ENV`. Log masking reduces accidental disclosure, but it is not access control and does not catch transformed values.
 
-Workflow token issuance requires an organization feature and a default-off pipeline setting. Buildkite reads the top-level permission policy from the workflow at the build's immutable commit. Omitted permissions resolve to exactly `contents: read`; write permissions require an explicit top-level map. Explicit empty permissions, scopes resolving only to `none`, job-level permission maps, and reusable-workflow jobs cannot receive a token. It denies incomplete or cyclic trigger and rebuild provenance. Pull-request ancestry retains a `contents: read` ceiling, and merge-queue ancestry is denied.
+Workflow token issuance requires an organization feature and a default-off pipeline setting. Buildkite reads the root top-level permission policy and each local reusable-workflow caller edge from the pipeline repository at the build's immutable commit. Compiler-owned pipeline metadata binds that chain and the effective permissions to the exact job-plan digest. Buildkite removes the metadata before the job runs. It denies incomplete or cyclic trigger and rebuild provenance. Pull-request ancestry retains a `contents: read` ceiling, and merge-queue ancestry is denied.
 
 For other builds, a user with permission to create a build at an arbitrary commit may select code that requests the workflow's allowed permissions. Enable write tokens only when those build-creation paths and branch builds are trusted.
 

--- a/internal/buildkite/pipeline.go
+++ b/internal/buildkite/pipeline.go
@@ -11,6 +11,8 @@ import (
 	"sort"
 	"strings"
 	"unicode/utf8"
+
+	"github.com/buildkite/buildkite-gha/internal/plan"
 )
 
 const planDirectory = ".buildkite-gha/plans"
@@ -36,7 +38,7 @@ const MinimumMiseVersion = "2026.5.12"
 var identifierPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,255}$`)
 var digestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
 var workflowFilenamePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*\.ya?ml$`)
-var permissionNamePattern = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+var workflowJobIDPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_-]{0,254}$`)
 var runtimeImagePattern = regexp.MustCompile(`^[a-z0-9]+(?:[._-][a-z0-9]+)*(?:/[a-z0-9]+(?:[._-][a-z0-9]+)*)+@sha256:[0-9a-f]{64}$`)
 var uuidPattern = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 
@@ -337,7 +339,10 @@ func emitWorkflow(out *bytes.Buffer, pipeline Pipeline, workflow preparedWorkflo
 		if job.RequiresMise || job.Authorization != nil {
 			_, _ = fmt.Fprintf(out, "%senv:\n", attributeIndent)
 			if job.Authorization != nil {
-				authorization := encodeJobAuthorization(job)
+				authorization, err := encodeJobAuthorization(job)
+				if err != nil {
+					return fmt.Errorf("encode job %q authorization: %w", job.Key, err)
+				}
 				_, _ = fmt.Fprintf(out, "%s  BUILDKITE_GHA_JOB_AUTHORIZATION: %s\n", attributeIndent, yamlScalar(string(authorization)))
 			}
 		}
@@ -561,25 +566,35 @@ func validateJobAuthorization(authorization *JobAuthorization) error {
 		if len(workflowJob.Workflow) > 255 || !workflowFilenamePattern.MatchString(workflowJob.Workflow) {
 			return fmt.Errorf("job authorization has invalid workflow filename %q", workflowJob.Workflow)
 		}
-		if !identifierPattern.MatchString(workflowJob.Job) {
+		if !workflowJobIDPattern.MatchString(workflowJob.Job) {
 			return fmt.Errorf("job authorization has invalid workflow job %q", workflowJob.Job)
 		}
 	}
-	if len(authorization.Permissions) == 0 {
-		return fmt.Errorf("job authorization requires effective permissions")
-	}
+	activePermissions := activeJobAuthorizationPermissions(authorization.Permissions)
 	for name, access := range authorization.Permissions {
-		if !permissionNamePattern.MatchString(name) || len(name) > 255 {
-			return fmt.Errorf("job authorization has invalid permission %q", name)
+		if access == "none" {
+			if err := plan.ValidateGitHubWorkflowAccessTokenPermissions(map[string]string{name: "read"}); err != nil {
+				return fmt.Errorf("job authorization: %w", err)
+			}
 		}
-		if access != "read" && access != "write" && access != "none" {
-			return fmt.Errorf("job authorization permission %q has invalid access %q", name, access)
-		}
+	}
+	if err := plan.ValidateGitHubWorkflowAccessTokenPermissions(activePermissions); err != nil {
+		return fmt.Errorf("job authorization: %w", err)
 	}
 	return nil
 }
 
-func encodeJobAuthorization(job Job) []byte {
+func activeJobAuthorizationPermissions(permissions map[string]string) map[string]string {
+	active := make(map[string]string, len(permissions))
+	for name, access := range permissions {
+		if access != "none" {
+			active[name] = access
+		}
+	}
+	return active
+}
+
+func encodeJobAuthorization(job Job) ([]byte, error) {
 	payload := struct {
 		Schema       string            `json:"schema"`
 		PlanDigest   string            `json:"plan_digest"`
@@ -589,10 +604,9 @@ func encodeJobAuthorization(job Job) []byte {
 		Schema:       jobAuthorizationSchema,
 		PlanDigest:   job.PlanDigest,
 		WorkflowJobs: job.Authorization.WorkflowJobs,
-		Permissions:  job.Authorization.Permissions,
+		Permissions:  activeJobAuthorizationPermissions(job.Authorization.Permissions),
 	}
-	encoded, _ := json.Marshal(payload)
-	return encoded
+	return json.Marshal(payload)
 }
 
 func validStepKey(key string) bool {

--- a/internal/buildkite/pipeline.go
+++ b/internal/buildkite/pipeline.go
@@ -19,6 +19,7 @@ const maxConcurrencyGroupLength = 200
 const runtimeCacheName = "buildkite-gha"
 const runtimeCacheRoot = "/cache/bkcache/buildkite-gha"
 const darwinRuntimeCacheRoot = "/tmp/bkcache/buildkite-gha"
+const jobAuthorizationSchema = "buildkite-gha/job-authorization/v1"
 
 // ContinueOnErrorExitStatus is reserved for a workflow failure that the job's
 // immutable plan explicitly allows Buildkite to soft-fail.
@@ -34,6 +35,8 @@ const MinimumMiseVersion = "2026.5.12"
 
 var identifierPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,255}$`)
 var digestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+var workflowFilenamePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*\.ya?ml$`)
+var permissionNamePattern = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
 var runtimeImagePattern = regexp.MustCompile(`^[a-z0-9]+(?:[._-][a-z0-9]+)*(?:/[a-z0-9]+(?:[._-][a-z0-9]+)*)+@sha256:[0-9a-f]{64}$`)
 var uuidPattern = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 
@@ -103,6 +106,20 @@ type Job struct {
 	SoftFail           bool
 	ConcurrencyGroup   string
 	Concurrency        int
+	Authorization      *JobAuthorization
+}
+
+// JobAuthorization is compiler-owned authorization metadata for one concrete
+// job that statically requires GITHUB_TOKEN.
+type JobAuthorization struct {
+	WorkflowJobs []WorkflowJob
+	Permissions  map[string]string
+}
+
+// WorkflowJob identifies one workflow/job edge in a concrete invocation chain.
+type WorkflowJob struct {
+	Workflow string `json:"workflow"`
+	Job      string `json:"job"`
 }
 
 // PlanPath returns the fixed local path for a content-addressed job plan.
@@ -317,8 +334,14 @@ func emitWorkflow(out *bytes.Buffer, pipeline Pipeline, workflow preparedWorkflo
 		if job.SoftFail {
 			_, _ = fmt.Fprintf(out, "%ssoft_fail:\n%s  - exit_status: %d\n", attributeIndent, attributeIndent, ContinueOnErrorExitStatus)
 		}
-		if job.RequiresMise {
+		if job.RequiresMise || job.Authorization != nil {
 			_, _ = fmt.Fprintf(out, "%senv:\n", attributeIndent)
+			if job.Authorization != nil {
+				authorization := encodeJobAuthorization(job)
+				_, _ = fmt.Fprintf(out, "%s  BUILDKITE_GHA_JOB_AUTHORIZATION: %s\n", attributeIndent, yamlScalar(string(authorization)))
+			}
+		}
+		if job.RequiresMise {
 			_, _ = fmt.Fprintf(out, "%s  BUILDKITE_GHA_MISE_DATA_DIR: %s\n", attributeIndent, yamlScalar(MiseDataDir(platform)))
 		}
 		if job.Concurrency != 0 {
@@ -507,6 +530,9 @@ func validateJob(compilerStep string, job Job) error {
 	if _, err := PlanPath(job.PlanDigest); err != nil {
 		return fmt.Errorf("job %q: %w", job.Key, err)
 	}
+	if err := validateJobAuthorization(job.Authorization); err != nil {
+		return fmt.Errorf("job %q: %w", job.Key, err)
+	}
 	if job.Concurrency < 0 {
 		return fmt.Errorf("job %q has invalid concurrency %d", job.Key, job.Concurrency)
 	}
@@ -522,6 +548,51 @@ func validateJob(compilerStep string, job Job) error {
 		}
 	}
 	return nil
+}
+
+func validateJobAuthorization(authorization *JobAuthorization) error {
+	if authorization == nil {
+		return nil
+	}
+	if len(authorization.WorkflowJobs) == 0 || len(authorization.WorkflowJobs) > 5 {
+		return fmt.Errorf("job authorization workflow chain must contain between 1 and 5 entries")
+	}
+	for _, workflowJob := range authorization.WorkflowJobs {
+		if len(workflowJob.Workflow) > 255 || !workflowFilenamePattern.MatchString(workflowJob.Workflow) {
+			return fmt.Errorf("job authorization has invalid workflow filename %q", workflowJob.Workflow)
+		}
+		if !identifierPattern.MatchString(workflowJob.Job) {
+			return fmt.Errorf("job authorization has invalid workflow job %q", workflowJob.Job)
+		}
+	}
+	if len(authorization.Permissions) == 0 {
+		return fmt.Errorf("job authorization requires effective permissions")
+	}
+	for name, access := range authorization.Permissions {
+		if !permissionNamePattern.MatchString(name) || len(name) > 255 {
+			return fmt.Errorf("job authorization has invalid permission %q", name)
+		}
+		if access != "read" && access != "write" && access != "none" {
+			return fmt.Errorf("job authorization permission %q has invalid access %q", name, access)
+		}
+	}
+	return nil
+}
+
+func encodeJobAuthorization(job Job) []byte {
+	payload := struct {
+		Schema       string            `json:"schema"`
+		PlanDigest   string            `json:"plan_digest"`
+		WorkflowJobs []WorkflowJob     `json:"workflow_jobs"`
+		Permissions  map[string]string `json:"permissions"`
+	}{
+		Schema:       jobAuthorizationSchema,
+		PlanDigest:   job.PlanDigest,
+		WorkflowJobs: job.Authorization.WorkflowJobs,
+		Permissions:  job.Authorization.Permissions,
+	}
+	encoded, _ := json.Marshal(payload)
+	return encoded
 }
 
 func validStepKey(key string) bool {

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -501,7 +501,7 @@ func TestEmitJobAuthorization(t *testing.T) {
 				Key: "authorized", Label: "Authorized", PlanDigest: planDigest,
 				Authorization: &JobAuthorization{
 					WorkflowJobs: []WorkflowJob{{Workflow: "caller.yml", Job: "call"}, {Workflow: "leaf.yml", Job: "run"}},
-					Permissions:  map[string]string{"pull_requests": "write", "contents": "read"},
+					Permissions:  map[string]string{"pull_requests": "write", "issues": "none", "contents": "read"},
 				},
 			},
 			{Key: "tokenless", Label: "Tokenless", PlanDigest: testDigest("tokenless plan")},
@@ -667,6 +667,9 @@ func TestEmitRejectsInvalidGraphsAndIdentifiers(t *testing.T) {
 		{name: "UUID compiler", in: Pipeline{CompilerStep: "123e4567-e89b-12d3-a456-426614174000", Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: digest}}}, want: "invalid compiler step key"},
 		{name: "UUID key", in: Pipeline{CompilerStep: "compiler", Jobs: []Job{{Key: "123e4567-e89b-12d3-a456-426614174000", Label: "One", Queue: "queue", PlanDigest: digest}}}, want: "invalid generated step key"},
 		{name: "bad digest", in: Pipeline{CompilerStep: "compiler", Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: "sha256:nope"}}}, want: "invalid plan digest"},
+		{name: "invalid authorization job", in: Pipeline{CompilerStep: "compiler", DistributionDigest: digest, Jobs: []Job{{Key: "one", Label: "One", PlanDigest: digest, Authorization: &JobAuthorization{WorkflowJobs: []WorkflowJob{{Workflow: "ci.yml", Job: "1invalid"}}, Permissions: map[string]string{"contents": "read"}}}}}, want: "invalid workflow job"},
+		{name: "inactive authorization", in: Pipeline{CompilerStep: "compiler", DistributionDigest: digest, Jobs: []Job{{Key: "one", Label: "One", PlanDigest: digest, Authorization: &JobAuthorization{WorkflowJobs: []WorkflowJob{{Workflow: "ci.yml", Job: "valid"}}, Permissions: map[string]string{"contents": "none"}}}}}, want: "non-empty bounded permission set"},
+		{name: "unsupported authorization permission", in: Pipeline{CompilerStep: "compiler", DistributionDigest: digest, Jobs: []Job{{Key: "one", Label: "One", PlanDigest: digest, Authorization: &JobAuthorization{WorkflowJobs: []WorkflowJob{{Workflow: "ci.yml", Job: "valid"}}, Permissions: map[string]string{"models": "read"}}}}}, want: "unsupported permission"},
 		{name: "mutable runtime image", in: Pipeline{CompilerStep: "compiler", DistributionDigest: digest, RuntimeImage: "buildkite/agent-base:ubuntu-jammy-hosted-toolchains", Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: digest}}}, want: "immutable registry sha256 reference"},
 		{name: "partial concurrency", in: Pipeline{CompilerStep: "compiler", Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: digest, Concurrency: 2}}}, want: "concurrency and concurrency group together"},
 		{name: "empty workflow concurrency group", in: Pipeline{CompilerStep: "compiler", DistributionDigest: digest, ConcurrencyGate: &ConcurrencyGate{Queue: "queue"}, Jobs: []Job{{Key: "one", Label: "One", Queue: "queue", PlanDigest: digest}}}, want: "invalid workflow concurrency group"},

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -491,6 +491,46 @@ func TestEmitActionRuntimeRequirement(t *testing.T) {
 	}
 }
 
+func TestEmitJobAuthorization(t *testing.T) {
+	planDigest := testDigest("authorized plan")
+	output, err := Emit(Pipeline{
+		CompilerStep:       "importer",
+		DistributionDigest: testDigest("distribution"),
+		Jobs: []Job{
+			{
+				Key: "authorized", Label: "Authorized", PlanDigest: planDigest,
+				Authorization: &JobAuthorization{
+					WorkflowJobs: []WorkflowJob{{Workflow: "caller.yml", Job: "call"}, {Workflow: "leaf.yml", Job: "run"}},
+					Permissions:  map[string]string{"pull_requests": "write", "contents": "read"},
+				},
+			},
+			{Key: "tokenless", Label: "Tokenless", PlanDigest: testDigest("tokenless plan")},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document struct {
+		Steps []struct {
+			Key string            `yaml:"key"`
+			Env map[string]string `yaml:"env"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(output, &document); err != nil {
+		t.Fatal(err)
+	}
+	if len(document.Steps) != 2 {
+		t.Fatalf("steps = %#v", document.Steps)
+	}
+	want := `{"schema":"buildkite-gha/job-authorization/v1","plan_digest":"` + planDigest + `","workflow_jobs":[{"workflow":"caller.yml","job":"call"},{"workflow":"leaf.yml","job":"run"}],"permissions":{"contents":"read","pull_requests":"write"}}`
+	if got := document.Steps[0].Env["BUILDKITE_GHA_JOB_AUTHORIZATION"]; got != want {
+		t.Fatalf("authorization = %q, want canonical %q", got, want)
+	}
+	if len(document.Steps[1].Env) != 0 {
+		t.Fatalf("tokenless environment = %#v", document.Steps[1].Env)
+	}
+}
+
 func TestEmitDarwinActionRuntimeUsesNativePlatformCache(t *testing.T) {
 	output, err := Emit(Pipeline{
 		CompilerStep: "importer",

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -100,6 +100,7 @@ const (
 var runnerQueuePattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,255}$`)
 var runnerImagePattern = regexp.MustCompile(`^[a-z0-9]+(?:[._-][a-z0-9]+)*(?:/[a-z0-9]+(?:[._-][a-z0-9]+)*)+@sha256:[0-9a-f]{64}$`)
 var stableVersionPattern = regexp.MustCompile(`^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$`)
+var reusableMatrixNamespacePattern = regexp.MustCompile(`^[0-9a-f]{12}$`)
 
 var pluginReleaseBaseURL = "https://github.com/buildkite/buildkite-gha/releases/download"
 var pluginHTTPClient = securePluginHTTPClient()
@@ -2194,11 +2195,33 @@ func validateWorkflowTokenAuthorization(artifact compiler.PlanArtifact) error {
 		return err
 	}
 	last := authorization.WorkflowJobs[len(authorization.WorkflowJobs)-1]
-	logicalJob := artifact.Job.Workflow.LogicalJobID
-	if last.Workflow != leafFilename || (last.Job != logicalJob && !strings.HasSuffix(logicalJob, "."+last.Job)) {
+	logicalJobID, err := workflowJobChainLogicalID(authorization.WorkflowJobs)
+	if err != nil {
+		return err
+	}
+	if last.Workflow != leafFilename || logicalJobID != artifact.Job.Workflow.LogicalJobID {
 		return fmt.Errorf("compiler-verified workflow invocation chain does not match the concrete job plan")
 	}
 	return nil
+}
+
+func workflowJobChainLogicalID(workflowJobs []compiler.WorkflowJob) (string, error) {
+	components := make([]string, len(workflowJobs))
+	for i, workflowJob := range workflowJobs {
+		component := workflowJob.LogicalIDComponent
+		if i == len(workflowJobs)-1 {
+			if component != workflowJob.Job {
+				return "", fmt.Errorf("compiler-verified workflow invocation chain has an invalid concrete job identity")
+			}
+		} else if component != workflowJob.Job {
+			suffix, ok := strings.CutPrefix(component, workflowJob.Job+"-")
+			if !ok || !reusableMatrixNamespacePattern.MatchString(suffix) {
+				return "", fmt.Errorf("compiler-verified workflow invocation chain has an invalid caller job identity")
+			}
+		}
+		components[i] = component
+	}
+	return strings.Join(components, "."), nil
 }
 
 func irUsesActions(ir compiler.IR) bool {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -2132,11 +2132,15 @@ func validateUnprivilegedBundle(bundle compiler.Bundle) error {
 				continue
 			}
 			if capability == "provider-token-write" {
-				filename, filenameErr := plan.GitHubWorkflowPolicyFilename(artifact.Job.Workflow.Path)
-				if artifact.Job.GitHubToken == nil || !slices.Equal(artifact.Authorization.ProviderTokenWriteCapabilitySources, []string{"effective-permissions"}) || filenameErr != nil || artifact.Authorization.WorkflowTokenPolicyFilename == "" || artifact.Authorization.WorkflowTokenPolicyFilename != filename {
+				authorizationErr := validateWorkflowTokenAuthorization(artifact)
+				if artifact.Job.GitHubToken == nil || !slices.Equal(artifact.Authorization.ProviderTokenWriteCapabilitySources, []string{"effective-permissions"}) || authorizationErr != nil {
 					reason := bundle.IR.Workflow.WorkflowTokenPolicyDiagnostic
 					if reason == "" {
-						reason = "compiler-verified workflow policy evidence is missing or does not match the job plan"
+						if authorizationErr != nil {
+							reason = authorizationErr.Error()
+						} else {
+							reason = "compiler-verified workflow policy evidence is missing or does not match the job plan"
+						}
 					}
 					addFailure(artifact, "provider token write capability lacks compiler-verified workflow policy", fmt.Errorf("job %q requires provider-token-write without a compiler-verified workflow policy: %s", artifact.Job.Workflow.LogicalJobID, reason))
 				}
@@ -2160,6 +2164,41 @@ func validateUnprivilegedBundle(bundle compiler.Bundle) error {
 		}
 	}
 	return errors.Join(diagnostics...)
+}
+
+func validateWorkflowTokenAuthorization(artifact compiler.PlanArtifact) error {
+	authorization := artifact.Authorization
+	if artifact.Job.GitHubToken == nil {
+		return fmt.Errorf("compiler-verified workflow token permissions are missing")
+	}
+	if err := plan.ValidateGitHubWorkflowAccessTokenPermissions(artifact.Job.GitHubToken.Permissions); err != nil {
+		return err
+	}
+	if len(authorization.WorkflowJobs) == 0 || len(authorization.WorkflowJobs) > 5 {
+		return fmt.Errorf("compiler-verified workflow invocation chain is missing or exceeds 5 entries")
+	}
+	for _, workflowJob := range authorization.WorkflowJobs {
+		if err := plan.ValidateGitHubWorkflowPolicyFilename(workflowJob.Workflow); err != nil {
+			return err
+		}
+		if workflowJob.Job == "" {
+			return fmt.Errorf("compiler-verified workflow invocation chain contains an empty job")
+		}
+	}
+	first := authorization.WorkflowJobs[0]
+	if authorization.WorkflowTokenPolicyFilename == "" || authorization.WorkflowTokenPolicyFilename != first.Workflow {
+		return fmt.Errorf("compiler-verified root workflow policy does not match the invocation chain")
+	}
+	leafFilename, err := plan.GitHubWorkflowPolicyFilename(artifact.Job.Workflow.Path)
+	if err != nil {
+		return err
+	}
+	last := authorization.WorkflowJobs[len(authorization.WorkflowJobs)-1]
+	logicalJob := artifact.Job.Workflow.LogicalJobID
+	if last.Workflow != leafFilename || (last.Job != logicalJob && !strings.HasSuffix(logicalJob, "."+last.Job)) {
+		return fmt.Errorf("compiler-verified workflow invocation chain does not match the concrete job plan")
+	}
+	return nil
 }
 
 func irUsesActions(ir compiler.IR) bool {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -4825,17 +4825,34 @@ func TestUnprivilegedUploadAdmitsOnlyCompilerVerifiedWorkflowToken(t *testing.T)
 	}
 	for _, test := range []struct {
 		name          string
+		workflow      plan.Workflow
+		permissions   map[string]string
 		authorization compiler.PlanAuthorization
 		wantError     bool
 	}{
-		{name: "verified policy", authorization: compiler.PlanAuthorization{ProviderTokenWriteCapabilitySources: []string{"effective-permissions"}, WorkflowTokenPolicyFilename: "comment.yml"}},
+		{name: "verified policy", authorization: compiler.PlanAuthorization{ProviderTokenWriteCapabilitySources: []string{"effective-permissions"}, WorkflowTokenPolicyFilename: "comment.yml", WorkflowJobs: []compiler.WorkflowJob{{Workflow: "comment.yml", Job: "comment"}}}},
+		{
+			name: "verified reusable chain", workflow: plan.Workflow{Path: "./.github/workflows/leaf.yml", LogicalJobID: "call.comment"},
+			authorization: compiler.PlanAuthorization{
+				ProviderTokenWriteCapabilitySources: []string{"effective-permissions"}, WorkflowTokenPolicyFilename: "comment.yml",
+				WorkflowJobs: []compiler.WorkflowJob{{Workflow: "comment.yml", Job: "call"}, {Workflow: "leaf.yml", Job: "comment"}},
+			},
+		},
 		{name: "missing provenance", wantError: true},
 		{name: "missing policy", authorization: compiler.PlanAuthorization{ProviderTokenWriteCapabilitySources: []string{"effective-permissions"}}, wantError: true},
-		{name: "mismatched policy", authorization: compiler.PlanAuthorization{ProviderTokenWriteCapabilitySources: []string{"effective-permissions"}, WorkflowTokenPolicyFilename: "other.yml"}, wantError: true},
-		{name: "broadened provenance", authorization: compiler.PlanAuthorization{ProviderTokenWriteCapabilitySources: []string{"effective-permissions", "step-input"}, WorkflowTokenPolicyFilename: "comment.yml"}, wantError: true},
+		{name: "mismatched policy", authorization: compiler.PlanAuthorization{ProviderTokenWriteCapabilitySources: []string{"effective-permissions"}, WorkflowTokenPolicyFilename: "other.yml", WorkflowJobs: []compiler.WorkflowJob{{Workflow: "comment.yml", Job: "comment"}}}, wantError: true},
+		{name: "broadened provenance", authorization: compiler.PlanAuthorization{ProviderTokenWriteCapabilitySources: []string{"effective-permissions", "step-input"}, WorkflowTokenPolicyFilename: "comment.yml", WorkflowJobs: []compiler.WorkflowJob{{Workflow: "comment.yml", Job: "comment"}}}, wantError: true},
+		{name: "unsupported effective permission", permissions: map[string]string{"models": "read"}, authorization: compiler.PlanAuthorization{ProviderTokenWriteCapabilitySources: []string{"effective-permissions"}, WorkflowTokenPolicyFilename: "comment.yml", WorkflowJobs: []compiler.WorkflowJob{{Workflow: "comment.yml", Job: "comment"}}}, wantError: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: job, Authorization: test.authorization}}}
+			configuredJob := job
+			if test.workflow.Path != "" {
+				configuredJob.Workflow = test.workflow
+			}
+			if test.permissions != nil {
+				configuredJob.GitHubToken = &plan.GitHubToken{Permissions: test.permissions}
+			}
+			bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: configuredJob, Authorization: test.authorization}}}
 			err := validateUnprivilegedBundle(bundle)
 			if test.wantError && (err == nil || !strings.Contains(err.Error(), "workflow policy")) {
 				t.Fatalf("validateUnprivilegedBundle() error = %v", err)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -4830,19 +4830,33 @@ func TestUnprivilegedUploadAdmitsOnlyCompilerVerifiedWorkflowToken(t *testing.T)
 		authorization compiler.PlanAuthorization
 		wantError     bool
 	}{
-		{name: "verified policy", authorization: compiler.PlanAuthorization{ProviderTokenWriteCapabilitySources: []string{"effective-permissions"}, WorkflowTokenPolicyFilename: "comment.yml", WorkflowJobs: []compiler.WorkflowJob{{Workflow: "comment.yml", Job: "comment"}}}},
+		{name: "verified policy", authorization: compiler.PlanAuthorization{ProviderTokenWriteCapabilitySources: []string{"effective-permissions"}, WorkflowTokenPolicyFilename: "comment.yml", WorkflowJobs: []compiler.WorkflowJob{{Workflow: "comment.yml", Job: "comment", LogicalIDComponent: "comment"}}}},
 		{
 			name: "verified reusable chain", workflow: plan.Workflow{Path: "./.github/workflows/leaf.yml", LogicalJobID: "call.comment"},
 			authorization: compiler.PlanAuthorization{
 				ProviderTokenWriteCapabilitySources: []string{"effective-permissions"}, WorkflowTokenPolicyFilename: "comment.yml",
-				WorkflowJobs: []compiler.WorkflowJob{{Workflow: "comment.yml", Job: "call"}, {Workflow: "leaf.yml", Job: "comment"}},
+				WorkflowJobs: []compiler.WorkflowJob{{Workflow: "comment.yml", Job: "call", LogicalIDComponent: "call"}, {Workflow: "leaf.yml", Job: "comment", LogicalIDComponent: "comment"}},
+			},
+		},
+		{
+			name: "verified reusable matrix chain", workflow: plan.Workflow{Path: "./.github/workflows/leaf.yml", LogicalJobID: "call-deadbeef1234.comment"},
+			authorization: compiler.PlanAuthorization{
+				ProviderTokenWriteCapabilitySources: []string{"effective-permissions"}, WorkflowTokenPolicyFilename: "comment.yml",
+				WorkflowJobs: []compiler.WorkflowJob{{Workflow: "comment.yml", Job: "call", LogicalIDComponent: "call-deadbeef1234"}, {Workflow: "leaf.yml", Job: "comment", LogicalIDComponent: "comment"}},
 			},
 		},
 		{name: "missing provenance", wantError: true},
 		{name: "missing policy", authorization: compiler.PlanAuthorization{ProviderTokenWriteCapabilitySources: []string{"effective-permissions"}}, wantError: true},
-		{name: "mismatched policy", authorization: compiler.PlanAuthorization{ProviderTokenWriteCapabilitySources: []string{"effective-permissions"}, WorkflowTokenPolicyFilename: "other.yml", WorkflowJobs: []compiler.WorkflowJob{{Workflow: "comment.yml", Job: "comment"}}}, wantError: true},
-		{name: "broadened provenance", authorization: compiler.PlanAuthorization{ProviderTokenWriteCapabilitySources: []string{"effective-permissions", "step-input"}, WorkflowTokenPolicyFilename: "comment.yml", WorkflowJobs: []compiler.WorkflowJob{{Workflow: "comment.yml", Job: "comment"}}}, wantError: true},
-		{name: "unsupported effective permission", permissions: map[string]string{"models": "read"}, authorization: compiler.PlanAuthorization{ProviderTokenWriteCapabilitySources: []string{"effective-permissions"}, WorkflowTokenPolicyFilename: "comment.yml", WorkflowJobs: []compiler.WorkflowJob{{Workflow: "comment.yml", Job: "comment"}}}, wantError: true},
+		{name: "mismatched policy", authorization: compiler.PlanAuthorization{ProviderTokenWriteCapabilitySources: []string{"effective-permissions"}, WorkflowTokenPolicyFilename: "other.yml", WorkflowJobs: []compiler.WorkflowJob{{Workflow: "comment.yml", Job: "comment", LogicalIDComponent: "comment"}}}, wantError: true},
+		{name: "broadened provenance", authorization: compiler.PlanAuthorization{ProviderTokenWriteCapabilitySources: []string{"effective-permissions", "step-input"}, WorkflowTokenPolicyFilename: "comment.yml", WorkflowJobs: []compiler.WorkflowJob{{Workflow: "comment.yml", Job: "comment", LogicalIDComponent: "comment"}}}, wantError: true},
+		{name: "unsupported effective permission", permissions: map[string]string{"models": "read"}, authorization: compiler.PlanAuthorization{ProviderTokenWriteCapabilitySources: []string{"effective-permissions"}, WorkflowTokenPolicyFilename: "comment.yml", WorkflowJobs: []compiler.WorkflowJob{{Workflow: "comment.yml", Job: "comment", LogicalIDComponent: "comment"}}}, wantError: true},
+		{
+			name: "logical ID suffix collision", workflow: plan.Workflow{Path: "./.github/workflows/leaf.yml", LogicalJobID: "unrelated.call.comment"}, wantError: true,
+			authorization: compiler.PlanAuthorization{
+				ProviderTokenWriteCapabilitySources: []string{"effective-permissions"}, WorkflowTokenPolicyFilename: "comment.yml",
+				WorkflowJobs: []compiler.WorkflowJob{{Workflow: "comment.yml", Job: "call", LogicalIDComponent: "call"}, {Workflow: "leaf.yml", Job: "comment", LogicalIDComponent: "comment"}},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			configuredJob := job

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2330,7 +2330,7 @@ func TestValidateHostedProfileRejectsProtectedCapabilityAfterCompile(t *testing.
 	}
 }
 
-func TestValidateHostedProfileAdmitsImplicitReadOnlyWorkflowToken(t *testing.T) {
+func TestValidateHostedProfileRejectsWorkflowTokenWithoutExplicitRootPermissions(t *testing.T) {
 	root := t.TempDir()
 	workflowPath := filepath.Join(root, ".github", "workflows", "token.yml")
 	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
@@ -2342,14 +2342,14 @@ func TestValidateHostedProfileAdmitsImplicitReadOnlyWorkflowToken(t *testing.T) 
 	}
 	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
 	var stdout, stderr bytes.Buffer
-	if code := Run([]string{"validate", "--profile", "hosted", "--format", "json", "--event-path", eventPath, workflowPath}, &stdout, &stderr, "dev"); code != 0 {
-		t.Fatalf("Run() code = %d, stderr = %q", code, stderr.String())
+	if code := Run([]string{"validate", "--profile", "hosted", "--format", "json", "--event-path", eventPath, workflowPath}, &stdout, &stderr, "dev"); code != 1 {
+		t.Fatalf("Run() code = %d, want 1; stderr = %q", code, stderr.String())
 	}
 	var report compatibility.ProcessingReport
 	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 		t.Fatal(err)
 	}
-	if report.Result != "admitted" || report.Compile.Result != "compilable" || report.Admission.Result != "admitted" || len(report.Diagnostics) != 0 {
+	if report.Result != "not-admitted" || report.Compile.Result != "compilable" || report.Admission.Result != "not-admitted" || len(report.Diagnostics) != 1 || report.Diagnostics[0].Code != "E_PROFILE" || !strings.Contains(report.Diagnostics[0].Message, "compiler-verified workflow policy") {
 		t.Fatalf("profile report = %#v", report)
 	}
 }

--- a/internal/compiler/bundle.go
+++ b/internal/compiler/bundle.go
@@ -29,6 +29,14 @@ type PlanAuthorization struct {
 	ProviderTokenReadCapabilitySources  []string
 	ProviderTokenWriteCapabilitySources []string
 	WorkflowTokenPolicyFilename         string
+	WorkflowJobs                        []WorkflowJob
+}
+
+// WorkflowJob identifies one exact workflow/job edge in a concrete reusable
+// workflow invocation chain.
+type WorkflowJob struct {
+	Workflow string
+	Job      string
 }
 
 // Bundle is the complete deterministic output of static compilation.
@@ -138,6 +146,16 @@ func GenerateBundlePipeline(bundle Bundle, compilerDistributionDigest, compilerS
 			Dependencies:       append([]string(nil), ir.Jobs[i].Needs...),
 			RequiresMise:       job.NeedsMise(),
 			SoftFail:           job.ContinueOnError,
+		}
+		if job.GitHubToken != nil {
+			workflowJobs := make([]buildkitepipeline.WorkflowJob, len(artifact.Authorization.WorkflowJobs))
+			for j, workflowJob := range artifact.Authorization.WorkflowJobs {
+				workflowJobs[j] = buildkitepipeline.WorkflowJob{Workflow: workflowJob.Workflow, Job: workflowJob.Job}
+			}
+			jobs[i].Authorization = &buildkitepipeline.JobAuthorization{
+				WorkflowJobs: workflowJobs,
+				Permissions:  cloneMap(job.GitHubToken.Permissions),
+			}
 		}
 		if ir.Jobs[i].Platform == PlatformLinuxAMD64 {
 			jobs[i].RuntimeImage = ir.Jobs[i].RuntimeImage

--- a/internal/compiler/bundle.go
+++ b/internal/compiler/bundle.go
@@ -33,10 +33,13 @@ type PlanAuthorization struct {
 }
 
 // WorkflowJob identifies one exact workflow/job edge in a concrete reusable
-// workflow invocation chain.
+// workflow invocation chain. LogicalIDComponent retains the compiler's matrix-
+// qualified namespace component for exact same-process admission checks; only
+// Workflow and Job enter the pipeline manifest.
 type WorkflowJob struct {
-	Workflow string
-	Job      string
+	Workflow           string
+	Job                string
+	LogicalIDComponent string
 }
 
 // Bundle is the complete deterministic output of static compilation.

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -944,7 +944,7 @@ func TestCompileBundleGitHubTokenUsesRestrictedDefaultPermissions(t *testing.T) 
 	if job.Job.GitHubToken == nil || !reflect.DeepEqual(job.Job.GitHubToken.Permissions, map[string]string{"contents": "read"}) {
 		t.Fatalf("default GitHub workflow token plan = %#v", job.Job)
 	}
-	if !reflect.DeepEqual(job.Authorization.ProviderTokenWriteCapabilitySources, []string{"effective-permissions"}) || job.Authorization.WorkflowTokenPolicyFilename != "workflow.yml" {
+	if !reflect.DeepEqual(job.Authorization.ProviderTokenWriteCapabilitySources, []string{"effective-permissions"}) || job.Authorization.WorkflowTokenPolicyFilename != "" {
 		t.Fatalf("default token authorization = %#v", job.Authorization)
 	}
 }

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -779,6 +779,161 @@ jobs:
 	}
 }
 
+func TestCompileBundleEmitsPerConcreteJobAuthorization(t *testing.T) {
+	repository := t.TempDir()
+	caller := writeWorkflow(t, repository, "caller.yml", `on: push
+permissions:
+  contents: read
+jobs:
+  direct:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo '${{ secrets.GITHUB_TOKEN }}'
+  delegated:
+    uses: ./.github/workflows/leaf.yml
+  tokenless:
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+`)
+	writeWorkflow(t, repository, "leaf.yml", `on: workflow_call
+jobs:
+  concrete:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo '${{ secrets.GITHUB_TOKEN }}'
+`)
+	bundle, err := CompileBundle(caller, readFile(t, caller), pushEvent(t), "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	jobs := make(map[string]buildkitepipeline.Job, len(bundle.GeneratedWorkflow.Jobs))
+	for _, job := range bundle.GeneratedWorkflow.Jobs {
+		jobs[job.Key] = job
+	}
+	for _, artifact := range bundle.Plans {
+		if artifact.Job.GitHubToken != nil && artifact.Authorization.WorkflowTokenPolicyFilename != "caller.yml" {
+			t.Fatalf("token job %q policy evidence = %#v", artifact.Job.Workflow.LogicalJobID, artifact.Authorization)
+		}
+	}
+	direct := jobs["gha-direct"]
+	if direct.Authorization == nil || !reflect.DeepEqual(direct.Authorization.WorkflowJobs, []buildkitepipeline.WorkflowJob{{Workflow: "caller.yml", Job: "direct"}}) {
+		t.Fatalf("direct sibling authorization = %#v", direct.Authorization)
+	}
+	delegated := jobs["gha-delegated-concrete"]
+	if delegated.Authorization == nil || !reflect.DeepEqual(delegated.Authorization.WorkflowJobs, []buildkitepipeline.WorkflowJob{{Workflow: "caller.yml", Job: "delegated"}, {Workflow: "leaf.yml", Job: "concrete"}}) {
+		t.Fatalf("delegated authorization = %#v", delegated.Authorization)
+	}
+	if jobs["gha-tokenless"].Authorization != nil || strings.Count(string(bundle.Pipeline), "BUILDKITE_GHA_JOB_AUTHORIZATION") != 2 {
+		t.Fatalf("tokenless job received metadata or token job metadata is missing:\n%s", bundle.Pipeline)
+	}
+}
+
+func TestCompileBundleEmitsDistinctReusableCallerAuthorizations(t *testing.T) {
+	repository := t.TempDir()
+	caller := writeWorkflow(t, repository, "caller.yml", `on: push
+permissions:
+  contents: read
+jobs:
+  read_call:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/leaf.yml
+  write_call:
+    permissions:
+      contents: write
+    uses: ./.github/workflows/leaf.yml
+`)
+	writeWorkflow(t, repository, "leaf.yml", `on: workflow_call
+jobs:
+  concrete:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo '${{ secrets.GITHUB_TOKEN }}'
+`)
+	bundle, err := CompileBundle(caller, readFile(t, caller), pushEvent(t), "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bundle.GeneratedWorkflow.Jobs) != 2 {
+		t.Fatalf("generated jobs = %#v", bundle.GeneratedWorkflow.Jobs)
+	}
+	byKey := make(map[string]buildkitepipeline.Job, 2)
+	for _, job := range bundle.GeneratedWorkflow.Jobs {
+		byKey[job.Key] = job
+	}
+	readJob, writeJob := byKey["gha-read_call-concrete"], byKey["gha-write_call-concrete"]
+	if readJob.Authorization == nil || writeJob.Authorization == nil {
+		t.Fatalf("authorizations = read %#v, write %#v", readJob.Authorization, writeJob.Authorization)
+	}
+	if !reflect.DeepEqual(readJob.Authorization.Permissions, map[string]string{"contents": "read"}) || !reflect.DeepEqual(writeJob.Authorization.Permissions, map[string]string{"contents": "write"}) {
+		t.Fatalf("authorization permissions = read %#v, write %#v", readJob.Authorization.Permissions, writeJob.Authorization.Permissions)
+	}
+	if readJob.PlanDigest == writeJob.PlanDigest || reflect.DeepEqual(readJob.Authorization.WorkflowJobs, writeJob.Authorization.WorkflowJobs) {
+		t.Fatalf("sibling caller authorizations were not distinct: read %#v, write %#v", readJob, writeJob)
+	}
+	var pipeline struct {
+		Steps []struct {
+			Key string            `yaml:"key"`
+			Env map[string]string `yaml:"env"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(bundle.Pipeline, &pipeline); err != nil {
+		t.Fatal(err)
+	}
+	manifests := make(map[string]string, len(pipeline.Steps))
+	for _, step := range pipeline.Steps {
+		manifests[step.Key] = step.Env["BUILDKITE_GHA_JOB_AUTHORIZATION"]
+	}
+	if manifests[readJob.Key] == "" || manifests[writeJob.Key] == "" || manifests[readJob.Key] == manifests[writeJob.Key] {
+		t.Fatalf("sibling caller manifests = %#v", manifests)
+	}
+}
+
+func TestCompileBundleFindsNestedCompositeTokenInReusableJob(t *testing.T) {
+	repository := t.TempDir()
+	caller := writeWorkflow(t, repository, "caller.yml", `on: push
+permissions:
+  contents: read
+jobs:
+  delegated:
+    uses: ./.github/workflows/leaf.yml
+`)
+	writeWorkflow(t, repository, "leaf.yml", `on: workflow_call
+jobs:
+  concrete:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/outer
+`)
+	writeAction(t, repository, ".github/actions/outer", `inputs: {}
+runs:
+  using: composite
+  steps:
+    - uses: ./.github/actions/inner
+`)
+	writeAction(t, repository, ".github/actions/inner", `inputs:
+  github_token:
+    default: ${{ github.token }}
+runs:
+  using: composite
+  steps:
+    - shell: sh
+      run: true
+`)
+	bundle, err := CompileBundle(caller, readFile(t, caller), pushEvent(t), "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bundle.Plans) != 1 || bundle.Plans[0].Job.GitHubToken == nil || len(bundle.GeneratedWorkflow.Jobs) != 1 || bundle.GeneratedWorkflow.Jobs[0].Authorization == nil {
+		t.Fatalf("nested composite token authorization = plans %#v, jobs %#v", bundle.Plans, bundle.GeneratedWorkflow.Jobs)
+	}
+	if got := bundle.GeneratedWorkflow.Jobs[0].Authorization.WorkflowJobs; !reflect.DeepEqual(got, []buildkitepipeline.WorkflowJob{{Workflow: "caller.yml", Job: "delegated"}, {Workflow: "leaf.yml", Job: "concrete"}}) {
+		t.Fatalf("nested composite workflow chain = %#v", got)
+	}
+}
+
 func TestCompileBundleGitHubTokenUsesRestrictedDefaultPermissions(t *testing.T) {
 	source := []byte("on: push\njobs:\n  token:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo '${{ secrets.GITHUB_TOKEN }}'\n")
 	bundle, err := CompileBundle(".github/workflows/workflow.yml", source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-importer")

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -949,6 +949,21 @@ func TestCompileBundleGitHubTokenUsesRestrictedDefaultPermissions(t *testing.T) 
 	}
 }
 
+func TestCompileBundleGitHubTokenOmitsNonePermissions(t *testing.T) {
+	source := []byte("on: push\npermissions:\n  contents: read\n  issues: none\njobs:\n  token:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo '${{ secrets.GITHUB_TOKEN }}'\n")
+	bundle, err := CompileBundle("workflow.yml", source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]string{"contents": "read"}
+	if got := bundle.Plans[0].Job.GitHubToken.Permissions; !reflect.DeepEqual(got, want) {
+		t.Fatalf("mixed GitHub workflow token permissions = %#v, want %#v", got, want)
+	}
+	if strings.Contains(string(bundle.Pipeline), `"issues":"none"`) {
+		t.Fatalf("pipeline authorization retained inactive permission:\n%s", bundle.Pipeline)
+	}
+}
+
 func TestCompileBundleGitHubTokenRejectsExplicitEmptyPermissions(t *testing.T) {
 	for _, permissions := range []string{"permissions: {}\n", "permissions:\n  contents: none\n"} {
 		source := []byte("on: push\n" + permissions + "jobs:\n  token:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo '${{ secrets.GITHUB_TOKEN }}'\n")

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -118,6 +118,7 @@ type JobInstance struct {
 	SourceDigest            string                  `json:"source_digest"`
 	RepositoryRoot          string                  `json:"-"`
 	Source                  workflow.Span           `json:"source"`
+	workflowJobs            []WorkflowJob
 	secretAuthority         bool
 }
 
@@ -523,6 +524,7 @@ instances:
 				capabilities = append(capabilities, "provider-token-write")
 				authorization.ProviderTokenWriteCapabilitySources = []string{"effective-permissions"}
 				authorization.WorkflowTokenPolicyFilename = ir.Workflow.WorkflowTokenPolicyFilename
+				authorization.WorkflowJobs = append([]WorkflowJob(nil), instance.workflowJobs...)
 			}
 			if len(secrets) != 0 {
 				capabilities = append(capabilities, "secrets")
@@ -727,27 +729,16 @@ func workflowTokenPolicyEvidence(path string, parsed *workflow.Workflow) (string
 	if err != nil {
 		return "", err.Error()
 	}
-	if parsed.Permissions != nil && len(parsed.Permissions.Scopes) == 0 {
+	if parsed.Permissions == nil || len(parsed.Permissions.Scopes) == 0 {
 		return "", "GitHub workflow access tokens require explicit non-empty top-level permissions"
 	}
-	permissions := defaultGitHubTokenPermissions().Scopes
-	if parsed.Permissions != nil {
-		permissions = parsed.Permissions.Scopes
-	}
+	permissions := parsed.Permissions.Scopes
 	normalizedPermissions := make(map[string]string, len(permissions))
 	for name, access := range permissions {
 		normalizedPermissions[strings.ReplaceAll(name, "-", "_")] = access
 	}
 	if err := plan.ValidateGitHubWorkflowAccessTokenPermissions(normalizedPermissions); err != nil {
 		return "", err.Error()
-	}
-	for _, job := range parsed.Jobs {
-		if job.Permissions != nil {
-			return "", "GitHub workflow access tokens do not support job-level permissions"
-		}
-		if job.Reusable != nil {
-			return "", "GitHub workflow access tokens do not support reusable-workflow jobs"
-		}
 	}
 	return filename, ""
 }
@@ -860,6 +851,7 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 	sourcePaths := make(map[string]string, len(resolved))
 	sourceDigests := make(map[string]string, len(resolved))
 	sourceRoots := make(map[string]string, len(resolved))
+	workflowJobs := make(map[string][]WorkflowJob, len(resolved))
 	secretAuthorities := make(map[string]bool, len(resolved))
 	needBindings := make(map[string]map[string]needBinding, len(resolved))
 	var diagnostics []error
@@ -874,6 +866,7 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 		sourcePaths[job.ID] = sourced.path
 		sourceDigests[job.ID] = sourced.digest
 		sourceRoots[job.ID] = sourced.root
+		workflowJobs[job.ID] = sourced.workflowJobs
 		secretAuthorities[job.ID] = sourced.secretAuthority
 		needBindings[job.ID] = sourced.needBindings
 		if err := supported(sourced.path, job); err != nil {
@@ -993,6 +986,7 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 				SourceDigest:            sourceDigests[id],
 				RepositoryRoot:          sourceRoots[id],
 				Source:                  job.Span,
+				workflowJobs:            append([]WorkflowJob(nil), workflowJobs[id]...),
 				secretAuthority:         secretAuthorities[id],
 			}
 			result.candidates = append(result.candidates, candidate)

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -21,23 +21,34 @@ import (
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
-func TestEffectiveReusablePermissionsOnlyNarrowCallerAuthority(t *testing.T) {
+func TestEffectiveReusablePermissionsRejectElevationAboveCallerAuthority(t *testing.T) {
 	span := workflow.Span{Start: workflow.Position{Line: 2, Column: 1}}
 	caller := &workflow.Permissions{Scopes: map[string]string{"contents": "read", "pull-requests": "write"}, Span: span}
-	callee := &workflow.Permissions{Scopes: map[string]string{"contents": "write", "issues": "write", "pull-requests": "read"}, Span: span}
-	if inherited := effectivePermissions(nil, nil, nil, false); !reflect.DeepEqual(inherited.Scopes, map[string]string{"contents": "read"}) {
+	callee := &workflow.Permissions{Scopes: map[string]string{"contents": "read", "pull-requests": "read"}, Span: span}
+	if inherited, err := effectivePermissions(nil, nil, nil, false); err != nil || !reflect.DeepEqual(inherited.Scopes, map[string]string{"contents": "read"}) {
 		t.Fatalf("root default permissions = %#v", inherited)
 	}
-	effective := effectivePermissions(callee, nil, caller, true)
+	effective, err := effectivePermissions(callee, nil, caller, true)
+	if err != nil {
+		t.Fatal(err)
+	}
 	want := map[string]string{"contents": "read", "pull-requests": "read"}
 	if !reflect.DeepEqual(effective.Scopes, want) {
 		t.Fatalf("effective permissions = %#v, want %#v", effective.Scopes, want)
 	}
-	if inherited := effectivePermissions(nil, nil, caller, true); !reflect.DeepEqual(inherited.Scopes, caller.Scopes) || inherited == caller {
+	if inherited, err := effectivePermissions(nil, nil, caller, true); err != nil || !reflect.DeepEqual(inherited.Scopes, caller.Scopes) || inherited == caller {
 		t.Fatalf("inherited permissions = %#v, want independent copy of %#v", inherited, caller)
 	}
-	if unbounded := effectivePermissions(callee, caller, nil, false); !reflect.DeepEqual(unbounded.Scopes, callee.Scopes) {
+	if unbounded, err := effectivePermissions(callee, caller, nil, false); err != nil || !reflect.DeepEqual(unbounded.Scopes, callee.Scopes) {
 		t.Fatalf("root job permissions = %#v, want job replacement %#v", unbounded, callee)
+	}
+	for _, elevated := range []*workflow.Permissions{
+		{Scopes: map[string]string{"contents": "write"}, Span: span},
+		{Scopes: map[string]string{"issues": "read"}, Span: span},
+	} {
+		if _, err := effectivePermissions(elevated, nil, caller, true); err == nil || !strings.Contains(err.Error(), "elevates") {
+			t.Fatalf("effectivePermissions(%#v) error = %v, want elevation rejection", elevated.Scopes, err)
+		}
 	}
 }
 
@@ -54,7 +65,7 @@ func TestWorkflowTokenPolicyEvidence(t *testing.T) {
 			source: "on: push\npermissions:\n  contents: read\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
 		},
 		{
-			name: "omitted top-level permissions", path: ".github/workflows/ci.yml", want: "ci.yml",
+			name: "omitted top-level permissions", path: ".github/workflows/ci.yml", diagnostic: "explicit non-empty",
 			source: "on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
 		},
 		{
@@ -66,11 +77,11 @@ func TestWorkflowTokenPolicyEvidence(t *testing.T) {
 			source: "on: push\npermissions:\n  contents: none\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
 		},
 		{
-			name: "job permissions", path: ".github/workflows/ci.yml", diagnostic: "job-level",
+			name: "job permissions", path: ".github/workflows/ci.yml", want: "ci.yml",
 			source: "on: push\npermissions:\n  contents: read\njobs:\n  test:\n    permissions:\n      contents: read\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
 		},
 		{
-			name: "reusable workflow", path: ".github/workflows/ci.yml", diagnostic: "reusable-workflow",
+			name: "reusable workflow", path: ".github/workflows/ci.yml", want: "ci.yml",
 			source: "on: push\npermissions:\n  contents: read\njobs:\n  test:\n    uses: ./.github/workflows/reusable.yml\n",
 		},
 		{
@@ -95,18 +106,18 @@ func TestWorkflowTokenPolicyEvidence(t *testing.T) {
 	}
 }
 
-func TestCompilePlansBoundsNestedReusableWorkflowDefaultPermissions(t *testing.T) {
+func TestCompilePlansRejectNestedReusableWorkflowPermissionElevation(t *testing.T) {
 	repository := t.TempDir()
 	caller := writeWorkflow(t, repository, "caller.yml", `on: push
 jobs:
   delegated:
+    permissions:
+      contents: read
     uses: ./.github/workflows/middle.yml
 `)
 	writeWorkflow(t, repository, "middle.yml", `on: workflow_call
 permissions:
   contents: write
-  issues: write
-  packages: read
 jobs:
   delegated:
     uses: ./.github/workflows/leaf.yml
@@ -119,12 +130,41 @@ jobs:
       - run: test -n '${{ secrets.GITHUB_TOKEN }}'
 `)
 
-	plans, err := compileUntrustedPlans(caller, readFile(t, caller), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), "gha-untrusted")
+	_, err := compileUntrustedPlans(caller, readFile(t, caller), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), "gha-untrusted")
+	if err == nil || !strings.Contains(err.Error(), `permission "contents" elevates from read to write`) {
+		t.Fatalf("nested reusable permission elevation error = %v", err)
+	}
+
+	allowedRepository := t.TempDir()
+	allowedCaller := writeWorkflow(t, allowedRepository, "caller.yml", `on: push
+jobs:
+  delegated:
+    permissions:
+      contents: write
+    uses: ./.github/workflows/middle.yml
+`)
+	writeWorkflow(t, allowedRepository, "middle.yml", `on: workflow_call
+permissions:
+  contents: read
+jobs:
+  delegated:
+    permissions:
+      contents: write
+    uses: ./.github/workflows/leaf.yml
+`)
+	writeWorkflow(t, allowedRepository, "leaf.yml", `on: workflow_call
+jobs:
+  token:
+    runs-on: ubuntu-latest
+    steps:
+      - run: test -n '${{ secrets.GITHUB_TOKEN }}'
+`)
+	plans, err := compileUntrustedPlans(allowedCaller, readFile(t, allowedCaller), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), "gha-untrusted")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(plans) != 1 || plans[0].GitHubToken == nil || !reflect.DeepEqual(plans[0].GitHubToken.Permissions, map[string]string{"contents": "read"}) {
-		t.Fatalf("nested reusable token plan = %#v", plans)
+	if len(plans) != 1 || plans[0].GitHubToken == nil || !reflect.DeepEqual(plans[0].GitHubToken.Permissions, map[string]string{"contents": "write"}) {
+		t.Fatalf("nested reusable job permission replacement = %#v", plans)
 	}
 
 	emptyRepository := t.TempDir()
@@ -1321,6 +1361,40 @@ func TestCompileRejectsReusableWorkflowCyclesAndDepthOverflow(t *testing.T) {
 		_, err := Compile(path, readFile(t, path), readFile(t, smokePath("events", "push.json")))
 		if err == nil || !strings.Contains(err.Error(), fmt.Sprintf("exceeds maximum depth %d", maxReusableWorkflowDepth)) {
 			t.Fatalf("Compile() error = %v, want explicit depth limit", err)
+		}
+	})
+
+	t.Run("maximum authorization chain", func(t *testing.T) {
+		repository := t.TempDir()
+		for i := 0; i < maxReusableWorkflowDepth; i++ {
+			on := "workflow_call"
+			permissions := ""
+			if i == 0 {
+				on = "push"
+				permissions = "permissions:\n  contents: read\n"
+			}
+			writeWorkflow(t, repository, fmt.Sprintf("%d.yml", i), fmt.Sprintf("on: %s\n%sjobs:\n  call_%d:\n    uses: ./.github/workflows/%d.yml\n", on, permissions, i, i+1))
+		}
+		writeWorkflow(t, repository, fmt.Sprintf("%d.yml", maxReusableWorkflowDepth), "on: workflow_call\njobs:\n  concrete:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo '${{ secrets.GITHUB_TOKEN }}'\n")
+		path := filepath.Join(repository, ".github", "workflows", "0.yml")
+		bundle, err := CompileBundle(path, readFile(t, path), pushEvent(t), "0.0.0-test", testDistributionDigest, "gha-importer")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(bundle.GeneratedWorkflow.Jobs) != 1 || bundle.GeneratedWorkflow.Jobs[0].Authorization == nil {
+			t.Fatalf("maximum-depth authorization = %#v", bundle.GeneratedWorkflow.Jobs)
+		}
+		chain := bundle.GeneratedWorkflow.Jobs[0].Authorization.WorkflowJobs
+		if len(chain) != maxReusableWorkflowDepth+1 {
+			t.Fatalf("maximum-depth workflow chain = %#v", chain)
+		}
+		for i := 0; i < maxReusableWorkflowDepth; i++ {
+			if chain[i].Workflow != fmt.Sprintf("%d.yml", i) || chain[i].Job != fmt.Sprintf("call_%d", i) {
+				t.Fatalf("maximum-depth workflow chain = %#v", chain)
+			}
+		}
+		if chain[len(chain)-1].Workflow != fmt.Sprintf("%d.yml", maxReusableWorkflowDepth) || chain[len(chain)-1].Job != "concrete" {
+			t.Fatalf("maximum-depth workflow chain = %#v", chain)
 		}
 	})
 }

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -28,6 +28,7 @@ type sourcedJob struct {
 	path            string
 	digest          string
 	root            string
+	workflowJobs    []WorkflowJob
 	secretAuthority bool
 	needBindings    map[string]needBinding
 }
@@ -83,12 +84,20 @@ func resolveReusableWorkflows(path string, source []byte, parsed *workflow.Workf
 		workflowJobs := make(map[string]workflow.Job, len(parsed.Jobs))
 		replacements := make(map[string]needBinding, len(parsed.Jobs))
 		for i, job := range parsed.Jobs {
-			job.Permissions = effectivePermissions(job.Permissions, parsed.Permissions, nil, false)
+			permissions, err := effectivePermissions(job.Permissions, parsed.Permissions, nil, false)
+			if err != nil {
+				return nil, runtimeMatrixBoundary, err
+			}
+			job.Permissions = permissions
 			bindings := make(map[string]needBinding, len(job.Needs))
 			for _, need := range job.Needs {
 				bindings[need] = needBinding{members: []string{need}}
 			}
-			jobs[i] = sourcedJob{Job: job, path: sourcePath, digest: digest, root: root, secretAuthority: true, needBindings: bindings}
+			jobs[i] = sourcedJob{
+				Job: job, path: sourcePath, digest: digest, root: root,
+				workflowJobs:    []WorkflowJob{{Workflow: filepath.Base(sourcePath), Job: job.ID}},
+				secretAuthority: true, needBindings: bindings,
+			}
 			workflowJobs[job.ID] = job
 			replacements[job.ID] = needBinding{members: []string{job.ID}}
 		}
@@ -108,7 +117,7 @@ func resolveReusableWorkflows(path string, source []byte, parsed *workflow.Workf
 	}
 	resolver := reusableResolver{root: root, stack: []string{canonicalPath}, context: context, runtimeMatrixBoundary: runtimeMatrixBoundary}
 	resolver.discoverRuntimeMatrixBoundaries(parsed, 0, map[string]int{canonicalPath: 0})
-	resolution, err := resolver.resolve(sourcePath, digest, parsed, "", "", nil, nil, nil, true, 0)
+	resolution, err := resolver.resolve(sourcePath, digest, parsed, "", "", nil, nil, nil, true, nil, 0)
 	return resolution.jobs, resolver.runtimeMatrixBoundary, err
 }
 
@@ -162,7 +171,7 @@ func (resolver *reusableResolver) discoverRuntimeMatrixBoundaries(parsed *workfl
 	}
 }
 
-func (resolver *reusableResolver) resolve(path, digest string, parsed *workflow.Workflow, namespace, labelPrefix string, inputs map[string]any, externalNeeds map[string]needBinding, permissionCeiling *workflow.Permissions, secretAuthority bool, depth int) (reusableResolution, error) {
+func (resolver *reusableResolver) resolve(path, digest string, parsed *workflow.Workflow, namespace, labelPrefix string, inputs map[string]any, externalNeeds map[string]needBinding, permissionCeiling *workflow.Permissions, secretAuthority bool, workflowJobs []WorkflowJob, depth int) (reusableResolution, error) {
 	resolver.runtimeMatrixBoundary = resolver.runtimeMatrixBoundary || hasRuntimeMatrixBoundary(parsed)
 	jobs := make(map[string]workflow.Job, len(parsed.Jobs))
 	for _, job := range parsed.Jobs {
@@ -177,7 +186,17 @@ func (resolver *reusableResolver) resolve(path, digest string, parsed *workflow.
 	var resolved []sourcedJob
 	for _, id := range order {
 		job := jobs[id]
-		job.Permissions = effectivePermissions(job.Permissions, parsed.Permissions, permissionCeiling, depth != 0)
+		jobPermissions := job.Permissions
+		job.Permissions, err = effectivePermissions(jobPermissions, parsed.Permissions, permissionCeiling, depth != 0)
+		if err != nil {
+			position := job.Span.Start
+			if jobPermissions != nil {
+				position = jobPermissions.Span.Start
+			} else if parsed.Permissions != nil {
+				position = parsed.Permissions.Span.Start
+			}
+			return reusableResolution{}, locatedJobError(path, job, position.Line, position.Column, err.Error())
+		}
 		job = applyStaticInputs(job, inputs)
 		if parsed.Callable {
 			if err := rejectUnresolvedInputExpressions(path, job); err != nil {
@@ -203,6 +222,7 @@ func (resolver *reusableResolver) resolve(path, digest string, parsed *workflow.
 		}
 		needs := bindingMembers(needBindings)
 		if job.Reusable == nil {
+			concreteWorkflowJobs := appendWorkflowJob(workflowJobs, WorkflowJob{Workflow: filepath.Base(path), Job: id})
 			job.ID = namespacedJobID(namespace, job.ID)
 			job.Needs = needs
 			if labelPrefix != "" {
@@ -216,7 +236,10 @@ func (resolver *reusableResolver) resolve(path, digest string, parsed *workflow.
 			if resolver.expanded > maxFlattenedJobs {
 				return reusableResolution{}, jobError(path, job, fmt.Sprintf("reusable-workflow graph expands beyond %d jobs", maxFlattenedJobs))
 			}
-			resolved = append(resolved, sourcedJob{Job: job, path: path, digest: digest, root: resolver.root, secretAuthority: secretAuthority, needBindings: needBindings})
+			resolved = append(resolved, sourcedJob{
+				Job: job, path: path, digest: digest, root: resolver.root, workflowJobs: concreteWorkflowJobs,
+				secretAuthority: secretAuthority, needBindings: needBindings,
+			})
 			replacements[id] = needBinding{members: []string{job.ID}}
 			continue
 		}
@@ -301,7 +324,8 @@ func (resolver *reusableResolver) resolve(path, digest string, parsed *workflow.
 				calleePermissionCeiling = &workflow.Permissions{Scopes: map[string]string{}, Span: call.Span}
 			}
 			resolver.stack = append(resolver.stack, calleePath)
-			calleeResolution, err := resolver.resolve(calleeSourcePath, calleeDigest, callee, callNamespace, callLabel, callInputs, needBindings, calleePermissionCeiling, secretAuthority && call.InheritSecrets, depth+1)
+			callerWorkflowJobs := appendWorkflowJob(workflowJobs, WorkflowJob{Workflow: filepath.Base(path), Job: id})
+			calleeResolution, err := resolver.resolve(calleeSourcePath, calleeDigest, callee, callNamespace, callLabel, callInputs, needBindings, calleePermissionCeiling, secretAuthority && call.InheritSecrets, callerWorkflowJobs, depth+1)
 			resolver.stack = resolver.stack[:len(resolver.stack)-1]
 			if err != nil {
 				return reusableResolution{}, &ProcessingFinding{
@@ -329,35 +353,40 @@ func (resolver *reusableResolver) resolve(path, digest string, parsed *workflow.
 	return reusableResolution{jobs: resolved, outputs: outputs}, nil
 }
 
-func effectivePermissions(job, workflowDefault, ceiling *workflow.Permissions, bounded bool) *workflow.Permissions {
+func effectivePermissions(job, workflowDefault, ceiling *workflow.Permissions, bounded bool) (*workflow.Permissions, error) {
 	declared := job
 	if declared == nil {
 		declared = workflowDefault
 	}
 	if !bounded {
 		if declared == nil {
-			return defaultGitHubTokenPermissions()
+			return defaultGitHubTokenPermissions(), nil
 		}
-		return clonePermissions(declared)
+		return clonePermissions(declared), nil
 	}
 	if declared == nil {
-		return clonePermissions(ceiling)
+		return clonePermissions(ceiling), nil
 	}
-	effective := &workflow.Permissions{Scopes: map[string]string{}, Span: declared.Span}
-	if ceiling == nil {
-		return effective
-	}
-	for name, access := range declared.Scopes {
-		ceilingAccess, ok := ceiling.Scopes[name]
-		if !ok {
-			continue
+	for _, name := range sortedKeys(declared.Scopes) {
+		access := declared.Scopes[name]
+		ceilingAccess := "none"
+		if ceiling != nil {
+			if inherited, ok := ceiling.Scopes[name]; ok {
+				ceilingAccess = inherited
+			}
 		}
-		if access == "write" && ceilingAccess == "read" {
-			access = "read"
+		if ceilingAccess == "none" || (access == "write" && ceilingAccess == "read") {
+			return nil, fmt.Errorf("permission %q elevates from %s to %s above inherited caller permissions", name, ceilingAccess, access)
 		}
-		effective.Scopes[name] = access
 	}
-	return effective
+	return clonePermissions(declared), nil
+}
+
+func appendWorkflowJob(chain []WorkflowJob, job WorkflowJob) []WorkflowJob {
+	result := make([]WorkflowJob, len(chain)+1)
+	copy(result, chain)
+	result[len(chain)] = job
+	return result
 }
 
 func defaultGitHubTokenPermissions() *workflow.Permissions {

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -95,7 +95,7 @@ func resolveReusableWorkflows(path string, source []byte, parsed *workflow.Workf
 			}
 			jobs[i] = sourcedJob{
 				Job: job, path: sourcePath, digest: digest, root: root,
-				workflowJobs:    []WorkflowJob{{Workflow: filepath.Base(sourcePath), Job: job.ID}},
+				workflowJobs:    []WorkflowJob{{Workflow: filepath.Base(sourcePath), Job: job.ID, LogicalIDComponent: job.ID}},
 				secretAuthority: true, needBindings: bindings,
 			}
 			workflowJobs[job.ID] = job
@@ -222,7 +222,7 @@ func (resolver *reusableResolver) resolve(path, digest string, parsed *workflow.
 		}
 		needs := bindingMembers(needBindings)
 		if job.Reusable == nil {
-			concreteWorkflowJobs := appendWorkflowJob(workflowJobs, WorkflowJob{Workflow: filepath.Base(path), Job: id})
+			concreteWorkflowJobs := appendWorkflowJob(workflowJobs, WorkflowJob{Workflow: filepath.Base(path), Job: id, LogicalIDComponent: id})
 			job.ID = namespacedJobID(namespace, job.ID)
 			job.Needs = needs
 			if labelPrefix != "" {
@@ -324,7 +324,7 @@ func (resolver *reusableResolver) resolve(path, digest string, parsed *workflow.
 				calleePermissionCeiling = &workflow.Permissions{Scopes: map[string]string{}, Span: call.Span}
 			}
 			resolver.stack = append(resolver.stack, calleePath)
-			callerWorkflowJobs := appendWorkflowJob(workflowJobs, WorkflowJob{Workflow: filepath.Base(path), Job: id})
+			callerWorkflowJobs := appendWorkflowJob(workflowJobs, WorkflowJob{Workflow: filepath.Base(path), Job: id, LogicalIDComponent: component})
 			calleeResolution, err := resolver.resolve(calleeSourcePath, calleeDigest, callee, callNamespace, callLabel, callInputs, needBindings, calleePermissionCeiling, secretAuthority && call.InheritSecrets, callerWorkflowJobs, depth+1)
 			resolver.stack = resolver.stack[:len(resolver.stack)-1]
 			if err != nil {


### PR DESCRIPTION
## Why

Buildkite’s trusted GitHub Actions plugin upload needs compiler-owned, per-concrete-job authorization evidence before issuing `GITHUB_TOKEN` across local reusable workflows.

Pairs with buildkite/buildkite#32402. Closes #160.

## What

- Emit canonical `BUILDKITE_GHA_JOB_AUTHORIZATION` manifests only for concrete jobs that statically require `GITHUB_TOKEN`, including recursive composite-action defaults.
- Preserve each exact local reusable-workflow caller chain and bind its effective permissions to the existing concrete plan digest.
- Match GitHub permission inheritance and replacement semantics while rejecting nested elevation above the caller ceiling.
- Replace workflow-wide reusable-call exclusion with compiler-verified per-job hosted admission, retaining the explicit root-permissions opt-in and existing provenance boundaries.
- Document the expanded supported subset and add focused authorization, sibling-path, nested-action, permission, cycle/depth, and tokenless coverage.

## Verification

- `mise run check`
