### PR TITLE
Refine actionable diagnostic guidance

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -2395,11 +2395,7 @@ func validateUnprivilegedBundle(bundle compiler.Bundle) error {
 		instances[instance.Key] = instance
 	}
 	var diagnostics []error
-	addFailure := func(artifact compiler.PlanArtifact, message string, err error) {
-		detail := err.Error()
-		if detail == message {
-			detail = ""
-		}
+	addFailure := func(artifact compiler.PlanArtifact, message, detail string, err error) {
 		finding := &compiler.ProcessingFinding{
 			Stage: compiler.StageAdmission, Code: "E_PROFILE", Category: "admission",
 			Job: artifact.Job.Workflow.LogicalJobID, Instance: artifact.Job.Target.StepKey,
@@ -2416,18 +2412,18 @@ func validateUnprivilegedBundle(bundle compiler.Bundle) error {
 		for _, capability := range artifact.Job.RequiredCapabilities {
 			if capability == "docker" && !slices.Equal(artifact.Authorization.DockerCapabilitySources, []string{"dockerfile-actions"}) {
 				if slices.Contains(artifact.Authorization.DockerCapabilitySources, "job-containers") || slices.Contains(artifact.Authorization.DockerCapabilitySources, "service-containers") {
-					message := hostedContainerDiagnostic(artifact.Job)
-					addFailure(artifact, message, errors.New("hosted container unsupported"))
+					message, detail := hostedContainerDiagnostic(artifact.Job)
+					addFailure(artifact, message, detail, errors.New("hosted container unsupported"))
 					continue
 				}
-				message := "Docker is unsupported for this job; hosted production allows Docker only for resolved Dockerfile actions"
-				addFailure(artifact, message, errors.New("unsupported Docker access"))
+				message := fmt.Sprintf("Job %q requires Docker, which hosted runs support only for Dockerfile actions. Use a Dockerfile action or remove the Docker requirement.", artifact.Job.Workflow.LogicalJobID)
+				addFailure(artifact, message, "", errors.New("unsupported Docker access"))
 				continue
 			}
 			if capability == "provider-token-read" {
 				if !slices.Equal(artifact.Authorization.ProviderTokenReadCapabilitySources, []string{"checkout-adapter"}) {
 					message := "GitHub checkout credentials are unsupported for this job; use the managed actions/checkout integration"
-					addFailure(artifact, message, errors.New("unsupported GitHub checkout credentials"))
+					addFailure(artifact, message, "", errors.New("unsupported GitHub checkout credentials"))
 				}
 				continue
 			}
@@ -2438,17 +2434,17 @@ func validateUnprivilegedBundle(bundle compiler.Bundle) error {
 					if reason == "" {
 						reason = "the workflow token request does not match the compiled job"
 					}
-					message := githubTokenAdmissionDiagnostic(artifact, reason)
-					addFailure(artifact, message, errors.New("hosted GITHUB_TOKEN unsupported"))
+					message, detail := githubTokenAdmissionDiagnostic(artifact, reason)
+					addFailure(artifact, message, detail, errors.New("hosted GITHUB_TOKEN unsupported"))
 				}
 				continue
 			}
 			if capability != "network" && capability != "docker" {
-				message := fmt.Sprintf("Job %q uses unsupported hosted runtime requirement %q", artifact.Job.Workflow.LogicalJobID, capability)
+				message := fmt.Sprintf("Job %q requires unsupported hosted runtime capability %q. Remove the requirement or use a runtime profile that supports it.", artifact.Job.Workflow.LogicalJobID, capability)
 				if capability == "secrets" {
-					message = fmt.Sprintf("Job %q uses GitHub Actions secrets, which hosted production does not provide", artifact.Job.Workflow.LogicalJobID)
+					message = fmt.Sprintf("Job %q uses GitHub Actions secrets, which hosted runs do not provide. Pass values through supported Buildkite secret handling or remove the dependency.", artifact.Job.Workflow.LogicalJobID)
 				}
-				addFailure(artifact, message, errors.New(message))
+				addFailure(artifact, message, "", errors.New(message))
 			}
 		}
 		for _, action := range artifact.Job.Actions {
@@ -2462,20 +2458,25 @@ func validateUnprivilegedBundle(bundle compiler.Bundle) error {
 					if action.RequestedRef != "" {
 						reference += "@" + action.RequestedRef
 					}
-					message, _, _ := actionintegration.UnsupportedVersionDiagnostic(reference, err)
-					addFailure(artifact, message, fmt.Errorf("job %q uses unsupported cache action: %w", artifact.Job.Workflow.LogicalJobID, err))
+					message, detail, _ := actionintegration.UnsupportedVersionDiagnostic(reference, err)
+					addFailure(artifact, message, detail, fmt.Errorf("job %q uses unsupported cache action: %w", artifact.Job.Workflow.LogicalJobID, err))
 				}
 				continue
 			}
 			if descriptor.Service != "" {
-				addFailure(artifact, "action requires a service unavailable to the hosted profile", fmt.Errorf("job %q uses action %q, which requires the unavailable GitHub Actions %s service", artifact.Job.Workflow.LogicalJobID, action.Repository, descriptor.Service))
+				reference := action.Repository
+				if action.Path != "" {
+					reference += "/" + action.Path
+				}
+				message := fmt.Sprintf("Action %q requires the GitHub Actions %s service, which hosted runs do not provide. Replace the action or use a runtime profile that provides this service.", reference, descriptor.Service)
+				addFailure(artifact, message, "", fmt.Errorf("job %q uses action %q, which requires the unavailable GitHub Actions %s service", artifact.Job.Workflow.LogicalJobID, reference, descriptor.Service))
 			}
 		}
 	}
 	return errors.Join(diagnostics...)
 }
 
