### PR TITLE
Add golangci-lint configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,57 @@
+version: "2"
+linters:
+  enable:
+    - errcheck
+    - bodyclose
+    - govet
+    - ineffassign
+    - intrange
+    - staticcheck
+    - unused
+    - gocritic
+    - usetesting
+    - usestdlibvars
+    - testifylint
+    - sloglint
+    - thelper
+  settings:
+    usetesting:
+      context-background: true
+      context-todo: true
+    testifylint:
+      disable-all: true
+      enable:
+        - require-error
+        - useless-assert
+        - len
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+    gofmt:
+      rewrite-rules:
+        - pattern: "interface{}"
+          replacement: "any"
+        - pattern: "a[b:len(a)]"
+          replacement: "a[b:]"
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
 version: "2"
 linters:
+  default: none
   enable:
     - errcheck
     - bodyclose

--- a/internal/action/source/file_lock_test.go
+++ b/internal/action/source/file_lock_test.go
@@ -1,7 +1,6 @@
 package source
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"sync"
@@ -36,29 +35,29 @@ func TestLockFileUnlockIsIdempotent(t *testing.T) {
 
 func TestActionCacheLockSharedExclusiveNonblocking(t *testing.T) {
 	path := filepath.Join(t.TempDir(), ".lock")
-	first, err := lockActionCache(context.Background(), path, actionCacheLockShared, false)
+	first, err := lockActionCache(t.Context(), path, actionCacheLockShared, false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	second, err := lockActionCache(context.Background(), path, actionCacheLockShared, true)
+	second, err := lockActionCache(t.Context(), path, actionCacheLockShared, true)
 	if err != nil {
 		first.unlock()
 		t.Fatal(err)
 	}
-	if _, err := lockActionCache(context.Background(), path, actionCacheLockExclusive, true); err != errActionCacheLockUnavailable {
+	if _, err := lockActionCache(t.Context(), path, actionCacheLockExclusive, true); err != errActionCacheLockUnavailable {
 		first.unlock()
 		second.unlock()
 		t.Fatalf("exclusive lock error = %v, want %v", err, errActionCacheLockUnavailable)
 	}
 	first.unlock()
 	first.unlock()
-	if _, err := lockActionCache(context.Background(), path, actionCacheLockExclusive, true); err != errActionCacheLockUnavailable {
+	if _, err := lockActionCache(t.Context(), path, actionCacheLockExclusive, true); err != errActionCacheLockUnavailable {
 		second.unlock()
 		t.Fatalf("exclusive lock with one shared holder error = %v, want %v", err, errActionCacheLockUnavailable)
 	}
 	second.unlock()
 	second.unlock()
-	exclusive, err := lockActionCache(context.Background(), path, actionCacheLockExclusive, true)
+	exclusive, err := lockActionCache(t.Context(), path, actionCacheLockExclusive, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/action/source/file_lock_unix_test.go
+++ b/internal/action/source/file_lock_unix_test.go
@@ -11,18 +11,18 @@ import (
 
 func TestActionCacheLockCancellationWhileHeld(t *testing.T) {
 	path := filepath.Join(t.TempDir(), ".lock")
-	holder, err := lockActionCache(context.Background(), path, actionCacheLockExclusive, false)
+	holder, err := lockActionCache(t.Context(), path, actionCacheLockExclusive, false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 	if _, err := lockActionCache(ctx, path, actionCacheLockShared, false); !errors.Is(err, context.Canceled) {
 		holder.unlock()
 		t.Fatalf("waiting lock error = %v, want %v", err, context.Canceled)
 	}
 	holder.unlock()
-	reacquired, err := lockActionCache(context.Background(), path, actionCacheLockExclusive, true)
+	reacquired, err := lockActionCache(t.Context(), path, actionCacheLockExclusive, true)
 	if err != nil {
 		t.Fatalf("reacquire lock: %v", err)
 	}

--- a/internal/action/source/mutable_ref_lock_unix_test.go
+++ b/internal/action/source/mutable_ref_lock_unix_test.go
@@ -11,11 +11,11 @@ import (
 
 func TestMutableRefLockCancellationWhileHeld(t *testing.T) {
 	path := filepath.Join(t.TempDir(), ".lock")
-	unlock, err := lockMutableRefCache(context.Background(), path)
+	unlock, err := lockMutableRefCache(t.Context(), path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 	if _, err := lockMutableRefCache(ctx, path); !errors.Is(err, context.Canceled) {
 		unlock()
@@ -23,7 +23,7 @@ func TestMutableRefLockCancellationWhileHeld(t *testing.T) {
 	}
 	unlock()
 	unlock()
-	release, err := lockMutableRefCache(context.Background(), path)
+	release, err := lockMutableRefCache(t.Context(), path)
 	if err != nil {
 		t.Fatalf("reacquire lock: %v", err)
 	}

--- a/internal/action/source/source.go
+++ b/internal/action/source/source.go
@@ -346,7 +346,7 @@ func (r *Resolver) resolveCommit(ctx context.Context, ref Reference) (Resolved, 
 	return Resolved{Reference: ref, Commit: v.SHA}, nil
 }
 func (r *Resolver) peel(ctx context.Context, ref Reference, typ, sha string) (string, error) {
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		if !shaRE.MatchString(sha) {
 			return "", fmt.Errorf("GitHub returned malformed object SHA")
 		}
@@ -409,7 +409,7 @@ func githubAPIGet(ctx context.Context, client *http.Client, cfg config, parts []
 	if len(body) > 1<<20 {
 		return fmt.Errorf("GitHub API response too large")
 	}
-	if resp.StatusCode == 404 {
+	if resp.StatusCode == http.StatusNotFound {
 		return &NotPublicError{}
 	}
 	if rate := rateLimitError(resp, body); rate != nil {
@@ -449,7 +449,7 @@ func actionSourceToken(cfg config, parts []string) string {
 	return cfg.credential.token
 }
 func rateLimitError(resp *http.Response, body []byte) error {
-	if resp.StatusCode != 429 && (resp.StatusCode != 403 || (resp.Header.Get("X-RateLimit-Remaining") != "0" && !strings.Contains(strings.ToLower(string(body)), "rate limit"))) {
+	if resp.StatusCode != http.StatusTooManyRequests && (resp.StatusCode != http.StatusForbidden || (resp.Header.Get("X-RateLimit-Remaining") != "0" && !strings.Contains(strings.ToLower(string(body)), "rate limit"))) {
 		return nil
 	}
 	var reset time.Time
@@ -711,10 +711,10 @@ func (s *Store) downloadExtract(ctx context.Context, r Resolved, dst string) err
 	if !validArchiveURL(resp.Request.URL, s.cfg.finalHosts) {
 		return fmt.Errorf("archive final URL denied")
 	}
-	if resp.StatusCode == 404 {
+	if resp.StatusCode == http.StatusNotFound {
 		return &NotPublicError{}
 	}
-	if resp.StatusCode == 403 || resp.StatusCode == 429 {
+	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests {
 		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 		if readErr != nil {
 			return fmt.Errorf("read archive error response: %w", readErr)
@@ -967,11 +967,12 @@ func extractTar(r io.Reader, dst string, c config) error {
 				if e == nil {
 					n, ce := io.CopyN(f, tr, h.Size)
 					cl := f.Close()
-					if ce != nil || n != h.Size {
+					switch {
+					case ce != nil || n != h.Size:
 						e = fmt.Errorf("short archive file")
-					} else if cl != nil {
+					case cl != nil:
 						e = cl
-					} else {
+					default:
 						mode := os.FileMode(0o644)
 						if h.Mode&0o100 != 0 {
 							mode = 0o755

--- a/internal/action/source/source_test.go
+++ b/internal/action/source/source_test.go
@@ -63,7 +63,7 @@ func TestResolverTagPeelingAndHeaders(t *testing.T) {
 		t.Fatal(err)
 	}
 	ref, _ := Parse("owner/repo@v1")
-	got, err := r.Resolve(context.Background(), ref)
+	got, err := r.Resolve(t.Context(), ref)
 	if err != nil || got.Commit != testSHA || len(calls) != 2 {
 		t.Fatalf("Resolve = %#v, %v; calls %v", got, err, calls)
 	}
@@ -118,7 +118,7 @@ func TestResolverOptionalAuthenticationAndVisibility(t *testing.T) {
 				t.Fatal(err)
 			}
 			ref, _ := Parse("o/r@v1")
-			_, err = resolver.Resolve(context.Background(), ref)
+			_, err = resolver.Resolve(t.Context(), ref)
 			if tt.wantNotPublic {
 				var notPublic *NotPublicError
 				if !errors.As(err, &notPublic) || refRequests != 0 {
@@ -162,7 +162,7 @@ func TestResolverFullSHADirectAndRefEncoding(t *testing.T) {
 			}
 			resolver, _ := NewResolver(ts.Client(), opts...)
 			ref, _ := Parse("o/r@" + tt.ref)
-			if _, err := resolver.Resolve(context.Background(), ref); err != nil {
+			if _, err := resolver.Resolve(t.Context(), ref); err != nil {
 				t.Fatal(err)
 			}
 			if fmt.Sprint(calls) != fmt.Sprint(tt.calls) || provisions != 0 {
@@ -192,7 +192,7 @@ func TestResolverOnlyTreatsLowercaseFullSHAAsResolved(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resolved, err := resolver.Resolve(context.Background(), ref)
+	resolved, err := resolver.Resolve(t.Context(), ref)
 	if err != nil || resolved.Commit != testSHA || !slices.Equal(calls, []string{"/repos/o/r/git/ref/tags/" + upperSHA, "/repos/o/r/git/ref/heads/" + upperSHA, "/repos/o/r/commits/" + upperSHA}) {
 		t.Fatalf("Resolve() = %#v, %v; calls = %v", resolved, err, calls)
 	}
@@ -217,7 +217,7 @@ func TestResolverCachesMutableRefsWithBoundedFreshness(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := resolver.Resolve(context.Background(), ref); err != nil {
+	if _, err := resolver.Resolve(t.Context(), ref); err != nil {
 		t.Fatal(err)
 	}
 	commit = strings.Repeat("a", 40)
@@ -229,12 +229,12 @@ func TestResolverCachesMutableRefsWithBoundedFreshness(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resolved, err := resolver.Resolve(context.Background(), ref)
+	resolved, err := resolver.Resolve(t.Context(), ref)
 	if err != nil || resolved.Commit != testSHA || calls.Load() != 1 {
 		t.Fatalf("cached Resolve() = %#v, %v; calls = %d", resolved, err, calls.Load())
 	}
 	time.Sleep(60 * time.Millisecond)
-	resolved, err = resolver.Resolve(context.Background(), ref)
+	resolved, err = resolver.Resolve(t.Context(), ref)
 	if err != nil || resolved.Commit != commit || calls.Load() != 2 {
 		t.Fatalf("revalidated Resolve() = %#v, %v; calls = %d", resolved, err, calls.Load())
 	}
@@ -263,7 +263,7 @@ func TestResolverMutableRefCacheCoalescesConcurrentProcesses(t *testing.T) {
 				resolver.cfg.mutableRefs, err = newMutableRefCache(cache, time.Hour)
 			}
 			if err == nil {
-				_, err = resolver.Resolve(context.Background(), ref)
+				_, err = resolver.Resolve(t.Context(), ref)
 			}
 			errors <- err
 		}()
@@ -299,13 +299,13 @@ func TestResolverFallbackErrorsAndCancellation(t *testing.T) {
 	t.Run("rate limit", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("X-RateLimit-Remaining", "0")
-			w.WriteHeader(403)
+			w.WriteHeader(http.StatusForbidden)
 		}))
 		defer ts.Close()
 		resolver, _ := NewResolver(ts.Client(), WithTestEndpoints(ts.URL))
 		ref, _ := Parse("o/r@v1")
 		var rate *RateLimitError
-		if _, err := resolver.Resolve(context.Background(), ref); !errors.As(err, &rate) {
+		if _, err := resolver.Resolve(t.Context(), ref); !errors.As(err, &rate) {
 			t.Fatalf("error = %v", err)
 		}
 	})
@@ -314,12 +314,12 @@ func TestResolverFallbackErrorsAndCancellation(t *testing.T) {
 		defer ts.Close()
 		resolver, _ := NewResolver(ts.Client(), WithTestEndpoints(ts.URL))
 		ref, _ := Parse("o/r@v1")
-		if _, err := resolver.Resolve(context.Background(), ref); err == nil {
+		if _, err := resolver.Resolve(t.Context(), ref); err == nil {
 			t.Fatal("expected malformed response error")
 		}
 	})
 	t.Run("cancelled", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		cancel()
 		resolver, _ := NewResolver(nil)
 		ref, _ := Parse("o/r@v1")
@@ -578,6 +578,7 @@ func tarBytes(t *testing.T, entries []tar.Header) []byte {
 	return b.Bytes()
 }
 func tgz(t *testing.T, entries []tar.Header) []byte {
+	t.Helper()
 	var b bytes.Buffer
 	gz := gzip.NewWriter(&b)
 	_, _ = gz.Write(tarBytes(t, entries))
@@ -604,7 +605,7 @@ func TestStoreExactCommitAtomicHitAndSubpath(t *testing.T) {
 	}
 	ref, _ := Parse("Owner/Repo/action@v1")
 	resolved := Resolved{Reference: ref, Commit: testSHA}
-	first, err := store.Materialize(context.Background(), resolved)
+	first, err := store.Materialize(t.Context(), resolved)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -614,7 +615,7 @@ func TestStoreExactCommitAtomicHitAndSubpath(t *testing.T) {
 	if !strings.HasPrefix(first.SourceDigest, "sha256:") || first.RepositoryRoot == first.ActionRoot {
 		t.Fatalf("materialized identity = %#v", first)
 	}
-	second, err := store.Materialize(context.Background(), resolved)
+	second, err := store.Materialize(t.Context(), resolved)
 	if err != nil || second.RepositoryRoot != first.RepositoryRoot || second.ActionRoot != first.ActionRoot || second.SourceDigest != first.SourceDigest || requests.Load() != 1 {
 		t.Fatalf("second = %v, %v; requests=%d", second, err, requests.Load())
 	}
@@ -658,7 +659,7 @@ func TestStoreRejectsInvalidUTF8ArchiveMetadataOnEveryMaterialization(t *testing
 			ref, _ := Parse("Owner/Repo@v1")
 			resolved := Resolved{Reference: ref, Commit: testSHA}
 			for attempt := 1; attempt <= 2; attempt++ {
-				materialized, err := store.Materialize(context.Background(), resolved)
+				materialized, err := store.Materialize(t.Context(), resolved)
 				if err == nil || !strings.Contains(err.Error(), "invalid UTF-8") {
 					materialized.Release()
 					t.Fatalf("materialization %d error = %v, want invalid UTF-8 rejection", attempt, err)
@@ -716,12 +717,12 @@ func TestStoreExpectedDigestAndManifestRejectTampering(t *testing.T) {
 	store, _ := NewStore(root, ts.Client(), WithTestEndpoints(ts.URL, ts.URL))
 	ref, _ := Parse("Owner/Repo@v1")
 	r := Resolved{Reference: ref, Commit: testSHA}
-	got, err := store.Materialize(context.Background(), r)
+	got, err := store.Materialize(t.Context(), r)
 	if err != nil {
 		t.Fatal(err)
 	}
 	r.SourceDigest = "sha256:" + strings.Repeat("0", 64)
-	if _, err = store.Materialize(context.Background(), r); err == nil || !strings.Contains(err.Error(), "source digest mismatch") {
+	if _, err = store.Materialize(t.Context(), r); err == nil || !strings.Contains(err.Error(), "source digest mismatch") {
 		t.Fatalf("digest mismatch error = %v", err)
 	}
 	manifestPath := filepath.Join(filepath.Dir(got.RepositoryRoot), manifestName)
@@ -729,7 +730,7 @@ func TestStoreExpectedDigestAndManifestRejectTampering(t *testing.T) {
 		t.Fatal(err)
 	}
 	r.SourceDigest = got.SourceDigest
-	if _, err = store.Materialize(context.Background(), r); err == nil || !strings.Contains(err.Error(), "verify action source cache") {
+	if _, err = store.Materialize(t.Context(), r); err == nil || !strings.Contains(err.Error(), "verify action source cache") {
 		t.Fatalf("tamper error = %v", err)
 	}
 }
@@ -751,7 +752,7 @@ func TestStoreArchiveHTTPClassification(t *testing.T) {
 			defer ts.Close()
 			store, _ := NewStore(t.TempDir(), ts.Client(), WithTestEndpoints(ts.URL, ts.URL))
 			ref, _ := Parse("o/r@v1")
-			_, err := store.Materialize(context.Background(), Resolved{Reference: ref, Commit: testSHA})
+			_, err := store.Materialize(t.Context(), Resolved{Reference: ref, Commit: testSHA})
 			if tt.rate {
 				var rate *RateLimitError
 				if !errors.As(err, &rate) || rate.Reset.IsZero() {
@@ -798,7 +799,7 @@ func TestStoreExactCommitDownloadsDirectlyFromCodeloadWithoutCredentials(t *test
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := store.Materialize(context.Background(), resolved); err != nil {
+	if _, err := store.Materialize(t.Context(), resolved); err != nil {
 		t.Fatal(err)
 	}
 	if apiRequests != 0 || archiveRequests != 1 || tokenProvisions != 0 {
@@ -830,7 +831,7 @@ func TestStoreCodeloadRedirectPolicy(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if _, err := store.Materialize(context.Background(), resolved); err != nil {
+		if _, err := store.Materialize(t.Context(), resolved); err != nil {
 			t.Fatal(err)
 		}
 		if requests != 2 {
@@ -851,7 +852,7 @@ func TestStoreCodeloadRedirectPolicy(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if _, err := store.Materialize(context.Background(), resolved); err == nil || !strings.Contains(err.Error(), "archive redirect denied") {
+		if _, err := store.Materialize(t.Context(), resolved); err == nil || !strings.Contains(err.Error(), "archive redirect denied") {
 			t.Fatalf("Materialize() error = %v, want denied redirect", err)
 		}
 		if deniedRequests != 0 {
@@ -878,7 +879,7 @@ func TestStoreConcurrentMaterialize(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			got, err := store.Materialize(context.Background(), resolved)
+			got, err := store.Materialize(t.Context(), resolved)
 			results <- got
 			errs <- err
 		}()
@@ -914,30 +915,30 @@ func TestStoreEvictionSkipsLeasedEntryAndRemovesItAfterRelease(t *testing.T) {
 		t.Fatal(err)
 	}
 	ref, _ := Parse("o/r@v1")
-	materialized, err := store.Materialize(context.Background(), Resolved{Reference: ref, Commit: testSHA})
+	materialized, err := store.Materialize(t.Context(), Resolved{Reference: ref, Commit: testSHA})
 	if err != nil {
 		t.Fatal(err)
 	}
 	base := filepath.Dir(materialized.RepositoryRoot)
-	if err := store.maintain(context.Background()); err != nil {
+	if err := store.maintain(t.Context()); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(base); err != nil {
 		t.Fatalf("leased entry was evicted: %v", err)
 	}
-	retained, err := materialized.Retain(context.Background())
+	retained, err := materialized.Retain(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
 	materialized.Release()
-	if err := store.maintain(context.Background()); err != nil {
+	if err := store.maintain(t.Context()); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(base); err != nil {
 		t.Fatalf("retained entry was evicted: %v", err)
 	}
 	retained.Release()
-	if err := store.maintain(context.Background()); err != nil {
+	if err := store.maintain(t.Context()); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(base); !errors.Is(err, os.ErrNotExist) {
@@ -978,7 +979,7 @@ func TestStoreMaintenanceUsesLRUAndCleansOnlyUnlockedPartials(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	activeLock, err := lockActionCache(context.Background(), filepath.Join(activePartial, ".lock"), actionCacheLockExclusive, false)
+	activeLock, err := lockActionCache(t.Context(), filepath.Join(activePartial, ".lock"), actionCacheLockExclusive, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1023,7 +1024,7 @@ func TestStoreConcurrentBoundedEviction(t *testing.T) {
 		go func() {
 			defer workers.Done()
 			commit := fmt.Sprintf("%040x", i+1)
-			materialized, err := stores[i%len(stores)].Materialize(context.Background(), Resolved{Reference: ref, Commit: commit})
+			materialized, err := stores[i%len(stores)].Materialize(t.Context(), Resolved{Reference: ref, Commit: commit})
 			if err == nil {
 				_, err = os.Stat(filepath.Join(materialized.ActionRoot, "action.yml"))
 				materialized.Release()
@@ -1038,7 +1039,7 @@ func TestStoreConcurrentBoundedEviction(t *testing.T) {
 			t.Fatalf("concurrent bounded materialization: %v", err)
 		}
 	}
-	if err := stores[0].maintain(context.Background()); err != nil {
+	if err := stores[0].maintain(t.Context()); err != nil {
 		t.Fatal(err)
 	}
 	entries, _, err := stores[0].cacheEntries()
@@ -1057,7 +1058,7 @@ func TestStoreBoundedEvictionProtectsUnboundedReader(t *testing.T) {
 		t.Fatal(err)
 	}
 	ref, _ := Parse("o/r@v1")
-	active, err := unbounded.Materialize(context.Background(), Resolved{Reference: ref, Commit: strings.Repeat("a", 40)})
+	active, err := unbounded.Materialize(t.Context(), Resolved{Reference: ref, Commit: strings.Repeat("a", 40)})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1070,7 +1071,7 @@ func TestStoreBoundedEvictionProtectsUnboundedReader(t *testing.T) {
 		t.Fatalf("bounded maintenance evicted an unbounded reader: %v", err)
 	}
 	active.Release()
-	if err := bounded.maintain(context.Background()); err != nil {
+	if err := bounded.maintain(t.Context()); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(active.ActionRoot); !errors.Is(err, os.ErrNotExist) {
@@ -1105,28 +1106,28 @@ func TestActionResolutionSnapshotPinsAndRefreshesMutableRefs(t *testing.T) {
 	}
 	ref, _ := Parse("owner/repo@v1")
 	first := newResolver(false)
-	resolved, err := first.Resolve(context.Background(), ref)
+	resolved, err := first.Resolve(t.Context(), ref)
 	if err != nil || resolved.Commit != testSHA || requests.Load() != 1 {
 		t.Fatalf("first resolution = %#v, %v; requests %d", resolved, err, requests.Load())
 	}
 	firstGeneration := first.ResolutionSnapshotID()
 	refreshed.Store(true)
 	second := newResolver(false)
-	resolved, err = second.Resolve(context.Background(), ref)
+	resolved, err = second.Resolve(t.Context(), ref)
 	if err != nil || resolved.Commit != testSHA || requests.Load() != 1 || second.ResolutionSnapshotID() != firstGeneration {
 		t.Fatalf("reused resolution = %#v, %v; requests %d; generation %q", resolved, err, requests.Load(), second.ResolutionSnapshotID())
 	}
 	if err := os.Remove(second.cfg.resolutionSnapshot.entryPath(ref)); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := newResolver(false).Resolve(context.Background(), ref); err == nil || !strings.Contains(err.Error(), "snapshot entry is missing") {
+	if _, err := newResolver(false).Resolve(t.Context(), ref); err == nil || !strings.Contains(err.Error(), "snapshot entry is missing") {
 		t.Fatalf("missing snapshot entry error = %v", err)
 	}
 	if requests.Load() != 1 {
 		t.Fatalf("missing snapshot entry caused %d requests, want 1", requests.Load())
 	}
 	third := newResolver(true)
-	resolved, err = third.Resolve(context.Background(), ref)
+	resolved, err = third.Resolve(t.Context(), ref)
 	if err != nil || resolved.Commit != nextSHA || requests.Load() != 2 || third.ResolutionSnapshotID() == firstGeneration {
 		t.Fatalf("refreshed resolution = %#v, %v; requests %d; generation %q", resolved, err, requests.Load(), third.ResolutionSnapshotID())
 	}
@@ -1201,11 +1202,11 @@ func TestActionResolutionSnapshotRetriesStorageFailures(t *testing.T) {
 				if operation == "entry short write" {
 					wantErr = io.ErrShortWrite
 				}
-				if _, err := snapshot.resolve(context.Background(), ref, resolve); !errors.Is(err, wantErr) {
+				if _, err := snapshot.resolve(t.Context(), ref, resolve); !errors.Is(err, wantErr) {
 					t.Fatalf("first resolution error = %v, want %v", err, wantErr)
 				}
 				actionResolutionSnapshotStorage = original
-				resolved, err := snapshot.resolve(context.Background(), ref, resolve)
+				resolved, err := snapshot.resolve(t.Context(), ref, resolve)
 				if err != nil || resolved.Commit != testSHA {
 					t.Fatalf("retry = %#v, %v", resolved, err)
 				}
@@ -1286,7 +1287,7 @@ func TestActionResolutionSnapshotRejectsMissingCurrentGeneration(t *testing.T) {
 	}
 	ref, _ := Parse("owner/repo@v1")
 	called := false
-	_, err = refreshed.cfg.resolutionSnapshot.resolve(context.Background(), ref, func(context.Context, Reference) (Resolved, error) {
+	_, err = refreshed.cfg.resolutionSnapshot.resolve(t.Context(), ref, func(context.Context, Reference) (Resolved, error) {
 		called = true
 		return Resolved{}, nil
 	})
@@ -1315,7 +1316,7 @@ func TestActionResolutionSnapshotPersistsOnlyDefinitiveMissingRefs(t *testing.T)
 		}
 		ref, _ := Parse("owner/repo@missing")
 		for range 2 {
-			_, err := resolver.Resolve(context.Background(), ref)
+			_, err := resolver.Resolve(t.Context(), ref)
 			var notPublic *NotPublicError
 			if !errors.As(err, &notPublic) {
 				t.Fatalf("resolution error = %v", err)
@@ -1344,11 +1345,11 @@ func TestActionResolutionSnapshotPersistsOnlyDefinitiveMissingRefs(t *testing.T)
 			t.Fatal(err)
 		}
 		ref, _ := Parse("owner/repo@v1")
-		if _, err := resolver.Resolve(context.Background(), ref); err == nil || !strings.Contains(err.Error(), "HTTP 500") {
+		if _, err := resolver.Resolve(t.Context(), ref); err == nil || !strings.Contains(err.Error(), "HTTP 500") {
 			t.Fatalf("transient resolution error = %v", err)
 		}
 		failed.Store(false)
-		resolved, err := resolver.Resolve(context.Background(), ref)
+		resolved, err := resolver.Resolve(t.Context(), ref)
 		if err != nil || resolved.Commit != testSHA || requests.Load() != 2 {
 			t.Fatalf("retried resolution = %#v, %v; requests %d", resolved, err, requests.Load())
 		}
@@ -1374,7 +1375,7 @@ func TestActionResolutionSnapshotCoalescesConcurrentResolution(t *testing.T) {
 		workers.Add(1)
 		go func() {
 			defer workers.Done()
-			resolved, err := resolver.Resolve(context.Background(), ref)
+			resolved, err := resolver.Resolve(t.Context(), ref)
 			if err == nil && resolved.Commit != testSHA {
 				err = fmt.Errorf("commit = %s", resolved.Commit)
 			}
@@ -1407,7 +1408,7 @@ func TestActionResolutionSnapshotRejectsCorruptEntry(t *testing.T) {
 	if err := os.WriteFile(path, []byte("not json"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := resolver.Resolve(context.Background(), ref); err == nil || !strings.Contains(err.Error(), "snapshot entry is invalid") {
+	if _, err := resolver.Resolve(t.Context(), ref); err == nil || !strings.Contains(err.Error(), "snapshot entry is invalid") {
 		t.Fatalf("corrupt snapshot error = %v", err)
 	}
 }

--- a/internal/buildkite/triggers.go
+++ b/internal/buildkite/triggers.go
@@ -328,11 +328,12 @@ func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpression
 		if err != nil {
 			return "", false, fmt.Errorf("push tags: %w", err)
 		}
-		if hasBranchFilter && hasTagFilter {
+		switch {
+		case hasBranchFilter && hasTagFilter:
 			parts = append(parts, "(("+expressions.Tag+" == null && ("+branch+")) || ("+expressions.Tag+" != null && ("+tag+")))")
-		} else if hasBranchFilter {
+		case hasBranchFilter:
 			parts = append(parts, expressions.Tag+" == null", branch)
-		} else if hasTagFilter {
+		case hasTagFilter:
 			parts = append(parts, expressions.Tag+" != null", tag)
 		}
 		if pathFilters && selected && snapshot.Tag == nil {
@@ -577,15 +578,14 @@ func refFilters(field string, include, exclude []string) (string, bool, error) {
 			return err
 		}
 		match := field + " =~ /" + r + "/"
-		if positive {
-			if state == "" {
-				state = match
-			} else {
-				state = "(" + state + " || " + match + ")"
-			}
-		} else if state == "" {
+		switch {
+		case positive && state == "":
+			state = match
+		case positive:
+			state = "(" + state + " || " + match + ")"
+		case state == "":
 			state = "!(" + match + ")"
-		} else {
+		default:
 			state = "(" + state + " && !(" + match + "))"
 		}
 		return nil
@@ -687,12 +687,13 @@ func githubGlob(glob string, pathPattern bool) (string, error) {
 		case '*':
 			if i+1 < len(runes) && runes[i+1] == '*' {
 				i++
-				if pathPattern && (i == 1 || runes[i-2] == '/') && i+1 < len(runes) && runes[i+1] == '/' {
+				switch {
+				case pathPattern && (i == 1 || runes[i-2] == '/') && i+1 < len(runes) && runes[i+1] == '/':
 					i++
 					atoms = append(atoms, atom{value: `((?s:.*)\/)?`})
-				} else if pathPattern {
+				case pathPattern:
 					atoms = append(atoms, atom{value: `(?s:.*)`})
-				} else {
+				default:
 					atoms = append(atoms, atom{value: ".*"})
 				}
 			} else {

--- a/internal/cli/buildkite_event.go
+++ b/internal/cli/buildkite_event.go
@@ -50,7 +50,8 @@ func buildkiteEventSource(getenv func(string) string) ([]byte, error) {
 		event = "workflow_dispatch"
 	}
 	payload := map[string]any{}
-	if pullRequest != "" && pullRequest != "false" {
+	switch {
+	case pullRequest != "" && pullRequest != "false":
 		number, parseErr := strconv.Atoi(pullRequest)
 		if parseErr != nil || number <= 0 {
 			return nil, fmt.Errorf("BUILDKITE_PULL_REQUEST must be false or a positive integer")
@@ -89,10 +90,10 @@ func buildkiteEventSource(getenv func(string) string) ([]byte, error) {
 		// head rather than a distinct GitHub delivery. Use synchronize to give
 		// that compatibility snapshot deterministic head-update semantics.
 		payload["action"], payload["number"], payload["pull_request"] = "synchronize", number, pr
-	} else if strings.TrimSpace(tag) != "" {
+	case strings.TrimSpace(tag) != "":
 		ref = "refs/tags/" + tag
 		payload["ref"] = ref
-	} else {
+	default:
 		if strings.TrimSpace(branch) == "" {
 			return nil, fmt.Errorf("BUILDKITE_BRANCH or BUILDKITE_TAG is required")
 		}

--- a/internal/cli/buildkite_event_test.go
+++ b/internal/cli/buildkite_event_test.go
@@ -125,6 +125,7 @@ func TestBuildkiteEventSourceMappings(t *testing.T) {
 		{name: "trigger job source fallback", event: "push", ref: "refs/heads/main", env: map[string]string{"BUILDKITE_BRANCH": "main", "BUILDKITE_SOURCE": "trigger_job"}},
 		{name: "tag", event: "push", ref: "refs/tags/v1.2.3", env: map[string]string{"BUILDKITE_TAG": "v1.2.3"}},
 		{name: "pull request head compatibility ref", event: "pull_request", ref: "refs/pull/42/head", env: map[string]string{"BUILDKITE_PULL_REQUEST": "42", "BUILDKITE_BRANCH": "contributor:feature", "BUILDKITE_PULL_REQUEST_BASE_BRANCH": "main", "BUILDKITE_PULL_REQUEST_REPO": "https://github.com/contributor/widgets.git"}, check: func(t *testing.T, snapshot map[string]any) {
+			t.Helper()
 			payload := snapshot["payload"].(map[string]any)
 			pr := payload["pull_request"].(map[string]any)
 			head := pr["head"].(map[string]any)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1434,7 +1434,7 @@ func TestProcessingAnnotationsUseActiveBoundedContext(t *testing.T) {
 		},
 	} {
 		t.Run(path.name, func(t *testing.T) {
-			active, cancel := context.WithCancel(context.Background())
+			active, cancel := context.WithCancel(t.Context())
 			cancel()
 			t.Setenv("BUILDKITE", "true")
 			t.Setenv("BUILDKITE_JOB_ID", cliTestJobID)

--- a/internal/cli/hosted_test.go
+++ b/internal/cli/hosted_test.go
@@ -353,18 +353,18 @@ func TestActionSourceAuthenticationUsesDedicatedTokenAndFallsBackAnonymously(t *
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := resolver.Resolve(context.Background(), exact); err != nil || requests != 0 || provider.calls != 0 || len(redactor.values) != 0 {
+	if _, err := resolver.Resolve(t.Context(), exact); err != nil || requests != 0 || provider.calls != 0 || len(redactor.values) != 0 {
 		t.Fatalf("exact Resolve() error/requests/provider/redactions = %v / %d / %d / %#v", err, requests, provider.calls, redactor.values)
 	}
 	ref, err := actionsource.Parse("o/r@v1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := resolver.Resolve(context.Background(), ref); err != nil || requests != 2 || provider.calls != 1 || provider.repository != "buildkite/buildkite-gha" || !slices.Equal(redactor.values, []string{token}) {
+	if _, err := resolver.Resolve(t.Context(), ref); err != nil || requests != 2 || provider.calls != 1 || provider.repository != "buildkite/buildkite-gha" || !slices.Equal(redactor.values, []string{token}) {
 		t.Fatalf("Resolve() error/requests = %v / %d", err, requests)
 	}
 	second, _ := actionsource.Parse("o/r@v2")
-	if _, err := resolver.Resolve(context.Background(), second); err != nil || provider.calls != 1 || !slices.Equal(redactor.values, []string{token}) {
+	if _, err := resolver.Resolve(t.Context(), second); err != nil || provider.calls != 1 || !slices.Equal(redactor.values, []string{token}) {
 		t.Fatalf("second Resolve() error/provider/redactions = %v / %d / %#v", err, provider.calls, redactor.values)
 	}
 
@@ -386,7 +386,7 @@ func TestActionSourceAuthenticationUsesDedicatedTokenAndFallsBackAnonymously(t *
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			var warnings bytes.Buffer
-			ctx := context.Background()
+			ctx := t.Context()
 			if test.cancelContext {
 				var cancel context.CancelFunc
 				ctx, cancel = context.WithCancel(ctx)
@@ -397,13 +397,14 @@ func TestActionSourceAuthenticationUsesDedicatedTokenAndFallsBackAnonymously(t *
 				authentication.provider = test.provider
 			}
 			gotToken, err := authentication.token(ctx, "buildkite/buildkite-gha")
-			if test.wantContext {
+			switch {
+			case test.wantContext:
 				if !errors.Is(err, context.Canceled) || gotToken != "" || warnings.Len() != 0 {
 					t.Fatalf("token/error/warnings = %q / %v / %q", gotToken, err, warnings.String())
 				}
-			} else if err != nil || gotToken != "" {
+			case err != nil || gotToken != "":
 				t.Fatalf("token/error = %q / %v, want anonymous fallback", gotToken, err)
-			} else if !strings.Contains(warnings.String(), "resolving mutable public action references anonymously") || strings.Contains(warnings.String(), token) || strings.Contains(warnings.String(), "backend details") {
+			case !strings.Contains(warnings.String(), "resolving mutable public action references anonymously") || strings.Contains(warnings.String(), token) || strings.Contains(warnings.String(), "backend details"):
 				t.Fatalf("fallback warning = %q, want sanitized observable warning", warnings.String())
 			}
 		})
@@ -444,7 +445,7 @@ func TestActionSourceAuthenticationReusesOneTokenAcrossConcurrentWorkflowResolve
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, err := resolver.Resolve(context.Background(), ref)
+			_, err := resolver.Resolve(t.Context(), ref)
 			errs <- err
 		}()
 	}
@@ -497,7 +498,7 @@ func TestHostedLocalActionDoesNotProvisionSourceToken(t *testing.T) {
 			redactor := &cliRedactor{}
 			var warnings bytes.Buffer
 			authentication := &actionSourceAuthentication{provider: provider, redactor: redactor, warnings: &warnings}
-			if _, err := compileHosted(context.Background(), workflowPath, workflowSource, test.event, "dev", "sha256:"+strings.Repeat("0", 64), "importer", "", nil, nil, authentication); err != nil {
+			if _, err := compileHosted(t.Context(), workflowPath, workflowSource, test.event, "dev", "sha256:"+strings.Repeat("0", 64), "importer", "", nil, nil, authentication); err != nil {
 				t.Fatal(err)
 			}
 			if provider.calls != 0 || len(redactor.values) != 0 || warnings.Len() != 0 {
@@ -515,16 +516,16 @@ func TestCompileHostedRequiresExplicitMacOSQueueAndRuntime(t *testing.T) {
 	}
 	compilerDigest := "sha256:" + strings.Repeat("0", 64)
 	darwinDigest := "sha256:" + strings.Repeat("1", 64)
-	_, err = compileHosted(context.Background(), "macos.yml", workflow, event, "0.0.0-test", compilerDigest, "importer", "", nil, nil, nil)
+	_, err = compileHosted(t.Context(), "macos.yml", workflow, event, "0.0.0-test", compilerDigest, "importer", "", nil, nil, nil)
 	if err == nil || !strings.Contains(err.Error(), `runner label "macos-15" is not mapped by policy`) {
 		t.Fatalf("missing macOS queue error = %v", err)
 	}
 	macOSTarget := map[string]compiler.RunnerTarget{"macos-15": {Queue: "macos", Platform: compiler.PlatformDarwinARM64}}
-	_, err = compileHosted(context.Background(), "macos.yml", workflow, event, "0.0.0-test", compilerDigest, "importer", "", macOSTarget, nil, nil)
+	_, err = compileHosted(t.Context(), "macos.yml", workflow, event, "0.0.0-test", compilerDigest, "importer", "", macOSTarget, nil, nil)
 	if err == nil || !strings.Contains(err.Error(), "no runtime distribution configured for darwin/arm64") {
 		t.Fatalf("missing macOS runtime error = %v", err)
 	}
-	compiled, err := compileHosted(context.Background(), "macos.yml", workflow, event, "0.0.0-test", compilerDigest, "importer", "", macOSTarget, map[compiler.Platform]string{compiler.PlatformDarwinARM64: darwinDigest}, nil)
+	compiled, err := compileHosted(t.Context(), "macos.yml", workflow, event, "0.0.0-test", compilerDigest, "importer", "", macOSTarget, map[compiler.Platform]string{compiler.PlatformDarwinARM64: darwinDigest}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -541,12 +542,12 @@ func TestCompileHostedDefaultsMacOSLatestAliasToHostedQueue(t *testing.T) {
 	}
 	compilerDigest := "sha256:" + strings.Repeat("0", 64)
 	darwinDigest := "sha256:" + strings.Repeat("1", 64)
-	_, err = compileHosted(context.Background(), "macos.yml", workflow, event, "0.0.0-test", compilerDigest, "importer", "", nil, nil, nil)
+	_, err = compileHosted(t.Context(), "macos.yml", workflow, event, "0.0.0-test", compilerDigest, "importer", "", nil, nil, nil)
 	if err == nil || !strings.Contains(err.Error(), "no runtime distribution configured for darwin/arm64") {
 		t.Fatalf("unmapped macos-latest without Darwin runtime error = %v", err)
 	}
 	darwinRuntime := map[compiler.Platform]string{compiler.PlatformDarwinARM64: darwinDigest}
-	compiled, err := compileHosted(context.Background(), "macos.yml", workflow, event, "0.0.0-test", compilerDigest, "importer", "", nil, darwinRuntime, nil)
+	compiled, err := compileHosted(t.Context(), "macos.yml", workflow, event, "0.0.0-test", compilerDigest, "importer", "", nil, darwinRuntime, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -554,7 +555,7 @@ func TestCompileHostedDefaultsMacOSLatestAliasToHostedQueue(t *testing.T) {
 		t.Fatalf("default macos-latest compilation = %#v\n%s", compiled.Bundle.Plans, compiled.Bundle.Pipeline)
 	}
 	override := map[string]compiler.RunnerTarget{"macos-latest": {Queue: "custom-macos", Platform: compiler.PlatformDarwinARM64}}
-	compiled, err = compileHosted(context.Background(), "macos.yml", workflow, event, "0.0.0-test", compilerDigest, "importer", "", override, darwinRuntime, nil)
+	compiled, err = compileHosted(t.Context(), "macos.yml", workflow, event, "0.0.0-test", compilerDigest, "importer", "", override, darwinRuntime, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -572,7 +573,7 @@ func TestJobScopedActionSourceAuthenticationIgnoresAmbientGitHubTokens(t *testin
 	t.Setenv("BUILDKITE_AGENT_ACCESS_TOKEN", "")
 	var warnings bytes.Buffer
 	authentication := importerJobActionSourceAuthentication(&warnings)
-	token, err := authentication.token(context.Background(), "buildkite/buildkite-gha")
+	token, err := authentication.token(t.Context(), "buildkite/buildkite-gha")
 	if err != nil || token != "" || authentication.provider != nil || !strings.Contains(warnings.String(), "authentication is unavailable") {
 		t.Fatalf("ambient GitHub token authentication = provider %v, token %q, error %v, warnings %q", authentication.provider != nil, token, err, warnings.String())
 	}
@@ -607,7 +608,7 @@ jobs:
 	targets := map[string]compiler.RunnerTarget{
 		"ubuntu-latest": {Queue: "hosted", Platform: compiler.PlatformLinuxAMD64, Image: image},
 	}
-	compiled, err := compileHosted(context.Background(), "profiles.yml", workflow, event, "dev", "sha256:"+strings.Repeat("1", 64), "importer", "", targets, nil, nil)
+	compiled, err := compileHosted(t.Context(), "profiles.yml", workflow, event, "dev", "sha256:"+strings.Repeat("1", 64), "importer", "", targets, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/plugin_runtime_test.go
+++ b/internal/cli/plugin_runtime_test.go
@@ -4,7 +4,6 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
-	"context"
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
@@ -23,15 +22,15 @@ func TestPluginDevCounterpartInjectionIsRequiredAndReleaseRejectsIt(t *testing.T
 	linux := runtimeDistribution{contents: []byte("linux"), digest: "sha256:linux"}
 	required := map[compiler.Platform]bool{compiler.PlatformDarwinARM64: true}
 	t.Setenv(pluginDevDarwinRuntimeEnvironment, "")
-	if _, err := (&pluginRuntimeAcquisition{version: "dev"}).acquire(context.Background(), required, compiler.PlatformLinuxAMD64, linux); err == nil || !strings.Contains(err.Error(), "required") {
+	if _, err := (&pluginRuntimeAcquisition{version: "dev"}).acquire(t.Context(), required, compiler.PlatformLinuxAMD64, linux); err == nil || !strings.Contains(err.Error(), "required") {
 		t.Fatalf("dev acquisition error = %v", err)
 	}
 	darwin := runtimeDistribution{contents: []byte("darwin"), digest: "sha256:darwin"}
-	if _, err := (&pluginRuntimeAcquisition{version: "dev"}).acquire(context.Background(), map[compiler.Platform]bool{compiler.PlatformLinuxAMD64: true}, compiler.PlatformDarwinARM64, darwin); err == nil || !strings.Contains(err.Error(), pluginDevLinuxRuntimeEnvironment) {
+	if _, err := (&pluginRuntimeAcquisition{version: "dev"}).acquire(t.Context(), map[compiler.Platform]bool{compiler.PlatformLinuxAMD64: true}, compiler.PlatformDarwinARM64, darwin); err == nil || !strings.Contains(err.Error(), pluginDevLinuxRuntimeEnvironment) {
 		t.Fatalf("Darwin-hosted dev acquisition error = %v", err)
 	}
 	t.Setenv(pluginDevDarwinRuntimeEnvironment, filepath.Join(t.TempDir(), "injected"))
-	if _, err := (&pluginRuntimeAcquisition{version: "1.2.3"}).acquire(context.Background(), map[compiler.Platform]bool{}, compiler.PlatformLinuxAMD64, linux); err == nil || !strings.Contains(err.Error(), "rejected") {
+	if _, err := (&pluginRuntimeAcquisition{version: "1.2.3"}).acquire(t.Context(), map[compiler.Platform]bool{}, compiler.PlatformLinuxAMD64, linux); err == nil || !strings.Contains(err.Error(), "rejected") {
 		t.Fatalf("release injection error = %v", err)
 	}
 }
@@ -51,7 +50,7 @@ func TestPluginAcquiresVerifiedLinuxRuntimeForDarwinHost(t *testing.T) {
 		}
 	}))
 	defer server.Close()
-	distribution, err := acquirePluginRuntime(context.Background(), "1.2.3", compiler.PlatformLinuxAMD64, server.Client(), server.URL, "")
+	distribution, err := acquirePluginRuntime(t.Context(), "1.2.3", compiler.PlatformLinuxAMD64, server.Client(), server.URL, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,7 +75,7 @@ func pluginTestLinuxExecutable() []byte {
 func TestPluginAcquisitionIsLazyAndBindsVerifiedDarwinContents(t *testing.T) {
 	linux := runtimeDistribution{contents: []byte("running executable"), digest: "sha256:running"}
 	t.Setenv(pluginDevDarwinRuntimeEnvironment, "")
-	got, err := (&pluginRuntimeAcquisition{version: "dev"}).acquire(context.Background(), map[compiler.Platform]bool{compiler.PlatformLinuxAMD64: true}, compiler.PlatformLinuxAMD64, linux)
+	got, err := (&pluginRuntimeAcquisition{version: "dev"}).acquire(t.Context(), map[compiler.Platform]bool{compiler.PlatformLinuxAMD64: true}, compiler.PlatformLinuxAMD64, linux)
 	if err != nil || got[compiler.PlatformLinuxAMD64].digest != linux.digest {
 		t.Fatalf("Linux-only acquisition = %#v, %v", got, err)
 	}
@@ -98,7 +97,7 @@ func TestPluginAcquisitionIsLazyAndBindsVerifiedDarwinContents(t *testing.T) {
 	}))
 	defer server.Close()
 	cache := filepath.Join(canonicalTempDir(t), pluginDarwinAsset)
-	distribution, err := acquirePluginRuntime(context.Background(), "1.2.3", compiler.PlatformDarwinARM64, server.Client(), server.URL, cache)
+	distribution, err := acquirePluginRuntime(t.Context(), "1.2.3", compiler.PlatformDarwinARM64, server.Client(), server.URL, cache)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -106,7 +105,7 @@ func TestPluginAcquisitionIsLazyAndBindsVerifiedDarwinContents(t *testing.T) {
 	if distribution.digest != wantDigest || !bytes.Equal(distribution.contents, darwin) {
 		t.Fatalf("Darwin distribution = %q, %x", distribution.digest, distribution.contents)
 	}
-	if _, err := acquirePluginRuntime(context.Background(), "1.2.3", compiler.PlatformDarwinARM64, server.Client(), server.URL, cache); err != nil {
+	if _, err := acquirePluginRuntime(t.Context(), "1.2.3", compiler.PlatformDarwinARM64, server.Client(), server.URL, cache); err != nil {
 		t.Fatal(err)
 	}
 	if requests["/v1.2.3/checksums.txt"] != 2 || requests["/v1.2.3/"+pluginDarwinAsset] != 1 {
@@ -115,7 +114,7 @@ func TestPluginAcquisitionIsLazyAndBindsVerifiedDarwinContents(t *testing.T) {
 	if err := os.WriteFile(cache, []byte("untrusted cache"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := acquirePluginRuntime(context.Background(), "1.2.3", compiler.PlatformDarwinARM64, server.Client(), server.URL, cache); err != nil {
+	if _, err := acquirePluginRuntime(t.Context(), "1.2.3", compiler.PlatformDarwinARM64, server.Client(), server.URL, cache); err != nil {
 		t.Fatal(err)
 	}
 	if requests["/v1.2.3/checksums.txt"] != 3 || requests["/v1.2.3/"+pluginDarwinAsset] != 2 {
@@ -143,7 +142,7 @@ func TestPluginDarwinRejectsChecksumArchiveAndBinaryFailures(t *testing.T) {
 		_, _ = response.Write(wrong)
 	}))
 	defer server.Close()
-	if _, err := acquirePluginRuntime(context.Background(), "1.2.3", compiler.PlatformDarwinARM64, server.Client(), server.URL, ""); err == nil || !strings.Contains(err.Error(), "Mach-O") {
+	if _, err := acquirePluginRuntime(t.Context(), "1.2.3", compiler.PlatformDarwinARM64, server.Client(), server.URL, ""); err == nil || !strings.Contains(err.Error(), "Mach-O") {
 		t.Fatalf("wrong binary error = %v", err)
 	}
 }

--- a/internal/cli/plugin_test.go
+++ b/internal/cli/plugin_test.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -623,7 +622,7 @@ func TestNormalizePluginCommit(t *testing.T) {
 	t.Run("preserves valid full commit", func(t *testing.T) {
 		runner := &cliCaptureRunner{}
 		setCalls := 0
-		err := normalizePluginCommit(context.Background(), func(string) string { return fullCommit }, func(string, string) error {
+		err := normalizePluginCommit(t.Context(), func(string) string { return fullCommit }, func(string, string) error {
 			setCalls++
 			return nil
 		}, runner)
@@ -634,7 +633,7 @@ func TestNormalizePluginCommit(t *testing.T) {
 	t.Run("resolves symbolic commit from HEAD", func(t *testing.T) {
 		runner := &cliCaptureRunner{gitOutput: []byte(fullCommit + "\n")}
 		name, value := "", ""
-		err := normalizePluginCommit(context.Background(), func(string) string { return "HEAD" }, func(gotName, gotValue string) error {
+		err := normalizePluginCommit(t.Context(), func(string) string { return "HEAD" }, func(gotName, gotValue string) error {
 			name, value = gotName, gotValue
 			return nil
 		}, runner)
@@ -647,7 +646,7 @@ func TestNormalizePluginCommit(t *testing.T) {
 	})
 	t.Run("propagates resolution failure", func(t *testing.T) {
 		runner := &cliCaptureRunner{gitErr: errors.New("no checkout")}
-		err := normalizePluginCommit(context.Background(), func(string) string { return "HEAD" }, os.Setenv, runner)
+		err := normalizePluginCommit(t.Context(), func(string) string { return "HEAD" }, func(string, string) error { return nil }, runner)
 		if err == nil || !strings.Contains(err.Error(), "resolve BUILDKITE_COMMIT from checked-out HEAD: no checkout") {
 			t.Fatalf("normalizePluginCommit() error = %v", err)
 		}

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -519,11 +519,12 @@ func validatedProcessingReport(out processingOutput, workflowPath, profile strin
 func validatedProcessingReportWithOptions(out processingOutput, workflowPath, profile string, source, event []byte, eventEvaluated bool, options *compiler.Options) (compatibility.ProcessingReport, bool) {
 	var validation compiler.Report
 	var err error
-	if eventEvaluated && options != nil {
+	switch {
+	case eventEvaluated && options != nil:
 		validation, err = compiler.ValidateEventWithOptions(workflowPath, source, event, *options)
-	} else if eventEvaluated {
+	case eventEvaluated:
 		validation, err = compiler.ValidateEvent(workflowPath, source, event)
-	} else {
+	default:
 		validation, err = compiler.Validate(workflowPath, source)
 	}
 	report := compatibility.InitialProcessingReport(workflowPath, profile, eventEvaluated, validation, err)

--- a/internal/cli/run_job_test.go
+++ b/internal/cli/run_job_test.go
@@ -149,14 +149,7 @@ func TestRunJobExecutesBoundPlanAndWritesResult(t *testing.T) {
 	t.Setenv("BUILDKITE_JOB_ID", cliTestJobID)
 	t.Setenv("BUILDKITE_STEP_KEY", job.Target.StepKey)
 	t.Setenv("BUILDKITE_AGENT_META_DATA_QUEUE", job.Target.Queue)
-	oldDirectory, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Chdir(workspace); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.Chdir(oldDirectory) })
+	t.Chdir(workspace)
 
 	var stdout, stderr bytes.Buffer
 	runner := &cliCaptureRunner{}
@@ -567,7 +560,7 @@ func TestRunJobPublishesEveryTerminalResultAfterCancellation(t *testing.T) {
 			planPath, planDigest := writeCLIJobPlan(t, job)
 			setCLIJobIdentity(t, job, planDigest)
 			runner := &cliCaptureRunner{}
-			ctx := context.Background()
+			ctx := t.Context()
 			if test.cancel {
 				cancelled, cancel := context.WithCancel(ctx)
 				cancel()
@@ -843,14 +836,7 @@ func TestRunJobExecutesPureRunPlanWithoutCheckout(t *testing.T) {
 	if err := os.WriteFile(planPath, encoded, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	oldDirectory, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Chdir(workspace); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.Chdir(oldDirectory) })
+	t.Chdir(workspace)
 
 	var stdout, stderr bytes.Buffer
 	if code := Run([]string{"run-job", "--plan", planPath, "--result", resultPath}, &stdout, &stderr, "dev"); code != 0 {

--- a/internal/cli/runtime_mise_test.go
+++ b/internal/cli/runtime_mise_test.go
@@ -85,7 +85,7 @@ func TestResolveRuntimeMisePinsRequiredExecutable(t *testing.T) {
 	}
 	t.Setenv("PATH", linkRoot)
 	t.Setenv("MISE_TEST_POISON", "must-not-reach-version-check")
-	got, err := resolveRuntimeMise(context.Background(), "", t.TempDir(), t.TempDir(), io.Discard)
+	got, err := resolveRuntimeMise(t.Context(), "", t.TempDir(), t.TempDir(), io.Discard)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,7 +100,7 @@ func TestResolveRuntimeMisePinsRequiredExecutable(t *testing.T) {
 
 func TestResolveRuntimeMiseAcceptsNewerVersion(t *testing.T) {
 	realMise := setFakeMise(t, "2026.8.1")
-	got, err := resolveRuntimeMiseWithInstaller(context.Background(), "", t.TempDir(), t.TempDir(), io.Discard, func(context.Context, string, string, io.Writer) (string, error) {
+	got, err := resolveRuntimeMiseWithInstaller(t.Context(), "", t.TempDir(), t.TempDir(), io.Discard, func(context.Context, string, string, io.Writer) (string, error) {
 		return "", errors.New("unexpected managed mise install")
 	})
 	if err != nil || got != realMise {
@@ -114,7 +114,7 @@ func TestResolveRuntimeMiseAcceptsPrefixedVersionOutput(t *testing.T) {
 	if err := os.WriteFile(mise, []byte("#!/bin/sh\nprintf 'mise v2026.8.1 linux-x64 (test)\\n'\n"), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	got, err := resolveRuntimeMise(context.Background(), mise, t.TempDir(), t.TempDir(), io.Discard)
+	got, err := resolveRuntimeMise(t.Context(), mise, t.TempDir(), t.TempDir(), io.Discard)
 	if err != nil || got != mise {
 		t.Fatalf("resolveRuntimeMise() = %q, %v; want %q", got, err, mise)
 	}
@@ -172,7 +172,7 @@ func TestResolveRuntimeMiseInstallsManagedCopyWhenNeeded(t *testing.T) {
 				}
 				return managed, nil
 			}
-			got, err := resolveRuntimeMiseWithInstaller(context.Background(), "", dataDir, privateRuntime, io.Discard, installer)
+			got, err := resolveRuntimeMiseWithInstaller(t.Context(), "", dataDir, privateRuntime, io.Discard, installer)
 			if err != nil || got != managed || called != 1 {
 				t.Fatalf("resolveRuntimeMiseWithInstaller() = %q, %v; calls = %d", got, err, called)
 			}
@@ -182,13 +182,13 @@ func TestResolveRuntimeMiseInstallsManagedCopyWhenNeeded(t *testing.T) {
 
 func TestResolveRuntimeMiseRejectsInvalidExplicitOverride(t *testing.T) {
 	t.Run("configured path must be absolute", func(t *testing.T) {
-		if _, err := resolveRuntimeMise(context.Background(), "mise", t.TempDir(), t.TempDir(), io.Discard); err == nil || !strings.Contains(err.Error(), "must be an absolute path") {
+		if _, err := resolveRuntimeMise(t.Context(), "mise", t.TempDir(), t.TempDir(), io.Discard); err == nil || !strings.Contains(err.Error(), "must be an absolute path") {
 			t.Fatalf("resolveRuntimeMise() error = %v", err)
 		}
 	})
 	t.Run("old version", func(t *testing.T) {
 		mise := setFakeMise(t, "2026.5.11")
-		if _, err := resolveRuntimeMise(context.Background(), mise, t.TempDir(), t.TempDir(), io.Discard); err == nil || !strings.Contains(err.Error(), `reported version "2026.5.11", want "2026.5.12" or newer`) {
+		if _, err := resolveRuntimeMise(t.Context(), mise, t.TempDir(), t.TempDir(), io.Discard); err == nil || !strings.Contains(err.Error(), `reported version "2026.5.11", want "2026.5.12" or newer`) {
 			t.Fatalf("resolveRuntimeMise() error = %v", err)
 		}
 	})
@@ -197,7 +197,7 @@ func TestResolveRuntimeMiseRejectsInvalidExplicitOverride(t *testing.T) {
 		if err := os.WriteFile(mise, []byte("mise"), 0o600); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := resolveRuntimeMise(context.Background(), mise, t.TempDir(), t.TempDir(), io.Discard); err == nil || !strings.Contains(err.Error(), "not an executable regular file") {
+		if _, err := resolveRuntimeMise(t.Context(), mise, t.TempDir(), t.TempDir(), io.Discard); err == nil || !strings.Contains(err.Error(), "not an executable regular file") {
 			t.Fatalf("resolveRuntimeMise() error = %v", err)
 		}
 	})
@@ -228,8 +228,8 @@ func TestInstallRuntimeMiseDownloadsVerifiesAndReusesCache(t *testing.T) {
 	}
 	root := filepath.Join(logicalParent, "cache")
 	want := filepath.Join(realParent, "cache", "linux-x64", "mise")
-	for i := 0; i < 2; i++ {
-		got, err := installRuntimeMiseFrom(context.Background(), root, server.Client(), server.URL, hex.EncodeToString(archiveHash[:]), hex.EncodeToString(binaryHash[:]))
+	for range 2 {
+		got, err := installRuntimeMiseFrom(t.Context(), root, server.Client(), server.URL, hex.EncodeToString(archiveHash[:]), hex.EncodeToString(binaryHash[:]))
 		if err != nil || got != want {
 			t.Fatalf("installRuntimeMiseFrom() = %q, %v", got, err)
 		}
@@ -250,7 +250,7 @@ func TestInstallRuntimeMiseRejectsInvalidArchive(t *testing.T) {
 	}))
 	defer server.Close()
 	binaryHash := sha256.Sum256(binary)
-	if _, err := installRuntimeMiseFrom(context.Background(), t.TempDir(), server.Client(), server.URL, strings.Repeat("0", 64), hex.EncodeToString(binaryHash[:])); err == nil || !strings.Contains(err.Error(), "archive checksum") {
+	if _, err := installRuntimeMiseFrom(t.Context(), t.TempDir(), server.Client(), server.URL, strings.Repeat("0", 64), hex.EncodeToString(binaryHash[:])); err == nil || !strings.Contains(err.Error(), "archive checksum") {
 		t.Fatalf("installRuntimeMiseFrom() error = %v", err)
 	}
 }
@@ -268,7 +268,7 @@ func TestValidateRuntimeMiseRejectsOversizedCacheEntry(t *testing.T) {
 	if err := file.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := validateRuntimeMiseFile(context.Background(), cached, strings.Repeat("0", 64)); err == nil || !strings.Contains(err.Error(), "exceeds") {
+	if _, err := validateRuntimeMiseFile(t.Context(), cached, strings.Repeat("0", 64)); err == nil || !strings.Contains(err.Error(), "exceeds") {
 		t.Fatalf("validateRuntimeMiseFile() error = %v, want size rejection", err)
 	}
 }
@@ -285,14 +285,14 @@ func TestManagedMiseCacheIsNotExecutedBeforePrivateCopy(t *testing.T) {
 	if err := os.WriteFile(cached, binary, 0o500); err != nil {
 		t.Fatal(err)
 	}
-	got, err := installRuntimeMiseFrom(context.Background(), root, nil, "", "", hex.EncodeToString(digest[:]))
+	got, err := installRuntimeMiseFrom(t.Context(), root, nil, "", "", hex.EncodeToString(digest[:]))
 	if err != nil || got != cached {
 		t.Fatalf("installRuntimeMiseFrom() = %q, %v; want cache hit %q", got, err, cached)
 	}
 	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("shared cache executable ran during validation: %v", err)
 	}
-	if _, err := pinRuntimeMise(context.Background(), cached, t.TempDir(), hex.EncodeToString(digest[:])); err != nil {
+	if _, err := pinRuntimeMise(t.Context(), cached, t.TempDir(), hex.EncodeToString(digest[:])); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(marker); err != nil {
@@ -310,14 +310,14 @@ func TestManagedMiseColdCacheIsNotExecutedBeforePrivateCopy(t *testing.T) {
 		_, _ = response.Write(archive)
 	}))
 	defer server.Close()
-	cached, err := installRuntimeMiseFrom(context.Background(), t.TempDir(), server.Client(), server.URL, hex.EncodeToString(archiveDigest[:]), hex.EncodeToString(binaryDigest[:]))
+	cached, err := installRuntimeMiseFrom(t.Context(), t.TempDir(), server.Client(), server.URL, hex.EncodeToString(archiveDigest[:]), hex.EncodeToString(binaryDigest[:]))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("shared staging executable ran during validation: %v", err)
 	}
-	if _, err := pinRuntimeMise(context.Background(), cached, t.TempDir(), hex.EncodeToString(binaryDigest[:])); err != nil {
+	if _, err := pinRuntimeMise(t.Context(), cached, t.TempDir(), hex.EncodeToString(binaryDigest[:])); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(marker); err != nil {
@@ -348,7 +348,7 @@ func TestPinRuntimeMiseCopiesVerifiedBytesPrivately(t *testing.T) {
 	if err := os.Mkdir(privateRuntime, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	got, err := pinRuntimeMise(context.Background(), cached, privateRuntime, hex.EncodeToString(digest[:]))
+	got, err := pinRuntimeMise(t.Context(), cached, privateRuntime, hex.EncodeToString(digest[:]))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -364,14 +364,14 @@ func TestPinRuntimeMiseCopiesVerifiedBytesPrivately(t *testing.T) {
 	if copied, err := os.ReadFile(got); err != nil || !bytes.Equal(copied, binary) {
 		t.Fatalf("private mise changed with cache: %q, %v", copied, err)
 	}
-	if _, err := pinRuntimeMise(context.Background(), cached, t.TempDir(), hex.EncodeToString(digest[:])); err == nil || !strings.Contains(err.Error(), "checksum") {
+	if _, err := pinRuntimeMise(t.Context(), cached, t.TempDir(), hex.EncodeToString(digest[:])); err == nil || !strings.Contains(err.Error(), "checksum") {
 		t.Fatalf("pinRuntimeMise() accepted tampered cache: %v", err)
 	}
 	linkedRuntime := filepath.Join(base, "linked-runtime")
 	if err := os.Symlink(filepath.Join(realParent, "runtime"), linkedRuntime); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := pinRuntimeMise(context.Background(), got, linkedRuntime, hex.EncodeToString(digest[:])); err == nil || !strings.Contains(err.Error(), "contains a symlink") {
+	if _, err := pinRuntimeMise(t.Context(), got, linkedRuntime, hex.EncodeToString(digest[:])); err == nil || !strings.Contains(err.Error(), "contains a symlink") {
 		t.Fatalf("pinRuntimeMise() accepted symlink root: %v", err)
 	}
 }
@@ -381,7 +381,7 @@ func TestInstallRuntimeMiseLiveRelease(t *testing.T) {
 		t.Skip("set BUILDKITE_GHA_LIVE_REQUIRED=1 to verify the pinned mise release")
 	}
 	privateRuntime := t.TempDir()
-	got, err := installRuntimeMise(context.Background(), t.TempDir(), privateRuntime, io.Discard)
+	got, err := installRuntimeMise(t.Context(), t.TempDir(), privateRuntime, io.Discard)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -392,7 +392,7 @@ func TestInstallRuntimeMiseLiveRelease(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := validateRuntimeMise(context.Background(), got, selected.binaryDigest); err != nil {
+	if _, err := validateRuntimeMise(t.Context(), got, selected.binaryDigest); err != nil {
 		t.Fatalf("validate installed mise release: %v", err)
 	}
 }

--- a/internal/cli/telemetry.go
+++ b/internal/cli/telemetry.go
@@ -36,8 +36,7 @@ func telemetryOutcome(code int, conclusion string, contextErr error) telemetry.O
 	if code == buildkitepipeline.ContinueOnErrorExitStatus {
 		return telemetry.OutcomeToleratedFailure
 	}
-	switch conclusion {
-	case "cancelled":
+	if conclusion == "cancelled" {
 		return telemetry.OutcomeCancelled
 	}
 	if errors.Is(contextErr, context.Canceled) || errors.Is(contextErr, context.DeadlineExceeded) {

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -279,7 +279,7 @@ func TestCompileActionLocksRequiresMiseOnlyForJavaScriptReachableGraphs(t *testi
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, _, _, got, err := compileActionLocks(context.Background(), workspace, source, test.refs)
+			_, _, _, got, err := compileActionLocks(t.Context(), workspace, source, test.refs)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -299,12 +299,12 @@ func TestCompileActionInvocationsValidatesNestedUploadArtifact(t *testing.T) {
 	}
 
 	writeAction(t, workspace, "parent", "name: parent\nruns:\n  using: composite\n  steps:\n    - uses: actions/upload-artifact@v4\n      with:\n        path: payload\n        overwrite: true\n")
-	if _, err := compileActionInvocations(context.Background(), workspace, source, "https://github.com", []string{"./parent"}, []map[string]string{{}}); err == nil || !strings.Contains(err.Error(), "bounded upload-artifact adapter") || !strings.Contains(err.Error(), "overwrite") {
+	if _, err := compileActionInvocations(t.Context(), workspace, source, "https://github.com", []string{"./parent"}, []map[string]string{{}}); err == nil || !strings.Contains(err.Error(), "bounded upload-artifact adapter") || !strings.Contains(err.Error(), "overwrite") {
 		t.Fatalf("nested literal validation error = %v", err)
 	}
 
 	writeAction(t, workspace, "parent", "name: parent\ninputs:\n  path:\n    required: true\nruns:\n  using: composite\n  steps:\n    - uses: actions/upload-artifact@v4\n      with:\n        path: ${{ inputs.path }}\n")
-	if _, err := compileActionInvocations(context.Background(), workspace, source, "https://github.com", []string{"./parent"}, []map[string]string{{"path": "payload"}}); err != nil {
+	if _, err := compileActionInvocations(t.Context(), workspace, source, "https://github.com", []string{"./parent"}, []map[string]string{{"path": "payload"}}); err != nil {
 		t.Fatalf("nested expression was not deferred to runtime: %v", err)
 	}
 }
@@ -312,7 +312,7 @@ func TestCompileActionInvocationsValidatesNestedUploadArtifact(t *testing.T) {
 func TestCompileActionLocksLocalAndDedup(t *testing.T) {
 	w := t.TempDir()
 	writeAction(t, w, "js", "name: js\nruns:\n  using: node20\n  main: index.js\n")
-	selectors, locks, caps, _, err := compileActionLocks(context.Background(), w, nil, []string{"./js", "./js"})
+	selectors, locks, caps, _, err := compileActionLocks(t.Context(), w, nil, []string{"./js", "./js"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -383,7 +383,7 @@ runs:
 		{name: "token before dynamic GitHub index", ref: "./mixed", wantErr: "index must be a string literal"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			compiled, err := compileActionInvocations(context.Background(), w, nil, "https://github.com", []string{test.ref}, []map[string]string{test.supplied})
+			compiled, err := compileActionInvocations(t.Context(), w, nil, "https://github.com", []string{test.ref}, []map[string]string{test.supplied})
 			if test.wantErr != "" {
 				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
 					t.Fatalf("compileActionInvocations() error = %v, want %q", err, test.wantErr)
@@ -413,7 +413,7 @@ runs:
   main: index.js
 `)
 	compiled, err := compileActionInvocations(
-		context.Background(), workspace, nil, "https://github.com", []string{"./secrets"},
+		t.Context(), workspace, nil, "https://github.com", []string{"./secrets"},
 		[]map[string]string{{"optional": "${{ secrets.OPTIONAL_TOKEN }}", "required": "${{ secrets.REQUIRED_TOKEN }}-${{ secrets.GITHUB_TOKEN }}-${{ github.token }}"}},
 	)
 	if err != nil {
@@ -446,7 +446,7 @@ runs:
         token: ${{ secrets.DEPLOY_KEY }}
 `)
 
-	_, err := compileActionInvocations(context.Background(), workspace, nil, "https://github.com", []string{"./parent"}, []map[string]string{nil})
+	_, err := compileActionInvocations(t.Context(), workspace, nil, "https://github.com", []string{"./parent"}, []map[string]string{nil})
 	if err == nil || !strings.Contains(err.Error(), "composite action metadata cannot grant secret authority") {
 		t.Fatalf("composite metadata secret error = %v", err)
 	}
@@ -463,7 +463,7 @@ runs:
   main: index.js
 `)
 	_, err := compileActionInvocations(
-		context.Background(), workspace, nil, "https://github.com", []string{"./event"},
+		t.Context(), workspace, nil, "https://github.com", []string{"./event"},
 		[]map[string]string{{"action": "${{ github.event.action }}"}},
 	)
 	if err == nil || !strings.Contains(err.Error(), "github.event cannot be retained in a job plan") {
@@ -481,7 +481,7 @@ runs:
   using: node24
   main: index.js
 `)
-	_, err := compileActionInvocations(context.Background(), workspace, nil, "https://github.com", []string{"./secrets"}, []map[string]string{nil})
+	_, err := compileActionInvocations(t.Context(), workspace, nil, "https://github.com", []string{"./secrets"}, []map[string]string{nil})
 	if err == nil || !strings.Contains(err.Error(), "action input defaults cannot grant secret authority") {
 		t.Fatalf("metadata secret default error = %v", err)
 	}
@@ -498,14 +498,14 @@ runs:
   main: index.js
 `)
 	actionSource := &fakeActionSource{root: remote, calls: map[string]int{}}
-	compiled, err := compileActionInvocations(context.Background(), workspace, actionSource, "https://github.com", []string{"owner/action@v1"}, []map[string]string{nil})
+	compiled, err := compileActionInvocations(t.Context(), workspace, actionSource, "https://github.com", []string{"owner/action@v1"}, []map[string]string{nil})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !compiled.requiresGitHubToken {
 		t.Fatal("conditional remote action default did not require a GitHub token")
 	}
-	compiled, err = compileActionInvocations(context.Background(), workspace, actionSource, "https://origin.cursor.com", []string{"owner/action@v1"}, []map[string]string{nil})
+	compiled, err = compileActionInvocations(t.Context(), workspace, actionSource, "https://origin.cursor.com", []string{"owner/action@v1"}, []map[string]string{nil})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -527,7 +527,7 @@ runs:
 	fake := &fakeActionSource{root: remote, calls: map[string]int{}}
 	shared := MemoizeActionSource(fake)
 	for range 2 {
-		if _, err := compileActionInvocations(context.Background(), workspace, shared, "https://github.com", []string{"owner/action@v1"}, []map[string]string{nil}); err != nil {
+		if _, err := compileActionInvocations(t.Context(), workspace, shared, "https://github.com", []string{"owner/action@v1"}, []map[string]string{nil}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -550,7 +550,7 @@ func TestMemoizeActionSourceCoalescesConcurrentResolution(t *testing.T) {
 		wait.Add(1)
 		go func() {
 			defer wait.Done()
-			_, _, err := shared.Fetch(context.Background(), ref)
+			_, _, err := shared.Fetch(t.Context(), ref)
 			errs <- err
 		}()
 	}
@@ -615,7 +615,7 @@ runs:
 		{ref: "./parent", want: true},
 		{ref: "./overridden"},
 	} {
-		compiled, err := compileActionInvocations(context.Background(), w, nil, "https://github.com", []string{test.ref}, []map[string]string{nil})
+		compiled, err := compileActionInvocations(t.Context(), w, nil, "https://github.com", []string{test.ref}, []map[string]string{nil})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -623,7 +623,7 @@ runs:
 			t.Fatalf("%s requires GitHub token = %t, want %t", test.ref, compiled.requiresGitHubToken, test.want)
 		}
 	}
-	if _, err := compileActionInvocations(context.Background(), w, nil, "https://github.com", []string{"./mixed-parent"}, []map[string]string{nil}); err == nil || !strings.Contains(err.Error(), "index must be a string literal") {
+	if _, err := compileActionInvocations(t.Context(), w, nil, "https://github.com", []string{"./mixed-parent"}, []map[string]string{nil}); err == nil || !strings.Contains(err.Error(), "index must be a string literal") {
 		t.Fatalf("mixed child traversal error = %v, want dynamic index rejection", err)
 	}
 }
@@ -645,7 +645,7 @@ runs:
     - uses: ./github-script
 `)
 
-	if _, err := compileActionInvocations(context.Background(), workspace, nil, "https://github.com", []string{"./parent"}, []map[string]string{nil}); err != nil {
+	if _, err := compileActionInvocations(t.Context(), workspace, nil, "https://github.com", []string{"./parent"}, []map[string]string{nil}); err != nil {
 		t.Fatalf("compile nested github-script action: %v", err)
 	}
 }
@@ -668,7 +668,7 @@ runs:
 		if err := os.WriteFile(workflowPath, []byte(workflow), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		return compilePlansForTest(context.Background(), workflowPath, []byte(workflow), pushEvent(t), "0.0.0-test", testDistributionDigest, defaultOptions())
+		return compilePlansForTest(t.Context(), workflowPath, []byte(workflow), pushEvent(t), "0.0.0-test", testDistributionDigest, defaultOptions())
 	}
 
 	effectiveWorkflow := `on: push
@@ -761,7 +761,7 @@ func TestCompileActionLocksRemoteCompositeUsesWorkspaceRoot(t *testing.T) {
 	writeAction(t, w, "child", "name: child\nruns:\n  using: docker\n  image: Dockerfile\n")
 	writeAction(t, remote, "", "name: parent\nruns:\n  using: composite\n  steps:\n    - uses: ./child\n")
 	f := &fakeActionSource{root: remote, calls: map[string]int{}}
-	_, locks, caps, _, err := compileActionLocks(context.Background(), w, f, []string{"Owner/Repo@v1", "Owner/Repo@v1"})
+	_, locks, caps, _, err := compileActionLocks(t.Context(), w, f, []string{"Owner/Repo@v1", "Owner/Repo@v1"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -782,14 +782,14 @@ func TestCompileActionLocksRemoteCompositeUsesWorkspaceRoot(t *testing.T) {
 func TestCompileActionLocksRecursion(t *testing.T) {
 	w := t.TempDir()
 	writeAction(t, w, "loop", "name: loop\nruns:\n  using: composite\n  steps:\n    - uses: ./loop\n")
-	_, _, _, _, err := compileActionLocks(context.Background(), w, nil, []string{"./loop"})
+	_, _, _, _, err := compileActionLocks(t.Context(), w, nil, []string{"./loop"})
 	if err == nil || !strings.Contains(err.Error(), "recursion") {
 		t.Fatalf("got %v", err)
 	}
 }
 
 func TestCompileActionLocksRequiresRepositoryRoot(t *testing.T) {
-	_, _, _, _, err := compileActionLocks(context.Background(), "", nil, []string{"./local"})
+	_, _, _, _, err := compileActionLocks(t.Context(), "", nil, []string{"./local"})
 	if err == nil || !strings.Contains(err.Error(), "workflow path must identify a repository root") {
 		t.Fatalf("compileActionLocks() error = %v, want repository-root rejection", err)
 	}
@@ -804,7 +804,7 @@ func TestCompileActionLocksRejectsExcessiveDepthBeforeResolvingLeaf(t *testing.T
 		}
 		writeAction(t, w, "depth-"+strconv.Itoa(i), "name: depth\nruns:\n  using: composite\n"+steps)
 	}
-	_, _, _, _, err := compileActionLocks(context.Background(), w, nil, []string{"./depth-0"})
+	_, _, _, _, err := compileActionLocks(t.Context(), w, nil, []string{"./depth-0"})
 	if err == nil || !strings.Contains(err.Error(), "exceeds maximum depth") {
 		t.Fatalf("compileActionLocks() error = %v, want depth rejection", err)
 	}
@@ -816,7 +816,7 @@ func TestCompileActionLocksRejectsEscapedJavaScriptEntrypoint(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(w, "outside.js"), []byte("// outside\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	_, _, _, _, err := compileActionLocks(context.Background(), w, nil, []string{"./js"})
+	_, _, _, _, err := compileActionLocks(t.Context(), w, nil, []string{"./js"})
 	if err == nil || !strings.Contains(err.Error(), "escapes action source") {
 		t.Fatalf("compileActionLocks() error = %v, want entry-point confinement rejection", err)
 	}
@@ -827,7 +827,7 @@ func TestCompileActionLocksExplicitRemoteAndDistinctRefs(t *testing.T) {
 	writeAction(t, remote, "", "name: parent\nruns:\n  using: composite\n  steps:\n    - uses: Other/Child/sub@v2\n")
 	writeAction(t, remote, "sub", "name: child\nruns:\n  using: node24\n  main: index.js\n")
 	f := &fakeActionSource{root: remote, calls: map[string]int{}}
-	selectors, locks, _, _, err := compileActionLocks(context.Background(), w, f, []string{"Owner/Repo@v1", "Owner/Repo@main"})
+	selectors, locks, _, _, err := compileActionLocks(t.Context(), w, f, []string{"Owner/Repo@v1", "Owner/Repo@main"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -845,11 +845,11 @@ func TestCompileActionLocksDeterministic(t *testing.T) {
 	w := t.TempDir()
 	writeAction(t, w, "parent", "name: parent\nruns:\n  using: composite\n  steps:\n    - uses: ./child\n")
 	writeAction(t, w, "child", "name: child\nruns:\n  using: node20\n  main: index.js\n")
-	aSelectors, aLocks, aCaps, _, err := compileActionLocks(context.Background(), w, nil, []string{"./parent"})
+	aSelectors, aLocks, aCaps, _, err := compileActionLocks(t.Context(), w, nil, []string{"./parent"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	bSelectors, bLocks, bCaps, _, err := compileActionLocks(context.Background(), w, nil, []string{"./parent"})
+	bSelectors, bLocks, bCaps, _, err := compileActionLocks(t.Context(), w, nil, []string{"./parent"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -862,18 +862,18 @@ func TestCompileActionLocksValidatesJavaScriptLifecycleConditions(t *testing.T) 
 	workspace := t.TempDir()
 	writeAction(t, workspace, "rust-cache", "name: rust-cache\nruns:\n  using: node24\n  main: index.js\n  post: index.js\n  post-if: (success() || env.CACHE_ON_FAILURE == 'true') && inputs.cache == true && hashFiles('Cargo.lock') != ''\n")
 	writeAction(t, workspace, "parent", "name: parent\nruns:\n  using: composite\n  steps:\n    - uses: ./rust-cache\n")
-	if _, _, _, _, err := compileActionLocks(context.Background(), workspace, nil, []string{"./parent"}); err != nil {
+	if _, _, _, _, err := compileActionLocks(t.Context(), workspace, nil, []string{"./parent"}); err != nil {
 		t.Fatalf("compileActionLocks() rejected rust-cache lifecycle condition: %v", err)
 	}
 
 	writeAction(t, workspace, "broken", "name: broken\nruns:\n  using: node24\n  pre: index.js\n  pre-if: success() || secrets.TOKEN != ''\n  main: index.js\n")
-	if _, _, _, _, err := compileActionLocks(context.Background(), workspace, nil, []string{"./broken"}); err == nil || !strings.Contains(err.Error(), "pre-if") || !strings.Contains(err.Error(), `context "secrets"`) {
+	if _, _, _, _, err := compileActionLocks(t.Context(), workspace, nil, []string{"./broken"}); err == nil || !strings.Contains(err.Error(), "pre-if") || !strings.Contains(err.Error(), `context "secrets"`) {
 		t.Fatalf("direct lifecycle validation error = %v", err)
 	}
 
 	writeAction(t, workspace, "nested-broken", "name: broken\nruns:\n  using: node24\n  main: index.js\n  post: index.js\n  post-if: needs[env.JOB].result == 'success'\n")
 	writeAction(t, workspace, "parent", "name: parent\nruns:\n  using: composite\n  steps:\n    - uses: ./nested-broken\n")
-	if _, _, _, _, err := compileActionLocks(context.Background(), workspace, nil, []string{"./parent"}); err == nil || !strings.Contains(err.Error(), `child action "./nested-broken"`) || !strings.Contains(err.Error(), "post-if") || !strings.Contains(err.Error(), `context "needs"`) {
+	if _, _, _, _, err := compileActionLocks(t.Context(), workspace, nil, []string{"./parent"}); err == nil || !strings.Contains(err.Error(), `child action "./nested-broken"`) || !strings.Contains(err.Error(), "post-if") || !strings.Contains(err.Error(), `context "needs"`) {
 		t.Fatalf("nested lifecycle validation error = %v", err)
 	}
 }
@@ -885,7 +885,7 @@ func TestCompileActionLocksDoesNotValidateUnusedNativeLifecycle(t *testing.T) {
 		roots:   map[string]string{"actions/checkout": remote},
 		commits: map[string]string{"actions/checkout": actionintegration.CheckoutV4Commit},
 	}
-	if _, _, _, _, err := compileActionLocks(context.Background(), workspace, source, []string{"actions/checkout@v4"}); err != nil {
+	if _, _, _, _, err := compileActionLocks(t.Context(), workspace, source, []string{"actions/checkout@v4"}); err != nil {
 		t.Fatalf("compileActionLocks() validated replaced native lifecycle: %v", err)
 	}
 }
@@ -907,7 +907,7 @@ func TestCompileActionLocksAllowsOnlyAuditedCacheCommits(t *testing.T) {
 					uses += "/" + path
 				}
 				uses += "@" + commit
-				_, locks, capabilities, _, err := compileActionLocks(context.Background(), workspace, &fakeActionSource{root: remote, calls: map[string]int{}, commit: commit}, []string{uses})
+				_, locks, capabilities, _, err := compileActionLocks(t.Context(), workspace, &fakeActionSource{root: remote, calls: map[string]int{}, commit: commit}, []string{uses})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -918,7 +918,7 @@ func TestCompileActionLocksAllowsOnlyAuditedCacheCommits(t *testing.T) {
 		}
 	}
 
-	_, locks, _, _, err := compileActionLocks(context.Background(), workspace, &fakeActionSource{root: remote, calls: map[string]int{}, commit: actionintegration.CacheCommit}, []string{"actions/cache@v6.1.0"})
+	_, locks, _, _, err := compileActionLocks(t.Context(), workspace, &fakeActionSource{root: remote, calls: map[string]int{}, commit: actionintegration.CacheCommit}, []string{"actions/cache@v6.1.0"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -927,18 +927,18 @@ func TestCompileActionLocksAllowsOnlyAuditedCacheCommits(t *testing.T) {
 	}
 
 	resolved := strings.Repeat("a", 40)
-	_, _, _, _, err = compileActionLocks(context.Background(), workspace, &fakeActionSource{root: remote, calls: map[string]int{}}, []string{"actions/cache@v6"})
+	_, _, _, _, err = compileActionLocks(t.Context(), workspace, &fakeActionSource{root: remote, calls: map[string]int{}}, []string{"actions/cache@v6"})
 	if err == nil || !strings.Contains(err.Error(), "actions/cache@v6 resolved to commit "+resolved) || !strings.Contains(err.Error(), actionintegration.CacheV3Commit) || !strings.Contains(err.Error(), actionintegration.CacheV4Commit) || !strings.Contains(err.Error(), actionintegration.CacheCommit) {
 		t.Fatalf("unsupported actions/cache commit error = %v", err)
 	}
-	_, _, _, _, err = compileActionLocks(context.Background(), workspace, &fakeActionSource{root: remote, calls: map[string]int{}}, []string{"actions/cache@v5"})
+	_, _, _, _, err = compileActionLocks(t.Context(), workspace, &fakeActionSource{root: remote, calls: map[string]int{}}, []string{"actions/cache@v5"})
 	if err == nil || !strings.Contains(err.Error(), "actions/cache@v5 resolved to commit "+resolved) {
 		t.Fatalf("moved actions/cache v5 error = %v", err)
 	}
 }
 
 func TestPublicActionSourceNil(t *testing.T) {
-	_, _, err := (PublicActionSource{}).Fetch(context.Background(), source.Reference{})
+	_, _, err := (PublicActionSource{}).Fetch(t.Context(), source.Reference{})
 	if err == nil {
 		t.Fatal("nil dependencies accepted")
 	}
@@ -980,11 +980,11 @@ jobs:
 		ResolveActions: true,
 		ActionSource:   fake,
 	}
-	first, err := compilePlansForTest(context.Background(), workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, options)
+	first, err := compilePlansForTest(t.Context(), workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, options)
 	if err != nil {
 		t.Fatal(err)
 	}
-	second, err := compilePlansForTest(context.Background(), workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, options)
+	second, err := compilePlansForTest(t.Context(), workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, options)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1094,7 +1094,7 @@ func TestCheckoutAdapterInputBoundary(t *testing.T) {
 		if err := os.WriteFile(workflowPath, workflow, 0o644); err != nil {
 			t.Fatal(err)
 		}
-		return compilePlansForTest(context.Background(), workflowPath, workflow, pushEvent(t), "checkout-test", testDistributionDigest, options)
+		return compilePlansForTest(t.Context(), workflowPath, workflow, pushEvent(t), "checkout-test", testDistributionDigest, options)
 	}
 
 	accepted := []string{
@@ -1163,7 +1163,7 @@ func TestCheckoutAdapterCommitBoundary(t *testing.T) {
 		t.Run(version, func(t *testing.T) {
 			writeAction(t, remote, "", checkoutTestManifest(commit))
 			actionSource := &fakeActionSource{root: remote, commit: commit, calls: map[string]int{}}
-			_, locks, _, _, err := compileActionLocks(context.Background(), workspace, actionSource, []string{"actions/checkout@" + version})
+			_, locks, _, _, err := compileActionLocks(t.Context(), workspace, actionSource, []string{"actions/checkout@" + version})
 			if err != nil || len(locks) != 1 || locks[0].Commit != commit {
 				t.Fatalf("compileActionLocks() locks = %#v, error = %v", locks, err)
 			}
@@ -1173,7 +1173,7 @@ func TestCheckoutAdapterCommitBoundary(t *testing.T) {
 	unknown := strings.Repeat("0", 40)
 	writeAction(t, remote, "", checkoutTestManifest(unknown))
 	actionSource := &fakeActionSource{root: remote, commit: unknown, calls: map[string]int{}}
-	if _, _, _, _, err := compileActionLocks(context.Background(), workspace, actionSource, []string{"actions/checkout@v7"}); err == nil || !strings.Contains(err.Error(), "does not admit") {
+	if _, _, _, _, err := compileActionLocks(t.Context(), workspace, actionSource, []string{"actions/checkout@v7"}); err == nil || !strings.Contains(err.Error(), "does not admit") {
 		t.Fatalf("unknown checkout commit error = %v", err)
 	}
 }
@@ -1358,7 +1358,7 @@ func TestUploadArtifactAdapterInputAndCommitBoundary(t *testing.T) {
 		if err := os.WriteFile(workflowPath, workflow, 0o644); err != nil {
 			t.Fatal(err)
 		}
-		return compilePlansForTest(context.Background(), workflowPath, workflow, pushEvent(t), "artifact-test", testDistributionDigest, Options{
+		return compilePlansForTest(t.Context(), workflowPath, workflow, pushEvent(t), "artifact-test", testDistributionDigest, Options{
 			EventTrust: EventUntrusted,
 			Runners: RunnerPolicy{
 				Labels:          map[string]string{"ubuntu-latest": "hosted"},
@@ -1431,7 +1431,7 @@ func TestUploadArtifactAdapterInputAndCommitBoundary(t *testing.T) {
 	if err := os.WriteFile(workflowPath, matrixWorkflow, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	plans, err = compilePlansForTest(context.Background(), workflowPath, matrixWorkflow, pushEvent(t), "artifact-test", testDistributionDigest, Options{
+	plans, err = compilePlansForTest(t.Context(), workflowPath, matrixWorkflow, pushEvent(t), "artifact-test", testDistributionDigest, Options{
 		EventTrust: EventUntrusted,
 		Runners: RunnerPolicy{
 			Labels:          map[string]string{"ubuntu-latest": "hosted"},
@@ -1465,7 +1465,7 @@ func TestDownloadArtifactAdapterInputCommitAndNeedsBoundary(t *testing.T) {
 		if err := os.WriteFile(workflowPath, workflow, 0o644); err != nil {
 			t.Fatal(err)
 		}
-		return compilePlansForTest(context.Background(), workflowPath, workflow, pushEvent(t), "artifact-test", testDistributionDigest, Options{
+		return compilePlansForTest(t.Context(), workflowPath, workflow, pushEvent(t), "artifact-test", testDistributionDigest, Options{
 			EventTrust: EventUntrusted,
 			Runners: RunnerPolicy{
 				Labels:          map[string]string{"ubuntu-latest": "hosted"},
@@ -1569,7 +1569,7 @@ jobs:
 	if err := os.WriteFile(workflowPath, workflow, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	plans, err := compilePlansForTest(context.Background(), workflowPath, workflow, pushEvent(t), "artifact-test", testDistributionDigest, Options{
+	plans, err := compilePlansForTest(t.Context(), workflowPath, workflow, pushEvent(t), "artifact-test", testDistributionDigest, Options{
 		EventTrust: EventUntrusted,
 		Runners: RunnerPolicy{
 			Labels:          map[string]string{"ubuntu-latest": "hosted"},
@@ -1603,7 +1603,7 @@ func TestDownloadArtifactMutableTagMustResolveToAuditedExactLock(t *testing.T) {
 	remote := t.TempDir()
 	writeAction(t, remote, "", "name: artifact action\nruns:\n  using: node24\n  main: index.js\n")
 	resolved := &fakeActionSource{root: remote, calls: map[string]int{}, commit: actionintegration.DownloadArtifactV801Commit}
-	_, locks, _, _, err := compileActionLocks(context.Background(), t.TempDir(), resolved, []string{"actions/download-artifact@v8"})
+	_, locks, _, _, err := compileActionLocks(t.Context(), t.TempDir(), resolved, []string{"actions/download-artifact@v8"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1612,7 +1612,7 @@ func TestDownloadArtifactMutableTagMustResolveToAuditedExactLock(t *testing.T) {
 	}
 
 	resolved.commit = strings.Repeat("b", 40)
-	if _, _, _, _, err := compileActionLocks(context.Background(), t.TempDir(), resolved, []string{"actions/download-artifact@v8"}); err == nil {
+	if _, _, _, _, err := compileActionLocks(t.Context(), t.TempDir(), resolved, []string{"actions/download-artifact@v8"}); err == nil {
 		t.Fatal("mutable v8 tag resolving to an unaudited commit was accepted")
 	}
 }
@@ -1622,7 +1622,7 @@ func TestCompilePlansDockerfileActionCapabilities(t *testing.T) {
 	writeAction(t, remote, "", "name: remote Docker\nruns:\n  using: docker\n  image: Dockerfile\n")
 	workflowPath := filepath.Join("..", "..", "testdata", "dockerfile-action", ".github", "workflows", "docker-action.yml")
 	templatePath := workflowPath + ".tmpl"
-	plans, err := compilePlansForTest(context.Background(), workflowPath, readFile(t, templatePath), pushEvent(t), "dockerfile-action-test", testDistributionDigest, Options{
+	plans, err := compilePlansForTest(t.Context(), workflowPath, readFile(t, templatePath), pushEvent(t), "dockerfile-action-test", testDistributionDigest, Options{
 		EventTrust: EventUntrusted,
 		Runners: RunnerPolicy{
 			Labels:          map[string]string{"ubuntu-latest": "hosted"},
@@ -1646,7 +1646,7 @@ func TestCompilePlansRemoteActionRequiresSource(t *testing.T) {
 		t.Fatal(err)
 	}
 	workflow := []byte("on: push\njobs:\n  action:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: owner/repo@v1\n")
-	_, err := compilePlansForTest(context.Background(), workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, Options{
+	_, err := compilePlansForTest(t.Context(), workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, Options{
 		EventTrust: EventUntrusted,
 		Runners: RunnerPolicy{
 			Labels:          map[string]string{"ubuntu-latest": "hosted"},
@@ -1666,7 +1666,7 @@ func TestCompilePlansContextCancelsRemoteResolution(t *testing.T) {
 		t.Fatal(err)
 	}
 	workflow := []byte("on: push\njobs:\n  action:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: owner/repo@v1\n")
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 	_, err := compilePlansForTest(ctx, workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, Options{
 		EventTrust: EventUntrusted,
@@ -1718,7 +1718,7 @@ jobs:
 	if err != nil {
 		t.Fatal(err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
 	defer cancel()
 	plans, err := compilePlansForTest(ctx, workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, Options{
 		EventTrust: EventUntrusted,

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -2,7 +2,6 @@ package compiler
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"os"
@@ -95,7 +94,7 @@ jobs:
 func TestBundlePlansPermitAdmissionBeforePipelineGeneration(t *testing.T) {
 	path := smokePath(".github", "workflows", "shell.yml")
 	options := defaultOptions()
-	bundle, err := CompileBundlePlansContext(context.Background(), path, readFile(t, path), readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, options)
+	bundle, err := CompileBundlePlansContext(t.Context(), path, readFile(t, path), readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, options)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -2,7 +2,6 @@ package compiler
 
 import (
 	"bytes"
-	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -130,7 +129,7 @@ func TestCompilePlansCarriesPluginOIDCConfigurationToEveryJob(t *testing.T) {
 	}
 	options := defaultOptions()
 	options.OIDC = configuration
-	plans, err := compilePlansForTest(context.Background(), "oidc.yml", []byte(`on: push
+	plans, err := compilePlansForTest(t.Context(), "oidc.yml", []byte(`on: push
 jobs:
   mint:
     permissions:
@@ -2072,7 +2071,7 @@ func TestCompileBoundsReusableWorkflowGraphExpansion(t *testing.T) {
 	path := writeWorkflow(t, repository, "caller.yml", fmt.Sprintf("on: push\njobs:\n  call:\n    strategy:\n      matrix:\n        value: [%s]\n    uses: ./.github/workflows/reusable.yml\n", strings.Join(values, ", ")))
 	var callee strings.Builder
 	callee.WriteString("on: workflow_call\njobs:\n")
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		_, _ = fmt.Fprintf(&callee, "  job%d:\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n", i)
 	}
 	writeWorkflow(t, repository, "reusable.yml", callee.String())
@@ -2626,7 +2625,7 @@ func TestCompileReusableInputDiagnosticsAreDeterministic(t *testing.T) {
 	repository := t.TempDir()
 	path := writeWorkflow(t, repository, "caller.yml", "on: push\njobs:\n  call:\n    uses: ./.github/workflows/reusable.yml\n    with:\n      zed: z\n      alpha: a\n")
 	writeWorkflow(t, repository, "reusable.yml", "on: workflow_call\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n")
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		_, err := Compile(path, readFile(t, path), readFile(t, smokePath("events", "push.json")))
 		if err == nil || !strings.Contains(err.Error(), `input "alpha" is not declared`) {
 			t.Fatalf("Compile() error = %v, want alphabetically first input diagnostic", err)
@@ -3427,7 +3426,7 @@ jobs:
 `)
 	options := defaultOptions()
 	options.Vars.Buildkite = map[string]string{"SERVICE_PORT": "5432", "REGISTRY_USER": "registry-user"}
-	plans, err := compilePlansForTest(context.Background(), "containers.yml", workflowSource, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("1", 64), options)
+	plans, err := compilePlansForTest(t.Context(), "containers.yml", workflowSource, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("1", 64), options)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3493,7 +3492,7 @@ jobs:
         image: ${{ matrix.image }}
     steps: [{run: true}]
 `)
-	plans, err := compilePlansForTest(context.Background(), "containers.yml", workflowSource, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("1", 64), defaultOptions())
+	plans, err := compilePlansForTest(t.Context(), "containers.yml", workflowSource, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("1", 64), defaultOptions())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3536,7 +3535,7 @@ jobs:
 	if err != nil {
 		t.Fatal(err)
 	}
-	plans, err := compilePlansForTest(context.Background(), "containers.yml", workflowSource, eventSource, "0.0.0-test", "sha256:"+strings.Repeat("1", 64), defaultOptions())
+	plans, err := compilePlansForTest(t.Context(), "containers.yml", workflowSource, eventSource, "0.0.0-test", "sha256:"+strings.Repeat("1", 64), defaultOptions())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3581,7 +3580,7 @@ jobs:
 	if err != nil {
 		t.Fatal(err)
 	}
-	plans, err := compilePlansForTest(context.Background(), "dispatch.yml", workflowSource, eventSource, "0.0.0-test", "sha256:"+strings.Repeat("1", 64), defaultOptions())
+	plans, err := compilePlansForTest(t.Context(), "dispatch.yml", workflowSource, eventSource, "0.0.0-test", "sha256:"+strings.Repeat("1", 64), defaultOptions())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3609,7 +3608,7 @@ jobs:
         image: ${{ needs.producer.outputs.image }}
     steps: [{run: true}]
 `)
-	plans, err := compilePlansForTest(context.Background(), "containers.yml", workflowSource, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("1", 64), defaultOptions())
+	plans, err := compilePlansForTest(t.Context(), "containers.yml", workflowSource, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("1", 64), defaultOptions())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3634,7 +3633,7 @@ jobs:
     services: ${{ fromJSON(needs.producer.outputs.services) }}
     steps: [{run: true}]
 `)
-	plans, err := compilePlansForTest(context.Background(), "containers.yml", workflowSource, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("1", 64), defaultOptions())
+	plans, err := compilePlansForTest(t.Context(), "containers.yml", workflowSource, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("1", 64), defaultOptions())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3663,7 +3662,7 @@ jobs:
           INVALID: ${{ needs.producer.result }}
     steps: [{run: true}]
 `)
-	_, err := compilePlansForTest(context.Background(), "containers.yml", workflowSource, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("1", 64), defaultOptions())
+	_, err := compilePlansForTest(t.Context(), "containers.yml", workflowSource, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("1", 64), defaultOptions())
 	if err == nil || !strings.Contains(err.Error(), "service runtime expression must directly reference needs") {
 		t.Fatalf("error = %v", err)
 	}

--- a/internal/compiler/config_test.go
+++ b/internal/compiler/config_test.go
@@ -2,7 +2,6 @@ package compiler
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"reflect"
@@ -385,7 +384,7 @@ func TestCompilePlansUsePolicyQueueAndContainOnlyNonSecretVars(t *testing.T) {
 		Vars:       VariableSources{Bridge: map[string]string{"PUBLIC": "snapshotted"}},
 		Runners:    RunnerPolicy{Labels: map[string]string{"ubuntu-24.04": "linux"}},
 	}
-	plans, err := compilePlansForTest(context.Background(), "plan.yml", workflow, pushEvent(t), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), options)
+	plans, err := compilePlansForTest(t.Context(), "plan.yml", workflow, pushEvent(t), "0.0.0-test", "sha256:"+strings.Repeat("2", 64), options)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/compiler/runtime_matrix_test.go
+++ b/internal/compiler/runtime_matrix_test.go
@@ -170,11 +170,11 @@ func TestExpandRuntimeMatrixOutputEnforcesByteCardinalityAndGraphBounds(t *testi
 	}
 
 	dimensions := make(map[string]any, MaxRuntimeMatrixProperties)
-	for i := 0; i < MaxRuntimeMatrixProperties-1; i++ {
+	for i := range MaxRuntimeMatrixProperties - 1 {
 		dimensions[fmt.Sprintf("d%d", i)] = []any{i}
 	}
 	include := make(map[string]any, MaxRuntimeMatrixProperties)
-	for i := 0; i < MaxRuntimeMatrixProperties; i++ {
+	for i := range MaxRuntimeMatrixProperties {
 		include[fmt.Sprintf("i%d", i)] = i
 	}
 	dimensions["include"] = []any{include}

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -669,7 +669,7 @@ func TestWorkspaceRootActionAndSharedChildDAG(t *testing.T) {
 	base := "manyletters/repository@v1"
 	for i := range 256 {
 		variant := []byte(base)
-		for bit := 0; bit < 8; bit++ {
+		for bit := range 8 {
 			if i&(1<<bit) != 0 {
 				variant[bit] -= 'a' - 'A'
 			}

--- a/internal/runtime/actions_test.go
+++ b/internal/runtime/actions_test.go
@@ -94,7 +94,7 @@ func TestActionLockResolverGitHubExactSourceSingleFlightAndTampering(t *testing.
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if _, _, err := r.resolve(context.Background(), plan.ActionSelector{Lock: "lock"}); err != nil {
+			if _, _, err := r.resolve(t.Context(), plan.ActionSelector{Lock: "lock"}); err != nil {
 				t.Errorf("resolve: %v", err)
 			}
 		}()
@@ -108,7 +108,7 @@ func TestActionLockResolverGitHubExactSourceSingleFlightAndTampering(t *testing.
 	if err := os.WriteFile(filepath.Join(repo, "nested", "index.js"), []byte("tampered\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := r.resolve(context.Background(), plan.ActionSelector{Lock: "lock"}); err == nil {
+	if _, _, err := r.resolve(t.Context(), plan.ActionSelector{Lock: "lock"}); err == nil {
 		t.Fatal("resolve after repository tampering succeeded")
 	}
 }
@@ -125,7 +125,7 @@ func TestActionLockResolverHardensOnlyNonContextMaterializationFailures(t *testi
 		{name: "integrity error racing deadline", err: errors.New("cache digest mismatch"), wantHard: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 0)
+			ctx, cancel := context.WithTimeout(t.Context(), 0)
 			defer cancel()
 			materializer := &fakeActionMaterializer{err: tc.err}
 
@@ -153,7 +153,7 @@ func TestActionLockResolverAllowsOnlyAuditedCacheCommitsAndEntryPoints(t *testin
 				lock := plan.ActionLock{ID: "cache", Source: "github", Repository: "actions/cache", Commit: commit, Path: path, SourceDigest: digest}
 				job := plan.Job{RequiredCapabilities: []string{"network"}, Actions: []plan.ActionLock{lock}}
 				materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: repo, SourceDigest: digest}}
-				if _, resolved, err := newActionLockResolver(job, "", materializer).resolve(context.Background(), plan.ActionSelector{Lock: lock.ID}); err != nil || !reflect.DeepEqual(resolved, lock) {
+				if _, resolved, err := newActionLockResolver(job, "", materializer).resolve(t.Context(), plan.ActionSelector{Lock: lock.ID}); err != nil || !reflect.DeepEqual(resolved, lock) {
 					t.Fatalf("resolve() = %#v, %v", resolved, err)
 				}
 				if materializer.calls != 1 || materializer.resolved.Commit != commit || materializer.resolved.Reference.Path != path || materializer.resolved.SourceDigest != digest {
@@ -165,7 +165,7 @@ func TestActionLockResolverAllowsOnlyAuditedCacheCommitsAndEntryPoints(t *testin
 
 	lock := plan.ActionLock{ID: "cache", Source: "github", Repository: "actions/cache", Commit: strings.Repeat("0", 40), SourceDigest: digest}
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: repo, SourceDigest: digest}}
-	if _, _, err := newActionLockResolver(plan.Job{RequiredCapabilities: []string{"network"}, Actions: []plan.ActionLock{lock}}, "", materializer).resolve(context.Background(), plan.ActionSelector{Lock: lock.ID}); err == nil {
+	if _, _, err := newActionLockResolver(plan.Job{RequiredCapabilities: []string{"network"}, Actions: []plan.ActionLock{lock}}, "", materializer).resolve(t.Context(), plan.ActionSelector{Lock: lock.ID}); err == nil {
 		t.Fatal("unproved cache commit resolved")
 	}
 	if materializer.calls != 0 {
@@ -195,7 +195,7 @@ func TestActionLockResolverAllowsSymlinkedRepositoryAncestor(t *testing.T) {
 		ActionRoot:     filepath.Join(repository, "nested"),
 		SourceDigest:   digest,
 	}}
-	resolved, _, err := newActionLockResolver(job, "", materializer).resolve(context.Background(), plan.ActionSelector{Lock: "lock"})
+	resolved, _, err := newActionLockResolver(job, "", materializer).resolve(t.Context(), plan.ActionSelector{Lock: "lock"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -218,7 +218,7 @@ func TestActionLockResolverAllowsSymlinkedRepositoryAncestor(t *testing.T) {
 		t.Fatal(err)
 	}
 	materializer.result.RepositoryRoot = linkedRepository
-	if _, _, err := newActionLockResolver(job, "", materializer).resolve(context.Background(), plan.ActionSelector{Lock: "lock"}); err == nil || !strings.Contains(err.Error(), "non-symlink directory") {
+	if _, _, err := newActionLockResolver(job, "", materializer).resolve(t.Context(), plan.ActionSelector{Lock: "lock"}); err == nil || !strings.Contains(err.Error(), "non-symlink directory") {
 		t.Fatalf("resolver accepted symlink repository root: %v", err)
 	}
 }
@@ -262,7 +262,7 @@ func TestActionLockResolverDownloadsExactCommitDirectlyFromCodeload(t *testing.T
 		}},
 	}
 	resolver := newActionLockResolver(job, "", store)
-	if _, _, err := resolver.resolve(context.Background(), plan.ActionSelector{Lock: "lock"}); err != nil {
+	if _, _, err := resolver.resolve(t.Context(), plan.ActionSelector{Lock: "lock"}); err != nil {
 		t.Fatal(err)
 	}
 	if apiRequests != 0 || archiveRequests != 1 || tokenProvisions != 0 {
@@ -308,17 +308,17 @@ func TestActionLockResolverWorkspaceLazyAndReverified(t *testing.T) {
 	writeAction(t, fixture, "")
 	job.Actions = []plan.ActionLock{{ID: "local", Source: "workspace", Path: "actions/local", SourceDigest: digestTree(t, fixture)}}
 	r := newActionLockResolver(job, workspace, nil)
-	if _, _, err := r.resolve(context.Background(), plan.ActionSelector{Lock: "local"}); err == nil {
+	if _, _, err := r.resolve(t.Context(), plan.ActionSelector{Lock: "local"}); err == nil {
 		t.Fatal("missing workspace action succeeded")
 	}
 	writeAction(t, workspace, "actions/local")
-	if _, _, err := r.resolve(context.Background(), plan.ActionSelector{Lock: "local"}); err != nil {
+	if _, _, err := r.resolve(t.Context(), plan.ActionSelector{Lock: "local"}); err != nil {
 		t.Fatalf("populated workspace action: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(action, "index.js"), []byte("tampered\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := r.resolve(context.Background(), plan.ActionSelector{Lock: "local"}); err == nil {
+	if _, _, err := r.resolve(t.Context(), plan.ActionSelector{Lock: "local"}); err == nil {
 		t.Fatal("tampered workspace action succeeded")
 	}
 }
@@ -326,7 +326,7 @@ func TestActionLockResolverWorkspaceLazyAndReverified(t *testing.T) {
 func TestActionLockResolverFailsClosed(t *testing.T) {
 	r := newActionLockResolver(plan.Job{Actions: []plan.ActionLock{{ID: "x", Source: "github", Repository: "owner/other", Commit: strings.Repeat("b", 40), SourceDigest: "sha256:" + strings.Repeat("0", 64)}}}, "", nil)
 	for _, selector := range []plan.ActionSelector{{}, {Lock: "missing"}, {Lock: "x"}} {
-		if _, _, err := r.resolve(context.Background(), selector); err == nil {
+		if _, _, err := r.resolve(t.Context(), selector); err == nil {
 			t.Fatalf("selector %#v unexpectedly succeeded", selector)
 		}
 	}
@@ -392,7 +392,7 @@ runs:
 		RequiresMise: &requiresMise,
 	}
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, ActionRoot: remote, SourceDigest: remoteDigest}}
-	result, err := (Runner{Actions: materializer}).RunJob(context.Background(), job, "")
+	result, err := (Runner{Actions: materializer}).RunJob(t.Context(), job, "")
 	if err != nil {
 		t.Fatalf("RunJob() error = %v", err)
 	}

--- a/internal/runtime/cache_service_test.go
+++ b/internal/runtime/cache_service_test.go
@@ -53,7 +53,7 @@ func TestAgentCacheCredentialsMintsBoundedJobCredential(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	credentials, err := provider.Credentials(context.Background())
+	credentials, err := provider.Credentials(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,7 +153,7 @@ func TestAgentCacheCredentialsRejectsRedirectsAndUntrustedResponses(t *testing.T
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, err = provider.Credentials(context.Background())
+			_, err = provider.Credentials(t.Context())
 			if err == nil || !strings.Contains(err.Error(), test.want) || strings.Contains(err.Error(), secret) {
 				t.Fatalf("Credentials() error = %v, want %q without response body", err, test.want)
 			}
@@ -176,13 +176,13 @@ func TestAgentCacheCredentialsRejectsRedirectsAndUntrustedResponses(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := provider.Credentials(context.Background()); err == nil || !strings.Contains(err.Error(), "HTTP 307") || redirected {
+	if _, err := provider.Credentials(t.Context()); err == nil || !strings.Contains(err.Error(), "HTTP 307") || redirected {
 		t.Fatalf("redirect Credentials() error/redirected = %v / %v", err, redirected)
 	}
 }
 
 func TestAgentCacheCredentialsHonorsCancellation(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 	provider, err := NewAgentCacheCredentials(AgentCacheConfig{
 		Endpoint: "https://agent.invalid/v3", JobID: testCacheJobID,
@@ -229,6 +229,7 @@ func TestCacheServiceLifecycleUsesFreshIsolatedCredentials(t *testing.T) {
 }
 
 func testCacheServiceLifecycleUsesFreshIsolatedCredentials(t *testing.T, using, commit string) {
+	t.Helper()
 	node := requireNode24(t)
 	workspace := t.TempDir()
 	workflowPath := ".github/workflows/cache.yml"
@@ -328,7 +329,7 @@ console.log("ordinary-credential=" + process.env.ACTIONS_RUNTIME_TOKEN);
 	result, err := (Runner{
 		Node24: node, Actions: materializer, Cache: provider, Redactor: redactor,
 		Stdout: &logs, Stderr: &logs,
-	}).RunJob(context.Background(), job, workspace)
+	}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v, logs = %q", result, err, logs.String())
 	}
@@ -386,7 +387,7 @@ console.log("ordinary-credential=" + process.env.ACTIONS_RUNTIME_TOKEN);
 	}
 
 	job.Actions[0].Commit = strings.Repeat("b", 40)
-	if _, err := (Runner{Node24: node, Actions: materializer, Cache: provider, Redactor: redactor}).RunJob(context.Background(), job, workspace); err == nil || !strings.Contains(err.Error(), actionintegration.CacheCommit) {
+	if _, err := (Runner{Node24: node, Actions: materializer, Cache: provider, Redactor: redactor}).RunJob(t.Context(), job, workspace); err == nil || !strings.Contains(err.Error(), actionintegration.CacheCommit) {
 		t.Fatalf("unsupported runtime cache commit error = %v", err)
 	}
 }
@@ -500,7 +501,7 @@ fs.appendFileSync(process.env.LIFECYCLE_LOG, %q + "\n");
 				Commit: strings.Repeat("a", 40), SourceDigest: digest,
 			}}
 			materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}
-			result, err := (Runner{Node24: node, Actions: materializer, Cache: provider, Redactor: &testRedactor{}}).RunJob(context.Background(), job, workspace)
+			result, err := (Runner{Node24: node, Actions: materializer, Cache: provider, Redactor: &testRedactor{}}).RunJob(t.Context(), job, workspace)
 			if err != nil || result.Conclusion != "success" {
 				t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 			}
@@ -558,7 +559,7 @@ func TestActionCacheRedactorIsPinnedBeforeWorkflowExecution(t *testing.T) {
 		SourceDigest: digestTree(t, filepath.Join(workspace, filepath.FromSlash(actionPath))),
 	}}
 	provider := &sequenceCacheCredentials{tokens: []string{token}}
-	result, err := (Runner{Node24: node, Cache: provider, Redactor: AgentRedactor{}}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node24: node, Cache: provider, Redactor: AgentRedactor{}}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -592,7 +593,7 @@ func TestGenericActionCacheDisablesWhenRedactorCannotBePinned(t *testing.T) {
 	result, err := (Runner{
 		Node24: node, Cache: provider,
 		Redactor: AgentRedactor{Executable: filepath.Join(t.TempDir(), "missing-agent")},
-	}).RunJob(context.Background(), job, workspace)
+	}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -625,7 +626,7 @@ func TestExplicitCacheRequiresPinnedRedactorBeforeWorkflowExecution(t *testing.T
 	_, err := (Runner{
 		Cache:    provider,
 		Redactor: AgentRedactor{Executable: filepath.Join(t.TempDir(), "missing-agent")},
-	}).RunJob(context.Background(), job, workspace)
+	}).RunJob(t.Context(), job, workspace)
 	if err == nil || !strings.Contains(err.Error(), "resolve Buildkite Agent redactor before workflow execution") {
 		t.Fatalf("RunJob() error = %v", err)
 	}
@@ -655,7 +656,7 @@ fs.writeFileSync(process.env.MARKER, "executed");
 	processor := newCommandProcessor(io.Discard, io.Discard)
 	runner := Runner{Cache: provider, Redactor: &testRedactor{}}
 	if err := runner.runJavaScriptPhase(
-		context.Background(), processor, actionRoot, node,
+		t.Context(), processor, actionRoot, node,
 		javaScriptAction{Name: "ordinary", Path: actionRoot, Main: "main.js"}, "main.js", nil, nil, &result,
 	); err != nil {
 		t.Fatalf("generic action cache fallback error = %v", err)
@@ -667,7 +668,7 @@ fs.writeFileSync(process.env.MARKER, "executed");
 		t.Fatal(err)
 	}
 	if err := runner.runJavaScriptPhase(
-		context.Background(), processor, actionRoot, node,
+		t.Context(), processor, actionRoot, node,
 		javaScriptAction{Name: "cache", Path: actionRoot, Main: "main.js", Cache: true}, "main.js", nil, nil, &result,
 	); err == nil || !strings.Contains(err.Error(), "configure actions/cache service: cache unavailable") {
 		t.Fatalf("explicit cache action error = %v", err)
@@ -686,7 +687,7 @@ func TestDockerActionReceivesCacheCredentialsWithoutTokenInArguments(t *testing.
 	action.Env["ACTIONS_RUNTIME_TOKEN"] = "workflow-token"
 	action.Env["ACTIONS_RESULTS_URL"] = "https://attacker.invalid"
 	action.Env["ACTIONS_CACHE_SERVICE_V2"] = "false"
-	if _, err := (Runner{Docker: fake.path, Cache: provider, Redactor: redactor}).runDockerAction(context.Background(), action); err != nil {
+	if _, err := (Runner{Docker: fake.path, Cache: provider, Redactor: redactor}).runDockerAction(t.Context(), action); err != nil {
 		t.Fatal(err)
 	}
 	cacheRuntime, err := os.ReadFile(filepath.Join(fake.root, "cache-runtime"))
@@ -731,7 +732,7 @@ func TestCacheRedactorFailureAbortsBeforeExecutionAndScrubsToken(t *testing.T) {
 	result := newResult()
 	result.Env["MARKER"] = marker
 	err := (Runner{Cache: provider, Redactor: failingCacheRedactor{token: token}}).runJavaScriptPhase(
-		context.Background(), processor, actionRoot, "node", javaScriptAction{Name: "cache", Path: actionRoot, Main: "main.js", Cache: true}, "main.js", nil, nil, &result,
+		t.Context(), processor, actionRoot, "node", javaScriptAction{Name: "cache", Path: actionRoot, Main: "main.js", Cache: true}, "main.js", nil, nil, &result,
 	)
 	if err == nil || strings.Contains(err.Error(), token) || !strings.Contains(err.Error(), "***") {
 		t.Fatalf("runJavaScriptPhase() error = %v", err)
@@ -765,7 +766,7 @@ func TestActionRuntimeCacheTokenCommandFileEffectsAreDiscarded(t *testing.T) {
 			result.Paths = []string{"/existing/path"}
 			state := map[string]string{"kept": "action state"}
 			err := (Runner{Cache: provider, Redactor: &testRedactor{}}).runJavaScriptPhase(
-				context.Background(), newCommandProcessor(io.Discard, io.Discard), actionRoot, node,
+				t.Context(), newCommandProcessor(io.Discard, io.Discard), actionRoot, node,
 				javaScriptAction{Name: "ordinary", Path: actionRoot, Main: "main.js"}, "main.js", nil, state, &result,
 			)
 			if err == nil || strings.Contains(err.Error(), token) || !strings.Contains(err.Error(), "phase effects were discarded") {

--- a/internal/runtime/checkout_test.go
+++ b/internal/runtime/checkout_test.go
@@ -113,7 +113,7 @@ esac
 		RequiresMise: &requiresMise,
 	}
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, ActionRoot: remote, SourceDigest: remoteDigest}}
-	result, err := (Runner{Git: git, Actions: materializer}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Git: git, Actions: materializer}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" || result.Env["CHECKOUT_CHAIN"] != "ok" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -147,7 +147,7 @@ esac
 	if err := os.Remove(gitLog); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := (Runner{Git: git, Actions: materializer}).RunJob(context.Background(), job, t.TempDir()); err == nil || !strings.Contains(err.Error(), "dynamic ref must resolve to the exact event SHA") {
+	if _, err := (Runner{Git: git, Actions: materializer}).RunJob(t.Context(), job, t.TempDir()); err == nil || !strings.Contains(err.Error(), "dynamic ref must resolve to the exact event SHA") {
 		t.Fatalf("dynamic checkout ref error = %v", err)
 	}
 	if _, err := os.Stat(gitLog); !os.IsNotExist(err) {
@@ -158,7 +158,7 @@ esac
 
 	job.Actions[0].Commit = strings.Repeat("0", 40)
 	unknownWorkspace := t.TempDir()
-	if _, err := (Runner{Git: git, Actions: materializer}).RunJob(context.Background(), job, unknownWorkspace); err == nil || !strings.Contains(err.Error(), "does not admit") {
+	if _, err := (Runner{Git: git, Actions: materializer}).RunJob(t.Context(), job, unknownWorkspace); err == nil || !strings.Contains(err.Error(), "does not admit") {
 		t.Fatalf("unknown checkout commit error = %v", err)
 	}
 	if _, err := os.Stat(gitLog); !os.IsNotExist(err) {
@@ -168,7 +168,7 @@ esac
 	job.Actions[0].Commit = actionintegration.CheckoutV7Commit
 	job.Actions[0].SourceDigest = "sha256:" + strings.Repeat("0", 64)
 	secondWorkspace := t.TempDir()
-	if _, err := (Runner{Git: git, Actions: materializer}).RunJob(context.Background(), job, secondWorkspace); err == nil || !strings.Contains(err.Error(), "digest mismatch") {
+	if _, err := (Runner{Git: git, Actions: materializer}).RunJob(t.Context(), job, secondWorkspace); err == nil || !strings.Contains(err.Error(), "digest mismatch") {
 		t.Fatalf("tampered checkout lock error = %v", err)
 	}
 	if _, err := os.Stat(gitLog); !os.IsNotExist(err) {
@@ -262,7 +262,7 @@ printf '%s\n' "$*" >> ` + shellTestQuote(gitLog) + `
 	}
 	var logs bytes.Buffer
 	result, err := (Runner{Git: git, RepositoryCredentials: credentials, Stdout: &logs, Stderr: &logs}).runCheckout(
-		context.Background(), newCommandProcessor(&logs, &logs), workspace, job, actionintegration.CheckoutV7Commit, nil,
+		t.Context(), newCommandProcessor(&logs, &logs), workspace, job, actionintegration.CheckoutV7Commit, nil,
 	)
 	if err != nil {
 		t.Fatalf("runCheckout() error = %v, logs = %q", err, logs.String())
@@ -292,18 +292,18 @@ func TestCheckoutAdapterRejectsUnsupportedInputsAndState(t *testing.T) {
 	repository, sha := "buildkite/buildkite-gha", strings.Repeat("a", 40)
 	processor := newCommandProcessor(io.Discard, io.Discard)
 	job := plan.Job{Event: plan.Event{Provider: "github", Repository: repository, SHA: sha}}
-	if _, err := (Runner{}).runCheckout(context.Background(), processor, t.TempDir(), job, actionintegration.CheckoutV7Commit, map[string]string{"token": ""}); err == nil || !strings.Contains(err.Error(), "unsupported") {
+	if _, err := (Runner{}).runCheckout(t.Context(), processor, t.TempDir(), job, actionintegration.CheckoutV7Commit, map[string]string{"token": ""}); err == nil || !strings.Contains(err.Error(), "unsupported") {
 		t.Fatalf("runCheckout() unsupported input error = %v", err)
 	}
 	workspace := t.TempDir()
 	if err := os.WriteFile(filepath.Join(workspace, "occupied"), []byte("x"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := (Runner{}).runCheckout(context.Background(), processor, workspace, job, actionintegration.CheckoutV7Commit, nil); err == nil || !strings.Contains(err.Error(), "empty workspace") {
+	if _, err := (Runner{}).runCheckout(t.Context(), processor, workspace, job, actionintegration.CheckoutV7Commit, nil); err == nil || !strings.Contains(err.Error(), "empty workspace") {
 		t.Fatalf("nonempty workspace error = %v", err)
 	}
 	job.Event.Provider = "other"
-	if _, err := (Runner{}).runCheckout(context.Background(), processor, t.TempDir(), job, actionintegration.CheckoutV7Commit, nil); err == nil || !strings.Contains(err.Error(), "valid GitHub or Origin event") {
+	if _, err := (Runner{}).runCheckout(t.Context(), processor, t.TempDir(), job, actionintegration.CheckoutV7Commit, nil); err == nil || !strings.Contains(err.Error(), "valid GitHub or Origin event") {
 		t.Fatalf("invalid event error = %v", err)
 	}
 }
@@ -422,7 +422,7 @@ func TestCheckoutSubmoduleNativeCommandSequenceAndFlags(t *testing.T) {
 		t.Fatal(err)
 	}
 	runner := Runner{Stdout: io.Discard, Stderr: io.Discard}
-	if err := runner.runCheckoutSubmodules(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), git, map[string]string{}, checkoutGitBaseArgs(), true, true, false, ""); err != nil {
+	if err := runner.runCheckoutSubmodules(t.Context(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), git, map[string]string{}, checkoutGitBaseArgs(), true, true, false, ""); err != nil {
 		t.Fatal(err)
 	}
 	contents, err := os.ReadFile(logPath)
@@ -461,7 +461,7 @@ exit 0
 			if err := os.WriteFile(git, []byte(script), 0o700); err != nil {
 				t.Fatal(err)
 			}
-			err := (Runner{Stdout: io.Discard, Stderr: io.Discard}).runCheckoutSubmodules(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), git, map[string]string{}, checkoutGitBaseArgs(), false, false, false, "")
+			err := (Runner{Stdout: io.Discard, Stderr: io.Discard}).runCheckoutSubmodules(t.Context(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), git, map[string]string{}, checkoutGitBaseArgs(), false, false, false, "")
 			if err == nil || !strings.Contains(err.Error(), "invalid state") {
 				t.Fatalf("status prefix %q error = %v", prefix, err)
 			}
@@ -489,7 +489,7 @@ func TestCheckoutSubmodulesUsesNativePorcelain(t *testing.T) {
 			runTestGit(t, workspace, "checkout", "--detach", parentOID)
 			base := append(checkoutGitBaseArgs(), "-c", "protocol.file.allow=always")
 			runner := Runner{Stdout: io.Discard, Stderr: io.Discard}
-			if err := runner.runCheckoutSubmodules(context.Background(), newCommandProcessor(io.Discard, io.Discard), workspace, "git", map[string]string{"HOME": filepath.Join(workspace, ".no-home"), "GIT_CONFIG_NOSYSTEM": "1", "GIT_CONFIG_GLOBAL": os.DevNull}, base, test.depthOne, test.recursive, false, ""); err != nil {
+			if err := runner.runCheckoutSubmodules(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, "git", map[string]string{"HOME": filepath.Join(workspace, ".no-home"), "GIT_CONFIG_NOSYSTEM": "1", "GIT_CONFIG_GLOBAL": os.DevNull}, base, test.depthOne, test.recursive, false, ""); err != nil {
 				t.Fatal(err)
 			}
 			childPath := filepath.Join(workspace, "deps", "child")
@@ -554,7 +554,7 @@ func TestSubmoduleResolvedCredentialsWithoutCapabilityDoNotInvokeHelper(t *testi
 		t.Fatal(err)
 	}
 	runner := Runner{RepositoryCredentials: &AgentRepositoryCredentials{Agent: agent, JobID: testCacheJobID, JobToken: "secret"}, Stdout: io.Discard, Stderr: io.Discard}
-	if err := runner.runCheckoutSubmodules(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), git, map[string]string{}, checkoutGitBaseArgs(), false, false, false, ""); err != nil {
+	if err := runner.runCheckoutSubmodules(t.Context(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), git, map[string]string{}, checkoutGitBaseArgs(), false, false, false, ""); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(marker); !os.IsNotExist(err) {
@@ -595,7 +595,7 @@ echo job-secret
 	}
 	var logs bytes.Buffer
 	runner := Runner{RepositoryCredentials: &AgentRepositoryCredentials{Agent: agent, JobID: testCacheJobID, JobToken: "job-secret"}, Stdout: &logs, Stderr: &logs}
-	if err := runner.runRepositoryProviderCheckoutFetch(context.Background(), newCommandProcessor(&logs, &logs), workspace, map[string]string{}, git, checkoutGitBaseArgs(), []string{"submodule", "update"}, "github.com"); err != nil {
+	if err := runner.runRepositoryProviderCheckoutFetch(t.Context(), newCommandProcessor(&logs, &logs), workspace, map[string]string{}, git, checkoutGitBaseArgs(), []string{"submodule", "update"}, "github.com"); err != nil {
 		t.Fatal(err)
 	}
 	input, err := os.ReadFile(inputLog)
@@ -756,7 +756,7 @@ exec ` + shellTestQuote(realGit) + ` "$@"
 	if err := os.WriteFile(wrapper, []byte(script), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	runner := Runner{Stdout: io.Discard, Stderr: io.Discard, InterruptGrace: 20 * time.Millisecond, TerminateGrace: 20 * time.Millisecond}
 	done := make(chan error, 1)
 	go func() {
@@ -804,7 +804,7 @@ exit 0
 	if err := os.WriteFile(git, []byte(script), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	runner := Runner{Stdout: io.Discard, Stderr: io.Discard, InterruptGrace: 20 * time.Millisecond, TerminateGrace: 20 * time.Millisecond}
 	done := make(chan error, 1)
 	go func() {
@@ -839,7 +839,7 @@ func TestCheckoutRejectsInvalidRepositoryBeforeInspectingWorkspace(t *testing.T)
 	}
 	job := plan.Job{Event: plan.Event{Provider: "github", Repository: "owner/..", SHA: strings.Repeat("a", 40)}}
 	processor := newCommandProcessor(io.Discard, io.Discard)
-	if _, err := (Runner{}).runCheckout(context.Background(), processor, workspace, job, actionintegration.CheckoutV7Commit, nil); err == nil || !strings.Contains(err.Error(), "valid GitHub or Origin event repository") {
+	if _, err := (Runner{}).runCheckout(t.Context(), processor, workspace, job, actionintegration.CheckoutV7Commit, nil); err == nil || !strings.Contains(err.Error(), "valid GitHub or Origin event repository") {
 		t.Fatalf("checkout repository validation error = %v", err)
 	}
 }
@@ -985,7 +985,7 @@ printf '%s|%s\n' "$PWD" "$*" >> ` + shellTestQuote(gitLog) + `
 	for name := range proxyEnvironment {
 		t.Setenv(name, "http://late-workflow-value.invalid")
 	}
-	result, err := (Runner{Git: git, RepositoryCredentials: credentials, Stdout: &logs, Stderr: &logs}).runCheckout(context.Background(), processor, workspace, job, actionintegration.CheckoutV7Commit, map[string]string{"path": "test-catalog"})
+	result, err := (Runner{Git: git, RepositoryCredentials: credentials, Stdout: &logs, Stderr: &logs}).runCheckout(t.Context(), processor, workspace, job, actionintegration.CheckoutV7Commit, map[string]string{"path": "test-catalog"})
 	if err != nil {
 		t.Fatalf("runCheckout() error = %v, logs = %q", err, logs.String())
 	}
@@ -1133,7 +1133,7 @@ esac
 	credentials := &AgentRepositoryCredentials{Agent: agent, JobID: testCacheJobID, JobToken: "job-secret"}
 	var logs bytes.Buffer
 	processor := newCommandProcessor(&logs, &logs)
-	if _, err := (Runner{Git: git, RepositoryCredentials: credentials, Stdout: &logs, Stderr: &logs}).runCheckout(context.Background(), processor, workspace, job, actionintegration.CheckoutV7Commit, nil); err == nil {
+	if _, err := (Runner{Git: git, RepositoryCredentials: credentials, Stdout: &logs, Stderr: &logs}).runCheckout(t.Context(), processor, workspace, job, actionintegration.CheckoutV7Commit, nil); err == nil {
 		t.Fatal("runCheckout() succeeded after repository-provider helper denial")
 	}
 	if strings.Contains(logs.String(), "job-secret") || !strings.Contains(logs.String(), "***") {
@@ -1282,7 +1282,7 @@ fi
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: remoteDigest}}
 	var logs bytes.Buffer
 	credentials := &AgentRepositoryCredentials{JobID: testCacheJobID, JobToken: "job-secret"}
-	result, err := (Runner{Node24: node, RepositoryCredentials: credentials, Actions: materializer, Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node24: node, RepositoryCredentials: credentials, Actions: materializer, Stdout: &logs, Stderr: &logs}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v, logs = %q", result, err, logs.String())
 	}
@@ -1399,7 +1399,7 @@ esac
 			}
 			materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, ActionRoot: remote, SourceDigest: remoteDigest}}
 			var logs bytes.Buffer
-			result, err := (Runner{Git: git, Actions: materializer, Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+			result, err := (Runner{Git: git, Actions: materializer, Stdout: &logs, Stderr: &logs}).RunJob(t.Context(), job, workspace)
 			if err != nil || result.Conclusion != "success" {
 				t.Fatalf("RunJob() result = %#v, error = %v, logs = %q", result, err, logs.String())
 			}
@@ -1438,10 +1438,10 @@ func TestContainerPreparationSkipsNativeCheckoutClassification(t *testing.T) {
 			materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, ActionRoot: remote, SourceDigest: remoteDigest}}
 			actions := newActionLockResolver(job, t.TempDir(), materializer)
 			runner := &Runner{}
-			if err := runner.verifyRemoteActionTree(context.Background(), actions, plan.ActionSelector{Lock: checkoutID}, nil); err != nil {
+			if err := runner.verifyRemoteActionTree(t.Context(), actions, plan.ActionSelector{Lock: checkoutID}, nil); err != nil {
 				t.Fatalf("verifyRemoteActionTree() error = %v", err)
 			}
-			mounts, err := runner.actionContainerMounts(context.Background(), actions)
+			mounts, err := runner.actionContainerMounts(t.Context(), actions)
 			if err != nil || len(mounts) != 0 {
 				t.Fatalf("actionContainerMounts() = %#v, error = %v", mounts, err)
 			}
@@ -1455,7 +1455,7 @@ func TestRepositoryProviderCheckoutRequiresPreResolvedGit(t *testing.T) {
 		RequiredCapabilities: []string{"provider-token-read"},
 	}
 	credentials := &AgentRepositoryCredentials{Agent: "/usr/bin/buildkite-agent", JobID: testCacheJobID, JobToken: "job-secret"}
-	if _, err := (Runner{Git: "git", RepositoryCredentials: credentials}).runCheckout(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), job, actionintegration.CheckoutV7Commit, nil); err == nil || !strings.Contains(err.Error(), "resolved before workflow execution") {
+	if _, err := (Runner{Git: "git", RepositoryCredentials: credentials}).runCheckout(t.Context(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), job, actionintegration.CheckoutV7Commit, nil); err == nil || !strings.Contains(err.Error(), "resolved before workflow execution") {
 		t.Fatalf("runCheckout() unresolved Git error = %v", err)
 	}
 }
@@ -1480,7 +1480,7 @@ func TestProviderTokenReadRuntimeAuthorityIsCheckoutOnly(t *testing.T) {
 	writeFixtureFile(t, workspace, workflowPath, "name: authority\n")
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "ordinary", Kind: "run", Command: "true"}})
 	job.RequiredCapabilities = []string{"provider-token-read"}
-	if _, err := (Runner{}).RunJob(context.Background(), job, workspace); err == nil || !strings.Contains(err.Error(), "restricted to the verified checkout adapter") {
+	if _, err := (Runner{}).RunJob(t.Context(), job, workspace); err == nil || !strings.Contains(err.Error(), "restricted to the verified checkout adapter") {
 		t.Fatalf("ordinary provider-token-read error = %v", err)
 	}
 }
@@ -1515,7 +1515,7 @@ func TestCompositeCheckoutPreservesDynamicRefProvenance(t *testing.T) {
 	}
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, ActionRoot: remote, SourceDigest: remoteDigest}}
 
-	if _, err := (Runner{Actions: materializer}).RunJob(context.Background(), job, workspace); err == nil || !strings.Contains(err.Error(), "dynamic ref must resolve to the exact event SHA") {
+	if _, err := (Runner{Actions: materializer}).RunJob(t.Context(), job, workspace); err == nil || !strings.Contains(err.Error(), "dynamic ref must resolve to the exact event SHA") {
 		t.Fatalf("nested dynamic checkout ref error = %v", err)
 	}
 }

--- a/internal/runtime/containers.go
+++ b/internal/runtime/containers.go
@@ -355,7 +355,7 @@ func dockerLogin(ctx context.Context, env map[string]string, docker, registry, u
 		args = append(args, registry)
 	}
 	args = append(args, "--username", username, "--password-stdin")
-	for attempt := 0; attempt < 3; attempt++ {
+	for attempt := range 3 {
 		cmd := exec.CommandContext(ctx, docker, args...)
 		cmd.Env = processEnv(env)
 		cmd.Stdin = strings.NewReader(password + "\n")
@@ -381,7 +381,7 @@ func dockerLogin(ctx context.Context, env map[string]string, docker, registry, u
 
 func (r Runner) pullContainerImage(ctx context.Context, processor *commandProcessor, env map[string]string, docker, image string) error {
 	var err error
-	for attempt := 0; attempt < 3; attempt++ {
+	for attempt := range 3 {
 		if err = r.runStreaming(ctx, processor, "", env, docker, "pull", image); err == nil {
 			return nil
 		}
@@ -803,7 +803,7 @@ func (b *jobContainerBackend) cleanup() error {
 		}
 	}
 	b.emitReadyServiceLogs(ctx)
-	for i := 0; i < len(b.services); i++ {
+	for i := range len(b.services) {
 		service := b.services[i]
 		if service.created {
 			name := service.name

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -633,7 +633,7 @@ func TestRunJobContainerLifecycleAndEnvironment(t *testing.T) {
 	j.Env = map[string]string{"P": "job"}
 	j.Container.Env = map[string]string{"P": "container"}
 	j.Outputs = map[string]string{"observed": "${{ steps.one.outputs.O }}"}
-	r, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(context.Background(), j, workspace)
+	r, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(t.Context(), j, workspace)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -671,7 +671,7 @@ func TestRunJobContainerDefaultsRunStepsToSh(t *testing.T) {
 	f := newJobDocker(t, "")
 	workspace := t.TempDir()
 	j := jobContainerPlan(t, workspace, []plan.Step{{ID: "default", Kind: "run", Command: "true"}})
-	if _, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(context.Background(), j, workspace); err != nil {
+	if _, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(t.Context(), j, workspace); err != nil {
 		t.Fatal(err)
 	}
 	for _, call := range f.calls(t) {
@@ -704,7 +704,7 @@ with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
 		{ID: "cleanup", Kind: "run", Shell: "sh", Command: `set -- "$RUNNER_TEMP"/buildkite-gha-shell-*.py; test ! -e "$1"`},
 	})
 	j.Outputs = map[string]string{"script": "${{ steps.python.outputs.script }}"}
-	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(context.Background(), j, workspace)
+	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(t.Context(), j, workspace)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -739,7 +739,7 @@ func TestRunJobContainerServicesLifecycleAndArguments(t *testing.T) {
 		"a-db":    {Image: "postgres:16", Env: map[string]string{"B": "two"}},
 	}
 	j.ServiceOrder = []string{"z-cache", "a-db"}
-	if _, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(context.Background(), j, w); err != nil {
+	if _, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(t.Context(), j, w); err != nil {
 		t.Fatal(err)
 	}
 	calls := f.calls(t)
@@ -766,7 +766,7 @@ func TestRunJobContainerServicesLifecycleAndArguments(t *testing.T) {
 	}
 	firstInspect := jobDockerCallIndex(calls, "inspect", "--format", `{{if .State.Health}}{{.State.Health.Status}}{{end}}`)
 	startsBeforeInspect := 0
-	for i := 0; i < firstInspect; i++ {
+	for i := range firstInspect {
 		if calls[i].Args[0] == "start" {
 			startsBeforeInspect++
 		}
@@ -806,7 +806,7 @@ func TestRunJobContainerServicesLifecycleAndArguments(t *testing.T) {
 
 func TestRunServiceContainerAutoRemoveCleanup(t *testing.T) {
 	f := newJobDocker(t, "service-auto-remove")
-	b, err := (Runner{Docker: f.path}).startJobContainer(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Options: "--rm"}})
+	b, err := (Runner{Docker: f.path}).startJobContainer(t.Context(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Options: "--rm"}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -832,7 +832,7 @@ func TestRunServiceContainerAutoRemoveCleanup(t *testing.T) {
 
 func TestRunServiceContainerAlreadyAutoRemovedCleanup(t *testing.T) {
 	f := newJobDocker(t, "")
-	b, err := (Runner{Docker: f.path}).startJobContainer(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Options: "--rm"}})
+	b, err := (Runner{Docker: f.path}).startJobContainer(t.Context(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Options: "--rm"}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -853,7 +853,7 @@ func TestRunServiceContainerAlreadyAutoRemovedCleanup(t *testing.T) {
 
 func TestRunServiceContainerAutoRemoveBetweenQueryAndStop(t *testing.T) {
 	f := newJobDocker(t, "service-auto-remove-before-stop")
-	b, err := (Runner{Docker: f.path}).startJobContainer(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Options: "--rm"}})
+	b, err := (Runner{Docker: f.path}).startJobContainer(t.Context(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Options: "--rm"}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -916,7 +916,7 @@ func TestRunServiceContainerCompleteArguments(t *testing.T) {
 		Options: `--health-cmd "pg_isready -U postgres" --health-retries 5`,
 		Command: `postgres -c "fsync = off"`, Entrypoint: "docker-entrypoint.sh",
 	}
-	b, err := (Runner{Docker: f.path}).startJobContainer(context.Background(), newCommandProcessor(os.Stdout, os.Stderr), w, tmp, nil, map[string]plan.ServiceContainer{"database": service})
+	b, err := (Runner{Docker: f.path}).startJobContainer(t.Context(), newCommandProcessor(os.Stdout, os.Stderr), w, tmp, nil, map[string]plan.ServiceContainer{"database": service})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -946,7 +946,7 @@ func TestRunServiceContainersUseDeclaredOrderAndEmitSuccessfulLogs(t *testing.T)
 	var output bytes.Buffer
 	processor := newCommandProcessor(&output, &output)
 	b, err := (Runner{Docker: f.path}).startJobContainerOrdered(
-		context.Background(), processor, t.TempDir(), t.TempDir(), nil,
+		t.Context(), processor, t.TempDir(), t.TempDir(), nil,
 		map[string]plan.ServiceContainer{"alpha": {Image: "one"}, "zed": {Image: "two"}}, []string{"zed", "alpha"},
 	)
 	if err != nil {
@@ -978,7 +978,7 @@ func TestRunServiceContainersUseDeclaredOrderAndEmitSuccessfulLogs(t *testing.T)
 func TestRunServiceContainerRegistryCredentialsUsePasswordStdin(t *testing.T) {
 	f := newJobDocker(t, "fail-login-once")
 	service := plan.ServiceContainer{Image: "registry.example.test/team/postgres:16", Credentials: &plan.ContainerCredentials{Username: "registry-user", Password: "registry-password"}}
-	b, err := (Runner{Docker: f.path}).startJobContainer(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": service})
+	b, err := (Runner{Docker: f.path}).startJobContainer(t.Context(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": service})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1009,7 +1009,7 @@ func TestRunServiceContainerRegistryCredentialsUsePasswordStdin(t *testing.T) {
 
 func TestDockerLoginCancellationStopsRetry(t *testing.T) {
 	f := newJobDocker(t, "block-login")
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 	defer cancel()
 	start := time.Now()
 	err := dockerLogin(ctx, map[string]string{"DOCKER_CONFIG": t.TempDir()}, f.path, "registry.example.test", "registry-user", "registry-password")
@@ -1040,7 +1040,7 @@ func TestRunServiceContainerPullsSameImagePerCredentialIdentity(t *testing.T) {
 		"a": {Image: image, Credentials: &plan.ContainerCredentials{Username: "user-a", Password: "password-a"}},
 		"b": {Image: image, Credentials: &plan.ContainerCredentials{Username: "user-b", Password: "password-b"}},
 	}
-	b, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).startJobContainer(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), &plan.Container{Image: image}, services)
+	b, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).startJobContainer(t.Context(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), &plan.Container{Image: image}, services)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1065,7 +1065,7 @@ func TestRunServiceContainerPullsSameImagePerCredentialIdentity(t *testing.T) {
 func TestRunServiceContainerPartialRegistryCredentialsDoNotLogin(t *testing.T) {
 	for _, credentials := range []*plan.ContainerCredentials{{Username: "registry-user"}, {Password: "registry-password"}} {
 		f := newJobDocker(t, "")
-		b, err := (Runner{Docker: f.path}).startJobContainer(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "registry.example.test/postgres:16", Credentials: credentials}})
+		b, err := (Runner{Docker: f.path}).startJobContainer(t.Context(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "registry.example.test/postgres:16", Credentials: credentials}})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1176,7 +1176,7 @@ func TestRunServiceContainerRemovesOnlyNewNamedVolumes(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			b, err := (Runner{Docker: f.path}).startJobContainer(context.Background(), newCommandProcessor(os.Stdout, os.Stderr), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Volumes: []string{test.volume}}})
+			b, err := (Runner{Docker: f.path}).startJobContainer(t.Context(), newCommandProcessor(os.Stdout, os.Stderr), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Volumes: []string{test.volume}}})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1196,7 +1196,7 @@ func TestRunServiceContainerRemovesOnlyNewNamedVolumes(t *testing.T) {
 
 func TestRunServiceContainerReportsLeftoverNamedVolume(t *testing.T) {
 	f := newJobDocker(t, "volume-leftover")
-	b, err := (Runner{Docker: f.path}).startJobContainer(context.Background(), newCommandProcessor(os.Stdout, os.Stderr), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Volumes: []string{"database:/data"}}})
+	b, err := (Runner{Docker: f.path}).startJobContainer(t.Context(), newCommandProcessor(os.Stdout, os.Stderr), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Volumes: []string{"database:/data"}}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1207,7 +1207,7 @@ func TestRunServiceContainerReportsLeftoverNamedVolume(t *testing.T) {
 
 func TestRunServiceContainerReadsBroadDockerPortOutput(t *testing.T) {
 	f := newJobDocker(t, "broad-port")
-	b, err := (Runner{Docker: f.path}).startJobContainer(context.Background(), newCommandProcessor(os.Stdout, os.Stderr), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Ports: []string{"8000-8001:80-81"}, Options: "--publish 8002:82/sctp"}})
+	b, err := (Runner{Docker: f.path}).startJobContainer(t.Context(), newCommandProcessor(os.Stdout, os.Stderr), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Ports: []string{"8000-8001:80-81"}, Options: "--publish 8002:82/sctp"}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1220,7 +1220,7 @@ func TestRunServiceContainerReadsBroadDockerPortOutput(t *testing.T) {
 
 func TestRunServiceContainerOptionNameUsesCreatedReference(t *testing.T) {
 	f := newJobDocker(t, "")
-	b, err := (Runner{Docker: f.path}).startJobContainer(context.Background(), newCommandProcessor(os.Stdout, os.Stderr), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Options: "--name custom-service"}})
+	b, err := (Runner{Docker: f.path}).startJobContainer(t.Context(), newCommandProcessor(os.Stdout, os.Stderr), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Options: "--name custom-service"}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1239,7 +1239,7 @@ func TestRunJobContainerServiceFailureDiagnosticsAreMasked(t *testing.T) {
 	var output bytes.Buffer
 	p := newCommandProcessor(&output, &output)
 	p.addMask("sibling-secret")
-	_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).startJobContainer(context.Background(), p, w, tmp, &plan.Container{Image: "alpine"}, map[string]plan.ServiceContainer{"db": {Image: "postgres"}})
+	_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).startJobContainer(t.Context(), p, w, tmp, &plan.Container{Image: "alpine"}, map[string]plan.ServiceContainer{"db": {Image: "postgres"}})
 	if err == nil || !strings.Contains(err.Error(), `service "db"`) || !strings.Contains(err.Error(), `status "unhealthy"`) {
 		t.Fatalf("error=%v", err)
 	}
@@ -1256,7 +1256,7 @@ func TestRunJobContinueOnErrorToleratesServiceStartupFailure(t *testing.T) {
 	job.ServiceOrder = []string{"db"}
 	job.ContinueOnError = true
 
-	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(context.Background(), job, w)
+	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(t.Context(), job, w)
 	if err == nil || !IsToleratedJobFailure(err) || result.Conclusion != "success" || !strings.Contains(err.Error(), `service "db"`) {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -1271,7 +1271,7 @@ func TestRunJobContinueOnErrorDoesNotTolerateServiceStartupTimeout(t *testing.T)
 	job.ContinueOnError = true
 	job.TimeoutMinutes = 0.001
 
-	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(context.Background(), job, w)
+	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(t.Context(), job, w)
 	if !errors.Is(err, context.DeadlineExceeded) || IsToleratedJobFailure(err) || result.Conclusion != "cancelled" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -1285,7 +1285,7 @@ func TestRunJobContinueOnErrorDoesNotTolerateMalformedServicePortEvidence(t *tes
 	job.ServiceOrder = []string{"db"}
 	job.ContinueOnError = true
 
-	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(context.Background(), job, w)
+	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(t.Context(), job, w)
 	if err == nil || IsToleratedJobFailure(err) || result.Conclusion != "failure" || !strings.Contains(err.Error(), "malformed Docker port output") {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -1297,7 +1297,7 @@ func TestRunJobContainerMalformedServicePortsIncludeMaskedDiagnostics(t *testing
 	var output bytes.Buffer
 	p := newCommandProcessor(&output, &output)
 	p.addMask("sibling-secret")
-	_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).startJobContainer(context.Background(), p, w, tmp, nil, map[string]plan.ServiceContainer{"db": {Image: "postgres", Ports: []string{"6379"}}})
+	_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).startJobContainer(t.Context(), p, w, tmp, nil, map[string]plan.ServiceContainer{"db": {Image: "postgres", Ports: []string{"6379"}}})
 	if err == nil || !strings.Contains(err.Error(), `service "db" has malformed Docker port output`) {
 		t.Fatalf("error=%v", err)
 	}
@@ -1309,7 +1309,7 @@ func TestRunJobContainerMalformedServicePortsIncludeMaskedDiagnostics(t *testing
 func TestRunJobContainerLaterServiceCreateFailureCleansExactServices(t *testing.T) {
 	f := newJobDocker(t, "fail-later-service-create")
 	w, tmp := t.TempDir(), t.TempDir()
-	_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).startJobContainer(context.Background(), newCommandProcessor(os.Stdout, os.Stderr), w, tmp, &plan.Container{Image: "alpine"}, map[string]plan.ServiceContainer{"a": {Image: "one"}, "b": {Image: "two"}})
+	_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).startJobContainer(t.Context(), newCommandProcessor(os.Stdout, os.Stderr), w, tmp, &plan.Container{Image: "alpine"}, map[string]plan.ServiceContainer{"a": {Image: "one"}, "b": {Image: "two"}})
 	if err == nil || !strings.Contains(err.Error(), `create service "b"`) {
 		t.Fatalf("error=%v, want second service create failure", err)
 	}
@@ -1333,7 +1333,7 @@ func TestRunJobContainerServiceReadinessCancellationCleansEverything(t *testing.
 
 	f := newJobDocker(t, "service-starting")
 	w, tmp := t.TempDir(), t.TempDir()
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	done := make(chan error, 1)
 	go func() {
 		_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).startJobContainer(ctx, newCommandProcessor(os.Stdout, os.Stderr), w, tmp, &plan.Container{Image: "alpine"}, map[string]plan.ServiceContainer{"db": {Image: "postgres"}})
@@ -1357,7 +1357,7 @@ func TestRunJobContainerServiceReadinessCancellationCleansEverything(t *testing.
 func TestRunHostJobServiceReadinessCancellationCleansEverything(t *testing.T) {
 	f := newJobDocker(t, "service-starting")
 	w, tmp := t.TempDir(), t.TempDir()
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	done := make(chan error, 1)
 	go func() {
 		_, err := (Runner{Docker: f.path}).startJobContainer(ctx, newCommandProcessor(os.Stdout, os.Stderr), w, tmp, nil, map[string]plan.ServiceContainer{"db": {Image: "postgres"}})
@@ -1392,7 +1392,7 @@ func TestRunJobHostServicesLifecycle(t *testing.T) {
 	j.Services = map[string]plan.ServiceContainer{"db": {Image: "postgres", Ports: []string{"6379"}}}
 	j.ServiceOrder = []string{"db"}
 	j.Steps = []plan.Step{{ID: "host", Kind: "run", Shell: "sh", Env: map[string]string{"SERVICE_PORT": "${{ job.services.db.ports[6379] }}"}, Command: `test "$SERVICE_PORT" = 49152`}}
-	if _, err := (Runner{Docker: f.path}).RunJob(context.Background(), j, w); err != nil {
+	if _, err := (Runner{Docker: f.path}).RunJob(t.Context(), j, w); err != nil {
 		t.Fatal(err)
 	}
 	for _, call := range f.calls(t) {
@@ -1415,7 +1415,7 @@ func TestRunHostJobServicesExposePortsAndNetworkToDockerActions(t *testing.T) {
 	job.Services = map[string]plan.ServiceContainer{"redis": {Image: "redis:7", Ports: []string{"6379"}}}
 	job.ServiceOrder = []string{"redis"}
 	job.Actions = []plan.ActionLock{{ID: lockID, Source: "workspace", Path: "actions/docker", SourceDigest: digestTree(t, filepath.Join(workspace, "actions/docker"))}}
-	if _, err := (Runner{Docker: f.path}).RunJob(context.Background(), job, workspace); err != nil {
+	if _, err := (Runner{Docker: f.path}).RunJob(t.Context(), job, workspace); err != nil {
 		t.Fatal(err)
 	}
 	calls := f.calls(t)
@@ -1449,7 +1449,7 @@ func TestRunJobHostServicePortProtocolCollisionIsDeterministic(t *testing.T) {
 	j.Services = map[string]plan.ServiceContainer{"db": {Image: "postgres", Ports: []string{"41001:6379/tcp", "41002:6379/udp"}}}
 	j.ServiceOrder = []string{"db"}
 	j.Steps = []plan.Step{{ID: "host", Kind: "run", Shell: "sh", Env: map[string]string{"SERVICE_PORT": "${{ job.services.db.ports[6379] }}"}, Command: `test "$SERVICE_PORT" = 41002`}}
-	if _, err := (Runner{Docker: f.path}).RunJob(context.Background(), j, w); err != nil {
+	if _, err := (Runner{Docker: f.path}).RunJob(t.Context(), j, w); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -1465,7 +1465,7 @@ func TestRunJobContainerSetupFailuresCleanOwnedResources(t *testing.T) {
 				t.Fatal(err)
 			}
 			j := jobContainerPlan(t, w, nil)
-			_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(context.Background(), j, w)
+			_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(t.Context(), j, w)
 			if err == nil {
 				t.Fatal("expected failure")
 			}
@@ -1500,7 +1500,7 @@ func TestRunJobContainerCleanupQueryFailureStillRemovesExactResources(t *testing
 	f := newJobDocker(t, "query-fail")
 	w := t.TempDir()
 	j := jobContainerPlan(t, w, nil)
-	_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(context.Background(), j, w)
+	_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(t.Context(), j, w)
 	if err == nil || !strings.Contains(err.Error(), "query job") {
 		t.Fatalf("error=%v", err)
 	}
@@ -1519,7 +1519,7 @@ func TestRunJobContainerReportsLeftoverAndVerificationFailure(t *testing.T) {
 			w := t.TempDir()
 			j := jobContainerPlan(t, w, nil)
 			j.ContinueOnError = true
-			result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(context.Background(), j, w)
+			result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(t.Context(), j, w)
 			if err == nil || IsToleratedJobFailure(err) || result.Conclusion != "failure" || !strings.Contains(err.Error(), "verify owned Docker cleanup") {
 				t.Fatalf("result=%#v, error=%v", result, err)
 			}
@@ -1532,16 +1532,17 @@ func TestRunJobContainerToleratesWorkflowFailureAfterSuccessfulCleanup(t *testin
 	w := t.TempDir()
 	j := jobContainerPlan(t, w, []plan.Step{{ID: "fail", Kind: "run", Shell: "sh", Command: "exit 7"}})
 	j.ContinueOnError = true
-	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(context.Background(), j, w)
+	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(t.Context(), j, w)
 	if err == nil || !IsToleratedJobFailure(err) || result.Conclusion != "success" {
 		t.Fatalf("result=%#v, error=%v", result, err)
 	}
 }
 
 func startTestBackend(t *testing.T, f fakeJobDocker) (*jobContainerBackend, string) {
+	t.Helper()
 	w := t.TempDir()
 	tmp := t.TempDir()
-	b, e := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], InterruptGrace: 20 * time.Millisecond, TerminateGrace: 20 * time.Millisecond}).startJobContainer(context.Background(), newCommandProcessor(os.Stdout, os.Stderr), w, tmp, &plan.Container{Image: "alpine:3.20"}, nil)
+	b, e := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], InterruptGrace: 20 * time.Millisecond, TerminateGrace: 20 * time.Millisecond}).startJobContainer(t.Context(), newCommandProcessor(os.Stdout, os.Stderr), w, tmp, &plan.Container{Image: "alpine:3.20"}, nil)
 	if e != nil {
 		t.Fatal(e)
 	}
@@ -1555,7 +1556,7 @@ func TestRunJobContainerCancellationTargetsProcessTree(t *testing.T) {
 	b, w := startTestBackend(t, f)
 	t.Cleanup(func() { _ = b.cleanup() })
 	marker := filepath.Join(w, "alive")
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	done := make(chan error, 1)
 	go func() {
@@ -1604,14 +1605,14 @@ func TestRunJobContainerConcurrentExecUsesUniquePIDFiles(t *testing.T) {
 
 	f := newJobDocker(t, "")
 	b, w := startTestBackend(t, f)
-	c1, x := context.WithCancel(context.Background())
+	c1, x := context.WithCancel(t.Context())
 	d1 := make(chan error, 1)
 	d2 := make(chan error, 1)
 	go func() {
 		d1 <- b.exec(c1, b.runner, newCommandProcessor(os.Stdout, os.Stderr), w, nil, "sh", "-c", "sleep 30")
 	}()
 	go func() {
-		d2 <- b.exec(context.Background(), b.runner, newCommandProcessor(os.Stdout, os.Stderr), w, nil, "sh", "-c", "sleep .3")
+		d2 <- b.exec(t.Context(), b.runner, newCommandProcessor(os.Stdout, os.Stderr), w, nil, "sh", "-c", "sleep .3")
 	}()
 	time.Sleep(100 * time.Millisecond)
 	x()
@@ -1644,7 +1645,7 @@ func TestRunJobContainerBarrierVisibility(t *testing.T) {
 	f := newJobDocker(t, "")
 	w := t.TempDir()
 	j := jobContainerPlan(t, w, []plan.Step{{ID: "bg", Kind: "run", Shell: "sh", Background: true, Command: `/bin/sleep .15; echo LATE=yes >> "$GITHUB_ENV"; echo value=x >> "$GITHUB_OUTPUT"; echo /late >> "$GITHUB_PATH"`}, {ID: "before", Kind: "run", Shell: "sh", Command: `test -z "${LATE-}"`}, {ID: "wait", Kind: "wait", Targets: []string{"bg"}}, {ID: "after", Kind: "run", Shell: "sh", Command: `test "$LATE" = yes; case "$PATH" in /late:*) ;; *) exit 9;; esac`}})
-	if _, e := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(context.Background(), j, w); e != nil {
+	if _, e := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(t.Context(), j, w); e != nil {
 		t.Fatal(e)
 	}
 }
@@ -1656,11 +1657,10 @@ func TestRunJobContainerRejectsDeferredFeaturesBeforeDocker(t *testing.T) {
 			w := t.TempDir()
 			j := jobContainerPlan(t, w, nil)
 			m := &fakeActionMaterializer{}
-			switch feature {
-			case "action":
+			if feature == "action" {
 				j.Steps = []plan.Step{{Kind: "uses", Uses: "x"}}
 			}
-			if _, e := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Actions: m}).RunJob(context.Background(), j, w); e == nil {
+			if _, e := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Actions: m}).RunJob(t.Context(), j, w); e == nil {
 				t.Fatal("accepted")
 			}
 			if len(f.calls(t)) != 0 || m.calls != 0 {
@@ -1676,7 +1676,7 @@ func TestRunJobContainerTimeoutCoversSetup(t *testing.T) {
 	j := jobContainerPlan(t, w, nil)
 	j.TimeoutMinutes = .001
 	start := time.Now()
-	_, e := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], CleanupTimeout: 100 * time.Millisecond}).RunJob(context.Background(), j, w)
+	_, e := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], CleanupTimeout: 100 * time.Millisecond}).RunJob(t.Context(), j, w)
 	if !errors.Is(e, context.DeadlineExceeded) || time.Since(start) > 2*time.Second {
 		t.Fatalf("error=%v elapsed=%s", e, time.Since(start))
 	}
@@ -1729,7 +1729,7 @@ func TestJobContainerExecRejectsInvalidEnvironmentNamesBeforeDocker(t *testing.T
 				t.Fatal(err)
 			}
 			backend := jobContainerBackend{docker: docker, container: "job", workspace: t.TempDir(), temp: t.TempDir()}
-			err := backend.exec(context.Background(), Runner{}, newCommandProcessor(io.Discard, io.Discard), backend.workspace, map[string]string{name: "value"}, "true")
+			err := backend.exec(t.Context(), Runner{}, newCommandProcessor(io.Discard, io.Discard), backend.workspace, map[string]string{name: "value"}, "true")
 			if err == nil || !strings.Contains(err.Error(), "invalid environment variable name") {
 				t.Fatalf("exec() error = %v, want invalid environment name", err)
 			}
@@ -1757,7 +1757,7 @@ func TestRunJobContainerNodeProbeFailureCleansOwnedResources(t *testing.T) {
 			lockID := remoteLifecycleLockID(1)
 			j.Steps = []plan.Step{{ID: "action", Kind: "uses", Uses: "./unused", Action: &plan.ActionSelector{Lock: lockID}}}
 			j.Actions = []plan.ActionLock{{ID: lockID, Source: "workspace", Path: "unused", SourceDigest: digestTree(t, filepath.Join(w, "unused"))}}
-			_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node24: node}).RunJob(context.Background(), j, w)
+			_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node24: node}).RunJob(t.Context(), j, w)
 			if err == nil || (!strings.Contains(err.Error(), "exact major") && !strings.Contains(err.Error(), "incompatible")) {
 				t.Fatalf("error = %v", err)
 			}
@@ -1783,7 +1783,7 @@ func TestRunJobContainerDoesNotProbeConfiguredNodeWithoutActions(t *testing.T) {
 		t.Fatal(err)
 	}
 	j := jobContainerPlan(t, w, []plan.Step{{ID: "shell", Kind: "run", Shell: "sh", Command: "true"}})
-	if _, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node24: node}).RunJob(context.Background(), j, w); err != nil {
+	if _, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node24: node}).RunJob(t.Context(), j, w); err != nil {
 		t.Fatal(err)
 	}
 	for _, call := range f.calls(t) {
@@ -1801,7 +1801,7 @@ func TestRunJobContainerDoesNotProbeConfiguredNodeForCompositeOnlyActions(t *tes
 	lockID := remoteLifecycleLockID(1)
 	j := jobContainerPlan(t, w, []plan.Step{{ID: "composite", Kind: "uses", Uses: "./composite", Action: &plan.ActionSelector{Lock: lockID}}})
 	j.Actions = []plan.ActionLock{{ID: lockID, Source: "workspace", Path: "composite", SourceDigest: digestTree(t, filepath.Join(w, "composite"))}}
-	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node24: node}).RunJob(context.Background(), j, w)
+	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node24: node}).RunJob(t.Context(), j, w)
 	if err != nil || result.Env["COMPOSITE_ONLY"] != "seen" {
 		t.Fatalf("composite-only container result = %#v, error = %v", result, err)
 	}
@@ -1831,7 +1831,7 @@ func TestActionContainerMountsNativeAdapterDoesNotResolveMise(t *testing.T) {
 		miseCalls++
 		return "", errors.New("unexpected mise resolution")
 	}}
-	mounts, err := runner.actionContainerMounts(context.Background(), actions)
+	mounts, err := runner.actionContainerMounts(t.Context(), actions)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1906,7 +1906,7 @@ esac
 		Container:    &plan.Container{Image: "debian:bookworm-slim"},
 	}
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, ActionRoot: remote, SourceDigest: remoteDigest}}
-	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Git: git, Actions: materializer}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Git: git, Actions: materializer}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" || result.Env["CHECKOUT_CHAIN"] != "ok" {
 		t.Fatalf("container checkout chain result = %#v, error = %v", result, err)
 	}
@@ -1928,7 +1928,7 @@ func TestRunJobContainerReadOnlyMountProbeFailureCleansOwnedResources(t *testing
 	j.Steps = []plan.Step{{ID: "action", Kind: "uses", Uses: remoteLifecycleUses("selected"), Action: &plan.ActionSelector{Lock: lockID}}}
 	j.Actions = []plan.ActionLock{remoteLifecycleLock(lockID, "selected", digest, nil)}
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, ActionRoot: filepath.Join(remote, "selected"), SourceDigest: digest}}
-	_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Actions: materializer}).RunJob(context.Background(), j, w)
+	_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Actions: materializer}).RunJob(t.Context(), j, w)
 	if err == nil || !strings.Contains(err.Error(), "not readable/traversable") {
 		t.Fatalf("read-only mount probe error = %v", err)
 	}
@@ -1958,7 +1958,7 @@ func TestRunJobContainerSkippedRemoteJavaScriptDoesNotRequireNode(t *testing.T) 
 	j.Actions = []plan.ActionLock{remoteLifecycleLock(lockID, "selected", digest, nil)}
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, ActionRoot: filepath.Join(remote, "selected"), SourceDigest: digest}}
 	missingNode := filepath.Join(t.TempDir(), "missing-node")
-	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node24: missingNode, Actions: materializer}).RunJob(context.Background(), j, w)
+	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node24: missingNode, Actions: materializer}).RunJob(t.Context(), j, w)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("skipped remote JavaScript result = %#v, error = %v", result, err)
 	}
@@ -1988,7 +1988,7 @@ func TestRunJobContainerJavaScriptLifecycle(t *testing.T) {
 	}}
 	job.Outputs = map[string]string{"result": "${{ steps.javascript.outputs.result }}"}
 	var logs bytes.Buffer
-	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node24: node, Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node24: node, Stdout: &logs, Stderr: &logs}).RunJob(t.Context(), job, workspace)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2080,7 +2080,7 @@ printf '%s:%s\n' "$action" "$phase" >> "$LIFECYCLE_LOG"
 		{ID: compositeID, Source: "workspace", Path: ".github/actions/composite", SourceDigest: digestTree(t, filepath.Join(workspace, ".github/actions/composite")), Children: map[string]plan.ActionSelector{"./.github/actions/nested": {Lock: nestedID}}},
 		{ID: nestedID, Source: "workspace", Path: ".github/actions/nested", SourceDigest: digestTree(t, filepath.Join(workspace, ".github/actions/nested"))},
 	}
-	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node24: fakeNode}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node24: fakeNode}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("container nested actions result = %#v, error = %v", result, err)
 	}
@@ -2117,7 +2117,7 @@ runs:
 		ID: compositeID, Source: "workspace", Path: ".github/actions/composite",
 		SourceDigest: digestTree(t, filepath.Join(workspace, ".github/actions/composite")),
 	}}
-	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("container composite action path result = %#v, error = %v", result, err)
 	}
@@ -2144,7 +2144,7 @@ func TestRunJobContainerRemoteActionsMountedReadOnly(t *testing.T) {
 	job.Actions = []plan.ActionLock{remoteLifecycleLock(lockID, "selected", digest, nil)}
 	job.Outputs = map[string]string{"remote": "${{ steps.remote.outputs.remote }}"}
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, ActionRoot: filepath.Join(remote, "selected"), SourceDigest: digest}}
-	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node24: requireNode24(t), Actions: materializer}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node24: requireNode24(t), Actions: materializer}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Outputs["remote"] != "yes" {
 		t.Fatalf("remote container action result = %#v, error = %v", result, err)
 	}
@@ -2191,7 +2191,7 @@ func TestRunJobContainerRemoteActionPreparationTimeoutIsCancelled(t *testing.T) 
 		return source.Materialized{}, ctx.Err()
 	}}
 
-	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Actions: materializer}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Actions: materializer}).RunJob(t.Context(), job, workspace)
 	if !errors.Is(err, context.DeadlineExceeded) || IsToleratedJobFailure(err) || result.Conclusion != "cancelled" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -2236,7 +2236,7 @@ echo NESTED_REMOTE=seen >> "$GITHUB_ENV"
 		remoteLifecycleLock(remoteID, "selected", digest, nil),
 	}
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, ActionRoot: filepath.Join(remote, "selected"), SourceDigest: digest}}
-	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node24: node, Actions: materializer}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node24: node, Actions: materializer}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Env["NESTED_REMOTE"] != "seen" {
 		t.Fatalf("nested remote container action result = %#v, error = %v", result, err)
 	}
@@ -2285,7 +2285,7 @@ func TestRunJobContainerWorkspaceActionRemainsLazy(t *testing.T) {
 	node20 := filepath.Join(t.TempDir(), "node20")
 	writeNodeExecutable(t, node20, 20)
 	node24 := requireNode24(t)
-	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node16: node16, Node20: node20, Node24: node24}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node16: node16, Node20: node20, Node24: node24}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Outputs["lazy"] != "ready" {
 		t.Fatalf("lazy container action result = %#v, error = %v", result, err)
 	}
@@ -2329,7 +2329,7 @@ func TestRunJobContainerRunsDockerActionsAsSiblings(t *testing.T) {
 		job.Env = map[string]string{"WORKSPACE_CHILD": filepath.Join(workspace, "child")}
 		job.Actions = []plan.ActionLock{{ID: lockID, Source: "workspace", Path: "actions/docker", SourceDigest: digestTree(t, filepath.Join(workspace, "actions/docker"))}}
 		job.Outputs = map[string]string{"container": "${{ steps.docker.outputs.container }}"}
-		result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+		result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Stdout: &logs, Stderr: &logs}).RunJob(t.Context(), job, workspace)
 		if err != nil || result.Outputs["container"] != "ran" || result.Env["DOCKER_RUNTIME_SEEN"] != "true" || result.State["docker_state"] != "seen" || result.Summary != "docker action summary\n" || !strings.HasPrefix(result.Env["PATH"], "/fake/action/bin:") {
 			t.Fatalf("workspace Docker action result = %#v, error = %v", result, err)
 		}
@@ -2383,7 +2383,7 @@ func TestRunJobContainerRunsDockerActionsAsSiblings(t *testing.T) {
 		job.Container = &plan.Container{Image: "debian:bookworm-slim"}
 		job.Actions = []plan.ActionLock{remoteLifecycleLock(lockID, "docker", digest, nil)}
 		materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, ActionRoot: filepath.Join(remote, "docker"), SourceDigest: digest}}
-		result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Actions: materializer}).RunJob(context.Background(), job, workspace)
+		result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Actions: materializer}).RunJob(t.Context(), job, workspace)
 		if err != nil || result.Env["DOCKER_RUNTIME_SEEN"] != "true" {
 			t.Fatalf("remote Docker action result = %#v, error = %v", result, err)
 		}
@@ -2417,7 +2417,7 @@ func TestRunJobContainerSiblingDockerFailureCleansActionAndJobResources(t *testi
 	job.RequiredCapabilities = []string{"docker", "network"}
 	job.Container = &plan.Container{Image: "debian:bookworm-slim"}
 	job.Actions = []plan.ActionLock{{ID: lockID, Source: "workspace", Path: "actions/docker", SourceDigest: digestTree(t, filepath.Join(workspace, "actions/docker"))}}
-	_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(context.Background(), job, workspace)
+	_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(t.Context(), job, workspace)
 	if err == nil || !strings.Contains(err.Error(), "run Docker action") {
 		t.Fatalf("sibling Docker action failure = %v", err)
 	}
@@ -2436,7 +2436,7 @@ func TestRunJobContainerSiblingDockerFailureCleansActionAndJobResources(t *testi
 
 func TestRunDockerRejectsMismatchedJobContainerPaths(t *testing.T) {
 	r := Runner{jobContainer: &jobContainerBackend{workspace: "/owned/workspace", temp: "/owned/temp"}}
-	_, err := r.runDocker(context.Background(), newCommandProcessor(nil, nil), dockerAction{Workspace: "/other/workspace", runnerTemp: "/owned/temp"})
+	_, err := r.runDocker(t.Context(), newCommandProcessor(nil, nil), dockerAction{Workspace: "/other/workspace", runnerTemp: "/owned/temp"})
 	if err == nil || !strings.Contains(err.Error(), "must match the job container's owned host paths") {
 		t.Fatalf("mismatched sibling paths error = %v", err)
 	}
@@ -2465,7 +2465,7 @@ func TestRunJobContainerJavaScriptCancellationRunsPost(t *testing.T) {
 	job.Container = &plan.Container{Image: "debian:bookworm-slim"}
 	job.Env = map[string]string{"READY": ready, "POST_MARKER": postMarker}
 	job.Actions = []plan.ActionLock{{ID: lockID, Source: "workspace", Path: ".github/actions/cancel", SourceDigest: digestTree(t, filepath.Join(workspace, ".github/actions/cancel"))}}
-	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node24: requireNode24(t), InterruptGrace: 20 * time.Millisecond, TerminateGrace: 20 * time.Millisecond, CleanupTimeout: 15 * time.Second}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node24: requireNode24(t), InterruptGrace: 20 * time.Millisecond, TerminateGrace: 20 * time.Millisecond, CleanupTimeout: 15 * time.Second}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("cancelled container JavaScript result = %#v, error = %v", result, err)
 	}
@@ -2507,9 +2507,10 @@ func TestValidateDockerMountFileRequiresExistingRegularExecutableSafeAbsoluteFil
 }
 
 func liveContainerJob(t *testing.T, docker string, steps []plan.Step) JobResult {
+	t.Helper()
 	w := t.TempDir()
 	j := jobContainerPlan(t, w, steps)
-	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 45*time.Second)
 	defer cancel()
 	r, e := (Runner{Docker: docker, RuntimeExecutable: buildLiveContainerRuntime(t), InterruptGrace: 100 * time.Millisecond, TerminateGrace: 100 * time.Millisecond}).RunJob(ctx, j, w)
 	if e != nil {
@@ -2545,7 +2546,7 @@ func TestLiveJobContainerDefaultNonRootUser(t *testing.T) {
 	w := t.TempDir()
 	j := jobContainerPlan(t, w, []plan.Step{{ID: "u", Kind: "run", Shell: "sh", Command: `test "$(id -u)" != 0`}})
 	j.Container.Image = "nginxinc/nginx-unprivileged:stable-alpine"
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
 	defer cancel()
 	if _, err := (Runner{Docker: d, RuntimeExecutable: buildLiveContainerRuntime(t)}).RunJob(ctx, j, w); err != nil {
 		t.Fatal(err)
@@ -2589,7 +2590,7 @@ runs:
 		{ID: compositeID, Source: "workspace", Path: ".github/actions/composite", SourceDigest: digestTree(t, filepath.Join(workspace, ".github/actions/composite"))},
 	}
 	job.Outputs = map[string]string{"value": "${{ steps.js.outputs.value }}"}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
 	defer cancel()
 	result, err := (Runner{Docker: docker, RuntimeExecutable: buildLiveContainerRuntime(t), Node24: requireNode24(t)}).RunJob(ctx, job, workspace)
 	if err != nil || result.Outputs["value"] != "live" || result.Env["COMPOSITE_LIVE"] != "yes" {
@@ -2661,7 +2662,7 @@ func TestLiveCompiledContainerRuntime(t *testing.T) {
 	for _, artifact := range bundle.Plans {
 		job := artifact.Job
 		var logs bytes.Buffer
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
 		result, runErr := (Runner{Docker: docker, RuntimeExecutable: runtimeExecutable, Node24: node24, Stdout: &logs, Stderr: &logs}).RunJob(ctx, job, workspace)
 		cancel()
 		if runErr != nil || result.Conclusion != "success" {
@@ -2736,7 +2737,7 @@ func TestLiveAuthenticatedServiceRegistry(t *testing.T) {
 	job.Services = map[string]plan.ServiceContainer{"private": {Image: privateImage, Credentials: &plan.ContainerCredentials{Username: "service-user", Password: "service-password"}, Command: "sleep 300"}}
 	job.ServiceOrder = []string{"private"}
 	before := liveDockerOwnedResources(t, docker)
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)
 	defer cancel()
 	result, runErr := (Runner{Docker: docker}).RunJob(ctx, job, workspace)
 	if runErr != nil || result.Conclusion != "success" {
@@ -2749,7 +2750,7 @@ func TestLiveAuthenticatedServiceRegistry(t *testing.T) {
 
 func runLiveDocker(t *testing.T, docker string, args ...string) string {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
 	defer cancel()
 	command := exec.CommandContext(ctx, docker, args...)
 	var stderr bytes.Buffer
@@ -2793,7 +2794,7 @@ func TestLiveManifestContainerFixtures(t *testing.T) {
 		if len(bundle.Plans) != 1 || bundle.Plans[0].Job.Schema != plan.Schema || bundle.Plans[0].Job.Workflow.LogicalJobID != test.logicalJob || !slices.Equal(bundle.Plans[0].Authorization.DockerCapabilitySources, []string{test.provenance}) {
 			t.Fatalf("compiled %s boundary = %#v", test.name, bundle.Plans)
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+		ctx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)
 		result, runErr := (Runner{Docker: docker, RuntimeExecutable: runtimeExecutable}).RunJob(ctx, bundle.Plans[0].Job, workspace)
 		cancel()
 		if runErr != nil || result.Conclusion != "success" {
@@ -2827,7 +2828,7 @@ func TestLiveServiceDifferentialFixture(t *testing.T) {
 		t.Fatalf("differential service plans = %#v", bundle.Plans)
 	}
 	before := liveDockerOwnedResources(t, docker)
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
 	defer cancel()
 	result, runErr := (Runner{Docker: docker}).RunJob(ctx, bundle.Plans[0].Job, workspace)
 	if runErr != nil || result.Conclusion != "success" || result.Outputs["observation"] != "selection,context,ports,command-entrypoint,health,volume,postgres,redis" {
@@ -2869,7 +2870,7 @@ CMD ["sh", "-c", "echo container-runtime-health-diagnostic >&2; sleep 300"]
 	job.Services = map[string]plan.ServiceContainer{"unhealthy": {Image: image}}
 	job.ServiceOrder = []string{"unhealthy"}
 	var logs bytes.Buffer
-	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 45*time.Second)
 	defer cancel()
 	_, err := (Runner{Docker: dockerWrapper, Stdout: &logs, Stderr: &logs}).RunJob(ctx, job, workspace)
 	if err == nil || !strings.Contains(err.Error(), `service "unhealthy" failed readiness with status "unhealthy"`) {
@@ -2892,7 +2893,7 @@ func liveDockerOwnedResources(t *testing.T, docker string) []string {
 	}
 	var resources []string
 	for _, query := range queries {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 		output, err := exec.CommandContext(ctx, docker, query.args...).CombinedOutput()
 		cancel()
 		if err != nil {

--- a/internal/runtime/download_artifact.go
+++ b/internal/runtime/download_artifact.go
@@ -455,7 +455,7 @@ func reserveDownloadMemberPath(root *os.Root, name string) error {
 }
 
 func downloadPathLess(left, right string) bool {
-	for i := 0; i < min(len(left), len(right)); i++ {
+	for i := range min(len(left), len(right)) {
 		if left[i] == right[i] {
 			continue
 		}
@@ -631,7 +631,7 @@ func preflightZIPExtraFields(fields []byte) error {
 		if fieldSize > len(fields)-4 {
 			return fmt.Errorf("artifact ZIP extra field is malformed")
 		}
-		if binary.LittleEndian.Uint16(fields[:]) == 0x0001 {
+		if binary.LittleEndian.Uint16(fields) == 0x0001 {
 			return fmt.Errorf("ZIP64 artifact member is unsupported")
 		}
 		fields = fields[4+fieldSize:]

--- a/internal/runtime/download_artifact_test.go
+++ b/internal/runtime/download_artifact_test.go
@@ -80,6 +80,7 @@ func (s *downloadStore) DownloadArtifact(ctx context.Context, path, destination,
 }
 
 func testDownloadZIP(t *testing.T, names ...string) (string, int64, string) {
+	t.Helper()
 	return testDownloadZIPPayload(t, "payload", names...)
 }
 
@@ -143,7 +144,7 @@ func TestDownloadArtifactExactNeedAndDirectExtraction(t *testing.T) {
 	workspace := t.TempDir()
 	processor := newCommandProcessor(io.Discard, io.Discard)
 	need := plan.NeedArtifact{Name: "payload", ID: "42", Path: "buildkite-gha/v1/artifacts/" + strings.Repeat("a", 64) + ".zip", Digest: digest, Size: size, FileCount: 1, Producer: plan.NeedProducer{JobID: "11111111-1111-4111-8111-111111111111"}}
-	result, err := (Runner{Artifacts: store}).runDownloadArtifact(context.Background(), processor, workspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{need}}}, actionintegration.DownloadArtifactCommit, map[string]string{"name": "payload", "path": "out"})
+	result, err := (Runner{Artifacts: store}).runDownloadArtifact(t.Context(), processor, workspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{need}}}, actionintegration.DownloadArtifactCommit, map[string]string{"name": "payload", "path": "out"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,16 +158,16 @@ func TestDownloadArtifactExactNeedAndDirectExtraction(t *testing.T) {
 	if result.Outputs["download-path"] != want {
 		t.Fatalf("download-path = %q", result.Outputs["download-path"])
 	}
-	if _, err := (Runner{Artifacts: store}).runDownloadArtifact(context.Background(), processor, workspace, map[string]plan.Need{}, actionintegration.DownloadArtifactCommit, map[string]string{"name": "payload"}); err == nil || strings.Contains(err.Error(), "payload") {
+	if _, err := (Runner{Artifacts: store}).runDownloadArtifact(t.Context(), processor, workspace, map[string]plan.Need{}, actionintegration.DownloadArtifactCommit, map[string]string{"name": "payload"}); err == nil || strings.Contains(err.Error(), "payload") {
 		t.Fatal("missing artifact accepted")
 	}
-	if _, err := (Runner{Artifacts: store}).runDownloadArtifact(context.Background(), processor, workspace, map[string]plan.Need{"a": {Artifacts: []plan.NeedArtifact{need}}, "b": {Artifacts: []plan.NeedArtifact{need}}}, actionintegration.DownloadArtifactCommit, map[string]string{"name": "payload"}); err == nil || strings.Contains(err.Error(), "payload") {
+	if _, err := (Runner{Artifacts: store}).runDownloadArtifact(t.Context(), processor, workspace, map[string]plan.Need{"a": {Artifacts: []plan.NeedArtifact{need}}, "b": {Artifacts: []plan.NeedArtifact{need}}}, actionintegration.DownloadArtifactCommit, map[string]string{"name": "payload"}); err == nil || strings.Contains(err.Error(), "payload") {
 		t.Fatal("ambiguous artifact accepted")
 	}
-	if _, err := (Runner{Artifacts: store}).runDownloadArtifact(context.Background(), processor, workspace, map[string]plan.Need{"matrix": {Artifacts: []plan.NeedArtifact{need, need}}}, actionintegration.DownloadArtifactCommit, map[string]string{"name": "payload"}); err == nil {
+	if _, err := (Runner{Artifacts: store}).runDownloadArtifact(t.Context(), processor, workspace, map[string]plan.Need{"matrix": {Artifacts: []plan.NeedArtifact{need, need}}}, actionintegration.DownloadArtifactCommit, map[string]string{"name": "payload"}); err == nil {
 		t.Fatal("duplicate matrix artifact name accepted")
 	}
-	if _, err := (Runner{Artifacts: store}).runDownloadArtifact(context.Background(), processor, workspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{need}}}, actionintegration.DownloadArtifactCommit, map[string]string{"name": "Payload"}); err == nil || strings.Contains(err.Error(), "Payload") {
+	if _, err := (Runner{Artifacts: store}).runDownloadArtifact(t.Context(), processor, workspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{need}}}, actionintegration.DownloadArtifactCommit, map[string]string{"name": "Payload"}); err == nil || strings.Contains(err.Error(), "Payload") {
 		t.Fatal("non-exact artifact name accepted")
 	}
 }
@@ -186,7 +187,7 @@ func TestDownloadArtifactSupportsAuditedCommitsAndNonASCIIExactName(t *testing.T
 				inputs["skip-decompress"] = "False"
 				inputs["digest-mismatch"] = "error"
 			}
-			result, err := (Runner{Artifacts: &downloadStore{archive: archive}}).runDownloadArtifact(context.Background(), newCommandProcessor(io.Discard, io.Discard), workspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{artifact}}}, commit, inputs)
+			result, err := (Runner{Artifacts: &downloadStore{archive: archive}}).runDownloadArtifact(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{artifact}}}, commit, inputs)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -209,7 +210,7 @@ func TestNativeArtifactRoundTripTrimsNameAndAcceptsHighCompression(t *testing.T)
 	}
 	uploader := &captureArtifactUploader{}
 	uploadRunner := Runner{Artifacts: uploader, artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
-	upload, err := uploadRunner.runUploadArtifact(context.Background(), newCommandProcessor(io.Discard, io.Discard), uploadWorkspace, map[string]string{"name": " payload ", "path": "zeros.bin"})
+	upload, err := uploadRunner.runUploadArtifact(t.Context(), newCommandProcessor(io.Discard, io.Discard), uploadWorkspace, map[string]string{"name": " payload ", "path": "zeros.bin"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -227,7 +228,7 @@ func TestNativeArtifactRoundTripTrimsNameAndAcceptsHighCompression(t *testing.T)
 		Producer: plan.NeedProducer{JobID: "11111111-1111-4111-8111-111111111111"},
 	}
 	downloadWorkspace := t.TempDir()
-	_, err = (Runner{Artifacts: &downloadStore{archive: archive}}).runDownloadArtifact(context.Background(), newCommandProcessor(io.Discard, io.Discard), downloadWorkspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{artifact}}}, actionintegration.DownloadArtifactV801Commit, map[string]string{"name": " payload "})
+	_, err = (Runner{Artifacts: &downloadStore{archive: archive}}).runDownloadArtifact(t.Context(), newCommandProcessor(io.Discard, io.Discard), downloadWorkspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{artifact}}}, actionintegration.DownloadArtifactV801Commit, map[string]string{"name": " payload "})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -250,7 +251,7 @@ func TestDownloadArtifactPatternMergesVerifiedDirectNeeds(t *testing.T) {
 	store := &downloadStore{archives: map[string]string{firstPath: firstArchive, secondPath: secondArchive}}
 	workspace := t.TempDir()
 	result, err := (Runner{Artifacts: store}).runDownloadArtifact(
-		context.Background(), newCommandProcessor(io.Discard, io.Discard), workspace,
+		t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace,
 		map[string]plan.Need{"test": {Artifacts: []plan.NeedArtifact{second, ignored, first}}},
 		actionintegration.DownloadArtifactV5Commit,
 		map[string]string{"pattern": "junit-xml-25-*", "path": "junit-xml", "merge-multiple": "true"},
@@ -283,7 +284,7 @@ func TestDownloadArtifactMultiPrefixDeduplicatesAndOrdersVerifiedProducers(t *te
 	workspace := t.TempDir()
 
 	_, err := (Runner{Artifacts: store}).runDownloadArtifact(
-		context.Background(), newCommandProcessor(io.Discard, io.Discard), workspace,
+		t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace,
 		map[string]plan.Need{"backend": {Artifacts: []plan.NeedArtifact{product}}, "products": {Artifacts: []plan.NeedArtifact{backend}}},
 		actionintegration.DownloadArtifactV5Commit,
 		map[string]string{"pattern": "{junit-results,junit-results-backend,product-junit-results}-*", "path": "junit", "merge-multiple": "true"},
@@ -308,7 +309,7 @@ func TestDownloadArtifactPatternRejectsTooManyMatchesBeforeDownload(t *testing.T
 	}
 	store := &downloadStore{}
 	_, err := (Runner{Artifacts: store}).runDownloadArtifact(
-		context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(),
+		t.Context(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(),
 		map[string]plan.Need{"producer": {Artifacts: artifacts}}, actionintegration.DownloadArtifactV5Commit,
 		map[string]string{"pattern": "{backend,product}-*", "merge-multiple": "true"},
 	)
@@ -333,7 +334,7 @@ func TestDownloadArtifactPatternStagesCompleteMergeBeforeDestinationMutation(t *
 	t.Run("later artifact name wins overlapping member", func(t *testing.T) {
 		workspace := t.TempDir()
 		store := &downloadStore{archives: map[string]string{firstPath: firstArchive, secondPath: secondArchive}}
-		if _, err := (Runner{Artifacts: store}).runDownloadArtifact(context.Background(), newCommandProcessor(io.Discard, io.Discard), workspace, needs, actionintegration.DownloadArtifactV5Commit, inputs); err != nil {
+		if _, err := (Runner{Artifacts: store}).runDownloadArtifact(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, needs, actionintegration.DownloadArtifactV5Commit, inputs); err != nil {
 			t.Fatal(err)
 		}
 		if got, err := os.ReadFile(filepath.Join(workspace, "merged", "result.xml")); err != nil || string(got) != "second" {
@@ -347,7 +348,7 @@ func TestDownloadArtifactPatternStagesCompleteMergeBeforeDestinationMutation(t *
 		invalid.Digest = "sha256:" + strings.Repeat("0", 64)
 		store := &downloadStore{archives: map[string]string{firstPath: firstArchive, secondPath: secondArchive}}
 		_, err := (Runner{Artifacts: store}).runDownloadArtifact(
-			context.Background(), newCommandProcessor(io.Discard, io.Discard), workspace,
+			t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace,
 			map[string]plan.Need{"test": {Artifacts: []plan.NeedArtifact{invalid, first}}},
 			actionintegration.DownloadArtifactV5Commit, inputs,
 		)
@@ -372,7 +373,7 @@ func TestDownloadArtifactPatternRejectsDuplicateNamesAcrossNeeds(t *testing.T) {
 	store := &downloadStore{archives: map[string]string{firstPath: archive, secondPath: archive}}
 
 	_, err := (Runner{Artifacts: store}).runDownloadArtifact(
-		context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(),
+		t.Context(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(),
 		map[string]plan.Need{"first": {Artifacts: []plan.NeedArtifact{first}}, "second": {Artifacts: []plan.NeedArtifact{second}}},
 		actionintegration.DownloadArtifactV5Commit,
 		map[string]string{"pattern": "*", "merge-multiple": "true"},
@@ -389,7 +390,7 @@ func TestDownloadArtifactRejectsMaskedNameWithoutDisclosure(t *testing.T) {
 	const maskedName = "runtime-secret-artifact"
 	processor := newCommandProcessor(io.Discard, io.Discard)
 	processor.addMask(maskedName)
-	_, err := (Runner{}).runDownloadArtifact(context.Background(), processor, t.TempDir(), nil, actionintegration.DownloadArtifactCommit, map[string]string{"name": maskedName})
+	_, err := (Runner{}).runDownloadArtifact(t.Context(), processor, t.TempDir(), nil, actionintegration.DownloadArtifactCommit, map[string]string{"name": maskedName})
 	if err == nil || strings.Contains(err.Error(), maskedName) || !strings.Contains(err.Error(), "registered mask") {
 		t.Fatalf("masked artifact lookup error = %v", err)
 	}
@@ -409,7 +410,7 @@ func TestDownloadArtifactScrubsMaskedMemberFromDestinationErrors(t *testing.T) {
 		Digest: digest, Size: size, FileCount: 1,
 		Producer: plan.NeedProducer{JobID: "11111111-1111-4111-8111-111111111111"},
 	}
-	_, err := (Runner{Artifacts: &downloadStore{archive: archive}}).runDownloadArtifact(context.Background(), processor, workspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{artifact}}}, actionintegration.DownloadArtifactCommit, map[string]string{"name": "payload"})
+	_, err := (Runner{Artifacts: &downloadStore{archive: archive}}).runDownloadArtifact(t.Context(), processor, workspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{artifact}}}, actionintegration.DownloadArtifactCommit, map[string]string{"name": "payload"})
 	if err == nil || strings.Contains(err.Error(), maskedMember) || !strings.Contains(err.Error(), "***") {
 		t.Fatalf("masked destination error = %v", err)
 	}
@@ -429,7 +430,7 @@ func TestDownloadArtifactScrubsQuotedMaskedDestinationFromErrors(t *testing.T) {
 		Digest: digest, Size: size, FileCount: 1,
 		Producer: plan.NeedProducer{JobID: "11111111-1111-4111-8111-111111111111"},
 	}
-	_, err := (Runner{Artifacts: &downloadStore{archive: archive}}).runDownloadArtifact(context.Background(), processor, workspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{artifact}}}, actionintegration.DownloadArtifactCommit, map[string]string{"name": "payload", "path": maskedDestination})
+	_, err := (Runner{Artifacts: &downloadStore{archive: archive}}).runDownloadArtifact(t.Context(), processor, workspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{artifact}}}, actionintegration.DownloadArtifactCommit, map[string]string{"name": "payload", "path": maskedDestination})
 	if err == nil || strings.Contains(err.Error(), maskedDestination) || strings.Contains(err.Error(), `runtime\"secret`) || !strings.Contains(err.Error(), "***") {
 		t.Fatalf("quoted masked destination error = %v", err)
 	}
@@ -439,20 +440,20 @@ func TestDownloadArtifactRejectsUnsafeZIPAndDigest(t *testing.T) {
 	for _, name := range []string{"../escape", "/absolute", "dir/../escape", "a\\b", "C:/drive", `\\server\share`} {
 		t.Run(name, func(t *testing.T) {
 			archive, _, _ := testDownloadZIP(t, name)
-			if err := extractDownloadZIP(context.Background(), archive, t.TempDir(), ".", 1); err == nil {
+			if err := extractDownloadZIP(t.Context(), archive, t.TempDir(), ".", 1); err == nil {
 				t.Fatal("unsafe member accepted")
 			}
 		})
 	}
 	archive, _, _ := testDownloadZIP(t, "A.txt", "a.txt")
-	if err := extractDownloadZIP(context.Background(), archive, t.TempDir(), ".", 2); err == nil || !strings.Contains(err.Error(), "duplicate") {
+	if err := extractDownloadZIP(t.Context(), archive, t.TempDir(), ".", 2); err == nil || !strings.Contains(err.Error(), "duplicate") {
 		t.Fatalf("case-folding collision error = %v", err)
 	}
 	archive, size, _ := testDownloadZIP(t, "ok")
-	if err := verifyDownloadDigest(context.Background(), archive, "sha256:"+strings.Repeat("0", 64), size); err == nil {
+	if err := verifyDownloadDigest(t.Context(), archive, "sha256:"+strings.Repeat("0", 64), size); err == nil {
 		t.Fatal("bad digest accepted")
 	}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 	if err := verifyDownloadDigest(ctx, archive, "", size); err == nil {
 		t.Fatal("cancellation ignored")
@@ -470,6 +471,7 @@ func TestDownloadArtifactRejectsRawCorruptAndDuplicateArchivesWithoutDestination
 		fileCount int
 	}{
 		{name: "raw", archive: func(t *testing.T) string {
+			t.Helper()
 			name := filepath.Join(t.TempDir(), "raw")
 			if err := os.WriteFile(name, []byte("not a ZIP"), 0o644); err != nil {
 				t.Fatal(err)
@@ -477,22 +479,27 @@ func TestDownloadArtifactRejectsRawCorruptAndDuplicateArchivesWithoutDestination
 			return name
 		}, fileCount: 1},
 		{name: "duplicate", archive: func(t *testing.T) string {
+			t.Helper()
 			name, _, _ := testDownloadZIP(t, "same", "same")
 			return name
 		}, fileCount: 2},
 		{name: "file before child", archive: func(t *testing.T) string {
+			t.Helper()
 			name, _, _ := testDownloadZIP(t, "same", "same/child")
 			return name
 		}, fileCount: 2},
 		{name: "child before file", archive: func(t *testing.T) string {
+			t.Helper()
 			name, _, _ := testDownloadZIP(t, "same/child", "same")
 			return name
 		}, fileCount: 2},
 		{name: "lexically separated file and child", archive: func(t *testing.T) string {
+			t.Helper()
 			name, _, _ := testDownloadZIP(t, "same", "same.", "same/child")
 			return name
 		}, fileCount: 3},
 		{name: "corrupt member", archive: func(t *testing.T) string {
+			t.Helper()
 			name, _, _ := testDownloadZIP(t, "first", "second")
 			zr, err := zip.OpenReader(name)
 			if err != nil {
@@ -521,7 +528,7 @@ func TestDownloadArtifactRejectsRawCorruptAndDuplicateArchivesWithoutDestination
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			destination := filepath.Join(workspace, strings.ReplaceAll(test.name, " ", "-"))
-			if err := extractDownloadZIP(context.Background(), test.archive(t), workspace, filepath.Base(destination), test.fileCount); err == nil {
+			if err := extractDownloadZIP(t.Context(), test.archive(t), workspace, filepath.Base(destination), test.fileCount); err == nil {
 				t.Fatal("unsafe archive accepted")
 			}
 			if _, err := os.Lstat(destination); !os.IsNotExist(err) {
@@ -951,7 +958,7 @@ func TestDownloadArtifactExtractionUsesVerifiedArchiveDescriptor(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = f.Close() }()
-	if err := verifyDownloadDigestFile(context.Background(), f, digest, size); err != nil {
+	if err := verifyDownloadDigestFile(t.Context(), f, digest, size); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.Rename(name, name+".verified"); err != nil {
@@ -965,7 +972,7 @@ func TestDownloadArtifactExtractionUsesVerifiedArchiveDescriptor(t *testing.T) {
 		t.Fatalf("descriptor-pinned expanded size = %d, %v", expanded, err)
 	}
 	workspace := t.TempDir()
-	if err := extractDownloadZIPFile(context.Background(), f, size, workspace, ".", 1); err != nil {
+	if err := extractDownloadZIPFile(t.Context(), f, size, workspace, ".", 1); err != nil {
 		t.Fatal(err)
 	}
 	if got, err := os.ReadFile(filepath.Join(workspace, "result.txt")); err != nil || string(got) != "payload" {
@@ -1028,7 +1035,7 @@ func TestDownloadArtifactInstallUsesPinnedDestinationDescriptor(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(staging, "result.txt"), []byte("poison!"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := installDownloadMembersAt(context.Background(), stagingRoot, destinationRoot, []downloadMember{{info: stagedInfo, name: "result.txt", staged: "result.txt", size: 7}}); err != nil {
+	if err := installDownloadMembersAt(t.Context(), stagingRoot, destinationRoot, []downloadMember{{info: stagedInfo, name: "result.txt", staged: "result.txt", size: 7}}); err != nil {
 		t.Fatal(err)
 	}
 	if got, err := os.ReadFile(filepath.Join(moved, "result.txt")); err != nil || string(got) != "payload" {
@@ -1064,7 +1071,7 @@ func TestDownloadArtifactInstallRejectsFIFOStagingReplacementWithoutBlocking(t *
 	defer func() { _ = destinationRoot.Close() }()
 	done := make(chan error, 1)
 	go func() {
-		done <- installDownloadMembersAt(context.Background(), stagingRoot, destinationRoot, []downloadMember{{name: "payload", staged: "payload", size: 7}})
+		done <- installDownloadMembersAt(t.Context(), stagingRoot, destinationRoot, []downloadMember{{name: "payload", staged: "payload", size: 7}})
 	}()
 	select {
 	case err := <-done:
@@ -1102,7 +1109,7 @@ func TestDownloadArtifactCancellationCleansPartialAgentDownload(t *testing.T) {
 		Digest: digest, Size: size, FileCount: 1,
 		Producer: plan.NeedProducer{JobID: "11111111-1111-4111-8111-111111111111"},
 	}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	store := &downloadStore{archive: archive, download: func(ctx context.Context, destination string) error {
 		if err := os.WriteFile(filepath.Join(destination, "partial"), []byte("partial"), 0o644); err != nil {
 			return err
@@ -1134,7 +1141,7 @@ func TestDownloadArtifactRejectsManifestAndDownloadMismatch(t *testing.T) {
 			artifact := base
 			store := &downloadStore{archive: archive}
 			test.alter(&artifact, store)
-			_, err := (Runner{Artifacts: store}).runDownloadArtifact(context.Background(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{artifact}}}, actionintegration.DownloadArtifactCommit, map[string]string{"name": "payload"})
+			_, err := (Runner{Artifacts: store}).runDownloadArtifact(t.Context(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{artifact}}}, actionintegration.DownloadArtifactCommit, map[string]string{"name": "payload"})
 			if err == nil {
 				t.Fatal("mismatched download accepted")
 			}
@@ -1152,7 +1159,7 @@ func TestDownloadArtifactDestinationCollisions(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(regular, "nested", "result.txt"), []byte("old"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := extractDownloadZIP(context.Background(), archive, workspace, "regular", 1); err != nil {
+	if err := extractDownloadZIP(t.Context(), archive, workspace, "regular", 1); err != nil {
 		t.Fatalf("replace regular file: %v", err)
 	}
 	if got, err := os.ReadFile(filepath.Join(regular, "nested", "result.txt")); err != nil || string(got) != "payload" {
@@ -1177,7 +1184,7 @@ func TestDownloadArtifactDestinationCollisions(t *testing.T) {
 			} else if err != nil {
 				t.Fatal(err)
 			}
-			if err := extractDownloadZIP(context.Background(), archive, workspace, test.name, 1); err == nil {
+			if err := extractDownloadZIP(t.Context(), archive, workspace, test.name, 1); err == nil {
 				t.Fatal("non-regular destination accepted")
 			}
 		})
@@ -1190,7 +1197,7 @@ func TestDownloadArtifactRejectsDestinationSymlinkEscape(t *testing.T) {
 	if err := os.Symlink(outside, filepath.Join(workspace, "linked")); err != nil {
 		t.Fatal(err)
 	}
-	if err := extractDownloadZIP(context.Background(), archive, workspace, "linked/out", 1); err == nil {
+	if err := extractDownloadZIP(t.Context(), archive, workspace, "linked/out", 1); err == nil {
 		t.Fatal("symlinked destination accepted")
 	}
 	if _, err := os.Stat(filepath.Join(outside, "out", "result.txt")); !os.IsNotExist(err) {
@@ -1225,7 +1232,7 @@ func TestDownloadArtifactRejectsUnsupportedMemberAndExpandedSize(t *testing.T) {
 			if err := errors.Join(zw.Close(), out.Close()); err != nil {
 				t.Fatal(err)
 			}
-			if err := extractDownloadZIP(context.Background(), filename, t.TempDir(), ".", 1); err == nil {
+			if err := extractDownloadZIP(t.Context(), filename, t.TempDir(), ".", 1); err == nil {
 				t.Fatal("unsupported ZIP member accepted")
 			}
 		})
@@ -1267,7 +1274,7 @@ func TestDownloadArtifactAdapterBypassesVerifiedUpstreamLifecycle(t *testing.T) 
 	job.Needs = map[string]plan.Need{"producer": {Result: "success", Artifacts: []plan.NeedArtifact{artifact}}}
 	store := &downloadStore{archive: archive}
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, ActionRoot: remote, SourceDigest: sourceDigest}}
-	result, err := (Runner{Actions: materializer, Artifacts: store}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Actions: materializer, Artifacts: store}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" || result.Outputs["download_path"] != filepath.Join(workspace, "downloaded") {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -1279,7 +1286,7 @@ func TestDownloadArtifactAdapterBypassesVerifiedUpstreamLifecycle(t *testing.T) 
 	}
 
 	job.Actions[0].Commit = strings.Repeat("b", 40)
-	if _, err := (Runner{Actions: materializer, Artifacts: store}).RunJob(context.Background(), job, workspace); err == nil || !strings.Contains(err.Error(), actionintegration.DownloadArtifactCommit) {
+	if _, err := (Runner{Actions: materializer, Artifacts: store}).RunJob(t.Context(), job, workspace); err == nil || !strings.Contains(err.Error(), actionintegration.DownloadArtifactCommit) {
 		t.Fatalf("unsupported runtime commit error = %v", err)
 	}
 }
@@ -1322,7 +1329,7 @@ func TestDownloadArtifactMatrixConsumersEvaluateNameAndNormalizeRootPath(t *test
 			}}
 			job.Needs = map[string]plan.Need{"producer": {Result: "success", Artifacts: []plan.NeedArtifact{artifact}}}
 
-			result, err := (Runner{Actions: materializer, Artifacts: store}).RunJob(context.Background(), job, workspace)
+			result, err := (Runner{Actions: materializer, Artifacts: store}).RunJob(t.Context(), job, workspace)
 			wantPath, absErr := filepath.Abs(workspace)
 			if absErr != nil {
 				t.Fatal(absErr)

--- a/internal/runtime/github_token_service_test.go
+++ b/internal/runtime/github_token_service_test.go
@@ -37,17 +37,17 @@ func TestAgentGitHubTokensMintsExactWorkflowPermissions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	token, err := provider.WorkflowToken(context.Background(), "buildkite/buildkite-gha", "ci.yml", map[string]string{"pull_requests": "write", "contents": "read"})
+	token, err := provider.WorkflowToken(t.Context(), "buildkite/buildkite-gha", "ci.yml", map[string]string{"pull_requests": "write", "contents": "read"})
 	if err != nil || token != statelessToken {
 		t.Fatalf("WorkflowToken() = %q, %v", token, err)
 	}
 	for _, permissions := range []map[string]string{nil, {}, {"contents": "admin"}, {"administration": "write"}, {"models": "write"}} {
-		if _, err := provider.WorkflowToken(context.Background(), "buildkite/buildkite-gha", "ci.yml", permissions); err == nil {
+		if _, err := provider.WorkflowToken(t.Context(), "buildkite/buildkite-gha", "ci.yml", permissions); err == nil {
 			t.Fatalf("WorkflowToken(%#v) succeeded", permissions)
 		}
 	}
 	for _, permissions := range []map[string]string{{"models": "read"}, {"repository_projects": "read"}} {
-		if _, err := provider.WorkflowToken(context.Background(), "buildkite/buildkite-gha", "ci.yml", permissions); err == nil {
+		if _, err := provider.WorkflowToken(t.Context(), "buildkite/buildkite-gha", "ci.yml", permissions); err == nil {
 			t.Fatalf("WorkflowToken(%#v) succeeded", permissions)
 		}
 	}
@@ -75,7 +75,7 @@ func TestAgentGitHubTokensMintsExactReadAllWorkflowPermissions(t *testing.T) {
 		"deployments": "read", "discussions": "read", "issues": "read", "packages": "read", "pages": "read",
 		"pull_requests": "read", "security_events": "read", "statuses": "read",
 	}
-	if token, err := provider.WorkflowToken(context.Background(), "buildkite/buildkite-gha", "ci.yml", permissions); err != nil || token != "ghs_read_all" {
+	if token, err := provider.WorkflowToken(t.Context(), "buildkite/buildkite-gha", "ci.yml", permissions); err != nil || token != "ghs_read_all" {
 		t.Fatalf("WorkflowToken(read-all) = %q, %v", token, err)
 	}
 }
@@ -102,7 +102,7 @@ func TestAgentGitHubTokensMintsActionSourceTokenWithRepositoryOnly(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if token, err := provider.ActionSourceToken(context.Background(), "actions/checkout"); err != nil || token != "ghs_action_source" {
+	if token, err := provider.ActionSourceToken(t.Context(), "actions/checkout"); err != nil || token != "ghs_action_source" {
 		t.Fatalf("ActionSourceToken() = %q, %v", token, err)
 	}
 }
@@ -116,7 +116,7 @@ func TestAgentGitHubTokensRejectsInvalidWorkflowBeforeNetwork(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, workflow := range []string{"", "../ci.yml", "nested/ci.yml", ".ci.yml", "ci.json"} {
-		if _, err := provider.WorkflowToken(context.Background(), "buildkite/buildkite-gha", workflow, map[string]string{"contents": "read"}); err == nil {
+		if _, err := provider.WorkflowToken(t.Context(), "buildkite/buildkite-gha", workflow, map[string]string{"contents": "read"}); err == nil {
 			t.Errorf("WorkflowToken(%q) succeeded", workflow)
 		}
 	}
@@ -167,10 +167,10 @@ func TestAgentGitHubTokensRejectsUnsafeConfigurationAndRepository(t *testing.T) 
 		t.Fatal(err)
 	}
 	for _, repository := range []string{"", "other", "../other/repo", "owner/..", "owner/repo/extra", "owner/repo?permission=write"} {
-		if _, err := provider.WorkflowToken(context.Background(), repository, "ci.yml", map[string]string{"contents": "read"}); err == nil {
+		if _, err := provider.WorkflowToken(t.Context(), repository, "ci.yml", map[string]string{"contents": "read"}); err == nil {
 			t.Fatalf("WorkflowToken(%q) succeeded", repository)
 		}
-		if _, err := provider.ActionSourceToken(context.Background(), repository); err == nil {
+		if _, err := provider.ActionSourceToken(t.Context(), repository); err == nil {
 			t.Fatalf("ActionSourceToken(%q) succeeded", repository)
 		}
 	}
@@ -212,7 +212,7 @@ func TestAgentGitHubTokensRejectsRedirectsAndUntrustedResponses(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, err = provider.WorkflowToken(context.Background(), "buildkite/buildkite-gha", "ci.yml", map[string]string{"contents": "read"})
+			_, err = provider.WorkflowToken(t.Context(), "buildkite/buildkite-gha", "ci.yml", map[string]string{"contents": "read"})
 			if err == nil || !strings.Contains(err.Error(), test.want) || strings.Contains(err.Error(), secret) {
 				t.Fatalf("WorkflowToken() error = %v, want %q without response data", err, test.want)
 			}
@@ -233,7 +233,7 @@ func TestAgentGitHubTokensRejectsRedirectsAndUntrustedResponses(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := provider.WorkflowToken(context.Background(), "buildkite/buildkite-gha", "ci.yml", map[string]string{"contents": "read"}); err == nil || !strings.Contains(err.Error(), "HTTP 307") || redirected {
+	if _, err := provider.WorkflowToken(t.Context(), "buildkite/buildkite-gha", "ci.yml", map[string]string{"contents": "read"}); err == nil || !strings.Contains(err.Error(), "HTTP 307") || redirected {
 		t.Fatalf("redirect WorkflowToken() error/redirected = %v / %v", err, redirected)
 	}
 }
@@ -282,7 +282,7 @@ func TestAgentGitHubTokensDisabledWorkflowTokenGuidance(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, err = provider.WorkflowToken(context.Background(), "buildkite/buildkite-gha", "ci.yml", map[string]string{"contents": "read"})
+			_, err = provider.WorkflowToken(t.Context(), "buildkite/buildkite-gha", "ci.yml", map[string]string{"contents": "read"})
 			if err == nil || err.Error() != test.want {
 				t.Fatalf("WorkflowToken() error = %q, want %q", err, test.want)
 			}
@@ -291,7 +291,7 @@ func TestAgentGitHubTokensDisabledWorkflowTokenGuidance(t *testing.T) {
 }
 
 func TestAgentGitHubTokensHonorsCancellation(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 	provider, err := NewAgentGitHubTokens(AgentGitHubTokenConfig{Endpoint: "https://agent.invalid/v3", JobID: testCacheJobID, JobToken: "job-token"})
 	if err != nil {
@@ -306,7 +306,7 @@ func TestAgentGitHubTokensAuthenticateUnrelatedPublicRepository(t *testing.T) {
 	if os.Getenv("BUILDKITE_GHA_LIVE_REQUIRED") != "1" {
 		t.Skip("set BUILDKITE_GHA_LIVE_REQUIRED=1 to verify job-scoped public GitHub access")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 	provider, err := NewAgentGitHubTokens(AgentGitHubTokenConfig{
 		Endpoint: os.Getenv("BUILDKITE_AGENT_ENDPOINT"),

--- a/internal/runtime/hash_files_test.go
+++ b/internal/runtime/hash_files_test.go
@@ -51,7 +51,7 @@ func TestHashWorkspaceFilesConformance(t *testing.T) {
 		{name: "spaced double negation", patterns: []string{"!! nested/c.txt"}, contents: []string{"charlie"}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := hashWorkspaceFiles(context.Background(), workspace, test.patterns)
+			got, err := hashWorkspaceFiles(t.Context(), workspace, test.patterns)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -65,12 +65,12 @@ func TestHashWorkspaceFilesConformance(t *testing.T) {
 		})
 	}
 
-	first, err := hashWorkspaceFiles(context.Background(), workspace, []string{"**"})
+	first, err := hashWorkspaceFiles(t.Context(), workspace, []string{"**"})
 	if err != nil {
 		t.Fatal(err)
 	}
 	for range 5 {
-		got, err := hashWorkspaceFiles(context.Background(), workspace, []string{"**"})
+		got, err := hashWorkspaceFiles(t.Context(), workspace, []string{"**"})
 		if err != nil || got != first {
 			t.Fatalf("repeated hash = %q, %v; want %q", got, err, first)
 		}
@@ -80,7 +80,7 @@ func TestHashWorkspaceFilesConformance(t *testing.T) {
 func TestHashWorkspaceFilesDirectoryPatternDoesNotMatchRegularFile(t *testing.T) {
 	workspace := t.TempDir()
 	writeFixtureFile(t, workspace, "plain", "regular")
-	if got, err := hashWorkspaceFiles(context.Background(), workspace, []string{"plain/"}); err != nil || got != "" {
+	if got, err := hashWorkspaceFiles(t.Context(), workspace, []string{"plain/"}); err != nil || got != "" {
 		t.Fatalf("directory-only regular file hash = %q, %v", got, err)
 	}
 }
@@ -105,13 +105,13 @@ func TestHashWorkspaceFilesRejectsEscapesAndUnsafeFiles(t *testing.T) {
 	writeFixtureFile(t, outside, "outside.txt", "outside")
 	for _, pattern := range []string{"/etc/passwd", "../outside", "safe/../../outside", `C:\outside`, "./safe/../outside"} {
 		t.Run(pattern, func(t *testing.T) {
-			if _, err := hashWorkspaceFiles(context.Background(), workspace, []string{pattern}); err == nil || !strings.Contains(err.Error(), "hashFiles pattern") {
+			if _, err := hashWorkspaceFiles(t.Context(), workspace, []string{pattern}); err == nil || !strings.Contains(err.Error(), "hashFiles pattern") {
 				t.Fatalf("escape pattern error = %v", err)
 			}
 		})
 	}
 	for _, pattern := range []string{"safe\n", "safe\t", "safe\x1b", "safe\x7f"} {
-		if _, err := hashWorkspaceFiles(context.Background(), workspace, []string{pattern}); err == nil || !strings.Contains(err.Error(), "control character") {
+		if _, err := hashWorkspaceFiles(t.Context(), workspace, []string{pattern}); err == nil || !strings.Contains(err.Error(), "control character") {
 			t.Fatalf("control pattern error = %v", err)
 		}
 	}
@@ -124,7 +124,7 @@ func TestHashWorkspaceFilesRejectsEscapesAndUnsafeFiles(t *testing.T) {
 		if err := os.Symlink(target, filepath.Join(workspace, name)); err != nil {
 			t.Skipf("symlinks unavailable: %v", err)
 		}
-		if _, err := hashWorkspaceFiles(context.Background(), workspace, []string{name}); err == nil || !strings.Contains(err.Error(), "symlink") {
+		if _, err := hashWorkspaceFiles(t.Context(), workspace, []string{name}); err == nil || !strings.Contains(err.Error(), "symlink") {
 			t.Fatalf("%s error = %v", name, err)
 		}
 	}
@@ -134,7 +134,7 @@ func TestHashWorkspaceFilesRejectsEscapesAndUnsafeFiles(t *testing.T) {
 		if err := unix.Mkfifo(fifo, 0o600); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := hashWorkspaceFiles(context.Background(), workspace, []string{"pipe"}); err == nil || !strings.Contains(err.Error(), "non-regular") {
+		if _, err := hashWorkspaceFiles(t.Context(), workspace, []string{"pipe"}); err == nil || !strings.Contains(err.Error(), "non-regular") {
 			t.Fatalf("special file error = %v", err)
 		}
 	}
@@ -165,7 +165,7 @@ func TestHashWorkspaceRootRemainsPinnedAfterPathReplacement(t *testing.T) {
 	if err := os.Symlink(outside, workspace); err != nil {
 		t.Skipf("symlinks unavailable: %v", err)
 	}
-	got, err := hashWorkspaceRootFilesWithLimits(context.Background(), root, []string{"value"}, defaultHashFilesLimits, false)
+	got, err := hashWorkspaceRootFilesWithLimits(t.Context(), root, []string{"value"}, defaultHashFilesLimits, false)
 	if err != nil || got != githubHash("inside") {
 		t.Fatalf("pinned workspace hash = %q, %v", got, err)
 	}
@@ -185,7 +185,7 @@ func TestRunJobPinsHashWorkspaceBeforePathReplacement(t *testing.T) {
 		{ID: "replace", Kind: "run", Shell: "sh", Env: map[string]string{"OUTSIDE": outside}, Command: `mv "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE-moved" && ln -s "$OUTSIDE" "$GITHUB_WORKSPACE"`},
 		{ID: "hash", Kind: "run", Shell: "sh", Env: map[string]string{"VALUE_HASH": "${{ hashFiles('value') }}"}, Command: "test \"$VALUE_HASH\" = " + githubHash("inside")},
 	})
-	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() pinned workspace result = %#v, %v", result, err)
 	}
@@ -204,7 +204,7 @@ func TestRunJobHashFilesArgumentsUseStepEnvironment(t *testing.T) {
 		Condition: "hashFiles(env.PATTERN) != ''",
 		Command:   `test "${{ hashFiles(env.PATTERN) }}" = "` + digest + `"`,
 	}})
-	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() step environment hashFiles result = %#v, %v", result, err)
 	}
@@ -224,27 +224,27 @@ func TestHashFilesRemainsUnavailableOutsideWorkflowStepFields(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			job := runtimePlan(t, workspace, ".github/workflows/test.yml", []plan.Step{{ID: "run", Kind: "run", Command: "true"}})
 			test.change(&job)
-			if _, err := (Runner{}).RunJob(context.Background(), job, workspace); err == nil || !strings.Contains(err.Error(), `unsupported runtime function "hashFiles"`) {
+			if _, err := (Runner{}).RunJob(t.Context(), job, workspace); err == nil || !strings.Contains(err.Error(), `unsupported runtime function "hashFiles"`) {
 				t.Fatalf("RunJob() default hashFiles error = %v", err)
 			}
 		})
 	}
 
 	job := runtimePlan(t, workspace, ".github/workflows/test.yml", []plan.Step{{ID: "name", Name: "${{ hashFiles('value') }}", Kind: "run", Shell: "sh", Command: "true"}})
-	if result, err := (Runner{}).RunJob(context.Background(), job, workspace); err != nil || result.Conclusion != "success" {
+	if result, err := (Runner{}).RunJob(t.Context(), job, workspace); err != nil || result.Conclusion != "success" {
 		t.Fatalf("step name unexpectedly evaluated hashFiles: %#v, %v", result, err)
 	}
 
 	writeFixtureFile(t, workspace, ".github/actions/composite/action.yml", "runs:\n  using: composite\n  steps:\n    - shell: sh\n      run: echo \"${{ hashFiles('value') }}\"\n")
 	job = runtimePlan(t, workspace, ".github/workflows/test.yml", []plan.Step{{ID: "composite", Kind: "uses", Uses: "./.github/actions/composite"}})
-	if _, err := (Runner{}).RunJob(context.Background(), job, workspace); err == nil || !strings.Contains(err.Error(), `runtime function "hashFiles" is unavailable`) {
+	if _, err := (Runner{}).RunJob(t.Context(), job, workspace); err == nil || !strings.Contains(err.Error(), `runtime function "hashFiles" is unavailable`) {
 		t.Fatalf("composite metadata hashFiles error = %v", err)
 	}
 
 	writeFixtureFile(t, workspace, ".github/actions/child/action.yml", "inputs:\n  value:\n    required: false\nruns:\n  using: composite\n  steps:\n    - shell: sh\n      run: true\n")
 	writeFixtureFile(t, workspace, ".github/actions/composite/action.yml", "runs:\n  using: composite\n  steps:\n    - shell: sh\n      run: printf 'TEMPLATE=$%s\\n' \"{{ false && hashFiles('value') || 'ok' }}\" >> \"$GITHUB_ENV\"\n    - uses: ./.github/actions/child\n      with:\n        value: ${{ env.TEMPLATE }}\n")
 	job = runtimePlan(t, workspace, ".github/workflows/test.yml", []plan.Step{{ID: "composite", Kind: "uses", Uses: "./.github/actions/composite"}})
-	if result, err := (Runner{}).RunJob(context.Background(), job, workspace); err != nil || result.Conclusion != "success" {
+	if result, err := (Runner{}).RunJob(t.Context(), job, workspace); err != nil || result.Conclusion != "success" {
 		t.Fatalf("nested composite input was evaluated twice: %#v, %v", result, err)
 	}
 }
@@ -268,7 +268,7 @@ func TestHashWorkspaceFilesEnforcesEveryBound(t *testing.T) {
 		{name: "workspace entries", patterns: []string{"missing"}, limits: withHashLimits(base, func(l *hashFilesLimits) { l.entries = 1 }), want: "more than 1 entries"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := hashWorkspaceFilesWithLimits(context.Background(), workspace, test.patterns, test.limits, false)
+			_, err := hashWorkspaceFilesWithLimits(t.Context(), workspace, test.patterns, test.limits, false)
 			if err == nil || !strings.Contains(err.Error(), test.want) {
 				t.Fatalf("bound error = %v, want %q", err, test.want)
 			}
@@ -283,7 +283,7 @@ func TestHashWorkspaceFilesBoundsSingleDirectoryEnumeration(t *testing.T) {
 	}
 	limits := defaultHashFilesLimits
 	limits.entries = 10
-	if _, err := hashWorkspaceFilesWithLimits(context.Background(), workspace, []string{"missing"}, limits, false); err == nil || !strings.Contains(err.Error(), "more than 10 entries") {
+	if _, err := hashWorkspaceFilesWithLimits(t.Context(), workspace, []string{"missing"}, limits, false); err == nil || !strings.Contains(err.Error(), "more than 10 entries") {
 		t.Fatalf("single-directory entry bound error = %v", err)
 	}
 }
@@ -297,11 +297,11 @@ func TestHashWorkspaceFilesDetectsMutationAndCancellation(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if _, err := hashWorkspaceFilesWithLimits(context.Background(), workspace, []string{"mutable"}, limits, false); err == nil || !strings.Contains(err.Error(), "changed") {
+	if _, err := hashWorkspaceFilesWithLimits(t.Context(), workspace, []string{"mutable"}, limits, false); err == nil || !strings.Contains(err.Error(), "changed") {
 		t.Fatalf("mutation error = %v", err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 	if _, err := hashWorkspaceFiles(ctx, workspace, []string{"mutable"}); err == nil {
 		t.Fatal("cancelled hashFiles succeeded")
@@ -326,7 +326,7 @@ func TestHashWorkspaceFilesDetectsDirectoryReplacementBeforeTraversal(t *testing
 			t.Skipf("symlinks unavailable: %v", err)
 		}
 	}
-	if _, err := hashWorkspaceFilesWithLimits(context.Background(), workspace, []string{"nested/**"}, limits, false); err == nil || !strings.Contains(err.Error(), "changed before traversal") {
+	if _, err := hashWorkspaceFilesWithLimits(t.Context(), workspace, []string{"nested/**"}, limits, false); err == nil || !strings.Contains(err.Error(), "changed before traversal") {
 		t.Fatalf("directory replacement error = %v", err)
 	}
 }
@@ -358,7 +358,7 @@ func TestHashWorkspaceFilesOpensMatchesThroughPinnedDirectories(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	digest, err := hashWorkspaceFilesWithLimits(context.Background(), workspace, []string{"nested/value"}, limits, false)
+	digest, err := hashWorkspaceFilesWithLimits(t.Context(), workspace, []string{"nested/value"}, limits, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -371,7 +371,7 @@ func TestHashWorkspaceFilesOpensMatchesThroughPinnedDirectories(t *testing.T) {
 func TestHashWorkspaceFilesFinalVerificationObservesCancellation(t *testing.T) {
 	workspace := t.TempDir()
 	writeFixtureFile(t, workspace, "nested/value", "value")
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	limits := defaultHashFilesLimits
 	limits.afterFileHash = func(string) { cancel() }
 	if _, err := hashWorkspaceFilesWithLimits(ctx, workspace, []string{"nested/value"}, limits, false); !errors.Is(err, context.Canceled) {
@@ -395,7 +395,7 @@ func TestHashWorkspaceFilesRejectsFIFORacedIntoMatch(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 	defer cancel()
 	if _, err := hashWorkspaceFilesWithLimits(ctx, workspace, []string{"value"}, limits, false); err == nil || !strings.Contains(err.Error(), "changed before hashing") {
 		t.Fatalf("FIFO race error = %v", err)
@@ -414,7 +414,7 @@ func TestHashFilesStepEnvironmentFailureUsesStepConclusion(t *testing.T) {
 		{ID: "invalid", Kind: "run", Shell: "sh", ContinueOnError: true, Env: map[string]string{"HASH": "${{ hashFiles('link') }}"}, Command: "exit 99"},
 		{ID: "after", Kind: "run", Shell: "sh", Condition: "steps.invalid.outcome == 'failure' && steps.invalid.conclusion == 'success'", Command: "touch " + marker},
 	})
-	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -435,7 +435,7 @@ func TestHashFilesStepConditionFailureRunsFailureCleanup(t *testing.T) {
 		{ID: "invalid", Kind: "run", Shell: "sh", Condition: "hashFiles('link') != ''", Command: "exit 99"},
 		{ID: "cleanup", Kind: "run", Shell: "sh", Condition: "failure()", Command: "touch " + marker},
 	})
-	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{}).RunJob(t.Context(), job, workspace)
 	if err == nil || result.Conclusion != "failure" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -460,7 +460,7 @@ func TestHashFilesSkippedStepsDoNotAccessWorkspace(t *testing.T) {
 		{ID: "condition", Kind: "run", Shell: "sh", Condition: "hashFiles('link') != ''", Command: "touch " + conditionMarker},
 		{ID: "cleanup", Kind: "run", Shell: "sh", Condition: "always()", Command: "touch " + cleanupMarker},
 	})
-	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{}).RunJob(t.Context(), job, workspace)
 	if err == nil || result.Conclusion != "failure" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -497,7 +497,7 @@ func TestHashFilesRemotePreFailureUsesStepConclusion(t *testing.T) {
 	job.RequiredCapabilities = []string{"network"}
 	job.Actions = []plan.ActionLock{remoteLifecycleLock(lockID, "action", digest, nil)}
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}
-	result, err := (Runner{Actions: materializer}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Actions: materializer}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -540,7 +540,7 @@ func TestHashFilesInterpolationUsesStepTimeoutContext(t *testing.T) {
 				Command:        "true",
 			}})
 			started := time.Now()
-			_, err = (Runner{}).RunJob(context.Background(), job, workspace)
+			_, err = (Runner{}).RunJob(t.Context(), job, workspace)
 			if !errors.Is(err, context.DeadlineExceeded) {
 				t.Fatalf("RunJob() timeout error = %v", err)
 			}
@@ -585,7 +585,7 @@ func TestHashFilesPrePhaseUsesStepTimeoutContext(t *testing.T) {
 	job.Actions = []plan.ActionLock{remoteLifecycleLock(lockID, "action", digest, nil)}
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}
 	started := time.Now()
-	_, err = (Runner{Actions: materializer}).RunJob(context.Background(), job, workspace)
+	_, err = (Runner{Actions: materializer}).RunJob(t.Context(), job, workspace)
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("RunJob() pre timeout error = %v", err)
 	}

--- a/internal/runtime/job.go
+++ b/internal/runtime/job.go
@@ -901,11 +901,12 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		}
 		jobResult.Outputs[name] = value
 	}
-	if runCtx.Err() != nil {
+	switch {
+	case runCtx.Err() != nil:
 		jobResult.Conclusion = "cancelled"
-	} else if runErr == nil {
+	case runErr == nil:
 		jobResult.Conclusion = "success"
-	} else if job.ContinueOnError && !hardFailure && !isHardJobFailure(runErr) {
+	case job.ContinueOnError && !hardFailure && !isHardJobFailure(runErr):
 		jobResult.Conclusion = "success"
 		runErr = &toleratedJobFailure{err: runErr}
 	}
@@ -2254,7 +2255,8 @@ func (r Runner) runCompositeMetadata(ctx context.Context, processor *commandProc
 		childErr := error(nil)
 		childJobEnv := mergeStepEnvironment(compositeProcessEnv, result.Env)
 		childJobEnv["GITHUB_ACTION_PATH"] = actionPath
-		if step.Uses != "" {
+		switch {
+		case step.Uses != "":
 			// Resolve composite child fields before entering workflow-authored
 			// action evaluation.
 			var childEnv map[string]string
@@ -2275,9 +2277,9 @@ func (r Runner) runCompositeMetadata(ctx context.Context, processor *commandProc
 			if childErr == nil {
 				stepResult, childErr = r.runActionStep(ctx, processor, workspace, job, child, childInvocationID, childJobEnv, childEnv, childWith, eval, posts, actions, prepared, actionStack, lifecycleEnvOverlay)
 			}
-		} else if strings.TrimSpace(step.Run) == "" {
+		case strings.TrimSpace(step.Run) == "":
 			childErr = fmt.Errorf("composite action step %d has no run command", i+1)
-		} else {
+		default:
 			var script, dir string
 			var env map[string]string
 			env, childErr = evaluateStepMap(step.Env, eval)

--- a/internal/runtime/oidc_token_service_test.go
+++ b/internal/runtime/oidc_token_service_test.go
@@ -47,7 +47,7 @@ func TestAgentOIDCTokensMintsRequestedAudienceAndConfiguredClaims(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	got, err := provider.OIDCToken(context.Background(), "sts.amazonaws.com")
+	got, err := provider.OIDCToken(t.Context(), "sts.amazonaws.com")
 	if err != nil || got != token {
 		t.Fatalf("OIDCToken() = %q, %v", got, err)
 	}
@@ -105,7 +105,7 @@ func TestAgentOIDCTokensRejectsAuthFailuresAndMalformedResponses(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, err = provider.OIDCToken(context.Background(), "audience")
+			_, err = provider.OIDCToken(t.Context(), "audience")
 			if err == nil || !strings.Contains(err.Error(), test.want) || strings.Contains(err.Error(), secret) {
 				t.Fatalf("OIDCToken() error = %v, want %q without response body", err, test.want)
 			}
@@ -135,12 +135,12 @@ func TestIDTokenServiceWireContract(t *testing.T) {
 	provider := &testOIDCTokenProvider{token: "header.payload.signature", requireLiveContext: true}
 	redactor := &testRedactor{}
 	processor := newCommandProcessor(&bytes.Buffer{}, &bytes.Buffer{})
-	service, err := startIDTokenService(context.Background(), provider, redactor, processor)
+	service, err := startIDTokenService(t.Context(), provider, redactor, processor)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() { _ = service.Close() }()
-	env, revoke, err := service.actionEnvironment(context.Background(), nil)
+	env, revoke, err := service.actionEnvironment(t.Context(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -181,12 +181,12 @@ func TestIDTokenServicePreservesPermanentMintFailureStatus(t *testing.T) {
 	for _, status := range []int{http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound, http.StatusUnprocessableEntity} {
 		t.Run(http.StatusText(status), func(t *testing.T) {
 			provider := &testOIDCTokenProvider{err: oidcTokenStatusError(status)}
-			service, err := startIDTokenService(context.Background(), provider, &testRedactor{}, newCommandProcessor(&bytes.Buffer{}, &bytes.Buffer{}))
+			service, err := startIDTokenService(t.Context(), provider, &testRedactor{}, newCommandProcessor(&bytes.Buffer{}, &bytes.Buffer{}))
 			if err != nil {
 				t.Fatal(err)
 			}
 			defer func() { _ = service.Close() }()
-			env, revoke, err := service.actionEnvironment(context.Background(), nil)
+			env, revoke, err := service.actionEnvironment(t.Context(), nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -276,7 +276,7 @@ if (process.env.no_proxy !== "lower.example,127.0.0.1") throw new Error("no_prox
 	job.Actions = []plan.ActionLock{{ID: lockID, Source: "workspace", Path: actionPath, SourceDigest: digestTree(t, filepath.Join(workspace, actionPath))}}
 	provider := &testOIDCTokenProvider{token: "header.payload.signature"}
 	redactor := &testRedactor{}
-	result, err := (Runner{Node24: node, OIDCToken: provider, Redactor: redactor}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node24: node, OIDCToken: provider, Redactor: redactor}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() = %#v, %v", result, err)
 	}
@@ -312,7 +312,7 @@ const core = require("@actions/core");
 	job.IDTokenPermission = "write"
 	job.Actions = []plan.ActionLock{{ID: lockID, Source: "workspace", Path: actionPath, SourceDigest: digestTree(t, filepath.Join(workspace, actionPath))}}
 	provider := &testOIDCTokenProvider{token: "header.payload.signature", requireLiveContext: true}
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 	defer cancel()
 	result, err := (Runner{Node24: node, OIDCToken: provider, Redactor: &testRedactor{}}).RunJob(ctx, job, workspace)
 	if !errors.Is(err, context.DeadlineExceeded) || result.Conclusion != "cancelled" {
@@ -356,7 +356,7 @@ const core = require("@actions/core");
 		Action: &plan.ActionSelector{Lock: lockID},
 	}})
 	job.Actions = []plan.ActionLock{{ID: lockID, Source: "workspace", Path: actionPath, SourceDigest: digestTree(t, filepath.Join(workspace, actionPath))}}
-	result, err := (Runner{Node24: node}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node24: node}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() = %#v, %v", result, err)
 	}

--- a/internal/runtime/runner_resolution_test.go
+++ b/internal/runtime/runner_resolution_test.go
@@ -1,7 +1,6 @@
 package runtime
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -49,7 +48,7 @@ func TestAgentRunnerResolverBatchesRequirementsAndReturnsSuggestions(t *testing.
 		requirements[i] = RunnerRequirement{ID: fmt.Sprintf("r%d", i), Labels: []string{"ubuntu-latest"}}
 	}
 	requirements[100].Labels = []string{"macos-26"}
-	suggestions, err := resolver.Resolve(context.Background(), requirements)
+	suggestions, err := resolver.Resolve(t.Context(), requirements)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1258,9 +1258,10 @@ func verifyManagedNodeExecutable(ctx context.Context, major int, path, want stri
 // major. It deliberately does not fall back to PATH.
 func discoverNodeContext(ctx context.Context, major int, explicit, managedRoot string) (string, error) {
 	var candidates []string
-	if explicit != "" {
+	switch {
+	case explicit != "":
 		candidates = append(candidates, explicit)
-	} else if managedRoot != "" {
+	case managedRoot != "":
 		name := "node"
 		if runtime.GOOS == "windows" {
 			name = "node.exe"
@@ -1271,7 +1272,7 @@ func discoverNodeContext(ctx context.Context, major int, explicit, managedRoot s
 			filepath.Join(managedRoot, "node", version, "bin", name),
 			filepath.Join(managedRoot, "bin", name),
 		)
-	} else {
+	default:
 		return "", fmt.Errorf("node %d is not configured: set the matching Runner.Node field or Runner.ManagedNodeRoot", major)
 	}
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -100,7 +100,7 @@ func TestBoundedDockerOutputRejectsOversizedOutput(t *testing.T) {
 	if err := os.WriteFile(script, []byte("#!/bin/sh\ni=0; while [ $i -lt 5000 ]; do printf x; i=$((i+1)); done\n"), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	out, err := boundedDockerOutput(context.Background(), nil, script, "buildx", "inspect")
+	out, err := boundedDockerOutput(t.Context(), nil, script, "buildx", "inspect")
 	if err == nil || !strings.Contains(err.Error(), "exceeds limit") || len(out) != 4096 {
 		t.Fatalf("boundedDockerOutput() = %d bytes, %v", len(out), err)
 	}
@@ -416,7 +416,7 @@ func TestRunDockerFakeLifecycle(t *testing.T) {
 	t.Setenv("BUILDX_BUILDER", "ambient-builder")
 	t.Setenv("BUILDKIT_HOST", "tcp://ambient.invalid:1234")
 	var logs bytes.Buffer
-	result, err := (Runner{Docker: fake.path, Stdout: &logs, Stderr: &logs}).runDockerAction(context.Background(), action)
+	result, err := (Runner{Docker: fake.path, Stdout: &logs, Stderr: &logs}).runDockerAction(t.Context(), action)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -573,7 +573,7 @@ func TestRunDockerPreservesExplicitPath(t *testing.T) {
 			if test.jobPATH != "" {
 				job.Env = map[string]string{"PATH": test.jobPATH}
 			}
-			if _, err := (Runner{Docker: fake.path}).RunJob(context.Background(), job, workspace); err != nil {
+			if _, err := (Runner{Docker: fake.path}).RunJob(t.Context(), job, workspace); err != nil {
 				t.Fatal(err)
 			}
 			calls := fake.calls(t)
@@ -600,7 +600,7 @@ func TestRunDockerPreservesPathWrittenThroughGitHubEnv(t *testing.T) {
 		{ID: "docker", Kind: "uses", Uses: "./.github/actions/docker"},
 	})
 	job.RequiredCapabilities = []string{"docker", "network"}
-	if _, err := (Runner{Docker: fake.path}).RunJob(context.Background(), job, workspace); err != nil {
+	if _, err := (Runner{Docker: fake.path}).RunJob(t.Context(), job, workspace); err != nil {
 		t.Fatal(err)
 	}
 	calls := fake.calls(t)
@@ -634,7 +634,7 @@ runs:
 		Env:  map[string]string{"MODE": "caller"},
 	}})
 	job.RequiredCapabilities = []string{"docker", "network"}
-	if _, err := (Runner{Docker: fake.path}).RunJob(context.Background(), job, workspace); err != nil {
+	if _, err := (Runner{Docker: fake.path}).RunJob(t.Context(), job, workspace); err != nil {
 		t.Fatal(err)
 	}
 	calls := fake.calls(t)
@@ -653,7 +653,7 @@ func TestRunDockerRejectsUntrustedBuilderBeforeExecution(t *testing.T) {
 	for _, scenario := range []string{"remote", "multiline", "oversized", "inspect-fail"} {
 		t.Run(scenario, func(t *testing.T) {
 			fake := newFakeDocker(t, scenario)
-			if _, err := (Runner{Docker: fake.path}).runDockerAction(context.Background(), fakeDockerAction(t)); err == nil {
+			if _, err := (Runner{Docker: fake.path}).runDockerAction(t.Context(), fakeDockerAction(t)); err == nil {
 				t.Fatal("untrusted builder was accepted")
 			}
 			calls := fake.calls(t)
@@ -670,7 +670,7 @@ func TestRunDockerFakeFailuresCleanOwnedResources(t *testing.T) {
 	for _, scenario := range []string{"build-fail", "run-fail", "leftover", "query-fail"} {
 		t.Run(scenario, func(t *testing.T) {
 			fake := newFakeDocker(t, scenario)
-			if _, err := (Runner{Docker: fake.path, CleanupTimeout: 2 * time.Second}).runDockerAction(context.Background(), fakeDockerAction(t)); err == nil {
+			if _, err := (Runner{Docker: fake.path, CleanupTimeout: 2 * time.Second}).runDockerAction(t.Context(), fakeDockerAction(t)); err == nil {
 				t.Fatal("Docker failure returned success")
 			}
 			calls := fake.calls(t)
@@ -696,7 +696,7 @@ func TestRunDockerFakeFailuresCleanOwnedResources(t *testing.T) {
 
 func TestRunDockerProcessesFileCommandsAfterFailure(t *testing.T) {
 	fake := newFakeDocker(t, "run-fail")
-	result, err := (Runner{Docker: fake.path}).runDockerAction(context.Background(), fakeDockerAction(t))
+	result, err := (Runner{Docker: fake.path}).runDockerAction(t.Context(), fakeDockerAction(t))
 	if err == nil || !strings.Contains(err.Error(), `run Docker action "fake Docker"`) {
 		t.Fatalf("runDockerAction() error = %v", err)
 	}
@@ -707,7 +707,7 @@ func TestRunDockerProcessesFileCommandsAfterFailure(t *testing.T) {
 
 func TestRunDockerJoinsRunAndFileCommandFailures(t *testing.T) {
 	fake := newFakeDocker(t, "run-fail-invalid-files")
-	_, err := (Runner{Docker: fake.path}).runDockerAction(context.Background(), fakeDockerAction(t))
+	_, err := (Runner{Docker: fake.path}).runDockerAction(t.Context(), fakeDockerAction(t))
 	if err == nil || !strings.Contains(err.Error(), `run Docker action "fake Docker"`) || !strings.Contains(err.Error(), `process Docker action "fake Docker" file commands`) || !strings.Contains(err.Error(), "invalid file command") {
 		t.Fatalf("runDockerAction() error = %v", err)
 	}
@@ -717,7 +717,7 @@ func TestRunDockerReadsOnlyOriginalCommandFiles(t *testing.T) {
 	t.Parallel()
 
 	fake := newFakeDocker(t, "replace-files")
-	result, err := (Runner{Docker: fake.path}).runDockerAction(context.Background(), fakeDockerAction(t))
+	result, err := (Runner{Docker: fake.path}).runDockerAction(t.Context(), fakeDockerAction(t))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -730,7 +730,7 @@ func TestRunDockerCancellationCleansOwnedResources(t *testing.T) {
 	t.Parallel()
 
 	fake := newFakeDocker(t, "cancel")
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	done := make(chan error, 1)
 	go func() {
 		_, err := (Runner{Docker: fake.path, CleanupTimeout: 2 * time.Second, InterruptGrace: 50 * time.Millisecond, TerminateGrace: 50 * time.Millisecond}).runDockerAction(ctx, fakeDockerAction(t))
@@ -769,7 +769,7 @@ func TestRunJobUnresolvedDockerActionUsesFakeBackend(t *testing.T) {
 	workspace := fixturePath(t)
 	job := runtimePlan(t, workspace, "smoke/.github/workflows/ci.yml", []plan.Step{{ID: "docker", Kind: "uses", Uses: "./actions/docker"}})
 	job.RequiredCapabilities = []string{"docker", "network"}
-	result, err := (Runner{Docker: fake.path}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Docker: fake.path}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" || result.Env["DOCKER_RUNTIME_SEEN"] != "true" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -786,7 +786,7 @@ func TestRunJobEvaluatesIndexedWorkflowInputs(t *testing.T) {
 	job.Inputs = map[string]any{"label": "dispatched"}
 	job.Env = map[string]string{"KEY": "label"}
 	var logs bytes.Buffer
-	result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v, logs = %q", result, err, logs.String())
 	}
@@ -802,7 +802,7 @@ func TestRunJobDoesNotTolerateDockerActionCleanupFailure(t *testing.T) {
 	job.RequiredCapabilities = []string{"docker", "network"}
 	job.ContinueOnError = true
 
-	result, err := (Runner{Docker: fake.path}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Docker: fake.path}).RunJob(t.Context(), job, workspace)
 	if err == nil || IsToleratedJobFailure(err) || result.Conclusion != "failure" || !strings.Contains(err.Error(), "owned Docker resources remain after cleanup") {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -838,7 +838,7 @@ echo after-soft`},
 	job.Event.Ref = "refs/heads/main"
 	job.Event.SHA = "0123456789abcdef"
 	job.Event.Actor = "octocat"
-	result, err := (Runner{Stdout: &logs, Stderr: &logs, Secrets: testSecretResolver{"CANARY": "mask-me"}, Redactor: redactor}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Stdout: &logs, Stderr: &logs, Secrets: testSecretResolver{"CANARY": "mask-me"}, Redactor: redactor}).RunJob(t.Context(), job, workspace)
 	if err != nil {
 		t.Fatalf("RunJob() error = %v, logs = %q", err, logs.String())
 	}
@@ -907,7 +907,7 @@ jobs:
 	if err != nil {
 		t.Fatal(err)
 	}
-	plans, err := compilePlansForTest(context.Background(),
+	plans, err := compilePlansForTest(t.Context(),
 		filepath.Join(workspace, workflowPath),
 		[]byte(source),
 		event,
@@ -933,7 +933,7 @@ jobs:
 		t.Fatalf("plans = %d, want four defaults cases", len(plans))
 	}
 	for _, job := range plans {
-		result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+		result, err := (Runner{}).RunJob(t.Context(), job, workspace)
 		if err != nil || result.Conclusion != "success" {
 			t.Fatalf("RunJob(%s) result = %#v, error = %v", job.Workflow.LogicalJobID, result, err)
 		}
@@ -958,7 +958,7 @@ func TestCompiledBracketSecretResolvesAndMasks(t *testing.T) {
 	}
 	var logs bytes.Buffer
 	redactor := &testRedactor{}
-	result, err := (Runner{Stdout: &logs, Stderr: &logs, Secrets: testSecretResolver{"TOKEN": "secret-value"}, Redactor: redactor}).RunJob(context.Background(), plans[0], workspace)
+	result, err := (Runner{Stdout: &logs, Stderr: &logs, Secrets: testSecretResolver{"TOKEN": "secret-value"}, Redactor: redactor}).RunJob(t.Context(), plans[0], workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -1020,7 +1020,7 @@ printf '%s\n' tap-secret
 	for name := range transportEnvironment {
 		t.Setenv(name, "http://workflow-controlled.example")
 	}
-	value, err := resolved.ResolveSecret(context.Background(), "HOMEBREW_TAP_GITHUB_TOKEN")
+	value, err := resolved.ResolveSecret(t.Context(), "HOMEBREW_TAP_GITHUB_TOKEN")
 	if err != nil || value != "tap-secret" {
 		t.Fatalf("ResolveSecret() = %q, %v", value, err)
 	}
@@ -1032,7 +1032,7 @@ func TestAgentSecretsDoesNotReturnCommandOutputOnFailure(t *testing.T) {
 	if err := os.Chmod(agent, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	_, err := (AgentSecrets{Executable: agent}).ResolveSecret(context.Background(), "DENIED")
+	_, err := (AgentSecrets{Executable: agent}).ResolveSecret(t.Context(), "DENIED")
 	if err == nil || strings.Contains(err.Error(), "stdout-secret") || strings.Contains(err.Error(), "stderr-secret") || !strings.Contains(err.Error(), "secret request failed") {
 		t.Fatalf("ResolveSecret() error = %v", err)
 	}
@@ -1088,7 +1088,7 @@ test -z "${AMBIENT_SECRET+x}" || exit 15
 	t.Setenv("BUILDKITE_AGENT_ENDPOINT", "https://agent.example/v3")
 	t.Setenv("AMBIENT_SECRET", "must-not-be-inherited")
 
-	if err := (AgentRedactor{Executable: agent}).AddRedaction(context.Background(), "redact-me"); err != nil {
+	if err := (AgentRedactor{Executable: agent}).AddRedaction(t.Context(), "redact-me"); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -1103,19 +1103,19 @@ func TestFailureConditionsAndCancellation(t *testing.T) {
 		{ID: "default", Kind: "run", Command: "echo must-not-run"},
 		{ID: "recover", Kind: "run", Condition: "failure()", Command: "echo recovered"},
 	})
-	result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(t.Context(), job, workspace)
 	if err == nil || result.Conclusion != "failure" || strings.Contains(logs.String(), "must-not-run") || !strings.Contains(logs.String(), "recovered") {
 		t.Fatalf("RunJob() result = %#v, error = %v, logs = %q", result, err, logs.String())
 	}
 
 	job = runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "timeout", Kind: "run", Command: "sleep 30", TimeoutMinutes: 0.0005}})
 	started := time.Now()
-	result, err = (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err = (Runner{}).RunJob(t.Context(), job, workspace)
 	if !errors.Is(err, context.DeadlineExceeded) || result.Conclusion != "failure" || time.Since(started) > 3*time.Second {
 		t.Fatalf("timed RunJob() result = %#v, error = %v, elapsed = %s", result, err, time.Since(started))
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 	job = runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "cancel", Kind: "run", Condition: "always()", Command: "sleep 30"}})
 	result, err = (Runner{}).RunJob(ctx, job, workspace)
@@ -1133,6 +1133,7 @@ func TestExplicitCancelCommitsEffectsWithoutFailingJob(t *testing.T) {
 }
 
 func testExplicitCancelCommitsEffectsWithoutFailingJob(t *testing.T) {
+	t.Helper()
 	workspace := t.TempDir()
 	workflowPath := ".github/workflows/test.yml"
 	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
@@ -1151,7 +1152,7 @@ while :; do sleep 1; done`},
 		{ID: "after-cancel", Kind: "run", Condition: "steps.background.outcome == 'cancelled' && steps.cancel.conclusion == 'success' && steps.cancel-again.conclusion == 'success'", Command: `test "$CANCEL_EFFECT" = visible; test -f "$TERMINATED"; echo after-cancel`},
 	})
 	job.Env = map[string]string{"READY": ready, "TERMINATED": terminated}
-	result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" || result.Env["CANCEL_EFFECT"] != "visible" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -1167,7 +1168,7 @@ func TestCancelQueuedBackgroundNeverStartsIt(t *testing.T) {
 	release := filepath.Join(workspace, "release")
 	queuedMarker := filepath.Join(workspace, "queued-started")
 	steps := make([]plan.Step, 0, maxActiveBackgroundSteps+4)
-	for i := 0; i < maxActiveBackgroundSteps; i++ {
+	for i := range maxActiveBackgroundSteps {
 		steps = append(steps, plan.Step{ID: fmt.Sprintf("blocker-%d", i), Kind: "run", Background: true, Command: `while [ ! -f "$RELEASE" ]; do sleep 0.01; done`})
 	}
 	steps = append(steps,
@@ -1179,7 +1180,7 @@ func TestCancelQueuedBackgroundNeverStartsIt(t *testing.T) {
 	job := runtimePlan(t, workspace, workflowPath, steps)
 	job.Env = map[string]string{"RELEASE": release, "QUEUED_MARKER": queuedMarker}
 
-	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -1195,7 +1196,7 @@ func TestQueuedBackgroundTimeoutStartsAtDispatch(t *testing.T) {
 	release := filepath.Join(workspace, "release")
 	queuedMarker := filepath.Join(workspace, "queued-started")
 	steps := make([]plan.Step, 0, maxActiveBackgroundSteps+3)
-	for i := 0; i < maxActiveBackgroundSteps; i++ {
+	for i := range maxActiveBackgroundSteps {
 		steps = append(steps, plan.Step{ID: fmt.Sprintf("blocker-%d", i), Kind: "run", Background: true, Command: `while [ ! -f "$RELEASE" ]; do sleep 0.01; done`})
 	}
 	steps = append(steps,
@@ -1206,7 +1207,7 @@ func TestQueuedBackgroundTimeoutStartsAtDispatch(t *testing.T) {
 	job := runtimePlan(t, workspace, workflowPath, steps)
 	job.Env = map[string]string{"RELEASE": release, "QUEUED_MARKER": queuedMarker}
 
-	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -1225,7 +1226,7 @@ func TestCancelQueuedBackgroundNeverRegistersPostAction(t *testing.T) {
 	writeFixtureFile(t, workspace, ".github/actions/queued/post.js", "console.log('queued-post-must-not-run')\n")
 	release := filepath.Join(workspace, "release")
 	steps := make([]plan.Step, 0, maxActiveBackgroundSteps+4)
-	for i := 0; i < maxActiveBackgroundSteps; i++ {
+	for i := range maxActiveBackgroundSteps {
 		steps = append(steps, plan.Step{ID: fmt.Sprintf("blocker-%d", i), Kind: "run", Background: true, Command: `while [ ! -f "$RELEASE" ]; do sleep 0.01; done`})
 	}
 	steps = append(steps,
@@ -1238,7 +1239,7 @@ func TestCancelQueuedBackgroundNeverRegistersPostAction(t *testing.T) {
 	job.Env = map[string]string{"RELEASE": release}
 	var logs bytes.Buffer
 
-	result, err := (Runner{Node24: node, Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node24: node, Stdout: &logs, Stderr: &logs}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -1262,7 +1263,7 @@ func TestFailureBeforeCancelStillFailsJob(t *testing.T) {
 	})
 	job.Env = map[string]string{"FAILED_PID": failedPID}
 
-	result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(t.Context(), job, workspace)
 	if err == nil || result.Conclusion != "failure" || !strings.Contains(logs.String(), "recovered") || strings.Contains(logs.String(), "must-not-run") {
 		t.Fatalf("RunJob() result = %#v, error = %v, logs = %q", result, err, logs.String())
 	}
@@ -1306,7 +1307,7 @@ test "${{ steps.two.outputs.value }}" = output-two`},
 	job.Env = map[string]string{"ONE_DONE": oneDone, "TWO_DONE": twoDone, "PATH_ENTRY": pathEntry}
 	job.Outputs = map[string]string{"one": "${{ steps.one.outputs.value }}", "two": "${{ steps.two.outputs.value }}"}
 
-	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{}).RunJob(t.Context(), job, workspace)
 	if err != nil {
 		t.Fatalf("RunJob() error = %v", err)
 	}
@@ -1326,28 +1327,28 @@ func TestBackgroundSummariesAreBoundedInCommitOrder(t *testing.T) {
 	second := plan.Step{ID: "second"}
 	summaryBytes := maxJobSummaryBytes * 3 / 4
 
-	supervisor.start(context.Background(), first.ID,
+	supervisor.start(t.Context(), first.ID,
 		func(context.Context) stepExecution {
 			<-releaseFirst
 			completionOrder <- first.ID
 			result := newResult()
 			result.Summary = strings.Repeat("a", summaryBytes)
-			return classifyStepExecution(context.Background(), context.Background(), first, result, nil)
+			return classifyStepExecution(t.Context(), t.Context(), first, result, nil)
 		},
 		func(ctx context.Context) stepExecution {
-			return cancelledStepExecution(context.Background(), ctx, first)
+			return cancelledStepExecution(t.Context(), ctx, first)
 		},
 	)
-	supervisor.start(context.Background(), second.ID,
+	supervisor.start(t.Context(), second.ID,
 		func(context.Context) stepExecution {
 			completionOrder <- second.ID
 			close(releaseFirst)
 			result := newResult()
 			result.Summary = strings.Repeat("b", summaryBytes)
-			return classifyStepExecution(context.Background(), context.Background(), second, result, nil)
+			return classifyStepExecution(t.Context(), t.Context(), second, result, nil)
 		},
 		func(ctx context.Context) stepExecution {
-			return cancelledStepExecution(context.Background(), ctx, second)
+			return cancelledStepExecution(t.Context(), ctx, second)
 		},
 	)
 
@@ -1441,7 +1442,7 @@ test "$(printf '%s' "$PATH" | tr ':' '\n' | grep -Fxc "$FOREGROUND_PATH")" -eq 1
 		"ONE_PATH": onePath, "TWO_PATH": twoPath, "FOREGROUND_PATH": foregroundPath,
 	}
 
-	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{}).RunJob(t.Context(), job, workspace)
 	if err != nil {
 		t.Fatalf("RunJob() error = %v", err)
 	}
@@ -1471,7 +1472,7 @@ runs:
 	})
 	job.Env = map[string]string{"COMPOSITE_PATH": compositePath, "FOREGROUND_PATH": foregroundPath}
 
-	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{}).RunJob(t.Context(), job, workspace)
 	if err != nil {
 		t.Fatalf("RunJob() error = %v", err)
 	}
@@ -1514,7 +1515,7 @@ esac
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "javascript", Kind: "uses", Uses: "./.github/actions/path"}})
 	job.Env = map[string]string{"PATH_ENTRY": pathEntry}
 
-	result, err := (Runner{Node24: fakeNode}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node24: fakeNode}).RunJob(t.Context(), job, workspace)
 	if err != nil {
 		t.Fatalf("RunJob() error = %v", err)
 	}
@@ -1557,7 +1558,7 @@ printf 'NODE16_%s=true\n' "$(basename "$1" .js | tr '[:lower:]' '[:upper:]')" >>
 	}
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "javascript", Kind: "uses", Uses: "./.github/actions/node16"}})
 	var logs bytes.Buffer
-	result, err := (Runner{Node16: fakeNode, Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node16: fakeNode, Stdout: &logs, Stderr: &logs}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -1594,7 +1595,7 @@ func TestNode16WarningAggregatesInvokedActions(t *testing.T) {
 		{ID: "modern", Kind: "uses", Uses: "./.github/actions/modern"},
 	})
 	var logs bytes.Buffer
-	result, err := (Runner{Node16: node16, Node24: node24, Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node16: node16, Node24: node24, Stdout: &logs, Stderr: &logs}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -1628,7 +1629,7 @@ printf '\n'
 	}
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "node16", Kind: "uses", Uses: "./.github/actions/sensitive"}})
 	var logs bytes.Buffer
-	result, err := (Runner{Node16: fakeNode, Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node16: fakeNode, Stdout: &logs, Stderr: &logs}).RunJob(t.Context(), job, workspace)
 	if err == nil || !strings.Contains(err.Error(), "line exceeds 1048576-byte limit") || result.Conclusion != "failure" {
 		t.Fatalf("RunJob() result = %#v, error = %v, want oversized-line failure", result, err)
 	}
@@ -1666,7 +1667,7 @@ done
 	}
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "node16", Kind: "uses", Uses: "./.github/actions/node16"}})
 	var logs bytes.Buffer
-	result, err := (Runner{Node16: fakeNode, Stdout: io.Discard, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node16: fakeNode, Stdout: io.Discard, Stderr: &logs}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -1694,7 +1695,7 @@ func TestBackgroundFailureSurfacesAtWait(t *testing.T) {
 	})
 	job.Env = map[string]string{"FAILURE_DONE": marker}
 
-	result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(t.Context(), job, workspace)
 	if err == nil || result.Conclusion != "failure" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -1714,7 +1715,7 @@ func TestBackgroundContinueOnError(t *testing.T) {
 		{ID: "after-soft", Kind: "run", Condition: "steps.soft-background.outcome == 'failure' && steps.soft-background.conclusion == 'success'", Command: "echo after-soft"},
 	})
 
-	result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -1738,7 +1739,7 @@ func TestSkippedBackgroundAndRepeatedWaitAreCommittedAtMostOnce(t *testing.T) {
 		{ID: "verify", Kind: "run", Condition: "steps.skipped.conclusion == 'skipped' && steps.skipped.outputs.missing == '' && steps.cancel-skipped.conclusion == 'success' && steps.cancel-skipped.outputs.missing == '' && steps.wait-skipped.conclusion == 'success' && steps.wait-skipped.outputs.missing == '' && steps.first-wait.outputs.missing == '' && steps.cancel-completed.conclusion == 'success' && steps.cancel-completed.outputs.missing == '' && steps.second-wait.outputs.missing == ''", Command: "true"},
 	})
 
-	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" || result.Summary != "once\n" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -1753,7 +1754,7 @@ func TestBackgroundOutputsReturnErrorBeforeBarrier(t *testing.T) {
 		{ID: "premature-reader", Kind: "run", Command: `echo "${{ steps.background.outputs.value }}"`},
 	})
 
-	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{}).RunJob(t.Context(), job, workspace)
 	if err == nil || result.Conclusion != "failure" || !strings.Contains(err.Error(), "unavailable step") {
 		t.Fatalf("RunJob() result = %#v, error = %v, want unavailable background output", result, err)
 	}
@@ -1777,7 +1778,7 @@ func TestExpressionValuedStepControls(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -1790,7 +1791,7 @@ func TestSkippedStepDoesNotEvaluateTypedControls(t *testing.T) {
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{
 		ID: "skipped", Kind: "run", Condition: "false", Command: "true", TimeoutMinutesExpression: "${{ fromJSON('invalid') }}",
 	}})
-	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -1830,14 +1831,14 @@ func TestExpressionValuedStepControlsRequireTypedBoundedResults(t *testing.T) {
 
 func TestExpressionContinueOnErrorAppliesToPreparedActionFailure(t *testing.T) {
 	step := plan.Step{ID: "action", ContinueOnErrorExpression: "${{ true }}"}
-	execution := classifyStepExecutionWithControls(context.Background(), context.Background(), step, newResult(), errors.New("pre failed"), expression.Context{})
+	execution := classifyStepExecutionWithControls(t.Context(), t.Context(), step, newResult(), errors.New("pre failed"), expression.Context{})
 	if execution.outcome != "failure" || execution.conclusion != "success" {
 		t.Fatalf("prepared action execution = %#v", execution)
 	}
 }
 
 func TestExpressionContinueOnErrorIsNotEvaluatedForCancellation(t *testing.T) {
-	jobCtx, cancel := context.WithCancel(context.Background())
+	jobCtx, cancel := context.WithCancel(t.Context())
 	cancel()
 	step := plan.Step{ID: "cancelled", ContinueOnErrorExpression: "${{ fromJSON('invalid') }}"}
 	execution := classifyStepExecutionWithControls(jobCtx, jobCtx, step, newResult(), context.Canceled, expression.Context{})
@@ -1855,7 +1856,7 @@ func TestStepNameFailsClosedOnUnavailableBackgroundOutput(t *testing.T) {
 		{ID: "premature-reader", Name: `${{ steps.background.outputs.value }}`, Kind: "run", Command: `touch should-not-run`},
 	})
 
-	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{}).RunJob(t.Context(), job, workspace)
 	if err == nil || result.Conclusion != "failure" || !strings.Contains(err.Error(), "name: expression references unavailable step") {
 		t.Fatalf("RunJob() result = %#v, error = %v, want unavailable background output in name", result, err)
 	}
@@ -1951,8 +1952,8 @@ func TestBackgroundSupervisorBoundsActiveWorkAndQueuesFIFO(t *testing.T) {
 	var active atomic.Int32
 	var maximum atomic.Int32
 	var started atomic.Int32
-	for i := 0; i < maxActiveBackgroundSteps+2; i++ {
-		supervisor.start(context.Background(), strconv.Itoa(i), func(context.Context) stepExecution {
+	for i := range maxActiveBackgroundSteps + 2 {
+		supervisor.start(t.Context(), strconv.Itoa(i), func(context.Context) stepExecution {
 			current := active.Add(1)
 			for current > maximum.Load() && !maximum.CompareAndSwap(maximum.Load(), current) {
 			}
@@ -1982,7 +1983,7 @@ func TestBackgroundSupervisorBoundsActiveWorkAndQueuesFIFO(t *testing.T) {
 	var mu sync.Mutex
 	var order []string
 	start := func(id string, wait <-chan struct{}) {
-		fifo.start(context.Background(), id, func(context.Context) stepExecution {
+		fifo.start(t.Context(), id, func(context.Context) stepExecution {
 			mu.Lock()
 			order = append(order, id)
 			mu.Unlock()
@@ -2028,7 +2029,7 @@ console.log('post-after-implicit-wait')
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "background", Kind: "uses", Uses: "./.github/actions/background", Background: true}})
 	job.Outputs = map[string]string{"value": "${{ steps.background.outputs.value }}"}
 
-	result, err := (Runner{Node24: node, Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node24: node, Stdout: &logs, Stderr: &logs}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" || result.Outputs["value"] != "implicit" || result.Env["BACKGROUND_READY"] != "true" {
 		t.Fatalf("RunJob() result = %#v, error = %v, logs = %q", result, err, logs.String())
 	}
@@ -2050,7 +2051,7 @@ require('node:fs').appendFileSync(process.env.CWD_LOG, %q + process.cwd() + '\t'
 	}
 	cwdLog := filepath.Join(t.TempDir(), "cwd.log")
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "cwd", Kind: "uses", Uses: "./.github/actions/cwd", Env: map[string]string{"CWD_LOG": cwdLog}}})
-	result, err := (Runner{Node24: node}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node24: node}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -2102,7 +2103,7 @@ require('node:fs').writeFileSync(process.env.CWD_LOG, process.cwd() + '\t' + pro
 `)
 	cwdLog := filepath.Join(base, "cwd.log")
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "cwd", Kind: "uses", Uses: "./.github/actions/cwd", Env: map[string]string{"CWD_LOG": cwdLog}}})
-	result, err := (Runner{Node24: node}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node24: node}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -2138,7 +2139,7 @@ func TestConcurrentStreamsShareMaskRegistration(t *testing.T) {
 		{ID: "wait", Kind: "wait-all"},
 	})
 	job.Env = map[string]string{"MASK_READY": marker}
-	result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -2167,12 +2168,12 @@ func TestConcurrentSmokeWorkflowEndToEnd(t *testing.T) {
 	}
 	var logs bytes.Buffer
 	runner := Runner{Stdout: &logs, Stderr: &logs}
-	concurrent, err := runner.RunJob(context.Background(), plans[0], workspace)
+	concurrent, err := runner.RunJob(t.Context(), plans[0], workspace)
 	if err != nil || concurrent.Conclusion != "success" {
 		t.Fatalf("concurrent result = %#v, error = %v, logs = %q", concurrent, err, logs.String())
 	}
 	plans[1].Needs = map[string]plan.Need{"concurrent": {Result: concurrent.Conclusion, Outputs: concurrent.Outputs}}
-	observer, err := runner.RunJob(context.Background(), plans[1], workspace)
+	observer, err := runner.RunJob(t.Context(), plans[1], workspace)
 	if err != nil || observer.Conclusion != "success" {
 		t.Fatalf("observer result = %#v, error = %v, logs = %q", observer, err, logs.String())
 	}
@@ -2192,7 +2193,7 @@ func TestCancellationTerminatesChildProcessGroup(t *testing.T) {
 		t.Skip("process groups are implemented for the initial Linux runtime and Darwin development hosts")
 	}
 	pidFile := filepath.Join(t.TempDir(), "child.pid")
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 	defer cancel()
 	err := (Runner{InterruptGrace: 50 * time.Millisecond, TerminateGrace: 50 * time.Millisecond}).runStreaming(ctx, newCommandProcessor(io.Discard, io.Discard), "", map[string]string{"PID_FILE": pidFile}, "sh", "-c", `(trap '' INT TERM; sleep 30) & echo $! > "$PID_FILE"; wait`)
 	if !errors.Is(err, context.DeadlineExceeded) {
@@ -2225,7 +2226,7 @@ func TestCancellationEscalatesFromInterruptToTermination(t *testing.T) {
 	dir := t.TempDir()
 	ready := filepath.Join(dir, "ready")
 	signals := filepath.Join(dir, "signals")
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	cancelled := make(chan struct{})
 	go func() {
@@ -2269,7 +2270,7 @@ func TestCancellationPreservesInterruptGraceForDescendants(t *testing.T) {
 	ready := filepath.Join(dir, "ready")
 	childReady := filepath.Join(dir, "child-ready")
 	cleaned := filepath.Join(dir, "cleaned")
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	go func() {
 		deadline := time.Now().Add(2 * time.Second)
@@ -2310,7 +2311,7 @@ func TestCancellationWaitsForProcessGroupCleanupAfterOutputCloses(t *testing.T) 
 	dir := t.TempDir()
 	pidFile := filepath.Join(dir, "child.pid")
 	ready := filepath.Join(dir, "ready")
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	go func() {
 		deadline := time.Now().Add(2 * time.Second)
@@ -2373,7 +2374,7 @@ func TestExplicitCancelTerminatesBackgroundProcessGroup(t *testing.T) {
 	})
 	job.Env = map[string]string{"PID_FILE": pidFile, "READY": ready}
 
-	result, err := (Runner{InterruptGrace: 50 * time.Millisecond, TerminateGrace: 50 * time.Millisecond}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{InterruptGrace: 50 * time.Millisecond, TerminateGrace: 50 * time.Millisecond}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -2429,13 +2430,13 @@ func TestJobConditionConsumesNeedResultAndOutput(t *testing.T) {
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "run", Kind: "run", Command: "true"}})
 	job.Needs = map[string]plan.Need{"producer": {Result: "failure", Outputs: map[string]string{"gate": "yes"}}}
 	job.Condition = "always() && needs.producer.result == 'failure' && needs.producer.outputs.gate"
-	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
 	job.Condition = ""
 	job.Needs["producer"] = plan.Need{Result: "skipped"}
-	result, err = (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err = (Runner{}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "skipped" {
 		t.Fatalf("RunJob() skipped prerequisite result = %#v, error = %v", result, err)
 	}
@@ -2452,7 +2453,7 @@ func TestReusableWorkflowCallGuardsRunBeforeCapabilitiesAndJobConditions(t *test
 	job.RequiredSecrets = []string{"TOKEN"}
 	job.Condition = "always()"
 
-	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "skipped" || len(result.Outputs) != 0 {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -2473,7 +2474,7 @@ func TestReusableWorkflowCallGuardUsesOnlyCallerNeeds(t *testing.T) {
 	job.Needs = map[string]plan.Need{"internal": {Result: "failure"}}
 	job.Condition = "always()"
 
-	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -2484,12 +2485,12 @@ func TestReusableWorkflowCallGuardUsesOnlyCallerNeeds(t *testing.T) {
 		t.Fatal("Validate() accepted an empty call guard condition")
 	}
 	job.CallGuards[0].Condition = "needs.caller.outputs.ready"
-	result, err = (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err = (Runner{}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "skipped" {
 		t.Fatalf("implicit success guard result = %#v, error = %v", result, err)
 	}
 	job.CallGuards[0].Condition = "failure()"
-	result, err = (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err = (Runner{}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("failure() guard result = %#v, error = %v", result, err)
 	}
@@ -2523,7 +2524,7 @@ func TestJobRuntimeFieldsEvaluateCompoundExpressions(t *testing.T) {
 		"result":      "${{ format('{0}-{1}', steps.run.outputs.value, needs.producer.result) }}",
 	}
 
-	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" || result.Outputs["result"] != "done-success" || result.Outputs["environment"] != "job" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -2553,7 +2554,7 @@ func TestDecodedPlanMatrixNumbersDriveRuntimeConditions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	result, err := (Runner{}).RunJob(context.Background(), decoded, workspace)
+	result, err := (Runner{}).RunJob(t.Context(), decoded, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -2576,7 +2577,7 @@ func TestRunJobRejectsRegisteredSecretInOutput(t *testing.T) {
 	job.RequiredCapabilities = []string{"secrets"}
 	job.RequiredSecrets = []string{"CANARY"}
 	job.Outputs = map[string]string{"leak": "${{ secrets.CANARY }}"}
-	_, err := (Runner{Secrets: testSecretResolver{"CANARY": "do-not-publish"}, Redactor: &testRedactor{}}).RunJob(context.Background(), job, workspace)
+	_, err := (Runner{Secrets: testSecretResolver{"CANARY": "do-not-publish"}, Redactor: &testRedactor{}}).RunJob(t.Context(), job, workspace)
 	if err == nil || !strings.Contains(err.Error(), "contains a registered secret") || strings.Contains(err.Error(), "do-not-publish") {
 		t.Fatalf("RunJob() error = %v, want non-disclosing secret-output rejection", err)
 	}
@@ -2589,7 +2590,7 @@ func TestRunJobScrubsSecretFromRedactorFailure(t *testing.T) {
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "run", Kind: "run", Command: "true"}})
 	job.RequiredCapabilities = []string{"secrets"}
 	job.RequiredSecrets = []string{"CANARY"}
-	_, err := (Runner{Secrets: testSecretResolver{"CANARY": "do-not-leak"}, Redactor: failingTokenRedactor{token: "do-not-leak"}}).RunJob(context.Background(), job, workspace)
+	_, err := (Runner{Secrets: testSecretResolver{"CANARY": "do-not-leak"}, Redactor: failingTokenRedactor{token: "do-not-leak"}}).RunJob(t.Context(), job, workspace)
 	if err == nil || strings.Contains(err.Error(), "do-not-leak") || !strings.Contains(err.Error(), "***") {
 		t.Fatalf("RunJob() error = %v, want scrubbed redactor failure", err)
 	}
@@ -2611,7 +2612,7 @@ func TestRunJobMintsAndRedactsScopedGitHubWorkflowToken(t *testing.T) {
 	provider := &testWorkflowTokenProvider{token: token}
 	redactor := &testRedactor{}
 	var logs bytes.Buffer
-	result, err := (Runner{Stdout: &logs, Stderr: &logs, WorkflowToken: provider, Redactor: redactor}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Stdout: &logs, Stderr: &logs, WorkflowToken: provider, Redactor: redactor}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -2636,7 +2637,7 @@ func TestRunJobRejectsInvalidWorkflowTokenPolicyBeforeMinting(t *testing.T) {
 	job.RequiredCapabilities = []string{"provider-token-write"}
 	job.GitHubToken = &plan.GitHubToken{Workflow: "nested/test.yml", Permissions: map[string]string{"contents": "read"}}
 	provider := &testWorkflowTokenProvider{token: "must-not-be-minted"}
-	_, err := (Runner{WorkflowToken: provider, Redactor: &testRedactor{}}).RunJob(context.Background(), job, workspace)
+	_, err := (Runner{WorkflowToken: provider, Redactor: &testRedactor{}}).RunJob(t.Context(), job, workspace)
 	if err == nil || !strings.Contains(err.Error(), "simple .yml or .yaml filename") || provider.calls != 0 {
 		t.Fatalf("RunJob() error/calls = %v / %d", err, provider.calls)
 	}
@@ -2883,7 +2884,7 @@ runs:
 	if err != nil {
 		t.Fatal(err)
 	}
-	plans, err := compilePlansForTest(context.Background(), workflowPath, workflow, event, "0.0.0-test", "sha256:"+strings.Repeat("2", 64), compiler.Options{
+	plans, err := compilePlansForTest(t.Context(), workflowPath, workflow, event, "0.0.0-test", "sha256:"+strings.Repeat("2", 64), compiler.Options{
 		EventTrust: compiler.EventUntrusted,
 		Runners: compiler.RunnerPolicy{
 			Labels:                     map[string]string{"ubuntu-latest": ""},
@@ -2899,7 +2900,7 @@ runs:
 	provider := &testWorkflowTokenProvider{token: "ghs_scoped_action_default"}
 	redactor := &testRedactor{}
 	var logs bytes.Buffer
-	result, err := (Runner{Node24: node, Stdout: &logs, Stderr: &logs, WorkflowToken: provider, Redactor: redactor}).RunJob(context.Background(), plans[0], workspace)
+	result, err := (Runner{Node24: node, Stdout: &logs, Stderr: &logs, WorkflowToken: provider, Redactor: redactor}).RunJob(t.Context(), plans[0], workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -2958,7 +2959,7 @@ runs:
 	}
 
 	provider := &testWorkflowTokenProvider{token: "must-not-be-minted"}
-	result, err := (Runner{WorkflowToken: provider, Secrets: testSecretResolver{}}).RunJob(context.Background(), plans[0], workspace)
+	result, err := (Runner{WorkflowToken: provider, Secrets: testSecretResolver{}}).RunJob(t.Context(), plans[0], workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -2977,7 +2978,7 @@ func TestRunJobAbortsAndScrubsWorkflowTokenWhenRedactionFails(t *testing.T) {
 	job.Event.Repository = "buildkite/buildkite-gha"
 	job.RequiredCapabilities = []string{"provider-token-write"}
 	job.GitHubToken = &plan.GitHubToken{Workflow: "test.yml", Permissions: map[string]string{"pull_requests": "write"}}
-	_, err := (Runner{WorkflowToken: &testWorkflowTokenProvider{token: token}, Redactor: failingTokenRedactor{token: token}}).RunJob(context.Background(), job, workspace)
+	_, err := (Runner{WorkflowToken: &testWorkflowTokenProvider{token: token}, Redactor: failingTokenRedactor{token: token}}).RunJob(t.Context(), job, workspace)
 	if err == nil || strings.Contains(err.Error(), token) || !strings.Contains(err.Error(), "***") {
 		t.Fatalf("RunJob() error = %v, want redaction failure without token disclosure", err)
 	}
@@ -2989,11 +2990,11 @@ func TestRunJobRequiresHydratedStaticDependencyResults(t *testing.T) {
 	job := runtimePlan(t, workspace, ".github/workflows/test.yml", []plan.Step{{ID: "run", Kind: "run", Command: "true"}})
 	job.Dependencies = []string{"gha-producer"}
 	job.NeedSources = map[string][]plan.NeedSource{"producer": {{StepKey: "gha-producer", PlanDigest: "sha256:" + strings.Repeat("1", 64)}}}
-	if _, err := (Runner{}).RunJob(context.Background(), job, workspace); err == nil || !strings.Contains(err.Error(), "no hydrated prerequisite results") {
+	if _, err := (Runner{}).RunJob(t.Context(), job, workspace); err == nil || !strings.Contains(err.Error(), "no hydrated prerequisite results") {
 		t.Fatalf("RunJob() error = %v, want missing hydration rejection", err)
 	}
 	job.Needs = map[string]plan.Need{"producer": {Result: "success"}}
-	if result, err := (Runner{}).RunJob(context.Background(), job, workspace); err != nil || result.Conclusion != "success" {
+	if result, err := (Runner{}).RunJob(t.Context(), job, workspace); err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() hydrated result = %#v, error = %v", result, err)
 	}
 }
@@ -3005,7 +3006,7 @@ func TestJavaScriptPreMainPostFilesAndMasking(t *testing.T) {
 	runner := Runner{Stdout: &logs, Stderr: &logs, Node24: node}
 	job := runtimePlan(t, workspace, "smoke/.github/workflows/ci.yml", []plan.Step{{ID: "javascript", Kind: "uses", Uses: "./actions/javascript", With: map[string]string{"message": "hello"}}})
 	job.Outputs = map[string]string{"result": "${{ steps.javascript.outputs.result }}"}
-	result, err := runner.RunJob(context.Background(), job, workspace)
+	result, err := runner.RunJob(t.Context(), job, workspace)
 	if err != nil {
 		t.Fatalf("RunJob() error = %v", err)
 	}
@@ -3070,7 +3071,7 @@ esac
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "summary", Kind: "uses", Uses: "./.github/actions/summary"}})
 	job.Env = map[string]string{"MAIN_SUMMARY_BYTES": strconv.Itoa(maxJobSummaryBytes)}
 
-	result, err := (Runner{Node24: fakeNode}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node24: fakeNode}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -3094,7 +3095,7 @@ printf 'retained summary\n' >> "$GITHUB_STEP_SUMMARY"`},
 	job.Env = map[string]string{"SUMMARY_BYTES": strconv.Itoa(maxCommandFileBytes + 1)}
 	var logs bytes.Buffer
 
-	result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" || result.Env["SUMMARY_EFFECT"] != "preserved" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -3114,7 +3115,7 @@ func TestPostActionsRunLIFOAfterMainFailure(t *testing.T) {
 		{ID: "one", Kind: "uses", Uses: "./actions/javascript", With: map[string]string{"message": "one", "order": "one"}},
 		{ID: "two", Kind: "uses", Uses: "./actions/javascript", With: map[string]string{"message": "two", "order": "two", "fail": "true"}},
 	})
-	_, err := runner.RunJob(context.Background(), job, workspace)
+	_, err := runner.RunJob(t.Context(), job, workspace)
 	if err == nil {
 		t.Fatal("RunJob() error = nil, want main failure")
 	}
@@ -3175,7 +3176,7 @@ if [ "${1##*/}" = post.js ]; then printenv INPUT_JOB_STATUS > "$POST_MARKER"; fi
 	post := filepath.Join(workspace, "post")
 	plans[0].Env = map[string]string{"ORDINARY_MARKER": ordinary, "RECOVERY_MARKER": recovery, "POST_MARKER": post}
 
-	result, runErr := (Runner{Node24: fakeNode}).RunJob(context.Background(), plans[0], workspace)
+	result, runErr := (Runner{Node24: fakeNode}).RunJob(t.Context(), plans[0], workspace)
 	if runErr == nil || !IsToleratedJobFailure(runErr) || result.Conclusion != "success" || result.Outputs["diagnostic"] != "failed" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, runErr)
 	}
@@ -3197,7 +3198,7 @@ if [ "${1##*/}" = post.js ]; then printenv INPUT_JOB_STATUS > "$POST_MARKER"; fi
 	timedOut.TimeoutMinutes = 0.001
 	timedOut.Steps = slices.Clone(timedOut.Steps)
 	timedOut.Steps[1].Command = "sleep 1"
-	result, runErr = (Runner{Node24: fakeNode}).RunJob(context.Background(), timedOut, workspace)
+	result, runErr = (Runner{Node24: fakeNode}).RunJob(t.Context(), timedOut, workspace)
 	if !errors.Is(runErr, context.DeadlineExceeded) || IsToleratedJobFailure(runErr) || result.Conclusion != "cancelled" {
 		t.Fatalf("timed out RunJob() result = %#v, error = %v", result, runErr)
 	}
@@ -3217,7 +3218,7 @@ func TestJobTimeoutDuringSetupIsCancelled(t *testing.T) {
 		return "", ctx.Err()
 	}}
 
-	result, err := runner.RunJob(context.Background(), job, workspace)
+	result, err := runner.RunJob(t.Context(), job, workspace)
 	if !errors.Is(err, context.DeadlineExceeded) || IsToleratedJobFailure(err) || result.Conclusion != "cancelled" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -3262,7 +3263,7 @@ if [ "${1##*/}" = main.js ] && [ "${FAIL_MAIN:-false}" = true ]; then exit 9; fi
 			job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "conditional", Kind: "uses", Uses: "./.github/actions/conditional"}})
 			job.Env = map[string]string{"POST_MARKER": marker, "FAIL_MAIN": strconv.FormatBool(test.failMain)}
 
-			result, err := (Runner{Node24: fakeNode}).RunJob(context.Background(), job, workspace)
+			result, err := (Runner{Node24: fakeNode}).RunJob(t.Context(), job, workspace)
 			if (err != nil) != test.wantFailure || (result.Conclusion == "failure") != test.wantFailure {
 				t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 			}
@@ -3338,7 +3339,7 @@ esac
 			}
 			job := runtimePlan(t, workspace, workflowPath, steps)
 			job.Env = map[string]string{"CACHE_SETTING": test.cacheValue, "POST_MARKER": marker}
-			result, err := (Runner{Node24: fakeNode}).RunJob(context.Background(), job, workspace)
+			result, err := (Runner{Node24: fakeNode}).RunJob(t.Context(), job, workspace)
 			if (err != nil) != test.failJob || (result.Conclusion == "failure") != test.failJob {
 				t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 			}
@@ -3398,7 +3399,7 @@ esac
 		{ID: "finalize", Kind: "run", Command: "exit 7"},
 	})
 	job.Env = map[string]string{"POST_MARKER": marker}
-	result, err := (Runner{Node24: fakeNode}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node24: fakeNode}).RunJob(t.Context(), job, workspace)
 	if err == nil || result.Conclusion != "failure" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -3434,7 +3435,7 @@ if [ "$(basename "$1")" = post.js ]; then touch "$POST_MARKER"; fi
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "cache", Kind: "uses", Uses: "./.github/actions/cache"}})
 	job.Inputs = map[string]any{"cache": true}
 	job.Env = map[string]string{"POST_MARKER": marker}
-	result, err := (Runner{Node24: fakeNode}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node24: fakeNode}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -3453,7 +3454,7 @@ func TestRunnerToolCacheIsPerJobAndReserved(t *testing.T) {
 		Command: `test -d "$RUNNER_TOOL_CACHE"; case "$RUNNER_TOOL_CACHE" in "$RUNNER_TEMP"/*) ;; *) exit 9 ;; esac`,
 	}})
 	job.Env = map[string]string{"RUNNER_TOOL_CACHE": filepath.Join(workspace, "untrusted")}
-	if result, err := (Runner{}).RunJob(context.Background(), job, workspace); err != nil || result.Conclusion != "success" {
+	if result, err := (Runner{}).RunJob(t.Context(), job, workspace); err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
 }
@@ -3472,7 +3473,7 @@ func TestRunnerUsesConfiguredToolCache(t *testing.T) {
 		Command: `test "$RUNNER_TOOL_CACHE" = "$EXPECTED_TOOL_CACHE"`,
 	}})
 	job.Env = map[string]string{"EXPECTED_TOOL_CACHE": toolCache}
-	if result, err := (Runner{ToolCache: toolCache}).RunJob(context.Background(), job, workspace); err != nil || result.Conclusion != "success" {
+	if result, err := (Runner{ToolCache: toolCache}).RunJob(t.Context(), job, workspace); err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
 }
@@ -3590,7 +3591,7 @@ func TestConcurrentPostActionsRunLIFOByRegistration(t *testing.T) {
 	job.Env = map[string]string{"READY": ready}
 	var logs bytes.Buffer
 
-	result, err := (Runner{Node24: node, Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node24: node, Stdout: &logs, Stderr: &logs}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v, logs = %q", result, err, logs.String())
 	}
@@ -3613,7 +3614,7 @@ func TestPostActionsUseBoundedCleanupContext(t *testing.T) {
 	runner := Runner{Node24: node, CleanupTimeout: 200 * time.Millisecond}
 	job := runtimePlan(t, workspace, ".github/workflows/test.yml", []plan.Step{{ID: "slow", Kind: "uses", Uses: "./.github/actions/slow"}})
 	started := time.Now()
-	_, err := runner.RunJob(context.Background(), job, workspace)
+	_, err := runner.RunJob(t.Context(), job, workspace)
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("RunJob() error = %v, want context deadline exceeded", err)
 	}
@@ -3651,7 +3652,7 @@ sleep 30
 		InterruptGrace: 20 * time.Millisecond, TerminateGrace: 20 * time.Millisecond,
 	}
 	started := time.Now()
-	result, err := runner.RunJob(context.Background(), job, workspace)
+	result, err := runner.RunJob(t.Context(), job, workspace)
 	if !errors.Is(err, context.DeadlineExceeded) || result.Conclusion != "cancelled" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -3674,7 +3675,7 @@ func TestCancellationStillRunsRegisteredPostAction(t *testing.T) {
 	writeFixtureFile(t, workspace, ".github/actions/cancel/post.js", "console.log('post-after-cancel')\n")
 	var logs bytes.Buffer
 	job := runtimePlan(t, workspace, ".github/workflows/test.yml", []plan.Step{{ID: "cancel", Kind: "uses", Uses: "./.github/actions/cancel"}})
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 	defer cancel()
 	result, err := (Runner{Node24: node, Stdout: &logs, Stderr: &logs}).RunJob(ctx, job, workspace)
 	if !errors.Is(err, context.DeadlineExceeded) || result.Conclusion != "cancelled" || !strings.Contains(logs.String(), "post-after-cancel") {
@@ -3700,7 +3701,7 @@ func TestExplicitBackgroundCancelStillRunsRegisteredPostAction(t *testing.T) {
 	})
 	job.Env = map[string]string{"READY": ready}
 
-	result, err := (Runner{Node24: node, Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node24: node, Stdout: &logs, Stderr: &logs}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" || !strings.Contains(logs.String(), "post-after-explicit-cancel") {
 		t.Fatalf("RunJob() result = %#v, error = %v, logs = %q", result, err, logs.String())
 	}
@@ -3947,7 +3948,7 @@ func TestRunStreamingDrainsOversizedLineAndPreservesMasking(t *testing.T) {
 	}
 	var logs bytes.Buffer
 	processor := newCommandProcessor(&logs, &logs)
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 	err = (Runner{}).runStreaming(ctx, processor, "", map[string]string{"GO_WANT_RUNTIME_LONG_LINE": "1"}, executable, "-test.run=^TestLongLineChildProcess$")
 	if err == nil || !strings.Contains(err.Error(), "stdout stream: line exceeds 1048576-byte limit and was discarded") {
@@ -4009,7 +4010,7 @@ test -z "${HTTP_PROXY+x}" && test -z "${HTTPS_PROXY+x}" && test -z "${ALL_PROXY+
 test -z "${http_proxy+x}" && test -z "${https_proxy+x}" && test -z "${all_proxy+x}" && test -z "${no_proxy+x}"
 printf '%s\n' environment-ok
 `
-	if err := (Runner{}).runStreaming(context.Background(), processor, "", map[string]string{"DECLARED": "visible"}, "sh", "-c", command); err != nil {
+	if err := (Runner{}).runStreaming(t.Context(), processor, "", map[string]string{"DECLARED": "visible"}, "sh", "-c", command); err != nil {
 		t.Fatalf("runStreaming() error = %v", err)
 	}
 	if logs.String() != "environment-ok\n" {
@@ -4026,7 +4027,7 @@ func TestRunStreamingRejectsInvalidEnvironmentNamesBeforeExecution(t *testing.T)
 	for _, name := range []string{"", "ALIAS=OTHER", "NUL\x00NAME"} {
 		t.Run(fmt.Sprintf("%q", name), func(t *testing.T) {
 			marker := filepath.Join(t.TempDir(), "ran")
-			err := (Runner{}).runStreaming(context.Background(), newCommandProcessor(io.Discard, io.Discard), "", map[string]string{name: "value"}, "sh", "-c", `touch "$1"`, "sh", marker)
+			err := (Runner{}).runStreaming(t.Context(), newCommandProcessor(io.Discard, io.Discard), "", map[string]string{name: "value"}, "sh", "-c", `touch "$1"`, "sh", marker)
 			if err == nil || !strings.Contains(err.Error(), "invalid environment variable name") {
 				t.Fatalf("runStreaming() error = %v, want invalid environment name", err)
 			}
@@ -4036,7 +4037,7 @@ func TestRunStreamingRejectsInvalidEnvironmentNamesBeforeExecution(t *testing.T)
 		})
 	}
 
-	if err := (Runner{}).runStreaming(context.Background(), newCommandProcessor(io.Discard, io.Discard), "", map[string]string{"GITHUB-ACTIONS_NAME.1": "valid"}, "true"); err != nil {
+	if err := (Runner{}).runStreaming(t.Context(), newCommandProcessor(io.Discard, io.Discard), "", map[string]string{"GITHUB-ACTIONS_NAME.1": "valid"}, "true"); err != nil {
 		t.Fatalf("valid GitHub Actions environment name was rejected: %v", err)
 	}
 }
@@ -4052,7 +4053,7 @@ func TestRunDockerRejectsInvalidEnvironmentNamesBeforeDocker(t *testing.T) {
 			action := fakeDockerAction(t)
 			action.runnerTemp = t.TempDir()
 			action.Env = map[string]string{name: "value"}
-			_, err := (Runner{Docker: docker}).runDocker(context.Background(), newCommandProcessor(io.Discard, io.Discard), action)
+			_, err := (Runner{Docker: docker}).runDocker(t.Context(), newCommandProcessor(io.Discard, io.Discard), action)
 			if err == nil || !strings.Contains(err.Error(), "invalid environment variable name") {
 				t.Fatalf("runDocker() error = %v, want invalid environment name", err)
 			}
@@ -4250,7 +4251,7 @@ func TestRunJobLogsSynchronousStepSectionsAndExpandsFailures(t *testing.T) {
 	job.Matrix = map[string]any{"version": "1.26"}
 	var logs bytes.Buffer
 
-	result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(t.Context(), job, workspace)
 	if err == nil || result.Conclusion != "failure" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -4290,7 +4291,7 @@ printf '::warning::untrusted warning-shaped output\r\n'
 printf '::crlf-stop-token::\r\n'
 printf '::add-mask::crlf-secret\r\n'
 printf 'masked after resume: crlf-secret\r\n'`
-	if err := (Runner{}).runStreaming(context.Background(), processor, "", nil, "sh", "-c", command); err != nil {
+	if err := (Runner{}).runStreaming(t.Context(), processor, "", nil, "sh", "-c", command); err != nil {
 		t.Fatalf("runStreaming() error = %v", err)
 	}
 	warnings, _, commandErrors, _ := processor.workflowCommandAnnotations()
@@ -4312,7 +4313,7 @@ func TestRunStreamingScopesWorkflowCommandFailuresToInvocation(t *testing.T) {
 	release := filepath.Join(t.TempDir(), "release-clean")
 	cleanDone := make(chan error, 1)
 	go func() {
-		cleanDone <- (Runner{}).runStreaming(context.Background(), processor, "", map[string]string{"READY": ready, "RELEASE": release}, "sh", "-c", `
+		cleanDone <- (Runner{}).runStreaming(t.Context(), processor, "", map[string]string{"READY": ready, "RELEASE": release}, "sh", "-c", `
 : > "$READY"
 while [ ! -e "$RELEASE" ]; do sleep .01; done
 printf '%s\n' 'clean invocation completed'`)
@@ -4327,7 +4328,7 @@ printf '%s\n' 'clean invocation completed'`)
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	invalidErr := (Runner{}).runStreaming(context.Background(), processor, "", map[string]string{"RELEASE": release}, "sh", "-c", `
+	invalidErr := (Runner{}).runStreaming(t.Context(), processor, "", map[string]string{"RELEASE": release}, "sh", "-c", `
 printf '%s\n' '::stop-commands::warning'
 : > "$RELEASE"`)
 	cleanErr := <-cleanDone
@@ -4351,7 +4352,7 @@ func TestInvalidWorkflowCommandStopTokenFailsTheStep(t *testing.T) {
 			}})
 			var logs bytes.Buffer
 
-			result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+			result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(t.Context(), job, workspace)
 			if err == nil || !strings.Contains(err.Error(), "invalid ::stop-commands workflow command") || result.Conclusion != "failure" {
 				t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 			}
@@ -4375,7 +4376,7 @@ func TestRunJobCollectsWarningAndErrorCommandsWithoutChangingConclusion(t *testi
 	}})
 	var stdout, stderr bytes.Buffer
 
-	result, err := (Runner{Stdout: &stdout, Stderr: &stderr}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Stdout: &stdout, Stderr: &stderr}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -4390,11 +4391,11 @@ func TestRunJobCollectsWarningAndErrorCommandsWithoutChangingConclusion(t *testi
 func TestWorkflowCommandAnnotationsAreConcurrentAndUTF8Bounded(t *testing.T) {
 	processor := newCommandProcessor(io.Discard, io.Discard)
 	var group sync.WaitGroup
-	for worker := 0; worker < 2; worker++ {
+	for worker := range 2 {
 		group.Add(1)
 		go func(worker int) {
 			defer group.Done()
-			for message := 0; message < 50; message++ {
+			for message := range 50 {
 				_ = processor.process(io.Discard, fmt.Sprintf("::warning::worker-%d-message-%d", worker, message))
 			}
 		}(worker)
@@ -4417,7 +4418,7 @@ func TestWorkflowCommandAnnotationsAreConcurrentAndUTF8Bounded(t *testing.T) {
 func TestWorkflowCommandAnnotationsNormalizeInvalidUTF8(t *testing.T) {
 	processor := newCommandProcessor(io.Discard, io.Discard)
 	command := `printf '::warning title=bad\377,file=bad\376.go::bad\375\n'`
-	if err := (Runner{}).runStreaming(context.Background(), processor, "", nil, "sh", "-c", command); err != nil {
+	if err := (Runner{}).runStreaming(t.Context(), processor, "", nil, "sh", "-c", command); err != nil {
 		t.Fatalf("runStreaming() error = %v", err)
 	}
 
@@ -4492,7 +4493,7 @@ runs:
   steps: []
 `)
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "conflict", Kind: "uses", Uses: "./.github/actions/conflict"}})
-	if _, err := (Runner{}).RunJob(context.Background(), job, workspace); err == nil || !strings.Contains(err.Error(), `duplicate case-insensitive name "result"`) {
+	if _, err := (Runner{}).RunJob(t.Context(), job, workspace); err == nil || !strings.Contains(err.Error(), `duplicate case-insensitive name "result"`) {
 		t.Fatalf("RunJob() error = %v, want duplicate output rejection", err)
 	}
 }
@@ -4506,7 +4507,7 @@ func TestDiscoverNodeManagedAndWrongExplicitVersion(t *testing.T) {
 	if err := os.WriteFile(node, []byte("#!/bin/sh\necho v24.99.0\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	got, err := discoverNodeContext(context.Background(), 24, "", managed)
+	got, err := discoverNodeContext(t.Context(), 24, "", managed)
 	if err != nil || got != node {
 		t.Fatalf("discoverNodeContext(24) = %q, %v, want %q, nil", got, err, node)
 	}
@@ -4515,7 +4516,7 @@ func TestDiscoverNodeManagedAndWrongExplicitVersion(t *testing.T) {
 	if err := os.WriteFile(wrong, []byte("#!/bin/sh\necho v23.1.0\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := discoverNodeContext(context.Background(), 24, wrong, ""); err == nil || !strings.Contains(err.Error(), `reported "v23.1.0"`) {
+	if _, err := discoverNodeContext(t.Context(), 24, wrong, ""); err == nil || !strings.Contains(err.Error(), `reported "v23.1.0"`) {
 		t.Fatalf("discoverNodeContext(24) error = %v, want wrong-version detail", err)
 	}
 
@@ -4526,10 +4527,10 @@ func TestDiscoverNodeManagedAndWrongExplicitVersion(t *testing.T) {
 	if err := os.WriteFile(node20, []byte("#!/bin/sh\necho v20.99.0\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if got, err := discoverNodeContext(context.Background(), 20, "", managed); err != nil || got != node20 {
+	if got, err := discoverNodeContext(t.Context(), 20, "", managed); err != nil || got != node20 {
 		t.Fatalf("discoverNodeContext(20) = %q, %v, want %q, nil", got, err, node20)
 	}
-	if _, err := discoverNodeContext(context.Background(), 24, node20, ""); err == nil || !strings.Contains(err.Error(), `reported "v20.99.0"`) {
+	if _, err := discoverNodeContext(t.Context(), 24, node20, ""); err == nil || !strings.Contains(err.Error(), `reported "v20.99.0"`) {
 		t.Fatalf("discoverNodeContext(24) error = %v, want exact-major rejection", err)
 	}
 }
@@ -4539,7 +4540,7 @@ func TestDiscoverNodePreservesDeadline(t *testing.T) {
 	if err := os.WriteFile(node, []byte("#!/bin/sh\nexec sleep 5\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
 	defer cancel()
 
 	_, err := discoverNodeContext(ctx, 24, node, "")
@@ -4550,7 +4551,7 @@ func TestDiscoverNodePreservesDeadline(t *testing.T) {
 	if err := os.WriteFile(node, []byte("#!/bin/sh\nexit 7\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	_, err = discoverNodeContext(context.Background(), 24, node, "")
+	_, err = discoverNodeContext(t.Context(), 24, node, "")
 	if err == nil || errors.Is(err, context.DeadlineExceeded) || !strings.Contains(err.Error(), "exit status 7") {
 		t.Fatalf("discoverNodeContext(24) error = %v, want genuine discovery failure", err)
 	}
@@ -4576,7 +4577,7 @@ func TestMiseNodeSelectionIsExactAndConfigFree(t *testing.T) {
 	}
 	digest := sha256.Sum256(nodeBytes)
 	r := Runner{Mise: mise, MiseDataDir: dataDir, nodeDigests: map[int]string{20: hex.EncodeToString(digest[:])}}
-	got, err := r.discoverNode(context.Background(), 20, "")
+	got, err := r.discoverNode(t.Context(), 20, "")
 	if err != nil || got != node {
 		t.Fatalf("discoverNode() = %q, %v", got, err)
 	}
@@ -4608,7 +4609,7 @@ func TestMiseNode16SelectionIsExactAndConfigFree(t *testing.T) {
 		t.Fatal(err)
 	}
 	digest := sha256.Sum256(nodeBytes)
-	got, err := (Runner{Mise: mise, MiseDataDir: dataDir, nodeDigests: map[int]string{16: hex.EncodeToString(digest[:])}}).discoverNode(context.Background(), 16, "")
+	got, err := (Runner{Mise: mise, MiseDataDir: dataDir, nodeDigests: map[int]string{16: hex.EncodeToString(digest[:])}}).discoverNode(t.Context(), 16, "")
 	if err != nil || got != node {
 		t.Fatalf("discoverNode() = %q, %v", got, err)
 	}
@@ -4643,7 +4644,7 @@ func TestMiseNodeInstallationAllowsSymlinkedDataDirAncestor(t *testing.T) {
 	if err := os.Chmod(mise, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	gotInstallation, gotNode, err := (Runner{MiseDataDir: dataDir}).miseNodeInstallation(context.Background(), 24, mise)
+	gotInstallation, gotNode, err := (Runner{MiseDataDir: dataDir}).miseNodeInstallation(t.Context(), 24, mise)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4662,7 +4663,7 @@ func TestMiseNodeInstallationAllowsSymlinkedDataDirAncestor(t *testing.T) {
 	if err := os.Symlink(outside, filepath.Join(wantInstallation, "bin")); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := (Runner{MiseDataDir: dataDir}).miseNodeInstallation(context.Background(), 24, mise); err == nil || !strings.Contains(err.Error(), "symlink") {
+	if _, _, err := (Runner{MiseDataDir: dataDir}).miseNodeInstallation(t.Context(), 24, mise); err == nil || !strings.Contains(err.Error(), "symlink") {
 		t.Fatalf("miseNodeInstallation() accepted symlinked bin directory: %v", err)
 	}
 }
@@ -4685,7 +4686,7 @@ func TestMiseNodePathIgnoresProgressOnStderr(t *testing.T) {
 		t.Fatal(err)
 	}
 	wrongDigest := sha256.Sum256(wrongBytes)
-	if _, err := (Runner{Mise: mise, nodeDigests: map[int]string{24: hex.EncodeToString(wrongDigest[:])}}).resolveMiseNodePath(context.Background(), 24); err == nil || !strings.Contains(err.Error(), `reported "v24.99.0", want "v24.18.0"`) {
+	if _, err := (Runner{Mise: mise, nodeDigests: map[int]string{24: hex.EncodeToString(wrongDigest[:])}}).resolveMiseNodePath(t.Context(), 24); err == nil || !strings.Contains(err.Error(), `reported "v24.99.0", want "v24.18.0"`) {
 		t.Fatalf("resolveMiseNodePath() error = %v, want exact executable version rejection", err)
 	}
 	correctBytes := []byte("#!/bin/sh\nprintf 'v24.18.0\\n'\n")
@@ -4693,7 +4694,7 @@ func TestMiseNodePathIgnoresProgressOnStderr(t *testing.T) {
 		t.Fatal(err)
 	}
 	correctDigest := sha256.Sum256(correctBytes)
-	got, err := (Runner{Mise: mise, nodeDigests: map[int]string{24: hex.EncodeToString(correctDigest[:])}}).resolveMiseNodePath(context.Background(), 24)
+	got, err := (Runner{Mise: mise, nodeDigests: map[int]string{24: hex.EncodeToString(correctDigest[:])}}).resolveMiseNodePath(t.Context(), 24)
 	if err != nil || got != filepath.Join(nodeRoot, "bin", "node") {
 		t.Fatalf("resolveMiseNodePath() = %q, %v", got, err)
 	}
@@ -4740,7 +4741,7 @@ esac
 		nodeDigests:      map[int]string{24: hex.EncodeToString(digest[:])},
 		nodeVerification: verification,
 	}
-	if got, err := runner.discoverNode(context.Background(), 24, ""); err != nil || got != node {
+	if got, err := runner.discoverNode(t.Context(), 24, ""); err != nil || got != node {
 		t.Fatalf("discoverNode() = %q, %v", got, err)
 	}
 	got, err := os.ReadFile(node)
@@ -4790,13 +4791,13 @@ func TestJavaScriptPhaseUsesVerifiedMiseNodeWithoutWorkflowRedirection(t *testin
 	writeNodeExecutable(t, node20, 20)
 	digest := sha256.Sum256(nodeBytes)
 	runner := Runner{Mise: mise, MiseDataDir: dataDir, Node20: node20, nodeDigests: map[int]string{24: hex.EncodeToString(digest[:])}}
-	resolvedNode, err := runner.discoverNode(context.Background(), 24, "")
+	resolvedNode, err := runner.discoverNode(t.Context(), 24, "")
 	if err != nil {
 		t.Fatal(err)
 	}
 	result := newResult()
 	action := javaScriptAction{Name: "mise", Path: root, Main: "main.js", Env: map[string]string{"MISE_DATA_DIR": "/workflow-controlled"}, nodeMajor: 24}
-	if err := runner.runJavaScriptPhase(context.Background(), newCommandProcessor(io.Discard, io.Discard), root, resolvedNode, action, action.Main, nil, nil, &result); err != nil {
+	if err := runner.runJavaScriptPhase(t.Context(), newCommandProcessor(io.Discard, io.Discard), root, resolvedNode, action, action.Main, nil, nil, &result); err != nil {
 		t.Fatal(err)
 	}
 	data, err := os.ReadFile(log)
@@ -4811,7 +4812,7 @@ func TestJavaScriptPhaseUsesVerifiedMiseNodeWithoutWorkflowRedirection(t *testin
 
 func TestMiseMissingIsClear(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
-	_, err := (Runner{}).discoverNode(context.Background(), 24, "")
+	_, err := (Runner{}).discoverNode(t.Context(), 24, "")
 	if err == nil || !strings.Contains(err.Error(), "mise is required") {
 		t.Fatalf("discoverNode() error = %v", err)
 	}
@@ -4834,7 +4835,7 @@ func TestMiseNodeSelectionRejectsWrongExactVersion(t *testing.T) {
 		t.Fatal(err)
 	}
 	digest := sha256.Sum256(nodeBytes)
-	_, err := (Runner{Mise: mise, nodeDigests: map[int]string{24: hex.EncodeToString(digest[:])}}).discoverNode(context.Background(), 24, "")
+	_, err := (Runner{Mise: mise, nodeDigests: map[int]string{24: hex.EncodeToString(digest[:])}}).discoverNode(t.Context(), 24, "")
 	if err == nil || !strings.Contains(err.Error(), `reported "v24.18.1", want "v24.18.0"`) {
 		t.Fatalf("discoverNode() error = %v", err)
 	}
@@ -4844,7 +4845,7 @@ func TestDockerAction(t *testing.T) {
 	docker := requireDocker(t)
 	var logs bytes.Buffer
 	runner := Runner{Stdout: &logs, Stderr: &logs, Docker: docker}
-	result, err := runner.runDockerAction(context.Background(), dockerAction{
+	result, err := runner.runDockerAction(t.Context(), dockerAction{
 		Name: "local Docker", Path: fixturePath(t, "actions", "docker"), Workspace: fixturePath(t),
 		Env: map[string]string{"INPUT_EXPECTED_FILE": "smoke/.github/workflows/ci.yml"},
 	})
@@ -4910,7 +4911,7 @@ func main() {
 	if err != nil {
 		t.Fatal(err)
 	}
-	result, err := (Runner{Docker: docker}).runDockerAction(context.Background(), dockerAction{Name: "non-root Docker", Path: action, Workspace: workspace})
+	result, err := (Runner{Docker: docker}).runDockerAction(t.Context(), dockerAction{Name: "non-root Docker", Path: action, Workspace: workspace})
 	if err != nil {
 		t.Fatalf("runDockerAction() error = %v", err)
 	}
@@ -4937,7 +4938,7 @@ func TestRunJobShellJavaScriptCompositeAndPost(t *testing.T) {
 	})
 	job.Outputs = map[string]string{"result": "${{ steps.composite.outputs.result }}"}
 	var logs bytes.Buffer
-	result, err := (Runner{Stdout: &logs, Stderr: &logs, Node24: node}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Stdout: &logs, Stderr: &logs, Node24: node}).RunJob(t.Context(), job, workspace)
 	if err != nil {
 		t.Fatalf("RunJob() error = %v\nlogs:\n%s", err, logs.String())
 	}
@@ -4970,7 +4971,7 @@ printf '%s\n' 'derived-mask-value' >> "$GITHUB_STEP_SUMMARY"`,
 	}})
 	job.Outputs = map[string]string{"secret": "${{ steps.derive.outputs.secret }}"}
 	var logs bytes.Buffer
-	result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(t.Context(), job, workspace)
 	if err == nil || !strings.Contains(err.Error(), `job output "secret" contains a registered secret`) {
 		t.Fatalf("RunJob() error = %v, want dynamically masked output rejection", err)
 	}
@@ -5007,7 +5008,7 @@ runs:
 		"private": "${{ steps.composite.outputs.private }}",
 		"public":  "${{ steps.composite.outputs.public }}",
 	}
-	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{}).RunJob(t.Context(), job, workspace)
 	if err != nil {
 		t.Fatalf("RunJob() error = %v", err)
 	}
@@ -5038,7 +5039,7 @@ with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
 `,
 	}})
 	job.Outputs = map[string]string{"script": "${{ steps.python.outputs.script }}"}
-	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{}).RunJob(t.Context(), job, workspace)
 	if err != nil {
 		t.Fatalf("RunJob() error = %v", err)
 	}
@@ -5072,7 +5073,7 @@ runs:
 `)
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "composite", Kind: "uses", Uses: "./.github/actions/composite"}})
 	job.Outputs = map[string]string{"value": "${{ steps.composite.outputs.value }}"}
-	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{}).RunJob(t.Context(), job, workspace)
 	if err != nil {
 		t.Fatalf("RunJob() error = %v", err)
 	}
@@ -5161,7 +5162,7 @@ runs:
 		}
 	}
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "composite", Kind: "uses", Uses: "./.github/actions/composite", With: map[string]string{"dir": "sub"}}})
-	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -5172,7 +5173,7 @@ func TestRunStepMissingWorkingDirectoryFailsClearly(t *testing.T) {
 	workflowPath := ".github/workflows/test.yml"
 	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "run", Kind: "run", Shell: "sh", Command: "true", WorkingDirectory: "missing"}})
-	if _, err := (Runner{}).RunJob(context.Background(), job, workspace); err == nil || !strings.Contains(err.Error(), `working directory "missing" does not exist`) {
+	if _, err := (Runner{}).RunJob(t.Context(), job, workspace); err == nil || !strings.Contains(err.Error(), `working directory "missing" does not exist`) {
 		t.Fatalf("RunJob() error = %v, want missing working directory diagnostic", err)
 	}
 }
@@ -5252,7 +5253,7 @@ printf '%s\n' 'result=nested-ok' >> "$GITHUB_OUTPUT"
 	}
 	job.Outputs = map[string]string{"result": "${{ steps.outer.outputs.result }}"}
 	var logs bytes.Buffer
-	result, err := (Runner{Node24: fakeNode, Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node24: fakeNode, Stdout: &logs, Stderr: &logs}).RunJob(t.Context(), job, workspace)
 	if err != nil {
 		t.Fatalf("RunJob() error = %v\nlogs: %s", err, logs.String())
 	}
@@ -5309,7 +5310,7 @@ runs:
 		"EXPECTED_WORKFLOW":   workflowPath,
 	}
 	var logs bytes.Buffer
-	if _, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace); err != nil {
+	if _, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(t.Context(), job, workspace); err != nil {
 		t.Fatalf("RunJob() error = %v\nlogs: %s", err, logs.String())
 	}
 }
@@ -5346,7 +5347,7 @@ if [ "$(basename "$(dirname "$1")")/$(basename "$1")" = child/pre.js ]; then sle
 	}
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}
 	started := time.Now()
-	_, err := (Runner{Node24: fakeNode, Actions: materializer}).RunJob(context.Background(), job, workspace)
+	_, err := (Runner{Node24: fakeNode, Actions: materializer}).RunJob(t.Context(), job, workspace)
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("RunJob() nested pre timeout error = %v", err)
 	}
@@ -5398,7 +5399,7 @@ test -z "$TARGETS"
 		remoteLifecycleLock(childID, "child", digest, nil),
 	}
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}
-	result, err := (Runner{Node24: fakeNode, Actions: materializer}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node24: fakeNode, Actions: materializer}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -5444,7 +5445,7 @@ test "$CALLER_PATH_ENV" = "$EXPECTED_ROOT_PATH"
 	}
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}
 	var logs bytes.Buffer
-	result, err := (Runner{Node24: fakeNode, Actions: materializer, Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node24: fakeNode, Actions: materializer, Stdout: &logs, Stderr: &logs}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v\nlogs: %s", result, err, logs.String())
 	}
@@ -5465,7 +5466,7 @@ func TestSkippedRemoteCompositeWithoutPreDoesNotEvaluateTimeout(t *testing.T) {
 	job.RequiredCapabilities = []string{"network"}
 	job.Actions = []plan.ActionLock{remoteLifecycleLock(rootID, "root", digest, nil)}
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}
-	if result, err := (Runner{Actions: materializer}).RunJob(context.Background(), job, workspace); err != nil || result.Conclusion != "success" {
+	if result, err := (Runner{Actions: materializer}).RunJob(t.Context(), job, workspace); err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() skipped composite result = %#v, error = %v", result, err)
 	}
 }
@@ -5499,7 +5500,7 @@ runs:
 	})
 	job.Env = map[string]string{"STATUS_MARKER": marker}
 
-	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{}).RunJob(t.Context(), job, workspace)
 	if err == nil || result.Conclusion != "failure" {
 		t.Fatalf("RunJob() result = %#v, error = %v; want original step failure", result, err)
 	}
@@ -5542,7 +5543,7 @@ printf '%s:%s\n' "$action" "$phase" >> "$LIFECYCLE_LOG"
 		{ID: "composite", Kind: "uses", Uses: "./.github/actions/composite"},
 	})
 	job.Env = map[string]string{"LIFECYCLE_LOG": lifecycle}
-	if result, err := (Runner{Node24: fakeNode}).RunJob(context.Background(), job, workspace); err != nil || result.Conclusion != "success" {
+	if result, err := (Runner{Node24: fakeNode}).RunJob(t.Context(), job, workspace); err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
 	events, err := os.ReadFile(lifecycle)
@@ -5568,7 +5569,7 @@ printf '%s:%s\n' "$action" "$phase" >> "$LIFECYCLE_LOG"
 		},
 		{ID: nestedID, Source: "workspace", Path: ".github/actions/nested", SourceDigest: digestTree(t, filepath.Join(workspace, ".github", "actions", "nested"))},
 	}
-	if result, err := (Runner{Node24: fakeNode}).RunJob(context.Background(), job, workspace); err != nil || result.Conclusion != "success" {
+	if result, err := (Runner{Node24: fakeNode}).RunJob(t.Context(), job, workspace); err != nil || result.Conclusion != "success" {
 		t.Fatalf("v3 RunJob() result = %#v, error = %v", result, err)
 	}
 	events, err = os.ReadFile(lifecycle)
@@ -5698,7 +5699,7 @@ printf '%s\n' 'job:main' >> "$LIFECYCLE_LOG"`},
 	}
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}
 	var logs bytes.Buffer
-	result, err := (Runner{Node24: fakeNode, Actions: materializer, Stdout: &logs, Stderr: &logs}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node24: fakeNode, Actions: materializer, Stdout: &logs, Stderr: &logs}).RunJob(t.Context(), job, workspace)
 	if err == nil || result.Conclusion != "failure" {
 		t.Fatalf("RunJob() result = %#v, error = %v, logs = %q", result, err, logs.String())
 	}
@@ -5779,7 +5780,7 @@ if [ "$action:$phase" = main-fails:main ]; then exit 7; fi
 	}
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}
 	provider := &testWorkflowTokenProvider{token: "ghs_scoped_pre"}
-	result, err := (Runner{Node24: fakeNode, Actions: materializer, WorkflowToken: provider, Redactor: &testRedactor{}}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node24: fakeNode, Actions: materializer, WorkflowToken: provider, Redactor: &testRedactor{}}).RunJob(t.Context(), job, workspace)
 	if err == nil || result.Conclusion != "failure" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -5844,7 +5845,7 @@ printf 'child:%s:%s\n' "$(basename "$1" .js)" "$INPUT_MESSAGE" >> "$LIFECYCLE_LO
 		remoteLifecycleLock(childID, "child", digest, nil),
 	}
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}
-	result, err := (Runner{Node24: fakeNode, Actions: materializer}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node24: fakeNode, Actions: materializer}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -5912,7 +5913,7 @@ if [ "$action:$phase" = fails:pre ]; then exit 7; fi
 		remoteLifecycleLock(onSuccessID, "on-success", digest, nil),
 	}
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}
-	result, err := (Runner{Node24: fakeNode, Actions: materializer}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node24: fakeNode, Actions: materializer}).RunJob(t.Context(), job, workspace)
 	if err == nil || result.Conclusion != "failure" || !strings.Contains(err.Error(), `action "owner/repo/fails@v1" pre`) {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -5968,7 +5969,7 @@ fi
 		remoteLifecycleLock(afterID, "after", digest, nil),
 	}
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}
-	result, err := (Runner{Node24: fakeNode, Actions: materializer}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node24: fakeNode, Actions: materializer}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -6024,7 +6025,7 @@ if [ "$action:$phase" = after:pre ]; then touch "$MARKER"; fi
 		remoteLifecycleLock(afterID, "after", digest, nil),
 	}
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}
-	result, err := (Runner{Node24: fakeNode, Actions: materializer}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node24: fakeNode, Actions: materializer}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -6078,7 +6079,7 @@ if [ "$action:$phase" = child:main ]; then touch "$CHILD_MAIN_MARKER"; fi
 		remoteLifecycleLock(childID, "child", digest, nil),
 	}
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}
-	result, err := (Runner{Node24: fakeNode, Actions: materializer}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node24: fakeNode, Actions: materializer}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -6126,7 +6127,7 @@ if [ "$action:$phase" = child:post ]; then touch "$POST_MARKER"; fi
 		remoteLifecycleLock(childID, "child", digest, nil),
 	}
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}
-	result, err := (Runner{Node24: fakeNode, Actions: materializer}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node24: fakeNode, Actions: materializer}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -6178,7 +6179,7 @@ if [ "$action:$phase" = after:pre ]; then touch "$MARKER"; fi
 		remoteLifecycleLock(afterID, "after", digest, nil),
 	}
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}
-	result, err := (Runner{Node24: fakeNode, Actions: materializer}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node24: fakeNode, Actions: materializer}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -6223,7 +6224,7 @@ printf '%s:%s\n' "$(basename "$(dirname "$1")")" "$(basename "$1" .js)" >> "$LIF
 	}
 	job.ContinueOnError = true
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}
-	result, err := (Runner{Node24: fakeNode, Actions: materializer}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node24: fakeNode, Actions: materializer}).RunJob(t.Context(), job, workspace)
 	if err == nil || IsToleratedJobFailure(err) || result.Conclusion != "failure" || !strings.Contains(err.Error(), "materialized source digest mismatch") {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -6251,7 +6252,7 @@ func TestJobContinueOnErrorDoesNotTolerateLazyWorkspaceActionIntegrityFailure(t 
 	job.Actions = []plan.ActionLock{lock}
 	job.ContinueOnError = true
 
-	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{}).RunJob(t.Context(), job, workspace)
 	if err == nil || IsToleratedJobFailure(err) || result.Conclusion != "failure" || !strings.Contains(err.Error(), "workspace action digest mismatch") {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -6294,7 +6295,7 @@ printf '%s:%s\n' "$(basename "$(dirname "$1")")" "$(basename "$1" .js)" >> "$LIF
 		remoteLifecycleLock(directID, "direct", digest, nil),
 	}
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}
-	result, err := (Runner{Node24: fakeNode, Actions: materializer}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Node24: fakeNode, Actions: materializer}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -6336,7 +6337,7 @@ runs:
 	shouldNotRun := filepath.Join(workspace, "should-not-run")
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "composite", Kind: "uses", Uses: "./.github/actions/conditions"}})
 	job.Env = map[string]string{"STATUS_RAN": statusRan, "ALWAYS_RAN": alwaysRan, "SHOULD_NOT_RUN": shouldNotRun}
-	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{}).RunJob(t.Context(), job, workspace)
 	if err == nil || result.Conclusion != "failure" {
 		t.Fatalf("RunJob() result = %#v, error = %v, want preserved composite failure", result, err)
 	}
@@ -6372,7 +6373,7 @@ runs:
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "composite", Kind: "uses", Uses: "./.github/actions/soft-failure"}})
 	job.Env = map[string]string{"LATER_STEP_RAN": laterStep}
 	job.Outputs = map[string]string{"status": "${{ steps.composite.outputs.status }}"}
-	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v, want soft composite failure", result, err)
 	}
@@ -6408,7 +6409,7 @@ runs:
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "composite", Kind: "uses", Uses: "./.github/actions/soft-condition"}})
 	job.Env = map[string]string{"LATER_STEP_RAN": laterStep, "SHOULD_NOT_RUN": shouldNotRun}
 	job.Outputs = map[string]string{"status": "${{ steps.composite.outputs.status }}"}
-	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v, want soft condition failure", result, err)
 	}
@@ -6443,7 +6444,7 @@ runs:
 			marker := filepath.Join(workspace, "conditional-ran")
 			job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "composite", Kind: "uses", Uses: "./.github/actions/conditional", With: map[string]string{"enabled": enabled}}})
 			job.Env = map[string]string{"CONDITIONAL_RAN": marker}
-			result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+			result, err := (Runner{}).RunJob(t.Context(), job, workspace)
 			if err != nil || result.Conclusion != "success" {
 				t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 			}
@@ -6495,7 +6496,7 @@ runs:
 	job.Env = map[string]string{"RESULT": output}
 	job.Event.Repository = "buildkite/buildkite-gha"
 
-	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -6514,7 +6515,7 @@ func TestRuntimeRejectsRecursiveAndOverDepthCompositeActions(t *testing.T) {
 	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
 	writeFixtureFile(t, workspace, ".github/actions/recursive/action.yml", "runs:\n  using: composite\n  steps:\n    - uses: ./.github/actions/recursive\n")
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "recursive", Kind: "uses", Uses: "./.github/actions/recursive"}})
-	if _, err := (Runner{}).RunJob(context.Background(), job, workspace); err == nil || !strings.Contains(err.Error(), "recursion detected") {
+	if _, err := (Runner{}).RunJob(t.Context(), job, workspace); err == nil || !strings.Contains(err.Error(), "recursion detected") {
 		t.Fatalf("RunJob() recursion error = %v", err)
 	}
 
@@ -6526,7 +6527,7 @@ func TestRuntimeRejectsRecursiveAndOverDepthCompositeActions(t *testing.T) {
 		writeFixtureFile(t, workspace, fmt.Sprintf(".github/actions/depth-%d/action.yml", i), "runs:\n  using: composite\n"+next)
 	}
 	job = runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "deep", Kind: "uses", Uses: "./.github/actions/depth-0"}})
-	if _, err := (Runner{}).RunJob(context.Background(), job, workspace); err == nil || !strings.Contains(err.Error(), fmt.Sprintf("exceeds maximum depth %d", metadata.MaxNestedActionDepth)) {
+	if _, err := (Runner{}).RunJob(t.Context(), job, workspace); err == nil || !strings.Contains(err.Error(), fmt.Sprintf("exceeds maximum depth %d", metadata.MaxNestedActionDepth)) {
 		t.Fatalf("RunJob() depth error = %v", err)
 	}
 }
@@ -6543,13 +6544,13 @@ func TestRuntimeMapDiagnosticsAreSorted(t *testing.T) {
 	workspace := fixturePath(t, "smoke")
 	job := runtimePlan(t, workspace, ".github/workflows/ci.yml", []plan.Step{{ID: "shell", Kind: "run", Shell: "sh", Command: "true"}})
 	job.Needs = map[string]plan.Need{"z-last": {}, "a-first": {}}
-	if _, err := (Runner{}).RunJob(context.Background(), job, workspace); err == nil || !strings.Contains(err.Error(), `prerequisite result "a-first"`) {
+	if _, err := (Runner{}).RunJob(t.Context(), job, workspace); err == nil || !strings.Contains(err.Error(), `prerequisite result "a-first"`) {
 		t.Fatalf("RunJob() prerequisite error = %v, want alphabetically first key", err)
 	}
 
 	job.Needs = nil
 	job.Outputs = map[string]string{"z-valid": "partial", "a-invalid": "${{ unsupported.a }}"}
-	result, err := (Runner{}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{}).RunJob(t.Context(), job, workspace)
 	if err == nil || !strings.Contains(err.Error(), `job output "a-invalid"`) {
 		t.Fatalf("RunJob() output error = %v, want alphabetically first key", err)
 	}
@@ -6601,7 +6602,7 @@ jobs:
 	if err != nil {
 		t.Fatal(err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Minute)
 	defer cancel()
 	event, err := os.ReadFile(fixturePath(t, "smoke", "events", "push.json"))
 	if err != nil {
@@ -6658,7 +6659,7 @@ jobs:
 	if err != nil || len(plans) != 1 {
 		t.Fatalf("compile hashFiles workflow = %#v, %v", plans, err)
 	}
-	result, err := (Runner{}).RunJob(context.Background(), plans[0], workspace)
+	result, err := (Runner{}).RunJob(t.Context(), plans[0], workspace)
 	if err != nil || result.Conclusion != "success" {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -6670,7 +6671,7 @@ func TestRunJobDockerUsesSharedMasking(t *testing.T) {
 	job := runtimePlan(t, workspace, "smoke/.github/workflows/ci.yml", []plan.Step{{ID: "docker", Kind: "uses", Uses: "./actions/docker"}})
 	job.RequiredCapabilities = []string{"docker", "network"}
 	var logs bytes.Buffer
-	result, err := (Runner{Stdout: &logs, Stderr: &logs, Docker: docker}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Stdout: &logs, Stderr: &logs, Docker: docker}).RunJob(t.Context(), job, workspace)
 	if err != nil {
 		t.Fatalf("RunJob() error = %v", err)
 	}
@@ -6683,11 +6684,11 @@ func TestRunJobRejectsWorkflowMismatchAndUnsupportedAction(t *testing.T) {
 	workspace := fixturePath(t, "smoke")
 	job := runtimePlan(t, workspace, ".github/workflows/ci.yml", []plan.Step{{ID: "local", Kind: "uses", Uses: "./actions/javascript"}})
 	job.Workflow.Digest = "sha256:" + strings.Repeat("0", 64)
-	if _, err := (Runner{}).RunJob(context.Background(), job, workspace); err == nil || !strings.Contains(err.Error(), "workflow digest mismatch") {
+	if _, err := (Runner{}).RunJob(t.Context(), job, workspace); err == nil || !strings.Contains(err.Error(), "workflow digest mismatch") {
 		t.Fatalf("RunJob() error = %v, want workflow digest mismatch", err)
 	}
 	job = runtimePlan(t, workspace, ".github/workflows/ci.yml", []plan.Step{{ID: "remote", Kind: "uses", Uses: "actions/checkout@v4"}})
-	if _, err := (Runner{}).RunJob(context.Background(), job, workspace); err == nil || !strings.Contains(err.Error(), "remote action") {
+	if _, err := (Runner{}).RunJob(t.Context(), job, workspace); err == nil || !strings.Contains(err.Error(), "remote action") {
 		t.Fatalf("RunJob() error = %v, want explicit remote action error", err)
 	}
 
@@ -6698,7 +6699,7 @@ func TestRunJobRejectsWorkflowMismatchAndUnsupportedAction(t *testing.T) {
 			writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
 			writeFixtureFile(t, workspace, ".github/actions/unsupported/action.yml", "runs:\n  using: "+using+"\n")
 			job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "unsupported", Kind: "uses", Uses: "./.github/actions/unsupported"}})
-			if _, err := (Runner{}).RunJob(context.Background(), job, workspace); err == nil || !strings.Contains(err.Error(), `unsupported runtime "`+using+`"`) {
+			if _, err := (Runner{}).RunJob(t.Context(), job, workspace); err == nil || !strings.Contains(err.Error(), `unsupported runtime "`+using+`"`) {
 				t.Fatalf("RunJob() error = %v, want %s runtime rejection", err, using)
 			}
 		})
@@ -6799,7 +6800,7 @@ func requireLinuxAMD64(t *testing.T) {
 func requireNode24(t *testing.T) string {
 	t.Helper()
 	if node := os.Getenv("BUILDKITE_GHA_TEST_NODE24"); node != "" {
-		if _, err := discoverNodeContext(context.Background(), 24, node, ""); err != nil {
+		if _, err := discoverNodeContext(t.Context(), 24, node, ""); err != nil {
 			t.Fatalf("BUILDKITE_GHA_TEST_NODE24 is not Node 24: %v", err)
 		}
 		return node
@@ -6808,7 +6809,7 @@ func requireNode24(t *testing.T) string {
 		output, err := exec.Command(mise, "where", "node@24").CombinedOutput()
 		if err == nil {
 			node := filepath.Join(strings.TrimSpace(string(output)), "bin", "node")
-			if _, err := discoverNodeContext(context.Background(), 24, node, ""); err == nil {
+			if _, err := discoverNodeContext(t.Context(), 24, node, ""); err == nil {
 				return node
 			}
 		}
@@ -6823,7 +6824,7 @@ func requireDocker(t *testing.T) string {
 	if err != nil {
 		livePrerequisiteUnavailable(t, "Docker unavailable: docker executable not found")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 	dockerConfig := t.TempDir()
 	if err := os.Chmod(dockerConfig, 0o700); err != nil {

--- a/internal/runtime/upload_artifact_test.go
+++ b/internal/runtime/upload_artifact_test.go
@@ -61,7 +61,7 @@ func TestUploadArtifactArchiveAndOutputs(t *testing.T) {
 	writeFixtureFile(t, workspace, "out/.hidden", "secret")
 	uploader := &captureArtifactUploader{}
 	r := Runner{Artifacts: uploader, artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
-	result, err := r.runUploadArtifact(context.Background(), newCommandProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "out", "name": "logs", "compression-level": "0"})
+	result, err := r.runUploadArtifact(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "out", "name": "logs", "compression-level": "0"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,7 +102,7 @@ func TestUploadArtifactRuntimeVersionMatrix(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			uploader := &captureArtifactUploader{}
 			r := Runner{Artifacts: uploader, artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
-			result, err := r.runUploadArtifactCommit(context.Background(), newCommandProcessor(io.Discard, io.Discard), workspace, test.commit, test.inputs)
+			result, err := r.runUploadArtifactCommit(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, test.commit, test.inputs)
 			if err != nil || len(uploader.uploads) != 1 || len(result.Artifacts) != 1 || result.Outputs["artifact-id"] == "" || result.Outputs["artifact-digest"] == "" || result.Outputs["artifact-url"] != "" {
 				t.Fatalf("runtime matrix result = %#v, uploads = %d, error = %v", result, len(uploader.uploads), err)
 			}
@@ -117,7 +117,7 @@ func TestUploadArtifactRuntimeVersionMatrix(t *testing.T) {
 	}
 
 	r := Runner{Artifacts: &captureArtifactUploader{}, artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
-	if _, err := r.runUploadArtifactCommit(context.Background(), newCommandProcessor(io.Discard, io.Discard), workspace, actionintegration.UploadArtifactCommit, map[string]string{"path": "payload", "archive": "true"}); err == nil || !strings.Contains(err.Error(), "only in actions/upload-artifact v7") {
+	if _, err := r.runUploadArtifactCommit(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, actionintegration.UploadArtifactCommit, map[string]string{"path": "payload", "archive": "true"}); err == nil || !strings.Contains(err.Error(), "only in actions/upload-artifact v7") {
 		t.Fatalf("runtime v4 archive mismatch error = %v", err)
 	}
 }
@@ -130,7 +130,7 @@ func TestUploadArtifactBoundedGlobAndAdvisoryRetention(t *testing.T) {
 	var stdout bytes.Buffer
 	uploader := &captureArtifactUploader{}
 	r := Runner{Artifacts: uploader, artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
-	result, err := r.runUploadArtifact(context.Background(), newCommandProcessor(&stdout, io.Discard), workspace, map[string]string{
+	result, err := r.runUploadArtifact(t.Context(), newCommandProcessor(&stdout, io.Discard), workspace, map[string]string{
 		"path": "tests/*.log", "retention-days": "7",
 	})
 	if err != nil {
@@ -146,7 +146,7 @@ func TestUploadArtifactBoundedGlobAndAdvisoryRetention(t *testing.T) {
 	if err := os.Mkdir(filepath.Join(workspace, "tests", "directory.log"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := r.runUploadArtifact(context.Background(), newCommandProcessor(io.Discard, io.Discard), workspace, map[string]string{
+	if _, err := r.runUploadArtifact(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, map[string]string{
 		"path": "tests/*.log", "name": "directory-match",
 	}); err != nil {
 		t.Fatal(err)
@@ -170,7 +170,7 @@ func TestUploadArtifactNormalizesFailurePathDirectories(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			uploader := &captureArtifactUploader{}
 			r := Runner{Artifacts: uploader, artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
-			_, err := r.runUploadArtifactCommit(context.Background(), newCommandProcessor(io.Discard, io.Discard), workspace, actionintegration.UploadArtifactV6Commit, map[string]string{
+			_, err := r.runUploadArtifactCommit(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, actionintegration.UploadArtifactV6Commit, map[string]string{
 				"name": test.name, "path": test.path,
 			})
 			if err != nil {
@@ -185,7 +185,7 @@ func TestUploadArtifactNormalizesFailurePathDirectories(t *testing.T) {
 	writeFixtureFile(t, workspace, "report.txt", "not a directory")
 	uploader := &captureArtifactUploader{}
 	r := Runner{Artifacts: uploader, artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
-	if _, err := r.runUploadArtifactCommit(context.Background(), newCommandProcessor(io.Discard, io.Discard), workspace, actionintegration.UploadArtifactV6Commit, map[string]string{
+	if _, err := r.runUploadArtifactCommit(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, actionintegration.UploadArtifactV6Commit, map[string]string{
 		"name": "directory-only", "path": "report.txt/", "if-no-files-found": "error",
 	}); err == nil || !strings.Contains(err.Error(), "No files were found") || len(uploader.uploads) != 0 {
 		t.Fatalf("trailing-slash file match error = %v, uploads = %d", err, len(uploader.uploads))
@@ -196,18 +196,18 @@ func TestUploadArtifactZIPIsDeterministicAtSupportedCompressionLevels(t *testing
 	workspace := t.TempDir()
 	writeFixtureFile(t, workspace, "payload/a.txt", strings.Repeat("compressible", 100))
 	writeFixtureFile(t, workspace, "payload/b.txt", "second")
-	files, err := collectUploadFiles(context.Background(), workspace, []string{"payload"}, false)
+	files, err := collectUploadFiles(t.Context(), workspace, []string{"payload"}, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	for _, level := range []int{0, 1, 6, 9} {
 		t.Run(strconv.Itoa(level), func(t *testing.T) {
 			first, second := filepath.Join(t.TempDir(), "first.zip"), filepath.Join(t.TempDir(), "second.zip")
-			firstDigest, firstSize, err := writeUploadZIP(context.Background(), first, workspace, files, level)
+			firstDigest, firstSize, err := writeUploadZIP(t.Context(), first, workspace, files, level)
 			if err != nil {
 				t.Fatal(err)
 			}
-			secondDigest, secondSize, err := writeUploadZIP(context.Background(), second, workspace, files, level)
+			secondDigest, secondSize, err := writeUploadZIP(t.Context(), second, workspace, files, level)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -238,7 +238,7 @@ func TestUploadArtifactCanIncludeHiddenFiles(t *testing.T) {
 	writeFixtureFile(t, workspace, "out/.hidden", "included")
 	uploader := &captureArtifactUploader{}
 	r := Runner{Artifacts: uploader, artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
-	if _, err := r.runUploadArtifact(context.Background(), newCommandProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "out", "include-hidden-files": "TRUE"}); err != nil {
+	if _, err := r.runUploadArtifact(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "out", "include-hidden-files": "TRUE"}); err != nil {
 		t.Fatal(err)
 	}
 	if got := readUploadZIP(t, uploader.uploads[0].data); !reflect.DeepEqual(got, map[string]string{".hidden": "included"}) {
@@ -253,7 +253,7 @@ func TestCollectUploadFilesExpandsBoundedGlobs(t *testing.T) {
 	writeFixtureFile(t, workspace, ".hidden/build/reports/hidden.html", "hidden")
 	writeFixtureFile(t, workspace, "clients/build/reports/tests/unit/index.html", "unit")
 
-	files, err := collectUploadFiles(context.Background(), workspace, []string{"**/build/**/*.html"}, false)
+	files, err := collectUploadFiles(t.Context(), workspace, []string{"**/build/**/*.html"}, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -266,7 +266,7 @@ func TestCollectUploadFilesExpandsBoundedGlobs(t *testing.T) {
 		t.Fatalf("recursive glob files = %#v, want %#v", names, want)
 	}
 
-	files, err = collectUploadFiles(context.Background(), workspace, []string{"**/build/reports/tests/*"}, false)
+	files, err = collectUploadFiles(t.Context(), workspace, []string{"**/build/reports/tests/*"}, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -281,7 +281,7 @@ func TestCollectUploadFilesGlobRejectsMatchedSymlink(t *testing.T) {
 	if err := os.Symlink(filepath.Join(workspace, "outside", "report.html"), filepath.Join(workspace, "report.html")); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := collectUploadFiles(context.Background(), workspace, []string{"*.html"}, false); err == nil || !strings.Contains(err.Error(), "symlink") {
+	if _, err := collectUploadFiles(t.Context(), workspace, []string{"*.html"}, false); err == nil || !strings.Contains(err.Error(), "symlink") {
 		t.Fatalf("matched glob symlink error = %v", err)
 	}
 }
@@ -289,7 +289,7 @@ func TestCollectUploadFilesGlobRejectsMatchedSymlink(t *testing.T) {
 func TestUploadArtifactRejectsPathsTheConsumerCannotExtract(t *testing.T) {
 	workspace := t.TempDir()
 	writeFixtureFile(t, workspace, "control\tcharacter", "unsafe")
-	if _, err := collectUploadFiles(context.Background(), workspace, []string{"control\tcharacter"}, false); err == nil || !strings.Contains(err.Error(), "forbidden characters") {
+	if _, err := collectUploadFiles(t.Context(), workspace, []string{"control\tcharacter"}, false); err == nil || !strings.Contains(err.Error(), "forbidden characters") {
 		t.Fatalf("control character error = %v", err)
 	}
 
@@ -300,7 +300,7 @@ func TestUploadArtifactRejectsPathsTheConsumerCannotExtract(t *testing.T) {
 	}
 	components[len(components)-1] = "file"
 	writeFixtureFile(t, workspace, filepath.Join(components...), "too deep")
-	if _, err := collectUploadFiles(context.Background(), workspace, []string{"deep"}, false); err == nil || !strings.Contains(err.Error(), "forbidden characters") {
+	if _, err := collectUploadFiles(t.Context(), workspace, []string{"deep"}, false); err == nil || !strings.Contains(err.Error(), "forbidden characters") {
 		t.Fatalf("deep path error = %v", err)
 	}
 }
@@ -310,7 +310,7 @@ func TestUploadArtifactArchiveRootUsesOnlyMatchedRoots(t *testing.T) {
 	writeFixtureFile(t, workspace, "out/result.txt", "matched")
 	uploader := &captureArtifactUploader{}
 	r := Runner{Artifacts: uploader, artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
-	if _, err := r.runUploadArtifact(context.Background(), newCommandProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "out\nmissing"}); err != nil {
+	if _, err := r.runUploadArtifact(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "out\nmissing"}); err != nil {
 		t.Fatal(err)
 	}
 	if got := readUploadZIP(t, uploader.uploads[0].data); !reflect.DeepEqual(got, map[string]string{"result.txt": "matched"}) {
@@ -327,7 +327,7 @@ func TestUploadArtifactDoesNotStageInContainerWritableRunnerTemp(t *testing.T) {
 		Artifacts: uploader, runnerTemp: sharedRunnerTemp,
 		artifactRegistry: &artifactRegistry{names: map[string]bool{}},
 	}
-	if _, err := r.runUploadArtifact(context.Background(), newCommandProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "result.txt"}); err != nil {
+	if _, err := r.runUploadArtifact(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "result.txt"}); err != nil {
 		t.Fatal(err)
 	}
 	if len(uploader.uploads) != 1 {
@@ -353,7 +353,7 @@ func TestUploadArtifactNoFilesModes(t *testing.T) {
 			var stdout, stderr bytes.Buffer
 			processor := newCommandProcessor(&stdout, &stderr)
 			r := Runner{artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
-			result, err := r.runUploadArtifact(context.Background(), processor, t.TempDir(), map[string]string{"path": "missing", "if-no-files-found": mode})
+			result, err := r.runUploadArtifact(t.Context(), processor, t.TempDir(), map[string]string{"path": "missing", "if-no-files-found": mode})
 			if err != nil || len(result.Outputs) != 0 || len(result.Artifacts) != 0 || len(r.artifactRegistry.names) != 0 {
 				t.Fatalf("runUploadArtifact() result = %#v, registry = %#v, error = %v", result, r.artifactRegistry.names, err)
 			}
@@ -372,7 +372,7 @@ func TestUploadArtifactNoFilesModes(t *testing.T) {
 	var stdout bytes.Buffer
 	processor := newCommandProcessor(&stdout, io.Discard)
 	r := Runner{artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
-	if _, err := r.runUploadArtifact(context.Background(), processor, t.TempDir(), map[string]string{"path": "missing", "if-no-files-found": "error"}); err == nil || err.Error() != message {
+	if _, err := r.runUploadArtifact(t.Context(), processor, t.TempDir(), map[string]string{"path": "missing", "if-no-files-found": "error"}); err == nil || err.Error() != message {
 		t.Fatalf("if-no-files-found error = %v", err)
 	}
 	_, _, commandErrors, _ := processor.workflowCommandAnnotations()
@@ -386,7 +386,7 @@ func TestUploadArtifactScrubsExpressionDerivedPathsFromErrors(t *testing.T) {
 	processor := newCommandProcessor(io.Discard, io.Discard)
 	processor.addMask(maskedPath)
 	r := Runner{artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
-	if _, err := r.runUploadArtifact(context.Background(), processor, t.TempDir(), map[string]string{
+	if _, err := r.runUploadArtifact(t.Context(), processor, t.TempDir(), map[string]string{
 		"path": maskedPath, "if-no-files-found": "error",
 	}); err == nil || strings.Contains(err.Error(), maskedPath) || !strings.Contains(err.Error(), "***") {
 		t.Fatalf("masked no-file error = %v", err)
@@ -397,7 +397,7 @@ func TestUploadArtifactScrubsExpressionDerivedPathsFromErrors(t *testing.T) {
 	writeFixtureFile(t, workspace, quotedMask, "masked")
 	processor = newCommandProcessor(io.Discard, io.Discard)
 	processor.addMask(quotedMask)
-	if _, err := r.runUploadArtifact(context.Background(), processor, workspace, map[string]string{"path": quotedMask}); err == nil || strings.Contains(err.Error(), quotedMask) || strings.Contains(err.Error(), `runtime\"secret`) || !strings.Contains(err.Error(), "***") {
+	if _, err := r.runUploadArtifact(t.Context(), processor, workspace, map[string]string{"path": quotedMask}); err == nil || strings.Contains(err.Error(), quotedMask) || strings.Contains(err.Error(), `runtime\"secret`) || !strings.Contains(err.Error(), "***") {
 		t.Fatalf("quoted masked path error = %v", err)
 	}
 }
@@ -411,18 +411,18 @@ func TestUploadArtifactRejectsSymlinksMasksAndDuplicateNamesBeforeUpload(t *test
 	uploader := &captureArtifactUploader{}
 	r := Runner{Artifacts: uploader, artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
 	processor := newCommandProcessor(io.Discard, io.Discard)
-	if _, err := r.runUploadArtifact(context.Background(), processor, workspace, map[string]string{"path": "link/file"}); err == nil || !strings.Contains(err.Error(), "symlink") {
+	if _, err := r.runUploadArtifact(t.Context(), processor, workspace, map[string]string{"path": "link/file"}); err == nil || !strings.Contains(err.Error(), "symlink") {
 		t.Fatalf("symlink error = %v", err)
 	}
 	processor.addMask("secret")
-	if _, err := r.runUploadArtifact(context.Background(), processor, workspace, map[string]string{"path": "real/file", "name": "prefix-secret"}); err == nil || !strings.Contains(err.Error(), "registered mask") {
+	if _, err := r.runUploadArtifact(t.Context(), processor, workspace, map[string]string{"path": "real/file", "name": "prefix-secret"}); err == nil || !strings.Contains(err.Error(), "registered mask") {
 		t.Fatalf("masked-name error = %v", err)
 	}
 	processor = newCommandProcessor(io.Discard, io.Discard)
-	if _, err := r.runUploadArtifact(context.Background(), processor, workspace, map[string]string{"path": "real/file", "name": "same"}); err != nil {
+	if _, err := r.runUploadArtifact(t.Context(), processor, workspace, map[string]string{"path": "real/file", "name": "same"}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := r.runUploadArtifact(context.Background(), processor, workspace, map[string]string{"path": "real/file", "name": "SAME"}); err == nil || len(uploader.uploads) != 1 {
+	if _, err := r.runUploadArtifact(t.Context(), processor, workspace, map[string]string{"path": "real/file", "name": "SAME"}); err == nil || len(uploader.uploads) != 1 {
 		t.Fatalf("duplicate error = %v, uploads=%d", err, len(uploader.uploads))
 	}
 }
@@ -432,7 +432,7 @@ func TestUploadArtifactUploadFailureReleasesName(t *testing.T) {
 	writeFixtureFile(t, workspace, "file", "x")
 	uploader := &captureArtifactUploader{err: errors.New("upload failed")}
 	r := Runner{Artifacts: uploader, artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
-	if _, err := r.runUploadArtifact(context.Background(), newCommandProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "file"}); err == nil {
+	if _, err := r.runUploadArtifact(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "file"}); err == nil {
 		t.Fatal("upload failure was ignored")
 	}
 	if len(r.artifactRegistry.names) != 0 {
@@ -443,17 +443,17 @@ func TestUploadArtifactUploadFailureReleasesName(t *testing.T) {
 func TestUploadArtifactCancellationStopsEveryArchiveStage(t *testing.T) {
 	workspace := t.TempDir()
 	writeFixtureFile(t, workspace, "payload", strings.Repeat("x", 128*1024))
-	files, err := collectUploadFiles(context.Background(), workspace, []string{"payload"}, false)
+	files, err := collectUploadFiles(t.Context(), workspace, []string{"payload"}, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	archive := filepath.Join(t.TempDir(), "payload.zip")
-	digest, size, err := writeUploadZIP(context.Background(), archive, workspace, files, 0)
+	digest, size, err := writeUploadZIP(t.Context(), archive, workspace, files, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 	if _, err := collectUploadFiles(ctx, workspace, []string{"payload"}, false); !errors.Is(err, context.Canceled) {
 		t.Fatalf("collect cancellation = %v", err)
@@ -470,7 +470,7 @@ func TestUploadArtifactCancellationStopsEveryArchiveStage(t *testing.T) {
 		t.Fatalf("adapter cancellation = %v, uploads = %d", err, len(uploader.uploads))
 	}
 
-	readCtx, cancelRead := context.WithCancel(context.Background())
+	readCtx, cancelRead := context.WithCancel(t.Context())
 	reader := contextReader{ctx: readCtx, reader: readerFunc(func(p []byte) (int, error) {
 		cancelRead()
 		return copy(p, "chunk"), nil
@@ -484,7 +484,7 @@ func TestUploadArtifactCancellationStopsEveryArchiveStage(t *testing.T) {
 func TestUploadArtifactRejectsFIFOReplacementWithoutBlockingPastCancellation(t *testing.T) {
 	workspace := t.TempDir()
 	writeFixtureFile(t, workspace, "payload", "regular before collection")
-	files, err := collectUploadFiles(context.Background(), workspace, []string{"payload"}, false)
+	files, err := collectUploadFiles(t.Context(), workspace, []string{"payload"}, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -498,7 +498,7 @@ func TestUploadArtifactRejectsFIFOReplacementWithoutBlockingPastCancellation(t *
 		t.Fatal(err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 	defer cancel()
 	done := make(chan error, 1)
 	archive := filepath.Join(t.TempDir(), "fifo.zip")
@@ -519,7 +519,7 @@ func TestUploadArtifactRejectsFIFOReplacementWithoutBlockingPastCancellation(t *
 func TestUploadArtifactRejectsSameSizeFileReplacement(t *testing.T) {
 	workspace := t.TempDir()
 	writeFixtureFile(t, workspace, "payload", "before")
-	files, err := collectUploadFiles(context.Background(), workspace, []string{"payload"}, false)
+	files, err := collectUploadFiles(t.Context(), workspace, []string{"payload"}, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -527,7 +527,7 @@ func TestUploadArtifactRejectsSameSizeFileReplacement(t *testing.T) {
 	if err := os.Rename(filepath.Join(workspace, "replacement"), filepath.Join(workspace, "payload")); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := writeUploadZIP(context.Background(), filepath.Join(t.TempDir(), "payload.zip"), workspace, files, 0); err == nil || !strings.Contains(err.Error(), "changed while archiving") {
+	if _, _, err := writeUploadZIP(t.Context(), filepath.Join(t.TempDir(), "payload.zip"), workspace, files, 0); err == nil || !strings.Contains(err.Error(), "changed while archiving") {
 		t.Fatalf("same-size replacement error = %v", err)
 	}
 }
@@ -542,7 +542,7 @@ func TestUploadArtifactRejectsSymlinkComponentReplacementToSelectedInode(t *test
 		t.Run(test.name, func(t *testing.T) {
 			workspace := t.TempDir()
 			writeFixtureFile(t, workspace, test.path, "selected")
-			files, err := collectUploadFiles(context.Background(), workspace, []string{test.path}, false)
+			files, err := collectUploadFiles(t.Context(), workspace, []string{test.path}, false)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -552,7 +552,7 @@ func TestUploadArtifactRejectsSymlinkComponentReplacementToSelectedInode(t *test
 			if err := os.Symlink(test.target, filepath.Join(workspace, test.link)); err != nil {
 				t.Fatal(err)
 			}
-			if _, _, err := writeUploadZIP(context.Background(), filepath.Join(t.TempDir(), "payload.zip"), workspace, files, 0); err == nil || !strings.Contains(err.Error(), "symlink") {
+			if _, _, err := writeUploadZIP(t.Context(), filepath.Join(t.TempDir(), "payload.zip"), workspace, files, 0); err == nil || !strings.Contains(err.Error(), "symlink") {
 				t.Fatalf("symlink replacement error = %v", err)
 			}
 		})
@@ -579,7 +579,7 @@ func TestUploadArtifactCancellationStopsAgentUpload(t *testing.T) {
 	workspace := t.TempDir()
 	writeFixtureFile(t, workspace, "payload", "upload")
 	started := make(chan struct{})
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 	defer cancel()
 	r := Runner{Artifacts: cancellationArtifactUploader{started: started}, artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
 	done := make(chan error, 1)
@@ -618,7 +618,7 @@ func TestUploadArtifactSourceBounds(t *testing.T) {
 	if err := file.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := collectUploadFiles(context.Background(), workspace, []string{"too-large"}, false); err == nil || !strings.Contains(err.Error(), "source bytes exceed") {
+	if _, err := collectUploadFiles(t.Context(), workspace, []string{"too-large"}, false); err == nil || !strings.Contains(err.Error(), "source bytes exceed") {
 		t.Fatalf("source-size bound error = %v", err)
 	}
 
@@ -636,7 +636,7 @@ func TestUploadArtifactSourceBounds(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if _, err := collectUploadFiles(context.Background(), many, []string{"files"}, false); err == nil || !strings.Contains(err.Error(), "more than 10000") {
+	if _, err := collectUploadFiles(t.Context(), many, []string{"files"}, false); err == nil || !strings.Contains(err.Error(), "more than 10000") {
 		t.Fatalf("file-count bound error = %v", err)
 	}
 }
@@ -677,7 +677,7 @@ func TestUploadArtifactAdapterBypassesVerifiedUpstreamLifecycle(t *testing.T) {
 	}}
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, ActionRoot: remote, SourceDigest: digest}}
 	uploader := &captureArtifactUploader{}
-	result, err := (Runner{Actions: materializer, Artifacts: uploader}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Actions: materializer, Artifacts: uploader}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" || len(result.Artifacts) != 1 || result.Outputs["artifact_id"] == "" || len(result.Outputs["artifact_digest"]) != 64 {
 		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
 	}
@@ -690,13 +690,13 @@ func TestUploadArtifactAdapterBypassesVerifiedUpstreamLifecycle(t *testing.T) {
 		ID: "mask-after-upload", Kind: "run", Shell: "bash",
 		Command: `echo "::add-mask::load"`,
 	})
-	maskedResult, err := (Runner{Actions: materializer, Artifacts: &captureArtifactUploader{}}).RunJob(context.Background(), maskedJob, workspace)
+	maskedResult, err := (Runner{Actions: materializer, Artifacts: &captureArtifactUploader{}}).RunJob(t.Context(), maskedJob, workspace)
 	if err == nil || !strings.Contains(err.Error(), "artifact name contains a registered secret") || len(maskedResult.Artifacts) != 0 || maskedResult.Conclusion != "failure" {
 		t.Fatalf("late artifact-name mask result = %#v, error = %v", maskedResult, err)
 	}
 
 	job.Actions[0].Commit = strings.Repeat("b", 40)
-	if _, err := (Runner{Actions: materializer, Artifacts: &captureArtifactUploader{}}).RunJob(context.Background(), job, workspace); err == nil || !strings.Contains(err.Error(), actionintegration.UploadArtifactCommit) {
+	if _, err := (Runner{Actions: materializer, Artifacts: &captureArtifactUploader{}}).RunJob(t.Context(), job, workspace); err == nil || !strings.Contains(err.Error(), actionintegration.UploadArtifactCommit) {
 		t.Fatalf("unsupported runtime commit error = %v", err)
 	}
 }
@@ -733,14 +733,14 @@ func TestUploadArtifactV6ConditionalMatrixAndExpressionName(t *testing.T) {
 
 	job.Matrix = map[string]any{"mode": "production"}
 	uploader := &captureArtifactUploader{}
-	result, err := (Runner{Actions: materializer, Artifacts: uploader}).RunJob(context.Background(), job, workspace)
+	result, err := (Runner{Actions: materializer, Artifacts: uploader}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" || len(uploader.uploads) != 0 || len(result.Artifacts) != 0 {
 		t.Fatalf("production matrix result = %#v, uploads = %d, error = %v", result, len(uploader.uploads), err)
 	}
 
 	job.Matrix = map[string]any{"mode": "test"}
 	uploader = &captureArtifactUploader{}
-	result, err = (Runner{Actions: materializer, Artifacts: uploader}).RunJob(context.Background(), job, workspace)
+	result, err = (Runner{Actions: materializer, Artifacts: uploader}).RunJob(t.Context(), job, workspace)
 	if err != nil || result.Conclusion != "success" || len(uploader.uploads) != 1 || len(result.Artifacts) != 1 || result.Artifacts[0].Name != strings.Repeat("a", 40) {
 		t.Fatalf("test matrix result = %#v, uploads = %d, error = %v", result, len(uploader.uploads), err)
 	}

--- a/internal/transport/model_test.go
+++ b/internal/transport/model_test.go
@@ -202,10 +202,10 @@ func (r *captureRunner) Run(_ context.Context, dir, name string, args []string, 
 func TestAgentUsesExactProducerAndSafeUploadFlags(t *testing.T) {
 	runner := &captureRunner{}
 	agent := Agent{Runner: runner}
-	if err := agent.DownloadArtifact(context.Background(), "result.json", ".", "gha-producer"); err != nil {
+	if err := agent.DownloadArtifact(t.Context(), "result.json", ".", "gha-producer"); err != nil {
 		t.Fatal(err)
 	}
-	if err := agent.UploadPipeline(context.Background(), []byte("steps: []\n")); err != nil {
+	if err := agent.UploadPipeline(t.Context(), []byte("steps: []\n")); err != nil {
 		t.Fatal(err)
 	}
 	want := []capturedCommand{
@@ -221,7 +221,7 @@ func TestAgentPublishesBoundedJobAnnotationThroughStdin(t *testing.T) {
 	runner := &captureRunner{}
 	agent := Agent{Runner: runner}
 	body := "### Job summary\n\nPassed.\n"
-	if err := agent.AnnotateJob(context.Background(), testJobID, "buildkite-gha-job-summary", "info", body); err != nil {
+	if err := agent.AnnotateJob(t.Context(), testJobID, "buildkite-gha-job-summary", "info", body); err != nil {
 		t.Fatal(err)
 	}
 	want := capturedCommand{
@@ -247,7 +247,7 @@ func TestAgentPublishesBoundedJobAnnotationThroughStdin(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			validationRunner := &captureRunner{}
-			err := (Agent{Runner: validationRunner}).AnnotateJob(context.Background(), test.jobID, test.context, test.style, test.body)
+			err := (Agent{Runner: validationRunner}).AnnotateJob(t.Context(), test.jobID, test.context, test.style, test.body)
 			if err == nil || len(validationRunner.commands) != 0 {
 				t.Fatalf("AnnotateJob() error = %v, commands = %#v", err, validationRunner.commands)
 			}
@@ -262,7 +262,7 @@ func TestUploadArtifactsMaterializesContentBeforePipeline(t *testing.T) {
 	distribution := Artifact{Path: ".buildkite-gha/distributions/bin/buildkite-gha", Contents: []byte("binary")}
 	distribution.Digest = Digest(distribution.Contents)
 	runner := &captureRunner{}
-	if err := UploadArtifacts(context.Background(), Agent{Runner: runner}, root, []Artifact{plan, distribution}, []byte("steps: []\n")); err != nil {
+	if err := UploadArtifacts(t.Context(), Agent{Runner: runner}, root, []Artifact{plan, distribution}, []byte("steps: []\n")); err != nil {
 		t.Fatal(err)
 	}
 	if len(runner.commands) != 3 {
@@ -303,7 +303,7 @@ func TestUploadArtifactsFailsBeforePipeline(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			runner := &captureRunner{failAt: test.failAt}
-			err := UploadArtifacts(context.Background(), Agent{Runner: runner}, t.TempDir(), test.artifacts, []byte("steps: []\n"))
+			err := UploadArtifacts(t.Context(), Agent{Runner: runner}, t.TempDir(), test.artifacts, []byte("steps: []\n"))
 			if err == nil {
 				t.Fatal("UploadArtifacts() succeeded")
 			}
@@ -317,14 +317,14 @@ func TestUploadArtifactsFailsBeforePipeline(t *testing.T) {
 func TestUploadArtifactsIdentifiesPipelineFailure(t *testing.T) {
 	artifact := Artifact{Path: ".buildkite-gha/plans/plan.json", Contents: []byte("plan")}
 	artifact.Digest = Digest(artifact.Contents)
-	err := UploadArtifacts(context.Background(), Agent{Runner: &captureRunner{failAt: 2}}, t.TempDir(), []Artifact{artifact}, []byte("steps: []\n"))
+	err := UploadArtifacts(t.Context(), Agent{Runner: &captureRunner{failAt: 2}}, t.TempDir(), []Artifact{artifact}, []byte("steps: []\n"))
 	if !errors.Is(err, ErrPipelineUpload) || !strings.Contains(err.Error(), "upload pipeline") {
 		t.Fatalf("UploadArtifacts() error = %v", err)
 	}
 }
 
 func TestCommandRunnerBoundsOutputWhileReading(t *testing.T) {
-	stdout, _, err := (CommandRunner{}).RunBounded(context.Background(), "", "sh", []string{"-c", "printf 123456789"}, nil, 8)
+	stdout, _, err := (CommandRunner{}).RunBounded(t.Context(), "", "sh", []string{"-c", "printf 123456789"}, nil, 8)
 	if err == nil || !strings.Contains(err.Error(), "exceeds 8 bytes") || len(stdout) != 0 {
 		t.Fatalf("runBounded() stdout = %q, error = %v", stdout, err)
 	}
@@ -350,7 +350,7 @@ func TestGetMetadataBoundedClassifiesOnlyExpectedWebhookAbsence(t *testing.T) {
 				t.Fatal(err)
 			}
 			t.Setenv("PATH", dir)
-			_, err := (Agent{Runner: CommandRunner{}}).GetMetadataBounded(context.Background(), "buildkite:webhook", 1024)
+			_, err := (Agent{Runner: CommandRunner{}}).GetMetadataBounded(t.Context(), "buildkite:webhook", 1024)
 			if got := errors.Is(err, ErrMetadataUnavailable); got != test.wantAbsent {
 				t.Fatalf("GetMetadataBounded() error = %v, absent = %t, want %t", err, got, test.wantAbsent)
 			}

--- a/internal/transport/results_test.go
+++ b/internal/transport/results_test.go
@@ -49,7 +49,7 @@ func TestPublishResultCoversTerminalConclusionsAndKeepsMetadataAdvisory(t *testi
 				outputs = []Output{{Name: "message", Value: "bounded"}}
 			}
 			manifest := resultManifest(testJobID, "gha-producer", Digest([]byte("plan")), conclusion, outputs...)
-			publication, err := PublishResult(context.Background(), Agent{Runner: runner}, t.TempDir(), "shell", "producer", manifest)
+			publication, err := PublishResult(t.Context(), Agent{Runner: runner}, t.TempDir(), "shell", "producer", manifest)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -88,7 +88,7 @@ func TestDownloadResultSelectsExactStepThenExactProducerJob(t *testing.T) {
 		jobByStep:  map[string]string{"gha-producer": testJobID},
 		dataByPath: map[string][]byte{path: encoded},
 	}
-	manifest, err := DownloadResult(context.Background(), Agent{Runner: runner}, t.TempDir(), testBuildID, ResultSource{StepKey: "gha-producer", PlanDigest: planDigest})
+	manifest, err := DownloadResult(t.Context(), Agent{Runner: runner}, t.TempDir(), testBuildID, ResultSource{StepKey: "gha-producer", PlanDigest: planDigest})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -126,7 +126,7 @@ func TestDownloadResultRejectsTamperWrongProducerAndSize(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			runner := &resultRunner{jobByStep: map[string]string{"gha-producer": testJobID}, dataByPath: map[string][]byte{path: test.data}}
-			_, err := DownloadResult(context.Background(), Agent{Runner: runner}, t.TempDir(), testBuildID, ResultSource{StepKey: "gha-producer", PlanDigest: planDigest})
+			_, err := DownloadResult(t.Context(), Agent{Runner: runner}, t.TempDir(), testBuildID, ResultSource{StepKey: "gha-producer", PlanDigest: planDigest})
 			if err == nil || !strings.Contains(err.Error(), test.want) {
 				t.Fatalf("DownloadResult() error = %v, want %q", err, test.want)
 			}
@@ -148,7 +148,7 @@ func TestLoadNeedsMapsLogicalFanInToVerifiedProducers(t *testing.T) {
 			secondPath: mustManifest(t, resultManifest(testJobID2, second.StepKey, second.PlanDigest, "failure", Output{Name: "second", Value: "two"})),
 		},
 	}
-	needs, err := LoadNeeds(context.Background(), Agent{Runner: runner}, t.TempDir(), testBuildID, map[string][]ResultSource{"reusable.build": {second, first}}, nil)
+	needs, err := LoadNeeds(t.Context(), Agent{Runner: runner}, t.TempDir(), testBuildID, map[string][]ResultSource{"reusable.build": {second, first}}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -158,14 +158,14 @@ func TestLoadNeedsMapsLogicalFanInToVerifiedProducers(t *testing.T) {
 	if got := needs["reusable.build"].Artifacts[0]; got.Artifact != firstManifest.Artifacts[0] || got.Producer != firstManifest.Producer {
 		t.Fatalf("retained artifact authority = %#v", got)
 	}
-	projected, err := LoadNeeds(context.Background(), Agent{Runner: runner}, t.TempDir(), testBuildID, map[string][]ResultSource{"delegated": {second, first}}, map[string][]OutputProjection{"delegated": {}})
+	projected, err := LoadNeeds(t.Context(), Agent{Runner: runner}, t.TempDir(), testBuildID, map[string][]ResultSource{"delegated": {second, first}}, map[string][]OutputProjection{"delegated": {}})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if projected["delegated"].Result != "failure" || len(projected["delegated"].Outputs) != 0 || len(projected["delegated"].Producers) != 2 {
 		t.Fatalf("projected reusable need = %#v, want aggregate failure without internal outputs", projected["delegated"])
 	}
-	projected, err = LoadNeeds(context.Background(), Agent{Runner: runner}, t.TempDir(), testBuildID, map[string][]ResultSource{"delegated": {second, first}}, map[string][]OutputProjection{
+	projected, err = LoadNeeds(t.Context(), Agent{Runner: runner}, t.TempDir(), testBuildID, map[string][]ResultSource{"delegated": {second, first}}, map[string][]OutputProjection{
 		"delegated": {{Name: "selected", StepKey: first.StepKey, Output: "first"}},
 	})
 	if err != nil {
@@ -174,7 +174,7 @@ func TestLoadNeedsMapsLogicalFanInToVerifiedProducers(t *testing.T) {
 	if !reflect.DeepEqual(projected["delegated"].Outputs, map[string]string{"selected": "one"}) {
 		t.Fatalf("selected reusable output = %#v", projected["delegated"].Outputs)
 	}
-	_, err = LoadNeeds(context.Background(), Agent{Runner: runner}, t.TempDir(), testBuildID, map[string][]ResultSource{"delegated": {second, first}}, map[string][]OutputProjection{
+	_, err = LoadNeeds(t.Context(), Agent{Runner: runner}, t.TempDir(), testBuildID, map[string][]ResultSource{"delegated": {second, first}}, map[string][]OutputProjection{
 		"delegated": {
 			{Name: "selected", StepKey: first.StepKey, Output: "first"},
 			{Name: "selected", StepKey: second.StepKey, Output: "second"},
@@ -185,11 +185,11 @@ func TestLoadNeedsMapsLogicalFanInToVerifiedProducers(t *testing.T) {
 	}
 
 	runner.dataByPath[secondPath] = mustManifest(t, resultManifest(testJobID2, second.StepKey, second.PlanDigest, "success", Output{Name: "first", Value: "different"}))
-	_, err = LoadNeeds(context.Background(), Agent{Runner: runner}, t.TempDir(), testBuildID, map[string][]ResultSource{"build": {first, second}}, nil)
+	_, err = LoadNeeds(t.Context(), Agent{Runner: runner}, t.TempDir(), testBuildID, map[string][]ResultSource{"build": {first, second}}, nil)
 	if err == nil || !strings.Contains(err.Error(), "conflicting matrix output") {
 		t.Fatalf("LoadNeeds() error = %v, want ambiguous matrix output rejection", err)
 	}
-	_, err = LoadNeeds(context.Background(), Agent{Runner: runner}, t.TempDir(), testBuildID, map[string][]ResultSource{"reusable/build": {first}}, nil)
+	_, err = LoadNeeds(t.Context(), Agent{Runner: runner}, t.TempDir(), testBuildID, map[string][]ResultSource{"reusable/build": {first}}, nil)
 	if err == nil || !strings.Contains(err.Error(), "has no valid producers") {
 		t.Fatalf("LoadNeeds() error = %v, want invalid logical need rejection", err)
 	}
@@ -207,7 +207,7 @@ func TestLoadNeedsRetainsOneConditionalMatrixArtifact(t *testing.T) {
 			ResultPath(second.StepKey, second.PlanDigest): mustManifest(t, resultManifest(testJobID2, second.StepKey, second.PlanDigest, "success")),
 		},
 	}
-	needs, err := LoadNeeds(context.Background(), Agent{Runner: runner}, t.TempDir(), testBuildID, map[string][]ResultSource{"build": {first, second}}, nil)
+	needs, err := LoadNeeds(t.Context(), Agent{Runner: runner}, t.TempDir(), testBuildID, map[string][]ResultSource{"build": {first, second}}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/workflow/parse.go
+++ b/internal/workflow/parse.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -62,7 +63,7 @@ func Parse(path string, source []byte) (*Workflow, error) {
 		return nil, err
 	}
 	parsed, errs := actionlint.Parse(source)
-	expectedDiagnostics := append(concurrency.Diagnostics, containerDiagnostics...)
+	expectedDiagnostics := slices.Concat(concurrency.Diagnostics, containerDiagnostics)
 	if err := filterActionlintDiagnostics(path, errs, expectedDiagnostics); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Why

Go linting currently relies on golangci-lint defaults, so the repository does not record its intended checks or formatting rules.

## What

Add a version 2 golangci-lint configuration with an explicit linter and formatter set, then update the existing code to satisfy it. Tests now use `t.Context`, `t.Chdir`, and related testing helpers, repeated standard-library values use their named constants, and the enabled gocritic checks are clean.

`gosec` is deferred to a focused follow-up because its findings need security review. `goconst` and `contextcheck` are omitted because they produced 419 low-value repeated-literal findings and 37 findings that included false positives, respectively.