### PR TITLE
Consolidate action source lock mechanics

### DIFF
--- a/internal/action/source/action_cache_lock.go
+++ b/internal/action/source/action_cache_lock.go
@@ -1,0 +1,33 @@
+package source
+
+import (
+	"errors"
+	"sync"
+)
+
+type actionCacheLockMode int
+
+const (
+	actionCacheLockShared actionCacheLockMode = iota
+	actionCacheLockExclusive
+)
+
+var errActionCacheLockUnavailable = errors.New("action cache lock is held")
+
+type actionCacheLock struct {
+	file    *lockFile
+	release func()
+	once    sync.Once
+}
+
+func (l *actionCacheLock) unlock() {
+	if l == nil {
+		return
+	}
+	l.once.Do(func() {
+		l.file.unlock()
+		if l.release != nil {
+			l.release()
+		}
+	})
+}

--- a/internal/action/source/action_cache_lock_other.go
+++ b/internal/action/source/action_cache_lock_other.go
@@ -4,29 +4,13 @@ package source
 
 import (
 	"context"
-	"errors"
-	"os"
 	"sync"
 )
 
-type actionCacheLockMode int
-
-const (
-	actionCacheLockShared actionCacheLockMode = iota
-	actionCacheLockExclusive
-)
-
 var (
-	errActionCacheLockUnavailable = errors.New("action cache lock is held")
-	actionCacheLocksMu            sync.Mutex
-	actionCacheLocks              = map[string]*sync.RWMutex{}
+	actionCacheLocksMu sync.Mutex
+	actionCacheLocks   = map[string]*sync.RWMutex{}
 )
