### PR TITLE
Clarify action admission diagnostics and expand runtime proof

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -123,6 +123,11 @@ steps:
               version: "2026.5.12"
         command: "mise run corpus:starter-profile"
 
+      - label: ":pipeline: Load public actions runtime proof"
+        key: "public-actions-ci-loader"
+        if: build.env("DEMO_SUITE") != "plugin" && build.env("SMOKE_PROBE") != "hosted" && build.env("COMPATIBILITY_PROOF") == null
+        command: "buildkite-agent pipeline upload .buildkite/public-actions-proof.yml"
+
       - label: ":github: Exact-source plugin smoke"
         key: "plugin-source-smoke-importer"
         if: build.env("DEMO_SUITE") != "plugin"

--- a/.buildkite/public-actions-proof.yml
+++ b/.buildkite/public-actions-proof.yml
@@ -9,7 +9,7 @@ steps:
           version: "2026.5.12"
     command: |
       set -euo pipefail
-      commit="$${COMPATIBILITY_PROOF_COMMIT:-$${SMOKE_COMMIT:-}}"
+      commit="$${COMPATIBILITY_PROOF_COMMIT:-$${SMOKE_COMMIT:-$${BUILDKITE_COMMIT:-}}}"
       scripts/verify-source-checkout "$$commit"
       test -z "$$(git status --porcelain --untracked-files=all)"
       distribution_root="$$(mktemp -d "$${TMPDIR:-/tmp}/buildkite-gha-public-actions.XXXXXXXX")"

--- a/docs/development.md
+++ b/docs/development.md
@@ -88,7 +88,7 @@ Admission covers generated event snapshots, not arbitrary real payloads or actio
 
 ## Verify runtime behavior
 
-Every normal Buildkite build runs repository checks, Test Engine-split Go tests, native macOS tests, the starter workflow compatibility report, and the shell smoke workflow against the build's exact CLI source. Test Engine records the Linux test results; the repository checks retain the race-enabled suite. GitHub Actions differential oracles run only when manually dispatched.
+Every normal Buildkite build runs repository checks, Test Engine-split Go tests, native macOS tests, the starter workflow compatibility report, and the shell and public-action smoke workflows against the build's exact CLI source. The public-action proof executes pinned checkout, Node, Go, Python, and Java setup actions. Test Engine records the Linux test results; the repository checks retain the race-enabled suite. GitHub Actions differential oracles run only when manually dispatched.
 
 The **Expression differential oracle** records hosted GitHub expression results
 for the conformance fixtures in `internal/expression/conformance_test.go`. Run it

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1444,7 +1444,7 @@ func validateOneSource(out processingOutput, workflowPath string, workflowSource
 		if preflight.HasActions {
 			processingReport.Diagnostics = append(processingReport.Diagnostics, compatibility.Diagnostic{
 				Level: "warning", Code: "W_ACTION_RUNTIME_UNKNOWN", Category: "compatibility", Stage: string(compiler.StageAdmission),
-				Message: "Third-party action runtime behavior was not validated. The action source, metadata, declared runtime, entrypoints, inputs, and nested actions were validated, but the action code was not executed and may depend on GitHub-only services. No action is required for admission; test the action on Buildkite if runtime compatibility is important.",
+				Message: "Action runtime behavior was not evaluated. The action source, metadata, declared runtime, entrypoints, inputs, and nested actions were validated, but the action code was not executed and may depend on GitHub-only services. No action is required for admission; test the action on Buildkite if runtime compatibility is important.",
 			})
 		}
 		if contextRequired {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -3337,10 +3337,10 @@ func TestProcessingAnnotationLeadsWithTheActionableDiagnostic(t *testing.T) {
 			want: `Job "test" requires Docker without matching compiler provenance.`,
 		},
 		{
-			name: "third-party runtime warning",
+			name: "action runtime warning",
 			diagnostic: compatibility.Diagnostic{Level: "warning", Code: "W_ACTION_RUNTIME_UNKNOWN",
-				Message: "Third-party action runtime behavior was not validated."},
-			want: "Third-party action runtime behavior was not validated.",
+				Message: "Action runtime behavior was not evaluated."},
+			want: "Action runtime behavior was not evaluated.",
 		},
 	}
 	for _, test := range tests {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -3012,6 +3012,17 @@ func TestProcessingAnnotationIsBoundedAndEscapesHTML(t *testing.T) {
 	}
 }
 
