### PR TITLE
Document compatibility template dependency

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,5 +1,7 @@
 # GitHub Actions compatibility
 
+<!-- # (internal) If this is ever moved, please update the GitHub Actions template -->
+
 This page defines the initial production contract for `buildkite-gha`. It applies to the `hosted` profile used by `upload` and the Buildkite plugin.
 
 The released plugin path supports Linux x86-64 and native macOS arm64 importers

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,6 +1,6 @@
 # GitHub Actions compatibility
 
-<!-- # (internal) If this is ever moved, please update the GitHub Actions template -->
+<!-- (internal) If this file is ever moved, please update the GitHub Actions template -->
 
 This page defines the initial production contract for `buildkite-gha`. It applies to the `hosted` profile used by `upload` and the Buildkite plugin.
 


### PR DESCRIPTION
## Summary

Add an internal maintenance comment noting that moving the compatibility document requires updating the GitHub Actions template. Keep the note hidden from rendered documentation with an HTML comment.

## Validation

- `git diff --check origin/main...HEAD`
- Verified the PR changes only `docs/compatibility.md`