### PR TITLE
Support contains and endsWith in compile-time expressions

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -225,7 +225,7 @@ defaults:
 
 ### Concurrency
 
-**🟡 Supported subset with different queue behavior.** A static group becomes a repository-scoped, case-insensitive Buildkite concurrency group. Groups may use `vars`, supported `github` fields, static reusable-workflow inputs, and concrete matrix values at job level. Boolean and equality operators, `fromJSON`, and case-insensitive `startsWith` are supported when the whole expression resolves during compilation. Runtime `needs` and `strategy` values remain unsupported.
+**🟡 Supported subset with different queue behavior.** A static group becomes a repository-scoped, case-insensitive Buildkite concurrency group. Groups may use `vars`, supported `github` fields, static reusable-workflow inputs, and concrete matrix values at job level. Boolean and equality operators, `fromJSON`, and the case-insensitive string functions `startsWith`, `contains`, and `endsWith` are supported when the whole expression resolves during compilation. Runtime `needs` and `strategy` values remain unsupported.
 
 A workflow can set a group and cancellation expression while a job uses a matrix-derived group:
 
@@ -455,7 +455,7 @@ Three expression modes intentionally support different syntax.
 | --- | --- | --- | --- |
 | `!`, `&&`, `\|\|`, `==`, `!=` | ✅ Supported | ❌ Unsupported | 🟡 When the result resolves fully |
 | `always()`, `success()`, `failure()`, `cancelled()` | ✅ Without arguments | ❌ Unsupported | ❌ Unsupported |
-| `fromJSON()`, case-insensitive `startsWith()` | 🟡 Compile time only | ❌ Unsupported | 🟡 When the result resolves fully |
+| `fromJSON()`, case-insensitive string `startsWith()`, `contains()`, `endsWith()` | 🟡 Compile time only | ❌ Unsupported | 🟡 When the result resolves fully |
 | `hashFiles()` | 🟡 Step `if` only | 🟡 Workflow steps only | ❌ Unsupported |
 
 ### Conditions

--- a/internal/expression/compile.go
+++ b/internal/expression/compile.go
@@ -279,21 +279,29 @@ func evaluateCompileNode(node actionlint.ExprNode, context CompileContext) (any,
 				return nil, fmt.Errorf("fromJSON argument resolved to %T, want string", value)
 			}
 			return decodeJSONValue(text)
-		case strings.EqualFold(node.Callee, "startsWith") && len(node.Args) == 2:
+		case (strings.EqualFold(node.Callee, "startsWith") || strings.EqualFold(node.Callee, "contains") || strings.EqualFold(node.Callee, "endsWith")) && len(node.Args) == 2:
 			value, err := evaluateCompileNode(node.Args[0], context)
 			if err != nil {
 				return nil, err
 			}
-			prefix, err := evaluateCompileNode(node.Args[1], context)
+			search, err := evaluateCompileNode(node.Args[1], context)
 			if err != nil {
 				return nil, err
 			}
 			valueText, valueOK := value.(string)
-			prefixText, prefixOK := prefix.(string)
-			if !valueOK || !prefixOK {
-				return nil, fmt.Errorf("startsWith arguments resolved to %T and %T, want strings", value, prefix)
+			searchText, searchOK := search.(string)
+			if !valueOK || !searchOK {
+				return nil, fmt.Errorf("%s arguments resolved to %T and %T, want strings", node.Callee, value, search)
 			}
-			return strings.HasPrefix(strings.ToLower(valueText), strings.ToLower(prefixText)), nil
+			valueText, searchText = strings.ToLower(valueText), strings.ToLower(searchText)
+			switch {
+			case strings.EqualFold(node.Callee, "startsWith"):
+				return strings.HasPrefix(valueText, searchText), nil
+			case strings.EqualFold(node.Callee, "contains"):
+				return strings.Contains(valueText, searchText), nil
+			default:
+				return strings.HasSuffix(valueText, searchText), nil
+			}
 		default:
 			return nil, fmt.Errorf("unsupported compile-time function %q", node.Callee)
 		}

