### PR TITLE
fix: support composite continue-on-error

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -621,7 +621,7 @@ Matrices, runner labels, names, concurrency groups, and event-backed conditions 
 | Public `owner/repo[/path]@ref` action | 🟡 Supported subset | Resolved to an exact commit and digest. |
 | Private action | ❌ Unsupported | No private action source access. |
 | JavaScript action | ✅ Supported | Declares `node16`, `node20`, or `node24`. |
-| Composite action | 🟡 Supported subset | Nested shell steps and locked local or public actions; `bash` or `sh` for `run`. |
+| Composite action | 🟡 Supported subset | Nested shell steps and locked local or public actions; `bash` or `sh` for `run`; literal `continue-on-error`. |
 | Dockerfile action | 🟡 Supported subset | Verified local or public Dockerfile action on Linux. Rejected on macOS, including through a composite action. |
 | `docker://` action | ❌ Unsupported | Rejected during validation. |
 | Top-level action metadata `env` | ➖ Accepted, no effect | Any valid YAML value is discarded. It is not evaluated, injected, retained in plans, or used to request secrets or tokens. |

--- a/internal/action/metadata/metadata.go
+++ b/internal/action/metadata/metadata.go
@@ -85,6 +85,7 @@ type CompositeStep struct {
 	Env              map[string]string `yaml:"env"`
 	If               string            `yaml:"if"`
 	With             map[string]string `yaml:"with"`
+	ContinueOnError  bool              `yaml:"continue-on-error"`
 }
 
 // Runtime identifies one supported action execution model.

--- a/internal/action/metadata/metadata_test.go
+++ b/internal/action/metadata/metadata_test.go
@@ -278,6 +278,18 @@ func TestLoadRejectsCompositeControlsWithLocation(t *testing.T) {
 	}
 }
 
