### PR TITLE
Refine workflow diagnostic annotation layout

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -28,7 +28,6 @@ import (
 	"sync"
 	"syscall"
 	"time"
-	"unicode/utf8"
 
 	actionintegration "github.com/buildkite/buildkite-gha/internal/action/integration"
 	actionsource "github.com/buildkite/buildkite-gha/internal/action/source"
@@ -97,6 +96,7 @@ const (
 	pluginArchiveLimit                          = 256 << 20
 	maxWebhookMetadataBytes                     = 25 << 20
 	workflowCheckSummaryLimit                   = 65535
+	workflowCheckSummaryNotice                  = "\n\n_Additional diagnostics omitted at the provider check summary size limit._\n"
 	defaultNobleRunnerImage                     = "buildkite.namespace-images.com/agent-base@sha256:62a45683afffaae9edfd669c16d2fee23b5a571679f31715e1063dada667ea24"
 	defaultJammyRunnerImage                     = "buildkite.namespace-images.com/agent-base@sha256:a014d0bae6b06bb315d10b5ff8bb226d5fe7fa468bcf140b3c0d7e72a33aa1ac"
 )
@@ -1863,6 +1863,7 @@ func failedGeneratedWorkflow(input workflowInput, event string, report compatibi
 		messages = append(messages, message)
 	}
 	_, annotation := processingAnnotation(report, sourceLinks)
+	_, checkSummary := processingAnnotationWithin(report, sourceLinks, workflowCheckSummaryLimit, workflowCheckSummaryNotice)
 	messageArtifact := generatedFailureArtifact("messages", ".txt", "\x1b[31m"+strings.Join(messages, "\n")+"\x1b[0m\n")
 	annotationArtifact := generatedFailureArtifact("annotations", ".html", annotation)
 	workflow := buildkitepipeline.Workflow{
@@ -1872,7 +1873,7 @@ func failedGeneratedWorkflow(input workflowInput, event string, report compatibi
 		Failure: &buildkitepipeline.Failure{
 			AnnotationPath: annotationArtifact.Path,
 			MessagePath:    messageArtifact.Path,
-			Summary:        failureCheckSummary(input.CanonicalPath, report, sourceLinks),
+			Summary:        checkSummary,
 		},
 	}
 	return workflow, []transport.Artifact{messageArtifact, annotationArtifact}
@@ -1883,133 +1884,6 @@ func generatedFailureArtifact(kind, extension, contents string) transport.Artifa
 	digest := transport.Digest(encoded)
 	path := ".buildkite-gha/failures/" + kind + "/" + strings.TrimPrefix(digest, "sha256:") + extension
 	return transport.Artifact{Path: path, Digest: digest, Contents: encoded}
-}
-
-func failureCheckSummary(path string, report compatibility.ProcessingReport, sourceLinks sourceLinkContext) string {
-	if path == "" {
-		path = report.Workflow
-	}
-	if _, linkable := processingAnnotationWorkflowPath(report.Workflow, ""); linkable {
-		sourceLinks.workflowSourceRoot = processingWorkflowSourceRoot(report.Workflow)
-	}
-	var summary strings.Builder
-	summary.WriteString("The workflow could not be prepared:\n")
-	for _, diagnostic := range report.Diagnostics {
-		if diagnostic.Level != "error" {
-			continue
-		}
-		diagnosticPath := failureCheckDiagnosticPath(path, report.Workflow, diagnostic.Location)
-		message := diagnostic.Message
-		prefixes := []string{report.Workflow + ": ", path + ": ", diagnosticPath + ": "}
-		if diagnostic.Location != nil {
-			prefixes = append(prefixes, diagnostic.Location.Path+": ")
-		}
-		for _, prefix := range prefixes {
-			message = strings.TrimPrefix(message, prefix)
-		}
-		if diagnostic.Job != "" {
-			message = strings.TrimPrefix(message, fmt.Sprintf("job %q: ", diagnostic.Job))
-		}
-		summary.WriteString("\n- ")
-		line := 0
-		sourcePath := report.Workflow
-		if diagnostic.Location != nil {
-			line = diagnostic.Location.Line
-			if diagnostic.Location.Path != "" {
-				sourcePath = diagnostic.Location.Path
-			}
-		}
-		linkedPath, linkable := processingAnnotationWorkflowPath(sourcePath, sourceLinks.workflowSourceRoot)
-		link := ""
-		if linkable {
-			link = sourceLinks.link(linkedPath, line)
-		}
-		if link != "" {
-			diagnosticPath = linkedPath
-		}
-		pathCode := markdownCode(diagnosticPath)
-		if link != "" {
-			summary.WriteString("[")
-			summary.WriteString(pathCode)
-			summary.WriteString("](")
-			summary.WriteString(link)
-			summary.WriteString(")")
-		} else {
-			summary.WriteString(pathCode)
-		}
-		if diagnostic.Job != "" {
-			summary.WriteString(", job ")
-			summary.WriteString(markdownCode(diagnostic.Job))
-		}
-		if diagnostic.Step != 0 {
-			_, _ = fmt.Fprintf(&summary, ", step %d", diagnostic.Step)
-		}
-		summary.WriteString(": ")
-		summary.WriteString(markdownText(message))
-	}
-	return truncateFailureCheckSummary(summary.String())
-}
-
-func markdownCode(value string) string {
-	value = strings.Join(strings.Fields(value), " ")
-	if strings.Contains(value, "`") {
-		longest, current := 0, 0
-		for _, r := range value {
-			if r == '`' {
-				current++
-				longest = max(longest, current)
-			} else {
-				current = 0
-			}
-		}
-		delimiter := strings.Repeat("`", longest+1)
-		return delimiter + " " + value + " " + delimiter
-	}
-	return "`" + value + "`"
-}
-
-func markdownText(value string) string {
-	value = strings.Join(strings.Fields(value), " ")
-	value = strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;").Replace(value)
-	replacer := strings.NewReplacer(
-		"\\", "\\\\", "`", "\\`", "*", "\\*", "_", "\\_", "[", "\\[", "]", "\\]",
-		"<", "\\<", ">", "\\>", "#", "\\#", "|", "\\|",
-	)
-	return replacer.Replace(value)
-}
-
-func failureCheckDiagnosticPath(rootPath, reportPath string, location *compatibility.SourceLocation) string {
-	rootPath = filepath.ToSlash(filepath.Clean(rootPath))
-	if location == nil || location.Path == "" {
-		return rootPath
-	}
-	reportPath = filepath.ToSlash(filepath.Clean(reportPath))
-	diagnosticPath := filepath.ToSlash(filepath.Clean(location.Path))
-	if diagnosticPath == reportPath || diagnosticPath == rootPath {
-		return rootPath
-	}
-	if filepath.IsAbs(diagnosticPath) && filepath.IsAbs(reportPath) && !filepath.IsAbs(rootPath) {
-		rootSuffix := "/" + strings.TrimPrefix(rootPath, "./")
-		if strings.HasSuffix(reportPath, rootSuffix) {
-			repositoryRoot := strings.TrimSuffix(reportPath, rootSuffix)
-			if relative, ok := strings.CutPrefix(diagnosticPath, repositoryRoot+"/"); ok {
-				return relative
-			}
-		}
-	}
-	return strings.TrimPrefix(diagnosticPath, "./")
-}
-
-func truncateFailureCheckSummary(summary string) string {
-	if len(summary) <= workflowCheckSummaryLimit {
-		return summary
-	}
-	const notice = "\n\n_Additional error details omitted at the provider check summary size limit._"
-	end := workflowCheckSummaryLimit - len(notice)
-	for !utf8.ValidString(summary[:end]) {
-		end--
-	}
-	return summary[:end] + notice
 }
 
 func requiredRuntimePlatforms(workflowPath string, workflowSource, eventSource []byte, groupLabel string, configuredTargets map[string]compiler.RunnerTarget) (map[compiler.Platform]bool, error) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2493,7 +2493,7 @@ func TestValidatePublishesProcessingDiagnosticsInBuildkite(t *testing.T) {
 		}
 		for _, want := range []string{
 			`<h2 class="h4 mb2">Workflow could not be run</h2>`,
-			`<div class="py2"><div><strong>Runner label &#34;windows-latest&#34; requires Windows, which is unsupported.`,
+			`<div><div><strong>Runner label &#34;windows-latest&#34; requires Windows, which is unsupported.`,
 			`<summary>Diagnostic detail</summary>`,
 			`Supported runner labels: ubuntu-22.04, ubuntu-24.04, ubuntu-latest.`,
 			"Job <code>test</code>",
@@ -2873,7 +2873,7 @@ func TestProcessingAnnotationPresentsActionFailureAsAConciseCard(t *testing.T) {
 
 	_, body := processingAnnotation(report, sourceLinkContext{})
 	for _, want := range []string{
-		`<div class="py2"><div><strong>Action metadata uses unsupported field &#34;deprecationMessage&#34;</strong></div>`,
+		`<div><div><strong>Action metadata uses unsupported field &#34;deprecationMessage&#34;</strong></div>`,
 		"Action <code>actions/setup-java@v4</code> · Job <code>test</code> · Step 2",
 	} {
 		if !strings.Contains(body, want) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2713,8 +2713,8 @@ func TestProcessingDiagnosticsRetainNestedWorkflowSourceRoot(t *testing.T) {
 	wantLink := "https://github.com/owner/repo/blob/abc123/nested/.github/workflows/build-security.yml#L35"
 
 	_, annotation := processingAnnotation(report, sourceLinks)
-	summary := failureCheckSummary("./.github/workflows/caller.yml", report, sourceLinks)
-	if !strings.Contains(annotation, `href="`+wantLink+`"`) || !strings.Contains(summary, "]("+wantLink+")") {
+	_, summary := processingAnnotationWithin(report, sourceLinks, workflowCheckSummaryLimit, workflowCheckSummaryNotice)
+	if !strings.Contains(annotation, `href="`+wantLink+`"`) || !strings.Contains(summary, `href="`+wantLink+`"`) {
 		t.Fatalf("nested workflow location was not retained: annotation=%q summary=%q", annotation, summary)
 	}
 }
@@ -2783,8 +2783,8 @@ func TestProcessingDiagnosticsDoNotLinkPathsOutsideCheckout(t *testing.T) {
 	sourceLinks := sourceLinkContext{serverURL: "https://github.com", repository: "owner/repo", sha: "abc123"}
 
 	_, annotation := processingAnnotation(report, sourceLinks)
-	summary := failureCheckSummary("ci.yml", report, sourceLinks)
-	if strings.Contains(annotation, "href=") || strings.Contains(summary, "](https://") {
+	_, summary := processingAnnotationWithin(report, sourceLinks, workflowCheckSummaryLimit, workflowCheckSummaryNotice)
+	if strings.Contains(annotation, "href=") || strings.Contains(summary, "href=") {
 		t.Fatalf("outside path was linked: annotation=%q summary=%q", annotation, summary)
 	}
 }
@@ -2809,8 +2809,8 @@ func TestProcessingDiagnosticsDoNotLinkSymlinksOutsideCheckout(t *testing.T) {
 	sourceLinks := sourceLinkContext{serverURL: "https://github.com", repository: "owner/repo", sha: "abc123"}
 
 	_, annotation := processingAnnotation(report, sourceLinks)
-	summary := failureCheckSummary(workflowPath, report, sourceLinks)
-	if strings.Contains(annotation, "href=") || strings.Contains(summary, "](https://") {
+	_, summary := processingAnnotationWithin(report, sourceLinks, workflowCheckSummaryLimit, workflowCheckSummaryNotice)
+	if strings.Contains(annotation, "href=") || strings.Contains(summary, "href=") {
 		t.Fatalf("outside symlink was linked: annotation=%q summary=%q", annotation, summary)
 	}
 }
@@ -4197,13 +4197,9 @@ func TestRunUploadEmitsApplicableCompilationFailuresAsFailingSteps(t *testing.T)
 		t.Fatalf("compiler failure pipeline = %#v\n%s", pipeline.Steps, pipelineCommand.stdin)
 	}
 	step := pipeline.Steps[0]
-	wantSummary := "The workflow could not be prepared:\n\n" +
-		"- `" + filepath.ToSlash(workflowPath) + "`, job `alpha`: Runner label has no runner-target mapping. Configure a mapping for this label or use a mapped runner label.\n" +
-		"- `" + filepath.ToSlash(workflowPath) + "`, job `beta`: runs-on expression cannot be resolved at compile time: compile-time object contains ambiguous properties\n" +
-		"- `" + filepath.ToSlash(workflowPath) + "`, job `gamma`: runs-on expression cannot be resolved at compile time: fromJSON argument is invalid JSON"
 	message := failureArtifactForStep(step.Plugins, runner.uploaded, "messages")
 	annotation := failureArtifactForStep(step.Plugins, runner.uploaded, "annotations")
-	if step.Label != ":github: Invalid push" || step.Condition != "" || !isGeneratedFailureCommand(step.Command) || strings.Contains(step.Command, "Runner label has no") || !strings.Contains(string(message), "Runner label has no") || !strings.Contains(string(message), "detail: Supported runner labels:") || !strings.Contains(string(annotation), `<h2 class="h4 mb2">Workflow could not be run</h2>`) || !strings.Contains(string(annotation), "Job <code>alpha</code>") || !strings.Contains(string(annotation), "Job <code>beta</code>") || !strings.Contains(string(annotation), "Job <code>gamma</code>") || len(step.Notify) != 1 || step.Notify[0].GitHubCheck.Output.Title != "Workflow could not be run" || step.Notify[0].GitHubCheck.Output.Summary != wantSummary || !step.Checkout.Skip {
+	if step.Label != ":github: Invalid push" || step.Condition != "" || !isGeneratedFailureCommand(step.Command) || strings.Contains(step.Command, "Runner label has no") || !strings.Contains(string(message), "Runner label has no") || !strings.Contains(string(message), "detail: Supported runner labels:") || !strings.Contains(string(annotation), `<h2 class="h4 mb2">Workflow could not be run</h2>`) || !strings.Contains(string(annotation), "Job <code>alpha</code>") || !strings.Contains(string(annotation), "Job <code>beta</code>") || !strings.Contains(string(annotation), "Job <code>gamma</code>") || len(step.Notify) != 1 || step.Notify[0].GitHubCheck.Output.Title != "Workflow could not be run" || step.Notify[0].GitHubCheck.Output.Summary != string(annotation) || !step.Checkout.Skip {
 		t.Fatalf("compiler failure step = %#v", step)
 	}
 	if strings.Contains(step.Notify[0].GitHubCheck.Output.Summary, "E_EXPRESSION_INVALID") {
@@ -4257,8 +4253,7 @@ func TestFailedGeneratedWorkflowIncludesWarnings(t *testing.T) {
 	)
 
 	workflow, artifacts := failedGeneratedWorkflow(workflowInput{Name: "CI", CanonicalPath: ".github/workflows/ci.yml", Identity: "ci", TriggerCondition: "false"}, "push", report, sourceLinkContext{})
-	wantSummary := "The workflow could not be prepared:\n\n- `.github/workflows/ci.yml`, job `test`: runner is unsupported"
-	if workflow.Condition != "" || workflow.Failure == nil || len(artifacts) != 2 || workflow.Failure.MessagePath != artifacts[0].Path || workflow.Failure.AnnotationPath != artifacts[1].Path || !bytes.HasPrefix(artifacts[0].Contents, []byte("\x1b[31m")) || !bytes.HasSuffix(artifacts[0].Contents, []byte("\x1b[0m\n")) || !strings.Contains(string(artifacts[1].Contents), `<h2 class="h4 mb2">Workflow could not be run</h2>`) || !strings.Contains(string(artifacts[1].Contents), "<strong>runner is unsupported</strong>") || !strings.Contains(string(artifacts[1].Contents), "<strong>cancel-in-progress is ignored</strong>") || workflow.Failure.Summary != wantSummary {
+	if workflow.Condition != "" || workflow.Failure == nil || len(artifacts) != 2 || workflow.Failure.MessagePath != artifacts[0].Path || workflow.Failure.AnnotationPath != artifacts[1].Path || !bytes.HasPrefix(artifacts[0].Contents, []byte("\x1b[31m")) || !bytes.HasSuffix(artifacts[0].Contents, []byte("\x1b[0m\n")) || !strings.Contains(string(artifacts[1].Contents), `<h2 class="h4 mb2">Workflow could not be run</h2>`) || !strings.Contains(string(artifacts[1].Contents), "<strong>runner is unsupported</strong>") || !strings.Contains(string(artifacts[1].Contents), "<strong>cancel-in-progress is ignored</strong>") || workflow.Failure.Summary != string(artifacts[1].Contents) {
 		t.Fatalf("failure = %#v", workflow.Failure)
 	}
 }
@@ -4301,30 +4296,13 @@ func TestFailureCheckSummaryFitsProviderLimit(t *testing.T) {
 		Level: "error", Message: strings.Repeat("x", workflowCheckSummaryLimit) + "🙂", Job: "test",
 	})
 
-	summary := failureCheckSummary("ci.yml", report, sourceLinkContext{})
-	if len(summary) > workflowCheckSummaryLimit || !utf8.ValidString(summary) || !strings.HasSuffix(summary, "_Additional error details omitted at the provider check summary size limit._") {
+	_, summary := processingAnnotationWithin(report, sourceLinkContext{}, workflowCheckSummaryLimit, workflowCheckSummaryNotice)
+	if len(summary) > workflowCheckSummaryLimit || !utf8.ValidString(summary) || !strings.HasSuffix(summary, workflowCheckSummaryNotice) {
 		t.Fatalf("truncated provider check summary is invalid: bytes=%d, valid UTF-8=%t, suffix=%q", len(summary), utf8.ValidString(summary), summary[len(summary)-100:])
 	}
 }
 
-func TestFailureCheckSummaryUsesDiagnosticWorkflowPath(t *testing.T) {
-	report := compatibility.NewProcessingReport("/work/repo/.github/workflows/caller.yml", "hosted")
-	report.Diagnostics = append(report.Diagnostics,
-		compatibility.Diagnostic{Level: "error", Message: "caller failed", Job: "caller", Location: &compatibility.SourceLocation{Path: "/work/repo/.github/workflows/caller.yml", Line: 5, Column: 3}},
-		compatibility.Diagnostic{Level: "error", Message: "reusable failed", Job: "called", Location: &compatibility.SourceLocation{Path: "./.github/workflows/reusable.yml", Line: 7, Column: 3}},
-		compatibility.Diagnostic{Level: "error", Message: "absolute reusable failed", Job: "absolute", Location: &compatibility.SourceLocation{Path: "/work/repo/.github/workflows/absolute.yml", Line: 9, Column: 3}},
-	)
-
-	want := "The workflow could not be prepared:\n\n" +
-		"- `.github/workflows/caller.yml`, job `caller`: caller failed\n" +
-		"- `.github/workflows/reusable.yml`, job `called`: reusable failed\n" +
-		"- `.github/workflows/absolute.yml`, job `absolute`: absolute reusable failed"
-	if got := failureCheckSummary(".github/workflows/caller.yml", report, sourceLinkContext{}); got != want {
-		t.Fatalf("failureCheckSummary() = %q, want %q", got, want)
-	}
-}
-
-func TestFailureCheckSummaryLinksDiagnosticWorkflowPath(t *testing.T) {
+func TestFailureCheckSummaryUsesAnnotationMarkupAndLinks(t *testing.T) {
 	repository := t.TempDir()
 	workflowPath := filepath.Join(repository, ".github", "workflows", "hello.yml")
 	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
@@ -4341,10 +4319,12 @@ func TestFailureCheckSummaryLinksDiagnosticWorkflowPath(t *testing.T) {
 		Location: &compatibility.SourceLocation{Path: ".github/workflows/hello.yml", Line: 100, Column: 3},
 	})
 	sourceLinks := sourceLinkContext{serverURL: "https://github.com", repository: "owner/repo", sha: "abc123"}
-	want := "The workflow could not be prepared:\n\n- [`.github/workflows/hello.yml`](https://github.com/owner/repo/blob/abc123/.github/workflows/hello.yml#L100), job `test`: runner is unsupported"
+	want := `<a href="https://github.com/owner/repo/blob/abc123/.github/workflows/hello.yml#L100"><code>.github/workflows/hello.yml:100:3</code></a>`
 
-	if got := failureCheckSummary(".github/workflows/hello.yml", report, sourceLinks); got != want {
-		t.Fatalf("failureCheckSummary() = %q, want %q", got, want)
+	workflow, artifacts := failedGeneratedWorkflow(workflowInput{Name: "CI", CanonicalPath: ".github/workflows/hello.yml", Identity: "ci"}, "push", report, sourceLinks)
+	annotation := string(artifacts[1].Contents)
+	if workflow.Failure.Summary != annotation || !strings.Contains(workflow.Failure.Summary, `<h2 class="h4 mb2">Workflow could not be run</h2>`) || !strings.Contains(workflow.Failure.Summary, want) {
+		t.Fatalf("check summary = %q, annotation = %q, want %q", workflow.Failure.Summary, annotation, want)
 	}
 }
 
@@ -4724,7 +4704,7 @@ func TestRunUploadEmitsReusableInputFailuresAsActionableFailingSteps(t *testing.
 	detail := `Reusable-workflow input "target" is not statically resolvable: unsupported compile-time context "needs"`
 	message := string(failureArtifactForStep(pipeline.Steps[0].Plugins, runner.uploaded, "messages"))
 	annotation := string(failureArtifactForStep(pipeline.Steps[0].Plugins, runner.uploaded, "annotations"))
-	if !strings.Contains(message, primary) || !strings.Contains(message, "detail: "+detail) || !strings.Contains(annotation, "<strong>Reusable workflow input &#34;target&#34; uses the needs context, which is unavailable before jobs run.</strong>") || !strings.Contains(annotation, "Replace it with a literal") || !strings.Contains(annotation, strings.ReplaceAll(detail, `"`, "&#34;")) || len(pipeline.Steps[0].Notify) != 1 || !strings.Contains(pipeline.Steps[0].Notify[0].GitHubCheck.Output.Summary, primary) || strings.Contains(pipeline.Steps[0].Notify[0].GitHubCheck.Output.Summary, detail) {
+	if !strings.Contains(message, primary) || !strings.Contains(message, "detail: "+detail) || !strings.Contains(annotation, "<strong>Reusable workflow input &#34;target&#34; uses the needs context, which is unavailable before jobs run.</strong>") || !strings.Contains(annotation, "Replace it with a literal") || !strings.Contains(annotation, strings.ReplaceAll(detail, `"`, "&#34;")) || len(pipeline.Steps[0].Notify) != 1 || pipeline.Steps[0].Notify[0].GitHubCheck.Output.Summary != annotation {
 		t.Fatalf("reusable input failure output = message %q, annotation %q, pipeline %#v", message, annotation, pipeline.Steps[0])
 	}
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2492,8 +2492,8 @@ func TestValidatePublishesProcessingDiagnosticsInBuildkite(t *testing.T) {
 			t.Fatalf("annotation args = %#v", annotation.args)
 		}
 		for _, want := range []string{
-			`<h2 class="h4 mb2">GitHub Actions workflow diagnostics</h2>`,
-			`<div class="border-top border-gray py2"><div><strong>Runner label &#34;windows-latest&#34; requires Windows, which is unsupported.`,
+			`<h2 class="h4 mb2">Workflow could not be run</h2>`,
+			`<div class="py2"><div><strong>Runner label &#34;windows-latest&#34; requires Windows, which is unsupported.`,
 			`<summary>Diagnostic detail</summary>`,
 			`Supported runner labels: ubuntu-22.04, ubuntu-24.04, ubuntu-latest.`,
 			"Job <code>test</code>",
@@ -2590,8 +2590,8 @@ func TestProcessingAnnotationReservesSpaceForTruncationNotice(t *testing.T) {
 	report := compatibility.NewProcessingReport("ci.yml", "")
 	probe := compatibility.Diagnostic{Level: "warning", Code: "W_LARGE", Message: "a"}
 	probeRow := renderProcessingDiagnostic(probe, sourceLinkContext{})
-	prefixBytes := len("<h2 class=\"h4 mb2\">GitHub Actions workflow diagnostics</h2>\n") +
-		len("<div class=\"mb2\"><strong>Workflow:</strong> ") + len(annotationCode(report.Workflow)) +
+	prefixBytes := len("<h2 class=\"h4 mb2\">Workflow could not be run</h2>\n") +
+		len("<div class=\"mb2\">") + len(annotationCode(report.Workflow)) +
 		len("</div>\n<div class=\"mb2\">\n")
 	messageBytes := processingAnnotationBodyLimit - prefixBytes - len(processingAnnotationEnd) - len(processingAnnotationNotice)/2 - (len(probeRow) - len(probe.Message))
 	report.Diagnostics = append(report.Diagnostics,
@@ -2630,7 +2630,7 @@ func TestProcessingAnnotationUsesRepositoryRelativeWorkflowPath(t *testing.T) {
 	})
 
 	_, body := processingAnnotation(report, sourceLinkContext{})
-	wantWorkflow := "<strong>Workflow:</strong> <code>.github/workflows/test-image-build.yml</code>"
+	wantWorkflow := "<div class=\"mb2\"><code>.github/workflows/test-image-build.yml</code></div>"
 	wantLocation := "<code>.github/workflows/test-image-build.yml:4:2</code>"
 	if !strings.Contains(body, wantWorkflow) || !strings.Contains(body, wantLocation) || strings.Contains(body, repository) {
 		t.Fatalf("annotation = %q, want %q and %q without checkout path", body, wantWorkflow, wantLocation)
@@ -2870,7 +2870,7 @@ func TestProcessingAnnotationPresentsActionFailureAsAConciseCard(t *testing.T) {
 
 	_, body := processingAnnotation(report, sourceLinkContext{})
 	for _, want := range []string{
-		`<div class="border-top border-gray py2"><div><strong>Action metadata uses unsupported field &#34;deprecationMessage&#34;</strong></div>`,
+		`<div class="py2"><div><strong>Action metadata uses unsupported field &#34;deprecationMessage&#34;</strong></div>`,
 		"Action <code>actions/setup-java@v4</code> · Job <code>test</code> · Step 2",
 	} {
 		if !strings.Contains(body, want) {
@@ -4203,7 +4203,7 @@ func TestRunUploadEmitsApplicableCompilationFailuresAsFailingSteps(t *testing.T)
 		"- `" + filepath.ToSlash(workflowPath) + "`, job `gamma`: runs-on expression cannot be resolved at compile time: fromJSON argument is invalid JSON"
 	message := failureArtifactForStep(step.Plugins, runner.uploaded, "messages")
 	annotation := failureArtifactForStep(step.Plugins, runner.uploaded, "annotations")
-	if step.Label != ":github: Invalid push" || step.Condition != "" || !isGeneratedFailureCommand(step.Command) || strings.Contains(step.Command, "Runner label has no") || !strings.Contains(string(message), "Runner label has no") || !strings.Contains(string(message), "detail: Supported runner labels:") || !strings.Contains(string(annotation), `<h2 class="h4 mb2">GitHub Actions workflow diagnostics</h2>`) || !strings.Contains(string(annotation), "Job <code>alpha</code>") || !strings.Contains(string(annotation), "Job <code>beta</code>") || !strings.Contains(string(annotation), "Job <code>gamma</code>") || len(step.Notify) != 1 || step.Notify[0].GitHubCheck.Output.Title != "Workflow could not be run" || step.Notify[0].GitHubCheck.Output.Summary != wantSummary || !step.Checkout.Skip {
+	if step.Label != ":github: Invalid push" || step.Condition != "" || !isGeneratedFailureCommand(step.Command) || strings.Contains(step.Command, "Runner label has no") || !strings.Contains(string(message), "Runner label has no") || !strings.Contains(string(message), "detail: Supported runner labels:") || !strings.Contains(string(annotation), `<h2 class="h4 mb2">Workflow could not be run</h2>`) || !strings.Contains(string(annotation), "Job <code>alpha</code>") || !strings.Contains(string(annotation), "Job <code>beta</code>") || !strings.Contains(string(annotation), "Job <code>gamma</code>") || len(step.Notify) != 1 || step.Notify[0].GitHubCheck.Output.Title != "Workflow could not be run" || step.Notify[0].GitHubCheck.Output.Summary != wantSummary || !step.Checkout.Skip {
 		t.Fatalf("compiler failure step = %#v", step)
 	}
 	if strings.Contains(step.Notify[0].GitHubCheck.Output.Summary, "E_EXPRESSION_INVALID") {
@@ -4239,7 +4239,7 @@ fi
 	command.Env = append(os.Environ(), "PATH="+agentDirectory+string(os.PathListSeparator)+os.Getenv("PATH"))
 	output, err := command.CombinedOutput()
 	plainIndex := strings.Index(string(output), "Runner label has no")
-	annotationIndex := strings.Index(string(output), `<h2 class="h4 mb2">GitHub Actions workflow diagnostics</h2>`)
+	annotationIndex := strings.Index(string(output), `<h2 class="h4 mb2">Workflow could not be run</h2>`)
 	logPrefix := "\x1b[31m"
 	if exitErr, ok := err.(*exec.ExitError); !ok || exitErr.ExitCode() != 1 || !strings.HasPrefix(string(output), logPrefix) || plainIndex == -1 || annotationIndex <= plainIndex {
 		t.Fatalf("compiler failure command output/error = %q / %v", output, err)
@@ -4258,7 +4258,7 @@ func TestFailedGeneratedWorkflowIncludesWarnings(t *testing.T) {
 
 	workflow, artifacts := failedGeneratedWorkflow(workflowInput{Name: "CI", CanonicalPath: ".github/workflows/ci.yml", Identity: "ci", TriggerCondition: "false"}, "push", report, sourceLinkContext{})
 	wantSummary := "The workflow could not be prepared:\n\n- `.github/workflows/ci.yml`, job `test`: runner is unsupported"
-	if workflow.Condition != "" || workflow.Failure == nil || len(artifacts) != 2 || workflow.Failure.MessagePath != artifacts[0].Path || workflow.Failure.AnnotationPath != artifacts[1].Path || !bytes.HasPrefix(artifacts[0].Contents, []byte("\x1b[31m")) || !bytes.HasSuffix(artifacts[0].Contents, []byte("\x1b[0m\n")) || !strings.Contains(string(artifacts[1].Contents), `<h2 class="h4 mb2">GitHub Actions workflow diagnostics</h2>`) || !strings.Contains(string(artifacts[1].Contents), "<strong>runner is unsupported</strong>") || !strings.Contains(string(artifacts[1].Contents), "<strong>cancel-in-progress is ignored</strong>") || workflow.Failure.Summary != wantSummary {
+	if workflow.Condition != "" || workflow.Failure == nil || len(artifacts) != 2 || workflow.Failure.MessagePath != artifacts[0].Path || workflow.Failure.AnnotationPath != artifacts[1].Path || !bytes.HasPrefix(artifacts[0].Contents, []byte("\x1b[31m")) || !bytes.HasSuffix(artifacts[0].Contents, []byte("\x1b[0m\n")) || !strings.Contains(string(artifacts[1].Contents), `<h2 class="h4 mb2">Workflow could not be run</h2>`) || !strings.Contains(string(artifacts[1].Contents), "<strong>runner is unsupported</strong>") || !strings.Contains(string(artifacts[1].Contents), "<strong>cancel-in-progress is ignored</strong>") || workflow.Failure.Summary != wantSummary {
 		t.Fatalf("failure = %#v", workflow.Failure)
 	}
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2527,6 +2527,9 @@ func TestValidatePublishesProcessingDiagnosticsInBuildkite(t *testing.T) {
 		if len(runner.commands) != 1 || runner.commands[0].args[8] != "warning" {
 			t.Fatalf("commands = %#v, want one warning annotation", runner.commands)
 		}
+		if body := string(runner.commands[0].stdin); !strings.Contains(body, `<h2 class="h4 mb2">GitHub Actions workflow diagnostics</h2>`) || strings.Contains(body, "Workflow could not be run") {
+			t.Fatalf("warning annotation = %q", body)
+		}
 		if !strings.Contains(stderr.String(), "warning: processing annotation: annotation unavailable") {
 			t.Fatalf("stderr = %q", stderr.String())
 		}
@@ -2590,7 +2593,7 @@ func TestProcessingAnnotationReservesSpaceForTruncationNotice(t *testing.T) {
 	report := compatibility.NewProcessingReport("ci.yml", "")
 	probe := compatibility.Diagnostic{Level: "warning", Code: "W_LARGE", Message: "a"}
 	probeRow := renderProcessingDiagnostic(probe, sourceLinkContext{})
-	prefixBytes := len("<h2 class=\"h4 mb2\">Workflow could not be run</h2>\n") +
+	prefixBytes := len("<h2 class=\"h4 mb2\">GitHub Actions workflow diagnostics</h2>\n") +
 		len("<div class=\"mb2\">") + len(annotationCode(report.Workflow)) +
 		len("</div>\n<div class=\"mb2\">\n")
 	messageBytes := processingAnnotationBodyLimit - prefixBytes - len(processingAnnotationEnd) - len(processingAnnotationNotice)/2 - (len(probeRow) - len(probe.Message))

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -289,7 +289,7 @@ func renderProcessingDiagnosticWithin(diagnostic compatibility.Diagnostic, limit
 func renderProcessingDiagnostic(diagnostic compatibility.Diagnostic, sourceLinks sourceLinkContext) string {
 	heading, details := annotationDiagnosticPresentation(diagnostic)
 	var out strings.Builder
-	out.WriteString("<div class=\"py2\"><div><strong>")
+	out.WriteString("<div><div><strong>")
 	out.WriteString(annotationHTML(heading))
 	out.WriteString("</strong></div>")
 	context := make([]string, 0, 4)

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -161,8 +161,8 @@ func processingAnnotation(report compatibility.ProcessingReport, sourceLinks sou
 	}
 
 	var out strings.Builder
-	out.WriteString("<h2 class=\"h4 mb2\">GitHub Actions workflow diagnostics</h2>\n")
-	out.WriteString("<div class=\"mb2\"><strong>Workflow:</strong> ")
+	out.WriteString("<h2 class=\"h4 mb2\">Workflow could not be run</h2>\n")
+	out.WriteString("<div class=\"mb2\">")
 	workflowPath, workflowLinkable := processingAnnotationWorkflowPath(report.Workflow, "")
 	if workflowLinkable {
 		sourceLinks.workflowSourceRoot = processingWorkflowSourceRoot(report.Workflow)
@@ -279,7 +279,7 @@ func renderProcessingDiagnosticWithin(diagnostic compatibility.Diagnostic, limit
 func renderProcessingDiagnostic(diagnostic compatibility.Diagnostic, sourceLinks sourceLinkContext) string {
 	heading, details := annotationDiagnosticPresentation(diagnostic)
 	var out strings.Builder
-	out.WriteString("<div class=\"border-top border-gray py2\"><div><strong>")
+	out.WriteString("<div class=\"py2\"><div><strong>")
 	out.WriteString(annotationHTML(heading))
 	out.WriteString("</strong></div>")
 	context := make([]string, 0, 4)

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -144,6 +144,10 @@ func skippedWorkflowsAnnotation(event string, labels []string, buildURL, stepID 
 }
 
 func processingAnnotation(report compatibility.ProcessingReport, sourceLinks sourceLinkContext) (style, body string) {
+	return processingAnnotationWithin(report, sourceLinks, processingAnnotationBodyLimit, processingAnnotationNotice)
+}
+
+func processingAnnotationWithin(report compatibility.ProcessingReport, sourceLinks sourceLinkContext, bodyLimit int, truncationNotice string) (style, body string) {
 	report.Finalize()
 	style = "warning"
 	diagnostics := make([]compatibility.Diagnostic, 0, len(report.Diagnostics))
@@ -175,7 +179,7 @@ func processingAnnotation(report compatibility.ProcessingReport, sourceLinks sou
 		rows[i] = renderProcessingDiagnostic(diagnostic, sourceLinks)
 		bodyBytes += len(rows[i])
 	}
-	if bodyBytes <= processingAnnotationBodyLimit {
+	if bodyBytes <= bodyLimit {
 		for _, row := range rows {
 			out.WriteString(row)
 		}
@@ -183,14 +187,14 @@ func processingAnnotation(report compatibility.ProcessingReport, sourceLinks sou
 		return style, out.String()
 	}
 
-	remaining := processingAnnotationBodyLimit - out.Len() - len(processingAnnotationEnd) - len(processingAnnotationNotice)
+	remaining := bodyLimit - out.Len() - len(processingAnnotationEnd) - len(truncationNotice)
 	for i, row := range rows {
 		if len(row) > remaining {
 			if row = renderProcessingDiagnosticWithin(diagnostics[i], remaining, sourceLinks); row != "" {
 				out.WriteString(row)
 			}
 			out.WriteString(processingAnnotationEnd)
-			out.WriteString(processingAnnotationNotice)
+			out.WriteString(truncationNotice)
 			return style, out.String()
 		}
 		out.WriteString(row)

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -164,8 +164,14 @@ func processingAnnotationWithin(report compatibility.ProcessingReport, sourceLin
 		return "", ""
 	}
 
+	heading := "GitHub Actions workflow diagnostics"
+	if style == "error" {
+		heading = "Workflow could not be run"
+	}
 	var out strings.Builder
-	out.WriteString("<h2 class=\"h4 mb2\">Workflow could not be run</h2>\n")
+	out.WriteString("<h2 class=\"h4 mb2\">")
+	out.WriteString(heading)
+	out.WriteString("</h2>\n")
 	out.WriteString("<div class=\"mb2\">")
 	workflowPath, workflowLinkable := processingAnnotationWorkflowPath(report.Workflow, "")
 	if workflowLinkable {


### PR DESCRIPTION
## Summary

- rename the annotation heading to “Workflow could not be run”
- show the workflow path without a `Workflow:` label
- remove borders between diagnostics while retaining their spacing
- use the same diagnostic HTML for Buildkite annotations and provider checks

## Example HTML

```html
<h2 class="h4 mb2">Workflow could not be run</h2>
<div class="mb2"><code>.github/workflows/ci.yml</code></div>
<div class="mb2">
  <div>
    <div><strong>Runner label “windows-latest” requires Windows, which is unsupported.</strong></div>
    <div class="mt1"><code>.github/workflows/ci.yml:10:3</code> · Job <code>test</code></div>
  </div>
  <div>
    <div><strong>Update actions/checkout from v3 to v4.</strong></div>
    <div class="mt1">Action <code>actions/checkout@v3</code> · Job <code>test</code> · Step 1</div>
  </div>
</div>
```

Source paths remain code-formatted and become links when source-link context is available. Provider checks use the same markup with their smaller summary size limit.

## Validation

- `mise exec -- go test ./internal/cli`
- `mise run check`

Refs #128