### PR TITLE
Refactor runtime execution around per-job sessions

### DIFF
--- a/internal/runtime/action_execution.go
+++ b/internal/runtime/action_execution.go
@@ -26,209 +26,6 @@ import (
 	"github.com/buildkite/buildkite-gha/internal/transport"
 )
 
-// JobResult is the bounded logical result returned to the transport layer.
-type JobResult struct {
-	Conclusion         string                     `json:"conclusion"`
-	Outputs            map[string]string          `json:"outputs,omitempty"`
-	Env                map[string]string          `json:"env,omitempty"`
-	State              map[string]string          `json:"state,omitempty"`
-	Summary            string                     `json:"summary,omitempty"`
-	WarningAnnotations string                     `json:"warning_annotations,omitempty"`
-	ErrorAnnotations   string                     `json:"error_annotations,omitempty"`
-	Artifacts          []transport.ResultArtifact `json:"artifacts,omitempty"`
-
-	summaryTruncated  bool
-	warningsTruncated bool
-	errorsTruncated   bool
-	failureVisible    bool
-}
-
-// FailureVisible reports whether the runtime expanded a section containing the failure.
-func (r JobResult) FailureVisible() bool { return r.failureVisible }
-
-const maxJobOutputBytes = 1024
-
-type toleratedJobFailure struct {
-	err error
-}
-
-func (e *toleratedJobFailure) Error() string { return e.err.Error() }
-func (e *toleratedJobFailure) Unwrap() error { return e.err }
-
-type hardJobFailure struct {
-	err error
-}
-
-func (e *hardJobFailure) Error() string { return e.err.Error() }
-func (e *hardJobFailure) Unwrap() error { return e.err }
-
-type workflowJobFailure struct {
-	err error
-}
-
-func (e *workflowJobFailure) Error() string { return e.err.Error() }
-func (e *workflowJobFailure) Unwrap() error { return e.err }
-
-func markHardJobFailure(err error) error {
-	if err == nil || isHardJobFailure(err) {
-		return err
-	}
-	return &hardJobFailure{err: err}
-}
-
-func isHardJobFailure(err error) bool {
-	var target *hardJobFailure
-	return errors.As(err, &target)
-}
-
-func markWorkflowJobFailure(err error) error {
-	if err == nil {
-		return nil
-	}
-	return &workflowJobFailure{err: err}
-}
-
-func isWorkflowJobFailure(err error) bool {
-	var target *workflowJobFailure
-	return errors.As(err, &target)
-}
-
-// IsToleratedJobFailure reports whether err contains only a workflow failure
-// admitted by the job's continue-on-error setting. Joined cleanup, integrity,
-// transport, and publication errors deliberately return false.
-func IsToleratedJobFailure(err error) bool {
-	_, ok := err.(*toleratedJobFailure)
-	return ok
-}
-
-func tolerateJobSetupFailure(runCtx context.Context, job plan.Job, result JobResult, err error) (JobResult, error) {
-	if runCtx.Err() != nil {
-		result.Conclusion = "cancelled"
-		return result, errors.Join(err, runCtx.Err())
-	}
-	if job.ContinueOnError && isWorkflowJobFailure(err) && !isHardJobFailure(err) {
-		result.Conclusion = "success"
-		return result, &toleratedJobFailure{err: err}
-	}
-	return result, err
-}
-
-type registeredPost struct {
-	condition  string
-	invocation *preparedInvocation
-}
-
-type postRegistry struct {
-	mu    sync.Mutex
-	posts []registeredPost
-}
-
-type preparedInvocation struct {
-	action         javaScriptAction
-	state          map[string]string
-	node           string
-	eval           expression.Context
-	envOverlay     map[string]string
-	isolated       bool
-	postRegistered bool
-	preFailure     error
-}
-
-type remotePreparations map[string]*preparedInvocation
-
-func bindCompositeInvocationSteps(invocation *preparedInvocation, steps map[string]expression.StepStatus) {
-	if invocation != nil && invocation.isolated {
-		invocation.eval.Steps = steps
-	}
-}
-
-type remotePreparationStatus struct {
-	unsuccessful bool
-}
-
-type remotePreparationTimeout struct {
-	step     plan.Step
-	eval     expression.Context
-	resolved bool
-	bounded  context.Context
-	cancel   context.CancelFunc
-}
-
-func (t *remotePreparationTimeout) context(parent context.Context) (context.Context, error) {
-	if !t.resolved {
-		step, err := evaluateStepTimeout(t.step, t.eval)
-		if err != nil {
-			return nil, fmt.Errorf("controls: %w", err)
-		}
-		t.bounded, t.cancel = stepContext(parent, step.TimeoutMinutes)
-		t.resolved = true
-	}
-	return t.bounded, nil
-}
-
-func (t *remotePreparationTimeout) close() {
-	if t != nil && t.cancel != nil {
-		t.cancel()
-	}
-}
-
-const node16DeprecationMessage = "Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: %s. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/."
-
-type node16DeprecationWarnings struct {
-	mu      sync.Mutex
-	actions map[string]struct{}
-}
-
-func (w *node16DeprecationWarnings) record(reference string) {
-	if w == nil || reference == "" {
-		return
-	}
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	if w.actions == nil {
-		w.actions = make(map[string]struct{})
-	}
-	w.actions[reference] = struct{}{}
-}
-
-func (w *node16DeprecationWarnings) emit(processor *commandProcessor) {
-	if w == nil || processor == nil {
-		return
-	}
-	w.mu.Lock()
-	actions := sortedKeys(w.actions)
-	w.mu.Unlock()
-	if len(actions) != 0 {
-		processor.trustedWarning(fmt.Sprintf(node16DeprecationMessage, strings.Join(actions, ", ")))
-	}
-}
-
-func actionNodeMajor(runtime metadata.Runtime) (int, bool) {
-	switch runtime {
-	case metadata.RuntimeNode16:
-		return 16, true
-	case metadata.RuntimeNode24:
-		return 24, true
-	default:
-		return 0, false
-	}
-}
-
-func (r *postRegistry) register(post *registeredPost) {
-	if post == nil {
-		return
-	}
-	r.mu.Lock()
-	r.posts = append(r.posts, *post)
-	r.mu.Unlock()
-}
-
-func (r *postRegistry) snapshot() []registeredPost {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return append([]registeredPost(nil), r.posts...)
-}
-
 // verifyWorkflow binds a plan to the workflow bytes in the supplied workspace.
 func verifyWorkflow(job plan.Job, workspace string) error {
 	if job.Workflow.Remote != nil {
@@ -254,20 +51,10 @@ func verifyWorkflow(job plan.Job, workspace string) error {
 	return nil
 }
 
-// RunJob executes the plan's ordered steps and always drains registered post actions.
-func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (final JobResult, runJobErr error) {
-	defer func() {
-		if final.Conclusion == "success" && runJobErr != nil && !IsToleratedJobFailure(runJobErr) {
-			final.Conclusion = "failure"
-		}
-	}()
-	callerWorkspace := workspace != ""
-	if r.nodeVerification == nil {
-		r.nodeVerification = &managedNodeVerification{paths: make(map[int]string, 2)}
-	}
-	if r.artifactRegistry == nil {
-		r.artifactRegistry = &artifactRegistry{names: make(map[string]bool)}
-	}
+func (r *jobRun) prepare(ctx context.Context) (final JobResult, runJobErr error) {
+	job := r.job
+	workspace := r.workspace
+	callerWorkspace := r.callerWorkspace
 	if err := job.Validate(); err != nil {
 		return JobResult{}, err
 	}
@@ -370,7 +157,6 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		return jobResult, fmt.Errorf("job has prerequisite sources but no hydrated prerequisite results")
 	}
 	processor := newCommandProcessor(r.stdout(), r.stderr())
-	r.node16Warnings = &node16DeprecationWarnings{}
 	eval := expression.Context{
 		WorkflowInputs: job.Inputs,
 		Matrix:         job.Matrix,
@@ -635,14 +421,33 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 		}
 	}
 	eval.Env = jobResult.Env
-	var posts postRegistry
-	supervisor := newBackgroundSupervisor(maxActiveBackgroundSteps)
+	r.workspace = workspace
+	r.processor = processor
+	r.eval = eval
+	r.result = jobResult
+	r.runtimeEnv = runtimeEnv
+	r.actions = actions
+	r.posts = &postRegistry{}
+	r.supervisor = newBackgroundSupervisor(maxActiveBackgroundSteps)
+	r.prepared = remotePreparations{}
+	r.preFailures = make(map[int]stepExecution)
+	return r.runPreActions(ctx, runCtx)
+}
 
-	var runErr error
-	hardFailure := false
-	prepared := remotePreparations{}
+func (r *jobRun) runPreActions(ctx, runCtx context.Context) (JobResult, error) {
+	job := r.job
+	workspace := r.workspace
+	processor := r.processor
+	eval := r.eval
+	jobResult := r.result
+	runtimeEnv := r.runtimeEnv
+	actions := r.actions
+	posts := r.posts
+	prepared := r.prepared
+	runErr := r.runErr
+	hardFailure := r.hardFailure
 	preStatus := remotePreparationStatus{}
-	preFailures := make(map[int]stepExecution)
+	preFailures := r.preFailures
 	if len(job.Actions) != 0 {
 		for stepIndex, step := range job.Steps {
 			eval.JobStatus = jobStatusValue(runErr != nil, runCtx.Err() != nil)
@@ -679,7 +484,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 			preCtx, cancelPre := stepContext(runCtx, step.TimeoutMinutes)
 			bindHashFilesContext(preCtx, &preEval)
 			wasUnsuccessful := preStatus.unsuccessful
-			preResult, preErr := r.prepareRemoteAction(preCtx, processor, workspace, step, strconv.Itoa(stepIndex), preEnv, preEval, &posts, actions, prepared, &preStatus, true, nil, nil, nil)
+			preResult, preErr := r.prepareRemoteAction(preCtx, processor, workspace, step, strconv.Itoa(stepIndex), preEnv, preEval, posts, actions, prepared, &preStatus, true, nil, nil, nil)
 			commitResultEnvironment(jobResult.Env, preResult)
 			mergeInto(jobResult.State, preResult.State)
 			appendJobSummary(&jobResult.Summary, &jobResult.summaryTruncated, preResult.Summary, preResult.summaryTruncated)
@@ -702,6 +507,26 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 			cancelPre()
 		}
 	}
+	r.eval = eval
+	r.result = jobResult
+	r.runErr = runErr
+	r.hardFailure = hardFailure
+	return r.runSteps(ctx, runCtx)
+}
+
+func (r *jobRun) runSteps(ctx, runCtx context.Context) (JobResult, error) {
+	job := r.job
+	workspace := r.workspace
+	processor := r.processor
+	eval := r.eval
+	jobResult := r.result
+	runtimeEnv := r.runtimeEnv
+	actions := r.actions
+	posts := r.posts
+	supervisor := r.supervisor
+	prepared := r.prepared
+	preFailures := r.preFailures
+	runErr := r.runErr
 	for stepIndex, step := range job.Steps {
 		eval.JobStatus = jobStatusValue(runErr != nil, runCtx.Err() != nil)
 		if step.Kind == "cancel" {
@@ -804,7 +629,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 					defer cancelExecution()
 					executionEval := cloneExpressionContext(evalSnapshot)
 					bindHashFilesContext(stepCtx, &executionEval)
-					return r.executePlanStep(runCtx, stepCtx, processor, workspace, job, step, strconv.Itoa(stepIndex), jobEnv, stepEnv, executionEval, &posts, actions, prepared)
+					return r.executePlanStep(runCtx, stepCtx, processor, workspace, job, step, strconv.Itoa(stepIndex), jobEnv, stepEnv, executionEval, posts, actions, prepared)
 				},
 				func(stepCtx context.Context) stepExecution {
 					return cancelledStepExecution(runCtx, stepCtx, step)
@@ -813,7 +638,7 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 			continue
 		}
 		processor.logSection(displayName)
-		execution := r.executePlanStep(runCtx, stepCtx, processor, workspace, job, step, strconv.Itoa(stepIndex), jobEnv, stepEnv, evalSnapshot, &posts, actions, prepared)
+		execution := r.executePlanStep(runCtx, stepCtx, processor, workspace, job, step, strconv.Itoa(stepIndex), jobEnv, stepEnv, evalSnapshot, posts, actions, prepared)
 		cancelStep()
 		if execution.outcome == "failure" {
 			processor.expandCurrentSection()
@@ -827,10 +652,21 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 	if runCtx.Err() != nil {
 		runErr = errors.Join(runErr, runCtx.Err())
 	}
+	r.eval = eval
+	r.result = jobResult
+	r.runErr = runErr
+	return r.runPostActions(runCtx)
+}
 
+func (r *jobRun) runPostActions(runCtx context.Context) (JobResult, error) {
+	jobResult := r.result
+	processor := r.processor
+	workspace := r.workspace
+	eval := r.eval
+	runErr := r.runErr
 	postCtx, cancelPosts := postPhaseContext(runCtx, r.postActionTimeout(), r.cleanupTimeout())
 	defer cancelPosts()
-	registeredPosts := posts.snapshot()
+	registeredPosts := r.posts.snapshot()
 	for i := len(registeredPosts) - 1; i >= 0; i-- {
 		post := registeredPosts[i]
 		invocation := post.invocation
@@ -876,7 +712,19 @@ func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (fin
 			runErr = errors.Join(runErr, fmt.Errorf("post action %q: %w", action.Name, postErr))
 		}
 	}
+	r.eval = eval
+	r.result = jobResult
+	r.runErr = runErr
+	return r.finalize(runCtx)
+}
 
+func (r *jobRun) finalize(runCtx context.Context) (JobResult, error) {
+	job := r.job
+	processor := r.processor
+	eval := r.eval
+	jobResult := r.result
+	runErr := r.runErr
+	hardFailure := r.hardFailure
 	r.node16Warnings.emit(processor)
 	jobResult.WarningAnnotations, jobResult.warningsTruncated, jobResult.ErrorAnnotations, jobResult.errorsTruncated = processor.workflowCommandAnnotations()
 	sensitiveValues := processor.maskValues()
@@ -1507,7 +1355,7 @@ type invocationEnvironment struct {
 	explicitPATH bool
 }
 
-func (r Runner) invocationEnvironment(jobEnv, stepEnv map[string]string) invocationEnvironment {
+func (r *jobRun) invocationEnvironment(jobEnv, stepEnv map[string]string) invocationEnvironment {
 	_, stepPATH := stepEnv["PATH"]
 	jobPATH := r.explicitJobPATH || jobEnv["PATH"] != r.implicitJobPATH
 	return invocationEnvironment{jobEnv: jobEnv, stepEnv: stepEnv, explicitPATH: jobPATH || stepPATH}
@@ -1568,7 +1416,7 @@ func isRuntimeContextEnvironment(name string) bool {
 	}
 }
 
-func (r Runner) runJobStep(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, step plan.Step, invocationID string, jobEnv, stepEnv map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations) (Result, error) {
+func (r *jobRun) runJobStep(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, step plan.Step, invocationID string, jobEnv, stepEnv map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations) (Result, error) {
 	return r.runActionStep(ctx, processor, workspace, job, step, invocationID, jobEnv, stepEnv, nil, eval, posts, actions, prepared, nil, nil)
 }
 
@@ -1621,7 +1469,7 @@ func (r Runner) verifyRemoteActionTree(ctx context.Context, actions *actionLockR
 	return nil
 }
 
-func (r *Runner) actionContainerMounts(ctx context.Context, actions *actionLockResolver) ([]containerMount, error) {
+func (r *jobRun) actionContainerMounts(ctx context.Context, actions *actionLockResolver) ([]containerMount, error) {
 	byTarget := map[string]containerMount{}
 	requiredNode := map[int]bool{}
 	unknownWorkspaceRuntime := false
@@ -1723,7 +1571,7 @@ func (r *Runner) actionContainerMounts(ctx context.Context, actions *actionLockR
 	return out, nil
 }
 
-func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProcessor, workspace string, step plan.Step, invocationID string, jobEnv map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations, status *remotePreparationStatus, workflowStep bool, inheritedEvalErr error, inheritedTimeout *remotePreparationTimeout, inheritedEnvOverlay map[string]string) (Result, error) {
+func (r *jobRun) prepareRemoteAction(ctx context.Context, processor *commandProcessor, workspace string, step plan.Step, invocationID string, jobEnv map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations, status *remotePreparationStatus, workflowStep bool, inheritedEvalErr error, inheritedTimeout *remotePreparationTimeout, inheritedEnvOverlay map[string]string) (Result, error) {
 	result := newResult()
 	eval.JobStatus = jobStatusValue(status.unsuccessful, ctx.Err() != nil)
 	evaluate := evaluateStepMap
@@ -1922,7 +1770,7 @@ func (r Runner) prepareRemoteAction(ctx context.Context, processor *commandProce
 	}
 }
 
-func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, step plan.Step, invocationID string, jobEnv, stepEnv, evaluatedWith map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations, actionStack []string, inheritedEnvOverlay map[string]string) (Result, error) {
+func (r *jobRun) runActionStep(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, step plan.Step, invocationID string, jobEnv, stepEnv, evaluatedWith map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations, actionStack []string, inheritedEnvOverlay map[string]string) (Result, error) {
 	if stepEnv == nil {
 		var err error
 		stepEnv, err = evaluateStepMap(step.Env, eval)
@@ -2187,7 +2035,7 @@ func (r Runner) runActionStep(ctx context.Context, processor *commandProcessor, 
 	return result, fmt.Errorf("action %q uses unsupported runtime %q", step.Uses, actionRuntime)
 }
 
-func (r Runner) runCompositeMetadata(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, actionPath string, action metadata.Metadata, inputs map[string]string, invocationID string, jobEnv, stepEnv, lifecycleEnvOverlay map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations, actionLock *plan.ActionLock, actionStack []string) (Result, error) {
+func (r *jobRun) runCompositeMetadata(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, actionPath string, action metadata.Metadata, inputs map[string]string, invocationID string, jobEnv, stepEnv, lifecycleEnvOverlay map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations, actionLock *plan.ActionLock, actionStack []string) (Result, error) {
 	result := newResult()
 	// Keep hashFiles unavailable to composite step metadata while retaining the
 	// context binder for nested JavaScript lifecycle conditions.
@@ -2466,7 +2314,7 @@ func shellCommand(shell, script string) ([]string, error) {
 	}
 }
 
-func (r Runner) runShellProcess(ctx context.Context, processor *commandProcessor, dir string, env map[string]string, result *Result, shell, script string) error {
+func (r *jobRun) runShellProcess(ctx context.Context, processor *commandProcessor, dir string, env map[string]string, result *Result, shell, script string) error {
 	if strings.TrimSpace(shell) != "python" {
 		args, err := shellCommand(shell, script)
 		if err != nil {

--- a/internal/runtime/action_lifecycle.go
+++ b/internal/runtime/action_lifecycle.go
@@ -1,0 +1,128 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/buildkite/buildkite-gha/internal/action/metadata"
+	"github.com/buildkite/buildkite-gha/internal/expression"
+	"github.com/buildkite/buildkite-gha/internal/plan"
+)
+
+type registeredPost struct {
+	condition  string
+	invocation *preparedInvocation
+}
+
+type postRegistry struct {
+	mu    sync.Mutex
+	posts []registeredPost
+}
+
+type preparedInvocation struct {
+	action         javaScriptAction
+	state          map[string]string
+	node           string
+	eval           expression.Context
+	envOverlay     map[string]string
+	isolated       bool
+	postRegistered bool
+	preFailure     error
+}
+
+type remotePreparations map[string]*preparedInvocation
+
+func bindCompositeInvocationSteps(invocation *preparedInvocation, steps map[string]expression.StepStatus) {
+	if invocation != nil && invocation.isolated {
+		invocation.eval.Steps = steps
+	}
+}
+
+type remotePreparationStatus struct {
+	unsuccessful bool
+}
+
+type remotePreparationTimeout struct {
+	step     plan.Step
+	eval     expression.Context
+	resolved bool
+	bounded  context.Context
+	cancel   context.CancelFunc
+}
+
+func (t *remotePreparationTimeout) context(parent context.Context) (context.Context, error) {
+	if !t.resolved {
+		step, err := evaluateStepTimeout(t.step, t.eval)
+		if err != nil {
+			return nil, fmt.Errorf("controls: %w", err)
+		}
+		t.bounded, t.cancel = stepContext(parent, step.TimeoutMinutes)
+		t.resolved = true
+	}
+	return t.bounded, nil
+}
+
+func (t *remotePreparationTimeout) close() {
+	if t != nil && t.cancel != nil {
+		t.cancel()
+	}
+}
+
+const node16DeprecationMessage = "Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: %s. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/."
+
+type node16DeprecationWarnings struct {
+	mu      sync.Mutex
+	actions map[string]struct{}
+}
+
+func (w *node16DeprecationWarnings) record(reference string) {
+	if w == nil || reference == "" {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.actions == nil {
+		w.actions = make(map[string]struct{})
+	}
+	w.actions[reference] = struct{}{}
+}
+
+func (w *node16DeprecationWarnings) emit(processor *commandProcessor) {
+	if w == nil || processor == nil {
+		return
+	}
+	w.mu.Lock()
+	actions := sortedKeys(w.actions)
+	w.mu.Unlock()
+	if len(actions) != 0 {
+		processor.trustedWarning(fmt.Sprintf(node16DeprecationMessage, strings.Join(actions, ", ")))
+	}
+}
+
+func actionNodeMajor(runtime metadata.Runtime) (int, bool) {
+	switch runtime {
+	case metadata.RuntimeNode16:
+		return 16, true
+	case metadata.RuntimeNode24:
+		return 24, true
+	default:
+		return 0, false
+	}
+}
+
+func (r *postRegistry) register(post *registeredPost) {
+	if post == nil {
+		return
+	}
+	r.mu.Lock()
+	r.posts = append(r.posts, *post)
+	r.mu.Unlock()
+}
+
+func (r *postRegistry) snapshot() []registeredPost {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]registeredPost(nil), r.posts...)
+}

--- a/internal/runtime/cache_service_test.go
+++ b/internal/runtime/cache_service_test.go
@@ -654,7 +654,7 @@ fs.writeFileSync(process.env.MARKER, "executed");
 	result.Env["MARKER"] = marker
 	result.Env["ACTIONS_RUNTIME_TOKEN"] = "workflow-token"
 	processor := newCommandProcessor(io.Discard, io.Discard)
-	runner := Runner{Cache: provider, Redactor: &testRedactor{}}
+	runner := newJobRun(Runner{Cache: provider, Redactor: &testRedactor{}})
 	if err := runner.runJavaScriptPhase(
 		t.Context(), processor, actionRoot, node,
 		javaScriptAction{Name: "ordinary", Path: actionRoot, Main: "main.js"}, "main.js", nil, nil, &result,
@@ -731,7 +731,7 @@ func TestCacheRedactorFailureAbortsBeforeExecutionAndScrubsToken(t *testing.T) {
 	processor := newCommandProcessor(&logs, &logs)
 	result := newResult()
 	result.Env["MARKER"] = marker
-	err := (Runner{Cache: provider, Redactor: failingCacheRedactor{token: token}}).runJavaScriptPhase(
+	err := newJobRun(Runner{Cache: provider, Redactor: failingCacheRedactor{token: token}}).runJavaScriptPhase(
 		t.Context(), processor, actionRoot, "node", javaScriptAction{Name: "cache", Path: actionRoot, Main: "main.js", Cache: true}, "main.js", nil, nil, &result,
 	)
 	if err == nil || strings.Contains(err.Error(), token) || !strings.Contains(err.Error(), "***") {
@@ -765,7 +765,7 @@ func TestActionRuntimeCacheTokenCommandFileEffectsAreDiscarded(t *testing.T) {
 			result.Summary = "existing summary\n"
 			result.Paths = []string{"/existing/path"}
 			state := map[string]string{"kept": "action state"}
-			err := (Runner{Cache: provider, Redactor: &testRedactor{}}).runJavaScriptPhase(
+			err := newJobRun(Runner{Cache: provider, Redactor: &testRedactor{}}).runJavaScriptPhase(
 				t.Context(), newCommandProcessor(io.Discard, io.Discard), actionRoot, node,
 				javaScriptAction{Name: "ordinary", Path: actionRoot, Main: "main.js"}, "main.js", nil, state, &result,
 			)

--- a/internal/runtime/checkout_test.go
+++ b/internal/runtime/checkout_test.go
@@ -1437,7 +1437,7 @@ func TestContainerPreparationSkipsNativeCheckoutClassification(t *testing.T) {
 			}
 			materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, ActionRoot: remote, SourceDigest: remoteDigest}}
 			actions := newActionLockResolver(job, t.TempDir(), materializer)
-			runner := &Runner{}
+			runner := newJobRun(Runner{})
 			if err := runner.verifyRemoteActionTree(t.Context(), actions, plan.ActionSelector{Lock: checkoutID}, nil); err != nil {
 				t.Fatalf("verifyRemoteActionTree() error = %v", err)
 			}

--- a/internal/runtime/concurrent.go
+++ b/internal/runtime/concurrent.go
@@ -188,7 +188,7 @@ func bindHashFilesContext(ctx context.Context, eval *expression.Context) {
 	}
 }
 
-func (r Runner) executePlanStep(jobCtx, runCtx context.Context, processor *commandProcessor, workspace string, job plan.Job, step plan.Step, invocationID string, jobEnv, stepEnv map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations) stepExecution {
+func (r *jobRun) executePlanStep(jobCtx, runCtx context.Context, processor *commandProcessor, workspace string, job plan.Job, step plan.Step, invocationID string, jobEnv, stepEnv map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations) stepExecution {
 	result, err := r.runJobStep(runCtx, processor, workspace, job, step, invocationID, jobEnv, stepEnv, eval, posts, actions, prepared)
 	return classifyStepExecutionWithControls(jobCtx, runCtx, step, result, err, eval)
 }

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -1827,10 +1827,10 @@ func TestActionContainerMountsNativeAdapterDoesNotResolveMise(t *testing.T) {
 	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, ActionRoot: remote, SourceDigest: digest}}
 	actions := newActionLockResolver(job, workspace, materializer)
 	miseCalls := 0
-	runner := Runner{ResolveMise: func(context.Context) (string, error) {
+	runner := newJobRun(Runner{ResolveMise: func(context.Context) (string, error) {
 		miseCalls++
 		return "", errors.New("unexpected mise resolution")
-	}}
+	}})
 	mounts, err := runner.actionContainerMounts(t.Context(), actions)
 	if err != nil {
 		t.Fatal(err)
@@ -2435,7 +2435,8 @@ func TestRunJobContainerSiblingDockerFailureCleansActionAndJobResources(t *testi
 }
 
 func TestRunDockerRejectsMismatchedJobContainerPaths(t *testing.T) {
-	r := Runner{jobContainer: &jobContainerBackend{workspace: "/owned/workspace", temp: "/owned/temp"}}
+	r := newJobRun(Runner{})
+	r.jobContainer = &jobContainerBackend{workspace: "/owned/workspace", temp: "/owned/temp"}
 	_, err := r.runDocker(t.Context(), newCommandProcessor(nil, nil), dockerAction{Workspace: "/other/workspace", runnerTemp: "/owned/temp"})
 	if err == nil || !strings.Contains(err.Error(), "must match the job container's owned host paths") {
 		t.Fatalf("mismatched sibling paths error = %v", err)

--- a/internal/runtime/download_artifact_test.go
+++ b/internal/runtime/download_artifact_test.go
@@ -209,7 +209,7 @@ func TestNativeArtifactRoundTripTrimsNameAndAcceptsHighCompression(t *testing.T)
 		t.Fatal(err)
 	}
 	uploader := &captureArtifactUploader{}
-	uploadRunner := Runner{Artifacts: uploader, artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
+	uploadRunner := newJobRun(Runner{Artifacts: uploader})
 	upload, err := uploadRunner.runUploadArtifact(t.Context(), newCommandProcessor(io.Discard, io.Discard), uploadWorkspace, map[string]string{"name": " payload ", "path": "zeros.bin"})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/runtime/invocation_env_test.go
+++ b/internal/runtime/invocation_env_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestInvocationEnvironmentProcessOverlayOrder(t *testing.T) {
-	var r Runner
+	var r jobRun
 	environment := r.invocationEnvironment(
 		map[string]string{"SHARED": "job", "JOB_ONLY": "job", "GITHUB_REPOSITORY": "owner/repo"},
 		map[string]string{"SHARED": "step", "STEP_ONLY": "step", "GITHUB_REPOSITORY": "spoofed"},
@@ -27,7 +27,7 @@ func TestInvocationEnvironmentProcessOverlayOrder(t *testing.T) {
 func TestInvocationEnvironmentDockerPATHPrecedence(t *testing.T) {
 	tests := []struct {
 		name             string
-		runner           Runner
+		runner           jobRun
 		jobEnv           map[string]string
 		stepEnv          map[string]string
 		actionEnv        map[string]string
@@ -36,7 +36,7 @@ func TestInvocationEnvironmentDockerPATHPrecedence(t *testing.T) {
 	}{
 		{
 			name:             "action PATH replaces implicit job PATH",
-			runner:           Runner{implicitJobPATH: "/usr/bin"},
+			runner:           jobRun{implicitJobPATH: "/usr/bin"},
 			jobEnv:           map[string]string{"PATH": "/usr/bin"},
 			actionEnv:        map[string]string{"PATH": "/action/bin"},
 			wantPATH:         "/action/bin",
@@ -44,7 +44,7 @@ func TestInvocationEnvironmentDockerPATHPrecedence(t *testing.T) {
 		},
 		{
 			name:             "explicit job PATH wins over action PATH",
-			runner:           Runner{explicitJobPATH: true, implicitJobPATH: "/usr/bin"},
+			runner:           jobRun{explicitJobPATH: true, implicitJobPATH: "/usr/bin"},
 			jobEnv:           map[string]string{"PATH": "/job/bin"},
 			actionEnv:        map[string]string{"PATH": "/action/bin"},
 			wantPATH:         "/job/bin",
@@ -52,7 +52,7 @@ func TestInvocationEnvironmentDockerPATHPrecedence(t *testing.T) {
 		},
 		{
 			name:             "step PATH wins over action PATH",
-			runner:           Runner{implicitJobPATH: "/usr/bin"},
+			runner:           jobRun{implicitJobPATH: "/usr/bin"},
 			jobEnv:           map[string]string{"PATH": "/usr/bin"},
 			stepEnv:          map[string]string{"PATH": "/step/bin"},
 			actionEnv:        map[string]string{"PATH": "/action/bin"},
@@ -61,7 +61,7 @@ func TestInvocationEnvironmentDockerPATHPrecedence(t *testing.T) {
 		},
 		{
 			name:             "implicit PATH everywhere keeps image PATH authority",
-			runner:           Runner{implicitJobPATH: "/usr/bin"},
+			runner:           jobRun{implicitJobPATH: "/usr/bin"},
 			jobEnv:           map[string]string{"PATH": "/usr/bin"},
 			actionEnv:        map[string]string{"OTHER": "value"},
 			wantPATH:         "/usr/bin",
@@ -80,7 +80,7 @@ func TestInvocationEnvironmentDockerPATHPrecedence(t *testing.T) {
 }
 
 func TestInvocationEnvironmentDockerOverlaysActionAndInputs(t *testing.T) {
-	runner := Runner{implicitJobPATH: "/usr/bin"}
+	runner := jobRun{implicitJobPATH: "/usr/bin"}
 	environment := runner.invocationEnvironment(
 		map[string]string{"PATH": "/usr/bin", "SHARED": "job"},
 		map[string]string{"STEP_ONLY": "step"},

--- a/internal/runtime/job_result.go
+++ b/internal/runtime/job_result.go
@@ -1,0 +1,96 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+
+	"github.com/buildkite/buildkite-gha/internal/plan"
+	"github.com/buildkite/buildkite-gha/internal/transport"
+)
+
+// JobResult is the bounded logical result returned to the transport layer.
+type JobResult struct {
+	Conclusion         string                     `json:"conclusion"`
+	Outputs            map[string]string          `json:"outputs,omitempty"`
+	Env                map[string]string          `json:"env,omitempty"`
+	State              map[string]string          `json:"state,omitempty"`
+	Summary            string                     `json:"summary,omitempty"`
+	WarningAnnotations string                     `json:"warning_annotations,omitempty"`
+	ErrorAnnotations   string                     `json:"error_annotations,omitempty"`
+	Artifacts          []transport.ResultArtifact `json:"artifacts,omitempty"`
+
+	summaryTruncated  bool
+	warningsTruncated bool
+	errorsTruncated   bool
+	failureVisible    bool
+}
+
+// FailureVisible reports whether the runtime expanded a section containing the failure.
+func (r JobResult) FailureVisible() bool { return r.failureVisible }
+
+const maxJobOutputBytes = 1024
+
+type toleratedJobFailure struct {
+	err error
+}
+
+func (e *toleratedJobFailure) Error() string { return e.err.Error() }
+func (e *toleratedJobFailure) Unwrap() error { return e.err }
+
+type hardJobFailure struct {
+	err error
+}
+
+func (e *hardJobFailure) Error() string { return e.err.Error() }
+func (e *hardJobFailure) Unwrap() error { return e.err }
+
+type workflowJobFailure struct {
+	err error
+}
+
+func (e *workflowJobFailure) Error() string { return e.err.Error() }
+func (e *workflowJobFailure) Unwrap() error { return e.err }
+
+func markHardJobFailure(err error) error {
+	if err == nil || isHardJobFailure(err) {
+		return err
+	}
+	return &hardJobFailure{err: err}
+}
+
+func isHardJobFailure(err error) bool {
+	var target *hardJobFailure
+	return errors.As(err, &target)
+}
+
+func markWorkflowJobFailure(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &workflowJobFailure{err: err}
+}
+
+func isWorkflowJobFailure(err error) bool {
+	var target *workflowJobFailure
+	return errors.As(err, &target)
+}
+
+// IsToleratedJobFailure reports whether err contains only a workflow failure
+// admitted by the job's continue-on-error setting. Joined cleanup, integrity,
+// transport, and publication errors deliberately return false.
+func IsToleratedJobFailure(err error) bool {
+	_, ok := err.(*toleratedJobFailure)
+	return ok
+}
+
+func tolerateJobSetupFailure(runCtx context.Context, job plan.Job, result JobResult, err error) (JobResult, error) {
+	if runCtx.Err() != nil {
+		result.Conclusion = "cancelled"
+		return result, errors.Join(err, runCtx.Err())
+	}
+	if job.ContinueOnError && isWorkflowJobFailure(err) && !isHardJobFailure(err) {
+		result.Conclusion = "success"
+		return result, &toleratedJobFailure{err: err}
+	}
+	return result, err
+}

--- a/internal/runtime/job_run.go
+++ b/internal/runtime/job_run.go
@@ -1,0 +1,69 @@
+package runtime
+
+import (
+	"context"
+
+	"github.com/buildkite/buildkite-gha/internal/expression"
+	"github.com/buildkite/buildkite-gha/internal/plan"
+)
+
+// jobRun owns all mutable state and resources for one job execution. Runner is
+// embedded as a private configuration copy so per-job state cannot leak when
+// callers reuse the public facade.
+type jobRun struct {
+	Runner
+
+	job             plan.Job
+	workspace       string
+	callerWorkspace bool
+	processor       *commandProcessor
+	eval            expression.Context
+	result          JobResult
+	runtimeEnv      map[string]string
+	actions         *actionLockResolver
+	posts           *postRegistry
+	supervisor      *backgroundSupervisor
+	prepared        remotePreparations
+	preFailures     map[int]stepExecution
+	runErr          error
+	hardFailure     bool
+
+	runnerTemp       string
+	implicitJobPATH  string
+	explicitJobPATH  bool
+	jobContainer     *jobContainerBackend
+	jobDocker        *jobContainerBackend
+	nodeVerification *managedNodeVerification
+	artifactRegistry *artifactRegistry
+	node16Warnings   *node16DeprecationWarnings
+	idTokenService   *idTokenService
+}
+
+// RunJob executes the plan's ordered steps and always drains registered post actions.
+func (r Runner) RunJob(ctx context.Context, job plan.Job, workspace string) (JobResult, error) {
+	run := newJobRun(r)
+	run.job = job
+	run.workspace = workspace
+	run.callerWorkspace = workspace != ""
+	return run.run(ctx)
+}
+
+func newJobRun(r Runner) *jobRun {
+	return &jobRun{
+		Runner:           r,
+		nodeVerification: &managedNodeVerification{paths: make(map[int]string, 2)},
+		artifactRegistry: &artifactRegistry{names: make(map[string]bool)},
+		node16Warnings:   &node16DeprecationWarnings{},
+	}
+}
+
+func (r *jobRun) run(ctx context.Context) (final JobResult, runJobErr error) {
+	defer func() {
+		if final.Conclusion == "success" && runJobErr != nil && !IsToleratedJobFailure(runJobErr) {
+			final.Conclusion = "failure"
+		}
+	}()
+	// prepare chains the remaining phases before it returns so its resource
+	// cleanup stays deferred until post actions and finalization complete.
+	return r.prepare(ctx)
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -75,16 +75,7 @@ type Runner struct {
 	RepositoryCredentials *AgentRepositoryCredentials
 	WorkflowToken         WorkflowTokenProvider
 	OIDCToken             OIDCTokenProvider
-	runnerTemp            string
-	implicitJobPATH       string
-	explicitJobPATH       bool
-	jobContainer          *jobContainerBackend
-	jobDocker             *jobContainerBackend
-	nodeVerification      *managedNodeVerification
 	nodeDigests           map[int]string
-	artifactRegistry      *artifactRegistry
-	node16Warnings        *node16DeprecationWarnings
-	idTokenService        *idTokenService
 }
 
 func resolveHostExecutableBeforeWorkflow(configured, fallback, label string) (string, error) {
@@ -281,10 +272,10 @@ func (r Runner) runDockerAction(ctx context.Context, action dockerAction) (resul
 		return newResult(), fmt.Errorf("make Docker runner temp writable: %w", e)
 	}
 	action.runnerTemp = temp
-	return r.runDocker(ctx, newCommandProcessor(r.stdout(), r.stderr()), action)
+	return newJobRun(r).runDocker(ctx, newCommandProcessor(r.stdout(), r.stderr()), action)
 }
 
-func (r Runner) runDocker(ctx context.Context, processor *commandProcessor, action dockerAction) (result Result, err error) {
+func (r *jobRun) runDocker(ctx context.Context, processor *commandProcessor, action dockerAction) (result Result, err error) {
 	result = newResult()
 	if err := validateEnvironmentNames(action.Env); err != nil {
 		return result, err
@@ -634,7 +625,7 @@ func (w *limitedWriter) Write(p []byte) (int, error) {
 	return w.writer.Write(p)
 }
 
-func (r Runner) runJavaScriptPhase(ctx context.Context, processor *commandProcessor, workspace, node string, action javaScriptAction, entry string, stateEnv, stateOut map[string]string, result *Result) error {
+func (r *jobRun) runJavaScriptPhase(ctx context.Context, processor *commandProcessor, workspace, node string, action javaScriptAction, entry string, stateEnv, stateOut map[string]string, result *Result) error {
 	env := mergeStringMaps(result.Env, action.Env, actionInputEnv(action.Inputs))
 	if path, ok := result.Env["PATH"]; ok {
 		env["PATH"] = path
@@ -759,7 +750,7 @@ func resultContains(result Result, value string) bool {
 	return false
 }
 
-func (r Runner) runProcess(ctx context.Context, processor *commandProcessor, dir string, env map[string]string, result *Result, state map[string]string, name string, args ...string) error {
+func (r *jobRun) runProcess(ctx context.Context, processor *commandProcessor, dir string, env map[string]string, result *Result, state map[string]string, name string, args ...string) error {
 	var files commandFiles
 	var err error
 	if r.jobContainer != nil {
@@ -783,7 +774,7 @@ func (r Runner) runProcess(ctx context.Context, processor *commandProcessor, dir
 	env = mergeStringMaps(env, commandPaths)
 	var runErr error
 	if r.jobContainer != nil {
-		runErr = r.jobContainer.exec(ctx, r, processor, dir, env, name, args...)
+		runErr = r.jobContainer.exec(ctx, r.Runner, processor, dir, env, name, args...)
 	} else {
 		runErr = r.runStreaming(ctx, processor, dir, env, name, args...)
 	}
@@ -989,7 +980,7 @@ func nodeTool(major int) string {
 	}
 }
 
-func (r Runner) discoverNode(ctx context.Context, major int, explicit string) (string, error) {
+func (r *jobRun) discoverNode(ctx context.Context, major int, explicit string) (string, error) {
 	if explicit != "" || r.ManagedNodeRoot != "" {
 		return discoverNodeContext(ctx, major, explicit, r.ManagedNodeRoot)
 	}
@@ -1003,7 +994,7 @@ func (r Runner) discoverNode(ctx context.Context, major int, explicit string) (s
 	return r.installAndVerifyMiseNode(ctx, major, r.Mise)
 }
 
-func (r Runner) resolveMiseNodePath(ctx context.Context, major int) (string, error) {
+func (r *jobRun) resolveMiseNodePath(ctx context.Context, major int) (string, error) {
 	return r.discoverNode(ctx, major, "")
 }
 
@@ -1014,7 +1005,7 @@ func (r Runner) miseEnv() map[string]string {
 	return map[string]string{"MISE_DATA_DIR": r.MiseDataDir}
 }
 
-func (r Runner) installAndVerifyMiseNode(ctx context.Context, major int, mise string) (string, error) {
+func (r *jobRun) installAndVerifyMiseNode(ctx context.Context, major int, mise string) (string, error) {
 	if r.nodeVerification != nil {
 		r.nodeVerification.mu.Lock()
 		defer r.nodeVerification.mu.Unlock()

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -4053,7 +4053,7 @@ func TestRunDockerRejectsInvalidEnvironmentNamesBeforeDocker(t *testing.T) {
 			action := fakeDockerAction(t)
 			action.runnerTemp = t.TempDir()
 			action.Env = map[string]string{name: "value"}
-			_, err := (Runner{Docker: docker}).runDocker(t.Context(), newCommandProcessor(io.Discard, io.Discard), action)
+			_, err := newJobRun(Runner{Docker: docker}).runDocker(t.Context(), newCommandProcessor(io.Discard, io.Discard), action)
 			if err == nil || !strings.Contains(err.Error(), "invalid environment variable name") {
 				t.Fatalf("runDocker() error = %v, want invalid environment name", err)
 			}
@@ -4576,7 +4576,7 @@ func TestMiseNodeSelectionIsExactAndConfigFree(t *testing.T) {
 		t.Fatal(err)
 	}
 	digest := sha256.Sum256(nodeBytes)
-	r := Runner{Mise: mise, MiseDataDir: dataDir, nodeDigests: map[int]string{20: hex.EncodeToString(digest[:])}}
+	r := newJobRun(Runner{Mise: mise, MiseDataDir: dataDir, nodeDigests: map[int]string{20: hex.EncodeToString(digest[:])}})
 	got, err := r.discoverNode(t.Context(), 20, "")
 	if err != nil || got != node {
 		t.Fatalf("discoverNode() = %q, %v", got, err)
@@ -4609,7 +4609,7 @@ func TestMiseNode16SelectionIsExactAndConfigFree(t *testing.T) {
 		t.Fatal(err)
 	}
 	digest := sha256.Sum256(nodeBytes)
-	got, err := (Runner{Mise: mise, MiseDataDir: dataDir, nodeDigests: map[int]string{16: hex.EncodeToString(digest[:])}}).discoverNode(t.Context(), 16, "")
+	got, err := newJobRun(Runner{Mise: mise, MiseDataDir: dataDir, nodeDigests: map[int]string{16: hex.EncodeToString(digest[:])}}).discoverNode(t.Context(), 16, "")
 	if err != nil || got != node {
 		t.Fatalf("discoverNode() = %q, %v", got, err)
 	}
@@ -4686,7 +4686,7 @@ func TestMiseNodePathIgnoresProgressOnStderr(t *testing.T) {
 		t.Fatal(err)
 	}
 	wrongDigest := sha256.Sum256(wrongBytes)
-	if _, err := (Runner{Mise: mise, nodeDigests: map[int]string{24: hex.EncodeToString(wrongDigest[:])}}).resolveMiseNodePath(t.Context(), 24); err == nil || !strings.Contains(err.Error(), `reported "v24.99.0", want "v24.18.0"`) {
+	if _, err := newJobRun(Runner{Mise: mise, nodeDigests: map[int]string{24: hex.EncodeToString(wrongDigest[:])}}).resolveMiseNodePath(t.Context(), 24); err == nil || !strings.Contains(err.Error(), `reported "v24.99.0", want "v24.18.0"`) {
 		t.Fatalf("resolveMiseNodePath() error = %v, want exact executable version rejection", err)
 	}
 	correctBytes := []byte("#!/bin/sh\nprintf 'v24.18.0\\n'\n")
@@ -4694,7 +4694,7 @@ func TestMiseNodePathIgnoresProgressOnStderr(t *testing.T) {
 		t.Fatal(err)
 	}
 	correctDigest := sha256.Sum256(correctBytes)
-	got, err := (Runner{Mise: mise, nodeDigests: map[int]string{24: hex.EncodeToString(correctDigest[:])}}).resolveMiseNodePath(t.Context(), 24)
+	got, err := newJobRun(Runner{Mise: mise, nodeDigests: map[int]string{24: hex.EncodeToString(correctDigest[:])}}).resolveMiseNodePath(t.Context(), 24)
 	if err != nil || got != filepath.Join(nodeRoot, "bin", "node") {
 		t.Fatalf("resolveMiseNodePath() = %q, %v", got, err)
 	}
@@ -4735,12 +4735,12 @@ esac
 		t.Fatal(err)
 	}
 	verification := &managedNodeVerification{paths: make(map[int]string)}
-	runner := Runner{
-		Mise:             mise,
-		MiseDataDir:      dataDir,
-		nodeDigests:      map[int]string{24: hex.EncodeToString(digest[:])},
-		nodeVerification: verification,
-	}
+	runner := newJobRun(Runner{
+		Mise:        mise,
+		MiseDataDir: dataDir,
+		nodeDigests: map[int]string{24: hex.EncodeToString(digest[:])},
+	})
+	runner.nodeVerification = verification
 	if got, err := runner.discoverNode(t.Context(), 24, ""); err != nil || got != node {
 		t.Fatalf("discoverNode() = %q, %v", got, err)
 	}
@@ -4790,7 +4790,7 @@ func TestJavaScriptPhaseUsesVerifiedMiseNodeWithoutWorkflowRedirection(t *testin
 	node20 := filepath.Join(root, "node20")
 	writeNodeExecutable(t, node20, 20)
 	digest := sha256.Sum256(nodeBytes)
-	runner := Runner{Mise: mise, MiseDataDir: dataDir, Node20: node20, nodeDigests: map[int]string{24: hex.EncodeToString(digest[:])}}
+	runner := newJobRun(Runner{Mise: mise, MiseDataDir: dataDir, Node20: node20, nodeDigests: map[int]string{24: hex.EncodeToString(digest[:])}})
 	resolvedNode, err := runner.discoverNode(t.Context(), 24, "")
 	if err != nil {
 		t.Fatal(err)
@@ -4812,7 +4812,7 @@ func TestJavaScriptPhaseUsesVerifiedMiseNodeWithoutWorkflowRedirection(t *testin
 
 func TestMiseMissingIsClear(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
-	_, err := (Runner{}).discoverNode(t.Context(), 24, "")
+	_, err := newJobRun(Runner{}).discoverNode(t.Context(), 24, "")
 	if err == nil || !strings.Contains(err.Error(), "mise is required") {
 		t.Fatalf("discoverNode() error = %v", err)
 	}
@@ -4835,7 +4835,7 @@ func TestMiseNodeSelectionRejectsWrongExactVersion(t *testing.T) {
 		t.Fatal(err)
 	}
 	digest := sha256.Sum256(nodeBytes)
-	_, err := (Runner{Mise: mise, nodeDigests: map[int]string{24: hex.EncodeToString(digest[:])}}).discoverNode(t.Context(), 24, "")
+	_, err := newJobRun(Runner{Mise: mise, nodeDigests: map[int]string{24: hex.EncodeToString(digest[:])}}).discoverNode(t.Context(), 24, "")
 	if err == nil || !strings.Contains(err.Error(), `reported "v24.18.1", want "v24.18.0"`) {
 		t.Fatalf("discoverNode() error = %v", err)
 	}

--- a/internal/runtime/upload_artifact.go
+++ b/internal/runtime/upload_artifact.go
@@ -127,7 +127,7 @@ type archiveFile struct {
 	info       os.FileInfo
 }
 
-func (r Runner) runUploadArtifactCommit(ctx context.Context, processor *commandProcessor, workspace, commit string, inputs map[string]string) (result Result, returnErr error) {
+func (r *jobRun) runUploadArtifactCommit(ctx context.Context, processor *commandProcessor, workspace, commit string, inputs map[string]string) (result Result, returnErr error) {
 	result = newResult()
 	defer func() { returnErr = processor.scrubError(returnErr) }()
 	if err := ctx.Err(); err != nil {

--- a/internal/runtime/upload_artifact_test.go
+++ b/internal/runtime/upload_artifact_test.go
@@ -34,7 +34,7 @@ type captureArtifactUploader struct {
 	err     error
 }
 
-func (r Runner) runUploadArtifact(ctx context.Context, processor *commandProcessor, workspace string, inputs map[string]string) (Result, error) {
+func (r *jobRun) runUploadArtifact(ctx context.Context, processor *commandProcessor, workspace string, inputs map[string]string) (Result, error) {
 	return r.runUploadArtifactCommit(ctx, processor, workspace, actionintegration.UploadArtifactCommit, inputs)
 }
 
@@ -60,7 +60,7 @@ func TestUploadArtifactArchiveAndOutputs(t *testing.T) {
 	writeFixtureFile(t, workspace, "out/nested/result.txt", "nested")
 	writeFixtureFile(t, workspace, "out/.hidden", "secret")
 	uploader := &captureArtifactUploader{}
-	r := Runner{Artifacts: uploader, artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
+	r := newJobRun(Runner{Artifacts: uploader})
 	result, err := r.runUploadArtifact(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "out", "name": "logs", "compression-level": "0"})
 	if err != nil {
 		t.Fatal(err)
@@ -101,7 +101,7 @@ func TestUploadArtifactRuntimeVersionMatrix(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			uploader := &captureArtifactUploader{}
-			r := Runner{Artifacts: uploader, artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
+			r := newJobRun(Runner{Artifacts: uploader})
 			result, err := r.runUploadArtifactCommit(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, test.commit, test.inputs)
 			if err != nil || len(uploader.uploads) != 1 || len(result.Artifacts) != 1 || result.Outputs["artifact-id"] == "" || result.Outputs["artifact-digest"] == "" || result.Outputs["artifact-url"] != "" {
 				t.Fatalf("runtime matrix result = %#v, uploads = %d, error = %v", result, len(uploader.uploads), err)
@@ -116,7 +116,7 @@ func TestUploadArtifactRuntimeVersionMatrix(t *testing.T) {
 		})
 	}
 
-	r := Runner{Artifacts: &captureArtifactUploader{}, artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
+	r := newJobRun(Runner{Artifacts: &captureArtifactUploader{}})
 	if _, err := r.runUploadArtifactCommit(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, actionintegration.UploadArtifactCommit, map[string]string{"path": "payload", "archive": "true"}); err == nil || !strings.Contains(err.Error(), "only in actions/upload-artifact v7") {
 		t.Fatalf("runtime v4 archive mismatch error = %v", err)
 	}
@@ -129,7 +129,7 @@ func TestUploadArtifactBoundedGlobAndAdvisoryRetention(t *testing.T) {
 	writeFixtureFile(t, workspace, "tests/.hidden.log", "hidden")
 	var stdout bytes.Buffer
 	uploader := &captureArtifactUploader{}
-	r := Runner{Artifacts: uploader, artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
+	r := newJobRun(Runner{Artifacts: uploader})
 	result, err := r.runUploadArtifact(t.Context(), newCommandProcessor(&stdout, io.Discard), workspace, map[string]string{
 		"path": "tests/*.log", "retention-days": "7",
 	})
@@ -169,7 +169,7 @@ func TestUploadArtifactNormalizesFailurePathDirectories(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			uploader := &captureArtifactUploader{}
-			r := Runner{Artifacts: uploader, artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
+			r := newJobRun(Runner{Artifacts: uploader})
 			_, err := r.runUploadArtifactCommit(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, actionintegration.UploadArtifactV6Commit, map[string]string{
 				"name": test.name, "path": test.path,
 			})
@@ -184,7 +184,7 @@ func TestUploadArtifactNormalizesFailurePathDirectories(t *testing.T) {
 
 	writeFixtureFile(t, workspace, "report.txt", "not a directory")
 	uploader := &captureArtifactUploader{}
-	r := Runner{Artifacts: uploader, artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
+	r := newJobRun(Runner{Artifacts: uploader})
 	if _, err := r.runUploadArtifactCommit(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, actionintegration.UploadArtifactV6Commit, map[string]string{
 		"name": "directory-only", "path": "report.txt/", "if-no-files-found": "error",
 	}); err == nil || !strings.Contains(err.Error(), "No files were found") || len(uploader.uploads) != 0 {
@@ -237,7 +237,7 @@ func TestUploadArtifactCanIncludeHiddenFiles(t *testing.T) {
 	workspace := t.TempDir()
 	writeFixtureFile(t, workspace, "out/.hidden", "included")
 	uploader := &captureArtifactUploader{}
-	r := Runner{Artifacts: uploader, artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
+	r := newJobRun(Runner{Artifacts: uploader})
 	if _, err := r.runUploadArtifact(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "out", "include-hidden-files": "TRUE"}); err != nil {
 		t.Fatal(err)
 	}
@@ -309,7 +309,7 @@ func TestUploadArtifactArchiveRootUsesOnlyMatchedRoots(t *testing.T) {
 	workspace := t.TempDir()
 	writeFixtureFile(t, workspace, "out/result.txt", "matched")
 	uploader := &captureArtifactUploader{}
-	r := Runner{Artifacts: uploader, artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
+	r := newJobRun(Runner{Artifacts: uploader})
 	if _, err := r.runUploadArtifact(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "out\nmissing"}); err != nil {
 		t.Fatal(err)
 	}
@@ -323,10 +323,8 @@ func TestUploadArtifactDoesNotStageInContainerWritableRunnerTemp(t *testing.T) {
 	writeFixtureFile(t, workspace, "result.txt", "private staging")
 	sharedRunnerTemp := t.TempDir()
 	uploader := &captureArtifactUploader{}
-	r := Runner{
-		Artifacts: uploader, runnerTemp: sharedRunnerTemp,
-		artifactRegistry: &artifactRegistry{names: map[string]bool{}},
-	}
+	r := newJobRun(Runner{Artifacts: uploader})
+	r.runnerTemp = sharedRunnerTemp
 	if _, err := r.runUploadArtifact(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "result.txt"}); err != nil {
 		t.Fatal(err)
 	}
@@ -352,7 +350,7 @@ func TestUploadArtifactNoFilesModes(t *testing.T) {
 		t.Run(mode, func(t *testing.T) {
 			var stdout, stderr bytes.Buffer
 			processor := newCommandProcessor(&stdout, &stderr)
-			r := Runner{artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
+			r := newJobRun(Runner{})
 			result, err := r.runUploadArtifact(t.Context(), processor, t.TempDir(), map[string]string{"path": "missing", "if-no-files-found": mode})
 			if err != nil || len(result.Outputs) != 0 || len(result.Artifacts) != 0 || len(r.artifactRegistry.names) != 0 {
 				t.Fatalf("runUploadArtifact() result = %#v, registry = %#v, error = %v", result, r.artifactRegistry.names, err)
@@ -371,7 +369,7 @@ func TestUploadArtifactNoFilesModes(t *testing.T) {
 	}
 	var stdout bytes.Buffer
 	processor := newCommandProcessor(&stdout, io.Discard)
-	r := Runner{artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
+	r := newJobRun(Runner{})
 	if _, err := r.runUploadArtifact(t.Context(), processor, t.TempDir(), map[string]string{"path": "missing", "if-no-files-found": "error"}); err == nil || err.Error() != message {
 		t.Fatalf("if-no-files-found error = %v", err)
 	}
@@ -385,7 +383,7 @@ func TestUploadArtifactScrubsExpressionDerivedPathsFromErrors(t *testing.T) {
 	const maskedPath = "runtime-secret-path"
 	processor := newCommandProcessor(io.Discard, io.Discard)
 	processor.addMask(maskedPath)
-	r := Runner{artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
+	r := newJobRun(Runner{})
 	if _, err := r.runUploadArtifact(t.Context(), processor, t.TempDir(), map[string]string{
 		"path": maskedPath, "if-no-files-found": "error",
 	}); err == nil || strings.Contains(err.Error(), maskedPath) || !strings.Contains(err.Error(), "***") {
@@ -409,7 +407,7 @@ func TestUploadArtifactRejectsSymlinksMasksAndDuplicateNamesBeforeUpload(t *test
 		t.Fatal(err)
 	}
 	uploader := &captureArtifactUploader{}
-	r := Runner{Artifacts: uploader, artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
+	r := newJobRun(Runner{Artifacts: uploader})
 	processor := newCommandProcessor(io.Discard, io.Discard)
 	if _, err := r.runUploadArtifact(t.Context(), processor, workspace, map[string]string{"path": "link/file"}); err == nil || !strings.Contains(err.Error(), "symlink") {
 		t.Fatalf("symlink error = %v", err)
@@ -431,7 +429,7 @@ func TestUploadArtifactUploadFailureReleasesName(t *testing.T) {
 	workspace := t.TempDir()
 	writeFixtureFile(t, workspace, "file", "x")
 	uploader := &captureArtifactUploader{err: errors.New("upload failed")}
-	r := Runner{Artifacts: uploader, artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
+	r := newJobRun(Runner{Artifacts: uploader})
 	if _, err := r.runUploadArtifact(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "file"}); err == nil {
 		t.Fatal("upload failure was ignored")
 	}
@@ -465,7 +463,7 @@ func TestUploadArtifactCancellationStopsEveryArchiveStage(t *testing.T) {
 		t.Fatalf("verification cancellation = %v", err)
 	}
 	uploader := &captureArtifactUploader{}
-	r := Runner{Artifacts: uploader, artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
+	r := newJobRun(Runner{Artifacts: uploader})
 	if _, err := r.runUploadArtifact(ctx, newCommandProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "payload"}); !errors.Is(err, context.Canceled) || len(uploader.uploads) != 0 {
 		t.Fatalf("adapter cancellation = %v, uploads = %d", err, len(uploader.uploads))
 	}
@@ -581,7 +579,7 @@ func TestUploadArtifactCancellationStopsAgentUpload(t *testing.T) {
 	started := make(chan struct{})
 	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 	defer cancel()
-	r := Runner{Artifacts: cancellationArtifactUploader{started: started}, artifactRegistry: &artifactRegistry{names: map[string]bool{}}}
+	r := newJobRun(Runner{Artifacts: cancellationArtifactUploader{started: started}})
 	done := make(chan error, 1)
 	go func() {
 		_, err := r.runUploadArtifact(ctx, newCommandProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "payload"})


### PR DESCRIPTION
## Why

`Runner` mixed reusable runtime configuration with mutable state for one job, while `RunJob` encoded preparation, action lifecycle, step execution, cleanup, and result publication in one procedure. That made job ownership and runner reuse semantics implicit and increased the risk of lifecycle changes.

## What

- Keep `Runner.RunJob` as the public facade, but create one private `jobRun` for each invocation.
- Move mutable execution state and resources into that session, including evaluation state, containers, action preparations, post actions, background work, artifacts, warnings, and token service lifecycle.
- Decompose execution into preparation, pre-action, step, post-action, and finalization phases while preserving deferred cleanup ordering.
- Separate job results and action lifecycle/execution concerns within the existing `runtime` package, without new interfaces or subpackages.

## Verification

- `mise run check`
- `go test -race ./internal/runtime`

The main risk is lifecycle cleanup ordering. The preparation phase deliberately keeps its deferred resources alive through post actions and finalization, and the full and targeted race suites pass.