### PR TITLE
Support R, Julia, and custom shell templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The [compatibility reference](docs/compatibility.md) is the source of truth. Use
 
 | Good fit | Not currently supported |
 | --- | --- |
-| Linux x86-64 and native macOS arm64 jobs using `bash`, `sh`, or `python` | Windows, Linux arm64, or macOS x86-64 |
+| Linux x86-64 and native macOS arm64 jobs using `bash`, `sh`, `python`, or an installed custom shell | Windows, Linux arm64, or macOS x86-64 |
 | Local and public JavaScript and composite actions; verified Dockerfile actions on Linux | Private actions or private reusable workflows, and Dockerfile actions on macOS |
 | Static matrices, `needs`, outputs, and local or literal public reusable workflows | Dynamic reusable calls, matrices, and expressions outside the documented subset |
 | Exact-commit checkout, including managed private repository access | GitHub environment secrets, GitHub-issued OIDC claims, or protected queues |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -33,7 +33,7 @@ Looking for something else? [Browse open compatibility issues](https://github.co
 | [Platforms](#job-configuration) | 🟡 Supported subset | The hosted importer provides Linux x86-64 with `ubuntu-latest`, `ubuntu-24.04`, or `ubuntu-22.04`. Its Agent API resolves single macOS labels to native macOS arm64 hosted queues before local runner mappings. Labels do not provide GitHub image, toolchain, or Xcode parity. |
 | [Jobs and dependencies](#job-configuration) | ✅ Supported | Static dependencies, matrix fan-out and fan-in, results, and bounded outputs. |
 | [Matrix strategies](#matrix-strategies) | 🟡 Supported subset | Static matrices, `include`, `exclude`, and literal `max-parallel`. Maximum 256 instances per job. `fail-fast` has no effect. |
-| [Shell steps](#commands-and-actions) | 🟡 Supported subset | Linux and macOS `bash`, `sh`, and `python`. |
+| [Shell steps](#commands-and-actions) | 🟡 Supported subset | Linux and macOS `bash`, `sh`, `python`, and custom shell templates. |
 | [Conditions and expressions](#expressions-and-contexts) | 🟡 Supported subset | GitHub-compatible core operators and direct references to selected contexts. |
 | [Reusable workflows](#reusable-workflows) | 🟡 Supported subset | Local and literal public GitHub workflows with static inputs, deferred string inputs from direct needs outputs, and direct job-output mappings. Local calls can inherit Buildkite secret authority. |
 | [Actions](#actions) | 🟡 Supported subset | Local and public JavaScript and composite actions on Linux and macOS; verified Dockerfile actions on Linux only. |
@@ -272,7 +272,7 @@ Jobs expanded from reusable workflows use the top-level requesting workflow's re
 | Key | Status | Behavior |
 | --- | --- | --- |
 | `env` | 🟡 Supported subset | Workflow, job, and step maps use normal precedence; the most specific value wins. Individual values may use supported interpolation. An entire map cannot be expression-valued. |
-| `defaults.run.shell` | 🟡 Supported subset | Supported at workflow and job level. Only `bash`, `sh`, and `python` are supported. Host jobs default to `bash`; job containers default to `sh`. |
+| `defaults.run.shell` | 🟡 Supported subset | Supported at workflow and job level for `bash`, `sh`, `python`, and custom shell templates. Host jobs default to `bash`; job containers default to `sh`. |
 | `defaults.run.working-directory` | 🟡 Supported subset | Supported at workflow and job level for workspace-relative paths. |
 
 A job-level value overrides the same workflow-level environment variable:
@@ -486,7 +486,7 @@ A step can continue after failure and expose its outcome to a later condition:
 
 ### Commands and actions
 
-**🟡 Supported subset.** Commands run in `bash`, `sh`, or `python` within the Linux or macOS workspace. PowerShell, Windows shells, and custom shell templates are unsupported. Working directories cannot escape the workspace. The runner or job container must provide the selected shell on `PATH`.
+**🟡 Supported subset.** Commands run in `bash`, `sh`, `python`, or a custom shell template within the Linux or macOS workspace. Custom templates use `command [options] {0} [more-options]`; `{0}` receives a temporary script path. Arguments support shell-style single quotes, double quotes, and backslash escaping without shell expansion. The runner or job container must provide the selected command on `PATH`; R and Julia are not preinstalled by this support. PowerShell and Windows shells remain unsupported. Working directories cannot escape the workspace.
 
 A shell step can specify its shell and workspace-relative working directory:
 
@@ -495,6 +495,19 @@ A shell step can specify its shell and workspace-relative working directory:
   shell: bash
   working-directory: ./src
   run: go test ./...
+```
+
+Use an interpreter installed by an earlier step or included in the job image:
+
+```yaml
+- shell: Rscript {0}
+  run: print("R script")
+
+- shell: julia --color=yes {0}
+  run: println("Julia script")
+
+- shell: bash -l {0}
+  run: conda info
 ```
 
 A `uses` step may call a supported local or public action. Action inputs under `with` may use supported direct interpolation. `docker://` actions and action `entrypoint` or `args` overrides are rejected.
@@ -644,7 +657,7 @@ Matrices, runner labels, names, concurrency groups, plan-retained runtime templa
 | Public `owner/repo[/path]@ref` action | 🟡 Supported subset | Resolved to an exact commit and digest. |
 | Private action | ❌ Unsupported | No private action source access. |
 | JavaScript action | ✅ Supported | Declares `node16`, `node20`, or `node24`. |
-| Composite action | 🟡 Supported subset | Nested shell steps and locked local or public actions; `bash`, `sh`, or `python` for `run`; literal `continue-on-error`. |
+| Composite action | 🟡 Supported subset | Nested shell steps and locked local or public actions; `bash`, `sh`, `python`, or a custom shell template for `run`; literal `continue-on-error`. |
 | Dockerfile action | 🟡 Supported subset | Verified local or public Dockerfile action on Linux. Rejected on macOS, including through a composite action. |
 | `docker://` action | ❌ Unsupported | Rejected during validation. |
 | Top-level action metadata `env` | ➖ Accepted, no effect | Any valid YAML value is discarded. It is not evaluated, injected, retained in plans, or used to request secrets or tokens. |

--- a/internal/runtime/action_execution.go
+++ b/internal/runtime/action_execution.go
@@ -2409,6 +2409,13 @@ func (r *jobRun) runShellProcess(ctx context.Context, processor *commandProcesso
 	for i := 1; i < len(args); i++ {
 		args[i] = strings.ReplaceAll(args[i], "{0}", path)
 	}
+	if r.jobContainer == nil {
+		command, err := resolveExecutableInPath(args[0], env["PATH"])
+		if err != nil {
+			return err
+		}
+		args[0] = command
+	}
 	return r.runProcess(ctx, processor, dir, env, result, nil, args[0], args[1:]...)
 }
 

--- a/internal/runtime/action_execution.go
+++ b/internal/runtime/action_execution.go
@@ -2364,7 +2364,8 @@ func shellCommand(shell, script string) ([]string, error) {
 }
 
 func (r *jobRun) runShellProcess(ctx context.Context, processor *commandProcessor, dir string, env map[string]string, result *Result, shell, script string) error {
-	if strings.TrimSpace(shell) != "python" {
+	shell = strings.TrimSpace(shell)
+	if shell != "python" && !strings.Contains(shell, "{0}") {
 		args, err := shellCommand(shell, script)
 		if err != nil {
 			return err
@@ -2372,31 +2373,130 @@ func (r *jobRun) runShellProcess(ctx context.Context, processor *commandProcesso
 		return r.runProcess(ctx, processor, dir, env, result, nil, args[0], args[1:]...)
 	}
 
+	args := []string{"python", "{0}"}
+	if shell != "python" {
+		var err error
+		args, err = parseShellTemplate(shell)
+		if err != nil {
+			return err
+		}
+	}
+	extension := shellScriptExtension(args[0])
 	parent := ""
 	if r.jobContainer != nil {
 		parent = r.runnerTemp
 	}
-	file, err := os.CreateTemp(parent, "buildkite-gha-shell-*.py")
+	file, err := os.CreateTemp(parent, "buildkite-gha-shell-*"+extension)
 	if err != nil {
-		return fmt.Errorf("create Python shell script: %w", err)
+		return fmt.Errorf("create shell script: %w", err)
 	}
 	path := file.Name()
 	defer func(path string) { _ = os.Remove(path) }(path)
 	if _, err := file.WriteString(script); err != nil {
-		return errors.Join(fmt.Errorf("write Python shell script: %w", err), file.Close())
+		return errors.Join(fmt.Errorf("write shell script: %w", err), file.Close())
 	}
 	if err := file.Close(); err != nil {
-		return fmt.Errorf("close Python shell script: %w", err)
+		return fmt.Errorf("close shell script: %w", err)
 	}
 	if r.jobContainer != nil {
 		// Job containers may declare any USER, so the mounted script must be
 		// readable without assuming a shared host UID or GID.
 		if err := os.Chmod(path, 0o644); err != nil {
-			return fmt.Errorf("make Python shell script container-readable: %w", err)
+			return fmt.Errorf("make shell script container-readable: %w", err)
 		}
 		path = r.jobContainer.containerPath(path)
 	}
-	return r.runProcess(ctx, processor, dir, env, result, nil, "python", path)
+	for i := 1; i < len(args); i++ {
+		args[i] = strings.ReplaceAll(args[i], "{0}", path)
+	}
+	return r.runProcess(ctx, processor, dir, env, result, nil, args[0], args[1:]...)
+}
+
+func parseShellTemplate(shell string) ([]string, error) {
+	args, err := splitShellTemplate(shell)
+	if err != nil {
+		return nil, fmt.Errorf("parse shell template %q: %w", shell, err)
+	}
+	if len(args) == 0 || args[0] == "" {
+		return nil, fmt.Errorf("shell template %q must contain a command", shell)
+	}
+	command := strings.ToLower(filepath.Base(args[0]))
+	switch command {
+	case "pwsh", "pwsh.exe", "cmd", "cmd.exe", "powershell", "powershell.exe", "msys2", "msys2.cmd", "msys2.exe":
+		return nil, fmt.Errorf("shell %q is unsupported in the supported runtime subset", shell)
+	}
+	hasPlaceholder := false
+	for _, arg := range args[1:] {
+		hasPlaceholder = hasPlaceholder || strings.Contains(arg, "{0}")
+	}
+	if !hasPlaceholder {
+		return nil, fmt.Errorf("shell template %q must contain {0} in its arguments", shell)
+	}
+	return args, nil
+}
+
+func splitShellTemplate(shell string) ([]string, error) {
+	var args []string
+	var arg strings.Builder
+	var quote rune
+	escaped := false
+	inArg := false
+	flush := func() {
+		if inArg {
+			args = append(args, arg.String())
+			arg.Reset()
+			inArg = false
+		}
+	}
+	for _, char := range shell {
+		if escaped {
+			arg.WriteRune(char)
+			escaped = false
+			inArg = true
+			continue
+		}
+		if quote != 0 {
+			switch {
+			case char == quote:
+				quote = 0
+			case char == '\\' && quote == '"':
+				escaped = true
+			default:
+				arg.WriteRune(char)
+			}
+			inArg = true
+			continue
+		}
+		switch char {
+		case '\\':
+			escaped = true
+			inArg = true
+		case '\'', '"':
+			quote = char
+			inArg = true
+		case ' ', '\t', '\r', '\n':
+			flush()
+		default:
+			arg.WriteRune(char)
+			inArg = true
+		}
+	}
+	if escaped || quote != 0 {
+		return nil, errors.New("unclosed quote or escape")
+	}
+	flush()
+	return args, nil
+}
+
+func shellScriptExtension(command string) string {
+	switch strings.ToLower(command) {
+	case "bash", "sh":
+		return ".sh"
+	case "python":
+		return ".py"
+	default:
+		return ""
+	}
 }
 
 // stepWorkingDirectory resolves a run step's working directory and requires it

--- a/internal/runtime/compatibility_gaps_test.go
+++ b/internal/runtime/compatibility_gaps_test.go
@@ -21,8 +21,16 @@ func TestCompatibilityGapOtherShells(t *testing.T) {
 	runCompatibilityGapWorkflow(t, "other-shells.yml")
 }
 
-func TestCompatibilityGapBashArgTemplate(t *testing.T) {
-	runCompatibilityGapWorkflow(t, "bash-arg-template.yml")
+func TestCompatibilityGapCustomShellTemplates(t *testing.T) {
+	for _, name := range []string{"Rscript", "julia"} {
+		bin := t.TempDir()
+		wrapper := filepath.Join(bin, name)
+		if err := os.WriteFile(wrapper, []byte("#!/bin/sh\nfor arg do case \"$arg\" in */buildkite-gha-shell-*) exec sh \"$arg\";; esac; done\nexit 2\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	}
+	runCompatibilityGapWorkflow(t, "custom-shell-templates.yml")
 }
 
 func runCompatibilityGapWorkflow(t *testing.T, name string) {

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -728,7 +728,8 @@ with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
 }
 
 func TestRunJobContainerCustomShellUsesMountedScript(t *testing.T) {
-	installCustomShellTestCommand(t, "julia")
+	bin := installCustomShellTestCommand(t, "julia")
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
 	f := newJobDocker(t, "")
 	workspace := t.TempDir()
 	arguments := filepath.Join(workspace, "arguments")

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -727,6 +727,57 @@ with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
 	t.Fatal("Python container exec call not found")
 }
 
+func TestRunJobContainerCustomShellUsesMountedScript(t *testing.T) {
+	installCustomShellTestCommand(t, "julia")
+	f := newJobDocker(t, "")
+	workspace := t.TempDir()
+	arguments := filepath.Join(workspace, "arguments")
+	j := jobContainerPlan(t, workspace, []plan.Step{
+		{
+			ID:      "julia",
+			Kind:    "run",
+			Shell:   `julia --color=yes {0} --project "two words"`,
+			Env:     map[string]string{"CUSTOM_SHELL_ARGS": arguments},
+			Command: `printf 'script=%s\n' "$0" >> "$GITHUB_OUTPUT"`,
+		},
+		{ID: "cleanup", Kind: "run", Shell: "sh", Command: `set -- "$RUNNER_TEMP"/buildkite-gha-shell-*; test ! -e "$1"`},
+	})
+	j.Outputs = map[string]string{"script": "${{ steps.julia.outputs.script }}"}
+	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(t.Context(), j, workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := result.Outputs["script"]
+	if base := filepath.Base(script); !strings.HasPrefix(base, "buildkite-gha-shell-") || filepath.Ext(base) != "" {
+		t.Fatalf("custom shell script path = %q", script)
+	}
+	if _, err := os.Stat(script); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("temporary custom shell script remains at %q: %v", script, err)
+	}
+	data, err := os.ReadFile(arguments)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := strings.Split(strings.TrimSpace(string(data)), "\n"), []string{"--color=yes", script, "--project", "two words"}; !slices.Equal(got, want) {
+		t.Fatalf("container custom shell arguments = %#v, want %#v", got, want)
+	}
+	for _, call := range f.calls(t) {
+		i := slices.Index(call.Args, ContainerProcessHelperCommand)
+		if i < 0 || len(call.Args) < i+8 || call.Args[i+3] != "julia" {
+			continue
+		}
+		containerScript := call.Args[i+5]
+		if !strings.HasPrefix(containerScript, jobContainerTemp+"/buildkite-gha-shell-") || filepath.Ext(containerScript) != "" {
+			t.Fatalf("container custom shell script path = %q", containerScript)
+		}
+		if got, want := call.Args[i+4:], []string{"--color=yes", containerScript, "--project", "two words"}; !slices.Equal(got, want) {
+			t.Fatalf("container custom shell argv = %#v, want %#v", got, want)
+		}
+		return
+	}
+	t.Fatal("custom shell container exec call not found")
+}
+
 func TestRunJobContainerServicesLifecycleAndArguments(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -808,6 +808,23 @@ func (r Runner) runStreaming(ctx context.Context, processor *commandProcessor, d
 	return r.runStreamingCommand(ctx, processor, cmd)
 }
 
+func resolveExecutableInPath(name, path string) (string, error) {
+	if strings.ContainsRune(name, filepath.Separator) {
+		return name, nil
+	}
+	for _, dir := range filepath.SplitList(path) {
+		if dir == "" {
+			dir = "."
+		}
+		candidate := filepath.Join(dir, name)
+		info, err := os.Stat(candidate)
+		if err == nil && !info.IsDir() && info.Mode().Perm()&0o111 != 0 {
+			return candidate, nil
+		}
+	}
+	return "", &exec.Error{Name: name, Err: exec.ErrNotFound}
+}
+
 func (r Runner) runStreamingCommand(ctx context.Context, processor *commandProcessor, cmd *exec.Cmd) error {
 	configureProcessGroup(cmd)
 	stdout, stdoutWriter, err := os.Pipe()

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -5236,6 +5236,98 @@ with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
 	}
 }
 
+func TestParseShellTemplate(t *testing.T) {
+	tests := []struct {
+		name    string
+		shell   string
+		want    []string
+		wantErr string
+	}{
+		{name: "arguments and quotes", shell: `julia --color=yes "two words" {0} --project='quoted value'`, want: []string{"julia", "--color=yes", "two words", "{0}", "--project=quoted value"}},
+		{name: "literal values without expansion", shell: `julia "" '$HOME' semi;colon escaped\ value {0}`, want: []string{"julia", "", "$HOME", "semi;colon", "escaped value", "{0}"}},
+		{name: "embedded and repeated placeholders", shell: `Rscript --file={0} {0}`, want: []string{"Rscript", "--file={0}", "{0}"}},
+		{name: "empty command", shell: `"" {0}`, wantErr: "must contain a command"},
+		{name: "missing placeholder", shell: `Rscript --vanilla`, wantErr: "must contain {0}"},
+		{name: "malformed quote", shell: `julia "unterminated {0}`, wantErr: "parse shell template"},
+		{name: "PowerShell remains unsupported", shell: `/usr/bin/pwsh -File {0}`, wantErr: "unsupported in the supported runtime subset"},
+		{name: "Windows shell remains unsupported", shell: `cmd.exe /C {0}`, wantErr: "unsupported in the supported runtime subset"},
+		{name: "MSYS2 remains unsupported", shell: `msys2 {0}`, wantErr: "unsupported in the supported runtime subset"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := parseShellTemplate(test.shell)
+			if test.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+					t.Fatalf("parseShellTemplate(%q) error = %v, want %q", test.shell, err, test.wantErr)
+				}
+				return
+			}
+			if err != nil || !slices.Equal(got, test.want) {
+				t.Fatalf("parseShellTemplate(%q) = %#v, %v, want %#v", test.shell, got, err, test.want)
+			}
+		})
+	}
+}
+
+func TestRunJobCustomShellTemplatesUseTemporaryScripts(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		command  string
+		shell    string
+		wantArgs []string
+	}{
+		{name: "R", command: "Rscript", shell: `Rscript --vanilla "two words" {0} --after='quoted value'`, wantArgs: []string{"--vanilla", "two words"}},
+		{name: "Julia", command: "julia", shell: `julia --color=yes {0} --project "two words"`, wantArgs: []string{"--color=yes"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			installCustomShellTestCommand(t, test.command)
+			workspace := t.TempDir()
+			arguments := filepath.Join(workspace, "arguments")
+			workflowPath := ".github/workflows/test.yml"
+			writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+			job := runtimePlan(t, workspace, workflowPath, []plan.Step{{
+				ID:      "custom",
+				Kind:    "run",
+				Shell:   test.shell,
+				Env:     map[string]string{"CUSTOM_SHELL_ARGS": arguments},
+				Command: `printf 'script=%s\n' "$0" >> "$GITHUB_OUTPUT"`,
+			}})
+			job.Outputs = map[string]string{"script": "${{ steps.custom.outputs.script }}"}
+			result, err := (Runner{}).RunJob(t.Context(), job, workspace)
+			if err != nil {
+				t.Fatalf("RunJob() error = %v", err)
+			}
+			script := result.Outputs["script"]
+			if base := filepath.Base(script); !strings.HasPrefix(base, "buildkite-gha-shell-") || filepath.Ext(base) != "" {
+				t.Fatalf("custom shell script path = %q, want extensionless temporary script", script)
+			}
+			if _, err := os.Stat(script); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("temporary custom shell script remains at %q: %v", script, err)
+			}
+			data, err := os.ReadFile(arguments)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := strings.Split(strings.TrimSpace(string(data)), "\n")
+			if len(got) < len(test.wantArgs)+1 || !slices.Equal(got[:len(test.wantArgs)], test.wantArgs) || got[len(test.wantArgs)] != script {
+				t.Fatalf("custom shell arguments = %#v, want prefix %#v followed by %q", got, test.wantArgs, script)
+			}
+		})
+	}
+}
+
+func TestRunJobLoginBashTemplate(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "login", Kind: "run", Shell: "bash -l {0}", Command: `printf 'value=login-bash\n' >> "$GITHUB_OUTPUT"`}})
+	job.Outputs = map[string]string{"value": "${{ steps.login.outputs.value }}"}
+	result, err := (Runner{}).RunJob(t.Context(), job, workspace)
+	if err != nil || result.Outputs["value"] != "login-bash" {
+		t.Fatalf("RunJob() output = %q, error = %v, want login-bash", result.Outputs["value"], err)
+	}
+}
+
 func TestCompositePythonShell(t *testing.T) {
 	installPythonShellTestCommand(t)
 	workspace := t.TempDir()
@@ -5264,6 +5356,27 @@ runs:
 	if result.Outputs["value"] != "python-composite" {
 		t.Fatalf("RunJob() output = %q, want python-composite", result.Outputs["value"])
 	}
+}
+
+func installCustomShellTestCommand(t *testing.T, name string) {
+	t.Helper()
+	dir := t.TempDir()
+	wrapper := `#!/bin/sh
+: > "$CUSTOM_SHELL_ARGS"
+script=
+for arg do
+  printf '%s\n' "$arg" >> "$CUSTOM_SHELL_ARGS"
+  case "$arg" in
+    */buildkite-gha-shell-*) script=$arg ;;
+  esac
+done
+test -n "$script"
+exec /bin/sh "$script"
+`
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(wrapper), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
 func installPythonShellTestCommand(t *testing.T) {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -5280,18 +5280,21 @@ func TestRunJobCustomShellTemplatesUseTemporaryScripts(t *testing.T) {
 		{name: "Julia", command: "julia", shell: `julia --color=yes {0} --project "two words"`, wantArgs: []string{"--color=yes"}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			installCustomShellTestCommand(t, test.command)
+			bin := installCustomShellTestCommand(t, test.command)
 			workspace := t.TempDir()
 			arguments := filepath.Join(workspace, "arguments")
 			workflowPath := ".github/workflows/test.yml"
 			writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
-			job := runtimePlan(t, workspace, workflowPath, []plan.Step{{
-				ID:      "custom",
-				Kind:    "run",
-				Shell:   test.shell,
-				Env:     map[string]string{"CUSTOM_SHELL_ARGS": arguments},
-				Command: `printf 'script=%s\n' "$0" >> "$GITHUB_OUTPUT"`,
-			}})
+			job := runtimePlan(t, workspace, workflowPath, []plan.Step{
+				{ID: "path", Kind: "run", Shell: "sh", Command: `printf '%s\n' "$CUSTOM_SHELL_BIN" >> "$GITHUB_PATH"`, Env: map[string]string{"CUSTOM_SHELL_BIN": bin}},
+				{
+					ID:      "custom",
+					Kind:    "run",
+					Shell:   test.shell,
+					Env:     map[string]string{"CUSTOM_SHELL_ARGS": arguments},
+					Command: `printf 'script=%s\n' "$0" >> "$GITHUB_OUTPUT"`,
+				},
+			})
 			job.Outputs = map[string]string{"script": "${{ steps.custom.outputs.script }}"}
 			result, err := (Runner{}).RunJob(t.Context(), job, workspace)
 			if err != nil {
@@ -5358,7 +5361,7 @@ runs:
 	}
 }
 
-func installCustomShellTestCommand(t *testing.T, name string) {
+func installCustomShellTestCommand(t *testing.T, name string) string {
 	t.Helper()
 	dir := t.TempDir()
 	wrapper := `#!/bin/sh
@@ -5376,7 +5379,7 @@ exec /bin/sh "$script"
 	if err := os.WriteFile(filepath.Join(dir, name), []byte(wrapper), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return dir
 }
 
 func installPythonShellTestCommand(t *testing.T) {

--- a/testdata/compatibility-gaps/.github/workflows/bash-arg-template.yml
+++ b/testdata/compatibility-gaps/.github/workflows/bash-arg-template.yml
@@ -1,8 +1,0 @@
-name: Compatibility gap - bash argument template
-on: push
-jobs:
-  probe:
-    runs-on: ubuntu-latest
-    steps:
-      - shell: bash -l {0}
-        run: echo compatible

--- a/testdata/compatibility-gaps/.github/workflows/custom-shell-templates.yml
+++ b/testdata/compatibility-gaps/.github/workflows/custom-shell-templates.yml
@@ -1,0 +1,12 @@
+name: Compatibility gap - custom shell templates
+on: push
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - shell: bash -l {0}
+        run: test -n "$BASH_VERSION"
+      - shell: Rscript {0}
+        run: echo R-compatible
+      - shell: julia --color=yes {0}
+        run: echo Julia-compatible

--- a/testdata/compatibility-gaps/manifest.json
+++ b/testdata/compatibility-gaps/manifest.json
@@ -10,7 +10,7 @@
     {"id":"checkout-commits","title":"actions/checkout outside admitted commits","workflow":"checkout-commits.yml","event":"push","mode":"profile"},
     {"id":"cache-commits","title":"actions/cache outside admitted commits","workflow":"cache-commits.yml","event":"push","mode":"profile"},
     {"id":"download-artifact-versions","title":"actions/download-artifact versions","workflow":"download-artifact-versions.yml","event":"push","mode":"profile"},
-    {"id":"bash-arg-template","title":"bash with a custom arg template","workflow":"bash-arg-template.yml","event":"push","mode":"runtime","test":"TestCompatibilityGapBashArgTemplate"},
+    {"id":"custom-shell-templates","title":"R, Julia, and custom shell templates","workflow":"custom-shell-templates.yml","event":"push","mode":"runtime","test":"TestCompatibilityGapCustomShellTemplates"},
     {"id":"release-types","title":"release without supported types","workflow":"release-types.yml","event":"release","mode":"profile"},
     {"id":"docker-actions","title":"docker:// actions","workflow":"docker-actions.yml","event":"push","mode":"profile"},
     {"id":"permissions-write-all","title":"permissions: write-all","workflow":"permissions-write-all.yml","event":"push","mode":"profile"},


### PR DESCRIPTION
## Why

GitHub Actions workflows can use custom shell templates such as `Rscript {0}`, `julia --color=yes {0}`, and `bash -l {0}`, but `buildkite-gha` rejected every shell outside its built-in `bash`, `sh`, and `python` paths.

Closes [PB-3028](https://linear.app/buildkite/issue/PB-3028/support-r-julia-and-custom-shell-templates-in-buildkite-gha).

## What

- Parse custom shell arguments without shell expansion, resolve host commands from the effective workflow `PATH`, substitute `{0}` with a temporary script, and support job-container path mapping and cleanup.
- Preserve existing built-in shell behavior and keep PowerShell, Windows shells, and MSYS2 unsupported.
- Cover R, Julia, login Bash, quoting, cleanup, and container execution, and document that workflows must provision custom interpreters.
