### PR TITLE
Batch public corpus validation

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -72,6 +72,18 @@ buildkite-gha validate \
 
 `--action-cache-dir` is available only with `--profile hosted`. The cache stores verified action source by immutable commit. Mutable ref resolutions are cached for up to one hour under `$XDG_CACHE_HOME/buildkite-gha/action-ref-resolutions/v1` (or the platform user cache directory). Concurrent validation processes can share this resolution cache. A moved tag or branch can therefore use its previous commit for up to one hour. Do not share either writable cache between mutually untrusted validation jobs.
 
+For a large workflow corpus, reuse one validator process and action resolver:
+
+```sh
+buildkite-gha validate-batch \
+  --manifest workflows.jsonl \
+  --output-dir reports \
+  --corpus-id zenodo:20340547 \
+  --action-cache-dir .buildkite-gha-action-cache
+```
+
+Each JSON Lines manifest record requires `id`, `repository`, `path`, `hash`, and `source` fields. Batch validation applies the hosted profile to all declared supported events and writes one `processing-report/v3` JSON file per workflow. It uses one worker per CPU by default; set `--jobs` to override the worker count. It publishes each report atomically and resumes valid reports keyed by the corpus ID, record identity, content hash, and validator executable digest.
+
 Inspect the aggregate result and each event outcome:
 
 ```sh

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -47,6 +47,7 @@ const usage = `Usage:
 
 Commands:
   validate  Validate the supported static workflow subset
+  validate-batch  Validate a workflow manifest for corpus analysis
   compile   Compile a workflow to deterministic Buildkite pipeline YAML
   upload    Compile and upload a Buildkite pipeline
   run-job   Run a compiled job plan
