### PR TITLE
Add Test Engine analytics for Go tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -80,7 +80,24 @@ steps:
           # previous build's checkout paths, which breaks nolint filtering
           # (golangci/golangci-lint#3502). Keep the cache local to this VM.
           export GOLANGCI_LINT_CACHE=/tmp/golangci-lint
-          mise run --jobs 1 check
+          mise run check:ci
+
+      - label: ":test_tube: Go tests %n/%t"
+        key: "go-tests"
+        if: build.env("DEMO_SUITE") != "plugin"
+        parallelism: 2
+        cache: ".buildkite/cache-volume"
+        plugins:
+          - setup-go#v0.1.0:
+              mise-version: "2026.5.12"
+          - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
+              version: "2026.5.12"
+          - tests#v1.0.0:
+              client-version: "3.0.0"
+              test-runner: "gotest"
+              test-cmd: "go test -count=1 -json {{packages}}"
+              result-path: "gotest-results.jsonl"
+        command: "bktec run"
 
       - label: ":go: macOS arm64 build and tests"
         key: "macos-arm64"

--- a/docs/development.md
+++ b/docs/development.md
@@ -50,7 +50,7 @@ The profile task uses the network to resolve selected public actions and apply t
 
 ## Verify runtime behavior
 
-Every normal Buildkite build runs repository checks, native macOS tests, the starter workflow compatibility report, and the shell smoke workflow against the build's exact CLI source. GitHub Actions differential oracles run only when manually dispatched.
+Every normal Buildkite build runs repository checks, Test Engine-split Go tests, native macOS tests, the starter workflow compatibility report, and the shell smoke workflow against the build's exact CLI source. Test Engine records the Linux test results; the repository checks retain the race-enabled suite. GitHub Actions differential oracles run only when manually dispatched.
 
 Run the complete hosted smoke suite for a pushed commit with:
 

--- a/internal/runtime/upload_artifact_test.go
+++ b/internal/runtime/upload_artifact_test.go
@@ -559,24 +559,43 @@ func TestUploadArtifactRejectsSymlinkComponentReplacementToSelectedInode(t *test
 	}
 }
 
-type cancellationArtifactUploader struct{}
+type cancellationArtifactUploader struct {
+	started chan<- struct{}
+}
 
 func (cancellationArtifactUploader) DownloadArtifact(context.Context, string, string, string) error {
 	return errors.New("unexpected artifact download")
 }
 
-func (cancellationArtifactUploader) UploadArtifactFrom(ctx context.Context, _, _ string) error {
+func (u cancellationArtifactUploader) UploadArtifactFrom(ctx context.Context, _, _ string) error {
+	close(u.started)
 	<-ctx.Done()
 	return ctx.Err()
 }
 
 func TestUploadArtifactCancellationStopsAgentUpload(t *testing.T) {
+	t.Parallel()
+
 	workspace := t.TempDir()
 	writeFixtureFile(t, workspace, "payload", "upload")
+	started := make(chan struct{})
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	r := Runner{Artifacts: cancellationArtifactUploader{}, artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
-	if _, err := r.runUploadArtifact(ctx, newCommandProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "payload"}); !errors.Is(err, context.DeadlineExceeded) {
+	r := Runner{Artifacts: cancellationArtifactUploader{started: started}, artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
+	done := make(chan error, 1)
+	go func() {
+		_, err := r.runUploadArtifact(ctx, newCommandProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "payload"})
+		done <- err
+	}()
+	select {
+	case <-started:
+		cancel()
+	case err := <-done:
+		t.Fatalf("upload returned before cancellation: %v", err)
+	case <-ctx.Done():
+		t.Fatal("agent upload did not start")
+	}
+	if err := <-done; !errors.Is(err, context.Canceled) {
 		t.Fatalf("agent upload cancellation = %v", err)
 	}
 	if len(r.artifactRegistry.names) != 0 {
@@ -585,6 +604,8 @@ func TestUploadArtifactCancellationStopsAgentUpload(t *testing.T) {
 }
 
 func TestUploadArtifactSourceBounds(t *testing.T) {
+	t.Parallel()
+
 	workspace := t.TempDir()
 	tooLarge := filepath.Join(workspace, "too-large")
 	file, err := os.Create(tooLarge)

--- a/mise.toml
+++ b/mise.toml
@@ -81,3 +81,7 @@ run = "./scripts/starter-workflows-corpus --profile"
 [tasks.check]
 description = "Run formatting, build, tests, lint, vet, and fixture checks"
 run = "mise run --jobs 1 format ::: build ::: build:darwin ::: test ::: test:race ::: lint ::: vet ::: smoke:local ::: release:check"
+
+[tasks."check:ci"]
+description = "Run CI checks not covered by the Test Engine step"
+run = "mise run --jobs 1 format ::: build ::: build:darwin ::: test:race ::: lint ::: vet ::: smoke:local ::: release:check"


### PR DESCRIPTION
## Why

The Go suite has no per-test analytics, and two packages dominate its runtime. A cancellation test also waits for a one-second deadline instead of synchronizing on the behavior it tests.

## What

- Run Linux Go tests through Buildkite Test Engine with two package-level partitions and JSONL result upload.
- Keep race tests in the repository checks without repeating the standard suite there.
- Make artifact cancellation deterministic and run isolated artifact boundary tests in parallel, reducing an uncached local suite from 28.9s to 15.3s.
