### PR TITLE
Support expressions in composite step fields

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -582,7 +582,7 @@ Job-level expressions support the same operators and pure functions with these f
 | `defaults.run` | `github`, `needs`, `matrix`, `env`, `vars`, `inputs` |
 | `outputs` | `github`, `needs`, `matrix`, `runner`, `env`, `vars`, `secrets`, `steps`, `inputs` |
 
-These workflow step fields support `hashFiles()`; job-level fields do not. General runtime interpolation and action metadata keep the direct-reference-only rule. The GitHub-authorized `strategy` context, and `job` in job outputs, remain unsupported because the runtime does not carry equivalent context values. Computed, whole, and projected `steps` and `needs` access also remains unsupported in job-level fields.
+These workflow step fields support `hashFiles()`; composite action step fields and job-level fields do not. Composite action step `run`, `env`, and `with` support the listed runtime operators and pure functions. Other action metadata follows the field-specific behavior in [Actions](#actions). The GitHub-authorized `strategy` context, and `job` in job outputs, remain unsupported because the runtime does not carry equivalent context values. Computed, whole, and projected `steps` and `needs` access also remains unsupported in job-level fields.
 
 Expression-valued `continue-on-error` must produce a Boolean. Expression-valued `timeout-minutes` must produce a number greater than 0 and at most 360.
 

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -692,6 +692,19 @@ func TestEvaluateStepSupportsCompoundRuntimeExpressions(t *testing.T) {
 	}
 }
 
