### PR TITLE
Style all Buildkite annotations

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2207,7 +2207,11 @@ func TestValidatePublishesProcessingDiagnosticsInBuildkite(t *testing.T) {
 		if len(annotation.args) != 9 || annotation.args[0] != "annotate" || annotation.args[2] != "job" || annotation.args[4] != cliTestJobID || !strings.HasPrefix(annotation.args[6], processingAnnotationContext+"-") || annotation.args[8] != "error" {
 			t.Fatalf("annotation args = %#v", annotation.args)
 		}
-		for _, want := range []string{"GitHub Actions workflow diagnostics", `#### Runner label "windows-latest" uses an unsupported operating system`, "Job `test`"} {
+		for _, want := range []string{
+			`<h2 class="h4 mb2">GitHub Actions workflow diagnostics</h2>`,
+			`<div class="border-top border-gray py2"><div><strong>Runner label &#34;windows-latest&#34; uses an unsupported operating system`,
+			"Job <code>test</code>",
+		} {
 			if !strings.Contains(string(annotation.stdin), want) {
 				t.Fatalf("annotation = %q, want %q", annotation.stdin, want)
 			}
@@ -2243,7 +2247,7 @@ func TestValidatePublishesProcessingDiagnosticsInBuildkite(t *testing.T) {
 	})
 }
 
-func TestProcessingAnnotationIsBoundedAndEscapesMarkdown(t *testing.T) {
+func TestProcessingAnnotationIsBoundedAndEscapesHTML(t *testing.T) {
 	report := compatibility.NewProcessingReport("<workflow>|name", "")
 	report.Diagnostics = append(report.Diagnostics, compatibility.Diagnostic{
 		Level: "error", Code: "E_TEST", Message: `line one
@@ -2253,10 +2257,13 @@ func TestProcessingAnnotationIsBoundedAndEscapesMarkdown(t *testing.T) {
 	if style != "error" || len(body) > processingAnnotationBodyLimit || !utf8.ValidString(body) {
 		t.Fatalf("style = %q, bytes = %d, valid UTF-8 = %v", style, len(body), utf8.ValidString(body))
 	}
-	for _, want := range []string{"&lt;workflow&gt;\\|name", `&lt;script&gt;\*unsafe\*&lt;/script&gt; "quoted"`, "Additional diagnostics omitted"} {
+	for _, want := range []string{"&lt;workflow&gt;|name", "&lt;script&gt;*unsafe*&lt;/script&gt; &#34;quoted&#34;", "Additional diagnostics omitted"} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("annotation lacks %q", want)
 		}
+	}
+	if strings.Count(body, "<div") != strings.Count(body, "</div>") {
+		t.Fatalf("annotation contains unbalanced styling markup")
 	}
 }
 
@@ -2275,9 +2282,9 @@ func TestProcessingAnnotationDoesNotRepeatDiagnosticLocation(t *testing.T) {
 	}
 }
 
-func TestMarkdownCodeContainsWorkflowBackticks(t *testing.T) {
-	if got, want := markdownCode("action` **not bold** & <tag> ``tail"), "``` action` **not bold** & <tag> ``tail ```"; got != want {
-		t.Fatalf("markdownCode() = %q, want %q", got, want)
+func TestAnnotationCodeEscapesHTML(t *testing.T) {
+	if got, want := annotationCode("action` **not bold** & <tag> ``tail"), "<code>action` **not bold** &amp; &lt;tag&gt; ``tail</code>"; got != want {
+		t.Fatalf("annotationCode() = %q, want %q", got, want)
 	}
 }
 
@@ -2291,8 +2298,8 @@ func TestProcessingAnnotationPresentsActionFailureAsAConciseCard(t *testing.T) {
 
 	_, body := processingAnnotation(report)
 	for _, want := range []string{
-		`#### Action metadata uses unsupported field "deprecationMessage"`,
-		"Action `actions/setup-java@v4` · Job `test` · Step 2",
+		`<div class="border-top border-gray py2"><div><strong>Action metadata uses unsupported field &#34;deprecationMessage&#34;</strong></div>`,
+		"Action <code>actions/setup-java@v4</code> · Job <code>test</code> · Step 2",
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("annotation = %q, want %q", body, want)
@@ -2324,7 +2331,7 @@ func TestProcessingAnnotationLeadsWithTheActionableDiagnostic(t *testing.T) {
 			name: "token configuration",
 			diagnostic: compatibility.Diagnostic{Code: "E_PROFILE",
 				Message: `Job "test" needs GITHUB_TOKEN, but job-level permissions are unsupported.`},
-			want: `Job "test" needs GITHUB\_TOKEN, but job-level permissions are unsupported.`,
+			want: `Job "test" needs GITHUB_TOKEN, but job-level permissions are unsupported.`,
 		},
 		{
 			name: "hosted container",
@@ -2377,7 +2384,7 @@ func TestProcessingDiagnosticRenderingsUseTheSameMessageAndAggregation(t *testin
 	}
 	_, annotation := processingAnnotation(report)
 	if strings.Count(textOutput.String(), message) != 1 ||
-		strings.Count(annotation, `Job "test" needs GITHUB\_TOKEN, but job-level permissions are unsupported.`) != 1 ||
+		strings.Count(annotation, `Job &#34;test&#34; needs GITHUB_TOKEN, but job-level permissions are unsupported.`) != 1 ||
 		strings.Count(annotation, `Effective permissions: contents: read.`) != 1 {
 		t.Fatalf("text = %q; annotation = %q", textOutput.String(), annotation)
 	}
@@ -5647,7 +5654,8 @@ func TestRunJobPublishesSummaryAsAdvisoryJobAnnotation(t *testing.T) {
 				return
 			}
 			wantArgs := []string{"annotate", "--scope", "job", "--job", cliTestJobID, "--context", "buildkite-gha-job-summary", "--style", "info"}
-			if len(annotations) != 1 || !slices.Equal(annotations[0].args, wantArgs) || string(annotations[0].stdin) != "### Job summary\n\nPassed.\n" {
+			wantBody := "<h2 class=\"h4 mb2\">GitHub Actions job summary</h2>\n<div class=\"border-top border-gray pt2\"></div>\n### Job summary\n\nPassed.\n"
+			if len(annotations) != 1 || !slices.Equal(annotations[0].args, wantArgs) || string(annotations[0].stdin) != wantBody {
 				t.Fatalf("annotations = %#v", annotations)
 			}
 			if last := runner.commands[len(runner.commands)-1]; len(last.args) == 0 || last.args[0] != "annotate" {
@@ -5821,7 +5829,11 @@ func TestPublishTerminalResultAnnotatesCancelledJobWithFreshContext(t *testing.T
 	if err != nil || publication.SummaryAnnotationError != nil || publication.WarningAnnotationError != nil || publication.ErrorAnnotationError != nil {
 		t.Fatalf("publishTerminalResult() publication = %#v, error = %v", publication, err)
 	}
-	wantBodies := []string{"summary before cancellation\n", "warning before cancellation\n", "error before cancellation\n"}
+	wantBodies := []string{
+		"<h2 class=\"h4 mb2\">GitHub Actions job summary</h2>\n<div class=\"border-top border-gray pt2\"></div>\nsummary before cancellation\n",
+		"warning before cancellation\n",
+		"error before cancellation\n",
+	}
 	commands := runner.commands[len(runner.commands)-len(wantBodies):]
 	for i, command := range commands {
 		if len(command.args) == 0 || command.args[0] != "annotate" || string(command.stdin) != wantBodies[i] {
@@ -5931,7 +5943,8 @@ func TestRunJobPublishesBoundedFailureForUnrepresentableOutputs(t *testing.T) {
 		t.Fatalf("published result = %#v, want bounded failure without outputs", manifest)
 	}
 	last := runner.commands[len(runner.commands)-1]
-	if len(last.args) == 0 || last.args[0] != "annotate" || string(last.stdin) != "summary from malformed result\n" {
+	wantSummary := "<h2 class=\"h4 mb2\">GitHub Actions job summary</h2>\n<div class=\"border-top border-gray pt2\"></div>\nsummary from malformed result\n"
+	if len(last.args) == 0 || last.args[0] != "annotate" || string(last.stdin) != wantSummary {
 		t.Fatalf("last command = %#v, want summary annotation after bounded failure", last)
 	}
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2267,6 +2267,25 @@ func TestProcessingAnnotationIsBoundedAndEscapesHTML(t *testing.T) {
 	}
 }
 
+func TestProcessingAnnotationReservesSpaceForTruncationNotice(t *testing.T) {
+	report := compatibility.NewProcessingReport("ci.yml", "")
+	probe := compatibility.Diagnostic{Level: "warning", Code: "W_LARGE", Message: "a"}
+	probeRow := renderProcessingDiagnostic(probe)
+	prefixBytes := len("<h2 class=\"h4 mb2\">GitHub Actions workflow diagnostics</h2>\n") +
+		len("<div class=\"mb2\"><strong>Workflow:</strong> ") + len(annotationCode(report.Workflow)) +
+		len("</div>\n<div class=\"mb2\">\n")
+	messageBytes := processingAnnotationBodyLimit - prefixBytes - len(processingAnnotationEnd) - len(processingAnnotationNotice)/2 - (len(probeRow) - len(probe.Message))
+	report.Diagnostics = append(report.Diagnostics,
+		compatibility.Diagnostic{Level: "warning", Code: "W_LARGE", Message: strings.Repeat("a", messageBytes)},
+		compatibility.Diagnostic{Level: "warning", Code: "W_OMITTED", Message: "omitted diagnostic"},
+	)
+
+	_, body := processingAnnotation(report)
+	if len(body) > processingAnnotationBodyLimit || !strings.Contains(body, "Additional diagnostics omitted") {
+		t.Fatalf("annotation bytes = %d, notice present = %v", len(body), strings.Contains(body, "Additional diagnostics omitted"))
+	}
+}
+
 func TestProcessingAnnotationDoesNotRepeatDiagnosticLocation(t *testing.T) {
 	report := compatibility.NewProcessingReport("ci.yml", "")
 	report.Diagnostics = append(report.Diagnostics, compatibility.Diagnostic{
@@ -5654,7 +5673,7 @@ func TestRunJobPublishesSummaryAsAdvisoryJobAnnotation(t *testing.T) {
 				return
 			}
 			wantArgs := []string{"annotate", "--scope", "job", "--job", cliTestJobID, "--context", "buildkite-gha-job-summary", "--style", "info"}
-			wantBody := "<h2 class=\"h4 mb2\">GitHub Actions job summary</h2>\n<div class=\"border-top border-gray pt2\"></div>\n### Job summary\n\nPassed.\n"
+			wantBody := "<h2 class=\"h4 mb2\">GitHub Actions job summary</h2>\n<div class=\"border-top border-gray pt2\"></div>\n\n### Job summary\n\nPassed.\n"
 			if len(annotations) != 1 || !slices.Equal(annotations[0].args, wantArgs) || string(annotations[0].stdin) != wantBody {
 				t.Fatalf("annotations = %#v", annotations)
 			}
@@ -5830,7 +5849,7 @@ func TestPublishTerminalResultAnnotatesCancelledJobWithFreshContext(t *testing.T
 		t.Fatalf("publishTerminalResult() publication = %#v, error = %v", publication, err)
 	}
 	wantBodies := []string{
-		"<h2 class=\"h4 mb2\">GitHub Actions job summary</h2>\n<div class=\"border-top border-gray pt2\"></div>\nsummary before cancellation\n",
+		"<h2 class=\"h4 mb2\">GitHub Actions job summary</h2>\n<div class=\"border-top border-gray pt2\"></div>\n\nsummary before cancellation\n",
 		"warning before cancellation\n",
 		"error before cancellation\n",
 	}
@@ -5943,7 +5962,7 @@ func TestRunJobPublishesBoundedFailureForUnrepresentableOutputs(t *testing.T) {
 		t.Fatalf("published result = %#v, want bounded failure without outputs", manifest)
 	}
 	last := runner.commands[len(runner.commands)-1]
-	wantSummary := "<h2 class=\"h4 mb2\">GitHub Actions job summary</h2>\n<div class=\"border-top border-gray pt2\"></div>\nsummary from malformed result\n"
+	wantSummary := "<h2 class=\"h4 mb2\">GitHub Actions job summary</h2>\n<div class=\"border-top border-gray pt2\"></div>\n\nsummary from malformed result\n"
 	if len(last.args) == 0 || last.args[0] != "annotate" || string(last.stdin) != wantSummary {
 		t.Fatalf("last command = %#v, want summary annotation after bounded failure", last)
 	}

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -91,12 +91,24 @@ func processingAnnotation(report compatibility.ProcessingReport) (style, body st
 	out.WriteString("<div class=\"mb2\"><strong>Workflow:</strong> ")
 	out.WriteString(annotationCode(report.Workflow))
 	out.WriteString("</div>\n<div class=\"mb2\">\n")
-	for _, diagnostic := range diagnostics {
-		remaining := processingAnnotationBodyLimit - out.Len() - len(processingAnnotationEnd)
-		row := renderProcessingDiagnostic(diagnostic)
+	rows := make([]string, len(diagnostics))
+	bodyBytes := out.Len() + len(processingAnnotationEnd)
+	for i, diagnostic := range diagnostics {
+		rows[i] = renderProcessingDiagnostic(diagnostic)
+		bodyBytes += len(rows[i])
+	}
+	if bodyBytes <= processingAnnotationBodyLimit {
+		for _, row := range rows {
+			out.WriteString(row)
+		}
+		out.WriteString(processingAnnotationEnd)
+		return style, out.String()
+	}
+
+	remaining := processingAnnotationBodyLimit - out.Len() - len(processingAnnotationEnd) - len(processingAnnotationNotice)
+	for i, row := range rows {
 		if len(row) > remaining {
-			remaining -= len(processingAnnotationNotice)
-			if row = renderProcessingDiagnosticWithin(diagnostic, remaining); row != "" {
+			if row = renderProcessingDiagnosticWithin(diagnostics[i], remaining); row != "" {
 				out.WriteString(row)
 			}
 			out.WriteString(processingAnnotationEnd)
@@ -104,9 +116,9 @@ func processingAnnotation(report compatibility.ProcessingReport) (style, body st
 			return style, out.String()
 		}
 		out.WriteString(row)
+		remaining -= len(row)
 	}
-	out.WriteString(processingAnnotationEnd)
-	return style, out.String()
+	panic("processing annotation exceeded its precomputed size")
 }
 
 func renderProcessingDiagnosticWithin(diagnostic compatibility.Diagnostic, limit int) string {

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"html"
 	"io"
 	"os"
 	"strings"
@@ -19,6 +20,8 @@ import (
 const (
 	processingAnnotationContext   = "buildkite-gha-processing"
 	processingAnnotationBodyLimit = 1024 * 1024
+	processingAnnotationEnd       = "</div>\n"
+	processingAnnotationNotice    = "\n_Additional diagnostics omitted at the Buildkite annotation size limit._\n"
 )
 
 // processingOutput owns where one command writes processing reports and
@@ -84,55 +87,82 @@ func processingAnnotation(report compatibility.ProcessingReport) (style, body st
 	}
 
 	var out strings.Builder
-	out.WriteString("### GitHub Actions workflow diagnostics\n\n")
-	out.WriteString("**Workflow:** ")
-	out.WriteString(markdownText(report.Workflow))
-	out.WriteString("\n")
+	out.WriteString("<h2 class=\"h4 mb2\">GitHub Actions workflow diagnostics</h2>\n")
+	out.WriteString("<div class=\"mb2\"><strong>Workflow:</strong> ")
+	out.WriteString(annotationCode(report.Workflow))
+	out.WriteString("</div>\n<div class=\"mb2\">\n")
 	for _, diagnostic := range diagnostics {
-		heading, details := annotationDiagnosticPresentation(diagnostic)
-		out.WriteString("\n#### ")
-		out.WriteString(heading)
-		context := make([]string, 0, 4)
-		if diagnostic.Action != "" {
-			context = append(context, "Action "+markdownCode(diagnostic.Action))
-		}
-		if diagnostic.Location != nil {
-			context = append(context, markdownCode(fmt.Sprintf("%s:%d:%d", diagnostic.Location.Path, diagnostic.Location.Line, diagnostic.Location.Column)))
-		}
-		if diagnostic.Job != "" {
-			context = append(context, "Job "+markdownCode(diagnostic.Job))
-		}
-		if diagnostic.Step != 0 {
-			context = append(context, fmt.Sprintf("Step %d", diagnostic.Step))
-		}
-		if len(context) != 0 {
-			out.WriteString("\n\n")
-			out.WriteString(strings.Join(context, " · "))
-		}
-		if len(details) != 0 {
-			out.WriteString("\n\n")
-		}
-		for i, sentence := range details {
-			if i != 0 {
-				out.WriteString("  \n")
+		remaining := processingAnnotationBodyLimit - out.Len() - len(processingAnnotationEnd)
+		row := renderProcessingDiagnostic(diagnostic)
+		if len(row) > remaining {
+			remaining -= len(processingAnnotationNotice)
+			if row = renderProcessingDiagnosticWithin(diagnostic, remaining); row != "" {
+				out.WriteString(row)
 			}
-			out.WriteString(markdownText(sentence))
+			out.WriteString(processingAnnotationEnd)
+			out.WriteString(processingAnnotationNotice)
+			return style, out.String()
 		}
-		out.WriteString("\n")
+		out.WriteString(row)
 	}
-	return style, truncateProcessingAnnotation(out.String())
+	out.WriteString(processingAnnotationEnd)
+	return style, out.String()
 }
 
-func truncateProcessingAnnotation(body string) string {
-	if len(body) <= processingAnnotationBodyLimit {
-		return body
+func renderProcessingDiagnosticWithin(diagnostic compatibility.Diagnostic, limit int) string {
+	message := diagnostic.Message
+	row := renderProcessingDiagnostic(diagnostic)
+	for len(row) > limit && message != "" {
+		end := max(0, len(message)-(len(row)-limit))
+		for end > 0 && !utf8.ValidString(message[:end]) {
+			end--
+		}
+		diagnostic.Message = message[:end] + "…"
+		message = message[:end]
+		row = renderProcessingDiagnostic(diagnostic)
 	}
-	const notice = "\n\n_Additional diagnostics omitted at the Buildkite annotation size limit._\n"
-	end := processingAnnotationBodyLimit - len(notice)
-	for !utf8.ValidString(body[:end]) {
-		end--
+	if len(row) > limit {
+		return ""
 	}
-	return body[:end] + notice
+	return row
+}
+
+func renderProcessingDiagnostic(diagnostic compatibility.Diagnostic) string {
+	heading, details := annotationDiagnosticPresentation(diagnostic)
+	var out strings.Builder
+	out.WriteString("<div class=\"border-top border-gray py2\"><div><strong>")
+	out.WriteString(annotationHTML(heading))
+	out.WriteString("</strong></div>")
+	context := make([]string, 0, 4)
+	if diagnostic.Action != "" {
+		context = append(context, "Action "+annotationCode(diagnostic.Action))
+	}
+	if diagnostic.Location != nil {
+		context = append(context, annotationCode(fmt.Sprintf("%s:%d:%d", diagnostic.Location.Path, diagnostic.Location.Line, diagnostic.Location.Column)))
+	}
+	if diagnostic.Job != "" {
+		context = append(context, "Job "+annotationCode(diagnostic.Job))
+	}
+	if diagnostic.Step != 0 {
+		context = append(context, fmt.Sprintf("Step %d", diagnostic.Step))
+	}
+	if len(context) != 0 {
+		out.WriteString("<div class=\"mt1\">")
+		out.WriteString(strings.Join(context, " · "))
+		out.WriteString("</div>")
+	}
+	if len(details) != 0 {
+		out.WriteString("<div class=\"mt1\">")
+		for i, sentence := range details {
+			if i != 0 {
+				out.WriteString("<br>\n")
+			}
+			out.WriteString(annotationHTML(sentence))
+		}
+		out.WriteString("</div>")
+	}
+	out.WriteString("</div>\n")
+	return out.String()
 }
 
 func annotationDiagnosticMessage(diagnostic compatibility.Diagnostic) string {
@@ -160,7 +190,7 @@ func annotationDiagnosticPresentation(diagnostic compatibility.Diagnostic) (head
 	if len(sentences) == 0 {
 		return "Compatibility diagnostic", nil
 	}
-	return markdownText(sentences[0]), sentences[1:]
+	return sentences[0], sentences[1:]
 }
 
 func annotationSentences(message string) []string {
@@ -179,32 +209,12 @@ func upperFirst(value string) string {
 	return string(unicode.ToUpper(first)) + value[size:]
 }
 
-func markdownCode(value string) string {
-	value = strings.Join(strings.Fields(value), " ")
-	if strings.Contains(value, "`") {
-		longest, current := 0, 0
-		for _, r := range value {
-			if r == '`' {
-				current++
-				longest = max(longest, current)
-			} else {
-				current = 0
-			}
-		}
-		delimiter := strings.Repeat("`", longest+1)
-		return delimiter + " " + value + " " + delimiter
-	}
-	return "`" + value + "`"
+func annotationCode(value string) string {
+	return "<code>" + annotationHTML(value) + "</code>"
 }
 
-func markdownText(value string) string {
-	value = strings.Join(strings.Fields(value), " ")
-	value = strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;").Replace(value)
-	replacer := strings.NewReplacer(
-		"\\", "\\\\", "`", "\\`", "*", "\\*", "_", "\\_", "[", "\\[", "]", "\\]",
-		"<", "\\<", ">", "\\>", "#", "\\#", "|", "\\|",
-	)
-	return replacer.Replace(value)
+func annotationHTML(value string) string {
+	return html.EscapeString(strings.Join(strings.Fields(value), " "))
 }
 
 // fail emits the report and the failure that ended the command.

--- a/internal/runtime/needs.go
+++ b/internal/runtime/needs.go
@@ -105,7 +105,8 @@ func publishJobSummary(ctx context.Context, agent transport.Agent, jobID, summar
 	if summary == "" {
 		return
 	}
-	if err := agent.AnnotateJob(ctx, jobID, jobSummaryAnnotationContext, "info", summary); err != nil {
+	body := jobSummaryAnnotationHeading + jobSummaryAnnotationSeparator + summary
+	if err := agent.AnnotateJob(ctx, jobID, jobSummaryAnnotationContext, "info", body); err != nil {
 		publication.SummaryAnnotationError = fmt.Errorf("publish job summary: %w", err)
 	}
 }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -35,8 +35,10 @@ const (
 	defaultTerminateGrace = 2500 * time.Millisecond
 	maxStreamLineBytes    = 1024 * 1024
 	// Match Buildkite's maximum annotation body size.
-	maxJobAnnotationBytes = 1024 * 1024
-	maxJobSummaryBytes    = maxJobAnnotationBytes
+	maxJobAnnotationBytes         = 1024 * 1024
+	jobSummaryAnnotationHeading   = "<h2 class=\"h4 mb2\">GitHub Actions job summary</h2>\n"
+	jobSummaryAnnotationSeparator = "<div class=\"border-top border-gray pt2\"></div>\n"
+	maxJobSummaryBytes            = maxJobAnnotationBytes - len(jobSummaryAnnotationHeading) - len(jobSummaryAnnotationSeparator)
 
 	jobSummaryTruncationNotice       = "\n\n---\n_Job summary truncated at the 1 MiB limit._\n"
 	workflowCommandTruncationNotice  = "\n\n---\n_Workflow command annotations truncated at the 1 MiB limit._\n"

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -37,7 +37,7 @@ const (
 	// Match Buildkite's maximum annotation body size.
 	maxJobAnnotationBytes         = 1024 * 1024
 	jobSummaryAnnotationHeading   = "<h2 class=\"h4 mb2\">GitHub Actions job summary</h2>\n"
-	jobSummaryAnnotationSeparator = "<div class=\"border-top border-gray pt2\"></div>\n"
+	jobSummaryAnnotationSeparator = "<div class=\"border-top border-gray pt2\"></div>\n\n"
 	maxJobSummaryBytes            = maxJobAnnotationBytes - len(jobSummaryAnnotationHeading) - len(jobSummaryAnnotationSeparator)
 
 	jobSummaryTruncationNotice       = "\n\n---\n_Job summary truncated at the 1 MiB limit._\n"

--- a/scripts/starter-workflows-corpus
+++ b/scripts/starter-workflows-corpus
@@ -69,7 +69,7 @@ if $profile; then
   validate_args=(--profile hosted)
 fi
 summary="$work/summary.md"
-printf '### Starter workflow compatibility — %s\n\n' "$mode" > "$summary"
+printf '<h2 class="h4 mb2">Starter workflow compatibility — %s</h2>\n<div class="border-top border-gray pt2"></div>\n' "$mode" > "$summary"
 passed=0
 blocked=0
 

--- a/scripts/starter-workflows-corpus
+++ b/scripts/starter-workflows-corpus
@@ -69,7 +69,7 @@ if $profile; then
   validate_args=(--profile hosted)
 fi
 summary="$work/summary.md"
-printf '<h2 class="h4 mb2">Starter workflow compatibility — %s</h2>\n<div class="border-top border-gray pt2"></div>\n' "$mode" > "$summary"
+printf '<h2 class="h4 mb2">Starter workflow compatibility — %s</h2>\n<div class="border-top border-gray pt2"></div>\n\n' "$mode" > "$summary"
 passed=0
 blocked=0
 


### PR DESCRIPTION
## Description

PR #144 introduced compact headings and gray borders for workflow-command annotations, but processing diagnostics, job summaries, and corpus annotations still used unstyled output.

Apply the same treatment to every annotation created by buildkite-gha. Diagnostic content is HTML-escaped, oversized annotations preserve balanced markup, and authored job-summary Markdown remains unchanged beneath the styled heading.

## Preview

![Styled workflow diagnostics annotation](https://ampcode.com/user-content/artifacts/f6948dcb3c7e61cbb1a9fe6ad4ed80166d951b5bb9d9583659cdd563486682b8-file.png)

## Deployment

Low risk. This changes annotation presentation only.

## Rollback

Revert this PR to restore the previous annotation formatting.

@buildsworth-bk approve up to L2