### PR TITLE
Harden runtime and reusable workflow input handling

### DIFF
--- a/internal/action/source/source.go
+++ b/internal/action/source/source.go
@@ -889,6 +889,9 @@ func extractTar(r io.Reader, dst string, c config) error {
 		if e != nil {
 			return fmt.Errorf("read archive: %w", e)
 		}
+		if !utf8.ValidString(h.Name) || !utf8.ValidString(h.Linkname) {
+			return fmt.Errorf("archive contains invalid UTF-8 metadata")
+		}
 		if h.Typeflag == tar.TypeXGlobalHeader {
 			// archive/tar still exposes legacy xattrs separately from PAX records.
 			if h.Xattrs != nil || h.Linkname != "" || !benignPAX(h.PAXRecords, false) { //nolint:staticcheck

--- a/internal/action/source/source_test.go
+++ b/internal/action/source/source_test.go
@@ -621,6 +621,52 @@ func TestStoreExactCommitAtomicHitAndSubpath(t *testing.T) {
 	second.Release()
 }
 
+func TestStoreRejectsInvalidUTF8ArchiveMetadataOnEveryMaterialization(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries []tar.Header
+	}{
+		{
+			name: "name",
+			entries: []tar.Header{
+				{Name: "root/", Typeflag: tar.TypeDir},
+				{Name: "root/\xff", Typeflag: tar.TypeReg},
+			},
+		},
+		{
+			name: "symlink target",
+			entries: []tar.Header{
+				{Name: "root/", Typeflag: tar.TypeDir},
+				{Name: "root/target", Typeflag: tar.TypeReg},
+				{Name: "root/link", Typeflag: tar.TypeSymlink, Linkname: "target/\xff/.."},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			archive := tgz(t, tt.entries)
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write(archive)
+			}))
+			defer server.Close()
+
+			store, err := NewStore(t.TempDir(), server.Client(), WithTestEndpoints(server.URL, server.URL))
+			if err != nil {
+				t.Fatal(err)
+			}
+			ref, _ := Parse("Owner/Repo@v1")
+			resolved := Resolved{Reference: ref, Commit: testSHA}
+			for attempt := 1; attempt <= 2; attempt++ {
+				materialized, err := store.Materialize(context.Background(), resolved)
+				if err == nil || !strings.Contains(err.Error(), "invalid UTF-8") {
+					materialized.Release()
+					t.Fatalf("materialization %d error = %v, want invalid UTF-8 rejection", attempt, err)
+				}
+			}
+		})
+	}
+}
+
 func TestStoreCanonicalizesAliasedAncestorAndRejectsSymlinkRoot(t *testing.T) {
 	base, err := filepath.EvalSymlinks(t.TempDir())
 	if err != nil {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1320,7 +1320,7 @@ func validate(args []string, stdout, stderr io.Writer, version string, agent tra
 	if profile != "" && eventPath == "" && eventName == "" && !allEvents {
 		return usageError(stderr, "validate: --profile hosted requires --event, --event-path, or --all-events; use bare validate <workflow> for event-independent syntax and trigger compatibility validation")
 	}
-	out := newProcessingOutput("validate", format, stdout, stderr, agent)
+	out := newProcessingOutput(context.Background(), "validate", format, stdout, stderr, agent)
 	if allEvents {
 		return validateAllEvents(out, workflowPath, version, actionCacheDir, nil, stderr)
 	}
@@ -1673,7 +1673,7 @@ func compile(args []string, stdout, stderr io.Writer, version string, agent tran
 	if eventPath == "" {
 		return usageError(stderr, "compile: --event-path is required")
 	}
-	out := newProcessingOutput("compile", "text", stderr, stderr, agent)
+	out := newProcessingOutput(context.Background(), "compile", "text", stderr, stderr, agent)
 	event, eventErr := os.ReadFile(eventPath)
 	if parsedEvent, parseErr := compiler.ParseEvent(event); eventErr == nil && parseErr == nil {
 		out.sourceLinks = sourceLinksForEvent(parsedEvent)
@@ -1769,7 +1769,7 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 			return usageError(stderr, "upload: %s is no longer supported; configure runner profiles with --runner-queue and --runner-image, or with the plugin runners array", retired)
 		}
 	}
-	out := newProcessingOutput("upload", "text", stderr, stderr, agent)
+	out := newProcessingOutput(ctx, "upload", "text", stderr, stderr, agent)
 	out.plugin = uploadArguments.pluginAcquisition != nil
 	if uploadArguments.telemetry != nil {
 		out.observe = uploadArguments.telemetry.observe

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2751,6 +2751,57 @@ func TestValidatePublishesProcessingDiagnosticsInBuildkite(t *testing.T) {
 	})
 }
 
+type annotationContextRunner struct {
+	contexts []context.Context
+}
+
+func (r *annotationContextRunner) Run(ctx context.Context, _ string, _ string, _ []string, _ []byte) ([]byte, error) {
+	r.contexts = append(r.contexts, ctx)
+	return nil, nil
+}
+
+func TestProcessingAnnotationsUseActiveBoundedContext(t *testing.T) {
+	for _, path := range []struct {
+		name    string
+		publish func(processingOutput)
+	}{
+		{
+			name: "processing",
+			publish: func(out processingOutput) {
+				report := compatibility.NewProcessingReport("ci.yml", "")
+				report.Diagnostics = append(report.Diagnostics, compatibility.Diagnostic{Level: "warning", Message: "test warning"})
+				out.annotate(report)
+			},
+		},
+		{
+			name: "skipped workflow",
+			publish: func(out processingOutput) {
+				out.annotateSkippedWorkflows("push", []skippedWorkflow{{label: "CI", key: "ci", reason: "not applicable"}})
+			},
+		},
+	} {
+		t.Run(path.name, func(t *testing.T) {
+			active, cancel := context.WithCancel(context.Background())
+			cancel()
+			t.Setenv("BUILDKITE", "true")
+			t.Setenv("BUILDKITE_JOB_ID", cliTestJobID)
+			t.Setenv("BUILDKITE_BUILD_URL", "https://buildkite.com/acme/widgets/builds/42")
+			runner := &annotationContextRunner{}
+			out := newProcessingOutput(active, "test", "text", io.Discard, io.Discard, transport.Agent{Runner: runner})
+			path.publish(out)
+			if len(runner.contexts) != 1 {
+				t.Fatalf("annotation calls = %d, want 1", len(runner.contexts))
+			}
+			if err := runner.contexts[0].Err(); !errors.Is(err, context.Canceled) {
+				t.Errorf("annotation context error = %v, want context canceled", err)
+			}
+			if _, ok := runner.contexts[0].Deadline(); !ok {
+				t.Error("annotation context has no deadline")
+			}
+		})
+	}
+}
+
 func TestEventBackedCommandsLinkEarlyWorkflowDiagnostics(t *testing.T) {
 	repository := t.TempDir()
 	workflowPath := filepath.Join(repository, ".github", "workflows", "broken.yml")

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 	"unicode"
 	"unicode/utf8"
 
@@ -25,11 +26,13 @@ const (
 	skippedWorkflowsContext       = "buildkite-gha-skipped-workflows"
 	processingAnnotationBodyLimit = 1024 * 1024
 	processingAnnotationNotice    = "\n_Additional diagnostics omitted at the Buildkite annotation size limit._\n"
+	processingAnnotationTimeout   = 5 * time.Second
 )
 
 // processingOutput owns where one command writes processing reports and
 // command diagnostics.
 type processingOutput struct {
+	context       context.Context
 	command       string
 	format        string
 	reports       io.Writer
@@ -73,8 +76,8 @@ func (c sourceLinkContext) link(path string, line int) string {
 	return link
 }
 
-func newProcessingOutput(command, format string, reports, stderr io.Writer, agent transport.Agent) processingOutput {
-	out := processingOutput{command: command, format: format, reports: reports, stderr: stderr}
+func newProcessingOutput(ctx context.Context, command, format string, reports, stderr io.Writer, agent transport.Agent) processingOutput {
+	out := processingOutput{context: ctx, command: command, format: format, reports: reports, stderr: stderr}
 	if os.Getenv("BUILDKITE") == "true" && os.Getenv("BUILDKITE_JOB_ID") != "" {
 		out.annotationJob = os.Getenv("BUILDKITE_JOB_ID")
 		out.buildURL = os.Getenv("BUILDKITE_BUILD_URL")
@@ -177,7 +180,9 @@ func (o processingOutput) annotate(report compatibility.ProcessingReport) {
 	}
 	digest := sha256.Sum256([]byte(report.Workflow))
 	annotationContext := fmt.Sprintf("%s-%x", processingAnnotationContext, digest[:6])
-	if err := o.agent.AnnotateJob(context.Background(), o.annotationJob, annotationContext, style, body); err != nil {
+	ctx, cancel := context.WithTimeout(o.context, processingAnnotationTimeout)
+	defer cancel()
+	if err := o.agent.AnnotateJob(ctx, o.annotationJob, annotationContext, style, body); err != nil {
 		_, _ = fmt.Fprintf(o.stderr, "buildkite-gha: %s: warning: processing annotation: %v\n", o.command, err)
 	}
 }
@@ -193,7 +198,9 @@ func (o processingOutput) annotateSkippedWorkflows(event string, workflows []ski
 	if o.annotationJob == "" || body == "" {
 		return
 	}
-	if err := o.agent.AnnotateJob(context.Background(), o.annotationJob, skippedWorkflowsContext, "info", body); err != nil {
+	ctx, cancel := context.WithTimeout(o.context, processingAnnotationTimeout)
+	defer cancel()
+	if err := o.agent.AnnotateJob(ctx, o.annotationJob, skippedWorkflowsContext, "info", body); err != nil {
 		_, _ = fmt.Fprintf(o.stderr, "buildkite-gha: %s: warning: skipped workflows annotation: %v\n", o.command, err)
 	}
 }

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -1223,7 +1223,7 @@ jobs:
         required: true
 jobs:
   gated:
-    if: ${{ inputs['enabled'] && github.ref }}
+    if: inputs.enabled && github.ref
     runs-on: ubuntu-latest
     env:
       LABEL: ${{ inputs['label'] }}
@@ -1231,7 +1231,7 @@ jobs:
       label: ${{ inputs['label'] }}
     steps:
       - run: echo ${{ inputs['enabled'] }} ${{ github.ref }}
-      - if: inputs['enabled']
+      - if: inputs['enabled'] && github.ref
         run: echo implicit
       - if: ${{ inputs [ 'label' ] }}
         run: echo string
@@ -1241,7 +1241,7 @@ jobs:
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(plans) != 1 || plans[0].Condition != "${{ true && github.ref }}" || plans[0].Inputs["enabled"] != true || plans[0].Inputs["label"] != "release" || plans[0].Env["LABEL"] != "release" || plans[0].Outputs["label"] != "release" || len(plans[0].Steps) != 3 || plans[0].Steps[0].Command != "echo true ${{ github.ref }}" || plans[0].Steps[1].Condition != "true" || plans[0].Steps[2].Condition != "'release'" {
+	if len(plans) != 1 || plans[0].Condition != "${{ true && github.ref }}" || plans[0].Inputs["enabled"] != true || plans[0].Inputs["label"] != "release" || plans[0].Env["LABEL"] != "release" || plans[0].Outputs["label"] != "release" || len(plans[0].Steps) != 3 || plans[0].Steps[0].Command != "echo true ${{ github.ref }}" || plans[0].Steps[1].Condition != "${{ true && github.ref }}" || plans[0].Steps[2].Condition != "'release'" {
 		t.Fatalf("reusable condition = %#v", plans)
 	}
 }
@@ -1296,11 +1296,13 @@ jobs:
   call:
     uses: ./.github/workflows/reusable.yml
     with:
+      key: target
       target: release
 `)
 	writeWorkflow(t, repository, "reusable.yml", `on:
   workflow_call:
     inputs:
+      key: {type: string, required: true}
       target: {type: string, required: true}
 jobs:
   test:
@@ -1310,14 +1312,15 @@ jobs:
     steps:
       - run: echo "$VALUE"
         env:
-          VALUE: ${{ inputs[env.KEY] }}
+          VALUE_ENV: ${{ inputs[env.KEY] }}
+          VALUE_INPUT: ${{ inputs[inputs.key] }}
 `)
 
 	plans, err := compileUntrustedPlans(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-untrusted")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(plans) != 1 || plans[0].Inputs["target"] != "release" || len(plans[0].Steps) != 1 || plans[0].Steps[0].Env["VALUE"] != "${{ inputs[env.KEY] }}" {
+	if len(plans) != 1 || plans[0].Inputs["target"] != "release" || len(plans[0].Steps) != 1 || plans[0].Steps[0].Env["VALUE_ENV"] != "${{ inputs[env.KEY] }}" || plans[0].Steps[0].Env["VALUE_INPUT"] != "release" {
 		t.Fatalf("computed reusable input plan = %#v", plans)
 	}
 }

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -1233,7 +1233,7 @@ jobs:
       - run: echo ${{ inputs['enabled'] }} ${{ github.ref }}
       - if: inputs['enabled']
         run: echo implicit
-      - if: ${{ inputs['label'] }}
+      - if: ${{ inputs [ 'label' ] }}
         run: echo string
 `)
 
@@ -1263,7 +1263,7 @@ jobs:
   call:
     uses: ./.github/workflows/leaf.yml
     with:
-      target: ${{ inputs['target'] }}
+      target: ${{ inputs [ 'target' ] }}
 `)
 	writeWorkflow(t, repository, "leaf.yml", `on:
   workflow_call:

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -1237,8 +1237,26 @@ jobs:
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(plans) != 1 || plans[0].Condition != "${{ inputs['enabled'] && github.ref }}" || plans[0].Inputs["enabled"] != true || plans[0].Inputs["label"] != "release" || plans[0].Env["LABEL"] != "${{ inputs['label'] }}" || plans[0].Outputs["label"] != "${{ inputs['label'] }}" || len(plans[0].Steps) != 1 || plans[0].Steps[0].Command != "echo ${{ inputs['enabled'] }} ${{ github.ref }}" {
+	if len(plans) != 1 || plans[0].Condition != "${{ true && github.ref }}" || plans[0].Inputs["enabled"] != true || plans[0].Inputs["label"] != "release" || plans[0].Env["LABEL"] != "release" || plans[0].Outputs["label"] != "release" || len(plans[0].Steps) != 1 || plans[0].Steps[0].Command != "echo true ${{ github.ref }}" {
 		t.Fatalf("reusable condition = %#v", plans)
+	}
+}
+
+func TestApplyStaticInputsSubstitutesIndexedInputsInStepFields(t *testing.T) {
+	span := workflow.Span{Start: workflow.Position{Line: 1, Column: 1}}
+	job := workflow.Job{ID: "test", Span: span, Steps: []workflow.Step{{
+		Span: span,
+		Run:  "echo ${{ inputs['target'] }}",
+		Env:  map[string]string{"TARGET": "${{ inputs['target'] }}"},
+		With: map[string]string{"target": "prefix-${{ inputs['target'] }}"},
+	}}}
+	resolved, err := applyStaticInputs("workflow.yml", job, map[string]any{"target": "production"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	step := resolved.Steps[0]
+	if step.Run != "echo production" || step.Env["TARGET"] != "production" || step.With["target"] != "prefix-production" {
+		t.Fatalf("resolved indexed inputs = %#v", step)
 	}
 }
 
@@ -1327,6 +1345,9 @@ func TestRejectUnresolvedIndexedInputsInCompileTimeFields(t *testing.T) {
 		{name: "job name", job: workflow.Job{Name: "${{ inputs['label'] }}"}},
 		{name: "runner label", job: workflow.Job{RunsOn: []string{"${{ inputs['runner'] }}"}}},
 		{name: "action reference", job: workflow.Job{Steps: []workflow.Step{{Uses: "${{ inputs['action'] }}", Span: span}}}},
+		{name: "command", job: workflow.Job{Steps: []workflow.Step{{Run: "echo ${{ inputs['target'] }}", Span: span}}}},
+		{name: "environment", job: workflow.Job{Steps: []workflow.Step{{Env: map[string]string{"TARGET": "${{ inputs['target'] }}"}, Span: span}}}},
+		{name: "action input", job: workflow.Job{Steps: []workflow.Step{{With: map[string]string{"target": "${{ inputs['target'] }}"}, Span: span}}}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			test.job.ID = "test"
@@ -3049,7 +3070,7 @@ jobs:
 		t.Fatalf("compiled plans = %d, want 1", len(plans))
 	}
 	job := plans[0]
-	if job.Env["LABEL"] != "bash" || job.Env["INDEXED_LABEL"] != "${{ inputs['label'] }}" || job.Inputs["label"] != "bash" || job.Inputs["timeout"] != json.Number("7") || job.DefaultShell != "bash" || job.Outputs["label"] != "bash" || job.Steps[0].TimeoutMinutes != 7 || job.Steps[0].TimeoutMinutesExpression != "" {
+	if job.Env["LABEL"] != "bash" || job.Env["INDEXED_LABEL"] != "bash" || job.Inputs["label"] != "bash" || job.Inputs["timeout"] != json.Number("7") || job.DefaultShell != "bash" || job.Outputs["label"] != "bash" || job.Steps[0].TimeoutMinutes != 7 || job.Steps[0].TimeoutMinutesExpression != "" {
 		t.Fatalf("compiled dispatch input surfaces = %#v", job)
 	}
 }

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -1289,6 +1289,39 @@ jobs:
 	}
 }
 
+func TestCompilePreservesComputedReusableInputIndexesForRuntime(t *testing.T) {
+	repository := t.TempDir()
+	callerPath := writeWorkflow(t, repository, "caller.yml", `on: push
+jobs:
+  call:
+    uses: ./.github/workflows/reusable.yml
+    with:
+      target: release
+`)
+	writeWorkflow(t, repository, "reusable.yml", `on:
+  workflow_call:
+    inputs:
+      target: {type: string, required: true}
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      KEY: target
+    steps:
+      - run: echo "$VALUE"
+        env:
+          VALUE: ${{ inputs[env.KEY] }}
+`)
+
+	plans, err := compileUntrustedPlans(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-untrusted")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 1 || plans[0].Inputs["target"] != "release" || len(plans[0].Steps) != 1 || plans[0].Steps[0].Env["VALUE"] != "${{ inputs[env.KEY] }}" {
+		t.Fatalf("computed reusable input plan = %#v", plans)
+	}
+}
+
 func TestApplyStaticInputsSubstitutesIndexedInputsInStepFields(t *testing.T) {
 	span := workflow.Span{Start: workflow.Position{Line: 1, Column: 1}}
 	job := workflow.Job{ID: "test", Span: span, Steps: []workflow.Step{{

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -1231,14 +1231,61 @@ jobs:
       label: ${{ inputs['label'] }}
     steps:
       - run: echo ${{ inputs['enabled'] }} ${{ github.ref }}
+      - if: inputs['enabled']
+        run: echo implicit
+      - if: ${{ inputs['label'] }}
+        run: echo string
 `)
 
 	plans, err := compileUntrustedPlans(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-untrusted")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(plans) != 1 || plans[0].Condition != "${{ true && github.ref }}" || plans[0].Inputs["enabled"] != true || plans[0].Inputs["label"] != "release" || plans[0].Env["LABEL"] != "release" || plans[0].Outputs["label"] != "release" || len(plans[0].Steps) != 1 || plans[0].Steps[0].Command != "echo true ${{ github.ref }}" {
+	if len(plans) != 1 || plans[0].Condition != "${{ true && github.ref }}" || plans[0].Inputs["enabled"] != true || plans[0].Inputs["label"] != "release" || plans[0].Env["LABEL"] != "release" || plans[0].Outputs["label"] != "release" || len(plans[0].Steps) != 3 || plans[0].Steps[0].Command != "echo true ${{ github.ref }}" || plans[0].Steps[1].Condition != "true" || plans[0].Steps[2].Condition != "'release'" {
 		t.Fatalf("reusable condition = %#v", plans)
+	}
+}
+
+func TestCompileForwardsIndexedStringInputToNestedReusableWorkflow(t *testing.T) {
+	repository := t.TempDir()
+	callerPath := writeWorkflow(t, repository, "caller.yml", `on: push
+jobs:
+  call:
+    uses: ./.github/workflows/middle.yml
+    with:
+      target: release
+`)
+	writeWorkflow(t, repository, "middle.yml", `on:
+  workflow_call:
+    inputs:
+      target: {type: string, required: true}
+jobs:
+  call:
+    uses: ./.github/workflows/leaf.yml
+    with:
+      target: ${{ inputs['target'] }}
+`)
+	writeWorkflow(t, repository, "leaf.yml", `on:
+  workflow_call:
+    inputs:
+      target: {type: string, required: true}
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ${{ inputs.target }}
+`)
+
+	result, err := Compile(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ir IR
+	if err := json.Unmarshal(result, &ir); err != nil {
+		t.Fatal(err)
+	}
+	if len(ir.Jobs) != 1 || len(ir.Jobs[0].Steps) != 1 || ir.Jobs[0].Steps[0].Run != "echo release" {
+		t.Fatalf("forwarded indexed input = %#v", ir.Jobs)
 	}
 }
 

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -833,9 +833,10 @@ func replaceSliceInputs(values []string, inputs map[string]any) []string {
 }
 
 func rejectUnresolvedInputExpressions(path string, job workflow.Job) error {
-	jobValues := []string{job.Name, job.If, job.DefaultShell, job.DefaultWorkingDirectory}
-	jobValues = appendMapValues(jobValues, job.Env)
-	jobValues = appendMapValues(jobValues, job.Outputs)
+	jobValues := []string{job.Name}
+	jobRuntimeValues := []string{job.DefaultShell, job.DefaultWorkingDirectory}
+	jobRuntimeValues = appendMapValues(jobRuntimeValues, job.Env)
+	jobRuntimeValues = appendMapValues(jobRuntimeValues, job.Outputs)
 	if job.Concurrency != nil {
 		jobValues = append(jobValues, job.Concurrency.Group)
 	}
@@ -882,15 +883,26 @@ func rejectUnresolvedInputExpressions(path string, job workflow.Job) error {
 			return jobError(path, job, "reusable-workflow input expression is not statically resolvable")
 		}
 	}
+	if hasStaticInputCondition(job.If) {
+		return jobError(path, job, "reusable-workflow input expression is not statically resolvable")
+	}
+	for _, value := range jobRuntimeValues {
+		if hasStaticInputExpression(value) {
+			return jobError(path, job, "reusable-workflow input expression is not statically resolvable")
+		}
+	}
 	for _, step := range job.Steps {
 		if hasInputExpression(step.Uses) {
 			return locatedJobError(path, job, step.Span.Start.Line, step.Span.Start.Column, "reusable-workflow action reference input expression is not statically resolvable")
 		}
-		stepValues := []string{step.Name, step.Run, step.Shell, step.WorkingDirectory, step.If, step.ContinueOnErrorExpression, step.TimeoutMinutesExpression}
+		if hasStaticInputCondition(step.If) {
+			return locatedJobError(path, job, step.Span.Start.Line, step.Span.Start.Column, "reusable-workflow input expression is not statically resolvable")
+		}
+		stepValues := []string{step.Name, step.Run, step.Shell, step.WorkingDirectory, step.ContinueOnErrorExpression, step.TimeoutMinutesExpression}
 		stepValues = appendMapValues(stepValues, step.Env)
 		stepValues = appendMapValues(stepValues, step.With)
 		for _, value := range stepValues {
-			if hasInputExpression(value) {
+			if hasStaticInputExpression(value) {
 				return locatedJobError(path, job, step.Span.Start.Line, step.Span.Start.Column, "reusable-workflow input expression is not statically resolvable")
 			}
 		}
@@ -956,6 +968,16 @@ func containsInputExpression(value any) bool {
 
 func hasInputExpression(value string) bool {
 	usesInputs, err := expression.TemplateUsesContext(value, "inputs")
+	return err != nil || usesInputs
+}
+
+func hasStaticInputExpression(value string) bool {
+	usesInputs, err := expression.TemplateUsesStaticContextReference(value, "inputs")
+	return err != nil || usesInputs
+}
+
+func hasStaticInputCondition(value string) bool {
+	usesInputs, err := expression.ConditionUsesStaticContextReference(value, "inputs")
 	return err != nil || usesInputs
 }
 

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -21,8 +21,8 @@ const (
 	maxFlattenedJobs         = 1024
 )
 
-var staticInputCondition = regexp.MustCompile(`(?i)^\s*(?:\$\{\{\s*inputs\.([A-Za-z_][A-Za-z0-9_-]*)\s*\}\}|inputs\.([A-Za-z_][A-Za-z0-9_-]*))\s*$`)
-var staticValueExpression = regexp.MustCompile(`^\s*\$\{\{\s*(inputs|matrix)\.([A-Za-z_][A-Za-z0-9_-]*)\s*\}\}\s*$`)
+var staticInputCondition = regexp.MustCompile(`(?i)^\s*(?:\$\{\{\s*inputs(?:\.([A-Za-z_][A-Za-z0-9_-]*)|\['([A-Za-z0-9_-]{1,255})'\])\s*\}\}|inputs(?:\.([A-Za-z_][A-Za-z0-9_-]*)|\['([A-Za-z0-9_-]{1,255})'\]))\s*$`)
+var staticValueExpression = regexp.MustCompile(`(?i)^\s*\$\{\{\s*(inputs|matrix)(?:\.([A-Za-z_][A-Za-z0-9_-]*)|\['([A-Za-z0-9_-]{1,255})'\])\s*\}\}\s*$`)
 var callOutputNamePattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,255}$`)
 
 type sourcedJob struct {
@@ -599,18 +599,22 @@ func resolveCallInputs(path string, job workflow.Job, call *workflow.ReusableWor
 func evaluateStaticCallValue(value string, inputs, matrix map[string]any, context expression.CompileContext) (any, error) {
 	if match := staticValueExpression.FindStringSubmatch(value); match != nil {
 		values := inputs
-		if match[1] == "matrix" {
+		if strings.EqualFold(match[1], "matrix") {
 			values = matrix
 		}
+		valueName := match[2]
+		if valueName == "" {
+			valueName = match[3]
+		}
 		for name, value := range values {
-			if strings.EqualFold(name, match[2]) {
+			if strings.EqualFold(name, valueName) {
 				if containsExpression(value) {
-					return nil, fmt.Errorf("expression references runtime-dependent %s value %q", match[1], match[2])
+					return nil, fmt.Errorf("expression references runtime-dependent %s value %q", match[1], valueName)
 				}
 				return value, nil
 			}
 		}
-		return nil, fmt.Errorf("expression references unavailable %s value %q", match[1], match[2])
+		return nil, fmt.Errorf("expression references unavailable %s value %q", match[1], valueName)
 	}
 	resolved := replaceStaticInputs(value, inputs)
 	if hasInputExpression(resolved) {
@@ -1002,9 +1006,12 @@ func replaceStaticInputCondition(value string, inputs map[string]any) string {
 	if match == nil {
 		return replaceStaticInputs(value, inputs)
 	}
-	inputName := match[1]
-	if inputName == "" {
-		inputName = match[2]
+	inputName := ""
+	for _, candidate := range match[1:] {
+		if candidate != "" {
+			inputName = candidate
+			break
+		}
 	}
 	for name, input := range inputs {
 		if strings.EqualFold(name, inputName) {

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -829,7 +829,9 @@ func replaceSliceInputs(values []string, inputs map[string]any) []string {
 }
 
 func rejectUnresolvedInputExpressions(path string, job workflow.Job) error {
-	jobValues := []string{job.Name}
+	jobValues := []string{job.Name, job.If, job.DefaultShell, job.DefaultWorkingDirectory}
+	jobValues = appendMapValues(jobValues, job.Env)
+	jobValues = appendMapValues(jobValues, job.Outputs)
 	if job.Concurrency != nil {
 		jobValues = append(jobValues, job.Concurrency.Group)
 	}
@@ -879,6 +881,14 @@ func rejectUnresolvedInputExpressions(path string, job workflow.Job) error {
 	for _, step := range job.Steps {
 		if hasInputExpression(step.Uses) {
 			return locatedJobError(path, job, step.Span.Start.Line, step.Span.Start.Column, "reusable-workflow action reference input expression is not statically resolvable")
+		}
+		stepValues := []string{step.Name, step.Run, step.Shell, step.WorkingDirectory, step.If, step.ContinueOnErrorExpression, step.TimeoutMinutesExpression}
+		stepValues = appendMapValues(stepValues, step.Env)
+		stepValues = appendMapValues(stepValues, step.With)
+		for _, value := range stepValues {
+			if hasInputExpression(value) {
+				return locatedJobError(path, job, step.Span.Start.Line, step.Span.Start.Column, "reusable-workflow input expression is not statically resolvable")
+			}
 		}
 	}
 	return nil

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -1026,6 +1026,12 @@ func replaceMapInputs(values map[string]string, inputs map[string]any) map[strin
 func replaceStaticInputCondition(value string, inputs map[string]any) string {
 	match := staticInputCondition.FindStringSubmatch(value)
 	if match == nil {
+		if !strings.Contains(value, "${{") {
+			usesInputs, err := expression.ConditionUsesContext(value, "inputs")
+			if err == nil && usesInputs {
+				return replaceStaticInputs("${{ "+value+" }}", inputs)
+			}
+		}
 		return replaceStaticInputs(value, inputs)
 	}
 	inputName := ""

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -21,8 +21,8 @@ const (
 	maxFlattenedJobs         = 1024
 )
 
-var staticInputCondition = regexp.MustCompile(`(?i)^\s*(?:\$\{\{\s*inputs(?:\.([A-Za-z_][A-Za-z0-9_-]*)|\['([A-Za-z0-9_-]{1,255})'\])\s*\}\}|inputs(?:\.([A-Za-z_][A-Za-z0-9_-]*)|\['([A-Za-z0-9_-]{1,255})'\]))\s*$`)
-var staticValueExpression = regexp.MustCompile(`(?i)^\s*\$\{\{\s*(inputs|matrix)(?:\.([A-Za-z_][A-Za-z0-9_-]*)|\['([A-Za-z0-9_-]{1,255})'\])\s*\}\}\s*$`)
+var staticInputCondition = regexp.MustCompile(`(?i)^\s*(?:\$\{\{\s*inputs\s*(?:\.\s*([A-Za-z_][A-Za-z0-9_-]*)|\[\s*'([A-Za-z0-9_-]{1,255})'\s*\])\s*\}\}|inputs\s*(?:\.\s*([A-Za-z_][A-Za-z0-9_-]*)|\[\s*'([A-Za-z0-9_-]{1,255})'\s*\]))\s*$`)
+var staticValueExpression = regexp.MustCompile(`(?i)^\s*\$\{\{\s*(inputs|matrix)\s*(?:\.\s*([A-Za-z_][A-Za-z0-9_-]*)|\[\s*'([A-Za-z0-9_-]{1,255})'\s*\])\s*\}\}\s*$`)
 var callOutputNamePattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,255}$`)
 
 type sourcedJob struct {

--- a/internal/expression/compile.go
+++ b/internal/expression/compile.go
@@ -390,9 +390,10 @@ func introducesExpressionSyntax(before, replacement, after string) bool {
 	return false
 }
 
-// SubstituteCompileInputs replaces static inputs.<name> references inside
-// expression regions with equivalent GitHub expression literals. Text and
-// string literals outside those references are preserved byte-for-byte.
+// SubstituteCompileInputs replaces static inputs.<name> and inputs['name']
+// references inside expression regions with equivalent GitHub expression
+// literals. Text and string literals outside those references are preserved
+// byte-for-byte.
 func SubstituteCompileInputs(template string, inputs map[string]any) (string, error) {
 	const open = "${{"
 	var substituted strings.Builder
@@ -415,8 +416,8 @@ func SubstituteCompileInputs(template string, inputs map[string]any) (string, er
 			value      string
 		}
 		var replacements []replacement
-		for i := 0; i+2 < len(tokens); i++ {
-			if tokens[i].Kind != actionlint.TokenKindIdent || !strings.EqualFold(tokens[i].Value, "inputs") || tokens[i+1].Kind != actionlint.TokenKindDot || tokens[i+2].Kind != actionlint.TokenKindIdent {
+		for i := 0; i < len(tokens); i++ {
+			if tokens[i].Kind != actionlint.TokenKindIdent || !strings.EqualFold(tokens[i].Value, "inputs") {
 				continue
 			}
 			// A preceding '.' means this is a property named "inputs" on
@@ -425,7 +426,21 @@ func SubstituteCompileInputs(template string, inputs map[string]any) (string, er
 			if i > 0 && tokens[i-1].Kind == actionlint.TokenKindDot {
 				continue
 			}
-			value, ok := findCompileInput(inputs, tokens[i+2].Value)
+			var name string
+			var end, consumedTokens int
+			switch {
+			case i+2 < len(tokens) && tokens[i+1].Kind == actionlint.TokenKindDot && tokens[i+2].Kind == actionlint.TokenKindIdent:
+				name = tokens[i+2].Value
+				end = tokens[i+2].Offset + len(tokens[i+2].Value)
+				consumedTokens = 2
+			case i+3 < len(tokens) && tokens[i+1].Kind == actionlint.TokenKindLeftBracket && tokens[i+2].Kind == actionlint.TokenKindString && tokens[i+3].Kind == actionlint.TokenKindRightBracket:
+				name = strings.ReplaceAll(strings.Trim(tokens[i+2].Value, "'"), "''", "'")
+				end = tokens[i+3].Offset + 1
+				consumedTokens = 3
+			default:
+				continue
+			}
+			value, ok := findCompileInput(inputs, name)
 			if !ok {
 				continue
 			}
@@ -435,10 +450,10 @@ func SubstituteCompileInputs(template string, inputs map[string]any) (string, er
 			}
 			replacements = append(replacements, replacement{
 				start: tokens[i].Offset,
-				end:   tokens[i+2].Offset + len(tokens[i+2].Value),
+				end:   end,
 				value: literal,
 			})
-			i += 2
+			i += consumedTokens
 		}
 		for i := len(replacements) - 1; i >= 0; i-- {
 			replacement := replacements[i]

--- a/internal/expression/compile.go
+++ b/internal/expression/compile.go
@@ -395,6 +395,20 @@ func introducesExpressionSyntax(before, replacement, after string) bool {
 // literals. Text and string literals outside those references are preserved
 // byte-for-byte.
 func SubstituteCompileInputs(template string, inputs map[string]any) (string, error) {
+	resolved := template
+	for {
+		next, err := substituteCompileInputsOnce(resolved, inputs)
+		if err != nil {
+			return "", err
+		}
+		if next == resolved {
+			return next, nil
+		}
+		resolved = next
+	}
+}
+
+func substituteCompileInputsOnce(template string, inputs map[string]any) (string, error) {
 	const open = "${{"
 	var substituted strings.Builder
 	remaining := template

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -1451,7 +1451,7 @@ func TestCompileInputLiteralRepresentations(t *testing.T) {
 }
 
 func TestSubstituteCompileInputsPreservesExpressionSyntax(t *testing.T) {
-	template := "${{ !inputs.enabled && matrix.run-new && 'inputs.enabled' || inputs.label }}"
+	template := "${{ !inputs.enabled && matrix.run-new && 'inputs.enabled' || inputs['label'] }}"
 	got, err := SubstituteCompileInputs(template, map[string]any{"enabled": false, "label": "it''s ready"})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -487,6 +487,27 @@ func TestTemplateUsesContextSupportsIndexedAccess(t *testing.T) {
 	}
 }
 
+func TestStaticContextReferencesExcludeRuntimeComputedAccess(t *testing.T) {
+	for _, source := range []string{"${{ inputs.enabled }}", "${{ inputs['enabled'] }}", "inputs.enabled"} {
+		var usesInputs bool
+		var err error
+		if strings.HasPrefix(source, "inputs") {
+			usesInputs, err = ConditionUsesStaticContextReference(source, "inputs")
+		} else {
+			usesInputs, err = TemplateUsesStaticContextReference(source, "inputs")
+		}
+		if err != nil || !usesInputs {
+			t.Fatalf("static context reference %q = %v, %v, want true", source, usesInputs, err)
+		}
+	}
+	for _, source := range []string{"${{ inputs[env.KEY] }}", "${{ inputs.* }}"} {
+		usesInputs, err := TemplateUsesStaticContextReference(source, "inputs")
+		if err != nil || usesInputs {
+			t.Fatalf("runtime context reference %q = %v, %v, want false", source, usesInputs, err)
+		}
+	}
+}
+
 func TestValidateConditionAllowsSupportedRuntimeExpressions(t *testing.T) {
 	for _, test := range []struct {
 		name   string

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -1483,6 +1483,16 @@ func TestSubstituteCompileInputsPreservesExpressionSyntax(t *testing.T) {
 	}
 }
 
+func TestSubstituteCompileInputsResolvesNestedComputedInputIndex(t *testing.T) {
+	got, err := SubstituteCompileInputs("${{ inputs[inputs.key] }}", map[string]any{"key": "target", "target": "release"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "${{ 'release' }}"; got != want {
+		t.Fatalf("SubstituteCompileInputs() = %q, want %q", got, want)
+	}
+}
+
 func TestSubstituteCompileInputsIgnoresNestedInputsProperties(t *testing.T) {
 	template := "${{ inputs.debug }} ${{ github.event.inputs.debug }} ${{ steps.inputs.name }} ${{ fromJSON(vars.CFG).inputs.name }}"
 	got, err := SubstituteCompileInputs(template, map[string]any{"debug": true, "name": "prod"})

--- a/internal/expression/references.go
+++ b/internal/expression/references.go
@@ -444,3 +444,43 @@ func TemplateUsesContext(source, contextName string) (bool, error) {
 	})
 	return found, err
 }
+
+// ConditionUsesStaticContextReference reports whether a condition contains a
+// direct or literal-index reference to a context. Computed indexes and
+// projections remain runtime expressions.
+func ConditionUsesStaticContextReference(source, contextName string) (bool, error) {
+	node, empty, err := parseCondition(source)
+	if err != nil || empty {
+		return false, err
+	}
+	return usesStaticContextReference(node, contextName), nil
+}
+
+// TemplateUsesStaticContextReference reports whether a template contains a
+// direct or literal-index reference to a context. Computed indexes and
+// projections remain runtime expressions.
+func TemplateUsesStaticContextReference(source, contextName string) (bool, error) {
+	found := false
+	err := visitTemplateExpressions(source, func(expression actionlint.ExprNode) error {
+		found = found || usesStaticContextReference(expression, contextName)
+		return nil
+	})
+	return found, err
+}
+
+func usesStaticContextReference(expression actionlint.ExprNode, contextName string) bool {
+	found := false
+	actionlint.VisitExprNode(expression, func(node, parent actionlint.ExprNode, entering bool) {
+		if !entering || found || referenceReceiver(node, parent) {
+			return
+		}
+		switch node.(type) {
+		case *actionlint.VariableNode, *actionlint.ObjectDerefNode, *actionlint.ArrayDerefNode, *actionlint.IndexAccessNode:
+		default:
+			return
+		}
+		root, _, err := referencePath(node)
+		found = err == nil && strings.EqualFold(root, contextName)
+	})
+	return found
+}

--- a/internal/runtime/containers.go
+++ b/internal/runtime/containers.go
@@ -84,6 +84,14 @@ func (r Runner) startJobContainer(ctx context.Context, processor *commandProcess
 }
 
 func (r Runner) startJobContainerOrdered(ctx context.Context, processor *commandProcessor, workspace, temp string, spec plan.Container, services map[string]plan.Container, serviceOrder []string, extra ...containerMount) (_ *jobContainerBackend, err error) {
+	if err := validateEnvironmentNames(spec.Env); err != nil {
+		return nil, fmt.Errorf("job container environment: %w", err)
+	}
+	for serviceID, service := range services {
+		if err := validateEnvironmentNames(service.Env); err != nil {
+			return nil, fmt.Errorf("service %q environment: %w", serviceID, err)
+		}
+	}
 	docker, config, env, err := privateDocker(r)
 	if err != nil {
 		return nil, err
@@ -628,6 +636,9 @@ func (b *jobContainerBackend) containerPath(path string) string {
 }
 
 func (b *jobContainerBackend) exec(ctx context.Context, r Runner, processor *commandProcessor, dir string, env map[string]string, name string, argv ...string) error {
+	if err := validateEnvironmentNames(env); err != nil {
+		return err
+	}
 	nonce, err := randomHex()
 	if err != nil {
 		return fmt.Errorf("create container exec identity: %w", err)

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -1679,6 +1679,27 @@ func TestContainerPathUsesLongestReadOnlyMount(t *testing.T) {
 	}
 }
 
+func TestJobContainerExecRejectsInvalidEnvironmentNamesBeforeDocker(t *testing.T) {
+	for _, name := range []string{"", "ALIAS=OTHER", "NUL\x00NAME"} {
+		t.Run(fmt.Sprintf("%q", name), func(t *testing.T) {
+			marker := filepath.Join(t.TempDir(), "docker-ran")
+			docker := filepath.Join(t.TempDir(), "docker")
+			writeFixtureFile(t, filepath.Dir(docker), filepath.Base(docker), "#!/bin/sh\ntouch "+shellTestQuote(marker)+"\n")
+			if err := os.Chmod(docker, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			backend := jobContainerBackend{docker: docker, container: "job", workspace: t.TempDir(), temp: t.TempDir()}
+			err := backend.exec(context.Background(), Runner{}, newCommandProcessor(io.Discard, io.Discard), backend.workspace, map[string]string{name: "value"}, "true")
+			if err == nil || !strings.Contains(err.Error(), "invalid environment variable name") {
+				t.Fatalf("exec() error = %v, want invalid environment name", err)
+			}
+			if _, statErr := os.Stat(marker); !errors.Is(statErr, os.ErrNotExist) {
+				t.Fatalf("Docker was invoked with invalid environment name: %v", statErr)
+			}
+		})
+	}
+}
+
 func TestRunJobContainerNodeProbeFailureCleansOwnedResources(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -233,9 +233,6 @@ func boundJobSummary(summary string, truncated bool) (string, bool) {
 // runDockerAction builds and executes an explicitly resolved local Docker
 // action, creating an isolated workspace when the caller supplies none.
 func (r Runner) runDockerAction(ctx context.Context, action dockerAction) (result Result, err error) {
-	if err := validateEnvironmentNames(action.Env); err != nil {
-		return newResult(), err
-	}
 	callerWorkspace := action.Workspace != ""
 	if !callerWorkspace {
 		action.Workspace, err = os.MkdirTemp("", "buildkite-gha-workspace-")
@@ -287,6 +284,9 @@ func (r Runner) runDockerAction(ctx context.Context, action dockerAction) (resul
 
 func (r Runner) runDocker(ctx context.Context, processor *commandProcessor, action dockerAction) (result Result, err error) {
 	result = newResult()
+	if err := validateEnvironmentNames(action.Env); err != nil {
+		return result, err
+	}
 	if action.runnerTemp == "" {
 		action.runnerTemp = r.runnerTemp
 	}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -233,6 +233,9 @@ func boundJobSummary(summary string, truncated bool) (string, bool) {
 // runDockerAction builds and executes an explicitly resolved local Docker
 // action, creating an isolated workspace when the caller supplies none.
 func (r Runner) runDockerAction(ctx context.Context, action dockerAction) (result Result, err error) {
+	if err := validateEnvironmentNames(action.Env); err != nil {
+		return newResult(), err
+	}
 	callerWorkspace := action.Workspace != ""
 	if !callerWorkspace {
 		action.Workspace, err = os.MkdirTemp("", "buildkite-gha-workspace-")
@@ -794,6 +797,9 @@ func (effects fileCommandEffects) reportSummaryUploadFailure(processor *commandP
 }
 
 func (r Runner) runStreaming(ctx context.Context, processor *commandProcessor, dir string, env map[string]string, name string, args ...string) error {
+	if err := validateEnvironmentNames(env); err != nil {
+		return err
+	}
 	cmd := exec.Command(name, args...)
 	cmd.Dir = dir
 	cmd.Env = processEnv(env)
@@ -1337,6 +1343,15 @@ func processEnv(overrides map[string]string) []string {
 	return mapEnv(values)
 }
 
+func validateEnvironmentNames(env map[string]string) error {
+	for name := range env {
+		if name == "" || strings.ContainsAny(name, "=\x00") {
+			return fmt.Errorf("invalid environment variable name %q", name)
+		}
+	}
+	return nil
+}
+
 func sortedKeys[V any](values map[string]V) []string {
 	keys := make([]string, 0, len(values))
 	for key := range values {
@@ -1641,12 +1656,27 @@ func (p *commandProcessor) addMaskLocked(value string) {
 	if value == "" {
 		return
 	}
-	p.masks = append(p.masks, value)
+	p.addMaskValueLocked(value)
 	for _, line := range strings.Split(strings.ReplaceAll(value, "\r\n", "\n"), "\n") {
 		if line != "" && line != value {
-			p.masks = append(p.masks, line)
+			p.addMaskValueLocked(line)
 		}
 	}
+	sort.Slice(p.masks, func(i, j int) bool {
+		if len(p.masks[i]) != len(p.masks[j]) {
+			return len(p.masks[i]) > len(p.masks[j])
+		}
+		return p.masks[i] < p.masks[j]
+	})
+}
+
+func (p *commandProcessor) addMaskValueLocked(value string) {
+	for _, mask := range p.masks {
+		if mask == value {
+			return
+		}
+	}
+	p.masks = append(p.masks, value)
 }
 
 func parseWorkflowCommand(line string) (parsedWorkflowCommand, bool) {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -3429,6 +3429,25 @@ func TestJobSummarySecretScrubbingIsOrderIndependent(t *testing.T) {
 	}
 }
 
+func TestLiveLogMaskingPrefersLongestMatchInEitherRegistrationOrder(t *testing.T) {
+	for _, masks := range [][]string{
+		{"credential", "credential-with-suffix\nsecond-line"},
+		{"credential-with-suffix\nsecond-line", "credential"},
+	} {
+		var logs bytes.Buffer
+		processor := newCommandProcessor(&logs, &logs)
+		for _, mask := range masks {
+			processor.addMask(mask)
+		}
+		processor.addMask("credential-with-suffix")
+
+		processor.writeLiteral(&logs, "credential-with-suffix second-line")
+		if got := logs.String(); got != "*** ***\n" {
+			t.Fatalf("masks %q produced logs %q, want longest overlapping masks without fragments", masks, got)
+		}
+	}
+}
+
 func TestExpressionEvaluationIsSinglePass(t *testing.T) {
 	literal := "literal ${{ matrix.secret }} and ${{"
 	values, err := evaluateMap(map[string]string{
@@ -3521,6 +3540,25 @@ printf '%s\n' environment-ok
 		if strings.HasPrefix(entry, "BUILDKITE_") {
 			t.Fatalf("processEnv() inherited agent variable %q", entry)
 		}
+	}
+}
+
+func TestRunStreamingRejectsInvalidEnvironmentNamesBeforeExecution(t *testing.T) {
+	for _, name := range []string{"", "ALIAS=OTHER", "NUL\x00NAME"} {
+		t.Run(fmt.Sprintf("%q", name), func(t *testing.T) {
+			marker := filepath.Join(t.TempDir(), "ran")
+			err := (Runner{}).runStreaming(context.Background(), newCommandProcessor(io.Discard, io.Discard), "", map[string]string{name: "value"}, "sh", "-c", `touch "$1"`, "sh", marker)
+			if err == nil || !strings.Contains(err.Error(), "invalid environment variable name") {
+				t.Fatalf("runStreaming() error = %v, want invalid environment name", err)
+			}
+			if _, statErr := os.Stat(marker); !errors.Is(statErr, os.ErrNotExist) {
+				t.Fatalf("host process ran with invalid environment name: %v", statErr)
+			}
+		})
+	}
+
+	if err := (Runner{}).runStreaming(context.Background(), newCommandProcessor(io.Discard, io.Discard), "", map[string]string{"GITHUB-ACTIONS_NAME.1": "valid"}, "true"); err != nil {
+		t.Fatalf("valid GitHub Actions environment name was rejected: %v", err)
 	}
 }
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -3562,6 +3562,28 @@ func TestRunStreamingRejectsInvalidEnvironmentNamesBeforeExecution(t *testing.T)
 	}
 }
 
+func TestRunDockerRejectsInvalidEnvironmentNamesBeforeDocker(t *testing.T) {
+	for _, name := range []string{"", "GITHUB_SHA=ALIAS", "NUL\x00NAME"} {
+		t.Run(fmt.Sprintf("%q", name), func(t *testing.T) {
+			marker := filepath.Join(t.TempDir(), "docker-ran")
+			docker := filepath.Join(t.TempDir(), "docker")
+			if err := os.WriteFile(docker, []byte("#!/bin/sh\ntouch "+shellTestQuote(marker)+"\n"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			action := fakeDockerAction(t)
+			action.runnerTemp = t.TempDir()
+			action.Env = map[string]string{name: "value"}
+			_, err := (Runner{Docker: docker}).runDocker(context.Background(), newCommandProcessor(io.Discard, io.Discard), action)
+			if err == nil || !strings.Contains(err.Error(), "invalid environment variable name") {
+				t.Fatalf("runDocker() error = %v, want invalid environment name", err)
+			}
+			if _, statErr := os.Stat(marker); !errors.Is(statErr, os.ErrNotExist) {
+				t.Fatalf("Docker was invoked with invalid environment name: %v", statErr)
+			}
+		})
+	}
+}
+
 func TestWorkflowCommandParsingIsCaseInsensitiveAndExact(t *testing.T) {
 	mask, ok := parseWorkflowCommand(" \t::ADD-MASK::secret%250Avalue")
 	if !ok || !strings.EqualFold(mask.name, "add-mask") || mask.message != "secret%0Avalue" {


### PR DESCRIPTION
## Why

A DeepSec scan found five reachable security and reliability gaps: overlapping masks could expose credential fragments, malformed environment names could alias protected values, invalid UTF-8 archive metadata could destabilize source-cache verification, annotation publication could outlive command cancellation, and bracket-form reusable inputs could bypass static substitution.

## What

- Apply deduplicated longest-match-first masking for live logs.
- Reject empty, `=`, and NUL environment names before host and Docker execution.
- Reject invalid UTF-8 archive names and symlink targets before extraction.
- Propagate command cancellation to annotation subprocesses and cap publication at five seconds.
- Resolve dot- and bracket-form compile-time inputs through the existing expression lexer, including nested references; preserve computed runtime indexes and reject unresolved static references.
