### PR TITLE
Resolve actions from tracked workflows anywhere in the checkout

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1928,6 +1928,7 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 		}
 		validationOptions := hostedOptions("", uploadArguments.runnerTargets, nil)
 		validationOptions.StepKeyNamespace = input.StepKeyNamespace
+		validationOptions.RepositoryRoot = input.RepositoryRoot
 		validation, validationErr := compiler.ValidateEventWithOptions(input.Path, input.Source, effectiveEvent.Source, validationOptions)
 		processingReports[i] = compatibility.InitialProcessingReport(input.Path, hostedProfile, true, validation, validationErr)
 		if validationErr != nil {
@@ -1952,7 +1953,7 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 		if !input.Applicable || processingReportHasErrors(processingReports[i]) {
 			continue
 		}
-		platforms, platformErr := requiredRuntimePlatforms(input.Path, input.Source, effectiveEvent.Source, "", uploadArguments.runnerTargets)
+		platforms, platformErr := requiredRuntimePlatforms(input.Path, input.Source, effectiveEvent.Source, "", uploadArguments.runnerTargets, input.RepositoryRoot)
 		if platformErr != nil {
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", platformErr)
 			return 1
@@ -2035,7 +2036,7 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 			failureArtifacts = append(failureArtifacts, artifacts...)
 			continue
 		}
-		preflight, err := compileHostedNamespaced(ctx, input.Path, input.Source, effectiveEvent.Source, version, distributionDigest, importerStep, "", uploadArguments.runnerTargets, runtimeDigests, input.StepKeyNamespace, authentication)
+		preflight, err := compileHostedNamespacedAtRoot(ctx, input.Path, input.Source, effectiveEvent.Source, version, distributionDigest, importerStep, "", uploadArguments.runnerTargets, runtimeDigests, input.StepKeyNamespace, input.RepositoryRoot, authentication)
 		applyHostedPreflight(&processingReports[i], preflight)
 		if err != nil {
 			processingReports[i].Result = classifyHostedFailure(&processingReports[i], input.Path, err)
@@ -2230,8 +2231,10 @@ func generatedFailureArtifact(kind, extension, contents string) transport.Artifa
 	return transport.Artifact{Path: path, Digest: digest, Contents: encoded}
 }
 
-func requiredRuntimePlatforms(workflowPath string, workflowSource, eventSource []byte, groupLabel string, configuredTargets map[string]compiler.RunnerTarget) (map[compiler.Platform]bool, error) {
-	preflight, err := compiler.CompileWithOptions(workflowPath, workflowSource, eventSource, hostedOptions(groupLabel, configuredTargets, nil))
+func requiredRuntimePlatforms(workflowPath string, workflowSource, eventSource []byte, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, repositoryRoot string) (map[compiler.Platform]bool, error) {
+	options := hostedOptions(groupLabel, configuredTargets, nil)
+	options.RepositoryRoot = repositoryRoot
+	preflight, err := compiler.CompileWithOptions(workflowPath, workflowSource, eventSource, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2434,12 +2437,12 @@ func triggerProcessingReport(path string, source []byte) compatibility.Processin
 }
 
 type workflowInput struct {
-	Path, CanonicalPath, Identity, StepKeyNamespace, Name string
-	Source                                                []byte
-	Triggers                                              []workflow.Trigger
-	TriggerCondition, SkipReason, AnnotationReason        string
-	PathFiltersError                                      string
-	ReusableOnly, Applicable                              bool
+	Path, CanonicalPath, RepositoryRoot, Identity, StepKeyNamespace, Name string
+	Source                                                                []byte
+	Triggers                                                              []workflow.Trigger
+	TriggerCondition, SkipReason, AnnotationReason                        string
+	PathFiltersError                                                      string
+	ReusableOnly, Applicable                                              bool
 }
 
 func resolveWorkflowOperands(operands []string) ([]workflowInput, error) {
@@ -2458,13 +2461,20 @@ func resolveWorkflowOperands(operands []string) ([]workflowInput, error) {
 		return nil, fmt.Errorf("workflow path %q must end in .yml or .yaml", operands[0])
 	}
 	canonical := filepath.ToSlash(filepath.Clean(operands[0]))
+	repositoryRoot := ""
 	if rootBytes, rootErr := exec.Command("git", "rev-parse", "--show-toplevel").Output(); rootErr == nil {
 		root := filepath.Clean(strings.TrimSpace(string(rootBytes)))
 		if relative, relativeErr := filepath.Rel(root, path); relativeErr == nil && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
-			canonical = filepath.ToSlash(filepath.Clean(relative))
+			candidate := filepath.ToSlash(filepath.Clean(relative))
+			output, trackedErr := exec.Command("git", "-C", root, "ls-files", "-z", "--", ":(top,literal)"+candidate).Output()
+			entries := bytes.Split(output, []byte{0})
+			if trackedErr == nil && len(entries) == 2 && string(entries[0]) == candidate && len(entries[1]) == 0 {
+				canonical = candidate
+				repositoryRoot = root
+			}
 		}
 	}
-	return workflowInputs([]workflowInput{{Path: path, CanonicalPath: canonical}}, false)
+	return workflowInputs([]workflowInput{{Path: path, CanonicalPath: canonical, RepositoryRoot: repositoryRoot}}, false)
 }
 
 func expandExplicitWorkflowPaths(operands []string) ([]workflowInput, error) {
@@ -2505,7 +2515,7 @@ func expandExplicitWorkflowPaths(operands []string) ([]workflowInput, error) {
 			}
 			return nil, fmt.Errorf("workflow path %q is not tracked by git", operand)
 		}
-		matches = append(matches, workflowInput{Path: filepath.Join(root, filepath.FromSlash(canonical)), CanonicalPath: canonical})
+		matches = append(matches, workflowInput{Path: filepath.Join(root, filepath.FromSlash(canonical)), CanonicalPath: canonical, RepositoryRoot: root})
 	}
 	return workflowInputs(matches, true)
 }
