### PR TITLE
Automate safe Renovate dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,17 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "minimumReleaseAge": "3 days",
+  "automerge": true,
+  "automergeType": "pr",
+  "platformAutomerge": true,
+  "packageRules": [
+    {
+      "description": "Require manual review for major updates",
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    }
+  ],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
## Why

Routine dependency updates currently require manual handling even after required checks pass.

## What

Automatically merge non-major Renovate PRs after checks pass, while keeping major upgrades manual. Wait three days after a release before proposing it to reduce exposure to newly published regressions.