+func TestLoadAcceptsCompositeContinueOnError(t *testing.T) {
+	root := t.TempDir()
+	writeAction(t, root, "action.yml", "runs:\n  using: composite\n  steps:\n    - run: exit 1\n      shell: sh\n      continue-on-error: true\n")
+	action, err := Load(root, ".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !action.Runs.Steps[0].ContinueOnError {
+		t.Fatal("Load() did not retain composite continue-on-error")
+	}
+}
+
 func TestLoadRejectsInvalidCompositeStepSyntax(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -136,6 +136,12 @@ type preparedInvocation struct {
 
 type remotePreparations map[string]*preparedInvocation
 
+func bindCompositeInvocationSteps(invocation *preparedInvocation, steps map[string]expression.StepStatus) {
+	if invocation != nil && invocation.isolated {
+		invocation.eval.Steps = steps
+	}
+}
+
 type remotePreparationStatus struct {
 	unsuccessful bool
 }
@@ -2084,6 +2090,7 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 		if invocation != nil && invocation.preFailure != nil {
 			invocation.eval = lifecycleEval
 			invocation.envOverlay = lifecycleEnvOverlay
+			bindCompositeInvocationSteps(invocation, eval.Steps)
 			return result, invocation.preFailure
 		}
 		if invocation == nil {
@@ -2190,16 +2197,17 @@ func (r Runner) runCompositeMetadata(ctx context.Context, processor *commandProc
 			if execution.conclusion != "success" {
 				runErr = errors.Join(runErr, childErr)
 			}
+			bindCompositeInvocationSteps(prepared[childInvocationID], eval.Steps)
 			continue
 		}
 		if !run {
 			if id != "" {
 				eval.Steps[id] = expression.StepStatus{Outcome: "skipped", Conclusion: "skipped", Outputs: map[string]string{}}
 			}
-			if invocation := prepared[childInvocationID]; invocation != nil && invocation.isolated {
+			if invocation := prepared[childInvocationID]; invocation != nil {
 				// Pre hooks register posts before composite execution. If main is
 				// skipped, retain this composite's live final step scope for post-if.
-				invocation.eval.Steps = eval.Steps
+				bindCompositeInvocationSteps(invocation, eval.Steps)
 			}
 			continue
 		}

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -1873,7 +1873,11 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 			mergeInto(result.State, childResult.State)
 			appendJobSummary(&result.Summary, &result.summaryTruncated, childResult.Summary, childResult.summaryTruncated)
 			if childErr != nil {
-				execution := classifyStepExecution(ctx, ctx, plan.Step{ContinueOnError: childStep.ContinueOnError}, childResult, childErr)
+				classificationCtx := ctx
+				if preparationTimeout != nil && preparationTimeout.bounded != nil {
+					classificationCtx = preparationTimeout.bounded
+				}
+				execution := classifyStepExecution(classificationCtx, classificationCtx, plan.Step{ContinueOnError: childStep.ContinueOnError}, childResult, childErr)
 				if execution.conclusion != "success" {
 					status.unsuccessful = true
 					err = errors.Join(err, fmt.Errorf("composite action step %d: %w", i+1, childErr))
@@ -2182,6 +2186,18 @@ func (r Runner) runCompositeMetadata(ctx context.Context, processor *commandProc
 		// rebuilding the map so a child's declared env cannot leak to siblings.
 		eval.Env = mergeStringMaps(compositeExpressionEnv, result.Env)
 		id := strings.ToLower(step.ID)
+		if invocation := prepared[childInvocationID]; invocation != nil && invocation.preFailure != nil {
+			childErr := invocation.preFailure
+			execution := classifyStepExecution(ctx, ctx, plan.Step{ContinueOnError: step.ContinueOnError}, newResult(), childErr)
+			if id != "" {
+				eval.Steps[id] = expression.StepStatus{Outcome: execution.outcome, Conclusion: execution.conclusion, Outputs: map[string]string{}}
+			}
+			if execution.conclusion != "success" {
+				runErr = errors.Join(runErr, childErr)
+			}
+			bindCompositeInvocationSteps(invocation, eval.Steps)
+			continue
+		}
 		inputs := make(map[string]any, len(eval.Inputs))
 		for name, value := range eval.Inputs {
 			inputs[name] = value

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -131,6 +131,7 @@ type preparedInvocation struct {
 	envOverlay     map[string]string
 	isolated       bool
 	postRegistered bool
+	preFailure     error
 }
 
 type remotePreparations map[string]*preparedInvocation
@@ -1812,6 +1813,7 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 			posts.register(postForInvocation(invocation, action.Runs.PostIf))
 			invocation.postRegistered = true
 			if err := r.runJavaScriptPhase(phaseCtx, processor, workspace, node, javascript, javascript.Pre, nil, invocation.state, &result); err != nil {
+				invocation.preFailure = err
 				return result, err
 			}
 		}
@@ -1861,8 +1863,11 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 			mergeInto(result.State, childResult.State)
 			appendJobSummary(&result.Summary, &result.summaryTruncated, childResult.Summary, childResult.summaryTruncated)
 			if childErr != nil {
-				status.unsuccessful = true
-				err = errors.Join(err, fmt.Errorf("composite action step %d: %w", i+1, childErr))
+				execution := classifyStepExecution(ctx, ctx, plan.Step{ContinueOnError: childStep.ContinueOnError}, childResult, childErr)
+				if execution.conclusion != "success" {
+					status.unsuccessful = true
+					err = errors.Join(err, fmt.Errorf("composite action step %d: %w", i+1, childErr))
+				}
 			}
 		}
 		return result, err
@@ -2056,6 +2061,9 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 			javascript.Inputs = inputs
 			javascript.Env = environment.process()
 			invocation.action = javascript
+			if invocation.preFailure != nil {
+				return result, invocation.preFailure
+			}
 		}
 		lifecycleEval := cloneExpressionContext(eval)
 		bindHashFilesContext(ctx, &lifecycleEval)

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -1757,24 +1757,28 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 		invocation := &preparedInvocation{action: javascript, state: map[string]string{}, eval: invocationEval, isolated: !workflowStep}
 		prepared[invocationID] = invocation
 		if javascript.Pre != "" {
+			failPre := func(err error) (Result, error) {
+				invocation.preFailure = err
+				return result, err
+			}
 			stepEnv := map[string]string{}
 			if inheritedEvalErr == nil {
 				stepEnv, err = evaluate(step.Env, eval)
 				if err != nil {
-					return result, err
+					return failPre(err)
 				}
 				invocationEval.Env = mergeStringMaps(invocationEval.Env, stepEnv)
 			}
 			condition := lifecycleConditionContext(invocationEval, status.unsuccessful, ctx.Err() != nil)
 			runPre, err := expression.EvaluateActionLifecycleCondition(action.Runs.PreIf, condition)
 			if err != nil {
-				return result, fmt.Errorf("JavaScript action %q pre-if: %w", step.Uses, err)
+				return failPre(fmt.Errorf("JavaScript action %q pre-if: %w", step.Uses, err))
 			}
 			if !runPre {
 				return result, nil
 			}
 			if inheritedEvalErr != nil {
-				return result, inheritedEvalErr
+				return failPre(inheritedEvalErr)
 			}
 			eval.Env = mergeStringMaps(eval.Env, stepEnv)
 			phaseCtx := ctx
@@ -1782,23 +1786,23 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 			if workflowStep {
 				resolvedStep, err := evaluateStepTimeout(step, eval)
 				if err != nil {
-					return result, fmt.Errorf("controls: %w", err)
+					return failPre(fmt.Errorf("controls: %w", err))
 				}
 				phaseCtx, cancelPhase = stepContext(ctx, resolvedStep.TimeoutMinutes)
 			} else if inheritedTimeout != nil {
 				phaseCtx, err = inheritedTimeout.context()
 				if err != nil {
-					return result, err
+					return failPre(err)
 				}
 			}
 			defer cancelPhase()
 			inputs, err := evaluate(step.With, eval)
 			if err != nil {
-				return result, err
+				return failPre(err)
 			}
 			inputs, err = resolveActionInputs(action, inputs, eval)
 			if err != nil {
-				return result, err
+				return failPre(err)
 			}
 			javascript.Inputs = inputs
 			javascript.Env = mergeStepEnvironment(jobEnv, stepEnv)
@@ -1807,14 +1811,13 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 			invocation.envOverlay = mergeStringMaps(inheritedEnvOverlay, stepEnv)
 			node, err := r.discoverNode(phaseCtx, major, explicit)
 			if err != nil {
-				return result, err
+				return failPre(err)
 			}
 			invocation.node = node
 			posts.register(postForInvocation(invocation, action.Runs.PostIf))
 			invocation.postRegistered = true
 			if err := r.runJavaScriptPhase(phaseCtx, processor, workspace, node, javascript, javascript.Pre, nil, invocation.state, &result); err != nil {
-				invocation.preFailure = err
-				return result, err
+				return failPre(err)
 			}
 		}
 		return result, nil
@@ -1852,6 +1855,7 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 			child := plan.Step{ID: childStep.ID, Name: childStep.Name, Kind: "uses", Uses: childStep.Uses, With: childStep.With, Env: childStep.Env, Action: &plan.ActionSelector{Lock: selector.Lock}}
 			childProcessEnv := mergeStepEnvironment(compositeProcessEnv, result.Env)
 			eval.Env = mergeStringMaps(compositeExpressionEnv, result.Env)
+			wasUnsuccessful := status.unsuccessful
 			childResult, childErr := r.prepareRemoteAction(ctx, processor, workspace, child, fmt.Sprintf("%s/%d", invocationID, i), childProcessEnv, eval, posts, actions, prepared, status, false, compositeEvalErr, preparationTimeout, lifecycleEnvOverlay)
 			mergeInto(result.Env, childResult.Env)
 			if childResult.pathBaseSet {
@@ -1867,6 +1871,8 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 				if execution.conclusion != "success" {
 					status.unsuccessful = true
 					err = errors.Join(err, fmt.Errorf("composite action step %d: %w", i+1, childErr))
+				} else {
+					status.unsuccessful = wasUnsuccessful
 				}
 			}
 		}
@@ -2061,9 +2067,6 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 			javascript.Inputs = inputs
 			javascript.Env = environment.process()
 			invocation.action = javascript
-			if invocation.preFailure != nil {
-				return result, invocation.preFailure
-			}
 		}
 		lifecycleEval := cloneExpressionContext(eval)
 		bindHashFilesContext(ctx, &lifecycleEval)
@@ -2077,6 +2080,11 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 			// map. Retain that map so post-if sees its final state without
 			// exposing workflow or sibling-composite steps.
 			lifecycleEval.Steps = eval.Steps
+		}
+		if invocation != nil && invocation.preFailure != nil {
+			invocation.eval = lifecycleEval
+			invocation.envOverlay = lifecycleEnvOverlay
+			return result, invocation.preFailure
 		}
 		if invocation == nil {
 			invocation = &preparedInvocation{action: javascript, state: state, node: node, eval: lifecycleEval, envOverlay: lifecycleEnvOverlay, isolated: isolated}

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -2182,7 +2182,14 @@ func (r Runner) runCompositeMetadata(ctx context.Context, processor *commandProc
 		condition := expression.ConditionContext{Inputs: inputs, Needs: eval.Needs, Steps: eval.Steps, Env: eval.Env, Vars: eval.Vars, Matrix: eval.Matrix, GitHub: eval.GitHub, Runner: eval.Runner, Services: eval.Services, Failure: failure, Unsuccessful: unsuccessful, Cancelled: cancelled}
 		run, err := expression.EvaluateCondition(step.If, condition)
 		if err != nil {
-			runErr = errors.Join(runErr, fmt.Errorf("composite action step %d condition: %w", i+1, err))
+			childErr := fmt.Errorf("composite action step %d condition: %w", i+1, err)
+			execution := classifyStepExecution(ctx, ctx, plan.Step{ContinueOnError: step.ContinueOnError}, newResult(), childErr)
+			if id != "" {
+				eval.Steps[id] = expression.StepStatus{Outcome: execution.outcome, Conclusion: execution.conclusion, Outputs: map[string]string{}}
+			}
+			if execution.conclusion != "success" {
+				runErr = errors.Join(runErr, childErr)
+			}
 			continue
 		}
 		if !run {

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -2235,14 +2235,11 @@ func (r Runner) runCompositeMetadata(ctx context.Context, processor *commandProc
 		result.Artifacts = append(result.Artifacts, stepResult.Artifacts...)
 		mergeInto(result.State, stepResult.State)
 		appendJobSummary(&result.Summary, &result.summaryTruncated, stepResult.Summary, stepResult.summaryTruncated)
+		execution := classifyStepExecution(ctx, ctx, plan.Step{ContinueOnError: step.ContinueOnError}, stepResult, childErr)
 		if id != "" {
-			outcome := "success"
-			if childErr != nil {
-				outcome = "failure"
-			}
-			eval.Steps[id] = expression.StepStatus{Outcome: outcome, Conclusion: outcome, Outputs: stepResult.Outputs}
+			eval.Steps[id] = expression.StepStatus{Outcome: execution.outcome, Conclusion: execution.conclusion, Outputs: stepResult.Outputs}
 		}
-		if childErr != nil {
+		if execution.conclusion != "success" {
 			runErr = errors.Join(runErr, fmt.Errorf("composite action step %d: %w", i+1, childErr))
 		}
 	}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -5676,7 +5676,7 @@ func TestRemoteCompositeSoftPreFailurePreservesSuccessForLaterPre(t *testing.T) 
 	workflowPath := ".github/workflows/test.yml"
 	writeFixtureFile(t, workspace, workflowPath, "name: softened composite pre failure\n")
 	remote := t.TempDir()
-	writeFixtureFile(t, remote, "parent/action.yml", "name: parent\nruns:\n  using: composite\n  steps:\n    - uses: owner/repo/child@v1\n")
+	writeFixtureFile(t, remote, "parent/action.yml", "name: parent\noutputs:\n  status:\n    value: ${{ steps.child.outcome }}-${{ steps.child.conclusion }}\nruns:\n  using: composite\n  steps:\n    - id: child\n      uses: owner/repo/child@v1\n      continue-on-error: true\n    - shell: sh\n      run: touch \"$COMPOSITE_MARKER\"\n")
 	writeFixtureFile(t, remote, "child/action.yml", "name: child\nruns:\n  using: node24\n  pre: pre.js\n  main: main.js\n")
 	writeFixtureFile(t, remote, "child/pre.js", "")
 	writeFixtureFile(t, remote, "child/main.js", "")
@@ -5684,6 +5684,8 @@ func TestRemoteCompositeSoftPreFailurePreservesSuccessForLaterPre(t *testing.T) 
 	writeFixtureFile(t, remote, "after/pre.js", "")
 	writeFixtureFile(t, remote, "after/main.js", "")
 	marker := filepath.Join(workspace, "observed")
+	compositeMarker := filepath.Join(workspace, "composite-observed")
+	childMainMarker := filepath.Join(workspace, "child-main-observed")
 	fakeNode := filepath.Join(workspace, "node24")
 	writeFixtureFile(t, workspace, "node24", `#!/bin/sh
 set -eu
@@ -5691,6 +5693,7 @@ if [ "${1:-}" = --version ]; then echo v24.0.0; exit 0; fi
 action=$(basename "$(dirname "$1")")
 phase=$(basename "$1" .js)
 if [ "$action:$phase" = child:pre ]; then exit 7; fi
+if [ "$action:$phase" = child:main ]; then touch "$CHILD_MAIN_MARKER"; fi
 if [ "$action:$phase" = after:pre ]; then touch "$MARKER"; fi
 `)
 	if err := os.Chmod(fakeNode, 0o700); err != nil {
@@ -5704,7 +5707,8 @@ if [ "$action:$phase" = after:pre ]; then touch "$MARKER"; fi
 	})
 	job.Schema = plan.Schema
 	job.RequiredCapabilities = []string{"network"}
-	job.Env = map[string]string{"MARKER": marker}
+	job.Env = map[string]string{"MARKER": marker, "COMPOSITE_MARKER": compositeMarker, "CHILD_MAIN_MARKER": childMainMarker}
+	job.Outputs = map[string]string{"status": "${{ steps.parent.outputs.status }}"}
 	job.Actions = []plan.ActionLock{
 		remoteLifecycleLock(parentID, "parent", digest, map[string]plan.ActionSelector{remoteLifecycleUses("child"): {Lock: childID}}),
 		remoteLifecycleLock(childID, "child", digest, nil),
@@ -5717,6 +5721,15 @@ if [ "$action:$phase" = after:pre ]; then touch "$MARKER"; fi
 	}
 	if _, err := os.Stat(marker); err != nil {
 		t.Fatalf("later success pre did not run: %v", err)
+	}
+	if result.Outputs["status"] != "failure-success" {
+		t.Fatalf("RunJob() outputs = %#v, want retained child pre-failure status", result.Outputs)
+	}
+	if _, err := os.Stat(compositeMarker); err != nil {
+		t.Fatalf("later composite step did not run: %v", err)
+	}
+	if _, err := os.Stat(childMainMarker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("child main ran after its pre failed: %v", err)
 	}
 }
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -5883,6 +5883,40 @@ runs:
 	}
 }
 
+func TestCompositeContinueOnErrorPreservesOutcomeAndRunsLaterSteps(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	writeFixtureFile(t, workspace, ".github/actions/soft-failure/action.yml", `name: Soft failure composite
+outputs:
+  status:
+    value: ${{ steps.failed.outcome }}-${{ steps.failed.conclusion }}
+runs:
+  using: composite
+  steps:
+    - id: failed
+      shell: sh
+      run: exit 7
+      continue-on-error: true
+    - shell: sh
+      run: touch "$LATER_STEP_RAN"
+`)
+	laterStep := filepath.Join(workspace, "later-step-ran")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "composite", Kind: "uses", Uses: "./.github/actions/soft-failure"}})
+	job.Env = map[string]string{"LATER_STEP_RAN": laterStep}
+	job.Outputs = map[string]string{"status": "${{ steps.composite.outputs.status }}"}
+	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v, want soft composite failure", result, err)
+	}
+	if result.Outputs["status"] != "failure-success" {
+		t.Fatalf("RunJob() outputs = %#v, want retained soft-failure status", result.Outputs)
+	}
+	if _, statErr := os.Stat(laterStep); statErr != nil {
+		t.Fatalf("later composite step did not run: %v", statErr)
+	}
+}
+
 func TestCompositeChildConditionUsesActionInputs(t *testing.T) {
 	for _, enabled := range []string{"true", "false"} {
 		t.Run(enabled, func(t *testing.T) {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -5676,16 +5676,18 @@ func TestRemoteCompositeSoftPreFailurePreservesSuccessForLaterPre(t *testing.T) 
 	workflowPath := ".github/workflows/test.yml"
 	writeFixtureFile(t, workspace, workflowPath, "name: softened composite pre failure\n")
 	remote := t.TempDir()
-	writeFixtureFile(t, remote, "parent/action.yml", "name: parent\noutputs:\n  status:\n    value: ${{ steps.child.outcome }}-${{ steps.child.conclusion }}\nruns:\n  using: composite\n  steps:\n    - id: child\n      uses: owner/repo/child@v1\n      continue-on-error: true\n    - shell: sh\n      run: touch \"$COMPOSITE_MARKER\"\n")
-	writeFixtureFile(t, remote, "child/action.yml", "name: child\nruns:\n  using: node24\n  pre: pre.js\n  main: main.js\n")
+	writeFixtureFile(t, remote, "parent/action.yml", "name: parent\noutputs:\n  status:\n    value: ${{ steps.child.outcome }}-${{ steps.child.conclusion }}\nruns:\n  using: composite\n  steps:\n    - id: child\n      uses: owner/repo/child@v1\n      continue-on-error: true\n    - id: finalize\n      shell: sh\n      run: touch \"$COMPOSITE_MARKER\"\n")
+	writeFixtureFile(t, remote, "child/action.yml", "name: child\nruns:\n  using: node24\n  pre: pre.js\n  main: main.js\n  post: post.js\n  post-if: steps.finalize.conclusion == 'success'\n")
 	writeFixtureFile(t, remote, "child/pre.js", "")
 	writeFixtureFile(t, remote, "child/main.js", "")
+	writeFixtureFile(t, remote, "child/post.js", "")
 	writeFixtureFile(t, remote, "after/action.yml", "name: after\nruns:\n  using: node24\n  pre: pre.js\n  pre-if: success()\n  main: main.js\n")
 	writeFixtureFile(t, remote, "after/pre.js", "")
 	writeFixtureFile(t, remote, "after/main.js", "")
 	marker := filepath.Join(workspace, "observed")
 	compositeMarker := filepath.Join(workspace, "composite-observed")
 	childMainMarker := filepath.Join(workspace, "child-main-observed")
+	childPostMarker := filepath.Join(workspace, "child-post-observed")
 	fakeNode := filepath.Join(workspace, "node24")
 	writeFixtureFile(t, workspace, "node24", `#!/bin/sh
 set -eu
@@ -5694,6 +5696,7 @@ action=$(basename "$(dirname "$1")")
 phase=$(basename "$1" .js)
 if [ "$action:$phase" = child:pre ]; then exit 7; fi
 if [ "$action:$phase" = child:main ]; then touch "$CHILD_MAIN_MARKER"; fi
+if [ "$action:$phase" = child:post ]; then touch "$CHILD_POST_MARKER"; fi
 if [ "$action:$phase" = after:pre ]; then touch "$MARKER"; fi
 `)
 	if err := os.Chmod(fakeNode, 0o700); err != nil {
@@ -5707,7 +5710,7 @@ if [ "$action:$phase" = after:pre ]; then touch "$MARKER"; fi
 	})
 	job.Schema = plan.Schema
 	job.RequiredCapabilities = []string{"network"}
-	job.Env = map[string]string{"MARKER": marker, "COMPOSITE_MARKER": compositeMarker, "CHILD_MAIN_MARKER": childMainMarker}
+	job.Env = map[string]string{"MARKER": marker, "COMPOSITE_MARKER": compositeMarker, "CHILD_MAIN_MARKER": childMainMarker, "CHILD_POST_MARKER": childPostMarker}
 	job.Outputs = map[string]string{"status": "${{ steps.parent.outputs.status }}"}
 	job.Actions = []plan.ActionLock{
 		remoteLifecycleLock(parentID, "parent", digest, map[string]plan.ActionSelector{remoteLifecycleUses("child"): {Lock: childID}}),
@@ -5730,6 +5733,101 @@ if [ "$action:$phase" = after:pre ]; then touch "$MARKER"; fi
 	}
 	if _, err := os.Stat(childMainMarker); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("child main ran after its pre failed: %v", err)
+	}
+	if _, err := os.Stat(childPostMarker); err != nil {
+		t.Fatalf("child post did not see the final composite step status: %v", err)
+	}
+}
+
+func TestRemoteCompositeSoftPreIfFailureSkipsMain(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: softened composite pre-if failure\n")
+	remote := t.TempDir()
+	writeFixtureFile(t, remote, "parent/action.yml", "name: parent\nruns:\n  using: composite\n  steps:\n    - uses: owner/repo/child@v1\n      continue-on-error: true\n    - shell: sh\n      run: touch \"$LATER_STEP_MARKER\"\n")
+	writeFixtureFile(t, remote, "child/action.yml", "name: child\nruns:\n  using: node24\n  pre: pre.js\n  pre-if: runner.debug == 'true'\n  main: main.js\n")
+	writeFixtureFile(t, remote, "child/pre.js", "")
+	writeFixtureFile(t, remote, "child/main.js", "")
+	laterStepMarker := filepath.Join(workspace, "later-step-observed")
+	childMainMarker := filepath.Join(workspace, "child-main-observed")
+	fakeNode := filepath.Join(workspace, "node24")
+	writeFixtureFile(t, workspace, "node24", `#!/bin/sh
+set -eu
+if [ "${1:-}" = --version ]; then echo v24.0.0; exit 0; fi
+action=$(basename "$(dirname "$1")")
+phase=$(basename "$1" .js)
+if [ "$action:$phase" = child:main ]; then touch "$CHILD_MAIN_MARKER"; fi
+`)
+	if err := os.Chmod(fakeNode, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	digest := digestTree(t, remote)
+	parentID, childID := remoteLifecycleLockID(1), remoteLifecycleLockID(2)
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "parent", Kind: "uses", Uses: remoteLifecycleUses("parent"), Action: &plan.ActionSelector{Lock: parentID}}})
+	job.Schema = plan.Schema
+	job.RequiredCapabilities = []string{"network"}
+	job.Env = map[string]string{"LATER_STEP_MARKER": laterStepMarker, "CHILD_MAIN_MARKER": childMainMarker}
+	job.Actions = []plan.ActionLock{
+		remoteLifecycleLock(parentID, "parent", digest, map[string]plan.ActionSelector{remoteLifecycleUses("child"): {Lock: childID}}),
+		remoteLifecycleLock(childID, "child", digest, nil),
+	}
+	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}
+	result, err := (Runner{Node24: fakeNode, Actions: materializer}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	if _, err := os.Stat(laterStepMarker); err != nil {
+		t.Fatalf("later composite step did not run: %v", err)
+	}
+	if _, err := os.Stat(childMainMarker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("child main ran after its pre-if failed: %v", err)
+	}
+}
+
+func TestRemoteCompositeSoftNestedPreparationFailurePreservesSuccessForLaterPre(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: softened nested composite preparation failure\n")
+	remote := t.TempDir()
+	writeFixtureFile(t, remote, "parent/action.yml", "name: parent\nruns:\n  using: composite\n  steps:\n    - uses: owner/repo/nested@v1\n      continue-on-error: true\n    - uses: owner/repo/after@v1\n")
+	writeFixtureFile(t, remote, "nested/action.yml", "name: nested\nruns:\n  using: composite\n  steps:\n    - uses: owner/repo/child@v1\n")
+	writeFixtureFile(t, remote, "child/action.yml", "name: child\nruns:\n  using: node24\n  pre: pre.js\n  main: main.js\n")
+	writeFixtureFile(t, remote, "after/action.yml", "name: after\nruns:\n  using: node24\n  pre: pre.js\n  pre-if: success()\n  main: main.js\n")
+	for _, path := range []string{"child/pre.js", "child/main.js", "after/pre.js", "after/main.js"} {
+		writeFixtureFile(t, remote, path, "")
+	}
+	marker := filepath.Join(workspace, "later-pre-observed")
+	fakeNode := filepath.Join(workspace, "node24")
+	writeFixtureFile(t, workspace, "node24", `#!/bin/sh
+set -eu
+if [ "${1:-}" = --version ]; then echo v24.0.0; exit 0; fi
+action=$(basename "$(dirname "$1")")
+phase=$(basename "$1" .js)
+if [ "$action:$phase" = child:pre ]; then exit 7; fi
+if [ "$action:$phase" = after:pre ]; then touch "$MARKER"; fi
+`)
+	if err := os.Chmod(fakeNode, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	digest := digestTree(t, remote)
+	parentID, nestedID, childID, afterID := remoteLifecycleLockID(1), remoteLifecycleLockID(2), remoteLifecycleLockID(3), remoteLifecycleLockID(4)
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "parent", Kind: "uses", Uses: remoteLifecycleUses("parent"), Action: &plan.ActionSelector{Lock: parentID}}})
+	job.Schema = plan.Schema
+	job.RequiredCapabilities = []string{"network"}
+	job.Env = map[string]string{"MARKER": marker}
+	job.Actions = []plan.ActionLock{
+		remoteLifecycleLock(parentID, "parent", digest, map[string]plan.ActionSelector{remoteLifecycleUses("nested"): {Lock: nestedID}, remoteLifecycleUses("after"): {Lock: afterID}}),
+		remoteLifecycleLock(nestedID, "nested", digest, map[string]plan.ActionSelector{remoteLifecycleUses("child"): {Lock: childID}}),
+		remoteLifecycleLock(childID, "child", digest, nil),
+		remoteLifecycleLock(afterID, "after", digest, nil),
+	}
+	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}
+	result, err := (Runner{Node24: fakeNode, Actions: materializer}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("later pre-if: success() did not run: %v", err)
 	}
 }
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -5784,6 +5784,56 @@ if [ "$action:$phase" = child:main ]; then touch "$CHILD_MAIN_MARKER"; fi
 	}
 }
 
