### PR TITLE
Remove unreachable Node 20 execution state

### DIFF
--- a/internal/action/metadata/metadata.go
+++ b/internal/action/metadata/metadata.go
@@ -91,14 +91,13 @@ type CompositeStep struct {
 // Runtime identifies one supported action execution model.
 type Runtime string
 
+const runtimeNode20Declaration = "node20"
+
 const (
 	// MaxNestedActionDepth bounds local action expansion in both compilation and execution.
 	MaxNestedActionDepth = 10
 	// RuntimeNode16 executes a JavaScript action with managed Node 16.
 	RuntimeNode16 Runtime = "node16"
-	// RuntimeNode20 identifies the accepted node20 action declaration. Matching
-	// GitHub-hosted runners, Runtime maps it to the managed Node 24 runtime.
-	RuntimeNode20 Runtime = "node20"
 	// RuntimeNode24 executes a JavaScript action with managed Node 24.
 	RuntimeNode24 Runtime = "node24"
 	// RuntimeComposite executes a composite action.
@@ -344,7 +343,7 @@ func (metadata Metadata) Runtime() (Runtime, error) {
 	switch metadata.Runs.Using {
 	case string(RuntimeNode16):
 		return RuntimeNode16, nil
-	case string(RuntimeNode20):
+	case runtimeNode20Declaration:
 		return RuntimeNode24, nil
 	case string(RuntimeNode24):
 		return RuntimeNode24, nil
@@ -382,7 +381,7 @@ func (metadata Metadata) ValidateEntrypoints(runtime Runtime) error {
 		}
 		return nil
 	}
-	if runtime != RuntimeNode16 && runtime != RuntimeNode20 && runtime != RuntimeNode24 {
+	if runtime != RuntimeNode16 && runtime != RuntimeNode24 {
 		return nil
 	}
 	if metadata.Runs.Main == "" {

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -338,7 +338,7 @@ func (b *actionLockBuilder) add(ctx context.Context, raw string, depth int) (*ac
 	if err := m.ValidateEntrypoints(runtime); err != nil {
 		return nil, err
 	}
-	if runtime == metadata.RuntimeNode16 || runtime == metadata.RuntimeNode20 || runtime == metadata.RuntimeNode24 {
+	if runtime == metadata.RuntimeNode16 || runtime == metadata.RuntimeNode24 {
 		if err := expression.ValidateActionLifecycleCondition(m.Runs.PreIf); err != nil {
 			return nil, fmt.Errorf("pre-if: %w", err)
 		}

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -208,8 +208,6 @@ func actionNodeMajor(runtime metadata.Runtime) (int, bool) {
 	switch runtime {
 	case metadata.RuntimeNode16:
 		return 16, true
-	case metadata.RuntimeNode20:
-		return 20, true
 	case metadata.RuntimeNode24:
 		return 24, true
 	default:
@@ -1759,7 +1757,7 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 	}
 
 	switch runtime {
-	case metadata.RuntimeNode16, metadata.RuntimeNode20, metadata.RuntimeNode24:
+	case metadata.RuntimeNode16, metadata.RuntimeNode24:
 		if err := expression.ValidateActionLifecycleCondition(action.Runs.PreIf); err != nil {
 			return result, fmt.Errorf("JavaScript action %q pre-if: %w", step.Uses, err)
 		}
@@ -2066,7 +2064,7 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 	actionEval := eval
 	actionEval.Inputs = inputs
 	switch actionRuntime {
-	case metadata.RuntimeNode16, metadata.RuntimeNode20, metadata.RuntimeNode24:
+	case metadata.RuntimeNode16, metadata.RuntimeNode24:
 		if action.Runs.Main == "" {
 			return result, fmt.Errorf("JavaScript action %q has no main entry point", step.Uses)
 		}


### PR DESCRIPTION
## Why

Action metadata declares `node20`, but classification already normalizes it to the managed Node 24 runtime. Retaining a separate Node 20 execution value leaves impossible branches in entrypoint validation, compilation, and lifecycle dispatch.

## What

Keep `node20` as a private accepted declaration spelling that maps to the typed Node 24 execution runtime. Remove the unreachable Node 20 runtime value and its downstream branches without changing supported declarations, Node selection, or lifecycle behavior.