### PR TITLE
Preserve values in compatibility annotation code spans

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2154,7 +2154,7 @@ func TestProcessingAnnotationDoesNotRepeatDiagnosticLocation(t *testing.T) {
 }
 
 func TestMarkdownCodeContainsWorkflowBackticks(t *testing.T) {
-	if got, want := markdownCode("action` **not bold** ``tail"), "``` action` **not bold** ``tail ```"; got != want {
+	if got, want := markdownCode("action` **not bold** & <tag> ``tail"), "``` action` **not bold** & <tag> ``tail ```"; got != want {
 		t.Fatalf("markdownCode() = %q, want %q", got, want)
 	}
 }

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -181,7 +181,6 @@ func upperFirst(value string) string {
 
 func markdownCode(value string) string {
 	value = strings.Join(strings.Fields(value), " ")
-	value = strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;").Replace(value)
 	if strings.Contains(value, "`") {
 		longest, current := 0, 0
 		for _, r := range value {


### PR DESCRIPTION
## Why

Follow-up to #187: annotation code spans pre-escaped `&`, `<`, and `>`, so Buildkite displayed valid workflow values such as `./.github/actions/a&b` as HTML entities.

## What

Leave code-span content unescaped for the Markdown renderer while retaining the variable-length backtick delimiter. The focused test covers HTML and Markdown metacharacters together.
