### PR TITLE
Identify development telemetry versions and runtime failure phases

### DIFF
--- a/.buildkite/concurrent-steps-proof.yml
+++ b/.buildkite/concurrent-steps-proof.yml
@@ -13,7 +13,8 @@ steps:
       scripts/verify-source-checkout "$$commit"
       distribution_root="$$(mktemp -d "$${TMPDIR:-/tmp}/buildkite-gha-concurrent-steps.XXXXXXXX")"
       trap 'rm -rf -- "$$distribution_root"' EXIT
-      CGO_ENABLED=0 mise exec -- go build -trimpath -buildvcs=false -o "$$distribution_root/buildkite-gha" ./cmd/buildkite-gha
+      revision="$$(git rev-parse HEAD)"
+      CGO_ENABLED=0 mise exec -- go build -trimpath -buildvcs=false -ldflags "-X main.revision=$$revision" -o "$$distribution_root/buildkite-gha" ./cmd/buildkite-gha
       "$$distribution_root/buildkite-gha" upload \
         --event-path testdata/smoke/events/push.json \
         --runner-queue ubuntu-latest=hosted \

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -134,7 +134,9 @@ steps:
         plugins:
           - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
               version: "2026.5.12"
-        command: "mise exec -- go run ./cmd/buildkite-gha plugin"
+        command: |
+          revision="$$(git rev-parse HEAD)"
+          mise exec -- go run -ldflags "-X main.revision=$$revision" ./cmd/buildkite-gha plugin
 
   - wait: ~
 

--- a/.buildkite/shell-upload-proof.yml
+++ b/.buildkite/shell-upload-proof.yml
@@ -13,7 +13,8 @@ steps:
       scripts/verify-source-checkout "$$commit"
       distribution_root="$$(mktemp -d "$${TMPDIR:-/tmp}/buildkite-gha-shell-upload.XXXXXXXX")"
       trap 'rm -rf -- "$$distribution_root"' EXIT
-      CGO_ENABLED=0 mise exec -- go build -trimpath -buildvcs=false -o "$$distribution_root/buildkite-gha" ./cmd/buildkite-gha
+      revision="$$(git rev-parse HEAD)"
+      CGO_ENABLED=0 mise exec -- go build -trimpath -buildvcs=false -ldflags "-X main.revision=$$revision" -o "$$distribution_root/buildkite-gha" ./cmd/buildkite-gha
       "$$distribution_root/buildkite-gha" upload \
         --event-path testdata/smoke/events/push.json \
         --runner-queue ubuntu-latest=hosted \

--- a/cmd/buildkite-gha/main.go
+++ b/cmd/buildkite-gha/main.go
@@ -2,12 +2,43 @@ package main
 
 import (
 	"os"
+	"runtime/debug"
 
 	"github.com/buildkite/buildkite-gha/internal/cli"
 )
 
 var version = "dev"
+var revision string
 
 func main() {
-	os.Exit(cli.Run(os.Args[1:], os.Stdout, os.Stderr, version))
+	os.Exit(cli.Run(os.Args[1:], os.Stdout, os.Stderr, resolvedVersion()))
+}
+
+func resolvedVersion() string {
+	if version != "dev" {
+		return version
+	}
+	if revision == "" {
+		if info, ok := debug.ReadBuildInfo(); ok {
+			for _, setting := range info.Settings {
+				if setting.Key == "vcs.revision" {
+					revision = setting.Value
+					break
+				}
+			}
+		}
+	}
+	return developmentVersion(version, revision)
+}
+
+func developmentVersion(base, commit string) string {
+	if base != "dev" || len(commit) < 12 {
+		return base
+	}
+	for _, character := range commit {
+		if (character < '0' || character > '9') && (character < 'a' || character > 'f') {
+			return base
+		}
+	}
+	return base + "+" + commit[:12]
 }

