### PR TITLE
Make compatibility diagnostics actionable

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -37,7 +37,7 @@ buildkite-gha validate \
 
 The deprecated `hosted-tokenless` profile name remains an alias for `hosted`.
 
-Use `--format json` for a `buildkite-gha/processing-report/v1` report.
+Use `--format json` for a `buildkite-gha/processing-report/v2` report.
 
 Reports cover workflow parsing, event validation, graph construction, matrix expansion, expressions, action discovery and resolution, plan construction, profile admission, and pipeline generation. A blocked downstream stage is `not-evaluated`, not `failed`.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -68,6 +68,10 @@ All directly runnable workflows are represented in one artifact and pipeline tra
 
 Reusable-only `workflow_call` files remain available to local callers but do not create groups. Selecting only reusable workflows is an error. Every directly runnable workflow is selected against the effective event. A workflow with safe compilation or trigger-translation errors is replaced by one failing top-level command step labeled `:github: <workflow-name-or-path>`. The replacement step publishes all redacted diagnostics as a job-scoped Buildkite annotation and exits with status 1. The provider check title is `Workflow could not be run`, and its summary lists redacted errors with workflow, job, and step context. Summaries are truncated at 65,535 bytes. A compiler failure takes precedence if the workflow also has a skip reason. Other workflows continue compiling and successful workflows retain their normal groups and jobs. Parse, event-input, admission, artifact, and upload failures still abort the whole transaction; no partial pipeline is uploaded.
 
+### Compatibility diagnostics
+
+Each diagnostic separates user guidance from implementation information. `message` names the user-visible cause and a corrective action. Optional `detail` contains lower-level context such as resolved commits, adapter or service boundaries, and supported-version or runner-policy allowlists. Text reports, JSON reports, Buildkite annotations, and generated workflow failure artifacts preserve this separation. GitHub check summaries show the concise message only.
+
 ## Workflow syntax
 
 ### Names and triggers

--- a/internal/action/integration/integration.go
+++ b/internal/action/integration/integration.go
@@ -3,6 +3,7 @@
 package integration
 
 import (
+	"errors"
 	"fmt"
 	"path"
 	"path/filepath"
@@ -142,12 +143,53 @@ var cacheCommits = map[string]string{
 	CacheCommit:     "v6.1.0",
 }
 
+type unsupportedVersionError struct {
+	action    string
+	commit    string
+	boundary  string
+	supported []string
+}
+
+func (e *unsupportedVersionError) Error() string {
+	return fmt.Sprintf("%s %s does not admit resolved commit %q; supported commits are %s", e.action, e.boundary, e.commit, strings.Join(e.supported, ", "))
+}
+
+// UnsupportedVersionDiagnostic separates corrective version guidance from
+// immutable admission details for a rejected action integration.
+func UnsupportedVersionDiagnostic(reference string, err error) (message, detail string, ok bool) {
+	var versionErr *unsupportedVersionError
+	if !errors.As(err, &versionErr) {
+		return "", "", false
+	}
+	requested := ""
+	if _, ref, found := strings.Cut(reference, "@"); found {
+		requested = strings.TrimSpace(ref)
+	}
+	anchor := map[string]string{
+		"actions/checkout":          "checkout-action",
+		"actions/upload-artifact":   "upload-artifact-action",
+		"actions/download-artifact": "download-artifact-action",
+		"actions/cache":             "cache-action",
+	}[versionErr.action]
+	docs := "https://github.com/buildkite/buildkite-gha/blob/main/docs/compatibility.md#" + anchor
+	if requested == "" {
+		message = fmt.Sprintf("This %s version is unsupported. Use a supported version from %s.", versionErr.action, docs)
+	} else {
+		message = fmt.Sprintf("%s %s is unsupported. Use a supported version from %s.", versionErr.action, requested, docs)
+	}
+	return message, versionErr.Error(), true
+}
+
+func versionError(action, boundary, commit string, supported []string) error {
+	return &unsupportedVersionError{action: action, boundary: boundary, commit: commit, supported: supported}
+}
+
 // ValidateCheckoutCommit rejects semantic drift from the audited upstream
 // manifests and implementations. Mutable references are resolved before this
 // check, so a moved major tag must be deliberately audited and added here.
 func ValidateCheckoutCommit(commit string) error {
 	if _, ok := checkoutCommits[commit]; !ok {
-		return fmt.Errorf("actions/checkout native adapter does not admit resolved commit %q; supported commits are %s", commit, strings.Join(sortedCheckoutCommits(), ", "))
+		return versionError("actions/checkout", "native adapter", commit, sortedCheckoutCommits())
 	}
 	return nil
 }
@@ -169,7 +211,7 @@ func ValidateUploadArtifactCommit(commit string) error {
 			commits = append(commits, version+" ("+supported+")")
 		}
 		sort.Strings(commits)
-		return fmt.Errorf("actions/upload-artifact native adapter does not admit resolved commit %q; supported commits are %s", commit, strings.Join(commits, ", "))
+		return versionError("actions/upload-artifact", "native adapter", commit, commits)
 	}
 	return nil
 }
@@ -180,7 +222,7 @@ func ValidateDownloadArtifactCommit(commit string) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("actions/download-artifact native adapter does not support resolved commit %q; supported commits are %s", commit, strings.Join(DownloadArtifactCommits(), ", "))
+	return versionError("actions/download-artifact", "native adapter", commit, DownloadArtifactCommits())
 }
 
 // DownloadArtifactCommits returns the complete immutable admission set.
@@ -204,7 +246,7 @@ func ValidateCacheCommit(commit string) error {
 			commits = append(commits, version+" ("+supported+")")
 		}
 		sort.Strings(commits)
-		return fmt.Errorf("buildkite cache-v2 service does not admit resolved actions/cache commit %q; supported commits are %s", commit, strings.Join(commits, ", "))
+		return versionError("actions/cache", "Buildkite cache-v2 service", commit, commits)
 	}
 	return nil
 }

--- a/internal/action/integration/integration_test.go
+++ b/internal/action/integration/integration_test.go
@@ -184,6 +184,38 @@ func TestCacheCommitsAreExact(t *testing.T) {
 	}
 }
 
