### PR TITLE
Reduce event expressions before plan serialization

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -589,6 +589,8 @@ Reusable-workflow call conditions use the same operators and status functions bu
 
 Workflow step `run`, `env`, `with`, `name`, explicit `shell`, explicit `working-directory`, `continue-on-error`, and `timeout-minutes` fields support the operators and pure functions listed above. They also support computed indexes and projections over available `matrix`, `vars`, `inputs`, `env`, and `runner` values. Computed, whole, and projected `steps` and `needs` access remains unsupported, so attempting to access an unavailable background output returns an error.
 
+In these fields and the job-level fields below, the compiler resolves scalar `github.event.*` values from the immutable event snapshot before creating a job plan. It also resolves event-dependent subtrees inside expressions that retain supported runtime values. Missing event members render as null, and template interpolation renders null as an empty string. Event values cannot introduce new `${{ ... }}` regions. Whole-event access and any residual event reference are unsupported because job plans retain only event identity and a payload digest.
+
 Job-level expressions support the same operators and pure functions with these field-specific contexts:
 
 | Field | Contexts |
@@ -627,7 +629,7 @@ Patterns cannot be absolute, contain a `..` path segment, or contain ASCII contr
 
 ### Compile-time expressions
 
-Matrices, runner labels, names, concurrency groups, and event-backed conditions may use statically known `github`, `event`, `vars`, and matrix values. Compile-time `github` values include `github.actor`, `github.base_ref`, `github.event_name`, `github.head_ref`, `github.ref`, `github.ref_name`, `github.ref_type`, `github.repository`, `github.repository_owner`, `github.sha`, and `github.workflow`. They support the compile-time syntax listed above, computed indexes, numeric array indexes, and `.*` projections where the complete expression resolves during compilation. Whole or dynamic `github` access and whole-event serialization remain unsupported. Event-backed conditions may also combine reducible event subtrees with supported runtime condition values such as `needs` and status functions.
+Matrices, runner labels, names, concurrency groups, plan-retained runtime templates, and event-backed conditions may use statically known `github`, `event`, `vars`, and matrix values. Compile-time `github` values include `github.actor`, `github.base_ref`, `github.event_name`, `github.head_ref`, `github.ref`, `github.ref_name`, `github.ref_type`, `github.repository`, `github.repository_owner`, `github.sha`, and `github.workflow`. They support the compile-time syntax listed above, computed indexes, numeric array indexes, and `.*` projections where the complete expression resolves during compilation. Whole or dynamic `github` access and whole-event serialization remain unsupported. Event-backed conditions and runtime templates may also combine reducible event subtrees with values supported by their runtime surface.
 
 ## Actions
 

--- a/internal/compiler/bundle.go
+++ b/internal/compiler/bundle.go
@@ -79,6 +79,10 @@ func CompileBundlePlansContext(ctx context.Context, path string, source, eventSo
 	if err != nil {
 		return Bundle{IR: ir}, err
 	}
+	ir, err = reducePlanEventExpressions(ir)
+	if err != nil {
+		return Bundle{IR: ir}, err
+	}
 	options.ActionSource = newMemoizedActionSource(options.ActionSource)
 	evidence, err := validateActionResolutions(ctx, ir, options)
 	bundle := Bundle{IR: ir, Processing: evidence}

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1342,17 +1343,132 @@ jobs:
 	}
 }
 
