### PR TITLE
Fix expression parity edge cases found reviewing #252

### DIFF
--- a/internal/expression/compile.go
+++ b/internal/expression/compile.go
@@ -416,6 +416,12 @@ func SubstituteCompileInputs(template string, inputs map[string]any) (string, er
 			if tokens[i].Kind != actionlint.TokenKindIdent || !strings.EqualFold(tokens[i].Value, "inputs") || tokens[i+1].Kind != actionlint.TokenKindDot || tokens[i+2].Kind != actionlint.TokenKindIdent {
 				continue
 			}
+			// A preceding '.' means this is a property named "inputs" on
+			// another receiver, such as github.event.inputs.<name>, not the
+			// workflow-call inputs context.
+			if i > 0 && tokens[i-1].Kind == actionlint.TokenKindDot {
+				continue
+			}
 			value, ok := findCompileInput(inputs, tokens[i+2].Value)
 			if !ok {
 				continue

--- a/internal/expression/compile.go
+++ b/internal/expression/compile.go
@@ -133,7 +133,10 @@ func validateCompileExpressionNode(node actionlint.ExprNode) error {
 		switch {
 		case strings.EqualFold(root, "vars") && len(path) == 1,
 			strings.EqualFold(root, "inputs") && len(path) == 1,
-			strings.EqualFold(root, "matrix") && len(path) == 1,
+			// Matrix values may be objects or arrays (matrix include entries
+			// and object lists), so nested references such as
+			// matrix.config.os are valid.
+			strings.EqualFold(root, "matrix") && len(path) >= 1,
 			strings.EqualFold(root, "strategy") && len(path) == 1,
 			strings.EqualFold(root, "event") && len(path) >= 1:
 			return nil

--- a/internal/expression/condition.go
+++ b/internal/expression/condition.go
@@ -204,11 +204,18 @@ func validateConditionReference(root string, path []string, scope ConditionScope
 			return nil
 		}
 		return fmt.Errorf("condition reference %q is unsupported; expected needs.<job>.result or needs.<job>.outputs.<name>", reference)
-	case "vars", "matrix":
+	case "vars":
 		if len(path) == 1 {
 			return nil
 		}
-		return fmt.Errorf("condition reference %q is unsupported; expected %s.<name>", reference, strings.ToLower(root))
+		return fmt.Errorf("condition reference %q is unsupported; expected vars.<name>", reference)
+	case "matrix":
+		// Matrix values may be objects or arrays, so nested references such
+		// as matrix.config.os are valid.
+		if len(path) >= 1 {
+			return nil
+		}
+		return fmt.Errorf("condition reference %q is unsupported; expected matrix.<name>", reference)
 	case "steps":
 		if scope == JobCondition {
 			return fmt.Errorf("condition context %q is unavailable in job conditions", root)
@@ -511,9 +518,25 @@ func resolveConditionReference(root string, path []string, context ConditionCont
 		return findString(context.Env, path[0]), nil
 	case len(path) == 1 && strings.EqualFold(root, "vars"):
 		return findString(context.Vars, path[0]), nil
-	case len(path) == 1 && strings.EqualFold(root, "matrix"):
+	case len(path) >= 1 && strings.EqualFold(root, "matrix"):
 		for name, value := range context.Matrix {
 			if strings.EqualFold(name, path[0]) {
+				// Nested references such as matrix.config.os walk into
+				// object-valued matrix entries; a missing or non-object
+				// segment yields null, matching GitHub.
+				for _, part := range path[1:] {
+					var (
+						ok  bool
+						err error
+					)
+					value, ok, err = objectValue(value, part)
+					if err != nil {
+						return nil, err
+					}
+					if !ok {
+						return nil, nil
+					}
+				}
 				return value, nil
 			}
 		}

--- a/internal/expression/condition.go
+++ b/internal/expression/condition.go
@@ -415,11 +415,6 @@ func evaluateConditionNode(node actionlint.ExprNode, context ConditionContext) (
 
 func resolveConditionRoot(root string, context ConditionContext) (any, error) {
 	switch strings.ToLower(root) {
-	case "github":
-		if context.GitHub == nil {
-			return nil, fmt.Errorf("condition context %q is unavailable", root)
-		}
-		return context.GitHub, nil
 	case "matrix":
 		if context.Matrix == nil {
 			return nil, fmt.Errorf("condition context %q is unavailable", root)

--- a/internal/expression/condition.go
+++ b/internal/expression/condition.go
@@ -408,6 +408,11 @@ func evaluateConditionNode(node actionlint.ExprNode, context ConditionContext) (
 
 func resolveConditionRoot(root string, context ConditionContext) (any, error) {
 	switch strings.ToLower(root) {
+	case "github":
+		if context.GitHub == nil {
+			return nil, fmt.Errorf("condition context %q is unavailable", root)
+		}
+		return context.GitHub, nil
 	case "matrix":
 		if context.Matrix == nil {
 			return nil, fmt.Errorf("condition context %q is unavailable", root)

--- a/internal/expression/evaluator.go
+++ b/internal/expression/evaluator.go
@@ -183,7 +183,11 @@ func (e *semanticEvaluator) evaluate(node actionlint.ExprNode) (any, error) {
 		return nil, err
 	case *actionlint.IndexAccessNode:
 		root, path, err := referencePath(node)
-		if err == nil && strings.EqualFold(root, "job") && len(path) == 4 && strings.EqualFold(path[0], "services") && strings.EqualFold(path[2], "ports") {
+		// Mirror the validator: static bracket references to authority
+		// contexts resolve as ordinary references so evaluation never
+		// exposes the whole context root.
+		staticAuthority := strings.EqualFold(root, "github") || strings.EqualFold(root, "secrets")
+		if err == nil && (staticAuthority || strings.EqualFold(root, "job") && len(path) == 4 && strings.EqualFold(path[0], "services") && strings.EqualFold(path[2], "ports")) {
 			return e.resolve(root, path)
 		}
 		if e.resolveRoot != nil {

--- a/internal/expression/expression.go
+++ b/internal/expression/expression.go
@@ -336,7 +336,7 @@ func objectValue(value any, name string) (any, bool, error) {
 		for candidate, item := range value {
 			if strings.EqualFold(candidate, name) {
 				if matchedKey != "" {
-					return nil, false, fmt.Errorf("compile-time object contains ambiguous properties")
+					return nil, false, fmt.Errorf("object contains ambiguous properties")
 				}
 				found, matchedKey = item, candidate
 			}
@@ -352,7 +352,7 @@ func objectValue(value any, name string) (any, bool, error) {
 		for candidate, item := range value {
 			if strings.EqualFold(candidate, name) {
 				if matchedKey != "" {
-					return nil, false, fmt.Errorf("compile-time object contains ambiguous properties")
+					return nil, false, fmt.Errorf("object contains ambiguous properties")
 				}
 				found, matchedKey = item, candidate
 			}
@@ -367,14 +367,71 @@ func objectValue(value any, name string) (any, bool, error) {
 func decodeJSONValue(source string) (any, error) {
 	decoder := json.NewDecoder(strings.NewReader(source))
 	decoder.UseNumber()
-	var value any
-	if err := decoder.Decode(&value); err != nil {
+	value, err := decodeJSONToken(decoder)
+	if err != nil {
 		return nil, fmt.Errorf("fromJSON argument is invalid JSON")
 	}
-	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+	if _, err := decoder.Token(); err != io.EOF {
 		return nil, fmt.Errorf("fromJSON argument contains multiple JSON values")
 	}
 	return normalizeJSONNumbers(value)
+}
+
+// decodeJSONToken decodes one JSON value token by token so object keys retain
+// document order. GitHub stores fromJSON objects in case-insensitive
+// dictionaries: a key that matches an earlier key case-insensitively replaces
+// its value while the earlier spelling survives, so {"a":1,"A":2} yields one
+// property a with value 2. A plain map decode loses key order and cannot
+// reproduce that.
+func decodeJSONToken(decoder *json.Decoder) (any, error) {
+	token, err := decoder.Token()
+	if err != nil {
+		return nil, err
+	}
+	delim, ok := token.(json.Delim)
+	if !ok {
+		return token, nil
+	}
+	switch delim {
+	case '{':
+		object := make(map[string]any)
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return nil, err
+			}
+			key, ok := keyToken.(string)
+			if !ok {
+				return nil, fmt.Errorf("fromJSON argument is invalid JSON")
+			}
+			value, err := decodeJSONToken(decoder)
+			if err != nil {
+				return nil, err
+			}
+			for existing := range object {
+				if strings.EqualFold(existing, key) {
+					key = existing
+					break
+				}
+			}
+			object[key] = value
+		}
+		_, err = decoder.Token()
+		return object, err
+	case '[':
+		values := make([]any, 0, 1)
+		for decoder.More() {
+			value, err := decodeJSONToken(decoder)
+			if err != nil {
+				return nil, err
+			}
+			values = append(values, value)
+		}
+		_, err = decoder.Token()
+		return values, err
+	default:
+		return nil, fmt.Errorf("fromJSON argument is invalid JSON")
+	}
 }
 
 func normalizeJSONNumbers(value any) (any, error) {

--- a/internal/expression/expression.go
+++ b/internal/expression/expression.go
@@ -395,6 +395,7 @@ func decodeJSONToken(decoder *json.Decoder) (any, error) {
 	switch delim {
 	case '{':
 		object := make(map[string]any)
+		spellings := make(map[string]string)
 		for decoder.More() {
 			keyToken, err := decoder.Token()
 			if err != nil {
@@ -408,11 +409,11 @@ func decodeJSONToken(decoder *json.Decoder) (any, error) {
 			if err != nil {
 				return nil, err
 			}
-			for existing := range object {
-				if strings.EqualFold(existing, key) {
-					key = existing
-					break
-				}
+			lower := strings.ToLower(key)
+			if first, ok := spellings[lower]; ok {
+				key = first
+			} else {
+				spellings[lower] = key
 			}
 			object[key] = value
 		}

--- a/internal/expression/expression.go
+++ b/internal/expression/expression.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/rhysd/actionlint"
 )
@@ -409,11 +410,11 @@ func decodeJSONToken(decoder *json.Decoder) (any, error) {
 			if err != nil {
 				return nil, err
 			}
-			lower := strings.ToLower(key)
-			if first, ok := spellings[lower]; ok {
+			folded := foldedKey(key)
+			if first, ok := spellings[folded]; ok {
 				key = first
 			} else {
-				spellings[lower] = key
+				spellings[folded] = key
 			}
 			object[key] = value
 		}
@@ -433,6 +434,22 @@ func decodeJSONToken(decoder *json.Decoder) (any, error) {
 	default:
 		return nil, fmt.Errorf("fromJSON argument is invalid JSON")
 	}
+}
+
+// foldedKey canonicalizes a key under the same case-fold equivalence
+// strings.EqualFold uses for object lookup: every rune maps to the smallest
+// rune in its unicode.SimpleFold orbit, so keys collapse exactly when
+// EqualFold considers them equal.
+func foldedKey(key string) string {
+	return strings.Map(func(r rune) rune {
+		minimum := r
+		for folded := unicode.SimpleFold(r); folded != r; folded = unicode.SimpleFold(folded) {
+			if folded < minimum {
+				minimum = folded
+			}
+		}
+		return minimum
+	}, key)
 }
 
 func normalizeJSONNumbers(value any) (any, error) {

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -1578,6 +1578,8 @@ func TestFromJSONCollapsesCaseInsensitiveDuplicateKeys(t *testing.T) {
 		`${{ fromJSON('{"a":1,"A":2}').A }}`:       "2",
 		`${{ fromJSON('{"a":1,"A":2}')['A'] }}`:    "2",
 		`${{ fromJSON('{"A":2,"a":1}').a }}`:       "1",
+		`${{ fromJSON('{"Σ":1,"ς":2}')['Σ'] }}`:    "2",
+		`${{ fromJSON('{"Σ":1,"ς":2}')['σ'] }}`:    "2",
 		`${{ toJSON(fromJSON('{"a":1,"A":2}')) }}`: "{\n  \"a\": 2\n}",
 	} {
 		got, err := EvaluateCompileTemplate(template, CompileContext{})

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -1025,6 +1025,33 @@ func TestEvaluateConditionSupportsPureFunctions(t *testing.T) {
 	}
 }
 
+func TestEvaluateConditionSupportsBracketFormGitHubReferences(t *testing.T) {
+	for condition, want := range map[string]bool{
+		"github['event_name'] == 'push'":       true,
+		"github['EVENT_NAME'] == 'push'":       true,
+		"github['event_name'] == 'workflow'":   false,
+		"github['head_ref'] == null":           true,
+		"github['ref'] == 'refs/heads/main'":   true,
+		"github['repository'] == 'acme/thing'": true,
+	} {
+		if err := ValidateCondition(condition, StepCondition); err != nil {
+			t.Errorf("ValidateCondition(%q) error = %v", condition, err)
+			continue
+		}
+		got, err := EvaluateCondition(condition, ConditionContext{GitHub: map[string]any{
+			"event_name": "push",
+			"ref":        "refs/heads/main",
+			"repository": "acme/thing",
+		}})
+		if err != nil || got != want {
+			t.Errorf("EvaluateCondition(%q) = %v, %v, want %v", condition, got, err, want)
+		}
+	}
+	if _, err := EvaluateCondition("github['event_name'] == 'push'", ConditionContext{}); err == nil || !strings.Contains(err.Error(), `condition context "github" is unavailable`) {
+		t.Fatalf("EvaluateCondition() without github context error = %v", err)
+	}
+}
+
 func TestEvaluateConditionSupportsIndexesFiltersAndWholeContexts(t *testing.T) {
 	context := ConditionContext{
 		Vars:   map[string]string{"KEY": "target"},
@@ -1384,6 +1411,18 @@ func TestSubstituteCompileInputsPreservesExpressionSyntax(t *testing.T) {
 	}
 }
 
+func TestSubstituteCompileInputsIgnoresNestedInputsProperties(t *testing.T) {
+	template := "${{ inputs.debug }} ${{ github.event.inputs.debug }} ${{ steps.inputs.name }} ${{ fromJSON(vars.CFG).inputs.name }}"
+	got, err := SubstituteCompileInputs(template, map[string]any{"debug": true, "name": "prod"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "${{ true }} ${{ github.event.inputs.debug }} ${{ steps.inputs.name }} ${{ fromJSON(vars.CFG).inputs.name }}"
+	if got != want {
+		t.Fatalf("SubstituteCompileInputs() = %q, want %q", got, want)
+	}
+}
+
 func TestEvaluateAvailableCompileTemplatePreservesRuntimeExpressions(t *testing.T) {
 	got, err := EvaluateAvailableCompileTemplate("echo ${{ 'target' }} ${{ fromJSON('1e20') }} ${{ github.ref }}", CompileContext{})
 	if err != nil {
@@ -1462,6 +1501,38 @@ func TestEvaluateCompileFailsClosed(t *testing.T) {
 				t.Fatalf("EvaluateCompile() error = %v, want %q", err, test.want)
 			}
 		})
+	}
+}
+
+func TestEvaluateCompileRejectsNonDigitFormatPlaceholders(t *testing.T) {
+	for _, template := range []string{
+		"${{ format('{+0}', 'x') }}",
+		"${{ format('{-0}', 'x') }}",
+		"${{ format('{ 0 }', 'x') }}",
+		"${{ format('{0x1}', 'x') }}",
+	} {
+		if _, err := EvaluateCompileTemplate(template, CompileContext{}); err == nil || !strings.Contains(err.Error(), "format placeholder") {
+			t.Errorf("EvaluateCompileTemplate(%q) error = %v, want format placeholder error", template, err)
+		}
+	}
+	got, err := EvaluateCompileTemplate("${{ format('{0} {01}', 'a', 'b') }}", CompileContext{})
+	if err != nil || got != "a b" {
+		t.Fatalf("EvaluateCompileTemplate() = %q, %v", got, err)
+	}
+}
+
+func TestFromJSONCollapsesCaseInsensitiveDuplicateKeys(t *testing.T) {
+	for template, want := range map[string]string{
+		`${{ fromJSON('{"a":1,"A":2}').a }}`:       "2",
+		`${{ fromJSON('{"a":1,"A":2}').A }}`:       "2",
+		`${{ fromJSON('{"a":1,"A":2}')['A'] }}`:    "2",
+		`${{ fromJSON('{"A":2,"a":1}').a }}`:       "1",
+		`${{ toJSON(fromJSON('{"a":1,"A":2}')) }}`: "{\n  \"a\": 2\n}",
+	} {
+		got, err := EvaluateCompileTemplate(template, CompileContext{})
+		if err != nil || got != want {
+			t.Errorf("EvaluateCompileTemplate(%q) = %q, %v, want %q", template, got, err, want)
+		}
 	}
 }
 

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -1025,6 +1025,50 @@ func TestEvaluateConditionSupportsPureFunctions(t *testing.T) {
 	}
 }
 
+func TestNestedMatrixReferencesAreSupported(t *testing.T) {
+	matrix := map[string]any{"config": map[string]any{"os": "ubuntu-24.04", "name": "linux"}, "os": "ubuntu-24.04"}
+
+	// Compile-time templates such as runs-on.
+	got, err := EvaluateCompileTemplate("${{ matrix.config.os }}", CompileContext{Matrix: matrix})
+	if err != nil || got != "ubuntu-24.04" {
+		t.Fatalf("EvaluateCompileTemplate() = %q, %v", got, err)
+	}
+	// Missing or scalar intermediate segments yield null, matching GitHub.
+	for _, template := range []string{"${{ matrix.config.missing }}", "${{ matrix.os.name }}"} {
+		if got, err := EvaluateCompileTemplate(template, CompileContext{Matrix: matrix}); err != nil || got != "" {
+			t.Errorf("EvaluateCompileTemplate(%q) = %q, %v, want empty", template, got, err)
+		}
+	}
+
+	// Runtime templates such as step run and env.
+	if err := ValidateRuntimeTemplate("${{ matrix.config.name }}"); err != nil {
+		t.Fatalf("ValidateRuntimeTemplate() error = %v", err)
+	}
+	if got, err := EvaluateStep("${{ matrix.config.name }}", Context{Matrix: matrix}); err != nil || got != "linux" {
+		t.Fatalf("EvaluateStep() = %q, %v", got, err)
+	}
+	if got, err := Evaluate("${{ matrix.config.missing }}", Context{Matrix: matrix}); err != nil || got != "" {
+		t.Fatalf("Evaluate() = %q, %v, want empty", got, err)
+	}
+
+	// Conditions.
+	for condition, want := range map[string]bool{
+		"matrix.config.name == 'linux'": true,
+		"matrix.config.name == 'mac'":   false,
+		"matrix.config.missing == null": true,
+		"matrix.os.name == null":        true,
+	} {
+		if err := ValidateCondition(condition, StepCondition); err != nil {
+			t.Errorf("ValidateCondition(%q) error = %v", condition, err)
+			continue
+		}
+		got, err := EvaluateCondition(condition, ConditionContext{Matrix: matrix})
+		if err != nil || got != want {
+			t.Errorf("EvaluateCondition(%q) = %v, %v, want %v", condition, got, err, want)
+		}
+	}
+}
+
 func TestEvaluateConditionSupportsBracketFormGitHubReferences(t *testing.T) {
 	for condition, want := range map[string]bool{
 		"github['event_name'] == 'push'":       true,

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -1091,8 +1091,15 @@ func TestEvaluateConditionSupportsBracketFormGitHubReferences(t *testing.T) {
 			t.Errorf("EvaluateCondition(%q) = %v, %v, want %v", condition, got, err, want)
 		}
 	}
-	if _, err := EvaluateCondition("github['event_name'] == 'push'", ConditionContext{}); err == nil || !strings.Contains(err.Error(), `condition context "github" is unavailable`) {
+	if _, err := EvaluateCondition("github['event_name'] == 'push'", ConditionContext{}); err == nil || !strings.Contains(err.Error(), "condition references unavailable value github.event_name") {
 		t.Fatalf("EvaluateCondition() without github context error = %v", err)
+	}
+	// Whole and dynamic github access fails closed at evaluation even
+	// without prior validation, such as composite-action if conditions.
+	for _, condition := range []string{"github", "github[vars.KEY]", "github.*"} {
+		if _, err := EvaluateCondition(condition, ConditionContext{GitHub: map[string]any{"event_name": "push"}, Vars: map[string]string{"KEY": "event_name"}}); err == nil {
+			t.Errorf("EvaluateCondition(%q) error = nil, want fail-closed error", condition)
+		}
 	}
 }
 

--- a/internal/expression/pure_functions.go
+++ b/internal/expression/pure_functions.go
@@ -438,8 +438,14 @@ func expressionFormat(format string, valueCount int, value func(int) (any, error
 				return "", fmt.Errorf("format string contains an unmatched '{'")
 			}
 			end += i + 1
-			index, err := strconv.Atoi(format[i+1 : end])
-			if err != nil || index < 0 || index >= valueCount {
+			indexText := format[i+1 : end]
+			// GitHub requires placeholder indexes to be bare digits; signs
+			// and whitespace are rejected, so strconv.Atoi alone is too loose.
+			if indexText == "" || strings.ContainsFunc(indexText, func(r rune) bool { return r < '0' || r > '9' }) {
+				return "", fmt.Errorf("format placeholder %q is invalid", format[i:end+1])
+			}
+			index, err := strconv.Atoi(indexText)
+			if err != nil || index >= valueCount {
 				return "", fmt.Errorf("format placeholder %q is invalid", format[i:end+1])
 			}
 			argument, exists := values[index]

--- a/internal/expression/runtime.go
+++ b/internal/expression/runtime.go
@@ -549,6 +549,22 @@ func resolveRuntimeReferenceValue(root string, path []string, context Context, a
 	case runtimeReferenceMatrix:
 		for name, value := range context.Matrix {
 			if strings.EqualFold(name, path[0]) {
+				// Nested references such as matrix.config.os walk into
+				// object-valued matrix entries; a missing or non-object
+				// segment yields null, matching GitHub.
+				for _, part := range path[1:] {
+					var (
+						ok  bool
+						err error
+					)
+					value, ok, err = objectValue(value, part)
+					if err != nil {
+						return nil, err
+					}
+					if !ok {
+						return nil, nil
+					}
+				}
 				return value, nil
 			}
 		}
@@ -611,7 +627,7 @@ func classifyRuntimeReference(root string, path []string) runtimeReferenceKind {
 		return runtimeReferenceGitHub
 	case len(path) == 1 && strings.EqualFold(root, "inputs"):
 		return runtimeReferenceInput
-	case len(path) == 1 && strings.EqualFold(root, "matrix"):
+	case len(path) >= 1 && strings.EqualFold(root, "matrix"):
 		return runtimeReferenceMatrix
 	case len(path) == 1 && strings.EqualFold(root, "secrets"):
 		return runtimeReferenceSecret


### PR DESCRIPTION
Follow-ups from a review of #252. Five behavioral gaps against GitHub's evaluator, each with regression tests.

## Nested matrix references failed validation (corpus regression)

#252 added `validateCompileExpressionNode` as a pre-evaluation gate in `EvaluateCompile` that restricted `matrix` references to one path segment. `runs-on: ${{ matrix.config.os }}` resolved before the merge and failed with `unsupported compile-time reference "matrix.config.os"` after it, flipping a previously admitted corpus workflow to incompatible. Matrix values may be objects or arrays (include entries and object lists), so nested references are valid; `resolveCompileReference` already walked them.

Runtime templates and conditions rejected nested matrix references on both sides of #252, which meant a workflow whose compile validation passed could still fail at run-job time. Both now walk nested paths as well, with missing or scalar intermediate segments yielding null to match GitHub.

| Surface | Before #252 | After #252 | Now |
|---|---|---|---|
| `runs-on: ${{ matrix.config.os }}` | resolved | rejected | resolved |
| `run: ${{ matrix.config.name }}` | fails at run-job | fails at run-job | evaluates |
| `if: matrix.config.name == 'linux'` | rejected | rejected | evaluates |

## Nested `inputs` receiver properties were rewritten

`SubstituteCompileInputs` matched any `inputs . <ident>` token run, so property chains on other receivers were corrupted:

| Template | Before | After |
|---|---|---|
| `${{ github.event.inputs.debug }}` | `${{ github.event.true }}` | unchanged |
| `${{ steps.inputs.name }}` | `${{ steps.'prod' }}` | unchanged |
| `${{ inputs.debug }}` | `${{ true }}` | `${{ true }}` |

A preceding `.` token now marks the sequence as a property access, not the workflow-call inputs context.

## Bracket-form `github` condition references failed at evaluation

`github['event_name'] == 'push'` passed `ValidateCondition` (validation treats `github` as a static-authority root) but errored at `EvaluateCondition` because `resolveConditionRoot` had no `github` case. It now returns the GitHub context, or the existing unavailable-context error when the context is nil.

## `format()` accepted placeholders GitHub rejects

`strconv.Atoi` accepts signs, so `format('{+0}', x)` and `format('{-0}', x)` compiled locally but fail on GitHub, whose parser requires bare digits. Placeholder indexes are now digit-only; `{0}` and `{01}` still work.

## `fromJSON` duplicate keys diverged from GitHub

For `fromJSON('{"a":1,"A":2}')`, GitHub's `DictionaryContextData` is case-insensitive at construction: the later value replaces the earlier one and the first spelling survives, so `.a`, `.A`, and `['A']` all yield `2` ([JTokenExtensions.ToPipelineContextData](https://github.com/actions/runner/blob/main/src/Sdk/DTPipelines/Pipelines/ContextData/JTokenExtensions.cs#L34-L43), [DictionaryContextData setter](https://github.com/actions/runner/blob/main/src/Sdk/DTPipelines/Pipelines/ContextData/DictionaryContextData.cs#L105-L126)). We errored with "ambiguous properties" instead. `decodeJSONValue` now decodes token by token (a plain map decode loses the key order the semantics depend on) and collapses case-insensitive duplicates the same way. The ambiguity error in `objectValue` remains as a safety net for caller-built context maps and drops its misleading "compile-time" prefix, since the helper also serves condition evaluation.

## Not changed

- Bracket-form `runner['os']` stays rejected at validation; only `github`/`secrets` are static-authority roots there, and GitHub-hosted parity for it was not part of the review findings.
- The timeout-minutes coercion switch in `internal/runtime/job.go` stays separate from `githubNumber`, which coerces strings and booleans that timeout handling must reject.

## Validation

`go build`, `go test ./...`, `go test -race ./internal/expression/...`, `go vet`, `golangci-lint run` (0 issues), and `mise run smoke:local` all pass.
