### PR TITLE
Make plugin import output concise and failure-first

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1498,6 +1498,7 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 		}
 	}
 	out := newProcessingOutput("upload", "text", stderr, stderr, agent)
+	out.plugin = uploadArguments.pluginAcquisition != nil
 	if uploadArguments.telemetry != nil {
 		out.observe = uploadArguments.telemetry.observe
 	}
@@ -1763,7 +1764,11 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 			if uploadArguments.telemetry != nil {
 				uploadArguments.telemetry.addReportDiagnostics(processingReports[i])
 			}
-			_ = compatibility.WriteProcessing(stdout, "text", processingReports[i])
+			if out.plugin {
+				_ = writePluginProcessing(stdout, processingReports[i])
+			} else {
+				_ = compatibility.WriteProcessing(stdout, "text", processingReports[i])
+			}
 			if !processingReportHasErrors(processingReports[i]) {
 				out.annotate(processingReports[i])
 			}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -632,6 +632,14 @@ func TestPluginUsesJSONConfigurationAndOnlyRequiredRuntime(t *testing.T) {
 	if !strings.Contains(stdout.String(), "Uploaded 3 jobs") {
 		t.Fatalf("stdout = %q", stdout.String())
 	}
+	if strings.Count(strings.TrimSpace(stdout.String()), "\n") != 0 {
+		t.Fatalf("plugin success output is not a one-line summary: %q", stdout.String())
+	}
+	for _, verbose := range []string{"Schema:", "- Workflow parsing:", "  job ", "  action "} {
+		if strings.Contains(stdout.String(), verbose) {
+			t.Fatalf("plugin success output contains verbose inventory %q: %q", verbose, stdout.String())
+		}
+	}
 	var pipeline struct {
 		Steps []struct {
 			Steps []struct {
@@ -651,6 +659,51 @@ func TestPluginUsesJSONConfigurationAndOnlyRequiredRuntime(t *testing.T) {
 		if step.Agents["queue"] != "hosted" || step.Image != defaultNobleRunnerImage || !strings.Contains(step.Command, "--hosted-tool-cache") || !strings.Contains(step.Command, "useradd --create-home") || !strings.Contains(step.Command, "sudo -n --preserve-env --user runner") {
 			t.Fatalf("plugin profile was not applied: %#v", step)
 		}
+	}
+}
+
+func TestPluginAdmissionFailurePrintsDiagnosticsBeforeSummaryAndAnnotatesDetails(t *testing.T) {
+	requireImporterHost(t)
+	repository := writeUploadWorkflowRepository(t, map[string]string{
+		"secret.yml": "name: Secret\non: push\njobs:\n  secret:\n    runs-on: ubuntu-latest\n    env:\n      TOKEN: ${{ secrets.TOKEN }}\n    steps: [{run: true}]\n",
+	})
+	t.Chdir(repository)
+	configuration, err := json.Marshal(map[string]any{"workflow": ".github/workflows/secret.yml"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(pluginConfigurationEnvironment, string(configuration))
+	setCLIPluginBuildkiteEnvironment(t, "plugin-admission-failure")
+	t.Setenv("BUILDKITE_JOB_ID", cliTestJobID)
+	t.Setenv("BUILDKITE_BUILD_CHECKOUT_PATH", repository)
+	runner := &cliCaptureRunner{}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"plugin"}, &stdout, &stderr, "dev", runner); code != 1 {
+		t.Fatalf("run() code = %d, want 1; stdout = %q; stderr = %q", code, stdout.String(), stderr.String())
+	}
+	output := stderr.String()
+	diagnostic := strings.Index(output, "x [E_PROFILE]")
+	summary := strings.Index(output, "Compilation: compilable. Admission: not-admitted.")
+	if !strings.HasPrefix(output, "^^^ +++\n") || diagnostic == -1 || summary <= diagnostic ||
+		!strings.Contains(output, "workflow=.github/workflows/secret.yml") ||
+		!strings.Contains(output, "stage=hosted-profile-admission") ||
+		!strings.Contains(output, "job=secret") {
+		t.Fatalf("plugin failure output = %q", output)
+	}
+	for _, verbose := range []string{"Schema:", "- Workflow parsing:", "  job secret:"} {
+		if strings.Contains(output, verbose) {
+			t.Fatalf("plugin failure output contains verbose inventory %q: %q", verbose, output)
+		}
+	}
+	var annotation *cliCommand
+	for i := range runner.commands {
+		if len(runner.commands[i].args) != 0 && runner.commands[i].args[0] == "annotate" {
+			annotation = &runner.commands[i]
+		}
+	}
+	if annotation == nil || !strings.Contains(string(annotation.stdin), "uses GitHub Actions secrets") ||
+		!strings.Contains(string(annotation.stdin), `href="https://github.com/buildkite/buildkite-gha/blob/0123456789abcdef0123456789abcdef01234567/.github/workflows/secret.yml#L`) {
+		t.Fatalf("admission failure annotation = %#v", annotation)
 	}
 }
 

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -34,6 +34,7 @@ type processingOutput struct {
 	format        string
 	reports       io.Writer
 	stderr        io.Writer
+	plugin        bool
 	observe       func(compatibility.ProcessingReport)
 	annotationJob string
 	buildURL      string
@@ -87,11 +88,64 @@ func (o processingOutput) write(report compatibility.ProcessingReport) error {
 	if o.observe != nil {
 		o.observe(report)
 	}
-	if err := compatibility.WriteProcessing(o.reports, o.format, report); err != nil {
+	var err error
+	if o.plugin {
+		err = writePluginProcessing(o.reports, report)
+	} else {
+		err = compatibility.WriteProcessing(o.reports, o.format, report)
+	}
+	if err != nil {
 		_, _ = fmt.Fprintf(o.stderr, "buildkite-gha: %s: write report: %v\n", o.command, err)
 		return err
 	}
 	o.annotate(report)
+	return nil
+}
+
+func writePluginProcessing(w io.Writer, report compatibility.ProcessingReport) error {
+	report.Finalize()
+	workflow, _ := processingAnnotationWorkflowPath(report.Workflow, "")
+	failed := processingReportHasErrors(report)
+	if failed {
+		if _, err := fmt.Fprintln(w, "^^^ +++"); err != nil {
+			return err
+		}
+	}
+	for _, level := range []string{"error", "warning"} {
+		for _, diagnostic := range report.Diagnostics {
+			if diagnostic.Level != level {
+				continue
+			}
+			marker := "!"
+			if level == "error" {
+				marker = "x"
+			}
+			metadata := []string{"workflow=" + workflow}
+			if diagnostic.Stage != "" {
+				metadata = append(metadata, "stage="+diagnostic.Stage)
+			}
+			if diagnostic.Job != "" {
+				metadata = append(metadata, "job="+diagnostic.Job)
+			}
+			if diagnostic.Action != "" {
+				metadata = append(metadata, "action="+diagnostic.Action)
+			}
+			if diagnostic.Step != 0 {
+				metadata = append(metadata, fmt.Sprintf("step=%d", diagnostic.Step))
+			}
+			location := ""
+			if diagnostic.Location != nil {
+				location = fmt.Sprintf(" (%s:%d:%d)", diagnostic.Location.Path, diagnostic.Location.Line, diagnostic.Location.Column)
+			}
+			if _, err := fmt.Fprintf(w, "%s [%s] %s%s {%s}\n", marker, diagnostic.Code, diagnostic.Message, location, strings.Join(metadata, ", ")); err != nil {
+				return err
+			}
+		}
+	}
+	if failed {
+		_, err := fmt.Fprintf(w, "Compilation: %s. Admission: %s.\n", report.Compile.Result, report.Admission.Result)
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Why

Plugin imports currently print the complete processing report, so passed stage, job, and action inventories bury the result and make admission failures harder to find. Public `validate` and direct `upload` output are stable contracts and should remain verbose.

## What

Use a plugin-only presentation boundary. Successful imports now keep the existing one-line result:

```text
Uploaded 3 jobs from 1 workflows using /path/to/buildkite-gha with importer plugin-linux.
```

Admission failures open the Buildkite log group and lead with the actionable diagnostic and its workflow, stage, and job context:

```text
^^^ +++
x [E_PROFILE] Job "secret" uses GitHub Actions secrets, which hosted runs do not provide. Pass values through supported Buildkite secret handling or remove the dependency. (./.github/workflows/secret.yml:4:3) {workflow=.github/workflows/secret.yml, stage=hosted-profile-admission, job=secret}
Compilation: compilable. Admission: not-admitted.
```

The existing job-scoped annotation continues to carry full diagnostic detail and source links. Public `validate --format text|json` and direct `upload` still use the stable verbose renderer.
