### PR TITLE
Accept inert top-level action metadata env

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -620,10 +620,13 @@ Matrices, runner labels, names, concurrency groups, and event-backed conditions 
 | Composite action | 🟡 Supported subset | Nested shell steps and locked local or public actions; `bash` or `sh` for `run`. |
 | Dockerfile action | 🟡 Supported subset | Verified local or public Dockerfile action on Linux. Rejected on macOS, including through a composite action. |
 | `docker://` action | ❌ Unsupported | Rejected during validation. |
+| Top-level action metadata `env` | ➖ Accepted, no effect | Any valid YAML value is discarded. It is not evaluated, injected, retained in plans, or used to request secrets or tokens. |
 
 Mutable public refs are resolved during upload, then locked to a commit. The importer lazily requests one Buildkite action-source token and reuses it across all workflow roots and nested composite actions. This token authenticates only public metadata requests for repositories other than the credential repository; the credential repository and codeload requests remain anonymous. If token issuance is unavailable during rollout, resolution safely falls back to anonymous GitHub API access. Exact lowercase commit SHAs need no GitHub API lookup. Complete source trees are verified again at runtime.
 
 Nested calls from a repository-local composite must be local. Public composites may call local children or other public actions; every child is resolved and locked. Dockerfile actions cannot request credentials, volumes, arbitrary options, or privileged mode.
+
+Action metadata parsing remains strict for every other unknown top-level field and for unknown nested fields. The inert top-level `env` exception does not replace workflow or action-step environments, populate `runs.env`, or add `GITHUB_TOKEN` authority.
 
 | Action declaration | Runtime |
 | --- | --- |

