### PR TITLE
Support Python shell steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The [compatibility reference](docs/compatibility.md) is the source of truth. Use
 
 | Good fit | Not currently supported |
 | --- | --- |
-| Linux x86-64 and native macOS arm64 jobs using `bash` or `sh` | Windows, Linux arm64, or macOS x86-64 |
+| Linux x86-64 and native macOS arm64 jobs using `bash`, `sh`, or `python` | Windows, Linux arm64, or macOS x86-64 |
 | Local and public JavaScript and composite actions; verified Dockerfile actions on Linux | Private actions, Dockerfile actions on macOS, or arbitrary reusable-workflow source |
 | Static matrices, `needs`, outputs, and local reusable workflows | Dynamic matrices and expressions outside the documented subset |
 | Exact-commit checkout, including managed private repository access | GitHub environment secrets, GitHub-issued OIDC claims, or protected queues |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -33,7 +33,7 @@ Looking for something else? [Browse open compatibility issues](https://github.co
 | [Platforms](#job-configuration) | 🟡 Supported subset | The hosted importer provides Linux x86-64 with `ubuntu-latest`, `ubuntu-24.04`, or `ubuntu-22.04`. Its Agent API resolves single macOS labels to native macOS arm64 hosted queues before local runner mappings. Labels do not provide GitHub image, toolchain, or Xcode parity. |
 | [Jobs and dependencies](#job-configuration) | ✅ Supported | Static dependencies, matrix fan-out and fan-in, results, and bounded outputs. |
 | [Matrix strategies](#matrix-strategies) | 🟡 Supported subset | Static matrices, `include`, `exclude`, and literal `max-parallel`. Maximum 256 instances per job. `fail-fast` has no effect. |
-| [Shell steps](#commands-and-actions) | 🟡 Supported subset | Linux and macOS `bash` and `sh`. |
+| [Shell steps](#commands-and-actions) | 🟡 Supported subset | Linux and macOS `bash`, `sh`, and `python`. |
 | [Conditions and expressions](#expressions-and-contexts) | 🟡 Supported subset | GitHub-compatible core operators and direct references to selected contexts. |
 | [Reusable workflows](#reusable-workflows) | 🟡 Supported subset | Local workflows with static inputs and direct job-output mappings. Secret forwarding is unsupported. |
 | [Actions](#actions) | 🟡 Supported subset | Local and public JavaScript and composite actions on Linux and macOS; verified Dockerfile actions on Linux only. |
@@ -255,7 +255,7 @@ Jobs expanded from local reusable workflows use the top-level requesting workflo
 | Key | Status | Behavior |
 | --- | --- | --- |
 | `env` | 🟡 Supported subset | Workflow, job, and step maps use normal precedence; the most specific value wins. Individual values may use supported interpolation. An entire map cannot be expression-valued. |
-| `defaults.run.shell` | 🟡 Supported subset | Supported at workflow and job level. Only `bash` and `sh` are supported. Host jobs default to `bash`; job containers default to `sh`. |
+| `defaults.run.shell` | 🟡 Supported subset | Supported at workflow and job level. Only `bash`, `sh`, and `python` are supported. Host jobs default to `bash`; job containers default to `sh`. |
 | `defaults.run.working-directory` | 🟡 Supported subset | Supported at workflow and job level for workspace-relative paths. |
 
 A job-level value overrides the same workflow-level environment variable:
@@ -469,7 +469,7 @@ A step can continue after failure and expose its outcome to a later condition:
 
 ### Commands and actions
 
-**🟡 Supported subset.** Commands run in `bash` or `sh` within the Linux or macOS workspace. PowerShell, Python as a shell, Windows shells, and custom shell templates are unsupported. Working directories cannot escape the workspace.
+**🟡 Supported subset.** Commands run in `bash`, `sh`, or `python` within the Linux or macOS workspace. PowerShell, Windows shells, and custom shell templates are unsupported. Working directories cannot escape the workspace. The runner or job container must provide the selected shell on `PATH`.
 
 A shell step can specify its shell and workspace-relative working directory:
 
@@ -625,7 +625,7 @@ Matrices, runner labels, names, concurrency groups, and event-backed conditions 
 | Public `owner/repo[/path]@ref` action | 🟡 Supported subset | Resolved to an exact commit and digest. |
 | Private action | ❌ Unsupported | No private action source access. |
 | JavaScript action | ✅ Supported | Declares `node16`, `node20`, or `node24`. |
-| Composite action | 🟡 Supported subset | Nested shell steps and locked local or public actions; `bash` or `sh` for `run`; literal `continue-on-error`. |
+| Composite action | 🟡 Supported subset | Nested shell steps and locked local or public actions; `bash`, `sh`, or `python` for `run`; literal `continue-on-error`. |
 | Dockerfile action | 🟡 Supported subset | Verified local or public Dockerfile action on Linux. Rejected on macOS, including through a composite action. |
 | `docker://` action | ❌ Unsupported | Rejected during validation. |
 | Top-level action metadata `env` | ➖ Accepted, no effect | Any valid YAML value is discarded. It is not evaluated, injected, retained in plans, or used to request secrets or tokens. |

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -687,6 +687,42 @@ func TestRunJobContainerDefaultsRunStepsToSh(t *testing.T) {
 	t.Fatal("default-shell container exec call not found")
 }
 
+func TestRunJobContainerPythonShellUsesMountedScript(t *testing.T) {
+	f := newJobDocker(t, "")
+	workspace := t.TempDir()
+	j := jobContainerPlan(t, workspace, []plan.Step{{
+		ID:    "python",
+		Kind:  "run",
+		Shell: "python",
+		Command: `import os
+with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+    output.write(f"script={__file__}\n")
+`,
+	}})
+	j.Outputs = map[string]string{"script": "${{ steps.python.outputs.script }}"}
+	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(context.Background(), j, workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if script := result.Outputs["script"]; !strings.HasSuffix(script, ".py") {
+		t.Fatalf("container Python script path = %q, want .py suffix", script)
+	} else if _, err := os.Stat(script); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("temporary Python script remains at %q: %v", script, err)
+	}
+	for _, call := range f.calls(t) {
+		i := slices.Index(call.Args, ContainerProcessHelperCommand)
+		if i < 0 || len(call.Args) < i+5 || call.Args[i+3] != "python" {
+			continue
+		}
+		script := call.Args[i+4]
+		if !strings.HasPrefix(script, jobContainerTemp+"/buildkite-gha-shell-") || !strings.HasSuffix(script, ".py") {
+			t.Fatalf("container Python argv = %#v", call.Args[i+3:])
+		}
+		return
+	}
+	t.Fatal("Python container exec call not found")
+}
+
 func TestRunJobContainerServicesLifecycleAndArguments(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -688,17 +688,21 @@ func TestRunJobContainerDefaultsRunStepsToSh(t *testing.T) {
 }
 
 func TestRunJobContainerPythonShellUsesMountedScript(t *testing.T) {
+	installPythonShellTestCommand(t)
 	f := newJobDocker(t, "")
 	workspace := t.TempDir()
-	j := jobContainerPlan(t, workspace, []plan.Step{{
-		ID:    "python",
-		Kind:  "run",
-		Shell: "python",
-		Command: `import os
+	j := jobContainerPlan(t, workspace, []plan.Step{
+		{
+			ID:    "python",
+			Kind:  "run",
+			Shell: "python",
+			Command: `import os
 with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
     output.write(f"script={__file__}\n")
 `,
-	}})
+		},
+		{ID: "cleanup", Kind: "run", Shell: "sh", Command: `set -- "$RUNNER_TEMP"/buildkite-gha-shell-*.py; test ! -e "$1"`},
+	})
 	j.Outputs = map[string]string{"script": "${{ steps.python.outputs.script }}"}
 	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(context.Background(), j, workspace)
 	if err != nil {

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -2469,7 +2469,7 @@ func (r Runner) runShellProcess(ctx context.Context, processor *commandProcessor
 		return fmt.Errorf("create Python shell script: %w", err)
 	}
 	path := file.Name()
-	defer func() { _ = os.Remove(path) }()
+	defer func(path string) { _ = os.Remove(path) }(path)
 	if _, err := file.WriteString(script); err != nil {
 		return errors.Join(fmt.Errorf("write Python shell script: %w", err), file.Close())
 	}

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -1955,12 +1955,8 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 		if err != nil {
 			return result, err
 		}
-		args, err := shellCommand(shell, script)
-		if err != nil {
-			return result, err
-		}
 		runEnv := environment.process()
-		err = r.runProcess(ctx, processor, dir, runEnv, &result, nil, args[0], args[1:]...)
+		err = r.runShellProcess(ctx, processor, dir, runEnv, &result, shell, script)
 		return result, err
 	}
 
@@ -2281,7 +2277,6 @@ func (r Runner) runCompositeMetadata(ctx context.Context, processor *commandProc
 			childErr = fmt.Errorf("composite action step %d has no run command", i+1)
 		} else {
 			var script, dir string
-			var args []string
 			var env map[string]string
 			env, childErr = evaluateStepMap(step.Env, eval)
 			if childErr == nil {
@@ -2295,10 +2290,7 @@ func (r Runner) runCompositeMetadata(ctx context.Context, processor *commandProc
 				}
 			}
 			if childErr == nil {
-				args, childErr = shellCommand(step.Shell, script)
-			}
-			if childErr == nil {
-				childErr = r.runProcess(ctx, processor, dir, mergeStepEnvironment(childJobEnv, env), &stepResult, nil, args[0], args[1:]...)
+				childErr = r.runShellProcess(ctx, processor, dir, mergeStepEnvironment(childJobEnv, env), &stepResult, step.Shell, script)
 			}
 		}
 		mergeInto(result.Env, stepResult.Env)
@@ -2457,6 +2449,42 @@ func shellCommand(shell, script string) ([]string, error) {
 	default:
 		return nil, fmt.Errorf("shell %q is unsupported in the supported runtime subset", shell)
 	}
+}
+
+func (r Runner) runShellProcess(ctx context.Context, processor *commandProcessor, dir string, env map[string]string, result *Result, shell, script string) error {
+	if strings.TrimSpace(shell) != "python" {
+		args, err := shellCommand(shell, script)
+		if err != nil {
+			return err
+		}
+		return r.runProcess(ctx, processor, dir, env, result, nil, args[0], args[1:]...)
+	}
+
+	parent := ""
+	if r.jobContainer != nil {
+		parent = r.runnerTemp
+	}
+	file, err := os.CreateTemp(parent, "buildkite-gha-shell-*.py")
+	if err != nil {
+		return fmt.Errorf("create Python shell script: %w", err)
+	}
+	path := file.Name()
+	defer func() { _ = os.Remove(path) }()
+	if _, err := file.WriteString(script); err != nil {
+		return errors.Join(fmt.Errorf("write Python shell script: %w", err), file.Close())
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close Python shell script: %w", err)
+	}
+	if r.jobContainer != nil {
+		// Job containers may declare any USER, so the mounted script must be
+		// readable without assuming a shared host UID or GID.
+		if err := os.Chmod(path, 0o644); err != nil {
+			return fmt.Errorf("make Python shell script container-readable: %w", err)
+		}
+		path = r.jobContainer.containerPath(path)
+	}
+	return r.runProcess(ctx, processor, dir, env, result, nil, "python", path)
 }
 
 // stepWorkingDirectory resolves a run step's working directory and requires it

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -5020,6 +5020,7 @@ runs:
 }
 
 func TestRunJobPythonShellUsesTemporaryScript(t *testing.T) {
+	installPythonShellTestCommand(t)
 	workspace := t.TempDir()
 	workflowPath := ".github/workflows/test.yml"
 	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
@@ -5051,6 +5052,7 @@ with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
 }
 
 func TestCompositePythonShell(t *testing.T) {
+	installPythonShellTestCommand(t)
 	workspace := t.TempDir()
 	workflowPath := ".github/workflows/test.yml"
 	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
@@ -5076,6 +5078,62 @@ runs:
 	}
 	if result.Outputs["value"] != "python-composite" {
 		t.Fatalf("RunJob() output = %q, want python-composite", result.Outputs["value"])
+	}
+}
+
+func installPythonShellTestCommand(t *testing.T) {
+	t.Helper()
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	python := filepath.Join(dir, "python")
+	wrapper := "#!/bin/sh\nBUILDKITE_GHA_TEST_PYTHON_HELPER=1 exec " + shellTestQuote(executable) + " -test.run '^TestPythonShellCommandHelper$' -- \"$@\"\n"
+	if err := os.WriteFile(python, []byte(wrapper), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func TestPythonShellCommandHelper(t *testing.T) {
+	if os.Getenv("BUILDKITE_GHA_TEST_PYTHON_HELPER") == "" {
+		return
+	}
+	separator := slices.Index(os.Args, "--")
+	if separator < 0 || separator+1 >= len(os.Args) {
+		t.Fatalf("Python helper arguments = %#v", os.Args)
+	}
+	script := os.Args[separator+1]
+	source, err := os.ReadFile(script)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Ext(script) != ".py" {
+		t.Fatalf("Python script = %q, want .py suffix", script)
+	}
+	if cwd, err := os.Getwd(); err != nil || cwd != os.Getenv("GITHUB_WORKSPACE") {
+		t.Fatalf("working directory = %q, %v; workspace = %q", cwd, err, os.Getenv("GITHUB_WORKSPACE"))
+	}
+	var output string
+	switch {
+	case bytes.Contains(source, []byte(`script={__file__}`)):
+		output = "script=" + script + "\n"
+	case bytes.Contains(source, []byte(`value=python-composite`)):
+		output = "value=python-composite\n"
+	default:
+		t.Fatalf("unexpected Python source: %s", source)
+	}
+	file, err := os.OpenFile(os.Getenv("GITHUB_OUTPUT"), os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.WriteString(output); err != nil {
+		_ = file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -5019,6 +5019,66 @@ runs:
 	}
 }
 
+func TestRunJobPythonShellUsesTemporaryScript(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{
+		ID:    "python",
+		Kind:  "run",
+		Shell: "python",
+		Command: `import os
+from pathlib import Path
+
+assert Path.cwd() == Path(os.environ["GITHUB_WORKSPACE"])
+assert Path(__file__).suffix == ".py"
+with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+    output.write(f"script={__file__}\n")
+`,
+	}})
+	job.Outputs = map[string]string{"script": "${{ steps.python.outputs.script }}"}
+	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	if err != nil {
+		t.Fatalf("RunJob() error = %v", err)
+	}
+	script := result.Outputs["script"]
+	if !strings.HasSuffix(script, ".py") {
+		t.Fatalf("Python script path = %q, want .py suffix", script)
+	}
+	if _, err := os.Stat(script); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("temporary Python script remains at %q: %v", script, err)
+	}
+}
+
+func TestCompositePythonShell(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	writeFixtureFile(t, workspace, ".github/actions/composite/action.yml", `name: Python composite
+outputs:
+  value:
+    value: ${{ steps.python.outputs.value }}
+runs:
+  using: composite
+  steps:
+    - id: python
+      shell: python
+      run: |
+        import os
+        with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+            output.write("value=python-composite\n")
+`)
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "composite", Kind: "uses", Uses: "./.github/actions/composite"}})
+	job.Outputs = map[string]string{"value": "${{ steps.composite.outputs.value }}"}
+	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	if err != nil {
+		t.Fatalf("RunJob() error = %v", err)
+	}
+	if result.Outputs["value"] != "python-composite" {
+		t.Fatalf("RunJob() output = %q, want python-composite", result.Outputs["value"])
+	}
+}
+
 func TestCompositeStepWorkingDirectoryEvaluatesExpressions(t *testing.T) {
 	workspace := t.TempDir()
 	workflowPath := ".github/workflows/test.yml"


### PR DESCRIPTION
## Why

Workflows using `shell: python` currently fail even when Python is available on supported runner images and job containers.

## What

Support Python shell steps in jobs and composite actions by writing each command to a temporary `.py` file and invoking `python`, matching GitHub Actions script-file semantics. Translate and expose the script inside job containers, clean it up after execution, and document the expanded shell compatibility.