### PR TITLE
Fix cache detection in setup actions

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -631,7 +631,7 @@ Only ZIPs produced by the supported upload adapter are accepted. Digest or ZIP v
 
 The hosted profile also admits the exact v5.0.3 and v5.1.0 commits for runtime-proof collection. They are not part of the public compatibility contract until that hosted proof is complete. Other v5 commits, v4, and unknown v6 commits remain unsupported.
 
-JavaScript and Docker actions with compatible bundled cache clients, such as `actions/setup-go`, also receive job-bound cache-v2 credentials when the service is available. Ordinary `run` steps and native action adapters do not.
+JavaScript and Docker actions with compatible bundled cache clients also receive job-bound cache-v2 credentials when the service is available. Root invocations of `actions/setup-node`, `actions/setup-java`, `actions/setup-python`, `actions/setup-go`, and `actions/setup-dotnet` use a subprocess-scoped synthetic `GITHUB_SERVER_URL` when the real host would make their clients select cache v1. Each allowlist entry requires an audit of the action source and bundled dependencies to confirm that `GITHUB_SERVER_URL` affects only caching behavior and is not load-bearing for any request the action makes. The workflow expression context retains the real server URL. Ordinary `run` steps and native action adapters do not receive cache credentials.
 
 ## Repositories, credentials, and GitHub services
 