+func TestUnsupportedActionVersionsSeparateGuidanceFromAdmissionDetail(t *testing.T) {
+	commit := strings.Repeat("0", 40)
+	tests := []struct {
+		name      string
+		reference string
+		validate  func(string) error
+		wantDocs  string
+		wantBound string
+	}{
+		{name: "checkout", reference: "actions/checkout@v3", validate: ValidateCheckoutCommit, wantDocs: "#checkout-action", wantBound: "native adapter"},
+		{name: "upload artifact", reference: "actions/upload-artifact@v6.0.2", validate: ValidateUploadArtifactCommit, wantDocs: "#upload-artifact-action", wantBound: "native adapter"},
+		{name: "download artifact", reference: "actions/download-artifact@v9", validate: ValidateDownloadArtifactCommit, wantDocs: "#download-artifact-action", wantBound: "native adapter"},
+		{name: "cache", reference: "actions/cache@v6.0.0", validate: ValidateCacheCommit, wantDocs: "#cache-action", wantBound: "cache-v2 service"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.validate(commit)
+			message, detail, ok := UnsupportedVersionDiagnostic(test.reference, err)
+			requested := test.reference[strings.LastIndex(test.reference, "@")+1:]
+			if !ok || !strings.Contains(message, requested+" is unsupported") || !strings.Contains(message, test.wantDocs) {
+				t.Fatalf("UnsupportedVersionDiagnostic() message = %q, ok = %t", message, ok)
+			}
+			if strings.Contains(message, commit) || strings.Contains(message, "supported commits") || strings.Contains(message, test.wantBound) {
+				t.Fatalf("message contains lower-level detail: %q", message)
+			}
+			if !strings.Contains(detail, commit) || !strings.Contains(detail, "supported commits") || !strings.Contains(detail, test.wantBound) {
+				t.Fatalf("detail = %q", detail)
+			}
+		})
+	}
+}
+
 func TestValidateUploadArtifactInputs(t *testing.T) {
 	for _, test := range []struct {
 		commit string

--- a/internal/action/metadata/metadata.go
+++ b/internal/action/metadata/metadata.go
@@ -293,6 +293,16 @@ func mappingKeyNode(node *yaml.Node, name string) *yaml.Node {
 	return nil
 }
 
+// UnsupportedRuntimeError identifies a runs.using value that cannot execute in
+// the compatibility runtime.
+type UnsupportedRuntimeError struct {
+	Runtime string
+}
+
+func (e *UnsupportedRuntimeError) Error() string {
+	return fmt.Sprintf("unsupported runtime %q", e.Runtime)
+}
+
 // Runtime classifies the action execution model and rejects unsupported values
 // so compilation and execution share one support boundary.
 func (metadata Metadata) Runtime() (Runtime, error) {
@@ -308,7 +318,7 @@ func (metadata Metadata) Runtime() (Runtime, error) {
 	case string(RuntimeDocker):
 		return RuntimeDocker, nil
 	default:
-		return "", fmt.Errorf("unsupported runtime %q", metadata.Runs.Using)
+		return "", &UnsupportedRuntimeError{Runtime: metadata.Runs.Using}
 	}
 }
 

--- a/internal/buildkite/triggers.go
+++ b/internal/buildkite/triggers.go
@@ -21,6 +21,16 @@ type TriggerConditionContext struct {
 	PullRequestAction     string
 }
 
+// UnsupportedPathFiltersError reports a trigger that cannot be translated
+// without changing its path-filter semantics.
+type UnsupportedPathFiltersError struct {
+	Event string
+}
+
+func (e *UnsupportedPathFiltersError) Error() string {
+	return fmt.Sprintf("%s path filters are unsupported: Buildkite if_changed is not equivalent", e.Event)
+}
+
 // LiveTriggerConditionContext uses fields from the Buildkite build that
 // supplied the effective event snapshot.
 func LiveTriggerConditionContext(eventPredicate string) TriggerConditionContext {
@@ -113,7 +123,7 @@ func liveTriggerContext(event string) TriggerConditionContext {
 
 func translateTrigger(t workflow.Trigger, context TriggerConditionContext) (string, bool, error) {
 	if t.Paths != nil || t.PathsIgnore != nil {
-		return "", false, fmt.Errorf("%s path filters are unsupported: Buildkite if_changed is not equivalent", t.Event)
+		return "", false, &UnsupportedPathFiltersError{Event: t.Event}
 	}
 	switch t.Event {
 	case "workflow_call":

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1542,7 +1542,6 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 		}
 		selection, triggerErr := selectWorkflowTrigger(workflows[i].Triggers, effectiveEvent)
 		if triggerErr != nil {
-			triggerErr = fmt.Errorf("%s: translate workflow triggers: %w", workflows[i].CanonicalPath, triggerErr)
 			workflows[i].Applicable = true
 			workflows[i].TriggerCondition = effectiveEvent.TriggerContext.EventPredicate
 			processingReports[i] = triggerFailureProcessingReport(workflows[i], triggerErr)
@@ -2075,6 +2074,15 @@ func triggerConditionLiteral(value string) string {
 
 func triggerFailureProcessingReport(input workflowInput, err error) compatibility.ProcessingReport {
 	report := triggerProcessingReport(input.Path, input.Source)
+	var pathFilters *buildkitepipeline.UnsupportedPathFiltersError
+	if errors.As(err, &pathFilters) {
+		err = &compiler.ProcessingFinding{
+			Stage: compiler.StagePipeline, Code: compiler.CodePipelineGeneration, Category: "compatibility",
+			Path: input.Path, Line: 1, Column: 1,
+			Message: fmt.Sprintf("%s trigger path filters cannot be translated safely. Remove paths and paths-ignore from this trigger, or move the filtering into a job or step.", upperFirst(pathFilters.Event)),
+			Detail:  pathFilters.Error(), Err: err,
+		}
+	}
 	report.AddFailure(input.Path, string(compiler.StagePipeline), compiler.CodePipelineGeneration, "compatibility", err)
 	report.Result = "incompatible"
 	return report

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -2396,11 +2396,7 @@ func validateUnprivilegedBundle(bundle compiler.Bundle) error {
 		instances[instance.Key] = instance
 	}
 	var diagnostics []error
-	addFailure := func(artifact compiler.PlanArtifact, message string, err error) {
-		detail := err.Error()
-		if detail == message {
-			detail = ""
-		}
+	addFailure := func(artifact compiler.PlanArtifact, message, detail string, err error) {
 		finding := &compiler.ProcessingFinding{
 			Stage: compiler.StageAdmission, Code: "E_PROFILE", Category: "admission",
 			Job: artifact.Job.Workflow.LogicalJobID, Instance: artifact.Job.Target.StepKey,
@@ -2417,18 +2413,18 @@ func validateUnprivilegedBundle(bundle compiler.Bundle) error {
 		for _, capability := range artifact.Job.RequiredCapabilities {
 			if capability == "docker" && !slices.Equal(artifact.Authorization.DockerCapabilitySources, []string{"dockerfile-actions"}) {
 				if slices.Contains(artifact.Authorization.DockerCapabilitySources, "job-containers") || slices.Contains(artifact.Authorization.DockerCapabilitySources, "service-containers") {
-					message := hostedContainerDiagnostic(artifact.Job)
-					addFailure(artifact, message, errors.New("hosted container unsupported"))
+					message, detail := hostedContainerDiagnostic(artifact.Job)
+					addFailure(artifact, message, detail, errors.New("hosted container unsupported"))
 					continue
 				}
-				message := "Docker is unsupported for this job; hosted production allows Docker only for resolved Dockerfile actions"
-				addFailure(artifact, message, errors.New("unsupported Docker access"))
+				message := fmt.Sprintf("Job %q requires Docker, which hosted runs support only for Dockerfile actions. Use a Dockerfile action or remove the Docker requirement.", artifact.Job.Workflow.LogicalJobID)
+				addFailure(artifact, message, "", errors.New("unsupported Docker access"))
 				continue
 			}
 			if capability == "provider-token-read" {
 				if !slices.Equal(artifact.Authorization.ProviderTokenReadCapabilitySources, []string{"checkout-adapter"}) {
 					message := "GitHub checkout credentials are unsupported for this job; use the managed actions/checkout integration"
-					addFailure(artifact, message, errors.New("unsupported GitHub checkout credentials"))
+					addFailure(artifact, message, "", errors.New("unsupported GitHub checkout credentials"))
 				}
 				continue
 			}
@@ -2439,17 +2435,17 @@ func validateUnprivilegedBundle(bundle compiler.Bundle) error {
 					if reason == "" {
 						reason = "the workflow token request does not match the compiled job"
 					}
-					message := githubTokenAdmissionDiagnostic(artifact, reason)
-					addFailure(artifact, message, errors.New("hosted GITHUB_TOKEN unsupported"))
+					message, detail := githubTokenAdmissionDiagnostic(artifact, reason)
+					addFailure(artifact, message, detail, errors.New("hosted GITHUB_TOKEN unsupported"))
 				}
 				continue
 			}
 			if capability != "network" && capability != "docker" {
-				message := fmt.Sprintf("Job %q uses unsupported hosted runtime requirement %q", artifact.Job.Workflow.LogicalJobID, capability)
+				message := fmt.Sprintf("Job %q requires unsupported hosted runtime capability %q. Remove the requirement or use a runtime profile that supports it.", artifact.Job.Workflow.LogicalJobID, capability)
 				if capability == "secrets" {
-					message = fmt.Sprintf("Job %q uses GitHub Actions secrets, which hosted production does not provide", artifact.Job.Workflow.LogicalJobID)
+					message = fmt.Sprintf("Job %q uses GitHub Actions secrets, which hosted runs do not provide. Pass values through supported Buildkite secret handling or remove the dependency.", artifact.Job.Workflow.LogicalJobID)
 				}
-				addFailure(artifact, message, errors.New(message))
+				addFailure(artifact, message, "", errors.New(message))
 			}
 		}
 		for _, action := range artifact.Job.Actions {
@@ -2463,20 +2459,25 @@ func validateUnprivilegedBundle(bundle compiler.Bundle) error {
 					if action.RequestedRef != "" {
 						reference += "@" + action.RequestedRef
 					}
-					message, _, _ := actionintegration.UnsupportedVersionDiagnostic(reference, err)
-					addFailure(artifact, message, fmt.Errorf("job %q uses unsupported cache action: %w", artifact.Job.Workflow.LogicalJobID, err))
+					message, detail, _ := actionintegration.UnsupportedVersionDiagnostic(reference, err)
+					addFailure(artifact, message, detail, fmt.Errorf("job %q uses unsupported cache action: %w", artifact.Job.Workflow.LogicalJobID, err))
 				}
 				continue
 			}
 			if descriptor.Service != "" {
-				addFailure(artifact, "action requires a service unavailable to the hosted profile", fmt.Errorf("job %q uses action %q, which requires the unavailable GitHub Actions %s service", artifact.Job.Workflow.LogicalJobID, action.Repository, descriptor.Service))
+				reference := action.Repository
+				if action.Path != "" {
+					reference += "/" + action.Path
+				}
+				message := fmt.Sprintf("Action %q requires the GitHub Actions %s service, which hosted runs do not provide. Replace the action or use a runtime profile that provides this service.", reference, descriptor.Service)
+				addFailure(artifact, message, "", fmt.Errorf("job %q uses action %q, which requires the unavailable GitHub Actions %s service", artifact.Job.Workflow.LogicalJobID, reference, descriptor.Service))
 			}
 		}
 	}
 	return errors.Join(diagnostics...)
 }
 
-func githubTokenAdmissionDiagnostic(artifact compiler.PlanArtifact, reason string) string {
+func githubTokenAdmissionDiagnostic(artifact compiler.PlanArtifact, reason string) (message, detail string) {
 	limitation := reason
 	fix := "Use a supported workflow-level permissions map or remove the GITHUB_TOKEN dependency."
 	switch {
@@ -2528,10 +2529,12 @@ func githubTokenAdmissionDiagnostic(artifact compiler.PlanArtifact, reason strin
 		}
 		permissions = strings.Join(values, ", ")
 	}
-	return fmt.Sprintf("Job %q needs GITHUB_TOKEN, but %s. Cause: %s. Effective permissions: %s. %s", artifact.Job.Workflow.LogicalJobID, limitation, strings.Join(causes, "; "), permissions, fix)
+	message = fmt.Sprintf("Job %q needs GITHUB_TOKEN, but %s. %s", artifact.Job.Workflow.LogicalJobID, limitation, fix)
+	detail = fmt.Sprintf("Cause: %s. Effective permissions: %s.", strings.Join(causes, "; "), permissions)
+	return message, detail
 }
 
-func hostedContainerDiagnostic(job plan.Job) string {
+func hostedContainerDiagnostic(job plan.Job) (message, detail string) {
 	var constructs []string
 	if job.Container != nil {
 		constructs = append(constructs, fmt.Sprintf("job container %q", job.Container.Image))
@@ -2547,7 +2550,9 @@ func hostedContainerDiagnostic(job plan.Job) string {
 	if len(constructs) == 0 {
 		constructs = append(constructs, "a job or service container")
 	}
-	return fmt.Sprintf("Job %q uses %s. The compiler supports this construct, but hosted production does not run job or service containers. Replace the container with ordinary steps or an externally reachable service; runner configuration cannot enable containers in the hosted profile.", job.Workflow.LogicalJobID, strings.Join(constructs, " and "))
+	message = fmt.Sprintf("Job %q uses %s, which hosted runs do not support. Replace it with ordinary steps or an externally reachable service.", job.Workflow.LogicalJobID, strings.Join(constructs, " and "))
+	detail = "The compiler supports job and service containers, but the hosted profile does not run them; runner configuration cannot enable them."
+	return message, detail
 }
 
 func irUsesActions(ir compiler.IR) bool {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1808,6 +1808,9 @@ func failedGeneratedWorkflow(input workflowInput, event string, report compatibi
 		if len(attribution) != 0 {
 			message += " {" + strings.Join(attribution, ", ") + "}"
 		}
+		if diagnostic.Detail != "" {
+			message += "\n  detail: " + diagnostic.Detail
+		}
 		messages = append(messages, message)
 	}
 	_, annotation := processingAnnotation(report)
@@ -2394,10 +2397,14 @@ func validateUnprivilegedBundle(bundle compiler.Bundle) error {
 	}
 	var diagnostics []error
 	addFailure := func(artifact compiler.PlanArtifact, message string, err error) {
+		detail := err.Error()
+		if detail == message {
+			detail = ""
+		}
 		finding := &compiler.ProcessingFinding{
 			Stage: compiler.StageAdmission, Code: "E_PROFILE", Category: "admission",
 			Job: artifact.Job.Workflow.LogicalJobID, Instance: artifact.Job.Target.StepKey,
-			Message: message, Err: err,
+			Message: message, Detail: detail, Err: err,
 		}
 		if instance, ok := instances[artifact.Job.Target.StepKey]; ok {
 			finding.Path = instance.SourcePath
@@ -2449,7 +2456,15 @@ func validateUnprivilegedBundle(bundle compiler.Bundle) error {
 			descriptor, _ := actionintegration.Lookup(actionintegration.Identity{Source: action.Source, Repository: action.Repository, Path: action.Path})
 			if descriptor.Service == actionintegration.ServiceCache {
 				if err := actionintegration.ValidateCacheCommit(action.Commit); err != nil {
-					addFailure(artifact, "cache action version is not admitted by the hosted profile", fmt.Errorf("job %q uses unsupported cache action: %w", artifact.Job.Workflow.LogicalJobID, err))
+					reference := action.Repository
+					if action.Path != "" {
+						reference += "/" + action.Path
+					}
+					if action.RequestedRef != "" {
+						reference += "@" + action.RequestedRef
+					}
+					message, _, _ := actionintegration.UnsupportedVersionDiagnostic(reference, err)
+					addFailure(artifact, message, fmt.Errorf("job %q uses unsupported cache action: %w", artifact.Job.Workflow.LogicalJobID, err))
 				}
 				continue
 			}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -5848,17 +5848,23 @@ func TestRunUploadFailsClosedBeforePipeline(t *testing.T) {
 }
 
 func TestUnprivilegedUploadRejectsCapabilities(t *testing.T) {
-	for _, capability := range []string{"secrets", "provider-token-write", "privileged-container", "future-capability"} {
+	tests := []struct {
+		capability string
+		want       string
+	}{
+		{capability: "secrets", want: `Job "protected" uses GitHub Actions secrets, which hosted runs do not provide. Pass values through supported Buildkite secret handling or remove the dependency.`},
+		{capability: "privileged-container", want: `Job "protected" requires unsupported hosted runtime capability "privileged-container". Remove the requirement or use a runtime profile that supports it.`},
+		{capability: "future-capability", want: `Job "protected" requires unsupported hosted runtime capability "future-capability". Remove the requirement or use a runtime profile that supports it.`},
+	}
+	for _, test := range tests {
+		capability := test.capability
 		bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: plan.Job{
 			Workflow:             plan.Workflow{LogicalJobID: "protected"},
 			RequiredCapabilities: []string{capability},
 		}}}}
 		err := validateUnprivilegedBundle(bundle)
-		want := capability
-		if capability == "provider-token-write" {
-			want = "GITHUB_TOKEN"
-		}
-		if err == nil || !strings.Contains(err.Error(), want) {
+		var finding *compiler.ProcessingFinding
+		if err == nil || !errors.As(err, &finding) || finding.Message != test.want || finding.Detail != "" {
 			t.Fatalf("validateUnprivilegedBundle(%q) error = %v, want capability rejection", capability, err)
 		}
 	}
@@ -5921,7 +5927,7 @@ func TestUnprivilegedUploadAdmitsOnlyCompilerVerifiedWorkflowToken(t *testing.T)
 	}
 }
 
-func TestGitHubTokenAdmissionDiagnosticExplainsCausePermissionsAndFix(t *testing.T) {
+func TestGitHubTokenAdmissionDiagnosticSeparatesGuidanceFromDetail(t *testing.T) {
 	artifact := compiler.PlanArtifact{
 		Job: plan.Job{
 			Workflow:    plan.Workflow{LogicalJobID: "build"},
@@ -5929,20 +5935,24 @@ func TestGitHubTokenAdmissionDiagnosticExplainsCausePermissionsAndFix(t *testing
 		},
 		Authorization: compiler.PlanAuthorization{GitHubTokenActions: []string{"owner/action@v1"}},
 	}
-	want := `Job "build" needs GITHUB_TOKEN, but job-level permissions are unsupported for hosted GITHUB_TOKEN issuance. Cause: action "owner/action@v1" defaults an input to github.token. Effective permissions: contents: read, pull-requests: write. Move the permissions map to the workflow top level.`
-	if got := githubTokenAdmissionDiagnostic(artifact, "GitHub workflow access tokens do not support job-level permissions"); got != want {
-		t.Fatalf("githubTokenAdmissionDiagnostic() = %q, want %q", got, want)
+	wantMessage := `Job "build" needs GITHUB_TOKEN, but job-level permissions are unsupported for hosted GITHUB_TOKEN issuance. Move the permissions map to the workflow top level.`
+	wantDetail := `Cause: action "owner/action@v1" defaults an input to github.token. Effective permissions: contents: read, pull-requests: write.`
+	message, detail := githubTokenAdmissionDiagnostic(artifact, "GitHub workflow access tokens do not support job-level permissions")
+	if message != wantMessage || detail != wantDetail {
+		t.Fatalf("githubTokenAdmissionDiagnostic() = %q, %q", message, detail)
 	}
 }
 
-func TestHostedContainerDiagnosticNamesServiceAndBoundary(t *testing.T) {
+func TestHostedContainerDiagnosticSeparatesGuidanceFromDetail(t *testing.T) {
 	job := plan.Job{
 		Workflow: plan.Workflow{LogicalJobID: "test"},
 		Services: map[string]plan.Container{"postgres": {Image: "postgres:11-alpine"}},
 	}
-	want := `Job "test" uses service container "postgres" (image "postgres:11-alpine"). The compiler supports this construct, but hosted production does not run job or service containers. Replace the container with ordinary steps or an externally reachable service; runner configuration cannot enable containers in the hosted profile.`
-	if got := hostedContainerDiagnostic(job); got != want {
-		t.Fatalf("hostedContainerDiagnostic() = %q, want %q", got, want)
+	wantMessage := `Job "test" uses service container "postgres" (image "postgres:11-alpine"), which hosted runs do not support. Replace it with ordinary steps or an externally reachable service.`
+	wantDetail := `The compiler supports job and service containers, but the hosted profile does not run them; runner configuration cannot enable them.`
+	message, detail := hostedContainerDiagnostic(job)
+	if message != wantMessage || detail != wantDetail {
+		t.Fatalf("hostedContainerDiagnostic() = %q, %q", message, detail)
 	}
 }
 
@@ -5964,7 +5974,10 @@ func TestUnprivilegedUploadRejectsDockerWithoutCompilerProvenance(t *testing.T) 
 		Workflow:             plan.Workflow{LogicalJobID: "unproven-docker"},
 		RequiredCapabilities: []string{"docker"},
 	}}}}
-	if err := validateUnprivilegedBundle(bundle); err == nil || !strings.Contains(err.Error(), "unsupported Docker access") {
+	err := validateUnprivilegedBundle(bundle)
+	var finding *compiler.ProcessingFinding
+	want := `Job "unproven-docker" requires Docker, which hosted runs support only for Dockerfile actions. Use a Dockerfile action or remove the Docker requirement.`
+	if err == nil || !errors.As(err, &finding) || finding.Message != want || finding.Detail != "" {
 		t.Fatalf("validateUnprivilegedBundle() error = %v, want Docker provenance rejection", err)
 	}
 }
@@ -6002,7 +6015,9 @@ func TestUnprivilegedUploadRejectsKnownGitHubServiceActions(t *testing.T) {
 				Actions:  []plan.ActionLock{test.action},
 			}}}}
 			err := validateUnprivilegedBundle(bundle)
-			if err == nil || !strings.Contains(err.Error(), "GitHub Actions "+test.service+" service") || !strings.Contains(err.Error(), "unavailable") {
+			var finding *compiler.ProcessingFinding
+			want := `Action "actions/upload-artifact/merge" requires the GitHub Actions artifact service, which hosted runs do not provide. Replace the action or use a runtime profile that provides this service.`
+			if err == nil || !errors.As(err, &finding) || finding.Message != want || finding.Detail != "" {
 				t.Fatalf("validateUnprivilegedBundle(%#v) error = %v", test.action, err)
 			}
 		})

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2543,6 +2543,20 @@ func TestProcessingAnnotationReservesSpaceForTruncationNotice(t *testing.T) {
 	}
 }
 
+func TestProcessingAnnotationDropsDetailBeforeTruncatingMessage(t *testing.T) {
+	diagnostic := compatibility.Diagnostic{
+		Level: "error", Message: "Keep this actionable guidance intact.", Detail: strings.Repeat("diagnostic context ", 20),
+	}
+	withoutDetail := diagnostic
+	withoutDetail.Detail = ""
+	want := renderProcessingDiagnostic(withoutDetail)
+
+	got := renderProcessingDiagnosticWithin(diagnostic, len(want))
+	if got != want || strings.Contains(got, "<details") {
+		t.Fatalf("bounded diagnostic = %q, want primary message without detail %q", got, want)
+	}
+}
+
 func TestProcessingAnnotationUsesRepositoryRelativeWorkflowPath(t *testing.T) {
 	repository := t.TempDir()
 	workflowPath := filepath.Join(repository, ".github", "workflows", "test-image-build.yml")
@@ -4329,7 +4343,8 @@ func TestRunUploadEmitsTriggerFailuresAsFailingSteps(t *testing.T) {
 func TestRunUploadEmitsReusableInputFailuresAsActionableFailingSteps(t *testing.T) {
 	requireImporterHost(t)
 	repository := writeUploadWorkflowRepository(t, map[string]string{
-		"caller.yml":   "name: Caller\non: push\njobs:\n  prepare:\n    runs-on: ubuntu-latest\n    outputs:\n      target: ${{ steps.value.outputs.target }}\n    steps:\n      - id: value\n        run: echo target=test >> $GITHUB_OUTPUT\n  call:\n    needs: prepare\n    uses: ./.github/workflows/reusable.yml\n    with:\n      target: ${{ needs.prepare.outputs.target }}\n",
+		"caller.yml":   "name: Caller\non: push\njobs:\n  middle:\n    uses: ./.github/workflows/middle.yml\n",
+		"middle.yml":   "on: workflow_call\njobs:\n  prepare:\n    runs-on: ubuntu-latest\n    outputs:\n      target: ${{ steps.value.outputs.target }}\n    steps:\n      - id: value\n        run: echo target=test >> $GITHUB_OUTPUT\n  call:\n    needs: prepare\n    uses: ./.github/workflows/reusable.yml\n    with:\n      target: ${{ needs.prepare.outputs.target }}\n",
 		"reusable.yml": "on:\n  workflow_call:\n    inputs:\n      target:\n        type: string\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
 	})
 	eventPath, err := filepath.Abs(filepath.Join("..", "..", "testdata", "smoke", "events", "push.json"))

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -4312,14 +4312,63 @@ func TestRunUploadEmitsTriggerFailuresAsFailingSteps(t *testing.T) {
 	}
 	failure := pipeline.Steps[0]
 	message := failureArtifactForStep(failure.Plugins, runner.uploaded, "messages")
-	if failure.Group != "" || failure.Label != ":github: Crowdin upload" || failure.Condition != "" || !isGeneratedFailureCommand(failure.Command) || !strings.Contains(string(message), "push path filters are unsupported") || !failure.Checkout.Skip || len(failure.Steps) != 0 {
-		t.Fatalf("trigger failure step = %#v", failure)
+	annotation := failureArtifactForStep(failure.Plugins, runner.uploaded, "annotations")
+	primary := "Push trigger path filters cannot be translated safely. Remove paths and paths-ignore from this trigger, or move the filtering into a job or step."
+	detail := "push path filters are unsupported: Buildkite if_changed is not equivalent"
+	if failure.Group != "" || failure.Label != ":github: Crowdin upload" || failure.Condition != "" || !isGeneratedFailureCommand(failure.Command) || !strings.Contains(string(message), primary) || !strings.Contains(string(message), "detail: "+detail) || !strings.Contains(string(annotation), "<strong>Push trigger path filters cannot be translated safely.</strong>") || !strings.Contains(string(annotation), "Remove paths and paths-ignore") || !strings.Contains(string(annotation), detail) || strings.Contains(string(message), "translate workflow triggers") || strings.Contains(string(message), ".github/workflows/crowdin-upload.yml") || !failure.Checkout.Skip || len(failure.Steps) != 0 {
+		t.Fatalf("trigger failure step = %#v, message = %q, annotation = %q", failure, message, annotation)
 	}
 	if success := pipeline.Steps[1]; success.Group != ":github: Success" || len(success.Steps) != 1 {
 		t.Fatalf("successful workflow after trigger failure = %#v", success)
 	}
-	if !strings.Contains(stdout.String(), "Pipeline generation: failed") || !strings.Contains(stdout.String(), compiler.CodePipelineGeneration) {
+	if !strings.Contains(stdout.String(), "Pipeline generation: failed") || !strings.Contains(stdout.String(), compiler.CodePipelineGeneration) || !strings.Contains(stdout.String(), primary) || !strings.Contains(stdout.String(), "detail: "+detail) {
 		t.Fatalf("trigger failure omitted processing report: %q", stdout.String())
+	}
+}
+
+func TestRunUploadEmitsReusableInputFailuresAsActionableFailingSteps(t *testing.T) {
+	requireImporterHost(t)
+	repository := writeUploadWorkflowRepository(t, map[string]string{
+		"caller.yml":   "name: Caller\non: push\njobs:\n  prepare:\n    runs-on: ubuntu-latest\n    outputs:\n      target: ${{ steps.value.outputs.target }}\n    steps:\n      - id: value\n        run: echo target=test >> $GITHUB_OUTPUT\n  call:\n    needs: prepare\n    uses: ./.github/workflows/reusable.yml\n    with:\n      target: ${{ needs.prepare.outputs.target }}\n",
+		"reusable.yml": "on:\n  workflow_call:\n    inputs:\n      target:\n        type: string\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
+	})
+	eventPath, err := filepath.Abs(filepath.Join("..", "..", "testdata", "smoke", "events", "push.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repository)
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_STEP_KEY", "reusable-input-failure-importer")
+	runner := &cliCaptureRunner{}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"upload", "--event-path", eventPath, ".github/workflows/caller.yml"}, &stdout, &stderr, "dev", runner); code != 0 || stderr.Len() != 0 {
+		t.Fatalf("run() code/stderr = %d / %q", code, stderr.String())
+	}
+	var pipeline struct {
+		Steps []struct {
+			Command string             `yaml:"command"`
+			Plugins failureStepPlugins `yaml:"plugins"`
+			Notify  []struct {
+				GitHubCheck struct {
+					Output struct {
+						Summary string `yaml:"summary"`
+					} `yaml:"output"`
+				} `yaml:"github_check"`
+			} `yaml:"notify"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(runner.commands[len(runner.commands)-1].stdin, &pipeline); err != nil {
+		t.Fatal(err)
+	}
+	if len(pipeline.Steps) != 1 || !isGeneratedFailureCommand(pipeline.Steps[0].Command) {
+		t.Fatalf("reusable input failure pipeline = %#v", pipeline.Steps)
+	}
+	primary := `Reusable workflow input "target" uses the needs context, which is unavailable before jobs run. Replace it with a literal or an expression that does not depend on job results.`
+	detail := `Reusable-workflow input "target" is not statically resolvable: unsupported compile-time context "needs"`
+	message := string(failureArtifactForStep(pipeline.Steps[0].Plugins, runner.uploaded, "messages"))
+	annotation := string(failureArtifactForStep(pipeline.Steps[0].Plugins, runner.uploaded, "annotations"))
+	if !strings.Contains(message, primary) || !strings.Contains(message, "detail: "+detail) || !strings.Contains(annotation, "<strong>Reusable workflow input &#34;target&#34; uses the needs context, which is unavailable before jobs run.</strong>") || !strings.Contains(annotation, "Replace it with a literal") || !strings.Contains(annotation, strings.ReplaceAll(detail, `"`, "&#34;")) || len(pipeline.Steps[0].Notify) != 1 || !strings.Contains(pipeline.Steps[0].Notify[0].GitHubCheck.Output.Summary, primary) || strings.Contains(pipeline.Steps[0].Notify[0].GitHubCheck.Output.Summary, detail) {
+		t.Fatalf("reusable input failure output = message %q, annotation %q, pipeline %#v", message, annotation, pipeline.Steps[0])
 	}
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1196,7 +1196,7 @@ func TestRunValidateAndCompile(t *testing.T) {
 		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 			t.Fatal(err)
 		}
-		if report.Result != "incompatible" || report.Compile.Result != "incompatible" || len(report.Diagnostics) != 1 || !strings.Contains(report.Diagnostics[0].Message, `Runner label "macos-15" is not mapped`) {
+		if report.Result != "incompatible" || report.Compile.Result != "incompatible" || len(report.Diagnostics) != 1 || !strings.Contains(report.Diagnostics[0].Message, `Runner label "macos-15" has no runner-target mapping`) || !strings.Contains(report.Diagnostics[0].Detail, "Supported runner labels:") {
 			t.Fatalf("macOS profile report = %#v", report)
 		}
 	})
@@ -2070,7 +2070,7 @@ func TestProcessingReportRedactsEventDerivedRunnerValues(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 		t.Fatal(err)
 	}
-	if len(report.Diagnostics) != 1 || strings.Contains(report.Diagnostics[0].Message, sentinel) || report.Diagnostics[0].Message != "Runner label is not mapped to a runner target; configure a runner-target mapping for this label or use ubuntu-22.04, ubuntu-24.04, ubuntu-latest" {
+	if len(report.Diagnostics) != 1 || strings.Contains(report.Diagnostics[0].Message, sentinel) || strings.Contains(report.Diagnostics[0].Detail, sentinel) || report.Diagnostics[0].Message != "Runner label has no runner-target mapping. Configure a mapping for this label or use a mapped runner label." || report.Diagnostics[0].Detail != "Supported runner labels: ubuntu-22.04, ubuntu-24.04, ubuntu-latest." {
 		t.Fatalf("diagnostics = %#v", report.Diagnostics)
 	}
 }
@@ -2464,7 +2464,9 @@ func TestValidatePublishesProcessingDiagnosticsInBuildkite(t *testing.T) {
 		}
 		for _, want := range []string{
 			`<h2 class="h4 mb2">GitHub Actions workflow diagnostics</h2>`,
-			`<div class="border-top border-gray py2"><div><strong>Runner label &#34;windows-latest&#34; uses an unsupported operating system`,
+			`<div class="border-top border-gray py2"><div><strong>Runner label &#34;windows-latest&#34; requires Windows, which is unsupported.`,
+			`<summary>Diagnostic detail</summary>`,
+			`Supported runner labels: ubuntu-22.04, ubuntu-24.04, ubuntu-latest.`,
 			"Job <code>test</code>",
 		} {
 			if !strings.Contains(string(annotation.stdin), want) {
@@ -2649,12 +2651,13 @@ func TestProcessingAnnotationLeadsWithTheActionableDiagnostic(t *testing.T) {
 }
 
 func TestProcessingDiagnosticRenderingsUseTheSameMessageAndAggregation(t *testing.T) {
-	const message = `Job "test" needs GITHUB_TOKEN, but job-level permissions are unsupported. Effective permissions: contents: read.`
+	const message = `Job "test" needs GITHUB_TOKEN, but job-level permissions are unsupported. Move permissions to the workflow level.`
+	const detail = `Effective permissions: contents: read.`
 	report := compatibility.NewProcessingReport("ci.yml", "hosted")
 	for _, instance := range []string{"gha-test-a", "gha-test-b"} {
 		report.Diagnostics = append(report.Diagnostics, compatibility.Diagnostic{
 			Level: "error", Code: "E_PROFILE", Stage: string(compiler.StageAdmission),
-			Message: message, Job: "test", Instance: instance,
+			Message: message, Detail: detail, Job: "test", Instance: instance,
 		})
 	}
 
@@ -2666,7 +2669,7 @@ func TestProcessingDiagnosticRenderingsUseTheSameMessageAndAggregation(t *testin
 	if err := json.Unmarshal(jsonOutput.Bytes(), &decoded); err != nil {
 		t.Fatal(err)
 	}
-	if len(decoded.Diagnostics) != 1 || decoded.Diagnostics[0].Message != message || decoded.Diagnostics[0].Instance != "" {
+	if len(decoded.Diagnostics) != 1 || decoded.Diagnostics[0].Message != message || decoded.Diagnostics[0].Detail != detail || decoded.Diagnostics[0].Instance != "" {
 		t.Fatalf("JSON diagnostics = %#v", decoded.Diagnostics)
 	}
 
@@ -2675,9 +2678,10 @@ func TestProcessingDiagnosticRenderingsUseTheSameMessageAndAggregation(t *testin
 		t.Fatal(err)
 	}
 	_, annotation := processingAnnotation(report)
-	if strings.Count(textOutput.String(), message) != 1 ||
+	if strings.Count(textOutput.String(), message) != 1 || strings.Count(textOutput.String(), "detail: "+detail) != 1 ||
 		strings.Count(annotation, `Job &#34;test&#34; needs GITHUB_TOKEN, but job-level permissions are unsupported.`) != 1 ||
-		strings.Count(annotation, `Effective permissions: contents: read.`) != 1 {
+		strings.Count(annotation, `Move permissions to the workflow level.`) != 1 ||
+		strings.Count(annotation, `<summary>Diagnostic detail</summary>`) != 1 || strings.Count(annotation, detail) != 1 {
 		t.Fatalf("text = %q; annotation = %q", textOutput.String(), annotation)
 	}
 	if strings.Contains(annotation, "gha-test-") {
@@ -3916,12 +3920,12 @@ func TestRunUploadEmitsApplicableCompilationFailuresAsFailingSteps(t *testing.T)
 	}
 	step := pipeline.Steps[0]
 	wantSummary := "The workflow could not be prepared:\n\n" +
-		"- `" + filepath.ToSlash(workflowPath) + "`, job `alpha`: Runner label is not mapped to a runner target; configure a runner-target mapping for this label or use ubuntu-22.04, ubuntu-24.04, ubuntu-latest\n" +
+		"- `" + filepath.ToSlash(workflowPath) + "`, job `alpha`: Runner label has no runner-target mapping. Configure a mapping for this label or use a mapped runner label.\n" +
 		"- `" + filepath.ToSlash(workflowPath) + "`, job `beta`: runs-on expression cannot be resolved at compile time: compile-time object contains ambiguous properties\n" +
 		"- `" + filepath.ToSlash(workflowPath) + "`, job `gamma`: runs-on expression cannot be resolved at compile time: fromJSON argument is invalid JSON"
 	message := failureArtifactForStep(step.Plugins, runner.uploaded, "messages")
 	annotation := failureArtifactForStep(step.Plugins, runner.uploaded, "annotations")
-	if step.Label != ":github: Invalid push" || step.Condition != "" || !isGeneratedFailureCommand(step.Command) || strings.Contains(step.Command, "Runner label is not mapped") || !strings.Contains(string(message), "Runner label is not mapped") || !strings.Contains(string(annotation), `<h2 class="h4 mb2">GitHub Actions workflow diagnostics</h2>`) || !strings.Contains(string(annotation), "Job <code>alpha</code>") || !strings.Contains(string(annotation), "Job <code>beta</code>") || !strings.Contains(string(annotation), "Job <code>gamma</code>") || len(step.Notify) != 1 || step.Notify[0].GitHubCheck.Output.Title != "Workflow could not be run" || step.Notify[0].GitHubCheck.Output.Summary != wantSummary || !step.Checkout.Skip {
+	if step.Label != ":github: Invalid push" || step.Condition != "" || !isGeneratedFailureCommand(step.Command) || strings.Contains(step.Command, "Runner label has no") || !strings.Contains(string(message), "Runner label has no") || !strings.Contains(string(message), "detail: Supported runner labels:") || !strings.Contains(string(annotation), `<h2 class="h4 mb2">GitHub Actions workflow diagnostics</h2>`) || !strings.Contains(string(annotation), "Job <code>alpha</code>") || !strings.Contains(string(annotation), "Job <code>beta</code>") || !strings.Contains(string(annotation), "Job <code>gamma</code>") || len(step.Notify) != 1 || step.Notify[0].GitHubCheck.Output.Title != "Workflow could not be run" || step.Notify[0].GitHubCheck.Output.Summary != wantSummary || !step.Checkout.Skip {
 		t.Fatalf("compiler failure step = %#v", step)
 	}
 	if strings.Contains(step.Notify[0].GitHubCheck.Output.Summary, "E_EXPRESSION_INVALID") {
@@ -3956,7 +3960,7 @@ fi
 	command.Dir = commandDirectory
 	command.Env = append(os.Environ(), "PATH="+agentDirectory+string(os.PathListSeparator)+os.Getenv("PATH"))
 	output, err := command.CombinedOutput()
-	plainIndex := strings.Index(string(output), "Runner label is not mapped")
+	plainIndex := strings.Index(string(output), "Runner label has no")
 	annotationIndex := strings.Index(string(output), `<h2 class="h4 mb2">GitHub Actions workflow diagnostics</h2>`)
 	logPrefix := "\x1b[31m"
 	if exitErr, ok := err.(*exec.ExitError); !ok || exitErr.ExitCode() != 1 || !strings.HasPrefix(string(output), logPrefix) || plainIndex == -1 || annotationIndex <= plainIndex {
@@ -4155,8 +4159,9 @@ func TestRunUploadContinuesAfterWorkflowCompilationFailures(t *testing.T) {
 		}
 	}
 	firstFailureMessage := string(failureArtifactForStep(pipeline.Steps[0].Plugins, runner.uploaded, "messages"))
-	if !strings.Contains(firstFailureMessage, `Runner label "windows-latest" uses an unsupported operating system (Windows); supported runner labels: ubuntu-22.04, ubuntu-24.04, ubuntu-latest`) ||
-		!strings.Contains(firstFailureMessage, `Runner label "macos-15" is not mapped to a runner target; configure a runner-target mapping for this label or use ubuntu-22.04, ubuntu-24.04, ubuntu-latest`) {
+	if !strings.Contains(firstFailureMessage, `Runner label "windows-latest" requires Windows, which is unsupported. Use a Linux or macOS runner label.`) ||
+		!strings.Contains(firstFailureMessage, `Runner label "macos-15" has no runner-target mapping. Configure a mapping for this label or use a mapped runner label.`) ||
+		strings.Count(firstFailureMessage, "detail: Supported runner labels: ubuntu-22.04, ubuntu-24.04, ubuntu-latest.") != 2 {
 		t.Fatalf("multi-diagnostic failure message = %q", firstFailureMessage)
 	}
 	actionFailureAnnotation := string(failureArtifactForStep(pipeline.Steps[1].Plugins, runner.uploaded, "annotations"))
@@ -6018,13 +6023,18 @@ func TestUnprivilegedUploadAllowsOnlyAuditedCacheCommits(t *testing.T) {
 		}
 	}
 
-	action := plan.ActionLock{Source: "github", Repository: "actions/cache", Commit: strings.Repeat("0", 40)}
+	action := plan.ActionLock{Source: "github", Repository: "actions/cache", RequestedRef: "v6.0.2", Commit: strings.Repeat("0", 40)}
 	bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: plan.Job{
 		Workflow: plan.Workflow{LogicalJobID: "cache-old"},
 		Actions:  []plan.ActionLock{action},
 	}}}}
-	if err := validateUnprivilegedBundle(bundle); err == nil || !strings.Contains(err.Error(), "v6.1.0") {
+	err := validateUnprivilegedBundle(bundle)
+	if err == nil || !strings.Contains(err.Error(), "v6.1.0") {
 		t.Fatalf("validateUnprivilegedBundle(%#v) error = %v", action, err)
+	}
+	var finding *compiler.ProcessingFinding
+	if !errors.As(err, &finding) || finding.Message != "actions/cache v6.0.2 is unsupported. Use a supported version from https://github.com/buildkite/buildkite-gha/blob/main/docs/compatibility.md#cache-action." || !strings.Contains(finding.Detail, "Buildkite cache-v2 service") || !strings.Contains(finding.Detail, action.Commit) || strings.Contains(finding.Message, action.Commit) {
+		t.Fatalf("hosted cache diagnostic = %#v", finding)
 	}
 }
 

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -142,8 +142,18 @@ func processingAnnotationWorkflowPath(path string) string {
 }
 
 func renderProcessingDiagnosticWithin(diagnostic compatibility.Diagnostic, limit int) string {
+	detail := diagnostic.Detail
 	message := diagnostic.Message
 	row := renderProcessingDiagnostic(diagnostic)
+	for len(row) > limit && detail != "" {
+		end := max(0, len(detail)-(len(row)-limit))
+		for end > 0 && !utf8.ValidString(detail[:end]) {
+			end--
+		}
+		diagnostic.Detail = detail[:end] + "…"
+		detail = detail[:end]
+		row = renderProcessingDiagnostic(diagnostic)
+	}
 	for len(row) > limit && message != "" {
 		end := max(0, len(message)-(len(row)-limit))
 		for end > 0 && !utf8.ValidString(message[:end]) {
@@ -192,6 +202,11 @@ func renderProcessingDiagnostic(diagnostic compatibility.Diagnostic) string {
 			out.WriteString(annotationHTML(sentence))
 		}
 		out.WriteString("</div>")
+	}
+	if diagnostic.Detail != "" {
+		out.WriteString("<details class=\"mt1\"><summary>Diagnostic detail</summary><div class=\"mt1\">")
+		out.WriteString(annotationHTML(diagnostic.Detail))
+		out.WriteString("</div></details>")
 	}
 	out.WriteString("</div>\n")
 	return out.String()

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -150,7 +150,11 @@ func renderProcessingDiagnosticWithin(diagnostic compatibility.Diagnostic, limit
 		for end > 0 && !utf8.ValidString(detail[:end]) {
 			end--
 		}
-		diagnostic.Detail = detail[:end] + "…"
+		if end == 0 {
+			diagnostic.Detail = ""
+		} else {
+			diagnostic.Detail = detail[:end] + "…"
+		}
 		detail = detail[:end]
 		row = renderProcessingDiagnostic(diagnostic)
 	}

--- a/internal/compatibility/processing_compiler.go
+++ b/internal/compatibility/processing_compiler.go
@@ -278,6 +278,7 @@ func processingErrorDetails(err error, fallbackStage, fallbackCode, fallbackCate
 
 func diagnosticFromError(defaultPath, stage, code, category string, err error) Diagnostic {
 	message := err.Error()
+	detail := ""
 	location := (*SourceLocation)(nil)
 	var finding *compiler.ProcessingFinding
 	if structured, ok := err.(*compiler.ProcessingFinding); ok {
@@ -285,6 +286,7 @@ func diagnosticFromError(defaultPath, stage, code, category string, err error) D
 		if finding.Message != "" {
 			message = finding.Message
 		}
+		detail = finding.Detail
 		if finding.Path != "" {
 			location = sourceLocation(finding.Path, finding.Line, finding.Column)
 		}
@@ -301,7 +303,7 @@ func diagnosticFromError(defaultPath, stage, code, category string, err error) D
 	}
 	diagnostic := Diagnostic{
 		Level: "error", Code: code, Category: category, Stage: stage,
-		Message: message, Location: location,
+		Message: message, Detail: detail, Location: location,
 	}
 	if finding != nil {
 		diagnostic.Job = finding.Job

--- a/internal/compatibility/report.go
+++ b/internal/compatibility/report.go
@@ -11,7 +11,7 @@ import (
 
 // ProcessingSchema is the versioned, stage-oriented report shared by all
 // workflow-processing commands.
-const ProcessingSchema = "buildkite-gha/processing-report/v1"
+const ProcessingSchema = "buildkite-gha/processing-report/v2"
 
 const (
 	Passed       = "passed"

--- a/internal/compatibility/report.go
+++ b/internal/compatibility/report.go
@@ -33,6 +33,7 @@ type Diagnostic struct {
 	Category string          `json:"category,omitempty"`
 	Stage    string          `json:"stage,omitempty"`
 	Message  string          `json:"message"`
+	Detail   string          `json:"detail,omitempty"`
 	Location *SourceLocation `json:"location,omitempty"`
 	Job      string          `json:"job,omitempty"`
 	Instance string          `json:"instance,omitempty"`
@@ -183,7 +184,10 @@ func (r *ProcessingReport) Finalize() {
 		if left.Code != right.Code {
 			return left.Code < right.Code
 		}
-		return left.Message < right.Message
+		if left.Message != right.Message {
+			return left.Message < right.Message
+		}
+		return left.Detail < right.Detail
 	})
 	r.Diagnostics = compactDiagnostics(r.Diagnostics)
 }
@@ -193,8 +197,8 @@ func compactDiagnostics(diagnostics []Diagnostic) []Diagnostic {
 		return diagnostics
 	}
 	type diagnosticKey struct {
-		level, code, category, stage, message, job, action, location string
-		step                                                         int
+		level, code, category, stage, message, detail, job, action, location string
+		step                                                                 int
 	}
 	type matrixDiagnostic struct {
 		index     int
@@ -205,7 +209,7 @@ func compactDiagnostics(diagnostics []Diagnostic) []Diagnostic {
 	for _, diagnostic := range diagnostics {
 		key := diagnosticKey{
 			level: diagnostic.Level, code: diagnostic.Code, category: diagnostic.Category,
-			stage: diagnostic.Stage, message: diagnostic.Message, job: diagnostic.Job,
+			stage: diagnostic.Stage, message: diagnostic.Message, detail: diagnostic.Detail, job: diagnostic.Job,
 			action: diagnostic.Action, step: diagnostic.Step,
 		}
 		if diagnostic.Location != nil {
@@ -240,7 +244,7 @@ func compactDiagnostics(diagnostics []Diagnostic) []Diagnostic {
 }
 
 func sameDiagnostic(left, right Diagnostic) bool {
-	return left.Level == right.Level && left.Code == right.Code && left.Category == right.Category && left.Stage == right.Stage && left.Message == right.Message && left.Job == right.Job && left.Instance == right.Instance && left.Action == right.Action && left.Step == right.Step && sameLocation(left.Location, right.Location)
+	return left.Level == right.Level && left.Code == right.Code && left.Category == right.Category && left.Stage == right.Stage && left.Message == right.Message && left.Detail == right.Detail && left.Job == right.Job && left.Instance == right.Instance && left.Action == right.Action && left.Step == right.Step && sameLocation(left.Location, right.Location)
 }
 
 func sameLocation(left, right *SourceLocation) bool {
@@ -294,6 +298,11 @@ func WriteProcessing(w io.Writer, format string, report ProcessingReport) error 
 			}
 			if _, err := fmt.Fprintf(w, "%s [%s] %s%s%s\n", marker, diagnostic.Code, diagnostic.Message, textLocation(diagnostic.Location), textDiagnosticMetadata(diagnostic)); err != nil {
 				return err
+			}
+			if diagnostic.Detail != "" {
+				if _, err := fmt.Fprintf(w, "  detail: %s\n", diagnostic.Detail); err != nil {
+					return err
+				}
 			}
 		}
 		return nil

--- a/internal/compatibility/report_test.go
+++ b/internal/compatibility/report_test.go
@@ -40,7 +40,7 @@ func TestProcessingReportContainsEveryStableStageInTextAndJSON(t *testing.T) {
 	if decoded.Schema != ProcessingSchema || len(decoded.Stages) != 10 || decoded.Status != Failed || decoded.Diagnostics[0].Detail != "unsupported runtime node12" {
 		t.Fatalf("decoded report = %#v", decoded)
 	}
-	schemaSource, err := os.ReadFile(filepath.Join("..", "..", "schemas", "processing-report-v1.schema.json"))
+	schemaSource, err := os.ReadFile(filepath.Join("..", "..", "schemas", "processing-report-v2.schema.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,10 +49,10 @@ func TestProcessingReportContainsEveryStableStageInTextAndJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 	compiler := jsonschema.NewCompiler()
-	if err := compiler.AddResource("processing-report-v1.schema.json", schemaDocument); err != nil {
+	if err := compiler.AddResource("processing-report-v2.schema.json", schemaDocument); err != nil {
 		t.Fatal(err)
 	}
-	schema, err := compiler.Compile("processing-report-v1.schema.json")
+	schema, err := compiler.Compile("processing-report-v2.schema.json")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,6 +92,48 @@ func TestProcessingReportContainsEveryStableStageInTextAndJSON(t *testing.T) {
 	}
 	if err := WriteProcessing(&bytes.Buffer{}, "yaml", report); err == nil {
 		t.Fatal("WriteProcessing() accepted unknown format")
+	}
+}
+
+func TestProcessingReportV1RemainsStrictWithoutDetail(t *testing.T) {
+	report := NewProcessingReport("ci.yml", "")
+	report.Diagnostics = append(report.Diagnostics, Diagnostic{
+		Level: "error", Code: "E_TEST", Message: "actionable guidance", Detail: "lower-level context",
+	})
+	var encoded bytes.Buffer
+	if err := WriteProcessing(&encoded, "json", report); err != nil {
+		t.Fatal(err)
+	}
+	var document map[string]any
+	if err := json.Unmarshal(encoded.Bytes(), &document); err != nil {
+		t.Fatal(err)
+	}
+	document["schema"] = "buildkite-gha/processing-report/v1"
+	diagnostic := document["diagnostics"].([]any)[0].(map[string]any)
+	delete(diagnostic, "detail")
+
+	schemaSource, err := os.ReadFile(filepath.Join("..", "..", "schemas", "processing-report-v1.schema.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var schemaDocument any
+	if err := json.Unmarshal(schemaSource, &schemaDocument); err != nil {
+		t.Fatal(err)
+	}
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource("processing-report-v1.schema.json", schemaDocument); err != nil {
+		t.Fatal(err)
+	}
+	schema, err := compiler.Compile("processing-report-v1.schema.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := schema.Validate(document); err != nil {
+		t.Fatalf("original v1 report does not satisfy v1 schema: %v", err)
+	}
+	diagnostic["detail"] = "lower-level context"
+	if err := schema.Validate(document); err == nil {
+		t.Fatal("v1 schema accepted the v2 detail field")
 	}
 }
 

--- a/internal/compatibility/report_test.go
+++ b/internal/compatibility/report_test.go
@@ -25,7 +25,7 @@ func TestProcessingReportContainsEveryStableStageInTextAndJSON(t *testing.T) {
 	report.Actions = append(report.Actions, ActionResult{Reference: "./.github/actions/test", Job: "gha-test", Step: 1, Result: Failed})
 	report.Diagnostics = append(report.Diagnostics, Diagnostic{
 		Level: "error", Code: "E_ACTION_RESOLUTION", Category: "action-resolution",
-		Stage: "action-resolution", Message: "action metadata is invalid", Job: "test", Instance: "gha-test", Action: "./.github/actions/test", Step: 1,
+		Stage: "action-resolution", Message: "action metadata is invalid; update the action", Detail: "unsupported runtime node12", Job: "test", Instance: "gha-test", Action: "./.github/actions/test", Step: 1,
 		Location: &SourceLocation{Path: "ci.yml", Line: 8, Column: 9},
 	})
 
@@ -37,7 +37,7 @@ func TestProcessingReportContainsEveryStableStageInTextAndJSON(t *testing.T) {
 	if err := json.Unmarshal(encoded.Bytes(), &decoded); err != nil {
 		t.Fatal(err)
 	}
-	if decoded.Schema != ProcessingSchema || len(decoded.Stages) != 10 || decoded.Status != Failed {
+	if decoded.Schema != ProcessingSchema || len(decoded.Stages) != 10 || decoded.Status != Failed || decoded.Diagnostics[0].Detail != "unsupported runtime node12" {
 		t.Fatalf("decoded report = %#v", decoded)
 	}
 	schemaSource, err := os.ReadFile(filepath.Join("..", "..", "schemas", "processing-report-v1.schema.json"))
@@ -82,7 +82,8 @@ func TestProcessingReportContainsEveryStableStageInTextAndJSON(t *testing.T) {
 		"Immutable action resolution: failed",
 		"Job-plan construction: not-evaluated",
 		"action ./.github/actions/test (job gha-test, step 1): failed",
-		"[E_ACTION_RESOLUTION] action metadata is invalid",
+		"[E_ACTION_RESOLUTION] action metadata is invalid; update the action",
+		"detail: unsupported runtime node12",
 		"instance=gha-test, action=./.github/actions/test, step=1",
 	} {
 		if !strings.Contains(rendered.String(), want) {

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -112,20 +112,20 @@ func validateActionResolutions(ctx context.Context, ir IR, options Options) (Pro
 				continue
 			}
 			position := step.Span.Start
-			message, action := actionResolutionMessage(step.Uses, err)
+			message, detail, action := actionResolutionMessage(step.Uses, err)
 			diagnostics = append(diagnostics, &ProcessingFinding{
 				Stage: StageResolution, Code: CodeActionResolution, Category: "action-resolution",
 				Path: instance.SourcePath, Line: position.Line, Column: position.Column,
 				Job: instance.LogicalJobID, Instance: instance.Key, Action: action, Step: i + 1,
-				Message: message,
-				Err:     fmt.Errorf("%s:%d:%d: job %q action %q at step %d: %w", instance.SourcePath, position.Line, position.Column, instance.LogicalJobID, step.Uses, i+1, err),
+				Message: message, Detail: detail,
+				Err: fmt.Errorf("%s:%d:%d: job %q action %q at step %d: %w", instance.SourcePath, position.Line, position.Column, instance.LogicalJobID, step.Uses, i+1, err),
 			})
 		}
 	}
 	return evidence, errors.Join(diagnostics...)
 }
 
-func actionResolutionMessage(reference string, err error) (message, action string) {
+func actionResolutionMessage(reference string, err error) (message, detail, action string) {
 	action = reference
 	for {
 		var childErr *actionChildError
@@ -135,9 +135,16 @@ func actionResolutionMessage(reference string, err error) (message, action strin
 		action = childErr.child
 		err = childErr.err
 	}
+	if message, detail, ok := actionintegration.UnsupportedVersionDiagnostic(action, err); ok {
+		return message, detail, action
+	}
+	var runtimeErr *metadata.UnsupportedRuntimeError
+	if errors.As(err, &runtimeErr) {
+		return fmt.Sprintf("Action %q uses unsupported runtime %q. Set runs.using to node16, node20, node24, composite, or docker.", action, runtimeErr.Runtime), runtimeErr.Error(), action
+	}
 	reason := strings.TrimPrefix(err.Error(), fmt.Sprintf("compile action %q: ", action))
 	if strings.HasPrefix(reason, "resolve action reference: ") || strings.HasPrefix(reason, "download action source: ") {
-		return fmt.Sprintf("Action %q could not be resolved: %s", action, reason[strings.Index(reason, ": ")+2:]), action
+		return fmt.Sprintf("Action %q could not be resolved: %s", action, reason[strings.Index(reason, ": ")+2:]), "", action
 	}
 	if start := strings.Index(reason, "parse action metadata \""); start >= 0 {
 		pathStart := start + len("parse action metadata \"")
@@ -148,7 +155,7 @@ func actionResolutionMessage(reference string, err error) (message, action strin
 	if fields := unsupportedMetadataFields(reason); fields != "" {
 		reason = "action metadata uses " + fields
 	}
-	return fmt.Sprintf("Action %q is unsupported: %s", action, reason), action
+	return fmt.Sprintf("Action %q is unsupported: %s", action, reason), "", action
 }
 
 type actionChildError struct {

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -140,7 +140,14 @@ func actionResolutionMessage(reference string, err error) (message, detail, acti
 	}
 	var runtimeErr *metadata.UnsupportedRuntimeError
 	if errors.As(err, &runtimeErr) {
-		return fmt.Sprintf("Action %q uses unsupported runtime %q. Set runs.using to node16, node20, node24, composite, or docker.", action, runtimeErr.Runtime), runtimeErr.Error(), action
+		runtime := fmt.Sprintf("runtime %q", runtimeErr.Runtime)
+		if version := strings.TrimPrefix(runtimeErr.Runtime, "node"); version != runtimeErr.Runtime {
+			runtime = "Node.js " + version
+		}
+		if strings.HasPrefix(action, "./") {
+			return fmt.Sprintf("Action %q uses %s, which is unsupported. Update runs.using to node16, node20, or node24.", action, runtime), "", action
+		}
+		return fmt.Sprintf("Action %q uses %s, which is unsupported. Use an action release that supports Node.js 16, 20, or 24.", action, runtime), "", action
 	}
 	reason := strings.TrimPrefix(err.Error(), fmt.Sprintf("compile action %q: ", action))
 	if strings.HasPrefix(reason, "resolve action reference: ") || strings.HasPrefix(reason, "download action source: ") {

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -127,14 +127,17 @@ func validateActionResolutions(ctx context.Context, ir IR, options Options) (Pro
 
 func actionResolutionMessage(reference string, err error) (message, detail, action string) {
 	action = reference
+	localMetadata := true
 	for {
 		var childErr *actionChildError
 		if !errors.As(err, &childErr) {
 			break
 		}
+		localMetadata = localMetadata && childErr.parentSource == "workspace"
 		action = childErr.child
 		err = childErr.err
 	}
+	localMetadata = localMetadata && strings.HasPrefix(action, "./")
 	if message, detail, ok := actionintegration.UnsupportedVersionDiagnostic(action, err); ok {
 		return message, detail, action
 	}
@@ -144,7 +147,7 @@ func actionResolutionMessage(reference string, err error) (message, detail, acti
 		if version := strings.TrimPrefix(runtimeErr.Runtime, "node"); version != runtimeErr.Runtime {
 			runtime = "Node.js " + version
 		}
-		if strings.HasPrefix(action, "./") {
+		if localMetadata {
 			return fmt.Sprintf("Action %q uses %s, which is unsupported. Update runs.using to node16, node20, or node24.", action, runtime), "", action
 		}
 		return fmt.Sprintf("Action %q uses %s, which is unsupported. Use an action release that supports Node.js 16, 20, or 24.", action, runtime), "", action
@@ -166,8 +169,9 @@ func actionResolutionMessage(reference string, err error) (message, detail, acti
 }
 
 type actionChildError struct {
-	child string
-	err   error
+	child        string
+	parentSource string
+	err          error
 }
 
 func (e *actionChildError) Error() string { return fmt.Sprintf("child action %q: %v", e.child, e.err) }
@@ -334,7 +338,7 @@ func (b *actionLockBuilder) add(ctx context.Context, raw string, depth int) (*ac
 			}
 			child, err := b.add(ctx, step.Uses, depth+1)
 			if err != nil {
-				return nil, &actionChildError{child: step.Uses, err: err}
+				return nil, &actionChildError{child: step.Uses, parentSource: n.lock.Source, err: err}
 			}
 			if n.lock.Children == nil {
 				n.lock.Children = map[string]plan.ActionSelector{}

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -127,17 +127,14 @@ func validateActionResolutions(ctx context.Context, ir IR, options Options) (Pro
 
 func actionResolutionMessage(reference string, err error) (message, detail, action string) {
 	action = reference
-	localMetadata := true
 	for {
 		var childErr *actionChildError
 		if !errors.As(err, &childErr) {
 			break
 		}
-		localMetadata = localMetadata && childErr.parentSource == "workspace"
 		action = childErr.child
 		err = childErr.err
 	}
-	localMetadata = localMetadata && strings.HasPrefix(action, "./")
 	if message, detail, ok := actionintegration.UnsupportedVersionDiagnostic(action, err); ok {
 		return message, detail, action
 	}
@@ -147,7 +144,7 @@ func actionResolutionMessage(reference string, err error) (message, detail, acti
 		if version := strings.TrimPrefix(runtimeErr.Runtime, "node"); version != runtimeErr.Runtime {
 			runtime = "Node.js " + version
 		}
-		if localMetadata {
+		if strings.HasPrefix(action, "./") {
 			return fmt.Sprintf("Action %q uses %s, which is unsupported. Update runs.using to node16, node20, or node24.", action, runtime), "", action
 		}
 		return fmt.Sprintf("Action %q uses %s, which is unsupported. Use an action release that supports Node.js 16, 20, or 24.", action, runtime), "", action
@@ -169,9 +166,8 @@ func actionResolutionMessage(reference string, err error) (message, detail, acti
 }
 
 type actionChildError struct {
-	child        string
-	parentSource string
-	err          error
+	child string
+	err   error
 }
 
 func (e *actionChildError) Error() string { return fmt.Sprintf("child action %q: %v", e.child, e.err) }
@@ -338,7 +334,7 @@ func (b *actionLockBuilder) add(ctx context.Context, raw string, depth int) (*ac
 			}
 			child, err := b.add(ctx, step.Uses, depth+1)
 			if err != nil {
-				return nil, &actionChildError{child: step.Uses, parentSource: n.lock.Source, err: err}
+				return nil, &actionChildError{child: step.Uses, err: err}
 			}
 			if n.lock.Children == nil {
 				n.lock.Children = map[string]plan.ActionSelector{}

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -84,16 +85,16 @@ func writeAction(t *testing.T, root, name, body string) {
 func TestActionResolutionMessageExplainsUnsupportedMetadata(t *testing.T) {
 	err := errors.New("compile action \"owner/action@v1\": parse action metadata \"/tmp/download/action.yml\": yaml: unmarshal errors:\n  line 11: field type not found in type metadata.Input\n  line 16: field type not found in type metadata.Input")
 	want := `Action "owner/action@v1" is unsupported: action metadata uses unsupported field "type" at lines 11, 16`
-	if got, action := actionResolutionMessage("owner/action@v1", err); got != want || action != "owner/action@v1" {
-		t.Fatalf("actionResolutionMessage() = %q, %q; want %q, %q", got, action, want, "owner/action@v1")
+	if got, detail, action := actionResolutionMessage("owner/action@v1", err); got != want || detail != "" || action != "owner/action@v1" {
+		t.Fatalf("actionResolutionMessage() = %q, %q, %q; want %q, empty detail, %q", got, detail, action, want, "owner/action@v1")
 	}
 }
 
 func TestActionResolutionMessageDistinguishesResolutionFailure(t *testing.T) {
 	err := errors.New("resolve action reference: tag v1 was not found")
 	want := `Action "owner/action@v1" could not be resolved: tag v1 was not found`
-	if got, action := actionResolutionMessage("owner/action@v1", err); got != want || action != "owner/action@v1" {
-		t.Fatalf("actionResolutionMessage() = %q, %q; want %q, %q", got, action, want, "owner/action@v1")
+	if got, detail, action := actionResolutionMessage("owner/action@v1", err); got != want || detail != "" || action != "owner/action@v1" {
+		t.Fatalf("actionResolutionMessage() = %q, %q, %q; want %q, empty detail, %q", got, detail, action, want, "owner/action@v1")
 	}
 }
 
@@ -106,8 +107,17 @@ func TestActionResolutionMessageIdentifiesNestedChild(t *testing.T) {
 		},
 	}
 	want := `Action "owner/missing@v2" could not be resolved: tag v2 was not found`
-	if got, action := actionResolutionMessage("owner/root@v1", err); got != want || action != "owner/missing@v2" {
-		t.Fatalf("actionResolutionMessage() = %q, %q; want %q, %q", got, action, want, "owner/missing@v2")
+	if got, detail, action := actionResolutionMessage("owner/root@v1", err); got != want || detail != "" || action != "owner/missing@v2" {
+		t.Fatalf("actionResolutionMessage() = %q, %q, %q; want %q, empty detail, %q", got, detail, action, want, "owner/missing@v2")
+	}
+}
+
+func TestActionResolutionMessageMakesUnsupportedRuntimeActionable(t *testing.T) {
+	err := fmt.Errorf(`compile action "owner/action@v1": %w`, &metadata.UnsupportedRuntimeError{Runtime: "node12"})
+	want := `Action "owner/action@v1" uses unsupported runtime "node12". Set runs.using to node16, node20, node24, composite, or docker.`
+	message, detail, action := actionResolutionMessage("owner/action@v1", err)
+	if message != want || detail != `unsupported runtime "node12"` || action != "owner/action@v1" {
+		t.Fatalf("actionResolutionMessage() = %q, %q, %q", message, detail, action)
 	}
 }
 

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -100,10 +100,10 @@ func TestActionResolutionMessageDistinguishesResolutionFailure(t *testing.T) {
 
 func TestActionResolutionMessageIdentifiesNestedChild(t *testing.T) {
 	err := &actionChildError{
-		child: "owner/composite@v1", parentSource: "workspace",
+		child: "owner/composite@v1",
 		err: &actionChildError{
-			child: "owner/missing@v2", parentSource: "github",
-			err: errors.New(`compile action "owner/missing@v2": resolve action reference: tag v2 was not found`),
+			child: "owner/missing@v2",
+			err:   errors.New(`compile action "owner/missing@v2": resolve action reference: tag v2 was not found`),
 		},
 	}
 	want := `Action "owner/missing@v2" could not be resolved: tag v2 was not found`
@@ -135,13 +135,12 @@ func TestActionResolutionMessageMakesUnsupportedRuntimeActionable(t *testing.T) 
 	}
 }
 
-func TestActionResolutionMessageTreatsPublicCompositeChildrenAsPublic(t *testing.T) {
+func TestActionResolutionMessageTreatsNestedWorkspaceChildrenAsLocal(t *testing.T) {
 	err := &actionChildError{
-		child:        "./child",
-		parentSource: "github",
-		err:          fmt.Errorf(`compile action "./child": %w`, &metadata.UnsupportedRuntimeError{Runtime: "node12"}),
+		child: "./child",
+		err:   fmt.Errorf(`compile action "./child": %w`, &metadata.UnsupportedRuntimeError{Runtime: "node12"}),
 	}
-	want := `Action "./child" uses Node.js 12, which is unsupported. Use an action release that supports Node.js 16, 20, or 24.`
+	want := `Action "./child" uses Node.js 12, which is unsupported. Update runs.using to node16, node20, or node24.`
 	if got, detail, action := actionResolutionMessage("owner/composite@v1", err); got != want || detail != "" || action != "./child" {
 		t.Fatalf("actionResolutionMessage() = %q, %q, %q; want %q, empty detail, %q", got, detail, action, want, "./child")
 	}

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -114,10 +114,24 @@ func TestActionResolutionMessageIdentifiesNestedChild(t *testing.T) {
 
 func TestActionResolutionMessageMakesUnsupportedRuntimeActionable(t *testing.T) {
 	err := fmt.Errorf(`compile action "owner/action@v1": %w`, &metadata.UnsupportedRuntimeError{Runtime: "node12"})
-	want := `Action "owner/action@v1" uses unsupported runtime "node12". Set runs.using to node16, node20, node24, composite, or docker.`
-	message, detail, action := actionResolutionMessage("owner/action@v1", err)
-	if message != want || detail != `unsupported runtime "node12"` || action != "owner/action@v1" {
-		t.Fatalf("actionResolutionMessage() = %q, %q, %q", message, detail, action)
+	tests := []struct {
+		reference string
+		want      string
+	}{
+		{
+			reference: "owner/action@v1",
+			want:      `Action "owner/action@v1" uses Node.js 12, which is unsupported. Use an action release that supports Node.js 16, 20, or 24.`,
+		},
+		{
+			reference: "./local-action",
+			want:      `Action "./local-action" uses Node.js 12, which is unsupported. Update runs.using to node16, node20, or node24.`,
+		},
+	}
+	for _, test := range tests {
+		message, detail, action := actionResolutionMessage(test.reference, err)
+		if message != test.want || detail != "" || action != test.reference {
+			t.Fatalf("actionResolutionMessage(%q) = %q, %q, %q", test.reference, message, detail, action)
+		}
 	}
 }
 

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -100,10 +100,10 @@ func TestActionResolutionMessageDistinguishesResolutionFailure(t *testing.T) {
 
 func TestActionResolutionMessageIdentifiesNestedChild(t *testing.T) {
 	err := &actionChildError{
-		child: "owner/composite@v1",
+		child: "owner/composite@v1", parentSource: "workspace",
 		err: &actionChildError{
-			child: "owner/missing@v2",
-			err:   errors.New(`compile action "owner/missing@v2": resolve action reference: tag v2 was not found`),
+			child: "owner/missing@v2", parentSource: "github",
+			err: errors.New(`compile action "owner/missing@v2": resolve action reference: tag v2 was not found`),
 		},
 	}
 	want := `Action "owner/missing@v2" could not be resolved: tag v2 was not found`
@@ -132,6 +132,18 @@ func TestActionResolutionMessageMakesUnsupportedRuntimeActionable(t *testing.T) 
 		if message != test.want || detail != "" || action != test.reference {
 			t.Fatalf("actionResolutionMessage(%q) = %q, %q, %q", test.reference, message, detail, action)
 		}
+	}
+}
+
+func TestActionResolutionMessageTreatsPublicCompositeChildrenAsPublic(t *testing.T) {
+	err := &actionChildError{
+		child:        "./child",
+		parentSource: "github",
+		err:          fmt.Errorf(`compile action "./child": %w`, &metadata.UnsupportedRuntimeError{Runtime: "node12"}),
+	}
+	want := `Action "./child" uses Node.js 12, which is unsupported. Use an action release that supports Node.js 16, 20, or 24.`
+	if got, detail, action := actionResolutionMessage("owner/composite@v1", err); got != want || detail != "" || action != "./child" {
+		t.Fatalf("actionResolutionMessage() = %q, %q, %q; want %q, empty detail, %q", got, detail, action, want, "./child")
 	}
 }
 

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -1016,10 +1016,11 @@ func expand(path string, source []byte, parsed *workflow.Workflow, context expre
 			if runsOnErr == nil {
 				target, err = options.Runners.resolve(labels, options.EventTrust)
 				if err != nil {
+					message, detail := runnerRejectionDiagnostic(err, reportableRunnerLabels(job, labels), options.Runners.supportedLabels(), options.Runners.UntrustedQueues)
 					finding := &ProcessingFinding{
 						Stage: StageExpressions, Code: CodeExpressionInvalid, Category: "compatibility",
 						Path: jobPath, Line: runsOnPosition(job).Line, Column: runsOnPosition(job).Column,
-						Job: job.ID, Instance: key, Message: runnerRejectionMessage(err, reportableRunnerLabels(job, labels), options.Runners.supportedLabels()),
+						Job: job.ID, Instance: key, Message: message, Detail: detail,
 						Err: locatedJobError(jobPath, job, runsOnPosition(job).Line, runsOnPosition(job).Column, err.Error()),
 					}
 					diagnostics = append(diagnostics, finding)

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1267,6 +1268,10 @@ jobs:
 		_, err := Compile(path, readFile(t, path), readFile(t, smokePath("events", "push.json")))
 		if err == nil || !strings.Contains(err.Error(), `input "target" is not statically resolvable`) || !strings.Contains(err.Error(), "./.github/workflows/caller.yml:6:15") {
 			t.Fatalf("Compile() error = %v, want source-located runtime input rejection", err)
+		}
+		var finding *ProcessingFinding
+		if !errors.As(err, &finding) || finding.Message != `Reusable workflow input "target" uses the needs context, which is unavailable before jobs run. Replace it with a literal or an expression that does not depend on job results.` || !strings.Contains(finding.Detail, `Reusable-workflow input "target" is not statically resolvable`) || !strings.Contains(finding.Detail, `unsupported compile-time context "needs"`) {
+			t.Fatalf("Compile() finding = %#v", finding)
 		}
 	})
 

--- a/internal/compiler/config.go
+++ b/internal/compiler/config.go
@@ -350,7 +350,7 @@ func runnerRejectionDiagnostic(err error, labels, supported, untrustedQueues []s
 	case reasonNoLabels:
 		return "runs-on resolves to no runner labels. Set runs-on to a mapped Linux or macOS runner label.", detail
 	case reasonDuplicateLabel:
-		return "runs-on contains a duplicate runner label. Remove duplicate labels from runs-on.", detail
+		return "runs-on contains a duplicate runner label. Remove duplicate labels from runs-on.", ""
 	case reasonUnsupportedOS:
 		return fmt.Sprintf("Runner label%s requires Windows, which is unsupported. Use a Linux or macOS runner label.", label), detail
 	case reasonUnmappedLabel:
@@ -358,14 +358,14 @@ func runnerRejectionDiagnostic(err error, labels, supported, untrustedQueues []s
 	case reasonConflictingQueues, reasonConflictingTarget:
 		return "runs-on labels map to conflicting runner targets. Use labels that map to one runner target.", detail
 	case reasonUntrustedDefault:
-		return "This untrusted event cannot use the default runner target. Map runs-on to a queue allowed for untrusted events.", detail
+		return "This untrusted event cannot use the default runner. Use a runner label allowed for untrusted events, or ask an administrator to configure one.", detail
 	case reasonUntrustedQueue:
 		queues := append([]string(nil), untrustedQueues...)
 		sort.Strings(queues)
 		if len(queues) != 0 {
 			detail = "Queues allowed for untrusted events: " + strings.Join(queues, ", ") + "."
 		}
-		return "This untrusted event targets a disallowed queue. Add the queue to the untrusted-event allowlist or use an allowed queue.", detail
+		return "This untrusted event uses a runner that is not allowed for untrusted events. Use an allowed runner label, or ask an administrator to allow its queue.", detail
 	default:
 		return "Runner target is unsupported. Use a configured Linux or macOS runner target.", detail
 	}

--- a/internal/compiler/config.go
+++ b/internal/compiler/config.go
@@ -332,29 +332,42 @@ func (policy RunnerPolicy) resolve(labels []string, trust EventTrust) (RunnerTar
 	return target, nil
 }
 
-// runnerRejectionMessage renders a rejected runs-on resolution. Callers pass
-// labels only when they came from workflow-authored static data.
-func runnerRejectionMessage(err error, labels, supported []string) string {
-	const message = "runner target is unsupported"
+// runnerRejectionDiagnostic renders a rejected runs-on resolution. Callers
+// pass labels only when they came from workflow-authored static data.
+func runnerRejectionDiagnostic(err error, labels, supported, untrustedQueues []string) (message, detail string) {
 	var rejection *runnerPolicyRejection
 	if !errors.As(err, &rejection) {
-		return message
+		return "Runner target is unsupported. Use a configured Linux or macOS runner target.", ""
 	}
 	label := ""
 	if len(labels) == 1 {
 		label = fmt.Sprintf(" %q", labels[0])
 	}
-	supportedTargets := "a configured runner target"
 	if len(supported) != 0 {
-		supportedTargets = strings.Join(supported, ", ")
+		detail = "Supported runner labels: " + strings.Join(supported, ", ") + "."
 	}
 	switch rejection.reason {
+	case reasonNoLabels:
+		return "runs-on resolves to no runner labels. Set runs-on to a mapped Linux or macOS runner label.", detail
+	case reasonDuplicateLabel:
+		return "runs-on contains a duplicate runner label. Remove duplicate labels from runs-on.", detail
 	case reasonUnsupportedOS:
-		return fmt.Sprintf("Runner label%s uses an unsupported operating system (Windows); supported runner labels: %s", label, supportedTargets)
+		return fmt.Sprintf("Runner label%s requires Windows, which is unsupported. Use a Linux or macOS runner label.", label), detail
 	case reasonUnmappedLabel:
-		return fmt.Sprintf("Runner label%s is not mapped to a runner target; configure a runner-target mapping for this label or use %s", label, supportedTargets)
+		return fmt.Sprintf("Runner label%s has no runner-target mapping. Configure a mapping for this label or use a mapped runner label.", label), detail
+	case reasonConflictingQueues, reasonConflictingTarget:
+		return "runs-on labels map to conflicting runner targets. Use labels that map to one runner target.", detail
+	case reasonUntrustedDefault:
+		return "This untrusted event cannot use the default runner target. Map runs-on to a queue allowed for untrusted events.", detail
+	case reasonUntrustedQueue:
+		queues := append([]string(nil), untrustedQueues...)
+		sort.Strings(queues)
+		if len(queues) != 0 {
+			detail = "Queues allowed for untrusted events: " + strings.Join(queues, ", ") + "."
+		}
+		return "This untrusted event targets a disallowed queue. Add the queue to the untrusted-event allowlist or use an allowed queue.", detail
 	default:
-		return message + ": " + rejection.reason
+		return "Runner target is unsupported. Use a configured Linux or macOS runner target.", detail
 	}
 }
 

--- a/internal/compiler/config_test.go
+++ b/internal/compiler/config_test.go
@@ -228,7 +228,7 @@ func TestRunsOnPolicyFailsClosedWithLocatedDiagnostics(t *testing.T) {
 	}
 }
 
-func TestRunnerRejectionMessageNamesReasonWithoutResolvedLabel(t *testing.T) {
+func TestRunnerRejectionDiagnosticIsActionableWithoutResolvedLabel(t *testing.T) {
 	policy := RunnerPolicy{
 		Labels:          map[string]string{"ubuntu-24.04": "linux", "self-hosted": "one", "linux": "two", "default": ""},
 		Targets:         map[string]RunnerTarget{"macos": {Queue: "macos", Platform: PlatformDarwinARM64}},
@@ -240,14 +240,14 @@ func TestRunnerRejectionMessageNamesReasonWithoutResolvedLabel(t *testing.T) {
 		trust  EventTrust
 		want   string
 	}{
-		{name: "no labels", trust: EventTrusted, want: reasonNoLabels},
-		{name: "duplicate label", labels: []string{"ubuntu-24.04", "ubuntu-24.04"}, trust: EventTrusted, want: reasonDuplicateLabel},
-		{name: "unsupported operating system", labels: []string{"windows-latest"}, trust: EventTrusted, want: reasonUnsupportedOS},
-		{name: "unmapped label", labels: []string{"macos-15"}, trust: EventTrusted, want: reasonUnmappedLabel},
-		{name: "conflicting queues", labels: []string{"self-hosted", "linux"}, trust: EventTrusted, want: reasonConflictingQueues},
-		{name: "conflicting targets", labels: []string{"ubuntu-24.04", "macos"}, trust: EventTrusted, want: reasonConflictingTarget},
-		{name: "untrusted default targeting", labels: []string{"default"}, trust: EventUntrusted, want: reasonUntrustedDefault},
-		{name: "untrusted queue", labels: []string{"ubuntu-24.04"}, trust: EventUntrusted, want: reasonUntrustedQueue},
+		{name: "no labels", trust: EventTrusted, want: "Set runs-on"},
+		{name: "duplicate label", labels: []string{"ubuntu-24.04", "ubuntu-24.04"}, trust: EventTrusted, want: "Remove duplicate labels"},
+		{name: "unsupported operating system", labels: []string{"windows-latest"}, trust: EventTrusted, want: "Use a Linux or macOS runner label"},
+		{name: "unmapped label", labels: []string{"macos-15"}, trust: EventTrusted, want: "Configure a mapping"},
+		{name: "conflicting queues", labels: []string{"self-hosted", "linux"}, trust: EventTrusted, want: "Use labels that map to one runner target"},
+		{name: "conflicting targets", labels: []string{"ubuntu-24.04", "macos"}, trust: EventTrusted, want: "Use labels that map to one runner target"},
+		{name: "untrusted default targeting", labels: []string{"default"}, trust: EventUntrusted, want: "Map runs-on to a queue allowed"},
+		{name: "untrusted queue", labels: []string{"ubuntu-24.04"}, trust: EventUntrusted, want: "Add the queue"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -255,33 +255,34 @@ func TestRunnerRejectionMessageNamesReasonWithoutResolvedLabel(t *testing.T) {
 			if err == nil {
 				t.Fatal("resolve() error = nil, want rejection")
 			}
-			message := runnerRejectionMessage(err, nil, []string{"ubuntu-latest"})
-			if !strings.Contains(message, test.want) && !strings.Contains(message, "unsupported operating system") && !strings.Contains(message, "not mapped") {
-				t.Fatalf("runnerRejectionMessage() = %q, want reason %q", message, test.want)
+			message, _ := runnerRejectionDiagnostic(err, nil, []string{"ubuntu-latest"}, policy.UntrustedQueues)
+			if !strings.Contains(message, test.want) {
+				t.Fatalf("runnerRejectionDiagnostic() = %q, want %q", message, test.want)
 			}
 		})
 	}
 }
 
-func TestRunnerRejectionMessageFallsBackWhenUnclassified(t *testing.T) {
-	if message := runnerRejectionMessage(errors.New("boom"), nil, nil); message != "runner target is unsupported" {
-		t.Fatalf("runnerRejectionMessage() = %q, want the bare policy message", message)
+func TestRunnerRejectionDiagnosticFallsBackWhenUnclassified(t *testing.T) {
+	message, detail := runnerRejectionDiagnostic(errors.New("boom"), nil, nil, nil)
+	if message != "Runner target is unsupported. Use a configured Linux or macOS runner target." || detail != "" {
+		t.Fatalf("runnerRejectionDiagnostic() = %q, %q", message, detail)
 	}
 }
 
-func TestRunnerRejectionMessageNamesStaticLabelAndSupportedTargets(t *testing.T) {
+func TestRunnerRejectionDiagnosticSeparatesStaticLabelFromAllowlist(t *testing.T) {
 	supported := []string{"ubuntu-22.04", "ubuntu-24.04", "ubuntu-latest"}
 	tests := []struct {
-		label string
-		want  string
+		label       string
+		wantMessage string
 	}{
 		{
-			label: "windows-latest",
-			want:  `Runner label "windows-latest" uses an unsupported operating system (Windows); supported runner labels: ubuntu-22.04, ubuntu-24.04, ubuntu-latest`,
+			label:       "windows-latest",
+			wantMessage: `Runner label "windows-latest" requires Windows, which is unsupported. Use a Linux or macOS runner label.`,
 		},
 		{
-			label: "macos-latest",
-			want:  `Runner label "macos-latest" is not mapped to a runner target; configure a runner-target mapping for this label or use ubuntu-22.04, ubuntu-24.04, ubuntu-latest`,
+			label:       "macos-latest",
+			wantMessage: `Runner label "macos-latest" has no runner-target mapping. Configure a mapping for this label or use a mapped runner label.`,
 		},
 	}
 	policy := RunnerPolicy{Targets: map[string]RunnerTarget{
@@ -294,8 +295,12 @@ func TestRunnerRejectionMessageNamesStaticLabelAndSupportedTargets(t *testing.T)
 		if err == nil {
 			t.Fatalf("resolve(%q) error = nil", test.label)
 		}
-		if got := runnerRejectionMessage(err, []string{test.label}, supported); got != test.want {
-			t.Fatalf("runnerRejectionMessage(%q) = %q, want %q", test.label, got, test.want)
+		message, detail := runnerRejectionDiagnostic(err, []string{test.label}, supported, nil)
+		if message != test.wantMessage || detail != "Supported runner labels: ubuntu-22.04, ubuntu-24.04, ubuntu-latest." {
+			t.Fatalf("runnerRejectionDiagnostic(%q) = %q, %q", test.label, message, detail)
+		}
+		if strings.Contains(message, "ubuntu-22.04") {
+			t.Fatalf("runner allowlist leaked into message: %q", message)
 		}
 	}
 }

--- a/internal/compiler/config_test.go
+++ b/internal/compiler/config_test.go
@@ -246,8 +246,8 @@ func TestRunnerRejectionDiagnosticIsActionableWithoutResolvedLabel(t *testing.T)
 		{name: "unmapped label", labels: []string{"macos-15"}, trust: EventTrusted, want: "Configure a mapping"},
 		{name: "conflicting queues", labels: []string{"self-hosted", "linux"}, trust: EventTrusted, want: "Use labels that map to one runner target"},
 		{name: "conflicting targets", labels: []string{"ubuntu-24.04", "macos"}, trust: EventTrusted, want: "Use labels that map to one runner target"},
-		{name: "untrusted default targeting", labels: []string{"default"}, trust: EventUntrusted, want: "Map runs-on to a queue allowed"},
-		{name: "untrusted queue", labels: []string{"ubuntu-24.04"}, trust: EventUntrusted, want: "Add the queue"},
+		{name: "untrusted default targeting", labels: []string{"default"}, trust: EventUntrusted, want: "Use a runner label allowed for untrusted events"},
+		{name: "untrusted queue", labels: []string{"ubuntu-24.04"}, trust: EventUntrusted, want: "ask an administrator to allow its queue"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -260,6 +260,18 @@ func TestRunnerRejectionDiagnosticIsActionableWithoutResolvedLabel(t *testing.T)
 				t.Fatalf("runnerRejectionDiagnostic() = %q, want %q", message, test.want)
 			}
 		})
+	}
+}
+
+func TestRunnerRejectionDiagnosticOmitsIrrelevantAllowlistForDuplicateLabel(t *testing.T) {
+	policy := RunnerPolicy{Labels: map[string]string{"ubuntu-24.04": "linux"}}
+	_, err := policy.resolve([]string{"ubuntu-24.04", "ubuntu-24.04"}, EventTrusted)
+	if err == nil {
+		t.Fatal("resolve() error = nil, want duplicate-label rejection")
+	}
+	message, detail := runnerRejectionDiagnostic(err, nil, []string{"ubuntu-24.04"}, nil)
+	if message != "runs-on contains a duplicate runner label. Remove duplicate labels from runs-on." || detail != "" {
+		t.Fatalf("runnerRejectionDiagnostic() = %q, %q", message, detail)
 	}
 }
 

--- a/internal/compiler/processing.go
+++ b/internal/compiler/processing.go
@@ -48,7 +48,10 @@ type ProcessingFinding struct {
 	// Message replaces Err's text in the rendered report. Set it whenever Err
 	// can quote event-derived data, so that data cannot reach the report.
 	Message string
-	Err     error
+	// Detail adds lower-level diagnostic information after Message. It must not
+	// contain event-derived data.
+	Detail string
+	Err    error
 }
 
 func (e *ProcessingFinding) Error() string { return e.Err.Error() }

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -519,7 +519,17 @@ func resolveCallInputs(path string, job workflow.Job, call *workflow.ReusableWor
 			var err error
 			resolved, err = evaluateStaticCallValue(text, parentInputs, matrix, context)
 			if err != nil {
-				return nil, locatedJobError(path, job, value.Span.Start.Line, value.Span.Start.Column, fmt.Sprintf("reusable-workflow input %q is not statically resolvable: %v", name, err))
+				detail := fmt.Sprintf("Reusable-workflow input %q is not statically resolvable: %v", name, err)
+				message := fmt.Sprintf("Reusable workflow input %q uses a value that is unavailable before jobs run. Replace it with a literal or an expression that does not depend on job results.", name)
+				if strings.Contains(err.Error(), `unsupported compile-time context "needs"`) {
+					message = fmt.Sprintf("Reusable workflow input %q uses the needs context, which is unavailable before jobs run. Replace it with a literal or an expression that does not depend on job results.", name)
+				}
+				return nil, &ProcessingFinding{
+					Stage: StageGraph, Code: CodeGraphInvalid, Category: "compatibility",
+					Path: path, Line: value.Span.Start.Line, Column: value.Span.Start.Column, Job: job.ID,
+					Message: message, Detail: detail,
+					Err: locatedJobError(path, job, value.Span.Start.Line, value.Span.Start.Column, detail),
+				}
 			}
 		}
 		values[name] = resolved

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -3,6 +3,7 @@ package compiler
 import (
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -304,10 +305,17 @@ func (resolver *reusableResolver) resolve(path, digest string, parsed *workflow.
 			calleeResolution, err := resolver.resolve(calleeSourcePath, calleeDigest, callee, callNamespace, callLabel, callInputs, needBindings, calleePermissionCeiling, secretAuthority && call.InheritSecrets, depth+1)
 			resolver.stack = resolver.stack[:len(resolver.stack)-1]
 			if err != nil {
+				message := "local reusable workflow could not be resolved"
+				detail := ""
+				var finding *ProcessingFinding
+				if errors.As(err, &finding) {
+					message = finding.Message
+					detail = finding.Detail
+				}
 				return reusableResolution{}, &ProcessingFinding{
 					Stage: StageGraph, Code: CodeGraphInvalid, Category: "compatibility",
 					Path: path, Line: call.Span.Start.Line, Column: call.Span.Start.Column, Job: job.ID,
-					Message: "local reusable workflow could not be resolved",
+					Message: message, Detail: detail,
 					Err: locatedJobError(path, job, call.Span.Start.Line, call.Span.Start.Column,
 						fmt.Sprintf("resolve local reusable workflow %q: %v", call.Uses, err)),
 				}

--- a/schemas/processing-report-v1.schema.json
+++ b/schemas/processing-report-v1.schema.json
@@ -104,6 +104,7 @@
         "category": {"enum": ["syntax", "compatibility", "action-resolution", "environment", "admission"]},
         "stage": {"$ref": "#/$defs/stageID"},
         "message": {"type": "string", "minLength": 1, "maxLength": 16384},
+        "detail": {"type": "string", "minLength": 1, "maxLength": 16384},
         "location": {"$ref": "#/$defs/location"},
         "job": {"type": "string", "minLength": 1, "maxLength": 255},
         "instance": {"type": "string", "minLength": 1, "maxLength": 255},

--- a/schemas/processing-report-v2.schema.json
+++ b/schemas/processing-report-v2.schema.json
@@ -1,12 +1,12 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://buildkite.com/schemas/buildkite-gha/processing-report-v1.schema.json",
-  "title": "buildkite-gha processing report v1",
+  "$id": "https://buildkite.com/schemas/buildkite-gha/processing-report-v2.schema.json",
+  "title": "buildkite-gha processing report v2",
   "type": "object",
   "additionalProperties": false,
   "required": ["schema", "workflow", "result", "status", "logical_jobs", "instances", "compile", "admission", "stages", "jobs", "actions", "diagnostics"],
   "properties": {
-    "schema": {"const": "buildkite-gha/processing-report/v1"},
+    "schema": {"const": "buildkite-gha/processing-report/v2"},
     "workflow": {"type": "string", "minLength": 1, "maxLength": 4096},
     "profile": {"type": "string", "maxLength": 128},
     "result": {"type": "string", "minLength": 1, "maxLength": 128},
@@ -104,6 +104,7 @@
         "category": {"enum": ["syntax", "compatibility", "action-resolution", "environment", "admission"]},
         "stage": {"$ref": "#/$defs/stageID"},
         "message": {"type": "string", "minLength": 1, "maxLength": 16384},
+        "detail": {"type": "string", "minLength": 1, "maxLength": 16384},
         "location": {"$ref": "#/$defs/location"},
         "job": {"type": "string", "minLength": 1, "maxLength": 255},
         "instance": {"type": "string", "minLength": 1, "maxLength": 255},


### PR DESCRIPTION
## Summary

- Separate concise, corrective compatibility guidance in `message` from optional lower-level `detail` across text, JSON, Buildkite annotations, and generated failure artifacts.
- Make unsupported checkout, upload, download, cache, action-runtime, runner-target, and hosted-cache diagnostics lead with user-visible causes and supported next steps.
- Keep immutable commit sets and runner policy allowlists in diagnostic detail, and document the contract in `docs/compatibility.md`.

Refs #128

## Example Buildkite annotation

<blockquote>
  <strong>actions/upload-artifact v6.0.2 is unsupported.</strong><br>
  Use a supported version from the <a href="https://github.com/buildkite/buildkite-gha/blob/main/docs/compatibility.md#upload-artifact-action">compatibility reference</a>.
  <details>
    <summary>Diagnostic detail</summary>
    <code>actions/upload-artifact native adapter does not admit resolved commit "…"; supported commits are v4.6.2 (…), v5.0.0 (…), v6.0.0 (…), v7.0.1 (…)</code>
  </details>
</blockquote>

The primary message gives the user-visible cause and next step. The collapsed detail retains immutable commits, adapter boundaries, and allowlists for debugging.

## Validation

- `mise exec -- go test ./internal/action/integration ./internal/action/metadata ./internal/compatibility ./internal/compiler ./internal/cli`
- `mise run check` (format, Linux and macOS builds, tests, race tests, vet, local smoke inventory, release configuration, Go lint, and shell lint; passed in 84.04s)

