### PR TITLE
PB-2722: Default macos-latest to the hosted macos-medium queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ plugins:
 ```
 
 Linux labels use the matching Noble or Jammy hosted-toolchains image, with or
-without a configured queue. A macOS label selects native Darwin/arm64, not a
-GitHub image or Xcode inventory.
+without a configured queue. Without a mapping, `macos-latest` targets the
+hosted `macos-medium` queue; `macos-14` and `macos-15` require one. A macOS
+label selects native Darwin/arm64, not a GitHub image or Xcode inventory.
 
 The imported workflows are a dynamic part of the Buildkite pipeline. The plugin creates one aggregate group per successfully compiled, explicitly listed workflow in a single transaction. Workflows that do not declare the selected event become top-level skipped steps. Groups and replacement steps depend on the importer. Each workflow publishes a provider check named `Buildkite / <workflow> (<event>)`: a GitHub check for GitHub events or an Origin check for Origin events. This approach lets you keep existing workflows while moving jobs to native Buildkite steps over time.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -175,8 +175,10 @@ buildkite-gha upload \
 `ubuntu-latest` and `ubuntu-24.04` default to the Noble hosted-toolchains
 image; `ubuntu-22.04` defaults to Jammy. Use `--runner-image` with an immutable
 digest to override the default for a configured profile. Unmapped Linux labels
-keep default agent targeting with the matching image. Every macOS label
-requires a queue and rejects images. Runtime distribution paths must be absolute executables. The
+keep default agent targeting with the matching image. Unmapped `macos-latest`
+targets the hosted `macos-medium` queue provisioned at signup; a mapping
+overrides it, and the queue must exist and allow macOS capacity. `macos-14`
+and `macos-15` require a queue. Every macOS label rejects images. Runtime distribution paths must be absolute executables. The
 importer's platform defaults to its running executable; the other platform has
 no direct-upload default.
 `BUILDKITE_GHA_TARGET_QUEUE` and `BUILDKITE_GHA_RUNTIME_IMAGE` are no longer

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -319,8 +319,10 @@ A job with `continue-on-error: true` stops ordinary steps after a failure, runs 
 Runner labels do not select GitHub images. Linux labels default to the
 corresponding Noble or Jammy hosted-toolchains image; an explicit immutable
 image overrides it for a configured profile. Unmapped Linux labels use default
-Buildkite agent targeting with that image. macOS labels require a runner
-profile with a native queue and reject images. They select Darwin/arm64, not a GitHub image or Xcode inventory.
+Buildkite agent targeting with that image. Through the upload path,
+unmapped `macos-latest` targets the hosted `macos-medium` queue; `macos-14`
+and `macos-15` require a runner profile with a native queue. macOS labels
+reject images. They select Darwin/arm64, not a GitHub image or Xcode inventory.
 
 ### Matrix strategies
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -70,7 +70,7 @@ func writeCommandHelp(stdout io.Writer, command string) {
 	case "compile":
 		_, _ = fmt.Fprint(stdout, "\nPipeline output references content-addressed plans; compile does not materialize or upload those artifacts.\n")
 	case "upload":
-		_, _ = fmt.Fprint(stdout, "\nEvery workflow operand must be an explicit .yml or .yaml path; use -- before paths that begin with a dash. Multiple operands must be tracked files inside the checked-out repository. Inputs are uploaded as one aggregate pipeline: successful workflows become groups, while failed or skipped workflows become top-level replacement steps. Reusable-only workflow_call files are imported through callers but do not become groups. Scheduled groups select only build.source == schedule: Buildkite schedules retain cron ownership, so every scheduled workflow group is eligible on any Buildkite scheduled build. Each repeatable --runner-queue argument maps one supported runs-on label to a Buildkite queue. Every supported Linux label defaults to the matching immutable hosted-toolchains image; --runner-image overrides it for a configured profile. Duplicate or unsupported mappings fail, unmapped supported Linux labels retain default agent targeting with that image, and every macOS label requires an explicit queue. Each repeatable --runtime-distribution argument binds linux/amd64 or darwin/arm64 to a verified executable. Upload importers may run on either platform; the matching runtime defaults to the importer executable, and workflows targeting the other platform require its distribution. The experimental --experimental-runner-user option provisions and uses a non-root Linux runner identity; it does not affect macOS jobs. The deprecated --runtime-queue hosted option is accepted for plugin compatibility but does not select a queue. Event precedence is an explicit event file, Buildkite's reserved webhook metadata, then reduced-fidelity Buildkite environment compatibility data; every source remains unsigned. Verified checkout jobs automatically use Buildkite repository-provider Git credentials when the job enables them; the deprecated --private-checkout option is accepted as a no-op.\n")
+		_, _ = fmt.Fprint(stdout, "\nEvery workflow operand must be an explicit .yml or .yaml path; use -- before paths that begin with a dash. Multiple operands must be tracked files inside the checked-out repository. Inputs are uploaded as one aggregate pipeline: successful workflows become groups, while failed or skipped workflows become top-level replacement steps. Reusable-only workflow_call files are imported through callers but do not become groups. Scheduled groups select only build.source == schedule: Buildkite schedules retain cron ownership, so every scheduled workflow group is eligible on any Buildkite scheduled build. Each repeatable --runner-queue argument maps one supported runs-on label to a Buildkite queue. Every supported Linux label defaults to the matching immutable hosted-toolchains image; --runner-image overrides it for a configured profile. Duplicate or unsupported mappings fail, unmapped supported Linux labels retain default agent targeting with that image, unmapped macos-latest targets the hosted macos-medium queue, and every other macOS label requires an explicit queue. Each repeatable --runtime-distribution argument binds linux/amd64 or darwin/arm64 to a verified executable. Upload importers may run on either platform; the matching runtime defaults to the importer executable, and workflows targeting the other platform require its distribution. The experimental --experimental-runner-user option provisions and uses a non-root Linux runner identity; it does not affect macOS jobs. The deprecated --runtime-queue hosted option is accepted for plugin compatibility but does not select a queue. Event precedence is an explicit event file, Buildkite's reserved webhook metadata, then reduced-fidelity Buildkite environment compatibility data; every source remains unsigned. Verified checkout jobs automatically use Buildkite repository-provider Git credentials when the job enables them; the deprecated --private-checkout option is accepted as a no-op.\n")
 	}
 }
 
@@ -99,6 +99,7 @@ const (
 	workflowCheckSummaryLimit                   = 65535
 	defaultNobleRunnerImage                     = "buildkite.namespace-images.com/agent-base@sha256:62a45683afffaae9edfd669c16d2fee23b5a571679f31715e1063dada667ea24"
 	defaultJammyRunnerImage                     = "buildkite.namespace-images.com/agent-base@sha256:a014d0bae6b06bb315d10b5ff8bb226d5fe7fa468bcf140b3c0d7e72a33aa1ac"
+	defaultMacOSRunnerQueue                     = "macos-medium"
 )
 
 var runnerQueuePattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,255}$`)
