### PR TITLE
Persist indeterminate batch reports

### DIFF
--- a/internal/cli/validate_batch.go
+++ b/internal/cli/validate_batch.go
@@ -221,29 +221,47 @@ func batchValidationResultPath(options batchValidationArgs, record batchValidati
 }
 
 func validBatchValidationResult(path, workflow string) bool {
+	report, valid := loadBatchValidationResult(path, workflow)
+	if !valid || report.Validation.Result == "indeterminate" {
+		return false
+	}
+	for _, evaluation := range report.Evaluations {
+		if evaluation.Report.Result == "indeterminate" {
+			return false
+		}
+	}
+	return true
+}
+
+func validBatchProcessingReport(path, workflow string) bool {
+	_, valid := loadBatchValidationResult(path, workflow)
+	return valid
+}
+
+func loadBatchValidationResult(path, workflow string) (compatibility.ProcessingReportV3, bool) {
 	file, err := os.Open(path)
 	if err != nil {
-		return false
+		return compatibility.ProcessingReportV3{}, false
 	}
 	defer func() { _ = file.Close() }()
 	var report compatibility.ProcessingReportV3
 	decoder := json.NewDecoder(file)
 	if decoder.Decode(&report) != nil || decoder.Decode(&struct{}{}) != io.EOF {
-		return false
+		return compatibility.ProcessingReportV3{}, false
 	}
 	if report.Schema != compatibility.ProcessingSchemaV3 || report.Profile != hostedProfile || report.Workflow != workflow ||
-		report.Validation.Schema != compatibility.ProcessingSchema || report.Validation.Result == "indeterminate" {
-		return false
+		report.Validation.Schema != compatibility.ProcessingSchema {
+		return compatibility.ProcessingReportV3{}, false
 	}
 	seen := make(map[string]bool, len(report.Evaluations))
 	for _, evaluation := range report.Evaluations {
-		if seen[evaluation.Event] || evaluation.Source != "generated" || evaluation.Report.Schema != compatibility.ProcessingSchema || evaluation.Report.Result == "indeterminate" ||
+		if seen[evaluation.Event] || evaluation.Source != "generated" || evaluation.Report.Schema != compatibility.ProcessingSchema ||
 			(evaluation.Event != "push" && evaluation.Event != "pull_request" && evaluation.Event != "workflow_dispatch" && evaluation.Event != "schedule") {
-			return false
+			return compatibility.ProcessingReportV3{}, false
 		}
 		seen[evaluation.Event] = true
 	}
-	return true
+	return report, true
 }
 
 func writeBatchValidationResult(path string, record batchValidationRecord, version, actionCacheDir string, runtime *profileValidationRuntime, stderr io.Writer) error {
@@ -265,7 +283,7 @@ func writeBatchValidationResult(path string, record batchValidationRecord, versi
 	if err := temporary.Close(); err != nil {
 		return fmt.Errorf("close report: %w", err)
 	}
-	if !validBatchValidationResult(temporaryPath, record.Source) {
+	if !validBatchProcessingReport(temporaryPath, record.Source) {
 		return fmt.Errorf("validation did not produce a valid processing report")
 	}
 	if err := os.Rename(temporaryPath, path); err != nil {

--- a/internal/cli/validate_batch_test.go
+++ b/internal/cli/validate_batch_test.go
@@ -151,6 +151,9 @@ func TestBatchValidationDoesNotResumeIndeterminateReports(t *testing.T) {
 	if validBatchValidationResult(path, "workflow.yml") {
 		t.Fatal("indeterminate validation report was resumable")
 	}
+	if !validBatchProcessingReport(path, "workflow.yml") {
+		t.Fatal("indeterminate validation report was not persistable")
+	}
 
 	report.Validation.Result = "compilable"
 	report.Evaluations = []compatibility.EventEvaluation{{
@@ -167,6 +170,9 @@ func TestBatchValidationDoesNotResumeIndeterminateReports(t *testing.T) {
 	}
 	if validBatchValidationResult(path, "workflow.yml") {
 		t.Fatal("indeterminate event report was resumable")
+	}
+	if !validBatchProcessingReport(path, "workflow.yml") {
+		t.Fatal("indeterminate event report was not persistable")
 	}
 }
 


### PR DESCRIPTION
## Why

`validate-batch` aborts a corpus run when hosted validation produces a structurally valid `indeterminate` report, which is expected for workflows whose referenced local actions are absent from the corpus snapshot.

## What

Persist structurally valid indeterminate reports so the current batch can finish, while continuing to reject them as resumable results so a later run retries them.
