### PR TITLE
Override GITHUB_SERVER_URL for actions/cache to avoid GHES misdetection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 dist/
 .release/
+.idea/
 
 # This repository intentionally tracks its reviewed DeepSec configuration.
 !/.deepsec/

--- a/internal/runtime/cache_service.go
+++ b/internal/runtime/cache_service.go
@@ -18,6 +18,12 @@ const (
 	cacheCredentialResponseLimit = 64 << 10
 	cacheActionToolPath          = "/usr/local/bin:/usr/bin:/bin"
 	defaultCacheResultsURL       = "https://ghacs.buildkite.com/"
+
+	// githubServerURLOverride is the synthetic, non-resolvable server URL
+	// substituted in when shouldOverrideGitHubServerURL reports true, so
+	// actions/cache's isGhes() check doesn't force the unsupported cache-v1
+	// path. Only its ".localhost" suffix is load-bearing.
+	githubServerURLOverride = "https://buildkite-gha.localhost"
 )
 
 var cacheRuntimeTokenPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$`)
@@ -214,6 +220,23 @@ func removeCacheServiceEnvironment(env map[string]string) map[string]string {
 	return clean
 }
 
+// shouldOverrideGitHubServerURL reports whether serverURL needs to be
+// replaced with githubServerURLOverride before starting actions/cache: its
+// isGhes() forces the unsupported cache-v1 path for every host outside its
+// own allowlist (github.com, *.ghe.com, *.localhost). Malformed/empty values
+// are left untouched.
+func shouldOverrideGitHubServerURL(serverURL string) bool {
+	u, err := url.Parse(serverURL)
+	if err != nil || u.Hostname() == "" {
+		return false
+	}
+	host := strings.ToUpper(strings.TrimRight(u.Hostname(), " "))
+	isGitHub := host == "GITHUB.COM"
+	isGheCloud := strings.HasSuffix(host, ".GHE.COM")
+	isLocal := strings.HasSuffix(host, ".LOCALHOST")
+	return !isGitHub && !isGheCloud && !isLocal
+}
+
 func isolateCacheActionEnvironment(env map[string]string) map[string]string {
 	isolated := removeCacheServiceEnvironment(env)
 	for _, name := range []string{
@@ -224,6 +247,9 @@ func isolateCacheActionEnvironment(env map[string]string) map[string]string {
 		"BUILDKITE_AGENT_ACCESS_TOKEN", "BUILDKITE_JOB_ID",
 	} {
 		delete(isolated, name)
+	}
+	if shouldOverrideGitHubServerURL(isolated["GITHUB_SERVER_URL"]) {
+		isolated["GITHUB_SERVER_URL"] = githubServerURLOverride
 	}
 	isolated["PATH"] = cacheActionToolPath
 	return isolated

--- a/internal/runtime/cache_service_test.go
+++ b/internal/runtime/cache_service_test.go
@@ -371,6 +371,62 @@ console.log("ordinary-credential=" + process.env.ACTIONS_RUNTIME_TOKEN);
 	}
 }
 
+func TestShouldOverrideGitHubServerURL(t *testing.T) {
+	cases := []struct {
+		name      string
+		serverURL string
+		want      bool
+	}{
+		{"github.com", "https://github.com", false},
+		{"ghe.com cloud", "https://x.ghe.com", false},
+		{"dot-localhost", "https://buildkite-gha.localhost", false},
+		{"cursor origin", "https://origin.cursor.com", true},
+		{"real GHES", "https://ghe.corp", true},
+		{"empty", "", false},
+		{"malformed", "://bad", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := shouldOverrideGitHubServerURL(c.serverURL); got != c.want {
+				t.Fatalf("shouldOverrideGitHubServerURL(%q) = %v, want %v", c.serverURL, got, c.want)
+			}
+		})
+	}
+}
+
+func TestIsolateCacheActionEnvironmentOverridesGitHubServerURLWhenNeeded(t *testing.T) {
+	env := map[string]string{
+		"GITHUB_SERVER_URL":            "https://origin.cursor.com",
+		"ACTIONS_CACHE_SERVICE_V2":     "true",
+		"ACTIONS_RESULTS_URL":          "https://ghacs.buildkite.com/",
+		"ACTIONS_RUNTIME_TOKEN":        "a.b.c",
+		"BUILDKITE_AGENT_ACCESS_TOKEN": "secret",
+		"BUILDKITE_JOB_ID":             "job-id",
+	}
+	isolated := isolateCacheActionEnvironment(env)
+	if got := isolated["GITHUB_SERVER_URL"]; got != githubServerURLOverride {
+		t.Fatalf("GITHUB_SERVER_URL = %q, want %q", got, githubServerURLOverride)
+	}
+	if isolated["PATH"] != cacheActionToolPath {
+		t.Fatalf("PATH = %q, want %q", isolated["PATH"], cacheActionToolPath)
+	}
+	for _, name := range []string{"BUILDKITE_AGENT_ACCESS_TOKEN", "BUILDKITE_JOB_ID"} {
+		if _, ok := isolated[name]; ok {
+			t.Fatalf("%s should have been stripped from the isolated environment", name)
+		}
+	}
+}
+
+func TestIsolateCacheActionEnvironmentLeavesRealGitHubServerURLUnchanged(t *testing.T) {
+	env := map[string]string{
+		"GITHUB_SERVER_URL": "https://github.com",
+	}
+	isolated := isolateCacheActionEnvironment(env)
+	if got := isolated["GITHUB_SERVER_URL"]; got != "https://github.com" {
+		t.Fatalf("GITHUB_SERVER_URL = %q, want unchanged https://github.com", got)
+	}
+}
+
 func TestActionCacheRedactorIsPinnedBeforeWorkflowExecution(t *testing.T) {
 	node := requireNode24(t)
 	workspace := t.TempDir()


### PR DESCRIPTION
## Problem

In the Cursor origin, `actions/cache` logs and skips caching:

```
[warning]Cache action is only supported on GHES version >= 3.5. If you are on version >=3.5 Please check with GHES admin ...
```

## Root cause

`actions/cache`'s bundled `isGhes()` decides "is this GHES?" purely from the `GITHUB_SERVER_URL` hostname, allowlisting only `github.com`, `*.ghe.com`, and `*.localhost`. The Cursor origin sets `GITHUB_SERVER_URL=https://origin.cursor.com`, which matches none of those, so `isGhes()` returns true. That forces the action onto the unsupported cache-v1 path, even though the Buildkite runtime only provisions a cache-v2 backend (`ACTIONS_CACHE_SERVICE_V2`, `ACTIONS_RESULTS_URL`, `ACTIONS_RUNTIME_TOKEN`), so the availability check fails and caching is skipped entirely.

