### PR TITLE
Fix Origin action token guard evaluation

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -457,7 +457,7 @@ Job and step `if` conditions support literals and the syntax listed above. Order
 
 | Context | Job `if` | Step `if` |
 | --- | --- | --- |
-| `github.actor`, `github.event_name`, `github.ref`, `github.repository`, `github.server_url`, `github.sha` | ✅ Yes | ✅ Yes |
+| `github.actor`, `github.event_name`, `github.ref`, `github.repository`, `github.sha` | ✅ Yes | ✅ Yes |
 | `github.head_ref`, `github.ref_name` | ❌ No | ❌ No |
 | `runner.os`, `runner.arch` | ✅ Yes | ✅ Yes |
 | `needs.<job>.result`, `needs.<job>.outputs.<name>` | ✅ Yes | ✅ Yes |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -173,7 +173,7 @@ jobs:
 
 ### Permissions
 
-**🟡 Supported subset.** Permissions matter only when a job statically references `secrets.GITHUB_TOKEN`, or an action input default references `github.token`.
+**🟡 Supported subset.** Permissions matter only when a job statically references `secrets.GITHUB_TOKEN`, or an effective action input default can reach `github.token` for the event provider.
 
 A workflow-level permissions map can request repository access:
 
@@ -457,7 +457,7 @@ Job and step `if` conditions support literals and the syntax listed above. Order
 
 | Context | Job `if` | Step `if` |
 | --- | --- | --- |
-| `github.actor`, `github.event_name`, `github.ref`, `github.repository`, `github.sha` | ✅ Yes | ✅ Yes |
+| `github.actor`, `github.event_name`, `github.ref`, `github.repository`, `github.server_url`, `github.sha` | ✅ Yes | ✅ Yes |
 | `github.head_ref`, `github.ref_name` | ❌ No | ❌ No |
 | `runner.os`, `runner.arch` | ✅ Yes | ✅ Yes |
 | `needs.<job>.result`, `needs.<job>.outputs.<name>` | ✅ Yes | ✅ Yes |
@@ -486,7 +486,7 @@ A runtime interpolation can read a verified upstream output directly:
 run: echo "${{ needs.build.outputs.image }}"
 ```
 
-At runtime, only `github.actor`, `github.event_name`, `github.ref`, `github.repository`, and `github.sha` are retained. `github.event` is unavailable.
+At runtime, only `github.actor`, `github.event_name`, `github.ref`, `github.repository`, `github.server_url`, and `github.sha` are retained. `github.server_url` identifies the event repository provider. `github.event` is unavailable.
 
 `hashFiles()` evaluates when its step field is consumed. A step condition and normal step execution observe earlier steps such as checkout. A JavaScript action's `with` and `env` values can also be evaluated for its `pre` phase, then reevaluated for `main`. Patterns apply in argument order. `!` excludes matches, and a later positive pattern can include them again. Directory matches include descendants, hidden files match normally, overlapping patterns hash each path once, and matching is case-insensitive on Windows only. An empty match returns an empty string.
 
@@ -647,7 +647,7 @@ JavaScript and Docker actions with compatible bundled cache clients, such as `ac
 
 ### GitHub token
 
