### PR TITLE
Disable the Windows starter workflow corpus case

### DIFF
--- a/scripts/starter-workflows-corpus
+++ b/scripts/starter-workflows-corpus
@@ -17,13 +17,14 @@ sha256_digest() {
 }
 
 profile=false
+explicit_cases=false
 case_ids=()
 while (( $# > 0 )); do
   case "$1" in
     --profile) profile=true ;;
     --help|-h) usage; exit 0 ;;
     -*) usage; exit 2 ;;
-    *) case_ids+=("$1") ;;
+    *) explicit_cases=true; case_ids+=("$1") ;;
   esac
   shift
 done
@@ -43,7 +44,9 @@ jq -e '
   all(.cases[];
     (.id | test("^[a-z0-9]+(?:-[a-z0-9]+)*$")) and
     (.template | test("^ci/[A-Za-z0-9_.-]+\\.yml$")) and
-    (.template_sha256 | test("^[0-9a-f]{64}$"))) and
+    (.template_sha256 | test("^[0-9a-f]{64}$")) and
+    ((has("disabled_reason") | not) or
+      (.disabled_reason | type == "string" and length > 0))) and
   ([.cases[].id] | length == (unique | length))
 ' "$manifest" >/dev/null
 
@@ -72,6 +75,7 @@ summary="$work/summary.md"
 printf '<h2 class="h4 mb2">Starter workflow compatibility — %s</h2>\n<div class="border-top border-gray pt2"></div>\n\n' "$mode" > "$summary"
 passed=0
 blocked=0
+disabled=0
 
 clean_env() {
   env \
@@ -161,6 +165,13 @@ make_event "$repository" "$commit" "$branch" "$event_path"
 
 for id in "${case_ids[@]}"; do
   entry="$(jq -c --arg id "$id" '.cases[] | select(.id == $id)' "$manifest")"
+  disabled_reason="$(jq -r '.disabled_reason // empty' <<<"$entry")"
+  if ! $explicit_cases && [[ -n "$disabled_reason" ]]; then
+    echo "⏭️ $id: disabled; $disabled_reason"
+    printf -- "- ⏭️ \`%s\`: disabled — %s\n" "$id" "$disabled_reason" >> "$summary"
+    disabled=$((disabled + 1))
+    continue
+  fi
   template="$(jq -r '.template' <<<"$entry")"
   template_sha256="$(jq -r '.template_sha256' <<<"$entry")"
 
@@ -190,11 +201,11 @@ for id in "${case_ids[@]}"; do
   record_report "$id" "$status" "$report"
 done
 
-printf '\n**%d passing; %d blocked.**\n' "$passed" "$blocked" >> "$summary"
+printf '\n**%d passing; %d blocked; %d disabled.**\n' "$passed" "$blocked" "$disabled" >> "$summary"
 cat "$summary"
 if [[ "${BUILDKITE:-}" == true ]] && command -v buildkite-agent >/dev/null; then
   style=success
-  (( blocked > 0 )) && style=warning
+  (( blocked > 0 || disabled > 0 )) && style=warning
   buildkite-agent annotate --context "starter-workflows-corpus-$mode" --style "$style" < "$summary" || \
     echo 'warning: failed to publish Buildkite annotation' >&2
 fi

--- a/testdata/starter-workflows/README.md
+++ b/testdata/starter-workflows/README.md
@@ -30,6 +30,9 @@ whether a template currently passes:
 | `rubyonrails` | PostgreSQL service container and a second lint job. |
 | `swift` | macOS runner and native Swift toolchain. |
 
+The CMake case is disabled by default because its matrix requires a Windows
+runner. Passing its case ID explicitly runs it.
+
 Run the networked compile and production-profile scans with:
 
 ```sh
@@ -38,12 +41,12 @@ mise run corpus:starter-profile
 mise run corpus:starter-profile -- go cmake-multi-platform swift
 ```
 
-Each command prints every result, reports a passing/blocked summary, and exits
-non-zero while any template misses its target state. The profile scan resolves
-public actions and applies the `hosted` admission policy, but neither
-mode executes action or project code. Mutable action tags remain as declared by
-the official template, so profile results are observational and runtime proof
-must retain immutable resolved action locks.
+Each command prints every result, reports passing, blocked, and disabled cases,
+and exits non-zero while any enabled template misses its target state. The
+profile scan resolves public actions and applies the `hosted` admission policy,
+but neither mode executes action or project code. Mutable action tags remain as
+declared by the official template, so profile results are observational and
+runtime proof must retain immutable resolved action locks.
 
 Buildkite runs the profile scan as a soft-failing step and publishes the result
 as an annotation. Both corpus commands are opt-in; `mise run check` remains

--- a/testdata/starter-workflows/manifest.json
+++ b/testdata/starter-workflows/manifest.json
@@ -42,7 +42,8 @@
     {
       "id": "cmake-multi-platform",
       "template": "ci/cmake-multi-platform.yml",
-      "template_sha256": "251f58c701753102802d0cb9a45f217d68ee1599475dcce1114641f3b42eacc0"
+      "template_sha256": "251f58c701753102802d0cb9a45f217d68ee1599475dcce1114641f3b42eacc0",
+      "disabled_reason": "requires a Windows runner"
     },
     {
       "id": "rubyonrails",


### PR DESCRIPTION
## Why

The pinned CMake starter workflow includes a `windows-latest` matrix row. The hosted profile does not support Windows, so this known platform gap blocks the otherwise compatible starter corpus.

## What

Keep the CMake template pinned but disable it by default with a recorded reason. Report disabled cases in the corpus summary and annotation, while allowing explicit case selection to recheck them when Windows support changes.
