### PR TITLE
Annotate unavailable Buildkite secrets

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -829,7 +829,7 @@ The token is not added to the initial job environment. Direct workflow-authored 
 
 ### Other secrets and OIDC
 
-**🟡 Supported subset.** Direct jobs can use statically named `${{ secrets.NAME }}` references. The compiler records names only in job plans. At runtime, the destination job runs `buildkite-agent secret get NAME` with its existing authenticated Agent session and registers each value with both the Buildkite Agent redactor and the local workflow-command redactor before use. Missing or denied secrets fail the job without printing the value or Agent error output. Secret values do not appear in plans or generated pipeline YAML.
+**🟡 Supported subset.** Direct jobs can use statically named `${{ secrets.NAME }}` references. The compiler records names only in job plans. At runtime, the destination job runs `buildkite-agent secret get NAME` with its existing authenticated Agent session and registers each value with both the Buildkite Agent redactor and the local workflow-command redactor before use. Missing or denied secrets fail the job without printing the value or Agent error output. The failed job includes an annotation with steps to create or migrate the secret and check its access policy. Secret values do not appear in plans or generated pipeline YAML.
 
 These are Buildkite secrets available to the destination job, not GitHub repository, environment, event, or fork-scoped secrets. Buildkite Secret access policies are the authorization boundary. A workflow can access any named secret that its destination job's Buildkite identity and secret policy permit, just as arbitrary code in that job can run `buildkite-agent secret get`.
 

