### PR TITLE
docs: bypass mise release age for CLI install

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -7,7 +7,7 @@ The [GitHub Actions Buildkite plugin](https://github.com/buildkite-plugins/githu
 Install `buildkite-gha` with `mise` 2026.5.12 or newer:
 
 ```sh
-mise use -g github:buildkite/buildkite-gha
+mise use -g --minimum-release-age 0s github:buildkite/buildkite-gha
 ```
 
 Append `@<version>` to install an exact release. A custom importer that runs macOS jobs must also download and verify the same release's Darwin/arm64 distribution.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -10,6 +10,8 @@ Install `buildkite-gha` with `mise` 2026.5.12 or newer:
 mise use -g --minimum-release-age 0s github:buildkite/buildkite-gha
 ```
 
+The `--minimum-release-age 0s` override prevents mise's default 24-hour delay from selecting an older release without an artifact for your platform.
+
 Append `@<version>` to install an exact release. A custom importer that runs macOS jobs must also download and verify the same release's Darwin/arm64 distribution.
 
 Jobs with JavaScript actions require `mise`. `run-job` checks `BUILDKITE_GHA_MISE`, then `PATH`, and then downloads a verified managed copy. Shell-only, native-adapter, and Docker-only jobs do not require `mise`.


### PR DESCRIPTION
Update the CLI installation command to bypass mise's default release-age delay. This prevents macOS installs from resolving to an older Linux-only release during the delay window.