### PR TITLE
Apply hosted runners to all-events validation

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1494,7 +1494,7 @@ func validateAllEvents(out processingOutput, workflowPath, version, actionCacheD
 }
 
 func validateAllEventsSource(out processingOutput, workflowPath string, source []byte, version, actionCacheDir string, runtime *profileValidationRuntime, stderr io.Writer) int {
-	validation, validationErr := compiler.Validate(workflowPath, source)
+	validation, validationErr := compiler.ValidateWithOptions(workflowPath, source, hostedOptions("", nil, nil))
 	validationReport := compatibility.InitialProcessingReport(workflowPath, "", false, validation, validationErr)
 	if validationErr != nil {
 		validationReport.Result = "incompatible"

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1373,6 +1373,25 @@ func TestRunValidateAndCompile(t *testing.T) {
 		}
 	})
 
+	t.Run("validate all events applies hosted runner policy", func(t *testing.T) {
+		workflow := filepath.Join(t.TempDir(), "events.yml")
+		if err := os.WriteFile(workflow, []byte("on: push\njobs:\n  test:\n    runs-on: macOS-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		var stdout, stderr bytes.Buffer
+		args := []string{"validate", "--profile", "hosted", "--all-events", "--format", "json", workflow}
+		if code := Run(args, &stdout, &stderr, "dev"); code != 0 {
+			t.Fatalf("Run() code = %d, stderr = %q", code, stderr.String())
+		}
+		var report compatibility.ProcessingReportV3
+		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+			t.Fatal(err)
+		}
+		if report.Result != "admitted" || report.Validation.Result != "compilable" || len(report.Validation.Diagnostics) != 0 || len(report.Evaluations) != 1 || report.Evaluations[0].Report.Result != "admitted" {
+			t.Fatalf("aggregate report = %#v", report)
+		}
+	})
+
 	t.Run("validate all events stops before admission on a malformed trigger", func(t *testing.T) {
 		workflow := filepath.Join(t.TempDir(), "events.yml")
 		if err := os.WriteFile(workflow, []byte("on:\n  push:\n    paths: ['!src/**']\n  pull_request:\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -209,12 +209,25 @@ func expansionReport(expanded expansionResult, warnings []Warning) Report {
 // Validate parses and validates the supported static graph without requiring an
 // event snapshot.
 func Validate(path string, source []byte) (Report, error) {
-	parsed, err := workflow.Parse(path, source)
-	if err != nil {
-		return Report{}, processingFinding(StageWorkflowParsing, CodeWorkflowSyntax, "syntax", err)
+	return ValidateWithOptions(path, source, defaultOptions())
+}
+
+// ValidateWithOptions validates the static graph against an explicit runner
+// policy without requiring an event snapshot.
+func ValidateWithOptions(path string, source []byte, options Options) (Report, error) {
+	var optionsErr error
+	if err := options.validate(); err != nil {
+		optionsErr = &ProcessingFinding{
+			Code: CodeEnvironment, Category: "environment",
+			Message: "workflow-processing configuration is invalid", Err: err,
+		}
+	}
+	parsed, parseErr := workflow.Parse(path, source)
+	parseErr = processingFinding(StageWorkflowParsing, CodeWorkflowSyntax, "syntax", parseErr)
+	if parseErr != nil {
+		return Report{}, errors.Join(parseErr, optionsErr)
 	}
 	triggerErr := processingFinding(StagePipeline, CodePipelineGeneration, "compatibility", buildkitepipeline.ValidateTriggerConditions(parsed.Triggers))
-	options := defaultOptions()
 	event := Event{
 		Event: "validation", Trust: options.EventTrust,
 		Repository: Repository{Owner: "validation", Name: "validation"},
@@ -229,7 +242,7 @@ func Validate(path string, source []byte) (Report, error) {
 	cancelInProgress, cancellationErr := resolveWorkflowCancellation(path, parsed.Concurrency, context)
 	cancellationErr = processingFinding(StageExpressions, CodeExpressionInvalid, "compatibility", cancellationErr)
 	expanded, expandErr := expand(path, source, parsed, context, options)
-	if err := errors.Join(triggerErr, concurrencyErr, cancellationErr, expandErr); err != nil {
+	if err := errors.Join(optionsErr, triggerErr, concurrencyErr, cancellationErr, expandErr); err != nil {
 		return expansionReport(expanded, compilerWarnings(parsed.Concurrency, cancelInProgress)), err
 	}
 	return expansionReport(expanded, compilerWarnings(parsed.Concurrency, cancelInProgress)), nil


### PR DESCRIPTION
## Why

`validate --profile hosted --all-events` performed its event-independent pass with the default Linux-only runner policy. It therefore rejected `macos-latest` before reaching hosted evaluation, even though the hosted preset supports that label.

The deterministic 10K corpus contained 600 workflows with this false diagnostic; it was the sole reported error for 164.

## What

Add event-independent validation with explicit compiler options and use the hosted runner policy for the aggregate all-events pass. Bare validation retains its existing default policy.

Add CLI coverage proving a case-insensitive `macOS-latest` workflow completes both aggregate validation and generated hosted event admission. In an exact 10K comparison, the false diagnostic fell from 600 workflows to zero, 73 workflows became admitted, and no workflow regressed.