--- a/internal/expression/condition.go
+++ b/internal/expression/condition.go
@@ -198,7 +198,7 @@ func validateCompileConditionNode(node actionlint.ExprNode, scope ConditionScope
 		case (strings.EqualFold(node.Callee, "always") || strings.EqualFold(node.Callee, "success") || strings.EqualFold(node.Callee, "failure") || strings.EqualFold(node.Callee, "cancelled")) && len(node.Args) == 0:
 			return nil
 		case strings.EqualFold(node.Callee, "fromJSON") && len(node.Args) == 1,
-			strings.EqualFold(node.Callee, "startsWith") && len(node.Args) == 2:
+			(strings.EqualFold(node.Callee, "startsWith") || strings.EqualFold(node.Callee, "contains") || strings.EqualFold(node.Callee, "endsWith")) && len(node.Args) == 2:
 			for _, argument := range node.Args {
 				if err := validateCompileConditionNode(argument, scope, context, matrix); err != nil {
 					return err

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -761,6 +761,10 @@ func TestEvaluateCompileSupportsGraphContextsAndFromJSON(t *testing.T) {
 		{expression: "${{ github.event.number || github.ref }}", want: "refs/pull/42/merge"},
 		{expression: "${{ github.ref == 'refs/pull/42/merge' }}", want: true},
 		{expression: "${{ startsWith(github.ref, 'REFS/PULL/') }}", want: true},
+		{expression: "${{ contains(github.ref, 'PULL/42') }}", want: true},
+		{expression: "${{ contains(github.ref, 'ISSUES') }}", want: false},
+		{expression: "${{ endsWith(github.ref, '/MERGE') }}", want: true},
+		{expression: "${{ endsWith(github.ref, '/HEAD') }}", want: false},
 	}
 	context.GitHub["ref"] = "refs/pull/42/merge"
 	context.GitHub["event"] = map[string]any{"action": "opened", "number": json.Number("0")}
@@ -813,6 +817,19 @@ func TestEvaluateCompileConditionUsesEventSnapshot(t *testing.T) {
 	}
 	if usesEvent, err := ReferencesGitHubEvent("github.event_name == 'push'"); err != nil || usesEvent {
 		t.Fatalf("ReferencesGitHubEvent(event_name) = %v, %v", usesEvent, err)
+	}
+}
+
+func TestCompileConditionValidationSupportsStringPredicates(t *testing.T) {
+	context := CompileContext{GitHub: map[string]any{
+		"event": map[string]any{"pull_request": map[string]any{"title": "Release is READY"}},
+	}}
+	source := "contains(github.event.pull_request.title, 'release') && endsWith(github.event.pull_request.title, 'ready')"
+	if err := ValidateCompileConditionWithMatrix(source, JobCondition, context, nil); err != nil {
+		t.Fatalf("ValidateCompileConditionWithMatrix() = %v", err)
+	}
+	if resolved, err := EvaluateCompileCondition(source, context); err != nil || !resolved {
+		t.Fatalf("EvaluateCompileCondition() = %v, %v, want true", resolved, err)
 	}
 }
 
@@ -883,6 +900,9 @@ func TestEvaluateCompileFailsClosed(t *testing.T) {
 		{expression: "${{ vars.MISSING }}", want: `unavailable value "vars.missing"`},
 		{expression: "${{ hashFiles('go.sum') }}", want: `unsupported compile-time function "hashFiles"`},
 		{expression: "${{ startsWith(github.ref) }}", want: `unsupported compile-time function "startsWith"`},
+		{expression: "${{ contains(github.ref) }}", want: `unsupported compile-time function "contains"`},
+		{expression: "${{ endsWith('ref', true) }}", want: "endsWith arguments resolved to string and bool, want strings"},
+		{expression: "${{ contains(fromJSON('[\"push\"]'), 'push') }}", want: "contains arguments resolved to []interface {} and string, want strings"},
 		{expression: "${{ fromJSON(vars.BAD) }}", want: "invalid JSON"},
 		{expression: "${{ event.Ref }}", want: "ambiguous properties"},
 	}


### PR DESCRIPTION
## Why

The narrow compile-time expression surfaces support `startsWith()` but reject the equivalent string checks workflows commonly express with `contains()` and `endsWith()`.

## What

Add case-insensitive string `contains()` and `endsWith()` evaluation alongside `startsWith()` when expressions resolve fully during compilation. Keep wrong arities, non-string arguments, runtime conditions, and general runtime interpolation fail-closed; GitHub's array form of `contains()` remains unsupported.

Update the compatibility reference and add focused coverage for compile-time conditions, case-insensitive matches, negative results, and rejected argument shapes.