-func githubTokenAdmissionDiagnostic(artifact compiler.PlanArtifact, reason string) string {
+func githubTokenAdmissionDiagnostic(artifact compiler.PlanArtifact, reason string) (message, detail string) {
 	limitation := reason
 	fix := "Use a supported workflow-level permissions map or remove the GITHUB_TOKEN dependency."
 	switch {
@@ -2527,10 +2528,12 @@ func githubTokenAdmissionDiagnostic(artifact compiler.PlanArtifact, reason strin
 		}
 		permissions = strings.Join(values, ", ")
 	}
-	return fmt.Sprintf("Job %q needs GITHUB_TOKEN, but %s. Cause: %s. Effective permissions: %s. %s", artifact.Job.Workflow.LogicalJobID, limitation, strings.Join(causes, "; "), permissions, fix)
+	message = fmt.Sprintf("Job %q needs GITHUB_TOKEN, but %s. %s", artifact.Job.Workflow.LogicalJobID, limitation, fix)
+	detail = fmt.Sprintf("Cause: %s. Effective permissions: %s.", strings.Join(causes, "; "), permissions)
+	return message, detail
 }
 
-func hostedContainerDiagnostic(job plan.Job) string {
+func hostedContainerDiagnostic(job plan.Job) (message, detail string) {
 	var constructs []string
 	if job.Container != nil {
 		constructs = append(constructs, fmt.Sprintf("job container %q", job.Container.Image))
@@ -2546,7 +2549,9 @@ func hostedContainerDiagnostic(job plan.Job) string {
 	if len(constructs) == 0 {
 		constructs = append(constructs, "a job or service container")
 	}
-	return fmt.Sprintf("Job %q uses %s. The compiler supports this construct, but hosted production does not run job or service containers. Replace the container with ordinary steps or an externally reachable service; runner configuration cannot enable containers in the hosted profile.", job.Workflow.LogicalJobID, strings.Join(constructs, " and "))
+	message = fmt.Sprintf("Job %q uses %s, which hosted runs do not support. Replace it with ordinary steps or an externally reachable service.", job.Workflow.LogicalJobID, strings.Join(constructs, " and "))
+	detail = "The compiler supports job and service containers, but the hosted profile does not run them; runner configuration cannot enable them."
+	return message, detail
 }
 
 func irUsesActions(ir compiler.IR) bool {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -5800,17 +5800,23 @@ func TestRunUploadFailsClosedBeforePipeline(t *testing.T) {
 }
 
 func TestUnprivilegedUploadRejectsCapabilities(t *testing.T) {
-	for _, capability := range []string{"secrets", "provider-token-write", "privileged-container", "future-capability"} {
+	tests := []struct {
+		capability string
+		want       string
+	}{
+		{capability: "secrets", want: `Job "protected" uses GitHub Actions secrets, which hosted runs do not provide. Pass values through supported Buildkite secret handling or remove the dependency.`},
+		{capability: "privileged-container", want: `Job "protected" requires unsupported hosted runtime capability "privileged-container". Remove the requirement or use a runtime profile that supports it.`},
+		{capability: "future-capability", want: `Job "protected" requires unsupported hosted runtime capability "future-capability". Remove the requirement or use a runtime profile that supports it.`},
+	}
+	for _, test := range tests {
+		capability := test.capability
 		bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: plan.Job{
 			Workflow:             plan.Workflow{LogicalJobID: "protected"},
 			RequiredCapabilities: []string{capability},
 		}}}}
 		err := validateUnprivilegedBundle(bundle)
-		want := capability
-		if capability == "provider-token-write" {
-			want = "GITHUB_TOKEN"
-		}
-		if err == nil || !strings.Contains(err.Error(), want) {
+		var finding *compiler.ProcessingFinding
+		if err == nil || !errors.As(err, &finding) || finding.Message != test.want || finding.Detail != "" {
 			t.Fatalf("validateUnprivilegedBundle(%q) error = %v, want capability rejection", capability, err)
 		}
 	}
@@ -5873,7 +5879,7 @@ func TestUnprivilegedUploadAdmitsOnlyCompilerVerifiedWorkflowToken(t *testing.T)
 	}
 }
 
-func TestGitHubTokenAdmissionDiagnosticExplainsCausePermissionsAndFix(t *testing.T) {
+func TestGitHubTokenAdmissionDiagnosticSeparatesGuidanceFromDetail(t *testing.T) {
 	artifact := compiler.PlanArtifact{
 		Job: plan.Job{
 			Workflow:    plan.Workflow{LogicalJobID: "build"},
@@ -5881,20 +5887,24 @@ func TestGitHubTokenAdmissionDiagnosticExplainsCausePermissionsAndFix(t *testing
 		},
 		Authorization: compiler.PlanAuthorization{GitHubTokenActions: []string{"owner/action@v1"}},
 	}
-	want := `Job "build" needs GITHUB_TOKEN, but job-level permissions are unsupported for hosted GITHUB_TOKEN issuance. Cause: action "owner/action@v1" defaults an input to github.token. Effective permissions: contents: read, pull-requests: write. Move the permissions map to the workflow top level.`
-	if got := githubTokenAdmissionDiagnostic(artifact, "GitHub workflow access tokens do not support job-level permissions"); got != want {
-		t.Fatalf("githubTokenAdmissionDiagnostic() = %q, want %q", got, want)
+	wantMessage := `Job "build" needs GITHUB_TOKEN, but job-level permissions are unsupported for hosted GITHUB_TOKEN issuance. Move the permissions map to the workflow top level.`
+	wantDetail := `Cause: action "owner/action@v1" defaults an input to github.token. Effective permissions: contents: read, pull-requests: write.`
+	message, detail := githubTokenAdmissionDiagnostic(artifact, "GitHub workflow access tokens do not support job-level permissions")
+	if message != wantMessage || detail != wantDetail {
+		t.Fatalf("githubTokenAdmissionDiagnostic() = %q, %q", message, detail)
 	}
 }
 
-func TestHostedContainerDiagnosticNamesServiceAndBoundary(t *testing.T) {
+func TestHostedContainerDiagnosticSeparatesGuidanceFromDetail(t *testing.T) {
 	job := plan.Job{
 		Workflow: plan.Workflow{LogicalJobID: "test"},
 		Services: map[string]plan.Container{"postgres": {Image: "postgres:11-alpine"}},
 	}
-	want := `Job "test" uses service container "postgres" (image "postgres:11-alpine"). The compiler supports this construct, but hosted production does not run job or service containers. Replace the container with ordinary steps or an externally reachable service; runner configuration cannot enable containers in the hosted profile.`
-	if got := hostedContainerDiagnostic(job); got != want {
-		t.Fatalf("hostedContainerDiagnostic() = %q, want %q", got, want)
+	wantMessage := `Job "test" uses service container "postgres" (image "postgres:11-alpine"), which hosted runs do not support. Replace it with ordinary steps or an externally reachable service.`
+	wantDetail := `The compiler supports job and service containers, but the hosted profile does not run them; runner configuration cannot enable them.`
+	message, detail := hostedContainerDiagnostic(job)
+	if message != wantMessage || detail != wantDetail {
+		t.Fatalf("hostedContainerDiagnostic() = %q, %q", message, detail)
 	}
 }
 
@@ -5916,7 +5926,10 @@ func TestUnprivilegedUploadRejectsDockerWithoutCompilerProvenance(t *testing.T) 
 		Workflow:             plan.Workflow{LogicalJobID: "unproven-docker"},
 		RequiredCapabilities: []string{"docker"},
 	}}}}
-	if err := validateUnprivilegedBundle(bundle); err == nil || !strings.Contains(err.Error(), "unsupported Docker access") {
+	err := validateUnprivilegedBundle(bundle)
+	var finding *compiler.ProcessingFinding
+	want := `Job "unproven-docker" requires Docker, which hosted runs support only for Dockerfile actions. Use a Dockerfile action or remove the Docker requirement.`
+	if err == nil || !errors.As(err, &finding) || finding.Message != want || finding.Detail != "" {
 		t.Fatalf("validateUnprivilegedBundle() error = %v, want Docker provenance rejection", err)
 	}
 }
@@ -5954,7 +5967,9 @@ func TestUnprivilegedUploadRejectsKnownGitHubServiceActions(t *testing.T) {
 				Actions:  []plan.ActionLock{test.action},
 			}}}}
 			err := validateUnprivilegedBundle(bundle)
-			if err == nil || !strings.Contains(err.Error(), "GitHub Actions "+test.service+" service") || !strings.Contains(err.Error(), "unavailable") {
+			var finding *compiler.ProcessingFinding
+			want := `Action "actions/upload-artifact/merge" requires the GitHub Actions artifact service, which hosted runs do not provide. Replace the action or use a runtime profile that provides this service.`
+			if err == nil || !errors.As(err, &finding) || finding.Message != want || finding.Detail != "" {
 				t.Fatalf("validateUnprivilegedBundle(%#v) error = %v", test.action, err)
 			}
 		})

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -140,7 +140,14 @@ func actionResolutionMessage(reference string, err error) (message, detail, acti
 	}
 	var runtimeErr *metadata.UnsupportedRuntimeError
 	if errors.As(err, &runtimeErr) {
-		return fmt.Sprintf("Action %q uses unsupported runtime %q. Set runs.using to node16, node20, node24, composite, or docker.", action, runtimeErr.Runtime), runtimeErr.Error(), action
+		runtime := fmt.Sprintf("runtime %q", runtimeErr.Runtime)
+		if version := strings.TrimPrefix(runtimeErr.Runtime, "node"); version != runtimeErr.Runtime {
+			runtime = "Node.js " + version
+		}
+		if strings.HasPrefix(action, "./") {
+			return fmt.Sprintf("Action %q uses %s, which is unsupported. Update runs.using to node16, node20, or node24.", action, runtime), "", action
+		}
+		return fmt.Sprintf("Action %q uses %s, which is unsupported. Use an action release that supports Node.js 16, 20, or 24.", action, runtime), "", action
 	}
 	reason := strings.TrimPrefix(err.Error(), fmt.Sprintf("compile action %q: ", action))
 	if strings.HasPrefix(reason, "resolve action reference: ") || strings.HasPrefix(reason, "download action source: ") {

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -114,10 +114,24 @@ func TestActionResolutionMessageIdentifiesNestedChild(t *testing.T) {
 
 func TestActionResolutionMessageMakesUnsupportedRuntimeActionable(t *testing.T) {
 	err := fmt.Errorf(`compile action "owner/action@v1": %w`, &metadata.UnsupportedRuntimeError{Runtime: "node12"})
-	want := `Action "owner/action@v1" uses unsupported runtime "node12". Set runs.using to node16, node20, node24, composite, or docker.`
-	message, detail, action := actionResolutionMessage("owner/action@v1", err)
-	if message != want || detail != `unsupported runtime "node12"` || action != "owner/action@v1" {
-		t.Fatalf("actionResolutionMessage() = %q, %q, %q", message, detail, action)
+	tests := []struct {
+		reference string
+		want      string
+	}{
+		{
+			reference: "owner/action@v1",
+			want:      `Action "owner/action@v1" uses Node.js 12, which is unsupported. Use an action release that supports Node.js 16, 20, or 24.`,
+		},
+		{
+			reference: "./local-action",
+			want:      `Action "./local-action" uses Node.js 12, which is unsupported. Update runs.using to node16, node20, or node24.`,
+		},
+	}
+	for _, test := range tests {
+		message, detail, action := actionResolutionMessage(test.reference, err)
+		if message != test.want || detail != "" || action != test.reference {
+			t.Fatalf("actionResolutionMessage(%q) = %q, %q, %q", test.reference, message, detail, action)
+		}
 	}
 }
 

--- a/internal/compiler/config.go
+++ b/internal/compiler/config.go
@@ -350,7 +350,7 @@ func runnerRejectionDiagnostic(err error, labels, supported, untrustedQueues []s
 	case reasonNoLabels:
 		return "runs-on resolves to no runner labels. Set runs-on to a mapped Linux or macOS runner label.", detail
 	case reasonDuplicateLabel:
-		return "runs-on contains a duplicate runner label. Remove duplicate labels from runs-on.", detail
+		return "runs-on contains a duplicate runner label. Remove duplicate labels from runs-on.", ""
 	case reasonUnsupportedOS:
 		return fmt.Sprintf("Runner label%s requires Windows, which is unsupported. Use a Linux or macOS runner label.", label), detail
 	case reasonUnmappedLabel:
@@ -358,14 +358,14 @@ func runnerRejectionDiagnostic(err error, labels, supported, untrustedQueues []s
 	case reasonConflictingQueues, reasonConflictingTarget:
 		return "runs-on labels map to conflicting runner targets. Use labels that map to one runner target.", detail
 	case reasonUntrustedDefault:
-		return "This untrusted event cannot use the default runner target. Map runs-on to a queue allowed for untrusted events.", detail
+		return "This untrusted event cannot use the default runner. Use a runner label allowed for untrusted events, or ask an administrator to configure one.", detail
 	case reasonUntrustedQueue:
 		queues := append([]string(nil), untrustedQueues...)
 		sort.Strings(queues)
 		if len(queues) != 0 {
 			detail = "Queues allowed for untrusted events: " + strings.Join(queues, ", ") + "."
 		}
-		return "This untrusted event targets a disallowed queue. Add the queue to the untrusted-event allowlist or use an allowed queue.", detail
+		return "This untrusted event uses a runner that is not allowed for untrusted events. Use an allowed runner label, or ask an administrator to allow its queue.", detail
 	default:
 		return "Runner target is unsupported. Use a configured Linux or macOS runner target.", detail
 	}

--- a/internal/compiler/config_test.go
+++ b/internal/compiler/config_test.go
@@ -246,8 +246,8 @@ func TestRunnerRejectionDiagnosticIsActionableWithoutResolvedLabel(t *testing.T)
 		{name: "unmapped label", labels: []string{"macos-15"}, trust: EventTrusted, want: "Configure a mapping"},
 		{name: "conflicting queues", labels: []string{"self-hosted", "linux"}, trust: EventTrusted, want: "Use labels that map to one runner target"},
 		{name: "conflicting targets", labels: []string{"ubuntu-24.04", "macos"}, trust: EventTrusted, want: "Use labels that map to one runner target"},
-		{name: "untrusted default targeting", labels: []string{"default"}, trust: EventUntrusted, want: "Map runs-on to a queue allowed"},
-		{name: "untrusted queue", labels: []string{"ubuntu-24.04"}, trust: EventUntrusted, want: "Add the queue"},
+		{name: "untrusted default targeting", labels: []string{"default"}, trust: EventUntrusted, want: "Use a runner label allowed for untrusted events"},
+		{name: "untrusted queue", labels: []string{"ubuntu-24.04"}, trust: EventUntrusted, want: "ask an administrator to allow its queue"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -260,6 +260,18 @@ func TestRunnerRejectionDiagnosticIsActionableWithoutResolvedLabel(t *testing.T)
 				t.Fatalf("runnerRejectionDiagnostic() = %q, want %q", message, test.want)
 			}
 		})
+	}
+}
+
+func TestRunnerRejectionDiagnosticOmitsIrrelevantAllowlistForDuplicateLabel(t *testing.T) {
+	policy := RunnerPolicy{Labels: map[string]string{"ubuntu-24.04": "linux"}}
+	_, err := policy.resolve([]string{"ubuntu-24.04", "ubuntu-24.04"}, EventTrusted)
+	if err == nil {
+		t.Fatal("resolve() error = nil, want duplicate-label rejection")
+	}
+	message, detail := runnerRejectionDiagnostic(err, nil, []string{"ubuntu-24.04"}, nil)
+	if message != "runs-on contains a duplicate runner label. Remove duplicate labels from runs-on." || detail != "" {
+		t.Fatalf("runnerRejectionDiagnostic() = %q, %q", message, detail)
 	}
 }
 