+func TestEvaluateStepSupportsGitHubEventIdentity(t *testing.T) {
+	context := Context{GitHub: map[string]any{
+		"repository_owner": "buildkite",
+		"ref_name":         "42/merge",
+		"ref_type":         "branch",
+		"base_ref":         "main",
+	}}
+	got, err := EvaluateStep("${{ github.repository_owner }}:${{ github.ref_name }}:${{ github.ref_type }}:${{ github.base_ref }}", context)
+	if err != nil || got != "buildkite:42/merge:branch:main" {
+		t.Fatalf("EvaluateStep() GitHub event identity = %q, %v", got, err)
+	}
+}
+
 func TestExpressionMapProjectionIsDeterministic(t *testing.T) {
 	context := Context{Matrix: map[string]any{"zed": "last", "alpha": "first", "middle": "second"}}
 	for range 100 {

--- a/internal/expression/runtime.go
+++ b/internal/expression/runtime.go
@@ -355,7 +355,7 @@ func validateStepRuntimeExpression(node actionlint.ExprNode, allowHashFiles, all
 					return fmt.Errorf("github.token is unavailable in this field")
 				}
 				return nil
-			case "actor", "event_name", "head_ref", "ref", "repository", "server_url", "sha":
+			case "actor", "base_ref", "event_name", "head_ref", "ref", "ref_name", "ref_type", "repository", "repository_owner", "server_url", "sha":
 				return nil
 			default:
 				return fmt.Errorf("unsupported runtime github reference %q", referenceName(root, path))

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -2232,13 +2232,13 @@ func (r Runner) runCompositeMetadata(ctx context.Context, processor *commandProc
 		childJobEnv := mergeStepEnvironment(compositeProcessEnv, result.Env)
 		childJobEnv["GITHUB_ACTION_PATH"] = actionPath
 		if step.Uses != "" {
-			// Composite metadata remains direct-reference-only. Resolve its child
-			// fields before entering workflow-authored action evaluation.
+			// Resolve composite child fields before entering workflow-authored
+			// action evaluation.
 			var childEnv map[string]string
-			childEnv, childErr = evaluateMap(step.Env, eval)
+			childEnv, childErr = evaluateStepMap(step.Env, eval)
 			var childWith map[string]string
 			if childErr == nil {
-				childWith, childErr = evaluateMap(step.With, eval)
+				childWith, childErr = evaluateStepMap(step.With, eval)
 			}
 			child := plan.Step{ID: step.ID, Name: step.Name, Kind: "uses", Uses: step.Uses, With: step.With, Env: step.Env}
 			if actionLock != nil {
@@ -2258,7 +2258,7 @@ func (r Runner) runCompositeMetadata(ctx context.Context, processor *commandProc
 			var script, dir string
 			var args []string
 			var env map[string]string
-			env, childErr = evaluateMap(step.Env, eval)
+			env, childErr = evaluateStepMap(step.Env, eval)
 			if childErr == nil {
 				script, childErr = expression.EvaluateStep(step.Run, eval)
 			}

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -1709,10 +1709,8 @@ func (r *Runner) actionContainerMounts(ctx context.Context, actions *actionLockR
 func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProcessor, workspace string, step plan.Step, invocationID string, jobEnv map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations, status *remotePreparationStatus, workflowStep bool, inheritedEvalErr error, inheritedTimeout *remotePreparationTimeout, inheritedEnvOverlay map[string]string) (Result, error) {
 	result := newResult()
 	eval.JobStatus = jobStatusValue(status.unsuccessful, ctx.Err() != nil)
-	evaluate := evaluateMap
-	if workflowStep {
-		evaluate = evaluateStepMap
-	} else {
+	evaluate := evaluateStepMap
+	if !workflowStep {
 		eval.HashFiles = nil
 	}
 	source, err := actions.source(*step.Action)

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -5144,6 +5144,55 @@ if [ "$(basename "$(dirname "$1")")/$(basename "$1")" = child/pre.js ]; then sle
 	}
 }
 
+func TestNestedRemoteCompositePreSupportsCompoundStepFields(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: nested pre expressions\n")
+	remote := t.TempDir()
+	writeFixtureFile(t, remote, "root/action.yml", `name: root
+inputs:
+  targets:
+    required: false
+  target:
+    required: false
+runs:
+  using: composite
+  steps:
+    - uses: owner/repo/child@v1
+      with:
+        message: ${{ inputs.targets || inputs.target || '' }}
+      env:
+        TARGETS: ${{ inputs.targets || inputs.target || '' }}
+`)
+	writeFixtureFile(t, remote, "child/action.yml", "name: child\ninputs:\n  message:\n    required: false\nruns:\n  using: node24\n  pre: pre.js\n  main: main.js\n")
+	writeFixtureFile(t, remote, "child/pre.js", "")
+	writeFixtureFile(t, remote, "child/main.js", "")
+	fakeNode := filepath.Join(workspace, "node24")
+	writeFixtureFile(t, workspace, "node24", `#!/bin/sh
+set -eu
+if [ "${1:-}" = --version ]; then echo v24.0.0; exit 0; fi
+test -z "$INPUT_MESSAGE"
+test -z "$TARGETS"
+`)
+	if err := os.Chmod(fakeNode, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	digest := digestTree(t, remote)
+	rootID, childID := remoteLifecycleLockID(1), remoteLifecycleLockID(2)
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "root", Kind: "uses", Uses: remoteLifecycleUses("root"), Action: &plan.ActionSelector{Lock: rootID}}})
+	job.Schema = plan.Schema
+	job.RequiredCapabilities = []string{"network"}
+	job.Actions = []plan.ActionLock{
+		remoteLifecycleLock(rootID, "root", digest, map[string]plan.ActionSelector{remoteLifecycleUses("child"): {Lock: childID}}),
+		remoteLifecycleLock(childID, "child", digest, nil),
+	}
+	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}
+	result, err := (Runner{Node24: fakeNode, Actions: materializer}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+}
+
 func TestSkippedRemoteCompositeWithoutPreDoesNotEvaluateTimeout(t *testing.T) {
 	workspace := t.TempDir()
 	workflowPath := ".github/workflows/test.yml"
@@ -6172,9 +6221,11 @@ runs:
     - shell: sh
       env:
         targets: ${{ inputs.targets || inputs.target || '' }}
+        owner: ${{ github.repository_owner }}
       run: |
         echo "downgrade=${{contains(inputs.toolchain, 'nightly') && inputs.components && ' --allow-downgrade' || ''}}" > "$RESULT"
         echo "targets=$targets" >> "$RESULT"
+        echo "owner=$owner" >> "$RESULT"
 `)
 	output := filepath.Join(workspace, "result")
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{
@@ -6184,6 +6235,7 @@ runs:
 		With: map[string]string{"toolchain": "nightly", "components": "rustfmt"},
 	}})
 	job.Env = map[string]string{"RESULT": output}
+	job.Event.Repository = "buildkite/buildkite-gha"
 
 	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
@@ -6193,7 +6245,7 @@ runs:
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got, want := string(contents), "downgrade= --allow-downgrade\ntargets=\n"; got != want {
+	if got, want := string(contents), "downgrade= --allow-downgrade\ntargets=\nowner=buildkite\n"; got != want {
 		t.Fatalf("compound composite step expressions = %q, want %q", got, want)
 	}
 }

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -6152,7 +6152,7 @@ runs:
 	}
 }
 
-func TestCompositeRunSupportsCompoundInputExpression(t *testing.T) {
+func TestCompositeStepSupportsCompoundInputExpression(t *testing.T) {
 	workspace := t.TempDir()
 	workflowPath := ".github/workflows/test.yml"
 	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
@@ -6162,11 +6162,19 @@ inputs:
     required: false
   components:
     required: false
+  targets:
+    required: false
+  target:
+    required: false
 runs:
   using: composite
   steps:
     - shell: sh
-      run: echo "downgrade=${{contains(inputs.toolchain, 'nightly') && inputs.components && ' --allow-downgrade' || ''}}" > "$RESULT"
+      env:
+        targets: ${{ inputs.targets || inputs.target || '' }}
+      run: |
+        echo "downgrade=${{contains(inputs.toolchain, 'nightly') && inputs.components && ' --allow-downgrade' || ''}}" > "$RESULT"
+        echo "targets=$targets" >> "$RESULT"
 `)
 	output := filepath.Join(workspace, "result")
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{
@@ -6185,8 +6193,8 @@ runs:
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got, want := string(contents), "downgrade= --allow-downgrade\n"; got != want {
-		t.Fatalf("compound composite run expression = %q, want %q", got, want)
+	if got, want := string(contents), "downgrade= --allow-downgrade\ntargets=\n"; got != want {
+		t.Fatalf("compound composite step expressions = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Why

Composite actions can use compound GitHub expressions in step fields. `dtolnay/rust-toolchain@stable` uses `${{ inputs.targets || inputs.target || '' }}` in a step environment value, which `run-job` rejected as an unsupported expression reference.

## What

Evaluate composite step `env` and `with` values with the existing workflow step expression evaluator, including during nested remote action preparation. Preserve supported GitHub event identity references and keep `hashFiles` unavailable during composite preparation.

Add regressions for the Rust toolchain expression, nested remote pre-hooks, and GitHub event identity fields.