### PR TITLE
Support audited actions/checkout v3.7.0

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -533,17 +533,18 @@ Pre, main, and post phases; inputs; outputs; state; and LIFO post ordering are s
 
 ### Checkout action
 
-**🟡 Supported subset.** Resolved commits in the v4-and-later range of the static [`actions/checkout` upstream `main` snapshot](https://github.com/actions/checkout/tree/f548e57e544e1ff5a4c46bf1e1b8685f8e4a348a) are admitted. The following known releases remain admitted even when their commits aren't reachable from that snapshot:
+**🟡 Supported subset.** The final v3.7.0 release commit is admitted exactly. Resolved commits in the v4-and-later range of the static [`actions/checkout` upstream `main` snapshot](https://github.com/actions/checkout/tree/f548e57e544e1ff5a4c46bf1e1b8685f8e4a348a) are also admitted. The following known releases remain admitted even when their commits aren't reachable from that snapshot:
 
 | Release | Commit |
 | --- | --- |
+| v3.7.0 | [`a37ce9120846195fa4ece8f58b268e6043cb2f26`](https://github.com/actions/checkout/tree/a37ce9120846195fa4ece8f58b268e6043cb2f26) |
 | v4 | [`11d5960a326750d5838078e36cf38b85af677262`](https://github.com/actions/checkout/tree/11d5960a326750d5838078e36cf38b85af677262) |
 | v5 | [`fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09`](https://github.com/actions/checkout/tree/fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09) |
 | v6 | [`d23441a48e516b6c34aea4fa41551a30e30af803`](https://github.com/actions/checkout/tree/d23441a48e516b6c34aea4fa41551a30e30af803) |
 | v7.0.0 corpus pin | [`9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0`](https://github.com/actions/checkout/tree/9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0) |
 | v7.0.1 | [`3d3c42e5aac5ba805825da76410c181273ba90b1`](https://github.com/actions/checkout/tree/3d3c42e5aac5ba805825da76410c181273ba90b1) |
 
-Mutable refs work only while they resolve to the upstream `main` snapshot or a known release above. Every admitted commit uses the current adapter contract; the upstream JavaScript doesn't run. v1 through v3 and unknown commits are unsupported. Maintainers can update the snapshot with `go generate ./internal/action/integration`.
+Mutable refs work only while they resolve to the upstream `main` snapshot or a known release above. Every admitted commit uses the native adapter; the upstream JavaScript doesn't run. v1, v2, pre-v3.7.0 commits, and unknown commits are unsupported. Maintainers can update the v4-and-later snapshot with `go generate ./internal/action/integration`; this doesn't widen v3 admission.
 
 The adapter checks out a detached commit or static branch from the event repository at the workspace root or a clean top-level directory. It uses Buildkite repository-provider Git credentials when the job provides them; otherwise, it fetches anonymously. Credentials are scoped to each fetch command and verified submodule fetch command and are never persisted.
 
@@ -554,19 +555,23 @@ The adapter checks out a detached commit or static branch from the event reposit
 | `token` | Omitted only. |
 | `ssh-key`, `ssh-known-hosts` | Omitted or empty. |
 | `ssh-strict` | Omitted or `true`. |
-| `ssh-user` | Omitted or `git`. |
+| `ssh-user` | v4 and later: omitted or `git`. v3.7.0: omitted. |
 | `persist-credentials` | Omitted or `false`. |
 | `path` | Omitted, empty, or one clean non-`.git` top-level workspace directory. |
 | `clean` | Omitted or `true`; the root workspace or selected path must be empty or absent. |
-| `filter`, `sparse-checkout` | Omitted or empty. |
+| `filter` | v4 and later: omitted or empty. v3.7.0: omitted. |
+| `sparse-checkout` | Omitted or empty. |
 | `sparse-checkout-cone-mode` | Omitted or `true`. |
 | `fetch-depth` | Omitted or a nonnegative integer; `0` fetches full history. |
-| `fetch-tags`, `show-progress` | Omitted, `true`, or `false`. |
+| `fetch-tags` | Omitted, `true`, or `false`. |
+| `show-progress` | v4 and later: omitted, `true`, or `false`. v3.7.0: omitted. |
 | `lfs` | Omitted or `false`. |
 | `submodules` | Omitted, `false`, `true`, or `recursive`; whitespace is trimmed and casing is ignored. |
 | `set-safe-directory` | Omitted or `true`. |
 | `github-server-url` | Omitted, empty, or `https://github.com`. |
 | `allow-unsafe-pr-checkout` | Omitted or `false`. |
+
+The adapter preserves the v3.7.0 runtime `ref` output, which upstream set without declaring in `action.yml`. The `commit` output is available only for v4 and later because upstream added it in v4.2.0.
 
 The `false` value and omission do not run submodule commands. The `true` value runs native Git for direct children, and `recursive` includes nested children. Relative URLs and `fetch-depth` follow native Git behavior. Public and private GitHub submodules are supported under the job's repository access; external HTTPS submodules are anonymous. `git@github.com:` URLs are rewritten to HTTPS. Other SSH and non-HTTPS transports are unsupported.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -571,7 +571,7 @@ The adapter checks out a detached commit or static branch from the event reposit
 | `github-server-url` | Omitted, empty, or `https://github.com`. |
 | `allow-unsafe-pr-checkout` | Omitted or `false`. |
 
-The adapter preserves the v3.7.0 runtime `ref` output, which upstream set without declaring in `action.yml`. The `commit` output is available only for v4 and later because upstream added it in v4.2.0.
+The `ref` and `commit` outputs are unavailable for v3.7.0. Upstream added them in v4.2.0.
 
 The `false` value and omission do not run submodule commands. The `true` value runs native Git for direct children, and `recursive` includes nested children. Relative URLs and `fetch-depth` follow native Git behavior. Public and private GitHub submodules are supported under the job's repository access; external HTTPS submodules are anonymous. `git@github.com:` URLs are rewritten to HTTPS. Other SSH and non-HTTPS transports are unsupported.
 

--- a/internal/action/integration/integration.go
+++ b/internal/action/integration/integration.go
@@ -39,10 +39,13 @@ const (
 	// AdapterDownloadArtifactBuildkite extracts one producer-attributed native
 	// archive without using the GitHub Actions artifact service.
 	AdapterDownloadArtifactBuildkite Adapter = "download-artifact-buildkite-v1"
-	// CheckoutV4Commit through CheckoutV7Commit are the current audited major
-	// release implementations. CheckoutV7InitialCommit is retained because it
-	// is pinned by the OSS compatibility corpus; its later v7.0.1 changes do
-	// not affect the adapter's bounded exact-event-SHA operation.
+	// CheckoutV3Commit through CheckoutV7Commit are the current audited release
+	// implementations. CheckoutV3Commit is the final v3 release and is admitted
+	// exactly rather than extending the v4-and-later main-branch snapshot.
+	// CheckoutV7InitialCommit is retained because it is pinned by the OSS
+	// compatibility corpus; its later v7.0.1 changes do not affect the adapter's
+	// bounded exact-event-SHA operation.
+	CheckoutV3Commit        = "a37ce9120846195fa4ece8f58b268e6043cb2f26"
 	CheckoutV4Commit        = "11d5960a326750d5838078e36cf38b85af677262"
 	CheckoutV5Commit        = "fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09"
 	CheckoutV6Commit        = "d23441a48e516b6c34aea4fa41551a30e30af803"
@@ -125,6 +128,7 @@ var catalog = map[Identity]Descriptor{
 }
 
 var checkoutCommits = map[string]string{
+	CheckoutV3Commit:        "v3.7.0",
 	CheckoutV4Commit:        "v4",
 	CheckoutV5Commit:        "v5",
 	CheckoutV6Commit:        "v6",
@@ -615,9 +619,9 @@ func Lookup(identity Identity) (Descriptor, bool) {
 	return descriptor, ok
 }
 
-// ValidateCheckoutInputs enforces the input contract implemented by the
-// tokenless event-repository checkout adapter.
-func ValidateCheckoutInputs(inputs map[string]string, repository, sha string) error {
+// ValidateCheckoutInputs enforces the release-specific input contract
+// implemented by the tokenless event-repository checkout adapter.
+func ValidateCheckoutInputs(commit string, inputs map[string]string, repository, sha string) error {
 	names := make([]string, 0, len(inputs))
 	for name := range inputs {
 		names = append(names, name)
@@ -661,16 +665,24 @@ func ValidateCheckoutInputs(inputs map[string]string, repository, sha string) er
 			case "", "false", "true", "recursive":
 				continue
 			}
-		case "fetch-tags", "show-progress":
+		case "fetch-tags":
 			if uploadArtifactBoolean(value) {
+				continue
+			}
+		case "show-progress":
+			if commit != CheckoutV3Commit && uploadArtifactBoolean(value) {
 				continue
 			}
 		case "path":
 			if value == "" || validCheckoutPath(value) {
 				continue
 			}
-		case "ssh-key", "ssh-known-hosts", "filter", "sparse-checkout":
+		case "ssh-key", "ssh-known-hosts", "sparse-checkout":
 			if value == "" {
+				continue
+			}
+		case "filter":
+			if commit != CheckoutV3Commit && value == "" {
 				continue
 			}
 		case "ssh-strict", "sparse-checkout-cone-mode":
@@ -678,7 +690,7 @@ func ValidateCheckoutInputs(inputs map[string]string, repository, sha string) er
 				continue
 			}
 		case "ssh-user":
-			if value == "git" {
+			if commit != CheckoutV3Commit && value == "git" {
 				continue
 			}
 		case "github-server-url":

--- a/internal/action/integration/integration_test.go
+++ b/internal/action/integration/integration_test.go
@@ -163,7 +163,7 @@ func TestUploadArtifactCommitsAreExact(t *testing.T) {
 }
 
 func TestCheckoutCommitAdmission(t *testing.T) {
-	for _, commit := range []string{CheckoutV4Commit, CheckoutV5Commit, CheckoutV6Commit, CheckoutV7InitialCommit, CheckoutV7Commit} {
+	for _, commit := range []string{CheckoutV3Commit, CheckoutV4Commit, CheckoutV5Commit, CheckoutV6Commit, CheckoutV7InitialCommit, CheckoutV7Commit} {
 		if err := ValidateCheckoutCommit(commit); err != nil {
 			t.Fatalf("audited commit %s rejected: %v", commit, err)
 		}
@@ -173,7 +173,6 @@ func TestCheckoutCommitAdmission(t *testing.T) {
 	}
 	for _, commit := range []string{
 		"f43a0e5ff2bd294095638e18286ca9a3d1956744", // v3.6.0 is an ancestor of upstream main.
-		"a37ce9120846195fa4ece8f58b268e6043cb2f26", // v3.7.0 isn't on upstream main.
 		strings.Repeat("0", 40),
 	} {
 		if err := ValidateCheckoutCommit(commit); err == nil || !strings.Contains(err.Error(), "does not admit") || !strings.Contains(err.Error(), CheckoutV7Commit) || !strings.Contains(err.Error(), checkoutMainSnapshotCommit) {
@@ -344,7 +343,7 @@ func TestValidateCheckoutInputs(t *testing.T) {
 		{"submodules": " TrUe "},
 		{"submodules": " ReCuRsIvE "},
 	} {
-		if err := ValidateCheckoutInputs(inputs, repository, sha); err != nil {
+		if err := ValidateCheckoutInputs(CheckoutV7Commit, inputs, repository, sha); err != nil {
 			t.Fatalf("ValidateCheckoutInputs(%#v) = %v", inputs, err)
 		}
 	}
@@ -370,9 +369,29 @@ func TestValidateCheckoutInputs(t *testing.T) {
 		"git metadata path":    {"path": ".git"},
 	} {
 		t.Run(name, func(t *testing.T) {
-			if err := ValidateCheckoutInputs(inputs, repository, sha); err == nil || !strings.Contains(err.Error(), "unsupported") {
+			if err := ValidateCheckoutInputs(CheckoutV7Commit, inputs, repository, sha); err == nil || !strings.Contains(err.Error(), "unsupported") {
 				t.Fatalf("ValidateCheckoutInputs(%#v) = %v, want unsupported-capability rejection", inputs, err)
 			}
 		})
+	}
+}
+
+func TestValidateCheckoutV3InputsRejectsLaterContract(t *testing.T) {
+	repository, sha := "buildkite/buildkite-gha", strings.Repeat("a", 40)
+	for _, input := range []map[string]string{
+		{"filter": ""},
+		{"show-progress": "true"},
+		{"ssh-user": "git"},
+	} {
+		if err := ValidateCheckoutInputs(CheckoutV3Commit, input, repository, sha); err == nil || !strings.Contains(err.Error(), "unsupported") {
+			t.Fatalf("ValidateCheckoutInputs(%#v) = %v, want v3 contract rejection", input, err)
+		}
+	}
+	if err := ValidateCheckoutInputs(CheckoutV3Commit, map[string]string{
+		"repository": repository,
+		"ref":        sha,
+		"fetch-tags": "false",
+	}, repository, sha); err != nil {
+		t.Fatalf("ValidateCheckoutInputs() rejected v3 inputs: %v", err)
 	}
 }

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -885,8 +885,8 @@ func TestCheckoutAdapterInputBoundary(t *testing.T) {
 		ResolveActions: true,
 		ActionSource:   &fakeActionSource{root: remote, calls: map[string]int{}},
 	}
-	compile := func(with string) ([]plan.Job, error) {
-		workflow := []byte("on: push\njobs:\n  checkout:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1\n" + with)
+	compile := func(commit, with string) ([]plan.Job, error) {
+		workflow := []byte("on: push\njobs:\n  checkout:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@" + commit + "\n" + with)
 		if err := os.WriteFile(workflowPath, workflow, 0o644); err != nil {
 			t.Fatal(err)
 		}
@@ -904,7 +904,7 @@ func TestCheckoutAdapterInputBoundary(t *testing.T) {
 		"        with:\n          submodules: ' ReCuRsIvE '\n",
 	}
 	for _, with := range accepted {
-		plans, err := compile(with)
+		plans, err := compile(actionintegration.CheckoutV7Commit, with)
 		if err != nil {
 			t.Fatalf("checkout with %q: %v", with, err)
 		}
@@ -925,11 +925,15 @@ func TestCheckoutAdapterInputBoundary(t *testing.T) {
 	}
 	for name, input := range rejected {
 		t.Run(name, func(t *testing.T) {
-			_, err := compile("        with:\n" + input)
+			_, err := compile(actionintegration.CheckoutV7Commit, "        with:\n"+input)
 			if err == nil || !strings.Contains(err.Error(), "checkout.yml:") || !strings.Contains(err.Error(), "checkout adapter") {
 				t.Fatalf("compilePlansForTest() error = %v", err)
 			}
 		})
+	}
+
+	if _, err := compile(actionintegration.CheckoutV3Commit, "        with:\n          show-progress: false\n"); err == nil || !strings.Contains(err.Error(), "explicit input \"show-progress\" value is unsupported") {
+		t.Fatalf("v3.7.0 later-contract input error = %v", err)
 	}
 }
 
@@ -937,6 +941,7 @@ func TestCheckoutAdapterCommitBoundary(t *testing.T) {
 	workspace, remote := t.TempDir(), t.TempDir()
 	writeAction(t, remote, "", "name: checkout\nruns:\n  using: node24\n  main: index.js\n")
 	for version, commit := range map[string]string{
+		"v3.7.0":     actionintegration.CheckoutV3Commit,
 		"v4":         actionintegration.CheckoutV4Commit,
 		"v5":         actionintegration.CheckoutV5Commit,
 		"v6":         actionintegration.CheckoutV6Commit,

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -420,7 +420,7 @@ instances:
 								checkoutInputs[name] = ir.Event.SHA
 							}
 						}
-						if err := actionintegration.ValidateCheckoutInputs(checkoutInputs, ir.Event.Repository.Owner+"/"+ir.Event.Repository.Name, ir.Event.SHA); err != nil {
+						if err := actionintegration.ValidateCheckoutInputs(lock.Commit, checkoutInputs, ir.Event.Repository.Owner+"/"+ir.Event.Repository.Name, ir.Event.SHA); err != nil {
 							span := instance.Steps[stepIndex].Span.Start
 							return fmt.Errorf("%s:%d:%d: checkout adapter: %w", instance.SourcePath, span.Line, span.Column, err)
 						}

--- a/internal/runtime/checkout.go
+++ b/internal/runtime/checkout.go
@@ -69,7 +69,7 @@ func validCheckoutRepository(repository string) bool {
 	return parts[0] != "." && parts[0] != ".." && parts[1] != "." && parts[1] != ".."
 }
 
-func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, inputs map[string]string) (Result, error) {
+func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, commit string, inputs map[string]string) (Result, error) {
 	result := newResult()
 	const adapter = "checkout adapter"
 	credentialed := job.HasCapability("provider-token-read") && r.RepositoryCredentials != nil
@@ -77,7 +77,7 @@ func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, wo
 	if !validProvider || !checkoutSHAPattern.MatchString(job.Event.SHA) {
 		return result, fmt.Errorf("%s requires a valid GitHub or Origin event repository and exact SHA; other event sources are unsupported", adapter)
 	}
-	if err := actionintegration.ValidateCheckoutInputs(inputs, job.Event.Repository, job.Event.SHA); err != nil {
+	if err := actionintegration.ValidateCheckoutInputs(commit, inputs, job.Event.Repository, job.Event.SHA); err != nil {
 		return result, fmt.Errorf("%s: %w", adapter, err)
 	}
 	checkoutDirectory, err := prepareCheckoutDirectory(workspace, inputs)
@@ -140,9 +140,17 @@ func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, wo
 	if err != nil || !checkoutSHAPattern.MatchString(headSHA) || checkoutSHAPattern.MatchString(checkoutTarget) && headSHA != checkoutTarget {
 		return result, fmt.Errorf("%s did not produce the requested detached revision", adapter)
 	}
-	result.Outputs["ref"] = checkoutRefOutput(inputs, job.Event.Ref)
-	result.Outputs["commit"] = headSHA
+	setCheckoutOutputs(result.Outputs, commit, checkoutRefOutput(inputs, job.Event.Ref), headSHA)
 	return result, nil
+}
+
+func setCheckoutOutputs(outputs map[string]string, commit, ref, headSHA string) {
+	// v3.7.0 set ref at runtime despite not declaring it in action.yml. The
+	// commit output was added in v4.2.0 and is not part of the v3 contract.
+	outputs["ref"] = ref
+	if commit != actionintegration.CheckoutV3Commit {
+		outputs["commit"] = headSHA
+	}
 }
 
 func checkoutRepositoryURL(provider, repository string) (url, credentialHost string, ok bool) {

--- a/internal/runtime/checkout.go
+++ b/internal/runtime/checkout.go
@@ -145,12 +145,12 @@ func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, wo
 }
 
 func setCheckoutOutputs(outputs map[string]string, commit, ref, headSHA string) {
-	// v3.7.0 set ref at runtime despite not declaring it in action.yml. The
-	// commit output was added in v4.2.0 and is not part of the v3 contract.
-	outputs["ref"] = ref
-	if commit != actionintegration.CheckoutV3Commit {
-		outputs["commit"] = headSHA
+	// Checkout outputs were added in v4.2.0 and aren't part of the v3 contract.
+	if commit == actionintegration.CheckoutV3Commit {
+		return
 	}
+	outputs["ref"] = ref
+	outputs["commit"] = headSHA
 }
 
 func checkoutRepositoryURL(provider, repository string) (url, credentialHost string, ok bool) {

--- a/internal/runtime/checkout_test.go
+++ b/internal/runtime/checkout_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -261,7 +262,7 @@ printf '%s\n' "$*" >> ` + shellTestQuote(gitLog) + `
 	}
 	var logs bytes.Buffer
 	result, err := (Runner{Git: git, RepositoryCredentials: credentials, Stdout: &logs, Stderr: &logs}).runCheckout(
-		context.Background(), newCommandProcessor(&logs, &logs), workspace, job, nil,
+		context.Background(), newCommandProcessor(&logs, &logs), workspace, job, actionintegration.CheckoutV7Commit, nil,
 	)
 	if err != nil {
 		t.Fatalf("runCheckout() error = %v, logs = %q", err, logs.String())
@@ -291,18 +292,18 @@ func TestCheckoutAdapterRejectsUnsupportedInputsAndState(t *testing.T) {
 	repository, sha := "buildkite/buildkite-gha", strings.Repeat("a", 40)
 	processor := newCommandProcessor(io.Discard, io.Discard)
 	job := plan.Job{Event: plan.Event{Provider: "github", Repository: repository, SHA: sha}}
-	if _, err := (Runner{}).runCheckout(context.Background(), processor, t.TempDir(), job, map[string]string{"token": ""}); err == nil || !strings.Contains(err.Error(), "unsupported") {
+	if _, err := (Runner{}).runCheckout(context.Background(), processor, t.TempDir(), job, actionintegration.CheckoutV7Commit, map[string]string{"token": ""}); err == nil || !strings.Contains(err.Error(), "unsupported") {
 		t.Fatalf("runCheckout() unsupported input error = %v", err)
 	}
 	workspace := t.TempDir()
 	if err := os.WriteFile(filepath.Join(workspace, "occupied"), []byte("x"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := (Runner{}).runCheckout(context.Background(), processor, workspace, job, nil); err == nil || !strings.Contains(err.Error(), "empty workspace") {
+	if _, err := (Runner{}).runCheckout(context.Background(), processor, workspace, job, actionintegration.CheckoutV7Commit, nil); err == nil || !strings.Contains(err.Error(), "empty workspace") {
 		t.Fatalf("nonempty workspace error = %v", err)
 	}
 	job.Event.Provider = "other"
-	if _, err := (Runner{}).runCheckout(context.Background(), processor, t.TempDir(), job, nil); err == nil || !strings.Contains(err.Error(), "valid GitHub or Origin event") {
+	if _, err := (Runner{}).runCheckout(context.Background(), processor, t.TempDir(), job, actionintegration.CheckoutV7Commit, nil); err == nil || !strings.Contains(err.Error(), "valid GitHub or Origin event") {
 		t.Fatalf("invalid event error = %v", err)
 	}
 }
@@ -361,6 +362,25 @@ func TestCheckoutRefOutput(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			if got := checkoutRefOutput(test.inputs, eventRef); got != test.want {
 				t.Fatalf("checkoutRefOutput() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestCheckoutOutputsMatchReleaseContract(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		commit string
+		want   map[string]string
+	}{
+		{name: "v3.7.0", commit: actionintegration.CheckoutV3Commit, want: map[string]string{"ref": "refs/heads/main"}},
+		{name: "v4 and later", commit: actionintegration.CheckoutV4Commit, want: map[string]string{"ref": "refs/heads/main", "commit": strings.Repeat("a", 40)}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			outputs := map[string]string{}
+			setCheckoutOutputs(outputs, test.commit, "refs/heads/main", strings.Repeat("a", 40))
+			if !maps.Equal(outputs, test.want) {
+				t.Fatalf("checkout outputs = %#v, want %#v", outputs, test.want)
 			}
 		})
 	}
@@ -797,7 +817,7 @@ func TestCheckoutRejectsInvalidRepositoryBeforeInspectingWorkspace(t *testing.T)
 	}
 	job := plan.Job{Event: plan.Event{Provider: "github", Repository: "owner/..", SHA: strings.Repeat("a", 40)}}
 	processor := newCommandProcessor(io.Discard, io.Discard)
-	if _, err := (Runner{}).runCheckout(context.Background(), processor, workspace, job, nil); err == nil || !strings.Contains(err.Error(), "valid GitHub or Origin event repository") {
+	if _, err := (Runner{}).runCheckout(context.Background(), processor, workspace, job, actionintegration.CheckoutV7Commit, nil); err == nil || !strings.Contains(err.Error(), "valid GitHub or Origin event repository") {
 		t.Fatalf("checkout repository validation error = %v", err)
 	}
 }
@@ -943,7 +963,7 @@ printf '%s|%s\n' "$PWD" "$*" >> ` + shellTestQuote(gitLog) + `
 	for name := range proxyEnvironment {
 		t.Setenv(name, "http://late-workflow-value.invalid")
 	}
-	result, err := (Runner{Git: git, RepositoryCredentials: credentials, Stdout: &logs, Stderr: &logs}).runCheckout(context.Background(), processor, workspace, job, map[string]string{"path": "test-catalog"})
+	result, err := (Runner{Git: git, RepositoryCredentials: credentials, Stdout: &logs, Stderr: &logs}).runCheckout(context.Background(), processor, workspace, job, actionintegration.CheckoutV7Commit, map[string]string{"path": "test-catalog"})
 	if err != nil {
 		t.Fatalf("runCheckout() error = %v, logs = %q", err, logs.String())
 	}
@@ -1091,7 +1111,7 @@ esac
 	credentials := &AgentRepositoryCredentials{Agent: agent, JobID: testCacheJobID, JobToken: "job-secret"}
 	var logs bytes.Buffer
 	processor := newCommandProcessor(&logs, &logs)
-	if _, err := (Runner{Git: git, RepositoryCredentials: credentials, Stdout: &logs, Stderr: &logs}).runCheckout(context.Background(), processor, workspace, job, nil); err == nil {
+	if _, err := (Runner{Git: git, RepositoryCredentials: credentials, Stdout: &logs, Stderr: &logs}).runCheckout(context.Background(), processor, workspace, job, actionintegration.CheckoutV7Commit, nil); err == nil {
 		t.Fatal("runCheckout() succeeded after repository-provider helper denial")
 	}
 	if strings.Contains(logs.String(), "job-secret") || !strings.Contains(logs.String(), "***") {
@@ -1272,7 +1292,7 @@ func TestRepositoryProviderCheckoutRequiresPreResolvedGit(t *testing.T) {
 		RequiredCapabilities: []string{"provider-token-read"},
 	}
 	credentials := &AgentRepositoryCredentials{Agent: "/usr/bin/buildkite-agent", JobID: testCacheJobID, JobToken: "job-secret"}
-	if _, err := (Runner{Git: "git", RepositoryCredentials: credentials}).runCheckout(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), job, nil); err == nil || !strings.Contains(err.Error(), "resolved before workflow execution") {
+	if _, err := (Runner{Git: "git", RepositoryCredentials: credentials}).runCheckout(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), job, actionintegration.CheckoutV7Commit, nil); err == nil || !strings.Contains(err.Error(), "resolved before workflow execution") {
 		t.Fatalf("runCheckout() unresolved Git error = %v", err)
 	}
 }

--- a/internal/runtime/checkout_test.go
+++ b/internal/runtime/checkout_test.go
@@ -373,7 +373,7 @@ func TestCheckoutOutputsMatchReleaseContract(t *testing.T) {
 		commit string
 		want   map[string]string
 	}{
-		{name: "v3.7.0", commit: actionintegration.CheckoutV3Commit, want: map[string]string{"ref": "refs/heads/main"}},
+		{name: "v3.7.0", commit: actionintegration.CheckoutV3Commit, want: map[string]string{}},
 		{name: "v4 and later", commit: actionintegration.CheckoutV4Commit, want: map[string]string{"ref": "refs/heads/main", "commit": strings.Repeat("a", 40)}},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -1482,7 +1482,7 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 			if err := validateCheckoutRefProvenance(step.With, inputs, job.Event.SHA); err != nil {
 				return result, err
 			}
-			return r.runCheckout(ctx, processor, workspace, job, inputs)
+			return r.runCheckout(ctx, processor, workspace, job, lock.Commit, inputs)
 		}
 		if usesUploadArtifactAdapter(lock) {
 			inputs, err := evaluateStepMap(step.With, eval)


### PR DESCRIPTION
## Why

Some imported workflows still use `actions/checkout@v3`, but admitting broad pre-v4 history would weaken the native checkout adapter's audited boundary.

## What

Admit only the final v3.7.0 release commit. Apply its narrower input contract, leave its unavailable `ref` and `commit` outputs unset, and retain the adapter's event-repository and command-scoped credential restrictions. Document the exact compatibility boundary and keep earlier v3 commits fail-closed.