### PR TITLE
Run workflow diagnostic steps unconditionally

### DIFF
--- a/internal/buildkite/pipeline.go
+++ b/internal/buildkite/pipeline.go
@@ -158,7 +158,7 @@ func Emit(pipeline Pipeline) ([]byte, error) {
 			if workflow.CheckName == "" {
 				return nil, fmt.Errorf("workflow %q requires a GitHub Check name", workflow.GroupKey)
 			}
-			if workflow.Condition == "" && workflow.SkipReason == "" {
+			if workflow.Failure == nil && workflow.Condition == "" && workflow.SkipReason == "" {
 				return nil, fmt.Errorf("workflow %q requires a trigger condition or skip reason", workflow.GroupKey)
 			}
 			if workflow.Failure == nil && workflow.Condition != "" && workflow.SkipReason != "" {

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -272,8 +272,6 @@ func TestEmitAggregateWorkflowFailures(t *testing.T) {
 			GroupLabel: "CI",
 			GroupKey:   "gha-workflow-1111111111111111",
 			CheckName:  "Buildkite / CI (push)",
-			Condition:  "true",
-			SkipReason: "This workflow is not triggered by a `push` event",
 			Failure: &Failure{
 				AnnotationPath: ".buildkite-gha/failures/annotations/annotation.html",
 				MessagePath:    ".buildkite-gha/failures/messages/message.txt",
@@ -334,7 +332,7 @@ func TestEmitAggregateWorkflowFailures(t *testing.T) {
 	if !ok {
 		t.Fatalf("failure step plugins = %#v", step.Plugins)
 	}
-	if step.Group != "" || len(step.Steps) != 0 || step.Label != ":github: CI" || step.Key != "gha-workflow-1111111111111111" || step.Condition != "true" || step.Skip != "" || plugin.Step != "importer" || len(plugin.Download) != 2 || plugin.Download[0].From != ".buildkite-gha/failures/messages/message.txt" || plugin.Download[0].To != ".buildkite-gha-failure-message.txt" || plugin.Download[1].From != ".buildkite-gha/failures/annotations/annotation.html" || plugin.Download[1].To != ".buildkite-gha-failure-annotation.html" || step.DependsOn != "importer" || step.Retry.Manual == nil || step.Retry.Manual.Allowed || len(step.Notify) != 1 || step.Notify[0].GitHubCheck.Name != "Buildkite / CI (push)" || step.Notify[0].GitHubCheck.Output.Title != "Workflow could not be run" || step.Notify[0].GitHubCheck.Output.Summary != "The workflow could not be prepared:\n\n- `ci.yml`, job `test`: runner isn't admitted\n- `ci.yml`: matrix could not be expanded" || step.Command != `cat .buildkite-gha-failure-message.txt
+	if step.Group != "" || len(step.Steps) != 0 || step.Label != ":github: CI" || step.Key != "gha-workflow-1111111111111111" || step.Condition != "" || step.Skip != "" || plugin.Step != "importer" || len(plugin.Download) != 2 || plugin.Download[0].From != ".buildkite-gha/failures/messages/message.txt" || plugin.Download[0].To != ".buildkite-gha-failure-message.txt" || plugin.Download[1].From != ".buildkite-gha/failures/annotations/annotation.html" || plugin.Download[1].To != ".buildkite-gha-failure-annotation.html" || step.DependsOn != "importer" || step.Retry.Manual == nil || step.Retry.Manual.Allowed || len(step.Notify) != 1 || step.Notify[0].GitHubCheck.Name != "Buildkite / CI (push)" || step.Notify[0].GitHubCheck.Output.Title != "Workflow could not be run" || step.Notify[0].GitHubCheck.Output.Summary != "The workflow could not be prepared:\n\n- `ci.yml`, job `test`: runner isn't admitted\n- `ci.yml`: matrix could not be expanded" || step.Command != `cat .buildkite-gha-failure-message.txt
 buildkite-agent annotate --scope=job --style=error < .buildkite-gha-failure-annotation.html
 exit 1` || !step.Checkout.Skip {
 		t.Fatalf("failure step = %#v", step)

--- a/internal/buildkite/triggers_test.go
+++ b/internal/buildkite/triggers_test.go
@@ -123,6 +123,30 @@ func TestTranslateEventTriggerConditionUsesSnapshotExpressions(t *testing.T) {
 	}
 }
 
+func TestTranslateEventTriggerConditionDistinguishesPullRequestBaseFromPushBranch(t *testing.T) {
+	triggers := []workflow.Trigger{
+		{Event: "push", Branches: []string{"main"}},
+		{Event: "pull_request", Branches: []string{"main"}},
+	}
+	context := TriggerConditionContext{
+		EventPredicate:        `build.source == "webhook"`,
+		Branch:                `"chore_updates"`,
+		Tag:                   "null",
+		PullRequestBaseBranch: `"main"`,
+		PullRequestAction:     `"opened"`,
+	}
+
+	push, applicable, err := TranslateEventTriggerCondition(triggers, "push", context)
+	if err != nil || !applicable || !strings.Contains(push, `"chore_updates" =~ /^main$/`) {
+		t.Fatalf("snapshot push condition = %q, %t, %v, want build branch", push, applicable, err)
+	}
+
+	pullRequest, applicable, err := TranslateEventTriggerCondition(triggers, "pull_request", context)
+	if err != nil || !applicable || !strings.Contains(pullRequest, `"main" =~ /^main$/`) || strings.Contains(pullRequest, "chore_updates") {
+		t.Fatalf("snapshot pull request condition = %q, %t, %v, want base branch", pullRequest, applicable, err)
+	}
+}
+
 func TestTranslateEventTriggerConditionRejectsIncompletePullRequestSnapshot(t *testing.T) {
 	context := TriggerConditionContext{
 		EventPredicate:        "true",

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1816,7 +1816,6 @@ func failedGeneratedWorkflow(input workflowInput, event string, report compatibi
 		GroupLabel: label,
 		GroupKey:   "gha-workflow-" + input.Identity,
 		CheckName:  "Buildkite / " + label + " (" + event + ")",
-		Condition:  input.TriggerCondition,
 		Failure: &buildkitepipeline.Failure{
 			AnnotationPath: annotationArtifact.Path,
 			MessagePath:    messageArtifact.Path,

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -3813,14 +3813,14 @@ func TestRunUploadEmitsApplicableCompilationFailuresAsFailingSteps(t *testing.T)
 	requireImporterHost(t)
 	directory := t.TempDir()
 	workflowPath := filepath.Join(directory, "invalid-push.yml")
-	workflow := "name: Invalid push\non: push\njobs:\n  alpha:\n    runs-on: ${{ github.event.runner }}\n    steps: [{run: true}]\n  beta:\n    runs-on: ${{ github.event.runners.event_secret_key }}\n    steps: [{run: true}]\n  gamma:\n    runs-on: ${{ fromJSON(github.event.runner_json) }}\n    steps: [{run: true}]\n"
+	workflow := "name: Invalid push\non:\n  push:\n    branches: [main]\njobs:\n  alpha:\n    runs-on: ${{ github.event.runner }}\n    steps: [{run: true}]\n  beta:\n    runs-on: ${{ github.event.runners.event_secret_key }}\n    steps: [{run: true}]\n  gamma:\n    runs-on: ${{ fromJSON(github.event.runner_json) }}\n    steps: [{run: true}]\n"
 	if err := os.WriteFile(workflowPath, []byte(workflow), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	const valueSentinel = "EVENT-DERIVED-RUNNER-SENTINEL"
 	const keySentinel = "EVENT_SECRET_KEY"
 	const jsonSentinel = "@"
-	eventPath := writeUploadEvent(t, directory, "push", "refs/heads/main", map[string]any{
+	eventPath := writeUploadEvent(t, directory, "push", "refs/heads/chore_updates", map[string]any{
 		"runner":      valueSentinel,
 		"runner_json": jsonSentinel,
 		"runners": map[string]any{
@@ -3840,11 +3840,12 @@ func TestRunUploadEmitsApplicableCompilationFailuresAsFailingSteps(t *testing.T)
 	}
 	var pipeline struct {
 		Steps []struct {
-			Group   string             `yaml:"group"`
-			Label   string             `yaml:"label"`
-			Command string             `yaml:"command"`
-			Plugins failureStepPlugins `yaml:"plugins"`
-			Notify  []struct {
+			Group     string             `yaml:"group"`
+			Label     string             `yaml:"label"`
+			Condition string             `yaml:"if"`
+			Command   string             `yaml:"command"`
+			Plugins   failureStepPlugins `yaml:"plugins"`
+			Notify    []struct {
 				GitHubCheck struct {
 					Output struct {
 						Title   string `yaml:"title"`
@@ -3872,7 +3873,7 @@ func TestRunUploadEmitsApplicableCompilationFailuresAsFailingSteps(t *testing.T)
 		"- `" + filepath.ToSlash(workflowPath) + "`, job `gamma`: runs-on expression cannot be resolved at compile time: fromJSON argument is invalid JSON"
 	message := failureArtifactForStep(step.Plugins, runner.uploaded, "messages")
 	annotation := failureArtifactForStep(step.Plugins, runner.uploaded, "annotations")
-	if step.Label != ":github: Invalid push" || !isGeneratedFailureCommand(step.Command) || strings.Contains(step.Command, "Runner label is not mapped") || !strings.Contains(string(message), "Runner label is not mapped") || !strings.Contains(string(annotation), `<h2 class="h4 mb2">GitHub Actions workflow diagnostics</h2>`) || !strings.Contains(string(annotation), "Job <code>alpha</code>") || !strings.Contains(string(annotation), "Job <code>beta</code>") || !strings.Contains(string(annotation), "Job <code>gamma</code>") || len(step.Notify) != 1 || step.Notify[0].GitHubCheck.Output.Title != "Workflow could not be run" || step.Notify[0].GitHubCheck.Output.Summary != wantSummary || !step.Checkout.Skip {
+	if step.Label != ":github: Invalid push" || step.Condition != "" || !isGeneratedFailureCommand(step.Command) || strings.Contains(step.Command, "Runner label is not mapped") || !strings.Contains(string(message), "Runner label is not mapped") || !strings.Contains(string(annotation), `<h2 class="h4 mb2">GitHub Actions workflow diagnostics</h2>`) || !strings.Contains(string(annotation), "Job <code>alpha</code>") || !strings.Contains(string(annotation), "Job <code>beta</code>") || !strings.Contains(string(annotation), "Job <code>gamma</code>") || len(step.Notify) != 1 || step.Notify[0].GitHubCheck.Output.Title != "Workflow could not be run" || step.Notify[0].GitHubCheck.Output.Summary != wantSummary || !step.Checkout.Skip {
 		t.Fatalf("compiler failure step = %#v", step)
 	}
 	if strings.Contains(step.Notify[0].GitHubCheck.Output.Summary, "E_EXPRESSION_INVALID") {
@@ -3925,9 +3926,9 @@ func TestFailedGeneratedWorkflowIncludesWarnings(t *testing.T) {
 		compatibility.Diagnostic{Level: "error", Code: "E_RUNNER", Message: "runner is unsupported", Job: "test"},
 	)
 
-	workflow, artifacts := failedGeneratedWorkflow(workflowInput{Name: "CI", CanonicalPath: ".github/workflows/ci.yml", Identity: "ci"}, "push", report)
+	workflow, artifacts := failedGeneratedWorkflow(workflowInput{Name: "CI", CanonicalPath: ".github/workflows/ci.yml", Identity: "ci", TriggerCondition: "false"}, "push", report)
 	wantSummary := "The workflow could not be prepared:\n\n- `.github/workflows/ci.yml`, job `test`: runner is unsupported"
-	if workflow.Failure == nil || len(artifacts) != 2 || workflow.Failure.MessagePath != artifacts[0].Path || workflow.Failure.AnnotationPath != artifacts[1].Path || !bytes.HasPrefix(artifacts[0].Contents, []byte("\x1b[31m")) || !bytes.HasSuffix(artifacts[0].Contents, []byte("\x1b[0m\n")) || !strings.Contains(string(artifacts[1].Contents), `<h2 class="h4 mb2">GitHub Actions workflow diagnostics</h2>`) || !strings.Contains(string(artifacts[1].Contents), "<strong>runner is unsupported</strong>") || !strings.Contains(string(artifacts[1].Contents), "<strong>cancel-in-progress is ignored</strong>") || workflow.Failure.Summary != wantSummary {
+	if workflow.Condition != "" || workflow.Failure == nil || len(artifacts) != 2 || workflow.Failure.MessagePath != artifacts[0].Path || workflow.Failure.AnnotationPath != artifacts[1].Path || !bytes.HasPrefix(artifacts[0].Contents, []byte("\x1b[31m")) || !bytes.HasSuffix(artifacts[0].Contents, []byte("\x1b[0m\n")) || !strings.Contains(string(artifacts[1].Contents), `<h2 class="h4 mb2">GitHub Actions workflow diagnostics</h2>`) || !strings.Contains(string(artifacts[1].Contents), "<strong>runner is unsupported</strong>") || !strings.Contains(string(artifacts[1].Contents), "<strong>cancel-in-progress is ignored</strong>") || workflow.Failure.Summary != wantSummary {
 		t.Fatalf("failure = %#v", workflow.Failure)
 	}
 }
@@ -4258,7 +4259,7 @@ func TestRunUploadEmitsTriggerFailuresAsFailingSteps(t *testing.T) {
 	}
 	failure := pipeline.Steps[0]
 	message := failureArtifactForStep(failure.Plugins, runner.uploaded, "messages")
-	if failure.Group != "" || failure.Label != ":github: Crowdin upload" || failure.Condition != "true" || !isGeneratedFailureCommand(failure.Command) || !strings.Contains(string(message), "push path filters are unsupported") || !failure.Checkout.Skip || len(failure.Steps) != 0 {
+	if failure.Group != "" || failure.Label != ":github: Crowdin upload" || failure.Condition != "" || !isGeneratedFailureCommand(failure.Command) || !strings.Contains(string(message), "push path filters are unsupported") || !failure.Checkout.Skip || len(failure.Steps) != 0 {
 		t.Fatalf("trigger failure step = %#v", failure)
 	}
 	if success := pipeline.Steps[1]; success.Group != ":github: Success" || len(success.Steps) != 1 {
@@ -4362,7 +4363,7 @@ func TestRunEmitsUnclassifiablePushSnapshotAsFailingStep(t *testing.T) {
 		t.Fatal(err)
 	}
 	message := failureArtifactForStep(pipeline.Steps[0].Plugins, runner.uploaded, "messages")
-	if len(pipeline.Steps) != 1 || pipeline.Steps[0].Group != "" || pipeline.Steps[0].Condition != "true" || !isGeneratedFailureCommand(pipeline.Steps[0].Command) || !strings.Contains(string(message), "refs/heads/") || strings.Contains(string(message), "null == null") {
+	if len(pipeline.Steps) != 1 || pipeline.Steps[0].Group != "" || pipeline.Steps[0].Condition != "" || !isGeneratedFailureCommand(pipeline.Steps[0].Command) || !strings.Contains(string(message), "refs/heads/") || strings.Contains(string(message), "null == null") {
 		t.Fatalf("unclassifiable push failure step = %#v\n%s", pipeline.Steps, pipelineCommand.stdin)
 	}
 }


### PR DESCRIPTION
## Summary

- keep generated diagnostic replacement steps unconditional
- retain translated trigger conditions on actual workflow groups
- cover pull request base-branch selection separately from push branch filtering

## Root cause

`failedGeneratedWorkflow` copied the workflow's translated trigger condition onto the top-level replacement step that downloads and publishes diagnostic artifacts. When the trigger condition was false—for example, a `chore_updates` push against `push.branches: [main]`—Buildkite skipped the diagnostic command, so the annotation explaining the filtered workflow never appeared.

Failure replacement steps now omit the trigger condition, and aggregate pipeline validation permits those steps without a condition or skip reason. Normal generated workflow groups continue to use their translated trigger conditions.

## Tests

- `mise exec -- go test ./internal/buildkite ./internal/cli -count=1`
