### PR TITLE
Support bounded Dockerfile action args

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -617,7 +617,7 @@ Use an interpreter installed by an earlier step or included in the job image:
   run: conda info
 ```
 
-A `uses` step may call a supported local or public action. Action inputs under `with` may use supported direct interpolation. `docker://` actions and action `entrypoint` or `args` overrides are rejected.
+A `uses` step may call a supported local or public action. Action inputs under `with` may use supported direct interpolation. `docker://` actions and explicit Docker action entrypoints are rejected.
 
 Action steps can call public and local actions:
 
@@ -867,13 +867,31 @@ parts with values supported by their runtime surface.
 | Private action | ❌ Unsupported | No private action source access. |
 | JavaScript action | ✅ Supported | Declares `node16`, `node20`, or `node24`. |
 | Composite action | 🟡 Supported subset | Nested shell steps and locked local or public actions; `bash`, `sh`, `python`, or a custom shell template for `run`; literal `continue-on-error`. |
-| Dockerfile action | 🟡 Supported subset | Verified local or public Dockerfile action on Linux. Rejected on macOS, including through a composite action. |
+| Dockerfile action | 🟡 Supported subset | Verified local or public Dockerfile action on Linux with optional bounded `runs.args`. Rejected on macOS, including through a composite action. |
 | `docker://` action | ❌ Unsupported | Rejected during validation. |
 | Top-level action metadata `env` | ➖ Accepted, no effect | Any valid YAML value is discarded. It is not evaluated, injected, retained in plans, or used to request secrets or tokens. |
 
 Mutable public refs are resolved during upload, then locked to a commit. The importer lazily requests one Buildkite action-source token and reuses it across all workflow roots and nested composite actions. This token authenticates only public metadata requests for repositories other than the credential repository; the credential repository and codeload requests remain anonymous. If token issuance is unavailable during rollout, resolution safely falls back to anonymous GitHub API access. Exact lowercase commit SHAs need no GitHub API lookup. Complete source trees are verified again at runtime.
 
-Nested calls from a repository-local composite must be local. Public composites may call local children or other public actions; every child is resolved and locked. Dockerfile actions cannot request credentials, volumes, arbitrary options, or privileged mode.
+Nested calls from a repository-local composite must be local. Public composites may call local children or other public actions; every child is resolved and locked.
+
+Dockerfile actions require exact `runs.image: Dockerfile`. Optional `runs.args`
+must be an ordered YAML string array. Each item becomes one argument after the
+image name, without a shell or an entrypoint override. Empty strings,
+whitespace, and shell metacharacters remain literal. Omitted or empty args keep
+the image `CMD`; any non-empty array replaces `CMD` while preserving the image
+`ENTRYPOINT`.
+
+Args may contain literals and direct `inputs.<name>` or `inputs['name']`
+interpolation. Operators, functions, whole or dynamic inputs, and every other
+context are rejected. Invocation inputs and metadata defaults resolve before
+args evaluation. Args remain in digest-bound action metadata and are not stored
+in job plans.
+
+Dockerfile actions cannot declare explicit entrypoints or pre/post lifecycle,
+or request credentials, volumes, arbitrary options, or privileged mode. An arg
+such as `--privileged` remains a container argument; it cannot become a Docker
+option.
 
 Action metadata parsing remains strict for every other unknown top-level field and for unknown nested fields. The inert top-level `env` exception does not replace workflow or action-step environments, populate `runs.env`, or add `GITHUB_TOKEN` authority.
 

