### PR TITLE
Support setup-node v4 cache detection

### DIFF
--- a/internal/action/integration/integration.go
+++ b/internal/action/integration/integration.go
@@ -98,6 +98,9 @@ type Descriptor struct {
 	// bundled dependencies. Confirm GITHUB_SERVER_URL affects only caching
 	// behavior and is not load-bearing for any request the action makes.
 	OverrideGitHubServerURL bool
+	// CacheURLCompatibility supplies the legacy ACTIONS_CACHE_URL presence
+	// check while cache-v2 requests continue to use ACTIONS_RESULTS_URL.
+	CacheURLCompatibility bool
 }
 
 // UsesNativeAdapter reports whether the resolved identity replaces the
@@ -115,7 +118,7 @@ var catalog = map[Identity]Descriptor{
 	{Source: "github", Repository: "actions/upload-artifact"}:                {Adapter: AdapterUploadArtifactBuildkite},
 	{Source: "github", Repository: "actions/upload-artifact", Path: "merge"}: {Service: ServiceArtifact},
 	{Source: "github", Repository: "actions/download-artifact"}:              {Adapter: AdapterDownloadArtifactBuildkite},
-	{Source: "github", Repository: "actions/setup-node"}:                     {OverrideGitHubServerURL: true},
+	{Source: "github", Repository: "actions/setup-node"}:                     {OverrideGitHubServerURL: true, CacheURLCompatibility: true},
 	{Source: "github", Repository: "actions/setup-java"}:                     {OverrideGitHubServerURL: true},
 	{Source: "github", Repository: "actions/setup-python"}:                   {OverrideGitHubServerURL: true},
 	{Source: "github", Repository: "actions/setup-go"}:                       {OverrideGitHubServerURL: true},

--- a/internal/action/integration/integration_test.go
+++ b/internal/action/integration/integration_test.go
@@ -17,7 +17,7 @@ func TestLookupMatchesKnownCanonicalActions(t *testing.T) {
 		{Identity{Source: "github", Repository: "actions/upload-artifact"}, Descriptor{Adapter: AdapterUploadArtifactBuildkite}},
 		{Identity{Source: "github", Repository: "actions/upload-artifact", Path: "merge"}, Descriptor{Service: ServiceArtifact}},
 		{Identity{Source: "github", Repository: "actions/download-artifact"}, Descriptor{Adapter: AdapterDownloadArtifactBuildkite}},
-		{Identity{Source: "github", Repository: "actions/setup-node"}, Descriptor{OverrideGitHubServerURL: true}},
+		{Identity{Source: "github", Repository: "actions/setup-node"}, Descriptor{OverrideGitHubServerURL: true, CacheURLCompatibility: true}},
 		{Identity{Source: "github", Repository: "actions/setup-java"}, Descriptor{OverrideGitHubServerURL: true}},
 		{Identity{Source: "github", Repository: "actions/setup-python"}, Descriptor{OverrideGitHubServerURL: true}},
 		{Identity{Source: "github", Repository: "actions/setup-go"}, Descriptor{OverrideGitHubServerURL: true}},

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -486,9 +486,6 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 			return 1
 		}
 		if err != nil {
-			if hasSetupNodeAction(job.Actions) {
-				_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: actions/setup-node cache credentials unavailable: %v\n", err)
-			}
 			cacheCredentials = nil
 		}
 	}