### PR DESCRIPTION
## Description

Follow up on #204 by making the remaining compatibility errors lead with a user-visible cause and an action the reader can take.

Public actions now direct users to choose a compatible release instead of editing downloaded metadata. Local actions retain metadata-editing guidance. Runner-policy errors distinguish workflow-author actions from administrator actions. Hosted admission errors separate concise guidance from useful diagnostic detail and omit redundant internal errors.

## Context

Follow-up to #204. Contributes to #128.

## Screenshots

### Public action runtime

![Public action runtime diagnostic](https://ampcode.com/user-content/artifacts/52f9fe931974edf7f549f682883e6a6879f54a1106210f1f8680fdcc49ea644c-file.png)

### Runner compatibility

![Runner compatibility diagnostic](https://ampcode.com/user-content/artifacts/9cd4b2d4356832279a035c31a84b77e798beefe822e2b16161323f00f3da2204-file.png)

### Hosted admission

![Hosted admission diagnostics](https://ampcode.com/user-content/artifacts/085697ef383ae4f17dd07b8e6414be09d8caf52bd4785bc001169964c67ddeb0-file.png)

## Deployment

Low risk. This changes diagnostic wording and detail placement without changing workflow admission decisions or report structure.

## Rollback

Revert this PR. It has no migrations or persisted-data changes.

@buildsworth-bk approve up to L2
