### PR TITLE
Fix trigger validation call

### DIFF
--- a/internal/buildkite/triggers.go
+++ b/internal/buildkite/triggers.go
@@ -79,7 +79,7 @@ func TranslateTriggerCondition(triggers []workflow.Trigger) (string, error) {
 // rules as pipeline generation without selecting an effective event.
 func ValidateTriggerConditions(triggers []workflow.Trigger) error {
 	for _, trigger := range triggers {
-		if _, _, err := translateTrigger(trigger, liveTriggerContext(trigger.Event)); err != nil {
+		if _, _, err := translateTrigger(trigger, liveTriggerContext(trigger.Event), true); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Why

The merged path-filter change added a required argument to the trigger translator but left one validation call unchanged, so `main` does not compile.

## What

Mark each trigger as selected when validating it against the same live-context rules used by pipeline translation.