+func TestRemoteCompositeSoftConditionFailureBindsPostToFinalStepState(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: softened composite condition failure post scope\n")
+	remote := t.TempDir()
+	writeFixtureFile(t, remote, "parent/action.yml", "name: parent\nruns:\n  using: composite\n  steps:\n    - id: child\n      if: runner.debug == 'true'\n      uses: owner/repo/child@v1\n      continue-on-error: true\n    - id: finalize\n      shell: sh\n      run: touch \"$FINALIZE_MARKER\"\n")
+	writeFixtureFile(t, remote, "child/action.yml", "name: child\nruns:\n  using: node24\n  pre: pre.js\n  main: main.js\n  post: post.js\n  post-if: steps.finalize.conclusion == 'success'\n")
+	for _, path := range []string{"child/pre.js", "child/main.js", "child/post.js"} {
+		writeFixtureFile(t, remote, path, "")
+	}
+	finalizeMarker := filepath.Join(workspace, "finalize-observed")
+	postMarker := filepath.Join(workspace, "post-observed")
+	mainMarker := filepath.Join(workspace, "main-observed")
+	fakeNode := filepath.Join(workspace, "node24")
+	writeFixtureFile(t, workspace, "node24", `#!/bin/sh
+set -eu
+if [ "${1:-}" = --version ]; then echo v24.0.0; exit 0; fi
+action=$(basename "$(dirname "$1")")
+phase=$(basename "$1" .js)
+if [ "$action:$phase" = child:main ]; then touch "$MAIN_MARKER"; fi
+if [ "$action:$phase" = child:post ]; then touch "$POST_MARKER"; fi
+`)
+	if err := os.Chmod(fakeNode, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	digest := digestTree(t, remote)
+	parentID, childID := remoteLifecycleLockID(1), remoteLifecycleLockID(2)
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "parent", Kind: "uses", Uses: remoteLifecycleUses("parent"), Action: &plan.ActionSelector{Lock: parentID}}})
+	job.Schema = plan.Schema
+	job.RequiredCapabilities = []string{"network"}
+	job.Env = map[string]string{"FINALIZE_MARKER": finalizeMarker, "MAIN_MARKER": mainMarker, "POST_MARKER": postMarker}
+	job.Actions = []plan.ActionLock{
+		remoteLifecycleLock(parentID, "parent", digest, map[string]plan.ActionSelector{remoteLifecycleUses("child"): {Lock: childID}}),
+		remoteLifecycleLock(childID, "child", digest, nil),
+	}
+	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}
+	result, err := (Runner{Node24: fakeNode, Actions: materializer}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	for _, path := range []string{finalizeMarker, postMarker} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected marker %q: %v", path, err)
+		}
+	}
+	if _, err := os.Stat(mainMarker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("condition-failed child main ran: %v", err)
+	}
+}
+
 func TestRemoteCompositeSoftNestedPreparationFailurePreservesSuccessForLaterPre(t *testing.T) {
 	workspace := t.TempDir()
 	workflowPath := ".github/workflows/test.yml"

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -6028,6 +6028,45 @@ runs:
 	}
 }
 
