### PR TITLE
Support safe push path-filter admission

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ GitHub image or Xcode inventory.
 
 The imported workflows are a dynamic part of the Buildkite pipeline. The plugin creates one aggregate group per successfully compiled, explicitly listed workflow in a single transaction. Workflows that do not declare the selected event become top-level skipped steps. Groups and replacement steps depend on the importer. Each runnable job publishes a provider check named `<workflow> / <job> (<event>)`: a GitHub check for GitHub events or an Origin check for Origin events. This approach lets you keep existing workflows while moving jobs to native Buildkite steps over time.
 
-Buildkite owns build creation and schedule configuration. Within that build, `buildkite-gha` maps push, pull request, merge queue, manual/API, and scheduled builds to `push`, `pull_request`, `merge_group`, `workflow_dispatch`, and `schedule`, then applies the matching `on:` filters. Cross-event workflows are excluded before event-dependent compilation and retained as top-level skipped steps.
+Buildkite owns build creation and schedule configuration. Within that build, `buildkite-gha` maps push, pull request, merge queue, manual/API, and scheduled builds to `push`, `pull_request`, `merge_group`, `workflow_dispatch`, and `schedule`, then applies the matching `on:` branch, tag, base-branch, activity, and safely evidenced path filters. Cross-event workflows are excluded before event-dependent compilation and retained as top-level skipped steps.
 
 ## Check workflow compatibility
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -26,7 +26,7 @@ Validate syntax, the static graph, and every declared trigger without an event:
 buildkite-gha validate .github/workflows/ci.yml
 ```
 
-This event-independent check accepts syntactically valid pull-request path filters because linked-webhook admission can evaluate them with a verified local git diff. It rejects push path filters, malformed path filters, unsupported events, unsupported branch and tag filter combinations, and unsupported pull-request activity types. It does not resolve actions, evaluate event payload expressions, or claim hosted admission.
+This event-independent check accepts syntactically valid push and pull-request path filters because linked-webhook admission can evaluate them with a verified local git diff. It rejects malformed path filters, unsupported events, unsupported branch and tag filter combinations, and unsupported pull-request activity types. It does not resolve actions, evaluate event payload expressions, or claim hosted admission.
 
 Resolve actions and apply production policy:
 
@@ -57,7 +57,7 @@ buildkite-gha validate \
   .github/workflows/ci.yml
 ```
 
-`--all-events` is mutually exclusive with `--event` and `--event-path`. It does not evaluate `workflow_call` as a standalone event. Admission applies separately to each generated snapshot, not to every possible real payload. A `context-required` result means every available compilation and hosted-policy check passed, but a supported admission path needs evidence that generated snapshots do not contain. For example, pull-request path filters need linked webhook data and a verified local git diff.
+`--all-events` is mutually exclusive with `--event` and `--event-path`. It does not evaluate `workflow_call` as a standalone event. Admission applies separately to each generated snapshot, not to every possible real payload. A `context-required` result means every available compilation and hosted-policy check passed, but a supported admission path needs evidence that generated snapshots do not contain. For example, push and pull-request path filters need linked webhook data and a verified local git diff.
 
 Reuse downloaded immutable action source across profile validation runs:
 
@@ -243,9 +243,9 @@ Raw webhook data is not retained in generated plans or pipeline YAML and cannot 
 
 The selected snapshot establishes one effective GitHub event for applicability, compilation, group conditions, and event-qualified check names; group labels remain static across events. An explicit event path uses its event directly and never re-reads live Buildkite event fields. Linked webhook metadata supplies the GitHub event name, including `merge_group`; merge queue builds require matching Buildkite head and base refs and commits. Without either source, pull request builds map to `pull_request`; Buildkite `ui` and `api` sources map to `workflow_dispatch`; `schedule` maps to `schedule`; and other sources, including `trigger_job`, map to `push` even when `build.source_event` is absent.
 
-Top-level workflows that do not declare the effective event are excluded before event-dependent validation and compilation, then emitted as top-level skipped command steps with no plan artifacts. Reusable-only workflows remain available to local callers. If no directly runnable workflow applies, upload succeeds with a skipped-only pipeline. For applicable workflows, only the selected event contributes a group condition: push branch/tag filters, pull request base-branch/activity/path filters, merge group base-branch/activity filters, or the corresponding manual/schedule Buildkite source predicate. Cross-event trigger conditions are never ORed into that group.
+Top-level workflows that do not declare the effective event are excluded before event-dependent validation and compilation, then emitted as top-level skipped command steps with no plan artifacts. Reusable-only workflows remain available to local callers. If no directly runnable workflow applies, upload succeeds with a skipped-only pipeline. For applicable workflows, only the selected event contributes a group condition: push branch/tag/path filters, pull request base-branch/activity/path filters, merge group base-branch/activity filters, or the corresponding manual/schedule Buildkite source predicate. Cross-event trigger conditions are never ORed into that group.
 
