### PR TITLE
Validate workflows with generated events

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ buildkite-gha validate \
 
 For a quick check, replace `--event-path` with `--event` and one of `push`, `pull_request`, `workflow_dispatch`, or `schedule`. The generated minimal snapshot is not equivalent to a real payload; use `--event-path` when exact payload data matters.
 
+Use `--all-events` with `--profile hosted` to evaluate every declared supported event separately. JSON output uses `processing-report/v3` to retain each event's result.
+
 An `admitted` result means the workflow satisfies upload policy. A `not-applicable` result means the workflow does not declare the selected event and upload would skip it without compiling it. Validation does not execute the workflow or prove that arbitrary action code works without GitHub services. Use `--format json` for machine-readable output.
 
 See the [CLI guide](docs/cli.md) for event snapshots, compilation, direct upload, and agent targeting.

--- a/README.md
+++ b/README.md
@@ -115,9 +115,27 @@ buildkite-gha validate \
   .github/workflows/ci.yml
 ```
 
-For a quick check, replace `--event-path` with `--event` and one of `push`, `pull_request`, `workflow_dispatch`, or `schedule`. The generated minimal snapshot is not equivalent to a real payload; use `--event-path` when exact payload data matters.
+For a quick push compatibility check, generate a minimal event snapshot:
 
-Use `--all-events` with `--profile hosted` to evaluate every declared supported event separately. JSON output uses `processing-report/v3` to retain each event's result.
+```sh
+buildkite-gha validate \
+  --profile hosted \
+  --event push \
+  .github/workflows/ci.yml
+```
+
+`--event` also supports `pull_request`, `workflow_dispatch`, and `schedule`. The generated minimal snapshot is not equivalent to a real payload; use `--event-path` when exact payload data matters.
+
+Use `--all-events` to evaluate every declared supported event separately:
+
+```sh
+buildkite-gha validate \
+  --profile hosted \
+  --all-events \
+  .github/workflows/ci.yml
+```
+
+JSON output uses `processing-report/v3` to retain each event's result.
 
 An `admitted` result means the workflow satisfies upload policy. A `not-applicable` result means the workflow does not declare the selected event and upload would skip it without compiling it. Validation does not execute the workflow or prove that arbitrary action code works without GitHub services. Use `--format json` for machine-readable output.
 

--- a/README.md
+++ b/README.md
@@ -98,11 +98,13 @@ Some features support a limited subset or behave differently on Buildkite. Check
 
 ## Validate a workflow
 
-Check syntax and the static job graph without contacting Buildkite or executing workflow code:
+Check syntax, the static job graph, and every declared trigger without contacting Buildkite or executing workflow code:
 
 ```sh
 buildkite-gha validate .github/workflows/ci.yml
 ```
+
+This event-independent result does not claim hosted admission.
 
 To resolve public actions and apply the production upload policy, provide an event snapshot:
 
@@ -112,6 +114,8 @@ buildkite-gha validate \
   --event-path .buildkite/events/current.json \
   .github/workflows/ci.yml
 ```
+
+For a quick check, replace `--event-path` with `--event` and one of `push`, `pull_request`, `workflow_dispatch`, or `schedule`. The generated minimal snapshot is not equivalent to a real payload; use `--event-path` when exact payload data matters.
 
 An `admitted` result means the workflow satisfies upload policy. A `not-applicable` result means the workflow does not declare the selected event and upload would skip it without compiling it. Validation does not execute the workflow or prove that arbitrary action code works without GitHub services. Use `--format json` for machine-readable output.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -20,11 +20,13 @@ Managed Node binaries require glibc 2.28 or newer. The Go CLI has no glibc requi
 
 ## Validate a workflow
 
-Validate syntax and the static graph:
+Validate syntax, the static graph, and every declared trigger without an event:
 
 ```sh
 buildkite-gha validate .github/workflows/ci.yml
 ```
+
+This event-independent check rejects unsupported events, path filters, branch and tag filter combinations, and pull request activity types. It does not resolve actions, evaluate event payload expressions, or claim hosted admission.
 
 Resolve actions and apply production policy:
 
