### PR TITLE
Use latest GitHub Actions plugin and mise cache in examples

### DIFF
--- a/.buildkite/examples.yml
+++ b/.buildkite/examples.yml
@@ -67,7 +67,7 @@ steps:
               timeout_in_minutes: 20
               retry:
                 automatic: false
-              cache: "/cache/bkcache/github-actions-buildkite-plugin"
+              cache: "/cache/bkcache/mise"
               plugins:
                 - github-actions#v0.9.3:
                     workflow: "$$workflow"

--- a/.buildkite/examples.yml
+++ b/.buildkite/examples.yml
@@ -69,7 +69,7 @@ steps:
                 automatic: false
               cache: "/cache/bkcache/mise"
               plugins:
-                - github-actions#v0.9.3:
+                - github-actions#latest:
                     workflow: "$$workflow"
                     source-ref: "$$commit"
       YAML

--- a/.buildkite/upload-examples.sh
+++ b/.buildkite/upload-examples.sh
@@ -103,7 +103,7 @@ steps:
           automatic: false
         cache: "/cache/bkcache/mise"
         plugins:
-          - github-actions#v0.9.3:
+          - github-actions#latest:
               workflow: "$workflow"
               source-ref: "$commit"
 YAML

--- a/.buildkite/upload-examples.sh
+++ b/.buildkite/upload-examples.sh
@@ -101,7 +101,7 @@ steps:
         timeout_in_minutes: 20
         retry:
           automatic: false
-        cache: "/cache/bkcache/github-actions-buildkite-plugin"
+        cache: "/cache/bkcache/mise"
         plugins:
           - github-actions#v0.9.3:
               workflow: "$workflow"


### PR DESCRIPTION
## Why

The example GitHub Actions importer caches mise-managed runtimes, but its cache volume still uses the old plugin-specific path and its plugin selector is pinned to an older release.

## What

Use `/cache/bkcache/mise` and `github-actions#latest` for the importer in both the checked-in example pipeline and the dynamically generated pipeline.

Related: https://github.com/buildkite/buildkite/pull/32603 adds the same cache to steps generated during new-pipeline workflow detection.