### PR TITLE
Report unmeasured PR path filters accurately

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -57,7 +57,7 @@ buildkite-gha validate \
   .github/workflows/ci.yml
 ```
 
-`--all-events` is mutually exclusive with `--event` and `--event-path`. It does not evaluate `workflow_call` as a standalone event. Admission applies separately to each generated snapshot, not to every possible real payload.
+`--all-events` is mutually exclusive with `--event` and `--event-path`. It does not evaluate `workflow_call` as a standalone event. Admission applies separately to each generated snapshot, not to every possible real payload. A `context-required` result means a supported admission path needs evidence that generated snapshots do not contain. For example, pull-request path filters need linked webhook data and a verified local git diff.
 
 Reuse downloaded immutable action source across profile validation runs:
 
@@ -130,7 +130,7 @@ buildkite-gha validate \
 The deprecated `hosted-tokenless` profile name remains an alias for `hosted`.
 Hosted validation uses the same runner preset as production upload.
 
-Use `--format json` for a `buildkite-gha/processing-report/v2` report. `--all-events` emits `buildkite-gha/processing-report/v3`, which contains the event-independent v2 report and one v2 report for each generated event evaluation. The top-level result is `admitted` only when every evaluation is admitted.
+Use `--format json` for a `buildkite-gha/processing-report/v2` report. `--all-events` emits `buildkite-gha/processing-report/v3`, which contains the event-independent v2 report and one v2 report for each generated event evaluation. The top-level result is `admitted` only when every evaluation is admitted. It is `context-required` when generated inputs cannot measure an otherwise supported path, unless another finding makes the workflow incompatible or indeterminate.
 
 Reports cover workflow parsing, event validation, graph construction, matrix expansion, expressions, action discovery and resolution, plan construction, profile admission, and pipeline generation. A blocked downstream stage is `not-evaluated`, not `failed`.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -130,7 +130,7 @@ buildkite-gha validate \
 The deprecated `hosted-tokenless` profile name remains an alias for `hosted`.
 Hosted validation uses the same runner preset as production upload.
 
-Use `--format json` for a `buildkite-gha/processing-report/v2` report. `--all-events` emits `buildkite-gha/processing-report/v3`, which contains the event-independent v2 report and one v2 report for each generated event evaluation. The top-level result is `admitted` only when every evaluation is admitted. It is `context-required` when generated inputs cannot measure an otherwise supported path, unless another finding makes the workflow incompatible or indeterminate.
+Use `--format json` for a `buildkite-gha/processing-report/v2` report. `--all-events` emits `buildkite-gha/processing-report/v3`, which contains the event-independent v2 report and one v2 report for each generated event evaluation. The top-level result is `admitted` only when every evaluation is admitted. It is `context-required` when generated inputs cannot measure an otherwise supported path, unless another finding makes the workflow incompatible, not admitted, or indeterminate.
 
 Reports cover workflow parsing, event validation, graph construction, matrix expansion, expressions, action discovery and resolution, plan construction, profile admission, and pipeline generation. A blocked downstream stage is `not-evaluated`, not `failed`.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -26,7 +26,7 @@ Validate syntax, the static graph, and every declared trigger without an event:
 buildkite-gha validate .github/workflows/ci.yml
 ```
 
-This event-independent check rejects unsupported events, path filters, branch and tag filter combinations, and pull request activity types. It does not resolve actions, evaluate event payload expressions, or claim hosted admission.
+This event-independent check accepts syntactically valid pull-request path filters because linked-webhook admission can evaluate them with a verified local git diff. It rejects push path filters, malformed path filters, unsupported events, unsupported branch and tag filter combinations, and unsupported pull-request activity types. It does not resolve actions, evaluate event payload expressions, or claim hosted admission.
 
 Resolve actions and apply production policy:
 
