### PR TITLE
Deduplicate native checkout policy

### DIFF
--- a/internal/action/integration/integration.go
+++ b/internal/action/integration/integration.go
@@ -204,6 +204,11 @@ func ValidateCheckoutCommit(commit string) error {
 	return nil
 }
 
+// IsCheckoutV3 reports whether commit uses the audited v3.7.0 contract.
+func IsCheckoutV3(commit string) bool {
+	return commit == CheckoutV3Commit
+}
+
 func sortedCheckoutCommits() []string {
 	commits := make([]string, 0, len(checkoutCommits))
 	for commit, version := range checkoutCommits {
@@ -628,6 +633,7 @@ func ValidateCheckoutInputs(commit string, inputs map[string]string, repository,
 	}
 	sort.Strings(names)
 	seen := make(map[string]bool, len(names))
+	v3 := IsCheckoutV3(commit)
 	for _, name := range names {
 		value := inputs[name]
 		normalized := strings.ToLower(name)
@@ -641,7 +647,7 @@ func ValidateCheckoutInputs(commit string, inputs map[string]string, repository,
 				continue
 			}
 		case "ref":
-			if value == "" || validCheckoutSHA(value) || validCheckoutBranch(value) {
+			if value == "" || ValidCheckoutSHA(value) || validCheckoutBranch(value) {
 				continue
 			}
 		case "persist-credentials":
@@ -670,7 +676,7 @@ func ValidateCheckoutInputs(commit string, inputs map[string]string, repository,
 				continue
 			}
 		case "show-progress":
-			if commit != CheckoutV3Commit && uploadArtifactBoolean(value) {
+			if !v3 && uploadArtifactBoolean(value) {
 				continue
 			}
 		case "path":
@@ -682,7 +688,7 @@ func ValidateCheckoutInputs(commit string, inputs map[string]string, repository,
 				continue
 			}
 		case "filter":
-			if commit != CheckoutV3Commit && value == "" {
+			if !v3 && value == "" {
 				continue
 			}
 		case "ssh-strict", "sparse-checkout-cone-mode":
@@ -690,7 +696,7 @@ func ValidateCheckoutInputs(commit string, inputs map[string]string, repository,
 				continue
 			}
 		case "ssh-user":
-			if commit != CheckoutV3Commit && value == "git" {
+			if !v3 && value == "git" {
 				continue
 			}
 		case "github-server-url":
@@ -734,7 +740,8 @@ func validCheckoutBranch(value string) bool {
 	return true
 }
 
-func validCheckoutSHA(value string) bool {
+// ValidCheckoutSHA reports whether value is a lowercase 40-hex Git commit ID.
+func ValidCheckoutSHA(value string) bool {
 	if len(value) != 40 {
 		return false
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -681,10 +681,10 @@ func TestPluginUsesJSONConfigurationAndOnlyRequiredRuntime(t *testing.T) {
 func TestPluginAdmissionFailurePrintsDiagnosticsBeforeSummaryAndAnnotatesDetails(t *testing.T) {
 	requireImporterHost(t)
 	repository := writeUploadWorkflowRepository(t, map[string]string{
-		"secret.yml": "name: Secret\non: push\njobs:\n  secret:\n    runs-on: ubuntu-latest\n    env:\n      TOKEN: ${{ secrets.TOKEN }}\n    steps: [{run: true}]\n",
+		"service.yml": "name: Service\non: push\njobs:\n  service:\n    runs-on: ubuntu-latest\n    services:\n      postgres:\n        image: postgres:17\n    steps: [{run: true}]\n",
 	})
 	t.Chdir(repository)
-	configuration, err := json.Marshal(map[string]any{"workflow": ".github/workflows/secret.yml"})
+	configuration, err := json.Marshal(map[string]any{"workflow": ".github/workflows/service.yml"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -701,12 +701,12 @@ func TestPluginAdmissionFailurePrintsDiagnosticsBeforeSummaryAndAnnotatesDetails
 	diagnostic := strings.Index(output, "x [E_PROFILE]")
 	summary := strings.Index(output, "Compilation: compilable. Admission: not-admitted.")
 	if !strings.HasPrefix(output, "^^^ +++\n") || diagnostic == -1 || summary <= diagnostic ||
-		!strings.Contains(output, "workflow=.github/workflows/secret.yml") ||
+		!strings.Contains(output, "workflow=.github/workflows/service.yml") ||
 		!strings.Contains(output, "stage=hosted-profile-admission") ||
-		!strings.Contains(output, "job=secret") {
+		!strings.Contains(output, "job=service") {
 		t.Fatalf("plugin failure output = %q", output)
 	}
-	for _, verbose := range []string{"Schema:", "- Workflow parsing:", "  job secret:"} {
+	for _, verbose := range []string{"Schema:", "- Workflow parsing:", "  job service:"} {
 		if strings.Contains(output, verbose) {
 			t.Fatalf("plugin failure output contains verbose inventory %q: %q", verbose, output)
 		}
@@ -717,8 +717,8 @@ func TestPluginAdmissionFailurePrintsDiagnosticsBeforeSummaryAndAnnotatesDetails
 			annotation = &runner.commands[i]
 		}
 	}
-	if annotation == nil || !strings.Contains(string(annotation.stdin), "uses GitHub Actions secrets") ||
-		!strings.Contains(string(annotation.stdin), `href="https://github.com/buildkite/buildkite-gha/blob/0123456789abcdef0123456789abcdef01234567/.github/workflows/secret.yml#L`) {
+	if annotation == nil || !strings.Contains(string(annotation.stdin), "uses service container") ||
+		!strings.Contains(string(annotation.stdin), `href="https://github.com/buildkite/buildkite-gha/blob/0123456789abcdef0123456789abcdef01234567/.github/workflows/service.yml#L`) {
 		t.Fatalf("admission failure annotation = %#v", annotation)
 	}
 }

--- a/internal/runtime/checkout.go
+++ b/internal/runtime/checkout.go
@@ -15,7 +15,6 @@ import (
 )
 
 var checkoutRepositoryPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`)
-var checkoutSHAPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
 var agentProxyEnvironmentNames = [...]string{
 	"HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY",
 	"http_proxy", "https_proxy", "all_proxy", "no_proxy",
@@ -74,7 +73,7 @@ func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, wo
 	const adapter = "checkout adapter"
 	credentialed := job.HasCapability("provider-token-read") && r.RepositoryCredentials != nil
 	url, credentialHost, validProvider := checkoutRepositoryURL(job.Event.Provider, job.Event.Repository)
-	if !validProvider || !checkoutSHAPattern.MatchString(job.Event.SHA) {
+	if !validProvider || !actionintegration.ValidCheckoutSHA(job.Event.SHA) {
 		return result, fmt.Errorf("%s requires a valid GitHub or Origin event repository and exact SHA; other event sources are unsupported", adapter)
 	}
 	if err := actionintegration.ValidateCheckoutInputs(commit, inputs, job.Event.Repository, job.Event.SHA); err != nil {
@@ -137,7 +136,7 @@ func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, wo
 	}
 	head, err := os.ReadFile(filepath.Join(checkoutDirectory, ".git", "HEAD"))
 	headSHA := strings.TrimSpace(string(head))
-	if err != nil || !checkoutSHAPattern.MatchString(headSHA) || checkoutSHAPattern.MatchString(checkoutTarget) && headSHA != checkoutTarget {
+	if err != nil || !actionintegration.ValidCheckoutSHA(headSHA) || actionintegration.ValidCheckoutSHA(checkoutTarget) && headSHA != checkoutTarget {
 		return result, fmt.Errorf("%s did not produce the requested detached revision", adapter)
 	}
 	setCheckoutOutputs(result.Outputs, commit, checkoutRefOutput(inputs, job.Event.Ref), headSHA)
@@ -146,7 +145,7 @@ func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, wo
 
 func setCheckoutOutputs(outputs map[string]string, commit, ref, headSHA string) {
 	// Checkout outputs were added in v4.2.0 and aren't part of the v3 contract.
-	if commit == actionintegration.CheckoutV3Commit {
+	if actionintegration.IsCheckoutV3(commit) {
 		return
 	}
 	outputs["ref"] = ref
@@ -311,7 +310,7 @@ func checkoutRefOutput(inputs map[string]string, eventRef string) string {
 	if ref == "" {
 		return eventRef
 	}
-	if checkoutSHAPattern.MatchString(ref) {
+	if actionintegration.ValidCheckoutSHA(ref) {
 		return ""
 	}
 	return ref
@@ -341,11 +340,13 @@ func checkoutFetchArgs(inputs map[string]string, sha string) []string {
 			"+refs/heads/*:refs/remotes/origin/*",
 			"+refs/tags/*:refs/tags/*",
 		)
-		ref := checkoutInput(inputs, "ref")
-		if ref == "" || ref == sha {
-			args = append(args, "+"+sha+":refs/buildkite-gha/event")
-		} else if checkoutSHAPattern.MatchString(ref) {
-			args = append(args, "+"+ref+":refs/buildkite-gha/selected")
+		revision, branch := checkoutSelectedRevision(inputs, sha)
+		if !branch {
+			namespace := "selected"
+			if revision == sha {
+				namespace = "event"
+			}
+			args = append(args, "+"+revision+":refs/buildkite-gha/"+namespace)
 		}
 		return args
 	}
@@ -357,26 +358,30 @@ func checkoutFetchArgs(inputs map[string]string, sha string) []string {
 }
 
 func checkoutFetchRevision(inputs map[string]string, sha string) string {
-	ref := checkoutInput(inputs, "ref")
-	if ref == "" || ref == sha {
-		return sha
+	revision, branch := checkoutSelectedRevision(inputs, sha)
+	if !branch {
+		return revision
 	}
-	if checkoutSHAPattern.MatchString(ref) {
-		return ref
-	}
-	branch := strings.TrimPrefix(ref, "refs/heads/")
-	return "+refs/heads/" + branch + ":refs/remotes/origin/" + branch
+	return "+refs/heads/" + revision + ":refs/remotes/origin/" + revision
 }
 
 func checkoutRevision(inputs map[string]string, sha string) string {
+	revision, branch := checkoutSelectedRevision(inputs, sha)
+	if !branch {
+		return revision
+	}
+	return "refs/remotes/origin/" + revision
+}
+
+func checkoutSelectedRevision(inputs map[string]string, sha string) (revision string, branch bool) {
 	ref := checkoutInput(inputs, "ref")
 	if ref == "" || ref == sha {
-		return sha
+		return sha, false
 	}
-	if checkoutSHAPattern.MatchString(ref) {
-		return ref
+	if actionintegration.ValidCheckoutSHA(ref) {
+		return ref, false
 	}
-	return "refs/remotes/origin/" + strings.TrimPrefix(ref, "refs/heads/")
+	return strings.TrimPrefix(ref, "refs/heads/"), true
 }
 
 func checkoutInput(inputs map[string]string, wanted string) string {


### PR DESCRIPTION
## Why

The native checkout path accumulated parallel version checks, duplicate SHA validation, and repeated ref classification while adding bounded v3 support.

## What

Centralize the v3 contract predicate and exact-SHA policy in the checkout integration, then classify the selected checkout revision once for shallow fetches, full-history fetches, and detached checkout targets. Preserve the existing security-focused test setups and behavior.