### PR TITLE
Reduce Test Engine parallelism

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -85,7 +85,7 @@ steps:
       - label: ":test_tube: Go tests %n/%t"
         key: "go-tests"
         if: build.env("DEMO_SUITE") != "plugin"
-        parallelism: 2
+        parallelism: 1
         cache: ".buildkite/cache-volume"
         plugins:
           - setup-go#v0.1.0:


### PR DESCRIPTION
## Why

Test Engine splits Go tests by package. `internal/runtime` takes about 24 seconds by itself, while the other 13 packages finish together in about 5 seconds, so a second agent does not shorten the critical path.

## What

Run the Test Engine step with one partition. This preserves Test Engine collection and duration history while avoiding an idle second agent.
