### PR TITLE
Use one prerequisite expression record

### DIFF
--- a/internal/expression/condition.go
+++ b/internal/expression/condition.go
@@ -13,8 +13,7 @@ import (
 // job or step condition.
 type ConditionContext struct {
 	Inputs       map[string]any
-	Needs        map[string]map[string]string
-	NeedResults  map[string]string
+	Needs        map[string]NeedStatus
 	Steps        map[string]StepStatus
 	Env          map[string]string
 	Vars         map[string]string
@@ -433,13 +432,8 @@ func resolveConditionRoot(root string, context ConditionContext) (any, error) {
 		return context.Env, nil
 	case "needs":
 		needs := make(map[string]any)
-		for name, outputs := range context.Needs {
-			needs[name] = map[string]any{"outputs": outputs, "result": context.NeedResults[name]}
-		}
-		for name, result := range context.NeedResults {
-			if _, ok := needs[name]; !ok {
-				needs[name] = map[string]any{"outputs": map[string]string{}, "result": result}
-			}
+		for name, status := range context.Needs {
+			needs[name] = map[string]any{"outputs": status.Outputs, "result": status.Result}
 		}
 		return needs, nil
 	case "steps":
@@ -542,14 +536,12 @@ func resolveConditionReference(root string, path []string, context ConditionCont
 		}
 		return nil, nil
 	case len(path) == 2 && strings.EqualFold(root, "needs") && strings.EqualFold(path[1], "result"):
-		for name, result := range context.NeedResults {
-			if strings.EqualFold(name, path[0]) {
-				return result, nil
-			}
+		if status, ok := findNeedStatus(context.Needs, path[0]); ok {
+			return status.Result, nil
 		}
 	case len(path) == 3 && strings.EqualFold(root, "needs") && strings.EqualFold(path[1], "outputs"):
-		if outputs, ok := findOutputs(context.Needs, path[0]); ok {
-			return findString(outputs, path[2]), nil
+		if status, ok := findNeedStatus(context.Needs, path[0]); ok {
+			return findString(status.Outputs, path[2]), nil
 		}
 	case len(path) == 2 && strings.EqualFold(root, "steps"):
 		for name, step := range context.Steps {

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -310,11 +310,10 @@ func TestEvaluateActionInputDefaultMatchesGitHubEqualityAndTemplateBoundaries(t 
 func TestEvaluateIsSinglePass(t *testing.T) {
 	literal := "literal ${{ matrix.secret }} and ${{"
 	context := Context{
-		Inputs:      map[string]string{"value": literal},
-		Matrix:      map[string]any{"value": literal, "secret": "reevaluated", "number": json.Number("1e3")},
-		Steps:       map[string]StepStatus{"producer": {Outcome: "failure", Conclusion: "success", Outputs: map[string]string{"value": literal}}},
-		Needs:       map[string]map[string]string{"producer": {"value": literal}},
-		NeedResults: map[string]string{"producer": "success"},
+		Inputs: map[string]string{"value": literal},
+		Matrix: map[string]any{"value": literal, "secret": "reevaluated", "number": json.Number("1e3")},
+		Steps:  map[string]StepStatus{"producer": {Outcome: "failure", Conclusion: "success", Outputs: map[string]string{"value": literal}}},
+		Needs:  map[string]NeedStatus{"producer": {Outputs: map[string]string{"value": literal}, Result: "success"}},
 	}
 	tests := map[string]string{
 		"${{ inputs.value }}":                 literal,
@@ -654,15 +653,14 @@ func TestExpressionMapProjectionIsDeterministic(t *testing.T) {
 
 func TestEvaluateJobSurfacesSupportAuthorizedCompoundExpressions(t *testing.T) {
 	context := Context{
-		GitHub:      map[string]any{"ref": "refs/heads/main"},
-		Inputs:      map[string]string{"suffix": "prod"},
-		Matrix:      map[string]any{"os": "linux"},
-		Needs:       map[string]map[string]string{"build": {"tag": "v1"}},
-		NeedResults: map[string]string{"build": "success"},
-		Secrets:     map[string]string{"TOKEN": "secret"},
-		Steps:       map[string]StepStatus{"build": {Outputs: map[string]string{"image": "app:v1"}}},
-		Vars:        map[string]string{"PREFIX": "release"},
-		Env:         map[string]string{"ROOT": "src"},
+		GitHub:  map[string]any{"ref": "refs/heads/main"},
+		Inputs:  map[string]string{"suffix": "prod"},
+		Matrix:  map[string]any{"os": "linux"},
+		Needs:   map[string]NeedStatus{"build": {Outputs: map[string]string{"tag": "v1"}, Result: "success"}},
+		Secrets: map[string]string{"TOKEN": "secret"},
+		Steps:   map[string]StepStatus{"build": {Outputs: map[string]string{"image": "app:v1"}}},
+		Vars:    map[string]string{"PREFIX": "release"},
+		Env:     map[string]string{"ROOT": "src"},
 	}
 
 	jobEnv := "${{ format('{0}-{1}-{2}', vars.PREFIX, matrix.os, inputs.suffix) }}:${{ needs.build.outputs.tag }}"
@@ -867,6 +865,29 @@ func TestEvaluateFailsClosed(t *testing.T) {
 	}
 }
 
+func TestEvaluateNeedLookupDistinguishesMissingNeedAndOutput(t *testing.T) {
+	needs := map[string]NeedStatus{
+		"build": {Outputs: map[string]string{"release": "v1"}, Result: "success"},
+	}
+	context := Context{Needs: needs}
+	if got, err := Evaluate("${{ needs.BUILD.outputs.RELEASE }}", context); err != nil || got != "v1" {
+		t.Fatalf("case-insensitive need output = %q, %v, want v1", got, err)
+	}
+	if got, err := Evaluate("${{ needs.BUILD.outputs.missing }}", context); err != nil || got != "" {
+		t.Fatalf("missing output = %q, %v, want empty value", got, err)
+	}
+	if _, err := Evaluate("${{ needs.missing.outputs.release }}", context); err == nil {
+		t.Fatal("missing need output did not fail")
+	}
+	condition := ConditionContext{Needs: needs}
+	if got, err := EvaluateCondition("needs.BUILD.result == 'success' && needs.BUILD.outputs.MISSING == ''", condition); err != nil || !got {
+		t.Fatalf("condition need lookup = %v, %v, want true", got, err)
+	}
+	if _, err := EvaluateCondition("needs.missing.result", condition); err == nil {
+		t.Fatal("missing condition need did not fail")
+	}
+}
+
 func TestEvaluateActionLifecycleCondition(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -922,11 +943,10 @@ func TestEvaluateActionLifecycleCondition(t *testing.T) {
 
 func TestEvaluateConditionStatusOutputsAndTruthiness(t *testing.T) {
 	context := ConditionContext{
-		Inputs:      map[string]any{"enabled": "true"},
-		Needs:       map[string]map[string]string{"build": {"gate": "yes"}},
-		NeedResults: map[string]string{"build": "failure"},
-		Steps:       map[string]StepStatus{"soft": {Outcome: "failure", Conclusion: "success", Outputs: map[string]string{"ready": "true"}}},
-		Failure:     true,
+		Inputs:  map[string]any{"enabled": "true"},
+		Needs:   map[string]NeedStatus{"build": {Outputs: map[string]string{"gate": "yes"}, Result: "failure"}},
+		Steps:   map[string]StepStatus{"soft": {Outcome: "failure", Conclusion: "success", Outputs: map[string]string{"ready": "true"}}},
+		Failure: true,
 	}
 	for _, condition := range []string{
 		"inputs.enabled == 'true'",
@@ -1137,9 +1157,11 @@ func TestEvaluateConditionSupportsIndexesFiltersAndWholeContexts(t *testing.T) {
 			"object": map[string]any{"true": "boolean", "2": "number"},
 			"items":  []any{[]any{"first"}, []any{}, []any{nil}},
 		},
-		Needs:       map[string]map[string]string{"build": {}, "lint": {}},
-		NeedResults: map[string]string{"build": "success", "lint": "failure"},
-		Env:         map[string]string{"STEP": "build"},
+		Needs: map[string]NeedStatus{
+			"build": {Outputs: map[string]string{}, Result: "success"},
+			"lint":  {Outputs: map[string]string{}, Result: "failure"},
+		},
+		Env: map[string]string{"STEP": "build"},
 		Steps: map[string]StepStatus{
 			"build": {Outcome: "success", Conclusion: "success"},
 			"lint":  {Outcome: "failure", Conclusion: "success"},

--- a/internal/expression/runtime.go
+++ b/internal/expression/runtime.go
@@ -12,14 +12,19 @@ import (
 	"github.com/rhysd/actionlint"
 )
 
+// NeedStatus contains the expression-visible state of one prerequisite.
+type NeedStatus struct {
+	Outputs map[string]string
+	Result  string
+}
+
 // Context contains the runtime values available while evaluating a template.
 type Context struct {
 	Inputs           map[string]string
 	WorkflowInputs   map[string]any
 	Matrix           map[string]any
 	Steps            map[string]StepStatus
-	Needs            map[string]map[string]string
-	NeedResults      map[string]string
+	Needs            map[string]NeedStatus
 	Secrets          map[string]string
 	Vars             map[string]string
 	Env              map[string]string
@@ -461,13 +466,8 @@ func resolveStepRuntimeRoot(root string, context Context) (any, error) {
 		return steps, nil
 	case "needs":
 		needs := make(map[string]any)
-		for name, outputs := range context.Needs {
-			needs[name] = map[string]any{"outputs": outputs, "result": context.NeedResults[name]}
-		}
-		for name, result := range context.NeedResults {
-			if _, ok := needs[name]; !ok {
-				needs[name] = map[string]any{"outputs": map[string]string{}, "result": result}
-			}
+		for name, status := range context.Needs {
+			needs[name] = map[string]any{"outputs": status.Outputs, "result": status.Result}
 		}
 		return needs, nil
 	default:
@@ -585,16 +585,14 @@ func resolveRuntimeReferenceValue(root string, path []string, context Context, a
 		}
 		return step.Conclusion, nil
 	case runtimeReferenceNeedOutput:
-		outputs, ok := findOutputs(context.Needs, path[0])
+		status, ok := findNeedStatus(context.Needs, path[0])
 		if !ok {
 			return "", fmt.Errorf("expression references unavailable need %q", path[0])
 		}
-		return findString(outputs, path[2]), nil
+		return findString(status.Outputs, path[2]), nil
 	case runtimeReferenceNeedResult:
-		for candidate, result := range context.NeedResults {
-			if strings.EqualFold(candidate, path[0]) {
-				return result, nil
-			}
+		if status, ok := findNeedStatus(context.Needs, path[0]); ok {
+			return status.Result, nil
 		}
 		return "", fmt.Errorf("expression references unavailable need %q", path[0])
 	default:
@@ -686,11 +684,11 @@ func findStepStatus(values map[string]StepStatus, name string) (StepStatus, bool
 	return StepStatus{}, false
 }
 
-func findOutputs(values map[string]map[string]string, name string) (map[string]string, bool) {
-	for candidate, outputs := range values {
+func findNeedStatus(values map[string]NeedStatus, name string) (NeedStatus, bool) {
+	for candidate, status := range values {
 		if strings.EqualFold(candidate, name) {
-			return outputs, true
+			return status, true
 		}
 	}
-	return nil, false
+	return NeedStatus{}, false
 }

--- a/internal/runtime/concurrent.go
+++ b/internal/runtime/concurrent.go
@@ -267,8 +267,7 @@ func cloneExpressionContext(in expression.Context) expression.Context {
 		WorkflowInputs:   cloneAnyMap(in.WorkflowInputs),
 		Matrix:           cloneAnyMap(in.Matrix),
 		Steps:            cloneStepStatuses(in.Steps),
-		Needs:            cloneNestedStrings(in.Needs),
-		NeedResults:      cloneStrings(in.NeedResults),
+		Needs:            cloneNeedStatuses(in.Needs),
 		Secrets:          cloneStrings(in.Secrets),
 		Vars:             cloneStrings(in.Vars),
 		Env:              cloneStrings(in.Env),
@@ -302,10 +301,11 @@ func cloneStepStatuses(in map[string]expression.StepStatus) map[string]expressio
 	return out
 }
 
-func cloneNestedStrings(in map[string]map[string]string) map[string]map[string]string {
-	out := make(map[string]map[string]string, len(in))
-	for name, values := range in {
-		out[name] = cloneStrings(values)
+func cloneNeedStatuses(in map[string]expression.NeedStatus) map[string]expression.NeedStatus {
+	out := make(map[string]expression.NeedStatus, len(in))
+	for name, status := range in {
+		status.Outputs = cloneStrings(status.Outputs)
+		out[name] = status
 	}
 	return out
 }

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -1061,9 +1061,9 @@ func TestEvaluateServicesResolvesNeedsAndSkipsEmptyImages(t *testing.T) {
 		},
 		"optional": {Image: "${{ needs.build.outputs.optional }}"},
 	}
-	got, err := evaluateServices(services, expression.Context{Needs: map[string]map[string]string{"build": {
+	got, err := evaluateServices(services, expression.Context{Needs: map[string]expression.NeedStatus{"build": {Outputs: map[string]string{
 		"version": "16", "source": "runtime", "port": "5432", "target": "/data", "setting": "fsync=off", "entrypoint": "docker-entrypoint.sh", "optional": "",
-	}}})
+	}}}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1077,7 +1077,7 @@ func TestEvaluateServicesResolvesNeedsAndSkipsEmptyImages(t *testing.T) {
 }
 
 func TestEvaluateServiceMapExpression(t *testing.T) {
-	eval := expression.Context{Needs: map[string]map[string]string{"build": {"services": `{"database":{"image":"postgres:16","env":{"MODE":"test","RETRIES":3.0,"NEGATIVE_ZERO":-0,"ENABLED":true},"ports":[5.432e3],"volumes":[2],"options":1e20,"command":1e2,"entrypoint":false},"cache":"redis:7"}`}}}
+	eval := expression.Context{Needs: map[string]expression.NeedStatus{"build": {Outputs: map[string]string{"services": `{"database":{"image":"postgres:16","env":{"MODE":"test","RETRIES":3.0,"NEGATIVE_ZERO":-0,"ENABLED":true},"ports":[5.432e3],"volumes":[2],"options":1e20,"command":1e2,"entrypoint":false},"cache":"redis:7"}`}}}}
 	got, order, err := evaluateServiceMap(nil, nil, "${{ fromJSON(needs.build.outputs.services) }}", eval)
 	if err != nil {
 		t.Fatal(err)
@@ -1106,7 +1106,7 @@ func TestEvaluateServiceMapExpressionRejectsUnsafeShapes(t *testing.T) {
 		{name: "nested expression", value: `{"db":{"image":"redis:7","options":"--label token=${{ secrets.TOKEN }}"}}`, want: "retains a runtime template"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			_, _, err := evaluateServiceMap(nil, nil, "${{ fromJSON(needs.build.outputs.services) }}", expression.Context{Needs: map[string]map[string]string{"build": {"services": test.value}}})
+			_, _, err := evaluateServiceMap(nil, nil, "${{ fromJSON(needs.build.outputs.services) }}", expression.Context{Needs: map[string]expression.NeedStatus{"build": {Outputs: map[string]string{"services": test.value}}}})
 			if err == nil || !strings.Contains(err.Error(), test.want) {
 				t.Fatalf("error = %v, want %q", err, test.want)
 			}
@@ -1115,7 +1115,7 @@ func TestEvaluateServiceMapExpressionRejectsUnsafeShapes(t *testing.T) {
 }
 
 func TestEvaluateServicesDoesNotHideErrorsBehindEmptyImage(t *testing.T) {
-	_, err := evaluateServices(map[string]plan.Container{"optional": {Image: "${{ needs.build.outputs.image }}", Env: map[string]string{"VALUE": "${{ needs.build.outputs.value"}}}, expression.Context{Needs: map[string]map[string]string{"build": {"image": ""}}})
+	_, err := evaluateServices(map[string]plan.Container{"optional": {Image: "${{ needs.build.outputs.image }}", Env: map[string]string{"VALUE": "${{ needs.build.outputs.value"}}}, expression.Context{Needs: map[string]expression.NeedStatus{"build": {Outputs: map[string]string{"image": ""}}}})
 	if err == nil || !strings.Contains(err.Error(), "unterminated") {
 		t.Fatalf("error = %v, want unterminated expression error", err)
 	}

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -355,8 +355,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		WorkflowInputs: job.Inputs,
 		Matrix:         job.Matrix,
 		Steps:          make(map[string]expression.StepStatus, len(job.Steps)),
-		Needs:          needOutputs(job.Needs),
-		NeedResults:    needResults(job.Needs),
+		Needs:          needStatuses(job.Needs),
 		Vars:           job.Vars,
 		GitHub:         githubContext(job),
 		JobStatus:      "success",
@@ -374,7 +373,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 			return jobResult, fmt.Errorf("prerequisite %q has invalid result %q", name, need.Result)
 		}
 	}
-	jobCondition := expression.ConditionContext{Inputs: job.Inputs, Needs: eval.Needs, NeedResults: eval.NeedResults, Matrix: job.Matrix, Vars: job.Vars, GitHub: eval.GitHub, Runner: eval.Runner}
+	jobCondition := expression.ConditionContext{Inputs: job.Inputs, Needs: eval.Needs, Matrix: job.Matrix, Vars: job.Vars, GitHub: eval.GitHub, Runner: eval.Runner}
 	for _, need := range job.Needs {
 		jobCondition.Failure = jobCondition.Failure || need.Result == "failure"
 		jobCondition.Cancelled = jobCondition.Cancelled || need.Result == "cancelled"
@@ -740,7 +739,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 			continue
 		}
 		stepEval.Env = mergeStringMaps(stepEval.Env, stepEnv)
-		condition := expression.ConditionContext{Inputs: job.Inputs, Needs: eval.Needs, NeedResults: eval.NeedResults, Steps: eval.Steps, Env: stepEval.Env, Vars: job.Vars, Matrix: job.Matrix, GitHub: eval.GitHub, Runner: eval.Runner, Services: eval.Services, Failure: runErr != nil && runCtx.Err() == nil, Unsuccessful: runErr != nil, Cancelled: evaluationCtx.Err() != nil, HashFiles: stepEval.HashFiles}
+		condition := expression.ConditionContext{Inputs: job.Inputs, Needs: eval.Needs, Steps: eval.Steps, Env: stepEval.Env, Vars: job.Vars, Matrix: job.Matrix, GitHub: eval.GitHub, Runner: eval.Runner, Services: eval.Services, Failure: runErr != nil && runCtx.Err() == nil, Unsuccessful: runErr != nil, Cancelled: evaluationCtx.Err() != nil, HashFiles: stepEval.HashFiles}
 		run, err := expression.EvaluateCondition(step.Condition, condition)
 		if err != nil {
 			execution := classifyStepExecutionWithControls(ctx, evaluationCtx, step, newResult(), fmt.Errorf("condition: %w", err), stepEval)
@@ -2057,7 +2056,7 @@ func (r Runner) runCompositeMetadata(ctx context.Context, processor *commandProc
 		for name, value := range eval.Inputs {
 			inputs[name] = value
 		}
-		condition := expression.ConditionContext{Inputs: inputs, Needs: eval.Needs, NeedResults: eval.NeedResults, Steps: eval.Steps, Env: eval.Env, Vars: eval.Vars, Matrix: eval.Matrix, GitHub: eval.GitHub, Runner: eval.Runner, Services: eval.Services, Failure: failure, Unsuccessful: unsuccessful, Cancelled: cancelled}
+		condition := expression.ConditionContext{Inputs: inputs, Needs: eval.Needs, Steps: eval.Steps, Env: eval.Env, Vars: eval.Vars, Matrix: eval.Matrix, GitHub: eval.GitHub, Runner: eval.Runner, Services: eval.Services, Failure: failure, Unsuccessful: unsuccessful, Cancelled: cancelled}
 		run, err := expression.EvaluateCondition(step.If, condition)
 		if err != nil {
 			runErr = errors.Join(runErr, fmt.Errorf("composite action step %d condition: %w", i+1, err))
@@ -2252,20 +2251,16 @@ func actionJobStatusInputs(action metadata.Metadata, supplied map[string]string)
 	return inputs, nil
 }
 
-func needOutputs(needs map[string]plan.Need) map[string]map[string]string {
-	outputs := make(map[string]map[string]string, len(needs))
+func needStatuses(needs map[string]plan.Need) map[string]expression.NeedStatus {
+	statuses := make(map[string]expression.NeedStatus, len(needs))
 	for name, need := range needs {
-		outputs[name] = need.Outputs
+		var outputs map[string]string
+		if need.Outputs != nil {
+			outputs = cloneStrings(need.Outputs)
+		}
+		statuses[name] = expression.NeedStatus{Outputs: outputs, Result: need.Result}
 	}
-	return outputs
-}
-
-func needResults(needs map[string]plan.Need) map[string]string {
-	results := make(map[string]string, len(needs))
-	for name, need := range needs {
-		results[name] = need.Result
-	}
-	return results
+	return statuses
 }
 
 func shellCommand(shell, script string) ([]string, error) {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1392,6 +1392,26 @@ func TestCloneExpressionContextDeepCopiesStepOutputs(t *testing.T) {
 	}
 }
 
+func TestCloneExpressionContextDeepCopiesNeedOutputs(t *testing.T) {
+	source := expression.Context{Needs: map[string]expression.NeedStatus{
+		"build": {Outputs: map[string]string{"result": "source"}, Result: "success"},
+	}}
+
+	cloned := cloneExpressionContext(source)
+	status := cloned.Needs["build"]
+	status.Result = "failure"
+	status.Outputs["result"] = "clone"
+	cloned.Needs["build"] = status
+	cloned.Needs["added"] = expression.NeedStatus{}
+
+	if got := source.Needs["build"]; got.Result != "success" || got.Outputs["result"] != "source" {
+		t.Fatalf("source need changed through clone: %#v", got)
+	}
+	if _, ok := source.Needs["added"]; ok {
+		t.Fatal("source needs map changed through clone")
+	}
+}
+
 func TestConcurrentPathEffectsComposeWithLiveBarrierState(t *testing.T) {
 	workspace := t.TempDir()
 	workflowPath := ".github/workflows/test.yml"
@@ -2372,6 +2392,33 @@ func TestExplicitCancelTerminatesBackgroundProcessGroup(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("explicitly canceled child process %d survived", pid)
+}
+
+func TestNeedStatusesCopiesOnlyExpressionVisibleState(t *testing.T) {
+	outputs := map[string]string{"release": "v1"}
+	needs := map[string]plan.Need{
+		"producer": {
+			Result:    "success",
+			Outputs:   outputs,
+			Artifacts: []plan.NeedArtifact{{Name: "private-runtime-authority"}},
+		},
+	}
+
+	got := needStatuses(needs)
+	want := map[string]expression.NeedStatus{
+		"producer": {Outputs: map[string]string{"release": "v1"}, Result: "success"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("needStatuses() = %#v, want %#v", got, want)
+	}
+	outputs["release"] = "plan"
+	if got["producer"].Outputs["release"] != "v1" {
+		t.Fatalf("expression output changed through plan: %#v", got)
+	}
+	got["producer"].Outputs["release"] = "expression"
+	if outputs["release"] != "plan" {
+		t.Fatalf("plan output changed through expression state: %#v", outputs)
+	}
 }
 
 func TestJobConditionConsumesNeedResultAndOutput(t *testing.T) {


### PR DESCRIPTION
## Why

Expression evaluation stores prerequisite outputs and results in parallel maps. Construction, cloning, and resolution must keep both representations aligned, obscuring that each result and its outputs belong to one prerequisite.

## What

Add an expression-owned `NeedStatus` record and use it in the distinct runtime and condition contexts. Project each verified `plan.Need` once, copying only its result and outputs; verified artifact authority remains runtime-only on `plan.Need` and never enters expression state.

Update whole and direct `needs` access, job and step conditions, and context cloning while preserving case-insensitive lookup, missing-value behavior, prerequisite conclusions and validation ordering, reusable and matrix output projection, and the existing expression surface. Focused tests cover lookup semantics and map isolation, the full check passes, and an Oracle review traced these boundaries without finding a behavior change.