-**🟡 Supported subset.** A job requests one short-lived `GITHUB_TOKEN` for the exact event repository by statically referencing `secrets.GITHUB_TOKEN` or by using an action whose effective input default references `github.token`. Native action adapters ignore upstream input defaults, so `actions/checkout` alone does not request a token. Effective `permissions` determine the token scope. The Buildkite organization feature and the pipeline's workflow access token setting must be enabled. Both are disabled by default.
+**🟡 Supported subset.** A job requests one short-lived `GITHUB_TOKEN` for the exact event repository by statically referencing `secrets.GITHUB_TOKEN` or by using an action whose effective input default can reach `github.token` for the event provider. A `github.server_url == 'https://github.com'` guard skips the token branch for an Origin event repository. Native action adapters ignore upstream input defaults, so `actions/checkout` alone does not request a token. Effective `permissions` determine the token scope. The Buildkite organization feature and the pipeline's workflow access token setting must be enabled. Both are disabled by default.
 
 Buildkite reads the workflow policy from the pipeline repository at the build's immutable commit. The workflow must be directly under `.github/workflows/`, use a simple `.yml` or `.yaml` filename, and contain no job-level permission maps or reusable-workflow jobs. The workflow-token endpoint must interpret omitted top-level permissions as exactly `contents: read`, without consulting GitHub repository or organization defaults. Write access requires an explicit, non-empty top-level map. An explicit empty map or scopes resolving only to `none` produce no token.
 

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -105,7 +105,7 @@ func validateActionResolutions(ctx context.Context, ir IR, options Options) (Pro
 				evidence.ActionResolutionComplete = false
 				continue
 			}
