### PR TITLE
PB-3029: Explain unsupported docker:// actions

### DIFF
--- a/internal/action/source/source.go
+++ b/internal/action/source/source.go
@@ -34,6 +34,8 @@ const (
 	defaultCodeload = "https://codeload.github.com"
 	manifestName    = "manifest-v1.json"
 	mutableRefTTL   = time.Hour
+	// UnsupportedContainerActionReason explains the supported alternative to docker:// actions.
+	UnsupportedContainerActionReason = "docker:// container actions are unsupported; use a Dockerfile action or replace the action with a run step"
 )
 
 var (
@@ -78,7 +80,13 @@ func (m Materialized) Retain(ctx context.Context) (Materialized, error) {
 
 // Parse parses owner/repository[/path]@ref.
 func Parse(raw string) (Reference, error) {
-	if len(raw) == 0 || len(raw) > 2048 || !utf8.ValidString(raw) || strings.ContainsAny(raw, "\\?#") || strings.Contains(raw, "${{") || hasControl(raw) {
+	if len(raw) == 0 || len(raw) > 2048 || !utf8.ValidString(raw) || hasControl(raw) {
+		return Reference{}, fmt.Errorf("invalid action reference")
+	}
+	if strings.HasPrefix(strings.ToLower(raw), "docker://") {
+		return Reference{}, errors.New(UnsupportedContainerActionReason)
+	}
+	if strings.ContainsAny(raw, "\\?#") || strings.Contains(raw, "${{") {
 		return Reference{}, fmt.Errorf("invalid action reference")
 	}
 	at := strings.LastIndexByte(raw, '@')
@@ -86,7 +94,7 @@ func Parse(raw string) (Reference, error) {
 		return Reference{}, fmt.Errorf("action reference must contain owner/repository@ref")
 	}
 	left, ref := raw[:at], raw[at+1:]
-	if len(ref) > 1024 || strings.HasPrefix(left, "./") || strings.HasPrefix(left, "/") || strings.HasPrefix(strings.ToLower(left), "docker://") {
+	if len(ref) > 1024 || strings.HasPrefix(left, "./") || strings.HasPrefix(left, "/") {
 		return Reference{}, fmt.Errorf("invalid action reference")
 	}
 	parts := strings.Split(left, "/")

--- a/internal/action/source/source_test.go
+++ b/internal/action/source/source_test.go
@@ -31,9 +31,17 @@ func TestParse(t *testing.T) {
 			t.Errorf("Parse(%q) = %#v, %v", good, r, err)
 		}
 	}
-	for _, bad := range []string{"", "./local@v1", "docker://image@v1", "owner@v1", "owner/repo", "owner/repo@", "owner//repo@v1", "owner/repo/../x@v1", `owner/repo\x@v1`, "owner/repo@a?b", "owner/repo@${{ x }}", "-owner/repo@v1", "owner/repo.git@v1", "owner/repo@a//b"} {
+	for _, bad := range []string{"", "./local@v1", "owner@v1", "owner/repo", "owner/repo@", "owner//repo@v1", "owner/repo/../x@v1", `owner/repo\x@v1`, "owner/repo@a?b", "owner/repo@${{ x }}", "-owner/repo@v1", "owner/repo.git@v1", "owner/repo@a//b"} {
 		if _, err := Parse(bad); err == nil {
 			t.Errorf("Parse(%q) succeeded", bad)
+		}
+	}
+}
+
+func TestParseExplainsUnsupportedContainerActions(t *testing.T) {
+	for _, reference := range []string{"docker://alpine:3.20", "docker://image@sha256:abc", "DOCKER://alpine:latest"} {
+		if _, err := Parse(reference); err == nil || err.Error() != UnsupportedContainerActionReason {
+			t.Errorf("Parse(%q) error = %v, want %q", reference, err, UnsupportedContainerActionReason)
 		}
 	}
 }

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -214,6 +214,15 @@ func TestActionResolutionMessageDistinguishesResolutionFailure(t *testing.T) {
 	}
 }
 
+func TestActionResolutionMessageExplainsUnsupportedContainerAction(t *testing.T) {
+	reference := "docker://alpine:3.20"
+	_, err := source.Parse(reference)
+	want := `Action "docker://alpine:3.20" is unsupported: docker:// container actions are unsupported; use a Dockerfile action or replace the action with a run step`
+	if got, detail, action := actionResolutionMessage(reference, err); got != want || detail != "" || action != reference {
+		t.Fatalf("actionResolutionMessage() = %q, %q, %q; want %q, empty detail, %q", got, detail, action, want, reference)
+	}
+}
+
 func TestActionResolutionMessageIdentifiesNestedChild(t *testing.T) {
 	err := &actionChildError{
 		child: "owner/composite@v1",

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 
+	actionsource "github.com/buildkite/buildkite-gha/internal/action/source"
 	buildkitepipeline "github.com/buildkite/buildkite-gha/internal/buildkite"
 	"github.com/buildkite/buildkite-gha/internal/expression"
 	"github.com/buildkite/buildkite-gha/internal/plan"
@@ -550,7 +551,14 @@ func supported(path string, job workflow.Job) error {
 		return attributedProcessingFinding(StageExpressions, CodeExpressionInvalid, "compatibility", path, 0, 0, job.ID, "", "", 0, jobError(path, job, "runs-on must resolve statically"))
 	}
 	ids := make(map[string]struct{}, len(job.Steps))
-	for _, step := range job.Steps {
+	for i, step := range job.Steps {
+		if step.Kind == "uses" && strings.HasPrefix(strings.ToLower(step.Uses), "docker://") {
+			return attributedProcessingFinding(
+				StageGraph, CodeGraphInvalid, "compatibility", path, step.Span.Start.Line, step.Span.Start.Column,
+				job.ID, "", step.Uses, i+1,
+				locatedJobError(path, job, step.Span.Start.Line, step.Span.Start.Column, actionsource.UnsupportedContainerActionReason),
+			)
+		}
 		if step.ID != "" {
 			id := strings.ToLower(step.ID)
 			if _, exists := ids[id]; exists {

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -44,6 +44,20 @@ func TestEffectiveReusablePermissionsOnlyNarrowCallerAuthority(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsDockerContainerActions(t *testing.T) {
+	source := []byte(`on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker://alpine:3.20
+`)
+	_, err := Validate("workflow.yml", source)
+	if err == nil || !strings.Contains(err.Error(), "docker:// container actions are unsupported; use a Dockerfile action or replace the action with a run step") {
+		t.Fatalf("Validate() error = %v", err)
+	}
+}
+
 func TestWorkflowTokenPolicyEvidence(t *testing.T) {
 	for _, test := range []struct {
 		name       string

--- a/internal/workflow/parse.go
+++ b/internal/workflow/parse.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	actionsource "github.com/buildkite/buildkite-gha/internal/action/source"
 	"github.com/buildkite/buildkite-gha/internal/expression"
 	"github.com/buildkite/buildkite-gha/internal/plan"
 	"github.com/rhysd/actionlint"
@@ -753,7 +754,11 @@ func adaptJob(path string, in *actionlint.Job, scalars map[Position]any, concurr
 			owned.Span = spanFrom(step.Pos, exec.Run.Value)
 		case *actionlint.ExecAction:
 			if exec.Entrypoint != nil || exec.Args != nil {
-				return Job{}, locatedError(path, step.Pos, in.ID.Value, "action entrypoint and args overrides are unsupported in the supported runtime subset")
+				reason := "action entrypoint and args overrides are unsupported in the supported runtime subset"
+				if strings.HasPrefix(strings.ToLower(exec.Uses.Value), "docker://") {
+					reason = actionsource.UnsupportedContainerActionReason
+				}
+				return Job{}, locatedError(path, step.Pos, in.ID.Value, reason)
 			}
 			owned.Kind = "uses"
 			owned.Uses = exec.Uses.Value
@@ -1352,7 +1357,7 @@ func parseParallelStep(path string, node *yaml.Node) (Step, error) {
 	_, hasEntrypoint := step.With["entrypoint"]
 	_, hasArgs := step.With["args"]
 	if strings.HasPrefix(strings.ToLower(step.Uses), "docker://") && (hasEntrypoint || hasArgs) {
-		return Step{}, yamlNodeError(path, entries["with"], "parallel docker action member uses unsupported entrypoint or args overrides")
+		return Step{}, yamlNodeError(path, entries["with"], actionsource.UnsupportedContainerActionReason)
 	}
 	return step, nil
 }

--- a/internal/workflow/parse_test.go
+++ b/internal/workflow/parse_test.go
@@ -638,7 +638,8 @@ func TestParseConcurrentControlsRejectInvalidInput(t *testing.T) {
 		{name: "parallel member execution", steps: "      - parallel:\n          - run: true\n            uses: ./action\n", want: "parallel member must declare exactly one"},
 		{name: "parallel outer field", steps: "      - name: group\n        parallel:\n          - run: true\n", want: `parallel control does not support "name"`},
 		{name: "parallel outer fields deterministic", steps: "      - name: group\n        id: group\n        parallel:\n          - run: true\n", want: `parallel control does not support "id"`},
-		{name: "parallel docker overrides", steps: "      - parallel:\n          - uses: docker://example/image\n            with:\n              Entrypoint: /bin/sh\n", want: "unsupported entrypoint or args overrides"},
+		{name: "docker overrides", steps: "      - uses: docker://example/image\n        with:\n          args: echo test\n", want: "docker:// container actions are unsupported; use a Dockerfile action or replace the action with a run step"},
+		{name: "parallel docker overrides", steps: "      - parallel:\n          - uses: docker://example/image\n            with:\n              Entrypoint: /bin/sh\n", want: "docker:// container actions are unsupported; use a Dockerfile action or replace the action with a run step"},
 		{name: "unmatched actionlint error", steps: "      - run: true\n        background: true\n        unexpected: true\n", want: `unexpected key "unexpected"`},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
## Why

`docker://` container actions currently reach action-source parsing and fail as an `invalid action reference`; bare `validate` can miss them because it does not resolve remote actions. Full support is a separate product and security project: it needs immutable registry resolution, authentication and digest verification, plan/runtime changes, container invocation parity, and platform policy beyond the existing verified Dockerfile-action path.

Resolves [PB-3029](https://linear.app/buildkite/issue/PB-3029/report-unsupported-docker-actions-clearly-in-buildkite-gha).

## What

Reject `docker://` actions with the actionable Dockerfile-action or `run`-step alternatives across normal and parallel workflow parsing, bare static validation, compilation, and nested action resolution. Parser paths that see container-specific `entrypoint` or `args` inputs now preserve the same root-cause explanation.