### PR TITLE
Cache mutable action ref resolutions

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -70,7 +70,7 @@ buildkite-gha validate \
   .github/workflows/ci.yml
 ```
 
-`--action-cache-dir` is available only with `--profile hosted`. The cache stores verified action source by immutable commit. Mutable refs resolve through GitHub at least once per hour, with resolutions cached under `$XDG_CACHE_HOME/buildkite-gha/action-ref-resolutions/v1` (or the platform user cache directory). Concurrent validation processes can share this resolution cache. A moved tag or branch can therefore use its previous commit for up to one hour. Do not share either writable cache between mutually untrusted validation jobs.
+`--action-cache-dir` is available only with `--profile hosted`. The cache stores verified action source by immutable commit. Mutable ref resolutions are cached for up to one hour under `$XDG_CACHE_HOME/buildkite-gha/action-ref-resolutions/v1` (or the platform user cache directory). Concurrent validation processes can share this resolution cache. A moved tag or branch can therefore use its previous commit for up to one hour. Do not share either writable cache between mutually untrusted validation jobs.
 
 Inspect the aggregate result and each event outcome:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -70,7 +70,7 @@ buildkite-gha validate \
   .github/workflows/ci.yml
 ```
 
-`--action-cache-dir` is available only with `--profile hosted`. The cache stores verified action source by immutable commit. Mutable refs still resolve through GitHub on every run, so a moved tag or branch selects its current commit. Do not share one writable cache between mutually untrusted validation jobs.
+`--action-cache-dir` is available only with `--profile hosted`. The cache stores verified action source by immutable commit. Mutable refs resolve through GitHub at least once per hour, with resolutions cached under `$XDG_CACHE_HOME/buildkite-gha/action-ref-resolutions/v1` (or the platform user cache directory). Concurrent validation processes can share this resolution cache. A moved tag or branch can therefore use its previous commit for up to one hour. Do not share either writable cache between mutually untrusted validation jobs.
 
 Inspect the aggregate result and each event outcome:
 

--- a/internal/action/source/mutable_ref_cache.go
+++ b/internal/action/source/mutable_ref_cache.go
@@ -1,0 +1,133 @@
+package source
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type mutableRefCache struct {
+	root      string
+	freshness time.Duration
+}
+
+type mutableRefEntry struct {
+	Schema     string    `json:"schema"`
+	Owner      string    `json:"owner"`
+	Repository string    `json:"repository"`
+	Ref        string    `json:"ref"`
+	Commit     string    `json:"commit"`
+	ResolvedAt time.Time `json:"resolved_at"`
+}
+
+func newMutableRefCache(root string, freshness time.Duration) (*mutableRefCache, error) {
+	if strings.TrimSpace(root) == "" {
+		return nil, fmt.Errorf("mutable ref cache root is required")
+	}
+	if freshness <= 0 {
+		return nil, fmt.Errorf("mutable ref cache freshness must be positive")
+	}
+	absolute, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("resolve mutable ref cache root: %w", err)
+	}
+	return &mutableRefCache{root: absolute, freshness: freshness}, nil
+}
+
+func (c *mutableRefCache) resolve(ctx context.Context, ref Reference, resolve func(context.Context, Reference) (Resolved, error)) (Resolved, error) {
+	path := c.path(ref)
+	if resolved, ok := c.load(path, ref, time.Now()); ok {
+		return resolved, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return resolve(ctx, ref)
+	}
+	unlock, err := lockMutableRefCache(ctx, path+".lock")
+	if err != nil {
+		if ctx.Err() != nil {
+			return Resolved{}, ctx.Err()
+		}
+		return resolve(ctx, ref)
+	}
+	defer unlock()
+	if resolved, ok := c.load(path, ref, time.Now()); ok {
+		return resolved, nil
+	}
+	resolved, err := resolve(ctx, ref)
+	if err != nil {
+		return Resolved{}, err
+	}
+	entry := mutableRefEntry{
+		Schema: "buildkite-gha-action-ref-resolution/v1", Owner: strings.ToLower(ref.Owner),
+		Repository: strings.ToLower(ref.Repository), Ref: ref.Ref, Commit: resolved.Commit, ResolvedAt: time.Now().UTC(),
+	}
+	if err := c.store(path, entry); err != nil {
+		return resolved, nil
+	}
+	return resolved, nil
+}
+
+func (c *mutableRefCache) path(ref Reference) string {
+	identity := strings.ToLower(ref.Owner) + "\x00" + strings.ToLower(ref.Repository) + "\x00" + ref.Ref
+	sum := sha256.Sum256([]byte(identity))
+	key := hex.EncodeToString(sum[:])
+	return filepath.Join(c.root, key[:2], key+".json")
+}
+
+func (c *mutableRefCache) load(path string, ref Reference, now time.Time) (Resolved, bool) {
+	file, err := os.Open(path)
+	if err != nil {
+		return Resolved{}, false
+	}
+	data, err := io.ReadAll(io.LimitReader(file, 4097))
+	_ = file.Close()
+	if err != nil || len(data) > 4096 {
+		return Resolved{}, false
+	}
+	var entry mutableRefEntry
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.DisallowUnknownFields()
+	if decoder.Decode(&entry) != nil || decoder.Decode(&struct{}{}) != io.EOF ||
+		entry.Schema != "buildkite-gha-action-ref-resolution/v1" ||
+		entry.Owner != strings.ToLower(ref.Owner) || entry.Repository != strings.ToLower(ref.Repository) ||
+		entry.Ref != ref.Ref || !shaRE.MatchString(entry.Commit) || entry.ResolvedAt.After(now) ||
+		now.Sub(entry.ResolvedAt) >= c.freshness {
+		return Resolved{}, false
+	}
+	return Resolved{Reference: ref, Commit: entry.Commit}, true
+}
+
+func (c *mutableRefCache) store(path string, entry mutableRefEntry) error {
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("encode mutable ref cache: %w", err)
+	}
+	temporary, err := os.CreateTemp(filepath.Dir(path), ".resolution-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create mutable ref cache entry: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	defer func() { _ = os.Remove(temporaryPath) }()
+	if err := temporary.Chmod(0o600); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("secure mutable ref cache entry: %w", err)
+	}
+	_, err = temporary.Write(data)
+	if closeErr := temporary.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return fmt.Errorf("write mutable ref cache entry: %w", err)
+	}
+	if err := os.Rename(temporaryPath, path); err != nil {
+		return fmt.Errorf("publish mutable ref cache entry: %w", err)
+	}
+	return nil
+}

