### PR TITLE
Add actionable failure telemetry

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -316,7 +316,9 @@ The plugin value must be a YAML boolean, not a quoted string.
 
 ## Disable telemetry
 
-In Buildkite jobs, the plugin importer and `run-job` send best-effort completion telemetry through the job-authenticated Buildkite Agent API. Events contain the command, outcome, client version, duration, and bounded diagnostic codes and severities. They do not contain diagnostic messages, workflow content, repository details, paths, action references, expressions, environment variables, or command text.
+In Buildkite jobs, the plugin importer and `run-job` send best-effort completion telemetry through the job-authenticated Buildkite Agent API. Events contain the command, outcome, client version, duration, bounded diagnostic codes and severities, and, for unsuccessful commands, up to 1,024 bytes of normalized user-visible error output. An `error_message_truncated` property indicates that earlier output or the end of the normalized message was omitted.
+
+Buildkite adds the organization, pipeline, build, and job identifiers on the server. The client does not send workflow or event content, environment variables, command text, or secrets as separate properties. Error output can include details already printed in the job log, such as workflow paths, action references, expressions, or values supplied in invalid configuration. Avoid writing secrets to error messages, and disable telemetry when this diagnostic context must not leave the job.
 
 Set `BUILDKITE_GHA_TELEMETRY_DISABLED=true` to disable telemetry. Missing Agent endpoint, job ID, or job token also disables it. Telemetry failures do not change command results.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -316,7 +316,7 @@ The plugin value must be a YAML boolean, not a quoted string.
 
 ## Disable telemetry
 
-In Buildkite jobs, the plugin importer and `run-job` send best-effort completion telemetry through the job-authenticated Buildkite Agent API. Events contain the command, outcome, client version, duration, bounded diagnostic codes and severities, and, for unsuccessful commands, up to 1,024 bytes of normalized user-visible error output. An `error_message_truncated` property indicates that earlier output or the end of the normalized message was omitted.
+In Buildkite jobs, the plugin importer and `run-job` send best-effort completion telemetry through the job-authenticated Buildkite Agent API. Events contain the command, outcome, client version, duration, bounded diagnostic codes and severities, and, for unsuccessful commands, the final 1,024 bytes of normalized user-visible error output. An `error_message_truncated` property indicates that earlier output was omitted.
 
 Buildkite adds the organization, pipeline, build, and job identifiers on the server. The client does not send workflow or event content, environment variables, command text, or secrets as separate properties. Error output can include details already printed in the job log, such as workflow paths, action references, expressions, or values supplied in invalid configuration. Avoid writing secrets to error messages, and disable telemetry when this diagnostic context must not leave the job.
 

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -30,6 +30,7 @@ func pluginContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 	started := time.Now()
 	details := &commandTelemetryDetails{}
 	stderr = details.captureErrors(stderr)
