### PR TITLE
Support cache detection in setup actions

### DIFF
--- a/internal/action/integration/integration.go
+++ b/internal/action/integration/integration.go
@@ -121,10 +121,10 @@ var catalog = map[Identity]Descriptor{
 	{Source: "github", Repository: "actions/upload-artifact", Path: "merge"}: {Service: ServiceArtifact},
 	{Source: "github", Repository: "actions/download-artifact"}:              {Adapter: AdapterDownloadArtifactBuildkite},
 	{Source: "github", Repository: "actions/setup-node"}:                     {OverrideGitHubServerURL: true, CacheURLCompatibility: true},
-	{Source: "github", Repository: "actions/setup-java"}:                     {OverrideGitHubServerURL: true},
-	{Source: "github", Repository: "actions/setup-python"}:                   {OverrideGitHubServerURL: true},
-	{Source: "github", Repository: "actions/setup-go"}:                       {OverrideGitHubServerURL: true},
-	{Source: "github", Repository: "actions/setup-dotnet"}:                   {OverrideGitHubServerURL: true},
+	{Source: "github", Repository: "actions/setup-java"}:                     {OverrideGitHubServerURL: true, CacheURLCompatibility: true},
+	{Source: "github", Repository: "actions/setup-python"}:                   {OverrideGitHubServerURL: true, CacheURLCompatibility: true},
+	{Source: "github", Repository: "actions/setup-go"}:                       {OverrideGitHubServerURL: true, CacheURLCompatibility: true},
+	{Source: "github", Repository: "actions/setup-dotnet"}:                   {OverrideGitHubServerURL: true, CacheURLCompatibility: true},
 }
 
 var checkoutCommits = map[string]string{

--- a/internal/action/integration/integration.go
+++ b/internal/action/integration/integration.go
@@ -96,13 +96,10 @@ const (
 type Descriptor struct {
 	Adapter Adapter
 	Service Service
-	// Before enabling OverrideGitHubServerURL, audit the action source and its
-	// bundled dependencies. Confirm GITHUB_SERVER_URL affects only caching
-	// behavior and is not load-bearing for any request the action makes.
-	OverrideGitHubServerURL bool
-	// CacheURLCompatibility supplies the legacy ACTIONS_CACHE_URL presence
-	// check while cache-v2 requests continue to use ACTIONS_RESULTS_URL.
-	CacheURLCompatibility bool
+	// CacheClientCompatibility adapts bundled cache clients to Buildkite's
+	// cache-v2 environment. Before enabling it, confirm GITHUB_SERVER_URL
+	// affects only caching and ACTIONS_CACHE_URL is only a presence check.
+	CacheClientCompatibility bool
 }
 
 // UsesNativeAdapter reports whether the resolved identity replaces the
@@ -114,17 +111,17 @@ func UsesNativeAdapter(identity Identity) bool {
 
 var catalog = map[Identity]Descriptor{
 	{Source: "github", Repository: "actions/checkout"}:                       {Adapter: AdapterCheckoutExactEventSHA},
-	{Source: "github", Repository: "actions/cache"}:                          {Service: ServiceCache, OverrideGitHubServerURL: true},
-	{Source: "github", Repository: "actions/cache", Path: "restore"}:         {Service: ServiceCache, OverrideGitHubServerURL: true},
-	{Source: "github", Repository: "actions/cache", Path: "save"}:            {Service: ServiceCache, OverrideGitHubServerURL: true},
+	{Source: "github", Repository: "actions/cache"}:                          {Service: ServiceCache},
+	{Source: "github", Repository: "actions/cache", Path: "restore"}:         {Service: ServiceCache},
+	{Source: "github", Repository: "actions/cache", Path: "save"}:            {Service: ServiceCache},
 	{Source: "github", Repository: "actions/upload-artifact"}:                {Adapter: AdapterUploadArtifactBuildkite},
 	{Source: "github", Repository: "actions/upload-artifact", Path: "merge"}: {Service: ServiceArtifact},
 	{Source: "github", Repository: "actions/download-artifact"}:              {Adapter: AdapterDownloadArtifactBuildkite},
-	{Source: "github", Repository: "actions/setup-node"}:                     {OverrideGitHubServerURL: true, CacheURLCompatibility: true},
-	{Source: "github", Repository: "actions/setup-java"}:                     {OverrideGitHubServerURL: true, CacheURLCompatibility: true},
-	{Source: "github", Repository: "actions/setup-python"}:                   {OverrideGitHubServerURL: true, CacheURLCompatibility: true},
-	{Source: "github", Repository: "actions/setup-go"}:                       {OverrideGitHubServerURL: true, CacheURLCompatibility: true},
-	{Source: "github", Repository: "actions/setup-dotnet"}:                   {OverrideGitHubServerURL: true, CacheURLCompatibility: true},
+	{Source: "github", Repository: "actions/setup-node"}:                     {CacheClientCompatibility: true},
+	{Source: "github", Repository: "actions/setup-java"}:                     {CacheClientCompatibility: true},
+	{Source: "github", Repository: "actions/setup-python"}:                   {CacheClientCompatibility: true},
+	{Source: "github", Repository: "actions/setup-go"}:                       {CacheClientCompatibility: true},
+	{Source: "github", Repository: "actions/setup-dotnet"}:                   {CacheClientCompatibility: true},
 }
 
 var checkoutCommits = map[string]string{

--- a/internal/action/integration/integration_test.go
+++ b/internal/action/integration/integration_test.go
@@ -11,17 +11,17 @@ func TestLookupMatchesKnownCanonicalActions(t *testing.T) {
 		want     Descriptor
 	}{
 		{Identity{Source: "github", Repository: "actions/checkout"}, Descriptor{Adapter: AdapterCheckoutExactEventSHA}},
-		{Identity{Source: "github", Repository: "actions/cache"}, Descriptor{Service: ServiceCache, OverrideGitHubServerURL: true}},
-		{Identity{Source: "github", Repository: "actions/cache", Path: "restore"}, Descriptor{Service: ServiceCache, OverrideGitHubServerURL: true}},
-		{Identity{Source: "github", Repository: "actions/cache", Path: "save"}, Descriptor{Service: ServiceCache, OverrideGitHubServerURL: true}},
+		{Identity{Source: "github", Repository: "actions/cache"}, Descriptor{Service: ServiceCache}},
+		{Identity{Source: "github", Repository: "actions/cache", Path: "restore"}, Descriptor{Service: ServiceCache}},
+		{Identity{Source: "github", Repository: "actions/cache", Path: "save"}, Descriptor{Service: ServiceCache}},
 		{Identity{Source: "github", Repository: "actions/upload-artifact"}, Descriptor{Adapter: AdapterUploadArtifactBuildkite}},
 		{Identity{Source: "github", Repository: "actions/upload-artifact", Path: "merge"}, Descriptor{Service: ServiceArtifact}},
 		{Identity{Source: "github", Repository: "actions/download-artifact"}, Descriptor{Adapter: AdapterDownloadArtifactBuildkite}},
-		{Identity{Source: "github", Repository: "actions/setup-node"}, Descriptor{OverrideGitHubServerURL: true, CacheURLCompatibility: true}},
-		{Identity{Source: "github", Repository: "actions/setup-java"}, Descriptor{OverrideGitHubServerURL: true, CacheURLCompatibility: true}},
-		{Identity{Source: "github", Repository: "actions/setup-python"}, Descriptor{OverrideGitHubServerURL: true, CacheURLCompatibility: true}},
-		{Identity{Source: "github", Repository: "actions/setup-go"}, Descriptor{OverrideGitHubServerURL: true, CacheURLCompatibility: true}},
-		{Identity{Source: "github", Repository: "actions/setup-dotnet"}, Descriptor{OverrideGitHubServerURL: true, CacheURLCompatibility: true}},
+		{Identity{Source: "github", Repository: "actions/setup-node"}, Descriptor{CacheClientCompatibility: true}},
+		{Identity{Source: "github", Repository: "actions/setup-java"}, Descriptor{CacheClientCompatibility: true}},
+		{Identity{Source: "github", Repository: "actions/setup-python"}, Descriptor{CacheClientCompatibility: true}},
+		{Identity{Source: "github", Repository: "actions/setup-go"}, Descriptor{CacheClientCompatibility: true}},
+		{Identity{Source: "github", Repository: "actions/setup-dotnet"}, Descriptor{CacheClientCompatibility: true}},
 	}
 	for _, test := range tests {
 		name := test.identity.Repository

--- a/internal/action/integration/integration_test.go
+++ b/internal/action/integration/integration_test.go
@@ -18,10 +18,10 @@ func TestLookupMatchesKnownCanonicalActions(t *testing.T) {
 		{Identity{Source: "github", Repository: "actions/upload-artifact", Path: "merge"}, Descriptor{Service: ServiceArtifact}},
 		{Identity{Source: "github", Repository: "actions/download-artifact"}, Descriptor{Adapter: AdapterDownloadArtifactBuildkite}},
 		{Identity{Source: "github", Repository: "actions/setup-node"}, Descriptor{OverrideGitHubServerURL: true, CacheURLCompatibility: true}},
-		{Identity{Source: "github", Repository: "actions/setup-java"}, Descriptor{OverrideGitHubServerURL: true}},
-		{Identity{Source: "github", Repository: "actions/setup-python"}, Descriptor{OverrideGitHubServerURL: true}},
-		{Identity{Source: "github", Repository: "actions/setup-go"}, Descriptor{OverrideGitHubServerURL: true}},
-		{Identity{Source: "github", Repository: "actions/setup-dotnet"}, Descriptor{OverrideGitHubServerURL: true}},
+		{Identity{Source: "github", Repository: "actions/setup-java"}, Descriptor{OverrideGitHubServerURL: true, CacheURLCompatibility: true}},
+		{Identity{Source: "github", Repository: "actions/setup-python"}, Descriptor{OverrideGitHubServerURL: true, CacheURLCompatibility: true}},
+		{Identity{Source: "github", Repository: "actions/setup-go"}, Descriptor{OverrideGitHubServerURL: true, CacheURLCompatibility: true}},
+		{Identity{Source: "github", Repository: "actions/setup-dotnet"}, Descriptor{OverrideGitHubServerURL: true, CacheURLCompatibility: true}},
 	}
 	for _, test := range tests {
 		name := test.identity.Repository

--- a/internal/runtime/actions.go
+++ b/internal/runtime/actions.go
@@ -103,14 +103,9 @@ func usesCacheService(lock plan.ActionLock) bool {
 	return descriptor.Service == actionintegration.ServiceCache
 }
 
-func overridesGitHubServerURL(lock plan.ActionLock) bool {
+func usesCacheClientCompatibility(lock plan.ActionLock) bool {
 	descriptor, _ := actionintegration.Lookup(actionintegration.Identity{Source: lock.Source, Repository: lock.Repository, Path: lock.Path})
-	return descriptor.OverrideGitHubServerURL
-}
-
-func usesCacheURLCompatibility(lock plan.ActionLock) bool {
-	descriptor, _ := actionintegration.Lookup(actionintegration.Identity{Source: lock.Source, Repository: lock.Repository, Path: lock.Path})
-	return descriptor.CacheURLCompatibility
+	return descriptor.CacheClientCompatibility
 }
 
 func (r *actionLockResolver) source(selector plan.ActionSelector) (_ string, err error) {

--- a/internal/runtime/cache_service_test.go
+++ b/internal/runtime/cache_service_test.go
@@ -430,7 +430,7 @@ func TestIsolateCacheActionEnvironmentLeavesRealGitHubServerURLUnchanged(t *test
 	}
 }
 
-func TestSetupActionsOverrideGitHubServerURLWithoutCacheActionIsolation(t *testing.T) {
+func TestSetupActionsUseCacheClientCompatibilityWithoutCacheActionIsolation(t *testing.T) {
 	node := requireNode24(t)
 	remote := t.TempDir()
 	writeFixtureFile(t, remote, "action.yml", "name: setup fixture\nruns:\n  using: node24\n  main: main.js\n  post: post.js\n  post-if: success()\n")

--- a/internal/runtime/cache_service_test.go
+++ b/internal/runtime/cache_service_test.go
@@ -450,39 +450,36 @@ fs.appendFileSync(process.env.LIFECYCLE_LOG, %q + "\n");
 		t.Fatal(err)
 	}
 
-	for _, repository := range []string{
-		"actions/setup-node",
-		"actions/setup-java",
-		"actions/setup-python",
-		"actions/setup-go",
-		"actions/setup-dotnet",
+	for _, setup := range []struct {
+		repository string
+		ref        string
+	}{
+		{repository: "actions/setup-node", ref: "v4"},
+		{repository: "actions/setup-java", ref: "v4"},
+		{repository: "actions/setup-python", ref: "v5"},
+		{repository: "actions/setup-go", ref: "v5"},
+		{repository: "actions/setup-dotnet", ref: "v4"},
 	} {
-		t.Run(strings.TrimPrefix(repository, "actions/"), func(t *testing.T) {
+		t.Run(strings.TrimPrefix(setup.repository, "actions/"), func(t *testing.T) {
 			provider := &sequenceCacheCredentials{tokens: []string{"header.main.signature", "header.post.signature"}}
 			workspace := t.TempDir()
 			workflowPath := ".github/workflows/setup.yml"
 			writeFixtureFile(t, workspace, workflowPath, "name: setup action override\n")
 			lifecycle := filepath.Join(workspace, "lifecycle.log")
 			lockID := remoteLifecycleLockID(1)
-			requestedRef := "v1"
-			expectedCacheURL := ""
-			if repository == "actions/setup-node" {
-				requestedRef = "v4"
-				expectedCacheURL = cacheURLCompatibility
-			}
 			job := runtimePlan(t, workspace, workflowPath, []plan.Step{{
-				ID: "setup", Kind: "uses", Uses: repository + "@" + requestedRef, Action: &plan.ActionSelector{Lock: lockID},
+				ID: "setup", Kind: "uses", Uses: setup.repository + "@" + setup.ref, Action: &plan.ActionSelector{Lock: lockID},
 			}})
 			job.Schema = plan.Schema
 			job.Event.Provider = "cursor-origin"
 			job.RequiredCapabilities = []string{"network"}
 			job.Env = map[string]string{
-				"EXPECTED_CACHE_URL": expectedCacheURL,
+				"EXPECTED_CACHE_URL": cacheURLCompatibility,
 				"HTTP_PROXY":         "http://proxy.example",
 				"LIFECYCLE_LOG":      lifecycle,
 			}
 			job.Actions = []plan.ActionLock{{
-				ID: lockID, Source: "github", Repository: repository, RequestedRef: requestedRef,
+				ID: lockID, Source: "github", Repository: setup.repository, RequestedRef: setup.ref,
 				Commit: strings.Repeat("a", 40), SourceDigest: digest,
 			}}
 			materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -1309,7 +1309,7 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 		if err != nil {
 			return result, err
 		}
-		javascript := javaScriptAction{Name: actionName(action, step), Path: action.Path, Pre: action.Runs.Pre, Main: action.Runs.Main, Post: action.Runs.Post, Cache: usesCacheService(lock), OverrideGitHubServerURL: overridesGitHubServerURL(lock), CacheURLCompatibility: usesCacheURLCompatibility(lock), nodeMajor: major, reference: step.Uses, jobStatusInputs: jobStatusInputs}
+		javascript := javaScriptAction{Name: actionName(action, step), Path: action.Path, Pre: action.Runs.Pre, Main: action.Runs.Main, Post: action.Runs.Post, Cache: usesCacheService(lock), CacheClientCompatibility: usesCacheClientCompatibility(lock), nodeMajor: major, reference: step.Uses, jobStatusInputs: jobStatusInputs}
 		invocation := &preparedInvocation{action: javascript, state: map[string]string{}}
 		prepared[invocationID] = invocation
 		if javascript.Pre != "" && runPre {
@@ -1549,7 +1549,7 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 			return result, err
 		}
 		actionEnv := environment.process()
-		javascript := javaScriptAction{Name: actionName(action, step), Path: actionPath, Pre: action.Runs.Pre, Main: action.Runs.Main, Post: action.Runs.Post, Inputs: inputs, Env: actionEnv, Cache: actionLock != nil && usesCacheService(*actionLock), OverrideGitHubServerURL: actionLock != nil && overridesGitHubServerURL(*actionLock), CacheURLCompatibility: actionLock != nil && usesCacheURLCompatibility(*actionLock), nodeMajor: major, reference: step.Uses, jobStatusInputs: jobStatusInputs}
+		javascript := javaScriptAction{Name: actionName(action, step), Path: actionPath, Pre: action.Runs.Pre, Main: action.Runs.Main, Post: action.Runs.Post, Inputs: inputs, Env: actionEnv, Cache: actionLock != nil && usesCacheService(*actionLock), CacheClientCompatibility: actionLock != nil && usesCacheClientCompatibility(*actionLock), nodeMajor: major, reference: step.Uses, jobStatusInputs: jobStatusInputs}
 		state := map[string]string{}
 		wasPrepared := false
 		if invocation := prepared[invocationID]; invocation != nil {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -140,16 +140,15 @@ func (r *Runner) setExplicitNode(major int, path string) {
 
 // javaScriptAction is an already-resolved local JavaScript action.
 type javaScriptAction struct {
-	Name                    string
-	Path                    string
-	Pre                     string
-	Main                    string
-	Post                    string
-	Inputs                  map[string]string
-	Env                     map[string]string
-	Cache                   bool
-	OverrideGitHubServerURL bool
-	CacheURLCompatibility   bool
+	Name                     string
+	Path                     string
+	Pre                      string
+	Main                     string
+	Post                     string
+	Inputs                   map[string]string
+	Env                      map[string]string
+	Cache                    bool
+	CacheClientCompatibility bool
 
 	nodeMajor       int
 	reference       string
@@ -643,7 +642,7 @@ func (r Runner) runJavaScriptPhase(ctx context.Context, processor *commandProces
 	if action.Cache {
 		env = isolateCacheActionEnvironment(env)
 	}
-	if action.OverrideGitHubServerURL {
+	if action.Cache || action.CacheClientCompatibility {
 		applyGitHubServerURLOverride(env)
 	}
 	cacheEnv, cacheErr := r.cacheActionEnvironment(ctx, processor)
@@ -655,7 +654,7 @@ func (r Runner) runJavaScriptPhase(ctx context.Context, processor *commandProces
 	}
 	cacheToken := ""
 	if cacheErr == nil {
-		if action.CacheURLCompatibility {
+		if action.CacheClientCompatibility {
 			cacheEnv["ACTIONS_CACHE_URL"] = cacheURLCompatibility
 		}
 		env = mergeStringMaps(env, cacheEnv)


### PR DESCRIPTION
## Summary

- provide the legacy `ACTIONS_CACHE_URL` presence marker to allowlisted setup actions
- cover setup-java, setup-python, setup-go, and setup-dotnet main and post phases
- continue routing cache-v2 requests through `ACTIONS_RESULTS_URL`

## Testing

- `mise run check`