### PR TITLE
Show trigger events for skipped workflows

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -102,11 +102,11 @@ All remaining runnable workflows use one artifact and pipeline transaction:
 - GitHub events publish GitHub checks. Origin events publish Origin checks.
 - A workflow that does not declare the event becomes one top-level skipped step
   with no plan artifacts.
-- An importer annotation lists workflows skipped by event or filters, their
-  configured events, and each mismatch, then links to the generated step. For
-  manual builds, it explains the `workflow_dispatch` mapping and how to run the
-  workflows. It also states when every workflow was skipped. If publication
-  fails, upload warns but still succeeds.
+- An importer annotation links to each workflow skipped by event or filters. It
+  shows configured events for event mismatches and the specific reason for
+  filter mismatches. For manual builds, it explains the `workflow_dispatch`
+  mapping and how to run the workflows. It also states when every workflow was
+  skipped. If publication fails, upload warns but still succeeds.
 
 Workflow names, group keys, and provider-check names stay the same across
 events; only an appended run title can vary. Groups and replacement steps

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -102,9 +102,11 @@ All remaining runnable workflows use one artifact and pipeline transaction:
 - GitHub events publish GitHub checks. Origin events publish Origin checks.
 - A workflow that does not declare the event becomes one top-level skipped step
   with no plan artifacts.
-- An importer annotation lists workflows skipped by event or filters, explains
-  each mismatch, and links to the generated step. If publication fails, upload
-  warns but still succeeds.
+- An importer annotation lists workflows skipped by event or filters, their
+  configured events, and each mismatch, then links to the generated step. For
+  manual builds, it explains the `workflow_dispatch` mapping and how to run the
+  workflows. It also states when every workflow was skipped. If publication
+  fails, upload warns but still succeeds.
 
 Workflow names, group keys, and provider-check names stay the same across
 events; only an appended run title can vary. Groups and replacement steps

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1490,7 +1490,7 @@ func TestProcessingAnnotationsUseActiveBoundedContext(t *testing.T) {
 		{
 			name: "skipped workflow",
 			publish: func(ctx context.Context, out processingOutput) {
-				out.annotateSkippedWorkflows(ctx, "push", []skippedWorkflow{{label: "CI", key: "ci", reason: "not applicable"}})
+				out.annotateSkippedWorkflows(ctx, "push", "", true, []skippedWorkflow{{label: "CI", key: "ci", reason: "not applicable"}})
 			},
 		},
 	} {

--- a/internal/cli/effective_event.go
+++ b/internal/cli/effective_event.go
@@ -30,6 +30,7 @@ type effectiveEventSelection struct {
 	Source             []byte
 	Event              compiler.Event
 	Origin             effectiveEventOrigin
+	BuildSource        string
 	TriggerExpressions buildkitepipeline.TriggerConditionExpressions
 	TriggerSnapshot    buildkitepipeline.TriggerEventSnapshot
 }
@@ -71,6 +72,9 @@ func newEffectiveEvent(source []byte, origin effectiveEventOrigin) (effectiveEve
 		return effective, nil
 	}
 	effective.TriggerExpressions.EventPredicate = buildkitepipeline.LiveEventPredicate(event.Event)
+	if origin == effectiveEventFromBuild {
+		effective.BuildSource = strings.TrimSpace(os.Getenv("BUILDKITE_SOURCE"))
+	}
 	return effective, nil
 }
 

--- a/internal/cli/effective_event_test.go
+++ b/internal/cli/effective_event_test.go
@@ -39,7 +39,16 @@ func TestNewEffectiveEventSeparatesExpressionsAndSnapshot(t *testing.T) {
 		t.Fatal(err)
 	}
 	wantExpressions.EventPredicate = buildkitepipeline.LiveEventPredicate("push")
