### PR TITLE
Support github.token in composite action metadata

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1057,8 +1057,9 @@ event repository when it:
 
 A `github.server_url == 'https://github.com'` guard skips the token branch for
 an Origin repository. Known guards skip unreachable token branches; unknown
-values conservatively request a token. Native adapters ignore upstream input
-defaults, so `actions/checkout` alone does not request a token.
+values used by a token guard conservatively request a token. Native adapters
+ignore upstream input defaults, so `actions/checkout` alone does not request a
+token.
 
 The top-level workflow's `permissions` set the scope. Token issuance needs a
 Buildkite organization feature and a pipeline setting; both are off by default.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -773,9 +773,10 @@ context listed below, including `token`, with sorted keys and two-space
 indentation.
 
 The compiler treats that call as a token reference, so normal permissions,
-admission, and redaction apply. Composite steps can consume an already
-authorized context, but composite metadata cannot grant token authority. A
-tokenless context is an error.
+admission, and redaction apply. Reachable immutable composite step fields can
+grant token authority through direct `github.token` references and consume the
+authorized context. `toJSON(github)` does not grant authority from composite
+metadata. A tokenless context is an error.
 
 Job-level fields and action input defaults cannot call `toJSON(github)`. Bare,
 projected, or dynamically indexed `github`, and passing the whole context to

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -348,7 +348,7 @@ jobs:
 
 ### Permissions
 
-**🟡 Supported subset.** Permissions matter only when a job statically references `secrets.GITHUB_TOKEN` or `github.token`, or an effective action input default can reach `github.token` for the event provider.
+**🟡 Supported subset.** Permissions matter only when a job statically references `secrets.GITHUB_TOKEN` or `github.token`, or reachable immutable action metadata can use `github.token` for the event provider.
 
 A workflow-level permissions map can request repository access:
 
@@ -1052,12 +1052,13 @@ JavaScript and Docker actions with compatible bundled cache clients also receive
 event repository when it:
 
 - statically references `secrets.GITHUB_TOKEN` or `github.token`; or
-- uses an action whose effective input default can reach `github.token` for the
-  event provider.
+- uses reachable immutable action metadata that can use `github.token` for the
+  event provider, including effective input defaults and composite step fields.
 
 A `github.server_url == 'https://github.com'` guard skips the token branch for
-an Origin repository. Native adapters ignore upstream input defaults, so
-`actions/checkout` alone does not request a token.
+an Origin repository. Known guards skip unreachable token branches; unknown
+values conservatively request a token. Native adapters ignore upstream input
+defaults, so `actions/checkout` alone does not request a token.
 
 The top-level workflow's `permissions` set the scope. Token issuance needs a
 Buildkite organization feature and a pipeline setting; both are off by default.
@@ -1107,9 +1108,9 @@ jobs:
 The server restricts pull requests, merge queues, and their descendants. For other builds, job binding does not establish that an arbitrary commit is trusted. Restrict who can create builds and enable write tokens only when branch builds run trusted code.
 
 The token is not part of the initial job environment. Workflow-authored
-`github.token` references are step-only and use the same token as
-`secrets.GITHUB_TOKEN`. Effective action input defaults can also use it.
-Automatic ambient `GITHUB_TOKEN` is unsupported.
+`github.token` references and supported immutable action metadata use the same
+token as `secrets.GITHUB_TOKEN`. Automatic ambient `GITHUB_TOKEN` is
+unsupported.
 
 ### Other secrets and OIDC
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -76,7 +76,7 @@ manifests. A missing or changed manifest stops the job.
 | Credential | Boundary |
 | --- | --- |
 | Repository checkout | The native adapter checks the event repository and exact commit. Buildkite authorizes private access. Credentials apply only to Git commands and are not persisted. |
-| `GITHUB_TOKEN` | A short-lived token for the event repository. Buildkite enforces the top-level workflow permission map and build provenance. The token is not ambient. |
+| `GITHUB_TOKEN` | Supported workflow references and reachable immutable action metadata receive a short-lived token for the event repository. Buildkite enforces the top-level workflow permission map and build provenance. The token is not ambient. |
 | Cache token | A fresh job-bound token for each compatible JavaScript or Docker action lifecycle. Shell steps do not receive it. |
 | Workflow secrets | Static names resolve with `buildkite-agent secret get` in the destination job. Buildkite Secret access policy is the authority. |
 | Registry credentials | Explicit credentials resolve in the destination job. Passwords go to Docker through standard input and use a private per-job Docker configuration. Secret-derived values stay out of plans and pipeline YAML; authored literals do not. |

--- a/internal/cli/hosted.go
+++ b/internal/cli/hosted.go
@@ -426,10 +426,14 @@ func githubTokenAdmissionDiagnostic(artifact compiler.PlanArtifact, reason strin
 			quoted[i] = fmt.Sprintf("%q", action)
 		}
 		actionLabel := "action"
+		verb := "references"
+		pronoun := "its"
 		if len(quoted) > 1 {
 			actionLabel = "actions"
+			verb = "reference"
+			pronoun = "their"
 		}
-		causes = append(causes, actionLabel+" "+strings.Join(quoted, ", ")+" defaults an input to github.token")
+		causes = append(causes, actionLabel+" "+strings.Join(quoted, ", ")+" "+verb+" github.token in "+pronoun+" metadata")
 	}
 	if len(causes) == 0 {
 		causes = append(causes, "the compiled job requests a workflow token")

--- a/internal/cli/hosted_test.go
+++ b/internal/cli/hosted_test.go
@@ -974,6 +974,25 @@ func TestBundleUsesActionsDetectsStepsAndLocks(t *testing.T) {
 	}
 }
 
