### PR TITLE
PB-2910: apply hosted-toolchains image to unmapped Linux runner labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ plugins:
           queue: macos-sonoma-arm64
 ```
 
-Configured Linux profiles use the matching Noble or Jammy hosted-toolchains
-image. A macOS label selects native Darwin/arm64, not a GitHub image or Xcode
-inventory.
+Linux labels use the matching Noble or Jammy hosted-toolchains image, with or
+without a configured queue. A macOS label selects native Darwin/arm64, not a
+GitHub image or Xcode inventory.
 
 The imported workflows are a dynamic part of the Buildkite pipeline. The plugin creates one aggregate group per successfully compiled, explicitly listed workflow in a single transaction. Workflows that do not declare the selected event become top-level skipped steps. Groups and replacement steps depend on the importer; each GitHub check is named `Buildkite / <workflow> (<event>)`. This approach lets you keep existing workflows while moving jobs to native Buildkite steps over time.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -171,11 +171,11 @@ buildkite-gha upload \
   .github/workflows/ci.yml
 ```
 
-Configured `ubuntu-latest` and `ubuntu-24.04` profiles default to the Noble
-hosted-toolchains image; `ubuntu-22.04` defaults to Jammy. Use `--runner-image`
-with an immutable digest to override the default. Unmapped Linux labels keep
-default targeting without an image. Every macOS label requires a queue and
-rejects images. Runtime distribution paths must be absolute executables. The
+`ubuntu-latest` and `ubuntu-24.04` default to the Noble hosted-toolchains
+image; `ubuntu-22.04` defaults to Jammy. Use `--runner-image` with an immutable
+digest to override the default for a configured profile. Unmapped Linux labels
+keep default agent targeting with the matching image. Every macOS label
+requires a queue and rejects images. Runtime distribution paths must be absolute executables. The
 importer's platform defaults to its running executable; the other platform has
 no direct-upload default.
 `BUILDKITE_GHA_TARGET_QUEUE` and `BUILDKITE_GHA_RUNTIME_IMAGE` are no longer

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -310,11 +310,11 @@ Results and outputs come from verified producer manifests. Retrying one producer
 
 A job with `continue-on-error: true` stops ordinary steps after a failure, runs eligible failure and always steps plus post-actions, publishes its outputs, and reports `success` through `needs.<job>.result`. The generated Buildkite job returns reserved status `78` for the tolerated workflow failure and soft-fails only that status, so the failure remains visible without blocking dependent jobs. Job timeout expiry remains `cancelled` and is never tolerated.
 
-Runner labels do not select GitHub images. Configured Linux profiles default to
-the corresponding Noble or Jammy hosted-toolchains image; an explicit immutable
-image overrides it. Unmapped Linux labels use default Buildkite targeting
-without an image. macOS labels require a runner profile with a native queue and
-reject images. They select Darwin/arm64, not a GitHub image or Xcode inventory.
+Runner labels do not select GitHub images. Linux labels default to the
+corresponding Noble or Jammy hosted-toolchains image; an explicit immutable
+image overrides it for a configured profile. Unmapped Linux labels use default
+Buildkite agent targeting with that image. macOS labels require a runner
+profile with a native queue and reject images. They select Darwin/arm64, not a GitHub image or Xcode inventory.
 
 ### Matrix strategies
 
@@ -688,13 +688,13 @@ The token is not added to the initial job environment. The `github.token` value 
 
 ### Runner tools
 
-Configured Linux profiles use the corresponding Noble or Jammy
-hosted-toolchains image. Unmapped Linux and macOS agents must provide tools used
-by shell steps. These images do not provide GitHub image parity. The runtime
+Linux labels use the corresponding Noble or Jammy hosted-toolchains image.
+macOS agents must provide tools used by shell steps. These images do not provide GitHub image parity. The runtime
 sets `RUNNER_OS` and `RUNNER_ARCH` to `Linux`/`X64` or `macOS`/`ARM64`.
 