-
-type actionCacheLock struct {
-	mu        *sync.RWMutex
-	exclusive bool
-	file      *os.File
-}
 
 func lockActionCache(ctx context.Context, path string, mode actionCacheLockMode, nonblocking bool) (*actionCacheLock, error) {
 	if err := ctx.Err(); err != nil {
@@ -54,7 +38,7 @@ func lockActionCache(ctx context.Context, path string, mode actionCacheLockMode,
 	} else {
 		mu.RLock()
 	}
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	file, err := openLockFile(path)
 	if err != nil {
 		if mode == actionCacheLockExclusive {
 			mu.Unlock()
@@ -63,18 +47,9 @@ func lockActionCache(ctx context.Context, path string, mode actionCacheLockMode,
 		}
 		return nil, err
 	}
-	return &actionCacheLock{mu: mu, exclusive: mode == actionCacheLockExclusive, file: file}, nil
-}
-
-func (l *actionCacheLock) unlock() {
-	if l == nil || l.file == nil {
-		return
+	release := mu.RUnlock
+	if mode == actionCacheLockExclusive {
+		release = mu.Unlock
 	}
-	_ = l.file.Close()
-	l.file = nil
-	if l.exclusive {
-		l.mu.Unlock()
-	} else {
-		l.mu.RUnlock()
-	}
+	return &actionCacheLock{file: file, release: release}, nil
 }

--- a/internal/action/source/action_cache_lock_unix.go
+++ b/internal/action/source/action_cache_lock_unix.go
@@ -4,60 +4,23 @@ package source
 
 import (
 	"context"
-	"errors"
-	"os"
 	"time"
 
 	"golang.org/x/sys/unix"
 )
 
-type actionCacheLockMode int
-
-const (
-	actionCacheLockShared actionCacheLockMode = iota
-	actionCacheLockExclusive
-)
-
-var errActionCacheLockUnavailable = errors.New("action cache lock is held")
-
-type actionCacheLock struct{ file *os.File }
-
 func lockActionCache(ctx context.Context, path string, mode actionCacheLockMode, nonblocking bool) (*actionCacheLock, error) {
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
-	if err != nil {
-		return nil, err
-	}
 	operation := unix.LOCK_SH
 	if mode == actionCacheLockExclusive {
 		operation = unix.LOCK_EX
 	}
-	for {
-		err = unix.Flock(int(file.Fd()), operation|unix.LOCK_NB)
-		if err == nil {
-			return &actionCacheLock{file: file}, nil
-		}
-		if !errors.Is(err, unix.EWOULDBLOCK) && !errors.Is(err, unix.EAGAIN) {
-			_ = file.Close()
-			return nil, err
-		}
-		if nonblocking {
-			_ = file.Close()
-			return nil, errActionCacheLockUnavailable
-		}
-		select {
-		case <-ctx.Done():
-			_ = file.Close()
-			return nil, ctx.Err()
-		case <-time.After(10 * time.Millisecond):
-		}
+	var unavailable error
+	if nonblocking {
+		unavailable = errActionCacheLockUnavailable
 	}
-}
-
-func (l *actionCacheLock) unlock() {
-	if l == nil || l.file == nil {
-		return
+	file, err := flockLockFile(ctx, path, operation, 10*time.Millisecond, unavailable)
+	if err != nil {
+		return nil, err
 	}
-	_ = unix.Flock(int(l.file.Fd()), unix.LOCK_UN)
-	_ = l.file.Close()
-	l.file = nil
+	return &actionCacheLock{file: file}, nil
 }

--- a/internal/action/source/file_lock.go
+++ b/internal/action/source/file_lock.go
@@ -1,0 +1,33 @@
+package source
+
+import (
+	"os"
+	"sync"
+)
+
+type lockFile struct {
+	file    *os.File
+	release func(*os.File)
+	once    sync.Once
+}
+
+func openLockFile(path string) (*lockFile, error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	return &lockFile{file: file}, nil
+}
+
+func (l *lockFile) unlock() {
+	if l == nil {
+		return
+	}
+	l.once.Do(func() {
+		if l.release != nil {
+			l.release(l.file)
+		}
+		_ = l.file.Close()
+		l.file = nil
+	})
+}

--- a/internal/action/source/file_lock_test.go
+++ b/internal/action/source/file_lock_test.go
@@ -1,0 +1,67 @@
+package source
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestLockFileUnlockIsIdempotent(t *testing.T) {
+	lock, err := openLockFile(filepath.Join(t.TempDir(), ".lock"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var releases atomic.Int32
+	lock.release = func(*os.File) { releases.Add(1) }
+	var callers sync.WaitGroup
+	for range 8 {
+		callers.Add(1)
+		go func() {
+			defer callers.Done()
+			lock.unlock()
+		}()
+	}
+	callers.Wait()
+	if releases.Load() != 1 {
+		t.Fatalf("lock release calls = %d, want 1", releases.Load())
+	}
+	if lock.file != nil {
+		t.Fatal("lock file remains owned after unlock")
+	}
+	lock.unlock()
+}
+
+func TestActionCacheLockSharedExclusiveNonblocking(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".lock")
+	first, err := lockActionCache(context.Background(), path, actionCacheLockShared, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := lockActionCache(context.Background(), path, actionCacheLockShared, true)
+	if err != nil {
+		first.unlock()
+		t.Fatal(err)
+	}
+	if _, err := lockActionCache(context.Background(), path, actionCacheLockExclusive, true); err != errActionCacheLockUnavailable {
+		first.unlock()
+		second.unlock()
+		t.Fatalf("exclusive lock error = %v, want %v", err, errActionCacheLockUnavailable)
+	}
+	first.unlock()
+	first.unlock()
+	if _, err := lockActionCache(context.Background(), path, actionCacheLockExclusive, true); err != errActionCacheLockUnavailable {
+		second.unlock()
+		t.Fatalf("exclusive lock with one shared holder error = %v, want %v", err, errActionCacheLockUnavailable)
+	}
+	second.unlock()
+	second.unlock()
+	exclusive, err := lockActionCache(context.Background(), path, actionCacheLockExclusive, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	exclusive.unlock()
+	exclusive.unlock()
+}

--- a/internal/action/source/file_lock_unix.go
+++ b/internal/action/source/file_lock_unix.go
@@ -1,0 +1,42 @@
+//go:build unix
+
+package source
+
+import (
+	"context"
+	"errors"
+	"os"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func flockLockFile(ctx context.Context, path string, operation int, pollInterval time.Duration, unavailable error) (*lockFile, error) {
+	lock, err := openLockFile(path)
+	if err != nil {
+		return nil, err
+	}
+	for {
+		err = unix.Flock(int(lock.file.Fd()), operation|unix.LOCK_NB)
+		if err == nil {
+			lock.release = func(file *os.File) {
+				_ = unix.Flock(int(file.Fd()), unix.LOCK_UN)
+			}
+			return lock, nil
+		}
+		if !errors.Is(err, unix.EWOULDBLOCK) && !errors.Is(err, unix.EAGAIN) {
+			lock.unlock()
+			return nil, err
+		}
+		if unavailable != nil {
+			lock.unlock()
+			return nil, unavailable
+		}
+		select {
+		case <-ctx.Done():
+			lock.unlock()
+			return nil, ctx.Err()
+		case <-time.After(pollInterval):
+		}
+	}
+}

--- a/internal/action/source/file_lock_unix_test.go
+++ b/internal/action/source/file_lock_unix_test.go
@@ -1,0 +1,30 @@
+//go:build unix
+
+package source
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func TestActionCacheLockCancellationWhileHeld(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".lock")
+	holder, err := lockActionCache(context.Background(), path, actionCacheLockExclusive, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := lockActionCache(ctx, path, actionCacheLockShared, false); !errors.Is(err, context.Canceled) {
+		holder.unlock()
+		t.Fatalf("waiting lock error = %v, want %v", err, context.Canceled)
+	}
+	holder.unlock()
+	reacquired, err := lockActionCache(context.Background(), path, actionCacheLockExclusive, true)
+	if err != nil {
+		t.Fatalf("reacquire lock: %v", err)
+	}
+	reacquired.unlock()
+}

--- a/internal/action/source/mutable_ref_lock_other.go
+++ b/internal/action/source/mutable_ref_lock_other.go
@@ -4,16 +4,15 @@ package source
 
 import (
 	"context"
-	"os"
 )
 
 func lockMutableRefCache(ctx context.Context, path string) (func(), error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	lock, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	lock, err := openLockFile(path)
 	if err != nil {
 		return nil, err
 	}
-	return func() { _ = lock.Close() }, nil
+	return lock.unlock, nil
 }

--- a/internal/action/source/mutable_ref_lock_unix.go
+++ b/internal/action/source/mutable_ref_lock_unix.go
@@ -4,35 +4,15 @@ package source
 
 import (
 	"context"
-	"errors"
-	"os"
 	"time"
 
 	"golang.org/x/sys/unix"
 )
 
 func lockMutableRefCache(ctx context.Context, path string) (func(), error) {
-	lock, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	lock, err := flockLockFile(ctx, path, unix.LOCK_EX, 25*time.Millisecond, nil)
 	if err != nil {
 		return nil, err
 	}
-	for {
-		err = unix.Flock(int(lock.Fd()), unix.LOCK_EX|unix.LOCK_NB)
-		if err == nil {
-			return func() {
-				_ = unix.Flock(int(lock.Fd()), unix.LOCK_UN)
-				_ = lock.Close()
-			}, nil
-		}
-		if !errors.Is(err, unix.EWOULDBLOCK) {
-			_ = lock.Close()
-			return nil, err
-		}
-		select {
-		case <-ctx.Done():
-			_ = lock.Close()
-			return nil, ctx.Err()
-		case <-time.After(25 * time.Millisecond):
-		}
-	}
+	return lock.unlock, nil
 }

--- a/internal/action/source/mutable_ref_lock_unix_test.go
+++ b/internal/action/source/mutable_ref_lock_unix_test.go
@@ -1,0 +1,31 @@
+//go:build linux || darwin
+
+package source
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func TestMutableRefLockCancellationWhileHeld(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".lock")
+	unlock, err := lockMutableRefCache(context.Background(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := lockMutableRefCache(ctx, path); !errors.Is(err, context.Canceled) {
+		unlock()
+		t.Fatalf("waiting lock error = %v, want %v", err, context.Canceled)
+	}
+	unlock()
+	unlock()
+	release, err := lockMutableRefCache(context.Background(), path)
+	if err != nil {
+		t.Fatalf("reacquire lock: %v", err)
+	}
+	release()
+}


### PR DESCRIPTION
## Why

Action-cache locks and mutable-reference and snapshot locks duplicate lock-file opening, flock polling, cancellation, and cleanup even though their policies and platform coverage differ. Keeping those mechanics separate makes behavior-preserving maintenance harder and creates room for the implementations to drift.

## What

Extract private lock-file ownership and Unix flock polling while retaining policy-specific wrappers:

| Platform | Action cache | Mutable references and snapshots |
| --- | --- | --- |
| Linux, Darwin | Shared/exclusive flock | Exclusive flock |
| FreeBSD | Shared/exclusive flock | Open file only; no exclusion |
| Windows | Process-local shared/exclusive `sync.RWMutex` | Open file only; no exclusion |

Preserve `0600` lock files, 10 ms action-cache and 25 ms mutable-reference polling, cancellation and error identities, nonblocking eviction semantics, lease lifetime, and close-once idempotent cleanup. Focused source and race tests, four-platform test-binary cross-compilation, and the full repository check pass; an Oracle review traced the build tags, policy paths, lock lifetime, polling, and cleanup without finding a behavior regression.
