### PR TITLE
Support native macOS arm64 importers

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ steps:
 
 The plugin is a thin wrapper around the hidden `buildkite-gha plugin` entrypoint. It uses mise to install and verify the selected CLI release, and defaults to the latest stable release. During the preview, leaving `version` unset means there is no CLI version to update as new stable releases ship. Set `workflow` to one explicit path or `workflows` to an explicit path list; plugin configuration does not accept directories or glob patterns.
 
+The importer can run on Linux x86-64 or native macOS arm64. Its agent targeting
+is independent of `runners`: each runner mapping selects the queue for generated
+workflow jobs, not the importer step.
+
 To hold the CLI at a specific release instead, set `version` to an exact stable release from `0.9.0` onward:
 
 ```yaml

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -12,7 +12,7 @@ mise use -g --minimum-release-age 0s github:buildkite/buildkite-gha
 
 The `--minimum-release-age 0s` override prevents mise's default 24-hour delay from selecting an older release without an artifact for your platform.
 
-Append `@<version>` to install an exact release. A custom importer that runs macOS jobs must also download and verify the same release's Darwin/arm64 distribution.
+Append `@<version>` to install an exact release. A custom importer that generates jobs for the other supported platform must also download and verify that platform's distribution from the same release.
 
 Jobs with JavaScript actions require `mise`. `run-job` checks `BUILDKITE_GHA_MISE`, then `PATH`, and then downloads a verified managed copy. Shell-only, native-adapter, and Docker-only jobs do not require `mise`.
 
@@ -103,7 +103,7 @@ buildkite-gha compile \
 buildkite-gha upload .github/workflows/ci.yml
 ```
 
-The importer must run on Linux/amd64 with `BUILDKITE=true` and `BUILDKITE_STEP_KEY`.
+The importer must run on Linux/amd64 or Darwin/arm64 with `BUILDKITE=true` and `BUILDKITE_STEP_KEY`.
 
 The hidden zero-argument `buildkite-gha plugin` entry point reads `workflow`,
 `workflows`, and `runners` from `BUILDKITE_PLUGIN_CONFIGURATION`. Set `workflow`
@@ -111,9 +111,11 @@ to one explicit path or `workflows` to a non-empty array of explicit paths; the
 fields are mutually exclusive. Every path must identify a regular, tracked
 `.yml` or `.yaml` file inside the repository; directories and glob patterns are
 rejected. It also accepts the plugin-owned `version`, `source-ref`, and
-`minimum-release-age` fields. The Linux/amd64 importer fetches the same release's
-Darwin runtime only when a workflow requires it. Custom importers can use the
-public flags below.
+`minimum-release-age` fields. The importer uses its verified executable for jobs
+on the same platform and fetches the other platform's distribution from the
+same release only when a workflow requires it. Custom importers can use the
+public flags below. Runner queue mappings affect generated jobs, not the
+importer step.
 
 ### Select workflows
 
@@ -173,8 +175,9 @@ Configured `ubuntu-latest` and `ubuntu-24.04` profiles default to the Noble
 hosted-toolchains image; `ubuntu-22.04` defaults to Jammy. Use `--runner-image`
 with an immutable digest to override the default. Unmapped Linux labels keep
 default targeting without an image. Every macOS label requires a queue and
-rejects images. Runtime distribution paths must be absolute executables; Linux
-defaults to the importer and Darwin has no direct-upload default.
+rejects images. Runtime distribution paths must be absolute executables. The
+importer's platform defaults to its running executable; the other platform has
+no direct-upload default.
 `BUILDKITE_GHA_TARGET_QUEUE` and `BUILDKITE_GHA_RUNTIME_IMAGE` are no longer
 supported.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -2,9 +2,10 @@
 
 This page defines the initial production contract for `buildkite-gha`. It applies to the `hosted` profile used by `upload` and the Buildkite plugin.
 