--- a/cmd/buildkite-gha/main_test.go
+++ b/cmd/buildkite-gha/main_test.go
@@ -1,0 +1,23 @@
+package main
+
+import "testing"
+
+func TestDevelopmentVersionIncludesRevision(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		version  string
+		revision string
+		want     string
+	}{
+		{name: "release", version: "0.13.11", revision: "0123456789abcdef0123456789abcdef01234567", want: "0.13.11"},
+		{name: "development revision", version: "dev", revision: "0123456789abcdef0123456789abcdef01234567", want: "dev+0123456789ab"},
+		{name: "missing revision", version: "dev", want: "dev"},
+		{name: "invalid revision", version: "dev", revision: "not-a-commit", want: "dev"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := developmentVersion(test.version, test.revision); got != test.want {
+				t.Fatalf("developmentVersion() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -118,7 +118,7 @@ func Run(args []string, stdout, stderr io.Writer, version string) int {
 	return run(args, stdout, stderr, version, transport.CommandRunner{Stderr: stderr})
 }
 
-func run(args []string, stdout, stderr io.Writer, version string, agentRunner transport.Runner) int {
+func run(args []string, stdout, stderr io.Writer, clientVersion string, agentRunner transport.Runner) int {
 	if len(args) == 0 {
 		_, _ = fmt.Fprint(stderr, usage)
 		return 2
@@ -126,6 +126,7 @@ func run(args []string, stdout, stderr io.Writer, version string, agentRunner tr
 	if args[0] == gharuntime.ContainerProcessHelperCommand {
 		return gharuntime.RunContainerProcessHelper(args[1:])
 	}
+	version := commandVersion(clientVersion)
 
 	switch args[0] {
 	case "-h", "--help":
@@ -137,10 +138,10 @@ func run(args []string, stdout, stderr io.Writer, version string, agentRunner tr
 		if len(args) != 1 {
 			return usageError(stderr, "%s does not accept arguments", args[0])
 		}
-		_, _ = fmt.Fprintf(stdout, "buildkite-gha %s\n", version)
+		_, _ = fmt.Fprintf(stdout, "buildkite-gha %s\n", clientVersion)
 		return 0
 	case "plugin":
-		return plugin(args[1:], stdout, stderr, version, agentRunner)
+		return plugin(args[1:], stdout, stderr, version, clientVersion, agentRunner)
 	default:
 		if _, ok := commandUsage[args[0]]; ok {
 			if len(args) == 2 && (args[1] == "-h" || args[1] == "--help") {
@@ -155,7 +156,7 @@ func run(args []string, stdout, stderr io.Writer, version string, agentRunner tr
 			case "upload":
 				return upload(args[1:], stdout, stderr, version, transport.Agent{Runner: agentRunner})
 			case "run-job":
-				return runJob(args[1:], stdout, stderr, version, transport.Agent{Runner: agentRunner})
+				return runJob(args[1:], stdout, stderr, version, clientVersion, transport.Agent{Runner: agentRunner})
 			default:
 				_, _ = fmt.Fprintf(stderr, "buildkite-gha: %s: not implemented\n", args[0])
 				return 1
@@ -166,18 +167,25 @@ func run(args []string, stdout, stderr io.Writer, version string, agentRunner tr
 	}
 }
 
-func plugin(args []string, stdout, stderr io.Writer, version string, runner transport.Runner) int {
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
-	return pluginContext(ctx, args, stdout, stderr, version, runner)
+func commandVersion(clientVersion string) string {
+	if clientVersion == "dev" || strings.HasPrefix(clientVersion, "dev+") {
+		return "dev"
+	}
+	return clientVersion
 }
 
-func pluginContext(ctx context.Context, args []string, stdout, stderr io.Writer, version string, runner transport.Runner) (code int) {
+func plugin(args []string, stdout, stderr io.Writer, version, clientVersion string, runner transport.Runner) int {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	return pluginContext(ctx, args, stdout, stderr, version, clientVersion, runner)
+}
+
+func pluginContext(ctx context.Context, args []string, stdout, stderr io.Writer, version, clientVersion string, runner transport.Runner) (code int) {
 	started := time.Now()
 	details := &commandTelemetryDetails{}
 	defer func() {
 		outcome := telemetryOutcome(code, "", ctx.Err())
-		emitCommandTelemetry(telemetry.CommandPluginImport, outcome, version, time.Since(started), details.forOutcome(outcome))
+		emitCommandTelemetry(telemetry.CommandPluginImport, outcome, clientVersion, time.Since(started), details.forOutcome(outcome))
 	}()
 	if len(args) != 0 {
 		return usageError(stderr, "plugin does not accept arguments")
@@ -367,19 +375,19 @@ func help(args []string, stdout, stderr io.Writer) int {
 	return 0
 }
 
-func runJob(args []string, stdout, stderr io.Writer, version string, agent transport.Agent) int {
+func runJob(args []string, stdout, stderr io.Writer, version, clientVersion string, agent transport.Agent) int {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
-	return runJobContext(ctx, args, stdout, stderr, version, agent)
+	return runJobContext(ctx, args, stdout, stderr, version, clientVersion, agent)
 }
 
-func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer, version string, agent transport.Agent) (code int) {
+func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer, version, clientVersion string, agent transport.Agent) (code int) {
 	started := time.Now()
 	var result gharuntime.JobResult
+	details := &commandTelemetryDetails{}
 	defer func() {
 		outcome := telemetryOutcome(code, result.Conclusion, ctx.Err())
-		details := (&commandTelemetryDetails{}).forOutcome(outcome)
-		emitCommandTelemetry(telemetry.CommandRunJob, outcome, version, time.Since(started), details)
+		emitCommandTelemetry(telemetry.CommandRunJob, outcome, clientVersion, time.Since(started), details.forOutcome(outcome))
 	}()
 	options, err := runJobArgs(args)
 	if err != nil {
@@ -563,17 +571,22 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 	if len(job.NeedSources) != 0 {
 		job.Needs, runErr = gharuntime.ResolveNeeds(ctx, agent, artifactRoot, producer.BuildID, job.NeedSources, job.NeedOutputs)
 		if runErr != nil {
+			details.setFailurePhase(telemetry.FailurePhaseSourceResolution)
 			runErr = fmt.Errorf("hydrate prerequisite results: %w", runErr)
 		}
 	}
 	if runErr == nil {
 		result, runErr = runner.RunJob(ctx, job, "")
+		if runErr != nil {
+			details.setFailurePhase(telemetry.FailurePhaseExecution)
+		}
 	}
 	if result.Conclusion == "" {
 		result.Conclusion = terminalErrorConclusion(ctx)
 	}
 	if options.resultPath != "" && result.Conclusion != "" {
 		if err := writeJobResult(options.resultPath, result); err != nil {
+			details.setFailurePhase(telemetry.FailurePhaseResultPublication)
 			runErr = errors.Join(runErr, err)
 			result.Conclusion = terminalErrorConclusion(ctx)
 		}
@@ -593,6 +606,7 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: warning: workflow error annotation: %v\n", publication.ErrorAnnotationError)
 		}
 		if err != nil {
+			details.setFailurePhase(telemetry.FailurePhaseResultPublication)
 			runErr = errors.Join(runErr, fmt.Errorf("publish terminal result: %w", err))
 		}
 	}
@@ -1810,6 +1824,9 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 	}
 	if len(artifacts) == 0 {
 		if err := agent.UploadPipeline(ctx, aggregatePipeline); err != nil {
+			if uploadArguments.telemetry != nil {
+				uploadArguments.telemetry.setFailurePhase(telemetry.FailurePhasePipelineUpload)
+			}
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: upload pipeline: %v\n", err)
 			return 1
 		}
@@ -1825,6 +1842,13 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 	defer func() { _ = os.RemoveAll(root) }()
 
 	if err := transport.UploadArtifacts(ctx, agent, root, artifacts, aggregatePipeline); err != nil {
+		if uploadArguments.telemetry != nil {
+			phase := telemetry.FailurePhaseArtifactUpload
+			if errors.Is(err, transport.ErrPipelineUpload) {
+				phase = telemetry.FailurePhasePipelineUpload
+			}
+			uploadArguments.telemetry.setFailurePhase(phase)
+		}
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
 		return 1
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -230,6 +230,12 @@ func TestCommandCompletionTelemetryFailureDoesNotChangeExit(t *testing.T) {
 	}
 }
 
+func TestRevisionedDevelopmentVersionKeepsPlanCompatibilityVersion(t *testing.T) {
+	if got := commandVersion("dev+0123456789ab"); got != "dev" {
+		t.Fatalf("commandVersion() = %q, want dev", got)
+	}
+}
+
 func TestCommandTelemetryDetailsCollectTypedDiagnostics(t *testing.T) {
 	details := &commandTelemetryDetails{}
 	details.observe(compatibility.ProcessingReport{Diagnostics: []compatibility.Diagnostic{
@@ -295,6 +301,16 @@ func TestHandledReportErrorsDoNotAttributeCommandFailure(t *testing.T) {
 	want := []telemetry.Diagnostic{{Code: compiler.CodeExpressionInvalid, Severity: telemetry.SeverityError}}
 	if !reflect.DeepEqual(got.Diagnostics, want) {
 		t.Fatalf("diagnostics = %#v, want %#v", got.Diagnostics, want)
+	}
+}
+
+func TestCommandTelemetryDetailsPreservesFirstFailurePhase(t *testing.T) {
+	details := &commandTelemetryDetails{}
+	details.setFailurePhase(telemetry.FailurePhaseExecution)
+	details.setFailurePhase(telemetry.FailurePhaseResultPublication)
+	got := details.forOutcome(telemetry.OutcomeFailure)
+	if got.FailurePhase != telemetry.FailurePhaseExecution || got.FailureCode != telemetry.FailureCodeUnknown {
+		t.Fatalf("failure details = %#v", got)
 	}
 }
 
@@ -7192,7 +7208,7 @@ func TestRunJobPublishesEveryTerminalResultAfterCancellation(t *testing.T) {
 				ctx = cancelled
 			}
 			var stdout, stderr bytes.Buffer
-			if code := runJobContext(ctx, []string{"--plan", planPath}, &stdout, &stderr, "dev", transport.Agent{Runner: runner}); code != test.wantCode {
+			if code := runJobContext(ctx, []string{"--plan", planPath}, &stdout, &stderr, "dev", "dev", transport.Agent{Runner: runner}); code != test.wantCode {
 				t.Fatalf("runJobContext() code = %d, stderr = %q, want %d", code, stderr.String(), test.wantCode)
 			}
 			manifest := publishedCLIManifest(t, runner, job, planDigest)
@@ -7324,10 +7340,29 @@ func TestRunJobFailsWhenAuthoritativePublicationFails(t *testing.T) {
 	job := cliRunJobPlan()
 	planPath, planDigest := writeCLIJobPlan(t, job)
 	setCLIJobIdentity(t, job, planDigest)
+	events := captureCommandTelemetry(t)
 	runner := &cliCaptureRunner{failAt: 1}
 	var stdout, stderr bytes.Buffer
 	if code := run([]string{"run-job", "--plan", planPath}, &stdout, &stderr, "dev", runner); code != 1 || !strings.Contains(stderr.String(), "publish terminal result") {
 		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	if event := <-events; event.FailurePhase != telemetry.FailurePhaseResultPublication || event.FailureCode != telemetry.FailureCodeUnknown {
+		t.Fatalf("telemetry = %#v", event)
+	}
+}
+
+func TestRunJobTelemetryClassifiesExecutionFailure(t *testing.T) {
+	job := cliRunJobPlan()
+	job.Steps[0].Command = "exit 7"
+	planPath, planDigest := writeCLIJobPlan(t, job)
+	setCLIJobIdentity(t, job, planDigest)
+	events := captureCommandTelemetry(t)
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"run-job", "--plan", planPath}, &stdout, &stderr, "dev", &cliCaptureRunner{}); code != 1 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	if event := <-events; event.FailurePhase != telemetry.FailurePhaseExecution || event.FailureCode != telemetry.FailureCodeUnknown {
+		t.Fatalf("telemetry = %#v", event)
 	}
 }
 
@@ -7676,6 +7711,26 @@ func setCLIJobIdentity(t *testing.T, job plan.Job, planDigest string) {
 	t.Setenv("BUILDKITE_STEP_KEY", job.Target.StepKey)
 	t.Setenv("BUILDKITE_AGENT_META_DATA_QUEUE", job.Target.Queue)
 	t.Setenv("BUILDKITE_GHA_PLAN_DIGEST", planDigest)
+}
+
+func captureCommandTelemetry(t *testing.T) <-chan telemetry.Properties {
+	t.Helper()
+	events := make(chan telemetry.Properties, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var received struct {
+			Properties telemetry.Properties `json:"properties"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&received); err != nil {
+			t.Errorf("decode telemetry event: %v", err)
+		}
+		events <- received.Properties
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv("BUILDKITE_AGENT_ENDPOINT", server.URL)
+	t.Setenv("BUILDKITE_AGENT_ACCESS_TOKEN", "telemetry-token")
+	t.Setenv("BUILDKITE_GHA_TELEMETRY_DISABLED", "")
+	return events
 }
 
 func clearCLIJobIdentity(t *testing.T) {

--- a/internal/cli/telemetry.go
+++ b/internal/cli/telemetry.go
@@ -17,6 +17,12 @@ type commandTelemetryDetails struct {
 	seen         map[string]int
 }
 
+func (d *commandTelemetryDetails) setFailurePhase(phase telemetry.FailurePhase) {
+	if d.failurePhase == "" {
+		d.failurePhase = phase
+	}
+}
+
 // addReportDiagnostics records a report's diagnostics. Errors a command
 // handles, such as workflows emitted as failing pipeline steps, belong here so
 // they never attribute an unrelated later failure.

--- a/internal/transport/boundary.go
+++ b/internal/transport/boundary.go
@@ -198,6 +198,10 @@ type Artifact struct {
 	Contents []byte
 }
 
+// ErrPipelineUpload identifies the pipeline-upload stage while preserving the
+// underlying agent error.
+var ErrPipelineUpload = errors.New("upload pipeline")
+
 // UploadArtifacts materializes and verifies every artifact before uploading
 // them from one root, then uploads the pipeline only after all artifacts pass.
 func UploadArtifacts(ctx context.Context, agent Agent, root string, artifacts []Artifact, pipeline []byte) error {
@@ -249,7 +253,7 @@ func UploadArtifacts(ctx context.Context, agent Agent, root string, artifacts []
 		}
 	}
 	if err := agent.UploadPipeline(ctx, pipeline); err != nil {
-		return fmt.Errorf("upload pipeline: %w", err)
+		return fmt.Errorf("%w: %w", ErrPipelineUpload, err)
 	}
 	return nil
 }

--- a/internal/transport/model_test.go
+++ b/internal/transport/model_test.go
@@ -314,6 +314,15 @@ func TestUploadArtifactsFailsBeforePipeline(t *testing.T) {
 	}
 }
 
+func TestUploadArtifactsIdentifiesPipelineFailure(t *testing.T) {
+	artifact := Artifact{Path: ".buildkite-gha/plans/plan.json", Contents: []byte("plan")}
+	artifact.Digest = Digest(artifact.Contents)
+	err := UploadArtifacts(context.Background(), Agent{Runner: &captureRunner{failAt: 2}}, t.TempDir(), []Artifact{artifact}, []byte("steps: []\n"))
+	if !errors.Is(err, ErrPipelineUpload) || !strings.Contains(err.Error(), "upload pipeline") {
+		t.Fatalf("UploadArtifacts() error = %v", err)
+	}
+}
+
 func TestCommandRunnerBoundsOutputWhileReading(t *testing.T) {
 	stdout, _, err := (CommandRunner{}).RunBounded(context.Background(), "", "sh", []string{"-c", "printf 123456789"}, nil, 8)
 	if err == nil || !strings.Contains(err.Error(), "exceeds 8 bytes") || len(stdout) != 0 {


### PR DESCRIPTION
## Why

Production telemetry is not actionable enough: 786 of 837 observed completion events report `client_version=dev`, and every observed command failure reports `failure_phase=unknown`. This prevents us from tying behavior to a development revision or identifying which runtime boundary failed.

Related to [PB-2631](https://linear.app/buildkite/issue/PB-2631/set-the-telemetry-baseline-and-dashboard) and the [telemetry dashboard](https://us.posthog.com/project/306063/dashboard/1997981). The job-scoped endpoint is already implemented and deployed by [buildkite/buildkite#32457](https://github.com/buildkite/buildkite/pull/32457) ([design thread](https://ampcode.com/threads/T-019ff905-9c5a-75ae-bee7-6b42b145b4d5), [implementation thread](https://ampcode.com/threads/T-019ff917-4597-708d-8eb5-acd78897b855), commits `14d1543a` and `8333c79e`).

## What

- Report development clients as bounded `dev+<12-character buildkite-gha revision>` values while keeping release versions unchanged.
- Keep the internal compiler/runtime compatibility version as `dev`, so revision metadata does not alter runtime acquisition or plan compatibility.
- Attribute failures to the existing `source_resolution`, `execution`, `artifact_upload`, `pipeline_upload`, and `result_publication` phases where the lifecycle boundary is known. `failure_code` remains `unknown` unless an existing typed diagnostic supplies one.
- Inject the source revision into CI proof binaries that intentionally disable Go VCS metadata.

This does not change the Rails allowlist or event shape. The client still emits one best-effort `pipelines:buildkite_gha:command_completed` event, and telemetry failures do not change command exit semantics. No workflow content, paths, repository details, rendered diagnostics, environment values, command text, or other customer data is added; the only new value is a bounded revision of the buildkite-gha client itself.

`mise run check` passes, including build, unit and race tests, vet, Go and shell lint, local smoke coverage, and release configuration validation.