--- a/internal/action/integration/integration.go
+++ b/internal/action/integration/integration.go
@@ -93,6 +93,10 @@ const (
 type Descriptor struct {
 	Adapter Adapter
 	Service Service
+	// Before enabling OverrideGitHubServerURL, audit the action source and its
+	// bundled dependencies. Confirm GITHUB_SERVER_URL affects only caching
+	// behavior and is not load-bearing for any request the action makes.
+	OverrideGitHubServerURL bool
 }
 
 // UsesNativeAdapter reports whether the resolved identity replaces the
@@ -104,12 +108,17 @@ func UsesNativeAdapter(identity Identity) bool {
 
 var catalog = map[Identity]Descriptor{
 	{Source: "github", Repository: "actions/checkout"}:                       {Adapter: AdapterCheckoutExactEventSHA},
-	{Source: "github", Repository: "actions/cache"}:                          {Service: ServiceCache},
-	{Source: "github", Repository: "actions/cache", Path: "restore"}:         {Service: ServiceCache},
-	{Source: "github", Repository: "actions/cache", Path: "save"}:            {Service: ServiceCache},
+	{Source: "github", Repository: "actions/cache"}:                          {Service: ServiceCache, OverrideGitHubServerURL: true},
+	{Source: "github", Repository: "actions/cache", Path: "restore"}:         {Service: ServiceCache, OverrideGitHubServerURL: true},
+	{Source: "github", Repository: "actions/cache", Path: "save"}:            {Service: ServiceCache, OverrideGitHubServerURL: true},
 	{Source: "github", Repository: "actions/upload-artifact"}:                {Adapter: AdapterUploadArtifactBuildkite},
 	{Source: "github", Repository: "actions/upload-artifact", Path: "merge"}: {Service: ServiceArtifact},
 	{Source: "github", Repository: "actions/download-artifact"}:              {Adapter: AdapterDownloadArtifactBuildkite},
+	{Source: "github", Repository: "actions/setup-node"}:                     {OverrideGitHubServerURL: true},
+	{Source: "github", Repository: "actions/setup-java"}:                     {OverrideGitHubServerURL: true},
+	{Source: "github", Repository: "actions/setup-python"}:                   {OverrideGitHubServerURL: true},
+	{Source: "github", Repository: "actions/setup-go"}:                       {OverrideGitHubServerURL: true},
+	{Source: "github", Repository: "actions/setup-dotnet"}:                   {OverrideGitHubServerURL: true},
 }
 
 var checkoutCommits = map[string]string{

--- a/internal/action/integration/integration_test.go
+++ b/internal/action/integration/integration_test.go
@@ -11,12 +11,17 @@ func TestLookupMatchesKnownCanonicalActions(t *testing.T) {
 		want     Descriptor
 	}{
 		{Identity{Source: "github", Repository: "actions/checkout"}, Descriptor{Adapter: AdapterCheckoutExactEventSHA}},
-		{Identity{Source: "github", Repository: "actions/cache"}, Descriptor{Service: ServiceCache}},
-		{Identity{Source: "github", Repository: "actions/cache", Path: "restore"}, Descriptor{Service: ServiceCache}},
-		{Identity{Source: "github", Repository: "actions/cache", Path: "save"}, Descriptor{Service: ServiceCache}},
+		{Identity{Source: "github", Repository: "actions/cache"}, Descriptor{Service: ServiceCache, OverrideGitHubServerURL: true}},
+		{Identity{Source: "github", Repository: "actions/cache", Path: "restore"}, Descriptor{Service: ServiceCache, OverrideGitHubServerURL: true}},
+		{Identity{Source: "github", Repository: "actions/cache", Path: "save"}, Descriptor{Service: ServiceCache, OverrideGitHubServerURL: true}},
 		{Identity{Source: "github", Repository: "actions/upload-artifact"}, Descriptor{Adapter: AdapterUploadArtifactBuildkite}},
 		{Identity{Source: "github", Repository: "actions/upload-artifact", Path: "merge"}, Descriptor{Service: ServiceArtifact}},
 		{Identity{Source: "github", Repository: "actions/download-artifact"}, Descriptor{Adapter: AdapterDownloadArtifactBuildkite}},
+		{Identity{Source: "github", Repository: "actions/setup-node"}, Descriptor{OverrideGitHubServerURL: true}},
+		{Identity{Source: "github", Repository: "actions/setup-java"}, Descriptor{OverrideGitHubServerURL: true}},
+		{Identity{Source: "github", Repository: "actions/setup-python"}, Descriptor{OverrideGitHubServerURL: true}},
+		{Identity{Source: "github", Repository: "actions/setup-go"}, Descriptor{OverrideGitHubServerURL: true}},
+		{Identity{Source: "github", Repository: "actions/setup-dotnet"}, Descriptor{OverrideGitHubServerURL: true}},
 	}
 	for _, test := range tests {
 		name := test.identity.Repository
@@ -267,6 +272,9 @@ func TestLookupDoesNotBroadenCanonicalIdentity(t *testing.T) {
 		{Source: "github", Repository: "actions/cache", Path: "nested"},
 		{Source: "github", Repository: "actions/upload-artifact", Path: "nested"},
 		{Source: "github", Repository: "actions/download-artifact", Path: "nested"},
+		{Source: "github", Repository: "actions/setup-node", Path: "nested"},
+		{Source: "github", Repository: "actions/setup-ruby"},
+		{Source: "workspace", Repository: "actions/setup-node"},
 		{Source: "github", Repository: "owner/action"},
 	} {
 		if descriptor, ok := Lookup(identity); ok {

--- a/internal/runtime/actions.go
+++ b/internal/runtime/actions.go
@@ -103,6 +103,11 @@ func usesCacheService(lock plan.ActionLock) bool {
 	return descriptor.Service == actionintegration.ServiceCache
 }
 
+func overridesGitHubServerURL(lock plan.ActionLock) bool {
+	descriptor, _ := actionintegration.Lookup(actionintegration.Identity{Source: lock.Source, Repository: lock.Repository, Path: lock.Path})
+	return descriptor.OverrideGitHubServerURL
+}
+
 func (r *actionLockResolver) source(selector plan.ActionSelector) (_ string, err error) {
 	defer func() { err = markHardJobFailure(err) }()
 	if r == nil || selector.Lock == "" {

--- a/internal/runtime/cache_service.go
+++ b/internal/runtime/cache_service.go
@@ -221,10 +221,10 @@ func removeCacheServiceEnvironment(env map[string]string) map[string]string {
 }
 
 // shouldOverrideGitHubServerURL reports whether serverURL needs to be
-// replaced with githubServerURLOverride before starting actions/cache: its
-// isGhes() forces the unsupported cache-v1 path for every host outside its
-// own allowlist (github.com, *.ghe.com, *.localhost). Malformed/empty values
-// are left untouched.
+// replaced with githubServerURLOverride before starting an audited action
+// with a bundled cache client. Its isGhes() forces the unsupported cache-v1
+// path for every host outside its own allowlist (github.com, *.ghe.com,
+// *.localhost). Malformed/empty values are left untouched.
 func shouldOverrideGitHubServerURL(serverURL string) bool {
 	u, err := url.Parse(serverURL)
 	if err != nil || u.Hostname() == "" {
@@ -248,11 +248,14 @@ func isolateCacheActionEnvironment(env map[string]string) map[string]string {
 	} {
 		delete(isolated, name)
 	}
-	if shouldOverrideGitHubServerURL(isolated["GITHUB_SERVER_URL"]) {
-		isolated["GITHUB_SERVER_URL"] = githubServerURLOverride
-	}
 	isolated["PATH"] = cacheActionToolPath
 	return isolated
+}
+
+func applyGitHubServerURLOverride(env map[string]string) {
+	if shouldOverrideGitHubServerURL(env["GITHUB_SERVER_URL"]) {
+		env["GITHUB_SERVER_URL"] = githubServerURLOverride
+	}
 }
 
 func (r Runner) cacheActionEnvironment(ctx context.Context, processor *commandProcessor) (map[string]string, error) {

--- a/internal/runtime/cache_service_test.go
+++ b/internal/runtime/cache_service_test.go
@@ -226,6 +226,7 @@ func TestCacheServiceLifecycleUsesFreshIsolatedCredentials(t *testing.T) {
 import {spawnSync} from "node:child_process";
 const required = ["ACTIONS_CACHE_SERVICE_V2", "ACTIONS_RESULTS_URL", "ACTIONS_RUNTIME_TOKEN"];
 for (const name of required) if (!process.env[name]) throw new Error("missing " + name);
+if (process.env.GITHUB_SERVER_URL !== %q) throw new Error("unexpected GITHUB_SERVER_URL: " + process.env.GITHUB_SERVER_URL);
 for (const name of [
   "ACTIONS_CACHE_URL", "ACTIONS_RUNTIME_URL",
   "NODE_OPTIONS", "NODE_PATH", "NODE_EXTRA_CA_CERTS", "NODE_TLS_REJECT_UNAUTHORIZED", "SSLKEYLOGFILE", "LD_AUDIT", "LD_PRELOAD", "LD_LIBRARY_PATH",
@@ -239,7 +240,7 @@ if (tar.status !== 0) throw new Error("trusted tar failed: " + tar.stderr);
 if (process.env.PATH !== %q) throw new Error("unsafe PATH: " + process.env.PATH);
 fs.appendFileSync(process.env.LIFECYCLE_LOG, "%s|" + process.env.ACTIONS_RUNTIME_TOKEN + "|" + process.env.ACTIONS_RESULTS_URL + "|" + process.env.ACTIONS_CACHE_SERVICE_V2 + "\n");
 console.log("credential=" + process.env.ACTIONS_RUNTIME_TOKEN);
-`, cacheActionToolPath, phase)
+`, githubServerURLOverride, cacheActionToolPath, phase)
 		writeFixtureFile(t, remote, phase+".js", program)
 	}
 	writeFixtureFile(t, remote, "ordinary/action.yml", "name: ordinary\nruns:\n  using: node24\n  pre: pre.js\n  main: main.js\n  post: post.js\n")
@@ -249,6 +250,7 @@ for (const name of ["ACTIONS_CACHE_SERVICE_V2", "ACTIONS_RESULTS_URL", "ACTIONS_
   if (!process.env[name]) throw new Error("missing " + name);
 for (const name of ["ACTIONS_CACHE_URL", "ACTIONS_RUNTIME_URL", "BUILDKITE_AGENT_ACCESS_TOKEN"])
   if (process.env[name]) throw new Error(name + " leaked");
+if (process.env.GITHUB_SERVER_URL !== "https://origin.cursor.com") throw new Error("ordinary action server URL changed");
 if (process.env.PATH === %q) throw new Error("ordinary action PATH was isolated");
 fs.appendFileSync(process.env.LIFECYCLE_LOG, "ordinary-%s|" + process.env.ACTIONS_RUNTIME_TOKEN + "|" + process.env.ACTIONS_RESULTS_URL + "|" + process.env.ACTIONS_CACHE_SERVICE_V2 + "\n");
 console.log("ordinary-credential=" + process.env.ACTIONS_RUNTIME_TOKEN);
@@ -291,6 +293,7 @@ console.log("ordinary-credential=" + process.env.ACTIONS_RUNTIME_TOKEN);
 		{ID: "shell-after", Kind: "run", Command: `test -z "${ACTIONS_RUNTIME_TOKEN:-}" && test -z "${ACTIONS_RESULTS_URL:-}" && test -z "${ACTIONS_CACHE_SERVICE_V2:-}"`},
 	})
 	job.Schema = plan.Schema
+	job.Event.Provider = "cursor-origin"
 	job.RequiredCapabilities = []string{"network"}
 	job.Env = map[string]string{"LIFECYCLE_LOG": lifecycle, "ATTACKER_BIN": attackerBin}
 	job.Actions = []plan.ActionLock{
@@ -394,7 +397,7 @@ func TestShouldOverrideGitHubServerURL(t *testing.T) {
 	}
 }
 
-func TestIsolateCacheActionEnvironmentOverridesGitHubServerURLWhenNeeded(t *testing.T) {
+func TestIsolateCacheActionEnvironmentLeavesGitHubServerURLForSharedOverride(t *testing.T) {
 	env := map[string]string{
 		"GITHUB_SERVER_URL":            "https://origin.cursor.com",
 		"ACTIONS_CACHE_SERVICE_V2":     "true",
@@ -404,8 +407,8 @@ func TestIsolateCacheActionEnvironmentOverridesGitHubServerURLWhenNeeded(t *test
 		"BUILDKITE_JOB_ID":             "job-id",
 	}
 	isolated := isolateCacheActionEnvironment(env)
-	if got := isolated["GITHUB_SERVER_URL"]; got != githubServerURLOverride {
-		t.Fatalf("GITHUB_SERVER_URL = %q, want %q", got, githubServerURLOverride)
+	if got := isolated["GITHUB_SERVER_URL"]; got != "https://origin.cursor.com" {
+		t.Fatalf("GITHUB_SERVER_URL = %q, want unchanged https://origin.cursor.com", got)
 	}
 	if isolated["PATH"] != cacheActionToolPath {
 		t.Fatalf("PATH = %q, want %q", isolated["PATH"], cacheActionToolPath)
@@ -424,6 +427,62 @@ func TestIsolateCacheActionEnvironmentLeavesRealGitHubServerURLUnchanged(t *test
 	isolated := isolateCacheActionEnvironment(env)
 	if got := isolated["GITHUB_SERVER_URL"]; got != "https://github.com" {
 		t.Fatalf("GITHUB_SERVER_URL = %q, want unchanged https://github.com", got)
+	}
+}
+
+func TestSetupActionsOverrideGitHubServerURLWithoutCacheActionIsolation(t *testing.T) {
+	node := requireNode24(t)
+	remote := t.TempDir()
+	writeFixtureFile(t, remote, "action.yml", "name: setup fixture\nruns:\n  using: node24\n  main: main.js\n  post: post.js\n  post-if: success()\n")
+	for _, phase := range []string{"main", "post"} {
+		writeFixtureFile(t, remote, phase+".js", fmt.Sprintf(`const fs = require("node:fs");
+if (process.env.GITHUB_SERVER_URL !== %q) throw new Error("unexpected GITHUB_SERVER_URL: " + process.env.GITHUB_SERVER_URL);
+if (process.env.HTTP_PROXY !== "http://proxy.example") throw new Error("setup action environment was isolated");
+fs.appendFileSync(process.env.LIFECYCLE_LOG, %q + "\n");
+`, githubServerURLOverride, phase))
+	}
+	digest, err := source.DigestTree(remote)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, repository := range []string{
+		"actions/setup-node",
+		"actions/setup-java",
+		"actions/setup-python",
+		"actions/setup-go",
+		"actions/setup-dotnet",
+	} {
+		t.Run(strings.TrimPrefix(repository, "actions/"), func(t *testing.T) {
+			workspace := t.TempDir()
+			workflowPath := ".github/workflows/setup.yml"
+			writeFixtureFile(t, workspace, workflowPath, "name: setup action override\n")
+			lifecycle := filepath.Join(workspace, "lifecycle.log")
+			lockID := remoteLifecycleLockID(1)
+			job := runtimePlan(t, workspace, workflowPath, []plan.Step{{
+				ID: "setup", Kind: "uses", Uses: repository + "@v1", Action: &plan.ActionSelector{Lock: lockID},
+			}})
+			job.Schema = plan.Schema
+			job.Event.Provider = "cursor-origin"
+			job.RequiredCapabilities = []string{"network"}
+			job.Env = map[string]string{
+				"HTTP_PROXY":    "http://proxy.example",
+				"LIFECYCLE_LOG": lifecycle,
+			}
+			job.Actions = []plan.ActionLock{{
+				ID: lockID, Source: "github", Repository: repository, RequestedRef: "v1",
+				Commit: strings.Repeat("a", 40), SourceDigest: digest,
+			}}
+			materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}
+			result, err := (Runner{Node24: node, Actions: materializer}).RunJob(context.Background(), job, workspace)
+			if err != nil || result.Conclusion != "success" {
+				t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+			}
+			contents, err := os.ReadFile(lifecycle)
+			if err != nil || string(contents) != "main\npost\n" {
+				t.Fatalf("setup lifecycle = %q, %v", contents, err)
+			}
+		})
 	}
 }
 

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -1309,7 +1309,7 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 		if err != nil {
 			return result, err
 		}
-		javascript := javaScriptAction{Name: actionName(action, step), Path: action.Path, Pre: action.Runs.Pre, Main: action.Runs.Main, Post: action.Runs.Post, Cache: usesCacheService(lock), nodeMajor: major, reference: step.Uses, jobStatusInputs: jobStatusInputs}
+		javascript := javaScriptAction{Name: actionName(action, step), Path: action.Path, Pre: action.Runs.Pre, Main: action.Runs.Main, Post: action.Runs.Post, Cache: usesCacheService(lock), OverrideGitHubServerURL: overridesGitHubServerURL(lock), nodeMajor: major, reference: step.Uses, jobStatusInputs: jobStatusInputs}
 		invocation := &preparedInvocation{action: javascript, state: map[string]string{}}
 		prepared[invocationID] = invocation
 		if javascript.Pre != "" && runPre {
@@ -1549,7 +1549,7 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 			return result, err
 		}
 		actionEnv := environment.process()
-		javascript := javaScriptAction{Name: actionName(action, step), Path: actionPath, Pre: action.Runs.Pre, Main: action.Runs.Main, Post: action.Runs.Post, Inputs: inputs, Env: actionEnv, Cache: actionLock != nil && usesCacheService(*actionLock), nodeMajor: major, reference: step.Uses, jobStatusInputs: jobStatusInputs}
+		javascript := javaScriptAction{Name: actionName(action, step), Path: actionPath, Pre: action.Runs.Pre, Main: action.Runs.Main, Post: action.Runs.Post, Inputs: inputs, Env: actionEnv, Cache: actionLock != nil && usesCacheService(*actionLock), OverrideGitHubServerURL: actionLock != nil && overridesGitHubServerURL(*actionLock), nodeMajor: major, reference: step.Uses, jobStatusInputs: jobStatusInputs}
 		state := map[string]string{}
 		wasPrepared := false
 		if invocation := prepared[invocationID]; invocation != nil {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -140,14 +140,15 @@ func (r *Runner) setExplicitNode(major int, path string) {
 
 // javaScriptAction is an already-resolved local JavaScript action.
 type javaScriptAction struct {
-	Name   string
-	Path   string
-	Pre    string
-	Main   string
-	Post   string
-	Inputs map[string]string
-	Env    map[string]string
-	Cache  bool
+	Name                    string
+	Path                    string
+	Pre                     string
+	Main                    string
+	Post                    string
+	Inputs                  map[string]string
+	Env                     map[string]string
+	Cache                   bool
+	OverrideGitHubServerURL bool
 
 	nodeMajor       int
 	reference       string
@@ -640,6 +641,9 @@ func (r Runner) runJavaScriptPhase(ctx context.Context, processor *commandProces
 	env = removeCacheServiceEnvironment(env)
 	if action.Cache {
 		env = isolateCacheActionEnvironment(env)
+	}
+	if action.OverrideGitHubServerURL {
+		applyGitHubServerURLOverride(env)
 	}
 	cacheEnv, cacheErr := r.cacheActionEnvironment(ctx, processor)
 	if cacheErr != nil && ctx.Err() != nil {


### PR DESCRIPTION
## Summary

Workflows from non-`github.com` repositories can expose a `GITHUB_SERVER_URL` that the cache clients bundled in setup actions misclassify as GHES. They then fail to use the Buildkite cache-v2 service despite receiving its endpoint and job-bound token.

This extends the workaround from #205 so the built-in dependency caches in root setup-node, setup-java, setup-python, setup-go, and setup-dotnet actions work for those repositories. It:

- shares one descriptor-driven, subprocess-scoped hostname override with direct `actions/cache`
- preserves the normal setup-action environment and real workflow expression context
- applies across versions while excluding nested and unlisted actions
- documents the source and request-path audit required before adding an action

## Verification

- `mise run check`