### PR TITLE
Support explicit reusable workflow secret forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The [compatibility reference](docs/compatibility.md) is the source of truth. Use
 | Local and public JavaScript and composite actions; verified Dockerfile actions on Linux | Private actions or private reusable workflows, and Dockerfile actions on macOS |
 | Static matrices, `needs`, outputs, and local or literal public reusable workflows | Dynamic reusable calls, matrices, and expressions outside the documented subset |
 | Exact-commit checkout, including managed private repository access | GitHub environment secrets, GitHub-issued OIDC claims, or protected queues |
-| Static Buildkite job-accessible secrets | Dynamic or reusable-workflow secret forwarding |
+| Static Buildkite job-accessible secrets, including declared aliases in local reusable workflows | Dynamic secret access or remote reusable-workflow secret forwarding |
 | Scoped `GITHUB_TOKEN` and step `github.token` use allowed by Buildkite policy | Ambient token injection or dynamic token access |
 | Buildkite OIDC tokens through host JavaScript and composite actions | OIDC in Docker actions or job containers |
 | Audited artifact action versions and cache v6 integration | Other artifact and cache modes or general GitHub service emulation |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -38,11 +38,11 @@ Looking for something else? [Browse open compatibility issues](https://github.co
 | [Matrix strategies](#matrix-strategies) | 🟡 Supported subset | Static matrices, `include`, `exclude`, and literal `max-parallel`. Maximum 256 instances per job. `fail-fast` has no effect. |
 | [Shell steps](#commands-and-actions) | 🟡 Supported subset | Linux and macOS `bash`, `sh`, `python`, and custom shell templates. |
 | [Conditions and expressions](#expressions-and-contexts) | 🟡 Supported subset | GitHub-compatible core operators and direct references to selected contexts. |
-| [Reusable workflows](#reusable-workflows) | 🟡 Supported subset | Local and literal public GitHub workflows with static inputs, deferred string inputs from direct needs outputs, and direct job-output mappings. Local calls can inherit Buildkite secret authority. |
+| [Reusable workflows](#reusable-workflows) | 🟡 Supported subset | Local and literal public GitHub workflows with static inputs, deferred string inputs from direct needs outputs, and direct job-output mappings. Local calls can inherit or explicitly map Buildkite secret authority. |
 | [Actions](#actions) | 🟡 Supported subset | Local and public JavaScript and composite actions on Linux and macOS; verified Dockerfile actions on Linux only. |
 | [Checkout, artifacts, and cache](#actions) | 🟡 Supported subset | Only the audited versions and modes listed below. |
 | [`GITHUB_TOKEN`](#github-token) | 🟡 Supported subset | One job-bound token for the event repository. Reusable-workflow jobs use the top-level workflow permissions. |
-| [Other workflow secrets](#other-secrets-and-oidc) | 🟡 Supported subset | Static names in direct jobs and locally inherited reusable jobs resolve through the destination job's Buildkite secret authority. |
+| [Other workflow secrets](#other-secrets-and-oidc) | 🟡 Supported subset | Static names in direct jobs and locally inherited or explicitly mapped reusable jobs resolve through the destination job's Buildkite secret authority. |
 | [Job and service containers](#containers-and-services) | 🟡 Supported subset | Linux job containers and broadly compatible service definitions, including explicit registry credentials. |
 | [Environments and snapshots](#job-configuration) | 🟡 Supported subset | Environments are rejected. Snapshots are accepted with no effect. |
 | [OIDC](#other-secrets-and-oidc) | 🟡 Supported subset | Host JavaScript and composite actions can request Buildkite OIDC tokens in jobs with `id-token: write`. |
@@ -304,6 +304,8 @@ A top-level workflow that does not declare the effective event is excluded befor
 - Literal defaults and expression defaults over graph-time `github` and `vars` values.
 - Nested calls up to four levels.
 - `secrets: inherit` for repository-local calls. Each nested edge must repeat it.
+- Explicit repository-local mappings from a declared callee alias to one direct `${{ secrets.NAME }}` or `${{ secrets['NAME'] }}` caller reference.
+- Required and optional `on.workflow_call.secrets` declarations.
 - Caller-visible aggregate results.
 - Outputs mapped directly from `jobs.<job>.outputs.<name>`.
 - Call-level `if` over caller `github`, `vars`, `inputs`, direct `needs`, and status functions.
@@ -311,7 +313,8 @@ A top-level workflow that does not declare the effective event is excluded befor
 **❌ Unsupported:**
 
 - Dynamic workflow paths and private repositories.
-- `secrets: inherit` for public remote calls, explicit secret mappings, or required called-workflow secrets.
+- Secret forwarding for public remote calls.
+- Literal, compound, dynamic, or non-secret explicit mapping values.
 - Compound `needs`-dependent inputs or dynamic matrices.
 - Input defaults that reference `inputs`.
 - Literal or compound output expressions.
@@ -320,6 +323,10 @@ A top-level workflow that does not declare the effective event is excluded befor
 Job-level `uses`, `with`, and `secrets` follow these boundaries.
 
 For a local call with `secrets: inherit`, each flattened callee job requests only the static ordinary secret names referenced by that job or its workflow-authored action inputs. Inheritance is one hop: an omitted nested `secrets: inherit` removes ordinary secret authority from every job below that edge. It does not affect direct caller jobs or `GITHUB_TOKEN`.
+
+Explicit mappings must target aliases declared by the called workflow. Every required alias must receive authority; an unmapped optional alias is empty. Nested mappings compose to the original Buildkite secret name and cannot recover an omitted same-named secret. Plans contain aliases and original names, never values. The runtime retrieves each original once, registers its value with both redactors, then projects it to the callee aliases.
+
+`${{ secrets.GITHUB_TOKEN }}` may be forwarded to a declared alias. The alias remains part of the scoped workflow-token contract and never becomes an ordinary Buildkite secret.
 
 A call condition runs in caller scope before static call-matrix expansion. It keeps the implicit `success()` guard. A false condition skips every flattened descendant, including jobs with `if: always()`, and exposes `skipped` with empty outputs to downstream `needs`. Nested calls evaluate ordered outer-to-inner guards. Callee job results do not change an outer guard. Call conditions cannot use `matrix`, `strategy`, callee inputs or needs, `steps`, `env`, `runner`, or `secrets`.
 
@@ -1160,7 +1167,8 @@ Automatic ambient `GITHUB_TOKEN` is unsupported.
 ### Other secrets and OIDC
 
 **🟡 Supported subset.** Direct jobs can use static `${{ secrets.NAME }}`
-references. Local reusable-workflow jobs can use them after `secrets: inherit`.
+references. Local reusable-workflow jobs can inherit or explicitly map declared
+secret aliases.
 
 The compiler records names, not values, in the destination job plan. At
 runtime, the job calls `buildkite-agent secret get NAME` and registers the value
@@ -1181,8 +1189,9 @@ Unsupported secret uses include:
 - dynamic, whole-context, filtered, or projected access
 - conditions and other compile-time expressions
 - GitHub environments and environment secrets
-- remote inheritance and explicit reusable-workflow mappings
-- required `on.workflow_call.secrets` declarations
+- remote reusable-workflow secret forwarding
+- literals, compound expressions, or references through `needs`, `vars`, `env`,
+  `inputs`, or arbitrary `github` properties in explicit mappings
 
 Action metadata cannot add secret authority to a plan. A secret used only by an
 optional action input becomes an empty value unless another field requires it.

--- a/docs/security.md
+++ b/docs/security.md
@@ -146,15 +146,23 @@ are not GitHub repository, environment, event, or fork-scoped secrets.
 
 `secrets: inherit` lets a local reusable-workflow call place that callee job's
 statically referenced secret names in its plan. It is one hop, and every nested
-edge must repeat it. It does not support aliases, remote calls, or secret names
-invented by action metadata.
+edge must repeat it. A local call can instead map a declared callee alias from
+one direct caller secret reference. Required declarations must be mapped;
+optional unmapped aliases stay empty.
+
+Nested explicit mappings compose aliases to the original Buildkite secret.
+They can forward only authority received from the parent and never fall back to
+a same-named Buildkite secret. The runtime retrieves each original once and
+projects its value to the authorized aliases. Remote forwarding and secret
+names invented by action metadata remain unsupported.
 
 Plans and pipeline YAML contain secret names, never values. Restrict the
 destination job with Buildkite Secret access policies. Arbitrary code in the
 same job identity can also run `buildkite-agent secret get`.
 
-`GITHUB_TOKEN` stays on its separate workflow-token boundary and is not affected
-by secret inheritance.
+`GITHUB_TOKEN` stays on its separate workflow-token boundary. Forwarding it to
+a declared alias preserves that scoped token boundary; it never requests an
+ordinary Buildkite secret.
 
 ### OIDC
 

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -1552,7 +1552,7 @@ jobs:
 
 func TestRequiredSecretsDoesNotInterpretConditionLiteralsAsTemplates(t *testing.T) {
 	instance := JobInstance{If: "'${{ github.token }} ${{ secrets.DEPLOY }} ${{ github.event.action }}' == runner.os"}
-	secrets, referencesToken, err := requiredSecrets(instance, nil, false)
+	secrets, _, _, referencesToken, err := requiredSecrets(instance, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -96,7 +96,7 @@ type JobInstance struct {
 	RemoteWorkflow          *RemoteWorkflowSource    `json:"remote_workflow,omitempty"`
 	RepositoryRoot          string                   `json:"-"`
 	Source                  workflow.Span            `json:"source"`
-	secretAuthority         bool
+	secretAuthority         secretAuthority
 	tokenPolicyNarrowed     bool
 	jobPermissionsIgnored   bool
 	reusableCall            workflow.Position

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -2336,6 +2336,53 @@ jobs:
 	}
 }
 
+func TestCompilePreservesTokenAliasUsedByOptionalActionInput(t *testing.T) {
+	repository := t.TempDir()
+	path := writeWorkflow(t, repository, "caller.yml", `on: push
+permissions:
+  contents: read
+jobs:
+  call:
+    uses: ./.github/workflows/reusable.yml
+    secrets:
+      token_alias: ${{ secrets.GITHUB_TOKEN }}
+      optional_alias: ${{ secrets.OPTIONAL }}
+`)
+	writeWorkflow(t, repository, "reusable.yml", `on:
+  workflow_call:
+    secrets:
+      token_alias:
+      optional_alias:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/optional-token
+        with:
+          token: ${{ secrets.token_alias }}
+          optional: ${{ secrets.optional_alias }}
+`)
+	writeAction(t, filepath.Join(repository, ".github", "actions"), "optional-token", `name: optional token
+inputs:
+  token:
+  optional:
+runs:
+  using: node24
+  main: index.js
+`)
+
+	plans, err := compileUntrustedPlans(path, readFile(t, path), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), "gha-untrusted")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 1 || plans[0].GitHubToken == nil || !slices.Equal(plans[0].GitHubToken.Aliases, []string{"TOKEN_ALIAS"}) {
+		t.Fatalf("token alias boundary = %#v", plans)
+	}
+	if len(plans[0].RequiredSecrets) != 0 || plans[0].HasCapability("secrets") {
+		t.Fatalf("optional ordinary action input granted secret authority: %#v", plans[0])
+	}
+}
+
 func TestCompileComposesNestedExplicitSecretAliasesWithoutFallback(t *testing.T) {
 	repository := t.TempDir()
 	path := writeWorkflow(t, repository, "caller.yml", `on: push

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -2259,7 +2259,7 @@ jobs:
 	}
 }
 
-func TestCompileRejectsRequiredReusableWorkflowSecrets(t *testing.T) {
+func TestCompileRejectsMissingRequiredReusableWorkflowSecrets(t *testing.T) {
 	repository := t.TempDir()
 	path := writeWorkflow(t, repository, "caller.yml", "on: push\njobs:\n  call:\n    uses: ./.github/workflows/reusable.yml\n")
 	writeWorkflow(t, repository, "reusable.yml", `on:
@@ -2274,8 +2274,111 @@ jobs:
       - run: true
 `)
 	_, err := Compile(path, readFile(t, path), readFile(t, smokePath("events", "push.json")))
-	if err == nil || !strings.Contains(err.Error(), `requires unsupported secret "token"`) {
-		t.Fatalf("Compile() error = %v, want required secret rejection", err)
+	if err == nil || !strings.Contains(err.Error(), `requires secret "token"`) {
+		t.Fatalf("Compile() error = %v, want missing required secret rejection", err)
+	}
+}
+
+func TestCompileExplicitReusableWorkflowSecretMappings(t *testing.T) {
+	repository := t.TempDir()
+	path := writeWorkflow(t, repository, "caller.yml", `on: push
+permissions:
+  contents: read
+jobs:
+  call:
+    strategy:
+      matrix:
+        value: [one, two]
+    uses: ./.github/workflows/reusable.yml
+    secrets:
+      required_alias: ${{ secrets.ORIGINAL }}
+      duplicate_alias: ${{ secrets.ORIGINAL }}
+      token_alias: ${{ secrets.GITHUB_TOKEN }}
+`)
+	writeWorkflow(t, repository, "reusable.yml", `on:
+  workflow_call:
+    secrets:
+      required_alias:
+        required: true
+      duplicate_alias:
+      optional_alias:
+      token_alias:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      REQUIRED: ${{ secrets.required_alias }}
+      DUPLICATE: ${{ secrets['duplicate_alias'] }}
+      OPTIONAL: ${{ secrets.optional_alias }}
+      TOKEN: ${{ secrets.token_alias }}
+    steps:
+      - run: true
+`)
+	plans, err := compileUntrustedPlans(path, readFile(t, path), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), "gha-untrusted")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 2 {
+		t.Fatalf("plans = %d, want two matrix instances", len(plans))
+	}
+	for _, job := range plans {
+		wantMappings := map[string]string{"DUPLICATE_ALIAS": "ORIGINAL", "REQUIRED_ALIAS": "ORIGINAL"}
+		if !slices.Equal(job.RequiredSecrets, []string{"ORIGINAL"}) || !reflect.DeepEqual(job.SecretMappings, wantMappings) || !job.HasCapability("secrets") {
+			t.Fatalf("ordinary secret boundary = %#v / %#v / %#v", job.RequiredSecrets, job.SecretMappings, job.RequiredCapabilities)
+		}
+		if job.GitHubToken == nil || !slices.Equal(job.GitHubToken.Aliases, []string{"TOKEN_ALIAS"}) || !job.HasCapability("provider-token-write") {
+			t.Fatalf("token alias boundary = %#v / %#v", job.GitHubToken, job.RequiredCapabilities)
+		}
+		encoded, encodeErr := plan.Encode(job)
+		if encodeErr != nil || bytes.Contains(encoded, []byte("secret-value")) {
+			t.Fatalf("encoded plan leaked a value or failed: %v\n%s", encodeErr, encoded)
+		}
+	}
+}
+
+func TestCompileComposesNestedExplicitSecretAliasesWithoutFallback(t *testing.T) {
+	repository := t.TempDir()
+	path := writeWorkflow(t, repository, "caller.yml", `on: push
+jobs:
+  call:
+    uses: ./.github/workflows/middle.yml
+    secrets:
+      middle_alias: ${{ secrets.ORIGINAL_SOURCE }}
+`)
+	writeWorkflow(t, repository, "middle.yml", `on:
+  workflow_call:
+    secrets:
+      middle_alias:
+        required: true
+      absent_optional:
+jobs:
+  nested:
+    uses: ./.github/workflows/leaf.yml
+    secrets:
+      leaf_alias: ${{ secrets.middle_alias }}
+      absent_leaf: ${{ secrets.absent_optional }}
+`)
+	writeWorkflow(t, repository, "leaf.yml", `on:
+  workflow_call:
+    secrets:
+      leaf_alias:
+        required: true
+      absent_leaf:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      PRESENT: ${{ secrets.leaf_alias }}
+      ABSENT: ${{ secrets.absent_leaf }}
+    steps:
+      - run: true
+`)
+	plans, err := compileUntrustedPlans(path, readFile(t, path), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), "gha-untrusted")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 1 || !slices.Equal(plans[0].RequiredSecrets, []string{"ORIGINAL_SOURCE"}) || !reflect.DeepEqual(plans[0].SecretMappings, map[string]string{"LEAF_ALIAS": "ORIGINAL_SOURCE"}) {
+		t.Fatalf("nested secret composition = %#v", plans)
 	}
 }
 
@@ -2936,7 +3039,7 @@ jobs:
 	}
 }
 
-func TestCompileRejectsExplicitReusableWorkflowSecretMappings(t *testing.T) {
+func TestCompileRejectsUndeclaredExplicitReusableWorkflowSecretMapping(t *testing.T) {
 	repository := t.TempDir()
 	path := writeWorkflow(t, repository, "caller.yml", `on: push
 jobs:
@@ -2947,8 +3050,8 @@ jobs:
 `)
 	writeWorkflow(t, repository, "reusable.yml", "on: workflow_call\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n")
 	_, err := Compile(path, readFile(t, path), readFile(t, smokePath("events", "push.json")))
-	if err == nil || !strings.Contains(err.Error(), "reusable-workflow secret forwarding is unsupported") {
-		t.Fatalf("Compile() error = %v, want explicit secret mapping rejection", err)
+	if err == nil || !strings.Contains(err.Error(), `secret mapping target "TOKEN" is not declared`) {
+		t.Fatalf("Compile() error = %v, want undeclared explicit secret mapping rejection", err)
 	}
 }
 

--- a/internal/compiler/plan_builder.go
+++ b/internal/compiler/plan_builder.go
@@ -706,6 +706,19 @@ func planConstructionFinding(instance JobInstance, err error) error {
 func requiredSecrets(instance JobInstance, actionRequired []string, actionInputsInspected bool) ([]string, map[string]string, []string, bool, error) {
 	found := map[string]string{}
 	referencesGitHubToken := false
+	collectTokenSecretAliases := func(value string) error {
+		names, err := expression.SecretReferences(value)
+		if err != nil {
+			return err
+		}
+		for _, name := range names {
+			binding, ok := instance.secretAuthority.resolve(name)
+			if strings.EqualFold(name, "GITHUB_TOKEN") || ok && binding.token {
+				found[name] = name
+			}
+		}
+		return nil
+	}
 	collect := func(value string, stepRuntime bool) error {
 		referencesEvent, err := expression.TemplateReferencesGitHubEvent(value)
 		if err != nil {
@@ -789,6 +802,12 @@ func requiredSecrets(instance JobInstance, actionRequired []string, actionInputs
 		valuesToInspect := []map[string]string{step.Env}
 		if step.Kind != "uses" || !actionInputsInspected {
 			valuesToInspect = append(valuesToInspect, step.With)
+		} else {
+			for _, name := range sortedValueKeys(step.With) {
+				if err := collectTokenSecretAliases(step.With[name]); err != nil {
+					return nil, nil, nil, false, err
+				}
+			}
 		}
 		for _, values := range valuesToInspect {
 			for _, name := range sortedValueKeys(values) {

--- a/internal/compiler/plan_builder.go
+++ b/internal/compiler/plan_builder.go
@@ -137,7 +137,7 @@ func (b planBuilder) buildPlan(instance JobInstance, runtimeDistributionDigest s
 	if err != nil {
 		return plan.Job{}, PlanAuthorization{}, nil, err
 	}
-	secrets, githubToken, err := b.authorizePlanSecrets(instance, &actions)
+	secrets, secretMappings, githubToken, err := b.authorizePlanSecrets(instance, &actions)
 	if err != nil {
 		return plan.Job{}, PlanAuthorization{}, nil, err
 	}
@@ -149,7 +149,7 @@ func (b planBuilder) buildPlan(instance JobInstance, runtimeDistributionDigest s
 	if instance.Platform == PlatformDarwinARM64 && slices.Contains(actions.capabilities, "docker") {
 		return plan.Job{}, PlanAuthorization{}, nil, fmt.Errorf("%s:%d:%d: job %q requires Docker, which is unavailable on darwin/arm64", instance.SourcePath, instance.Source.Start.Line, instance.Source.Start.Column, instance.LogicalJobID)
 	}
-	job := b.lowerPlanJob(instance, runtimeDistributionDigest, steps, actions, needSources, buildPlanNeedOutputs(instance), deferredInputs, callGuards, secrets, githubToken)
+	job := b.lowerPlanJob(instance, runtimeDistributionDigest, steps, actions, needSources, buildPlanNeedOutputs(instance), deferredInputs, callGuards, secrets, secretMappings, githubToken)
 	if err := job.Validate(); err != nil {
 		return plan.Job{}, PlanAuthorization{}, nil, fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err)
 	}
@@ -586,17 +586,15 @@ func buildPlanCallGuards(instance JobInstance, planDigests map[string]string) ([
 	return callGuards, nil
 }
 
-func (b planBuilder) authorizePlanSecrets(instance JobInstance, actions *builtPlanActions) ([]string, *plan.GitHubToken, error) {
-	secrets, referencesGitHubToken, err := requiredSecrets(instance, actions.requiredSecrets, actions.inputsInspected)
+func (b planBuilder) authorizePlanSecrets(instance JobInstance, actions *builtPlanActions) ([]string, map[string]string, *plan.GitHubToken, error) {
+	secrets, mappings, tokenAliases, referencesGitHubToken, err := requiredSecrets(instance, actions.requiredSecrets, actions.inputsInspected)
 	if err != nil {
-		return nil, nil, fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err)
+		return nil, nil, nil, fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err)
 	}
-	referencesGitHubTokenSecret := slices.Contains(secrets, "GITHUB_TOKEN")
-	if referencesGitHubTokenSecret {
-		secrets = slices.DeleteFunc(secrets, func(name string) bool { return name == "GITHUB_TOKEN" })
-	}
+	referencesGitHubTokenSecret := len(tokenAliases) != 0
+	tokenAliases = slices.DeleteFunc(tokenAliases, func(name string) bool { return name == "GITHUB_TOKEN" })
 	if !referencesGitHubTokenSecret && !referencesGitHubToken && !actions.requiresGitHubToken {
-		return secrets, nil, nil
+		return secrets, mappings, nil, nil
 	}
 	policyWorkflow := b.ir.Workflow.WorkflowTokenPolicyFilename
 	if policyWorkflow == "" {
@@ -609,16 +607,16 @@ func (b planBuilder) authorizePlanSecrets(instance JobInstance, actions *builtPl
 		} else if referencesGitHubToken {
 			reference = "github.token"
 		}
-		return nil, nil, fmt.Errorf("%s:%d:%d: job %q references %s but has no effective permissions", instance.SourcePath, instance.Source.Start.Line, instance.Source.Start.Column, instance.LogicalJobID, reference)
+		return nil, nil, nil, fmt.Errorf("%s:%d:%d: job %q references %s but has no effective permissions", instance.SourcePath, instance.Source.Start.Line, instance.Source.Start.Column, instance.LogicalJobID, reference)
 	}
 	actions.capabilities = append(actions.capabilities, "provider-token-write")
 	actions.authorization.ProviderTokenWriteCapabilitySources = []string{"effective-permissions"}
 	actions.authorization.WorkflowTokenPolicyFilename = b.ir.Workflow.WorkflowTokenPolicyFilename
 	actions.authorization.GitHubTokenSecretReference = referencesGitHubTokenSecret
-	return secrets, &plan.GitHubToken{Workflow: policyWorkflow, Permissions: cloneMap(b.ir.Workflow.WorkflowTokenPermissions)}, nil
+	return secrets, mappings, &plan.GitHubToken{Workflow: policyWorkflow, Permissions: cloneMap(b.ir.Workflow.WorkflowTokenPermissions), Aliases: tokenAliases}, nil
 }
 
-func (b planBuilder) lowerPlanJob(instance JobInstance, runtimeDistributionDigest string, steps []plan.Step, actions builtPlanActions, needSources map[string][]plan.NeedSource, needOutputs map[string][]plan.NeedOutput, deferredInputs map[string]plan.DeferredInput, callGuards []plan.CallGuard, secrets []string, githubToken *plan.GitHubToken) plan.Job {
+func (b planBuilder) lowerPlanJob(instance JobInstance, runtimeDistributionDigest string, steps []plan.Step, actions builtPlanActions, needSources map[string][]plan.NeedSource, needOutputs map[string][]plan.NeedOutput, deferredInputs map[string]plan.DeferredInput, callGuards []plan.CallGuard, secrets []string, secretMappings map[string]string, githubToken *plan.GitHubToken) plan.Job {
 	job := plan.Job{
 		Schema: plan.Schema,
 		Compiler: plan.Compiler{
@@ -640,6 +638,7 @@ func (b planBuilder) lowerPlanJob(instance JobInstance, runtimeDistributionDiges
 		Target:                  plan.Target{StepKey: instance.Key, Queue: instance.Queue},
 		RequiredCapabilities:    actions.capabilities,
 		RequiredSecrets:         secrets,
+		SecretMappings:          secretMappings,
 		GitHubToken:             githubToken,
 		IDTokenPermission:       instance.Permissions["id-token"],
 		OIDC:                    cloneOIDCConfiguration(b.options.OIDC),
@@ -704,7 +703,7 @@ func planConstructionFinding(instance JobInstance, err error) error {
 	}
 }
 
-func requiredSecrets(instance JobInstance, actionRequired []string, actionInputsInspected bool) ([]string, bool, error) {
+func requiredSecrets(instance JobInstance, actionRequired []string, actionInputsInspected bool) ([]string, map[string]string, []string, bool, error) {
 	found := map[string]string{}
 	referencesGitHubToken := false
 	collect := func(value string, stepRuntime bool) error {
@@ -761,31 +760,31 @@ func requiredSecrets(instance JobInstance, actionRequired []string, actionInputs
 		return nil
 	}
 	if err := checkCondition(instance.If); err != nil {
-		return nil, false, err
+		return nil, nil, nil, false, err
 	}
 	for _, value := range []string{instance.DefaultShell, instance.DefaultWorkingDirectory} {
 		if err := collect(value, false); err != nil {
-			return nil, false, err
+			return nil, nil, nil, false, err
 		}
 	}
 	for _, values := range []map[string]string{instance.Env, instance.Outputs} {
 		for _, name := range sortedValueKeys(values) {
 			if err := collect(values[name], false); err != nil {
-				return nil, false, err
+				return nil, nil, nil, false, err
 			}
 		}
 	}
 	for _, step := range instance.Steps {
 		if err := checkCondition(step.If); err != nil {
-			return nil, false, err
+			return nil, nil, nil, false, err
 		}
 		for _, value := range []string{step.Name, step.Run, step.Shell, step.WorkingDirectory, step.ContinueOnErrorExpression, step.TimeoutMinutesExpression} {
 			if err := collect(value, true); err != nil {
-				return nil, false, err
+				return nil, nil, nil, false, err
 			}
 		}
 		if err := collect(step.Uses, false); err != nil {
-			return nil, false, err
+			return nil, nil, nil, false, err
 		}
 		valuesToInspect := []map[string]string{step.Env}
 		if step.Kind != "uses" || !actionInputsInspected {
@@ -794,7 +793,7 @@ func requiredSecrets(instance JobInstance, actionRequired []string, actionInputs
 		for _, values := range valuesToInspect {
 			for _, name := range sortedValueKeys(values) {
 				if err := collect(values[name], true); err != nil {
-					return nil, false, err
+					return nil, nil, nil, false, err
 				}
 			}
 		}
@@ -802,51 +801,65 @@ func requiredSecrets(instance JobInstance, actionRequired []string, actionInputs
 	if instance.Container != nil {
 		for _, value := range append([]string{instance.Container.Image}, instance.Container.Ports...) {
 			if err := collect(value, false); err != nil {
-				return nil, false, err
+				return nil, nil, nil, false, err
 			}
 		}
 		for _, name := range sortedValueKeys(instance.Container.Env) {
 			if err := collect(instance.Container.Env[name], false); err != nil {
-				return nil, false, err
+				return nil, nil, nil, false, err
 			}
 		}
 	}
 	for _, service := range instance.Services {
 		for _, value := range append([]string{service.Container.Image}, service.Container.Ports...) {
 			if err := collect(value, false); err != nil {
-				return nil, false, err
+				return nil, nil, nil, false, err
 			}
 		}
 		for _, name := range sortedValueKeys(service.Container.Env) {
 			if err := collect(service.Container.Env[name], false); err != nil {
-				return nil, false, err
+				return nil, nil, nil, false, err
 			}
 		}
 		if service.Container.Credentials != nil {
 			if err := collect(service.Container.Credentials.Username, false); err != nil {
-				return nil, false, err
+				return nil, nil, nil, false, err
 			}
 			if err := collect(service.Container.Credentials.Password, false); err != nil {
-				return nil, false, err
+				return nil, nil, nil, false, err
 			}
 		}
 	}
 	for _, name := range actionRequired {
 		found[name] = name
 	}
-	if !instance.secretAuthority {
-		for name := range found {
-			if name != "GITHUB_TOKEN" {
-				delete(found, name)
-			}
+	sources := make(map[string]struct{}, len(found))
+	mappings := map[string]string{}
+	var tokenAliases []string
+	for alias := range found {
+		if alias == "GITHUB_TOKEN" {
+			tokenAliases = append(tokenAliases, alias)
+			continue
+		}
+		binding, ok := instance.secretAuthority.resolve(alias)
+		if !ok {
+			continue
+		}
+		if binding.token {
+			tokenAliases = append(tokenAliases, alias)
+			continue
+		}
+		sources[binding.source] = struct{}{}
+		if !instance.secretAuthority.unrestricted {
+			mappings[alias] = binding.source
 		}
 	}
-	names := make([]string, 0, len(found))
-	for name := range found {
-		names = append(names, name)
+	names := sortedKeys(sources)
+	sort.Strings(tokenAliases)
+	if len(mappings) == 0 {
+		mappings = nil
 	}
-	sort.Strings(names)
-	return names, referencesGitHubToken, nil
+	return names, mappings, tokenAliases, referencesGitHubToken, nil
 }
 
 func planSpan(span workflow.Span) plan.Span {

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -35,12 +35,22 @@ type sourcedJob struct {
 	root                  string
 	remote                *RemoteWorkflowSource
 	inputs                reusableInputs
-	secretAuthority       bool
+	secretAuthority       secretAuthority
 	needBindings          map[string]needBinding
 	tokenPolicyNarrowed   bool
 	jobPermissionsIgnored bool
 	reusableCall          workflow.Position
 	callGuards            []sourcedCallGuard
+}
+
+type secretAuthority struct {
+	unrestricted bool
+	bindings     map[string]secretBinding
+}
+
+type secretBinding struct {
+	source string
+	token  bool
 }
 
 type sourcedCallGuard struct {
@@ -118,7 +128,7 @@ func resolveReusableWorkflows(ctx context.Context, path string, source []byte, p
 			for _, need := range job.Needs {
 				bindings[need] = needBinding{members: []string{need}}
 			}
-			jobs[i] = sourcedJob{Job: job, path: sourcePath, digest: digest, root: root, inputs: reusableInputs{values: cloneAnyMap(context.Inputs)}, secretAuthority: true, needBindings: bindings}
+			jobs[i] = sourcedJob{Job: job, path: sourcePath, digest: digest, root: root, inputs: reusableInputs{values: cloneAnyMap(context.Inputs)}, secretAuthority: secretAuthority{unrestricted: true}, needBindings: bindings}
 			workflowJobs[job.ID] = job
 			replacements[job.ID] = needBinding{members: []string{job.ID}}
 		}
@@ -142,7 +152,7 @@ func resolveReusableWorkflows(ctx context.Context, path string, source []byte, p
 		}
 	}()
 	resolver.discoverRuntimeMatrixBoundaries(ctx, rootSource, parsed, 0, map[string]int{rootSource.identity.key(): 0})
-	resolution, err := resolver.resolve(ctx, rootSource, digest, parsed, "", "", reusableInputs{values: context.Inputs}, nil, nil, true, false, workflow.Position{}, nil, 0)
+	resolution, err := resolver.resolve(ctx, rootSource, digest, parsed, "", "", reusableInputs{values: context.Inputs}, nil, nil, secretAuthority{unrestricted: true}, false, workflow.Position{}, nil, 0)
 	return resolution.jobs, resolver.runtimeMatrixBoundary, err
 }
 
@@ -192,7 +202,7 @@ func (resolver *reusableResolver) discoverRuntimeMatrixBoundaries(ctx context.Co
 	}
 }
 
-func (resolver *reusableResolver) resolve(ctx context.Context, current reusableWorkflowSource, digest string, parsed *workflow.Workflow, namespace, labelPrefix string, inputs reusableInputs, externalNeeds map[string]needBinding, permissionCeiling *workflow.Permissions, secretAuthority, tokenPolicyNarrowed bool, reusableCallPosition workflow.Position, callGuards []sourcedCallGuard, depth int) (reusableResolution, error) {
+func (resolver *reusableResolver) resolve(ctx context.Context, current reusableWorkflowSource, digest string, parsed *workflow.Workflow, namespace, labelPrefix string, inputs reusableInputs, externalNeeds map[string]needBinding, permissionCeiling *workflow.Permissions, secrets secretAuthority, tokenPolicyNarrowed bool, reusableCallPosition workflow.Position, callGuards []sourcedCallGuard, depth int) (reusableResolution, error) {
 	path := current.displayPath
 	resolver.runtimeMatrixBoundary = resolver.runtimeMatrixBoundary || hasRuntimeMatrixBoundary(parsed)
 	jobs := make(map[string]workflow.Job, len(parsed.Jobs))
@@ -262,7 +272,7 @@ func (resolver *reusableResolver) resolve(ctx context.Context, current reusableW
 			}
 			resolved = append(resolved, sourcedJob{
 				Job: job, path: path, digest: digest, root: resolver.workspaceRoot, remote: cloneRemoteWorkflowSource(current.remote), inputs: cloneReusableInputs(inputs),
-				secretAuthority: secretAuthority, needBindings: needBindings,
+				secretAuthority: cloneSecretAuthority(secrets), needBindings: needBindings,
 				tokenPolicyNarrowed: jobTokenPolicyNarrowed, jobPermissionsIgnored: jobPermissionsIgnored, reusableCall: reusableCallPosition,
 				callGuards: cloneSourcedCallGuards(callGuards),
 			})
@@ -291,9 +301,6 @@ func (resolver *reusableResolver) resolve(ctx context.Context, current reusableW
 				condition: condition, inputs: cloneReusableInputs(inputs), needBindings: cloneNeedBindings(callNeedBindings),
 			})
 		}
-		if call.Secrets {
-			return reusableResolution{}, locatedJobError(path, job, call.Span.Start.Line, call.Span.Start.Column, "reusable-workflow secret forwarding is unsupported")
-		}
 		if depth >= MaxReusableWorkflowDepth {
 			return reusableResolution{}, locatedJobError(path, job, call.Span.Start.Line, call.Span.Start.Column, fmt.Sprintf("reusable-workflow nesting exceeds maximum depth %d", MaxReusableWorkflowDepth))
 		}
@@ -301,8 +308,8 @@ func (resolver *reusableResolver) resolve(ctx context.Context, current reusableW
 		if err != nil {
 			return reusableResolution{}, locatedJobWrappedError(path, job, call.Span.Start.Line, call.Span.Start.Column, "", err)
 		}
-		if call.InheritSecrets && calleeSource.identity.kind != "workspace" {
-			return reusableResolution{}, locatedJobError(path, job, call.Span.Start.Line, call.Span.Start.Column, "secrets: inherit is supported only for repository-local reusable workflows")
+		if (call.InheritSecrets || len(call.Secrets) != 0) && calleeSource.identity.kind != "workspace" {
+			return reusableResolution{}, locatedJobError(path, job, call.Span.Start.Line, call.Span.Start.Column, "secret forwarding is supported only for repository-local reusable workflows")
 		}
 		if cycle := resolver.cycle(calleeSource); cycle != "" {
 			return reusableResolution{}, locatedJobError(path, job, call.Span.Start.Line, call.Span.Start.Column, "reusable-workflow cycle detected: "+cycle)
@@ -315,8 +322,9 @@ func (resolver *reusableResolver) resolve(ctx context.Context, current reusableW
 		if !callee.Callable {
 			return reusableResolution{}, locatedJobError(path, job, call.Span.Start.Line, call.Span.Start.Column, fmt.Sprintf("reusable workflow %q does not declare on.workflow_call", call.Uses))
 		}
-		if len(callee.RequiredCallSecrets) != 0 {
-			return reusableResolution{}, locatedJobError(path, job, call.Span.Start.Line, call.Span.Start.Column, fmt.Sprintf("reusable workflow %q requires unsupported secret %q", call.Uses, callee.RequiredCallSecrets[0]))
+		calleeSecrets, err := resolveCallSecretAuthority(path, job, call, callee, secrets)
+		if err != nil {
+			return reusableResolution{}, err
 		}
 		if callee.Concurrency != nil {
 			return reusableResolution{}, fmt.Errorf("%s:%d:%d: workflow concurrency in a called reusable workflow is unsupported", calleeSource.displayPath, callee.Concurrency.Span.Start.Line, callee.Concurrency.Span.Start.Column)
@@ -368,7 +376,7 @@ func (resolver *reusableResolver) resolve(ctx context.Context, current reusableW
 				calleeCallPosition = call.Span.Start
 			}
 			resolver.stack = append(resolver.stack, calleeSource.identity)
-			calleeResolution, err := resolver.resolve(ctx, calleeSource, calleeDigest, callee, callNamespace, callLabel, callInputs, needBindings, calleePermissionCeiling, secretAuthority && call.InheritSecrets, jobTokenPolicyNarrowed, calleeCallPosition, calleeGuards, depth+1)
+			calleeResolution, err := resolver.resolve(ctx, calleeSource, calleeDigest, callee, callNamespace, callLabel, callInputs, needBindings, calleePermissionCeiling, calleeSecrets, jobTokenPolicyNarrowed, calleeCallPosition, calleeGuards, depth+1)
 			resolver.stack = resolver.stack[:len(resolver.stack)-1]
 			if err != nil {
 				message := "reusable workflow could not be resolved"
@@ -406,6 +414,69 @@ func (resolver *reusableResolver) resolve(ctx context.Context, current reusableW
 		return reusableResolution{}, err
 	}
 	return reusableResolution{jobs: resolved, outputs: outputs}, nil
+}
+
+func resolveCallSecretAuthority(path string, job workflow.Job, call *workflow.ReusableWorkflowCall, callee *workflow.Workflow, parent secretAuthority) (secretAuthority, error) {
+	if call.InheritSecrets {
+		for _, name := range sortedValueKeys(callee.CallSecrets) {
+			declaration := callee.CallSecrets[name]
+			if declaration.Required && !parent.has(name) {
+				return secretAuthority{}, locatedJobError(path, job, call.Span.Start.Line, call.Span.Start.Column, fmt.Sprintf("reusable workflow %q requires secret %q", call.Uses, declaration.Name))
+			}
+		}
+		return cloneSecretAuthority(parent), nil
+	}
+
+	forwarded := secretAuthority{bindings: make(map[string]secretBinding, len(call.Secrets))}
+	for _, target := range sortedValueKeys(call.Secrets) {
+		mapping := call.Secrets[target]
+		_, declared := callee.CallSecrets[target]
+		if !declared {
+			return secretAuthority{}, locatedJobError(path, job, mapping.Span.Start.Line, mapping.Span.Start.Column, fmt.Sprintf("secret mapping target %q is not declared by reusable workflow %q", mapping.Target, call.Uses))
+		}
+		if target == "GITHUB_TOKEN" {
+			return secretAuthority{}, locatedJobError(path, job, mapping.Span.Start.Line, mapping.Span.Start.Column, "GITHUB_TOKEN cannot be an explicit secret mapping target")
+		}
+		if mapping.Source == "GITHUB_TOKEN" {
+			forwarded.bindings[target] = secretBinding{source: "GITHUB_TOKEN", token: true}
+			continue
+		}
+		if binding, ok := parent.resolve(mapping.Source); ok {
+			forwarded.bindings[target] = binding
+		}
+	}
+	for _, name := range sortedValueKeys(callee.CallSecrets) {
+		declaration := callee.CallSecrets[name]
+		if declaration.Required && !forwarded.has(name) {
+			return secretAuthority{}, locatedJobError(path, job, call.Span.Start.Line, call.Span.Start.Column, fmt.Sprintf("reusable workflow %q requires secret %q", call.Uses, declaration.Name))
+		}
+	}
+	return forwarded, nil
+}
+
+func (authority secretAuthority) resolve(alias string) (secretBinding, bool) {
+	alias = strings.ToUpper(alias)
+	if authority.unrestricted {
+		return secretBinding{source: alias}, true
+	}
+	binding, ok := authority.bindings[alias]
+	return binding, ok
+}
+
+func (authority secretAuthority) has(alias string) bool {
+	_, ok := authority.resolve(alias)
+	return ok
+}
+
+func cloneSecretAuthority(authority secretAuthority) secretAuthority {
+	cloned := secretAuthority{unrestricted: authority.unrestricted}
+	if authority.bindings != nil {
+		cloned.bindings = make(map[string]secretBinding, len(authority.bindings))
+		for alias, binding := range authority.bindings {
+			cloned.bindings[alias] = binding
+		}
+	}
+	return cloned
 }
 
 func effectivePermissions(job, workflowDefault, ceiling *workflow.Permissions, bounded bool) *workflow.Permissions {

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -432,7 +432,7 @@ func resolveCallSecretAuthority(path string, job workflow.Job, call *workflow.Re
 		mapping := call.Secrets[target]
 		_, declared := callee.CallSecrets[target]
 		if !declared {
-			return secretAuthority{}, locatedJobError(path, job, mapping.Span.Start.Line, mapping.Span.Start.Column, fmt.Sprintf("secret mapping target %q is not declared by reusable workflow %q", mapping.Target, call.Uses))
+			return secretAuthority{}, locatedJobError(path, job, mapping.Span.Start.Line, mapping.Span.Start.Column, fmt.Sprintf("secret mapping target %q is not declared by reusable workflow %q", target, call.Uses))
 		}
 		if target == "GITHUB_TOKEN" {
 			return secretAuthority{}, locatedJobError(path, job, mapping.Span.Start.Line, mapping.Span.Start.Column, "GITHUB_TOKEN cannot be an explicit secret mapping target")

--- a/internal/compiler/reusable_remote_test.go
+++ b/internal/compiler/reusable_remote_test.go
@@ -152,6 +152,11 @@ func TestCompileRejectsSecretInheritanceIntoRemoteReusableWorkflows(t *testing.T
 			remote: "on: workflow_call\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
 		},
 		{
+			name:   "explicit remote call",
+			caller: "on: push\njobs:\n  call:\n    uses: owner/workflows/.github/workflows/ci.yml@v1\n    secrets:\n      token: ${{ secrets.SOURCE }}\n",
+			remote: "on:\n  workflow_call:\n    secrets:\n      token:\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
+		},
+		{
 			name:   "local path within remote repository",
 			caller: "on: push\njobs:\n  call:\n    uses: owner/workflows/.github/workflows/ci.yml@v1\n",
 			remote: "on: workflow_call\njobs:\n  nested:\n    uses: ./.github/workflows/nested.yml\n    secrets: inherit\n",
@@ -166,7 +171,7 @@ func TestCompileRejectsSecretInheritanceIntoRemoteReusableWorkflows(t *testing.T
 			options := defaultOptions()
 			options.RepositorySource = MemoizeRepositorySource(newFakeReusableRepositorySource(t, map[string]string{"owner/workflows": remoteRoot}))
 			_, err := CompileWithOptions(callerPath, readFile(t, callerPath), pushEvent(t), options)
-			if err == nil || !strings.Contains(err.Error(), "secrets: inherit is supported only for repository-local reusable workflows") {
+			if err == nil || !strings.Contains(err.Error(), "secret forwarding is supported only for repository-local reusable workflows") {
 				t.Fatalf("CompileWithOptions() error = %v, want remote inheritance rejection", err)
 			}
 		})

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -53,6 +53,24 @@ func TestReferencePathOwnsOnlyOneStaticReference(t *testing.T) {
 	}
 }
 
+func TestDirectSecretReferenceAcceptsOnlyOneStaticSecret(t *testing.T) {
+	for _, source := range []string{"${{ secrets.SOURCE }}", "${{ secrets['source'] }}"} {
+		name, err := DirectSecretReference(source)
+		if err != nil || name != "SOURCE" {
+			t.Fatalf("DirectSecretReference(%q) = %q, %v", source, name, err)
+		}
+	}
+	for _, source := range []string{
+		"literal", "${{ secrets.SOURCE }}-suffix", "${{ secrets[inputs.name] }}",
+		"${{ needs.build.outputs.secret }}", "${{ vars.SECRET }}", "${{ env.SECRET }}",
+		"${{ inputs.secret }}", "${{ github.token }}", "${{ secrets.SOURCE || secrets.OTHER }}",
+	} {
+		if _, err := DirectSecretReference(source); err == nil {
+			t.Fatalf("DirectSecretReference(%q) succeeded", source)
+		}
+	}
+}
+
 func TestRuntimeMatrixOutputAcceptsOnlyExactDirectNeedOutput(t *testing.T) {
 	for _, source := range []string{
 		"${{ fromJSON(needs.build_django_matrix.outputs.include) }}",

--- a/internal/expression/references.go
+++ b/internal/expression/references.go
@@ -32,6 +32,16 @@ func ReferencePath(text string) (string, []string, error) {
 	return referencePath(node)
 }
 
+// DirectSecretReference accepts exactly one direct dot or literal-bracket
+// secret expression, such as ${{ secrets.NAME }} or ${{ secrets['NAME'] }}.
+func DirectSecretReference(text string) (string, error) {
+	root, path, err := ReferencePath(text)
+	if err != nil || !strings.EqualFold(root, "secrets") || len(path) != 1 {
+		return "", fmt.Errorf("secret mapping must be exactly ${{ secrets.NAME }} or ${{ secrets['NAME'] }}")
+	}
+	return strings.ToUpper(path[0]), nil
+}
+
 // RuntimeMatrixOutput accepts only the complete runtime matrix expression
 // fromJSON(needs.<job>.outputs.<name>). Dot access is required so the source
 // cannot hide dynamic indexes or compose the producer output with other data.

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -608,7 +608,7 @@ func (job Job) Validate() error {
 		if !secretNamePattern.MatchString(name) || i > 0 && job.RequiredSecrets[i-1] == name {
 			return fmt.Errorf("job plan contains invalid or repeated required secret %q", name)
 		}
-		if name == "GITHUB_TOKEN" {
+		if strings.EqualFold(name, "GITHUB_TOKEN") {
 			return fmt.Errorf("job plan must provide GITHUB_TOKEN through the scoped workflow token contract")
 		}
 		normalized := strings.ToUpper(name)

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -287,6 +287,7 @@ type DeferredInput struct {
 type GitHubToken struct {
 	Workflow    string            `json:"workflow"`
 	Permissions map[string]string `json:"permissions"`
+	Aliases     []string          `json:"aliases,omitempty"`
 }
 
 // OIDCConfiguration applies additional Buildkite claims to every OIDC token
@@ -307,6 +308,7 @@ type Job struct {
 	Target               Target                   `json:"target"`
 	RequiredCapabilities []string                 `json:"required_capabilities"`
 	RequiredSecrets      []string                 `json:"required_secrets,omitempty"`
+	SecretMappings       map[string]string        `json:"secret_mappings,omitempty"`
 	GitHubToken          *GitHubToken             `json:"github_token,omitempty"`
 	IDTokenPermission    string                   `json:"id_token_permission,omitempty"`
 	OIDC                 *OIDCConfiguration       `json:"oidc,omitempty"`
@@ -532,8 +534,8 @@ func (job Job) Validate() error {
 	if job.TimeoutMinutes < 0 || job.TimeoutMinutes > 360 {
 		return fmt.Errorf("job timeout_minutes must be between 0 and 360")
 	}
-	if len(job.Condition) > 65536 || len(job.RequiredSecrets) > 128 {
-		return fmt.Errorf("job plan condition or required secrets exceed their size limit")
+	if len(job.Condition) > 65536 || len(job.RequiredSecrets) > 128 || len(job.SecretMappings) > 128 {
+		return fmt.Errorf("job plan condition, required secrets, or secret mappings exceed their size limit")
 	}
 	if err := validateInputs(job.Inputs); err != nil {
 		return err
@@ -601,6 +603,7 @@ func (job Job) Validate() error {
 	if !sort.StringsAreSorted(job.RequiredSecrets) {
 		return fmt.Errorf("job plan required secrets must be sorted")
 	}
+	seenRequiredSecrets := make(map[string]struct{}, len(job.RequiredSecrets))
 	for i, name := range job.RequiredSecrets {
 		if !secretNamePattern.MatchString(name) || i > 0 && job.RequiredSecrets[i-1] == name {
 			return fmt.Errorf("job plan contains invalid or repeated required secret %q", name)
@@ -608,10 +611,41 @@ func (job Job) Validate() error {
 		if name == "GITHUB_TOKEN" {
 			return fmt.Errorf("job plan must provide GITHUB_TOKEN through the scoped workflow token contract")
 		}
+		normalized := strings.ToUpper(name)
+		if _, exists := seenRequiredSecrets[normalized]; exists {
+			return fmt.Errorf("job plan repeats case-insensitive required secret %q", name)
+		}
+		seenRequiredSecrets[normalized] = struct{}{}
 	}
 	if len(job.RequiredSecrets) != 0 {
 		if _, ok := capabilities["secrets"]; !ok {
 			return fmt.Errorf("job plan required secrets need the secrets capability")
+		}
+	}
+	requiredSecrets := make(map[string]struct{}, len(job.RequiredSecrets))
+	ordinaryAliases := make(map[string]struct{}, max(len(job.RequiredSecrets), len(job.SecretMappings)))
+	for _, name := range job.RequiredSecrets {
+		requiredSecrets[name] = struct{}{}
+		if len(job.SecretMappings) == 0 {
+			ordinaryAliases[strings.ToUpper(name)] = struct{}{}
+		}
+	}
+	for alias, source := range job.SecretMappings {
+		if !secretNamePattern.MatchString(alias) || strings.EqualFold(alias, "GITHUB_TOKEN") || !secretNamePattern.MatchString(source) {
+			return fmt.Errorf("job plan contains invalid secret mapping %q to %q", alias, source)
+		}
+		if _, ok := requiredSecrets[source]; !ok {
+			return fmt.Errorf("job plan secret mapping %q references undeclared source %q", alias, source)
+		}
+		normalized := strings.ToUpper(alias)
+		if _, exists := ordinaryAliases[normalized]; exists {
+			return fmt.Errorf("job plan repeats case-insensitive secret alias %q", alias)
+		}
+		ordinaryAliases[normalized] = struct{}{}
+	}
+	if len(job.SecretMappings) != 0 {
+		if _, ok := capabilities["secrets"]; !ok {
+			return fmt.Errorf("job plan secret mappings need the secrets capability")
 		}
 	}
 	_, workflowTokenCapability := capabilities["provider-token-write"]
@@ -627,6 +661,17 @@ func (job Job) Validate() error {
 		}
 		if err := validateGitHubTokenPermissions(job.GitHubToken.Permissions); err != nil {
 			return err
+		}
+		if !sort.StringsAreSorted(job.GitHubToken.Aliases) {
+			return fmt.Errorf("job plan GitHub token aliases must be sorted")
+		}
+		for i, alias := range job.GitHubToken.Aliases {
+			if !secretNamePattern.MatchString(alias) || strings.EqualFold(alias, "GITHUB_TOKEN") || i > 0 && strings.EqualFold(job.GitHubToken.Aliases[i-1], alias) {
+				return fmt.Errorf("job plan contains invalid or repeated GitHub token alias %q", alias)
+			}
+			if _, exists := ordinaryAliases[strings.ToUpper(alias)]; exists {
+				return fmt.Errorf("job plan GitHub token alias %q overlaps ordinary secret authority", alias)
+			}
 		}
 	}
 	if job.IDTokenPermission != "" && job.IDTokenPermission != "read" && job.IDTokenPermission != "write" {

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -1088,7 +1088,7 @@ func TestGitHubWorkflowTokenContractAndSchema(t *testing.T) {
 		}, want: "overlaps ordinary secret authority"},
 		{name: "reserved ambient secret", edit: func(j *Job) {
 			j.RequiredCapabilities = []string{"provider-token-write", "secrets"}
-			j.RequiredSecrets = []string{"GITHUB_TOKEN"}
+			j.RequiredSecrets = []string{"github_token"}
 		}, want: "scoped workflow token contract"},
 		{name: "other provider", edit: func(j *Job) { j.Event.Provider = "cursor-origin" }, want: "valid github.com event repository"},
 	} {

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -2,6 +2,7 @@ package plan
 
 import (
 	"encoding/json"
+	"maps"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -433,6 +434,44 @@ func TestRequiredSecretsRoundTripAsNamesOnly(t *testing.T) {
 	}
 	if !slices.Equal(decoded.RequiredSecrets, job.RequiredSecrets) {
 		t.Fatalf("required secrets = %#v", decoded.RequiredSecrets)
+	}
+}
+
+func TestSecretMappingsRoundTripAsNamesOnlyAndValidateAuthority(t *testing.T) {
+	job := validJob()
+	job.RequiredCapabilities = []string{"secrets"}
+	job.RequiredSecrets = []string{"ORIGINAL"}
+	job.SecretMappings = map[string]string{"ALIAS": "ORIGINAL"}
+	encoded, err := Encode(job)
+	if err != nil {
+		t.Fatal(err)
+	}
+	validateJobPlanSchema(t, encoded)
+	if !strings.Contains(string(encoded), `"secret_mappings"`) || !strings.Contains(string(encoded), `"ALIAS": "ORIGINAL"`) || strings.Contains(string(encoded), "secret-value") {
+		t.Fatalf("Encode() = %s", encoded)
+	}
+	decoded, err := Decode(encoded)
+	if err != nil || !reflect.DeepEqual(decoded.SecretMappings, job.SecretMappings) {
+		t.Fatalf("Decode() mappings = %#v, error = %v", decoded.SecretMappings, err)
+	}
+	for _, test := range []struct {
+		name string
+		edit func(*Job)
+		want string
+	}{
+		{name: "missing source", edit: func(j *Job) { j.SecretMappings["ALIAS"] = "OTHER" }, want: "undeclared source"},
+		{name: "reserved alias", edit: func(j *Job) { j.SecretMappings = map[string]string{"GITHUB_TOKEN": "ORIGINAL"} }, want: "invalid secret mapping"},
+		{name: "missing capability", edit: func(j *Job) { j.RequiredCapabilities = nil }, want: "secrets capability"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			changed := job
+			changed.RequiredCapabilities = append([]string(nil), job.RequiredCapabilities...)
+			changed.SecretMappings = maps.Clone(job.SecretMappings)
+			test.edit(&changed)
+			if err := changed.Validate(); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Validate() error = %v", err)
+			}
+		})
 	}
 }
 
@@ -985,7 +1024,7 @@ func TestGitHubWorkflowTokenContractAndSchema(t *testing.T) {
 	job := validJob()
 	job.Event.Repository = "buildkite/buildkite-gha"
 	job.RequiredCapabilities = []string{"provider-token-write"}
-	job.GitHubToken = &GitHubToken{Workflow: "ci.yml", Permissions: map[string]string{"contents": "read", "pull_requests": "write"}}
+	job.GitHubToken = &GitHubToken{Workflow: "ci.yml", Permissions: map[string]string{"contents": "read", "pull_requests": "write"}, Aliases: []string{"TOKEN_ALIAS"}}
 	encoded, err := Encode(job)
 	if err != nil {
 		t.Fatal(err)
@@ -1041,6 +1080,12 @@ func TestGitHubWorkflowTokenContractAndSchema(t *testing.T) {
 		{name: "missing workflow", edit: func(j *Job) { j.GitHubToken.Workflow = "" }, want: "simple .yml or .yaml filename"},
 		{name: "unknown permission", edit: func(j *Job) { j.GitHubToken.Permissions = map[string]string{"administration": "write"} }, want: "unsupported permission"},
 		{name: "invalid access", edit: func(j *Job) { j.GitHubToken.Permissions = map[string]string{"contents": "admin"} }, want: "unsupported permission"},
+		{name: "reserved alias", edit: func(j *Job) { j.GitHubToken.Aliases = []string{"GITHUB_TOKEN"} }, want: "invalid or repeated GitHub token alias"},
+		{name: "unsorted aliases", edit: func(j *Job) { j.GitHubToken.Aliases = []string{"Z_TOKEN", "A_TOKEN"} }, want: "aliases must be sorted"},
+		{name: "ordinary alias overlap", edit: func(j *Job) {
+			j.RequiredCapabilities = []string{"provider-token-write", "secrets"}
+			j.RequiredSecrets = []string{"TOKEN_ALIAS"}
+		}, want: "overlaps ordinary secret authority"},
 		{name: "reserved ambient secret", edit: func(j *Job) {
 			j.RequiredCapabilities = []string{"provider-token-write", "secrets"}
 			j.RequiredSecrets = []string{"GITHUB_TOKEN"}
@@ -1055,7 +1100,7 @@ func TestGitHubWorkflowTokenContractAndSchema(t *testing.T) {
 			for name, access := range job.GitHubToken.Permissions {
 				permissions[name] = access
 			}
-			changed.GitHubToken = &GitHubToken{Workflow: job.GitHubToken.Workflow, Permissions: permissions}
+			changed.GitHubToken = &GitHubToken{Workflow: job.GitHubToken.Workflow, Permissions: permissions, Aliases: append([]string(nil), job.GitHubToken.Aliases...)}
 			test.edit(&changed)
 			if err := changed.Validate(); err == nil || !strings.Contains(err.Error(), test.want) {
 				t.Fatalf("Validate() error = %v, want %q", err, test.want)

--- a/internal/runtime/action_execution.go
+++ b/internal/runtime/action_execution.go
@@ -228,13 +228,24 @@ func (r *jobRun) prepare(ctx context.Context) (final JobResult, runJobErr error)
 	if err != nil {
 		return tolerateJobSetupFailure(runCtx, job, jobResult, err)
 	}
+	if len(job.SecretMappings) != 0 {
+		projected := make(map[string]string, len(job.SecretMappings))
+		for alias, source := range job.SecretMappings {
+			projected[alias] = secrets[source]
+		}
+		secrets = projected
+	}
 	if job.GitHubToken != nil {
 		if secrets == nil {
 			secrets = map[string]string{}
 		}
-		secrets["GITHUB_TOKEN"], err = r.resolveWorkflowToken(runCtx, processor, job.Event.Repository, job.GitHubToken.Workflow, job.GitHubToken.Permissions)
+		token, err := r.resolveWorkflowToken(runCtx, processor, job.Event.Repository, job.GitHubToken.Workflow, job.GitHubToken.Permissions)
 		if err != nil {
 			return tolerateJobSetupFailure(runCtx, job, jobResult, err)
+		}
+		secrets["GITHUB_TOKEN"] = token
+		for _, alias := range job.GitHubToken.Aliases {
+			secrets[alias] = token
 		}
 	}
 	eval.Secrets = secrets

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -42,6 +42,20 @@ func (s testSecretResolver) ResolveSecret(_ context.Context, name string) (strin
 	return value, nil
 }
 
+type countingSecretResolver struct {
+	values map[string]string
+	calls  map[string]int
+}
+
+func (s *countingSecretResolver) ResolveSecret(_ context.Context, name string) (string, error) {
+	s.calls[name]++
+	value, ok := s.values[name]
+	if !ok {
+		return "", fmt.Errorf("denied")
+	}
+	return value, nil
+}
+
 type testRedactor struct{ values []string }
 
 func (r *testRedactor) AddRedaction(_ context.Context, value string) error {
@@ -982,6 +996,34 @@ echo after-soft`},
 		t.Fatalf("RunJob() result = %#v, redactions = %#v", result, redactor.values)
 	}
 	if strings.Contains(logs.String(), "mask-me") || !strings.Contains(logs.String(), "secret=***") || !strings.Contains(logs.String(), "after-soft") {
+		t.Fatalf("RunJob() logs = %q", logs.String())
+	}
+}
+
+func TestRunJobResolvesOriginalSecretOnceAndProjectsAliases(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/aliases.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: aliases\n")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{
+		ID: "aliases", Kind: "run", Command: `test "${{ secrets.FIRST }}" = shared-value
+test "${{ secrets.SECOND }}" = shared-value
+test -z "${{ secrets.OPTIONAL }}"
+echo "first=${{ secrets.FIRST }} second=${{ secrets.SECOND }}"`,
+	}})
+	job.RequiredCapabilities = []string{"secrets"}
+	job.RequiredSecrets = []string{"ORIGINAL"}
+	job.SecretMappings = map[string]string{"FIRST": "ORIGINAL", "SECOND": "ORIGINAL"}
+	resolver := &countingSecretResolver{values: map[string]string{"ORIGINAL": "shared-value"}, calls: map[string]int{}}
+	redactor := &testRedactor{}
+	var logs bytes.Buffer
+	result, err := (Runner{Stdout: &logs, Stderr: &logs, Secrets: resolver, Redactor: redactor}).RunJob(t.Context(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v, logs = %q", result, err, logs.String())
+	}
+	if resolver.calls["ORIGINAL"] != 1 || len(resolver.calls) != 1 || !slices.Equal(redactor.values, []string{"shared-value"}) {
+		t.Fatalf("secret resolution calls = %#v, redactions = %#v", resolver.calls, redactor.values)
+	}
+	if strings.Contains(logs.String(), "shared-value") || !strings.Contains(logs.String(), "first=*** second=***") {
 		t.Fatalf("RunJob() logs = %q", logs.String())
 	}
 }
@@ -2805,13 +2847,15 @@ func TestRunJobMintsAndRedactsScopedGitHubWorkflowToken(t *testing.T) {
 	writeFixtureFile(t, workspace, workflowPath, "name: workflow token\n")
 	const token = "ghs_scoped_workflow_token"
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{
-		ID: "use-token", Kind: "run", Shell: "sh", Command: `test "$GH_TOKEN" = "ghs_scoped_workflow_token" && printf '%s\n' "$GH_TOKEN"`,
+		ID: "use-token", Kind: "run", Shell: "sh", Command: `test "$GH_TOKEN" = "ghs_scoped_workflow_token"
+test "$ALIAS_TOKEN" = "$GH_TOKEN"
+printf '%s %s\n' "$GH_TOKEN" "$ALIAS_TOKEN"`,
 	}})
 	job.Schema = plan.Schema
 	job.Event.Repository = "buildkite/buildkite-gha"
 	job.RequiredCapabilities = []string{"provider-token-write"}
-	job.GitHubToken = &plan.GitHubToken{Workflow: "caller.yml", Permissions: map[string]string{"contents": "read", "pull_requests": "write"}}
-	job.Env = map[string]string{"GH_TOKEN": "${{ secrets.GITHUB_TOKEN }}"}
+	job.GitHubToken = &plan.GitHubToken{Workflow: "caller.yml", Permissions: map[string]string{"contents": "read", "pull_requests": "write"}, Aliases: []string{"TOKEN_ALIAS"}}
+	job.Env = map[string]string{"GH_TOKEN": "${{ secrets.GITHUB_TOKEN }}", "ALIAS_TOKEN": "${{ secrets.TOKEN_ALIAS }}"}
 	provider := &testWorkflowTokenProvider{token: token}
 	redactor := &testRedactor{}
 	var logs bytes.Buffer

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -28,7 +28,7 @@ type Workflow struct {
 	DefaultWorkingDirectory string                `json:"default_working_directory,omitempty"`
 	CallInputs              map[string]CallInput  `json:"call_inputs,omitempty"`
 	CallOutputs             map[string]CallOutput `json:"call_outputs,omitempty"`
-	RequiredCallSecrets     []string              `json:"required_call_secrets,omitempty"`
+	CallSecrets             map[string]CallSecret `json:"call_secrets,omitempty"`
 	Callable                bool                  `json:"callable,omitempty"`
 	Jobs                    []Job                 `json:"jobs"`
 }
@@ -114,6 +114,14 @@ type CallOutput struct {
 	Span  Span   `json:"span"`
 }
 
+// CallSecret declares one secret accepted by workflow_call. Map keys are
+// case-normalized aliases; Name and Span retain the callee-owned declaration.
+type CallSecret struct {
+	Name     string `json:"name"`
+	Required bool   `json:"required,omitempty"`
+	Span     Span   `json:"span"`
+}
+
 // Job is one logical GitHub Actions job.
 type Job struct {
 	ID                      string                 `json:"id"`
@@ -177,11 +185,19 @@ type ContainerCredentials struct {
 
 // ReusableWorkflowCall is a job-level invocation of another workflow.
 type ReusableWorkflowCall struct {
-	Uses           string           `json:"uses"`
-	Inputs         map[string]Value `json:"inputs,omitempty"`
-	Secrets        bool             `json:"secrets,omitempty"`
-	InheritSecrets bool             `json:"inherit_secrets,omitempty"`
-	Span           Span             `json:"span"`
+	Uses           string                   `json:"uses"`
+	Inputs         map[string]Value         `json:"inputs,omitempty"`
+	Secrets        map[string]SecretMapping `json:"secrets,omitempty"`
+	InheritSecrets bool                     `json:"inherit_secrets,omitempty"`
+	Span           Span                     `json:"span"`
+}
+
+// SecretMapping binds one callee alias to a direct caller secret reference.
+// Both names are normalized for case-insensitive lookup; Span owns the source.
+type SecretMapping struct {
+	Target string `json:"target"`
+	Source string `json:"source"`
+	Span   Span   `json:"span"`
 }
 
 // Matrix retains either static rows or a deferred expression.

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -193,9 +193,8 @@ type ReusableWorkflowCall struct {
 }
 
 // SecretMapping binds one callee alias to a direct caller secret reference.
-// Both names are normalized for case-insensitive lookup; Span owns the source.
+// The source is normalized for case-insensitive lookup; Span owns the source.
 type SecretMapping struct {
-	Target string `json:"target"`
 	Source string `json:"source"`
 	Span   Span   `json:"span"`
 }

--- a/internal/workflow/parse.go
+++ b/internal/workflow/parse.go
@@ -170,11 +170,18 @@ func Parse(path string, source []byte) (*Workflow, error) {
 			if secret.Required != nil && secret.Required.Expression != nil {
 				return nil, locatedError(path, secret.Required.Expression.Pos, "workflow", fmt.Sprintf("expression-valued required flag for workflow_call secret %q is unsupported", name))
 			}
-			if secret.Required != nil && secret.Required.Value {
-				owned.RequiredCallSecrets = append(owned.RequiredCallSecrets, name)
+			if owned.CallSecrets == nil {
+				owned.CallSecrets = make(map[string]CallSecret, len(call.Secrets))
 			}
+			declaration := CallSecret{
+				Name: secret.Name.Value,
+				Span: spanFrom(secret.Name.Pos, secret.Name.Value),
+			}
+			if secret.Required != nil && secret.Required.Value {
+				declaration.Required = true
+			}
+			owned.CallSecrets[strings.ToUpper(name)] = declaration
 		}
-		sort.Strings(owned.RequiredCallSecrets)
 	}
 
 	ids := make([]string, 0, len(parsed.Jobs))
@@ -553,9 +560,23 @@ func adaptJob(path string, in *actionlint.Job, scalars map[Position]any, concurr
 		call := in.WorkflowCall
 		out.Reusable = &ReusableWorkflowCall{
 			Uses:           call.Uses.Value,
-			Secrets:        len(call.Secrets) != 0,
 			InheritSecrets: call.InheritSecrets,
 			Span:           spanFrom(call.Uses.Pos, call.Uses.Value),
+		}
+		if len(call.Secrets) != 0 {
+			out.Reusable.Secrets = make(map[string]SecretMapping, len(call.Secrets))
+			for name, secret := range call.Secrets {
+				source, err := expression.DirectSecretReference(secret.Value.Value)
+				if err != nil {
+					return Job{}, locatedError(path, secret.Value.Pos, fmt.Sprintf("job %q", in.ID.Value), fmt.Sprintf("secret mapping %q: %v", secret.Name.Value, err))
+				}
+				target := strings.ToUpper(name)
+				out.Reusable.Secrets[target] = SecretMapping{
+					Target: target,
+					Source: source,
+					Span:   spanFrom(secret.Value.Pos, secret.Value.Value),
+				}
+			}
 		}
 		if len(call.Inputs) != 0 {
 			out.Reusable.Inputs = make(map[string]Value, len(call.Inputs))

--- a/internal/workflow/parse.go
+++ b/internal/workflow/parse.go
@@ -572,7 +572,6 @@ func adaptJob(path string, in *actionlint.Job, scalars map[Position]any, concurr
 				}
 				target := strings.ToUpper(name)
 				out.Reusable.Secrets[target] = SecretMapping{
-					Target: target,
 					Source: source,
 					Span:   spanFrom(secret.Value.Pos, secret.Value.Value),
 				}

--- a/internal/workflow/parse_test.go
+++ b/internal/workflow/parse_test.go
@@ -47,6 +47,52 @@ func TestParseRetainsRunNameAndSourceSpan(t *testing.T) {
 	}
 }
 
+func TestParseOwnsReusableWorkflowSecretDeclarationsAndMappings(t *testing.T) {
+	source := []byte(`on:
+  workflow_call:
+    secrets:
+      Required_Token:
+        required: true
+      optional_token:
+jobs:
+  nested:
+    uses: ./.github/workflows/nested.yml
+    secrets:
+      target_token: ${{ secrets['SOURCE_TOKEN'] }}
+`)
+	parsed, err := Parse("reusable.yml", source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(parsed.CallSecrets) != 2 || !parsed.CallSecrets["REQUIRED_TOKEN"].Required || parsed.CallSecrets["REQUIRED_TOKEN"].Span.Start.Line != 4 {
+		t.Fatalf("call secret declarations = %#v", parsed.CallSecrets)
+	}
+	mapping := parsed.Jobs[0].Reusable.Secrets["TARGET_TOKEN"]
+	if mapping.Source != "SOURCE_TOKEN" || mapping.Span.Start.Line != 11 {
+		t.Fatalf("call secret mapping = %#v", mapping)
+	}
+}
+
+func TestParseRejectsUnsupportedReusableWorkflowSecretMappings(t *testing.T) {
+	for _, value := range []string{"literal", "${{ vars.SOURCE }}", "${{ secrets[inputs.name] }}", "${{ secrets.A }}-${{ secrets.B }}"} {
+		source := "on: push\njobs:\n  call:\n    uses: ./.github/workflows/reusable.yml\n    secrets:\n      target: " + value + "\n"
+		if _, err := Parse("caller.yml", []byte(source)); err == nil || !strings.Contains(err.Error(), "secret mapping") {
+			t.Fatalf("Parse(%q) error = %v", value, err)
+		}
+	}
+}
+
+func TestParseRejectsCaseCollidingReusableWorkflowSecretAliases(t *testing.T) {
+	for _, source := range []string{
+		"on:\n  workflow_call:\n    secrets:\n      TOKEN: {}\n      token: {}\njobs:\n  test: {runs-on: ubuntu-latest, steps: [{run: true}]}\n",
+		"on: push\njobs:\n  call:\n    uses: ./.github/workflows/reusable.yml\n    secrets:\n      TOKEN: ${{ secrets.A }}\n      token: ${{ secrets.B }}\n",
+	} {
+		if _, err := Parse("collision.yml", []byte(source)); err == nil {
+			t.Fatal("Parse() accepted case-colliding secret aliases")
+		}
+	}
+}
+
 func TestParsePreservesEnvironmentVariableCase(t *testing.T) {
 	source := []byte("on: push\nenv:\n  WorkflowValue: workflow\njobs:\n  build:\n    runs-on: ubuntu-latest\n    env:\n      JobValue: job\n    steps:\n      - run: true\n        env:\n          STEP_VALUE: step\n")
 	parsed, err := Parse("env.yml", source)

--- a/schemas/job-plan.schema.json
+++ b/schemas/job-plan.schema.json
@@ -14,6 +14,7 @@
     "target": {"$ref": "#/$defs/target"},
     "required_capabilities": {"type": "array", "uniqueItems": true, "maxItems": 16, "items": {"$ref": "#/$defs/capability"}},
     "required_secrets": {"type": "array", "uniqueItems": true, "maxItems": 128, "items": {"type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_]*$", "not": {"const": "GITHUB_TOKEN"}}},
+    "secret_mappings": {"type": "object", "maxProperties": 128, "propertyNames": {"pattern": "^[A-Za-z_][A-Za-z0-9_]*$", "not": {"const": "GITHUB_TOKEN"}}, "additionalProperties": {"type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"}},
     "github_token": {"$ref": "#/$defs/githubToken"},
     "id_token_permission": {"enum": ["read", "write"]},
     "oidc": {"$ref": "#/$defs/oidcConfiguration"},
@@ -71,7 +72,7 @@
     "event": {"type": "object", "additionalProperties": false, "required": ["provider", "name", "payload_digest"], "properties": {"provider": {"enum": ["github", "cursor-origin"]}, "name": {"type": "string", "pattern": "^[A-Za-z0-9_.-]+$", "maxLength": 128}, "payload_digest": {"$ref": "#/$defs/digest"}, "repository": {"type": "string", "maxLength": 512}, "ref": {"type": "string", "maxLength": 1024}, "head_ref": {"type": "string", "maxLength": 1024}, "base_ref": {"type": "string", "maxLength": 1024}, "sha": {"type": "string", "maxLength": 128}, "actor": {"type": "string", "maxLength": 256}}},
     "target": {"type": "object", "additionalProperties": false, "required": ["step_key"], "properties": {"step_key": {"$ref": "#/$defs/buildkiteName"}, "queue": {"$ref": "#/$defs/buildkiteName"}}},
     "githubEventRepository": {"type": "string", "maxLength": 140, "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$", "not": {"pattern": "^(?:\\.\\.?/|[A-Za-z0-9_.-]+/\\.\\.?)$"}},
-    "githubToken": {"type": "object", "additionalProperties": false, "required": ["workflow", "permissions"], "properties": {"workflow": {"type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*\\.ya?ml$", "maxLength": 255}, "permissions": {"$ref": "#/$defs/githubPermissions"}}},
+    "githubToken": {"type": "object", "additionalProperties": false, "required": ["workflow", "permissions"], "properties": {"workflow": {"type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*\\.ya?ml$", "maxLength": 255}, "permissions": {"$ref": "#/$defs/githubPermissions"}, "aliases": {"type": "array", "uniqueItems": true, "maxItems": 128, "items": {"type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_]*$", "not": {"const": "GITHUB_TOKEN"}}}}},
     "oidcConfiguration": {"type": "object", "additionalProperties": false, "properties": {"claims": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}}, "aws_session_tags": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}}, "subject_claim": {"type": "string", "minLength": 1}}},
     "githubPermissions": {
       "type": "object", "additionalProperties": false, "minProperties": 1, "maxProperties": 15,


### PR DESCRIPTION
## Why

Local reusable workflows can inherit all static secret authority, but they cannot declare and explicitly forward aliases. This rejects valid workflows and prevents least-privilege secret composition across nested local calls.

## What

Support declaration-checked mappings from direct `secrets.NAME` or literal-bracket references. Compose nested aliases to their original Buildkite secret, retrieve each original once, and project only authorized aliases at runtime.

Keep optional unmapped aliases empty, reject unsupported expressions and remote forwarding, and preserve `GITHUB_TOKEN` on the scoped provider-token boundary. Plans and pipeline YAML continue to contain names only, never secret values.