@@ -57,7 +57,7 @@ buildkite-gha validate \
   .github/workflows/ci.yml
 ```
 
-`--all-events` is mutually exclusive with `--event` and `--event-path`. It does not evaluate `workflow_call` as a standalone event. Admission applies separately to each generated snapshot, not to every possible real payload. A `context-required` result means a supported admission path needs evidence that generated snapshots do not contain. For example, pull-request path filters need linked webhook data and a verified local git diff.
+`--all-events` is mutually exclusive with `--event` and `--event-path`. It does not evaluate `workflow_call` as a standalone event. Admission applies separately to each generated snapshot, not to every possible real payload. A `context-required` result means every available compilation and hosted-policy check passed, but a supported admission path needs evidence that generated snapshots do not contain. For example, pull-request path filters need linked webhook data and a verified local git diff.
 
 Reuse downloaded immutable action source across profile validation runs:
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -861,13 +861,14 @@ buildkite-gha validate \
 
 Use `--event push`, `--event pull_request`, `--event workflow_dispatch`, or `--event schedule` instead of `--event-path` to evaluate the hosted profile with a generated minimal snapshot. Generated snapshots are compatibility test inputs, not equivalents to real payloads. The options are mutually exclusive.
 
-Use `--all-events` to evaluate every declared supported event separately. Its `processing-report/v3` output preserves the event-independent result and each generated event's v2 report. Aggregate admission means every generated snapshot was admitted; it does not cover other payload shapes.
+Use `--all-events` to evaluate every declared supported event separately. Its `processing-report/v3` output preserves the event-independent result and each generated event's v2 report. Aggregate admission means every generated snapshot was admitted; it does not cover other payload shapes. A `context-required` result preserves supported paths that generated inputs cannot measure, such as pull-request path filters without linked webhook and local diff evidence. It does not claim admission.
 
 The results mean:
 
 - **Compilable**: Syntax, declared triggers, and the static job graph can be translated.
 - **Not applicable**: The workflow does not declare the selected event, so upload would skip it without compiling it.
 - **Admitted**: Resolved actions and generated plans pass production policy.
+- **Context required**: A supported admission path needs evidence that this validation input does not provide.
 - **Runtime-proven**: Repository tests or hosted evidence have executed the behavior.
 
 Admission does not execute arbitrary action code. An admitted action may still depend on an unsupported GitHub service.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -861,7 +861,7 @@ buildkite-gha validate \
 
 Use `--event push`, `--event pull_request`, `--event workflow_dispatch`, or `--event schedule` instead of `--event-path` to evaluate the hosted profile with a generated minimal snapshot. Generated snapshots are compatibility test inputs, not equivalents to real payloads. The options are mutually exclusive.
 
-Use `--all-events` to evaluate every declared supported event separately. Its `processing-report/v3` output preserves the event-independent result and each generated event's v2 report. Aggregate admission means every generated snapshot was admitted; it does not cover other payload shapes. A `context-required` result preserves supported paths that generated inputs cannot measure, such as pull-request path filters without linked webhook and local diff evidence. It does not claim admission.
+Use `--all-events` to evaluate every declared supported event separately. Its `processing-report/v3` output preserves the event-independent result and each generated event's v2 report. Aggregate admission means every generated snapshot was admitted; it does not cover other payload shapes. A `context-required` result means compilation and hosted-policy checks passed, but generated inputs cannot measure a supported admission path, such as pull-request path filters without linked webhook and local diff evidence. It does not claim admission.
 
 The results mean:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -78,7 +78,7 @@ Useful environment variables are:
 | `ACTION_CACHE_MAX_BYTES` | `21474836480` | Bound extracted immutable action trees. |
 | `REFRESH_ACTION_RESOLUTIONS` | `0` | Set to `1` to start a new action-resolution generation. This removes existing report sets for the record. |
 
-The script reports compatible and incompatible repositories among those the generated snapshots measured. It reports repositories that require context separately and excludes them from the compatibility percentage. The tally also records workflow result counts and keeps every diagnostic in the per-workflow report.
+The script reports compatible, incompatible, and policy-rejected repositories among those the generated snapshots measured. It reports context-required and indeterminate repositories separately and excludes them from the compatibility percentage. The tally also records workflow result counts and keeps every diagnostic in the per-workflow report.
 
 Pull-request path filters require a linked Buildkite webhook and a verified, bounded local git diff. The public corpus has workflow files but no repository checkouts or pull-request history. It still compiles these workflows, resolves their actions, constructs their plans, and applies hosted policy. When the diff is the only missing evidence, it reports the workflow as `context-required`. This does not claim admission. Push path filters, malformed filters, and workflows with another incompatibility remain incompatible.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -78,7 +78,11 @@ Useful environment variables are:
 | `ACTION_CACHE_MAX_BYTES` | `21474836480` | Bound extracted immutable action trees. |
 | `REFRESH_ACTION_RESOLUTIONS` | `0` | Set to `1` to start a new action-resolution generation. This removes existing report sets for the record. |
 
-The script prints a repository-level diagnostic tally. Sample metadata is also written to `records/<record-id>/samples/<sample-key>/validate-tally.json`; per-workflow v3 reports are under `reports/<record-id>/samples/<sample-key>/<validator-digest>/`. Full-corpus tallies and reports retain their existing paths.
+The script reports compatible and incompatible repositories among those the generated snapshots measured. It reports repositories that require context separately and excludes them from the compatibility percentage. The tally also records workflow result counts and keeps every diagnostic in the per-workflow report.
+
+Pull-request path filters require a linked Buildkite webhook and a verified, bounded local git diff. The public corpus has workflow files but no repository checkouts or pull-request history, so it reports otherwise-compatible workflows with these filters as `context-required`. This does not claim admission. Push path filters, malformed filters, and workflows with another incompatibility remain incompatible.
+
+Sample metadata is written to `records/<record-id>/samples/<sample-key>/validate-tally.json`; per-workflow v3 reports are under `reports/<record-id>/samples/<sample-key>/<validator-digest>/`. Full-corpus tallies and reports retain their existing paths.
 
 Admission covers generated event snapshots, not arbitrary real payloads or action execution. The action-resolution snapshot pins action revisions only. Preserve the snapshot, corpus record, sample seed, and sample size when comparing compatibility across commits.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -80,7 +80,7 @@ Useful environment variables are:
 
 The script reports compatible and incompatible repositories among those the generated snapshots measured. It reports repositories that require context separately and excludes them from the compatibility percentage. The tally also records workflow result counts and keeps every diagnostic in the per-workflow report.
 
-Pull-request path filters require a linked Buildkite webhook and a verified, bounded local git diff. The public corpus has workflow files but no repository checkouts or pull-request history, so it reports otherwise-compatible workflows with these filters as `context-required`. This does not claim admission. Push path filters, malformed filters, and workflows with another incompatibility remain incompatible.
+Pull-request path filters require a linked Buildkite webhook and a verified, bounded local git diff. The public corpus has workflow files but no repository checkouts or pull-request history. It still compiles these workflows, resolves their actions, constructs their plans, and applies hosted policy. When the diff is the only missing evidence, it reports the workflow as `context-required`. This does not claim admission. Push path filters, malformed filters, and workflows with another incompatibility remain incompatible.
 
 Sample metadata is written to `records/<record-id>/samples/<sample-key>/validate-tally.json`; per-workflow v3 reports are under `reports/<record-id>/samples/<sample-key>/<validator-digest>/`. Full-corpus tallies and reports retain their existing paths.
 

--- a/internal/buildkite/triggers.go
+++ b/internal/buildkite/triggers.go
@@ -44,16 +44,6 @@ func (e *UnsupportedPathFiltersError) Error() string {
 	return fmt.Sprintf("%s path filters are unsupported: Buildkite if_changed is not equivalent", e.Event)
 }
 
-// PathFilterContextRequiredError reports a supported path-filter mode that
-// cannot be evaluated without linked webhook and local checkout evidence.
-type PathFilterContextRequiredError struct {
-	Event string
-}
-
-func (e *PathFilterContextRequiredError) Error() string {
-	return fmt.Sprintf("%s path filters require linked webhook data and a verified local git diff", e.Event)
-}
-
 // LiveTriggerConditionContext uses fields from the Buildkite build that
 // supplied the effective event snapshot.
 func LiveTriggerConditionContext(eventPredicate string) TriggerConditionContext {
@@ -94,10 +84,9 @@ func ValidateTriggerConditions(triggers []workflow.Trigger) error {
 		if _, _, err := translateTrigger(trigger, liveTriggerContext(trigger.Event), true); err != nil {
 			var pathFilters *UnsupportedPathFiltersError
 			if errors.As(err, &pathFilters) && pathFilters.Event == "pull_request" && pathFilters.Reason == "" {
-				findings = append(findings, &PathFilterContextRequiredError{Event: pathFilters.Event})
-			} else {
-				findings = append(findings, err)
+				continue
 			}
+			findings = append(findings, err)
 		}
 	}
 	return errors.Join(findings...)

--- a/internal/buildkite/triggers.go
+++ b/internal/buildkite/triggers.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -43,6 +44,16 @@ func (e *UnsupportedPathFiltersError) Error() string {
 	return fmt.Sprintf("%s path filters are unsupported: Buildkite if_changed is not equivalent", e.Event)
 }
 
+// PathFilterContextRequiredError reports a supported path-filter mode that
+// cannot be evaluated without linked webhook and local checkout evidence.
+type PathFilterContextRequiredError struct {
+	Event string
+}
+
+func (e *PathFilterContextRequiredError) Error() string {
+	return fmt.Sprintf("%s path filters require linked webhook data and a verified local git diff", e.Event)
+}
+
 // LiveTriggerConditionContext uses fields from the Buildkite build that
 // supplied the effective event snapshot.
 func LiveTriggerConditionContext(eventPredicate string) TriggerConditionContext {
@@ -78,12 +89,18 @@ func TranslateTriggerCondition(triggers []workflow.Trigger) (string, error) {
 // ValidateTriggerConditions validates every trigger using the same translation
 // rules as pipeline generation without selecting an effective event.
 func ValidateTriggerConditions(triggers []workflow.Trigger) error {
+	var findings []error
 	for _, trigger := range triggers {
 		if _, _, err := translateTrigger(trigger, liveTriggerContext(trigger.Event), true); err != nil {
-			return err
+			var pathFilters *UnsupportedPathFiltersError
+			if errors.As(err, &pathFilters) && pathFilters.Event == "pull_request" && pathFilters.Reason == "" {
+				findings = append(findings, &PathFilterContextRequiredError{Event: pathFilters.Event})
+			} else {
+				findings = append(findings, err)
+			}
 		}
 	}
-	return nil
+	return errors.Join(findings...)
 }
 
 // TranslateEventTriggerCondition validates every trigger but emits a

--- a/internal/buildkite/triggers_test.go
+++ b/internal/buildkite/triggers_test.go
@@ -61,22 +61,22 @@ func TestValidateTriggerConditionsAllowsReusableOnlyWorkflow(t *testing.T) {
 	}
 }
 
-func TestValidateTriggerConditionsClassifiesOnlySupportedPullRequestPathsAsContextRequired(t *testing.T) {
+func TestValidateTriggerConditionsAcceptsSupportedPullRequestPaths(t *testing.T) {
+	if err := ValidateTriggerConditions([]workflow.Trigger{{Event: "pull_request", Paths: []string{"src/**"}}}); err != nil {
+		t.Fatalf("ValidateTriggerConditions() pull request paths error = %v", err)
+	}
+
 	err := ValidateTriggerConditions([]workflow.Trigger{
 		{Event: "pull_request", Paths: []string{"src/**"}},
 		{Event: "push", Paths: []string{"docs/**"}},
 	})
-	var contextRequired *PathFilterContextRequiredError
 	var unsupported *UnsupportedPathFiltersError
-	if !errors.As(err, &contextRequired) || contextRequired.Event != "pull_request" {
-		t.Fatalf("ValidateTriggerConditions() context error = %v", err)
-	}
 	if !errors.As(err, &unsupported) || unsupported.Event != "push" {
 		t.Fatalf("ValidateTriggerConditions() unsupported error = %v", err)
 	}
 
 	err = ValidateTriggerConditions([]workflow.Trigger{{Event: "pull_request", Paths: []string{"!src/**"}}})
-	if errors.As(err, &contextRequired) || err == nil || !strings.Contains(err.Error(), "must follow a positive pattern") {
+	if err == nil || !strings.Contains(err.Error(), "must follow a positive pattern") {
 		t.Fatalf("ValidateTriggerConditions() invalid pull request path error = %v", err)
 	}
 }

--- a/internal/buildkite/triggers_test.go
+++ b/internal/buildkite/triggers_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -57,6 +58,26 @@ func TestValidateTriggerConditionsAllowsReusableOnlyWorkflow(t *testing.T) {
 	}
 	if err := ValidateTriggerConditions([]workflow.Trigger{{Event: "issues"}}); err == nil || !strings.Contains(err.Error(), "unsupported GitHub trigger") {
 		t.Fatalf("ValidateTriggerConditions(issues) error = %v", err)
+	}
+}
+
+func TestValidateTriggerConditionsClassifiesOnlySupportedPullRequestPathsAsContextRequired(t *testing.T) {
+	err := ValidateTriggerConditions([]workflow.Trigger{
+		{Event: "pull_request", Paths: []string{"src/**"}},
+		{Event: "push", Paths: []string{"docs/**"}},
+	})
+	var contextRequired *PathFilterContextRequiredError
+	var unsupported *UnsupportedPathFiltersError
+	if !errors.As(err, &contextRequired) || contextRequired.Event != "pull_request" {
+		t.Fatalf("ValidateTriggerConditions() context error = %v", err)
+	}
+	if !errors.As(err, &unsupported) || unsupported.Event != "push" {
+		t.Fatalf("ValidateTriggerConditions() unsupported error = %v", err)
+	}
+
+	err = ValidateTriggerConditions([]workflow.Trigger{{Event: "pull_request", Paths: []string{"!src/**"}}})
+	if errors.As(err, &contextRequired) || err == nil || !strings.Contains(err.Error(), "must follow a positive pattern") {
+		t.Fatalf("ValidateTriggerConditions() invalid pull request path error = %v", err)
 	}
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1464,14 +1464,20 @@ func validateAllEventsSource(out processingOutput, workflowPath string, source [
 	validation, validationErr := compiler.Validate(workflowPath, source)
 	validationReport := compatibility.InitialProcessingReport(workflowPath, "", false, validation, validationErr)
 	if validationErr != nil {
-		validationReport.Result = "incompatible"
-		report := compatibility.NewProcessingReportV3(workflowPath, hostedProfile, validationReport)
-		if out.writeV3(report) != nil {
+		if processingReportOnlyRequiresContext(validationReport) {
+			validationReport.Result = "context-required"
+		} else {
+			validationReport.Result = "incompatible"
+			report := compatibility.NewProcessingReportV3(workflowPath, hostedProfile, validationReport)
+			if out.writeV3(report) != nil {
+				return 1
+			}
 			return 1
 		}
-		return 1
 	}
-	validationReport.Result = "compilable"
+	if validationErr == nil {
+		validationReport.Result = "compilable"
+	}
 	report := compatibility.NewProcessingReportV3(workflowPath, hostedProfile, validationReport)
 	parsed, err := workflow.Parse(workflowPath, source)
 	if err != nil {
@@ -1481,6 +1487,7 @@ func validateAllEventsSource(out processingOutput, workflowPath string, source [
 	for _, trigger := range parsed.Triggers {
 		declared[trigger.Event] = true
 	}
+	contextRequired := validationReport.Result == "context-required"
 	cleanup := func() {}
 	if runtime == nil {
 		actionSource, sourceCleanup, sourceErr := newHostedActionSource(actionCacheDir, nil, nil)
@@ -1498,9 +1505,17 @@ func validateAllEventsSource(out processingOutput, workflowPath string, source [
 		runtime = &profileValidationRuntime{actionSource: actionSource, distributionDigest: distributionDigest, executableErr: executableErr}
 	}
 	defer cleanup()
-	failed := false
+	failed := contextRequired
 	for _, event := range []string{"push", "pull_request", "workflow_dispatch", "schedule"} {
 		if !declared[event] {
+			continue
+		}
+		if event == "pull_request" && contextRequired {
+			eventReport := validationReport
+			eventReport.Profile = hostedProfile
+			report.Evaluations = append(report.Evaluations, compatibility.EventEvaluation{
+				Event: event, Source: "generated", Report: eventReport,
+			})
 			continue
 		}
 		var eventReport *compatibility.ProcessingReport
@@ -1525,6 +1540,20 @@ func validateAllEventsSource(out processingOutput, workflowPath string, source [
 		return 1
 	}
 	return 0
+}
+
+func processingReportOnlyRequiresContext(report compatibility.ProcessingReport) bool {
+	found := false
+	for _, diagnostic := range report.Diagnostics {
+		if diagnostic.Level != "error" {
+			continue
+		}
+		if diagnostic.Code != compiler.CodeContextRequired {
+			return false
+		}
+		found = true
+	}
+	return found
 }
 
 func validateActionCacheArgs(args []string) ([]string, string, error) {
@@ -2342,19 +2371,26 @@ func triggerFailureProcessingReport(input workflowInput, err error) compatibilit
 	report := triggerProcessingReport(input.Path, input.Source)
 	var pathFilters *buildkitepipeline.UnsupportedPathFiltersError
 	if errors.As(err, &pathFilters) {
+		code, category := compiler.CodePipelineGeneration, "compatibility"
 		message := fmt.Sprintf("%s trigger path filters cannot be translated safely. Remove paths and paths-ignore from this trigger, or move the filtering into a job or step.", upperFirst(pathFilters.Event))
-		if pathFilters.Reason != "" {
+		if pathFilters.Event == "pull_request" && pathFilters.Reason == "" {
+			code, category = compiler.CodeContextRequired, "context"
+			message = "Pull request path filters require linked Buildkite webhook data and a verified local git diff."
+			report.Result = "context-required"
+		} else if pathFilters.Reason != "" {
 			message = fmt.Sprintf("%s trigger path filters could not be evaluated safely. Ensure the linked webhook and local checkout contain matching pull-request history, or remove the path filters.", upperFirst(pathFilters.Event))
 		}
 		err = &compiler.ProcessingFinding{
-			Stage: compiler.StagePipeline, Code: compiler.CodePipelineGeneration, Category: "compatibility",
+			Stage: compiler.StagePipeline, Code: code, Category: category,
 			Path: input.Path, Line: 1, Column: 1,
 			Message: message,
 			Detail:  pathFilters.Error(), Err: err,
 		}
 	}
 	report.AddFailure(input.Path, string(compiler.StagePipeline), compiler.CodePipelineGeneration, "compatibility", err)
-	report.Result = "incompatible"
+	if report.Result != "context-required" {
+		report.Result = "incompatible"
+	}
 	return report
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1332,6 +1332,7 @@ func validateOne(out processingOutput, workflowPath, eventPath, eventName, profi
 }
 
 func validateOneSource(out processingOutput, workflowPath string, workflowSource []byte, eventPath, eventName, profile, version, actionCacheDir string, runtime *profileValidationRuntime, stderr io.Writer) int {
+	contextRequired := false
 	var loadEvent func() ([]byte, error)
 	if eventPath != "" {
 		event, eventErr := os.ReadFile(eventPath)
@@ -1359,11 +1360,13 @@ func validateOneSource(out processingOutput, workflowPath string, workflowSource
 		if parseErr == nil && eventErr == nil && !parsed.ReusableOnly() {
 			selection, triggerErr := selectWorkflowTrigger(parsed.Triggers, effectiveEvent)
 			if triggerErr != nil {
-				report := triggerFailureProcessingReport(workflowInput{Path: workflowPath, Source: source}, triggerErr)
-				_ = out.write(report)
-				return 1
-			}
-			if !selection.Applicable {
+				contextRequired = pullRequestPathContextRequired(triggerErr)
+				if !contextRequired {
+					report := triggerFailureProcessingReport(workflowInput{Path: workflowPath, Source: source}, triggerErr)
+					_ = out.write(report)
+					return 1
+				}
+			} else if !selection.Applicable {
 				report := triggerProcessingReport(workflowPath, source)
 				report.Result = "not-applicable"
 				if out.write(report) != nil {
@@ -1421,14 +1424,27 @@ func validateOneSource(out processingOutput, workflowPath string, workflowSource
 			_ = out.write(processingReport)
 			return 1
 		}
-		processingReport.SetStage(string(compiler.StageAdmission), compatibility.Passed)
-		processingReport.Admission.Result = "admitted"
 		if preflight.HasActions {
 			processingReport.Diagnostics = append(processingReport.Diagnostics, compatibility.Diagnostic{
 				Level: "warning", Code: "W_ACTION_RUNTIME_UNKNOWN", Category: "compatibility", Stage: string(compiler.StageAdmission),
 				Message: "Third-party action runtime behavior was not validated. The action source, metadata, declared runtime, entrypoints, inputs, and nested actions were validated, but the action code was not executed and may depend on GitHub-only services. No action is required for admission; test the action on Buildkite if runtime compatibility is important.",
 			})
 		}
+		if contextRequired {
+			processingReport.SetStage(string(compiler.StageAdmission), compatibility.NotEvaluated)
+			processingReport.Admission.Result = compatibility.NotEvaluated
+			processingReport.Diagnostics = append(processingReport.Diagnostics, compatibility.Diagnostic{
+				Level: "error", Code: compiler.CodeContextRequired, Category: "context", Stage: string(compiler.StageAdmission),
+				Message: "Pull request path filters require linked Buildkite webhook data and a verified local git diff before admission can be determined.",
+			})
+			processingReport.Result = "context-required"
+			if out.write(processingReport) != nil {
+				return 1
+			}
+			return 1
+		}
+		processingReport.SetStage(string(compiler.StageAdmission), compatibility.Passed)
+		processingReport.Admission.Result = "admitted"
 		processingReport.Result = "admitted"
 		if out.write(processingReport) != nil {
 			return 1
@@ -1464,20 +1480,14 @@ func validateAllEventsSource(out processingOutput, workflowPath string, source [
 	validation, validationErr := compiler.Validate(workflowPath, source)
 	validationReport := compatibility.InitialProcessingReport(workflowPath, "", false, validation, validationErr)
 	if validationErr != nil {
-		if processingReportOnlyRequiresContext(validationReport) {
-			validationReport.Result = "context-required"
-		} else {
-			validationReport.Result = "incompatible"
-			report := compatibility.NewProcessingReportV3(workflowPath, hostedProfile, validationReport)
-			if out.writeV3(report) != nil {
-				return 1
-			}
+		validationReport.Result = "incompatible"
+		report := compatibility.NewProcessingReportV3(workflowPath, hostedProfile, validationReport)
+		if out.writeV3(report) != nil {
 			return 1
 		}
+		return 1
 	}
-	if validationErr == nil {
-		validationReport.Result = "compilable"
-	}
+	validationReport.Result = "compilable"
 	report := compatibility.NewProcessingReportV3(workflowPath, hostedProfile, validationReport)
 	parsed, err := workflow.Parse(workflowPath, source)
 	if err != nil {
@@ -1487,7 +1497,6 @@ func validateAllEventsSource(out processingOutput, workflowPath string, source [
 	for _, trigger := range parsed.Triggers {
 		declared[trigger.Event] = true
 	}
-	contextRequired := validationReport.Result == "context-required"
 	cleanup := func() {}
 	if runtime == nil {
 		actionSource, sourceCleanup, sourceErr := newHostedActionSource(actionCacheDir, nil, nil)
@@ -1505,17 +1514,9 @@ func validateAllEventsSource(out processingOutput, workflowPath string, source [
 		runtime = &profileValidationRuntime{actionSource: actionSource, distributionDigest: distributionDigest, executableErr: executableErr}
 	}
 	defer cleanup()
-	failed := contextRequired
+	failed := false
 	for _, event := range []string{"push", "pull_request", "workflow_dispatch", "schedule"} {
 		if !declared[event] {
-			continue
-		}
-		if event == "pull_request" && contextRequired {
-			eventReport := validationReport
-			eventReport.Profile = hostedProfile
-			report.Evaluations = append(report.Evaluations, compatibility.EventEvaluation{
-				Event: event, Source: "generated", Report: eventReport,
-			})
 			continue
 		}
 		var eventReport *compatibility.ProcessingReport
@@ -1540,20 +1541,6 @@ func validateAllEventsSource(out processingOutput, workflowPath string, source [
 		return 1
 	}
 	return 0
-}
-
-func processingReportOnlyRequiresContext(report compatibility.ProcessingReport) bool {
-	found := false
-	for _, diagnostic := range report.Diagnostics {
-		if diagnostic.Level != "error" {
-			continue
-		}
-		if diagnostic.Code != compiler.CodeContextRequired {
-			return false
-		}
-		found = true
-	}
-	return found
 }
 
 func validateActionCacheArgs(args []string) ([]string, string, error) {
@@ -2360,6 +2347,11 @@ func selectWorkflowTrigger(triggers []workflow.Trigger, event effectiveEventSele
 		SkipReason:       buildkitepipeline.TriggerEventSkipReason(triggers, event.Event.Event),
 		AnnotationReason: annotationReason,
 	}, nil
+}
+
+func pullRequestPathContextRequired(err error) bool {
+	var pathFilters *buildkitepipeline.UnsupportedPathFiltersError
+	return errors.As(err, &pathFilters) && pathFilters.Event == "pull_request" && pathFilters.Reason == ""
 }
 
 func triggerConditionLiteral(value string) string {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1361,6 +1361,10 @@ func validateOneSource(out processingOutput, workflowPath string, workflowSource
 			selection, triggerErr := selectWorkflowTrigger(parsed.Triggers, effectiveEvent)
 			if triggerErr != nil {
 				contextRequired = pullRequestPathContextRequired(triggerErr)
+				if contextRequired {
+					triggerErr = buildkitepipeline.ValidateTriggerConditions(parsed.Triggers)
+					contextRequired = triggerErr == nil
+				}
 				if !contextRequired {
 					report := triggerFailureProcessingReport(workflowInput{Path: workflowPath, Source: source}, triggerErr)
 					_ = out.write(report)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -2363,26 +2363,19 @@ func triggerFailureProcessingReport(input workflowInput, err error) compatibilit
 	report := triggerProcessingReport(input.Path, input.Source)
 	var pathFilters *buildkitepipeline.UnsupportedPathFiltersError
 	if errors.As(err, &pathFilters) {
-		code, category := compiler.CodePipelineGeneration, "compatibility"
 		message := fmt.Sprintf("%s trigger path filters cannot be translated safely. Remove paths and paths-ignore from this trigger, or move the filtering into a job or step.", upperFirst(pathFilters.Event))
-		if pathFilters.Event == "pull_request" && pathFilters.Reason == "" {
-			code, category = compiler.CodeContextRequired, "context"
-			message = "Pull request path filters require linked Buildkite webhook data and a verified local git diff."
-			report.Result = "context-required"
-		} else if pathFilters.Reason != "" {
+		if pathFilters.Reason != "" {
 			message = fmt.Sprintf("%s trigger path filters could not be evaluated safely. Ensure the linked webhook and local checkout contain matching pull-request history, or remove the path filters.", upperFirst(pathFilters.Event))
 		}
 		err = &compiler.ProcessingFinding{
-			Stage: compiler.StagePipeline, Code: code, Category: category,
+			Stage: compiler.StagePipeline, Code: compiler.CodePipelineGeneration, Category: "compatibility",
 			Path: input.Path, Line: 1, Column: 1,
 			Message: message,
 			Detail:  pathFilters.Error(), Err: err,
 		}
 	}
 	report.AddFailure(input.Path, string(compiler.StagePipeline), compiler.CodePipelineGeneration, "compatibility", err)
-	if report.Result != "context-required" {
-		report.Result = "incompatible"
-	}
+	report.Result = "incompatible"
 	return report
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1436,6 +1436,30 @@ func TestRunValidateAndCompile(t *testing.T) {
 		}
 	})
 
+	t.Run("validate generated pull request still finds unsupported triggers", func(t *testing.T) {
+		for _, triggers := range []string{
+			"  pull_request:\n    paths: [src/**]\n  push:\n    paths: [docs/**]\n",
+			"  push:\n    paths: [docs/**]\n  pull_request:\n    paths: [src/**]\n",
+		} {
+			workflow := filepath.Join(t.TempDir(), "events.yml")
+			if err := os.WriteFile(workflow, []byte("on:\n"+triggers+"jobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			var stdout, stderr bytes.Buffer
+			args := []string{"validate", "--profile", "hosted", "--event", "pull_request", "--format", "json", workflow}
+			if code := Run(args, &stdout, &stderr, "dev"); code != 1 {
+				t.Fatalf("Run() code = %d, want 1; stderr = %q", code, stderr.String())
+			}
+			var report compatibility.ProcessingReport
+			if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+				t.Fatal(err)
+			}
+			if report.Result != "incompatible" || len(report.Diagnostics) != 1 || report.Diagnostics[0].Code != compiler.CodePipelineGeneration || !strings.Contains(report.Diagnostics[0].Message, "Push trigger path filters cannot be translated safely") {
+				t.Fatalf("processing report = %#v", report)
+			}
+		}
+	})
+
 	t.Run("validate generated pull request still finds body incompatibility", func(t *testing.T) {
 		workflow := filepath.Join(t.TempDir(), "events.yml")
 		if err := os.WriteFile(workflow, []byte("on:\n  pull_request:\n    paths: [src/**]\njobs:\n  test:\n    runs-on: windows-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1240,6 +1240,24 @@ func TestRunValidateAndCompile(t *testing.T) {
 		}
 	})
 
+	t.Run("bare validation requires pull request path context", func(t *testing.T) {
+		workflow := filepath.Join(t.TempDir(), "trigger.yml")
+		if err := os.WriteFile(workflow, []byte("on:\n  pull_request:\n    paths: [src/**]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		var stdout, stderr bytes.Buffer
+		if code := Run([]string{"validate", "--format", "json", workflow}, &stdout, &stderr, "dev"); code != 1 {
+			t.Fatalf("Run() code = %d, want 1; stderr = %q", code, stderr.String())
+		}
+		var report compatibility.ProcessingReport
+		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+			t.Fatal(err)
+		}
+		if report.Result != "incompatible" || len(report.Diagnostics) != 1 || report.Diagnostics[0].Code != compiler.CodeContextRequired {
+			t.Fatalf("report = %#v", report)
+		}
+	})
+
 	t.Run("validate json", func(t *testing.T) {
 		var stdout, stderr bytes.Buffer
 		if code := Run([]string{"validate", "--format", "json", workflowPath}, &stdout, &stderr, "dev"); code != 0 {
@@ -1367,6 +1385,73 @@ func TestRunValidateAndCompile(t *testing.T) {
 		}
 		if report.Result != "incompatible" || len(report.Evaluations) != 0 || len(report.Validation.Diagnostics) != 1 || !strings.Contains(report.Validation.Diagnostics[0].Message, "path filters are unsupported") {
 			t.Fatalf("aggregate report = %#v", report)
+		}
+	})
+
+	t.Run("validate all events leaves supported pull request paths unmeasured", func(t *testing.T) {
+		workflow := filepath.Join(t.TempDir(), "events.yml")
+		if err := os.WriteFile(workflow, []byte("on:\n  push:\n  pull_request:\n    paths: [src/**]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		var stdout, stderr bytes.Buffer
+		args := []string{"validate", "--profile", "hosted", "--all-events", "--format", "json", workflow}
+		if code := Run(args, &stdout, &stderr, "dev"); code != 1 {
+			t.Fatalf("Run() code = %d, want 1; stderr = %q", code, stderr.String())
+		}
+		var report compatibility.ProcessingReportV3
+		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+			t.Fatal(err)
+		}
+		if report.Result != "context-required" || report.Validation.Result != "context-required" || len(report.Evaluations) != 2 {
+			t.Fatalf("aggregate report = %#v", report)
+		}
+		if report.Evaluations[0].Event != "push" || report.Evaluations[0].Report.Result != "admitted" || report.Evaluations[1].Event != "pull_request" || report.Evaluations[1].Report.Result != "context-required" {
+			t.Fatalf("event evaluations = %#v", report.Evaluations)
+		}
+		if len(report.Validation.Diagnostics) != 1 || report.Validation.Diagnostics[0].Code != compiler.CodeContextRequired || !strings.Contains(report.Validation.Diagnostics[0].Message, "verified local git diff") {
+			t.Fatalf("validation diagnostics = %#v", report.Validation.Diagnostics)
+		}
+	})
+
+	t.Run("validate generated pull request leaves path filters unmeasured", func(t *testing.T) {
+		workflow := filepath.Join(t.TempDir(), "events.yml")
+		if err := os.WriteFile(workflow, []byte("on:\n  pull_request:\n    paths: [src/**]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		var stdout, stderr bytes.Buffer
+		args := []string{"validate", "--profile", "hosted", "--event", "pull_request", "--format", "json", workflow}
+		if code := Run(args, &stdout, &stderr, "dev"); code != 1 {
+			t.Fatalf("Run() code = %d, want 1; stderr = %q", code, stderr.String())
+		}
+		var report compatibility.ProcessingReport
+		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+			t.Fatal(err)
+		}
+		if report.Result != "context-required" || len(report.Diagnostics) != 1 || report.Diagnostics[0].Code != compiler.CodeContextRequired {
+			t.Fatalf("processing report = %#v", report)
+		}
+	})
+
+	t.Run("validate all events keeps mixed push and pull request paths incompatible", func(t *testing.T) {
+		workflow := filepath.Join(t.TempDir(), "events.yml")
+		if err := os.WriteFile(workflow, []byte("on:\n  pull_request:\n    paths: [src/**]\n  push:\n    paths: [docs/**]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		var stdout, stderr bytes.Buffer
+		args := []string{"validate", "--profile", "hosted", "--all-events", "--format", "json", workflow}
+		if code := Run(args, &stdout, &stderr, "dev"); code != 1 {
+			t.Fatalf("Run() code = %d, want 1; stderr = %q", code, stderr.String())
+		}
+		var report compatibility.ProcessingReportV3
+		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+			t.Fatal(err)
+		}
+		if report.Result != "incompatible" || len(report.Evaluations) != 0 || len(report.Validation.Diagnostics) != 2 {
+			t.Fatalf("aggregate report = %#v", report)
+		}
+		codes := []string{report.Validation.Diagnostics[0].Code, report.Validation.Diagnostics[1].Code}
+		if !slices.Contains(codes, compiler.CodeContextRequired) || !slices.Contains(codes, compiler.CodePipelineGeneration) {
+			t.Fatalf("validation diagnostic codes = %v", codes)
 		}
 	})
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1240,20 +1240,20 @@ func TestRunValidateAndCompile(t *testing.T) {
 		}
 	})
 
-	t.Run("bare validation requires pull request path context", func(t *testing.T) {
+	t.Run("bare validation accepts supported pull request paths", func(t *testing.T) {
 		workflow := filepath.Join(t.TempDir(), "trigger.yml")
 		if err := os.WriteFile(workflow, []byte("on:\n  pull_request:\n    paths: [src/**]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
 			t.Fatal(err)
 		}
 		var stdout, stderr bytes.Buffer
-		if code := Run([]string{"validate", "--format", "json", workflow}, &stdout, &stderr, "dev"); code != 1 {
-			t.Fatalf("Run() code = %d, want 1; stderr = %q", code, stderr.String())
+		if code := Run([]string{"validate", "--format", "json", workflow}, &stdout, &stderr, "dev"); code != 0 {
+			t.Fatalf("Run() code = %d, stderr = %q", code, stderr.String())
 		}
 		var report compatibility.ProcessingReport
 		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 			t.Fatal(err)
 		}
-		if report.Result != "incompatible" || len(report.Diagnostics) != 1 || report.Diagnostics[0].Code != compiler.CodeContextRequired {
+		if report.Result != "compilable" || len(report.Diagnostics) != 0 {
 			t.Fatalf("report = %#v", report)
 		}
 	})
@@ -1402,14 +1402,15 @@ func TestRunValidateAndCompile(t *testing.T) {
 		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 			t.Fatal(err)
 		}
-		if report.Result != "context-required" || report.Validation.Result != "context-required" || len(report.Evaluations) != 2 {
+		if report.Result != "context-required" || report.Validation.Result != "compilable" || len(report.Validation.Diagnostics) != 0 || len(report.Evaluations) != 2 {
 			t.Fatalf("aggregate report = %#v", report)
 		}
 		if report.Evaluations[0].Event != "push" || report.Evaluations[0].Report.Result != "admitted" || report.Evaluations[1].Event != "pull_request" || report.Evaluations[1].Report.Result != "context-required" {
 			t.Fatalf("event evaluations = %#v", report.Evaluations)
 		}
-		if len(report.Validation.Diagnostics) != 1 || report.Validation.Diagnostics[0].Code != compiler.CodeContextRequired || !strings.Contains(report.Validation.Diagnostics[0].Message, "verified local git diff") {
-			t.Fatalf("validation diagnostics = %#v", report.Validation.Diagnostics)
+		pullRequest := report.Evaluations[1].Report
+		if pullRequest.Compile.Result != "compilable" || pullRequest.Admission.Result != compatibility.NotEvaluated || len(pullRequest.Diagnostics) != 1 || pullRequest.Diagnostics[0].Code != compiler.CodeContextRequired || !strings.Contains(pullRequest.Diagnostics[0].Message, "verified local git diff") {
+			t.Fatalf("pull request evaluation = %#v", pullRequest)
 		}
 	})
 
@@ -1430,6 +1431,28 @@ func TestRunValidateAndCompile(t *testing.T) {
 		if report.Result != "context-required" || len(report.Diagnostics) != 1 || report.Diagnostics[0].Code != compiler.CodeContextRequired {
 			t.Fatalf("processing report = %#v", report)
 		}
+		if report.Compile.Result != "compilable" || report.Admission.Result != compatibility.NotEvaluated {
+			t.Fatalf("processing stages = compile %#v, admission %#v", report.Compile, report.Admission)
+		}
+	})
+
+	t.Run("validate generated pull request still finds body incompatibility", func(t *testing.T) {
+		workflow := filepath.Join(t.TempDir(), "events.yml")
+		if err := os.WriteFile(workflow, []byte("on:\n  pull_request:\n    paths: [src/**]\njobs:\n  test:\n    runs-on: windows-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		var stdout, stderr bytes.Buffer
+		args := []string{"validate", "--profile", "hosted", "--event", "pull_request", "--format", "json", workflow}
+		if code := Run(args, &stdout, &stderr, "dev"); code != 1 {
+			t.Fatalf("Run() code = %d, want 1; stderr = %q", code, stderr.String())
+		}
+		var report compatibility.ProcessingReport
+		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+			t.Fatal(err)
+		}
+		if report.Result != "incompatible" || len(report.Diagnostics) != 1 || report.Diagnostics[0].Code == compiler.CodeContextRequired || !strings.Contains(report.Diagnostics[0].Message, "Windows") {
+			t.Fatalf("processing report = %#v", report)
+		}
 	})
 
 	t.Run("validate all events keeps mixed push and pull request paths incompatible", func(t *testing.T) {
@@ -1446,12 +1469,11 @@ func TestRunValidateAndCompile(t *testing.T) {
 		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 			t.Fatal(err)
 		}
-		if report.Result != "incompatible" || len(report.Evaluations) != 0 || len(report.Validation.Diagnostics) != 2 {
+		if report.Result != "incompatible" || len(report.Evaluations) != 0 || len(report.Validation.Diagnostics) != 1 {
 			t.Fatalf("aggregate report = %#v", report)
 		}
-		codes := []string{report.Validation.Diagnostics[0].Code, report.Validation.Diagnostics[1].Code}
-		if !slices.Contains(codes, compiler.CodeContextRequired) || !slices.Contains(codes, compiler.CodePipelineGeneration) {
-			t.Fatalf("validation diagnostic codes = %v", codes)
+		if report.Validation.Diagnostics[0].Code != compiler.CodePipelineGeneration {
+			t.Fatalf("validation diagnostics = %#v", report.Validation.Diagnostics)
 		}
 	})
 

--- a/internal/compatibility/report_test.go
+++ b/internal/compatibility/report_test.go
@@ -28,6 +28,10 @@ func TestProcessingReportContainsEveryStableStageInTextAndJSON(t *testing.T) {
 		Stage: "action-resolution", Message: "action metadata is invalid; update the action", Detail: "unsupported runtime node12", Job: "test", Instance: "gha-test", Action: "./.github/actions/test", Step: 1,
 		Location: &SourceLocation{Path: "ci.yml", Line: 8, Column: 9},
 	})
+	report.Diagnostics = append(report.Diagnostics, Diagnostic{
+		Level: "error", Code: "E_CONTEXT_REQUIRED", Category: "context",
+		Stage: "hosted-profile-admission", Message: "linked webhook context is required",
+	})
 
 	var encoded bytes.Buffer
 	if err := WriteProcessing(&encoded, "json", report); err != nil {

--- a/internal/compatibility/report_test.go
+++ b/internal/compatibility/report_test.go
@@ -173,7 +173,7 @@ func TestProcessingReportV3PreservesPerEventOutcomes(t *testing.T) {
 
 func TestProcessingReportV3ClassifiesContextRequiredWithoutHidingIncompatibility(t *testing.T) {
 	validation := NewProcessingReport("ci.yml", "")
-	validation.Result = "context-required"
+	validation.Result = "compilable"
 	contextRequired := NewProcessingReport("ci.yml", "hosted")
 	contextRequired.Result = "context-required"
 	report := NewProcessingReportV3("ci.yml", "hosted", validation)
@@ -193,6 +193,17 @@ func TestProcessingReportV3ClassifiesContextRequiredWithoutHidingIncompatibility
 	report.Finalize()
 	if report.Result != "incompatible" {
 		t.Fatalf("mixed report result = %q", report.Result)
+	}
+
+	notAdmitted := NewProcessingReport("ci.yml", "hosted")
+	notAdmitted.Result = "not-admitted"
+	report.Evaluations = []EventEvaluation{
+		{Event: "pull_request", Source: "generated", Report: contextRequired},
+		{Event: "push", Source: "generated", Report: notAdmitted},
+	}
+	report.Finalize()
+	if report.Result != "not-admitted" {
+		t.Fatalf("context-required and not-admitted report result = %q", report.Result)
 	}
 }
 

--- a/internal/compatibility/report_test.go
+++ b/internal/compatibility/report_test.go
@@ -171,6 +171,31 @@ func TestProcessingReportV3PreservesPerEventOutcomes(t *testing.T) {
 	}
 }
 
+func TestProcessingReportV3ClassifiesContextRequiredWithoutHidingIncompatibility(t *testing.T) {
+	validation := NewProcessingReport("ci.yml", "")
+	validation.Result = "context-required"
+	contextRequired := NewProcessingReport("ci.yml", "hosted")
+	contextRequired.Result = "context-required"
+	report := NewProcessingReportV3("ci.yml", "hosted", validation)
+	report.Evaluations = append(report.Evaluations, EventEvaluation{
+		Event: "pull_request", Source: "generated", Report: contextRequired,
+	})
+	report.Finalize()
+	if report.Result != "context-required" {
+		t.Fatalf("context-required report result = %q", report.Result)
+	}
+
+	incompatible := NewProcessingReport("ci.yml", "hosted")
+	incompatible.Result = "incompatible"
+	report.Evaluations = append(report.Evaluations, EventEvaluation{
+		Event: "push", Source: "generated", Report: incompatible,
+	})
+	report.Finalize()
+	if report.Result != "incompatible" {
+		t.Fatalf("mixed report result = %q", report.Result)
+	}
+}
+
 func TestProcessingReportV1RemainsStrictWithoutDetail(t *testing.T) {
 	report := NewProcessingReport("ci.yml", "")
 	report.Diagnostics = append(report.Diagnostics, Diagnostic{

--- a/internal/compatibility/report_v3.go
+++ b/internal/compatibility/report_v3.go
@@ -68,11 +68,11 @@ func (r *ProcessingReportV3) Finalize() {
 				r.Result = "incompatible"
 			}
 		case "context-required":
-			if r.Result == "admitted" || r.Result == "not-admitted" {
+			if r.Result == "admitted" {
 				r.Result = "context-required"
 			}
 		case "not-admitted":
-			if r.Result == "admitted" {
+			if r.Result == "admitted" || r.Result == "context-required" {
 				r.Result = "not-admitted"
 			}
 		case "admitted":

--- a/internal/compatibility/report_v3.go
+++ b/internal/compatibility/report_v3.go
@@ -41,10 +41,12 @@ func NewProcessingReportV3(workflow, profile string, validation ProcessingReport
 
 // Finalize derives the aggregate outcome without merging event-specific
 // evidence. Admission means every generated event evaluation was admitted.
+// Context-required means the generated inputs could not measure a supported
+// admission path that requires repository evidence.
 func (r *ProcessingReportV3) Finalize() {
 	r.Validation.Finalize()
 	r.Status = r.Validation.Status
-	if r.Validation.Result != "compilable" {
+	if r.Validation.Result != "compilable" && r.Validation.Result != "context-required" {
 		r.Result = r.Validation.Result
 		return
 	}
@@ -64,6 +66,10 @@ func (r *ProcessingReportV3) Finalize() {
 		case "incompatible":
 			if r.Result != "indeterminate" {
 				r.Result = "incompatible"
+			}
+		case "context-required":
+			if r.Result == "admitted" || r.Result == "not-admitted" {
+				r.Result = "context-required"
 			}
 		case "not-admitted":
 			if r.Result == "admitted" {

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -213,7 +213,7 @@ func Validate(path string, source []byte) (Report, error) {
 	if err != nil {
 		return Report{}, processingFinding(StageWorkflowParsing, CodeWorkflowSyntax, "syntax", err)
 	}
-	triggerErr := processingFinding(StagePipeline, CodePipelineGeneration, "compatibility", buildkitepipeline.ValidateTriggerConditions(parsed.Triggers))
+	triggerErr := triggerValidationFinding(buildkitepipeline.ValidateTriggerConditions(parsed.Triggers))
 	options := defaultOptions()
 	event := Event{
 		Event: "validation", Trust: options.EventTrust,
@@ -233,6 +233,25 @@ func Validate(path string, source []byte) (Report, error) {
 		return expansionReport(expanded, compilerWarnings(parsed.Concurrency, cancelInProgress)), err
 	}
 	return expansionReport(expanded, compilerWarnings(parsed.Concurrency, cancelInProgress)), nil
+}
+
+func triggerValidationFinding(err error) error {
+	if err == nil {
+		return nil
+	}
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		children := joined.Unwrap()
+		findings := make([]error, 0, len(children))
+		for _, child := range children {
+			findings = append(findings, triggerValidationFinding(child))
+		}
+		return errors.Join(findings...)
+	}
+	var contextRequired *buildkitepipeline.PathFilterContextRequiredError
+	if errors.As(err, &contextRequired) {
+		return processingFinding(StagePipeline, CodeContextRequired, "context", err)
+	}
+	return processingFinding(StagePipeline, CodePipelineGeneration, "compatibility", err)
 }
 
 // ValidateEvent validates both the supported static graph and its event input.

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -213,7 +213,7 @@ func Validate(path string, source []byte) (Report, error) {
 	if err != nil {
 		return Report{}, processingFinding(StageWorkflowParsing, CodeWorkflowSyntax, "syntax", err)
 	}
-	triggerErr := triggerValidationFinding(buildkitepipeline.ValidateTriggerConditions(parsed.Triggers))
+	triggerErr := processingFinding(StagePipeline, CodePipelineGeneration, "compatibility", buildkitepipeline.ValidateTriggerConditions(parsed.Triggers))
 	options := defaultOptions()
 	event := Event{
 		Event: "validation", Trust: options.EventTrust,
@@ -233,25 +233,6 @@ func Validate(path string, source []byte) (Report, error) {
 		return expansionReport(expanded, compilerWarnings(parsed.Concurrency, cancelInProgress)), err
 	}
 	return expansionReport(expanded, compilerWarnings(parsed.Concurrency, cancelInProgress)), nil
-}
-
-func triggerValidationFinding(err error) error {
-	if err == nil {
-		return nil
-	}
-	if joined, ok := err.(interface{ Unwrap() []error }); ok {
-		children := joined.Unwrap()
-		findings := make([]error, 0, len(children))
-		for _, child := range children {
-			findings = append(findings, triggerValidationFinding(child))
-		}
-		return errors.Join(findings...)
-	}
-	var contextRequired *buildkitepipeline.PathFilterContextRequiredError
-	if errors.As(err, &contextRequired) {
-		return processingFinding(StagePipeline, CodeContextRequired, "context", err)
-	}
-	return processingFinding(StagePipeline, CodePipelineGeneration, "compatibility", err)
 }
 
 // ValidateEvent validates both the supported static graph and its event input.

--- a/internal/compiler/processing.go
+++ b/internal/compiler/processing.go
@@ -29,6 +29,7 @@ const (
 	CodeActionResolution   = "E_ACTION_RESOLUTION"
 	CodePlanConstruction   = "E_PLAN_CONSTRUCTION"
 	CodePipelineGeneration = "E_PIPELINE_GENERATION"
+	CodeContextRequired    = "E_CONTEXT_REQUIRED"
 	CodeEnvironment        = "E_ENVIRONMENT"
 )
 

--- a/schemas/processing-report-v2.schema.json
+++ b/schemas/processing-report-v2.schema.json
@@ -101,7 +101,7 @@
       "properties": {
         "level": {"enum": ["error", "warning"]},
         "code": {"type": "string", "pattern": "^[EW]_[A-Z0-9_]+$"},
-        "category": {"enum": ["syntax", "compatibility", "action-resolution", "environment", "admission"]},
+        "category": {"enum": ["syntax", "compatibility", "action-resolution", "environment", "admission", "context"]},
         "stage": {"$ref": "#/$defs/stageID"},
         "message": {"type": "string", "minLength": 1, "maxLength": 16384},
         "detail": {"type": "string", "minLength": 1, "maxLength": 16384},

--- a/scripts/validate-public-workflow-corpus
+++ b/scripts/validate-public-workflow-corpus
@@ -306,10 +306,12 @@ with open(os.environ["manifest"], encoding="utf-8") as manifest:
         record = json.loads(line)
         repositories[record["source"]] = record["repository"]
 
-blocked_repos = set()
+incompatible_repos = set()
+context_required_repos = set()
 codes_by_repo = collections.defaultdict(set)
 findings = collections.Counter()
 evaluations = collections.Counter()
+workflow_results = collections.Counter()
 seen_workflows = set()
 bad_reports = 0
 for path in glob.glob(os.path.join(os.environ["reports"], "**", "*.json"), recursive=True):
@@ -332,12 +334,16 @@ for path in glob.glob(os.path.join(os.environ["reports"], "**", "*.json"), recur
         or not isinstance(result.get("evaluations"), list)
     ):
         bad_reports += 1
-        blocked_repos.add(repository)
+        incompatible_repos.add(repository)
         codes_by_repo[repository].add("E_REPORT")
         findings["E_REPORT"] += 1
         continue
-    if result.get("result") not in ("admitted", "not-applicable"):
-        blocked_repos.add(repository)
+    workflow_result = result.get("result")
+    workflow_results[workflow_result or "missing"] += 1
+    if workflow_result == "context-required":
+        context_required_repos.add(repository)
+    elif workflow_result not in ("admitted", "not-applicable"):
+        incompatible_repos.add(repository)
     reports = [("validation", result["validation"])]
     seen_events = set()
     for evaluation in result["evaluations"]:
@@ -350,7 +356,7 @@ for path in glob.glob(os.path.join(os.environ["reports"], "**", "*.json"), recur
             or not isinstance(evaluation.get("report"), dict)
         ):
             bad_reports += 1
-            blocked_repos.add(repository)
+            incompatible_repos.add(repository)
             codes_by_repo[repository].add("E_REPORT")
             findings["E_REPORT"] += 1
             reports = []
@@ -361,7 +367,7 @@ for path in glob.glob(os.path.join(os.environ["reports"], "**", "*.json"), recur
     for _, report in reports:
         if report.get("schema") != "buildkite-gha/processing-report/v2":
             bad_reports += 1
-            blocked_repos.add(repository)
+            incompatible_repos.add(repository)
             codes_by_repo[repository].add("E_REPORT")
             findings["E_REPORT"] += 1
             break
@@ -374,17 +380,26 @@ for path in glob.glob(os.path.join(os.environ["reports"], "**", "*.json"), recur
 for workflow in repositories.keys() - seen_workflows:
     repository = repositories[workflow]
     bad_reports += 1
-    blocked_repos.add(repository)
+    incompatible_repos.add(repository)
     codes_by_repo[repository].add("E_REPORT")
     findings["E_REPORT"] += 1
 
 all_repos = set(repositories.values())
-clean = len(all_repos - blocked_repos)
+context_required_only = context_required_repos - incompatible_repos
+compatible_repos = all_repos - incompatible_repos - context_required_only
+measured = len(all_repos) - len(context_required_only)
+compatible = len(compatible_repos)
+compatible_percent = 100 * compatible / measured if measured else 0
 print(
-    f"repos: {len(all_repos):,}   clean: {clean:,} "
-    f"({100 * clean / len(all_repos):.2f}%)   unparseable reports: {bad_reports:,}"
+    f"repos: {len(all_repos):,}   measured: {measured:,}   "
+    f"compatible: {compatible:,} ({compatible_percent:.2f}% of measured)   "
+    f"context required: {len(context_required_only):,}   "
+    f"incompatible: {len(incompatible_repos):,}   unparseable reports: {bad_reports:,}"
 )
 print("admission scope: generated event snapshots, not arbitrary real payloads")
+print("workflow results: " + ", ".join(
+    f"{result}={count:,}" for result, count in sorted(workflow_results.items())
+))
 print("\ndiagnostic code -> repos affected")
 repos_by_code = collections.Counter(
     code for codes in codes_by_repo.values() for code in codes
@@ -394,7 +409,10 @@ for code, count in repos_by_code.most_common(40):
 
 tally = {
     "repos": len(all_repos),
-    "clean": clean,
+    "measured_repos": measured,
+    "compatible_repos": compatible,
+    "context_required_repos": len(context_required_only),
+    "incompatible_repos": len(incompatible_repos),
     "validator_commit": os.environ["validator_commit"],
     "validator_version": os.environ["validator_version"],
     "validator_digest": "sha256:" + os.environ["validator_digest"],
@@ -402,6 +420,7 @@ tally = {
     "by_repo": dict(repos_by_code),
     "by_finding": dict(findings),
     "evaluations": dict(evaluations),
+    "workflow_results": dict(workflow_results),
     "unparseable_reports": bad_reports,
 }
 if os.environ["sample_key"] != "full":

--- a/scripts/validate-public-workflow-corpus
+++ b/scripts/validate-public-workflow-corpus
@@ -306,8 +306,7 @@ with open(os.environ["manifest"], encoding="utf-8") as manifest:
         record = json.loads(line)
         repositories[record["source"]] = record["repository"]
 
-incompatible_repos = set()
-context_required_repos = set()
+results_by_repo = collections.defaultdict(set)
 codes_by_repo = collections.defaultdict(set)
 findings = collections.Counter()
 evaluations = collections.Counter()
@@ -334,16 +333,24 @@ for path in glob.glob(os.path.join(os.environ["reports"], "**", "*.json"), recur
         or not isinstance(result.get("evaluations"), list)
     ):
         bad_reports += 1
-        incompatible_repos.add(repository)
+        results_by_repo[repository].add("indeterminate")
         codes_by_repo[repository].add("E_REPORT")
         findings["E_REPORT"] += 1
+        workflow_results["invalid-report"] += 1
         continue
     workflow_result = result.get("result")
     workflow_results[workflow_result or "missing"] += 1
-    if workflow_result == "context-required":
-        context_required_repos.add(repository)
-    elif workflow_result not in ("admitted", "not-applicable"):
-        incompatible_repos.add(repository)
+    if workflow_result in (
+        "admitted",
+        "not-applicable",
+        "context-required",
+        "incompatible",
+        "not-admitted",
+        "indeterminate",
+    ):
+        results_by_repo[repository].add(workflow_result)
+    else:
+        results_by_repo[repository].add("indeterminate")
     reports = [("validation", result["validation"])]
     seen_events = set()
     for evaluation in result["evaluations"]:
@@ -356,7 +363,7 @@ for path in glob.glob(os.path.join(os.environ["reports"], "**", "*.json"), recur
             or not isinstance(evaluation.get("report"), dict)
         ):
             bad_reports += 1
-            incompatible_repos.add(repository)
+            results_by_repo[repository].add("indeterminate")
             codes_by_repo[repository].add("E_REPORT")
             findings["E_REPORT"] += 1
             reports = []
@@ -367,7 +374,7 @@ for path in glob.glob(os.path.join(os.environ["reports"], "**", "*.json"), recur
     for _, report in reports:
         if report.get("schema") != "buildkite-gha/processing-report/v2":
             bad_reports += 1
-            incompatible_repos.add(repository)
+            results_by_repo[repository].add("indeterminate")
             codes_by_repo[repository].add("E_REPORT")
             findings["E_REPORT"] += 1
             break
@@ -380,21 +387,35 @@ for path in glob.glob(os.path.join(os.environ["reports"], "**", "*.json"), recur
 for workflow in repositories.keys() - seen_workflows:
     repository = repositories[workflow]
     bad_reports += 1
-    incompatible_repos.add(repository)
+    results_by_repo[repository].add("indeterminate")
     codes_by_repo[repository].add("E_REPORT")
     findings["E_REPORT"] += 1
+    workflow_results["missing"] += 1
 
 all_repos = set(repositories.values())
-context_required_only = context_required_repos - incompatible_repos
-compatible_repos = all_repos - incompatible_repos - context_required_only
-measured = len(all_repos) - len(context_required_only)
-compatible = len(compatible_repos)
+repo_results = collections.Counter()
+for repository in all_repos:
+    outcomes = results_by_repo[repository]
+    if "incompatible" in outcomes:
+        repo_results["incompatible"] += 1
+    elif "not-admitted" in outcomes:
+        repo_results["not-admitted"] += 1
+    elif "indeterminate" in outcomes:
+        repo_results["indeterminate"] += 1
+    elif "context-required" in outcomes:
+        repo_results["context-required"] += 1
+    else:
+        repo_results["compatible"] += 1
+measured = sum(repo_results[result] for result in ("compatible", "incompatible", "not-admitted"))
+compatible = repo_results["compatible"]
 compatible_percent = 100 * compatible / measured if measured else 0
 print(
     f"repos: {len(all_repos):,}   measured: {measured:,}   "
     f"compatible: {compatible:,} ({compatible_percent:.2f}% of measured)   "
-    f"context required: {len(context_required_only):,}   "
-    f"incompatible: {len(incompatible_repos):,}   unparseable reports: {bad_reports:,}"
+    f"context required: {repo_results['context-required']:,}   "
+    f"indeterminate: {repo_results['indeterminate']:,}   "
+    f"incompatible: {repo_results['incompatible']:,}   "
+    f"not admitted: {repo_results['not-admitted']:,}   unparseable reports: {bad_reports:,}"
 )
 print("admission scope: generated event snapshots, not arbitrary real payloads")
 print("workflow results: " + ", ".join(
@@ -411,8 +432,10 @@ tally = {
     "repos": len(all_repos),
     "measured_repos": measured,
     "compatible_repos": compatible,
-    "context_required_repos": len(context_required_only),
-    "incompatible_repos": len(incompatible_repos),
+    "context_required_repos": repo_results["context-required"],
+    "indeterminate_repos": repo_results["indeterminate"],
+    "incompatible_repos": repo_results["incompatible"],
+    "not_admitted_repos": repo_results["not-admitted"],
     "validator_commit": os.environ["validator_commit"],
     "validator_version": os.environ["validator_version"],
     "validator_digest": "sha256:" + os.environ["validator_digest"],


### PR DESCRIPTION
## Why

The generated-event public workflow benchmark has no repository checkout or git diff, so it cannot exercise production support for pull-request path filters. Treating that missing evidence as incompatibility inflates the incompatible count, while treating it as admission would overclaim what the benchmark proved.

## What

Accept syntactically valid pull-request path filters during event-independent validation. Hosted generated-event validation now continues compilation, action resolution, plan construction, and policy checks, then reports `context-required` only when a linked webhook and verified local diff are the sole missing admission evidence. Genuine push path filters, malformed filters, and other workflow failures remain incompatible.

The corpus tally excludes context-required and indeterminate repositories from its measured compatibility denominator, keeps incompatible and not-admitted outcomes distinct, and preserves complete per-workflow diagnostics.
