### PR TITLE
PB-3002: Ignore unsupported trigger events beside supported ones

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -26,7 +26,7 @@ Validate syntax, the static graph, and every declared trigger without an event:
 buildkite-gha validate .github/workflows/ci.yml
 ```
 
-This event-independent check accepts syntactically valid push and pull-request path filters because linked-webhook admission can evaluate them with a verified local git diff. It rejects malformed path filters, unsupported events, unsupported branch and tag filter combinations, and unsupported pull-request activity types. It does not resolve actions, evaluate event payload expressions, or claim hosted admission.
+This event-independent check accepts syntactically valid push and pull-request path filters because linked-webhook admission can evaluate them with a verified local git diff. It rejects malformed path filters, unsupported branch and tag filter combinations, unsupported pull-request activity types, and workflows whose only triggers are unsupported events. An unsupported event beside a supported trigger produces a `W_TRIGGER_EVENT_UNSUPPORTED` warning; see [Names and triggers](compatibility.md#names-and-triggers). It does not resolve actions, evaluate event payload expressions, or claim hosted admission.
 
 Resolve actions and apply production policy:
 
@@ -136,7 +136,7 @@ Reports cover workflow parsing, event validation, graph construction, matrix exp
 
 Report warnings and errors become job-scoped Buildkite annotations. `validate`, `compile`, and upload failures that abort the transaction attach them to the current job. Generated failure steps attach their diagnostics to themselves. CLI-side annotation failures produce a warning but do not change the command result.
 
-Profile validation applies the upload trigger policy before compilation. A `not-applicable` result means the workflow does not declare the selected event and would become a top-level skipped step during upload. Unsupported triggers and malformed data are incompatible.
+Profile validation applies the upload trigger policy before compilation. A `not-applicable` result means the workflow does not declare the selected event and would become a top-level skipped step during upload. Malformed event data is incompatible. An unsupported trigger beside a supported event is ignored with a warning.
 
 Validation may use the public network to resolve actions. Apart from annotation publication when it runs in a Buildkite job, it does not call Buildkite, install Node, or execute workflow code.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -127,6 +127,7 @@ An explicit event snapshot never consults contradictory live Buildkite event fie
 | `workflow_dispatch` | Selected for Buildkite UI and API builds. Webhook-style branch, tag, type, and workflow filters are unsupported. |
 | `schedule` | Selected for Buildkite scheduled builds. Buildkite owns cron configuration and does not expose which schedule started a build, so every `on.schedule` workflow is eligible for every Buildkite scheduled build. |
 | `workflow_call` | Defines a reusable-workflow interface. A reusable-only local file is available to callers but does not become a top-level group. |
+| Any other event | No Buildkite build source exists, so the trigger can never start a build. It is ignored with a `W_TRIGGER_EVENT_UNSUPPORTED` warning when the workflow also declares a supported event. A workflow declaring only unsupported events fails event-independent validation and is a skipped step in an uploaded pipeline. |
 
 Supported `pull_request` activity types are `assigned`, `unassigned`, `labeled`, `unlabeled`, `opened`, `edited`, `closed`, `reopened`, `synchronize`, `converted_to_draft`, `locked`, `unlocked`, `enqueued`, `dequeued`, `milestoned`, `demilestoned`, `ready_for_review`, `review_requested`, `review_request_removed`, `auto_merge_enabled`, and `auto_merge_disabled`.
 

--- a/internal/buildkite/triggers.go
+++ b/internal/buildkite/triggers.go
@@ -50,6 +50,40 @@ type TriggerEventSnapshot struct {
 	ChangedPaths          ChangedPathEvaluation
 }
 
+// supportedTriggerEvents is the single source of truth for GitHub trigger
+// events that map to a Buildkite build source.
+var supportedTriggerEvents = map[string]bool{
+	"workflow_call":     true,
+	"workflow_dispatch": true,
+	"schedule":          true,
+	"push":              true,
+	"pull_request":      true,
+	"merge_group":       true,
+	"release":           true,
+}
+
+// SupportedTriggerEvent reports whether the GitHub trigger event maps to a
+// Buildkite build source.
+func SupportedTriggerEvent(event string) bool {
+	return supportedTriggerEvents[event]
+}
+
+// UnsupportedTriggerEventError reports a trigger event with no Buildkite
+// build source. Such a trigger can never start a build, so it is ignored
+// when the workflow also declares a supported trigger.
+type UnsupportedTriggerEventError struct {
+	Event string
+}
+
+func (e *UnsupportedTriggerEventError) Error() string {
+	return fmt.Sprintf("unsupported GitHub trigger event %q", e.Event)
+}
+
+func unsupportedTriggerEvent(err error) bool {
+	var unsupported *UnsupportedTriggerEventError
+	return errors.As(err, &unsupported)
+}
+
 // UnsupportedPathFiltersError reports a trigger that cannot be translated
 // without changing its path-filter semantics.
 type UnsupportedPathFiltersError struct {
@@ -82,10 +116,17 @@ func LiveTriggerConditionExpressions(eventPredicate string) TriggerConditionExpr
 // TranslateTriggerCondition converts GitHub's trigger selection into a
 // deterministic Buildkite conditional. It deliberately does not approximate
 // path filtering: Buildkite if_changed has materially different semantics.
+// Unsupported trigger events contribute nothing unless no trigger has a
+// Buildkite build source at all.
 func TranslateTriggerCondition(triggers []workflow.Trigger) (string, error) {
 	var terms []string
+	var unsupported []error
 	for _, t := range triggers {
 		term, contributes, err := translateTrigger(t, liveTriggerExpressions(t.Event), TriggerEventSnapshot{}, true)
+		if unsupportedTriggerEvent(err) {
+			unsupported = append(unsupported, err)
+			continue
+		}
 		if err != nil {
 			return "", err
 		}
@@ -94,6 +135,9 @@ func TranslateTriggerCondition(triggers []workflow.Trigger) (string, error) {
 		}
 	}
 	if len(terms) == 0 {
+		if len(unsupported) > 0 {
+			return "", errors.Join(unsupported...)
+		}
 		return "", fmt.Errorf("workflow has no supported build source trigger")
 	}
 	return strings.Join(terms, " || "), nil
@@ -101,16 +145,31 @@ func TranslateTriggerCondition(triggers []workflow.Trigger) (string, error) {
 
 // ValidateTriggerConditions validates every trigger using the same translation
 // rules as pipeline generation without selecting an effective event.
+// Unsupported trigger events are reported only when the workflow declares no
+// supported trigger event at all; otherwise they are ignored because they can
+// never start a Buildkite build.
 func ValidateTriggerConditions(triggers []workflow.Trigger) error {
 	var findings []error
+	var unsupported []error
+	supportedEvent := false
 	for _, trigger := range triggers {
-		if _, _, err := translateTrigger(trigger, liveTriggerExpressions(trigger.Event), TriggerEventSnapshot{}, true); err != nil {
-			var pathFilters *UnsupportedPathFiltersError
-			if errors.As(err, &pathFilters) && (pathFilters.Event == "push" || pathFilters.Event == "pull_request") && pathFilters.Reason == "" {
-				continue
-			}
-			findings = append(findings, err)
+		_, _, err := translateTrigger(trigger, liveTriggerExpressions(trigger.Event), TriggerEventSnapshot{}, true)
+		if unsupportedTriggerEvent(err) {
+			unsupported = append(unsupported, err)
+			continue
 		}
+		supportedEvent = true
+		if err == nil {
+			continue
+		}
+		var pathFilters *UnsupportedPathFiltersError
+		if errors.As(err, &pathFilters) && (pathFilters.Event == "push" || pathFilters.Event == "pull_request") && pathFilters.Reason == "" {
+			continue
+		}
+		findings = append(findings, err)
+	}
+	if !supportedEvent {
+		findings = append(findings, unsupported...)
 	}
 	return errors.Join(findings...)
 }
@@ -129,6 +188,9 @@ func TranslateEventTriggerCondition(triggers []workflow.Trigger, event string, e
 			triggerSnapshot = snapshot
 		}
 		term, contributes, err := translateTrigger(trigger, triggerExpressions, triggerSnapshot, selected)
+		if !selected && unsupportedTriggerEvent(err) {
+			continue
+		}
 		if err != nil {
 			return "", false, err
 		}
@@ -278,6 +340,9 @@ func liveTriggerExpressions(event string) TriggerConditionExpressions {
 }
 
 func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpressions, snapshot TriggerEventSnapshot, selected bool) (string, bool, error) {
+	if !SupportedTriggerEvent(t.Event) {
+		return "", false, &UnsupportedTriggerEventError{Event: t.Event}
+	}
 	pathFilters := t.Paths != nil || t.PathsIgnore != nil
 	if pathFilters {
 		if t.Event != "push" && t.Event != "pull_request" {
@@ -483,7 +548,7 @@ func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpression
 		}
 		return expressions.EventPredicate + " && (" + strings.Join(actions, " || ") + ")", true, nil
 	default:
-		return "", false, fmt.Errorf("unsupported GitHub trigger event %q", t.Event)
+		return "", false, &UnsupportedTriggerEventError{Event: t.Event}
 	}
 }
 

--- a/internal/buildkite/triggers_test.go
+++ b/internal/buildkite/triggers_test.go
@@ -118,6 +118,75 @@ func TestTranslateTriggerConditionRequiresDirectBuildSource(t *testing.T) {
 	}
 }
 
+func TestTranslateTriggerConditionIgnoresUnsupportedEventsBesideSupportedOnes(t *testing.T) {
+	got, err := TranslateTriggerCondition([]workflow.Trigger{
+		{Event: "push"},
+		{Event: "issues", Types: []string{"opened"}},
+		{Event: "pull_request_target", Paths: []string{"src/**"}, Branches: []string{"main"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, `build.source_event == "push"`) || strings.Contains(got, "issues") || strings.Contains(got, "pull_request_target") {
+		t.Fatalf("condition = %q", got)
+	}
+}
+
+func TestValidateTriggerConditionsIgnoresUnsupportedEventsBesideSupportedOnes(t *testing.T) {
+	if err := ValidateTriggerConditions([]workflow.Trigger{
+		{Event: "push"},
+		{Event: "issues", Types: []string{"opened"}},
+		{Event: "pull_request_target", Paths: []string{"src/**"}},
+		{Event: "workflow_run"},
+	}); err != nil {
+		t.Fatalf("ValidateTriggerConditions() error = %v", err)
+	}
+	err := ValidateTriggerConditions([]workflow.Trigger{{Event: "issues"}, {Event: "issue_comment"}})
+	if err == nil || !strings.Contains(err.Error(), `unsupported GitHub trigger event "issues"`) || !strings.Contains(err.Error(), `unsupported GitHub trigger event "issue_comment"`) {
+		t.Fatalf("ValidateTriggerConditions() error = %v", err)
+	}
+}
+
+func TestTranslateEventTriggerConditionIgnoresUnsupportedEvents(t *testing.T) {
+	expressions := TriggerConditionExpressions{
+		EventPredicate: `build.source_event == "push"`,
+		Branch:         "build.branch",
+		Tag:            "build.tag",
+	}
+	condition, applicable, err := TranslateEventTriggerCondition([]workflow.Trigger{
+		{Event: "push"}, {Event: "issues"}, {Event: "pull_request_target", Paths: []string{"src/**"}},
+	}, "push", expressions, TriggerEventSnapshot{})
+	if err != nil || !applicable {
+		t.Fatalf("condition/applicable/error = %q / %t / %v", condition, applicable, err)
+	}
+	if !strings.Contains(condition, `build.source_event == "push"`) {
+		t.Fatalf("condition = %q", condition)
+	}
+	condition, applicable, err = TranslateEventTriggerCondition([]workflow.Trigger{
+		{Event: "issues"},
+	}, "push", expressions, TriggerEventSnapshot{})
+	if err != nil || applicable || condition != "" {
+		t.Fatalf("condition/applicable/error = %q / %t / %v", condition, applicable, err)
+	}
+}
+
+func TestSupportedTriggerEvent(t *testing.T) {
+	for event := range supportedTriggerEvents {
+		trigger := workflow.Trigger{Event: event}
+		if event == "release" {
+			trigger.Types = []string{"published"}
+		}
+		_, _, err := translateTrigger(trigger, liveTriggerExpressions(event), TriggerEventSnapshot{}, true)
+		if unsupportedTriggerEvent(err) {
+			t.Errorf("translateTrigger(%q) reports an unsupported event", event)
+		}
+	}
+	_, _, err := translateTrigger(workflow.Trigger{Event: "issues"}, liveTriggerExpressions("issues"), TriggerEventSnapshot{}, true)
+	if SupportedTriggerEvent("issues") || !unsupportedTriggerEvent(err) {
+		t.Errorf("issues must be an unsupported trigger event, error = %v", err)
+	}
+}
+
 func TestValidateTriggerConditionsAllowsReusableOnlyWorkflow(t *testing.T) {
 	if err := ValidateTriggerConditions([]workflow.Trigger{{Event: "workflow_call"}}); err != nil {
 		t.Fatalf("ValidateTriggerConditions(workflow_call) error = %v", err)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -76,7 +76,13 @@ func TestRunValidateAndCompile(t *testing.T) {
 				for _, stage := range report.Stages {
 					pipelineFailed = pipelineFailed || stage.ID == string(compiler.StagePipeline) && stage.Result == compatibility.Failed
 				}
-				if report.Result != "incompatible" || !pipelineFailed || len(report.Diagnostics) != 1 || report.Diagnostics[0].Stage != string(compiler.StagePipeline) || !strings.Contains(report.Diagnostics[0].Message+report.Diagnostics[0].Detail, test.want) {
+				var failures []compatibility.Diagnostic
+				for _, diagnostic := range report.Diagnostics {
+					if diagnostic.Level == "error" {
+						failures = append(failures, diagnostic)
+					}
+				}
+				if report.Result != "incompatible" || !pipelineFailed || len(failures) != 1 || failures[0].Stage != string(compiler.StagePipeline) || !strings.Contains(failures[0].Message+failures[0].Detail, test.want) {
 					t.Fatalf("report = %#v, want trigger failure containing %q", report, test.want)
 				}
 			})
@@ -366,22 +372,77 @@ func TestRunValidateAndCompile(t *testing.T) {
 		}
 	})
 
-	t.Run("validate hosted profile applies upload trigger policy", func(t *testing.T) {
+	t.Run("validate hosted profile skips a workflow with only unsupported trigger events", func(t *testing.T) {
 		workflow := filepath.Join(t.TempDir(), "issues.yml")
 		if err := os.WriteFile(workflow, []byte("on: issues\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
 			t.Fatal(err)
 		}
 		var stdout, stderr bytes.Buffer
 		args := []string{"validate", "--profile", "hosted", "--format", "json", "--event-path", eventPath, workflow}
-		if code := Run(args, &stdout, &stderr, "dev"); code != 1 {
-			t.Fatalf("Run() code = %d, want 1; stderr = %q", code, stderr.String())
+		if code := Run(args, &stdout, &stderr, "dev"); code != 0 {
+			t.Fatalf("Run() code = %d, stderr = %q", code, stderr.String())
 		}
 		var report compatibility.ProcessingReport
 		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 			t.Fatal(err)
 		}
-		if report.Result != "incompatible" || len(report.Diagnostics) != 1 || report.Diagnostics[0].Code != compiler.CodePipelineGeneration || !strings.Contains(report.Diagnostics[0].Message, `unsupported GitHub trigger event "issues"`) {
+		if report.Result != "not-applicable" || report.Compile.Result != compatibility.NotEvaluated || report.Admission.Result != compatibility.NotEvaluated {
 			t.Fatalf("profile trigger report = %#v", report)
+		}
+	})
+
+	t.Run("validate hosted profile ignores unsupported trigger events beside a supported one", func(t *testing.T) {
+		workflow := filepath.Join(t.TempDir(), "mixed.yml")
+		if err := os.WriteFile(workflow, []byte("on: [push, issues, pull_request_target]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		var stdout, stderr bytes.Buffer
+		args := []string{"validate", "--profile", "hosted", "--format", "json", "--event-path", eventPath, workflow}
+		if code := Run(args, &stdout, &stderr, "dev"); code != 0 {
+			t.Fatalf("Run() code = %d, stderr = %q", code, stderr.String())
+		}
+		var report compatibility.ProcessingReport
+		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+			t.Fatal(err)
+		}
+		if report.Result != "admitted" {
+			t.Fatalf("mixed trigger report = %#v", report)
+		}
+		warned := false
+		for _, diagnostic := range report.Diagnostics {
+			if diagnostic.Level == "error" {
+				t.Fatalf("unexpected error diagnostic %#v", diagnostic)
+			}
+			warned = warned || diagnostic.Code == "W_TRIGGER_EVENT_UNSUPPORTED"
+		}
+		if !warned {
+			t.Fatalf("mixed trigger report missing unsupported-trigger warning: %#v", report)
+		}
+	})
+
+	t.Run("validate hosted profile keeps unsupported-trigger warnings in a not-applicable report", func(t *testing.T) {
+		workflow := filepath.Join(t.TempDir(), "cross-event.yml")
+		if err := os.WriteFile(workflow, []byte("on: [pull_request, issues]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		var stdout, stderr bytes.Buffer
+		args := []string{"validate", "--profile", "hosted", "--format", "json", "--event-path", eventPath, workflow}
+		if code := Run(args, &stdout, &stderr, "dev"); code != 0 {
+			t.Fatalf("Run() code = %d, stderr = %q", code, stderr.String())
+		}
+		var report compatibility.ProcessingReport
+		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+			t.Fatal(err)
+		}
+		if report.Result != "not-applicable" {
+			t.Fatalf("cross-event report = %#v", report)
+		}
+		warned := false
+		for _, diagnostic := range report.Diagnostics {
+			warned = warned || diagnostic.Code == "W_TRIGGER_EVENT_UNSUPPORTED"
+		}
+		if !warned {
+			t.Fatalf("not-applicable report missing unsupported-trigger warning: %#v", report)
 		}
 	})
 

--- a/internal/cli/effective_event.go
+++ b/internal/cli/effective_event.go
@@ -187,6 +187,7 @@ func triggerProcessingReport(path string, source []byte) compatibility.Processin
 	report.LogicalJobs = parsed.LogicalJobs
 	report.SetStage(string(compiler.StageWorkflowParsing), compatibility.Passed)
 	report.SetStage(string(compiler.StageEventValidation), compatibility.Passed)
+	report.ApplyWarnings(path, parsed.Warnings)
 	for _, job := range parsed.ParsedJobs {
 		report.Jobs = append(report.Jobs, compatibility.JobResult{
 			ID: job.ID, Result: compatibility.NotEvaluated,

--- a/internal/cli/upload.go
+++ b/internal/cli/upload.go
@@ -356,6 +356,11 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 				SkipReason: input.SkipReason,
 			})
 			skippedWorkflows = append(skippedWorkflows, skippedWorkflow{label: label, key: groupKey, reason: input.AnnotationReason})
+			parsed, _ := compiler.ParseWorkflow(input.Path, input.Source)
+			writeCompilerWarnings(stderr, "upload", input.CanonicalPath, parsed.Warnings)
+			if uploadArguments.telemetry != nil {
+				uploadArguments.telemetry.addWarnings(parsed.Warnings)
+			}
 			continue
 		}
 		if processingReportHasErrors(processingReports[i]) {

--- a/internal/cli/upload_test.go
+++ b/internal/cli/upload_test.go
@@ -1364,6 +1364,28 @@ func TestRunUploadContinuesAfterWorkflowCompilationFailures(t *testing.T) {
 	}
 }
 
+func TestRunUploadWarnsAboutUnsupportedTriggersOnSkippedWorkflows(t *testing.T) {
+	requireImporterHost(t)
+	workflowPath := filepath.Join(t.TempDir(), "cross-event.yml")
+	if err := os.WriteFile(workflowPath, []byte("on: [pull_request, issues]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_BUILD_URL", "https://buildkite.com/acme/widgets/builds/42")
+	t.Setenv("BUILDKITE_JOB_ID", cliTestJobID)
+	t.Setenv("BUILDKITE_STEP_ID", cliTestBuildID)
+	t.Setenv("BUILDKITE_STEP_KEY", "skipped-warning-importer")
+	runner := &cliCaptureRunner{webhookErr: errors.New("metadata must not be read with --event-path")}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"upload", "--event-path", eventPath, workflowPath}, &stdout, &stderr, "dev", runner); code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "W_TRIGGER_EVENT_UNSUPPORTED") || !strings.Contains(stderr.String(), "on.issues") {
+		t.Fatalf("skipped workflow upload stderr missing unsupported-trigger warning: %q", stderr.String())
+	}
+}
+
 func TestRunUploadExplainsWhenNoWorkflowsApply(t *testing.T) {
 	requireImporterHost(t)
 	workflowPath := filepath.Join(t.TempDir(), "pull-request.yml")

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -347,6 +347,17 @@ func workflowTokenPolicyEvidence(path string, parsed *workflow.Workflow) (string
 
 func compilerWarnings(parsed *workflow.Workflow, cancelInProgress bool) []Warning {
 	var warnings []Warning
+	for _, trigger := range parsed.Triggers {
+		if buildkitepipeline.SupportedTriggerEvent(trigger.Event) {
+			continue
+		}
+		warnings = append(warnings, Warning{
+			Code:    "W_TRIGGER_EVENT_UNSUPPORTED",
+			Line:    trigger.Position.Line,
+			Column:  trigger.Position.Column,
+			Message: fmt.Sprintf("on.%s has no Buildkite build source; this trigger is ignored and never starts a build", trigger.Event),
+		})
+	}
 	if parsed.Concurrency != nil && cancelInProgress {
 		position := parsed.Concurrency.CancelInProgressPosition
 		warnings = append(warnings, Warning{

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -50,6 +50,7 @@ func (w Workflow) ReusableOnly() bool {
 // empty list), which is significant for GitHub's defaults.
 type Trigger struct {
 	Event          string           `json:"event"`
+	Position       Position         `json:"position"`
 	Types          []string         `json:"types,omitempty"`
 	Branches       []string         `json:"branches,omitempty"`
 	BranchesIgnore []string         `json:"branches_ignore,omitempty"`

--- a/internal/workflow/parse.go
+++ b/internal/workflow/parse.go
@@ -215,6 +215,24 @@ func Parse(path string, source []byte) (*Workflow, error) {
 	return owned, nil
 }
 
+func triggerPosition(event actionlint.Event) Position {
+	switch e := event.(type) {
+	case *actionlint.WebhookEvent:
+		return pointSpan(e.Pos).Start
+	case *actionlint.ScheduledEvent:
+		return pointSpan(e.Pos).Start
+	case *actionlint.WorkflowDispatchEvent:
+		return pointSpan(e.Pos).Start
+	case *actionlint.RepositoryDispatchEvent:
+		return pointSpan(e.Pos).Start
+	case *actionlint.WorkflowCallEvent:
+		return pointSpan(e.Pos).Start
+	case *actionlint.ImageVersionEvent:
+		return pointSpan(e.Pos).Start
+	}
+	return Position{}
+}
+
 func adaptTriggers(events []actionlint.Event) []Trigger {
 	out := make([]Trigger, 0, len(events))
 	values := func(f *actionlint.WebhookEventFilter) []string {
@@ -238,7 +256,7 @@ func adaptTriggers(events []actionlint.Event) []Trigger {
 		return out
 	}
 	for _, event := range events {
-		t := Trigger{Event: event.EventName()}
+		t := Trigger{Event: event.EventName(), Position: triggerPosition(event)}
 		switch e := event.(type) {
 		case *actionlint.WebhookEvent:
 			t.Types, t.Branches, t.BranchesIgnore = stringsOf(e.Types), values(e.Branches), values(e.BranchesIgnore)

--- a/internal/workflow/triggers_test.go
+++ b/internal/workflow/triggers_test.go
@@ -57,6 +57,21 @@ func TestParseRetainsTriggerConfiguration(t *testing.T) {
 	}
 }
 
+func TestParseRetainsImageVersionTriggerPosition(t *testing.T) {
+	source := []byte("on:\n  push:\n  image_version:\n    names: [ubuntu]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n")
+	w, err := Parse("workflow.yml", source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(w.Triggers) != 2 {
+		t.Fatalf("got %d triggers: %#v", len(w.Triggers), w.Triggers)
+	}
+	trigger := w.Triggers[1]
+	if trigger.Event != "image_version" || trigger.Position == (Position{}) {
+		t.Fatalf("image_version trigger position lost: %#v", trigger)
+	}
+}
+
 func TestWorkflowReusableOnly(t *testing.T) {
 	for _, test := range []struct {
 		name     string


### PR DESCRIPTION
## Why

The largest single compatibility blocker in the public workflow corpus: a workflow mixing supported and unsupported trigger events, such as `on: [push, issues]`, failed to compile because every declared trigger was validated regardless of which event fired. One `issues` or `pull_request_target` trigger broke CI for the `push` events we fully support.

Decision recorded in [PB-3002](https://linear.app/buildkite/issue/PB-3002): events like `issues`, `issue_comment`, `pull_request_target`, and `workflow_run` stay unsupported for now, but they must not break the build.

## What

An unsupported trigger event has no Buildkite build source and can never start a build, so translation now ignores it instead of failing:

- `TranslateEventTriggerCondition` skips unsupported non-selected triggers. A mixed workflow compiles for its supported events; a workflow declaring only unsupported events becomes not-applicable (a skipped step on upload) instead of a failing step.
- Event-independent validation (`ValidateTriggerConditions`) tolerates unsupported events when the workflow declares at least one supported trigger event, and still rejects a workflow with none.
- The compiler emits a source-located `W_TRIGGER_EVENT_UNSUPPORTED` warning for each ignored trigger, so users still learn that their issue automation will not run. Triggers now carry a parse position to locate the warning.
- `docs/compatibility.md` documents the behavior in the trigger event table.
