### PR TITLE
Allow durable plans in docs/plans

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Follow the Buildkite [writing style guide](https://github.com/buildkite/docs/blo
 
 - Use the fewest words that preserve meaning. Prefer examples and tables to long explanations.
 - Write directly, in active voice, with sentence-case headings.
-- Describe current behavior. Keep plans and remaining work in Linear.
+- Describe current behavior in product documentation. Durable engineering plans may live in `docs/plans/`; keep task tracking and remaining work in Linear.
 - State each fact once, then link to its source of truth. `README.md` is the overview; `docs/compatibility.md` owns supported behavior; the CLI, security, and development guides own their respective details.
 - Remove repetition, not behavior, boundaries, limits, warnings, or useful examples.
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -681,7 +681,7 @@ func TestPluginUsesJSONConfigurationAndOnlyRequiredRuntime(t *testing.T) {
 func TestPluginAdmissionFailurePrintsDiagnosticsBeforeSummaryAndAnnotatesDetails(t *testing.T) {
 	requireImporterHost(t)
 	repository := writeUploadWorkflowRepository(t, map[string]string{
-		"secret.yml": "name: Secret\non: push\njobs:\n  secret:\n    runs-on: ubuntu-latest\n    env:\n      TOKEN: ${{ secrets.TOKEN }}\n    steps: [{run: true}]\n",
+		"secret.yml": "name: Secret\non: push\njobs:\n  secret:\n    runs-on: ubuntu-latest\n    permissions:\n      contents: read\n    env:\n      TOKEN: ${{ secrets.GITHUB_TOKEN }}\n    steps: [{run: true}]\n",
 	})
 	t.Chdir(repository)
 	configuration, err := json.Marshal(map[string]any{"workflow": ".github/workflows/secret.yml"})
@@ -717,7 +717,7 @@ func TestPluginAdmissionFailurePrintsDiagnosticsBeforeSummaryAndAnnotatesDetails
 			annotation = &runner.commands[i]
 		}
 	}
-	if annotation == nil || !strings.Contains(string(annotation.stdin), "uses GitHub Actions secrets") ||
+	if annotation == nil || !strings.Contains(string(annotation.stdin), "needs GITHUB_TOKEN") ||
 		!strings.Contains(string(annotation.stdin), `href="https://github.com/buildkite/buildkite-gha/blob/0123456789abcdef0123456789abcdef01234567/.github/workflows/secret.yml#L`) {
 		t.Fatalf("admission failure annotation = %#v", annotation)
 	}


### PR DESCRIPTION
## Why

The repository guidance currently requires plans to live in Linear, which prevents useful durable engineering plans from living alongside the code they describe.

The plugin admission-failure test also still used ordinary secrets as its rejected fixture even though ordinary secrets are now supported.

## What

Allow durable engineering plans in `docs/plans/` while keeping task tracking and remaining work in Linear. Product documentation continues to describe current behavior.

Keep the admission-failure diagnostic coverage by using the still-unsupported job-level `GITHUB_TOKEN` permissions shape.