@@ -2689,12 +2699,21 @@ func compileHostedWithActionCache(ctx context.Context, workflowPath string, work
 }
 
 func compileHostedNamespaced(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runtimeDistributions map[compiler.Platform]string, stepKeyNamespace string, actionAuthentication *actionSourceAuthentication) (hostedCompilation, error) {
-	return compileHostedNamespacedWithActionCache(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, groupLabel, configuredTargets, runtimeDistributions, stepKeyNamespace, "", nil, actionAuthentication)
+	return compileHostedNamespacedAtRoot(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, groupLabel, configuredTargets, runtimeDistributions, stepKeyNamespace, "", actionAuthentication)
+}
+
+func compileHostedNamespacedAtRoot(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runtimeDistributions map[compiler.Platform]string, stepKeyNamespace, repositoryRoot string, actionAuthentication *actionSourceAuthentication) (hostedCompilation, error) {
+	return compileHostedNamespacedWithActionCacheAtRoot(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, groupLabel, configuredTargets, runtimeDistributions, stepKeyNamespace, repositoryRoot, "", nil, actionAuthentication)
 }
 
 func compileHostedNamespacedWithActionCache(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runtimeDistributions map[compiler.Platform]string, stepKeyNamespace, actionCacheDir string, sharedActionSource compiler.ActionSource, actionAuthentication *actionSourceAuthentication) (hostedCompilation, error) {
+	return compileHostedNamespacedWithActionCacheAtRoot(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, groupLabel, configuredTargets, runtimeDistributions, stepKeyNamespace, "", actionCacheDir, sharedActionSource, actionAuthentication)
+}
+
+func compileHostedNamespacedWithActionCacheAtRoot(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runtimeDistributions map[compiler.Platform]string, stepKeyNamespace, repositoryRoot, actionCacheDir string, sharedActionSource compiler.ActionSource, actionAuthentication *actionSourceAuthentication) (hostedCompilation, error) {
 	options := hostedOptions(groupLabel, configuredTargets, runtimeDistributions)
 	options.StepKeyNamespace = stepKeyNamespace
+	options.RepositoryRoot = repositoryRoot
 	preflight, err := compiler.CompileWithOptions(workflowPath, workflowSource, eventSource, options)
 	if err != nil {
 		return hostedCompilation{}, hostedError(hostedEvaluationFailure, err)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -3633,6 +3633,30 @@ func TestValidateHostedProfileAdmitsImplicitReadOnlyWorkflowToken(t *testing.T) 
 	}
 }
 