## Fix

Override `GITHUB_SERVER_URL` to a synthetic `.localhost` host (`https://buildkite-gha.localhost`), but only for the cache action's own subprocess environment, and only when the real value would be misdetected as GHES:

- `shouldOverrideGitHubServerURL` mirrors `actions/cache`'s own hostname allowlist to detect misdetection.
- `isolateCacheActionEnvironment` applies the override only when needed, so cache-compatible actions like `setup-go` (which share `cacheActionEnvironment` but not this isolation path) keep their genuine `GITHUB_SERVER_URL`.

This is scoped narrowly: `GITHUB_SERVER_URL` is referenced only by `isGhes()` inside the cache action's dist bundles, and cache traffic targets `ACTIONS_RESULTS_URL`, so the non-resolvable `.localhost` host is never contacted.

## Tests

- `TestShouldOverrideGitHubServerURL`: table test covering github.com, `*.ghe.com`, `*.localhost`, the Cursor origin, real GHES, empty, and malformed inputs.
- `TestIsolateCacheActionEnvironmentOverridesGitHubServerURLWhenNeeded`: confirms the override applies and existing isolation guarantees (PATH forced, secrets stripped) still hold.
- `TestIsolateCacheActionEnvironmentLeavesRealGitHubServerURLUnchanged`: confirms `github.com` passes through untouched.

## Verify

```
mise exec -- go test ./internal/runtime/...
mise run check
```

Both green locally.