### PR TITLE
Admit event-derived GitHub ref scalars at compile time

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -594,7 +594,7 @@ Patterns cannot be absolute, contain a `..` path segment, or contain ASCII contr
 
 ### Compile-time expressions
 
-Matrices, runner labels, names, concurrency groups, and event-backed conditions may use statically known `github`, `event`, `vars`, and matrix values. They support the compile-time syntax listed above, computed indexes, numeric array indexes, and `.*` projections where the complete expression resolves during compilation. Whole or dynamic `github` access and whole-event serialization remain unsupported. Event-backed conditions may also combine reducible event subtrees with supported runtime condition values such as `needs` and status functions.
+Matrices, runner labels, names, concurrency groups, and event-backed conditions may use statically known `github`, `event`, `vars`, and matrix values. Compile-time `github` values include `github.actor`, `github.base_ref`, `github.event_name`, `github.head_ref`, `github.ref`, `github.ref_name`, `github.ref_type`, `github.repository`, `github.repository_owner`, `github.sha`, and `github.workflow`. They support the compile-time syntax listed above, computed indexes, numeric array indexes, and `.*` projections where the complete expression resolves during compilation. Whole or dynamic `github` access and whole-event serialization remain unsupported. Event-backed conditions may also combine reducible event subtrees with supported runtime condition values such as `needs` and status functions.
 
 ## Actions
 

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -526,6 +526,78 @@ func TestCompileBundleRetainsGitHubHeadRefWithoutPayload(t *testing.T) {
 	}
 }
 