+func TestArbitraryRepositoryWorkflowTokenKeepsHostedPolicyLimit(t *testing.T) {
+	repository := t.TempDir()
+	workflowPath := filepath.Join(repository, "ci", "token.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	workflow := []byte("on: push\npermissions:\n  contents: read\njobs:\n  token:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo '${{ secrets.GITHUB_TOKEN }}'\n")
+	if err := os.WriteFile(workflowPath, workflow, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	event, err := os.ReadFile(filepath.Join("..", "..", "testdata", "smoke", "events", "push.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	compiled, err := compileHostedNamespacedAtRoot(context.Background(), workflowPath, workflow, event, "0.0.0-test", "sha256:"+strings.Repeat("a", 64), "importer", "", nil, nil, "", repository, nil)
+	if err == nil || len(compiled.Bundle.Plans) != 1 {
+		t.Fatalf("arbitrary-path token compilation = %#v, %v", compiled, err)
+	}
+	message, _ := githubTokenAdmissionDiagnostic(compiled.Bundle.Plans[0], compiled.Bundle.IR.Workflow.WorkflowTokenPolicyDiagnostic)
+	if !strings.Contains(message, "hosted GITHUB_TOKEN issuance requires the workflow directly under .github/workflows") {
+		t.Fatalf("arbitrary-path token diagnostic = %q", message)
+	}
+}
+
 func TestRunUploadCompilesArtifactsAndUploadsSelfContainedPipeline(t *testing.T) {
 	requireImporterHost(t)
 	workflowPath := filepath.Join("..", "..", "testdata", "smoke", ".github", "workflows", "shell.yml")
@@ -3932,9 +3956,17 @@ func TestExpandExplicitWorkflowPathsCanonicalizesTrackedPaths(t *testing.T) {
 		t.Fatalf("canonical explicit inputs = %#v and %#v", first, second)
 	}
 	for _, input := range first {
-		if input.Identity == "" || input.StepKeyNamespace != input.Identity || !filepath.IsAbs(input.Path) {
+		if input.Identity == "" || input.StepKeyNamespace != input.Identity || !filepath.IsAbs(input.Path) || input.RepositoryRoot != repository {
 			t.Fatalf("explicit workflow identity = %#v", input)
 		}
+	}
+	single, err := resolveWorkflowOperands([]string{aPath})
+	if err != nil || len(single) != 1 || single[0].RepositoryRoot != repository {
+		t.Fatalf("single tracked workflow root = %#v, %v", single, err)
+	}
+	untracked, err := resolveWorkflowOperands([]string{filepath.Join(".github", "workflows", "untracked.yml")})
+	if err != nil || len(untracked) != 1 || untracked[0].RepositoryRoot != "" {
+		t.Fatalf("single untracked workflow root = %#v, %v", untracked, err)
 	}
 	metacharacter, err := expandExplicitWorkflowPaths([]string{filepath.Join(".github", "workflows", "workflow[1].yml"), aPath})
 	if err != nil || len(metacharacter) != 2 || metacharacter[1].CanonicalPath != ".github/workflows/workflow[1].yml" {

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -708,6 +708,123 @@ func TestCompileActionLocksRequiresRepositoryRoot(t *testing.T) {
 	}
 }
 
+func TestCompileArbitraryRepositoryWorkflowActions(t *testing.T) {
+	repository := t.TempDir()
+	workflowPath := filepath.Join(repository, "ci", "node.js.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeAction(t, repository, "actions/local", "name: local\nruns:\n  using: node24\n  main: index.js\n")
+	remote := t.TempDir()
+	writeAction(t, remote, "", "name: setup\nruns:\n  using: node24\n  main: index.js\n")
+	source := []byte("on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/setup-node@v4\n      - uses: ./actions/local\n")
+	if err := os.WriteFile(workflowPath, source, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	options := Options{
+		EventTrust:     EventUntrusted,
+		RepositoryRoot: repository,
+		Runners: RunnerPolicy{
+			Labels:                     map[string]string{"ubuntu-latest": ""},
+			AllowUntrustedDefaultQueue: true,
+		},
+		ResolveActions: true,
+		ActionSource:   &fakeActionSource{root: remote, calls: map[string]int{}},
+	}
+	bundle, err := CompileBundlePlansContext(context.Background(), workflowPath, source, pushEvent(t), "0.0.0-test", testDistributionDigest, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bundle.IR.Workflow.Path != "./ci/node.js.yml" || len(bundle.Plans) != 1 || bundle.Plans[0].Job.Workflow.Path != "./ci/node.js.yml" {
+		t.Fatalf("repository-relative workflow provenance = IR %q, plans %#v", bundle.IR.Workflow.Path, bundle.Plans)
+	}
+	if got := bundle.Plans[0].Job.Actions; len(got) != 2 || got[0].Source != "workspace" || got[0].Path != "actions/local" || got[1].Source != "github" {
+		t.Fatalf("action locks = %#v", got)
+	}
+}
+
+func TestCompileRepositoryRootConfinement(t *testing.T) {
+	repository := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside.yml")
+	source := []byte("on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n")
+	if err := os.WriteFile(outside, source, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	options := defaultOptions()
+	options.RepositoryRoot = repository
+	if _, err := CompileWithOptions(outside, source, pushEvent(t), options); err == nil || !strings.Contains(err.Error(), "escapes repository root") {
+		t.Fatalf("outside-root error = %v", err)
+	}
+
+	symlink := filepath.Join(repository, "ci.yml")
+	if err := os.Symlink(outside, symlink); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := CompileWithOptions(symlink, source, pushEvent(t), options); err == nil || !strings.Contains(err.Error(), "escapes repository root") {
+		t.Fatalf("symlink escape error = %v", err)
+	}
+}
+
+func TestCompileRepositoryRootIsOptionalAndSourcePathsAreDeterministic(t *testing.T) {
+	source := []byte("on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: ./actions/local\n")
+	options := defaultOptions()
+	if _, err := CompileBundlePlansContext(context.Background(), "ci/workflow.yml", source, pushEvent(t), "0.0.0-test", testDistributionDigest, options); err == nil || !strings.Contains(err.Error(), "workflow path") {
+		t.Fatalf("empty-root local action error = %v", err)
+	}
+
+	var outputs [][]byte
+	for range 2 {
+		repository := t.TempDir()
+		workflowPath := filepath.Join(repository, "ci", "workflow.yml")
+		if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(workflowPath, source, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		writeAction(t, repository, "actions/local", "name: local\nruns:\n  using: node24\n  main: index.js\n")
+		options.RepositoryRoot = repository
+		compiled, err := CompileWithOptions(workflowPath, source, pushEvent(t), options)
+		if err != nil {
+			t.Fatal(err)
+		}
+		outputs = append(outputs, compiled)
+	}
+	if !bytes.Equal(outputs[0], outputs[1]) {
+		t.Fatalf("compilation depends on checkout location:\n%s\n%s", outputs[0], outputs[1])
+	}
+}
+
+func TestCompileArbitraryRepositoryWorkflowPreservesPolicyBoundaries(t *testing.T) {
+	repository := t.TempDir()
+	workflowPath := filepath.Join(repository, "ci", "caller.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	options := defaultOptions()
+	options.RepositoryRoot = repository
+
+	reusable := []byte("on: push\njobs:\n  call:\n    uses: ./.github/workflows/reusable.yml\n")
+	if err := os.WriteFile(workflowPath, reusable, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := CompileWithOptions(workflowPath, reusable, pushEvent(t), options); err == nil || !strings.Contains(err.Error(), "local reusable workflows require the caller under .github/workflows") {
+		t.Fatalf("reusable caller error = %v", err)
+	}
+
+	token := []byte("on: push\npermissions:\n  contents: read\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo '${{ secrets.GITHUB_TOKEN }}'\n")
+	if err := os.WriteFile(workflowPath, token, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	bundle, err := CompileBundlePlansContext(context.Background(), workflowPath, token, pushEvent(t), "0.0.0-test", testDistributionDigest, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bundle.Plans) != 1 || bundle.Plans[0].Authorization.WorkflowTokenPolicyFilename != "" || !strings.Contains(bundle.IR.Workflow.WorkflowTokenPolicyDiagnostic, "directly under .github/workflows") {
+		t.Fatalf("arbitrary-path token policy = IR %#v, authorization %#v", bundle.IR.Workflow, bundle.Plans)
+	}
+}
+
 func TestCompileActionLocksRejectsExcessiveDepthBeforeResolvingLeaf(t *testing.T) {
 	w := t.TempDir()
 	for i := 0; i <= metadata.MaxNestedActionDepth; i++ {

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -803,14 +803,25 @@ func compile(path string, source, eventSource []byte, options Options) (IR, erro
 	if err != nil {
 		return IR{}, processingFinding(StageWorkflowParsing, CodeWorkflowSyntax, "syntax", err)
 	}
-	workflowTokenPolicyFilename, workflowTokenPolicyDiagnostic := workflowTokenPolicyEvidence(path, parsed)
+	displayPath := path
+	if options.RepositoryRoot != "" {
+		root, canonicalPath, locationErr := workflowRepository(path, options.RepositoryRoot)
+		if locationErr != nil {
+			return IR{}, &ProcessingFinding{Code: CodeEnvironment, Category: "environment", Message: "workflow-processing configuration is invalid", Err: locationErr}
+		}
+		displayPath, locationErr = repositoryWorkflowPath(root, canonicalPath)
+		if locationErr != nil {
+			return IR{}, &ProcessingFinding{Code: CodeEnvironment, Category: "environment", Message: "workflow-processing configuration is invalid", Err: locationErr}
+		}
+	}
+	workflowTokenPolicyFilename, workflowTokenPolicyDiagnostic := workflowTokenPolicyEvidence(displayPath, parsed)
 	event, err := parseEvent(eventSource)
 	if err != nil {
 		return IR{}, processingFinding(StageEventValidation, CodeEventInvalid, "environment", err)
 	}
 	event.Trust = options.EventTrust
 	vars := options.Vars.snapshot()
-	context := compileContext(event, vars, path, parsed.Name)
+	context := compileContext(event, vars, displayPath, parsed.Name)
 	context.Inputs = workflowDispatchInputs(parsed, event)
 	workflowConcurrencyGroup, concurrencyErr := resolveConcurrency(path, "", parsed.Concurrency, context, nil)
 	concurrencyErr = processingFinding(StageExpressions, CodeExpressionInvalid, "compatibility", concurrencyErr)
@@ -821,7 +832,7 @@ func compile(path string, source, eventSource []byte, options Options) (IR, erro
 	ir := IR{
 		Schema: schema,
 		Workflow: WorkflowSource{
-			Path: path, Name: parsed.Name, Digest: "sha256:" + hex.EncodeToString(digest[:]), ConcurrencyGroup: workflowConcurrencyGroup, Triggers: parsed.Triggers,
+			Path: displayPath, Name: parsed.Name, Digest: "sha256:" + hex.EncodeToString(digest[:]), ConcurrencyGroup: workflowConcurrencyGroup, Triggers: parsed.Triggers,
 			WorkflowTokenPolicyFilename: workflowTokenPolicyFilename, WorkflowTokenPolicyDiagnostic: workflowTokenPolicyDiagnostic,
 		},
 		Event:    event,
@@ -1063,7 +1074,7 @@ func eventBaseRef(event Event) string {
 
 func canonicalWorkflowName(path string) string {
 	if isRepositoryWorkflowPath(path) {
-		root, canonicalPath, err := workflowRepository(path)
+		root, canonicalPath, err := workflowRepository(path, "")
 		if err == nil {
 			if relative, err := repositoryWorkflowPath(root, canonicalPath); err == nil {
 				return strings.TrimPrefix(relative, "./")
@@ -1074,7 +1085,7 @@ func canonicalWorkflowName(path string) string {
 }
 
 func expand(path string, source []byte, parsed *workflow.Workflow, context expression.CompileContext, options Options) (expansionResult, error) {
-	resolved, runtimeMatrixBoundary, err := resolveReusableWorkflows(path, source, parsed, context)
+	resolved, runtimeMatrixBoundary, err := resolveReusableWorkflows(path, source, parsed, context, options.RepositoryRoot)
 	if err != nil {
 		notEvaluatedJobs := make(map[string]bool, len(parsed.Jobs))
 		for _, job := range parsed.Jobs {

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -2951,7 +2951,7 @@ func TestLocalActionCapabilityResolutionStaysWithinRepository(t *testing.T) {
 func TestWorkflowRepositoryNormalizesInMemoryWorkflowPath(t *testing.T) {
 	repository := t.TempDir()
 	path := filepath.Join(repository, ".github", "workflows", "memory.yml")
-	root, canonical, err := workflowRepository(path)
+	root, canonical, err := workflowRepository(path, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/compiler/config.go
+++ b/internal/compiler/config.go
@@ -107,6 +107,9 @@ type Options struct {
 	Vars       VariableSources
 	Runners    RunnerPolicy
 	EventTrust EventTrust
+	// RepositoryRoot identifies the verified checkout containing the workflow.
+	// Empty preserves standalone and in-memory compiler behavior.
+	RepositoryRoot string
 	// ResolveActions enables immutable remote action locking independently of
 	// event trust. Workspace-local actions are always locked without network
 	// access. ActionSource is required only when a workflow uses remote actions.

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -66,19 +66,19 @@ type reusableResolver struct {
 	runtimeMatrixBoundary bool
 }
 
-func resolveReusableWorkflows(path string, source []byte, parsed *workflow.Workflow, context expression.CompileContext) ([]sourcedJob, bool, error) {
+func resolveReusableWorkflows(path string, source []byte, parsed *workflow.Workflow, context expression.CompileContext, repositoryRoot string) ([]sourcedJob, bool, error) {
 	digest := "sha256:" + sha256Sum(source)
 	runtimeMatrixBoundary := hasRuntimeMatrixBoundary(parsed)
 	if !hasReusableCall(parsed) {
 		sourcePath := path
 		root := ""
-		if isRepositoryWorkflowPath(path) {
-			repositoryRoot, canonicalPath, err := workflowRepository(path)
+		if repositoryRoot != "" || isRepositoryWorkflowPath(path) {
+			resolvedRoot, canonicalPath, err := workflowRepository(path, repositoryRoot)
 			if err != nil {
 				return nil, runtimeMatrixBoundary, err
 			}
-			root = repositoryRoot
-			sourcePath, err = repositoryWorkflowPath(repositoryRoot, canonicalPath)
+			root = resolvedRoot
+			sourcePath, err = repositoryWorkflowPath(resolvedRoot, canonicalPath)
 			if err != nil {
 				return nil, runtimeMatrixBoundary, err
 			}
@@ -107,13 +107,16 @@ func resolveReusableWorkflows(path string, source []byte, parsed *workflow.Workf
 		return jobs, runtimeMatrixBoundary, nil
 	}
 
-	root, canonicalPath, err := workflowRepository(path)
+	root, canonicalPath, err := workflowRepository(path, repositoryRoot)
 	if err != nil {
 		return nil, runtimeMatrixBoundary, err
 	}
 	sourcePath, err := repositoryWorkflowPath(root, canonicalPath)
 	if err != nil {
 		return nil, runtimeMatrixBoundary, err
+	}
+	if filepath.Dir(filepath.FromSlash(strings.TrimPrefix(sourcePath, "./"))) != filepath.Join(".github", "workflows") {
+		return nil, runtimeMatrixBoundary, fmt.Errorf("%s: local reusable workflows require the caller under .github/workflows", path)
 	}
 	resolver := reusableResolver{root: root, stack: []string{canonicalPath}, context: context, runtimeMatrixBoundary: runtimeMatrixBoundary}
 	resolver.discoverRuntimeMatrixBoundaries(parsed, 0, map[string]int{canonicalPath: 0})
@@ -1069,23 +1072,31 @@ func isRepositoryWorkflowPath(path string) bool {
 	return filepath.Base(workflowDir) == "workflows" && filepath.Base(filepath.Dir(workflowDir)) == ".github"
 }
 
-func workflowRepository(path string) (string, string, error) {
+func workflowRepository(path, suppliedRoot string) (string, string, error) {
 	absPath, err := filepath.Abs(filepath.Clean(path))
 	if err != nil {
 		return "", "", fmt.Errorf("resolve workflow path: %w", err)
 	}
-	workflowDir := filepath.Dir(absPath)
-	if filepath.Base(workflowDir) != "workflows" || filepath.Base(filepath.Dir(workflowDir)) != ".github" {
-		return "", "", fmt.Errorf("%s: local reusable workflows require the caller under .github/workflows", path)
+	repositoryDir := suppliedRoot
+	if repositoryDir == "" {
+		workflowDir := filepath.Dir(absPath)
+		if filepath.Base(workflowDir) != "workflows" || filepath.Base(filepath.Dir(workflowDir)) != ".github" {
+			return "", "", fmt.Errorf("%s: local reusable workflows require the caller under .github/workflows", path)
+		}
+		repositoryDir = filepath.Dir(filepath.Dir(workflowDir))
+	} else {
+		repositoryDir, err = filepath.Abs(filepath.Clean(repositoryDir))
+		if err != nil {
+			return "", "", fmt.Errorf("resolve repository root %q: %w", suppliedRoot, err)
+		}
 	}
-	repositoryDir := filepath.Dir(filepath.Dir(workflowDir))
 	root, err := filepath.EvalSymlinks(repositoryDir)
 	if err != nil {
 		return "", "", fmt.Errorf("resolve repository root for %q: %w", path, err)
 	}
 	canonicalPath, err := filepath.EvalSymlinks(absPath)
 	if err != nil {
-		if !os.IsNotExist(err) {
+		if suppliedRoot != "" || !os.IsNotExist(err) {
 			return "", "", fmt.Errorf("resolve workflow path %q: %w", path, err)
 		}
 		relative, relativeErr := filepath.Rel(repositoryDir, absPath)


### PR DESCRIPTION
## Why

Tracked workflow files outside `.github/workflows` pass CLI validation, but action plan construction cannot locate the repository root. This prevents workflows such as `ci/node.js.yml` from using public or repository-local actions.

## What

Carry the CLI-verified Git repository root into compiler options, canonicalize and confine workflow paths to that root, and use repository-relative source paths in compiler output. Preserve the existing `.github/workflows` restrictions for local reusable-workflow callers and hosted `GITHUB_TOKEN` issuance.