--- a/internal/action/metadata/metadata.go
+++ b/internal/action/metadata/metadata.go
@@ -170,6 +170,15 @@ func Load(root, path string) (Metadata, error) {
 		return Metadata{}, err
 	}
 	if discardTopLevelEnv(&document) {
+		var validated struct {
+			Metadata `yaml:",inline"`
+			Env      yaml.Node `yaml:"env"`
+		}
+		validator := yaml.NewDecoder(bytes.NewReader(source))
+		validator.KnownFields(true)
+		if err := validator.Decode(&validated); err != nil {
+			return Metadata{}, fmt.Errorf("parse action metadata %q: %w", metadataPath, err)
+		}
 		source, err = yaml.Marshal(&document)
 		if err != nil {
 			return Metadata{}, fmt.Errorf("parse action metadata %q: discard top-level env: %w", metadataPath, err)

--- a/internal/action/metadata/metadata.go
+++ b/internal/action/metadata/metadata.go
@@ -152,7 +152,15 @@ func Load(root, path string) (Metadata, error) {
 
 	metadata := Metadata{Path: actionPath}
 	var document yaml.Node
-	if err := yaml.Unmarshal(source, &document); err != nil {
+	documentDecoder := yaml.NewDecoder(bytes.NewReader(source))
+	if err := documentDecoder.Decode(&document); err != nil {
+		return Metadata{}, fmt.Errorf("parse action metadata %q: %w", metadataPath, err)
+	}
+	var trailing any
+	if err := documentDecoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return Metadata{}, fmt.Errorf("parse action metadata %q: multiple YAML documents", metadataPath)
+		}
 		return Metadata{}, fmt.Errorf("parse action metadata %q: %w", metadataPath, err)
 	}
 	if err := rejectCompositeControls(metadataPath, &document); err != nil {
@@ -161,16 +169,15 @@ func Load(root, path string) (Metadata, error) {
 	if err := validateCompositeSteps(metadataPath, &document); err != nil {
 		return Metadata{}, err
 	}
+	if discardTopLevelEnv(&document) {
+		source, err = yaml.Marshal(&document)
+		if err != nil {
+			return Metadata{}, fmt.Errorf("parse action metadata %q: discard top-level env: %w", metadataPath, err)
+		}
+	}
 	decoder := yaml.NewDecoder(bytes.NewReader(source))
 	decoder.KnownFields(true)
 	if err := decoder.Decode(&metadata); err != nil {
-		return Metadata{}, fmt.Errorf("parse action metadata %q: %w", metadataPath, err)
-	}
-	var trailing any
-	if err := decoder.Decode(&trailing); err != io.EOF {
-		if err == nil {
-			return Metadata{}, fmt.Errorf("parse action metadata %q: multiple YAML documents", metadataPath)
-		}
 		return Metadata{}, fmt.Errorf("parse action metadata %q: %w", metadataPath, err)
 	}
 	if metadata.Runs.Using == "" {
@@ -195,6 +202,24 @@ func Load(root, path string) (Metadata, error) {
 		return Metadata{}, fmt.Errorf("parse action metadata %q: %w", metadataPath, err)
 	}
 	return metadata, nil
+}
+
+func discardTopLevelEnv(document *yaml.Node) bool {
+	root := document
+	if root.Kind == yaml.DocumentNode && len(root.Content) != 0 {
+		root = root.Content[0]
+	}
+	if root.Kind != yaml.MappingNode {
+		return false
+	}
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		if root.Content[i].Value != "env" {
+			continue
+		}
+		root.Content = append(root.Content[:i], root.Content[i+2:]...)
+		return true
+	}
+	return false
 }
 
 func rejectCompositeControls(path string, document *yaml.Node) error {

--- a/internal/action/metadata/metadata_test.go
+++ b/internal/action/metadata/metadata_test.go
@@ -204,7 +204,7 @@ runs:
 	t.Run("unknown field", func(t *testing.T) {
 		root := t.TempDir()
 		writeAction(t, root, "action.yml", "env:\n  GITHUB_TOKEN: ignored\nunexpected: true\nruns:\n  using: node24\n")
-		if _, err := Load(root, "."); err == nil || !strings.Contains(err.Error(), "field unexpected not found") {
+		if _, err := Load(root, "."); err == nil || !strings.Contains(err.Error(), "line 3: field unexpected not found") {
 			t.Fatalf("Load() error = %v, want unknown field rejection", err)
 		}
 	})
@@ -212,7 +212,7 @@ runs:
 	t.Run("unknown nested field", func(t *testing.T) {
 		root := t.TempDir()
 		writeAction(t, root, "action.yml", "env:\n  GITHUB_TOKEN: ignored\nbranding:\n  unexpected: true\nruns:\n  using: node24\n")
-		if _, err := Load(root, "."); err == nil || !strings.Contains(err.Error(), "field unexpected not found") {
+		if _, err := Load(root, "."); err == nil || !strings.Contains(err.Error(), "line 4: field unexpected not found") {
 			t.Fatalf("Load() error = %v, want nested unknown field rejection", err)
 		}
 	})

--- a/internal/action/metadata/metadata_test.go
+++ b/internal/action/metadata/metadata_test.go
@@ -1,6 +1,7 @@
 package metadata
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -110,6 +111,52 @@ func TestValidateDockerEntrypoints(t *testing.T) {
 }
 
 func TestLoadIsStrictAndConfined(t *testing.T) {
+	t.Run("softprops top-level env is inert", func(t *testing.T) {
+		root := t.TempDir()
+		writeAction(t, root, "action.yml", `name: GH Release
+description: Github Action for creating Github Releases
+author: softprops
+inputs:
+  token:
+    description: Authorized GitHub token or PAT
+    required: false
+    default: ${{ github.token }}
+env:
+  GITHUB_TOKEN: "As provided by Github Actions"
+runs:
+  using: node24
+  main: dist/index.js
+`)
+		action, err := Load(root, ".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		encoded, err := json.Marshal(action)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(encoded), "As provided by Github Actions") || action.Runs.Env != nil {
+			t.Fatalf("Load() retained top-level env: %s", encoded)
+		}
+		if token := action.Inputs["token"].Default; token == nil || *token != "${{ github.token }}" {
+			t.Fatalf("Load() token input default = %v, want retained input authority", token)
+		}
+	})
+
+	t.Run("top-level env accepts arbitrary YAML values", func(t *testing.T) {
+		for _, value := range []string{
+			"placeholder",
+			"[GITHUB_TOKEN, {nested: true}]",
+			"{GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}', nested: {token: value}}",
+		} {
+			root := t.TempDir()
+			writeAction(t, root, "action.yml", "env: "+value+"\nruns:\n  using: node24\n  main: dist/index.js\n")
+			if _, err := Load(root, "."); err != nil {
+				t.Fatalf("Load() env %q error = %v", value, err)
+			}
+		}
+	})
+
 	t.Run("official declarative fields", func(t *testing.T) {
 		root := t.TempDir()
 		writeAction(t, root, "action.yml", "name: Setup tool\ndescription: Installs a tool\ndeprecationMessage: Use setup-tool v2 instead\nauthor: GitHub\ninputs:\n  version:\n    deprecationMessage: Use version-file instead\n    type: string\nbranding:\n  icon: package\n  color: blue\nruns:\n  using: node24\n  main: dist/index.js\n")
@@ -156,7 +203,7 @@ func TestLoadIsStrictAndConfined(t *testing.T) {
 
 	t.Run("unknown field", func(t *testing.T) {
 		root := t.TempDir()
-		writeAction(t, root, "action.yml", "unexpected: true\nruns:\n  using: node24\n")
+		writeAction(t, root, "action.yml", "env:\n  GITHUB_TOKEN: ignored\nunexpected: true\nruns:\n  using: node24\n")
 		if _, err := Load(root, "."); err == nil || !strings.Contains(err.Error(), "field unexpected not found") {
 			t.Fatalf("Load() error = %v, want unknown field rejection", err)
 		}
@@ -164,9 +211,17 @@ func TestLoadIsStrictAndConfined(t *testing.T) {
 
 	t.Run("unknown nested field", func(t *testing.T) {
 		root := t.TempDir()
-		writeAction(t, root, "action.yml", "branding:\n  unexpected: true\nruns:\n  using: node24\n")
+		writeAction(t, root, "action.yml", "env:\n  GITHUB_TOKEN: ignored\nbranding:\n  unexpected: true\nruns:\n  using: node24\n")
 		if _, err := Load(root, "."); err == nil || !strings.Contains(err.Error(), "field unexpected not found") {
 			t.Fatalf("Load() error = %v, want nested unknown field rejection", err)
+		}
+	})
+
+	t.Run("malformed top-level env", func(t *testing.T) {
+		root := t.TempDir()
+		writeAction(t, root, "action.yml", "env: [unterminated\nruns:\n  using: node24\n")
+		if _, err := Load(root, "."); err == nil || !strings.Contains(err.Error(), "parse action metadata") {
+			t.Fatalf("Load() error = %v, want malformed YAML rejection", err)
 		}
 	})
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -2853,6 +2854,62 @@ runs:
 	}
 	if result.Env["GITHUB_TOKEN"] != "***" || result.Env["GITHUB_SHA"] != "action-sha" || result.Env["RUNNER_TEMP"] != "/action-temp" || strings.Contains(logs.String(), "ghs_scoped_action_default") || !strings.Contains(logs.String(), "exported token: ***") {
 		t.Fatalf("exported workflow token leaked: result = %#v, logs = %q", result, logs.String())
+	}
+}
+
+func TestCompileAndRunJobDiscardsTopLevelActionEnv(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := filepath.Join(workspace, ".github", "workflows", "test.yml")
+	workflow := []byte(`on: push
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/release
+        env:
+          GITHUB_TOKEN: workflow-step-token
+          PRESERVED: workflow-step-env
+`)
+	writeFixtureFile(t, workspace, ".github/workflows/test.yml", string(workflow))
+	writeFixtureFile(t, workspace, ".github/actions/release/action.yml", `name: GH Release
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  METADATA_ONLY: ${{ secrets.DEPLOY_TOKEN }}
+runs:
+  using: composite
+  steps:
+    - shell: sh
+      run: |
+        test "$GITHUB_TOKEN" = workflow-step-token
+        test "$PRESERVED" = workflow-step-env
+        test -z "${METADATA_ONLY:-}"
+`)
+	event, err := os.ReadFile(fixturePath(t, "smoke", "events", "push.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	plans, err := compileUntrustedPlans(workflowPath, workflow, event, "0.0.0-test", "sha256:"+strings.Repeat("2", 64), "gha-untrusted")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 1 || plans[0].GitHubToken != nil || len(plans[0].RequiredSecrets) != 0 || plans[0].HasCapability("provider-token-write") || plans[0].HasCapability("secrets") {
+		t.Fatalf("top-level action env added authority to plan: %#v", plans)
+	}
+	encoded, err := json.Marshal(plans[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "METADATA_ONLY") || strings.Contains(string(encoded), "DEPLOY_TOKEN") {
+		t.Fatalf("top-level action env leaked into plan: %s", encoded)
+	}
+
+	provider := &testWorkflowTokenProvider{token: "must-not-be-minted"}
+	result, err := (Runner{WorkflowToken: provider, Secrets: testSecretResolver{}}).RunJob(context.Background(), plans[0], workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	if provider.calls != 0 {
+		t.Fatalf("top-level action env requested %d workflow tokens", provider.calls)
 	}
 }
 


### PR DESCRIPTION
## Why

GitHub Runner accepts and ignores a top-level `env` field in action metadata. Actions such as `softprops/action-gh-release` use it as a placeholder, so strict metadata decoding currently rejects otherwise compatible workflows.

## What

Accept and discard only the root action-metadata `env` value before strict typed decoding. The value is never evaluated, injected, serialized, or used as secret or token authority; all other unknown root and nested fields remain strict. Parser and compiler/runtime coverage verifies the boundary, and the compatibility reference documents the inert exception.

On the pinned 10,000-workflow corpus, this removes the rejection from all 118 affected workflows: 40 become admitted and compatible repositories increase by 33.