--- a/internal/action/metadata/metadata.go
+++ b/internal/action/metadata/metadata.go
@@ -217,25 +217,26 @@ func Load(root, path string) (Metadata, error) {
 }
 
 func validateDockerArgs(path string, document *yaml.Node) error {
-	node := document
-	if node.Kind == yaml.DocumentNode && len(node.Content) != 0 {
-		node = node.Content[0]
+	var resolved struct {
+		Runs map[string]any `yaml:"runs"`
 	}
-	runs := mappingValue(node, "runs")
-	using := mappingValue(runs, "using")
-	if using == nil || using.Value != string(RuntimeDocker) {
+	if err := document.Decode(&resolved); err != nil {
+		return nil // The strict metadata decoder reports malformed values.
+	}
+	if resolved.Runs["using"] != string(RuntimeDocker) {
 		return nil
 	}
-	args := mappingValue(runs, "args")
-	if args == nil {
+	value, exists := resolved.Runs["args"]
+	if !exists {
 		return nil
 	}
-	if args.Kind != yaml.SequenceNode {
-		return fmt.Errorf("parse action metadata %q:%d:%d: docker runs.args must be a string array", path, args.Line, args.Column)
+	args, ok := value.([]any)
+	if !ok {
+		return fmt.Errorf("parse action metadata %q: docker runs.args must be a string array", path)
 	}
-	for i, argument := range args.Content {
-		if argument.Kind != yaml.ScalarNode || argument.ShortTag() != "!!str" {
-			return fmt.Errorf("parse action metadata %q:%d:%d: docker runs.args item %d must be a string", path, argument.Line, argument.Column, i+1)
+	for i, argument := range args {
+		if _, ok := argument.(string); !ok {
+			return fmt.Errorf("parse action metadata %q: docker runs.args item %d must be a string", path, i+1)
 		}
 	}
 	return nil

--- a/internal/action/metadata/metadata.go
+++ b/internal/action/metadata/metadata.go
@@ -169,6 +169,9 @@ func Load(root, path string) (Metadata, error) {
 	if err := validateCompositeSteps(metadataPath, &document); err != nil {
 		return Metadata{}, err
 	}
+	if err := validateDockerArgs(metadataPath, &document); err != nil {
+		return Metadata{}, err
+	}
 	if discardTopLevelEnv(&document) {
 		var validated struct {
 			Metadata `yaml:",inline"`
@@ -211,6 +214,31 @@ func Load(root, path string) (Metadata, error) {
 		return Metadata{}, fmt.Errorf("parse action metadata %q: %w", metadataPath, err)
 	}
 	return metadata, nil
+}
+
+func validateDockerArgs(path string, document *yaml.Node) error {
+	node := document
+	if node.Kind == yaml.DocumentNode && len(node.Content) != 0 {
+		node = node.Content[0]
+	}
+	runs := mappingValue(node, "runs")
+	using := mappingValue(runs, "using")
+	if using == nil || using.Value != string(RuntimeDocker) {
+		return nil
+	}
+	args := mappingValue(runs, "args")
+	if args == nil {
+		return nil
+	}
+	if args.Kind != yaml.SequenceNode {
+		return fmt.Errorf("parse action metadata %q:%d:%d: docker runs.args must be a string array", path, args.Line, args.Column)
+	}
+	for i, argument := range args.Content {
+		if argument.Kind != yaml.ScalarNode || argument.ShortTag() != "!!str" {
+			return fmt.Errorf("parse action metadata %q:%d:%d: docker runs.args item %d must be a string", path, argument.Line, argument.Column, i+1)
+		}
+	}
+	return nil
 }
 
 func discardTopLevelEnv(document *yaml.Node) bool {
@@ -366,10 +394,10 @@ func (metadata Metadata) ValidateEntrypoints(runtime Runtime) error {
 		if metadata.Runs.Image != "Dockerfile" {
 			return fmt.Errorf("docker action requires exact runs.image %q", "Dockerfile")
 		}
-		if metadata.Runs.Main != "" || metadata.Runs.Entrypoint != "" || len(metadata.Runs.Args) != 0 ||
+		if metadata.Runs.Main != "" || metadata.Runs.Entrypoint != "" ||
 			metadata.Runs.Pre != "" || metadata.Runs.PreIf != "" || metadata.Runs.PreEntrypoint != "" ||
 			metadata.Runs.Post != "" || metadata.Runs.PostIf != "" || metadata.Runs.PostEntrypoint != "" {
-			return fmt.Errorf("docker action may not declare entrypoint, arguments, or pre/post lifecycle")
+			return fmt.Errorf("docker action may not declare entrypoint or pre/post lifecycle")
 		}
 		dockerfile := filepath.Join(metadata.Path, "Dockerfile")
 		info, err := os.Lstat(dockerfile)

--- a/internal/action/metadata/metadata_test.go
+++ b/internal/action/metadata/metadata_test.go
@@ -141,6 +141,43 @@ func TestLoadDockerArgsRequiresStringSequence(t *testing.T) {
 	}
 }
 
+func TestLoadDockerArgsResolvesAliasesBeforeStringValidation(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		metadata string
+		ok       bool
+	}{
+		{name: "aliased runtime strings", ok: true, metadata: `name: &runtime docker
+runs:
+  using: *runtime
+  image: Dockerfile
+  args: [first, ""]
+`},
+		{name: "aliased runtime number", metadata: `name: &runtime docker
+runs:
+  using: *runtime
+  image: Dockerfile
+  args: [1]
+`},
+		{name: "merged runtime boolean", metadata: `runs:
+  <<: &defaults
+    using: docker
+    image: Dockerfile
+  args: [true]
+`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeAction(t, root, "Dockerfile", "FROM scratch\n")
+			writeAction(t, root, "action.yml", test.metadata)
+			_, err := Load(root, ".")
+			if (err == nil) != test.ok {
+				t.Fatalf("Load() error = %v, want success %v", err, test.ok)
+			}
+		})
+	}
+}
+
 func TestLoadIsStrictAndConfined(t *testing.T) {
 	t.Run("softprops top-level env is inert", func(t *testing.T) {
 		root := t.TempDir()

--- a/internal/action/metadata/metadata_test.go
+++ b/internal/action/metadata/metadata_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -67,7 +68,7 @@ func TestValidateDockerEntrypoints(t *testing.T) {
 		{name: "exact Dockerfile", ok: true},
 		{name: "non Dockerfile image", mutate: func(m *Metadata) { m.Runs.Image = "docker://alpine" }},
 		{name: "entrypoint", mutate: func(m *Metadata) { m.Runs.Entrypoint = "main.sh" }},
-		{name: "args", mutate: func(m *Metadata) { m.Runs.Args = []string{"x"} }},
+		{name: "args", mutate: func(m *Metadata) { m.Runs.Args = []string{"", " --flag "} }, ok: true},
 		{name: "main", mutate: func(m *Metadata) { m.Runs.Main = "main.sh" }},
 		{name: "pre", mutate: func(m *Metadata) { m.Runs.Pre = "pre.sh" }},
 		{name: "pre condition", mutate: func(m *Metadata) { m.Runs.PreIf = "always()" }},
@@ -105,6 +106,36 @@ func TestValidateDockerEntrypoints(t *testing.T) {
 			}
 			if (err == nil) != test.ok {
 				t.Fatalf("validation error = %v, want success %v", err, test.ok)
+			}
+		})
+	}
+}
+
+func TestLoadDockerArgsRequiresStringSequence(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		args string
+		ok   bool
+	}{
+		{name: "ordered strings", args: "[first, '', '  ', '--privileged']", ok: true},
+		{name: "empty sequence", args: "[]", ok: true},
+		{name: "scalar", args: "value"},
+		{name: "number", args: "[1]"},
+		{name: "mapping", args: "{name: value}"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeAction(t, root, "Dockerfile", "FROM scratch\n")
+			writeAction(t, root, "action.yml", "runs:\n  using: docker\n  image: Dockerfile\n  args: "+test.args+"\n")
+			action, err := Load(root, ".")
+			if (err == nil) != test.ok {
+				t.Fatalf("Load() error = %v, want success %v", err, test.ok)
+			}
+			if test.ok && test.name == "ordered strings" {
+				want := []string{"first", "", "  ", "--privileged"}
+				if !slices.Equal(action.Runs.Args, want) {
+					t.Fatalf("runs.args = %#v, want %#v", action.Runs.Args, want)
+				}
 			}
 		})
 	}

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -426,6 +426,13 @@ func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAutho
 		}
 		requirements.githubToken = requirements.githubToken || referencesToken
 	}
+	if n.runtime == metadata.RuntimeDocker {
+		for i, argument := range n.metadata.Runs.Args {
+			if err := expression.ValidateDockerActionArg(argument); err != nil {
+				return actionRequirements{}, fmt.Errorf("docker action argument %d: %w", i+1, err)
+			}
+		}
+	}
 	if n.runtime != metadata.RuntimeComposite {
 		return requirements, nil
 	}

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -3,6 +3,7 @@ package compiler
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -1800,6 +1801,64 @@ func TestCompilePlansDockerfileActionCapabilities(t *testing.T) {
 	}
 	if len(plans) != 1 || !reflect.DeepEqual(plans[0].RequiredCapabilities, []string{"docker", "network"}) || len(plans[0].Actions) != 1 || plans[0].Actions[0].Source != "github" {
 		t.Fatalf("Dockerfile action plans = %#v", plans)
+	}
+}
+
+func TestCompileDockerfileActionArgsAreValidatedButNotPlanned(t *testing.T) {
+	workspace := t.TempDir()
+	writeAction(t, workspace, "docker", `name: Docker args
+inputs:
+  target:
+    default: default-value
+runs:
+  using: docker
+  image: Dockerfile
+  args:
+    - literal
+    - ${{ inputs.target }}
+`)
+	compiled, err := compileActionInvocations(t.Context(), workspace, nil, "https://github.com", []string{"./docker"}, []map[string]string{{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(compiled.locks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(encoded, []byte("literal")) || bytes.Contains(encoded, []byte("inputs.target")) {
+		t.Fatalf("job-plan locks retained Docker args: %s", encoded)
+	}
+
+	invalid := []string{
+		"${{ inputs }}",
+		"${{ inputs[env.name] }}",
+		"${{ secrets.token }}",
+		"${{ inputs.target || 'fallback' }}",
+		"${{ format('{0}', inputs.target) }}",
+	}
+	for _, argument := range invalid {
+		writeAction(t, workspace, "docker", "runs:\n  using: docker\n  image: Dockerfile\n  args:\n    - \""+strings.ReplaceAll(argument, "\"", "\\\"")+"\"\n")
+		_, err := compileActionInvocations(t.Context(), workspace, nil, "https://github.com", []string{"./docker"}, []map[string]string{{}})
+		if err == nil || !strings.Contains(err.Error(), "docker action argument 1") {
+			t.Errorf("argument %q error = %v, want resolution rejection", argument, err)
+		}
+	}
+}
+
+func TestCompileDockerfileActionValidatesInputDefaultsBeforeArgs(t *testing.T) {
+	workspace := t.TempDir()
+	writeAction(t, workspace, "docker", `inputs:
+  target:
+    default: ${{ runner.temp }}
+runs:
+  using: docker
+  image: Dockerfile
+  args:
+    - ${{ secrets.token }}
+`)
+	_, err := compileActionInvocations(t.Context(), workspace, nil, "https://github.com", []string{"./docker"}, []map[string]string{{}})
+	if err == nil || !strings.Contains(err.Error(), `action input "target" default`) || strings.Contains(err.Error(), "docker action argument") {
+		t.Fatalf("compileActionInvocations() error = %v, want input-default rejection first", err)
 	}
 }
 

--- a/internal/expression/docker_action_arg.go
+++ b/internal/expression/docker_action_arg.go
@@ -1,0 +1,37 @@
+package expression
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rhysd/actionlint"
+)
+
+// ValidateDockerActionArg permits literals and direct inputs.<name>
+// interpolation in one Docker action argument.
+func ValidateDockerActionArg(template string) error {
+	return visitTemplateExpressions(template, validateDockerActionArgNode)
+}
+
+// EvaluateDockerActionArg revalidates and evaluates one Docker action argument
+// without exposing any context other than resolved action inputs.
+func EvaluateDockerActionArg(template string, inputs map[string]string) (string, error) {
+	if err := ValidateDockerActionArg(template); err != nil {
+		return "", err
+	}
+	return evaluateRuntimeTemplate(template, Context{Inputs: inputs}, func(node actionlint.ExprNode, context Context) (any, error) {
+		root, path, _ := referencePath(node)
+		return resolveRuntimeReference(root, path, context)
+	})
+}
+
+func validateDockerActionArgNode(node actionlint.ExprNode) error {
+	root, path, err := referencePath(node)
+	if err != nil {
+		return fmt.Errorf("docker action argument requires a direct inputs reference: %w", err)
+	}
+	if !strings.EqualFold(root, "inputs") || len(path) != 1 {
+		return fmt.Errorf("docker action argument may reference only inputs.<name>")
+	}
+	return nil
+}

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -136,6 +136,46 @@ func TestValidateRuntimeTemplateMatchesEvaluateReferenceGrammar(t *testing.T) {
 	}
 }
 
+func TestDockerActionArgsUseOnlyDirectInputs(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		want     string
+		invalid  bool
+	}{
+		{name: "literal", template: " --flag=$value; ", want: " --flag=$value; "},
+		{name: "property", template: "prefix-${{ inputs.Name }}-suffix", want: "prefix-value-suffix"},
+		{name: "literal index", template: "${{ inputs['name'] }}", want: "value"},
+		{name: "whole inputs", template: "${{ inputs }}", invalid: true},
+		{name: "dynamic input", template: "${{ inputs[env.name] }}", invalid: true},
+		{name: "nested input", template: "${{ inputs.name.value }}", invalid: true},
+		{name: "other context", template: "${{ secrets.token }}", invalid: true},
+		{name: "operator", template: "${{ inputs.name || 'fallback' }}", invalid: true},
+		{name: "function", template: "${{ format('{0}', inputs.name) }}", invalid: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := ValidateDockerActionArg(test.template)
+			if test.invalid {
+				if err == nil {
+					t.Fatalf("ValidateDockerActionArg(%q) succeeded", test.template)
+				}
+				if _, evalErr := EvaluateDockerActionArg(test.template, map[string]string{"name": "value"}); evalErr == nil {
+					t.Fatalf("EvaluateDockerActionArg(%q) succeeded", test.template)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := EvaluateDockerActionArg(test.template, map[string]string{"name": "value"})
+			if err != nil || got != test.want {
+				t.Fatalf("EvaluateDockerActionArg(%q) = %q, %v; want %q", test.template, got, err, test.want)
+			}
+		})
+	}
+}
+
 func TestRunnerDirectReferencesWorkAcrossRuntimeEvaluationSurfaces(t *testing.T) {
 	runner := map[string]string{"os": "macOS", "arch": "ARM64", "temp": "/runner/temp"}
 	if got, err := Evaluate("${{ runner.os }}/${{ RUNNER.ARCH }}", Context{Runner: runner}); err != nil || got != "macOS/ARM64" {

--- a/internal/runtime/action_execution.go
+++ b/internal/runtime/action_execution.go
@@ -2049,11 +2049,18 @@ func (r *jobRun) runActionStep(ctx context.Context, processor *commandProcessor,
 		if !job.HasCapability("docker") {
 			return result, fmt.Errorf("docker action %q requires the plan's docker capability", step.Uses)
 		}
-		if action.Runs.PreEntrypoint != "" || action.Runs.PostEntrypoint != "" || action.Runs.Entrypoint != "" || len(action.Runs.Args) != 0 {
-			return result, fmt.Errorf("docker action %q uses unsupported entrypoint, arguments, or pre/post lifecycle", step.Uses)
+		if action.Runs.Main != "" || action.Runs.Pre != "" || action.Runs.PreIf != "" || action.Runs.Post != "" || action.Runs.PostIf != "" || action.Runs.PreEntrypoint != "" || action.Runs.PostEntrypoint != "" || action.Runs.Entrypoint != "" {
+			return result, fmt.Errorf("docker action %q uses unsupported entrypoint or pre/post lifecycle", step.Uses)
 		}
 		if action.Runs.Image != "Dockerfile" {
 			return result, fmt.Errorf("docker action image %q is unsupported; the supported runtime subset requires a local Dockerfile", action.Runs.Image)
+		}
+		dockerArgs := make([]string, len(action.Runs.Args))
+		for i, argument := range action.Runs.Args {
+			dockerArgs[i], err = expression.EvaluateDockerActionArg(argument, inputs)
+			if err != nil {
+				return result, fmt.Errorf("docker action %q argument %d: %w", step.Uses, i+1, err)
+			}
 		}
 		dockerEnv, err := evaluateMap(action.Runs.Env, actionEval)
 		if err != nil {
@@ -2067,7 +2074,7 @@ func (r *jobRun) runActionStep(ctx context.Context, processor *commandProcessor,
 			sourceDigest = actionLock.SourceDigest
 		}
 		invocationEnv, explicitPATH := environment.docker(dockerEnv, inputs)
-		result, err := r.runDocker(ctx, processor, dockerAction{Name: actionName(action, step), Path: actionPath, SourceRoot: sourceRoot, SourceDigest: sourceDigest, Workspace: workspace, Env: invocationEnv, explicitPATH: explicitPATH})
+		result, err := r.runDocker(ctx, processor, dockerAction{Name: actionName(action, step), Path: actionPath, SourceRoot: sourceRoot, SourceDigest: sourceDigest, Args: dockerArgs, Workspace: workspace, Env: invocationEnv, explicitPATH: explicitPATH})
 		return result, err
 	}
 	return result, fmt.Errorf("action %q uses unsupported runtime %q", step.Uses, actionRuntime)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -155,6 +155,7 @@ type dockerAction struct {
 	SourceRoot   string
 	SourceDigest string
 	Dockerfile   string
+	Args         []string
 	Workspace    string
 	Env          map[string]string
 	runnerTemp   string
@@ -468,6 +469,7 @@ func (r *jobRun) runDocker(ctx context.Context, processor *commandProcessor, act
 		dockerRunEnv = mergeStringMaps(dockerEnv, cacheEnv)
 	}
 	args = append(args, image)
+	args = append(args, action.Args...)
 	ran = true
 	runErr := r.runStreaming(ctx, processor, "", dockerRunEnv, docker, args...)
 	if runErr != nil {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -253,6 +253,7 @@ if [[ "$1" == buildx && "$2" == build ]]; then
 fi
 
 if [[ "$1" == run ]]; then
+	printf '%s\0' "$@" > "$state/run-argv"
 	if [[ -n "${ACTIONS_RUNTIME_TOKEN:-}" ]]; then
 		printf '%s|%s|%s' "$ACTIONS_RUNTIME_TOKEN" "${ACTIONS_RESULTS_URL:-}" "${ACTIONS_CACHE_SERVICE_V2:-}" > "$state/cache-runtime"
 	fi
@@ -263,8 +264,14 @@ if [[ "$1" == run ]]; then
   args=("$@")
   name=''
   owner=''
+  image_index=-1
+  expected_image="$(cat "$state/image-name")"
   for ((i = 0; i < ${#args[@]}; i++)); do
     arg="${args[$i]}"
+    if [[ "$arg" == "$expected_image" ]]; then
+      image_index=$i
+      break
+    fi
     case "$arg" in
       --name) name="${args[$((i + 1))]}" ;;
       --label) owner="${args[$((i + 1))]}" ;;
@@ -286,7 +293,7 @@ if [[ "$1" == run ]]; then
   [[ -n "$files" && -n "$workspace" && -n "$runner_temp" && "$workdir" == /github/workspace ]] || exit 33
   [[ -d "$workspace" && -d "$runner_temp" ]] || exit 41
   [[ "$name" == "$(cat "$state/image-name" | sed 's/-image-/-container-/')" ]] || exit 33
-  [[ "$owner" == "$(cat "$state/owner")" && "${args[$((${#args[@]} - 1))]}" == "$(cat "$state/image-name")" ]] || exit 39
+  [[ "$owner" == "$(cat "$state/owner")" && $image_index -gt 0 ]] || exit 39
   printf '%s' "$files" > "$state/command-files-path"
   touch "$state/container"
   printf 'container=ran\n' > "$files/output"
@@ -403,6 +410,21 @@ func fakeDockerAction(t *testing.T) dockerAction {
 		Name: "fake Docker", Path: path, SourceRoot: path, SourceDigest: digest,
 		Workspace: t.TempDir(), Env: map[string]string{"Z_LAST": "z", "A_FIRST": "a"},
 	}
+}
+
+func fakeDockerRunArgv(t *testing.T, fake fakeDocker) []string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(fake.root, "run-argv"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fields := bytes.Split(data, []byte{0})
+	fields = fields[:len(fields)-1]
+	argv := make([]string, len(fields))
+	for i := range fields {
+		argv[i] = string(fields[i])
+	}
+	return argv
 }
 
 func callIndex(calls []fakeDockerCall, command ...string) int {
@@ -555,6 +577,99 @@ func TestRunDockerFakeLifecycle(t *testing.T) {
 				t.Fatalf("Docker call contains forbidden option %q: %s", forbidden, text)
 			}
 		}
+	}
+}
+
+func TestRunDockerAppendsExactArgsAfterImage(t *testing.T) {
+	fake := newFakeDocker(t, "success")
+	action := fakeDockerAction(t)
+	action.Args = []string{"--privileged", "", "  ", `$(touch /tmp/nope); * | &`, "a|b"}
+	if _, err := (Runner{Docker: fake.path}).runDockerAction(t.Context(), action); err != nil {
+		t.Fatal(err)
+	}
+	argv := fakeDockerRunArgv(t, fake)
+	imageBytes, err := os.ReadFile(filepath.Join(fake.root, "image-name"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	image := string(imageBytes)
+	imageIndex := slices.Index(argv, image)
+	if imageIndex < 0 {
+		t.Fatalf("image absent from Docker argv: %#v", argv)
+	}
+	if !slices.Equal(argv[imageIndex+1:], action.Args) {
+		t.Fatalf("Docker action argv suffix = %#v, want %#v", argv[imageIndex+1:], action.Args)
+	}
+	if slices.Contains(argv[:imageIndex], "--entrypoint") || slices.Contains(argv[:imageIndex], "--privileged") {
+		t.Fatalf("action args became Docker options: %#v", argv)
+	}
+}
+
+func TestRunJobResolvesDockerArgsFromInvocationInputsAndDefaults(t *testing.T) {
+	requireLinuxAMD64(t)
+	fake := newFakeDocker(t, "success")
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/docker.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: Docker args\n")
+	writeFixtureFile(t, workspace, "action/action.yml", `name: Docker args
+inputs:
+  supplied:
+    default: unused
+  fallback:
+    default: default value
+  blank:
+    default: ""
+runs:
+  using: docker
+  image: Dockerfile
+  args:
+    - ${{ inputs.supplied }}
+    - prefix-${{ inputs['fallback'] }}
+    - ${{ inputs.blank }}
+    - "  "
+`)
+	writeFixtureFile(t, workspace, "action/Dockerfile", "FROM scratch\n")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{
+		ID: "docker", Kind: "uses", Uses: "./action", With: map[string]string{"supplied": "--privileged"},
+	}})
+	job.RequiredCapabilities = []string{"docker", "network"}
+	result, err := (Runner{Docker: fake.path}).RunJob(t.Context(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	argv := fakeDockerRunArgv(t, fake)
+	imageBytes, err := os.ReadFile(filepath.Join(fake.root, "image-name"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	image := string(imageBytes)
+	imageIndex := slices.Index(argv, image)
+	want := []string{"--privileged", "prefix-default value", "", "  "}
+	if imageIndex < 0 {
+		t.Fatalf("image absent from Docker argv: %#v", argv)
+	}
+	if !slices.Equal(argv[imageIndex+1:], want) {
+		t.Fatalf("resolved Docker args = %#v, want %#v; full argv %#v", argv[imageIndex+1:], want, argv)
+	}
+}
+
+func TestRunJobRevalidatesDockerArgsWithInputsOnly(t *testing.T) {
+	requireLinuxAMD64(t)
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/docker.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: Docker args\n")
+	writeFixtureFile(t, workspace, "action/action.yml", `runs:
+  using: docker
+  image: Dockerfile
+  args:
+    - ${{ secrets.token }}
+`)
+	writeFixtureFile(t, workspace, "action/Dockerfile", "FROM scratch\n")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "docker", Kind: "uses", Uses: "./action"}})
+	job.RequiredCapabilities = []string{"docker", "network"}
+	_, err := (Runner{Docker: filepath.Join(t.TempDir(), "docker-must-not-run")}).RunJob(t.Context(), job, workspace)
+	if err == nil || !strings.Contains(err.Error(), "argument 1") || !strings.Contains(err.Error(), "only inputs.<name>") {
+		t.Fatalf("RunJob() error = %v, want runtime inputs-only rejection", err)
 	}
 }
 
@@ -5048,6 +5163,64 @@ func TestDockerAction(t *testing.T) {
 	}
 	if !strings.Contains(logs.String(), "masked docker probe: ***") {
 		t.Errorf("Docker logs = %q, want masked probe", logs.String())
+	}
+}
+
+func TestDockerActionArgsPreserveEntrypointAndControlCMD(t *testing.T) {
+	docker := requireDocker(t)
+	action := t.TempDir()
+	writeFixtureFile(t, action, "main.go", `package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+func main() {
+	encoded, err := json.Marshal(os.Args[1:])
+	if err != nil {
+		panic(err)
+	}
+	output, err := os.OpenFile(os.Getenv("GITHUB_OUTPUT"), os.O_WRONLY|os.O_APPEND, 0)
+	if err != nil {
+		panic(err)
+	}
+	defer output.Close()
+	if _, err := fmt.Fprintf(output, "args=%s\n", encoded); err != nil {
+		panic(err)
+	}
+}
+`)
+	binary := filepath.Join(action, "entrypoint")
+	build := exec.Command("go", "build", "-trimpath", "-o", binary, filepath.Join(action, "main.go"))
+	build.Env = append(os.Environ(), "CGO_ENABLED=0")
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build Docker args entrypoint: %v: %s", err, output)
+	}
+	writeFixtureFile(t, action, "Dockerfile", "FROM scratch\nCOPY entrypoint /entrypoint\nENTRYPOINT [\"/entrypoint\"]\nCMD [\"image-default\"]\n")
+
+	for _, test := range []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{name: "omitted preserves CMD", want: []string{"image-default"}},
+		{name: "nonempty replaces CMD", args: []string{"", "  ", "--privileged", `$(echo no-shell)`}, want: []string{"", "  ", "--privileged", `$(echo no-shell)`}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := (Runner{Docker: docker}).runDockerAction(t.Context(), dockerAction{Name: "Docker args", Path: action, Workspace: t.TempDir(), Args: test.args})
+			if err != nil {
+				t.Fatal(err)
+			}
+			var got []string
+			if err := json.Unmarshal([]byte(result.Outputs["args"]), &got); err != nil {
+				t.Fatalf("decode observed argv %q: %v", result.Outputs["args"], err)
+			}
+			if !slices.Equal(got, test.want) {
+				t.Fatalf("entrypoint argv = %#v, want %#v", got, test.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Why

Dockerfile actions that declare `runs.args` are currently rejected together with unsupported entrypoint and lifecycle metadata, even though args can be supported without granting broader Docker or expression authority.

## What

Accept ordered string-array `runs.args` for digest-locked local and public Dockerfile actions on Linux. Args may contain literals and direct input interpolation, are reloaded and evaluated from bound metadata at runtime, and are appended after the image as exact argv elements so they cannot become Docker options. Explicit entrypoints, lifecycle hooks, other contexts and expressions, non-Dockerfile images, and macOS execution remain unsupported.

This also adds metadata, expression, compiler, fake-Docker, runtime, and optional live-Docker coverage, and documents the bounded compatibility contract.