### PR TITLE
Add native Buildkite secrets support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Run GitHub Actions workflows as native Buildkite jobs without creating a GitHub 
 `buildkite-gha` turns each supported workflow job and static matrix entry into a Buildkite job. Steps run in a compatibility runtime inside that job. Buildkite owns scheduling, logs, retries, cancellation, and the build UI.
 
 > [!IMPORTANT]
-> `buildkite-gha` is an experimental pre-1.0 preview. The released plugin path supports Linux x86-64 and native macOS arm64. The production path supports local and public actions and narrowly scoped, job-bound checkout, `GITHUB_TOKEN`, artifact, and cache integrations. Private actions, ordinary workflow secrets, and GitHub-compatible OIDC are unsupported.
+> `buildkite-gha` is an experimental pre-1.0 preview. The released plugin path supports Linux x86-64 and native macOS arm64. The production path supports local and public actions, static Buildkite job-accessible secrets, and narrowly scoped, job-bound checkout, `GITHUB_TOKEN`, artifact, and cache integrations. Private actions and GitHub-compatible OIDC are unsupported.
 
 ## How it works
 
@@ -88,7 +88,8 @@ The [compatibility reference](docs/compatibility.md) is the source of truth. Use
 | Linux x86-64 and native macOS arm64 jobs using `bash` or `sh` | Windows, Linux arm64, or macOS x86-64 |
 | Local and public JavaScript and composite actions; verified Dockerfile actions on Linux | Private actions, Dockerfile actions on macOS, or arbitrary reusable-workflow source |
 | Static matrices, `needs`, outputs, and local reusable workflows | Dynamic matrices and expressions outside the documented subset |
