### PR TITLE
Emit job-scoped buildkite-gha telemetry

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -180,4 +180,10 @@ supported.
 
 The deprecated `--runtime-queue hosted` argument is accepted as a no-op for compatibility with plugin releases that pass it. Other values are rejected.
 
+## Disable telemetry
+
+In Buildkite jobs, the plugin importer and `run-job` send best-effort completion telemetry through the job-authenticated Buildkite Agent API. Events contain the command, outcome, client version, duration, and bounded diagnostic codes and severities. They do not contain diagnostic messages, workflow content, repository details, paths, action references, expressions, environment variables, or command text.
+
+Set `BUILDKITE_GHA_TELEMETRY_DISABLED=true` to disable telemetry. Missing Agent endpoint, job ID, or job token also disables it. Telemetry failures do not change command results.
+
 `run-job` is internal. Users should not invoke it directly.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1647,6 +1647,9 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 		writeCompilerWarnings(stderr, "upload", input.CanonicalPath, bundle.IR.Warnings)
 		if uploadArguments.telemetry != nil {
 			uploadArguments.telemetry.addWarnings(bundle.IR.Warnings)
+			if preflight.HasActions {
+				uploadArguments.telemetry.addActionRuntimeUnknown()
+			}
 		}
 	}
 	aggregatePipeline, err := buildkitepipeline.Emit(buildkitepipeline.Pipeline{

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -162,11 +162,17 @@ func run(args []string, stdout, stderr io.Writer, version string, agentRunner tr
 	}
 }
 
-func plugin(args []string, stdout, stderr io.Writer, version string, runner transport.Runner) (code int) {
+func plugin(args []string, stdout, stderr io.Writer, version string, runner transport.Runner) int {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	return pluginContext(ctx, args, stdout, stderr, version, runner)
+}
+
+func pluginContext(ctx context.Context, args []string, stdout, stderr io.Writer, version string, runner transport.Runner) (code int) {
 	started := time.Now()
 	details := &commandTelemetryDetails{}
 	defer func() {
-		outcome := telemetryOutcome(code, "", nil)
+		outcome := telemetryOutcome(code, "", ctx.Err())
 		emitCommandTelemetry(telemetry.CommandPluginImport, outcome, version, time.Since(started), details.forOutcome(outcome))
 	}()
 	if len(args) != 0 {
@@ -180,11 +186,11 @@ func plugin(args []string, stdout, stderr io.Writer, version string, runner tran
 	if err != nil {
 		return usageError(stderr, "plugin: %v", err)
 	}
-	if err := normalizePluginCommit(context.Background(), os.Getenv, os.Setenv, runner); err != nil {
+	if err := normalizePluginCommit(ctx, os.Getenv, os.Setenv, runner); err != nil {
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: plugin: %v\n", err)
 		return 1
 	}
-	return uploadParsed(parsedUploadArgs{
+	return uploadParsedContext(ctx, parsedUploadArgs{
 		workflowOperands:      configuration.Workflows,
 		explicitWorkflowPaths: true,
 		runnerTargets:         configuration.runnerTargets,
@@ -602,14 +608,15 @@ func telemetryOutcome(code int, conclusion string, contextErr error) telemetry.O
 	switch conclusion {
 	case "cancelled":
 		return telemetry.OutcomeCancelled
-	case "skipped":
-		return telemetry.OutcomeSkipped
 	}
 	if errors.Is(contextErr, context.Canceled) || errors.Is(contextErr, context.DeadlineExceeded) {
 		return telemetry.OutcomeCancelled
 	}
 	if code != 0 || conclusion == "failure" {
 		return telemetry.OutcomeFailure
+	}
+	if conclusion == "skipped" {
+		return telemetry.OutcomeSkipped
 	}
 	return telemetry.OutcomeSuccess
 }
@@ -1432,6 +1439,12 @@ func uploadFromPlatform(goos, goarch string, args []string, stdout, stderr io.Wr
 }
 
 func uploadParsed(uploadArguments parsedUploadArgs, stdout, stderr io.Writer, version string, agent transport.Agent) int {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	return uploadParsedContext(ctx, uploadArguments, stdout, stderr, version, agent)
+}
+
+func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, stdout, stderr io.Writer, version string, agent transport.Agent) int {
 	workflowOperands, eventPath := uploadArguments.workflowOperands, uploadArguments.eventPath
 	importerStep := os.Getenv("BUILDKITE_STEP_KEY")
 	if os.Getenv("BUILDKITE") != "true" || strings.TrimSpace(importerStep) == "" {
@@ -1480,8 +1493,6 @@ func uploadParsed(uploadArguments parsedUploadArgs, stdout, stderr io.Writer, ve
 		_, _ = fmt.Fprintln(stderr, "buildkite-gha: upload: workflow paths matched only reusable workflow_call workflows; there is nothing to upload")
 		return 1
 	}
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
 	for _, input := range workflows {
 		if input.ReusableOnly {
 			continue

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1691,7 +1691,7 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 		writeCompilerWarnings(stderr, "upload", input.CanonicalPath, bundle.IR.Warnings)
 		if uploadArguments.telemetry != nil {
 			uploadArguments.telemetry.addWarnings(bundle.IR.Warnings)
-			if preflight.HasActions {
+			if bundleUsesActions(bundle) {
 				uploadArguments.telemetry.addActionRuntimeUnknown()
 			}
 		}
@@ -1706,8 +1706,8 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 	}
 	for i, input := range workflows {
 		if input.Applicable {
-			if out.observe != nil {
-				out.observe(processingReports[i])
+			if uploadArguments.telemetry != nil {
+				uploadArguments.telemetry.addReportDiagnostics(processingReports[i])
 			}
 			_ = compatibility.WriteProcessing(stdout, "text", processingReports[i])
 			if !processingReportHasErrors(processingReports[i]) {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -36,6 +36,7 @@ import (
 	"github.com/buildkite/buildkite-gha/internal/compiler"
 	"github.com/buildkite/buildkite-gha/internal/plan"
 	gharuntime "github.com/buildkite/buildkite-gha/internal/runtime"
+	"github.com/buildkite/buildkite-gha/internal/telemetry"
 	"github.com/buildkite/buildkite-gha/internal/transport"
 	"github.com/buildkite/buildkite-gha/internal/workflow"
 )
@@ -161,7 +162,13 @@ func run(args []string, stdout, stderr io.Writer, version string, agentRunner tr
 	}
 }
 
-func plugin(args []string, stdout, stderr io.Writer, version string, runner transport.Runner) int {
+func plugin(args []string, stdout, stderr io.Writer, version string, runner transport.Runner) (code int) {
+	started := time.Now()
+	details := &commandTelemetryDetails{}
+	defer func() {
+		outcome := telemetryOutcome(code, "", nil)
+		emitCommandTelemetry(telemetry.CommandPluginImport, outcome, version, time.Since(started), details.forOutcome(telemetry.CommandPluginImport, outcome))
+	}()
 	if len(args) != 0 {
 		return usageError(stderr, "plugin does not accept arguments")
 	}
@@ -182,6 +189,7 @@ func plugin(args []string, stdout, stderr io.Writer, version string, runner tran
 		explicitWorkflowPaths: true,
 		runnerTargets:         configuration.runnerTargets,
 		pluginAcquisition:     &pluginRuntimeAcquisition{version: version},
+		telemetry:             details,
 	}, stdout, stderr, version, transport.Agent{Runner: runner})
 }
 
@@ -339,7 +347,14 @@ func runJob(args []string, stdout, stderr io.Writer, version string, agent trans
 	return runJobContext(ctx, args, stdout, stderr, version, agent)
 }
 
-func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer, version string, agent transport.Agent) int {
+func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer, version string, agent transport.Agent) (code int) {
+	started := time.Now()
+	var result gharuntime.JobResult
+	defer func() {
+		outcome := telemetryOutcome(code, result.Conclusion, ctx.Err())
+		details := (&commandTelemetryDetails{}).forOutcome(telemetry.CommandRunJob, outcome)
+		emitCommandTelemetry(telemetry.CommandRunJob, outcome, version, time.Since(started), details)
+	}()
 	options, err := runJobArgs(args)
 	if err != nil {
 		return usageError(stderr, "run-job: %v", err)
@@ -516,7 +531,6 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 			}
 		}()
 	}
-	var result gharuntime.JobResult
 	var runErr error
 	if len(job.NeedSources) != 0 {
 		job.Needs, runErr = gharuntime.ResolveNeeds(ctx, agent, artifactRoot, producer.BuildID, job.NeedSources, job.NeedOutputs)
@@ -562,6 +576,42 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 		return 1
 	}
 	return 0
+}
+
+func emitCommandTelemetry(command telemetry.Command, outcome telemetry.Outcome, version string, duration time.Duration, details telemetry.Details) {
+	client, err := telemetry.New(telemetry.Config{
+		Endpoint:      os.Getenv("BUILDKITE_AGENT_ENDPOINT"),
+		JobID:         os.Getenv("BUILDKITE_JOB_ID"),
+		JobToken:      os.Getenv("BUILDKITE_AGENT_ACCESS_TOKEN"),
+		ClientVersion: version,
+		Disabled:      os.Getenv("BUILDKITE_GHA_TELEMETRY_DISABLED") == "true",
+	})
+	if err != nil || client == nil {
+		return
+	}
+	_ = client.Emit(command, outcome, duration, details)
+}
+
+func telemetryOutcome(code int, conclusion string, contextErr error) telemetry.Outcome {
+	if code == 2 {
+		return telemetry.OutcomeUsageError
+	}
+	if code == buildkitepipeline.ContinueOnErrorExitStatus {
+		return telemetry.OutcomeToleratedFailure
+	}
+	switch conclusion {
+	case "cancelled":
+		return telemetry.OutcomeCancelled
+	case "skipped":
+		return telemetry.OutcomeSkipped
+	}
+	if errors.Is(contextErr, context.Canceled) || errors.Is(contextErr, context.DeadlineExceeded) {
+		return telemetry.OutcomeCancelled
+	}
+	if code != 0 || conclusion == "failure" {
+		return telemetry.OutcomeFailure
+	}
+	return telemetry.OutcomeSuccess
 }
 
 func resolveRuntimeMise(ctx context.Context, configured, dataDir, privateRuntime string, stderr io.Writer) (string, error) {
@@ -1393,6 +1443,9 @@ func uploadParsed(uploadArguments parsedUploadArgs, stdout, stderr io.Writer, ve
 		}
 	}
 	out := newProcessingOutput("upload", "text", stderr, stderr, agent)
+	if uploadArguments.telemetry != nil {
+		out.observe = uploadArguments.telemetry.observe
+	}
 	var workflows []workflowInput
 	var err error
 	if uploadArguments.explicitWorkflowPaths {
@@ -1581,6 +1634,9 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 		processingReports[i].Admission.Result = "admitted"
 		processingReports[i].Result = "admitted"
 		writeCompilerWarnings(stderr, "upload", input.CanonicalPath, bundle.IR.Warnings)
+		if uploadArguments.telemetry != nil {
+			uploadArguments.telemetry.addWarnings(bundle.IR.Warnings)
+		}
 	}
 	aggregatePipeline, err := buildkitepipeline.Emit(buildkitepipeline.Pipeline{
 		CompilerStep: importerStep,
@@ -1592,6 +1648,9 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 	}
 	for i, input := range workflows {
 		if input.Applicable {
+			if out.observe != nil {
+				out.observe(processingReports[i])
+			}
 			_ = compatibility.WriteProcessing(stdout, "text", processingReports[i])
 			out.annotate(processingReports[i])
 		}
@@ -2276,6 +2335,7 @@ type parsedUploadArgs struct {
 	runtimeDistributionPaths map[compiler.Platform]string
 	runnerTargets            map[string]compiler.RunnerTarget
 	pluginAcquisition        *pluginRuntimeAcquisition
+	telemetry                *commandTelemetryDetails
 }
 
 func uploadArgs(args []string) (workflowOperands []string, eventPath string, err error) {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -167,7 +167,7 @@ func plugin(args []string, stdout, stderr io.Writer, version string, runner tran
 	details := &commandTelemetryDetails{}
 	defer func() {
 		outcome := telemetryOutcome(code, "", nil)
-		emitCommandTelemetry(telemetry.CommandPluginImport, outcome, version, time.Since(started), details.forOutcome(telemetry.CommandPluginImport, outcome))
+		emitCommandTelemetry(telemetry.CommandPluginImport, outcome, version, time.Since(started), details.forOutcome(outcome))
 	}()
 	if len(args) != 0 {
 		return usageError(stderr, "plugin does not accept arguments")
@@ -352,7 +352,7 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 	var result gharuntime.JobResult
 	defer func() {
 		outcome := telemetryOutcome(code, result.Conclusion, ctx.Err())
-		details := (&commandTelemetryDetails{}).forOutcome(telemetry.CommandRunJob, outcome)
+		details := (&commandTelemetryDetails{}).forOutcome(outcome)
 		emitCommandTelemetry(telemetry.CommandRunJob, outcome, version, time.Since(started), details)
 	}()
 	options, err := runJobArgs(args)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1691,7 +1691,7 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 		writeCompilerWarnings(stderr, "upload", input.CanonicalPath, bundle.IR.Warnings)
 		if uploadArguments.telemetry != nil {
 			uploadArguments.telemetry.addWarnings(bundle.IR.Warnings)
-			if bundleUsesActions(bundle) {
+			if bundleRunsUnprovenActions(bundle) {
 				uploadArguments.telemetry.addActionRuntimeUnknown()
 			}
 		}
@@ -2412,6 +2412,22 @@ func irUsesActions(ir compiler.IR) bool {
 	for _, job := range ir.Jobs {
 		for _, step := range job.Steps {
 			if step.Uses != "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// bundleRunsUnprovenActions reports whether a compiled bundle executes action
+// code the compiler never ran. Actions a native adapter replaces keep both
+// their locks and their `uses` steps in the plan, so the adapter decision is
+// the only thing separating them from actions that really run.
+func bundleRunsUnprovenActions(bundle compiler.Bundle) bool {
+	for _, artifact := range bundle.Plans {
+		for _, lock := range artifact.Job.Actions {
+			identity := actionintegration.Identity{Source: lock.Source, Repository: lock.Repository, Path: lock.Path}
+			if !actionintegration.UsesNativeAdapter(identity) {
 				return true
 			}
 		}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/buildkite/buildkite-gha/internal/compiler"
 	"github.com/buildkite/buildkite-gha/internal/plan"
 	gharuntime "github.com/buildkite/buildkite-gha/internal/runtime"
+	"github.com/buildkite/buildkite-gha/internal/telemetry"
 	"github.com/buildkite/buildkite-gha/internal/transport"
 	"go.yaml.in/yaml/v4"
 )
@@ -136,6 +137,141 @@ func TestPluginIsHiddenAndZeroArgument(t *testing.T) {
 		if stdout.Len() != 0 || strings.Contains(stderr.String(), "buildkite-gha plugin") {
 			t.Fatalf("Run(%q) exposed plugin help: stdout=%q stderr=%q", args, stdout.String(), stderr.String())
 		}
+	}
+}
+
+func TestCommandCompletionTelemetryPlacementAndExitSemantics(t *testing.T) {
+	type event struct {
+		Event      string `json:"event"`
+		Properties struct {
+			Command       string `json:"command"`
+			Outcome       string `json:"outcome"`
+			ClientVersion string `json:"client_version"`
+			DurationMS    int64  `json:"duration_ms"`
+			FailurePhase  string `json:"failure_phase"`
+			FailureCode   string `json:"failure_code"`
+		} `json:"properties"`
+	}
+	events := make(chan event, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Token telemetry-token" {
+			t.Errorf("Authorization = %q", got)
+		}
+		var received event
+		if err := json.NewDecoder(r.Body).Decode(&received); err != nil {
+			t.Errorf("decode telemetry event: %v", err)
+		}
+		events <- received
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+	t.Setenv("BUILDKITE_AGENT_ENDPOINT", server.URL+"/v3")
+	t.Setenv("BUILDKITE_JOB_ID", cliTestJobID)
+	t.Setenv("BUILDKITE_AGENT_ACCESS_TOKEN", "telemetry-token")
+	t.Setenv("BUILDKITE_GHA_TELEMETRY_DISABLED", "")
+
+	for _, test := range []struct {
+		args        []string
+		wantCode    int
+		wantCommand string
+	}{
+		{args: []string{"plugin", "unexpected"}, wantCode: 2, wantCommand: "plugin_import"},
+		{args: []string{"run-job", "--unknown"}, wantCode: 2, wantCommand: "run_job"},
+	} {
+		var stdout, stderr bytes.Buffer
+		if code := run(test.args, &stdout, &stderr, "test-version", &cliCaptureRunner{}); code != test.wantCode {
+			t.Fatalf("run(%q) code = %d, stderr = %q; want %d", test.args, code, stderr.String(), test.wantCode)
+		}
+		received := <-events
+		if received.Event != "pipelines:buildkite_gha:command_completed" || received.Properties.Command != test.wantCommand || received.Properties.Outcome != "usage_error" || received.Properties.ClientVersion != "test-version" || received.Properties.DurationMS < 0 || received.Properties.FailurePhase != "configuration" || received.Properties.FailureCode != "unknown" {
+			t.Fatalf("run(%q) event = %#v", test.args, received)
+		}
+	}
+}
+
+func TestCommandCompletionTelemetryOptOut(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+	t.Setenv("BUILDKITE_AGENT_ENDPOINT", server.URL)
+	t.Setenv("BUILDKITE_JOB_ID", cliTestJobID)
+	t.Setenv("BUILDKITE_AGENT_ACCESS_TOKEN", "telemetry-token")
+	t.Setenv("BUILDKITE_GHA_TELEMETRY_DISABLED", "true")
+
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"run-job", "--unknown"}, &stdout, &stderr, "dev", &cliCaptureRunner{}); code != 2 {
+		t.Fatalf("run() code = %d, stderr = %q; want 2", code, stderr.String())
+	}
+	if requests != 0 {
+		t.Fatalf("telemetry requests = %d, want 0", requests)
+	}
+}
+
+func TestCommandCompletionTelemetryFailureDoesNotChangeExit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "private response", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	t.Setenv("BUILDKITE_AGENT_ENDPOINT", server.URL)
+	t.Setenv("BUILDKITE_JOB_ID", cliTestJobID)
+	t.Setenv("BUILDKITE_AGENT_ACCESS_TOKEN", "telemetry-token")
+	t.Setenv("BUILDKITE_GHA_TELEMETRY_DISABLED", "")
+
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"run-job", "--unknown"}, &stdout, &stderr, "dev", &cliCaptureRunner{}); code != 2 {
+		t.Fatalf("run() code = %d, stderr = %q; want 2", code, stderr.String())
+	}
+	if strings.Contains(stderr.String(), "private response") || strings.Contains(stderr.String(), "telemetry") {
+		t.Fatalf("telemetry failure leaked to stderr: %q", stderr.String())
+	}
+}
+
+func TestCommandTelemetryDetailsCollectTypedDiagnostics(t *testing.T) {
+	details := &commandTelemetryDetails{}
+	details.observe(compatibility.ProcessingReport{Diagnostics: []compatibility.Diagnostic{
+		{Level: "error", Code: compiler.CodeWorkflowSyntax, Stage: string(compiler.StageWorkflowParsing), Message: "must not be uploaded"},
+		{Level: "error", Code: compiler.CodeWorkflowSyntax, Stage: string(compiler.StageWorkflowParsing), Message: "different sensitive text"},
+		{Level: "warning", Code: "W_ACTION_RUNTIME_UNKNOWN", Stage: string(compiler.StageAdmission), Message: "must not be uploaded"},
+		{Level: "error", Code: "E_FUTURE_UNALLOWLISTED", Stage: string(compiler.StageGraph), Message: "must not be uploaded"},
+	}})
+	got := details.telemetryDetails()
+	if got.FailurePhase != "parsing" || got.FailureCode != "E_WORKFLOW_SYNTAX" {
+		t.Fatalf("failure details = %#v", got)
+	}
+	want := []telemetry.Diagnostic{
+		{Code: compiler.CodeWorkflowSyntax, Severity: telemetry.SeverityError},
+		{Code: "W_ACTION_RUNTIME_UNKNOWN", Severity: telemetry.SeverityWarning},
+	}
+	if !reflect.DeepEqual(got.Diagnostics, want) {
+		t.Fatalf("diagnostics = %#v, want %#v", got.Diagnostics, want)
+	}
+}
+
+func TestTelemetryOutcomePreservesCommandSemantics(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		code       int
+		conclusion string
+		contextErr error
+		want       telemetry.Outcome
+	}{
+		{name: "success", conclusion: "success", want: telemetry.OutcomeSuccess},
+		{name: "failure", code: 1, conclusion: "failure", want: telemetry.OutcomeFailure},
+		{name: "result publication failure", code: 1, conclusion: "success", want: telemetry.OutcomeFailure},
+		{name: "cancelled result", code: 1, conclusion: "cancelled", want: telemetry.OutcomeCancelled},
+		{name: "cancelled context", code: 1, contextErr: context.Canceled, want: telemetry.OutcomeCancelled},
+		{name: "skipped", conclusion: "skipped", want: telemetry.OutcomeSkipped},
+		{name: "tolerated", code: buildkitepipeline.ContinueOnErrorExitStatus, conclusion: "success", want: telemetry.OutcomeToleratedFailure},
+		{name: "usage", code: 2, want: telemetry.OutcomeUsageError},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := telemetryOutcome(test.code, test.conclusion, test.contextErr); got != test.want {
+				t.Fatalf("telemetryOutcome() = %q, want %q", got, test.want)
+			}
+		})
 	}
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -283,6 +283,69 @@ func TestRunJobUntypedFailurePhaseIsUnknown(t *testing.T) {
 	}
 }
 
+func TestPluginTelemetryReportsUnprovenActionRuntime(t *testing.T) {
+	requireImporterHost(t)
+	repository := writeUploadWorkflowRepository(t, map[string]string{
+		"action.yml": "on: push\njobs:\n  action:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: ./.github/actions/local\n",
+	})
+	actionPath := filepath.Join(repository, ".github", "actions", "local")
+	if err := os.MkdirAll(actionPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(actionPath, "action.yml"), []byte("runs:\n  using: node24\n  main: main.js\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(actionPath, "main.js"), []byte("console.log('local action')\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repository)
+	t.Setenv("BUILDKITE_GHA_NODE20", writeFakeNode(t, repository, 20))
+	t.Setenv("BUILDKITE_GHA_NODE24", writeFakeNode(t, repository, 24))
+
+	events := make(chan telemetry.Properties, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var received struct {
+			Properties telemetry.Properties `json:"properties"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&received); err != nil {
+			t.Errorf("decode telemetry event: %v", err)
+		}
+		events <- received.Properties
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+	t.Setenv("BUILDKITE_AGENT_ENDPOINT", server.URL+"/v3")
+	t.Setenv("BUILDKITE_JOB_ID", cliTestJobID)
+	t.Setenv("BUILDKITE_AGENT_ACCESS_TOKEN", "telemetry-token")
+	t.Setenv("BUILDKITE_GHA_TELEMETRY_DISABLED", "")
+
+	configuration, err := json.Marshal(map[string]any{"workflow": filepath.Join(".github", "workflows", "action.yml")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(pluginConfigurationEnvironment, string(configuration))
+	setCLIPluginBuildkiteEnvironment(t, "telemetry-action-importer")
+
+	runner := &cliCaptureRunner{}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"plugin"}, &stdout, &stderr, "dev", runner); code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	properties := <-events
+	if properties.Command != telemetry.CommandPluginImport || properties.Outcome != telemetry.OutcomeSuccess {
+		t.Fatalf("event = %#v", properties)
+	}
+	want := []telemetry.Diagnostic{{Code: "W_ACTION_RUNTIME_UNKNOWN", Severity: telemetry.SeverityWarning}}
+	if !reflect.DeepEqual(properties.Diagnostics, want) {
+		t.Fatalf("diagnostics = %#v, want %#v", properties.Diagnostics, want)
+	}
+	for _, command := range runner.commands {
+		if len(command.args) != 0 && command.args[0] == "annotate" {
+			t.Fatalf("unproven action runtime annotated the build: %#v", command.args)
+		}
+	}
+}
+
 func TestPluginRequiresConfigurationWithoutSideEffects(t *testing.T) {
 	requireImporterHost(t)
 	t.Setenv(pluginConfigurationEnvironment, "")

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -251,6 +251,21 @@ func TestCommandTelemetryDetailsCollectTypedDiagnostics(t *testing.T) {
 	}
 }
 
+func TestHandledReportErrorsDoNotAttributeCommandFailure(t *testing.T) {
+	details := &commandTelemetryDetails{}
+	details.addReportDiagnostics(compatibility.ProcessingReport{Diagnostics: []compatibility.Diagnostic{
+		{Level: "error", Code: compiler.CodeExpressionInvalid, Stage: string(compiler.StageExpressions), Message: "emitted as a failing step"},
+	}})
+	got := details.forOutcome(telemetry.OutcomeFailure)
+	if got.FailurePhase != telemetry.FailurePhaseUnknown || got.FailureCode != telemetry.FailureCodeUnknown {
+		t.Fatalf("handled error attributed a later failure: %#v", got)
+	}
+	want := []telemetry.Diagnostic{{Code: compiler.CodeExpressionInvalid, Severity: telemetry.SeverityError}}
+	if !reflect.DeepEqual(got.Diagnostics, want) {
+		t.Fatalf("diagnostics = %#v, want %#v", got.Diagnostics, want)
+	}
+}
+
 func TestTelemetryOutcomePreservesCommandSemantics(t *testing.T) {
 	for _, test := range []struct {
 		name       string

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -251,6 +251,38 @@ func TestCommandTelemetryDetailsCollectTypedDiagnostics(t *testing.T) {
 	}
 }
 
+func TestUnprovenActionRuntimeIgnoresNativeAdapters(t *testing.T) {
+	bundleWith := func(locks ...plan.ActionLock) compiler.Bundle {
+		return compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: plan.Job{
+			Actions: locks,
+			Steps:   []plan.Step{{Kind: "uses", Uses: "actions/checkout@v4"}},
+		}}}}
+	}
+	checkout := plan.ActionLock{Source: "github", Repository: "actions/checkout"}
+	upload := plan.ActionLock{Source: "github", Repository: "actions/upload-artifact"}
+	download := plan.ActionLock{Source: "github", Repository: "actions/download-artifact"}
+	setupGo := plan.ActionLock{Source: "github", Repository: "actions/setup-go"}
+	local := plan.ActionLock{Source: "workspace", Path: "actions/build"}
+
+	for _, test := range []struct {
+		name  string
+		locks []plan.ActionLock
+		want  bool
+	}{
+		{name: "no actions"},
+		{name: "native adapters only", locks: []plan.ActionLock{checkout, upload, download}},
+		{name: "public action", locks: []plan.ActionLock{setupGo}, want: true},
+		{name: "local action", locks: []plan.ActionLock{local}, want: true},
+		{name: "native adapter alongside public action", locks: []plan.ActionLock{checkout, setupGo}, want: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := bundleRunsUnprovenActions(bundleWith(test.locks...)); got != test.want {
+				t.Fatalf("bundleRunsUnprovenActions() = %t, want %t", got, test.want)
+			}
+		})
+	}
+}
+
 func TestHandledReportErrorsDoNotAttributeCommandFailure(t *testing.T) {
 	details := &commandTelemetryDetails{}
 	details.addReportDiagnostics(compatibility.ProcessingReport{Diagnostics: []compatibility.Diagnostic{

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -275,6 +275,13 @@ func TestTelemetryOutcomePreservesCommandSemantics(t *testing.T) {
 	}
 }
 
+func TestRunJobUntypedFailurePhaseIsUnknown(t *testing.T) {
+	details := (&commandTelemetryDetails{}).forOutcome(telemetry.OutcomeFailure)
+	if details.FailurePhase != telemetry.FailurePhaseUnknown || details.FailureCode != telemetry.FailureCodeUnknown {
+		t.Fatalf("run-job fallback details = %#v", details)
+	}
+}
+
 func TestPluginRequiresConfigurationWithoutSideEffects(t *testing.T) {
 	requireImporterHost(t)
 	t.Setenv(pluginConfigurationEnvironment, "")

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -264,6 +264,7 @@ func TestTelemetryOutcomePreservesCommandSemantics(t *testing.T) {
 		{name: "cancelled result", code: 1, conclusion: "cancelled", want: telemetry.OutcomeCancelled},
 		{name: "cancelled context", code: 1, contextErr: context.Canceled, want: telemetry.OutcomeCancelled},
 		{name: "skipped", conclusion: "skipped", want: telemetry.OutcomeSkipped},
+		{name: "skipped result publication failure", code: 1, conclusion: "skipped", want: telemetry.OutcomeFailure},
 		{name: "tolerated", code: buildkitepipeline.ContinueOnErrorExitStatus, conclusion: "success", want: telemetry.OutcomeToleratedFailure},
 		{name: "usage", code: 2, want: telemetry.OutcomeUsageError},
 	} {

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -28,6 +28,7 @@ type processingOutput struct {
 	format        string
 	reports       io.Writer
 	stderr        io.Writer
+	observe       func(compatibility.ProcessingReport)
 	annotationJob string
 	agent         transport.Agent
 }
@@ -43,6 +44,9 @@ func newProcessingOutput(command, format string, reports, stderr io.Writer, agen
 
 // write emits the report, reporting write failures on stderr.
 func (o processingOutput) write(report compatibility.ProcessingReport) error {
+	if o.observe != nil {
+		o.observe(report)
+	}
 	if err := compatibility.WriteProcessing(o.reports, o.format, report); err != nil {
 		_, _ = fmt.Fprintf(o.stderr, "buildkite-gha: %s: write report: %v\n", o.command, err)
 		return err

--- a/internal/cli/telemetry.go
+++ b/internal/cli/telemetry.go
@@ -17,14 +17,25 @@ type commandTelemetryDetails struct {
 	seen         map[string]int
 }
 
-func (d *commandTelemetryDetails) observe(report compatibility.ProcessingReport) {
+// addReportDiagnostics records a report's diagnostics. Errors a command
+// handles, such as workflows emitted as failing pipeline steps, belong here so
+// they never attribute an unrelated later failure.
+func (d *commandTelemetryDetails) addReportDiagnostics(report compatibility.ProcessingReport) {
 	for _, diagnostic := range report.Diagnostics {
 		severity, ok := telemetrySeverity(diagnostic.Level)
 		if !ok || !allowlistedTelemetryDiagnosticCode(diagnostic.Code) {
 			continue
 		}
 		d.addDiagnostic(diagnostic.Code, severity)
-		if diagnostic.Level == "error" && d.failureCode == "" {
+	}
+}
+
+// observe records a report that ends the command, so its first error also
+// attributes the failure.
+func (d *commandTelemetryDetails) observe(report compatibility.ProcessingReport) {
+	d.addReportDiagnostics(report)
+	for _, diagnostic := range report.Diagnostics {
+		if diagnostic.Level == "error" && d.failureCode == "" && allowlistedTelemetryDiagnosticCode(diagnostic.Code) {
 			d.failurePhase = telemetryPhase(diagnostic.Stage)
 			d.failureCode = telemetry.FailureCode(diagnostic.Code)
 		}

--- a/internal/cli/telemetry.go
+++ b/internal/cli/telemetry.go
@@ -39,6 +39,13 @@ func (d *commandTelemetryDetails) addWarnings(warnings []compiler.Warning) {
 	}
 }
 
+// addActionRuntimeUnknown records admitted actions whose runtime behavior was
+// never proven. Upload keeps this in telemetry rather than the processing
+// report, where it would annotate every import that uses actions.
+func (d *commandTelemetryDetails) addActionRuntimeUnknown() {
+	d.addDiagnostic("W_ACTION_RUNTIME_UNKNOWN", telemetry.SeverityWarning)
+}
+
 func (d *commandTelemetryDetails) addDiagnostic(code string, severity telemetry.Severity) {
 	if d.seen == nil {
 		d.seen = make(map[string]int)

--- a/internal/cli/telemetry.go
+++ b/internal/cli/telemetry.go
@@ -1,0 +1,123 @@
+package cli
+
+import (
+	"slices"
+
+	"github.com/buildkite/buildkite-gha/internal/compatibility"
+	"github.com/buildkite/buildkite-gha/internal/compiler"
+	"github.com/buildkite/buildkite-gha/internal/telemetry"
+)
+
+const maxCommandTelemetryDiagnostics = 20
+
+type commandTelemetryDetails struct {
+	failurePhase telemetry.FailurePhase
+	failureCode  telemetry.FailureCode
+	diagnostics  []telemetry.Diagnostic
+	seen         map[string]int
+}
+
+func (d *commandTelemetryDetails) observe(report compatibility.ProcessingReport) {
+	for _, diagnostic := range report.Diagnostics {
+		severity, ok := telemetrySeverity(diagnostic.Level)
+		if !ok || !allowlistedTelemetryDiagnosticCode(diagnostic.Code) {
+			continue
+		}
+		d.addDiagnostic(diagnostic.Code, severity)
+		if diagnostic.Level == "error" && d.failureCode == "" {
+			d.failurePhase = telemetryPhase(diagnostic.Stage)
+			d.failureCode = telemetry.FailureCode(diagnostic.Code)
+		}
+	}
+}
+
+func (d *commandTelemetryDetails) addWarnings(warnings []compiler.Warning) {
+	for _, warning := range warnings {
+		if allowlistedTelemetryDiagnosticCode(warning.Code) {
+			d.addDiagnostic(warning.Code, telemetry.SeverityWarning)
+		}
+	}
+}
+
+func (d *commandTelemetryDetails) addDiagnostic(code string, severity telemetry.Severity) {
+	if d.seen == nil {
+		d.seen = make(map[string]int)
+	}
+	if index, exists := d.seen[code]; exists {
+		if severity == telemetry.SeverityError {
+			d.diagnostics[index].Severity = severity
+		}
+		return
+	}
+	if len(d.diagnostics) == maxCommandTelemetryDiagnostics {
+		return
+	}
+	d.seen[code] = len(d.diagnostics)
+	d.diagnostics = append(d.diagnostics, telemetry.Diagnostic{Code: code, Severity: severity})
+}
+
+func (d *commandTelemetryDetails) forOutcome(command telemetry.Command, outcome telemetry.Outcome) telemetry.Details {
+	if outcome == telemetry.OutcomeSuccess || outcome == telemetry.OutcomeSkipped {
+		return telemetry.Details{Diagnostics: slices.Clone(d.diagnostics)}
+	}
+	phase, code := d.failurePhase, d.failureCode
+	if phase == "" {
+		switch {
+		case outcome == telemetry.OutcomeUsageError:
+			phase = telemetry.FailurePhaseConfiguration
+		case command == telemetry.CommandRunJob:
+			phase = telemetry.FailurePhaseExecution
+		default:
+			phase = telemetry.FailurePhaseUnknown
+		}
+	}
+	if code == "" {
+		code = telemetry.FailureCodeUnknown
+	}
+	return telemetry.Details{FailurePhase: phase, FailureCode: code, Diagnostics: slices.Clone(d.diagnostics)}
+}
+
+func (d *commandTelemetryDetails) telemetryDetails() telemetry.Details {
+	return telemetry.Details{FailurePhase: d.failurePhase, FailureCode: d.failureCode, Diagnostics: slices.Clone(d.diagnostics)}
+}
+
+func telemetrySeverity(level string) (telemetry.Severity, bool) {
+	switch level {
+	case "error":
+		return telemetry.SeverityError, true
+	case "warning":
+		return telemetry.SeverityWarning, true
+	default:
+		return "", false
+	}
+}
+
+func allowlistedTelemetryDiagnosticCode(code string) bool {
+	switch code {
+	case compiler.CodeWorkflowSyntax, compiler.CodeEventInvalid, compiler.CodeGraphInvalid,
+		compiler.CodeMatrixInvalid, compiler.CodeExpressionInvalid, compiler.CodeActionDiscovery,
+		compiler.CodeActionResolution, compiler.CodePlanConstruction, compiler.CodePipelineGeneration,
+		compiler.CodeEnvironment, "E_PROFILE", "W_ACTION_RUNTIME_UNKNOWN",
+		"W_WORKFLOW_CONCURRENCY_CANCEL_IN_PROGRESS_IGNORED":
+		return true
+	default:
+		return false
+	}
+}
+
+func telemetryPhase(stage string) telemetry.FailurePhase {
+	switch compiler.ProcessingStage(stage) {
+	case compiler.StageWorkflowParsing:
+		return telemetry.FailurePhaseParsing
+	case compiler.StageEventValidation, compiler.StageGraph, compiler.StageMatrix, compiler.StageExpressions:
+		return telemetry.FailurePhaseEvaluation
+	case compiler.StageDiscovery, compiler.StageResolution:
+		return telemetry.FailurePhaseSourceResolution
+	case compiler.StageAdmission:
+		return telemetry.FailurePhaseAdmission
+	case compiler.StagePlans, compiler.StagePipeline:
+		return telemetry.FailurePhaseCompilation
+	default:
+		return telemetry.FailurePhaseUnknown
+	}
+}

--- a/internal/cli/telemetry.go
+++ b/internal/cli/telemetry.go
@@ -56,18 +56,15 @@ func (d *commandTelemetryDetails) addDiagnostic(code string, severity telemetry.
 	d.diagnostics = append(d.diagnostics, telemetry.Diagnostic{Code: code, Severity: severity})
 }
 
-func (d *commandTelemetryDetails) forOutcome(command telemetry.Command, outcome telemetry.Outcome) telemetry.Details {
+func (d *commandTelemetryDetails) forOutcome(outcome telemetry.Outcome) telemetry.Details {
 	if outcome == telemetry.OutcomeSuccess || outcome == telemetry.OutcomeSkipped {
 		return telemetry.Details{Diagnostics: slices.Clone(d.diagnostics)}
 	}
 	phase, code := d.failurePhase, d.failureCode
 	if phase == "" {
-		switch {
-		case outcome == telemetry.OutcomeUsageError:
+		if outcome == telemetry.OutcomeUsageError {
 			phase = telemetry.FailurePhaseConfiguration
-		case command == telemetry.CommandRunJob:
-			phase = telemetry.FailurePhaseExecution
-		default:
+		} else {
 			phase = telemetry.FailurePhaseUnknown
 		}
 	}

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -1,0 +1,333 @@
+// Package telemetry emits bounded, best-effort buildkite-gha product events.
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	EventCommandCompleted = "pipelines:buildkite_gha:command_completed"
+
+	defaultTimeout        = 1500 * time.Millisecond
+	responseDrainLimit    = 32 << 10
+	maxClientVersionBytes = 64
+	maxDurationMS         = int64(1<<31 - 1)
+	maxDiagnostics        = 20
+)
+
+type Command string
+
+const (
+	CommandPluginImport Command = "plugin_import"
+	CommandRunJob       Command = "run_job"
+)
+
+type Outcome string
+
+const (
+	OutcomeSuccess          Outcome = "success"
+	OutcomeFailure          Outcome = "failure"
+	OutcomeCancelled        Outcome = "cancelled"
+	OutcomeSkipped          Outcome = "skipped"
+	OutcomeToleratedFailure Outcome = "tolerated_failure"
+	OutcomeUsageError       Outcome = "usage_error"
+)
+
+type FailurePhase string
+
+const (
+	FailurePhaseConfiguration     FailurePhase = "configuration"
+	FailurePhaseSourceResolution  FailurePhase = "source_resolution"
+	FailurePhaseParsing           FailurePhase = "parsing"
+	FailurePhaseEvaluation        FailurePhase = "evaluation"
+	FailurePhaseAdmission         FailurePhase = "admission"
+	FailurePhaseCompilation       FailurePhase = "compilation"
+	FailurePhaseArtifactUpload    FailurePhase = "artifact_upload"
+	FailurePhasePipelineUpload    FailurePhase = "pipeline_upload"
+	FailurePhaseExecution         FailurePhase = "execution"
+	FailurePhaseResultPublication FailurePhase = "result_publication"
+	FailurePhaseUnknown           FailurePhase = "unknown"
+)
+
+type FailureCode string
+
+const (
+	FailureCodeUnknown            FailureCode = "unknown"
+	FailureCodeWorkflowSyntax     FailureCode = "E_WORKFLOW_SYNTAX"
+	FailureCodeEventInvalid       FailureCode = "E_EVENT_INVALID"
+	FailureCodeGraphInvalid       FailureCode = "E_GRAPH_INVALID"
+	FailureCodeMatrixInvalid      FailureCode = "E_MATRIX_INVALID"
+	FailureCodeExpressionInvalid  FailureCode = "E_EXPRESSION_INVALID"
+	FailureCodeActionDiscovery    FailureCode = "E_ACTION_DISCOVERY"
+	FailureCodeActionResolution   FailureCode = "E_ACTION_RESOLUTION"
+	FailureCodePlanConstruction   FailureCode = "E_PLAN_CONSTRUCTION"
+	FailureCodePipelineGeneration FailureCode = "E_PIPELINE_GENERATION"
+	FailureCodeEnvironment        FailureCode = "E_ENVIRONMENT"
+	FailureCodeProfile            FailureCode = "E_PROFILE"
+)
+
+type Severity string
+
+const (
+	SeverityError   Severity = "error"
+	SeverityWarning Severity = "warning"
+)
+
+type Diagnostic struct {
+	Code     string   `json:"code"`
+	Severity Severity `json:"severity"`
+}
+
+type Details struct {
+	FailurePhase FailurePhase
+	FailureCode  FailureCode
+	Diagnostics  []Diagnostic
+}
+
+type Properties struct {
+	Command       Command      `json:"command"`
+	Outcome       Outcome      `json:"outcome"`
+	ClientVersion string       `json:"client_version"`
+	DurationMS    int64        `json:"duration_ms,omitempty"`
+	FailurePhase  FailurePhase `json:"failure_phase,omitempty"`
+	FailureCode   FailureCode  `json:"failure_code,omitempty"`
+	Diagnostics   []Diagnostic `json:"diagnostics,omitempty"`
+}
+
+type Config struct {
+	Endpoint      string
+	JobID         string
+	JobToken      string
+	ClientVersion string
+	Disabled      bool
+	Client        *http.Client
+	Timeout       time.Duration
+}
+
+type Client struct {
+	eventsURL     string
+	jobToken      string
+	clientVersion string
+	client        *http.Client
+	timeout       time.Duration
+}
+
+func New(config Config) (*Client, error) {
+	if config.Disabled || config.Endpoint == "" || config.JobID == "" || config.JobToken == "" {
+		return nil, nil
+	}
+	if !validJobID(config.JobID) {
+		return nil, fmt.Errorf("telemetry Agent job ID is invalid")
+	}
+	if strings.ContainsAny(config.JobToken, "\r\n") {
+		return nil, fmt.Errorf("telemetry Agent job token is invalid")
+	}
+	u, err := url.Parse(config.Endpoint)
+	if err != nil || !validAgentURL(u) {
+		return nil, fmt.Errorf("safe telemetry Agent endpoint using HTTPS or loopback HTTP is required")
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + "/jobs/" + config.JobID + "/posthog/events"
+	u.RawPath = ""
+
+	client := config.Client
+	if client == nil {
+		client = &http.Client{}
+	}
+	bounded := *client
+	bounded.Jar = nil
+	bounded.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	timeout := config.Timeout
+	if timeout <= 0 || timeout > defaultTimeout {
+		timeout = defaultTimeout
+	}
+	return &Client{
+		eventsURL:     u.String(),
+		jobToken:      config.JobToken,
+		clientVersion: boundedClientVersion(config.ClientVersion),
+		client:        &bounded,
+		timeout:       timeout,
+	}, nil
+}
+
+func (c *Client) Emit(command Command, outcome Outcome, duration time.Duration, details Details) error {
+	if c == nil {
+		return nil
+	}
+	if !validCommand(command) {
+		return fmt.Errorf("invalid telemetry command")
+	}
+	if !validOutcome(outcome) {
+		return fmt.Errorf("invalid telemetry outcome")
+	}
+	if details.FailurePhase != "" && !validFailurePhase(details.FailurePhase) {
+		return fmt.Errorf("invalid telemetry failure phase")
+	}
+	if details.FailureCode != "" && !validFailureCode(details.FailureCode) {
+		return fmt.Errorf("invalid telemetry failure code")
+	}
+	diagnostics, err := boundedDiagnostics(details.Diagnostics)
+	if err != nil {
+		return err
+	}
+	durationMS := duration.Milliseconds()
+	if durationMS < 0 {
+		durationMS = 0
+	} else if durationMS > maxDurationMS {
+		durationMS = maxDurationMS
+	}
+	body, err := json.Marshal(struct {
+		Event      string     `json:"event"`
+		Properties Properties `json:"properties"`
+	}{
+		Event: EventCommandCompleted,
+		Properties: Properties{
+			Command: command, Outcome: outcome, ClientVersion: c.clientVersion, DurationMS: durationMS,
+			FailurePhase: details.FailurePhase, FailureCode: details.FailureCode, Diagnostics: diagnostics,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("encode telemetry event: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, c.eventsURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create telemetry request: %v", err)
+	}
+	request.Header.Set("Authorization", "Token "+c.jobToken)
+	request.Header.Set("Content-Type", "application/json")
+	response, err := c.client.Do(request)
+	if err != nil {
+		return fmt.Errorf("send telemetry event: %w", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, responseDrainLimit))
+	if response.StatusCode != http.StatusAccepted {
+		return fmt.Errorf("telemetry service returned HTTP %d", response.StatusCode)
+	}
+	return nil
+}
+
+func validFailurePhase(phase FailurePhase) bool {
+	switch phase {
+	case FailurePhaseConfiguration, FailurePhaseSourceResolution, FailurePhaseParsing, FailurePhaseEvaluation,
+		FailurePhaseAdmission, FailurePhaseCompilation, FailurePhaseArtifactUpload, FailurePhasePipelineUpload,
+		FailurePhaseExecution, FailurePhaseResultPublication, FailurePhaseUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
+func validFailureCode(code FailureCode) bool {
+	switch code {
+	case FailureCodeUnknown, FailureCodeWorkflowSyntax, FailureCodeEventInvalid, FailureCodeGraphInvalid,
+		FailureCodeMatrixInvalid, FailureCodeExpressionInvalid, FailureCodeActionDiscovery,
+		FailureCodeActionResolution, FailureCodePlanConstruction, FailureCodePipelineGeneration,
+		FailureCodeEnvironment, FailureCodeProfile:
+		return true
+	default:
+		return false
+	}
+}
+
+func boundedDiagnostics(in []Diagnostic) ([]Diagnostic, error) {
+	seen := make(map[Diagnostic]bool, min(len(in), maxDiagnostics))
+	out := make([]Diagnostic, 0, min(len(in), maxDiagnostics))
+	for _, diagnostic := range in {
+		if !validDiagnosticCode(diagnostic.Code) || diagnostic.Severity != SeverityError && diagnostic.Severity != SeverityWarning {
+			return nil, fmt.Errorf("invalid telemetry diagnostic")
+		}
+		if seen[diagnostic] {
+			continue
+		}
+		seen[diagnostic] = true
+		out = append(out, diagnostic)
+		if len(out) == maxDiagnostics {
+			break
+		}
+	}
+	return out, nil
+}
+
+func validDiagnosticCode(code string) bool {
+	switch code {
+	case string(FailureCodeWorkflowSyntax), string(FailureCodeEventInvalid), string(FailureCodeGraphInvalid),
+		string(FailureCodeMatrixInvalid), string(FailureCodeExpressionInvalid), string(FailureCodeActionDiscovery),
+		string(FailureCodeActionResolution), string(FailureCodePlanConstruction), string(FailureCodePipelineGeneration),
+		string(FailureCodeEnvironment), string(FailureCodeProfile), "W_ACTION_RUNTIME_UNKNOWN",
+		"W_WORKFLOW_CONCURRENCY_CANCEL_IN_PROGRESS_IGNORED":
+		return true
+	default:
+		return false
+	}
+}
+
+func validCommand(command Command) bool {
+	return command == CommandPluginImport || command == CommandRunJob
+}
+
+func validOutcome(outcome Outcome) bool {
+	switch outcome {
+	case OutcomeSuccess, OutcomeFailure, OutcomeCancelled, OutcomeSkipped, OutcomeToleratedFailure, OutcomeUsageError:
+		return true
+	default:
+		return false
+	}
+}
+
+func boundedClientVersion(version string) string {
+	if version == "" {
+		return "unknown"
+	}
+	if len(version) > maxClientVersionBytes {
+		version = version[:maxClientVersionBytes]
+	}
+	for _, character := range version {
+		if character < 0x20 || character > 0x7e {
+			return "unknown"
+		}
+	}
+	return version
+}
+
+func validAgentURL(u *url.URL) bool {
+	if u == nil || u.Host == "" || u.Hostname() == "" || u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+		return false
+	}
+	if u.Scheme == "https" {
+		return true
+	}
+	if u.Scheme != "http" {
+		return false
+	}
+	ip := net.ParseIP(u.Hostname())
+	return ip != nil && ip.IsLoopback()
+}
+
+func validJobID(value string) bool {
+	if len(value) != 36 {
+		return false
+	}
+	for index, character := range []byte(value) {
+		if index == 8 || index == 13 || index == 18 || index == 23 {
+			if character != '-' {
+				return false
+			}
+			continue
+		}
+		if character < '0' || character > '9' && character < 'a' || character > 'f' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -241,16 +241,17 @@ func validFailureCode(code FailureCode) bool {
 }
 
 func boundedDiagnostics(in []Diagnostic) ([]Diagnostic, error) {
-	seen := make(map[Diagnostic]bool, min(len(in), maxDiagnostics))
+	seen := make(map[string]bool, min(len(in), maxDiagnostics))
 	out := make([]Diagnostic, 0, min(len(in), maxDiagnostics))
 	for _, diagnostic := range in {
-		if !validDiagnosticCode(diagnostic.Code) || diagnostic.Severity != SeverityError && diagnostic.Severity != SeverityWarning {
+		severity, ok := diagnosticSeverity(diagnostic.Code)
+		if !ok || diagnostic.Severity != severity {
 			return nil, fmt.Errorf("invalid telemetry diagnostic")
 		}
-		if seen[diagnostic] {
+		if seen[diagnostic.Code] {
 			continue
 		}
-		seen[diagnostic] = true
+		seen[diagnostic.Code] = true
 		out = append(out, diagnostic)
 		if len(out) == maxDiagnostics {
 			break
@@ -259,16 +260,17 @@ func boundedDiagnostics(in []Diagnostic) ([]Diagnostic, error) {
 	return out, nil
 }
 
-func validDiagnosticCode(code string) bool {
+func diagnosticSeverity(code string) (Severity, bool) {
 	switch code {
 	case string(FailureCodeWorkflowSyntax), string(FailureCodeEventInvalid), string(FailureCodeGraphInvalid),
 		string(FailureCodeMatrixInvalid), string(FailureCodeExpressionInvalid), string(FailureCodeActionDiscovery),
 		string(FailureCodeActionResolution), string(FailureCodePlanConstruction), string(FailureCodePipelineGeneration),
-		string(FailureCodeEnvironment), string(FailureCodeProfile), "W_ACTION_RUNTIME_UNKNOWN",
-		"W_WORKFLOW_CONCURRENCY_CANCEL_IN_PROGRESS_IGNORED":
-		return true
+		string(FailureCodeEnvironment), string(FailureCodeProfile):
+		return SeverityError, true
+	case "W_ACTION_RUNTIME_UNKNOWN", "W_WORKFLOW_CONCURRENCY_CANCEL_IN_PROGRESS_IGNORED":
+		return SeverityWarning, true
 	default:
-		return false
+		return "", false
 	}
 }
 

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -197,27 +197,42 @@ func TestPropertiesAreBounded(t *testing.T) {
 	}
 }
 
-func TestDiagnosticsAreAllowlistedDeduplicatedAndCapped(t *testing.T) {
-	allowed := []string{
+func TestDiagnosticsEnforceSeverityAndDeduplicateByCode(t *testing.T) {
+	errorCodes := []string{
 		string(FailureCodeWorkflowSyntax), string(FailureCodeEventInvalid), string(FailureCodeGraphInvalid),
 		string(FailureCodeMatrixInvalid), string(FailureCodeExpressionInvalid), string(FailureCodeActionDiscovery),
 		string(FailureCodeActionResolution), string(FailureCodePlanConstruction), string(FailureCodePipelineGeneration),
-		string(FailureCodeEnvironment), string(FailureCodeProfile), "W_ACTION_RUNTIME_UNKNOWN",
-		"W_WORKFLOW_CONCURRENCY_CANCEL_IN_PROGRESS_IGNORED",
+		string(FailureCodeEnvironment), string(FailureCodeProfile),
 	}
-	input := make([]Diagnostic, 0, len(allowed)*2)
-	for _, code := range allowed {
-		input = append(input, Diagnostic{Code: code, Severity: SeverityError}, Diagnostic{Code: code, Severity: SeverityWarning})
+	warningCodes := []string{"W_ACTION_RUNTIME_UNKNOWN", "W_WORKFLOW_CONCURRENCY_CANCEL_IN_PROGRESS_IGNORED"}
+	input := make([]Diagnostic, 0, len(errorCodes)+len(warningCodes)+2)
+	for _, code := range errorCodes {
+		input = append(input, Diagnostic{Code: code, Severity: SeverityError})
 	}
+	for _, code := range warningCodes {
+		input = append(input, Diagnostic{Code: code, Severity: SeverityWarning})
+	}
+	input = append(input, input[0], input[len(errorCodes)])
 	bounded, err := boundedDiagnostics(input)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(bounded) != maxDiagnostics {
-		t.Fatalf("diagnostics = %d, want cap %d", len(bounded), maxDiagnostics)
+	if len(bounded) != len(errorCodes)+len(warningCodes) {
+		t.Fatalf("diagnostics = %d, want %d unique codes", len(bounded), len(errorCodes)+len(warningCodes))
 	}
 	if _, err := boundedDiagnostics([]Diagnostic{{Code: "CUSTOMER_VALUE", Severity: SeverityError}}); err == nil {
 		t.Fatal("boundedDiagnostics() accepted non-allowlisted code")
+	}
+}
+
+func TestDiagnosticsRejectMismatchedSeverity(t *testing.T) {
+	for _, diagnostic := range []Diagnostic{
+		{Code: string(FailureCodeWorkflowSyntax), Severity: SeverityWarning},
+		{Code: "W_ACTION_RUNTIME_UNKNOWN", Severity: SeverityError},
+	} {
+		if _, err := boundedDiagnostics([]Diagnostic{diagnostic}); err == nil {
+			t.Fatalf("boundedDiagnostics(%#v) accepted mismatched severity", diagnostic)
+		}
 	}
 }
 

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -1,0 +1,249 @@
+package telemetry
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+const testJobID = "22222222-2222-4222-8222-222222222222"
+
+func TestClientEmitsCommandCompletedEvent(t *testing.T) {
+	var request struct {
+		Event      string     `json:"event"`
+		Properties Properties `json:"properties"`
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v3/jobs/"+testJobID+"/posthog/events" {
+			t.Errorf("request = %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Token job-token" {
+			t.Errorf("Authorization = %q", got)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("Content-Type = %q", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	client, err := New(Config{Endpoint: server.URL + "/v3", JobID: testJobID, JobToken: "job-token", ClientVersion: "1.2.3"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	duration := 1234 * time.Millisecond
+	if err := client.Emit(CommandRunJob, OutcomeFailure, duration, Details{
+		FailurePhase: FailurePhaseParsing,
+		FailureCode:  FailureCodeWorkflowSyntax,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if request.Event != EventCommandCompleted || request.Properties.Command != CommandRunJob || request.Properties.Outcome != OutcomeFailure || request.Properties.ClientVersion != "1.2.3" || request.Properties.DurationMS != 1234 || request.Properties.FailurePhase != FailurePhaseParsing || request.Properties.FailureCode != FailureCodeWorkflowSyntax {
+		t.Fatalf("event = %#v", request)
+	}
+}
+
+func TestNewSkipsMissingCredentialsAndOptOut(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		config Config
+	}{
+		{name: "missing endpoint", config: Config{JobID: testJobID, JobToken: "token"}},
+		{name: "missing job", config: Config{Endpoint: "https://agent.example/v3", JobToken: "token"}},
+		{name: "missing token", config: Config{Endpoint: "https://agent.example/v3", JobID: testJobID}},
+		{name: "disabled", config: Config{Endpoint: "https://agent.example/v3", JobID: testJobID, JobToken: "token", Disabled: true}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			client, err := New(test.config)
+			if err != nil || client != nil {
+				t.Fatalf("New() = %#v, %v; want nil, nil", client, err)
+			}
+		})
+	}
+}
+
+func TestNewRejectsUnsafeConfiguration(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		jobID    string
+		token    string
+	}{
+		{name: "non-loopback HTTP", endpoint: "http://agent.example/v3", jobID: testJobID, token: "token"},
+		{name: "userinfo", endpoint: "https://user@agent.example/v3", jobID: testJobID, token: "token"},
+		{name: "query", endpoint: "https://agent.example/v3?q=1", jobID: testJobID, token: "token"},
+		{name: "fragment", endpoint: "https://agent.example/v3#x", jobID: testJobID, token: "token"},
+		{name: "invalid job", endpoint: "https://agent.example/v3", jobID: "../job", token: "token"},
+		{name: "header injection", endpoint: "https://agent.example/v3", jobID: testJobID, token: "token\r\nX: y"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if client, err := New(Config{Endpoint: test.endpoint, JobID: test.jobID, JobToken: test.token}); err == nil || client != nil {
+				t.Fatalf("New() = %#v, %v; want safe rejection", client, err)
+			}
+		})
+	}
+}
+
+func TestClientDoesNotFollowRedirectsOrExposeSecrets(t *testing.T) {
+	const secret = "job-token-secret"
+	var redirected bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/elsewhere" {
+			redirected = true
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		http.Redirect(w, r, "/elsewhere", http.StatusTemporaryRedirect)
+	}))
+	defer server.Close()
+	client, err := New(Config{Endpoint: server.URL, JobID: testJobID, JobToken: secret})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = client.Emit(CommandPluginImport, OutcomeFailure, 0, Details{})
+	if err == nil || redirected || strings.Contains(err.Error(), secret) {
+		t.Fatalf("Emit() error/redirected = %v / %v", err, redirected)
+	}
+}
+
+func TestClientTreatsServiceFailuresAsBodyFreeErrors(t *testing.T) {
+	const responseSecret = "customer-response-must-not-escape"
+	for _, status := range []int{http.StatusUnauthorized, http.StatusNotFound, http.StatusTooManyRequests, http.StatusInternalServerError} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(status)
+				_, _ = io.WriteString(w, responseSecret)
+			}))
+			defer server.Close()
+			client, err := New(Config{Endpoint: server.URL, JobID: testJobID, JobToken: "job-token"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = client.Emit(CommandPluginImport, OutcomeFailure, 0, Details{})
+			if err == nil || !strings.Contains(err.Error(), strconv.Itoa(status)) || strings.Contains(err.Error(), responseSecret) {
+				t.Fatalf("Emit() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestClientUsesIndependentTimeout(t *testing.T) {
+	transport := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		<-r.Context().Done()
+		return nil, r.Context().Err()
+	})
+	client, err := New(Config{
+		Endpoint: "https://agent.example/v3", JobID: testJobID, JobToken: "token",
+		Client: &http.Client{Transport: transport}, Timeout: 20 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	started := time.Now()
+	err = client.Emit(CommandRunJob, OutcomeCancelled, 0, Details{})
+	if !errors.Is(err, context.DeadlineExceeded) || time.Since(started) > time.Second {
+		t.Fatalf("Emit() = %v after %s", err, time.Since(started))
+	}
+}
+
+func TestClientBoundsResponseDrain(t *testing.T) {
+	body := &countingBody{remaining: responseDrainLimit * 4}
+	transport := roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusInternalServerError, Body: body, Header: make(http.Header)}, nil
+	})
+	client, err := New(Config{
+		Endpoint: "https://agent.example/v3", JobID: testJobID, JobToken: "token",
+		Client: &http.Client{Transport: transport},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = client.Emit(CommandRunJob, OutcomeFailure, 0, Details{})
+	if err == nil || body.read > responseDrainLimit || strings.Contains(err.Error(), strings.Repeat("x", 10)) {
+		t.Fatalf("Emit() error/read = %v / %d", err, body.read)
+	}
+}
+
+func TestPropertiesAreBounded(t *testing.T) {
+	client, err := New(Config{Endpoint: "https://agent.example/v3", JobID: testJobID, JobToken: "token", ClientVersion: strings.Repeat("v", maxClientVersionBytes+10)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(client.clientVersion) != maxClientVersionBytes {
+		t.Fatalf("client version length = %d", len(client.clientVersion))
+	}
+	if err := client.Emit(Command("arbitrary"), OutcomeSuccess, 0, Details{}); err == nil {
+		t.Fatal("Emit() accepted an unknown command")
+	}
+	if err := client.Emit(CommandRunJob, Outcome("arbitrary"), 0, Details{}); err == nil {
+		t.Fatal("Emit() accepted an unknown outcome")
+	}
+	if err := client.Emit(CommandRunJob, OutcomeFailure, 0, Details{FailurePhase: FailurePhase("arbitrary"), FailureCode: FailureCodeUnknown}); err == nil {
+		t.Fatal("Emit() accepted an unknown failure phase")
+	}
+	if err := client.Emit(CommandRunJob, OutcomeFailure, 0, Details{FailurePhase: FailurePhaseUnknown, FailureCode: FailureCode("arbitrary")}); err == nil {
+		t.Fatal("Emit() accepted an unknown failure code")
+	}
+}
+
+func TestDiagnosticsAreAllowlistedDeduplicatedAndCapped(t *testing.T) {
+	allowed := []string{
+		string(FailureCodeWorkflowSyntax), string(FailureCodeEventInvalid), string(FailureCodeGraphInvalid),
+		string(FailureCodeMatrixInvalid), string(FailureCodeExpressionInvalid), string(FailureCodeActionDiscovery),
+		string(FailureCodeActionResolution), string(FailureCodePlanConstruction), string(FailureCodePipelineGeneration),
+		string(FailureCodeEnvironment), string(FailureCodeProfile), "W_ACTION_RUNTIME_UNKNOWN",
+		"W_WORKFLOW_CONCURRENCY_CANCEL_IN_PROGRESS_IGNORED",
+	}
+	input := make([]Diagnostic, 0, len(allowed)*2)
+	for _, code := range allowed {
+		input = append(input, Diagnostic{Code: code, Severity: SeverityError}, Diagnostic{Code: code, Severity: SeverityWarning})
+	}
+	bounded, err := boundedDiagnostics(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bounded) != maxDiagnostics {
+		t.Fatalf("diagnostics = %d, want cap %d", len(bounded), maxDiagnostics)
+	}
+	if _, err := boundedDiagnostics([]Diagnostic{{Code: "CUSTOMER_VALUE", Severity: SeverityError}}); err == nil {
+		t.Fatal("boundedDiagnostics() accepted non-allowlisted code")
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(request *http.Request) (*http.Response, error) { return f(request) }
+
+type countingBody struct {
+	remaining int64
+	read      int64
+}
+
+func (b *countingBody) Read(p []byte) (int, error) {
+	if b.remaining == 0 {
+		return 0, io.EOF
+	}
+	n := int64(len(p))
+	if n > b.remaining {
+		n = b.remaining
+	}
+	for i := range p[:n] {
+		p[i] = 'x'
+	}
+	b.remaining -= n
+	b.read += n
+	return int(n), nil
+}
+
+func (*countingBody) Close() error { return nil }


### PR DESCRIPTION
## Why

Failed imports and unsupported GitHub Actions features are currently invisible outside job logs, which makes compatibility work hard to prioritize. This establishes the client side of [PB-2631](https://linear.app/buildkite/issue/PB-2631/set-the-telemetry-baseline-and-dashboard).

Design: [PostHog telemetry endpoint thread](https://ampcode.com/threads/T-019ff905-9c5a-75ae-bee7-6b42b145b4d5). Server implementation: [Buildkite endpoint thread](https://ampcode.com/threads/T-019ff917-4597-708d-8eb5-acd78897b855), commits `14d1543a` and `8333c79e`, published as [buildkite/buildkite#32457](https://github.com/buildkite/buildkite/pull/32457). The Rails endpoint must deploy before this client is released; until then the resulting 404 is silently ignored.

## What

Emit one job-authenticated `pipelines:buildkite_gha:command_completed` event after plugin imports and `run-job` complete:

- `POST $BUILDKITE_AGENT_ENDPOINT/jobs/$BUILDKITE_JOB_ID/posthog/events`
- `Authorization: Token $BUILDKITE_AGENT_ACCESS_TOKEN`
- command: `plugin_import` or `run_job`
- outcome: `success`, `failure`, `cancelled`, `skipped`, `tolerated_failure`, or `usage_error`
- bounded client version and duration
- optional failure phase/code and at most 20 unique allowlisted `{code, severity}` compiler diagnostics

The client sends no rendered diagnostic text, workflow content, repository or actor details, paths, locations, action references, expressions, environment, command text, or secrets. Diagnostic data comes only from typed compiler codes. The endpoint must use HTTPS except loopback HTTP for tests; redirects and cookies are disabled, response draining is bounded, and the request has an independent 1.5-second timeout.

Telemetry is strictly best-effort: missing credentials, opt-out, invalid configuration, 401/404/429/5xx responses, redirects, timeouts, and cancellation are silent and never change command output or exit status. Set `BUILDKITE_GHA_TELEMETRY_DISABLED=true` to opt out.

## Tests

- `mise run check`
- `mise exec -- go test ./internal/telemetry ./internal/cli -count=1`
- `mise exec -- go vet ./internal/telemetry ./internal/cli`
- `mise exec -- golangci-lint run ./internal/telemetry ./internal/cli`