### PR TITLE
Include warning diagnostics in failure steps

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1709,23 +1709,21 @@ func failedGeneratedWorkflow(input workflowInput, event string, report compatibi
 	report.Finalize()
 	messages := make([]string, 0, len(report.Diagnostics))
 	for _, diagnostic := range report.Diagnostics {
-		if diagnostic.Level == "error" {
-			message := diagnostic.Message
-			if diagnostic.Code != "" {
-				message = "[" + diagnostic.Code + "] " + message
-			}
-			var attribution []string
-			if diagnostic.Job != "" {
-				attribution = append(attribution, "job="+diagnostic.Job)
-			}
-			if diagnostic.Step != 0 {
-				attribution = append(attribution, fmt.Sprintf("step=%d", diagnostic.Step))
-			}
-			if len(attribution) != 0 {
-				message += " {" + strings.Join(attribution, ", ") + "}"
-			}
-			messages = append(messages, message)
+		message := diagnostic.Message
+		if diagnostic.Code != "" {
+			message = "[" + diagnostic.Code + "] " + message
 		}
+		var attribution []string
+		if diagnostic.Job != "" {
+			attribution = append(attribution, "job="+diagnostic.Job)
+		}
+		if diagnostic.Step != 0 {
+			attribution = append(attribution, fmt.Sprintf("step=%d", diagnostic.Step))
+		}
+		if len(attribution) != 0 {
+			message += " {" + strings.Join(attribution, ", ") + "}"
+		}
+		messages = append(messages, message)
 	}
 	return buildkitepipeline.Workflow{
 		GroupLabel: label,

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -3536,6 +3536,20 @@ func TestRunUploadEmitsApplicableCompilationFailuresAsFailingSteps(t *testing.T)
 	}
 }
 
+func TestFailedGeneratedWorkflowIncludesWarnings(t *testing.T) {
+	report := compatibility.NewProcessingReport("ci.yml", "hosted")
+	report.Diagnostics = append(report.Diagnostics,
+		compatibility.Diagnostic{Level: "warning", Code: "W_CONCURRENCY", Message: "cancel-in-progress is ignored"},
+		compatibility.Diagnostic{Level: "error", Code: "E_RUNNER", Message: "runner is unsupported", Job: "test"},
+	)
+
+	workflow := failedGeneratedWorkflow(workflowInput{Name: "CI", Identity: "ci"}, "push", report)
+	want := "[E_RUNNER] runner is unsupported {job=test}\n[W_CONCURRENCY] cancel-in-progress is ignored"
+	if workflow.Failure == nil || workflow.Failure.Message != want {
+		t.Fatalf("failure = %#v, want message %q", workflow.Failure, want)
+	}
+}
+
 func TestRunUploadEmitsUnsupportedJobCancellationAsFailingStep(t *testing.T) {
 	requireImporterHost(t)
 	directory := t.TempDir()


### PR DESCRIPTION
## Summary

- include warnings alongside errors in synthetic workflow failure steps
- cover mixed warning and error diagnostics

Follow-up to https://github.com/buildkite/buildkite-gha/pull/177#discussion_r3772752766.

## Testing

- `mise run check`