### PR TITLE
Link diagnostics to workflow source

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1866,7 +1866,7 @@ func failureCheckSummary(path string, report compatibility.ProcessingReport, sou
 	if path == "" {
 		path = report.Workflow
 	}
-	_, sourceLinks.workflowInCheckout = processingAnnotationWorkflowPath(report.Workflow, false)
+	sourceLinks.workflowSourceRoot = processingWorkflowSourceRoot(report.Workflow)
 	var summary strings.Builder
 	summary.WriteString("The workflow could not be prepared:\n")
 	for _, diagnostic := range report.Diagnostics {
@@ -1886,7 +1886,6 @@ func failureCheckSummary(path string, report compatibility.ProcessingReport, sou
 			message = strings.TrimPrefix(message, fmt.Sprintf("job %q: ", diagnostic.Job))
 		}
 		summary.WriteString("\n- ")
-		pathCode := markdownCode(diagnosticPath)
 		line := 0
 		sourcePath := report.Workflow
 		if diagnostic.Location != nil {
@@ -1895,8 +1894,16 @@ func failureCheckSummary(path string, report compatibility.ProcessingReport, sou
 				sourcePath = diagnostic.Location.Path
 			}
 		}
-		_, linkable := processingAnnotationWorkflowPath(sourcePath, sourceLinks.workflowInCheckout)
-		if link := sourceLinks.link(diagnosticPath, line); linkable && link != "" {
+		linkedPath, linkable := processingAnnotationWorkflowPath(sourcePath, sourceLinks.workflowSourceRoot)
+		link := ""
+		if linkable {
+			link = sourceLinks.link(linkedPath, line)
+		}
+		if link != "" {
+			diagnosticPath = linkedPath
+		}
+		pathCode := markdownCode(diagnosticPath)
+		if link != "" {
 			summary.WriteString("[")
 			summary.WriteString(pathCode)
 			summary.WriteString("](")

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1887,10 +1887,15 @@ func failureCheckSummary(path string, report compatibility.ProcessingReport, sou
 		summary.WriteString("\n- ")
 		pathCode := markdownCode(diagnosticPath)
 		line := 0
+		sourcePath := report.Workflow
 		if diagnostic.Location != nil {
 			line = diagnostic.Location.Line
+			if diagnostic.Location.Path != "" {
+				sourcePath = diagnostic.Location.Path
+			}
 		}
-		if link := sourceLinks.link(diagnosticPath, line); link != "" {
+		_, linkable := processingAnnotationWorkflowPath(sourcePath)
+		if link := sourceLinks.link(diagnosticPath, line); linkable && link != "" {
 			summary.WriteString("[")
 			summary.WriteString(pathCode)
 			summary.WriteString("](")

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1866,6 +1866,7 @@ func failureCheckSummary(path string, report compatibility.ProcessingReport, sou
 	if path == "" {
 		path = report.Workflow
 	}
+	_, sourceLinks.workflowInCheckout = processingAnnotationWorkflowPath(report.Workflow, false)
 	var summary strings.Builder
 	summary.WriteString("The workflow could not be prepared:\n")
 	for _, diagnostic := range report.Diagnostics {
@@ -1894,7 +1895,7 @@ func failureCheckSummary(path string, report compatibility.ProcessingReport, sou
 				sourcePath = diagnostic.Location.Path
 			}
 		}
-		_, linkable := processingAnnotationWorkflowPath(sourcePath)
+		_, linkable := processingAnnotationWorkflowPath(sourcePath, sourceLinks.workflowInCheckout)
 		if link := sourceLinks.link(diagnosticPath, line); linkable && link != "" {
 			summary.WriteString("[")
 			summary.WriteString(pathCode)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1379,6 +1379,9 @@ func compile(args []string, stdout, stderr io.Writer, version string, agent tran
 	if !ok {
 		return 1
 	}
+	if parsedEvent, parseErr := compiler.ParseEvent(event); parseErr == nil {
+		out.sourceLinks = sourceLinksForEvent(parsedEvent)
+	}
 	processingReport, ok := validatedProcessingReport(out, workflowPath, "", source, event, true)
 	if !ok {
 		return 1
@@ -1535,6 +1538,7 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 		}
 		return 1
 	}
+	out.sourceLinks = sourceLinksForEvent(effectiveEvent.Event)
 	processingReports := make([]compatibility.ProcessingReport, len(workflows))
 	for i := range workflows {
 		if workflows[i].ReusableOnly {
@@ -1658,7 +1662,7 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 			continue
 		}
 		if processingReportHasErrors(processingReports[i]) {
-			failed, artifacts := failedGeneratedWorkflow(input, effectiveEvent.Event.Event, processingReports[i])
+			failed, artifacts := failedGeneratedWorkflow(input, effectiveEvent.Event.Event, processingReports[i], out.sourceLinks)
 			generatedWorkflows = append(generatedWorkflows, failed)
 			failureArtifacts = append(failureArtifacts, artifacts...)
 			continue
@@ -1669,7 +1673,7 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 			processingReports[i].Result = classifyHostedFailure(&processingReports[i], input.Path, err)
 			var failure *hostedFailure
 			if errors.As(err, &failure) && failure.Kind == hostedEvaluationFailure {
-				failed, artifacts := failedGeneratedWorkflow(input, effectiveEvent.Event.Event, processingReports[i])
+				failed, artifacts := failedGeneratedWorkflow(input, effectiveEvent.Event.Event, processingReports[i], out.sourceLinks)
 				generatedWorkflows = append(generatedWorkflows, failed)
 				failureArtifacts = append(failureArtifacts, artifacts...)
 				continue
@@ -1788,7 +1792,7 @@ func processingReportHasErrors(report compatibility.ProcessingReport) bool {
 	return false
 }
 
-func failedGeneratedWorkflow(input workflowInput, event string, report compatibility.ProcessingReport) (buildkitepipeline.Workflow, []transport.Artifact) {
+func failedGeneratedWorkflow(input workflowInput, event string, report compatibility.ProcessingReport, sourceLinks sourceLinkContext) (buildkitepipeline.Workflow, []transport.Artifact) {
 	label := input.Name
 	if label == "" {
 		label = input.CanonicalPath
@@ -1816,7 +1820,7 @@ func failedGeneratedWorkflow(input workflowInput, event string, report compatibi
 		}
 		messages = append(messages, message)
 	}
-	_, annotation := processingAnnotation(report)
+	_, annotation := processingAnnotation(report, sourceLinks)
 	messageArtifact := generatedFailureArtifact("messages", ".txt", "\x1b[31m"+strings.Join(messages, "\n")+"\x1b[0m\n")
 	annotationArtifact := generatedFailureArtifact("annotations", ".html", annotation)
 	workflow := buildkitepipeline.Workflow{
@@ -1826,7 +1830,7 @@ func failedGeneratedWorkflow(input workflowInput, event string, report compatibi
 		Failure: &buildkitepipeline.Failure{
 			AnnotationPath: annotationArtifact.Path,
 			MessagePath:    messageArtifact.Path,
-			Summary:        failureCheckSummary(input.CanonicalPath, report),
+			Summary:        failureCheckSummary(input.CanonicalPath, report, sourceLinks),
 		},
 	}
 	return workflow, []transport.Artifact{messageArtifact, annotationArtifact}
@@ -1839,7 +1843,7 @@ func generatedFailureArtifact(kind, extension, contents string) transport.Artifa
 	return transport.Artifact{Path: path, Digest: digest, Contents: encoded}
 }
 
-func failureCheckSummary(path string, report compatibility.ProcessingReport) string {
+func failureCheckSummary(path string, report compatibility.ProcessingReport, sourceLinks sourceLinkContext) string {
 	if path == "" {
 		path = report.Workflow
 	}
@@ -1862,7 +1866,20 @@ func failureCheckSummary(path string, report compatibility.ProcessingReport) str
 			message = strings.TrimPrefix(message, fmt.Sprintf("job %q: ", diagnostic.Job))
 		}
 		summary.WriteString("\n- ")
-		summary.WriteString(markdownCode(diagnosticPath))
+		pathCode := markdownCode(diagnosticPath)
+		line := 0
+		if diagnostic.Location != nil {
+			line = diagnostic.Location.Line
+		}
+		if link := sourceLinks.link(diagnosticPath, line); link != "" {
+			summary.WriteString("[")
+			summary.WriteString(pathCode)
+			summary.WriteString("](")
+			summary.WriteString(link)
+			summary.WriteString(")")
+		} else {
+			summary.WriteString(pathCode)
+		}
 		if diagnostic.Job != "" {
 			summary.WriteString(", job ")
 			summary.WriteString(markdownCode(diagnostic.Job))

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1866,7 +1866,9 @@ func failureCheckSummary(path string, report compatibility.ProcessingReport, sou
 	if path == "" {
 		path = report.Workflow
 	}
-	sourceLinks.workflowSourceRoot = processingWorkflowSourceRoot(report.Workflow)
+	if _, linkable := processingAnnotationWorkflowPath(report.Workflow, ""); linkable {
+		sourceLinks.workflowSourceRoot = processingWorkflowSourceRoot(report.Workflow)
+	}
 	var summary strings.Builder
 	summary.WriteString("The workflow could not be prepared:\n")
 	for _, diagnostic := range report.Diagnostics {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1253,7 +1253,11 @@ func validate(args []string, stdout, stderr io.Writer, version string, agent tra
 	out := newProcessingOutput("validate", format, stdout, stderr, agent)
 	var loadEvent func() ([]byte, error)
 	if eventPath != "" {
-		loadEvent = func() ([]byte, error) { return os.ReadFile(eventPath) }
+		event, eventErr := os.ReadFile(eventPath)
+		if parsedEvent, parseErr := compiler.ParseEvent(event); eventErr == nil && parseErr == nil {
+			out.sourceLinks = sourceLinksForEvent(parsedEvent)
+		}
+		loadEvent = func() ([]byte, error) { return event, eventErr }
 	}
 	source, event, ok := loadProcessingInputs(out, workflowPath, profile, "event input could not be read", loadEvent)
 	if !ok {
@@ -1375,12 +1379,13 @@ func compile(args []string, stdout, stderr io.Writer, version string, agent tran
 		return usageError(stderr, "compile: --event-path is required")
 	}
 	out := newProcessingOutput("compile", "text", stderr, stderr, agent)
-	source, event, ok := loadProcessingInputs(out, workflowPath, "", "event input could not be read", func() ([]byte, error) { return os.ReadFile(eventPath) })
+	event, eventErr := os.ReadFile(eventPath)
+	if parsedEvent, parseErr := compiler.ParseEvent(event); eventErr == nil && parseErr == nil {
+		out.sourceLinks = sourceLinksForEvent(parsedEvent)
+	}
+	source, event, ok := loadProcessingInputs(out, workflowPath, "", "event input could not be read", func() ([]byte, error) { return event, eventErr })
 	if !ok {
 		return 1
-	}
-	if parsedEvent, parseErr := compiler.ParseEvent(event); parseErr == nil {
-		out.sourceLinks = sourceLinksForEvent(parsedEvent)
 	}
 	processingReport, ok := validatedProcessingReport(out, workflowPath, "", source, event, true)
 	if !ok {
@@ -1473,6 +1478,19 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 	if uploadArguments.telemetry != nil {
 		out.observe = uploadArguments.telemetry.observe
 	}
+	var eventSource []byte
+	var eventOrigin effectiveEventOrigin
+	var eventLoadErr error
+	if eventPath != "" {
+		eventSource, eventOrigin, eventLoadErr = loadEffectiveEventSource(ctx, eventPath, agent)
+		if parsedEvent, parseErr := compiler.ParseEvent(eventSource); eventLoadErr == nil && parseErr == nil {
+			out.sourceLinks = sourceLinksForEvent(parsedEvent)
+		}
+	} else if buildEvent, buildEventErr := buildkiteEventSource(os.Getenv); buildEventErr == nil {
+		if parsedEvent, parseErr := compiler.ParseEvent(buildEvent); parseErr == nil {
+			out.sourceLinks = sourceLinksForEvent(parsedEvent)
+		}
+	}
 	var workflows []workflowInput
 	var err error
 	if uploadArguments.explicitWorkflowPaths {
@@ -1519,17 +1537,19 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 			return 1
 		}
 	}
-	eventSource, eventOrigin, err := loadEffectiveEventSource(ctx, eventPath, agent)
-	if err != nil {
+	if eventPath == "" {
+		eventSource, eventOrigin, eventLoadErr = loadEffectiveEventSource(ctx, eventPath, agent)
+	}
+	if eventLoadErr != nil {
 		for _, input := range workflows {
 			if !input.ReusableOnly {
-				return out.fail(compatibility.EventInputProcessingReport(input.Path, hostedProfile, input.Source, "event input could not be acquired"), err)
+				return out.fail(compatibility.EventInputProcessingReport(input.Path, hostedProfile, input.Source, "event input could not be acquired"), eventLoadErr)
 			}
 		}
 		return 1
 	}
-	effectiveEvent, err := newEffectiveEvent(eventSource, eventOrigin, os.Getenv)
-	if err != nil {
+	effectiveEvent, eventParseErr := newEffectiveEvent(eventSource, eventOrigin, os.Getenv)
+	if eventParseErr != nil {
 		for _, input := range workflows {
 			if !input.ReusableOnly {
 				_, _ = validatedProcessingReport(out, input.Path, hostedProfile, input.Source, eventSource, true)
@@ -1538,7 +1558,6 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 		}
 		return 1
 	}
-	out.sourceLinks = sourceLinksForEvent(effectiveEvent.Event)
 	processingReports := make([]compatibility.ProcessingReport, len(workflows))
 	for i := range workflows {
 		if workflows[i].ReusableOnly {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2608,6 +2608,28 @@ func TestProcessingAnnotationUsesRepositoryRelativeWorkflowPath(t *testing.T) {
 	}
 }
 
+func TestProcessingAnnotationResolvesPathsFromBelowCheckoutRoot(t *testing.T) {
+	repository := t.TempDir()
+	workingDirectory := filepath.Join(repository, ".github")
+	if err := os.MkdirAll(workingDirectory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(workingDirectory)
+	t.Setenv("BUILDKITE_BUILD_CHECKOUT_PATH", repository)
+	report := compatibility.NewProcessingReport("workflows/hello.yml", "")
+	report.Diagnostics = append(report.Diagnostics, compatibility.Diagnostic{
+		Level: "error", Message: "invalid workflow",
+		Location: &compatibility.SourceLocation{Path: "workflows/hello.yml", Line: 100, Column: 3},
+	})
+	sourceLinks := sourceLinkContext{serverURL: "https://github.com", repository: "owner/repo", sha: "abc123"}
+
+	_, body := processingAnnotation(report, sourceLinks)
+	want := `href="https://github.com/owner/repo/blob/abc123/.github/workflows/hello.yml#L100"`
+	if !strings.Contains(body, want) {
+		t.Fatalf("annotation = %q, want %q", body, want)
+	}
+}
+
 func TestProcessingAnnotationLinksWorkflowLocationsToSource(t *testing.T) {
 	report := compatibility.NewProcessingReport(".github/workflows/hello world.yml", "")
 	report.Diagnostics = append(report.Diagnostics, compatibility.Diagnostic{

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2631,6 +2631,9 @@ func TestProcessingAnnotationResolvesPathsFromBelowCheckoutRoot(t *testing.T) {
 }
 
 func TestProcessingAnnotationLinksWorkflowLocationsToSource(t *testing.T) {
+	repository := t.TempDir()
+	t.Chdir(repository)
+	t.Setenv("BUILDKITE_BUILD_CHECKOUT_PATH", repository)
 	report := compatibility.NewProcessingReport(".github/workflows/hello world.yml", "")
 	report.Diagnostics = append(report.Diagnostics, compatibility.Diagnostic{
 		Level: "error", Message: "invalid workflow",

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2504,6 +2504,39 @@ func TestValidatePublishesProcessingDiagnosticsInBuildkite(t *testing.T) {
 	})
 }
 
+func TestEventBackedCommandsLinkEarlyWorkflowDiagnostics(t *testing.T) {
+	repository := t.TempDir()
+	workflowPath := filepath.Join(repository, ".github", "workflows", "broken.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(workflowPath, []byte("on: push\njobs: [\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	eventPath := writeUploadEvent(t, repository, "push", "refs/heads/main", map[string]any{})
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_JOB_ID", cliTestJobID)
+	t.Setenv("BUILDKITE_STEP_KEY", "importer")
+	t.Setenv("BUILDKITE_BUILD_CHECKOUT_PATH", repository)
+
+	for _, command := range []string{"validate", "upload"} {
+		t.Run(command, func(t *testing.T) {
+			runner := &cliCaptureRunner{}
+			var stdout, stderr bytes.Buffer
+			if code := run([]string{command, "--event-path", eventPath, workflowPath}, &stdout, &stderr, "dev", runner); code != 1 {
+				t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+			}
+			if len(runner.commands) != 1 {
+				t.Fatalf("commands = %#v, want one annotation", runner.commands)
+			}
+			want := `href="https://github.com/buildkite/buildkite-gha/blob/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/.github/workflows/broken.yml`
+			if !strings.Contains(string(runner.commands[0].stdin), want) {
+				t.Fatalf("annotation = %q, want linked workflow path %q", runner.commands[0].stdin, want)
+			}
+		})
+	}
+}
+
 func TestProcessingAnnotationIsBoundedAndEscapesHTML(t *testing.T) {
 	report := compatibility.NewProcessingReport("<workflow>|name", "")
 	report.Diagnostics = append(report.Diagnostics, compatibility.Diagnostic{

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2582,9 +2582,9 @@ func TestProcessingAnnotationDropsDetailBeforeTruncatingMessage(t *testing.T) {
 	}
 	withoutDetail := diagnostic
 	withoutDetail.Detail = ""
-	want := renderProcessingDiagnostic(withoutDetail)
+	want := renderProcessingDiagnostic(withoutDetail, sourceLinkContext{})
 
-	got := renderProcessingDiagnosticWithin(diagnostic, len(want))
+	got := renderProcessingDiagnosticWithin(diagnostic, len(want), sourceLinkContext{})
 	if got != want || strings.Contains(got, "<details") {
 		t.Fatalf("bounded diagnostic = %q, want primary message without detail %q", got, want)
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2702,6 +2702,9 @@ func TestProcessingDiagnosticsDoNotLinkPathsOutsideCheckout(t *testing.T) {
 	report.Diagnostics = append(report.Diagnostics, compatibility.Diagnostic{
 		Level: "error", Message: "invalid workflow",
 		Location: &compatibility.SourceLocation{Path: "ci.yml", Line: 4, Column: 2},
+	}, compatibility.Diagnostic{
+		Level: "error", Message: "invalid reusable workflow",
+		Location: &compatibility.SourceLocation{Path: "./.github/workflows/ci.yml", Line: 5, Column: 3},
 	})
 	sourceLinks := sourceLinkContext{serverURL: "https://github.com", repository: "owner/repo", sha: "abc123"}
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2611,7 +2611,11 @@ func TestProcessingAnnotationUsesRepositoryRelativeWorkflowPath(t *testing.T) {
 func TestProcessingAnnotationResolvesPathsFromBelowCheckoutRoot(t *testing.T) {
 	repository := t.TempDir()
 	workingDirectory := filepath.Join(repository, ".github")
-	if err := os.MkdirAll(workingDirectory, 0o755); err != nil {
+	workflowPath := filepath.Join(workingDirectory, "workflows", "hello.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(workflowPath, []byte("on: push\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	t.Chdir(workingDirectory)
@@ -2633,8 +2637,14 @@ func TestProcessingAnnotationResolvesPathsFromBelowCheckoutRoot(t *testing.T) {
 func TestProcessingAnnotationResolvesCompilerLocationsFromCheckoutRoot(t *testing.T) {
 	repository := t.TempDir()
 	workingDirectory := filepath.Join(repository, ".github")
-	if err := os.MkdirAll(workingDirectory, 0o755); err != nil {
+	workflowDirectory := filepath.Join(workingDirectory, "workflows")
+	if err := os.MkdirAll(workflowDirectory, 0o755); err != nil {
 		t.Fatal(err)
+	}
+	for _, name := range []string{"caller.yml", "build-security.yml"} {
+		if err := os.WriteFile(filepath.Join(workflowDirectory, name), []byte("on: workflow_call\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
 	}
 	t.Chdir(workingDirectory)
 	t.Setenv("BUILDKITE_BUILD_CHECKOUT_PATH", repository)
@@ -2658,6 +2668,11 @@ func TestProcessingDiagnosticsRetainNestedWorkflowSourceRoot(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(workingDirectory, ".github", "workflows"), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	for _, name := range []string{"caller.yml", "build-security.yml"} {
+		if err := os.WriteFile(filepath.Join(workingDirectory, ".github", "workflows", name), []byte("on: workflow_call\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
 	t.Chdir(workingDirectory)
 	t.Setenv("BUILDKITE_BUILD_CHECKOUT_PATH", repository)
 	report := compatibility.NewProcessingReport("./.github/workflows/caller.yml", "")
@@ -2677,6 +2692,13 @@ func TestProcessingDiagnosticsRetainNestedWorkflowSourceRoot(t *testing.T) {
 
 func TestProcessingAnnotationLinksWorkflowLocationsToSource(t *testing.T) {
 	repository := t.TempDir()
+	workflowPath := filepath.Join(repository, ".github", "workflows", "hello world.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(workflowPath, []byte("on: push\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	t.Chdir(repository)
 	t.Setenv("BUILDKITE_BUILD_CHECKOUT_PATH", repository)
 	report := compatibility.NewProcessingReport(".github/workflows/hello world.yml", "")
@@ -2735,6 +2757,32 @@ func TestProcessingDiagnosticsDoNotLinkPathsOutsideCheckout(t *testing.T) {
 	summary := failureCheckSummary("ci.yml", report, sourceLinks)
 	if strings.Contains(annotation, "href=") || strings.Contains(summary, "](https://") {
 		t.Fatalf("outside path was linked: annotation=%q summary=%q", annotation, summary)
+	}
+}
+
+func TestProcessingDiagnosticsDoNotLinkSymlinksOutsideCheckout(t *testing.T) {
+	checkout := t.TempDir()
+	outside := t.TempDir()
+	target := filepath.Join(outside, "ci.yml")
+	if err := os.WriteFile(target, []byte("on: push\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	workflowPath := filepath.Join(checkout, "ci.yml")
+	if err := os.Symlink(target, workflowPath); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BUILDKITE_BUILD_CHECKOUT_PATH", checkout)
+	report := compatibility.NewProcessingReport(workflowPath, "hosted")
+	report.Diagnostics = append(report.Diagnostics, compatibility.Diagnostic{
+		Level: "error", Message: "invalid workflow",
+		Location: &compatibility.SourceLocation{Path: workflowPath, Line: 1, Column: 1},
+	})
+	sourceLinks := sourceLinkContext{serverURL: "https://github.com", repository: "owner/repo", sha: "abc123"}
+
+	_, annotation := processingAnnotation(report, sourceLinks)
+	summary := failureCheckSummary(workflowPath, report, sourceLinks)
+	if strings.Contains(annotation, "href=") || strings.Contains(summary, "](https://") {
+		t.Fatalf("outside symlink was linked: annotation=%q summary=%q", annotation, summary)
 	}
 }
 
@@ -4225,6 +4273,13 @@ func TestFailureCheckSummaryUsesDiagnosticWorkflowPath(t *testing.T) {
 
 func TestFailureCheckSummaryLinksDiagnosticWorkflowPath(t *testing.T) {
 	repository := t.TempDir()
+	workflowPath := filepath.Join(repository, ".github", "workflows", "hello.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(workflowPath, []byte("on: push\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	t.Chdir(repository)
 	t.Setenv("BUILDKITE_BUILD_CHECKOUT_PATH", repository)
 	report := compatibility.NewProcessingReport(".github/workflows/hello.yml", "hosted")

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2510,7 +2510,7 @@ func TestProcessingAnnotationIsBoundedAndEscapesHTML(t *testing.T) {
 		Level: "error", Code: "E_TEST", Message: `line one
 <script>*unsafe*</script> "quoted" ` + strings.Repeat("界", processingAnnotationBodyLimit),
 	})
-	style, body := processingAnnotation(report)
+	style, body := processingAnnotation(report, sourceLinkContext{})
 	if style != "error" || len(body) > processingAnnotationBodyLimit || !utf8.ValidString(body) {
 		t.Fatalf("style = %q, bytes = %d, valid UTF-8 = %v", style, len(body), utf8.ValidString(body))
 	}
@@ -2527,7 +2527,7 @@ func TestProcessingAnnotationIsBoundedAndEscapesHTML(t *testing.T) {
 func TestProcessingAnnotationReservesSpaceForTruncationNotice(t *testing.T) {
 	report := compatibility.NewProcessingReport("ci.yml", "")
 	probe := compatibility.Diagnostic{Level: "warning", Code: "W_LARGE", Message: "a"}
-	probeRow := renderProcessingDiagnostic(probe)
+	probeRow := renderProcessingDiagnostic(probe, sourceLinkContext{})
 	prefixBytes := len("<h2 class=\"h4 mb2\">GitHub Actions workflow diagnostics</h2>\n") +
 		len("<div class=\"mb2\"><strong>Workflow:</strong> ") + len(annotationCode(report.Workflow)) +
 		len("</div>\n<div class=\"mb2\">\n")
@@ -2537,7 +2537,7 @@ func TestProcessingAnnotationReservesSpaceForTruncationNotice(t *testing.T) {
 		compatibility.Diagnostic{Level: "warning", Code: "W_OMITTED", Message: "omitted diagnostic"},
 	)
 
-	_, body := processingAnnotation(report)
+	_, body := processingAnnotation(report, sourceLinkContext{})
 	if len(body) > processingAnnotationBodyLimit || !strings.Contains(body, "Additional diagnostics omitted") {
 		t.Fatalf("annotation bytes = %d, notice present = %v", len(body), strings.Contains(body, "Additional diagnostics omitted"))
 	}
@@ -2567,11 +2567,49 @@ func TestProcessingAnnotationUsesRepositoryRelativeWorkflowPath(t *testing.T) {
 		Location: &compatibility.SourceLocation{Path: workflowPath, Line: 4, Column: 2},
 	})
 
-	_, body := processingAnnotation(report)
+	_, body := processingAnnotation(report, sourceLinkContext{})
 	wantWorkflow := "<strong>Workflow:</strong> <code>.github/workflows/test-image-build.yml</code>"
 	wantLocation := "<code>.github/workflows/test-image-build.yml:4:2</code>"
 	if !strings.Contains(body, wantWorkflow) || !strings.Contains(body, wantLocation) || strings.Contains(body, repository) {
 		t.Fatalf("annotation = %q, want %q and %q without checkout path", body, wantWorkflow, wantLocation)
+	}
+}
+
+func TestProcessingAnnotationLinksWorkflowLocationsToSource(t *testing.T) {
+	report := compatibility.NewProcessingReport(".github/workflows/hello world.yml", "")
+	report.Diagnostics = append(report.Diagnostics, compatibility.Diagnostic{
+		Level: "error", Message: "invalid workflow",
+		Location: &compatibility.SourceLocation{Path: ".github/workflows/hello world.yml", Line: 100, Column: 3},
+	})
+	sourceLinks := sourceLinkContext{serverURL: "https://github.example.com", repository: "owner/repo", sha: "abc123"}
+
+	_, body := processingAnnotation(report, sourceLinks)
+	for _, want := range []string{
+		`<a href="https://github.example.com/owner/repo/blob/abc123/.github/workflows/hello%20world.yml"><code>.github/workflows/hello world.yml</code></a>`,
+		`<a href="https://github.example.com/owner/repo/blob/abc123/.github/workflows/hello%20world.yml#L100"><code>.github/workflows/hello world.yml:100:3</code></a>`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("annotation = %q, want %q", body, want)
+		}
+	}
+}
+
+func TestSourceLinkRequiresRepositoryContextAndRelativePath(t *testing.T) {
+	configured := sourceLinkContext{serverURL: "https://github.com", repository: "owner/repo", sha: "abc123"}
+	for _, test := range []struct {
+		name    string
+		context sourceLinkContext
+		path    string
+	}{
+		{name: "missing context", path: ".github/workflows/ci.yml"},
+		{name: "absolute path", context: configured, path: "/tmp/ci.yml"},
+		{name: "path traversal", context: configured, path: "../ci.yml"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.context.link(test.path, 1); got != "" {
+				t.Fatalf("link() = %q, want empty", got)
+			}
+		})
 	}
 }
 
@@ -2581,7 +2619,7 @@ func TestProcessingAnnotationDoesNotRepeatDiagnosticLocation(t *testing.T) {
 		Level: "warning", Code: "W_TEST", Message: "ci.yml:4:23: warning message",
 		Location: &compatibility.SourceLocation{Path: "ci.yml", Line: 4, Column: 23},
 	})
-	_, body := processingAnnotation(report)
+	_, body := processingAnnotation(report, sourceLinkContext{})
 	if count := strings.Count(body, "ci.yml:4:23"); count != 1 {
 		t.Fatalf("annotation location count = %d, want 1: %q", count, body)
 	}
@@ -2604,7 +2642,7 @@ func TestProcessingAnnotationPresentsActionFailureAsAConciseCard(t *testing.T) {
 		Job:     "test", Instance: "gha-test-a1b2", Action: "actions/setup-java@v4", Step: 2,
 	})
 
-	_, body := processingAnnotation(report)
+	_, body := processingAnnotation(report, sourceLinkContext{})
 	for _, want := range []string{
 		`<div class="border-top border-gray py2"><div><strong>Action metadata uses unsupported field &#34;deprecationMessage&#34;</strong></div>`,
 		"Action <code>actions/setup-java@v4</code> · Job <code>test</code> · Step 2",
@@ -2691,7 +2729,7 @@ func TestProcessingDiagnosticRenderingsUseTheSameMessageAndAggregation(t *testin
 	if err := compatibility.WriteProcessing(&textOutput, "text", report); err != nil {
 		t.Fatal(err)
 	}
-	_, annotation := processingAnnotation(report)
+	_, annotation := processingAnnotation(report, sourceLinkContext{})
 	if strings.Count(textOutput.String(), message) != 1 || strings.Count(textOutput.String(), "detail: "+detail) != 1 ||
 		strings.Count(annotation, `Job &#34;test&#34; needs GITHUB_TOKEN, but job-level permissions are unsupported.`) != 1 ||
 		strings.Count(annotation, `Move permissions to the workflow level.`) != 1 ||
@@ -3992,7 +4030,7 @@ func TestFailedGeneratedWorkflowIncludesWarnings(t *testing.T) {
 		compatibility.Diagnostic{Level: "error", Code: "E_RUNNER", Message: "runner is unsupported", Job: "test"},
 	)
 
-	workflow, artifacts := failedGeneratedWorkflow(workflowInput{Name: "CI", CanonicalPath: ".github/workflows/ci.yml", Identity: "ci", TriggerCondition: "false"}, "push", report)
+	workflow, artifacts := failedGeneratedWorkflow(workflowInput{Name: "CI", CanonicalPath: ".github/workflows/ci.yml", Identity: "ci", TriggerCondition: "false"}, "push", report, sourceLinkContext{})
 	wantSummary := "The workflow could not be prepared:\n\n- `.github/workflows/ci.yml`, job `test`: runner is unsupported"
 	if workflow.Condition != "" || workflow.Failure == nil || len(artifacts) != 2 || workflow.Failure.MessagePath != artifacts[0].Path || workflow.Failure.AnnotationPath != artifacts[1].Path || !bytes.HasPrefix(artifacts[0].Contents, []byte("\x1b[31m")) || !bytes.HasSuffix(artifacts[0].Contents, []byte("\x1b[0m\n")) || !strings.Contains(string(artifacts[1].Contents), `<h2 class="h4 mb2">GitHub Actions workflow diagnostics</h2>`) || !strings.Contains(string(artifacts[1].Contents), "<strong>runner is unsupported</strong>") || !strings.Contains(string(artifacts[1].Contents), "<strong>cancel-in-progress is ignored</strong>") || workflow.Failure.Summary != wantSummary {
 		t.Fatalf("failure = %#v", workflow.Failure)
@@ -4003,7 +4041,7 @@ func TestFailedGeneratedWorkflowKeepsLargeDiagnosticsOutOfCommand(t *testing.T) 
 	message := strings.Repeat("large diagnostic ", 16*1024)
 	report := compatibility.NewProcessingReport("ci.yml", "hosted")
 	report.Diagnostics = append(report.Diagnostics, compatibility.Diagnostic{Level: "error", Message: message})
-	workflow, artifacts := failedGeneratedWorkflow(workflowInput{Name: "CI", CanonicalPath: "ci.yml", Identity: "ci", TriggerCondition: "true"}, "push", report)
+	workflow, artifacts := failedGeneratedWorkflow(workflowInput{Name: "CI", CanonicalPath: "ci.yml", Identity: "ci", TriggerCondition: "true"}, "push", report, sourceLinkContext{})
 
 	pipeline, err := buildkitepipeline.Emit(buildkitepipeline.Pipeline{CompilerStep: "importer", EventProvider: "github", Workflows: []buildkitepipeline.Workflow{workflow}})
 	if err != nil {
@@ -4037,7 +4075,7 @@ func TestFailureCheckSummaryFitsProviderLimit(t *testing.T) {
 		Level: "error", Message: strings.Repeat("x", workflowCheckSummaryLimit) + "🙂", Job: "test",
 	})
 
-	summary := failureCheckSummary("ci.yml", report)
+	summary := failureCheckSummary("ci.yml", report, sourceLinkContext{})
 	if len(summary) > workflowCheckSummaryLimit || !utf8.ValidString(summary) || !strings.HasSuffix(summary, "_Additional error details omitted at the provider check summary size limit._") {
 		t.Fatalf("truncated provider check summary is invalid: bytes=%d, valid UTF-8=%t, suffix=%q", len(summary), utf8.ValidString(summary), summary[len(summary)-100:])
 	}
@@ -4055,7 +4093,21 @@ func TestFailureCheckSummaryUsesDiagnosticWorkflowPath(t *testing.T) {
 		"- `.github/workflows/caller.yml`, job `caller`: caller failed\n" +
 		"- `.github/workflows/reusable.yml`, job `called`: reusable failed\n" +
 		"- `.github/workflows/absolute.yml`, job `absolute`: absolute reusable failed"
-	if got := failureCheckSummary(".github/workflows/caller.yml", report); got != want {
+	if got := failureCheckSummary(".github/workflows/caller.yml", report, sourceLinkContext{}); got != want {
+		t.Fatalf("failureCheckSummary() = %q, want %q", got, want)
+	}
+}
+
+func TestFailureCheckSummaryLinksDiagnosticWorkflowPath(t *testing.T) {
+	report := compatibility.NewProcessingReport(".github/workflows/hello.yml", "hosted")
+	report.Diagnostics = append(report.Diagnostics, compatibility.Diagnostic{
+		Level: "error", Message: "runner is unsupported", Job: "test",
+		Location: &compatibility.SourceLocation{Path: ".github/workflows/hello.yml", Line: 100, Column: 3},
+	})
+	sourceLinks := sourceLinkContext{serverURL: "https://github.com", repository: "owner/repo", sha: "abc123"}
+	want := "The workflow could not be prepared:\n\n- [`.github/workflows/hello.yml`](https://github.com/owner/repo/blob/abc123/.github/workflows/hello.yml#L100), job `test`: runner is unsupported"
+
+	if got := failureCheckSummary(".github/workflows/hello.yml", report, sourceLinks); got != want {
 		t.Fatalf("failureCheckSummary() = %q, want %q", got, want)
 	}
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2786,6 +2786,30 @@ func TestProcessingDiagnosticsDoNotLinkSymlinksOutsideCheckout(t *testing.T) {
 	}
 }
 
+func TestProcessingDiagnosticsLinkThroughCheckoutRootSymlink(t *testing.T) {
+	realCheckout := t.TempDir()
+	workflowPath := filepath.Join(realCheckout, "ci.yml")
+	if err := os.WriteFile(workflowPath, []byte("on: push\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	checkout := filepath.Join(t.TempDir(), "checkout")
+	if err := os.Symlink(realCheckout, checkout); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BUILDKITE_BUILD_CHECKOUT_PATH", checkout)
+	report := compatibility.NewProcessingReport(filepath.Join(checkout, "ci.yml"), "hosted")
+	report.Diagnostics = append(report.Diagnostics, compatibility.Diagnostic{
+		Level: "error", Message: "invalid workflow",
+		Location: &compatibility.SourceLocation{Path: filepath.Join(checkout, "ci.yml"), Line: 1, Column: 1},
+	})
+	sourceLinks := sourceLinkContext{serverURL: "https://github.com", repository: "owner/repo", sha: "abc123"}
+
+	_, annotation := processingAnnotation(report, sourceLinks)
+	if want := `href="https://github.com/owner/repo/blob/abc123/ci.yml#L1"`; !strings.Contains(annotation, want) {
+		t.Fatalf("checkout symlink location was not linked: annotation=%q want=%q", annotation, want)
+	}
+}
+
 func TestProcessingAnnotationDoesNotRepeatDiagnosticLocation(t *testing.T) {
 	report := compatibility.NewProcessingReport("ci.yml", "")
 	report.Diagnostics = append(report.Diagnostics, compatibility.Diagnostic{

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2630,6 +2630,28 @@ func TestProcessingAnnotationResolvesPathsFromBelowCheckoutRoot(t *testing.T) {
 	}
 }
 
+func TestProcessingAnnotationResolvesCompilerLocationsFromCheckoutRoot(t *testing.T) {
+	repository := t.TempDir()
+	workingDirectory := filepath.Join(repository, ".github")
+	if err := os.MkdirAll(workingDirectory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(workingDirectory)
+	t.Setenv("BUILDKITE_BUILD_CHECKOUT_PATH", repository)
+	report := compatibility.NewProcessingReport("workflows/caller.yml", "")
+	report.Diagnostics = append(report.Diagnostics, compatibility.Diagnostic{
+		Level: "error", Message: "invalid reusable workflow",
+		Location: &compatibility.SourceLocation{Path: "./.github/workflows/build-security.yml", Line: 35, Column: 13},
+	})
+	sourceLinks := sourceLinkContext{serverURL: "https://github.com", repository: "owner/repo", sha: "abc123"}
+
+	_, body := processingAnnotation(report, sourceLinks)
+	want := `<a href="https://github.com/owner/repo/blob/abc123/.github/workflows/build-security.yml#L35"><code>.github/workflows/build-security.yml:35:13</code></a>`
+	if !strings.Contains(body, want) {
+		t.Fatalf("annotation = %q, want %q", body, want)
+	}
+}
+
 func TestProcessingAnnotationLinksWorkflowLocationsToSource(t *testing.T) {
 	repository := t.TempDir()
 	t.Chdir(repository)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2671,6 +2671,25 @@ func TestSourceLinkRequiresRepositoryContextAndRelativePath(t *testing.T) {
 	}
 }
 
+func TestProcessingDiagnosticsDoNotLinkPathsOutsideCheckout(t *testing.T) {
+	checkout := t.TempDir()
+	outside := t.TempDir()
+	t.Chdir(outside)
+	t.Setenv("BUILDKITE_BUILD_CHECKOUT_PATH", checkout)
+	report := compatibility.NewProcessingReport("ci.yml", "hosted")
+	report.Diagnostics = append(report.Diagnostics, compatibility.Diagnostic{
+		Level: "error", Message: "invalid workflow",
+		Location: &compatibility.SourceLocation{Path: "ci.yml", Line: 4, Column: 2},
+	})
+	sourceLinks := sourceLinkContext{serverURL: "https://github.com", repository: "owner/repo", sha: "abc123"}
+
+	_, annotation := processingAnnotation(report, sourceLinks)
+	summary := failureCheckSummary("ci.yml", report, sourceLinks)
+	if strings.Contains(annotation, "href=") || strings.Contains(summary, "](https://") {
+		t.Fatalf("outside path was linked: annotation=%q summary=%q", annotation, summary)
+	}
+}
+
 func TestProcessingAnnotationDoesNotRepeatDiagnosticLocation(t *testing.T) {
 	report := compatibility.NewProcessingReport("ci.yml", "")
 	report.Diagnostics = append(report.Diagnostics, compatibility.Diagnostic{
@@ -4157,6 +4176,9 @@ func TestFailureCheckSummaryUsesDiagnosticWorkflowPath(t *testing.T) {
 }
 
 func TestFailureCheckSummaryLinksDiagnosticWorkflowPath(t *testing.T) {
+	repository := t.TempDir()
+	t.Chdir(repository)
+	t.Setenv("BUILDKITE_BUILD_CHECKOUT_PATH", repository)
 	report := compatibility.NewProcessingReport(".github/workflows/hello.yml", "hosted")
 	report.Diagnostics = append(report.Diagnostics, compatibility.Diagnostic{
 		Level: "error", Message: "runner is unsupported", Job: "test",

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2652,6 +2652,29 @@ func TestProcessingAnnotationResolvesCompilerLocationsFromCheckoutRoot(t *testin
 	}
 }
 
+func TestProcessingDiagnosticsRetainNestedWorkflowSourceRoot(t *testing.T) {
+	repository := t.TempDir()
+	workingDirectory := filepath.Join(repository, "nested")
+	if err := os.MkdirAll(filepath.Join(workingDirectory, ".github", "workflows"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(workingDirectory)
+	t.Setenv("BUILDKITE_BUILD_CHECKOUT_PATH", repository)
+	report := compatibility.NewProcessingReport("./.github/workflows/caller.yml", "")
+	report.Diagnostics = append(report.Diagnostics, compatibility.Diagnostic{
+		Level: "error", Message: "invalid reusable workflow",
+		Location: &compatibility.SourceLocation{Path: "./.github/workflows/build-security.yml", Line: 35, Column: 13},
+	})
+	sourceLinks := sourceLinkContext{serverURL: "https://github.com", repository: "owner/repo", sha: "abc123"}
+	wantLink := "https://github.com/owner/repo/blob/abc123/nested/.github/workflows/build-security.yml#L35"
+
+	_, annotation := processingAnnotation(report, sourceLinks)
+	summary := failureCheckSummary("./.github/workflows/caller.yml", report, sourceLinks)
+	if !strings.Contains(annotation, `href="`+wantLink+`"`) || !strings.Contains(summary, "]("+wantLink+")") {
+		t.Fatalf("nested workflow location was not retained: annotation=%q summary=%q", annotation, summary)
+	}
+}
+
 func TestProcessingAnnotationLinksWorkflowLocationsToSource(t *testing.T) {
 	repository := t.TempDir()
 	t.Chdir(repository)

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -196,14 +196,17 @@ func processingAnnotation(report compatibility.ProcessingReport, sourceLinks sou
 }
 
 func processingAnnotationWorkflowPath(path string) string {
-	if !filepath.IsAbs(path) {
-		return filepath.ToSlash(filepath.Clean(path))
-	}
 	root := os.Getenv("BUILDKITE_BUILD_CHECKOUT_PATH")
 	if root == "" {
 		root, _ = os.Getwd()
 	}
-	relative, err := filepath.Rel(root, path)
+	resolved := path
+	if !filepath.IsAbs(resolved) {
+		if workingDirectory, err := os.Getwd(); err == nil {
+			resolved = filepath.Join(workingDirectory, resolved)
+		}
+	}
+	relative, err := filepath.Rel(root, resolved)
 	if err == nil && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
 		return filepath.ToSlash(relative)
 	}

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -163,8 +163,10 @@ func processingAnnotation(report compatibility.ProcessingReport, sourceLinks sou
 	var out strings.Builder
 	out.WriteString("<h2 class=\"h4 mb2\">GitHub Actions workflow diagnostics</h2>\n")
 	out.WriteString("<div class=\"mb2\"><strong>Workflow:</strong> ")
-	sourceLinks.workflowSourceRoot = processingWorkflowSourceRoot(report.Workflow)
 	workflowPath, workflowLinkable := processingAnnotationWorkflowPath(report.Workflow, "")
+	if workflowLinkable {
+		sourceLinks.workflowSourceRoot = processingWorkflowSourceRoot(report.Workflow)
+	}
 	out.WriteString(annotationSourcePath(workflowPath, 0, 0, workflowLinkable, sourceLinks))
 	out.WriteString("</div>\n<div class=\"mb2\">\n")
 	rows := make([]string, len(diagnostics))
@@ -223,11 +225,19 @@ func processingAnnotationWorkflowPath(path, workflowSourceRoot string) (display 
 			resolved = filepath.Join(workingDirectory, resolved)
 		}
 	}
-	relative, err := filepath.Rel(root, resolved)
+	display = filepath.ToSlash(filepath.Clean(path))
+	if relative, err := filepath.Rel(root, resolved); err == nil && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		display = filepath.ToSlash(relative)
+	}
+	canonical, err := filepath.EvalSymlinks(resolved)
+	if err != nil {
+		return display, false
+	}
+	relative, err := filepath.Rel(root, canonical)
 	if err == nil && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
 		return filepath.ToSlash(relative), true
 	}
-	return filepath.ToSlash(filepath.Clean(path)), false
+	return display, false
 }
 
 func renderProcessingDiagnosticWithin(diagnostic compatibility.Diagnostic, limit int, sourceLinks sourceLinkContext) string {

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"html"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/buildkite/buildkite-gha/internal/compatibility"
 	"github.com/buildkite/buildkite-gha/internal/compiler"
+	"github.com/buildkite/buildkite-gha/internal/plan"
 	"github.com/buildkite/buildkite-gha/internal/transport"
 )
 
@@ -38,6 +40,37 @@ type processingOutput struct {
 	buildURL      string
 	stepID        string
 	agent         transport.Agent
+	sourceLinks   sourceLinkContext
+}
+
+type sourceLinkContext struct {
+	serverURL  string
+	repository string
+	sha        string
+}
+
+func sourceLinksForEvent(event compiler.Event) sourceLinkContext {
+	return sourceLinkContext{
+		serverURL:  plan.EventServerURL(event.Provider),
+		repository: event.Repository.Owner + "/" + event.Repository.Name,
+		sha:        event.SHA,
+	}
+}
+
+func (c sourceLinkContext) link(path string, line int) string {
+	path = strings.TrimPrefix(filepath.ToSlash(filepath.Clean(path)), "./")
+	if c.serverURL == "" || c.repository == "" || c.sha == "" || path == "." || filepath.IsAbs(path) || path == ".." || strings.HasPrefix(path, "../") {
+		return ""
+	}
+	segments := strings.Split(c.repository+"/blob/"+c.sha+"/"+path, "/")
+	for i := range segments {
+		segments[i] = url.PathEscape(segments[i])
+	}
+	link := strings.TrimSuffix(c.serverURL, "/") + "/" + strings.Join(segments, "/")
+	if line > 0 {
+		link += fmt.Sprintf("#L%d", line)
+	}
+	return link
 }
 
 func newProcessingOutput(command, format string, reports, stderr io.Writer, agent transport.Agent) processingOutput {
@@ -68,7 +101,7 @@ func (o processingOutput) annotate(report compatibility.ProcessingReport) {
 	if o.annotationJob == "" {
 		return
 	}
-	style, body := processingAnnotation(report)
+	style, body := processingAnnotation(report, o.sourceLinks)
 	if body == "" {
 		return
 	}
@@ -109,7 +142,7 @@ func skippedWorkflowsAnnotation(event string, labels []string, buildURL, stepID 
 	return out.String()
 }
 
-func processingAnnotation(report compatibility.ProcessingReport) (style, body string) {
+func processingAnnotation(report compatibility.ProcessingReport, sourceLinks sourceLinkContext) (style, body string) {
 	report.Finalize()
 	style = "warning"
 	diagnostics := make([]compatibility.Diagnostic, 0, len(report.Diagnostics))
@@ -129,12 +162,13 @@ func processingAnnotation(report compatibility.ProcessingReport) (style, body st
 	var out strings.Builder
 	out.WriteString("<h2 class=\"h4 mb2\">GitHub Actions workflow diagnostics</h2>\n")
 	out.WriteString("<div class=\"mb2\"><strong>Workflow:</strong> ")
-	out.WriteString(annotationCode(processingAnnotationWorkflowPath(report.Workflow)))
+	workflowPath := processingAnnotationWorkflowPath(report.Workflow)
+	out.WriteString(annotationSourcePath(workflowPath, 0, 0, sourceLinks))
 	out.WriteString("</div>\n<div class=\"mb2\">\n")
 	rows := make([]string, len(diagnostics))
 	bodyBytes := out.Len() + len(processingAnnotationEnd)
 	for i, diagnostic := range diagnostics {
-		rows[i] = renderProcessingDiagnostic(diagnostic)
+		rows[i] = renderProcessingDiagnostic(diagnostic, sourceLinks)
 		bodyBytes += len(rows[i])
 	}
 	if bodyBytes <= processingAnnotationBodyLimit {
@@ -148,7 +182,7 @@ func processingAnnotation(report compatibility.ProcessingReport) (style, body st
 	remaining := processingAnnotationBodyLimit - out.Len() - len(processingAnnotationEnd) - len(processingAnnotationNotice)
 	for i, row := range rows {
 		if len(row) > remaining {
-			if row = renderProcessingDiagnosticWithin(diagnostics[i], remaining); row != "" {
+			if row = renderProcessingDiagnosticWithin(diagnostics[i], remaining, sourceLinks); row != "" {
 				out.WriteString(row)
 			}
 			out.WriteString(processingAnnotationEnd)
@@ -176,10 +210,10 @@ func processingAnnotationWorkflowPath(path string) string {
 	return filepath.ToSlash(filepath.Clean(path))
 }
 
-func renderProcessingDiagnosticWithin(diagnostic compatibility.Diagnostic, limit int) string {
+func renderProcessingDiagnosticWithin(diagnostic compatibility.Diagnostic, limit int, sourceLinks sourceLinkContext) string {
 	detail := diagnostic.Detail
 	message := diagnostic.Message
-	row := renderProcessingDiagnostic(diagnostic)
+	row := renderProcessingDiagnostic(diagnostic, sourceLinks)
 	for len(row) > limit && detail != "" {
 		end := max(0, len(detail)-(len(row)-limit))
 		for end > 0 && !utf8.ValidString(detail[:end]) {
@@ -191,7 +225,7 @@ func renderProcessingDiagnosticWithin(diagnostic compatibility.Diagnostic, limit
 			diagnostic.Detail = detail[:end] + "…"
 		}
 		detail = detail[:end]
-		row = renderProcessingDiagnostic(diagnostic)
+		row = renderProcessingDiagnostic(diagnostic, sourceLinks)
 	}
 	for len(row) > limit && message != "" {
 		end := max(0, len(message)-(len(row)-limit))
@@ -200,7 +234,7 @@ func renderProcessingDiagnosticWithin(diagnostic compatibility.Diagnostic, limit
 		}
 		diagnostic.Message = message[:end] + "…"
 		message = message[:end]
-		row = renderProcessingDiagnostic(diagnostic)
+		row = renderProcessingDiagnostic(diagnostic, sourceLinks)
 	}
 	if len(row) > limit {
 		return ""
@@ -208,7 +242,7 @@ func renderProcessingDiagnosticWithin(diagnostic compatibility.Diagnostic, limit
 	return row
 }
 
-func renderProcessingDiagnostic(diagnostic compatibility.Diagnostic) string {
+func renderProcessingDiagnostic(diagnostic compatibility.Diagnostic, sourceLinks sourceLinkContext) string {
 	heading, details := annotationDiagnosticPresentation(diagnostic)
 	var out strings.Builder
 	out.WriteString("<div class=\"border-top border-gray py2\"><div><strong>")
@@ -219,7 +253,7 @@ func renderProcessingDiagnostic(diagnostic compatibility.Diagnostic) string {
 		context = append(context, "Action "+annotationCode(diagnostic.Action))
 	}
 	if diagnostic.Location != nil {
-		context = append(context, annotationCode(fmt.Sprintf("%s:%d:%d", processingAnnotationWorkflowPath(diagnostic.Location.Path), diagnostic.Location.Line, diagnostic.Location.Column)))
+		context = append(context, annotationSourcePath(processingAnnotationWorkflowPath(diagnostic.Location.Path), diagnostic.Location.Line, diagnostic.Location.Column, sourceLinks))
 	}
 	if diagnostic.Job != "" {
 		context = append(context, "Job "+annotationCode(diagnostic.Job))
@@ -249,6 +283,21 @@ func renderProcessingDiagnostic(diagnostic compatibility.Diagnostic) string {
 	}
 	out.WriteString("</div>\n")
 	return out.String()
+}
+
+func annotationSourcePath(path string, line, column int, sourceLinks sourceLinkContext) string {
+	display := path
+	if line > 0 {
+		display += fmt.Sprintf(":%d", line)
+		if column > 0 {
+			display += fmt.Sprintf(":%d", column)
+		}
+	}
+	code := annotationCode(display)
+	if link := sourceLinks.link(path, line); link != "" {
+		return `<a href="` + html.EscapeString(link) + `">` + code + `</a>`
+	}
+	return code
 }
 
 func annotationDiagnosticMessage(diagnostic compatibility.Diagnostic) string {

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -162,8 +162,8 @@ func processingAnnotation(report compatibility.ProcessingReport, sourceLinks sou
 	var out strings.Builder
 	out.WriteString("<h2 class=\"h4 mb2\">GitHub Actions workflow diagnostics</h2>\n")
 	out.WriteString("<div class=\"mb2\"><strong>Workflow:</strong> ")
-	workflowPath := processingAnnotationWorkflowPath(report.Workflow)
-	out.WriteString(annotationSourcePath(workflowPath, 0, 0, sourceLinks))
+	workflowPath, workflowLinkable := processingAnnotationWorkflowPath(report.Workflow)
+	out.WriteString(annotationSourcePath(workflowPath, 0, 0, workflowLinkable, sourceLinks))
 	out.WriteString("</div>\n<div class=\"mb2\">\n")
 	rows := make([]string, len(diagnostics))
 	bodyBytes := out.Len() + len(processingAnnotationEnd)
@@ -195,7 +195,7 @@ func processingAnnotation(report compatibility.ProcessingReport, sourceLinks sou
 	panic("processing annotation exceeded its precomputed size")
 }
 
-func processingAnnotationWorkflowPath(path string) string {
+func processingAnnotationWorkflowPath(path string) (display string, linkable bool) {
 	root := os.Getenv("BUILDKITE_BUILD_CHECKOUT_PATH")
 	if root == "" {
 		root, _ = os.Getwd()
@@ -208,9 +208,9 @@ func processingAnnotationWorkflowPath(path string) string {
 	}
 	relative, err := filepath.Rel(root, resolved)
 	if err == nil && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
-		return filepath.ToSlash(relative)
+		return filepath.ToSlash(relative), true
 	}
-	return filepath.ToSlash(filepath.Clean(path))
+	return filepath.ToSlash(filepath.Clean(path)), false
 }
 
 func renderProcessingDiagnosticWithin(diagnostic compatibility.Diagnostic, limit int, sourceLinks sourceLinkContext) string {
@@ -256,7 +256,8 @@ func renderProcessingDiagnostic(diagnostic compatibility.Diagnostic, sourceLinks
 		context = append(context, "Action "+annotationCode(diagnostic.Action))
 	}
 	if diagnostic.Location != nil {
-		context = append(context, annotationSourcePath(processingAnnotationWorkflowPath(diagnostic.Location.Path), diagnostic.Location.Line, diagnostic.Location.Column, sourceLinks))
+		path, linkable := processingAnnotationWorkflowPath(diagnostic.Location.Path)
+		context = append(context, annotationSourcePath(path, diagnostic.Location.Line, diagnostic.Location.Column, linkable, sourceLinks))
 	}
 	if diagnostic.Job != "" {
 		context = append(context, "Job "+annotationCode(diagnostic.Job))
@@ -288,7 +289,7 @@ func renderProcessingDiagnostic(diagnostic compatibility.Diagnostic, sourceLinks
 	return out.String()
 }
 
-func annotationSourcePath(path string, line, column int, sourceLinks sourceLinkContext) string {
+func annotationSourcePath(path string, line, column int, linkable bool, sourceLinks sourceLinkContext) string {
 	display := path
 	if line > 0 {
 		display += fmt.Sprintf(":%d", line)
@@ -297,7 +298,7 @@ func annotationSourcePath(path string, line, column int, sourceLinks sourceLinkC
 		}
 	}
 	code := annotationCode(display)
-	if link := sourceLinks.link(path, line); link != "" {
+	if link := sourceLinks.link(path, line); linkable && link != "" {
 		return `<a href="` + html.EscapeString(link) + `">` + code + `</a>`
 	}
 	return code

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -44,9 +44,10 @@ type processingOutput struct {
 }
 
 type sourceLinkContext struct {
-	serverURL  string
-	repository string
-	sha        string
+	serverURL          string
+	repository         string
+	sha                string
+	workflowInCheckout bool
 }
 
 func sourceLinksForEvent(event compiler.Event) sourceLinkContext {
@@ -162,7 +163,8 @@ func processingAnnotation(report compatibility.ProcessingReport, sourceLinks sou
 	var out strings.Builder
 	out.WriteString("<h2 class=\"h4 mb2\">GitHub Actions workflow diagnostics</h2>\n")
 	out.WriteString("<div class=\"mb2\"><strong>Workflow:</strong> ")
-	workflowPath, workflowLinkable := processingAnnotationWorkflowPath(report.Workflow)
+	workflowPath, workflowLinkable := processingAnnotationWorkflowPath(report.Workflow, false)
+	sourceLinks.workflowInCheckout = workflowLinkable
 	out.WriteString(annotationSourcePath(workflowPath, 0, 0, workflowLinkable, sourceLinks))
 	out.WriteString("</div>\n<div class=\"mb2\">\n")
 	rows := make([]string, len(diagnostics))
@@ -195,7 +197,7 @@ func processingAnnotation(report compatibility.ProcessingReport, sourceLinks sou
 	panic("processing annotation exceeded its precomputed size")
 }
 
-func processingAnnotationWorkflowPath(path string) (display string, linkable bool) {
+func processingAnnotationWorkflowPath(path string, repositoryRelative bool) (display string, linkable bool) {
 	root := os.Getenv("BUILDKITE_BUILD_CHECKOUT_PATH")
 	if root == "" {
 		root, _ = os.Getwd()
@@ -203,7 +205,7 @@ func processingAnnotationWorkflowPath(path string) (display string, linkable boo
 	resolved := path
 	if !filepath.IsAbs(resolved) {
 		slashPath := filepath.ToSlash(path)
-		if strings.HasPrefix(slashPath, "./.github/workflows/") {
+		if repositoryRelative && strings.HasPrefix(slashPath, "./.github/workflows/") {
 			resolved = filepath.Join(root, filepath.FromSlash(strings.TrimPrefix(slashPath, "./")))
 		} else if workingDirectory, err := os.Getwd(); err == nil {
 			resolved = filepath.Join(workingDirectory, resolved)
@@ -259,7 +261,7 @@ func renderProcessingDiagnostic(diagnostic compatibility.Diagnostic, sourceLinks
 		context = append(context, "Action "+annotationCode(diagnostic.Action))
 	}
 	if diagnostic.Location != nil {
-		path, linkable := processingAnnotationWorkflowPath(diagnostic.Location.Path)
+		path, linkable := processingAnnotationWorkflowPath(diagnostic.Location.Path, sourceLinks.workflowInCheckout)
 		context = append(context, annotationSourcePath(path, diagnostic.Location.Line, diagnostic.Location.Column, linkable, sourceLinks))
 	}
 	if diagnostic.Job != "" {

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -233,7 +233,11 @@ func processingAnnotationWorkflowPath(path, workflowSourceRoot string) (display 
 	if err != nil {
 		return display, false
 	}
-	relative, err := filepath.Rel(root, canonical)
+	canonicalRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return display, false
+	}
+	relative, err := filepath.Rel(canonicalRoot, canonical)
 	if err == nil && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
 		return filepath.ToSlash(relative), true
 	}

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -202,7 +202,10 @@ func processingAnnotationWorkflowPath(path string) (display string, linkable boo
 	}
 	resolved := path
 	if !filepath.IsAbs(resolved) {
-		if workingDirectory, err := os.Getwd(); err == nil {
+		slashPath := filepath.ToSlash(path)
+		if strings.HasPrefix(slashPath, "./.github/workflows/") {
+			resolved = filepath.Join(root, filepath.FromSlash(strings.TrimPrefix(slashPath, "./")))
+		} else if workingDirectory, err := os.Getwd(); err == nil {
 			resolved = filepath.Join(workingDirectory, resolved)
 		}
 	}

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -47,7 +47,7 @@ type sourceLinkContext struct {
 	serverURL          string
 	repository         string
 	sha                string
-	workflowInCheckout bool
+	workflowSourceRoot string
 }
 
 func sourceLinksForEvent(event compiler.Event) sourceLinkContext {
@@ -163,8 +163,8 @@ func processingAnnotation(report compatibility.ProcessingReport, sourceLinks sou
 	var out strings.Builder
 	out.WriteString("<h2 class=\"h4 mb2\">GitHub Actions workflow diagnostics</h2>\n")
 	out.WriteString("<div class=\"mb2\"><strong>Workflow:</strong> ")
-	workflowPath, workflowLinkable := processingAnnotationWorkflowPath(report.Workflow, false)
-	sourceLinks.workflowInCheckout = workflowLinkable
+	sourceLinks.workflowSourceRoot = processingWorkflowSourceRoot(report.Workflow)
+	workflowPath, workflowLinkable := processingAnnotationWorkflowPath(report.Workflow, "")
 	out.WriteString(annotationSourcePath(workflowPath, 0, 0, workflowLinkable, sourceLinks))
 	out.WriteString("</div>\n<div class=\"mb2\">\n")
 	rows := make([]string, len(diagnostics))
@@ -197,7 +197,19 @@ func processingAnnotation(report compatibility.ProcessingReport, sourceLinks sou
 	panic("processing annotation exceeded its precomputed size")
 }
 
-func processingAnnotationWorkflowPath(path string, repositoryRelative bool) (display string, linkable bool) {
+func processingWorkflowSourceRoot(path string) string {
+	resolved := path
+	if !filepath.IsAbs(resolved) {
+		workingDirectory, err := os.Getwd()
+		if err != nil {
+			return ""
+		}
+		resolved = filepath.Join(workingDirectory, resolved)
+	}
+	return filepath.Dir(filepath.Dir(filepath.Dir(resolved)))
+}
+
+func processingAnnotationWorkflowPath(path, workflowSourceRoot string) (display string, linkable bool) {
 	root := os.Getenv("BUILDKITE_BUILD_CHECKOUT_PATH")
 	if root == "" {
 		root, _ = os.Getwd()
@@ -205,8 +217,8 @@ func processingAnnotationWorkflowPath(path string, repositoryRelative bool) (dis
 	resolved := path
 	if !filepath.IsAbs(resolved) {
 		slashPath := filepath.ToSlash(path)
-		if repositoryRelative && strings.HasPrefix(slashPath, "./.github/workflows/") {
-			resolved = filepath.Join(root, filepath.FromSlash(strings.TrimPrefix(slashPath, "./")))
+		if workflowSourceRoot != "" && strings.HasPrefix(slashPath, "./.github/workflows/") {
+			resolved = filepath.Join(workflowSourceRoot, filepath.FromSlash(strings.TrimPrefix(slashPath, "./")))
 		} else if workingDirectory, err := os.Getwd(); err == nil {
 			resolved = filepath.Join(workingDirectory, resolved)
 		}
@@ -261,7 +273,7 @@ func renderProcessingDiagnostic(diagnostic compatibility.Diagnostic, sourceLinks
 		context = append(context, "Action "+annotationCode(diagnostic.Action))
 	}
 	if diagnostic.Location != nil {
-		path, linkable := processingAnnotationWorkflowPath(diagnostic.Location.Path, sourceLinks.workflowInCheckout)
+		path, linkable := processingAnnotationWorkflowPath(diagnostic.Location.Path, sourceLinks.workflowSourceRoot)
 		context = append(context, annotationSourcePath(path, diagnostic.Location.Line, diagnostic.Location.Column, linkable, sourceLinks))
 	}
 	if diagnostic.Job != "" {


### PR DESCRIPTION
## Summary

- Link workflow paths in Buildkite diagnostic annotations to the exact source revision.
- Link workflow paths in generated GitHub check summaries to the exact source line.
- Preserve plain paths when repository context is unavailable or a path is outside the repository.
- Keep text and JSON processing reports unchanged.

This is stacked on #204. Refs #128.

## Example

```html
<a href="https://github.com/buildkite/buildkite-gha/blob/abc123/.github/workflows/hello.yml#L100"><code>.github/workflows/hello.yml:100:3</code></a>
```

```markdown
[`.github/workflows/hello.yml`](https://github.com/buildkite/buildkite-gha/blob/abc123/.github/workflows/hello.yml#L100)
```

## Validation

- `mise exec -- go test ./internal/cli`
- `mise run check`