### PR TITLE
Support runner.debug in action input defaults

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -574,7 +574,9 @@ Direct `github.token` references are step-only. Whole, filtered, or dynamically 
 
 The only runner references are `runner.os` and `runner.arch`. They resolve to
 `Linux`/`X64` or `macOS`/`ARM64`. Other runner fields and compile-time positions
-that require runner identity are unsupported.
+that require runner identity are unsupported. Action metadata input defaults
+may also use direct `runner.debug`, which resolves to the string `false` because
+Buildkite has no equivalent step-debug mode.
 
 A runtime interpolation can read a verified upstream output directly:
 

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -563,6 +563,28 @@ runs:
 	}
 }
 
+func TestCompileActionInvocationsSupportsNestedRunnerDebugDefault(t *testing.T) {
+	workspace := t.TempDir()
+	writeAction(t, workspace, "github-script", `name: GitHub Script
+inputs:
+  debug:
+    default: ${{ runner.debug == '1' }}
+runs:
+  using: node24
+  main: index.js
+`)
+	writeAction(t, workspace, "parent", `name: Parent
+runs:
+  using: composite
+  steps:
+    - uses: ./github-script
+`)
+
+	if _, err := compileActionInvocations(context.Background(), workspace, nil, "https://github.com", []string{"./parent"}, []map[string]string{nil}); err != nil {
+		t.Fatalf("compile nested github-script action: %v", err)
+	}
+}
+
 func TestCompilePlansScopesGitHubTokenForEffectiveActionDefaults(t *testing.T) {
 	w := t.TempDir()
 	workflowPath := filepath.Join(w, ".github", "workflows", "token.yml")

--- a/internal/expression/action_input_default.go
+++ b/internal/expression/action_input_default.go
@@ -28,8 +28,11 @@ func ValidateActionInputDefault(template string) error {
 
 func validateActionInputDefaultNode(node actionlint.ExprNode) error {
 	validator := newSemanticValidator(actionInputDefaultSurface)
-	validator.validateReference = func(_ actionlint.ExprNode, root string, path []string) error {
+	validator.validateReference = func(node actionlint.ExprNode, root string, path []string) error {
 		if isJobStatusReference(root, path) {
+			return nil
+		}
+		if isDirectRunnerDebug(node, root, path) {
 			return nil
 		}
 		kind := classifyRuntimeReference(root, path)
@@ -68,6 +71,11 @@ func validateActionInputDefaultNode(node actionlint.ExprNode) error {
 // supported only in action metadata input defaults.
 func EvaluateActionInputDefault(template string, context Context) (string, error) {
 	return evaluateRuntimeTemplate(template, context, evaluateActionInputDefaultNode)
+}
+
+func isDirectRunnerDebug(node actionlint.ExprNode, root string, path []string) bool {
+	_, direct := node.(*actionlint.ObjectDerefNode)
+	return direct && strings.EqualFold(root, "runner") && len(path) == 1 && strings.EqualFold(path[0], "debug")
 }
 
 // ActionInputDefaultRequiresGitHubToken reports whether a metadata default can
@@ -123,6 +131,10 @@ func ActionInputDefaultRequiresGitHubToken(template, serverURL string) (bool, er
 }
 
 func evaluateActionInputDefaultNode(node actionlint.ExprNode, context Context) (any, error) {
+	root, path, err := referencePath(node)
+	if err == nil && strings.EqualFold(root, "runner") && len(path) == 1 && strings.EqualFold(path[0], "debug") && !isDirectRunnerDebug(node, root, path) {
+		return nil, fmt.Errorf("unsupported runtime expression %q", referenceName(root, path))
+	}
 	evaluator := newSemanticEvaluator(actionInputDefaultSurface)
 	evaluator.resolve = func(root string, path []string) (any, error) {
 		if isJobStatusReference(root, path) {
@@ -130,6 +142,9 @@ func evaluateActionInputDefaultNode(node actionlint.ExprNode, context Context) (
 				return nil, fmt.Errorf("expression references unavailable job.status")
 			}
 			return context.JobStatus, nil
+		}
+		if strings.EqualFold(root, "runner") && len(path) == 1 && strings.EqualFold(path[0], "debug") {
+			return "false", nil
 		}
 		return resolveRuntimeReferenceWithMissingMembers(root, path, context)
 	}

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -157,6 +157,8 @@ func TestRunnerDirectReferencesWorkAcrossRuntimeEvaluationSurfaces(t *testing.T)
 func TestValidateActionInputDefaultSupportsRestrictedCompoundExpressions(t *testing.T) {
 	for _, template := range []string{
 		"${{ github.server_url == 'https://github.com' && github.token || '' }}",
+		"${{ runner.debug }}",
+		"${{ runner.debug == '1' }}",
 		"${{ job.status }}",
 		"${{ toJSON(matrix) }}",
 		"${{ true && 'quoted }} braces' || '' }}",
@@ -166,10 +168,44 @@ func TestValidateActionInputDefaultSupportsRestrictedCompoundExpressions(t *test
 			t.Errorf("ValidateActionInputDefault(%q) error = %v", template, err)
 		}
 	}
-	for _, template := range []string{"${{ secrets.TOKEN }}", "${{ hashFiles('go.sum') }}", "${{ toJSON(secrets) }}", "${{ github[env.NAME] }}", "${{ job.status == 'success' }}", "status-${{ job.status }}"} {
+	for _, template := range []string{"${{ secrets.TOKEN }}", "${{ hashFiles('go.sum') }}", "${{ toJSON(secrets) }}", "${{ github[env.NAME] }}", "${{ runner['debug'] }}", "${{ runner[env.NAME] }}", "${{ runner }}", "${{ runner.debug.extra }}", "${{ runner.name }}", "${{ job.status == 'success' }}", "status-${{ job.status }}"} {
 		if err := ValidateActionInputDefault(template); err == nil {
 			t.Errorf("ValidateActionInputDefault(%q) unexpectedly succeeded", template)
 		}
+	}
+}
+
+func TestEvaluateActionInputDefaultTreatsRunnerDebugAsFalse(t *testing.T) {
+	for _, test := range []struct {
+		template string
+		want     string
+	}{
+		{template: "${{ runner.debug }}", want: "false"},
+		{template: "${{ runner.debug == '1' }}", want: "false"},
+	} {
+		got, err := EvaluateActionInputDefault(test.template, Context{})
+		if err != nil || got != test.want {
+			t.Errorf("EvaluateActionInputDefault(%q) = %q, %v; want %q", test.template, got, err, test.want)
+		}
+	}
+}
+
+func TestRunnerDebugRemainsUnavailableOutsideActionInputDefaults(t *testing.T) {
+	template := "${{ runner.debug }}"
+	if err := ValidateRuntimeTemplate(template); err == nil {
+		t.Fatal("ValidateRuntimeTemplate() accepted runner.debug")
+	}
+	if _, err := Evaluate(template, Context{}); err == nil {
+		t.Fatal("Evaluate() accepted runner.debug")
+	}
+	if _, err := EvaluateStep(template, Context{}); err == nil {
+		t.Fatal("EvaluateStep() accepted runner.debug")
+	}
+	if _, err := EvaluateCondition("runner.debug", ConditionContext{}); err == nil {
+		t.Fatal("EvaluateCondition() accepted runner.debug")
+	}
+	if _, err := EvaluateActionLifecycleCondition("runner.debug", ConditionContext{}); err == nil {
+		t.Fatal("EvaluateActionLifecycleCondition() accepted runner.debug")
 	}
 }
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -2638,6 +2638,20 @@ func TestResolveActionInputsExposesScopedTokenToMetadataDefaults(t *testing.T) {
 	}
 }
 
+func TestResolveActionInputsUsesRunnerDebugDefaultUnlessExplicitlySupplied(t *testing.T) {
+	debugDefault := "${{ runner.debug }}"
+	action := metadata.Metadata{Inputs: map[string]metadata.Input{"debug": {Default: &debugDefault}}}
+
+	inputs, err := resolveActionInputs(action, nil, expression.Context{})
+	if err != nil || inputs["debug"] != "false" {
+		t.Fatalf("runner.debug default = %#v, %v; want false", inputs, err)
+	}
+	inputs, err = resolveActionInputs(action, map[string]string{"DEBUG": "true"}, expression.Context{})
+	if err != nil || inputs["debug"] != "true" {
+		t.Fatalf("explicit debug input = %#v, %v; want true", inputs, err)
+	}
+}
+
 func TestStepExpressionContextExposesScopedTokenWithoutMutatingJobContext(t *testing.T) {
 	eval := expression.Context{
 		GitHub:  map[string]any{"actor": "octocat"},


### PR DESCRIPTION
## Why

Actions including Codecov v5 and `actions/github-script` v6–v8 use `runner.debug` in metadata input defaults. In the deterministic 10K corpus, this currently affects 177 workflows across 176 repositories; 129 workflows across 128 repositories have no other current compatibility error.

## What

Allow only direct `runner.debug` references in action metadata input-default expressions and resolve them to the string `false`, since Buildkite has no equivalent step-debug mode. Explicit workflow inputs still override metadata defaults.

Keep workflow-authored expressions, other runner properties, indexed or whole runner access, authority analysis, event retention, immutable action resolution, and OIDC policy unchanged. This does not claim Codecov OIDC compatibility.