-| Exact-commit checkout, including managed private repository access | Ordinary workflow secrets, GitHub-compatible OIDC, or protected queues |
+| Exact-commit checkout, including managed private repository access | GitHub environment secrets, GitHub-compatible OIDC, or protected queues |
+| Static Buildkite job-accessible secrets | Dynamic or reusable-workflow secret forwarding |
 | Scoped `GITHUB_TOKEN` use allowed by Buildkite policy | Ambient or workflow-authored `github.token` use |
 | Audited artifact action versions and cache v6 integration | Other artifact and cache modes or general GitHub service emulation |
 | Background, wait, cancellation, and parallel step controls | Job and service containers through the production plugin path; all Docker use on macOS |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -32,13 +32,13 @@ Looking for something else? [Browse open compatibility issues](https://github.co
 | [Matrix strategies](#matrix-strategies) | 🟡 Supported subset | Static matrices, `include`, `exclude`, and literal `max-parallel`. Maximum 256 instances per job. `fail-fast` has no effect. |
 | [Shell steps](#commands-and-actions) | 🟡 Supported subset | Linux and macOS `bash` and `sh`. |
 | [Conditions and expressions](#expressions-and-contexts) | 🟡 Supported subset | Boolean and equality conditions and direct references to selected contexts. |
-| [Reusable workflows](#reusable-workflows) | 🟡 Supported subset | Local workflows with static inputs, `secrets: inherit`, and direct job-output mappings. |
+| [Reusable workflows](#reusable-workflows) | 🟡 Supported subset | Local workflows with static inputs and direct job-output mappings. Secret forwarding is unsupported. |
 | [Actions](#actions) | 🟡 Supported subset | Local and public JavaScript and composite actions on Linux and macOS; verified Dockerfile actions on Linux only. |
 | [Checkout, artifacts, and cache](#actions) | 🟡 Supported subset | Only the audited versions and modes listed below. |
 | [`GITHUB_TOKEN`](#github-token) | 🟡 Supported subset | One job-bound token for the event repository. Workflows containing reusable-workflow jobs cannot receive one. |
-| [Other workflow secrets](#other-secrets-and-oidc) | 🚧 Not available in production | Production upload rejects ordinary secret requirements. |
+| [Other workflow secrets](#other-secrets-and-oidc) | 🟡 Supported subset | Static names in direct jobs resolve through the destination job's Buildkite secret authority. |
 | [Job and service containers](#containers-and-services) | 🚧 Not available in production | A bounded container subset exists, but production upload rejects it. |
-| [Environments and snapshots](#job-configuration) | ➖ Accepted, no effect | No approvals, environment secrets, deployment state, or custom-image creation. |
+| [Environments and snapshots](#job-configuration) | 🟡 Supported subset | Environments are rejected. Snapshots are accepted with no effect. |
 | [OIDC](#other-secrets-and-oidc) | ❌ Unsupported | GitHub-compatible OIDC is outside the initial release. |
 | [Other platforms](#job-configuration) and [providers](#repositories) | ❌ Unsupported | Windows, Linux arm64, macOS x86-64, GitHub Enterprise Server, and unlisted providers are outside the initial release. |
 | [Other GitHub services](#github-services) | ❌ Unsupported | No general emulation for Releases, Packages, Checks, deployments, or GitHub artifact APIs. |
@@ -127,7 +127,6 @@ A top-level workflow that does not declare the effective event is excluded befor
 - Local `./.github/workflows/...` paths.
 - `boolean`, `number`, and `string` inputs.
 - Static input values and defaults.
-- `secrets: inherit` when the called workflow declares no required secrets. Nested workflows must inherit again at every call edge.
 - Nested calls up to four levels.
 - Caller-visible aggregate results.
 - Outputs mapped directly from `jobs.<job>.outputs.<name>`.
@@ -137,7 +136,7 @@ A top-level workflow that does not declare the effective event is excluded befor
 - Remote or dynamic workflow paths.
 - Call-level `if`.
 - Token requests from any direct or expanded job in a workflow containing a reusable-workflow call.
-- Explicit secret mappings or required called-workflow secrets.
+- `secrets: inherit`, explicit secret mappings, or required called-workflow secrets.
 - Dynamic inputs or matrices.
 - Literal or compound output expressions.
 - Top-level concurrency in the called workflow.
@@ -260,7 +259,7 @@ Cancel the whole Buildkite build rather than one job when a workflow-level concu
 | `env`, `defaults.run` | 🟡 Supported subset | Uses the [workflow-level behavior](#environment-and-defaults). |
 | `timeout-minutes` | 🟡 Supported subset | Accepts literal timeouts up to 360 minutes. Expressions are rejected. |
 | `continue-on-error` | 🟡 Supported subset | Accepts literal booleans. Expressions are rejected. A tolerated failure remains visible as a Buildkite soft failure and reports `success` through downstream `needs`. |
-| `environment` | ➖ Accepted, no effect | Creates no deployment record, approval, environment secret, or protection rule. |
+| `environment` | ❌ Unsupported | Environment approvals, secrets, deployment records, and protection rules are unavailable. |
 | `snapshot` | ➖ Accepted, no effect | Custom image creation is not implemented. |
 
 Job names can interpolate matrix values:
@@ -684,7 +683,11 @@ The token is not added to the initial job environment. The `github.token` value 
 
 ### Other secrets and OIDC
 
-**🚧 Not available in production.** The production profile rejects ordinary workflow secrets, although the compiler and runtime define an explicit boundary for them. Reusable workflow secret mappings and environment secrets are also unavailable. Action metadata defaults cannot add a secret to the plan; such defaults fail compilation rather than becoming an authority source. A secret referenced only by a declared optional action input does not add a job secret requirement and resolves to an empty value unless the same secret is required elsewhere. `GITHUB_TOKEN` continues to use its separate permission-scoped contract regardless of action input optionality.
+**🟡 Supported subset.** Direct jobs can use statically named `${{ secrets.NAME }}` references. The compiler records names only in job plans. At runtime, the destination job runs `buildkite-agent secret get NAME` with its existing authenticated Agent session and registers each value with both the Buildkite Agent redactor and the local workflow-command redactor before use. Missing or denied secrets fail the job without printing the value or Agent error output. Secret values do not appear in plans or generated pipeline YAML.
+
+These are Buildkite secrets available to the destination job, not GitHub repository, environment, event, or fork-scoped secrets. Buildkite Secret access policies are the authorization boundary. A workflow can access any named secret that its destination job's Buildkite identity and secret policy permit, just as arbitrary code in that job can run `buildkite-agent secret get`.
+
+`GITHUB_TOKEN` always uses the separate scoped workflow-token contract described above and cannot be replaced by an ordinary Buildkite secret. Dynamic names, secret use in conditions or other compile-time expressions, GitHub environments and environment secrets, `secrets: inherit`, and reusable-workflow secret forwarding are unsupported. Action metadata defaults cannot add a secret to the plan; such defaults fail compilation rather than becoming an authority source. A secret referenced only by a declared optional action input does not add a job secret requirement and resolves to an empty value unless the same secret is required elsewhere.
 
 **❌ Unsupported.** GitHub-compatible OIDC and `id-token` are not implemented.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -29,10 +29,12 @@ Digests and immutable action locks detect changed code. They do not make code tr
 | Repository checkout | The verified adapter checks the event repository and exact commit. Buildkite authorizes managed private access; credentials are command-scoped and not persisted. |
 | `GITHUB_TOKEN` | Supported static uses receive one short-lived token for the event repository and compiler-resolved permissions. Omitted workflow permissions mean exactly `contents: read`; GitHub repository and organization settings are not inherited. Buildkite verifies the pipeline repository, immutable commit, workflow policy, and build provenance. Pull requests are limited to `contents: read`; merge queues are denied. The token is not ambient. |
 | Cache token | When caching is configured, every JavaScript or Docker action lifecycle receives a fresh job-bound token. This includes compatible clients such as `actions/setup-go`, not only `actions/cache`. Shell steps do not receive it. |
-| Ordinary workflow secrets | Rejected by production admission. |
+| Ordinary workflow secrets | Static names are resolved with `buildkite-agent secret get` in the destination job. The job's Buildkite identity and Secret access policies are the sole authorization boundary. Values are registered with Agent and local redaction before use. |
 | GitHub-compatible OIDC | Unsupported. |
 
 An action that receives a credential can use or exfiltrate it. It can also export `GITHUB_TOKEN` to later steps through `GITHUB_ENV`. Log masking reduces accidental disclosure, but it is not access control and does not catch transformed values.
+
+Ordinary workflow secrets are Buildkite job-accessible secrets, not GitHub event or fork-scoped secrets. Workflow syntax adds no authority: arbitrary workflow code already runs with the destination job's identity and can call `buildkite-agent secret get`. Restrict that identity with Buildkite Secret access policies. Plans and generated pipeline YAML contain secret names only, never values. `GITHUB_TOKEN` remains on its separate workflow-token boundary.
 
 Workflow token issuance requires an organization feature and a default-off pipeline setting. Buildkite reads the top-level permission policy from the workflow at the build's immutable commit. Omitted permissions resolve to exactly `contents: read`; write permissions require an explicit top-level map. Explicit empty permissions, scopes resolving only to `none`, job-level permission maps, and reusable-workflow jobs cannot receive a token. It denies incomplete or cyclic trigger and rebuild provenance. Pull-request ancestry retains a `contents: read` ceiling, and merge-queue ancestry is denied.
 
@@ -62,4 +64,4 @@ Command scoping limits accidental spread. It does not stop a hostile concurrent 
       .github/workflows/ci.yml
     ```
 
-1. Keep unsupported secrets, private actions, OIDC, and protected queues out of imported workflows.
+1. Keep private actions, OIDC, and protected queues out of imported workflows.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -520,13 +520,19 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 		runnerToolCache = buildkitepipeline.HostedToolCachePath
 	}
 	runner := gharuntime.Runner{
-		Stdout:                stdout,
-		Stderr:                stderr,
-		MiseDataDir:           prepareMiseDataDir(os.Getenv("BUILDKITE_GHA_MISE_DATA_DIR"), stderr),
-		ToolCache:             runnerToolCache,
-		Docker:                os.Getenv("BUILDKITE_GHA_DOCKER"),
-		Git:                   os.Getenv("BUILDKITE_GHA_GIT"),
-		Secrets:               gharuntime.EnvironmentSecrets{},
+		Stdout:      stdout,
+		Stderr:      stderr,
+		MiseDataDir: prepareMiseDataDir(os.Getenv("BUILDKITE_GHA_MISE_DATA_DIR"), stderr),
+		ToolCache:   runnerToolCache,
+		Docker:      os.Getenv("BUILDKITE_GHA_DOCKER"),
+		Git:         os.Getenv("BUILDKITE_GHA_GIT"),
+		Secrets: gharuntime.AgentSecrets{
+			Executable: os.Getenv("BUILDKITE_GHA_AGENT"),
+			Endpoint:   os.Getenv("BUILDKITE_AGENT_ENDPOINT"),
+			JobID:      os.Getenv("BUILDKITE_JOB_ID"),
+			JobToken:   os.Getenv("BUILDKITE_AGENT_ACCESS_TOKEN"),
+			NoHTTP2:    os.Getenv("BUILDKITE_NO_HTTP2"),
+		},
 		Redactor:              gharuntime.AgentRedactor{Executable: os.Getenv("BUILDKITE_GHA_AGENT")},
 		Actions:               actionMaterializer,
 		Artifacts:             agent,
@@ -2398,6 +2404,9 @@ func validateUnprivilegedBundle(bundle compiler.Bundle) error {
 	}
 	for _, artifact := range bundle.Plans {
 		for _, capability := range artifact.Job.RequiredCapabilities {
+			if capability == "secrets" {
+				continue
+			}
 			if capability == "docker" && !slices.Equal(artifact.Authorization.DockerCapabilitySources, []string{"dockerfile-actions"}) {
 				if slices.Contains(artifact.Authorization.DockerCapabilitySources, "job-containers") || slices.Contains(artifact.Authorization.DockerCapabilitySources, "service-containers") {
 					message, detail := hostedContainerDiagnostic(artifact.Job)
@@ -2429,9 +2438,6 @@ func validateUnprivilegedBundle(bundle compiler.Bundle) error {
 			}
 			if capability != "network" && capability != "docker" {
 				message := fmt.Sprintf("Job %q requires unsupported hosted runtime capability %q. Remove the requirement or use a runtime profile that supports it.", artifact.Job.Workflow.LogicalJobID, capability)
-				if capability == "secrets" {
-					message = fmt.Sprintf("Job %q uses GitHub Actions secrets, which hosted runs do not provide. Pass values through supported Buildkite secret handling or remove the dependency.", artifact.Job.Workflow.LogicalJobID)
-				}
 				addFailure(artifact, message, "", errors.New(message))
 			}
 		}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -3205,21 +3205,21 @@ func TestValidateHostedProfileResolvesActionsWithoutClaimingRuntime(t *testing.T
 	}
 }
 
-func TestValidateHostedProfileRejectsProtectedCapabilityAfterCompile(t *testing.T) {
+func TestValidateHostedProfileAdmitsOrdinarySecretsAfterCompile(t *testing.T) {
 	workflowPath := filepath.Join(t.TempDir(), "secret.yml")
 	if err := os.WriteFile(workflowPath, []byte("on: push\njobs:\n  secret:\n    runs-on: ubuntu-latest\n    env:\n      TOKEN: ${{ secrets.TOKEN }}\n    steps:\n      - run: true\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
 	var stdout, stderr bytes.Buffer
-	if code := Run([]string{"validate", "--profile", "hosted-tokenless", "--format", "json", "--event-path", eventPath, workflowPath}, &stdout, &stderr, "dev"); code != 1 {
-		t.Fatalf("Run() code = %d, want 1; stderr = %q", code, stderr.String())
+	if code := Run([]string{"validate", "--profile", "hosted-tokenless", "--format", "json", "--event-path", eventPath, workflowPath}, &stdout, &stderr, "dev"); code != 0 {
+		t.Fatalf("Run() code = %d, want 0; stderr = %q", code, stderr.String())
 	}
 	var report compatibility.ProcessingReport
 	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 		t.Fatal(err)
 	}
-	if report.Result != "not-admitted" || report.Compile.Result != "compilable" || report.Admission.Result != "not-admitted" || len(report.Diagnostics) != 1 || report.Diagnostics[0].Code != "E_PROFILE" || !strings.Contains(report.Diagnostics[0].Message, "uses GitHub Actions secrets") {
+	if report.Result != "admitted" || report.Compile.Result != "compilable" || report.Admission.Result != "admitted" || len(report.Diagnostics) != 0 {
 		t.Fatalf("profile report = %#v", report)
 	}
 }
@@ -6384,7 +6384,6 @@ func TestUnprivilegedUploadRejectsCapabilities(t *testing.T) {
 		capability string
 		want       string
 	}{
-		{capability: "secrets", want: `Job "protected" uses GitHub Actions secrets, which hosted runs do not provide. Pass values through supported Buildkite secret handling or remove the dependency.`},
 		{capability: "privileged-container", want: `Job "protected" requires unsupported hosted runtime capability "privileged-container". Remove the requirement or use a runtime profile that supports it.`},
 		{capability: "future-capability", want: `Job "protected" requires unsupported hosted runtime capability "future-capability". Remove the requirement or use a runtime profile that supports it.`},
 	}
@@ -6399,6 +6398,17 @@ func TestUnprivilegedUploadRejectsCapabilities(t *testing.T) {
 		if err == nil || !errors.As(err, &finding) || finding.Message != test.want || finding.Detail != "" {
 			t.Fatalf("validateUnprivilegedBundle(%q) error = %v, want capability rejection", capability, err)
 		}
+	}
+}
+
+func TestUnprivilegedUploadAdmitsSecretsCapability(t *testing.T) {
+	bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: plan.Job{
+		Workflow:             plan.Workflow{LogicalJobID: "release"},
+		RequiredCapabilities: []string{"secrets"},
+		RequiredSecrets:      []string{"HOMEBREW_TAP_GITHUB_TOKEN"},
+	}}}}
+	if err := validateUnprivilegedBundle(bundle); err != nil {
+		t.Fatalf("validateUnprivilegedBundle() error = %v", err)
 	}
 }
 

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -819,6 +819,36 @@ jobs:
 	}
 }
 
+func TestCompileBundleKeepsReleaseTokensOnSeparateBoundaries(t *testing.T) {
+	source := []byte(`name: Release
+on: push
+permissions:
+  contents: write
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+    steps:
+      - run: goreleaser release
+`)
+	bundle, err := CompileBundle(".github/workflows/release.yml", source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	job := bundle.Plans[0].Job
+	if job.GitHubToken == nil || !reflect.DeepEqual(job.GitHubToken.Permissions, map[string]string{"contents": "write"}) {
+		t.Fatalf("GITHUB_TOKEN boundary = %#v", job.GitHubToken)
+	}
+	if !reflect.DeepEqual(job.RequiredSecrets, []string{"HOMEBREW_TAP_GITHUB_TOKEN"}) || !reflect.DeepEqual(job.RequiredCapabilities, []string{"provider-token-write", "secrets"}) {
+		t.Fatalf("ordinary secret boundary = names %#v capabilities %#v", job.RequiredSecrets, job.RequiredCapabilities)
+	}
+	if bytes.Contains(bundle.Pipeline, []byte("GITHUB_TOKEN")) || bytes.Contains(bundle.Pipeline, []byte("HOMEBREW_TAP_GITHUB_TOKEN")) {
+		t.Fatalf("generated pipeline contains secret names:\n%s", bundle.Pipeline)
+	}
+}
+
 func TestCompileBundleGitHubTokenUsesRestrictedDefaultPermissions(t *testing.T) {
 	source := []byte("on: push\njobs:\n  token:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo '${{ secrets.GITHUB_TOKEN }}'\n")
 	bundle, err := CompileBundle(".github/workflows/workflow.yml", source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-importer")

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -1568,7 +1568,7 @@ jobs:
 	}
 }
 
-func TestCompileFlattensInheritedReusableWorkflowSecrets(t *testing.T) {
+func TestCompileRejectsInheritedReusableWorkflowSecrets(t *testing.T) {
 	repository := t.TempDir()
 	path := writeWorkflow(t, repository, "caller.yml", `on: push
 jobs:
@@ -1585,12 +1585,9 @@ jobs:
         env:
           OPTIONAL_TOKEN: ${{ secrets.OPTIONAL_TOKEN }}
 `)
-	plans, err := compileUntrustedPlans(path, readFile(t, path), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), "gha-untrusted")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(plans) != 1 || !reflect.DeepEqual(plans[0].RequiredSecrets, []string{"OPTIONAL_TOKEN"}) || !plans[0].HasCapability("secrets") {
-		t.Fatalf("inherited reusable secrets = plans %#v", plans)
+	_, err := compileUntrustedPlans(path, readFile(t, path), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), "gha-untrusted")
+	if err == nil || !strings.Contains(err.Error(), "secrets: inherit is unsupported") {
+		t.Fatalf("Compile() error = %v", err)
 	}
 }
 
@@ -1616,53 +1613,6 @@ jobs:
 	}
 	if len(plans) != 1 || len(plans[0].RequiredSecrets) != 0 || plans[0].HasCapability("secrets") {
 		t.Fatalf("uninherited reusable secrets = plans %#v", plans)
-	}
-}
-
-func TestCompileRequiresSecretInheritanceAcrossEveryReusableEdge(t *testing.T) {
-	for _, test := range []struct {
-		name          string
-		rootInherit   bool
-		middleInherit bool
-		wantSecret    bool
-	}{
-		{name: "neither edge"},
-		{name: "root edge only", rootInherit: true},
-		{name: "middle edge only", middleInherit: true},
-		{name: "both edges", rootInherit: true, middleInherit: true, wantSecret: true},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			repository := t.TempDir()
-			rootSecrets := ""
-			if test.rootInherit {
-				rootSecrets = "    secrets: inherit\n"
-			}
-			middleSecrets := ""
-			if test.middleInherit {
-				middleSecrets = "    secrets: inherit\n"
-			}
-			path := writeWorkflow(t, repository, "caller.yml", "on: push\njobs:\n  call:\n    uses: ./.github/workflows/middle.yml\n"+rootSecrets)
-			writeWorkflow(t, repository, "middle.yml", "on: workflow_call\njobs:\n  call:\n    uses: ./.github/workflows/leaf.yml\n"+middleSecrets)
-			writeWorkflow(t, repository, "leaf.yml", `on: workflow_call
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "${{ secrets.NESTED_TOKEN }}"
-`)
-
-			plans, err := compileUntrustedPlans(path, readFile(t, path), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), "gha-untrusted")
-			if err != nil {
-				t.Fatal(err)
-			}
-			want := []string{}
-			if test.wantSecret {
-				want = []string{"NESTED_TOKEN"}
-			}
-			if len(plans) != 1 || !reflect.DeepEqual(plans[0].RequiredSecrets, want) || plans[0].HasCapability("secrets") != test.wantSecret {
-				t.Fatalf("nested reusable secrets = plans %#v, want %v", plans, want)
-			}
-		})
 	}
 }
 
@@ -1838,7 +1788,7 @@ jobs:
 `)
 	writeWorkflow(t, repository, "reusable.yml", "on: workflow_call\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n")
 	_, err := Compile(path, readFile(t, path), readFile(t, smokePath("events", "push.json")))
-	if err == nil || !strings.Contains(err.Error(), "reusable-workflow secrets are runtime-dependent and unsupported") {
+	if err == nil || !strings.Contains(err.Error(), "reusable-workflow secret forwarding is unsupported") {
 		t.Fatalf("Compile() error = %v, want explicit secret mapping rejection", err)
 	}
 }

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -223,8 +223,11 @@ func (resolver *reusableResolver) resolve(path, digest string, parsed *workflow.
 		}
 
 		call := job.Reusable
+		if call.InheritSecrets {
+			return reusableResolution{}, locatedJobError(path, job, call.Span.Start.Line, call.Span.Start.Column, "secrets: inherit is unsupported")
+		}
 		if call.Secrets {
-			return reusableResolution{}, locatedJobError(path, job, call.Span.Start.Line, call.Span.Start.Column, "reusable-workflow secrets are runtime-dependent and unsupported")
+			return reusableResolution{}, locatedJobError(path, job, call.Span.Start.Line, call.Span.Start.Column, "reusable-workflow secret forwarding is unsupported")
 		}
 		if depth >= maxReusableWorkflowDepth {
 			return reusableResolution{}, locatedJobError(path, job, call.Span.Start.Line, call.Span.Start.Column, fmt.Sprintf("reusable-workflow nesting exceeds maximum depth %d", maxReusableWorkflowDepth))

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -218,6 +219,26 @@ func TestRequiredSecretsRequireCapability(t *testing.T) {
 	job.RequiredSecrets = []string{"TOKEN"}
 	if err := job.Validate(); err == nil || !strings.Contains(err.Error(), "secrets capability") {
 		t.Fatalf("Validate() error = %v, want capability binding", err)
+	}
+}
+
+func TestRequiredSecretsRoundTripAsNamesOnly(t *testing.T) {
+	job := validJob()
+	job.RequiredCapabilities = []string{"secrets"}
+	job.RequiredSecrets = []string{"HOMEBREW_TAP_GITHUB_TOKEN"}
+	encoded, err := Encode(job)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(encoded), `"required_secrets"`) || !strings.Contains(string(encoded), `"HOMEBREW_TAP_GITHUB_TOKEN"`) || strings.Contains(string(encoded), "secret-value") {
+		t.Fatalf("Encode() = %s", encoded)
+	}
+	decoded, err := Decode(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(decoded.RequiredSecrets, job.RequiredSecrets) {
+		t.Fatalf("required secrets = %#v", decoded.RequiredSecrets)
 	}
 }
 

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -262,6 +262,17 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		return JobResult{}, fmt.Errorf("provider-token-write capability requires the GitHub workflow token provider")
 	}
 	providerTokenRequired := job.HasCapability("provider-token-write")
+	secretsRequired := job.HasCapability("secrets")
+	if secretsRequired {
+		if r.Secrets == nil {
+			return JobResult{}, fmt.Errorf("secrets capability requires the Buildkite Agent secret resolver")
+		}
+		resolved, err := resolveAgentSecretsBeforeWorkflow(r.Secrets)
+		if err != nil {
+			return JobResult{}, err
+		}
+		r.Secrets = resolved
+	}
 	cacheRequired := false
 	for _, lock := range job.Actions {
 		if usesCacheService(lock) {
@@ -269,10 +280,13 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 			break
 		}
 	}
-	if providerTokenRequired || r.Cache != nil {
+	if providerTokenRequired || secretsRequired || r.Cache != nil {
 		if r.Redactor == nil {
 			if providerTokenRequired {
 				return JobResult{}, fmt.Errorf("provider token capability requires the Buildkite Agent redactor")
+			}
+			if secretsRequired {
+				return JobResult{}, fmt.Errorf("secrets capability requires the Buildkite Agent redactor")
 			}
 			if cacheRequired {
 				return JobResult{}, fmt.Errorf("actions/cache requires the Buildkite Agent redactor")
@@ -281,7 +295,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		} else {
 			resolved, err := resolveAgentRedactorBeforeWorkflow(r.Redactor)
 			if err != nil {
-				if providerTokenRequired || cacheRequired {
+				if providerTokenRequired || secretsRequired || cacheRequired {
 					return JobResult{}, err
 				}
 				r.Cache = nil
@@ -888,10 +902,10 @@ func (r Runner) resolveSecrets(ctx context.Context, processor *commandProcessor,
 			return nil, fmt.Errorf("resolve secret %q: %w", name, err)
 		}
 		if value != "" {
-			if err := r.Redactor.AddRedaction(ctx, value); err != nil {
-				return nil, err
-			}
 			processor.addMask(value)
+			if err := r.Redactor.AddRedaction(ctx, value); err != nil {
+				return nil, processor.scrubError(err)
+			}
 		}
 		values[name] = value
 	}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -960,7 +960,17 @@ test "$BUILDKITE_AGENT_ENDPOINT" = https://agent.example/v3 || exit 14
 test "$BUILDKITE_AGENT_JOB_API_SOCKET" = /tmp/job-api.sock || exit 15
 test "$BUILDKITE_AGENT_JOB_API_TOKEN" = job-api-token || exit 16
 test "$BUILDKITE_NO_HTTP2" = true || exit 17
-test -z "${AMBIENT_SECRET+x}" || exit 18
+test "$HTTP_PROXY" = http://upper-http.example:8080 || exit 18
+test "$HTTPS_PROXY" = http://upper-https.example:8080 || exit 19
+test "$ALL_PROXY" = socks5://upper-all.example:1080 || exit 20
+test "$NO_PROXY" = upper-no-proxy.example || exit 21
+test "$http_proxy" = http://lower-http.example:8080 || exit 22
+test "$https_proxy" = http://lower-https.example:8080 || exit 23
+test "$all_proxy" = socks5://lower-all.example:1080 || exit 24
+test "$no_proxy" = lower-no-proxy.example || exit 25
+test "$SSL_CERT_FILE" = /etc/buildkite/ca.pem || exit 26
+test "$SSL_CERT_DIR" = /etc/buildkite/certs || exit 27
+test -z "${AMBIENT_SECRET+x}" || exit 28
 printf '%s\n' tap-secret
 `)
 	if err := os.Chmod(agent, 0o700); err != nil {
@@ -969,13 +979,30 @@ printf '%s\n' tap-secret
 	t.Setenv("BUILDKITE_AGENT_JOB_API_SOCKET", "/tmp/job-api.sock")
 	t.Setenv("BUILDKITE_AGENT_JOB_API_TOKEN", "job-api-token")
 	t.Setenv("AMBIENT_SECRET", "must-not-be-inherited")
-	value, err := (AgentSecrets{
+	transportEnvironment := map[string]string{
+		"HTTP_PROXY": "http://upper-http.example:8080", "HTTPS_PROXY": "http://upper-https.example:8080",
+		"ALL_PROXY": "socks5://upper-all.example:1080", "NO_PROXY": "upper-no-proxy.example",
+		"http_proxy": "http://lower-http.example:8080", "https_proxy": "http://lower-https.example:8080",
+		"all_proxy": "socks5://lower-all.example:1080", "no_proxy": "lower-no-proxy.example",
+		"SSL_CERT_FILE": "/etc/buildkite/ca.pem", "SSL_CERT_DIR": "/etc/buildkite/certs",
+	}
+	for name, value := range transportEnvironment {
+		t.Setenv(name, value)
+	}
+	resolved, err := resolveAgentSecretsBeforeWorkflow(AgentSecrets{
 		Executable: agent,
 		Endpoint:   "https://agent.example/v3",
 		JobID:      "job-id",
 		JobToken:   "job-token",
 		NoHTTP2:    "true",
-	}).ResolveSecret(context.Background(), "HOMEBREW_TAP_GITHUB_TOKEN")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name := range transportEnvironment {
+		t.Setenv(name, "http://workflow-controlled.example")
+	}
+	value, err := resolved.ResolveSecret(context.Background(), "HOMEBREW_TAP_GITHUB_TOKEN")
 	if err != nil || value != "tap-secret" {
 		t.Fatalf("ResolveSecret() = %q, %v", value, err)
 	}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -949,17 +949,47 @@ func TestCompiledBracketSecretResolvesAndMasks(t *testing.T) {
 	}
 }
 
-func TestEnvironmentSecretsCannotReadAmbientAgentVariables(t *testing.T) {
-	t.Setenv("BUILDKITE_AGENT_ACCESS_TOKEN", "ambient-token")
-	t.Setenv("BUILDKITE_GHA_SECRET_BUILDKITE_AGENT_ACCESS_TOKEN", "")
-	if _, err := (EnvironmentSecrets{}).ResolveSecret(context.Background(), "BUILDKITE_AGENT_ACCESS_TOKEN"); err != nil {
-		// The explicit namespace exists but is empty; this still proves the ambient
-		// variable was not selected.
-		return
+func TestAgentSecretsUsesOnlyJobBoundConfiguration(t *testing.T) {
+	agent := filepath.Join(t.TempDir(), "buildkite-agent")
+	writeFixtureFile(t, filepath.Dir(agent), filepath.Base(agent), `#!/bin/sh
+test "$#" -eq 3 || exit 10
+test "$1" = secret && test "$2" = get && test "$3" = HOMEBREW_TAP_GITHUB_TOKEN || exit 11
+test "$BUILDKITE_JOB_ID" = job-id || exit 12
+test "$BUILDKITE_AGENT_ACCESS_TOKEN" = job-token || exit 13
+test "$BUILDKITE_AGENT_ENDPOINT" = https://agent.example/v3 || exit 14
+test "$BUILDKITE_AGENT_JOB_API_SOCKET" = /tmp/job-api.sock || exit 15
+test "$BUILDKITE_AGENT_JOB_API_TOKEN" = job-api-token || exit 16
+test "$BUILDKITE_NO_HTTP2" = true || exit 17
+test -z "${AMBIENT_SECRET+x}" || exit 18
+printf '%s\n' tap-secret
+`)
+	if err := os.Chmod(agent, 0o700); err != nil {
+		t.Fatal(err)
 	}
-	value, _ := (EnvironmentSecrets{}).ResolveSecret(context.Background(), "BUILDKITE_AGENT_ACCESS_TOKEN")
-	if value == "ambient-token" {
-		t.Fatal("EnvironmentSecrets exposed the ambient Buildkite Agent token")
+	t.Setenv("BUILDKITE_AGENT_JOB_API_SOCKET", "/tmp/job-api.sock")
+	t.Setenv("BUILDKITE_AGENT_JOB_API_TOKEN", "job-api-token")
+	t.Setenv("AMBIENT_SECRET", "must-not-be-inherited")
+	value, err := (AgentSecrets{
+		Executable: agent,
+		Endpoint:   "https://agent.example/v3",
+		JobID:      "job-id",
+		JobToken:   "job-token",
+		NoHTTP2:    "true",
+	}).ResolveSecret(context.Background(), "HOMEBREW_TAP_GITHUB_TOKEN")
+	if err != nil || value != "tap-secret" {
+		t.Fatalf("ResolveSecret() = %q, %v", value, err)
+	}
+}
+
+func TestAgentSecretsDoesNotReturnCommandOutputOnFailure(t *testing.T) {
+	agent := filepath.Join(t.TempDir(), "buildkite-agent")
+	writeFixtureFile(t, filepath.Dir(agent), filepath.Base(agent), "#!/bin/sh\nprintf 'stdout-secret'\nprintf 'stderr-secret' >&2\nexit 1\n")
+	if err := os.Chmod(agent, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	_, err := (AgentSecrets{Executable: agent}).ResolveSecret(context.Background(), "DENIED")
+	if err == nil || strings.Contains(err.Error(), "stdout-secret") || strings.Contains(err.Error(), "stderr-secret") || !strings.Contains(err.Error(), "secret request failed") {
+		t.Fatalf("ResolveSecret() error = %v", err)
 	}
 }
 
@@ -2164,6 +2194,19 @@ func TestRunJobRejectsRegisteredSecretInOutput(t *testing.T) {
 	_, err := (Runner{Secrets: testSecretResolver{"CANARY": "do-not-publish"}, Redactor: &testRedactor{}}).RunJob(context.Background(), job, workspace)
 	if err == nil || !strings.Contains(err.Error(), "contains a registered secret") || strings.Contains(err.Error(), "do-not-publish") {
 		t.Fatalf("RunJob() error = %v, want non-disclosing secret-output rejection", err)
+	}
+}
+
+func TestRunJobScrubsSecretFromRedactorFailure(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "run", Kind: "run", Command: "true"}})
+	job.RequiredCapabilities = []string{"secrets"}
+	job.RequiredSecrets = []string{"CANARY"}
+	_, err := (Runner{Secrets: testSecretResolver{"CANARY": "do-not-leak"}, Redactor: failingTokenRedactor{token: "do-not-leak"}}).RunJob(context.Background(), job, workspace)
+	if err == nil || strings.Contains(err.Error(), "do-not-leak") || !strings.Contains(err.Error(), "***") {
+		t.Fatalf("RunJob() error = %v, want scrubbed redactor failure", err)
 	}
 }
 

--- a/internal/runtime/secrets.go
+++ b/internal/runtime/secrets.go
@@ -13,6 +13,8 @@ import (
 
 const maxSecretBytes = 64 << 10
 
+var agentTLSEnvironmentNames = [...]string{"SSL_CERT_FILE", "SSL_CERT_DIR"}
+
 // SecretResolver resolves only names declared by the verified job plan.
 type SecretResolver interface {
 	ResolveSecret(context.Context, string) (string, error)
@@ -26,11 +28,12 @@ type Redactor interface {
 // AgentSecrets resolves plan-declared secrets with the destination job's
 // authenticated Buildkite Agent session.
 type AgentSecrets struct {
-	Executable string
-	Endpoint   string
-	JobID      string
-	JobToken   string
-	NoHTTP2    string
+	Executable           string
+	Endpoint             string
+	JobID                string
+	JobToken             string
+	NoHTTP2              string
+	transportEnvironment map[string]string
 }
 
 func resolveAgentSecretsBeforeWorkflow(secrets SecretResolver) (SecretResolver, error) {
@@ -40,6 +43,17 @@ func resolveAgentSecretsBeforeWorkflow(secrets SecretResolver) (SecretResolver, 
 			return AgentSecrets{}, err
 		}
 		secrets.Executable = executable
+		secrets.transportEnvironment = make(map[string]string, len(agentProxyEnvironmentNames)+len(agentTLSEnvironmentNames))
+		for _, name := range agentProxyEnvironmentNames {
+			if value, ok := os.LookupEnv(name); ok {
+				secrets.transportEnvironment[name] = value
+			}
+		}
+		for _, name := range agentTLSEnvironmentNames {
+			if value, ok := os.LookupEnv(name); ok {
+				secrets.transportEnvironment[name] = value
+			}
+		}
 		return secrets, nil
 	}
 	switch secrets := secrets.(type) {
@@ -76,6 +90,16 @@ func (r AgentSecrets) ResolveSecret(ctx context.Context, name string) (string, e
 	}
 	if r.NoHTTP2 != "" {
 		command.Env = append(command.Env, "BUILDKITE_NO_HTTP2="+r.NoHTTP2)
+	}
+	for _, name := range agentProxyEnvironmentNames {
+		if value, ok := r.transportEnvironment[name]; ok {
+			command.Env = append(command.Env, name+"="+value)
+		}
+	}
+	for _, name := range agentTLSEnvironmentNames {
+		if value, ok := r.transportEnvironment[name]; ok {
+			command.Env = append(command.Env, name+"="+value)
+		}
 	}
 	var output boundedSecretBuffer
 	command.Stdout = &output

--- a/internal/runtime/secrets.go
+++ b/internal/runtime/secrets.go
@@ -1,12 +1,17 @@
 package runtime
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
 )
+
+const maxSecretBytes = 64 << 10
 
 // SecretResolver resolves only names declared by the verified job plan.
 type SecretResolver interface {
@@ -18,15 +23,90 @@ type Redactor interface {
 	AddRedaction(context.Context, string) error
 }
 
-// EnvironmentSecrets resolves plan-declared secrets from the job environment.
-type EnvironmentSecrets struct{}
+// AgentSecrets resolves plan-declared secrets with the destination job's
+// authenticated Buildkite Agent session.
+type AgentSecrets struct {
+	Executable string
+	Endpoint   string
+	JobID      string
+	JobToken   string
+	NoHTTP2    string
+}
 
-func (EnvironmentSecrets) ResolveSecret(_ context.Context, name string) (string, error) {
-	value, ok := os.LookupEnv("BUILDKITE_GHA_SECRET_" + name)
-	if !ok {
-		return "", fmt.Errorf("secret %q is unavailable", name)
+func resolveAgentSecretsBeforeWorkflow(secrets SecretResolver) (SecretResolver, error) {
+	resolve := func(secrets AgentSecrets) (AgentSecrets, error) {
+		executable, err := resolveHostExecutableBeforeWorkflow(secrets.Executable, "buildkite-agent", "Buildkite Agent secret resolver")
+		if err != nil {
+			return AgentSecrets{}, err
+		}
+		secrets.Executable = executable
+		return secrets, nil
 	}
-	return value, nil
+	switch secrets := secrets.(type) {
+	case AgentSecrets:
+		return resolve(secrets)
+	case *AgentSecrets:
+		if secrets == nil {
+			return nil, fmt.Errorf("buildkite Agent secret resolver is nil")
+		}
+		resolved, err := resolve(*secrets)
+		if err != nil {
+			return nil, err
+		}
+		return &resolved, nil
+	default:
+		return secrets, nil
+	}
+}
+
+func (r AgentSecrets) ResolveSecret(ctx context.Context, name string) (string, error) {
+	executable := r.Executable
+	if executable == "" {
+		executable = "buildkite-agent"
+	}
+	command := exec.CommandContext(ctx, executable, "secret", "get", name)
+	command.Env = []string{
+		"BUILDKITE_JOB_ID=" + r.JobID,
+		"BUILDKITE_AGENT_ACCESS_TOKEN=" + r.JobToken,
+		"BUILDKITE_AGENT_JOB_API_SOCKET=" + os.Getenv("BUILDKITE_AGENT_JOB_API_SOCKET"),
+		"BUILDKITE_AGENT_JOB_API_TOKEN=" + os.Getenv("BUILDKITE_AGENT_JOB_API_TOKEN"),
+	}
+	if r.Endpoint != "" {
+		command.Env = append(command.Env, "BUILDKITE_AGENT_ENDPOINT="+r.Endpoint)
+	}
+	if r.NoHTTP2 != "" {
+		command.Env = append(command.Env, "BUILDKITE_NO_HTTP2="+r.NoHTTP2)
+	}
+	var output boundedSecretBuffer
+	command.Stdout = &output
+	command.Stderr = io.Discard
+	if err := command.Run(); err != nil {
+		return "", errors.New("buildkite Agent secret request failed")
+	}
+	if output.exceeded {
+		return "", fmt.Errorf("buildkite Agent secret response exceeds %d bytes", maxSecretBytes)
+	}
+	return strings.TrimSuffix(output.String(), "\n"), nil
+}
+
+type boundedSecretBuffer struct {
+	bytes.Buffer
+	exceeded bool
+}
+
+func (b *boundedSecretBuffer) Write(p []byte) (int, error) {
+	original := len(p)
+	remaining := maxSecretBytes + 1 - b.Len()
+	if remaining <= 0 {
+		b.exceeded = true
+		return original, nil
+	}
+	if len(p) > remaining {
+		p = p[:remaining]
+	}
+	_, _ = b.Buffer.Write(p)
+	b.exceeded = b.Len() > maxSecretBytes
+	return original, nil
 }
 
 // AgentRedactor registers values with the Buildkite Agent redactor.

--- a/internal/workflow/parse.go
+++ b/internal/workflow/parse.go
@@ -387,6 +387,9 @@ func validateRawContainer(path string, node *yaml.Node) error {
 
 func adaptJob(path string, in *actionlint.Job, scalars map[Position]any, concurrency map[Position]stepConcurrency) (Job, error) {
 	out := Job{ID: in.ID.Value, Span: pointSpan(in.Pos)}
+	if in.Environment != nil {
+		return Job{}, locatedError(path, in.Environment.Pos, fmt.Sprintf("job %q", in.ID.Value), "GitHub environments and environment secrets are unsupported")
+	}
 	ownedConcurrency, err := adaptConcurrency(path, in.ID.Value, in.Concurrency)
 	if err != nil {
 		return Job{}, err

--- a/internal/workflow/parse_test.go
+++ b/internal/workflow/parse_test.go
@@ -56,6 +56,13 @@ func TestParsePreservesEnvironmentVariableCase(t *testing.T) {
 	}
 }
 
+func TestParseRejectsGitHubEnvironment(t *testing.T) {
+	_, err := Parse("environment.yml", []byte("on: push\njobs:\n  deploy:\n    environment: production\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"))
+	if err == nil || !strings.Contains(err.Error(), "GitHub environments and environment secrets are unsupported") {
+		t.Fatalf("Parse() error = %v", err)
+	}
+}
+
 func TestParseOwnsExplicitWorkflowAndJobPermissions(t *testing.T) {
 	source := []byte(`on: push
 permissions:


### PR DESCRIPTION
## Why

Workflows need syntax-compatible `${{ secrets.NAME }}` access without granting authority beyond the destination Buildkite job. In particular, release jobs need ordinary credentials such as `HOMEBREW_TAP_GITHUB_TOKEN` while keeping `GITHUB_TOKEN` on its existing scoped workflow-token path.

## What

Resolve statically declared secret names at runtime with the destination job's authenticated `buildkite-agent secret get` authority. Plans retain names only, generated pipeline YAML remains tokenless, and values are registered with Agent and local redaction before use.

This V0 supports direct jobs only. It rejects dynamic names, GitHub environments, `secrets: inherit`, and reusable-workflow secret forwarding. Buildkite Secret access policies remain the sole authorization boundary.
