### PR TITLE
Bound batch action source cache

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -79,10 +79,13 @@ buildkite-gha validate-batch \
   --manifest workflows.jsonl \
   --output-dir reports \
   --corpus-id zenodo:20340547 \
-  --action-cache-dir .buildkite-gha-action-cache
+  --action-cache-dir .buildkite-gha-action-cache \
+  --action-cache-max-bytes 21474836480
 ```
 
 Each JSON Lines manifest record requires `id`, `repository`, `path`, `hash`, and `source` fields. Batch validation applies the hosted profile to all declared supported events and writes one `processing-report/v3` JSON file per workflow. It uses one worker per CPU by default; set `--jobs` to override the worker count. It publishes each report atomically and resumes valid reports keyed by the corpus ID, record identity, content hash, and validator executable digest.
+
+`--action-cache-max-bytes` requires `--action-cache-dir`. It evicts the least recently used immutable action trees until the cache is within the byte budget. Concurrent validators protect entries while reading or publishing them. Maintenance also removes abandoned partial entries; active partial entries remain locked. The public corpus script defaults to 20 GiB, leaving headroom on a 64 GB orb.
 
 Inspect the aggregate result and each event outcome:
 

--- a/internal/action/source/action_cache.go
+++ b/internal/action/source/action_cache.go
@@ -3,6 +3,7 @@ package source
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -33,14 +34,13 @@ func (s *Store) materializedLease(lock *actionCacheLock, resolved Resolved, tree
 		lock.unlock()
 		return Materialized{}, err
 	}
-	if s.cfg.cacheMaxBytes == 0 {
-		lock.unlock()
-		return m, nil
-	}
 	lease := &materializedLease{}
 	lease.release = func() {
 		lease.once.Do(func() {
 			lock.unlock()
+			if s.cfg.cacheMaxBytes == 0 {
+				return
+			}
 			total, _ := s.readCacheSize()
 			if s.pressure.Load() || total > s.cfg.cacheMaxBytes {
 				_ = s.maintain(context.Background())
@@ -148,6 +148,11 @@ func (s *Store) maintainLocked(ctx context.Context) error {
 		if lockErr != nil {
 			continue
 		}
+		manifest, statErr := os.Stat(filepath.Join(entry.path, manifestName))
+		if statErr != nil || manifest.ModTime().After(entry.lastUse) {
+			lock.unlock()
+			continue
+		}
 		if err := os.RemoveAll(entry.path); err != nil {
 			lock.unlock()
 			return err
@@ -160,9 +165,6 @@ func (s *Store) maintainLocked(ctx context.Context) error {
 }
 
 func (s *Store) publishCacheEntry(ctx context.Context, temporary, base string) error {
-	if s.cfg.cacheMaxBytes == 0 {
-		return os.Rename(temporary, base)
-	}
 	maintenance, err := lockActionCache(ctx, filepath.Join(s.root, ".maintenance.lock"), actionCacheLockExclusive, false)
 	if err != nil {
 		return err
@@ -182,12 +184,24 @@ func (s *Store) publishCacheEntry(ctx context.Context, temporary, base string) e
 		return err
 	}
 	total, err := s.readCacheSize()
+	if s.cfg.cacheMaxBytes == 0 && errors.Is(err, os.ErrNotExist) {
+		published = false
+		return nil
+	}
 	if err != nil {
+		if s.cfg.cacheMaxBytes == 0 {
+			return err
+		}
 		err = s.maintainLocked(ctx)
 		published = err != nil
 		return err
 	}
 	total += size
+	if s.cfg.cacheMaxBytes == 0 {
+		err = s.writeCacheSize(total)
+		published = err != nil
+		return err
+	}
 	if total > s.cfg.cacheMaxBytes {
 		err = s.maintainLocked(ctx)
 		published = err != nil

--- a/internal/action/source/action_cache.go
+++ b/internal/action/source/action_cache.go
@@ -1,0 +1,294 @@
+package source
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+type cacheEntry struct {
+	path    string
+	size    int64
+	lastUse time.Time
+}
+
+type materializedLease struct {
+	release func()
+	retain  func(context.Context) (Materialized, error)
+	once    sync.Once
+}
+
+func (s *Store) materializedLease(lock *actionCacheLock, resolved Resolved, tree, actionPath, digest string) (Materialized, error) {
+	m, err := materialized(tree, actionPath, digest)
+	if err != nil {
+		lock.unlock()
+		return Materialized{}, err
+	}
+	if s.cfg.cacheMaxBytes == 0 {
+		lock.unlock()
+		return m, nil
+	}
+	lease := &materializedLease{}
+	lease.release = func() {
+		lease.once.Do(func() {
+			lock.unlock()
+			total, _ := s.readCacheSize()
+			if s.pressure.Load() || total > s.cfg.cacheMaxBytes {
+				_ = s.maintain(context.Background())
+			}
+		})
+	}
+	lease.retain = func(ctx context.Context) (Materialized, error) {
+		base := filepath.Dir(tree)
+		retained, err := lockActionCache(ctx, base+".lock", actionCacheLockShared, false)
+		if err != nil {
+			return Materialized{}, err
+		}
+		cached, err := s.cachedManifest(base, resolved)
+		if err != nil {
+			retained.unlock()
+			return s.Materialize(ctx, resolved)
+		}
+		s.touch(base)
+		return s.materializedLease(retained, resolved, tree, actionPath, cached.Digest)
+	}
+	m.lease = lease
+	return m, nil
+}
+
+func (s *Store) cachedManifest(base string, resolved Resolved) (manifest, error) {
+	data, err := os.ReadFile(filepath.Join(base, manifestName))
+	if err != nil || len(data) > 16<<20 {
+		return manifest{}, fmt.Errorf("invalid manifest")
+	}
+	var cached manifest
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.DisallowUnknownFields()
+	if decoder.Decode(&cached) != nil || decoder.Decode(&struct{}{}) != io.EOF ||
+		cached.Schema != "buildkite-gha-action-source/v1" ||
+		cached.Owner != strings.ToLower(resolved.Reference.Owner) ||
+		cached.Repository != strings.ToLower(resolved.Reference.Repository) ||
+		cached.Commit != resolved.Commit || cached.Digest == "" ||
+		(resolved.SourceDigest != "" && cached.Digest != resolved.SourceDigest) {
+		return manifest{}, fmt.Errorf("invalid manifest")
+	}
+	return cached, nil
+}
+
+func (s *Store) touch(base string) {
+	now := time.Now()
+	_ = os.Chtimes(filepath.Join(base, manifestName), now, now)
+}
+
+func (s *Store) createPartial(ctx context.Context, parent string) (string, *actionCacheLock, error) {
+	maintenance, err := lockActionCache(ctx, filepath.Join(s.root, ".maintenance.lock"), actionCacheLockExclusive, false)
+	if err != nil {
+		return "", nil, err
+	}
+	defer maintenance.unlock()
+	tmp, err := os.MkdirTemp(parent, ".partial-")
+	if err != nil {
+		return "", nil, err
+	}
+	lock, err := lockActionCache(ctx, filepath.Join(tmp, ".lock"), actionCacheLockExclusive, false)
+	if err != nil {
+		_ = os.RemoveAll(tmp)
+		return "", nil, err
+	}
+	return tmp, lock, nil
+}
+
+func (s *Store) maintain(ctx context.Context) error {
+	maintenance, err := lockActionCache(ctx, filepath.Join(s.root, ".maintenance.lock"), actionCacheLockExclusive, false)
+	if err != nil {
+		return err
+	}
+	defer maintenance.unlock()
+	return s.maintainLocked(ctx)
+}
+
+func (s *Store) maintainLocked(ctx context.Context) error {
+	entries, partials, err := s.cacheEntries()
+	if err != nil {
+		return err
+	}
+	for _, partial := range partials {
+		lock, lockErr := lockActionCache(ctx, filepath.Join(partial, ".lock"), actionCacheLockExclusive, true)
+		if lockErr != nil {
+			continue
+		}
+		_ = os.RemoveAll(partial)
+		lock.unlock()
+	}
+	var total int64
+	for _, entry := range entries {
+		total += entry.size
+	}
+	if total <= s.cfg.cacheMaxBytes {
+		s.pressure.Store(false)
+		return s.writeCacheSize(total)
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].lastUse.Before(entries[j].lastUse)
+	})
+	for _, entry := range entries {
+		if total <= s.cfg.cacheMaxBytes {
+			break
+		}
+		lock, lockErr := lockActionCache(ctx, entry.path+".lock", actionCacheLockExclusive, true)
+		if lockErr != nil {
+			continue
+		}
+		if err := os.RemoveAll(entry.path); err != nil {
+			lock.unlock()
+			return err
+		}
+		total -= entry.size
+		lock.unlock()
+	}
+	s.pressure.Store(total > s.cfg.cacheMaxBytes)
+	return s.writeCacheSize(total)
+}
+
+func (s *Store) publishCacheEntry(ctx context.Context, temporary, base string) error {
+	if s.cfg.cacheMaxBytes == 0 {
+		return os.Rename(temporary, base)
+	}
+	maintenance, err := lockActionCache(ctx, filepath.Join(s.root, ".maintenance.lock"), actionCacheLockExclusive, false)
+	if err != nil {
+		return err
+	}
+	defer maintenance.unlock()
+	if err := os.Rename(temporary, base); err != nil {
+		return err
+	}
+	published := true
+	defer func() {
+		if published {
+			_ = os.RemoveAll(base)
+		}
+	}()
+	size, err := cacheEntrySize(base)
+	if err != nil {
+		return err
+	}
+	total, err := s.readCacheSize()
+	if err != nil {
+		err = s.maintainLocked(ctx)
+		published = err != nil
+		return err
+	}
+	total += size
+	if total > s.cfg.cacheMaxBytes {
+		err = s.maintainLocked(ctx)
+		published = err != nil
+		return err
+	}
+	s.pressure.Store(false)
+	err = s.writeCacheSize(total)
+	published = err != nil
+	return err
+}
+
+func (s *Store) readCacheSize() (int64, error) {
+	data, err := os.ReadFile(filepath.Join(s.root, ".size-v1"))
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
+}
+
+func (s *Store) writeCacheSize(size int64) error {
+	temporary, err := os.CreateTemp(s.root, ".size-*.tmp")
+	if err != nil {
+		return err
+	}
+	path := temporary.Name()
+	defer func() { _ = os.Remove(path) }()
+	if err = temporary.Chmod(0o600); err == nil {
+		_, err = fmt.Fprintf(temporary, "%d\n", size)
+	}
+	if closeErr := temporary.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return err
+	}
+	return os.Rename(path, filepath.Join(s.root, ".size-v1"))
+}
+
+func (s *Store) cacheEntries() ([]cacheEntry, []string, error) {
+	owners, err := os.ReadDir(s.root)
+	if err != nil {
+		return nil, nil, err
+	}
+	var entries []cacheEntry
+	var partials []string
+	for _, owner := range owners {
+		if !owner.IsDir() || strings.HasPrefix(owner.Name(), ".") {
+			continue
+		}
+		ownerPath := filepath.Join(s.root, owner.Name())
+		repositories, readErr := os.ReadDir(ownerPath)
+		if readErr != nil {
+			return nil, nil, readErr
+		}
+		for _, repository := range repositories {
+			if !repository.IsDir() || strings.HasPrefix(repository.Name(), ".") {
+				continue
+			}
+			repositoryPath := filepath.Join(ownerPath, repository.Name())
+			commits, readErr := os.ReadDir(repositoryPath)
+			if readErr != nil {
+				return nil, nil, readErr
+			}
+			for _, commit := range commits {
+				path := filepath.Join(repositoryPath, commit.Name())
+				if commit.IsDir() && strings.HasPrefix(commit.Name(), ".partial-") {
+					partials = append(partials, path)
+					continue
+				}
+				if !commit.IsDir() || !shaRE.MatchString(commit.Name()) {
+					continue
+				}
+				size, sizeErr := cacheEntrySize(path)
+				manifest, statErr := os.Stat(filepath.Join(path, manifestName))
+				if sizeErr != nil {
+					return nil, nil, sizeErr
+				}
+				if statErr != nil {
+					return nil, nil, statErr
+				}
+				entries = append(entries, cacheEntry{path: path, size: size, lastUse: manifest.ModTime()})
+			}
+		}
+	}
+	return entries, partials, nil
+}
+
+func cacheEntrySize(root string) (int64, error) {
+	var size int64
+	err := filepath.WalkDir(root, func(_ string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if info.Mode().IsRegular() {
+			size += info.Size()
+		}
+		return nil
+	})
+	return size, err
+}

--- a/internal/action/source/action_cache_lock_other.go
+++ b/internal/action/source/action_cache_lock_other.go
@@ -1,0 +1,89 @@
+//go:build !unix
+
+package source
+
+import (
+	"context"
+	"errors"
+	"os"
+	"sync"
+)
+
+type actionCacheLockMode int
+
+const (
+	actionCacheLockShared actionCacheLockMode = iota
+	actionCacheLockExclusive
+)
+
+var (
+	errActionCacheLockUnavailable = errors.New("action cache lock is held")
+	actionCacheLocksMu            sync.Mutex
+	actionCacheLocks              = map[string]*sync.RWMutex{}
+)
+
+type actionCacheLock struct {
+	mu        *sync.RWMutex
+	exclusive bool
+	file      *os.File
+}
+
+func lockActionCache(ctx context.Context, path string, mode actionCacheLockMode, nonblocking bool) (*actionCacheLock, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	actionCacheLocksMu.Lock()
+	mu := actionCacheLocks[path]
+	if mu == nil {
+		mu = &sync.RWMutex{}
+		actionCacheLocks[path] = mu
+	}
+	actionCacheLocksMu.Unlock()
+	if nonblocking {
+		var ok bool
+		if mode == actionCacheLockExclusive {
+			ok = mu.TryLock()
+		} else {
+			ok = mu.TryRLock()
+		}
+		if !ok {
+			return nil, errActionCacheLockUnavailable
+		}
+	} else if mode == actionCacheLockExclusive {
+		mu.Lock()
+	} else {
+		mu.RLock()
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		if mode == actionCacheLockExclusive {
+			mu.Unlock()
+		} else {
+			mu.RUnlock()
+		}
+		return nil, err
+	}
+	return &actionCacheLock{mu: mu, exclusive: mode == actionCacheLockExclusive, file: file}, nil
+}
+
+func (l *actionCacheLock) shared() error {
+	if l.exclusive {
+		l.mu.Unlock()
+		l.mu.RLock()
+		l.exclusive = false
+	}
+	return nil
+}
+
+func (l *actionCacheLock) unlock() {
+	if l == nil || l.file == nil {
+		return
+	}
+	_ = l.file.Close()
+	l.file = nil
+	if l.exclusive {
+		l.mu.Unlock()
+	} else {
+		l.mu.RUnlock()
+	}
+}

--- a/internal/action/source/action_cache_lock_other.go
+++ b/internal/action/source/action_cache_lock_other.go
@@ -66,15 +66,6 @@ func lockActionCache(ctx context.Context, path string, mode actionCacheLockMode,
 	return &actionCacheLock{mu: mu, exclusive: mode == actionCacheLockExclusive, file: file}, nil
 }
 
-func (l *actionCacheLock) shared() error {
-	if l.exclusive {
-		l.mu.Unlock()
-		l.mu.RLock()
-		l.exclusive = false
-	}
-	return nil
-}
-
 func (l *actionCacheLock) unlock() {
 	if l == nil || l.file == nil {
 		return

--- a/internal/action/source/action_cache_lock_unix.go
+++ b/internal/action/source/action_cache_lock_unix.go
@@ -1,0 +1,67 @@
+//go:build unix
+
+package source
+
+import (
+	"context"
+	"errors"
+	"os"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+type actionCacheLockMode int
+
+const (
+	actionCacheLockShared actionCacheLockMode = iota
+	actionCacheLockExclusive
+)
+
+var errActionCacheLockUnavailable = errors.New("action cache lock is held")
+
+type actionCacheLock struct{ file *os.File }
+
+func lockActionCache(ctx context.Context, path string, mode actionCacheLockMode, nonblocking bool) (*actionCacheLock, error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	operation := unix.LOCK_SH
+	if mode == actionCacheLockExclusive {
+		operation = unix.LOCK_EX
+	}
+	for {
+		err = unix.Flock(int(file.Fd()), operation|unix.LOCK_NB)
+		if err == nil {
+			return &actionCacheLock{file: file}, nil
+		}
+		if !errors.Is(err, unix.EWOULDBLOCK) && !errors.Is(err, unix.EAGAIN) {
+			_ = file.Close()
+			return nil, err
+		}
+		if nonblocking {
+			_ = file.Close()
+			return nil, errActionCacheLockUnavailable
+		}
+		select {
+		case <-ctx.Done():
+			_ = file.Close()
+			return nil, ctx.Err()
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+func (l *actionCacheLock) shared() error {
+	return unix.Flock(int(l.file.Fd()), unix.LOCK_SH)
+}
+
+func (l *actionCacheLock) unlock() {
+	if l == nil || l.file == nil {
+		return
+	}
+	_ = unix.Flock(int(l.file.Fd()), unix.LOCK_UN)
+	_ = l.file.Close()
+	l.file = nil
+}

--- a/internal/action/source/action_cache_lock_unix.go
+++ b/internal/action/source/action_cache_lock_unix.go
@@ -53,10 +53,6 @@ func lockActionCache(ctx context.Context, path string, mode actionCacheLockMode,
 	}
 }
 
-func (l *actionCacheLock) shared() error {
-	return unix.Flock(int(l.file.Fd()), unix.LOCK_SH)
-}
-
 func (l *actionCacheLock) unlock() {
 	if l == nil || l.file == nil {
 		return

--- a/internal/action/source/source.go
+++ b/internal/action/source/source.go
@@ -61,7 +61,7 @@ type Materialized struct {
 }
 
 // Release marks the materialized tree as no longer in use. Callers must
-// release bounded persistent-cache entries after reading them.
+// release persistent-cache entries after reading them.
 func (m Materialized) Release() {
 	if m.lease != nil {
 		m.lease.release()
@@ -538,9 +538,12 @@ func (s *Store) Materialize(ctx context.Context, resolved Resolved) (Materialize
 	if err := ctx.Err(); err != nil {
 		return Materialized{}, err
 	}
-	entryLock, err = lockActionCache(ctx, base+".lock", actionCacheLockExclusive, false)
+	entryLock, cached, err := s.lockMissingEntry(ctx, base, tree, parsed.Path, resolved)
 	if err != nil {
 		return Materialized{}, err
+	}
+	if cached != nil {
+		return *cached, nil
 	}
 	defer func() {
 		if entryLock != nil {
@@ -548,13 +551,9 @@ func (s *Store) Materialize(ctx context.Context, resolved Resolved) (Materialize
 		}
 	}()
 	if m, verifyErr = s.verify(base, resolved); verifyErr == nil {
-		if err := entryLock.shared(); err != nil {
-			return Materialized{}, err
-		}
-		s.touch(base)
-		lease, err := s.materializedLease(entryLock, resolved, tree, parsed.Path, m.Digest)
+		exclusive := entryLock
 		entryLock = nil
-		return lease, err
+		return s.reacquireMaterializedLease(ctx, exclusive, resolved, base, tree, parsed.Path)
 	}
 	tmp, partialLock, err := s.createPartial(ctx, parent)
 	if err != nil {
@@ -585,14 +584,53 @@ func (s *Store) Materialize(ctx context.Context, resolved Resolved) (Materialize
 			return Materialized{}, fmt.Errorf("publish cache: %w (existing cache invalid: %v)", err, verifyErr)
 		}
 	}
-	if err := entryLock.shared(); err != nil {
+	exclusive := entryLock
+	entryLock = nil
+	return s.reacquireMaterializedLease(ctx, exclusive, resolved, base, tree, parsed.Path)
+}
+
+func (s *Store) lockMissingEntry(ctx context.Context, base, tree, actionPath string, resolved Resolved) (*actionCacheLock, *Materialized, error) {
+	for {
+		exclusive, err := lockActionCache(ctx, base+".lock", actionCacheLockExclusive, true)
+		if err == nil {
+			return exclusive, nil, nil
+		}
+		if !errors.Is(err, errActionCacheLockUnavailable) {
+			return nil, nil, err
+		}
+		shared, sharedErr := lockActionCache(ctx, base+".lock", actionCacheLockShared, true)
+		if sharedErr == nil {
+			m, verifyErr := s.verify(base, resolved)
+			if verifyErr == nil {
+				s.touch(base)
+				materialized, leaseErr := s.materializedLease(shared, resolved, tree, actionPath, m.Digest)
+				return nil, &materialized, leaseErr
+			}
+			shared.unlock()
+		}
+		select {
+		case <-ctx.Done():
+			return nil, nil, ctx.Err()
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+func (s *Store) reacquireMaterializedLease(ctx context.Context, exclusive *actionCacheLock, resolved Resolved, base, tree, actionPath string) (Materialized, error) {
+	exclusive.unlock()
+	shared, err := lockActionCache(ctx, base+".lock", actionCacheLockShared, false)
+	if err != nil {
 		return Materialized{}, err
 	}
+	m, err := s.verify(base, resolved)
+	if err != nil {
+		shared.unlock()
+		return s.Materialize(ctx, resolved)
+	}
 	s.touch(base)
-	lease, err := s.materializedLease(entryLock, resolved, tree, parsed.Path, m.Digest)
-	entryLock = nil
-	return lease, err
+	return s.materializedLease(shared, resolved, tree, actionPath, m.Digest)
 }
+
 func materialized(tree, p, digest string) (Materialized, error) {
 	action, err := selected(tree, p)
 	if err != nil {

--- a/internal/action/source/source.go
+++ b/internal/action/source/source.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode/utf8"
 )
@@ -56,6 +57,23 @@ type Materialized struct {
 	RepositoryRoot string
 	ActionRoot     string
 	SourceDigest   string
+	lease          *materializedLease
+}
+
+// Release marks the materialized tree as no longer in use. Callers must
+// release bounded persistent-cache entries after reading them.
+func (m Materialized) Release() {
+	if m.lease != nil {
+		m.lease.release()
+	}
+}
+
+// Retain acquires another lease for a memoized materialization.
+func (m Materialized) Retain(ctx context.Context) (Materialized, error) {
+	if m.lease == nil {
+		return m, nil
+	}
+	return m.lease.retain(ctx)
 }
 
 // Parse parses owner/repository[/path]@ref.
@@ -113,6 +131,7 @@ type config struct {
 	finalHosts                          map[string]bool
 	credential                          *actionSourceCredential
 	mutableRefs                         *mutableRefCache
+	cacheMaxBytes                       int64
 	maxCompressed, maxExpanded, maxFile int64
 	maxEntries                          int
 	maxPath, maxSegment                 int
@@ -195,6 +214,18 @@ func WithLimits(compressed, expanded, perFile int64, entries int) Option {
 			return fmt.Errorf("limits must be positive")
 		}
 		c.maxCompressed, c.maxExpanded, c.maxFile, c.maxEntries = compressed, expanded, perFile, entries
+		return nil
+	}
+}
+
+// WithCacheMaxBytes bounds the immutable action-source cache. A materialized
+// entry remains protected from eviction until its lease is released.
+func WithCacheMaxBytes(maxBytes int64) Option {
+	return func(c *config) error {
+		if maxBytes <= 0 {
+			return fmt.Errorf("cache maximum bytes must be positive")
+		}
+		c.cacheMaxBytes = maxBytes
 		return nil
 	}
 }
@@ -422,9 +453,10 @@ func setAPIHeaders(r *http.Request, token string) {
 // caches them in an existing real directory. A Store must not be shared by
 // mutually untrusted processes writing the same cache root.
 type Store struct {
-	root   string
-	client *http.Client
-	cfg    config
+	root     string
+	client   *http.Client
+	cfg      config
+	pressure atomic.Bool
 }
 
 func NewStore(root string, client *http.Client, opts ...Option) (*Store, error) {
@@ -454,7 +486,13 @@ func NewStore(root string, client *http.Client, opts ...Option) (*Store, error) 
 	if client == nil {
 		client = &http.Client{Timeout: 2 * time.Minute}
 	}
-	return &Store{root, client, c}, nil
+	store := &Store{root: root, client: client, cfg: c}
+	if c.cacheMaxBytes > 0 {
+		if err := store.maintain(context.Background()); err != nil {
+			return nil, fmt.Errorf("maintain action source cache: %w", err)
+		}
+	}
+	return store, nil
 }
 
 // Materialize returns the verified repository and selected action identity.
@@ -469,32 +507,60 @@ func (s *Store) Materialize(ctx context.Context, resolved Resolved) (Materialize
 	resolved.Reference = parsed
 	base := filepath.Join(s.root, strings.ToLower(parsed.Owner), strings.ToLower(parsed.Repository), resolved.Commit)
 	tree := filepath.Join(base, "tree")
+	parent := filepath.Dir(base)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return Materialized{}, err
+	}
+	entryLock, err := lockActionCache(ctx, base+".lock", actionCacheLockShared, false)
+	if err != nil {
+		return Materialized{}, err
+	}
 	m, verifyErr := s.verify(base, resolved)
 	if verifyErr == nil {
-		return materialized(tree, parsed.Path, m.Digest)
+		s.touch(base)
+		return s.materializedLease(entryLock, resolved, tree, parsed.Path, m.Digest)
 	}
 	if _, statErr := os.Stat(base); statErr == nil {
 		// The initial verification may have raced a publisher between its
 		// manifest and tree operations. Once base exists, verify the complete
 		// publication again before treating it as corrupt.
 		if m, retryErr := s.verify(base, resolved); retryErr == nil {
-			return materialized(tree, parsed.Path, m.Digest)
+			s.touch(base)
+			return s.materializedLease(entryLock, resolved, tree, parsed.Path, m.Digest)
 		}
+		entryLock.unlock()
 		return Materialized{}, fmt.Errorf("verify action source cache: %w", verifyErr)
 	} else if !errors.Is(statErr, os.ErrNotExist) {
+		entryLock.unlock()
 		return Materialized{}, fmt.Errorf("stat action source cache: %w", statErr)
 	}
+	entryLock.unlock()
 	if err := ctx.Err(); err != nil {
 		return Materialized{}, err
 	}
-	parent := filepath.Dir(base)
-	if err := os.MkdirAll(parent, 0o755); err != nil {
-		return Materialized{}, err
-	}
-	tmp, err := os.MkdirTemp(parent, ".partial-")
+	entryLock, err = lockActionCache(ctx, base+".lock", actionCacheLockExclusive, false)
 	if err != nil {
 		return Materialized{}, err
 	}
+	defer func() {
+		if entryLock != nil {
+			entryLock.unlock()
+		}
+	}()
+	if m, verifyErr = s.verify(base, resolved); verifyErr == nil {
+		if err := entryLock.shared(); err != nil {
+			return Materialized{}, err
+		}
+		s.touch(base)
+		lease, err := s.materializedLease(entryLock, resolved, tree, parsed.Path, m.Digest)
+		entryLock = nil
+		return lease, err
+	}
+	tmp, partialLock, err := s.createPartial(ctx, parent)
+	if err != nil {
+		return Materialized{}, err
+	}
+	defer partialLock.unlock()
 	defer func() { _ = os.RemoveAll(tmp) }()
 	if err = s.downloadExtract(ctx, resolved, filepath.Join(tmp, "tree")); err != nil {
 		return Materialized{}, err
@@ -513,13 +579,19 @@ func (s *Store) Materialize(ctx context.Context, resolved Resolved) (Materialize
 	if err = os.WriteFile(filepath.Join(tmp, manifestName), data, 0o644); err != nil {
 		return Materialized{}, err
 	}
-	if err = os.Rename(tmp, base); err != nil {
+	if err = s.publishCacheEntry(ctx, tmp, base); err != nil {
 		m, verifyErr = s.verify(base, resolved)
 		if verifyErr != nil {
 			return Materialized{}, fmt.Errorf("publish cache: %w (existing cache invalid: %v)", err, verifyErr)
 		}
 	}
-	return materialized(tree, parsed.Path, m.Digest)
+	if err := entryLock.shared(); err != nil {
+		return Materialized{}, err
+	}
+	s.touch(base)
+	lease, err := s.materializedLease(entryLock, resolved, tree, parsed.Path, m.Digest)
+	entryLock = nil
+	return lease, err
 }
 func materialized(tree, p, digest string) (Materialized, error) {
 	action, err := selected(tree, p)

--- a/internal/action/source/source_test.go
+++ b/internal/action/source/source_test.go
@@ -610,7 +610,7 @@ func TestStoreExactCommitAtomicHitAndSubpath(t *testing.T) {
 	}
 	second, err := store.Materialize(context.Background(), resolved)
 	if err != nil || second != first || requests.Load() != 1 {
-		t.Fatalf("second = %q, %v; requests=%d", second, err, requests.Load())
+		t.Fatalf("second = %v, %v; requests=%d", second, err, requests.Load())
 	}
 }
 
@@ -809,12 +809,8 @@ func TestStoreCodeloadRedirectPolicy(t *testing.T) {
 func TestStoreConcurrentMaterialize(t *testing.T) {
 	archive := tgz(t, []tar.Header{{Name: "root/", Typeflag: tar.TypeDir}, {Name: "root/action.yml", Typeflag: tar.TypeReg, Size: 1}})
 	var requests atomic.Int32
-	release := make(chan struct{})
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		if requests.Add(1) == 2 {
-			close(release)
-		}
-		<-release
+		requests.Add(1)
 		_, _ = w.Write(archive)
 	}))
 	defer ts.Close()
@@ -847,5 +843,151 @@ func TestStoreConcurrentMaterialize(t *testing.T) {
 			t.Fatalf("digests differ: %q and %q", digest, got.SourceDigest)
 		}
 		digest = got.SourceDigest
+	}
+	if requests.Load() != 1 {
+		t.Fatalf("archive requests = %d, want 1", requests.Load())
+	}
+}
+
+func TestStoreEvictionSkipsLeasedEntryAndRemovesItAfterRelease(t *testing.T) {
+	archive := tgz(t, []tar.Header{{Name: "root/", Typeflag: tar.TypeDir}, {Name: "root/action.yml", Typeflag: tar.TypeReg, Size: 1}})
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write(archive) }))
+	defer ts.Close()
+	root := t.TempDir()
+	store, err := NewStore(root, ts.Client(), WithTestEndpoints(ts.URL, ts.URL), WithCacheMaxBytes(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref, _ := Parse("o/r@v1")
+	materialized, err := store.Materialize(context.Background(), Resolved{Reference: ref, Commit: testSHA})
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := filepath.Dir(materialized.RepositoryRoot)
+	if err := store.maintain(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(base); err != nil {
+		t.Fatalf("leased entry was evicted: %v", err)
+	}
+	retained, err := materialized.Retain(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	materialized.Release()
+	if err := store.maintain(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(base); err != nil {
+		t.Fatalf("retained entry was evicted: %v", err)
+	}
+	retained.Release()
+	if err := store.maintain(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(base); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("released entry still exists: %v", err)
+	}
+}
+
+func TestStoreMaintenanceUsesLRUAndCleansOnlyUnlockedPartials(t *testing.T) {
+	root := t.TempDir()
+	repository := filepath.Join(root, "owner", "repo")
+	if err := os.MkdirAll(repository, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	commits := []string{strings.Repeat("a", 40), strings.Repeat("b", 40), strings.Repeat("c", 40)}
+	var entrySize int64
+	for i, commit := range commits {
+		base := filepath.Join(repository, commit)
+		if err := os.MkdirAll(filepath.Join(base, "tree"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(base, "tree", "payload"), bytes.Repeat([]byte{byte('a' + i)}, 32), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		manifest := filepath.Join(base, manifestName)
+		if err := os.WriteFile(manifest, []byte("manifest"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		when := time.Unix(int64(i+1), 0)
+		if err := os.Chtimes(manifest, when, when); err != nil {
+			t.Fatal(err)
+		}
+		entrySize, _ = cacheEntrySize(base)
+	}
+	activePartial := filepath.Join(repository, ".partial-active")
+	abandonedPartial := filepath.Join(repository, ".partial-abandoned")
+	for _, partial := range []string{activePartial, abandonedPartial} {
+		if err := os.Mkdir(partial, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	activeLock, err := lockActionCache(context.Background(), filepath.Join(activePartial, ".lock"), actionCacheLockExclusive, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer activeLock.unlock()
+	if _, err := NewStore(root, nil, WithCacheMaxBytes(2*entrySize)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(repository, commits[0])); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("oldest entry still exists: %v", err)
+	}
+	for _, commit := range commits[1:] {
+		if _, err := os.Stat(filepath.Join(repository, commit)); err != nil {
+			t.Fatalf("newer entry %s was evicted: %v", commit, err)
+		}
+	}
+	if _, err := os.Stat(activePartial); err != nil {
+		t.Fatalf("active partial was removed: %v", err)
+	}
+	if _, err := os.Stat(abandonedPartial); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("abandoned partial still exists: %v", err)
+	}
+}
+
+func TestStoreConcurrentBoundedEviction(t *testing.T) {
+	archive := tgz(t, []tar.Header{{Name: "root/", Typeflag: tar.TypeDir}, {Name: "root/action.yml", Typeflag: tar.TypeReg, Size: 1}})
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write(archive) }))
+	defer ts.Close()
+	root := t.TempDir()
+	stores := make([]*Store, 2)
+	for i := range stores {
+		store, err := NewStore(root, ts.Client(), WithTestEndpoints(ts.URL, ts.URL), WithCacheMaxBytes(1))
+		if err != nil {
+			t.Fatal(err)
+		}
+		stores[i] = store
+	}
+	ref, _ := Parse("o/r@v1")
+	errs := make(chan error, 8)
+	var workers sync.WaitGroup
+	for i := range 8 {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			commit := fmt.Sprintf("%040x", i+1)
+			materialized, err := stores[i%len(stores)].Materialize(context.Background(), Resolved{Reference: ref, Commit: commit})
+			if err == nil {
+				_, err = os.Stat(filepath.Join(materialized.ActionRoot, "action.yml"))
+				materialized.Release()
+			}
+			errs <- err
+		}()
+	}
+	workers.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent bounded materialization: %v", err)
+		}
+	}
+	if err := stores[0].maintain(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	entries, _, err := stores[0].cacheEntries()
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("bounded entries = %d, error %v", len(entries), err)
 	}
 }

--- a/internal/action/source/source_test.go
+++ b/internal/action/source/source_test.go
@@ -609,9 +609,11 @@ func TestStoreExactCommitAtomicHitAndSubpath(t *testing.T) {
 		t.Fatalf("materialized identity = %#v", first)
 	}
 	second, err := store.Materialize(context.Background(), resolved)
-	if err != nil || second != first || requests.Load() != 1 {
+	if err != nil || second.RepositoryRoot != first.RepositoryRoot || second.ActionRoot != first.ActionRoot || second.SourceDigest != first.SourceDigest || requests.Load() != 1 {
 		t.Fatalf("second = %v, %v; requests=%d", second, err, requests.Load())
 	}
+	first.Release()
+	second.Release()
 }
 
 func TestStoreCanonicalizesAliasedAncestorAndRejectsSymlinkRoot(t *testing.T) {
@@ -843,6 +845,7 @@ func TestStoreConcurrentMaterialize(t *testing.T) {
 			t.Fatalf("digests differ: %q and %q", digest, got.SourceDigest)
 		}
 		digest = got.SourceDigest
+		got.Release()
 	}
 	if requests.Load() != 1 {
 		t.Fatalf("archive requests = %d, want 1", requests.Load())
@@ -989,5 +992,36 @@ func TestStoreConcurrentBoundedEviction(t *testing.T) {
 	entries, _, err := stores[0].cacheEntries()
 	if err != nil || len(entries) != 0 {
 		t.Fatalf("bounded entries = %d, error %v", len(entries), err)
+	}
+}
+
+func TestStoreBoundedEvictionProtectsUnboundedReader(t *testing.T) {
+	archive := tgz(t, []tar.Header{{Name: "root/", Typeflag: tar.TypeDir}, {Name: "root/action.yml", Typeflag: tar.TypeReg, Size: 1}})
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write(archive) }))
+	defer ts.Close()
+	root := t.TempDir()
+	unbounded, err := NewStore(root, ts.Client(), WithTestEndpoints(ts.URL, ts.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref, _ := Parse("o/r@v1")
+	active, err := unbounded.Materialize(context.Background(), Resolved{Reference: ref, Commit: strings.Repeat("a", 40)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer active.Release()
+	bounded, err := NewStore(root, ts.Client(), WithTestEndpoints(ts.URL, ts.URL), WithCacheMaxBytes(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(active.ActionRoot); err != nil {
+		t.Fatalf("bounded maintenance evicted an unbounded reader: %v", err)
+	}
+	active.Release()
+	if err := bounded.maintain(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(active.ActionRoot); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("released entry still exists: %v", err)
 	}
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -57,7 +57,7 @@ Run "buildkite-gha help <command>" for command help.
 
 var commandUsage = map[string]string{
 	"validate":       "Usage: buildkite-gha validate [--profile hosted] [--event <name> | --event-path <path> | --all-events] [--action-cache-dir <path>] [--format text|json] <workflow>\n",
-	"validate-batch": "Usage: buildkite-gha validate-batch --manifest <path> --output-dir <path> --corpus-id <id> [--action-cache-dir <path>] [--jobs <count>]\n",
+	"validate-batch": "Usage: buildkite-gha validate-batch --manifest <path> --output-dir <path> --corpus-id <id> [--action-cache-dir <path> --action-cache-max-bytes <bytes>] [--jobs <count>]\n",
 	"compile":        "Usage: buildkite-gha compile --event-path <path> [--format pipeline|ir-json] <workflow>\n",
 	"upload":         "Usage: buildkite-gha upload [--event-path <path>] [--runner-queue <runs-on>=<queue>]... [--runner-image <runs-on>=<immutable-image>]... [--runtime-distribution <platform>=<absolute-path>]... [--experimental-runner-user] [--runtime-queue hosted] [--] <workflow-path> [<workflow-path>...]\n",
 	"run-job":        "Usage: buildkite-gha run-job (--plan <path> | --plan-digest <digest> --plan-producer <step>) [--result <path>] [--hosted-tool-cache]\n",
@@ -2682,7 +2682,7 @@ func newHostedActionSource(actionCacheDir string, sourceOptions []actionsource.O
 		cleanup()
 		return nil, func() {}, fmt.Errorf("configure public action resolver: %w", err)
 	}
-	store, err := actionsource.NewStore(actionRoot, nil)
+	store, err := actionsource.NewStore(actionRoot, nil, sourceOptions...)
 	if err != nil {
 		cleanup()
 		return nil, func() {}, fmt.Errorf("configure public action source store: %w", err)

--- a/internal/cli/validate_batch.go
+++ b/internal/cli/validate_batch.go
@@ -27,6 +27,7 @@ const batchResultIdentity = "buildkite-gha-corpus-result/v1"
 type batchValidationArgs struct {
 	manifest, outputDir, corpusID, actionCacheDir string
 	jobs                                          int
+	actionCacheMaxBytes                           int64
 }
 
 type batchValidationRecord struct {
@@ -57,12 +58,11 @@ func validateBatch(args []string, stderr io.Writer, version string) int {
 	if err != nil {
 		return usageError(stderr, "validate-batch: %v", err)
 	}
-	if options.actionCacheDir != "" {
-		if _, err := actionsource.NewStore(options.actionCacheDir, nil); err != nil {
-			return usageError(stderr, "validate-batch: --action-cache-dir: %v", err)
-		}
+	var sourceOptions []actionsource.Option
+	if options.actionCacheMaxBytes > 0 {
+		sourceOptions = append(sourceOptions, actionsource.WithCacheMaxBytes(options.actionCacheMaxBytes))
 	}
-	actionSource, cleanup, err := newHostedActionSource(options.actionCacheDir, nil)
+	actionSource, cleanup, err := newHostedActionSource(options.actionCacheDir, sourceOptions)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate-batch: %v\n", err)
 		return 1
@@ -138,7 +138,7 @@ func parseBatchValidationArgs(args []string) (batchValidationArgs, error) {
 	seen := map[string]bool{}
 	for i := 0; i < len(args); i++ {
 		name := args[i]
-		if name != "--manifest" && name != "--output-dir" && name != "--corpus-id" && name != "--action-cache-dir" && name != "--jobs" {
+		if name != "--manifest" && name != "--output-dir" && name != "--corpus-id" && name != "--action-cache-dir" && name != "--action-cache-max-bytes" && name != "--jobs" {
 			return options, fmt.Errorf("unknown option %q", name)
 		}
 		if seen[name] {
@@ -158,6 +158,12 @@ func parseBatchValidationArgs(args []string) (batchValidationArgs, error) {
 			options.corpusID = args[i]
 		case "--action-cache-dir":
 			options.actionCacheDir = args[i]
+		case "--action-cache-max-bytes":
+			maxBytes, parseErr := strconv.ParseInt(args[i], 10, 64)
+			if parseErr != nil || maxBytes <= 0 {
+				return options, fmt.Errorf("--action-cache-max-bytes must be a positive integer")
+			}
+			options.actionCacheMaxBytes = maxBytes
 		case "--jobs":
 			jobs, parseErr := strconv.Atoi(args[i])
 			if parseErr != nil || jobs <= 0 {
@@ -168,6 +174,9 @@ func parseBatchValidationArgs(args []string) (batchValidationArgs, error) {
 	}
 	if options.manifest == "" || options.outputDir == "" || options.corpusID == "" {
 		return options, fmt.Errorf("--manifest, --output-dir, and --corpus-id are required")
+	}
+	if options.actionCacheMaxBytes > 0 && options.actionCacheDir == "" {
+		return options, fmt.Errorf("--action-cache-max-bytes requires --action-cache-dir")
 	}
 	return options, nil
 }

--- a/internal/cli/validate_batch_test.go
+++ b/internal/cli/validate_batch_test.go
@@ -119,6 +119,17 @@ func TestBatchValidationManifestAndIdentity(t *testing.T) {
 	if _, err := parseBatchValidationArgs([]string{"--manifest", "manifest"}); err == nil || !strings.Contains(err.Error(), "required") {
 		t.Fatalf("missing options error = %v", err)
 	}
+	baseArgs := []string{"--manifest", "manifest", "--output-dir", "reports", "--corpus-id", "corpus"}
+	if _, err := parseBatchValidationArgs(append(append([]string{}, baseArgs...), "--action-cache-max-bytes", "1024")); err == nil || !strings.Contains(err.Error(), "requires --action-cache-dir") {
+		t.Fatalf("cache budget without directory error = %v", err)
+	}
+	cacheArgs := append(append([]string{}, baseArgs...), "--action-cache-dir", "cache", "--action-cache-max-bytes", "1024")
+	if options, err := parseBatchValidationArgs(cacheArgs); err != nil || options.actionCacheMaxBytes != 1024 {
+		t.Fatalf("cache budget options = %#v, %v", options, err)
+	}
+	if _, err := parseBatchValidationArgs(append(append([]string{}, baseArgs...), "--action-cache-dir", "cache", "--action-cache-max-bytes", "0")); err == nil || !strings.Contains(err.Error(), "positive integer") {
+		t.Fatalf("invalid cache budget error = %v", err)
+	}
 	options := batchValidationArgs{outputDir: root, corpusID: "record-one"}
 	base := batchValidationResultPath(options, valid, "validator-one")
 	variants := []string{

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -64,6 +64,7 @@ type actionLockBuilder struct {
 	ids          map[string]string
 	active       map[string]bool
 	caps         map[string]bool
+	materialized []source.Materialized
 	requiresMise bool
 }
 
@@ -223,6 +224,11 @@ func compileActionInvocations(ctx context.Context, workspace string, actionSourc
 		return actionCompilation{}, fmt.Errorf("resolve workspace: %w", err)
 	}
 	b := &actionLockBuilder{workspace: abs, source: actionSource, nodes: map[string]*actionNode{}, ids: map[string]string{}, active: map[string]bool{}, caps: map[string]bool{}}
+	defer func() {
+		for _, materialized := range b.materialized {
+			materialized.Release()
+		}
+	}()
 	selectors := make([]plan.ActionSelector, 0, len(refs))
 	roots := make([]*actionNode, 0, len(refs))
 	for _, ref := range refs {
@@ -450,6 +456,7 @@ func (b *actionLockBuilder) describe(ctx context.Context, raw string) (string, p
 	if err != nil {
 		return "", plan.ActionLock{}, "", "", err
 	}
+	b.materialized = append(b.materialized, materialized)
 	repositoryRoot, err := filepath.Abs(materialized.RepositoryRoot)
 	if err != nil {
 		return "", plan.ActionLock{}, "", "", fmt.Errorf("resolve materialized repository root: %w", err)
@@ -520,7 +527,8 @@ func (s *memoizedActionSource) Fetch(ctx context.Context, ref source.Reference) 
 	s.mu.Lock()
 	if cached, ok := s.cache[key]; ok {
 		s.mu.Unlock()
-		return cached.resolved, cached.materialized, nil
+		materialized, err := cached.materialized.Retain(ctx)
+		return cached.resolved, materialized, err
 	}
 	if active, ok := s.active[key]; ok {
 		s.mu.Unlock()
@@ -531,7 +539,11 @@ func (s *memoizedActionSource) Fetch(ctx context.Context, ref source.Reference) 
 			if active.err != nil && ctx.Err() == nil && (errors.Is(active.err, context.Canceled) || errors.Is(active.err, context.DeadlineExceeded)) {
 				return s.Fetch(ctx, ref)
 			}
-			return active.resolved, active.materialized, active.err
+			if active.err != nil {
+				return active.resolved, active.materialized, active.err
+			}
+			materialized, err := active.materialized.Retain(ctx)
+			return active.resolved, materialized, err
 		}
 	}
 	call := &memoizedActionCall{done: make(chan struct{})}

--- a/scripts/validate-public-workflow-corpus
+++ b/scripts/validate-public-workflow-corpus
@@ -164,6 +164,10 @@ printf 'validator: %s (%s, sha256:%s)\n' "$validator_version" "$validator_commit
   echo 'buildkite-gha validate-batch must support --action-cache-dir' >&2
   exit 1
 }
+[[ "$("$validator" help validate-batch)" == *"--action-cache-max-bytes"* ]] || {
+  echo 'buildkite-gha validate-batch must support --action-cache-max-bytes' >&2
+  exit 1
+}
 
 action_cache="$workdir/action-cache"
 reports="$workdir/reports/$record_id/$validator_digest"
@@ -177,6 +181,7 @@ batch_args=(
   --output-dir "$reports"
   --corpus-id "zenodo:$record_id"
   --action-cache-dir "$action_cache"
+  --action-cache-max-bytes "${ACTION_CACHE_MAX_BYTES:-21474836480}"
 )
 if [[ -n "${JOBS:-}" ]]; then
   batch_args+=(--jobs "$JOBS")


### PR DESCRIPTION
## Why

Corpus validation retains immutable action trees indefinitely, so repeated runs can exhaust a 64 GB orb even though old commits can be downloaded again. Concurrent validators also need to avoid deleting trees or partial downloads that another worker is using.

## What

Add a byte budget for `validate-batch` with concurrency-safe least-recently-used eviction. Per-entry leases protect active readers and publishers, maintenance removes only unlocked abandoned partials, and a shared size ledger avoids rescanning every tree after each download.

The public corpus script uses a 20 GiB default budget. Interactive validation remains unbounded unless the batch-only budget is selected.