### PR TITLE
Support reusable workflows in .github repositories

### DIFF
--- a/internal/action/source/action_cache.go
+++ b/internal/action/source/action_cache.go
@@ -257,7 +257,7 @@ func (s *Store) cacheEntries() ([]cacheEntry, []string, error) {
 			return nil, nil, readErr
 		}
 		for _, repository := range repositories {
-			if !repository.IsDir() || strings.HasPrefix(repository.Name(), ".") {
+			if !repository.IsDir() || !validRepository(owner.Name()+"/"+repository.Name()) {
 				continue
 			}
 			repositoryPath := filepath.Join(ownerPath, repository.Name())

--- a/internal/action/source/source.go
+++ b/internal/action/source/source.go
@@ -42,7 +42,7 @@ const (
 
 var (
 	ownerRE = regexp.MustCompile(`^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$`)
-	repoRE  = regexp.MustCompile(`^[A-Za-z0-9](?:[A-Za-z0-9_.-]{0,98}[A-Za-z0-9])?$`)
+	repoRE  = regexp.MustCompile(`^(?:[A-Za-z0-9](?:[A-Za-z0-9_.-]{0,98}[A-Za-z0-9])?|\.[A-Za-z0-9](?:[A-Za-z0-9_.-]{0,97}[A-Za-z0-9])?)$`)
 	shaRE   = regexp.MustCompile(`^[0-9a-f]{40}$`)
 )
 

--- a/internal/action/source/source_test.go
+++ b/internal/action/source/source_test.go
@@ -970,7 +970,7 @@ func TestStoreEvictionSkipsLeasedEntryAndRemovesItAfterRelease(t *testing.T) {
 
 func TestStoreMaintenanceUsesLRUAndCleansOnlyUnlockedPartials(t *testing.T) {
 	root := t.TempDir()
-	repository := filepath.Join(root, "owner", "repo")
+	repository := filepath.Join(root, "owner", ".github")
 	if err := os.MkdirAll(repository, 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/action/source/source_test.go
+++ b/internal/action/source/source_test.go
@@ -31,10 +31,21 @@ func TestParse(t *testing.T) {
 			t.Errorf("Parse(%q) = %#v, %v", good, r, err)
 		}
 	}
-	for _, bad := range []string{"", "./local@v1", "owner@v1", "owner/repo", "owner/repo@", "owner//repo@v1", "owner/repo/../x@v1", `owner/repo\x@v1`, "owner/repo@a?b", "owner/repo@${{ x }}", "-owner/repo@v1", "owner/repo.git@v1", "owner/repo@a//b"} {
+	for _, bad := range []string{"", "./local@v1", "owner@v1", "owner/repo", "owner/repo@", "owner//repo@v1", "owner/./x@v1", "owner/../x@v1", "owner/..github/x@v1", "owner/.github/../x@v1", `owner/repo\x@v1`, "owner/repo@a?b", "owner/repo@${{ x }}", "-owner/repo@v1", "owner/repo.git@v1", "owner/repo@a//b"} {
 		if _, err := Parse(bad); err == nil {
 			t.Errorf("Parse(%q) succeeded", bad)
 		}
+	}
+}
+
+func TestParseDotPrefixedRepository(t *testing.T) {
+	raw := "GaloisInc/.github/.github/workflows/haskell-ci.yml@v2"
+	got, err := Parse(raw)
+	want := Reference{
+		Owner: "GaloisInc", Repository: ".github", Path: ".github/workflows/haskell-ci.yml", Ref: "v2", Raw: raw,
+	}
+	if err != nil || got != want {
+		t.Fatalf("Parse(%q) = %#v, %v; want %#v", raw, got, err, want)
 	}
 }
 

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -3585,7 +3585,11 @@ func TestCompiledPlansValidateAgainstSchema(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	validateCompiledPlansAgainstSchema(t, plans)
+}
 
+func validateCompiledPlansAgainstSchema(t *testing.T, plans []plan.Job) {
+	t.Helper()
 	schemaSource := readFile(t, filepath.Join("..", "..", "schemas", "job-plan.schema.json"))
 	var schemaDocument any
 	if err := json.Unmarshal(schemaSource, &schemaDocument); err != nil {

--- a/internal/compiler/reusable_remote_test.go
+++ b/internal/compiler/reusable_remote_test.go
@@ -141,6 +141,7 @@ jobs:
 	if plans[1].Workflow.Remote == nil || *plans[1].Workflow.Remote != wantRemote || plans[1].Workflow.Path != nested.SourcePath || plans[1].Workflow.Digest != wantNestedDigest {
 		t.Fatalf("remote plan provenance = %#v", plans)
 	}
+	validateCompiledPlansAgainstSchema(t, plans)
 	if calls := fake.references(); len(calls) != 1 || calls[0].Raw != "GaloisInc/.github@v2" || calls[0].Path != "" {
 		t.Fatalf("repository source calls = %#v, want one repository-root resolution", calls)
 	}

--- a/internal/compiler/reusable_remote_test.go
+++ b/internal/compiler/reusable_remote_test.go
@@ -76,9 +76,9 @@ func (s *fakeReusableRepositorySource) references() []actionsource.Reference {
 
 func TestCompilePublicReusableWorkflowWithNestedPinnedLocalCall(t *testing.T) {
 	callerRoot := t.TempDir()
-	callerPath := writeWorkflow(t, callerRoot, "caller.yml", "on: push\njobs:\n  delegated:\n    uses: Octo/Workflows/.github/workflows/ci.yml@v1\n")
+	callerPath := writeWorkflow(t, callerRoot, "caller.yml", "on: push\njobs:\n  delegated:\n    uses: GaloisInc/.github/.github/workflows/haskell-ci.yml@v2\n")
 	remoteRoot := t.TempDir()
-	writeWorkflow(t, remoteRoot, "ci.yml", `on: workflow_call
+	writeWorkflow(t, remoteRoot, "haskell-ci.yml", `on: workflow_call
 jobs:
   prepare:
     runs-on: ubuntu-latest
@@ -95,7 +95,7 @@ jobs:
     steps:
       - run: nested
 `)
-	fake := newFakeReusableRepositorySource(t, map[string]string{"octo/workflows": remoteRoot})
+	fake := newFakeReusableRepositorySource(t, map[string]string{"galoisinc/.github": remoteRoot})
 	shared := MemoizeRepositorySource(fake)
 	options := defaultOptions()
 	options.RepositorySource = shared
@@ -117,10 +117,10 @@ jobs:
 	}
 	direct := byID["delegated.prepare"]
 	nested := byID["delegated.nested.test"]
-	if direct.SourcePath != "octo/workflows/.github/workflows/ci.yml@v1" || nested.SourcePath != "octo/workflows/.github/workflows/nested.yml@v1" {
+	if direct.SourcePath != "galoisinc/.github/.github/workflows/haskell-ci.yml@v2" || nested.SourcePath != "galoisinc/.github/.github/workflows/nested.yml@v2" {
 		t.Fatalf("remote source paths = %q / %q", direct.SourcePath, nested.SourcePath)
 	}
-	if nested.RemoteWorkflow == nil || nested.RemoteWorkflow.Repository != "octo/workflows" || nested.RemoteWorkflow.RequestedRef != "v1" || nested.RemoteWorkflow.Commit != fake.commits["octo/workflows"] || nested.RemoteWorkflow.SourceDigest != fake.digests["octo/workflows"] {
+	if nested.RemoteWorkflow == nil || nested.RemoteWorkflow.Repository != "galoisinc/.github" || nested.RemoteWorkflow.RequestedRef != "v2" || nested.RemoteWorkflow.Commit != fake.commits["galoisinc/.github"] || nested.RemoteWorkflow.SourceDigest != fake.digests["galoisinc/.github"] {
 		t.Fatalf("remote workflow provenance = %#v", nested.RemoteWorkflow)
 	}
 	wantNestedDigest := "sha256:" + sha256Sum(readFile(t, nestedPath))
@@ -132,10 +132,16 @@ jobs:
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(plans) != 2 || plans[1].Workflow.Remote == nil || plans[1].Workflow.Path != nested.SourcePath || plans[1].Workflow.Digest != wantNestedDigest || plans[1].Workflow.Remote.SourceDigest != fake.digests["octo/workflows"] {
+	if len(plans) != 2 {
+		t.Fatalf("remote plans = %#v", plans)
+	}
+	wantRemote := plan.RemoteWorkflowSource{
+		Repository: "galoisinc/.github", RequestedRef: "v2", Commit: fake.commits["galoisinc/.github"], SourceDigest: fake.digests["galoisinc/.github"],
+	}
+	if plans[1].Workflow.Remote == nil || *plans[1].Workflow.Remote != wantRemote || plans[1].Workflow.Path != nested.SourcePath || plans[1].Workflow.Digest != wantNestedDigest {
 		t.Fatalf("remote plan provenance = %#v", plans)
 	}
-	if calls := fake.references(); len(calls) != 1 || calls[0].Raw != "Octo/Workflows@v1" || calls[0].Path != "" {
+	if calls := fake.references(); len(calls) != 1 || calls[0].Raw != "GaloisInc/.github@v2" || calls[0].Path != "" {
 		t.Fatalf("repository source calls = %#v, want one repository-root resolution", calls)
 	}
 }

--- a/schemas/job-plan.schema.json
+++ b/schemas/job-plan.schema.json
@@ -101,7 +101,7 @@
     "span": {"type": "object", "additionalProperties": false, "required": ["start", "end"], "properties": {"start": {"$ref": "#/$defs/position"}, "end": {"$ref": "#/$defs/position"}}},
     "selector": {"type": "object", "additionalProperties": false, "required": ["lock"], "properties": {"lock": {"type": "string", "pattern": "^a-[0-9a-f]{16}$"}}},
     "path": {"type": "string", "minLength": 1, "maxLength": 1024, "pattern": "^[^/\\\\\\x00-\\x1f\\x7f]{1,255}(?:/[^/\\\\\\x00-\\x1f\\x7f]{1,255})*$", "not": {"pattern": "(^|/)\\.\\.?(/|$)"}},
-    "repository": {"type": "string", "maxLength": 140, "pattern": "^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?/[a-z0-9](?:[a-z0-9_.-]{0,98}[a-z0-9])?$"},
+    "repository": {"type": "string", "maxLength": 140, "pattern": "^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?/(?:[a-z0-9](?:[a-z0-9_.-]{0,98}[a-z0-9])?|\\.[a-z0-9](?:[a-z0-9_.-]{0,97}[a-z0-9])?)$"},
     "actionLock": {
       "type": "object", "additionalProperties": false,
       "required": ["id", "source", "source_digest"],


### PR DESCRIPTION
## Why

Public static reusable workflows can live in repositories named `.github`, but the shared GitHub source parser required repository names to begin with an alphanumeric character. Valid references such as `GaloisInc/.github/.github/workflows/haskell-ci.yml@v2` were therefore rejected before immutable resolution.

## What

Allow a single leading dot followed by an alphanumeric repository name while preserving existing length, suffix, path-confinement, public-only, and immutable-source checks. Keep bounded cache maintenance and the checked-in job-plan schema aligned with the accepted repository form. Cover exact parsing, malformed dot and traversal references, cache eviction, nested remote workflow expansion, immutable provenance, and schema validation.
