### PR TITLE
Support merge group trigger events

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ GitHub image or Xcode inventory.
 
 The imported workflows are a dynamic part of the Buildkite pipeline. The plugin creates one aggregate group per successfully compiled, explicitly listed workflow in a single transaction. Workflows that do not declare the selected event become top-level skipped steps. Groups and replacement steps depend on the importer. Each runnable job publishes a provider check named `<workflow> / <job> (<event>)`: a GitHub check for GitHub events or an Origin check for Origin events. This approach lets you keep existing workflows while moving jobs to native Buildkite steps over time.
 
-Buildkite owns build creation and schedule configuration. Within that build, `buildkite-gha` maps push, pull request, manual/API, and scheduled builds to `push`, `pull_request`, `workflow_dispatch`, and `schedule`, then applies the matching `on:` branch, tag, base-branch, and pull request activity filters. Cross-event workflows are excluded before event-dependent compilation and retained as top-level skipped steps.
+Buildkite owns build creation and schedule configuration. Within that build, `buildkite-gha` maps push, pull request, merge queue, manual/API, and scheduled builds to `push`, `pull_request`, `merge_group`, `workflow_dispatch`, and `schedule`, then applies the matching `on:` filters. Cross-event workflows are excluded before event-dependent compilation and retained as top-level skipped steps.
 
 ## Check workflow compatibility
 
@@ -126,7 +126,7 @@ buildkite-gha validate \
   .github/workflows/ci.yml
 ```
 
-`--event` also supports `pull_request`, `workflow_dispatch`, and `schedule`. The generated minimal snapshot is not equivalent to a real payload; use `--event-path` when exact payload data matters.
+`--event` also supports `pull_request`, `merge_group`, `workflow_dispatch`, and `schedule`. The generated minimal snapshot is not equivalent to a real payload; use `--event-path` when exact payload data matters.
 
 Use `--all-events` to evaluate every declared supported event separately:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -46,9 +46,9 @@ buildkite-gha validate \
   .github/workflows/ci.yml
 ```
 
-`--event` supports `push`, `pull_request`, `workflow_dispatch`, and `schedule`. It is available only with `--profile hosted` and is mutually exclusive with `--event-path`. The generated snapshot uses example repository identity and minimal event fields. It can expose payload-dependent incompatibilities, but it is not equivalent to a real payload and cannot prove behavior for every payload shape. Use `--event-path` when exact refs, activity, repository identity, or payload fields matter.
+`--event` supports `push`, `pull_request`, `merge_group`, `workflow_dispatch`, and `schedule`. It is available only with `--profile hosted` and is mutually exclusive with `--event-path`. The generated snapshot uses example repository identity and minimal event fields. It can expose payload-dependent incompatibilities, but it is not equivalent to a real payload and cannot prove behavior for every payload shape. Use `--event-path` when exact refs, activity, repository identity, or payload fields matter.
 
