### PR TITLE
Cache actions during hosted validation

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -59,6 +59,19 @@ buildkite-gha validate \
 
 `--all-events` is mutually exclusive with `--event` and `--event-path`. It does not evaluate `workflow_call` as a standalone event. Admission applies separately to each generated snapshot, not to every possible real payload.
 
+Reuse downloaded immutable action source across profile validation runs:
+
+```sh
+mkdir -p .buildkite-gha-action-cache
+buildkite-gha validate \
+  --profile hosted \
+  --all-events \
+  --action-cache-dir .buildkite-gha-action-cache \
+  .github/workflows/ci.yml
+```
+
+`--action-cache-dir` is available only with `--profile hosted`. The cache stores verified action source by immutable commit. Mutable refs still resolve through GitHub on every run, so a moved tag or branch selects its current commit. Do not share one writable cache between mutually untrusted validation jobs.
+
 Inspect the aggregate result and each event outcome:
 
 ```sh

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -55,7 +55,7 @@ Run "buildkite-gha help <command>" for command help.
 `
 
 var commandUsage = map[string]string{
-	"validate": "Usage: buildkite-gha validate [--profile hosted] [--event <name> | --event-path <path> | --all-events] [--format text|json] <workflow>\n",
+	"validate": "Usage: buildkite-gha validate [--profile hosted] [--event <name> | --event-path <path> | --all-events] [--action-cache-dir <path>] [--format text|json] <workflow>\n",
 	"compile":  "Usage: buildkite-gha compile --event-path <path> [--format pipeline|ir-json] <workflow>\n",
 	"upload":   "Usage: buildkite-gha upload [--event-path <path>] [--runner-queue <runs-on>=<queue>]... [--runner-image <runs-on>=<immutable-image>]... [--runtime-distribution <platform>=<absolute-path>]... [--experimental-runner-user] [--runtime-queue hosted] [--] <workflow-path> [<workflow-path>...]\n",
 	"run-job":  "Usage: buildkite-gha run-job (--plan <path> | --plan-digest <digest> --plan-producer <step>) [--result <path>] [--hosted-tool-cache]\n",
@@ -1295,21 +1295,33 @@ func verifyBuildkiteTarget(job plan.Job) error {
 }
 
 func validate(args []string, stdout, stderr io.Writer, version string, agent transport.Agent) int {
+	args, actionCacheDir, err := validateActionCacheArgs(args)
+	if err != nil {
+		return usageError(stderr, "validate: %v", err)
+	}
 	workflowPath, eventPath, eventName, format, profile, allEvents, err := validateArgs(args)
 	if err != nil {
 		return usageError(stderr, "validate: %v", err)
+	}
+	if actionCacheDir != "" && profile == "" {
+		return usageError(stderr, "validate: --action-cache-dir requires --profile hosted")
+	}
+	if actionCacheDir != "" {
+		if _, err := actionsource.NewStore(actionCacheDir, nil); err != nil {
+			return usageError(stderr, "validate: --action-cache-dir: %v", err)
+		}
 	}
 	if profile != "" && eventPath == "" && eventName == "" && !allEvents {
 		return usageError(stderr, "validate: --profile hosted requires --event, --event-path, or --all-events; use bare validate <workflow> for event-independent syntax and trigger compatibility validation")
 	}
 	out := newProcessingOutput("validate", format, stdout, stderr, agent)
 	if allEvents {
-		return validateAllEvents(out, workflowPath, version, stderr)
+		return validateAllEvents(out, workflowPath, version, actionCacheDir, stderr)
 	}
-	return validateOne(out, workflowPath, eventPath, eventName, profile, version, stderr)
+	return validateOne(out, workflowPath, eventPath, eventName, profile, version, actionCacheDir, stderr)
 }
 
-func validateOne(out processingOutput, workflowPath, eventPath, eventName, profile, version string, stderr io.Writer) int {
+func validateOne(out processingOutput, workflowPath, eventPath, eventName, profile, version, actionCacheDir string, stderr io.Writer) int {
 	var loadEvent func() ([]byte, error)
 	if eventPath != "" {
 		event, eventErr := os.ReadFile(eventPath)
@@ -1372,7 +1384,7 @@ func validateOne(out processingOutput, workflowPath, eventPath, eventName, profi
 			compiler.PlatformLinuxAMD64:  distributionDigest,
 			compiler.PlatformDarwinARM64: distributionDigest,
 		}
-		preflight, profileErr := compileHosted(ctx, workflowPath, source, event, version, distributionDigest, "buildkite-gha-profile-importer", "", nil, runtimeDistributions, nil)
+		preflight, profileErr := compileHostedWithActionCache(ctx, workflowPath, source, event, version, distributionDigest, "buildkite-gha-profile-importer", "", nil, runtimeDistributions, actionCacheDir, nil)
 		applyHostedPreflight(&processingReport, preflight)
 		if profileErr != nil {
 			if ctx.Err() != nil || errors.Is(profileErr, context.Canceled) {
@@ -1404,7 +1416,7 @@ func validateOne(out processingOutput, workflowPath, eventPath, eventName, profi
 	return 0
 }
 
-func validateAllEvents(out processingOutput, workflowPath, version string, stderr io.Writer) int {
+func validateAllEvents(out processingOutput, workflowPath, version, actionCacheDir string, stderr io.Writer) int {
 	source, err := os.ReadFile(workflowPath)
 	if err != nil {
 		validation := compatibility.EnvironmentProcessingReport(workflowPath, "", "workflow input could not be read")
@@ -1443,7 +1455,7 @@ func validateAllEvents(out processingOutput, workflowPath, version string, stder
 			command: "validate", format: "json", reports: io.Discard, stderr: stderr,
 			observe: func(observed compatibility.ProcessingReport) { eventReport = &observed },
 		}
-		if code := validateOne(eventOut, workflowPath, "", event, hostedProfile, version, stderr); code != 0 {
+		if code := validateOne(eventOut, workflowPath, "", event, hostedProfile, version, actionCacheDir, stderr); code != 0 {
 			failed = true
 		}
 		if eventReport == nil {
@@ -1460,6 +1472,28 @@ func validateAllEvents(out processingOutput, workflowPath, version string, stder
 		return 1
 	}
 	return 0
+}
+
+func validateActionCacheArgs(args []string) ([]string, string, error) {
+	filtered := make([]string, 0, len(args))
+	var cacheDir string
+	seen := false
+	for i := 0; i < len(args); i++ {
+		if args[i] != "--action-cache-dir" {
+			filtered = append(filtered, args[i])
+			continue
+		}
+		if seen {
+			return nil, "", fmt.Errorf("--action-cache-dir may only be specified once")
+		}
+		seen = true
+		i++
+		if i == len(args) || strings.TrimSpace(args[i]) == "" {
+			return nil, "", fmt.Errorf("--action-cache-dir requires a path")
+		}
+		cacheDir = args[i]
+	}
+	return filtered, cacheDir, nil
 }
 
 func validateArgs(args []string) (workflowPath, eventPath, eventName, format, profile string, allEvents bool, err error) {
@@ -2522,7 +2556,15 @@ func compileHosted(ctx context.Context, workflowPath string, workflowSource, eve
 	return compileHostedNamespaced(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, groupLabel, configuredTargets, runtimeDistributions, "", actionAuthentication)
 }
 
+func compileHostedWithActionCache(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runtimeDistributions map[compiler.Platform]string, actionCacheDir string, actionAuthentication *actionSourceAuthentication) (hostedCompilation, error) {
+	return compileHostedNamespacedWithActionCache(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, groupLabel, configuredTargets, runtimeDistributions, "", actionCacheDir, actionAuthentication)
+}
+
 func compileHostedNamespaced(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runtimeDistributions map[compiler.Platform]string, stepKeyNamespace string, actionAuthentication *actionSourceAuthentication) (hostedCompilation, error) {
+	return compileHostedNamespacedWithActionCache(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, groupLabel, configuredTargets, runtimeDistributions, stepKeyNamespace, "", actionAuthentication)
+}
+
+func compileHostedNamespacedWithActionCache(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runtimeDistributions map[compiler.Platform]string, stepKeyNamespace, actionCacheDir string, actionAuthentication *actionSourceAuthentication) (hostedCompilation, error) {
 	options := hostedOptions(groupLabel, configuredTargets, runtimeDistributions)
 	options.StepKeyNamespace = stepKeyNamespace
 	preflight, err := compiler.CompileWithOptions(workflowPath, workflowSource, eventSource, options)
@@ -2535,11 +2577,14 @@ func compileHostedNamespaced(ctx context.Context, workflowPath string, workflowS
 	}
 	hasActions := irUsesActions(ir)
 	if hasActions {
-		actionRoot, err := os.MkdirTemp("", "buildkite-gha-action-source-")
-		if err != nil {
-			return hostedCompilation{}, hostedError(hostedEnvironmentFailure, fmt.Errorf("create action source store: %w", err))
+		actionRoot := actionCacheDir
+		if actionRoot == "" {
+			actionRoot, err = os.MkdirTemp("", "buildkite-gha-action-source-")
+			if err != nil {
+				return hostedCompilation{}, hostedError(hostedEnvironmentFailure, fmt.Errorf("create action source store: %w", err))
+			}
+			defer func() { _ = os.RemoveAll(actionRoot) }()
 		}
-		defer func() { _ = os.RemoveAll(actionRoot) }()
 		var sourceOptions []actionsource.Option
 		if ir.Event.Provider == "github" {
 			authenticationOption := actionAuthentication.option(ir.Event.Repository.Owner + "/" + ir.Event.Repository.Name)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1318,10 +1318,10 @@ func validate(args []string, stdout, stderr io.Writer, version string, agent tra
 	if allEvents {
 		return validateAllEvents(out, workflowPath, version, actionCacheDir, stderr)
 	}
-	return validateOne(out, workflowPath, eventPath, eventName, profile, version, actionCacheDir, stderr)
+	return validateOne(out, workflowPath, eventPath, eventName, profile, version, actionCacheDir, nil, stderr)
 }
 
-func validateOne(out processingOutput, workflowPath, eventPath, eventName, profile, version, actionCacheDir string, stderr io.Writer) int {
+func validateOne(out processingOutput, workflowPath, eventPath, eventName, profile, version, actionCacheDir string, sharedActionSource compiler.ActionSource, stderr io.Writer) int {
 	var loadEvent func() ([]byte, error)
 	if eventPath != "" {
 		event, eventErr := os.ReadFile(eventPath)
@@ -1384,7 +1384,7 @@ func validateOne(out processingOutput, workflowPath, eventPath, eventName, profi
 			compiler.PlatformLinuxAMD64:  distributionDigest,
 			compiler.PlatformDarwinARM64: distributionDigest,
 		}
-		preflight, profileErr := compileHostedWithActionCache(ctx, workflowPath, source, event, version, distributionDigest, "buildkite-gha-profile-importer", "", nil, runtimeDistributions, actionCacheDir, nil)
+		preflight, profileErr := compileHostedWithActionCache(ctx, workflowPath, source, event, version, distributionDigest, "buildkite-gha-profile-importer", "", nil, runtimeDistributions, actionCacheDir, sharedActionSource, nil)
 		applyHostedPreflight(&processingReport, preflight)
 		if profileErr != nil {
 			if ctx.Err() != nil || errors.Is(profileErr, context.Canceled) {
@@ -1445,6 +1445,16 @@ func validateAllEvents(out processingOutput, workflowPath, version, actionCacheD
 	for _, trigger := range parsed.Triggers {
 		declared[trigger.Event] = true
 	}
+	sharedActionSource, cleanup, err := newHostedActionSource(actionCacheDir, nil)
+	if err != nil {
+		validationReport.AddEnvironmentFailure("public action source could not be configured")
+		validationReport.Result = "indeterminate"
+		report.Validation = validationReport
+		_ = out.writeV3(report)
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: %v\n", err)
+		return 1
+	}
+	defer cleanup()
 	failed := false
 	for _, event := range []string{"push", "pull_request", "workflow_dispatch", "schedule"} {
 		if !declared[event] {
@@ -1455,7 +1465,7 @@ func validateAllEvents(out processingOutput, workflowPath, version, actionCacheD
 			command: "validate", format: "json", reports: io.Discard, stderr: stderr,
 			observe: func(observed compatibility.ProcessingReport) { eventReport = &observed },
 		}
-		if code := validateOne(eventOut, workflowPath, "", event, hostedProfile, version, actionCacheDir, stderr); code != 0 {
+		if code := validateOne(eventOut, workflowPath, "", event, hostedProfile, version, actionCacheDir, sharedActionSource, stderr); code != 0 {
 			failed = true
 		}
 		if eventReport == nil {
@@ -2556,15 +2566,15 @@ func compileHosted(ctx context.Context, workflowPath string, workflowSource, eve
 	return compileHostedNamespaced(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, groupLabel, configuredTargets, runtimeDistributions, "", actionAuthentication)
 }
 
-func compileHostedWithActionCache(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runtimeDistributions map[compiler.Platform]string, actionCacheDir string, actionAuthentication *actionSourceAuthentication) (hostedCompilation, error) {
-	return compileHostedNamespacedWithActionCache(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, groupLabel, configuredTargets, runtimeDistributions, "", actionCacheDir, actionAuthentication)
+func compileHostedWithActionCache(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runtimeDistributions map[compiler.Platform]string, actionCacheDir string, sharedActionSource compiler.ActionSource, actionAuthentication *actionSourceAuthentication) (hostedCompilation, error) {
+	return compileHostedNamespacedWithActionCache(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, groupLabel, configuredTargets, runtimeDistributions, "", actionCacheDir, sharedActionSource, actionAuthentication)
 }
 
 func compileHostedNamespaced(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runtimeDistributions map[compiler.Platform]string, stepKeyNamespace string, actionAuthentication *actionSourceAuthentication) (hostedCompilation, error) {
-	return compileHostedNamespacedWithActionCache(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, groupLabel, configuredTargets, runtimeDistributions, stepKeyNamespace, "", actionAuthentication)
+	return compileHostedNamespacedWithActionCache(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, groupLabel, configuredTargets, runtimeDistributions, stepKeyNamespace, "", nil, actionAuthentication)
 }
 
-func compileHostedNamespacedWithActionCache(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runtimeDistributions map[compiler.Platform]string, stepKeyNamespace, actionCacheDir string, actionAuthentication *actionSourceAuthentication) (hostedCompilation, error) {
+func compileHostedNamespacedWithActionCache(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runtimeDistributions map[compiler.Platform]string, stepKeyNamespace, actionCacheDir string, sharedActionSource compiler.ActionSource, actionAuthentication *actionSourceAuthentication) (hostedCompilation, error) {
 	options := hostedOptions(groupLabel, configuredTargets, runtimeDistributions)
 	options.StepKeyNamespace = stepKeyNamespace
 	preflight, err := compiler.CompileWithOptions(workflowPath, workflowSource, eventSource, options)
@@ -2577,31 +2587,24 @@ func compileHostedNamespacedWithActionCache(ctx context.Context, workflowPath st
 	}
 	hasActions := irUsesActions(ir)
 	if hasActions {
-		actionRoot := actionCacheDir
-		if actionRoot == "" {
-			actionRoot, err = os.MkdirTemp("", "buildkite-gha-action-source-")
+		actionSource := sharedActionSource
+		cleanup := func() {}
+		if actionSource == nil {
+			var sourceOptions []actionsource.Option
+			if ir.Event.Provider == "github" {
+				authenticationOption := actionAuthentication.option(ir.Event.Repository.Owner + "/" + ir.Event.Repository.Name)
+				if authenticationOption != nil {
+					sourceOptions = append(sourceOptions, authenticationOption)
+				}
+			}
+			actionSource, cleanup, err = newHostedActionSource(actionCacheDir, sourceOptions)
 			if err != nil {
-				return hostedCompilation{}, hostedError(hostedEnvironmentFailure, fmt.Errorf("create action source store: %w", err))
-			}
-			defer func() { _ = os.RemoveAll(actionRoot) }()
-		}
-		var sourceOptions []actionsource.Option
-		if ir.Event.Provider == "github" {
-			authenticationOption := actionAuthentication.option(ir.Event.Repository.Owner + "/" + ir.Event.Repository.Name)
-			if authenticationOption != nil {
-				sourceOptions = append(sourceOptions, authenticationOption)
+				return hostedCompilation{}, hostedError(hostedEnvironmentFailure, err)
 			}
 		}
-		resolver, err := actionsource.NewResolver(nil, sourceOptions...)
-		if err != nil {
-			return hostedCompilation{}, hostedError(hostedEnvironmentFailure, fmt.Errorf("configure public action resolver: %w", err))
-		}
-		store, err := actionsource.NewStore(actionRoot, nil)
-		if err != nil {
-			return hostedCompilation{}, hostedError(hostedEnvironmentFailure, fmt.Errorf("configure public action source store: %w", err))
-		}
+		defer cleanup()
 		options.ResolveActions = true
-		options.ActionSource = compiler.PublicActionSource{Resolver: resolver, Store: store}
+		options.ActionSource = actionSource
 	}
 	bundle, err := compiler.CompileBundlePlansContext(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, options)
 	if err != nil {
@@ -2618,6 +2621,30 @@ func compileHostedNamespacedWithActionCache(ctx context.Context, workflowPath st
 		return hostedCompilation{Bundle: bundle, HasActions: hasActions, Admitted: true}, hostedError(hostedEvaluationFailure, fmt.Errorf("final compilation introduced actions absent from preflight"))
 	}
 	return hostedCompilation{Bundle: bundle, HasActions: hasActions, Admitted: true}, nil
+}
+
+func newHostedActionSource(actionCacheDir string, sourceOptions []actionsource.Option) (compiler.ActionSource, func(), error) {
+	actionRoot := actionCacheDir
+	cleanup := func() {}
+	if actionRoot == "" {
+		var err error
+		actionRoot, err = os.MkdirTemp("", "buildkite-gha-action-source-")
+		if err != nil {
+			return nil, cleanup, fmt.Errorf("create action source store: %w", err)
+		}
+		cleanup = func() { _ = os.RemoveAll(actionRoot) }
+	}
+	resolver, err := actionsource.NewResolver(nil, sourceOptions...)
+	if err != nil {
+		cleanup()
+		return nil, func() {}, fmt.Errorf("configure public action resolver: %w", err)
+	}
+	store, err := actionsource.NewStore(actionRoot, nil)
+	if err != nil {
+		cleanup()
+		return nil, func() {}, fmt.Errorf("configure public action source store: %w", err)
+	}
+	return compiler.MemoizeActionSource(compiler.PublicActionSource{Resolver: resolver, Store: store}), cleanup, nil
 }
 
 func validateUnprivilegedBundle(bundle compiler.Bundle) error {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -7619,6 +7619,15 @@ func TestVerifyBuildkiteTargetFailsClosed(t *testing.T) {
 }
 
 func TestArgumentParsersRejectRepeatedOptions(t *testing.T) {
+	if _, _, err := validateActionCacheArgs([]string{"--action-cache-dir", "one", "--action-cache-dir", "two", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
+		t.Fatalf("validateActionCacheArgs() error = %v, want duplicate cache directory error", err)
+	}
+	if _, _, err := validateActionCacheArgs([]string{"--action-cache-dir", ""}); err == nil || !strings.Contains(err.Error(), "requires a path") {
+		t.Fatalf("validateActionCacheArgs() error = %v, want empty cache directory error", err)
+	}
+	if args, cacheDir, err := validateActionCacheArgs([]string{"--profile", "hosted", "--action-cache-dir", "cache", "--all-events", "workflow.yml"}); err != nil || cacheDir != "cache" || !slices.Equal(args, []string{"--profile", "hosted", "--all-events", "workflow.yml"}) {
+		t.Fatalf("validateActionCacheArgs() = %q, %q, %v", args, cacheDir, err)
+	}
 	if _, err := runJobArgs([]string{"--plan", "one", "--plan", "two"}); err == nil || !strings.Contains(err.Error(), "only be specified once") {
 		t.Fatalf("runJobArgs() error = %v, want duplicate option error", err)
 	}
@@ -7766,6 +7775,18 @@ func TestUploadArgsParsesPlatformRuntimeDistributions(t *testing.T) {
 		if _, err := parseUploadArgs(test.args); err == nil || !strings.Contains(err.Error(), test.want) {
 			t.Fatalf("parseUploadArgs(%#v) error = %v, want %q", test.args, err, test.want)
 		}
+	}
+}
+
+func TestValidateActionCacheRequiresHostedProfile(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"validate", "--action-cache-dir", t.TempDir(), "workflow.yml"}, &stdout, &stderr, "dev"); code != 2 || !strings.Contains(stderr.String(), "requires --profile hosted") {
+		t.Fatalf("Run() code = %d, stderr = %q", code, stderr.String())
+	}
+	stderr.Reset()
+	missing := filepath.Join(t.TempDir(), "missing")
+	if code := Run([]string{"validate", "--profile", "hosted", "--event", "push", "--action-cache-dir", missing, "workflow.yml"}, &stdout, &stderr, "dev"); code != 2 || !strings.Contains(stderr.String(), "cache root is not a non-symlink directory") {
+		t.Fatalf("Run() code = %d, stderr = %q", code, stderr.String())
 	}
 }
 

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 
 	actionintegration "github.com/buildkite/buildkite-gha/internal/action/integration"
 	"github.com/buildkite/buildkite-gha/internal/action/metadata"
@@ -484,6 +485,7 @@ func (b *actionLockBuilder) describe(ctx context.Context, raw string) (string, p
 
 type memoizedActionSource struct {
 	source ActionSource
+	mu     sync.Mutex
 	cache  map[string]memoizedAction
 }
 
@@ -499,15 +501,26 @@ func newMemoizedActionSource(actionSource ActionSource) ActionSource {
 	return &memoizedActionSource{source: actionSource, cache: map[string]memoizedAction{}}
 }
 
+// MemoizeActionSource reuses successful action resolutions and materializations
+// across compiler invocations that share the returned source.
+func MemoizeActionSource(actionSource ActionSource) ActionSource {
+	return newMemoizedActionSource(actionSource)
+}
+
 func (s *memoizedActionSource) Fetch(ctx context.Context, ref source.Reference) (source.Resolved, source.Materialized, error) {
 	key := strings.ToLower(ref.Owner+"/"+ref.Repository) + "\x00" + ref.Path + "\x00" + ref.Ref
+	s.mu.Lock()
 	if cached, ok := s.cache[key]; ok {
+		s.mu.Unlock()
 		return cached.resolved, cached.materialized, nil
 	}
+	s.mu.Unlock()
 	resolved, materialized, err := s.source.Fetch(ctx, ref)
 	if err != nil {
 		return source.Resolved{}, source.Materialized{}, err
 	}
+	s.mu.Lock()
 	s.cache[key] = memoizedAction{resolved: resolved, materialized: materialized}
+	s.mu.Unlock()
 	return resolved, materialized, nil
 }

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -414,6 +414,25 @@ runs:
 	}
 }
 
+func TestMemoizeActionSourceSharesResolutionAcrossCompilations(t *testing.T) {
+	workspace, remote := t.TempDir(), t.TempDir()
+	writeAction(t, remote, "", `name: shared
+runs:
+  using: node24
+  main: index.js
+`)
+	fake := &fakeActionSource{root: remote, calls: map[string]int{}}
+	shared := MemoizeActionSource(fake)
+	for range 2 {
+		if _, err := compileActionInvocations(context.Background(), workspace, shared, "https://github.com", []string{"owner/action@v1"}, []map[string]string{nil}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if fake.calls["owner/action@v1"] != 1 {
+		t.Fatalf("remote action resolutions = %d, want one shared resolution", fake.calls["owner/action@v1"])
+	}
+}
+
 func TestCompileActionInvocationsDetectsOnlyEffectiveNestedGitHubTokenDefaults(t *testing.T) {
 	w := t.TempDir()
 	writeAction(t, w, "child", `name: child

--- a/mise.toml
+++ b/mise.toml
@@ -34,7 +34,7 @@ run = "echo '--- Lint Go'; golangci-lint run"
 
 [tasks."lint:shell"]
 description = "Lint shell scripts"
-run = "echo '--- Lint shell'; shellcheck -x .buildkite/upload-examples.sh scripts/ci-buildkite-release scripts/compare-example scripts/starter-workflows-corpus scripts/update-checkout-main-commits scripts/verify-source-checkout scripts/hosted-docker-probe scripts/container-runtime-probe scripts/verify-summary-annotation scripts/verify-workflow-annotations scripts/verify-upload-artifact scripts/verify-artifact-roundtrip scripts/release scripts/release-test scripts/smoke-local testdata/actions/docker/entrypoint.sh testdata/container-runtime/.github/actions/docker/entrypoint.sh"
+run = "echo '--- Lint shell'; shellcheck -x .buildkite/upload-examples.sh scripts/ci-buildkite-release scripts/compare-example scripts/starter-workflows-corpus scripts/update-checkout-main-commits scripts/validate-public-workflow-corpus scripts/verify-source-checkout scripts/hosted-docker-probe scripts/container-runtime-probe scripts/verify-summary-annotation scripts/verify-workflow-annotations scripts/verify-upload-artifact scripts/verify-artifact-roundtrip scripts/release scripts/release-test scripts/smoke-local testdata/actions/docker/entrypoint.sh testdata/container-runtime/.github/actions/docker/entrypoint.sh"
 
 [tasks.lint]
 description = "Lint Go code and shell scripts"

--- a/scripts/validate-public-workflow-corpus
+++ b/scripts/validate-public-workflow-corpus
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly root
+
+workdir="${WORKDIR:-$HOME/gha-corpus}"
+record_id="${RECORD_ID:-20340547}"
+if [[ -n "${JOBS:-}" ]]; then
+  jobs="$JOBS"
+elif command -v nproc >/dev/null; then
+  jobs="$(nproc)"
+else
+  jobs="$(sysctl -n hw.ncpu)"
+fi
+readonly workdir record_id jobs
+
+for command in curl python3; do
+  command -v "$command" >/dev/null || {
+    echo "$command is required" >&2
+    exit 127
+  }
+done
+[[ "$jobs" =~ ^[1-9][0-9]*$ ]] || {
+  echo "JOBS must be a positive integer, got: $jobs" >&2
+  exit 2
+}
+
+mkdir -p "$workdir"
+cd "$workdir"
+
+download() {
+  local name=$1
+  [[ -f "$name" ]] && return
+  curl --fail --location --retry 3 --output "$name.partial" \
+    "https://zenodo.org/api/records/$record_id/files/$name/content"
+  mv "$name.partial" "$name"
+}
+
+download workflows.csv.gz
+download workflows.tar.gz
+
+if [[ ! -f files/.complete-v2 ]]; then
+  rm -rf files reports workflows.tsv
+  mkdir -p files
+  python3 - <<'PY'
+import csv
+import gzip
+import os
+import sys
+import tarfile
+
+csv.field_size_limit(sys.maxsize)
+latest = {}
+with gzip.open("workflows.csv.gz", "rt", newline="") as source:
+    for row in csv.DictReader(source):
+        if row["valid_workflow"] != "True":
+            continue
+        key = (row["repository"], row["file_path"])
+        committed = int(row["committed_date"])
+        if key not in latest or committed > latest[key][0]:
+            latest[key] = (committed, row["file_hash"], row["git_change_type"])
+
+workflows = []
+for (repository, path), (_, file_hash, change_type) in latest.items():
+    if change_type != "D" and file_hash:
+        workflows.append((repository, path, file_hash))
+workflows.sort()
+
+wanted = {}
+with open("workflows.tsv", "w", encoding="utf-8") as manifest:
+    for index, (repository, path, file_hash) in enumerate(workflows):
+        workflow_id = f"{index:06d}"
+        wanted.setdefault(file_hash, []).append((workflow_id, os.path.basename(path)))
+        manifest.write(f"{workflow_id}\t{repository}\t{path}\t{file_hash}\n")
+
+print(
+    f"{len(workflows):,} live workflow files across "
+    f"{len({repository for repository, _, _ in workflows}):,} repos"
+)
+
+extracted = 0
+with tarfile.open("workflows.tar.gz", "r|gz") as archive:
+    for member in archive:
+        if not member.isfile():
+            continue
+        file_hash = member.name.rsplit("/", 1)[-1]
+        destinations = wanted.pop(file_hash, None)
+        if not destinations:
+            continue
+        source = archive.extractfile(member)
+        if source is None:
+            continue
+        content = source.read()
+        for workflow_id, filename in destinations:
+            directory = os.path.join(
+                "files", workflow_id[:3], workflow_id, ".github", "workflows"
+            )
+            os.makedirs(directory)
+            with open(os.path.join(directory, filename), "wb") as destination:
+                destination.write(content)
+            extracted += 1
+
+if wanted:
+    missing = sum(len(destinations) for destinations in wanted.values())
+    raise SystemExit(f"corpus archive is missing {missing:,} selected workflows")
+print(f"extracted {extracted:,}")
+open("files/.complete-v2", "w").close()
+PY
+fi
+
+validator="$workdir/buildkite-gha"
+(
+  cd "$root"
+  CGO_ENABLED=0 mise exec -- go build -trimpath -buildvcs=false \
+    -o "$validator" ./cmd/buildkite-gha
+)
+validator_commit="$(git -C "$root" rev-parse HEAD)"
+validator_version="$("$validator" --version)"
+readonly validator validator_commit validator_version
+printf 'validator: %s (%s)\n' "$validator_version" "$validator_commit"
+[[ "$("$validator" help validate)" == *"--action-cache-dir"* ]] || {
+  echo 'buildkite-gha validate must support --action-cache-dir' >&2
+  exit 1
+}
+
+action_cache="$workdir/action-cache"
+readonly action_cache
+mkdir -p "$action_cache"
+rm -rf reports
+mkdir -p reports
+export action_cache validator validator_commit validator_version
+# The quoted variables expand in each xargs child shell.
+# shellcheck disable=SC2016
+find files -mindepth 3 -type f \( -name '*.yml' -o -name '*.yaml' \) -print0 \
+  | xargs -0 -P "$jobs" -n 1 bash -c '
+      workflow=$1
+      workflow_id=${workflow#files/*/}
+      workflow_id=${workflow_id%%/*}
+      "$validator" validate --profile hosted --all-events --action-cache-dir "$action_cache" --format json "$workflow" > "reports/$workflow_id.json" 2>/dev/null || true
+    ' _
+
+python3 - <<'PY'
+import collections
+import glob
+import json
+import os
+
+repositories = {}
+with open("workflows.tsv", encoding="utf-8") as manifest:
+    for line in manifest:
+        workflow_id, repository, _, _ = line.rstrip("\n").split("\t")
+        repositories[workflow_id] = repository
+
+blocked_repos = set()
+codes_by_repo = collections.defaultdict(set)
+findings = collections.Counter()
+evaluations = collections.Counter()
+seen_workflows = set()
+bad_reports = 0
+for path in glob.glob("reports/*.json"):
+    workflow_id = path.rsplit("/", 1)[-1].removesuffix(".json")
+    repository = repositories[workflow_id]
+    seen_workflows.add(workflow_id)
+    try:
+        with open(path, encoding="utf-8") as report:
+            result = json.load(report)
+    except (OSError, json.JSONDecodeError):
+        bad_reports += 1
+        blocked_repos.add(repository)
+        codes_by_repo[repository].add("E_REPORT")
+        findings["E_REPORT"] += 1
+        continue
+    if (
+        result.get("schema") != "buildkite-gha/processing-report/v3"
+        or result.get("profile") != "hosted"
+        or not isinstance(result.get("validation"), dict)
+        or not isinstance(result.get("evaluations"), list)
+    ):
+        bad_reports += 1
+        blocked_repos.add(repository)
+        codes_by_repo[repository].add("E_REPORT")
+        findings["E_REPORT"] += 1
+        continue
+    if result.get("result") not in ("admitted", "not-applicable"):
+        blocked_repos.add(repository)
+    reports = [("validation", result["validation"])]
+    seen_events = set()
+    for evaluation in result["evaluations"]:
+        event = evaluation.get("event") if isinstance(evaluation, dict) else None
+        if (
+            not isinstance(evaluation, dict)
+            or event not in ("push", "pull_request", "workflow_dispatch", "schedule")
+            or event in seen_events
+            or evaluation.get("event_source") != "generated"
+            or not isinstance(evaluation.get("report"), dict)
+        ):
+            bad_reports += 1
+            blocked_repos.add(repository)
+            codes_by_repo[repository].add("E_REPORT")
+            findings["E_REPORT"] += 1
+            reports = []
+            break
+        seen_events.add(event)
+        evaluations[event] += 1
+        reports.append((event, evaluation["report"]))
+    for _, report in reports:
+        if report.get("schema") != "buildkite-gha/processing-report/v2":
+            bad_reports += 1
+            blocked_repos.add(repository)
+            codes_by_repo[repository].add("E_REPORT")
+            findings["E_REPORT"] += 1
+            break
+    for _, report in reports:
+        for diagnostic in report.get("diagnostics") or []:
+            code = diagnostic.get("code") or "unknown"
+            codes_by_repo[repository].add(code)
+            findings[code] += 1
+
+for workflow_id in repositories.keys() - seen_workflows:
+    repository = repositories[workflow_id]
+    bad_reports += 1
+    blocked_repos.add(repository)
+    codes_by_repo[repository].add("E_REPORT")
+    findings["E_REPORT"] += 1
+
+all_repos = set(repositories.values())
+clean = len(all_repos - blocked_repos)
+print(
+    f"repos: {len(all_repos):,}   clean: {clean:,} "
+    f"({100 * clean / len(all_repos):.2f}%)   unparseable reports: {bad_reports:,}"
+)
+print("admission scope: generated event snapshots, not arbitrary real payloads")
+print("\ndiagnostic code -> repos affected")
+repos_by_code = collections.Counter(
+    code for codes in codes_by_repo.values() for code in codes
+)
+for code, count in repos_by_code.most_common(40):
+    print(f"{100 * count / len(all_repos):6.2f}%  {count:6,}  {code}")
+
+with open("validate-tally.json", "w", encoding="utf-8") as destination:
+    json.dump(
+        {
+            "repos": len(all_repos),
+            "clean": clean,
+            "validator_commit": os.environ["validator_commit"],
+            "validator_version": os.environ["validator_version"],
+            "admission_scope": "generated-event-snapshots",
+            "by_repo": dict(repos_by_code),
+            "by_finding": dict(findings),
+            "evaluations": dict(evaluations),
+            "unparseable_reports": bad_reports,
+        },
+        destination,
+        indent=2,
+        sort_keys=True,
+    )
+    destination.write("\n")
+PY

--- a/scripts/validate-public-workflow-corpus
+++ b/scripts/validate-public-workflow-corpus
@@ -13,7 +13,7 @@ elif command -v nproc >/dev/null; then
 else
   jobs="$(sysctl -n hw.ncpu)"
 fi
-readonly workdir record_id jobs
+readonly record_id jobs
 
 for command in curl python3; do
   command -v "$command" >/dev/null || {
@@ -27,7 +27,11 @@ done
 }
 
 mkdir -p "$workdir"
-cd "$workdir"
+workdir="$(cd "$workdir" && pwd)"
+corpus_dir="$workdir/records/$record_id"
+readonly workdir corpus_dir
+mkdir -p "$corpus_dir"
+cd "$corpus_dir"
 
 download() {
   local name=$1
@@ -40,7 +44,7 @@ download() {
 download workflows.csv.gz
 download workflows.tar.gz
 
-if [[ ! -f files/.complete-v2 ]]; then
+if [[ ! -f files/.complete-v3 ]]; then
   rm -rf files reports workflows.tsv
   mkdir -p files
   python3 - <<'PY'
@@ -54,17 +58,20 @@ csv.field_size_limit(sys.maxsize)
 latest = {}
 with gzip.open("workflows.csv.gz", "rt", newline="") as source:
     for row in csv.DictReader(source):
-        if row["valid_workflow"] != "True":
-            continue
-        key = (row["repository"], row["file_path"])
+        key = row["uid"]
         committed = int(row["committed_date"])
         if key not in latest or committed > latest[key][0]:
-            latest[key] = (committed, row["file_hash"], row["git_change_type"])
+            latest[key] = (committed, row)
 
 workflows = []
-for (repository, path), (_, file_hash, change_type) in latest.items():
-    if change_type != "D" and file_hash:
-        workflows.append((repository, path, file_hash))
+for _, row in latest.values():
+    if (
+        row["valid_workflow"] == "True"
+        and row["git_change_type"] != "D"
+        and row["file_path"]
+        and row["file_hash"]
+    ):
+        workflows.append((row["repository"], row["file_path"], row["file_hash"]))
 workflows.sort()
 
 wanted = {}
@@ -105,7 +112,7 @@ if wanted:
     missing = sum(len(destinations) for destinations in wanted.values())
     raise SystemExit(f"corpus archive is missing {missing:,} selected workflows")
 print(f"extracted {extracted:,}")
-open("files/.complete-v2", "w").close()
+open("files/.complete-v3", "w").close()
 PY
 fi
 


### PR DESCRIPTION
## Why

Hosted corpus validation repeatedly downloads the same immutable action source and resolves the same mutable refs for every generated event, making large reruns slow and increasing GitHub API pressure.

## What

- add `validate --action-cache-dir` to persist verified action source by immutable commit
- share successful action resolution across `--all-events` evaluations within one invocation
- add a reusable public-workflow corpus script that consumes processing-report/v3 and retains the action cache across runs