+func TestCompileBundleFoldsGitHubRefScalarsForConcurrencyAndRunnerSelection(t *testing.T) {
+	source := []byte(`on: [push, pull_request]
+concurrency: ${{ github.ref_type }}-${{ github.ref_name }}-${{ github.base_ref }}
+jobs:
+  test:
+    if: github.ref_type == 'branch' && (github.base_ref == '' || github.base_ref == 'trunk') && github.ref_name
+    runs-on: ${{ format('runner-{0}-{1}', github.ref_type, github.base_ref || github.ref_name) }}
+    steps: [{run: true}]
+`)
+	pullRequest := []byte(`{
+  "provider": "github",
+  "event": "pull_request",
+  "repository": {"owner": "buildkite", "name": "buildkite-gha"},
+  "ref": "refs/pull/42/merge",
+  "sha": "1111111111111111111111111111111111111111",
+  "actor": "buildkite-gha-smoke",
+  "payload": {"pull_request": {"base": {"ref": "trunk"}}}
+}`)
+	tests := []struct {
+		name, concurrency, label, queue string
+		event                           []byte
+	}{
+		{name: "push", event: pushEvent(t), concurrency: "branch-main-", label: "runner-branch-main", queue: "push-linux"},
+		{name: "pull request", event: pullRequest, concurrency: "branch-42/merge-trunk", label: "runner-branch-trunk", queue: "pr-linux"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			bundle, err := CompileBundleWithOptions("refs.yml", source, test.event, "0.0.0-test", testDistributionDigest, "gha-importer", Options{
+				EventTrust: EventTrusted,
+				Runners: RunnerPolicy{Labels: map[string]string{
+					"runner-branch-main":  "push-linux",
+					"runner-branch-trunk": "pr-linux",
+				}},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if bundle.IR.Workflow.ConcurrencyGroup != test.concurrency || len(bundle.IR.Jobs) != 1 || bundle.IR.Jobs[0].Queue != test.queue || bundle.IR.Jobs[0].RunsOn[0] != test.label {
+				t.Fatalf("folded bundle = concurrency %q, jobs %#v", bundle.IR.Workflow.ConcurrencyGroup, bundle.IR.Jobs)
+			}
+			if strings.Contains(bundle.IR.Jobs[0].If, "github.") || bytes.Contains(bundle.Plans[0].Contents, []byte("github.ref_")) || bytes.Contains(bundle.Plans[0].Contents, []byte("github.base_ref")) {
+				t.Fatalf("compile-time GitHub ref scalar reached emitted plan: %s", bundle.Plans[0].Contents)
+			}
+		})
+	}
+}
+
+func TestCompileBundleAppliesRunnerPolicyAfterGitHubRefScalarResolution(t *testing.T) {
+	source := []byte(`on: pull_request
+jobs:
+  test:
+    runs-on: runner-${{ github.ref_type }}-${{ github.base_ref }}
+    steps: [{run: true}]
+`)
+	event := []byte(`{
+  "provider": "github",
+  "event": "pull_request",
+  "repository": {"owner": "buildkite", "name": "buildkite-gha"},
+  "ref": "refs/pull/42/merge",
+  "sha": "1111111111111111111111111111111111111111",
+  "actor": "buildkite-gha-smoke",
+  "payload": {"pull_request": {"base": {"ref": "trunk"}}}
+}`)
+	_, err := CompileBundleWithOptions("refs.yml", source, event, "0.0.0-test", testDistributionDigest, "gha-importer", Options{
+		EventTrust: EventTrusted,
+		Runners:    RunnerPolicy{Labels: map[string]string{"runner-branch-main": "linux"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), `runner label "runner-branch-trunk" is not mapped by policy`) {
+		t.Fatalf("CompileBundleWithOptions() error = %v, want resolved-label policy rejection", err)
+	}
+}
+
 func TestCompileBundleTranslatesWorkflowAndJobConcurrency(t *testing.T) {
 	source := []byte(`name: Deployment
 on: push

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -1761,6 +1761,159 @@ jobs:
 	})
 }
 
+func TestExpandMatrixPreservesRegressedStaticExpressionValues(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+	}{
+		{
+			name: "unit_tests.yml",
+			source: `on: [push, pull_request]
+jobs:
+  build:
+    needs: setup
+    runs-on: ${{ matrix.os || 'ubuntu-24.04' }}
+    strategy:
+      matrix:
+        python: ['3.10']
+        modules_tool:
+          - ${{ needs.setup.outputs.lmod8 }}
+          - ${{ needs.setup.outputs.modules4 }}
+          - ${{ needs.setup.outputs.modules5 }}
+        include:
+          - python: '3.6.1'
+            modules_tool: ${{ needs.setup.outputs.lmod8 }}
+            use_pyenv: '2.6.15'
+          - python: '3.7'
+            modules_tool: ${{ needs.setup.outputs.lmod8 }}
+            os: ubuntu-22.04
+    steps: [{run: true}]
+`,
+		},
+		{
+			name: "product-creation-tests.yml",
+			source: `on: pull_request
+jobs:
+  e2e-tests:
+    needs: [check-secrets, resolve-versions]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        test-group: [plugin-events, product-crud, product-batch, product-category]
+        version-set: [supported, latest]
+        include:
+          - version-set: supported
+            wp-version: ${{ needs.resolve-versions.outputs.wp-supported }}
+            wc-version: ${{ needs.resolve-versions.outputs.wc-supported }}
+            version-label: Currently supported
+          - version-set: latest
+            wp-version: latest
+            wc-version: latest
+            version-label: Latest
+    steps: [{run: true}]
+`,
+		},
+		{
+			name: "apis-v21.yaml",
+			source: `on: push
+jobs:
+  cache:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: [coordinator-4_0, coordinator-dse-68]
+    steps: [{run: true}]
+  test:
+    needs: resolve-coordinator-docker
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        project: [sgv2-docsapi, sgv2-graphqlapi, sgv2-restapi]
+        name: [cassandra-40, dse-68]
+        include:
+          - name: cassandra-40
+            image-cache-key: docker-coordinator-4_0-${{ needs.resolve-coordinator-docker.outputs.sha }}
+            image-file: coordinator-4_0-${{ needs.resolve-coordinator-docker.outputs.sha }}.tar
+          - name: dse-68
+            image-cache-key: docker-coordinator-dse-68-${{ needs.resolve-coordinator-docker.outputs.sha }}
+            image-file: coordinator-dse-68-${{ needs.resolve-coordinator-docker.outputs.sha }}.tar
+    steps: [{run: true}]
+`,
+		},
+		{
+			name: "php-unit-tests.yml",
+			source: `on: workflow_dispatch
+jobs:
+  tests:
+    needs: GetMatrix
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: [8.2]
+        wp-version: [latest]
+        wc-versions: ['${{ join(fromJson(needs.GetMatrix.outputs.wc-versions)) }}']
+        include:
+          - php: 7.4
+            wp-version: ${{ fromJson(needs.GetMatrix.outputs.wp-versions)[1] }}
+            wc-versions: ${{ fromJson(needs.GetMatrix.outputs.wc-versions)[1] }}
+          - php: 8.3
+            wp-version: latest
+            wc-versions: latest
+    steps: [{run: true}]
+`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			parsed, err := workflow.Parse(test.name, []byte(test.source))
+			if err != nil {
+				t.Fatal(err)
+			}
+			matrixJobs := 0
+			for _, job := range parsed.Jobs {
+				if job.Matrix == nil {
+					continue
+				}
+				matrixJobs++
+				matrices, err := expandMatrix(test.name, job, expression.CompileContext{})
+				if err != nil {
+					t.Fatalf("expandMatrix(%q): %v", job.ID, err)
+				}
+				if len(matrices) == 0 {
+					t.Fatalf("expandMatrix(%q) returned no combinations", job.ID)
+				}
+			}
+			if matrixJobs == 0 {
+				t.Fatal("fixture has no matrix jobs")
+			}
+		})
+	}
+}
+
+func TestCompileResolvesGitHubRefNameInMatrixDimension(t *testing.T) {
+	workflow := []byte(`on: push
+jobs:
+  test:
+    strategy:
+      matrix:
+        target: ${{ fromJSON(format('["{0}"]', github.ref_name)) }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ${{ matrix.target }}
+`)
+	result, err := Compile("matrix.yml", workflow, readFile(t, smokePath("events", "push.json")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ir IR
+	if err := json.Unmarshal(result, &ir); err != nil {
+		t.Fatal(err)
+	}
+	if len(ir.Jobs) != 1 || ir.Jobs[0].Matrix["target"] != "main" {
+		t.Fatalf("resolved github.ref_name matrix value = %#v", ir.Jobs)
+	}
+}
+
 func TestCompileRejectsFlattenedReusableJobIDCollisions(t *testing.T) {
 	repository := t.TempDir()
 	suffix, err := matrixDigest(map[string]any{"target": "linux"})
@@ -2170,7 +2323,7 @@ jobs:
 	}
 }
 
-func TestCompileRetainsGitHubRuntimeEventIdentity(t *testing.T) {
+func TestCompileFoldsGitHubRefIdentityInConditions(t *testing.T) {
 	workflow := []byte(`on: [push, pull_request, pull_request_target]
 jobs:
   test:
@@ -2180,13 +2333,13 @@ jobs:
       - run: true
 `)
 	tests := []struct {
-		name, event, ref, payload, wantBaseRef string
+		name, event, ref, payload, wantBaseRef, wantCondition string
 	}{
-		{name: "branch", event: "push", ref: "refs/heads/feature/runtime", payload: `{}`},
-		{name: "tag", event: "push", ref: "refs/tags/v1.2.3", payload: `{}`},
-		{name: "pull request", event: "pull_request", ref: "refs/pull/42/merge", payload: `{"pull_request":{"base":{"ref":"main"},"head":{"ref":"feature/pr"}}}`, wantBaseRef: "main"},
-		{name: "pull request target", event: "pull_request_target", ref: "refs/heads/main", payload: `{"pull_request":{"base":{"ref":"main"},"head":{"ref":"feature/target"}}}`, wantBaseRef: "main"},
-		{name: "missing pull request shape", event: "pull_request", ref: "refs/pull/42/merge", payload: `{}`},
+		{name: "branch", event: "push", ref: "refs/heads/feature/runtime", payload: `{}`, wantCondition: "(always() && true)"},
+		{name: "tag", event: "push", ref: "refs/tags/v1.2.3", payload: `{}`, wantCondition: "(always() && true)"},
+		{name: "pull request", event: "pull_request", ref: "refs/pull/42/merge", payload: `{"pull_request":{"base":{"ref":"main"},"head":{"ref":"feature/pr"}}}`, wantBaseRef: "main", wantCondition: "(always() && false)"},
+		{name: "pull request target", event: "pull_request_target", ref: "refs/heads/main", payload: `{"pull_request":{"base":{"ref":"main"},"head":{"ref":"feature/target"}}}`, wantBaseRef: "main", wantCondition: "(always() && false)"},
+		{name: "missing pull request shape", event: "pull_request", ref: "refs/pull/42/merge", payload: `{}`, wantCondition: "(always() && true)"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -2203,8 +2356,8 @@ jobs:
 			if err != nil {
 				t.Fatal(err)
 			}
-			if len(plans) != 1 || plans[0].Event.BaseRef != test.wantBaseRef || !strings.Contains(plans[0].Condition, "github.repository_owner") {
-				t.Fatalf("runtime event identity plan = %#v", plans)
+			if len(plans) != 1 || plans[0].Event.BaseRef != test.wantBaseRef || plans[0].Condition != test.wantCondition {
+				t.Fatalf("compile-time event identity plan = %#v", plans)
 			}
 		})
 	}

--- a/internal/expression/compile.go
+++ b/internal/expression/compile.go
@@ -142,7 +142,7 @@ func validateCompileExpressionNode(node actionlint.ExprNode) error {
 			return nil
 		case strings.EqualFold(root, "github") && len(path) == 1:
 			switch strings.ToLower(path[0]) {
-			case "actor", "event_name", "head_ref", "ref", "repository", "repository_owner", "sha", "workflow":
+			case "actor", "base_ref", "event_name", "head_ref", "ref", "ref_name", "ref_type", "repository", "repository_owner", "sha", "workflow":
 				return nil
 			}
 		case strings.EqualFold(root, "github") && len(path) >= 2 && strings.EqualFold(path[0], "event"):

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -1337,7 +1337,13 @@ func TestEvaluateConditionFailsClosed(t *testing.T) {
 
 func TestEvaluateCompileSupportsGraphContextsAndFromJSON(t *testing.T) {
 	context := CompileContext{
-		GitHub: map[string]any{"event_name": "push", "event": map[string]any{"action": "opened"}},
+		GitHub: map[string]any{
+			"base_ref":   "main",
+			"event_name": "push",
+			"event":      map[string]any{"action": "opened"},
+			"ref_name":   "42/merge",
+			"ref_type":   "branch",
+		},
 		Event:  map[string]any{"action": "opened"},
 		Vars:   map[string]string{"RUNNERS": `["ubuntu-24.04","ubuntu-22.04"]`},
 		Matrix: map[string]any{"os": "ubuntu-24.04"},
@@ -1347,6 +1353,9 @@ func TestEvaluateCompileSupportsGraphContextsAndFromJSON(t *testing.T) {
 		want       any
 	}{
 		{expression: "${{ github.event_name }}", want: "push"},
+		{expression: "${{ github.ref_name }}", want: "42/merge"},
+		{expression: "${{ github.ref_type }}", want: "branch"},
+		{expression: "${{ github.base_ref }}", want: "main"},
 		{expression: "${{ github.event.action }}", want: "opened"},
 		{expression: "${{ event.action }}", want: "opened"},
 		{expression: "${{ matrix.os }}", want: "ubuntu-24.04"},
@@ -1403,6 +1412,33 @@ func TestEvaluateCompileSupportsGraphContextsAndFromJSON(t *testing.T) {
 	runners, ok := got.([]any)
 	if !ok || len(runners) != 2 || runners[0] != "ubuntu-24.04" {
 		t.Fatalf("fromJSON runners = %#v", got)
+	}
+}
+
+func TestEvaluateCompileTemplateSupportsGitHubRefScalars(t *testing.T) {
+	context := CompileContext{GitHub: map[string]any{
+		"base_ref": "main",
+		"ref_name": "42/merge",
+		"ref_type": "branch",
+	}}
+	got, err := EvaluateCompileTemplate("${{ github.ref_type }}-${{ github.ref_name }}-${{ github.base_ref }}", context)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "branch-42/merge-main" {
+		t.Fatalf("EvaluateCompileTemplate() = %q, want branch-42/merge-main", got)
+	}
+
+	got, err = EvaluateCompileTemplate("base-${{ github.base_ref }}", CompileContext{GitHub: map[string]any{"base_ref": ""}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "base-" {
+		t.Fatalf("EvaluateCompileTemplate() empty base_ref = %q, want base-", got)
+	}
+
+	if _, err := EvaluateCompileTemplate("${{ github.run_id }}", CompileContext{GitHub: map[string]any{"run_id": "123"}}); err == nil {
+		t.Fatal("EvaluateCompileTemplate() admitted unsupported github.run_id")
 	}
 }
 
@@ -1492,8 +1528,13 @@ func TestEvaluateCompileConditionUsesEventSnapshot(t *testing.T) {
 	if err != nil || !usesEvent {
 		t.Fatalf("ReferencesGitHubEvent() = %v, %v", usesEvent, err)
 	}
-	if usesEvent, err := ReferencesGitHubEvent("github.event_name == 'push'"); err != nil || usesEvent {
-		t.Fatalf("ReferencesGitHubEvent(event_name) = %v, %v", usesEvent, err)
+	for _, source := range []string{"github.event_name == 'push'", "github.ref == 'refs/heads/main'"} {
+		if usesEvent, err := ReferencesGitHubEvent(source); err != nil || usesEvent {
+			t.Fatalf("ReferencesGitHubEvent(%q) = %v, %v", source, usesEvent, err)
+		}
+	}
+	if usesEvent, err := ReferencesGitHubEvent("github.ref_type == 'branch' && github.ref_name && github.base_ref == ''"); err != nil || !usesEvent {
+		t.Fatalf("ReferencesGitHubEvent(ref scalars) = %v, %v", usesEvent, err)
 	}
 }
 

--- a/internal/expression/references.go
+++ b/internal/expression/references.go
@@ -348,15 +348,14 @@ func ReferencesJobStatus(template string) (bool, error) {
 	return found, err
 }
 
-// ReferencesGitHubEvent reports whether a condition reads the event payload
-// through github.event. The compiler can fold those conditions before the
-// immutable runtime boundary, which deliberately omits the payload body.
+// ReferencesGitHubEvent reports whether a condition reads the event payload or
+// an event-derived GitHub ref scalar that the compiler must fold.
 func ReferencesGitHubEvent(source string) (bool, error) {
 	node, empty, err := parseCondition(source)
 	if err != nil || empty {
 		return false, err
 	}
-	return nodeReferencesGitHubEvent(node), nil
+	return nodeReferencesCompileGitHubEvent(node), nil
 }
 
 // TemplateReferencesGitHubEvent reports whether an interpolated template
@@ -364,13 +363,35 @@ func ReferencesGitHubEvent(source string) (bool, error) {
 func TemplateReferencesGitHubEvent(template string) (bool, error) {
 	found := false
 	err := visitTemplateExpressions(template, func(node actionlint.ExprNode) error {
-		found = found || nodeReferencesGitHubEvent(node)
+		found = found || nodeReferencesGitHubEventPayload(node)
 		return nil
 	})
 	return found, err
 }
 
-func nodeReferencesGitHubEvent(node actionlint.ExprNode) bool {
+func nodeReferencesCompileGitHubEvent(node actionlint.ExprNode) bool {
+	return nodeReferencesGitHub(node, func(path []string) bool {
+		if len(path) == 0 {
+			return false
+		}
+		switch strings.ToLower(path[0]) {
+		case "base_ref", "ref_name", "ref_type":
+			return len(path) == 1
+		case "event":
+			return true
+		default:
+			return false
+		}
+	})
+}
+
+func nodeReferencesGitHubEventPayload(node actionlint.ExprNode) bool {
+	return nodeReferencesGitHub(node, func(path []string) bool {
+		return len(path) != 0 && strings.EqualFold(path[0], "event")
+	})
+}
+
+func nodeReferencesGitHub(node actionlint.ExprNode, matches func([]string) bool) bool {
 	found := false
 	actionlint.VisitExprNode(node, func(node, _ actionlint.ExprNode, entering bool) {
 		if !entering || found {
@@ -382,7 +403,7 @@ func nodeReferencesGitHubEvent(node actionlint.ExprNode) bool {
 			return
 		}
 		root, path, pathErr := referencePath(node)
-		found = pathErr == nil && strings.EqualFold(root, "github") && len(path) != 0 && strings.EqualFold(path[0], "event")
+		found = pathErr == nil && strings.EqualFold(root, "github") && matches(path)
 	})
 	return found
 }


### PR DESCRIPTION
## Why

The compiler already derives `github.ref_name`, `github.ref_type`, and `github.base_ref`, but its compile-time whitelist rejects them in matrices, runner labels, names, concurrency groups, and event-backed condition reduction.

The first implementation in #294 also evaluated expression-looking static matrix values, which caused unrelated `E_MATRIX_INVALID` regressions. The corrected implementation's deterministic 10K A/B moved 18 workflows out of incompatible with no regressions and left `E_MATRIX_INVALID` unchanged.

## What

Admit only those three event-derived scalars through the existing compile-time expression surface and fold their condition references before plan emission. Preserve existing ref derivation, static matrix expansion, unsupported runtime fields, and runner-policy enforcement.

Add focused push, pull-request, matrix, policy, and regression coverage, and document the complete compile-time GitHub scalar surface.