+func TestGitHubTokenAdmissionDiagnosticDescribesActionMetadata(t *testing.T) {
+	for _, test := range []struct {
+		actions []string
+		want    string
+	}{
+		{actions: []string{"owner/action@v1"}, want: `action "owner/action@v1" references github.token in its metadata`},
+		{actions: []string{"owner/one@v1", "owner/two@v2"}, want: `actions "owner/one@v1", "owner/two@v2" reference github.token in their metadata`},
+	} {
+		artifact := compiler.PlanArtifact{
+			Job:           plan.Job{Workflow: plan.Workflow{LogicalJobID: "token"}},
+			Authorization: compiler.PlanAuthorization{GitHubTokenActions: test.actions},
+		}
+		_, detail := githubTokenAdmissionDiagnostic(artifact, "token issuance is unavailable")
+		if !strings.Contains(detail, test.want) {
+			t.Fatalf("githubTokenAdmissionDiagnostic() detail = %q, want %q", detail, test.want)
+		}
+	}
+}
+
 func TestUnprivilegedUploadAllowsCapabilityFreeConcurrentShellSteps(t *testing.T) {
 	bundle := compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: plan.Job{
 		Workflow: plan.Workflow{LogicalJobID: "concurrent-job"},

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -94,6 +94,17 @@ type actionRequirements struct {
 	requiredSecrets        map[string]bool
 }
 
+type actionPlanningContext struct {
+	workflowInputs        map[string]any
+	unknownWorkflowInputs map[string]bool
+	environment           map[string]string
+}
+
+type actionStepPlanningContext struct {
+	actionPlanningContext
+	condition string
+}
+
 // validateActionResolutions resolves each independent root invocation before
 // plan construction. It deliberately aggregates failures while sharing one
 // immutable source snapshot; no plan can be emitted unless every root passes.
@@ -216,21 +227,18 @@ func compileActionLocks(ctx context.Context, workspace string, actionSource Acti
 }
 
 func compileActionInvocations(ctx context.Context, workspace string, actionSource ActionSource, serverURL string, refs []string, suppliedInputs []map[string]string) (actionCompilation, error) {
-	return compileActionInvocationsWithStepContext(ctx, workspace, actionSource, serverURL, refs, suppliedInputs, nil, nil)
+	return compileActionInvocationsWithStepContext(ctx, workspace, actionSource, serverURL, refs, suppliedInputs, nil)
 }
 
-func compileActionInvocationsWithStepContext(ctx context.Context, workspace string, actionSource ActionSource, serverURL string, refs []string, suppliedInputs []map[string]string, conditions []string, environments []map[string]string) (actionCompilation, error) {
+func compileActionInvocationsWithStepContext(ctx context.Context, workspace string, actionSource ActionSource, serverURL string, refs []string, suppliedInputs []map[string]string, stepContexts []actionStepPlanningContext) (actionCompilation, error) {
 	if workspace == "" {
 		return actionCompilation{}, fmt.Errorf("workflow path must identify a repository root")
 	}
 	if suppliedInputs != nil && len(suppliedInputs) != len(refs) {
 		return actionCompilation{}, fmt.Errorf("action references and supplied inputs have different lengths")
 	}
-	if conditions != nil && len(conditions) != len(refs) {
-		return actionCompilation{}, fmt.Errorf("action references and conditions have different lengths")
-	}
-	if environments != nil && len(environments) != len(refs) {
-		return actionCompilation{}, fmt.Errorf("action references and environments have different lengths")
+	if stepContexts != nil && len(stepContexts) != len(refs) {
+		return actionCompilation{}, fmt.Errorf("action references and step contexts have different lengths")
 	}
 	abs, err := filepath.Abs(workspace)
 	if err != nil {
@@ -267,17 +275,17 @@ func compileActionInvocationsWithStepContext(ctx context.Context, workspace stri
 	var githubTokenActions []string
 	if suppliedInputs != nil {
 		for i, root := range roots {
-			var environment map[string]string
-			if environments != nil {
-				environment = knownValues(resolveKnownValues(environments[i], expression.Context{GitHub: map[string]any{"server_url": serverURL}}, nil))
+			var stepContext actionStepPlanningContext
+			if stepContexts != nil {
+				stepContext = stepContexts[i]
 			}
-			requirements, err := root.inspectInvocation(suppliedInputs[i], true, serverURL, environment)
+			requirements, err := root.inspectInvocation(suppliedInputs[i], true, serverURL, stepContext.actionPlanningContext)
 			if err != nil {
 				return actionCompilation{}, fmt.Errorf("compile action %q: %w", refs[i], err)
 			}
 			mainReachable := true
-			if conditions != nil {
-				run, known, conditionErr := expression.EvaluateKnownCondition(conditions[i], expression.ConditionContext{GitHub: map[string]any{"server_url": serverURL}}, nil)
+			if stepContexts != nil {
+				run, known, conditionErr := expression.EvaluateKnownCondition(stepContext.condition, expression.ConditionContext{Inputs: stepContext.workflowInputs, Env: stepContext.environment, GitHub: map[string]any{"server_url": serverURL}}, stepContext.unknownWorkflowInputs)
 				if conditionErr != nil {
 					return actionCompilation{}, fmt.Errorf("compile action %q condition: %w", refs[i], conditionErr)
 				}
@@ -394,7 +402,7 @@ func (b *actionLockBuilder) add(ctx context.Context, raw string, depth int) (*ac
 	return n, nil
 }
 
-func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAuthored bool, serverURL string, environment map[string]string) (actionRequirements, error) {
+func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAuthored bool, serverURL string, planning actionPlanningContext) (actionRequirements, error) {
 	requirements := actionRequirements{requiredSecrets: map[string]bool{}}
 	for _, suppliedName := range sortedKeys(supplied) {
 		value := supplied[suppliedName]
@@ -423,7 +431,7 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 		}
 		if workflowAuthored {
 			requirements.githubToken = requirements.githubToken || referencesToken
-			_, preparesInputs, preparationErr := n.preparationFields(serverURL, environment)
+			_, preparesInputs, preparationErr := n.preparationFields(serverURL, planning)
 			if preparationErr != nil {
 				return actionRequirements{}, preparationErr
 			}
@@ -440,12 +448,12 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 	if n.native {
 		return requirements, nil
 	}
-	effectiveInputs, unknownInputs, defaultsRequireToken, err := n.effectiveInputs(supplied, serverURL, workflowAuthored, environment)
+	effectiveInputs, unknownInputs, defaultsRequireToken, err := n.effectiveInputs(supplied, serverURL, workflowAuthored, planning)
 	if err != nil {
 		return actionRequirements{}, err
 	}
 	requirements.githubToken = requirements.githubToken || defaultsRequireToken
-	_, preparesInputs, err := n.preparationFields(serverURL, environment)
+	_, preparesInputs, err := n.preparationFields(serverURL, planning)
 	if err != nil {
 		return actionRequirements{}, err
 	}
@@ -461,13 +469,14 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 		requirements.githubToken = requirements.githubToken || requiresToken
 	}
 	for i, step := range n.metadata.Runs.Steps {
-		run, known, err := compositeStepCondition(step.If, effectiveInputs, unknownInputs, environment, serverURL)
+		run, known, err := compositeStepCondition(step.If, effectiveInputs, unknownInputs, planning.environment, serverURL)
 		if err != nil {
 			return actionRequirements{}, fmt.Errorf("composite action step %d condition: %w", i+1, err)
 		}
 		stepReachable := !known || run
-		stepEnvironment := knownValues(resolveKnownValues(step.Env, expression.Context{Inputs: effectiveInputs, Env: environment, GitHub: map[string]any{"server_url": serverURL}}, unknownInputs))
-		childEnvironment := mergeKnownValues(environment, stepEnvironment)
+		stepEnvironment := knownValues(resolveKnownValues(step.Env, expression.Context{Inputs: effectiveInputs, Env: planning.environment, GitHub: map[string]any{"server_url": serverURL}}, unknownInputs))
+		childPlanning := planning
+		childPlanning.environment = mergeKnownValues(planning.environment, stepEnvironment)
 		var child *actionNode
 		preparesEnvironment, preparesInputs := false, false
 		if step.Uses != "" {
@@ -475,7 +484,7 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 			if child == nil {
 				return actionRequirements{}, fmt.Errorf("composite action step %d child %q is missing", i+1, step.Uses)
 			}
-			preparesEnvironment, preparesInputs, err = child.preparationFields(serverURL, childEnvironment)
+			preparesEnvironment, preparesInputs, err = child.preparationFields(serverURL, childPlanning)
 			if err != nil {
 				return actionRequirements{}, fmt.Errorf("composite action step %d child %q: %w", i+1, step.Uses, err)
 			}
@@ -522,8 +531,8 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 				return actionRequirements{}, fmt.Errorf("composite action step %d child %q: bounded upload-artifact adapter: %w", i+1, step.Uses, err)
 			}
 		}
-		childInputs := resolveKnownValues(step.With, expression.Context{Inputs: effectiveInputs, Env: childEnvironment, GitHub: map[string]any{"server_url": serverURL}}, unknownInputs)
-		childRequirements, err := child.inspectInvocation(childInputs, false, serverURL, childEnvironment)
+		childInputs := resolveKnownValues(step.With, expression.Context{Inputs: effectiveInputs, Env: childPlanning.environment, GitHub: map[string]any{"server_url": serverURL}}, unknownInputs)
+		childRequirements, err := child.inspectInvocation(childInputs, false, serverURL, childPlanning)
 		if err != nil {
 			return actionRequirements{}, fmt.Errorf("composite action step %d child %q: %w", i+1, step.Uses, err)
 		}
@@ -536,7 +545,7 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 	return requirements, nil
 }
 
-func (n *actionNode) preparationFields(serverURL string, knownEnvironment map[string]string) (environment, inputs bool, err error) {
+func (n *actionNode) preparationFields(serverURL string, planning actionPlanningContext) (environment, inputs bool, err error) {
 	if n.lock.Source != "github" {
 		return false, false, nil
 	}
@@ -546,19 +555,19 @@ func (n *actionNode) preparationFields(serverURL string, knownEnvironment map[st
 	if n.metadata.Runs.Pre == "" {
 		return false, false, nil
 	}
-	run, known, err := expression.EvaluateKnownCondition(n.metadata.Runs.PreIf, expression.ConditionContext{Env: knownEnvironment, GitHub: map[string]any{"server_url": serverURL}}, nil)
+	run, known, err := expression.EvaluateKnownCondition(n.metadata.Runs.PreIf, expression.ConditionContext{Inputs: planning.workflowInputs, Env: planning.environment, GitHub: map[string]any{"server_url": serverURL}}, planning.unknownWorkflowInputs)
 	if err != nil {
 		return false, false, err
 	}
 	return true, !known || run, nil
 }
 
-func (n *actionNode) effectiveInputs(supplied map[string]string, serverURL string, workflowAuthored bool, environment map[string]string) (map[string]string, map[string]bool, bool, error) {
+func (n *actionNode) effectiveInputs(supplied map[string]string, serverURL string, workflowAuthored bool, planning actionPlanningContext) (map[string]string, map[string]bool, bool, error) {
 	inputs := make(map[string]string, len(n.metadata.Inputs)+len(supplied))
 	unknown := map[string]bool{}
 	resolvedSupplied := supplied
 	if workflowAuthored {
-		resolvedSupplied = resolveKnownValues(supplied, expression.Context{Env: environment, GitHub: map[string]any{"server_url": serverURL}}, nil)
+		resolvedSupplied = resolveKnownValues(supplied, expression.Context{WorkflowInputs: planning.workflowInputs, Env: planning.environment, GitHub: map[string]any{"server_url": serverURL}}, planning.unknownWorkflowInputs)
 	}
 	for _, name := range sortedKeys(resolvedSupplied) {
 		value := resolvedSupplied[name]

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -216,10 +216,10 @@ func compileActionLocks(ctx context.Context, workspace string, actionSource Acti
 }
 
 func compileActionInvocations(ctx context.Context, workspace string, actionSource ActionSource, serverURL string, refs []string, suppliedInputs []map[string]string) (actionCompilation, error) {
-	return compileActionInvocationsWithConditions(ctx, workspace, actionSource, serverURL, refs, suppliedInputs, nil)
+	return compileActionInvocationsWithStepContext(ctx, workspace, actionSource, serverURL, refs, suppliedInputs, nil, nil)
 }
 
-func compileActionInvocationsWithConditions(ctx context.Context, workspace string, actionSource ActionSource, serverURL string, refs []string, suppliedInputs []map[string]string, conditions []string) (actionCompilation, error) {
+func compileActionInvocationsWithStepContext(ctx context.Context, workspace string, actionSource ActionSource, serverURL string, refs []string, suppliedInputs []map[string]string, conditions []string, environments []map[string]string) (actionCompilation, error) {
 	if workspace == "" {
 		return actionCompilation{}, fmt.Errorf("workflow path must identify a repository root")
 	}
@@ -228,6 +228,9 @@ func compileActionInvocationsWithConditions(ctx context.Context, workspace strin
 	}
 	if conditions != nil && len(conditions) != len(refs) {
 		return actionCompilation{}, fmt.Errorf("action references and conditions have different lengths")
+	}
+	if environments != nil && len(environments) != len(refs) {
+		return actionCompilation{}, fmt.Errorf("action references and environments have different lengths")
 	}
 	abs, err := filepath.Abs(workspace)
 	if err != nil {
@@ -264,7 +267,11 @@ func compileActionInvocationsWithConditions(ctx context.Context, workspace strin
 	var githubTokenActions []string
 	if suppliedInputs != nil {
 		for i, root := range roots {
-			requirements, err := root.inspectInvocation(suppliedInputs[i], true, serverURL)
+			var environment map[string]string
+			if environments != nil {
+				environment = knownValues(resolveKnownValues(environments[i], expression.Context{GitHub: map[string]any{"server_url": serverURL}}, nil))
+			}
+			requirements, err := root.inspectInvocation(suppliedInputs[i], true, serverURL, environment)
 			if err != nil {
 				return actionCompilation{}, fmt.Errorf("compile action %q: %w", refs[i], err)
 			}
@@ -387,7 +394,7 @@ func (b *actionLockBuilder) add(ctx context.Context, raw string, depth int) (*ac
 	return n, nil
 }
 
-func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAuthored bool, serverURL string) (actionRequirements, error) {
+func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAuthored bool, serverURL string, environment map[string]string) (actionRequirements, error) {
 	requirements := actionRequirements{requiredSecrets: map[string]bool{}}
 	for _, suppliedName := range sortedKeys(supplied) {
 		value := supplied[suppliedName]
@@ -416,7 +423,7 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 		}
 		if workflowAuthored {
 			requirements.githubToken = requirements.githubToken || referencesToken
-			_, preparesInputs, preparationErr := n.preparationFields(serverURL)
+			_, preparesInputs, preparationErr := n.preparationFields(serverURL, environment)
 			if preparationErr != nil {
 				return actionRequirements{}, preparationErr
 			}
@@ -433,12 +440,12 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 	if n.native {
 		return requirements, nil
 	}
-	effectiveInputs, unknownInputs, defaultsRequireToken, err := n.effectiveInputs(supplied, serverURL, workflowAuthored)
+	effectiveInputs, unknownInputs, defaultsRequireToken, err := n.effectiveInputs(supplied, serverURL, workflowAuthored, environment)
 	if err != nil {
 		return actionRequirements{}, err
 	}
 	requirements.githubToken = requirements.githubToken || defaultsRequireToken
-	_, preparesInputs, err := n.preparationFields(serverURL)
+	_, preparesInputs, err := n.preparationFields(serverURL, environment)
 	if err != nil {
 		return actionRequirements{}, err
 	}
@@ -454,11 +461,13 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 		requirements.githubToken = requirements.githubToken || requiresToken
 	}
 	for i, step := range n.metadata.Runs.Steps {
-		run, known, err := compositeStepCondition(step.If, effectiveInputs, unknownInputs, serverURL)
+		run, known, err := compositeStepCondition(step.If, effectiveInputs, unknownInputs, environment, serverURL)
 		if err != nil {
 			return actionRequirements{}, fmt.Errorf("composite action step %d condition: %w", i+1, err)
 		}
 		stepReachable := !known || run
+		stepEnvironment := knownValues(resolveKnownValues(step.Env, expression.Context{Inputs: effectiveInputs, Env: environment, GitHub: map[string]any{"server_url": serverURL}}, unknownInputs))
+		childEnvironment := mergeKnownValues(environment, stepEnvironment)
 		var child *actionNode
 		preparesEnvironment, preparesInputs := false, false
 		if step.Uses != "" {
@@ -466,7 +475,7 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 			if child == nil {
 				return actionRequirements{}, fmt.Errorf("composite action step %d child %q is missing", i+1, step.Uses)
 			}
-			preparesEnvironment, preparesInputs, err = child.preparationFields(serverURL)
+			preparesEnvironment, preparesInputs, err = child.preparationFields(serverURL, childEnvironment)
 			if err != nil {
 				return actionRequirements{}, fmt.Errorf("composite action step %d child %q: %w", i+1, step.Uses, err)
 			}
@@ -513,8 +522,8 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 				return actionRequirements{}, fmt.Errorf("composite action step %d child %q: bounded upload-artifact adapter: %w", i+1, step.Uses, err)
 			}
 		}
-		childInputs := resolveKnownCompositeValues(step.With, effectiveInputs, unknownInputs, serverURL)
-		childRequirements, err := child.inspectInvocation(childInputs, false, serverURL)
+		childInputs := resolveKnownValues(step.With, expression.Context{Inputs: effectiveInputs, Env: childEnvironment, GitHub: map[string]any{"server_url": serverURL}}, unknownInputs)
+		childRequirements, err := child.inspectInvocation(childInputs, false, serverURL, childEnvironment)
 		if err != nil {
 			return actionRequirements{}, fmt.Errorf("composite action step %d child %q: %w", i+1, step.Uses, err)
 		}
@@ -527,7 +536,7 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 	return requirements, nil
 }
 
-func (n *actionNode) preparationFields(serverURL string) (environment, inputs bool, err error) {
+func (n *actionNode) preparationFields(serverURL string, knownEnvironment map[string]string) (environment, inputs bool, err error) {
 	if n.lock.Source != "github" {
 		return false, false, nil
 	}
@@ -537,19 +546,19 @@ func (n *actionNode) preparationFields(serverURL string) (environment, inputs bo
 	if n.metadata.Runs.Pre == "" {
 		return false, false, nil
 	}
-	run, known, err := expression.EvaluateKnownCondition(n.metadata.Runs.PreIf, expression.ConditionContext{GitHub: map[string]any{"server_url": serverURL}}, nil)
+	run, known, err := expression.EvaluateKnownCondition(n.metadata.Runs.PreIf, expression.ConditionContext{Env: knownEnvironment, GitHub: map[string]any{"server_url": serverURL}}, nil)
 	if err != nil {
 		return false, false, err
 	}
 	return true, !known || run, nil
 }
 
-func (n *actionNode) effectiveInputs(supplied map[string]string, serverURL string, workflowAuthored bool) (map[string]string, map[string]bool, bool, error) {
+func (n *actionNode) effectiveInputs(supplied map[string]string, serverURL string, workflowAuthored bool, environment map[string]string) (map[string]string, map[string]bool, bool, error) {
 	inputs := make(map[string]string, len(n.metadata.Inputs)+len(supplied))
 	unknown := map[string]bool{}
 	resolvedSupplied := supplied
 	if workflowAuthored {
-		resolvedSupplied = resolveKnownWorkflowValues(supplied, serverURL)
+		resolvedSupplied = resolveKnownValues(supplied, expression.Context{Env: environment, GitHub: map[string]any{"server_url": serverURL}}, nil)
 	}
 	for _, name := range sortedKeys(resolvedSupplied) {
 		value := resolvedSupplied[name]
@@ -594,67 +603,46 @@ func (n *actionNode) effectiveInputs(supplied map[string]string, serverURL strin
 	return inputs, unknown, requiresToken, nil
 }
 
-func resolveKnownWorkflowValues(values map[string]string, serverURL string) map[string]string {
-	resolved := make(map[string]string, len(values))
-	for name, value := range values {
-		resolved[name] = value
-		if !strings.Contains(value, "${{") {
-			continue
-		}
-		evaluated, known, err := expression.EvaluateKnownStep(value, expression.Context{GitHub: map[string]any{"server_url": serverURL}}, nil)
-		if err == nil && known {
-			resolved[name] = evaluated
-		}
-	}
-	return resolved
-}
-
-func compositeStepCondition(condition string, inputs map[string]string, unknownInputs map[string]bool, serverURL string) (bool, bool, error) {
+func compositeStepCondition(condition string, inputs map[string]string, unknownInputs map[string]bool, environment map[string]string, serverURL string) (bool, bool, error) {
 	conditionInputs := make(map[string]any, len(inputs))
 	for name, value := range inputs {
 		conditionInputs[name] = value
 	}
-	return expression.EvaluateKnownCondition(condition, expression.ConditionContext{Inputs: conditionInputs, GitHub: map[string]any{"server_url": serverURL}}, unknownInputs)
+	return expression.EvaluateKnownCondition(condition, expression.ConditionContext{Inputs: conditionInputs, Env: environment, GitHub: map[string]any{"server_url": serverURL}}, unknownInputs)
 }
 
-func resolveKnownCompositeValues(values, inputs map[string]string, unknownInputs map[string]bool, serverURL string) map[string]string {
+func resolveKnownValues(values map[string]string, context expression.Context, unknownInputs map[string]bool) map[string]string {
 	resolved := make(map[string]string, len(values))
-	context := expression.Context{Inputs: inputs, GitHub: map[string]any{"server_url": serverURL}}
 	for _, name := range sortedKeys(values) {
 		original := values[name]
-		inputNames, dynamic, err := expression.TemplateInputReferences(original)
-		unknown := dynamic && len(unknownInputs) != 0
-		for _, inputName := range inputNames {
-			unknown = unknown || unknownInputs[inputName]
-		}
-		if unknown || err != nil {
-			resolved[name] = original
-			continue
-		}
-		for _, contextName := range []string{"env", "job", "matrix", "needs", "runner", "secrets", "services", "steps", "vars"} {
-			usesContext, contextErr := expression.TemplateUsesContext(original, contextName)
-			if contextErr != nil || usesContext {
-				unknown = true
-				break
-			}
-		}
-		if unknown {
-			resolved[name] = original
-			continue
-		}
-		usesUnknownGitHub, githubErr := expression.TemplateUsesGitHubPropertyOutside(original, "server_url")
-		usesSerializedContext, tokenErr := expression.ReferencesStepGitHubToken(original)
-		if githubErr != nil || tokenErr != nil || usesUnknownGitHub || usesSerializedContext {
-			resolved[name] = original
-			continue
-		}
-		value, err := expression.EvaluateStep(original, context)
-		if err != nil {
+		value, known, err := expression.EvaluateKnownStep(original, context, unknownInputs)
+		if err != nil || !known {
 			value = original
 		}
 		resolved[name] = value
 	}
 	return resolved
+}
+
+func knownValues(values map[string]string) map[string]string {
+	known := make(map[string]string, len(values))
+	for name, value := range values {
+		if !strings.Contains(value, "${{") {
+			known[name] = value
+		}
+	}
+	return known
+}
+
+func mergeKnownValues(base, overlay map[string]string) map[string]string {
+	merged := make(map[string]string, len(base)+len(overlay))
+	for name, value := range base {
+		merged[name] = value
+	}
+	for name, value := range overlay {
+		merged[name] = value
+	}
+	return merged
 }
 
 func inspectCompositeTemplate(field, template string, inputs map[string]string, unknownInputs map[string]bool, serverURL string) (bool, error) {

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -428,9 +428,9 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 	if n.runtime != metadata.RuntimeComposite {
 		return requirements, nil
 	}
-	effectiveInputs, inputsKnown := n.effectiveInputs(supplied)
+	effectiveInputs, unknownInputs := n.effectiveInputs(supplied)
 	for _, name := range sortedKeys(n.metadata.Outputs) {
-		requiresToken, err := inspectCompositeTemplate("output "+name, n.metadata.Outputs[name].Value, effectiveInputs, inputsKnown, serverURL)
+		requiresToken, err := inspectCompositeTemplate("output "+name, n.metadata.Outputs[name].Value, effectiveInputs, unknownInputs, serverURL)
 		if err != nil {
 			return actionRequirements{}, err
 		}
@@ -445,7 +445,7 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 			{name: "input", values: step.With},
 		} {
 			for _, name := range sortedKeys(field.values) {
-				requiresToken, err := inspectCompositeTemplate(fmt.Sprintf("step %d %s %q", i+1, field.name, name), field.values[name], effectiveInputs, inputsKnown, serverURL)
+				requiresToken, err := inspectCompositeTemplate(fmt.Sprintf("step %d %s %q", i+1, field.name, name), field.values[name], effectiveInputs, unknownInputs, serverURL)
 				if err != nil {
 					return actionRequirements{}, err
 				}
@@ -462,7 +462,7 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 			if field.value == "" {
 				continue
 			}
-			requiresToken, err := inspectCompositeTemplate(fmt.Sprintf("step %d %s", i+1, field.name), field.value, effectiveInputs, inputsKnown, serverURL)
+			requiresToken, err := inspectCompositeTemplate(fmt.Sprintf("step %d %s", i+1, field.name), field.value, effectiveInputs, unknownInputs, serverURL)
 			if err != nil {
 				return actionRequirements{}, err
 			}
@@ -493,9 +493,9 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 	return requirements, nil
 }
 
-func (n *actionNode) effectiveInputs(supplied map[string]string) (map[string]string, bool) {
+func (n *actionNode) effectiveInputs(supplied map[string]string) (map[string]string, map[string]bool) {
 	inputs := make(map[string]string, len(n.metadata.Inputs)+len(supplied))
-	known := true
+	unknown := map[string]bool{}
 	for _, name := range sortedKeys(n.metadata.Inputs) {
 		definition := n.metadata.Inputs[name]
 		value := ""
@@ -503,23 +503,26 @@ func (n *actionNode) effectiveInputs(supplied map[string]string) (map[string]str
 			value = *definition.Default
 		}
 		if strings.Contains(value, "${{") {
-			known = false
+			unknown[name] = true
 			continue
 		}
 		inputs[name] = value
 	}
 	for _, name := range sortedKeys(supplied) {
 		value := supplied[name]
+		name = strings.ToLower(name)
+		delete(inputs, name)
+		delete(unknown, name)
 		if strings.Contains(value, "${{") {
-			known = false
+			unknown[name] = true
 			continue
 		}
-		inputs[strings.ToLower(name)] = value
+		inputs[name] = value
 	}
-	return inputs, known
+	return inputs, unknown
 }
 
-func inspectCompositeTemplate(field, template string, inputs map[string]string, inputsKnown bool, serverURL string) (bool, error) {
+func inspectCompositeTemplate(field, template string, inputs map[string]string, unknownInputs map[string]bool, serverURL string) (bool, error) {
 	referencesEvent, err := expression.TemplateReferencesGitHubEvent(template)
 	if err != nil {
 		return false, fmt.Errorf("composite action %s: %w", field, err)
@@ -541,12 +544,17 @@ func inspectCompositeTemplate(field, template string, inputs map[string]string, 
 	if !referencesToken {
 		return false, nil
 	}
-	usesInputs, err := expression.TemplateUsesContext(template, "inputs")
+	inputNames, dynamicInputs, err := expression.TemplateContextReferences(template, "inputs")
 	if err != nil {
 		return false, fmt.Errorf("composite action %s: %w", field, err)
 	}
-	if usesInputs && !inputsKnown {
+	if dynamicInputs && len(unknownInputs) != 0 {
 		return true, nil
+	}
+	for _, name := range inputNames {
+		if unknownInputs[name] {
+			return true, nil
+		}
 	}
 	usesUnknownGitHubProperty, err := expression.TemplateUsesGitHubPropertyOutside(template, "server_url", "token")
 	if err != nil {

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -529,43 +529,11 @@ func (n *actionNode) effectiveInputs(supplied map[string]string) (map[string]str
 }
 
 func compositeStepCondition(condition string, inputs map[string]string, unknownInputs map[string]bool) (bool, bool, error) {
-	names, dynamic, err := expression.ConditionInputReferences(condition)
-	if err != nil {
-		return false, false, err
-	}
-	if dynamic && len(unknownInputs) != 0 {
-		return false, false, nil
-	}
-	for _, name := range names {
-		if unknownInputs[name] {
-			return false, false, nil
-		}
-	}
-	status, err := expression.ReferencesStatusFunction(condition)
-	if err != nil {
-		return false, false, err
-	}
-	if status {
-		return false, false, nil
-	}
-	for _, contextName := range []string{"env", "github", "job", "matrix", "needs", "runner", "steps", "vars"} {
-		usesContext, err := expression.ConditionUsesContext(condition, contextName)
-		if err != nil {
-			return false, false, err
-		}
-		if usesContext {
-			return false, false, nil
-		}
-	}
 	conditionInputs := make(map[string]any, len(inputs))
 	for name, value := range inputs {
 		conditionInputs[name] = value
 	}
-	run, err := expression.EvaluateCondition(condition, expression.ConditionContext{Inputs: conditionInputs})
-	if err != nil {
-		return false, false, nil
-	}
-	return run, true, nil
+	return expression.EvaluateKnownInputCondition(condition, conditionInputs, unknownInputs)
 }
 
 func resolveKnownCompositeValues(values, inputs map[string]string, unknownInputs map[string]bool, serverURL string) map[string]string {
@@ -579,6 +547,17 @@ func resolveKnownCompositeValues(values, inputs map[string]string, unknownInputs
 			unknown = unknown || unknownInputs[inputName]
 		}
 		if unknown || err != nil {
+			resolved[name] = original
+			continue
+		}
+		for _, contextName := range []string{"env", "github", "job", "matrix", "needs", "runner", "secrets", "services", "steps", "vars"} {
+			usesContext, contextErr := expression.TemplateUsesContext(original, contextName)
+			if contextErr != nil || usesContext {
+				unknown = true
+				break
+			}
+		}
+		if unknown {
 			resolved[name] = original
 			continue
 		}
@@ -625,21 +604,12 @@ func inspectCompositeTemplate(field, template string, inputs map[string]string, 
 			return true, nil
 		}
 	}
-	usesUnknownGitHubProperty, err := expression.TemplateUsesGitHubPropertyOutside(template, "server_url", "token")
+	usesRuntimeValue, err := expression.GitHubTokenReferencesRuntimeValue(template)
 	if err != nil {
 		return false, fmt.Errorf("composite action %s: %w", field, err)
 	}
-	if usesUnknownGitHubProperty {
+	if usesRuntimeValue {
 		return true, nil
-	}
-	for _, contextName := range []string{"env", "job", "matrix", "needs", "runner", "services", "steps", "vars"} {
-		usesContext, err := expression.TemplateUsesContext(template, contextName)
-		if err != nil {
-			return false, fmt.Errorf("composite action %s: %w", field, err)
-		}
-		if usesContext {
-			return true, nil
-		}
 	}
 	_, err = expression.EvaluateStep(template, expression.Context{Inputs: inputs, GitHub: map[string]any{"server_url": serverURL}})
 	return err != nil, nil

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -102,6 +102,11 @@ type actionPlanningContext struct {
 	preparationEnvironment map[string]string
 }
 
+type actionInvocationInputs struct {
+	main        map[string]string
+	preparation map[string]string
+}
+
 type actionStepPlanningContext struct {
 	actionPlanningContext
 	condition string
@@ -281,7 +286,8 @@ func compileActionInvocationsWithStepContext(ctx context.Context, workspace stri
 			if stepContexts != nil {
 				stepContext = stepContexts[i]
 			}
-			requirements, err := root.inspectInvocation(suppliedInputs[i], true, serverURL, stepContext.actionPlanningContext)
+			invocationInputs := actionInvocationInputs{main: suppliedInputs[i], preparation: suppliedInputs[i]}
+			requirements, err := root.inspectInvocation(invocationInputs, true, serverURL, stepContext.actionPlanningContext)
 			if err != nil {
 				return actionCompilation{}, fmt.Errorf("compile action %q: %w", refs[i], err)
 			}
@@ -404,10 +410,10 @@ func (b *actionLockBuilder) add(ctx context.Context, raw string, depth int) (*ac
 	return n, nil
 }
 
-func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAuthored bool, serverURL string, planning actionPlanningContext) (actionRequirements, error) {
+func (n *actionNode) inspectInvocation(supplied actionInvocationInputs, workflowAuthored bool, serverURL string, planning actionPlanningContext) (actionRequirements, error) {
 	requirements := actionRequirements{requiredSecrets: map[string]bool{}}
-	for _, suppliedName := range sortedKeys(supplied) {
-		value := supplied[suppliedName]
+	for _, suppliedName := range sortedKeys(supplied.main) {
+		value := supplied.main[suppliedName]
 		referencesEvent, err := expression.TemplateReferencesGitHubEvent(value)
 		if err != nil {
 			return actionRequirements{}, fmt.Errorf("action input %q: %w", suppliedName, err)
@@ -450,7 +456,13 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 	if n.native {
 		return requirements, nil
 	}
-	effectiveInputs, unknownInputs, defaultsRequireToken, err := n.effectiveInputs(supplied, serverURL, workflowAuthored, planning)
+	effectiveInputs, unknownInputs, defaultsRequireToken, err := n.effectiveInputs(supplied.main, serverURL, workflowAuthored, planning)
+	if err != nil {
+		return actionRequirements{}, err
+	}
+	preparationPlanning := planning
+	preparationPlanning.environment = planning.preparationEnvironment
+	preparationInputs, unknownPreparationInputs, preparationDefaultsRequireToken, err := n.effectiveInputs(supplied.preparation, serverURL, workflowAuthored, preparationPlanning)
 	if err != nil {
 		return actionRequirements{}, err
 	}
@@ -459,7 +471,7 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 	if err != nil {
 		return actionRequirements{}, err
 	}
-	requirements.preparationGitHubToken = requirements.preparationGitHubToken || preparesInputs && defaultsRequireToken
+	requirements.preparationGitHubToken = requirements.preparationGitHubToken || preparesInputs && preparationDefaultsRequireToken
 	if n.runtime != metadata.RuntimeComposite {
 		requirements.preparationMutatesEnv = preparesInputs
 		return requirements, nil
@@ -483,7 +495,7 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 		}
 		stepReachable := !known || run
 		stepEnvironment := knownValues(resolveKnownValues(step.Env, expression.Context{Inputs: effectiveInputs, Env: currentPlanning.environment, GitHub: map[string]any{"server_url": serverURL}}, unknownInputs))
-		preparationStepEnvironment := knownValues(resolveKnownValues(step.Env, expression.Context{Inputs: effectiveInputs, Env: currentPlanning.preparationEnvironment, GitHub: map[string]any{"server_url": serverURL}}, unknownInputs))
+		preparationStepEnvironment := knownValues(resolveKnownValues(step.Env, expression.Context{Inputs: preparationInputs, Env: currentPlanning.preparationEnvironment, GitHub: map[string]any{"server_url": serverURL}}, unknownPreparationInputs))
 		childPlanning := currentPlanning
 		childPlanning.environment = mergeKnownValues(currentPlanning.environment, stepEnvironment)
 		childPlanning.preparationEnvironment = mergeKnownValues(currentPlanning.preparationEnvironment, preparationStepEnvironment)
@@ -511,9 +523,15 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 				if err != nil {
 					return actionRequirements{}, err
 				}
-				requirements.githubToken = requirements.githubToken || stepReachable && requiresToken
 				preparesField := field.name == "environment" && preparesEnvironment || field.name == "input" && preparesInputs
-				requirements.preparationGitHubToken = requirements.preparationGitHubToken || preparesField && requiresToken
+				requirements.githubToken = requirements.githubToken || stepReachable && requiresToken
+				if preparesField {
+					preparationRequiresToken, err := inspectCompositeTemplate(fmt.Sprintf("step %d %s %q", i+1, field.name, name), field.values[name], preparationInputs, unknownPreparationInputs, serverURL)
+					if err != nil {
+						return actionRequirements{}, err
+					}
+					requirements.preparationGitHubToken = requirements.preparationGitHubToken || preparationRequiresToken
+				}
 			}
 		}
 		for _, field := range []struct {
@@ -541,9 +559,12 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 				return actionRequirements{}, fmt.Errorf("composite action step %d child %q: bounded upload-artifact adapter: %w", i+1, step.Uses, err)
 			}
 		}
-		// Composite child env and with maps are sibling fields: runtime resolves
-		// both against the parent context before overlaying the child's env.
-		childInputs := resolveKnownValues(step.With, expression.Context{Inputs: effectiveInputs, Env: currentPlanning.environment, GitHub: map[string]any{"server_url": serverURL}}, unknownInputs)
+		// Main execution resolves sibling env and with maps against the parent.
+		// Preparation overlays the child env before resolving its inputs.
+		childInputs := actionInvocationInputs{
+			main:        resolveKnownValues(step.With, expression.Context{Inputs: effectiveInputs, Env: currentPlanning.environment, GitHub: map[string]any{"server_url": serverURL}}, unknownInputs),
+			preparation: resolveKnownValues(step.With, expression.Context{Inputs: preparationInputs, Env: childPlanning.preparationEnvironment, GitHub: map[string]any{"server_url": serverURL}}, unknownPreparationInputs),
+		}
 		childRequirements, err := child.inspectInvocation(childInputs, false, serverURL, childPlanning)
 		if err != nil {
 			return actionRequirements{}, fmt.Errorf("composite action step %d child %q: %w", i+1, step.Uses, err)

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -544,7 +544,7 @@ func inspectCompositeTemplate(field, template string, inputs map[string]string, 
 	if !referencesToken {
 		return false, nil
 	}
-	inputNames, dynamicInputs, err := expression.TemplateContextReferences(template, "inputs")
+	inputNames, dynamicInputs, err := expression.GitHubTokenInputReferences(template)
 	if err != nil {
 		return false, fmt.Errorf("composite action %s: %w", field, err)
 	}

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -216,11 +216,18 @@ func compileActionLocks(ctx context.Context, workspace string, actionSource Acti
 }
 
 func compileActionInvocations(ctx context.Context, workspace string, actionSource ActionSource, serverURL string, refs []string, suppliedInputs []map[string]string) (actionCompilation, error) {
+	return compileActionInvocationsWithConditions(ctx, workspace, actionSource, serverURL, refs, suppliedInputs, nil)
+}
+
+func compileActionInvocationsWithConditions(ctx context.Context, workspace string, actionSource ActionSource, serverURL string, refs []string, suppliedInputs []map[string]string, conditions []string) (actionCompilation, error) {
 	if workspace == "" {
 		return actionCompilation{}, fmt.Errorf("workflow path must identify a repository root")
 	}
 	if suppliedInputs != nil && len(suppliedInputs) != len(refs) {
 		return actionCompilation{}, fmt.Errorf("action references and supplied inputs have different lengths")
+	}
+	if conditions != nil && len(conditions) != len(refs) {
+		return actionCompilation{}, fmt.Errorf("action references and conditions have different lengths")
 	}
 	abs, err := filepath.Abs(workspace)
 	if err != nil {
@@ -261,8 +268,17 @@ func compileActionInvocations(ctx context.Context, workspace string, actionSourc
 			if err != nil {
 				return actionCompilation{}, fmt.Errorf("compile action %q: %w", refs[i], err)
 			}
-			requiresGitHubToken = requiresGitHubToken || requirements.githubToken || requirements.preparationGitHubToken
-			if requirements.githubToken || requirements.preparationGitHubToken {
+			mainReachable := true
+			if conditions != nil {
+				run, known, conditionErr := expression.EvaluateKnownCondition(conditions[i], expression.ConditionContext{GitHub: map[string]any{"server_url": serverURL}}, nil)
+				if conditionErr != nil {
+					return actionCompilation{}, fmt.Errorf("compile action %q condition: %w", refs[i], conditionErr)
+				}
+				mainReachable = !known || run
+			}
+			requiresToken := requirements.preparationGitHubToken || mainReachable && requirements.githubToken
+			requiresGitHubToken = requiresGitHubToken || requiresToken
+			if requiresToken {
 				githubTokenActions = append(githubTokenActions, refs[i])
 			}
 			for name := range requirements.requiredSecrets {
@@ -400,6 +416,11 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 		}
 		if workflowAuthored {
 			requirements.githubToken = requirements.githubToken || referencesToken
+			_, preparesInputs, preparationErr := n.preparationFields(serverURL)
+			if preparationErr != nil {
+				return actionRequirements{}, preparationErr
+			}
+			requirements.preparationGitHubToken = requirements.preparationGitHubToken || preparesInputs && referencesToken
 		}
 		input, declared := n.metadata.Inputs[strings.ToLower(suppliedName)]
 		for _, name := range names {
@@ -412,29 +433,19 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 	if n.native {
 		return requirements, nil
 	}
-	for _, name := range sortedKeys(n.metadata.Inputs) {
-		input := n.metadata.Inputs[name]
-		if input.Default == nil || hasActionInput(supplied, name) {
-			continue
-		}
-		if err := expression.ValidateActionInputDefault(*input.Default); err != nil {
-			return actionRequirements{}, fmt.Errorf("action input %q default: %w", name, err)
-		}
-		referencesToken, err := expression.ActionInputDefaultRequiresGitHubToken(*input.Default, serverURL)
-		if err != nil {
-			return actionRequirements{}, fmt.Errorf("action input %q default: %w", name, err)
-		}
-		requirements.githubToken = requirements.githubToken || referencesToken
-		_, preparesInputs, preparationErr := n.preparationFields(serverURL)
-		if preparationErr != nil {
-			return actionRequirements{}, preparationErr
-		}
-		requirements.preparationGitHubToken = requirements.preparationGitHubToken || preparesInputs && referencesToken
+	effectiveInputs, unknownInputs, defaultsRequireToken, err := n.effectiveInputs(supplied, serverURL, workflowAuthored)
+	if err != nil {
+		return actionRequirements{}, err
 	}
+	requirements.githubToken = requirements.githubToken || defaultsRequireToken
+	_, preparesInputs, err := n.preparationFields(serverURL)
+	if err != nil {
+		return actionRequirements{}, err
+	}
+	requirements.preparationGitHubToken = requirements.preparationGitHubToken || preparesInputs && defaultsRequireToken
 	if n.runtime != metadata.RuntimeComposite {
 		return requirements, nil
 	}
-	effectiveInputs, unknownInputs := n.effectiveInputs(supplied, serverURL)
 	for _, name := range sortedKeys(n.metadata.Outputs) {
 		requiresToken, err := inspectCompositeTemplate("output "+name, n.metadata.Outputs[name].Value, effectiveInputs, unknownInputs, serverURL)
 		if err != nil {
@@ -533,11 +544,15 @@ func (n *actionNode) preparationFields(serverURL string) (environment, inputs bo
 	return true, !known || run, nil
 }
 
-func (n *actionNode) effectiveInputs(supplied map[string]string, serverURL string) (map[string]string, map[string]bool) {
+func (n *actionNode) effectiveInputs(supplied map[string]string, serverURL string, workflowAuthored bool) (map[string]string, map[string]bool, bool, error) {
 	inputs := make(map[string]string, len(n.metadata.Inputs)+len(supplied))
 	unknown := map[string]bool{}
-	for _, name := range sortedKeys(supplied) {
-		value := supplied[name]
+	resolvedSupplied := supplied
+	if workflowAuthored {
+		resolvedSupplied = resolveKnownWorkflowValues(supplied, serverURL)
+	}
+	for _, name := range sortedKeys(resolvedSupplied) {
+		value := resolvedSupplied[name]
 		name = strings.ToLower(name)
 		if strings.Contains(value, "${{") {
 			unknown[name] = true
@@ -545,6 +560,7 @@ func (n *actionNode) effectiveInputs(supplied map[string]string, serverURL strin
 		}
 		inputs[name] = value
 	}
+	requiresToken := false
 	for _, name := range sortedKeys(n.metadata.Inputs) {
 		if _, ok := inputs[name]; ok || unknown[name] {
 			continue
@@ -554,26 +570,43 @@ func (n *actionNode) effectiveInputs(supplied map[string]string, serverURL strin
 			continue
 		}
 		value := *definition.Default
+		if err := expression.ValidateActionInputDefault(value); err != nil {
+			return nil, nil, false, fmt.Errorf("action input %q default: %w", name, err)
+		}
+		defaultRequiresToken, err := expression.GitHubTokenRequiresEvaluation(value, expression.Context{Inputs: inputs, GitHub: map[string]any{"server_url": serverURL}}, unknown)
+		if err != nil {
+			return nil, nil, false, fmt.Errorf("action input %q default: %w", name, err)
+		}
+		requiresToken = requiresToken || defaultRequiresToken
 		if strings.Contains(value, "${{") {
-			inputNames, dynamic, referenceErr := expression.TemplateInputReferences(value)
-			dependsOnUnknown := dynamic && len(unknown) != 0
-			for _, inputName := range inputNames {
-				dependsOnUnknown = dependsOnUnknown || unknown[inputName]
+			var known bool
+			value, known, err = expression.EvaluateKnownStep(value, expression.Context{Inputs: inputs, GitHub: map[string]any{"server_url": serverURL}}, unknown)
+			if err != nil {
+				return nil, nil, false, fmt.Errorf("action input %q default: %w", name, err)
 			}
-			if referenceErr != nil || dependsOnUnknown {
-				unknown[name] = true
-				continue
-			}
-			var err error
-			value, err = expression.EvaluateActionInputDefault(value, expression.Context{Inputs: inputs, GitHub: map[string]any{"server_url": serverURL}})
-			if err != nil || strings.Contains(value, "${{") {
+			if !known || strings.Contains(value, "${{") {
 				unknown[name] = true
 				continue
 			}
 		}
 		inputs[name] = value
 	}
-	return inputs, unknown
+	return inputs, unknown, requiresToken, nil
+}
+
+func resolveKnownWorkflowValues(values map[string]string, serverURL string) map[string]string {
+	resolved := make(map[string]string, len(values))
+	for name, value := range values {
+		resolved[name] = value
+		if !strings.Contains(value, "${{") {
+			continue
+		}
+		evaluated, known, err := expression.EvaluateKnownStep(value, expression.Context{GitHub: map[string]any{"server_url": serverURL}}, nil)
+		if err == nil && known {
+			resolved[name] = evaluated
+		}
+	}
+	return resolved
 }
 
 func compositeStepCondition(condition string, inputs map[string]string, unknownInputs map[string]bool, serverURL string) (bool, bool, error) {
@@ -651,15 +684,6 @@ func inspectCompositeTemplate(field, template string, inputs map[string]string, 
 		return false, fmt.Errorf("composite action %s: %w", field, err)
 	}
 	return requiresToken, nil
-}
-
-func hasActionInput(inputs map[string]string, name string) bool {
-	for candidate := range inputs {
-		if strings.EqualFold(candidate, name) {
-			return true
-		}
-	}
-	return false
 }
 
 func (b *actionLockBuilder) describe(ctx context.Context, raw string) (string, plan.ActionLock, string, string, error) {

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -606,7 +606,7 @@ func inspectCompositeTemplate(field, template string, inputs map[string]string, 
 	if len(names) != 0 {
 		return false, fmt.Errorf("composite action %s: composite action metadata cannot grant secret authority", field)
 	}
-	referencesToken, err := expression.ReferencesGitHubToken(template)
+	referencesToken, err := expression.ReferencesCompositeStepGitHubToken(template)
 	if err != nil {
 		return false, fmt.Errorf("composite action %s: %w", field, err)
 	}

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -437,6 +437,11 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 		requirements.githubToken = requirements.githubToken || requiresToken
 	}
 	for i, step := range n.metadata.Runs.Steps {
+		run, known, err := compositeStepCondition(step.If, effectiveInputs, unknownInputs)
+		if err != nil {
+			return actionRequirements{}, fmt.Errorf("composite action step %d condition: %w", i+1, err)
+		}
+		stepReachable := !known || run
 		for _, field := range []struct {
 			name   string
 			values map[string]string
@@ -449,7 +454,7 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 				if err != nil {
 					return actionRequirements{}, err
 				}
-				requirements.githubToken = requirements.githubToken || requiresToken
+				requirements.githubToken = requirements.githubToken || stepReachable && requiresToken
 			}
 		}
 		for _, field := range []struct {
@@ -466,7 +471,7 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 			if err != nil {
 				return actionRequirements{}, err
 			}
-			requirements.githubToken = requirements.githubToken || requiresToken
+			requirements.githubToken = requirements.githubToken || stepReachable && requiresToken
 		}
 		if step.Uses == "" {
 			continue
@@ -481,11 +486,12 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 				return actionRequirements{}, fmt.Errorf("composite action step %d child %q: bounded upload-artifact adapter: %w", i+1, step.Uses, err)
 			}
 		}
-		childRequirements, err := child.inspectInvocation(step.With, false, serverURL)
+		childInputs := resolveKnownCompositeValues(step.With, effectiveInputs, unknownInputs, serverURL)
+		childRequirements, err := child.inspectInvocation(childInputs, false, serverURL)
 		if err != nil {
 			return actionRequirements{}, fmt.Errorf("composite action step %d child %q: %w", i+1, step.Uses, err)
 		}
-		requirements.githubToken = requirements.githubToken || childRequirements.githubToken
+		requirements.githubToken = requirements.githubToken || stepReachable && childRequirements.githubToken
 		for name := range childRequirements.requiredSecrets {
 			requirements.requiredSecrets[name] = true
 		}
@@ -520,6 +526,69 @@ func (n *actionNode) effectiveInputs(supplied map[string]string) (map[string]str
 		inputs[name] = value
 	}
 	return inputs, unknown
+}
+
+func compositeStepCondition(condition string, inputs map[string]string, unknownInputs map[string]bool) (bool, bool, error) {
+	names, dynamic, err := expression.ConditionInputReferences(condition)
+	if err != nil {
+		return false, false, err
+	}
+	if dynamic && len(unknownInputs) != 0 {
+		return false, false, nil
+	}
+	for _, name := range names {
+		if unknownInputs[name] {
+			return false, false, nil
+		}
+	}
+	status, err := expression.ReferencesStatusFunction(condition)
+	if err != nil {
+		return false, false, err
+	}
+	if status {
+		return false, false, nil
+	}
+	for _, contextName := range []string{"env", "github", "job", "matrix", "needs", "runner", "steps", "vars"} {
+		usesContext, err := expression.ConditionUsesContext(condition, contextName)
+		if err != nil {
+			return false, false, err
+		}
+		if usesContext {
+			return false, false, nil
+		}
+	}
+	conditionInputs := make(map[string]any, len(inputs))
+	for name, value := range inputs {
+		conditionInputs[name] = value
+	}
+	run, err := expression.EvaluateCondition(condition, expression.ConditionContext{Inputs: conditionInputs})
+	if err != nil {
+		return false, false, nil
+	}
+	return run, true, nil
+}
+
+func resolveKnownCompositeValues(values, inputs map[string]string, unknownInputs map[string]bool, serverURL string) map[string]string {
+	resolved := make(map[string]string, len(values))
+	context := expression.Context{Inputs: inputs, GitHub: map[string]any{"server_url": serverURL}}
+	for _, name := range sortedKeys(values) {
+		original := values[name]
+		inputNames, dynamic, err := expression.TemplateInputReferences(original)
+		unknown := dynamic && len(unknownInputs) != 0
+		for _, inputName := range inputNames {
+			unknown = unknown || unknownInputs[inputName]
+		}
+		if unknown || err != nil {
+			resolved[name] = original
+			continue
+		}
+		value, err := expression.EvaluateStep(original, context)
+		if err != nil {
+			value = original
+		}
+		resolved[name] = value
+	}
+	return resolved
 }
 
 func inspectCompositeTemplate(field, template string, inputs map[string]string, unknownInputs map[string]bool, serverURL string) (bool, error) {

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -89,8 +89,9 @@ type actionCompilation struct {
 }
 
 type actionRequirements struct {
-	githubToken     bool
-	requiredSecrets map[string]bool
+	githubToken            bool
+	preparationGitHubToken bool
+	requiredSecrets        map[string]bool
 }
 
 // validateActionResolutions resolves each independent root invocation before
@@ -260,8 +261,8 @@ func compileActionInvocations(ctx context.Context, workspace string, actionSourc
 			if err != nil {
 				return actionCompilation{}, fmt.Errorf("compile action %q: %w", refs[i], err)
 			}
-			requiresGitHubToken = requiresGitHubToken || requirements.githubToken
-			if requirements.githubToken {
+			requiresGitHubToken = requiresGitHubToken || requirements.githubToken || requirements.preparationGitHubToken
+			if requirements.githubToken || requirements.preparationGitHubToken {
 				githubTokenActions = append(githubTokenActions, refs[i])
 			}
 			for name := range requirements.requiredSecrets {
@@ -424,6 +425,7 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 			return actionRequirements{}, fmt.Errorf("action input %q default: %w", name, err)
 		}
 		requirements.githubToken = requirements.githubToken || referencesToken
+		requirements.preparationGitHubToken = requirements.preparationGitHubToken || n.preparationEvaluatesInvocation() && referencesToken
 	}
 	if n.runtime != metadata.RuntimeComposite {
 		return requirements, nil
@@ -442,6 +444,15 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 			return actionRequirements{}, fmt.Errorf("composite action step %d condition: %w", i+1, err)
 		}
 		stepReachable := !known || run
+		var child *actionNode
+		preparationEvaluatesStep := false
+		if step.Uses != "" {
+			child = n.children[step.Uses]
+			if child == nil {
+				return actionRequirements{}, fmt.Errorf("composite action step %d child %q is missing", i+1, step.Uses)
+			}
+			preparationEvaluatesStep = child.preparationEvaluatesInvocation()
+		}
 		for _, field := range []struct {
 			name   string
 			values map[string]string
@@ -455,6 +466,7 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 					return actionRequirements{}, err
 				}
 				requirements.githubToken = requirements.githubToken || stepReachable && requiresToken
+				requirements.preparationGitHubToken = requirements.preparationGitHubToken || preparationEvaluatesStep && requiresToken
 			}
 		}
 		for _, field := range []struct {
@@ -472,13 +484,10 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 				return actionRequirements{}, err
 			}
 			requirements.githubToken = requirements.githubToken || stepReachable && requiresToken
+			requirements.preparationGitHubToken = requirements.preparationGitHubToken || preparationEvaluatesStep && requiresToken
 		}
 		if step.Uses == "" {
 			continue
-		}
-		child := n.children[step.Uses]
-		if child == nil {
-			return actionRequirements{}, fmt.Errorf("composite action step %d child %q is missing", i+1, step.Uses)
 		}
 		descriptor, _ := actionintegration.Lookup(actionintegration.Identity{Source: child.lock.Source, Repository: child.lock.Repository, Path: child.lock.Path})
 		if descriptor.Adapter == actionintegration.AdapterUploadArtifactBuildkite {
@@ -492,11 +501,16 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 			return actionRequirements{}, fmt.Errorf("composite action step %d child %q: %w", i+1, step.Uses, err)
 		}
 		requirements.githubToken = requirements.githubToken || stepReachable && childRequirements.githubToken
+		requirements.preparationGitHubToken = requirements.preparationGitHubToken || childRequirements.preparationGitHubToken
 		for name := range childRequirements.requiredSecrets {
 			requirements.requiredSecrets[name] = true
 		}
 	}
 	return requirements, nil
+}
+
+func (n *actionNode) preparationEvaluatesInvocation() bool {
+	return n.runtime == metadata.RuntimeComposite || n.metadata.Runs.Pre != ""
 }
 
 func (n *actionNode) effectiveInputs(supplied map[string]string) (map[string]string, map[string]bool) {
@@ -550,7 +564,7 @@ func resolveKnownCompositeValues(values, inputs map[string]string, unknownInputs
 			resolved[name] = original
 			continue
 		}
-		for _, contextName := range []string{"env", "github", "job", "matrix", "needs", "runner", "secrets", "services", "steps", "vars"} {
+		for _, contextName := range []string{"env", "job", "matrix", "needs", "runner", "secrets", "services", "steps", "vars"} {
 			usesContext, contextErr := expression.TemplateUsesContext(original, contextName)
 			if contextErr != nil || usesContext {
 				unknown = true
@@ -558,6 +572,12 @@ func resolveKnownCompositeValues(values, inputs map[string]string, unknownInputs
 			}
 		}
 		if unknown {
+			resolved[name] = original
+			continue
+		}
+		usesUnknownGitHub, githubErr := expression.TemplateUsesGitHubPropertyOutside(original, "server_url")
+		usesSerializedContext, tokenErr := expression.ReferencesStepGitHubToken(original)
+		if githubErr != nil || tokenErr != nil || usesUnknownGitHub || usesSerializedContext {
 			resolved[name] = original
 			continue
 		}
@@ -592,27 +612,11 @@ func inspectCompositeTemplate(field, template string, inputs map[string]string, 
 	if !referencesToken {
 		return false, nil
 	}
-	inputNames, dynamicInputs, err := expression.GitHubTokenInputReferences(template)
+	requiresToken, err := expression.GitHubTokenRequiresEvaluation(template, expression.Context{Inputs: inputs, GitHub: map[string]any{"server_url": serverURL}}, unknownInputs)
 	if err != nil {
 		return false, fmt.Errorf("composite action %s: %w", field, err)
 	}
-	if dynamicInputs && len(unknownInputs) != 0 {
-		return true, nil
-	}
-	for _, name := range inputNames {
-		if unknownInputs[name] {
-			return true, nil
-		}
-	}
-	usesRuntimeValue, err := expression.GitHubTokenReferencesRuntimeValue(template)
-	if err != nil {
-		return false, fmt.Errorf("composite action %s: %w", field, err)
-	}
-	if usesRuntimeValue {
-		return true, nil
-	}
-	_, err = expression.EvaluateStep(template, expression.Context{Inputs: inputs, GitHub: map[string]any{"server_url": serverURL}})
-	return err != nil, nil
+	return requiresToken, nil
 }
 
 func hasActionInput(inputs map[string]string, name string) bool {

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -469,14 +469,19 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 		requirements.githubToken = requirements.githubToken || requiresToken
 	}
 	for i, step := range n.metadata.Runs.Steps {
-		run, known, err := compositeStepCondition(step.If, effectiveInputs, unknownInputs, planning.environment, serverURL)
+		currentPlanning := planning
+		// A preceding composite child can update GITHUB_ENV before this step.
+		// Retain known inherited values only for the first child; declared step
+		// values below remain fixed overrides for that child's preparation.
+		planning.environment = nil
+		run, known, err := compositeStepCondition(step.If, effectiveInputs, unknownInputs, currentPlanning.environment, serverURL)
 		if err != nil {
 			return actionRequirements{}, fmt.Errorf("composite action step %d condition: %w", i+1, err)
 		}
 		stepReachable := !known || run
-		stepEnvironment := knownValues(resolveKnownValues(step.Env, expression.Context{Inputs: effectiveInputs, Env: planning.environment, GitHub: map[string]any{"server_url": serverURL}}, unknownInputs))
-		childPlanning := planning
-		childPlanning.environment = mergeKnownValues(planning.environment, stepEnvironment)
+		stepEnvironment := knownValues(resolveKnownValues(step.Env, expression.Context{Inputs: effectiveInputs, Env: currentPlanning.environment, GitHub: map[string]any{"server_url": serverURL}}, unknownInputs))
+		childPlanning := currentPlanning
+		childPlanning.environment = mergeKnownValues(currentPlanning.environment, stepEnvironment)
 		var child *actionNode
 		preparesEnvironment, preparesInputs := false, false
 		if step.Uses != "" {
@@ -531,7 +536,9 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 				return actionRequirements{}, fmt.Errorf("composite action step %d child %q: bounded upload-artifact adapter: %w", i+1, step.Uses, err)
 			}
 		}
-		childInputs := resolveKnownValues(step.With, expression.Context{Inputs: effectiveInputs, Env: childPlanning.environment, GitHub: map[string]any{"server_url": serverURL}}, unknownInputs)
+		// Composite child env and with maps are sibling fields: runtime resolves
+		// both against the parent context before overlaying the child's env.
+		childInputs := resolveKnownValues(step.With, expression.Context{Inputs: effectiveInputs, Env: currentPlanning.environment, GitHub: map[string]any{"server_url": serverURL}}, unknownInputs)
 		childRequirements, err := child.inspectInvocation(childInputs, false, serverURL, childPlanning)
 		if err != nil {
 			return actionRequirements{}, fmt.Errorf("composite action step %d child %q: %w", i+1, step.Uses, err)

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -425,12 +425,16 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 			return actionRequirements{}, fmt.Errorf("action input %q default: %w", name, err)
 		}
 		requirements.githubToken = requirements.githubToken || referencesToken
-		requirements.preparationGitHubToken = requirements.preparationGitHubToken || n.preparationEvaluatesInvocation() && referencesToken
+		_, preparesInputs, preparationErr := n.preparationFields(serverURL)
+		if preparationErr != nil {
+			return actionRequirements{}, preparationErr
+		}
+		requirements.preparationGitHubToken = requirements.preparationGitHubToken || preparesInputs && referencesToken
 	}
 	if n.runtime != metadata.RuntimeComposite {
 		return requirements, nil
 	}
-	effectiveInputs, unknownInputs := n.effectiveInputs(supplied)
+	effectiveInputs, unknownInputs := n.effectiveInputs(supplied, serverURL)
 	for _, name := range sortedKeys(n.metadata.Outputs) {
 		requiresToken, err := inspectCompositeTemplate("output "+name, n.metadata.Outputs[name].Value, effectiveInputs, unknownInputs, serverURL)
 		if err != nil {
@@ -439,19 +443,22 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 		requirements.githubToken = requirements.githubToken || requiresToken
 	}
 	for i, step := range n.metadata.Runs.Steps {
-		run, known, err := compositeStepCondition(step.If, effectiveInputs, unknownInputs)
+		run, known, err := compositeStepCondition(step.If, effectiveInputs, unknownInputs, serverURL)
 		if err != nil {
 			return actionRequirements{}, fmt.Errorf("composite action step %d condition: %w", i+1, err)
 		}
 		stepReachable := !known || run
 		var child *actionNode
-		preparationEvaluatesStep := false
+		preparesEnvironment, preparesInputs := false, false
 		if step.Uses != "" {
 			child = n.children[step.Uses]
 			if child == nil {
 				return actionRequirements{}, fmt.Errorf("composite action step %d child %q is missing", i+1, step.Uses)
 			}
-			preparationEvaluatesStep = child.preparationEvaluatesInvocation()
+			preparesEnvironment, preparesInputs, err = child.preparationFields(serverURL)
+			if err != nil {
+				return actionRequirements{}, fmt.Errorf("composite action step %d child %q: %w", i+1, step.Uses, err)
+			}
 		}
 		for _, field := range []struct {
 			name   string
@@ -466,7 +473,8 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 					return actionRequirements{}, err
 				}
 				requirements.githubToken = requirements.githubToken || stepReachable && requiresToken
-				requirements.preparationGitHubToken = requirements.preparationGitHubToken || preparationEvaluatesStep && requiresToken
+				preparesField := field.name == "environment" && preparesEnvironment || field.name == "input" && preparesInputs
+				requirements.preparationGitHubToken = requirements.preparationGitHubToken || preparesField && requiresToken
 			}
 		}
 		for _, field := range []struct {
@@ -484,7 +492,6 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 				return actionRequirements{}, err
 			}
 			requirements.githubToken = requirements.githubToken || stepReachable && requiresToken
-			requirements.preparationGitHubToken = requirements.preparationGitHubToken || preparationEvaluatesStep && requiresToken
 		}
 		if step.Uses == "" {
 			continue
@@ -501,7 +508,7 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 			return actionRequirements{}, fmt.Errorf("composite action step %d child %q: %w", i+1, step.Uses, err)
 		}
 		requirements.githubToken = requirements.githubToken || stepReachable && childRequirements.githubToken
-		requirements.preparationGitHubToken = requirements.preparationGitHubToken || childRequirements.preparationGitHubToken
+		requirements.preparationGitHubToken = requirements.preparationGitHubToken || n.lock.Source == "github" && childRequirements.preparationGitHubToken
 		for name := range childRequirements.requiredSecrets {
 			requirements.requiredSecrets[name] = true
 		}
@@ -509,11 +516,24 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 	return requirements, nil
 }
 
-func (n *actionNode) preparationEvaluatesInvocation() bool {
-	return n.runtime == metadata.RuntimeComposite || n.metadata.Runs.Pre != ""
+func (n *actionNode) preparationFields(serverURL string) (environment, inputs bool, err error) {
+	if n.lock.Source != "github" {
+		return false, false, nil
+	}
+	if n.runtime == metadata.RuntimeComposite {
+		return true, true, nil
+	}
+	if n.metadata.Runs.Pre == "" {
+		return false, false, nil
+	}
+	run, known, err := expression.EvaluateKnownCondition(n.metadata.Runs.PreIf, expression.ConditionContext{GitHub: map[string]any{"server_url": serverURL}}, nil)
+	if err != nil {
+		return false, false, err
+	}
+	return true, !known || run, nil
 }
 
-func (n *actionNode) effectiveInputs(supplied map[string]string) (map[string]string, map[string]bool) {
+func (n *actionNode) effectiveInputs(supplied map[string]string, serverURL string) (map[string]string, map[string]bool) {
 	inputs := make(map[string]string, len(n.metadata.Inputs)+len(supplied))
 	unknown := map[string]bool{}
 	for _, name := range sortedKeys(n.metadata.Inputs) {
@@ -523,8 +543,12 @@ func (n *actionNode) effectiveInputs(supplied map[string]string) (map[string]str
 			value = *definition.Default
 		}
 		if strings.Contains(value, "${{") {
-			unknown[name] = true
-			continue
+			var err error
+			value, err = expression.EvaluateActionInputDefault(value, expression.Context{GitHub: map[string]any{"server_url": serverURL}})
+			if err != nil || strings.Contains(value, "${{") {
+				unknown[name] = true
+				continue
+			}
 		}
 		inputs[name] = value
 	}
@@ -542,12 +566,12 @@ func (n *actionNode) effectiveInputs(supplied map[string]string) (map[string]str
 	return inputs, unknown
 }
 
-func compositeStepCondition(condition string, inputs map[string]string, unknownInputs map[string]bool) (bool, bool, error) {
+func compositeStepCondition(condition string, inputs map[string]string, unknownInputs map[string]bool, serverURL string) (bool, bool, error) {
 	conditionInputs := make(map[string]any, len(inputs))
 	for name, value := range inputs {
 		conditionInputs[name] = value
 	}
-	return expression.EvaluateKnownInputCondition(condition, conditionInputs, unknownInputs)
+	return expression.EvaluateKnownCondition(condition, expression.ConditionContext{Inputs: conditionInputs, GitHub: map[string]any{"server_url": serverURL}}, unknownInputs)
 }
 
 func resolveKnownCompositeValues(values, inputs map[string]string, unknownInputs map[string]bool, serverURL string) map[string]string {

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -91,13 +91,15 @@ type actionCompilation struct {
 type actionRequirements struct {
 	githubToken            bool
 	preparationGitHubToken bool
+	preparationMutatesEnv  bool
 	requiredSecrets        map[string]bool
 }
 
 type actionPlanningContext struct {
-	workflowInputs        map[string]any
-	unknownWorkflowInputs map[string]bool
-	environment           map[string]string
+	workflowInputs         map[string]any
+	unknownWorkflowInputs  map[string]bool
+	environment            map[string]string
+	preparationEnvironment map[string]string
 }
 
 type actionStepPlanningContext struct {
@@ -459,6 +461,7 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 	}
 	requirements.preparationGitHubToken = requirements.preparationGitHubToken || preparesInputs && defaultsRequireToken
 	if n.runtime != metadata.RuntimeComposite {
+		requirements.preparationMutatesEnv = preparesInputs
 		return requirements, nil
 	}
 	for _, name := range sortedKeys(n.metadata.Outputs) {
@@ -480,8 +483,10 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 		}
 		stepReachable := !known || run
 		stepEnvironment := knownValues(resolveKnownValues(step.Env, expression.Context{Inputs: effectiveInputs, Env: currentPlanning.environment, GitHub: map[string]any{"server_url": serverURL}}, unknownInputs))
+		preparationStepEnvironment := knownValues(resolveKnownValues(step.Env, expression.Context{Inputs: effectiveInputs, Env: currentPlanning.preparationEnvironment, GitHub: map[string]any{"server_url": serverURL}}, unknownInputs))
 		childPlanning := currentPlanning
 		childPlanning.environment = mergeKnownValues(currentPlanning.environment, stepEnvironment)
+		childPlanning.preparationEnvironment = mergeKnownValues(currentPlanning.preparationEnvironment, preparationStepEnvironment)
 		var child *actionNode
 		preparesEnvironment, preparesInputs := false, false
 		if step.Uses != "" {
@@ -545,6 +550,10 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 		}
 		requirements.githubToken = requirements.githubToken || stepReachable && childRequirements.githubToken
 		requirements.preparationGitHubToken = requirements.preparationGitHubToken || n.lock.Source == "github" && childRequirements.preparationGitHubToken
+		if n.lock.Source == "github" && childRequirements.preparationMutatesEnv {
+			requirements.preparationMutatesEnv = true
+			planning.preparationEnvironment = nil
+		}
 		for name := range childRequirements.requiredSecrets {
 			requirements.requiredSecrets[name] = true
 		}
@@ -562,7 +571,7 @@ func (n *actionNode) preparationFields(serverURL string, planning actionPlanning
 	if n.metadata.Runs.Pre == "" {
 		return false, false, nil
 	}
-	run, known, err := expression.EvaluateKnownCondition(n.metadata.Runs.PreIf, expression.ConditionContext{Inputs: planning.workflowInputs, Env: planning.environment, GitHub: map[string]any{"server_url": serverURL}}, planning.unknownWorkflowInputs)
+	run, known, err := expression.EvaluateKnownCondition(n.metadata.Runs.PreIf, expression.ConditionContext{Inputs: planning.workflowInputs, Env: planning.preparationEnvironment, GitHub: map[string]any{"server_url": serverURL}}, planning.unknownWorkflowInputs)
 	if err != nil {
 		return false, false, err
 	}

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -536,30 +536,40 @@ func (n *actionNode) preparationFields(serverURL string) (environment, inputs bo
 func (n *actionNode) effectiveInputs(supplied map[string]string, serverURL string) (map[string]string, map[string]bool) {
 	inputs := make(map[string]string, len(n.metadata.Inputs)+len(supplied))
 	unknown := map[string]bool{}
-	for _, name := range sortedKeys(n.metadata.Inputs) {
-		definition := n.metadata.Inputs[name]
-		value := ""
-		if definition.Default != nil {
-			value = *definition.Default
-		}
+	for _, name := range sortedKeys(supplied) {
+		value := supplied[name]
+		name = strings.ToLower(name)
 		if strings.Contains(value, "${{") {
+			unknown[name] = true
+			continue
+		}
+		inputs[name] = value
+	}
+	for _, name := range sortedKeys(n.metadata.Inputs) {
+		if _, ok := inputs[name]; ok || unknown[name] {
+			continue
+		}
+		definition := n.metadata.Inputs[name]
+		if definition.Default == nil {
+			continue
+		}
+		value := *definition.Default
+		if strings.Contains(value, "${{") {
+			inputNames, dynamic, referenceErr := expression.TemplateInputReferences(value)
+			dependsOnUnknown := dynamic && len(unknown) != 0
+			for _, inputName := range inputNames {
+				dependsOnUnknown = dependsOnUnknown || unknown[inputName]
+			}
+			if referenceErr != nil || dependsOnUnknown {
+				unknown[name] = true
+				continue
+			}
 			var err error
-			value, err = expression.EvaluateActionInputDefault(value, expression.Context{GitHub: map[string]any{"server_url": serverURL}})
+			value, err = expression.EvaluateActionInputDefault(value, expression.Context{Inputs: inputs, GitHub: map[string]any{"server_url": serverURL}})
 			if err != nil || strings.Contains(value, "${{") {
 				unknown[name] = true
 				continue
 			}
-		}
-		inputs[name] = value
-	}
-	for _, name := range sortedKeys(supplied) {
-		value := supplied[name]
-		name = strings.ToLower(name)
-		delete(inputs, name)
-		delete(unknown, name)
-		if strings.Contains(value, "${{") {
-			unknown[name] = true
-			continue
 		}
 		inputs[name] = value
 	}

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -397,10 +397,9 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 		if !workflowAuthored && len(names) != 0 {
 			return actionRequirements{}, fmt.Errorf("action input %q: composite action metadata cannot grant secret authority", suppliedName)
 		}
-		if !workflowAuthored && referencesToken {
-			return actionRequirements{}, fmt.Errorf("action input %q: composite action metadata cannot grant github.token authority", suppliedName)
+		if workflowAuthored {
+			requirements.githubToken = requirements.githubToken || referencesToken
 		}
-		requirements.githubToken = requirements.githubToken || referencesToken
 		input, declared := n.metadata.Inputs[strings.ToLower(suppliedName)]
 		for _, name := range names {
 			if declared && !input.Required && name != "GITHUB_TOKEN" {
@@ -429,7 +428,46 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 	if n.runtime != metadata.RuntimeComposite {
 		return requirements, nil
 	}
+	effectiveInputs, inputsKnown := n.effectiveInputs(supplied)
+	for _, name := range sortedKeys(n.metadata.Outputs) {
+		requiresToken, err := inspectCompositeTemplate("output "+name, n.metadata.Outputs[name].Value, effectiveInputs, inputsKnown, serverURL)
+		if err != nil {
+			return actionRequirements{}, err
+		}
+		requirements.githubToken = requirements.githubToken || requiresToken
+	}
 	for i, step := range n.metadata.Runs.Steps {
+		for _, field := range []struct {
+			name   string
+			values map[string]string
+		}{
+			{name: "environment", values: step.Env},
+			{name: "input", values: step.With},
+		} {
+			for _, name := range sortedKeys(field.values) {
+				requiresToken, err := inspectCompositeTemplate(fmt.Sprintf("step %d %s %q", i+1, field.name, name), field.values[name], effectiveInputs, inputsKnown, serverURL)
+				if err != nil {
+					return actionRequirements{}, err
+				}
+				requirements.githubToken = requirements.githubToken || requiresToken
+			}
+		}
+		for _, field := range []struct {
+			name  string
+			value string
+		}{
+			{name: "run", value: step.Run},
+			{name: "working-directory", value: step.WorkingDirectory},
+		} {
+			if field.value == "" {
+				continue
+			}
+			requiresToken, err := inspectCompositeTemplate(fmt.Sprintf("step %d %s", i+1, field.name), field.value, effectiveInputs, inputsKnown, serverURL)
+			if err != nil {
+				return actionRequirements{}, err
+			}
+			requirements.githubToken = requirements.githubToken || requiresToken
+		}
 		if step.Uses == "" {
 			continue
 		}
@@ -453,6 +491,81 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 		}
 	}
 	return requirements, nil
+}
+
+func (n *actionNode) effectiveInputs(supplied map[string]string) (map[string]string, bool) {
+	inputs := make(map[string]string, len(n.metadata.Inputs)+len(supplied))
+	known := true
+	for _, name := range sortedKeys(n.metadata.Inputs) {
+		definition := n.metadata.Inputs[name]
+		value := ""
+		if definition.Default != nil {
+			value = *definition.Default
+		}
+		if strings.Contains(value, "${{") {
+			known = false
+			continue
+		}
+		inputs[name] = value
+	}
+	for _, name := range sortedKeys(supplied) {
+		value := supplied[name]
+		if strings.Contains(value, "${{") {
+			known = false
+			continue
+		}
+		inputs[strings.ToLower(name)] = value
+	}
+	return inputs, known
+}
+
+func inspectCompositeTemplate(field, template string, inputs map[string]string, inputsKnown bool, serverURL string) (bool, error) {
+	referencesEvent, err := expression.TemplateReferencesGitHubEvent(template)
+	if err != nil {
+		return false, fmt.Errorf("composite action %s: %w", field, err)
+	}
+	if referencesEvent {
+		return false, fmt.Errorf("composite action %s: github.event cannot be retained in a job plan", field)
+	}
+	names, err := expression.SecretReferences(template)
+	if err != nil {
+		return false, fmt.Errorf("composite action %s: %w", field, err)
+	}
+	if len(names) != 0 {
+		return false, fmt.Errorf("composite action %s: composite action metadata cannot grant secret authority", field)
+	}
+	referencesToken, err := expression.ReferencesGitHubToken(template)
+	if err != nil {
+		return false, fmt.Errorf("composite action %s: %w", field, err)
+	}
+	if !referencesToken {
+		return false, nil
+	}
+	usesInputs, err := expression.TemplateUsesContext(template, "inputs")
+	if err != nil {
+		return false, fmt.Errorf("composite action %s: %w", field, err)
+	}
+	if usesInputs && !inputsKnown {
+		return true, nil
+	}
+	usesUnknownGitHubProperty, err := expression.TemplateUsesGitHubPropertyOutside(template, "server_url", "token")
+	if err != nil {
+		return false, fmt.Errorf("composite action %s: %w", field, err)
+	}
+	if usesUnknownGitHubProperty {
+		return true, nil
+	}
+	for _, contextName := range []string{"env", "job", "matrix", "needs", "runner", "services", "steps", "vars"} {
+		usesContext, err := expression.TemplateUsesContext(template, contextName)
+		if err != nil {
+			return false, fmt.Errorf("composite action %s: %w", field, err)
+		}
+		if usesContext {
+			return true, nil
+		}
+	}
+	_, err = expression.EvaluateStep(template, expression.Context{Inputs: inputs, GitHub: map[string]any{"server_url": serverURL}})
+	return err != nil, nil
 }
 
 func hasActionInput(inputs map[string]string, name string) bool {

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -828,6 +828,40 @@ runs:
 	}
 }
 
+func TestCompileActionInvocationsResolvesOrderedInputDefaults(t *testing.T) {
+	workspace := t.TempDir()
+	writeAction(t, workspace, "guarded", `name: guarded
+inputs:
+  enabled:
+    default: "false"
+  gate:
+    default: ${{ inputs.enabled }}
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        TOKEN: ${{ inputs.gate == 'true' && github.token || '' }}
+      run: echo guarded
+`)
+	for _, test := range []struct {
+		enabled string
+		want    bool
+	}{
+		{enabled: "false"},
+		{enabled: "true", want: true},
+		{enabled: "${{ matrix.enabled }}", want: true},
+	} {
+		compiled, err := compileActionInvocations(t.Context(), workspace, nil, "https://github.com", []string{"./guarded"}, []map[string]string{{"enabled": test.enabled}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if compiled.requiresGitHubToken != test.want {
+			t.Fatalf("enabled %q requires GitHub token = %t, want %t", test.enabled, compiled.requiresGitHubToken, test.want)
+		}
+	}
+}
+
 func TestCompileActionInvocationsResolvesForwardedServerURL(t *testing.T) {
 	workspace := t.TempDir()
 	writeAction(t, workspace, "child", `name: child

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -502,6 +502,25 @@ runs:
 	if compiled.requiresGitHubToken {
 		t.Fatal("overridden expression default required a GitHub token")
 	}
+	writeAction(t, workspace, "whole-inputs", `name: whole input context
+inputs:
+  unknown:
+    default: ${{ github.actor }}
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        TOKEN: ${{ toJSON(inputs) != '{}' && github.token || '' }}
+      run: echo "$TOKEN"
+`)
+	compiled, err = compileActionInvocations(t.Context(), workspace, nil, "https://github.com", []string{"./whole-inputs"}, []map[string]string{nil})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !compiled.requiresGitHubToken {
+		t.Fatal("whole input context with an unknown input did not request a GitHub token")
+	}
 }
 
 func TestCompileActionInvocationsDetectsGitHubTokenAcrossCompositeMetadata(t *testing.T) {
@@ -558,6 +577,84 @@ runs:
 		{enabled: "true", want: true},
 	} {
 		compiled, err := compileActionInvocations(t.Context(), workspace, nil, "https://github.com", []string{"./parent"}, []map[string]string{{"enabled": test.enabled}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if compiled.requiresGitHubToken != test.want {
+			t.Fatalf("enabled %q requires GitHub token = %t, want %t", test.enabled, compiled.requiresGitHubToken, test.want)
+		}
+	}
+}
+
+func TestCompileActionInvocationsPreservesKnownInputsAcrossCompositeChildren(t *testing.T) {
+	workspace := t.TempDir()
+	writeAction(t, workspace, "child", `name: child
+inputs:
+  enabled:
+    default: "false"
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        TOKEN: ${{ inputs.enabled == 'true' && github.token || '' }}
+      run: echo "$TOKEN"
+`)
+	writeAction(t, workspace, "parent", `name: parent
+inputs:
+  enabled:
+    default: "false"
+runs:
+  using: composite
+  steps:
+    - uses: ./child
+      with:
+        enabled: ${{ inputs.enabled }}
+`)
+
+	for _, test := range []struct {
+		enabled string
+		want    bool
+	}{
+		{enabled: "false"},
+		{enabled: "true", want: true},
+		{enabled: "${{ matrix.enabled }}", want: true},
+	} {
+		compiled, err := compileActionInvocations(t.Context(), workspace, nil, "https://github.com", []string{"./parent"}, []map[string]string{{"enabled": test.enabled}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if compiled.requiresGitHubToken != test.want {
+			t.Fatalf("enabled %q requires GitHub token = %t, want %t", test.enabled, compiled.requiresGitHubToken, test.want)
+		}
+	}
+}
+
+func TestCompileActionInvocationsSkipsStaticallyDisabledCompositeSteps(t *testing.T) {
+	workspace := t.TempDir()
+	writeAction(t, workspace, "conditional", `name: conditional
+inputs:
+  enabled:
+    default: "false"
+runs:
+  using: composite
+  steps:
+    - if: inputs.enabled == 'true'
+      shell: bash
+      env:
+        TOKEN: ${{ github.token }}
+      run: echo "$TOKEN"
+`)
+
+	for _, test := range []struct {
+		enabled string
+		want    bool
+	}{
+		{enabled: "false"},
+		{enabled: "true", want: true},
+		{enabled: "${{ matrix.enabled }}", want: true},
+	} {
+		compiled, err := compileActionInvocations(t.Context(), workspace, nil, "https://github.com", []string{"./conditional"}, []map[string]string{{"enabled": test.enabled}})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -450,6 +450,8 @@ func TestCompileActionInvocationsDetectsReachableCompositeMetadataGitHubToken(t 
 inputs:
   fallback:
     default: cargo-binstall
+  unrelated:
+    default: ${{ github.actor }}
 runs:
   using: composite
   steps:
@@ -468,6 +470,7 @@ runs:
 		{name: "explicit matching value", supplied: map[string]string{"fallback": "cargo-binstall"}, want: true},
 		{name: "unreachable cargo install", supplied: map[string]string{"fallback": "cargo-install"}},
 		{name: "unreachable none", supplied: map[string]string{"fallback": "none"}},
+		{name: "overridden unrelated expression default", supplied: map[string]string{"fallback": "none", "unrelated": "literal"}},
 		{name: "unknown expression", supplied: map[string]string{"fallback": "${{ matrix.fallback }}"}, want: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -479,6 +482,25 @@ runs:
 				t.Fatalf("requires GitHub token = %t, want %t", compiled.requiresGitHubToken, test.want)
 			}
 		})
+	}
+	writeAction(t, workspace, "overridden-token", `name: overridden composite token
+inputs:
+  fallback:
+    default: ${{ github.actor }}
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        DEFAULT_GITHUB_TOKEN: ${{ inputs.fallback == 'cargo-binstall' && github.token || '' }}
+      run: echo "$DEFAULT_GITHUB_TOKEN"
+`)
+	compiled, err := compileActionInvocations(t.Context(), workspace, nil, "https://github.com", []string{"./overridden-token"}, []map[string]string{{"fallback": "none"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if compiled.requiresGitHubToken {
+		t.Fatal("overridden expression default required a GitHub token")
 	}
 }
 

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -685,11 +685,45 @@ runs:
 }
 
 func TestCompileActionInvocationsRetainsTokenForSkippedChildPreHook(t *testing.T) {
+	parent, child := t.TempDir(), t.TempDir()
+	writeAction(t, child, "", `name: child
+runs:
+  using: node24
+  pre: pre.js
+  main: index.js
+`)
+	if err := os.WriteFile(filepath.Join(child, "pre.js"), []byte("// fixture\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeAction(t, parent, "", `name: parent
+runs:
+  using: composite
+  steps:
+    - if: ${{ false }}
+      uses: owner/child@v1
+      env:
+        TOKEN: ${{ github.token }}
+`)
+	source := classifiedActionSource{
+		roots:   map[string]string{"owner/parent": parent, "owner/child": child},
+		commits: map[string]string{"owner/parent": strings.Repeat("a", 40), "owner/child": strings.Repeat("b", 40)},
+	}
+	compiled, err := compileActionInvocations(t.Context(), t.TempDir(), source, "https://github.com", []string{"owner/parent@v1"}, []map[string]string{nil})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !compiled.requiresGitHubToken {
+		t.Fatal("skipped child pre hook did not retain token authority for prepared metadata")
+	}
+}
+
+func TestCompileActionInvocationsDoesNotPrepareWorkspaceOrFalsePreInputs(t *testing.T) {
 	workspace := t.TempDir()
 	writeAction(t, workspace, "child", `name: child
 runs:
   using: node24
   pre: pre.js
+  pre-if: ${{ false }}
   main: index.js
 `)
 	if err := os.WriteFile(filepath.Join(workspace, "child", "pre.js"), []byte("// fixture\n"), 0o644); err != nil {
@@ -701,15 +735,96 @@ runs:
   steps:
     - if: ${{ false }}
       uses: ./child
-      env:
-        TOKEN: ${{ github.token }}
+      with:
+        token: ${{ github.token }}
 `)
 	compiled, err := compileActionInvocations(t.Context(), workspace, nil, "https://github.com", []string{"./parent"}, []map[string]string{nil})
 	if err != nil {
 		t.Fatal(err)
 	}
+	if compiled.requiresGitHubToken {
+		t.Fatal("workspace child or statically skipped pre inputs retained token authority")
+	}
+
+	parent, child := t.TempDir(), t.TempDir()
+	writeAction(t, child, "", `name: child
+runs:
+  using: node24
+  pre: pre.js
+  pre-if: ${{ false }}
+  main: index.js
+`)
+	if err := os.WriteFile(filepath.Join(child, "pre.js"), []byte("// fixture\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeAction(t, parent, "", `name: parent
+runs:
+  using: composite
+  steps:
+    - if: ${{ false }}
+      uses: owner/child@v1
+      with:
+        token: ${{ github.token }}
+`)
+	source := classifiedActionSource{
+		roots:   map[string]string{"owner/parent": parent, "owner/child": child},
+		commits: map[string]string{"owner/parent": strings.Repeat("a", 40), "owner/child": strings.Repeat("b", 40)},
+	}
+	compiled, err = compileActionInvocations(t.Context(), t.TempDir(), source, "https://github.com", []string{"owner/parent@v1"}, []map[string]string{nil})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if compiled.requiresGitHubToken {
+		t.Fatal("statically skipped remote pre inputs retained token authority")
+	}
+	writeAction(t, parent, "", `name: parent
+runs:
+  using: composite
+  steps:
+    - if: ${{ false }}
+      uses: owner/child@v1
+      env:
+        TOKEN: ${{ github.token }}
+`)
+	compiled, err = compileActionInvocations(t.Context(), t.TempDir(), source, "https://github.com", []string{"owner/parent@v1"}, []map[string]string{nil})
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !compiled.requiresGitHubToken {
-		t.Fatal("skipped child pre hook did not retain token authority for prepared metadata")
+		t.Fatal("remote pre environment did not retain token authority before a false pre-if")
+	}
+}
+
+func TestCompileActionInvocationsResolvesProviderGuardsInDefaultsAndConditions(t *testing.T) {
+	workspace := t.TempDir()
+	writeAction(t, workspace, "guarded", `name: guarded
+inputs:
+  enabled:
+    default: ${{ github.server_url == 'https://github.com' && 'true' || 'false' }}
+runs:
+  using: composite
+  steps:
+    - if: github.server_url == 'https://github.com'
+      shell: bash
+      env:
+        DEFAULT_TOKEN: ${{ inputs.enabled == 'true' && github.token || '' }}
+        CONDITION_TOKEN: ${{ github.token }}
+      run: echo guarded
+`)
+	for _, test := range []struct {
+		serverURL string
+		want      bool
+	}{
+		{serverURL: "https://origin.cursor.com"},
+		{serverURL: "https://github.com", want: true},
+	} {
+		compiled, err := compileActionInvocations(t.Context(), workspace, nil, test.serverURL, []string{"./guarded"}, []map[string]string{nil})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if compiled.requiresGitHubToken != test.want {
+			t.Fatalf("server URL %q requires GitHub token = %t, want %t", test.serverURL, compiled.requiresGitHubToken, test.want)
+		}
 	}
 }
 

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -708,7 +708,7 @@ runs:
 		roots:   map[string]string{"owner/parent": parent, "owner/child": child},
 		commits: map[string]string{"owner/parent": strings.Repeat("a", 40), "owner/child": strings.Repeat("b", 40)},
 	}
-	compiled, err := compileActionInvocations(t.Context(), t.TempDir(), source, "https://github.com", []string{"owner/parent@v1"}, []map[string]string{nil})
+	compiled, err := compileActionInvocationsWithConditions(t.Context(), t.TempDir(), source, "https://github.com", []string{"owner/parent@v1"}, []map[string]string{nil}, []string{"${{ false }}"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -858,6 +858,109 @@ runs:
 		}
 		if compiled.requiresGitHubToken != test.want {
 			t.Fatalf("enabled %q requires GitHub token = %t, want %t", test.enabled, compiled.requiresGitHubToken, test.want)
+		}
+	}
+
+	writeAction(t, workspace, "default-guarded", `name: default guarded
+inputs:
+  a_enabled:
+    default: "false"
+  b_token:
+    default: ${{ inputs.a_enabled == 'true' && github.token || '' }}
+runs:
+  using: node24
+  main: index.js
+`)
+	compiled, err := compileActionInvocations(t.Context(), workspace, nil, "https://github.com", []string{"./default-guarded"}, []map[string]string{nil})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if compiled.requiresGitHubToken {
+		t.Fatal("ordered false input default retained unreachable token authority")
+	}
+}
+
+func TestCompileActionInvocationsKeepsRuntimeDefaultInputsUnknown(t *testing.T) {
+	workspace := t.TempDir()
+	writeAction(t, workspace, "guarded", `name: guarded
+inputs:
+  gate:
+    default: ${{ github.actor }}
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        TOKEN: ${{ inputs.gate != '' && github.token || '' }}
+      run: echo guarded
+`)
+	compiled, err := compileActionInvocations(t.Context(), workspace, nil, "https://github.com", []string{"./guarded"}, []map[string]string{nil})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !compiled.requiresGitHubToken {
+		t.Fatal("runtime-dependent default omitted reachable token authority")
+	}
+}
+
+func TestCompileActionInvocationsResolvesTopLevelProviderInputs(t *testing.T) {
+	workspace := t.TempDir()
+	writeAction(t, workspace, "guarded", `name: guarded
+inputs:
+  enabled:
+    default: "false"
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        TOKEN: ${{ inputs.enabled == 'true' && github.token || '' }}
+      run: echo guarded
+`)
+	supplied := map[string]string{"enabled": "${{ github.server_url == 'https://github.com' && 'true' || 'false' }}"}
+	for _, test := range []struct {
+		serverURL string
+		want      bool
+	}{
+		{serverURL: "https://origin.cursor.com"},
+		{serverURL: "https://github.com", want: true},
+	} {
+		compiled, err := compileActionInvocations(t.Context(), workspace, nil, test.serverURL, []string{"./guarded"}, []map[string]string{supplied})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if compiled.requiresGitHubToken != test.want {
+			t.Fatalf("server URL %q requires GitHub token = %t, want %t", test.serverURL, compiled.requiresGitHubToken, test.want)
+		}
+	}
+}
+
+func TestCompileActionInvocationsGatesMainAuthorityByWorkflowCondition(t *testing.T) {
+	workspace := t.TempDir()
+	writeAction(t, workspace, "token", `name: token
+inputs:
+  token:
+    default: ${{ github.token }}
+runs:
+  using: node24
+  main: index.js
+`)
+	for _, test := range []struct {
+		serverURL string
+		condition string
+		want      bool
+	}{
+		{serverURL: "https://github.com", condition: "${{ false }}"},
+		{serverURL: "https://github.com", condition: "${{ github.server_url == 'https://github.com' }}", want: true},
+		{serverURL: "https://origin.cursor.com", condition: "${{ github.server_url == 'https://github.com' }}"},
+		{serverURL: "https://github.com", condition: "${{ env.RUNTIME == 'yes' }}", want: true},
+	} {
+		compiled, err := compileActionInvocationsWithConditions(t.Context(), workspace, nil, test.serverURL, []string{"./token"}, []map[string]string{nil}, []string{test.condition})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if compiled.requiresGitHubToken != test.want {
+			t.Fatalf("server URL %q condition %q requires GitHub token = %t, want %t", test.serverURL, test.condition, compiled.requiresGitHubToken, test.want)
 		}
 	}
 }

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -521,6 +521,25 @@ runs:
 	if !compiled.requiresGitHubToken {
 		t.Fatal("whole input context with an unknown input did not request a GitHub token")
 	}
+	writeAction(t, workspace, "unrelated-runtime", `name: unrelated runtime interpolation
+inputs:
+  enabled:
+    default: "false"
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        TOKEN: ${{ env.UNRELATED }}-${{ inputs.enabled == 'true' && github.token || '' }}
+      run: echo "$TOKEN"
+`)
+	compiled, err = compileActionInvocations(t.Context(), workspace, nil, "https://github.com", []string{"./unrelated-runtime"}, []map[string]string{nil})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if compiled.requiresGitHubToken {
+		t.Fatal("unrelated runtime interpolation required a GitHub token past a false guard")
+	}
 }
 
 func TestCompileActionInvocationsDetectsGitHubTokenAcrossCompositeMetadata(t *testing.T) {
@@ -619,6 +638,7 @@ runs:
 		{enabled: "false"},
 		{enabled: "true", want: true},
 		{enabled: "${{ matrix.enabled }}", want: true},
+		{enabled: "${{ env.ENABLED }}", want: true},
 	} {
 		compiled, err := compileActionInvocations(t.Context(), workspace, nil, "https://github.com", []string{"./parent"}, []map[string]string{{"enabled": test.enabled}})
 		if err != nil {
@@ -626,6 +646,34 @@ runs:
 		}
 		if compiled.requiresGitHubToken != test.want {
 			t.Fatalf("enabled %q requires GitHub token = %t, want %t", test.enabled, compiled.requiresGitHubToken, test.want)
+		}
+	}
+	writeAction(t, workspace, "conditional-runtime", `name: conditional runtime
+inputs:
+  enabled:
+    default: "false"
+runs:
+  using: composite
+  steps:
+    - if: inputs.enabled == 'true' && env.RUNTIME == 'yes'
+      shell: bash
+      env:
+        TOKEN: ${{ github.token }}
+      run: echo "$TOKEN"
+`)
+	for _, test := range []struct {
+		enabled string
+		want    bool
+	}{
+		{enabled: "false"},
+		{enabled: "true", want: true},
+	} {
+		compiled, err := compileActionInvocations(t.Context(), workspace, nil, "https://github.com", []string{"./conditional-runtime"}, []map[string]string{{"enabled": test.enabled}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if compiled.requiresGitHubToken != test.want {
+			t.Fatalf("runtime condition enabled %q requires GitHub token = %t, want %t", test.enabled, compiled.requiresGitHubToken, test.want)
 		}
 	}
 }

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -835,7 +835,7 @@ runs:
 		[]string{"owner/child@v1"},
 		[]map[string]string{{"token": "${{ github.token }}"}},
 		[]actionStepPlanningContext{{
-			actionPlanningContext: actionPlanningContext{environment: map[string]string{"RUN_PRE": "false"}},
+			actionPlanningContext: actionPlanningContext{environment: map[string]string{"RUN_PRE": "false"}, preparationEnvironment: map[string]string{"RUN_PRE": "false"}},
 			condition:             "${{ false }}",
 		}},
 	)
@@ -871,6 +871,47 @@ runs:
 	}
 	if !compiled.requiresGitHubToken {
 		t.Fatal("mutable environment made a later token-bearing composite step unreachable")
+	}
+}
+
+func TestCompileActionInvocationsKeepsPreparationEnvironmentAcrossShellSteps(t *testing.T) {
+	parent, child := t.TempDir(), t.TempDir()
+	writeAction(t, child, "", `name: child
+runs:
+  using: node24
+  pre: pre.js
+  pre-if: env.RUN_PRE == 'true'
+  main: index.js
+`)
+	if err := os.WriteFile(filepath.Join(child, "pre.js"), []byte("// fixture\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeAction(t, parent, "", `name: parent
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: echo RUN_PRE=true >> "$GITHUB_ENV"
+    - if: ${{ false }}
+      uses: owner/child@v1
+      with:
+        token: ${{ github.token }}
+`)
+	source := classifiedActionSource{
+		roots:   map[string]string{"owner/parent": parent, "owner/child": child},
+		commits: map[string]string{"owner/parent": strings.Repeat("a", 40), "owner/child": strings.Repeat("b", 40)},
+	}
+	knownEnvironment := map[string]string{"RUN_PRE": "false"}
+	compiled, err := compileActionInvocationsWithStepContext(
+		t.Context(), t.TempDir(), source, "https://github.com",
+		[]string{"owner/parent@v1"}, []map[string]string{nil},
+		[]actionStepPlanningContext{{actionPlanningContext: actionPlanningContext{environment: knownEnvironment, preparationEnvironment: knownEnvironment}}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if compiled.requiresGitHubToken {
+		t.Fatal("run-only child invalidated the fixed preparation environment")
 	}
 }
 

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -444,6 +444,107 @@ runs:
 	}
 }
 
+func TestCompileActionInvocationsDetectsReachableCompositeMetadataGitHubToken(t *testing.T) {
+	workspace := t.TempDir()
+	writeAction(t, workspace, "token", `name: composite token
+inputs:
+  fallback:
+    default: cargo-binstall
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        DEFAULT_GITHUB_TOKEN: ${{ inputs.fallback == 'cargo-binstall' && github.token || '' }}
+      run: echo "$DEFAULT_GITHUB_TOKEN"
+`)
+
+	for _, test := range []struct {
+		name     string
+		supplied map[string]string
+		want     bool
+	}{
+		{name: "default", want: true},
+		{name: "explicit matching value", supplied: map[string]string{"fallback": "cargo-binstall"}, want: true},
+		{name: "unreachable cargo install", supplied: map[string]string{"fallback": "cargo-install"}},
+		{name: "unreachable none", supplied: map[string]string{"fallback": "none"}},
+		{name: "unknown expression", supplied: map[string]string{"fallback": "${{ matrix.fallback }}"}, want: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			compiled, err := compileActionInvocations(t.Context(), workspace, nil, "https://github.com", []string{"./token"}, []map[string]string{test.supplied})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if compiled.requiresGitHubToken != test.want {
+				t.Fatalf("requires GitHub token = %t, want %t", compiled.requiresGitHubToken, test.want)
+			}
+		})
+	}
+}
+
+func TestCompileActionInvocationsDetectsGitHubTokenAcrossCompositeMetadata(t *testing.T) {
+	workspace := t.TempDir()
+	for _, test := range []struct {
+		name   string
+		action string
+	}{
+		{name: "environment", action: "name: token\nruns:\n  using: composite\n  steps:\n    - shell: bash\n      env:\n        TOKEN: ${{ github.token }}\n      run: echo token\n"},
+		{name: "run", action: "name: token\nruns:\n  using: composite\n  steps:\n    - shell: bash\n      run: echo '${{ github.token }}'\n"},
+		{name: "working-directory", action: "name: token\nruns:\n  using: composite\n  steps:\n    - shell: bash\n      working-directory: ${{ github.token }}\n      run: pwd\n"},
+		{name: "output", action: "name: token\noutputs:\n  token:\n    value: ${{ github.token }}\nruns:\n  using: composite\n  steps:\n    - shell: bash\n      run: echo token\n"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			writeAction(t, workspace, test.name, test.action)
+			compiled, err := compileActionInvocations(t.Context(), workspace, nil, "https://github.com", []string{"./" + test.name}, []map[string]string{nil})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !compiled.requiresGitHubToken {
+				t.Fatal("composite metadata did not request a GitHub token")
+			}
+		})
+	}
+}
+
+func TestCompileActionInvocationsDetectsReachableCompositeChildInputGitHubToken(t *testing.T) {
+	workspace := t.TempDir()
+	writeAction(t, workspace, "child", `name: child
+inputs:
+  token:
+    required: true
+runs:
+  using: node24
+  main: index.js
+`)
+	writeAction(t, workspace, "parent", `name: parent
+inputs:
+  enabled:
+    default: "false"
+runs:
+  using: composite
+  steps:
+    - uses: ./child
+      with:
+        token: ${{ inputs.enabled == 'true' && github.token || '' }}
+`)
+
+	for _, test := range []struct {
+		enabled string
+		want    bool
+	}{
+		{enabled: "false"},
+		{enabled: "true", want: true},
+	} {
+		compiled, err := compileActionInvocations(t.Context(), workspace, nil, "https://github.com", []string{"./parent"}, []map[string]string{{"enabled": test.enabled}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if compiled.requiresGitHubToken != test.want {
+			t.Fatalf("enabled %q requires GitHub token = %t, want %t", test.enabled, compiled.requiresGitHubToken, test.want)
+		}
+	}
+}
+
 func TestCompileActionInvocationsScopesWorkflowAuthoredSecretsByInputContract(t *testing.T) {
 	workspace := t.TempDir()
 	writeAction(t, workspace, "secrets", `name: secret inputs
@@ -546,6 +647,24 @@ runs:
 	_, err := compileActionInvocations(t.Context(), workspace, nil, "https://github.com", []string{"./parent"}, []map[string]string{nil})
 	if err == nil || !strings.Contains(err.Error(), "composite action metadata cannot grant github.token authority") {
 		t.Fatalf("composite metadata token error = %v", err)
+	}
+}
+
+func TestCompileActionInvocationsRejectsSecretAuthorityFromCompositeEnvironment(t *testing.T) {
+	workspace := t.TempDir()
+	writeAction(t, workspace, "secrets", `name: composite secret
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        TOKEN: ${{ secrets.DEPLOY_KEY }}
+      run: echo token
+`)
+
+	_, err := compileActionInvocations(t.Context(), workspace, nil, "https://github.com", []string{"./secrets"}, []map[string]string{nil})
+	if err == nil || !strings.Contains(err.Error(), "composite action metadata cannot grant secret authority") {
+		t.Fatalf("composite environment secret error = %v", err)
 	}
 }
 
@@ -840,6 +959,42 @@ jobs:
 		t.Fatalf("default action token plan = %#v", plans)
 	}
 
+	writeAction(t, w, ".github/actions/composite-token", `name: composite token
+inputs:
+  fallback:
+    default: cargo-binstall
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        DEFAULT_GITHUB_TOKEN: ${{ inputs.fallback == 'cargo-binstall' && github.token || '' }}
+      run: echo token
+`)
+	compositeWorkflow := `on: push
+permissions:
+  contents: read
+jobs:
+  token:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/composite-token
+`
+	plans, err = compile(compositeWorkflow)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 1 || plans[0].GitHubToken == nil || !plans[0].HasCapability("provider-token-write") {
+		t.Fatalf("composite metadata token plan = %#v", plans)
+	}
+	bundle, err = CompileBundleWithOptions(workflowPath, []byte(compositeWorkflow), pushEvent(t), "0.0.0-test", testDistributionDigest, "importer", defaultOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bundle.Plans) != 1 || !reflect.DeepEqual(bundle.Plans[0].Authorization.GitHubTokenActions, []string{"./.github/actions/composite-token"}) {
+		t.Fatalf("composite metadata token attribution = %#v", bundle.Plans)
+	}
+
 	_, err = compile(`on: push
 permissions: {}
 jobs:
@@ -848,7 +1003,7 @@ jobs:
     steps:
       - uses: ./.github/actions/token
 `)
-	if err == nil || !strings.Contains(err.Error(), "action input default that references github.token") || !strings.Contains(err.Error(), "no effective permissions") {
+	if err == nil || !strings.Contains(err.Error(), "action metadata that references github.token") || !strings.Contains(err.Error(), "no effective permissions") {
 		t.Fatalf("compilePlansForTest() error = %v, want empty permission rejection", err)
 	}
 }

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -847,6 +847,66 @@ runs:
 	}
 }
 
+func TestCompileActionInvocationsKeepsEnvironmentMutableBetweenCompositeSteps(t *testing.T) {
+	workspace := t.TempDir()
+	writeAction(t, workspace, "parent", `name: parent
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: echo FLAG=true >> "$GITHUB_ENV"
+    - if: env.FLAG == 'true'
+      shell: bash
+      env:
+        TOKEN: ${{ github.token }}
+      run: echo guarded
+`)
+	compiled, err := compileActionInvocationsWithStepContext(
+		t.Context(), workspace, nil, "https://github.com",
+		[]string{"./parent"}, []map[string]string{nil},
+		[]actionStepPlanningContext{{actionPlanningContext: actionPlanningContext{environment: map[string]string{"FLAG": "false"}}}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !compiled.requiresGitHubToken {
+		t.Fatal("mutable environment made a later token-bearing composite step unreachable")
+	}
+}
+
+func TestCompileActionInvocationsResolvesChildWithBeforeChildEnvironment(t *testing.T) {
+	workspace := t.TempDir()
+	writeAction(t, workspace, "child", `name: child
+inputs:
+  enabled:
+    default: "true"
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        TOKEN: ${{ inputs.enabled != 'false' && github.token || '' }}
+      run: echo guarded
+`)
+	writeAction(t, workspace, "parent", `name: parent
+runs:
+  using: composite
+  steps:
+    - uses: ./child
+      env:
+        ENABLED: "false"
+      with:
+        enabled: ${{ env.ENABLED }}
+`)
+	compiled, err := compileActionInvocations(t.Context(), workspace, nil, "https://github.com", []string{"./parent"}, []map[string]string{nil})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !compiled.requiresGitHubToken {
+		t.Fatal("child with expression incorrectly observed its sibling environment")
+	}
+}
+
 func TestCompileActionInvocationsResolvesProviderGuardsInDefaultsAndConditions(t *testing.T) {
 	workspace := t.TempDir()
 	writeAction(t, workspace, "guarded", `name: guarded
@@ -1595,6 +1655,59 @@ jobs:
 	}
 	if len(bundle.Plans) != 1 || !reflect.DeepEqual(bundle.Plans[0].Authorization.GitHubTokenActions, []string{"./.github/actions/composite-token"}) {
 		t.Fatalf("composite metadata token attribution = %#v", bundle.Plans)
+	}
+
+	writeAction(t, w, ".github/actions/environment-guarded", `name: environment guarded token
+inputs:
+  enabled:
+    default: "false"
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        TOKEN: ${{ inputs.enabled == 'true' && github.token || '' }}
+      run: echo guarded
+`)
+	plans, err = compile(`on: push
+permissions:
+  contents: read
+jobs:
+  token:
+    runs-on: ubuntu-latest
+    env:
+      ENABLED: "false"
+    steps:
+      - run: echo ENABLED=true >> "$GITHUB_ENV"
+      - uses: ./.github/actions/environment-guarded
+        with:
+          enabled: ${{ env.ENABLED }}
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 1 || plans[0].GitHubToken == nil {
+		t.Fatalf("mutable inherited job environment omitted action token: %#v", plans)
+	}
+
+	plans, err = compile(`on: push
+jobs:
+  token:
+    runs-on: ubuntu-latest
+    env:
+      ENABLED: "true"
+    steps:
+      - uses: ./.github/actions/environment-guarded
+        env:
+          ENABLED: "false"
+        with:
+          enabled: ${{ env.ENABLED }}
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 1 || plans[0].GitHubToken != nil {
+		t.Fatalf("fixed step environment retained unreachable action token: %#v", plans)
 	}
 
 	_, err = compile(`on: push

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -531,6 +531,7 @@ runs:
     - shell: bash
       env:
         TOKEN: ${{ env.UNRELATED }}-${{ inputs.enabled == 'true' && github.token || '' }}
+        GUARDED_TOKEN: ${{ inputs.enabled == 'true' && env.RUNTIME == 'yes' && github.token || '' }}
       run: echo "$TOKEN"
 `)
 	compiled, err = compileActionInvocations(t.Context(), workspace, nil, "https://github.com", []string{"./unrelated-runtime"}, []map[string]string{nil})
@@ -660,6 +661,11 @@ runs:
       env:
         TOKEN: ${{ github.token }}
       run: echo "$TOKEN"
+    - if: env.RUNTIME == 'yes' && inputs.enabled == 'true'
+      shell: bash
+      env:
+        TOKEN: ${{ github.token }}
+      run: echo "$TOKEN"
 `)
 	for _, test := range []struct {
 		enabled string
@@ -674,6 +680,74 @@ runs:
 		}
 		if compiled.requiresGitHubToken != test.want {
 			t.Fatalf("runtime condition enabled %q requires GitHub token = %t, want %t", test.enabled, compiled.requiresGitHubToken, test.want)
+		}
+	}
+}
+
+func TestCompileActionInvocationsRetainsTokenForSkippedChildPreHook(t *testing.T) {
+	workspace := t.TempDir()
+	writeAction(t, workspace, "child", `name: child
+runs:
+  using: node24
+  pre: pre.js
+  main: index.js
+`)
+	if err := os.WriteFile(filepath.Join(workspace, "child", "pre.js"), []byte("// fixture\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeAction(t, workspace, "parent", `name: parent
+runs:
+  using: composite
+  steps:
+    - if: ${{ false }}
+      uses: ./child
+      env:
+        TOKEN: ${{ github.token }}
+`)
+	compiled, err := compileActionInvocations(t.Context(), workspace, nil, "https://github.com", []string{"./parent"}, []map[string]string{nil})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !compiled.requiresGitHubToken {
+		t.Fatal("skipped child pre hook did not retain token authority for prepared metadata")
+	}
+}
+
+func TestCompileActionInvocationsResolvesForwardedServerURL(t *testing.T) {
+	workspace := t.TempDir()
+	writeAction(t, workspace, "child", `name: child
+inputs:
+  enabled:
+    default: "false"
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        TOKEN: ${{ inputs.enabled == 'true' && github.token || '' }}
+      run: echo "$TOKEN"
+`)
+	writeAction(t, workspace, "parent", `name: parent
+runs:
+  using: composite
+  steps:
+    - uses: ./child
+      with:
+        enabled: ${{ github.server_url == 'https://github.com' && 'true' || 'false' }}
+`)
+	for _, test := range []struct {
+		serverURL string
+		want      bool
+	}{
+		{serverURL: "https://origin.cursor.com"},
+		{serverURL: "https://github.com", want: true},
+	} {
+		compiled, err := compileActionInvocations(t.Context(), workspace, nil, test.serverURL, []string{"./parent"}, []map[string]string{nil})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if compiled.requiresGitHubToken != test.want {
+			t.Fatalf("server URL %q requires GitHub token = %t, want %t", test.serverURL, compiled.requiresGitHubToken, test.want)
 		}
 	}
 }

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -744,7 +744,7 @@ runs:
 	}
 }
 
-func TestCompileActionInvocationsRejectsGitHubTokenAuthorityFromCompositeMetadata(t *testing.T) {
+func TestCompileActionInvocationsAllowsGitHubTokenAuthorityFromCompositeMetadata(t *testing.T) {
 	workspace := t.TempDir()
 	writeAction(t, workspace, "child", `name: child
 inputs:
@@ -763,9 +763,12 @@ runs:
         token: ${{ github.token }}-${{ toJSON(github) }}
 `)
 
-	_, err := compileActionInvocations(t.Context(), workspace, nil, "https://github.com", []string{"./parent"}, []map[string]string{nil})
-	if err == nil || !strings.Contains(err.Error(), "composite action metadata cannot grant github.token authority") {
-		t.Fatalf("composite metadata token error = %v", err)
+	compiled, err := compileActionInvocations(t.Context(), workspace, nil, "https://github.com", []string{"./parent"}, []map[string]string{nil})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !compiled.requiresGitHubToken {
+		t.Fatal("composite metadata did not request a GitHub token")
 	}
 }
 

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -708,7 +708,7 @@ runs:
 		roots:   map[string]string{"owner/parent": parent, "owner/child": child},
 		commits: map[string]string{"owner/parent": strings.Repeat("a", 40), "owner/child": strings.Repeat("b", 40)},
 	}
-	compiled, err := compileActionInvocationsWithStepContext(t.Context(), t.TempDir(), source, "https://github.com", []string{"owner/parent@v1"}, []map[string]string{nil}, []string{"${{ false }}"}, nil)
+	compiled, err := compileActionInvocationsWithStepContext(t.Context(), t.TempDir(), source, "https://github.com", []string{"owner/parent@v1"}, []map[string]string{nil}, []actionStepPlanningContext{{condition: "${{ false }}"}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -834,8 +834,10 @@ runs:
 		t.Context(), t.TempDir(), source, "https://github.com",
 		[]string{"owner/child@v1"},
 		[]map[string]string{{"token": "${{ github.token }}"}},
-		[]string{"${{ false }}"},
-		[]map[string]string{{"RUN_PRE": "false"}},
+		[]actionStepPlanningContext{{
+			actionPlanningContext: actionPlanningContext{environment: map[string]string{"RUN_PRE": "false"}},
+			condition:             "${{ false }}",
+		}},
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -983,6 +985,19 @@ runs:
 			t.Fatalf("server URL %q requires GitHub token = %t, want %t", test.serverURL, compiled.requiresGitHubToken, test.want)
 		}
 	}
+
+	stepContext := actionStepPlanningContext{actionPlanningContext: actionPlanningContext{workflowInputs: map[string]any{"enabled": false}}}
+	compiled, err := compileActionInvocationsWithStepContext(
+		t.Context(), workspace, nil, "https://github.com",
+		[]string{"./guarded"}, []map[string]string{{"enabled": "${{ inputs.enabled }}"}},
+		[]actionStepPlanningContext{stepContext},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if compiled.requiresGitHubToken {
+		t.Fatal("known false workflow input kept a forwarded token guard reachable")
+	}
 }
 
 func TestCompileActionInvocationsGatesMainAuthorityByWorkflowCondition(t *testing.T) {
@@ -998,14 +1013,24 @@ runs:
 	for _, test := range []struct {
 		serverURL string
 		condition string
+		inputs    map[string]any
+		unknown   map[string]bool
+		env       map[string]string
 		want      bool
 	}{
 		{serverURL: "https://github.com", condition: "${{ false }}"},
 		{serverURL: "https://github.com", condition: "${{ github.server_url == 'https://github.com' }}", want: true},
 		{serverURL: "https://origin.cursor.com", condition: "${{ github.server_url == 'https://github.com' }}"},
 		{serverURL: "https://github.com", condition: "${{ env.RUNTIME == 'yes' }}", want: true},
+		{serverURL: "https://github.com", condition: "${{ inputs.enabled == 'true' }}", inputs: map[string]any{"enabled": false}},
+		{serverURL: "https://github.com", condition: "${{ inputs.enabled == 'true' }}", inputs: map[string]any{"enabled": false}, unknown: map[string]bool{"enabled": true}, want: true},
+		{serverURL: "https://github.com", condition: "${{ env.RUN_ACTION == 'true' }}", env: map[string]string{"RUN_ACTION": "false"}},
 	} {
-		compiled, err := compileActionInvocationsWithStepContext(t.Context(), workspace, nil, test.serverURL, []string{"./token"}, []map[string]string{nil}, []string{test.condition}, nil)
+		stepContext := actionStepPlanningContext{
+			actionPlanningContext: actionPlanningContext{workflowInputs: test.inputs, unknownWorkflowInputs: test.unknown, environment: test.env},
+			condition:             test.condition,
+		}
+		compiled, err := compileActionInvocationsWithStepContext(t.Context(), workspace, nil, test.serverURL, []string{"./token"}, []map[string]string{nil}, []actionStepPlanningContext{stepContext})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -708,7 +708,7 @@ runs:
 		roots:   map[string]string{"owner/parent": parent, "owner/child": child},
 		commits: map[string]string{"owner/parent": strings.Repeat("a", 40), "owner/child": strings.Repeat("b", 40)},
 	}
-	compiled, err := compileActionInvocationsWithConditions(t.Context(), t.TempDir(), source, "https://github.com", []string{"owner/parent@v1"}, []map[string]string{nil}, []string{"${{ false }}"})
+	compiled, err := compileActionInvocationsWithStepContext(t.Context(), t.TempDir(), source, "https://github.com", []string{"owner/parent@v1"}, []map[string]string{nil}, []string{"${{ false }}"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -792,6 +792,56 @@ runs:
 	}
 	if !compiled.requiresGitHubToken {
 		t.Fatal("remote pre environment did not retain token authority before a false pre-if")
+	}
+}
+
+func TestCompileActionInvocationsGatesRemotePreInputsWithStepEnvironment(t *testing.T) {
+	parent, child := t.TempDir(), t.TempDir()
+	writeAction(t, child, "", `name: child
+runs:
+  using: node24
+  pre: pre.js
+  pre-if: env.RUN_PRE == 'true'
+  main: index.js
+`)
+	if err := os.WriteFile(filepath.Join(child, "pre.js"), []byte("// fixture\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeAction(t, parent, "", `name: parent
+runs:
+  using: composite
+  steps:
+    - if: ${{ false }}
+      uses: owner/child@v1
+      env:
+        RUN_PRE: "false"
+      with:
+        token: ${{ github.token }}
+`)
+	source := classifiedActionSource{
+		roots:   map[string]string{"owner/parent": parent, "owner/child": child},
+		commits: map[string]string{"owner/parent": strings.Repeat("a", 40), "owner/child": strings.Repeat("b", 40)},
+	}
+	compiled, err := compileActionInvocations(t.Context(), t.TempDir(), source, "https://github.com", []string{"owner/parent@v1"}, []map[string]string{nil})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if compiled.requiresGitHubToken {
+		t.Fatal("statically skipped child retained token authority behind a false environment-gated pre hook")
+	}
+
+	compiled, err = compileActionInvocationsWithStepContext(
+		t.Context(), t.TempDir(), source, "https://github.com",
+		[]string{"owner/child@v1"},
+		[]map[string]string{{"token": "${{ github.token }}"}},
+		[]string{"${{ false }}"},
+		[]map[string]string{{"RUN_PRE": "false"}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if compiled.requiresGitHubToken {
+		t.Fatal("statically skipped workflow action retained token authority behind a false environment-gated pre hook")
 	}
 }
 
@@ -955,7 +1005,7 @@ runs:
 		{serverURL: "https://origin.cursor.com", condition: "${{ github.server_url == 'https://github.com' }}"},
 		{serverURL: "https://github.com", condition: "${{ env.RUNTIME == 'yes' }}", want: true},
 	} {
-		compiled, err := compileActionInvocationsWithConditions(t.Context(), workspace, nil, test.serverURL, []string{"./token"}, []map[string]string{nil}, []string{test.condition})
+		compiled, err := compileActionInvocationsWithStepContext(t.Context(), workspace, nil, test.serverURL, []string{"./token"}, []map[string]string{nil}, []string{test.condition}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1001,6 +1051,37 @@ runs:
 		if compiled.requiresGitHubToken != test.want {
 			t.Fatalf("server URL %q requires GitHub token = %t, want %t", test.serverURL, compiled.requiresGitHubToken, test.want)
 		}
+	}
+}
+
+func TestCompileActionInvocationsLazilyResolvesForwardedInputs(t *testing.T) {
+	workspace := t.TempDir()
+	writeAction(t, workspace, "child", `name: child
+inputs:
+  enabled:
+    default: "true"
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        TOKEN: ${{ inputs.enabled == 'true' && github.token || '' }}
+      run: echo "$TOKEN"
+`)
+	writeAction(t, workspace, "parent", `name: parent
+runs:
+  using: composite
+  steps:
+    - uses: ./child
+      with:
+        enabled: ${{ false && env.RUNTIME || 'false' }}
+`)
+	compiled, err := compileActionInvocations(t.Context(), workspace, nil, "https://github.com", []string{"./parent"}, []map[string]string{nil})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if compiled.requiresGitHubToken {
+		t.Fatal("unreachable runtime value kept a forwarded input and token branch unknown")
 	}
 }
 

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -457,7 +457,7 @@ runs:
   steps:
     - shell: bash
       env:
-        DEFAULT_GITHUB_TOKEN: ${{ inputs.fallback == 'cargo-binstall' && github.token || '' }}
+        DEFAULT_GITHUB_TOKEN: ${{ inputs.unrelated }}-${{ inputs.fallback == 'cargo-binstall' && github.token || '' }}
       run: echo "$DEFAULT_GITHUB_TOKEN"
 `)
 

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -915,6 +915,51 @@ runs:
 	}
 }
 
+func TestCompileActionInvocationsResolvesPreparationInputsAfterChildEnvironment(t *testing.T) {
+	parent, child := t.TempDir(), t.TempDir()
+	writeAction(t, child, "", `name: child
+inputs:
+  enabled:
+    default: "false"
+  token:
+    default: ${{ inputs.enabled == 'true' && github.token || '' }}
+runs:
+  using: node24
+  pre: pre.js
+  main: index.js
+`)
+	if err := os.WriteFile(filepath.Join(child, "pre.js"), []byte("// fixture\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeAction(t, parent, "", `name: parent
+runs:
+  using: composite
+  steps:
+    - if: ${{ false }}
+      uses: owner/child@v1
+      env:
+        ENABLED: "true"
+      with:
+        enabled: ${{ env.ENABLED }}
+`)
+	source := classifiedActionSource{
+		roots:   map[string]string{"owner/parent": parent, "owner/child": child},
+		commits: map[string]string{"owner/parent": strings.Repeat("a", 40), "owner/child": strings.Repeat("b", 40)},
+	}
+	knownEnvironment := map[string]string{"ENABLED": "false"}
+	compiled, err := compileActionInvocationsWithStepContext(
+		t.Context(), t.TempDir(), source, "https://github.com",
+		[]string{"owner/parent@v1"}, []map[string]string{nil},
+		[]actionStepPlanningContext{{actionPlanningContext: actionPlanningContext{environment: knownEnvironment, preparationEnvironment: knownEnvironment}}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !compiled.requiresGitHubToken {
+		t.Fatal("preparation input did not observe the child environment overlay")
+	}
+}
+
 func TestCompileActionInvocationsResolvesChildWithBeforeChildEnvironment(t *testing.T) {
 	workspace := t.TempDir()
 	writeAction(t, workspace, "child", `name: child

--- a/internal/compiler/plan_builder.go
+++ b/internal/compiler/plan_builder.go
@@ -413,9 +413,10 @@ func (b planBuilder) buildActions(instance JobInstance, steps []plan.Step, actio
 		stepEnvironment := knownValues(resolveKnownValues(steps[stepIndex].Env, workflowContext, unknownWorkflowInputs))
 		actionStepContexts[i] = actionStepPlanningContext{
 			actionPlanningContext: actionPlanningContext{
-				workflowInputs:        instance.Inputs,
-				unknownWorkflowInputs: unknownWorkflowInputs,
-				environment:           stepEnvironment,
+				workflowInputs:         instance.Inputs,
+				unknownWorkflowInputs:  unknownWorkflowInputs,
+				environment:            stepEnvironment,
+				preparationEnvironment: stepEnvironment,
 			},
 			condition: steps[stepIndex].Condition,
 		}

--- a/internal/compiler/plan_builder.go
+++ b/internal/compiler/plan_builder.go
@@ -402,13 +402,27 @@ func (b planBuilder) buildActions(instance JobInstance, steps []plan.Step, actio
 		built.capabilities = capabilities
 		return built, nil
 	}
-	actionConditions := make([]string, len(actionIndexes))
-	actionEnvironments := make([]map[string]string, len(actionIndexes))
-	for i, stepIndex := range actionIndexes {
-		actionConditions[i] = steps[stepIndex].Condition
-		actionEnvironments[i] = steps[stepIndex].Env
+	serverURL := plan.EventServerURL(b.ir.Event.Provider)
+	unknownWorkflowInputs := make(map[string]bool, len(instance.DeferredInputs))
+	for name := range instance.DeferredInputs {
+		unknownWorkflowInputs[name] = true
 	}
-	compiled, err := compileActionInvocationsWithStepContext(b.ctx, instance.RepositoryRoot, b.actionSource, plan.EventServerURL(b.ir.Event.Provider), actionRefs, actionInputs, actionConditions, actionEnvironments)
+	workflowContext := expression.Context{WorkflowInputs: instance.Inputs, GitHub: map[string]any{"server_url": serverURL}}
+	jobEnvironment := knownValues(resolveKnownValues(instance.Env, workflowContext, unknownWorkflowInputs))
+	actionStepContexts := make([]actionStepPlanningContext, len(actionIndexes))
+	for i, stepIndex := range actionIndexes {
+		workflowContext.Env = jobEnvironment
+		stepEnvironment := knownValues(resolveKnownValues(steps[stepIndex].Env, workflowContext, unknownWorkflowInputs))
+		actionStepContexts[i] = actionStepPlanningContext{
+			actionPlanningContext: actionPlanningContext{
+				workflowInputs:        instance.Inputs,
+				unknownWorkflowInputs: unknownWorkflowInputs,
+				environment:           mergeKnownValues(jobEnvironment, stepEnvironment),
+			},
+			condition: steps[stepIndex].Condition,
+		}
+	}
+	compiled, err := compileActionInvocationsWithStepContext(b.ctx, instance.RepositoryRoot, b.actionSource, serverURL, actionRefs, actionInputs, actionStepContexts)
 	if err != nil {
 		return built, fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err)
 	}

--- a/internal/compiler/plan_builder.go
+++ b/internal/compiler/plan_builder.go
@@ -402,7 +402,11 @@ func (b planBuilder) buildActions(instance JobInstance, steps []plan.Step, actio
 		built.capabilities = capabilities
 		return built, nil
 	}
-	compiled, err := compileActionInvocations(b.ctx, instance.RepositoryRoot, b.actionSource, plan.EventServerURL(b.ir.Event.Provider), actionRefs, actionInputs)
+	actionConditions := make([]string, len(actionIndexes))
+	for i, stepIndex := range actionIndexes {
+		actionConditions[i] = steps[stepIndex].Condition
+	}
+	compiled, err := compileActionInvocationsWithConditions(b.ctx, instance.RepositoryRoot, b.actionSource, plan.EventServerURL(b.ir.Event.Provider), actionRefs, actionInputs, actionConditions)
 	if err != nil {
 		return built, fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err)
 	}

--- a/internal/compiler/plan_builder.go
+++ b/internal/compiler/plan_builder.go
@@ -603,7 +603,7 @@ func (b planBuilder) authorizePlanSecrets(instance JobInstance, actions *builtPl
 		policyWorkflow = filepath.Base(instance.SourcePath)
 	}
 	if len(b.ir.Workflow.WorkflowTokenPermissions) == 0 {
-		reference := "an action input default that references github.token"
+		reference := "action metadata that references github.token"
 		if referencesGitHubTokenSecret {
 			reference = "secrets.GITHUB_TOKEN"
 		} else if referencesGitHubToken {

--- a/internal/compiler/plan_builder.go
+++ b/internal/compiler/plan_builder.go
@@ -403,10 +403,12 @@ func (b planBuilder) buildActions(instance JobInstance, steps []plan.Step, actio
 		return built, nil
 	}
 	actionConditions := make([]string, len(actionIndexes))
+	actionEnvironments := make([]map[string]string, len(actionIndexes))
 	for i, stepIndex := range actionIndexes {
 		actionConditions[i] = steps[stepIndex].Condition
+		actionEnvironments[i] = steps[stepIndex].Env
 	}
-	compiled, err := compileActionInvocationsWithConditions(b.ctx, instance.RepositoryRoot, b.actionSource, plan.EventServerURL(b.ir.Event.Provider), actionRefs, actionInputs, actionConditions)
+	compiled, err := compileActionInvocationsWithStepContext(b.ctx, instance.RepositoryRoot, b.actionSource, plan.EventServerURL(b.ir.Event.Provider), actionRefs, actionInputs, actionConditions, actionEnvironments)
 	if err != nil {
 		return built, fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err)
 	}

--- a/internal/compiler/plan_builder.go
+++ b/internal/compiler/plan_builder.go
@@ -408,16 +408,14 @@ func (b planBuilder) buildActions(instance JobInstance, steps []plan.Step, actio
 		unknownWorkflowInputs[name] = true
 	}
 	workflowContext := expression.Context{WorkflowInputs: instance.Inputs, GitHub: map[string]any{"server_url": serverURL}}
-	jobEnvironment := knownValues(resolveKnownValues(instance.Env, workflowContext, unknownWorkflowInputs))
 	actionStepContexts := make([]actionStepPlanningContext, len(actionIndexes))
 	for i, stepIndex := range actionIndexes {
-		workflowContext.Env = jobEnvironment
 		stepEnvironment := knownValues(resolveKnownValues(steps[stepIndex].Env, workflowContext, unknownWorkflowInputs))
 		actionStepContexts[i] = actionStepPlanningContext{
 			actionPlanningContext: actionPlanningContext{
 				workflowInputs:        instance.Inputs,
 				unknownWorkflowInputs: unknownWorkflowInputs,
-				environment:           mergeKnownValues(jobEnvironment, stepEnvironment),
+				environment:           stepEnvironment,
 			},
 			condition: steps[stepIndex].Condition,
 		}

--- a/internal/expression/action_input_default.go
+++ b/internal/expression/action_input_default.go
@@ -85,58 +85,6 @@ func isRunnerTempReference(root string, path []string) bool {
 	return strings.EqualFold(root, "runner") && len(path) == 1 && strings.EqualFold(path[0], "temp")
 }
 
-// ActionInputDefaultRequiresGitHubToken reports whether a metadata default can
-// reach github.token for the event provider. Defaults involving any other
-// runtime value require the token because those values are not known during
-// compilation.
-func ActionInputDefaultRequiresGitHubToken(template, serverURL string) (bool, error) {
-	referencesToken, err := ReferencesGitHubToken(template)
-	if err != nil || !referencesToken {
-		return referencesToken, err
-	}
-	onlyKnownReferences := true
-	err = visitTemplateExpressions(template, func(expression actionlint.ExprNode) error {
-		actionlint.VisitExprNode(expression, func(node, parent actionlint.ExprNode, entering bool) {
-			if !entering || !onlyKnownReferences {
-				return
-			}
-			switch node.(type) {
-			case *actionlint.VariableNode, *actionlint.ObjectDerefNode, *actionlint.IndexAccessNode:
-			default:
-				return
-			}
-			root, path, referenceErr := referencePath(node)
-			if referenceErr != nil {
-				onlyKnownReferences = false
-				return
-			}
-			if len(path) == 0 {
-				switch parent := parent.(type) {
-				case *actionlint.ObjectDerefNode:
-					if parent.Receiver == node {
-						return
-					}
-				case *actionlint.IndexAccessNode:
-					if parent.Operand == node {
-						return
-					}
-				}
-			}
-			onlyKnownReferences = strings.EqualFold(root, "github") && len(path) == 1 &&
-				(strings.EqualFold(path[0], "server_url") || strings.EqualFold(path[0], "token"))
-		})
-		return nil
-	})
-	if err != nil {
-		return false, err
-	}
-	if !onlyKnownReferences {
-		return true, nil
-	}
-	_, err = EvaluateActionInputDefault(template, Context{GitHub: map[string]any{"server_url": serverURL}})
-	return err != nil, nil
-}
-
 func evaluateActionInputDefaultNode(node actionlint.ExprNode, context Context) (any, error) {
 	root, path, err := referencePath(node)
 	if err == nil && strings.EqualFold(root, "runner") && len(path) == 1 && strings.EqualFold(path[0], "debug") && !isDirectRunnerDebug(node, root, path) {

--- a/internal/expression/condition.go
+++ b/internal/expression/condition.go
@@ -500,6 +500,11 @@ func evaluateKnownConditionValue(node actionlint.ExprNode, context ConditionCont
 				return nil, fmt.Errorf("condition input %q is unknown", path[0])
 			}
 			return resolveConditionReference(root, path, context)
+		case strings.EqualFold(root, "env") && len(path) == 1:
+			if _, ok := findStringValue(context.Env, path[0]); !ok {
+				return nil, fmt.Errorf("condition environment value %q is unknown", path[0])
+			}
+			return resolveConditionReference(root, path, context)
 		case strings.EqualFold(root, "github") && len(path) == 1 && strings.EqualFold(path[0], "server_url"):
 			return resolveConditionReference(root, path, context)
 		default:

--- a/internal/expression/condition.go
+++ b/internal/expression/condition.go
@@ -429,6 +429,13 @@ func EvaluateCondition(source string, context ConditionContext) (bool, error) {
 // by known action inputs and short-circuiting. Runtime-dependent results are
 // reported as unknown.
 func EvaluateKnownInputCondition(source string, inputs map[string]any, unknownInputs map[string]bool) (bool, bool, error) {
+	return EvaluateKnownCondition(source, ConditionContext{Inputs: inputs}, unknownInputs)
+}
+
+// EvaluateKnownCondition evaluates a condition when its result is fixed by
+// retained context values and short-circuiting. Runtime-dependent results are
+// reported as unknown.
+func EvaluateKnownCondition(source string, context ConditionContext, unknownInputs map[string]bool) (bool, bool, error) {
 	node, empty, err := parseCondition(source)
 	if err != nil {
 		return false, false, err
@@ -436,7 +443,7 @@ func EvaluateKnownInputCondition(source string, inputs map[string]any, unknownIn
 	if empty {
 		return true, true, nil
 	}
-	return evaluateKnownInputConditionNode(node, ConditionContext{Inputs: inputs}, unknownInputs)
+	return evaluateKnownInputConditionNode(node, context, unknownInputs)
 }
 
 func evaluateKnownInputConditionNode(node actionlint.ExprNode, context ConditionContext, unknownInputs map[string]bool) (bool, bool, error) {
@@ -467,6 +474,18 @@ func evaluateKnownInputConditionNode(node actionlint.ExprNode, context Condition
 		}
 		return evaluateKnownInputConditionNode(logical.Right, context, unknownInputs)
 	}
+	if call, ok := node.(*actionlint.FuncCallNode); ok && strings.EqualFold(call.Callee, "case") && len(call.Args) >= 3 && len(call.Args)%2 == 1 {
+		for i := 0; i < len(call.Args)-1; i += 2 {
+			selected, known, err := evaluateKnownInputConditionNode(call.Args[i], context, unknownInputs)
+			if err != nil || !known {
+				return false, known, err
+			}
+			if selected {
+				return evaluateKnownInputConditionNode(call.Args[i+1], context, unknownInputs)
+			}
+		}
+		return evaluateKnownInputConditionNode(call.Args[len(call.Args)-1], context, unknownInputs)
+	}
 
 	names, dynamic := nodeInputReferences(node)
 	if dynamic && len(unknownInputs) != 0 {
@@ -480,7 +499,10 @@ func evaluateKnownInputConditionNode(node actionlint.ExprNode, context Condition
 	if containsStatusFunction(node) {
 		return false, false, nil
 	}
-	for _, contextName := range []string{"env", "github", "job", "matrix", "needs", "runner", "steps", "vars"} {
+	if nodeUsesGitHubPropertyOutside(node, "server_url") {
+		return false, false, nil
+	}
+	for _, contextName := range []string{"env", "job", "matrix", "needs", "runner", "steps", "vars"} {
 		if nodeUsesContext(node, contextName) {
 			return false, false, nil
 		}

--- a/internal/expression/condition.go
+++ b/internal/expression/condition.go
@@ -442,8 +442,18 @@ func EvaluateKnownInputCondition(source string, inputs map[string]any, unknownIn
 func evaluateKnownInputConditionNode(node actionlint.ExprNode, context ConditionContext, unknownInputs map[string]bool) (bool, bool, error) {
 	if logical, ok := node.(*actionlint.LogicalOpNode); ok {
 		left, known, err := evaluateKnownInputConditionNode(logical.Left, context, unknownInputs)
-		if err != nil || !known {
-			return false, known, err
+		if err != nil {
+			return false, false, err
+		}
+		if !known {
+			right, rightKnown, rightErr := evaluateKnownInputConditionNode(logical.Right, context, unknownInputs)
+			if rightErr != nil {
+				return false, false, rightErr
+			}
+			if rightKnown && (logical.Kind == actionlint.LogicalOpNodeKindAnd && !right || logical.Kind == actionlint.LogicalOpNodeKindOr && right) {
+				return right, true, nil
+			}
+			return false, false, nil
 		}
 		switch logical.Kind {
 		case actionlint.LogicalOpNodeKindAnd:

--- a/internal/expression/condition.go
+++ b/internal/expression/condition.go
@@ -487,31 +487,45 @@ func evaluateKnownInputConditionNode(node actionlint.ExprNode, context Condition
 		return evaluateKnownInputConditionNode(call.Args[len(call.Args)-1], context, unknownInputs)
 	}
 
-	names, dynamic := nodeInputReferences(node)
-	if dynamic && len(unknownInputs) != 0 {
-		return false, false, nil
-	}
-	for _, name := range names {
-		if unknownInputs[name] {
-			return false, false, nil
+	value, known := evaluateKnownConditionValue(node, context, unknownInputs)
+	return githubTruthy(value), known, nil
+}
+
+func evaluateKnownConditionValue(node actionlint.ExprNode, context ConditionContext, unknownInputs map[string]bool) (any, bool) {
+	evaluator := newSemanticEvaluator(conditionSurface)
+	evaluator.resolve = func(root string, path []string) (any, error) {
+		switch {
+		case strings.EqualFold(root, "inputs") && len(path) == 1:
+			if unknownInputs[strings.ToLower(path[0])] {
+				return nil, fmt.Errorf("condition input %q is unknown", path[0])
+			}
+			return resolveConditionReference(root, path, context)
+		case strings.EqualFold(root, "github") && len(path) == 1 && strings.EqualFold(path[0], "server_url"):
+			return resolveConditionReference(root, path, context)
+		default:
+			return nil, fmt.Errorf("condition runtime value is unknown")
 		}
 	}
-	if containsStatusFunction(node) {
-		return false, false, nil
-	}
-	if nodeUsesGitHubPropertyOutside(node, "server_url") {
-		return false, false, nil
-	}
-	for _, contextName := range []string{"env", "job", "matrix", "needs", "runner", "steps", "vars"} {
-		if nodeUsesContext(node, contextName) {
-			return false, false, nil
+	evaluator.resolveRoot = func(root string) (any, error) {
+		if !strings.EqualFold(root, "inputs") || len(unknownInputs) != 0 {
+			return nil, fmt.Errorf("condition runtime context is unknown")
 		}
+		return context.Inputs, nil
 	}
-	value, err := evaluateConditionNode(node, context)
-	if err != nil {
-		return false, false, nil
+	evaluator.truthy = githubTruthy
+	evaluator.compare = func(kind actionlint.CompareOpNodeKind, left, right any) (any, error) {
+		return githubCompare(kind, left, right)
 	}
-	return githubTruthy(value), true, nil
+	evaluator.unsupported = func(actionlint.ExprNode) error { return fmt.Errorf("condition expression is unknown") }
+	evaluator.logicalError = func(actionlint.LogicalOpNodeKind) error { return fmt.Errorf("condition expression is unknown") }
+	evaluator.call = func(evaluator *semanticEvaluator, call *actionlint.FuncCallNode) (any, error) {
+		if value, recognized, err := evaluatePureFunction(evaluator, call); recognized {
+			return value, err
+		}
+		return nil, fmt.Errorf("condition function %q is unknown", call.Callee)
+	}
+	value, err := evaluator.evaluate(node)
+	return value, err == nil
 }
 
 func evaluateConditionNode(node actionlint.ExprNode, context ConditionContext) (any, error) {

--- a/internal/expression/condition.go
+++ b/internal/expression/condition.go
@@ -425,6 +425,63 @@ func EvaluateCondition(source string, context ConditionContext) (bool, error) {
 	return result, nil
 }
 
+// EvaluateKnownInputCondition evaluates a condition when its result is fixed
+// by known action inputs and short-circuiting. Runtime-dependent results are
+// reported as unknown.
+func EvaluateKnownInputCondition(source string, inputs map[string]any, unknownInputs map[string]bool) (bool, bool, error) {
+	node, empty, err := parseCondition(source)
+	if err != nil {
+		return false, false, err
+	}
+	if empty {
+		return true, true, nil
+	}
+	return evaluateKnownInputConditionNode(node, ConditionContext{Inputs: inputs}, unknownInputs)
+}
+
+func evaluateKnownInputConditionNode(node actionlint.ExprNode, context ConditionContext, unknownInputs map[string]bool) (bool, bool, error) {
+	if logical, ok := node.(*actionlint.LogicalOpNode); ok {
+		left, known, err := evaluateKnownInputConditionNode(logical.Left, context, unknownInputs)
+		if err != nil || !known {
+			return false, known, err
+		}
+		switch logical.Kind {
+		case actionlint.LogicalOpNodeKindAnd:
+			if !left {
+				return false, true, nil
+			}
+		case actionlint.LogicalOpNodeKindOr:
+			if left {
+				return true, true, nil
+			}
+		}
+		return evaluateKnownInputConditionNode(logical.Right, context, unknownInputs)
+	}
+
+	names, dynamic := nodeInputReferences(node)
+	if dynamic && len(unknownInputs) != 0 {
+		return false, false, nil
+	}
+	for _, name := range names {
+		if unknownInputs[name] {
+			return false, false, nil
+		}
+	}
+	if containsStatusFunction(node) {
+		return false, false, nil
+	}
+	for _, contextName := range []string{"env", "github", "job", "matrix", "needs", "runner", "steps", "vars"} {
+		if nodeUsesContext(node, contextName) {
+			return false, false, nil
+		}
+	}
+	value, err := evaluateConditionNode(node, context)
+	if err != nil {
+		return false, false, nil
+	}
+	return githubTruthy(value), true, nil
+}
+
 func evaluateConditionNode(node actionlint.ExprNode, context ConditionContext) (any, error) {
 	evaluator := newSemanticEvaluator(conditionSurface)
 	rootValues := make(map[string]any)

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -558,12 +558,32 @@ func TestTemplateUsesContextSupportsIndexedAccess(t *testing.T) {
 }
 
 func TestGitHubTokenInputReferences(t *testing.T) {
-	names, dynamic, err := GitHubTokenInputReferences("${{ inputs.unrelated }}-${{ inputs.beta && github.token }}-${{ inputs['alpha'] }}-${{ inputs[env.KEY] && github.token }}")
+	names, dynamic, err := GitHubTokenInputReferences("${{ inputs.unrelated }}-${{ inputs.beta && github.token }}-${{ inputs['alpha'] }}-${{ inputs[env.KEY] && github.token }}-${{ toJSON(inputs) != '{}' && github.token || '' }}")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(names, []string{"beta"}) || !dynamic {
-		t.Fatalf("GitHubTokenInputReferences() = %#v, %t, want beta and dynamic access", names, dynamic)
+		t.Fatalf("GitHubTokenInputReferences() = %#v, %t, want beta and dynamic or whole-context access", names, dynamic)
+	}
+}
+
+func TestConditionInputReferences(t *testing.T) {
+	names, dynamic, err := ConditionInputReferences("inputs.enabled && inputs['other'] && inputs[env.KEY] && toJSON(inputs) != '{}'")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(names, []string{"enabled", "other"}) || !dynamic {
+		t.Fatalf("ConditionInputReferences() = %#v, %t, want enabled, other, and dynamic access", names, dynamic)
+	}
+}
+
+func TestTemplateInputReferences(t *testing.T) {
+	names, dynamic, err := TemplateInputReferences("${{ inputs.enabled }}-${{ inputs['other'] }}-${{ toJSON(inputs) }}")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(names, []string{"enabled", "other"}) || !dynamic {
+		t.Fatalf("TemplateInputReferences() = %#v, %t, want enabled, other, and whole-context access", names, dynamic)
 	}
 }
 

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -1259,6 +1259,17 @@ func TestEvaluateKnownInputConditionShortCircuitsRuntimeValues(t *testing.T) {
 	}
 }
 
+func TestEvaluateKnownConditionUsesKnownEnvironment(t *testing.T) {
+	run, known, err := EvaluateKnownCondition("env.RUN_PRE == 'true'", ConditionContext{Env: map[string]string{"RUN_PRE": "false"}}, nil)
+	if err != nil || run || !known {
+		t.Fatalf("EvaluateKnownCondition() = %t, %t, %v, want false, true, nil", run, known, err)
+	}
+	_, known, err = EvaluateKnownCondition("env.RUNTIME == 'true'", ConditionContext{Env: map[string]string{"RUN_PRE": "false"}}, nil)
+	if err != nil || known {
+		t.Fatalf("EvaluateKnownCondition() unavailable env = _, %t, %v, want _, false, nil", known, err)
+	}
+}
+
 func TestGitHubTokenRequiresEvaluationShortCircuitsKnownInputs(t *testing.T) {
 	context := Context{Inputs: map[string]string{"enabled": "false"}, GitHub: map[string]any{"server_url": "https://github.com"}}
 	for _, test := range []struct {

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -557,6 +557,16 @@ func TestTemplateUsesContextSupportsIndexedAccess(t *testing.T) {
 	}
 }
 
+func TestTemplateContextReferences(t *testing.T) {
+	names, dynamic, err := TemplateContextReferences("${{ inputs.beta }}-${{ inputs['alpha'] }}-${{ inputs[env.KEY] }}", "inputs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(names, []string{"alpha", "beta"}) || !dynamic {
+		t.Fatalf("TemplateContextReferences() = %#v, %t, want alpha/beta and dynamic access", names, dynamic)
+	}
+}
+
 func TestTemplateUsesGitHubPropertyOutside(t *testing.T) {
 	for _, test := range []struct {
 		template string

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -1274,12 +1274,29 @@ func TestEvaluateKnownInputConditionShortCircuitsRuntimeValues(t *testing.T) {
 		known     bool
 	}{
 		{condition: "inputs.enabled == 'true' && env.RUNTIME == 'yes'", inputs: map[string]any{"enabled": "false"}, known: true},
+		{condition: "env.RUNTIME == 'yes' && inputs.enabled == 'true'", inputs: map[string]any{"enabled": "false"}, known: true},
 		{condition: "inputs.enabled == 'true' && env.RUNTIME == 'yes'", inputs: map[string]any{"enabled": "true"}},
 		{condition: "inputs.enabled == 'true'", inputs: map[string]any{"enabled": "true"}, want: true, known: true},
 	} {
 		got, known, err := EvaluateKnownInputCondition(test.condition, test.inputs, nil)
 		if err != nil || got != test.want || known != test.known {
 			t.Errorf("EvaluateKnownInputCondition(%q) = %t, %t, %v; want %t, %t", test.condition, got, known, err, test.want, test.known)
+		}
+	}
+}
+
+func TestGitHubTokenRequiresEvaluationShortCircuitsKnownInputs(t *testing.T) {
+	context := Context{Inputs: map[string]string{"enabled": "false"}, GitHub: map[string]any{"server_url": "https://github.com"}}
+	for _, test := range []struct {
+		template string
+		want     bool
+	}{
+		{template: "${{ inputs.enabled == 'true' && env.RUNTIME == 'yes' && github.token || '' }}"},
+		{template: "${{ env.RUNTIME == 'yes' && github.token || '' }}", want: true},
+	} {
+		got, err := GitHubTokenRequiresEvaluation(test.template, context, nil)
+		if err != nil || got != test.want {
+			t.Errorf("GitHubTokenRequiresEvaluation(%q) = %t, %v, want %t", test.template, got, err, test.want)
 		}
 	}
 }

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -557,6 +557,25 @@ func TestTemplateUsesContextSupportsIndexedAccess(t *testing.T) {
 	}
 }
 
+func TestTemplateUsesGitHubPropertyOutside(t *testing.T) {
+	for _, test := range []struct {
+		template string
+		want     bool
+	}{
+		{template: "${{ github.server_url == 'https://github.com' && github.token || '' }}"},
+		{template: "${{ github.actor == 'octocat' && github.token || '' }}", want: true},
+		{template: "${{ inputs.actor }}"},
+	} {
+		got, err := TemplateUsesGitHubPropertyOutside(test.template, "server_url", "token")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != test.want {
+			t.Fatalf("TemplateUsesGitHubPropertyOutside(%q) = %t, want %t", test.template, got, test.want)
+		}
+	}
+}
+
 func TestStaticContextReferencesExcludeRuntimeComputedAccess(t *testing.T) {
 	for _, source := range []string{"${{ inputs.enabled }}", "${{ inputs['enabled'] }}", "inputs.enabled"} {
 		var usesInputs bool

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -1294,6 +1294,10 @@ func TestGitHubTokenRequiresEvaluationShortCircuitsKnownInputs(t *testing.T) {
 	}{
 		{template: "${{ inputs.enabled == 'true' && env.RUNTIME == 'yes' && github.token || '' }}"},
 		{template: "${{ case(inputs.enabled == 'true', github.token, '') }}"},
+		{template: "${{ format('constant', github.token) }}"},
+		{template: "${{ contains(fromJSON('[]'), github.token) }}"},
+		{template: "${{ join(fromJSON('[\"one\"]'), github.token) }}"},
+		{template: "${{ format('{0}', github.token) }}", want: true},
 		{template: "${{ env.RUNTIME == 'yes' && github.token || '' }}", want: true},
 	} {
 		got, err := GitHubTokenRequiresEvaluation(test.template, context, nil)

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -557,13 +557,13 @@ func TestTemplateUsesContextSupportsIndexedAccess(t *testing.T) {
 	}
 }
 
-func TestTemplateContextReferences(t *testing.T) {
-	names, dynamic, err := TemplateContextReferences("${{ inputs.beta }}-${{ inputs['alpha'] }}-${{ inputs[env.KEY] }}", "inputs")
+func TestGitHubTokenInputReferences(t *testing.T) {
+	names, dynamic, err := GitHubTokenInputReferences("${{ inputs.unrelated }}-${{ inputs.beta && github.token }}-${{ inputs['alpha'] }}-${{ inputs[env.KEY] && github.token }}")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(names, []string{"alpha", "beta"}) || !dynamic {
-		t.Fatalf("TemplateContextReferences() = %#v, %t, want alpha/beta and dynamic access", names, dynamic)
+	if !reflect.DeepEqual(names, []string{"beta"}) || !dynamic {
+		t.Fatalf("GitHubTokenInputReferences() = %#v, %t, want beta and dynamic access", names, dynamic)
 	}
 }
 

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -252,34 +252,6 @@ func TestEvaluateActionInputDefaultSupportsConditionalValueExpressions(t *testin
 	}
 }
 
-func TestActionInputDefaultRequiresGitHubTokenUsesProviderServerURL(t *testing.T) {
-	for _, test := range []struct {
-		name      string
-		template  string
-		serverURL string
-		want      bool
-	}{
-		{name: "direct GitHub.com token", template: "${{ github.token }}", serverURL: "https://github.com", want: true},
-		{name: "direct Origin token", template: "${{ github.token }}", serverURL: "https://origin.cursor.com", want: true},
-		{name: "GitHub.com guarded token", template: "${{ github.server_url == 'https://github.com' && github.token || '' }}", serverURL: "https://github.com", want: true},
-		{name: "Origin skips GitHub.com token", template: "${{ github.server_url == 'https://github.com' && github.token || '' }}", serverURL: "https://origin.cursor.com"},
-		{name: "Origin reaches reverse guard", template: "${{ github.server_url != 'https://github.com' && github.token || '' }}", serverURL: "https://origin.cursor.com", want: true},
-		{name: "literal false skips token", template: "${{ false && github.token || '' }}", serverURL: "https://origin.cursor.com"},
-		{name: "unknown guard requires token", template: "${{ inputs.use_token && github.token || '' }}", serverURL: "https://origin.cursor.com", want: true},
-		{name: "no token reference", template: "${{ github.server_url }}", serverURL: "https://origin.cursor.com"},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			got, err := ActionInputDefaultRequiresGitHubToken(test.template, test.serverURL)
-			if err != nil || got != test.want {
-				t.Fatalf("ActionInputDefaultRequiresGitHubToken() = %v, %v, want %v", got, err, test.want)
-			}
-		})
-	}
-	if _, err := ActionInputDefaultRequiresGitHubToken("${{ github[env.NAME] }}", "https://origin.cursor.com"); err == nil || !strings.Contains(err.Error(), "index must be a string literal") {
-		t.Fatalf("ActionInputDefaultRequiresGitHubToken() error = %v, want dynamic index rejection", err)
-	}
-}
-
 func TestEvaluateActionInputDefaultSupportsJobStatus(t *testing.T) {
 	references, err := ReferencesJobStatus("${{ job.status }}")
 	if err != nil || !references {
@@ -1276,6 +1248,7 @@ func TestEvaluateKnownInputConditionShortCircuitsRuntimeValues(t *testing.T) {
 		{condition: "inputs.enabled == 'true' && env.RUNTIME == 'yes'", inputs: map[string]any{"enabled": "false"}, known: true},
 		{condition: "env.RUNTIME == 'yes' && inputs.enabled == 'true'", inputs: map[string]any{"enabled": "false"}, known: true},
 		{condition: "case(inputs.enabled == 'true', env.RUNTIME == 'yes', false)", inputs: map[string]any{"enabled": "false"}, known: true},
+		{condition: "format('never', env.RUNTIME) == 'run'", known: true},
 		{condition: "inputs.enabled == 'true' && env.RUNTIME == 'yes'", inputs: map[string]any{"enabled": "true"}},
 		{condition: "inputs.enabled == 'true'", inputs: map[string]any{"enabled": "true"}, want: true, known: true},
 	} {
@@ -1294,6 +1267,7 @@ func TestGitHubTokenRequiresEvaluationShortCircuitsKnownInputs(t *testing.T) {
 	}{
 		{template: "${{ inputs.enabled == 'true' && env.RUNTIME == 'yes' && github.token || '' }}"},
 		{template: "${{ case(inputs.enabled == 'true', github.token, '') }}"},
+		{template: "${{ case(env.RUNTIME == 'yes', '', inputs.enabled == 'true', github.token, '') }}"},
 		{template: "${{ format('constant', github.token) }}"},
 		{template: "${{ contains(fromJSON('[]'), github.token) }}"},
 		{template: "${{ join(fromJSON('[\"one\"]'), github.token) }}"},

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -587,6 +587,21 @@ func TestTemplateInputReferences(t *testing.T) {
 	}
 }
 
+func TestGitHubTokenReferencesRuntimeValueScopesInterpolations(t *testing.T) {
+	for _, test := range []struct {
+		template string
+		want     bool
+	}{
+		{template: "${{ env.UNRELATED }}-${{ inputs.enabled && github.token || '' }}"},
+		{template: "${{ env.GUARD && github.token || '' }}", want: true},
+	} {
+		got, err := GitHubTokenReferencesRuntimeValue(test.template)
+		if err != nil || got != test.want {
+			t.Errorf("GitHubTokenReferencesRuntimeValue(%q) = %t, %v, want %t", test.template, got, err, test.want)
+		}
+	}
+}
+
 func TestTemplateUsesGitHubPropertyOutside(t *testing.T) {
 	for _, test := range []struct {
 		template string
@@ -1247,6 +1262,24 @@ func TestEvaluateConditionInputsMatchNormalExpressionSemantics(t *testing.T) {
 		got, err := EvaluateCondition(condition, context)
 		if err != nil || got != want {
 			t.Errorf("EvaluateCondition(%q) = %v, %v, want %v", condition, got, err, want)
+		}
+	}
+}
+
+func TestEvaluateKnownInputConditionShortCircuitsRuntimeValues(t *testing.T) {
+	for _, test := range []struct {
+		condition string
+		inputs    map[string]any
+		want      bool
+		known     bool
+	}{
+		{condition: "inputs.enabled == 'true' && env.RUNTIME == 'yes'", inputs: map[string]any{"enabled": "false"}, known: true},
+		{condition: "inputs.enabled == 'true' && env.RUNTIME == 'yes'", inputs: map[string]any{"enabled": "true"}},
+		{condition: "inputs.enabled == 'true'", inputs: map[string]any{"enabled": "true"}, want: true, known: true},
+	} {
+		got, known, err := EvaluateKnownInputCondition(test.condition, test.inputs, nil)
+		if err != nil || got != test.want || known != test.known {
+			t.Errorf("EvaluateKnownInputCondition(%q) = %t, %t, %v; want %t, %t", test.condition, got, known, err, test.want, test.known)
 		}
 	}
 }

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -1275,6 +1275,7 @@ func TestEvaluateKnownInputConditionShortCircuitsRuntimeValues(t *testing.T) {
 	}{
 		{condition: "inputs.enabled == 'true' && env.RUNTIME == 'yes'", inputs: map[string]any{"enabled": "false"}, known: true},
 		{condition: "env.RUNTIME == 'yes' && inputs.enabled == 'true'", inputs: map[string]any{"enabled": "false"}, known: true},
+		{condition: "case(inputs.enabled == 'true', env.RUNTIME == 'yes', false)", inputs: map[string]any{"enabled": "false"}, known: true},
 		{condition: "inputs.enabled == 'true' && env.RUNTIME == 'yes'", inputs: map[string]any{"enabled": "true"}},
 		{condition: "inputs.enabled == 'true'", inputs: map[string]any{"enabled": "true"}, want: true, known: true},
 	} {
@@ -1292,6 +1293,7 @@ func TestGitHubTokenRequiresEvaluationShortCircuitsKnownInputs(t *testing.T) {
 		want     bool
 	}{
 		{template: "${{ inputs.enabled == 'true' && env.RUNTIME == 'yes' && github.token || '' }}"},
+		{template: "${{ case(inputs.enabled == 'true', github.token, '') }}"},
 		{template: "${{ env.RUNTIME == 'yes' && github.token || '' }}", want: true},
 	} {
 		got, err := GitHubTokenRequiresEvaluation(test.template, context, nil)

--- a/internal/expression/references.go
+++ b/internal/expression/references.go
@@ -495,12 +495,17 @@ func TemplateUsesContext(source, contextName string) (bool, error) {
 	return found, err
 }
 
-// TemplateContextReferences returns statically named first-level members of a
-// context and reports whether the template also uses computed access.
-func TemplateContextReferences(source, contextName string) ([]string, bool, error) {
+// GitHubTokenInputReferences returns inputs referenced in the same template
+// expressions as github.token and reports whether those expressions also use
+// computed input access.
+func GitHubTokenInputReferences(source string) ([]string, bool, error) {
 	found := map[string]struct{}{}
 	dynamic := false
 	err := visitTemplateExpressions(source, func(expression actionlint.ExprNode) error {
+		referencesToken, err := nodeReferencesGitHubToken(expression)
+		if err != nil || !referencesToken {
+			return err
+		}
 		actionlint.VisitExprNode(expression, func(node, _ actionlint.ExprNode, entering bool) {
 			if !entering {
 				return
@@ -510,7 +515,7 @@ func TemplateContextReferences(source, contextName string) ([]string, bool, erro
 			default:
 				return
 			}
-			if !strings.EqualFold(referenceRoot(node), contextName) {
+			if !strings.EqualFold(referenceRoot(node), "inputs") {
 				return
 			}
 			root, path, err := referencePath(node)
@@ -518,7 +523,7 @@ func TemplateContextReferences(source, contextName string) ([]string, bool, erro
 				dynamic = true
 				return
 			}
-			if strings.EqualFold(root, contextName) && len(path) != 0 {
+			if strings.EqualFold(root, "inputs") && len(path) != 0 {
 				found[strings.ToLower(path[0])] = struct{}{}
 			}
 		})

--- a/internal/expression/references.go
+++ b/internal/expression/references.go
@@ -577,6 +577,26 @@ func githubTokenReachable(node actionlint.ExprNode, context Context, unknownInpu
 	case *actionlint.CompareOpNode:
 		return githubTokenReachable(node.Left, context, unknownInputs) || githubTokenReachable(node.Right, context, unknownInputs)
 	case *actionlint.FuncCallNode:
+		if strings.EqualFold(node.Callee, "case") && len(node.Args) >= 3 && len(node.Args)%2 == 1 {
+			for i := 0; i < len(node.Args)-1; i += 2 {
+				if githubTokenReachable(node.Args[i], context, unknownInputs) {
+					return true
+				}
+				selected, known := evaluateKnownStepNode(node.Args[i], context, unknownInputs)
+				if !known {
+					for _, argument := range node.Args[i+1:] {
+						if githubTokenReachable(argument, context, unknownInputs) {
+							return true
+						}
+					}
+					return false
+				}
+				if selected {
+					return githubTokenReachable(node.Args[i+1], context, unknownInputs)
+				}
+			}
+			return githubTokenReachable(node.Args[len(node.Args)-1], context, unknownInputs)
+		}
 		for _, argument := range node.Args {
 			if githubTokenReachable(argument, context, unknownInputs) {
 				return true
@@ -610,6 +630,18 @@ func evaluateKnownStepNode(node actionlint.ExprNode, context Context, unknownInp
 			return right, true
 		}
 		return false, false
+	}
+	if call, ok := node.(*actionlint.FuncCallNode); ok && strings.EqualFold(call.Callee, "case") && len(call.Args) >= 3 && len(call.Args)%2 == 1 {
+		for i := 0; i < len(call.Args)-1; i += 2 {
+			selected, known := evaluateKnownStepNode(call.Args[i], context, unknownInputs)
+			if !known {
+				return false, false
+			}
+			if selected {
+				return evaluateKnownStepNode(call.Args[i+1], context, unknownInputs)
+			}
+		}
+		return evaluateKnownStepNode(call.Args[len(call.Args)-1], context, unknownInputs)
 	}
 	names, dynamic := nodeInputReferences(node)
 	if dynamic && len(unknownInputs) != 0 {

--- a/internal/expression/references.go
+++ b/internal/expression/references.go
@@ -502,7 +502,7 @@ func GitHubTokenInputReferences(source string) ([]string, bool, error) {
 	found := map[string]struct{}{}
 	dynamic := false
 	err := visitTemplateExpressions(source, func(expression actionlint.ExprNode) error {
-		referencesToken, err := nodeReferencesGitHubToken(expression)
+		referencesToken, err := nodeReferencesGitHubToken(expression, true, false)
 		if err != nil || !referencesToken {
 			return err
 		}

--- a/internal/expression/references.go
+++ b/internal/expression/references.go
@@ -495,6 +495,38 @@ func TemplateUsesContext(source, contextName string) (bool, error) {
 	return found, err
 }
 
+// TemplateContextReferences returns statically named first-level members of a
+// context and reports whether the template also uses computed access.
+func TemplateContextReferences(source, contextName string) ([]string, bool, error) {
+	found := map[string]struct{}{}
+	dynamic := false
+	err := visitTemplateExpressions(source, func(expression actionlint.ExprNode) error {
+		actionlint.VisitExprNode(expression, func(node, _ actionlint.ExprNode, entering bool) {
+			if !entering {
+				return
+			}
+			switch node.(type) {
+			case *actionlint.VariableNode, *actionlint.ObjectDerefNode, *actionlint.ArrayDerefNode, *actionlint.IndexAccessNode:
+			default:
+				return
+			}
+			if !strings.EqualFold(referenceRoot(node), contextName) {
+				return
+			}
+			root, path, err := referencePath(node)
+			if err != nil {
+				dynamic = true
+				return
+			}
+			if strings.EqualFold(root, contextName) && len(path) != 0 {
+				found[strings.ToLower(path[0])] = struct{}{}
+			}
+		})
+		return nil
+	})
+	return sortedReferenceNames(found), dynamic, err
+}
+
 // TemplateUsesGitHubPropertyOutside reports whether a template references a
 // github property other than the allowed static properties.
 func TemplateUsesGitHubPropertyOutside(source string, allowed ...string) (bool, error) {

--- a/internal/expression/references.go
+++ b/internal/expression/references.go
@@ -495,6 +495,32 @@ func TemplateUsesContext(source, contextName string) (bool, error) {
 	return found, err
 }
 
+// TemplateUsesGitHubPropertyOutside reports whether a template references a
+// github property other than the allowed static properties.
+func TemplateUsesGitHubPropertyOutside(source string, allowed ...string) (bool, error) {
+	allowedProperties := make(map[string]bool, len(allowed))
+	for _, property := range allowed {
+		allowedProperties[strings.ToLower(property)] = true
+	}
+	found := false
+	err := visitTemplateExpressions(source, func(expression actionlint.ExprNode) error {
+		actionlint.VisitExprNode(expression, func(node, _ actionlint.ExprNode, entering bool) {
+			if !entering || found {
+				return
+			}
+			switch node.(type) {
+			case *actionlint.VariableNode, *actionlint.ObjectDerefNode, *actionlint.IndexAccessNode:
+			default:
+				return
+			}
+			root, path, _ := referencePath(node)
+			found = strings.EqualFold(root, "github") && len(path) != 0 && !allowedProperties[strings.ToLower(path[0])]
+		})
+		return nil
+	})
+	return found, err
+}
+
 // ConditionUsesStaticContextReference reports whether a condition contains a
 // direct or literal-index reference to a context. Computed indexes and
 // projections remain runtime expressions.

--- a/internal/expression/references.go
+++ b/internal/expression/references.go
@@ -750,7 +750,7 @@ func evaluateKnownStepExpression(node actionlint.ExprNode, context Context, unkn
 	evaluator.resolve = func(root string, path []string) (any, error) {
 		switch {
 		case strings.EqualFold(root, "inputs") && len(path) == 1:
-			if context.Inputs == nil || unknownInputs[strings.ToLower(path[0])] {
+			if (context.Inputs == nil && context.WorkflowInputs == nil) || unknownInputs[strings.ToLower(path[0])] {
 				return nil, errKnownStepValueUnavailable
 			}
 			return resolveRuntimeReferenceWithMissingMembers(root, path, context)
@@ -766,10 +766,13 @@ func evaluateKnownStepExpression(node actionlint.ExprNode, context Context, unkn
 		}
 	}
 	evaluator.resolveRoot = func(root string) (any, error) {
-		if !strings.EqualFold(root, "inputs") || context.Inputs == nil || len(unknownInputs) != 0 {
+		if !strings.EqualFold(root, "inputs") || (context.Inputs == nil && context.WorkflowInputs == nil) || len(unknownInputs) != 0 {
 			return nil, errKnownStepValueUnavailable
 		}
-		return context.Inputs, nil
+		if context.Inputs != nil {
+			return context.Inputs, nil
+		}
+		return context.WorkflowInputs, nil
 	}
 	evaluator.truthy = githubTruthy
 	evaluator.compare = func(kind actionlint.CompareOpNodeKind, left, right any) (any, error) {

--- a/internal/expression/references.go
+++ b/internal/expression/references.go
@@ -597,10 +597,88 @@ func githubTokenReachable(node actionlint.ExprNode, context Context, unknownInpu
 			}
 			return githubTokenReachable(node.Args[len(node.Args)-1], context, unknownInputs)
 		}
+		if reachable, handled := githubTokenReachablePureCall(node, context, unknownInputs); handled {
+			return reachable
+		}
 		for _, argument := range node.Args {
 			if githubTokenReachable(argument, context, unknownInputs) {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+func githubTokenReachablePureCall(node *actionlint.FuncCallNode, context Context, unknownInputs map[string]bool) (bool, bool) {
+	if len(node.Args) == 0 {
+		return false, false
+	}
+	firstReachable := githubTokenReachable(node.Args[0], context, unknownInputs)
+	first, firstKnown := evaluateKnownStepValue(node.Args[0], context, unknownInputs)
+	switch strings.ToLower(node.Callee) {
+	case "format":
+		if firstReachable {
+			return true, true
+		}
+		format, convertible := expressionAggregateString(first)
+		if !firstKnown || !convertible {
+			return !firstKnown && anyGitHubTokenReachable(node.Args[1:], context, unknownInputs), true
+		}
+		reachable := false
+		_, _ = expressionFormat(format, len(node.Args)-1, func(index int) (any, error) {
+			reachable = reachable || githubTokenReachable(node.Args[index+1], context, unknownInputs)
+			return "", nil
+		})
+		return reachable, true
+	case "contains":
+		if firstReachable {
+			return true, true
+		}
+		if !firstKnown {
+			return anyGitHubTokenReachable(node.Args[1:], context, unknownInputs), true
+		}
+		if items, ok := expressionCollection(first); ok && len(items) == 0 {
+			return false, true
+		}
+		if _, ok := expressionString(first); !ok {
+			if _, collection := expressionCollection(first); !collection {
+				return false, true
+			}
+		}
+		return anyGitHubTokenReachable(node.Args[1:], context, unknownInputs), true
+	case "startswith", "endswith":
+		if firstReachable {
+			return true, true
+		}
+		if firstKnown {
+			if _, convertible := expressionString(first); !convertible {
+				return false, true
+			}
+		}
+		return anyGitHubTokenReachable(node.Args[1:], context, unknownInputs), true
+	case "join":
+		if firstReachable {
+			return true, true
+		}
+		if !firstKnown {
+			return anyGitHubTokenReachable(node.Args[1:], context, unknownInputs), true
+		}
+		items, collection := expressionCollection(first)
+		if !collection || len(items) <= 1 {
+			return false, true
+		}
+		return anyGitHubTokenReachable(node.Args[1:], context, unknownInputs), true
+	case "tojson", "fromjson":
+		return firstReachable, true
+	default:
+		return false, false
+	}
+}
+
+func anyGitHubTokenReachable(nodes []actionlint.ExprNode, context Context, unknownInputs map[string]bool) bool {
+	for _, node := range nodes {
+		if githubTokenReachable(node, context, unknownInputs) {
+			return true
 		}
 	}
 	return false
@@ -643,28 +721,33 @@ func evaluateKnownStepNode(node actionlint.ExprNode, context Context, unknownInp
 		}
 		return evaluateKnownStepNode(call.Args[len(call.Args)-1], context, unknownInputs)
 	}
+	value, known := evaluateKnownStepValue(node, context, unknownInputs)
+	return githubTruthy(value), known
+}
+
+func evaluateKnownStepValue(node actionlint.ExprNode, context Context, unknownInputs map[string]bool) (any, bool) {
 	names, dynamic := nodeInputReferences(node)
 	if dynamic && len(unknownInputs) != 0 {
-		return false, false
+		return nil, false
 	}
 	for _, name := range names {
 		if unknownInputs[name] {
-			return false, false
+			return nil, false
 		}
 	}
 	if nodeUsesGitHubPropertyOutside(node, "server_url") {
-		return false, false
+		return nil, false
 	}
 	for _, contextName := range []string{"env", "job", "matrix", "needs", "runner", "services", "steps", "vars"} {
 		if nodeUsesContext(node, contextName) {
-			return false, false
+			return nil, false
 		}
 	}
 	value, err := evaluateStepRuntimeExpression(node, context, true, false, nil)
 	if err != nil {
-		return false, false
+		return nil, false
 	}
-	return githubTruthy(value), true
+	return value, true
 }
 
 func visitGitHubTokenExpressions(source string, visit func(actionlint.ExprNode) error) error {

--- a/internal/expression/references.go
+++ b/internal/expression/references.go
@@ -754,6 +754,11 @@ func evaluateKnownStepExpression(node actionlint.ExprNode, context Context, unkn
 				return nil, errKnownStepValueUnavailable
 			}
 			return resolveRuntimeReferenceWithMissingMembers(root, path, context)
+		case strings.EqualFold(root, "env") && len(path) == 1:
+			if _, ok := findStringValue(context.Env, path[0]); !ok {
+				return nil, errKnownStepValueUnavailable
+			}
+			return resolveRuntimeReferenceWithMissingMembers(root, path, context)
 		case strings.EqualFold(root, "github") && len(path) == 1 && strings.EqualFold(path[0], "server_url"):
 			return resolveRuntimeReferenceWithMissingMembers(root, path, context)
 		default:

--- a/internal/expression/references.go
+++ b/internal/expression/references.go
@@ -4,6 +4,7 @@
 package expression
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -578,24 +579,7 @@ func githubTokenReachable(node actionlint.ExprNode, context Context, unknownInpu
 		return githubTokenReachable(node.Left, context, unknownInputs) || githubTokenReachable(node.Right, context, unknownInputs)
 	case *actionlint.FuncCallNode:
 		if strings.EqualFold(node.Callee, "case") && len(node.Args) >= 3 && len(node.Args)%2 == 1 {
-			for i := 0; i < len(node.Args)-1; i += 2 {
-				if githubTokenReachable(node.Args[i], context, unknownInputs) {
-					return true
-				}
-				selected, known := evaluateKnownStepNode(node.Args[i], context, unknownInputs)
-				if !known {
-					for _, argument := range node.Args[i+1:] {
-						if githubTokenReachable(argument, context, unknownInputs) {
-							return true
-						}
-					}
-					return false
-				}
-				if selected {
-					return githubTokenReachable(node.Args[i+1], context, unknownInputs)
-				}
-			}
-			return githubTokenReachable(node.Args[len(node.Args)-1], context, unknownInputs)
+			return githubTokenReachableCase(node.Args, context, unknownInputs)
 		}
 		if reachable, handled := githubTokenReachablePureCall(node, context, unknownInputs); handled {
 			return reachable
@@ -607,6 +591,23 @@ func githubTokenReachable(node actionlint.ExprNode, context Context, unknownInpu
 		}
 	}
 	return false
+}
+
+func githubTokenReachableCase(arguments []actionlint.ExprNode, context Context, unknownInputs map[string]bool) bool {
+	if len(arguments) == 1 {
+		return githubTokenReachable(arguments[0], context, unknownInputs)
+	}
+	if githubTokenReachable(arguments[0], context, unknownInputs) {
+		return true
+	}
+	selected, known := evaluateKnownStepNode(arguments[0], context, unknownInputs)
+	if known && selected {
+		return githubTokenReachable(arguments[1], context, unknownInputs)
+	}
+	if !known && githubTokenReachable(arguments[1], context, unknownInputs) {
+		return true
+	}
+	return githubTokenReachableCase(arguments[2:], context, unknownInputs)
 }
 
 func githubTokenReachablePureCall(node *actionlint.FuncCallNode, context Context, unknownInputs map[string]bool) (bool, bool) {
@@ -726,28 +727,58 @@ func evaluateKnownStepNode(node actionlint.ExprNode, context Context, unknownInp
 }
 
 func evaluateKnownStepValue(node actionlint.ExprNode, context Context, unknownInputs map[string]bool) (any, bool) {
-	names, dynamic := nodeInputReferences(node)
-	if dynamic && len(unknownInputs) != 0 {
-		return nil, false
+	value, err := evaluateKnownStepExpression(node, context, unknownInputs)
+	return value, err == nil
+}
+
+var errKnownStepValueUnavailable = errors.New("step runtime value is unavailable during planning")
+
+// EvaluateKnownStep evaluates a step template using only retained planning
+// values. Runtime-dependent templates are reported as unknown.
+func EvaluateKnownStep(template string, context Context, unknownInputs map[string]bool) (string, bool, error) {
+	value, err := evaluateRuntimeTemplate(template, context, func(node actionlint.ExprNode, context Context) (any, error) {
+		return evaluateKnownStepExpression(node, context, unknownInputs)
+	})
+	if errors.Is(err, errKnownStepValueUnavailable) {
+		return "", false, nil
 	}
-	for _, name := range names {
-		if unknownInputs[name] {
-			return nil, false
+	return value, err == nil, err
+}
+
+func evaluateKnownStepExpression(node actionlint.ExprNode, context Context, unknownInputs map[string]bool) (any, error) {
+	evaluator := newSemanticEvaluator(stepRuntimeSurface)
+	evaluator.resolve = func(root string, path []string) (any, error) {
+		switch {
+		case strings.EqualFold(root, "inputs") && len(path) == 1:
+			if context.Inputs == nil || unknownInputs[strings.ToLower(path[0])] {
+				return nil, errKnownStepValueUnavailable
+			}
+			return resolveRuntimeReferenceWithMissingMembers(root, path, context)
+		case strings.EqualFold(root, "github") && len(path) == 1 && strings.EqualFold(path[0], "server_url"):
+			return resolveRuntimeReferenceWithMissingMembers(root, path, context)
+		default:
+			return nil, errKnownStepValueUnavailable
 		}
 	}
-	if nodeUsesGitHubPropertyOutside(node, "server_url") {
-		return nil, false
-	}
-	for _, contextName := range []string{"env", "job", "matrix", "needs", "runner", "services", "steps", "vars"} {
-		if nodeUsesContext(node, contextName) {
-			return nil, false
+	evaluator.resolveRoot = func(root string) (any, error) {
+		if !strings.EqualFold(root, "inputs") || context.Inputs == nil || len(unknownInputs) != 0 {
+			return nil, errKnownStepValueUnavailable
 		}
+		return context.Inputs, nil
 	}
-	value, err := evaluateStepRuntimeExpression(node, context, true, false, nil)
-	if err != nil {
-		return nil, false
+	evaluator.truthy = githubTruthy
+	evaluator.compare = func(kind actionlint.CompareOpNodeKind, left, right any) (any, error) {
+		return githubCompare(kind, left, right)
 	}
-	return value, true
+	evaluator.unsupported = func(actionlint.ExprNode) error { return errKnownStepValueUnavailable }
+	evaluator.logicalError = func(actionlint.LogicalOpNodeKind) error { return errKnownStepValueUnavailable }
+	evaluator.call = func(evaluator *semanticEvaluator, call *actionlint.FuncCallNode) (any, error) {
+		if value, recognized, err := evaluatePureFunction(evaluator, call); recognized {
+			return value, err
+		}
+		return nil, errKnownStepValueUnavailable
+	}
+	return evaluator.evaluate(node)
 }
 
 func visitGitHubTokenExpressions(source string, visit func(actionlint.ExprNode) error) error {

--- a/internal/expression/references.go
+++ b/internal/expression/references.go
@@ -539,6 +539,102 @@ func GitHubTokenReferencesRuntimeValue(source string) (bool, error) {
 	return found, err
 }
 
+// GitHubTokenRequiresEvaluation reports whether evaluating a template can
+// reach github.token after reducing known inputs and the retained server URL.
+func GitHubTokenRequiresEvaluation(source string, context Context, unknownInputs map[string]bool) (bool, error) {
+	required := false
+	err := visitGitHubTokenExpressions(source, func(expression actionlint.ExprNode) error {
+		required = required || githubTokenReachable(expression, context, unknownInputs)
+		return nil
+	})
+	return required, err
+}
+
+func githubTokenReachable(node actionlint.ExprNode, context Context, unknownInputs map[string]bool) bool {
+	logical, ok := node.(*actionlint.LogicalOpNode)
+	if ok {
+		if githubTokenReachable(logical.Left, context, unknownInputs) {
+			return true
+		}
+		left, known := evaluateKnownStepNode(logical.Left, context, unknownInputs)
+		if known && (logical.Kind == actionlint.LogicalOpNodeKindAnd && !left || logical.Kind == actionlint.LogicalOpNodeKindOr && left) {
+			return false
+		}
+		return githubTokenReachable(logical.Right, context, unknownInputs)
+	}
+	if directGitHubTokenReference(node) {
+		return true
+	}
+	switch node := node.(type) {
+	case *actionlint.ObjectDerefNode:
+		return githubTokenReachable(node.Receiver, context, unknownInputs)
+	case *actionlint.ArrayDerefNode:
+		return githubTokenReachable(node.Receiver, context, unknownInputs)
+	case *actionlint.IndexAccessNode:
+		return githubTokenReachable(node.Operand, context, unknownInputs) || githubTokenReachable(node.Index, context, unknownInputs)
+	case *actionlint.NotOpNode:
+		return githubTokenReachable(node.Operand, context, unknownInputs)
+	case *actionlint.CompareOpNode:
+		return githubTokenReachable(node.Left, context, unknownInputs) || githubTokenReachable(node.Right, context, unknownInputs)
+	case *actionlint.FuncCallNode:
+		for _, argument := range node.Args {
+			if githubTokenReachable(argument, context, unknownInputs) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func directGitHubTokenReference(node actionlint.ExprNode) bool {
+	switch node.(type) {
+	case *actionlint.VariableNode, *actionlint.ObjectDerefNode, *actionlint.IndexAccessNode:
+	default:
+		return false
+	}
+	root, path, err := referencePath(node)
+	return err == nil && strings.EqualFold(root, "github") && len(path) == 1 && strings.EqualFold(path[0], "token")
+}
+
+func evaluateKnownStepNode(node actionlint.ExprNode, context Context, unknownInputs map[string]bool) (bool, bool) {
+	if logical, ok := node.(*actionlint.LogicalOpNode); ok {
+		left, known := evaluateKnownStepNode(logical.Left, context, unknownInputs)
+		if known {
+			if logical.Kind == actionlint.LogicalOpNodeKindAnd && !left || logical.Kind == actionlint.LogicalOpNodeKindOr && left {
+				return left, true
+			}
+			return evaluateKnownStepNode(logical.Right, context, unknownInputs)
+		}
+		right, rightKnown := evaluateKnownStepNode(logical.Right, context, unknownInputs)
+		if rightKnown && (logical.Kind == actionlint.LogicalOpNodeKindAnd && !right || logical.Kind == actionlint.LogicalOpNodeKindOr && right) {
+			return right, true
+		}
+		return false, false
+	}
+	names, dynamic := nodeInputReferences(node)
+	if dynamic && len(unknownInputs) != 0 {
+		return false, false
+	}
+	for _, name := range names {
+		if unknownInputs[name] {
+			return false, false
+		}
+	}
+	if nodeUsesGitHubPropertyOutside(node, "server_url") {
+		return false, false
+	}
+	for _, contextName := range []string{"env", "job", "matrix", "needs", "runner", "services", "steps", "vars"} {
+		if nodeUsesContext(node, contextName) {
+			return false, false
+		}
+	}
+	value, err := evaluateStepRuntimeExpression(node, context, true, false, nil)
+	if err != nil {
+		return false, false
+	}
+	return githubTruthy(value), true
+}
+
 func visitGitHubTokenExpressions(source string, visit func(actionlint.ExprNode) error) error {
 	return visitTemplateExpressions(source, func(expression actionlint.ExprNode) error {
 		referencesToken, err := nodeReferencesGitHubToken(expression, true, false)

--- a/internal/expression/references.go
+++ b/internal/expression/references.go
@@ -478,21 +478,27 @@ func ConditionUsesContext(source, contextName string) (bool, error) {
 func TemplateUsesContext(source, contextName string) (bool, error) {
 	found := false
 	err := visitTemplateExpressions(source, func(expression actionlint.ExprNode) error {
-		actionlint.VisitExprNode(expression, func(node, _ actionlint.ExprNode, entering bool) {
-			if !entering || found {
-				return
-			}
-			switch node.(type) {
-			case *actionlint.VariableNode, *actionlint.ObjectDerefNode, *actionlint.IndexAccessNode:
-			default:
-				return
-			}
-			root, _, _ := referencePath(node)
-			found = strings.EqualFold(root, contextName)
-		})
+		found = found || nodeUsesContext(expression, contextName)
 		return nil
 	})
 	return found, err
+}
+
+func nodeUsesContext(expression actionlint.ExprNode, contextName string) bool {
+	found := false
+	actionlint.VisitExprNode(expression, func(node, _ actionlint.ExprNode, entering bool) {
+		if !entering || found {
+			return
+		}
+		switch node.(type) {
+		case *actionlint.VariableNode, *actionlint.ObjectDerefNode, *actionlint.IndexAccessNode:
+		default:
+			return
+		}
+		root, _, _ := referencePath(node)
+		found = strings.EqualFold(root, contextName)
+	})
+	return found
 }
 
 // GitHubTokenInputReferences returns inputs referenced in the same template
@@ -501,11 +507,7 @@ func TemplateUsesContext(source, contextName string) (bool, error) {
 func GitHubTokenInputReferences(source string) ([]string, bool, error) {
 	found := map[string]struct{}{}
 	dynamic := false
-	err := visitTemplateExpressions(source, func(expression actionlint.ExprNode) error {
-		referencesToken, err := nodeReferencesGitHubToken(expression, true, false)
-		if err != nil || !referencesToken {
-			return err
-		}
+	err := visitGitHubTokenExpressions(source, func(expression actionlint.ExprNode) error {
 		inputNames, dynamicInputs := nodeInputReferences(expression)
 		for _, name := range inputNames {
 			found[name] = struct{}{}
@@ -514,6 +516,37 @@ func GitHubTokenInputReferences(source string) ([]string, bool, error) {
 		return nil
 	})
 	return sortedReferenceNames(found), dynamic, err
+}
+
+// GitHubTokenReferencesRuntimeValue reports whether an interpolation that
+// references github.token also depends on a runtime context other than inputs
+// or the retained server URL.
+func GitHubTokenReferencesRuntimeValue(source string) (bool, error) {
+	found := false
+	err := visitGitHubTokenExpressions(source, func(expression actionlint.ExprNode) error {
+		if nodeUsesGitHubPropertyOutside(expression, "server_url", "token") {
+			found = true
+			return nil
+		}
+		for _, contextName := range []string{"env", "job", "matrix", "needs", "runner", "services", "steps", "vars"} {
+			if nodeUsesContext(expression, contextName) {
+				found = true
+				break
+			}
+		}
+		return nil
+	})
+	return found, err
+}
+
+func visitGitHubTokenExpressions(source string, visit func(actionlint.ExprNode) error) error {
+	return visitTemplateExpressions(source, func(expression actionlint.ExprNode) error {
+		referencesToken, err := nodeReferencesGitHubToken(expression, true, false)
+		if err != nil || !referencesToken {
+			return err
+		}
+		return visit(expression)
+	})
 }
 
 // ConditionInputReferences returns statically named inputs from a condition
@@ -573,27 +606,33 @@ func nodeInputReferences(expression actionlint.ExprNode) ([]string, bool) {
 // TemplateUsesGitHubPropertyOutside reports whether a template references a
 // github property other than the allowed static properties.
 func TemplateUsesGitHubPropertyOutside(source string, allowed ...string) (bool, error) {
+	found := false
+	err := visitTemplateExpressions(source, func(expression actionlint.ExprNode) error {
+		found = found || nodeUsesGitHubPropertyOutside(expression, allowed...)
+		return nil
+	})
+	return found, err
+}
+
+func nodeUsesGitHubPropertyOutside(expression actionlint.ExprNode, allowed ...string) bool {
 	allowedProperties := make(map[string]bool, len(allowed))
 	for _, property := range allowed {
 		allowedProperties[strings.ToLower(property)] = true
 	}
 	found := false
-	err := visitTemplateExpressions(source, func(expression actionlint.ExprNode) error {
-		actionlint.VisitExprNode(expression, func(node, _ actionlint.ExprNode, entering bool) {
-			if !entering || found {
-				return
-			}
-			switch node.(type) {
-			case *actionlint.VariableNode, *actionlint.ObjectDerefNode, *actionlint.IndexAccessNode:
-			default:
-				return
-			}
-			root, path, _ := referencePath(node)
-			found = strings.EqualFold(root, "github") && len(path) != 0 && !allowedProperties[strings.ToLower(path[0])]
-		})
-		return nil
+	actionlint.VisitExprNode(expression, func(node, _ actionlint.ExprNode, entering bool) {
+		if !entering || found {
+			return
+		}
+		switch node.(type) {
+		case *actionlint.VariableNode, *actionlint.ObjectDerefNode, *actionlint.IndexAccessNode:
+		default:
+			return
+		}
+		root, path, _ := referencePath(node)
+		found = strings.EqualFold(root, "github") && len(path) != 0 && !allowedProperties[strings.ToLower(path[0])]
 	})
-	return found, err
+	return found
 }
 
 // ConditionUsesStaticContextReference reports whether a condition contains a

--- a/internal/expression/references.go
+++ b/internal/expression/references.go
@@ -506,30 +506,68 @@ func GitHubTokenInputReferences(source string) ([]string, bool, error) {
 		if err != nil || !referencesToken {
 			return err
 		}
-		actionlint.VisitExprNode(expression, func(node, _ actionlint.ExprNode, entering bool) {
-			if !entering {
-				return
-			}
-			switch node.(type) {
-			case *actionlint.VariableNode, *actionlint.ObjectDerefNode, *actionlint.ArrayDerefNode, *actionlint.IndexAccessNode:
-			default:
-				return
-			}
-			if !strings.EqualFold(referenceRoot(node), "inputs") {
-				return
-			}
-			root, path, err := referencePath(node)
-			if err != nil {
-				dynamic = true
-				return
-			}
-			if strings.EqualFold(root, "inputs") && len(path) != 0 {
-				found[strings.ToLower(path[0])] = struct{}{}
-			}
-		})
+		inputNames, dynamicInputs := nodeInputReferences(expression)
+		for _, name := range inputNames {
+			found[name] = struct{}{}
+		}
+		dynamic = dynamic || dynamicInputs
 		return nil
 	})
 	return sortedReferenceNames(found), dynamic, err
+}
+
+// ConditionInputReferences returns statically named inputs from a condition
+// and reports whether it also reads the whole context or uses computed access.
+func ConditionInputReferences(source string) ([]string, bool, error) {
+	node, empty, err := parseCondition(source)
+	if err != nil || empty {
+		return nil, false, err
+	}
+	names, dynamic := nodeInputReferences(node)
+	return names, dynamic, nil
+}
+
+// TemplateInputReferences returns statically named inputs from a template and
+// reports whether it also reads the whole context or uses computed access.
+func TemplateInputReferences(source string) ([]string, bool, error) {
+	found := map[string]struct{}{}
+	dynamic := false
+	err := visitTemplateExpressions(source, func(expression actionlint.ExprNode) error {
+		names, expressionDynamic := nodeInputReferences(expression)
+		for _, name := range names {
+			found[name] = struct{}{}
+		}
+		dynamic = dynamic || expressionDynamic
+		return nil
+	})
+	return sortedReferenceNames(found), dynamic, err
+}
+
+func nodeInputReferences(expression actionlint.ExprNode) ([]string, bool) {
+	found := map[string]struct{}{}
+	dynamic := false
+	actionlint.VisitExprNode(expression, func(node, parent actionlint.ExprNode, entering bool) {
+		if !entering || referenceReceiver(node, parent) {
+			return
+		}
+		switch node.(type) {
+		case *actionlint.VariableNode, *actionlint.ObjectDerefNode, *actionlint.ArrayDerefNode, *actionlint.IndexAccessNode:
+		default:
+			return
+		}
+		if !strings.EqualFold(referenceRoot(node), "inputs") {
+			return
+		}
+		root, path, err := referencePath(node)
+		if err != nil || len(path) == 0 {
+			dynamic = true
+			return
+		}
+		if strings.EqualFold(root, "inputs") {
+			found[strings.ToLower(path[0])] = struct{}{}
+		}
+	})
+	return sortedReferenceNames(found), dynamic
 }
 
 // TemplateUsesGitHubPropertyOutside reports whether a template references a

--- a/internal/runtime/action_execution.go
+++ b/internal/runtime/action_execution.go
@@ -2215,7 +2215,7 @@ func (r *jobRun) runCompositeMetadata(ctx context.Context, processor *commandPro
 	}
 	for _, name := range sortedKeys(action.Outputs) {
 		output := action.Outputs[name]
-		value, err := expression.Evaluate(output.Value, eval)
+		value, err := expression.EvaluateStep(output.Value, eval)
 		if err != nil {
 			runErr = errors.Join(runErr, fmt.Errorf("composite output %q: %w", name, err))
 			continue

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -3007,7 +3007,8 @@ jobs:
           test "$ENV_RUNNER_TEMP" = "/action-temp"
           printf 'exported token: %s\n' "$GITHUB_TOKEN"
 
-      - uses: ./.github/actions/observer
+      - id: observer
+        uses: ./.github/actions/observer
 
       - env:
           GITHUB_ACTION_PATH: step-action-path
@@ -3017,6 +3018,7 @@ jobs:
           ENV_GITHUB_ACTION_PATH: ${{ env.GITHUB_ACTION_PATH }}
           ENV_GITHUB_SHA: ${{ env.GITHUB_SHA }}
           ENV_RUNNER_TEMP: ${{ env.RUNNER_TEMP }}
+          OBSERVED_GITHUB_TOKEN: ${{ steps.observer.outputs.token }}
         run: |
           test "$GITHUB_ACTION_PATH" = "step-action-path"
           test "$GITHUB_TOKEN" = "step-token"
@@ -3025,6 +3027,7 @@ jobs:
           test "$ENV_GITHUB_ACTION_PATH" = "file-action-path"
           test "$ENV_GITHUB_SHA" = "action-sha"
           test "$ENV_RUNNER_TEMP" = "/action-temp"
+          test "$OBSERVED_GITHUB_TOKEN" = "ghs_scoped_action_default"
 `)
 	writeFixtureFile(t, workspace, ".github/actions/token/action.yml", `name: token default
 inputs:
@@ -3045,6 +3048,12 @@ fs.appendFileSync(process.env.GITHUB_ENV,
   "EXPECTED_RUNNER_TEMP=" + process.env.RUNNER_TEMP + "\n");
 `)
 	writeFixtureFile(t, workspace, ".github/actions/observer/action.yml", `name: context observer
+inputs:
+  enabled:
+    default: "true"
+outputs:
+  token:
+    value: ${{ inputs.enabled == 'true' && github.token || '' }}
 runs:
   using: composite
   steps:

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -3050,10 +3050,12 @@ runs:
   steps:
     - shell: sh
       env:
+        DEFAULT_GITHUB_TOKEN: ${{ github.token }}
         ENV_GITHUB_ACTION_PATH: ${{ env.GITHUB_ACTION_PATH }}
         ENV_GITHUB_SHA: ${{ env.GITHUB_SHA }}
         ENV_RUNNER_TEMP: ${{ env.RUNNER_TEMP }}
       run: |
+        test "$DEFAULT_GITHUB_TOKEN" = "ghs_scoped_action_default"
         test "$GITHUB_TOKEN" = "ghs_scoped_action_default"
         test "$GITHUB_ACTION_PATH" != "file-action-path"
         test -f "$GITHUB_ACTION_PATH/action.yml"


### PR DESCRIPTION
## Why

Composite actions such as `taiki-e/install-action@v2` can reference `github.token` from guarded step environment expressions. The compiler did not inspect those fields, so the job plan omitted the scoped token and execution failed while evaluating `DEFAULT_GITHUB_TOKEN`.

## What

Inspect runtime-evaluated composite environment, input, command, working-directory, and output expressions when planning token authority. Known input guards skip unreachable token branches, while unknown values used by a token guard conservatively request a token. Ordinary secrets and retained event payloads remain rejected as metadata authority sources.