### PR TITLE
PB-2994: Admit actions/checkout v1 and v2 release commits

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -650,10 +650,12 @@ Pre conditions use the status and action-scoped environment available when prepa
 
 ### Checkout action
 
-**🟡 Supported subset.** The final v3.7.0 release commit is admitted exactly. Resolved commits in the v4-and-later range of the static [`actions/checkout` upstream `main` snapshot](https://github.com/actions/checkout/tree/f548e57e544e1ff5a4c46bf1e1b8685f8e4a348a) are also admitted. The following known releases remain admitted even when their commits aren't reachable from that snapshot:
+**🟡 Supported subset.** The final v1.2.0, v2.8.0, and v3.7.0 release commits are admitted exactly. Resolved commits in the v4-and-later range of the static [`actions/checkout` upstream `main` snapshot](https://github.com/actions/checkout/tree/f548e57e544e1ff5a4c46bf1e1b8685f8e4a348a) are also admitted. The following known releases remain admitted even when their commits aren't reachable from that snapshot:
 
 | Release | Commit |
 | --- | --- |
+| v1.2.0 | [`50fbc622fc4ef5163becd7fab6573eac35f8462e`](https://github.com/actions/checkout/tree/50fbc622fc4ef5163becd7fab6573eac35f8462e) |
+| v2.8.0 | [`0717577d45739eb3c851188b29f50ed6c0b2194e`](https://github.com/actions/checkout/tree/0717577d45739eb3c851188b29f50ed6c0b2194e) |
 | v3.7.0 | [`a37ce9120846195fa4ece8f58b268e6043cb2f26`](https://github.com/actions/checkout/tree/a37ce9120846195fa4ece8f58b268e6043cb2f26) |
 | v4 | [`11d5960a326750d5838078e36cf38b85af677262`](https://github.com/actions/checkout/tree/11d5960a326750d5838078e36cf38b85af677262) |
 | v5 | [`fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09`](https://github.com/actions/checkout/tree/fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09) |
@@ -661,7 +663,7 @@ Pre conditions use the status and action-scoped environment available when prepa
 | v7.0.0 corpus pin | [`9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0`](https://github.com/actions/checkout/tree/9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0) |
 | v7.0.1 | [`3d3c42e5aac5ba805825da76410c181273ba90b1`](https://github.com/actions/checkout/tree/3d3c42e5aac5ba805825da76410c181273ba90b1) |
 
-Mutable refs work only while they resolve to the upstream `main` snapshot or a known release above. Every admitted commit uses the native adapter; the upstream JavaScript doesn't run. v1, v2, pre-v3.7.0 commits, and unknown commits are unsupported. Maintainers can update the v4-and-later snapshot with `go generate ./internal/action/integration`; this doesn't widen v3 admission.
+Mutable refs work only while they resolve to the upstream `main` snapshot or a known release above. Every admitted commit uses the native adapter; the upstream JavaScript doesn't run. Each admitted release accepts only the inputs it declares, so earlier releases reject later inputs. Other pre-v3.7.0 commits and unknown commits are unsupported. Compilation emits `W_CHECKOUT_LEGACY_RELEASE` for v1.2.0 and v2.8.0 to nudge an upgrade to v4 or later. Maintainers can update the v4-and-later snapshot with `go generate ./internal/action/integration`; this doesn't widen release admission.
 
 The adapter checks out a detached commit or static branch from the event repository at the workspace root or a clean top-level directory. It uses Buildkite repository-provider Git credentials when the job provides them; otherwise, it fetches anonymously. Credentials are scoped to each fetch command and verified submodule fetch command and are never persisted.
 
@@ -670,25 +672,25 @@ The adapter checks out a detached commit or static branch from the event reposit
 | `repository` | Omitted, or the event `owner/repo`. |
 | `ref` | Omitted, empty, a lowercase 40-hex commit, or a static branch in the event repository. A direct `github.sha` or `needs.<job>.outputs.<name>` expression must resolve at runtime to the exact event SHA. |
 | `token` | Omitted only. |
-| `ssh-key`, `ssh-known-hosts` | Omitted or empty. |
-| `ssh-strict` | Omitted or `true`. |
-| `ssh-user` | v4 and later: omitted or `git`. v3.7.0: omitted. |
-| `persist-credentials` | Omitted or `false`. |
+| `ssh-key`, `ssh-known-hosts` | v2.8.0 and later: omitted or empty. v1.2.0: omitted. |
+| `ssh-strict` | v2.8.0 and later: omitted or `true`. v1.2.0: omitted. |
+| `ssh-user` | v4 and later: omitted or `git`. Earlier releases: omitted. |
+| `persist-credentials` | v2.8.0 and later: omitted or `false`. v1.2.0: omitted. |
 | `path` | Omitted, empty, or one clean non-`.git` top-level workspace directory. |
 | `clean` | Omitted or `true`; the root workspace or selected path must be empty or absent. |
-| `filter` | v4 and later: omitted or empty. v3.7.0: omitted. |
-| `sparse-checkout` | Omitted or empty. |
-| `sparse-checkout-cone-mode` | Omitted or `true`. |
-| `fetch-depth` | Omitted or a nonnegative integer; `0` fetches full history. |
-| `fetch-tags` | Omitted, `true`, or `false`. |
-| `show-progress` | v4 and later: omitted, `true`, or `false`. v3.7.0: omitted. |
+| `filter` | v4 and later: omitted or empty. Earlier releases: omitted. |
+| `sparse-checkout` | v3.7.0 and later: omitted or empty. Earlier releases: omitted. |
+| `sparse-checkout-cone-mode` | v3.7.0 and later: omitted or `true`. Earlier releases: omitted. |
+| `fetch-depth` | Omitted or a nonnegative integer; `0` fetches full history. v1.2.0 fetches full history when omitted. |
+| `fetch-tags` | v3.7.0 and later: omitted, `true`, or `false`. Earlier releases: omitted. |
+| `show-progress` | v4 and later: omitted, `true`, or `false`. Earlier releases: omitted. |
 | `lfs` | Omitted or `false`. |
 | `submodules` | Omitted, `false`, `true`, or `recursive`; whitespace is trimmed and casing is ignored. |
-| `set-safe-directory` | Omitted or `true`. |
-| `github-server-url` | Omitted, empty, or `https://github.com`. |
-| `allow-unsafe-pr-checkout` | Omitted or `false`. |
+| `set-safe-directory` | v2.8.0 and later: omitted or `true`. v1.2.0: omitted. |
+| `github-server-url` | v3.7.0 and later: omitted, empty, or `https://github.com`. Earlier releases: omitted. |
+| `allow-unsafe-pr-checkout` | v2.8.0 and later: omitted or `false`. v1.2.0: omitted. |
 
-The `ref` and `commit` outputs are unavailable for v3.7.0. Upstream added them in v4.2.0.
+The `ref` and `commit` outputs are unavailable for v1.2.0, v2.8.0, and v3.7.0. Upstream added them in v4.2.0.
 
 The `false` value and omission do not run submodule commands. The `true` value runs native Git for direct children, and `recursive` includes nested children. Relative URLs and `fetch-depth` follow native Git behavior. Public and private GitHub submodules are supported under the job's repository access; external HTTPS submodules are anonymous. `git@github.com:` URLs are rewritten to HTTPS. Other SSH and non-HTTPS transports are unsupported.
 

--- a/internal/action/integration/checkout.go
+++ b/internal/action/integration/checkout.go
@@ -12,12 +12,15 @@ import (
 )
 
 const (
-	// CheckoutV3Commit through CheckoutV7Commit are the current audited release
-	// implementations. CheckoutV3Commit is the final v3 release and is admitted
-	// exactly rather than extending the v4-and-later main-branch snapshot.
+	// CheckoutV1Commit through CheckoutV7Commit are the current audited release
+	// implementations. CheckoutV1Commit, CheckoutV2Commit, and CheckoutV3Commit
+	// are the final v1, v2, and v3 releases and are admitted exactly rather
+	// than extending the v4-and-later main-branch snapshot.
 	// CheckoutV7InitialCommit is retained because it is pinned by the OSS
 	// compatibility corpus; its later v7.0.1 changes do not affect the adapter's
 	// bounded exact-event-SHA operation.
+	CheckoutV1Commit        = "50fbc622fc4ef5163becd7fab6573eac35f8462e"
+	CheckoutV2Commit        = "0717577d45739eb3c851188b29f50ed6c0b2194e"
 	CheckoutV3Commit        = "a37ce9120846195fa4ece8f58b268e6043cb2f26"
 	CheckoutV4Commit        = "11d5960a326750d5838078e36cf38b85af677262"
 	CheckoutV5Commit        = "fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09"
@@ -27,12 +30,66 @@ const (
 )
 
 var checkoutCommits = map[string]string{
+	CheckoutV1Commit:        "v1.2.0",
+	CheckoutV2Commit:        "v2.8.0",
 	CheckoutV3Commit:        "v3.7.0",
 	CheckoutV4Commit:        "v4",
 	CheckoutV5Commit:        "v5",
 	CheckoutV6Commit:        "v6",
 	CheckoutV7InitialCommit: "v7.0.0",
 	CheckoutV7Commit:        "v7.0.1",
+}
+
+// checkoutInputIntroduced records the earliest admitted release generation
+// declaring each version-gated input. Inputs absent from this map are declared
+// by every admitted release.
+var checkoutInputIntroduced = map[string]int{
+	"ssh-key":                   2,
+	"ssh-known-hosts":           2,
+	"ssh-strict":                2,
+	"persist-credentials":       2,
+	"set-safe-directory":        2,
+	"allow-unsafe-pr-checkout":  2,
+	"fetch-tags":                3,
+	"sparse-checkout":           3,
+	"sparse-checkout-cone-mode": 3,
+	"github-server-url":         3,
+	"filter":                    4,
+	"show-progress":             4,
+	"ssh-user":                  4,
+}
+
+func checkoutGeneration(commit string) int {
+	switch commit {
+	case CheckoutV1Commit:
+		return 1
+	case CheckoutV2Commit:
+		return 2
+	case CheckoutV3Commit:
+		return 3
+	}
+	return 4
+}
+
+// CheckoutSupportsOutputs reports whether the admitted release declares the
+// ref and commit outputs, added upstream in v4.2.0.
+func CheckoutSupportsOutputs(commit string) bool {
+	return checkoutGeneration(commit) >= 4
+}
+
+// CheckoutDefaultsToFullHistory reports whether the admitted release fetched
+// full history when fetch-depth was omitted, as v1's runner plugin did.
+func CheckoutDefaultsToFullHistory(commit string) bool {
+	return commit == CheckoutV1Commit
+}
+
+// LegacyCheckoutRelease reports the admitted release label for the v1 and v2
+// commits, which predate the v3.7.0 contract and warrant an upgrade warning.
+func LegacyCheckoutRelease(commit string) (string, bool) {
+	if commit == CheckoutV1Commit || commit == CheckoutV2Commit {
+		return checkoutCommits[commit], true
+	}
+	return "", false
 }
 
 // validateCheckoutCommit admits known releases and a static snapshot of
@@ -49,11 +106,6 @@ func validateCheckoutCommit(commit string) error {
 	return nil
 }
 
-// IsCheckoutV3 reports whether commit uses the audited v3.7.0 contract.
-func IsCheckoutV3(commit string) bool {
-	return commit == CheckoutV3Commit
-}
-
 func sortedCheckoutCommits() []string {
 	commits := make([]string, 0, len(checkoutCommits))
 	for commit, version := range checkoutCommits {
@@ -68,7 +120,7 @@ func sortedCheckoutCommits() []string {
 func ValidateCheckoutInputs(commit string, inputs map[string]string, repository, sha string) error {
 	names := sortedNames(inputs)
 	seen := make(map[string]bool, len(names))
-	v3 := IsCheckoutV3(commit)
+	generation := checkoutGeneration(commit)
 	for _, name := range names {
 		value := inputs[name]
 		normalized := strings.ToLower(name)
@@ -76,6 +128,9 @@ func ValidateCheckoutInputs(commit string, inputs map[string]string, repository,
 			return fmt.Errorf("duplicate case-insensitive input %q is unsupported", name)
 		}
 		seen[normalized] = true
+		if checkoutInputIntroduced[normalized] > generation {
+			return fmt.Errorf("explicit input %q is unsupported by this actions/checkout release", name)
+		}
 		switch normalized {
 		case "repository":
 			if strings.EqualFold(value, repository) {
@@ -111,7 +166,7 @@ func ValidateCheckoutInputs(commit string, inputs map[string]string, repository,
 				continue
 			}
 		case "show-progress":
-			if !v3 && actionBoolean(value) {
+			if actionBoolean(value) {
 				continue
 			}
 		case "path":
@@ -123,7 +178,7 @@ func ValidateCheckoutInputs(commit string, inputs map[string]string, repository,
 				continue
 			}
 		case "filter":
-			if !v3 && value == "" {
+			if value == "" {
 				continue
 			}
 		case "ssh-strict", "sparse-checkout-cone-mode":
@@ -131,7 +186,7 @@ func ValidateCheckoutInputs(commit string, inputs map[string]string, repository,
 				continue
 			}
 		case "ssh-user":
-			if !v3 && value == "git" {
+			if value == "git" {
 				continue
 			}
 		case "github-server-url":

--- a/internal/action/integration/checkout_test.go
+++ b/internal/action/integration/checkout_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestCheckoutCommitAdmission(t *testing.T) {
-	for _, commit := range []string{CheckoutV3Commit, CheckoutV4Commit, CheckoutV5Commit, CheckoutV6Commit, CheckoutV7InitialCommit, CheckoutV7Commit} {
+	for _, commit := range []string{CheckoutV1Commit, CheckoutV2Commit, CheckoutV3Commit, CheckoutV4Commit, CheckoutV5Commit, CheckoutV6Commit, CheckoutV7InitialCommit, CheckoutV7Commit} {
 		if err := validateCheckoutCommit(commit); err != nil {
 			t.Fatalf("audited commit %s rejected: %v", commit, err)
 		}
@@ -94,5 +94,45 @@ func TestValidateCheckoutV3InputsRejectsLaterContract(t *testing.T) {
 		"fetch-tags": "false",
 	}, repository, sha); err != nil {
 		t.Fatalf("ValidateCheckoutInputs() rejected v3 inputs: %v", err)
+	}
+}
+
+func TestValidateCheckoutLegacyInputsRejectLaterContracts(t *testing.T) {
+	repository, sha := "buildkite/buildkite-gha", strings.Repeat("a", 40)
+	if err := ValidateCheckoutInputs(CheckoutV1Commit, map[string]string{
+		"repository": repository, "ref": sha, "fetch-depth": "0",
+		"clean": "true", "lfs": "false", "submodules": "recursive", "path": "sources",
+	}, repository, sha); err != nil {
+		t.Fatalf("ValidateCheckoutInputs() rejected v1 inputs: %v", err)
+	}
+	if err := ValidateCheckoutInputs(CheckoutV2Commit, map[string]string{
+		"repository": repository, "ref": sha, "fetch-depth": "1",
+		"ssh-key": "", "ssh-known-hosts": "", "ssh-strict": "true", "persist-credentials": "false",
+		"set-safe-directory": "true", "allow-unsafe-pr-checkout": "false",
+	}, repository, sha); err != nil {
+		t.Fatalf("ValidateCheckoutInputs() rejected v2 inputs: %v", err)
+	}
+
+	for name, test := range map[string]struct {
+		commit string
+		inputs map[string]string
+	}{
+		"v1 persist-credentials": {CheckoutV1Commit, map[string]string{"persist-credentials": "false"}},
+		"v1 ssh-key":             {CheckoutV1Commit, map[string]string{"ssh-key": ""}},
+		"v1 set-safe-directory":  {CheckoutV1Commit, map[string]string{"set-safe-directory": "true"}},
+		"v1 fetch-tags":          {CheckoutV1Commit, map[string]string{"fetch-tags": "false"}},
+		"v2 fetch-tags":          {CheckoutV2Commit, map[string]string{"fetch-tags": "true"}},
+		"v2 sparse-checkout":     {CheckoutV2Commit, map[string]string{"sparse-checkout": ""}},
+		"v2 github-server-url":   {CheckoutV2Commit, map[string]string{"github-server-url": ""}},
+		"v2 filter":              {CheckoutV2Commit, map[string]string{"filter": ""}},
+		"v2 show-progress":       {CheckoutV2Commit, map[string]string{"show-progress": "true"}},
+		"v2 ssh-user":            {CheckoutV2Commit, map[string]string{"ssh-user": "git"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := ValidateCheckoutInputs(test.commit, test.inputs, repository, sha)
+			if err == nil || !strings.Contains(err.Error(), "unsupported by this actions/checkout release") {
+				t.Fatalf("ValidateCheckoutInputs(%#v) = %v, want release-contract rejection", test.inputs, err)
+			}
+		})
 	}
 }

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -306,6 +306,18 @@ func (b *actionLockBuilder) add(ctx context.Context, raw string, depth int) (*ac
 	b.active[key] = true
 	defer delete(b.active, key)
 
+	if actionintegration.UsesNativeAdapter(actionintegration.Identity{Source: n.lock.Source, Repository: n.lock.Repository, Path: n.lock.Path}) {
+		// The native adapter replaces the admitted release's execution
+		// entirely, and admitted legacy releases predate the supported
+		// metadata and runtime set, so upstream metadata must not gate
+		// admission. It still informs input declarations when it loads.
+		n.native = true
+		if m, err := metadata.Load(root, loadPath); err == nil {
+			m.SourceRoot = root
+			n.metadata = m
+		}
+		return n, nil
+	}
 	m, err := metadata.Load(root, loadPath)
 	if err != nil {
 		return nil, err
@@ -323,10 +335,6 @@ func (b *actionLockBuilder) add(ctx context.Context, raw string, depth int) (*ac
 	n.runtime = runtime
 	if err := m.ValidateEntrypoints(runtime); err != nil {
 		return nil, err
-	}
-	if actionintegration.UsesNativeAdapter(actionintegration.Identity{Source: n.lock.Source, Repository: n.lock.Repository, Path: n.lock.Path}) {
-		n.native = true
-		return n, nil
 	}
 	if runtime == metadata.RuntimeNode16 || runtime == metadata.RuntimeNode20 || runtime == metadata.RuntimeNode24 {
 		if err := expression.ValidateActionLifecycleCondition(m.Runs.PreIf); err != nil {

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -75,6 +75,71 @@ func (f *fakeActionSource) Fetch(_ context.Context, r source.Reference) (source.
 	return source.Resolved{Reference: r, Commit: commit}, source.Materialized{RepositoryRoot: f.root, ActionRoot: filepath.Join(f.root, r.Path), SourceDigest: d}, err
 }
 
+// checkoutV1LegacyManifest and checkoutV2LegacyManifest mirror the real
+// actions/checkout manifests at the admitted v1.2.0 and v2.8.0 release
+// commits: v1.2.0 declares runs.plugin with no runs.using and v2.8.0 declares
+// the retired node12 runtime, so neither passes generic metadata admission.
+const checkoutV1LegacyManifest = `name: 'Checkout'
+description: 'Checkout a Git repository.'
+inputs:
+  repository:
+    description: 'Repository name'
+  ref:
+    description: 'Ref to checkout (SHA, branch, tag)'
+  token:
+    description: 'Access token for clone repository'
+  fetch-depth:
+    description: 'The depth of commits to ask Git to fetch; defaults to no limit'
+  path:
+    description: 'Optional path to check out source code'
+runs:
+  # Plugins live on the runner and are only available to a certain set of first party actions.
+  plugin: 'checkout'
+`
+
+const checkoutV2LegacyManifest = `name: 'Checkout'
+description: 'Checkout a Git repository at a particular version'
+inputs:
+  repository:
+    description: 'Repository name with owner. For example, actions/checkout'
+    default: ${{ github.repository }}
+  token:
+    description: 'Personal access token (PAT) used to fetch the repository.'
+    default: ${{ github.token }}
+  fetch-depth:
+    description: 'Number of commits to fetch. 0 indicates all history for all branches and tags.'
+    default: 1
+  path:
+    description: 'Relative path under $GITHUB_WORKSPACE to place the repository'
+runs:
+  using: node12
+  main: dist/index.js
+  post: dist/index.js
+`
+
+func checkoutTestManifest(commit string) string {
+	switch commit {
+	case actionintegration.CheckoutV1Commit:
+		return checkoutV1LegacyManifest
+	case actionintegration.CheckoutV2Commit:
+		return checkoutV2LegacyManifest
+	default:
+		return "name: checkout\nruns:\n  using: node24\n  main: index.js\n"
+	}
+}
+
+type commitActionSource struct{ roots map[string]string }
+
+func (s commitActionSource) Fetch(_ context.Context, r source.Reference) (source.Resolved, source.Materialized, error) {
+	commit := strings.ToLower(r.Ref)
+	root, ok := s.roots[commit]
+	if !ok {
+		return source.Resolved{}, source.Materialized{}, fmt.Errorf("no fixture tree for ref %q", r.Ref)
+	}
+	d, err := source.DigestTree(filepath.Join(root, r.Path))
+	return source.Resolved{Reference: r, Commit: commit}, source.Materialized{RepositoryRoot: root, ActionRoot: filepath.Join(root, r.Path), SourceDigest: d}, err
+}
+
 func writeAction(t *testing.T, root, name, body string) {
 	t.Helper()
 	d := filepath.Join(root, name)
@@ -1014,7 +1079,6 @@ func TestCheckoutAdapterInputBoundary(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	writeAction(t, remote, "", "name: checkout\nruns:\n  using: node24\n  main: index.js\n")
 	options := Options{
 		EventTrust: EventUntrusted,
 		Runners: RunnerPolicy{
@@ -1025,6 +1089,7 @@ func TestCheckoutAdapterInputBoundary(t *testing.T) {
 		ActionSource:   &fakeActionSource{root: remote, calls: map[string]int{}},
 	}
 	compile := func(commit, with string) ([]plan.Job, error) {
+		writeAction(t, remote, "", checkoutTestManifest(commit))
 		workflow := []byte("on: push\njobs:\n  checkout:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@" + commit + "\n" + with)
 		if err := os.WriteFile(workflowPath, workflow, 0o644); err != nil {
 			t.Fatal(err)
@@ -1071,15 +1136,22 @@ func TestCheckoutAdapterInputBoundary(t *testing.T) {
 		})
 	}
 
-	if _, err := compile(actionintegration.CheckoutV3Commit, "        with:\n          show-progress: false\n"); err == nil || !strings.Contains(err.Error(), "explicit input \"show-progress\" value is unsupported") {
+	if _, err := compile(actionintegration.CheckoutV3Commit, "        with:\n          show-progress: false\n"); err == nil || !strings.Contains(err.Error(), "explicit input \"show-progress\" is unsupported by this actions/checkout release") {
 		t.Fatalf("v3.7.0 later-contract input error = %v", err)
+	}
+	if _, err := compile(actionintegration.CheckoutV2Commit, "        with:\n          fetch-tags: 'true'\n"); err == nil || !strings.Contains(err.Error(), "explicit input \"fetch-tags\" is unsupported by this actions/checkout release") {
+		t.Fatalf("v2.8.0 later-contract input error = %v", err)
+	}
+	if _, err := compile(actionintegration.CheckoutV1Commit, "        with:\n          persist-credentials: false\n"); err == nil || !strings.Contains(err.Error(), "explicit input \"persist-credentials\" is unsupported by this actions/checkout release") {
+		t.Fatalf("v1.2.0 later-contract input error = %v", err)
 	}
 }
 
 func TestCheckoutAdapterCommitBoundary(t *testing.T) {
 	workspace, remote := t.TempDir(), t.TempDir()
-	writeAction(t, remote, "", "name: checkout\nruns:\n  using: node24\n  main: index.js\n")
 	for version, commit := range map[string]string{
+		"v1.2.0":     actionintegration.CheckoutV1Commit,
+		"v2.8.0":     actionintegration.CheckoutV2Commit,
 		"v3.7.0":     actionintegration.CheckoutV3Commit,
 		"v4":         actionintegration.CheckoutV4Commit,
 		"v5":         actionintegration.CheckoutV5Commit,
@@ -1089,6 +1161,7 @@ func TestCheckoutAdapterCommitBoundary(t *testing.T) {
 		"v7.0.1":     actionintegration.CheckoutV7Commit,
 	} {
 		t.Run(version, func(t *testing.T) {
+			writeAction(t, remote, "", checkoutTestManifest(commit))
 			actionSource := &fakeActionSource{root: remote, commit: commit, calls: map[string]int{}}
 			_, locks, _, _, err := compileActionLocks(context.Background(), workspace, actionSource, []string{"actions/checkout@" + version})
 			if err != nil || len(locks) != 1 || locks[0].Commit != commit {
@@ -1098,6 +1171,7 @@ func TestCheckoutAdapterCommitBoundary(t *testing.T) {
 	}
 
 	unknown := strings.Repeat("0", 40)
+	writeAction(t, remote, "", checkoutTestManifest(unknown))
 	actionSource := &fakeActionSource{root: remote, commit: unknown, calls: map[string]int{}}
 	if _, _, _, _, err := compileActionLocks(context.Background(), workspace, actionSource, []string{"actions/checkout@v7"}); err == nil || !strings.Contains(err.Error(), "does not admit") {
 		t.Fatalf("unknown checkout commit error = %v", err)
@@ -1147,6 +1221,56 @@ func TestCheckoutCapabilityRequiresVerifiedRootAdapter(t *testing.T) {
 	_, err = compile("actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1", "        with:\n          token: '${{ github.token }}'\n")
 	if err == nil || !strings.Contains(err.Error(), "checkout adapter") {
 		t.Fatalf("workflow token input error = %v", err)
+	}
+}
+
+func TestCompileBundleLegacyCheckoutWarning(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := filepath.Join(workspace, ".github", "workflows", "checkout.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	roots := map[string]string{}
+	for _, commit := range []string{actionintegration.CheckoutV1Commit, actionintegration.CheckoutV2Commit, actionintegration.CheckoutV4Commit} {
+		root := t.TempDir()
+		writeAction(t, root, "", checkoutTestManifest(commit))
+		roots[commit] = root
+	}
+	compile := func(steps string) Bundle {
+		t.Helper()
+		workflow := []byte("on: push\njobs:\n  checkout:\n    runs-on: ubuntu-latest\n    steps:\n" + steps)
+		if err := os.WriteFile(workflowPath, workflow, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		bundle, err := CompileBundleWithOptions(workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, "importer", Options{
+			EventTrust: EventUntrusted,
+			Runners: RunnerPolicy{
+				Labels:          map[string]string{"ubuntu-latest": "hosted"},
+				UntrustedQueues: []string{"hosted"},
+			},
+			ResolveActions: true,
+			ActionSource:   commitActionSource{roots: roots},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return bundle
+	}
+
+	bundle := compile("      - uses: actions/checkout@" + actionintegration.CheckoutV1Commit + "\n" +
+		"      - uses: actions/checkout@" + actionintegration.CheckoutV1Commit + "\n" +
+		"        with:\n          path: again\n" +
+		"      - uses: actions/checkout@" + actionintegration.CheckoutV2Commit + "\n" +
+		"        with:\n          path: legacy\n")
+	if len(bundle.IR.Warnings) != 2 ||
+		bundle.IR.Warnings[0].Code != "W_CHECKOUT_LEGACY_RELEASE" || !strings.Contains(bundle.IR.Warnings[0].Message, "v1.2.0") || bundle.IR.Warnings[0].Line == 0 ||
+		bundle.IR.Warnings[1].Code != "W_CHECKOUT_LEGACY_RELEASE" || !strings.Contains(bundle.IR.Warnings[1].Message, "v2.8.0") {
+		t.Fatalf("legacy checkout warnings = %#v", bundle.IR.Warnings)
+	}
+
+	bundle = compile("      - uses: actions/checkout@" + actionintegration.CheckoutV4Commit + "\n")
+	if len(bundle.IR.Warnings) != 0 {
+		t.Fatalf("warnings = %#v, want none", bundle.IR.Warnings)
 	}
 }
 

--- a/internal/compiler/bundle.go
+++ b/internal/compiler/bundle.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"strings"
 
+	actionintegration "github.com/buildkite/buildkite-gha/internal/action/integration"
 	buildkitepipeline "github.com/buildkite/buildkite-gha/internal/buildkite"
 	"github.com/buildkite/buildkite-gha/internal/plan"
 	"github.com/buildkite/buildkite-gha/internal/transport"
@@ -91,6 +92,29 @@ func CompileBundlePlansContext(ctx context.Context, path string, source, eventSo
 	}
 	if len(plans) != len(ir.Jobs) || len(authorizations) != len(plans) {
 		return bundle, processingFinding(StagePlans, CodePlanConstruction, "compatibility", fmt.Errorf("compiler produced %d plans and %d authorizations for %d job instances", len(plans), len(authorizations), len(ir.Jobs)))
+	}
+	warnedLegacyCheckout := map[string]bool{}
+	for i, job := range plans {
+		locks := make(map[string]plan.ActionLock, len(job.Actions))
+		for _, lock := range job.Actions {
+			locks[lock.ID] = lock
+		}
+		for stepIndex, step := range job.Steps {
+			if step.Action == nil || stepIndex >= len(ir.Jobs[i].Steps) {
+				continue
+			}
+			lock := locks[step.Action.Lock]
+			descriptor, _ := actionintegration.Lookup(actionintegration.Identity{Source: lock.Source, Repository: lock.Repository, Path: lock.Path})
+			if descriptor.Adapter != actionintegration.AdapterCheckoutExactEventSHA {
+				continue
+			}
+			release, legacy := actionintegration.LegacyCheckoutRelease(lock.Commit)
+			if !legacy || warnedLegacyCheckout[release] {
+				continue
+			}
+			warnedLegacyCheckout[release] = true
+			bundle.IR.Warnings = append(bundle.IR.Warnings, legacyCheckoutWarning(ir.Jobs[i].Steps[stepIndex].Span.Start, release))
+		}
 	}
 	warnedReusablePermissions := false
 	warnedJobPermissions := false

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -934,6 +934,15 @@ func compilerWarnings(parsed *workflow.Workflow, cancelInProgress bool) []Warnin
 	return warnings
 }
 
+func legacyCheckoutWarning(position workflow.Position, release string) Warning {
+	return Warning{
+		Code:    "W_CHECKOUT_LEGACY_RELEASE",
+		Line:    position.Line,
+		Column:  position.Column,
+		Message: fmt.Sprintf("actions/checkout %s is emulated by the native adapter with its release contract; upgrade to v4 or later", release),
+	}
+}
+
 func reusableWorkflowTokenWarning(position workflow.Position) Warning {
 	return Warning{
 		Code:    "W_REUSABLE_WORKFLOW_TOKEN_USES_ROOT_PERMISSIONS",

--- a/internal/runtime/actions.go
+++ b/internal/runtime/actions.go
@@ -249,6 +249,12 @@ func (r *actionLockResolver) verifyGitHub(ctx context.Context, entry *actionLock
 	}
 	m, err := metadata.Load(repositoryRoot, lock.Path)
 	if err != nil {
+		// Admitted legacy releases predate the supported metadata set, and a
+		// native adapter replaces their execution entirely, so the verified
+		// tree digest is the admission boundary rather than the manifest.
+		if usesNativeAdapter(lock) {
+			return metadata.Metadata{SourceRoot: repositoryRoot}, nil
+		}
 		return metadata.Metadata{}, fmt.Errorf("load materialized action: %w", err)
 	}
 	digest, err = source.DigestTree(repositoryRoot)

--- a/internal/runtime/checkout.go
+++ b/internal/runtime/checkout.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -79,6 +80,7 @@ func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, wo
 	if err := actionintegration.ValidateCheckoutInputs(commit, inputs, job.Event.Repository, job.Event.SHA); err != nil {
 		return result, fmt.Errorf("%s: %w", adapter, err)
 	}
+	inputs = checkoutInputsWithReleaseDefaults(commit, inputs)
 	checkoutDirectory, err := prepareCheckoutDirectory(workspace, inputs)
 	if err != nil {
 		return result, fmt.Errorf("%s: %w", adapter, err)
@@ -144,12 +146,26 @@ func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, wo
 }
 
 func setCheckoutOutputs(outputs map[string]string, commit, ref, headSHA string) {
-	// Checkout outputs were added in v4.2.0 and aren't part of the v3 contract.
-	if actionintegration.IsCheckoutV3(commit) {
+	// Checkout outputs were added in v4.2.0 and aren't part of earlier contracts.
+	if !actionintegration.CheckoutSupportsOutputs(commit) {
 		return
 	}
 	outputs["ref"] = ref
 	outputs["commit"] = headSHA
+}
+
+// checkoutInputsWithReleaseDefaults applies v1's full-history fetch default,
+// which lived in the historical runner plugin rather than an action manifest.
+func checkoutInputsWithReleaseDefaults(commit string, inputs map[string]string) map[string]string {
+	if !actionintegration.CheckoutDefaultsToFullHistory(commit) || checkoutInput(inputs, "fetch-depth") != "" {
+		return inputs
+	}
+	defaulted := maps.Clone(inputs)
+	if defaulted == nil {
+		defaulted = map[string]string{}
+	}
+	defaulted["fetch-depth"] = "0"
+	return defaulted
 }
 
 func checkoutRepositoryURL(provider, repository string) (url, credentialHost string, ok bool) {

--- a/internal/runtime/checkout_test.go
+++ b/internal/runtime/checkout_test.go
@@ -373,6 +373,8 @@ func TestCheckoutOutputsMatchReleaseContract(t *testing.T) {
 		commit string
 		want   map[string]string
 	}{
+		{name: "v1.2.0", commit: actionintegration.CheckoutV1Commit, want: map[string]string{}},
+		{name: "v2.8.0", commit: actionintegration.CheckoutV2Commit, want: map[string]string{}},
 		{name: "v3.7.0", commit: actionintegration.CheckoutV3Commit, want: map[string]string{}},
 		{name: "v4 and later", commit: actionintegration.CheckoutV4Commit, want: map[string]string{"ref": "refs/heads/main", "commit": strings.Repeat("a", 40)}},
 	} {
@@ -381,6 +383,26 @@ func TestCheckoutOutputsMatchReleaseContract(t *testing.T) {
 			setCheckoutOutputs(outputs, test.commit, "refs/heads/main", strings.Repeat("a", 40))
 			if !maps.Equal(outputs, test.want) {
 				t.Fatalf("checkout outputs = %#v, want %#v", outputs, test.want)
+			}
+		})
+	}
+}
+
+func TestCheckoutInputsWithReleaseDefaults(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		commit string
+		inputs map[string]string
+		want   map[string]string
+	}{
+		{name: "v1 defaults to full history", commit: actionintegration.CheckoutV1Commit, inputs: nil, want: map[string]string{"fetch-depth": "0"}},
+		{name: "v1 keeps explicit depth", commit: actionintegration.CheckoutV1Commit, inputs: map[string]string{"Fetch-Depth": "5"}, want: map[string]string{"Fetch-Depth": "5"}},
+		{name: "v2 keeps shallow default", commit: actionintegration.CheckoutV2Commit, inputs: nil, want: nil},
+		{name: "v4 keeps shallow default", commit: actionintegration.CheckoutV4Commit, inputs: map[string]string{"ref": "main"}, want: map[string]string{"ref": "main"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := checkoutInputsWithReleaseDefaults(test.commit, test.inputs); !maps.Equal(got, test.want) {
+				t.Fatalf("checkoutInputsWithReleaseDefaults() = %#v, want %#v", got, test.want)
 			}
 		})
 	}
@@ -1283,6 +1305,147 @@ fi
 	}
 	if strings.Contains(logs.String(), repositoryToken) {
 		t.Fatalf("checkout exposed repository token in logs: %q", logs.String())
+	}
+}
+
+// legacyCheckoutManifests mirror the real actions/checkout manifests at the
+// admitted v1.2.0 and v2.8.0 release commits: v1.2.0 declares runs.plugin
+// with no runs.using and v2.8.0 declares the retired node12 runtime, so
+// neither passes generic metadata admission.
+var legacyCheckoutManifests = map[string]string{
+	actionintegration.CheckoutV1Commit: "name: 'Checkout'\ndescription: 'Checkout a Git repository.'\nruns:\n  plugin: 'checkout'\n",
+	actionintegration.CheckoutV2Commit: "name: 'Checkout'\nruns:\n  using: node12\n  main: dist/index.js\n  post: dist/index.js\n",
+}
+
+func writeLegacyCheckoutTree(t *testing.T, commit string) (string, string) {
+	t.Helper()
+	remote := t.TempDir()
+	manifest := legacyCheckoutManifests[commit]
+	if err := os.WriteFile(filepath.Join(remote, "action.yml"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(manifest, "dist/index.js") {
+		if err := os.Mkdir(filepath.Join(remote, "dist"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(remote, "dist", "index.js"), []byte("throw new Error('adapter must not execute checkout JavaScript')\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	digest, err := source.DigestTree(remote)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return remote, digest
+}
+
+func TestCheckoutAdapterRunsLegacyReleaseManifests(t *testing.T) {
+	for name, test := range map[string]struct {
+		commit    string
+		fetchWant string
+		fetchSkip string
+	}{
+		"v1.2.0 plugin manifest": {commit: actionintegration.CheckoutV1Commit, fetchWant: "--prune origin", fetchSkip: "--depth="},
+		"v2.8.0 node12 manifest": {commit: actionintegration.CheckoutV2Commit, fetchWant: "--depth=1 origin"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			workspace := t.TempDir()
+			remote, remoteDigest := writeLegacyCheckoutTree(t, test.commit)
+
+			sha := strings.Repeat("a", 40)
+			gitLog := filepath.Join(t.TempDir(), "git.log")
+			git := filepath.Join(t.TempDir(), "git")
+			script := `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> ` + shellTestQuote(gitLog) + `
+operation=
+for argument in "$@"; do
+  case "$argument" in init|checkout) operation="$argument"; break ;; esac
+done
+case "$operation" in
+  init) mkdir -p .git ;;
+  checkout) printf '%s\n' ` + shellTestQuote(sha) + ` > .git/HEAD ;;
+esac
+`
+			if err := os.WriteFile(git, []byte(script), 0o700); err != nil {
+				t.Fatal(err)
+			}
+
+			workflowSource := []byte("name: legacy checkout\n")
+			workflowDigest := sha256.Sum256(workflowSource)
+			checkoutID := "a-0000000000000001"
+			requiresMise := false
+			job := plan.Job{
+				Schema: plan.Schema,
+				Compiler: plan.Compiler{
+					Version: "checkout-test", DistributionDigest: "sha256:" + strings.Repeat("2", 64),
+				},
+				Runtime: &plan.Runtime{DistributionDigest: "sha256:" + strings.Repeat("2", 64)},
+				Workflow: plan.Workflow{
+					Path: ".github/workflows/test.yml", Digest: "sha256:" + hex.EncodeToString(workflowDigest[:]), LogicalJobID: "checkout",
+				},
+				Event: plan.Event{
+					Provider: "github", Name: "push", PayloadDigest: "sha256:" + strings.Repeat("3", 64), Repository: "buildkite/buildkite-gha", Ref: "refs/heads/main", SHA: sha,
+				},
+				Target:               plan.Target{StepKey: "gha-checkout", Queue: "trusted"},
+				RequiredCapabilities: []string{"network"},
+				Steps: []plan.Step{
+					{ID: "checkout", Kind: "uses", Uses: "actions/checkout@" + test.commit, Action: &plan.ActionSelector{Lock: checkoutID}},
+				},
+				Actions: []plan.ActionLock{
+					{ID: checkoutID, Source: "github", Repository: "actions/checkout", RequestedRef: test.commit, Commit: test.commit, SourceDigest: remoteDigest},
+				},
+				RequiresMise: &requiresMise,
+			}
+			materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, ActionRoot: remote, SourceDigest: remoteDigest}}
+			var logs bytes.Buffer
+			result, err := (Runner{Git: git, Actions: materializer, Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+			if err != nil || result.Conclusion != "success" {
+				t.Fatalf("RunJob() result = %#v, error = %v, logs = %q", result, err, logs.String())
+			}
+			logBytes, err := os.ReadFile(gitLog)
+			if err != nil {
+				t.Fatal(err)
+			}
+			log := string(logBytes)
+			if !strings.Contains(log, test.fetchWant) {
+				t.Fatalf("Git log lacks %q:\n%s", test.fetchWant, log)
+			}
+			if test.fetchSkip != "" && strings.Contains(log, test.fetchSkip) {
+				t.Fatalf("Git log contains %q:\n%s", test.fetchSkip, log)
+			}
+		})
+	}
+}
+
+func TestContainerPreparationSkipsNativeCheckoutClassification(t *testing.T) {
+	for name, commit := range map[string]string{
+		"v1.2.0 plugin manifest": actionintegration.CheckoutV1Commit,
+		"v2.8.0 node12 manifest": actionintegration.CheckoutV2Commit,
+	} {
+		t.Run(name, func(t *testing.T) {
+			remote, remoteDigest := writeLegacyCheckoutTree(t, commit)
+			checkoutID := "a-0000000000000001"
+			job := plan.Job{
+				RequiredCapabilities: []string{"network"},
+				Steps: []plan.Step{
+					{ID: "checkout", Kind: "uses", Uses: "actions/checkout@" + commit, Action: &plan.ActionSelector{Lock: checkoutID}},
+				},
+				Actions: []plan.ActionLock{
+					{ID: checkoutID, Source: "github", Repository: "actions/checkout", RequestedRef: commit, Commit: commit, SourceDigest: remoteDigest},
+				},
+			}
+			materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, ActionRoot: remote, SourceDigest: remoteDigest}}
+			actions := newActionLockResolver(job, t.TempDir(), materializer)
+			runner := &Runner{}
+			if err := runner.verifyRemoteActionTree(context.Background(), actions, plan.ActionSelector{Lock: checkoutID}, nil); err != nil {
+				t.Fatalf("verifyRemoteActionTree() error = %v", err)
+			}
+			mounts, err := runner.actionContainerMounts(context.Background(), actions)
+			if err != nil || len(mounts) != 0 {
+				t.Fatalf("actionContainerMounts() = %#v, error = %v", mounts, err)
+			}
+		})
 	}
 }
 

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -551,7 +551,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		// lazy. Materialize every remote lock now because bind mounts cannot be
 		// added after the persistent container is created.
 		for _, lock := range job.Actions {
-			if lock.Source != "github" {
+			if lock.Source != "github" || usesNativeAdapter(lock) {
 				continue
 			}
 			action, _, resolveErr := actions.resolve(runCtx, plan.ActionSelector{Lock: lock.ID})
@@ -1587,15 +1587,15 @@ func (r Runner) verifyRemoteActionTree(ctx context.Context, actions *actionLockR
 			return fmt.Errorf("action recursion detected at lock %q", lock.ID)
 		}
 	}
+	if usesNativeAdapter(lock) {
+		return nil
+	}
 	runtime, err := action.Runtime()
 	if err != nil {
 		return err
 	}
 	if err := action.ValidateEntrypoints(runtime); err != nil {
 		return err
-	}
-	if usesNativeAdapter(lock) {
-		return nil
 	}
 	if runtime != metadata.RuntimeComposite {
 		return nil
@@ -1621,6 +1621,11 @@ func (r *Runner) actionContainerMounts(ctx context.Context, actions *actionLockR
 	requiredNode := map[int]bool{}
 	unknownWorkspaceRuntime := false
 	for _, lock := range actions.job.Actions {
+		// A native adapter replaces the admitted action's execution entirely,
+		// so its source tree is never mounted or classified for the container.
+		if usesNativeAdapter(lock) {
+			continue
+		}
 		entry := actions.locks[lock.ID]
 		entry.mu.Lock()
 		material := entry.material
@@ -1660,9 +1665,6 @@ func (r *Runner) actionContainerMounts(ctx context.Context, actions *actionLockR
 				return nil, fmt.Errorf("conflicting verified action roots for %q", target)
 			}
 			byTarget[target] = m
-		}
-		if usesNativeAdapter(lock) {
-			continue
 		}
 		if major, ok := actionNodeMajor(actionRuntime); ok {
 			requiredNode[major] = true
@@ -1734,6 +1736,12 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 	if err != nil {
 		return result, err
 	}
+	// The native adapters replace the verified action's lifecycle as one
+	// indivisible operation, so upstream metadata never classifies and no
+	// upstream cleanup is registered for phases this runtime never executes.
+	if usesCheckoutAdapter(lock) || usesUploadArtifactAdapter(lock) || usesDownloadArtifactAdapter(lock) {
+		return result, nil
+	}
 	runtime, err := action.Runtime()
 	if err != nil {
 		return result, fmt.Errorf("action %q uses %w", step.Uses, err)
@@ -1744,12 +1752,6 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 
 	switch runtime {
 	case metadata.RuntimeNode16, metadata.RuntimeNode20, metadata.RuntimeNode24:
-		// The checkout adapter replaces the verified action's JavaScript
-		// lifecycle as one indivisible operation. Do not register upstream
-		// checkout cleanup for a main phase that this runtime never executes.
-		if usesCheckoutAdapter(lock) || usesUploadArtifactAdapter(lock) || usesDownloadArtifactAdapter(lock) {
-			return result, nil
-		}
 		if err := expression.ValidateActionLifecycleCondition(action.Runs.PreIf); err != nil {
 			return result, fmt.Errorf("JavaScript action %q pre-if: %w", step.Uses, err)
 		}


### PR DESCRIPTION
## Why

`actions/checkout@v1` and `@v2` resolve to commits outside the admitted set, so workflows pinning them fail compilation with "This actions/checkout version is unsupported". Corpus data shows this is the largest single compatibility gap: 6,986 repos are blocked by this alone.

Resolves PB-2994.

## What

- Admit the final v1 (`v1.2.0`, `50fbc62`) and v2 (`v2.8.0`, `0717577`) release commits for the native checkout adapter.
- Gate inputs per release: each admitted release accepts only the inputs its `action.yml` declares (verified against the upstream manifests), rejecting later inputs fail-closed, generalizing the existing v3.7.0 gating.
- Keep the `ref`/`commit` outputs suppressed for every pre-v4 release; upstream added them in v4.2.0, and previously only v3.7.0 was exempt.
- Fetch full history for v1 when `fetch-depth` is omitted, matching its historical runner-plugin default, so jobs relying on full history don't break at runtime.
- Emit a `W_CHECKOUT_LEGACY_RELEASE` compile warning for v1/v2, once per release, nudging an upgrade to v4 or later.
- Document the new admitted releases and per-release input gating in `docs/compatibility.md`.

Covered by `TestValidateCheckoutLegacyInputsRejectLaterContracts`, `TestCheckoutInputsWithReleaseDefaults`, `TestCheckoutOutputsMatchReleaseContract`, and `TestCompileBundleLegacyCheckoutWarning`.