@@ -55,10 +56,11 @@ Run "buildkite-gha help <command>" for command help.
 `
 
 var commandUsage = map[string]string{
-	"validate": "Usage: buildkite-gha validate [--profile hosted] [--event <name> | --event-path <path> | --all-events] [--action-cache-dir <path>] [--format text|json] <workflow>\n",
-	"compile":  "Usage: buildkite-gha compile --event-path <path> [--format pipeline|ir-json] <workflow>\n",
-	"upload":   "Usage: buildkite-gha upload [--event-path <path>] [--runner-queue <runs-on>=<queue>]... [--runner-image <runs-on>=<immutable-image>]... [--runtime-distribution <platform>=<absolute-path>]... [--experimental-runner-user] [--runtime-queue hosted] [--] <workflow-path> [<workflow-path>...]\n",
-	"run-job":  "Usage: buildkite-gha run-job (--plan <path> | --plan-digest <digest> --plan-producer <step>) [--result <path>] [--hosted-tool-cache]\n",
+	"validate":       "Usage: buildkite-gha validate [--profile hosted] [--event <name> | --event-path <path> | --all-events] [--action-cache-dir <path>] [--format text|json] <workflow>\n",
+	"validate-batch": "Usage: buildkite-gha validate-batch --manifest <path> --output-dir <path> --corpus-id <id> [--action-cache-dir <path>] [--jobs <count>]\n",
+	"compile":        "Usage: buildkite-gha compile --event-path <path> [--format pipeline|ir-json] <workflow>\n",
+	"upload":         "Usage: buildkite-gha upload [--event-path <path>] [--runner-queue <runs-on>=<queue>]... [--runner-image <runs-on>=<immutable-image>]... [--runtime-distribution <platform>=<absolute-path>]... [--experimental-runner-user] [--runtime-queue hosted] [--] <workflow-path> [<workflow-path>...]\n",
+	"run-job":        "Usage: buildkite-gha run-job (--plan <path> | --plan-digest <digest> --plan-producer <step>) [--result <path>] [--hosted-tool-cache]\n",
 }
 
 func writeCommandHelp(stdout io.Writer, command string) {
@@ -66,6 +68,8 @@ func writeCommandHelp(stdout io.Writer, command string) {
 	switch command {
 	case "validate":
 		_, _ = fmt.Fprint(stdout, "\nWithout --profile, validate checks event-independent syntax, the static graph, and every declared trigger; it does not evaluate hosted admission. The hosted profile resolves actions and applies production upload policy without executing jobs or proving arbitrary action runtime compatibility. Use --event-path for an exact snapshot, --event to generate one minimal compatibility snapshot, or --all-events to evaluate every declared supported event separately. Generated snapshots are test inputs, not substitutes for real payloads.\n")
+	case "validate-batch":
+		_, _ = fmt.Fprint(stdout, "\nThe manifest is newline-delimited JSON. Each record requires id, repository, path, hash, and source fields. Results are atomic processing-report/v3 JSON files keyed by the corpus ID, record identity, content hash, and validator executable. Existing valid results resume the batch.\n")
 	case "compile":
 		_, _ = fmt.Fprint(stdout, "\nPipeline output references content-addressed plans; compile does not materialize or upload those artifacts.\n")
 	case "upload":
@@ -151,6 +155,8 @@ func run(args []string, stdout, stderr io.Writer, clientVersion string, agentRun
 			switch args[0] {
 			case "validate":
 				return validate(args[1:], stdout, stderr, version, transport.Agent{Runner: agentRunner})
+			case "validate-batch":
+				return validateBatch(args[1:], stderr, version)
 			case "compile":
 				return compile(args[1:], stdout, stderr, version, transport.Agent{Runner: agentRunner})
 			case "upload":
@@ -1316,12 +1322,12 @@ func validate(args []string, stdout, stderr io.Writer, version string, agent tra
 	}
 	out := newProcessingOutput("validate", format, stdout, stderr, agent)
 	if allEvents {
-		return validateAllEvents(out, workflowPath, version, actionCacheDir, stderr)
+		return validateAllEvents(out, workflowPath, version, actionCacheDir, nil, stderr)
 	}
 	return validateOne(out, workflowPath, eventPath, eventName, profile, version, actionCacheDir, nil, stderr)
 }
 
-func validateOne(out processingOutput, workflowPath, eventPath, eventName, profile, version, actionCacheDir string, sharedActionSource compiler.ActionSource, stderr io.Writer) int {
+func validateOne(out processingOutput, workflowPath, eventPath, eventName, profile, version, actionCacheDir string, runtime *profileValidationRuntime, stderr io.Writer) int {
 	var loadEvent func() ([]byte, error)
 	if eventPath != "" {
 		event, eventErr := os.ReadFile(eventPath)
@@ -1369,7 +1375,13 @@ func validateOne(out processingOutput, workflowPath, eventPath, eventName, profi
 		return 1
 	}
 	if profile != "" {
-		_, _, distributionDigest, executableErr := executable()
+		distributionDigest := ""
+		var executableErr error
+		if runtime != nil {
+			distributionDigest, executableErr = runtime.distributionDigest, runtime.executableErr
+		} else {
+			_, _, distributionDigest, executableErr = executable()
+		}
 		if executableErr != nil {
 			processingReport.AddEnvironmentFailure("compiler executable could not be inspected")
 			processingReport.Result = "indeterminate"
@@ -1384,7 +1396,11 @@ func validateOne(out processingOutput, workflowPath, eventPath, eventName, profi
 			compiler.PlatformLinuxAMD64:  distributionDigest,
 			compiler.PlatformDarwinARM64: distributionDigest,
 		}
-		preflight, profileErr := compileHostedWithActionCache(ctx, workflowPath, source, event, version, distributionDigest, "buildkite-gha-profile-importer", "", nil, runtimeDistributions, actionCacheDir, sharedActionSource, nil)
+		var actionSource compiler.ActionSource
+		if runtime != nil {
+			actionSource = runtime.actionSource
+		}
+		preflight, profileErr := compileHostedWithActionCache(ctx, workflowPath, source, event, version, distributionDigest, "buildkite-gha-profile-importer", "", nil, runtimeDistributions, actionCacheDir, actionSource, nil)
 		applyHostedPreflight(&processingReport, preflight)
 		if profileErr != nil {
 			if ctx.Err() != nil || errors.Is(profileErr, context.Canceled) {
@@ -1416,7 +1432,13 @@ func validateOne(out processingOutput, workflowPath, eventPath, eventName, profi
 	return 0
 }
 
-func validateAllEvents(out processingOutput, workflowPath, version, actionCacheDir string, stderr io.Writer) int {
+type profileValidationRuntime struct {
+	actionSource       compiler.ActionSource
+	distributionDigest string
+	executableErr      error
+}
+
+func validateAllEvents(out processingOutput, workflowPath, version, actionCacheDir string, runtime *profileValidationRuntime, stderr io.Writer) int {
 	source, err := os.ReadFile(workflowPath)
 	if err != nil {
 		validation := compatibility.EnvironmentProcessingReport(workflowPath, "", "workflow input could not be read")
@@ -1445,14 +1467,21 @@ func validateAllEvents(out processingOutput, workflowPath, version, actionCacheD
 	for _, trigger := range parsed.Triggers {
 		declared[trigger.Event] = true
 	}
-	sharedActionSource, cleanup, err := newHostedActionSource(actionCacheDir, nil)
-	if err != nil {
-		validationReport.AddEnvironmentFailure("public action source could not be configured")
-		validationReport.Result = "indeterminate"
-		report.Validation = validationReport
-		_ = out.writeV3(report)
-		_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: %v\n", err)
-		return 1
+	cleanup := func() {}
+	if runtime == nil {
+		actionSource, sourceCleanup, sourceErr := newHostedActionSource(actionCacheDir, nil)
+		cleanup = sourceCleanup
+		if sourceErr != nil {
+			validationReport.AddEnvironmentFailure("public action source could not be configured")
+			validationReport.Result = "indeterminate"
+			report.Validation = validationReport
+			_ = out.writeV3(report)
+			_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: %v\n", sourceErr)
+			cleanup()
+			return 1
+		}
+		_, _, distributionDigest, executableErr := executable()
+		runtime = &profileValidationRuntime{actionSource: actionSource, distributionDigest: distributionDigest, executableErr: executableErr}
 	}
 	defer cleanup()
 	failed := false
@@ -1465,7 +1494,7 @@ func validateAllEvents(out processingOutput, workflowPath, version, actionCacheD
 			command: "validate", format: "json", reports: io.Discard, stderr: stderr,
 			observe: func(observed compatibility.ProcessingReport) { eventReport = &observed },
 		}
-		if code := validateOne(eventOut, workflowPath, "", event, hostedProfile, version, actionCacheDir, sharedActionSource, stderr); code != 0 {
+		if code := validateOne(eventOut, workflowPath, "", event, hostedProfile, version, actionCacheDir, runtime, stderr); code != 0 {
 			failed = true
 		}
 		if eventReport == nil {

--- a/internal/cli/validate_batch.go
+++ b/internal/cli/validate_batch.go
@@ -1,0 +1,274 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+
+	actionsource "github.com/buildkite/buildkite-gha/internal/action/source"
+	"github.com/buildkite/buildkite-gha/internal/compatibility"
+)
+
+const batchResultIdentity = "buildkite-gha-corpus-result/v1"
+
+type batchValidationArgs struct {
+	manifest, outputDir, corpusID, actionCacheDir string
+	jobs                                          int
+}
+
+type batchValidationRecord struct {
+	ID         string `json:"id"`
+	Repository string `json:"repository"`
+	Path       string `json:"path"`
+	Hash       string `json:"hash"`
+	Source     string `json:"source"`
+}
+
+type synchronizedWriter struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+func (w *synchronizedWriter) Write(data []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.w.Write(data)
+}
+
+func validateBatch(args []string, stderr io.Writer, version string) int {
+	options, err := parseBatchValidationArgs(args)
+	if err != nil {
+		return usageError(stderr, "validate-batch: %v", err)
+	}
+	records, err := loadBatchValidationManifest(options.manifest)
+	if err != nil {
+		return usageError(stderr, "validate-batch: %v", err)
+	}
+	if options.actionCacheDir != "" {
+		if _, err := actionsource.NewStore(options.actionCacheDir, nil); err != nil {
+			return usageError(stderr, "validate-batch: --action-cache-dir: %v", err)
+		}
+	}
+	actionSource, cleanup, err := newHostedActionSource(options.actionCacheDir, nil)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate-batch: %v\n", err)
+		return 1
+	}
+	defer cleanup()
+	_, _, distributionDigest, err := executable()
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate-batch: inspect validator executable: %v\n", err)
+		return 1
+	}
+	runtime := &profileValidationRuntime{actionSource: actionSource, distributionDigest: distributionDigest}
+	workerStderr := &synchronizedWriter{w: stderr}
+	ctx, stopSignals := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	defer stopSignals()
+	work := make(chan batchValidationRecord)
+	failures := make(chan error, 1)
+	var completed atomic.Int64
+	var resumed atomic.Int64
+	var workers sync.WaitGroup
+	for range options.jobs {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			for record := range work {
+				if ctx.Err() != nil {
+					return
+				}
+				resultPath := batchValidationResultPath(options, record, distributionDigest)
+				if validBatchValidationResult(resultPath, record.Source) {
+					resumed.Add(1)
+					continue
+				}
+				if err := writeBatchValidationResult(resultPath, record, version, options.actionCacheDir, runtime, workerStderr); err != nil {
+					select {
+					case failures <- fmt.Errorf("%s: %w", record.ID, err):
+						cancel()
+					default:
+					}
+					return
+				}
+				completed.Add(1)
+			}
+		}()
+	}
+sendRecords:
+	for _, record := range records {
+		select {
+		case <-ctx.Done():
+			break sendRecords
+		case work <- record:
+		}
+	}
+	close(work)
+	workers.Wait()
+	select {
+	case err := <-failures:
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate-batch: %v\n", err)
+		return 1
+	default:
+	}
+	if err := ctx.Err(); err != nil {
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate-batch: interrupted: %v\n", err)
+		return 1
+	}
+	_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate-batch: wrote %d reports; resumed %d\n", completed.Load(), resumed.Load())
+	return 0
+}
+
+func parseBatchValidationArgs(args []string) (batchValidationArgs, error) {
+	options := batchValidationArgs{jobs: runtime.NumCPU()}
+	seen := map[string]bool{}
+	for i := 0; i < len(args); i++ {
+		name := args[i]
+		if name != "--manifest" && name != "--output-dir" && name != "--corpus-id" && name != "--action-cache-dir" && name != "--jobs" {
+			return options, fmt.Errorf("unknown option %q", name)
+		}
+		if seen[name] {
+			return options, fmt.Errorf("%s may only be specified once", name)
+		}
+		seen[name] = true
+		i++
+		if i == len(args) || strings.TrimSpace(args[i]) == "" {
+			return options, fmt.Errorf("%s requires a value", name)
+		}
+		switch name {
+		case "--manifest":
+			options.manifest = args[i]
+		case "--output-dir":
+			options.outputDir = args[i]
+		case "--corpus-id":
+			options.corpusID = args[i]
+		case "--action-cache-dir":
+			options.actionCacheDir = args[i]
+		case "--jobs":
+			jobs, parseErr := strconv.Atoi(args[i])
+			if parseErr != nil || jobs <= 0 {
+				return options, fmt.Errorf("--jobs must be a positive integer")
+			}
+			options.jobs = jobs
+		}
+	}
+	if options.manifest == "" || options.outputDir == "" || options.corpusID == "" {
+		return options, fmt.Errorf("--manifest, --output-dir, and --corpus-id are required")
+	}
+	return options, nil
+}
+
+func loadBatchValidationManifest(path string) ([]batchValidationRecord, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open manifest: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	var records []batchValidationRecord
+	seen := map[string]bool{}
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for line := 1; scanner.Scan(); line++ {
+		var record batchValidationRecord
+		decoder := json.NewDecoder(strings.NewReader(scanner.Text()))
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&record); err != nil {
+			return nil, fmt.Errorf("manifest line %d: %w", line, err)
+		}
+		if decoder.Decode(&struct{}{}) != io.EOF {
+			return nil, fmt.Errorf("manifest line %d contains multiple JSON values", line)
+		}
+		if record.ID == "" || record.Repository == "" || record.Path == "" || record.Hash == "" || record.Source == "" {
+			return nil, fmt.Errorf("manifest line %d requires non-empty id, repository, path, hash, and source", line)
+		}
+		if strings.ContainsRune(record.ID+record.Repository+record.Path+record.Hash, '\x00') {
+			return nil, fmt.Errorf("manifest line %d identity fields must not contain NUL", line)
+		}
+		if seen[record.ID] {
+			return nil, fmt.Errorf("manifest line %d repeats id %q", line, record.ID)
+		}
+		seen[record.ID] = true
+		records = append(records, record)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read manifest: %w", err)
+	}
+	if len(records) == 0 {
+		return nil, fmt.Errorf("manifest contains no records")
+	}
+	return records, nil
+}
+
+func batchValidationResultPath(options batchValidationArgs, record batchValidationRecord, validatorDigest string) string {
+	identity := strings.Join([]string{batchResultIdentity, options.corpusID, validatorDigest, record.ID, record.Repository, record.Path, record.Hash}, "\x00")
+	digest := sha256.Sum256([]byte(identity))
+	key := hex.EncodeToString(digest[:])
+	return filepath.Join(options.outputDir, key[:2], key+".json")
+}
+
+func validBatchValidationResult(path, workflow string) bool {
+	file, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = file.Close() }()
+	var report compatibility.ProcessingReportV3
+	decoder := json.NewDecoder(file)
+	if decoder.Decode(&report) != nil || decoder.Decode(&struct{}{}) != io.EOF {
+		return false
+	}
+	if report.Schema != compatibility.ProcessingSchemaV3 || report.Profile != hostedProfile || report.Workflow != workflow || report.Validation.Schema != compatibility.ProcessingSchema {
+		return false
+	}
+	seen := make(map[string]bool, len(report.Evaluations))
+	for _, evaluation := range report.Evaluations {
+		if seen[evaluation.Event] || evaluation.Source != "generated" || evaluation.Report.Schema != compatibility.ProcessingSchema ||
+			(evaluation.Event != "push" && evaluation.Event != "pull_request" && evaluation.Event != "workflow_dispatch" && evaluation.Event != "schedule") {
+			return false
+		}
+		seen[evaluation.Event] = true
+	}
+	return true
+}
+
+func writeBatchValidationResult(path string, record batchValidationRecord, version, actionCacheDir string, runtime *profileValidationRuntime, stderr io.Writer) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create report directory: %w", err)
+	}
+	temporary, err := os.CreateTemp(filepath.Dir(path), ".report-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create report: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	defer func() { _ = os.Remove(temporaryPath) }()
+	out := processingOutput{command: "validate-batch", format: "json", reports: temporary, stderr: stderr}
+	_ = validateAllEvents(out, record.Source, version, actionCacheDir, runtime, stderr)
+	if err := temporary.Sync(); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("sync report: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close report: %w", err)
+	}
+	if !validBatchValidationResult(temporaryPath, record.Source) {
+		return fmt.Errorf("validation did not produce a valid processing report")
+	}
+	if err := os.Rename(temporaryPath, path); err != nil {
+		return fmt.Errorf("publish report: %w", err)
+	}
+	return nil
+}

--- a/internal/cli/validate_batch.go
+++ b/internal/cli/validate_batch.go
@@ -231,12 +231,13 @@ func validBatchValidationResult(path, workflow string) bool {
 	if decoder.Decode(&report) != nil || decoder.Decode(&struct{}{}) != io.EOF {
 		return false
 	}
-	if report.Schema != compatibility.ProcessingSchemaV3 || report.Profile != hostedProfile || report.Workflow != workflow || report.Validation.Schema != compatibility.ProcessingSchema {
+	if report.Schema != compatibility.ProcessingSchemaV3 || report.Profile != hostedProfile || report.Workflow != workflow ||
+		report.Validation.Schema != compatibility.ProcessingSchema || report.Validation.Result == "indeterminate" {
 		return false
 	}
 	seen := make(map[string]bool, len(report.Evaluations))
 	for _, evaluation := range report.Evaluations {
-		if seen[evaluation.Event] || evaluation.Source != "generated" || evaluation.Report.Schema != compatibility.ProcessingSchema ||
+		if seen[evaluation.Event] || evaluation.Source != "generated" || evaluation.Report.Schema != compatibility.ProcessingSchema || evaluation.Report.Result == "indeterminate" ||
 			(evaluation.Event != "push" && evaluation.Event != "pull_request" && evaluation.Event != "workflow_dispatch" && evaluation.Event != "schedule") {
 			return false
 		}

--- a/internal/cli/validate_batch_test.go
+++ b/internal/cli/validate_batch_test.go
@@ -134,6 +134,42 @@ func TestBatchValidationManifestAndIdentity(t *testing.T) {
 	}
 }
 
+func TestBatchValidationDoesNotResumeIndeterminateReports(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "report.json")
+	report := compatibility.NewProcessingReportV3("workflow.yml", hostedProfile, compatibility.ProcessingReport{
+		Schema: compatibility.ProcessingSchema,
+		Result: "indeterminate",
+	})
+	contents, err := json.Marshal(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, contents, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if validBatchValidationResult(path, "workflow.yml") {
+		t.Fatal("indeterminate validation report was resumable")
+	}
+
+	report.Validation.Result = "compilable"
+	report.Evaluations = []compatibility.EventEvaluation{{
+		Event:  "push",
+		Source: "generated",
+		Report: compatibility.ProcessingReport{Schema: compatibility.ProcessingSchema, Result: "indeterminate"},
+	}}
+	contents, err = json.Marshal(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, contents, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if validBatchValidationResult(path, "workflow.yml") {
+		t.Fatal("indeterminate event report was resumable")
+	}
+}
+
 func writeBatchManifest(t *testing.T, root string, records []batchValidationRecord) string {
 	t.Helper()
 	path := filepath.Join(root, "manifest.jsonl")

--- a/internal/cli/validate_batch_test.go
+++ b/internal/cli/validate_batch_test.go
@@ -1,0 +1,168 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	actionsource "github.com/buildkite/buildkite-gha/internal/action/source"
+	"github.com/buildkite/buildkite-gha/internal/compatibility"
+	"github.com/buildkite/buildkite-gha/internal/compiler"
+)
+
+type batchCountingActionSource struct {
+	calls  int
+	root   string
+	digest string
+}
+
+func (s *batchCountingActionSource) Fetch(_ context.Context, ref actionsource.Reference) (actionsource.Resolved, actionsource.Materialized, error) {
+	s.calls++
+	commit := strings.Repeat("a", 40)
+	return actionsource.Resolved{Reference: ref, Commit: commit, SourceDigest: s.digest}, actionsource.Materialized{RepositoryRoot: s.root, ActionRoot: s.root, SourceDigest: s.digest}, nil
+}
+
+func TestValidateBatchWritesAndResumesAtomicReports(t *testing.T) {
+	root := t.TempDir()
+	output := filepath.Join(root, "reports")
+	records := []batchValidationRecord{
+		{ID: "one", Repository: "owner/one", Path: ".github/workflows/ci.yml", Hash: strings.Repeat("1", 64), Source: filepath.Join(root, "one.yml")},
+		{ID: "two", Repository: "owner/two", Path: ".github/workflows/test.yml", Hash: strings.Repeat("2", 64), Source: filepath.Join(root, "two.yml")},
+	}
+	workflow := []byte("on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo ok\n")
+	for _, record := range records {
+		if err := os.WriteFile(record.Source, workflow, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	manifest := writeBatchManifest(t, root, records)
+	args := []string{"validate-batch", "--manifest", manifest, "--output-dir", output, "--corpus-id", "test-corpus"}
+	var stdout, stderr bytes.Buffer
+	if code := Run(args, &stdout, &stderr, "dev"); code != 0 || stdout.Len() != 0 {
+		t.Fatalf("Run() = %d, stdout %q, stderr %q", code, stdout.String(), stderr.String())
+	}
+	reports := batchReports(t, output)
+	if len(reports) != len(records) {
+		t.Fatalf("reports = %v, want %d", reports, len(records))
+	}
+	for _, path := range reports {
+		var report compatibility.ProcessingReportV3
+		contents, err := os.ReadFile(path)
+		if err != nil || json.Unmarshal(contents, &report) != nil || report.Schema != compatibility.ProcessingSchemaV3 || report.Profile != hostedProfile {
+			t.Fatalf("report %q is invalid: %v\n%s", path, err, contents)
+		}
+	}
+
+	first := reports[0]
+	if err := os.WriteFile(first, []byte("{"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stderr.Reset()
+	if code := Run(args, &stdout, &stderr, "dev"); code != 0 || !strings.Contains(stderr.String(), "wrote 1 reports; resumed 1") {
+		t.Fatalf("resumed Run() = %d, stderr %q", code, stderr.String())
+	}
+}
+
+func TestBatchValidationReusesActionResolutionAcrossWorkflows(t *testing.T) {
+	root := t.TempDir()
+	actionRoot := filepath.Join(root, "action")
+	if err := os.Mkdir(actionRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(actionRoot, "action.yml"), []byte("runs:\n  using: node24\n  main: index.js\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(actionRoot, "index.js"), []byte("console.log('ok')\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	digest, err := actionsource.DigestTree(actionRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := &batchCountingActionSource{root: actionRoot, digest: digest}
+	_, _, distributionDigest, err := executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime := &profileValidationRuntime{actionSource: compiler.MemoizeActionSource(source), distributionDigest: distributionDigest}
+	workflow := []byte("on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: owner/action@v1\n")
+	for _, name := range []string{"one", "two"} {
+		path := filepath.Join(root, name, ".github", "workflows", "ci.yml")
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, workflow, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		out := processingOutput{command: "validate-batch", format: "json", reports: io.Discard, stderr: io.Discard}
+		if code := validateAllEvents(out, path, "dev", "", runtime, io.Discard); code != 0 {
+			t.Fatalf("validateAllEvents(%s) = %d", name, code)
+		}
+	}
+	if source.calls != 1 {
+		t.Fatalf("action source calls = %d, want 1", source.calls)
+	}
+}
+
+func TestBatchValidationManifestAndIdentity(t *testing.T) {
+	root := t.TempDir()
+	valid := batchValidationRecord{ID: "one", Repository: "owner/repo", Path: "ci.yml", Hash: "hash", Source: "source.yml"}
+	manifest := writeBatchManifest(t, root, []batchValidationRecord{valid, valid})
+	if _, err := loadBatchValidationManifest(manifest); err == nil || !strings.Contains(err.Error(), "repeats id") {
+		t.Fatalf("duplicate manifest error = %v", err)
+	}
+	if _, err := parseBatchValidationArgs([]string{"--manifest", "manifest"}); err == nil || !strings.Contains(err.Error(), "required") {
+		t.Fatalf("missing options error = %v", err)
+	}
+	options := batchValidationArgs{outputDir: root, corpusID: "record-one"}
+	base := batchValidationResultPath(options, valid, "validator-one")
+	variants := []string{
+		batchValidationResultPath(batchValidationArgs{outputDir: root, corpusID: "record-two"}, valid, "validator-one"),
+		batchValidationResultPath(options, valid, "validator-two"),
+		batchValidationResultPath(options, batchValidationRecord{ID: "two", Repository: valid.Repository, Path: valid.Path, Hash: valid.Hash}, "validator-one"),
+		batchValidationResultPath(options, batchValidationRecord{ID: valid.ID, Repository: valid.Repository, Path: valid.Path, Hash: "other"}, "validator-one"),
+	}
+	for _, variant := range variants {
+		if variant == base {
+			t.Fatalf("result identity collision: %q", variant)
+		}
+	}
+}
+
+func writeBatchManifest(t *testing.T, root string, records []batchValidationRecord) string {
+	t.Helper()
+	path := filepath.Join(root, "manifest.jsonl")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoder := json.NewEncoder(file)
+	for _, record := range records {
+		if err := encoder.Encode(record); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func batchReports(t *testing.T, root string) []string {
+	t.Helper()
+	var reports []string
+	if err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err == nil && !entry.IsDir() && strings.HasSuffix(path, ".json") {
+			reports = append(reports, path)
+		}
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return reports
+}

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -487,6 +487,7 @@ type memoizedActionSource struct {
 	source ActionSource
 	mu     sync.Mutex
 	cache  map[string]memoizedAction
+	active map[string]*memoizedActionCall
 }
 
 type memoizedAction struct {
@@ -494,11 +495,18 @@ type memoizedAction struct {
 	materialized source.Materialized
 }
 
+type memoizedActionCall struct {
+	done         chan struct{}
+	resolved     source.Resolved
+	materialized source.Materialized
+	err          error
+}
+
 func newMemoizedActionSource(actionSource ActionSource) ActionSource {
 	if actionSource == nil {
 		return nil
 	}
-	return &memoizedActionSource{source: actionSource, cache: map[string]memoizedAction{}}
+	return &memoizedActionSource{source: actionSource, cache: map[string]memoizedAction{}, active: map[string]*memoizedActionCall{}}
 }
 
 // MemoizeActionSource reuses successful action resolutions and materializations
@@ -514,13 +522,28 @@ func (s *memoizedActionSource) Fetch(ctx context.Context, ref source.Reference) 
 		s.mu.Unlock()
 		return cached.resolved, cached.materialized, nil
 	}
-	s.mu.Unlock()
-	resolved, materialized, err := s.source.Fetch(ctx, ref)
-	if err != nil {
-		return source.Resolved{}, source.Materialized{}, err
+	if active, ok := s.active[key]; ok {
+		s.mu.Unlock()
+		select {
+		case <-ctx.Done():
+			return source.Resolved{}, source.Materialized{}, ctx.Err()
+		case <-active.done:
+			if active.err != nil && ctx.Err() == nil && (errors.Is(active.err, context.Canceled) || errors.Is(active.err, context.DeadlineExceeded)) {
+				return s.Fetch(ctx, ref)
+			}
+			return active.resolved, active.materialized, active.err
+		}
 	}
-	s.mu.Lock()
-	s.cache[key] = memoizedAction{resolved: resolved, materialized: materialized}
+	call := &memoizedActionCall{done: make(chan struct{})}
+	s.active[key] = call
 	s.mu.Unlock()
-	return resolved, materialized, nil
+	call.resolved, call.materialized, call.err = s.source.Fetch(ctx, ref)
+	s.mu.Lock()
+	delete(s.active, key)
+	if call.err == nil {
+		s.cache[key] = memoizedAction{resolved: call.resolved, materialized: call.materialized}
+	}
+	close(call.done)
+	s.mu.Unlock()
+	return call.resolved, call.materialized, call.err
 }

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -10,6 +10,8 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -26,6 +28,20 @@ type fakeActionSource struct {
 }
 
 type contextActionSource struct{}
+
+type blockingActionSource struct {
+	calls   atomic.Int32
+	started chan struct{}
+	release chan struct{}
+}
+
+func (s *blockingActionSource) Fetch(_ context.Context, ref source.Reference) (source.Resolved, source.Materialized, error) {
+	if s.calls.Add(1) == 1 {
+		close(s.started)
+	}
+	<-s.release
+	return source.Resolved{Reference: ref, Commit: strings.Repeat("a", 40)}, source.Materialized{}, nil
+}
 
 func (contextActionSource) Fetch(ctx context.Context, _ source.Reference) (source.Resolved, source.Materialized, error) {
 	<-ctx.Done()
@@ -430,6 +446,38 @@ runs:
 	}
 	if fake.calls["owner/action@v1"] != 1 {
 		t.Fatalf("remote action resolutions = %d, want one shared resolution", fake.calls["owner/action@v1"])
+	}
+}
+
+func TestMemoizeActionSourceCoalescesConcurrentResolution(t *testing.T) {
+	fake := &blockingActionSource{started: make(chan struct{}), release: make(chan struct{})}
+	shared := MemoizeActionSource(fake)
+	ref, err := source.Parse("owner/action@v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	const workers = 20
+	var wait sync.WaitGroup
+	errs := make(chan error, workers)
+	for range workers {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			_, _, err := shared.Fetch(context.Background(), ref)
+			errs <- err
+		}()
+	}
+	<-fake.started
+	close(fake.release)
+	wait.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if fake.calls.Load() != 1 {
+		t.Fatalf("underlying resolutions = %d, want 1", fake.calls.Load())
 	}
 }
 

--- a/scripts/validate-public-workflow-corpus
+++ b/scripts/validate-public-workflow-corpus
@@ -6,14 +6,7 @@ readonly root
 
 workdir="${WORKDIR:-$HOME/gha-corpus}"
 record_id="${RECORD_ID:-20340547}"
-if [[ -n "${JOBS:-}" ]]; then
-  jobs="$JOBS"
-elif command -v nproc >/dev/null; then
-  jobs="$(nproc)"
-else
-  jobs="$(sysctl -n hw.ncpu)"
-fi
-readonly record_id jobs
+readonly record_id
 
 for command in curl python3; do
   command -v "$command" >/dev/null || {
@@ -21,11 +14,6 @@ for command in curl python3; do
     exit 127
   }
 done
-[[ "$jobs" =~ ^[1-9][0-9]*$ ]] || {
-  echo "JOBS must be a positive integer, got: $jobs" >&2
-  exit 2
-}
-
 mkdir -p "$workdir"
 workdir="$(cd "$workdir" && pwd)"
 corpus_dir="$workdir/records/$record_id"
@@ -45,7 +33,7 @@ download workflows.csv.gz
 download workflows.tar.gz
 
 if [[ ! -f files/.complete-v3 ]]; then
-  rm -rf files reports workflows.tsv
+  rm -rf files reports workflows.tsv workflows.jsonl
   mkdir -p files
   python3 - <<'PY'
 import csv
@@ -116,6 +104,41 @@ open("files/.complete-v3", "w").close()
 PY
 fi
 
+if [[ ! -f workflows.jsonl ]]; then
+  python3 - <<'PY'
+import json
+import os
+
+with open("workflows.tsv", encoding="utf-8") as source, open(
+    "workflows.jsonl", "w", encoding="utf-8"
+) as destination:
+    for line in source:
+        workflow_id, repository, path, file_hash = line.rstrip("\n").split("\t")
+        local_path = os.path.abspath(
+            os.path.join(
+                "files",
+                workflow_id[:3],
+                workflow_id,
+                ".github",
+                "workflows",
+                os.path.basename(path),
+            )
+        )
+        json.dump(
+            {
+                "id": workflow_id,
+                "repository": repository,
+                "path": path,
+                "hash": file_hash,
+                "source": local_path,
+            },
+            destination,
+            sort_keys=True,
+        )
+        destination.write("\n")
+PY
+fi
+
 validator="$workdir/buildkite-gha"
 (
   cd "$root"
@@ -124,28 +147,41 @@ validator="$workdir/buildkite-gha"
 )
 validator_commit="$(git -C "$root" rev-parse HEAD)"
 validator_version="$("$validator" --version)"
-readonly validator validator_commit validator_version
-printf 'validator: %s (%s)\n' "$validator_version" "$validator_commit"
-[[ "$("$validator" help validate)" == *"--action-cache-dir"* ]] || {
-  echo 'buildkite-gha validate must support --action-cache-dir' >&2
+validator_digest="$(python3 - "$validator" <<'PY'
+import hashlib
+import sys
+
+digest = hashlib.sha256()
+with open(sys.argv[1], "rb") as source:
+    for chunk in iter(lambda: source.read(1024 * 1024), b""):
+        digest.update(chunk)
+print(digest.hexdigest())
+PY
+)"
+readonly validator validator_commit validator_version validator_digest
+printf 'validator: %s (%s, sha256:%s)\n' "$validator_version" "$validator_commit" "$validator_digest"
+[[ "$("$validator" help validate-batch)" == *"--action-cache-dir"* ]] || {
+  echo 'buildkite-gha validate-batch must support --action-cache-dir' >&2
   exit 1
 }
 
 action_cache="$workdir/action-cache"
-readonly action_cache
+reports="$workdir/reports/$record_id/$validator_digest"
+readonly action_cache reports
 mkdir -p "$action_cache"
-rm -rf reports
-mkdir -p reports
-export action_cache validator validator_commit validator_version
-# The quoted variables expand in each xargs child shell.
-# shellcheck disable=SC2016
-find files -mindepth 3 -type f \( -name '*.yml' -o -name '*.yaml' \) -print0 \
-  | xargs -0 -P "$jobs" -n 1 bash -c '
-      workflow=$1
-      workflow_id=${workflow#files/*/}
-      workflow_id=${workflow_id%%/*}
-      "$validator" validate --profile hosted --all-events --action-cache-dir "$action_cache" --format json "$workflow" > "reports/$workflow_id.json" 2>/dev/null || true
-    ' _
+mkdir -p "$reports"
+export reports validator_commit validator_version validator_digest
+batch_args=(
+  validate-batch
+  --manifest workflows.jsonl
+  --output-dir "$reports"
+  --corpus-id "zenodo:$record_id"
+  --action-cache-dir "$action_cache"
+)
+if [[ -n "${JOBS:-}" ]]; then
+  batch_args+=(--jobs "$JOBS")
+fi
+"$validator" "${batch_args[@]}"
 
 python3 - <<'PY'
 import collections
@@ -154,10 +190,10 @@ import json
 import os
 
 repositories = {}
-with open("workflows.tsv", encoding="utf-8") as manifest:
+with open("workflows.jsonl", encoding="utf-8") as manifest:
     for line in manifest:
-        workflow_id, repository, _, _ = line.rstrip("\n").split("\t")
-        repositories[workflow_id] = repository
+        record = json.loads(line)
+        repositories[record["source"]] = record["repository"]
 
 blocked_repos = set()
 codes_by_repo = collections.defaultdict(set)
@@ -165,19 +201,19 @@ findings = collections.Counter()
 evaluations = collections.Counter()
 seen_workflows = set()
 bad_reports = 0
-for path in glob.glob("reports/*.json"):
-    workflow_id = path.rsplit("/", 1)[-1].removesuffix(".json")
-    repository = repositories[workflow_id]
-    seen_workflows.add(workflow_id)
+for path in glob.glob(os.path.join(os.environ["reports"], "**", "*.json"), recursive=True):
     try:
         with open(path, encoding="utf-8") as report:
             result = json.load(report)
     except (OSError, json.JSONDecodeError):
+        continue
+    workflow = result.get("workflow")
+    repository = repositories.get(workflow)
+    if repository is None or workflow in seen_workflows:
         bad_reports += 1
-        blocked_repos.add(repository)
-        codes_by_repo[repository].add("E_REPORT")
         findings["E_REPORT"] += 1
         continue
+    seen_workflows.add(workflow)
     if (
         result.get("schema") != "buildkite-gha/processing-report/v3"
         or result.get("profile") != "hosted"
@@ -224,8 +260,8 @@ for path in glob.glob("reports/*.json"):
             codes_by_repo[repository].add(code)
             findings[code] += 1
 
-for workflow_id in repositories.keys() - seen_workflows:
-    repository = repositories[workflow_id]
+for workflow in repositories.keys() - seen_workflows:
+    repository = repositories[workflow]
     bad_reports += 1
     blocked_repos.add(repository)
     codes_by_repo[repository].add("E_REPORT")
@@ -252,6 +288,7 @@ with open("validate-tally.json", "w", encoding="utf-8") as destination:
             "clean": clean,
             "validator_commit": os.environ["validator_commit"],
             "validator_version": os.environ["validator_version"],
+            "validator_digest": "sha256:" + os.environ["validator_digest"],
             "admission_scope": "generated-event-snapshots",
             "by_repo": dict(repos_by_code),
             "by_finding": dict(findings),


### PR DESCRIPTION
## Why

The public workflow corpus is too large to launch one validator process per workflow, and interrupted runs currently restart completed work.

## What

Add a concurrent batch validation command that shares action resolution across workflows and atomically resumes results keyed by corpus record, content, and validator executable. Update the corpus script to use the batch path while retaining one `processing-report/v3` result per workflow.
