### PR TITLE
Accept unknown pull request mergeability

### DIFF
--- a/internal/cli/path_filters.go
+++ b/internal/cli/path_filters.go
@@ -343,8 +343,10 @@ func pullRequestChangedPaths(event compiler.Event, pullRequestNumber int, baseRe
 	if nestedInt(event.Payload, "number") != pullRequestNumber {
 		return nil, nil, fmt.Errorf("webhook pull request number does not match the Buildkite build")
 	}
+	// GitHub may report null while it computes mergeability. The merge commit
+	// and its exact base and head parents are verified below.
 	mergeable, mergeabilityKnown := pullRequest["mergeable"].(bool)
-	if !mergeabilityKnown || !mergeable {
+	if mergeabilityKnown && !mergeable {
 		return nil, nil, fmt.Errorf("webhook pull request must report a mergeable synthetic merge")
 	}
 	if !validBuildkiteCommit(baseSHA) || !validBuildkiteCommit(headSHA) || !validBuildkiteCommit(mergeSHA) {

--- a/internal/cli/path_filters_test.go
+++ b/internal/cli/path_filters_test.go
@@ -216,6 +216,10 @@ func TestPullRequestChangedPathsUsesPayloadCommits(t *testing.T) {
 		t.Fatalf("workflow errors = %#v", workflowErrors)
 	}
 	pullRequest := event.Payload["pull_request"].(map[string]any)
+	delete(pullRequest, "mergeable")
+	if paths, _, err := pullRequestChangedPaths(event, 42, "main", []workflowInput{input}); err != nil || !reflect.DeepEqual(paths, []string{"src/main.go"}) {
+		t.Fatalf("unknown mergeability result = %#v, %v", paths, err)
+	}
 	pullRequest["mergeable"] = false
 	if _, _, err := pullRequestChangedPaths(event, 42, "main", nil); err == nil || !strings.Contains(err.Error(), "mergeable synthetic merge") {
 		t.Fatalf("conflicted pull request error = %v", err)


### PR DESCRIPTION
## Why

GitHub can report `mergeable: null` while it computes pull request mergeability. We rejected that transient webhook state even when the local checkout contained a valid synthetic merge, producing a misleading path-filter failure.

## What

Accept unknown mergeability when the synthetic merge commit, base, and head pass the existing local verification. Continue rejecting pull requests that explicitly report `mergeable: false`.