-`RUNNER_TOOL_CACHE` is job-private unless a Linux runner profile selects an
-immutable image with `/opt/hostedtoolcache`. macOS images are unsupported.
+`RUNNER_TOOL_CACHE` is job-private unless the Linux job selects an immutable
+image with `/opt/hostedtoolcache`, which the default and configured
+hosted-toolchains images provide. macOS images are unsupported.
 
 ### Results, retries, and cancellation
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -70,7 +70,7 @@ func writeCommandHelp(stdout io.Writer, command string) {
 	case "compile":
 		_, _ = fmt.Fprint(stdout, "\nPipeline output references content-addressed plans; compile does not materialize or upload those artifacts.\n")
 	case "upload":
-		_, _ = fmt.Fprint(stdout, "\nEvery workflow operand must be an explicit .yml or .yaml path; use -- before paths that begin with a dash. Multiple operands must be tracked files inside the checked-out repository. Inputs are uploaded as one aggregate pipeline: successful workflows become groups, while failed or skipped workflows become top-level replacement steps. Reusable-only workflow_call files are imported through callers but do not become groups. Scheduled groups select only build.source == schedule: Buildkite schedules retain cron ownership, so every scheduled workflow group is eligible on any Buildkite scheduled build. Each repeatable --runner-queue argument maps one supported runs-on label to a Buildkite queue. Configured Linux profiles default to the matching immutable hosted-toolchains image; --runner-image overrides it. Duplicate or unsupported mappings fail, unmapped supported Linux labels retain their default targeting, and every macOS label requires an explicit queue. Each repeatable --runtime-distribution argument binds linux/amd64 or darwin/arm64 to a verified executable. Upload importers may run on either platform; the matching runtime defaults to the importer executable, and workflows targeting the other platform require its distribution. The deprecated --runtime-queue hosted option is accepted for plugin compatibility but does not select a queue. Event precedence is an explicit event file, Buildkite's reserved webhook metadata, then reduced-fidelity Buildkite environment compatibility data; every source remains unsigned. Verified checkout jobs automatically use Buildkite repository-provider Git credentials when the job enables them; the deprecated --private-checkout option is accepted as a no-op.\n")
+		_, _ = fmt.Fprint(stdout, "\nEvery workflow operand must be an explicit .yml or .yaml path; use -- before paths that begin with a dash. Multiple operands must be tracked files inside the checked-out repository. Inputs are uploaded as one aggregate pipeline: successful workflows become groups, while failed or skipped workflows become top-level replacement steps. Reusable-only workflow_call files are imported through callers but do not become groups. Scheduled groups select only build.source == schedule: Buildkite schedules retain cron ownership, so every scheduled workflow group is eligible on any Buildkite scheduled build. Each repeatable --runner-queue argument maps one supported runs-on label to a Buildkite queue. Every supported Linux label defaults to the matching immutable hosted-toolchains image; --runner-image overrides it for a configured profile. Duplicate or unsupported mappings fail, unmapped supported Linux labels retain default agent targeting with that image, and every macOS label requires an explicit queue. Each repeatable --runtime-distribution argument binds linux/amd64 or darwin/arm64 to a verified executable. Upload importers may run on either platform; the matching runtime defaults to the importer executable, and workflows targeting the other platform require its distribution. The deprecated --runtime-queue hosted option is accepted for plugin compatibility but does not select a queue. Event precedence is an explicit event file, Buildkite's reserved webhook metadata, then reduced-fidelity Buildkite environment compatibility data; every source remains unsigned. Verified checkout jobs automatically use Buildkite repository-provider Git credentials when the job enables them; the deprecated --private-checkout option is accepted as a no-op.\n")
 	}
 }
 
