### PR TITLE
PB-2991: Clarify Windows runner diagnostics

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1508,6 +1508,18 @@ func TestProcessingAnnotationIsBoundedAndEscapesHTML(t *testing.T) {
 	}
 }
 
+func TestProcessingAnnotationPreservesLongerRepositoryURLs(t *testing.T) {
+	const docsURL = "https://github.com/buildkite/buildkite-gha/blob/main/docs/compatibility.md#cache-action"
+	diagnostic := compatibility.Diagnostic{
+		Level: "error", Code: "E_TEST", Message: "Unsupported action. Use a supported version from " + docsURL + ".",
+	}
+
+	body := renderProcessingDiagnostic(diagnostic, sourceLinkContext{})
+	if !strings.Contains(body, docsURL) || strings.Contains(body, `href="https://github.com/buildkite/buildkite-gha"`) {
+		t.Fatalf("annotation = %q, want intact documentation URL", body)
+	}
+}
+
 func TestProcessingAnnotationOmitsUnknownActionRuntime(t *testing.T) {
 	report := compatibility.NewProcessingReport("ci.yml", "")
 	report.Diagnostics = append(report.Diagnostics, compatibility.Diagnostic{

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -399,7 +399,10 @@ func renderProcessingDiagnostic(diagnostic compatibility.Diagnostic, sourceLinks
 	if len(details) != 0 {
 		for _, sentence := range details {
 			out.WriteString("<p>")
-			out.WriteString(annotationHTML(sentence))
+			detail := annotationHTML(sentence)
+			const issueURL = "https://github.com/buildkite/buildkite-gha"
+			detail = strings.ReplaceAll(detail, issueURL, `<a href="`+issueURL+`" target="_blank">github.com/buildkite/buildkite-gha</a>`)
+			out.WriteString(detail)
 			out.WriteString("</p>\n")
 		}
 	}

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -401,7 +401,7 @@ func renderProcessingDiagnostic(diagnostic compatibility.Diagnostic, sourceLinks
 			out.WriteString("<p>")
 			detail := annotationHTML(sentence)
 			const issueURL = "https://github.com/buildkite/buildkite-gha"
-			detail = strings.ReplaceAll(detail, issueURL, `<a href="`+issueURL+`" target="_blank">buildkite/buildkite-gha</a>`)
+			detail = strings.ReplaceAll(detail, issueURL+" ", `<a href="`+issueURL+`" target="_blank">buildkite/buildkite-gha</a> `)
 			out.WriteString(detail)
 			out.WriteString("</p>\n")
 		}

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -401,7 +401,7 @@ func renderProcessingDiagnostic(diagnostic compatibility.Diagnostic, sourceLinks
 			out.WriteString("<p>")
 			detail := annotationHTML(sentence)
 			const issueURL = "https://github.com/buildkite/buildkite-gha"
-			detail = strings.ReplaceAll(detail, issueURL, `<a href="`+issueURL+`" target="_blank">github.com/buildkite/buildkite-gha</a>`)
+			detail = strings.ReplaceAll(detail, issueURL, `<a href="`+issueURL+`" target="_blank">buildkite/buildkite-gha</a>`)
 			out.WriteString(detail)
 			out.WriteString("</p>\n")
 		}

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -400,6 +400,8 @@ func renderProcessingDiagnostic(diagnostic compatibility.Diagnostic, sourceLinks
 		for _, sentence := range details {
 			out.WriteString("<p>")
 			detail := annotationHTML(sentence)
+			detail = strings.ReplaceAll(detail, "&#34;windows-latest&#34;", annotationCode("windows-latest"))
+			detail = strings.ReplaceAll(detail, "&#34;ubuntu-latest&#34;", annotationCode("ubuntu-latest"))
 			const issueURL = "https://github.com/buildkite/buildkite-gha"
 			detail = strings.ReplaceAll(detail, issueURL+" ", `<a href="`+issueURL+`" target="_blank">buildkite/buildkite-gha</a> `)
 			out.WriteString(detail)

--- a/internal/cli/upload_test.go
+++ b/internal/cli/upload_test.go
@@ -1350,7 +1350,7 @@ func TestRunUploadContinuesAfterWorkflowCompilationFailures(t *testing.T) {
 		}
 	}
 	firstFailureMessage := string(failureArtifactForStep(pipeline.Steps[0].Plugins, runner.uploaded, "messages"))
-	if !strings.Contains(firstFailureMessage, `Windows runners in GitHub workflows aren't currently supported. Imported jobs run on Linux or macOS Buildkite hosted agents. If this job can run on Linux, change "windows-latest" to "ubuntu-latest". If it requires Windows, open an issue in https://github.com/buildkite/buildkite-gha to help us prioritize Windows support.`) ||
+	if !strings.Contains(firstFailureMessage, `Windows runners aren't currently supported. Imported jobs run on Linux or macOS Buildkite hosted agents. If this job can run on Linux, change "windows-latest" to "ubuntu-latest". If it requires Windows, open an issue in https://github.com/buildkite/buildkite-gha to help us prioritize Windows support.`) ||
 		!strings.Contains(firstFailureMessage, `Runner label "macos-15" has no runner-target mapping. Configure a mapping for this label or use a mapped runner label.`) ||
 		strings.Count(firstFailureMessage, "detail: Supported runner labels: macos-latest, ubuntu-22.04, ubuntu-24.04, ubuntu-latest.") != 1 {
 		t.Fatalf("multi-diagnostic failure message = %q", firstFailureMessage)

--- a/internal/cli/upload_test.go
+++ b/internal/cli/upload_test.go
@@ -1350,9 +1350,9 @@ func TestRunUploadContinuesAfterWorkflowCompilationFailures(t *testing.T) {
 		}
 	}
 	firstFailureMessage := string(failureArtifactForStep(pipeline.Steps[0].Plugins, runner.uploaded, "messages"))
-	if !strings.Contains(firstFailureMessage, `Runner label "windows-latest" requires Windows, which is unsupported. Use a Linux or macOS runner label.`) ||
+	if !strings.Contains(firstFailureMessage, `Windows runners aren't supported yet. Buildkite hosted agents run Linux and macOS only, so this job can't be imported to one. If the job can run on Linux, change "windows-latest" to "ubuntu-latest". If it needs Windows, log an issue on https://github.com/buildkite/buildkite-gha so we can prioritise it.`) ||
 		!strings.Contains(firstFailureMessage, `Runner label "macos-15" has no runner-target mapping. Configure a mapping for this label or use a mapped runner label.`) ||
-		strings.Count(firstFailureMessage, "detail: Supported runner labels: macos-latest, ubuntu-22.04, ubuntu-24.04, ubuntu-latest.") != 2 {
+		strings.Count(firstFailureMessage, "detail: Supported runner labels: macos-latest, ubuntu-22.04, ubuntu-24.04, ubuntu-latest.") != 1 {
 		t.Fatalf("multi-diagnostic failure message = %q", firstFailureMessage)
 	}
 	actionFailureAnnotation := string(failureArtifactForStep(pipeline.Steps[1].Plugins, runner.uploaded, "annotations"))

--- a/internal/cli/upload_test.go
+++ b/internal/cli/upload_test.go
@@ -1350,7 +1350,7 @@ func TestRunUploadContinuesAfterWorkflowCompilationFailures(t *testing.T) {
 		}
 	}
 	firstFailureMessage := string(failureArtifactForStep(pipeline.Steps[0].Plugins, runner.uploaded, "messages"))
-	if !strings.Contains(firstFailureMessage, `Windows runners aren't supported yet. Buildkite hosted agents run Linux and macOS only, so this job can't be imported to one. If the job can run on Linux, change "windows-latest" to "ubuntu-latest". If it needs Windows, log an issue on https://github.com/buildkite/buildkite-gha so we can prioritise it.`) ||
+	if !strings.Contains(firstFailureMessage, `Windows runners in GitHub workflows aren't currently supported. Imported jobs run on Linux or macOS Buildkite hosted agents. If this job can run on Linux, change "windows-latest" to "ubuntu-latest". If it requires Windows, open an issue in https://github.com/buildkite/buildkite-gha to help us prioritize Windows support.`) ||
 		!strings.Contains(firstFailureMessage, `Runner label "macos-15" has no runner-target mapping. Configure a mapping for this label or use a mapped runner label.`) ||
 		strings.Count(firstFailureMessage, "detail: Supported runner labels: macos-latest, ubuntu-22.04, ubuntu-24.04, ubuntu-latest.") != 1 {
 		t.Fatalf("multi-diagnostic failure message = %q", firstFailureMessage)

--- a/internal/cli/validate_test.go
+++ b/internal/cli/validate_test.go
@@ -86,7 +86,7 @@ func TestValidatePublishesProcessingDiagnosticsInBuildkite(t *testing.T) {
 			`<h2 class="h4 mb2">Workflow could not be run</h2>`,
 			`<p><strong>Windows runners in GitHub workflows aren&#39;t currently supported.</strong></p>`,
 			`Imported jobs run on Linux or macOS Buildkite hosted agents.`,
-			`If this job can run on Linux, change &#34;windows-latest&#34; to &#34;ubuntu-latest&#34;.`,
+			`If this job can run on Linux, change <code>windows-latest</code> to <code>ubuntu-latest</code>.`,
 			`If it requires Windows, open an issue in <a href="https://github.com/buildkite/buildkite-gha" target="_blank">buildkite/buildkite-gha</a> to help us prioritize Windows support.`,
 			"Job <code>test</code>",
 		} {

--- a/internal/cli/validate_test.go
+++ b/internal/cli/validate_test.go
@@ -84,10 +84,10 @@ func TestValidatePublishesProcessingDiagnosticsInBuildkite(t *testing.T) {
 		}
 		for _, want := range []string{
 			`<h2 class="h4 mb2">Workflow could not be run</h2>`,
-			`<p><strong>Windows runners aren&#39;t supported yet.</strong></p>`,
-			`Buildkite hosted agents run Linux and macOS only, so this job can&#39;t be imported to one.`,
-			`If the job can run on Linux, change &#34;windows-latest&#34; to &#34;ubuntu-latest&#34;.`,
-			`If it needs Windows, log an issue on <a href="https://github.com/buildkite/buildkite-gha" target="_blank">github.com/buildkite/buildkite-gha</a> so we can prioritise it.`,
+			`<p><strong>Windows runners in GitHub workflows aren&#39;t currently supported.</strong></p>`,
+			`Imported jobs run on Linux or macOS Buildkite hosted agents.`,
+			`If this job can run on Linux, change &#34;windows-latest&#34; to &#34;ubuntu-latest&#34;.`,
+			`If it requires Windows, open an issue in <a href="https://github.com/buildkite/buildkite-gha" target="_blank">buildkite/buildkite-gha</a> to help us prioritize Windows support.`,
 			"Job <code>test</code>",
 		} {
 			if !strings.Contains(string(annotation.stdin), want) {

--- a/internal/cli/validate_test.go
+++ b/internal/cli/validate_test.go
@@ -84,7 +84,7 @@ func TestValidatePublishesProcessingDiagnosticsInBuildkite(t *testing.T) {
 		}
 		for _, want := range []string{
 			`<h2 class="h4 mb2">Workflow could not be run</h2>`,
-			`<p><strong>Windows runners in GitHub workflows aren&#39;t currently supported.</strong></p>`,
+			`<p><strong>Windows runners aren&#39;t currently supported.</strong></p>`,
 			`Imported jobs run on Linux or macOS Buildkite hosted agents.`,
 			`If this job can run on Linux, change <code>windows-latest</code> to <code>ubuntu-latest</code>.`,
 			`If it requires Windows, open an issue in <a href="https://github.com/buildkite/buildkite-gha" target="_blank">buildkite/buildkite-gha</a> to help us prioritize Windows support.`,

--- a/internal/cli/validate_test.go
+++ b/internal/cli/validate_test.go
@@ -84,16 +84,17 @@ func TestValidatePublishesProcessingDiagnosticsInBuildkite(t *testing.T) {
 		}
 		for _, want := range []string{
 			`<h2 class="h4 mb2">Workflow could not be run</h2>`,
-			`<p><strong>Runner label &#34;windows-latest&#34; requires Windows, which is unsupported.`,
-			`<summary>Diagnostic detail</summary>`,
-			`Supported runner labels: ubuntu-22.04, ubuntu-24.04, ubuntu-latest.`,
+			`<p><strong>Windows runners aren&#39;t supported yet.</strong></p>`,
+			`Buildkite hosted agents run Linux and macOS only, so this job can&#39;t be imported to one.`,
+			`If the job can run on Linux, change &#34;windows-latest&#34; to &#34;ubuntu-latest&#34;.`,
+			`If it needs Windows, log an issue on <a href="https://github.com/buildkite/buildkite-gha" target="_blank">github.com/buildkite/buildkite-gha</a> so we can prioritise it.`,
 			"Job <code>test</code>",
 		} {
 			if !strings.Contains(string(annotation.stdin), want) {
 				t.Fatalf("annotation = %q, want %q", annotation.stdin, want)
 			}
 		}
-		for _, unwanted := range []string{"E_EXPRESSION_INVALID", "stage:", "instance:", "gha-test"} {
+		for _, unwanted := range []string{"E_EXPRESSION_INVALID", "stage:", "instance:", "gha-test", "Diagnostic detail", "Supported runner labels:"} {
 			if strings.Contains(string(annotation.stdin), unwanted) {
 				t.Fatalf("annotation = %q, does not want %q", annotation.stdin, unwanted)
 			}

--- a/internal/compiler/config.go
+++ b/internal/compiler/config.go
@@ -363,7 +363,11 @@ func runnerRejectionDiagnostic(err error, labels, supported, untrustedQueues []s
 	case reasonDuplicateLabel:
 		return "runs-on contains a duplicate runner label. Remove duplicate labels from runs-on.", ""
 	case reasonUnsupportedOS:
-		return fmt.Sprintf("Runner label%s requires Windows, which is unsupported. Use a Linux or macOS runner label.", label), detail
+		linuxGuidance := `If the job can run on Linux, change runs-on to "ubuntu-latest".`
+		if label != "" {
+			linuxGuidance = fmt.Sprintf(`If the job can run on Linux, change%s to "ubuntu-latest".`, label)
+		}
+		return "Windows runners aren't supported yet. Buildkite hosted agents run Linux and macOS only, so this job can't be imported to one. " + linuxGuidance + " If it needs Windows, log an issue on https://github.com/buildkite/buildkite-gha so we can prioritise it.", ""
 	case reasonUnmappedLabel:
 		return fmt.Sprintf("Runner label%s has no runner-target mapping. Configure a mapping for this label or use a mapped runner label.", label), detail
 	case reasonConflictingQueues, reasonConflictingTarget:

--- a/internal/compiler/config.go
+++ b/internal/compiler/config.go
@@ -363,11 +363,11 @@ func runnerRejectionDiagnostic(err error, labels, supported, untrustedQueues []s
 	case reasonDuplicateLabel:
 		return "runs-on contains a duplicate runner label. Remove duplicate labels from runs-on.", ""
 	case reasonUnsupportedOS:
-		linuxGuidance := `If the job can run on Linux, change runs-on to "ubuntu-latest".`
+		linuxGuidance := `If this job can run on Linux, change runs-on to "ubuntu-latest".`
 		if label != "" {
-			linuxGuidance = fmt.Sprintf(`If the job can run on Linux, change%s to "ubuntu-latest".`, label)
+			linuxGuidance = fmt.Sprintf(`If this job can run on Linux, change%s to "ubuntu-latest".`, label)
 		}
-		return "Windows runners aren't supported yet. Buildkite hosted agents run Linux and macOS only, so this job can't be imported to one. " + linuxGuidance + " If it needs Windows, log an issue on https://github.com/buildkite/buildkite-gha so we can prioritise it.", ""
+		return "Windows runners in GitHub workflows aren't currently supported. Imported jobs run on Linux or macOS Buildkite hosted agents. " + linuxGuidance + " If it requires Windows, open an issue in https://github.com/buildkite/buildkite-gha to help us prioritize Windows support.", ""
 	case reasonUnmappedLabel:
 		return fmt.Sprintf("Runner label%s has no runner-target mapping. Configure a mapping for this label or use a mapped runner label.", label), detail
 	case reasonConflictingQueues, reasonConflictingTarget:

--- a/internal/compiler/config.go
+++ b/internal/compiler/config.go
@@ -367,7 +367,7 @@ func runnerRejectionDiagnostic(err error, labels, supported, untrustedQueues []s
 		if label != "" {
 			linuxGuidance = fmt.Sprintf(`If this job can run on Linux, change%s to "ubuntu-latest".`, label)
 		}
-		return "Windows runners in GitHub workflows aren't currently supported. Imported jobs run on Linux or macOS Buildkite hosted agents. " + linuxGuidance + " If it requires Windows, open an issue in https://github.com/buildkite/buildkite-gha to help us prioritize Windows support.", ""
+		return "Windows runners aren't currently supported. Imported jobs run on Linux or macOS Buildkite hosted agents. " + linuxGuidance + " If it requires Windows, open an issue in https://github.com/buildkite/buildkite-gha to help us prioritize Windows support.", ""
 	case reasonUnmappedLabel:
 		return fmt.Sprintf("Runner label%s has no runner-target mapping. Configure a mapping for this label or use a mapped runner label.", label), detail
 	case reasonConflictingQueues, reasonConflictingTarget:

--- a/internal/compiler/config_test.go
+++ b/internal/compiler/config_test.go
@@ -305,7 +305,7 @@ func TestRunnerRejectionDiagnosticSeparatesStaticLabelFromAllowlist(t *testing.T
 	}{
 		{
 			label:       "windows-latest",
-			wantMessage: `Windows runners aren't supported yet. Buildkite hosted agents run Linux and macOS only, so this job can't be imported to one. If the job can run on Linux, change "windows-latest" to "ubuntu-latest". If it needs Windows, log an issue on https://github.com/buildkite/buildkite-gha so we can prioritise it.`,
+			wantMessage: `Windows runners in GitHub workflows aren't currently supported. Imported jobs run on Linux or macOS Buildkite hosted agents. If this job can run on Linux, change "windows-latest" to "ubuntu-latest". If it requires Windows, open an issue in https://github.com/buildkite/buildkite-gha to help us prioritize Windows support.`,
 		},
 		{
 			label:       "macos-latest",

--- a/internal/compiler/config_test.go
+++ b/internal/compiler/config_test.go
@@ -256,7 +256,7 @@ func TestRunnerRejectionDiagnosticIsActionableWithoutResolvedLabel(t *testing.T)
 	}{
 		{name: "no labels", trust: EventTrusted, want: "Set runs-on"},
 		{name: "duplicate label", labels: []string{"ubuntu-24.04", "ubuntu-24.04"}, trust: EventTrusted, want: "Remove duplicate labels"},
-		{name: "unsupported operating system", labels: []string{"windows-latest"}, trust: EventTrusted, want: "Use a Linux or macOS runner label"},
+		{name: "unsupported operating system", labels: []string{"windows-latest"}, trust: EventTrusted, want: `change runs-on to "ubuntu-latest"`},
 		{name: "unmapped label", labels: []string{"macos-15"}, trust: EventTrusted, want: "Configure a mapping"},
 		{name: "conflicting queues", labels: []string{"self-hosted", "linux"}, trust: EventTrusted, want: "Use labels that map to one runner target"},
 		{name: "conflicting targets", labels: []string{"ubuntu-24.04", "macos"}, trust: EventTrusted, want: "Use labels that map to one runner target"},
@@ -301,14 +301,16 @@ func TestRunnerRejectionDiagnosticSeparatesStaticLabelFromAllowlist(t *testing.T
 	tests := []struct {
 		label       string
 		wantMessage string
+		wantDetail  string
 	}{
 		{
 			label:       "windows-latest",
-			wantMessage: `Runner label "windows-latest" requires Windows, which is unsupported. Use a Linux or macOS runner label.`,
+			wantMessage: `Windows runners aren't supported yet. Buildkite hosted agents run Linux and macOS only, so this job can't be imported to one. If the job can run on Linux, change "windows-latest" to "ubuntu-latest". If it needs Windows, log an issue on https://github.com/buildkite/buildkite-gha so we can prioritise it.`,
 		},
 		{
 			label:       "macos-latest",
 			wantMessage: `Runner label "macos-latest" has no runner-target mapping. Configure a mapping for this label or use a mapped runner label.`,
+			wantDetail:  "Supported runner labels: ubuntu-22.04, ubuntu-24.04, ubuntu-latest.",
 		},
 	}
 	policy := RunnerPolicy{Targets: map[string]RunnerTarget{
@@ -322,7 +324,7 @@ func TestRunnerRejectionDiagnosticSeparatesStaticLabelFromAllowlist(t *testing.T
 			t.Fatalf("resolve(%q) error = nil", test.label)
 		}
 		message, detail := runnerRejectionDiagnostic(err, []string{test.label}, supported, nil)
-		if message != test.wantMessage || detail != "Supported runner labels: ubuntu-22.04, ubuntu-24.04, ubuntu-latest." {
+		if message != test.wantMessage || detail != test.wantDetail {
 			t.Fatalf("runnerRejectionDiagnostic(%q) = %q, %q", test.label, message, detail)
 		}
 		if strings.Contains(message, "ubuntu-22.04") {

--- a/internal/compiler/config_test.go
+++ b/internal/compiler/config_test.go
@@ -305,7 +305,7 @@ func TestRunnerRejectionDiagnosticSeparatesStaticLabelFromAllowlist(t *testing.T
 	}{
 		{
 			label:       "windows-latest",
-			wantMessage: `Windows runners in GitHub workflows aren't currently supported. Imported jobs run on Linux or macOS Buildkite hosted agents. If this job can run on Linux, change "windows-latest" to "ubuntu-latest". If it requires Windows, open an issue in https://github.com/buildkite/buildkite-gha to help us prioritize Windows support.`,
+			wantMessage: `Windows runners aren't currently supported. Imported jobs run on Linux or macOS Buildkite hosted agents. If this job can run on Linux, change "windows-latest" to "ubuntu-latest". If it requires Windows, open an issue in https://github.com/buildkite/buildkite-gha to help us prioritize Windows support.`,
 		},
 		{
 			label:       "macos-latest",


### PR DESCRIPTION
## Why

Windows runner annotations read like a Buildkite-wide limitation and only suggest switching operating systems, which does not help jobs that require Windows. 

Closes [PB-2991](https://linear.app/buildkite/issue/PB-2991/bugfix-windows-runner-annotation-reads-like-a-buildkite-wide).

**Before**

<img width="1554" height="482" alt="CleanShot 2026-08-20 at 11 47 59@2x" src="https://github.com/user-attachments/assets/5893d34e-f83f-4bd8-b10e-dd74996382c1" />

**After**

<img width="1804" height="500" alt="CleanShot 2026-08-20 at 12 39 25@2x" src="https://github.com/user-attachments/assets/0579bd62-1152-4188-b9af-3eaa98450a1d" />


## What

Scope the limitation to Buildkite hosted agents, suggest `ubuntu-latest` when Linux is viable, and link to this repository for Windows support requests. The annotation link opens in a new tab.