### PR TITLE
Make background task lifecycle explicit

### DIFF
--- a/internal/runtime/concurrent.go
+++ b/internal/runtime/concurrent.go
@@ -23,6 +23,15 @@ type stepExecution struct {
 	conclusion string
 }
 
+type backgroundTaskState uint8
+
+const (
+	backgroundTaskQueued backgroundTaskState = iota
+	backgroundTaskRunning
+	backgroundTaskFinished
+	backgroundTaskCommitted
+)
+
 type backgroundTask struct {
 	id     string
 	ctx    context.Context
@@ -32,9 +41,18 @@ type backgroundTask struct {
 	// cancelled may run while the supervisor mutex is held and must not block.
 	cancelled func(context.Context) stepExecution
 	execution stepExecution
-	started   bool
-	finished  bool
-	committed bool
+	// state is protected by the supervisor mutex.
+	state backgroundTaskState
+}
+
+func (task *backgroundTask) transitionLocked(next backgroundTaskState) {
+	valid := task.state == backgroundTaskQueued && (next == backgroundTaskRunning || next == backgroundTaskFinished) ||
+		task.state == backgroundTaskRunning && next == backgroundTaskFinished ||
+		task.state == backgroundTaskFinished && next == backgroundTaskCommitted
+	if !valid {
+		panic(fmt.Sprintf("invalid background task transition %d -> %d", task.state, next))
+	}
+	task.state = next
 }
 
 // backgroundSupervisor owns private task admission and completion state. It
@@ -72,7 +90,7 @@ func (s *backgroundSupervisor) dispatchLocked() {
 			s.finishLocked(task, task.cancelled(task.ctx))
 			continue
 		}
-		task.started = true
+		task.transitionLocked(backgroundTaskRunning)
 		s.active++
 		go func() {
 			execution := task.run(task.ctx)
@@ -87,7 +105,7 @@ func (s *backgroundSupervisor) dispatchLocked() {
 
 func (s *backgroundSupervisor) finishLocked(task *backgroundTask, execution stepExecution) {
 	task.execution = execution
-	task.finished = true
+	task.transitionLocked(backgroundTaskFinished)
 	task.cancel(nil)
 	close(task.done)
 }
@@ -95,12 +113,12 @@ func (s *backgroundSupervisor) finishLocked(task *backgroundTask, execution step
 func (s *backgroundSupervisor) cancel(target string) []stepExecution {
 	s.mu.Lock()
 	task := s.tasks[strings.ToLower(target)]
-	if task == nil || task.committed {
+	if task == nil || task.state == backgroundTaskCommitted {
 		s.mu.Unlock()
 		return nil
 	}
 	task.cancel(errExplicitBackgroundCancel)
-	if !task.started && !task.finished {
+	if task.state == backgroundTaskQueued {
 		for i, queued := range s.queue {
 			if queued == task {
 				s.queue = append(s.queue[:i], s.queue[i+1:]...)
@@ -118,7 +136,7 @@ func (s *backgroundSupervisor) wait(targets []string) []stepExecution {
 	tasks := make([]*backgroundTask, 0, len(targets))
 	for _, target := range targets {
 		task := s.tasks[strings.ToLower(target)]
-		if task != nil && !task.committed {
+		if task != nil && task.state != backgroundTaskCommitted {
 			tasks = append(tasks, task)
 		}
 	}
@@ -130,7 +148,7 @@ func (s *backgroundSupervisor) waitAll() []stepExecution {
 	s.mu.Lock()
 	tasks := make([]*backgroundTask, 0, len(s.order))
 	for _, task := range s.order {
-		if !task.committed {
+		if task.state != backgroundTaskCommitted {
 			tasks = append(tasks, task)
 		}
 	}
@@ -146,10 +164,10 @@ func (s *backgroundSupervisor) commitCompleted(tasks []*backgroundTask) []stepEx
 	defer s.mu.Unlock()
 	executions := make([]stepExecution, 0, len(tasks))
 	for _, task := range tasks {
-		if task.committed {
+		if task.state == backgroundTaskCommitted {
 			continue
 		}
-		task.committed = true
+		task.transitionLocked(backgroundTaskCommitted)
 		executions = append(executions, task.execution)
 	}
 	return executions

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1824,6 +1824,87 @@ func TestStepNameFailsClosedOnUnavailableBackgroundOutput(t *testing.T) {
 	}
 }
 
+func TestBackgroundTaskLifecycleTransitions(t *testing.T) {
+	states := []struct {
+		name  string
+		state backgroundTaskState
+	}{
+		{name: "queued", state: backgroundTaskQueued},
+		{name: "running", state: backgroundTaskRunning},
+		{name: "finished", state: backgroundTaskFinished},
+		{name: "committed", state: backgroundTaskCommitted},
+	}
+	valid := map[[2]backgroundTaskState]bool{
+		{backgroundTaskQueued, backgroundTaskRunning}:     true,
+		{backgroundTaskQueued, backgroundTaskFinished}:    true,
+		{backgroundTaskRunning, backgroundTaskFinished}:   true,
+		{backgroundTaskFinished, backgroundTaskCommitted}: true,
+	}
+
+	for _, from := range states {
+		for _, to := range states {
+			t.Run(from.name+"-to-"+to.name, func(t *testing.T) {
+				task := backgroundTask{state: from.state}
+				var panicked bool
+				func() {
+					defer func() { panicked = recover() != nil }()
+					task.transitionLocked(to.state)
+				}()
+
+				if valid[[2]backgroundTaskState{from.state, to.state}] {
+					if panicked || task.state != to.state {
+						t.Fatalf("transition %d -> %d: state = %d, panicked = %v", from.state, to.state, task.state, panicked)
+					}
+				} else if !panicked || task.state != from.state {
+					t.Fatalf("invalid transition %d -> %d: state = %d, panicked = %v", from.state, to.state, task.state, panicked)
+				}
+			})
+		}
+	}
+}
+
+func TestBackgroundSupervisorCommitsCompletedTaskExactlyOnceUnderContention(t *testing.T) {
+	supervisor := newBackgroundSupervisor(1)
+	task := &backgroundTask{
+		done:      make(chan struct{}),
+		execution: stepExecution{step: plan.Step{ID: "only"}},
+		state:     backgroundTaskFinished,
+	}
+	close(task.done)
+
+	const callers = 32
+	start := make(chan struct{})
+	results := make(chan []stepExecution, callers)
+	var group sync.WaitGroup
+	for range callers {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			<-start
+			results <- supervisor.commitCompleted([]*backgroundTask{task})
+		}()
+	}
+	close(start)
+	group.Wait()
+	close(results)
+
+	commits := 0
+	for executions := range results {
+		commits += len(executions)
+		if len(executions) == 1 && executions[0].step.ID != "only" {
+			t.Fatalf("committed execution ID = %q, want only", executions[0].step.ID)
+		}
+	}
+	if commits != 1 {
+		t.Fatalf("commits = %d, want 1", commits)
+	}
+	supervisor.mu.Lock()
+	defer supervisor.mu.Unlock()
+	if task.state != backgroundTaskCommitted {
+		t.Fatalf("state = %d, want committed", task.state)
+	}
+}
+
 func TestBackgroundSupervisorBoundsActiveWorkAndQueuesFIFO(t *testing.T) {
 	supervisor := newBackgroundSupervisor(maxActiveBackgroundSteps)
 	release := make(chan struct{})


### PR DESCRIPTION
## Why

Background tasks track lifecycle with three booleans whose combinations can represent invalid states and obscure cancellation and commit invariants.

## What

Replace the booleans with one private, mutex-protected lifecycle state that allows only queued, running, finished, and committed transitions. Keep completion synchronization, context cancellation, dispatch ordering, and the supervisor call surface unchanged.

Add focused coverage for valid and impossible transitions and exactly-once commit under concurrent barriers.