-The released plugin path supports Linux x86-64 and native macOS arm64, including
-the matching `runner.os` and `runner.arch` values. Platform labels do not provide
-GitHub image or toolchain parity.
+The released plugin path supports Linux x86-64 and native macOS arm64 importers
+and generated jobs, including the matching `runner.os` and `runner.arch` values.
+Importer agent targeting is independent of generated-job runner mappings.
+Platform labels do not provide GitHub image or toolchain parity.
 
 GitHub Actions syntax changes over time. If a feature is not listed here, treat it as unsupported. GitHub's [workflow syntax reference](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax) describes the original syntax; this page describes the subset that runs on Buildkite.
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -68,7 +68,7 @@ func writeCommandHelp(stdout io.Writer, command string) {
 	case "compile":
 		_, _ = fmt.Fprint(stdout, "\nPipeline output references content-addressed plans; compile does not materialize or upload those artifacts.\n")
 	case "upload":
-		_, _ = fmt.Fprint(stdout, "\nEvery workflow operand must be an explicit .yml or .yaml path; use -- before paths that begin with a dash. Multiple operands must be tracked files inside the checked-out repository. Inputs are uploaded as one aggregate pipeline with one group per directly runnable workflow; reusable-only workflow_call files are imported through callers but do not become groups. Scheduled groups select only build.source == schedule: Buildkite schedules retain cron ownership, so every scheduled workflow group is eligible on any Buildkite scheduled build. Each repeatable --runner-queue argument maps one supported runs-on label to a Buildkite queue. Configured Linux profiles default to the matching immutable hosted-toolchains image; --runner-image overrides it. Duplicate or unsupported mappings fail, unmapped supported Linux labels retain their default targeting, and every macOS label requires an explicit queue. Each repeatable --runtime-distribution argument binds linux/amd64 or darwin/arm64 to a verified executable. Upload importers must run on linux/amd64; the Linux runtime defaults to the importer executable when omitted, and macOS has no default. The deprecated --runtime-queue hosted option is accepted for plugin compatibility but does not select a queue. Event precedence is an explicit event file, Buildkite's reserved webhook metadata, then reduced-fidelity Buildkite environment compatibility data; every source remains unsigned. Verified checkout jobs automatically use Buildkite repository-provider Git credentials when the job enables them; the deprecated --private-checkout option is accepted as a no-op.\n")
+		_, _ = fmt.Fprint(stdout, "\nEvery workflow operand must be an explicit .yml or .yaml path; use -- before paths that begin with a dash. Multiple operands must be tracked files inside the checked-out repository. Inputs are uploaded as one aggregate pipeline with one group per directly runnable workflow; reusable-only workflow_call files are imported through callers but do not become groups. Scheduled groups select only build.source == schedule: Buildkite schedules retain cron ownership, so every scheduled workflow group is eligible on any Buildkite scheduled build. Each repeatable --runner-queue argument maps one supported runs-on label to a Buildkite queue. Configured Linux profiles default to the matching immutable hosted-toolchains image; --runner-image overrides it. Duplicate or unsupported mappings fail, unmapped supported Linux labels retain their default targeting, and every macOS label requires an explicit queue. Each repeatable --runtime-distribution argument binds linux/amd64 or darwin/arm64 to a verified executable. Upload importers may run on either platform; the matching runtime defaults to the importer executable, and workflows targeting the other platform require its distribution. The deprecated --runtime-queue hosted option is accepted for plugin compatibility but does not select a queue. Event precedence is an explicit event file, Buildkite's reserved webhook metadata, then reduced-fidelity Buildkite environment compatibility data; every source remains unsigned. Verified checkout jobs automatically use Buildkite repository-provider Git credentials when the job enables them; the deprecated --private-checkout option is accepted as a no-op.\n")
 	}
 }
 
@@ -77,6 +77,7 @@ const (
 	legacyRuntimeQueue                          = "hosted"
 	pluginConfigurationEnvironment              = "BUILDKITE_PLUGIN_CONFIGURATION"
 	pluginDevDarwinRuntimeEnvironment           = "BUILDKITE_GHA_PLUGIN_DEV_DARWIN_RUNTIME"
+	pluginDevLinuxRuntimeEnvironment            = "BUILDKITE_GHA_PLUGIN_DEV_LINUX_RUNTIME"
 	legacyTargetQueueEnvironment                = "BUILDKITE_GHA_TARGET_QUEUE"
 	legacyRuntimeImageEnvironment               = "BUILDKITE_GHA_RUNTIME_IMAGE"
 	repositoryProviderGitCredentialsEnvironment = "BUILDKITE_USE_REPOSITORY_PROVIDER_GIT_CREDENTIALS"
@@ -165,7 +166,8 @@ func plugin(args []string, stdout, stderr io.Writer, version string, runner tran
 	if len(args) != 0 {
 		return usageError(stderr, "plugin does not accept arguments")
 	}
-	if err := validateImporterPlatform(runtime.GOOS, runtime.GOARCH); err != nil {
+	importerPlatform, err := importerPlatform(runtime.GOOS, runtime.GOARCH)
+	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: plugin: %v\n", err)
 		return 1
 	}
@@ -182,14 +184,19 @@ func plugin(args []string, stdout, stderr io.Writer, version string, runner tran
 		explicitWorkflowPaths: true,
 		runnerTargets:         configuration.runnerTargets,
 		pluginAcquisition:     &pluginRuntimeAcquisition{version: version},
+		importerPlatform:      importerPlatform,
 	}, stdout, stderr, version, transport.Agent{Runner: runner})
 }
 