-Use `--all-events` with `--profile hosted` to evaluate every declared `push`, `pull_request`, `workflow_dispatch`, and `schedule` trigger with a separate generated snapshot:
+Use `--all-events` with `--profile hosted` to evaluate every declared `push`, `pull_request`, `merge_group`, `workflow_dispatch`, and `schedule` trigger with a separate generated snapshot:
 
 ```sh
 buildkite-gha validate \
@@ -241,9 +241,9 @@ An explicit event path never reads Buildkite metadata. Webhook metadata must be 
 
 Raw webhook data is not retained in generated plans or pipeline YAML and cannot grant queues, secrets, or tokens.
 
-The selected snapshot establishes one effective GitHub event for applicability, compilation, group conditions, and event-qualified check names; group labels remain static across events. An explicit event path uses its event directly and never re-reads live Buildkite event fields. Linked webhook metadata supplies the GitHub event name. Without either source, pull request builds map to `pull_request`; Buildkite `ui` and `api` sources map to `workflow_dispatch`; `schedule` maps to `schedule`; and other sources, including `trigger_job`, map to `push` even when `build.source_event` is absent.
+The selected snapshot establishes one effective GitHub event for applicability, compilation, group conditions, and event-qualified check names; group labels remain static across events. An explicit event path uses its event directly and never re-reads live Buildkite event fields. Linked webhook metadata supplies the GitHub event name, including `merge_group`; merge queue builds require matching Buildkite head and base refs and commits. Without either source, pull request builds map to `pull_request`; Buildkite `ui` and `api` sources map to `workflow_dispatch`; `schedule` maps to `schedule`; and other sources, including `trigger_job`, map to `push` even when `build.source_event` is absent.
 
-Top-level workflows that do not declare the effective event are excluded before event-dependent validation and compilation, then emitted as top-level skipped command steps with no plan artifacts. Reusable-only workflows remain available to local callers. If no directly runnable workflow applies, upload succeeds with a skipped-only pipeline. For applicable workflows, only the selected event contributes a group condition: push branch/tag filters, pull request base-branch/activity/path filters, or the corresponding manual/schedule Buildkite source predicate. Cross-event trigger conditions are never ORed into that group.
+Top-level workflows that do not declare the effective event are excluded before event-dependent validation and compilation, then emitted as top-level skipped command steps with no plan artifacts. Reusable-only workflows remain available to local callers. If no directly runnable workflow applies, upload succeeds with a skipped-only pipeline. For applicable workflows, only the selected event contributes a group condition: push branch/tag filters, pull request base-branch/activity/path filters, merge group base-branch/activity filters, or the corresponding manual/schedule Buildkite source predicate. Cross-event trigger conditions are never ORed into that group.
 
 Unsupported or uncertain filters replace only the affected workflow with a failing top-level step. Pull request path filters run only when the linked webhook and local checkout prove a match; see [Pull request path filters](compatibility.md#pull-request-path-filters). Malformed event data still stops the import. Buildkite owns build creation and schedule identity, so every workflow with `on.schedule` is eligible for every Buildkite scheduled build.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -102,12 +102,13 @@ Upload selects one authoritative effective event, in this order:
 1. The GitHub event name accompanying Buildkite's reserved linked-webhook metadata.
 1. A Buildkite environment fallback: pull request builds use `pull_request`; `ui` and `api` use `workflow_dispatch`; `schedule` uses `schedule`; and every other source, including `trigger_job`, uses `push`.
 
-An explicit event snapshot never consults contradictory live Buildkite event fields. The fallback can classify `trigger_job` as `push` even when `build.source_event` is absent. The selected snapshot is then used consistently for applicability, event-dependent validation and compilation, the group condition, and the event suffix in its provider check.
+An explicit event snapshot never consults contradictory live Buildkite event fields. Linked `merge_group` webhooks must match the Buildkite merge queue head and base refs and commits. The fallback cannot infer a merge group without linked webhook data and can classify `trigger_job` as `push` even when `build.source_event` is absent. The selected snapshot is then used consistently for applicability, event-dependent validation and compilation, the group condition, and the event suffix in its provider check.
 
 | Event | Supported trigger behavior |
 | --- | --- |
 | `push` | `branches`, `branches-ignore`, `tags`, and `tags-ignore`, including ordered negative patterns in an include list. Branch and tag filters select their corresponding ref kind. |
 | `pull_request` | `branches` and `branches-ignore` match the base branch. Omitted `types` defaults to `opened`, `synchronize`, and `reopened`; explicitly listed activity types must map exactly to a supported Buildkite source action. Matching `paths` and `paths-ignore` can be admitted when the bounded local-diff requirements below are met. |
+| `merge_group` | Native Buildkite merge queue builds only. Enable merge queue builds and Merge groups webhook delivery in the pipeline's GitHub settings. `branches` and `branches-ignore` match the target branch. The only supported activity is `checks_requested`; other types and path, tag, and workflow filters are rejected. The merge group ref and SHA identify the speculative queue commit. |
 | `workflow_dispatch` | Selected for Buildkite UI and API builds. Webhook-style branch, tag, type, and workflow filters are unsupported. |
 | `schedule` | Selected for Buildkite scheduled builds. Buildkite owns cron configuration and does not expose which schedule started a build, so every `on.schedule` workflow is eligible for every Buildkite scheduled build. |
 | `workflow_call` | Defines a local reusable-workflow interface. A reusable-only file is available to callers but does not become a top-level group. |
@@ -859,7 +860,7 @@ buildkite-gha validate \
   .github/workflows/ci.yml
 ```
 
-Use `--event push`, `--event pull_request`, `--event workflow_dispatch`, or `--event schedule` instead of `--event-path` to evaluate the hosted profile with a generated minimal snapshot. Generated snapshots are compatibility test inputs, not equivalents to real payloads. The options are mutually exclusive.
+Use `--event push`, `--event pull_request`, `--event merge_group`, `--event workflow_dispatch`, or `--event schedule` instead of `--event-path` to evaluate the hosted profile with a generated minimal snapshot. Generated snapshots are compatibility test inputs, not equivalents to real payloads. The options are mutually exclusive.
 
 Use `--all-events` to evaluate every declared supported event separately. Its `processing-report/v3` output preserves the event-independent result and each generated event's v2 report. Aggregate admission means every generated snapshot was admitted; it does not cover other payload shapes.
 

--- a/internal/buildkite/triggers.go
+++ b/internal/buildkite/triggers.go
@@ -20,6 +20,8 @@ type TriggerConditionContext struct {
 	Tag                    string
 	PullRequestBaseBranch  string
 	PullRequestAction      string
+	MergeGroupBaseBranch   string
+	MergeGroupAction       string
 	ChangedPaths           []string
 	ChangedPathsKnown      bool
 	ChangedPathsError      string
@@ -27,6 +29,8 @@ type TriggerConditionContext struct {
 	TagValue               *string
 	PullRequestBaseValue   *string
 	PullRequestActionValue *string
+	MergeGroupBaseValue    *string
+	MergeGroupActionValue  *string
 }
 
 // UnsupportedPathFiltersError reports a trigger that cannot be translated
@@ -52,6 +56,8 @@ func LiveTriggerConditionContext(eventPredicate string) TriggerConditionContext 
 		Tag:                   "build.tag",
 		PullRequestBaseBranch: "build.pull_request.base_branch",
 		PullRequestAction:     "build.source_action",
+		MergeGroupBaseBranch:  "build.merge_queue.base_branch",
+		MergeGroupAction:      "build.source_action",
 	}
 }
 
@@ -198,6 +204,19 @@ func TriggerFilterMismatchReason(triggers []workflow.Trigger, event string, cont
 					return fmt.Sprintf("Pull request activity %q does not match this workflow's pull_request activity filters.", *context.PullRequestActionValue), nil
 				}
 			}
