### PR TITLE
Split job and service container plan models

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -7180,9 +7180,9 @@ func TestUnprivilegedUploadAdmitsCompilerVerifiedContainerProvenance(t *testing.
 		sources []string
 	}{
 		{name: "job", job: plan.Job{Container: &plan.Container{Image: "node:24"}}, sources: []string{"job-containers"}},
-		{name: "service", job: plan.Job{Services: map[string]plan.Container{"redis": {Image: "redis:7"}}}, sources: []string{"service-containers"}},
+		{name: "service", job: plan.Job{Services: map[string]plan.ServiceContainer{"redis": {Image: "redis:7"}}}, sources: []string{"service-containers"}},
 		{name: "dynamic services", job: plan.Job{ServicesExpression: "${{ fromJSON(needs.build.outputs.services) }}"}, sources: []string{"service-containers"}},
-		{name: "all", job: plan.Job{Container: &plan.Container{Image: "node:24"}, Services: map[string]plan.Container{"redis": {Image: "redis:7"}}}, sources: []string{"dockerfile-actions", "job-containers", "service-containers"}},
+		{name: "all", job: plan.Job{Container: &plan.Container{Image: "node:24"}, Services: map[string]plan.ServiceContainer{"redis": {Image: "redis:7"}}}, sources: []string{"dockerfile-actions", "job-containers", "service-containers"}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: plan.Job{

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -616,11 +616,11 @@ instances:
 				job.Container = &plan.Container{Image: instance.Container.Image, Env: cloneMap(instance.Container.Env), Ports: append([]string(nil), instance.Container.Ports...)}
 			}
 			if len(instance.Services) != 0 {
-				job.Services = make(map[string]plan.Container, len(instance.Services))
+				job.Services = make(map[string]plan.ServiceContainer, len(instance.Services))
 				job.ServiceOrder = make([]string, 0, len(instance.Services))
 			}
 			for _, service := range instance.Services {
-				container := plan.Container{
+				container := plan.ServiceContainer{
 					Image: service.Container.Image, Env: cloneMap(service.Container.Env), Ports: append([]string(nil), service.Container.Ports...),
 					Volumes: append([]string(nil), service.Container.Volumes...), Options: service.Container.Options,
 					Command: service.Container.Command, Entrypoint: service.Container.Entrypoint,

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -229,6 +229,17 @@ type Step struct {
 }
 
 type Container struct {
+	Image string            `json:"image"`
+	Env   map[string]string `json:"env,omitempty"`
+	Ports []string          `json:"ports,omitempty"`
+}
+
+type ContainerCredentials struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+type ServiceContainer struct {
 	Image       string                `json:"image"`
 	Credentials *ContainerCredentials `json:"credentials,omitempty"`
 	Env         map[string]string     `json:"env,omitempty"`
@@ -238,13 +249,6 @@ type Container struct {
 	Command     string                `json:"command,omitempty"`
 	Entrypoint  string                `json:"entrypoint,omitempty"`
 }
-
-type ContainerCredentials struct {
-	Username string `json:"username"`
-	Password string `json:"password"`
-}
-
-type ServiceContainer = Container
 
 // GitHubToken describes one synthetic secrets.GITHUB_TOKEN value. Workflow is
 // the top-level policy filename. Permissions are API-normalized and
@@ -294,11 +298,11 @@ type Job struct {
 	Steps                   []Step            `json:"steps"`
 	Actions                 []ActionLock      `json:"actions,omitempty"`
 	// RequiresMise is the compiler's explicit action-runtime decision.
-	RequiresMise       *bool                `json:"requires_mise,omitempty"`
-	Container          *Container           `json:"container,omitempty"`
-	Services           map[string]Container `json:"services,omitempty"`
-	ServiceOrder       []string             `json:"service_order,omitempty"`
-	ServicesExpression string               `json:"services_expression,omitempty"`
+	RequiresMise       *bool                       `json:"requires_mise,omitempty"`
+	Container          *Container                  `json:"container,omitempty"`
+	Services           map[string]ServiceContainer `json:"services,omitempty"`
+	ServiceOrder       []string                    `json:"service_order,omitempty"`
+	ServicesExpression string                      `json:"services_expression,omitempty"`
 }
 
 // NeedsMise reports whether a generated job needs the managed action runtime.
@@ -537,9 +541,6 @@ func (job Job) Validate() error {
 			return fmt.Errorf("job containers and services require network capability")
 		}
 		if job.Container != nil {
-			if job.Container.Credentials != nil || len(job.Container.Volumes) != 0 || job.Container.Options != "" || job.Container.Command != "" || job.Container.Entrypoint != "" {
-				return fmt.Errorf("job container contains service-only fields")
-			}
 			if err := validateContainer(job.Container.Image, job.Container.Env, job.Container.Ports); err != nil {
 				return fmt.Errorf("job container: %w", err)
 			}

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strings"
 	"testing"
@@ -742,26 +743,63 @@ func TestContainerContract(t *testing.T) {
 	job := validJob()
 	job.RequiredCapabilities = []string{"docker", "network"}
 	job.Container = &Container{Image: "node:24", Env: map[string]string{"NODE_ENV": "test"}, Ports: []string{"8080"}}
-	job.Services = map[string]Container{"redis": {Image: "redis:7", Ports: []string{"6379:6379"}}}
-	job.ServiceOrder = []string{"redis"}
+	job.Services = map[string]ServiceContainer{"database": {
+		Image:       "postgres:16",
+		Credentials: &ContainerCredentials{Username: "user", Password: "password"},
+		Env:         map[string]string{"POSTGRES_DB": "app"},
+		Ports:       []string{"5432:5432"},
+		Volumes:     []string{"database:/data"},
+		Options:     "--health-retries 5",
+		Command:     "postgres -c fsync=off",
+		Entrypoint:  "docker-entrypoint.sh",
+	}}
+	job.ServiceOrder = []string{"database"}
 	job.Steps = []Step{{ID: "local", Kind: "uses", Uses: "./actions/build", Action: &ActionSelector{Lock: "a-0000000000000001"}}}
 	job.Actions = []ActionLock{{ID: "a-0000000000000001", Source: "workspace", Path: "actions/build", SourceDigest: "sha256:" + strings.Repeat("a", 64)}}
 	encoded, err := Encode(job)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := Decode(encoded); err != nil {
+	decoded, err := Decode(encoded)
+	if err != nil {
 		t.Fatal(err)
 	}
+	if !reflect.DeepEqual(decoded.Container, job.Container) || !reflect.DeepEqual(decoded.Services, job.Services) {
+		t.Fatalf("decoded containers = %#v, %#v", decoded.Container, decoded.Services)
+	}
 	validateJobPlanSchema(t, encoded)
+	wire, err := json.Marshal(struct {
+		Container *Container                  `json:"container"`
+		Services  map[string]ServiceContainer `json:"services"`
+	}{Container: job.Container, Services: job.Services})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `{"container":{"image":"node:24","env":{"NODE_ENV":"test"},"ports":["8080"]},"services":{"database":{"image":"postgres:16","credentials":{"username":"user","password":"password"},"env":{"POSTGRES_DB":"app"},"ports":["5432:5432"],"volumes":["database:/data"],"options":"--health-retries 5","command":"postgres -c fsync=off","entrypoint":"docker-entrypoint.sh"}}}`
+	if string(wire) != want {
+		t.Fatalf("encoded containers = %s, want %s", wire, want)
+	}
 }
 
-func TestJobContainerRejectsServiceCredentials(t *testing.T) {
-	job := validJob()
-	job.RequiredCapabilities = []string{"docker", "network"}
-	job.Container = &Container{Image: "node:24", Credentials: &ContainerCredentials{Username: "user", Password: "password"}}
-	if err := job.Validate(); err == nil || !strings.Contains(err.Error(), "service-only fields") {
-		t.Fatalf("Validate() error = %v, want service-only fields", err)
+func TestContainerModelFields(t *testing.T) {
+	tests := []struct {
+		name   string
+		typeOf reflect.Type
+		fields []string
+	}{
+		{name: "job", typeOf: reflect.TypeFor[Container](), fields: []string{"Image:image", "Env:env,omitempty", "Ports:ports,omitempty"}},
+		{name: "service", typeOf: reflect.TypeFor[ServiceContainer](), fields: []string{"Image:image", "Credentials:credentials,omitempty", "Env:env,omitempty", "Ports:ports,omitempty", "Volumes:volumes,omitempty", "Options:options,omitempty", "Command:command,omitempty", "Entrypoint:entrypoint,omitempty"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var got []string
+			for field := range test.typeOf.Fields() {
+				got = append(got, field.Name+":"+string(field.Tag.Get("json")))
+			}
+			if !slices.Equal(got, test.fields) {
+				t.Fatalf("fields = %#v, want %#v", got, test.fields)
+			}
+		})
 	}
 }
 

--- a/internal/runtime/containers.go
+++ b/internal/runtime/containers.go
@@ -79,13 +79,15 @@ func privateDocker(r Runner) (string, string, map[string]string, error) {
 	return docker, config, map[string]string{"DOCKER_CONFIG": config}, nil
 }
 
-func (r Runner) startJobContainer(ctx context.Context, processor *commandProcessor, workspace, temp string, spec plan.Container, services map[string]plan.Container, extra ...containerMount) (_ *jobContainerBackend, err error) {
+func (r Runner) startJobContainer(ctx context.Context, processor *commandProcessor, workspace, temp string, spec *plan.Container, services map[string]plan.ServiceContainer, extra ...containerMount) (_ *jobContainerBackend, err error) {
 	return r.startJobContainerOrdered(ctx, processor, workspace, temp, spec, services, sortedKeys(services), extra...)
 }
 
-func (r Runner) startJobContainerOrdered(ctx context.Context, processor *commandProcessor, workspace, temp string, spec plan.Container, services map[string]plan.Container, serviceOrder []string, extra ...containerMount) (_ *jobContainerBackend, err error) {
-	if err := validateEnvironmentNames(spec.Env); err != nil {
-		return nil, fmt.Errorf("job container environment: %w", err)
+func (r Runner) startJobContainerOrdered(ctx context.Context, processor *commandProcessor, workspace, temp string, spec *plan.Container, services map[string]plan.ServiceContainer, serviceOrder []string, extra ...containerMount) (_ *jobContainerBackend, err error) {
+	if spec != nil {
+		if err := validateEnvironmentNames(spec.Env); err != nil {
+			return nil, fmt.Errorf("job container environment: %w", err)
+		}
 	}
 	for serviceID, service := range services {
 		if err := validateEnvironmentNames(service.Env); err != nil {
@@ -103,7 +105,7 @@ func (r Runner) startJobContainerOrdered(ctx context.Context, processor *command
 	}
 	id := hex.EncodeToString(nonce[:])
 	b := &jobContainerBackend{runner: r, processor: processor, docker: docker, env: env, config: config, owner: "com.buildkite.gha.owner." + id + "=true", network: "buildkite-gha-network-" + id, workspace: workspace, temp: temp, servicePorts: make(map[string]expression.ServiceContext)}
-	if spec.Image != "" {
+	if spec != nil {
 		b.container = "buildkite-gha-job-" + id
 	}
 	b.mounts = []containerMount{{host: workspace, target: jobContainerWorkspace}, {host: temp, target: jobContainerTemp}}
@@ -147,7 +149,7 @@ func (r Runner) startJobContainerOrdered(ctx context.Context, processor *command
 		return nil, err
 	}
 	var runtimeExecutable string
-	if spec.Image != "" {
+	if spec != nil {
 		runtimeExecutable = r.RuntimeExecutable
 		if runtimeExecutable == "" {
 			runtimeExecutable, err = os.Executable()
@@ -171,7 +173,7 @@ func (r Runner) startJobContainerOrdered(ctx context.Context, processor *command
 		}
 		b.existingVolumes = lineSet(volumes)
 	}
-	if spec.Image != "" {
+	if spec != nil {
 		if err = r.pullContainerImage(ctx, processor, env, docker, spec.Image); err != nil {
 			return nil, fmt.Errorf("pull job container image: %w", err)
 		}
@@ -294,7 +296,7 @@ func (r Runner) startJobContainerOrdered(ctx context.Context, processor *command
 		}
 		service.ready = true
 	}
-	if spec.Image != "" {
+	if spec != nil {
 		args := []string{"create", "--name", b.container, "--label", "com.buildkite.gha=true", "--label", b.owner, "--network", b.network,
 			"--mount", "type=bind,source=" + workspace + ",target=" + jobContainerWorkspace,
 			"--mount", "type=bind,source=" + temp + ",target=" + jobContainerTemp,

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -694,7 +694,7 @@ func TestRunJobContainerServicesLifecycleAndArguments(t *testing.T) {
 	w := t.TempDir()
 	j := jobContainerPlan(t, w, nil)
 	j.Container.Ports = []string{"8080", "5432:5432", "9000:90/udp"}
-	j.Services = map[string]plan.Container{
+	j.Services = map[string]plan.ServiceContainer{
 		"z-cache": {Image: "redis:7", Env: map[string]string{"Z": "last", "A": "first"}, Ports: j.Container.Ports},
 		"a-db":    {Image: "postgres:16", Env: map[string]string{"B": "two"}},
 	}
@@ -766,7 +766,7 @@ func TestRunJobContainerServicesLifecycleAndArguments(t *testing.T) {
 
 func TestRunServiceContainerAutoRemoveCleanup(t *testing.T) {
 	f := newJobDocker(t, "service-auto-remove")
-	b, err := (Runner{Docker: f.path}).startJobContainer(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), plan.Container{}, map[string]plan.Container{"database": {Image: "postgres:16", Options: "--rm"}})
+	b, err := (Runner{Docker: f.path}).startJobContainer(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Options: "--rm"}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -792,7 +792,7 @@ func TestRunServiceContainerAutoRemoveCleanup(t *testing.T) {
 
 func TestRunServiceContainerAlreadyAutoRemovedCleanup(t *testing.T) {
 	f := newJobDocker(t, "")
-	b, err := (Runner{Docker: f.path}).startJobContainer(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), plan.Container{}, map[string]plan.Container{"database": {Image: "postgres:16", Options: "--rm"}})
+	b, err := (Runner{Docker: f.path}).startJobContainer(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Options: "--rm"}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -813,7 +813,7 @@ func TestRunServiceContainerAlreadyAutoRemovedCleanup(t *testing.T) {
 
 func TestRunServiceContainerAutoRemoveBetweenQueryAndStop(t *testing.T) {
 	f := newJobDocker(t, "service-auto-remove-before-stop")
-	b, err := (Runner{Docker: f.path}).startJobContainer(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), plan.Container{}, map[string]plan.Container{"database": {Image: "postgres:16", Options: "--rm"}})
+	b, err := (Runner{Docker: f.path}).startJobContainer(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Options: "--rm"}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -870,13 +870,13 @@ func TestServiceOptionsRejectOnlyNetworkOverride(t *testing.T) {
 func TestRunServiceContainerCompleteArguments(t *testing.T) {
 	f := newJobDocker(t, "")
 	w, tmp := t.TempDir(), t.TempDir()
-	service := plan.Container{
+	service := plan.ServiceContainer{
 		Image: "postgres:16", Env: map[string]string{"POSTGRES_PASSWORD": "test"}, Ports: []string{"5432"},
 		Volumes: []string{"database:/var/lib/postgresql/data:ro"},
 		Options: `--health-cmd "pg_isready -U postgres" --health-retries 5`,
 		Command: `postgres -c "fsync = off"`, Entrypoint: "docker-entrypoint.sh",
 	}
-	b, err := (Runner{Docker: f.path}).startJobContainer(context.Background(), newCommandProcessor(os.Stdout, os.Stderr), w, tmp, plan.Container{}, map[string]plan.Container{"database": service})
+	b, err := (Runner{Docker: f.path}).startJobContainer(context.Background(), newCommandProcessor(os.Stdout, os.Stderr), w, tmp, nil, map[string]plan.ServiceContainer{"database": service})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -906,8 +906,8 @@ func TestRunServiceContainersUseDeclaredOrderAndEmitSuccessfulLogs(t *testing.T)
 	var output bytes.Buffer
 	processor := newCommandProcessor(&output, &output)
 	b, err := (Runner{Docker: f.path}).startJobContainerOrdered(
-		context.Background(), processor, t.TempDir(), t.TempDir(), plan.Container{},
-		map[string]plan.Container{"alpha": {Image: "one"}, "zed": {Image: "two"}}, []string{"zed", "alpha"},
+		context.Background(), processor, t.TempDir(), t.TempDir(), nil,
+		map[string]plan.ServiceContainer{"alpha": {Image: "one"}, "zed": {Image: "two"}}, []string{"zed", "alpha"},
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -937,8 +937,8 @@ func TestRunServiceContainersUseDeclaredOrderAndEmitSuccessfulLogs(t *testing.T)
 
 func TestRunServiceContainerRegistryCredentialsUsePasswordStdin(t *testing.T) {
 	f := newJobDocker(t, "fail-login-once")
-	service := plan.Container{Image: "registry.example.test/team/postgres:16", Credentials: &plan.ContainerCredentials{Username: "registry-user", Password: "registry-password"}}
-	b, err := (Runner{Docker: f.path}).startJobContainer(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), plan.Container{}, map[string]plan.Container{"database": service})
+	service := plan.ServiceContainer{Image: "registry.example.test/team/postgres:16", Credentials: &plan.ContainerCredentials{Username: "registry-user", Password: "registry-password"}}
+	b, err := (Runner{Docker: f.path}).startJobContainer(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": service})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -996,11 +996,11 @@ func TestDockerRegistryMatchesRunnerInference(t *testing.T) {
 func TestRunServiceContainerPullsSameImagePerCredentialIdentity(t *testing.T) {
 	f := newJobDocker(t, "")
 	image := "registry.example/team/postgres:16"
-	services := map[string]plan.Container{
+	services := map[string]plan.ServiceContainer{
 		"a": {Image: image, Credentials: &plan.ContainerCredentials{Username: "user-a", Password: "password-a"}},
 		"b": {Image: image, Credentials: &plan.ContainerCredentials{Username: "user-b", Password: "password-b"}},
 	}
-	b, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).startJobContainer(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), plan.Container{Image: image}, services)
+	b, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).startJobContainer(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), &plan.Container{Image: image}, services)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1025,7 +1025,7 @@ func TestRunServiceContainerPullsSameImagePerCredentialIdentity(t *testing.T) {
 func TestRunServiceContainerPartialRegistryCredentialsDoNotLogin(t *testing.T) {
 	for _, credentials := range []*plan.ContainerCredentials{{Username: "registry-user"}, {Password: "registry-password"}} {
 		f := newJobDocker(t, "")
-		b, err := (Runner{Docker: f.path}).startJobContainer(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), plan.Container{}, map[string]plan.Container{"database": {Image: "registry.example.test/postgres:16", Credentials: credentials}})
+		b, err := (Runner{Docker: f.path}).startJobContainer(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "registry.example.test/postgres:16", Credentials: credentials}})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1049,7 +1049,7 @@ func TestRemoveDockerConfigReportsCleanupFailure(t *testing.T) {
 }
 
 func TestEvaluateServicesResolvesNeedsAndSkipsEmptyImages(t *testing.T) {
-	services := map[string]plan.Container{
+	services := map[string]plan.ServiceContainer{
 		"database": {
 			Image:      "postgres:${{ needs.build.outputs.version }}",
 			Env:        map[string]string{"SOURCE": "${{ needs.build.outputs.source }}"},
@@ -1115,7 +1115,7 @@ func TestEvaluateServiceMapExpressionRejectsUnsafeShapes(t *testing.T) {
 }
 
 func TestEvaluateServicesDoesNotHideErrorsBehindEmptyImage(t *testing.T) {
-	_, err := evaluateServices(map[string]plan.Container{"optional": {Image: "${{ needs.build.outputs.image }}", Env: map[string]string{"VALUE": "${{ needs.build.outputs.value"}}}, expression.Context{Needs: map[string]expression.NeedStatus{"build": {Outputs: map[string]string{"image": ""}}}})
+	_, err := evaluateServices(map[string]plan.ServiceContainer{"optional": {Image: "${{ needs.build.outputs.image }}", Env: map[string]string{"VALUE": "${{ needs.build.outputs.value"}}}, expression.Context{Needs: map[string]expression.NeedStatus{"build": {Outputs: map[string]string{"image": ""}}}})
 	if err == nil || !strings.Contains(err.Error(), "unterminated") {
 		t.Fatalf("error = %v, want unterminated expression error", err)
 	}
@@ -1136,7 +1136,7 @@ func TestRunServiceContainerRemovesOnlyNewNamedVolumes(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			b, err := (Runner{Docker: f.path}).startJobContainer(context.Background(), newCommandProcessor(os.Stdout, os.Stderr), t.TempDir(), t.TempDir(), plan.Container{}, map[string]plan.Container{"database": {Image: "postgres:16", Volumes: []string{test.volume}}})
+			b, err := (Runner{Docker: f.path}).startJobContainer(context.Background(), newCommandProcessor(os.Stdout, os.Stderr), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Volumes: []string{test.volume}}})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1156,7 +1156,7 @@ func TestRunServiceContainerRemovesOnlyNewNamedVolumes(t *testing.T) {
 
 func TestRunServiceContainerReportsLeftoverNamedVolume(t *testing.T) {
 	f := newJobDocker(t, "volume-leftover")
-	b, err := (Runner{Docker: f.path}).startJobContainer(context.Background(), newCommandProcessor(os.Stdout, os.Stderr), t.TempDir(), t.TempDir(), plan.Container{}, map[string]plan.Container{"database": {Image: "postgres:16", Volumes: []string{"database:/data"}}})
+	b, err := (Runner{Docker: f.path}).startJobContainer(context.Background(), newCommandProcessor(os.Stdout, os.Stderr), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Volumes: []string{"database:/data"}}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1167,7 +1167,7 @@ func TestRunServiceContainerReportsLeftoverNamedVolume(t *testing.T) {
 
 func TestRunServiceContainerReadsBroadDockerPortOutput(t *testing.T) {
 	f := newJobDocker(t, "broad-port")
-	b, err := (Runner{Docker: f.path}).startJobContainer(context.Background(), newCommandProcessor(os.Stdout, os.Stderr), t.TempDir(), t.TempDir(), plan.Container{}, map[string]plan.Container{"database": {Image: "postgres:16", Ports: []string{"8000-8001:80-81"}, Options: "--publish 8002:82/sctp"}})
+	b, err := (Runner{Docker: f.path}).startJobContainer(context.Background(), newCommandProcessor(os.Stdout, os.Stderr), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Ports: []string{"8000-8001:80-81"}, Options: "--publish 8002:82/sctp"}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1180,7 +1180,7 @@ func TestRunServiceContainerReadsBroadDockerPortOutput(t *testing.T) {
 
 func TestRunServiceContainerOptionNameUsesCreatedReference(t *testing.T) {
 	f := newJobDocker(t, "")
-	b, err := (Runner{Docker: f.path}).startJobContainer(context.Background(), newCommandProcessor(os.Stdout, os.Stderr), t.TempDir(), t.TempDir(), plan.Container{}, map[string]plan.Container{"database": {Image: "postgres:16", Options: "--name custom-service"}})
+	b, err := (Runner{Docker: f.path}).startJobContainer(context.Background(), newCommandProcessor(os.Stdout, os.Stderr), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Options: "--name custom-service"}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1199,7 +1199,7 @@ func TestRunJobContainerServiceFailureDiagnosticsAreMasked(t *testing.T) {
 	var output bytes.Buffer
 	p := newCommandProcessor(&output, &output)
 	p.addMask("sibling-secret")
-	_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).startJobContainer(context.Background(), p, w, tmp, plan.Container{Image: "alpine"}, map[string]plan.Container{"db": {Image: "postgres"}})
+	_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).startJobContainer(context.Background(), p, w, tmp, &plan.Container{Image: "alpine"}, map[string]plan.ServiceContainer{"db": {Image: "postgres"}})
 	if err == nil || !strings.Contains(err.Error(), `service "db"`) || !strings.Contains(err.Error(), `status "unhealthy"`) {
 		t.Fatalf("error=%v", err)
 	}
@@ -1212,7 +1212,7 @@ func TestRunJobContinueOnErrorToleratesServiceStartupFailure(t *testing.T) {
 	f := newJobDocker(t, "service-unhealthy")
 	w := t.TempDir()
 	job := jobContainerPlan(t, w, nil)
-	job.Services = map[string]plan.Container{"db": {Image: "postgres"}}
+	job.Services = map[string]plan.ServiceContainer{"db": {Image: "postgres"}}
 	job.ServiceOrder = []string{"db"}
 	job.ContinueOnError = true
 
@@ -1226,7 +1226,7 @@ func TestRunJobContinueOnErrorDoesNotTolerateServiceStartupTimeout(t *testing.T)
 	f := newJobDocker(t, "service-starting")
 	w := t.TempDir()
 	job := jobContainerPlan(t, w, nil)
-	job.Services = map[string]plan.Container{"db": {Image: "postgres"}}
+	job.Services = map[string]plan.ServiceContainer{"db": {Image: "postgres"}}
 	job.ServiceOrder = []string{"db"}
 	job.ContinueOnError = true
 	job.TimeoutMinutes = 0.001
@@ -1241,7 +1241,7 @@ func TestRunJobContinueOnErrorDoesNotTolerateMalformedServicePortEvidence(t *tes
 	f := newJobDocker(t, "malformed-port")
 	w := t.TempDir()
 	job := jobContainerPlan(t, w, nil)
-	job.Services = map[string]plan.Container{"db": {Image: "postgres", Ports: []string{"6379"}}}
+	job.Services = map[string]plan.ServiceContainer{"db": {Image: "postgres", Ports: []string{"6379"}}}
 	job.ServiceOrder = []string{"db"}
 	job.ContinueOnError = true
 
@@ -1257,7 +1257,7 @@ func TestRunJobContainerMalformedServicePortsIncludeMaskedDiagnostics(t *testing
 	var output bytes.Buffer
 	p := newCommandProcessor(&output, &output)
 	p.addMask("sibling-secret")
-	_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).startJobContainer(context.Background(), p, w, tmp, plan.Container{}, map[string]plan.Container{"db": {Image: "postgres", Ports: []string{"6379"}}})
+	_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).startJobContainer(context.Background(), p, w, tmp, nil, map[string]plan.ServiceContainer{"db": {Image: "postgres", Ports: []string{"6379"}}})
 	if err == nil || !strings.Contains(err.Error(), `service "db" has malformed Docker port output`) {
 		t.Fatalf("error=%v", err)
 	}
@@ -1269,7 +1269,7 @@ func TestRunJobContainerMalformedServicePortsIncludeMaskedDiagnostics(t *testing
 func TestRunJobContainerLaterServiceCreateFailureCleansExactServices(t *testing.T) {
 	f := newJobDocker(t, "fail-later-service-create")
 	w, tmp := t.TempDir(), t.TempDir()
-	_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).startJobContainer(context.Background(), newCommandProcessor(os.Stdout, os.Stderr), w, tmp, plan.Container{Image: "alpine"}, map[string]plan.Container{"a": {Image: "one"}, "b": {Image: "two"}})
+	_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).startJobContainer(context.Background(), newCommandProcessor(os.Stdout, os.Stderr), w, tmp, &plan.Container{Image: "alpine"}, map[string]plan.ServiceContainer{"a": {Image: "one"}, "b": {Image: "two"}})
 	if err == nil || !strings.Contains(err.Error(), `create service "b"`) {
 		t.Fatalf("error=%v, want second service create failure", err)
 	}
@@ -1296,7 +1296,7 @@ func TestRunJobContainerServiceReadinessCancellationCleansEverything(t *testing.
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).startJobContainer(ctx, newCommandProcessor(os.Stdout, os.Stderr), w, tmp, plan.Container{Image: "alpine"}, map[string]plan.Container{"db": {Image: "postgres"}})
+		_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).startJobContainer(ctx, newCommandProcessor(os.Stdout, os.Stderr), w, tmp, &plan.Container{Image: "alpine"}, map[string]plan.ServiceContainer{"db": {Image: "postgres"}})
 		done <- err
 	}()
 	deadline := time.Now().Add(10 * time.Second)
@@ -1320,7 +1320,7 @@ func TestRunHostJobServiceReadinessCancellationCleansEverything(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() {
-		_, err := (Runner{Docker: f.path}).startJobContainer(ctx, newCommandProcessor(os.Stdout, os.Stderr), w, tmp, plan.Container{}, map[string]plan.Container{"db": {Image: "postgres"}})
+		_, err := (Runner{Docker: f.path}).startJobContainer(ctx, newCommandProcessor(os.Stdout, os.Stderr), w, tmp, nil, map[string]plan.ServiceContainer{"db": {Image: "postgres"}})
 		done <- err
 	}()
 	deadline := time.Now().Add(10 * time.Second)
@@ -1349,7 +1349,7 @@ func TestRunJobHostServicesLifecycle(t *testing.T) {
 	w := t.TempDir()
 	j := jobContainerPlan(t, w, nil)
 	j.Container = nil
-	j.Services = map[string]plan.Container{"db": {Image: "postgres", Ports: []string{"6379"}}}
+	j.Services = map[string]plan.ServiceContainer{"db": {Image: "postgres", Ports: []string{"6379"}}}
 	j.ServiceOrder = []string{"db"}
 	j.Steps = []plan.Step{{ID: "host", Kind: "run", Shell: "sh", Env: map[string]string{"SERVICE_PORT": "${{ job.services.db.ports[6379] }}"}, Command: `test "$SERVICE_PORT" = 49152`}}
 	if _, err := (Runner{Docker: f.path}).RunJob(context.Background(), j, w); err != nil {
@@ -1372,7 +1372,7 @@ func TestRunHostJobServicesExposePortsAndNetworkToDockerActions(t *testing.T) {
 	})
 	job.Schema = plan.Schema
 	job.RequiredCapabilities = []string{"docker", "network"}
-	job.Services = map[string]plan.Container{"redis": {Image: "redis:7", Ports: []string{"6379"}}}
+	job.Services = map[string]plan.ServiceContainer{"redis": {Image: "redis:7", Ports: []string{"6379"}}}
 	job.ServiceOrder = []string{"redis"}
 	job.Actions = []plan.ActionLock{{ID: lockID, Source: "workspace", Path: "actions/docker", SourceDigest: digestTree(t, filepath.Join(workspace, "actions/docker"))}}
 	if _, err := (Runner{Docker: f.path}).RunJob(context.Background(), job, workspace); err != nil {
@@ -1406,7 +1406,7 @@ func TestRunJobHostServicePortProtocolCollisionIsDeterministic(t *testing.T) {
 	w := t.TempDir()
 	j := jobContainerPlan(t, w, nil)
 	j.Container = nil
-	j.Services = map[string]plan.Container{"db": {Image: "postgres", Ports: []string{"41001:6379/tcp", "41002:6379/udp"}}}
+	j.Services = map[string]plan.ServiceContainer{"db": {Image: "postgres", Ports: []string{"41001:6379/tcp", "41002:6379/udp"}}}
 	j.ServiceOrder = []string{"db"}
 	j.Steps = []plan.Step{{ID: "host", Kind: "run", Shell: "sh", Env: map[string]string{"SERVICE_PORT": "${{ job.services.db.ports[6379] }}"}, Command: `test "$SERVICE_PORT" = 41002`}}
 	if _, err := (Runner{Docker: f.path}).RunJob(context.Background(), j, w); err != nil {
@@ -1501,7 +1501,7 @@ func TestRunJobContainerToleratesWorkflowFailureAfterSuccessfulCleanup(t *testin
 func startTestBackend(t *testing.T, f fakeJobDocker) (*jobContainerBackend, string) {
 	w := t.TempDir()
 	tmp := t.TempDir()
-	b, e := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], InterruptGrace: 20 * time.Millisecond, TerminateGrace: 20 * time.Millisecond}).startJobContainer(context.Background(), newCommandProcessor(os.Stdout, os.Stderr), w, tmp, plan.Container{Image: "alpine:3.20"}, nil)
+	b, e := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], InterruptGrace: 20 * time.Millisecond, TerminateGrace: 20 * time.Millisecond}).startJobContainer(context.Background(), newCommandProcessor(os.Stdout, os.Stderr), w, tmp, &plan.Container{Image: "alpine:3.20"}, nil)
 	if e != nil {
 		t.Fatal(e)
 	}
@@ -2663,7 +2663,7 @@ func TestLiveAuthenticatedServiceRegistry(t *testing.T) {
 	job := runtimePlan(t, workspace, ".github/workflows/authenticated.yml", []plan.Step{{ID: "verify", Kind: "run", Shell: "sh", Command: "true"}})
 	job.Schema = plan.Schema
 	job.RequiredCapabilities = []string{"docker", "network"}
-	job.Services = map[string]plan.Container{"private": {Image: privateImage, Credentials: &plan.ContainerCredentials{Username: "service-user", Password: "service-password"}, Command: "sleep 300"}}
+	job.Services = map[string]plan.ServiceContainer{"private": {Image: privateImage, Credentials: &plan.ContainerCredentials{Username: "service-user", Password: "service-password"}, Command: "sleep 300"}}
 	job.ServiceOrder = []string{"private"}
 	before := liveDockerOwnedResources(t, docker)
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
@@ -2796,7 +2796,7 @@ CMD ["sh", "-c", "echo container-runtime-health-diagnostic >&2; sleep 300"]
 	job := runtimePlan(t, workspace, ".github/workflows/health.yml", []plan.Step{{ID: "unreachable", Kind: "run", Shell: "sh", Command: "true"}})
 	job.Schema = plan.Schema
 	job.RequiredCapabilities = []string{"docker", "network"}
-	job.Services = map[string]plan.Container{"unhealthy": {Image: image}}
+	job.Services = map[string]plan.ServiceContainer{"unhealthy": {Image: image}}
 	job.ServiceOrder = []string{"unhealthy"}
 	var logs bytes.Buffer
 	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -570,7 +570,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 				return tolerateJobSetupFailure(runCtx, job, jobResult, mountErr)
 			}
 		}
-		backend, setupErr := r.startJobContainerOrdered(runCtx, processor, workspace, runnerTemp, *job.Container, services, evaluatedServiceOrder, containerMounts...)
+		backend, setupErr := r.startJobContainerOrdered(runCtx, processor, workspace, runnerTemp, job.Container, services, evaluatedServiceOrder, containerMounts...)
 		if setupErr != nil {
 			return tolerateJobSetupFailure(runCtx, job, jobResult, setupErr)
 		}
@@ -583,7 +583,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 			}
 		}()
 	} else if len(services) != 0 {
-		backend, setupErr := r.startJobContainerOrdered(runCtx, processor, workspace, runnerTemp, plan.Container{}, services, evaluatedServiceOrder)
+		backend, setupErr := r.startJobContainerOrdered(runCtx, processor, workspace, runnerTemp, nil, services, evaluatedServiceOrder)
 		if setupErr != nil {
 			return tolerateJobSetupFailure(runCtx, job, jobResult, setupErr)
 		}
@@ -893,11 +893,11 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 	return scrubJobResult(jobResult, sensitiveValues), runErr
 }
 
-func evaluateServices(services map[string]plan.Container, eval expression.Context) (map[string]plan.Container, error) {
+func evaluateServices(services map[string]plan.ServiceContainer, eval expression.Context) (map[string]plan.ServiceContainer, error) {
 	if len(services) == 0 {
 		return services, nil
 	}
-	result := make(map[string]plan.Container, len(services))
+	result := make(map[string]plan.ServiceContainer, len(services))
 	for name, service := range services {
 		service.Env = maps.Clone(service.Env)
 		service.Ports = append([]string(nil), service.Ports...)
@@ -949,7 +949,7 @@ func evaluateServices(services map[string]plan.Container, eval expression.Contex
 	return result, nil
 }
 
-func serviceOrder(services map[string]plan.Container, preferred []string) []string {
+func serviceOrder(services map[string]plan.ServiceContainer, preferred []string) []string {
 	result := make([]string, 0, len(services))
 	seen := make(map[string]bool, len(services))
 	for _, name := range preferred {
@@ -966,7 +966,7 @@ func serviceOrder(services map[string]plan.Container, preferred []string) []stri
 	return result
 }
 
-func evaluateServiceMap(static map[string]plan.Container, staticOrder []string, source string, eval expression.Context) (map[string]plan.Container, []string, error) {
+func evaluateServiceMap(static map[string]plan.ServiceContainer, staticOrder []string, source string, eval expression.Context) (map[string]plan.ServiceContainer, []string, error) {
 	if source == "" {
 		services, err := evaluateServices(static, eval)
 		return services, serviceOrder(services, staticOrder), err
@@ -978,14 +978,14 @@ func evaluateServiceMap(static map[string]plan.Container, staticOrder []string, 
 	if len(entries) > 32 {
 		return nil, nil, fmt.Errorf("services expression has more than 32 entries")
 	}
-	services := make(map[string]plan.Container, len(entries))
+	services := make(map[string]plan.ServiceContainer, len(entries))
 	order := make([]string, 0, len(entries))
 	for _, entry := range entries {
 		name, raw := entry.Name, entry.Value
 		if !plan.ValidateServiceName(name) {
 			return nil, nil, fmt.Errorf("service name %q must be lowercase and valid", name)
 		}
-		var service plan.Container
+		var service plan.ServiceContainer
 		if image, ok := raw.(string); ok {
 			service.Image = image
 		} else {


### PR DESCRIPTION
## Summary

- Split the Go job-plan model into a restricted job container and the full service-container contract already defined by the schema.
- Keep service construction, template evaluation, Docker arguments, ordering, readiness, logs, and cleanup unchanged.
- Represent services-only startup with a nil job container instead of an empty broad container.

## Compatibility

`schemas/job-plan.schema.json` is unchanged. A representative job-container and full-service fixture produced byte-identical outputs before and after the refactor:

| Artifact | SHA-256 |
| --- | --- |
| Job plan | `aca3ef92cc32160a43445d4a6aa6221be637728b2c95b0d4b41406439130579a` |
| Compiler IR | `d6b6d33917cb69fa56f7eccd884918437f16ec111167053f0c986634657132cb` |
| Processing report | `d34c39f56afca9559f2148f3a2e1b7b3b4f3ea088dcb3a16816570524f560cb5` |
| Buildkite pipeline | `152fe5ac3b7a9287acb24ba8de446560da3bd5ece4ed31651edf925811114584` |

Oracle traced JSON field order, strict decoding and validation, compiler construction, static and dynamic services, and the runtime service lifecycle. It found no issues.

## Verification

- `mise run check`
- `mise exec -- go test -race ./internal/runtime -run '(Container|Service)' -count=1`