-			_, err := compileActionInvocations(ctx, instance.RepositoryRoot, actionSource, []string{step.Uses}, []map[string]string{step.With})
+			_, err := compileActionInvocations(ctx, instance.RepositoryRoot, actionSource, plan.EventServerURL(ir.Event.Provider), []string{step.Uses}, []map[string]string{step.With})
 			evaluation := ActionEvaluation{Instance: instance.Key, Job: instance.LogicalJobID, Reference: step.Uses, Step: i + 1, Passed: err == nil}
 			evidence.Actions = append(evidence.Actions, evaluation)
 			if err == nil {
@@ -189,14 +189,14 @@ func unsupportedMetadataFields(reason string) string {
 // compileActionLocks builds one shared action DAG for all roots. Selectors are
 // returned in the same order as refs.
 func compileActionLocks(ctx context.Context, workspace string, actionSource ActionSource, refs []string) ([]plan.ActionSelector, []plan.ActionLock, []string, bool, error) {
-	compiled, err := compileActionInvocations(ctx, workspace, actionSource, refs, nil)
+	compiled, err := compileActionInvocations(ctx, workspace, actionSource, plan.EventServerURL("github"), refs, nil)
 	if err != nil {
 		return nil, nil, nil, true, err
 	}
 	return compiled.selectors, compiled.locks, compiled.capabilities, compiled.requiresMise, nil
 }
 
-func compileActionInvocations(ctx context.Context, workspace string, actionSource ActionSource, refs []string, suppliedInputs []map[string]string) (actionCompilation, error) {
+func compileActionInvocations(ctx context.Context, workspace string, actionSource ActionSource, serverURL string, refs []string, suppliedInputs []map[string]string) (actionCompilation, error) {
 	if workspace == "" {
 		return actionCompilation{}, fmt.Errorf("workflow path must identify a repository root")
 	}
@@ -233,7 +233,7 @@ func compileActionInvocations(ctx context.Context, workspace string, actionSourc
 	var githubTokenActions []string
 	if suppliedInputs != nil {
 		for i, root := range roots {
-			requirements, err := root.inspectInvocation(suppliedInputs[i], true)
+			requirements, err := root.inspectInvocation(suppliedInputs[i], true, serverURL)
 			if err != nil {
 				return actionCompilation{}, fmt.Errorf("compile action %q: %w", refs[i], err)
 			}
@@ -333,7 +333,7 @@ func (b *actionLockBuilder) add(ctx context.Context, raw string, depth int) (*ac
 	return n, nil
 }
 
-func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAuthored bool) (actionRequirements, error) {
+func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAuthored bool, serverURL string) (actionRequirements, error) {
 	requirements := actionRequirements{requiredSecrets: map[string]bool{}}
 	for _, suppliedName := range sortedKeys(supplied) {
 		names, err := expression.SecretReferences(supplied[suppliedName])
@@ -362,7 +362,7 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 		if err := expression.ValidateActionInputDefault(*input.Default); err != nil {
 			return actionRequirements{}, fmt.Errorf("action input %q default: %w", name, err)
 		}
-		referencesToken, err := expression.ReferencesGitHubToken(*input.Default)
+		referencesToken, err := expression.ActionInputDefaultRequiresGitHubToken(*input.Default, serverURL)
 		if err != nil {
 			return actionRequirements{}, fmt.Errorf("action input %q default: %w", name, err)
 		}
@@ -385,7 +385,7 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 				return actionRequirements{}, fmt.Errorf("composite action step %d child %q: bounded upload-artifact adapter: %w", i+1, step.Uses, err)
 			}
 		}
-		childRequirements, err := child.inspectInvocation(step.With, false)
+		childRequirements, err := child.inspectInvocation(step.With, false, serverURL)
 		if err != nil {
 			return actionRequirements{}, fmt.Errorf("composite action step %d child %q: %w", i+1, step.Uses, err)
 		}

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -1000,17 +1000,17 @@ func TestNativeCheckoutIgnoresUpstreamTokenDefaultForOrigin(t *testing.T) {
 	}
 }
 
-func TestOriginActionSkipsGitHubOnlyConditionalTokenDefault(t *testing.T) {
+func TestNonGitHubActionSkipsGitHubOnlyConditionalTokenDefault(t *testing.T) {
 	workspace, remote := t.TempDir(), t.TempDir()
-	workflowPath := filepath.Join(workspace, ".github", "workflows", "build.yml")
+	workflowPath := filepath.Join(workspace, ".github", "workflows", "conditional-token.yml")
 	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	workflow := []byte("on: push\npermissions:\n  contents: read\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: oven-sh/setup-bun@v2\n        with:\n          bun-version: 1.3.11\n")
+	workflow := []byte("on: push\npermissions:\n  contents: read\njobs:\n  action:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: owner/action@v1\n")
 	if err := os.WriteFile(workflowPath, workflow, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	writeAction(t, remote, "", `name: Setup Bun
+	writeAction(t, remote, "", `name: Conditional token
 inputs:
   token:
     default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
@@ -1032,7 +1032,7 @@ runs:
 		t.Fatal(err)
 	}
 	if len(bundle.Plans) != 1 || bundle.Plans[0].Job.GitHubToken != nil || bundle.Plans[0].Job.HasCapability("provider-token-write") {
-		t.Fatalf("Origin setup-bun plan = %#v", bundle.Plans)
+		t.Fatalf("non-GitHub conditional-token plan = %#v", bundle.Plans)
 	}
 }
 

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -183,12 +183,12 @@ func TestCompileActionInvocationsValidatesNestedUploadArtifact(t *testing.T) {
 	}
 
 	writeAction(t, workspace, "parent", "name: parent\nruns:\n  using: composite\n  steps:\n    - uses: actions/upload-artifact@v4\n      with:\n        path: payload\n        overwrite: true\n")
-	if _, err := compileActionInvocations(context.Background(), workspace, source, []string{"./parent"}, []map[string]string{{}}); err == nil || !strings.Contains(err.Error(), "bounded upload-artifact adapter") || !strings.Contains(err.Error(), "overwrite") {
+	if _, err := compileActionInvocations(context.Background(), workspace, source, "https://github.com", []string{"./parent"}, []map[string]string{{}}); err == nil || !strings.Contains(err.Error(), "bounded upload-artifact adapter") || !strings.Contains(err.Error(), "overwrite") {
 		t.Fatalf("nested literal validation error = %v", err)
 	}
 
 	writeAction(t, workspace, "parent", "name: parent\ninputs:\n  path:\n    required: true\nruns:\n  using: composite\n  steps:\n    - uses: actions/upload-artifact@v4\n      with:\n        path: ${{ inputs.path }}\n")
-	if _, err := compileActionInvocations(context.Background(), workspace, source, []string{"./parent"}, []map[string]string{{"path": "payload"}}); err != nil {
+	if _, err := compileActionInvocations(context.Background(), workspace, source, "https://github.com", []string{"./parent"}, []map[string]string{{"path": "payload"}}); err != nil {
 		t.Fatalf("nested expression was not deferred to runtime: %v", err)
 	}
 }
@@ -267,7 +267,7 @@ runs:
 		{name: "token before dynamic GitHub index", ref: "./mixed", wantErr: "index must be a string literal"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			compiled, err := compileActionInvocations(context.Background(), w, nil, []string{test.ref}, []map[string]string{test.supplied})
+			compiled, err := compileActionInvocations(context.Background(), w, nil, "https://github.com", []string{test.ref}, []map[string]string{test.supplied})
 			if test.wantErr != "" {
 				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
 					t.Fatalf("compileActionInvocations() error = %v, want %q", err, test.wantErr)
@@ -297,7 +297,7 @@ runs:
   main: index.js
 `)
 	compiled, err := compileActionInvocations(
-		context.Background(), workspace, nil, []string{"./secrets"},
+		context.Background(), workspace, nil, "https://github.com", []string{"./secrets"},
 		[]map[string]string{{"optional": "${{ secrets.OPTIONAL_TOKEN }}", "required": "${{ secrets.REQUIRED_TOKEN }}-${{ secrets.GITHUB_TOKEN }}"}},
 	)
 	if err != nil {
@@ -327,7 +327,7 @@ runs:
         token: ${{ secrets.DEPLOY_KEY }}
 `)
 
-	_, err := compileActionInvocations(context.Background(), workspace, nil, []string{"./parent"}, []map[string]string{nil})
+	_, err := compileActionInvocations(context.Background(), workspace, nil, "https://github.com", []string{"./parent"}, []map[string]string{nil})
 	if err == nil || !strings.Contains(err.Error(), "composite action metadata cannot grant secret authority") {
 		t.Fatalf("composite metadata secret error = %v", err)
 	}
@@ -343,13 +343,13 @@ runs:
   using: node24
   main: index.js
 `)
-	_, err := compileActionInvocations(context.Background(), workspace, nil, []string{"./secrets"}, []map[string]string{nil})
+	_, err := compileActionInvocations(context.Background(), workspace, nil, "https://github.com", []string{"./secrets"}, []map[string]string{nil})
 	if err == nil || !strings.Contains(err.Error(), "action input defaults cannot grant secret authority") {
 		t.Fatalf("metadata secret default error = %v", err)
 	}
 }
 
-func TestCompileActionInvocationsAcceptsResolvedRemoteConditionalDefaults(t *testing.T) {
+func TestCompileActionInvocationsEvaluatesRemoteTokenDefaultForProvider(t *testing.T) {
 	workspace, remote := t.TempDir(), t.TempDir()
 	writeAction(t, remote, "", `name: complex remote default
 inputs:
@@ -360,15 +360,22 @@ runs:
   main: index.js
 `)
 	actionSource := &fakeActionSource{root: remote, calls: map[string]int{}}
-	compiled, err := compileActionInvocations(context.Background(), workspace, actionSource, []string{"owner/action@v1"}, []map[string]string{nil})
+	compiled, err := compileActionInvocations(context.Background(), workspace, actionSource, "https://github.com", []string{"owner/action@v1"}, []map[string]string{nil})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !compiled.requiresGitHubToken {
 		t.Fatal("conditional remote action default did not require a GitHub token")
 	}
-	if actionSource.calls["owner/action@v1"] != 1 {
-		t.Fatalf("remote action resolutions = %#v, want one", actionSource.calls)
+	compiled, err = compileActionInvocations(context.Background(), workspace, actionSource, "https://origin.cursor.com", []string{"owner/action@v1"}, []map[string]string{nil})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if compiled.requiresGitHubToken {
+		t.Fatal("GitHub.com-only action default required a token for Origin")
+	}
+	if actionSource.calls["owner/action@v1"] != 2 {
+		t.Fatalf("remote action resolutions = %#v, want two", actionSource.calls)
 	}
 }
 
@@ -419,7 +426,7 @@ runs:
 		{ref: "./parent", want: true},
 		{ref: "./overridden"},
 	} {
-		compiled, err := compileActionInvocations(context.Background(), w, nil, []string{test.ref}, []map[string]string{nil})
+		compiled, err := compileActionInvocations(context.Background(), w, nil, "https://github.com", []string{test.ref}, []map[string]string{nil})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -427,7 +434,7 @@ runs:
 			t.Fatalf("%s requires GitHub token = %t, want %t", test.ref, compiled.requiresGitHubToken, test.want)
 		}
 	}
-	if _, err := compileActionInvocations(context.Background(), w, nil, []string{"./mixed-parent"}, []map[string]string{nil}); err == nil || !strings.Contains(err.Error(), "index must be a string literal") {
+	if _, err := compileActionInvocations(context.Background(), w, nil, "https://github.com", []string{"./mixed-parent"}, []map[string]string{nil}); err == nil || !strings.Contains(err.Error(), "index must be a string literal") {
 		t.Fatalf("mixed child traversal error = %v, want dynamic index rejection", err)
 	}
 }
@@ -990,6 +997,42 @@ func TestNativeCheckoutIgnoresUpstreamTokenDefaultForOrigin(t *testing.T) {
 	if len(bundle.Plans) != 1 || bundle.Plans[0].Job.Event.Provider != "cursor-origin" || bundle.Plans[0].Job.GitHubToken != nil ||
 		!reflect.DeepEqual(bundle.Plans[0].Job.RequiredCapabilities, []string{"network", "provider-token-read"}) {
 		t.Fatalf("Origin checkout plan = %#v", bundle.Plans)
+	}
+}
+
+func TestOriginActionSkipsGitHubOnlyConditionalTokenDefault(t *testing.T) {
+	workspace, remote := t.TempDir(), t.TempDir()
+	workflowPath := filepath.Join(workspace, ".github", "workflows", "build.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	workflow := []byte("on: push\npermissions:\n  contents: read\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: oven-sh/setup-bun@v2\n        with:\n          bun-version: 1.3.11\n")
+	if err := os.WriteFile(workflowPath, workflow, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeAction(t, remote, "", `name: Setup Bun
+inputs:
+  token:
+    default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
+runs:
+  using: node24
+  main: index.js
+`)
+	event := bytes.Replace(pushEvent(t), []byte(`"provider": "github"`), []byte(`"provider": "cursor-origin"`), 1)
+	bundle, err := CompileBundleWithOptions(workflowPath, workflow, event, "0.0.0-test", testDistributionDigest, "importer", Options{
+		EventTrust: EventUntrusted,
+		Runners: RunnerPolicy{
+			Labels:          map[string]string{"ubuntu-latest": "hosted"},
+			UntrustedQueues: []string{"hosted"},
+		},
+		ResolveActions: true,
+		ActionSource:   &fakeActionSource{root: remote, calls: map[string]int{}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bundle.Plans) != 1 || bundle.Plans[0].Job.GitHubToken != nil || bundle.Plans[0].Job.HasCapability("provider-token-write") {
+		t.Fatalf("Origin setup-bun plan = %#v", bundle.Plans)
 	}
 }
 

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -383,7 +383,7 @@ instances:
 			}
 			actionRequiresGitHubToken := false
 			if lockActions && len(actionRefs) != 0 {
-				compiledActions, err := compileActionInvocations(ctx, instance.RepositoryRoot, actionSource, actionRefs, actionInputs)
+				compiledActions, err := compileActionInvocations(ctx, instance.RepositoryRoot, actionSource, plan.EventServerURL(ir.Event.Provider), actionRefs, actionInputs)
 				if err != nil {
 					return fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err)
 				}

--- a/internal/expression/action_input_default.go
+++ b/internal/expression/action_input_default.go
@@ -82,6 +82,58 @@ func EvaluateActionInputDefault(template string, context Context) (string, error
 	return evaluateRuntimeTemplate(template, context, evaluateActionInputDefaultNode)
 }
 
+// ActionInputDefaultRequiresGitHubToken reports whether a metadata default can
+// reach github.token for the event provider. Defaults involving any other
+// runtime value fail closed because those values are not known during
+// compilation.
+func ActionInputDefaultRequiresGitHubToken(template, serverURL string) (bool, error) {
+	referencesToken, err := ReferencesGitHubToken(template)
+	if err != nil || !referencesToken {
+		return referencesToken, err
+	}
+	onlyKnownReferences := true
+	err = visitTemplateExpressions(template, func(expression actionlint.ExprNode) error {
+		actionlint.VisitExprNode(expression, func(node, parent actionlint.ExprNode, entering bool) {
+			if !entering || !onlyKnownReferences {
+				return
+			}
+			switch node.(type) {
+			case *actionlint.VariableNode, *actionlint.ObjectDerefNode, *actionlint.IndexAccessNode:
+			default:
+				return
+			}
+			root, path, referenceErr := referencePath(node)
+			if referenceErr != nil {
+				onlyKnownReferences = false
+				return
+			}
+			if len(path) == 0 {
+				switch parent := parent.(type) {
+				case *actionlint.ObjectDerefNode:
+					if parent.Receiver == node {
+						return
+					}
+				case *actionlint.IndexAccessNode:
+					if parent.Operand == node {
+						return
+					}
+				}
+			}
+			onlyKnownReferences = strings.EqualFold(root, "github") && len(path) == 1 &&
+				(strings.EqualFold(path[0], "server_url") || strings.EqualFold(path[0], "token"))
+		})
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+	if !onlyKnownReferences {
+		return true, nil
+	}
+	_, err = EvaluateActionInputDefault(template, Context{GitHub: map[string]any{"server_url": serverURL}})
+	return err != nil, nil
+}
+
 func evaluateActionInputDefaultNode(node actionlint.ExprNode, context Context) (any, error) {
 	switch node := node.(type) {
 	case *actionlint.NullNode:

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -202,6 +202,34 @@ func TestEvaluateActionInputDefaultSupportsConditionalValueExpressions(t *testin
 	}
 }
 
+func TestActionInputDefaultRequiresGitHubTokenUsesProviderServerURL(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		template  string
+		serverURL string
+		want      bool
+	}{
+		{name: "direct GitHub.com token", template: "${{ github.token }}", serverURL: "https://github.com", want: true},
+		{name: "direct Origin token", template: "${{ github.token }}", serverURL: "https://origin.cursor.com", want: true},
+		{name: "GitHub.com guarded token", template: "${{ github.server_url == 'https://github.com' && github.token || '' }}", serverURL: "https://github.com", want: true},
+		{name: "Origin skips GitHub.com token", template: "${{ github.server_url == 'https://github.com' && github.token || '' }}", serverURL: "https://origin.cursor.com"},
+		{name: "Origin reaches reverse guard", template: "${{ github.server_url != 'https://github.com' && github.token || '' }}", serverURL: "https://origin.cursor.com", want: true},
+		{name: "literal false skips token", template: "${{ false && github.token || '' }}", serverURL: "https://origin.cursor.com"},
+		{name: "unknown guard fails closed", template: "${{ inputs.use_token && github.token || '' }}", serverURL: "https://origin.cursor.com", want: true},
+		{name: "no token reference", template: "${{ github.server_url }}", serverURL: "https://origin.cursor.com"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := ActionInputDefaultRequiresGitHubToken(test.template, test.serverURL)
+			if err != nil || got != test.want {
+				t.Fatalf("ActionInputDefaultRequiresGitHubToken() = %v, %v, want %v", got, err, test.want)
+			}
+		})
+	}
+	if _, err := ActionInputDefaultRequiresGitHubToken("${{ github[env.NAME] }}", "https://origin.cursor.com"); err == nil || !strings.Contains(err.Error(), "index must be a string literal") {
+		t.Fatalf("ActionInputDefaultRequiresGitHubToken() error = %v, want dynamic index rejection", err)
+	}
+}
+
 func TestEvaluateActionInputDefaultSupportsJobStatus(t *testing.T) {
 	references, err := ReferencesJobStatus("${{ job.status }}")
 	if err != nil || !references {

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -104,6 +104,19 @@ type Event struct {
 	Actor         string `json:"actor,omitempty"`
 }
 
+// EventServerURL returns the repository provider URL exposed through the
+// GitHub-compatible expression context and environment.
+func EventServerURL(provider string) string {
+	switch provider {
+	case "github":
+		return "https://github.com"
+	case "cursor-origin":
+		return "https://origin.cursor.com"
+	default:
+		return ""
+	}
+}
+
 type Workflow struct {
 	Path         string `json:"path"`
 	Digest       string `json:"digest"`

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -944,7 +944,7 @@ func githubContext(job plan.Job) map[string]any {
 		"sha":        job.Event.SHA,
 		"actor":      job.Event.Actor,
 		"event_name": job.Event.Name,
-		"server_url": "https://github.com",
+		"server_url": plan.EventServerURL(job.Event.Provider),
 	}
 }
 
@@ -958,7 +958,7 @@ func standardEnvironment(job plan.Job, workspace, runnerTemp, toolCache string) 
 		"GITHUB_JOB":        job.Workflow.LogicalJobID,
 		"GITHUB_REF":        job.Event.Ref,
 		"GITHUB_REPOSITORY": job.Event.Repository,
-		"GITHUB_SERVER_URL": "https://github.com",
+		"GITHUB_SERVER_URL": plan.EventServerURL(job.Event.Provider),
 		"GITHUB_SHA":        job.Event.SHA,
 		"GITHUB_WORKSPACE":  workspace,
 		"RUNNER_OS":         runner["os"],

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -2265,6 +2265,21 @@ func TestResolveActionInputsExposesScopedTokenOnlyToMetadataDefaults(t *testing.
 	}
 }
 
+func TestOriginUsesProviderServerURLWithoutGitHubToken(t *testing.T) {
+	job := plan.Job{Event: plan.Event{Provider: "cursor-origin"}}
+	github := githubContext(job)
+	env := standardEnvironment(job, "/workspace", "/tmp", "/tool-cache")
+	if github["server_url"] != "https://origin.cursor.com" || env["GITHUB_SERVER_URL"] != "https://origin.cursor.com" {
+		t.Fatalf("Origin server URLs = context %#v, environment %q", github["server_url"], env["GITHUB_SERVER_URL"])
+	}
+	conditionalTokenDefault := "${{ github.server_url == 'https://github.com' && github.token || '' }}"
+	action := metadata.Metadata{Inputs: map[string]metadata.Input{"token": {Default: &conditionalTokenDefault}}}
+	inputs, err := resolveActionInputs(action, nil, expression.Context{GitHub: github})
+	if err != nil || inputs["token"] != "" {
+		t.Fatalf("Origin conditional token input = %#v, %v, want empty token", inputs, err)
+	}
+}
+
 func TestRunJobSuppliesScopedGitHubTokenToEffectiveActionDefault(t *testing.T) {
 	node := requireNode24(t)
 	workspace := t.TempDir()


### PR DESCRIPTION
## Summary

- expose the event repository provider through `github.server_url` and `GITHUB_SERVER_URL`
- evaluate provider-only action input guards before requesting `GITHUB_TOKEN`
- avoid adding a GitHub workflow token when a non-GitHub provider cannot reach the token branch
- keep direct and dynamically guarded token references fail-closed

## Context

Public actions can define provider-sensitive optional token defaults:

```yaml
inputs:
  token:
    default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
```

The compiler previously treated any syntactic `github.token` reference as unconditional. For a non-GitHub event repository, that added a GitHub workflow token to the job plan and then failed validation with `GitHub workflow token requires a valid github.com event repository`.

This change evaluates guards containing only `github.server_url` and `github.token`. If another runtime value affects reachability, compilation continues to require the token and fails closed.

## Verification

- `mise run check`
- generic regression coverage for a public action with a GitHub-only conditional token default