+func TestCompositeContinueOnErrorToleratesConditionFailure(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	writeFixtureFile(t, workspace, ".github/actions/soft-condition/action.yml", `name: Soft condition failure composite
+outputs:
+  status:
+    value: ${{ steps.failed.outcome }}-${{ steps.failed.conclusion }}
+runs:
+  using: composite
+  steps:
+    - id: failed
+      if: runner.debug == 'true'
+      shell: sh
+      run: touch "$SHOULD_NOT_RUN"
+      continue-on-error: true
+    - shell: sh
+      run: touch "$LATER_STEP_RAN"
+`)
+	laterStep := filepath.Join(workspace, "later-step-ran")
+	shouldNotRun := filepath.Join(workspace, "should-not-run")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "composite", Kind: "uses", Uses: "./.github/actions/soft-condition"}})
+	job.Env = map[string]string{"LATER_STEP_RAN": laterStep, "SHOULD_NOT_RUN": shouldNotRun}
+	job.Outputs = map[string]string{"status": "${{ steps.composite.outputs.status }}"}
+	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v, want soft condition failure", result, err)
+	}
+	if result.Outputs["status"] != "failure-success" {
+		t.Fatalf("RunJob() outputs = %#v, want retained soft-failure status", result.Outputs)
+	}
+	if _, statErr := os.Stat(laterStep); statErr != nil {
+		t.Fatalf("later composite step did not run: %v", statErr)
+	}
+	if _, statErr := os.Stat(shouldNotRun); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("condition-failed child ran: %v", statErr)
+	}
+}
+
 func TestCompositeChildConditionUsesActionInputs(t *testing.T) {
 	for _, enabled := range []string{"true", "false"} {
 		t.Run(enabled, func(t *testing.T) {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -5108,7 +5108,7 @@ func TestExpressionTimeoutBoundsNestedCompositePre(t *testing.T) {
 	workflowPath := ".github/workflows/test.yml"
 	writeFixtureFile(t, workspace, workflowPath, "name: nested pre timeout\n")
 	remote := t.TempDir()
-	writeFixtureFile(t, remote, "root/action.yml", "name: root\nruns:\n  using: composite\n  steps:\n    - uses: "+remoteLifecycleUses("child")+"\n")
+	writeFixtureFile(t, remote, "root/action.yml", "name: root\nruns:\n  using: composite\n  steps:\n    - uses: "+remoteLifecycleUses("child")+"\n      continue-on-error: true\n")
 	writeFixtureFile(t, remote, "child/action.yml", "name: child\nruns:\n  using: node24\n  pre: pre.js\n  main: main.js\n")
 	writeFixtureFile(t, remote, "child/pre.js", "")
 	writeFixtureFile(t, remote, "child/main.js", "")
@@ -5676,7 +5676,7 @@ func TestRemoteCompositeSoftPreFailurePreservesSuccessForLaterPre(t *testing.T) 
 	workflowPath := ".github/workflows/test.yml"
 	writeFixtureFile(t, workspace, workflowPath, "name: softened composite pre failure\n")
 	remote := t.TempDir()
-	writeFixtureFile(t, remote, "parent/action.yml", "name: parent\noutputs:\n  status:\n    value: ${{ steps.child.outcome }}-${{ steps.child.conclusion }}\nruns:\n  using: composite\n  steps:\n    - id: child\n      uses: owner/repo/child@v1\n      continue-on-error: true\n    - id: finalize\n      shell: sh\n      run: touch \"$COMPOSITE_MARKER\"\n")
+	writeFixtureFile(t, remote, "parent/action.yml", "name: parent\noutputs:\n  status:\n    value: ${{ steps.child.outcome }}-${{ steps.child.conclusion }}\nruns:\n  using: composite\n  steps:\n    - id: child\n      if: false\n      uses: owner/repo/child@v1\n      continue-on-error: true\n    - id: finalize\n      shell: sh\n      run: touch \"$COMPOSITE_MARKER\"\n")
 	writeFixtureFile(t, remote, "child/action.yml", "name: child\nruns:\n  using: node24\n  pre: pre.js\n  main: main.js\n  post: post.js\n  post-if: steps.finalize.conclusion == 'success'\n")
 	writeFixtureFile(t, remote, "child/pre.js", "")
 	writeFixtureFile(t, remote, "child/main.js", "")


### PR DESCRIPTION
## Summary

Support literal `continue-on-error` on composite action steps. This allows compatible composite actions, including `dtolnay/rust-toolchain`, to resolve instead of failing metadata validation.

Before this change, affected workflows failed with:

```text
[E_ACTION_RESOLUTION] Action "dtolnay/rust-toolchain@stable" is unsupported: action metadata uses unsupported field "continue-on-error" at line 101 {job=test, step=2}
```

A tolerated child failure retains `outcome: failure` and reports `conclusion: success`, allowing later composite steps to run.

## Testing

- `mise exec -- go test ./internal/compiler ./internal/action/metadata`
- `mise exec -- go test ./internal/runtime -run 'TestComposite(ContinueOnErrorPreservesOutcomeAndRunsLaterSteps|ConditionsRunAfterFailureAndPreserveFailure)$'