### PR TITLE
Diagnose setup-node cache credential failures

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -476,6 +476,9 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 			return 1
 		}
 		if err != nil {
+			if hasSetupNodeAction(job.Actions) {
+				_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: actions/setup-node cache credentials unavailable: %v\n", err)
+			}
 			cacheCredentials = nil
 		}
 	}
@@ -1088,6 +1091,15 @@ func canonicalNonSymlinkDirectory(path string) (string, error) {
 func hasGitHubActionLocks(locks []plan.ActionLock) bool {
 	for _, lock := range locks {
 		if lock.Source == "github" {
+			return true
+		}
+	}
+	return false
+}
+
+func hasSetupNodeAction(locks []plan.ActionLock) bool {
+	for _, lock := range locks {
+		if lock.Source == "github" && lock.Repository == "actions/setup-node" && lock.Path == "" {
 			return true
 		}
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -6176,6 +6176,21 @@ func TestCacheServiceRequiredUsesOnlyAuditedCacheLocks(t *testing.T) {
 	}
 }
 
+func TestHasSetupNodeActionMatchesOnlyRootGitHubAction(t *testing.T) {
+	if !hasSetupNodeAction([]plan.ActionLock{{Source: "github", Repository: "actions/setup-node"}}) {
+		t.Fatal("root actions/setup-node lock was not detected")
+	}
+	for _, lock := range []plan.ActionLock{
+		{Source: "github", Repository: "actions/setup-node", Path: "nested"},
+		{Source: "workspace", Repository: "actions/setup-node"},
+		{Source: "github", Repository: "owner/setup-node"},
+	} {
+		if hasSetupNodeAction([]plan.ActionLock{lock}) {
+			t.Fatalf("unexpected setup-node match for %#v", lock)
+		}
+	}
+}
+
 func TestUnprivilegedUploadAllowsNativeDownloadArtifactAdapter(t *testing.T) {
 	bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: plan.Job{Workflow: plan.Workflow{LogicalJobID: "consumer"}, Actions: []plan.ActionLock{{Source: "github", Repository: "actions/download-artifact", Commit: actionintegration.DownloadArtifactCommit}}}}}}
 	if err := validateUnprivilegedBundle(bundle); err != nil {

--- a/internal/runtime/cache_service_test.go
+++ b/internal/runtime/cache_service_test.go
@@ -623,7 +623,8 @@ fs.writeFileSync(process.env.MARKER, "executed");
 	result := newResult()
 	result.Env["MARKER"] = marker
 	result.Env["ACTIONS_RUNTIME_TOKEN"] = "workflow-token"
-	processor := newCommandProcessor(io.Discard, io.Discard)
+	var logs bytes.Buffer
+	processor := newCommandProcessor(&logs, &logs)
 	runner := Runner{Cache: provider, Redactor: &testRedactor{}}
 	if err := runner.runJavaScriptPhase(
 		context.Background(), processor, actionRoot, node,
@@ -633,6 +634,18 @@ fs.writeFileSync(process.env.MARKER, "executed");
 	}
 	if contents, err := os.ReadFile(marker); err != nil || string(contents) != "executed" {
 		t.Fatalf("generic action marker = %q, %v", contents, err)
+	}
+	if err := os.Remove(marker); err != nil {
+		t.Fatal(err)
+	}
+	if err := runner.runJavaScriptPhase(
+		context.Background(), processor, actionRoot, node,
+		javaScriptAction{Name: "setup-node", Path: actionRoot, Main: "main.js", reference: "actions/setup-node@v6"}, "main.js", nil, nil, &result,
+	); err != nil {
+		t.Fatalf("setup-node cache fallback error = %v", err)
+	}
+	if !strings.Contains(logs.String(), `Cache credentials unavailable for "actions/setup-node@v6" entry "main.js"; ACTIONS_RESULTS_URL will be omitted: cache unavailable`) {
+		t.Fatalf("setup-node cache diagnostic = %q", logs.String())
 	}
 	if err := os.Remove(marker); err != nil {
 		t.Fatal(err)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -652,6 +652,9 @@ func (r Runner) runJavaScriptPhase(ctx context.Context, processor *commandProces
 	if cacheErr != nil && action.Cache {
 		return fmt.Errorf("configure actions/cache service: %w", cacheErr)
 	}
+	if cacheErr != nil && strings.HasPrefix(action.reference, "actions/setup-node@") {
+		processor.trustedWarning(fmt.Sprintf("Cache credentials unavailable for %q entry %q; ACTIONS_RESULTS_URL will be omitted: %v", action.reference, entry, processor.scrubError(cacheErr)))
+	}
 	cacheToken := ""
 	if cacheErr == nil {
 		env = mergeStringMaps(env, cacheEnv)


### PR DESCRIPTION
## Summary

- report cache credential provider setup failures when a job uses root `actions/setup-node`
- emit a trusted setup-node lifecycle warning explaining why `ACTIONS_RESULTS_URL` is omitted
- preserve the existing nonfatal, uncached fallback

## Verification

- `mise run check`