### PR TITLE
Separate trigger expressions from event snapshots

### DIFF
--- a/internal/buildkite/triggers.go
+++ b/internal/buildkite/triggers.go
@@ -13,25 +13,39 @@ import (
 
 const maxSkipReasonLength = 70
 
-// TriggerConditionContext supplies the trusted Buildkite expressions used to
-// select one effective event and apply its supported trigger filters.
-type TriggerConditionContext struct {
-	EventPredicate         string
-	Branch                 string
-	Tag                    string
-	PullRequestBaseBranch  string
-	PullRequestAction      string
-	MergeGroupBaseBranch   string
-	MergeGroupAction       string
-	ChangedPaths           []string
-	ChangedPathsKnown      bool
-	ChangedPathsError      string
-	BranchValue            *string
-	TagValue               *string
-	PullRequestBaseValue   *string
-	PullRequestActionValue *string
-	MergeGroupBaseValue    *string
-	MergeGroupActionValue  *string
+// TriggerConditionExpressions supplies the trusted Buildkite expressions used
+// to select one effective event and apply its supported trigger filters.
+type TriggerConditionExpressions struct {
+	EventPredicate        string
+	Branch                string
+	Tag                   string
+	PullRequestBaseBranch string
+	PullRequestAction     string
+	MergeGroupBaseBranch  string
+	MergeGroupAction      string
+}
+
+// ChangedPathEvaluation records either the available changed paths or why
+// they could not be acquired. A non-nil Paths slice means paths are available.
+type ChangedPathEvaluation struct {
+	Paths             []string
+	UnavailableReason string
+}
+
+func (e ChangedPathEvaluation) available() bool {
+	return e.Paths != nil
+}
+
+// TriggerEventSnapshot supplies observed effective-event values used to match
+// trigger filters and explain mismatches.
+type TriggerEventSnapshot struct {
+	Branch                *string
+	Tag                   *string
+	PullRequestBaseBranch *string
+	PullRequestAction     *string
+	MergeGroupBaseBranch  *string
+	MergeGroupAction      *string
+	ChangedPaths          ChangedPathEvaluation
 }
 
 // UnsupportedPathFiltersError reports a trigger that cannot be translated
@@ -48,10 +62,10 @@ func (e *UnsupportedPathFiltersError) Error() string {
 	return fmt.Sprintf("%s path filters are unsupported: Buildkite if_changed is not equivalent", e.Event)
 }
 
-// LiveTriggerConditionContext uses fields from the Buildkite build that
+// LiveTriggerConditionExpressions uses fields from the Buildkite build that
 // supplied the effective event snapshot.
-func LiveTriggerConditionContext(eventPredicate string) TriggerConditionContext {
-	return TriggerConditionContext{
+func LiveTriggerConditionExpressions(eventPredicate string) TriggerConditionExpressions {
+	return TriggerConditionExpressions{
 		EventPredicate:        eventPredicate,
 		Branch:                "build.branch",
 		Tag:                   "build.tag",
@@ -68,7 +82,7 @@ func LiveTriggerConditionContext(eventPredicate string) TriggerConditionContext 
 func TranslateTriggerCondition(triggers []workflow.Trigger) (string, error) {
 	var terms []string
 	for _, t := range triggers {
-		term, contributes, err := translateTrigger(t, liveTriggerContext(t.Event), true)
+		term, contributes, err := translateTrigger(t, liveTriggerExpressions(t.Event), TriggerEventSnapshot{}, true)
 		if err != nil {
 			return "", err
 		}
@@ -87,7 +101,7 @@ func TranslateTriggerCondition(triggers []workflow.Trigger) (string, error) {
 func ValidateTriggerConditions(triggers []workflow.Trigger) error {
 	var findings []error
 	for _, trigger := range triggers {
-		if _, _, err := translateTrigger(trigger, liveTriggerContext(trigger.Event), true); err != nil {
+		if _, _, err := translateTrigger(trigger, liveTriggerExpressions(trigger.Event), TriggerEventSnapshot{}, true); err != nil {
 			var pathFilters *UnsupportedPathFiltersError
 			if errors.As(err, &pathFilters) && (pathFilters.Event == "push" || pathFilters.Event == "pull_request") && pathFilters.Reason == "" {
 				continue
@@ -101,15 +115,17 @@ func ValidateTriggerConditions(triggers []workflow.Trigger) error {
 // TranslateEventTriggerCondition validates every trigger but emits a
 // condition only for the selected effective event. A false applicable result
 // means the workflow must not be compiled for that event.
-func TranslateEventTriggerCondition(triggers []workflow.Trigger, event string, context TriggerConditionContext) (condition string, applicable bool, err error) {
+func TranslateEventTriggerCondition(triggers []workflow.Trigger, event string, expressions TriggerConditionExpressions, snapshot TriggerEventSnapshot) (condition string, applicable bool, err error) {
 	var terms []string
 	for _, trigger := range triggers {
-		triggerContext := liveTriggerContext(trigger.Event)
+		triggerExpressions := liveTriggerExpressions(trigger.Event)
+		triggerSnapshot := TriggerEventSnapshot{}
 		selected := trigger.Event == event
 		if selected {
-			triggerContext = context
+			triggerExpressions = expressions
+			triggerSnapshot = snapshot
 		}
-		term, contributes, err := translateTrigger(trigger, triggerContext, selected)
+		term, contributes, err := translateTrigger(trigger, triggerExpressions, triggerSnapshot, selected)
 		if err != nil {
 			return "", false, err
 		}
@@ -139,18 +155,18 @@ func TriggerEventSkipReason(triggers []workflow.Trigger, event string) string {
 
 // TriggerFilterMismatchReason describes why a concrete effective event does
 // not satisfy the filters on its matching workflow trigger.
-func TriggerFilterMismatchReason(triggers []workflow.Trigger, event string, context TriggerConditionContext) (string, error) {
+func TriggerFilterMismatchReason(triggers []workflow.Trigger, event string, snapshot TriggerEventSnapshot) (string, error) {
 	for _, trigger := range triggers {
 		if trigger.Event != event {
 			continue
 		}
 		switch event {
 		case "push":
-			if context.BranchValue != nil {
+			if snapshot.Branch != nil {
 				if trigger.Branches == nil && trigger.BranchesIgnore == nil && (trigger.Tags != nil || trigger.TagsIgnore != nil) {
-					return fmt.Sprintf("Branch push %q does not match this workflow's push tag filters.", *context.BranchValue), nil
+					return fmt.Sprintf("Branch push %q does not match this workflow's push tag filters.", *snapshot.Branch), nil
 				}
-				matches, err := refFilterMatches(*context.BranchValue, trigger.Branches, trigger.BranchesIgnore)
+				matches, err := refFilterMatches(*snapshot.Branch, trigger.Branches, trigger.BranchesIgnore)
 				if err != nil {
 					return "", fmt.Errorf("push branches: %w", err)
 				}
@@ -159,7 +175,7 @@ func TriggerFilterMismatchReason(triggers []workflow.Trigger, event string, cont
 						branches := make([]string, len(trigger.Branches))
 						for i, branch := range trigger.Branches {
 							if strings.HasPrefix(branch, "!") {
-								return fmt.Sprintf("Doesn’t run on the `%s` branch.", *context.BranchValue), nil
+								return fmt.Sprintf("Doesn’t run on the `%s` branch.", *snapshot.Branch), nil
 							}
 							branches[i] = fmt.Sprintf("`%s`", branch)
 						}
@@ -172,56 +188,56 @@ func TriggerFilterMismatchReason(triggers []workflow.Trigger, event string, cont
 						}
 						return fmt.Sprintf("Only runs on %s%s%s.", strings.Join(branches[:len(branches)-1], ", "), separator, branches[len(branches)-1]), nil
 					}
-					return fmt.Sprintf("Doesn’t run on the `%s` branch.", *context.BranchValue), nil
+					return fmt.Sprintf("Doesn’t run on the `%s` branch.", *snapshot.Branch), nil
 				}
 			}
-			if context.TagValue != nil {
+			if snapshot.Tag != nil {
 				if trigger.Tags == nil && trigger.TagsIgnore == nil && (trigger.Branches != nil || trigger.BranchesIgnore != nil) {
-					return fmt.Sprintf("Tag push %q does not match this workflow's push branch filters.", *context.TagValue), nil
+					return fmt.Sprintf("Tag push %q does not match this workflow's push branch filters.", *snapshot.Tag), nil
 				}
-				matches, err := refFilterMatches(*context.TagValue, trigger.Tags, trigger.TagsIgnore)
+				matches, err := refFilterMatches(*snapshot.Tag, trigger.Tags, trigger.TagsIgnore)
 				if err != nil {
 					return "", fmt.Errorf("push tags: %w", err)
 				}
 				if !matches {
-					return fmt.Sprintf("Tag %q does not match this workflow's push tag filters.", *context.TagValue), nil
+					return fmt.Sprintf("Tag %q does not match this workflow's push tag filters.", *snapshot.Tag), nil
 				}
 			}
 		case "pull_request":
-			if context.PullRequestBaseValue != nil {
-				matches, err := refFilterMatches(*context.PullRequestBaseValue, trigger.Branches, trigger.BranchesIgnore)
+			if snapshot.PullRequestBaseBranch != nil {
+				matches, err := refFilterMatches(*snapshot.PullRequestBaseBranch, trigger.Branches, trigger.BranchesIgnore)
 				if err != nil {
 					return "", fmt.Errorf("pull_request branches: %w", err)
 				}
 				if !matches {
-					return fmt.Sprintf("Base branch %q does not match this workflow's pull_request branch filters.", *context.PullRequestBaseValue), nil
+					return fmt.Sprintf("Base branch %q does not match this workflow's pull_request branch filters.", *snapshot.PullRequestBaseBranch), nil
 				}
 			}
-			if context.PullRequestActionValue != nil {
+			if snapshot.PullRequestAction != nil {
 				types := trigger.Types
 				if types == nil {
 					types = []string{"opened", "synchronize", "reopened"}
 				}
 				matched := false
 				for _, action := range types {
-					matched = matched || action == *context.PullRequestActionValue
+					matched = matched || action == *snapshot.PullRequestAction
 				}
 				if !matched {
-					return fmt.Sprintf("Pull request activity %q does not match this workflow's pull_request activity filters.", *context.PullRequestActionValue), nil
+					return fmt.Sprintf("Pull request activity %q does not match this workflow's pull_request activity filters.", *snapshot.PullRequestAction), nil
 				}
 			}
 		case "merge_group":
-			if context.MergeGroupBaseValue != nil {
-				matches, err := refFilterMatches(*context.MergeGroupBaseValue, trigger.Branches, trigger.BranchesIgnore)
+			if snapshot.MergeGroupBaseBranch != nil {
+				matches, err := refFilterMatches(*snapshot.MergeGroupBaseBranch, trigger.Branches, trigger.BranchesIgnore)
 				if err != nil {
 					return "", fmt.Errorf("merge_group branches: %w", err)
 				}
 				if !matches {
-					return fmt.Sprintf("Base branch %q does not match this workflow's merge_group branch filters.", *context.MergeGroupBaseValue), nil
+					return fmt.Sprintf("Base branch %q does not match this workflow's merge_group branch filters.", *snapshot.MergeGroupBaseBranch), nil
 				}
 			}
-			if context.MergeGroupActionValue != nil && *context.MergeGroupActionValue != "checks_requested" {
-				return fmt.Sprintf("Merge group activity %q does not match this workflow's merge_group activity filters.", *context.MergeGroupActionValue), nil
+			if snapshot.MergeGroupAction != nil && *snapshot.MergeGroupAction != "checks_requested" {
+				return fmt.Sprintf("Merge group activity %q does not match this workflow's merge_group activity filters.", *snapshot.MergeGroupAction), nil
 			}
 		}
 		return "", nil
@@ -236,7 +252,7 @@ func skipReason(reason, fallback string) string {
 	return fallback
 }
 
-func liveTriggerContext(event string) TriggerConditionContext {
+func liveTriggerExpressions(event string) TriggerConditionExpressions {
 	predicate := ""
 	switch event {
 	case "workflow_dispatch":
@@ -246,10 +262,10 @@ func liveTriggerContext(event string) TriggerConditionContext {
 	case "push", "pull_request", "merge_group":
 		predicate = `build.source_event == ` + yamlScalar(event)
 	}
-	return LiveTriggerConditionContext(predicate)
+	return LiveTriggerConditionExpressions(predicate)
 }
 
-func translateTrigger(t workflow.Trigger, context TriggerConditionContext, selected bool) (string, bool, error) {
+func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpressions, snapshot TriggerEventSnapshot, selected bool) (string, bool, error) {
 	pathFilters := t.Paths != nil || t.PathsIgnore != nil
 	if pathFilters {
 		if t.Event != "push" && t.Event != "pull_request" {
@@ -266,10 +282,10 @@ func translateTrigger(t workflow.Trigger, context TriggerConditionContext, selec
 		if hasWebhookFilters(t) {
 			return "", false, fmt.Errorf("workflow_dispatch has unsupported webhook filters")
 		}
-		if context.EventPredicate == "" {
+		if expressions.EventPredicate == "" {
 			return "", false, fmt.Errorf("workflow_dispatch requires an effective event predicate")
 		}
-		return context.EventPredicate, true, nil
+		return expressions.EventPredicate, true, nil
 	case "schedule":
 		if hasWebhookFilters(t) {
 			return "", false, fmt.Errorf("schedule has unsupported webhook filters")
@@ -277,43 +293,43 @@ func translateTrigger(t workflow.Trigger, context TriggerConditionContext, selec
 		// Buildkite does not expose the identity of the schedule that created a
 		// build. Cron ownership therefore stays in Buildkite, and every scheduled
 		// workflow group is eligible on any Buildkite scheduled build.
-		if context.EventPredicate == "" {
+		if expressions.EventPredicate == "" {
 			return "", false, fmt.Errorf("schedule requires an effective event predicate")
 		}
-		return context.EventPredicate, true, nil
+		return expressions.EventPredicate, true, nil
 	case "push":
 		if t.Types != nil || t.Workflows != nil {
 			return "", false, fmt.Errorf("push has unsupported filters")
 		}
-		if context.EventPredicate == "" || context.Branch == "" || context.Tag == "" {
+		if expressions.EventPredicate == "" || expressions.Branch == "" || expressions.Tag == "" {
 			return "", false, fmt.Errorf("push requires effective event, branch, and tag expressions")
 		}
-		if context.Branch == "null" && context.Tag == "null" {
+		if expressions.Branch == "null" && expressions.Tag == "null" {
 			return "", false, fmt.Errorf("push event snapshot requires ref to start with refs/heads/ or refs/tags/")
 		}
-		parts := []string{context.EventPredicate}
-		branch, hasBranchFilter, err := refFilters(context.Branch, t.Branches, t.BranchesIgnore)
+		parts := []string{expressions.EventPredicate}
+		branch, hasBranchFilter, err := refFilters(expressions.Branch, t.Branches, t.BranchesIgnore)
 		if err != nil {
 			return "", false, fmt.Errorf("push branches: %w", err)
 		}
-		tag, hasTagFilter, err := refFilters(context.Tag, t.Tags, t.TagsIgnore)
+		tag, hasTagFilter, err := refFilters(expressions.Tag, t.Tags, t.TagsIgnore)
 		if err != nil {
 			return "", false, fmt.Errorf("push tags: %w", err)
 		}
 		if hasBranchFilter && hasTagFilter {
-			parts = append(parts, "(("+context.Tag+" == null && ("+branch+")) || ("+context.Tag+" != null && ("+tag+")))")
+			parts = append(parts, "(("+expressions.Tag+" == null && ("+branch+")) || ("+expressions.Tag+" != null && ("+tag+")))")
 		} else if hasBranchFilter {
-			parts = append(parts, context.Tag+" == null", branch)
+			parts = append(parts, expressions.Tag+" == null", branch)
 		} else if hasTagFilter {
-			parts = append(parts, context.Tag+" != null", tag)
+			parts = append(parts, expressions.Tag+" != null", tag)
 		}
-		if pathFilters && selected && context.TagValue == nil {
-			if context.BranchValue != nil {
+		if pathFilters && selected && snapshot.Tag == nil {
+			if snapshot.Branch != nil {
 				branchMatches := true
 				if !hasBranchFilter && hasTagFilter {
 					branchMatches = false
 				} else if hasBranchFilter {
-					branchMatches, err = refFilterMatches(*context.BranchValue, t.Branches, t.BranchesIgnore)
+					branchMatches, err = refFilterMatches(*snapshot.Branch, t.Branches, t.BranchesIgnore)
 					if err != nil {
 						return "", false, fmt.Errorf("push branches: %w", err)
 					}
@@ -322,10 +338,10 @@ func translateTrigger(t workflow.Trigger, context TriggerConditionContext, selec
 					return strings.Join(parts, " && "), true, nil
 				}
 			}
-			if !context.ChangedPathsKnown {
-				return "", false, &UnsupportedPathFiltersError{Event: t.Event, Reason: context.ChangedPathsError}
+			if !snapshot.ChangedPaths.available() {
+				return "", false, &UnsupportedPathFiltersError{Event: t.Event, Reason: snapshot.ChangedPaths.UnavailableReason}
 			}
-			matches, err := pathFiltersMatch(context.ChangedPaths, t.Paths, t.PathsIgnore)
+			matches, err := pathFiltersMatch(snapshot.ChangedPaths.Paths, t.Paths, t.PathsIgnore)
 			if err != nil {
 				return "", false, fmt.Errorf("push paths: %w", err)
 			}
@@ -341,21 +357,21 @@ func translateTrigger(t workflow.Trigger, context TriggerConditionContext, selec
 		if t.Tags != nil || t.TagsIgnore != nil || t.Workflows != nil {
 			return "", false, fmt.Errorf("pull_request tag filters are unsupported")
 		}
-		if context.EventPredicate == "" || context.PullRequestAction == "" {
+		if expressions.EventPredicate == "" || expressions.PullRequestAction == "" {
 			return "", false, fmt.Errorf("pull_request requires effective event and action expressions")
 		}
-		if context.PullRequestAction == "null" {
+		if expressions.PullRequestAction == "null" {
 			return "", false, fmt.Errorf("pull_request event snapshot requires payload.action")
 		}
-		parts := []string{context.EventPredicate}
+		parts := []string{expressions.EventPredicate}
 		hasBranchFilter := t.Branches != nil || t.BranchesIgnore != nil
-		if hasBranchFilter && context.PullRequestBaseBranch == "" {
+		if hasBranchFilter && expressions.PullRequestBaseBranch == "" {
 			return "", false, fmt.Errorf("pull_request branch filters require a base branch expression")
 		}
-		if hasBranchFilter && context.PullRequestBaseBranch == "null" {
+		if hasBranchFilter && expressions.PullRequestBaseBranch == "null" {
 			return "", false, fmt.Errorf("pull_request branch filters require payload.pull_request.base.ref")
 		}
-		b, hasBranchFilter, err := refFilters(context.PullRequestBaseBranch, t.Branches, t.BranchesIgnore)
+		b, hasBranchFilter, err := refFilters(expressions.PullRequestBaseBranch, t.Branches, t.BranchesIgnore)
 		if err != nil {
 			return "", false, fmt.Errorf("pull_request branches: %w", err)
 		}
@@ -374,14 +390,14 @@ func translateTrigger(t workflow.Trigger, context TriggerConditionContext, selec
 			if !supportedPullRequestAction[a] {
 				return "", false, fmt.Errorf("pull_request activity type %q cannot be mapped exactly", a)
 			}
-			actions = append(actions, context.PullRequestAction+` == `+yamlScalar(a))
+			actions = append(actions, expressions.PullRequestAction+` == `+yamlScalar(a))
 		}
 		parts = append(parts, "("+strings.Join(actions, " || ")+")")
 		if pathFilters && selected {
-			if !context.ChangedPathsKnown {
-				return "", false, &UnsupportedPathFiltersError{Event: t.Event, Reason: context.ChangedPathsError}
+			if !snapshot.ChangedPaths.available() {
+				return "", false, &UnsupportedPathFiltersError{Event: t.Event, Reason: snapshot.ChangedPaths.UnavailableReason}
 			}
-			matches, err := pathFiltersMatch(context.ChangedPaths, t.Paths, t.PathsIgnore)
+			matches, err := pathFiltersMatch(snapshot.ChangedPaths.Paths, t.Paths, t.PathsIgnore)
 			if err != nil {
 				return "", false, fmt.Errorf("pull_request paths: %w", err)
 			}
@@ -397,21 +413,21 @@ func translateTrigger(t workflow.Trigger, context TriggerConditionContext, selec
 		if t.Tags != nil || t.TagsIgnore != nil || t.Paths != nil || t.PathsIgnore != nil || t.Workflows != nil {
 			return "", false, fmt.Errorf("merge_group has unsupported filters")
 		}
-		if context.EventPredicate == "" || context.MergeGroupAction == "" {
+		if expressions.EventPredicate == "" || expressions.MergeGroupAction == "" {
 			return "", false, fmt.Errorf("merge_group requires effective event and action expressions")
 		}
-		if context.MergeGroupAction == "null" {
+		if expressions.MergeGroupAction == "null" {
 			return "", false, fmt.Errorf("merge_group event snapshot requires payload.action")
 		}
-		if context.MergeGroupActionValue != nil && *context.MergeGroupActionValue != "checks_requested" {
+		if snapshot.MergeGroupAction != nil && *snapshot.MergeGroupAction != "checks_requested" {
 			return "", false, fmt.Errorf("merge_group activity must be checks_requested")
 		}
-		parts := []string{context.EventPredicate, context.MergeGroupAction + ` == "checks_requested"`}
+		parts := []string{expressions.EventPredicate, expressions.MergeGroupAction + ` == "checks_requested"`}
 		hasBranchFilter := t.Branches != nil || t.BranchesIgnore != nil
-		if hasBranchFilter && (context.MergeGroupBaseBranch == "" || context.MergeGroupBaseBranch == "null") {
+		if hasBranchFilter && (expressions.MergeGroupBaseBranch == "" || expressions.MergeGroupBaseBranch == "null") {
 			return "", false, fmt.Errorf("merge_group branch filters require payload.merge_group.base_ref")
 		}
-		branch, hasBranchFilter, err := refFilters(context.MergeGroupBaseBranch, t.Branches, t.BranchesIgnore)
+		branch, hasBranchFilter, err := refFilters(expressions.MergeGroupBaseBranch, t.Branches, t.BranchesIgnore)
 		if err != nil {
 			return "", false, fmt.Errorf("merge_group branches: %w", err)
 		}

--- a/internal/buildkite/triggers_test.go
+++ b/internal/buildkite/triggers_test.go
@@ -48,16 +48,18 @@ func TestTranslateTriggerConditionRejectsUnsafeTriggers(t *testing.T) {
 
 func TestTranslateEventTriggerConditionUsesMergeGroupSnapshot(t *testing.T) {
 	base, action := "main", "checks_requested"
-	context := TriggerConditionContext{
-		EventPredicate:        `build.source == "webhook"`,
-		MergeGroupBaseBranch:  `"main"`,
-		MergeGroupAction:      `"checks_requested"`,
-		MergeGroupBaseValue:   &base,
-		MergeGroupActionValue: &action,
+	expressions := TriggerConditionExpressions{
+		EventPredicate:       `build.source == "webhook"`,
+		MergeGroupBaseBranch: `"main"`,
+		MergeGroupAction:     `"checks_requested"`,
+	}
+	snapshot := TriggerEventSnapshot{
+		MergeGroupBaseBranch: &base,
+		MergeGroupAction:     &action,
 	}
 	condition, applicable, err := TranslateEventTriggerCondition([]workflow.Trigger{{
 		Event: "merge_group", Branches: []string{"main"}, Types: []string{"checks_requested"},
-	}}, "merge_group", context)
+	}}, "merge_group", expressions, snapshot)
 	if err != nil || !applicable {
 		t.Fatalf("condition/applicable/error = %q / %t / %v", condition, applicable, err)
 	}
@@ -106,7 +108,7 @@ func TestTranslateEventTriggerConditionSelectsOnlyEffectiveEvent(t *testing.T) {
 		{Event: "schedule"},
 		{Event: "workflow_call"},
 	}
-	condition, applicable, err := TranslateEventTriggerCondition(triggers, "push", LiveTriggerConditionContext(`build.source == "trigger_job"`))
+	condition, applicable, err := TranslateEventTriggerCondition(triggers, "push", LiveTriggerConditionExpressions(`build.source == "trigger_job"`), TriggerEventSnapshot{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,7 +121,7 @@ func TestTranslateEventTriggerConditionSelectsOnlyEffectiveEvent(t *testing.T) {
 		}
 	}
 
-	condition, applicable, err = TranslateEventTriggerCondition(triggers, "issues", LiveTriggerConditionContext("true"))
+	condition, applicable, err = TranslateEventTriggerCondition(triggers, "issues", LiveTriggerConditionExpressions("true"), TriggerEventSnapshot{})
 	if err != nil || applicable || condition != "" {
 		t.Fatalf("non-applicable condition = %q, %t, %v", condition, applicable, err)
 	}
@@ -129,7 +131,7 @@ func TestTranslateEventTriggerConditionValidatesInactiveTriggers(t *testing.T) {
 	_, _, err := TranslateEventTriggerCondition([]workflow.Trigger{
 		{Event: "push"},
 		{Event: "pull_request", Paths: []string{"!src/**"}},
-	}, "push", LiveTriggerConditionContext("true"))
+	}, "push", LiveTriggerConditionExpressions("true"), TriggerEventSnapshot{})
 	if err == nil || !strings.Contains(err.Error(), "must follow a positive pattern") {
 		t.Fatalf("inactive path filter error = %v", err)
 	}
@@ -139,19 +141,20 @@ func TestTranslateEventTriggerConditionAllowsInactivePushPathFilters(t *testing.
 	condition, applicable, err := TranslateEventTriggerCondition([]workflow.Trigger{
 		{Event: "push", Paths: []string{"src/**"}},
 		{Event: "pull_request"},
-	}, "pull_request", TriggerConditionContext{EventPredicate: "true", PullRequestAction: `"opened"`})
+	}, "pull_request", TriggerConditionExpressions{EventPredicate: "true", PullRequestAction: `"opened"`}, TriggerEventSnapshot{})
 	if err != nil || !applicable || !strings.Contains(condition, `"opened"`) {
 		t.Fatalf("inactive push path filter condition/applicable/error = %q / %t / %v", condition, applicable, err)
 	}
 }
 
 func TestTranslateEventTriggerConditionMatchesPullRequestPaths(t *testing.T) {
-	context := TriggerConditionContext{
+	expressions := TriggerConditionExpressions{
 		EventPredicate:        "true",
 		PullRequestBaseBranch: `"main"`,
 		PullRequestAction:     `"opened"`,
-		ChangedPaths:          []string{"docs/readme.md", "src/main.go"},
-		ChangedPathsKnown:     true,
+	}
+	snapshot := TriggerEventSnapshot{
+		ChangedPaths: ChangedPathEvaluation{Paths: []string{"docs/readme.md", "src/main.go"}},
 	}
 	for _, test := range []struct {
 		name    string
@@ -167,7 +170,7 @@ func TestTranslateEventTriggerConditionMatchesPullRequestPaths(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			condition, applicable, err := TranslateEventTriggerCondition([]workflow.Trigger{test.trigger}, "pull_request", context)
+			condition, applicable, err := TranslateEventTriggerCondition([]workflow.Trigger{test.trigger}, "pull_request", expressions, snapshot)
 			if err != nil || !applicable || strings.Contains(condition, "false") {
 				t.Fatalf("condition/applicable/error = %q / %t / %v", condition, applicable, err)
 			}
@@ -176,48 +179,61 @@ func TestTranslateEventTriggerConditionMatchesPullRequestPaths(t *testing.T) {
 	_, _, err := TranslateEventTriggerCondition(
 		[]workflow.Trigger{{Event: "pull_request", Paths: []string{"web/**"}}},
 		"pull_request",
-		context,
+		expressions,
+		snapshot,
 	)
 	if err == nil || !strings.Contains(err.Error(), "diff-timeout outcome is unavailable") {
 		t.Fatalf("nonmatching local paths error = %v", err)
 	}
 }
 
+func TestTranslateEventTriggerConditionTreatsEmptyChangedPathsAsAvailable(t *testing.T) {
+	_, _, err := TranslateEventTriggerCondition(
+		[]workflow.Trigger{{Event: "pull_request", Paths: []string{"src/**"}}},
+		"pull_request",
+		TriggerConditionExpressions{EventPredicate: "true", PullRequestAction: `"opened"`},
+		TriggerEventSnapshot{ChangedPaths: ChangedPathEvaluation{Paths: []string{}}},
+	)
+	if err == nil || !strings.Contains(err.Error(), "local changed paths do not match") {
+		t.Fatalf("empty available changed paths error = %v", err)
+	}
+}
+
 func TestTranslateEventTriggerConditionMatchesPushPaths(t *testing.T) {
 	branch := "main"
-	context := TriggerConditionContext{
-		EventPredicate:    "true",
-		Branch:            `"main"`,
-		Tag:               "null",
-		BranchValue:       &branch,
-		ChangedPaths:      []string{"docs/readme.md", "src/generated/api.go", "src/main.go"},
-		ChangedPathsKnown: true,
+	expressions := TriggerConditionExpressions{
+		EventPredicate: "true",
+		Branch:         `"main"`,
+		Tag:            "null",
+	}
+	snapshot := TriggerEventSnapshot{
+		Branch:       &branch,
+		ChangedPaths: ChangedPathEvaluation{Paths: []string{"docs/readme.md", "src/generated/api.go", "src/main.go"}},
 	}
 	trigger := workflow.Trigger{Event: "push", Paths: []string{"src/**", "!src/generated/**"}}
-	condition, applicable, err := TranslateEventTriggerCondition([]workflow.Trigger{trigger}, "push", context)
+	condition, applicable, err := TranslateEventTriggerCondition([]workflow.Trigger{trigger}, "push", expressions, snapshot)
 	if err != nil || !applicable || condition != "(true)" {
 		t.Fatalf("push condition/applicable/error = %q / %t / %v", condition, applicable, err)
 	}
-	context.ChangedPaths = []string{"docs/readme.md", "src/generated/api.go"}
-	if _, _, err := TranslateEventTriggerCondition([]workflow.Trigger{trigger}, "push", context); err == nil || !strings.Contains(err.Error(), "diff-timeout outcome is unavailable") {
+	snapshot.ChangedPaths = ChangedPathEvaluation{Paths: []string{"docs/readme.md", "src/generated/api.go"}}
+	if _, _, err := TranslateEventTriggerCondition([]workflow.Trigger{trigger}, "push", expressions, snapshot); err == nil || !strings.Contains(err.Error(), "diff-timeout outcome is unavailable") {
 		t.Fatalf("nonmatching push paths error = %v", err)
 	}
-	context.ChangedPathsKnown = false
-	context.ChangedPathsError = "verified push diff unavailable"
-	if _, _, err := TranslateEventTriggerCondition([]workflow.Trigger{trigger}, "push", context); err == nil || !strings.Contains(err.Error(), "verified push diff unavailable") {
+	snapshot.ChangedPaths = ChangedPathEvaluation{UnavailableReason: "verified push diff unavailable"}
+	if _, _, err := TranslateEventTriggerCondition([]workflow.Trigger{trigger}, "push", expressions, snapshot); err == nil || !strings.Contains(err.Error(), "verified push diff unavailable") {
 		t.Fatalf("unknown push paths error = %v", err)
 	}
 
 	tag := "v1.0.0"
-	tagContext := TriggerConditionContext{EventPredicate: "true", Branch: "null", Tag: `"v1.0.0"`, TagValue: &tag}
-	if _, applicable, err := TranslateEventTriggerCondition([]workflow.Trigger{trigger}, "push", tagContext); err != nil || !applicable {
+	tagExpressions := TriggerConditionExpressions{EventPredicate: "true", Branch: "null", Tag: `"v1.0.0"`}
+	tagSnapshot := TriggerEventSnapshot{Tag: &tag}
+	if _, applicable, err := TranslateEventTriggerCondition([]workflow.Trigger{trigger}, "push", tagExpressions, tagSnapshot); err != nil || !applicable {
 		t.Fatalf("tag push path filter = %t, %v", applicable, err)
 	}
 
-	context.ChangedPathsKnown = false
-	context.ChangedPathsError = "verified push diff unavailable"
+	snapshot.ChangedPaths = ChangedPathEvaluation{UnavailableReason: "verified push diff unavailable"}
 	trigger.Branches = []string{"release"}
-	if condition, applicable, err := TranslateEventTriggerCondition([]workflow.Trigger{trigger}, "push", context); err != nil || !applicable || !strings.Contains(condition, `"main" =~ /^release$/`) {
+	if condition, applicable, err := TranslateEventTriggerCondition([]workflow.Trigger{trigger}, "push", expressions, snapshot); err != nil || !applicable || !strings.Contains(condition, `"main" =~ /^release$/`) {
 		t.Fatalf("branch-mismatched push path filter = %q, %t, %v", condition, applicable, err)
 	}
 }
@@ -260,14 +276,14 @@ func TestPathFiltersMatchOrderedPatternsPerPath(t *testing.T) {
 }
 
 func TestTranslateEventTriggerConditionUsesSnapshotExpressions(t *testing.T) {
-	context := TriggerConditionContext{
+	expressions := TriggerConditionExpressions{
 		EventPredicate:        "true",
 		Branch:                `"main"`,
 		Tag:                   `"v1"`,
 		PullRequestBaseBranch: `"release"`,
 		PullRequestAction:     `"opened"`,
 	}
-	condition, applicable, err := TranslateEventTriggerCondition([]workflow.Trigger{{Event: "push", Branches: []string{"main"}, Tags: []string{"v*"}}}, "push", context)
+	condition, applicable, err := TranslateEventTriggerCondition([]workflow.Trigger{{Event: "push", Branches: []string{"main"}, Tags: []string{"v*"}}}, "push", expressions, TriggerEventSnapshot{})
 	if err != nil || !applicable {
 		t.Fatalf("snapshot push condition = %q, %t, %v", condition, applicable, err)
 	}
@@ -280,7 +296,7 @@ func TestTranslateEventTriggerConditionUsesSnapshotExpressions(t *testing.T) {
 		t.Fatalf("snapshot push condition reads live Buildkite fields: %s", condition)
 	}
 
-	condition, applicable, err = TranslateEventTriggerCondition([]workflow.Trigger{{Event: "pull_request", Branches: []string{"release"}, Types: []string{"opened"}}}, "pull_request", context)
+	condition, applicable, err = TranslateEventTriggerCondition([]workflow.Trigger{{Event: "pull_request", Branches: []string{"release"}, Types: []string{"opened"}}}, "pull_request", expressions, TriggerEventSnapshot{})
 	if err != nil || !applicable {
 		t.Fatalf("snapshot pull request condition = %q, %t, %v", condition, applicable, err)
 	}
@@ -299,7 +315,7 @@ func TestTranslateEventTriggerConditionDistinguishesPullRequestBaseFromPushBranc
 		{Event: "push", Branches: []string{"main"}},
 		{Event: "pull_request", Branches: []string{"main"}},
 	}
-	context := TriggerConditionContext{
+	expressions := TriggerConditionExpressions{
 		EventPredicate:        `build.source == "webhook"`,
 		Branch:                `"chore_updates"`,
 		Tag:                   "null",
@@ -307,34 +323,34 @@ func TestTranslateEventTriggerConditionDistinguishesPullRequestBaseFromPushBranc
 		PullRequestAction:     `"opened"`,
 	}
 
-	push, applicable, err := TranslateEventTriggerCondition(triggers, "push", context)
+	push, applicable, err := TranslateEventTriggerCondition(triggers, "push", expressions, TriggerEventSnapshot{})
 	if err != nil || !applicable || !strings.Contains(push, `"chore_updates" =~ /^main$/`) {
 		t.Fatalf("snapshot push condition = %q, %t, %v, want build branch", push, applicable, err)
 	}
 
-	pullRequest, applicable, err := TranslateEventTriggerCondition(triggers, "pull_request", context)
+	pullRequest, applicable, err := TranslateEventTriggerCondition(triggers, "pull_request", expressions, TriggerEventSnapshot{})
 	if err != nil || !applicable || !strings.Contains(pullRequest, `"main" =~ /^main$/`) || strings.Contains(pullRequest, "chore_updates") {
 		t.Fatalf("snapshot pull request condition = %q, %t, %v, want base branch", pullRequest, applicable, err)
 	}
 }
 
 func TestTranslateEventTriggerConditionRejectsIncompletePullRequestSnapshot(t *testing.T) {
-	context := TriggerConditionContext{
+	expressions := TriggerConditionExpressions{
 		EventPredicate:        "true",
 		PullRequestBaseBranch: `"main"`,
 		PullRequestAction:     "null",
 	}
-	if _, _, err := TranslateEventTriggerCondition([]workflow.Trigger{{Event: "pull_request"}}, "pull_request", context); err == nil || !strings.Contains(err.Error(), "payload.action") {
+	if _, _, err := TranslateEventTriggerCondition([]workflow.Trigger{{Event: "pull_request"}}, "pull_request", expressions, TriggerEventSnapshot{}); err == nil || !strings.Contains(err.Error(), "payload.action") {
 		t.Fatalf("missing action error = %v", err)
 	}
 
-	context.PullRequestAction = `"opened"`
-	context.PullRequestBaseBranch = "null"
-	if _, _, err := TranslateEventTriggerCondition([]workflow.Trigger{{Event: "pull_request", Branches: []string{"main"}}}, "pull_request", context); err == nil || !strings.Contains(err.Error(), "payload.pull_request.base.ref") {
+	expressions.PullRequestAction = `"opened"`
+	expressions.PullRequestBaseBranch = "null"
+	if _, _, err := TranslateEventTriggerCondition([]workflow.Trigger{{Event: "pull_request", Branches: []string{"main"}}}, "pull_request", expressions, TriggerEventSnapshot{}); err == nil || !strings.Contains(err.Error(), "payload.pull_request.base.ref") {
 		t.Fatalf("missing filtered base branch error = %v", err)
 	}
 
-	if _, applicable, err := TranslateEventTriggerCondition([]workflow.Trigger{{Event: "pull_request"}}, "pull_request", context); err != nil || !applicable {
+	if _, applicable, err := TranslateEventTriggerCondition([]workflow.Trigger{{Event: "pull_request"}}, "pull_request", expressions, TriggerEventSnapshot{}); err != nil || !applicable {
 		t.Fatalf("unfiltered pull request with omitted base branch = applicable %t, error %v", applicable, err)
 	}
 }
@@ -343,11 +359,11 @@ func TestTranslateEventTriggerConditionRejectsUnclassifiablePushSnapshot(t *test
 	condition, applicable, err := TranslateEventTriggerCondition([]workflow.Trigger{{
 		Event:    "push",
 		Branches: []string{"main"},
-	}}, "push", TriggerConditionContext{
+	}}, "push", TriggerConditionExpressions{
 		EventPredicate: "true",
 		Branch:         "null",
 		Tag:            "null",
-	})
+	}, TriggerEventSnapshot{})
 	if err == nil || !strings.Contains(err.Error(), "refs/heads/") {
 		t.Fatalf("unclassifiable push error = %v", err)
 	}
@@ -375,77 +391,77 @@ func TestTriggerEventSkipReason(t *testing.T) {
 func TestTriggerFilterMismatchReason(t *testing.T) {
 	value := func(value string) *string { return &value }
 	for _, test := range []struct {
-		name    string
-		trigger workflow.Trigger
-		event   string
-		context TriggerConditionContext
-		want    string
+		name     string
+		trigger  workflow.Trigger
+		event    string
+		snapshot TriggerEventSnapshot
+		want     string
 	}{
 		{
-			name:    "push branch mismatch",
-			trigger: workflow.Trigger{Event: "push", Branches: []string{"main", "development"}},
-			event:   "push",
-			context: TriggerConditionContext{BranchValue: value("feature")},
-			want:    "Only runs on `main` or `development`.",
+			name:     "push branch mismatch",
+			trigger:  workflow.Trigger{Event: "push", Branches: []string{"main", "development"}},
+			event:    "push",
+			snapshot: TriggerEventSnapshot{Branch: value("feature")},
+			want:     "Only runs on `main` or `development`.",
 		},
 		{
-			name:    "push branch mismatch with several configured branches",
-			trigger: workflow.Trigger{Event: "push", Branches: []string{"main", "development", "staging", "production"}},
-			event:   "push",
-			context: TriggerConditionContext{BranchValue: value("feature")},
-			want:    "Only runs on `main`, `development`, `staging`, or `production`.",
+			name:     "push branch mismatch with several configured branches",
+			trigger:  workflow.Trigger{Event: "push", Branches: []string{"main", "development", "staging", "production"}},
+			event:    "push",
+			snapshot: TriggerEventSnapshot{Branch: value("feature")},
+			want:     "Only runs on `main`, `development`, `staging`, or `production`.",
 		},
 		{
-			name:    "push branch exclusion mismatch",
-			trigger: workflow.Trigger{Event: "push", BranchesIgnore: []string{"feature"}},
-			event:   "push",
-			context: TriggerConditionContext{BranchValue: value("feature")},
-			want:    "Doesn’t run on the `feature` branch.",
+			name:     "push branch exclusion mismatch",
+			trigger:  workflow.Trigger{Event: "push", BranchesIgnore: []string{"feature"}},
+			event:    "push",
+			snapshot: TriggerEventSnapshot{Branch: value("feature")},
+			want:     "Doesn’t run on the `feature` branch.",
 		},
 		{
-			name:    "ordered push branch match",
-			trigger: workflow.Trigger{Event: "push", Branches: []string{"release/**", "!release/**-alpha", "release/special-alpha"}},
-			event:   "push",
-			context: TriggerConditionContext{BranchValue: value("release/special-alpha")},
+			name:     "ordered push branch match",
+			trigger:  workflow.Trigger{Event: "push", Branches: []string{"release/**", "!release/**-alpha", "release/special-alpha"}},
+			event:    "push",
+			snapshot: TriggerEventSnapshot{Branch: value("release/special-alpha")},
 		},
 		{
-			name:    "push tag mismatch",
-			trigger: workflow.Trigger{Event: "push", TagsIgnore: []string{"v0"}},
-			event:   "push",
-			context: TriggerConditionContext{TagValue: value("v0")},
-			want:    `Tag "v0" does not match this workflow's push tag filters.`,
+			name:     "push tag mismatch",
+			trigger:  workflow.Trigger{Event: "push", TagsIgnore: []string{"v0"}},
+			event:    "push",
+			snapshot: TriggerEventSnapshot{Tag: value("v0")},
+			want:     `Tag "v0" does not match this workflow's push tag filters.`,
 		},
 		{
-			name:    "branch push with only tag filters",
-			trigger: workflow.Trigger{Event: "push", Tags: []string{"v*"}},
-			event:   "push",
-			context: TriggerConditionContext{BranchValue: value("main")},
-			want:    `Branch push "main" does not match this workflow's push tag filters.`,
+			name:     "branch push with only tag filters",
+			trigger:  workflow.Trigger{Event: "push", Tags: []string{"v*"}},
+			event:    "push",
+			snapshot: TriggerEventSnapshot{Branch: value("main")},
+			want:     `Branch push "main" does not match this workflow's push tag filters.`,
 		},
 		{
-			name:    "tag push with only branch filters",
-			trigger: workflow.Trigger{Event: "push", Branches: []string{"main"}},
-			event:   "push",
-			context: TriggerConditionContext{TagValue: value("v1")},
-			want:    `Tag push "v1" does not match this workflow's push branch filters.`,
+			name:     "tag push with only branch filters",
+			trigger:  workflow.Trigger{Event: "push", Branches: []string{"main"}},
+			event:    "push",
+			snapshot: TriggerEventSnapshot{Tag: value("v1")},
+			want:     `Tag push "v1" does not match this workflow's push branch filters.`,
 		},
 		{
-			name:    "pull request base mismatch",
-			trigger: workflow.Trigger{Event: "pull_request", Branches: []string{"main"}},
-			event:   "pull_request",
-			context: TriggerConditionContext{PullRequestBaseValue: value("development"), PullRequestActionValue: value("opened")},
-			want:    `Base branch "development" does not match this workflow's pull_request branch filters.`,
+			name:     "pull request base mismatch",
+			trigger:  workflow.Trigger{Event: "pull_request", Branches: []string{"main"}},
+			event:    "pull_request",
+			snapshot: TriggerEventSnapshot{PullRequestBaseBranch: value("development"), PullRequestAction: value("opened")},
+			want:     `Base branch "development" does not match this workflow's pull_request branch filters.`,
 		},
 		{
-			name:    "pull request activity mismatch",
-			trigger: workflow.Trigger{Event: "pull_request"},
-			event:   "pull_request",
-			context: TriggerConditionContext{PullRequestActionValue: value("closed")},
-			want:    `Pull request activity "closed" does not match this workflow's pull_request activity filters.`,
+			name:     "pull request activity mismatch",
+			trigger:  workflow.Trigger{Event: "pull_request"},
+			event:    "pull_request",
+			snapshot: TriggerEventSnapshot{PullRequestAction: value("closed")},
+			want:     `Pull request activity "closed" does not match this workflow's pull_request activity filters.`,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := TriggerFilterMismatchReason([]workflow.Trigger{test.trigger}, test.event, test.context)
+			got, err := TriggerFilterMismatchReason([]workflow.Trigger{test.trigger}, test.event, test.snapshot)
 			if err != nil || got != test.want {
 				t.Fatalf("TriggerFilterMismatchReason() = %q, %v, want %q", got, err, test.want)
 			}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1896,7 +1896,7 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 		}
 		return 1
 	}
-	populateChangedPaths(&effectiveEvent.TriggerContext, effectiveEvent.Event, effectiveEvent.Origin, workflows)
+	populateChangedPaths(&effectiveEvent.TriggerSnapshot, effectiveEvent.Event, effectiveEvent.Origin, workflows)
 	processingReports := make([]compatibility.ProcessingReport, len(workflows))
 	for i := range workflows {
 		if workflows[i].ReusableOnly {
@@ -1905,13 +1905,13 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 		selection, triggerErr := selectWorkflowTrigger(workflows[i].Triggers, effectiveEvent)
 		if triggerErr != nil {
 			workflows[i].Applicable = true
-			workflows[i].TriggerCondition = effectiveEvent.TriggerContext.EventPredicate
+			workflows[i].TriggerCondition = effectiveEvent.TriggerExpressions.EventPredicate
 			processingReports[i] = triggerFailureProcessingReport(workflows[i], triggerErr)
 			continue
 		}
 		if workflows[i].PathFiltersError != "" && selection.AnnotationReason == "" {
 			workflows[i].Applicable = true
-			workflows[i].TriggerCondition = effectiveEvent.TriggerContext.EventPredicate
+			workflows[i].TriggerCondition = effectiveEvent.TriggerExpressions.EventPredicate
 			processingReports[i] = triggerFailureProcessingReport(workflows[i], &buildkitepipeline.UnsupportedPathFiltersError{
 				Event: effectiveEvent.Event.Event, Reason: workflows[i].PathFiltersError,
 			})
@@ -2271,10 +2271,11 @@ const (
 )
 
 type effectiveEventSelection struct {
-	Source         []byte
-	Event          compiler.Event
-	Origin         effectiveEventOrigin
-	TriggerContext buildkitepipeline.TriggerConditionContext
+	Source             []byte
+	Event              compiler.Event
+	Origin             effectiveEventOrigin
+	TriggerExpressions buildkitepipeline.TriggerConditionExpressions
+	TriggerSnapshot    buildkitepipeline.TriggerEventSnapshot
 }
 
 func loadEffectiveEventSource(ctx context.Context, eventPath string, agent transport.Agent) ([]byte, effectiveEventOrigin, error) {
@@ -2304,9 +2305,11 @@ func newEffectiveEvent(source []byte, origin effectiveEventOrigin, getenv func(s
 	if err != nil {
 		return effectiveEventSelection{}, err
 	}
+	expressions, snapshot := snapshotTriggerState(event)
 	effective := effectiveEventSelection{
 		Source: source, Event: event, Origin: origin,
-		TriggerContext: snapshotTriggerConditionContext(event),
+		TriggerExpressions: expressions,
+		TriggerSnapshot:    snapshot,
 	}
 	if origin == effectiveEventFromPath {
 		return effective, nil
@@ -2315,12 +2318,12 @@ func newEffectiveEvent(source []byte, origin effectiveEventOrigin, getenv func(s
 	if buildSource := strings.TrimSpace(getenv("BUILDKITE_SOURCE")); buildSource != "" {
 		predicate = "build.source == " + triggerConditionLiteral(buildSource)
 	}
-	effective.TriggerContext.EventPredicate = predicate
+	effective.TriggerExpressions.EventPredicate = predicate
 	return effective, nil
 }
 
-func snapshotTriggerConditionContext(event compiler.Event) buildkitepipeline.TriggerConditionContext {
-	context := buildkitepipeline.TriggerConditionContext{
+func snapshotTriggerState(event compiler.Event) (buildkitepipeline.TriggerConditionExpressions, buildkitepipeline.TriggerEventSnapshot) {
+	expressions := buildkitepipeline.TriggerConditionExpressions{
 		EventPredicate:        "true",
 		Branch:                "null",
 		Tag:                   "null",
@@ -2329,37 +2332,38 @@ func snapshotTriggerConditionContext(event compiler.Event) buildkitepipeline.Tri
 		MergeGroupBaseBranch:  "null",
 		MergeGroupAction:      "null",
 	}
+	snapshot := buildkitepipeline.TriggerEventSnapshot{}
 	if branch, ok := strings.CutPrefix(event.Ref, "refs/heads/"); ok {
-		context.Branch = triggerConditionLiteral(branch)
-		context.BranchValue = &branch
+		expressions.Branch = triggerConditionLiteral(branch)
+		snapshot.Branch = &branch
 	}
 	if tag, ok := strings.CutPrefix(event.Ref, "refs/tags/"); ok {
-		context.Tag = triggerConditionLiteral(tag)
-		context.TagValue = &tag
+		expressions.Tag = triggerConditionLiteral(tag)
+		snapshot.Tag = &tag
 	}
 	if action, ok := event.Payload["action"].(string); ok && strings.TrimSpace(action) != "" {
-		context.PullRequestAction = triggerConditionLiteral(action)
-		context.PullRequestActionValue = &action
-		context.MergeGroupAction = triggerConditionLiteral(action)
-		context.MergeGroupActionValue = &action
+		expressions.PullRequestAction = triggerConditionLiteral(action)
+		snapshot.PullRequestAction = &action
+		expressions.MergeGroupAction = triggerConditionLiteral(action)
+		snapshot.MergeGroupAction = &action
 	}
 	if pullRequest, ok := event.Payload["pull_request"].(map[string]any); ok {
 		if base, ok := pullRequest["base"].(map[string]any); ok {
 			if branch, ok := base["ref"].(string); ok && strings.TrimSpace(branch) != "" {
-				context.PullRequestBaseBranch = triggerConditionLiteral(branch)
-				context.PullRequestBaseValue = &branch
+				expressions.PullRequestBaseBranch = triggerConditionLiteral(branch)
+				snapshot.PullRequestBaseBranch = &branch
 			}
 		}
 	}
 	if mergeGroup, ok := event.Payload["merge_group"].(map[string]any); ok {
 		if baseRef, ok := mergeGroup["base_ref"].(string); ok {
 			if branch, ok := strings.CutPrefix(baseRef, "refs/heads/"); ok && branch != "" {
-				context.MergeGroupBaseBranch = triggerConditionLiteral(branch)
-				context.MergeGroupBaseValue = &branch
+				expressions.MergeGroupBaseBranch = triggerConditionLiteral(branch)
+				snapshot.MergeGroupBaseBranch = &branch
 			}
 		}
 	}
-	return context
+	return expressions, snapshot
 }
 
 type workflowTriggerSelection struct {
@@ -2368,13 +2372,13 @@ type workflowTriggerSelection struct {
 }
 
 func selectWorkflowTrigger(triggers []workflow.Trigger, event effectiveEventSelection) (workflowTriggerSelection, error) {
-	condition, applicable, err := buildkitepipeline.TranslateEventTriggerCondition(triggers, event.Event.Event, event.TriggerContext)
+	condition, applicable, err := buildkitepipeline.TranslateEventTriggerCondition(triggers, event.Event.Event, event.TriggerExpressions, event.TriggerSnapshot)
 	if err != nil {
 		return workflowTriggerSelection{}, err
 	}
 	annotationReason := buildkitepipeline.TriggerEventSkipReason(triggers, event.Event.Event)
 	if applicable {
-		annotationReason, err = buildkitepipeline.TriggerFilterMismatchReason(triggers, event.Event.Event, event.TriggerContext)
+		annotationReason, err = buildkitepipeline.TriggerFilterMismatchReason(triggers, event.Event.Event, event.TriggerSnapshot)
 		if err != nil {
 			return workflowTriggerSelection{}, err
 		}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -4282,6 +4282,45 @@ func TestRunUploadNamesAggregateGitHubChecksFromWorkflowLabels(t *testing.T) {
 	}
 }
 
+func TestNewEffectiveEventSeparatesExpressionsAndSnapshot(t *testing.T) {
+	source, err := os.ReadFile(filepath.Join("..", "..", "testdata", "smoke", "events", "push.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	explicit, err := newEffectiveEvent(source, effectiveEventFromPath, func(string) string { return "webhook" })
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantExpressions := buildkitepipeline.TriggerConditionExpressions{
+		EventPredicate:        "true",
+		Branch:                `"main"`,
+		Tag:                   "null",
+		PullRequestBaseBranch: "null",
+		PullRequestAction:     "null",
+		MergeGroupBaseBranch:  "null",
+		MergeGroupAction:      "null",
+	}
+	branch := "main"
+	wantSnapshot := buildkitepipeline.TriggerEventSnapshot{Branch: &branch}
+	if !reflect.DeepEqual(explicit.TriggerExpressions, wantExpressions) || !reflect.DeepEqual(explicit.TriggerSnapshot, wantSnapshot) {
+		t.Fatalf("explicit effective event = expressions %#v, snapshot %#v", explicit.TriggerExpressions, explicit.TriggerSnapshot)
+	}
+
+	webhook, err := newEffectiveEvent(source, effectiveEventFromWebhook, func(key string) string {
+		if key == "BUILDKITE_SOURCE" {
+			return "webhook"
+		}
+		return ""
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantExpressions.EventPredicate = `build.source == "webhook"`
+	if !reflect.DeepEqual(webhook.TriggerExpressions, wantExpressions) || !reflect.DeepEqual(webhook.TriggerSnapshot, wantSnapshot) {
+		t.Fatalf("webhook effective event = expressions %#v, snapshot %#v", webhook.TriggerExpressions, webhook.TriggerSnapshot)
+	}
+}
+
 func TestRunUploadNamesGitHubCheckForActiveEvent(t *testing.T) {
 	requireImporterHost(t)
 	workflowPath := filepath.Join(t.TempDir(), "multi-trigger.yml")

--- a/internal/cli/path_filters.go
+++ b/internal/cli/path_filters.go
@@ -24,16 +24,18 @@ const (
 	zeroGitCommit                      = "0000000000000000000000000000000000000000"
 )
 
-func populateChangedPaths(context *buildkitepipeline.TriggerConditionContext, event compiler.Event, origin effectiveEventOrigin, workflows []workflowInput) {
+func populateChangedPaths(snapshot *buildkitepipeline.TriggerEventSnapshot, event compiler.Event, origin effectiveEventOrigin, workflows []workflowInput) {
 	if event.Event != "pull_request" && event.Event != "push" {
 		return
 	}
-	if event.Event == "push" && context.TagValue != nil {
+	if event.Event == "push" && snapshot.Tag != nil {
 		return
 	}
 	if origin != effectiveEventFromWebhook {
 		if workflowsUsePathFilters(workflows, event.Event) {
-			context.ChangedPathsError = event.Event + " path filters require linked Buildkite webhook data"
+			snapshot.ChangedPaths = buildkitepipeline.ChangedPathEvaluation{
+				UnavailableReason: event.Event + " path filters require linked Buildkite webhook data",
+			}
 		}
 		return
 	}
@@ -43,11 +45,10 @@ func populateChangedPaths(context *buildkitepipeline.TriggerConditionContext, ev
 		}
 		paths, workflowErrors, err := pushChangedPaths(event, workflows)
 		if err != nil {
-			setPathFiltersError(context, workflows, event.Event, err.Error(), true)
+			setPathFiltersError(snapshot, workflows, event.Event, err.Error(), true)
 			return
 		}
-		context.ChangedPaths = paths
-		context.ChangedPathsKnown = true
+		snapshot.ChangedPaths = buildkitepipeline.ChangedPathEvaluation{Paths: append([]string{}, paths...)}
 		for i := range workflows {
 			workflows[i].PathFiltersError = workflowErrors[workflows[i].CanonicalPath]
 		}
@@ -59,21 +60,20 @@ func populateChangedPaths(context *buildkitepipeline.TriggerConditionContext, ev
 	}
 	pullRequestNumber, err := strconv.Atoi(os.Getenv("BUILDKITE_PULL_REQUEST"))
 	if err != nil || pullRequestNumber <= 0 {
-		setPathFiltersError(context, workflows, event.Event, "pull request path filters require the Buildkite pull request number", closed)
+		setPathFiltersError(snapshot, workflows, event.Event, "pull request path filters require the Buildkite pull request number", closed)
 		return
 	}
 	baseRef := os.Getenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH")
 	if baseRef == "" {
-		setPathFiltersError(context, workflows, event.Event, "pull request path filters require the Buildkite pull request base branch", closed)
+		setPathFiltersError(snapshot, workflows, event.Event, "pull request path filters require the Buildkite pull request base branch", closed)
 		return
 	}
 	paths, workflowErrors, err := pullRequestChangedPaths(event, pullRequestNumber, baseRef, workflows)
 	if err != nil {
-		setPathFiltersError(context, workflows, event.Event, err.Error(), closed)
+		setPathFiltersError(snapshot, workflows, event.Event, err.Error(), closed)
 		return
 	}
-	context.ChangedPaths = paths
-	context.ChangedPathsKnown = true
+	snapshot.ChangedPaths = buildkitepipeline.ChangedPathEvaluation{Paths: append([]string{}, paths...)}
 	for i := range workflows {
 		if closed && !workflowUsesPathFilters(workflows[i], event.Event) {
 			continue
@@ -306,8 +306,8 @@ func gitIsAncestor(root, ancestor, descendant string) (bool, error) {
 	return false, err
 }
 
-func setPathFiltersError(context *buildkitepipeline.TriggerConditionContext, workflows []workflowInput, event, reason string, filteredOnly bool) {
-	context.ChangedPathsError = reason
+func setPathFiltersError(snapshot *buildkitepipeline.TriggerEventSnapshot, workflows []workflowInput, event, reason string, filteredOnly bool) {
+	snapshot.ChangedPaths = buildkitepipeline.ChangedPathEvaluation{UnavailableReason: reason}
 	rootBytes, rootErr := exec.Command("git", "rev-parse", "--show-toplevel").Output()
 	root := filepath.Clean(strings.TrimSpace(string(rootBytes)))
 	for i := range workflows {

--- a/internal/cli/path_filters_test.go
+++ b/internal/cli/path_filters_test.go
@@ -338,8 +338,8 @@ func TestPullRequestChangedPathsRejectsPathFiltersAddedByMerge(t *testing.T) {
 		Path: workflowPath, CanonicalPath: "ci.yml", Source: unfiltered,
 		Triggers: []workflow.Trigger{{Event: "pull_request"}},
 	}}
-	context := buildkitepipeline.TriggerConditionContext{}
-	populateChangedPaths(&context, event, effectiveEventFromWebhook, closedWorkflows)
+	snapshot := buildkitepipeline.TriggerEventSnapshot{}
+	populateChangedPaths(&snapshot, event, effectiveEventFromWebhook, closedWorkflows)
 	if closedWorkflows[0].PathFiltersError != "" {
 		t.Fatalf("unfiltered closed workflow provenance error = %q", closedWorkflows[0].PathFiltersError)
 	}
@@ -348,8 +348,8 @@ func TestPullRequestChangedPathsRejectsPathFiltersAddedByMerge(t *testing.T) {
 		Path: workflowPath, CanonicalPath: "ci.yml", Source: unfiltered,
 		Triggers: []workflow.Trigger{{Event: "pull_request"}},
 	})
-	context = buildkitepipeline.TriggerConditionContext{}
-	populateChangedPaths(&context, event, effectiveEventFromWebhook, closedWorkflows)
+	snapshot = buildkitepipeline.TriggerEventSnapshot{}
+	populateChangedPaths(&snapshot, event, effectiveEventFromWebhook, closedWorkflows)
 	if !strings.Contains(closedWorkflows[0].PathFiltersError, "does not bind the event base and head") {
 		t.Fatalf("filtered closed workflow provenance error = %q", closedWorkflows[0].PathFiltersError)
 	}
@@ -363,8 +363,8 @@ func TestPullRequestChangedPathsRejectsPathFiltersAddedByMerge(t *testing.T) {
 		Path: customPath, CanonicalPath: customPath,
 		Triggers: []workflow.Trigger{{Event: "pull_request"}},
 	}}
-	context = buildkitepipeline.TriggerConditionContext{}
-	populateChangedPaths(&context, event, effectiveEventFromWebhook, customWorkflows)
+	snapshot = buildkitepipeline.TriggerEventSnapshot{}
+	populateChangedPaths(&snapshot, event, effectiveEventFromWebhook, customWorkflows)
 	if customWorkflows[0].PathFiltersError != "" {
 		t.Fatalf("unfiltered custom workflow provenance error = %q", customWorkflows[0].PathFiltersError)
 	}
@@ -374,8 +374,8 @@ func TestPullRequestChangedPathsRejectsPathFiltersAddedByMerge(t *testing.T) {
 		Path: workflowPath, CanonicalPath: "ci.yml", Source: unfiltered,
 		Triggers: []workflow.Trigger{{Event: "pull_request"}},
 	}}
-	context = buildkitepipeline.TriggerConditionContext{}
-	populateChangedPaths(&context, event, effectiveEventFromWebhook, workflows)
+	snapshot = buildkitepipeline.TriggerEventSnapshot{}
+	populateChangedPaths(&snapshot, event, effectiveEventFromWebhook, workflows)
 	if !strings.Contains(workflows[0].PathFiltersError, "merge commit SHAs") {
 		t.Fatalf("missing merge commit workflow error = %q", workflows[0].PathFiltersError)
 	}
@@ -383,8 +383,8 @@ func TestPullRequestChangedPathsRejectsPathFiltersAddedByMerge(t *testing.T) {
 	pullRequest["base"].(map[string]any)["sha"] = ""
 	pullRequest["head"].(map[string]any)["sha"] = ""
 	workflows[0].PathFiltersError = ""
-	context = buildkitepipeline.TriggerConditionContext{}
-	populateChangedPaths(&context, event, effectiveEventFromWebhook, workflows)
+	snapshot = buildkitepipeline.TriggerEventSnapshot{}
+	populateChangedPaths(&snapshot, event, effectiveEventFromWebhook, workflows)
 	if !strings.Contains(workflows[0].PathFiltersError, "base, head, and merge commit SHAs") {
 		t.Fatalf("missing base and head workflow error = %q", workflows[0].PathFiltersError)
 	}
@@ -438,12 +438,12 @@ func TestBoundedCommandOutput(t *testing.T) {
 func TestPopulateChangedPathsRequiresLinkedWebhook(t *testing.T) {
 	for _, event := range []string{"push", "pull_request"} {
 		t.Run(event, func(t *testing.T) {
-			context := buildkitepipeline.TriggerConditionContext{}
-			populateChangedPaths(&context, compiler.Event{Event: event}, effectiveEventFromPath, []workflowInput{{
+			snapshot := buildkitepipeline.TriggerEventSnapshot{}
+			populateChangedPaths(&snapshot, compiler.Event{Event: event}, effectiveEventFromPath, []workflowInput{{
 				Triggers: []workflow.Trigger{{Event: event, Paths: []string{"src/**"}}},
 			}})
-			if context.ChangedPathsKnown || !strings.Contains(context.ChangedPathsError, event+" path filters require linked Buildkite webhook") {
-				t.Fatalf("changed-path context = %#v", context)
+			if snapshot.ChangedPaths.Paths != nil || !strings.Contains(snapshot.ChangedPaths.UnavailableReason, event+" path filters require linked Buildkite webhook") {
+				t.Fatalf("changed-path snapshot = %#v", snapshot)
 			}
 		})
 	}


### PR DESCRIPTION
## Why

Trigger selection stores trusted Buildkite expression strings, observed effective-event values, and changed-path acquisition flags in one flat context. Expression construction, concrete event matching, and mismatch explanations therefore share unrelated mutable state.

## What

Split trigger state into expression-only `TriggerConditionExpressions` and concrete `TriggerEventSnapshot` representations. Model changed-path evaluation as available paths—including a known-empty result—or an unavailable reason, and limit path population and mismatch explanations to snapshot state.

Effective-event selection owns both representations while preserving explicit-event constants, live `build.source` predicates, inactive-trigger validation, filter and error behavior, and generated pipeline and report output. Focused tests and the full check pass; an Oracle review traced the event, ref, pull-request, path, mismatch, and output boundaries without finding a behavior change.
