### PR TITLE
Fix compatibility gap report parsing

### DIFF
--- a/internal/cli/compatibility_gaps_script_test.go
+++ b/internal/cli/compatibility_gaps_script_test.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCompatibilityGapsKeepsBuildkiteOutputOutOfJSONReports(t *testing.T) {
+	bin := t.TempDir()
+	writeExecutable(t, filepath.Join(bin, "mise"), `#!/bin/sh
+set -eu
+if [ "$1" = exec ] && [ "$2" = -- ] && [ "$3" = go ] && [ "$4" = build ]; then
+  while [ "$1" != -o ]; do shift; done
+  cat >"$2" <<'EOF'
+#!/bin/sh
+echo '{"result":"admitted","diagnostics":[{"message":"legacy release warning"}]}'
+echo 'buildkite-agent: annotation published' >&2
+EOF
+  chmod +x "$2"
+  exit 0
+fi
+if [ "$1" = exec ] && [ "$2" = -- ] && [ "$3" = go ] && [ "$4" = test ]; then
+  exit 0
+fi
+exit 2
+`)
+	writeExecutable(t, filepath.Join(bin, "buildkite-agent"), "#!/bin/sh\ncat >/dev/null\n")
+
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(filepath.Join(root, "scripts", "compatibility-gaps"))
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(),
+		"PATH="+bin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"BUILDKITE=true",
+		"BUILDKITE_JOB_ID=test-job",
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("compatibility-gaps: %v\n%s", err, output)
+	}
+	text := string(output)
+	if !strings.Contains(text, "upload-artifact-versions: passing") || !strings.Contains(text, "Compatibility gaps: 16 passing; 0 blocked.") {
+		t.Fatalf("compatibility-gaps output:\n%s", text)
+	}
+}
+
+func writeExecutable(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(contents), 0o700); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/scripts/compatibility-gaps
+++ b/scripts/compatibility-gaps
@@ -46,11 +46,12 @@ while IFS=$'\t' read -r id title workflow event mode test_name; do
   status=0
   report="$work/$id.out"
   if [[ "$mode" == profile ]]; then
+    report_stderr="$work/$id.err"
     (
       cd "$fixture_root"
       "$work/buildkite-gha" validate --profile hosted --format json \
         --event "$event" ".github/workflows/$workflow"
-    ) >"$report" 2>&1 || status=$?
+    ) >"$report" 2>"$report_stderr" || status=$?
     result="$(jq -r '.result // "invalid-report"' "$report" 2>/dev/null || echo invalid-report)"
     if [[ "$status" == 0 && "$result" == admitted ]]; then
       outcome=passing
@@ -80,6 +81,7 @@ while IFS=$'\t' read -r id title workflow event mode test_name; do
     icon='⚠️'
     if [[ "$mode" == profile ]]; then
       jq -r '.diagnostics[]? | "  \(.code): \(.message)"' "$report" >&2 || true
+      sed -n '1,20p' "$report_stderr" >&2
     else
       sed -n '1,20p' "$report" >&2
     fi


### PR DESCRIPTION
## Why

The compatibility-gap harness merged `validate` stderr into its JSON report. In Buildkite, automatic annotation progress is written to stderr, so valid admitted reports were followed by non-JSON text and classified as blocked.

## What

Keep validator stderr separate from the machine-readable report, while retaining it for blocked-case diagnostics. Add a Buildkite-mode regression test that emits annotation chatter alongside admitted JSON and verifies the aggregate tally remains accurate.
