### PR TITLE
PB-3050: Send versioned User-Agent headers

### DIFF
--- a/internal/action/source/source.go
+++ b/internal/action/source/source.go
@@ -27,6 +27,8 @@ import (
 	"sync/atomic"
 	"time"
 	"unicode/utf8"
+
+	"github.com/buildkite/buildkite-gha/internal/useragent"
 )
 
 const (
@@ -141,6 +143,7 @@ type config struct {
 	mutableRefs                         *mutableRefCache
 	resolutionSnapshot                  *actionResolutionSnapshot
 	cacheMaxBytes                       int64
+	userAgent                           string
 	maxCompressed, maxExpanded, maxFile int64
 	maxEntries                          int
 	maxPath, maxSegment                 int
@@ -149,12 +152,20 @@ type config struct {
 func defaults() config {
 	api, _ := url.Parse(defaultAPI)
 	codeload, _ := url.Parse(defaultCodeload)
-	return config{api: api, codeload: codeload, finalHosts: map[string]bool{"codeload.github.com": true}, maxCompressed: 100 << 20, maxExpanded: 512 << 20, maxFile: 100 << 20, maxEntries: 50000, maxPath: 4096, maxSegment: 255}
+	return config{api: api, codeload: codeload, finalHosts: map[string]bool{"codeload.github.com": true}, userAgent: useragent.FromVersion(""), maxCompressed: 100 << 20, maxExpanded: 512 << 20, maxFile: 100 << 20, maxEntries: 50000, maxPath: 4096, maxSegment: 255}
 }
 
 // Option configures trusted process-level limits or test endpoints. Options must
 // never be populated from workflow input.
 type Option func(*config) error
+
+// WithUserAgentVersion identifies the buildkite-gha client making requests.
+func WithUserAgentVersion(version string) Option {
+	return func(c *config) error {
+		c.userAgent = useragent.FromVersion(version)
+		return nil
+	}
+}
 
 // WithGitHubActionSourceTokenProvider authenticates mutable-ref API requests using a
 // credential provisioned at the first such request and cached for this client.
@@ -400,7 +411,7 @@ func githubAPIGet(ctx context.Context, client *http.Client, cfg config, parts []
 	if err != nil {
 		return err
 	}
-	setAPIHeaders(req, actionSourceToken(cfg, parts))
+	setAPIHeaders(req, actionSourceToken(cfg, parts), cfg.userAgent)
 	c := *client
 	c.Jar = nil
 	c.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
@@ -470,13 +481,13 @@ func rateLimitError(resp *http.Response, body []byte) error {
 	}
 	return &RateLimitError{reset}
 }
-func setAPIHeaders(r *http.Request, token string) {
+func setAPIHeaders(r *http.Request, token, userAgent string) {
 	r.Header.Del("Authorization")
 	r.Header.Del("Cookie")
 	if token != "" {
 		r.Header.Set("Authorization", "Bearer "+token)
 	}
-	r.Header.Set("User-Agent", "buildkite-gha-action-source/1")
+	r.Header.Set("User-Agent", userAgent)
 	r.Header.Set("Accept", "application/vnd.github+json")
 	r.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 }
@@ -701,7 +712,7 @@ func (s *Store) downloadExtract(ctx context.Context, r Resolved, dst string) err
 	}
 	req.Header.Del("Authorization")
 	req.Header.Del("Cookie")
-	req.Header.Set("User-Agent", "buildkite-gha-action-source/1")
+	req.Header.Set("User-Agent", s.cfg.userAgent)
 	c := *s.client
 	c.Jar = nil
 	c.CheckRedirect = func(req *http.Request, via []*http.Request) error {
@@ -713,6 +724,7 @@ func (s *Store) downloadExtract(ctx context.Context, r Resolved, dst string) err
 		}
 		req.Header.Del("Authorization")
 		req.Header.Del("Cookie")
+		req.Header.Set("User-Agent", s.cfg.userAgent)
 		return nil
 	}
 	resp, e := c.Do(req)

--- a/internal/action/source/source_test.go
+++ b/internal/action/source/source_test.go
@@ -53,7 +53,7 @@ func TestResolverTagPeelingAndHeaders(t *testing.T) {
 		if r.Header.Get("Authorization") != "" || r.Header.Get("Cookie") != "" {
 			t.Error("credentials sent")
 		}
-		if r.Header.Get("User-Agent") == "" || r.Header.Get("Accept") == "" || r.Header.Get("X-GitHub-Api-Version") == "" {
+		if r.Header.Get("User-Agent") != "buildkite-gha/1.2.3" || r.Header.Get("Accept") == "" || r.Header.Get("X-GitHub-Api-Version") == "" {
 			t.Error("required headers missing")
 		}
 		switch {
@@ -66,7 +66,7 @@ func TestResolverTagPeelingAndHeaders(t *testing.T) {
 		}
 	}))
 	defer ts.Close()
-	r, err := NewResolver(&http.Client{}, WithTestEndpoints(ts.URL))
+	r, err := NewResolver(&http.Client{}, WithTestEndpoints(ts.URL), WithUserAgentVersion("1.2.3"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -604,10 +604,13 @@ func TestStoreExactCommitAtomicHitAndSubpath(t *testing.T) {
 		if r.URL.Path != "/Owner/Repo/tar.gz/"+testSHA {
 			t.Errorf("URL = %s", r.URL.Path)
 		}
+		if r.Header.Get("User-Agent") != "buildkite-gha/1.2.3" {
+			t.Errorf("User-Agent = %q", r.Header.Get("User-Agent"))
+		}
 		_, _ = w.Write(archive)
 	}))
 	defer ts.Close()
-	store, err := NewStore(t.TempDir(), ts.Client(), WithTestEndpoints(ts.URL, ts.URL))
+	store, err := NewStore(t.TempDir(), ts.Client(), WithTestEndpoints(ts.URL, ts.URL), WithUserAgentVersion("1.2.3"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -47,13 +47,13 @@ func run(args []string, stdout, stderr io.Writer, clientVersion string, agentRun
 			}
 			switch args[0] {
 			case "validate":
-				return validate(args[1:], stdout, stderr, version, transport.Agent{Runner: agentRunner})
+				return validate(args[1:], stdout, stderr, clientVersion, transport.Agent{Runner: agentRunner})
 			case "validate-batch":
-				return validateBatch(args[1:], stderr, version)
+				return validateBatch(args[1:], stderr, clientVersion)
 			case "compile":
-				return compile(args[1:], stdout, stderr, version, transport.Agent{Runner: agentRunner})
+				return compile(args[1:], stdout, stderr, clientVersion, transport.Agent{Runner: agentRunner})
 			case "upload":
-				return upload(args[1:], stdout, stderr, version, transport.Agent{Runner: agentRunner})
+				return upload(args[1:], stdout, stderr, clientVersion, transport.Agent{Runner: agentRunner})
 			case "run-job":
 				return runJob(args[1:], stdout, stderr, version, clientVersion, transport.Agent{Runner: agentRunner})
 			default:

--- a/internal/cli/compile.go
+++ b/internal/cli/compile.go
@@ -14,7 +14,8 @@ import (
 	"github.com/buildkite/buildkite-gha/internal/transport"
 )
 
-func compile(args []string, stdout, stderr io.Writer, version string, agent transport.Agent) int {
+func compile(args []string, stdout, stderr io.Writer, clientVersion string, agent transport.Agent) int {
+	version := commandVersion(clientVersion)
 	workflowPath, eventPath, format, err := compileArgs(args)
 	if err != nil {
 		return usageError(stderr, "compile: %v", err)
@@ -33,7 +34,7 @@ func compile(args []string, stdout, stderr io.Writer, version string, agent tran
 	if !ok {
 		return 1
 	}
-	repositorySource, cleanup, sourceErr := newHostedActionSource(ctx, "", nil, nil)
+	repositorySource, cleanup, sourceErr := newHostedActionSource(ctx, "", clientVersion, nil, nil)
 	if sourceErr != nil {
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: compile: configure public repository source: %v\n", sourceErr)
 		return 1

--- a/internal/cli/hosted.go
+++ b/internal/cli/hosted.go
@@ -96,15 +96,16 @@ func (s *repositorySourceSwitch) set(source compiler.RepositorySource) {
 	s.mu.Unlock()
 }
 
-func importerJobActionSourceAuthentication(warnings io.Writer) *actionSourceAuthentication {
+func importerJobActionSourceAuthentication(warnings io.Writer, clientVersion string) *actionSourceAuthentication {
 	authentication := &actionSourceAuthentication{
 		redactor: gharuntime.AgentRedactor{Executable: os.Getenv("BUILDKITE_GHA_AGENT")},
 		warnings: warnings,
 	}
 	provider, err := gharuntime.NewAgentGitHubTokens(gharuntime.AgentGitHubTokenConfig{
-		Endpoint: os.Getenv("BUILDKITE_AGENT_ENDPOINT"),
-		JobID:    os.Getenv("BUILDKITE_JOB_ID"),
-		JobToken: os.Getenv("BUILDKITE_AGENT_ACCESS_TOKEN"),
+		Endpoint:      os.Getenv("BUILDKITE_AGENT_ENDPOINT"),
+		JobID:         os.Getenv("BUILDKITE_JOB_ID"),
+		JobToken:      os.Getenv("BUILDKITE_AGENT_ACCESS_TOKEN"),
+		ClientVersion: clientVersion,
 	})
 	if err != nil {
 		return authentication
@@ -228,7 +229,7 @@ func compileHostedNamespacedWithActionCache(ctx context.Context, workflowPath st
 			}
 		}
 		var err error
-		repositorySource, cleanup, err = newHostedActionSource(ctx, actionCacheDir, sourceOptions, nil)
+		repositorySource, cleanup, err = newHostedActionSource(ctx, actionCacheDir, version, sourceOptions, nil)
 		if err != nil {
 			return hostedCompilation{}, hostedError(hostedEnvironmentFailure, err)
 		}
@@ -265,12 +266,14 @@ func compileHostedNamespacedWithActionCache(ctx context.Context, workflowPath st
 	return hostedCompilation{Bundle: bundle, HasActions: hasActions, Admitted: true}, nil
 }
 
-func newHostedActionSource(ctx context.Context, actionCacheDir string, resolverOptions, storeOptions []actionsource.Option) (compiler.ActionSource, func(), error) {
-	actionSource, cleanup, _, err := newHostedActionSourceWithSnapshot(ctx, actionCacheDir, resolverOptions, storeOptions)
+func newHostedActionSource(ctx context.Context, actionCacheDir, clientVersion string, resolverOptions, storeOptions []actionsource.Option) (compiler.ActionSource, func(), error) {
+	actionSource, cleanup, _, err := newHostedActionSourceWithSnapshot(ctx, actionCacheDir, clientVersion, resolverOptions, storeOptions)
 	return actionSource, cleanup, err
 }
 
-func newHostedActionSourceWithSnapshot(ctx context.Context, actionCacheDir string, resolverOptions, storeOptions []actionsource.Option) (compiler.ActionSource, func(), string, error) {
+func newHostedActionSourceWithSnapshot(ctx context.Context, actionCacheDir, clientVersion string, resolverOptions, storeOptions []actionsource.Option) (compiler.ActionSource, func(), string, error) {
+	resolverOptions = append(resolverOptions, actionsource.WithUserAgentVersion(clientVersion))
+	storeOptions = append(storeOptions, actionsource.WithUserAgentVersion(clientVersion))
 	actionRoot := actionCacheDir
 	cleanup := func() {}
 	if actionRoot == "" {

--- a/internal/cli/hosted_test.go
+++ b/internal/cli/hosted_test.go
@@ -613,7 +613,7 @@ func TestJobScopedActionSourceAuthenticationIgnoresAmbientGitHubTokens(t *testin
 	t.Setenv("BUILDKITE_JOB_ID", "")
 	t.Setenv("BUILDKITE_AGENT_ACCESS_TOKEN", "")
 	var warnings bytes.Buffer
-	authentication := importerJobActionSourceAuthentication(&warnings)
+	authentication := importerJobActionSourceAuthentication(&warnings, "test-version")
 	token, err := authentication.token(t.Context(), "buildkite/buildkite-gha")
 	if err != nil || token != "" || authentication.provider != nil || !strings.Contains(warnings.String(), "authentication is unavailable") {
 		t.Fatalf("ambient GitHub token authentication = provider %v, token %q, error %v, warnings %q", authentication.provider != nil, token, err, warnings.String())
@@ -624,7 +624,7 @@ func TestJobScopedActionSourceAuthenticationIgnoresAmbientGitHubTokens(t *testin
 	t.Setenv("BUILDKITE_AGENT_ENDPOINT", server.URL)
 	t.Setenv("BUILDKITE_JOB_ID", cliTestJobID)
 	t.Setenv("BUILDKITE_AGENT_ACCESS_TOKEN", "job-token")
-	if authentication := importerJobActionSourceAuthentication(io.Discard); authentication.provider == nil {
+	if authentication := importerJobActionSourceAuthentication(io.Discard, "test-version"); authentication.provider == nil {
 		t.Fatal("job-scoped Agent configuration did not configure action-source authentication")
 	}
 }

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -54,6 +54,7 @@ func pluginContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 	return uploadParsedContext(ctx, parsedUploadArgs{
 		workflowOperands:       configuration.Workflows,
 		explicitWorkflowPaths:  true,
+		clientVersion:          clientVersion,
 		runnerTargets:          configuration.runnerTargets,
 		oidc:                   configuration.OIDC,
 		experimentalRunnerUser: configuration.ExperimentalRunnerUser,

--- a/internal/cli/plugin_runtime.go
+++ b/internal/cli/plugin_runtime.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/buildkite/buildkite-gha/internal/compiler"
+	"github.com/buildkite/buildkite-gha/internal/useragent"
 )
 
 const (
@@ -118,7 +119,7 @@ func pluginRuntimeAsset(platform compiler.Platform) string {
 
 func acquirePluginRuntime(ctx context.Context, version string, platform compiler.Platform, client *http.Client, baseURL, cachePath string) (runtimeDistribution, error) {
 	asset := pluginRuntimeAsset(platform)
-	checksums, err := downloadPluginReleaseFile(ctx, client, baseURL+"/v"+version+"/checksums.txt", pluginChecksumLimit)
+	checksums, err := downloadPluginReleaseFile(ctx, client, baseURL+"/v"+version+"/checksums.txt", version, pluginChecksumLimit)
 	if err != nil {
 		return runtimeDistribution{}, fmt.Errorf("download release checksums: %w", err)
 	}
@@ -128,7 +129,7 @@ func acquirePluginRuntime(ctx context.Context, version string, platform compiler
 	}
 	archive := readVerifiedPluginArchiveCache(cachePath, expected)
 	if archive == nil {
-		archive, err = downloadPluginReleaseFile(ctx, client, baseURL+"/v"+version+"/"+asset, pluginArchiveLimit)
+		archive, err = downloadPluginReleaseFile(ctx, client, baseURL+"/v"+version+"/"+asset, version, pluginArchiveLimit)
 		if err != nil {
 			return runtimeDistribution{}, fmt.Errorf("download %s runtime: %w", platform, err)
 		}
@@ -148,11 +149,12 @@ func acquirePluginRuntime(ctx context.Context, version string, platform compiler
 	return runtimeDistribution{contents: contents, digest: fmt.Sprintf("sha256:%x", digest)}, nil
 }
 
-func downloadPluginReleaseFile(ctx context.Context, client *http.Client, source string, limit int64) ([]byte, error) {
+func downloadPluginReleaseFile(ctx context.Context, client *http.Client, source, version string, limit int64) ([]byte, error) {
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, source, nil)
 	if err != nil || request.URL.Scheme != "https" {
 		return nil, fmt.Errorf("release URL must use HTTPS")
 	}
+	request.Header.Set("User-Agent", useragent.FromVersion(version))
 	response, err := client.Do(request)
 	if err != nil {
 		return nil, err

--- a/internal/cli/plugin_runtime_test.go
+++ b/internal/cli/plugin_runtime_test.go
@@ -40,6 +40,9 @@ func TestPluginAcquiresVerifiedLinuxRuntimeForDarwinHost(t *testing.T) {
 	archive := pluginTestArchive(t, linux, false)
 	archiveDigest := sha256.Sum256(archive)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.Header.Get("User-Agent") != "buildkite-gha/1.2.3" {
+			t.Errorf("User-Agent = %q", request.Header.Get("User-Agent"))
+		}
 		switch filepath.Base(request.URL.Path) {
 		case "checksums.txt":
 			_, _ = fmt.Fprintf(response, "%x  %s\n", archiveDigest, pluginLinuxAsset)

--- a/internal/cli/run_job.go
+++ b/internal/cli/run_job.go
@@ -138,7 +138,7 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 			return 1
 		}
 		defer func() { _ = os.RemoveAll(actionCache) }()
-		store, err := actionsource.NewStoreContext(ctx, actionCache, nil)
+		store, err := actionsource.NewStoreContext(ctx, actionCache, nil, actionsource.WithUserAgentVersion(clientVersion))
 		if err != nil {
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: configure action cache: %v\n", err)
 			return 1
@@ -153,10 +153,11 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 	}
 	if cacheRequired || len(job.Actions) > 0 {
 		cacheCredentials, err = gharuntime.NewAgentCacheCredentials(gharuntime.AgentCacheConfig{
-			Endpoint:   os.Getenv("BUILDKITE_AGENT_ENDPOINT"),
-			JobID:      os.Getenv("BUILDKITE_JOB_ID"),
-			JobToken:   os.Getenv("BUILDKITE_AGENT_ACCESS_TOKEN"),
-			ResultsURL: os.Getenv("BUILDKITE_GHA_CACHE_URL"),
+			Endpoint:      os.Getenv("BUILDKITE_AGENT_ENDPOINT"),
+			JobID:         os.Getenv("BUILDKITE_JOB_ID"),
+			JobToken:      os.Getenv("BUILDKITE_AGENT_ACCESS_TOKEN"),
+			ResultsURL:    os.Getenv("BUILDKITE_GHA_CACHE_URL"),
+			ClientVersion: clientVersion,
 		})
 		if err != nil && cacheRequired {
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: configure actions/cache service: %v\n", err)
@@ -174,6 +175,7 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 			JobToken:         os.Getenv("BUILDKITE_AGENT_ACCESS_TOKEN"),
 			OrganizationSlug: os.Getenv("BUILDKITE_ORGANIZATION_SLUG"),
 			PipelineSlug:     os.Getenv("BUILDKITE_PIPELINE_SLUG"),
+			ClientVersion:    clientVersion,
 		})
 		if tokenErr != nil {
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: configure GitHub token service: %v\n", tokenErr)
@@ -184,9 +186,10 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 	var oidcTokens gharuntime.OIDCTokenProvider
 	if job.IDTokenPermission == "write" {
 		config := gharuntime.AgentOIDCTokenConfig{
-			Endpoint: os.Getenv("BUILDKITE_AGENT_ENDPOINT"),
-			JobID:    os.Getenv("BUILDKITE_JOB_ID"),
-			JobToken: os.Getenv("BUILDKITE_AGENT_ACCESS_TOKEN"),
+			Endpoint:      os.Getenv("BUILDKITE_AGENT_ENDPOINT"),
+			JobID:         os.Getenv("BUILDKITE_JOB_ID"),
+			JobToken:      os.Getenv("BUILDKITE_AGENT_ACCESS_TOKEN"),
+			ClientVersion: clientVersion,
 		}
 		if job.OIDC != nil {
 			config.Claims = job.OIDC.Claims
@@ -248,7 +251,7 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 			if err != nil {
 				return "", fmt.Errorf("prepare action runtime: create private action runtime: %w", err)
 			}
-			mise, err := resolveRuntimeMise(ctx, os.Getenv("BUILDKITE_GHA_MISE"), runner.MiseDataDir, privateRuntime, stderr)
+			mise, err := resolveRuntimeMiseVersion(ctx, os.Getenv("BUILDKITE_GHA_MISE"), runner.MiseDataDir, privateRuntime, stderr, clientVersion)
 			if err != nil {
 				return "", fmt.Errorf("prepare action runtime: %w", err)
 			}

--- a/internal/cli/runner_resolution.go
+++ b/internal/cli/runner_resolution.go
@@ -11,7 +11,7 @@ import (
 	gharuntime "github.com/buildkite/buildkite-gha/internal/runtime"
 )
 
-func suggestedRunnerTargets(ctx context.Context, reports []compiler.Report) (map[string]compiler.RunnerTarget, error) {
+func suggestedRunnerTargets(ctx context.Context, reports []compiler.Report, clientVersion string) (map[string]compiler.RunnerTarget, error) {
 	endpoint := os.Getenv("BUILDKITE_AGENT_ENDPOINT")
 	jobID := os.Getenv("BUILDKITE_JOB_ID")
 	jobToken := os.Getenv("BUILDKITE_AGENT_ACCESS_TOKEN")
@@ -19,9 +19,10 @@ func suggestedRunnerTargets(ctx context.Context, reports []compiler.Report) (map
 		return nil, nil
 	}
 	resolver, err := gharuntime.NewAgentRunnerResolver(gharuntime.AgentRunnerResolverConfig{
-		Endpoint: endpoint,
-		JobID:    jobID,
-		JobToken: jobToken,
+		Endpoint:      endpoint,
+		JobID:         jobID,
+		JobToken:      jobToken,
+		ClientVersion: clientVersion,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/cli/runtime_distribution_test.go
+++ b/internal/cli/runtime_distribution_test.go
@@ -51,7 +51,7 @@ func TestUploadRejectsUnsupportedImporterBeforeProcessing(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			runner := &cliCaptureRunner{}
 			var stdout, stderr bytes.Buffer
-			if code := uploadFromPlatform("linux", "arm64", test.args, &stdout, &stderr, "dev", transport.Agent{Runner: runner}); code != 1 {
+			if code := uploadFromPlatform("linux", "arm64", test.args, &stdout, &stderr, "dev", "dev", transport.Agent{Runner: runner}); code != 1 {
 				t.Fatalf("uploadFromPlatform() code = %d, want 1", code)
 			}
 			if got := stderr.String(); got != "buildkite-gha: upload: importer requires linux/amd64 or darwin/arm64, running on linux/arm64\n" {
@@ -74,7 +74,7 @@ func TestDarwinUploadRequiresLinuxDistributionForLinuxWorkflow(t *testing.T) {
 	runner := &cliCaptureRunner{}
 	var stdout, stderr bytes.Buffer
 	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
-	code := uploadFromPlatform("darwin", "arm64", []string{"--event-path", eventPath, workflowPath}, &stdout, &stderr, "dev", transport.Agent{Runner: runner})
+	code := uploadFromPlatform("darwin", "arm64", []string{"--event-path", eventPath, workflowPath}, &stdout, &stderr, "dev", "dev", transport.Agent{Runner: runner})
 	if code != 1 || !strings.Contains(stderr.String(), "runtime distribution for linux/amd64 is required by the selected workflows") {
 		t.Fatalf("uploadFromPlatform() = %d, stderr = %q", code, stderr.String())
 	}

--- a/internal/cli/runtime_mise.go
+++ b/internal/cli/runtime_mise.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	buildkitepipeline "github.com/buildkite/buildkite-gha/internal/buildkite"
+	"github.com/buildkite/buildkite-gha/internal/useragent"
 )
 
 const (
@@ -32,6 +33,12 @@ const (
 
 func resolveRuntimeMise(ctx context.Context, configured, dataDir, privateRuntime string, stderr io.Writer) (string, error) {
 	return resolveRuntimeMiseWithInstaller(ctx, configured, dataDir, privateRuntime, stderr, installRuntimeMise)
+}
+
+func resolveRuntimeMiseVersion(ctx context.Context, configured, dataDir, privateRuntime string, stderr io.Writer, clientVersion string) (string, error) {
+	return resolveRuntimeMiseWithInstaller(ctx, configured, dataDir, privateRuntime, stderr, func(ctx context.Context, dataDir, privateRuntime string, stderr io.Writer) (string, error) {
+		return installRuntimeMiseVersion(ctx, dataDir, privateRuntime, stderr, clientVersion)
+	})
 }
 
 func resolveRuntimeMiseWithInstaller(ctx context.Context, configured, dataDir, privateRuntime string, stderr io.Writer, install func(context.Context, string, string, io.Writer) (string, error)) (string, error) {
@@ -175,6 +182,10 @@ func selectRuntimeMiseRelease(goos, goarch string) (runtimeMiseRelease, error) {
 }
 
 func installRuntimeMise(ctx context.Context, dataDir, privateRuntime string, stderr io.Writer) (string, error) {
+	return installRuntimeMiseVersion(ctx, dataDir, privateRuntime, stderr, "")
+}
+
+func installRuntimeMiseVersion(ctx context.Context, dataDir, privateRuntime string, stderr io.Writer, clientVersion string) (string, error) {
 	selected, err := selectRuntimeMiseRelease(runtime.GOOS, runtime.GOARCH)
 	if err != nil {
 		return "", err
@@ -195,6 +206,7 @@ func installRuntimeMise(ctx context.Context, dataDir, privateRuntime string, std
 	}
 	_, _ = fmt.Fprintf(stderr, "~~~ :mise: Install mise %s\n", buildkitepipeline.MinimumMiseVersion)
 	url := fmt.Sprintf("https://github.com/jdx/mise/releases/download/v%s/mise-v%s-%s.tar.gz", buildkitepipeline.MinimumMiseVersion, buildkitepipeline.MinimumMiseVersion, selected.asset)
+	requestUserAgent := useragent.FromVersion(clientVersion)
 	client := &http.Client{
 		Timeout: 2 * time.Minute,
 		CheckRedirect: func(request *http.Request, via []*http.Request) error {
@@ -204,10 +216,11 @@ func installRuntimeMise(ctx context.Context, dataDir, privateRuntime string, std
 			if len(via) >= 10 {
 				return errors.New("too many mise download redirects")
 			}
+			request.Header.Set("User-Agent", requestUserAgent)
 			return nil
 		},
 	}
-	cached, err := installRuntimeMiseFromPlatform(ctx, root, selected.cacheKey, client, url, selected.archiveDigest, selected.binaryDigest)
+	cached, err := installRuntimeMiseFromPlatform(ctx, root, selected.cacheKey, client, url, selected.archiveDigest, selected.binaryDigest, clientVersion)
 	if err != nil {
 		return "", err
 	}
@@ -254,11 +267,11 @@ func pinRuntimeMise(ctx context.Context, cached, privateRuntime, expectedDigest 
 	return resolved, nil
 }
 
-func installRuntimeMiseFrom(ctx context.Context, root string, client *http.Client, sourceURL, archiveDigest, binaryDigest string) (string, error) {
-	return installRuntimeMiseFromPlatform(ctx, root, "linux-x64", client, sourceURL, archiveDigest, binaryDigest)
+func installRuntimeMiseFrom(ctx context.Context, root string, client *http.Client, sourceURL, archiveDigest, binaryDigest, clientVersion string) (string, error) {
+	return installRuntimeMiseFromPlatform(ctx, root, "linux-x64", client, sourceURL, archiveDigest, binaryDigest, clientVersion)
 }
 
-func installRuntimeMiseFromPlatform(ctx context.Context, root, cacheKey string, client *http.Client, sourceURL, archiveDigest, binaryDigest string) (string, error) {
+func installRuntimeMiseFromPlatform(ctx context.Context, root, cacheKey string, client *http.Client, sourceURL, archiveDigest, binaryDigest, clientVersion string) (string, error) {
 	destinationDir := filepath.Join(root, cacheKey)
 	parent := filepath.Dir(destinationDir)
 	if err := os.MkdirAll(parent, 0o755); err != nil {
@@ -279,7 +292,7 @@ func installRuntimeMiseFromPlatform(ctx context.Context, root, cacheKey string, 
 	}
 	defer func() { _ = os.RemoveAll(staging) }()
 	archive := filepath.Join(staging, "mise.tar.gz")
-	if err := downloadRuntimeMise(ctx, client, sourceURL, archive, archiveDigest); err != nil {
+	if err := downloadRuntimeMise(ctx, client, sourceURL, archive, archiveDigest, clientVersion); err != nil {
 		return "", err
 	}
 	stagedExecutable := filepath.Join(staging, "mise")
@@ -317,11 +330,12 @@ func installRuntimeMiseFromPlatform(ctx context.Context, root, cacheKey string, 
 	return resolved, nil
 }
 
-func downloadRuntimeMise(ctx context.Context, client *http.Client, sourceURL, destination, expectedDigest string) error {
+func downloadRuntimeMise(ctx context.Context, client *http.Client, sourceURL, destination, expectedDigest, clientVersion string) error {
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, sourceURL, nil)
 	if err != nil {
 		return fmt.Errorf("create mise download request: %w", err)
 	}
+	request.Header.Set("User-Agent", useragent.FromVersion(clientVersion))
 	response, err := client.Do(request)
 	if err != nil {
 		return fmt.Errorf("download mise: %w", err)

--- a/internal/cli/runtime_mise_test.go
+++ b/internal/cli/runtime_mise_test.go
@@ -209,8 +209,11 @@ func TestInstallRuntimeMiseDownloadsVerifiesAndReusesCache(t *testing.T) {
 	archiveHash := sha256.Sum256(archive)
 	binaryHash := sha256.Sum256(binary)
 	requests := 0
-	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		requests++
+		if request.Header.Get("User-Agent") != "buildkite-gha/1.2.3" {
+			t.Errorf("User-Agent = %q", request.Header.Get("User-Agent"))
+		}
 		_, _ = response.Write(archive)
 	}))
 	defer server.Close()
@@ -229,7 +232,7 @@ func TestInstallRuntimeMiseDownloadsVerifiesAndReusesCache(t *testing.T) {
 	root := filepath.Join(logicalParent, "cache")
 	want := filepath.Join(realParent, "cache", "linux-x64", "mise")
 	for range 2 {
-		got, err := installRuntimeMiseFrom(t.Context(), root, server.Client(), server.URL, hex.EncodeToString(archiveHash[:]), hex.EncodeToString(binaryHash[:]))
+		got, err := installRuntimeMiseFrom(t.Context(), root, server.Client(), server.URL, hex.EncodeToString(archiveHash[:]), hex.EncodeToString(binaryHash[:]), "1.2.3")
 		if err != nil || got != want {
 			t.Fatalf("installRuntimeMiseFrom() = %q, %v", got, err)
 		}
@@ -250,7 +253,7 @@ func TestInstallRuntimeMiseRejectsInvalidArchive(t *testing.T) {
 	}))
 	defer server.Close()
 	binaryHash := sha256.Sum256(binary)
-	if _, err := installRuntimeMiseFrom(t.Context(), t.TempDir(), server.Client(), server.URL, strings.Repeat("0", 64), hex.EncodeToString(binaryHash[:])); err == nil || !strings.Contains(err.Error(), "archive checksum") {
+	if _, err := installRuntimeMiseFrom(t.Context(), t.TempDir(), server.Client(), server.URL, strings.Repeat("0", 64), hex.EncodeToString(binaryHash[:]), "test-version"); err == nil || !strings.Contains(err.Error(), "archive checksum") {
 		t.Fatalf("installRuntimeMiseFrom() error = %v", err)
 	}
 }
@@ -285,7 +288,7 @@ func TestManagedMiseCacheIsNotExecutedBeforePrivateCopy(t *testing.T) {
 	if err := os.WriteFile(cached, binary, 0o500); err != nil {
 		t.Fatal(err)
 	}
-	got, err := installRuntimeMiseFrom(t.Context(), root, nil, "", "", hex.EncodeToString(digest[:]))
+	got, err := installRuntimeMiseFrom(t.Context(), root, nil, "", "", hex.EncodeToString(digest[:]), "test-version")
 	if err != nil || got != cached {
 		t.Fatalf("installRuntimeMiseFrom() = %q, %v; want cache hit %q", got, err, cached)
 	}
@@ -310,7 +313,7 @@ func TestManagedMiseColdCacheIsNotExecutedBeforePrivateCopy(t *testing.T) {
 		_, _ = response.Write(archive)
 	}))
 	defer server.Close()
-	cached, err := installRuntimeMiseFrom(t.Context(), t.TempDir(), server.Client(), server.URL, hex.EncodeToString(archiveDigest[:]), hex.EncodeToString(binaryDigest[:]))
+	cached, err := installRuntimeMiseFrom(t.Context(), t.TempDir(), server.Client(), server.URL, hex.EncodeToString(archiveDigest[:]), hex.EncodeToString(binaryDigest[:]), "test-version")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/upload.go
+++ b/internal/cli/upload.go
@@ -36,11 +36,11 @@ const (
 	workflowCheckSummaryNotice    = "\n\n_Additional diagnostics omitted at the provider check summary size limit._\n"
 )
 
-func upload(args []string, stdout, stderr io.Writer, version string, agent transport.Agent) int {
-	return uploadFromPlatform(runtime.GOOS, runtime.GOARCH, args, stdout, stderr, version, agent)
+func upload(args []string, stdout, stderr io.Writer, clientVersion string, agent transport.Agent) int {
+	return uploadFromPlatform(runtime.GOOS, runtime.GOARCH, args, stdout, stderr, commandVersion(clientVersion), clientVersion, agent)
 }
 
-func uploadFromPlatform(goos, goarch string, args []string, stdout, stderr io.Writer, version string, agent transport.Agent) int {
+func uploadFromPlatform(goos, goarch string, args []string, stdout, stderr io.Writer, version, clientVersion string, agent transport.Agent) int {
 	platform, err := importerPlatform(goos, goarch)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
@@ -51,6 +51,7 @@ func uploadFromPlatform(goos, goarch string, args []string, stdout, stderr io.Wr
 		return usageError(stderr, "upload: %v", err)
 	}
 	uploadArguments.importerPlatform = platform
+	uploadArguments.clientVersion = clientVersion
 	return uploadParsed(uploadArguments, stdout, stderr, version, agent)
 }
 
@@ -127,7 +128,7 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 		_, _ = fmt.Fprintln(stderr, "buildkite-gha: upload: workflow paths matched only reusable workflow_call workflows; there is nothing to upload")
 		return 1
 	}
-	anonymousSource, cleanupAnonymousSource, sourceErr := newHostedActionSource(ctx, "", nil, nil)
+	anonymousSource, cleanupAnonymousSource, sourceErr := newHostedActionSource(ctx, "", uploadArguments.clientVersion, nil, nil)
 	if sourceErr != nil {
 		for _, input := range workflows {
 			if !input.ReusableOnly {
@@ -174,14 +175,14 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 		}
 		return 1
 	}
-	authentication := importerJobActionSourceAuthentication(stderr)
+	authentication := importerJobActionSourceAuthentication(stderr, uploadArguments.clientVersion)
 	var sourceOptions []actionsource.Option
 	if effectiveEvent.Event.Provider == "github" {
 		if authenticationOption := authentication.option(effectiveEvent.Event.Repository.Owner + "/" + effectiveEvent.Event.Repository.Name); authenticationOption != nil {
 			sourceOptions = append(sourceOptions, authenticationOption)
 		}
 	}
-	authenticatedSource, cleanupSource, sourceErr := newHostedActionSource(ctx, "", sourceOptions, nil)
+	authenticatedSource, cleanupSource, sourceErr := newHostedActionSource(ctx, "", uploadArguments.clientVersion, sourceOptions, nil)
 	if sourceErr != nil {
 		for _, input := range workflows {
 			if !input.ReusableOnly {
@@ -229,7 +230,7 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 		validationOptions.RepositorySource = repositorySource
 		validations[i], validationErrs[i] = compiler.ValidateEventWithOptionsContext(ctx, input.Path, input.Source, effectiveEvent.Source, validationOptions)
 	}
-	suggestedTargets, err := suggestedRunnerTargets(ctx, validations)
+	suggestedTargets, err := suggestedRunnerTargets(ctx, validations, uploadArguments.clientVersion)
 	if err != nil {
 		if ctx.Err() != nil {
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", ctx.Err())
@@ -697,6 +698,7 @@ type parsedUploadArgs struct {
 	workflowOperands         []string
 	explicitWorkflowPaths    bool
 	eventPath                string
+	clientVersion            string
 	runtimeDistributionPaths map[compiler.Platform]string
 	runnerTargets            map[string]compiler.RunnerTarget
 	oidc                     *plan.OIDCConfiguration

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -21,7 +21,6 @@ import (
 )
 
 func validate(args []string, stdout, stderr io.Writer, clientVersion string, agent transport.Agent) int {
-	version := commandVersion(clientVersion)
 	args, actionCacheDir, err := validateActionCacheArgs(args)
 	if err != nil {
 		return usageError(stderr, "validate: %v", err)
@@ -45,16 +44,16 @@ func validate(args []string, stdout, stderr io.Writer, clientVersion string, age
 	defer stop()
 	out := newProcessingOutput(ctx, "validate", format, stdout, stderr, agent)
 	if allEvents {
-		return validateAllEvents(ctx, out, workflowPath, version, actionCacheDir, nil, stderr)
+		return validateAllEvents(ctx, out, workflowPath, clientVersion, actionCacheDir, nil, stderr)
 	}
-	return validateOne(ctx, out, workflowPath, eventPath, eventName, profile, version, actionCacheDir, nil, stderr)
+	return validateOne(ctx, out, workflowPath, eventPath, eventName, profile, clientVersion, actionCacheDir, nil, stderr)
 }
 
-func validateOne(ctx context.Context, out processingOutput, workflowPath, eventPath, eventName, profile, version, actionCacheDir string, runtime *profileValidationRuntime, stderr io.Writer) int {
-	return validateOneSource(ctx, out, workflowPath, nil, eventPath, eventName, profile, version, actionCacheDir, runtime, stderr)
+func validateOne(ctx context.Context, out processingOutput, workflowPath, eventPath, eventName, profile, clientVersion, actionCacheDir string, runtime *profileValidationRuntime, stderr io.Writer) int {
+	return validateOneSource(ctx, out, workflowPath, nil, eventPath, eventName, profile, clientVersion, actionCacheDir, runtime, stderr)
 }
 
-func validateOneSource(ctx context.Context, out processingOutput, workflowPath string, workflowSource []byte, eventPath, eventName, profile, version, actionCacheDir string, runtime *profileValidationRuntime, stderr io.Writer) int {
+func validateOneSource(ctx context.Context, out processingOutput, workflowPath string, workflowSource []byte, eventPath, eventName, profile, clientVersion, actionCacheDir string, runtime *profileValidationRuntime, stderr io.Writer) int {
 	contextRequired := false
 	var loadEvent func() ([]byte, error)
 	if eventPath != "" {
@@ -84,7 +83,7 @@ func validateOneSource(ctx context.Context, out processingOutput, workflowPath s
 	cleanupSource := func() {}
 	if repositorySource == nil {
 		var sourceErr error
-		repositorySource, cleanupSource, sourceErr = newHostedActionSource(ctx, actionCacheDir, version, nil, nil)
+		repositorySource, cleanupSource, sourceErr = newHostedActionSource(ctx, actionCacheDir, clientVersion, nil, nil)
 		if sourceErr != nil {
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: configure public repository source: %v\n", sourceErr)
 			return 1
@@ -154,7 +153,7 @@ func validateOneSource(ctx context.Context, out processingOutput, workflowPath s
 			compiler.PlatformLinuxAMD64:  distributionDigest,
 			compiler.PlatformDarwinARM64: distributionDigest,
 		}
-		preflight, profileErr := compileHostedWithActionCache(ctx, workflowPath, source, event, version, distributionDigest, "buildkite-gha-profile-importer", "", nil, runtimeDistributions, actionCacheDir, repositorySource, nil)
+		preflight, profileErr := compileHostedWithActionCache(ctx, workflowPath, source, event, commandVersion(clientVersion), distributionDigest, "buildkite-gha-profile-importer", "", nil, runtimeDistributions, actionCacheDir, repositorySource, nil)
 		applyHostedPreflight(&processingReport, preflight)
 		if profileErr != nil {
 			if ctx.Err() != nil || errors.Is(profileErr, context.Canceled) {
@@ -205,7 +204,7 @@ type profileValidationRuntime struct {
 	executableErr      error
 }
 
-func validateAllEvents(ctx context.Context, out processingOutput, workflowPath, version, actionCacheDir string, runtime *profileValidationRuntime, stderr io.Writer) int {
+func validateAllEvents(ctx context.Context, out processingOutput, workflowPath, clientVersion, actionCacheDir string, runtime *profileValidationRuntime, stderr io.Writer) int {
 	source, err := os.ReadFile(workflowPath)
 	if err != nil {
 		validation := compatibility.EnvironmentProcessingReport(workflowPath, "", "workflow input could not be read")
@@ -214,13 +213,13 @@ func validateAllEvents(ctx context.Context, out processingOutput, workflowPath, 
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: %v\n", err)
 		return 1
 	}
-	return validateAllEventsSource(ctx, out, workflowPath, source, version, actionCacheDir, runtime, stderr)
+	return validateAllEventsSource(ctx, out, workflowPath, source, clientVersion, actionCacheDir, runtime, stderr)
 }
 
-func validateAllEventsSource(ctx context.Context, out processingOutput, workflowPath string, source []byte, version, actionCacheDir string, runtime *profileValidationRuntime, stderr io.Writer) int {
+func validateAllEventsSource(ctx context.Context, out processingOutput, workflowPath string, source []byte, clientVersion, actionCacheDir string, runtime *profileValidationRuntime, stderr io.Writer) int {
 	cleanup := func() {}
 	if runtime == nil || runtime.actionSource == nil {
-		actionSource, sourceCleanup, sourceErr := newHostedActionSource(ctx, actionCacheDir, version, nil, nil)
+		actionSource, sourceCleanup, sourceErr := newHostedActionSource(ctx, actionCacheDir, clientVersion, nil, nil)
 		cleanup = sourceCleanup
 		if sourceErr != nil {
 			validationReport := compatibility.EnvironmentProcessingReport(workflowPath, hostedProfile, "public repository source could not be configured")
@@ -272,7 +271,7 @@ func validateAllEventsSource(ctx context.Context, out processingOutput, workflow
 			command: "validate", format: "json", reports: io.Discard, stderr: stderr,
 			observe: func(observed compatibility.ProcessingReport) { eventReport = &observed },
 		}
-		if code := validateOneSource(ctx, eventOut, workflowPath, source, "", event, hostedProfile, version, actionCacheDir, runtime, stderr); code != 0 {
+		if code := validateOneSource(ctx, eventOut, workflowPath, source, "", event, hostedProfile, clientVersion, actionCacheDir, runtime, stderr); code != 0 {
 			failed = true
 		}
 		if eventReport == nil {

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -20,7 +20,8 @@ import (
 	"github.com/buildkite/buildkite-gha/internal/workflow"
 )
 
-func validate(args []string, stdout, stderr io.Writer, version string, agent transport.Agent) int {
+func validate(args []string, stdout, stderr io.Writer, clientVersion string, agent transport.Agent) int {
+	version := commandVersion(clientVersion)
 	args, actionCacheDir, err := validateActionCacheArgs(args)
 	if err != nil {
 		return usageError(stderr, "validate: %v", err)
@@ -83,7 +84,7 @@ func validateOneSource(ctx context.Context, out processingOutput, workflowPath s
 	cleanupSource := func() {}
 	if repositorySource == nil {
 		var sourceErr error
-		repositorySource, cleanupSource, sourceErr = newHostedActionSource(ctx, actionCacheDir, nil, nil)
+		repositorySource, cleanupSource, sourceErr = newHostedActionSource(ctx, actionCacheDir, version, nil, nil)
 		if sourceErr != nil {
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate: configure public repository source: %v\n", sourceErr)
 			return 1
@@ -219,7 +220,7 @@ func validateAllEvents(ctx context.Context, out processingOutput, workflowPath, 
 func validateAllEventsSource(ctx context.Context, out processingOutput, workflowPath string, source []byte, version, actionCacheDir string, runtime *profileValidationRuntime, stderr io.Writer) int {
 	cleanup := func() {}
 	if runtime == nil || runtime.actionSource == nil {
-		actionSource, sourceCleanup, sourceErr := newHostedActionSource(ctx, actionCacheDir, nil, nil)
+		actionSource, sourceCleanup, sourceErr := newHostedActionSource(ctx, actionCacheDir, version, nil, nil)
 		cleanup = sourceCleanup
 		if sourceErr != nil {
 			validationReport := compatibility.EnvironmentProcessingReport(workflowPath, hostedProfile, "public repository source could not be configured")

--- a/internal/cli/validate_batch.go
+++ b/internal/cli/validate_batch.go
@@ -57,7 +57,8 @@ func (w *synchronizedWriter) Write(data []byte) (int, error) {
 	return w.w.Write(data)
 }
 
-func validateBatch(args []string, stderr io.Writer, version string) int {
+func validateBatch(args []string, stderr io.Writer, clientVersion string) int {
+	version := commandVersion(clientVersion)
 	options, err := parseBatchValidationArgs(args)
 	if err != nil {
 		return usageError(stderr, "validate-batch: %v", err)
@@ -80,7 +81,7 @@ func validateBatch(args []string, stderr io.Writer, version string) int {
 		}
 		resolverOptions = append(resolverOptions, actionsource.WithGitHubAPITokenProvider(func(context.Context) (string, error) { return token, nil }))
 	}
-	actionSource, cleanup, resolutionSnapshotID, err := newHostedActionSourceWithSnapshot(context.Background(), options.actionCacheDir, resolverOptions, storeOptions)
+	actionSource, cleanup, resolutionSnapshotID, err := newHostedActionSourceWithSnapshot(context.Background(), options.actionCacheDir, clientVersion, resolverOptions, storeOptions)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: validate-batch: %v\n", err)
 		return 1

--- a/internal/cli/validate_batch.go
+++ b/internal/cli/validate_batch.go
@@ -58,7 +58,6 @@ func (w *synchronizedWriter) Write(data []byte) (int, error) {
 }
 
 func validateBatch(args []string, stderr io.Writer, clientVersion string) int {
-	version := commandVersion(clientVersion)
 	options, err := parseBatchValidationArgs(args)
 	if err != nil {
 		return usageError(stderr, "validate-batch: %v", err)
@@ -126,7 +125,7 @@ func validateBatch(args []string, stderr io.Writer, clientVersion string) int {
 					resumed.Add(1)
 					continue
 				}
-				if err := writeBatchValidationResult(ctx, resultPath, record, version, options.actionCacheDir, runtime, workerStderr); err != nil {
+				if err := writeBatchValidationResult(ctx, resultPath, record, clientVersion, options.actionCacheDir, runtime, workerStderr); err != nil {
 					select {
 					case failures <- fmt.Errorf("%s: %w", record.ID, err):
 						cancel()
@@ -483,7 +482,7 @@ func loadBatchValidationResult(path, workflow string) (compatibility.ProcessingR
 	return report, true
 }
 
-func writeBatchValidationResult(ctx context.Context, path string, record batchValidationRecord, version, actionCacheDir string, runtime *profileValidationRuntime, stderr io.Writer) error {
+func writeBatchValidationResult(ctx context.Context, path string, record batchValidationRecord, clientVersion, actionCacheDir string, runtime *profileValidationRuntime, stderr io.Writer) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("create report directory: %w", err)
 	}
@@ -494,7 +493,7 @@ func writeBatchValidationResult(ctx context.Context, path string, record batchVa
 	temporaryPath := temporary.Name()
 	defer func() { _ = os.Remove(temporaryPath) }()
 	out := processingOutput{context: ctx, command: "validate-batch", format: "json", reports: temporary, stderr: stderr}
-	_ = validateAllEventsSource(ctx, out, record.Source, record.content, version, actionCacheDir, runtime, stderr)
+	_ = validateAllEventsSource(ctx, out, record.Source, record.content, clientVersion, actionCacheDir, runtime, stderr)
 	if record.resumable {
 		contentID, complete := localCompilationDependencyDigest(record.Source, record.content)
 		if !complete || contentID != record.contentID {

--- a/internal/runtime/cache_service.go
+++ b/internal/runtime/cache_service.go
@@ -12,6 +12,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/buildkite/buildkite-gha/internal/useragent"
 )
 
 const (
@@ -45,11 +47,12 @@ type CacheCredentialProvider interface {
 // service. Endpoint and JobToken are runtime connection and authentication
 // material; this provider does not add them to action subprocess environments.
 type AgentCacheConfig struct {
-	Endpoint   string
-	JobID      string
-	JobToken   string
-	ResultsURL string
-	Client     *http.Client
+	Endpoint      string
+	JobID         string
+	JobToken      string
+	ResultsURL    string
+	ClientVersion string
+	Client        *http.Client
 }
 
 // AgentCacheCredentials mints GHAC tokens through Buildkite's job-bound Agent
@@ -58,6 +61,7 @@ type AgentCacheCredentials struct {
 	mintURL    string
 	jobToken   string
 	resultsURL string
+	userAgent  string
 	client     *http.Client
 }
 
@@ -86,7 +90,10 @@ func NewAgentCacheCredentials(config AgentCacheConfig) (*AgentCacheCredentials, 
 	if bounded.Timeout == 0 {
 		bounded.Timeout = 15 * time.Second
 	}
-	return &AgentCacheCredentials{mintURL: mintURL, jobToken: config.JobToken, resultsURL: resultsURL, client: &bounded}, nil
+	return &AgentCacheCredentials{
+		mintURL: mintURL, jobToken: config.JobToken, resultsURL: resultsURL,
+		userAgent: useragent.FromVersion(config.ClientVersion), client: &bounded,
+	}, nil
 }
 
 func (c *AgentCacheCredentials) Credentials(ctx context.Context) (CacheCredentials, error) {
@@ -99,6 +106,7 @@ func (c *AgentCacheCredentials) Credentials(ctx context.Context) (CacheCredentia
 	}
 	request.Header.Set("Authorization", "Token "+c.jobToken)
 	request.Header.Set("Accept", "application/json")
+	request.Header.Set("User-Agent", c.userAgent)
 	response, err := c.client.Do(request)
 	if err != nil {
 		return CacheCredentials{}, fmt.Errorf("request cache credential: %w", err)

--- a/internal/runtime/cache_service_test.go
+++ b/internal/runtime/cache_service_test.go
@@ -38,7 +38,7 @@ func TestAgentCacheCredentialsMintsBoundedJobCredential(t *testing.T) {
 		if r.Method != http.MethodPost || r.URL.EscapedPath() != "/v3/jobs/"+testCacheJobID+"/ghac_tokens" || r.URL.RawQuery != "" {
 			t.Errorf("request = %s %s", r.Method, r.URL.String())
 		}
-		if r.Header.Get("Authorization") != "Token job-secret" || r.Header.Get("Accept") != "application/json" || len(body) != 0 {
+		if r.Header.Get("Authorization") != "Token job-secret" || r.Header.Get("Accept") != "application/json" || r.Header.Get("User-Agent") != "buildkite-gha/1.2.3" || len(body) != 0 {
 			t.Errorf("request headers/body = %#v / %q", r.Header, body)
 		}
 		_, _ = io.WriteString(w, `{"token":"header.payload.signature"}`)
@@ -46,9 +46,11 @@ func TestAgentCacheCredentialsMintsBoundedJobCredential(t *testing.T) {
 	defer server.Close()
 
 	provider, err := NewAgentCacheCredentials(AgentCacheConfig{
-		Endpoint: server.URL + "/v3/",
-		JobID:    testCacheJobID, JobToken: "job-secret",
-		ResultsURL: server.URL,
+		Endpoint:      server.URL + "/v3/",
+		JobID:         testCacheJobID,
+		JobToken:      "job-secret",
+		ResultsURL:    server.URL,
+		ClientVersion: "1.2.3",
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/runtime/github_token_service.go
+++ b/internal/runtime/github_token_service.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/buildkite/buildkite-gha/internal/plan"
+	"github.com/buildkite/buildkite-gha/internal/useragent"
 )
 
 const githubTokenResponseLimit = 64 << 10
@@ -43,6 +44,7 @@ type AgentGitHubTokenConfig struct {
 	JobToken         string
 	OrganizationSlug string
 	PipelineSlug     string
+	ClientVersion    string
 	Client           *http.Client
 }
 
@@ -53,6 +55,7 @@ type AgentGitHubTokens struct {
 	workflowURL        string
 	repositorySettings string
 	jobToken           string
+	userAgent          string
 	client             *http.Client
 }
 
@@ -83,6 +86,7 @@ func NewAgentGitHubTokens(config AgentGitHubTokenConfig) (*AgentGitHubTokens, er
 		workflowURL:        workflowURL,
 		repositorySettings: pipelineRepositorySettingsURL(config.OrganizationSlug, config.PipelineSlug),
 		jobToken:           config.JobToken,
+		userAgent:          useragent.FromVersion(config.ClientVersion),
 		client:             &bounded,
 	}, nil
 }
@@ -133,6 +137,7 @@ func (c *AgentGitHubTokens) mint(ctx context.Context, mintURL, repository, workf
 	request.Header.Set("Authorization", "Token "+c.jobToken)
 	request.Header.Set("Accept", "application/json")
 	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("User-Agent", c.userAgent)
 	response, err := c.client.Do(request)
 	if err != nil {
 		return "", fmt.Errorf("request GitHub %s token: %w", purpose, err)

--- a/internal/runtime/github_token_service_test.go
+++ b/internal/runtime/github_token_service_test.go
@@ -20,7 +20,7 @@ func TestAgentGitHubTokensMintsExactWorkflowPermissions(t *testing.T) {
 		if r.URL.Path != "/jobs/"+testCacheJobID+"/github_workflow_access_token" {
 			t.Errorf("path = %q", r.URL.Path)
 		}
-		if r.Method != http.MethodPost || r.Header.Get("Authorization") != "Token job-secret" || r.Header.Get("Accept") != "application/json" || r.Header.Get("Content-Type") != "application/json" {
+		if r.Method != http.MethodPost || r.Header.Get("Authorization") != "Token job-secret" || r.Header.Get("Accept") != "application/json" || r.Header.Get("Content-Type") != "application/json" || r.Header.Get("User-Agent") != "buildkite-gha/1.2.3" {
 			t.Errorf("request = %s headers %#v", r.Method, r.Header)
 		}
 		body, err := io.ReadAll(r.Body)
@@ -33,7 +33,7 @@ func TestAgentGitHubTokensMintsExactWorkflowPermissions(t *testing.T) {
 		_, _ = io.WriteString(w, `{"token":"`+statelessToken+`"}`)
 	}))
 	defer server.Close()
-	provider, err := NewAgentGitHubTokens(AgentGitHubTokenConfig{Endpoint: server.URL, JobID: testCacheJobID, JobToken: "job-secret"})
+	provider, err := NewAgentGitHubTokens(AgentGitHubTokenConfig{Endpoint: server.URL, JobID: testCacheJobID, JobToken: "job-secret", ClientVersion: "1.2.3"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/runtime/oidc_token_service.go
+++ b/internal/runtime/oidc_token_service.go
@@ -19,6 +19,8 @@ import (
 	"sync"
 	"time"
 	"unicode/utf8"
+
+	"github.com/buildkite/buildkite-gha/internal/useragent"
 )
 
 const oidcTokenResponseLimit = 64 << 10
@@ -38,17 +40,19 @@ type AgentOIDCTokenConfig struct {
 	Claims         []string
 	AWSSessionTags []string
 	SubjectClaim   string
+	ClientVersion  string
 	Client         *http.Client
 }
 
 // AgentOIDCTokens mints job-bound Buildkite OIDC tokens through the Agent API.
 type AgentOIDCTokens struct {
-	mintURL  string
-	jobToken string
-	claims   []string
-	awsTags  []string
-	subject  string
-	client   *http.Client
+	mintURL   string
+	jobToken  string
+	claims    []string
+	awsTags   []string
+	subject   string
+	userAgent string
+	client    *http.Client
 }
 
 func NewAgentOIDCTokens(config AgentOIDCTokenConfig) (*AgentOIDCTokens, error) {
@@ -70,12 +74,13 @@ func NewAgentOIDCTokens(config AgentOIDCTokenConfig) (*AgentOIDCTokens, error) {
 		bounded.Timeout = 15 * time.Second
 	}
 	return &AgentOIDCTokens{
-		mintURL:  mintURL,
-		jobToken: config.JobToken,
-		claims:   append([]string(nil), config.Claims...),
-		awsTags:  append([]string(nil), config.AWSSessionTags...),
-		subject:  config.SubjectClaim,
-		client:   &bounded,
+		mintURL:   mintURL,
+		jobToken:  config.JobToken,
+		claims:    append([]string(nil), config.Claims...),
+		awsTags:   append([]string(nil), config.AWSSessionTags...),
+		subject:   config.SubjectClaim,
+		userAgent: useragent.FromVersion(config.ClientVersion),
+		client:    &bounded,
 	}, nil
 }
 
@@ -102,6 +107,7 @@ func (c *AgentOIDCTokens) OIDCToken(ctx context.Context, audience string) (strin
 	request.Header.Set("Authorization", "Token "+c.jobToken)
 	request.Header.Set("Accept", "application/json")
 	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("User-Agent", c.userAgent)
 	response, err := c.client.Do(request)
 	if err != nil {
 		return "", fmt.Errorf("request OIDC token: %w", err)

--- a/internal/runtime/oidc_token_service_test.go
+++ b/internal/runtime/oidc_token_service_test.go
@@ -23,7 +23,7 @@ func TestAgentOIDCTokensMintsRequestedAudienceAndConfiguredClaims(t *testing.T) 
 		if request.URL.Path != "/jobs/"+testCacheJobID+"/oidc/tokens" {
 			t.Errorf("path = %q", request.URL.Path)
 		}
-		if request.Method != http.MethodPost || request.Header.Get("Authorization") != "Token job-secret" || request.Header.Get("Accept") != "application/json" || request.Header.Get("Content-Type") != "application/json" {
+		if request.Method != http.MethodPost || request.Header.Get("Authorization") != "Token job-secret" || request.Header.Get("Accept") != "application/json" || request.Header.Get("Content-Type") != "application/json" || request.Header.Get("User-Agent") != "buildkite-gha/1.2.3" {
 			t.Errorf("request = %s headers %#v", request.Method, request.Header)
 		}
 		body, err := io.ReadAll(request.Body)
@@ -43,6 +43,7 @@ func TestAgentOIDCTokensMintsRequestedAudienceAndConfiguredClaims(t *testing.T) 
 		Claims:         []string{"organization_id"},
 		AWSSessionTags: []string{"organization_slug", "pipeline_id"},
 		SubjectClaim:   "pipeline_id",
+		ClientVersion:  "1.2.3",
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/runtime/runner_resolution.go
+++ b/internal/runtime/runner_resolution.go
@@ -11,6 +11,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/buildkite/buildkite-gha/internal/useragent"
 )
 
 const runnerResolutionResponseLimit = 64 << 10
@@ -28,15 +30,17 @@ type RunnerSuggestion struct {
 }
 
 type AgentRunnerResolverConfig struct {
-	Endpoint string
-	JobID    string
-	JobToken string
-	Client   *http.Client
+	Endpoint      string
+	JobID         string
+	JobToken      string
+	ClientVersion string
+	Client        *http.Client
 }
 
 type AgentRunnerResolver struct {
 	resolveURL string
 	jobToken   string
+	userAgent  string
 	client     *http.Client
 }
 
@@ -58,7 +62,10 @@ func NewAgentRunnerResolver(config AgentRunnerResolverConfig) (*AgentRunnerResol
 	if bounded.Timeout == 0 {
 		bounded.Timeout = 15 * time.Second
 	}
-	return &AgentRunnerResolver{resolveURL: resolveURL, jobToken: config.JobToken, client: &bounded}, nil
+	return &AgentRunnerResolver{
+		resolveURL: resolveURL, jobToken: config.JobToken,
+		userAgent: useragent.FromVersion(config.ClientVersion), client: &bounded,
+	}, nil
 }
 
 func (c *AgentRunnerResolver) Resolve(ctx context.Context, requirements []RunnerRequirement) ([]RunnerSuggestion, error) {
@@ -107,6 +114,7 @@ func (c *AgentRunnerResolver) resolveBatch(ctx context.Context, requirements []R
 	request.Header.Set("Authorization", "Token "+c.jobToken)
 	request.Header.Set("Accept", "application/json")
 	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("User-Agent", c.userAgent)
 	response, err := c.client.Do(request)
 	if err != nil {
 		return nil, fmt.Errorf("request runner resolution: %w", err)

--- a/internal/runtime/runner_resolution_test.go
+++ b/internal/runtime/runner_resolution_test.go
@@ -13,7 +13,7 @@ func TestAgentRunnerResolverBatchesRequirementsAndReturnsSuggestions(t *testing.
 	requests := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests++
-		if r.Method != http.MethodPost || r.URL.Path != "/v3/jobs/"+jobID+"/github-actions/runners" || r.Header.Get("Authorization") != "Token job-token" || r.Header.Get("Accept") != "application/json" || r.Header.Get("Content-Type") != "application/json" {
+		if r.Method != http.MethodPost || r.URL.Path != "/v3/jobs/"+jobID+"/github-actions/runners" || r.Header.Get("Authorization") != "Token job-token" || r.Header.Get("Accept") != "application/json" || r.Header.Get("Content-Type") != "application/json" || r.Header.Get("User-Agent") != "buildkite-gha/1.2.3" {
 			t.Errorf("request = %s %s, headers %#v", r.Method, r.URL.Path, r.Header)
 		}
 		var body struct {
@@ -39,7 +39,7 @@ func TestAgentRunnerResolverBatchesRequirementsAndReturnsSuggestions(t *testing.
 	}))
 	defer server.Close()
 
-	resolver, err := NewAgentRunnerResolver(AgentRunnerResolverConfig{Endpoint: server.URL + "/v3", JobID: jobID, JobToken: "job-token", Client: server.Client()})
+	resolver, err := NewAgentRunnerResolver(AgentRunnerResolverConfig{Endpoint: server.URL + "/v3", JobID: jobID, JobToken: "job-token", ClientVersion: "1.2.3", Client: server.Client()})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -14,6 +14,8 @@ import (
 	"time"
 	"unicode"
 	"unicode/utf8"
+
+	"github.com/buildkite/buildkite-gha/internal/useragent"
 )
 
 const (
@@ -124,6 +126,7 @@ type Client struct {
 	eventsURL     string
 	jobToken      string
 	clientVersion string
+	userAgent     string
 	client        *http.Client
 	timeout       time.Duration
 }
@@ -156,10 +159,12 @@ func New(config Config) (*Client, error) {
 	if timeout <= 0 || timeout > defaultTimeout {
 		timeout = defaultTimeout
 	}
+	clientVersion := boundedClientVersion(config.ClientVersion)
 	return &Client{
 		eventsURL:     u.String(),
 		jobToken:      config.JobToken,
-		clientVersion: boundedClientVersion(config.ClientVersion),
+		clientVersion: clientVersion,
+		userAgent:     useragent.FromVersion(config.ClientVersion),
 		client:        &bounded,
 		timeout:       timeout,
 	}, nil
@@ -219,6 +224,7 @@ func (c *Client) EmitContext(ctx context.Context, command Command, outcome Outco
 	}
 	request.Header.Set("Authorization", "Token "+c.jobToken)
 	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("User-Agent", c.userAgent)
 	response, err := c.client.Do(request)
 	if err != nil {
 		return fmt.Errorf("send telemetry event: %w", err)

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -32,6 +32,9 @@ func TestClientEmitsCommandCompletedEvent(t *testing.T) {
 		if got := r.Header.Get("Content-Type"); got != "application/json" {
 			t.Errorf("Content-Type = %q", got)
 		}
+		if got := r.Header.Get("User-Agent"); got != "buildkite-gha/1.2.3" {
+			t.Errorf("User-Agent = %q", got)
+		}
 		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 			t.Errorf("decode request: %v", err)
 		}
@@ -194,6 +197,9 @@ func TestPropertiesAreBounded(t *testing.T) {
 	}
 	if len(client.clientVersion) != maxClientVersionBytes {
 		t.Fatalf("client version length = %d", len(client.clientVersion))
+	}
+	if client.userAgent != "buildkite-gha/unknown" {
+		t.Fatalf("User-Agent = %q, want bounded fallback", client.userAgent)
 	}
 	if err := client.Emit(Command("arbitrary"), OutcomeSuccess, 0, Details{}); err == nil {
 		t.Fatal("Emit() accepted an unknown command")

--- a/internal/useragent/useragent.go
+++ b/internal/useragent/useragent.go
@@ -1,0 +1,33 @@
+// Package useragent identifies buildkite-gha HTTP requests.
+package useragent
+
+const (
+	product         = "buildkite-gha"
+	maxVersionBytes = 64
+)
+
+// FromVersion returns the product token sent with HTTP requests.
+func FromVersion(version string) string {
+	if !validToken(version) {
+		version = "unknown"
+	}
+	return product + "/" + version
+}
+
+func validToken(value string) bool {
+	if value == "" || len(value) > maxVersionBytes {
+		return false
+	}
+	for _, character := range value {
+		if character >= 'a' && character <= 'z' ||
+			character >= 'A' && character <= 'Z' ||
+			character >= '0' && character <= '9' ||
+			character == '!' || character == '#' || character == '$' || character == '%' || character == '&' ||
+			character == '\'' || character == '*' || character == '+' || character == '-' || character == '.' ||
+			character == '^' || character == '_' || character == '`' || character == '|' || character == '~' {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/internal/useragent/useragent_test.go
+++ b/internal/useragent/useragent_test.go
@@ -1,0 +1,23 @@
+package useragent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFromVersion(t *testing.T) {
+	for _, test := range []struct {
+		version string
+		want    string
+	}{
+		{version: "1.2.3", want: "buildkite-gha/1.2.3"},
+		{version: "dev+0123456789ab", want: "buildkite-gha/dev+0123456789ab"},
+		{want: "buildkite-gha/unknown"},
+		{version: "unsafe\r\nHeader", want: "buildkite-gha/unknown"},
+		{version: strings.Repeat("v", maxVersionBytes+1), want: "buildkite-gha/unknown"},
+	} {
+		if got := FromVersion(test.version); got != test.want {
+			t.Errorf("FromVersion(%q) = %q, want %q", test.version, got, test.want)
+		}
+	}
+}


### PR DESCRIPTION
## Why

Buildkite API protocol compatibility needs a reliable way to identify buildkite-gha client versions. The need came from this [Slack discussion](https://buildkite-corp.slack.com/archives/C0BKA9NUYS0/p1787284624481019?thread_ts=1787284101.757749&cid=C0BKA9NUYS0) about preserving compatibility as the runner-resolution response evolves.

Resolves [PB-3050](https://linear.app/buildkite/issue/PB-3050/send-versioned-user-agent-headers-from-buildkite-gha).

## What

Send `User-Agent: buildkite-gha/<version>` on every direct HTTP request, including Agent API calls, action-source requests, and runtime downloads. Invalid, missing, or oversized versions use `buildkite-gha/unknown`; requests delegated to `buildkite-agent` remain agent-owned.