--- a/internal/cli/run_job.go
+++ b/internal/cli/run_job.go
@@ -27,6 +27,7 @@ const (
 	resultPublicationTimeout                    = 10 * time.Second
 	repositoryProviderGitCredentialsEnvironment = "BUILDKITE_USE_REPOSITORY_PROVIDER_GIT_CREDENTIALS"
 	legacyGitHubAppGitCredentialsEnvironment    = "BUILDKITE_USE_GITHUB_APP_GIT_CREDENTIALS"
+	secretResolutionAnnotationContext           = "buildkite-gha-secret-resolution"
 )
 
 func repositoryProviderGitCredentialsEnabled(getenv func(string) string) bool {
@@ -297,6 +298,7 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 	if publish {
 		_, _ = fmt.Fprintln(stdout, "~~~ :package: Publish GitHub Actions result")
 		publication, err := publishTerminalResult(agent, artifactRoot, job, planDigest, producer, result)
+		secretAnnotationError := publishSecretResolutionAnnotation(agent, producer.JobID, runErr)
 		if publication.MetadataMirrorError != nil {
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: warning: result metadata mirror: %v\n", publication.MetadataMirrorError)
 		}
@@ -309,7 +311,10 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 		if publication.ErrorAnnotationError != nil {
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: warning: workflow error annotation: %v\n", publication.ErrorAnnotationError)
 		}
-		if err != nil || publication.MetadataMirrorError != nil || publication.SummaryAnnotationError != nil || publication.WarningAnnotationError != nil || publication.ErrorAnnotationError != nil {
+		if secretAnnotationError != nil {
+			_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: warning: secret resolution annotation: %v\n", secretAnnotationError)
+		}
+		if err != nil || publication.MetadataMirrorError != nil || publication.SummaryAnnotationError != nil || publication.WarningAnnotationError != nil || publication.ErrorAnnotationError != nil || secretAnnotationError != nil {
 			_, _ = fmt.Fprintln(stdout, "^^^ +++")
 			failureVisible = true
 		}
@@ -412,6 +417,26 @@ func publishTerminalResult(agent transport.Agent, root string, job plan.Job, pla
 	defer cancel()
 	workflow := strings.TrimPrefix(job.Workflow.Digest, "sha256:")
 	return gharuntime.PublishJobResult(ctx, agent, root, workflow, job.Target.StepKey, planDigest, producer, result)
+}
+
+func publishSecretResolutionAnnotation(agent transport.Agent, jobID string, runErr error) error {
+	var secretError *gharuntime.SecretResolutionError
+	if !errors.As(runErr, &secretError) {
+		return nil
+	}
+	body := fmt.Sprintf(`## Buildkite secret %s is unavailable
+
+This job could not retrieve the Buildkite secret %s.
+
+1. [Create or migrate the secret into Buildkite](https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets).
+1. If the secret already exists, [grant this job access with its access policy](https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets/access-policies).
+1. Retry the job.
+
+GitHub does not expose an existing secret's value after creation. Copy or rotate the value manually. GitHub repository and environment secrets are not available directly to this job.
+`, annotationCode(secretError.Name), annotationCode(secretError.Name))
+	ctx, cancel := context.WithTimeout(context.Background(), resultPublicationTimeout)
+	defer cancel()
+	return agent.AnnotateJob(ctx, jobID, secretResolutionAnnotationContext, "error", body)
 }
 
 type runJobOptions struct {

--- a/internal/cli/run_job.go
+++ b/internal/cli/run_job.go
@@ -424,7 +424,7 @@ func publishSecretResolutionAnnotation(agent transport.Agent, jobID string, runE
 	if !errors.As(runErr, &secretError) {
 		return nil
 	}
-	body := fmt.Sprintf(`## Buildkite secret %s is unavailable
+	body := fmt.Sprintf(`## Missing secret
 
 This job could not retrieve the Buildkite secret %s.
 
@@ -432,7 +432,7 @@ This job could not retrieve the Buildkite secret %s.
 1. If the secret already exists, <a href="https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets/access-policies" target="_blank">grant this job access with its access policy</a>.
 
 > ℹ️ GitHub does not expose an existing secret's value after creation. Copy or rotate the value manually. GitHub repository and environment secrets are not available directly to this job.
-`, annotationCode(secretError.Name), annotationCode(secretError.Name))
+`, annotationCode(secretError.Name))
 	ctx, cancel := context.WithTimeout(context.Background(), resultPublicationTimeout)
 	defer cancel()
 	return agent.AnnotateJob(ctx, jobID, secretResolutionAnnotationContext, "error", body)

--- a/internal/cli/run_job.go
+++ b/internal/cli/run_job.go
@@ -424,7 +424,7 @@ func publishSecretResolutionAnnotation(agent transport.Agent, jobID string, runE
 	if !errors.As(runErr, &secretError) {
 		return nil
 	}
-	body := fmt.Sprintf(`## Missing secret
+	body := fmt.Sprintf(`#### Missing secret
 
 This job could not retrieve the Buildkite secret %s.
 

--- a/internal/cli/run_job.go
+++ b/internal/cli/run_job.go
@@ -428,11 +428,10 @@ func publishSecretResolutionAnnotation(agent transport.Agent, jobID string, runE
 
 This job could not retrieve the Buildkite secret %s.
 
-1. [Create or migrate the secret into Buildkite](https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets).
-1. If the secret already exists, [grant this job access with its access policy](https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets/access-policies).
-1. Retry the job.
+1. <a href="https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets" target="_blank">Create or migrate the secret into Buildkite</a>.
+1. If the secret already exists, <a href="https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets/access-policies" target="_blank">grant this job access with its access policy</a>.
 
-GitHub does not expose an existing secret's value after creation. Copy or rotate the value manually. GitHub repository and environment secrets are not available directly to this job.
+> ℹ️ GitHub does not expose an existing secret's value after creation. Copy or rotate the value manually. GitHub repository and environment secrets are not available directly to this job.
 `, annotationCode(secretError.Name), annotationCode(secretError.Name))
 	ctx, cancel := context.WithTimeout(context.Background(), resultPublicationTimeout)
 	defer cancel()

--- a/internal/cli/run_job_test.go
+++ b/internal/cli/run_job_test.go
@@ -442,7 +442,8 @@ func TestRunJobAnnotatesUnavailableBuildkiteSecretWithMigrationGuidance(t *testi
 	}
 	body := string(annotations[0].stdin)
 	for _, want := range []string{
-		"Buildkite secret <code>EXAMPLE_SECRET</code> is unavailable",
+		"## Missing secret",
+		"Buildkite secret <code>EXAMPLE_SECRET</code>",
 		`<a href="https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets" target="_blank">Create or migrate the secret into Buildkite</a>`,
 		`<a href="https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets/access-policies" target="_blank">grant this job access with its access policy</a>`,
 		"> ℹ️ GitHub does not expose an existing secret's value after creation",

--- a/internal/cli/run_job_test.go
+++ b/internal/cli/run_job_test.go
@@ -443,13 +443,16 @@ func TestRunJobAnnotatesUnavailableBuildkiteSecretWithMigrationGuidance(t *testi
 	body := string(annotations[0].stdin)
 	for _, want := range []string{
 		"Buildkite secret <code>EXAMPLE_SECRET</code> is unavailable",
-		"Create or migrate the secret into Buildkite",
-		"grant this job access with its access policy",
-		"GitHub does not expose an existing secret's value after creation",
+		`<a href="https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets" target="_blank">Create or migrate the secret into Buildkite</a>`,
+		`<a href="https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets/access-policies" target="_blank">grant this job access with its access policy</a>`,
+		"> ℹ️ GitHub does not expose an existing secret's value after creation",
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("annotation = %q, want %q", body, want)
 		}
+	}
+	if strings.Contains(body, "Retry the job") {
+		t.Errorf("annotation = %q, does not want retry guidance", body)
 	}
 	if last := runner.commands[len(runner.commands)-1]; len(last.args) == 0 || last.args[0] != "annotate" {
 		t.Fatalf("last command = %#v, want guidance annotation after authoritative publication", last)

--- a/internal/cli/run_job_test.go
+++ b/internal/cli/run_job_test.go
@@ -442,7 +442,7 @@ func TestRunJobAnnotatesUnavailableBuildkiteSecretWithMigrationGuidance(t *testi
 	}
 	body := string(annotations[0].stdin)
 	for _, want := range []string{
-		"## Missing secret",
+		"#### Missing secret",
 		"Buildkite secret <code>EXAMPLE_SECRET</code>",
 		`<a href="https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets" target="_blank">Create or migrate the secret into Buildkite</a>`,
 		`<a href="https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets/access-policies" target="_blank">grant this job access with its access policy</a>`,

--- a/internal/cli/run_job_test.go
+++ b/internal/cli/run_job_test.go
@@ -410,6 +410,52 @@ func TestRunJobDisabledWorkflowTokenLinksPipelineSettings(t *testing.T) {
 	}
 }
 
+func TestRunJobAnnotatesUnavailableBuildkiteSecretWithMigrationGuidance(t *testing.T) {
+	job := cliRunJobPlan()
+	job.RequiredCapabilities = []string{"secrets"}
+	job.RequiredSecrets = []string{"EXAMPLE_SECRET"}
+	planPath, planDigest := writeCLIJobPlan(t, job)
+	setCLIJobIdentity(t, job, planDigest)
+	agentPath := filepath.Join(t.TempDir(), "buildkite-agent")
+	if err := os.WriteFile(agentPath, []byte("#!/bin/sh\nexit 1\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BUILDKITE_GHA_AGENT", agentPath)
+	runner := &cliCaptureRunner{}
+	var stdout, stderr bytes.Buffer
+
+	if code := run([]string{"run-job", "--plan", planPath}, &stdout, &stderr, "dev", runner); code != 1 {
+		t.Fatalf("run() code = %d, stderr = %q, want 1", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), `resolve secret "EXAMPLE_SECRET": buildkite Agent secret request failed`) {
+		t.Fatalf("stderr = %q, want secret resolution failure", stderr.String())
+	}
+	var annotations []cliCommand
+	for _, command := range runner.commands {
+		if len(command.args) > 0 && command.args[0] == "annotate" {
+			annotations = append(annotations, command)
+		}
+	}
+	wantArgs := []string{"annotate", "--scope", "job", "--job", cliTestJobID, "--context", secretResolutionAnnotationContext, "--style", "error"}
+	if len(annotations) != 1 || !slices.Equal(annotations[0].args, wantArgs) {
+		t.Fatalf("annotations = %#v, want one secret resolution annotation", annotations)
+	}
+	body := string(annotations[0].stdin)
+	for _, want := range []string{
+		"Buildkite secret <code>EXAMPLE_SECRET</code> is unavailable",
+		"Create or migrate the secret into Buildkite",
+		"grant this job access with its access policy",
+		"GitHub does not expose an existing secret's value after creation",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("annotation = %q, want %q", body, want)
+		}
+	}
+	if last := runner.commands[len(runner.commands)-1]; len(last.args) == 0 || last.args[0] != "annotate" {
+		t.Fatalf("last command = %#v, want guidance annotation after authoritative publication", last)
+	}
+}
+
 func TestRunJobPublishesWorkflowCommandsAsAdvisoryJobAnnotations(t *testing.T) {
 	diagnostics := "printf '%s\\n' '::warning title=Lint::warning body'; printf '%s\\n' '::error file=main.go,line=7::error body' >&2"
 	tests := []struct {

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -1257,7 +1257,7 @@ func (r Runner) resolveSecrets(ctx context.Context, processor *commandProcessor,
 	for _, name := range names {
 		value, err := r.Secrets.ResolveSecret(ctx, name)
 		if err != nil {
-			return nil, fmt.Errorf("resolve secret %q: %w", name, err)
+			return nil, &SecretResolutionError{Name: name, Err: err}
 		}
 		if value != "" {
 			processor.addMask(value)

--- a/internal/runtime/secrets.go
+++ b/internal/runtime/secrets.go
@@ -20,6 +20,21 @@ type SecretResolver interface {
 	ResolveSecret(context.Context, string) (string, error)
 }
 
+// SecretResolutionError identifies a plan-declared secret that could not be
+// retrieved.
+type SecretResolutionError struct {
+	Name string
+	Err  error
+}
+
+func (e *SecretResolutionError) Error() string {
+	return fmt.Sprintf("resolve secret %q: %v", e.Name, e.Err)
+}
+
+func (e *SecretResolutionError) Unwrap() error {
+	return e.Err
+}
+
 // Redactor registers a secret with the log sink before any step can run.
 type Redactor interface {
 	AddRedaction(context.Context, string) error


### PR DESCRIPTION
## Why

A missing or inaccessible Buildkite secret currently fails a GitHub Actions job with a terse retrieval error and no migration guidance.

e.g.

<img width="2994" height="1611" alt="CleanShot 2026-08-18 at 15 10 32@2x" src="https://github.com/user-attachments/assets/c1dd7a7b-3dfc-4397-99e9-9433f70dc93e" />

## What

- Publish a job-scoped error annotation that names the unavailable secret and links to Buildkite secret creation and access-policy guidance.
- Explain that GitHub does not expose existing secret values, so users must copy or rotate them manually.
- Preserve the non-disclosing runtime error and treat annotation publication as advisory.
- Document and test the guided failure experience.