-Unsupported or uncertain filters replace only the affected workflow with a failing top-level step. Pull request path filters run only when the linked webhook and local checkout prove a match; see [Pull request path filters](compatibility.md#pull-request-path-filters). Malformed event data still stops the import. Buildkite owns build creation and schedule identity, so every workflow with `on.schedule` is eligible for every Buildkite scheduled build.
+Unsupported or uncertain filters replace only the affected workflow with a failing top-level step. Push and pull request path filters run only when the linked webhook and local checkout prove a match; see [Push path filters](compatibility.md#push-path-filters) and [Pull request path filters](compatibility.md#pull-request-path-filters). Generated or explicit snapshots can report the dependency but cannot stand in for real linked-webhook admission. Malformed event data still stops the import. Buildkite owns build creation and schedule identity, so every workflow with `on.schedule` is eligible for every Buildkite scheduled build.
 
 After all applicable workflows have been attempted, the command uploads the exact executable, content-addressed plans, and synthetic failure steps before running one:
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -109,7 +109,7 @@ An explicit event snapshot never consults contradictory live Buildkite event fie
 
 | Event | Supported trigger behavior |
 | --- | --- |
-| `push` | `branches`, `branches-ignore`, `tags`, and `tags-ignore`, including ordered negative patterns in an include list. Branch and tag filters select their corresponding ref kind. |
+| `push` | `branches`, `branches-ignore`, `tags`, and `tags-ignore`, including ordered negative patterns in an include list. Branch and tag filters select their corresponding ref kind. Matching `paths` and `paths-ignore` can be admitted for linked GitHub branch pushes when the bounded local-diff requirements below are met. |
 | `pull_request` | `branches` and `branches-ignore` match the base branch. Omitted `types` defaults to `opened`, `synchronize`, and `reopened`; explicitly listed activity types must map exactly to a supported Buildkite source action. Matching `paths` and `paths-ignore` can be admitted when the bounded local-diff requirements below are met. |
 | `merge_group` | Native Buildkite merge queue builds only. Enable merge queue builds and Merge groups webhook delivery in the pipeline's GitHub settings. `branches` and `branches-ignore` match the target branch. The only supported activity is `checks_requested`; other types and path, tag, and workflow filters are rejected. The merge group ref and SHA identify the speculative queue commit. |
 | `workflow_dispatch` | Selected for Buildkite UI and API builds. Webhook-style branch, tag, type, and workflow filters are unsupported. |
@@ -117,6 +117,16 @@ An explicit event snapshot never consults contradictory live Buildkite event fie
 | `workflow_call` | Defines a local reusable-workflow interface. A reusable-only file is available to callers but does not become a top-level group. |
 
 Supported `pull_request` activity types are `assigned`, `unassigned`, `labeled`, `unlabeled`, `opened`, `edited`, `closed`, `reopened`, `synchronize`, `converted_to_draft`, `locked`, `unlocked`, `enqueued`, `dequeued`, `milestoned`, `demilestoned`, `ready_for_review`, `review_requested`, `review_request_removed`, `auto_merge_enabled`, and `auto_merge_disabled`.
+
+#### Push path filters
+
+For a linked GitHub branch push, the importer binds the webhook repository, ref, `before`, `after`, `created`, `deleted`, `forced`, and complete pushed-commit list to the Buildkite build and local checkout. It also requires `HEAD`, the local `origin` repository and remote branch, and the workflow file to match the pushed commit.
+
+Normal and force pushes use GitHub's two-dot `before..after` comparison. A new branch uses the parent of its oldest pushed commit when the complete webhook commit set forms one unambiguous, single-parent boundary. Matching added, modified, deleted, and type-changed paths are admitted. Path patterns use the same ordered matching described below.
+
+Admission fails closed for deleted refs, non-GitHub repositories, missing or shallow history, a stale or mismatched checkout, origin, remote branch, workflow, ref, repository, commit set, or force state, and ambiguous new-branch history. It also fails closed for more than 1,000 pushed commits, more than 300 changed files, combined additions and deletions, renames, malformed Git output, invalid patterns, and local non-matches. GitHub runs automatically after its 1,000-commit or diff-timeout fallback, but the importer does not manufacture that admission without matching changed-path evidence.
+
+Tag pushes do not evaluate path filters, matching GitHub. Explicit and generated event snapshots, and Buildkite environment fallbacks, cannot admit push path filters because they are not linked webhook evidence.
 
 #### Pull request path filters
 
@@ -139,9 +149,7 @@ Before upload, the importer compares the pull request merge base with its head u
 | At most 300 changed files from complete local history | Missing or shallow history, multiple merge bases, or more than 300 files |
 | A mergeable pull request with matching webhook and workflow data | A conflict, stale data, changed merge workflow, path or pattern containing a backslash, invalid pattern, or malformed Git output |
 
-A local non-match fails closed because GitHub does not report whether its diff timed out and ran the workflow anyway. Unfiltered `closed` workflows remain supported; filtered `closed` workflows fail closed when GitHub supplies an actual merge, squash, or rebase commit instead of a synthetic merge.
-
-Push path filters remain unsupported because GitHub uses a different diff range and timeout rules without exposing enough data to reproduce them safely. Tag pushes do not evaluate path filters, matching GitHub behavior. Other unsupported or inexact trigger filters also replace the affected workflow with a failing step rather than broadening when it runs.
+A local non-match fails closed because GitHub does not report whether its diff timed out and ran the workflow anyway. Unfiltered `closed` workflows remain supported; filtered `closed` workflows fail closed when GitHub supplies an actual merge, squash, or rebase commit instead of a synthetic merge. Other unsupported or inexact trigger filters replace the affected workflow with a failing step rather than broadening when it runs.
 
 A top-level workflow that does not declare the effective event is excluded before event-dependent validation or compilation and represented by one top-level skipped command step. A workflow that declares that event remains represented by a group even when a same-event branch, tag, base-branch, or action condition evaluates false in Buildkite. If no directly runnable workflow declares the event, upload succeeds with a skipped-only pipeline.
 
@@ -867,7 +875,7 @@ buildkite-gha validate \
 
 Use `--event push`, `--event pull_request`, `--event merge_group`, `--event workflow_dispatch`, or `--event schedule` instead of `--event-path` to evaluate the hosted profile with a generated minimal snapshot. Generated snapshots are compatibility test inputs, not equivalents to real payloads. The options are mutually exclusive.
 
-Use `--all-events` to evaluate every declared supported event separately. Its `processing-report/v3` output preserves the event-independent result and each generated event's v2 report. Aggregate admission means every generated snapshot was admitted; it does not cover other payload shapes. A `context-required` result means compilation and hosted-policy checks passed, but generated inputs cannot measure a supported admission path, such as pull-request path filters without linked webhook and local diff evidence. It does not claim admission.
+Use `--all-events` to evaluate every declared supported event separately. Its `processing-report/v3` output preserves the event-independent result and each generated event's v2 report. Aggregate admission means every generated snapshot was admitted; it does not cover other payload shapes. A `context-required` result means compilation and hosted-policy checks passed, but generated inputs cannot measure a supported admission path, such as push or pull-request path filters without linked webhook and local diff evidence. It does not claim admission.
 
 The results mean:
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -24,6 +24,8 @@ Workflow files, action metadata, event snapshots, and job plans are untrusted in
 
 Digests and immutable action locks detect changed code. They do not make code trusted or grant credentials.
 
+Push and pull request path-filter admission uses Buildkite's reserved linked-webhook metadata only after binding it to the Buildkite repository and commit and matching local Git history. Missing, shallow, ambiguous, oversized, or mismatched evidence fails closed. Explicit and generated snapshots cannot grant this admission. This check controls workflow selection; it does not make the selected workflow trusted.
+
 ## Credential boundaries
 
 | Credential | Current boundary |

--- a/internal/buildkite/triggers.go
+++ b/internal/buildkite/triggers.go
@@ -89,7 +89,7 @@ func ValidateTriggerConditions(triggers []workflow.Trigger) error {
 	for _, trigger := range triggers {
 		if _, _, err := translateTrigger(trigger, liveTriggerContext(trigger.Event), true); err != nil {
 			var pathFilters *UnsupportedPathFiltersError
-			if errors.As(err, &pathFilters) && pathFilters.Event == "pull_request" && pathFilters.Reason == "" {
+			if errors.As(err, &pathFilters) && (pathFilters.Event == "push" || pathFilters.Event == "pull_request") && pathFilters.Reason == "" {
 				continue
 			}
 			findings = append(findings, err)
@@ -307,8 +307,20 @@ func translateTrigger(t workflow.Trigger, context TriggerConditionContext, selec
 		} else if hasTagFilter {
 			parts = append(parts, context.Tag+" != null", tag)
 		}
-		if pathFilters && (!selected || context.TagValue == nil) {
-			return "", false, &UnsupportedPathFiltersError{Event: t.Event}
+		if pathFilters && selected && context.TagValue == nil {
+			if !context.ChangedPathsKnown {
+				return "", false, &UnsupportedPathFiltersError{Event: t.Event, Reason: context.ChangedPathsError}
+			}
+			matches, err := pathFiltersMatch(context.ChangedPaths, t.Paths, t.PathsIgnore)
+			if err != nil {
+				return "", false, fmt.Errorf("push paths: %w", err)
+			}
+			if !matches {
+				return "", false, &UnsupportedPathFiltersError{
+					Event:  t.Event,
+					Reason: "local changed paths do not match, and GitHub's diff-timeout outcome is unavailable",
+				}
+			}
 		}
 		return strings.Join(parts, " && "), true, nil
 	case "pull_request":

--- a/internal/buildkite/triggers.go
+++ b/internal/buildkite/triggers.go
@@ -308,6 +308,20 @@ func translateTrigger(t workflow.Trigger, context TriggerConditionContext, selec
 			parts = append(parts, context.Tag+" != null", tag)
 		}
 		if pathFilters && selected && context.TagValue == nil {
+			if context.BranchValue != nil {
+				branchMatches := true
+				if !hasBranchFilter && hasTagFilter {
+					branchMatches = false
+				} else if hasBranchFilter {
+					branchMatches, err = refFilterMatches(*context.BranchValue, t.Branches, t.BranchesIgnore)
+					if err != nil {
+						return "", false, fmt.Errorf("push branches: %w", err)
+					}
+				}
+				if !branchMatches {
+					return strings.Join(parts, " && "), true, nil
+				}
+			}
 			if !context.ChangedPathsKnown {
 				return "", false, &UnsupportedPathFiltersError{Event: t.Event, Reason: context.ChangedPathsError}
 			}

--- a/internal/buildkite/triggers_test.go
+++ b/internal/buildkite/triggers_test.go
@@ -1,7 +1,6 @@
 package buildkite
 
 import (
-	"errors"
 	"strings"
 	"testing"
 
@@ -85,21 +84,15 @@ func TestValidateTriggerConditionsAllowsReusableOnlyWorkflow(t *testing.T) {
 	}
 }
 
-func TestValidateTriggerConditionsAcceptsSupportedPullRequestPaths(t *testing.T) {
-	if err := ValidateTriggerConditions([]workflow.Trigger{{Event: "pull_request", Paths: []string{"src/**"}}}); err != nil {
-		t.Fatalf("ValidateTriggerConditions() pull request paths error = %v", err)
-	}
-
-	err := ValidateTriggerConditions([]workflow.Trigger{
+func TestValidateTriggerConditionsAcceptsSupportedPathFilters(t *testing.T) {
+	if err := ValidateTriggerConditions([]workflow.Trigger{
 		{Event: "pull_request", Paths: []string{"src/**"}},
 		{Event: "push", Paths: []string{"docs/**"}},
-	})
-	var unsupported *UnsupportedPathFiltersError
-	if !errors.As(err, &unsupported) || unsupported.Event != "push" {
-		t.Fatalf("ValidateTriggerConditions() unsupported error = %v", err)
+	}); err != nil {
+		t.Fatalf("ValidateTriggerConditions() path filters error = %v", err)
 	}
 
-	err = ValidateTriggerConditions([]workflow.Trigger{{Event: "pull_request", Paths: []string{"!src/**"}}})
+	err := ValidateTriggerConditions([]workflow.Trigger{{Event: "pull_request", Paths: []string{"!src/**"}}})
 	if err == nil || !strings.Contains(err.Error(), "must follow a positive pattern") {
 		t.Fatalf("ValidateTriggerConditions() invalid pull request path error = %v", err)
 	}
@@ -142,13 +135,13 @@ func TestTranslateEventTriggerConditionValidatesInactiveTriggers(t *testing.T) {
 	}
 }
 
-func TestTranslateEventTriggerConditionRejectsInactivePushPathFilters(t *testing.T) {
-	_, _, err := TranslateEventTriggerCondition([]workflow.Trigger{
+func TestTranslateEventTriggerConditionAllowsInactivePushPathFilters(t *testing.T) {
+	condition, applicable, err := TranslateEventTriggerCondition([]workflow.Trigger{
 		{Event: "push", Paths: []string{"src/**"}},
 		{Event: "pull_request"},
 	}, "pull_request", TriggerConditionContext{EventPredicate: "true", PullRequestAction: `"opened"`})
-	if err == nil || !strings.Contains(err.Error(), "path filters are unsupported") {
-		t.Fatalf("inactive push path filter error = %v", err)
+	if err != nil || !applicable || !strings.Contains(condition, `"opened"`) {
+		t.Fatalf("inactive push path filter condition/applicable/error = %q / %t / %v", condition, applicable, err)
 	}
 }
 
@@ -187,6 +180,38 @@ func TestTranslateEventTriggerConditionMatchesPullRequestPaths(t *testing.T) {
 	)
 	if err == nil || !strings.Contains(err.Error(), "diff-timeout outcome is unavailable") {
 		t.Fatalf("nonmatching local paths error = %v", err)
+	}
+}
+
+func TestTranslateEventTriggerConditionMatchesPushPaths(t *testing.T) {
+	branch := "main"
+	context := TriggerConditionContext{
+		EventPredicate:    "true",
+		Branch:            `"main"`,
+		Tag:               "null",
+		BranchValue:       &branch,
+		ChangedPaths:      []string{"docs/readme.md", "src/generated/api.go", "src/main.go"},
+		ChangedPathsKnown: true,
+	}
+	trigger := workflow.Trigger{Event: "push", Paths: []string{"src/**", "!src/generated/**"}}
+	condition, applicable, err := TranslateEventTriggerCondition([]workflow.Trigger{trigger}, "push", context)
+	if err != nil || !applicable || condition != "(true)" {
+		t.Fatalf("push condition/applicable/error = %q / %t / %v", condition, applicable, err)
+	}
+	context.ChangedPaths = []string{"docs/readme.md", "src/generated/api.go"}
+	if _, _, err := TranslateEventTriggerCondition([]workflow.Trigger{trigger}, "push", context); err == nil || !strings.Contains(err.Error(), "diff-timeout outcome is unavailable") {
+		t.Fatalf("nonmatching push paths error = %v", err)
+	}
+	context.ChangedPathsKnown = false
+	context.ChangedPathsError = "verified push diff unavailable"
+	if _, _, err := TranslateEventTriggerCondition([]workflow.Trigger{trigger}, "push", context); err == nil || !strings.Contains(err.Error(), "verified push diff unavailable") {
+		t.Fatalf("unknown push paths error = %v", err)
+	}
+
+	tag := "v1.0.0"
+	tagContext := TriggerConditionContext{EventPredicate: "true", Branch: "null", Tag: `"v1.0.0"`, TagValue: &tag}
+	if _, applicable, err := TranslateEventTriggerCondition([]workflow.Trigger{trigger}, "push", tagContext); err != nil || !applicable {
+		t.Fatalf("tag push path filter = %t, %v", applicable, err)
 	}
 }
 

--- a/internal/buildkite/triggers_test.go
+++ b/internal/buildkite/triggers_test.go
@@ -213,6 +213,13 @@ func TestTranslateEventTriggerConditionMatchesPushPaths(t *testing.T) {
 	if _, applicable, err := TranslateEventTriggerCondition([]workflow.Trigger{trigger}, "push", tagContext); err != nil || !applicable {
 		t.Fatalf("tag push path filter = %t, %v", applicable, err)
 	}
+
+	context.ChangedPathsKnown = false
+	context.ChangedPathsError = "verified push diff unavailable"
+	trigger.Branches = []string{"release"}
+	if condition, applicable, err := TranslateEventTriggerCondition([]workflow.Trigger{trigger}, "push", context); err != nil || !applicable || !strings.Contains(condition, `"main" =~ /^release$/`) {
+		t.Fatalf("branch-mismatched push path filter = %q, %t, %v", condition, applicable, err)
+	}
 }
 
 func TestPathFiltersMatchOrderedPatternsPerPath(t *testing.T) {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1373,7 +1373,7 @@ func validateOneSource(out processingOutput, workflowPath string, workflowSource
 		if parseErr == nil && eventErr == nil && !parsed.ReusableOnly() {
 			selection, triggerErr := selectWorkflowTrigger(parsed.Triggers, effectiveEvent)
 			if triggerErr != nil {
-				contextRequired = pullRequestPathContextRequired(triggerErr)
+				contextRequired = pathFilterContextRequired(triggerErr)
 				if contextRequired {
 					triggerErr = buildkitepipeline.ValidateTriggerConditions(parsed.Triggers)
 					contextRequired = triggerErr == nil
@@ -1452,7 +1452,7 @@ func validateOneSource(out processingOutput, workflowPath string, workflowSource
 			processingReport.Admission.Result = compatibility.NotEvaluated
 			processingReport.Diagnostics = append(processingReport.Diagnostics, compatibility.Diagnostic{
 				Level: "error", Code: compiler.CodeContextRequired, Category: "context", Stage: string(compiler.StageAdmission),
-				Message: "Pull request path filters require linked Buildkite webhook data and a verified local git diff before admission can be determined.",
+				Message: "Push and pull request path filters require linked Buildkite webhook data and a verified local git diff before admission can be determined.",
 			})
 			processingReport.Result = "context-required"
 			if out.write(processingReport) != nil {
@@ -2387,9 +2387,9 @@ func selectWorkflowTrigger(triggers []workflow.Trigger, event effectiveEventSele
 	}, nil
 }
 
-func pullRequestPathContextRequired(err error) bool {
+func pathFilterContextRequired(err error) bool {
 	var pathFilters *buildkitepipeline.UnsupportedPathFiltersError
-	return errors.As(err, &pathFilters) && pathFilters.Event == "pull_request" && pathFilters.Reason == ""
+	return errors.As(err, &pathFilters) && (pathFilters.Event == "push" || pathFilters.Event == "pull_request") && pathFilters.Reason == ""
 }
 
 func triggerConditionLiteral(value string) string {
@@ -2403,7 +2403,8 @@ func triggerFailureProcessingReport(input workflowInput, err error) compatibilit
 	if errors.As(err, &pathFilters) {
 		message := fmt.Sprintf("%s trigger path filters cannot be translated safely. Remove paths and paths-ignore from this trigger, or move the filtering into a job or step.", upperFirst(pathFilters.Event))
 		if pathFilters.Reason != "" {
-			message = fmt.Sprintf("%s trigger path filters could not be evaluated safely. Ensure the linked webhook and local checkout contain matching pull-request history, or remove the path filters.", upperFirst(pathFilters.Event))
+			history := strings.ReplaceAll(pathFilters.Event, "_", "-")
+			message = fmt.Sprintf("%s trigger path filters could not be evaluated safely. Ensure the linked webhook and local checkout contain matching %s history, or remove the path filters.", upperFirst(pathFilters.Event), history)
 		}
 		err = &compiler.ProcessingFinding{
 			Stage: compiler.StagePipeline, Code: compiler.CodePipelineGeneration, Category: "compatibility",

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1902,19 +1902,19 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 		if workflows[i].ReusableOnly {
 			continue
 		}
-		if workflows[i].PathFiltersError != "" {
-			workflows[i].Applicable = true
-			workflows[i].TriggerCondition = effectiveEvent.TriggerContext.EventPredicate
-			processingReports[i] = triggerFailureProcessingReport(workflows[i], &buildkitepipeline.UnsupportedPathFiltersError{
-				Event: effectiveEvent.Event.Event, Reason: workflows[i].PathFiltersError,
-			})
-			continue
-		}
 		selection, triggerErr := selectWorkflowTrigger(workflows[i].Triggers, effectiveEvent)
 		if triggerErr != nil {
 			workflows[i].Applicable = true
 			workflows[i].TriggerCondition = effectiveEvent.TriggerContext.EventPredicate
 			processingReports[i] = triggerFailureProcessingReport(workflows[i], triggerErr)
+			continue
+		}
+		if workflows[i].PathFiltersError != "" && selection.AnnotationReason == "" {
+			workflows[i].Applicable = true
+			workflows[i].TriggerCondition = effectiveEvent.TriggerContext.EventPredicate
+			processingReports[i] = triggerFailureProcessingReport(workflows[i], &buildkitepipeline.UnsupportedPathFiltersError{
+				Event: effectiveEvent.Event.Event, Reason: workflows[i].PathFiltersError,
+			})
 			continue
 		}
 		workflows[i].Applicable = selection.Applicable

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1213,7 +1213,7 @@ func TestRunValidateAndCompile(t *testing.T) {
 			name, trigger, want string
 		}{
 			{name: "unsupported event", trigger: "issues", want: `unsupported GitHub trigger event "issues"`},
-			{name: "path filter", trigger: "push:\n    paths: [src/**]", want: "path filters are unsupported"},
+			{name: "malformed path filter", trigger: "push:\n    paths: ['!src/**']", want: "must follow a positive pattern"},
 			{name: "mixed branch filters", trigger: "push:\n    branches: [main]\n    branches-ignore: [release]", want: "include and ignore filters cannot be combined"},
 			{name: "pull request tag filter", trigger: "pull_request:\n    tags: [v1]", want: "pull_request tag filters are unsupported"},
 			{name: "pull request activity", trigger: "pull_request:\n    types: [auto_merge_enabled, submitted]", want: `activity type "submitted" cannot be mapped exactly`},
@@ -1244,9 +1244,9 @@ func TestRunValidateAndCompile(t *testing.T) {
 		}
 	})
 
-	t.Run("bare validation accepts supported pull request paths", func(t *testing.T) {
+	t.Run("bare validation accepts supported path filters", func(t *testing.T) {
 		workflow := filepath.Join(t.TempDir(), "trigger.yml")
-		if err := os.WriteFile(workflow, []byte("on:\n  pull_request:\n    paths: [src/**]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
+		if err := os.WriteFile(workflow, []byte("on:\n  push:\n    paths: [docs/**]\n  pull_request:\n    paths: [src/**]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
 			t.Fatal(err)
 		}
 		var stdout, stderr bytes.Buffer
@@ -1373,9 +1373,9 @@ func TestRunValidateAndCompile(t *testing.T) {
 		}
 	})
 
-	t.Run("validate all events stops before admission on an unsafe trigger", func(t *testing.T) {
+	t.Run("validate all events stops before admission on a malformed trigger", func(t *testing.T) {
 		workflow := filepath.Join(t.TempDir(), "events.yml")
-		if err := os.WriteFile(workflow, []byte("on:\n  push:\n    paths: [src/**]\n  pull_request:\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
+		if err := os.WriteFile(workflow, []byte("on:\n  push:\n    paths: ['!src/**']\n  pull_request:\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
 			t.Fatal(err)
 		}
 		var stdout, stderr bytes.Buffer
@@ -1387,14 +1387,14 @@ func TestRunValidateAndCompile(t *testing.T) {
 		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 			t.Fatal(err)
 		}
-		if report.Result != "incompatible" || len(report.Evaluations) != 0 || len(report.Validation.Diagnostics) != 1 || !strings.Contains(report.Validation.Diagnostics[0].Message, "path filters are unsupported") {
+		if report.Result != "incompatible" || len(report.Evaluations) != 0 || len(report.Validation.Diagnostics) != 1 || !strings.Contains(report.Validation.Diagnostics[0].Message, "must follow a positive pattern") {
 			t.Fatalf("aggregate report = %#v", report)
 		}
 	})
 
-	t.Run("validate all events leaves supported pull request paths unmeasured", func(t *testing.T) {
+	t.Run("validate all events leaves supported paths unmeasured", func(t *testing.T) {
 		workflow := filepath.Join(t.TempDir(), "events.yml")
-		if err := os.WriteFile(workflow, []byte("on:\n  push:\n  pull_request:\n    paths: [src/**]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
+		if err := os.WriteFile(workflow, []byte("on:\n  push:\n    paths: [docs/**]\n  pull_request:\n    paths: [src/**]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
 			t.Fatal(err)
 		}
 		var stdout, stderr bytes.Buffer
@@ -1409,12 +1409,13 @@ func TestRunValidateAndCompile(t *testing.T) {
 		if report.Result != "context-required" || report.Validation.Result != "compilable" || len(report.Validation.Diagnostics) != 0 || len(report.Evaluations) != 2 {
 			t.Fatalf("aggregate report = %#v", report)
 		}
-		if report.Evaluations[0].Event != "push" || report.Evaluations[0].Report.Result != "admitted" || report.Evaluations[1].Event != "pull_request" || report.Evaluations[1].Report.Result != "context-required" {
+		if report.Evaluations[0].Event != "push" || report.Evaluations[0].Report.Result != "context-required" || report.Evaluations[1].Event != "pull_request" || report.Evaluations[1].Report.Result != "context-required" {
 			t.Fatalf("event evaluations = %#v", report.Evaluations)
 		}
-		pullRequest := report.Evaluations[1].Report
-		if pullRequest.Compile.Result != "compilable" || pullRequest.Admission.Result != compatibility.NotEvaluated || len(pullRequest.Diagnostics) != 1 || pullRequest.Diagnostics[0].Code != compiler.CodeContextRequired || !strings.Contains(pullRequest.Diagnostics[0].Message, "verified local git diff") {
-			t.Fatalf("pull request evaluation = %#v", pullRequest)
+		for _, evaluation := range report.Evaluations {
+			if evaluation.Report.Compile.Result != "compilable" || evaluation.Report.Admission.Result != compatibility.NotEvaluated || len(evaluation.Report.Diagnostics) != 1 || evaluation.Report.Diagnostics[0].Code != compiler.CodeContextRequired || !strings.Contains(evaluation.Report.Diagnostics[0].Message, "verified local git diff") {
+				t.Fatalf("%s evaluation = %#v", evaluation.Event, evaluation.Report)
+			}
 		}
 	})
 
@@ -1440,10 +1441,10 @@ func TestRunValidateAndCompile(t *testing.T) {
 		}
 	})
 
-	t.Run("validate generated pull request still finds unsupported triggers", func(t *testing.T) {
+	t.Run("validate generated pull request still finds malformed inactive triggers", func(t *testing.T) {
 		for _, triggers := range []string{
-			"  pull_request:\n    paths: [src/**]\n  push:\n    paths: [docs/**]\n",
-			"  push:\n    paths: [docs/**]\n  pull_request:\n    paths: [src/**]\n",
+			"  pull_request:\n    paths: [src/**]\n  push:\n    paths: ['!docs/**']\n",
+			"  push:\n    paths: ['!docs/**']\n  pull_request:\n    paths: [src/**]\n",
 		} {
 			workflow := filepath.Join(t.TempDir(), "events.yml")
 			if err := os.WriteFile(workflow, []byte("on:\n"+triggers+"jobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
@@ -1458,7 +1459,7 @@ func TestRunValidateAndCompile(t *testing.T) {
 			if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 				t.Fatal(err)
 			}
-			if report.Result != "incompatible" || len(report.Diagnostics) != 1 || report.Diagnostics[0].Code != compiler.CodePipelineGeneration || !strings.Contains(report.Diagnostics[0].Message, "Push trigger path filters cannot be translated safely") {
+			if report.Result != "incompatible" || len(report.Diagnostics) != 1 || report.Diagnostics[0].Code != compiler.CodePipelineGeneration || !strings.Contains(report.Diagnostics[0].Message+report.Diagnostics[0].Detail, "must follow a positive pattern") {
 				t.Fatalf("processing report = %#v", report)
 			}
 		}
@@ -1483,7 +1484,7 @@ func TestRunValidateAndCompile(t *testing.T) {
 		}
 	})
 
-	t.Run("validate all events keeps mixed push and pull request paths incompatible", func(t *testing.T) {
+	t.Run("validate all events keeps mixed push and pull request paths context required", func(t *testing.T) {
 		workflow := filepath.Join(t.TempDir(), "events.yml")
 		if err := os.WriteFile(workflow, []byte("on:\n  pull_request:\n    paths: [src/**]\n  push:\n    paths: [docs/**]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
 			t.Fatal(err)
@@ -1497,11 +1498,13 @@ func TestRunValidateAndCompile(t *testing.T) {
 		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 			t.Fatal(err)
 		}
-		if report.Result != "incompatible" || len(report.Evaluations) != 0 || len(report.Validation.Diagnostics) != 1 {
+		if report.Result != "context-required" || len(report.Evaluations) != 2 || len(report.Validation.Diagnostics) != 0 {
 			t.Fatalf("aggregate report = %#v", report)
 		}
-		if report.Validation.Diagnostics[0].Code != compiler.CodePipelineGeneration {
-			t.Fatalf("validation diagnostics = %#v", report.Validation.Diagnostics)
+		for _, evaluation := range report.Evaluations {
+			if evaluation.Report.Result != "context-required" {
+				t.Fatalf("evaluation = %#v", evaluation)
+			}
 		}
 	})
 
@@ -5113,9 +5116,9 @@ func TestRunUploadEmitsTriggerFailuresAsFailingSteps(t *testing.T) {
 	failure := pipeline.Steps[0]
 	message := failureArtifactForStep(failure.Plugins, runner.uploaded, "messages")
 	annotation := failureArtifactForStep(failure.Plugins, runner.uploaded, "annotations")
-	primary := "Push trigger path filters cannot be translated safely. Remove paths and paths-ignore from this trigger, or move the filtering into a job or step."
-	detail := "push path filters are unsupported: Buildkite if_changed is not equivalent"
-	if failure.Group != "" || failure.Label != ":github: Crowdin upload" || failure.Condition != "" || !isGeneratedFailureCommand(failure.Command) || !strings.Contains(string(message), primary) || !strings.Contains(string(message), "detail: "+detail) || !strings.Contains(string(annotation), "<strong>Push trigger path filters cannot be translated safely.</strong>") || !strings.Contains(string(annotation), "Remove paths and paths-ignore") || !strings.Contains(string(annotation), detail) || strings.Contains(string(message), "translate workflow triggers") || strings.Contains(string(message), ".github/workflows/crowdin-upload.yml") || !failure.Checkout.Skip || len(failure.Steps) != 0 {
+	primary := "Push trigger path filters could not be evaluated safely. Ensure the linked webhook and local checkout contain matching push history, or remove the path filters."
+	detail := "push path filters are unsupported: push path filters require linked Buildkite webhook data"
+	if failure.Group != "" || failure.Label != ":github: Crowdin upload" || failure.Condition != "" || !isGeneratedFailureCommand(failure.Command) || !strings.Contains(string(message), primary) || !strings.Contains(string(message), "detail: "+detail) || !strings.Contains(string(annotation), "<strong>Push trigger path filters could not be evaluated safely.</strong>") || !strings.Contains(string(annotation), "matching push history") || !strings.Contains(string(annotation), detail) || strings.Contains(string(message), "translate workflow triggers") || strings.Contains(string(message), ".github/workflows/crowdin-upload.yml") || !failure.Checkout.Skip || len(failure.Steps) != 0 {
 		t.Fatalf("trigger failure step = %#v, message = %q, annotation = %q", failure, message, annotation)
 	}
 	if success := pipeline.Steps[1]; success.Group != ":github: Success" || len(success.Steps) != 1 {

--- a/internal/cli/path_filters.go
+++ b/internal/cli/path_filters.go
@@ -3,10 +3,12 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -18,15 +20,36 @@ import (
 const (
 	maxLocallyEvaluatedPathFilterFiles = 300
 	maxGitChangedPathBytes             = 2 << 20
+	maxGitHubPushCommits               = 1000
+	zeroGitCommit                      = "0000000000000000000000000000000000000000"
 )
 
 func populateChangedPaths(context *buildkitepipeline.TriggerConditionContext, event compiler.Event, origin effectiveEventOrigin, workflows []workflowInput) {
-	if event.Event != "pull_request" {
+	if event.Event != "pull_request" && event.Event != "push" {
+		return
+	}
+	if event.Event == "push" && context.TagValue != nil {
 		return
 	}
 	if origin != effectiveEventFromWebhook {
 		if workflowsUsePathFilters(workflows, event.Event) {
-			context.ChangedPathsError = "pull request path filters require linked Buildkite webhook data"
+			context.ChangedPathsError = event.Event + " path filters require linked Buildkite webhook data"
+		}
+		return
+	}
+	if event.Event == "push" {
+		if !workflowsUsePathFilters(workflows, event.Event) {
+			return
+		}
+		paths, workflowErrors, err := pushChangedPaths(event, workflows)
+		if err != nil {
+			setPathFiltersError(context, workflows, event.Event, err.Error(), true)
+			return
+		}
+		context.ChangedPaths = paths
+		context.ChangedPathsKnown = true
+		for i := range workflows {
+			workflows[i].PathFiltersError = workflowErrors[workflows[i].CanonicalPath]
 		}
 		return
 	}
@@ -57,6 +80,219 @@ func populateChangedPaths(context *buildkitepipeline.TriggerConditionContext, ev
 		}
 		workflows[i].PathFiltersError = workflowErrors[workflows[i].CanonicalPath]
 	}
+}
+
+func pushChangedPaths(event compiler.Event, workflows []workflowInput) ([]string, map[string]string, error) {
+	if event.Provider != "github" {
+		return nil, nil, fmt.Errorf("push path filters require a GitHub repository webhook")
+	}
+	if nestedString(event.Payload, "repository", "full_name") != event.Repository.Owner+"/"+event.Repository.Name {
+		return nil, nil, fmt.Errorf("webhook push repository does not match the Buildkite build")
+	}
+	if nestedString(event.Payload, "ref") != event.Ref || !strings.HasPrefix(event.Ref, "refs/heads/") {
+		return nil, nil, fmt.Errorf("webhook push branch ref does not match the Buildkite build")
+	}
+	after, before := nestedString(event.Payload, "after"), nestedString(event.Payload, "before")
+	created, createdOK := event.Payload["created"].(bool)
+	deleted, deletedOK := event.Payload["deleted"].(bool)
+	forced, forcedOK := event.Payload["forced"].(bool)
+	if !createdOK || !deletedOK || !forcedOK {
+		return nil, nil, fmt.Errorf("webhook push requires boolean created, deleted, and forced fields")
+	}
+	if deleted || after == zeroGitCommit {
+		return nil, nil, fmt.Errorf("deleted-ref pushes cannot admit path-filtered workflows")
+	}
+	if !validBuildkiteCommit(after) || after != event.SHA {
+		return nil, nil, fmt.Errorf("webhook push after commit does not match the Buildkite build")
+	}
+	if created != (before == zeroGitCommit) || !created && !validBuildkiteCommit(before) {
+		return nil, nil, fmt.Errorf("webhook push before commit is inconsistent with ref creation")
+	}
+
+	rootBytes, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return nil, nil, fmt.Errorf("locate checked-out git repository: %w", err)
+	}
+	root := filepath.Clean(strings.TrimSpace(string(rootBytes)))
+	shallowBytes, err := gitCommand(root, "rev-parse", "--is-shallow-repository").Output()
+	if err != nil || strings.TrimSpace(string(shallowBytes)) != "false" {
+		return nil, nil, fmt.Errorf("push path filters require a complete non-shallow checkout")
+	}
+	remoteURLBytes, err := gitCommand(root, "remote", "get-url", "origin").Output()
+	if err != nil {
+		return nil, nil, fmt.Errorf("push path filters require the local origin repository")
+	}
+	provider, owner, name, _, err := parseBuildkiteRepository(strings.TrimSpace(string(remoteURLBytes)))
+	if err != nil || provider != event.Provider || owner != event.Repository.Owner || name != event.Repository.Name {
+		return nil, nil, fmt.Errorf("local origin repository does not match the Buildkite build")
+	}
+	branch := strings.TrimPrefix(event.Ref, "refs/heads/")
+	if err := gitCommand(root, "check-ref-format", "refs/heads/"+branch).Run(); err != nil {
+		return nil, nil, fmt.Errorf("webhook push branch is invalid")
+	}
+	for label, revision := range map[string]string{"checkout": "HEAD", "origin branch": "refs/remotes/origin/" + branch} {
+		value, err := gitCommand(root, "rev-parse", "--verify", revision+"^{commit}").Output()
+		if err != nil || strings.TrimSpace(string(value)) != after {
+			return nil, nil, fmt.Errorf("push after commit does not match the local %s", label)
+		}
+	}
+	if err := gitCommand(root, "cat-file", "-e", after+"^{commit}").Run(); err != nil {
+		return nil, nil, fmt.Errorf("push after commit is unavailable in the local checkout")
+	}
+
+	webhookCommits, err := pushWebhookCommits(event.Payload)
+	if err != nil {
+		return nil, nil, err
+	}
+	diffBase := before
+	if created {
+		if forced {
+			return nil, nil, fmt.Errorf("new-branch push cannot also be forced")
+		}
+		diffBase, err = newBranchPushDiffBase(root, after, webhookCommits)
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		if err := gitCommand(root, "cat-file", "-e", before+"^{commit}").Run(); err != nil {
+			return nil, nil, fmt.Errorf("push before commit is unavailable in the local checkout")
+		}
+		isAncestor, err := gitIsAncestor(root, before, after)
+		if err != nil {
+			return nil, nil, fmt.Errorf("verify push force state: %w", err)
+		}
+		if forced == isAncestor {
+			return nil, nil, fmt.Errorf("webhook push forced state does not match local commit history")
+		}
+		commitsBytes, err := gitCommand(root, "rev-list", "--max-count=1001", before+".."+after).Output()
+		if err != nil {
+			return nil, nil, fmt.Errorf("list pushed commits: %w", err)
+		}
+		localCommits := strings.Fields(string(commitsBytes))
+		if len(localCommits) > maxGitHubPushCommits {
+			return nil, nil, fmt.Errorf("push exceeds GitHub's %d-commit path-filter diff bound", maxGitHubPushCommits)
+		}
+		if !sameCommitSet(localCommits, webhookCommits) {
+			return nil, nil, fmt.Errorf("webhook pushed commits do not match local commit history")
+		}
+	}
+
+	workflowErrors := make(map[string]string)
+	for _, input := range workflows {
+		if !workflowUsesPathFilters(input, event.Event) {
+			continue
+		}
+		if !gitTracksWorkflow(root, input) {
+			workflowErrors[input.CanonicalPath] = fmt.Sprintf("workflow %q is not provider-backed and cannot use push path filters", input.CanonicalPath)
+			continue
+		}
+		committedSource, err := gitCommand(root, "cat-file", "blob", after+":"+input.CanonicalPath).Output()
+		if err != nil || !bytes.Equal(committedSource, input.Source) {
+			workflowErrors[input.CanonicalPath] = fmt.Sprintf("workflow %q does not match the pushed commit", input.CanonicalPath)
+		}
+	}
+
+	output, err := boundedCommandOutput(gitCommand(root, "diff", "--name-status", "-z", "--no-renames", "--no-ext-diff", "--no-textconv", diffBase, after), maxGitChangedPathBytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("list push changed paths: %w", err)
+	}
+	paths, err := parseChangedPaths(output)
+	if err != nil {
+		return nil, nil, err
+	}
+	return paths, workflowErrors, nil
+}
+
+func pushWebhookCommits(payload map[string]any) ([]string, error) {
+	values, ok := payload["commits"].([]any)
+	if !ok {
+		return nil, fmt.Errorf("webhook push requires its commits array")
+	}
+	if len(values) > maxGitHubPushCommits {
+		return nil, fmt.Errorf("push exceeds GitHub's %d-commit path-filter diff bound", maxGitHubPushCommits)
+	}
+	commits := make([]string, 0, len(values))
+	seen := make(map[string]bool, len(values))
+	for _, value := range values {
+		commit, ok := value.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("webhook push contains an invalid commit")
+		}
+		id, _ := commit["id"].(string)
+		if !validBuildkiteCommit(id) || seen[id] {
+			return nil, fmt.Errorf("webhook push contains an invalid or duplicate commit ID")
+		}
+		seen[id] = true
+		commits = append(commits, id)
+	}
+	return commits, nil
+}
+
+func newBranchPushDiffBase(root, after string, commits []string) (string, error) {
+	if len(commits) == 0 || !slices.Contains(commits, after) {
+		return "", fmt.Errorf("new-branch push requires complete pushed commit evidence")
+	}
+	pushed := make(map[string]bool, len(commits))
+	for _, commit := range commits {
+		pushed[commit] = true
+		if err := gitCommand(root, "cat-file", "-e", commit+"^{commit}").Run(); err != nil {
+			return "", fmt.Errorf("new-branch pushed commit is unavailable in the local checkout")
+		}
+		if err := gitCommand(root, "merge-base", "--is-ancestor", commit, after).Run(); err != nil {
+			return "", fmt.Errorf("new-branch pushed commit is not an ancestor of the after commit")
+		}
+	}
+	var rootCommit, parent string
+	for _, commit := range commits {
+		output, err := gitCommand(root, "rev-list", "--parents", "-n", "1", commit).Output()
+		fields := strings.Fields(string(output))
+		if err != nil || len(fields) == 0 || fields[0] != commit {
+			return "", fmt.Errorf("inspect new-branch pushed commit parents")
+		}
+		hasPushedParent := false
+		for _, candidate := range fields[1:] {
+			hasPushedParent = hasPushedParent || pushed[candidate]
+		}
+		if hasPushedParent {
+			continue
+		}
+		if rootCommit != "" || len(fields) != 2 {
+			return "", fmt.Errorf("new-branch push does not have one unambiguous diff ancestor")
+		}
+		rootCommit, parent = commit, fields[1]
+	}
+	if rootCommit == "" {
+		return "", fmt.Errorf("new-branch push does not have one unambiguous diff ancestor")
+	}
+	return parent, nil
+}
+
+func sameCommitSet(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	commits := make(map[string]bool, len(left))
+	for _, commit := range left {
+		commits[commit] = true
+	}
+	for _, commit := range right {
+		if !commits[commit] {
+			return false
+		}
+	}
+	return true
+}
+
+func gitIsAncestor(root, ancestor, descendant string) (bool, error) {
+	err := gitCommand(root, "merge-base", "--is-ancestor", ancestor, descendant).Run()
+	if err == nil {
+		return true, nil
+	}
+	var exitError *exec.ExitError
+	if errors.As(err, &exitError) && exitError.ExitCode() == 1 {
+		return false, nil
+	}
+	return false, err
 }
 
 func setPathFiltersError(context *buildkitepipeline.TriggerConditionContext, workflows []workflowInput, event, reason string, filteredOnly bool) {
@@ -346,7 +582,7 @@ func parseChangedPaths(output []byte) ([]string, error) {
 			return nil, fmt.Errorf("git returned unsupported changed-path status %q", status)
 		}
 		if len(paths) > maxLocallyEvaluatedPathFilterFiles {
-			return nil, fmt.Errorf("pull request changes exceed the importer's %d-file local evaluation bound", maxLocallyEvaluatedPathFilterFiles)
+			return nil, fmt.Errorf("changed paths exceed the importer's %d-file local evaluation bound", maxLocallyEvaluatedPathFilterFiles)
 		}
 	}
 	if added && deleted {

--- a/internal/cli/path_filters.go
+++ b/internal/cli/path_filters.go
@@ -208,11 +208,7 @@ func pushWebhookCommits(payload map[string]any) ([]string, error) {
 	if !ok {
 		return nil, fmt.Errorf("webhook push requires its commits array")
 	}
-	commitCount, countOK := exactNonNegativeInt(payload["size"])
-	if !countOK || commitCount != len(values) {
-		return nil, fmt.Errorf("webhook push does not contain its complete commit list")
-	}
-	if commitCount > maxGitHubPushCommits {
+	if len(values) > maxGitHubPushCommits {
 		return nil, fmt.Errorf("push exceeds GitHub's %d-commit path-filter diff bound", maxGitHubPushCommits)
 	}
 	commits := make([]string, 0, len(values))
@@ -230,28 +226,6 @@ func pushWebhookCommits(payload map[string]any) ([]string, error) {
 		commits = append(commits, id)
 	}
 	return commits, nil
-}
-
-func exactNonNegativeInt(value any) (int, bool) {
-	var result int
-	switch number := value.(type) {
-	case json.Number:
-		parsed, err := strconv.Atoi(number.String())
-		if err != nil {
-			return 0, false
-		}
-		result = parsed
-	case float64:
-		result = int(number)
-		if float64(result) != number {
-			return 0, false
-		}
-	case int:
-		result = number
-	default:
-		return 0, false
-	}
-	return result, result >= 0
 }
 
 func newBranchPushDiffBase(root, after string, commits []string) (string, error) {

--- a/internal/cli/path_filters.go
+++ b/internal/cli/path_filters.go
@@ -208,7 +208,11 @@ func pushWebhookCommits(payload map[string]any) ([]string, error) {
 	if !ok {
 		return nil, fmt.Errorf("webhook push requires its commits array")
 	}
-	if len(values) > maxGitHubPushCommits {
+	commitCount, countOK := exactNonNegativeInt(payload["size"])
+	if !countOK || commitCount != len(values) {
+		return nil, fmt.Errorf("webhook push does not contain its complete commit list")
+	}
+	if commitCount > maxGitHubPushCommits {
 		return nil, fmt.Errorf("push exceeds GitHub's %d-commit path-filter diff bound", maxGitHubPushCommits)
 	}
 	commits := make([]string, 0, len(values))
@@ -226,6 +230,28 @@ func pushWebhookCommits(payload map[string]any) ([]string, error) {
 		commits = append(commits, id)
 	}
 	return commits, nil
+}
+
+func exactNonNegativeInt(value any) (int, bool) {
+	var result int
+	switch number := value.(type) {
+	case json.Number:
+		parsed, err := strconv.Atoi(number.String())
+		if err != nil {
+			return 0, false
+		}
+		result = parsed
+	case float64:
+		result = int(number)
+		if float64(result) != number {
+			return 0, false
+		}
+	case int:
+		result = number
+	default:
+		return 0, false
+	}
+	return result, result >= 0
 }
 
 func newBranchPushDiffBase(root, after string, commits []string) (string, error) {
@@ -263,6 +289,17 @@ func newBranchPushDiffBase(root, after string, commits []string) (string, error)
 	}
 	if rootCommit == "" {
 		return "", fmt.Errorf("new-branch push does not have one unambiguous diff ancestor")
+	}
+	commitsBytes, err := gitCommand(root, "rev-list", "--max-count=1001", parent+".."+after).Output()
+	if err != nil {
+		return "", fmt.Errorf("list new-branch pushed commits: %w", err)
+	}
+	localCommits := strings.Fields(string(commitsBytes))
+	if len(localCommits) > maxGitHubPushCommits {
+		return "", fmt.Errorf("push exceeds GitHub's %d-commit path-filter diff bound", maxGitHubPushCommits)
+	}
+	if !sameCommitSet(localCommits, commits) {
+		return "", fmt.Errorf("webhook pushed commits do not match local new-branch history")
 	}
 	return parent, nil
 }

--- a/internal/cli/path_filters_test.go
+++ b/internal/cli/path_filters_test.go
@@ -77,7 +77,7 @@ func TestPushChangedPathsBindsWebhookAndLocalDiff(t *testing.T) {
 			Repository: compiler.Repository{Owner: "buildkite", Name: "buildkite-gha"},
 			Payload: map[string]any{
 				"ref": "refs/heads/main", "before": before, "after": after,
-				"created": created, "deleted": false, "forced": forced, "commits": commitValues, "size": len(commitValues),
+				"created": created, "deleted": false, "forced": forced, "commits": commitValues,
 				"repository": map[string]any{"full_name": "buildkite/buildkite-gha"},
 			},
 		}
@@ -132,14 +132,8 @@ func TestPushChangedPathsBindsWebhookAndLocalDiff(t *testing.T) {
 	}
 	newBranchEvent.Payload["deleted"] = false
 	newBranchEvent.Payload["commits"] = []any{map[string]any{"id": first}}
-	newBranchEvent.Payload["size"] = 1
 	if _, _, err := pushChangedPaths(newBranchEvent, []workflowInput{input}); err == nil || !strings.Contains(err.Error(), "complete pushed commit evidence") {
 		t.Fatalf("incomplete new-branch commits error = %v", err)
-	}
-	newBranchEvent.Payload["commits"] = []any{map[string]any{"id": newAfter}}
-	newBranchEvent.Payload["size"] = 2
-	if _, _, err := pushChangedPaths(newBranchEvent, []workflowInput{input}); err == nil || !strings.Contains(err.Error(), "complete commit list") {
-		t.Fatalf("omitted new-branch commit error = %v", err)
 	}
 	newBranchEvent.Payload["commits"] = []any{map[string]any{"id": first}, map[string]any{"id": newAfter}}
 	input.Source = []byte("modified worktree workflow\n")
@@ -156,7 +150,7 @@ func TestPushChangedPathsBindsWebhookAndLocalDiff(t *testing.T) {
 
 func TestPushWebhookCommitsEnforcesGitHubBound(t *testing.T) {
 	commits := make([]any, maxGitHubPushCommits+1)
-	if _, err := pushWebhookCommits(map[string]any{"commits": commits, "size": len(commits)}); err == nil || !strings.Contains(err.Error(), "1000-commit") {
+	if _, err := pushWebhookCommits(map[string]any{"commits": commits}); err == nil || !strings.Contains(err.Error(), "1000-commit") {
 		t.Fatalf("push commit bound error = %v", err)
 	}
 }

--- a/internal/cli/path_filters_test.go
+++ b/internal/cli/path_filters_test.go
@@ -77,7 +77,7 @@ func TestPushChangedPathsBindsWebhookAndLocalDiff(t *testing.T) {
 			Repository: compiler.Repository{Owner: "buildkite", Name: "buildkite-gha"},
 			Payload: map[string]any{
 				"ref": "refs/heads/main", "before": before, "after": after,
-				"created": created, "deleted": false, "forced": forced, "commits": commitValues,
+				"created": created, "deleted": false, "forced": forced, "commits": commitValues, "size": len(commitValues),
 				"repository": map[string]any{"full_name": "buildkite/buildkite-gha"},
 			},
 		}
@@ -132,8 +132,14 @@ func TestPushChangedPathsBindsWebhookAndLocalDiff(t *testing.T) {
 	}
 	newBranchEvent.Payload["deleted"] = false
 	newBranchEvent.Payload["commits"] = []any{map[string]any{"id": first}}
+	newBranchEvent.Payload["size"] = 1
 	if _, _, err := pushChangedPaths(newBranchEvent, []workflowInput{input}); err == nil || !strings.Contains(err.Error(), "complete pushed commit evidence") {
 		t.Fatalf("incomplete new-branch commits error = %v", err)
+	}
+	newBranchEvent.Payload["commits"] = []any{map[string]any{"id": newAfter}}
+	newBranchEvent.Payload["size"] = 2
+	if _, _, err := pushChangedPaths(newBranchEvent, []workflowInput{input}); err == nil || !strings.Contains(err.Error(), "complete commit list") {
+		t.Fatalf("omitted new-branch commit error = %v", err)
 	}
 	newBranchEvent.Payload["commits"] = []any{map[string]any{"id": first}, map[string]any{"id": newAfter}}
 	input.Source = []byte("modified worktree workflow\n")
@@ -150,7 +156,7 @@ func TestPushChangedPathsBindsWebhookAndLocalDiff(t *testing.T) {
 
 func TestPushWebhookCommitsEnforcesGitHubBound(t *testing.T) {
 	commits := make([]any, maxGitHubPushCommits+1)
-	if _, err := pushWebhookCommits(map[string]any{"commits": commits}); err == nil || !strings.Contains(err.Error(), "1000-commit") {
+	if _, err := pushWebhookCommits(map[string]any{"commits": commits, "size": len(commits)}); err == nil || !strings.Contains(err.Error(), "1000-commit") {
 		t.Fatalf("push commit bound error = %v", err)
 	}
 }

--- a/internal/cli/path_filters_test.go
+++ b/internal/cli/path_filters_test.go
@@ -15,6 +15,146 @@ import (
 	"github.com/buildkite/buildkite-gha/internal/workflow"
 )
 
+func TestPushChangedPathsBindsWebhookAndLocalDiff(t *testing.T) {
+	workflowSource := []byte("name: CI\non:\n  push:\n    paths: [\"src/**\"]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n")
+	repository := t.TempDir()
+	runGit := func(args ...string) string {
+		t.Helper()
+		command := exec.Command("git", append([]string{"-C", repository}, args...)...)
+		output, err := command.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, output)
+		}
+		return strings.TrimSpace(string(output))
+	}
+	runGit("init", "-q")
+	runGit("config", "user.email", "test@example.com")
+	runGit("config", "user.name", "Test")
+	runGit("remote", "add", "origin", "https://github.com/buildkite/buildkite-gha.git")
+	for path, source := range map[string][]byte{
+		"ci.yml": workflowSource, "src/main.go": []byte("package main\n"),
+		"docs/old.md": []byte("old\n"), "src/tool": []byte("regular\n"),
+	} {
+		if err := os.MkdirAll(filepath.Dir(filepath.Join(repository, path)), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(repository, path), source, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	runGit("add", ".")
+	runGit("commit", "-qm", "base")
+	base := runGit("rev-parse", "HEAD")
+	if err := os.WriteFile(filepath.Join(repository, "src/main.go"), []byte("package main\n// changed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(repository, "docs/old.md")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(repository, "src/tool")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("main.go", filepath.Join(repository, "src/tool")); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", "-A")
+	runGit("commit", "-qm", "normal push")
+	after := runGit("rev-parse", "HEAD")
+	runGit("update-ref", "refs/remotes/origin/main", after)
+	t.Chdir(repository)
+
+	input := workflowInput{
+		Path: filepath.Join(repository, "ci.yml"), CanonicalPath: "ci.yml", Source: workflowSource,
+		Triggers: []workflow.Trigger{{Event: "push", Paths: []string{"src/**"}}},
+	}
+	newEvent := func(before, after string, created, forced bool, commits ...string) compiler.Event {
+		commitValues := make([]any, len(commits))
+		for i, commit := range commits {
+			commitValues[i] = map[string]any{"id": commit}
+		}
+		return compiler.Event{
+			Provider: "github", Event: "push", SHA: after, Ref: "refs/heads/main",
+			Repository: compiler.Repository{Owner: "buildkite", Name: "buildkite-gha"},
+			Payload: map[string]any{
+				"ref": "refs/heads/main", "before": before, "after": after,
+				"created": created, "deleted": false, "forced": forced, "commits": commitValues,
+				"repository": map[string]any{"full_name": "buildkite/buildkite-gha"},
+			},
+		}
+	}
+	event := newEvent(base, after, false, false, after)
+	paths, workflowErrors, err := pushChangedPaths(event, []workflowInput{input})
+	want := []string{"docs/old.md", "src/main.go", "src/tool"}
+	if err != nil || !reflect.DeepEqual(paths, want) || len(workflowErrors) != 0 {
+		t.Fatalf("normal push paths/errors = %#v / %#v / %v, want %#v", paths, workflowErrors, err, want)
+	}
+
+	runGit("checkout", "-q", "-B", "force", base)
+	if err := os.WriteFile(filepath.Join(repository, "src/main.go"), []byte("package forced\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", "src/main.go")
+	runGit("commit", "-qm", "force push")
+	forceAfter := runGit("rev-parse", "HEAD")
+	runGit("update-ref", "refs/remotes/origin/main", forceAfter)
+	forceEvent := newEvent(after, forceAfter, false, true, forceAfter)
+	if paths, _, err := pushChangedPaths(forceEvent, []workflowInput{input}); err != nil || !reflect.DeepEqual(paths, want) {
+		t.Fatalf("force push paths = %#v, %v", paths, err)
+	}
+
+	runGit("checkout", "-q", "-B", "new", base)
+	if err := os.WriteFile(filepath.Join(repository, "src/main.go"), []byte("package first\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", "src/main.go")
+	runGit("commit", "-qm", "first new-branch commit")
+	first := runGit("rev-parse", "HEAD")
+	if err := os.WriteFile(filepath.Join(repository, "src/main.go"), []byte("package second\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", "src/main.go")
+	runGit("commit", "-qm", "second new-branch commit")
+	newAfter := runGit("rev-parse", "HEAD")
+	runGit("update-ref", "refs/remotes/origin/main", newAfter)
+	newBranchEvent := newEvent(zeroGitCommit, newAfter, true, false, first, newAfter)
+	if paths, _, err := pushChangedPaths(newBranchEvent, []workflowInput{input}); err != nil || !reflect.DeepEqual(paths, []string{"src/main.go"}) {
+		t.Fatalf("new-branch push paths = %#v, %v", paths, err)
+	}
+
+	newBranchEvent.Payload["repository"].(map[string]any)["full_name"] = "attacker/other"
+	if _, _, err := pushChangedPaths(newBranchEvent, []workflowInput{input}); err == nil || !strings.Contains(err.Error(), "repository does not match") {
+		t.Fatalf("mismatched repository error = %v", err)
+	}
+	newBranchEvent.Payload["repository"].(map[string]any)["full_name"] = "buildkite/buildkite-gha"
+	newBranchEvent.Payload["deleted"] = true
+	if _, _, err := pushChangedPaths(newBranchEvent, []workflowInput{input}); err == nil || !strings.Contains(err.Error(), "deleted-ref") {
+		t.Fatalf("deleted ref error = %v", err)
+	}
+	newBranchEvent.Payload["deleted"] = false
+	newBranchEvent.Payload["commits"] = []any{map[string]any{"id": first}}
+	if _, _, err := pushChangedPaths(newBranchEvent, []workflowInput{input}); err == nil || !strings.Contains(err.Error(), "complete pushed commit evidence") {
+		t.Fatalf("incomplete new-branch commits error = %v", err)
+	}
+	newBranchEvent.Payload["commits"] = []any{map[string]any{"id": first}, map[string]any{"id": newAfter}}
+	input.Source = []byte("modified worktree workflow\n")
+	if _, workflowErrors, err := pushChangedPaths(newBranchEvent, []workflowInput{input}); err != nil || !strings.Contains(workflowErrors["ci.yml"], "does not match the pushed commit") {
+		t.Fatalf("mismatched workflow result = %#v, %v", workflowErrors, err)
+	}
+	if err := os.WriteFile(filepath.Join(repository, ".git", "shallow"), []byte(base+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := pushChangedPaths(newBranchEvent, []workflowInput{input}); err == nil || !strings.Contains(err.Error(), "non-shallow checkout") {
+		t.Fatalf("shallow checkout error = %v", err)
+	}
+}
+
+func TestPushWebhookCommitsEnforcesGitHubBound(t *testing.T) {
+	commits := make([]any, maxGitHubPushCommits+1)
+	if _, err := pushWebhookCommits(map[string]any{"commits": commits}); err == nil || !strings.Contains(err.Error(), "1000-commit") {
+		t.Fatalf("push commit bound error = %v", err)
+	}
+}
+
 func TestPullRequestChangedPathsUsesPayloadCommits(t *testing.T) {
 	filteredWorkflow := []byte("name: CI\non:\n  pull_request:\n    paths: [\"src/**\"]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n")
 	repository := t.TempDir()
@@ -296,11 +436,15 @@ func TestBoundedCommandOutput(t *testing.T) {
 }
 
 func TestPopulateChangedPathsRequiresLinkedWebhook(t *testing.T) {
-	context := buildkitepipeline.TriggerConditionContext{}
-	populateChangedPaths(&context, compiler.Event{Event: "pull_request"}, effectiveEventFromPath, []workflowInput{{
-		Triggers: []workflow.Trigger{{Event: "pull_request", Paths: []string{"src/**"}}},
-	}})
-	if context.ChangedPathsKnown || !strings.Contains(context.ChangedPathsError, "linked Buildkite webhook") {
-		t.Fatalf("changed-path context = %#v", context)
+	for _, event := range []string{"push", "pull_request"} {
+		t.Run(event, func(t *testing.T) {
+			context := buildkitepipeline.TriggerConditionContext{}
+			populateChangedPaths(&context, compiler.Event{Event: event}, effectiveEventFromPath, []workflowInput{{
+				Triggers: []workflow.Trigger{{Event: event, Paths: []string{"src/**"}}},
+			}})
+			if context.ChangedPathsKnown || !strings.Contains(context.ChangedPathsError, event+" path filters require linked Buildkite webhook") {
+				t.Fatalf("changed-path context = %#v", context)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Why

The deterministic compatibility benchmark found 804 workflows blocked by push path filters. Translating them to Buildkite `if_changed` would change GitHub's ordered path-pattern and diff semantics, while generated snapshots do not contain enough evidence to admit them safely.

## What

Admit matching `push.paths` and `push.paths-ignore` workflows only for linked GitHub branch webhooks whose repository, ref, before/after commits, create/force state, pushed commit set, workflow source, local origin, remote branch, and complete checkout agree. Existing and force pushes use GitHub's two-dot comparison; unambiguous new branches compare the parent of the oldest pushed commit with the new head. The existing GitHub path matcher retains ordered negation and re-inclusion semantics.

Tag pushes continue to ignore path filters. Static validation accepts valid push path filters, while generated or explicit hosted snapshots report `context-required` after completing available compilation and policy checks. They cannot grant admission. Missing, shallow, mismatched, ambiguous, oversized, or non-matching production evidence fails closed rather than falling back to `if_changed` or GitHub's unobservable timeout admission.