+		case "merge_group":
+			if context.MergeGroupBaseValue != nil {
+				matches, err := refFilterMatches(*context.MergeGroupBaseValue, trigger.Branches, trigger.BranchesIgnore)
+				if err != nil {
+					return "", fmt.Errorf("merge_group branches: %w", err)
+				}
+				if !matches {
+					return fmt.Sprintf("Base branch %q does not match this workflow's merge_group branch filters.", *context.MergeGroupBaseValue), nil
+				}
+			}
+			if context.MergeGroupActionValue != nil && *context.MergeGroupActionValue != "checks_requested" {
+				return fmt.Sprintf("Merge group activity %q does not match this workflow's merge_group activity filters.", *context.MergeGroupActionValue), nil
+			}
 		}
 		return "", nil
 	}
@@ -218,7 +237,7 @@ func liveTriggerContext(event string) TriggerConditionContext {
 		predicate = `(build.source == "ui" || build.source == "api")`
 	case "schedule":
 		predicate = `build.source == "schedule"`
-	case "push", "pull_request":
+	case "push", "pull_request", "merge_group":
 		predicate = `build.source_event == ` + yamlScalar(event)
 	}
 	return LiveTriggerConditionContext(predicate)
@@ -338,6 +357,42 @@ func translateTrigger(t workflow.Trigger, context TriggerConditionContext, selec
 				return "", false, &UnsupportedPathFiltersError{
 					Event:  t.Event,
 					Reason: "local changed paths do not match, and GitHub's diff-timeout outcome is unavailable",
+				}
+			}
+		}
+		return strings.Join(parts, " && "), true, nil
+	case "merge_group":
+		if t.Tags != nil || t.TagsIgnore != nil || t.Paths != nil || t.PathsIgnore != nil || t.Workflows != nil {
+			return "", false, fmt.Errorf("merge_group has unsupported filters")
+		}
+		if context.EventPredicate == "" || context.MergeGroupAction == "" {
+			return "", false, fmt.Errorf("merge_group requires effective event and action expressions")
+		}
+		if context.MergeGroupAction == "null" {
+			return "", false, fmt.Errorf("merge_group event snapshot requires payload.action")
+		}
+		if context.MergeGroupActionValue != nil && *context.MergeGroupActionValue != "checks_requested" {
+			return "", false, fmt.Errorf("merge_group activity must be checks_requested")
+		}
+		parts := []string{context.EventPredicate, context.MergeGroupAction + ` == "checks_requested"`}
+		hasBranchFilter := t.Branches != nil || t.BranchesIgnore != nil
+		if hasBranchFilter && (context.MergeGroupBaseBranch == "" || context.MergeGroupBaseBranch == "null") {
+			return "", false, fmt.Errorf("merge_group branch filters require payload.merge_group.base_ref")
+		}
+		branch, hasBranchFilter, err := refFilters(context.MergeGroupBaseBranch, t.Branches, t.BranchesIgnore)
+		if err != nil {
+			return "", false, fmt.Errorf("merge_group branches: %w", err)
+		}
+		if hasBranchFilter {
+			parts = append(parts, branch)
+		}
+		if t.Types != nil {
+			if len(t.Types) == 0 {
+				return "", false, fmt.Errorf("merge_group types is explicitly empty")
+			}
+			for _, activity := range t.Types {
+				if activity != "checks_requested" {
+					return "", false, fmt.Errorf("merge_group activity type %q cannot be mapped exactly", activity)
 				}
 			}
 		}