@@ -2305,10 +2305,13 @@ func (a *actionSourceAuthentication) warnAnonymousFallback(reason string) {
 }
 
 func hostedOptions(groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runtimeDistributions map[compiler.Platform]string) compiler.Options {
+	// Unmapped Linux labels keep Buildkite default agent targeting but still
+	// select the matching hosted-toolchains image, so ubuntu-latest jobs get
+	// GitHub-comparable tooling without an explicit runners mapping.
 	targets := map[string]compiler.RunnerTarget{
-		"ubuntu-latest": {Platform: compiler.PlatformLinuxAMD64},
-		"ubuntu-24.04":  {Platform: compiler.PlatformLinuxAMD64},
-		"ubuntu-22.04":  {Platform: compiler.PlatformLinuxAMD64},
+		"ubuntu-latest": {Platform: compiler.PlatformLinuxAMD64, Image: defaultNobleRunnerImage},
+		"ubuntu-24.04":  {Platform: compiler.PlatformLinuxAMD64, Image: defaultNobleRunnerImage},
+		"ubuntu-22.04":  {Platform: compiler.PlatformLinuxAMD64, Image: defaultJammyRunnerImage},
 	}
 	for label, target := range configuredTargets {
 		targets[label] = target

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -4793,6 +4793,44 @@ func TestRunUploadUsesExplicitTargetQueue(t *testing.T) {
 	}
 }
 
+func TestRunUploadDefaultsHostedToolchainImageWithoutRunnerQueue(t *testing.T) {
+	requireImporterHost(t)
+	workflowPath := filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "shell.yml")
+	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_STEP_KEY", "default-image-importer")
+	runner := &cliCaptureRunner{}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"upload", "--event-path", eventPath, workflowPath}, &stdout, &stderr, "dev", runner); code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+
+	var pipeline struct {
+		Steps []struct {
+			Steps []struct {
+				Key     string            `yaml:"key"`
+				Image   string            `yaml:"image"`
+				Agents  map[string]string `yaml:"agents"`
+				Command string            `yaml:"command"`
+			} `yaml:"steps"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(runner.commands[len(runner.commands)-1].stdin, &pipeline); err != nil {
+		t.Fatalf("uploaded pipeline YAML: %v", err)
+	}
+	if len(pipeline.Steps) != 1 || len(pipeline.Steps[0].Steps) != 3 {
+		t.Fatalf("uploaded steps = %#v", pipeline.Steps)
+	}
+	for _, step := range pipeline.Steps[0].Steps {
+		if len(step.Agents) != 0 {
+			t.Fatalf("step %q agents = %#v, want default targeting", step.Key, step.Agents)
+		}
+		if step.Image != defaultNobleRunnerImage || !strings.Contains(step.Command, "--hosted-tool-cache") {
+			t.Fatalf("step %q image = %q, command = %q", step.Key, step.Image, step.Command)
+		}
+	}
+}
+
 func TestRunUploadUsesExplicitRuntimeImage(t *testing.T) {
 	requireImporterHost(t)
 	workflowPath := filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "shell.yml")
@@ -4877,8 +4915,8 @@ jobs:
 	if selected.Image != image || selected.Agents["queue"] != "hosted" || !strings.Contains(selected.Command, "--hosted-tool-cache") {
 		t.Fatalf("selected profile step = %#v", selected)
 	}
-	if defaulted.Image != "" || len(defaulted.Agents) != 0 || strings.Contains(defaulted.Command, "--hosted-tool-cache") {
-		t.Fatalf("unmapped Linux step inherited selected profile = %#v", defaulted)
+	if defaulted.Image != defaultJammyRunnerImage || len(defaulted.Agents) != 0 || !strings.Contains(defaulted.Command, "--hosted-tool-cache") {
+		t.Fatalf("unmapped Linux step = %#v, want default targeting with the Jammy hosted-toolchains image", defaulted)
 	}
 }
 


### PR DESCRIPTION
Context: [PB-2910](https://linear.app/buildkite/issue/PB-2910)

Unconfigured `ubuntu-latest` / `ubuntu-24.04` / `ubuntu-22.04` labels previously compiled to steps with neither `agents.queue` nor `image`. Jobs landing on the default Hosted Linux queue ran without the agent-base toolchains (`yarn: command not found`), and the only fix was an explicit `runners` mapping.

## Change

Hosted upload defaults now carry the matching hosted-toolchains image while keeping default agent targeting:

| Label | Queue | Image |
| --- | --- | --- |
| `ubuntu-latest`, `ubuntu-24.04` | default targeting | Noble agent-base |
| `ubuntu-22.04` | default targeting | Jammy agent-base |

Explicit `runners` mappings override as before. macOS behavior is unchanged. The standalone `compile` command is unchanged; only the hosted upload/plugin path is affected.

Steps that get the image also get `--hosted-tool-cache`, matching configured profiles.

## Behavior notes

- This assumes GHA pipelines run on Hosted Linux agents (team consensus; self-hosted is out of scope for this product).
- `runs-on: [ubuntu-latest, ubuntu-22.04]` is now rejected as conflicting targets (Noble vs Jammy). Previously both resolved to the same empty target. That label combination never matches a real GitHub-hosted runner either.

## Testing

- `mise run check` passes (format, build, test, race, lint, vet, smoke:local, release:check).
- New `TestRunUploadDefaultsHostedToolchainImageWithoutRunnerQueue` covers the no-config upload path.
- Updated `TestRunnerProfileDoesNotAffectOtherLinuxLabels` for the new default.
