### PR TITLE
PB-3051 client: surface runner fallback warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ plugins:
 
 Hosted runner labels are case-insensitive. Linux labels use the matching Noble
 or Jammy hosted-toolchains image, with or without a configured queue.
-During upload, the importer asks the job-scoped Agent API to resolve each
-`runs-on` selector before using configured mappings or the local preset. A macOS
-label selects native Darwin/arm64, not a GitHub image or Xcode inventory.
+During upload, the Agent API returns complete targets for selectors without an
+explicit mapping. The importer annotates heuristic fallback warnings. See the
+[compatibility guide](docs/compatibility.md#job-configuration).
 
 The imported workflows are a dynamic part of the Buildkite pipeline. The plugin creates one aggregate group per successfully compiled, explicitly listed workflow in a single transaction. Workflows that do not declare the selected event become top-level skipped steps. Groups and replacement steps depend on the importer. Each runnable job publishes a provider check named `<workflow> / <job> (<event>)`: a GitHub check for GitHub events or an Origin check for Origin events. This approach lets you keep existing workflows while moving jobs to native Buildkite steps over time.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -414,15 +414,14 @@ The hosted preset accepts runner labels case-insensitively, so aliases such as
 `macOS-latest` and `Ubuntu-Latest` are equivalent to their lowercase forms.
 `ubuntu-latest` and `ubuntu-24.04` default to the Noble hosted-toolchains image;
 `ubuntu-22.04` defaults to Jammy. Use `--runner-image` with an immutable digest
-to override the default for a configured profile. Linux labels keep default
-agent targeting with the matching image when unmapped. During upload, the
-importer first asks the job-scoped Agent API to resolve each `runs-on` selector.
-A returned target takes precedence over `--runner-queue` and the local preset.
-Configured mappings and the local `macos-latest` preset remain fallbacks when
-the API does not return a target. Linux ARM, macOS x86-64, Windows, and other
-labels are unsupported. Every macOS label rejects images. Runtime distribution
-paths must be absolute executables. The importer's platform defaults to its
-running executable; the other platform has no direct-upload default.
+to override the default for a configured profile. An explicit mapping declares
+that its selector runs on Linux x86-64, except for the known macOS labels, and
+bypasses Agent API resolution. The Agent API owns compatibility and returns the
+complete target for every other selector. The importer publishes returned
+warnings as annotations. See [Compatibility](compatibility.md#job-configuration)
+for runner behavior. Runtime distribution paths must be absolute executables.
+The importer's platform defaults to its running executable; the other platform
+has no direct-upload default.
 `BUILDKITE_GHA_TARGET_QUEUE` and `BUILDKITE_GHA_RUNTIME_IMAGE` are no longer
 supported.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -33,7 +33,7 @@ Looking for something else? [Browse open compatibility issues](https://github.co
 | --- | --- | --- |
 | [Workflow and job names](#workflow-syntax) | 🟡 Supported subset | `name` and job names are retained. `run-name` has no effect. |
 | [Triggers and filters under `on`](#names-and-triggers) | 🟡 Supported subset | Buildkite creates builds; upload selects aggregate workflow groups for one effective event. `workflow_call` is supported for composition. |
-| [Platforms](#job-configuration) | 🟡 Supported subset | The hosted importer provides Linux x86-64 with `ubuntu-latest`, `ubuntu-24.04`, or `ubuntu-22.04`. Its Agent API resolves single macOS labels to native macOS arm64 hosted queues before local runner mappings. Labels do not provide GitHub image, toolchain, or Xcode parity. |
+| [Platforms](#job-configuration) | 🟡 Supported subset | The hosted importer provides Linux x86-64. The Agent API can map compatible selectors to hosted Linux or native macOS arm64 targets. Labels do not provide GitHub image, toolchain, or Xcode parity. |
 | [Jobs and dependencies](#job-configuration) | ✅ Supported | Static dependencies, matrix fan-out and fan-in, results, and bounded outputs. |
 | [Matrix strategies](#matrix-strategies) | 🟡 Supported subset | Static matrices, `include`, `exclude`, and literal `max-parallel`. Maximum 256 instances per job. `fail-fast` has no effect. |
 | [Shell steps](#commands-and-actions) | 🟡 Supported subset | Linux and macOS `bash`, `sh`, `python`, and custom shell templates. |
@@ -427,7 +427,7 @@ Cancel the whole Buildkite build rather than one job when a workflow-level concu
 | --- | --- | --- |
 | `name` | ✅ Supported | Labels may use static `github`, `vars`, reusable-workflow `inputs`, and matrix values. |
 | `needs` | ✅ Supported | Accepts a string or list of static job IDs. Matrix fan-out and fan-in are automatic. |
-| `runs-on` | 🟡 Supported subset | The hosted importer asks the Agent API to resolve each selector before using configured mappings or its local preset. The preset accepts `ubuntu-latest`, `ubuntu-24.04`, `ubuntu-22.04`, and `macos-latest`; configured fallbacks can map `macos-14` and `macos-15`. Labels are case-insensitive. Static expressions may resolve to an accepted label or list whose labels map to the same complete queue, platform, and image target. |
+| `runs-on` | 🟡 Supported subset | Explicit mappings are authoritative. The Agent API returns a complete target for every other selector and can return a fallback warning annotation. The local preset accepts `ubuntu-latest`, `ubuntu-24.04`, `ubuntu-22.04`, and `macos-latest`. Labels are case-insensitive. Static expressions may resolve to an accepted label or label list. |
 | `if` | 🟡 Supported subset | Runs before the job starts. See [Conditions](#conditions). |
 | `outputs` | 🟡 Supported subset | Maps step outputs for consumption through `needs`. A job may publish 64 outputs of up to 1 KiB each. Ambiguous matrix output values stop the job with an error. |
 | `env`, `defaults.run` | 🟡 Supported subset | Uses the [workflow-level behavior](#environment-and-defaults). |
@@ -493,12 +493,18 @@ Runner labels are case-insensitive. Runner aliases such as `macOS-latest` use
 the same target as `macos-latest`. Linux labels default to the corresponding
 Noble or Jammy hosted-toolchains image; an explicit immutable image overrides
 it for a configured profile. Linux labels use default Buildkite agent targeting
-with that image when unmapped. During upload, the job-scoped Agent API resolves
-each `runs-on` selector before configured mappings or the local preset. API
-targets take precedence. `validate --profile hosted` has no job-scoped API and
-admits only the local `macos-latest` preset. macOS labels reject images. They
-select Darwin/arm64, not a GitHub image or Xcode inventory. Linux ARM, macOS
-x86-64, Windows, and other labels are unsupported.
+with that image when unmapped.
+
+An explicit mapping is authoritative and bypasses Agent API resolution. It
+declares that the selector runs on Linux x86-64, except for the known macOS
+labels, which select Darwin arm64 and reject images. For every other selector,
+the job-scoped Agent API owns compatibility and returns the complete queue,
+platform, and immutable Linux image. The importer applies that target verbatim
+and publishes returned fallback warnings as annotations. The server rejects
+selectors that require an incompatible operating system or architecture.
+
+`validate --profile hosted` has no job-scoped API and admits only the local
+`macos-latest` preset.
 
 ### Matrix strategies
 

--- a/internal/cli/hosted.go
+++ b/internal/cli/hosted.go
@@ -31,18 +31,6 @@ const (
 var runnerQueuePattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,255}$`)
 var runnerImagePattern = regexp.MustCompile(`^[a-z0-9]+(?:[._-][a-z0-9]+)*(?:/[a-z0-9]+(?:[._-][a-z0-9]+)*)+@sha256:[0-9a-f]{64}$`)
 
-func configuredRunnerPlatform(labels []string, configuredTargets map[string]compiler.RunnerTarget) (compiler.Platform, error) {
-	if len(labels) == 0 {
-		return compiler.Platform{}, fmt.Errorf("runs-on resolved to no labels")
-	}
-	canonical := strings.ToLower(strings.TrimSpace(labels[0]))
-	if target, ok := configuredTargets[canonical]; ok {
-		return target.Platform, nil
-	}
-	_, platform, err := supportedRunnerTarget(canonical)
-	return platform, err
-}
-
 type hostedCompilation struct {
 	Bundle     compiler.Bundle
 	HasActions bool
@@ -190,6 +178,15 @@ func hostedOptions(groupLabel string, configuredTargets map[string]compiler.Runn
 	return options
 }
 
+func applyRunnerSelectors(options *compiler.Options, selectors []compiler.RunnerSelector) {
+	options.Runners.Selectors = selectors
+	for _, selector := range selectors {
+		if selector.Target.Queue != "" && !slices.Contains(options.Runners.UntrustedQueues, selector.Target.Queue) {
+			options.Runners.UntrustedQueues = append(options.Runners.UntrustedQueues, selector.Target.Queue)
+		}
+	}
+}
+
 // hostedRunnerTargets is the runner preset shared by hosted validation and
 // production upload. RunnerPolicy resolves these labels case-insensitively.
 // Keep API-resolved and organization-provided targets out of this preset.
@@ -207,15 +204,16 @@ func compileHosted(ctx context.Context, workflowPath string, workflowSource, eve
 }
 
 func compileHostedWithActionCache(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runtimeDistributions map[compiler.Platform]string, actionCacheDir string, sharedActionSource compiler.ActionSource, actionAuthentication *actionSourceAuthentication) (hostedCompilation, error) {
-	return compileHostedNamespacedWithActionCache(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, groupLabel, configuredTargets, runtimeDistributions, "", nil, actionCacheDir, sharedActionSource, actionAuthentication)
+	return compileHostedNamespacedWithActionCache(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, groupLabel, configuredTargets, nil, runtimeDistributions, "", nil, actionCacheDir, sharedActionSource, actionAuthentication)
 }
 
 func compileHostedNamespaced(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runtimeDistributions map[compiler.Platform]string, stepKeyNamespace string, oidc *plan.OIDCConfiguration, actionAuthentication *actionSourceAuthentication) (hostedCompilation, error) {
-	return compileHostedNamespacedWithActionCache(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, groupLabel, configuredTargets, runtimeDistributions, stepKeyNamespace, oidc, "", nil, actionAuthentication)
+	return compileHostedNamespacedWithActionCache(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, groupLabel, configuredTargets, nil, runtimeDistributions, stepKeyNamespace, oidc, "", nil, actionAuthentication)
 }
 
-func compileHostedNamespacedWithActionCache(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runtimeDistributions map[compiler.Platform]string, stepKeyNamespace string, oidc *plan.OIDCConfiguration, actionCacheDir string, sharedActionSource compiler.ActionSource, actionAuthentication *actionSourceAuthentication) (hostedCompilation, error) {
+func compileHostedNamespacedWithActionCache(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runnerSelectors []compiler.RunnerSelector, runtimeDistributions map[compiler.Platform]string, stepKeyNamespace string, oidc *plan.OIDCConfiguration, actionCacheDir string, sharedActionSource compiler.ActionSource, actionAuthentication *actionSourceAuthentication) (hostedCompilation, error) {
 	options := hostedOptions(groupLabel, configuredTargets, runtimeDistributions)
+	applyRunnerSelectors(&options, runnerSelectors)
 	options.StepKeyNamespace = stepKeyNamespace
 	options.OIDC = oidc
 	repositorySource := sharedActionSource
@@ -519,7 +517,7 @@ func configuredRunnerTarget(label, queue, image string) (string, compiler.Runner
 }
 
 func supportedRunnerTarget(label string) (string, compiler.Platform, error) {
-	if label != strings.TrimSpace(label) || strings.ContainsAny(label, "\r\n") {
+	if label == "" || label != strings.TrimSpace(label) || strings.ContainsAny(label, "\r\n") {
 		return "", compiler.Platform{}, fmt.Errorf("unsupported runner label %q", label)
 	}
 	canonical := strings.ToLower(label)
@@ -531,6 +529,9 @@ func supportedRunnerTarget(label string) (string, compiler.Platform, error) {
 		// These remain available as local fallbacks when the Agent API is absent.
 		return canonical, compiler.PlatformDarwinARM64, nil
 	default:
-		return "", compiler.Platform{}, fmt.Errorf("unsupported runner label %q", label)
+		// Configuring an otherwise unknown selector explicitly maps it to the
+		// supported Linux/amd64 platform. The Agent API owns compatibility
+		// policy for every selector that is not configured locally.
+		return canonical, compiler.PlatformLinuxAMD64, nil
 	}
 }

--- a/internal/cli/hosted_test.go
+++ b/internal/cli/hosted_test.go
@@ -51,6 +51,11 @@ func TestConfiguredLinuxRunnerTargetsDefaultHostedToolchainImages(t *testing.T) 
 	if target.Image != override {
 		t.Fatalf("explicit image = %q, want %q", target.Image, override)
 	}
+
+	canonical, target, err := configuredRunnerTarget("ubuntu-18.04", "legacy-linux", "")
+	if err != nil || canonical != "ubuntu-18.04" || target != (compiler.RunnerTarget{Queue: "legacy-linux", Platform: compiler.PlatformLinuxAMD64}) {
+		t.Fatalf("fallback override = %q, %#v, %v", canonical, target, err)
+	}
 }
 
 func TestHostedRunnerTargetsContainOnlyHostedGuarantees(t *testing.T) {

--- a/internal/cli/plugin_test.go
+++ b/internal/cli/plugin_test.go
@@ -217,6 +217,7 @@ func TestParsePluginConfiguration(t *testing.T) {
 		{name: "unknown runner field", source: `{"workflow":"ci.yml","runners":[{"runs-on":"ubuntu-latest","queue":"hosted","extra":true}]}`, want: "unknown field"},
 		{name: "case alias runner field", source: `{"workflow":"ci.yml","runners":[{"Runs-On":"ubuntu-latest","queue":"hosted"}]}`, want: "unknown field"},
 		{name: "duplicate runner field", source: `{"workflow":"ci.yml","runners":[{"runs-on":"windows-latest","runs-on":"ubuntu-latest","queue":"hosted"}]}`, want: "duplicate object key"},
+		{name: "empty runner label", source: `{"workflow":"ci.yml","runners":[{"runs-on":"","queue":"hosted"}]}`, want: "unsupported runner label"},
 		{name: "duplicate runner", source: `{"workflow":"ci.yml","runners":[{"runs-on":"ubuntu-latest","queue":"one"},{"runs-on":"UBUNTU-LATEST","queue":"two"}]}`, want: "only be configured once"},
 		{name: "missing queue", source: `{"workflow":"ci.yml","runners":[{"runs-on":"ubuntu-latest"}]}`, want: "queue must be a string"},
 		{name: "empty image", source: `{"workflow":"ci.yml","runners":[{"runs-on":"ubuntu-latest","queue":"hosted","image":""}]}`, want: "immutable registry"},
@@ -426,7 +427,7 @@ func TestPluginPublishesMixedRuntimeDistributions(t *testing.T) {
 	requireImporterHost(t)
 	const fullCommit = "0123456789abcdef0123456789abcdef01234567"
 	repository := writeUploadWorkflowRepository(t, map[string]string{
-		"mixed.yml": "on: push\njobs:\n  linux:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo linux\n  macos:\n    needs: linux\n    runs-on: macos-26\n    steps:\n      - run: echo macos\n",
+		"mixed.yml": "on: push\njobs:\n  linux:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo linux\n  configured:\n    needs: linux\n    runs-on: ubuntu-18.04\n    steps:\n      - run: echo configured\n  fallback:\n    needs: linux\n    runs-on: [self-hosted, ubuntu-20.04]\n    steps:\n      - run: echo fallback\n  macos:\n    needs: linux\n    runs-on: macos-26\n    steps:\n      - run: echo macos\n",
 	})
 	t.Chdir(repository)
 	workflowPath := filepath.Join(".github", "workflows", "mixed.yml")
@@ -448,11 +449,10 @@ func TestPluginPublishesMixedRuntimeDistributions(t *testing.T) {
 	if err := os.WriteFile(darwinPath, darwinContents, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	image := "buildkite.namespace-images.com/agent-base@sha256:" + strings.Repeat("0", 64)
 	configuration, err := json.Marshal(map[string]any{
 		"workflow": workflowPath,
 		"runners": []map[string]any{
-			{"runs-on": "ubuntu-latest", "queue": "linux", "image": image},
+			{"runs-on": "ubuntu-18.04", "queue": "legacy-linux"},
 		},
 	})
 	if err != nil {
@@ -462,7 +462,7 @@ func TestPluginPublishesMixedRuntimeDistributions(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resolutionRequests++
 		if r.URL.Path != "/v3/jobs/"+cliTestJobID+"/github-actions/runners" || r.Header.Get("Authorization") != "Token job-token" {
-			t.Errorf("runner resolution request = %s, authorization %q", r.URL.Path, r.Header.Get("Authorization"))
+			t.Errorf("runner resolution request = %s, headers %#v", r.URL.Path, r.Header)
 		}
 		var body struct {
 			Requirements []struct {
@@ -477,9 +477,24 @@ func TestPluginPublishesMixedRuntimeDistributions(t *testing.T) {
 		}
 		resolutions := make([]map[string]any, len(body.Requirements))
 		for i, requirement := range body.Requirements {
-			if slices.Equal(requirement.Selector.Labels, []string{"macos-26"}) {
+			switch {
+			case slices.Equal(requirement.Selector.Labels, []string{"ubuntu-latest"}):
+				resolutions[i] = map[string]any{
+					"id":     requirement.ID,
+					"target": map[string]string{"queue": "linux-medium", "platform": "linux/amd64", "image": defaultNobleRunnerImage},
+				}
+			case slices.Equal(requirement.Selector.Labels, []string{"self-hosted", "ubuntu-20.04"}):
+				resolutions[i] = map[string]any{
+					"id":     requirement.ID,
+					"target": map[string]string{"queue": "linux-medium", "platform": "linux/amd64", "image": defaultNobleRunnerImage},
+					"warnings": []map[string]string{{
+						"code":    "runner_label_fallback",
+						"message": "This runner selector is not supported directly; using the linux-medium queue via a heuristic fallback. Configure an explicit runner mapping to use an appropriate Buildkite queue and avoid this fallback: https://github.com/buildkite/buildkite-gha/blob/main/docs/compatibility.md",
+					}},
+				}
+			case slices.Equal(requirement.Selector.Labels, []string{"macos-26"}):
 				resolutions[i] = map[string]any{"id": requirement.ID, "target": map[string]string{"queue": "macos-26-medium", "platform": "darwin/arm64"}}
-			} else {
+			default:
 				resolutions[i] = map[string]any{"id": requirement.ID, "error": map[string]string{"code": "unmapped_labels", "message": "No compatible runner is configured."}}
 			}
 		}
@@ -502,6 +517,17 @@ func TestPluginPublishesMixedRuntimeDistributions(t *testing.T) {
 	}
 	if resolutionRequests != 1 {
 		t.Fatalf("runner resolution requests = %d, want 1", resolutionRequests)
+	}
+	var runnerAnnotation *cliCommand
+	for i := range runner.commands {
+		command := &runner.commands[i]
+		if len(command.args) >= 7 && command.args[0] == "annotate" && command.args[6] == runnerResolutionContext {
+			runnerAnnotation = command
+			break
+		}
+	}
+	if runnerAnnotation == nil || runnerAnnotation.args[8] != "warning" || !strings.Contains(string(runnerAnnotation.stdin), "heuristic fallback") || !strings.Contains(string(runnerAnnotation.stdin), "linux-medium") || !strings.Contains(string(runnerAnnotation.stdin), "docs/compatibility.md") {
+		t.Fatalf("runner resolution annotation = %#v", runnerAnnotation)
 	}
 	darwinDigest := transport.Digest(darwinContents)
 	planRuntimes := map[string]string{}
@@ -556,7 +582,7 @@ func TestPluginPublishesMixedRuntimeDistributions(t *testing.T) {
 			Command string
 		}{Image: step.Image, Queue: step.Agents["queue"], Command: step.Command}
 	}
-	var linux, macos struct {
+	var linux, configured, fallback, macos struct {
 		Image   string
 		Queue   string
 		Command string
@@ -565,12 +591,22 @@ func TestPluginPublishesMixedRuntimeDistributions(t *testing.T) {
 		switch {
 		case strings.HasSuffix(key, "-linux"):
 			linux = step
+		case strings.HasSuffix(key, "-configured"):
+			configured = step
+		case strings.HasSuffix(key, "-fallback"):
+			fallback = step
 		case strings.HasSuffix(key, "-macos"):
 			macos = step
 		}
 	}
-	if linux.Queue != "linux" || linux.Image != image || !strings.Contains(linux.Command, "--hosted-tool-cache") || !strings.Contains(linux.Command, strings.TrimPrefix(cliTestRuntimeDigest(), "sha256:")) {
+	if linux.Queue != "linux-medium" || linux.Image != defaultNobleRunnerImage || !strings.Contains(linux.Command, "--hosted-tool-cache") || !strings.Contains(linux.Command, strings.TrimPrefix(cliTestRuntimeDigest(), "sha256:")) {
 		t.Fatalf("Linux pipeline step = %#v", linux)
+	}
+	if configured.Queue != "legacy-linux" || configured.Image != "" || strings.Contains(configured.Command, "--hosted-tool-cache") || !strings.Contains(configured.Command, strings.TrimPrefix(cliTestRuntimeDigest(), "sha256:")) {
+		t.Fatalf("configured Linux pipeline step = %#v", configured)
+	}
+	if fallback.Queue != "linux-medium" || fallback.Image != defaultNobleRunnerImage || !strings.Contains(fallback.Command, "--hosted-tool-cache") || !strings.Contains(fallback.Command, strings.TrimPrefix(cliTestRuntimeDigest(), "sha256:")) {
+		t.Fatalf("fallback Linux pipeline step = %#v", fallback)
 	}
 	if macos.Queue != "macos-26-medium" || macos.Image != "" || strings.Contains(macos.Command, "--hosted-tool-cache") || !strings.Contains(macos.Command, strings.TrimPrefix(darwinDigest, "sha256:")) {
 		t.Fatalf("Darwin pipeline step = %#v", macos)

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -18,12 +18,14 @@ import (
 	"github.com/buildkite/buildkite-gha/internal/compatibility"
 	"github.com/buildkite/buildkite-gha/internal/compiler"
 	"github.com/buildkite/buildkite-gha/internal/plan"
+	"github.com/buildkite/buildkite-gha/internal/runtime"
 	"github.com/buildkite/buildkite-gha/internal/transport"
 )
 
 const (
 	processingAnnotationContext   = "buildkite-gha-processing"
 	skippedWorkflowsContext       = "buildkite-gha-skipped-workflows"
+	runnerResolutionContext       = "buildkite-gha-runner-resolution"
 	processingAnnotationBodyLimit = 1024 * 1024
 	processingAnnotationNotice    = "\n_Additional diagnostics omitted at the Buildkite annotation size limit._\n"
 	processingAnnotationTimeout   = 5 * time.Second
@@ -202,6 +204,22 @@ func (o processingOutput) annotateSkippedWorkflows(parent context.Context, event
 	defer cancel()
 	if err := o.agent.AnnotateJob(ctx, o.annotationJob, skippedWorkflowsContext, "info", body); err != nil {
 		_, _ = fmt.Fprintf(o.stderr, "buildkite-gha: %s: warning: skipped workflows annotation: %v\n", o.command, err)
+	}
+}
+
+func (o processingOutput) annotateRunnerResolutionWarnings(parent context.Context, warnings []runtime.RunnerWarning) {
+	if o.annotationJob == "" || len(warnings) == 0 {
+		return
+	}
+	var body strings.Builder
+	body.WriteString("#### Unsupported runner labels were mapped to Ubuntu\n\nBuildkite used heuristic runner mappings:\n\n")
+	for _, warning := range warnings {
+		_, _ = fmt.Fprintf(&body, "* %s — %s\n", annotationCode(warning.Code), annotationHTML(warning.Message))
+	}
+	ctx, cancel := context.WithTimeout(parent, processingAnnotationTimeout)
+	defer cancel()
+	if err := o.agent.AnnotateJob(ctx, o.annotationJob, runnerResolutionContext, "warning", body.String()); err != nil {
+		_, _ = fmt.Fprintf(o.stderr, "buildkite-gha: %s: warning: runner resolution annotation: %v\n", o.command, err)
 	}
 }
 

--- a/internal/cli/runner_resolution.go
+++ b/internal/cli/runner_resolution.go
@@ -11,12 +11,12 @@ import (
 	gharuntime "github.com/buildkite/buildkite-gha/internal/runtime"
 )
 
-func suggestedRunnerTargets(ctx context.Context, reports []compiler.Report, clientVersion string) (map[string]compiler.RunnerTarget, error) {
+func suggestedRunnerTargets(ctx context.Context, reports []compiler.Report, configuredTargets map[string]compiler.RunnerTarget, clientVersion string) ([]compiler.RunnerSelector, []gharuntime.RunnerWarning, error) {
 	endpoint := os.Getenv("BUILDKITE_AGENT_ENDPOINT")
 	jobID := os.Getenv("BUILDKITE_JOB_ID")
 	jobToken := os.Getenv("BUILDKITE_AGENT_ACCESS_TOKEN")
 	if endpoint == "" || jobID == "" || jobToken == "" {
-		return nil, nil
+		return nil, nil, nil
 	}
 	resolver, err := gharuntime.NewAgentRunnerResolver(gharuntime.AgentRunnerResolverConfig{
 		Endpoint:      endpoint,
@@ -25,43 +25,60 @@ func suggestedRunnerTargets(ctx context.Context, reports []compiler.Report, clie
 		ClientVersion: clientVersion,
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	requirements := uniqueRunnerRequirements(reports)
+	requirements := uniqueRunnerRequirements(reports, configuredTargets)
 	suggestions, err := resolver.Resolve(ctx, requirements)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	byID := make(map[string]gharuntime.RunnerRequirement, len(requirements))
 	for _, requirement := range requirements {
 		byID[requirement.ID] = requirement
 	}
-	targets := make(map[string]compiler.RunnerTarget, len(suggestions))
+	selectors := make([]compiler.RunnerSelector, 0, len(suggestions))
+	var warnings []gharuntime.RunnerWarning
 	for _, suggestion := range suggestions {
 		requirement := byID[suggestion.ID]
-		if len(requirement.Labels) != 1 || !runnerQueuePattern.MatchString(suggestion.Queue) {
-			return nil, fmt.Errorf("runner resolution response contains an invalid target")
+		labels := make([]string, len(requirement.Labels))
+		seenLabels := make(map[string]bool, len(requirement.Labels))
+		validLabels := len(requirement.Labels) != 0
+		for i, label := range requirement.Labels {
+			labels[i] = strings.ToLower(strings.TrimSpace(label))
+			if labels[i] == "" || seenLabels[labels[i]] {
+				validLabels = false
+			}
+			seenLabels[labels[i]] = true
+		}
+		if !validLabels {
+			continue
+		}
+		if !runnerQueuePattern.MatchString(suggestion.Queue) {
+			return nil, nil, fmt.Errorf("runner resolution response contains an invalid target")
 		}
 		platform, err := compiler.ParsePlatform(suggestion.Platform)
 		if err != nil {
-			return nil, fmt.Errorf("runner resolution response contains an invalid target: %w", err)
+			return nil, nil, fmt.Errorf("runner resolution response contains an invalid target: %w", err)
 		}
-		label := strings.ToLower(strings.TrimSpace(requirement.Labels[0]))
-		target := compiler.RunnerTarget{Queue: suggestion.Queue, Platform: platform}
-		if existing, ok := targets[label]; ok && existing != target {
-			return nil, fmt.Errorf("runner resolution response contains conflicting targets")
+		if platform == compiler.PlatformLinuxAMD64 && !runnerImagePattern.MatchString(suggestion.Image) {
+			return nil, nil, fmt.Errorf("runner resolution response contains an invalid target image")
 		}
-		targets[label] = target
+		if platform == compiler.PlatformDarwinARM64 && suggestion.Image != "" {
+			return nil, nil, fmt.Errorf("runner resolution response contains an invalid target image")
+		}
+		target := compiler.RunnerTarget{Queue: suggestion.Queue, Platform: platform, Image: suggestion.Image}
+		selectors = append(selectors, compiler.RunnerSelector{Labels: labels, Target: target})
+		warnings = append(warnings, suggestion.Warnings...)
 	}
-	return targets, nil
+	return selectors, warnings, nil
 }
 
-func uniqueRunnerRequirements(reports []compiler.Report) []gharuntime.RunnerRequirement {
+func uniqueRunnerRequirements(reports []compiler.Report, configuredTargets map[string]compiler.RunnerTarget) []gharuntime.RunnerRequirement {
 	seen := make(map[string]bool)
 	var requirements []gharuntime.RunnerRequirement
 	for _, report := range reports {
 		for _, job := range report.Jobs {
-			if len(job.RunsOn) == 0 {
+			if len(job.RunsOn) == 0 || runnerSelectorIsConfigured(job.RunsOn, configuredTargets) {
 				continue
 			}
 			encoded, _ := json.Marshal(job.RunsOn)
@@ -77,4 +94,16 @@ func uniqueRunnerRequirements(reports []compiler.Report) []gharuntime.RunnerRequ
 		}
 	}
 	return requirements
+}
+
+func runnerSelectorIsConfigured(labels []string, configuredTargets map[string]compiler.RunnerTarget) bool {
+	var target compiler.RunnerTarget
+	for i, label := range labels {
+		configured, ok := configuredTargets[strings.ToLower(strings.TrimSpace(label))]
+		if !ok || (i != 0 && configured != target) {
+			return false
+		}
+		target = configured
+	}
+	return len(labels) != 0
 }

--- a/internal/cli/runner_resolution_test.go
+++ b/internal/cli/runner_resolution_test.go
@@ -1,0 +1,27 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/buildkite/buildkite-gha/internal/compiler"
+)
+
+func TestRunnerSelectorIsConfigured(t *testing.T) {
+	linux := compiler.RunnerTarget{Queue: "linux", Platform: compiler.PlatformLinuxAMD64}
+	other := compiler.RunnerTarget{Queue: "other", Platform: compiler.PlatformLinuxAMD64}
+	targets := map[string]compiler.RunnerTarget{"ubuntu-18.04": linux, "self-hosted": linux, "other": other}
+	for _, test := range []struct {
+		labels []string
+		want   bool
+	}{
+		{labels: []string{"Ubuntu-18.04"}, want: true},
+		{labels: []string{"self-hosted", "ubuntu-18.04"}, want: true},
+		{labels: []string{"self-hosted", "missing"}},
+		{labels: []string{"self-hosted", "other"}},
+		{labels: nil},
+	} {
+		if got := runnerSelectorIsConfigured(test.labels, targets); got != test.want {
+			t.Errorf("runnerSelectorIsConfigured(%q) = %v, want %v", test.labels, got, test.want)
+		}
+	}
+}

--- a/internal/cli/upload.go
+++ b/internal/cli/upload.go
@@ -230,32 +230,27 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 		validationOptions.RepositorySource = repositorySource
 		validations[i], validationErrs[i] = compiler.ValidateEventWithOptionsContext(ctx, input.Path, input.Source, effectiveEvent.Source, validationOptions)
 	}
-	suggestedTargets, err := suggestedRunnerTargets(ctx, validations, uploadArguments.clientVersion)
+	runnerSelectors, runnerWarnings, err := suggestedRunnerTargets(ctx, validations, uploadArguments.runnerTargets, uploadArguments.clientVersion)
 	if err != nil {
 		if ctx.Err() != nil {
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", ctx.Err())
 			return 1
 		}
 	}
-	if len(suggestedTargets) != 0 {
-		runnerTargets := make(map[string]compiler.RunnerTarget, len(uploadArguments.runnerTargets)+len(suggestedTargets))
-		for label, target := range uploadArguments.runnerTargets {
-			runnerTargets[label] = target
-		}
-		for label, target := range suggestedTargets {
-			runnerTargets[label] = target
-		}
-		uploadArguments.runnerTargets = runnerTargets
+	if len(runnerSelectors) != 0 {
+		uploadArguments.runnerSelectors = runnerSelectors
 		for i, input := range workflows {
 			if !input.Applicable || processingReportHasErrors(processingReports[i]) {
 				continue
 			}
 			validationOptions := hostedOptions("", uploadArguments.runnerTargets, nil)
+			applyRunnerSelectors(&validationOptions, runnerSelectors)
 			validationOptions.StepKeyNamespace = input.StepKeyNamespace
 			validationOptions.RepositorySource = repositorySource
 			validations[i], validationErrs[i] = compiler.ValidateEventWithOptionsContext(ctx, input.Path, input.Source, effectiveEvent.Source, validationOptions)
 		}
 	}
+	out.annotateRunnerResolutionWarnings(ctx, runnerWarnings)
 	for i, input := range workflows {
 		if !input.Applicable || processingReportHasErrors(processingReports[i]) {
 			continue
@@ -283,7 +278,7 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 		if !input.Applicable || processingReportHasErrors(processingReports[i]) {
 			continue
 		}
-		platforms, platformErr := requiredRuntimePlatforms(ctx, input.Path, input.Source, effectiveEvent.Source, "", uploadArguments.runnerTargets, repositorySource)
+		platforms, platformErr := requiredRuntimePlatforms(ctx, input.Path, input.Source, effectiveEvent.Source, "", uploadArguments.runnerTargets, uploadArguments.runnerSelectors, repositorySource)
 		if platformErr != nil {
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", platformErr)
 			return 1
@@ -370,7 +365,7 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 			failureArtifacts = append(failureArtifacts, artifacts...)
 			continue
 		}
-		preflight, err := compileHostedNamespacedWithActionCache(ctx, input.Path, input.Source, effectiveEvent.Source, version, distributionDigest, importerStep, "", uploadArguments.runnerTargets, runtimeDigests, input.StepKeyNamespace, uploadArguments.oidc, "", repositorySource, authentication)
+		preflight, err := compileHostedNamespacedWithActionCache(ctx, input.Path, input.Source, effectiveEvent.Source, version, distributionDigest, importerStep, "", uploadArguments.runnerTargets, uploadArguments.runnerSelectors, runtimeDigests, input.StepKeyNamespace, uploadArguments.oidc, "", repositorySource, authentication)
 		applyHostedPreflight(&processingReports[i], preflight)
 		if err != nil {
 			processingReports[i].Result = classifyHostedFailure(&processingReports[i], input.Path, err)
@@ -565,8 +560,9 @@ func generatedFailureArtifact(kind, extension, contents string) transport.Artifa
 	return transport.Artifact{Path: path, Digest: digest, Contents: encoded}
 }
 
-func requiredRuntimePlatforms(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, repositorySource compiler.RepositorySource) (map[compiler.Platform]bool, error) {
+func requiredRuntimePlatforms(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runnerSelectors []compiler.RunnerSelector, repositorySource compiler.RepositorySource) (map[compiler.Platform]bool, error) {
 	options := hostedOptions(groupLabel, configuredTargets, nil)
+	applyRunnerSelectors(&options, runnerSelectors)
 	options.RepositorySource = repositorySource
 	preflight, err := compiler.CompileWithOptionsContext(ctx, workflowPath, workflowSource, eventSource, options)
 	if err != nil {
@@ -578,11 +574,11 @@ func requiredRuntimePlatforms(ctx context.Context, workflowPath string, workflow
 	}
 	platforms := make(map[compiler.Platform]bool, 2)
 	for _, job := range ir.Jobs {
-		platform, err := configuredRunnerPlatform(job.RunsOn, configuredTargets)
+		target, err := options.Runners.Resolve(job.RunsOn, options.EventTrust)
 		if err != nil {
 			return nil, fmt.Errorf("resolve runtime platform for job %q: %w", job.LogicalJobID, err)
 		}
-		platforms[platform] = true
+		platforms[target.Platform] = true
 	}
 	return platforms, nil
 }
@@ -701,6 +697,7 @@ type parsedUploadArgs struct {
 	clientVersion            string
 	runtimeDistributionPaths map[compiler.Platform]string
 	runnerTargets            map[string]compiler.RunnerTarget
+	runnerSelectors          []compiler.RunnerSelector
 	oidc                     *plan.OIDCConfiguration
 	experimentalRunnerUser   bool
 	pluginAcquisition        *pluginRuntimeAcquisition

--- a/internal/cli/upload_test.go
+++ b/internal/cli/upload_test.go
@@ -2538,6 +2538,7 @@ func TestUploadArgsParsesPlatformRuntimeDistributions(t *testing.T) {
 		"--experimental-runner-user",
 		"--runner-queue", "ubuntu-latest=hosted",
 		"--runner-image", "ubuntu-latest=" + image,
+		"--runner-queue", "ubuntu-20.04=legacy-linux",
 		"--runner-queue", "macos-14=macos-sonoma-arm64",
 		"--runtime-distribution", "linux/amd64=/tmp/buildkite-gha-linux",
 		"--event-path", "event.json",
@@ -2553,6 +2554,9 @@ func TestUploadArgsParsesPlatformRuntimeDistributions(t *testing.T) {
 	if got := parsed.runnerTargets["ubuntu-latest"]; got != (compiler.RunnerTarget{Queue: "hosted", Platform: compiler.PlatformLinuxAMD64, Image: image}) {
 		t.Fatalf("Linux runner target = %#v", got)
 	}
+	if got := parsed.runnerTargets["ubuntu-20.04"]; got != (compiler.RunnerTarget{Queue: "legacy-linux", Platform: compiler.PlatformLinuxAMD64}) {
+		t.Fatalf("explicit fallback runner target = %#v", got)
+	}
 	if got := parsed.runnerTargets["macos-14"]; got != (compiler.RunnerTarget{Queue: "macos-sonoma-arm64", Platform: compiler.PlatformDarwinARM64}) {
 		t.Fatalf("macOS runner target = %#v", got)
 	}
@@ -2567,8 +2571,6 @@ func TestUploadArgsParsesPlatformRuntimeDistributions(t *testing.T) {
 		{args: []string{"--runner-queue", "ubuntu-latest=one", "--runner-queue", "UBUNTU-LATEST=two", "workflow.yml"}, want: "may only be specified once"},
 		{args: []string{"--runner-image", "ubuntu-latest=" + image, "workflow.yml"}, want: "requires --runner-queue"},
 		{args: []string{"--runner-queue", "macos-14=macos", "--runner-image", "macos-14=" + image, "workflow.yml"}, want: "unsupported on darwin/arm64"},
-		{args: []string{"--runner-queue", "windows-latest=windows", "workflow.yml"}, want: "unsupported runner label"},
-		{args: []string{"--runner-queue", "ubuntu-20.04=hosted", "workflow.yml"}, want: "unsupported runner label"},
 		{args: []string{"--runner-queue", "ubuntu-latest=not a queue", "workflow.yml"}, want: "runner queue"},
 		{args: []string{"--runner-queue", "ubuntu-latest=hosted", "--runner-image", "ubuntu-latest=ubuntu:latest", "workflow.yml"}, want: "immutable registry sha256 reference"},
 	} {

--- a/internal/compiler/config.go
+++ b/internal/compiler/config.go
@@ -88,17 +88,25 @@ type RunnerTarget struct {
 	Image    string
 }
 
+// RunnerSelector maps one complete runs-on selector to a target without
+// changing how any of its individual labels resolve in other selectors.
+type RunnerSelector struct {
+	Labels []string
+	Target RunnerTarget
+}
+
 // RunnerPolicy maps every accepted runner label to a Buildkite queue and
 // execution platform. An empty Linux queue uses Buildkite's default agent
 // targeting. Darwin always requires an explicit queue. Multi-label targets are
-// accepted only when every label maps to the same complete target. Untrusted
-// events are additionally restricted to UntrustedQueues unless the default is
-// explicitly allowed.
+// resolved by Selectors first, then accepted only when every label maps to the
+// same complete target. Untrusted events are additionally restricted to
+// UntrustedQueues unless the default is explicitly allowed.
 type RunnerPolicy struct {
 	// Labels retains the Linux/amd64 label-to-queue shorthand used by direct
 	// compiler callers. New multi-platform policy should use Targets.
 	Labels                     map[string]string
 	Targets                    map[string]RunnerTarget
+	Selectors                  []RunnerSelector
 	UntrustedQueues            []string
 	AllowUntrustedDefaultQueue bool
 }
@@ -163,7 +171,7 @@ func (options Options) validate() error {
 	if options.StepKeyNamespace != "" && !stepKeyNamespacePattern.MatchString(options.StepKeyNamespace) {
 		return fmt.Errorf("step key namespace %q must be 16 lowercase hexadecimal characters", options.StepKeyNamespace)
 	}
-	if len(options.Runners.Labels) == 0 && len(options.Runners.Targets) == 0 {
+	if len(options.Runners.Labels) == 0 && len(options.Runners.Targets) == 0 && len(options.Runners.Selectors) == 0 {
 		return fmt.Errorf("runner policy requires at least one label mapping")
 	}
 	labels := make(map[string]RunnerTarget, len(options.Runners.Labels)+len(options.Runners.Targets))
@@ -176,6 +184,20 @@ func (options Options) validate() error {
 		if err := validateRunnerTarget(labels, label, target); err != nil {
 			return err
 		}
+	}
+	selectors := make(map[string]RunnerTarget, len(options.Runners.Selectors))
+	for _, selector := range options.Runners.Selectors {
+		key, err := runnerSelectorKey(selector.Labels)
+		if err != nil {
+			return err
+		}
+		if err := validateRunnerTarget(make(map[string]RunnerTarget), strings.Join(selector.Labels, ", "), selector.Target); err != nil {
+			return err
+		}
+		if existing, ok := selectors[key]; ok && existing != selector.Target {
+			return fmt.Errorf("runner selector has conflicting target mappings")
+		}
+		selectors[key] = selector.Target
 	}
 	for _, queue := range options.Runners.UntrustedQueues {
 		if !queuePattern.MatchString(queue) {
@@ -283,19 +305,37 @@ func rejectRunner(reason, format string, args ...any) error {
 	return &runnerPolicyRejection{reason: reason, err: fmt.Errorf(format, args...)}
 }
 
+// Resolve returns the target selected by labels under this policy and trust
+// boundary.
+func (policy RunnerPolicy) Resolve(labels []string, trust EventTrust) (RunnerTarget, error) {
+	return policy.resolve(labels, trust)
+}
+
 func (policy RunnerPolicy) resolve(labels []string, trust EventTrust) (RunnerTarget, error) {
 	if len(labels) == 0 {
 		return RunnerTarget{}, rejectRunner(reasonNoLabels, reasonNoLabels)
 	}
-	var target RunnerTarget
-	resolved := false
+	normalizedLabels := make([]string, len(labels))
 	seen := make(map[string]struct{}, len(labels))
-	for _, label := range labels {
+	for i, label := range labels {
 		normalized := strings.ToLower(strings.TrimSpace(label))
 		if _, duplicate := seen[normalized]; duplicate {
 			return RunnerTarget{}, rejectRunner(reasonDuplicateLabel, "runs-on contains duplicate runner label %q", label)
 		}
 		seen[normalized] = struct{}{}
+		normalizedLabels[i] = normalized
+	}
+	selectorKey, _ := runnerSelectorKey(normalizedLabels)
+	for _, selector := range policy.Selectors {
+		key, err := runnerSelectorKey(selector.Labels)
+		if err == nil && key == selectorKey {
+			return policy.enforceRunnerTrust(selector.Target, trust)
+		}
+	}
+	var target RunnerTarget
+	resolved := false
+	for i, label := range labels {
+		normalized := normalizedLabels[i]
 		if unsupportedOS(normalized) {
 			return RunnerTarget{}, rejectRunner(reasonUnsupportedOS, "unsupported operating system runner label %q", label)
 		}
@@ -332,6 +372,10 @@ func (policy RunnerPolicy) resolve(labels []string, trust EventTrust) (RunnerTar
 		target = mapped
 		resolved = true
 	}
+	return policy.enforceRunnerTrust(target, trust)
+}
+
+func (policy RunnerPolicy) enforceRunnerTrust(target RunnerTarget, trust EventTrust) (RunnerTarget, error) {
 	if trust == EventUntrusted && target.Queue == "" && !policy.AllowUntrustedDefaultQueue {
 		return RunnerTarget{}, rejectRunner(reasonUntrustedDefault, reasonUntrustedDefault)
 	}
@@ -341,6 +385,26 @@ func (policy RunnerPolicy) resolve(labels []string, trust EventTrust) (RunnerTar
 		return RunnerTarget{}, rejectRunner(reasonUntrustedQueue, "untrusted event cannot target queue %q; allowed queues: %s", target.Queue, strings.Join(allowlist, ", "))
 	}
 	return target, nil
+}
+
+func runnerSelectorKey(labels []string) (string, error) {
+	if len(labels) == 0 {
+		return "", fmt.Errorf("runner selector must contain at least one label")
+	}
+	normalized := make([]string, len(labels))
+	seen := make(map[string]bool, len(labels))
+	for i, label := range labels {
+		normalized[i] = strings.ToLower(strings.TrimSpace(label))
+		if normalized[i] == "" {
+			return "", fmt.Errorf("runner selector labels must be non-empty")
+		}
+		if seen[normalized[i]] {
+			return "", fmt.Errorf("runner selector contains duplicate label %q", label)
+		}
+		seen[normalized[i]] = true
+	}
+	sort.Strings(normalized)
+	return strings.Join(normalized, "\x00"), nil
 }
 
 // runnerRejectionDiagnostic renders a rejected runs-on resolution. Callers

--- a/internal/compiler/config_test.go
+++ b/internal/compiler/config_test.go
@@ -289,6 +289,27 @@ func TestRunnerRejectionDiagnosticOmitsIrrelevantAllowlistForDuplicateLabel(t *t
 	}
 }
 
+func TestRunnerPolicySelectorTargetDoesNotChangeOverlappingLabelTarget(t *testing.T) {
+	jammy := RunnerTarget{Platform: PlatformLinuxAMD64, Image: "example.com/toolchains/jammy@sha256:" + strings.Repeat("0", 64)}
+	fallback := RunnerTarget{Queue: "linux-medium", Platform: PlatformLinuxAMD64}
+	policy := RunnerPolicy{
+		Targets: map[string]RunnerTarget{"ubuntu-22.04": jammy},
+		Selectors: []RunnerSelector{{
+			Labels: []string{"self-hosted", "ubuntu-22.04"},
+			Target: fallback,
+		}},
+	}
+	if got, err := policy.resolve([]string{"ubuntu-22.04"}, EventTrusted); err != nil || got != jammy {
+		t.Fatalf("standalone preset = %#v, %v", got, err)
+	}
+	if got, err := policy.resolve([]string{"ubuntu-22.04", "self-hosted"}, EventTrusted); err != nil || got != fallback {
+		t.Fatalf("multi-label selector = %#v, %v", got, err)
+	}
+	if got, err := (RunnerPolicy{Selectors: []RunnerSelector{{Labels: []string{"windows-latest"}, Target: fallback}}}).resolve([]string{"windows-latest"}, EventTrusted); err != nil || got != fallback {
+		t.Fatalf("server target = %#v, %v", got, err)
+	}
+}
+
 func TestRunnerRejectionDiagnosticFallsBackWhenUnclassified(t *testing.T) {
 	message, detail := runnerRejectionDiagnostic(errors.New("boom"), nil, nil, nil)
 	if message != "Runner target is unsupported. Use a configured Linux or macOS runner target." || detail != "" {

--- a/internal/runtime/runner_resolution.go
+++ b/internal/runtime/runner_resolution.go
@@ -27,6 +27,13 @@ type RunnerSuggestion struct {
 	ID       string
 	Queue    string
 	Platform string
+	Image    string
+	Warnings []RunnerWarning
+}
+
+type RunnerWarning struct {
+	Code    string
+	Message string
 }
 
 type AgentRunnerResolverConfig struct {
@@ -137,15 +144,19 @@ func (c *AgentRunnerResolver) resolveBatch(ctx context.Context, requirements []R
 			Target *struct {
 				Queue    string `json:"queue"`
 				Platform string `json:"platform"`
+				Image    string `json:"image"`
 			} `json:"target"`
 			Error *struct {
 				Code    string `json:"code"`
 				Message string `json:"message"`
 			} `json:"error"`
+			Warnings []struct {
+				Code    string `json:"code"`
+				Message string `json:"message"`
+			} `json:"warnings"`
 		} `json:"resolutions"`
 	}
 	decoder := json.NewDecoder(bytes.NewReader(payload))
-	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(&decoded); err != nil {
 		return nil, fmt.Errorf("decode runner resolution response: %w", err)
 	}
@@ -165,7 +176,16 @@ func (c *AgentRunnerResolver) resolveBatch(ctx context.Context, requirements []R
 		}
 		seen[resolution.ID] = true
 		if resolution.Target != nil {
-			suggestions = append(suggestions, RunnerSuggestion{ID: resolution.ID, Queue: resolution.Target.Queue, Platform: resolution.Target.Platform})
+			suggestion := RunnerSuggestion{ID: resolution.ID, Queue: resolution.Target.Queue, Platform: resolution.Target.Platform, Image: resolution.Target.Image}
+			for _, warning := range resolution.Warnings {
+				if strings.TrimSpace(warning.Code) == "" || strings.TrimSpace(warning.Message) == "" {
+					return nil, fmt.Errorf("runner resolution response contains an invalid warning")
+				}
+				suggestion.Warnings = append(suggestion.Warnings, RunnerWarning{Code: warning.Code, Message: warning.Message})
+			}
+			suggestions = append(suggestions, suggestion)
+		} else if len(resolution.Warnings) != 0 {
+			return nil, fmt.Errorf("runner resolution response contains warnings without a target")
 		}
 	}
 	return suggestions, nil

--- a/internal/runtime/runner_resolution_test.go
+++ b/internal/runtime/runner_resolution_test.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
-func TestAgentRunnerResolverBatchesRequirementsAndReturnsSuggestions(t *testing.T) {
+func TestAgentRunnerResolverBatchesRequirementsIgnoresUnknownFieldsAndReturnsSuggestions(t *testing.T) {
 	const jobID = "11111111-1111-4111-8111-111111111111"
 	requests := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -29,13 +30,18 @@ func TestAgentRunnerResolverBatchesRequirementsAndReturnsSuggestions(t *testing.
 		}
 		resolutions := make([]map[string]any, len(body.Requirements))
 		for i, requirement := range body.Requirements {
-			if len(requirement.Selector.Labels) == 1 && requirement.Selector.Labels[0] == "macos-26" {
-				resolutions[i] = map[string]any{"id": requirement.ID, "target": map[string]string{"queue": "macos-26-medium", "platform": "darwin/arm64"}}
+			if len(requirement.Selector.Labels) == 1 && requirement.Selector.Labels[0] == "ubuntu-18.04" {
+				resolutions[i] = map[string]any{
+					"id":       requirement.ID,
+					"target":   map[string]string{"queue": "linux-medium", "platform": "linux/amd64", "image": "registry.example.com/ubuntu@sha256:" + strings.Repeat("0", 64), "future": "ignored"},
+					"warnings": []map[string]string{{"code": "runner_label_fallback", "message": "Runner labels [ubuntu-18.04] are not supported directly; using the linux-medium queue via a heuristic fallback. Configure an explicit runner mapping to use an appropriate Buildkite queue and avoid this fallback.", "future": "ignored"}},
+					"future":   "ignored",
+				}
 			} else {
-				resolutions[i] = map[string]any{"id": requirement.ID, "error": map[string]string{"code": "unmapped_labels", "message": "No compatible runner is configured."}}
+				resolutions[i] = map[string]any{"id": requirement.ID, "error": map[string]string{"code": "unmapped_labels", "message": "No compatible runner is configured.", "future": "ignored"}}
 			}
 		}
-		_ = json.NewEncoder(w).Encode(map[string]any{"resolutions": resolutions})
+		_ = json.NewEncoder(w).Encode(map[string]any{"resolutions": resolutions, "future": "ignored"})
 	}))
 	defer server.Close()
 
@@ -47,12 +53,12 @@ func TestAgentRunnerResolverBatchesRequirementsAndReturnsSuggestions(t *testing.
 	for i := range requirements {
 		requirements[i] = RunnerRequirement{ID: fmt.Sprintf("r%d", i), Labels: []string{"ubuntu-latest"}}
 	}
-	requirements[100].Labels = []string{"macos-26"}
+	requirements[100].Labels = []string{"ubuntu-18.04"}
 	suggestions, err := resolver.Resolve(t.Context(), requirements)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if requests != 2 || len(suggestions) != 1 || suggestions[0] != (RunnerSuggestion{ID: "r100", Queue: "macos-26-medium", Platform: "darwin/arm64"}) {
+	if requests != 2 || len(suggestions) != 1 || suggestions[0].ID != "r100" || suggestions[0].Queue != "linux-medium" || suggestions[0].Platform != "linux/amd64" || suggestions[0].Image != "registry.example.com/ubuntu@sha256:"+strings.Repeat("0", 64) || len(suggestions[0].Warnings) != 1 || suggestions[0].Warnings[0] != (RunnerWarning{Code: "runner_label_fallback", Message: "Runner labels [ubuntu-18.04] are not supported directly; using the linux-medium queue via a heuristic fallback. Configure an explicit runner mapping to use an appropriate Buildkite queue and avoid this fallback."}) {
 		t.Fatalf("requests/suggestions = %d / %#v", requests, suggestions)
 	}
 }


### PR DESCRIPTION
## Why

The runner-resolution API can map unsupported GitHub Actions runner selectors to complete Buildkite targets. The client needs to apply those targets and surface fallback guidance without duplicating server compatibility policy.

## What

Decode additive response fields and complete queue, platform, and immutable Linux image targets. Apply successful targets verbatim to the exact selector and publish server-authored warnings in one job-scoped Buildkite warning annotation.

Explicit local mappings remain authoritative and bypass the API. The server owns compatibility for every other selector. This is the client for [buildkite/buildkite#32905](https://github.com/buildkite/buildkite/pull/32905).
