### PR TITLE
Link workflow token errors to pipeline settings

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -493,9 +493,11 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 	var workflowTokens gharuntime.WorkflowTokenProvider
 	if job.HasCapability("provider-token-write") {
 		githubTokens, tokenErr := gharuntime.NewAgentGitHubTokens(gharuntime.AgentGitHubTokenConfig{
-			Endpoint: os.Getenv("BUILDKITE_AGENT_ENDPOINT"),
-			JobID:    os.Getenv("BUILDKITE_JOB_ID"),
-			JobToken: os.Getenv("BUILDKITE_AGENT_ACCESS_TOKEN"),
+			Endpoint:         os.Getenv("BUILDKITE_AGENT_ENDPOINT"),
+			JobID:            os.Getenv("BUILDKITE_JOB_ID"),
+			JobToken:         os.Getenv("BUILDKITE_AGENT_ACCESS_TOKEN"),
+			OrganizationSlug: os.Getenv("BUILDKITE_ORGANIZATION_SLUG"),
+			PipelineSlug:     os.Getenv("BUILDKITE_PIPELINE_SLUG"),
 		})
 		if tokenErr != nil {
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: configure GitHub token service: %v\n", tokenErr)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -7025,9 +7025,13 @@ func TestRunJobDisabledWorkflowTokenLinksPipelineSettings(t *testing.T) {
 	job.GitHubToken = &plan.GitHubToken{Permissions: map[string]string{"contents": "read"}}
 	planPath, planDigest := writeCLIJobPlan(t, job)
 	setCLIJobIdentity(t, job, planDigest)
+	truePath, err := exec.LookPath("true")
+	if err != nil {
+		t.Fatal(err)
+	}
 	t.Setenv("BUILDKITE_AGENT_ENDPOINT", server.URL)
 	t.Setenv("BUILDKITE_AGENT_ACCESS_TOKEN", "job-token")
-	t.Setenv("BUILDKITE_GHA_AGENT", "/bin/true")
+	t.Setenv("BUILDKITE_GHA_AGENT", truePath)
 	t.Setenv("BUILDKITE_ORGANIZATION_SLUG", "acme-inc")
 	t.Setenv("BUILDKITE_PIPELINE_SLUG", "my-pipeline")
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -7014,6 +7014,33 @@ func TestRunJobPublishesSummaryAsAdvisoryJobAnnotation(t *testing.T) {
 	}
 }
 
+func TestRunJobDisabledWorkflowTokenLinksPipelineSettings(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+
+	job := cliRunJobPlan()
+	job.Workflow.Path = ".github/workflows/ci.yml"
+	job.Event.Repository = "buildkite/buildkite-gha"
+	job.RequiredCapabilities = []string{"provider-token-write"}
+	job.GitHubToken = &plan.GitHubToken{Permissions: map[string]string{"contents": "read"}}
+	planPath, planDigest := writeCLIJobPlan(t, job)
+	setCLIJobIdentity(t, job, planDigest)
+	t.Setenv("BUILDKITE_AGENT_ENDPOINT", server.URL)
+	t.Setenv("BUILDKITE_AGENT_ACCESS_TOKEN", "job-token")
+	t.Setenv("BUILDKITE_GHA_AGENT", "/bin/true")
+	t.Setenv("BUILDKITE_ORGANIZATION_SLUG", "acme-inc")
+	t.Setenv("BUILDKITE_PIPELINE_SLUG", "my-pipeline")
+
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"run-job", "--plan", planPath}, &stdout, &stderr, "dev", &cliCaptureRunner{}); code != 1 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	want := `enable "Allow workflow-authorized GitHub access tokens" in the pipeline's repository settings: https://buildkite.com/acme-inc/my-pipeline/settings/repository`
+	if !strings.Contains(stderr.String(), want) {
+		t.Fatalf("stderr = %q, want %q", stderr.String(), want)
+	}
+}
+
 func TestRunJobPublishesWorkflowCommandsAsAdvisoryJobAnnotations(t *testing.T) {
 	diagnostics := "printf '%s\\n' '::warning title=Lint::warning body'; printf '%s\\n' '::error file=main.go,line=7::error body' >&2"
 	tests := []struct {

--- a/internal/runtime/github_token_service.go
+++ b/internal/runtime/github_token_service.go
@@ -20,6 +20,7 @@ const githubTokenResponseLimit = 64 << 10
 
 var githubInstallationTokenPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
 var retryAfterSecondsPattern = regexp.MustCompile(`^[0-9]{1,10}$`)
+var buildkiteSlugPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
 
 // WorkflowTokenProvider mints one repository-scoped credential with the exact
 // plan-declared permissions accepted by the Buildkite backend.
@@ -33,23 +34,26 @@ type ActionSourceTokenProvider interface {
 	ActionSourceToken(context.Context, string) (string, error)
 }
 
-// AgentGitHubTokenConfig carries the current Buildkite job's Agent connection
-// and authentication material. This client does not add it to Git or action
-// subprocess environments.
+// AgentGitHubTokenConfig carries the current Buildkite job's Agent connection,
+// authentication material, and immutable Buildkite pipeline slugs. This client
+// does not add them to Git or action subprocess environments.
 type AgentGitHubTokenConfig struct {
-	Endpoint string
-	JobID    string
-	JobToken string
-	Client   *http.Client
+	Endpoint         string
+	JobID            string
+	JobToken         string
+	OrganizationSlug string
+	PipelineSlug     string
+	Client           *http.Client
 }
 
 // AgentGitHubTokens mints repository-scoped tokens through Buildkite's
 // job-bound Agent API endpoint.
 type AgentGitHubTokens struct {
-	actionSourceURL string
-	workflowURL     string
-	jobToken        string
-	client          *http.Client
+	actionSourceURL    string
+	workflowURL        string
+	repositorySettings string
+	jobToken           string
+	client             *http.Client
 }
 
 func NewAgentGitHubTokens(config AgentGitHubTokenConfig) (*AgentGitHubTokens, error) {
@@ -74,7 +78,13 @@ func NewAgentGitHubTokens(config AgentGitHubTokenConfig) (*AgentGitHubTokens, er
 	if bounded.Timeout == 0 {
 		bounded.Timeout = 15 * time.Second
 	}
-	return &AgentGitHubTokens{actionSourceURL: actionSourceURL, workflowURL: workflowURL, jobToken: config.JobToken, client: &bounded}, nil
+	return &AgentGitHubTokens{
+		actionSourceURL:    actionSourceURL,
+		workflowURL:        workflowURL,
+		repositorySettings: pipelineRepositorySettingsURL(config.OrganizationSlug, config.PipelineSlug),
+		jobToken:           config.JobToken,
+		client:             &bounded,
+	}, nil
 }
 
 func (c *AgentGitHubTokens) WorkflowToken(ctx context.Context, repository, workflow string, permissions map[string]string) (string, error) {
@@ -130,7 +140,7 @@ func (c *AgentGitHubTokens) mint(ctx context.Context, mintURL, repository, workf
 	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
 		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, githubTokenResponseLimit))
-		return "", githubTokenStatusError(response.StatusCode, response.Header.Get("Retry-After"), purpose)
+		return "", githubTokenStatusError(response.StatusCode, response.Header.Get("Retry-After"), purpose, c.repositorySettings)
 	}
 	payload, err := io.ReadAll(io.LimitReader(response.Body, githubTokenResponseLimit+1))
 	if err != nil {
@@ -169,7 +179,14 @@ func agentGitHubTokenURL(endpoint, jobID, endpointName string) (string, error) {
 	return u.String(), nil
 }
 
-func githubTokenStatusError(status int, retryAfter, purpose string) error {
+func pipelineRepositorySettingsURL(organization, pipeline string) string {
+	if !buildkiteSlugPattern.MatchString(organization) || !buildkiteSlugPattern.MatchString(pipeline) {
+		return ""
+	}
+	return "https://buildkite.com/" + organization + "/" + pipeline + "/settings/repository"
+}
+
+func githubTokenStatusError(status int, retryAfter, purpose, repositorySettings string) error {
 	credential := "GitHub " + purpose + " token"
 	switch status {
 	case http.StatusBadRequest:
@@ -178,7 +195,11 @@ func githubTokenStatusError(status int, retryAfter, purpose string) error {
 		return fmt.Errorf("%s request was denied", credential)
 	case http.StatusNotFound:
 		if purpose == "workflow" {
-			return fmt.Errorf("GitHub workflow access tokens are not enabled for this organization or pipeline")
+			message := `GitHub workflow access tokens are not enabled for this organization or pipeline; enable "Allow workflow-authorized GitHub access tokens" in the pipeline's repository settings`
+			if repositorySettings != "" {
+				message += ": " + repositorySettings
+			}
+			return errors.New(message)
 		}
 		return fmt.Errorf("GitHub action source access tokens are not enabled for this organization")
 	case http.StatusServiceUnavailable:

--- a/internal/runtime/github_token_service_test.go
+++ b/internal/runtime/github_token_service_test.go
@@ -211,6 +211,58 @@ func TestAgentGitHubTokensRejectsRedirectsAndUntrustedResponses(t *testing.T) {
 	}
 }
 
+func TestAgentGitHubTokensDisabledWorkflowTokenGuidance(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+
+	for _, test := range []struct {
+		name         string
+		organization string
+		pipeline     string
+		want         string
+	}{
+		{
+			name:         "affected pipeline link",
+			organization: "acme-inc",
+			pipeline:     "my-pipeline",
+			want:         `GitHub workflow access tokens are not enabled for this organization or pipeline; enable "Allow workflow-authorized GitHub access tokens" in the pipeline's repository settings: https://buildkite.com/acme-inc/my-pipeline/settings/repository`,
+		},
+		{
+			name:         "unsafe organization",
+			organization: "acme/other",
+			pipeline:     "my-pipeline",
+			want:         `GitHub workflow access tokens are not enabled for this organization or pipeline; enable "Allow workflow-authorized GitHub access tokens" in the pipeline's repository settings`,
+		},
+		{
+			name:         "unsafe pipeline",
+			organization: "acme-inc",
+			pipeline:     "my-pipeline?token=secret",
+			want:         `GitHub workflow access tokens are not enabled for this organization or pipeline; enable "Allow workflow-authorized GitHub access tokens" in the pipeline's repository settings`,
+		},
+		{
+			name: "missing identity",
+			want: `GitHub workflow access tokens are not enabled for this organization or pipeline; enable "Allow workflow-authorized GitHub access tokens" in the pipeline's repository settings`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			provider, err := NewAgentGitHubTokens(AgentGitHubTokenConfig{
+				Endpoint:         server.URL,
+				JobID:            testCacheJobID,
+				JobToken:         "job-token",
+				OrganizationSlug: test.organization,
+				PipelineSlug:     test.pipeline,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = provider.WorkflowToken(context.Background(), "buildkite/buildkite-gha", "ci.yml", map[string]string{"contents": "read"})
+			if err == nil || err.Error() != test.want {
+				t.Fatalf("WorkflowToken() error = %q, want %q", err, test.want)
+			}
+		})
+	}
+}
+
 func TestAgentGitHubTokensHonorsCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()


### PR DESCRIPTION
## Why

A disabled workflow-token request currently says only that the organization or pipeline is not enabled. The organization rollout can already be active while the required per-pipeline repository setting remains off, leaving users without the actual fix.

## What

Tell users to enable **Allow workflow-authorized GitHub access tokens** and link directly to the affected pipeline's repository settings. The URL is included only when the immutable Buildkite organization and pipeline slugs are safe canonical values; otherwise the instruction remains without a link.

For example:

```text
buildkite-gha: run-job: GitHub workflow access tokens are not enabled for this organization or pipeline; enable "Allow workflow-authorized GitHub access tokens" in the pipeline's repository settings: https://buildkite.com/acme-inc/my-pipeline/settings/repository
```