### PR TITLE
PB-2962: Support compound expressions in composite run steps

### DIFF
--- a/internal/runtime/hash_files_test.go
+++ b/internal/runtime/hash_files_test.go
@@ -237,7 +237,7 @@ func TestHashFilesRemainsUnavailableOutsideWorkflowStepFields(t *testing.T) {
 
 	writeFixtureFile(t, workspace, ".github/actions/composite/action.yml", "runs:\n  using: composite\n  steps:\n    - shell: sh\n      run: echo \"${{ hashFiles('value') }}\"\n")
 	job = runtimePlan(t, workspace, ".github/workflows/test.yml", []plan.Step{{ID: "composite", Kind: "uses", Uses: "./.github/actions/composite"}})
-	if _, err := (Runner{}).RunJob(context.Background(), job, workspace); err == nil || !strings.Contains(err.Error(), "unsupported expression reference") {
+	if _, err := (Runner{}).RunJob(context.Background(), job, workspace); err == nil || !strings.Contains(err.Error(), `runtime function "hashFiles" is unavailable`) {
 		t.Fatalf("composite metadata hashFiles error = %v", err)
 	}
 

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -2213,7 +2213,7 @@ func (r Runner) runCompositeMetadata(ctx context.Context, processor *commandProc
 			var env map[string]string
 			env, childErr = evaluateMap(step.Env, eval)
 			if childErr == nil {
-				script, childErr = expression.Evaluate(step.Run, eval)
+				script, childErr = expression.EvaluateStep(step.Run, eval)
 			}
 			if childErr == nil {
 				dir, childErr = workspacePath(workspace, step.WorkingDirectory)

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -5918,6 +5918,44 @@ runs:
 	}
 }
 
+func TestCompositeRunSupportsCompoundInputExpression(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	writeFixtureFile(t, workspace, ".github/actions/rust/action.yml", `name: Rust setup expression
+inputs:
+  toolchain:
+    required: false
+  components:
+    required: false
+runs:
+  using: composite
+  steps:
+    - shell: sh
+      run: echo "downgrade=${{contains(inputs.toolchain, 'nightly') && inputs.components && ' --allow-downgrade' || ''}}" > "$RESULT"
+`)
+	output := filepath.Join(workspace, "result")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{
+		ID:   "rust",
+		Kind: "uses",
+		Uses: "./.github/actions/rust",
+		With: map[string]string{"toolchain": "nightly", "components": "rustfmt"},
+	}})
+	job.Env = map[string]string{"RESULT": output}
+
+	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	contents, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(contents), "downgrade= --allow-downgrade\n"; got != want {
+		t.Fatalf("compound composite run expression = %q, want %q", got, want)
+	}
+}
+
 func TestRuntimeRejectsRecursiveAndOverDepthCompositeActions(t *testing.T) {
 	workspace := t.TempDir()
 	workflowPath := ".github/workflows/test.yml"


### PR DESCRIPTION
## Root cause

[starter-workflows-unified-test build 10](https://buildkite.com/buildkite-github-actions/starter-workflows-unified-test/builds/10) reaches `actions-rust-lang/setup-rust-toolchain@v1` after the PB-2962 lifecycle-expression work, then fails in composite step 2 (`id: flags`) on:

```yaml
${{ contains(inputs.toolchain, 'nightly') && inputs.components && ' --allow-downgrade' || '' }}
```

Composite action `run` fields used the direct-reference-only runtime evaluator. The function call and logical operators therefore returned `unsupported expression reference`, even though GitHub Actions supports this expression surface and ordinary workflow `run` fields already use the full step evaluator.

## Implementation

Evaluate composite action `run` scripts with the existing step-expression evaluator. This supports compound expressions without broadening unrelated expression surfaces. Composite metadata still cannot call `hashFiles()`; its error is now the specific unavailable-function diagnostic.

## Regression coverage

- Added an end-to-end composite action runtime test using the exact `setup-rust-toolchain` expression.
- Verifies the nightly toolchain and components inputs resolve to ` --allow-downgrade`.
- Updated the existing composite `hashFiles()` restriction assertion for the more specific diagnostic.

## Verification

`mise run check` passed in full:

- formatting
- Linux and macOS builds
- unit tests
- race tests
- Go lint and vet
- shellcheck
- local smoke tests
- release configuration checks
