### PR TITLE
Support plugin OIDC configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,21 @@ For example, the Buildkite statement can use these conditions:
 
 The workflow must grant `id-token: write`. The endpoint is available to host
 JavaScript and composite actions, including `aws-actions/configure-aws-credentials`.
+Use the plugin's `oidc` block to add claims, AWS session tags, or replace the
+default compound subject for every token minted by imported jobs:
+
+```yaml
+plugins:
+  - github-actions#latest:
+      workflow: .github/workflows/deploy.yml
+      oidc:
+        claims: [organization_id]
+        aws-session-tags: [organization_slug, pipeline_id]
+        subject-claim: pipeline_id
+```
+
+This configuration does not grant OIDC access. Each workflow job must still
+declare `permissions: {id-token: write}` to receive the endpoint.
 See Buildkite's [AWS setup guide](https://buildkite.com/docs/pipelines/security/oidc/aws)
 for the complete IAM configuration and [OIDC claims reference](https://buildkite.com/docs/agent/cli/reference/oidc#claims)
 for the full subject format and available claims.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -199,13 +199,15 @@ buildkite-gha upload .github/workflows/ci.yml
 The importer must run on Linux/amd64 or Darwin/arm64 with `BUILDKITE=true` and `BUILDKITE_STEP_KEY`.
 
 The hidden zero-argument `buildkite-gha plugin` entry point reads `workflow`,
-`workflows`, and `runners` from `BUILDKITE_PLUGIN_CONFIGURATION`. Set `workflow`
+`workflows`, `runners`, and `oidc` from `BUILDKITE_PLUGIN_CONFIGURATION`. Set `workflow`
 to one explicit path or `workflows` to a non-empty array of explicit paths; the
 fields are mutually exclusive. Every path must identify a regular, tracked
 `.yml` or `.yaml` file inside the repository; directories and glob patterns are
 rejected. It also accepts the plugin-owned `version`, `source-ref`, and
 `minimum-release-age` fields, plus the boolean `experimental-runner-user` field.
-Unknown fields and non-boolean values are rejected before upload.
+The optional `oidc` object accepts `claims`, `aws-session-tags`, and
+`subject-claim`; configured lists and strings must be non-empty. Unknown fields
+and invalid values are rejected before upload.
 The importer uses its verified executable for jobs on the same platform and
 fetches the other platform's distribution from the same release only when a
 workflow requires it. Custom importers can use the public flags below. Runner

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -808,6 +808,24 @@ These are Buildkite secrets available to the destination job, not GitHub reposit
 
 Jobs with `id-token: write` expose the GitHub Actions `getIDToken()` wire contract to host JavaScript actions, including JavaScript actions called by composite actions. The endpoint mints a Buildkite OIDC token for the requested audience. Cloud identity providers must trust Buildkite's issuer and claims, not GitHub's. `id-token: read`, `id-token: none`, and omitted permission maps do not expose the endpoint. Repository tests verify the wire contract with a shim that mirrors `actions/toolkit`'s `oidc-utils.ts`; the hosted runtime proof remains pending.
 
+The plugin can apply additional Buildkite OIDC settings to every mint:
+
+```yaml
+plugins:
+  - github-actions#latest:
+      workflow: .github/workflows/deploy.yml
+      oidc:
+        claims: [organization_id]
+        aws-session-tags: [organization_slug, pipeline_id]
+        subject-claim: pipeline_id
+```
+
+`claims` and `aws-session-tags` accept non-empty claim-name lists.
+`subject-claim` accepts one non-empty immutable claim name. The Agent API owns
+the available claim vocabulary and rejects unsupported names when a job mints
+a token. Plugin OIDC configuration applies to jobs without granting
+`id-token: write`; those jobs still receive no endpoint.
+
 The endpoint variables are scoped to each host action lifecycle invocation. Shell steps, Docker container actions, and actions running in job containers do not receive them. Container actions that call `getIDToken()` fail with its missing endpoint variable diagnostic.
 
 ### GitHub services

--- a/docs/plans/github-actions-oidc.md
+++ b/docs/plans/github-actions-oidc.md
@@ -106,7 +106,7 @@ action-time parameters:
 | --- | --- |
 | `--audience` | Query parameter; the only knob the GitHub contract gives actions |
 | `--lifetime` | Fixed API default (five minutes) |
-| `--claim`, `--aws-session-tag`, `--subject-claim` | Plugin `oidc` configuration applied to every mint (later slice) |
+| `--claim`, `--aws-session-tag`, `--subject-claim` | Plugin `oidc` configuration applied to every mint |
 | `--format gcp` | Not needed; `google-github-actions/auth` consumes the raw JWT |
 | `--skip-redaction` | Never; both redactors always apply |
 

--- a/docs/plans/github-actions-oidc.md
+++ b/docs/plans/github-actions-oidc.md
@@ -140,7 +140,7 @@ workflows cannot express.
   the loopback service is the exposure surface, and injecting a step would
   require handing a credential to action code or new backend credentials.
 
-## Delivery slices
+## Delivered slices
 
 ### 1. Endpoint contract and minting client
 
@@ -178,8 +178,9 @@ plugins:
         subject-claim: pipeline_id
 ```
 
-Deliver when a workflow needs AWS session tags or Azure exact-match
-subjects.
+The plugin configuration is validated before compilation, recorded in every
+job plan, and forwarded to every Agent API mint. It does not grant
+`id-token: write` or expose the loopback endpoint by itself.
 
 ## Open questions
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -213,6 +213,7 @@ func pluginContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 		workflowOperands:       configuration.Workflows,
 		explicitWorkflowPaths:  true,
 		runnerTargets:          configuration.runnerTargets,
+		oidc:                   configuration.OIDC,
 		experimentalRunnerUser: configuration.ExperimentalRunnerUser,
 		pluginAcquisition:      &pluginRuntimeAcquisition{version: version},
 		importerPlatform:       importerPlatform,
@@ -234,6 +235,7 @@ func importerPlatform(goos, goarch string) (compiler.Platform, error) {
 type pluginConfiguration struct {
 	Workflows              []string
 	ExperimentalRunnerUser bool
+	OIDC                   *plan.OIDCConfiguration
 	runnerTargets          map[string]compiler.RunnerTarget
 }
 
@@ -258,7 +260,7 @@ func parsePluginConfiguration(source string) (pluginConfiguration, error) {
 	}
 	for key := range encoded {
 		switch key {
-		case "workflow", "workflows", "runners", "version", "source-ref", "minimum-release-age", "experimental-runner-user":
+		case "workflow", "workflows", "runners", "oidc", "version", "source-ref", "minimum-release-age", "experimental-runner-user":
 		default:
 			return pluginConfiguration{}, fmt.Errorf("%s contains unknown field %q", pluginConfigurationEnvironment, key)
 		}
@@ -343,7 +345,65 @@ func parsePluginConfiguration(source string) (pluginConfiguration, error) {
 			targets[label] = target
 		}
 	}
-	return pluginConfiguration{Workflows: workflows, ExperimentalRunnerUser: experimentalRunnerUser, runnerTargets: targets}, nil
+	var oidc *plan.OIDCConfiguration
+	if value, configured := encoded["oidc"]; configured {
+		oidc, err = parsePluginOIDCConfiguration(value)
+		if err != nil {
+			return pluginConfiguration{}, err
+		}
+	}
+	return pluginConfiguration{Workflows: workflows, ExperimentalRunnerUser: experimentalRunnerUser, OIDC: oidc, runnerTargets: targets}, nil
+}
+
+func parsePluginOIDCConfiguration(value any) (*plan.OIDCConfiguration, error) {
+	oidc, ok := value.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%s oidc must be a JSON object", pluginConfigurationEnvironment)
+	}
+	for key := range oidc {
+		switch key {
+		case "claims", "aws-session-tags", "subject-claim":
+		default:
+			return nil, fmt.Errorf("%s oidc contains unknown field %q", pluginConfigurationEnvironment, key)
+		}
+	}
+	configuration := &plan.OIDCConfiguration{}
+	var err error
+	if claims, configured := oidc["claims"]; configured {
+		configuration.Claims, err = pluginNonEmptyStringList(claims, "oidc claims")
+		if err != nil {
+			return nil, err
+		}
+	}
+	if tags, configured := oidc["aws-session-tags"]; configured {
+		configuration.AWSSessionTags, err = pluginNonEmptyStringList(tags, "oidc aws-session-tags")
+		if err != nil {
+			return nil, err
+		}
+	}
+	if subject, configured := oidc["subject-claim"]; configured {
+		configuration.SubjectClaim, ok = subject.(string)
+		if !ok || strings.TrimSpace(configuration.SubjectClaim) == "" {
+			return nil, fmt.Errorf("%s oidc subject-claim must be a non-empty string", pluginConfigurationEnvironment)
+		}
+	}
+	return configuration, nil
+}
+
+func pluginNonEmptyStringList(value any, field string) ([]string, error) {
+	values, ok := value.([]any)
+	if !ok || len(values) == 0 {
+		return nil, fmt.Errorf("%s %s must be a non-empty array of non-empty strings", pluginConfigurationEnvironment, field)
+	}
+	result := make([]string, len(values))
+	for index, value := range values {
+		entry, ok := value.(string)
+		if !ok || strings.TrimSpace(entry) == "" {
+			return nil, fmt.Errorf("%s %s entry %d must be a non-empty string", pluginConfigurationEnvironment, field, index)
+		}
+		result[index] = entry
+	}
+	return result, nil
 }
 
 func normalizePluginCommit(ctx context.Context, getenv func(string) string, setenv func(string, string) error, runner transport.Runner) error {
@@ -528,11 +588,17 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 	}
 	var oidcTokens gharuntime.OIDCTokenProvider
 	if job.IDTokenPermission == "write" {
-		oidcTokens, err = gharuntime.NewAgentOIDCTokens(gharuntime.AgentOIDCTokenConfig{
+		config := gharuntime.AgentOIDCTokenConfig{
 			Endpoint: os.Getenv("BUILDKITE_AGENT_ENDPOINT"),
 			JobID:    os.Getenv("BUILDKITE_JOB_ID"),
 			JobToken: os.Getenv("BUILDKITE_AGENT_ACCESS_TOKEN"),
-		})
+		}
+		if job.OIDC != nil {
+			config.Claims = job.OIDC.Claims
+			config.AWSSessionTags = job.OIDC.AWSSessionTags
+			config.SubjectClaim = job.OIDC.SubjectClaim
+		}
+		oidcTokens, err = gharuntime.NewAgentOIDCTokens(config)
 		if err != nil {
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: configure OIDC token service: %v\n", err)
 			return 1
@@ -2035,7 +2101,7 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 			failureArtifacts = append(failureArtifacts, artifacts...)
 			continue
 		}
-		preflight, err := compileHostedNamespaced(ctx, input.Path, input.Source, effectiveEvent.Source, version, distributionDigest, importerStep, "", uploadArguments.runnerTargets, runtimeDigests, input.StepKeyNamespace, authentication)
+		preflight, err := compileHostedNamespaced(ctx, input.Path, input.Source, effectiveEvent.Source, version, distributionDigest, importerStep, "", uploadArguments.runnerTargets, runtimeDigests, input.StepKeyNamespace, uploadArguments.oidc, authentication)
 		applyHostedPreflight(&processingReports[i], preflight)
 		if err != nil {
 			processingReports[i].Result = classifyHostedFailure(&processingReports[i], input.Path, err)
@@ -2681,20 +2747,21 @@ func hostedRunnerTargets() map[string]compiler.RunnerTarget {
 }
 
 func compileHosted(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runtimeDistributions map[compiler.Platform]string, actionAuthentication *actionSourceAuthentication) (hostedCompilation, error) {
-	return compileHostedNamespaced(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, groupLabel, configuredTargets, runtimeDistributions, "", actionAuthentication)
+	return compileHostedNamespaced(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, groupLabel, configuredTargets, runtimeDistributions, "", nil, actionAuthentication)
 }
 
 func compileHostedWithActionCache(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runtimeDistributions map[compiler.Platform]string, actionCacheDir string, sharedActionSource compiler.ActionSource, actionAuthentication *actionSourceAuthentication) (hostedCompilation, error) {
-	return compileHostedNamespacedWithActionCache(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, groupLabel, configuredTargets, runtimeDistributions, "", actionCacheDir, sharedActionSource, actionAuthentication)
+	return compileHostedNamespacedWithActionCache(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, groupLabel, configuredTargets, runtimeDistributions, "", nil, actionCacheDir, sharedActionSource, actionAuthentication)
 }
 
-func compileHostedNamespaced(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runtimeDistributions map[compiler.Platform]string, stepKeyNamespace string, actionAuthentication *actionSourceAuthentication) (hostedCompilation, error) {
-	return compileHostedNamespacedWithActionCache(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, groupLabel, configuredTargets, runtimeDistributions, stepKeyNamespace, "", nil, actionAuthentication)
+func compileHostedNamespaced(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runtimeDistributions map[compiler.Platform]string, stepKeyNamespace string, oidc *plan.OIDCConfiguration, actionAuthentication *actionSourceAuthentication) (hostedCompilation, error) {
+	return compileHostedNamespacedWithActionCache(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, groupLabel, configuredTargets, runtimeDistributions, stepKeyNamespace, oidc, "", nil, actionAuthentication)
 }
 
-func compileHostedNamespacedWithActionCache(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runtimeDistributions map[compiler.Platform]string, stepKeyNamespace, actionCacheDir string, sharedActionSource compiler.ActionSource, actionAuthentication *actionSourceAuthentication) (hostedCompilation, error) {
+func compileHostedNamespacedWithActionCache(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runtimeDistributions map[compiler.Platform]string, stepKeyNamespace string, oidc *plan.OIDCConfiguration, actionCacheDir string, sharedActionSource compiler.ActionSource, actionAuthentication *actionSourceAuthentication) (hostedCompilation, error) {
 	options := hostedOptions(groupLabel, configuredTargets, runtimeDistributions)
 	options.StepKeyNamespace = stepKeyNamespace
+	options.OIDC = oidc
 	preflight, err := compiler.CompileWithOptions(workflowPath, workflowSource, eventSource, options)
 	if err != nil {
 		return hostedCompilation{}, hostedError(hostedEvaluationFailure, err)
@@ -2978,6 +3045,7 @@ type parsedUploadArgs struct {
 	eventPath                string
 	runtimeDistributionPaths map[compiler.Platform]string
 	runnerTargets            map[string]compiler.RunnerTarget
+	oidc                     *plan.OIDCConfiguration
 	experimentalRunnerUser   bool
 	pluginAcquisition        *pluginRuntimeAcquisition
 	importerPlatform         compiler.Platform

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -456,6 +456,11 @@ func TestParsePluginConfiguration(t *testing.T) {
   "source-ref": "0123456789abcdef0123456789abcdef01234567",
   "minimum-release-age": "24h",
   "experimental-runner-user": true,
+  "oidc": {
+    "claims": ["organization_id", "future_server_claim"],
+    "aws-session-tags": ["organization_slug", "pipeline_id"],
+    "subject-claim": "pipeline_id"
+  },
   "runners": [
     {"runs-on":"ubuntu-latest","queue":"hosted","image":"` + image + `"},
     {"runs-on":"macos-14","queue":"macos-sonoma-arm64"}
@@ -466,6 +471,9 @@ func TestParsePluginConfiguration(t *testing.T) {
 	}
 	if !slices.Equal(configuration.Workflows, []string{".github/workflows/ci.yml", ".github/workflows/release.yml"}) || !configuration.ExperimentalRunnerUser || len(configuration.runnerTargets) != 2 {
 		t.Fatalf("configuration = %#v", configuration)
+	}
+	if configuration.OIDC == nil || !slices.Equal(configuration.OIDC.Claims, []string{"organization_id", "future_server_claim"}) || !slices.Equal(configuration.OIDC.AWSSessionTags, []string{"organization_slug", "pipeline_id"}) || configuration.OIDC.SubjectClaim != "pipeline_id" {
+		t.Fatalf("OIDC configuration = %#v", configuration.OIDC)
 	}
 	if got := configuration.runnerTargets["ubuntu-latest"]; got != (compiler.RunnerTarget{Queue: "hosted", Platform: compiler.PlatformLinuxAMD64, Image: image}) {
 		t.Fatalf("Linux target = %#v", got)
@@ -501,6 +509,15 @@ func TestParsePluginConfiguration(t *testing.T) {
 		{name: "string experimental runner user", source: `{"workflow":"ci.yml","experimental-runner-user":"true"}`, want: "must be a boolean"},
 		{name: "numeric experimental runner user", source: `{"workflow":"ci.yml","experimental-runner-user":1}`, want: "must be a boolean"},
 		{name: "null experimental runner user", source: `{"workflow":"ci.yml","experimental-runner-user":null}`, want: "must be a boolean"},
+		{name: "null oidc", source: `{"workflow":"ci.yml","oidc":null}`, want: "oidc must be a JSON object"},
+		{name: "array oidc", source: `{"workflow":"ci.yml","oidc":[]}`, want: "oidc must be a JSON object"},
+		{name: "unknown oidc field", source: `{"workflow":"ci.yml","oidc":{"subject_claim":"pipeline_id"}}`, want: "oidc contains unknown field"},
+		{name: "empty claims", source: `{"workflow":"ci.yml","oidc":{"claims":[]}}`, want: "oidc claims must be a non-empty array"},
+		{name: "claims string", source: `{"workflow":"ci.yml","oidc":{"claims":"organization_id"}}`, want: "oidc claims must be a non-empty array"},
+		{name: "empty claim entry", source: `{"workflow":"ci.yml","oidc":{"claims":["organization_id",""]}}`, want: "oidc claims entry 1 must be a non-empty string"},
+		{name: "non-string AWS tag entry", source: `{"workflow":"ci.yml","oidc":{"aws-session-tags":["pipeline_id",null]}}`, want: "oidc aws-session-tags entry 1 must be a non-empty string"},
+		{name: "empty subject claim", source: `{"workflow":"ci.yml","oidc":{"subject-claim":" "}}`, want: "oidc subject-claim must be a non-empty string"},
+		{name: "non-string subject claim", source: `{"workflow":"ci.yml","oidc":{"subject-claim":1}}`, want: "oidc subject-claim must be a non-empty string"},
 		{name: "null runners", source: `{"workflow":"ci.yml","runners":null}`, want: "non-empty array"},
 		{name: "empty runners", source: `{"workflow":"ci.yml","runners":[]}`, want: "non-empty array"},
 		{name: "unknown runner field", source: `{"workflow":"ci.yml","runners":[{"runs-on":"ubuntu-latest","queue":"hosted","extra":true}]}`, want: "unknown field"},
@@ -659,6 +676,11 @@ func TestPluginUsesJSONConfigurationAndOnlyRequiredRuntime(t *testing.T) {
 		"workflow":                 workflowPath,
 		"version":                  "0.8.0",
 		"experimental-runner-user": true,
+		"oidc": map[string]any{
+			"claims":           []string{"organization_id"},
+			"aws-session-tags": []string{"pipeline_id"},
+			"subject-claim":    "pipeline_id",
+		},
 		"runners": []map[string]string{
 			{"runs-on": "ubuntu-latest", "queue": "hosted"},
 		},
@@ -705,6 +727,26 @@ func TestPluginUsesJSONConfigurationAndOnlyRequiredRuntime(t *testing.T) {
 		if step.Agents["queue"] != "hosted" || step.Image != defaultNobleRunnerImage || !strings.Contains(step.Command, "--hosted-tool-cache") || !strings.Contains(step.Command, "useradd --create-home") || !strings.Contains(step.Command, "sudo -n --preserve-env --user runner") {
 			t.Fatalf("plugin profile was not applied: %#v", step)
 		}
+	}
+	planCount := 0
+	for path, contents := range runner.uploaded {
+		if !strings.HasSuffix(path, ".json") {
+			continue
+		}
+		job, err := plan.Decode(contents)
+		if err != nil {
+			t.Fatal(err)
+		}
+		planCount++
+		if job.OIDC == nil || !slices.Equal(job.OIDC.Claims, []string{"organization_id"}) || !slices.Equal(job.OIDC.AWSSessionTags, []string{"pipeline_id"}) || job.OIDC.SubjectClaim != "pipeline_id" {
+			t.Errorf("plan %q OIDC configuration = %#v", job.Workflow.LogicalJobID, job.OIDC)
+		}
+		if job.IDTokenPermission != "" {
+			t.Errorf("plugin OIDC configuration implied plan permission %q", job.IDTokenPermission)
+		}
+	}
+	if planCount != 3 {
+		t.Fatalf("plan count = %d, want 3", planCount)
 	}
 }
 

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -593,6 +593,7 @@ instances:
 				RequiredSecrets:         secrets,
 				GitHubToken:             githubToken,
 				IDTokenPermission:       instance.Permissions["id-token"],
+				OIDC:                    cloneOIDCConfiguration(options.OIDC),
 				Matrix:                  instance.Matrix,
 				Inputs:                  cloneAnyMap(instance.Inputs),
 				Vars:                    cloneMap(ir.Vars),
@@ -655,6 +656,17 @@ instances:
 		evaluations = append(evaluations, JobEvaluation{Instance: instance.Key, Job: instance.LogicalJobID, Evaluated: true, Passed: true})
 	}
 	return plans, authorizations, evaluations, errors.Join(diagnostics...)
+}
+
+func cloneOIDCConfiguration(configuration *plan.OIDCConfiguration) *plan.OIDCConfiguration {
+	if configuration == nil {
+		return nil
+	}
+	return &plan.OIDCConfiguration{
+		Claims:         append([]string(nil), configuration.Claims...),
+		AWSSessionTags: append([]string(nil), configuration.AWSSessionTags...),
+		SubjectClaim:   configuration.SubjectClaim,
+	}
 }
 
 func planConstructionFinding(instance JobInstance, err error) error {

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -122,6 +122,41 @@ jobs:
 	}
 }
 
+func TestCompilePlansCarriesPluginOIDCConfigurationToEveryJob(t *testing.T) {
+	configuration := &plan.OIDCConfiguration{
+		Claims:         []string{"organization_id"},
+		AWSSessionTags: []string{"organization_slug", "pipeline_id"},
+		SubjectClaim:   "pipeline_id",
+	}
+	options := defaultOptions()
+	options.OIDC = configuration
+	plans, err := compilePlansForTest(context.Background(), "oidc.yml", []byte(`on: push
+jobs:
+  mint:
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    steps: [{run: echo mint}]
+  no-permission:
+    runs-on: ubuntu-latest
+    steps: [{run: echo no endpoint}]
+`), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 2 {
+		t.Fatalf("plans = %#v", plans)
+	}
+	for _, job := range plans {
+		if !reflect.DeepEqual(job.OIDC, configuration) {
+			t.Errorf("job %q OIDC configuration = %#v", job.Workflow.LogicalJobID, job.OIDC)
+		}
+		if job.Workflow.LogicalJobID == "no-permission" && job.IDTokenPermission != "" {
+			t.Errorf("OIDC configuration implied id-token permission %q", job.IDTokenPermission)
+		}
+	}
+}
+
 func TestCompilePlansBoundsNestedReusableWorkflowDefaultPermissions(t *testing.T) {
 	repository := t.TempDir()
 	caller := writeWorkflow(t, repository, "caller.yml", `on: push

--- a/internal/compiler/config.go
+++ b/internal/compiler/config.go
@@ -6,6 +6,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/buildkite/buildkite-gha/internal/plan"
 )
 
 var queuePattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,255}$`)
@@ -107,6 +109,7 @@ type Options struct {
 	Vars       VariableSources
 	Runners    RunnerPolicy
 	EventTrust EventTrust
+	OIDC       *plan.OIDCConfiguration
 	// ResolveActions enables immutable remote action locking independently of
 	// event trust. Workspace-local actions are always locked without network
 	// access. ActionSource is required only when a workflow uses remote actions.

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -254,6 +254,14 @@ type GitHubToken struct {
 	Permissions map[string]string `json:"permissions"`
 }
 
+// OIDCConfiguration applies additional Buildkite claims to every OIDC token
+// minted for the job.
+type OIDCConfiguration struct {
+	Claims         []string `json:"claims,omitempty"`
+	AWSSessionTags []string `json:"aws_session_tags,omitempty"`
+	SubjectClaim   string   `json:"subject_claim,omitempty"`
+}
+
 // Job is one immutable, compiler-selected workflow job instance.
 type Job struct {
 	Schema               string                  `json:"schema"`
@@ -266,6 +274,7 @@ type Job struct {
 	RequiredSecrets      []string                `json:"required_secrets,omitempty"`
 	GitHubToken          *GitHubToken            `json:"github_token,omitempty"`
 	IDTokenPermission    string                  `json:"id_token_permission,omitempty"`
+	OIDC                 *OIDCConfiguration      `json:"oidc,omitempty"`
 	Matrix               map[string]any          `json:"matrix,omitempty"`
 	Inputs               map[string]any          `json:"inputs,omitempty"`
 	Vars                 map[string]string       `json:"vars,omitempty"`
@@ -598,6 +607,21 @@ func (job Job) Validate() error {
 	}
 	if job.IDTokenPermission != "" && job.IDTokenPermission != "read" && job.IDTokenPermission != "write" {
 		return fmt.Errorf("job plan contains invalid id-token permission %q", job.IDTokenPermission)
+	}
+	if job.OIDC != nil {
+		for i, claim := range job.OIDC.Claims {
+			if strings.TrimSpace(claim) == "" {
+				return fmt.Errorf("job plan OIDC claims entry %d must be a non-empty string", i)
+			}
+		}
+		for i, claim := range job.OIDC.AWSSessionTags {
+			if strings.TrimSpace(claim) == "" {
+				return fmt.Errorf("job plan OIDC AWS session tags entry %d must be a non-empty string", i)
+			}
+		}
+		if job.OIDC.SubjectClaim != "" && strings.TrimSpace(job.OIDC.SubjectClaim) == "" {
+			return fmt.Errorf("job plan OIDC subject claim must be a non-empty string")
+		}
 	}
 	if !sort.StringsAreSorted(job.Dependencies) {
 		return fmt.Errorf("job plan dependencies must be sorted")

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -16,6 +16,7 @@ func TestDecodePreservesPlanContract(t *testing.T) {
 	fixture := validJob()
 	fixture.Event.HeadRef = "feature/head-ref"
 	fixture.Event.BaseRef = "main"
+	fixture.OIDC = &OIDCConfiguration{Claims: []string{"organization_id"}, AWSSessionTags: []string{"pipeline_id"}, SubjectClaim: "pipeline_id"}
 	source, err := Encode(fixture)
 	if err != nil {
 		t.Fatal(err)
@@ -24,7 +25,7 @@ func TestDecodePreservesPlanContract(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Decode() error = %v", err)
 	}
-	if job.Compiler.DistributionDigest == "" || job.Workflow.Name != "CI" || job.Event.PayloadDigest == "" || job.Event.HeadRef != "feature/head-ref" || job.Event.BaseRef != "main" || job.Target.StepKey != "gha-test" {
+	if job.Compiler.DistributionDigest == "" || job.Workflow.Name != "CI" || job.Event.PayloadDigest == "" || job.Event.HeadRef != "feature/head-ref" || job.Event.BaseRef != "main" || job.Target.StepKey != "gha-test" || !slices.Equal(job.OIDC.Claims, []string{"organization_id"}) {
 		t.Fatalf("decoded fixture lost trust bindings: %#v", job)
 	}
 	validateJobPlanSchema(t, source)

--- a/internal/runtime/oidc_token_service.go
+++ b/internal/runtime/oidc_token_service.go
@@ -32,16 +32,22 @@ type OIDCTokenProvider interface {
 
 // AgentOIDCTokenConfig identifies the current Buildkite job's Agent API.
 type AgentOIDCTokenConfig struct {
-	Endpoint string
-	JobID    string
-	JobToken string
-	Client   *http.Client
+	Endpoint       string
+	JobID          string
+	JobToken       string
+	Claims         []string
+	AWSSessionTags []string
+	SubjectClaim   string
+	Client         *http.Client
 }
 
 // AgentOIDCTokens mints job-bound Buildkite OIDC tokens through the Agent API.
 type AgentOIDCTokens struct {
 	mintURL  string
 	jobToken string
+	claims   []string
+	awsTags  []string
+	subject  string
 	client   *http.Client
 }
 
@@ -63,7 +69,14 @@ func NewAgentOIDCTokens(config AgentOIDCTokenConfig) (*AgentOIDCTokens, error) {
 	if bounded.Timeout == 0 {
 		bounded.Timeout = 15 * time.Second
 	}
-	return &AgentOIDCTokens{mintURL: mintURL, jobToken: config.JobToken, client: &bounded}, nil
+	return &AgentOIDCTokens{
+		mintURL:  mintURL,
+		jobToken: config.JobToken,
+		claims:   append([]string(nil), config.Claims...),
+		awsTags:  append([]string(nil), config.AWSSessionTags...),
+		subject:  config.SubjectClaim,
+		client:   &bounded,
+	}, nil
 }
 
 func (c *AgentOIDCTokens) OIDCToken(ctx context.Context, audience string) (string, error) {
@@ -74,8 +87,11 @@ func (c *AgentOIDCTokens) OIDCToken(ctx context.Context, audience string) (strin
 		return "", fmt.Errorf("OIDC token audience is invalid")
 	}
 	body, err := json.Marshal(struct {
-		Audience string `json:"audience"`
-	}{Audience: audience})
+		Audience       string   `json:"audience"`
+		Claims         []string `json:"claims,omitempty"`
+		AWSSessionTags []string `json:"aws_session_tags,omitempty"`
+		SubjectClaim   string   `json:"subject_claim,omitempty"`
+	}{Audience: audience, Claims: c.claims, AWSSessionTags: c.awsTags, SubjectClaim: c.subject})
 	if err != nil {
 		return "", fmt.Errorf("encode OIDC token request: %w", err)
 	}

--- a/internal/runtime/oidc_token_service_test.go
+++ b/internal/runtime/oidc_token_service_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/buildkite/buildkite-gha/internal/plan"
 )
 
-func TestAgentOIDCTokensMintsRequestedAudience(t *testing.T) {
+func TestAgentOIDCTokensMintsRequestedAudienceAndConfiguredClaims(t *testing.T) {
 	const token = "header.payload.signature"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 		if request.URL.Path != "/jobs/"+testCacheJobID+"/oidc/tokens" {
@@ -30,13 +30,20 @@ func TestAgentOIDCTokensMintsRequestedAudience(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if string(body) != `{"audience":"sts.amazonaws.com"}` {
+		if string(body) != `{"audience":"sts.amazonaws.com","claims":["organization_id"],"aws_session_tags":["organization_slug","pipeline_id"],"subject_claim":"pipeline_id"}` {
 			t.Errorf("body = %s", body)
 		}
 		_, _ = io.WriteString(w, `{"token":"`+token+`"}`)
 	}))
 	defer server.Close()
-	provider, err := NewAgentOIDCTokens(AgentOIDCTokenConfig{Endpoint: server.URL, JobID: testCacheJobID, JobToken: "job-secret"})
+	provider, err := NewAgentOIDCTokens(AgentOIDCTokenConfig{
+		Endpoint:       server.URL,
+		JobID:          testCacheJobID,
+		JobToken:       "job-secret",
+		Claims:         []string{"organization_id"},
+		AWSSessionTags: []string{"organization_slug", "pipeline_id"},
+		SubjectClaim:   "pipeline_id",
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/schemas/job-plan.schema.json
+++ b/schemas/job-plan.schema.json
@@ -16,6 +16,7 @@
     "required_secrets": {"type": "array", "uniqueItems": true, "maxItems": 128, "items": {"type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_]*$", "not": {"const": "GITHUB_TOKEN"}}},
     "github_token": {"$ref": "#/$defs/githubToken"},
     "id_token_permission": {"enum": ["read", "write"]},
+    "oidc": {"$ref": "#/$defs/oidcConfiguration"},
     "matrix": {"type": "object"},
     "inputs": {"type": "object", "maxProperties": 25, "propertyNames": {"minLength": 1, "maxLength": 255}, "additionalProperties": {"type": ["string", "number", "boolean"], "maxLength": 65536}},
     "vars": {"$ref": "#/$defs/stringMap"},
@@ -68,6 +69,7 @@
     "target": {"type": "object", "additionalProperties": false, "required": ["step_key"], "properties": {"step_key": {"$ref": "#/$defs/buildkiteName"}, "queue": {"$ref": "#/$defs/buildkiteName"}}},
     "githubEventRepository": {"type": "string", "maxLength": 140, "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$", "not": {"pattern": "^(?:\\.\\.?/|[A-Za-z0-9_.-]+/\\.\\.?)$"}},
     "githubToken": {"type": "object", "additionalProperties": false, "required": ["workflow", "permissions"], "properties": {"workflow": {"type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*\\.ya?ml$", "maxLength": 255}, "permissions": {"$ref": "#/$defs/githubPermissions"}}},
+    "oidcConfiguration": {"type": "object", "additionalProperties": false, "properties": {"claims": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}}, "aws_session_tags": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}}, "subject_claim": {"type": "string", "minLength": 1}}},
     "githubPermissions": {
       "type": "object", "additionalProperties": false, "minProperties": 1, "maxProperties": 15,
       "properties": {


### PR DESCRIPTION
## Why

The GitHub Actions plugin forwards its `oidc` block to `buildkite-gha`, but the CLI currently rejects that configuration. This prevents imported workflows from selecting additional Buildkite claims, AWS session tags, or an exact subject claim.

## What

- Validate the plugin's kebab-case OIDC fields while leaving the Agent API responsible for its claim-name vocabulary.
- Record the settings in every generated job plan and include them in every Agent OIDC mint without granting `id-token: write`.
- Cover configuration rejection, plan carriage, and Agent request bodies, and document the supported plugin shape.