@@ -1101,15 +1098,6 @@ func canonicalNonSymlinkDirectory(path string) (string, error) {
 func hasGitHubActionLocks(locks []plan.ActionLock) bool {
 	for _, lock := range locks {
 		if lock.Source == "github" {
-			return true
-		}
-	}
-	return false
-}
-
-func hasSetupNodeAction(locks []plan.ActionLock) bool {
-	for _, lock := range locks {
-		if lock.Source == "github" && lock.Repository == "actions/setup-node" && lock.Path == "" {
 			return true
 		}
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -6259,21 +6259,6 @@ func TestCacheServiceRequiredUsesOnlyAuditedCacheLocks(t *testing.T) {
 	}
 }
 
-func TestHasSetupNodeActionMatchesOnlyRootGitHubAction(t *testing.T) {
-	if !hasSetupNodeAction([]plan.ActionLock{{Source: "github", Repository: "actions/setup-node"}}) {
-		t.Fatal("root actions/setup-node lock was not detected")
-	}
-	for _, lock := range []plan.ActionLock{
-		{Source: "github", Repository: "actions/setup-node", Path: "nested"},
-		{Source: "workspace", Repository: "actions/setup-node"},
-		{Source: "github", Repository: "owner/setup-node"},
-	} {
-		if hasSetupNodeAction([]plan.ActionLock{lock}) {
-			t.Fatalf("unexpected setup-node match for %#v", lock)
-		}
-	}
-}
-
 func TestUnprivilegedUploadAllowsNativeDownloadArtifactAdapter(t *testing.T) {
 	bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: plan.Job{Workflow: plan.Workflow{LogicalJobID: "consumer"}, Actions: []plan.ActionLock{{Source: "github", Repository: "actions/download-artifact", Commit: actionintegration.DownloadArtifactCommit}}}}}}
 	if err := validateUnprivilegedBundle(bundle); err != nil {

--- a/internal/runtime/actions.go
+++ b/internal/runtime/actions.go
@@ -108,6 +108,11 @@ func overridesGitHubServerURL(lock plan.ActionLock) bool {
 	return descriptor.OverrideGitHubServerURL
 }
 
+func usesCacheURLCompatibility(lock plan.ActionLock) bool {
+	descriptor, _ := actionintegration.Lookup(actionintegration.Identity{Source: lock.Source, Repository: lock.Repository, Path: lock.Path})
+	return descriptor.CacheURLCompatibility
+}
+
 func (r *actionLockResolver) source(selector plan.ActionSelector) (_ string, err error) {
 	defer func() { err = markHardJobFailure(err) }()
 	if r == nil || selector.Lock == "" {

--- a/internal/runtime/cache_service.go
+++ b/internal/runtime/cache_service.go
@@ -18,6 +18,7 @@ const (
 	cacheCredentialResponseLimit = 64 << 10
 	cacheActionToolPath          = "/usr/local/bin:/usr/bin:/bin"
 	defaultCacheResultsURL       = "https://ghacs.buildkite.com/"
+	cacheURLCompatibility        = "https://buildkite-gha-cache-gate.invalid/"
 
 	// githubServerURLOverride is the synthetic, non-resolvable server URL
 	// substituted in when shouldOverrideGitHubServerURL reports true, so

--- a/internal/runtime/cache_service_test.go
+++ b/internal/runtime/cache_service_test.go
@@ -438,6 +438,10 @@ func TestSetupActionsOverrideGitHubServerURLWithoutCacheActionIsolation(t *testi
 		writeFixtureFile(t, remote, phase+".js", fmt.Sprintf(`const fs = require("node:fs");
 if (process.env.GITHUB_SERVER_URL !== %q) throw new Error("unexpected GITHUB_SERVER_URL: " + process.env.GITHUB_SERVER_URL);
 if (process.env.HTTP_PROXY !== "http://proxy.example") throw new Error("setup action environment was isolated");
+for (const name of ["ACTIONS_CACHE_SERVICE_V2", "ACTIONS_RESULTS_URL", "ACTIONS_RUNTIME_TOKEN"])
+  if (!process.env[name]) throw new Error("missing " + name);
+if ((process.env.ACTIONS_CACHE_URL || "") !== process.env.EXPECTED_CACHE_URL)
+  throw new Error("unexpected ACTIONS_CACHE_URL: " + process.env.ACTIONS_CACHE_URL);
 fs.appendFileSync(process.env.LIFECYCLE_LOG, %q + "\n");
 `, githubServerURLOverride, phase))
 	}
@@ -454,33 +458,44 @@ fs.appendFileSync(process.env.LIFECYCLE_LOG, %q + "\n");
 		"actions/setup-dotnet",
 	} {
 		t.Run(strings.TrimPrefix(repository, "actions/"), func(t *testing.T) {
+			provider := &sequenceCacheCredentials{tokens: []string{"header.main.signature", "header.post.signature"}}
 			workspace := t.TempDir()
 			workflowPath := ".github/workflows/setup.yml"
 			writeFixtureFile(t, workspace, workflowPath, "name: setup action override\n")
 			lifecycle := filepath.Join(workspace, "lifecycle.log")
 			lockID := remoteLifecycleLockID(1)
+			requestedRef := "v1"
+			expectedCacheURL := ""
+			if repository == "actions/setup-node" {
+				requestedRef = "v4"
+				expectedCacheURL = cacheURLCompatibility
+			}
 			job := runtimePlan(t, workspace, workflowPath, []plan.Step{{
-				ID: "setup", Kind: "uses", Uses: repository + "@v1", Action: &plan.ActionSelector{Lock: lockID},
+				ID: "setup", Kind: "uses", Uses: repository + "@" + requestedRef, Action: &plan.ActionSelector{Lock: lockID},
 			}})
 			job.Schema = plan.Schema
 			job.Event.Provider = "cursor-origin"
 			job.RequiredCapabilities = []string{"network"}
 			job.Env = map[string]string{
-				"HTTP_PROXY":    "http://proxy.example",
-				"LIFECYCLE_LOG": lifecycle,
+				"EXPECTED_CACHE_URL": expectedCacheURL,
+				"HTTP_PROXY":         "http://proxy.example",
+				"LIFECYCLE_LOG":      lifecycle,
 			}
 			job.Actions = []plan.ActionLock{{
-				ID: lockID, Source: "github", Repository: repository, RequestedRef: "v1",
+				ID: lockID, Source: "github", Repository: repository, RequestedRef: requestedRef,
 				Commit: strings.Repeat("a", 40), SourceDigest: digest,
 			}}
 			materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}
-			result, err := (Runner{Node24: node, Actions: materializer}).RunJob(context.Background(), job, workspace)
+			result, err := (Runner{Node24: node, Actions: materializer, Cache: provider, Redactor: &testRedactor{}}).RunJob(context.Background(), job, workspace)
 			if err != nil || result.Conclusion != "success" {
 				t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 			}
 			contents, err := os.ReadFile(lifecycle)
 			if err != nil || string(contents) != "main\npost\n" {
 				t.Fatalf("setup lifecycle = %q, %v", contents, err)
+			}
+			if provider.calls != 2 {
+				t.Fatalf("cache credential calls = %d, want 2", provider.calls)
 			}
 		})
 	}
@@ -623,8 +638,7 @@ fs.writeFileSync(process.env.MARKER, "executed");
 	result := newResult()
 	result.Env["MARKER"] = marker
 	result.Env["ACTIONS_RUNTIME_TOKEN"] = "workflow-token"
-	var logs bytes.Buffer
-	processor := newCommandProcessor(&logs, &logs)
+	processor := newCommandProcessor(io.Discard, io.Discard)
 	runner := Runner{Cache: provider, Redactor: &testRedactor{}}
 	if err := runner.runJavaScriptPhase(
 		context.Background(), processor, actionRoot, node,
@@ -634,18 +648,6 @@ fs.writeFileSync(process.env.MARKER, "executed");
 	}
 	if contents, err := os.ReadFile(marker); err != nil || string(contents) != "executed" {
 		t.Fatalf("generic action marker = %q, %v", contents, err)
-	}
-	if err := os.Remove(marker); err != nil {
-		t.Fatal(err)
-	}
-	if err := runner.runJavaScriptPhase(
-		context.Background(), processor, actionRoot, node,
-		javaScriptAction{Name: "setup-node", Path: actionRoot, Main: "main.js", reference: "actions/setup-node@v6"}, "main.js", nil, nil, &result,
-	); err != nil {
-		t.Fatalf("setup-node cache fallback error = %v", err)
-	}
-	if !strings.Contains(logs.String(), `Cache credentials unavailable for "actions/setup-node@v6" entry "main.js"; ACTIONS_RESULTS_URL will be omitted: cache unavailable`) {
-		t.Fatalf("setup-node cache diagnostic = %q", logs.String())
 	}
 	if err := os.Remove(marker); err != nil {
 		t.Fatal(err)

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -1309,7 +1309,7 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 		if err != nil {
 			return result, err
 		}
-		javascript := javaScriptAction{Name: actionName(action, step), Path: action.Path, Pre: action.Runs.Pre, Main: action.Runs.Main, Post: action.Runs.Post, Cache: usesCacheService(lock), OverrideGitHubServerURL: overridesGitHubServerURL(lock), nodeMajor: major, reference: step.Uses, jobStatusInputs: jobStatusInputs}
+		javascript := javaScriptAction{Name: actionName(action, step), Path: action.Path, Pre: action.Runs.Pre, Main: action.Runs.Main, Post: action.Runs.Post, Cache: usesCacheService(lock), OverrideGitHubServerURL: overridesGitHubServerURL(lock), CacheURLCompatibility: usesCacheURLCompatibility(lock), nodeMajor: major, reference: step.Uses, jobStatusInputs: jobStatusInputs}
 		invocation := &preparedInvocation{action: javascript, state: map[string]string{}}
 		prepared[invocationID] = invocation
 		if javascript.Pre != "" && runPre {
@@ -1549,7 +1549,7 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 			return result, err
 		}
 		actionEnv := environment.process()
-		javascript := javaScriptAction{Name: actionName(action, step), Path: actionPath, Pre: action.Runs.Pre, Main: action.Runs.Main, Post: action.Runs.Post, Inputs: inputs, Env: actionEnv, Cache: actionLock != nil && usesCacheService(*actionLock), OverrideGitHubServerURL: actionLock != nil && overridesGitHubServerURL(*actionLock), nodeMajor: major, reference: step.Uses, jobStatusInputs: jobStatusInputs}
+		javascript := javaScriptAction{Name: actionName(action, step), Path: actionPath, Pre: action.Runs.Pre, Main: action.Runs.Main, Post: action.Runs.Post, Inputs: inputs, Env: actionEnv, Cache: actionLock != nil && usesCacheService(*actionLock), OverrideGitHubServerURL: actionLock != nil && overridesGitHubServerURL(*actionLock), CacheURLCompatibility: actionLock != nil && usesCacheURLCompatibility(*actionLock), nodeMajor: major, reference: step.Uses, jobStatusInputs: jobStatusInputs}
 		state := map[string]string{}
 		wasPrepared := false
 		if invocation := prepared[invocationID]; invocation != nil {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -149,6 +149,7 @@ type javaScriptAction struct {
 	Env                     map[string]string
 	Cache                   bool
 	OverrideGitHubServerURL bool
+	CacheURLCompatibility   bool
 
 	nodeMajor       int
 	reference       string
@@ -652,11 +653,11 @@ func (r Runner) runJavaScriptPhase(ctx context.Context, processor *commandProces
 	if cacheErr != nil && action.Cache {
 		return fmt.Errorf("configure actions/cache service: %w", cacheErr)
 	}
-	if cacheErr != nil && strings.HasPrefix(action.reference, "actions/setup-node@") {
-		processor.trustedWarning(fmt.Sprintf("Cache credentials unavailable for %q entry %q; ACTIONS_RESULTS_URL will be omitted: %v", action.reference, entry, processor.scrubError(cacheErr)))
-	}
 	cacheToken := ""
 	if cacheErr == nil {
+		if action.CacheURLCompatibility {
+			cacheEnv["ACTIONS_CACHE_URL"] = cacheURLCompatibility
+		}
 		env = mergeStringMaps(env, cacheEnv)
 		cacheToken = cacheEnv["ACTIONS_RUNTIME_TOKEN"]
 	}


### PR DESCRIPTION
## Summary

- provide the legacy `ACTIONS_CACHE_URL` presence marker required by the `@actions/cache` version bundled with `actions/setup-node@v4`
- keep cache requests on cache v2 through `ACTIONS_RESULTS_URL`
- scope the non-routable compatibility marker to root `actions/setup-node` main and post phases
- remove the temporary setup-node cache diagnostics

## Verification

- `mise run check`