-func TestCompileBundleRejectsRetainedGitHubEventPayload(t *testing.T) {
+func TestCompileBundleReducesRetainedGitHubEventPayload(t *testing.T) {
+	repository := t.TempDir()
+	path := writeWorkflow(t, repository, "event.yml", `on: pull_request
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      JOB_SHA: ${{ github.event.pull_request.head.sha }}
+    defaults:
+      run:
+        shell: ${{ github.event.shell }}
+        working-directory: ${{ github.event.directory }}
+    steps:
+      - name: Head ${{ github.event.pull_request.head.sha }}
+        run: echo '${{ github.event.pull_request.head.sha }}' '${{ github.event.missing }}' '${{ github.event.action }}' '${{ github.event.pull_request.head.sha == steps.previous.outputs.sha }}'
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        shell: ${{ github.event.shell }}
+        working-directory: ${{ github.event.directory }}
+      - uses: ./event-action
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+`)
+	writeAction(t, repository, "event-action", `name: event action
+inputs:
+  ref:
+    required: true
+runs:
+  using: node24
+  main: index.js
+`)
+	event := []byte(`{
+  "provider": "github",
+  "event": "pull_request",
+  "repository": {"owner": "buildkite", "name": "buildkite-gha", "clone_url": "https://github.com/buildkite/buildkite-gha.git", "default_branch": "main"},
+  "ref": "refs/pull/42/merge",
+  "sha": "1111111111111111111111111111111111111111",
+  "actor": "octocat",
+  "payload": {"action": "opened", "shell": "bash", "directory": ".", "pull_request": {"head": {"sha": "2222222222222222222222222222222222222222"}}}
+}`)
+	bundle, err := CompileBundle(path, readFile(t, path), event, "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	job := bundle.Plans[0].Job
+	if job.Env["JOB_SHA"] != "2222222222222222222222222222222222222222" || job.DefaultShell != "bash" || job.DefaultWorkingDirectory != "." {
+		t.Fatalf("job templates were not reduced: env = %#v, shell = %q, working-directory = %q", job.Env, job.DefaultShell, job.DefaultWorkingDirectory)
+	}
+	step := job.Steps[0]
+	if step.Name != "Head 2222222222222222222222222222222222222222" || step.Env["HEAD_SHA"] != "2222222222222222222222222222222222222222" || step.Shell != "bash" || step.WorkingDirectory != "." {
+		t.Fatalf("step templates were not reduced: %#v", step)
+	}
+	if want := "echo '2222222222222222222222222222222222222222' '' 'opened' '${{ ('2222222222222222222222222222222222222222' == steps.previous.outputs.sha) }}'"; step.Command != want {
+		t.Fatalf("command = %q, want %q", step.Command, want)
+	}
+	if got := job.Steps[1].With["ref"]; got != "2222222222222222222222222222222222222222" {
+		t.Fatalf("action input = %q", got)
+	}
+}
+
+func TestCompileBundleRejectsEventValueExpressionInjection(t *testing.T) {
 	source := []byte(`on: push
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - run: echo '${{ github.event.action }}'
+      - run: echo '${{ github.event.value }}'
 `)
-	_, err := CompileBundle("workflow.yml", source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-importer")
-	if err == nil || !strings.Contains(err.Error(), "github.event cannot be retained in a job plan") {
-		t.Fatalf("CompileBundle() error = %v, want retained event rejection", err)
+	event := []byte(`{
+  "provider": "github", "event": "push",
+  "repository": {"owner": "buildkite", "name": "buildkite-gha", "clone_url": "https://github.com/buildkite/buildkite-gha.git", "default_branch": "main"},
+  "ref": "refs/heads/main", "sha": "1111111111111111111111111111111111111111", "actor": "octocat",
+  "payload": {"value": "${{ secrets.ADMIN }}"}
+}`)
+	_, err := CompileBundle("workflow.yml", source, event, "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err == nil || !strings.Contains(err.Error(), "result contains expression syntax") {
+		t.Fatalf("CompileBundle() error = %v, want expression injection rejection", err)
+	}
+}
+
+func TestCompileBundleReducesEventExpressionsAfterMatrixExpansion(t *testing.T) {
+	source := []byte(`on: push
+jobs:
+  test:
+    strategy:
+      matrix:
+        part: [one, two]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ${{ format('{0}-{1}', github.event.ref, matrix.part) }}
+`)
+	bundle, err := CompileBundle("workflow.yml", source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bundle.Plans) != 2 {
+		t.Fatalf("plans = %d, want 2", len(bundle.Plans))
+	}
+	for _, artifact := range bundle.Plans {
+		part := artifact.Job.Matrix["part"]
+		if want := fmt.Sprintf("echo refs/heads/main-%s", part); artifact.Job.Steps[0].Command != want {
+			t.Errorf("matrix %v command = %q, want %q", part, artifact.Job.Steps[0].Command, want)
+		}
+	}
+}
+
+func TestCompileBundleReducesEventExpressionsInReusableWorkflowJobs(t *testing.T) {
+	repository := t.TempDir()
+	callerPath := writeWorkflow(t, repository, "caller.yml", `on: push
+jobs:
+  call:
+    uses: ./.github/workflows/reusable.yml
+`)
+	writeWorkflow(t, repository, "reusable.yml", `on: workflow_call
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ${{ github.event.ref }}
+`)
+	bundle, err := CompileBundle(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bundle.Plans) != 1 || bundle.Plans[0].Job.Steps[0].Command != "echo refs/heads/main" {
+		t.Fatalf("reusable-workflow plan = %#v", bundle.Plans)
 	}
 }
 

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -1358,6 +1358,8 @@ jobs:
     steps:
       - name: Head ${{ github.event.pull_request.head.sha }}
         run: echo '${{ github.event.pull_request.head.sha }}' '${{ github.event.missing }}' '${{ github.event.action }}' '${{ github.event.pull_request.head.sha == steps.previous.outputs.sha }}'
+        continue-on-error: ${{ github.event.allow_failure }}
+        timeout-minutes: ${{ github.event.timeout }}
         env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         shell: ${{ github.event.shell }}
@@ -1381,7 +1383,7 @@ runs:
   "ref": "refs/pull/42/merge",
   "sha": "1111111111111111111111111111111111111111",
   "actor": "octocat",
-  "payload": {"action": "opened", "shell": "bash", "directory": ".", "pull_request": {"head": {"sha": "2222222222222222222222222222222222222222"}}}
+  "payload": {"action": "opened", "allow_failure": true, "timeout": 7, "shell": "bash", "directory": ".", "pull_request": {"head": {"sha": "2222222222222222222222222222222222222222"}}}
 }`)
 	bundle, err := CompileBundle(path, readFile(t, path), event, "0.0.0-test", testDistributionDigest, "gha-importer")
 	if err != nil {
@@ -1394,6 +1396,9 @@ runs:
 	step := job.Steps[0]
 	if step.Name != "Head 2222222222222222222222222222222222222222" || step.Env["HEAD_SHA"] != "2222222222222222222222222222222222222222" || step.Shell != "bash" || step.WorkingDirectory != "." {
 		t.Fatalf("step templates were not reduced: %#v", step)
+	}
+	if step.ContinueOnErrorExpression != "${{ true }}" || step.TimeoutMinutesExpression != "${{ 7 }}" {
+		t.Fatalf("typed step expressions were not reduced: %#v", step)
 	}
 	if want := "echo '2222222222222222222222222222222222222222' '' 'opened' '${{ ('2222222222222222222222222222222222222222' == steps.previous.outputs.sha) }}'"; step.Command != want {
 		t.Fatalf("command = %q, want %q", step.Command, want)

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -1423,6 +1423,26 @@ jobs:
 	}
 }
 
+func TestCompileBundleDoesNotReduceEventExpressionsInActionReferences(t *testing.T) {
+	source := []byte(`on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ${{ github.event.action_ref }}
+`)
+	event := []byte(`{
+  "provider": "github", "event": "push",
+  "repository": {"owner": "buildkite", "name": "buildkite-gha", "clone_url": "https://github.com/buildkite/buildkite-gha.git", "default_branch": "main"},
+  "ref": "refs/heads/main", "sha": "1111111111111111111111111111111111111111", "actor": "octocat",
+  "payload": {"action_ref": "owner/action@1111111111111111111111111111111111111111"}
+}`)
+	_, err := CompileBundle("workflow.yml", source, event, "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err == nil || !strings.Contains(err.Error(), "github.event cannot be retained") {
+		t.Fatalf("CompileBundle() error = %v, want static action reference rejection", err)
+	}
+}
+
 func TestCompileBundleReducesEventExpressionsAfterMatrixExpansion(t *testing.T) {
 	source := []byte(`on: push
 jobs:

--- a/internal/compiler/plan_builder.go
+++ b/internal/compiler/plan_builder.go
@@ -177,7 +177,7 @@ func (b planBuilder) reducePlanInstanceEventExpressions(instance JobInstance) (J
 		if err != nil {
 			return "", err
 		}
-		referencesEventAlias, err := expression.TemplateUsesStaticContextReference(reduced, "event")
+		referencesEventAlias, err := expression.TemplateUsesContext(reduced, "event")
 		if err != nil {
 			return "", err
 		}
@@ -268,7 +268,7 @@ func (b planBuilder) reducePlanInstanceEventExpressions(instance JobInstance) (J
 		if step.If, err = reduceCondition(step.If); err != nil {
 			return JobInstance{}, err
 		}
-		for _, field := range []*string{&step.Name, &step.Run, &step.Uses, &step.Shell, &step.WorkingDirectory, &step.ContinueOnErrorExpression, &step.TimeoutMinutesExpression} {
+		for _, field := range []*string{&step.Name, &step.Run, &step.Shell, &step.WorkingDirectory, &step.ContinueOnErrorExpression, &step.TimeoutMinutesExpression} {
 			if *field, err = reduceTemplate(*field); err != nil {
 				return JobInstance{}, err
 			}

--- a/internal/compiler/plan_builder.go
+++ b/internal/compiler/plan_builder.go
@@ -210,6 +210,17 @@ func (b planBuilder) reducePlanInstanceEventExpressions(instance JobInstance) (J
 		}
 		return reduced, nil
 	}
+	reduceTypedExpression := func(value string) (string, error) {
+		referencesEvent, err := expression.ReferencesGitHubEvent(value)
+		if err != nil || !referencesEvent {
+			return value, err
+		}
+		reduced, err := reduceCondition(value)
+		if err != nil {
+			return "", err
+		}
+		return "${{ " + reduced + " }}", nil
+	}
 	reduceMap := func(values map[string]string) (map[string]string, error) {
 		if values == nil {
 			return nil, nil
@@ -268,8 +279,13 @@ func (b planBuilder) reducePlanInstanceEventExpressions(instance JobInstance) (J
 		if step.If, err = reduceCondition(step.If); err != nil {
 			return JobInstance{}, err
 		}
-		for _, field := range []*string{&step.Name, &step.Run, &step.Shell, &step.WorkingDirectory, &step.ContinueOnErrorExpression, &step.TimeoutMinutesExpression} {
+		for _, field := range []*string{&step.Name, &step.Run, &step.Shell, &step.WorkingDirectory} {
 			if *field, err = reduceTemplate(*field); err != nil {
+				return JobInstance{}, err
+			}
+		}
+		for _, field := range []*string{&step.ContinueOnErrorExpression, &step.TimeoutMinutesExpression} {
+			if *field, err = reduceTypedExpression(*field); err != nil {
 				return JobInstance{}, err
 			}
 		}

--- a/internal/compiler/plan_builder.go
+++ b/internal/compiler/plan_builder.go
@@ -91,6 +91,28 @@ instances:
 	return plans, authorizations, evaluations, errors.Join(diagnostics...)
 }
 
+// reducePlanEventExpressions is the phase boundary for compile-time-only event
+// data. It runs before action inspection, authority inventory, and plan
+// serialization, so every downstream consumer sees the same reduced values.
+func reducePlanEventExpressions(ir IR) (IR, error) {
+	workflowName := ir.Workflow.Name
+	if workflowName == "" {
+		workflowName = canonicalWorkflowName(ir.Workflow.Path)
+	}
+	builder := planBuilder{ir: ir, workflowName: workflowName}
+	ir.Jobs = append([]JobInstance(nil), ir.Jobs...)
+	var diagnostics []error
+	for i, instance := range ir.Jobs {
+		reduced, err := builder.reducePlanInstanceEventExpressions(instance)
+		if err != nil {
+			diagnostics = append(diagnostics, planConstructionFinding(instance, err))
+			continue
+		}
+		ir.Jobs[i] = reduced
+	}
+	return ir, errors.Join(diagnostics...)
+}
+
 func (b planBuilder) buildPlan(instance JobInstance, runtimeDistributionDigest string) (plan.Job, PlanAuthorization, []byte, error) {
 	if runtimeDistributionDigest == "" {
 		return plan.Job{}, PlanAuthorization{}, nil, fmt.Errorf("build plan for job %q: no runtime distribution configured for %s", instance.LogicalJobID, instance.Platform)
@@ -136,6 +158,173 @@ func (b planBuilder) buildPlan(instance JobInstance, runtimeDistributionDigest s
 		return plan.Job{}, PlanAuthorization{}, nil, fmt.Errorf("encode plan for job %q: %w", instance.LogicalJobID, err)
 	}
 	return job, actions.authorization, encoded, nil
+}
+
+func (b planBuilder) reducePlanInstanceEventExpressions(instance JobInstance) (JobInstance, error) {
+	context := compileContext(b.ir.Event, b.ir.Vars, instance.SourcePath, b.workflowName)
+	context.Inputs = instance.Inputs
+	context.Matrix = instance.Matrix
+
+	reduceTemplate := func(value string) (string, error) {
+		if value == "" {
+			return value, nil
+		}
+		reduced, err := expression.ReduceAvailableCompileTemplate(value, context)
+		if err != nil {
+			return "", err
+		}
+		referencesEvent, err := expression.TemplateReferencesGitHubEvent(reduced)
+		if err != nil {
+			return "", err
+		}
+		referencesEventAlias, err := expression.TemplateUsesStaticContextReference(reduced, "event")
+		if err != nil {
+			return "", err
+		}
+		if referencesEvent || referencesEventAlias {
+			return "", fmt.Errorf("github.event cannot be retained in a job plan")
+		}
+		return reduced, nil
+	}
+	reduceCondition := func(value string) (string, error) {
+		if value == "" {
+			return value, nil
+		}
+		referencesEvent, err := expression.ReferencesGitHubEvent(value)
+		if err != nil {
+			return "", err
+		}
+		if !referencesEvent {
+			return value, nil
+		}
+		reduced, err := expression.ReduceCompileCondition(value, context)
+		if err != nil {
+			return "", err
+		}
+		referencesEvent, err = expression.ReferencesGitHubEvent(reduced)
+		if err != nil {
+			return "", err
+		}
+		if referencesEvent {
+			return "", fmt.Errorf("github.event cannot be retained in a job plan")
+		}
+		return reduced, nil
+	}
+	reduceMap := func(values map[string]string) (map[string]string, error) {
+		if values == nil {
+			return nil, nil
+		}
+		result := cloneMap(values)
+		for _, name := range sortedValueKeys(result) {
+			value, err := reduceTemplate(result[name])
+			if err != nil {
+				return nil, err
+			}
+			result[name] = value
+		}
+		return result, nil
+	}
+	reduceSlice := func(values []string) ([]string, error) {
+		if values == nil {
+			return nil, nil
+		}
+		result := append([]string(nil), values...)
+		for i := range result {
+			value, err := reduceTemplate(result[i])
+			if err != nil {
+				return nil, err
+			}
+			result[i] = value
+		}
+		return result, nil
+	}
+
+	var err error
+	if instance.If, err = reduceCondition(instance.If); err != nil {
+		return JobInstance{}, err
+	}
+	for _, field := range []*string{&instance.DefaultShell, &instance.DefaultWorkingDirectory, &instance.ServicesExpression} {
+		if *field, err = reduceTemplate(*field); err != nil {
+			return JobInstance{}, err
+		}
+	}
+	if instance.Env, err = reduceMap(instance.Env); err != nil {
+		return JobInstance{}, err
+	}
+	if instance.Outputs, err = reduceMap(instance.Outputs); err != nil {
+		return JobInstance{}, err
+	}
+
+	instance.CallGuards = append([]CallGuard(nil), instance.CallGuards...)
+	for i := range instance.CallGuards {
+		if instance.CallGuards[i].Condition, err = reduceCondition(instance.CallGuards[i].Condition); err != nil {
+			return JobInstance{}, err
+		}
+	}
+
+	instance.Steps = append([]workflow.Step(nil), instance.Steps...)
+	for i := range instance.Steps {
+		step := &instance.Steps[i]
+		if step.If, err = reduceCondition(step.If); err != nil {
+			return JobInstance{}, err
+		}
+		for _, field := range []*string{&step.Name, &step.Run, &step.Uses, &step.Shell, &step.WorkingDirectory, &step.ContinueOnErrorExpression, &step.TimeoutMinutesExpression} {
+			if *field, err = reduceTemplate(*field); err != nil {
+				return JobInstance{}, err
+			}
+		}
+		if step.Env, err = reduceMap(step.Env); err != nil {
+			return JobInstance{}, err
+		}
+		if step.With, err = reduceMap(step.With); err != nil {
+			return JobInstance{}, err
+		}
+	}
+
+	if instance.Container != nil {
+		container := *instance.Container
+		if container.Image, err = reduceTemplate(container.Image); err != nil {
+			return JobInstance{}, err
+		}
+		if container.Env, err = reduceMap(container.Env); err != nil {
+			return JobInstance{}, err
+		}
+		if container.Ports, err = reduceSlice(container.Ports); err != nil {
+			return JobInstance{}, err
+		}
+		instance.Container = &container
+	}
+
+	instance.Services = append([]workflow.Service(nil), instance.Services...)
+	for i := range instance.Services {
+		container := instance.Services[i].Container
+		for _, field := range []*string{&container.Image, &container.Options, &container.Command, &container.Entrypoint} {
+			if *field, err = reduceTemplate(*field); err != nil {
+				return JobInstance{}, err
+			}
+		}
+		if container.Env, err = reduceMap(container.Env); err != nil {
+			return JobInstance{}, err
+		}
+		if container.Ports, err = reduceSlice(container.Ports); err != nil {
+			return JobInstance{}, err
+		}
+		if container.Volumes, err = reduceSlice(container.Volumes); err != nil {
+			return JobInstance{}, err
+		}
+		if container.Credentials != nil {
+			credentials := *container.Credentials
+			if credentials.Username, err = reduceTemplate(credentials.Username); err != nil {
+				return JobInstance{}, err
+			}
+			if credentials.Password, err = reduceTemplate(credentials.Password); err != nil {
+				return JobInstance{}, err
+			}
+			container.Credentials = &credentials
+		}
+		instance.Services[i].Container = container
+	}
+	return instance, nil
 }
 
 func lowerPlanSteps(source []workflow.Step) ([]plan.Step, []int, []string, []map[string]string) {

--- a/internal/expression/compile.go
+++ b/internal/expression/compile.go
@@ -451,7 +451,7 @@ func ReduceAvailableCompileTemplate(template string, context CompileContext) (st
 		if err != nil {
 			return "", err
 		}
-		if !nodeReferencesGitHubEventPayload(node) && !usesStaticContextReference(node, "event") {
+		if !nodeReferencesGitHubEventPayload(node) && !nodeReferencesContext(node, "event") {
 			reduced.WriteString(complete)
 			remaining = source[consumed:]
 			continue
@@ -485,7 +485,18 @@ func ReduceAvailableCompileTemplate(template string, context CompileContext) (st
 func referencesWholeEvent(expression actionlint.ExprNode) bool {
 	found := false
 	actionlint.VisitExprNode(expression, func(node, parent actionlint.ExprNode, entering bool) {
-		if !entering || found || referenceReceiver(node, parent) {
+		if !entering || found {
+			return
+		}
+		if projection, ok := node.(*actionlint.ArrayDerefNode); ok {
+			root, path, err := referencePath(projection.Receiver)
+			found = err == nil && (strings.EqualFold(root, "event") && len(path) == 0 ||
+				strings.EqualFold(root, "github") && len(path) == 1 && strings.EqualFold(path[0], "event"))
+			if found {
+				return
+			}
+		}
+		if referenceReceiver(node, parent) {
 			return
 		}
 		switch node.(type) {
@@ -499,6 +510,15 @@ func referencesWholeEvent(expression actionlint.ExprNode) bool {
 		}
 		found = strings.EqualFold(root, "event") && len(path) == 0 ||
 			strings.EqualFold(root, "github") && len(path) == 1 && strings.EqualFold(path[0], "event")
+	})
+	return found
+}
+
+func nodeReferencesContext(expression actionlint.ExprNode, contextName string) bool {
+	found := false
+	actionlint.VisitExprNode(expression, func(node, _ actionlint.ExprNode, entering bool) {
+		variable, ok := node.(*actionlint.VariableNode)
+		found = found || entering && ok && strings.EqualFold(variable.Name, contextName)
 	})
 	return found
 }

--- a/internal/expression/compile.go
+++ b/internal/expression/compile.go
@@ -313,6 +313,14 @@ func evaluateCompileNodeAvailable(node actionlint.ExprNode, context CompileConte
 		return available, nil
 	}
 	switch node := node.(type) {
+	case *actionlint.ObjectDerefNode:
+		if available, err := children(node.Receiver); err != nil || !available {
+			return nil, available, err
+		}
+	case *actionlint.ArrayDerefNode:
+		if available, err := children(node.Receiver); err != nil || !available {
+			return nil, available, err
+		}
 	case *actionlint.NotOpNode:
 		if available, err := children(node.Operand); err != nil || !available {
 			return nil, available, err

--- a/internal/expression/compile.go
+++ b/internal/expression/compile.go
@@ -259,11 +259,14 @@ func ReduceCompileCondition(source string, context CompileContext) (string, erro
 	if err != nil || empty {
 		return source, err
 	}
+	if _, _, err := evaluateCompileNodeAvailable(node, context); err != nil {
+		return "", err
+	}
 	return reduceCompileNode(node, context), nil
 }
 
 func reduceCompileNode(node actionlint.ExprNode, context CompileContext) string {
-	if value, err := evaluateCompileNode(node, context); err == nil {
+	if value, available, _ := evaluateCompileNodeAvailable(node, context); available {
 		if literal, ok := compileScalarLiteral(value); ok {
 			return literal
 		}
@@ -292,6 +295,51 @@ func reduceCompileNode(node actionlint.ExprNode, context CompileContext) string 
 	default:
 		return ""
 	}
+}
+
+// evaluateCompileNodeAvailable checks every branch before evaluation. This
+// prevents short-circuit evaluation from hiding runtime dependencies or
+// deterministic errors in an unselected branch.
+func evaluateCompileNodeAvailable(node actionlint.ExprNode, context CompileContext) (any, bool, error) {
+	children := func(nodes ...actionlint.ExprNode) (bool, error) {
+		available := true
+		for _, child := range nodes {
+			_, childAvailable, err := evaluateCompileNodeAvailable(child, context)
+			if err != nil {
+				return false, err
+			}
+			available = available && childAvailable
+		}
+		return available, nil
+	}
+	switch node := node.(type) {
+	case *actionlint.NotOpNode:
+		if available, err := children(node.Operand); err != nil || !available {
+			return nil, available, err
+		}
+	case *actionlint.CompareOpNode:
+		if available, err := children(node.Left, node.Right); err != nil || !available {
+			return nil, available, err
+		}
+	case *actionlint.LogicalOpNode:
+		if available, err := children(node.Left, node.Right); err != nil || !available {
+			return nil, available, err
+		}
+	case *actionlint.FuncCallNode:
+		if available, err := children(node.Args...); err != nil || !available {
+			return nil, available, err
+		}
+	case *actionlint.IndexAccessNode:
+		if available, err := children(node.Operand, node.Index); err != nil || !available {
+			return nil, available, err
+		}
+	}
+	value, err := evaluateCompileNode(node, context)
+	var dependency compileRuntimeDependencyError
+	if errors.As(err, &dependency) {
+		return nil, false, nil
+	}
+	return value, err == nil, err
 }
 
 func compileScalarLiteral(value any) (string, bool) {
@@ -364,6 +412,87 @@ func EvaluateAvailableCompileTemplate(template string, context CompileContext) (
 		}
 		remaining = source[consumed:]
 	}
+}
+
+// ReduceAvailableCompileTemplate replaces statically available scalar
+// subtrees in each template expression while preserving runtime-dependent
+// subtrees. Values rendered outside an expression retain the same expression
+// injection protection as EvaluateAvailableCompileTemplate.
+func ReduceAvailableCompileTemplate(template string, context CompileContext) (string, error) {
+	const open = "${{"
+	var reduced strings.Builder
+	remaining := template
+	for {
+		start := strings.Index(remaining, open)
+		if start < 0 {
+			reduced.WriteString(remaining)
+			return reduced.String(), nil
+		}
+		reduced.WriteString(remaining[:start])
+		source := remaining[start+len(open):]
+		_, consumed, lexErr := actionlint.LexExpression(source)
+		if lexErr != nil {
+			return "", fmt.Errorf("invalid expression: %w", lexErr)
+		}
+		complete := open + source[:consumed]
+		expr, err := Parse(complete, 1, 1)
+		if err != nil {
+			return "", err
+		}
+		node, err := parseCompileExpression(expr)
+		if err != nil {
+			return "", err
+		}
+		if !nodeReferencesGitHubEventPayload(node) && !usesStaticContextReference(node, "event") {
+			reduced.WriteString(complete)
+			remaining = source[consumed:]
+			continue
+		}
+		if referencesWholeEvent(node) {
+			return "", fmt.Errorf("whole github.event access is unsupported")
+		}
+		value, available, err := evaluateCompileNodeAvailable(node, context)
+		if err != nil {
+			return "", err
+		}
+		if available {
+			replacement, scalar := expressionString(value)
+			if !scalar {
+				return "", fmt.Errorf("template expression resolved to %T, want a scalar", value)
+			}
+			if introducesExpressionSyntax(reduced.String(), replacement, source[consumed:]) {
+				return "", fmt.Errorf("compile-time expression result contains expression syntax")
+			}
+			reduced.WriteString(replacement)
+		} else {
+			reduced.WriteString(open)
+			reduced.WriteString(" ")
+			reduced.WriteString(reduceCompileNode(node, context))
+			reduced.WriteString(" }}")
+		}
+		remaining = source[consumed:]
+	}
+}
+
+func referencesWholeEvent(expression actionlint.ExprNode) bool {
+	found := false
+	actionlint.VisitExprNode(expression, func(node, parent actionlint.ExprNode, entering bool) {
+		if !entering || found || referenceReceiver(node, parent) {
+			return
+		}
+		switch node.(type) {
+		case *actionlint.VariableNode, *actionlint.ObjectDerefNode, *actionlint.ArrayDerefNode, *actionlint.IndexAccessNode:
+		default:
+			return
+		}
+		root, path, err := referencePath(node)
+		if err != nil {
+			return
+		}
+		found = strings.EqualFold(root, "event") && len(path) == 0 ||
+			strings.EqualFold(root, "github") && len(path) == 1 && strings.EqualFold(path[0], "event")
+	})
+	return found
 }
 
 func introducesExpressionSyntax(before, replacement, after string) bool {
@@ -563,10 +692,7 @@ func evaluateCompileNode(node actionlint.ExprNode, context CompileContext) (any,
 		if recognized {
 			return value, err
 		}
-		if strings.EqualFold(node.Callee, "hashFiles") {
-			return nil, compileRuntimeDependencyError{fmt.Errorf("unsupported compile-time function %q", node.Callee)}
-		}
-		return nil, fmt.Errorf("unsupported compile-time function %q", node.Callee)
+		return nil, compileRuntimeDependencyError{fmt.Errorf("unsupported compile-time function %q", node.Callee)}
 	}
 	return evaluator.evaluate(node)
 }

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -1784,6 +1784,8 @@ func TestReduceAvailableCompileTemplateRejectsDeterministicEventErrors(t *testin
 	for _, template := range []string{
 		"${{ fromJSON(github.event.value) }}",
 		"${{ needs.build.outputs.ready || fromJSON(github.event.value) }}",
+		"${{ (fromJSON(needs.build.outputs.config) || fromJSON(github.event.value)).foo }}",
+		"${{ (fromJSON(needs.build.outputs.config) || fromJSON(github.event.value)).*.foo }}",
 	} {
 		_, err := ReduceAvailableCompileTemplate(template, context)
 		if err == nil || !strings.Contains(err.Error(), "invalid JSON") {

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -1773,9 +1773,16 @@ func TestReduceAvailableCompileTemplateRejectsIntroducedExpressionSyntax(t *test
 
 func TestReduceAvailableCompileTemplateRejectsWholeEventAccess(t *testing.T) {
 	context := CompileContext{GitHub: map[string]any{"event": map[string]any{"action": "opened"}}}
-	_, err := ReduceAvailableCompileTemplate("${{ toJSON(github.event) }}", context)
-	if err == nil || !strings.Contains(err.Error(), "whole github.event access is unsupported") {
-		t.Fatalf("ReduceAvailableCompileTemplate() error = %v", err)
+	context.Event = context.GitHub["event"].(map[string]any)
+	for _, template := range []string{
+		"${{ toJSON(github.event) }}",
+		"${{ toJSON(github.event.*) }}",
+		"${{ toJSON(event.*) }}",
+	} {
+		_, err := ReduceAvailableCompileTemplate(template, context)
+		if err == nil || !strings.Contains(err.Error(), "whole github.event access is unsupported") {
+			t.Errorf("ReduceAvailableCompileTemplate(%q) error = %v", template, err)
+		}
 	}
 }
 

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -1733,6 +1733,73 @@ func TestEvaluateAvailableCompileTemplatePreservesRuntimeExpressions(t *testing.
 	}
 }
 
+func TestReduceAvailableCompileTemplateReducesEventSubtrees(t *testing.T) {
+	context := CompileContext{GitHub: map[string]any{"event": map[string]any{
+		"action":       "opened",
+		"pull_request": map[string]any{"head": map[string]any{"sha": "abc123"}},
+	}}, Event: map[string]any{"action": "opened"}}
+	tests := []struct {
+		name     string
+		template string
+		want     string
+	}{
+		{name: "direct", template: "${{ github.event.pull_request.head.sha }}", want: "abc123"},
+		{name: "missing member", template: "before-${{ github.event.push.missing }}-after", want: "before--after"},
+		{name: "mixed runtime", template: "${{ github.event.pull_request.head.sha == steps.checkout.outputs.sha }}", want: "${{ ('abc123' == steps.checkout.outputs.sha) }}"},
+		{name: "multiple", template: "${{ github.event.pull_request.head.sha }}-${{ event.action }}-${{ needs.build.outputs.suffix }}", want: "abc123-opened-${{ needs.build.outputs.suffix }}"},
+		{name: "runtime short circuit branch", template: "${{ github.event.action == 'opened' || needs.build.outputs.ready }}", want: "${{ (true || needs.build.outputs.ready) }}"},
+		{name: "unrelated compile value", template: "${{ github.sha }}", want: "${{ github.sha }}"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := ReduceAvailableCompileTemplate(test.template, context)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != test.want {
+				t.Fatalf("ReduceAvailableCompileTemplate() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestReduceAvailableCompileTemplateRejectsIntroducedExpressionSyntax(t *testing.T) {
+	context := CompileContext{GitHub: map[string]any{"event": map[string]any{"value": "${{ secrets.ADMIN }}"}}}
+	_, err := ReduceAvailableCompileTemplate("${{ github.event.value }}", context)
+	if err == nil || !strings.Contains(err.Error(), "result contains expression syntax") {
+		t.Fatalf("ReduceAvailableCompileTemplate() error = %v", err)
+	}
+}
+
+func TestReduceAvailableCompileTemplateRejectsWholeEventAccess(t *testing.T) {
+	context := CompileContext{GitHub: map[string]any{"event": map[string]any{"action": "opened"}}}
+	_, err := ReduceAvailableCompileTemplate("${{ toJSON(github.event) }}", context)
+	if err == nil || !strings.Contains(err.Error(), "whole github.event access is unsupported") {
+		t.Fatalf("ReduceAvailableCompileTemplate() error = %v", err)
+	}
+}
+
+func TestReduceAvailableCompileTemplateRejectsDeterministicEventErrors(t *testing.T) {
+	context := CompileContext{GitHub: map[string]any{"event": map[string]any{"value": "["}}}
+	for _, template := range []string{
+		"${{ fromJSON(github.event.value) }}",
+		"${{ needs.build.outputs.ready || fromJSON(github.event.value) }}",
+	} {
+		_, err := ReduceAvailableCompileTemplate(template, context)
+		if err == nil || !strings.Contains(err.Error(), "invalid JSON") {
+			t.Errorf("ReduceAvailableCompileTemplate(%q) error = %v", template, err)
+		}
+	}
+}
+
+func TestReduceCompileConditionRejectsDeterministicEventErrors(t *testing.T) {
+	context := CompileContext{GitHub: map[string]any{"event": map[string]any{"value": "["}}}
+	_, err := ReduceCompileCondition("needs.build.outputs.ready || fromJSON(github.event.value)", context)
+	if err == nil || !strings.Contains(err.Error(), "invalid JSON") {
+		t.Fatalf("ReduceCompileCondition() error = %v", err)
+	}
+}
+
 func TestEvaluateCompileTemplateUsesGitHubNumberRendering(t *testing.T) {
 	got, err := EvaluateCompileTemplate("prefix-${{ fromJSON('1e20') }}", CompileContext{})
 	if err != nil {


### PR DESCRIPTION
## Summary
- reduce scalar `github.event.*` values from the immutable compiler snapshot before action inspection, authority inventory, and plan serialization
- preserve supported runtime-dependent expressions by reducing only compile-time AST subtrees
- cover retained step, job, action input, matrix, and reusable-workflow surfaces while rejecting residual or unsafe event expressions

## Testing
- `mise exec -- go test ./internal/expression ./internal/compiler`
- `mise run check`