### PR TITLE
Support runner.temp expressions

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -557,6 +557,7 @@ Conditions support computed object indexes, numeric array indexes, whole `matrix
 | --- | --- | --- |
 | `github.actor`, `github.base_ref`, `github.event_name`, `github.head_ref`, `github.ref`, `github.ref_name`, `github.ref_type`, `github.repository`, `github.repository_owner`, `github.sha` | ✅ Yes | ✅ Yes |
 | `runner.os`, `runner.arch` | ✅ Yes | ✅ Yes |
+| `runner.temp` | ❌ No | ✅ Yes |
 | `needs.<job>.result`, `needs.<job>.outputs.<name>` | ✅ Yes | ✅ Yes |
 | `vars.<name>`, `matrix.<name>` | ✅ Yes | ✅ Yes |
 | `inputs.<name>` and computed input indexes | ✅ Yes | ✅ Yes |
@@ -588,11 +589,13 @@ Expression-valued `continue-on-error` must produce a Boolean. Expression-valued 
 
 Direct `github.token` references are step-only. Whole, filtered, or dynamically indexed `github` access fails closed because the compiler cannot prove token authority.
 
-The only runner references are `runner.os` and `runner.arch`. They resolve to
-`Linux`/`X64` or `macOS`/`ARM64`. Other runner fields and compile-time positions
-that require runner identity are unsupported. Action metadata input defaults
-may also use direct `runner.debug`, which resolves to the string `false` because
-Buildkite has no equivalent step-debug mode.
+`runner.os` and `runner.arch` resolve to `Linux`/`X64` or `macOS`/`ARM64`.
+After runner setup, step runtime fields and job outputs can also use
+`runner.temp`, which resolves to the canonical temporary directory exposed as
+`RUNNER_TEMP`. Other runner fields and compile-time positions that require
+runner identity are unsupported. Action metadata input defaults may also use
+direct `runner.debug`, which resolves to the string `false` because Buildkite
+has no equivalent step-debug mode.
 
 A runtime interpolation can read a verified upstream output directly:
 

--- a/internal/expression/action_input_default.go
+++ b/internal/expression/action_input_default.go
@@ -32,6 +32,9 @@ func validateActionInputDefaultNode(node actionlint.ExprNode) error {
 		if isJobStatusReference(root, path) {
 			return nil
 		}
+		if isRunnerTempReference(root, path) {
+			return fmt.Errorf("action input defaults cannot reference runner.temp")
+		}
 		if isDirectRunnerDebug(node, root, path) {
 			return nil
 		}
@@ -76,6 +79,10 @@ func EvaluateActionInputDefault(template string, context Context) (string, error
 func isDirectRunnerDebug(node actionlint.ExprNode, root string, path []string) bool {
 	_, direct := node.(*actionlint.ObjectDerefNode)
 	return direct && strings.EqualFold(root, "runner") && len(path) == 1 && strings.EqualFold(path[0], "debug")
+}
+
+func isRunnerTempReference(root string, path []string) bool {
+	return strings.EqualFold(root, "runner") && len(path) == 1 && strings.EqualFold(path[0], "temp")
 }
 
 // ActionInputDefaultRequiresGitHubToken reports whether a metadata default can
@@ -142,6 +149,9 @@ func evaluateActionInputDefaultNode(node actionlint.ExprNode, context Context) (
 				return nil, fmt.Errorf("expression references unavailable job.status")
 			}
 			return context.JobStatus, nil
+		}
+		if isRunnerTempReference(root, path) {
+			return nil, fmt.Errorf("action input defaults cannot reference runner.temp")
 		}
 		if strings.EqualFold(root, "runner") && len(path) == 1 && strings.EqualFold(path[0], "debug") {
 			return "false", nil

--- a/internal/expression/condition.go
+++ b/internal/expression/condition.go
@@ -239,10 +239,18 @@ func validateConditionReference(root string, path []string, scope ConditionScope
 	}
 	switch strings.ToLower(root) {
 	case "runner":
-		if len(path) == 1 && (strings.EqualFold(path[0], "os") || strings.EqualFold(path[0], "arch")) {
-			return nil
+		if len(path) == 1 {
+			if strings.EqualFold(path[0], "os") || strings.EqualFold(path[0], "arch") {
+				return nil
+			}
+			if strings.EqualFold(path[0], "temp") && scope != JobCondition && scope != CallCondition {
+				return nil
+			}
 		}
-		return fmt.Errorf("condition reference %q is unsupported; expected runner.os or runner.arch", reference)
+		if scope == JobCondition {
+			return fmt.Errorf("condition reference %q is unsupported; expected runner.os or runner.arch", reference)
+		}
+		return fmt.Errorf("condition reference %q is unsupported; expected runner.os, runner.arch, or runner.temp", reference)
 	case "github":
 		if len(path) == 1 {
 			switch strings.ToLower(path[0]) {

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -177,10 +177,13 @@ func TestValidateActionInputDefaultSupportsRestrictedCompoundExpressions(t *test
 			t.Errorf("ValidateActionInputDefault(%q) error = %v", template, err)
 		}
 	}
-	for _, template := range []string{"${{ secrets.TOKEN }}", "${{ hashFiles('go.sum') }}", "${{ toJSON(secrets) }}", "${{ github[env.NAME] }}", "${{ runner['debug'] }}", "${{ runner[env.NAME] }}", "${{ runner }}", "${{ runner.debug.extra }}", "${{ runner.name }}", "${{ job.status == 'success' }}", "status-${{ job.status }}"} {
+	for _, template := range []string{"${{ secrets.TOKEN }}", "${{ hashFiles('go.sum') }}", "${{ toJSON(secrets) }}", "${{ github[env.NAME] }}", "${{ runner['debug'] }}", "${{ runner[env.NAME] }}", "${{ runner }}", "${{ runner.debug.extra }}", "${{ runner.name }}", "${{ runner.temp }}", "${{ job.status == 'success' }}", "status-${{ job.status }}"} {
 		if err := ValidateActionInputDefault(template); err == nil {
 			t.Errorf("ValidateActionInputDefault(%q) unexpectedly succeeded", template)
 		}
+	}
+	if _, err := EvaluateActionInputDefault("${{ runner.temp || '' }}", Context{Runner: map[string]string{"temp": "/runner/temp"}}); err == nil {
+		t.Fatal("EvaluateActionInputDefault() accepted runner.temp")
 	}
 }
 

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -137,12 +137,21 @@ func TestValidateRuntimeTemplateMatchesEvaluateReferenceGrammar(t *testing.T) {
 }
 
 func TestRunnerDirectReferencesWorkAcrossRuntimeEvaluationSurfaces(t *testing.T) {
-	runner := map[string]string{"os": "macOS", "arch": "ARM64"}
+	runner := map[string]string{"os": "macOS", "arch": "ARM64", "temp": "/runner/temp"}
 	if got, err := Evaluate("${{ runner.os }}/${{ RUNNER.ARCH }}", Context{Runner: runner}); err != nil || got != "macOS/ARM64" {
 		t.Fatalf("Evaluate() = %q, %v", got, err)
 	}
+	if got, err := EvaluateStep("${{ runner.temp }}", Context{Runner: runner}); err != nil || got != "/runner/temp" {
+		t.Fatalf("EvaluateStep() runner.temp = %q, %v", got, err)
+	}
 	if got, err := EvaluateCondition("runner.os == 'macOS' && runner.arch == 'ARM64'", ConditionContext{Runner: runner}); err != nil || !got {
 		t.Fatalf("EvaluateCondition() = %v, %v", got, err)
+	}
+	if err := ValidateCondition("runner.temp != ''", StepCondition); err != nil {
+		t.Fatalf("ValidateCondition() step runner.temp = %v", err)
+	}
+	if err := ValidateCondition("runner.temp != ''", JobCondition); err == nil {
+		t.Fatal("ValidateCondition() accepted runner.temp before job setup")
 	}
 	if got, err := EvaluateActionInputDefault("${{ runner.os == 'macOS' && runner.arch || 'X64' }}", Context{Runner: runner}); err != nil || got != "ARM64" {
 		t.Fatalf("EvaluateActionInputDefault() = %q, %v", got, err)

--- a/internal/expression/runtime.go
+++ b/internal/expression/runtime.go
@@ -602,7 +602,7 @@ func resolveRuntimeReferenceValue(root string, path []string, context Context, a
 
 func classifyRuntimeReference(root string, path []string) runtimeReferenceKind {
 	switch {
-	case len(path) == 1 && strings.EqualFold(root, "runner") && (strings.EqualFold(path[0], "os") || strings.EqualFold(path[0], "arch")):
+	case len(path) == 1 && strings.EqualFold(root, "runner") && (strings.EqualFold(path[0], "os") || strings.EqualFold(path[0], "arch") || strings.EqualFold(path[0], "temp")):
 		return runtimeReferenceRunner
 	case len(path) == 4 && strings.EqualFold(root, "job") && strings.EqualFold(path[0], "services") && strings.EqualFold(path[2], "ports"):
 		return runtimeReferenceServicePort

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -629,7 +629,7 @@ func TestRunJobContainerLifecycleAndEnvironment(t *testing.T) {
 	t.Setenv("DOCKER_CONTEXT", "bad")
 	t.Setenv("BUILDX_BUILDER", "bad")
 	t.Setenv("BUILDKIT_HOST", "bad")
-	j := jobContainerPlan(t, workspace, []plan.Step{{ID: "one", Kind: "run", Shell: "sh", WorkingDirectory: "nested", Env: map[string]string{"P": "step"}, Command: `test "$PATH" = /image/bin:/usr/bin; test "$P" = step; test "$PWD" = "$GITHUB_WORKSPACE/nested"; echo E=ok >> "$GITHUB_ENV"; echo O=out >> "$GITHUB_OUTPUT"; echo /extra >> "$GITHUB_PATH"; echo S=state >> "$GITHUB_STATE"; echo summary >> "$GITHUB_STEP_SUMMARY"`}, {ID: "two", Kind: "run", Shell: "sh", Command: `test "$E" = ok; case "$PATH" in /extra:*) ;; *) exit 8;; esac`}})
+	j := jobContainerPlan(t, workspace, []plan.Step{{ID: "one", Kind: "run", Shell: "sh", WorkingDirectory: "nested", Env: map[string]string{"P": "step"}, Command: `test "$PATH" = /image/bin:/usr/bin; test "$P" = step; test "$PWD" = "$GITHUB_WORKSPACE/nested"; test "${{ runner.temp }}" = /__w/_temp; echo E=ok >> "$GITHUB_ENV"; echo O=out >> "$GITHUB_OUTPUT"; echo /extra >> "$GITHUB_PATH"; echo S=state >> "$GITHUB_STATE"; echo summary >> "$GITHUB_STEP_SUMMARY"`}, {ID: "two", Kind: "run", Shell: "sh", Command: `test "$E" = ok; case "$PATH" in /extra:*) ;; *) exit 8;; esac`}})
 	j.Env = map[string]string{"P": "job"}
 	j.Container.Env = map[string]string{"P": "container"}
 	j.Outputs = map[string]string{"observed": "${{ steps.one.outputs.O }}"}

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -610,6 +610,10 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 			}
 		}()
 	}
+	runnerContext["temp"] = runnerTemp
+	if r.jobContainer != nil {
+		runnerContext["temp"] = r.jobContainer.containerPath(runnerTemp)
+	}
 	runtimeEnv := standardEnvironment(job, workspace, runnerTemp, toolCache)
 	jobResult.Env = mergeStepEnvironment(runtimeEnv, jobEnv)
 	if r.jobContainer != nil && !explicitJobPATH {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -6322,6 +6322,7 @@ runs:
         targets: ${{ inputs.targets || inputs.target || '' }}
         owner: ${{ github.repository_owner }}
       run: |
+        test "${{ runner.temp }}" = "$RUNNER_TEMP"
         echo "downgrade=${{contains(inputs.toolchain, 'nightly') && inputs.components && ' --allow-downgrade' || ''}}" > "$RESULT"
         echo "targets=$targets" >> "$RESULT"
         echo "owner=$owner" >> "$RESULT"


### PR DESCRIPTION
## Why

`dtolnay/rust-toolchain@stable` uses `${{ runner.temp }}` in its composite sparse-registry setup. `run-job` already creates and exports `RUNNER_TEMP`, but rejects the equivalent expression reference.

## What

Expose the canonical runner temporary directory to step runtime expressions, step conditions, and job outputs after runner setup. Translate the value for job containers and keep it unavailable to pre-job conditions and action input defaults.

Add host, composite-action, and job-container regressions and document the supported context boundary.
