### PR TITLE
Use one completed-step runtime record

### DIFF
--- a/internal/expression/expression.go
+++ b/internal/expression/expression.go
@@ -33,8 +33,7 @@ type Expression struct {
 	Span Span   `json:"span"`
 }
 
-// StepStatus contains the values exposed for one completed step while
-// evaluating a condition.
+// StepStatus contains the runtime values exposed for one completed step.
 type StepStatus struct {
 	Outcome    string
 	Conclusion string

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -310,12 +310,11 @@ func TestEvaluateActionInputDefaultMatchesGitHubEqualityAndTemplateBoundaries(t 
 func TestEvaluateIsSinglePass(t *testing.T) {
 	literal := "literal ${{ matrix.secret }} and ${{"
 	context := Context{
-		Inputs:       map[string]string{"value": literal},
-		Matrix:       map[string]any{"value": literal, "secret": "reevaluated", "number": json.Number("1e3")},
-		Steps:        map[string]map[string]string{"producer": {"value": literal}},
-		StepStatuses: map[string]StepStatus{"producer": {Outcome: "failure", Conclusion: "success"}},
-		Needs:        map[string]map[string]string{"producer": {"value": literal}},
-		NeedResults:  map[string]string{"producer": "success"},
+		Inputs:      map[string]string{"value": literal},
+		Matrix:      map[string]any{"value": literal, "secret": "reevaluated", "number": json.Number("1e3")},
+		Steps:       map[string]StepStatus{"producer": {Outcome: "failure", Conclusion: "success", Outputs: map[string]string{"value": literal}}},
+		Needs:       map[string]map[string]string{"producer": {"value": literal}},
+		NeedResults: map[string]string{"producer": "success"},
 	}
 	tests := map[string]string{
 		"${{ inputs.value }}":                 literal,
@@ -599,11 +598,10 @@ func TestHashFilesIsLimitedToStepRuntimeExpressions(t *testing.T) {
 
 func TestEvaluateStepSupportsCompoundRuntimeExpressions(t *testing.T) {
 	context := Context{
-		Matrix:       map[string]any{"os": "linux", "versions": []any{1, 2}},
-		Vars:         map[string]string{"PREFIX": "release"},
-		Env:          map[string]string{"KEY": "os"},
-		Steps:        map[string]map[string]string{"build": {"image": "app:v1"}},
-		StepStatuses: map[string]StepStatus{"build": {Outcome: "success", Conclusion: "success"}},
+		Matrix: map[string]any{"os": "linux", "versions": []any{1, 2}},
+		Vars:   map[string]string{"PREFIX": "release"},
+		Env:    map[string]string{"KEY": "os"},
+		Steps:  map[string]StepStatus{"build": {Outcome: "success", Conclusion: "success", Outputs: map[string]string{"image": "app:v1"}}},
 	}
 	template := "${{ format('{0}-{1}-{2}', vars.PREFIX, matrix[env.KEY], join(matrix.versions, '.')) }}:${{ matrix.missing || steps.build.outputs.image }}"
 	got, err := EvaluateStep(template, context)
@@ -660,7 +658,7 @@ func TestEvaluateJobSurfacesSupportAuthorizedCompoundExpressions(t *testing.T) {
 		Needs:       map[string]map[string]string{"build": {"tag": "v1"}},
 		NeedResults: map[string]string{"build": "success"},
 		Secrets:     map[string]string{"TOKEN": "secret"},
-		Steps:       map[string]map[string]string{"build": {"image": "app:v1"}},
+		Steps:       map[string]StepStatus{"build": {Outputs: map[string]string{"image": "app:v1"}}},
 		Vars:        map[string]string{"PREFIX": "release"},
 		Env:         map[string]string{"ROOT": "src"},
 	}
@@ -686,7 +684,7 @@ func TestEvaluateJobSurfacesFailClosed(t *testing.T) {
 	context := Context{
 		GitHub: map[string]any{"token": "secret"},
 		Env:    map[string]string{"KEY": "TOKEN"},
-		Steps:  map[string]map[string]string{"build": {"value": "ok"}},
+		Steps:  map[string]StepStatus{"build": {Outputs: map[string]string{"value": "ok"}}},
 	}
 	tests := []struct {
 		name     string

--- a/internal/expression/runtime.go
+++ b/internal/expression/runtime.go
@@ -12,13 +12,12 @@ import (
 	"github.com/rhysd/actionlint"
 )
 
-// Context contains the compile-time values available while evaluating a template.
+// Context contains the runtime values available while evaluating a template.
 type Context struct {
 	Inputs           map[string]string
 	WorkflowInputs   map[string]any
 	Matrix           map[string]any
-	Steps            map[string]map[string]string
-	StepStatuses     map[string]StepStatus
+	Steps            map[string]StepStatus
 	Needs            map[string]map[string]string
 	NeedResults      map[string]string
 	Secrets          map[string]string
@@ -456,16 +455,8 @@ func resolveStepRuntimeRoot(root string, context Context) (any, error) {
 		return map[string]any{"services": services}, nil
 	case "steps":
 		steps := make(map[string]any)
-		for name, outputs := range context.Steps {
-			steps[name] = map[string]any{"outputs": outputs}
-		}
-		for name, status := range context.StepStatuses {
-			step, _ := steps[name].(map[string]any)
-			if step == nil {
-				step = map[string]any{"outputs": map[string]string{}}
-				steps[name] = step
-			}
-			step["outcome"], step["conclusion"] = status.Outcome, status.Conclusion
+		for name, step := range context.Steps {
+			steps[name] = map[string]any{"outputs": step.Outputs, "outcome": step.Outcome, "conclusion": step.Conclusion}
 		}
 		return steps, nil
 	case "needs":
@@ -579,24 +570,20 @@ func resolveRuntimeReferenceValue(root string, path []string, context Context, a
 	case runtimeReferenceEnv:
 		return findString(context.Env, path[0]), nil
 	case runtimeReferenceStepOutput:
-		outputs, ok := findOutputs(context.Steps, path[0])
+		step, ok := findStepStatus(context.Steps, path[0])
 		if !ok {
 			return "", fmt.Errorf("expression references unavailable step %q", path[0])
 		}
-		return findString(outputs, path[2]), nil
+		return findString(step.Outputs, path[2]), nil
 	case runtimeReferenceStepStatus:
-		for candidate, status := range context.StepStatuses {
-			if !strings.EqualFold(candidate, path[0]) {
-				continue
-			}
-			switch {
-			case strings.EqualFold(path[1], "outcome"):
-				return status.Outcome, nil
-			case strings.EqualFold(path[1], "conclusion"):
-				return status.Conclusion, nil
-			}
+		step, ok := findStepStatus(context.Steps, path[0])
+		if !ok {
+			return "", fmt.Errorf("expression references unavailable step %q", path[0])
 		}
-		return "", fmt.Errorf("expression references unavailable step %q", path[0])
+		if strings.EqualFold(path[1], "outcome") {
+			return step.Outcome, nil
+		}
+		return step.Conclusion, nil
 	case runtimeReferenceNeedOutput:
 		outputs, ok := findOutputs(context.Needs, path[0])
 		if !ok {
@@ -688,6 +675,15 @@ func findStringValue(values map[string]string, name string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+func findStepStatus(values map[string]StepStatus, name string) (StepStatus, bool) {
+	for candidate, status := range values {
+		if strings.EqualFold(candidate, name) {
+			return status, true
+		}
+	}
+	return StepStatus{}, false
 }
 
 func findOutputs(values map[string]map[string]string, name string) (map[string]string, bool) {

--- a/internal/runtime/concurrent.go
+++ b/internal/runtime/concurrent.go
@@ -229,20 +229,14 @@ func cancelledStepExecution(jobCtx, runCtx context.Context, step plan.Step) step
 	return classifyStepExecution(jobCtx, runCtx, step, newResult(), err)
 }
 
-func commitStepExecution(execution stepExecution, jobResult *JobResult, eval *expression.Context, statuses map[string]expression.StepStatus) error {
+func commitStepExecution(execution stepExecution, jobResult *JobResult, eval *expression.Context) error {
 	id := strings.ToLower(execution.step.ID)
-	eval.Steps[id] = execution.result.Outputs
+	eval.Steps[id] = expression.StepStatus{Outcome: execution.outcome, Conclusion: execution.conclusion, Outputs: execution.result.Outputs}
 	commitResultEnvironment(jobResult.Env, execution.result)
 	eval.Env = jobResult.Env
 	mergeInto(jobResult.State, execution.result.State)
 	appendJobSummary(&jobResult.Summary, &jobResult.summaryTruncated, execution.result.Summary, execution.result.summaryTruncated)
 	jobResult.Artifacts = append(jobResult.Artifacts, execution.result.Artifacts...)
-	status := expression.StepStatus{Outcome: execution.outcome, Conclusion: execution.conclusion, Outputs: execution.result.Outputs}
-	statuses[id] = status
-	if eval.StepStatuses == nil {
-		eval.StepStatuses = make(map[string]expression.StepStatus)
-	}
-	eval.StepStatuses[id] = status
 	if execution.conclusion != "success" {
 		return fmt.Errorf("step %q: %w", execution.step.ID, execution.err)
 	}
@@ -272,8 +266,7 @@ func cloneExpressionContext(in expression.Context) expression.Context {
 		Inputs:           inputs,
 		WorkflowInputs:   cloneAnyMap(in.WorkflowInputs),
 		Matrix:           cloneAnyMap(in.Matrix),
-		Steps:            cloneNestedStrings(in.Steps),
-		StepStatuses:     cloneStepStatuses(in.StepStatuses),
+		Steps:            cloneStepStatuses(in.Steps),
 		Needs:            cloneNestedStrings(in.Needs),
 		NeedResults:      cloneStrings(in.NeedResults),
 		Secrets:          cloneStrings(in.Secrets),

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -354,8 +354,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 	eval := expression.Context{
 		WorkflowInputs: job.Inputs,
 		Matrix:         job.Matrix,
-		Steps:          make(map[string]map[string]string, len(job.Steps)),
-		StepStatuses:   make(map[string]expression.StepStatus, len(job.Steps)),
+		Steps:          make(map[string]expression.StepStatus, len(job.Steps)),
 		Needs:          needOutputs(job.Needs),
 		NeedResults:    needResults(job.Needs),
 		Vars:           job.Vars,
@@ -615,7 +614,6 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 	}
 	eval.Env = jobResult.Env
 	var posts postRegistry
-	statuses := eval.StepStatuses
 	supervisor := newBackgroundSupervisor(maxActiveBackgroundSteps)
 
 	var runErr error
@@ -686,13 +684,12 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		eval.JobStatus = jobStatusValue(runErr != nil, runCtx.Err() != nil)
 		if step.Kind == "cancel" {
 			for _, execution := range supervisor.cancel(step.Targets[0]) {
-				targetErr := commitStepExecution(execution, &jobResult, &eval, statuses)
+				targetErr := commitStepExecution(execution, &jobResult, &eval)
 				if execution.conclusion != "cancelled" {
 					runErr = errors.Join(runErr, targetErr)
 				}
 			}
-			statuses[strings.ToLower(step.ID)] = expression.StepStatus{Outcome: "success", Conclusion: "success", Outputs: map[string]string{}}
-			eval.Steps[strings.ToLower(step.ID)] = map[string]string{}
+			eval.Steps[strings.ToLower(step.ID)] = expression.StepStatus{Outcome: "success", Conclusion: "success", Outputs: map[string]string{}}
 			continue
 		}
 		if step.Kind == "wait" || step.Kind == "wait-all" {
@@ -704,7 +701,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 			}
 			var barrierErr error
 			for _, execution := range completed {
-				barrierErr = errors.Join(barrierErr, commitStepExecution(execution, &jobResult, &eval, statuses))
+				barrierErr = errors.Join(barrierErr, commitStepExecution(execution, &jobResult, &eval))
 			}
 			outcome, conclusion := "success", "success"
 			if barrierErr != nil {
@@ -715,23 +712,21 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 				conclusion = outcome
 				runErr = errors.Join(runErr, fmt.Errorf("step %q: %w", step.ID, barrierErr))
 			}
-			statuses[strings.ToLower(step.ID)] = expression.StepStatus{Outcome: outcome, Conclusion: conclusion, Outputs: map[string]string{}}
-			eval.Steps[strings.ToLower(step.ID)] = map[string]string{}
+			eval.Steps[strings.ToLower(step.ID)] = expression.StepStatus{Outcome: outcome, Conclusion: conclusion, Outputs: map[string]string{}}
 			continue
 		}
 		if execution, ok := preFailures[stepIndex]; ok {
-			runErr = errors.Join(runErr, commitStepExecution(execution, &jobResult, &eval, statuses))
+			runErr = errors.Join(runErr, commitStepExecution(execution, &jobResult, &eval))
 			continue
 		}
 		referencesStatus, err := expression.ReferencesStatusFunction(step.Condition)
 		if err != nil {
 			execution := classifyStepExecution(ctx, runCtx, step, newResult(), fmt.Errorf("condition: %w", err))
-			runErr = errors.Join(runErr, commitStepExecution(execution, &jobResult, &eval, statuses))
+			runErr = errors.Join(runErr, commitStepExecution(execution, &jobResult, &eval))
 			continue
 		}
 		if !referencesStatus && (runErr != nil || runCtx.Err() != nil) {
-			statuses[strings.ToLower(step.ID)] = expression.StepStatus{Outcome: "skipped", Conclusion: "skipped", Outputs: map[string]string{}}
-			eval.Steps[strings.ToLower(step.ID)] = map[string]string{}
+			eval.Steps[strings.ToLower(step.ID)] = expression.StepStatus{Outcome: "skipped", Conclusion: "skipped", Outputs: map[string]string{}}
 			continue
 		}
 		evaluationCtx, cancelEvaluation := stepContext(runCtx, step.TimeoutMinutes)
@@ -741,29 +736,28 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		if err != nil {
 			execution := classifyStepExecutionWithControls(ctx, evaluationCtx, step, newResult(), fmt.Errorf("environment: %w", err), stepEval)
 			cancelEvaluation()
-			runErr = errors.Join(runErr, commitStepExecution(execution, &jobResult, &eval, statuses))
+			runErr = errors.Join(runErr, commitStepExecution(execution, &jobResult, &eval))
 			continue
 		}
 		stepEval.Env = mergeStringMaps(stepEval.Env, stepEnv)
-		condition := expression.ConditionContext{Inputs: job.Inputs, Needs: eval.Needs, NeedResults: eval.NeedResults, Steps: statuses, Env: stepEval.Env, Vars: job.Vars, Matrix: job.Matrix, GitHub: eval.GitHub, Runner: eval.Runner, Services: eval.Services, Failure: runErr != nil && runCtx.Err() == nil, Unsuccessful: runErr != nil, Cancelled: evaluationCtx.Err() != nil, HashFiles: stepEval.HashFiles}
+		condition := expression.ConditionContext{Inputs: job.Inputs, Needs: eval.Needs, NeedResults: eval.NeedResults, Steps: eval.Steps, Env: stepEval.Env, Vars: job.Vars, Matrix: job.Matrix, GitHub: eval.GitHub, Runner: eval.Runner, Services: eval.Services, Failure: runErr != nil && runCtx.Err() == nil, Unsuccessful: runErr != nil, Cancelled: evaluationCtx.Err() != nil, HashFiles: stepEval.HashFiles}
 		run, err := expression.EvaluateCondition(step.Condition, condition)
 		if err != nil {
 			execution := classifyStepExecutionWithControls(ctx, evaluationCtx, step, newResult(), fmt.Errorf("condition: %w", err), stepEval)
 			cancelEvaluation()
-			runErr = errors.Join(runErr, commitStepExecution(execution, &jobResult, &eval, statuses))
+			runErr = errors.Join(runErr, commitStepExecution(execution, &jobResult, &eval))
 			continue
 		}
 		if !run {
 			cancelEvaluation()
-			statuses[strings.ToLower(step.ID)] = expression.StepStatus{Outcome: "skipped", Conclusion: "skipped", Outputs: map[string]string{}}
-			eval.Steps[strings.ToLower(step.ID)] = map[string]string{}
+			eval.Steps[strings.ToLower(step.ID)] = expression.StepStatus{Outcome: "skipped", Conclusion: "skipped", Outputs: map[string]string{}}
 			continue
 		}
 		step, err = evaluateStepTimeout(step, stepEval)
 		if err != nil {
 			execution := classifyStepExecutionWithControls(ctx, evaluationCtx, step, newResult(), fmt.Errorf("controls: %w", err), stepEval)
 			cancelEvaluation()
-			runErr = errors.Join(runErr, commitStepExecution(execution, &jobResult, &eval, statuses))
+			runErr = errors.Join(runErr, commitStepExecution(execution, &jobResult, &eval))
 			continue
 		}
 		cancelEvaluation()
@@ -773,7 +767,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		if err != nil {
 			execution := classifyStepExecutionWithControls(ctx, stepCtx, step, newResult(), fmt.Errorf("name: %w", err), stepEval)
 			cancelStep()
-			runErr = errors.Join(runErr, commitStepExecution(execution, &jobResult, &eval, statuses))
+			runErr = errors.Join(runErr, commitStepExecution(execution, &jobResult, &eval))
 			continue
 		}
 
@@ -803,10 +797,10 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 			processor.expandCurrentSection()
 			jobResult.failureVisible = true
 		}
-		runErr = errors.Join(runErr, commitStepExecution(execution, &jobResult, &eval, statuses))
+		runErr = errors.Join(runErr, commitStepExecution(execution, &jobResult, &eval))
 	}
 	for _, execution := range supervisor.waitAll() {
-		runErr = errors.Join(runErr, commitStepExecution(execution, &jobResult, &eval, statuses))
+		runErr = errors.Join(runErr, commitStepExecution(execution, &jobResult, &eval))
 	}
 	if runCtx.Err() != nil {
 		runErr = errors.Join(runErr, runCtx.Err())
@@ -2037,9 +2031,7 @@ func (r Runner) runCompositeMetadata(ctx context.Context, processor *commandProc
 	eval.HashFiles = nil
 	eval.HashFilesContext = nil
 	eval.Inputs = inputs
-	eval.Steps = make(map[string]map[string]string)
-	eval.StepStatuses = make(map[string]expression.StepStatus)
-	statuses := eval.StepStatuses
+	eval.Steps = make(map[string]expression.StepStatus)
 	compositeProcessEnv := mergeStepEnvironment(jobEnv, stepEnv)
 	compositeProcessEnv["GITHUB_ACTION_PATH"] = actionPath
 	compositeExpressionEnv := mergeStringMaps(eval.Env, stepEnv)
@@ -2061,7 +2053,7 @@ func (r Runner) runCompositeMetadata(ctx context.Context, processor *commandProc
 		for name, value := range eval.Inputs {
 			inputs[name] = value
 		}
-		condition := expression.ConditionContext{Inputs: inputs, Needs: eval.Needs, NeedResults: eval.NeedResults, Steps: statuses, Env: eval.Env, Vars: eval.Vars, Matrix: eval.Matrix, GitHub: eval.GitHub, Runner: eval.Runner, Services: eval.Services, Failure: failure, Unsuccessful: unsuccessful, Cancelled: cancelled}
+		condition := expression.ConditionContext{Inputs: inputs, Needs: eval.Needs, NeedResults: eval.NeedResults, Steps: eval.Steps, Env: eval.Env, Vars: eval.Vars, Matrix: eval.Matrix, GitHub: eval.GitHub, Runner: eval.Runner, Services: eval.Services, Failure: failure, Unsuccessful: unsuccessful, Cancelled: cancelled}
 		run, err := expression.EvaluateCondition(step.If, condition)
 		if err != nil {
 			runErr = errors.Join(runErr, fmt.Errorf("composite action step %d condition: %w", i+1, err))
@@ -2069,8 +2061,7 @@ func (r Runner) runCompositeMetadata(ctx context.Context, processor *commandProc
 		}
 		if !run {
 			if id != "" {
-				eval.Steps[id] = map[string]string{}
-				statuses[id] = expression.StepStatus{Outcome: "skipped", Conclusion: "skipped", Outputs: map[string]string{}}
+				eval.Steps[id] = expression.StepStatus{Outcome: "skipped", Conclusion: "skipped", Outputs: map[string]string{}}
 			}
 			continue
 		}
@@ -2130,12 +2121,11 @@ func (r Runner) runCompositeMetadata(ctx context.Context, processor *commandProc
 		mergeInto(result.State, stepResult.State)
 		appendJobSummary(&result.Summary, &result.summaryTruncated, stepResult.Summary, stepResult.summaryTruncated)
 		if id != "" {
-			eval.Steps[id] = stepResult.Outputs
 			outcome := "success"
 			if childErr != nil {
 				outcome = "failure"
 			}
-			statuses[id] = expression.StepStatus{Outcome: outcome, Conclusion: outcome, Outputs: stepResult.Outputs}
+			eval.Steps[id] = expression.StepStatus{Outcome: outcome, Conclusion: outcome, Outputs: stepResult.Outputs}
 		}
 		if childErr != nil {
 			runErr = errors.Join(runErr, fmt.Errorf("composite action step %d: %w", i+1, childErr))

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1351,10 +1351,9 @@ func TestBackgroundSummariesAreBoundedInCommitOrder(t *testing.T) {
 	)
 
 	jobResult := JobResult{Env: map[string]string{}, State: map[string]string{}}
-	eval := expression.Context{Steps: map[string]map[string]string{}}
-	statuses := map[string]expression.StepStatus{}
+	eval := expression.Context{Steps: map[string]expression.StepStatus{}}
 	for _, execution := range supervisor.waitAll() {
-		if err := commitStepExecution(execution, &jobResult, &eval, statuses); err != nil {
+		if err := commitStepExecution(execution, &jobResult, &eval); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -1370,6 +1369,26 @@ func TestBackgroundSummariesAreBoundedInCommitOrder(t *testing.T) {
 	wantPrefix := strings.Repeat("a", summaryBytes) + strings.Repeat("b", len(prefix)-summaryBytes)
 	if prefix != wantPrefix {
 		t.Fatalf("summary did not preserve commit order")
+	}
+}
+
+func TestCloneExpressionContextDeepCopiesStepOutputs(t *testing.T) {
+	source := expression.Context{Steps: map[string]expression.StepStatus{
+		"build": {Outcome: "success", Conclusion: "success", Outputs: map[string]string{"result": "source"}},
+	}}
+
+	cloned := cloneExpressionContext(source)
+	status := cloned.Steps["build"]
+	status.Outcome = "failure"
+	status.Outputs["result"] = "clone"
+	cloned.Steps["build"] = status
+	cloned.Steps["added"] = expression.StepStatus{}
+
+	if got := source.Steps["build"]; got.Outcome != "success" || got.Outputs["result"] != "source" {
+		t.Fatalf("source step changed through clone: %#v", got)
+	}
+	if _, ok := source.Steps["added"]; ok {
+		t.Fatal("source steps map changed through clone")
 	}
 }
 
@@ -1695,7 +1714,7 @@ func TestSkippedBackgroundAndRepeatedWaitAreCommittedAtMostOnce(t *testing.T) {
 		{ID: "first-wait", Kind: "wait", Targets: []string{"completed"}},
 		{ID: "cancel-completed", Kind: "cancel", Targets: []string{"completed"}},
 		{ID: "second-wait", Kind: "wait", Targets: []string{"completed"}},
-		{ID: "verify", Kind: "run", Condition: "steps.skipped.conclusion == 'skipped' && steps.cancel-skipped.conclusion == 'success' && steps.cancel-completed.conclusion == 'success'", Command: "true"},
+		{ID: "verify", Kind: "run", Condition: "steps.skipped.conclusion == 'skipped' && steps.skipped.outputs.missing == '' && steps.cancel-skipped.conclusion == 'success' && steps.cancel-skipped.outputs.missing == '' && steps.wait-skipped.conclusion == 'success' && steps.wait-skipped.outputs.missing == '' && steps.first-wait.outputs.missing == '' && steps.cancel-completed.conclusion == 'success' && steps.cancel-completed.outputs.missing == '' && steps.second-wait.outputs.missing == ''", Command: "true"},
 	})
 
 	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
@@ -5452,7 +5471,7 @@ runs:
       shell: sh
       run: touch "$SHOULD_NOT_RUN"
     - id: observed
-      if: failure() && steps.failed.outcome == 'failure'
+      if: failure() && steps.failed.outcome == 'failure' && steps.skipped.outcome == 'skipped' && steps.skipped.outputs.missing == ''
       shell: sh
       run: touch "$STATUS_RAN"
     - id: cleanup


### PR DESCRIPTION
## Why

Runtime expression evaluation stores completed-step outputs and outcome/conclusion in parallel maps. Every completion path must update both representations, which obscures ownership and allows the values to diverge.

## What

Use `expression.StepStatus` records in `expression.Context.Steps` as the single source for direct references, whole `steps` objects, conditions, controls, background barriers, and composite children. Keep `Context` and `ConditionContext` phase-specific while preserving case-insensitive lookup, missing-value behavior, continue-on-error semantics, barrier visibility, and composite isolation.

Deep-copy step output maps in context clones, with focused coverage for skipped and control records and composite child state. An Oracle review traced the ordinary, skipped, control, background, composite, and continue-on-error paths and found no behavior change.