+func TestProcessingAnnotationOmitsUnknownActionRuntime(t *testing.T) {
+	report := compatibility.NewProcessingReport("ci.yml", "")
+	report.Diagnostics = append(report.Diagnostics, compatibility.Diagnostic{
+		Level: "warning", Code: "W_ACTION_RUNTIME_UNKNOWN", Message: "Action runtime behavior was not evaluated.",
+	})
+	style, body := processingAnnotation(report, sourceLinkContext{})
+	if style != "" || body != "" {
+		t.Fatalf("processingAnnotation() = %q, %q, want no Buildkite annotation", style, body)
+	}
+}
+
 func TestProcessingAnnotationReservesSpaceForTruncationNotice(t *testing.T) {
 	report := compatibility.NewProcessingReport("ci.yml", "")
 	probe := compatibility.Diagnostic{Level: "warning", Code: "W_LARGE", Message: "a"}

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -234,6 +234,9 @@ func processingAnnotationWithin(report compatibility.ProcessingReport, sourceLin
 	style = "warning"
 	diagnostics := make([]compatibility.Diagnostic, 0, len(report.Diagnostics))
 	for _, diagnostic := range report.Diagnostics {
+		if diagnostic.Code == "W_ACTION_RUNTIME_UNKNOWN" {
+			continue
+		}
 		if diagnostic.Level != "warning" && diagnostic.Level != "error" {
 			continue
 		}

--- a/scripts/starter-workflows-corpus
+++ b/scripts/starter-workflows-corpus
@@ -130,8 +130,8 @@ expand_template() {
 record_report() {
   local id=$1 status=$2 output=$3 result codes reason graph icon
   if result="$(jq -er '.result | select(type == "string")' "$output")"; then
-    codes="$(jq -r '[.diagnostics[]?.code] | unique | join(", ")' "$output")"
-    reason="$(jq -r '[.diagnostics[]?.message | split(". ")[0] | gsub("\\s+"; " ")] | unique | if length == 0 then "" elif length == 1 then .[0] else .[0] + " (+" + ((length - 1) | tostring) + " more)" end | if length > 180 then .[:177] + "..." else . end' "$output")"
+    codes="$(jq -r '[.diagnostics[]? | select(.code != "W_ACTION_RUNTIME_UNKNOWN") | .code] | unique | join(", ")' "$output")"
+    reason="$(jq -r '[.diagnostics[]? | select(.code != "W_ACTION_RUNTIME_UNKNOWN") | .message | split(". ")[0] | gsub("\\s+"; " ")] | unique | if length == 0 then "" elif length == 1 then .[0] else .[0] + " (+" + ((length - 1) | tostring) + " more)" end | if length > 180 then .[:177] + "..." else . end' "$output")"
     graph="$(jq -r 'if has("compile") then .compile else . end | "\(.logical_jobs // 0) jobs, \(.instances // 0) instances"' "$output")"
   else
     result=invalid-report
@@ -201,6 +201,9 @@ for id in "${case_ids[@]}"; do
   record_report "$id" "$status" "$report"
 done
 
+if $profile; then
+  printf '\n_Profile admission resolves and validates actions but does not execute action code._\n' >> "$summary"
+fi
 printf '\n**%d passing; %d blocked; %d disabled.**\n' "$passed" "$blocked" "$disabled" >> "$summary"
 cat "$summary"
 if [[ "${BUILDKITE:-}" == true ]] && command -v buildkite-agent >/dev/null; then
@@ -208,8 +211,5 @@ if [[ "${BUILDKITE:-}" == true ]] && command -v buildkite-agent >/dev/null; then
   (( blocked > 0 || disabled > 0 )) && style=warning
   buildkite-agent annotate --context "starter-workflows-corpus-$mode" --style "$style" < "$summary" || \
     echo 'warning: failed to publish Buildkite annotation' >&2
-fi
-if $profile; then
-  echo 'CAVEAT: profile checks resolve actions but do not execute third-party code.'
 fi
 (( blocked == 0 ))

--- a/testdata/public-actions/.github/workflows/public-actions.yml
+++ b/testdata/public-actions/.github/workflows/public-actions.yml
@@ -33,8 +33,23 @@ jobs:
           cache: "false"
           token: ""
 
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.13"
+          token: ""
+
+      - name: Set up Java
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          distribution: temurin
+          java-version: "21"
+          token: ""
+
       - name: Verify portable setup actions
         shell: bash
         run: |
           node --version | grep '^v24\.'
           go version | grep 'go1\.26\.5 '
+          python --version | grep '^Python 3\.13\.'
+          java -version 2>&1 | grep 'version "21\.'


### PR DESCRIPTION
## Why

Hosted admission validates action source and metadata without executing action code, but the repeated third-party runtime warning makes successful starter-workflow validation look like an error. Normal CI also admitted well-known starter workflows without executing the existing public-action runtime proof.

## What

Describe the limitation as unevaluated action runtime behavior and retain it in processing reports without publishing it as a Buildkite warning annotation. Replace repeated starter-workflow warnings with one admission caveat.

Extend the pinned public-actions proof with Python 3.13 through setup-python v7 and Temurin Java 21 through setup-java v5, then run that proof in normal CI against the build's exact CLI source.