### PR TITLE
Resolve plugin workflows from the build checkout

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -310,6 +310,9 @@ repository. Directories and globs are rejected. The optional `oidc` object
 accepts non-empty `claims`, `aws-session-tags`, and `subject-claim` values.
 Unknown fields and invalid values fail before upload.
 
+The plugin resolves relative workflow paths from `BUILDKITE_BUILD_CHECKOUT_PATH`,
+not the command hook's working directory.
+
 The importer reuses its verified executable for jobs on the same platform. It
 downloads the other platform's distribution from the same release only when a
 workflow needs it. Runner mappings apply to generated jobs, not the importer.

--- a/internal/cli/path_filters.go
+++ b/internal/cli/path_filters.go
@@ -24,7 +24,14 @@ const (
 	zeroGitCommit                      = "0000000000000000000000000000000000000000"
 )
 
-func populateChangedPaths(snapshot *buildkitepipeline.TriggerEventSnapshot, event compiler.Event, origin effectiveEventOrigin, workflows []workflowInput) {
+func gitRootCommand(checkoutPath string) *exec.Cmd {
+	if checkoutPath != "" {
+		return exec.Command("git", "-C", checkoutPath, "rev-parse", "--show-toplevel")
+	}
+	return exec.Command("git", "rev-parse", "--show-toplevel")
+}
+
+func populateChangedPaths(snapshot *buildkitepipeline.TriggerEventSnapshot, event compiler.Event, origin effectiveEventOrigin, workflows []workflowInput, checkoutPath string) {
 	if event.Event != "pull_request" && event.Event != "push" {
 		return
 	}
@@ -43,9 +50,9 @@ func populateChangedPaths(snapshot *buildkitepipeline.TriggerEventSnapshot, even
 		if !workflowsUsePathFilters(workflows, event.Event) {
 			return
 		}
-		paths, workflowErrors, err := pushChangedPaths(event, workflows)
+		paths, workflowErrors, err := pushChangedPaths(event, workflows, checkoutPath)
 		if err != nil {
-			setPathFiltersError(snapshot, workflows, event.Event, err.Error(), true)
+			setPathFiltersError(snapshot, workflows, event.Event, err.Error(), true, checkoutPath)
 			return
 		}
 		snapshot.ChangedPaths = buildkitepipeline.ChangedPathEvaluation{Paths: append([]string{}, paths...)}
@@ -60,17 +67,17 @@ func populateChangedPaths(snapshot *buildkitepipeline.TriggerEventSnapshot, even
 	}
 	pullRequestNumber, err := strconv.Atoi(os.Getenv("BUILDKITE_PULL_REQUEST"))
 	if err != nil || pullRequestNumber <= 0 {
-		setPathFiltersError(snapshot, workflows, event.Event, "pull request path filters require the Buildkite pull request number", closed)
+		setPathFiltersError(snapshot, workflows, event.Event, "pull request path filters require the Buildkite pull request number", closed, checkoutPath)
 		return
 	}
 	baseRef := os.Getenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH")
 	if baseRef == "" {
-		setPathFiltersError(snapshot, workflows, event.Event, "pull request path filters require the Buildkite pull request base branch", closed)
+		setPathFiltersError(snapshot, workflows, event.Event, "pull request path filters require the Buildkite pull request base branch", closed, checkoutPath)
 		return
 	}
-	paths, workflowErrors, err := pullRequestChangedPaths(event, pullRequestNumber, baseRef, workflows)
+	paths, workflowErrors, err := pullRequestChangedPaths(event, pullRequestNumber, baseRef, workflows, checkoutPath)
 	if err != nil {
-		setPathFiltersError(snapshot, workflows, event.Event, err.Error(), closed)
+		setPathFiltersError(snapshot, workflows, event.Event, err.Error(), closed, checkoutPath)
 		return
 	}
 	snapshot.ChangedPaths = buildkitepipeline.ChangedPathEvaluation{Paths: append([]string{}, paths...)}
@@ -82,7 +89,7 @@ func populateChangedPaths(snapshot *buildkitepipeline.TriggerEventSnapshot, even
 	}
 }
 
-func pushChangedPaths(event compiler.Event, workflows []workflowInput) ([]string, map[string]string, error) {
+func pushChangedPaths(event compiler.Event, workflows []workflowInput, checkoutPath string) ([]string, map[string]string, error) {
 	if event.Provider != "github" {
 		return nil, nil, fmt.Errorf("push path filters require a GitHub repository webhook")
 	}
@@ -109,7 +116,7 @@ func pushChangedPaths(event compiler.Event, workflows []workflowInput) ([]string
 		return nil, nil, fmt.Errorf("webhook push before commit is inconsistent with ref creation")
 	}
 
-	rootBytes, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	rootBytes, err := gitRootCommand(checkoutPath).Output()
 	if err != nil {
 		return nil, nil, fmt.Errorf("locate checked-out git repository: %w", err)
 	}
@@ -306,9 +313,9 @@ func gitIsAncestor(root, ancestor, descendant string) (bool, error) {
 	return false, err
 }
 
-func setPathFiltersError(snapshot *buildkitepipeline.TriggerEventSnapshot, workflows []workflowInput, event, reason string, filteredOnly bool) {
+func setPathFiltersError(snapshot *buildkitepipeline.TriggerEventSnapshot, workflows []workflowInput, event, reason string, filteredOnly bool, checkoutPath string) {
 	snapshot.ChangedPaths = buildkitepipeline.ChangedPathEvaluation{UnavailableReason: reason}
-	rootBytes, rootErr := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	rootBytes, rootErr := gitRootCommand(checkoutPath).Output()
 	root := filepath.Clean(strings.TrimSpace(string(rootBytes)))
 	for i := range workflows {
 		if workflowUsesPathFilters(workflows[i], event) || !filteredOnly && rootErr == nil && gitTracksWorkflow(root, workflows[i]) {
@@ -326,7 +333,7 @@ func workflowsUsePathFilters(workflows []workflowInput, event string) bool {
 	return false
 }
 
-func pullRequestChangedPaths(event compiler.Event, pullRequestNumber int, baseRef string, workflows []workflowInput) ([]string, map[string]string, error) {
+func pullRequestChangedPaths(event compiler.Event, pullRequestNumber int, baseRef string, workflows []workflowInput, checkoutPath string) ([]string, map[string]string, error) {
 	pullRequest, ok := event.Payload["pull_request"].(map[string]any)
 	if !ok {
 		return nil, nil, fmt.Errorf("event snapshot requires payload.pull_request")
@@ -355,7 +362,7 @@ func pullRequestChangedPaths(event compiler.Event, pullRequestNumber int, baseRe
 	if headSHA != event.SHA {
 		return nil, nil, fmt.Errorf("pull request head SHA does not match the checked-out event SHA")
 	}
-	rootBytes, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	rootBytes, err := gitRootCommand(checkoutPath).Output()
 	if err != nil {
 		return nil, nil, fmt.Errorf("locate checked-out git repository: %w", err)
 	}

--- a/internal/cli/path_filters_test.go
+++ b/internal/cli/path_filters_test.go
@@ -83,11 +83,17 @@ func TestPushChangedPathsBindsWebhookAndLocalDiff(t *testing.T) {
 		}
 	}
 	event := newEvent(base, after, false, false, after)
-	paths, workflowErrors, err := pushChangedPaths(event, []workflowInput{input})
+	paths, workflowErrors, err := pushChangedPaths(event, []workflowInput{input}, "")
 	want := []string{"docs/old.md", "src/main.go", "src/tool"}
 	if err != nil || !reflect.DeepEqual(paths, want) || len(workflowErrors) != 0 {
 		t.Fatalf("normal push paths/errors = %#v / %#v / %v, want %#v", paths, workflowErrors, err, want)
 	}
+	t.Chdir(t.TempDir())
+	paths, _, err = pushChangedPaths(event, []workflowInput{input}, repository)
+	if err != nil || !reflect.DeepEqual(paths, want) {
+		t.Fatalf("push paths outside checkout = %#v, %v", paths, err)
+	}
+	t.Chdir(repository)
 
 	runGit("checkout", "-q", "-B", "force", base)
 	if err := os.WriteFile(filepath.Join(repository, "src/main.go"), []byte("package forced\n"), 0o600); err != nil {
@@ -98,7 +104,7 @@ func TestPushChangedPathsBindsWebhookAndLocalDiff(t *testing.T) {
 	forceAfter := runGit("rev-parse", "HEAD")
 	runGit("update-ref", "refs/remotes/origin/main", forceAfter)
 	forceEvent := newEvent(after, forceAfter, false, true, forceAfter)
-	if paths, _, err := pushChangedPaths(forceEvent, []workflowInput{input}); err != nil || !reflect.DeepEqual(paths, want) {
+	if paths, _, err := pushChangedPaths(forceEvent, []workflowInput{input}, ""); err != nil || !reflect.DeepEqual(paths, want) {
 		t.Fatalf("force push paths = %#v, %v", paths, err)
 	}
 
@@ -117,33 +123,33 @@ func TestPushChangedPathsBindsWebhookAndLocalDiff(t *testing.T) {
 	newAfter := runGit("rev-parse", "HEAD")
 	runGit("update-ref", "refs/remotes/origin/main", newAfter)
 	newBranchEvent := newEvent(zeroGitCommit, newAfter, true, false, first, newAfter)
-	if paths, _, err := pushChangedPaths(newBranchEvent, []workflowInput{input}); err != nil || !reflect.DeepEqual(paths, []string{"src/main.go"}) {
+	if paths, _, err := pushChangedPaths(newBranchEvent, []workflowInput{input}, ""); err != nil || !reflect.DeepEqual(paths, []string{"src/main.go"}) {
 		t.Fatalf("new-branch push paths = %#v, %v", paths, err)
 	}
 
 	newBranchEvent.Payload["repository"].(map[string]any)["full_name"] = "attacker/other"
-	if _, _, err := pushChangedPaths(newBranchEvent, []workflowInput{input}); err == nil || !strings.Contains(err.Error(), "repository does not match") {
+	if _, _, err := pushChangedPaths(newBranchEvent, []workflowInput{input}, ""); err == nil || !strings.Contains(err.Error(), "repository does not match") {
 		t.Fatalf("mismatched repository error = %v", err)
 	}
 	newBranchEvent.Payload["repository"].(map[string]any)["full_name"] = "buildkite/buildkite-gha"
 	newBranchEvent.Payload["deleted"] = true
-	if _, _, err := pushChangedPaths(newBranchEvent, []workflowInput{input}); err == nil || !strings.Contains(err.Error(), "deleted-ref") {
+	if _, _, err := pushChangedPaths(newBranchEvent, []workflowInput{input}, ""); err == nil || !strings.Contains(err.Error(), "deleted-ref") {
 		t.Fatalf("deleted ref error = %v", err)
 	}
 	newBranchEvent.Payload["deleted"] = false
 	newBranchEvent.Payload["commits"] = []any{map[string]any{"id": first}}
-	if _, _, err := pushChangedPaths(newBranchEvent, []workflowInput{input}); err == nil || !strings.Contains(err.Error(), "complete pushed commit evidence") {
+	if _, _, err := pushChangedPaths(newBranchEvent, []workflowInput{input}, ""); err == nil || !strings.Contains(err.Error(), "complete pushed commit evidence") {
 		t.Fatalf("incomplete new-branch commits error = %v", err)
 	}
 	newBranchEvent.Payload["commits"] = []any{map[string]any{"id": first}, map[string]any{"id": newAfter}}
 	input.Source = []byte("modified worktree workflow\n")
-	if _, workflowErrors, err := pushChangedPaths(newBranchEvent, []workflowInput{input}); err != nil || !strings.Contains(workflowErrors["ci.yml"], "does not match the pushed commit") {
+	if _, workflowErrors, err := pushChangedPaths(newBranchEvent, []workflowInput{input}, ""); err != nil || !strings.Contains(workflowErrors["ci.yml"], "does not match the pushed commit") {
 		t.Fatalf("mismatched workflow result = %#v, %v", workflowErrors, err)
 	}
 	if err := os.WriteFile(filepath.Join(repository, ".git", "shallow"), []byte(base+"\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := pushChangedPaths(newBranchEvent, []workflowInput{input}); err == nil || !strings.Contains(err.Error(), "non-shallow checkout") {
+	if _, _, err := pushChangedPaths(newBranchEvent, []workflowInput{input}, ""); err == nil || !strings.Contains(err.Error(), "non-shallow checkout") {
 		t.Fatalf("shallow checkout error = %v", err)
 	}
 }
@@ -208,20 +214,26 @@ func TestPullRequestChangedPathsUsesPayloadCommits(t *testing.T) {
 		Source:        filteredWorkflow,
 		Triggers:      []workflow.Trigger{{Event: "pull_request", Paths: []string{"src/**"}}},
 	}
-	paths, workflowErrors, err := pullRequestChangedPaths(event, 42, "main", []workflowInput{input})
+	paths, workflowErrors, err := pullRequestChangedPaths(event, 42, "main", []workflowInput{input}, "")
 	if err != nil || !reflect.DeepEqual(paths, []string{"src/main.go"}) {
 		t.Fatalf("pullRequestChangedPaths() = %#v, %v", paths, err)
 	}
 	if len(workflowErrors) != 0 {
 		t.Fatalf("workflow errors = %#v", workflowErrors)
 	}
+	t.Chdir(t.TempDir())
+	paths, _, err = pullRequestChangedPaths(event, 42, "main", []workflowInput{input}, repository)
+	if err != nil || !reflect.DeepEqual(paths, []string{"src/main.go"}) {
+		t.Fatalf("pull request paths outside checkout = %#v, %v", paths, err)
+	}
+	t.Chdir(repository)
 	pullRequest := event.Payload["pull_request"].(map[string]any)
 	delete(pullRequest, "mergeable")
-	if paths, _, err := pullRequestChangedPaths(event, 42, "main", []workflowInput{input}); err != nil || !reflect.DeepEqual(paths, []string{"src/main.go"}) {
+	if paths, _, err := pullRequestChangedPaths(event, 42, "main", []workflowInput{input}, ""); err != nil || !reflect.DeepEqual(paths, []string{"src/main.go"}) {
 		t.Fatalf("unknown mergeability result = %#v, %v", paths, err)
 	}
 	pullRequest["mergeable"] = false
-	if _, _, err := pullRequestChangedPaths(event, 42, "main", nil); err == nil || !strings.Contains(err.Error(), "mergeable synthetic merge") {
+	if _, _, err := pullRequestChangedPaths(event, 42, "main", nil, ""); err == nil || !strings.Contains(err.Error(), "mergeable synthetic merge") {
 		t.Fatalf("conflicted pull request error = %v", err)
 	}
 	pullRequest["mergeable"] = true
@@ -231,12 +243,12 @@ func TestPullRequestChangedPathsUsesPayloadCommits(t *testing.T) {
 		Source:        []byte("different\n"),
 		Triggers:      []workflow.Trigger{{Event: "pull_request", Paths: []string{"src/**"}}},
 	}
-	_, workflowErrors, err = pullRequestChangedPaths(event, 42, "main", []workflowInput{workflow})
+	_, workflowErrors, err = pullRequestChangedPaths(event, 42, "main", []workflowInput{workflow}, "")
 	if err != nil || !strings.Contains(workflowErrors["ci.yml"], "does not match the event merge commit") {
 		t.Fatalf("workflow merge source result = %#v, %v", workflowErrors, err)
 	}
 	pullRequest["base"].(map[string]any)["sha"] = head
-	if _, _, err := pullRequestChangedPaths(event, 42, "main", []workflowInput{input}); err == nil || !strings.Contains(err.Error(), "does not bind the event base and head") {
+	if _, _, err := pullRequestChangedPaths(event, 42, "main", []workflowInput{input}, ""); err == nil || !strings.Contains(err.Error(), "does not bind the event base and head") {
 		t.Fatalf("forged base SHA error = %v", err)
 	}
 }
@@ -313,7 +325,7 @@ func TestPullRequestChangedPathsRejectsPathFiltersAddedByMerge(t *testing.T) {
 	_, workflowErrors, err := pullRequestChangedPaths(event, 42, "main", []workflowInput{{
 		Path: workflowPath, CanonicalPath: "ci.yml", Source: unfiltered,
 		Triggers: []workflow.Trigger{{Event: "pull_request"}},
-	}})
+	}}, "")
 	if err != nil || !strings.Contains(workflowErrors["ci.yml"], "does not match the event merge commit") {
 		t.Fatalf("merge-added path filter result = %#v, %v", workflowErrors, err)
 	}
@@ -321,7 +333,7 @@ func TestPullRequestChangedPathsRejectsPathFiltersAddedByMerge(t *testing.T) {
 	_, workflowErrors, err = pullRequestChangedPaths(event, 42, "main", []workflowInput{{
 		Path: workflowPath, CanonicalPath: "ci.yml", Source: withoutPullRequest,
 		Triggers: []workflow.Trigger{{Event: "push"}},
-	}})
+	}}, "")
 	if err != nil || !strings.Contains(workflowErrors["ci.yml"], "does not match the event merge commit") {
 		t.Fatalf("merge-added pull request trigger result = %#v, %v", workflowErrors, err)
 	}
@@ -329,7 +341,7 @@ func TestPullRequestChangedPathsRejectsPathFiltersAddedByMerge(t *testing.T) {
 	_, workflowErrors, err = pullRequestChangedPaths(event, 42, "main", []workflowInput{{
 		Path: customPath, CanonicalPath: customPath,
 		Triggers: []workflow.Trigger{{Event: "pull_request"}},
-	}})
+	}}, "")
 	if err != nil || len(workflowErrors) != 0 {
 		t.Fatalf("unfiltered custom workflow result = %#v, %v", workflowErrors, err)
 	}
@@ -343,7 +355,7 @@ func TestPullRequestChangedPathsRejectsPathFiltersAddedByMerge(t *testing.T) {
 		Triggers: []workflow.Trigger{{Event: "pull_request"}},
 	}}
 	snapshot := buildkitepipeline.TriggerEventSnapshot{}
-	populateChangedPaths(&snapshot, event, effectiveEventFromWebhook, closedWorkflows)
+	populateChangedPaths(&snapshot, event, effectiveEventFromWebhook, closedWorkflows, "")
 	if closedWorkflows[0].PathFiltersError != "" {
 		t.Fatalf("unfiltered closed workflow provenance error = %q", closedWorkflows[0].PathFiltersError)
 	}
@@ -353,7 +365,7 @@ func TestPullRequestChangedPathsRejectsPathFiltersAddedByMerge(t *testing.T) {
 		Triggers: []workflow.Trigger{{Event: "pull_request"}},
 	})
 	snapshot = buildkitepipeline.TriggerEventSnapshot{}
-	populateChangedPaths(&snapshot, event, effectiveEventFromWebhook, closedWorkflows)
+	populateChangedPaths(&snapshot, event, effectiveEventFromWebhook, closedWorkflows, "")
 	if !strings.Contains(closedWorkflows[0].PathFiltersError, "does not bind the event base and head") {
 		t.Fatalf("filtered closed workflow provenance error = %q", closedWorkflows[0].PathFiltersError)
 	}
@@ -368,7 +380,7 @@ func TestPullRequestChangedPathsRejectsPathFiltersAddedByMerge(t *testing.T) {
 		Triggers: []workflow.Trigger{{Event: "pull_request"}},
 	}}
 	snapshot = buildkitepipeline.TriggerEventSnapshot{}
-	populateChangedPaths(&snapshot, event, effectiveEventFromWebhook, customWorkflows)
+	populateChangedPaths(&snapshot, event, effectiveEventFromWebhook, customWorkflows, "")
 	if customWorkflows[0].PathFiltersError != "" {
 		t.Fatalf("unfiltered custom workflow provenance error = %q", customWorkflows[0].PathFiltersError)
 	}
@@ -379,7 +391,7 @@ func TestPullRequestChangedPathsRejectsPathFiltersAddedByMerge(t *testing.T) {
 		Triggers: []workflow.Trigger{{Event: "pull_request"}},
 	}}
 	snapshot = buildkitepipeline.TriggerEventSnapshot{}
-	populateChangedPaths(&snapshot, event, effectiveEventFromWebhook, workflows)
+	populateChangedPaths(&snapshot, event, effectiveEventFromWebhook, workflows, "")
 	if !strings.Contains(workflows[0].PathFiltersError, "merge commit SHAs") {
 		t.Fatalf("missing merge commit workflow error = %q", workflows[0].PathFiltersError)
 	}
@@ -388,7 +400,7 @@ func TestPullRequestChangedPathsRejectsPathFiltersAddedByMerge(t *testing.T) {
 	pullRequest["head"].(map[string]any)["sha"] = ""
 	workflows[0].PathFiltersError = ""
 	snapshot = buildkitepipeline.TriggerEventSnapshot{}
-	populateChangedPaths(&snapshot, event, effectiveEventFromWebhook, workflows)
+	populateChangedPaths(&snapshot, event, effectiveEventFromWebhook, workflows, "")
 	if !strings.Contains(workflows[0].PathFiltersError, "base, head, and merge commit SHAs") {
 		t.Fatalf("missing base and head workflow error = %q", workflows[0].PathFiltersError)
 	}
@@ -445,7 +457,7 @@ func TestPopulateChangedPathsRequiresLinkedWebhook(t *testing.T) {
 			snapshot := buildkitepipeline.TriggerEventSnapshot{}
 			populateChangedPaths(&snapshot, compiler.Event{Event: event}, effectiveEventFromPath, []workflowInput{{
 				Triggers: []workflow.Trigger{{Event: event, Paths: []string{"src/**"}}},
-			}})
+			}}, "")
 			if snapshot.ChangedPaths.Paths != nil || !strings.Contains(snapshot.ChangedPaths.UnavailableReason, event+" path filters require linked Buildkite webhook") {
 				t.Fatalf("changed-path snapshot = %#v", snapshot)
 			}

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -54,6 +54,7 @@ func pluginContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 	return uploadParsedContext(ctx, parsedUploadArgs{
 		workflowOperands:       configuration.Workflows,
 		explicitWorkflowPaths:  true,
+		checkoutPath:           os.Getenv("BUILDKITE_BUILD_CHECKOUT_PATH"),
 		clientVersion:          clientVersion,
 		runnerTargets:          configuration.runnerTargets,
 		oidc:                   configuration.OIDC,

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -47,14 +47,15 @@ func pluginContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 	if err != nil {
 		return usageError(stderr, "plugin: %v", err)
 	}
-	if err := normalizePluginCommit(ctx, os.Getenv, os.Setenv, runner); err != nil {
+	checkoutPath := os.Getenv("BUILDKITE_BUILD_CHECKOUT_PATH")
+	if err := normalizePluginCommit(ctx, checkoutPath, os.Getenv, os.Setenv, runner); err != nil {
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: plugin: %v\n", err)
 		return 1
 	}
 	return uploadParsedContext(ctx, parsedUploadArgs{
 		workflowOperands:       configuration.Workflows,
 		explicitWorkflowPaths:  true,
-		checkoutPath:           os.Getenv("BUILDKITE_BUILD_CHECKOUT_PATH"),
+		checkoutPath:           checkoutPath,
 		clientVersion:          clientVersion,
 		runnerTargets:          configuration.runnerTargets,
 		oidc:                   configuration.OIDC,
@@ -239,11 +240,11 @@ func pluginNonEmptyStringList(value any, field string) ([]string, error) {
 	return result, nil
 }
 
-func normalizePluginCommit(ctx context.Context, getenv func(string) string, setenv func(string, string) error, runner transport.Runner) error {
+func normalizePluginCommit(ctx context.Context, checkoutPath string, getenv func(string) string, setenv func(string, string) error, runner transport.Runner) error {
 	if validBuildkiteCommit(getenv("BUILDKITE_COMMIT")) {
 		return nil
 	}
-	output, err := runner.Run(ctx, "", "git", []string{"rev-parse", "HEAD"}, nil)
+	output, err := runner.Run(ctx, checkoutPath, "git", []string{"rev-parse", "HEAD"}, nil)
 	if err != nil {
 		return fmt.Errorf("resolve BUILDKITE_COMMIT from checked-out HEAD: %w", err)
 	}

--- a/internal/cli/plugin_test.go
+++ b/internal/cli/plugin_test.go
@@ -356,6 +356,29 @@ func TestPluginIgnoresJobPermissionsForHostedGitHubToken(t *testing.T) {
 	t.Fatalf("uploaded artifacts = %#v, want job plan", runner.uploaded)
 }
 
+func TestPluginResolvesWorkflowFromBuildCheckoutOutsideWorkingDirectory(t *testing.T) {
+	requireImporterHost(t)
+	repository := writeUploadWorkflowRepository(t, map[string]string{
+		"deploy.yml": "name: Deploy\non: push\njobs:\n  deploy:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
+	})
+	t.Chdir(t.TempDir())
+	configuration, err := json.Marshal(map[string]any{"workflow": ".github/workflows/deploy.yml"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(pluginConfigurationEnvironment, string(configuration))
+	setCLIPluginBuildkiteEnvironment(t, "plugin-checkout-path")
+	t.Setenv("BUILDKITE_BUILD_CHECKOUT_PATH", repository)
+	runner := &cliCaptureRunner{}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"plugin"}, &stdout, &stderr, "dev", runner); code != 0 {
+		t.Fatalf("run() code = %d, want 0; stdout = %q; stderr = %q", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Uploaded 1 job") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
 func TestPluginUploadsPluralWorkflowList(t *testing.T) {
 	requireImporterHost(t)
 	configuration, err := json.Marshal(map[string]any{
@@ -402,7 +425,7 @@ func TestPluginRejectsNonExplicitWorkflowSelectors(t *testing.T) {
 		{name: "all shorthand", field: "workflow", workflows: "*", want: "explicit paths"},
 		{name: "string glob", field: "workflow", workflows: filepath.Join(workflowDirectory, "*.yml"), want: "explicit paths"},
 		{name: "array glob", field: "workflows", workflows: []string{filepath.Join(workflowDirectory, "*.yml")}, want: "explicit paths"},
-		{name: "directory", field: "workflow", workflows: workflowDirectory, want: "does not name a regular tracked file"},
+		{name: "directory", field: "workflow", workflows: workflowDirectory, want: "directory"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			configuration, err := json.Marshal(map[string]any{test.field: test.workflows})

--- a/internal/cli/plugin_test.go
+++ b/internal/cli/plugin_test.go
@@ -684,7 +684,7 @@ func TestNormalizePluginCommit(t *testing.T) {
 	t.Run("preserves valid full commit", func(t *testing.T) {
 		runner := &cliCaptureRunner{}
 		setCalls := 0
-		err := normalizePluginCommit(t.Context(), func(string) string { return fullCommit }, func(string, string) error {
+		err := normalizePluginCommit(t.Context(), "", func(string) string { return fullCommit }, func(string, string) error {
 			setCalls++
 			return nil
 		}, runner)
@@ -695,20 +695,20 @@ func TestNormalizePluginCommit(t *testing.T) {
 	t.Run("resolves symbolic commit from HEAD", func(t *testing.T) {
 		runner := &cliCaptureRunner{gitOutput: []byte(fullCommit + "\n")}
 		name, value := "", ""
-		err := normalizePluginCommit(t.Context(), func(string) string { return "HEAD" }, func(gotName, gotValue string) error {
+		err := normalizePluginCommit(t.Context(), "/checkout", func(string) string { return "HEAD" }, func(gotName, gotValue string) error {
 			name, value = gotName, gotValue
 			return nil
 		}, runner)
 		if err != nil || name != "BUILDKITE_COMMIT" || value != fullCommit {
 			t.Fatalf("normalizePluginCommit() = %q, %q, %v", name, value, err)
 		}
-		if len(runner.commands) != 1 || runner.commands[0].name != "git" || !slices.Equal(runner.commands[0].args, []string{"rev-parse", "HEAD"}) {
+		if len(runner.commands) != 1 || runner.commands[0].dir != "/checkout" || runner.commands[0].name != "git" || !slices.Equal(runner.commands[0].args, []string{"rev-parse", "HEAD"}) {
 			t.Fatalf("commands = %#v, want exact git rev-parse HEAD invocation", runner.commands)
 		}
 	})
 	t.Run("propagates resolution failure", func(t *testing.T) {
 		runner := &cliCaptureRunner{gitErr: errors.New("no checkout")}
-		err := normalizePluginCommit(t.Context(), func(string) string { return "HEAD" }, func(string, string) error { return nil }, runner)
+		err := normalizePluginCommit(t.Context(), "", func(string) string { return "HEAD" }, func(string, string) error { return nil }, runner)
 		if err == nil || !strings.Contains(err.Error(), "resolve BUILDKITE_COMMIT from checked-out HEAD: no checkout") {
 			t.Fatalf("normalizePluginCommit() error = %v", err)
 		}

--- a/internal/cli/plugin_test.go
+++ b/internal/cli/plugin_test.go
@@ -787,6 +787,7 @@ func TestPluginCarriesReleaseCommitIntoPlans(t *testing.T) {
 func setCLIPluginBuildkiteEnvironment(t *testing.T, stepKey string) {
 	t.Helper()
 	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_BUILD_CHECKOUT_PATH", "")
 	t.Setenv("BUILDKITE_STEP_KEY", stepKey)
 	t.Setenv("BUILDKITE_REPO", "https://github.com/buildkite/buildkite-gha")
 	t.Setenv("BUILDKITE_COMMIT", "0123456789abcdef0123456789abcdef01234567")

--- a/internal/cli/upload.go
+++ b/internal/cli/upload.go
@@ -193,7 +193,7 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 	}
 	defer cleanupSource()
 	sourceSwitch.set(authenticatedSource)
-	populateChangedPaths(&effectiveEvent.TriggerSnapshot, effectiveEvent.Event, effectiveEvent.Origin, workflows)
+	populateChangedPaths(&effectiveEvent.TriggerSnapshot, effectiveEvent.Event, effectiveEvent.Origin, workflows, uploadArguments.checkoutPath)
 	processingReports := make([]compatibility.ProcessingReport, len(workflows))
 	for i := range workflows {
 		if workflows[i].ReusableOnly {
@@ -621,11 +621,7 @@ func expandExplicitWorkflowPaths(operands []string, checkoutPath string) ([]work
 	if len(operands) == 0 {
 		return nil, fmt.Errorf("workflow path is required")
 	}
-	gitArgs := []string{"rev-parse", "--show-toplevel"}
-	if checkoutPath != "" {
-		gitArgs = append([]string{"-C", checkoutPath}, gitArgs...)
-	}
-	rootBytes, err := exec.Command("git", gitArgs...).Output()
+	rootBytes, err := gitRootCommand(checkoutPath).Output()
 	if err != nil {
 		if checkoutPath != "" {
 			return nil, fmt.Errorf("locate git repository from BUILDKITE_BUILD_CHECKOUT_PATH %q: %w", checkoutPath, err)

--- a/internal/cli/upload.go
+++ b/internal/cli/upload.go
@@ -645,19 +645,20 @@ func expandExplicitWorkflowPaths(operands []string, checkoutPath string) ([]work
 		}
 		canonical := filepath.ToSlash(filepath.Clean(relative))
 		info, statErr := os.Lstat(absolute)
-		if statErr != nil && strings.ContainsAny(operand, "*?[") {
-			return nil, fmt.Errorf("workflow list entries must be explicit paths; glob pattern %q is not allowed", operand)
-		}
 		if statErr == nil && !info.Mode().IsRegular() {
 			return nil, requireRegularWorkflowFile(absolute, operand)
+		}
+		output, gitErr := exec.Command("git", "-C", root, "ls-files", "-z", "--", ":(top,literal)"+canonical).Output()
+		entries := bytes.Split(output, []byte{0})
+		tracked := gitErr == nil && len(entries) == 2 && string(entries[0]) == canonical && len(entries[1]) == 0
+		if !tracked && strings.ContainsAny(operand, "*?[") {
+			return nil, fmt.Errorf("workflow list entries must be explicit paths; glob pattern %q is not allowed", operand)
 		}
 		extension := filepath.Ext(canonical)
 		if extension != ".yml" && extension != ".yaml" {
 			return nil, fmt.Errorf("workflow path %q must end in .yml or .yaml", operand)
 		}
-		output, err := exec.Command("git", "-C", root, "ls-files", "-z", "--", ":(top,literal)"+canonical).Output()
-		entries := bytes.Split(output, []byte{0})
-		if err != nil || len(entries) != 2 || string(entries[0]) != canonical || len(entries[1]) != 0 {
+		if !tracked {
 			return nil, fmt.Errorf("workflow path %q is not tracked by git", operand)
 		}
 		if err := requireRegularWorkflowFile(absolute, operand); err != nil {

--- a/internal/cli/upload.go
+++ b/internal/cli/upload.go
@@ -93,7 +93,7 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 	var workflows []workflowInput
 	var err error
 	if uploadArguments.explicitWorkflowPaths {
-		workflows, err = expandExplicitWorkflowPaths(workflowOperands)
+		workflows, err = expandExplicitWorkflowPaths(workflowOperands, uploadArguments.checkoutPath)
 	} else {
 		workflows, err = resolveWorkflowOperands(workflowOperands)
 	}
@@ -594,14 +594,14 @@ type workflowInput struct {
 
 func resolveWorkflowOperands(operands []string) ([]workflowInput, error) {
 	if len(operands) != 1 {
-		return expandExplicitWorkflowPaths(operands)
+		return expandExplicitWorkflowPaths(operands, "")
 	}
 	path, err := filepath.Abs(operands[0])
 	if err != nil {
 		return nil, fmt.Errorf("resolve workflow path %q: %w", operands[0], err)
 	}
 	if err := requireRegularWorkflowFile(path, operands[0]); err != nil {
-		return expandExplicitWorkflowPaths(operands)
+		return expandExplicitWorkflowPaths(operands, "")
 	}
 	extension := filepath.Ext(path)
 	if extension != ".yml" && extension != ".yaml" {
@@ -617,18 +617,29 @@ func resolveWorkflowOperands(operands []string) ([]workflowInput, error) {
 	return workflowInputs([]workflowInput{{Path: path, CanonicalPath: canonical}}, false)
 }
 
-func expandExplicitWorkflowPaths(operands []string) ([]workflowInput, error) {
+func expandExplicitWorkflowPaths(operands []string, checkoutPath string) ([]workflowInput, error) {
 	if len(operands) == 0 {
 		return nil, fmt.Errorf("workflow path is required")
 	}
-	rootBytes, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	gitArgs := []string{"rev-parse", "--show-toplevel"}
+	if checkoutPath != "" {
+		gitArgs = append([]string{"-C", checkoutPath}, gitArgs...)
+	}
+	rootBytes, err := exec.Command("git", gitArgs...).Output()
 	if err != nil {
+		if checkoutPath != "" {
+			return nil, fmt.Errorf("locate git repository from BUILDKITE_BUILD_CHECKOUT_PATH %q: %w", checkoutPath, err)
+		}
 		return nil, fmt.Errorf("locate checked-out git repository: %w", err)
 	}
 	root := filepath.Clean(strings.TrimSpace(string(rootBytes)))
 	matches := make([]workflowInput, 0, len(operands))
 	for _, operand := range operands {
-		absolute, err := filepath.Abs(operand)
+		inputPath := operand
+		if checkoutPath != "" && !filepath.IsAbs(inputPath) {
+			inputPath = filepath.Join(root, inputPath)
+		}
+		absolute, err := filepath.Abs(inputPath)
 		if err != nil {
 			return nil, fmt.Errorf("resolve workflow path %q: %w", operand, err)
 		}
@@ -637,11 +648,12 @@ func expandExplicitWorkflowPaths(operands []string) ([]workflowInput, error) {
 			return nil, fmt.Errorf("workflow path %q is outside the checked-out git repository", operand)
 		}
 		canonical := filepath.ToSlash(filepath.Clean(relative))
-		if err := requireRegularWorkflowFile(absolute, operand); err != nil {
-			if strings.ContainsAny(operand, "*?[") {
-				return nil, fmt.Errorf("workflow list entries must be explicit paths; glob pattern %q is not allowed", operand)
-			}
-			return nil, err
+		info, statErr := os.Lstat(absolute)
+		if statErr != nil && strings.ContainsAny(operand, "*?[") {
+			return nil, fmt.Errorf("workflow list entries must be explicit paths; glob pattern %q is not allowed", operand)
+		}
+		if statErr == nil && !info.Mode().IsRegular() {
+			return nil, requireRegularWorkflowFile(absolute, operand)
 		}
 		extension := filepath.Ext(canonical)
 		if extension != ".yml" && extension != ".yaml" {
@@ -650,10 +662,10 @@ func expandExplicitWorkflowPaths(operands []string) ([]workflowInput, error) {
 		output, err := exec.Command("git", "-C", root, "ls-files", "-z", "--", ":(top,literal)"+canonical).Output()
 		entries := bytes.Split(output, []byte{0})
 		if err != nil || len(entries) != 2 || string(entries[0]) != canonical || len(entries[1]) != 0 {
-			if strings.ContainsAny(operand, "*?[") {
-				return nil, fmt.Errorf("workflow list entries must be explicit paths; glob pattern %q is not allowed", operand)
-			}
 			return nil, fmt.Errorf("workflow path %q is not tracked by git", operand)
+		}
+		if err := requireRegularWorkflowFile(absolute, operand); err != nil {
+			return nil, err
 		}
 		matches = append(matches, workflowInput{Path: filepath.Join(root, filepath.FromSlash(canonical)), CanonicalPath: canonical})
 	}
@@ -662,8 +674,20 @@ func expandExplicitWorkflowPaths(operands []string) ([]workflowInput, error) {
 
 func requireRegularWorkflowFile(path, displayPath string) error {
 	info, err := os.Lstat(path)
-	if err != nil || !info.Mode().IsRegular() {
-		return fmt.Errorf("workflow path %q does not name a regular tracked file", displayPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("workflow path %q is tracked by git but missing from the checkout; restore the file or check sparse-checkout configuration", displayPath)
+	}
+	if err != nil {
+		return fmt.Errorf("inspect workflow path %q: %w", displayPath, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("workflow path %q is a symbolic link; workflow paths must be regular tracked files", displayPath)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("workflow path %q is a directory; workflow paths must be regular tracked files", displayPath)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("workflow path %q is not a regular file", displayPath)
 	}
 	return nil
 }
@@ -693,6 +717,7 @@ func workflowInputs(matches []workflowInput, namespaceKeys bool) ([]workflowInpu
 type parsedUploadArgs struct {
 	workflowOperands         []string
 	explicitWorkflowPaths    bool
+	checkoutPath             string
 	eventPath                string
 	clientVersion            string
 	runtimeDistributionPaths map[compiler.Platform]string

--- a/internal/cli/upload_test.go
+++ b/internal/cli/upload_test.go
@@ -440,9 +440,9 @@ func TestExpandExplicitWorkflowPathsCanonicalizesTrackedPaths(t *testing.T) {
 
 func TestExpandExplicitWorkflowPathsExplainsTrackedFileMissingFromCheckout(t *testing.T) {
 	repository := writeUploadWorkflowRepository(t, map[string]string{
-		"deploy.yml": "on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
+		"deploy[prod].yml": "on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
 	})
-	workflowPath := filepath.Join(".github", "workflows", "deploy.yml")
+	workflowPath := filepath.Join(".github", "workflows", "deploy[prod].yml")
 	if err := os.Remove(filepath.Join(repository, workflowPath)); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/upload_test.go
+++ b/internal/cli/upload_test.go
@@ -339,7 +339,7 @@ func TestRunUploadRejectsExplicitTrackedSymlinks(t *testing.T) {
 			t.Setenv("BUILDKITE_STEP_KEY", "symlink-importer")
 			runner := &cliCaptureRunner{}
 			var stdout, stderr bytes.Buffer
-			if code := run([]string{"upload", "--event-path", eventPath, ".github/workflows/linked.yml"}, &stdout, &stderr, "dev", runner); code != 1 || !strings.Contains(stderr.String(), "does not name a regular tracked file") {
+			if code := run([]string{"upload", "--event-path", eventPath, ".github/workflows/linked.yml"}, &stdout, &stderr, "dev", runner); code != 1 || !strings.Contains(stderr.String(), "symbolic link") {
 				t.Fatalf("run() code/stderr = %d / %q", code, stderr.String())
 			}
 			if stdout.Len() != 0 || len(runner.commands) != 0 || len(runner.uploaded) != 0 {
@@ -387,11 +387,11 @@ func TestExpandExplicitWorkflowPathsCanonicalizesTrackedPaths(t *testing.T) {
 
 	aPath := filepath.Join(".github", "workflows", "a.yml")
 	bPath := filepath.Join(".github", "workflows", "b.yaml")
-	first, err := expandExplicitWorkflowPaths([]string{filepath.Join(repository, bPath), "./" + aPath, aPath})
+	first, err := expandExplicitWorkflowPaths([]string{filepath.Join(repository, bPath), "./" + aPath, aPath}, "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	second, err := expandExplicitWorkflowPaths([]string{aPath, filepath.Join(repository, bPath)})
+	second, err := expandExplicitWorkflowPaths([]string{aPath, filepath.Join(repository, bPath)}, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -403,7 +403,7 @@ func TestExpandExplicitWorkflowPathsCanonicalizesTrackedPaths(t *testing.T) {
 			t.Fatalf("explicit workflow identity = %#v", input)
 		}
 	}
-	metacharacter, err := expandExplicitWorkflowPaths([]string{filepath.Join(".github", "workflows", "workflow[1].yml"), aPath})
+	metacharacter, err := expandExplicitWorkflowPaths([]string{filepath.Join(".github", "workflows", "workflow[1].yml"), aPath}, "")
 	if err != nil || len(metacharacter) != 2 || metacharacter[1].CanonicalPath != ".github/workflows/workflow[1].yml" {
 		t.Fatalf("literal metacharacter list = %#v, %v", metacharacter, err)
 	}
@@ -411,7 +411,7 @@ func TestExpandExplicitWorkflowPathsCanonicalizesTrackedPaths(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	leadingDash, err := expandExplicitWorkflowPaths(operands)
+	leadingDash, err := expandExplicitWorkflowPaths(operands, "")
 	if err != nil || len(leadingDash) != 2 || leadingDash[0].CanonicalPath != "-leading.yml" {
 		t.Fatalf("leading-dash explicit path = %#v, %v", leadingDash, err)
 	}
@@ -423,18 +423,33 @@ func TestExpandExplicitWorkflowPathsCanonicalizesTrackedPaths(t *testing.T) {
 	}{
 		{name: "mixed glob and literal", operands: []string{filepath.Join(".github", "workflows", "*.yml"), aPath}, want: "glob pattern"},
 		{name: "multiple globs", operands: []string{filepath.Join(".github", "workflows", "*.yml"), filepath.Join(".github", "workflows", "*.yaml")}, want: "glob pattern"},
-		{name: "missing", operands: []string{filepath.Join(".github", "workflows", "missing.yml"), aPath}, want: "regular tracked file"},
+		{name: "missing", operands: []string{filepath.Join(".github", "workflows", "missing.yml"), aPath}, want: "not tracked by git"},
 		{name: "untracked", operands: []string{untrackedPath, aPath}, want: "not tracked by git"},
-		{name: "directory", operands: []string{workflowDirectory, aPath}, want: "regular tracked file"},
+		{name: "directory", operands: []string{workflowDirectory, aPath}, want: "directory"},
 		{name: "outside repository", operands: []string{outsidePath, aPath}, want: "outside the checked-out git repository"},
 		{name: "non-workflow extension", operands: []string{notePath, aPath}, want: "must end in .yml or .yaml"},
-		{name: "symlink", operands: []string{symlinkPath, aPath}, want: "regular tracked file"},
+		{name: "symlink", operands: []string{symlinkPath, aPath}, want: "symbolic link"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			if _, err := expandExplicitWorkflowPaths(test.operands); err == nil || !strings.Contains(err.Error(), test.want) {
+			if _, err := expandExplicitWorkflowPaths(test.operands, ""); err == nil || !strings.Contains(err.Error(), test.want) {
 				t.Fatalf("expandExplicitWorkflowPaths(%q) error = %v, want %q", test.operands, err, test.want)
 			}
 		})
+	}
+}
+
+func TestExpandExplicitWorkflowPathsExplainsTrackedFileMissingFromCheckout(t *testing.T) {
+	repository := writeUploadWorkflowRepository(t, map[string]string{
+		"deploy.yml": "on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
+	})
+	workflowPath := filepath.Join(".github", "workflows", "deploy.yml")
+	if err := os.Remove(filepath.Join(repository, workflowPath)); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repository)
+	_, err := expandExplicitWorkflowPaths([]string{workflowPath}, "")
+	if err == nil || !strings.Contains(err.Error(), "tracked by git but missing from the checkout") || !strings.Contains(err.Error(), "sparse-checkout") {
+		t.Fatalf("expandExplicitWorkflowPaths() error = %v", err)
 	}
 }
 
@@ -524,7 +539,7 @@ func TestRunUploadAggregatesExplicitPathsAtomicallyWithNamespacedJobs(t *testing
 		filepath.Join(workflowDirectory, "shell.yml"),
 	}
 	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
-	inputs, err := expandExplicitWorkflowPaths(workflowPaths)
+	inputs, err := expandExplicitWorkflowPaths(workflowPaths, "")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Why

The GitHub Actions plugin resolves repository-relative workflow paths from the command hook's inherited working directory. If that directory differs from the Buildkite checkout, an ordinary tracked workflow fails with the misleading claim that it is not a regular tracked file.

## What

Resolve plugin workflow paths from `BUILDKITE_BUILD_CHECKOUT_PATH` while preserving current-directory semantics for direct CLI uploads. Distinguish untracked, sparse-omitted or deleted, symlink, directory, and invalid checkout cases so failures identify the corrective action.
