### PR TITLE
Evaluate composite step working-directory expressions

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -583,7 +583,7 @@ Job-level expressions support the same operators and pure functions with these f
 | `defaults.run` | `github`, `needs`, `matrix`, `env`, `vars`, `inputs` |
 | `outputs` | `github`, `needs`, `matrix`, `runner`, `env`, `vars`, `secrets`, `steps`, `inputs` |
 
-These workflow step fields support `hashFiles()`; composite action step fields and job-level fields do not. Composite action step `run`, `env`, and `with` support the listed runtime operators and pure functions. Other action metadata follows the field-specific behavior in [Actions](#actions). The GitHub-authorized `strategy` context, and `job` in job outputs, remain unsupported because the runtime does not carry equivalent context values. Computed, whole, and projected `steps` and `needs` access also remains unsupported in job-level fields.
+These workflow step fields support `hashFiles()`; composite action step fields and job-level fields do not. Composite action step `run`, `env`, `with`, and `working-directory` support the listed runtime operators and pure functions. Other action metadata follows the field-specific behavior in [Actions](#actions). The GitHub-authorized `strategy` context, and `job` in job outputs, remain unsupported because the runtime does not carry equivalent context values. Computed, whole, and projected `steps` and `needs` access also remains unsupported in job-level fields.
 
 Expression-valued `continue-on-error` must produce a Boolean. Expression-valued `timeout-minutes` must produce a number greater than 0 and at most 360.
 

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -1951,7 +1951,7 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 		if err != nil {
 			return result, err
 		}
-		dir, err := workspacePath(workspace, workingDirectory)
+		dir, err := stepWorkingDirectory(workspace, workingDirectory)
 		if err != nil {
 			return result, err
 		}
@@ -2288,7 +2288,11 @@ func (r Runner) runCompositeMetadata(ctx context.Context, processor *commandProc
 				script, childErr = expression.EvaluateStep(step.Run, eval)
 			}
 			if childErr == nil {
-				dir, childErr = workspacePath(workspace, step.WorkingDirectory)
+				var workingDirectory string
+				workingDirectory, childErr = expression.EvaluateStep(step.WorkingDirectory, eval)
+				if childErr == nil {
+					dir, childErr = stepWorkingDirectory(workspace, workingDirectory)
+				}
 			}
 			if childErr == nil {
 				args, childErr = shellCommand(step.Shell, script)
@@ -2453,6 +2457,20 @@ func shellCommand(shell, script string) ([]string, error) {
 	default:
 		return nil, fmt.Errorf("shell %q is unsupported in the supported runtime subset", shell)
 	}
+}
+
+// stepWorkingDirectory resolves a run step's working directory and requires it
+// to exist. Failing here names the directory instead of surfacing the child
+// process's chdir failure as a misleading "fork/exec <shell>" error.
+func stepWorkingDirectory(root, path string) (string, error) {
+	resolved, err := workspacePath(root, path)
+	if err != nil {
+		return "", err
+	}
+	if info, statErr := os.Stat(resolved); statErr != nil || !info.IsDir() {
+		return "", fmt.Errorf("working directory %q does not exist in the workspace", path)
+	}
+	return resolved, nil
 }
 
 func workspacePath(root, path string) (string, error) {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -5019,6 +5019,46 @@ runs:
 	}
 }
 
+func TestCompositeStepWorkingDirectoryEvaluatesExpressions(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	writeFixtureFile(t, workspace, ".github/actions/composite/action.yml", `name: Working-directory composite
+inputs:
+  dir:
+    required: false
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      working-directory: ${{ inputs.dir || '.' }}
+      run: test "$(basename "$PWD")" = sub
+    - shell: bash
+      working-directory: literal-dir
+      run: test "$(basename "$PWD")" = literal-dir
+`)
+	for _, directory := range []string{"sub", "literal-dir"} {
+		if err := os.Mkdir(filepath.Join(workspace, directory), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "composite", Kind: "uses", Uses: "./.github/actions/composite", With: map[string]string{"dir": "sub"}}})
+	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+}
+
+func TestRunStepMissingWorkingDirectoryFailsClearly(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "run", Kind: "run", Shell: "sh", Command: "true", WorkingDirectory: "missing"}})
+	if _, err := (Runner{}).RunJob(context.Background(), job, workspace); err == nil || !strings.Contains(err.Error(), `working directory "missing" does not exist`) {
+		t.Fatalf("RunJob() error = %v, want missing working directory diagnostic", err)
+	}
+}
+
 func TestNestedCompositeEvaluatesEnvironmentOnceAndIsolatesStepScopes(t *testing.T) {
 	workspace := canonicalTempDir(t)
 	workflowPath := ".github/workflows/test.yml"


### PR DESCRIPTION
## Why

Running a plain starter Go workflow failed with:

```
buildkite-gha: run-job: step "step-2": composite action step 7: fork/exec /usr/bin/bash: no such file or directory
```

The workflow was fine. A composite action step (`actions-rust-lang/setup-rust-toolchain@v1` step 7 in the reproduction; `actions/setup-go` pulls in a similar pattern) declared `working-directory: ${{ inputs.rust-src-dir || '.' }}`. The runtime used the expression text literally as a path, the child process failed to chdir, and Go surfaced that as a misleading `fork/exec <shell>` error.

## What

- Evaluate composite action step `working-directory` with the step expression evaluator, matching the existing handling of `run`, `env`, and `with`.
- Resolve run-step working directories through a shared `stepWorkingDirectory` helper that requires the directory to exist, so a bad path now fails with `working directory "<path>" does not exist in the workspace` instead of a `fork/exec` error.
- Document composite `working-directory` expression support in `docs/compatibility.md`.

Covered by `TestCompositeStepWorkingDirectoryEvaluatesExpressions` and `TestRunStepMissingWorkingDirectoryFailsClearly`.
