### PR TITLE
Document initial compatibility scope boundaries

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -46,6 +46,17 @@ Looking for something else? [Browse open compatibility issues](https://github.co
 | [Other platforms](#job-configuration) and [providers](#repositories) | ❌ Unsupported | Windows, Linux arm64, macOS x86-64, GitHub Enterprise Server, and unlisted providers are outside the initial release. |
 | [Other GitHub services](#github-services) | ❌ Unsupported | No general emulation for Releases, Packages, Checks, deployments, or GitHub artifact APIs. |
 
+## Outside the initial scope
+
+Windows execution is outside the initial product scope. `buildkite-gha`
+currently targets Linux x86-64 and native macOS arm64. It rejects Windows
+runner labels instead of mapping them to a different platform.
+
+Compatibility analysis should distinguish this scope boundary from features
+that could be added to the supported platforms. This distinction does not
+change validation: Windows workflows remain unsupported and appear in raw
+corpus results.
+
 ## How workflows run on Buildkite
 
 GitHub Actions combines run creation and workload definition in one file. Buildkite keeps them separate.

--- a/docs/development.md
+++ b/docs/development.md
@@ -80,6 +80,8 @@ Useful environment variables are:
 
 The script reports compatible, incompatible, and policy-rejected repositories among those the generated snapshots measured. It reports context-required and indeterminate repositories separately and excludes them from the compatibility percentage. The tally also records workflow result counts and keeps every diagnostic in the per-workflow report.
 
+Windows execution is [outside the initial product scope](compatibility.md#outside-the-initial-scope), not a compatibility gap to close on Linux or macOS. Keep Windows workflows in raw corpus outcomes so the benchmark continues to describe the complete sample. A report may add an in-scope compatibility view, but it must classify records individually and account for overlapping findings. Do not derive its denominator by subtracting aggregate diagnostic or repository counts.
+
 Pull-request path filters require a linked Buildkite webhook and a verified, bounded local git diff. The public corpus has workflow files but no repository checkouts or pull-request history. It still compiles these workflows, resolves their actions, constructs their plans, and applies hosted policy. When the diff is the only missing evidence, it reports the workflow as `context-required`. This does not claim admission. Push path filters, malformed filters, and workflows with another incompatibility remain incompatible.
 
 Sample metadata is written to `records/<record-id>/samples/<sample-key>/validate-tally.json`; per-workflow v3 reports are under `reports/<record-id>/samples/<sample-key>/<validator-digest>/`. Full-corpus tallies and reports retain their existing paths.


### PR DESCRIPTION
## Why

Raw compatibility results currently mix product-scope decisions with gaps we intend to close. Windows execution requires a real Windows target and is not part of the initial Linux and Apple-silicon macOS product scope.

## What

Document Windows execution as outside the initial scope and retain fail-closed runner-label behavior. Clarify that corpus reports must keep Windows in raw totals and compute any additional in-scope view from individual records rather than subtracting overlapping aggregate counts.

This changes documentation and benchmark interpretation only; validation and runtime behavior are unchanged.