### PR TITLE
Support Origin event repositories

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -74,7 +74,13 @@ steps:
               mise-version: "2026.5.12"
           - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
               version: "2026.5.12"
-        command: "mise run --jobs 1 check"
+        command: |
+          set -euo pipefail
+          # A golangci-lint cache shared across builds returns issues with the
+          # previous build's checkout paths, which breaks nolint filtering
+          # (golangci/golangci-lint#3502). Keep the cache local to this VM.
+          export GOLANGCI_LINT_CACHE=/tmp/golangci-lint
+          mise run --jobs 1 check
 
       - label: ":go: macOS arm64 build and tests"
         key: "macos-arm64"

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -638,7 +638,7 @@ JavaScript and Docker actions with compatible bundled cache clients, such as `ac
 | --- | --- | --- |
 | Public GitHub event repository | ✅ Supported | No additional boundary. |
 | Private GitHub event repository | 🟡 Supported subset | Buildkite must authorize repository-provider Git credentials. |
-| Internal or private Cursor Origin event repository | 🟡 Supported subset | `BUILDKITE_REPO` must be the pipeline's exact `https://origin.cursor.com/git/<namespace>/<repository>.git` URL. Buildkite must authorize repository-provider Git credentials. |
+| Internal or private Origin event repository | 🟡 Supported subset | `BUILDKITE_REPO` must be the pipeline's exact `https://origin.cursor.com/git/<namespace>/<repository>.git` URL. Buildkite must authorize repository-provider Git credentials. |
 | Alternate repository in `actions/checkout` | ❌ Unsupported | Not available. |
 | Public GitHub action | 🟡 Supported subset | Subject to the action boundaries above. |
 | Private action or reusable workflow | ❌ Unsupported | Not available. |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -37,7 +37,7 @@ Looking for something else? [Browse open compatibility issues](https://github.co
 | [Job and service containers](#containers-and-services) | 🚧 Not available in production | A bounded container subset exists, but production upload rejects it. |
 | [Environments and snapshots](#job-configuration) | ➖ Accepted, no effect | No approvals, environment secrets, deployment state, or custom-image creation. |
 | [OIDC](#other-secrets-and-oidc) | ❌ Unsupported | GitHub-compatible OIDC is outside the initial release. |
-| [Other platforms](#job-configuration) and [providers](#repositories) | ❌ Unsupported | Windows, Linux arm64, macOS x86-64, GitHub Enterprise Server, and other providers are outside the initial release. |
+| [Other platforms](#job-configuration) and [providers](#repositories) | ❌ Unsupported | Windows, Linux arm64, macOS x86-64, GitHub Enterprise Server, and unlisted providers are outside the initial release. |
 | [Other GitHub services](#github-services) | ❌ Unsupported | No general emulation for Releases, Packages, Checks, deployments, or GitHub artifact APIs. |
 
 ## How workflows run on Buildkite
@@ -638,10 +638,11 @@ JavaScript and Docker actions with compatible bundled cache clients, such as `ac
 | --- | --- | --- |
 | Public GitHub event repository | ✅ Supported | No additional boundary. |
 | Private GitHub event repository | 🟡 Supported subset | Buildkite must authorize repository-provider Git credentials. |
+| Internal or private Cursor Origin event repository | 🟡 Supported subset | `BUILDKITE_REPO` must be the pipeline's exact `https://origin.cursor.com/git/<namespace>/<repository>.git` URL. Buildkite must authorize repository-provider Git credentials. |
 | Alternate repository in `actions/checkout` | ❌ Unsupported | Not available. |
 | Public GitHub action | 🟡 Supported subset | Subject to the action boundaries above. |
 | Private action or reusable workflow | ❌ Unsupported | Not available. |
-| GitHub Enterprise Server or another provider | ❌ Unsupported | Not available. |
+| GitHub Enterprise Server or an unlisted provider | ❌ Unsupported | Not available. |
 
 ### GitHub token
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -646,11 +646,11 @@ JavaScript and Docker actions with compatible bundled cache clients, such as `ac
 
 ### GitHub token
 
-**🟡 Supported subset.** A job requests one short-lived `GITHUB_TOKEN` for the exact event repository by statically referencing `secrets.GITHUB_TOKEN` or by using an action whose effective input default references `github.token`. Effective `permissions` determine the token scope. The Buildkite organization feature and the pipeline's workflow access token setting must be enabled. Both are disabled by default.
+**🟡 Supported subset.** A job requests one short-lived `GITHUB_TOKEN` for the exact event repository by statically referencing `secrets.GITHUB_TOKEN` or by using an action whose effective input default references `github.token`. Native action adapters ignore upstream input defaults, so `actions/checkout` alone does not request a token. Effective `permissions` determine the token scope. The Buildkite organization feature and the pipeline's workflow access token setting must be enabled. Both are disabled by default.
 
 Buildkite reads the workflow policy from the pipeline repository at the build's immutable commit. The workflow must be directly under `.github/workflows/`, use a simple `.yml` or `.yaml` filename, and contain no job-level permission maps or reusable-workflow jobs. The workflow-token endpoint must interpret omitted top-level permissions as exactly `contents: read`, without consulting GitHub repository or organization defaults. Write access requires an explicit, non-empty top-level map. An explicit empty map or scopes resolving only to `none` produce no token.
 
-If the selected workflow contains a reusable-workflow job, no direct or expanded job can receive a token. This includes `actions/checkout` in a called workflow when its effective `token` input defaults to `${{ github.token }}`. Tokenless local reusable workflows remain supported.
+If the selected workflow contains a reusable-workflow job, no direct or expanded job can receive a token. Tokenless local reusable workflows remain supported.
 
 Pull-request builds and their triggered or rebuilt descendants may request only `contents: read`. Merge-queue builds and their descendants cannot request a token. The endpoint does not support GitHub Enterprise Server. The backend verifies this provenance and remains authoritative.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -40,9 +40,9 @@ For other builds, a user with permission to create a build at an arbitrary commi
 
 ### Checkout and submodules
 
-Buildkite authorizes every managed GitHub repository requested through the Git credential protocol. A checked-in `.gitmodules` file may select another repository in the same GitHub account when the connected GitHub App installation includes it. Those tokens are repository-specific and read-only. External HTTPS submodules are anonymous. SSH and non-HTTPS transports are disabled.
+Buildkite authorizes managed GitHub and Origin repositories requested through the Git credential protocol. A checked-in `.gitmodules` file may select another repository from the same provider when Buildkite authorizes access to it. Those tokens are repository-specific and read-only. External HTTPS submodules are anonymous. SSH and non-HTTPS transports are disabled.
 
-The credential helper is offered only to `github.com`, uses HTTP-path matching, and is not persisted. The installed Git executable owns submodule parsing and recursion, so keep it current and preferably pin it in the job image.
+The credential helper is offered only to the event provider's host (`github.com` or `origin.cursor.com`), uses HTTP-path matching, and is not persisted. The installed Git executable owns submodule parsing and recursion, so keep it current and preferably pin it in the job image.
 
 Command scoping limits accidental spread. It does not stop a hostile concurrent process under the same job identity from reaching the agent or helper. That requires a separate UID, sandbox, or pre-job credential broker.
 

--- a/internal/cli/buildkite_event.go
+++ b/internal/cli/buildkite_event.go
@@ -309,6 +309,9 @@ func parseBuildkiteRepository(raw string) (provider, owner, name, cloneURL strin
 		if owner == "." || owner == ".." || name == "" || name == "." || name == ".." || !validGitHubPathPart(owner, true) || !validGitHubPathPart(name, true) {
 			return "", "", "", "", fmt.Errorf("has a malformed namespace or repository name")
 		}
+		if raw != "https://origin.cursor.com/git/"+owner+"/"+name+".git" {
+			return "", "", "", "", fmt.Errorf("repository URL for Cursor Origin must use its canonical form")
+		}
 		return provider, owner, name, raw, nil
 	}
 	parts := strings.Split(path, "/")

--- a/internal/cli/buildkite_event.go
+++ b/internal/cli/buildkite_event.go
@@ -265,7 +265,7 @@ func parseBuildkiteRepository(raw string) (provider, owner, name, cloneURL strin
 	} else {
 		u, parseErr := url.Parse(raw)
 		if parseErr != nil || u.Port() != "" || u.RawQuery != "" || u.Fragment != "" {
-			return "", "", "", "", fmt.Errorf("must be a github.com or Cursor Origin repository URL")
+			return "", "", "", "", fmt.Errorf("must be a github.com or Origin repository URL")
 		}
 		switch u.Hostname() {
 		case "github.com":
@@ -285,13 +285,13 @@ func parseBuildkiteRepository(raw string) (provider, owner, name, cloneURL strin
 		case "origin.cursor.com":
 			provider = "cursor-origin"
 			if u.Scheme != "https" {
-				return "", "", "", "", fmt.Errorf("repository URL for Cursor Origin must use HTTPS")
+				return "", "", "", "", fmt.Errorf("repository URL for Origin must use HTTPS")
 			}
 			if u.User != nil {
 				return "", "", "", "", fmt.Errorf("must not contain credentials")
 			}
 		default:
-			return "", "", "", "", fmt.Errorf("must be a github.com or Cursor Origin repository URL")
+			return "", "", "", "", fmt.Errorf("must be a github.com or Origin repository URL")
 		}
 		path = strings.TrimPrefix(u.EscapedPath(), "/")
 		if decodedPath, decodeErr := url.PathUnescape(path); decodeErr == nil {
@@ -303,14 +303,14 @@ func parseBuildkiteRepository(raw string) (provider, owner, name, cloneURL strin
 	if provider == "cursor-origin" {
 		parts := strings.Split(path, "/")
 		if len(parts) != 3 || parts[0] != "git" || parts[1] == "" || !strings.HasSuffix(parts[2], ".git") {
-			return "", "", "", "", fmt.Errorf("repository URL for Cursor Origin must be https://origin.cursor.com/git/<namespace>/<repository>.git")
+			return "", "", "", "", fmt.Errorf("repository URL for Origin must be https://origin.cursor.com/git/<namespace>/<repository>.git")
 		}
 		owner, name = parts[1], strings.TrimSuffix(parts[2], ".git")
 		if owner == "." || owner == ".." || name == "" || name == "." || name == ".." || !validGitHubPathPart(owner, true) || !validGitHubPathPart(name, true) {
 			return "", "", "", "", fmt.Errorf("has a malformed namespace or repository name")
 		}
 		if raw != "https://origin.cursor.com/git/"+owner+"/"+name+".git" {
-			return "", "", "", "", fmt.Errorf("repository URL for Cursor Origin must use its canonical form")
+			return "", "", "", "", fmt.Errorf("repository URL for Origin must use its canonical form")
 		}
 		return provider, owner, name, raw, nil
 	}

--- a/internal/cli/buildkite_event.go
+++ b/internal/cli/buildkite_event.go
@@ -25,7 +25,7 @@ func buildkiteEventSource(getenv func(string) string) ([]byte, error) {
 	if strings.TrimSpace(getenv("BUILDKITE_STEP_KEY")) == "" {
 		return nil, fmt.Errorf("BUILDKITE_STEP_KEY is required")
 	}
-	owner, name, cloneURL, err := parsePublicGitHubRepository(getenv("BUILDKITE_REPO"))
+	provider, owner, name, cloneURL, err := parseBuildkiteRepository(getenv("BUILDKITE_REPO"))
 	if err != nil {
 		return nil, fmt.Errorf("BUILDKITE_REPO: %w", err)
 	}
@@ -64,7 +64,7 @@ func buildkiteEventSource(getenv func(string) string) ([]byte, error) {
 		event, ref = "pull_request", fmt.Sprintf("refs/pull/%d/head", number)
 		headOwner, headName, headCloneURL := owner, name, cloneURL
 		if pullRequestRepo := strings.TrimSpace(getenv("BUILDKITE_PULL_REQUEST_REPO")); pullRequestRepo != "" {
-			headOwner, headName, headCloneURL, err = parsePublicGitHubRepository(pullRequestRepo)
+			_, headOwner, headName, headCloneURL, err = parseBuildkiteRepository(pullRequestRepo)
 			if err != nil {
 				return nil, fmt.Errorf("BUILDKITE_PULL_REQUEST_REPO: %w", err)
 			}
@@ -112,7 +112,7 @@ func buildkiteEventSource(getenv func(string) string) ([]byte, error) {
 		SHA      string         `json:"sha"`
 		Actor    string         `json:"actor"`
 		Payload  map[string]any `json:"payload"`
-	}{"github", event, repository, ref, sha, actor, payload}
+	}{provider, event, repository, ref, sha, actor, payload}
 	result, err := json.Marshal(snapshot)
 	if err != nil {
 		return nil, fmt.Errorf("encode Buildkite compatibility snapshot: %w", err)
@@ -254,46 +254,72 @@ func safeGitHubLogin(login string) bool {
 	return true
 }
 
-func parsePublicGitHubRepository(raw string) (owner, name, cloneURL string, err error) {
+func parseBuildkiteRepository(raw string) (provider, owner, name, cloneURL string, err error) {
 	if raw == "" {
-		return "", "", "", fmt.Errorf("is required")
+		return "", "", "", "", fmt.Errorf("is required")
 	}
 	path := ""
 	if strings.HasPrefix(raw, "git@github.com:") {
 		path = strings.TrimPrefix(raw, "git@github.com:")
+		provider = "github"
 	} else {
 		u, parseErr := url.Parse(raw)
-		if parseErr != nil || u.Hostname() != "github.com" || u.Port() != "" || u.RawQuery != "" || u.Fragment != "" {
-			return "", "", "", fmt.Errorf("must be a public github.com repository URL")
+		if parseErr != nil || u.Port() != "" || u.RawQuery != "" || u.Fragment != "" {
+			return "", "", "", "", fmt.Errorf("must be a github.com or Cursor Origin repository URL")
 		}
-		switch u.Scheme {
-		case "https", "git":
-			if u.User != nil {
-				return "", "", "", fmt.Errorf("must not contain credentials")
+		switch u.Hostname() {
+		case "github.com":
+			provider = "github"
+			switch u.Scheme {
+			case "https", "git":
+				if u.User != nil {
+					return "", "", "", "", fmt.Errorf("must not contain credentials")
+				}
+			case "ssh":
+				if u.User == nil || u.User.String() != "git" {
+					return "", "", "", "", fmt.Errorf("SSH repository URL must use the git user")
+				}
+			default:
+				return "", "", "", "", fmt.Errorf("must use https, git, or SSH")
 			}
-		case "ssh":
-			if u.User == nil || u.User.String() != "git" {
-				return "", "", "", fmt.Errorf("SSH repository URL must use the git user")
+		case "origin.cursor.com":
+			provider = "cursor-origin"
+			if u.Scheme != "https" {
+				return "", "", "", "", fmt.Errorf("repository URL for Cursor Origin must use HTTPS")
+			}
+			if u.User != nil {
+				return "", "", "", "", fmt.Errorf("must not contain credentials")
 			}
 		default:
-			return "", "", "", fmt.Errorf("must use https, git, or SSH")
+			return "", "", "", "", fmt.Errorf("must be a github.com or Cursor Origin repository URL")
 		}
 		path = strings.TrimPrefix(u.EscapedPath(), "/")
 		if decodedPath, decodeErr := url.PathUnescape(path); decodeErr == nil {
 			path = decodedPath
 		} else {
-			return "", "", "", fmt.Errorf("has a malformed path")
+			return "", "", "", "", fmt.Errorf("has a malformed path")
 		}
+	}
+	if provider == "cursor-origin" {
+		parts := strings.Split(path, "/")
+		if len(parts) != 3 || parts[0] != "git" || parts[1] == "" || !strings.HasSuffix(parts[2], ".git") {
+			return "", "", "", "", fmt.Errorf("repository URL for Cursor Origin must be https://origin.cursor.com/git/<namespace>/<repository>.git")
+		}
+		owner, name = parts[1], strings.TrimSuffix(parts[2], ".git")
+		if owner == "." || owner == ".." || name == "" || name == "." || name == ".." || !validGitHubPathPart(owner, true) || !validGitHubPathPart(name, true) {
+			return "", "", "", "", fmt.Errorf("has a malformed namespace or repository name")
+		}
+		return provider, owner, name, raw, nil
 	}
 	parts := strings.Split(path, "/")
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return "", "", "", fmt.Errorf("must contain exactly an owner and repository name")
+		return "", "", "", "", fmt.Errorf("must contain exactly an owner and repository name")
 	}
 	owner, name = parts[0], strings.TrimSuffix(parts[1], ".git")
 	if name == "" || name == "." || name == ".." || !validGitHubPathPart(owner, false) || !validGitHubPathPart(name, true) {
-		return "", "", "", fmt.Errorf("has a malformed owner or repository name")
+		return "", "", "", "", fmt.Errorf("has a malformed owner or repository name")
 	}
-	return owner, name, "https://github.com/" + owner + "/" + name + ".git", nil
+	return provider, owner, name, "https://github.com/" + owner + "/" + name + ".git", nil
 }
 
 func validGitHubPathPart(value string, allowDotUnderscore bool) bool {

--- a/internal/cli/buildkite_event_test.go
+++ b/internal/cli/buildkite_event_test.go
@@ -6,25 +6,95 @@ import (
 	"testing"
 )
 
-func TestParsePublicGitHubRepository(t *testing.T) {
+func TestParseBuildkiteRepository(t *testing.T) {
 	for _, raw := range []string{
 		"https://github.com/acme/widgets", "https://github.com/acme/widgets.git",
 		"git://github.com/acme/widgets.git", "ssh://git@github.com/acme/widgets.git",
 		"git@github.com:acme/widgets.git",
 	} {
 		t.Run(raw, func(t *testing.T) {
-			owner, name, cloneURL, err := parsePublicGitHubRepository(raw)
-			if err != nil || owner != "acme" || name != "widgets" || cloneURL != "https://github.com/acme/widgets.git" {
-				t.Fatalf("parsePublicGitHubRepository() = %q, %q, %q, %v", owner, name, cloneURL, err)
+			provider, owner, name, cloneURL, err := parseBuildkiteRepository(raw)
+			if err != nil || provider != "github" || owner != "acme" || name != "widgets" || cloneURL != "https://github.com/acme/widgets.git" {
+				t.Fatalf("parseBuildkiteRepository() = %q, %q, %q, %q, %v", provider, owner, name, cloneURL, err)
 			}
 		})
 	}
+	t.Run("Cursor Origin", func(t *testing.T) {
+		raw := "https://origin.cursor.com/git/acme/widgets.git"
+		provider, owner, name, cloneURL, err := parseBuildkiteRepository(raw)
+		if err != nil || provider != "cursor-origin" || owner != "acme" || name != "widgets" || cloneURL != raw {
+			t.Fatalf("parseBuildkiteRepository() = %q, %q, %q, %q, %v", provider, owner, name, cloneURL, err)
+		}
+	})
 	for _, raw := range []string{"", "http://github.com/a/b", "https://user:pass@github.com/a/b", "https://github.example/a/b", "https://github.com/a", "https://github.com/a/b/extra", "https://github.com/a/..", "git@evil.example:a/b", "ssh://user@github.com/a/b"} {
 		t.Run("reject "+raw, func(t *testing.T) {
-			if _, _, _, err := parsePublicGitHubRepository(raw); err == nil {
-				t.Fatalf("parsePublicGitHubRepository(%q) unexpectedly succeeded", raw)
+			if _, _, _, _, err := parseBuildkiteRepository(raw); err == nil {
+				t.Fatalf("parseBuildkiteRepository(%q) unexpectedly succeeded", raw)
 			}
 		})
+	}
+	for _, raw := range []string{
+		"http://origin.cursor.com/git/acme/widgets.git",
+		"ssh://git@origin.cursor.com/git/acme/widgets.git",
+		"https://origin.cursor.com/acme/widgets.git",
+		"https://origin.cursor.com/git/acme/widgets",
+		"https://origin.cursor.com/git/acme/widgets.git/extra",
+		"https://origin.cursor.com/git/acme/widgets.git?ref=main",
+		"https://user:pass@origin.cursor.com/git/acme/widgets.git",
+	} {
+		t.Run("reject Cursor Origin "+raw, func(t *testing.T) {
+			if _, _, _, _, err := parseBuildkiteRepository(raw); err == nil {
+				t.Fatalf("parseBuildkiteRepository(%q) unexpectedly succeeded", raw)
+			}
+		})
+	}
+}
+
+func TestBuildkiteEventSourceCursorOriginIdentity(t *testing.T) {
+	raw := "https://origin.cursor.com/git/acme/widgets.git"
+	env := map[string]string{
+		"BUILDKITE": "true", "BUILDKITE_STEP_KEY": "importer",
+		"BUILDKITE_REPO": raw, "BUILDKITE_COMMIT": strings.Repeat("a", 40),
+		"BUILDKITE_BRANCH": "main", "BUILDKITE_BUILD_AUTHOR": "Origin Author",
+	}
+	source, err := buildkiteEventSource(func(key string) string { return env[key] })
+	if err != nil {
+		t.Fatal(err)
+	}
+	var snapshot map[string]any
+	if err := json.Unmarshal(source, &snapshot); err != nil {
+		t.Fatal(err)
+	}
+	repository := snapshot["repository"].(map[string]any)
+	if snapshot["provider"] != "cursor-origin" || snapshot["event"] != "push" ||
+		repository["owner"] != "acme" || repository["name"] != "widgets" || repository["clone_url"] != raw {
+		t.Fatalf("Cursor Origin snapshot = %#v", snapshot)
+	}
+}
+
+func TestBuildkiteWebhookEventSourceCursorOriginGitHubCompatibleMetadata(t *testing.T) {
+	env := map[string]string{
+		"BUILDKITE": "true", "BUILDKITE_STEP_KEY": "importer",
+		"BUILDKITE_REPO":         "https://origin.cursor.com/git/acme/widgets.git",
+		"BUILDKITE_COMMIT":       strings.Repeat("a", 40),
+		"BUILDKITE_BRANCH":       "feature",
+		"BUILDKITE_GITHUB_EVENT": "pull_request",
+		"BUILDKITE_BUILD_AUTHOR": "Origin Author",
+	}
+	webhook := []byte(`{"action":"opened","repository":{"full_name":"untrusted/other"},"sender":{"login":"origin-user"}}`)
+	source, err := buildkiteWebhookEventSource(func(key string) string { return env[key] }, webhook)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var snapshot map[string]any
+	if err := json.Unmarshal(source, &snapshot); err != nil {
+		t.Fatal(err)
+	}
+	repository := snapshot["repository"].(map[string]any)
+	payload := snapshot["payload"].(map[string]any)
+	if snapshot["provider"] != "cursor-origin" || snapshot["event"] != "pull_request" || snapshot["actor"] != "origin-user" ||
+		repository["owner"] != "acme" || repository["name"] != "widgets" || payload["action"] != "opened" {
+		t.Fatalf("Cursor Origin webhook snapshot = %#v", snapshot)
 	}
 }
 

--- a/internal/cli/buildkite_event_test.go
+++ b/internal/cli/buildkite_event_test.go
@@ -19,7 +19,7 @@ func TestParseBuildkiteRepository(t *testing.T) {
 			}
 		})
 	}
-	t.Run("Cursor Origin", func(t *testing.T) {
+	t.Run("Origin", func(t *testing.T) {
 		raw := "https://origin.cursor.com/git/acme/widgets.git"
 		provider, owner, name, cloneURL, err := parseBuildkiteRepository(raw)
 		if err != nil || provider != "cursor-origin" || owner != "acme" || name != "widgets" || cloneURL != raw {
@@ -45,7 +45,7 @@ func TestParseBuildkiteRepository(t *testing.T) {
 		"https://origin.cursor.com/git/acme/widgets%2Egit",
 		"https://user:pass@origin.cursor.com/git/acme/widgets.git",
 	} {
-		t.Run("reject Cursor Origin "+raw, func(t *testing.T) {
+		t.Run("reject Origin "+raw, func(t *testing.T) {
 			if _, _, _, _, err := parseBuildkiteRepository(raw); err == nil {
 				t.Fatalf("parseBuildkiteRepository(%q) unexpectedly succeeded", raw)
 			}
@@ -53,7 +53,7 @@ func TestParseBuildkiteRepository(t *testing.T) {
 	}
 }
 
-func TestBuildkiteEventSourceCursorOriginIdentity(t *testing.T) {
+func TestBuildkiteEventSourceOriginIdentity(t *testing.T) {
 	raw := "https://origin.cursor.com/git/acme/widgets.git"
 	env := map[string]string{
 		"BUILDKITE": "true", "BUILDKITE_STEP_KEY": "importer",
@@ -71,11 +71,11 @@ func TestBuildkiteEventSourceCursorOriginIdentity(t *testing.T) {
 	repository := snapshot["repository"].(map[string]any)
 	if snapshot["provider"] != "cursor-origin" || snapshot["event"] != "push" ||
 		repository["owner"] != "acme" || repository["name"] != "widgets" || repository["clone_url"] != raw {
-		t.Fatalf("Cursor Origin snapshot = %#v", snapshot)
+		t.Fatalf("Origin snapshot = %#v", snapshot)
 	}
 }
 
-func TestBuildkiteWebhookEventSourceCursorOriginGitHubCompatibleMetadata(t *testing.T) {
+func TestBuildkiteWebhookEventSourceOriginGitHubCompatibleMetadata(t *testing.T) {
 	env := map[string]string{
 		"BUILDKITE": "true", "BUILDKITE_STEP_KEY": "importer",
 		"BUILDKITE_REPO":         "https://origin.cursor.com/git/acme/widgets.git",
@@ -97,7 +97,7 @@ func TestBuildkiteWebhookEventSourceCursorOriginGitHubCompatibleMetadata(t *test
 	payload := snapshot["payload"].(map[string]any)
 	if snapshot["provider"] != "cursor-origin" || snapshot["event"] != "pull_request" || snapshot["actor"] != "origin-user" ||
 		repository["owner"] != "acme" || repository["name"] != "widgets" || payload["action"] != "opened" {
-		t.Fatalf("Cursor Origin webhook snapshot = %#v", snapshot)
+		t.Fatalf("Origin webhook snapshot = %#v", snapshot)
 	}
 }
 

--- a/internal/cli/buildkite_event_test.go
+++ b/internal/cli/buildkite_event_test.go
@@ -40,6 +40,9 @@ func TestParseBuildkiteRepository(t *testing.T) {
 		"https://origin.cursor.com/git/acme/widgets",
 		"https://origin.cursor.com/git/acme/widgets.git/extra",
 		"https://origin.cursor.com/git/acme/widgets.git?ref=main",
+		"https://origin.cursor.com/git/acme/widgets.git?",
+		"https://origin.cursor.com/git/acme/widgets.git#",
+		"https://origin.cursor.com/git/acme/widgets%2Egit",
 		"https://user:pass@origin.cursor.com/git/acme/widgets.git",
 	} {
 		t.Run("reject Cursor Origin "+raw, func(t *testing.T) {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -2064,9 +2064,11 @@ func compileHostedNamespaced(ctx context.Context, workflowPath string, workflowS
 		}
 		defer func() { _ = os.RemoveAll(actionRoot) }()
 		var sourceOptions []actionsource.Option
-		authenticationOption := actionAuthentication.option(ir.Event.Repository.Owner + "/" + ir.Event.Repository.Name)
-		if authenticationOption != nil {
-			sourceOptions = append(sourceOptions, authenticationOption)
+		if ir.Event.Provider == "github" {
+			authenticationOption := actionAuthentication.option(ir.Event.Repository.Owner + "/" + ir.Event.Repository.Name)
+			if authenticationOption != nil {
+				sourceOptions = append(sourceOptions, authenticationOption)
+			}
 		}
 		resolver, err := actionsource.NewResolver(nil, sourceOptions...)
 		if err != nil {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -4116,7 +4116,7 @@ func TestRunUploadDerivesUnattestedBuildkiteEvent(t *testing.T) {
 	}
 }
 
-func TestRunUploadDerivesCursorOriginEvent(t *testing.T) {
+func TestRunUploadDerivesOriginEvent(t *testing.T) {
 	requireImporterHost(t)
 	workflowPath := filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "shell.yml")
 	sha := "0123456789abcdef0123456789abcdef01234567"
@@ -4140,15 +4140,15 @@ func TestRunUploadDerivesCursorOriginEvent(t *testing.T) {
 		}
 		job, err := plan.Decode(contents)
 		if err != nil {
-			t.Fatalf("decode Cursor Origin plan %q: %v", path, err)
+			t.Fatalf("decode Origin plan %q: %v", path, err)
 		}
 		planCount++
 		if job.Event.Provider != "cursor-origin" || job.Event.Repository != "acme/widgets" || job.Event.Ref != "refs/heads/main" || job.Event.SHA != sha {
-			t.Fatalf("Cursor Origin plan event = %#v", job.Event)
+			t.Fatalf("Origin plan event = %#v", job.Event)
 		}
 	}
 	if planCount != 3 {
-		t.Fatalf("Cursor Origin plan count = %d, want 3", planCount)
+		t.Fatalf("Origin plan count = %d, want 3", planCount)
 	}
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -3813,15 +3813,29 @@ func TestHostedLocalActionDoesNotProvisionSourceToken(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	provider := &cliActionSourceTokenProvider{token: "must-not-be-minted"}
-	redactor := &cliRedactor{}
-	var warnings bytes.Buffer
-	authentication := &actionSourceAuthentication{provider: provider, redactor: redactor, warnings: &warnings}
-	if _, err := compileHosted(context.Background(), workflowPath, workflowSource, eventSource, "dev", "sha256:"+strings.Repeat("0", 64), "importer", "", nil, nil, authentication); err != nil {
-		t.Fatal(err)
-	}
-	if provider.calls != 0 || len(redactor.values) != 0 || warnings.Len() != 0 {
-		t.Fatalf("local action provisioned source credential: calls %d, redactions %#v, warnings %q", provider.calls, redactor.values, warnings.String())
+	originEventSource := bytes.Replace(eventSource, []byte(`"provider": "github"`), []byte(`"provider": "cursor-origin"`), 1)
+	originEventSource = bytes.Replace(originEventSource, []byte(`"owner": "buildkite"`), []byte(`"owner": "acme_team"`), 1)
+	originEventSource = bytes.Replace(originEventSource, []byte(`"name": "buildkite-gha"`), []byte(`"name": "widgets"`), 1)
+	originEventSource = bytes.Replace(originEventSource, []byte(`"clone_url": "https://github.com/buildkite/buildkite-gha.git"`), []byte(`"clone_url": "https://origin.cursor.com/git/acme_team/widgets.git"`), 1)
+	for _, test := range []struct {
+		name  string
+		event []byte
+	}{
+		{name: "GitHub", event: eventSource},
+		{name: "Origin repository with GitHub-incompatible namespace", event: originEventSource},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			provider := &cliActionSourceTokenProvider{token: "must-not-be-minted"}
+			redactor := &cliRedactor{}
+			var warnings bytes.Buffer
+			authentication := &actionSourceAuthentication{provider: provider, redactor: redactor, warnings: &warnings}
+			if _, err := compileHosted(context.Background(), workflowPath, workflowSource, test.event, "dev", "sha256:"+strings.Repeat("0", 64), "importer", "", nil, nil, authentication); err != nil {
+				t.Fatal(err)
+			}
+			if provider.calls != 0 || len(redactor.values) != 0 || warnings.Len() != 0 {
+				t.Fatalf("local action provisioned source credential: calls %d, redactions %#v, warnings %q", provider.calls, redactor.values, warnings.String())
+			}
+		})
 	}
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -4116,6 +4116,42 @@ func TestRunUploadDerivesUnattestedBuildkiteEvent(t *testing.T) {
 	}
 }
 
+func TestRunUploadDerivesCursorOriginEvent(t *testing.T) {
+	requireImporterHost(t)
+	workflowPath := filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "shell.yml")
+	sha := "0123456789abcdef0123456789abcdef01234567"
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_STEP_KEY", "origin-event-importer")
+	t.Setenv("BUILDKITE_REPO", "https://origin.cursor.com/git/acme/widgets.git")
+	t.Setenv("BUILDKITE_COMMIT", sha)
+	t.Setenv("BUILDKITE_BRANCH", "main")
+	t.Setenv("BUILDKITE_TAG", "")
+	t.Setenv("BUILDKITE_PULL_REQUEST", "false")
+	t.Setenv("BUILDKITE_BUILD_AUTHOR", "Origin Author")
+	runner := &cliCaptureRunner{}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"upload", "--runtime-queue", "hosted", workflowPath}, &stdout, &stderr, "dev", runner); code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	planCount := 0
+	for path, contents := range runner.uploaded {
+		if !strings.HasSuffix(path, ".json") {
+			continue
+		}
+		job, err := plan.Decode(contents)
+		if err != nil {
+			t.Fatalf("decode Cursor Origin plan %q: %v", path, err)
+		}
+		planCount++
+		if job.Event.Provider != "cursor-origin" || job.Event.Repository != "acme/widgets" || job.Event.Ref != "refs/heads/main" || job.Event.SHA != sha {
+			t.Fatalf("Cursor Origin plan event = %#v", job.Event)
+		}
+	}
+	if planCount != 3 {
+		t.Fatalf("Cursor Origin plan count = %d, want 3", planCount)
+	}
+}
+
 func TestRunUploadUsesWebhookPayloadWithoutRetainingIt(t *testing.T) {
 	requireImporterHost(t)
 	workflowPath := filepath.Join(t.TempDir(), "webhook.yml")

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -351,6 +351,9 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 			requirements.requiredSecrets[name] = true
 		}
 	}
+	if n.native {
+		return requirements, nil
+	}
 	for _, name := range sortedKeys(n.metadata.Inputs) {
 		input := n.metadata.Inputs[name]
 		if input.Default == nil || hasActionInput(supplied, name) {
@@ -364,9 +367,6 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 			return actionRequirements{}, fmt.Errorf("action input %q default: %w", name, err)
 		}
 		requirements.githubToken = requirements.githubToken || referencesToken
-	}
-	if n.native {
-		return requirements, nil
 	}
 	if n.runtime != metadata.RuntimeComposite {
 		return requirements, nil

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -963,6 +963,36 @@ func TestCheckoutCapabilityRequiresVerifiedRootAdapter(t *testing.T) {
 	}
 }
 
+func TestNativeCheckoutIgnoresUpstreamTokenDefaultForOrigin(t *testing.T) {
+	workspace, remote := t.TempDir(), t.TempDir()
+	workflowPath := filepath.Join(workspace, ".github", "workflows", "checkout.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	workflow := []byte("on: push\njobs:\n  checkout:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1\n")
+	if err := os.WriteFile(workflowPath, workflow, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeAction(t, remote, "", "name: checkout\ninputs:\n  token:\n    default: ${{ github.token }}\nruns:\n  using: node24\n  main: index.js\n")
+	event := bytes.Replace(pushEvent(t), []byte(`"provider": "github"`), []byte(`"provider": "cursor-origin"`), 1)
+	bundle, err := CompileBundleWithOptions(workflowPath, workflow, event, "0.0.0-test", testDistributionDigest, "importer", Options{
+		EventTrust: EventUntrusted,
+		Runners: RunnerPolicy{
+			Labels:          map[string]string{"ubuntu-latest": "hosted"},
+			UntrustedQueues: []string{"hosted"},
+		},
+		ResolveActions: true,
+		ActionSource:   &fakeActionSource{root: remote, calls: map[string]int{}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bundle.Plans) != 1 || bundle.Plans[0].Job.Event.Provider != "cursor-origin" || bundle.Plans[0].Job.GitHubToken != nil ||
+		!reflect.DeepEqual(bundle.Plans[0].Job.RequiredCapabilities, []string{"network", "provider-token-read"}) {
+		t.Fatalf("Origin checkout plan = %#v", bundle.Plans)
+	}
+}
+
 func TestUploadArtifactAdapterInputAndCommitBoundary(t *testing.T) {
 	workspace, remote := t.TempDir(), t.TempDir()
 	workflowPath := filepath.Join(workspace, ".github", "workflows", "artifact.yml")

--- a/internal/runtime/checkout.go
+++ b/internal/runtime/checkout.go
@@ -73,8 +73,9 @@ func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, wo
 	result := newResult()
 	const adapter = "checkout adapter"
 	credentialed := job.HasCapability("provider-token-read") && r.RepositoryCredentials != nil
-	if job.Event.Provider != "github" || !validCheckoutRepository(job.Event.Repository) || !checkoutSHAPattern.MatchString(job.Event.SHA) {
-		return result, fmt.Errorf("%s requires a valid github.com event repository and exact SHA; other event sources are unsupported", adapter)
+	url, credentialHost, validProvider := checkoutRepositoryURL(job.Event.Provider, job.Event.Repository)
+	if !validProvider || !checkoutSHAPattern.MatchString(job.Event.SHA) {
+		return result, fmt.Errorf("%s requires a valid GitHub or Cursor Origin event repository and exact SHA; other event sources are unsupported", adapter)
 	}
 	if err := actionintegration.ValidateCheckoutInputs(inputs, job.Event.Repository, job.Event.SHA); err != nil {
 		return result, fmt.Errorf("%s: %w", adapter, err)
@@ -113,13 +114,12 @@ func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, wo
 	if err := run(env, "init", "--template=", "."); err != nil {
 		return result, err
 	}
-	url := "https://github.com/" + job.Event.Repository + ".git"
 	if err := run(env, "remote", "add", "origin", url); err != nil {
 		return result, err
 	}
 	fetchArgs := checkoutFetchArgs(inputs, job.Event.SHA)
 	if credentialed {
-		if err := r.runRepositoryProviderCheckoutFetch(ctx, processor, checkoutDirectory, env, git, base, fetchArgs); err != nil {
+		if err := r.runRepositoryProviderCheckoutFetch(ctx, processor, checkoutDirectory, env, git, base, fetchArgs, credentialHost); err != nil {
 			return result, fmt.Errorf("%s git fetch: %w", adapter, err)
 		}
 	} else if err := run(env, fetchArgs...); err != nil {
@@ -131,7 +131,7 @@ func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, wo
 	}
 	mode := checkoutSubmoduleMode(inputs)
 	if mode != "" {
-		if err := r.runCheckoutSubmodules(ctx, processor, checkoutDirectory, git, env, base, checkoutFetchDepth(inputs) != "0", mode == "recursive", credentialed); err != nil {
+		if err := r.runCheckoutSubmodules(ctx, processor, checkoutDirectory, git, env, base, checkoutFetchDepth(inputs) != "0", mode == "recursive", credentialed, credentialHost); err != nil {
 			return result, fmt.Errorf("%s submodules: %w", adapter, err)
 		}
 	}
@@ -143,6 +143,20 @@ func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, wo
 	result.Outputs["ref"] = checkoutRefOutput(inputs, job.Event.Ref)
 	result.Outputs["commit"] = headSHA
 	return result, nil
+}
+
+func checkoutRepositoryURL(provider, repository string) (url, credentialHost string, ok bool) {
+	if !validCheckoutRepository(repository) {
+		return "", "", false
+	}
+	switch provider {
+	case "github":
+		return "https://github.com/" + repository + ".git", "github.com", true
+	case "cursor-origin":
+		return "https://origin.cursor.com/git/" + repository + ".git", "origin.cursor.com", true
+	default:
+		return "", "", false
+	}
 }
 
 func validateCheckoutRefProvenance(sourceInputs, evaluatedInputs map[string]string, eventSHA string) error {
@@ -215,11 +229,11 @@ func (w *checkoutSubmoduleStatusWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-func (r Runner) runCheckoutSubmodules(ctx context.Context, processor *commandProcessor, workspace string, git string, env map[string]string, base []string, depthOne, recursive, credentialed bool) error {
+func (r Runner) runCheckoutSubmodules(ctx context.Context, processor *commandProcessor, workspace string, git string, env map[string]string, base []string, depthOne, recursive, credentialed bool, credentialHost string) error {
 	policy := append(append([]string{}, base...), "-c", "url.https://github.com/.insteadOf=git@github.com:")
 	run := func(withCredentials bool, args ...string) error {
 		if withCredentials {
-			if err := r.runRepositoryProviderCheckoutFetch(ctx, processor, workspace, env, git, policy, args); err != nil {
+			if err := r.runRepositoryProviderCheckoutFetch(ctx, processor, workspace, env, git, policy, args, credentialHost); err != nil {
 				return fmt.Errorf("git %s: %w", args[0], err)
 			}
 			return nil
@@ -370,18 +384,21 @@ func checkoutInputTrue(value string) bool {
 	return value == "true" || value == "True" || value == "TRUE"
 }
 
-func repositoryProviderCheckoutCredentialArgs(base []string, agent string) []string {
+func repositoryProviderCheckoutCredentialArgs(base []string, agent, host string) []string {
 	return append(append([]string(nil), base...),
-		"-c", "credential.https://github.com.useHttpPath=true",
+		"-c", "credential.https://"+host+".useHttpPath=true",
 		"-c", "http.followRedirects=false",
-		"-c", "credential.https://github.com.helper="+agentGitCredentialHelperCommand(agent),
+		"-c", "credential.https://"+host+".helper="+agentGitCredentialHelperCommand(agent),
 	)
 }
 
-func (r Runner) runRepositoryProviderCheckoutFetch(ctx context.Context, processor *commandProcessor, workspace string, env map[string]string, git string, base, fetchArgs []string) error {
+func (r Runner) runRepositoryProviderCheckoutFetch(ctx context.Context, processor *commandProcessor, workspace string, env map[string]string, git string, base, fetchArgs []string, credentialHost string) error {
 	credentials := r.RepositoryCredentials
 	if credentials == nil || credentials.Agent == "" || !filepath.IsAbs(credentials.Agent) {
 		return fmt.Errorf("repository-provider credentials were not resolved before workflow execution")
+	}
+	if credentialHost != "github.com" && credentialHost != "origin.cursor.com" {
+		return fmt.Errorf("repository-provider credentials require a supported event repository host")
 	}
 	processor.addMask(credentials.JobToken)
 	credentialEnv := cloneStrings(env)
@@ -396,7 +413,7 @@ func (r Runner) runRepositoryProviderCheckoutFetch(ctx context.Context, processo
 	for name, value := range credentials.proxyEnvironment {
 		credentialEnv[name] = value
 	}
-	credentialArgs := repositoryProviderCheckoutCredentialArgs(base, credentials.Agent)
+	credentialArgs := repositoryProviderCheckoutCredentialArgs(base, credentials.Agent, credentialHost)
 	cmd := exec.Command(git, append(credentialArgs, fetchArgs...)...)
 	cmd.Dir = workspace
 	cmd.Env = processEnv(credentialEnv)

--- a/internal/runtime/checkout.go
+++ b/internal/runtime/checkout.go
@@ -75,7 +75,7 @@ func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, wo
 	credentialed := job.HasCapability("provider-token-read") && r.RepositoryCredentials != nil
 	url, credentialHost, validProvider := checkoutRepositoryURL(job.Event.Provider, job.Event.Repository)
 	if !validProvider || !checkoutSHAPattern.MatchString(job.Event.SHA) {
-		return result, fmt.Errorf("%s requires a valid GitHub or Cursor Origin event repository and exact SHA; other event sources are unsupported", adapter)
+		return result, fmt.Errorf("%s requires a valid GitHub or Origin event repository and exact SHA; other event sources are unsupported", adapter)
 	}
 	if err := actionintegration.ValidateCheckoutInputs(inputs, job.Event.Repository, job.Event.SHA); err != nil {
 		return result, fmt.Errorf("%s: %w", adapter, err)

--- a/internal/runtime/checkout_test.go
+++ b/internal/runtime/checkout_test.go
@@ -175,6 +175,33 @@ esac
 	}
 }
 
+func TestCheckoutRepositoryURL(t *testing.T) {
+	for _, test := range []struct {
+		provider, repository, wantURL, wantHost string
+		wantOK                                  bool
+	}{
+		{provider: "github", repository: "acme/widgets", wantURL: "https://github.com/acme/widgets.git", wantHost: "github.com", wantOK: true},
+		{provider: "cursor-origin", repository: "acme/widgets", wantURL: "https://origin.cursor.com/git/acme/widgets.git", wantHost: "origin.cursor.com", wantOK: true},
+		{provider: "other", repository: "acme/widgets"},
+		{provider: "cursor-origin", repository: "acme/widgets/extra"},
+	} {
+		t.Run(test.provider+"/"+test.repository, func(t *testing.T) {
+			url, host, ok := checkoutRepositoryURL(test.provider, test.repository)
+			if url != test.wantURL || host != test.wantHost || ok != test.wantOK {
+				t.Fatalf("checkoutRepositoryURL() = %q, %q, %t", url, host, ok)
+			}
+		})
+	}
+}
+
+func TestRepositoryProviderCheckoutCredentialArgsUseProviderHost(t *testing.T) {
+	args := strings.Join(repositoryProviderCheckoutCredentialArgs([]string{"git"}, "/usr/bin/buildkite-agent", "origin.cursor.com"), "\n")
+	if !strings.Contains(args, "credential.https://origin.cursor.com.useHttpPath=true") ||
+		!strings.Contains(args, "credential.https://origin.cursor.com.helper=") || strings.Contains(args, "credential.https://github.com") {
+		t.Fatalf("Cursor Origin credential arguments = %q", args)
+	}
+}
+
 func TestCheckoutAdapterRejectsUnsupportedInputsAndState(t *testing.T) {
 	repository, sha := "buildkite/buildkite-gha", strings.Repeat("a", 40)
 	processor := newCommandProcessor(io.Discard, io.Discard)
@@ -190,7 +217,7 @@ func TestCheckoutAdapterRejectsUnsupportedInputsAndState(t *testing.T) {
 		t.Fatalf("nonempty workspace error = %v", err)
 	}
 	job.Event.Provider = "other"
-	if _, err := (Runner{}).runCheckout(context.Background(), processor, t.TempDir(), job, nil); err == nil || !strings.Contains(err.Error(), "valid github.com event") {
+	if _, err := (Runner{}).runCheckout(context.Background(), processor, t.TempDir(), job, nil); err == nil || !strings.Contains(err.Error(), "valid GitHub or Cursor Origin event") {
 		t.Fatalf("invalid event error = %v", err)
 	}
 }
@@ -268,7 +295,7 @@ func TestCheckoutSubmoduleNativeCommandSequenceAndFlags(t *testing.T) {
 		t.Fatal(err)
 	}
 	runner := Runner{Stdout: io.Discard, Stderr: io.Discard}
-	if err := runner.runCheckoutSubmodules(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), git, map[string]string{}, checkoutGitBaseArgs(), true, true, false); err != nil {
+	if err := runner.runCheckoutSubmodules(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), git, map[string]string{}, checkoutGitBaseArgs(), true, true, false, ""); err != nil {
 		t.Fatal(err)
 	}
 	contents, err := os.ReadFile(logPath)
@@ -307,7 +334,7 @@ exit 0
 			if err := os.WriteFile(git, []byte(script), 0o700); err != nil {
 				t.Fatal(err)
 			}
-			err := (Runner{Stdout: io.Discard, Stderr: io.Discard}).runCheckoutSubmodules(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), git, map[string]string{}, checkoutGitBaseArgs(), false, false, false)
+			err := (Runner{Stdout: io.Discard, Stderr: io.Discard}).runCheckoutSubmodules(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), git, map[string]string{}, checkoutGitBaseArgs(), false, false, false, "")
 			if err == nil || !strings.Contains(err.Error(), "invalid state") {
 				t.Fatalf("status prefix %q error = %v", prefix, err)
 			}
@@ -335,7 +362,7 @@ func TestCheckoutSubmodulesUsesNativePorcelain(t *testing.T) {
 			runTestGit(t, workspace, "checkout", "--detach", parentOID)
 			base := append(checkoutGitBaseArgs(), "-c", "protocol.file.allow=always")
 			runner := Runner{Stdout: io.Discard, Stderr: io.Discard}
-			if err := runner.runCheckoutSubmodules(context.Background(), newCommandProcessor(io.Discard, io.Discard), workspace, "git", map[string]string{"HOME": filepath.Join(workspace, ".no-home"), "GIT_CONFIG_NOSYSTEM": "1", "GIT_CONFIG_GLOBAL": os.DevNull}, base, test.depthOne, test.recursive, false); err != nil {
+			if err := runner.runCheckoutSubmodules(context.Background(), newCommandProcessor(io.Discard, io.Discard), workspace, "git", map[string]string{"HOME": filepath.Join(workspace, ".no-home"), "GIT_CONFIG_NOSYSTEM": "1", "GIT_CONFIG_GLOBAL": os.DevNull}, base, test.depthOne, test.recursive, false, ""); err != nil {
 				t.Fatal(err)
 			}
 			childPath := filepath.Join(workspace, "deps", "child")
@@ -400,7 +427,7 @@ func TestSubmoduleResolvedCredentialsWithoutCapabilityDoNotInvokeHelper(t *testi
 		t.Fatal(err)
 	}
 	runner := Runner{RepositoryCredentials: &AgentRepositoryCredentials{Agent: agent, JobID: testCacheJobID, JobToken: "secret"}, Stdout: io.Discard, Stderr: io.Discard}
-	if err := runner.runCheckoutSubmodules(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), git, map[string]string{}, checkoutGitBaseArgs(), false, false, false); err != nil {
+	if err := runner.runCheckoutSubmodules(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), git, map[string]string{}, checkoutGitBaseArgs(), false, false, false, ""); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(marker); !os.IsNotExist(err) {
@@ -441,7 +468,7 @@ echo job-secret
 	}
 	var logs bytes.Buffer
 	runner := Runner{RepositoryCredentials: &AgentRepositoryCredentials{Agent: agent, JobID: testCacheJobID, JobToken: "job-secret"}, Stdout: &logs, Stderr: &logs}
-	if err := runner.runRepositoryProviderCheckoutFetch(context.Background(), newCommandProcessor(&logs, &logs), workspace, map[string]string{}, git, checkoutGitBaseArgs(), []string{"submodule", "update"}); err != nil {
+	if err := runner.runRepositoryProviderCheckoutFetch(context.Background(), newCommandProcessor(&logs, &logs), workspace, map[string]string{}, git, checkoutGitBaseArgs(), []string{"submodule", "update"}, "github.com"); err != nil {
 		t.Fatal(err)
 	}
 	input, err := os.ReadFile(inputLog)
@@ -606,7 +633,7 @@ exec ` + shellTestQuote(realGit) + ` "$@"
 	runner := Runner{Stdout: io.Discard, Stderr: io.Discard, InterruptGrace: 20 * time.Millisecond, TerminateGrace: 20 * time.Millisecond}
 	done := make(chan error, 1)
 	go func() {
-		done <- runner.runCheckoutSubmodules(ctx, newCommandProcessor(io.Discard, io.Discard), workspace, wrapper, map[string]string{}, append(checkoutGitBaseArgs(), "-c", "protocol.file.allow=always"), true, false, false)
+		done <- runner.runCheckoutSubmodules(ctx, newCommandProcessor(io.Discard, io.Discard), workspace, wrapper, map[string]string{}, append(checkoutGitBaseArgs(), "-c", "protocol.file.allow=always"), true, false, false, "")
 	}()
 	deadline := time.Now().Add(5 * time.Second)
 	for {
@@ -654,7 +681,7 @@ exit 0
 	runner := Runner{Stdout: io.Discard, Stderr: io.Discard, InterruptGrace: 20 * time.Millisecond, TerminateGrace: 20 * time.Millisecond}
 	done := make(chan error, 1)
 	go func() {
-		done <- runner.runCheckoutSubmodules(ctx, newCommandProcessor(io.Discard, io.Discard), t.TempDir(), git, map[string]string{}, checkoutGitBaseArgs(), false, true, false)
+		done <- runner.runCheckoutSubmodules(ctx, newCommandProcessor(io.Discard, io.Discard), t.TempDir(), git, map[string]string{}, checkoutGitBaseArgs(), false, true, false, "")
 	}()
 	deadline := time.Now().Add(5 * time.Second)
 	for {
@@ -685,7 +712,7 @@ func TestCheckoutRejectsInvalidRepositoryBeforeInspectingWorkspace(t *testing.T)
 	}
 	job := plan.Job{Event: plan.Event{Provider: "github", Repository: "owner/..", SHA: strings.Repeat("a", 40)}}
 	processor := newCommandProcessor(io.Discard, io.Discard)
-	if _, err := (Runner{}).runCheckout(context.Background(), processor, workspace, job, nil); err == nil || !strings.Contains(err.Error(), "valid github.com event repository") {
+	if _, err := (Runner{}).runCheckout(context.Background(), processor, workspace, job, nil); err == nil || !strings.Contains(err.Error(), "valid GitHub or Cursor Origin event repository") {
 		t.Fatalf("checkout repository validation error = %v", err)
 	}
 }
@@ -914,7 +941,7 @@ printf 'username=token\npassword=secret\n'
 	if err := os.WriteFile(agent, []byte(script), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	args := repositoryProviderCheckoutCredentialArgs(checkoutGitBaseArgs(), agent)
+	args := repositoryProviderCheckoutCredentialArgs(checkoutGitBaseArgs(), agent, "github.com")
 	fill := func(host, path string) error {
 		cmd := exec.Command("git", append(args, "credential", "fill")...)
 		cmd.Env = processEnv(map[string]string{"GIT_TERMINAL_PROMPT": "0"})

--- a/internal/runtime/checkout_test.go
+++ b/internal/runtime/checkout_test.go
@@ -198,11 +198,11 @@ func TestRepositoryProviderCheckoutCredentialArgsUseProviderHost(t *testing.T) {
 	args := strings.Join(repositoryProviderCheckoutCredentialArgs([]string{"git"}, "/usr/bin/buildkite-agent", "origin.cursor.com"), "\n")
 	if !strings.Contains(args, "credential.https://origin.cursor.com.useHttpPath=true") ||
 		!strings.Contains(args, "credential.https://origin.cursor.com.helper=") || strings.Contains(args, "credential.https://github.com") {
-		t.Fatalf("Cursor Origin credential arguments = %q", args)
+		t.Fatalf("Origin credential arguments = %q", args)
 	}
 }
 
-func TestCursorOriginCheckoutUsesExactRemoteAndCredentialHost(t *testing.T) {
+func TestOriginCheckoutUsesExactRemoteAndCredentialHost(t *testing.T) {
 	workspace := t.TempDir()
 	sha := strings.Repeat("a", 40)
 	gitLog := filepath.Join(t.TempDir(), "git.log")
@@ -276,14 +276,14 @@ printf '%s\n' "$*" >> ` + shellTestQuote(gitLog) + `
 	if !strings.Contains(string(gitCommands), "remote add origin https://origin.cursor.com/git/acme/widgets.git") ||
 		!strings.Contains(string(gitCommands), "credential.https://origin.cursor.com.useHttpPath=true") ||
 		strings.Contains(string(gitCommands), "credential.https://github.com") {
-		t.Fatalf("Cursor Origin Git commands = %q", gitCommands)
+		t.Fatalf("Origin Git commands = %q", gitCommands)
 	}
 	input, err := os.ReadFile(helperInput)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if string(input) != "protocol=https\nhost=origin.cursor.com\npath=git/acme/widgets.git\n\n" {
-		t.Fatalf("Cursor Origin credential input = %q", input)
+		t.Fatalf("Origin credential input = %q", input)
 	}
 }
 
@@ -302,7 +302,7 @@ func TestCheckoutAdapterRejectsUnsupportedInputsAndState(t *testing.T) {
 		t.Fatalf("nonempty workspace error = %v", err)
 	}
 	job.Event.Provider = "other"
-	if _, err := (Runner{}).runCheckout(context.Background(), processor, t.TempDir(), job, nil); err == nil || !strings.Contains(err.Error(), "valid GitHub or Cursor Origin event") {
+	if _, err := (Runner{}).runCheckout(context.Background(), processor, t.TempDir(), job, nil); err == nil || !strings.Contains(err.Error(), "valid GitHub or Origin event") {
 		t.Fatalf("invalid event error = %v", err)
 	}
 }
@@ -797,7 +797,7 @@ func TestCheckoutRejectsInvalidRepositoryBeforeInspectingWorkspace(t *testing.T)
 	}
 	job := plan.Job{Event: plan.Event{Provider: "github", Repository: "owner/..", SHA: strings.Repeat("a", 40)}}
 	processor := newCommandProcessor(io.Discard, io.Discard)
-	if _, err := (Runner{}).runCheckout(context.Background(), processor, workspace, job, nil); err == nil || !strings.Contains(err.Error(), "valid GitHub or Cursor Origin event repository") {
+	if _, err := (Runner{}).runCheckout(context.Background(), processor, workspace, job, nil); err == nil || !strings.Contains(err.Error(), "valid GitHub or Origin event repository") {
 		t.Fatalf("checkout repository validation error = %v", err)
 	}
 }

--- a/internal/runtime/checkout_test.go
+++ b/internal/runtime/checkout_test.go
@@ -202,6 +202,91 @@ func TestRepositoryProviderCheckoutCredentialArgsUseProviderHost(t *testing.T) {
 	}
 }
 
+func TestCursorOriginCheckoutUsesExactRemoteAndCredentialHost(t *testing.T) {
+	workspace := t.TempDir()
+	sha := strings.Repeat("a", 40)
+	gitLog := filepath.Join(t.TempDir(), "git.log")
+	helperInput := filepath.Join(t.TempDir(), "helper-input")
+	agent := filepath.Join(t.TempDir(), "buildkite-agent")
+	agentScript := `#!/bin/sh
+set -eu
+test "$1" = git-credentials-helper
+test "$2" = get
+cat > ` + shellTestQuote(helperInput) + `
+printf 'username=token\npassword=origin-repository-token\n'
+`
+	if err := os.WriteFile(agent, []byte(agentScript), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	git := filepath.Join(t.TempDir(), "git")
+	gitScript := `#!/bin/sh
+set -eu
+operation=
+for argument in "$@"; do
+  case "$argument" in init|remote|fetch|checkout) operation="$argument"; break ;; esac
+done
+case "$operation" in
+  init) mkdir -p .git ;;
+  fetch)
+    helper=
+    for argument in "$@"; do
+      case "$argument" in
+        credential.https://origin.cursor.com.helper=!*) helper="${argument#credential.https://origin.cursor.com.helper=!}" ;;
+        credential.https://github.com.*) exit 42 ;;
+      esac
+    done
+    test -n "$helper"
+    credentials="$(printf 'protocol=https\nhost=origin.cursor.com\npath=git/acme/widgets.git\n\n' | sh -c "$helper get")"
+    case "$credentials" in
+      *"username=token"*"password=origin-repository-token"*) ;;
+      *) exit 43 ;;
+    esac
+    ;;
+  checkout) printf '%s\n' ` + shellTestQuote(sha) + ` > .git/HEAD ;;
+esac
+printf '%s\n' "$*" >> ` + shellTestQuote(gitLog) + `
+`
+	if err := os.WriteFile(git, []byte(gitScript), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	credentials, err := resolveAgentRepositoryCredentialsBeforeWorkflow(&AgentRepositoryCredentials{
+		Agent: agent, JobID: testCacheJobID, JobToken: "job-secret",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	job := plan.Job{
+		Event:                plan.Event{Provider: "cursor-origin", Repository: "acme/widgets", Ref: "refs/heads/main", SHA: sha},
+		RequiredCapabilities: []string{"network", "provider-token-read"},
+	}
+	var logs bytes.Buffer
+	result, err := (Runner{Git: git, RepositoryCredentials: credentials, Stdout: &logs, Stderr: &logs}).runCheckout(
+		context.Background(), newCommandProcessor(&logs, &logs), workspace, job, nil,
+	)
+	if err != nil {
+		t.Fatalf("runCheckout() error = %v, logs = %q", err, logs.String())
+	}
+	if result.Outputs["commit"] != sha {
+		t.Fatalf("checkout outputs = %#v", result.Outputs)
+	}
+	gitCommands, err := os.ReadFile(gitLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(gitCommands), "remote add origin https://origin.cursor.com/git/acme/widgets.git") ||
+		!strings.Contains(string(gitCommands), "credential.https://origin.cursor.com.useHttpPath=true") ||
+		strings.Contains(string(gitCommands), "credential.https://github.com") {
+		t.Fatalf("Cursor Origin Git commands = %q", gitCommands)
+	}
+	input, err := os.ReadFile(helperInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(input) != "protocol=https\nhost=origin.cursor.com\npath=git/acme/widgets.git\n\n" {
+		t.Fatalf("Cursor Origin credential input = %q", input)
+	}
+}
+
 func TestCheckoutAdapterRejectsUnsupportedInputsAndState(t *testing.T) {
 	repository, sha := "buildkite/buildkite-gha", strings.Repeat("a", 40)
 	processor := newCommandProcessor(io.Discard, io.Discard)


### PR DESCRIPTION
## Why

`buildkite-gha upload` rejects Internal and Private Origin pipelines because `BUILDKITE_REPO` only accepts public `github.com` repository URLs.

## What

Accept the canonical `https://origin.cursor.com/git/<namespace>/<repository>.git` URL, preserve its exact identity, and emit `cursor-origin` event metadata while retaining GitHub-compatible payload behavior. Native `actions/checkout` reconstructs the Origin remote, scopes Buildkite repository credentials to `origin.cursor.com`, and ignores the upstream action’s unused GitHub token default. Public GitHub actions resolve anonymously for Origin events; existing GitHub behavior is unchanged.