@@ -1301,7 +1302,14 @@ func validate(args []string, stdout, stderr io.Writer, version string, agent tra
 			}
 		}
 	}
-	processingReport, ok := validatedProcessingReport(out, workflowPath, profile, source, event, eventPath != "")
+	// Profile validation applies the hosted runner policy so validate and
+	// upload agree on supported labels, including the default macOS queue.
+	var validationOptions *compiler.Options
+	if profile != "" {
+		hosted := hostedOptions("", nil, nil)
+		validationOptions = &hosted
+	}
+	processingReport, ok := validatedProcessingReportWithOptions(out, workflowPath, profile, source, event, eventPath != "", validationOptions)
 	if !ok {
 		return 1
 	}
@@ -1315,7 +1323,12 @@ func validate(args []string, stdout, stderr io.Writer, version string, agent tra
 		}
 		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 		defer stop()
-		runtimeDistributions := map[compiler.Platform]string{compiler.PlatformLinuxAMD64: distributionDigest}
+		// Profile validation never executes generated plans, so the importer
+		// digest stands in for every platform's runtime distribution.
+		runtimeDistributions := map[compiler.Platform]string{
+			compiler.PlatformLinuxAMD64:  distributionDigest,
+			compiler.PlatformDarwinARM64: distributionDigest,
+		}
 		preflight, profileErr := compileHosted(ctx, workflowPath, source, event, version, distributionDigest, "buildkite-gha-profile-importer", "", nil, runtimeDistributions, nil)
 		applyHostedPreflight(&processingReport, preflight)
 		if profileErr != nil {
@@ -2346,10 +2359,14 @@ func hostedOptions(groupLabel string, configuredTargets map[string]compiler.Runn
 	// Unmapped Linux labels keep Buildkite default agent targeting but still
 	// select the matching hosted-toolchains image, so ubuntu-latest jobs get
 	// GitHub-comparable tooling without an explicit runners mapping.
+	// Unmapped macos-latest routes to the hosted macOS queue provisioned at
+	// signup; versioned macOS labels still require an explicit queue because
+	// no default queue can guarantee a specific macOS or Xcode version.
 	targets := map[string]compiler.RunnerTarget{
 		"ubuntu-latest": {Platform: compiler.PlatformLinuxAMD64, Image: defaultNobleRunnerImage},
 		"ubuntu-24.04":  {Platform: compiler.PlatformLinuxAMD64, Image: defaultNobleRunnerImage},
 		"ubuntu-22.04":  {Platform: compiler.PlatformLinuxAMD64, Image: defaultJammyRunnerImage},
+		"macos-latest":  {Platform: compiler.PlatformDarwinARM64, Queue: defaultMacOSRunnerQueue},
 	}
 	for label, target := range configuredTargets {
 		targets[label] = target
@@ -2363,8 +2380,8 @@ func hostedOptions(groupLabel string, configuredTargets map[string]compiler.Runn
 			AllowUntrustedDefaultQueue: true,
 		},
 	}
-	for _, target := range configuredTargets {
-		if !slices.Contains(options.Runners.UntrustedQueues, target.Queue) {
+	for _, target := range targets {
+		if target.Queue != "" && !slices.Contains(options.Runners.UntrustedQueues, target.Queue) {
 			options.Runners.UntrustedQueues = append(options.Runners.UntrustedQueues, target.Queue)
 		}
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1211,6 +1211,25 @@ func TestRunValidateAndCompile(t *testing.T) {
 		}
 	})
 
+	t.Run("validate hosted profile admits unmapped macos-latest", func(t *testing.T) {
+		workflow := filepath.Join(t.TempDir(), "macos-latest.yml")
+		if err := os.WriteFile(workflow, []byte("on: push\njobs:\n  macos:\n    runs-on: macos-latest\n    steps:\n      - run: echo macos\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		var stdout, stderr bytes.Buffer
+		args := []string{"validate", "--profile", "hosted", "--format", "json", "--event-path", eventPath, workflow}
+		if code := Run(args, &stdout, &stderr, "dev"); code != 0 {
+			t.Fatalf("Run() code = %d, stderr = %q", code, stderr.String())
+		}
+		var report compatibility.ProcessingReport
+		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+			t.Fatal(err)
+		}
+		if report.Result != "admitted" || report.Admission.Result != "admitted" || len(report.Diagnostics) != 0 {
+			t.Fatalf("macos-latest profile report = %#v", report)
+		}
+	})
+
 	t.Run("validate hosted macOS profile requires upload mapping", func(t *testing.T) {
 		workflow := filepath.Join(t.TempDir(), "macos.yml")
 		if err := os.WriteFile(workflow, []byte("on: push\njobs:\n  macos:\n    runs-on: macos-15\n    steps:\n      - run: echo macos\n"), 0o600); err != nil {
@@ -4204,7 +4223,7 @@ func TestRunUploadContinuesAfterWorkflowCompilationFailures(t *testing.T) {
 	firstFailureMessage := string(failureArtifactForStep(pipeline.Steps[0].Plugins, runner.uploaded, "messages"))
 	if !strings.Contains(firstFailureMessage, `Runner label "windows-latest" requires Windows, which is unsupported. Use a Linux or macOS runner label.`) ||
 		!strings.Contains(firstFailureMessage, `Runner label "macos-15" has no runner-target mapping. Configure a mapping for this label or use a mapped runner label.`) ||
-		strings.Count(firstFailureMessage, "detail: Supported runner labels: ubuntu-22.04, ubuntu-24.04, ubuntu-latest.") != 2 {
+		strings.Count(firstFailureMessage, "detail: Supported runner labels: macos-latest, ubuntu-22.04, ubuntu-24.04, ubuntu-latest.") != 2 {
 		t.Fatalf("multi-diagnostic failure message = %q", firstFailureMessage)
 	}
 	actionFailureAnnotation := string(failureArtifactForStep(pipeline.Steps[1].Plugins, runner.uploaded, "annotations"))
@@ -4911,6 +4930,36 @@ func TestCompileHostedRequiresExplicitMacOSQueueAndRuntime(t *testing.T) {
 	}
 	if len(compiled.Bundle.Plans) != 1 || compiled.Bundle.Plans[0].Job.Target.Queue != "macos" || compiled.Bundle.Plans[0].Job.RuntimeDistributionDigest() != darwinDigest || !bytes.Contains(compiled.Bundle.Pipeline, []byte("queue: \"macos\"")) {
 		t.Fatalf("macOS compilation = %#v\n%s", compiled.Bundle.Plans, compiled.Bundle.Pipeline)
+	}
+}
+
+func TestCompileHostedDefaultsMacOSLatestToHostedQueue(t *testing.T) {
+	workflow := []byte("on: push\njobs:\n  macos:\n    runs-on: macos-latest\n    steps:\n      - run: echo macos\n")
+	event, err := os.ReadFile(filepath.Join("..", "..", "testdata", "smoke", "events", "push.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	compilerDigest := "sha256:" + strings.Repeat("0", 64)
+	darwinDigest := "sha256:" + strings.Repeat("1", 64)
+	_, err = compileHosted(context.Background(), "macos.yml", workflow, event, "0.0.0-test", compilerDigest, "importer", "", nil, nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "no runtime distribution configured for darwin/arm64") {
+		t.Fatalf("unmapped macos-latest without Darwin runtime error = %v", err)
+	}
+	darwinRuntime := map[compiler.Platform]string{compiler.PlatformDarwinARM64: darwinDigest}
+	compiled, err := compileHosted(context.Background(), "macos.yml", workflow, event, "0.0.0-test", compilerDigest, "importer", "", nil, darwinRuntime, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(compiled.Bundle.Plans) != 1 || compiled.Bundle.Plans[0].Job.Target.Queue != defaultMacOSRunnerQueue || compiled.Bundle.Plans[0].Job.RuntimeDistributionDigest() != darwinDigest || !bytes.Contains(compiled.Bundle.Pipeline, []byte("queue: \"macos-medium\"")) {
+		t.Fatalf("default macos-latest compilation = %#v\n%s", compiled.Bundle.Plans, compiled.Bundle.Pipeline)
+	}
+	override := map[string]compiler.RunnerTarget{"macos-latest": {Queue: "custom-macos", Platform: compiler.PlatformDarwinARM64}}
+	compiled, err = compileHosted(context.Background(), "macos.yml", workflow, event, "0.0.0-test", compilerDigest, "importer", "", override, darwinRuntime, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(compiled.Bundle.Plans) != 1 || compiled.Bundle.Plans[0].Job.Target.Queue != "custom-macos" || !bytes.Contains(compiled.Bundle.Pipeline, []byte("queue: \"custom-macos\"")) {
+		t.Fatalf("overridden macos-latest compilation = %#v\n%s", compiled.Bundle.Plans, compiled.Bundle.Pipeline)
 	}
 }
 


### PR DESCRIPTION
Part of [PB-2722](https://linear.app/buildkite/issue/PB-2722). Closes the `macos-latest` auto-routing gap discussed in [#project-buildkite-gha](https://buildkite-corp.slack.com/archives/C0BKA9NUYS0/p1786683008012169).

## What

Unmapped `runs-on: macos-latest` in the hosted upload path now targets the `macos-medium` queue that Buildkite provisions at signup, instead of failing compilation with an unmapped-label diagnostic.

| Label | Without a mapping | With a mapping |
| --- | --- | --- |
| `macos-latest` | queue `macos-medium` | configured queue |
| `macos-14`, `macos-15` | rejected (unchanged) | configured queue |

- Versioned macOS labels keep requiring an explicit queue: no default queue can guarantee a specific macOS or Xcode version. `macos-latest` floats on GHA too, so routing it to a floating queue is honest.
- The default queue joins the untrusted-queue allowlist the same way configured queues always have.
- Scope is `hostedOptions` only (`upload` and `validate --profile hosted`). Standalone `compile` and plain `validate` are unchanged, matching how PB-2910 scoped the Ubuntu image defaults.
- No runtime-distribution changes: the plugin acquisition path already fetches the Darwin runtime when a workflow resolves to darwin/arm64.

## Caveat

The failure mode for `macos-latest` shifts from a compile-time diagnostic to a job waiting on a queue with no agents when an org renamed `macos-medium` or has no macOS capacity (for example, after eval expiry). Documented in `docs/cli.md`; the queue-discovery API is the longer-term fix.

## Testing

- New `TestCompileHostedDefaultsMacOSLatestToHostedQueue`: unmapped `macos-latest` still requires the Darwin runtime distribution, compiles to `queue: "macos-medium"` when present, and an explicit mapping overrides the default.
- `mise run check` passes (format, build, test, race, lint, vet, local smoke, release check).