@@ -34,6 +36,19 @@ buildkite-gha validate \
   --event-path .buildkite/events/current.json \
   .github/workflows/ci.yml
 ```
+
+For a quick compatibility check, generate a minimal supported event snapshot:
+
+```sh
+buildkite-gha validate \
+  --profile hosted \
+  --event pull_request \
+  .github/workflows/ci.yml
+```
+
+`--event` supports `push`, `pull_request`, `workflow_dispatch`, and `schedule`. It is available only with `--profile hosted` and is mutually exclusive with `--event-path`. The generated snapshot uses example repository identity and minimal event fields. It can expose payload-dependent incompatibilities, but it is not equivalent to a real payload and cannot prove behavior for every payload shape. Use `--event-path` when exact refs, activity, repository identity, or payload fields matter.
+
+Validation produces one processing report for one event. There is no `--all-events` option: combining generated evaluations under the current single-report contract would overstate admission when behavior depends on payload fields. Run `--event` once per event you need to inspect, and use exact snapshots for payload-dependent workflows.
 
 The deprecated `hosted-tokenless` profile name remains an alias for `hosted`.
 
@@ -49,7 +64,7 @@ Validation may use the public network to resolve actions. Apart from annotation 
 
 ## Provide an event snapshot
 
-`compile` and profile validation need a bounded event snapshot:
+`compile` and profile validation with `--event-path` need a bounded event snapshot:
 
 ```json
 {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -48,11 +48,20 @@ buildkite-gha validate \
 
 `--event` supports `push`, `pull_request`, `workflow_dispatch`, and `schedule`. It is available only with `--profile hosted` and is mutually exclusive with `--event-path`. The generated snapshot uses example repository identity and minimal event fields. It can expose payload-dependent incompatibilities, but it is not equivalent to a real payload and cannot prove behavior for every payload shape. Use `--event-path` when exact refs, activity, repository identity, or payload fields matter.
 
-Validation produces one processing report for one event. There is no `--all-events` option: combining generated evaluations under the current single-report contract would overstate admission when behavior depends on payload fields. Run `--event` once per event you need to inspect, and use exact snapshots for payload-dependent workflows.
+Use `--all-events` with `--profile hosted` to evaluate every declared `push`, `pull_request`, `workflow_dispatch`, and `schedule` trigger with a separate generated snapshot:
+
+```sh
+buildkite-gha validate \
+  --profile hosted \
+  --all-events \
+  .github/workflows/ci.yml
+```
+
+`--all-events` is mutually exclusive with `--event` and `--event-path`. It does not evaluate `workflow_call` as a standalone event. Admission applies separately to each generated snapshot, not to every possible real payload.
 
 The deprecated `hosted-tokenless` profile name remains an alias for `hosted`.
 
-Use `--format json` for a `buildkite-gha/processing-report/v2` report.
+Use `--format json` for a `buildkite-gha/processing-report/v2` report. `--all-events` emits `buildkite-gha/processing-report/v3`, which contains the event-independent v2 report and one v2 report for each generated event evaluation. The top-level result is `admitted` only when every evaluation is admitted.
 
 Reports cover workflow parsing, event validation, graph construction, matrix expansion, expressions, action discovery and resolution, plan construction, profile admission, and pipeline generation. A blocked downstream stage is `not-evaluated`, not `failed`.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -59,6 +59,29 @@ buildkite-gha validate \
 
 `--all-events` is mutually exclusive with `--event` and `--event-path`. It does not evaluate `workflow_call` as a standalone event. Admission applies separately to each generated snapshot, not to every possible real payload.
 
+Inspect the aggregate result and each event outcome:
+
+```sh
+buildkite-gha validate \
+  --profile hosted \
+  --all-events \
+  --format json \
+  .github/workflows/ci.yml |
+  jq '{result, events: [.evaluations[] | {event, result: .report.result}]}'
+```
+
+Inspect diagnostics with their generated event names:
+
+```sh
+buildkite-gha validate \
+  --profile hosted \
+  --all-events \
+  --format json \
+  .github/workflows/ci.yml |
+  jq -r '(.validation.diagnostics[] | "validation: \(.code): \(.message)"),
+    (.evaluations[] | .event as $event | .report.diagnostics[] | "\($event): \(.code): \(.message)")'
+```
+
 The deprecated `hosted-tokenless` profile name remains an alias for `hosted`.
 
 Use `--format json` for a `buildkite-gha/processing-report/v2` report. `--all-events` emits `buildkite-gha/processing-report/v3`, which contains the event-independent v2 report and one v2 report for each generated event evaluation. The top-level result is `admitted` only when every evaluation is admitted.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -787,6 +787,8 @@ buildkite-gha validate \
 
 Use `--event push`, `--event pull_request`, `--event workflow_dispatch`, or `--event schedule` instead of `--event-path` to evaluate the hosted profile with a generated minimal snapshot. Generated snapshots are compatibility test inputs, not equivalents to real payloads. The options are mutually exclusive.
 
+Use `--all-events` to evaluate every declared supported event separately. Its `processing-report/v3` output preserves the event-independent result and each generated event's v2 report. Aggregate admission means every generated snapshot was admitted; it does not cover other payload shapes.
+
 The results mean:
 
 - **Compilable**: Syntax, declared triggers, and the static job graph can be translated.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -768,11 +768,13 @@ hosted-toolchains images provide. macOS images are unsupported.
 
 ## Validation
 
-Check syntax and static graph construction without an event:
+Check syntax, static graph construction, and every declared trigger without an event:
 
 ```sh
 buildkite-gha validate .github/workflows/ci.yml
 ```
+
+This result is event-independent and does not claim hosted admission.
 
 Apply the same profile as production upload:
 
@@ -783,9 +785,11 @@ buildkite-gha validate \
   .github/workflows/ci.yml
 ```
 
+Use `--event push`, `--event pull_request`, `--event workflow_dispatch`, or `--event schedule` instead of `--event-path` to evaluate the hosted profile with a generated minimal snapshot. Generated snapshots are compatibility test inputs, not equivalents to real payloads. The options are mutually exclusive.
+
 The results mean:
 
-- **Compilable**: Syntax and the static job graph can be translated.
+- **Compilable**: Syntax, declared triggers, and the static job graph can be translated.
 - **Not applicable**: The workflow does not declare the selected event, so upload would skip it without compiling it.
 - **Admitted**: Resolved actions and generated plans pass production policy.
 - **Runtime-proven**: Repository tests or hosted evidence have executed the behavior.

--- a/internal/buildkite/triggers.go
+++ b/internal/buildkite/triggers.go
@@ -67,6 +67,17 @@ func TranslateTriggerCondition(triggers []workflow.Trigger) (string, error) {
 	return strings.Join(terms, " || "), nil
 }
 
+// ValidateTriggerConditions validates every trigger using the same translation
+// rules as pipeline generation without selecting an effective event.
+func ValidateTriggerConditions(triggers []workflow.Trigger) error {
+	for _, trigger := range triggers {
+		if _, _, err := translateTrigger(trigger, liveTriggerContext(trigger.Event)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // TranslateEventTriggerCondition validates every trigger but emits a
 // condition only for the selected effective event. A false applicable result
 // means the workflow must not be compiled for that event.

--- a/internal/buildkite/triggers_test.go
+++ b/internal/buildkite/triggers_test.go
@@ -51,6 +51,15 @@ func TestTranslateTriggerConditionRequiresDirectBuildSource(t *testing.T) {
 	}
 }
 
+func TestValidateTriggerConditionsAllowsReusableOnlyWorkflow(t *testing.T) {
+	if err := ValidateTriggerConditions([]workflow.Trigger{{Event: "workflow_call"}}); err != nil {
+		t.Fatalf("ValidateTriggerConditions(workflow_call) error = %v", err)
+	}
+	if err := ValidateTriggerConditions([]workflow.Trigger{{Event: "issues"}}); err == nil || !strings.Contains(err.Error(), "unsupported GitHub trigger") {
+		t.Fatalf("ValidateTriggerConditions(issues) error = %v", err)
+	}
+}
+
 func TestTranslateEventTriggerConditionSelectsOnlyEffectiveEvent(t *testing.T) {
 	triggers := []workflow.Trigger{
 		{Event: "push", Branches: []string{"main"}},

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -55,7 +55,7 @@ Run "buildkite-gha help <command>" for command help.
 `
 
 var commandUsage = map[string]string{
-	"validate": "Usage: buildkite-gha validate [--event-path <path>] [--profile hosted] [--format text|json] <workflow>\n",
+	"validate": "Usage: buildkite-gha validate [--profile hosted] [--event <name> | --event-path <path>] [--format text|json] <workflow>\n",
 	"compile":  "Usage: buildkite-gha compile --event-path <path> [--format pipeline|ir-json] <workflow>\n",
 	"upload":   "Usage: buildkite-gha upload [--event-path <path>] [--runner-queue <runs-on>=<queue>]... [--runner-image <runs-on>=<immutable-image>]... [--runtime-distribution <platform>=<absolute-path>]... [--experimental-runner-user] [--runtime-queue hosted] [--] <workflow-path> [<workflow-path>...]\n",
 	"run-job":  "Usage: buildkite-gha run-job (--plan <path> | --plan-digest <digest> --plan-producer <step>) [--result <path>] [--hosted-tool-cache]\n",
@@ -65,7 +65,7 @@ func writeCommandHelp(stdout io.Writer, command string) {
 	_, _ = fmt.Fprint(stdout, commandUsage[command])
 	switch command {
 	case "validate":
-		_, _ = fmt.Fprint(stdout, "\nThe hosted profile resolves actions and applies production upload policy without executing jobs or proving arbitrary action runtime compatibility.\n")
+		_, _ = fmt.Fprint(stdout, "\nWithout --profile, validate checks event-independent syntax, the static graph, and every declared trigger; it does not evaluate hosted admission. The hosted profile resolves actions and applies production upload policy without executing jobs or proving arbitrary action runtime compatibility. Use --event-path for an exact snapshot, or --event to generate a minimal compatibility snapshot for push, pull_request, workflow_dispatch, or schedule. Generated snapshots are test inputs, not substitutes for real payloads.\n")
 	case "compile":
 		_, _ = fmt.Fprint(stdout, "\nPipeline output references content-addressed plans; compile does not materialize or upload those artifacts.\n")
 	case "upload":
@@ -1295,12 +1295,12 @@ func verifyBuildkiteTarget(job plan.Job) error {
 }
 
 func validate(args []string, stdout, stderr io.Writer, version string, agent transport.Agent) int {
-	workflowPath, eventPath, format, profile, err := validateArgs(args)
+	workflowPath, eventPath, eventName, format, profile, err := validateArgs(args)
 	if err != nil {
 		return usageError(stderr, "validate: %v", err)
 	}
-	if profile != "" && eventPath == "" {
-		return usageError(stderr, "validate: --event-path is required with --profile")
+	if profile != "" && eventPath == "" && eventName == "" {
+		return usageError(stderr, "validate: --profile hosted requires --event or --event-path; use bare validate <workflow> for event-independent syntax and trigger compatibility validation")
 	}
 	out := newProcessingOutput("validate", format, stdout, stderr, agent)
 	var loadEvent func() ([]byte, error)
@@ -1309,6 +1309,9 @@ func validate(args []string, stdout, stderr io.Writer, version string, agent tra
 		if parsedEvent, parseErr := compiler.ParseEvent(event); eventErr == nil && parseErr == nil {
 			out.sourceLinks = sourceLinksForEvent(parsedEvent)
 		}
+		loadEvent = func() ([]byte, error) { return event, eventErr }
+	} else if eventName != "" {
+		event, eventErr := generatedEventSnapshot(eventName)
 		loadEvent = func() ([]byte, error) { return event, eventErr }
 	}
 	source, event, ok := loadProcessingInputs(out, workflowPath, profile, "event input could not be read", loadEvent)
@@ -1342,7 +1345,7 @@ func validate(args []string, stdout, stderr io.Writer, version string, agent tra
 		hosted := hostedOptions("", nil, nil)
 		validationOptions = &hosted
 	}
-	processingReport, ok := validatedProcessingReportWithOptions(out, workflowPath, profile, source, event, eventPath != "", validationOptions)
+	processingReport, ok := validatedProcessingReportWithOptions(out, workflowPath, profile, source, event, loadEvent != nil, validationOptions)
 	if !ok {
 		return 1
 	}
@@ -1394,44 +1397,106 @@ func validate(args []string, stdout, stderr io.Writer, version string, agent tra
 	return 0
 }
 
-func validateArgs(args []string) (workflowPath, eventPath, format, profile string, err error) {
+func validateArgs(args []string) (workflowPath, eventPath, eventName, format, profile string, err error) {
 	format = "text"
-	filtered := make([]string, 0, len(args))
 	formatSeen := false
 	profileSeen := false
+	eventPathSeen := false
+	eventSeen := false
 	for i := 0; i < len(args); i++ {
-		if args[i] != "--format" && args[i] != "--profile" {
-			filtered = append(filtered, args[i])
+		option := args[i]
+		switch option {
+		case "--format", "--profile", "--event-path", "--event":
+			seen := map[string]bool{"--format": formatSeen, "--profile": profileSeen, "--event-path": eventPathSeen, "--event": eventSeen}[option]
+			if seen {
+				return "", "", "", "", "", fmt.Errorf("%s may only be specified once", option)
+			}
+			i++
+			if i == len(args) {
+				return "", "", "", "", "", fmt.Errorf("%s requires a value", option)
+			}
+		case "-h", "--help":
+			return "", "", "", "", "", fmt.Errorf("help must be requested immediately after the command")
+		default:
+			if strings.HasPrefix(option, "-") {
+				return "", "", "", "", "", fmt.Errorf("unknown option %q", option)
+			}
+			if workflowPath != "" {
+				return "", "", "", "", "", fmt.Errorf("expected one workflow path")
+			}
+			workflowPath = option
 			continue
 		}
-		option := args[i]
-		if option == "--format" && formatSeen {
-			return "", "", "", "", fmt.Errorf("--format may only be specified once")
-		}
-		if option == "--profile" && profileSeen {
-			return "", "", "", "", fmt.Errorf("--profile may only be specified once")
-		}
-		i++
-		if i == len(args) {
-			return "", "", "", "", fmt.Errorf("%s requires a value", option)
-		}
-		if option == "--format" {
+		switch option {
+		case "--format":
 			formatSeen = true
 			format = args[i]
 			if format != "text" && format != "json" {
-				return "", "", "", "", fmt.Errorf("--format must be text or json")
+				return "", "", "", "", "", fmt.Errorf("--format must be text or json")
 			}
-		} else {
+		case "--profile":
 			profileSeen = true
 			profile = args[i]
 			if profile != hostedProfile && profile != legacyHostedTokenlessProfile {
-				return "", "", "", "", fmt.Errorf("--profile must be %q", hostedProfile)
+				return "", "", "", "", "", fmt.Errorf("--profile must be %q", hostedProfile)
 			}
 			profile = hostedProfile
+		case "--event-path":
+			eventPathSeen = true
+			eventPath = args[i]
+		case "--event":
+			eventSeen = true
+			eventName = args[i]
 		}
 	}
-	workflowPath, eventPath, err = workflowArgs(filtered)
-	return workflowPath, eventPath, format, profile, err
+	if workflowPath == "" {
+		return "", "", "", "", "", fmt.Errorf("workflow path is required")
+	}
+	if eventPathSeen && eventSeen {
+		return "", "", "", "", "", fmt.Errorf("--event and --event-path are mutually exclusive")
+	}
+	if eventSeen && profile == "" {
+		return "", "", "", "", "", fmt.Errorf("--event requires --profile hosted")
+	}
+	if eventSeen && !slices.Contains([]string{"push", "pull_request", "workflow_dispatch", "schedule"}, eventName) {
+		return "", "", "", "", "", fmt.Errorf("unsupported --event %q; supported events are push, pull_request, workflow_dispatch, and schedule", eventName)
+	}
+	return workflowPath, eventPath, eventName, format, profile, nil
+}
+
+func generatedEventSnapshot(name string) ([]byte, error) {
+	event := struct {
+		Provider   string              `json:"provider"`
+		Event      string              `json:"event"`
+		Repository compiler.Repository `json:"repository"`
+		Ref        string              `json:"ref"`
+		SHA        string              `json:"sha"`
+		Actor      string              `json:"actor"`
+		Payload    map[string]any      `json:"payload"`
+	}{
+		Provider: "github", Event: name,
+		Repository: compiler.Repository{Owner: "example", Name: "repository", CloneURL: "https://github.com/example/repository.git", DefaultBranch: "main"},
+		Ref:        "refs/heads/main", SHA: strings.Repeat("0", 40), Actor: "buildkite-gha", Payload: map[string]any{},
+	}
+	switch name {
+	case "push":
+		event.Payload["ref"] = event.Ref
+	case "pull_request":
+		event.Ref = "refs/pull/1/merge"
+		event.Payload["action"] = "opened"
+		event.Payload["number"] = 1
+		event.Payload["pull_request"] = map[string]any{
+			"number": 1,
+			"base":   map[string]any{"ref": "main"},
+			"head":   map[string]any{"ref": "example"},
+		}
+	case "schedule":
+		event.Payload["schedule"] = "0 0 * * *"
+	case "workflow_dispatch":
+	default:
+		return nil, fmt.Errorf("unsupported generated event %q; supported events are push, pull_request, workflow_dispatch, and schedule", name)
+	}
+	return json.Marshal(event)
 }
 
 func compile(args []string, stdout, stderr io.Writer, version string, agent transport.Agent) int {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -55,7 +55,7 @@ Run "buildkite-gha help <command>" for command help.
 `
 
 var commandUsage = map[string]string{
-	"validate": "Usage: buildkite-gha validate [--profile hosted] [--event <name> | --event-path <path>] [--format text|json] <workflow>\n",
+	"validate": "Usage: buildkite-gha validate [--profile hosted] [--event <name> | --event-path <path> | --all-events] [--format text|json] <workflow>\n",
 	"compile":  "Usage: buildkite-gha compile --event-path <path> [--format pipeline|ir-json] <workflow>\n",
 	"upload":   "Usage: buildkite-gha upload [--event-path <path>] [--runner-queue <runs-on>=<queue>]... [--runner-image <runs-on>=<immutable-image>]... [--runtime-distribution <platform>=<absolute-path>]... [--experimental-runner-user] [--runtime-queue hosted] [--] <workflow-path> [<workflow-path>...]\n",
 	"run-job":  "Usage: buildkite-gha run-job (--plan <path> | --plan-digest <digest> --plan-producer <step>) [--result <path>] [--hosted-tool-cache]\n",
@@ -65,7 +65,7 @@ func writeCommandHelp(stdout io.Writer, command string) {
 	_, _ = fmt.Fprint(stdout, commandUsage[command])
 	switch command {
 	case "validate":
-		_, _ = fmt.Fprint(stdout, "\nWithout --profile, validate checks event-independent syntax, the static graph, and every declared trigger; it does not evaluate hosted admission. The hosted profile resolves actions and applies production upload policy without executing jobs or proving arbitrary action runtime compatibility. Use --event-path for an exact snapshot, or --event to generate a minimal compatibility snapshot for push, pull_request, workflow_dispatch, or schedule. Generated snapshots are test inputs, not substitutes for real payloads.\n")
+		_, _ = fmt.Fprint(stdout, "\nWithout --profile, validate checks event-independent syntax, the static graph, and every declared trigger; it does not evaluate hosted admission. The hosted profile resolves actions and applies production upload policy without executing jobs or proving arbitrary action runtime compatibility. Use --event-path for an exact snapshot, --event to generate one minimal compatibility snapshot, or --all-events to evaluate every declared supported event separately. Generated snapshots are test inputs, not substitutes for real payloads.\n")
 	case "compile":
 		_, _ = fmt.Fprint(stdout, "\nPipeline output references content-addressed plans; compile does not materialize or upload those artifacts.\n")
 	case "upload":
@@ -1295,14 +1295,21 @@ func verifyBuildkiteTarget(job plan.Job) error {
 }
 
 func validate(args []string, stdout, stderr io.Writer, version string, agent transport.Agent) int {
-	workflowPath, eventPath, eventName, format, profile, err := validateArgs(args)
+	workflowPath, eventPath, eventName, format, profile, allEvents, err := validateArgs(args)
 	if err != nil {
 		return usageError(stderr, "validate: %v", err)
 	}
-	if profile != "" && eventPath == "" && eventName == "" {
-		return usageError(stderr, "validate: --profile hosted requires --event or --event-path; use bare validate <workflow> for event-independent syntax and trigger compatibility validation")
+	if profile != "" && eventPath == "" && eventName == "" && !allEvents {
+		return usageError(stderr, "validate: --profile hosted requires --event, --event-path, or --all-events; use bare validate <workflow> for event-independent syntax and trigger compatibility validation")
 	}
 	out := newProcessingOutput("validate", format, stdout, stderr, agent)
+	if allEvents {
+		return validateAllEvents(out, workflowPath, version, stderr)
+	}
+	return validateOne(out, workflowPath, eventPath, eventName, profile, version, stderr)
+}
+
+func validateOne(out processingOutput, workflowPath, eventPath, eventName, profile, version string, stderr io.Writer) int {
 	var loadEvent func() ([]byte, error)
 	if eventPath != "" {
 		event, eventErr := os.ReadFile(eventPath)
@@ -1397,32 +1404,98 @@ func validate(args []string, stdout, stderr io.Writer, version string, agent tra
 	return 0
 }
 
-func validateArgs(args []string) (workflowPath, eventPath, eventName, format, profile string, err error) {
+func validateAllEvents(out processingOutput, workflowPath, version string, stderr io.Writer) int {
+	source, err := os.ReadFile(workflowPath)
+	if err != nil {
+		validation := compatibility.EnvironmentProcessingReport(workflowPath, "", "workflow input could not be read")
+		report := compatibility.NewProcessingReportV3(workflowPath, hostedProfile, validation)
+		_ = out.writeV3(report)
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: %v\n", err)
+		return 1
+	}
+	validation, validationErr := compiler.Validate(workflowPath, source)
+	validationReport := compatibility.InitialProcessingReport(workflowPath, "", false, validation, validationErr)
+	if validationErr != nil {
+		validationReport.Result = "incompatible"
+		report := compatibility.NewProcessingReportV3(workflowPath, hostedProfile, validationReport)
+		if out.writeV3(report) != nil {
+			return 1
+		}
+		return 1
+	}
+	validationReport.Result = "compilable"
+	report := compatibility.NewProcessingReportV3(workflowPath, hostedProfile, validationReport)
+	parsed, err := workflow.Parse(workflowPath, source)
+	if err != nil {
+		return 1
+	}
+	declared := make(map[string]bool, len(parsed.Triggers))
+	for _, trigger := range parsed.Triggers {
+		declared[trigger.Event] = true
+	}
+	failed := false
+	for _, event := range []string{"push", "pull_request", "workflow_dispatch", "schedule"} {
+		if !declared[event] {
+			continue
+		}
+		var eventReport *compatibility.ProcessingReport
+		eventOut := processingOutput{
+			command: "validate", format: "json", reports: io.Discard, stderr: stderr,
+			observe: func(observed compatibility.ProcessingReport) { eventReport = &observed },
+		}
+		if code := validateOne(eventOut, workflowPath, "", event, hostedProfile, version, stderr); code != 0 {
+			failed = true
+		}
+		if eventReport == nil {
+			return 1
+		}
+		report.Evaluations = append(report.Evaluations, compatibility.EventEvaluation{
+			Event: event, Source: "generated", Report: *eventReport,
+		})
+	}
+	if out.writeV3(report) != nil {
+		return 1
+	}
+	if failed {
+		return 1
+	}
+	return 0
+}
+
+func validateArgs(args []string) (workflowPath, eventPath, eventName, format, profile string, allEvents bool, err error) {
 	format = "text"
 	formatSeen := false
 	profileSeen := false
 	eventPathSeen := false
 	eventSeen := false
+	allEventsSeen := false
 	for i := 0; i < len(args); i++ {
 		option := args[i]
 		switch option {
 		case "--format", "--profile", "--event-path", "--event":
 			seen := map[string]bool{"--format": formatSeen, "--profile": profileSeen, "--event-path": eventPathSeen, "--event": eventSeen}[option]
 			if seen {
-				return "", "", "", "", "", fmt.Errorf("%s may only be specified once", option)
+				return "", "", "", "", "", false, fmt.Errorf("%s may only be specified once", option)
 			}
 			i++
 			if i == len(args) {
-				return "", "", "", "", "", fmt.Errorf("%s requires a value", option)
+				return "", "", "", "", "", false, fmt.Errorf("%s requires a value", option)
 			}
+		case "--all-events":
+			if allEventsSeen {
+				return "", "", "", "", "", false, fmt.Errorf("--all-events may only be specified once")
+			}
+			allEventsSeen = true
+			allEvents = true
+			continue
 		case "-h", "--help":
-			return "", "", "", "", "", fmt.Errorf("help must be requested immediately after the command")
+			return "", "", "", "", "", false, fmt.Errorf("help must be requested immediately after the command")
 		default:
 			if strings.HasPrefix(option, "-") {
-				return "", "", "", "", "", fmt.Errorf("unknown option %q", option)
+				return "", "", "", "", "", false, fmt.Errorf("unknown option %q", option)
 			}
 			if workflowPath != "" {
-				return "", "", "", "", "", fmt.Errorf("expected one workflow path")
+				return "", "", "", "", "", false, fmt.Errorf("expected one workflow path")
 			}
 			workflowPath = option
 			continue
@@ -1432,13 +1505,13 @@ func validateArgs(args []string) (workflowPath, eventPath, eventName, format, pr
 			formatSeen = true
 			format = args[i]
 			if format != "text" && format != "json" {
-				return "", "", "", "", "", fmt.Errorf("--format must be text or json")
+				return "", "", "", "", "", false, fmt.Errorf("--format must be text or json")
 			}
 		case "--profile":
 			profileSeen = true
 			profile = args[i]
 			if profile != hostedProfile && profile != legacyHostedTokenlessProfile {
-				return "", "", "", "", "", fmt.Errorf("--profile must be %q", hostedProfile)
+				return "", "", "", "", "", false, fmt.Errorf("--profile must be %q", hostedProfile)
 			}
 			profile = hostedProfile
 		case "--event-path":
@@ -1450,18 +1523,24 @@ func validateArgs(args []string) (workflowPath, eventPath, eventName, format, pr
 		}
 	}
 	if workflowPath == "" {
-		return "", "", "", "", "", fmt.Errorf("workflow path is required")
+		return "", "", "", "", "", false, fmt.Errorf("workflow path is required")
 	}
 	if eventPathSeen && eventSeen {
-		return "", "", "", "", "", fmt.Errorf("--event and --event-path are mutually exclusive")
+		return "", "", "", "", "", false, fmt.Errorf("--event and --event-path are mutually exclusive")
 	}
 	if eventSeen && profile == "" {
-		return "", "", "", "", "", fmt.Errorf("--event requires --profile hosted")
+		return "", "", "", "", "", false, fmt.Errorf("--event requires --profile hosted")
 	}
 	if eventSeen && !slices.Contains([]string{"push", "pull_request", "workflow_dispatch", "schedule"}, eventName) {
-		return "", "", "", "", "", fmt.Errorf("unsupported --event %q; supported events are push, pull_request, workflow_dispatch, and schedule", eventName)
+		return "", "", "", "", "", false, fmt.Errorf("unsupported --event %q; supported events are push, pull_request, workflow_dispatch, and schedule", eventName)
 	}
-	return workflowPath, eventPath, eventName, format, profile, nil
+	if allEvents && (eventPathSeen || eventSeen) {
+		return "", "", "", "", "", false, fmt.Errorf("--all-events is mutually exclusive with --event and --event-path")
+	}
+	if allEvents && profile == "" {
+		return "", "", "", "", "", false, fmt.Errorf("--all-events requires --profile hosted")
+	}
+	return workflowPath, eventPath, eventName, format, profile, allEvents, nil
 }
 
 func generatedEventSnapshot(name string) ([]byte, error) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1178,6 +1178,42 @@ func TestRunValidateAndCompile(t *testing.T) {
 		}
 	})
 
+	t.Run("validate checks every trigger without an event", func(t *testing.T) {
+		tests := []struct {
+			name, trigger, want string
+		}{
+			{name: "unsupported event", trigger: "issues", want: `unsupported GitHub trigger event "issues"`},
+			{name: "path filter", trigger: "push:\n    paths: [src/**]", want: "path filters are unsupported"},
+			{name: "mixed branch filters", trigger: "push:\n    branches: [main]\n    branches-ignore: [release]", want: "include and ignore filters cannot be combined"},
+			{name: "pull request tag filter", trigger: "pull_request:\n    tags: [v1]", want: "pull_request tag filters are unsupported"},
+			{name: "pull request activity", trigger: "pull_request:\n    types: [auto_merge_enabled, submitted]", want: `activity type "submitted" cannot be mapped exactly`},
+		}
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				workflow := filepath.Join(t.TempDir(), "trigger.yml")
+				source := "on:\n  " + test.trigger + "\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"
+				if err := os.WriteFile(workflow, []byte(source), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				var stdout, stderr bytes.Buffer
+				if code := Run([]string{"validate", "--format", "json", workflow}, &stdout, &stderr, "dev"); code != 1 {
+					t.Fatalf("Run() code = %d, want 1; stderr = %q", code, stderr.String())
+				}
+				var report compatibility.ProcessingReport
+				if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+					t.Fatal(err)
+				}
+				pipelineFailed := false
+				for _, stage := range report.Stages {
+					pipelineFailed = pipelineFailed || stage.ID == string(compiler.StagePipeline) && stage.Result == compatibility.Failed
+				}
+				if report.Result != "incompatible" || !pipelineFailed || len(report.Diagnostics) != 1 || report.Diagnostics[0].Stage != string(compiler.StagePipeline) || !strings.Contains(report.Diagnostics[0].Message+report.Diagnostics[0].Detail, test.want) {
+					t.Fatalf("report = %#v, want trigger failure containing %q", report, test.want)
+				}
+			})
+		}
+	})
+
 	t.Run("validate json", func(t *testing.T) {
 		var stdout, stderr bytes.Buffer
 		if code := Run([]string{"validate", "--format", "json", workflowPath}, &stdout, &stderr, "dev"); code != 0 {
@@ -1239,6 +1275,29 @@ func TestRunValidateAndCompile(t *testing.T) {
 		}
 		if report.Result != "admitted" || report.Profile != "hosted" || report.Compile.Instances != 3 || report.Admission.Result != "admitted" || len(report.Diagnostics) != 0 {
 			t.Fatalf("profile report = %#v", report)
+		}
+	})
+
+	t.Run("validate hosted profile with generated events", func(t *testing.T) {
+		workflow := filepath.Join(t.TempDir(), "events.yml")
+		if err := os.WriteFile(workflow, []byte("on:\n  push:\n  pull_request:\n  workflow_dispatch:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		for _, event := range []string{"push", "pull_request", "workflow_dispatch", "schedule"} {
+			t.Run(event, func(t *testing.T) {
+				var stdout, stderr bytes.Buffer
+				args := []string{"validate", "--profile", "hosted", "--event", event, "--format", "json", workflow}
+				if code := Run(args, &stdout, &stderr, "dev"); code != 0 {
+					t.Fatalf("Run() code = %d, stderr = %q", code, stderr.String())
+				}
+				var report compatibility.ProcessingReport
+				if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+					t.Fatal(err)
+				}
+				if report.Result != "admitted" || report.Profile != "hosted" || report.Admission.Result != "admitted" {
+					t.Fatalf("profile report = %#v", report)
+				}
+			})
 		}
 	})
 
@@ -1320,7 +1379,7 @@ func TestRunValidateAndCompile(t *testing.T) {
 
 	t.Run("validate profile requires event", func(t *testing.T) {
 		var stdout, stderr bytes.Buffer
-		if code := Run([]string{"validate", "--profile", "hosted", workflowPath}, &stdout, &stderr, "dev"); code != 2 || !strings.Contains(stderr.String(), "--event-path is required with --profile") {
+		if code := Run([]string{"validate", "--profile", "hosted", workflowPath}, &stdout, &stderr, "dev"); code != 2 || !strings.Contains(stderr.String(), "use bare validate <workflow> for event-independent syntax and trigger compatibility validation") {
 			t.Fatalf("Run() code = %d, stderr = %q", code, stderr.String())
 		}
 	})
@@ -7544,17 +7603,26 @@ func TestArgumentParsersRejectRepeatedOptions(t *testing.T) {
 	if _, _, err := workflowArgs([]string{"--event-path", "one", "--event-path", "two", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
 		t.Fatalf("workflowArgs() error = %v, want duplicate option error", err)
 	}
-	if _, _, _, _, err := validateArgs([]string{"--format", "json", "--format", "text", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
+	if _, _, _, _, _, err := validateArgs([]string{"--format", "json", "--format", "text", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
 		t.Fatalf("validateArgs() error = %v, want duplicate format error", err)
 	}
-	if _, _, _, _, err := validateArgs([]string{"--profile", "hosted", "--profile", "hosted", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
+	if _, _, _, _, _, err := validateArgs([]string{"--profile", "hosted", "--profile", "hosted", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
 		t.Fatalf("validateArgs() error = %v, want duplicate profile error", err)
 	}
-	if _, _, _, profile, err := validateArgs([]string{"--profile", "hosted-tokenless", "workflow.yml"}); err != nil || profile != "hosted" {
+	if _, _, _, _, profile, err := validateArgs([]string{"--profile", "hosted-tokenless", "workflow.yml"}); err != nil || profile != "hosted" {
 		t.Fatalf("validateArgs() legacy profile = %q, %v", profile, err)
 	}
-	if _, _, _, _, err := validateArgs([]string{"--profile", "unknown", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), `must be "hosted"`) {
+	if _, _, _, _, _, err := validateArgs([]string{"--profile", "unknown", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), `must be "hosted"`) {
 		t.Fatalf("validateArgs() error = %v, want unknown profile error", err)
+	}
+	if _, _, _, _, _, err := validateArgs([]string{"--profile", "hosted", "--event", "push", "--event-path", "event.json", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("validateArgs() error = %v, want mutually exclusive event inputs", err)
+	}
+	if _, _, _, _, _, err := validateArgs([]string{"--event", "push", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "requires --profile hosted") {
+		t.Fatalf("validateArgs() error = %v, want profile requirement", err)
+	}
+	if _, _, _, _, _, err := validateArgs([]string{"--profile", "hosted", "--event", "issues", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "supported events") {
+		t.Fatalf("validateArgs() error = %v, want supported event list", err)
 	}
 	if _, _, _, err := compileArgs([]string{"--format", "pipeline", "--format", "ir-json", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
 		t.Fatalf("compileArgs() error = %v, want duplicate format error", err)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1301,6 +1301,49 @@ func TestRunValidateAndCompile(t *testing.T) {
 		}
 	})
 
+	t.Run("validate hosted profile with all generated events", func(t *testing.T) {
+		workflow := filepath.Join(t.TempDir(), "events.yml")
+		if err := os.WriteFile(workflow, []byte("on:\n  push:\n  pull_request:\n  workflow_dispatch:\n  schedule:\n    - cron: '0 0 * * *'\n  workflow_call:\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		var stdout, stderr bytes.Buffer
+		args := []string{"validate", "--profile", "hosted", "--all-events", "--format", "json", workflow}
+		if code := Run(args, &stdout, &stderr, "dev"); code != 0 {
+			t.Fatalf("Run() code = %d, stderr = %q", code, stderr.String())
+		}
+		var report compatibility.ProcessingReportV3
+		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+			t.Fatal(err)
+		}
+		if report.Schema != compatibility.ProcessingSchemaV3 || report.Result != "admitted" || report.Status != compatibility.Passed || report.Validation.Result != "compilable" || len(report.Evaluations) != 4 {
+			t.Fatalf("aggregate report = %#v", report)
+		}
+		for i, event := range []string{"push", "pull_request", "workflow_dispatch", "schedule"} {
+			if report.Evaluations[i].Event != event || report.Evaluations[i].Source != "generated" || report.Evaluations[i].Report.Result != "admitted" {
+				t.Fatalf("evaluation %d = %#v", i, report.Evaluations[i])
+			}
+		}
+	})
+
+	t.Run("validate all events stops before admission on an unsafe trigger", func(t *testing.T) {
+		workflow := filepath.Join(t.TempDir(), "events.yml")
+		if err := os.WriteFile(workflow, []byte("on:\n  push:\n    paths: [src/**]\n  pull_request:\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		var stdout, stderr bytes.Buffer
+		args := []string{"validate", "--profile", "hosted", "--all-events", "--format", "json", workflow}
+		if code := Run(args, &stdout, &stderr, "dev"); code != 1 {
+			t.Fatalf("Run() code = %d, want 1; stderr = %q", code, stderr.String())
+		}
+		var report compatibility.ProcessingReportV3
+		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+			t.Fatal(err)
+		}
+		if report.Result != "incompatible" || len(report.Evaluations) != 0 || len(report.Validation.Diagnostics) != 1 || !strings.Contains(report.Validation.Diagnostics[0].Message, "path filters are unsupported") {
+			t.Fatalf("aggregate report = %#v", report)
+		}
+	})
+
 	t.Run("validate hosted profile applies upload trigger policy", func(t *testing.T) {
 		workflow := filepath.Join(t.TempDir(), "issues.yml")
 		if err := os.WriteFile(workflow, []byte("on: issues\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
@@ -7603,26 +7646,32 @@ func TestArgumentParsersRejectRepeatedOptions(t *testing.T) {
 	if _, _, err := workflowArgs([]string{"--event-path", "one", "--event-path", "two", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
 		t.Fatalf("workflowArgs() error = %v, want duplicate option error", err)
 	}
-	if _, _, _, _, _, err := validateArgs([]string{"--format", "json", "--format", "text", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
+	if _, _, _, _, _, _, err := validateArgs([]string{"--format", "json", "--format", "text", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
 		t.Fatalf("validateArgs() error = %v, want duplicate format error", err)
 	}
-	if _, _, _, _, _, err := validateArgs([]string{"--profile", "hosted", "--profile", "hosted", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
+	if _, _, _, _, _, _, err := validateArgs([]string{"--profile", "hosted", "--profile", "hosted", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
 		t.Fatalf("validateArgs() error = %v, want duplicate profile error", err)
 	}
-	if _, _, _, _, profile, err := validateArgs([]string{"--profile", "hosted-tokenless", "workflow.yml"}); err != nil || profile != "hosted" {
+	if _, _, _, _, profile, _, err := validateArgs([]string{"--profile", "hosted-tokenless", "workflow.yml"}); err != nil || profile != "hosted" {
 		t.Fatalf("validateArgs() legacy profile = %q, %v", profile, err)
 	}
-	if _, _, _, _, _, err := validateArgs([]string{"--profile", "unknown", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), `must be "hosted"`) {
+	if _, _, _, _, _, _, err := validateArgs([]string{"--profile", "unknown", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), `must be "hosted"`) {
 		t.Fatalf("validateArgs() error = %v, want unknown profile error", err)
 	}
-	if _, _, _, _, _, err := validateArgs([]string{"--profile", "hosted", "--event", "push", "--event-path", "event.json", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+	if _, _, _, _, _, _, err := validateArgs([]string{"--profile", "hosted", "--event", "push", "--event-path", "event.json", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
 		t.Fatalf("validateArgs() error = %v, want mutually exclusive event inputs", err)
 	}
-	if _, _, _, _, _, err := validateArgs([]string{"--event", "push", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "requires --profile hosted") {
+	if _, _, _, _, _, _, err := validateArgs([]string{"--event", "push", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "requires --profile hosted") {
 		t.Fatalf("validateArgs() error = %v, want profile requirement", err)
 	}
-	if _, _, _, _, _, err := validateArgs([]string{"--profile", "hosted", "--event", "issues", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "supported events") {
+	if _, _, _, _, _, _, err := validateArgs([]string{"--profile", "hosted", "--event", "issues", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "supported events") {
 		t.Fatalf("validateArgs() error = %v, want supported event list", err)
+	}
+	if _, _, _, _, _, _, err := validateArgs([]string{"--profile", "hosted", "--all-events", "--event", "push", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("validateArgs() error = %v, want mutually exclusive all-events input", err)
+	}
+	if _, _, _, _, _, _, err := validateArgs([]string{"--all-events", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "requires --profile hosted") {
+		t.Fatalf("validateArgs() error = %v, want all-events profile requirement", err)
 	}
 	if _, _, _, err := compileArgs([]string{"--format", "pipeline", "--format", "ir-json", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
 		t.Fatalf("compileArgs() error = %v, want duplicate format error", err)

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -102,6 +102,24 @@ func (o processingOutput) write(report compatibility.ProcessingReport) error {
 	return nil
 }
 
+func (o processingOutput) writeV3(report compatibility.ProcessingReportV3) error {
+	if err := compatibility.WriteProcessingV3(o.reports, o.format, report); err != nil {
+		_, _ = fmt.Fprintf(o.stderr, "buildkite-gha: %s: write report: %v\n", o.command, err)
+		return err
+	}
+	combined := report.Validation
+	combined.Profile = report.Profile
+	combined.Diagnostics = append([]compatibility.Diagnostic(nil), report.Validation.Diagnostics...)
+	for _, evaluation := range report.Evaluations {
+		for _, diagnostic := range evaluation.Report.Diagnostics {
+			diagnostic.Message = fmt.Sprintf("Generated %s event: %s", evaluation.Event, diagnostic.Message)
+			combined.Diagnostics = append(combined.Diagnostics, diagnostic)
+		}
+	}
+	o.annotate(combined)
+	return nil
+}
+
 func writePluginProcessing(w io.Writer, report compatibility.ProcessingReport) error {
 	report.Finalize()
 	workflow, _ := processingAnnotationWorkflowPath(report.Workflow, "")

--- a/internal/compatibility/processing_compiler.go
+++ b/internal/compatibility/processing_compiler.go
@@ -96,25 +96,23 @@ func InitialProcessingReport(path, profile string, eventEvaluated bool, report c
 }
 
 func setInitialStageResults(report *ProcessingReport, eventEvaluated bool, failed map[string]bool) {
+	for stage := range failed {
+		report.SetStage(stage, Failed)
+	}
 	workflowFailed := failed[stageWorkflowParsing]
-	if workflowFailed {
-		report.SetStage(stageWorkflowParsing, Failed)
-	} else {
+	if !workflowFailed {
 		report.SetStage(stageWorkflowParsing, Passed)
 	}
 	eventFailed := false
 	if eventEvaluated {
 		eventFailed = failed[stageEventValidation]
-		if eventFailed {
-			report.SetStage(stageEventValidation, Failed)
-		} else {
+		if !eventFailed {
 			report.SetStage(stageEventValidation, Passed)
 		}
 	}
 	blocked := workflowFailed || eventFailed || failed[""]
 	for _, stage := range []string{stageGraph, stageMatrix, stageExpressions, stageDiscovery} {
 		if failed[stage] {
-			report.SetStage(stage, Failed)
 			blocked = true
 			continue
 		}

--- a/internal/compatibility/report_test.go
+++ b/internal/compatibility/report_test.go
@@ -95,6 +95,82 @@ func TestProcessingReportContainsEveryStableStageInTextAndJSON(t *testing.T) {
 	}
 }
 
+func TestProcessingReportV3PreservesPerEventOutcomes(t *testing.T) {
+	validation := NewProcessingReport("ci.yml", "")
+	validation.Result = "compilable"
+	validation.SetStage("workflow-parsing", Passed)
+	push := NewProcessingReport("ci.yml", "hosted")
+	push.Result = "admitted"
+	push.Admission.Result = "admitted"
+	pullRequest := NewProcessingReport("ci.yml", "hosted")
+	pullRequest.Result = "incompatible"
+	pullRequest.SetStage("expression-validation", Failed)
+	pullRequest.Diagnostics = append(pullRequest.Diagnostics, Diagnostic{
+		Level: "error", Code: "E_EXPRESSION", Category: "compatibility",
+		Stage: "expression-validation", Message: "payload field is unsupported",
+	})
+	report := NewProcessingReportV3("ci.yml", "hosted", validation)
+	report.Evaluations = append(report.Evaluations,
+		EventEvaluation{Event: "push", Source: "generated", Report: push},
+		EventEvaluation{Event: "pull_request", Source: "generated", Report: pullRequest},
+	)
+
+	var encoded bytes.Buffer
+	if err := WriteProcessingV3(&encoded, "json", report); err != nil {
+		t.Fatal(err)
+	}
+	var decoded ProcessingReportV3
+	if err := json.Unmarshal(encoded.Bytes(), &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Schema != ProcessingSchemaV3 || decoded.Result != "incompatible" || decoded.Status != Failed || len(decoded.Evaluations) != 2 || decoded.Evaluations[0].Report.Result != "admitted" || decoded.Evaluations[1].Report.Result != "incompatible" {
+		t.Fatalf("decoded report = %#v", decoded)
+	}
+	v2Source, err := os.ReadFile(filepath.Join("..", "..", "schemas", "processing-report-v2.schema.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	v3Source, err := os.ReadFile(filepath.Join("..", "..", "schemas", "processing-report-v3.schema.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var v2Document, v3Document any
+	if err := json.Unmarshal(v2Source, &v2Document); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(v3Source, &v3Document); err != nil {
+		t.Fatal(err)
+	}
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource("https://buildkite.com/schemas/buildkite-gha/processing-report-v2.schema.json", v2Document); err != nil {
+		t.Fatal(err)
+	}
+	if err := compiler.AddResource("processing-report-v3.schema.json", v3Document); err != nil {
+		t.Fatal(err)
+	}
+	schema, err := compiler.Compile("processing-report-v3.schema.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document any
+	if err := json.Unmarshal(encoded.Bytes(), &document); err != nil {
+		t.Fatal(err)
+	}
+	if err := schema.Validate(document); err != nil {
+		t.Fatalf("processing report does not satisfy v3 schema: %v", err)
+	}
+
+	var rendered bytes.Buffer
+	if err := WriteProcessingV3(&rendered, "text", report); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"processing-report/v3", "Event-independent validation:", "Generated event push:", "Generated event pull_request:", "Result: incompatible"} {
+		if !strings.Contains(rendered.String(), want) {
+			t.Fatalf("text report = %q, want %q", rendered.String(), want)
+		}
+	}
+}
+
 func TestProcessingReportV1RemainsStrictWithoutDetail(t *testing.T) {
 	report := NewProcessingReport("ci.yml", "")
 	report.Diagnostics = append(report.Diagnostics, Diagnostic{

--- a/internal/compatibility/report_v3.go
+++ b/internal/compatibility/report_v3.go
@@ -1,0 +1,122 @@
+package compatibility
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// ProcessingSchemaV3 is the aggregate report emitted by multi-event
+// validation. Each evaluation retains one complete v2 processing report.
+const ProcessingSchemaV3 = "buildkite-gha/processing-report/v3"
+
+// EventEvaluation records hosted validation for one generated event snapshot.
+type EventEvaluation struct {
+	Event  string           `json:"event"`
+	Source string           `json:"event_source"`
+	Report ProcessingReport `json:"report"`
+}
+
+// ProcessingReportV3 preserves event-independent validation separately from
+// each event-specific hosted admission evaluation.
+type ProcessingReportV3 struct {
+	Schema      string            `json:"schema"`
+	Workflow    string            `json:"workflow"`
+	Profile     string            `json:"profile"`
+	Result      string            `json:"result"`
+	Status      string            `json:"status"`
+	Validation  ProcessingReport  `json:"validation"`
+	Evaluations []EventEvaluation `json:"evaluations"`
+}
+
+// NewProcessingReportV3 returns an aggregate report with no event evaluations.
+func NewProcessingReportV3(workflow, profile string, validation ProcessingReport) ProcessingReportV3 {
+	return ProcessingReportV3{
+		Schema: ProcessingSchemaV3, Workflow: workflow, Profile: profile,
+		Validation: validation, Evaluations: []EventEvaluation{},
+	}
+}
+
+// Finalize derives the aggregate outcome without merging event-specific
+// evidence. Admission means every generated event evaluation was admitted.
+func (r *ProcessingReportV3) Finalize() {
+	r.Validation.Finalize()
+	r.Status = r.Validation.Status
+	if r.Validation.Result != "compilable" {
+		r.Result = r.Validation.Result
+		return
+	}
+	if len(r.Evaluations) == 0 {
+		r.Result = "not-applicable"
+		return
+	}
+	r.Result = "admitted"
+	for i := range r.Evaluations {
+		r.Evaluations[i].Report.Finalize()
+		if r.Evaluations[i].Report.Status == Failed {
+			r.Status = Failed
+		}
+		switch r.Evaluations[i].Report.Result {
+		case "indeterminate":
+			r.Result = "indeterminate"
+		case "incompatible":
+			if r.Result != "indeterminate" {
+				r.Result = "incompatible"
+			}
+		case "not-admitted":
+			if r.Result == "admitted" {
+				r.Result = "not-admitted"
+			}
+		case "admitted":
+		default:
+			if r.Result == "admitted" {
+				r.Result = r.Evaluations[i].Report.Result
+			}
+		}
+	}
+}
+
+// WriteProcessingV3 renders an aggregate report in text or deterministic JSON.
+func WriteProcessingV3(w io.Writer, format string, report ProcessingReportV3) error {
+	report.Finalize()
+	switch format {
+	case "text":
+		if _, err := fmt.Fprintf(w, "Schema: %s\nWorkflow: %s\nProfile: %s\nResult: %s\nStatus: %s\n\nEvent-independent validation:\n", report.Schema, report.Workflow, report.Profile, report.Result, report.Status); err != nil {
+			return err
+		}
+		if err := writeIndentedProcessing(w, report.Validation); err != nil {
+			return err
+		}
+		for _, evaluation := range report.Evaluations {
+			if _, err := fmt.Fprintf(w, "\nGenerated event %s:\n", evaluation.Event); err != nil {
+				return err
+			}
+			if err := writeIndentedProcessing(w, evaluation.Report); err != nil {
+				return err
+			}
+		}
+		return nil
+	case "json":
+		encoder := json.NewEncoder(w)
+		encoder.SetEscapeHTML(false)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(report)
+	default:
+		return fmt.Errorf("unsupported processing report format %q", format)
+	}
+}
+
+func writeIndentedProcessing(w io.Writer, report ProcessingReport) error {
+	var rendered bytes.Buffer
+	if err := WriteProcessing(&rendered, "text", report); err != nil {
+		return err
+	}
+	for _, line := range strings.Split(strings.TrimSuffix(rendered.String(), "\n"), "\n") {
+		if _, err := fmt.Fprintf(w, "  %s\n", line); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -21,6 +21,7 @@ import (
 
 	actionintegration "github.com/buildkite/buildkite-gha/internal/action/integration"
 	"github.com/buildkite/buildkite-gha/internal/action/metadata"
+	buildkitepipeline "github.com/buildkite/buildkite-gha/internal/buildkite"
 	"github.com/buildkite/buildkite-gha/internal/expression"
 	"github.com/buildkite/buildkite-gha/internal/plan"
 	"github.com/buildkite/buildkite-gha/internal/workflow"
@@ -210,6 +211,7 @@ func Validate(path string, source []byte) (Report, error) {
 	if err != nil {
 		return Report{}, processingFinding(StageWorkflowParsing, CodeWorkflowSyntax, "syntax", err)
 	}
+	triggerErr := processingFinding(StagePipeline, CodePipelineGeneration, "compatibility", buildkitepipeline.ValidateTriggerConditions(parsed.Triggers))
 	options := defaultOptions()
 	event := Event{
 		Event: "validation", Trust: options.EventTrust,
@@ -224,7 +226,7 @@ func Validate(path string, source []byte) (Report, error) {
 	cancelInProgress, cancellationErr := resolveWorkflowCancellation(path, parsed.Concurrency, context)
 	cancellationErr = processingFinding(StageExpressions, CodeExpressionInvalid, "compatibility", cancellationErr)
 	expanded, expandErr := expand(path, source, parsed, context, options)
-	if err := errors.Join(concurrencyErr, cancellationErr, expandErr); err != nil {
+	if err := errors.Join(triggerErr, concurrencyErr, cancellationErr, expandErr); err != nil {
 		return expansionReport(expanded, compilerWarnings(parsed.Concurrency, cancelInProgress)), err
 	}
 	return expansionReport(expanded, compilerWarnings(parsed.Concurrency, cancelInProgress)), nil

--- a/schemas/processing-report-v3.schema.json
+++ b/schemas/processing-report-v3.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://buildkite.com/schemas/buildkite-gha/processing-report-v3.schema.json",
+  "title": "buildkite-gha processing report v3",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "workflow", "profile", "result", "status", "validation", "evaluations"],
+  "properties": {
+    "schema": {"const": "buildkite-gha/processing-report/v3"},
+    "workflow": {"type": "string", "minLength": 1, "maxLength": 4096},
+    "profile": {"const": "hosted"},
+    "result": {"type": "string", "minLength": 1, "maxLength": 128},
+    "status": {"enum": ["passed", "failed", "not-evaluated"]},
+    "validation": {"$ref": "processing-report-v2.schema.json"},
+    "evaluations": {
+      "type": "array",
+      "maxItems": 4,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["event", "event_source", "report"],
+        "properties": {
+          "event": {"enum": ["push", "pull_request", "workflow_dispatch", "schedule"]},
+          "event_source": {"const": "generated"},
+          "report": {"$ref": "processing-report-v2.schema.json"}
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Why

Users currently need to craft a complete event snapshot before checking hosted workflow compatibility, while bare validation can miss trigger translation failures that upload rejects.

## What

Validate every declared trigger during event-independent validation, and add generated snapshots through `--event` for one event or `--all-events` for every declared supported event. Single-event reports remain v2; all-event validation uses a v3 aggregate that preserves the event-independent report and each event-specific admission result without treating generated payloads as real webhook evidence.
