### PR TITLE
PB-3013: Admit legacy actions/upload-artifact releases

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -721,27 +721,32 @@ Alternate repositories, tags, non-event dynamic commits, LFS, sparse checkout, G
 
 | Release | Commit |
 | --- | --- |
+| v1.0.0 | [`3446296876d12d4e3a0f3145a3c87e67bf0a16b5`](https://github.com/actions/upload-artifact/tree/3446296876d12d4e3a0f3145a3c87e67bf0a16b5) |
+| v2.3.1 | [`82c141cc518b40d92cc801eee768e7aafc9c2fa2`](https://github.com/actions/upload-artifact/tree/82c141cc518b40d92cc801eee768e7aafc9c2fa2) |
+| v3.2.1 | [`ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5`](https://github.com/actions/upload-artifact/tree/ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5) |
 | v4.6.2 | [`ea165f8d65b6e75b540449e92b4886f43607fa02`](https://github.com/actions/upload-artifact/tree/ea165f8d65b6e75b540449e92b4886f43607fa02) |
 | v5.0.0 | [`330a01c490aca151604b8cf639adc76d48f6c5d4`](https://github.com/actions/upload-artifact/tree/330a01c490aca151604b8cf639adc76d48f6c5d4) |
 | v6.0.0 | [`b7c566a772e6b6bfb58ed0dc250532a479d7789f`](https://github.com/actions/upload-artifact/tree/b7c566a772e6b6bfb58ed0dc250532a479d7789f) |
 | v7.0.1 | [`043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`](https://github.com/actions/upload-artifact/tree/043fb46d1a93c77aae656e7c1c64a875d1fc6a0a) |
 
+The v1.0.0, v2.3.1, and v3.2.1 commits match the floating legacy major tags used on github.com. Other legacy commits are unsupported, including v3.2.2, which upstream publishes only as a GitHub Enterprise Server security backport and deprecates on github.com. Every admitted release accepts only its declared inputs. Compilation emits `W_UPLOAD_ARTIFACT_LEGACY_RELEASE` for v1 through v3 to recommend v4 or later.
+
 | Input | Supported values |
 | --- | --- |
-| `name` | ✅ Supported; defaults to `artifact`. |
-| `path` | Required; literal files or directories, or bounded `*`, `?`, character-class, and `**` file globs. |
-| `if-no-files-found` | `warn`, `error`, or `ignore`. |
-| `retention-days` | Nonnegative integer; advisory only. |
-| `compression-level` | `0` through `9`. |
-| `overwrite` | Omitted or `false`. |
-| `include-hidden-files` | ✅ Supported. |
+| `name` | v1.0.0: required. v2.3.1 and later: defaults to `artifact`. |
+| `path` | Required. v1.0.0 accepts one literal file or directory. v2.3.1 and later accept literal paths or bounded `*`, `?`, character-class, and `**` file globs. |
+| `if-no-files-found` | v2.3.1 and later: `warn`, `error`, or `ignore`. v1.0.0 fails when its literal path is missing and uploads an empty existing directory. |
+| `retention-days` | v2.3.1 and later: nonnegative integer; advisory only. |
+| `compression-level` | v4.6.2 and later: `0` through `9`. |
+| `overwrite` | v4.6.2 and later: omitted or `false`. |
+| `include-hidden-files` | v3.2.1 and later. v1.0.0 and v2.3.1 include hidden paths by default. |
 | `archive` | v7.0.1 only; omitted or `true`. |
 
-Unsupported path forms include exclusions, symlinks, absolute paths, traversal, braces, extglobs, leading glob comments, and special files. At most 32 path roots may be selected. Hidden path segments remain excluded unless explicitly enabled.
+Unsupported path forms include exclusions, symlinks, absolute paths, traversal, braces, extglobs, leading glob comments, and special files. At most 32 path roots may be selected. For v3.2.1 and later, hidden path segments remain excluded unless explicitly enabled.
 
 An artifact may contain at most 10,000 files and 1 GiB of source data. The ZIP must also be no larger than 1 GiB. A job may publish 64 artifacts.
 
-The adapter sets `artifact-id` and `artifact-digest`. The `artifact-url` output is empty because no GitHub run-scoped URL exists. Merge, raw upload, overwrite, and effective retention control are unsupported.
+For v4.6.2 and later, the adapter sets `artifact-id` and `artifact-digest`; `artifact-url` is empty because no GitHub run-scoped URL exists. The v1 through v3 releases expose no outputs. Merge, raw upload, overwrite, and effective retention control are unsupported.
 
 ### Download artifact action
 

--- a/internal/action/integration/upload_artifact.go
+++ b/internal/action/integration/upload_artifact.go
@@ -13,10 +13,14 @@ import (
 )
 
 const (
-	// UploadArtifactCommit through UploadArtifactV7Commit are the audited
+	// UploadArtifactV1Commit through UploadArtifactV7Commit are the audited
 	// upstream implementations whose ZIP-mode semantics this adapter implements.
-	// Raw v7 uploads remain explicitly unsupported by
-	// ValidateUploadArtifactInputs.
+	// The v1, v2, and v3 commits are the floating legacy major releases used on
+	// github.com and are admitted exactly. Raw v7 uploads remain explicitly
+	// unsupported by ValidateUploadArtifactInputs.
+	UploadArtifactV1Commit = "3446296876d12d4e3a0f3145a3c87e67bf0a16b5"
+	UploadArtifactV2Commit = "82c141cc518b40d92cc801eee768e7aafc9c2fa2"
+	UploadArtifactV3Commit = "ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5"
 	UploadArtifactCommit   = "ea165f8d65b6e75b540449e92b4886f43607fa02"
 	UploadArtifactV5Commit = "330a01c490aca151604b8cf639adc76d48f6c5d4"
 	UploadArtifactV6Commit = "b7c566a772e6b6bfb58ed0dc250532a479d7789f"
@@ -28,10 +32,58 @@ const (
 )
 
 var uploadArtifactCommits = map[string]string{
+	UploadArtifactV1Commit: "v1.0.0",
+	UploadArtifactV2Commit: "v2.3.1",
+	UploadArtifactV3Commit: "v3.2.1",
 	UploadArtifactCommit:   "v4.6.2",
 	UploadArtifactV5Commit: "v5.0.0",
 	UploadArtifactV6Commit: "v6.0.0",
 	UploadArtifactV7Commit: "v7.0.1",
+}
+
+// uploadArtifactInputIntroduced records the first admitted generation that
+// declared each version-gated input. Inputs absent from this map are declared
+// by every admitted release. The v7 archive input retains its more specific
+// validation below.
+var uploadArtifactInputIntroduced = map[string]int{
+	"if-no-files-found":    2,
+	"retention-days":       2,
+	"include-hidden-files": 3,
+	"compression-level":    4,
+	"overwrite":            4,
+}
+
+func uploadArtifactGeneration(commit string) int {
+	switch commit {
+	case UploadArtifactV1Commit:
+		return 1
+	case UploadArtifactV2Commit:
+		return 2
+	case UploadArtifactV3Commit:
+		return 3
+	}
+	return 4
+}
+
+// UploadArtifactSupportsOutputs reports whether the admitted release declares
+// artifact outputs. Upstream legacy v1 through v3 releases declared none.
+func UploadArtifactSupportsOutputs(commit string) bool {
+	return uploadArtifactGeneration(commit) >= 4
+}
+
+// UploadArtifactIncludesHiddenByDefault reports whether omission of
+// include-hidden-files retains hidden paths for the admitted release.
+func UploadArtifactIncludesHiddenByDefault(commit string) bool {
+	return commit == UploadArtifactV1Commit || commit == UploadArtifactV2Commit
+}
+
+// LegacyUploadArtifactRelease reports the release label for admitted v1
+// through v3 commits, which warrant an upgrade warning.
+func LegacyUploadArtifactRelease(commit string) (string, bool) {
+	if uploadArtifactGeneration(commit) <= 3 {
+		return uploadArtifactCommits[commit], true
+	}
+	return "", false
 }
 
 func validateUploadArtifactCommit(commit string) error {
@@ -63,6 +115,7 @@ func validateUploadArtifactInputs(commit string, inputs map[string]string, evalu
 	if err := validateUploadArtifactCommit(commit); err != nil {
 		return err
 	}
+	generation := uploadArtifactGeneration(commit)
 	allowed := map[string]bool{"name": true, "path": true, "if-no-files-found": true, "include-hidden-files": true, "compression-level": true, "overwrite": true, "archive": true, "retention-days": true}
 	seen := map[string]bool{}
 	for _, name := range sortedNames(inputs) {
@@ -77,15 +130,27 @@ func validateUploadArtifactInputs(commit string, inputs map[string]string, evalu
 		if lower == "archive" && commit != UploadArtifactV7Commit {
 			return fmt.Errorf("input %q exists only in actions/upload-artifact v7", name)
 		}
+		if uploadArtifactInputIntroduced[lower] > generation {
+			return fmt.Errorf("explicit input %q is unsupported by this actions/upload-artifact release", name)
+		}
 	}
 	pathValue, ok := inputFold(inputs, "path")
 	if !ok || strings.TrimSpace(pathValue) == "" {
 		return fmt.Errorf("required input %q is missing", "path")
 	}
 	if evaluated || !uploadArtifactExpression(pathValue) {
-		_, err := UploadArtifactPaths(pathValue)
+		paths, err := UploadArtifactPaths(pathValue)
 		if err != nil {
 			return err
+		}
+		if generation == 1 && (len(paths) != 1 || strings.ContainsAny(paths[0], "*?[")) {
+			return fmt.Errorf("input %q in actions/upload-artifact v1 must be one literal file or directory", "path")
+		}
+	}
+	if generation == 1 {
+		name, ok := inputFold(inputs, "name")
+		if !ok || strings.TrimSpace(name) == "" {
+			return fmt.Errorf("required input %q is missing", "name")
 		}
 	}
 	if value, ok := inputFold(inputs, "name"); ok && (evaluated || !uploadArtifactExpression(value)) {

--- a/internal/action/integration/upload_artifact_test.go
+++ b/internal/action/integration/upload_artifact_test.go
@@ -6,14 +6,24 @@ import (
 )
 
 func TestUploadArtifactCommitsAreExact(t *testing.T) {
-	for _, commit := range []string{UploadArtifactCommit, UploadArtifactV5Commit, UploadArtifactV6Commit, UploadArtifactV7Commit} {
+	commits := []string{
+		UploadArtifactV1Commit, UploadArtifactV2Commit, UploadArtifactV3Commit,
+		UploadArtifactCommit, UploadArtifactV5Commit, UploadArtifactV6Commit, UploadArtifactV7Commit,
+	}
+	for _, commit := range commits {
 		if err := validateUploadArtifactCommit(commit); err != nil {
 			t.Fatalf("audited commit %s rejected: %v", commit, err)
 		}
 	}
 	for _, commit := range []string{"bbbca2ddaa5d8feaa63e36b76fdaad77386f024f", strings.Repeat("0", 40)} {
-		if err := validateUploadArtifactCommit(commit); err == nil || !strings.Contains(err.Error(), UploadArtifactCommit) || !strings.Contains(err.Error(), UploadArtifactV5Commit) || !strings.Contains(err.Error(), UploadArtifactV6Commit) || !strings.Contains(err.Error(), UploadArtifactV7Commit) {
-			t.Fatalf("unrecognized commit %s error = %v, want all audited commits", commit, err)
+		err := validateUploadArtifactCommit(commit)
+		if err == nil {
+			t.Fatalf("unrecognized commit %s accepted", commit)
+		}
+		for _, supported := range commits {
+			if !strings.Contains(err.Error(), supported) {
+				t.Fatalf("unrecognized commit %s error = %v, want audited commit %s", commit, err, supported)
+			}
 		}
 	}
 }
@@ -23,6 +33,9 @@ func TestValidateUploadArtifactInputs(t *testing.T) {
 		commit string
 		inputs map[string]string
 	}{
+		{UploadArtifactV1Commit, map[string]string{"name": "payload", "path": "payload/result.txt"}},
+		{UploadArtifactV2Commit, map[string]string{"path": "payload/result.txt", "retention-days": "7", "if-no-files-found": "error"}},
+		{UploadArtifactV3Commit, map[string]string{"path": "payload/", "include-hidden-files": "true"}},
 		{UploadArtifactCommit, map[string]string{"path": "payload/result.txt"}},
 		{UploadArtifactCommit, map[string]string{"name": " payload ", "path": "payload/result.txt"}},
 		{UploadArtifactV5Commit, map[string]string{"path": "./payload/result.txt"}},
@@ -70,6 +83,24 @@ func TestValidateUploadArtifactInputs(t *testing.T) {
 	}
 	if err := ValidateUploadArtifactInputs(UploadArtifactCommit, map[string]string{"path": "payload", "archive": "true"}); err == nil || !strings.Contains(err.Error(), "only in actions/upload-artifact v7") {
 		t.Fatalf("v4 archive input error = %v", err)
+	}
+	for _, test := range []struct {
+		name   string
+		commit string
+		inputs map[string]string
+		want   string
+	}{
+		{name: "v1 requires name", commit: UploadArtifactV1Commit, inputs: map[string]string{"path": "payload"}, want: `required input "name" is missing`},
+		{name: "v1 rejects glob path", commit: UploadArtifactV1Commit, inputs: map[string]string{"name": "payload", "path": "payload/*.txt"}, want: "must be one literal file or directory"},
+		{name: "v1 rejects v2 input", commit: UploadArtifactV1Commit, inputs: map[string]string{"name": "payload", "path": "payload", "if-no-files-found": "warn"}, want: `explicit input "if-no-files-found" is unsupported`},
+		{name: "v2 rejects v3 input", commit: UploadArtifactV2Commit, inputs: map[string]string{"path": "payload", "include-hidden-files": "true"}, want: `explicit input "include-hidden-files" is unsupported`},
+		{name: "v3 rejects v4 input", commit: UploadArtifactV3Commit, inputs: map[string]string{"path": "payload", "compression-level": "0"}, want: `explicit input "compression-level" is unsupported`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := ValidateUploadArtifactInputs(test.commit, test.inputs); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("ValidateUploadArtifactInputs(%s, %#v) error = %v, want %q", test.commit, test.inputs, err, test.want)
+			}
+		})
 	}
 	if err := ValidateEvaluatedUploadArtifactInputs(UploadArtifactV7Commit, map[string]string{"path": "${{ still.unresolved }}"}); err == nil {
 		t.Fatal("runtime accepted an unevaluated path expression")

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -128,6 +128,41 @@ func checkoutTestManifest(commit string) string {
 	}
 }
 
+// These manifests mirror the admitted legacy upload-artifact releases. v1's
+// runner plugin and v2's retired node12 runtime don't pass generic metadata
+// admission, but their execution is replaced entirely by the native adapter.
+const uploadArtifactV1LegacyManifest = `name: 'Upload a Build Artifact'
+inputs:
+  name:
+    required: true
+  path:
+    required: true
+runs:
+  plugin: publish
+`
+
+const uploadArtifactV2LegacyManifest = `name: 'Upload a Build Artifact'
+inputs:
+  name:
+    default: artifact
+  path:
+    required: true
+runs:
+  using: node12
+  main: dist/index.js
+`
+
+func uploadArtifactTestManifest(commit string) string {
+	switch commit {
+	case actionintegration.UploadArtifactV1Commit:
+		return uploadArtifactV1LegacyManifest
+	case actionintegration.UploadArtifactV2Commit:
+		return uploadArtifactV2LegacyManifest
+	default:
+		return "name: upload artifact\nruns:\n  using: node24\n  main: index.js\n"
+	}
+}
+
 type commitActionSource struct{ roots map[string]string }
 
 func (s commitActionSource) Fetch(_ context.Context, r source.Reference) (source.Resolved, source.Materialized, error) {
@@ -1274,6 +1309,66 @@ func TestCompileBundleLegacyCheckoutWarning(t *testing.T) {
 	}
 }
 
+func TestCompileBundleLegacyUploadArtifactWarning(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := filepath.Join(workspace, ".github", "workflows", "artifact.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	roots := map[string]string{}
+	for _, commit := range []string{
+		actionintegration.UploadArtifactV1Commit,
+		actionintegration.UploadArtifactV2Commit,
+		actionintegration.UploadArtifactV3Commit,
+		actionintegration.UploadArtifactCommit,
+	} {
+		root := t.TempDir()
+		writeAction(t, root, "", uploadArtifactTestManifest(commit))
+		roots[commit] = root
+	}
+	compile := func(steps string) Bundle {
+		t.Helper()
+		workflow := []byte("on: push\njobs:\n  upload:\n    runs-on: ubuntu-latest\n    steps:\n" + steps)
+		if err := os.WriteFile(workflowPath, workflow, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		bundle, err := CompileBundleWithOptions(workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, "importer", Options{
+			EventTrust: EventUntrusted,
+			Runners: RunnerPolicy{
+				Labels:          map[string]string{"ubuntu-latest": "hosted"},
+				UntrustedQueues: []string{"hosted"},
+			},
+			ResolveActions: true,
+			ActionSource:   commitActionSource{roots: roots},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return bundle
+	}
+
+	bundle := compile("      - uses: actions/upload-artifact@" + actionintegration.UploadArtifactV1Commit + "\n" +
+		"        with:\n          name: v1\n          path: payload\n" +
+		"      - uses: actions/upload-artifact@" + actionintegration.UploadArtifactV1Commit + "\n" +
+		"        with:\n          name: v1-again\n          path: payload\n" +
+		"      - uses: actions/upload-artifact@" + actionintegration.UploadArtifactV2Commit + "\n" +
+		"        with:\n          path: payload\n" +
+		"      - uses: actions/upload-artifact@" + actionintegration.UploadArtifactV3Commit + "\n" +
+		"        with:\n          path: payload\n")
+	if len(bundle.IR.Warnings) != 3 ||
+		bundle.IR.Warnings[0].Code != "W_UPLOAD_ARTIFACT_LEGACY_RELEASE" || !strings.Contains(bundle.IR.Warnings[0].Message, "v1.0.0") || bundle.IR.Warnings[0].Line == 0 ||
+		bundle.IR.Warnings[1].Code != "W_UPLOAD_ARTIFACT_LEGACY_RELEASE" || !strings.Contains(bundle.IR.Warnings[1].Message, "v2.3.1") ||
+		bundle.IR.Warnings[2].Code != "W_UPLOAD_ARTIFACT_LEGACY_RELEASE" || !strings.Contains(bundle.IR.Warnings[2].Message, "v3.2.1") {
+		t.Fatalf("legacy upload-artifact warnings = %#v", bundle.IR.Warnings)
+	}
+
+	bundle = compile("      - uses: actions/upload-artifact@" + actionintegration.UploadArtifactCommit + "\n" +
+		"        with:\n          path: payload\n")
+	if len(bundle.IR.Warnings) != 0 {
+		t.Fatalf("warnings = %#v, want none", bundle.IR.Warnings)
+	}
+}
+
 func TestNativeCheckoutIgnoresUpstreamTokenDefaultForOrigin(t *testing.T) {
 	workspace, remote := t.TempDir(), t.TempDir()
 	workflowPath := filepath.Join(workspace, ".github", "workflows", "checkout.yml")
@@ -1346,14 +1441,8 @@ func TestUploadArtifactAdapterInputAndCommitBoundary(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	writeAction(t, remote, "", "name: upload artifact\nruns:\n  using: node24\n  main: dist/index.js\n")
-	if err := os.MkdirAll(filepath.Join(remote, "dist"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(remote, "dist", "index.js"), []byte("throw new Error('adapter only')\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
 	compile := func(commit, with string) ([]plan.Job, error) {
+		writeAction(t, remote, "", uploadArtifactTestManifest(commit))
 		workflow := []byte("on: push\njobs:\n  upload:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/upload-artifact@" + commit + "\n" + with)
 		if err := os.WriteFile(workflowPath, workflow, 0o644); err != nil {
 			t.Fatal(err)
@@ -1367,6 +1456,19 @@ func TestUploadArtifactAdapterInputAndCommitBoundary(t *testing.T) {
 			ResolveActions: true,
 			ActionSource:   &fakeActionSource{root: remote, calls: map[string]int{}},
 		})
+	}
+
+	for version, test := range map[string]struct {
+		commit string
+		with   string
+	}{
+		"v1.0.0": {commit: actionintegration.UploadArtifactV1Commit, with: "        with:\n          name: payload\n          path: payload/result.txt\n"},
+		"v2.3.1": {commit: actionintegration.UploadArtifactV2Commit, with: "        with:\n          path: payload/result.txt\n          if-no-files-found: error\n"},
+		"v3.2.1": {commit: actionintegration.UploadArtifactV3Commit, with: "        with:\n          path: payload/result.txt\n          include-hidden-files: true\n"},
+	} {
+		if plans, err := compile(test.commit, test.with); err != nil || len(plans) != 1 {
+			t.Fatalf("audited %s upload rejected: plans = %#v, error = %v", version, plans, err)
+		}
 	}
 
 	plans, err := compile(actionintegration.UploadArtifactCommit, "        with:\n          name: payload\n          path: payload/result.txt\n          if-no-files-found: error\n          compression-level: '0'\n")
@@ -1423,7 +1525,7 @@ func TestUploadArtifactAdapterInputAndCommitBoundary(t *testing.T) {
 		})
 	}
 
-	if _, err := compile(strings.Repeat("b", 40), "        with:\n          path: payload\n"); err == nil || !strings.Contains(err.Error(), actionintegration.UploadArtifactCommit) || !strings.Contains(err.Error(), actionintegration.UploadArtifactV5Commit) || !strings.Contains(err.Error(), actionintegration.UploadArtifactV6Commit) || !strings.Contains(err.Error(), actionintegration.UploadArtifactV7Commit) {
+	if _, err := compile(strings.Repeat("b", 40), "        with:\n          path: payload\n"); err == nil || !strings.Contains(err.Error(), actionintegration.UploadArtifactV1Commit) || !strings.Contains(err.Error(), actionintegration.UploadArtifactV2Commit) || !strings.Contains(err.Error(), actionintegration.UploadArtifactV3Commit) || !strings.Contains(err.Error(), actionintegration.UploadArtifactCommit) || !strings.Contains(err.Error(), actionintegration.UploadArtifactV5Commit) || !strings.Contains(err.Error(), actionintegration.UploadArtifactV6Commit) || !strings.Contains(err.Error(), actionintegration.UploadArtifactV7Commit) {
 		t.Fatalf("unsupported upload-artifact commit error = %v", err)
 	}
 

--- a/internal/compiler/bundle.go
+++ b/internal/compiler/bundle.go
@@ -94,6 +94,7 @@ func CompileBundlePlansContext(ctx context.Context, path string, source, eventSo
 		return bundle, processingFinding(StagePlans, CodePlanConstruction, "compatibility", fmt.Errorf("compiler produced %d plans and %d authorizations for %d job instances", len(plans), len(authorizations), len(ir.Jobs)))
 	}
 	warnedLegacyCheckout := map[string]bool{}
+	warnedLegacyUploadArtifact := map[string]bool{}
 	for i, job := range plans {
 		locks := make(map[string]plan.ActionLock, len(job.Actions))
 		for _, lock := range job.Actions {
@@ -105,15 +106,22 @@ func CompileBundlePlansContext(ctx context.Context, path string, source, eventSo
 			}
 			lock := locks[step.Action.Lock]
 			descriptor, _ := actionintegration.Lookup(actionintegration.Identity{Source: lock.Source, Repository: lock.Repository, Path: lock.Path})
-			if descriptor.Adapter != actionintegration.AdapterCheckoutExactEventSHA {
-				continue
+			switch descriptor.Adapter {
+			case actionintegration.AdapterCheckoutExactEventSHA:
+				release, legacy := actionintegration.LegacyCheckoutRelease(lock.Commit)
+				if !legacy || warnedLegacyCheckout[release] {
+					continue
+				}
+				warnedLegacyCheckout[release] = true
+				bundle.IR.Warnings = append(bundle.IR.Warnings, legacyCheckoutWarning(ir.Jobs[i].Steps[stepIndex].Span.Start, release))
+			case actionintegration.AdapterUploadArtifactBuildkite:
+				release, legacy := actionintegration.LegacyUploadArtifactRelease(lock.Commit)
+				if !legacy || warnedLegacyUploadArtifact[release] {
+					continue
+				}
+				warnedLegacyUploadArtifact[release] = true
+				bundle.IR.Warnings = append(bundle.IR.Warnings, legacyUploadArtifactWarning(ir.Jobs[i].Steps[stepIndex].Span.Start, release))
 			}
-			release, legacy := actionintegration.LegacyCheckoutRelease(lock.Commit)
-			if !legacy || warnedLegacyCheckout[release] {
-				continue
-			}
-			warnedLegacyCheckout[release] = true
-			bundle.IR.Warnings = append(bundle.IR.Warnings, legacyCheckoutWarning(ir.Jobs[i].Steps[stepIndex].Span.Start, release))
 		}
 	}
 	warnedReusablePermissions := false

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -388,6 +388,15 @@ func legacyCheckoutWarning(position workflow.Position, release string) Warning {
 	}
 }
 
+func legacyUploadArtifactWarning(position workflow.Position, release string) Warning {
+	return Warning{
+		Code:    "W_UPLOAD_ARTIFACT_LEGACY_RELEASE",
+		Line:    position.Line,
+		Column:  position.Column,
+		Message: fmt.Sprintf("actions/upload-artifact %s is emulated by the native adapter with its release contract; upgrade to v4 or later", release),
+	}
+}
+
 func reusableWorkflowTokenWarning(position workflow.Position) Warning {
 	return Warning{
 		Code:    "W_REUSABLE_WORKFLOW_TOKEN_USES_ROOT_PERMISSIONS",

--- a/internal/runtime/upload_artifact.go
+++ b/internal/runtime/upload_artifact.go
@@ -71,7 +71,15 @@ func parseUploadOptions(commit string, inputs map[string]string) (uploadOptions,
 	for k, v := range inputs {
 		values[strings.ToLower(k)] = strings.TrimSpace(v)
 	}
-	o := uploadOptions{name: "artifact", noFiles: "warn", level: 6}
+	o := uploadOptions{
+		name:    "artifact",
+		noFiles: "warn",
+		hidden:  actionintegration.UploadArtifactIncludesHiddenByDefault(commit),
+		level:   6,
+	}
+	if commit == actionintegration.UploadArtifactV1Commit {
+		o.noFiles = "error"
+	}
 	if v, ok := values["name"]; ok {
 		o.name = strings.TrimSpace(v)
 	}
@@ -159,7 +167,12 @@ func (r *jobRun) runUploadArtifactCommit(ctx context.Context, processor *command
 	if err != nil {
 		return result, err
 	}
-	if len(files) == 0 {
+	emptyV1Directory := false
+	if commit == actionintegration.UploadArtifactV1Commit {
+		info, statErr := os.Stat(filepath.Join(workspace, filepath.FromSlash(o.paths[0])))
+		emptyV1Directory = statErr == nil && info.IsDir()
+	}
+	if len(files) == 0 && !emptyV1Directory {
 		message := fmt.Sprintf("No files were found with the provided path: %s. No artifacts will be uploaded.", o.searchPath)
 		switch o.noFiles {
 		case "error":
@@ -222,8 +235,10 @@ func (r *jobRun) runUploadArtifactCommit(ctx context.Context, processor *command
 	}
 	// The future download adapter resolves this opaque ID through the result manifest.
 	id := strconv.FormatUint(idNumber, 10)
-	result.Outputs["artifact-id"] = id
-	result.Outputs["artifact-digest"] = digest
+	if actionintegration.UploadArtifactSupportsOutputs(commit) {
+		result.Outputs["artifact-id"] = id
+		result.Outputs["artifact-digest"] = digest
+	}
 	result.Artifacts = []transport.ResultArtifact{{Name: o.name, ID: id, Path: rel, Digest: "sha256:" + digest, Size: size, FileCount: len(files)}}
 	success = true
 	return result, nil

--- a/internal/runtime/upload_artifact_test.go
+++ b/internal/runtime/upload_artifact_test.go
@@ -90,21 +90,31 @@ func TestUploadArtifactRuntimeVersionMatrix(t *testing.T) {
 	workspace := t.TempDir()
 	writeFixtureFile(t, workspace, "payload", "versioned")
 	for _, test := range []struct {
-		name   string
-		commit string
-		inputs map[string]string
+		name        string
+		commit      string
+		inputs      map[string]string
+		wantOutputs bool
 	}{
-		{name: "v4.6.2 defaults", commit: actionintegration.UploadArtifactCommit, inputs: map[string]string{"path": "payload"}},
-		{name: "v5.0.0 defaults", commit: actionintegration.UploadArtifactV5Commit, inputs: map[string]string{"path": "./payload"}},
-		{name: "v6.0.0 defaults", commit: actionintegration.UploadArtifactV6Commit, inputs: map[string]string{"path": "./payload", "retention-days": "0"}},
-		{name: "v7.0.1 ZIP", commit: actionintegration.UploadArtifactV7Commit, inputs: map[string]string{"path": "payload", "archive": " true ", "name": "v7"}},
+		{name: "v1.0.0", commit: actionintegration.UploadArtifactV1Commit, inputs: map[string]string{"name": "v1", "path": "payload"}},
+		{name: "v2.3.1 defaults", commit: actionintegration.UploadArtifactV2Commit, inputs: map[string]string{"path": "payload"}},
+		{name: "v3.2.1 defaults", commit: actionintegration.UploadArtifactV3Commit, inputs: map[string]string{"path": "payload"}},
+		{name: "v4.6.2 defaults", commit: actionintegration.UploadArtifactCommit, inputs: map[string]string{"path": "payload"}, wantOutputs: true},
+		{name: "v5.0.0 defaults", commit: actionintegration.UploadArtifactV5Commit, inputs: map[string]string{"path": "./payload"}, wantOutputs: true},
+		{name: "v6.0.0 defaults", commit: actionintegration.UploadArtifactV6Commit, inputs: map[string]string{"path": "./payload", "retention-days": "0"}, wantOutputs: true},
+		{name: "v7.0.1 ZIP", commit: actionintegration.UploadArtifactV7Commit, inputs: map[string]string{"path": "payload", "archive": " true ", "name": "v7"}, wantOutputs: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			uploader := &captureArtifactUploader{}
 			r := newJobRun(Runner{Artifacts: uploader})
 			result, err := r.runUploadArtifactCommit(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, test.commit, test.inputs)
-			if err != nil || len(uploader.uploads) != 1 || len(result.Artifacts) != 1 || result.Outputs["artifact-id"] == "" || result.Outputs["artifact-digest"] == "" || result.Outputs["artifact-url"] != "" {
+			if err != nil || len(uploader.uploads) != 1 || len(result.Artifacts) != 1 {
 				t.Fatalf("runtime matrix result = %#v, uploads = %d, error = %v", result, len(uploader.uploads), err)
+			}
+			if test.wantOutputs && (result.Outputs["artifact-id"] == "" || result.Outputs["artifact-digest"] == "" || result.Outputs["artifact-url"] != "") {
+				t.Fatalf("runtime matrix outputs = %#v", result.Outputs)
+			}
+			if !test.wantOutputs && len(result.Outputs) != 0 {
+				t.Fatalf("legacy runtime outputs = %#v, want none", result.Outputs)
 			}
 			reader, err := zip.NewReader(bytes.NewReader(uploader.uploads[0].data), int64(len(uploader.uploads[0].data)))
 			if err != nil {
@@ -119,6 +129,50 @@ func TestUploadArtifactRuntimeVersionMatrix(t *testing.T) {
 	r := newJobRun(Runner{Artifacts: &captureArtifactUploader{}})
 	if _, err := r.runUploadArtifactCommit(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, actionintegration.UploadArtifactCommit, map[string]string{"path": "payload", "archive": "true"}); err == nil || !strings.Contains(err.Error(), "only in actions/upload-artifact v7") {
 		t.Fatalf("runtime v4 archive mismatch error = %v", err)
+	}
+}
+
+func TestUploadArtifactLegacyReleaseBehavior(t *testing.T) {
+	workspace := t.TempDir()
+	writeFixtureFile(t, workspace, "payload/visible.txt", "visible")
+	writeFixtureFile(t, workspace, "payload/.hidden.txt", "hidden")
+	if err := os.Mkdir(filepath.Join(workspace, "empty"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name   string
+		commit string
+		inputs map[string]string
+		want   map[string]string
+	}{
+		{name: "v1 includes hidden files", commit: actionintegration.UploadArtifactV1Commit, inputs: map[string]string{"name": "v1", "path": "payload"}, want: map[string]string{".hidden.txt": "hidden", "visible.txt": "visible"}},
+		{name: "v2 includes hidden files", commit: actionintegration.UploadArtifactV2Commit, inputs: map[string]string{"path": "payload"}, want: map[string]string{".hidden.txt": "hidden", "visible.txt": "visible"}},
+		{name: "v3 excludes hidden files", commit: actionintegration.UploadArtifactV3Commit, inputs: map[string]string{"path": "payload"}, want: map[string]string{"visible.txt": "visible"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			uploader := &captureArtifactUploader{}
+			r := newJobRun(Runner{Artifacts: uploader})
+			result, err := r.runUploadArtifactCommit(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, test.commit, test.inputs)
+			if err != nil || len(uploader.uploads) != 1 || len(result.Artifacts) != 1 || len(result.Outputs) != 0 {
+				t.Fatalf("legacy upload result = %#v, uploads = %d, error = %v", result, len(uploader.uploads), err)
+			}
+			if got := readUploadZIP(t, uploader.uploads[0].data); !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("archive entries = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+
+	r := newJobRun(Runner{Artifacts: &captureArtifactUploader{}})
+	if _, err := r.runUploadArtifactCommit(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, actionintegration.UploadArtifactV1Commit, map[string]string{"name": "missing", "path": "missing"}); err == nil || !strings.Contains(err.Error(), "No files were found") {
+		t.Fatalf("v1 missing path error = %v", err)
+	}
+
+	uploader := &captureArtifactUploader{}
+	r = newJobRun(Runner{Artifacts: uploader})
+	result, err := r.runUploadArtifactCommit(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, actionintegration.UploadArtifactV1Commit, map[string]string{"name": "empty", "path": "empty"})
+	if err != nil || len(uploader.uploads) != 1 || len(result.Artifacts) != 1 || result.Artifacts[0].FileCount != 0 || len(readUploadZIP(t, uploader.uploads[0].data)) != 0 {
+		t.Fatalf("v1 empty directory result = %#v, uploads = %d, error = %v", result, len(uploader.uploads), err)
 	}
 }
 
@@ -696,6 +750,54 @@ func TestUploadArtifactAdapterBypassesVerifiedUpstreamLifecycle(t *testing.T) {
 	job.Actions[0].Commit = strings.Repeat("b", 40)
 	if _, err := (Runner{Actions: materializer, Artifacts: &captureArtifactUploader{}}).RunJob(t.Context(), job, workspace); err == nil || !strings.Contains(err.Error(), actionintegration.UploadArtifactCommit) {
 		t.Fatalf("unsupported runtime commit error = %v", err)
+	}
+}
+
+func TestUploadArtifactLegacyManifestsUseNativeAdapter(t *testing.T) {
+	for _, test := range []struct {
+		name, commit, manifest string
+		inputs                 map[string]string
+	}{
+		{
+			name: "v1 runner plugin", commit: actionintegration.UploadArtifactV1Commit,
+			manifest: "name: upload artifact\ninputs:\n  name:\n    required: true\n  path:\n    required: true\nruns:\n  plugin: publish\n",
+			inputs:   map[string]string{"name": "legacy-v1", "path": "payload"},
+		},
+		{
+			name: "v2 node12", commit: actionintegration.UploadArtifactV2Commit,
+			manifest: "name: upload artifact\ninputs:\n  path:\n    required: true\nruns:\n  using: node12\n  main: dist/index.js\n",
+			inputs:   map[string]string{"path": "payload"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			workspace := t.TempDir()
+			workflowPath := ".github/workflows/upload.yml"
+			writeFixtureFile(t, workspace, workflowPath, "name: legacy upload proof\n")
+			writeFixtureFile(t, workspace, "payload/result.txt", "payload")
+			remote := canonicalTempDir(t)
+			writeFixtureFile(t, remote, "action.yml", test.manifest)
+			digest, err := source.DigestTree(remote)
+			if err != nil {
+				t.Fatal(err)
+			}
+			const lockID = "a-0000000000000001"
+			job := runtimePlan(t, workspace, workflowPath, []plan.Step{{
+				ID: "upload", Kind: "uses", Uses: "actions/upload-artifact@" + test.commit,
+				With: test.inputs, Action: &plan.ActionSelector{Lock: lockID},
+			}})
+			job.Schema = plan.Schema
+			job.RequiredCapabilities = []string{"network"}
+			job.Actions = []plan.ActionLock{{
+				ID: lockID, Source: "github", Repository: "actions/upload-artifact", RequestedRef: test.commit,
+				Commit: test.commit, SourceDigest: digest,
+			}}
+			materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, ActionRoot: remote, SourceDigest: digest}}
+			uploader := &captureArtifactUploader{}
+			result, err := (Runner{Actions: materializer, Artifacts: uploader}).RunJob(t.Context(), job, workspace)
+			if err != nil || result.Conclusion != "success" || len(result.Artifacts) != 1 || len(uploader.uploads) != 1 || materializer.calls != 1 {
+				t.Fatalf("legacy RunJob() result = %#v, uploads = %d, materializations = %d, error = %v", result, len(uploader.uploads), materializer.calls, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Why

`actions/upload-artifact@v1`, `@v2`, and `@v3` resolve outside the native adapter's admitted set, so affected workflows fail compilation. Corpus data shows 1,278 repositories blocked by this alone and 6,762 affected repositories overall.

Resolves [PB-3013](https://linear.app/buildkite/issue/PB-3013/admit-legacy-actionsupload-artifact-release-commits-in-the-native).

## What

- Admit the floating github.com legacy releases exactly: v1.0.0, v2.3.1, and v3.2.1. Keep the GHES-only v3.2.2 backport excluded.
- Enforce each release's declared inputs and preserve v1/v2 hidden-file defaults, v1 missing and empty-directory behavior, and pre-v4 output contracts.
- Emit one upgrade warning per legacy release and document the exact compatibility boundary.

## Test

- `mise run check` (format, Linux/macOS builds, tests, race tests, lint, vet, local smoke inventory, and release checks)