-func validateImporterPlatform(goos, goarch string) error {
-	if goos != "linux" || goarch != "amd64" {
-		return fmt.Errorf("importer requires linux/amd64, running on %s/%s", goos, goarch)
+func importerPlatform(goos, goarch string) (compiler.Platform, error) {
+	switch {
+	case goos == "linux" && goarch == "amd64":
+		return compiler.PlatformLinuxAMD64, nil
+	case goos == "darwin" && goarch == "arm64":
+		return compiler.PlatformDarwinARM64, nil
+	default:
+		return compiler.Platform{}, fmt.Errorf("importer requires linux/amd64 or darwin/arm64, running on %s/%s", goos, goarch)
 	}
-	return nil
 }
 
 type pluginConfiguration struct {
@@ -1370,7 +1377,8 @@ func upload(args []string, stdout, stderr io.Writer, version string, agent trans
 }
 
 func uploadFromPlatform(goos, goarch string, args []string, stdout, stderr io.Writer, version string, agent transport.Agent) int {
-	if err := validateImporterPlatform(goos, goarch); err != nil {
+	platform, err := importerPlatform(goos, goarch)
+	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
 		return 1
 	}
@@ -1378,6 +1386,7 @@ func uploadFromPlatform(goos, goarch string, args []string, stdout, stderr io.Wr
 	if err != nil {
 		return usageError(stderr, "upload: %v", err)
 	}
+	uploadArguments.importerPlatform = platform
 	return uploadParsed(uploadArguments, stdout, stderr, version, agent)
 }
 
@@ -1500,39 +1509,61 @@ func uploadParsed(uploadArguments parsedUploadArgs, stdout, stderr io.Writer, ve
 		}
 		return 1
 	}
-	runtimePaths := uploadArguments.runtimeDistributionPaths
-	if uploadArguments.pluginAcquisition != nil {
-		requiredPlatforms := make(map[compiler.Platform]bool, 2)
-		for _, input := range workflows {
-			if !input.Applicable {
-				continue
-			}
-			platforms, platformErr := requiredRuntimePlatforms(input.Path, input.Source, effectiveEvent.Source, "", uploadArguments.runnerTargets)
-			if platformErr != nil {
-				_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", platformErr)
-				return 1
-			}
-			for platform := range platforms {
-				requiredPlatforms[platform] = true
-			}
+	importerDistribution := runtimeDistribution{contents: executableContents, digest: distributionDigest}
+	requiredPlatforms := make(map[compiler.Platform]bool, 2)
+	for _, input := range workflows {
+		if !input.Applicable {
+			continue
 		}
-		runtimeDistributions, acquireErr := uploadArguments.pluginAcquisition.acquire(ctx, requiredPlatforms, runtimeDistribution{contents: executableContents, digest: distributionDigest})
+		platforms, platformErr := requiredRuntimePlatforms(input.Path, input.Source, effectiveEvent.Source, "", uploadArguments.runnerTargets)
+		if platformErr != nil {
+			_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", platformErr)
+			return 1
+		}
+		for platform := range platforms {
+			requiredPlatforms[platform] = true
+		}
+	}
+	if uploadArguments.pluginAcquisition != nil {
+		runtimeDistributions, acquireErr := uploadArguments.pluginAcquisition.acquire(ctx, requiredPlatforms, uploadArguments.importerPlatform, importerDistribution)
 		if acquireErr != nil {
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: plugin: %v\n", acquireErr)
 			return 1
 		}
-		return finishUpload(ctx, uploadArguments, stdout, stderr, version, agent, workflows, effectiveEvent, executablePath, executableContents, distributionDigest, importerStep, processingReports, out, runtimeDistributions)
+		return finishUpload(ctx, uploadArguments, stdout, stderr, version, agent, workflows, effectiveEvent, executablePath, distributionDigest, importerStep, processingReports, out, runtimeDistributions)
 	}
-	runtimeDistributions, err := loadRuntimeDistributions(runtimePaths)
+	requiredDistributionPaths := make(map[compiler.Platform]string, len(requiredPlatforms))
+	for platform := range requiredPlatforms {
+		if path, ok := uploadArguments.runtimeDistributionPaths[platform]; ok {
+			requiredDistributionPaths[platform] = path
+		}
+	}
+	configuredDistributions, err := loadRuntimeDistributions(requiredDistributionPaths)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
 		return 1
 	}
-	return finishUpload(ctx, uploadArguments, stdout, stderr, version, agent, workflows, effectiveEvent, executablePath, executableContents, distributionDigest, importerStep, processingReports, out, runtimeDistributions)
+	runtimeDistributions := make(map[compiler.Platform]runtimeDistribution, len(requiredPlatforms))
+	for _, platform := range []compiler.Platform{compiler.PlatformLinuxAMD64, compiler.PlatformDarwinARM64} {
+		if !requiredPlatforms[platform] {
+			continue
+		}
+		if configured, ok := configuredDistributions[platform]; ok {
+			runtimeDistributions[platform] = configured
+			continue
+		}
+		if platform == uploadArguments.importerPlatform {
+			runtimeDistributions[platform] = importerDistribution
+			continue
+		}
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: runtime distribution for %s is required by the selected workflows\n", platform)
+		return 1
+	}
+	return finishUpload(ctx, uploadArguments, stdout, stderr, version, agent, workflows, effectiveEvent, executablePath, distributionDigest, importerStep, processingReports, out, runtimeDistributions)
 }
 
-func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout, stderr io.Writer, version string, agent transport.Agent, workflows []workflowInput, effectiveEvent effectiveEventSelection, executablePath string, executableContents []byte, distributionDigest, importerStep string, processingReports []compatibility.ProcessingReport, out processingOutput, runtimeDistributions map[compiler.Platform]runtimeDistribution) int {
-	runtimeDigests := map[compiler.Platform]string{compiler.PlatformLinuxAMD64: distributionDigest}
+func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout, stderr io.Writer, version string, agent transport.Agent, workflows []workflowInput, effectiveEvent effectiveEventSelection, executablePath, distributionDigest, importerStep string, processingReports []compatibility.ProcessingReport, out processingOutput, runtimeDistributions map[compiler.Platform]runtimeDistribution) int {
+	runtimeDigests := make(map[compiler.Platform]string, len(runtimeDistributions))
 	for platform, runtimeDistribution := range runtimeDistributions {
 		runtimeDigests[platform] = runtimeDistribution.digest
 	}
@@ -1596,17 +1627,11 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 			out.annotate(processingReports[i])
 		}
 	}
-	artifacts := make([]transport.Artifact, 0, 1+len(runtimeDistributions)+len(planArtifacts))
-	distributionPath, err := buildkitepipeline.DistributionPath(distributionDigest)
-	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
-		return 1
-	}
-	artifacts = append(artifacts, transport.Artifact{Path: distributionPath, Digest: distributionDigest, Contents: executableContents})
-	artifactPaths := map[string]struct{}{distributionPath: {}}
+	artifacts := make([]transport.Artifact, 0, len(runtimeDistributions)+len(planArtifacts))
+	artifactPaths := make(map[string]struct{}, cap(artifacts))
 	for _, platform := range []compiler.Platform{compiler.PlatformLinuxAMD64, compiler.PlatformDarwinARM64} {
 		runtimeDistribution, ok := runtimeDistributions[platform]
-		if !ok || runtimeDistribution.digest == distributionDigest {
+		if !ok {
 			continue
 		}
 		path, pathErr := buildkitepipeline.DistributionPath(runtimeDistribution.digest)
@@ -1627,6 +1652,14 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 		}
 		artifactPaths[jobPlan.Path] = struct{}{}
 		artifacts = append(artifacts, transport.Artifact{Path: jobPlan.Path, Digest: jobPlan.Digest, Contents: jobPlan.Contents})
+	}
+	if len(artifacts) == 0 {
+		if err := agent.UploadPipeline(ctx, aggregatePipeline); err != nil {
+			_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: upload pipeline: %v\n", err)
+			return 1
+		}
+		_, _ = fmt.Fprintf(stdout, "Uploaded %d jobs from %d workflows using %s with importer %s.\n", jobCount, len(generatedWorkflows), executablePath, importerStep)
+		return 0
 	}
 	root, err := os.MkdirTemp("", "buildkite-gha-upload-")
 	if err != nil {
@@ -2276,6 +2309,7 @@ type parsedUploadArgs struct {
 	runtimeDistributionPaths map[compiler.Platform]string
 	runnerTargets            map[string]compiler.RunnerTarget
 	pluginAcquisition        *pluginRuntimeAcquisition
+	importerPlatform         compiler.Platform
 }
 
 func uploadArgs(args []string) (workflowOperands []string, eventPath string, err error) {
@@ -2460,7 +2494,10 @@ type pluginRuntimeAcquisition struct {
 	version string
 }
 
-const pluginDarwinAsset = "buildkite-gha_Darwin_arm64.tar.gz"
+const (
+	pluginLinuxAsset  = "buildkite-gha_Linux_x86_64.tar.gz"
+	pluginDarwinAsset = "buildkite-gha_Darwin_arm64.tar.gz"
+)
 
 func securePluginHTTPClient() *http.Client {
 	return &http.Client{
@@ -2477,66 +2514,92 @@ func securePluginHTTPClient() *http.Client {
 	}
 }
 
-func (a *pluginRuntimeAcquisition) acquire(ctx context.Context, required map[compiler.Platform]bool, linux runtimeDistribution) (map[compiler.Platform]runtimeDistribution, error) {
-	distributions := map[compiler.Platform]runtimeDistribution{}
-	if required[compiler.PlatformLinuxAMD64] {
-		distributions[compiler.PlatformLinuxAMD64] = linux
+func (a *pluginRuntimeAcquisition) acquire(ctx context.Context, required map[compiler.Platform]bool, hostPlatform compiler.Platform, host runtimeDistribution) (map[compiler.Platform]runtimeDistribution, error) {
+	distributions := make(map[compiler.Platform]runtimeDistribution, len(required))
+	devPaths := map[compiler.Platform]string{
+		compiler.PlatformLinuxAMD64:  os.Getenv(pluginDevLinuxRuntimeEnvironment),
+		compiler.PlatformDarwinARM64: os.Getenv(pluginDevDarwinRuntimeEnvironment),
 	}
-	injected := os.Getenv(pluginDevDarwinRuntimeEnvironment)
-	if a.version != "dev" && injected != "" {
-		return nil, fmt.Errorf("%s is test/dev-only and is rejected by release builds", pluginDevDarwinRuntimeEnvironment)
-	}
-	if !required[compiler.PlatformDarwinARM64] {
-		return distributions, nil
-	}
-	if a.version == "dev" {
-		if injected == "" {
-			return nil, fmt.Errorf("%s is required for a dev build using darwin/arm64", pluginDevDarwinRuntimeEnvironment)
+	if a.version != "dev" {
+		for platform, path := range devPaths {
+			if path != "" {
+				return nil, fmt.Errorf("%s is test/dev-only and is rejected by release builds", pluginDevRuntimeEnvironment(platform))
+			}
 		}
-		loaded, err := loadRuntimeDistributions(map[compiler.Platform]string{compiler.PlatformDarwinARM64: injected})
+	}
+	for _, platform := range []compiler.Platform{compiler.PlatformLinuxAMD64, compiler.PlatformDarwinARM64} {
+		if !required[platform] {
+			continue
+		}
+		if platform == hostPlatform {
+			distributions[platform] = host
+			continue
+		}
+		if a.version == "dev" {
+			path := devPaths[platform]
+			if path == "" {
+				return nil, fmt.Errorf("%s is required for a dev build using %s", pluginDevRuntimeEnvironment(platform), platform)
+			}
+			loaded, err := loadRuntimeDistributions(map[compiler.Platform]string{platform: path})
+			if err != nil {
+				return nil, err
+			}
+			distributions[platform] = loaded[platform]
+			continue
+		}
+		if !stableVersionPattern.MatchString(a.version) {
+			return nil, fmt.Errorf("running version %q is not a stable semantic version", a.version)
+		}
+		distribution, err := acquirePluginRuntime(ctx, a.version, platform, pluginHTTPClient, pluginReleaseBaseURL, pluginArchiveCachePath(a.version, pluginRuntimeAsset(platform)))
 		if err != nil {
 			return nil, err
 		}
-		distributions[compiler.PlatformDarwinARM64] = loaded[compiler.PlatformDarwinARM64]
-		return distributions, nil
+		distributions[platform] = distribution
 	}
-	if !stableVersionPattern.MatchString(a.version) {
-		return nil, fmt.Errorf("running version %q is not a stable semantic version", a.version)
-	}
-	darwin, err := acquirePluginDarwin(ctx, a.version, pluginHTTPClient, pluginReleaseBaseURL, pluginArchiveCachePath(a.version))
-	if err != nil {
-		return nil, err
-	}
-	distributions[compiler.PlatformDarwinARM64] = darwin
 	return distributions, nil
 }
 
-func acquirePluginDarwin(ctx context.Context, version string, client *http.Client, baseURL, cachePath string) (runtimeDistribution, error) {
+func pluginDevRuntimeEnvironment(platform compiler.Platform) string {
+	if platform == compiler.PlatformDarwinARM64 {
+		return pluginDevDarwinRuntimeEnvironment
+	}
+	return pluginDevLinuxRuntimeEnvironment
+}
+
+func pluginRuntimeAsset(platform compiler.Platform) string {
+	if platform == compiler.PlatformDarwinARM64 {
+		return pluginDarwinAsset
+	}
+	return pluginLinuxAsset
+}
+
+func acquirePluginRuntime(ctx context.Context, version string, platform compiler.Platform, client *http.Client, baseURL, cachePath string) (runtimeDistribution, error) {
+	asset := pluginRuntimeAsset(platform)
 	checksums, err := downloadPluginReleaseFile(ctx, client, baseURL+"/v"+version+"/checksums.txt", pluginChecksumLimit)
 	if err != nil {
 		return runtimeDistribution{}, fmt.Errorf("download release checksums: %w", err)
 	}
-	expected, err := pluginAssetChecksum(checksums, pluginDarwinAsset)
+	expected, err := pluginAssetChecksum(checksums, asset)
 	if err != nil {
 		return runtimeDistribution{}, err
 	}
 	archive := readVerifiedPluginArchiveCache(cachePath, expected)
 	if archive == nil {
-		archive, err = downloadPluginReleaseFile(ctx, client, baseURL+"/v"+version+"/"+pluginDarwinAsset, pluginArchiveLimit)
+		archive, err = downloadPluginReleaseFile(ctx, client, baseURL+"/v"+version+"/"+asset, pluginArchiveLimit)
 		if err != nil {
-			return runtimeDistribution{}, fmt.Errorf("download Darwin runtime: %w", err)
+			return runtimeDistribution{}, fmt.Errorf("download %s runtime: %w", platform, err)
 		}
 		if sha256.Sum256(archive) != expected {
-			return runtimeDistribution{}, fmt.Errorf("darwin archive checksum verification failed")
+			return runtimeDistribution{}, fmt.Errorf("%s archive checksum verification failed", platform)
 		}
 		writePluginArchiveCache(cachePath, archive)
 	}
-	contents, err := extractPluginDarwin(archive)
+	contents, err := extractPluginRuntime(archive, platform)
 	if err != nil {
 		return runtimeDistribution{}, err
 	}
-	if err := validateRuntimeDistributionBinary(compiler.PlatformDarwinARM64, contents); err != nil {
-		return runtimeDistribution{}, fmt.Errorf("validate Darwin runtime: %w", err)
+	if err := validateRuntimeDistributionBinary(platform, contents); err != nil {
+		return runtimeDistribution{}, fmt.Errorf("validate %s runtime: %w", platform, err)
 	}
 	digest := sha256.Sum256(contents)
 	return runtimeDistribution{contents: contents, digest: fmt.Sprintf("sha256:%x", digest)}, nil
@@ -2586,10 +2649,10 @@ func pluginAssetChecksum(contents []byte, asset string) ([sha256.Size]byte, erro
 	return result, nil
 }
 
-func extractPluginDarwin(archive []byte) ([]byte, error) {
+func extractPluginRuntime(archive []byte, platform compiler.Platform) ([]byte, error) {
 	gzipReader, err := gzip.NewReader(bytes.NewReader(archive))
 	if err != nil {
-		return nil, fmt.Errorf("open Darwin archive: %w", err)
+		return nil, fmt.Errorf("open %s archive: %w", platform, err)
 	}
 	defer func() { _ = gzipReader.Close() }()
 	tarReader := tar.NewReader(gzipReader)
@@ -2601,42 +2664,42 @@ func extractPluginDarwin(archive []byte) ([]byte, error) {
 			break
 		}
 		if err != nil {
-			return nil, fmt.Errorf("read Darwin archive: %w", err)
+			return nil, fmt.Errorf("read %s archive: %w", platform, err)
 		}
 		if header.Typeflag != tar.TypeReg || header.Size < 0 || header.Size > runtimeDistributionLimit {
-			return nil, fmt.Errorf("darwin archive contains an unsafe member %q", header.Name)
+			return nil, fmt.Errorf("%s archive contains an unsafe member %q", platform, header.Name)
 		}
 		switch header.Name {
 		case "buildkite-gha":
 			if seenBinary || header.Mode&0o111 == 0 {
-				return nil, fmt.Errorf("darwin archive has an invalid executable member")
+				return nil, fmt.Errorf("%s archive has an invalid executable member", platform)
 			}
 			seenBinary = true
 			executable, err = io.ReadAll(io.LimitReader(tarReader, runtimeDistributionLimit+1))
 			if err != nil || int64(len(executable)) != header.Size {
-				return nil, fmt.Errorf("read Darwin executable")
+				return nil, fmt.Errorf("read %s executable", platform)
 			}
 		case "LICENSE":
 			if seenLicense {
-				return nil, fmt.Errorf("darwin archive contains duplicate LICENSE")
+				return nil, fmt.Errorf("%s archive contains duplicate LICENSE", platform)
 			}
 			seenLicense = true
 		default:
-			return nil, fmt.Errorf("darwin archive contains unexpected member %q", header.Name)
+			return nil, fmt.Errorf("%s archive contains unexpected member %q", platform, header.Name)
 		}
 	}
 	if !seenBinary || !seenLicense {
-		return nil, fmt.Errorf("darwin archive must contain exactly buildkite-gha and LICENSE")
+		return nil, fmt.Errorf("%s archive must contain exactly buildkite-gha and LICENSE", platform)
 	}
 	return executable, nil
 }
 
-func pluginArchiveCachePath(version string) string {
+func pluginArchiveCachePath(version, asset string) string {
 	root := os.Getenv("MISE_DATA_DIR")
 	if !filepath.IsAbs(root) {
 		return ""
 	}
-	return filepath.Join(root, "buildkite-gha", "releases", version, pluginDarwinAsset)
+	return filepath.Join(root, "buildkite-gha", "releases", version, asset)
 }
 
 func readVerifiedPluginArchiveCache(path string, expected [sha256.Size]byte) []byte {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -248,7 +249,25 @@ func TestConfiguredLinuxRunnerTargetsDefaultHostedToolchainImages(t *testing.T) 
 	}
 }
 
-func TestUploadRejectsDarwinImporterBeforeProcessing(t *testing.T) {
+func TestImporterPlatform(t *testing.T) {
+	for _, test := range []struct {
+		goos, goarch string
+		want         compiler.Platform
+	}{
+		{goos: "linux", goarch: "amd64", want: compiler.PlatformLinuxAMD64},
+		{goos: "darwin", goarch: "arm64", want: compiler.PlatformDarwinARM64},
+	} {
+		got, err := importerPlatform(test.goos, test.goarch)
+		if err != nil || got != test.want {
+			t.Fatalf("importerPlatform(%q, %q) = %s, %v", test.goos, test.goarch, got, err)
+		}
+	}
+	if _, err := importerPlatform("linux", "arm64"); err == nil || !strings.Contains(err.Error(), "linux/amd64 or darwin/arm64") {
+		t.Fatalf("unsupported importer error = %v", err)
+	}
+}
+
+func TestUploadRejectsUnsupportedImporterBeforeProcessing(t *testing.T) {
 	workflowPath := filepath.Join(t.TempDir(), "linux.yml")
 	if err := os.WriteFile(workflowPath, []byte("on: push\njobs:\n  linux:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo linux\n"), 0o600); err != nil {
 		t.Fatal(err)
@@ -269,16 +288,35 @@ func TestUploadRejectsDarwinImporterBeforeProcessing(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			runner := &cliCaptureRunner{}
 			var stdout, stderr bytes.Buffer
-			if code := uploadFromPlatform("darwin", "arm64", test.args, &stdout, &stderr, "dev", transport.Agent{Runner: runner}); code != 1 {
+			if code := uploadFromPlatform("linux", "arm64", test.args, &stdout, &stderr, "dev", transport.Agent{Runner: runner}); code != 1 {
 				t.Fatalf("uploadFromPlatform() code = %d, want 1", code)
 			}
-			if got := stderr.String(); got != "buildkite-gha: upload: importer requires linux/amd64, running on darwin/arm64\n" {
+			if got := stderr.String(); got != "buildkite-gha: upload: importer requires linux/amd64 or darwin/arm64, running on linux/arm64\n" {
 				t.Fatalf("stderr = %q", got)
 			}
 			if stdout.Len() != 0 || len(runner.commands) != 0 || len(runner.uploaded) != 0 {
-				t.Fatalf("Darwin importer performed work: stdout = %q, commands = %d, uploads = %d", stdout.String(), len(runner.commands), len(runner.uploaded))
+				t.Fatalf("unsupported importer performed work: stdout = %q, commands = %d, uploads = %d", stdout.String(), len(runner.commands), len(runner.uploaded))
 			}
 		})
+	}
+}
+
+func TestDarwinUploadRequiresLinuxDistributionForLinuxWorkflow(t *testing.T) {
+	workflowPath := filepath.Join(t.TempDir(), "linux.yml")
+	if err := os.WriteFile(workflowPath, []byte("on: push\njobs:\n  linux:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo linux\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_STEP_KEY", "darwin-importer")
+	runner := &cliCaptureRunner{}
+	var stdout, stderr bytes.Buffer
+	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
+	code := uploadFromPlatform("darwin", "arm64", []string{"--event-path", eventPath, workflowPath}, &stdout, &stderr, "dev", transport.Agent{Runner: runner})
+	if code != 1 || !strings.Contains(stderr.String(), "runtime distribution for linux/amd64 is required by the selected workflows") {
+		t.Fatalf("uploadFromPlatform() = %d, stderr = %q", code, stderr.String())
+	}
+	if len(runner.uploaded) != 0 {
+		t.Fatalf("missing runtime reached artifact upload: %#v", runner.uploaded)
 	}
 }
 
@@ -521,23 +559,107 @@ func TestPluginPublishesMixedRuntimeDistributions(t *testing.T) {
 	}
 }
 
-func TestPluginDevDarwinInjectionIsRequiredAndReleaseRejectsIt(t *testing.T) {
+func TestPluginRunsNativelyOnDarwinARM64(t *testing.T) {
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		t.Skip("native Darwin/arm64 importer test")
+	}
+	const fullCommit = "0123456789abcdef0123456789abcdef01234567"
+	repository := writeUploadWorkflowRepository(t, map[string]string{
+		"macos.yml": "on: push\njobs:\n  macos:\n    runs-on: macos-15\n    steps:\n      - run: echo macos\n",
+	})
+	t.Chdir(repository)
+	configuration, err := json.Marshal(map[string]any{
+		"workflow": filepath.Join(".github", "workflows", "macos.yml"),
+		"runners":  []map[string]string{{"runs-on": "macos-15", "queue": "macos"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(pluginConfigurationEnvironment, string(configuration))
+	setCLIPluginBuildkiteEnvironment(t, "plugin-darwin-importer")
+	t.Setenv("BUILDKITE_COMMIT", "HEAD")
+	runner := &cliCaptureRunner{gitOutput: []byte(fullCommit + "\n")}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"plugin"}, &stdout, &stderr, "dev", runner); code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Uploaded 1 jobs") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+	for path, contents := range runner.uploaded {
+		if !strings.HasSuffix(path, ".json") {
+			continue
+		}
+		job, err := plan.Decode(contents)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if job.RuntimeDistributionDigest() != cliTestRuntimeDigest() {
+			t.Fatalf("Darwin job runtime = %q, want importer %q", job.RuntimeDistributionDigest(), cliTestRuntimeDigest())
+		}
+		return
+	}
+	t.Fatal("Darwin importer did not upload a job plan")
+}
+
+func TestPluginDevCounterpartInjectionIsRequiredAndReleaseRejectsIt(t *testing.T) {
 	linux := runtimeDistribution{contents: []byte("linux"), digest: "sha256:linux"}
 	required := map[compiler.Platform]bool{compiler.PlatformDarwinARM64: true}
 	t.Setenv(pluginDevDarwinRuntimeEnvironment, "")
-	if _, err := (&pluginRuntimeAcquisition{version: "dev"}).acquire(context.Background(), required, linux); err == nil || !strings.Contains(err.Error(), "required") {
+	if _, err := (&pluginRuntimeAcquisition{version: "dev"}).acquire(context.Background(), required, compiler.PlatformLinuxAMD64, linux); err == nil || !strings.Contains(err.Error(), "required") {
 		t.Fatalf("dev acquisition error = %v", err)
 	}
+	darwin := runtimeDistribution{contents: []byte("darwin"), digest: "sha256:darwin"}
+	if _, err := (&pluginRuntimeAcquisition{version: "dev"}).acquire(context.Background(), map[compiler.Platform]bool{compiler.PlatformLinuxAMD64: true}, compiler.PlatformDarwinARM64, darwin); err == nil || !strings.Contains(err.Error(), pluginDevLinuxRuntimeEnvironment) {
+		t.Fatalf("Darwin-hosted dev acquisition error = %v", err)
+	}
 	t.Setenv(pluginDevDarwinRuntimeEnvironment, filepath.Join(t.TempDir(), "injected"))
-	if _, err := (&pluginRuntimeAcquisition{version: "1.2.3"}).acquire(context.Background(), map[compiler.Platform]bool{}, linux); err == nil || !strings.Contains(err.Error(), "rejected") {
+	if _, err := (&pluginRuntimeAcquisition{version: "1.2.3"}).acquire(context.Background(), map[compiler.Platform]bool{}, compiler.PlatformLinuxAMD64, linux); err == nil || !strings.Contains(err.Error(), "rejected") {
 		t.Fatalf("release injection error = %v", err)
 	}
+}
+
+func TestPluginAcquiresVerifiedLinuxRuntimeForDarwinHost(t *testing.T) {
+	linux := pluginTestLinuxExecutable()
+	archive := pluginTestArchive(t, linux, false)
+	archiveDigest := sha256.Sum256(archive)
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		switch filepath.Base(request.URL.Path) {
+		case "checksums.txt":
+			_, _ = fmt.Fprintf(response, "%x  %s\n", archiveDigest, pluginLinuxAsset)
+		case pluginLinuxAsset:
+			_, _ = response.Write(archive)
+		default:
+			http.NotFound(response, request)
+		}
+	}))
+	defer server.Close()
+	distribution, err := acquirePluginRuntime(context.Background(), "1.2.3", compiler.PlatformLinuxAMD64, server.Client(), server.URL, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if distribution.digest != transport.Digest(linux) || !bytes.Equal(distribution.contents, linux) {
+		t.Fatalf("Linux distribution = %q, %d bytes", distribution.digest, len(distribution.contents))
+	}
+}
+
+func pluginTestLinuxExecutable() []byte {
+	contents := make([]byte, 64)
+	copy(contents, []byte("\x7fELF"))
+	contents[4] = 2                                    // ELFCLASS64
+	contents[5] = 1                                    // ELFDATA2LSB
+	contents[6] = 1                                    // EV_CURRENT
+	binary.LittleEndian.PutUint16(contents[16:18], 2)  // ET_EXEC
+	binary.LittleEndian.PutUint16(contents[18:20], 62) // EM_X86_64
+	binary.LittleEndian.PutUint32(contents[20:24], 1)  // EV_CURRENT
+	binary.LittleEndian.PutUint16(contents[52:54], 64) // ELF header size
+	return contents
 }
 
 func TestPluginAcquisitionIsLazyAndBindsVerifiedDarwinContents(t *testing.T) {
 	linux := runtimeDistribution{contents: []byte("running executable"), digest: "sha256:running"}
 	t.Setenv(pluginDevDarwinRuntimeEnvironment, "")
-	got, err := (&pluginRuntimeAcquisition{version: "dev"}).acquire(context.Background(), map[compiler.Platform]bool{compiler.PlatformLinuxAMD64: true}, linux)
+	got, err := (&pluginRuntimeAcquisition{version: "dev"}).acquire(context.Background(), map[compiler.Platform]bool{compiler.PlatformLinuxAMD64: true}, compiler.PlatformLinuxAMD64, linux)
 	if err != nil || got[compiler.PlatformLinuxAMD64].digest != linux.digest {
 		t.Fatalf("Linux-only acquisition = %#v, %v", got, err)
 	}
@@ -559,7 +681,7 @@ func TestPluginAcquisitionIsLazyAndBindsVerifiedDarwinContents(t *testing.T) {
 	}))
 	defer server.Close()
 	cache := filepath.Join(canonicalTempDir(t), pluginDarwinAsset)
-	distribution, err := acquirePluginDarwin(context.Background(), "1.2.3", server.Client(), server.URL, cache)
+	distribution, err := acquirePluginRuntime(context.Background(), "1.2.3", compiler.PlatformDarwinARM64, server.Client(), server.URL, cache)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -567,7 +689,7 @@ func TestPluginAcquisitionIsLazyAndBindsVerifiedDarwinContents(t *testing.T) {
 	if distribution.digest != wantDigest || !bytes.Equal(distribution.contents, darwin) {
 		t.Fatalf("Darwin distribution = %q, %x", distribution.digest, distribution.contents)
 	}
-	if _, err := acquirePluginDarwin(context.Background(), "1.2.3", server.Client(), server.URL, cache); err != nil {
+	if _, err := acquirePluginRuntime(context.Background(), "1.2.3", compiler.PlatformDarwinARM64, server.Client(), server.URL, cache); err != nil {
 		t.Fatal(err)
 	}
 	if requests["/v1.2.3/checksums.txt"] != 2 || requests["/v1.2.3/"+pluginDarwinAsset] != 1 {
@@ -576,7 +698,7 @@ func TestPluginAcquisitionIsLazyAndBindsVerifiedDarwinContents(t *testing.T) {
 	if err := os.WriteFile(cache, []byte("untrusted cache"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := acquirePluginDarwin(context.Background(), "1.2.3", server.Client(), server.URL, cache); err != nil {
+	if _, err := acquirePluginRuntime(context.Background(), "1.2.3", compiler.PlatformDarwinARM64, server.Client(), server.URL, cache); err != nil {
 		t.Fatal(err)
 	}
 	if requests["/v1.2.3/checksums.txt"] != 3 || requests["/v1.2.3/"+pluginDarwinAsset] != 2 {
@@ -591,7 +713,7 @@ func TestPluginDarwinRejectsChecksumArchiveAndBinaryFailures(t *testing.T) {
 	if _, err := pluginAssetChecksum([]byte(fmt.Sprintf("%x  %s\n%x  %s\n", digest, pluginDarwinAsset, digest, pluginDarwinAsset)), pluginDarwinAsset); err == nil || !strings.Contains(err.Error(), "exactly one") {
 		t.Fatalf("duplicate checksum error = %v", err)
 	}
-	if _, err := extractPluginDarwin(pluginTestArchive(t, validBinary, true)); err == nil || !strings.Contains(err.Error(), "unexpected member") {
+	if _, err := extractPluginRuntime(pluginTestArchive(t, validBinary, true), compiler.PlatformDarwinARM64); err == nil || !strings.Contains(err.Error(), "unexpected member") {
 		t.Fatalf("unsafe archive error = %v", err)
 	}
 	wrong := pluginTestArchive(t, []byte("not Mach-O"), false)
@@ -604,7 +726,7 @@ func TestPluginDarwinRejectsChecksumArchiveAndBinaryFailures(t *testing.T) {
 		_, _ = response.Write(wrong)
 	}))
 	defer server.Close()
-	if _, err := acquirePluginDarwin(context.Background(), "1.2.3", server.Client(), server.URL, ""); err == nil || !strings.Contains(err.Error(), "Mach-O") {
+	if _, err := acquirePluginRuntime(context.Background(), "1.2.3", compiler.PlatformDarwinARM64, server.Client(), server.URL, ""); err == nil || !strings.Contains(err.Error(), "Mach-O") {
 		t.Fatalf("wrong binary error = %v", err)
 	}
 }
@@ -2564,7 +2686,7 @@ func TestRunUploadPublishesMixedRuntimeDistributions(t *testing.T) {
 		t.Fatal(err)
 	}
 	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
-	_, importerContents, importerDigest, err := executable()
+	_, importerContents, _, err := executable()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2605,7 +2727,7 @@ func TestRunUploadPublishesMixedRuntimeDistributions(t *testing.T) {
 		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
 	}
 
-	wantDistributionDigests := []string{importerDigest, linuxDigest, darwinDigest}
+	wantDistributionDigests := []string{linuxDigest, darwinDigest}
 	for _, digest := range wantDistributionDigests {
 		path, err := buildkitepipeline.DistributionPath(digest)
 		if err != nil {
@@ -2621,8 +2743,8 @@ func TestRunUploadPublishesMixedRuntimeDistributions(t *testing.T) {
 			artifactUploads[command.args[2]]++
 		}
 	}
-	if len(runner.uploaded) != 5 {
-		t.Fatalf("uploaded artifacts = %#v, want importer, two runtimes, and two plans", runner.uploaded)
+	if len(runner.uploaded) != 4 {
+		t.Fatalf("uploaded artifact count = %d, want two runtimes and two plans", len(runner.uploaded))
 	}
 	for path, count := range artifactUploads {
 		if count != 1 {


### PR DESCRIPTION
## Why

The released CLI already includes a Darwin arm64 artifact, but the importer rejects that platform and assumes its executable is the Linux job runtime. This prevents the plugin importer from running natively on macOS and makes importer targeting easy to confuse with generated-job queues.

## What

Allow importer execution on Linux amd64 or Darwin arm64. Plan applicable workflows first, then acquire, verify, and upload only the required same-release runtime distributions. Reuse the importer executable only for its matching platform and fail before artifact upload when a required counterpart is unavailable. Clarify the independent importer and generated-job targeting contracts in the docs.

Companion plugin change: buildkite-plugins/github-actions-buildkite-plugin#44.