--- a/internal/buildkite/triggers_test.go
+++ b/internal/buildkite/triggers_test.go
@@ -10,12 +10,12 @@ import (
 func TestTranslateTriggerCondition(t *testing.T) {
 	got, err := TranslateTriggerCondition([]workflow.Trigger{
 		{Event: "push", Branches: []string{"main", "releases/**", "!releases/**-alpha", "releases/v[0-9]+"}},
-		{Event: "pull_request"}, {Event: "workflow_dispatch"}, {Event: "schedule"}, {Event: "workflow_call"},
+		{Event: "pull_request"}, {Event: "merge_group", Branches: []string{"main"}}, {Event: "workflow_dispatch"}, {Event: "schedule"}, {Event: "workflow_call"},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{`build.source_event == "push"`, `build.branch =~ /^main$/`, `releases\/.*`, `build.source_event == "pull_request"`, `build.source_action == "opened"`, `build.source_action == "synchronize"`, `build.source == "ui"`, `build.source == "schedule"`} {
+	for _, want := range []string{`build.source_event == "push"`, `build.branch =~ /^main$/`, `releases\/.*`, `build.source_event == "pull_request"`, `build.source_action == "opened"`, `build.source_action == "synchronize"`, `build.source_event == "merge_group"`, `build.merge_queue.base_branch =~ /^main$/`, `build.source_action == "checks_requested"`, `build.source == "ui"`, `build.source == "schedule"`} {
 		if !strings.Contains(got, want) {
 			t.Errorf("condition missing %q:\n%s", want, got)
 		}
@@ -33,6 +33,8 @@ func TestTranslateTriggerConditionRejectsUnsafeTriggers(t *testing.T) {
 		{name: "mixed include ignore", triggers: []workflow.Trigger{{Event: "push", Branches: []string{"main"}, BranchesIgnore: []string{"release"}}}, want: "cannot be combined"},
 		{name: "leading negative", triggers: []workflow.Trigger{{Event: "push", Branches: []string{"!release/**"}}}, want: "must follow a positive"},
 		{name: "unsupported PR type", triggers: []workflow.Trigger{{Event: "pull_request", Types: []string{"not-real"}}}, want: "cannot be mapped exactly"},
+		{name: "unsupported merge group type", triggers: []workflow.Trigger{{Event: "merge_group", Types: []string{"destroyed"}}}, want: "cannot be mapped exactly"},
+		{name: "merge group paths", triggers: []workflow.Trigger{{Event: "merge_group", Paths: []string{"src/**"}}}, want: "path filters are unsupported"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -41,6 +43,28 @@ func TestTranslateTriggerConditionRejectsUnsafeTriggers(t *testing.T) {
 				t.Errorf("TranslateTriggerCondition(%v) error = %v, want %q", test.triggers, err, test.want)
 			}
 		})
+	}
+}
+
+func TestTranslateEventTriggerConditionUsesMergeGroupSnapshot(t *testing.T) {
+	base, action := "main", "checks_requested"
+	context := TriggerConditionContext{
+		EventPredicate:        `build.source == "webhook"`,
+		MergeGroupBaseBranch:  `"main"`,
+		MergeGroupAction:      `"checks_requested"`,
+		MergeGroupBaseValue:   &base,
+		MergeGroupActionValue: &action,
+	}
+	condition, applicable, err := TranslateEventTriggerCondition([]workflow.Trigger{{
+		Event: "merge_group", Branches: []string{"main"}, Types: []string{"checks_requested"},
+	}}, "merge_group", context)
+	if err != nil || !applicable {
+		t.Fatalf("condition/applicable/error = %q / %t / %v", condition, applicable, err)
+	}
+	for _, want := range []string{`build.source == "webhook"`, `"main" =~ /^main$/`, `"checks_requested" == "checks_requested"`} {
+		if !strings.Contains(condition, want) {
+			t.Fatalf("merge_group condition missing %q: %s", want, condition)
+		}
 	}
 }
 

--- a/internal/cli/buildkite_event.go
+++ b/internal/cli/buildkite_event.go
@@ -161,11 +161,50 @@ func buildkiteWebhookEventSource(getenv func(string) string, webhook []byte) ([]
 			snapshot["actor"] = login
 		}
 	}
+	if snapshot["event"] == "merge_group" {
+		if err := validateBuildkiteMergeGroup(snapshot, getenv); err != nil {
+			return nil, err
+		}
+	}
 	result, err := json.Marshal(snapshot)
 	if err != nil {
 		return nil, fmt.Errorf("encode Buildkite webhook snapshot: %w", err)
 	}
 	return result, nil
+}
+
+func validateBuildkiteMergeGroup(snapshot map[string]any, getenv func(string) string) error {
+	payload := snapshot["payload"].(map[string]any)
+	mergeGroup, ok := payload["merge_group"].(map[string]any)
+	if !ok {
+		return fmt.Errorf("merge_group webhook requires payload.merge_group")
+	}
+	if action, _ := payload["action"].(string); action != "checks_requested" {
+		return fmt.Errorf("merge_group webhook action must be checks_requested")
+	}
+	ref, _ := snapshot["ref"].(string)
+	sha, _ := snapshot["sha"].(string)
+	if headRef, _ := mergeGroup["head_ref"].(string); headRef != ref {
+		return fmt.Errorf("merge_group webhook head_ref does not match the Buildkite build branch")
+	}
+	if headSHA, _ := mergeGroup["head_sha"].(string); headSHA != sha {
+		return fmt.Errorf("merge_group webhook head_sha does not match BUILDKITE_COMMIT")
+	}
+	baseBranch := strings.TrimSpace(getenv("BUILDKITE_MERGE_QUEUE_BASE_BRANCH"))
+	if baseBranch == "" {
+		return fmt.Errorf("BUILDKITE_MERGE_QUEUE_BASE_BRANCH is required for a merge_group webhook")
+	}
+	if baseRef, _ := mergeGroup["base_ref"].(string); baseRef != "refs/heads/"+baseBranch {
+		return fmt.Errorf("merge_group webhook base_ref does not match BUILDKITE_MERGE_QUEUE_BASE_BRANCH")
+	}
+	baseCommit := getenv("BUILDKITE_MERGE_QUEUE_BASE_COMMIT")
+	if !validBuildkiteCommit(baseCommit) {
+		return fmt.Errorf("BUILDKITE_MERGE_QUEUE_BASE_COMMIT must be a full lowercase 40-hex commit")
+	}
+	if baseSHA, _ := mergeGroup["base_sha"].(string); baseSHA != baseCommit {
+		return fmt.Errorf("merge_group webhook base_sha does not match BUILDKITE_MERGE_QUEUE_BASE_COMMIT")
+	}
+	return nil
 }
 
 func parseWebhookPayload(source []byte) (map[string]any, error) {

--- a/internal/cli/buildkite_event_test.go
+++ b/internal/cli/buildkite_event_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -218,6 +219,45 @@ func TestBuildkiteWebhookEventSourceUsesPayloadButPreservesExecutionIdentity(t *
 		repository["owner"] != "buildkite" || repository["name"] != "buildkite-gha" ||
 		payload["after"] != strings.Repeat("b", 40) || payload["nested"].(map[string]any)["complete"] != true {
 		t.Fatalf("webhook snapshot = %#v", snapshot)
+	}
+}
+
+func TestBuildkiteWebhookEventSourceBindsMergeGroupIdentity(t *testing.T) {
+	headSHA, baseSHA := strings.Repeat("a", 40), strings.Repeat("b", 40)
+	branch := "gh-readonly-queue/main/pr-1-deadbeef"
+	env := map[string]string{
+		"BUILDKITE": "true", "BUILDKITE_STEP_KEY": "step",
+		"BUILDKITE_REPO":                    "https://github.com/acme/widgets",
+		"BUILDKITE_COMMIT":                  headSHA,
+		"BUILDKITE_BRANCH":                  branch,
+		"BUILDKITE_GITHUB_EVENT":            "merge_group",
+		"BUILDKITE_MERGE_QUEUE_BASE_BRANCH": "main",
+		"BUILDKITE_MERGE_QUEUE_BASE_COMMIT": baseSHA,
+	}
+	webhook := fmt.Sprintf(`{"action":"checks_requested","merge_group":{"head_ref":"refs/heads/%s","head_sha":"%s","base_ref":"refs/heads/main","base_sha":"%s"}}`, branch, headSHA, baseSHA)
+	source, err := buildkiteWebhookEventSource(func(key string) string { return env[key] }, []byte(webhook))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var snapshot map[string]any
+	if err := json.Unmarshal(source, &snapshot); err != nil {
+		t.Fatal(err)
+	}
+	if snapshot["event"] != "merge_group" || snapshot["ref"] != "refs/heads/"+branch || snapshot["sha"] != headSHA {
+		t.Fatalf("merge_group snapshot = %#v", snapshot)
+	}
+
+	for _, test := range []struct{ name, old, replacement, want string }{
+		{name: "head", old: headSHA, replacement: strings.Repeat("c", 40), want: "head_sha"},
+		{name: "base", old: baseSHA, replacement: strings.Repeat("c", 40), want: "base_sha"},
+		{name: "action", old: "checks_requested", replacement: "destroyed", want: "action"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			changed := strings.Replace(webhook, test.old, test.replacement, 1)
+			if _, err := buildkiteWebhookEventSource(func(key string) string { return env[key] }, []byte(changed)); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("buildkiteWebhookEventSource() error = %v, want %q", err, test.want)
+			}
+		})
 	}
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1499,7 +1499,7 @@ func validateAllEventsSource(out processingOutput, workflowPath string, source [
 	}
 	defer cleanup()
 	failed := false
-	for _, event := range []string{"push", "pull_request", "workflow_dispatch", "schedule"} {
+	for _, event := range []string{"push", "pull_request", "merge_group", "workflow_dispatch", "schedule"} {
 		if !declared[event] {
 			continue
 		}
@@ -1618,8 +1618,8 @@ func validateArgs(args []string) (workflowPath, eventPath, eventName, format, pr
 	if eventSeen && profile == "" {
 		return "", "", "", "", "", false, fmt.Errorf("--event requires --profile hosted")
 	}
-	if eventSeen && !slices.Contains([]string{"push", "pull_request", "workflow_dispatch", "schedule"}, eventName) {
-		return "", "", "", "", "", false, fmt.Errorf("unsupported --event %q; supported events are push, pull_request, workflow_dispatch, and schedule", eventName)
+	if eventSeen && !slices.Contains([]string{"push", "pull_request", "merge_group", "workflow_dispatch", "schedule"}, eventName) {
+		return "", "", "", "", "", false, fmt.Errorf("unsupported --event %q; supported events are push, pull_request, merge_group, workflow_dispatch, and schedule", eventName)
 	}
 	if allEvents && (eventPathSeen || eventSeen) {
 		return "", "", "", "", "", false, fmt.Errorf("--all-events is mutually exclusive with --event and --event-path")
@@ -1656,11 +1656,20 @@ func generatedEventSnapshot(name string) ([]byte, error) {
 			"base":   map[string]any{"ref": "main"},
 			"head":   map[string]any{"ref": "example"},
 		}
+	case "merge_group":
+		event.Ref = "refs/heads/gh-readonly-queue/main/pr-1-deadbeef"
+		event.Payload["action"] = "checks_requested"
+		event.Payload["merge_group"] = map[string]any{
+			"head_ref": event.Ref,
+			"head_sha": event.SHA,
+			"base_ref": "refs/heads/main",
+			"base_sha": strings.Repeat("1", 40),
+		}
 	case "schedule":
 		event.Payload["schedule"] = "0 0 * * *"
 	case "workflow_dispatch":
 	default:
-		return nil, fmt.Errorf("unsupported generated event %q; supported events are push, pull_request, workflow_dispatch, and schedule", name)
+		return nil, fmt.Errorf("unsupported generated event %q; supported events are push, pull_request, merge_group, workflow_dispatch, and schedule", name)
 	}
 	return json.Marshal(event)
 }
@@ -2284,6 +2293,8 @@ func snapshotTriggerConditionContext(event compiler.Event) buildkitepipeline.Tri
 		Tag:                   "null",
 		PullRequestBaseBranch: "null",
 		PullRequestAction:     "null",
+		MergeGroupBaseBranch:  "null",
+		MergeGroupAction:      "null",
 	}
 	if branch, ok := strings.CutPrefix(event.Ref, "refs/heads/"); ok {
 		context.Branch = triggerConditionLiteral(branch)
@@ -2296,12 +2307,22 @@ func snapshotTriggerConditionContext(event compiler.Event) buildkitepipeline.Tri
 	if action, ok := event.Payload["action"].(string); ok && strings.TrimSpace(action) != "" {
 		context.PullRequestAction = triggerConditionLiteral(action)
 		context.PullRequestActionValue = &action
+		context.MergeGroupAction = triggerConditionLiteral(action)
+		context.MergeGroupActionValue = &action
 	}
 	if pullRequest, ok := event.Payload["pull_request"].(map[string]any); ok {
 		if base, ok := pullRequest["base"].(map[string]any); ok {
 			if branch, ok := base["ref"].(string); ok && strings.TrimSpace(branch) != "" {
 				context.PullRequestBaseBranch = triggerConditionLiteral(branch)
 				context.PullRequestBaseValue = &branch
+			}
+		}
+	}
+	if mergeGroup, ok := event.Payload["merge_group"].(map[string]any); ok {
+		if baseRef, ok := mergeGroup["base_ref"].(string); ok {
+			if branch, ok := strings.CutPrefix(baseRef, "refs/heads/"); ok && branch != "" {
+				context.MergeGroupBaseBranch = triggerConditionLiteral(branch)
+				context.MergeGroupBaseValue = &branch
 			}
 		}
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1306,10 +1306,10 @@ func TestRunValidateAndCompile(t *testing.T) {
 
 	t.Run("validate hosted profile with generated events", func(t *testing.T) {
 		workflow := filepath.Join(t.TempDir(), "events.yml")
-		if err := os.WriteFile(workflow, []byte("on:\n  push:\n  pull_request:\n  workflow_dispatch:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
+		if err := os.WriteFile(workflow, []byte("on:\n  push:\n  pull_request:\n  merge_group:\n  workflow_dispatch:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
 			t.Fatal(err)
 		}
-		for _, event := range []string{"push", "pull_request", "workflow_dispatch", "schedule"} {
+		for _, event := range []string{"push", "pull_request", "merge_group", "workflow_dispatch", "schedule"} {
 			t.Run(event, func(t *testing.T) {
 				var stdout, stderr bytes.Buffer
 				args := []string{"validate", "--profile", "hosted", "--event", event, "--format", "json", workflow}
@@ -1329,7 +1329,7 @@ func TestRunValidateAndCompile(t *testing.T) {
 
 	t.Run("validate hosted profile with all generated events", func(t *testing.T) {
 		workflow := filepath.Join(t.TempDir(), "events.yml")
-		if err := os.WriteFile(workflow, []byte("on:\n  push:\n  pull_request:\n  workflow_dispatch:\n  schedule:\n    - cron: '0 0 * * *'\n  workflow_call:\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
+		if err := os.WriteFile(workflow, []byte("on:\n  push:\n  pull_request:\n  merge_group:\n  workflow_dispatch:\n  schedule:\n    - cron: '0 0 * * *'\n  workflow_call:\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
 			t.Fatal(err)
 		}
 		var stdout, stderr bytes.Buffer
@@ -1341,10 +1341,10 @@ func TestRunValidateAndCompile(t *testing.T) {
 		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 			t.Fatal(err)
 		}
-		if report.Schema != compatibility.ProcessingSchemaV3 || report.Result != "admitted" || report.Status != compatibility.Passed || report.Validation.Result != "compilable" || len(report.Evaluations) != 4 {
+		if report.Schema != compatibility.ProcessingSchemaV3 || report.Result != "admitted" || report.Status != compatibility.Passed || report.Validation.Result != "compilable" || len(report.Evaluations) != 5 {
 			t.Fatalf("aggregate report = %#v", report)
 		}
-		for i, event := range []string{"push", "pull_request", "workflow_dispatch", "schedule"} {
+		for i, event := range []string{"push", "pull_request", "merge_group", "workflow_dispatch", "schedule"} {
 			if report.Evaluations[i].Event != event || report.Evaluations[i].Source != "generated" || report.Evaluations[i].Report.Result != "admitted" {
 				t.Fatalf("evaluation %d = %#v", i, report.Evaluations[i])
 			}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -4076,7 +4076,7 @@ func TestRunUploadNamesAggregateGitHubChecksFromWorkflowLabels(t *testing.T) {
 func TestRunUploadNamesGitHubCheckForActiveEvent(t *testing.T) {
 	requireImporterHost(t)
 	workflowPath := filepath.Join(t.TempDir(), "multi-trigger.yml")
-	workflowSource := "name: Active event\non:\n  push:\n  pull_request:\n  workflow_dispatch:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo ok\n"
+	workflowSource := "name: Active event\non:\n  push:\n  pull_request:\n  merge_group:\n  workflow_dispatch:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo ok\n"
 	if err := os.WriteFile(workflowPath, []byte(workflowSource), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -4092,6 +4092,7 @@ func TestRunUploadNamesGitHubCheckForActiveEvent(t *testing.T) {
 	}{
 		{name: "push fallback", source: "webhook", wantEvent: "push", wantCondition: `build.source == "webhook"`},
 		{name: "pull request webhook metadata", source: "webhook", githubEvent: "pull_request", webhook: []byte(`{"action":"opened","pull_request":{"base":{"ref":"main"}}}`), wantEvent: "pull_request", wantCondition: `build.source == "webhook"`},
+		{name: "merge group webhook metadata", source: "webhook", githubEvent: "merge_group", webhook: []byte(`{"action":"checks_requested","merge_group":{"head_ref":"refs/heads/gh-readonly-queue/main/pr-1-deadbeef","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","base_ref":"refs/heads/main","base_sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}}`), wantEvent: "merge_group", wantCondition: `build.source == "webhook"`},
 		{name: "UI fallback", source: "ui", wantEvent: "workflow_dispatch", wantCondition: `build.source == "ui"`},
 		{name: "API fallback", source: "api", wantEvent: "workflow_dispatch", wantCondition: `build.source == "api"`},
 		{name: "schedule fallback", source: "schedule", wantEvent: "schedule", wantCondition: `build.source == "schedule"`},
@@ -4106,6 +4107,11 @@ func TestRunUploadNamesGitHubCheckForActiveEvent(t *testing.T) {
 			t.Setenv("BUILDKITE_PULL_REQUEST", "false")
 			t.Setenv("BUILDKITE_SOURCE", test.source)
 			t.Setenv("BUILDKITE_GITHUB_EVENT", test.githubEvent)
+			if test.githubEvent == "merge_group" {
+				t.Setenv("BUILDKITE_BRANCH", "gh-readonly-queue/main/pr-1-deadbeef")
+				t.Setenv("BUILDKITE_MERGE_QUEUE_BASE_BRANCH", "main")
+				t.Setenv("BUILDKITE_MERGE_QUEUE_BASE_COMMIT", strings.Repeat("b", 40))
+			}
 			runner := &cliCaptureRunner{webhook: test.webhook}
 			args := []string{"upload"}
 			if test.eventPath != "" {

--- a/internal/cli/validate_batch.go
+++ b/internal/cli/validate_batch.go
@@ -319,7 +319,7 @@ func loadBatchValidationResult(path, workflow string) (compatibility.ProcessingR
 	seen := make(map[string]bool, len(report.Evaluations))
 	for _, evaluation := range report.Evaluations {
 		if seen[evaluation.Event] || evaluation.Source != "generated" || evaluation.Report.Schema != compatibility.ProcessingSchema ||
-			(evaluation.Event != "push" && evaluation.Event != "pull_request" && evaluation.Event != "workflow_dispatch" && evaluation.Event != "schedule") {
+			(evaluation.Event != "push" && evaluation.Event != "pull_request" && evaluation.Event != "merge_group" && evaluation.Event != "workflow_dispatch" && evaluation.Event != "schedule") {
 			return compatibility.ProcessingReportV3{}, false
 		}
 		seen[evaluation.Event] = true

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -905,10 +905,47 @@ func parseEvent(source []byte) (Event, error) {
 	if input.Payload == nil {
 		input.Payload = map[string]any{}
 	}
+	if input.Event == "merge_group" {
+		if err := validateMergeGroupEvent(input.Ref, input.SHA, input.Payload); err != nil {
+			return Event{}, err
+		}
+	}
 	return Event{
 		Provider: input.Provider, Event: input.Event, Repository: input.Repository,
 		Ref: input.Ref, SHA: input.SHA, Actor: input.Actor, Payload: input.Payload,
 	}, nil
+}
+
+func validateMergeGroupEvent(ref, sha string, payload map[string]any) error {
+	if action, _ := payload["action"].(string); action != "checks_requested" {
+		return fmt.Errorf("merge_group event snapshot requires payload.action to be checks_requested")
+	}
+	mergeGroup, ok := payload["merge_group"].(map[string]any)
+	if !ok {
+		return fmt.Errorf("merge_group event snapshot requires payload.merge_group")
+	}
+	headRef, _ := mergeGroup["head_ref"].(string)
+	baseRef, _ := mergeGroup["base_ref"].(string)
+	headSHA, _ := mergeGroup["head_sha"].(string)
+	baseSHA, _ := mergeGroup["base_sha"].(string)
+	if !strings.HasPrefix(headRef, "refs/heads/") || strings.TrimPrefix(headRef, "refs/heads/") == "" {
+		return fmt.Errorf("merge_group event snapshot requires payload.merge_group.head_ref to be a branch ref")
+	}
+	if !strings.HasPrefix(baseRef, "refs/heads/") || strings.TrimPrefix(baseRef, "refs/heads/") == "" {
+		return fmt.Errorf("merge_group event snapshot requires payload.merge_group.base_ref to be a branch ref")
+	}
+	if !validEventCommit(headSHA) || !validEventCommit(baseSHA) {
+		return fmt.Errorf("merge_group event snapshot requires full lowercase payload.merge_group head and base SHAs")
+	}
+	if ref != headRef || sha != headSHA {
+		return fmt.Errorf("merge_group event snapshot ref and sha must match payload.merge_group head_ref and head_sha")
+	}
+	return nil
+}
+
+func validEventCommit(commit string) bool {
+	decoded, err := hex.DecodeString(commit)
+	return err == nil && len(decoded) == 20 && commit == strings.ToLower(commit)
 }
 
 func compileContext(event Event, vars map[string]string, workflowPath, workflowName string) expression.CompileContext {

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -2839,6 +2839,32 @@ func TestCompileRejectsInvalidEventSnapshots(t *testing.T) {
 	}
 }
 
+func TestParseEventValidatesMergeGroupIdentity(t *testing.T) {
+	headSHA, baseSHA := strings.Repeat("a", 40), strings.Repeat("b", 40)
+	headRef := "refs/heads/gh-readonly-queue/main/pr-1-deadbeef"
+	event := fmt.Sprintf(`{"provider":"github","event":"merge_group","repository":{"owner":"acme","name":"widgets"},"ref":%q,"sha":%q,"actor":"octocat","payload":{"action":"checks_requested","merge_group":{"head_ref":%q,"head_sha":%q,"base_ref":"refs/heads/main","base_sha":%q}}}`, headRef, headSHA, headRef, headSHA, baseSHA)
+	parsed, err := ParseEvent([]byte(event))
+	if err != nil || parsed.Event != "merge_group" || parsed.Ref != headRef || parsed.SHA != headSHA {
+		t.Fatalf("ParseEvent() = %#v, %v", parsed, err)
+	}
+	for _, test := range []struct {
+		name, old, replacement, want string
+	}{
+		{name: "activity", old: `"checks_requested"`, replacement: `"destroyed"`, want: "checks_requested"},
+		{name: "head ref", old: headRef, replacement: "refs/heads/other", want: "must match"},
+		{name: "head sha", old: headSHA, replacement: strings.Repeat("c", 40), want: "must match"},
+		{name: "base ref", old: "refs/heads/main", replacement: "main", want: "base_ref"},
+		{name: "base sha", old: baseSHA, replacement: "main", want: "head and base SHAs"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			changed := strings.Replace(event, test.old, test.replacement, 1)
+			if _, err := ParseEvent([]byte(changed)); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("ParseEvent() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
 func smokePath(parts ...string) string {
 	return filepath.Join(append([]string{"..", "..", "testdata", "smoke"}, parts...)...)
 }

--- a/internal/workflow/triggers_test.go
+++ b/internal/workflow/triggers_test.go
@@ -32,12 +32,12 @@ func TestParseRetainsShorthandTriggerForms(t *testing.T) {
 }
 
 func TestParseRetainsTriggerConfiguration(t *testing.T) {
-	source := []byte("on:\n  push:\n    branches: [main, '!release/**', 'release/**']\n  pull_request:\n    types: [opened]\n  workflow_dispatch:\n    inputs:\n      target:\n        type: string\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n")
+	source := []byte("on:\n  push:\n    branches: [main, '!release/**', 'release/**']\n  pull_request:\n    types: [opened]\n  merge_group:\n    types: [checks_requested]\n    branches: [main]\n  workflow_dispatch:\n    inputs:\n      target:\n        type: string\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n")
 	w, err := Parse("workflow.yml", source)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(w.Triggers) != 4 {
+	if len(w.Triggers) != 5 {
 		t.Fatalf("got %d triggers: %#v", len(w.Triggers), w.Triggers)
 	}
 	if got := w.Triggers[0].Branches; len(got) != 3 || got[1] != "!release/**" || got[2] != "release/**" {
@@ -46,11 +46,14 @@ func TestParseRetainsTriggerConfiguration(t *testing.T) {
 	if w.Triggers[1].Types == nil || len(w.Triggers[1].Types) != 1 {
 		t.Fatalf("types not retained: %#v", w.Triggers[1])
 	}
-	if w.Triggers[2].Dispatch == nil || len(w.Triggers[2].Dispatch.Inputs) != 1 || w.Triggers[2].Dispatch.Inputs[0].Name != "target" {
-		t.Fatalf("dispatch not retained: %#v", w.Triggers[2])
+	if len(w.Triggers[2].Types) != 1 || w.Triggers[2].Types[0] != "checks_requested" || len(w.Triggers[2].Branches) != 1 || w.Triggers[2].Branches[0] != "main" {
+		t.Fatalf("merge_group filters not retained: %#v", w.Triggers[2])
 	}
-	if len(w.Triggers[3].Schedules) != 1 || w.Triggers[3].Schedules[0].Cron != "0 0 * * *" {
-		t.Fatalf("schedule not retained: %#v", w.Triggers[3])
+	if w.Triggers[3].Dispatch == nil || len(w.Triggers[3].Dispatch.Inputs) != 1 || w.Triggers[3].Dispatch.Inputs[0].Name != "target" {
+		t.Fatalf("dispatch not retained: %#v", w.Triggers[3])
+	}
+	if len(w.Triggers[4].Schedules) != 1 || w.Triggers[4].Schedules[0].Cron != "0 0 * * *" {
+		t.Fatalf("schedule not retained: %#v", w.Triggers[4])
 	}
 }
 

--- a/schemas/processing-report-v3.schema.json
+++ b/schemas/processing-report-v3.schema.json
@@ -14,13 +14,13 @@
     "validation": {"$ref": "processing-report-v2.schema.json"},
     "evaluations": {
       "type": "array",
-      "maxItems": 4,
+      "maxItems": 5,
       "items": {
         "type": "object",
         "additionalProperties": false,
         "required": ["event", "event_source", "report"],
         "properties": {
-          "event": {"enum": ["push", "pull_request", "workflow_dispatch", "schedule"]},
+          "event": {"enum": ["push", "pull_request", "merge_group", "workflow_dispatch", "schedule"]},
           "event_source": {"const": "generated"},
           "report": {"$ref": "processing-report-v2.schema.json"}
         }

--- a/scripts/validate-public-workflow-corpus
+++ b/scripts/validate-public-workflow-corpus
@@ -344,7 +344,13 @@ for path in glob.glob(os.path.join(os.environ["reports"], "**", "*.json"), recur
         event = evaluation.get("event") if isinstance(evaluation, dict) else None
         if (
             not isinstance(evaluation, dict)
-            or event not in ("push", "pull_request", "workflow_dispatch", "schedule")
+            or event not in (
+                "push",
+                "pull_request",
+                "merge_group",
+                "workflow_dispatch",
+                "schedule",
+            )
             or event in seen_events
             or evaluation.get("event_source") != "generated"
             or not isinstance(evaluation.get("report"), dict)


### PR DESCRIPTION
## Why

GitHub merge queues emit a distinct `merge_group` event, and Buildkite now creates native merge-queue builds with the exact speculative head and target base identity. Rejecting these workflows leaves a high-impact compatibility gap; treating them as push or pull request events would lose their trigger and security semantics.

## What

Add end-to-end `merge_group` support for the sole GitHub activity, `checks_requested`, with target-branch filters and exact ref/SHA validation. Linked webhook payloads must match Buildkite's native merge-queue head and base fields, while unsupported filters fail closed and existing untrusted execution and merge-queue token policy remain unchanged.

Include generated `--event merge_group` and `--all-events` validation, processing-report schema and corpus summarizer coverage, tests, and compatibility and CLI documentation.
