### PR TITLE
PB-2962: Support action lifecycle conditions

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -617,6 +617,10 @@ Nested calls from a repository-local composite must be local. Public composites 
 
 Pre, main, and post phases; inputs; outputs; state; and LIFO post ordering are supported. Other Node declarations are rejected.
 
+JavaScript action `pre-if` and `post-if` metadata uses the condition operators, status functions, and pure functions described in [Conditions](#conditions). Lifecycle conditions can read `env`, `github`, `job.services`, `matrix`, `runner`, and `steps`. Other contexts and `hashFiles()` fail closed. An empty lifecycle condition always runs and does not receive an implicit `success()` guard.
+
+Pre conditions use the status and action-scoped environment available when preparation reaches the action. Post conditions run during job teardown and use the final job status and environment, including `GITHUB_ENV` changes from main. Root action posts also see final workflow step state. Nested composite actions retain their isolated step context. Cancellation remains distinct from failure, and posts keep LIFO order.
+
 ### Checkout action
 
 **🟡 Supported subset.** The final v3.7.0 release commit is admitted exactly. Resolved commits in the v4-and-later range of the static [`actions/checkout` upstream `main` snapshot](https://github.com/actions/checkout/tree/f548e57e544e1ff5a4c46bf1e1b8685f8e4a348a) are also admitted. The following known releases remain admitted even when their commits aren't reachable from that snapshot:

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -528,11 +528,11 @@ Three expression modes intentionally support different syntax.
 | `!`, `&&`, `\|\|`, `==`, `!=`, `<`, `<=`, `>`, `>=` | ✅ Supported | 🟡 Listed workflow fields | 🟡 When the result resolves fully |
 | `always()`, `success()`, `failure()`, `cancelled()` | ✅ Without arguments | ❌ Unsupported | ❌ Unsupported |
 | `startsWith()`, `contains()`, `endsWith()`, `format()`, `join()`, `toJSON()`, `fromJSON()`, `case()` | ✅ Supported | 🟡 Listed workflow fields | 🟡 When the result resolves fully |
-| `hashFiles()` | 🟡 Step `if` only | 🟡 Workflow steps only | ❌ Unsupported |
+| `hashFiles()` | 🟡 Step `if` and action lifecycle conditions | 🟡 Workflow steps only | ❌ Unsupported |
 
 ### Conditions
 
-Job and step `if` conditions support literals and the syntax listed above. Values use GitHub's truthiness, loose numeric coercion, case-insensitive string comparison, and operand-returning `&&` and `||` semantics. String functions convert primitive arguments; `contains()` also searches arrays. `case()` takes 3–255 odd-numbered arguments, requires Boolean predicates, and evaluates values lazily through the first match. Missing properties in an available `github` or matrix context evaluate to null; unavailable contexts still fail closed. Other functions are unsupported. `hashFiles()` accepts 1–255 literal or direct-reference arguments in step conditions only.
+Job and step `if` conditions support literals and the syntax listed above. Values use GitHub's truthiness, loose numeric coercion, case-insensitive string comparison, and operand-returning `&&` and `||` semantics. String functions convert primitive arguments; `contains()` also searches arrays. `case()` takes 3–255 odd-numbered arguments, requires Boolean predicates, and evaluates values lazily through the first match. Missing properties in an available `github` or matrix context evaluate to null; unavailable contexts still fail closed. Other functions are unsupported. `hashFiles()` accepts 1–255 literal or direct-reference arguments in step and JavaScript action lifecycle conditions.
 
 Conditions support computed object indexes, numeric array indexes, whole `matrix`, `needs`, and step-scoped `steps` objects, and `.*` projections. Missing and out-of-range indexes evaluate to null. Projections omit missing children; a later wildcard flattens one collection level. The equivalent `[*]` spelling is unsupported by the current expression parser. Whole or dynamic `github` access, whole `inputs`, and the `strategy` context remain unsupported.
 
@@ -617,7 +617,7 @@ Nested calls from a repository-local composite must be local. Public composites 
 
 Pre, main, and post phases; inputs; outputs; state; and LIFO post ordering are supported. Other Node declarations are rejected.
 
-JavaScript action `pre-if` and `post-if` metadata uses the condition operators, status functions, and pure functions described in [Conditions](#conditions). Lifecycle conditions can read `env`, `github`, `job.services`, `matrix`, `runner`, and `steps`. Other contexts and `hashFiles()` fail closed. An empty lifecycle condition always runs and does not receive an implicit `success()` guard.
+JavaScript action `pre-if` and `post-if` metadata uses the condition operators, status functions, pure functions, and `hashFiles()` described in [Conditions](#conditions). Lifecycle conditions can read direct properties from workflow `inputs`, `env`, `github`, `job.services`, `matrix`, `runner`, and `steps`. Other contexts and dynamic or whole-context access fail closed. An empty lifecycle condition always runs and does not receive an implicit `success()` guard.
 
 Pre conditions use the status and action-scoped environment available when preparation reaches the action. Post conditions run during job teardown and use the final job status and environment, including `GITHUB_ENV` changes from main. Root action posts also see final workflow step state. Nested composite actions retain their isolated step context. Cancellation remains distinct from failure, and posts keep LIFO order.
 

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -329,6 +329,12 @@ func (b *actionLockBuilder) add(ctx context.Context, raw string, depth int) (*ac
 		return n, nil
 	}
 	if runtime == metadata.RuntimeNode16 || runtime == metadata.RuntimeNode20 || runtime == metadata.RuntimeNode24 {
+		if err := expression.ValidateActionLifecycleCondition(m.Runs.PreIf); err != nil {
+			return nil, fmt.Errorf("pre-if: %w", err)
+		}
+		if err := expression.ValidateActionLifecycleCondition(m.Runs.PostIf); err != nil {
+			return nil, fmt.Errorf("post-if: %w", err)
+		}
 		b.requiresMise = true
 	}
 	for _, capability := range runtime.RequiredCapabilities() {

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -773,7 +773,7 @@ func TestCompileActionLocksDeterministic(t *testing.T) {
 
 func TestCompileActionLocksValidatesJavaScriptLifecycleConditions(t *testing.T) {
 	workspace := t.TempDir()
-	writeAction(t, workspace, "rust-cache", "name: rust-cache\nruns:\n  using: node24\n  main: index.js\n  post: index.js\n  post-if: success() || env.CACHE_ON_FAILURE == 'true'\n")
+	writeAction(t, workspace, "rust-cache", "name: rust-cache\nruns:\n  using: node24\n  main: index.js\n  post: index.js\n  post-if: (success() || env.CACHE_ON_FAILURE == 'true') && inputs.cache == true && hashFiles('Cargo.lock') != ''\n")
 	writeAction(t, workspace, "parent", "name: parent\nruns:\n  using: composite\n  steps:\n    - uses: ./rust-cache\n")
 	if _, _, _, _, err := compileActionLocks(context.Background(), workspace, nil, []string{"./parent"}); err != nil {
 		t.Fatalf("compileActionLocks() rejected rust-cache lifecycle condition: %v", err)
@@ -784,8 +784,9 @@ func TestCompileActionLocksValidatesJavaScriptLifecycleConditions(t *testing.T) 
 		t.Fatalf("direct lifecycle validation error = %v", err)
 	}
 
-	writeAction(t, workspace, "parent", "name: parent\nruns:\n  using: composite\n  steps:\n    - uses: ./broken\n")
-	if _, _, _, _, err := compileActionLocks(context.Background(), workspace, nil, []string{"./parent"}); err == nil || !strings.Contains(err.Error(), `child action "./broken"`) || !strings.Contains(err.Error(), "pre-if") {
+	writeAction(t, workspace, "nested-broken", "name: broken\nruns:\n  using: node24\n  main: index.js\n  post: index.js\n  post-if: needs[env.JOB].result == 'success'\n")
+	writeAction(t, workspace, "parent", "name: parent\nruns:\n  using: composite\n  steps:\n    - uses: ./nested-broken\n")
+	if _, _, _, _, err := compileActionLocks(context.Background(), workspace, nil, []string{"./parent"}); err == nil || !strings.Contains(err.Error(), `child action "./nested-broken"`) || !strings.Contains(err.Error(), "post-if") || !strings.Contains(err.Error(), `context "needs"`) {
 		t.Fatalf("nested lifecycle validation error = %v", err)
 	}
 }

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -771,6 +771,37 @@ func TestCompileActionLocksDeterministic(t *testing.T) {
 	}
 }
 
+func TestCompileActionLocksValidatesJavaScriptLifecycleConditions(t *testing.T) {
+	workspace := t.TempDir()
+	writeAction(t, workspace, "rust-cache", "name: rust-cache\nruns:\n  using: node24\n  main: index.js\n  post: index.js\n  post-if: success() || env.CACHE_ON_FAILURE == 'true'\n")
+	writeAction(t, workspace, "parent", "name: parent\nruns:\n  using: composite\n  steps:\n    - uses: ./rust-cache\n")
+	if _, _, _, _, err := compileActionLocks(context.Background(), workspace, nil, []string{"./parent"}); err != nil {
+		t.Fatalf("compileActionLocks() rejected rust-cache lifecycle condition: %v", err)
+	}
+
+	writeAction(t, workspace, "broken", "name: broken\nruns:\n  using: node24\n  pre: index.js\n  pre-if: success() || secrets.TOKEN != ''\n  main: index.js\n")
+	if _, _, _, _, err := compileActionLocks(context.Background(), workspace, nil, []string{"./broken"}); err == nil || !strings.Contains(err.Error(), "pre-if") || !strings.Contains(err.Error(), `context "secrets"`) {
+		t.Fatalf("direct lifecycle validation error = %v", err)
+	}
+
+	writeAction(t, workspace, "parent", "name: parent\nruns:\n  using: composite\n  steps:\n    - uses: ./broken\n")
+	if _, _, _, _, err := compileActionLocks(context.Background(), workspace, nil, []string{"./parent"}); err == nil || !strings.Contains(err.Error(), `child action "./broken"`) || !strings.Contains(err.Error(), "pre-if") {
+		t.Fatalf("nested lifecycle validation error = %v", err)
+	}
+}
+
+func TestCompileActionLocksDoesNotValidateUnusedNativeLifecycle(t *testing.T) {
+	workspace, remote := t.TempDir(), t.TempDir()
+	writeAction(t, remote, "", "name: checkout\nruns:\n  using: node24\n  pre: index.js\n  pre-if: secrets.UNSUPPORTED\n  main: index.js\n")
+	source := classifiedActionSource{
+		roots:   map[string]string{"actions/checkout": remote},
+		commits: map[string]string{"actions/checkout": actionintegration.CheckoutV4Commit},
+	}
+	if _, _, _, _, err := compileActionLocks(context.Background(), workspace, source, []string{"actions/checkout@v4"}); err != nil {
+		t.Fatalf("compileActionLocks() validated replaced native lifecycle: %v", err)
+	}
+}
+
 func TestCompileActionLocksAllowsOnlyAuditedCacheCommits(t *testing.T) {
 	workspace, remote := t.TempDir(), t.TempDir()
 	for _, path := range []string{"", "restore", "save"} {

--- a/internal/expression/condition.go
+++ b/internal/expression/condition.go
@@ -115,10 +115,7 @@ func validateConditionNode(node actionlint.ExprNode, scope ConditionScope, matri
 			}
 			return nil
 		case "hashfiles":
-			if scope == actionLifecycleCondition {
-				return fmt.Errorf("condition function %q is unsupported in action lifecycle conditions", node.Callee)
-			}
-			if scope != StepCondition {
+			if scope != StepCondition && scope != actionLifecycleCondition {
 				return fmt.Errorf("condition function %q is unavailable in job conditions", node.Callee)
 			}
 			if len(node.Args) == 0 || len(node.Args) > 255 {
@@ -209,7 +206,7 @@ func validateConditionReference(root string, path []string, scope ConditionScope
 	}
 	if scope == actionLifecycleCondition {
 		switch strings.ToLower(root) {
-		case "env", "github", "job", "matrix", "runner", "steps":
+		case "env", "github", "inputs", "job", "matrix", "runner", "steps":
 		default:
 			return fmt.Errorf("lifecycle condition context %q is unsupported", root)
 		}
@@ -238,6 +235,11 @@ func validateConditionReference(root string, path []string, scope ConditionScope
 			return nil
 		}
 		return fmt.Errorf("condition reference %q is unsupported; expected vars.<name>", reference)
+	case "inputs":
+		if len(path) == 1 {
+			return nil
+		}
+		return fmt.Errorf("condition reference %q is unsupported; expected inputs.<name>", reference)
 	case "matrix":
 		// Matrix values may be objects or arrays, so nested references such
 		// as matrix.config.os are valid.
@@ -276,6 +278,21 @@ func validateConditionReference(root string, path []string, scope ConditionScope
 
 func validateConditionAccessNode(validator *semanticValidator, node actionlint.ExprNode, scope ConditionScope) error {
 	root := strings.ToLower(referenceRoot(node))
+	if scope == actionLifecycleCondition {
+		switch root {
+		case "env", "github", "inputs", "job", "matrix", "runner", "steps":
+		default:
+			return fmt.Errorf("lifecycle condition context %q is unsupported", root)
+		}
+		if _, whole := node.(*actionlint.VariableNode); whole {
+			return fmt.Errorf("whole lifecycle condition context %q is unsupported", root)
+		}
+		staticRoot, path, err := referencePath(node)
+		if err != nil {
+			return fmt.Errorf("dynamic lifecycle condition access is unsupported")
+		}
+		return validateConditionReference(staticRoot, path, scope)
+	}
 	switch root {
 	case "":
 		switch node := node.(type) {

--- a/internal/expression/condition.go
+++ b/internal/expression/condition.go
@@ -36,6 +36,9 @@ const (
 	JobCondition ConditionScope = iota
 	// StepCondition is evaluated while a job is running.
 	StepCondition
+	// ActionLifecycleCondition is evaluated for action pre-if and post-if
+	// metadata. It has its own context policy and no implicit success guard.
+	ActionLifecycleCondition
 )
 
 // ValidateCondition verifies that a job or step condition uses only expression
@@ -49,6 +52,23 @@ func ValidateCondition(source string, scope ConditionScope) error {
 // types against one concrete, statically expanded matrix instance.
 func ValidateConditionWithMatrix(source string, scope ConditionScope, matrix map[string]any) error {
 	return validateCondition(source, scope, matrix, true)
+}
+
+// ValidateActionLifecycleCondition verifies an action pre-if or post-if
+// expression without resolving runtime-dependent values.
+func ValidateActionLifecycleCondition(source string) error {
+	if err := validateLifecycleDelimiters(source); err != nil {
+		return err
+	}
+	return validateCondition(source, ActionLifecycleCondition, nil, false)
+}
+
+func validateLifecycleDelimiters(source string) error {
+	condition := strings.TrimSpace(source)
+	if strings.HasPrefix(condition, "${{") != strings.HasSuffix(condition, "}}") {
+		return fmt.Errorf("parse condition: mismatched expression delimiters")
+	}
+	return nil
 }
 
 // ValidateCompileConditionWithMatrix verifies every branch of an event-backed
@@ -95,6 +115,9 @@ func validateConditionNode(node actionlint.ExprNode, scope ConditionScope, matri
 			}
 			return nil
 		case "hashfiles":
+			if scope == ActionLifecycleCondition {
+				return fmt.Errorf("condition function %q is unsupported in action lifecycle conditions", node.Callee)
+			}
 			if scope != StepCondition {
 				return fmt.Errorf("condition function %q is unavailable in job conditions", node.Callee)
 			}
@@ -183,6 +206,13 @@ func validateConditionReference(root string, path []string, scope ConditionScope
 	reference := root
 	if len(path) != 0 {
 		reference += "." + strings.Join(path, ".")
+	}
+	if scope == ActionLifecycleCondition {
+		switch strings.ToLower(root) {
+		case "env", "github", "job", "matrix", "runner", "steps":
+		default:
+			return fmt.Errorf("lifecycle condition context %q is unsupported", root)
+		}
 	}
 	switch strings.ToLower(root) {
 	case "runner":
@@ -297,32 +327,30 @@ func validateConditionAccessNode(validator *semanticValidator, node actionlint.E
 	return validationErr
 }
 
-// EvaluateActionLifecycleCondition evaluates an action pre-if or post-if
-// condition against the supplied lifecycle state. The accepted grammar is
-// deliberately narrower than general conditions: exactly one status function,
-// or !cancelled(), with optional ${{ }} delimiters. An empty condition is
-// unconditionally true (unlike general conditions, which apply the implicit
-// success guard), failure() means unsuccessful and not cancelled, and any
-// other expression fails closed with an error.
-func EvaluateActionLifecycleCondition(value string, unsuccessful, cancelled bool) (bool, error) {
-	value = strings.TrimSpace(value)
-	if strings.HasPrefix(value, "${{") && strings.HasSuffix(value, "}}") {
-		value = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(value, "${{"), "}}"))
+// EvaluateActionLifecycleCondition evaluates action pre-if or post-if
+// metadata. Empty conditions are unconditionally true and, unlike workflow
+// step conditions, lifecycle conditions have no implicit success guard.
+func EvaluateActionLifecycleCondition(source string, context ConditionContext) (bool, error) {
+	if err := validateLifecycleDelimiters(source); err != nil {
+		return false, err
 	}
-	switch strings.ToLower(value) {
-	case "", "always()":
+	node, empty, err := parseCondition(source)
+	if err != nil {
+		return false, err
+	}
+	if empty {
 		return true, nil
-	case "success()":
-		return !unsuccessful && !cancelled, nil
-	case "failure()":
-		return unsuccessful && !cancelled, nil
-	case "cancelled()":
-		return cancelled, nil
-	case "!cancelled()":
-		return !cancelled, nil
-	default:
-		return false, fmt.Errorf("condition %q is unsupported", value)
 	}
+	// Validate before evaluation so short-circuiting cannot hide an
+	// unsupported context or function in an unselected branch.
+	if err := validateConditionNode(node, ActionLifecycleCondition, nil, false); err != nil {
+		return false, err
+	}
+	value, err := evaluateConditionNode(node, context)
+	if err != nil {
+		return false, err
+	}
+	return githubTruthy(value), nil
 }
 
 // EvaluateCondition evaluates a job or step condition. Unsupported syntax and

--- a/internal/expression/condition.go
+++ b/internal/expression/condition.go
@@ -36,9 +36,9 @@ const (
 	JobCondition ConditionScope = iota
 	// StepCondition is evaluated while a job is running.
 	StepCondition
-	// ActionLifecycleCondition is evaluated for action pre-if and post-if
+	// actionLifecycleCondition is evaluated for action pre-if and post-if
 	// metadata. It has its own context policy and no implicit success guard.
-	ActionLifecycleCondition
+	actionLifecycleCondition
 )
 
 // ValidateCondition verifies that a job or step condition uses only expression
@@ -60,7 +60,7 @@ func ValidateActionLifecycleCondition(source string) error {
 	if err := validateLifecycleDelimiters(source); err != nil {
 		return err
 	}
-	return validateCondition(source, ActionLifecycleCondition, nil, false)
+	return validateCondition(source, actionLifecycleCondition, nil, false)
 }
 
 func validateLifecycleDelimiters(source string) error {
@@ -115,7 +115,7 @@ func validateConditionNode(node actionlint.ExprNode, scope ConditionScope, matri
 			}
 			return nil
 		case "hashfiles":
-			if scope == ActionLifecycleCondition {
+			if scope == actionLifecycleCondition {
 				return fmt.Errorf("condition function %q is unsupported in action lifecycle conditions", node.Callee)
 			}
 			if scope != StepCondition {
@@ -207,7 +207,7 @@ func validateConditionReference(root string, path []string, scope ConditionScope
 	if len(path) != 0 {
 		reference += "." + strings.Join(path, ".")
 	}
-	if scope == ActionLifecycleCondition {
+	if scope == actionLifecycleCondition {
 		switch strings.ToLower(root) {
 		case "env", "github", "job", "matrix", "runner", "steps":
 		default:
@@ -343,7 +343,7 @@ func EvaluateActionLifecycleCondition(source string, context ConditionContext) (
 	}
 	// Validate before evaluation so short-circuiting cannot hide an
 	// unsupported context or function in an unselected branch.
-	if err := validateConditionNode(node, ActionLifecycleCondition, nil, false); err != nil {
+	if err := validateConditionNode(node, actionLifecycleCondition, nil, false); err != nil {
 		return false, err
 	}
 	value, err := evaluateConditionNode(node, context)

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -894,6 +894,7 @@ func TestEvaluateActionLifecycleCondition(t *testing.T) {
 		condition    string
 		unsuccessful bool
 		cancelled    bool
+		env          map[string]string
 		want         bool
 		wantErr      bool
 	}{
@@ -917,17 +918,29 @@ func TestEvaluateActionLifecycleCondition(t *testing.T) {
 		{name: "delimiters without spaces", condition: "${{always()}}", cancelled: true, want: true},
 		{name: "case is insensitive", condition: "ALWAYS()", want: true},
 		{name: "surrounding whitespace trims", condition: "  success()  ", want: true},
-		{name: "literals fail closed", condition: "true", wantErr: true},
+		{name: "literal", condition: "true", want: true},
+		{name: "rust-cache succeeds normally", condition: "success() || env.CACHE_ON_FAILURE == 'true'", want: true},
+		{name: "rust-cache skips after failure by default", condition: "success() || env.CACHE_ON_FAILURE == 'true'", unsuccessful: true},
+		{name: "rust-cache skips after failure when disabled", condition: "success() || env.CACHE_ON_FAILURE == 'true'", unsuccessful: true, env: map[string]string{"CACHE_ON_FAILURE": "false"}},
+		{name: "rust-cache runs after opted-in failure", condition: "success() || env.CACHE_ON_FAILURE == 'true'", unsuccessful: true, env: map[string]string{"CACHE_ON_FAILURE": "true"}, want: true},
+		{name: "rust-cache skips after cancellation", condition: "success() || env.CACHE_ON_FAILURE == 'true'", cancelled: true},
 		{name: "references fail closed", condition: "github.event_name == 'push'", wantErr: true},
-		{name: "compound expressions fail closed", condition: "success() || failure()", wantErr: true},
+		{name: "compound status expression", condition: "success() || failure()", unsuccessful: true, want: true},
 		{name: "arguments fail closed", condition: "success('build')", wantErr: true},
 		{name: "unknown functions fail closed", condition: "finished()", wantErr: true},
+		{name: "unsupported lazy branch fails closed", condition: "success() || secrets.TOKEN != ''", wantErr: true},
 		{name: "unopened delimiter fails closed", condition: "failure() }}", wantErr: true},
 		{name: "unclosed delimiter fails closed", condition: "${{ failure()", wantErr: true},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := EvaluateActionLifecycleCondition(test.condition, test.unsuccessful, test.cancelled)
+			context := ConditionContext{
+				Env:          test.env,
+				Failure:      test.unsuccessful && !test.cancelled,
+				Unsuccessful: test.unsuccessful,
+				Cancelled:    test.cancelled,
+			}
+			got, err := EvaluateActionLifecycleCondition(test.condition, context)
 			if test.wantErr {
 				if err == nil || got {
 					t.Fatalf("EvaluateActionLifecycleCondition(%q) = %v, %v, want false with error", test.condition, got, err)
@@ -938,6 +951,28 @@ func TestEvaluateActionLifecycleCondition(t *testing.T) {
 				t.Fatalf("EvaluateActionLifecycleCondition(%q, unsuccessful=%v, cancelled=%v) = %v, %v, want %v", test.condition, test.unsuccessful, test.cancelled, got, err, test.want)
 			}
 		})
+	}
+}
+
+func TestValidateActionLifecycleCondition(t *testing.T) {
+	for _, condition := range []string{
+		"success() || env.CACHE_ON_FAILURE == 'true'",
+		"${{ failure() && matrix.allow_failure }}",
+		"steps.build.conclusion == 'success' && runner.os == 'Linux'",
+	} {
+		if err := ValidateActionLifecycleCondition(condition); err != nil {
+			t.Errorf("ValidateActionLifecycleCondition(%q) error = %v", condition, err)
+		}
+	}
+	for _, condition := range []string{
+		"success() || secrets.TOKEN != ''",
+		"success() || needs.build.result == 'success'",
+		"hashFiles('go.mod') != ''",
+		"unknown()",
+	} {
+		if err := ValidateActionLifecycleCondition(condition); err == nil {
+			t.Errorf("ValidateActionLifecycleCondition(%q) accepted unsupported expression", condition)
+		}
 	}
 }
 

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -959,6 +959,8 @@ func TestValidateActionLifecycleCondition(t *testing.T) {
 		"success() || env.CACHE_ON_FAILURE == 'true'",
 		"${{ failure() && matrix.allow_failure }}",
 		"steps.build.conclusion == 'success' && runner.os == 'Linux'",
+		"inputs.cache == true && hashFiles('Cargo.lock') != ''",
+		"inputs['cache'] == true",
 	} {
 		if err := ValidateActionLifecycleCondition(condition); err != nil {
 			t.Errorf("ValidateActionLifecycleCondition(%q) error = %v", condition, err)
@@ -967,12 +969,33 @@ func TestValidateActionLifecycleCondition(t *testing.T) {
 	for _, condition := range []string{
 		"success() || secrets.TOKEN != ''",
 		"success() || needs.build.result == 'success'",
-		"hashFiles('go.mod') != ''",
+		"needs[env.JOB].result == 'success'",
+		"vars[env.FLAG] == 'true'",
+		"steps[env.STEP].conclusion == 'success'",
+		"inputs[env.INPUT] == true",
 		"unknown()",
 	} {
 		if err := ValidateActionLifecycleCondition(condition); err == nil {
 			t.Errorf("ValidateActionLifecycleCondition(%q) accepted unsupported expression", condition)
 		}
+	}
+}
+
+func TestEvaluateActionLifecycleConditionUsesWorkflowInputsAndHashFiles(t *testing.T) {
+	var patterns []string
+	context := ConditionContext{
+		Inputs: map[string]any{"cache": true},
+		HashFiles: func(got []string) (string, error) {
+			patterns = append([]string(nil), got...)
+			return "digest", nil
+		},
+	}
+	got, err := EvaluateActionLifecycleCondition("inputs.cache && hashFiles('Cargo.lock') != ''", context)
+	if err != nil || !got {
+		t.Fatalf("EvaluateActionLifecycleCondition() = %v, %v, want true", got, err)
+	}
+	if !reflect.DeepEqual(patterns, []string{"Cargo.lock"}) {
+		t.Fatalf("hashFiles patterns = %#v, want [Cargo.lock]", patterns)
 	}
 }
 

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -128,7 +128,7 @@ type preparedInvocation struct {
 	state          map[string]string
 	node           string
 	eval           expression.Context
-	env            map[string]string
+	envOverlay     map[string]string
 	isolated       bool
 	postRegistered bool
 }
@@ -656,7 +656,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 			preCtx, cancelPre := stepContext(runCtx, step.TimeoutMinutes)
 			bindHashFilesContext(preCtx, &preEval)
 			wasUnsuccessful := preStatus.unsuccessful
-			preResult, preErr := r.prepareRemoteAction(preCtx, processor, workspace, step, strconv.Itoa(stepIndex), preEnv, preEval, &posts, actions, prepared, &preStatus, true, nil, nil)
+			preResult, preErr := r.prepareRemoteAction(preCtx, processor, workspace, step, strconv.Itoa(stepIndex), preEnv, preEval, &posts, actions, prepared, &preStatus, true, nil, nil, nil)
 			commitResultEnvironment(jobResult.Env, preResult)
 			mergeInto(jobResult.State, preResult.State)
 			appendJobSummary(&jobResult.Summary, &jobResult.summaryTruncated, preResult.Summary, preResult.summaryTruncated)
@@ -816,7 +816,8 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		if !invocation.isolated {
 			postEval.Steps = cloneStepStatuses(eval.Steps)
 		}
-		postEval.Env = mergeStringMaps(jobResult.Env, invocation.env)
+		postEval.Env = mergeStringMaps(jobResult.Env, invocation.envOverlay)
+		bindHashFilesContext(postCtx, &postEval)
 		unsuccessful, cancelled := runErr != nil, runCtx.Err() != nil
 		condition := lifecycleConditionContext(postEval, unsuccessful, cancelled)
 		runPost, conditionErr := expression.EvaluateActionLifecycleCondition(post.condition, condition)
@@ -1105,6 +1106,7 @@ func stepExpressionContext(context expression.Context) expression.Context {
 
 func lifecycleConditionContext(eval expression.Context, unsuccessful, cancelled bool) expression.ConditionContext {
 	return expression.ConditionContext{
+		Inputs:       eval.WorkflowInputs,
 		Steps:        eval.Steps,
 		Env:          eval.Env,
 		Matrix:       eval.Matrix,
@@ -1114,6 +1116,7 @@ func lifecycleConditionContext(eval expression.Context, unsuccessful, cancelled 
 		Failure:      unsuccessful && !cancelled,
 		Unsuccessful: unsuccessful,
 		Cancelled:    cancelled,
+		HashFiles:    eval.HashFiles,
 	}
 }
 
@@ -1497,7 +1500,7 @@ func isRuntimeContextEnvironment(name string) bool {
 }
 
 func (r Runner) runJobStep(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, step plan.Step, invocationID string, jobEnv, stepEnv map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations) (Result, error) {
-	return r.runActionStep(ctx, processor, workspace, job, step, invocationID, jobEnv, stepEnv, nil, eval, posts, actions, prepared, nil)
+	return r.runActionStep(ctx, processor, workspace, job, step, invocationID, jobEnv, stepEnv, nil, eval, posts, actions, prepared, nil, nil)
 }
 
 // verifyRemoteActionTree materializes and verifies every remote subtree before
@@ -1649,7 +1652,7 @@ func (r *Runner) actionContainerMounts(ctx context.Context, actions *actionLockR
 	return out, nil
 }
 
-func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProcessor, workspace string, step plan.Step, invocationID string, jobEnv map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations, status *remotePreparationStatus, workflowStep bool, inheritedEvalErr error, inheritedTimeout *remotePreparationTimeout) (Result, error) {
+func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProcessor, workspace string, step plan.Step, invocationID string, jobEnv map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations, status *remotePreparationStatus, workflowStep bool, inheritedEvalErr error, inheritedTimeout *remotePreparationTimeout, inheritedEnvOverlay map[string]string) (Result, error) {
 	result := newResult()
 	eval.JobStatus = jobStatusValue(status.unsuccessful, ctx.Err() != nil)
 	evaluate := evaluateMap
@@ -1702,6 +1705,7 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 		}
 		javascript := javaScriptAction{Name: actionName(action, step), Path: action.Path, Pre: action.Runs.Pre, Main: action.Runs.Main, Post: action.Runs.Post, Cache: usesCacheService(lock), CacheClientCompatibility: usesCacheClientCompatibility(lock), nodeMajor: major, reference: step.Uses, jobStatusInputs: jobStatusInputs}
 		invocationEval := cloneExpressionContext(eval)
+		bindHashFilesContext(ctx, &invocationEval)
 		invocation := &preparedInvocation{action: javascript, state: map[string]string{}, eval: invocationEval, isolated: !workflowStep}
 		prepared[invocationID] = invocation
 		if javascript.Pre != "" {
@@ -1752,7 +1756,7 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 			javascript.Env = mergeStepEnvironment(jobEnv, stepEnv)
 			invocation.action = javascript
 			invocation.eval = invocationEval
-			invocation.env = cloneStrings(stepEnv)
+			invocation.envOverlay = mergeStringMaps(inheritedEnvOverlay, stepEnv)
 			node, err := r.discoverNode(phaseCtx, major, explicit)
 			if err != nil {
 				return result, err
@@ -1787,6 +1791,7 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 		eval.Inputs = inputs
 		compositeProcessEnv := mergeStepEnvironment(jobEnv, stepEnv)
 		compositeExpressionEnv := mergeStringMaps(eval.Env, stepEnv)
+		lifecycleEnvOverlay := mergeStringMaps(inheritedEnvOverlay, stepEnv)
 		for i, childStep := range action.Runs.Steps {
 			if childStep.Uses == "" {
 				continue
@@ -1798,7 +1803,7 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 			child := plan.Step{ID: childStep.ID, Name: childStep.Name, Kind: "uses", Uses: childStep.Uses, With: childStep.With, Env: childStep.Env, Action: &plan.ActionSelector{Lock: selector.Lock}}
 			childProcessEnv := mergeStepEnvironment(compositeProcessEnv, result.Env)
 			eval.Env = mergeStringMaps(compositeExpressionEnv, result.Env)
-			childResult, childErr := r.prepareRemoteAction(ctx, processor, workspace, child, fmt.Sprintf("%s/%d", invocationID, i), childProcessEnv, eval, posts, actions, prepared, status, false, compositeEvalErr, preparationTimeout)
+			childResult, childErr := r.prepareRemoteAction(ctx, processor, workspace, child, fmt.Sprintf("%s/%d", invocationID, i), childProcessEnv, eval, posts, actions, prepared, status, false, compositeEvalErr, preparationTimeout, lifecycleEnvOverlay)
 			mergeInto(result.Env, childResult.Env)
 			if childResult.pathBaseSet {
 				result.pathBase = childResult.pathBase
@@ -1819,7 +1824,7 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 	}
 }
 
-func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, step plan.Step, invocationID string, jobEnv, stepEnv, evaluatedWith map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations, actionStack []string) (Result, error) {
+func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, step plan.Step, invocationID string, jobEnv, stepEnv, evaluatedWith map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations, actionStack []string, inheritedEnvOverlay map[string]string) (Result, error) {
 	if stepEnv == nil {
 		var err error
 		stepEnv, err = evaluateStepMap(step.Env, eval)
@@ -1827,6 +1832,7 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 			return newResult(), err
 		}
 	}
+	lifecycleEnvOverlay := mergeStringMaps(inheritedEnvOverlay, stepEnv)
 	environment := r.invocationEnvironment(jobEnv, stepEnv)
 	result := newResult()
 	if step.Kind == "run" {
@@ -2005,6 +2011,7 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 			invocation.action = javascript
 		}
 		lifecycleEval := cloneExpressionContext(eval)
+		bindHashFilesContext(ctx, &lifecycleEval)
 		lifecycleEval.Env = mergeStringMaps(lifecycleEval.Env, stepEnv)
 		isolated := len(actionStack) > 1
 		if invocation != nil {
@@ -2017,7 +2024,7 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 			lifecycleEval.Steps = eval.Steps
 		}
 		if invocation == nil {
-			invocation = &preparedInvocation{action: javascript, state: state, node: node, eval: lifecycleEval, env: cloneStrings(stepEnv), isolated: isolated}
+			invocation = &preparedInvocation{action: javascript, state: state, node: node, eval: lifecycleEval, envOverlay: lifecycleEnvOverlay, isolated: isolated}
 		}
 		if !invocation.postRegistered {
 			posts.register(postForInvocation(invocation, action.Runs.PostIf))
@@ -2041,13 +2048,13 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 		invocation.action = javascript
 		invocation.node = node
 		invocation.eval = lifecycleEval
-		invocation.env = mergeStringMaps(stepEnv, result.Env)
+		invocation.envOverlay = lifecycleEnvOverlay
 		if mainErr != nil {
 			return result, mainErr
 		}
 		return result, nil
 	case metadata.RuntimeComposite:
-		composite, err := r.runCompositeMetadata(ctx, processor, workspace, job, actionPath, action, inputs, invocationID, jobEnv, stepEnv, actionEval, posts, actions, prepared, actionLock, actionStack)
+		composite, err := r.runCompositeMetadata(ctx, processor, workspace, job, actionPath, action, inputs, invocationID, jobEnv, stepEnv, lifecycleEnvOverlay, actionEval, posts, actions, prepared, actionLock, actionStack)
 		return composite, err
 	case metadata.RuntimeDocker:
 		if goruntime.GOOS == "darwin" {
@@ -2080,12 +2087,11 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 	return result, fmt.Errorf("action %q uses unsupported runtime %q", step.Uses, actionRuntime)
 }
 
-func (r Runner) runCompositeMetadata(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, actionPath string, action metadata.Metadata, inputs map[string]string, invocationID string, jobEnv, stepEnv map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations, actionLock *plan.ActionLock, actionStack []string) (Result, error) {
+func (r Runner) runCompositeMetadata(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, actionPath string, action metadata.Metadata, inputs map[string]string, invocationID string, jobEnv, stepEnv, lifecycleEnvOverlay map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations, actionLock *plan.ActionLock, actionStack []string) (Result, error) {
 	result := newResult()
-	// hashFiles is a workflow-step surface. Do not extend it into action
-	// metadata expressions while executing a composite action.
+	// Keep hashFiles unavailable to composite step metadata while retaining the
+	// context binder for nested JavaScript lifecycle conditions.
 	eval.HashFiles = nil
-	eval.HashFilesContext = nil
 	eval.Inputs = inputs
 	eval.Steps = make(map[string]expression.StepStatus)
 	compositeProcessEnv := mergeStepEnvironment(jobEnv, stepEnv)
@@ -2144,7 +2150,7 @@ func (r Runner) runCompositeMetadata(ctx context.Context, processor *commandProc
 				}
 			}
 			if childErr == nil {
-				stepResult, childErr = r.runActionStep(ctx, processor, workspace, job, child, fmt.Sprintf("%s/%d", invocationID, i), childJobEnv, childEnv, childWith, eval, posts, actions, prepared, actionStack)
+				stepResult, childErr = r.runActionStep(ctx, processor, workspace, job, child, fmt.Sprintf("%s/%d", invocationID, i), childJobEnv, childEnv, childWith, eval, posts, actions, prepared, actionStack, lifecycleEnvOverlay)
 			}
 		} else if strings.TrimSpace(step.Run) == "" {
 			childErr = fmt.Errorf("composite action step %d has no run command", i+1)

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -828,6 +828,9 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		if !runPost {
 			continue
 		}
+		// The post process uses the same live final environment and declared
+		// invocation overlays as its condition, not the main-time snapshot.
+		action.Env = cloneStrings(invocation.envOverlay)
 		if len(action.jobStatusInputs) != 0 {
 			action.Inputs = cloneStrings(action.Inputs)
 			status := jobStatusValue(runErr != nil, runCtx.Err() != nil)

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -114,9 +114,6 @@ func tolerateJobSetupFailure(runCtx context.Context, job plan.Job, result JobRes
 }
 
 type registeredPost struct {
-	action     javaScriptAction
-	state      map[string]string
-	node       string
 	condition  string
 	invocation *preparedInvocation
 }
@@ -130,6 +127,9 @@ type preparedInvocation struct {
 	action         javaScriptAction
 	state          map[string]string
 	node           string
+	eval           expression.Context
+	env            map[string]string
+	isolated       bool
 	postRegistered bool
 }
 
@@ -810,34 +810,38 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 	registeredPosts := posts.snapshot()
 	for i := len(registeredPosts) - 1; i >= 0; i-- {
 		post := registeredPosts[i]
-		if post.invocation != nil {
-			post.action = post.invocation.action
-			post.state = post.invocation.state
-			post.node = post.invocation.node
+		invocation := post.invocation
+		action := invocation.action
+		postEval := cloneExpressionContext(invocation.eval)
+		if !invocation.isolated {
+			postEval.Steps = cloneStepStatuses(eval.Steps)
 		}
-		runPost, conditionErr := expression.EvaluateActionLifecycleCondition(post.condition, runErr != nil, runCtx.Err() != nil)
+		postEval.Env = mergeStringMaps(jobResult.Env, invocation.env)
+		unsuccessful, cancelled := runErr != nil, runCtx.Err() != nil
+		condition := lifecycleConditionContext(postEval, postEval.Env, unsuccessful, cancelled)
+		runPost, conditionErr := expression.EvaluateActionLifecycleCondition(post.condition, condition)
 		if conditionErr != nil {
-			runErr = errors.Join(runErr, fmt.Errorf("post action %q condition: %w", post.action.Name, conditionErr))
+			runErr = errors.Join(runErr, fmt.Errorf("post action %q condition: %w", action.Name, conditionErr))
 			continue
 		}
 		if !runPost {
 			continue
 		}
-		if len(post.action.jobStatusInputs) != 0 {
-			post.action.Inputs = cloneStrings(post.action.Inputs)
+		if len(action.jobStatusInputs) != 0 {
+			action.Inputs = cloneStrings(action.Inputs)
 			status := jobStatusValue(runErr != nil, runCtx.Err() != nil)
-			for _, name := range post.action.jobStatusInputs {
-				post.action.Inputs[name] = status
+			for _, name := range action.jobStatusInputs {
+				action.Inputs[name] = status
 			}
 		}
 		postResult := newResult()
 		postResult.Env = cloneStrings(jobResult.Env)
-		postErr := r.runJavaScriptPhase(postCtx, processor, workspace, post.node, post.action, post.action.Post, post.state, post.state, &postResult)
+		postErr := r.runJavaScriptPhase(postCtx, processor, workspace, invocation.node, action, action.Post, invocation.state, invocation.state, &postResult)
 		mergeInto(jobResult.Env, postResult.Env)
 		mergeInto(jobResult.State, postResult.State)
 		appendJobSummary(&jobResult.Summary, &jobResult.summaryTruncated, postResult.Summary, postResult.summaryTruncated)
 		if postErr != nil {
-			runErr = errors.Join(runErr, fmt.Errorf("post action %q: %w", post.action.Name, postErr))
+			runErr = errors.Join(runErr, fmt.Errorf("post action %q: %w", action.Name, postErr))
 		}
 	}
 
@@ -1097,6 +1101,22 @@ func stepExpressionContext(context expression.Context) expression.Context {
 		context.GitHub["token"] = token
 	}
 	return context
+}
+
+func lifecycleConditionContext(eval expression.Context, env map[string]string, unsuccessful, cancelled bool) expression.ConditionContext {
+	return expression.ConditionContext{
+		Needs:        eval.Needs,
+		Steps:        eval.Steps,
+		Env:          env,
+		Vars:         eval.Vars,
+		Matrix:       eval.Matrix,
+		GitHub:       eval.GitHub,
+		Runner:       eval.Runner,
+		Services:     eval.Services,
+		Failure:      unsuccessful && !cancelled,
+		Unsuccessful: unsuccessful,
+		Cancelled:    cancelled,
+	}
 }
 
 func scrubJobResult(result JobResult, sensitiveValues []string) JobResult {
@@ -1667,11 +1687,10 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 		if usesCheckoutAdapter(lock) || usesUploadArtifactAdapter(lock) || usesDownloadArtifactAdapter(lock) {
 			return result, nil
 		}
-		runPre, err := expression.EvaluateActionLifecycleCondition(action.Runs.PreIf, status.unsuccessful, ctx.Err() != nil)
-		if err != nil {
+		if err := expression.ValidateActionLifecycleCondition(action.Runs.PreIf); err != nil {
 			return result, fmt.Errorf("JavaScript action %q pre-if: %w", step.Uses, err)
 		}
-		if _, err := expression.EvaluateActionLifecycleCondition(action.Runs.PostIf, false, false); err != nil {
+		if err := expression.ValidateActionLifecycleCondition(action.Runs.PostIf); err != nil {
 			return result, fmt.Errorf("JavaScript action %q post-if: %w", step.Uses, err)
 		}
 		if action.Runs.Pre == "" && action.Runs.Post == "" {
@@ -1684,15 +1703,28 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 			return result, err
 		}
 		javascript := javaScriptAction{Name: actionName(action, step), Path: action.Path, Pre: action.Runs.Pre, Main: action.Runs.Main, Post: action.Runs.Post, Cache: usesCacheService(lock), CacheClientCompatibility: usesCacheClientCompatibility(lock), nodeMajor: major, reference: step.Uses, jobStatusInputs: jobStatusInputs}
-		invocation := &preparedInvocation{action: javascript, state: map[string]string{}}
+		invocationEval := cloneExpressionContext(eval)
+		invocation := &preparedInvocation{action: javascript, state: map[string]string{}, eval: invocationEval, isolated: !workflowStep}
 		prepared[invocationID] = invocation
-		if javascript.Pre != "" && runPre {
+		if javascript.Pre != "" {
+			stepEnv := map[string]string{}
+			if inheritedEvalErr == nil {
+				stepEnv, err = evaluate(step.Env, eval)
+				if err != nil {
+					return result, err
+				}
+				invocationEval.Env = mergeStringMaps(invocationEval.Env, stepEnv)
+			}
+			condition := lifecycleConditionContext(invocationEval, invocationEval.Env, status.unsuccessful, ctx.Err() != nil)
+			runPre, err := expression.EvaluateActionLifecycleCondition(action.Runs.PreIf, condition)
+			if err != nil {
+				return result, fmt.Errorf("JavaScript action %q pre-if: %w", step.Uses, err)
+			}
+			if !runPre {
+				return result, nil
+			}
 			if inheritedEvalErr != nil {
 				return result, inheritedEvalErr
-			}
-			stepEnv, err := evaluate(step.Env, eval)
-			if err != nil {
-				return result, err
 			}
 			eval.Env = mergeStringMaps(eval.Env, stepEnv)
 			phaseCtx := ctx
@@ -1721,6 +1753,8 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 			javascript.Inputs = inputs
 			javascript.Env = mergeStepEnvironment(jobEnv, stepEnv)
 			invocation.action = javascript
+			invocation.eval = invocationEval
+			invocation.env = cloneStrings(stepEnv)
 			node, err := r.discoverNode(phaseCtx, major, explicit)
 			if err != nil {
 				return result, err
@@ -1942,10 +1976,10 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 		if action.Runs.Main == "" {
 			return result, fmt.Errorf("JavaScript action %q has no main entry point", step.Uses)
 		}
-		if _, err := expression.EvaluateActionLifecycleCondition(action.Runs.PreIf, false, false); err != nil {
+		if err := expression.ValidateActionLifecycleCondition(action.Runs.PreIf); err != nil {
 			return result, fmt.Errorf("JavaScript action %q pre-if: %w", step.Uses, err)
 		}
-		if _, err := expression.EvaluateActionLifecycleCondition(action.Runs.PostIf, false, false); err != nil {
+		if err := expression.ValidateActionLifecycleCondition(action.Runs.PostIf); err != nil {
 			return result, fmt.Errorf("JavaScript action %q post-if: %w", step.Uses, err)
 		}
 		major, _ := actionNodeMajor(actionRuntime)
@@ -1958,7 +1992,8 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 		javascript := javaScriptAction{Name: actionName(action, step), Path: actionPath, Pre: action.Runs.Pre, Main: action.Runs.Main, Post: action.Runs.Post, Inputs: inputs, Env: actionEnv, Cache: actionLock != nil && usesCacheService(*actionLock), CacheClientCompatibility: actionLock != nil && usesCacheClientCompatibility(*actionLock), nodeMajor: major, reference: step.Uses, jobStatusInputs: jobStatusInputs}
 		state := map[string]string{}
 		wasPrepared := false
-		if invocation := prepared[invocationID]; invocation != nil {
+		invocation := prepared[invocationID]
+		if invocation != nil {
 			javascript, state, wasPrepared = invocation.action, invocation.state, true
 			if invocation.node != "" {
 				node = invocation.node
@@ -1971,22 +2006,36 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 			javascript.Env = environment.process()
 			invocation.action = javascript
 		}
-		if !wasPrepared {
-			posts.register(postFor(javascript, state, node, action.Runs.PostIf))
-		} else if invocation := prepared[invocationID]; !invocation.postRegistered {
+		lifecycleEval := cloneExpressionContext(eval)
+		lifecycleEval.Env = mergeStringMaps(lifecycleEval.Env, stepEnv)
+		if invocation == nil {
+			invocation = &preparedInvocation{action: javascript, state: state, node: node, eval: lifecycleEval, env: cloneStrings(stepEnv), isolated: len(actionStack) > 1}
+		}
+		if !invocation.postRegistered {
 			posts.register(postForInvocation(invocation, action.Runs.PostIf))
 			invocation.postRegistered = true
 		}
 		if javascript.Pre != "" && !wasPrepared {
-			runPre, _ := expression.EvaluateActionLifecycleCondition(action.Runs.PreIf, false, false)
+			cancelled := eval.JobStatus == "cancelled"
+			unsuccessful := eval.JobStatus == "failure" || cancelled
+			condition := lifecycleConditionContext(lifecycleEval, lifecycleEval.Env, unsuccessful, cancelled)
+			runPre, err := expression.EvaluateActionLifecycleCondition(action.Runs.PreIf, condition)
+			if err != nil {
+				return result, fmt.Errorf("JavaScript action %q pre-if: %w", step.Uses, err)
+			}
 			if runPre {
 				if err := r.runJavaScriptPhase(ctx, processor, workspace, node, javascript, javascript.Pre, nil, state, &result); err != nil {
 					return result, err
 				}
 			}
 		}
-		if err := r.runJavaScriptPhase(ctx, processor, workspace, node, javascript, javascript.Main, nil, state, &result); err != nil {
-			return result, err
+		mainErr := r.runJavaScriptPhase(ctx, processor, workspace, node, javascript, javascript.Main, nil, state, &result)
+		invocation.action = javascript
+		invocation.node = node
+		invocation.eval = lifecycleEval
+		invocation.env = mergeStringMaps(stepEnv, result.Env)
+		if mainErr != nil {
+			return result, mainErr
 		}
 		return result, nil
 	case metadata.RuntimeComposite:
@@ -2296,13 +2345,6 @@ func workspacePath(root, path string) (string, error) {
 		return "", fmt.Errorf("path %q escapes workspace %q", path, root)
 	}
 	return resolved, nil
-}
-
-func postFor(action javaScriptAction, state map[string]string, node, condition string) *registeredPost {
-	if action.Post == "" {
-		return nil
-	}
-	return &registeredPost{action: action, state: state, node: node, condition: condition}
 }
 
 func postForInvocation(invocation *preparedInvocation, condition string) *registeredPost {

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -818,7 +818,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		}
 		postEval.Env = mergeStringMaps(jobResult.Env, invocation.env)
 		unsuccessful, cancelled := runErr != nil, runCtx.Err() != nil
-		condition := lifecycleConditionContext(postEval, postEval.Env, unsuccessful, cancelled)
+		condition := lifecycleConditionContext(postEval, unsuccessful, cancelled)
 		runPost, conditionErr := expression.EvaluateActionLifecycleCondition(post.condition, condition)
 		if conditionErr != nil {
 			runErr = errors.Join(runErr, fmt.Errorf("post action %q condition: %w", action.Name, conditionErr))
@@ -1103,12 +1103,10 @@ func stepExpressionContext(context expression.Context) expression.Context {
 	return context
 }
 
-func lifecycleConditionContext(eval expression.Context, env map[string]string, unsuccessful, cancelled bool) expression.ConditionContext {
+func lifecycleConditionContext(eval expression.Context, unsuccessful, cancelled bool) expression.ConditionContext {
 	return expression.ConditionContext{
-		Needs:        eval.Needs,
 		Steps:        eval.Steps,
-		Env:          env,
-		Vars:         eval.Vars,
+		Env:          eval.Env,
 		Matrix:       eval.Matrix,
 		GitHub:       eval.GitHub,
 		Runner:       eval.Runner,
@@ -1715,7 +1713,7 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 				}
 				invocationEval.Env = mergeStringMaps(invocationEval.Env, stepEnv)
 			}
-			condition := lifecycleConditionContext(invocationEval, invocationEval.Env, status.unsuccessful, ctx.Err() != nil)
+			condition := lifecycleConditionContext(invocationEval, status.unsuccessful, ctx.Err() != nil)
 			runPre, err := expression.EvaluateActionLifecycleCondition(action.Runs.PreIf, condition)
 			if err != nil {
 				return result, fmt.Errorf("JavaScript action %q pre-if: %w", step.Uses, err)
@@ -2008,8 +2006,18 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 		}
 		lifecycleEval := cloneExpressionContext(eval)
 		lifecycleEval.Env = mergeStringMaps(lifecycleEval.Env, stepEnv)
+		isolated := len(actionStack) > 1
+		if invocation != nil {
+			isolated = invocation.isolated
+		}
+		if isolated {
+			// Composite steps execute sequentially and own a per-invocation
+			// map. Retain that map so post-if sees its final state without
+			// exposing workflow or sibling-composite steps.
+			lifecycleEval.Steps = eval.Steps
+		}
 		if invocation == nil {
-			invocation = &preparedInvocation{action: javascript, state: state, node: node, eval: lifecycleEval, env: cloneStrings(stepEnv), isolated: len(actionStack) > 1}
+			invocation = &preparedInvocation{action: javascript, state: state, node: node, eval: lifecycleEval, env: cloneStrings(stepEnv), isolated: isolated}
 		}
 		if !invocation.postRegistered {
 			posts.register(postForInvocation(invocation, action.Runs.PostIf))
@@ -2018,7 +2026,7 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 		if javascript.Pre != "" && !wasPrepared {
 			cancelled := eval.JobStatus == "cancelled"
 			unsuccessful := eval.JobStatus == "failure" || cancelled
-			condition := lifecycleConditionContext(lifecycleEval, lifecycleEval.Env, unsuccessful, cancelled)
+			condition := lifecycleConditionContext(lifecycleEval, unsuccessful, cancelled)
 			runPre, err := expression.EvaluateActionLifecycleCondition(action.Runs.PreIf, condition)
 			if err != nil {
 				return result, fmt.Errorf("JavaScript action %q pre-if: %w", step.Uses, err)

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -831,6 +831,11 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		// The post process uses the same live final environment and declared
 		// invocation overlays as its condition, not the main-time snapshot.
 		action.Env = cloneStrings(invocation.envOverlay)
+		for name, value := range invocation.action.Env {
+			if isRuntimeContextEnvironment(name) {
+				action.Env[name] = value
+			}
+		}
 		if len(action.jobStatusInputs) != 0 {
 			action.Inputs = cloneStrings(action.Inputs)
 			status := jobStatusValue(runErr != nil, runCtx.Err() != nil)

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -2110,6 +2110,7 @@ func (r Runner) runCompositeMetadata(ctx context.Context, processor *commandProc
 	inheritedUnsuccessful := inheritedFailure || inheritedCancelled
 	var runErr error
 	for i, step := range action.Runs.Steps {
+		childInvocationID := fmt.Sprintf("%s/%d", invocationID, i)
 		failure := inheritedFailure || runErr != nil
 		cancelled := inheritedCancelled || ctx.Err() != nil
 		unsuccessful := inheritedUnsuccessful || runErr != nil
@@ -2132,6 +2133,11 @@ func (r Runner) runCompositeMetadata(ctx context.Context, processor *commandProc
 		if !run {
 			if id != "" {
 				eval.Steps[id] = expression.StepStatus{Outcome: "skipped", Conclusion: "skipped", Outputs: map[string]string{}}
+			}
+			if invocation := prepared[childInvocationID]; invocation != nil && invocation.isolated {
+				// Pre hooks register posts before composite execution. If main is
+				// skipped, retain this composite's live final step scope for post-if.
+				invocation.eval.Steps = eval.Steps
 			}
 			continue
 		}
@@ -2158,7 +2164,7 @@ func (r Runner) runCompositeMetadata(ctx context.Context, processor *commandProc
 				}
 			}
 			if childErr == nil {
-				stepResult, childErr = r.runActionStep(ctx, processor, workspace, job, child, fmt.Sprintf("%s/%d", invocationID, i), childJobEnv, childEnv, childWith, eval, posts, actions, prepared, actionStack, lifecycleEnvOverlay)
+				stepResult, childErr = r.runActionStep(ctx, processor, workspace, job, child, childInvocationID, childJobEnv, childEnv, childWith, eval, posts, actions, prepared, actionStack, lifecycleEnvOverlay)
 			}
 		} else if strings.TrimSpace(step.Run) == "" {
 			childErr = fmt.Errorf("composite action step %d has no run command", i+1)

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -3184,8 +3184,9 @@ if [ "${1:-}" = --version ]; then echo v24.0.0; exit 0; fi
 case "$(basename "$1")" in
   main.js)
     if [ -n "${CACHE_SETTING:-}" ]; then printf 'CACHE_ON_FAILURE=%s\n' "$CACHE_SETTING" >> "$GITHUB_ENV"; fi
+    printf '%s\n' 'GITHUB_WORKSPACE=/tmp/spoofed' >> "$GITHUB_ENV"
     ;;
-  post.js) printf '%s' "${CACHE_ON_FAILURE:-}" > "$POST_MARKER" ;;
+  post.js) printf '%s|%s' "${CACHE_ON_FAILURE:-}" "$GITHUB_WORKSPACE" > "$POST_MARKER" ;;
 esac
 `)
 			if err := os.Chmod(fakeNode, 0o700); err != nil {
@@ -3211,8 +3212,9 @@ esac
 			}
 			if test.wantPost && test.finalCacheValue != "" {
 				value, err := os.ReadFile(marker)
-				if err != nil || string(value) != test.finalCacheValue {
-					t.Fatalf("post environment = %q, %v, want %q", value, err, test.finalCacheValue)
+				want := test.finalCacheValue + "|" + workspace
+				if err != nil || string(value) != want {
+					t.Fatalf("post environment = %q, %v, want %q", value, err, want)
 				}
 			}
 		})

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -5152,7 +5152,11 @@ func TestRemoteActionPreHooksRunBeforeJobMainInDepthFirstOrder(t *testing.T) {
 		if i == 0 {
 			using = "node20"
 		}
-		writeFixtureFile(t, remote, name+"/action.yml", "name: "+name+"\nruns:\n  using: "+using+"\n  pre: pre.js\n  main: main.js\n  post: post.js\n")
+		postIf := ""
+		if name == "skipped" {
+			postIf = "  post-if: steps.failed.outcome == 'failure' && steps.skipped.outcome == 'skipped' && steps.second.outcome == 'success'\n"
+		}
+		writeFixtureFile(t, remote, name+"/action.yml", "name: "+name+"\nruns:\n  using: "+using+"\n  pre: pre.js\n  main: main.js\n  post: post.js\n"+postIf)
 		for _, phase := range []string{"pre", "main", "post"} {
 			writeFixtureFile(t, remote, name+"/"+phase+".js", "")
 		}
@@ -5176,9 +5180,14 @@ runs:
 runs:
   using: composite
   steps:
-    - if: failure()
+    - id: failed
+      shell: sh
+      run: exit 7
+    - id: skipped
       uses: owner/repo/skipped@v1
-    - uses: owner/repo/second@v1
+    - id: second
+      if: always()
+      uses: owner/repo/second@v1
 `)
 	lifecycle := filepath.Join(workspace, "lifecycle.log")
 	preBin := filepath.Join(workspace, "pre-bin")
@@ -5252,7 +5261,7 @@ printf '%s\n' 'job:main' >> "$LIFECYCLE_LOG"`},
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}
 	var logs bytes.Buffer
 	result, err := (Runner{Node24: fakeNode, Actions: materializer, Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
-	if err != nil || result.Conclusion != "success" {
+	if err == nil || result.Conclusion != "failure" {
 		t.Fatalf("RunJob() result = %#v, error = %v, logs = %q", result, err, logs.String())
 	}
 	events, err := os.ReadFile(lifecycle)

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -3161,6 +3161,7 @@ func TestRustCachePostConditionUsesFinalStatusAndMainEnvironment(t *testing.T) {
 		{name: "failure disabled", failJob: true, cacheValue: "false"},
 		{name: "failure enabled", failJob: true, cacheValue: "true", wantPost: true},
 		{name: "later environment wins", failJob: true, cacheValue: "true", finalCacheValue: "false"},
+		{name: "post process sees later environment", cacheValue: "true", finalCacheValue: "false", wantPost: true},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -3184,7 +3185,7 @@ case "$(basename "$1")" in
   main.js)
     if [ -n "${CACHE_SETTING:-}" ]; then printf 'CACHE_ON_FAILURE=%s\n' "$CACHE_SETTING" >> "$GITHUB_ENV"; fi
     ;;
-  post.js) touch "$POST_MARKER" ;;
+  post.js) printf '%s' "${CACHE_ON_FAILURE:-}" > "$POST_MARKER" ;;
 esac
 `)
 			if err := os.Chmod(fakeNode, 0o700); err != nil {
@@ -3207,6 +3208,12 @@ esac
 			_, statErr := os.Stat(marker)
 			if got := statErr == nil; got != test.wantPost {
 				t.Fatalf("post ran = %v, want %v (stat error %v)", got, test.wantPost, statErr)
+			}
+			if test.wantPost && test.finalCacheValue != "" {
+				value, err := os.ReadFile(marker)
+				if err != nil || string(value) != test.finalCacheValue {
+					t.Fatalf("post environment = %q, %v, want %q", value, err, test.finalCacheValue)
+				}
 			}
 		})
 	}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -3216,13 +3216,16 @@ runs:
   using: composite
   steps:
     - uses: ./.github/actions/rust-cache
+    - id: finalize
+      shell: sh
+      run: "true"
 `)
 	writeFixtureFile(t, workspace, ".github/actions/rust-cache/action.yml", `name: rust-cache
 runs:
   using: node24
   main: main.js
   post: post.js
-  post-if: success() || env.CACHE_ON_FAILURE == 'true'
+  post-if: (success() || env.CACHE_ON_FAILURE == 'true') && steps.finalize.conclusion == 'success'
 `)
 	writeFixtureFile(t, workspace, ".github/actions/rust-cache/main.js", "")
 	writeFixtureFile(t, workspace, ".github/actions/rust-cache/post.js", "")
@@ -3242,7 +3245,7 @@ esac
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{
 		{ID: "setup", Kind: "uses", Uses: "./.github/actions/setup-rust-toolchain"},
 		{ID: "not-yet", Kind: "run", Command: `test ! -e "$POST_MARKER"`},
-		{ID: "fail", Kind: "run", Command: "exit 7"},
+		{ID: "finalize", Kind: "run", Command: "exit 7"},
 	})
 	job.Env = map[string]string{"POST_MARKER": marker}
 	result, err := (Runner{Node24: fakeNode}).RunJob(context.Background(), job, workspace)

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -3103,6 +3103,7 @@ func TestJavaScriptPostConditionsUseFinalJobStatus(t *testing.T) {
 		{name: "success after success", condition: "success()", wantPost: true, wantStatus: "success"},
 		{name: "success after failure", condition: "${{ success() }}", failMain: true, wantFailure: true},
 		{name: "failure after failure", condition: "failure()", failMain: true, wantPost: true, wantStatus: "failure", wantFailure: true},
+		{name: "final step state after failure", condition: "failure() && steps.conditional.outcome == 'failure'", failMain: true, wantPost: true, wantStatus: "failure", wantFailure: true},
 		{name: "always after failure", condition: "always()", failMain: true, wantPost: true, wantStatus: "failure", wantFailure: true},
 		{name: "not cancelled after success", condition: "!cancelled()", wantPost: true, wantStatus: "success"},
 		{name: "not cancelled after failure", condition: "!cancelled()", failMain: true, wantPost: true, wantStatus: "failure", wantFailure: true},
@@ -3144,6 +3145,112 @@ if [ "${1##*/}" = main.js ] && [ "${FAIL_MAIN:-false}" = true ]; then exit 9; fi
 				}
 			}
 		})
+	}
+}
+
+func TestRustCachePostConditionUsesFinalStatusAndMainEnvironment(t *testing.T) {
+	tests := []struct {
+		name       string
+		failJob    bool
+		cacheValue string
+		wantPost   bool
+	}{
+		{name: "success", wantPost: true},
+		{name: "failure default", failJob: true},
+		{name: "failure disabled", failJob: true, cacheValue: "false"},
+		{name: "failure enabled", failJob: true, cacheValue: "true", wantPost: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			workspace := t.TempDir()
+			workflowPath := ".github/workflows/test.yml"
+			writeFixtureFile(t, workspace, workflowPath, "name: rust-cache lifecycle\n")
+			writeFixtureFile(t, workspace, ".github/actions/rust-cache/action.yml", `name: rust-cache
+runs:
+  using: node24
+  main: main.js
+  post: post.js
+  post-if: success() || env.CACHE_ON_FAILURE == 'true'
+`)
+			writeFixtureFile(t, workspace, ".github/actions/rust-cache/main.js", "")
+			writeFixtureFile(t, workspace, ".github/actions/rust-cache/post.js", "")
+			fakeNode := filepath.Join(workspace, "node24")
+			writeFixtureFile(t, workspace, "node24", `#!/bin/sh
+set -eu
+if [ "${1:-}" = --version ]; then echo v24.0.0; exit 0; fi
+case "$(basename "$1")" in
+  main.js)
+    if [ -n "${CACHE_SETTING:-}" ]; then printf 'CACHE_ON_FAILURE=%s\n' "$CACHE_SETTING" >> "$GITHUB_ENV"; fi
+    ;;
+  post.js) touch "$POST_MARKER" ;;
+esac
+`)
+			if err := os.Chmod(fakeNode, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			marker := filepath.Join(workspace, "post")
+			steps := []plan.Step{{ID: "cache", Kind: "uses", Uses: "./.github/actions/rust-cache"}}
+			if test.failJob {
+				steps = append(steps, plan.Step{ID: "fail", Kind: "run", Command: "exit 7"})
+			}
+			job := runtimePlan(t, workspace, workflowPath, steps)
+			job.Env = map[string]string{"CACHE_SETTING": test.cacheValue, "POST_MARKER": marker}
+			result, err := (Runner{Node24: fakeNode}).RunJob(context.Background(), job, workspace)
+			if (err != nil) != test.failJob || (result.Conclusion == "failure") != test.failJob {
+				t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+			}
+			_, statErr := os.Stat(marker)
+			if got := statErr == nil; got != test.wantPost {
+				t.Fatalf("post ran = %v, want %v (stat error %v)", got, test.wantPost, statErr)
+			}
+		})
+	}
+}
+
+func TestNestedSetupRustToolchainPostUsesMainEnvironmentAtJobTeardown(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: nested rust-cache lifecycle\n")
+	writeFixtureFile(t, workspace, ".github/actions/setup-rust-toolchain/action.yml", `name: setup-rust-toolchain
+runs:
+  using: composite
+  steps:
+    - uses: ./.github/actions/rust-cache
+`)
+	writeFixtureFile(t, workspace, ".github/actions/rust-cache/action.yml", `name: rust-cache
+runs:
+  using: node24
+  main: main.js
+  post: post.js
+  post-if: success() || env.CACHE_ON_FAILURE == 'true'
+`)
+	writeFixtureFile(t, workspace, ".github/actions/rust-cache/main.js", "")
+	writeFixtureFile(t, workspace, ".github/actions/rust-cache/post.js", "")
+	fakeNode := filepath.Join(workspace, "node24")
+	writeFixtureFile(t, workspace, "node24", `#!/bin/sh
+set -eu
+if [ "${1:-}" = --version ]; then echo v24.0.0; exit 0; fi
+case "$(basename "$1")" in
+  main.js) printf '%s\n' 'CACHE_ON_FAILURE=true' >> "$GITHUB_ENV" ;;
+  post.js) touch "$POST_MARKER" ;;
+esac
+`)
+	if err := os.Chmod(fakeNode, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(workspace, "post")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{
+		{ID: "setup", Kind: "uses", Uses: "./.github/actions/setup-rust-toolchain"},
+		{ID: "not-yet", Kind: "run", Command: `test ! -e "$POST_MARKER"`},
+		{ID: "fail", Kind: "run", Command: "exit 7"},
+	})
+	job.Env = map[string]string{"POST_MARKER": marker}
+	result, err := (Runner{Node24: fakeNode}).RunJob(context.Background(), job, workspace)
+	if err == nil || result.Conclusion != "failure" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("nested rust-cache post did not run during teardown: %v", err)
 	}
 }
 
@@ -5125,7 +5232,7 @@ func TestRemoteActionPostRegistrationFollowsStartedLifecycle(t *testing.T) {
 	writeFixtureFile(t, remote, "without-pre/action.yml", "name: without pre\nruns:\n  using: node24\n  main: main.js\n  post: post.js\n")
 	writeFixtureFile(t, remote, "without-pre/main.js", "")
 	writeFixtureFile(t, remote, "without-pre/post.js", "")
-	writeFixtureFile(t, remote, "pre-if-false/action.yml", "name: pre condition false\nruns:\n  using: node24\n  pre: pre.js\n  pre-if: failure()\n  main: main.js\n  post: post.js\n")
+	writeFixtureFile(t, remote, "pre-if-false/action.yml", "name: pre condition false\nruns:\n  using: node24\n  pre: pre.js\n  pre-if: success() && env.RUN_PRE == 'true'\n  main: main.js\n  post: post.js\n")
 	for _, phase := range []string{"pre", "main", "post"} {
 		writeFixtureFile(t, remote, "pre-if-false/"+phase+".js", "")
 	}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -3166,6 +3166,10 @@ func TestRustCachePostConditionUsesFinalStatusAndMainEnvironment(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			workspace := t.TempDir()
+			resolvedWorkspace, err := filepath.EvalSymlinks(workspace)
+			if err != nil {
+				t.Fatal(err)
+			}
 			workflowPath := ".github/workflows/test.yml"
 			writeFixtureFile(t, workspace, workflowPath, "name: rust-cache lifecycle\n")
 			writeFixtureFile(t, workspace, ".github/actions/rust-cache/action.yml", `name: rust-cache
@@ -3212,7 +3216,7 @@ esac
 			}
 			if test.wantPost && test.finalCacheValue != "" {
 				value, err := os.ReadFile(marker)
-				want := test.finalCacheValue + "|" + workspace
+				want := test.finalCacheValue + "|" + resolvedWorkspace
 				if err != nil || string(value) != want {
 					t.Fatalf("post environment = %q, %v, want %q", value, err, want)
 				}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -3150,15 +3150,17 @@ if [ "${1##*/}" = main.js ] && [ "${FAIL_MAIN:-false}" = true ]; then exit 9; fi
 
 func TestRustCachePostConditionUsesFinalStatusAndMainEnvironment(t *testing.T) {
 	tests := []struct {
-		name       string
-		failJob    bool
-		cacheValue string
-		wantPost   bool
+		name            string
+		failJob         bool
+		cacheValue      string
+		finalCacheValue string
+		wantPost        bool
 	}{
 		{name: "success", wantPost: true},
 		{name: "failure default", failJob: true},
 		{name: "failure disabled", failJob: true, cacheValue: "false"},
 		{name: "failure enabled", failJob: true, cacheValue: "true", wantPost: true},
+		{name: "later environment wins", failJob: true, cacheValue: "true", finalCacheValue: "false"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -3190,6 +3192,9 @@ esac
 			}
 			marker := filepath.Join(workspace, "post")
 			steps := []plan.Step{{ID: "cache", Kind: "uses", Uses: "./.github/actions/rust-cache"}}
+			if test.finalCacheValue != "" {
+				steps = append(steps, plan.Step{ID: "override", Kind: "run", Command: fmt.Sprintf("printf 'CACHE_ON_FAILURE=%s\\n' >> \"$GITHUB_ENV\"", test.finalCacheValue)})
+			}
 			if test.failJob {
 				steps = append(steps, plan.Step{ID: "fail", Kind: "run", Command: "exit 7"})
 			}
@@ -3225,7 +3230,7 @@ runs:
   using: node24
   main: main.js
   post: post.js
-  post-if: (success() || env.CACHE_ON_FAILURE == 'true') && steps.finalize.conclusion == 'success'
+  post-if: (success() || env.CACHE_ON_FAILURE == 'true') && env.PARENT_FLAG == 'true' && steps.finalize.conclusion == 'success'
 `)
 	writeFixtureFile(t, workspace, ".github/actions/rust-cache/main.js", "")
 	writeFixtureFile(t, workspace, ".github/actions/rust-cache/post.js", "")
@@ -3243,7 +3248,7 @@ esac
 	}
 	marker := filepath.Join(workspace, "post")
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{
-		{ID: "setup", Kind: "uses", Uses: "./.github/actions/setup-rust-toolchain"},
+		{ID: "setup", Kind: "uses", Uses: "./.github/actions/setup-rust-toolchain", Env: map[string]string{"PARENT_FLAG": "true"}},
 		{ID: "not-yet", Kind: "run", Command: `test ! -e "$POST_MARKER"`},
 		{ID: "finalize", Kind: "run", Command: "exit 7"},
 	})
@@ -3254,6 +3259,42 @@ esac
 	}
 	if _, err := os.Stat(marker); err != nil {
 		t.Fatalf("nested rust-cache post did not run during teardown: %v", err)
+	}
+}
+
+func TestJavaScriptPostConditionUsesWorkflowInputsAndPostHashFiles(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: lifecycle hashFiles\n")
+	writeFixtureFile(t, workspace, "Cargo.lock", "locked")
+	writeFixtureFile(t, workspace, ".github/actions/cache/action.yml", `name: cache
+runs:
+  using: node24
+  main: main.js
+  post: post.js
+  post-if: inputs.cache == true && hashFiles('Cargo.lock') != ''
+`)
+	writeFixtureFile(t, workspace, ".github/actions/cache/main.js", "")
+	writeFixtureFile(t, workspace, ".github/actions/cache/post.js", "")
+	fakeNode := filepath.Join(workspace, "node24")
+	writeFixtureFile(t, workspace, "node24", `#!/bin/sh
+set -eu
+if [ "${1:-}" = --version ]; then echo v24.0.0; exit 0; fi
+if [ "$(basename "$1")" = post.js ]; then touch "$POST_MARKER"; fi
+`)
+	if err := os.Chmod(fakeNode, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(workspace, "post")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "cache", Kind: "uses", Uses: "./.github/actions/cache"}})
+	job.Inputs = map[string]any{"cache": true}
+	job.Env = map[string]string{"POST_MARKER": marker}
+	result, err := (Runner{Node24: fakeNode}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("post did not run: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Why

Action lifecycle conditions only accept a small set of literal status expressions. This rejects compound conditions such as `success() || env.CACHE_ON_FAILURE == 'true'`, preventing `Swatinem/rust-cache` and nested consumers such as `actions-rust-lang/setup-rust-toolchain` from completing.

## What

Evaluate `pre-if` and `post-if` through the shared expression engine with a lifecycle-specific, fail-closed context policy. Validate resolved direct and nested JavaScript actions during compilation while leaving replaced native lifecycles exempt.

Carry the runtime-backed workflow inputs, environment, step state, and phase-bound `hashFiles()` context into lifecycle evaluation. Merge live final status and `GITHUB_ENV` effects with action-scoped overrides for teardown without changing empty-condition behavior, LIFO ordering, cancellation semantics, or composite isolation.

Linear: PB-2962