+	runner = captureCommandRunnerErrors(runner, stderr)
 	defer func() {
 		outcome := telemetryOutcome(code, "", ctx.Err())
 		emitCommandTelemetry(ctx, telemetry.CommandPluginImport, outcome, clientVersion, time.Since(started), details.forOutcome(outcome))

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -29,6 +29,7 @@ func plugin(args []string, stdout, stderr io.Writer, version, clientVersion stri
 func pluginContext(ctx context.Context, args []string, stdout, stderr io.Writer, version, clientVersion string, runner transport.Runner) (code int) {
 	started := time.Now()
 	details := &commandTelemetryDetails{}
+	stderr = details.captureErrors(stderr)
 	defer func() {
 		outcome := telemetryOutcome(code, "", ctx.Err())
 		emitCommandTelemetry(ctx, telemetry.CommandPluginImport, outcome, clientVersion, time.Since(started), details.forOutcome(outcome))

--- a/internal/cli/plugin_test.go
+++ b/internal/cli/plugin_test.go
@@ -90,6 +90,9 @@ func TestPluginTelemetryReportsUnprovenActionRuntime(t *testing.T) {
 	if properties.Command != telemetry.CommandPluginImport || properties.Outcome != telemetry.OutcomeSuccess {
 		t.Fatalf("event = %#v", properties)
 	}
+	if properties.ErrorMessage != "" || properties.ErrorMessageTruncated {
+		t.Fatalf("successful event included error output: %#v", properties)
+	}
 	want := []telemetry.Diagnostic{{Code: "W_ACTION_RUNTIME_UNKNOWN", Severity: telemetry.SeverityWarning}}
 	if !reflect.DeepEqual(properties.Diagnostics, want) {
 		t.Fatalf("diagnostics = %#v, want %#v", properties.Diagnostics, want)

--- a/internal/cli/run_job.go
+++ b/internal/cli/run_job.go
@@ -45,6 +45,7 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 	var result gharuntime.JobResult
 	details := &commandTelemetryDetails{}
 	stderr = details.captureErrors(stderr)
+	agent.Runner = captureCommandRunnerErrors(agent.Runner, stderr)
 	defer func() {
 		outcome := telemetryOutcome(code, result.Conclusion, ctx.Err())
 		emitCommandTelemetry(ctx, telemetry.CommandRunJob, outcome, clientVersion, time.Since(started), details.forOutcome(outcome))

--- a/internal/cli/run_job.go
+++ b/internal/cli/run_job.go
@@ -44,6 +44,7 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 	started := time.Now()
 	var result gharuntime.JobResult
 	details := &commandTelemetryDetails{}
+	stderr = details.captureErrors(stderr)
 	defer func() {
 		outcome := telemetryOutcome(code, result.Conclusion, ctx.Err())
 		emitCommandTelemetry(ctx, telemetry.CommandRunJob, outcome, clientVersion, time.Since(started), details.forOutcome(outcome))

--- a/internal/cli/run_job_test.go
+++ b/internal/cli/run_job_test.go
@@ -712,7 +712,7 @@ func TestRunJobFailsWhenAuthoritativePublicationFails(t *testing.T) {
 	if !strings.Contains(stdout.String(), "~~~ :package: Publish GitHub Actions result\n") || !strings.Contains(stdout.String(), "^^^ +++\n") {
 		t.Fatalf("stdout = %q, want failed publication group expanded", stdout.String())
 	}
-	if event := <-events; event.FailurePhase != telemetry.FailurePhaseResultPublication || event.FailureCode != telemetry.FailureCodeUnknown {
+	if event := <-events; event.FailurePhase != telemetry.FailurePhaseResultPublication || event.FailureCode != telemetry.FailureCodeUnknown || !strings.Contains(event.ErrorMessage, "publish terminal result") {
 		t.Fatalf("telemetry = %#v", event)
 	}
 }
@@ -727,7 +727,7 @@ func TestRunJobTelemetryClassifiesExecutionFailure(t *testing.T) {
 	if code := run([]string{"run-job", "--plan", planPath}, &stdout, &stderr, "dev", &cliCaptureRunner{}); code != 1 {
 		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
 	}
-	if event := <-events; event.FailurePhase != telemetry.FailurePhaseExecution || event.FailureCode != telemetry.FailureCodeUnknown {
+	if event := <-events; event.FailurePhase != telemetry.FailurePhaseExecution || event.FailureCode != telemetry.FailureCodeUnknown || !strings.Contains(event.ErrorMessage, "exit status 7") {
 		t.Fatalf("telemetry = %#v", event)
 	}
 }

--- a/internal/cli/run_job_test.go
+++ b/internal/cli/run_job_test.go
@@ -712,8 +712,12 @@ func TestRunJobFailsWhenAuthoritativePublicationFails(t *testing.T) {
 	if !strings.Contains(stdout.String(), "~~~ :package: Publish GitHub Actions result\n") || !strings.Contains(stdout.String(), "^^^ +++\n") {
 		t.Fatalf("stdout = %q, want failed publication group expanded", stdout.String())
 	}
-	if event := <-events; event.FailurePhase != telemetry.FailurePhaseResultPublication || event.FailureCode != telemetry.FailureCodeUnknown || !strings.Contains(event.ErrorMessage, "publish terminal result") {
+	event := <-events
+	if event.FailurePhase != telemetry.FailurePhaseResultPublication || event.FailureCode != telemetry.FailureCodeUnknown {
 		t.Fatalf("telemetry = %#v", event)
+	}
+	if !strings.Contains(event.ErrorMessage, "publish terminal result") {
+		t.Fatalf("telemetry error message = %q", event.ErrorMessage)
 	}
 }
 
@@ -727,8 +731,12 @@ func TestRunJobTelemetryClassifiesExecutionFailure(t *testing.T) {
 	if code := run([]string{"run-job", "--plan", planPath}, &stdout, &stderr, "dev", &cliCaptureRunner{}); code != 1 {
 		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
 	}
-	if event := <-events; event.FailurePhase != telemetry.FailurePhaseExecution || event.FailureCode != telemetry.FailureCodeUnknown || !strings.Contains(event.ErrorMessage, "exit status 7") {
+	event := <-events
+	if event.FailurePhase != telemetry.FailurePhaseExecution || event.FailureCode != telemetry.FailureCodeUnknown {
 		t.Fatalf("telemetry = %#v", event)
+	}
+	if !strings.Contains(event.ErrorMessage, "exit status 7") {
+		t.Fatalf("telemetry error message = %q", event.ErrorMessage)
 	}
 }
 

--- a/internal/cli/telemetry.go
+++ b/internal/cli/telemetry.go
@@ -12,6 +12,7 @@ import (
 	"github.com/buildkite/buildkite-gha/internal/compatibility"
 	"github.com/buildkite/buildkite-gha/internal/compiler"
 	"github.com/buildkite/buildkite-gha/internal/telemetry"
+	"github.com/buildkite/buildkite-gha/internal/transport"
 )
 
 const (
@@ -65,6 +66,15 @@ type commandTelemetryDetails struct {
 
 func (d *commandTelemetryDetails) captureErrors(writer io.Writer) io.Writer {
 	return errorCaptureWriter{writer: writer, capture: &d.errorOutput}
+}
+
+func captureCommandRunnerErrors(runner transport.Runner, writer io.Writer) transport.Runner {
+	commandRunner, ok := runner.(transport.CommandRunner)
+	if !ok {
+		return runner
+	}
+	commandRunner.Stderr = writer
+	return commandRunner
 }
 
 func (d *commandTelemetryDetails) setFailurePhase(phase telemetry.FailurePhase) {

--- a/internal/cli/telemetry.go
+++ b/internal/cli/telemetry.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"errors"
+	"io"
 	"os"
 	"slices"
 	"time"
@@ -13,7 +14,10 @@ import (
 	"github.com/buildkite/buildkite-gha/internal/telemetry"
 )
 
-const maxCommandTelemetryDiagnostics = 20
+const (
+	maxCommandTelemetryDiagnostics = 20
+	maxCommandErrorCaptureBytes    = 64 << 10
+)
 
 func emitCommandTelemetry(ctx context.Context, command telemetry.Command, outcome telemetry.Outcome, version string, duration time.Duration, details telemetry.Details) {
 	client, err := telemetry.New(telemetry.Config{
@@ -56,6 +60,11 @@ type commandTelemetryDetails struct {
 	failureCode  telemetry.FailureCode
 	diagnostics  []telemetry.Diagnostic
 	seen         map[string]int
+	errorOutput  boundedTailBuffer
+}
+
+func (d *commandTelemetryDetails) captureErrors(writer io.Writer) io.Writer {
+	return errorCaptureWriter{writer: writer, capture: &d.errorOutput}
 }
 
 func (d *commandTelemetryDetails) setFailurePhase(phase telemetry.FailurePhase) {
@@ -136,7 +145,10 @@ func (d *commandTelemetryDetails) forOutcome(outcome telemetry.Outcome) telemetr
 	if code == "" {
 		code = telemetry.FailureCodeUnknown
 	}
-	return telemetry.Details{FailurePhase: phase, FailureCode: code, Diagnostics: slices.Clone(d.diagnostics)}
+	return telemetry.Details{
+		FailurePhase: phase, FailureCode: code, Diagnostics: slices.Clone(d.diagnostics),
+		ErrorMessage: string(d.errorOutput.bytes), ErrorMessageTruncated: d.errorOutput.truncated,
+	}
 }
 
 func (d *commandTelemetryDetails) telemetryDetails() telemetry.Details {
@@ -182,4 +194,34 @@ func telemetryPhase(stage string) telemetry.FailurePhase {
 	default:
 		return telemetry.FailurePhaseUnknown
 	}
+}
+
+type errorCaptureWriter struct {
+	writer  io.Writer
+	capture *boundedTailBuffer
+}
+
+func (w errorCaptureWriter) Write(p []byte) (int, error) {
+	n, err := w.writer.Write(p)
+	w.capture.Write(p[:n])
+	return n, err
+}
+
+type boundedTailBuffer struct {
+	bytes     []byte
+	truncated bool
+}
+
+func (b *boundedTailBuffer) Write(p []byte) {
+	if len(p) >= maxCommandErrorCaptureBytes {
+		b.bytes = append(b.bytes[:0], p[len(p)-maxCommandErrorCaptureBytes:]...)
+		b.truncated = true
+		return
+	}
+	if overflow := len(b.bytes) + len(p) - maxCommandErrorCaptureBytes; overflow > 0 {
+		copy(b.bytes, b.bytes[overflow:])
+		b.bytes = b.bytes[:len(b.bytes)-overflow]
+		b.truncated = true
+	}
+	b.bytes = append(b.bytes, p...)
 }

--- a/internal/cli/telemetry.go
+++ b/internal/cli/telemetry.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"slices"
+	"sync"
 	"time"
 
 	buildkitepipeline "github.com/buildkite/buildkite-gha/internal/buildkite"
@@ -65,7 +66,7 @@ type commandTelemetryDetails struct {
 }
 
 func (d *commandTelemetryDetails) captureErrors(writer io.Writer) io.Writer {
-	return errorCaptureWriter{writer: writer, capture: &d.errorOutput}
+	return &errorCaptureWriter{writer: writer, capture: &d.errorOutput}
 }
 
 func captureCommandRunnerErrors(runner transport.Runner, writer io.Writer) transport.Runner {
@@ -207,11 +208,14 @@ func telemetryPhase(stage string) telemetry.FailurePhase {
 }
 
 type errorCaptureWriter struct {
+	mu      sync.Mutex
 	writer  io.Writer
 	capture *boundedTailBuffer
 }
 
-func (w errorCaptureWriter) Write(p []byte) (int, error) {
+func (w *errorCaptureWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	n, err := w.writer.Write(p)
 	w.capture.Write(p[:n])
 	return n, err

--- a/internal/cli/telemetry.go
+++ b/internal/cli/telemetry.go
@@ -228,8 +228,8 @@ type boundedTailBuffer struct {
 
 func (b *boundedTailBuffer) Write(p []byte) {
 	if len(p) >= maxCommandErrorCaptureBytes {
+		b.truncated = b.truncated || len(b.bytes) > 0 || len(p) > maxCommandErrorCaptureBytes
 		b.bytes = append(b.bytes[:0], p[len(p)-maxCommandErrorCaptureBytes:]...)
-		b.truncated = true
 		return
 	}
 	if overflow := len(b.bytes) + len(p) - maxCommandErrorCaptureBytes; overflow > 0 {

--- a/internal/cli/telemetry_test.go
+++ b/internal/cli/telemetry_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/buildkite/buildkite-gha/internal/compiler"
 	"github.com/buildkite/buildkite-gha/internal/plan"
 	"github.com/buildkite/buildkite-gha/internal/telemetry"
+	"github.com/buildkite/buildkite-gha/internal/transport"
 )
 
 func TestCommandCompletionTelemetryPlacementAndExitSemantics(t *testing.T) {
@@ -238,5 +239,26 @@ func TestCommandTelemetryCapturesBoundedErrorTailWithoutChangingOutput(t *testin
 	}
 	if success := details.forOutcome(telemetry.OutcomeSuccess); success.ErrorMessage != "" || success.ErrorMessageTruncated {
 		t.Fatalf("successful telemetry included error output: %#v", success)
+	}
+}
+
+func TestCommandTelemetryCapturesCommandRunnerErrors(t *testing.T) {
+	details := &commandTelemetryDetails{}
+	var stderr bytes.Buffer
+	writer := details.captureErrors(&stderr)
+	runner := captureCommandRunnerErrors(transport.CommandRunner{}, writer)
+
+	commandRunner, ok := runner.(transport.CommandRunner)
+	if !ok {
+		t.Fatalf("runner = %T", runner)
+	}
+	if _, err := commandRunner.Stderr.Write([]byte("agent-diagnostic")); err != nil {
+		t.Fatal(err)
+	}
+	if stderr.String() != "agent-diagnostic" {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+	if got := details.forOutcome(telemetry.OutcomeFailure); got.ErrorMessage != "agent-diagnostic" {
+		t.Fatalf("error message = %q", got.ErrorMessage)
 	}
 }

--- a/internal/cli/telemetry_test.go
+++ b/internal/cli/telemetry_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -240,6 +241,17 @@ func TestCommandTelemetryCapturesBoundedErrorTailWithoutChangingOutput(t *testin
 	}
 	if success := details.forOutcome(telemetry.OutcomeSuccess); success.ErrorMessage != "" || success.ErrorMessageTruncated {
 		t.Fatalf("successful telemetry included error output: %#v", success)
+	}
+}
+
+func TestCommandTelemetryDoesNotMarkExactCaptureAsTruncated(t *testing.T) {
+	details := &commandTelemetryDetails{}
+	writer := details.captureErrors(io.Discard)
+	if _, err := writer.Write([]byte(strings.Repeat("x", maxCommandErrorCaptureBytes))); err != nil {
+		t.Fatal(err)
+	}
+	if got := details.forOutcome(telemetry.OutcomeFailure); got.ErrorMessageTruncated {
+		t.Fatal("exact-capacity error capture was marked truncated")
 	}
 }
 

--- a/internal/cli/telemetry_test.go
+++ b/internal/cli/telemetry_test.go
@@ -27,6 +27,7 @@ func TestCommandCompletionTelemetryPlacementAndExitSemantics(t *testing.T) {
 			DurationMS    int64  `json:"duration_ms"`
 			FailurePhase  string `json:"failure_phase"`
 			FailureCode   string `json:"failure_code"`
+			ErrorMessage  string `json:"error_message"`
 		} `json:"properties"`
 	}
 	events := make(chan event, 2)
@@ -60,8 +61,11 @@ func TestCommandCompletionTelemetryPlacementAndExitSemantics(t *testing.T) {
 			t.Fatalf("run(%q) code = %d, stderr = %q; want %d", test.args, code, stderr.String(), test.wantCode)
 		}
 		received := <-events
-		if received.Event != "pipelines:buildkite_gha:command_completed" || received.Properties.Command != test.wantCommand || received.Properties.Outcome != "usage_error" || received.Properties.ClientVersion != "test-version" || received.Properties.DurationMS < 0 || received.Properties.FailurePhase != "configuration" || received.Properties.FailureCode != "unknown" {
+		if received.Event != "pipelines:buildkite_gha:command_completed" || received.Properties.Command != test.wantCommand || received.Properties.Outcome != "usage_error" || received.Properties.ClientVersion != "test-version" || received.Properties.DurationMS < 0 || received.Properties.FailurePhase != "configuration" || received.Properties.FailureCode != "unknown" || !strings.Contains(received.Properties.ErrorMessage, "unknown") && !strings.Contains(received.Properties.ErrorMessage, "does not accept arguments") {
 			t.Fatalf("run(%q) event = %#v", test.args, received)
+		}
+		if strings.ContainsAny(received.Properties.ErrorMessage, "\r\n\t") {
+			t.Fatalf("run(%q) error_message is not normalized: %q", test.args, received.Properties.ErrorMessage)
 		}
 	}
 }
@@ -214,5 +218,25 @@ func TestRunJobUntypedFailurePhaseIsUnknown(t *testing.T) {
 	details := (&commandTelemetryDetails{}).forOutcome(telemetry.OutcomeFailure)
 	if details.FailurePhase != telemetry.FailurePhaseUnknown || details.FailureCode != telemetry.FailureCodeUnknown {
 		t.Fatalf("run-job fallback details = %#v", details)
+	}
+}
+
+func TestCommandTelemetryCapturesBoundedErrorTailWithoutChangingOutput(t *testing.T) {
+	details := &commandTelemetryDetails{}
+	var stderr bytes.Buffer
+	writer := details.captureErrors(&stderr)
+	message := "omitted" + strings.Repeat("x", maxCommandErrorCaptureBytes) + " final failure"
+	if _, err := writer.Write([]byte(message)); err != nil {
+		t.Fatal(err)
+	}
+	if stderr.String() != message {
+		t.Fatal("error capture changed stderr output")
+	}
+	got := details.forOutcome(telemetry.OutcomeFailure)
+	if !got.ErrorMessageTruncated || len(got.ErrorMessage) != maxCommandErrorCaptureBytes || !strings.HasSuffix(got.ErrorMessage, " final failure") || strings.Contains(got.ErrorMessage, "omitted") {
+		t.Fatalf("captured error = %q (%d bytes), truncated = %t", got.ErrorMessage, len(got.ErrorMessage), got.ErrorMessageTruncated)
+	}
+	if success := details.forOutcome(telemetry.OutcomeSuccess); success.ErrorMessage != "" || success.ErrorMessageTruncated {
+		t.Fatalf("successful telemetry included error output: %#v", success)
 	}
 }

--- a/internal/cli/telemetry_test.go
+++ b/internal/cli/telemetry_test.go
@@ -64,8 +64,20 @@ func TestCommandCompletionTelemetryPlacementAndExitSemantics(t *testing.T) {
 			t.Fatalf("run(%q) code = %d, stderr = %q; want %d", test.args, code, stderr.String(), test.wantCode)
 		}
 		received := <-events
-		if received.Event != "pipelines:buildkite_gha:command_completed" || received.Properties.Command != test.wantCommand || received.Properties.Outcome != "usage_error" || received.Properties.ClientVersion != "test-version" || received.Properties.DurationMS < 0 || received.Properties.FailurePhase != "configuration" || received.Properties.FailureCode != "unknown" || !strings.Contains(received.Properties.ErrorMessage, "unknown") && !strings.Contains(received.Properties.ErrorMessage, "does not accept arguments") {
-			t.Fatalf("run(%q) event = %#v", test.args, received)
+		if received.Event != telemetry.EventCommandCompleted {
+			t.Fatalf("run(%q) event = %q, want %q", test.args, received.Event, telemetry.EventCommandCompleted)
+		}
+		if received.Properties.Command != test.wantCommand || received.Properties.Outcome != "usage_error" {
+			t.Fatalf("run(%q) command/outcome = %q/%q", test.args, received.Properties.Command, received.Properties.Outcome)
+		}
+		if received.Properties.ClientVersion != "test-version" || received.Properties.DurationMS < 0 {
+			t.Fatalf("run(%q) client version/duration = %q/%d", test.args, received.Properties.ClientVersion, received.Properties.DurationMS)
+		}
+		if received.Properties.FailurePhase != "configuration" || received.Properties.FailureCode != "unknown" {
+			t.Fatalf("run(%q) failure = %q/%q", test.args, received.Properties.FailurePhase, received.Properties.FailureCode)
+		}
+		if !strings.Contains(received.Properties.ErrorMessage, "unknown") && !strings.Contains(received.Properties.ErrorMessage, "does not accept arguments") {
+			t.Fatalf("run(%q) error_message = %q", test.args, received.Properties.ErrorMessage)
 		}
 		if strings.ContainsAny(received.Properties.ErrorMessage, "\r\n\t") {
 			t.Fatalf("run(%q) error_message is not normalized: %q", test.args, received.Properties.ErrorMessage)
@@ -236,8 +248,14 @@ func TestCommandTelemetryCapturesBoundedErrorTailWithoutChangingOutput(t *testin
 		t.Fatal("error capture changed stderr output")
 	}
 	got := details.forOutcome(telemetry.OutcomeFailure)
-	if !got.ErrorMessageTruncated || len(got.ErrorMessage) != maxCommandErrorCaptureBytes || !strings.HasSuffix(got.ErrorMessage, " final failure") || strings.Contains(got.ErrorMessage, "omitted") {
-		t.Fatalf("captured error = %q (%d bytes), truncated = %t", got.ErrorMessage, len(got.ErrorMessage), got.ErrorMessageTruncated)
+	if !got.ErrorMessageTruncated {
+		t.Fatal("bounded error capture did not report truncation")
+	}
+	if len(got.ErrorMessage) != maxCommandErrorCaptureBytes {
+		t.Fatalf("captured error = %d bytes, want %d", len(got.ErrorMessage), maxCommandErrorCaptureBytes)
+	}
+	if !strings.HasSuffix(got.ErrorMessage, " final failure") || strings.Contains(got.ErrorMessage, "omitted") {
+		t.Fatalf("captured error = %q, want final failure without omitted prefix", got.ErrorMessage)
 	}
 	if success := details.forOutcome(telemetry.OutcomeSuccess); success.ErrorMessage != "" || success.ErrorMessageTruncated {
 		t.Fatalf("successful telemetry included error output: %#v", success)

--- a/internal/cli/telemetry_test.go
+++ b/internal/cli/telemetry_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 
 	buildkitepipeline "github.com/buildkite/buildkite-gha/internal/buildkite"
@@ -239,6 +240,33 @@ func TestCommandTelemetryCapturesBoundedErrorTailWithoutChangingOutput(t *testin
 	}
 	if success := details.forOutcome(telemetry.OutcomeSuccess); success.ErrorMessage != "" || success.ErrorMessageTruncated {
 		t.Fatalf("successful telemetry included error output: %#v", success)
+	}
+}
+
+func TestCommandTelemetrySerializesConcurrentErrorWrites(t *testing.T) {
+	details := &commandTelemetryDetails{}
+	var stderr bytes.Buffer
+	writer := details.captureErrors(&stderr)
+
+	const writes = 100
+	var wait sync.WaitGroup
+	wait.Add(writes)
+	for range writes {
+		go func() {
+			defer wait.Done()
+			if _, err := writer.Write([]byte("failure\n")); err != nil {
+				t.Errorf("Write() error = %v", err)
+			}
+		}()
+	}
+	wait.Wait()
+
+	want := strings.Repeat("failure\n", writes)
+	if stderr.String() != want {
+		t.Fatalf("stderr = %q, want %q", stderr.String(), want)
+	}
+	if got := details.forOutcome(telemetry.OutcomeFailure).ErrorMessage; got != want {
+		t.Fatalf("captured error = %q, want %q", got, want)
 	}
 }
 

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -327,11 +327,11 @@ func boundedErrorMessage(message string) (string, bool) {
 	if len(message) <= maxErrorMessageBytes {
 		return message, false
 	}
-	end := maxErrorMessageBytes
-	for !utf8.ValidString(message[:end]) {
-		end--
+	start := len(message) - maxErrorMessageBytes
+	for !utf8.RuneStart(message[start]) {
+		start++
 	}
-	return strings.TrimSpace(message[:end]), true
+	return strings.TrimSpace(message[start:]), true
 }
 
 func validAgentURL(u *url.URL) bool {

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -12,6 +12,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 )
 
 const (
@@ -20,6 +22,7 @@ const (
 	defaultTimeout        = 1500 * time.Millisecond
 	responseDrainLimit    = 32 << 10
 	maxClientVersionBytes = 64
+	maxErrorMessageBytes  = 1024
 	maxDurationMS         = int64(1<<31 - 1)
 	maxDiagnostics        = 20
 )
@@ -88,19 +91,23 @@ type Diagnostic struct {
 }
 
 type Details struct {
-	FailurePhase FailurePhase
-	FailureCode  FailureCode
-	Diagnostics  []Diagnostic
+	FailurePhase          FailurePhase
+	FailureCode           FailureCode
+	ErrorMessage          string
+	ErrorMessageTruncated bool
+	Diagnostics           []Diagnostic
 }
 
 type Properties struct {
-	Command       Command      `json:"command"`
-	Outcome       Outcome      `json:"outcome"`
-	ClientVersion string       `json:"client_version"`
-	DurationMS    int64        `json:"duration_ms,omitempty"`
-	FailurePhase  FailurePhase `json:"failure_phase,omitempty"`
-	FailureCode   FailureCode  `json:"failure_code,omitempty"`
-	Diagnostics   []Diagnostic `json:"diagnostics,omitempty"`
+	Command               Command      `json:"command"`
+	Outcome               Outcome      `json:"outcome"`
+	ClientVersion         string       `json:"client_version"`
+	DurationMS            int64        `json:"duration_ms,omitempty"`
+	FailurePhase          FailurePhase `json:"failure_phase,omitempty"`
+	FailureCode           FailureCode  `json:"failure_code,omitempty"`
+	ErrorMessage          string       `json:"error_message,omitempty"`
+	ErrorMessageTruncated bool         `json:"error_message_truncated,omitempty"`
+	Diagnostics           []Diagnostic `json:"diagnostics,omitempty"`
 }
 
 type Config struct {
@@ -182,6 +189,8 @@ func (c *Client) EmitContext(ctx context.Context, command Command, outcome Outco
 	if err != nil {
 		return err
 	}
+	errorMessage, errorMessageTruncated := boundedErrorMessage(details.ErrorMessage)
+	errorMessageTruncated = errorMessage != "" && (errorMessageTruncated || details.ErrorMessageTruncated)
 	durationMS := duration.Milliseconds()
 	if durationMS < 0 {
 		durationMS = 0
@@ -195,7 +204,8 @@ func (c *Client) EmitContext(ctx context.Context, command Command, outcome Outco
 		Event: EventCommandCompleted,
 		Properties: Properties{
 			Command: command, Outcome: outcome, ClientVersion: c.clientVersion, DurationMS: durationMS,
-			FailurePhase: details.FailurePhase, FailureCode: details.FailureCode, Diagnostics: diagnostics,
+			FailurePhase: details.FailurePhase, FailureCode: details.FailureCode,
+			ErrorMessage: errorMessage, ErrorMessageTruncated: errorMessageTruncated, Diagnostics: diagnostics,
 		},
 	})
 	if err != nil {
@@ -304,6 +314,24 @@ func boundedClientVersion(version string) string {
 		}
 	}
 	return version
+}
+
+func boundedErrorMessage(message string) (string, bool) {
+	message = strings.Map(func(character rune) rune {
+		if unicode.IsControl(character) {
+			return ' '
+		}
+		return character
+	}, strings.ToValidUTF8(message, "�"))
+	message = strings.Join(strings.Fields(message), " ")
+	if len(message) <= maxErrorMessageBytes {
+		return message, false
+	}
+	end := maxErrorMessageBytes
+	for !utf8.ValidString(message[:end]) {
+		end--
+	}
+	return strings.TrimSpace(message[:end]), true
 }
 
 func validAgentURL(u *url.URL) bool {

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -51,8 +52,16 @@ func TestClientEmitsCommandCompletedEvent(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if request.Event != EventCommandCompleted || request.Properties.Command != CommandRunJob || request.Properties.Outcome != OutcomeFailure || request.Properties.ClientVersion != "1.2.3" || request.Properties.DurationMS != 1234 || request.Properties.FailurePhase != FailurePhaseParsing || request.Properties.FailureCode != FailureCodeWorkflowSyntax || request.Properties.ErrorMessage != "buildkite-gha: run-job: invalid workflow value" || !request.Properties.ErrorMessageTruncated {
-		t.Fatalf("event = %#v", request)
+	if request.Event != EventCommandCompleted {
+		t.Fatalf("event = %q, want %q", request.Event, EventCommandCompleted)
+	}
+	want := Properties{
+		Command: CommandRunJob, Outcome: OutcomeFailure, ClientVersion: "1.2.3", DurationMS: 1234,
+		FailurePhase: FailurePhaseParsing, FailureCode: FailureCodeWorkflowSyntax,
+		ErrorMessage: "buildkite-gha: run-job: invalid workflow value", ErrorMessageTruncated: true,
+	}
+	if !reflect.DeepEqual(request.Properties, want) {
+		t.Fatalf("properties = %#v, want %#v", request.Properties, want)
 	}
 }
 
@@ -203,8 +212,17 @@ func TestPropertiesAreBounded(t *testing.T) {
 func TestErrorMessageIsNormalizedAndUTF8Bounded(t *testing.T) {
 	message := "earlier output\n\t" + strings.Repeat("界", maxErrorMessageBytes) + "\n immediate failure"
 	bounded, truncated := boundedErrorMessage(message)
-	if !truncated || len(bounded) > maxErrorMessageBytes || !utf8.ValidString(bounded) || strings.HasPrefix(bounded, "earlier output") || !strings.HasSuffix(bounded, "immediate failure") {
-		t.Fatalf("boundedErrorMessage() = %q (%d bytes), %t", bounded, len(bounded), truncated)
+	if !truncated {
+		t.Fatal("boundedErrorMessage() did not report truncation")
+	}
+	if len(bounded) > maxErrorMessageBytes {
+		t.Fatalf("boundedErrorMessage() returned %d bytes, want at most %d", len(bounded), maxErrorMessageBytes)
+	}
+	if !utf8.ValidString(bounded) {
+		t.Fatalf("boundedErrorMessage() returned invalid UTF-8: %q", bounded)
+	}
+	if strings.HasPrefix(bounded, "earlier output") || !strings.HasSuffix(bounded, "immediate failure") {
+		t.Fatalf("boundedErrorMessage() = %q, want final failure without earlier output", bounded)
 	}
 	if got, truncated := boundedErrorMessage("\n failure\t details\x00 \r\n"); got != "failure details" || truncated {
 		t.Fatalf("boundedErrorMessage() = %q, %t", got, truncated)

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 )
 
 const testJobID = "22222222-2222-4222-8222-222222222222"
@@ -200,9 +201,9 @@ func TestPropertiesAreBounded(t *testing.T) {
 }
 
 func TestErrorMessageIsNormalizedAndUTF8Bounded(t *testing.T) {
-	message := "failure\n\t" + strings.Repeat("界", maxErrorMessageBytes)
+	message := "earlier output\n\t" + strings.Repeat("界", maxErrorMessageBytes) + "\n immediate failure"
 	bounded, truncated := boundedErrorMessage(message)
-	if !truncated || len(bounded) > maxErrorMessageBytes || !strings.HasPrefix(bounded, "failure ") || !strings.Contains(bounded, "界") {
+	if !truncated || len(bounded) > maxErrorMessageBytes || !utf8.ValidString(bounded) || strings.HasPrefix(bounded, "earlier output") || !strings.HasSuffix(bounded, "immediate failure") {
 		t.Fatalf("boundedErrorMessage() = %q (%d bytes), %t", bounded, len(bounded), truncated)
 	}
 	if got, truncated := boundedErrorMessage("\n failure\t details\x00 \r\n"); got != "failure details" || truncated {

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -43,12 +43,14 @@ func TestClientEmitsCommandCompletedEvent(t *testing.T) {
 	}
 	duration := 1234 * time.Millisecond
 	if err := client.Emit(CommandRunJob, OutcomeFailure, duration, Details{
-		FailurePhase: FailurePhaseParsing,
-		FailureCode:  FailureCodeWorkflowSyntax,
+		FailurePhase:          FailurePhaseParsing,
+		FailureCode:           FailureCodeWorkflowSyntax,
+		ErrorMessage:          "  buildkite-gha: run-job:\ninvalid workflow\tvalue  ",
+		ErrorMessageTruncated: true,
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if request.Event != EventCommandCompleted || request.Properties.Command != CommandRunJob || request.Properties.Outcome != OutcomeFailure || request.Properties.ClientVersion != "1.2.3" || request.Properties.DurationMS != 1234 || request.Properties.FailurePhase != FailurePhaseParsing || request.Properties.FailureCode != FailureCodeWorkflowSyntax {
+	if request.Event != EventCommandCompleted || request.Properties.Command != CommandRunJob || request.Properties.Outcome != OutcomeFailure || request.Properties.ClientVersion != "1.2.3" || request.Properties.DurationMS != 1234 || request.Properties.FailurePhase != FailurePhaseParsing || request.Properties.FailureCode != FailureCodeWorkflowSyntax || request.Properties.ErrorMessage != "buildkite-gha: run-job: invalid workflow value" || !request.Properties.ErrorMessageTruncated {
 		t.Fatalf("event = %#v", request)
 	}
 }
@@ -194,6 +196,17 @@ func TestPropertiesAreBounded(t *testing.T) {
 	}
 	if err := client.Emit(CommandRunJob, OutcomeFailure, 0, Details{FailurePhase: FailurePhaseUnknown, FailureCode: FailureCode("arbitrary")}); err == nil {
 		t.Fatal("Emit() accepted an unknown failure code")
+	}
+}
+
+func TestErrorMessageIsNormalizedAndUTF8Bounded(t *testing.T) {
+	message := "failure\n\t" + strings.Repeat("界", maxErrorMessageBytes)
+	bounded, truncated := boundedErrorMessage(message)
+	if !truncated || len(bounded) > maxErrorMessageBytes || !strings.HasPrefix(bounded, "failure ") || !strings.Contains(bounded, "界") {
+		t.Fatalf("boundedErrorMessage() = %q (%d bytes), %t", bounded, len(bounded), truncated)
+	}
+	if got, truncated := boundedErrorMessage("\n failure\t details\x00 \r\n"); got != "failure details" || truncated {
+		t.Fatalf("boundedErrorMessage() = %q, %t", got, truncated)
 	}
 }
 


### PR DESCRIPTION
## Why

Recent command failures retain trusted Buildkite job identifiers but broad telemetry buckets such as `execution/unknown` and `E_WORKFLOW_SYNTAX` do not expose the immediate failure reason. Triaging them requires manually locating and reading each job log.

## What

Add a normalized, UTF-8-safe `error_message` excerpt of up to 1,024 bytes to unsuccessful command completion events, with `error_message_truncated` indicating omitted output. Capture remains bounded and best effort, successful commands omit error output, and the telemetry documentation describes the diagnostic context and opt-out privacy boundary.

This depends on [buildkite/buildkite#32859](https://github.com/buildkite/buildkite/pull/32859) being deployed first. The current endpoint rejects unknown properties, so releasing this client before the server would drop completion events. After this client is released, roll it back before reverting the server schema.