### PR TITLE
Support compile-time job container image expressions

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -551,6 +551,7 @@ services:
 
 Services support `image`, `credentials`, `env`, `ports`, `volumes`, `options`, `command`, and `entrypoint`.
 
+- Job container images can use compile-time `github`, `inputs`, `vars`, `strategy`, and `matrix` values. The complete image must resolve to a non-empty string and a valid image reference during compilation. Secrets, `needs`, step outputs, and whole or dynamic contexts are unsupported.
 - Service fields can use compile-time `github`, `inputs`, `vars`, `strategy`, and `matrix` values or runtime `needs` outputs. An empty evaluated image skips the service.
 - A complete non-credential service map can use `${{ fromJSON(needs.<job>.outputs.<name>) }}`. Declare credentials statically so the compiler can prove their secret authority.
 - Credentials accept direct values and `github`, `vars`, `secrets`, or `env` expressions. Passwords pass to `docker login` through standard input. Authentication uses a private per-job Docker configuration and never reads ambient Docker credentials.

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -59,6 +59,36 @@ func TestCompileBundleGoldenAndDeterministic(t *testing.T) {
 	}
 }
 
+func TestCompileBundleGeneratesDeterministicPipelineForResolvedContainerImage(t *testing.T) {
+	source := []byte(`on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: [node:24, node:25]
+    container: ${{ matrix.image }}
+    steps: [{run: true}]
+`)
+	event := readFile(t, smokePath("events", "push.json"))
+	first, err := CompileBundle("containers.yml", source, event, "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := CompileBundle("containers.yml", source, event, "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(first, second) || len(first.Plans) != 2 || len(first.Pipeline) == 0 {
+		t.Fatalf("container bundle was not deterministic: %#v", first)
+	}
+	for i, image := range []string{"node:24", "node:25"} {
+		if first.Plans[i].Job.Container == nil || first.Plans[i].Job.Container.Image != image || bytes.Contains(first.Plans[i].Contents, []byte("${{")) {
+			t.Fatalf("plan %d container = %#v", i, first.Plans[i].Job.Container)
+		}
+	}
+}
+
 func TestCompileBundleDoesNotActivateValidatedRuntimeMatrixWithoutFencing(t *testing.T) {
 	source := []byte(`on: push
 jobs:

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -416,6 +416,29 @@ func jobWorkflowTokenWarning(position workflow.Position) Warning {
 	}
 }
 
+func resolveCompileContainer(container *workflow.Container, context expression.CompileContext) (*workflow.Container, error) {
+	if container == nil {
+		return nil, nil
+	}
+	resolved := *container
+	resolved.Env = cloneMap(container.Env)
+	resolved.Ports = append([]string(nil), container.Ports...)
+	if strings.Contains(resolved.Image, "${{") {
+		image, err := expression.EvaluateCompileStringTemplate(resolved.Image, context)
+		if err != nil {
+			return nil, err
+		}
+		resolved.Image = image
+	}
+	if strings.TrimSpace(resolved.Image) == "" {
+		return nil, fmt.Errorf("container image resolved to an empty string")
+	}
+	if len(resolved.Image) > 512 || !plan.ValidContainerImageReference(resolved.Image) {
+		return nil, fmt.Errorf("container image resolved to an invalid image reference")
+	}
+	return &resolved, nil
+}
+
 func resolveCompileServices(services []workflow.Service, context expression.CompileContext) ([]workflow.Service, error) {
 	resolved := make([]workflow.Service, 0, len(services))
 	for _, service := range services {

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -3733,6 +3733,86 @@ func TestCompilePlansEmitV8ForContainers(t *testing.T) {
 	}
 }
 
+func TestCompilePlansResolveJobContainerImageExpressions(t *testing.T) {
+	workflowSource := []byte(`on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: ['24', '25']
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/${{ vars.IMAGE }}:${{ matrix.version }}
+    steps: [{run: true}]
+`)
+	options := defaultOptions()
+	options.Vars.Buildkite = map[string]string{"IMAGE": "tool"}
+	plans, err := compilePlansForTest(t.Context(), "containers.yml", workflowSource, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("1", 64), options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 2 || plans[0].Container == nil || plans[1].Container == nil || plans[0].Container.Image != "ghcr.io/buildkite/tool:24" || plans[1].Container.Image != "ghcr.io/buildkite/tool:25" {
+		t.Fatalf("compiled container images = %#v, %#v", plans[0].Container, plans[1].Container)
+	}
+	if encoded, err := plan.Encode(plans[0]); err != nil || bytes.Contains(encoded, []byte("${{")) {
+		t.Fatalf("encoded plan retained an expression: %s, %v", encoded, err)
+	}
+}
+
+func TestCompilePlansResolveReusableWorkflowInputJobContainerImage(t *testing.T) {
+	repository := t.TempDir()
+	caller := writeWorkflow(t, repository, "caller.yml", `on: push
+jobs:
+  delegated:
+    uses: ./.github/workflows/container.yml
+    with:
+      image: node:24
+`)
+	writeWorkflow(t, repository, "container.yml", `on:
+  workflow_call:
+    inputs:
+      image:
+        required: true
+        type: string
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ inputs.image }}
+    steps: [{run: true}]
+`)
+	plans, err := compileUntrustedPlans(caller, readFile(t, caller), readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("1", 64), "gha-untrusted")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 1 || plans[0].Container == nil || plans[0].Container.Image != "node:24" {
+		t.Fatalf("reusable job container = %#v", plans)
+	}
+}
+
+func TestCompilePlansRejectInvalidJobContainerImageExpressions(t *testing.T) {
+	for name, image := range map[string]string{
+		"secret":        "${{ secrets.IMAGE }}",
+		"needs output":  "${{ needs.build.outputs.image }}",
+		"step output":   "${{ steps.build.outputs.image }}",
+		"whole context": "${{ github }}",
+		"boolean":       "${{ true }}",
+		"empty":         "${{ '' }}",
+		"invalid":       "${{ 'bad image' }}",
+	} {
+		t.Run(name, func(t *testing.T) {
+			workflowSource := []byte("on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    container:\n      image: \"" + image + "\"\n    steps: [{run: true}]\n")
+			_, err := compileUntrustedPlans("containers.yml", workflowSource, readFile(t, smokePath("events", "push.json")), "0.0.0-test", "sha256:"+strings.Repeat("1", 64), "gha-untrusted")
+			if err == nil || !strings.Contains(err.Error(), "resolve job container") {
+				t.Fatalf("compile error = %v", err)
+			}
+			if strings.Contains(err.Error(), "[REDACTED:") {
+				t.Fatalf("compile error leaked a secret: %v", err)
+			}
+		})
+	}
+}
+
 func TestCompilePlansResolveStaticServiceContainerFields(t *testing.T) {
 	workflowSource := []byte(`on: push
 jobs:

--- a/internal/compiler/job_graph_expansion.go
+++ b/internal/compiler/job_graph_expansion.go
@@ -243,11 +243,16 @@ func (e *jobGraphExpansion) expandJobInstances(id string) {
 			continue
 		}
 		e.instanceKeys[key] = job.ID
+		resolvedContainer, containerErr := resolveCompileContainer(instanceJob.Container, instanceContext)
+		instanceJob.Container = resolvedContainer
 		resolvedServices, serviceErr := resolveCompileServices(instanceJob.Services, instanceContext)
 		candidate := newJobCandidate(sourced, instanceJob, matrix, key, resolvedServices)
 
 		valid := true
-		if serviceErr != nil {
+		if containerErr != nil {
+			e.diagnostics = append(e.diagnostics, attributedProcessingFinding(StageExpressions, CodeExpressionInvalid, "compatibility", jobPath, job.Span.Start.Line, job.Span.Start.Column, job.ID, key, "", 0, jobError(jobPath, job, fmt.Sprintf("resolve job container: %v", containerErr))))
+			valid = false
+		} else if serviceErr != nil {
 			e.diagnostics = append(e.diagnostics, attributedProcessingFinding(StageExpressions, CodeExpressionInvalid, "compatibility", jobPath, job.Span.Start.Line, job.Span.Start.Column, job.ID, key, "", 0, jobError(jobPath, job, fmt.Sprintf("resolve service containers: %v", serviceErr))))
 			valid = false
 		} else if compileConditionErr != nil {

--- a/internal/expression/compile.go
+++ b/internal/expression/compile.go
@@ -386,6 +386,34 @@ func EvaluateCompileTemplate(template string, context CompileContext) (string, e
 	}
 }
 
+// EvaluateCompileStringTemplate evaluates a compile-time template whose
+// complete-expression form must produce a string. Interpolated scalar values
+// retain the normal template rendering rules.
+func EvaluateCompileStringTemplate(template string, context CompileContext) (string, error) {
+	if expr, err := Parse(template, 1, 1); err == nil {
+		value, err := EvaluateCompile(expr, context)
+		if err != nil {
+			return "", err
+		}
+		text, ok := value.(string)
+		if !ok {
+			return "", fmt.Errorf("expression resolved to %T, want string", value)
+		}
+		if strings.Contains(text, "${{") {
+			return "", fmt.Errorf("compile-time expression result contains expression syntax")
+		}
+		return text, nil
+	}
+	evaluated, err := EvaluateCompileTemplate(template, context)
+	if err != nil {
+		return "", err
+	}
+	if strings.Contains(evaluated, "${{") {
+		return "", fmt.Errorf("compile-time expression result contains expression syntax")
+	}
+	return evaluated, nil
+}
+
 // EvaluateAvailableCompileTemplate folds each graph-time expression that can be
 // resolved independently and preserves expressions that need runtime context.
 func EvaluateAvailableCompileTemplate(template string, context CompileContext) (string, error) {

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -1567,6 +1567,27 @@ func TestEvaluateCompileTemplateSupportsGitHubRefScalars(t *testing.T) {
 	}
 }
 
+func TestEvaluateCompileStringTemplateRequiresStringCompleteExpression(t *testing.T) {
+	context := CompileContext{
+		Inputs: map[string]any{"image": "node:24", "enabled": true, "injected": "${{ secrets.TOKEN }}"},
+		Matrix: map[string]any{"version": 24},
+	}
+	for template, want := range map[string]string{
+		"${{ inputs.image }}":        "node:24",
+		"node:${{ matrix.version }}": "node:24",
+	} {
+		got, err := EvaluateCompileStringTemplate(template, context)
+		if err != nil || got != want {
+			t.Errorf("EvaluateCompileStringTemplate(%q) = %q, %v, want %q", template, got, err, want)
+		}
+	}
+	for _, template := range []string{"${{ inputs.enabled }}", "${{ matrix }}", "${{ secrets.TOKEN }}", "${{ needs.build.outputs.image }}", "${{ inputs.injected }}"} {
+		if _, err := EvaluateCompileStringTemplate(template, context); err == nil {
+			t.Errorf("EvaluateCompileStringTemplate(%q) succeeded", template)
+		}
+	}
+}
+
 func TestEncodeExpressionJSONSupportsNonFiniteNumbers(t *testing.T) {
 	got, err := encodeExpressionJSON(map[string]any{
 		"values": []any{math.Inf(1), math.Inf(-1), math.NaN()},

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -1134,6 +1134,8 @@ func TestContainerImageGrammarMatchesSchema(t *testing.T) {
 		{"localhost:0/private/service", false},
 		{"localhost:65536/private/service", false},
 		{"LOCALHOST:5000/private/service", false},
+		{"${{ matrix.image }}", false},
+		{"${{ secrets.IMAGE }}", false},
 		{"${{ needs.build.outputs.image }}", false},
 	} {
 		t.Run(test.image, func(t *testing.T) {

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -667,6 +667,22 @@ func TestRunJobContainerLifecycleAndEnvironment(t *testing.T) {
 	}
 }
 
+func TestRunJobContainerUsesPlanSelectedImageWithoutRuntimeEvaluation(t *testing.T) {
+	f := newJobDocker(t, "")
+	workspace := t.TempDir()
+	j := jobContainerPlan(t, workspace, nil)
+	j.Container.Image = "ghcr.io/acme/tool:25"
+	if _, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).RunJob(t.Context(), j, workspace); err != nil {
+		t.Fatal(err)
+	}
+	calls := f.calls(t)
+	pull := jobDockerCallIndex(calls, "pull", j.Container.Image)
+	create := jobDockerCallIndex(calls, "create")
+	if pull < 0 || create < pull || !slices.Contains(calls[create].Args, j.Container.Image) {
+		t.Fatalf("selected image was not pulled and created unchanged: %#v", calls)
+	}
+}
+
 func TestRunJobContainerDefaultsRunStepsToSh(t *testing.T) {
 	f := newJobDocker(t, "")
 	workspace := t.TempDir()

--- a/internal/workflow/parse.go
+++ b/internal/workflow/parse.go
@@ -913,10 +913,7 @@ var serviceIDPattern = regexp.MustCompile(`^[a-z_][a-z0-9_-]*$`)
 
 func adaptContainer(path, jobID string, in *actionlint.Container) (Container, error) {
 	if in.Image == nil || strings.TrimSpace(in.Image.Value) == "" {
-		return Container{}, locatedError(path, in.Pos, jobID, "container image must be a non-empty literal")
-	}
-	if in.Image.ContainsExpression() {
-		return Container{}, locatedError(path, in.Image.Pos, jobID, "expression-valued container image is unsupported")
+		return Container{}, locatedError(path, in.Pos, jobID, "container image must be non-empty")
 	}
 	if in.Credentials != nil {
 		return Container{}, locatedError(path, in.Credentials.Pos, jobID, "container credentials are unsupported")

--- a/internal/workflow/parse_test.go
+++ b/internal/workflow/parse_test.go
@@ -206,6 +206,17 @@ func TestParseOwnsLiteralContainersInDeclarationOrder(t *testing.T) {
 	}
 }
 
+func TestParseRetainsJobContainerImageExpression(t *testing.T) {
+	source := []byte("on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    container: ghcr.io/acme/tool:${{ matrix.version }}\n    steps: [{run: true}]\n")
+	parsed, err := Parse("containers.yml", source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := parsed.Jobs[0].Container.Image; got != "ghcr.io/acme/tool:${{ matrix.version }}" {
+		t.Fatalf("container image = %q", got)
+	}
+}
+
 func TestParseContainerImageRegistryPorts(t *testing.T) {
 	for _, test := range []struct {
 		image string


### PR DESCRIPTION
## Why

Job container images currently reject expressions even when their values are immutable and fully known during compilation. This blocks otherwise compatible workflows that select images from static matrix entries, reusable inputs, variables, or GitHub event metadata.

## What

Resolve job container image expressions for each statically expanded job instance using the existing compile-time expression context. Complete expressions must produce a non-empty string and the final value must pass the existing image validation; secrets, runtime outputs, whole contexts, and deferred expressions remain unsupported.

Plans stay literal-only, so image selection remains deterministic and the existing runner, registry credential, platform, and runtime policies are unchanged. Compatibility documentation and focused parser, expression, compiler, plan, pipeline, and runtime coverage are included.