--- a/internal/action/source/mutable_ref_lock_other.go
+++ b/internal/action/source/mutable_ref_lock_other.go
@@ -1,0 +1,19 @@
+//go:build !linux && !darwin
+
+package source
+
+import (
+	"context"
+	"os"
+)
+
+func lockMutableRefCache(ctx context.Context, path string) (func(), error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	lock, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	return func() { _ = lock.Close() }, nil
+}

--- a/internal/action/source/mutable_ref_lock_unix.go
+++ b/internal/action/source/mutable_ref_lock_unix.go
@@ -1,0 +1,38 @@
+//go:build linux || darwin
+
+package source
+
+import (
+	"context"
+	"errors"
+	"os"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func lockMutableRefCache(ctx context.Context, path string) (func(), error) {
+	lock, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	for {
+		err = unix.Flock(int(lock.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+		if err == nil {
+			return func() {
+				_ = unix.Flock(int(lock.Fd()), unix.LOCK_UN)
+				_ = lock.Close()
+			}, nil
+		}
+		if !errors.Is(err, unix.EWOULDBLOCK) {
+			_ = lock.Close()
+			return nil, err
+		}
+		select {
+		case <-ctx.Done():
+			_ = lock.Close()
+			return nil, ctx.Err()
+		case <-time.After(25 * time.Millisecond):
+		}
+	}
+}

--- a/internal/action/source/source.go
+++ b/internal/action/source/source.go
@@ -32,6 +32,7 @@ const (
 	defaultAPI      = "https://api.github.com"
 	defaultCodeload = "https://codeload.github.com"
 	manifestName    = "manifest-v1.json"
+	mutableRefTTL   = time.Hour
 )
 
 var (
@@ -111,6 +112,7 @@ type config struct {
 	codeload                            *url.URL
 	finalHosts                          map[string]bool
 	credential                          *actionSourceCredential
+	mutableRefs                         *mutableRefCache
 	maxCompressed, maxExpanded, maxFile int64
 	maxEntries                          int
 	maxPath, maxSegment                 int
@@ -212,6 +214,11 @@ func NewResolver(client *http.Client, opts ...Option) (*Resolver, error) {
 	if client == nil {
 		client = &http.Client{Timeout: 30 * time.Second}
 	}
+	if c.mutableRefs == nil && c.api.String() == defaultAPI {
+		if root, cacheErr := os.UserCacheDir(); cacheErr == nil {
+			c.mutableRefs, _ = newMutableRefCache(filepath.Join(root, "buildkite-gha", "action-ref-resolutions", "v1"), mutableRefTTL)
+		}
+	}
 	return &Resolver{client, c}, nil
 }
 func makeConfig(opts []Option) (config, error) {
@@ -234,6 +241,13 @@ func (r *Resolver) Resolve(ctx context.Context, ref Reference) (Resolved, error)
 	if shaRE.MatchString(ref.Ref) {
 		return Resolved{Reference: ref, Commit: ref.Ref}, nil
 	}
+	if r.cfg.mutableRefs != nil {
+		return r.cfg.mutableRefs.resolve(ctx, ref, r.resolveMutable)
+	}
+	return r.resolveMutable(ctx, ref)
+}
+
+func (r *Resolver) resolveMutable(ctx context.Context, ref Reference) (Resolved, error) {
 	if err := r.cfg.credential.provision(ctx); err != nil {
 		return Resolved{}, err
 	}

--- a/internal/action/source/source_test.go
+++ b/internal/action/source/source_test.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/buildkite/buildkite-gha/internal/action/metadata"
 )
@@ -188,6 +189,101 @@ func TestResolverOnlyTreatsLowercaseFullSHAAsResolved(t *testing.T) {
 	resolved, err := resolver.Resolve(context.Background(), ref)
 	if err != nil || resolved.Commit != testSHA || !slices.Equal(calls, []string{"/repos/o/r/git/ref/tags/" + upperSHA, "/repos/o/r/git/ref/heads/" + upperSHA, "/repos/o/r/commits/" + upperSHA}) {
 		t.Fatalf("Resolve() = %#v, %v; calls = %v", resolved, err, calls)
+	}
+}
+
+func TestResolverCachesMutableRefsWithBoundedFreshness(t *testing.T) {
+	cache := t.TempDir()
+	var calls atomic.Int32
+	commit := testSHA
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		_, _ = fmt.Fprintf(w, `{"object":{"type":"commit","sha":%q}}`, commit)
+	}))
+	defer server.Close()
+	ref, _ := Parse("owner/repo@v1")
+
+	resolver, err := NewResolver(server.Client(), WithTestEndpoints(server.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolver.cfg.mutableRefs, err = newMutableRefCache(cache, 50*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resolver.Resolve(context.Background(), ref); err != nil {
+		t.Fatal(err)
+	}
+	commit = strings.Repeat("a", 40)
+	resolver, err = NewResolver(server.Client(), WithTestEndpoints(server.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolver.cfg.mutableRefs, err = newMutableRefCache(cache, 50*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved, err := resolver.Resolve(context.Background(), ref)
+	if err != nil || resolved.Commit != testSHA || calls.Load() != 1 {
+		t.Fatalf("cached Resolve() = %#v, %v; calls = %d", resolved, err, calls.Load())
+	}
+	time.Sleep(60 * time.Millisecond)
+	resolved, err = resolver.Resolve(context.Background(), ref)
+	if err != nil || resolved.Commit != commit || calls.Load() != 2 {
+		t.Fatalf("revalidated Resolve() = %#v, %v; calls = %d", resolved, err, calls.Load())
+	}
+}
+
+func TestResolverMutableRefCacheCoalescesConcurrentProcesses(t *testing.T) {
+	cache := t.TempDir()
+	var calls atomic.Int32
+	started := make(chan struct{})
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) == 1 {
+			close(started)
+		}
+		<-release
+		_, _ = fmt.Fprintf(w, `{"object":{"type":"commit","sha":%q}}`, testSHA)
+	}))
+	defer server.Close()
+	ref, _ := Parse("owner/repo@v1")
+	const workers = 12
+	errors := make(chan error, workers)
+	for range workers {
+		go func() {
+			resolver, err := NewResolver(server.Client(), WithTestEndpoints(server.URL))
+			if err == nil {
+				resolver.cfg.mutableRefs, err = newMutableRefCache(cache, time.Hour)
+			}
+			if err == nil {
+				_, err = resolver.Resolve(context.Background(), ref)
+			}
+			errors <- err
+		}()
+	}
+	<-started
+	close(release)
+	for range workers {
+		if err := <-errors; err != nil {
+			t.Fatal(err)
+		}
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("GitHub requests = %d, want 1", calls.Load())
+	}
+}
+
+func TestResolverUsesXDGMutableRefCache(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", root)
+	resolver, err := NewResolver(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(root, "buildkite-gha", "action-ref-resolutions", "v1")
+	if resolver.cfg.mutableRefs == nil || resolver.cfg.mutableRefs.root != want || resolver.cfg.mutableRefs.freshness != time.Hour {
+		t.Fatalf("mutable ref cache = %#v, want root %q with one-hour freshness", resolver.cfg.mutableRefs, want)
 	}
 }
 

--- a/internal/action/source/source_test.go
+++ b/internal/action/source/source_test.go
@@ -274,9 +274,11 @@ func TestResolverMutableRefCacheCoalescesConcurrentProcesses(t *testing.T) {
 	}
 }
 
-func TestResolverUsesXDGMutableRefCache(t *testing.T) {
-	root := t.TempDir()
-	t.Setenv("XDG_CACHE_HOME", root)
+func TestResolverUsesPlatformMutableRefCache(t *testing.T) {
+	root, err := os.UserCacheDir()
+	if err != nil {
+		t.Fatal(err)
+	}
 	resolver, err := NewResolver(nil)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Why

Corpus validation repeatedly resolves the same mutable action refs through GitHub, consuming API quota and time even when another trusted worker resolved them recently.

## What

Cache mutable ref resolutions for one hour in the platform XDG cache. Per-ref file locks coalesce concurrent validation workers, and atomic bounded entries preserve a clear revalidation window when tags or branches move.
