### PR TITLE
Improve unsupported GitHub event diagnostics

### DIFF
--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -1481,6 +1481,52 @@ jobs:
 	}
 }
 
+func TestCompileBundleExplainsUnsupportedRetainedEventAccess(t *testing.T) {
+	tests := []struct {
+		name       string
+		expression string
+	}{
+		{name: "whole event", expression: "toJSON(github.event)"},
+		{name: "dynamic property", expression: "github.event[needs.prepare.outputs.property]"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source := []byte(fmt.Sprintf(`on: push
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      property: ${{ steps.select.outputs.property }}
+    steps:
+      - id: select
+        run: echo 'property=action' >> "$GITHUB_OUTPUT"
+  test:
+    needs: prepare
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo '${{ %s }}'
+`, test.expression))
+			_, err := CompileBundle("workflow.yml", source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-importer")
+			if err == nil {
+				t.Fatal("CompileBundle() succeeded, want unsupported event access")
+			}
+			var finding *ProcessingFinding
+			if !errors.As(err, &finding) {
+				t.Fatalf("CompileBundle() error = %T, want ProcessingFinding", err)
+			}
+			if finding.Path != "workflow.yml" || finding.Line != 14 || finding.Column != 9 || finding.Job != "test" || finding.Step != 1 {
+				t.Fatalf("finding attribution = %#v", finding)
+			}
+			if !strings.Contains(finding.Message, "Reference a specific scalar property") || !strings.Contains(finding.Message, "full event payload is unavailable at runtime") {
+				t.Fatalf("finding message = %q", finding.Message)
+			}
+			if want := fmt.Sprintf(`Expression in steps[1].run: "echo '${{ %s }}'"`, test.expression); finding.Detail != want {
+				t.Fatalf("finding detail = %q, want %q", finding.Detail, want)
+			}
+		})
+	}
+}
+
 func TestCompileBundleDoesNotReduceEventExpressionsInActionReferences(t *testing.T) {
 	source := []byte(`on: push
 jobs:
@@ -1496,8 +1542,9 @@ jobs:
   "payload": {"action_ref": "owner/action@1111111111111111111111111111111111111111"}
 }`)
 	_, err := CompileBundle("workflow.yml", source, event, "0.0.0-test", testDistributionDigest, "gha-importer")
-	if err == nil || !strings.Contains(err.Error(), "github.event cannot be retained") {
-		t.Fatalf("CompileBundle() error = %v, want static action reference rejection", err)
+	var finding *ProcessingFinding
+	if err == nil || !errors.As(err, &finding) || !strings.Contains(finding.Message, "action reference must be a static value") || finding.Step != 1 || !strings.Contains(finding.Detail, "steps[1].uses") {
+		t.Fatalf("CompileBundle() finding = %#v, error = %v, want actionable static action reference rejection", finding, err)
 	}
 }
 

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -1504,7 +1504,8 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     steps:
-      - run: echo '${{ %s }}'
+      - name: Locate the run expression, not this name
+        run: echo '${{ %s }}'
 `, test.expression))
 			_, err := CompileBundle("workflow.yml", source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-importer")
 			if err == nil {
@@ -1514,7 +1515,7 @@ jobs:
 			if !errors.As(err, &finding) {
 				t.Fatalf("CompileBundle() error = %T, want ProcessingFinding", err)
 			}
-			if finding.Path != "workflow.yml" || finding.Line != 14 || finding.Column != 9 || finding.Job != "test" || finding.Step != 1 {
+			if finding.Path != "workflow.yml" || finding.Line != 15 || finding.Column != 14 || finding.Job != "test" || finding.Step != 1 {
 				t.Fatalf("finding attribution = %#v", finding)
 			}
 			if !strings.Contains(finding.Message, "Reference a specific scalar property") || !strings.Contains(finding.Message, "full event payload is unavailable at runtime") {
@@ -1524,6 +1525,32 @@ jobs:
 				t.Fatalf("finding detail = %q, want %q", finding.Detail, want)
 			}
 		})
+	}
+}
+
+func TestCompileBundleLocatesUnsupportedJobEventAccess(t *testing.T) {
+	source := []byte(`on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    env:
+      EVENT: ${{ toJSON(github.event) }}
+    steps:
+      - run: true
+`)
+	_, err := CompileBundle("workflow.yml", source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-importer")
+	var finding *ProcessingFinding
+	if err == nil || !errors.As(err, &finding) {
+		t.Fatalf("CompileBundle() finding = %#v, error = %v", finding, err)
+	}
+	if finding.Path != "workflow.yml" || finding.Line != 9 || finding.Column != 14 || finding.Job != "test" || finding.Step != 0 {
+		t.Fatalf("finding attribution = %#v", finding)
+	}
+	if finding.Detail != `Expression in job.env.EVENT: "${{ toJSON(github.event) }}"` {
+		t.Fatalf("finding detail = %q", finding.Detail)
 	}
 }
 

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -1554,6 +1554,57 @@ jobs:
 	}
 }
 
+func TestCompileBundleRetainedEventDiagnosticUsesAuthoredExpression(t *testing.T) {
+	source := []byte(`on:
+  workflow_dispatch:
+    inputs:
+      label:
+        type: string
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo '${{ inputs.label }}' '${{ github.event }}'
+`)
+	event := []byte(`{
+  "provider": "github", "event": "workflow_dispatch",
+  "repository": {"owner": "buildkite", "name": "buildkite-gha", "clone_url": "https://github.com/buildkite/buildkite-gha.git", "default_branch": "main"},
+  "ref": "refs/heads/main", "sha": "1111111111111111111111111111111111111111", "actor": "octocat",
+  "payload": {"inputs": {"label": "event-derived-sensitive-value"}}
+}`)
+	_, err := CompileBundle("workflow.yml", source, event, "0.0.0-test", testDistributionDigest, "gha-importer")
+	var finding *ProcessingFinding
+	if err == nil || !errors.As(err, &finding) {
+		t.Fatalf("CompileBundle() finding = %#v, error = %v", finding, err)
+	}
+	if finding.Detail != `Expression in steps[1].run: "echo '${{ inputs.label }}' '${{ github.event }}'"` {
+		t.Fatalf("finding detail = %q", finding.Detail)
+	}
+	if strings.Contains(err.Error(), "event-derived-sensitive-value") {
+		t.Fatalf("finding exposed an event-derived input: %v", err)
+	}
+}
+
+func TestCompileBundleLocatesInheritedWorkflowEventAccess(t *testing.T) {
+	source := []byte(`on: push
+env:
+  EVENT: ${{ github.event }}
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+`)
+	_, err := CompileBundle("workflow.yml", source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-importer")
+	var finding *ProcessingFinding
+	if err == nil || !errors.As(err, &finding) {
+		t.Fatalf("CompileBundle() finding = %#v, error = %v", finding, err)
+	}
+	if finding.Line != 3 || finding.Column != 10 || finding.Detail != `Expression in job.env.EVENT: "${{ github.event }}"` {
+		t.Fatalf("inherited workflow finding = %#v, error = %v", finding, err)
+	}
+}
+
 func TestCompileBundleDoesNotReduceEventExpressionsInActionReferences(t *testing.T) {
 	source := []byte(`on: push
 jobs:

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -61,40 +61,41 @@ type WorkflowSource struct {
 
 // JobInstance is one statically expanded job in the owned IR.
 type JobInstance struct {
-	Key                     string                   `json:"key"`
-	LogicalJobID            string                   `json:"logical_job_id"`
-	Label                   string                   `json:"label"`
-	Needs                   []string                 `json:"needs,omitempty"`
-	NeedGroups              map[string][]string      `json:"need_groups,omitempty"`
-	NeedOutputs             map[string][]NeedOutput  `json:"need_outputs,omitempty"`
-	CallGuards              []CallGuard              `json:"call_guards,omitempty"`
-	RunsOn                  []string                 `json:"runs_on"`
-	Queue                   string                   `json:"queue"`
-	Platform                Platform                 `json:"-"`
-	RuntimeImage            string                   `json:"runtime_image,omitempty"`
-	Matrix                  map[string]any           `json:"matrix,omitempty"`
-	Inputs                  map[string]any           `json:"inputs,omitempty"`
-	DeferredInputs          map[string]DeferredInput `json:"deferred_inputs,omitempty"`
-	FailFast                *bool                    `json:"fail_fast,omitempty"`
-	MaxParallel             *int                     `json:"max_parallel,omitempty"`
-	ConcurrencyGroup        string                   `json:"concurrency_group,omitempty"`
-	Steps                   []workflow.Step          `json:"steps"`
-	Env                     map[string]string        `json:"env,omitempty"`
-	Permissions             map[string]string        `json:"permissions,omitempty"`
-	If                      string                   `json:"if,omitempty"`
-	ContinueOnError         bool                     `json:"continue_on_error,omitempty"`
-	TimeoutMinutes          float64                  `json:"timeout_minutes,omitempty"`
-	DefaultShell            string                   `json:"default_shell,omitempty"`
-	DefaultWorkingDirectory string                   `json:"default_working_directory,omitempty"`
-	Outputs                 map[string]string        `json:"outputs,omitempty"`
-	Container               *workflow.Container      `json:"container,omitempty"`
-	Services                []workflow.Service       `json:"services,omitempty"`
-	ServicesExpression      string                   `json:"services_expression,omitempty"`
-	SourcePath              string                   `json:"source_path"`
-	SourceDigest            string                   `json:"source_digest"`
-	RemoteWorkflow          *RemoteWorkflowSource    `json:"remote_workflow,omitempty"`
-	RepositoryRoot          string                   `json:"-"`
-	Source                  workflow.Span            `json:"source"`
+	Key                     string                       `json:"key"`
+	LogicalJobID            string                       `json:"logical_job_id"`
+	Label                   string                       `json:"label"`
+	Needs                   []string                     `json:"needs,omitempty"`
+	NeedGroups              map[string][]string          `json:"need_groups,omitempty"`
+	NeedOutputs             map[string][]NeedOutput      `json:"need_outputs,omitempty"`
+	CallGuards              []CallGuard                  `json:"call_guards,omitempty"`
+	RunsOn                  []string                     `json:"runs_on"`
+	Queue                   string                       `json:"queue"`
+	Platform                Platform                     `json:"-"`
+	RuntimeImage            string                       `json:"runtime_image,omitempty"`
+	Matrix                  map[string]any               `json:"matrix,omitempty"`
+	Inputs                  map[string]any               `json:"inputs,omitempty"`
+	DeferredInputs          map[string]DeferredInput     `json:"deferred_inputs,omitempty"`
+	FailFast                *bool                        `json:"fail_fast,omitempty"`
+	MaxParallel             *int                         `json:"max_parallel,omitempty"`
+	ConcurrencyGroup        string                       `json:"concurrency_group,omitempty"`
+	Steps                   []workflow.Step              `json:"steps"`
+	Env                     map[string]string            `json:"env,omitempty"`
+	Permissions             map[string]string            `json:"permissions,omitempty"`
+	If                      string                       `json:"if,omitempty"`
+	ContinueOnError         bool                         `json:"continue_on_error,omitempty"`
+	TimeoutMinutes          float64                      `json:"timeout_minutes,omitempty"`
+	DefaultShell            string                       `json:"default_shell,omitempty"`
+	DefaultWorkingDirectory string                       `json:"default_working_directory,omitempty"`
+	Outputs                 map[string]string            `json:"outputs,omitempty"`
+	Container               *workflow.Container          `json:"container,omitempty"`
+	Services                []workflow.Service           `json:"services,omitempty"`
+	ServicesExpression      string                       `json:"services_expression,omitempty"`
+	SourcePath              string                       `json:"source_path"`
+	SourceDigest            string                       `json:"source_digest"`
+	RemoteWorkflow          *RemoteWorkflowSource        `json:"remote_workflow,omitempty"`
+	RepositoryRoot          string                       `json:"-"`
+	Source                  workflow.Span                `json:"source"`
+	Positions               map[string]workflow.Position `json:"-"`
 	secretAuthority         bool
 	tokenPolicyNarrowed     bool
 	jobPermissionsIgnored   bool
@@ -109,6 +110,8 @@ type CallGuard struct {
 	DeferredInputs map[string]DeferredInput `json:"deferred_inputs,omitempty"`
 	NeedGroups     map[string][]string      `json:"need_groups,omitempty"`
 	NeedOutputs    map[string][]NeedOutput  `json:"need_outputs,omitempty"`
+	SourcePath     string                   `json:"-"`
+	Position       workflow.Position        `json:"-"`
 }
 
 // DeferredInput binds one string workflow_call input to exact prerequisite

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -96,6 +96,7 @@ type JobInstance struct {
 	RepositoryRoot          string                       `json:"-"`
 	Source                  workflow.Span                `json:"source"`
 	Positions               map[string]workflow.Position `json:"-"`
+	Sources                 map[string]string            `json:"-"`
 	secretAuthority         bool
 	tokenPolicyNarrowed     bool
 	jobPermissionsIgnored   bool
@@ -112,6 +113,7 @@ type CallGuard struct {
 	NeedOutputs    map[string][]NeedOutput  `json:"need_outputs,omitempty"`
 	SourcePath     string                   `json:"-"`
 	Position       workflow.Position        `json:"-"`
+	Source         string                   `json:"-"`
 }
 
 // DeferredInput binds one string workflow_call input to exact prerequisite

--- a/internal/compiler/job_graph_expansion.go
+++ b/internal/compiler/job_graph_expansion.go
@@ -346,13 +346,25 @@ func newJobCandidate(sourced sourcedJob, job workflow.Job, matrix map[string]any
 		Outputs: cloneMap(job.Outputs), Container: job.Container, Services: services,
 		ServicesExpression: job.ServicesExpression, SourcePath: sourced.path, SourceDigest: sourced.digest,
 		RemoteWorkflow: cloneRemoteWorkflowSource(sourced.remote), RepositoryRoot: sourced.root, Source: job.Span,
+		Positions:       clonePositionMap(job.Positions),
 		secretAuthority: sourced.secretAuthority, tokenPolicyNarrowed: sourced.tokenPolicyNarrowed,
 		jobPermissionsIgnored: sourced.jobPermissionsIgnored, reusableCall: sourced.reusableCall,
 	}
 	for _, guard := range sourced.callGuards {
-		candidate.CallGuards = append(candidate.CallGuards, CallGuard{Condition: guard.condition, Inputs: cloneAnyMap(guard.inputs.values)})
+		candidate.CallGuards = append(candidate.CallGuards, CallGuard{Condition: guard.condition, Inputs: cloneAnyMap(guard.inputs.values), SourcePath: guard.sourcePath, Position: guard.position})
 	}
 	return candidate
+}
+
+func clonePositionMap(source map[string]workflow.Position) map[string]workflow.Position {
+	if source == nil {
+		return nil
+	}
+	clone := make(map[string]workflow.Position, len(source))
+	for name, position := range source {
+		clone[name] = position
+	}
+	return clone
 }
 
 func (e *jobGraphExpansion) jobBlocked(sourced sourcedJob) bool {

--- a/internal/compiler/job_graph_expansion.go
+++ b/internal/compiler/job_graph_expansion.go
@@ -347,11 +347,12 @@ func newJobCandidate(sourced sourcedJob, job workflow.Job, matrix map[string]any
 		ServicesExpression: job.ServicesExpression, SourcePath: sourced.path, SourceDigest: sourced.digest,
 		RemoteWorkflow: cloneRemoteWorkflowSource(sourced.remote), RepositoryRoot: sourced.root, Source: job.Span,
 		Positions:       clonePositionMap(job.Positions),
+		Sources:         cloneMap(job.Sources),
 		secretAuthority: sourced.secretAuthority, tokenPolicyNarrowed: sourced.tokenPolicyNarrowed,
 		jobPermissionsIgnored: sourced.jobPermissionsIgnored, reusableCall: sourced.reusableCall,
 	}
 	for _, guard := range sourced.callGuards {
-		candidate.CallGuards = append(candidate.CallGuards, CallGuard{Condition: guard.condition, Inputs: cloneAnyMap(guard.inputs.values), SourcePath: guard.sourcePath, Position: guard.position})
+		candidate.CallGuards = append(candidate.CallGuards, CallGuard{Condition: guard.condition, Source: guard.source, Inputs: cloneAnyMap(guard.inputs.values), SourcePath: guard.sourcePath, Position: guard.position})
 	}
 	return candidate
 }

--- a/internal/compiler/plan_builder.go
+++ b/internal/compiler/plan_builder.go
@@ -43,6 +43,11 @@ type builtPlanActions struct {
 	resolved            bool
 }
 
+var (
+	errRetainedGitHubEvent  = errors.New("github.event cannot be retained in a job plan")
+	errEventActionReference = errors.New("github.event cannot select an action reference")
+)
+
 func compilePlansWithAuthorization(ctx context.Context, ir IR, compilerVersion, compilerDistributionDigest string, options Options) ([]plan.Job, []PlanAuthorization, []JobEvaluation, error) {
 	payload, err := json.Marshal(ir.Event.Payload)
 	if err != nil {
@@ -165,7 +170,7 @@ func (b planBuilder) reducePlanInstanceEventExpressions(instance JobInstance) (J
 	context.Inputs = instance.Inputs
 	context.Matrix = instance.Matrix
 
-	reduceTemplate := func(value string) (string, error) {
+	reduceTemplateValue := func(value string) (string, error) {
 		if value == "" {
 			return value, nil
 		}
@@ -182,11 +187,11 @@ func (b planBuilder) reducePlanInstanceEventExpressions(instance JobInstance) (J
 			return "", err
 		}
 		if referencesEvent || referencesEventAlias {
-			return "", fmt.Errorf("github.event cannot be retained in a job plan")
+			return "", errRetainedGitHubEvent
 		}
 		return reduced, nil
 	}
-	reduceCondition := func(value string) (string, error) {
+	reduceConditionValue := func(value string) (string, error) {
 		if value == "" {
 			return value, nil
 		}
@@ -206,28 +211,45 @@ func (b planBuilder) reducePlanInstanceEventExpressions(instance JobInstance) (J
 			return "", err
 		}
 		if referencesEvent {
-			return "", fmt.Errorf("github.event cannot be retained in a job plan")
+			return "", errRetainedGitHubEvent
 		}
 		return reduced, nil
 	}
-	reduceTypedExpression := func(value string) (string, error) {
-		referencesEvent, err := expression.ReferencesGitHubEvent(value)
-		if err != nil || !referencesEvent {
-			return value, err
+	reduceTemplate := func(value, field string, position workflow.Position, step int) (string, error) {
+		reduced, err := reduceTemplateValue(value)
+		if err != nil {
+			return "", planExpressionFinding(instance, field, value, position, step, err)
 		}
-		reduced, err := reduceCondition(value)
+		return reduced, nil
+	}
+	reduceCondition := func(value, field string, position workflow.Position, step int) (string, error) {
+		reduced, err := reduceConditionValue(value)
+		if err != nil {
+			return "", planExpressionFinding(instance, field, value, position, step, err)
+		}
+		return reduced, nil
+	}
+	reduceTypedExpression := func(value, field string, position workflow.Position, step int) (string, error) {
+		referencesEvent, err := expression.ReferencesGitHubEvent(value)
+		if err != nil {
+			return "", planExpressionFinding(instance, field, value, position, step, err)
+		}
+		if !referencesEvent {
+			return value, nil
+		}
+		reduced, err := reduceCondition(value, field, position, step)
 		if err != nil {
 			return "", err
 		}
 		return "${{ " + reduced + " }}", nil
 	}
-	reduceMap := func(values map[string]string) (map[string]string, error) {
+	reduceMap := func(values map[string]string, field string, position workflow.Position, step int) (map[string]string, error) {
 		if values == nil {
 			return nil, nil
 		}
 		result := cloneMap(values)
 		for _, name := range sortedValueKeys(result) {
-			value, err := reduceTemplate(result[name])
+			value, err := reduceTemplate(result[name], fmt.Sprintf("%s.%s", field, name), position, step)
 			if err != nil {
 				return nil, err
 			}
@@ -235,13 +257,13 @@ func (b planBuilder) reducePlanInstanceEventExpressions(instance JobInstance) (J
 		}
 		return result, nil
 	}
-	reduceSlice := func(values []string) ([]string, error) {
+	reduceSlice := func(values []string, field string, position workflow.Position) ([]string, error) {
 		if values == nil {
 			return nil, nil
 		}
 		result := append([]string(nil), values...)
 		for i := range result {
-			value, err := reduceTemplate(result[i])
+			value, err := reduceTemplate(result[i], fmt.Sprintf("%s[%d]", field, i), position, 0)
 			if err != nil {
 				return nil, err
 			}
@@ -251,24 +273,32 @@ func (b planBuilder) reducePlanInstanceEventExpressions(instance JobInstance) (J
 	}
 
 	var err error
-	if instance.If, err = reduceCondition(instance.If); err != nil {
+	if instance.If, err = reduceCondition(instance.If, "job.if", instance.Source.Start, 0); err != nil {
 		return JobInstance{}, err
 	}
-	for _, field := range []*string{&instance.DefaultShell, &instance.DefaultWorkingDirectory, &instance.ServicesExpression} {
-		if *field, err = reduceTemplate(*field); err != nil {
+	jobFields := []struct {
+		name  string
+		value *string
+	}{
+		{"job.defaults.run.shell", &instance.DefaultShell},
+		{"job.defaults.run.working-directory", &instance.DefaultWorkingDirectory},
+		{"job.services", &instance.ServicesExpression},
+	}
+	for _, field := range jobFields {
+		if *field.value, err = reduceTemplate(*field.value, field.name, instance.Source.Start, 0); err != nil {
 			return JobInstance{}, err
 		}
 	}
-	if instance.Env, err = reduceMap(instance.Env); err != nil {
+	if instance.Env, err = reduceMap(instance.Env, "job.env", instance.Source.Start, 0); err != nil {
 		return JobInstance{}, err
 	}
-	if instance.Outputs, err = reduceMap(instance.Outputs); err != nil {
+	if instance.Outputs, err = reduceMap(instance.Outputs, "job.outputs", instance.Source.Start, 0); err != nil {
 		return JobInstance{}, err
 	}
 
 	instance.CallGuards = append([]CallGuard(nil), instance.CallGuards...)
 	for i := range instance.CallGuards {
-		if instance.CallGuards[i].Condition, err = reduceCondition(instance.CallGuards[i].Condition); err != nil {
+		if instance.CallGuards[i].Condition, err = reduceCondition(instance.CallGuards[i].Condition, fmt.Sprintf("job.call-guards[%d]", i), instance.Source.Start, 0); err != nil {
 			return JobInstance{}, err
 		}
 	}
@@ -276,36 +306,55 @@ func (b planBuilder) reducePlanInstanceEventExpressions(instance JobInstance) (J
 	instance.Steps = append([]workflow.Step(nil), instance.Steps...)
 	for i := range instance.Steps {
 		step := &instance.Steps[i]
-		if step.If, err = reduceCondition(step.If); err != nil {
+		field := fmt.Sprintf("steps[%d]", i+1)
+		if step.If, err = reduceCondition(step.If, field+".if", step.IfSpan.Start, i+1); err != nil {
 			return JobInstance{}, err
 		}
-		for _, field := range []*string{&step.Name, &step.Run, &step.Shell, &step.WorkingDirectory} {
-			if *field, err = reduceTemplate(*field); err != nil {
+		stepTemplates := []struct {
+			name  string
+			value *string
+		}{{"name", &step.Name}, {"run", &step.Run}, {"shell", &step.Shell}, {"working-directory", &step.WorkingDirectory}}
+		for _, template := range stepTemplates {
+			if *template.value, err = reduceTemplate(*template.value, field+"."+template.name, step.Span.Start, i+1); err != nil {
 				return JobInstance{}, err
 			}
 		}
-		for _, field := range []*string{&step.ContinueOnErrorExpression, &step.TimeoutMinutesExpression} {
-			if *field, err = reduceTypedExpression(*field); err != nil {
+		typedExpressions := []struct {
+			name  string
+			value *string
+		}{{"continue-on-error", &step.ContinueOnErrorExpression}, {"timeout-minutes", &step.TimeoutMinutesExpression}}
+		for _, typed := range typedExpressions {
+			if *typed.value, err = reduceTypedExpression(*typed.value, field+"."+typed.name, step.Span.Start, i+1); err != nil {
 				return JobInstance{}, err
 			}
 		}
-		if step.Env, err = reduceMap(step.Env); err != nil {
+		if step.Env, err = reduceMap(step.Env, field+".env", step.Span.Start, i+1); err != nil {
 			return JobInstance{}, err
 		}
-		if step.With, err = reduceMap(step.With); err != nil {
+		if step.With, err = reduceMap(step.With, field+".with", step.Span.Start, i+1); err != nil {
 			return JobInstance{}, err
+		}
+		referencesEvent, referencesErr := expression.TemplateReferencesGitHubEvent(step.Uses)
+		if referencesErr == nil && !referencesEvent {
+			referencesEvent, referencesErr = expression.TemplateUsesContext(step.Uses, "event")
+		}
+		if referencesErr != nil {
+			return JobInstance{}, planExpressionFinding(instance, field+".uses", step.Uses, step.Span.Start, i+1, referencesErr)
+		}
+		if referencesEvent {
+			return JobInstance{}, planExpressionFinding(instance, field+".uses", step.Uses, step.Span.Start, i+1, errEventActionReference)
 		}
 	}
 
 	if instance.Container != nil {
 		container := *instance.Container
-		if container.Image, err = reduceTemplate(container.Image); err != nil {
+		if container.Image, err = reduceTemplate(container.Image, "job.container.image", container.Span.Start, 0); err != nil {
 			return JobInstance{}, err
 		}
-		if container.Env, err = reduceMap(container.Env); err != nil {
+		if container.Env, err = reduceMap(container.Env, "job.container.env", container.Span.Start, 0); err != nil {
 			return JobInstance{}, err
 		}
-		if container.Ports, err = reduceSlice(container.Ports); err != nil {
+		if container.Ports, err = reduceSlice(container.Ports, "job.container.ports", container.Span.Start); err != nil {
 			return JobInstance{}, err
 		}
 		instance.Container = &container
@@ -314,26 +363,31 @@ func (b planBuilder) reducePlanInstanceEventExpressions(instance JobInstance) (J
 	instance.Services = append([]workflow.Service(nil), instance.Services...)
 	for i := range instance.Services {
 		container := instance.Services[i].Container
-		for _, field := range []*string{&container.Image, &container.Options, &container.Command, &container.Entrypoint} {
-			if *field, err = reduceTemplate(*field); err != nil {
+		field := fmt.Sprintf("job.services.%s", instance.Services[i].Name)
+		serviceFields := []struct {
+			name  string
+			value *string
+		}{{"image", &container.Image}, {"options", &container.Options}, {"command", &container.Command}, {"entrypoint", &container.Entrypoint}}
+		for _, serviceField := range serviceFields {
+			if *serviceField.value, err = reduceTemplate(*serviceField.value, field+"."+serviceField.name, container.Span.Start, 0); err != nil {
 				return JobInstance{}, err
 			}
 		}
-		if container.Env, err = reduceMap(container.Env); err != nil {
+		if container.Env, err = reduceMap(container.Env, field+".env", container.Span.Start, 0); err != nil {
 			return JobInstance{}, err
 		}
-		if container.Ports, err = reduceSlice(container.Ports); err != nil {
+		if container.Ports, err = reduceSlice(container.Ports, field+".ports", container.Span.Start); err != nil {
 			return JobInstance{}, err
 		}
-		if container.Volumes, err = reduceSlice(container.Volumes); err != nil {
+		if container.Volumes, err = reduceSlice(container.Volumes, field+".volumes", container.Span.Start); err != nil {
 			return JobInstance{}, err
 		}
 		if container.Credentials != nil {
 			credentials := *container.Credentials
-			if credentials.Username, err = reduceTemplate(credentials.Username); err != nil {
+			if credentials.Username, err = reduceTemplate(credentials.Username, field+".credentials.username", container.Span.Start, 0); err != nil {
 				return JobInstance{}, err
 			}
-			if credentials.Password, err = reduceTemplate(credentials.Password); err != nil {
+			if credentials.Password, err = reduceTemplate(credentials.Password, field+".credentials.password", container.Span.Start, 0); err != nil {
 				return JobInstance{}, err
 			}
 			container.Credentials = &credentials
@@ -696,12 +750,29 @@ func cloneOIDCConfiguration(configuration *plan.OIDCConfiguration) *plan.OIDCCon
 	}
 }
 
-func planConstructionFinding(instance JobInstance, err error) error {
-	return &ProcessingFinding{
+func planExpressionFinding(instance JobInstance, field, source string, position workflow.Position, step int, err error) error {
+	finding := &ProcessingFinding{
 		Stage: StagePlans, Code: CodePlanConstruction, Category: "compatibility",
-		Path: instance.SourcePath, Line: instance.Source.Start.Line, Column: instance.Source.Start.Column,
-		Job: instance.LogicalJobID, Instance: instance.Key, Err: err,
+		Path: instance.SourcePath, Line: position.Line, Column: position.Column,
+		Job: instance.LogicalJobID, Instance: instance.Key, Step: step,
+		Err: fmt.Errorf("%s:%d:%d: job %q %s expression %q: %w", instance.SourcePath, position.Line, position.Column, instance.LogicalJobID, field, source, err),
 	}
+	if errors.Is(err, errRetainedGitHubEvent) || strings.Contains(err.Error(), "whole github.event access is unsupported") {
+		finding.Message = "This expression uses the whole GitHub event or accesses it dynamically. Reference a specific scalar property, such as github.event.pull_request.head.sha. The full event payload is unavailable at runtime."
+		finding.Detail = fmt.Sprintf("Expression in %s: %q", field, source)
+	} else if errors.Is(err, errEventActionReference) {
+		finding.Message = "An action reference must be a static value and cannot use github.event. Replace the expression with a literal owner/repository/path@ref or local action path."
+		finding.Detail = fmt.Sprintf("Expression in %s: %q", field, source)
+	}
+	return finding
+}
+
+func planConstructionFinding(instance JobInstance, err error) error {
+	return attributedProcessingFinding(
+		StagePlans, CodePlanConstruction, "compatibility",
+		instance.SourcePath, instance.Source.Start.Line, instance.Source.Start.Column,
+		instance.LogicalJobID, instance.Key, "", 0, err,
+	)
 }
 
 func requiredSecrets(instance JobInstance, actionRequired []string, actionInputsInspected bool) ([]string, bool, error) {
@@ -713,7 +784,7 @@ func requiredSecrets(instance JobInstance, actionRequired []string, actionInputs
 			return err
 		}
 		if referencesEvent {
-			return fmt.Errorf("github.event cannot be retained in a job plan")
+			return errRetainedGitHubEvent
 		}
 		names, err := expression.SecretReferences(value)
 		if err != nil {
@@ -742,7 +813,7 @@ func requiredSecrets(instance JobInstance, actionRequired []string, actionInputs
 			return err
 		}
 		if referencesEvent {
-			return fmt.Errorf("github.event cannot be retained in a job plan")
+			return errRetainedGitHubEvent
 		}
 		names, err := expression.ConditionSecretReferences(value)
 		if err != nil {

--- a/internal/compiler/plan_builder.go
+++ b/internal/compiler/plan_builder.go
@@ -243,28 +243,32 @@ func (b planBuilder) reducePlanInstanceEventExpressions(instance JobInstance) (J
 		}
 		return "${{ " + reduced + " }}", nil
 	}
-	reduceMap := func(values map[string]string, field, positionPrefix string, positions map[string]workflow.Position, fallback workflow.Position, step int) (map[string]string, error) {
+	reduceMap := func(values map[string]string, field, positionPrefix string, positions map[string]workflow.Position, sources map[string]string, fallback workflow.Position, step int) (map[string]string, error) {
 		if values == nil {
 			return nil, nil
 		}
 		result := cloneMap(values)
 		for _, name := range sortedValueKeys(result) {
-			value, err := reduceTemplate(result[name], fmt.Sprintf("%s.%s", field, name), sourcePosition(positions, positionPrefix+"."+name, fallback), step)
+			positionField := positionPrefix + "." + name
+			value, err := reduceTemplate(result[name], fmt.Sprintf("%s.%s", field, name), sourcePosition(positions, positionField, fallback), step)
 			if err != nil {
+				setFindingSource(err, fmt.Sprintf("%s.%s", field, name), sourceValue(sources, positionField, result[name]))
 				return nil, err
 			}
 			result[name] = value
 		}
 		return result, nil
 	}
-	reduceSlice := func(values []string, field, positionPrefix string, positions map[string]workflow.Position, fallback workflow.Position) ([]string, error) {
+	reduceSlice := func(values []string, field, positionPrefix string, positions map[string]workflow.Position, sources map[string]string, fallback workflow.Position) ([]string, error) {
 		if values == nil {
 			return nil, nil
 		}
 		result := append([]string(nil), values...)
 		for i := range result {
-			value, err := reduceTemplate(result[i], fmt.Sprintf("%s[%d]", field, i), sourcePosition(positions, fmt.Sprintf("%s[%d]", positionPrefix, i), fallback), 0)
+			positionField := fmt.Sprintf("%s[%d]", positionPrefix, i)
+			value, err := reduceTemplate(result[i], fmt.Sprintf("%s[%d]", field, i), sourcePosition(positions, positionField, fallback), 0)
 			if err != nil {
+				setFindingSource(err, fmt.Sprintf("%s[%d]", field, i), sourceValue(sources, positionField, result[i]))
 				return nil, err
 			}
 			result[i] = value
@@ -274,6 +278,7 @@ func (b planBuilder) reducePlanInstanceEventExpressions(instance JobInstance) (J
 
 	var err error
 	if instance.If, err = reduceCondition(instance.If, "job.if", sourcePosition(instance.Positions, "if", instance.Source.Start), 0); err != nil {
+		setFindingSource(err, "job.if", sourceValue(instance.Sources, "if", instance.If))
 		return JobInstance{}, err
 	}
 	jobFields := []struct {
@@ -287,13 +292,14 @@ func (b planBuilder) reducePlanInstanceEventExpressions(instance JobInstance) (J
 	}
 	for _, field := range jobFields {
 		if *field.value, err = reduceTemplate(*field.value, field.name, sourcePosition(instance.Positions, field.position, instance.Source.Start), 0); err != nil {
+			setFindingSource(err, field.name, sourceValue(instance.Sources, field.position, *field.value))
 			return JobInstance{}, err
 		}
 	}
-	if instance.Env, err = reduceMap(instance.Env, "job.env", "env", instance.Positions, instance.Source.Start, 0); err != nil {
+	if instance.Env, err = reduceMap(instance.Env, "job.env", "env", instance.Positions, instance.Sources, instance.Source.Start, 0); err != nil {
 		return JobInstance{}, err
 	}
-	if instance.Outputs, err = reduceMap(instance.Outputs, "job.outputs", "outputs", instance.Positions, instance.Source.Start, 0); err != nil {
+	if instance.Outputs, err = reduceMap(instance.Outputs, "job.outputs", "outputs", instance.Positions, instance.Sources, instance.Source.Start, 0); err != nil {
 		return JobInstance{}, err
 	}
 
@@ -310,7 +316,11 @@ func (b planBuilder) reducePlanInstanceEventExpressions(instance JobInstance) (J
 			if position.Line == 0 || position.Column == 0 {
 				position = instance.Source.Start
 			}
-			return JobInstance{}, planExpressionFinding(instance, path, fmt.Sprintf("job.call-guards[%d]", i), guard.Condition, position, 0, guardErr)
+			source := guard.Source
+			if source == "" {
+				source = guard.Condition
+			}
+			return JobInstance{}, planExpressionFinding(instance, path, fmt.Sprintf("job.call-guards[%d]", i), source, position, 0, guardErr)
 		}
 		guard.Condition = reduced
 	}
@@ -320,6 +330,7 @@ func (b planBuilder) reducePlanInstanceEventExpressions(instance JobInstance) (J
 		step := &instance.Steps[i]
 		field := fmt.Sprintf("steps[%d]", i+1)
 		if step.If, err = reduceCondition(step.If, field+".if", sourcePosition(step.Positions, "if", step.IfSpan.Start), i+1); err != nil {
+			setFindingSource(err, field+".if", sourceValue(step.Sources, "if", step.If))
 			return JobInstance{}, err
 		}
 		stepTemplates := []struct {
@@ -328,6 +339,7 @@ func (b planBuilder) reducePlanInstanceEventExpressions(instance JobInstance) (J
 		}{{"name", &step.Name}, {"run", &step.Run}, {"shell", &step.Shell}, {"working-directory", &step.WorkingDirectory}}
 		for _, template := range stepTemplates {
 			if *template.value, err = reduceTemplate(*template.value, field+"."+template.name, sourcePosition(step.Positions, template.name, step.Span.Start), i+1); err != nil {
+				setFindingSource(err, field+"."+template.name, sourceValue(step.Sources, template.name, *template.value))
 				return JobInstance{}, err
 			}
 		}
@@ -337,13 +349,14 @@ func (b planBuilder) reducePlanInstanceEventExpressions(instance JobInstance) (J
 		}{{"continue-on-error", &step.ContinueOnErrorExpression}, {"timeout-minutes", &step.TimeoutMinutesExpression}}
 		for _, typed := range typedExpressions {
 			if *typed.value, err = reduceTypedExpression(*typed.value, field+"."+typed.name, sourcePosition(step.Positions, typed.name, step.Span.Start), i+1); err != nil {
+				setFindingSource(err, field+"."+typed.name, sourceValue(step.Sources, typed.name, *typed.value))
 				return JobInstance{}, err
 			}
 		}
-		if step.Env, err = reduceMap(step.Env, field+".env", "env", step.Positions, step.Span.Start, i+1); err != nil {
+		if step.Env, err = reduceMap(step.Env, field+".env", "env", step.Positions, step.Sources, step.Span.Start, i+1); err != nil {
 			return JobInstance{}, err
 		}
-		if step.With, err = reduceMap(step.With, field+".with", "with", step.Positions, step.Span.Start, i+1); err != nil {
+		if step.With, err = reduceMap(step.With, field+".with", "with", step.Positions, step.Sources, step.Span.Start, i+1); err != nil {
 			return JobInstance{}, err
 		}
 		referencesEvent, referencesErr := expression.TemplateReferencesGitHubEvent(step.Uses)
@@ -351,22 +364,23 @@ func (b planBuilder) reducePlanInstanceEventExpressions(instance JobInstance) (J
 			referencesEvent, referencesErr = expression.TemplateUsesContext(step.Uses, "event")
 		}
 		if referencesErr != nil {
-			return JobInstance{}, planExpressionFinding(instance, instance.SourcePath, field+".uses", step.Uses, sourcePosition(step.Positions, "uses", step.Span.Start), i+1, referencesErr)
+			return JobInstance{}, planExpressionFinding(instance, instance.SourcePath, field+".uses", sourceValue(step.Sources, "uses", step.Uses), sourcePosition(step.Positions, "uses", step.Span.Start), i+1, referencesErr)
 		}
 		if referencesEvent {
-			return JobInstance{}, planExpressionFinding(instance, instance.SourcePath, field+".uses", step.Uses, sourcePosition(step.Positions, "uses", step.Span.Start), i+1, errEventActionReference)
+			return JobInstance{}, planExpressionFinding(instance, instance.SourcePath, field+".uses", sourceValue(step.Sources, "uses", step.Uses), sourcePosition(step.Positions, "uses", step.Span.Start), i+1, errEventActionReference)
 		}
 	}
 
 	if instance.Container != nil {
 		container := *instance.Container
 		if container.Image, err = reduceTemplate(container.Image, "job.container.image", sourcePosition(container.Positions, "image", container.Span.Start), 0); err != nil {
+			setFindingSource(err, "job.container.image", sourceValue(container.Sources, "image", container.Image))
 			return JobInstance{}, err
 		}
-		if container.Env, err = reduceMap(container.Env, "job.container.env", "env", container.Positions, container.Span.Start, 0); err != nil {
+		if container.Env, err = reduceMap(container.Env, "job.container.env", "env", container.Positions, container.Sources, container.Span.Start, 0); err != nil {
 			return JobInstance{}, err
 		}
-		if container.Ports, err = reduceSlice(container.Ports, "job.container.ports", "ports", container.Positions, container.Span.Start); err != nil {
+		if container.Ports, err = reduceSlice(container.Ports, "job.container.ports", "ports", container.Positions, container.Sources, container.Span.Start); err != nil {
 			return JobInstance{}, err
 		}
 		instance.Container = &container
@@ -382,24 +396,27 @@ func (b planBuilder) reducePlanInstanceEventExpressions(instance JobInstance) (J
 		}{{"image", &container.Image}, {"options", &container.Options}, {"command", &container.Command}, {"entrypoint", &container.Entrypoint}}
 		for _, serviceField := range serviceFields {
 			if *serviceField.value, err = reduceTemplate(*serviceField.value, field+"."+serviceField.name, sourcePosition(container.Positions, serviceField.name, container.Span.Start), 0); err != nil {
+				setFindingSource(err, field+"."+serviceField.name, sourceValue(container.Sources, serviceField.name, *serviceField.value))
 				return JobInstance{}, err
 			}
 		}
-		if container.Env, err = reduceMap(container.Env, field+".env", "env", container.Positions, container.Span.Start, 0); err != nil {
+		if container.Env, err = reduceMap(container.Env, field+".env", "env", container.Positions, container.Sources, container.Span.Start, 0); err != nil {
 			return JobInstance{}, err
 		}
-		if container.Ports, err = reduceSlice(container.Ports, field+".ports", "ports", container.Positions, container.Span.Start); err != nil {
+		if container.Ports, err = reduceSlice(container.Ports, field+".ports", "ports", container.Positions, container.Sources, container.Span.Start); err != nil {
 			return JobInstance{}, err
 		}
-		if container.Volumes, err = reduceSlice(container.Volumes, field+".volumes", "volumes", container.Positions, container.Span.Start); err != nil {
+		if container.Volumes, err = reduceSlice(container.Volumes, field+".volumes", "volumes", container.Positions, container.Sources, container.Span.Start); err != nil {
 			return JobInstance{}, err
 		}
 		if container.Credentials != nil {
 			credentials := *container.Credentials
 			if credentials.Username, err = reduceTemplate(credentials.Username, field+".credentials.username", sourcePosition(container.Positions, "credentials.username", container.Span.Start), 0); err != nil {
+				setFindingSource(err, field+".credentials.username", sourceValue(container.Sources, "credentials.username", credentials.Username))
 				return JobInstance{}, err
 			}
 			if credentials.Password, err = reduceTemplate(credentials.Password, field+".credentials.password", sourcePosition(container.Positions, "credentials.password", container.Span.Start), 0); err != nil {
+				setFindingSource(err, field+".credentials.password", sourceValue(container.Sources, "credentials.password", credentials.Password))
 				return JobInstance{}, err
 			}
 			container.Credentials = &credentials
@@ -767,6 +784,25 @@ func sourcePosition(positions map[string]workflow.Position, field string, fallba
 		return position
 	}
 	return fallback
+}
+
+func sourceValue(sources map[string]string, field, fallback string) string {
+	if source, ok := sources[field]; ok {
+		return source
+	}
+	return fallback
+}
+
+func setFindingSource(err error, field, source string) {
+	var finding *ProcessingFinding
+	if errors.As(err, &finding) {
+		finding.Detail = fmt.Sprintf("Expression in %s: %q", field, source)
+		cause := errors.Unwrap(finding.Err)
+		if cause == nil {
+			cause = finding.Err
+		}
+		finding.Err = fmt.Errorf("%s:%d:%d: job %q %s expression %q: %w", finding.Path, finding.Line, finding.Column, finding.Job, field, source, cause)
+	}
 }
 
 func planExpressionFinding(instance JobInstance, sourcePath, field, source string, position workflow.Position, step int, err error) error {

--- a/internal/compiler/plan_builder.go
+++ b/internal/compiler/plan_builder.go
@@ -218,21 +218,21 @@ func (b planBuilder) reducePlanInstanceEventExpressions(instance JobInstance) (J
 	reduceTemplate := func(value, field string, position workflow.Position, step int) (string, error) {
 		reduced, err := reduceTemplateValue(value)
 		if err != nil {
-			return "", planExpressionFinding(instance, field, value, position, step, err)
+			return "", planExpressionFinding(instance, instance.SourcePath, field, value, position, step, err)
 		}
 		return reduced, nil
 	}
 	reduceCondition := func(value, field string, position workflow.Position, step int) (string, error) {
 		reduced, err := reduceConditionValue(value)
 		if err != nil {
-			return "", planExpressionFinding(instance, field, value, position, step, err)
+			return "", planExpressionFinding(instance, instance.SourcePath, field, value, position, step, err)
 		}
 		return reduced, nil
 	}
 	reduceTypedExpression := func(value, field string, position workflow.Position, step int) (string, error) {
 		referencesEvent, err := expression.ReferencesGitHubEvent(value)
 		if err != nil {
-			return "", planExpressionFinding(instance, field, value, position, step, err)
+			return "", planExpressionFinding(instance, instance.SourcePath, field, value, position, step, err)
 		}
 		if !referencesEvent {
 			return value, nil
@@ -243,13 +243,13 @@ func (b planBuilder) reducePlanInstanceEventExpressions(instance JobInstance) (J
 		}
 		return "${{ " + reduced + " }}", nil
 	}
-	reduceMap := func(values map[string]string, field string, position workflow.Position, step int) (map[string]string, error) {
+	reduceMap := func(values map[string]string, field, positionPrefix string, positions map[string]workflow.Position, fallback workflow.Position, step int) (map[string]string, error) {
 		if values == nil {
 			return nil, nil
 		}
 		result := cloneMap(values)
 		for _, name := range sortedValueKeys(result) {
-			value, err := reduceTemplate(result[name], fmt.Sprintf("%s.%s", field, name), position, step)
+			value, err := reduceTemplate(result[name], fmt.Sprintf("%s.%s", field, name), sourcePosition(positions, positionPrefix+"."+name, fallback), step)
 			if err != nil {
 				return nil, err
 			}
@@ -257,13 +257,13 @@ func (b planBuilder) reducePlanInstanceEventExpressions(instance JobInstance) (J
 		}
 		return result, nil
 	}
-	reduceSlice := func(values []string, field string, position workflow.Position) ([]string, error) {
+	reduceSlice := func(values []string, field, positionPrefix string, positions map[string]workflow.Position, fallback workflow.Position) ([]string, error) {
 		if values == nil {
 			return nil, nil
 		}
 		result := append([]string(nil), values...)
 		for i := range result {
-			value, err := reduceTemplate(result[i], fmt.Sprintf("%s[%d]", field, i), position, 0)
+			value, err := reduceTemplate(result[i], fmt.Sprintf("%s[%d]", field, i), sourcePosition(positions, fmt.Sprintf("%s[%d]", positionPrefix, i), fallback), 0)
 			if err != nil {
 				return nil, err
 			}
@@ -273,41 +273,53 @@ func (b planBuilder) reducePlanInstanceEventExpressions(instance JobInstance) (J
 	}
 
 	var err error
-	if instance.If, err = reduceCondition(instance.If, "job.if", instance.Source.Start, 0); err != nil {
+	if instance.If, err = reduceCondition(instance.If, "job.if", sourcePosition(instance.Positions, "if", instance.Source.Start), 0); err != nil {
 		return JobInstance{}, err
 	}
 	jobFields := []struct {
-		name  string
-		value *string
+		name     string
+		position string
+		value    *string
 	}{
-		{"job.defaults.run.shell", &instance.DefaultShell},
-		{"job.defaults.run.working-directory", &instance.DefaultWorkingDirectory},
-		{"job.services", &instance.ServicesExpression},
+		{"job.defaults.run.shell", "defaults.run.shell", &instance.DefaultShell},
+		{"job.defaults.run.working-directory", "defaults.run.working-directory", &instance.DefaultWorkingDirectory},
+		{"job.services", "services", &instance.ServicesExpression},
 	}
 	for _, field := range jobFields {
-		if *field.value, err = reduceTemplate(*field.value, field.name, instance.Source.Start, 0); err != nil {
+		if *field.value, err = reduceTemplate(*field.value, field.name, sourcePosition(instance.Positions, field.position, instance.Source.Start), 0); err != nil {
 			return JobInstance{}, err
 		}
 	}
-	if instance.Env, err = reduceMap(instance.Env, "job.env", instance.Source.Start, 0); err != nil {
+	if instance.Env, err = reduceMap(instance.Env, "job.env", "env", instance.Positions, instance.Source.Start, 0); err != nil {
 		return JobInstance{}, err
 	}
-	if instance.Outputs, err = reduceMap(instance.Outputs, "job.outputs", instance.Source.Start, 0); err != nil {
+	if instance.Outputs, err = reduceMap(instance.Outputs, "job.outputs", "outputs", instance.Positions, instance.Source.Start, 0); err != nil {
 		return JobInstance{}, err
 	}
 
 	instance.CallGuards = append([]CallGuard(nil), instance.CallGuards...)
 	for i := range instance.CallGuards {
-		if instance.CallGuards[i].Condition, err = reduceCondition(instance.CallGuards[i].Condition, fmt.Sprintf("job.call-guards[%d]", i), instance.Source.Start, 0); err != nil {
-			return JobInstance{}, err
+		guard := &instance.CallGuards[i]
+		reduced, guardErr := reduceConditionValue(guard.Condition)
+		if guardErr != nil {
+			path := guard.SourcePath
+			if path == "" {
+				path = instance.SourcePath
+			}
+			position := guard.Position
+			if position.Line == 0 || position.Column == 0 {
+				position = instance.Source.Start
+			}
+			return JobInstance{}, planExpressionFinding(instance, path, fmt.Sprintf("job.call-guards[%d]", i), guard.Condition, position, 0, guardErr)
 		}
+		guard.Condition = reduced
 	}
 
 	instance.Steps = append([]workflow.Step(nil), instance.Steps...)
 	for i := range instance.Steps {
 		step := &instance.Steps[i]
 		field := fmt.Sprintf("steps[%d]", i+1)
-		if step.If, err = reduceCondition(step.If, field+".if", step.IfSpan.Start, i+1); err != nil {
+		if step.If, err = reduceCondition(step.If, field+".if", sourcePosition(step.Positions, "if", step.IfSpan.Start), i+1); err != nil {
 			return JobInstance{}, err
 		}
 		stepTemplates := []struct {
@@ -315,7 +327,7 @@ func (b planBuilder) reducePlanInstanceEventExpressions(instance JobInstance) (J
 			value *string
 		}{{"name", &step.Name}, {"run", &step.Run}, {"shell", &step.Shell}, {"working-directory", &step.WorkingDirectory}}
 		for _, template := range stepTemplates {
-			if *template.value, err = reduceTemplate(*template.value, field+"."+template.name, step.Span.Start, i+1); err != nil {
+			if *template.value, err = reduceTemplate(*template.value, field+"."+template.name, sourcePosition(step.Positions, template.name, step.Span.Start), i+1); err != nil {
 				return JobInstance{}, err
 			}
 		}
@@ -324,14 +336,14 @@ func (b planBuilder) reducePlanInstanceEventExpressions(instance JobInstance) (J
 			value *string
 		}{{"continue-on-error", &step.ContinueOnErrorExpression}, {"timeout-minutes", &step.TimeoutMinutesExpression}}
 		for _, typed := range typedExpressions {
-			if *typed.value, err = reduceTypedExpression(*typed.value, field+"."+typed.name, step.Span.Start, i+1); err != nil {
+			if *typed.value, err = reduceTypedExpression(*typed.value, field+"."+typed.name, sourcePosition(step.Positions, typed.name, step.Span.Start), i+1); err != nil {
 				return JobInstance{}, err
 			}
 		}
-		if step.Env, err = reduceMap(step.Env, field+".env", step.Span.Start, i+1); err != nil {
+		if step.Env, err = reduceMap(step.Env, field+".env", "env", step.Positions, step.Span.Start, i+1); err != nil {
 			return JobInstance{}, err
 		}
-		if step.With, err = reduceMap(step.With, field+".with", step.Span.Start, i+1); err != nil {
+		if step.With, err = reduceMap(step.With, field+".with", "with", step.Positions, step.Span.Start, i+1); err != nil {
 			return JobInstance{}, err
 		}
 		referencesEvent, referencesErr := expression.TemplateReferencesGitHubEvent(step.Uses)
@@ -339,22 +351,22 @@ func (b planBuilder) reducePlanInstanceEventExpressions(instance JobInstance) (J
 			referencesEvent, referencesErr = expression.TemplateUsesContext(step.Uses, "event")
 		}
 		if referencesErr != nil {
-			return JobInstance{}, planExpressionFinding(instance, field+".uses", step.Uses, step.Span.Start, i+1, referencesErr)
+			return JobInstance{}, planExpressionFinding(instance, instance.SourcePath, field+".uses", step.Uses, sourcePosition(step.Positions, "uses", step.Span.Start), i+1, referencesErr)
 		}
 		if referencesEvent {
-			return JobInstance{}, planExpressionFinding(instance, field+".uses", step.Uses, step.Span.Start, i+1, errEventActionReference)
+			return JobInstance{}, planExpressionFinding(instance, instance.SourcePath, field+".uses", step.Uses, sourcePosition(step.Positions, "uses", step.Span.Start), i+1, errEventActionReference)
 		}
 	}
 
 	if instance.Container != nil {
 		container := *instance.Container
-		if container.Image, err = reduceTemplate(container.Image, "job.container.image", container.Span.Start, 0); err != nil {
+		if container.Image, err = reduceTemplate(container.Image, "job.container.image", sourcePosition(container.Positions, "image", container.Span.Start), 0); err != nil {
 			return JobInstance{}, err
 		}
-		if container.Env, err = reduceMap(container.Env, "job.container.env", container.Span.Start, 0); err != nil {
+		if container.Env, err = reduceMap(container.Env, "job.container.env", "env", container.Positions, container.Span.Start, 0); err != nil {
 			return JobInstance{}, err
 		}
-		if container.Ports, err = reduceSlice(container.Ports, "job.container.ports", container.Span.Start); err != nil {
+		if container.Ports, err = reduceSlice(container.Ports, "job.container.ports", "ports", container.Positions, container.Span.Start); err != nil {
 			return JobInstance{}, err
 		}
 		instance.Container = &container
@@ -369,25 +381,25 @@ func (b planBuilder) reducePlanInstanceEventExpressions(instance JobInstance) (J
 			value *string
 		}{{"image", &container.Image}, {"options", &container.Options}, {"command", &container.Command}, {"entrypoint", &container.Entrypoint}}
 		for _, serviceField := range serviceFields {
-			if *serviceField.value, err = reduceTemplate(*serviceField.value, field+"."+serviceField.name, container.Span.Start, 0); err != nil {
+			if *serviceField.value, err = reduceTemplate(*serviceField.value, field+"."+serviceField.name, sourcePosition(container.Positions, serviceField.name, container.Span.Start), 0); err != nil {
 				return JobInstance{}, err
 			}
 		}
-		if container.Env, err = reduceMap(container.Env, field+".env", container.Span.Start, 0); err != nil {
+		if container.Env, err = reduceMap(container.Env, field+".env", "env", container.Positions, container.Span.Start, 0); err != nil {
 			return JobInstance{}, err
 		}
-		if container.Ports, err = reduceSlice(container.Ports, field+".ports", container.Span.Start); err != nil {
+		if container.Ports, err = reduceSlice(container.Ports, field+".ports", "ports", container.Positions, container.Span.Start); err != nil {
 			return JobInstance{}, err
 		}
-		if container.Volumes, err = reduceSlice(container.Volumes, field+".volumes", container.Span.Start); err != nil {
+		if container.Volumes, err = reduceSlice(container.Volumes, field+".volumes", "volumes", container.Positions, container.Span.Start); err != nil {
 			return JobInstance{}, err
 		}
 		if container.Credentials != nil {
 			credentials := *container.Credentials
-			if credentials.Username, err = reduceTemplate(credentials.Username, field+".credentials.username", container.Span.Start, 0); err != nil {
+			if credentials.Username, err = reduceTemplate(credentials.Username, field+".credentials.username", sourcePosition(container.Positions, "credentials.username", container.Span.Start), 0); err != nil {
 				return JobInstance{}, err
 			}
-			if credentials.Password, err = reduceTemplate(credentials.Password, field+".credentials.password", container.Span.Start, 0); err != nil {
+			if credentials.Password, err = reduceTemplate(credentials.Password, field+".credentials.password", sourcePosition(container.Positions, "credentials.password", container.Span.Start), 0); err != nil {
 				return JobInstance{}, err
 			}
 			container.Credentials = &credentials
@@ -750,12 +762,19 @@ func cloneOIDCConfiguration(configuration *plan.OIDCConfiguration) *plan.OIDCCon
 	}
 }
 
-func planExpressionFinding(instance JobInstance, field, source string, position workflow.Position, step int, err error) error {
+func sourcePosition(positions map[string]workflow.Position, field string, fallback workflow.Position) workflow.Position {
+	if position := positions[field]; position.Line > 0 && position.Column > 0 {
+		return position
+	}
+	return fallback
+}
+
+func planExpressionFinding(instance JobInstance, sourcePath, field, source string, position workflow.Position, step int, err error) error {
 	finding := &ProcessingFinding{
 		Stage: StagePlans, Code: CodePlanConstruction, Category: "compatibility",
-		Path: instance.SourcePath, Line: position.Line, Column: position.Column,
+		Path: sourcePath, Line: position.Line, Column: position.Column,
 		Job: instance.LogicalJobID, Instance: instance.Key, Step: step,
-		Err: fmt.Errorf("%s:%d:%d: job %q %s expression %q: %w", instance.SourcePath, position.Line, position.Column, instance.LogicalJobID, field, source, err),
+		Err: fmt.Errorf("%s:%d:%d: job %q %s expression %q: %w", sourcePath, position.Line, position.Column, instance.LogicalJobID, field, source, err),
 	}
 	if errors.Is(err, errRetainedGitHubEvent) || strings.Contains(err.Error(), "whole github.event access is unsupported") {
 		finding.Message = "This expression uses the whole GitHub event or accesses it dynamically. Reference a specific scalar property, such as github.event.pull_request.head.sha. The full event payload is unavailable at runtime."

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -47,6 +47,8 @@ type sourcedCallGuard struct {
 	condition    string
 	inputs       reusableInputs
 	needBindings map[string]needBinding
+	sourcePath   string
+	position     workflow.Position
 }
 
 type reusableInputs struct {
@@ -289,6 +291,7 @@ func (resolver *reusableResolver) resolve(ctx context.Context, current reusableW
 			}
 			calleeGuards = append(cloneSourcedCallGuards(callGuards), sourcedCallGuard{
 				condition: condition, inputs: cloneReusableInputs(inputs), needBindings: cloneNeedBindings(callNeedBindings),
+				sourcePath: path, position: job.IfSpan.Start,
 			})
 		}
 		if call.Secrets {
@@ -610,6 +613,7 @@ func cloneSourcedCallGuards(guards []sourcedCallGuard) []sourcedCallGuard {
 	for i, guard := range guards {
 		cloned[i] = sourcedCallGuard{
 			condition: guard.condition, inputs: cloneReusableInputs(guard.inputs), needBindings: cloneNeedBindings(guard.needBindings),
+			sourcePath: guard.sourcePath, position: guard.position,
 		}
 	}
 	return cloned

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -45,6 +45,7 @@ type sourcedJob struct {
 
 type sourcedCallGuard struct {
 	condition    string
+	source       string
 	inputs       reusableInputs
 	needBindings map[string]needBinding
 	sourcePath   string
@@ -290,7 +291,7 @@ func (resolver *reusableResolver) resolve(ctx context.Context, current reusableW
 				return reusableResolution{}, jobError(path, job, fmt.Sprintf("reusable-workflow call condition: %v", err))
 			}
 			calleeGuards = append(cloneSourcedCallGuards(callGuards), sourcedCallGuard{
-				condition: condition, inputs: cloneReusableInputs(inputs), needBindings: cloneNeedBindings(callNeedBindings),
+				condition: condition, source: sourceValue(job.Sources, "if", job.If), inputs: cloneReusableInputs(inputs), needBindings: cloneNeedBindings(callNeedBindings),
 				sourcePath: path, position: job.IfSpan.Start,
 			})
 		}
@@ -612,7 +613,7 @@ func cloneSourcedCallGuards(guards []sourcedCallGuard) []sourcedCallGuard {
 	cloned := make([]sourcedCallGuard, len(guards))
 	for i, guard := range guards {
 		cloned[i] = sourcedCallGuard{
-			condition: guard.condition, inputs: cloneReusableInputs(guard.inputs), needBindings: cloneNeedBindings(guard.needBindings),
+			condition: guard.condition, source: guard.source, inputs: cloneReusableInputs(guard.inputs), needBindings: cloneNeedBindings(guard.needBindings),
 			sourcePath: guard.sourcePath, position: guard.position,
 		}
 	}

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -138,14 +138,16 @@ type Job struct {
 	DefaultWorkingDirectory string                 `json:"default_working_directory,omitempty"`
 	Steps                   []Step                 `json:"steps"`
 	Span                    Span                   `json:"span"`
+	Positions               map[string]Position    `json:"-"`
 }
 
 // Container is the statically owned subset of a GitHub Actions container.
 type Container struct {
-	Image string            `json:"image"`
-	Env   map[string]string `json:"env,omitempty"`
-	Ports []string          `json:"ports,omitempty"`
-	Span  Span              `json:"span"`
+	Image     string              `json:"image"`
+	Env       map[string]string   `json:"env,omitempty"`
+	Ports     []string            `json:"ports,omitempty"`
+	Span      Span                `json:"span"`
+	Positions map[string]Position `json:"-"`
 }
 
 // Service is a named service container. Services retain workflow declaration
@@ -166,6 +168,7 @@ type ServiceContainer struct {
 	Command     string                `json:"command,omitempty"`
 	Entrypoint  string                `json:"entrypoint,omitempty"`
 	Span        Span                  `json:"span"`
+	Positions   map[string]Position   `json:"-"`
 }
 
 type ContainerCredentials struct {
@@ -214,22 +217,23 @@ type Value struct {
 
 // Step is the execution data retained in the workflow compiler IR.
 type Step struct {
-	ID                        string            `json:"id,omitempty"`
-	Name                      string            `json:"name,omitempty"`
-	Kind                      string            `json:"kind"`
-	Background                bool              `json:"background,omitempty"`
-	Targets                   []string          `json:"targets,omitempty"`
-	Run                       string            `json:"run,omitempty"`
-	Uses                      string            `json:"uses,omitempty"`
-	Shell                     string            `json:"shell,omitempty"`
-	WorkingDirectory          string            `json:"working_directory,omitempty"`
-	Env                       map[string]string `json:"env,omitempty"`
-	With                      map[string]string `json:"with,omitempty"`
-	If                        string            `json:"if,omitempty"`
-	IfSpan                    Span              `json:"-"`
-	ContinueOnError           bool              `json:"continue_on_error,omitempty"`
-	ContinueOnErrorExpression string            `json:"continue_on_error_expression,omitempty"`
-	TimeoutMinutes            float64           `json:"timeout_minutes,omitempty"`
-	TimeoutMinutesExpression  string            `json:"timeout_minutes_expression,omitempty"`
-	Span                      Span              `json:"span"`
+	ID                        string              `json:"id,omitempty"`
+	Name                      string              `json:"name,omitempty"`
+	Kind                      string              `json:"kind"`
+	Background                bool                `json:"background,omitempty"`
+	Targets                   []string            `json:"targets,omitempty"`
+	Run                       string              `json:"run,omitempty"`
+	Uses                      string              `json:"uses,omitempty"`
+	Shell                     string              `json:"shell,omitempty"`
+	WorkingDirectory          string              `json:"working_directory,omitempty"`
+	Env                       map[string]string   `json:"env,omitempty"`
+	With                      map[string]string   `json:"with,omitempty"`
+	If                        string              `json:"if,omitempty"`
+	IfSpan                    Span                `json:"-"`
+	ContinueOnError           bool                `json:"continue_on_error,omitempty"`
+	ContinueOnErrorExpression string              `json:"continue_on_error_expression,omitempty"`
+	TimeoutMinutes            float64             `json:"timeout_minutes,omitempty"`
+	TimeoutMinutesExpression  string              `json:"timeout_minutes_expression,omitempty"`
+	Span                      Span                `json:"span"`
+	Positions                 map[string]Position `json:"-"`
 }

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -29,6 +29,8 @@ type Workflow struct {
 	RequiredCallSecrets     []string              `json:"required_call_secrets,omitempty"`
 	Callable                bool                  `json:"callable,omitempty"`
 	Jobs                    []Job                 `json:"jobs"`
+	Positions               map[string]Position   `json:"-"`
+	Sources                 map[string]string     `json:"-"`
 }
 
 // ReusableOnly reports whether the workflow can only be invoked through
@@ -139,6 +141,7 @@ type Job struct {
 	Steps                   []Step                 `json:"steps"`
 	Span                    Span                   `json:"span"`
 	Positions               map[string]Position    `json:"-"`
+	Sources                 map[string]string      `json:"-"`
 }
 
 // Container is the statically owned subset of a GitHub Actions container.
@@ -148,6 +151,7 @@ type Container struct {
 	Ports     []string            `json:"ports,omitempty"`
 	Span      Span                `json:"span"`
 	Positions map[string]Position `json:"-"`
+	Sources   map[string]string   `json:"-"`
 }
 
 // Service is a named service container. Services retain workflow declaration
@@ -169,6 +173,7 @@ type ServiceContainer struct {
 	Entrypoint  string                `json:"entrypoint,omitempty"`
 	Span        Span                  `json:"span"`
 	Positions   map[string]Position   `json:"-"`
+	Sources     map[string]string     `json:"-"`
 }
 
 type ContainerCredentials struct {
@@ -236,4 +241,5 @@ type Step struct {
 	TimeoutMinutesExpression  string              `json:"timeout_minutes_expression,omitempty"`
 	Span                      Span                `json:"span"`
 	Positions                 map[string]Position `json:"-"`
+	Sources                   map[string]string   `json:"-"`
 }

--- a/internal/workflow/parse.go
+++ b/internal/workflow/parse.go
@@ -45,6 +45,7 @@ type rawServiceContainer struct {
 	Command     string
 	Entrypoint  string
 	Order       int
+	Positions   map[string]Position
 }
 
 // Parse uses actionlint as the syntax frontend and immediately converts its AST
@@ -406,7 +407,7 @@ func rawConcurrencyCancellation(concurrency *yaml.Node) *Position {
 }
 
 func validateRawContainer(path string, node *yaml.Node, service bool) (rawServiceContainer, []expectedActionlintDiagnostic, error) {
-	var extra rawServiceContainer
+	extra := rawServiceContainer{Positions: map[string]Position{}}
 	var diagnostics []expectedActionlintDiagnostic
 	image := node
 	if node.Kind == yaml.MappingNode {
@@ -434,9 +435,11 @@ func validateRawContainer(path string, node *yaml.Node, service bool) (rawServic
 				extra.Credentials = &ContainerCredentials{}
 				if username != nil {
 					extra.Credentials.Username = username.Value
+					extra.Positions["credentials.username"] = nodePosition(username)
 				}
 				if password != nil {
 					extra.Credentials.Password = password.Value
+					extra.Positions["credentials.password"] = nodePosition(password)
 				}
 				if (username == nil) != (password == nil) {
 					diagnostics = append(diagnostics, expectedActionlintDiagnostic{Position: nodePosition(mappingKey(node, "credentials")), Prefix: "both \"username\" and \"password\" must be specified"})
@@ -452,6 +455,7 @@ func validateRawContainer(path string, node *yaml.Node, service bool) (rawServic
 						return extra, nil, rawError(path, value, "invalid service container "+field.name)
 					}
 					*field.dest = value.Value
+					extra.Positions[field.name] = nodePosition(value)
 					key := mappingKey(node, field.name)
 					diagnostics = append(diagnostics, expectedActionlintDiagnostic{Position: nodePosition(key), Prefix: "unexpected key \"" + field.name + "\""})
 				}
@@ -465,6 +469,7 @@ func validateRawContainer(path string, node *yaml.Node, service bool) (rawServic
 		return extra, nil, rawError(path, image, "invalid container image")
 	}
 	extra.Image = image.Value
+	extra.Positions["image"] = nodePosition(image)
 	env := mappingValue(node, "env")
 	if env != nil && env.Kind == yaml.MappingNode {
 		if len(env.Content)/2 > 256 {
@@ -485,6 +490,7 @@ func validateRawContainer(path string, node *yaml.Node, service bool) (rawServic
 					extra.Env = map[string]string{}
 				}
 				extra.Env[key.Value] = value.Value
+				extra.Positions["env."+key.Value] = nodePosition(value)
 			}
 		}
 		if total > 1048576 {
@@ -497,13 +503,14 @@ func validateRawContainer(path string, node *yaml.Node, service bool) (rawServic
 			return extra, nil, rawError(path, ports, "container has more than 128 ports")
 		}
 		seen := map[string]bool{}
-		for _, port := range ports.Content {
+		for i, port := range ports.Content {
 			if port.Kind != yaml.ScalarNode || len(port.Value) > 4096 || strings.ContainsAny(port.Value, "\x00\r\n") || seen[port.Value] || !service && !containerPortPattern.MatchString(port.Value) {
 				return extra, nil, rawError(path, port, "invalid or repeated container port")
 			}
 			seen[port.Value] = true
 			if service {
 				extra.Ports = append(extra.Ports, port.Value)
+				extra.Positions[fmt.Sprintf("ports[%d]", i)] = nodePosition(port)
 			}
 		}
 	}
@@ -513,11 +520,12 @@ func validateRawContainer(path string, node *yaml.Node, service bool) (rawServic
 			if volumes.Kind != yaml.SequenceNode || len(volumes.Content) > 128 {
 				return extra, nil, rawError(path, volumes, "invalid service container volumes")
 			}
-			for _, volume := range volumes.Content {
+			for i, volume := range volumes.Content {
 				if volume.Kind != yaml.ScalarNode || len(volume.Value) > 4096 || strings.ContainsAny(volume.Value, "\x00\r\n") {
 					return extra, nil, rawError(path, volume, "invalid service container volume")
 				}
 				extra.Volumes = append(extra.Volumes, volume.Value)
+				extra.Positions[fmt.Sprintf("volumes[%d]", i)] = nodePosition(volume)
 			}
 		}
 		if options := mappingValue(node, "options"); options != nil {
@@ -525,13 +533,14 @@ func validateRawContainer(path string, node *yaml.Node, service bool) (rawServic
 				return extra, nil, rawError(path, options, "invalid service container options")
 			}
 			extra.Options = options.Value
+			extra.Positions["options"] = nodePosition(options)
 		}
 	}
 	return extra, diagnostics, nil
 }
 
 func adaptJob(path string, in *actionlint.Job, scalars map[Position]any, concurrency map[Position]stepConcurrency, serviceContainers map[string]rawServiceContainer) (Job, error) {
-	out := Job{ID: in.ID.Value, Span: pointSpan(in.Pos)}
+	out := Job{ID: in.ID.Value, Span: pointSpan(in.Pos), Positions: map[string]Position{}}
 	if in.Environment != nil {
 		return Job{}, locatedError(path, in.Environment.Pos, fmt.Sprintf("job %q", in.ID.Value), "GitHub environments and environment secrets are unsupported")
 	}
@@ -566,6 +575,7 @@ func adaptJob(path string, in *actionlint.Job, scalars map[Position]any, concurr
 	if in.If != nil {
 		out.If = in.If.Value
 		out.IfSpan = spanFrom(in.If.Pos, in.If.Value)
+		out.Positions["if"] = pointSpan(in.If.Pos).Start
 	}
 	if in.Container != nil {
 		container, err := adaptContainer(path, in.ID.Value, in.Container)
@@ -577,6 +587,7 @@ func adaptJob(path string, in *actionlint.Job, scalars map[Position]any, concurr
 	if in.Services != nil {
 		if in.Services.Expression != nil {
 			out.ServicesExpression = in.Services.Expression.Value
+			out.Positions["services"] = pointSpan(in.Services.Expression.Pos).Start
 			if err := expression.ValidateServiceMapRuntimeExpression(out.ServicesExpression); err != nil {
 				return Job{}, locatedError(path, in.Services.Expression.Pos, in.ID.Value, err.Error())
 			}
@@ -629,18 +640,22 @@ func adaptJob(path string, in *actionlint.Job, scalars map[Position]any, concurr
 		out.Name = in.Name.Value
 	}
 	out.Env = adaptEnv(in.Env)
+	out.Positions = mergePositions(out.Positions, adaptEnvPositions("env", in.Env))
 	if in.Defaults != nil && in.Defaults.Run != nil {
 		if in.Defaults.Run.Shell != nil {
 			out.DefaultShell = in.Defaults.Run.Shell.Value
+			out.Positions["defaults.run.shell"] = pointSpan(in.Defaults.Run.Shell.Pos).Start
 		}
 		if in.Defaults.Run.WorkingDirectory != nil {
 			out.DefaultWorkingDirectory = in.Defaults.Run.WorkingDirectory.Value
+			out.Positions["defaults.run.working-directory"] = pointSpan(in.Defaults.Run.WorkingDirectory.Pos).Start
 		}
 	}
 	if len(in.Outputs) != 0 {
 		out.Outputs = make(map[string]string, len(in.Outputs))
 		for name, output := range in.Outputs {
 			out.Outputs[name] = output.Value.Value
+			out.Positions["outputs."+name] = pointSpan(output.Value.Pos).Start
 		}
 	}
 	for _, need := range in.Needs {
@@ -712,20 +727,23 @@ func adaptJob(path string, in *actionlint.Job, scalars map[Position]any, concurr
 			out.Span.End = barrier.Span.End
 			continue
 		}
-		owned := Step{Background: control.Background, Targets: append([]string(nil), control.Targets...), Span: pointSpan(step.Pos)}
+		owned := Step{Background: control.Background, Targets: append([]string(nil), control.Targets...), Span: pointSpan(step.Pos), Positions: map[string]Position{}}
 		if step.ID != nil {
 			owned.ID = step.ID.Value
 		}
 		if step.Name != nil {
 			owned.Name = step.Name.Value
+			owned.Positions["name"] = pointSpan(step.Name.Pos).Start
 		}
 		if step.If != nil {
 			owned.If = step.If.Value
 			owned.IfSpan = spanFrom(step.If.Pos, step.If.Value)
+			owned.Positions["if"] = pointSpan(step.If.Pos).Start
 		}
 		if step.ContinueOnError != nil {
 			if step.ContinueOnError.Expression != nil {
 				owned.ContinueOnErrorExpression = step.ContinueOnError.Expression.Value
+				owned.Positions["continue-on-error"] = pointSpan(step.ContinueOnError.Expression.Pos).Start
 			} else {
 				owned.ContinueOnError = step.ContinueOnError.Value
 			}
@@ -733,6 +751,7 @@ func adaptJob(path string, in *actionlint.Job, scalars map[Position]any, concurr
 		if step.TimeoutMinutes != nil {
 			if step.TimeoutMinutes.Expression != nil {
 				owned.TimeoutMinutesExpression = step.TimeoutMinutes.Expression.Value
+				owned.Positions["timeout-minutes"] = pointSpan(step.TimeoutMinutes.Expression.Pos).Start
 			} else {
 				owned.TimeoutMinutes = step.TimeoutMinutes.Value
 			}
@@ -741,15 +760,19 @@ func adaptJob(path string, in *actionlint.Job, scalars map[Position]any, concurr
 			return Job{}, locatedError(path, step.Env.Expression.Pos, in.ID.Value, "expression-valued step env is unsupported")
 		}
 		owned.Env = adaptEnv(step.Env)
+		owned.Positions = mergePositions(owned.Positions, adaptEnvPositions("env", step.Env))
 		switch exec := step.Exec.(type) {
 		case *actionlint.ExecRun:
 			owned.Kind = "run"
 			owned.Run = exec.Run.Value
+			owned.Positions["run"] = pointSpan(exec.Run.Pos).Start
 			if exec.Shell != nil {
 				owned.Shell = exec.Shell.Value
+				owned.Positions["shell"] = pointSpan(exec.Shell.Pos).Start
 			}
 			if exec.WorkingDirectory != nil {
 				owned.WorkingDirectory = exec.WorkingDirectory.Value
+				owned.Positions["working-directory"] = pointSpan(exec.WorkingDirectory.Pos).Start
 			}
 			owned.Span = spanFrom(step.Pos, exec.Run.Value)
 		case *actionlint.ExecAction:
@@ -762,10 +785,12 @@ func adaptJob(path string, in *actionlint.Job, scalars map[Position]any, concurr
 			}
 			owned.Kind = "uses"
 			owned.Uses = exec.Uses.Value
+			owned.Positions["uses"] = pointSpan(exec.Uses.Pos).Start
 			if len(exec.Inputs) != 0 {
 				owned.With = make(map[string]string, len(exec.Inputs))
 				for name, input := range exec.Inputs {
 					owned.With[name] = input.Value.Value
+					owned.Positions["with."+name] = pointSpan(input.Value.Pos).Start
 				}
 			}
 			owned.Span = spanFrom(step.Pos, exec.Uses.Value)
@@ -909,6 +934,27 @@ func adaptEnv(in *actionlint.Env) map[string]string {
 	return out
 }
 
+func adaptEnvPositions(prefix string, in *actionlint.Env) map[string]Position {
+	if in == nil || len(in.Vars) == 0 {
+		return nil
+	}
+	positions := make(map[string]Position, len(in.Vars))
+	for _, variable := range in.Vars {
+		positions[prefix+"."+variable.Name.Value] = pointSpan(variable.Value.Pos).Start
+	}
+	return positions
+}
+
+func mergePositions(base, additional map[string]Position) map[string]Position {
+	if base == nil && len(additional) != 0 {
+		base = make(map[string]Position, len(additional))
+	}
+	for name, position := range additional {
+		base[name] = position
+	}
+	return base
+}
+
 var serviceIDPattern = regexp.MustCompile(`^[a-z_][a-z0-9_-]*$`)
 
 func adaptContainer(path, jobID string, in *actionlint.Container) (Container, error) {
@@ -934,12 +980,14 @@ func adaptContainer(path, jobID string, in *actionlint.Container) (Container, er
 			}
 		}
 	}
-	out := Container{Image: in.Image.Value, Env: adaptEnv(in.Env), Span: pointSpan(in.Pos)}
-	for _, port := range in.Ports {
+	out := Container{Image: in.Image.Value, Env: adaptEnv(in.Env), Span: pointSpan(in.Pos), Positions: map[string]Position{"image": pointSpan(in.Image.Pos).Start}}
+	out.Positions = mergePositions(out.Positions, adaptEnvPositions("env", in.Env))
+	for i, port := range in.Ports {
 		if port.ContainsExpression() {
 			return Container{}, locatedError(path, port.Pos, jobID, "expression-valued container port is unsupported")
 		}
 		out.Ports = append(out.Ports, port.Value)
+		out.Positions[fmt.Sprintf("ports[%d]", i)] = pointSpan(port.Pos).Start
 	}
 	return out, nil
 }
@@ -951,7 +999,7 @@ func adaptServiceContainer(path, jobID string, in *actionlint.Container, raw raw
 	if in.Env != nil && in.Env.Expression != nil {
 		return ServiceContainer{}, locatedError(path, in.Env.Expression.Pos, jobID, "expression-valued service container env is unsupported")
 	}
-	out := ServiceContainer{Image: raw.Image, Credentials: raw.Credentials, Env: raw.Env, Ports: raw.Ports, Volumes: raw.Volumes, Options: raw.Options, Command: raw.Command, Entrypoint: raw.Entrypoint, Span: pointSpan(in.Pos)}
+	out := ServiceContainer{Image: raw.Image, Credentials: raw.Credentials, Env: raw.Env, Ports: raw.Ports, Volumes: raw.Volumes, Options: raw.Options, Command: raw.Command, Entrypoint: raw.Entrypoint, Span: pointSpan(in.Pos), Positions: raw.Positions}
 	return out, nil
 }
 
@@ -1289,7 +1337,7 @@ func parseParallelStep(path string, node *yaml.Node) (Step, error) {
 	if execution.Kind != yaml.ScalarNode || execution.ShortTag() == "!!null" || strings.TrimSpace(execution.Value) == "" {
 		return Step{}, yamlNodeError(path, execution, "parallel member execution must be a non-empty scalar")
 	}
-	step := Step{Span: yamlStepSpan(node, execution)}
+	step := Step{Span: yamlStepSpan(node, execution), Positions: map[string]Position{}}
 	var err error
 	if step.ID, err = optionalString(entries["id"]); err != nil {
 		return Step{}, yamlNodeError(path, entries["id"], "parallel member id must be a string")
@@ -1297,15 +1345,20 @@ func parseParallelStep(path string, node *yaml.Node) (Step, error) {
 	if step.Name, err = optionalScalar(entries["name"]); err != nil {
 		return Step{}, yamlNodeError(path, entries["name"], "parallel member name must be a scalar")
 	}
+	if entries["name"] != nil {
+		step.Positions["name"] = nodePosition(entries["name"])
+	}
 	if step.If, err = optionalScalar(entries["if"]); err != nil {
 		return Step{}, yamlNodeError(path, entries["if"], "parallel member if must be a scalar")
 	}
 	if value := entries["if"]; value != nil {
 		step.IfSpan = yamlStepSpan(value, value)
+		step.Positions["if"] = nodePosition(value)
 	}
 	if step.Env, err = scalarMap(entries["env"]); err != nil {
 		return Step{}, yamlNodeError(path, entries["env"], "parallel member env must be a scalar mapping")
 	}
+	step.Positions = mergePositions(step.Positions, scalarMapPositions("env", entries["env"]))
 	if value := entries["continue-on-error"]; value != nil {
 		if value.Kind != yaml.ScalarNode || value.ShortTag() != "!!bool" {
 			return Step{}, yamlNodeError(path, value, "parallel member continue-on-error must be a literal boolean")
@@ -1329,11 +1382,18 @@ func parseParallelStep(path string, node *yaml.Node) (Step, error) {
 		}
 		step.Kind = "run"
 		step.Run = run.Value
+		step.Positions["run"] = nodePosition(run)
 		if step.Shell, err = optionalScalar(entries["shell"]); err != nil {
 			return Step{}, yamlNodeError(path, entries["shell"], "parallel member shell must be a scalar")
 		}
+		if entries["shell"] != nil {
+			step.Positions["shell"] = nodePosition(entries["shell"])
+		}
 		if step.WorkingDirectory, err = optionalScalar(entries["working-directory"]); err != nil {
 			return Step{}, yamlNodeError(path, entries["working-directory"], "parallel member working-directory must be a scalar")
+		}
+		if entries["working-directory"] != nil {
+			step.Positions["working-directory"] = nodePosition(entries["working-directory"])
 		}
 		return step, nil
 	}
@@ -1342,14 +1402,18 @@ func parseParallelStep(path string, node *yaml.Node) (Step, error) {
 	}
 	step.Kind = "uses"
 	step.Uses = uses.Value
+	step.Positions["uses"] = nodePosition(uses)
 	if step.With, err = scalarMap(entries["with"]); err != nil {
 		return Step{}, yamlNodeError(path, entries["with"], "parallel member with must be a scalar mapping")
 	}
+	step.Positions = mergePositions(step.Positions, scalarMapPositions("with", entries["with"]))
 	for name, value := range step.With {
 		lower := strings.ToLower(name)
 		if lower != name {
 			delete(step.With, name)
 			step.With[lower] = value
+			step.Positions["with."+lower] = step.Positions["with."+name]
+			delete(step.Positions, "with."+name)
 		}
 	}
 	_, hasEntrypoint := step.With["entrypoint"]
@@ -1425,6 +1489,17 @@ func scalarMap(node *yaml.Node) (map[string]string, error) {
 		values[key.Value] = value.Value
 	}
 	return values, nil
+}
+
+func scalarMapPositions(prefix string, node *yaml.Node) map[string]Position {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	positions := make(map[string]Position, len(node.Content)/2)
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		positions[prefix+"."+node.Content[i].Value] = nodePosition(node.Content[i+1])
+	}
+	return positions
 }
 
 func parallelStepID(position Position, member int) string {

--- a/internal/workflow/parse.go
+++ b/internal/workflow/parse.go
@@ -46,6 +46,7 @@ type rawServiceContainer struct {
 	Entrypoint  string
 	Order       int
 	Positions   map[string]Position
+	Sources     map[string]string
 }
 
 // Parse uses actionlint as the syntax frontend and immediately converts its AST
@@ -74,7 +75,7 @@ func Parse(path string, source []byte) (*Workflow, error) {
 		return nil, fmt.Errorf("%s: parse scalar values: %w", path, err)
 	}
 
-	owned := &Workflow{}
+	owned := &Workflow{Positions: map[string]Position{}, Sources: map[string]string{}}
 	owned.Triggers = adaptTriggers(parsed.On)
 	if parsed.Name != nil {
 		owned.Name = parsed.Name.Value
@@ -98,6 +99,8 @@ func Parse(path string, source []byte) (*Workflow, error) {
 		return nil, locatedError(path, parsed.Env.Expression.Pos, "workflow", "expression-valued workflow env is unsupported")
 	}
 	owned.Env = adaptEnv(parsed.Env)
+	owned.Positions = mergePositions(owned.Positions, adaptEnvPositions("env", parsed.Env))
+	owned.Sources = mergeSources(owned.Sources, mapSources("env", owned.Env))
 	envNames := make([]string, 0, len(owned.Env))
 	for name := range owned.Env {
 		envNames = append(envNames, name)
@@ -111,9 +114,13 @@ func Parse(path string, source []byte) (*Workflow, error) {
 	if parsed.Defaults != nil && parsed.Defaults.Run != nil {
 		if parsed.Defaults.Run.Shell != nil {
 			owned.DefaultShell = parsed.Defaults.Run.Shell.Value
+			owned.Positions["defaults.run.shell"] = pointSpan(parsed.Defaults.Run.Shell.Pos).Start
+			owned.Sources["defaults.run.shell"] = owned.DefaultShell
 		}
 		if parsed.Defaults.Run.WorkingDirectory != nil {
 			owned.DefaultWorkingDirectory = parsed.Defaults.Run.WorkingDirectory.Value
+			owned.Positions["defaults.run.working-directory"] = pointSpan(parsed.Defaults.Run.WorkingDirectory.Pos).Start
+			owned.Sources["defaults.run.working-directory"] = owned.DefaultWorkingDirectory
 		}
 		if err := expression.ValidateRuntimeTemplate(owned.DefaultShell); err != nil {
 			return nil, fmt.Errorf("%s: workflow default shell: %w", path, err)
@@ -191,12 +198,23 @@ func Parse(path string, source []byte) (*Workflow, error) {
 			job.Concurrency.CancelInProgress = true
 			job.Concurrency.CancelInProgressPosition = position
 		}
+		for name := range owned.Env {
+			field := "env." + name
+			if _, exists := job.Env[name]; !exists {
+				job.Positions[field] = owned.Positions[field]
+				job.Sources[field] = owned.Sources[field]
+			}
+		}
 		job.Env = mergeEnv(owned.Env, job.Env)
 		if job.DefaultShell == "" {
 			job.DefaultShell = owned.DefaultShell
+			job.Positions["defaults.run.shell"] = owned.Positions["defaults.run.shell"]
+			job.Sources["defaults.run.shell"] = owned.Sources["defaults.run.shell"]
 		}
 		if job.DefaultWorkingDirectory == "" {
 			job.DefaultWorkingDirectory = owned.DefaultWorkingDirectory
+			job.Positions["defaults.run.working-directory"] = owned.Positions["defaults.run.working-directory"]
+			job.Sources["defaults.run.working-directory"] = owned.Sources["defaults.run.working-directory"]
 		}
 		owned.Jobs = append(owned.Jobs, job)
 	}
@@ -407,7 +425,7 @@ func rawConcurrencyCancellation(concurrency *yaml.Node) *Position {
 }
 
 func validateRawContainer(path string, node *yaml.Node, service bool) (rawServiceContainer, []expectedActionlintDiagnostic, error) {
-	extra := rawServiceContainer{Positions: map[string]Position{}}
+	extra := rawServiceContainer{Positions: map[string]Position{}, Sources: map[string]string{}}
 	var diagnostics []expectedActionlintDiagnostic
 	image := node
 	if node.Kind == yaml.MappingNode {
@@ -436,10 +454,12 @@ func validateRawContainer(path string, node *yaml.Node, service bool) (rawServic
 				if username != nil {
 					extra.Credentials.Username = username.Value
 					extra.Positions["credentials.username"] = nodePosition(username)
+					extra.Sources["credentials.username"] = username.Value
 				}
 				if password != nil {
 					extra.Credentials.Password = password.Value
 					extra.Positions["credentials.password"] = nodePosition(password)
+					extra.Sources["credentials.password"] = password.Value
 				}
 				if (username == nil) != (password == nil) {
 					diagnostics = append(diagnostics, expectedActionlintDiagnostic{Position: nodePosition(mappingKey(node, "credentials")), Prefix: "both \"username\" and \"password\" must be specified"})
@@ -456,6 +476,7 @@ func validateRawContainer(path string, node *yaml.Node, service bool) (rawServic
 					}
 					*field.dest = value.Value
 					extra.Positions[field.name] = nodePosition(value)
+					extra.Sources[field.name] = value.Value
 					key := mappingKey(node, field.name)
 					diagnostics = append(diagnostics, expectedActionlintDiagnostic{Position: nodePosition(key), Prefix: "unexpected key \"" + field.name + "\""})
 				}
@@ -470,6 +491,7 @@ func validateRawContainer(path string, node *yaml.Node, service bool) (rawServic
 	}
 	extra.Image = image.Value
 	extra.Positions["image"] = nodePosition(image)
+	extra.Sources["image"] = image.Value
 	env := mappingValue(node, "env")
 	if env != nil && env.Kind == yaml.MappingNode {
 		if len(env.Content)/2 > 256 {
@@ -491,6 +513,7 @@ func validateRawContainer(path string, node *yaml.Node, service bool) (rawServic
 				}
 				extra.Env[key.Value] = value.Value
 				extra.Positions["env."+key.Value] = nodePosition(value)
+				extra.Sources["env."+key.Value] = value.Value
 			}
 		}
 		if total > 1048576 {
@@ -511,6 +534,7 @@ func validateRawContainer(path string, node *yaml.Node, service bool) (rawServic
 			if service {
 				extra.Ports = append(extra.Ports, port.Value)
 				extra.Positions[fmt.Sprintf("ports[%d]", i)] = nodePosition(port)
+				extra.Sources[fmt.Sprintf("ports[%d]", i)] = port.Value
 			}
 		}
 	}
@@ -526,6 +550,7 @@ func validateRawContainer(path string, node *yaml.Node, service bool) (rawServic
 				}
 				extra.Volumes = append(extra.Volumes, volume.Value)
 				extra.Positions[fmt.Sprintf("volumes[%d]", i)] = nodePosition(volume)
+				extra.Sources[fmt.Sprintf("volumes[%d]", i)] = volume.Value
 			}
 		}
 		if options := mappingValue(node, "options"); options != nil {
@@ -534,13 +559,14 @@ func validateRawContainer(path string, node *yaml.Node, service bool) (rawServic
 			}
 			extra.Options = options.Value
 			extra.Positions["options"] = nodePosition(options)
+			extra.Sources["options"] = options.Value
 		}
 	}
 	return extra, diagnostics, nil
 }
 
 func adaptJob(path string, in *actionlint.Job, scalars map[Position]any, concurrency map[Position]stepConcurrency, serviceContainers map[string]rawServiceContainer) (Job, error) {
-	out := Job{ID: in.ID.Value, Span: pointSpan(in.Pos), Positions: map[string]Position{}}
+	out := Job{ID: in.ID.Value, Span: pointSpan(in.Pos), Positions: map[string]Position{}, Sources: map[string]string{}}
 	if in.Environment != nil {
 		return Job{}, locatedError(path, in.Environment.Pos, fmt.Sprintf("job %q", in.ID.Value), "GitHub environments and environment secrets are unsupported")
 	}
@@ -576,6 +602,7 @@ func adaptJob(path string, in *actionlint.Job, scalars map[Position]any, concurr
 		out.If = in.If.Value
 		out.IfSpan = spanFrom(in.If.Pos, in.If.Value)
 		out.Positions["if"] = pointSpan(in.If.Pos).Start
+		out.Sources["if"] = out.If
 	}
 	if in.Container != nil {
 		container, err := adaptContainer(path, in.ID.Value, in.Container)
@@ -588,6 +615,7 @@ func adaptJob(path string, in *actionlint.Job, scalars map[Position]any, concurr
 		if in.Services.Expression != nil {
 			out.ServicesExpression = in.Services.Expression.Value
 			out.Positions["services"] = pointSpan(in.Services.Expression.Pos).Start
+			out.Sources["services"] = out.ServicesExpression
 			if err := expression.ValidateServiceMapRuntimeExpression(out.ServicesExpression); err != nil {
 				return Job{}, locatedError(path, in.Services.Expression.Pos, in.ID.Value, err.Error())
 			}
@@ -641,14 +669,17 @@ func adaptJob(path string, in *actionlint.Job, scalars map[Position]any, concurr
 	}
 	out.Env = adaptEnv(in.Env)
 	out.Positions = mergePositions(out.Positions, adaptEnvPositions("env", in.Env))
+	out.Sources = mergeSources(out.Sources, mapSources("env", out.Env))
 	if in.Defaults != nil && in.Defaults.Run != nil {
 		if in.Defaults.Run.Shell != nil {
 			out.DefaultShell = in.Defaults.Run.Shell.Value
 			out.Positions["defaults.run.shell"] = pointSpan(in.Defaults.Run.Shell.Pos).Start
+			out.Sources["defaults.run.shell"] = out.DefaultShell
 		}
 		if in.Defaults.Run.WorkingDirectory != nil {
 			out.DefaultWorkingDirectory = in.Defaults.Run.WorkingDirectory.Value
 			out.Positions["defaults.run.working-directory"] = pointSpan(in.Defaults.Run.WorkingDirectory.Pos).Start
+			out.Sources["defaults.run.working-directory"] = out.DefaultWorkingDirectory
 		}
 	}
 	if len(in.Outputs) != 0 {
@@ -656,6 +687,7 @@ func adaptJob(path string, in *actionlint.Job, scalars map[Position]any, concurr
 		for name, output := range in.Outputs {
 			out.Outputs[name] = output.Value.Value
 			out.Positions["outputs."+name] = pointSpan(output.Value.Pos).Start
+			out.Sources["outputs."+name] = output.Value.Value
 		}
 	}
 	for _, need := range in.Needs {
@@ -727,23 +759,26 @@ func adaptJob(path string, in *actionlint.Job, scalars map[Position]any, concurr
 			out.Span.End = barrier.Span.End
 			continue
 		}
-		owned := Step{Background: control.Background, Targets: append([]string(nil), control.Targets...), Span: pointSpan(step.Pos), Positions: map[string]Position{}}
+		owned := Step{Background: control.Background, Targets: append([]string(nil), control.Targets...), Span: pointSpan(step.Pos), Positions: map[string]Position{}, Sources: map[string]string{}}
 		if step.ID != nil {
 			owned.ID = step.ID.Value
 		}
 		if step.Name != nil {
 			owned.Name = step.Name.Value
 			owned.Positions["name"] = pointSpan(step.Name.Pos).Start
+			owned.Sources["name"] = owned.Name
 		}
 		if step.If != nil {
 			owned.If = step.If.Value
 			owned.IfSpan = spanFrom(step.If.Pos, step.If.Value)
 			owned.Positions["if"] = pointSpan(step.If.Pos).Start
+			owned.Sources["if"] = owned.If
 		}
 		if step.ContinueOnError != nil {
 			if step.ContinueOnError.Expression != nil {
 				owned.ContinueOnErrorExpression = step.ContinueOnError.Expression.Value
 				owned.Positions["continue-on-error"] = pointSpan(step.ContinueOnError.Expression.Pos).Start
+				owned.Sources["continue-on-error"] = owned.ContinueOnErrorExpression
 			} else {
 				owned.ContinueOnError = step.ContinueOnError.Value
 			}
@@ -752,6 +787,7 @@ func adaptJob(path string, in *actionlint.Job, scalars map[Position]any, concurr
 			if step.TimeoutMinutes.Expression != nil {
 				owned.TimeoutMinutesExpression = step.TimeoutMinutes.Expression.Value
 				owned.Positions["timeout-minutes"] = pointSpan(step.TimeoutMinutes.Expression.Pos).Start
+				owned.Sources["timeout-minutes"] = owned.TimeoutMinutesExpression
 			} else {
 				owned.TimeoutMinutes = step.TimeoutMinutes.Value
 			}
@@ -761,18 +797,22 @@ func adaptJob(path string, in *actionlint.Job, scalars map[Position]any, concurr
 		}
 		owned.Env = adaptEnv(step.Env)
 		owned.Positions = mergePositions(owned.Positions, adaptEnvPositions("env", step.Env))
+		owned.Sources = mergeSources(owned.Sources, mapSources("env", owned.Env))
 		switch exec := step.Exec.(type) {
 		case *actionlint.ExecRun:
 			owned.Kind = "run"
 			owned.Run = exec.Run.Value
 			owned.Positions["run"] = pointSpan(exec.Run.Pos).Start
+			owned.Sources["run"] = owned.Run
 			if exec.Shell != nil {
 				owned.Shell = exec.Shell.Value
 				owned.Positions["shell"] = pointSpan(exec.Shell.Pos).Start
+				owned.Sources["shell"] = owned.Shell
 			}
 			if exec.WorkingDirectory != nil {
 				owned.WorkingDirectory = exec.WorkingDirectory.Value
 				owned.Positions["working-directory"] = pointSpan(exec.WorkingDirectory.Pos).Start
+				owned.Sources["working-directory"] = owned.WorkingDirectory
 			}
 			owned.Span = spanFrom(step.Pos, exec.Run.Value)
 		case *actionlint.ExecAction:
@@ -786,11 +826,13 @@ func adaptJob(path string, in *actionlint.Job, scalars map[Position]any, concurr
 			owned.Kind = "uses"
 			owned.Uses = exec.Uses.Value
 			owned.Positions["uses"] = pointSpan(exec.Uses.Pos).Start
+			owned.Sources["uses"] = owned.Uses
 			if len(exec.Inputs) != 0 {
 				owned.With = make(map[string]string, len(exec.Inputs))
 				for name, input := range exec.Inputs {
 					owned.With[name] = input.Value.Value
 					owned.Positions["with."+name] = pointSpan(input.Value.Pos).Start
+					owned.Sources["with."+name] = input.Value.Value
 				}
 			}
 			owned.Span = spanFrom(step.Pos, exec.Uses.Value)
@@ -955,6 +997,27 @@ func mergePositions(base, additional map[string]Position) map[string]Position {
 	return base
 }
 
+func mapSources(prefix string, values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	sources := make(map[string]string, len(values))
+	for name, value := range values {
+		sources[prefix+"."+name] = value
+	}
+	return sources
+}
+
+func mergeSources(base, additional map[string]string) map[string]string {
+	if base == nil && len(additional) != 0 {
+		base = make(map[string]string, len(additional))
+	}
+	for name, source := range additional {
+		base[name] = source
+	}
+	return base
+}
+
 var serviceIDPattern = regexp.MustCompile(`^[a-z_][a-z0-9_-]*$`)
 
 func adaptContainer(path, jobID string, in *actionlint.Container) (Container, error) {
@@ -980,14 +1043,16 @@ func adaptContainer(path, jobID string, in *actionlint.Container) (Container, er
 			}
 		}
 	}
-	out := Container{Image: in.Image.Value, Env: adaptEnv(in.Env), Span: pointSpan(in.Pos), Positions: map[string]Position{"image": pointSpan(in.Image.Pos).Start}}
+	out := Container{Image: in.Image.Value, Env: adaptEnv(in.Env), Span: pointSpan(in.Pos), Positions: map[string]Position{"image": pointSpan(in.Image.Pos).Start}, Sources: map[string]string{"image": in.Image.Value}}
 	out.Positions = mergePositions(out.Positions, adaptEnvPositions("env", in.Env))
+	out.Sources = mergeSources(out.Sources, mapSources("env", out.Env))
 	for i, port := range in.Ports {
 		if port.ContainsExpression() {
 			return Container{}, locatedError(path, port.Pos, jobID, "expression-valued container port is unsupported")
 		}
 		out.Ports = append(out.Ports, port.Value)
 		out.Positions[fmt.Sprintf("ports[%d]", i)] = pointSpan(port.Pos).Start
+		out.Sources[fmt.Sprintf("ports[%d]", i)] = port.Value
 	}
 	return out, nil
 }
@@ -999,7 +1064,7 @@ func adaptServiceContainer(path, jobID string, in *actionlint.Container, raw raw
 	if in.Env != nil && in.Env.Expression != nil {
 		return ServiceContainer{}, locatedError(path, in.Env.Expression.Pos, jobID, "expression-valued service container env is unsupported")
 	}
-	out := ServiceContainer{Image: raw.Image, Credentials: raw.Credentials, Env: raw.Env, Ports: raw.Ports, Volumes: raw.Volumes, Options: raw.Options, Command: raw.Command, Entrypoint: raw.Entrypoint, Span: pointSpan(in.Pos), Positions: raw.Positions}
+	out := ServiceContainer{Image: raw.Image, Credentials: raw.Credentials, Env: raw.Env, Ports: raw.Ports, Volumes: raw.Volumes, Options: raw.Options, Command: raw.Command, Entrypoint: raw.Entrypoint, Span: pointSpan(in.Pos), Positions: raw.Positions, Sources: raw.Sources}
 	return out, nil
 }
 
@@ -1337,7 +1402,7 @@ func parseParallelStep(path string, node *yaml.Node) (Step, error) {
 	if execution.Kind != yaml.ScalarNode || execution.ShortTag() == "!!null" || strings.TrimSpace(execution.Value) == "" {
 		return Step{}, yamlNodeError(path, execution, "parallel member execution must be a non-empty scalar")
 	}
-	step := Step{Span: yamlStepSpan(node, execution), Positions: map[string]Position{}}
+	step := Step{Span: yamlStepSpan(node, execution), Positions: map[string]Position{}, Sources: map[string]string{}}
 	var err error
 	if step.ID, err = optionalString(entries["id"]); err != nil {
 		return Step{}, yamlNodeError(path, entries["id"], "parallel member id must be a string")
@@ -1347,6 +1412,7 @@ func parseParallelStep(path string, node *yaml.Node) (Step, error) {
 	}
 	if entries["name"] != nil {
 		step.Positions["name"] = nodePosition(entries["name"])
+		step.Sources["name"] = step.Name
 	}
 	if step.If, err = optionalScalar(entries["if"]); err != nil {
 		return Step{}, yamlNodeError(path, entries["if"], "parallel member if must be a scalar")
@@ -1354,11 +1420,13 @@ func parseParallelStep(path string, node *yaml.Node) (Step, error) {
 	if value := entries["if"]; value != nil {
 		step.IfSpan = yamlStepSpan(value, value)
 		step.Positions["if"] = nodePosition(value)
+		step.Sources["if"] = step.If
 	}
 	if step.Env, err = scalarMap(entries["env"]); err != nil {
 		return Step{}, yamlNodeError(path, entries["env"], "parallel member env must be a scalar mapping")
 	}
 	step.Positions = mergePositions(step.Positions, scalarMapPositions("env", entries["env"]))
+	step.Sources = mergeSources(step.Sources, mapSources("env", step.Env))
 	if value := entries["continue-on-error"]; value != nil {
 		if value.Kind != yaml.ScalarNode || value.ShortTag() != "!!bool" {
 			return Step{}, yamlNodeError(path, value, "parallel member continue-on-error must be a literal boolean")
@@ -1383,17 +1451,20 @@ func parseParallelStep(path string, node *yaml.Node) (Step, error) {
 		step.Kind = "run"
 		step.Run = run.Value
 		step.Positions["run"] = nodePosition(run)
+		step.Sources["run"] = step.Run
 		if step.Shell, err = optionalScalar(entries["shell"]); err != nil {
 			return Step{}, yamlNodeError(path, entries["shell"], "parallel member shell must be a scalar")
 		}
 		if entries["shell"] != nil {
 			step.Positions["shell"] = nodePosition(entries["shell"])
+			step.Sources["shell"] = step.Shell
 		}
 		if step.WorkingDirectory, err = optionalScalar(entries["working-directory"]); err != nil {
 			return Step{}, yamlNodeError(path, entries["working-directory"], "parallel member working-directory must be a scalar")
 		}
 		if entries["working-directory"] != nil {
 			step.Positions["working-directory"] = nodePosition(entries["working-directory"])
+			step.Sources["working-directory"] = step.WorkingDirectory
 		}
 		return step, nil
 	}
@@ -1403,10 +1474,12 @@ func parseParallelStep(path string, node *yaml.Node) (Step, error) {
 	step.Kind = "uses"
 	step.Uses = uses.Value
 	step.Positions["uses"] = nodePosition(uses)
+	step.Sources["uses"] = step.Uses
 	if step.With, err = scalarMap(entries["with"]); err != nil {
 		return Step{}, yamlNodeError(path, entries["with"], "parallel member with must be a scalar mapping")
 	}
 	step.Positions = mergePositions(step.Positions, scalarMapPositions("with", entries["with"]))
+	step.Sources = mergeSources(step.Sources, mapSources("with", step.With))
 	for name, value := range step.With {
 		lower := strings.ToLower(name)
 		if lower != name {
@@ -1414,6 +1487,8 @@ func parseParallelStep(path string, node *yaml.Node) (Step, error) {
 			step.With[lower] = value
 			step.Positions["with."+lower] = step.Positions["with."+name]
 			delete(step.Positions, "with."+name)
+			step.Sources["with."+lower] = step.Sources["with."+name]
+			delete(step.Sources, "with."+name)
 		}
 	}
 	_, hasEntrypoint := step.With["entrypoint"]


### PR DESCRIPTION
## Why

Unsupported whole or runtime-dynamic `github.event` accesses currently fail with `github.event cannot be retained in a job plan`. The plan boundary is intentional, but the diagnostic does not identify the workflow expression or explain how to make it compatible.

## What

Attribute plan-expression failures to the owning workflow path, job, field, and step, and include the authored expression in diagnostic detail. Whole and dynamic event access now explains that plans can use compile-time-reducible scalar paths such as `github.event.pull_request.head.sha`, while full payload access remains unavailable at runtime.

Keep event-derived action references static-only and report separate guidance for replacing them with literal action references. Existing scalar event reduction and the no-event-payload plan boundary remain unchanged. Focused tests cover whole-event access, runtime-dynamic property access, exact source attribution, and action-reference guidance.