-	if !reflect.DeepEqual(webhook.TriggerExpressions, wantExpressions) || !reflect.DeepEqual(webhook.TriggerSnapshot, wantSnapshot) {
+	if !reflect.DeepEqual(webhook.TriggerExpressions, wantExpressions) || !reflect.DeepEqual(webhook.TriggerSnapshot, wantSnapshot) || webhook.BuildSource != "" {
 		t.Fatalf("webhook effective event = expressions %#v, snapshot %#v", webhook.TriggerExpressions, webhook.TriggerSnapshot)
+	}
+
+	t.Setenv("BUILDKITE_SOURCE", "ui")
+	build, err := newEffectiveEvent(source, effectiveEventFromBuild)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if build.BuildSource != "ui" || build.TriggerExpressions.EventPredicate != buildkitepipeline.LiveEventPredicate("push") {
+		t.Fatalf("build effective event = source %q, predicate %q", build.BuildSource, build.TriggerExpressions.EventPredicate)
 	}
 }

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -193,6 +193,7 @@ type skippedWorkflow struct {
 	label  string
 	key    string
 	reason string
+	events []string
 }
 
 func (o processingOutput) annotateSkippedWorkflows(parent context.Context, event string, workflows []skippedWorkflow) {
@@ -238,7 +239,15 @@ func skippedWorkflowsAnnotation(event string, workflows []skippedWorkflow, build
 		annotationURL := fmt.Sprintf("%s/canvas?key=%s&open=false", strings.TrimRight(buildURL, "/"), url.QueryEscape(workflow.key))
 		label := annotationHTML(strings.Join(strings.Fields(workflow.label), " "))
 		label = strings.NewReplacer("\\", "\\\\", "[", "\\[", "]", "\\]").Replace(label)
-		_, _ = fmt.Fprintf(&out, "* [:github: %s](%s) — %s\n", label, annotationURL, annotationHTML(workflow.reason))
+		events := ""
+		if len(workflow.events) > 0 {
+			escaped := make([]string, len(workflow.events))
+			for i, event := range workflow.events {
+				escaped[i] = annotationHTML(event)
+			}
+			events = " (" + strings.Join(escaped, ", ") + ")"
+		}
+		_, _ = fmt.Fprintf(&out, "* [:github: %s](%s)%s — %s\n", label, annotationURL, events, annotationHTML(workflow.reason))
 	}
 	return out.String()
 }

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -26,6 +26,7 @@ const (
 	processingAnnotationContext   = "buildkite-gha-processing"
 	skippedWorkflowsContext       = "buildkite-gha-skipped-workflows"
 	runnerResolutionContext       = "buildkite-gha-runner-resolution"
+	eventMappingDocumentationURL  = "https://github.com/buildkite/buildkite-gha/blob/main/docs/cli.md#select-the-effective-event"
 	processingAnnotationBodyLimit = 1024 * 1024
 	processingAnnotationNotice    = "\n_Additional diagnostics omitted at the Buildkite annotation size limit._\n"
 	processingAnnotationTimeout   = 5 * time.Second
@@ -196,8 +197,8 @@ type skippedWorkflow struct {
 	events []string
 }
 
-func (o processingOutput) annotateSkippedWorkflows(parent context.Context, event string, workflows []skippedWorkflow) {
-	body := skippedWorkflowsAnnotation(event, workflows, o.buildURL)
+func (o processingOutput) annotateSkippedWorkflows(parent context.Context, event, buildSource string, allSkipped bool, workflows []skippedWorkflow) {
+	body := skippedWorkflowsAnnotation(event, buildSource, allSkipped, workflows, o.buildURL)
 	if o.annotationJob == "" || body == "" {
 		return
 	}
@@ -224,17 +225,30 @@ func (o processingOutput) annotateRunnerResolutionWarnings(parent context.Contex
 	}
 }
 
-func skippedWorkflowsAnnotation(event string, workflows []skippedWorkflow, buildURL string) string {
+func skippedWorkflowsAnnotation(event, buildSource string, allSkipped bool, workflows []skippedWorkflow, buildURL string) string {
 	if len(workflows) == 0 || buildURL == "" {
 		return ""
 	}
 	var out strings.Builder
 	if len(workflows) == 1 {
-		out.WriteString("#### 1 workflow was skipped\n\n")
+		out.WriteString("#### 1 workflow was skipped")
 	} else {
-		_, _ = fmt.Fprintf(&out, "#### %d workflows were skipped\n\n", len(workflows))
+		_, _ = fmt.Fprintf(&out, "#### %d workflows were skipped", len(workflows))
 	}
-	_, _ = fmt.Fprintf(&out, "The current <code>%s</code> event does not match these workflows:\n\n", annotationHTML(event))
+	if allSkipped {
+		out.WriteString(", so this build ran nothing")
+	}
+	out.WriteString("\n\n")
+	if event == "workflow_dispatch" && (buildSource == "ui" || buildSource == "api") {
+		if buildSource == "ui" {
+			out.WriteString("You started this build from the Buildkite UI, which is a manual run. ")
+		} else {
+			out.WriteString("This build started through the Buildkite API. ")
+		}
+		out.WriteString("In GitHub Actions terms, this maps to a <code>workflow_dispatch</code> event, and these workflows don't accept it:\n\n")
+	} else {
+		_, _ = fmt.Fprintf(&out, "The current <code>%s</code> event does not match these workflows:\n\n", annotationHTML(event))
+	}
 	for _, workflow := range workflows {
 		annotationURL := fmt.Sprintf("%s/canvas?key=%s&open=false", strings.TrimRight(buildURL, "/"), url.QueryEscape(workflow.key))
 		label := annotationHTML(strings.Join(strings.Fields(workflow.label), " "))
@@ -248,6 +262,11 @@ func skippedWorkflowsAnnotation(event string, workflows []skippedWorkflow, build
 			events = " (" + strings.Join(escaped, ", ") + ")"
 		}
 		_, _ = fmt.Fprintf(&out, "* [:github: %s](%s)%s — %s\n", label, annotationURL, events, annotationHTML(workflow.reason))
+	}
+	if event == "workflow_dispatch" && (buildSource == "ui" || buildSource == "api") {
+		out.WriteString("\nPush a commit or open a pull request to run workflows configured for those events. ")
+		out.WriteString("Or add <code>workflow_dispatch:</code> to the <code>on:</code> block to make a workflow runnable from here. ")
+		_, _ = fmt.Fprintf(&out, "[Learn about event mapping →](%s)\n", eventMappingDocumentationURL)
 	}
 	return out.String()
 }

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -247,21 +247,25 @@ func skippedWorkflowsAnnotation(event, buildSource string, allSkipped bool, work
 		}
 		out.WriteString("In GitHub Actions terms, this maps to a <code>workflow_dispatch</code> event, and these workflows don't accept it:\n\n")
 	} else {
-		_, _ = fmt.Fprintf(&out, "The current <code>%s</code> event does not match these workflows:\n\n", annotationHTML(event))
+		_, _ = fmt.Fprintf(&out, "The current <code>%s</code> event does not match the following workflows:\n\n", annotationHTML(event))
 	}
 	for _, workflow := range workflows {
 		annotationURL := fmt.Sprintf("%s/canvas?key=%s&open=false", strings.TrimRight(buildURL, "/"), url.QueryEscape(workflow.key))
 		label := annotationHTML(strings.Join(strings.Fields(workflow.label), " "))
 		label = strings.NewReplacer("\\", "\\\\", "[", "\\[", "]", "\\]").Replace(label)
-		events := ""
+		detail := annotationHTML(workflow.reason)
 		if len(workflow.events) > 0 {
-			escaped := make([]string, len(workflow.events))
-			for i, event := range workflow.events {
-				escaped[i] = annotationHTML(event)
+			eventMatched := false
+			configuredEvents := make([]string, len(workflow.events))
+			for i, configuredEvent := range workflow.events {
+				eventMatched = eventMatched || configuredEvent == event
+				configuredEvents[i] = annotationCode(configuredEvent)
 			}
-			events = " (" + strings.Join(escaped, ", ") + ")"
+			if !eventMatched {
+				detail = "This workflow is triggered on: " + strings.Join(configuredEvents, ", ")
+			}
 		}
-		_, _ = fmt.Fprintf(&out, "* [:github: %s](%s)%s — %s\n", label, annotationURL, events, annotationHTML(workflow.reason))
+		_, _ = fmt.Fprintf(&out, "* [:github: %s](%s) — %s\n", label, annotationURL, detail)
 	}
 	if event == "workflow_dispatch" && (buildSource == "ui" || buildSource == "api") {
 		out.WriteString("\nPush a commit or open a pull request to run workflows configured for those events. ")

--- a/internal/cli/upload.go
+++ b/internal/cli/upload.go
@@ -500,6 +500,7 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 		artifactPaths[jobPlan.Path] = struct{}{}
 		artifacts = append(artifacts, transport.Artifact{Path: jobPlan.Path, Digest: jobPlan.Digest, Contents: jobPlan.Contents})
 	}
+	allSkipped := len(generatedWorkflows) > 0 && len(skippedWorkflows) == len(generatedWorkflows)
 	if len(artifacts) == 0 {
 		if err := agent.UploadPipeline(ctx, aggregatePipeline); err != nil {
 			if uploadArguments.telemetry != nil {
@@ -508,7 +509,7 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: upload pipeline: %v\n", err)
 			return 1
 		}
-		out.annotateSkippedWorkflows(ctx, effectiveEvent.Event.Event, skippedWorkflows)
+		out.annotateSkippedWorkflows(ctx, effectiveEvent.Event.Event, effectiveEvent.BuildSource, allSkipped, skippedWorkflows)
 		_, _ = fmt.Fprintf(stdout, "Uploaded %d jobs from %d workflows using %s with importer %s.\n", jobCount, len(generatedWorkflows), executablePath, importerStep)
 		return 0
 	}
@@ -530,7 +531,7 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
 		return 1
 	}
-	out.annotateSkippedWorkflows(ctx, effectiveEvent.Event.Event, skippedWorkflows)
+	out.annotateSkippedWorkflows(ctx, effectiveEvent.Event.Event, effectiveEvent.BuildSource, allSkipped, skippedWorkflows)
 	_, _ = fmt.Fprintf(stdout, "Uploaded %d jobs from %d workflows using %s with importer %s.\n", jobCount, len(generatedWorkflows), executablePath, importerStep)
 	return 0
 }

--- a/internal/cli/upload.go
+++ b/internal/cli/upload.go
@@ -369,6 +369,10 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 				checkName = input.CanonicalPath
 			}
 			label := workflowGroupLabel(checkName, input.RunName)
+			events := make([]string, len(input.Triggers))
+			for i, trigger := range input.Triggers {
+				events[i] = trigger.Event
+			}
 			groupKey := "gha-workflow-" + input.Identity
 			generatedWorkflows = append(generatedWorkflows, buildkitepipeline.Workflow{
 				GroupLabel: label,
@@ -377,7 +381,7 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 				Event:      effectiveEvent.Event.Event,
 				SkipReason: input.SkipReason,
 			})
-			skippedWorkflows = append(skippedWorkflows, skippedWorkflow{label: label, key: groupKey, reason: input.AnnotationReason})
+			skippedWorkflows = append(skippedWorkflows, skippedWorkflow{label: label, key: groupKey, reason: input.AnnotationReason, events: events})
 			parsed, _ := compiler.ParseWorkflow(input.Path, input.Source)
 			writeCompilerWarnings(stderr, "upload", input.CanonicalPath, parsed.Warnings)
 			if uploadArguments.telemetry != nil {
@@ -419,7 +423,11 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 		generated.Condition = input.TriggerCondition
 		generatedWorkflows = append(generatedWorkflows, generated)
 		if input.AnnotationReason != "" {
-			skippedWorkflows = append(skippedWorkflows, skippedWorkflow{label: label, key: generated.GroupKey, reason: input.AnnotationReason})
+			events := make([]string, len(input.Triggers))
+			for i, trigger := range input.Triggers {
+				events[i] = trigger.Event
+			}
+			skippedWorkflows = append(skippedWorkflows, skippedWorkflow{label: label, key: generated.GroupKey, reason: input.AnnotationReason, events: events})
 		}
 		planArtifacts = append(planArtifacts, bundle.Plans...)
 		jobCount += len(bundle.Plans)

--- a/internal/cli/upload_test.go
+++ b/internal/cli/upload_test.go
@@ -1475,7 +1475,7 @@ func TestRunUploadExplainsWhenNoWorkflowsApply(t *testing.T) {
 		t.Fatalf("ignored-only pipeline = %#v", pipeline.Steps)
 	}
 	wantAnnotationArgs := []string{"annotate", "--scope", "job", "--job", cliTestJobID, "--context", skippedWorkflowsContext, "--style", "info"}
-	wantWorkflows := []skippedWorkflow{{label: wantLabel, key: pipeline.Steps[0].Key, reason: "This workflow is not triggered by a `push` event"}}
+	wantWorkflows := []skippedWorkflow{{label: wantLabel, key: pipeline.Steps[0].Key, reason: "This workflow is not triggered by a `push` event", events: []string{"pull_request"}}}
 	if annotation == nil || !slices.Equal(annotation.args, wantAnnotationArgs) || string(annotation.stdin) != skippedWorkflowsAnnotation("push", wantWorkflows, "https://buildkite.com/acme/widgets/builds/42") {
 		t.Fatalf("skipped workflow annotation = %#v", annotation)
 	}
@@ -1523,21 +1523,21 @@ func TestSkippedWorkflowsAnnotation(t *testing.T) {
 	}{
 		{
 			name:      "singular",
-			workflows: []skippedWorkflow{{label: "CI", key: "gha-workflow-ci", reason: "This workflow is not triggered by a `push` event"}},
+			workflows: []skippedWorkflow{{label: "CI", key: "gha-workflow-ci", reason: "This workflow is not triggered by a `push` event", events: []string{"workflow_dispatch", "pull_request"}}},
 			want: "#### 1 workflow was skipped\n\n" +
 				"The current <code>push</code> event does not match these workflows:\n\n" +
-				"* [:github: CI](https://buildkite.com/acme/widgets/builds/42/canvas?key=gha-workflow-ci&open=false) — This workflow is not triggered by a `push` event\n",
+				"* [:github: CI](https://buildkite.com/acme/widgets/builds/42/canvas?key=gha-workflow-ci&open=false) (workflow_dispatch, pull_request) — This workflow is not triggered by a `push` event\n",
 		},
 		{
 			name: "plural",
 			workflows: []skippedWorkflow{
-				{label: "CI", key: "gha-workflow-ci", reason: "Only runs on `main` or `development`."},
-				{label: "Release [production]", key: "gha-workflow-release?production", reason: "This workflow is not triggered by a `push` event"},
+				{label: "CI", key: "gha-workflow-ci", reason: "Only runs on `main` or `development`.", events: []string{"push", "pull_request"}},
+				{label: "Release [production]", key: "gha-workflow-release?production", reason: "This workflow is not triggered by a `push` event", events: []string{"release"}},
 			},
 			want: "#### 2 workflows were skipped\n\n" +
 				"The current <code>push</code> event does not match these workflows:\n\n" +
-				"* [:github: CI](https://buildkite.com/acme/widgets/builds/42/canvas?key=gha-workflow-ci&open=false) — Only runs on `main` or `development`.\n" +
-				"* [:github: Release \\[production\\]](https://buildkite.com/acme/widgets/builds/42/canvas?key=gha-workflow-release%3Fproduction&open=false) — This workflow is not triggered by a `push` event\n",
+				"* [:github: CI](https://buildkite.com/acme/widgets/builds/42/canvas?key=gha-workflow-ci&open=false) (push, pull_request) — Only runs on `main` or `development`.\n" +
+				"* [:github: Release \\[production\\]](https://buildkite.com/acme/widgets/builds/42/canvas?key=gha-workflow-release%3Fproduction&open=false) (release) — This workflow is not triggered by a `push` event\n",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/cli/upload_test.go
+++ b/internal/cli/upload_test.go
@@ -1476,7 +1476,7 @@ func TestRunUploadExplainsWhenNoWorkflowsApply(t *testing.T) {
 	}
 	wantAnnotationArgs := []string{"annotate", "--scope", "job", "--job", cliTestJobID, "--context", skippedWorkflowsContext, "--style", "info"}
 	wantWorkflows := []skippedWorkflow{{label: wantLabel, key: pipeline.Steps[0].Key, reason: "This workflow is not triggered by a `push` event", events: []string{"pull_request"}}}
-	if annotation == nil || !slices.Equal(annotation.args, wantAnnotationArgs) || string(annotation.stdin) != skippedWorkflowsAnnotation("push", wantWorkflows, "https://buildkite.com/acme/widgets/builds/42") {
+	if annotation == nil || !slices.Equal(annotation.args, wantAnnotationArgs) || string(annotation.stdin) != skippedWorkflowsAnnotation("push", "", true, wantWorkflows, "https://buildkite.com/acme/widgets/builds/42") {
 		t.Fatalf("skipped workflow annotation = %#v", annotation)
 	}
 	for path := range runner.uploaded {
@@ -1517,19 +1517,24 @@ func TestRunUploadExplainsWhenWorkflowTriggerFiltersDoNotMatch(t *testing.T) {
 
 func TestSkippedWorkflowsAnnotation(t *testing.T) {
 	for _, test := range []struct {
-		name      string
-		workflows []skippedWorkflow
-		want      string
+		name        string
+		event       string
+		buildSource string
+		allSkipped  bool
+		workflows   []skippedWorkflow
+		want        string
 	}{
 		{
 			name:      "singular",
+			event:     "push",
 			workflows: []skippedWorkflow{{label: "CI", key: "gha-workflow-ci", reason: "This workflow is not triggered by a `push` event", events: []string{"workflow_dispatch", "pull_request"}}},
 			want: "#### 1 workflow was skipped\n\n" +
 				"The current <code>push</code> event does not match these workflows:\n\n" +
 				"* [:github: CI](https://buildkite.com/acme/widgets/builds/42/canvas?key=gha-workflow-ci&open=false) (workflow_dispatch, pull_request) — This workflow is not triggered by a `push` event\n",
 		},
 		{
-			name: "plural",
+			name:  "plural",
+			event: "push",
 			workflows: []skippedWorkflow{
 				{label: "CI", key: "gha-workflow-ci", reason: "Only runs on `main` or `development`.", events: []string{"push", "pull_request"}},
 				{label: "Release [production]", key: "gha-workflow-release?production", reason: "This workflow is not triggered by a `push` event", events: []string{"release"}},
@@ -1539,10 +1544,25 @@ func TestSkippedWorkflowsAnnotation(t *testing.T) {
 				"* [:github: CI](https://buildkite.com/acme/widgets/builds/42/canvas?key=gha-workflow-ci&open=false) (push, pull_request) — Only runs on `main` or `development`.\n" +
 				"* [:github: Release \\[production\\]](https://buildkite.com/acme/widgets/builds/42/canvas?key=gha-workflow-release%3Fproduction&open=false) (release) — This workflow is not triggered by a `push` event\n",
 		},
+		{
+			name:        "manual build with no matching workflows",
+			event:       "workflow_dispatch",
+			buildSource: "ui",
+			allSkipped:  true,
+			workflows: []skippedWorkflow{
+				{label: "CI", key: "gha-workflow-ci", reason: "This workflow is not triggered by a `workflow_dispatch` event", events: []string{"push", "pull_request"}},
+			},
+			want: "#### 1 workflow was skipped, so this build ran nothing\n\n" +
+				"You started this build from the Buildkite UI, which is a manual run. In GitHub Actions terms, this maps to a <code>workflow_dispatch</code> event, and these workflows don't accept it:\n\n" +
+				"* [:github: CI](https://buildkite.com/acme/widgets/builds/42/canvas?key=gha-workflow-ci&open=false) (push, pull_request) — This workflow is not triggered by a `workflow_dispatch` event\n\n" +
+				"Push a commit or open a pull request to run workflows configured for those events. Or add <code>workflow_dispatch:</code> to the <code>on:</code> block to make a workflow runnable from here. [Learn about event mapping →](https://github.com/buildkite/buildkite-gha/blob/main/docs/cli.md#select-the-effective-event)\n",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			body := skippedWorkflowsAnnotation(
-				"push",
+				test.event,
+				test.buildSource,
+				test.allSkipped,
 				test.workflows,
 				"https://buildkite.com/acme/widgets/builds/42",
 			)

--- a/internal/cli/upload_test.go
+++ b/internal/cli/upload_test.go
@@ -1529,20 +1529,20 @@ func TestSkippedWorkflowsAnnotation(t *testing.T) {
 			event:     "push",
 			workflows: []skippedWorkflow{{label: "CI", key: "gha-workflow-ci", reason: "This workflow is not triggered by a `push` event", events: []string{"workflow_dispatch", "pull_request"}}},
 			want: "#### 1 workflow was skipped\n\n" +
-				"The current <code>push</code> event does not match these workflows:\n\n" +
-				"* [:github: CI](https://buildkite.com/acme/widgets/builds/42/canvas?key=gha-workflow-ci&open=false) (workflow_dispatch, pull_request) — This workflow is not triggered by a `push` event\n",
+				"The current <code>push</code> event does not match the following workflows:\n\n" +
+				"* [:github: CI](https://buildkite.com/acme/widgets/builds/42/canvas?key=gha-workflow-ci&open=false) — This workflow is triggered on: <code>workflow_dispatch</code>, <code>pull_request</code>\n",
 		},
 		{
-			name:  "plural",
+			name:  "event and filter mismatches",
 			event: "push",
 			workflows: []skippedWorkflow{
 				{label: "CI", key: "gha-workflow-ci", reason: "Only runs on `main` or `development`.", events: []string{"push", "pull_request"}},
 				{label: "Release [production]", key: "gha-workflow-release?production", reason: "This workflow is not triggered by a `push` event", events: []string{"release"}},
 			},
 			want: "#### 2 workflows were skipped\n\n" +
-				"The current <code>push</code> event does not match these workflows:\n\n" +
-				"* [:github: CI](https://buildkite.com/acme/widgets/builds/42/canvas?key=gha-workflow-ci&open=false) (push, pull_request) — Only runs on `main` or `development`.\n" +
-				"* [:github: Release \\[production\\]](https://buildkite.com/acme/widgets/builds/42/canvas?key=gha-workflow-release%3Fproduction&open=false) (release) — This workflow is not triggered by a `push` event\n",
+				"The current <code>push</code> event does not match the following workflows:\n\n" +
+				"* [:github: CI](https://buildkite.com/acme/widgets/builds/42/canvas?key=gha-workflow-ci&open=false) — Only runs on `main` or `development`.\n" +
+				"* [:github: Release \\[production\\]](https://buildkite.com/acme/widgets/builds/42/canvas?key=gha-workflow-release%3Fproduction&open=false) — This workflow is triggered on: <code>release</code>\n",
 		},
 		{
 			name:        "manual build with no matching workflows",
@@ -1554,7 +1554,7 @@ func TestSkippedWorkflowsAnnotation(t *testing.T) {
 			},
 			want: "#### 1 workflow was skipped, so this build ran nothing\n\n" +
 				"You started this build from the Buildkite UI, which is a manual run. In GitHub Actions terms, this maps to a <code>workflow_dispatch</code> event, and these workflows don't accept it:\n\n" +
-				"* [:github: CI](https://buildkite.com/acme/widgets/builds/42/canvas?key=gha-workflow-ci&open=false) (push, pull_request) — This workflow is not triggered by a `workflow_dispatch` event\n\n" +
+				"* [:github: CI](https://buildkite.com/acme/widgets/builds/42/canvas?key=gha-workflow-ci&open=false) — This workflow is triggered on: <code>push</code>, <code>pull_request</code>\n\n" +
 				"Push a commit or open a pull request to run workflows configured for those events. Or add <code>workflow_dispatch:</code> to the <code>on:</code> block to make a workflow runnable from here. [Learn about event mapping →](https://github.com/buildkite/buildkite-gha/blob/main/docs/cli.md#select-the-effective-event)\n",
 		},
 	} {


### PR DESCRIPTION
## Summary

- show each skipped workflow's configured trigger events in the Buildkite annotation
- preserve trigger declaration order
- cover event-mismatch and trigger-filter annotations

## Testing

- `mise exec -- go test ./...`