### PR TITLE
Replace fail-closed jargon with explicit behavior

### DIFF
--- a/.deepsec/data/buildkite-gha/INFO.md
+++ b/.deepsec/data/buildkite-gha/INFO.md
@@ -17,7 +17,7 @@ cache, and narrowly supported Docker action behaviour.
   compiler `PlanAuthorization` evidence decides whether requested Docker or
   provider-token capabilities may enter an uploaded plan.
 - `plan.Job.Validate`, `verifyWorkflow`, and runtime capability checks bind a
-  job to exact workflow bytes and fail closed on unknown authority.
+  job to exact workflow bytes and reject unknown authority.
 - `resolveAgentRepositoryCredentialsBeforeWorkflow` and
   `runRepositoryProviderCheckoutFetch` confine the Buildkite Agent access token
   to Git fetches through the repository-provider credential helper.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -138,7 +138,7 @@ For a linked GitHub branch push, the importer binds the webhook repository, ref,
 
 Normal and force pushes use GitHub's two-dot `before..after` comparison. A new branch uses the parent of its oldest pushed commit when the complete webhook commit set forms one unambiguous, single-parent boundary. Matching added, modified, deleted, and type-changed paths are admitted. Path patterns use the same ordered matching described below.
 
-Admission fails closed for deleted refs, non-GitHub repositories, missing or shallow history, a stale or mismatched checkout, origin, remote branch, workflow, ref, repository, commit set, or force state, and ambiguous new-branch history. It also fails closed for more than 1,000 pushed commits, more than 300 changed files, combined additions and deletions, renames, malformed Git output, invalid patterns, and local non-matches. GitHub runs automatically after its 1,000-commit or diff-timeout fallback, but the importer does not manufacture that admission without matching changed-path evidence.
+The importer rejects admission for deleted refs, non-GitHub repositories, missing or shallow history, a stale or mismatched checkout, origin, remote branch, workflow, ref, repository, commit set, or force state, and ambiguous new-branch history. It also rejects admission for more than 1,000 pushed commits, more than 300 changed files, combined additions and deletions, renames, malformed Git output, invalid patterns, and local non-matches. GitHub runs automatically after its 1,000-commit or diff-timeout fallback, but the importer does not manufacture that admission without matching changed-path evidence.
 
 Tag pushes do not evaluate path filters, matching GitHub. Explicit and generated event snapshots, and Buildkite environment fallbacks, cannot admit push path filters because they are not linked webhook evidence.
 
@@ -156,14 +156,14 @@ on:
 
 Before upload, the importer compares the pull request merge base with its head using the local checkout. It admits a workflow only when a changed path matches and the linked webhook, commits, synthetic merge, base branch, and workflow file all agree. It uses the checkout's existing Git access for public, private, and fork pull requests. It does not call GitHub or use Buildkite `if_changed`.
 
-| Admitted | Fails closed |
+| Admitted | Rejected |
 | --- | --- |
 | A matching added, modified, deleted, or type-changed path | No local match |
 | A copied destination that matches | A rename, or a diff containing both additions and deletions |
 | At most 300 changed files from complete local history | Missing or shallow history, multiple merge bases, or more than 300 files |
 | A mergeable pull request with matching webhook and workflow data | A conflict, stale data, changed merge workflow, path or pattern containing a backslash, invalid pattern, or malformed Git output |
 
-A local non-match fails closed because GitHub does not report whether its diff timed out and ran the workflow anyway. Unfiltered `closed` workflows remain supported; filtered `closed` workflows fail closed when GitHub supplies an actual merge, squash, or rebase commit instead of a synthetic merge. Other unsupported or inexact trigger filters replace the affected workflow with a failing step rather than broadening when it runs.
+A local non-match is rejected because GitHub does not report whether its diff timed out and ran the workflow anyway. Unfiltered `closed` workflows remain supported; filtered `closed` workflows are rejected when GitHub supplies an actual merge, squash, or rebase commit instead of a synthetic merge. Other unsupported or inexact trigger filters replace the affected workflow with a failing step rather than broadening when it runs.
 
 A top-level workflow that does not declare the effective event is excluded before event-dependent validation or compilation and represented by one top-level skipped command step. A workflow that declares that event remains represented by a group even when a same-event branch, tag, base-branch, or action condition evaluates false in Buildkite. If no directly runnable workflow declares the event, upload succeeds with a skipped-only pipeline.
 
