### PR TITLE
Assess documented compatibility gaps in CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -123,6 +123,15 @@ steps:
               version: "2026.5.12"
         command: "mise run corpus:starter-profile"
 
+      - label: ":github: Documented compatibility gaps"
+        key: "compatibility-gaps"
+        soft_fail: true
+        timeout_in_minutes: 20
+        plugins:
+          - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
+              version: "2026.5.12"
+        command: "mise run compatibility:gaps"
+
       - label: ":pipeline: Load public actions runtime proof"
         key: "public-actions-ci-loader"
         if: build.env("DEMO_SUITE") != "plugin" && build.env("SMOKE_PROBE") != "hosted" && build.env("COMPATIBILITY_PROOF") == null

--- a/internal/runtime/compatibility_gaps_test.go
+++ b/internal/runtime/compatibility_gaps_test.go
@@ -1,0 +1,51 @@
+//go:build compatibility_gaps
+
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/buildkite-gha/internal/compiler"
+)
+
+func TestCompatibilityGapOtherShells(t *testing.T) {
+	bin := t.TempDir()
+	pwsh := filepath.Join(bin, "pwsh")
+	if err := os.WriteFile(pwsh, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	runCompatibilityGapWorkflow(t, "other-shells.yml")
+}
+
+func TestCompatibilityGapBashArgTemplate(t *testing.T) {
+	runCompatibilityGapWorkflow(t, "bash-arg-template.yml")
+}
+
+func runCompatibilityGapWorkflow(t *testing.T, name string) {
+	t.Helper()
+	root := filepath.Join("..", "..", "testdata", "compatibility-gaps")
+	workflowPath := filepath.Join(".github", "workflows", name)
+	source, err := os.ReadFile(filepath.Join(root, workflowPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	event, err := os.ReadFile(filepath.Join("..", "..", "testdata", "smoke", "events", "push.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle, err := compiler.CompileBundle(workflowPath, source, event, "compatibility-gap", "sha256:"+strings.Repeat("0", 64), "compatibility-gap")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bundle.Plans) != 1 {
+		t.Fatalf("plans = %d, want 1", len(bundle.Plans))
+	}
+	result, err := (Runner{}).RunJob(t.Context(), bundle.Plans[0].Job, root)
+	if err != nil {
+		t.Fatalf("RunJob() conclusion = %q, error = %v", result.Conclusion, err)
+	}
+}

--- a/mise.toml
+++ b/mise.toml
@@ -34,7 +34,7 @@ run = "echo '--- Lint Go'; golangci-lint run"
 
 [tasks."lint:shell"]
 description = "Lint shell scripts"
-run = "echo '--- Lint shell'; shellcheck -x .buildkite/upload-examples.sh scripts/ci-buildkite-release scripts/compare-example scripts/starter-workflows-corpus scripts/update-checkout-main-commits scripts/validate-public-workflow-corpus scripts/verify-source-checkout scripts/hosted-docker-probe scripts/container-runtime-probe scripts/verify-summary-annotation scripts/verify-workflow-annotations scripts/verify-upload-artifact scripts/verify-artifact-roundtrip scripts/release scripts/release-test scripts/smoke-local testdata/actions/docker/entrypoint.sh testdata/container-runtime/.github/actions/docker/entrypoint.sh"
+run = "echo '--- Lint shell'; shellcheck -x .buildkite/upload-examples.sh scripts/ci-buildkite-release scripts/compare-example scripts/compatibility-gaps scripts/starter-workflows-corpus scripts/update-checkout-main-commits scripts/validate-public-workflow-corpus scripts/verify-source-checkout scripts/hosted-docker-probe scripts/container-runtime-probe scripts/verify-summary-annotation scripts/verify-workflow-annotations scripts/verify-upload-artifact scripts/verify-artifact-roundtrip scripts/release scripts/release-test scripts/smoke-local testdata/actions/docker/entrypoint.sh testdata/container-runtime/.github/actions/docker/entrypoint.sh"
 
 [tasks.lint]
 description = "Lint Go code and shell scripts"
@@ -68,6 +68,10 @@ run = "echo '--- Run local smoke tests'; ./scripts/smoke-local"
 [tasks."smoke:profile"]
 description = "Resolve actions and apply the hosted profile to smoke fixtures"
 run = "./scripts/smoke-local --profile hosted"
+
+[tasks."compatibility:gaps"]
+description = "Assess the documented compatibility gaps"
+run = "./scripts/compatibility-gaps"
 
 [tasks."corpus:starter"]
 description = "Report compile compatibility for the pinned GitHub starter workflow corpus"

--- a/scripts/compatibility-gaps
+++ b/scripts/compatibility-gaps
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Run the tracked compatibility-gap manifest through the exact CLI source under test.
+# Input comes from testdata/compatibility-gaps; the script accepts no arguments.
+# Output is a console tally and, in Buildkite, one aggregated build annotation.
+# A remaining gap makes this command exit 1; CI deliberately soft-fails that step.
+# Keep this harness tracked so local and CI assessments change atomically with the fixtures.
 set -euo pipefail
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/scripts/compatibility-gaps
+++ b/scripts/compatibility-gaps
@@ -35,6 +35,8 @@ CGO_ENABLED=0 mise exec -- go build -trimpath -buildvcs=false -o "$work/buildkit
 
 blocked=0
 passed=0
+summary="$work/summary.md"
+printf '## Compatibility gap assessment\n\nSource: %s\n\n' "$(jq -r .source "$manifest")" >"$summary"
 while IFS=$'\t' read -r id title workflow event mode test_name; do
   status=0
   report="$work/$id.out"
@@ -67,11 +69,9 @@ while IFS=$'\t' read -r id title workflow event mode test_name; do
   printf '%s: %s\n' "$id" "$outcome"
   if [[ "$outcome" == passing ]]; then
     passed=$((passed + 1))
-    style=success
     icon='✅'
   else
     blocked=$((blocked + 1))
-    style=warning
     icon='⚠️'
     if [[ "$mode" == profile ]]; then
       jq -r '.diagnostics[]? | "  \(.code): \(.message)"' "$report" >&2 || true
@@ -79,16 +79,14 @@ while IFS=$'\t' read -r id title workflow event mode test_name; do
       sed -n '1,20p' "$report" >&2
     fi
   fi
-  printf '## %s %s\n\n%s\n\nSource: %s\n' \
-    "$icon" "$title" "$reason" "$(jq -r .source "$manifest")" >"$work/$id.md"
-  printf '%s\t%s\n' "$id" "$style" >>"$work/annotations.tsv"
+  printf -- '- %s **%s** — %s\n' "$icon" "$title" "$reason" >>"$summary"
 done < <(jq -r '.gaps[] | [.id, .title, .workflow, .event, .mode, (.test // "-")] | @tsv' "$manifest")
 
 if [[ "${BUILDKITE:-}" == true ]] && command -v buildkite-agent >/dev/null; then
-  while IFS=$'\t' read -r id style; do
-    buildkite-agent annotate --context "compatibility-gap-$id" --style "$style" <"$work/$id.md" || \
-      echo "warning: failed to publish Buildkite annotation for $id" >&2
-  done <"$work/annotations.tsv"
+  style=success
+  (( blocked > 0 )) && style=warning
+  buildkite-agent annotate --context compatibility-gaps --style "$style" <"$summary" || \
+    echo "warning: failed to publish Buildkite compatibility gap annotation" >&2
 fi
 
 printf 'Compatibility gaps: %d passing; %d blocked.\n' "$passed" "$blocked"

--- a/scripts/compatibility-gaps
+++ b/scripts/compatibility-gaps
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly root
+readonly fixture_root="$root/testdata/compatibility-gaps"
+readonly manifest="$fixture_root/manifest.json"
+work="$(mktemp -d "${TMPDIR:-/tmp}/buildkite-gha-compatibility-gaps.XXXXXXXX")"
+trap 'rm -rf -- "$work"' EXIT
+
+cd "$root"
+jq -e '
+  .schema == "buildkite-gha/compatibility-gaps/v1" and
+  (.source | startswith("https://slopcannon.tail952194.ts.net/")) and
+  (.gaps | type == "array" and length == 16) and
+  all(.gaps[];
+    (.id | test("^[a-z0-9]+(?:-[a-z0-9]+)*$")) and
+    (.title | type == "string" and length > 0) and
+    (.workflow | test("^[a-z0-9]+(?:-[a-z0-9]+)*\\.yml$")) and
+    (.event | IN("push", "pull_request", "merge_group", "release")) and
+    (.mode | IN("profile", "runtime")) and
+    (if .mode == "runtime" then (.test | test("^TestCompatibilityGap[A-Za-z]+$")) else (has("test") | not) end)) and
+  ([.gaps[].id] | length == (unique | length)) and
+  ([.gaps[].workflow] | length == (unique | length))
+' "$manifest" >/dev/null
+
+while IFS= read -r workflow; do
+  [[ -f "$fixture_root/.github/workflows/$workflow" ]] || {
+    echo "missing compatibility gap workflow: $workflow" >&2
+    exit 1
+  }
+done < <(jq -r '.gaps[].workflow' "$manifest")
+
+CGO_ENABLED=0 mise exec -- go build -trimpath -buildvcs=false -o "$work/buildkite-gha" ./cmd/buildkite-gha
+
+blocked=0
+passed=0
+while IFS=$'\t' read -r id title workflow event mode test_name; do
+  status=0
+  report="$work/$id.out"
+  if [[ "$mode" == profile ]]; then
+    (
+      cd "$fixture_root"
+      "$work/buildkite-gha" validate --profile hosted --format json \
+        --event "$event" ".github/workflows/$workflow"
+    ) >"$report" 2>&1 || status=$?
+    result="$(jq -r '.result // "invalid-report"' "$report" 2>/dev/null || echo invalid-report)"
+    if [[ "$status" == 0 && "$result" == admitted ]]; then
+      outcome=passing
+      reason="Hosted profile admitted the workflow."
+    else
+      outcome=blocked
+      reason="$(jq -r '[.diagnostics[]?.message] | unique | join(" ") | if length == 0 then "Validation did not produce a diagnostic." else . end' "$report" 2>/dev/null || echo 'Validation report could not be read.')"
+    fi
+  else
+    mise exec -- go test -tags compatibility_gaps ./internal/runtime \
+      -run "^${test_name}$" -count=1 >"$report" 2>&1 || status=$?
+    if [[ "$status" == 0 ]]; then
+      outcome=passing
+      reason="The compiled workflow completed in the compatibility runtime."
+    else
+      outcome=blocked
+      reason="The compiled workflow did not complete in the compatibility runtime."
+    fi
+  fi
+
+  printf '%s: %s\n' "$id" "$outcome"
+  if [[ "$outcome" == passing ]]; then
+    passed=$((passed + 1))
+    style=success
+    icon='✅'
+  else
+    blocked=$((blocked + 1))
+    style=warning
+    icon='⚠️'
+    if [[ "$mode" == profile ]]; then
+      jq -r '.diagnostics[]? | "  \(.code): \(.message)"' "$report" >&2 || true
+    else
+      sed -n '1,20p' "$report" >&2
+    fi
+  fi
+  printf '## %s %s\n\n%s\n\nSource: %s\n' \
+    "$icon" "$title" "$reason" "$(jq -r .source "$manifest")" >"$work/$id.md"
+  printf '%s\t%s\n' "$id" "$style" >>"$work/annotations.tsv"
+done < <(jq -r '.gaps[] | [.id, .title, .workflow, .event, .mode, (.test // "-")] | @tsv' "$manifest")
+
+if [[ "${BUILDKITE:-}" == true ]] && command -v buildkite-agent >/dev/null; then
+  while IFS=$'\t' read -r id style; do
+    buildkite-agent annotate --context "compatibility-gap-$id" --style "$style" <"$work/$id.md" || \
+      echo "warning: failed to publish Buildkite annotation for $id" >&2
+  done <"$work/annotations.tsv"
+fi
+
+printf 'Compatibility gaps: %d passing; %d blocked.\n' "$passed" "$blocked"
+(( blocked == 0 ))

--- a/testdata/compatibility-gaps/.github/workflows/bash-arg-template.yml
+++ b/testdata/compatibility-gaps/.github/workflows/bash-arg-template.yml
@@ -1,0 +1,8 @@
+name: Compatibility gap - bash argument template
+on: push
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - shell: bash -l {0}
+        run: echo compatible

--- a/testdata/compatibility-gaps/.github/workflows/cache-commits.yml
+++ b/testdata/compatibility-gaps/.github/workflows/cache-commits.yml
@@ -1,0 +1,10 @@
+name: Compatibility gap - cache commits
+on: push
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/cache@v2
+        with:
+          path: .buildkite
+          key: compatibility-gap

--- a/testdata/compatibility-gaps/.github/workflows/checkout-commits.yml
+++ b/testdata/compatibility-gaps/.github/workflows/checkout-commits.yml
@@ -1,0 +1,7 @@
+name: Compatibility gap - checkout commits
+on: push
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4

--- a/testdata/compatibility-gaps/.github/workflows/docker-actions.yml
+++ b/testdata/compatibility-gaps/.github/workflows/docker-actions.yml
@@ -1,0 +1,7 @@
+name: Compatibility gap - docker actions
+on: push
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker://alpine:3.20

--- a/testdata/compatibility-gaps/.github/workflows/download-artifact-versions.yml
+++ b/testdata/compatibility-gaps/.github/workflows/download-artifact-versions.yml
@@ -1,0 +1,9 @@
+name: Compatibility gap - download-artifact versions
+on: push
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: compatibility-gap

--- a/testdata/compatibility-gaps/.github/workflows/github-environments.yml
+++ b/testdata/compatibility-gaps/.github/workflows/github-environments.yml
@@ -1,0 +1,8 @@
+name: Compatibility gap - GitHub environments
+on: push
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - run: echo compatible

--- a/testdata/compatibility-gaps/.github/workflows/merge-group-filters.yml
+++ b/testdata/compatibility-gaps/.github/workflows/merge-group-filters.yml
@@ -1,0 +1,9 @@
+name: Compatibility gap - merge group filters
+on:
+  merge_group:
+    paths: ["src/**"]
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo compatible

--- a/testdata/compatibility-gaps/.github/workflows/other-shells.yml
+++ b/testdata/compatibility-gaps/.github/workflows/other-shells.yml
@@ -1,0 +1,8 @@
+name: Compatibility gap - other shells
+on: push
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - shell: pwsh
+        run: Write-Output compatible

--- a/testdata/compatibility-gaps/.github/workflows/permissions-write-all.yml
+++ b/testdata/compatibility-gaps/.github/workflows/permissions-write-all.yml
@@ -1,0 +1,8 @@
+name: Compatibility gap - permissions write-all
+on: push
+permissions: write-all
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo compatible

--- a/testdata/compatibility-gaps/.github/workflows/pull-request-tag-filters.yml
+++ b/testdata/compatibility-gaps/.github/workflows/pull-request-tag-filters.yml
@@ -1,0 +1,9 @@
+name: Compatibility gap - pull request tag filters
+on:
+  pull_request:
+    tags: ["v*"]
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo compatible

--- a/testdata/compatibility-gaps/.github/workflows/release-types.yml
+++ b/testdata/compatibility-gaps/.github/workflows/release-types.yml
@@ -1,0 +1,7 @@
+name: Compatibility gap - release types
+on: release
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo compatible

--- a/testdata/compatibility-gaps/.github/workflows/remote-reusable-workflows.yml
+++ b/testdata/compatibility-gaps/.github/workflows/remote-reusable-workflows.yml
@@ -1,0 +1,7 @@
+name: Compatibility gap - remote reusable workflows
+on: push
+jobs:
+  probe:
+    uses: buildkite/buildkite-gha/.github/workflows/example-reusable-package.yml@ef121d3d0f33b5b5532028de9398f6a0fe1f0b39
+    with:
+      package: ./internal/compiler

--- a/testdata/compatibility-gaps/.github/workflows/runner-labels.yml
+++ b/testdata/compatibility-gaps/.github/workflows/runner-labels.yml
@@ -1,0 +1,7 @@
+name: Compatibility gap - runner labels
+on: push
+jobs:
+  probe:
+    runs-on: windows-latest
+    steps:
+      - run: echo compatible

--- a/testdata/compatibility-gaps/.github/workflows/secret-forwarding-called.yml
+++ b/testdata/compatibility-gaps/.github/workflows/secret-forwarding-called.yml
@@ -1,0 +1,7 @@
+name: Compatibility gap - secret forwarding target
+on: workflow_call
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo compatible

--- a/testdata/compatibility-gaps/.github/workflows/secret-forwarding-mapped-called.yml
+++ b/testdata/compatibility-gaps/.github/workflows/secret-forwarding-mapped-called.yml
@@ -1,0 +1,11 @@
+name: Compatibility gap - mapped secret forwarding target
+on:
+  workflow_call:
+    secrets:
+      compatibility-gap-token:
+        required: true
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo compatible

--- a/testdata/compatibility-gaps/.github/workflows/secret-forwarding.yml
+++ b/testdata/compatibility-gaps/.github/workflows/secret-forwarding.yml
@@ -1,0 +1,10 @@
+name: Compatibility gap - secret forwarding
+on: push
+jobs:
+  inherit:
+    uses: ./.github/workflows/secret-forwarding-called.yml
+    secrets: inherit
+  map:
+    uses: ./.github/workflows/secret-forwarding-mapped-called.yml
+    secrets:
+      compatibility-gap-token: ${{ secrets.COMPATIBILITY_GAP_TOKEN }}

--- a/testdata/compatibility-gaps/.github/workflows/secrets-in-conditions.yml
+++ b/testdata/compatibility-gaps/.github/workflows/secrets-in-conditions.yml
@@ -1,0 +1,8 @@
+name: Compatibility gap - secrets in conditions
+on: push
+jobs:
+  probe:
+    if: ${{ secrets.COMPATIBILITY_GAP_TOKEN != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo compatible

--- a/testdata/compatibility-gaps/.github/workflows/upload-artifact-versions.yml
+++ b/testdata/compatibility-gaps/.github/workflows/upload-artifact-versions.yml
@@ -1,0 +1,10 @@
+name: Compatibility gap - upload-artifact versions
+on: push
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/upload-artifact@v3
+        with:
+          name: compatibility-gap
+          path: README.md

--- a/testdata/compatibility-gaps/README.md
+++ b/testdata/compatibility-gaps/README.md
@@ -1,0 +1,13 @@
+# Compatibility gap smoke tests
+
+These fixtures continuously assess the 16 gaps in the linked [compatibility analysis](https://slopcannon.tail952194.ts.net/simone/gha-plugin-what-to-build-next/).
+
+Run the assessment with:
+
+```sh
+mise run compatibility:gaps
+```
+
+The command applies the `hosted` profile to compile-time and admission gaps. It compiles and executes the two runtime shell fixtures. A passing case means the representative workflow is currently compatible. A blocked case makes the command fail.
+
+CI soft-fails the aggregate step while gaps remain. After all cases finish, the step publishes one Buildkite annotation per gap. This keeps each result visible without blocking unrelated builds.

--- a/testdata/compatibility-gaps/README.md
+++ b/testdata/compatibility-gaps/README.md
@@ -10,4 +10,4 @@ mise run compatibility:gaps
 
 The command applies the `hosted` profile to compile-time and admission gaps. It compiles and executes the two runtime shell fixtures. A passing case means the representative workflow is currently compatible. A blocked case makes the command fail.
 
-CI soft-fails the aggregate step while gaps remain. After all cases finish, the step publishes one Buildkite annotation per gap. This keeps each result visible without blocking unrelated builds.
+CI soft-fails the aggregate step while gaps remain. After all cases finish, the step publishes one Buildkite annotation containing every result. This keeps the assessment visible without blocking unrelated builds.

--- a/testdata/compatibility-gaps/manifest.json
+++ b/testdata/compatibility-gaps/manifest.json
@@ -1,0 +1,22 @@
+{
+  "schema": "buildkite-gha/compatibility-gaps/v1",
+  "source": "https://slopcannon.tail952194.ts.net/simone/gha-plugin-what-to-build-next/",
+  "gaps": [
+    {"id":"runner-labels","title":"Runner labels (Windows + unmapped)","workflow":"runner-labels.yml","event":"push","mode":"profile"},
+    {"id":"github-environments","title":"GitHub environments","workflow":"github-environments.yml","event":"push","mode":"profile"},
+    {"id":"other-shells","title":"Shells other than bash/sh","workflow":"other-shells.yml","event":"push","mode":"runtime","test":"TestCompatibilityGapOtherShells"},
+    {"id":"upload-artifact-versions","title":"actions/upload-artifact versions","workflow":"upload-artifact-versions.yml","event":"push","mode":"profile"},
+    {"id":"secret-forwarding","title":"Secret forwarding (inherit + maps)","workflow":"secret-forwarding.yml","event":"push","mode":"profile"},
+    {"id":"checkout-commits","title":"actions/checkout outside admitted commits","workflow":"checkout-commits.yml","event":"push","mode":"profile"},
+    {"id":"cache-commits","title":"actions/cache outside admitted commits","workflow":"cache-commits.yml","event":"push","mode":"profile"},
+    {"id":"download-artifact-versions","title":"actions/download-artifact versions","workflow":"download-artifact-versions.yml","event":"push","mode":"profile"},
+    {"id":"bash-arg-template","title":"bash with a custom arg template","workflow":"bash-arg-template.yml","event":"push","mode":"runtime","test":"TestCompatibilityGapBashArgTemplate"},
+    {"id":"release-types","title":"release without supported types","workflow":"release-types.yml","event":"release","mode":"profile"},
+    {"id":"docker-actions","title":"docker:// actions","workflow":"docker-actions.yml","event":"push","mode":"profile"},
+    {"id":"permissions-write-all","title":"permissions: write-all","workflow":"permissions-write-all.yml","event":"push","mode":"profile"},
+    {"id":"secrets-in-conditions","title":"Secrets in conditions or dynamic names","workflow":"secrets-in-conditions.yml","event":"push","mode":"profile"},
+    {"id":"remote-reusable-workflows","title":"Remote reusable workflows","workflow":"remote-reusable-workflows.yml","event":"push","mode":"profile"},
+    {"id":"pull-request-tag-filters","title":"pull_request tag filters","workflow":"pull-request-tag-filters.yml","event":"pull_request","mode":"profile"},
+    {"id":"merge-group-filters","title":"merge_group filters or types","workflow":"merge-group-filters.yml","event":"merge_group","mode":"profile"}
+  ]
+}


### PR DESCRIPTION
## Why

The documented compatibility gaps need continuous assessment so changes in compiler, admission, and runtime support are visible before the gaps become release blockers.

## What

- Add one representative fixture for each of the 16 documented gaps.
- Exercise hosted-profile behavior and run the two shell gaps through the compatibility runtime.
- Add a soft-failing CI assessment that publishes one aggregated success or warning annotation containing all gap results.