@@ -311,7 +311,7 @@ Cancel the whole Buildkite build rather than one job when a workflow-level concu
 | `needs` | ✅ Supported | Accepts a string or list of static job IDs. Matrix fan-out and fan-in are automatic. |
 | `runs-on` | 🟡 Supported subset | The hosted importer asks the Agent API to resolve each selector before using configured mappings or its local preset. The preset accepts `ubuntu-latest`, `ubuntu-24.04`, `ubuntu-22.04`, and `macos-latest`; configured fallbacks can map `macos-14` and `macos-15`. Labels are case-insensitive. Static expressions may resolve to an accepted label or list whose labels map to the same complete queue, platform, and image target. |
 | `if` | 🟡 Supported subset | Runs before the job starts. See [Conditions](#conditions). |
-| `outputs` | 🟡 Supported subset | Maps step outputs for consumption through `needs`. A job may publish 64 outputs of up to 1 KiB each. Ambiguous matrix output values fail closed. |
+| `outputs` | 🟡 Supported subset | Maps step outputs for consumption through `needs`. A job may publish 64 outputs of up to 1 KiB each. Ambiguous matrix output values stop the job with an error. |
 | `env`, `defaults.run` | 🟡 Supported subset | Uses the [workflow-level behavior](#environment-and-defaults). |
 | `timeout-minutes` | 🟡 Supported subset | Accepts literal timeouts up to 360 minutes. Expressions are rejected. |
 | `continue-on-error` | 🟡 Supported subset | Accepts literal booleans. Expressions are rejected. A tolerated failure remains visible as a Buildkite soft failure and reports `success` through downstream `needs`. |
@@ -549,7 +549,7 @@ Three expression modes intentionally support different syntax.
 
 ### Conditions
 
-Job and step `if` conditions support literals and the syntax listed above. Values use GitHub's truthiness, loose numeric coercion, case-insensitive string comparison, and operand-returning `&&` and `||` semantics. String functions convert primitive arguments; `contains()` also searches arrays. `case()` takes 3–255 odd-numbered arguments, requires Boolean predicates, and evaluates values lazily through the first match. Missing properties in an available `github` or matrix context evaluate to null; unavailable contexts still fail closed. Other functions are unsupported. `hashFiles()` accepts 1–255 literal or direct-reference arguments in step and JavaScript action lifecycle conditions.
+Job and step `if` conditions support literals and the syntax listed above. Values use GitHub's truthiness, loose numeric coercion, case-insensitive string comparison, and operand-returning `&&` and `||` semantics. String functions convert primitive arguments; `contains()` also searches arrays. `case()` takes 3–255 odd-numbered arguments, requires Boolean predicates, and evaluates values lazily through the first match. Missing properties in an available `github` or matrix context evaluate to null; unavailable contexts return an error. Other functions are unsupported. `hashFiles()` accepts 1–255 literal or direct-reference arguments in step and JavaScript action lifecycle conditions.
 
 Conditions support computed object indexes, numeric array indexes, whole `matrix`, `needs`, and step-scoped `steps` objects, and `.*` projections. Missing and out-of-range indexes evaluate to null. Projections omit missing children; a later wildcard flattens one collection level. The equivalent `[*]` spelling is unsupported by the current expression parser. Whole or dynamic `github` access, whole `inputs`, and the `strategy` context remain unsupported.
 
@@ -573,7 +573,7 @@ Reusable-workflow call conditions use the same operators and status functions bu
 
 ### Runtime interpolation
 
-Workflow step `run`, `env`, `with`, `name`, explicit `shell`, explicit `working-directory`, `continue-on-error`, and `timeout-minutes` fields support the operators and pure functions listed above. They also support computed indexes and projections over available `matrix`, `vars`, `inputs`, `env`, and `runner` values. Computed, whole, and projected `steps` and `needs` access remains unsupported so unavailable background outputs fail closed.
+Workflow step `run`, `env`, `with`, `name`, explicit `shell`, explicit `working-directory`, `continue-on-error`, and `timeout-minutes` fields support the operators and pure functions listed above. They also support computed indexes and projections over available `matrix`, `vars`, `inputs`, `env`, and `runner` values. Computed, whole, and projected `steps` and `needs` access remains unsupported, so attempting to access an unavailable background output returns an error.
 
 Job-level expressions support the same operators and pure functions with these field-specific contexts:
 
@@ -587,7 +587,7 @@ These workflow step fields support `hashFiles()`; composite action step fields a
 
 Expression-valued `continue-on-error` must produce a Boolean. Expression-valued `timeout-minutes` must produce a number greater than 0 and at most 360.
 
-Direct `github.token` references are step-only. Whole, filtered, or dynamically indexed `github` access fails closed because the compiler cannot prove token authority.
+Direct `github.token` references are step-only. The compiler rejects whole, filtered, or dynamically indexed `github` access because it cannot prove token authority.
 
 `runner.os` and `runner.arch` resolve to `Linux`/`X64` or `macOS`/`ARM64`.
 After runner setup, step runtime fields and job outputs can also use
@@ -644,7 +644,7 @@ Action metadata parsing remains strict for every other unknown top-level field a
 
 Pre, main, and post phases; inputs; outputs; state; and LIFO post ordering are supported. Other Node declarations are rejected.
 
-JavaScript action `pre-if` and `post-if` metadata uses the condition operators, status functions, pure functions, and `hashFiles()` described in [Conditions](#conditions). Lifecycle conditions can read direct properties from workflow `inputs`, `env`, `github`, `job.services`, `matrix`, `runner`, and `steps`. Other contexts and dynamic or whole-context access fail closed. An empty lifecycle condition always runs and does not receive an implicit `success()` guard.
+JavaScript action `pre-if` and `post-if` metadata uses the condition operators, status functions, pure functions, and `hashFiles()` described in [Conditions](#conditions). Lifecycle conditions can read direct properties from workflow `inputs`, `env`, `github`, `job.services`, `matrix`, `runner`, and `steps`. Other contexts and dynamic or whole-context access return an error. An empty lifecycle condition always runs and does not receive an implicit `success()` guard.
 
 Pre conditions use the status and action-scoped environment available when preparation reaches the action. Post conditions run during job teardown and use the final job status and environment, including `GITHUB_ENV` changes from main. Root action posts also see final workflow step state. Nested composite actions retain their isolated step context. Cancellation remains distinct from failure, and posts keep LIFO order.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -24,11 +24,11 @@ Workflow files, action metadata, event snapshots, and job plans are untrusted in
 
 Digests and immutable action locks detect changed code. They do not make code trusted or grant credentials.
 
-Push and pull request path-filter admission uses Buildkite's reserved linked-webhook metadata only after binding it to the Buildkite repository and commit and matching local Git history. Missing, shallow, ambiguous, oversized, or mismatched evidence fails closed. Explicit and generated snapshots cannot grant this admission. This check controls workflow selection; it does not make the selected workflow trusted.
+Push and pull request path-filter admission uses Buildkite's reserved linked-webhook metadata only after binding it to the Buildkite repository and commit and matching local Git history. Missing, shallow, ambiguous, oversized, or mismatched evidence prevents admission. Explicit and generated snapshots cannot grant this admission. This check controls workflow selection; it does not make the selected workflow trusted.
 
 Release ingestion also requires reserved linked-webhook metadata. It binds the webhook activity to `BUILDKITE_GITHUB_ACTION`, the release tag to both `BUILDKITE_TAG` and `BUILDKITE_BRANCH`, and the event SHA to the checked-out commit after the plugin resolves Buildkite's symbolic `HEAD`. Environment fallback cannot invent a release event. Enable **Additional Webhooks** > **Releases** only with **Code** trigger mode.
 
-Local reusable-workflow call conditions are immutable plan guards evaluated in caller scope. Direct `needs` values come only from producer-attributed, digest-bound result manifests; missing or changed manifests fail closed. A false guard skips the flattened job before secret retrieval, workflow-token minting, OIDC startup, action materialization, containers, or steps.
+Local reusable-workflow call conditions are immutable plan guards evaluated in caller scope. Direct `needs` values come only from producer-attributed, digest-bound result manifests; a missing or changed manifest stops the job with an error. A false guard skips the flattened job before secret retrieval, workflow-token minting, OIDC startup, action materialization, containers, or steps.
 
 ## Credential boundaries
 

--- a/internal/action/integration/checkout.go
+++ b/internal/action/integration/checkout.go
@@ -94,7 +94,7 @@ func LegacyCheckoutRelease(commit string) (string, bool) {
 
 // validateCheckoutCommit admits known releases and a static snapshot of
 // commits reachable from upstream main. Mutable references are resolved before
-// this check, so changes after the snapshot remain fail-closed until regeneration.
+// this check, so changes after the snapshot are rejected until regeneration.
 func validateCheckoutCommit(commit string) error {
 	if _, ok := checkoutCommits[commit]; ok {
 		return nil

--- a/internal/action/source/source.go
+++ b/internal/action/source/source.go
@@ -772,7 +772,7 @@ type manifestFile struct {
 
 // DigestTree returns the canonical source digest for a local action directory.
 // It uses the same bounded manifest and file-mode model as immutable remote
-// action source. Symlinks and other special files fail closed.
+// action source. It rejects symlinks and other special files.
 func DigestTree(root string) (string, error) {
 	info, err := os.Stat(root)
 	if err != nil {

--- a/internal/action/source/source_test.go
+++ b/internal/action/source/source_test.go
@@ -708,7 +708,7 @@ func TestStoreCanonicalizesAliasedAncestorAndRejectsSymlinkRoot(t *testing.T) {
 	}
 }
 
-func TestStoreExpectedDigestAndManifestTamperFailClosed(t *testing.T) {
+func TestStoreExpectedDigestAndManifestRejectTampering(t *testing.T) {
 	archive := tgz(t, []tar.Header{{Name: "root/", Typeflag: tar.TypeDir}, {Name: "root/action.yml", Typeflag: tar.TypeReg, Size: 1}})
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write(archive) }))
 	defer ts.Close()

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -745,7 +745,7 @@ jobs:
 			t.Fatal(err)
 		}
 	}
-	t.Run("depth-limited reusable discovery fails closed before event metadata", func(t *testing.T) {
+	t.Run("depth-limited reusable discovery stops before event metadata", func(t *testing.T) {
 		requireImporterHost(t)
 		var stdout, stderr bytes.Buffer
 		runner := &cliCaptureRunner{}
@@ -789,7 +789,7 @@ jobs:
 `), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	t.Run("incomplete reusable discovery fails closed before event metadata", func(t *testing.T) {
+	t.Run("incomplete reusable discovery stops before event metadata", func(t *testing.T) {
 		requireImporterHost(t)
 		var stdout, stderr bytes.Buffer
 		runner := &cliCaptureRunner{}

--- a/internal/compiler/bundle.go
+++ b/internal/compiler/bundle.go
@@ -44,8 +44,8 @@ type Bundle struct {
 	Processing        ProcessingEvidence
 }
 
-// CompileBundle compiles an unattested event snapshot with the fail-closed
-// default runner policy.
+// CompileBundle compiles an unattested event snapshot with the default runner
+// policy, which rejects unsupported runner labels.
 func CompileBundle(path string, source, eventSource []byte, compilerVersion, compilerDistributionDigest, compilerStep string) (Bundle, error) {
 	return CompileBundleWithOptions(path, source, eventSource, compilerVersion, compilerDistributionDigest, compilerStep, defaultOptions())
 }

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -888,7 +888,7 @@ func compile(path string, source, eventSource []byte, options Options) (IR, erro
 		Warnings: compilerWarnings(parsed, cancelInProgress),
 		Execution: ExecutionBoundary{
 			Supported: true,
-			Reason:    "run-job supports the fail-closed supported shell and local-action subset",
+			Reason:    "run-job rejects unsupported shells and local actions",
 		},
 		Jobs: expanded.instances,
 	}

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -2044,7 +2044,7 @@ jobs:
 `)
 	ir, err := compile(path, readFile(t, path), readFile(t, smokePath("events", "push.json")), defaultOptions())
 	if err == nil || !strings.Contains(err.Error(), "flattened job id") || !strings.Contains(err.Error(), "collides with another job") {
-		t.Fatalf("Compile() error = %v, want fail-closed flattened ID collision", err)
+		t.Fatalf("Compile() error = %v, want flattened ID collision rejection", err)
 	}
 	collisionID := fmt.Sprintf("call-%s.test", suffix)
 	var collision *JobInstance

--- a/internal/expression/action_input_default.go
+++ b/internal/expression/action_input_default.go
@@ -87,7 +87,7 @@ func isRunnerTempReference(root string, path []string) bool {
 
 // ActionInputDefaultRequiresGitHubToken reports whether a metadata default can
 // reach github.token for the event provider. Defaults involving any other
-// runtime value fail closed because those values are not known during
+// runtime value require the token because those values are not known during
 // compilation.
 func ActionInputDefaultRequiresGitHubToken(template, serverURL string) (bool, error) {
 	referencesToken, err := ReferencesGitHubToken(template)

--- a/internal/expression/condition.go
+++ b/internal/expression/condition.go
@@ -1,5 +1,5 @@
 // Condition validation and strict runtime condition evaluation. The
-// condition* value helpers fail closed on mixed-type comparisons.
+// condition* value helpers reject mixed-type comparisons.
 package expression
 
 import (
@@ -405,7 +405,7 @@ func EvaluateActionLifecycleCondition(source string, context ConditionContext) (
 }
 
 // EvaluateCondition evaluates a job or step condition. Unsupported syntax and
-// unavailable values fail closed with an error.
+// unavailable values return an error.
 func EvaluateCondition(source string, context ConditionContext) (bool, error) {
 	node, empty, err := parseCondition(source)
 	if err != nil {

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -265,7 +265,7 @@ func TestActionInputDefaultRequiresGitHubTokenUsesProviderServerURL(t *testing.T
 		{name: "Origin skips GitHub.com token", template: "${{ github.server_url == 'https://github.com' && github.token || '' }}", serverURL: "https://origin.cursor.com"},
 		{name: "Origin reaches reverse guard", template: "${{ github.server_url != 'https://github.com' && github.token || '' }}", serverURL: "https://origin.cursor.com", want: true},
 		{name: "literal false skips token", template: "${{ false && github.token || '' }}", serverURL: "https://origin.cursor.com"},
-		{name: "unknown guard fails closed", template: "${{ inputs.use_token && github.token || '' }}", serverURL: "https://origin.cursor.com", want: true},
+		{name: "unknown guard requires token", template: "${{ inputs.use_token && github.token || '' }}", serverURL: "https://origin.cursor.com", want: true},
 		{name: "no token reference", template: "${{ github.server_url }}", serverURL: "https://origin.cursor.com"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -502,7 +502,7 @@ func TestReferencesGitHubTokenUsesExpressionAST(t *testing.T) {
 	}
 	for _, template := range []string{"${{ github }}", "${{ github.* }}", "${{ github.event.*.token }}"} {
 		if _, err := ReferencesGitHubToken(template); err == nil || !strings.Contains(err.Error(), "must name one static property") {
-			t.Fatalf("ReferencesGitHubToken(%q) error = %v, want fail-closed static-property rejection", template, err)
+			t.Fatalf("ReferencesGitHubToken(%q) error = %v, want static-property rejection", template, err)
 		}
 	}
 }
@@ -774,7 +774,7 @@ func TestEvaluateJobSurfacesSupportAuthorizedCompoundExpressions(t *testing.T) {
 	}
 }
 
-func TestEvaluateJobSurfacesFailClosed(t *testing.T) {
+func TestEvaluateJobSurfacesErrors(t *testing.T) {
 	context := Context{
 		GitHub: map[string]any{"token": "secret"},
 		Env:    map[string]string{"KEY": "TOKEN"},
@@ -1018,13 +1018,13 @@ func TestEvaluateActionLifecycleCondition(t *testing.T) {
 		{name: "rust-cache skips after failure when disabled", condition: "success() || env.CACHE_ON_FAILURE == 'true'", unsuccessful: true, env: map[string]string{"CACHE_ON_FAILURE": "false"}},
 		{name: "rust-cache runs after opted-in failure", condition: "success() || env.CACHE_ON_FAILURE == 'true'", unsuccessful: true, env: map[string]string{"CACHE_ON_FAILURE": "true"}, want: true},
 		{name: "rust-cache skips after cancellation", condition: "success() || env.CACHE_ON_FAILURE == 'true'", cancelled: true},
-		{name: "references fail closed", condition: "github.event_name == 'push'", wantErr: true},
+		{name: "unavailable references return errors", condition: "github.event_name == 'push'", wantErr: true},
 		{name: "compound status expression", condition: "success() || failure()", unsuccessful: true, want: true},
-		{name: "arguments fail closed", condition: "success('build')", wantErr: true},
-		{name: "unknown functions fail closed", condition: "finished()", wantErr: true},
-		{name: "unsupported lazy branch fails closed", condition: "success() || secrets.TOKEN != ''", wantErr: true},
-		{name: "unopened delimiter fails closed", condition: "failure() }}", wantErr: true},
-		{name: "unclosed delimiter fails closed", condition: "${{ failure()", wantErr: true},
+		{name: "arguments return errors", condition: "success('build')", wantErr: true},
+		{name: "unknown functions return errors", condition: "finished()", wantErr: true},
+		{name: "unsupported lazy branch returns error", condition: "success() || secrets.TOKEN != ''", wantErr: true},
+		{name: "unopened delimiter returns error", condition: "failure() }}", wantErr: true},
+		{name: "unclosed delimiter returns error", condition: "${{ failure()", wantErr: true},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -1290,11 +1290,11 @@ func TestEvaluateConditionSupportsBracketFormGitHubReferences(t *testing.T) {
 	if _, err := EvaluateCondition("github['event_name'] == 'push'", ConditionContext{}); err == nil || !strings.Contains(err.Error(), "condition references unavailable value github.event_name") {
 		t.Fatalf("EvaluateCondition() without github context error = %v", err)
 	}
-	// Whole and dynamic github access fails closed at evaluation even
+	// Whole and dynamic github access returns an error at evaluation even
 	// without prior validation, such as composite-action if conditions.
 	for _, condition := range []string{"github", "github[vars.KEY]", "github.*"} {
 		if _, err := EvaluateCondition(condition, ConditionContext{GitHub: map[string]any{"event_name": "push"}, Vars: map[string]string{"KEY": "event_name"}}); err == nil {
-			t.Errorf("EvaluateCondition(%q) error = nil, want fail-closed error", condition)
+			t.Errorf("EvaluateCondition(%q) error = nil, want unsupported access error", condition)
 		}
 	}
 }
@@ -1671,7 +1671,7 @@ func TestCompileInputLiteralRepresentations(t *testing.T) {
 		{name: "float64 uses shortest form", value: 2.5, want: "2.5"},
 		{name: "aggregate values cannot be literals", value: []any{"x"}, wantErr: "cannot be represented"},
 		{name: "maps cannot be literals", value: map[string]any{"x": "y"}, wantErr: "cannot be represented"},
-		{name: "typed numerics outside the YAML model fail closed", value: int32(7), wantErr: "cannot be represented"},
+		{name: "typed numerics outside the YAML model are rejected", value: int32(7), wantErr: "cannot be represented"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/expression/references.go
+++ b/internal/expression/references.go
@@ -1,6 +1,6 @@
 // Static reference introspection over templates, complete expressions, and
 // conditions. Each predicate deliberately answers one narrow question with
-// its own fail-closed behavior.
+// an error for unsupported input.
 package expression
 
 import (
@@ -19,7 +19,7 @@ type NeedOutputReference struct {
 
 // ReferencePath extracts one complete static variable reference. Dot and
 // literal string index access are accepted; functions, operators, literals,
-// compound templates, and dynamic indexes fail closed.
+// compound templates, and dynamic indexes return an error.
 func ReferencePath(text string) (string, []string, error) {
 	body, err := expressionBody(text)
 	if err != nil {
@@ -75,7 +75,7 @@ func runtimeMatrixIdentifier(value string) bool {
 }
 
 // SecretReferences returns the statically named secrets referenced by a
-// template. Dynamic indexes fail closed because the runtime cannot determine
+// template. Dynamic indexes return an error because the runtime cannot determine
 // which values to resolve and register with the log redactor before execution.
 func SecretReferences(template string) ([]string, error) {
 	found := map[string]struct{}{}
@@ -208,7 +208,7 @@ func sortedReferenceNames(found map[string]struct{}) []string {
 }
 
 // ReferencesGitHubToken reports whether a template statically references
-// github.token. Dynamic GitHub indexes fail closed so compiler-owned token
+// github.token. Dynamic GitHub indexes return an error so compiler-owned token
 // authority cannot depend on a runtime-selected property.
 func ReferencesGitHubToken(template string) (bool, error) {
 	found := false

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -337,7 +337,7 @@ func (job Job) RuntimeDistributionDigest() string {
 	return ""
 }
 
-// Decode rejects unknown fields and trailing JSON so schema drift fails closed.
+// Decode rejects unknown fields and trailing JSON to stop on schema drift.
 func Decode(source []byte) (Job, error) {
 	if err := rejectDuplicateKeys(source); err != nil {
 		return Job{}, fmt.Errorf("decode job plan: %w", err)

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -620,7 +620,7 @@ func TestRemoteCompositeLocalChildUsesWorkspaceIdentity(t *testing.T) {
 	}
 }
 
-func TestActionSelectorsAndPathsFailClosed(t *testing.T) {
+func TestActionSelectorsAndPathsRejectInvalidValues(t *testing.T) {
 	local := func() Job {
 		job := validJob()
 		requiresMise := true

--- a/internal/runtime/checkout_test.go
+++ b/internal/runtime/checkout_test.go
@@ -1534,7 +1534,7 @@ func TestProviderTokenReadPreflightRejectsAnyUnknownCheckoutCommit(t *testing.T)
 		},
 	}
 	if found, err := validateJobCheckoutAdapters(job); err == nil || found || !strings.Contains(err.Error(), "does not admit") {
-		t.Fatalf("validateJobCheckoutAdapters() = %t, %v, want fail-closed rejection", found, err)
+		t.Fatalf("validateJobCheckoutAdapters() = %t, %v, want unknown commit rejection", found, err)
 	}
 }
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1744,7 +1744,7 @@ func TestSkippedBackgroundAndRepeatedWaitAreCommittedAtMostOnce(t *testing.T) {
 	}
 }
 
-func TestBackgroundOutputsFailClosedBeforeBarrier(t *testing.T) {
+func TestBackgroundOutputsReturnErrorBeforeBarrier(t *testing.T) {
 	workspace := t.TempDir()
 	workflowPath := ".github/workflows/test.yml"
 	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
@@ -2990,7 +2990,7 @@ func TestRunJobRequiresHydratedStaticDependencyResults(t *testing.T) {
 	job.Dependencies = []string{"gha-producer"}
 	job.NeedSources = map[string][]plan.NeedSource{"producer": {{StepKey: "gha-producer", PlanDigest: "sha256:" + strings.Repeat("1", 64)}}}
 	if _, err := (Runner{}).RunJob(context.Background(), job, workspace); err == nil || !strings.Contains(err.Error(), "no hydrated prerequisite results") {
-		t.Fatalf("RunJob() error = %v, want fail-closed hydration boundary", err)
+		t.Fatalf("RunJob() error = %v, want missing hydration rejection", err)
 	}
 	job.Needs = map[string]plan.Need{"producer": {Result: "success"}}
 	if result, err := (Runner{}).RunJob(context.Background(), job, workspace); err != nil || result.Conclusion != "success" {
@@ -6699,7 +6699,7 @@ func TestRunJobRejectsWorkflowMismatchAndUnsupportedAction(t *testing.T) {
 			writeFixtureFile(t, workspace, ".github/actions/unsupported/action.yml", "runs:\n  using: "+using+"\n")
 			job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "unsupported", Kind: "uses", Uses: "./.github/actions/unsupported"}})
 			if _, err := (Runner{}).RunJob(context.Background(), job, workspace); err == nil || !strings.Contains(err.Error(), `unsupported runtime "`+using+`"`) {
-				t.Fatalf("RunJob() error = %v, want %s fail-closed boundary", err, using)
+				t.Fatalf("RunJob() error = %v, want %s runtime rejection", err, using)
 			}
 		})
 	}

--- a/internal/workflow/parse_test.go
+++ b/internal/workflow/parse_test.go
@@ -622,7 +622,7 @@ jobs:
 	}
 }
 
-func TestParseConcurrentControlsFailClosed(t *testing.T) {
+func TestParseConcurrentControlsRejectInvalidInput(t *testing.T) {
 	tests := []struct {
 		name  string
 		steps string


### PR DESCRIPTION
## Why

“Fail closed” obscures whether the importer rejects admission, returns an error, or stops a job.

## What

Replace each use in documentation, diagnostics, comments, and tests with concise wording that states the actual behavior while preserving the existing security guarantees.