### PR TITLE
Make GitHub token checks follow expression behavior

### DIFF
--- a/internal/expression/abstract.go
+++ b/internal/expression/abstract.go
@@ -1,0 +1,143 @@
+package expression
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/rhysd/actionlint"
+)
+
+// AbstractValue is either one concrete expression value or an unknown runtime
+// value. Unknown is distinct from a known null value.
+type AbstractValue struct {
+	Known bool
+	Value any
+}
+
+// GitHubTokenEffect records why evaluation can require github.token.
+type GitHubTokenEffect uint8
+
+const (
+	GitHubTokenDirect GitHubTokenEffect = 1 << iota
+	GitHubTokenWorkflowContext
+	GitHubTokenCompositeContext
+)
+
+// Effects are the authority effects reachable while evaluating an expression.
+type Effects struct {
+	GitHubToken GitHubTokenEffect
+}
+
+// Analysis contains an abstract expression result and its reachable authority
+// effects.
+type Analysis struct {
+	Value   AbstractValue
+	Effects Effects
+}
+
+func knownAnalysis(value any) Analysis {
+	return Analysis{Value: AbstractValue{Known: true, Value: value}}
+}
+
+func unknownAnalysis(values ...Analysis) Analysis {
+	var effects Effects
+	for _, value := range values {
+		effects.GitHubToken |= value.Effects.GitHubToken
+	}
+	return Analysis{Effects: effects}
+}
+
+func derivedAnalysis(value any, inputs ...Analysis) Analysis {
+	analysis := knownAnalysis(value)
+	for _, input := range inputs {
+		analysis.Effects.GitHubToken |= input.Effects.GitHubToken
+	}
+	return analysis
+}
+
+type abstractExpressionDomain struct{}
+
+func (abstractExpressionDomain) known(value any) Analysis { return knownAnalysis(value) }
+func (abstractExpressionDomain) derive(value any, inputs ...Analysis) Analysis {
+	return derivedAnalysis(value, inputs...)
+}
+func (abstractExpressionDomain) value(analysis Analysis) (any, bool) {
+	return analysis.Value.Value, analysis.Value.Known
+}
+func (abstractExpressionDomain) unknown(values ...Analysis) Analysis {
+	return unknownAnalysis(values...)
+}
+func (abstractExpressionDomain) join(values ...Analysis) Analysis {
+	if len(values) == 0 {
+		return Analysis{}
+	}
+	result := unknownAnalysis(values...)
+	first := values[0].Value
+	if !first.Known {
+		return result
+	}
+	for _, value := range values[1:] {
+		if !value.Value.Known || !abstractValuesIdentical(value.Value.Value, first.Value) {
+			return result
+		}
+	}
+	result.Value = first
+	return result
+}
+
+func abstractValuesIdentical(left, right any) bool {
+	if left == nil || right == nil || reflect.TypeOf(left) != reflect.TypeOf(right) {
+		return left == nil && right == nil
+	}
+	leftValue, rightValue := reflect.ValueOf(left), reflect.ValueOf(right)
+	switch leftValue.Kind() {
+	case reflect.Map:
+		return leftValue.UnsafePointer() == rightValue.UnsafePointer()
+	case reflect.Pointer, reflect.Slice:
+		return leftValue.Pointer() == rightValue.Pointer()
+	default:
+		return reflect.DeepEqual(left, right)
+	}
+}
+
+func newAbstractEvaluator(surface evaluationSurface) expressionEvaluator[Analysis] {
+	return expressionEvaluator[Analysis]{
+		policy: newSemanticEvaluator(surface).policy,
+		domain: abstractExpressionDomain{},
+		truthy: githubTruthy,
+		compare: func(kind actionlint.CompareOpNodeKind, left, right any) (any, error) {
+			return githubCompare(kind, left, right)
+		},
+		unsupported: func(actionlint.ExprNode) error {
+			return fmt.Errorf("action input default expression is unsupported")
+		},
+		logicalError: func(kind actionlint.LogicalOpNodeKind) error {
+			return fmt.Errorf("action input default logical operator %s is unsupported", kind)
+		},
+	}
+}
+
+func analyzeActionInputDefault(node actionlint.ExprNode, knownReferences map[string]any) (Analysis, error) {
+	evaluator := newAbstractEvaluator(actionInputDefaultSurface)
+	evaluator.resolve = func(root string, path []string) (Analysis, error) {
+		if strings.EqualFold(root, "github") && len(path) == 1 && strings.EqualFold(path[0], "token") {
+			analysis := Analysis{Effects: Effects{GitHubToken: GitHubTokenDirect}}
+			if value, ok := knownReferences["github.token"]; ok {
+				analysis.Value = AbstractValue{Known: true, Value: value}
+			}
+			return analysis, nil
+		}
+		if value, ok := knownReferences[strings.ToLower(referenceName(root, path))]; ok {
+			return knownAnalysis(value), nil
+		}
+		return Analysis{}, nil
+	}
+	evaluator.call = func(evaluator *expressionEvaluator[Analysis], node *actionlint.FuncCallNode) (Analysis, error) {
+		if value, recognized, err := evaluatePureFunction(evaluator, node); recognized {
+			return value, err
+		}
+		return Analysis{}, fmt.Errorf("action input default function %q is unsupported", node.Callee)
+	}
+	return evaluator.evaluate(node)
+}

--- a/internal/expression/abstract_test.go
+++ b/internal/expression/abstract_test.go
@@ -1,0 +1,198 @@
+package expression
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/rhysd/actionlint"
+)
+
+func TestAbstractActionInputDefaultMatchesConcreteWhenKnown(t *testing.T) {
+	for _, source := range []string{
+		"false && 'unreachable' || 'fallback'",
+		"github.server_url == 'https://github.com' && 'github' || 'other'",
+		"case(false, 'unused', true, format('{0}-{1}', 'selected', 2), 'fallback')",
+		"contains(fromJSON('[1, 2]'), 2)",
+		"join(fromJSON('[\"one\", \"two\"]'), '-')",
+	} {
+		t.Run(source, func(t *testing.T) {
+			node := parseAbstractTestExpression(t, source)
+			context := Context{GitHub: map[string]any{"server_url": "https://github.com"}}
+			concrete, err := evaluateActionInputDefaultNode(node, context)
+			if err != nil {
+				t.Fatal(err)
+			}
+			abstract, err := analyzeActionInputDefault(node, map[string]any{"github.server_url": "https://github.com"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !abstract.Value.Known || !reflect.DeepEqual(abstract.Value.Value, concrete) {
+				t.Fatalf("abstract value = %#v, concrete value = %#v", abstract.Value, concrete)
+			}
+			if abstract.Effects != (Effects{}) {
+				t.Fatalf("abstract effects = %#v, want none", abstract.Effects)
+			}
+		})
+	}
+}
+
+func TestAbstractActionInputDefaultTokenEffectsNarrowWithKnownValues(t *testing.T) {
+	node := parseAbstractTestExpression(t, "github.server_url == 'https://github.com' && github.token || ''")
+	for _, test := range []struct {
+		name  string
+		known map[string]any
+		want  GitHubTokenEffect
+	}{
+		{name: "unknown provider", want: GitHubTokenDirect},
+		{name: "GitHub provider", known: map[string]any{"github.server_url": "https://github.com"}, want: GitHubTokenDirect},
+		{name: "Origin provider", known: map[string]any{"github.server_url": "https://origin.cursor.com"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			analysis, err := analyzeActionInputDefault(node, test.known)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if analysis.Effects.GitHubToken != test.want {
+				t.Fatalf("github.token effects = %v, want %v", analysis.Effects.GitHubToken, test.want)
+			}
+		})
+	}
+}
+
+func TestAbstractActionInputDefaultPreservesLazyAuthority(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		source string
+		want   bool
+	}{
+		{name: "known false logical branch", source: "false && github.token || ''"},
+		{name: "selected case branch", source: "case(false, github.token, true, 'selected', github.token)"},
+		{name: "unused format argument", source: "format('constant', github.token)"},
+		{name: "empty contains collection", source: "contains(fromJSON('[]'), github.token)"},
+		{name: "single join item", source: "join(fromJSON('[\"one\"]'), github.token)"},
+		{name: "unknown logical branch", source: "inputs.enabled && github.token || ''", want: true},
+		{name: "unknown case branch", source: "case(inputs.enabled, '', true, github.token, '')", want: true},
+		{name: "unknown case before false branch", source: "case(inputs.enabled, '', false, github.token, '')"},
+		{name: "equal unknown case results", source: "case(inputs.enabled, false, false) && github.token"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			analysis, err := analyzeActionInputDefault(parseAbstractTestExpression(t, test.source), nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := analysis.Effects.GitHubToken != 0; got != test.want {
+				t.Fatalf("requires github.token = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestActionInputDefaultAuthorityPreservesRuntimeErrorFallback(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		source string
+		want   bool
+	}{
+		{name: "known false skips error and token", source: "${{ false && fromJSON('bad') && github.token || '' }}"},
+		{name: "unknown guard conservatively falls back", source: "${{ inputs.enabled && fromJSON('bad') && github.token || '' }}", want: true},
+		{name: "reachable error conservatively falls back", source: "${{ fromJSON('bad') && github.token || '' }}", want: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := ActionInputDefaultRequiresGitHubToken(test.source, "https://origin.cursor.com")
+			if err != nil || got != test.want {
+				t.Fatalf("ActionInputDefaultRequiresGitHubToken() = %v, %v, want %v", got, err, test.want)
+			}
+		})
+	}
+}
+
+func TestAbstractActionInputDefaultIsSoundAsValuesBecomeKnown(t *testing.T) {
+	for _, source := range []string{
+		"matrix.enabled && github.token || ''",
+		"case(matrix.enabled, '', true, github.token, '')",
+		"format(case(matrix.enabled, '{0}', 'constant'), github.token)",
+		"contains(case(matrix.enabled, fromJSON('[]'), fromJSON('[1]')), github.token)",
+		"join(case(matrix.enabled, fromJSON('[1]'), fromJSON('[1, 2]')), github.token)",
+	} {
+		t.Run(source, func(t *testing.T) {
+			node := parseAbstractTestExpression(t, source)
+			lessKnown, err := analyzeActionInputDefault(node, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, enabled := range []bool{false, true} {
+				known := map[string]any{"matrix.enabled": enabled, "github.token": "ghs_scoped"}
+				refined, err := analyzeActionInputDefault(node, known)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if refined.Effects.GitHubToken&^lessKnown.Effects.GitHubToken != 0 {
+					t.Fatalf("refined effects %v are not contained by less-known effects %v", refined.Effects.GitHubToken, lessKnown.Effects.GitHubToken)
+				}
+				concrete, err := evaluateActionInputDefaultNode(node, Context{Matrix: map[string]any{"enabled": enabled}, GitHub: map[string]any{"token": "ghs_scoped"}})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !refined.Value.Known || !reflect.DeepEqual(refined.Value.Value, concrete) {
+					t.Fatalf("abstract value = %#v, concrete value = %#v", refined.Value, concrete)
+				}
+			}
+		})
+	}
+}
+
+func TestAbstractCaseDoesNotMergeDistinctObjectIdentities(t *testing.T) {
+	node := parseAbstractTestExpression(t, "case(matrix.enabled, matrix.left, matrix.right) != matrix.left && github.token || ''")
+	left := map[string]any{"value": true}
+	right := map[string]any{"value": true}
+	analysis, err := analyzeActionInputDefault(node, map[string]any{
+		"matrix.left":  left,
+		"matrix.right": right,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if analysis.Effects.GitHubToken != GitHubTokenDirect {
+		t.Fatalf("github.token effects = %v, want %v", analysis.Effects.GitHubToken, GitHubTokenDirect)
+	}
+}
+
+func FuzzAbstractActionInputDefaultMatchesConcrete(f *testing.F) {
+	for _, serverURL := range []string{"https://github.com", "HTTPS://GITHUB.COM", "https://origin.cursor.com", ""} {
+		f.Add(serverURL, "ghs_scoped")
+	}
+	node, err := actionlint.NewExprParser().Parse(actionlint.NewExprLexer("github.server_url == 'https://github.com' && github.token || ''}}"))
+	if err != nil {
+		f.Fatal(err)
+	}
+	f.Fuzz(func(t *testing.T, serverURL, token string) {
+		concrete, err := evaluateActionInputDefaultNode(node, Context{GitHub: map[string]any{"server_url": serverURL, "token": token}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		abstract, err := analyzeActionInputDefault(node, map[string]any{"github.server_url": serverURL, "github.token": token})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !abstract.Value.Known || !reflect.DeepEqual(abstract.Value.Value, concrete) {
+			t.Fatalf("abstract value = %#v, concrete value = %#v", abstract.Value, concrete)
+		}
+		wantEffect := GitHubTokenEffect(0)
+		if strings.EqualFold(serverURL, "https://github.com") {
+			wantEffect = GitHubTokenDirect
+		}
+		if abstract.Effects.GitHubToken != wantEffect {
+			t.Fatalf("github.token effects = %v, want %v", abstract.Effects.GitHubToken, wantEffect)
+		}
+	})
+}
+
+func parseAbstractTestExpression(t *testing.T, source string) actionlint.ExprNode {
+	t.Helper()
+	node, err := actionlint.NewExprParser().Parse(actionlint.NewExprLexer(source + "}}"))
+	if err != nil {
+		t.Fatalf("parse expression: %v", err)
+	}
+	return node
+}

--- a/internal/expression/action_input_default.go
+++ b/internal/expression/action_input_default.go
@@ -101,48 +101,23 @@ func ActionInputDefaultRequiresGitHubToken(template, serverURL string) (bool, er
 	if err != nil || !referencesToken {
 		return referencesToken, err
 	}
-	onlyKnownReferences := true
+	requiresToken := false
 	err = visitTemplateExpressions(template, func(expression actionlint.ExprNode) error {
-		actionlint.VisitExprNode(expression, func(node, parent actionlint.ExprNode, entering bool) {
-			if !entering || !onlyKnownReferences {
-				return
-			}
-			switch node.(type) {
-			case *actionlint.VariableNode, *actionlint.ObjectDerefNode, *actionlint.IndexAccessNode:
-			default:
-				return
-			}
-			root, path, referenceErr := referencePath(node)
-			if referenceErr != nil {
-				onlyKnownReferences = false
-				return
-			}
-			if len(path) == 0 {
-				switch parent := parent.(type) {
-				case *actionlint.ObjectDerefNode:
-					if parent.Receiver == node {
-						return
-					}
-				case *actionlint.IndexAccessNode:
-					if parent.Operand == node {
-						return
-					}
-				}
-			}
-			onlyKnownReferences = isJobCheckRunIDReference(root, path) ||
-				strings.EqualFold(root, "github") && len(path) == 1 &&
-					(strings.EqualFold(path[0], "server_url") || strings.EqualFold(path[0], "token"))
+		analysis, analysisErr := analyzeActionInputDefault(expression, map[string]any{
+			"github.server_url": serverURL,
+			"job.check_run_id":  "",
 		})
+		if analysisErr != nil {
+			// Runtime-dependent evaluation failures previously fell back to
+			// conservative authority. Preserve that behavior while the
+			// exhaustive reference pass above continues to own validation.
+			requiresToken = true
+			return nil
+		}
+		requiresToken = requiresToken || analysis.Effects.GitHubToken != 0
 		return nil
 	})
-	if err != nil {
-		return false, err
-	}
-	if !onlyKnownReferences {
-		return true, nil
-	}
-	_, err = EvaluateActionInputDefault(template, Context{GitHub: map[string]any{"server_url": serverURL}})
-	return err != nil, nil
+	return requiresToken, err
 }
 
 func evaluateActionInputDefaultNode(node actionlint.ExprNode, context Context) (any, error) {

--- a/internal/expression/evaluator.go
+++ b/internal/expression/evaluator.go
@@ -9,20 +9,44 @@ import (
 	"github.com/rhysd/actionlint"
 )
 
-// semanticEvaluator owns expression-tree traversal while each fixed surface
-// supplies its existing reference, comparison, function, and error behavior.
-// Validation and authority analysis remain separate and run at their existing
-// call sites.
-type semanticEvaluator struct {
+// expressionEvaluator owns expression-tree traversal while each fixed surface
+// and value domain supplies its reference, comparison, function, and error
+// behavior. The concrete semanticEvaluator alias preserves the existing
+// runtime evaluators; abstract evaluation uses the same traversal with a value
+// that can represent unknown runtime data and authority effects.
+type expressionEvaluator[T any] struct {
 	policy          evaluationPolicy
-	resolve         func(string, []string) (any, error)
-	resolveRoot     func(string) (any, error)
+	resolve         func(string, []string) (T, error)
+	resolveRoot     func(string) (T, error)
+	domain          expressionDomain[T]
 	truthy          func(any) bool
 	validateCompare func(actionlint.CompareOpNodeKind) error
 	compare         func(actionlint.CompareOpNodeKind, any, any) (any, error)
-	call            func(*semanticEvaluator, *actionlint.FuncCallNode) (any, error)
+	call            func(*expressionEvaluator[T], *actionlint.FuncCallNode) (T, error)
 	unsupported     func(actionlint.ExprNode) error
 	logicalError    func(actionlint.LogicalOpNodeKind) error
+}
+
+type semanticEvaluator = expressionEvaluator[any]
+
+type expressionDomain[T any] interface {
+	known(any) T
+	derive(any, ...T) T
+	value(T) (any, bool)
+	unknown(...T) T
+	join(...T) T
+}
+
+type concreteExpressionDomain struct{}
+
+func (concreteExpressionDomain) known(value any) any            { return value }
+func (concreteExpressionDomain) derive(value any, _ ...any) any { return value }
+func (concreteExpressionDomain) value(value any) (any, bool)    { return value, true }
+func (concreteExpressionDomain) unknown(...any) any {
+	panic("concrete expression evaluation produced an unknown value")
+}
+func (concreteExpressionDomain) join(...any) any {
+	panic("concrete expression evaluation joined multiple paths")
 }
 
 type evaluationSurface uint8
@@ -58,7 +82,19 @@ func newSemanticEvaluator(surface evaluationSurface) semanticEvaluator {
 		policy = evaluationPolicy{allowLiterals: true, allowNot: true, allowLogical: true, allowCompare: true, allowFunction: true, resolveStaticIndexedReference: true}
 	case runtimeReferenceSurface:
 	}
-	return semanticEvaluator{policy: policy}
+	return semanticEvaluator{
+		policy: policy,
+		domain: concreteExpressionDomain{},
+	}
+}
+
+func (e *expressionEvaluator[T]) result(value T, inputs ...T) T {
+	concrete, known := e.domain.value(value)
+	inputs = append(inputs, value)
+	if !known {
+		return e.domain.unknown(inputs...)
+	}
+	return e.domain.derive(concrete, inputs...)
 }
 
 type semanticValidator struct {
@@ -144,27 +180,28 @@ func (v *semanticValidator) validate(node actionlint.ExprNode) error {
 	return v.unsupported(node)
 }
 
-func (e *semanticEvaluator) evaluate(node actionlint.ExprNode) (any, error) {
+func (e *expressionEvaluator[T]) evaluate(node actionlint.ExprNode) (T, error) {
+	var zero T
 	switch node := node.(type) {
 	case *actionlint.NullNode:
 		if e.policy.allowLiterals {
-			return nil, nil
+			return e.domain.known(nil), nil
 		}
 	case *actionlint.BoolNode:
 		if e.policy.allowLiterals {
-			return node.Value, nil
+			return e.domain.known(node.Value), nil
 		}
 	case *actionlint.IntNode:
 		if e.policy.allowLiterals {
-			return node.Value, nil
+			return e.domain.known(node.Value), nil
 		}
 	case *actionlint.FloatNode:
 		if e.policy.allowLiterals {
-			return node.Value, nil
+			return e.domain.known(node.Value), nil
 		}
 	case *actionlint.StringNode:
 		if e.policy.allowLiterals {
-			return node.Value, nil
+			return e.domain.known(node.Value), nil
 		}
 	case *actionlint.VariableNode, *actionlint.ObjectDerefNode:
 		root, path, err := referencePath(node)
@@ -180,7 +217,7 @@ func (e *semanticEvaluator) evaluate(node actionlint.ExprNode) (any, error) {
 		if e.resolveRoot != nil {
 			return e.evaluateAccess(node)
 		}
-		return nil, err
+		return zero, err
 	case *actionlint.IndexAccessNode:
 		root, path, err := referencePath(node)
 		// Mirror the validator: static bracket references to authority
@@ -194,79 +231,104 @@ func (e *semanticEvaluator) evaluate(node actionlint.ExprNode) (any, error) {
 			return e.evaluateAccess(node)
 		}
 		if err != nil {
-			return nil, err
+			return zero, err
 		}
 		return e.resolve(root, path)
 	case *actionlint.ArrayDerefNode:
 		if e.resolveRoot != nil {
 			return e.evaluateAccess(node)
 		}
-		return nil, e.unsupported(node)
+		return zero, e.unsupported(node)
 	case *actionlint.NotOpNode:
 		if e.policy.allowNot {
 			value, err := e.evaluate(node.Operand)
 			if err != nil {
-				return nil, err
+				return zero, err
 			}
-			return !e.truthy(value), nil
+			concrete, known := e.domain.value(value)
+			if !known {
+				return e.domain.unknown(value), nil
+			}
+			return e.domain.derive(!e.truthy(concrete), value), nil
 		}
 	case *actionlint.LogicalOpNode:
 		if e.policy.allowLogical {
 			left, err := e.evaluate(node.Left)
 			if err != nil {
-				return nil, err
+				return zero, err
 			}
-			leftTruthy := e.truthy(left)
+			leftValue, leftKnown := e.domain.value(left)
+			if !leftKnown {
+				right, err := e.evaluate(node.Right)
+				if err != nil {
+					return zero, err
+				}
+				return e.domain.unknown(left, right), nil
+			}
+			leftTruthy := e.truthy(leftValue)
 			switch node.Kind {
 			case actionlint.LogicalOpNodeKindAnd:
 				if !leftTruthy {
 					if e.policy.logicalBool {
-						return false, nil
+						return e.domain.derive(false, left), nil
 					}
 					return left, nil
 				}
 			case actionlint.LogicalOpNodeKindOr:
 				if leftTruthy {
 					if e.policy.logicalBool {
-						return true, nil
+						return e.domain.derive(true, left), nil
 					}
 					return left, nil
 				}
 			default:
-				return nil, e.logicalError(node.Kind)
+				return zero, e.logicalError(node.Kind)
 			}
 			right, err := e.evaluate(node.Right)
 			if err != nil {
-				return nil, err
+				return zero, err
 			}
 			if e.policy.logicalBool {
-				return e.truthy(right), nil
+				rightValue, rightKnown := e.domain.value(right)
+				if !rightKnown {
+					return e.domain.unknown(left, right), nil
+				}
+				return e.domain.derive(e.truthy(rightValue), left, right), nil
 			}
-			return right, nil
+			return e.result(right, left), nil
 		}
 	case *actionlint.CompareOpNode:
 		if e.policy.allowCompare {
 			if e.validateCompare != nil {
 				if err := e.validateCompare(node.Kind); err != nil {
-					return nil, err
+					return zero, err
 				}
 			}
 			left, err := e.evaluate(node.Left)
 			if err != nil {
-				return nil, err
+				return zero, err
 			}
 			right, err := e.evaluate(node.Right)
 			if err != nil {
-				return nil, err
+				return zero, err
 			}
-			return e.compare(node.Kind, left, right)
+			leftValue, leftKnown := e.domain.value(left)
+			rightValue, rightKnown := e.domain.value(right)
+			if !leftKnown || !rightKnown {
+				return e.domain.unknown(left, right), nil
+			}
+			compared, err := e.compare(node.Kind, leftValue, rightValue)
+			if err != nil {
+				return zero, err
+			}
+			return e.domain.derive(compared, left, right), nil
 		}
 	case *actionlint.FuncCallNode:
 		if e.policy.allowFunction {
 			return e.call(e, node)
 		}
 	}
-	return nil, e.unsupported(node)
+	return zero, e.unsupported(node)
 }
 
 func expressionReferenceUsesIndex(node actionlint.ExprNode) bool {
@@ -289,62 +351,80 @@ func newExpressionProjection(capacity int) expressionProjection {
 	return make(expressionProjection, 0, capacity)
 }
 
-func (e *semanticEvaluator) evaluateAccess(node actionlint.ExprNode) (any, error) {
+func (e *expressionEvaluator[T]) evaluateAccess(node actionlint.ExprNode) (T, error) {
+	var zero T
 	switch node := node.(type) {
 	case *actionlint.VariableNode:
 		return e.resolveRoot(node.Name)
 	case *actionlint.ObjectDerefNode:
 		receiver, err := e.evaluateAccess(node.Receiver)
 		if err != nil {
-			return nil, err
+			return zero, err
 		}
-		if projection, ok := receiver.(expressionProjection); ok {
+		receiverValue, known := e.domain.value(receiver)
+		if !known {
+			return e.domain.unknown(receiver), nil
+		}
+		if projection, ok := receiverValue.(expressionProjection); ok {
 			result := newExpressionProjection(len(projection))
 			for _, item := range projection {
 				value, found, err := objectValue(item, node.Property)
 				if err != nil {
-					return nil, err
+					return zero, err
 				}
 				if found {
 					result = append(result, value)
 				}
 			}
-			return result, nil
+			return e.domain.derive(result, receiver), nil
 		}
-		value, found, err := objectValue(receiver, node.Property)
+		value, found, err := objectValue(receiverValue, node.Property)
 		if err != nil || found {
-			return value, err
+			return e.domain.derive(value, receiver), err
 		}
-		return nil, nil
+		return e.domain.derive(nil, receiver), nil
 	case *actionlint.IndexAccessNode:
 		operand, err := e.evaluateAccess(node.Operand)
 		if err != nil {
-			return nil, err
+			return zero, err
 		}
 		index, err := e.evaluate(node.Index)
 		if err != nil {
-			return nil, err
+			return zero, err
 		}
-		return expressionIndex(operand, index)
+		operandValue, operandKnown := e.domain.value(operand)
+		indexValue, indexKnown := e.domain.value(index)
+		if !operandKnown || !indexKnown {
+			return e.domain.unknown(operand, index), nil
+		}
+		value, err := expressionIndex(operandValue, indexValue)
+		if err != nil {
+			return zero, err
+		}
+		return e.domain.derive(value, operand, index), nil
 	case *actionlint.ArrayDerefNode:
 		receiver, err := e.evaluateAccess(node.Receiver)
 		if err != nil {
-			return nil, err
+			return zero, err
 		}
-		if projection, ok := receiver.(expressionProjection); ok {
+		receiverValue, known := e.domain.value(receiver)
+		if !known {
+			return e.domain.unknown(receiver), nil
+		}
+		if projection, ok := receiverValue.(expressionProjection); ok {
 			result := newExpressionProjection(0)
 			for _, item := range projection {
 				if values, ok := expressionChildren(item); ok {
 					result = append(result, values...)
 				}
 			}
-			return result, nil
+			return e.domain.derive(result, receiver), nil
 		}
-		values, ok := expressionChildren(receiver)
+		values, ok := expressionChildren(receiverValue)
 		if !ok {
-			return newExpressionProjection(0), nil
+			return e.domain.derive(newExpressionProjection(0), receiver), nil
 		}
-		return append(newExpressionProjection(len(values)), values...), nil
+		return e.domain.derive(append(newExpressionProjection(len(values)), values...), receiver), nil
 	default:
 		return e.evaluate(node)
 	}

--- a/internal/expression/pure_functions.go
+++ b/internal/expression/pure_functions.go
@@ -42,117 +42,167 @@ func validatePureFunction(validator *semanticValidator, node *actionlint.FuncCal
 	return true, nil
 }
 
-func evaluatePureFunction(evaluator *semanticEvaluator, node *actionlint.FuncCallNode) (any, bool, error) {
+func evaluatePureFunction[T any](evaluator *expressionEvaluator[T], node *actionlint.FuncCallNode) (T, bool, error) {
+	var zero T
 	name := strings.ToLower(node.Callee)
 	argc := len(node.Args)
 	switch name {
 	case "case":
 		if argc < 3 || argc > 255 || argc%2 != 1 {
-			return nil, true, fmt.Errorf("function %q requires 3 to 255 odd-numbered arguments", node.Callee)
+			return zero, true, fmt.Errorf("function %q requires 3 to 255 odd-numbered arguments", node.Callee)
 		}
-		for i := 0; i < argc-1; i += 2 {
-			predicate, err := evaluator.evaluate(node.Args[i])
-			if err != nil {
-				return nil, true, err
-			}
-			selected, ok := predicate.(bool)
-			if !ok {
-				return nil, true, fmt.Errorf("function %q predicate %d resolved to %T, want boolean", node.Callee, i/2+1, predicate)
-			}
-			if selected {
-				value, err := evaluator.evaluate(node.Args[i+1])
-				return value, true, err
-			}
-		}
-		value, err := evaluator.evaluate(node.Args[argc-1])
+		value, err := evaluateCaseFunction(evaluator, node, 0)
 		return value, true, err
 	case "startswith", "contains", "endswith":
 		if argc != 2 {
-			return nil, true, fmt.Errorf("function %q requires 2 arguments", node.Callee)
+			return zero, true, fmt.Errorf("function %q requires 2 arguments", node.Callee)
 		}
-		value, err := evaluator.evaluate(node.Args[0])
+		first, err := evaluator.evaluate(node.Args[0])
 		if err != nil {
-			return nil, true, err
+			return zero, true, err
+		}
+		value, known := evaluator.domain.value(first)
+		if !known {
+			second, err := evaluator.evaluate(node.Args[1])
+			if err != nil {
+				return zero, true, err
+			}
+			return evaluator.domain.unknown(first, second), true, nil
 		}
 		if name == "contains" {
 			if items, ok := expressionCollection(value); ok {
 				if len(items) == 0 {
-					return false, true, nil
+					return evaluator.domain.derive(false, first), true, nil
 				}
-				search, err := evaluator.evaluate(node.Args[1])
+				searchValue, err := evaluator.evaluate(node.Args[1])
 				if err != nil {
-					return nil, true, err
+					return zero, true, err
+				}
+				search, searchKnown := evaluator.domain.value(searchValue)
+				if !searchKnown {
+					return evaluator.domain.unknown(first, searchValue), true, nil
 				}
 				for _, item := range items {
 					if githubEqual(item, search) {
-						return true, true, nil
+						return evaluator.domain.derive(true, first, searchValue), true, nil
 					}
 				}
-				return false, true, nil
+				return evaluator.domain.derive(false, first, searchValue), true, nil
 			}
 		}
 		valueText, ok := expressionString(value)
 		if !ok {
-			return false, true, nil
+			return evaluator.domain.derive(false, first), true, nil
 		}
-		search, err := evaluator.evaluate(node.Args[1])
+		searchValue, err := evaluator.evaluate(node.Args[1])
 		if err != nil {
-			return nil, true, err
+			return zero, true, err
+		}
+		search, searchKnown := evaluator.domain.value(searchValue)
+		if !searchKnown {
+			return evaluator.domain.unknown(first, searchValue), true, nil
 		}
 		searchText, ok := expressionString(search)
 		if !ok {
-			return false, true, nil
+			return evaluator.domain.derive(false, first, searchValue), true, nil
 		}
 		valueText, searchText = strings.ToLower(valueText), strings.ToLower(searchText)
 		switch name {
 		case "startswith":
-			return strings.HasPrefix(valueText, searchText), true, nil
+			return evaluator.domain.derive(strings.HasPrefix(valueText, searchText), first, searchValue), true, nil
 		case "contains":
-			return strings.Contains(valueText, searchText), true, nil
+			return evaluator.domain.derive(strings.Contains(valueText, searchText), first, searchValue), true, nil
 		default:
-			return strings.HasSuffix(valueText, searchText), true, nil
+			return evaluator.domain.derive(strings.HasSuffix(valueText, searchText), first, searchValue), true, nil
 		}
 	case "format":
 		if argc < 1 || argc > 255 {
-			return nil, true, fmt.Errorf("function %q requires 1 to 255 arguments", node.Callee)
+			return zero, true, fmt.Errorf("function %q requires 1 to 255 arguments", node.Callee)
 		}
-		value, err := evaluator.evaluate(node.Args[0])
+		formatValue, err := evaluator.evaluate(node.Args[0])
 		if err != nil {
-			return nil, true, err
+			return zero, true, err
+		}
+		value, known := evaluator.domain.value(formatValue)
+		if !known {
+			values := []T{formatValue}
+			for _, argument := range node.Args[1:] {
+				value, err := evaluator.evaluate(argument)
+				if err != nil {
+					return zero, true, err
+				}
+				values = append(values, value)
+			}
+			return evaluator.domain.unknown(values...), true, nil
 		}
 		format, ok := expressionAggregateString(value)
 		if !ok {
-			return nil, true, fmt.Errorf("function %q cannot convert %T to a format string", node.Callee, value)
+			return zero, true, fmt.Errorf("function %q cannot convert %T to a format string", node.Callee, value)
 		}
+		values := []T{formatValue}
+		unknown := false
 		formatted, err := expressionFormat(format, len(node.Args)-1, func(index int) (any, error) {
-			return evaluator.evaluate(node.Args[index+1])
+			value, err := evaluator.evaluate(node.Args[index+1])
+			if err != nil {
+				return nil, err
+			}
+			values = append(values, value)
+			concrete, known := evaluator.domain.value(value)
+			if !known {
+				unknown = true
+				return "", nil
+			}
+			return concrete, nil
 		})
-		return formatted, true, err
+		if err != nil {
+			return zero, true, err
+		}
+		if unknown {
+			return evaluator.domain.unknown(values...), true, nil
+		}
+		return evaluator.domain.derive(formatted, values...), true, nil
 	case "join":
 		if argc != 1 && argc != 2 {
-			return nil, true, fmt.Errorf("function %q requires 1 or 2 arguments", node.Callee)
+			return zero, true, fmt.Errorf("function %q requires 1 or 2 arguments", node.Callee)
 		}
-		value, err := evaluator.evaluate(node.Args[0])
+		first, err := evaluator.evaluate(node.Args[0])
 		if err != nil {
-			return nil, true, err
+			return zero, true, err
+		}
+		value, known := evaluator.domain.value(first)
+		if !known {
+			if argc == 1 {
+				return evaluator.domain.unknown(first), true, nil
+			}
+			separator, err := evaluator.evaluate(node.Args[1])
+			if err != nil {
+				return zero, true, err
+			}
+			return evaluator.domain.unknown(first, separator), true, nil
 		}
 		items, ok := expressionCollection(value)
 		if !ok {
 			if reflected := reflect.ValueOf(value); reflected.IsValid() && reflected.Kind() == reflect.Map {
-				return "", true, nil
+				return evaluator.domain.derive("", first), true, nil
 			}
 			joined, convertible := expressionString(value)
 			if !convertible {
-				return nil, true, fmt.Errorf("function %q cannot convert %T to a string", node.Callee, value)
+				return zero, true, fmt.Errorf("function %q cannot convert %T to a string", node.Callee, value)
 			}
-			return joined, true, nil
+			return evaluator.domain.derive(joined, first), true, nil
 		}
 		separator := ","
+		values := []T{first}
 		if argc == 2 && len(items) > 1 {
-			value, err := evaluator.evaluate(node.Args[1])
+			separatorValue, err := evaluator.evaluate(node.Args[1])
 			if err != nil {
-				return nil, true, err
+				return zero, true, err
 			}
+			value, separatorKnown := evaluator.domain.value(separatorValue)
+			if !separatorKnown {
+				return evaluator.domain.unknown(first, separatorValue), true, nil
+			}
+			values = append(values, separatorValue)
 			separator, ok = expressionString(value)
 			if !ok {
 				separator = ","
@@ -162,40 +212,90 @@ func evaluatePureFunction(evaluator *semanticEvaluator, node *actionlint.FuncCal
 		for i, item := range items {
 			parts[i], ok = expressionAggregateString(item)
 			if !ok {
-				return nil, true, fmt.Errorf("function %q item %d cannot convert %T to a string", node.Callee, i, item)
+				return zero, true, fmt.Errorf("function %q item %d cannot convert %T to a string", node.Callee, i, item)
 			}
 		}
-		return strings.Join(parts, separator), true, nil
+		return evaluator.domain.derive(strings.Join(parts, separator), values...), true, nil
 	case "tojson":
 		if argc != 1 {
-			return nil, true, fmt.Errorf("function %q requires 1 argument", node.Callee)
+			return zero, true, fmt.Errorf("function %q requires 1 argument", node.Callee)
 		}
-		value, err := evaluator.evaluate(node.Args[0])
+		argument, err := evaluator.evaluate(node.Args[0])
 		if err != nil {
-			return nil, true, err
+			return zero, true, err
+		}
+		value, known := evaluator.domain.value(argument)
+		if !known {
+			return evaluator.domain.unknown(argument), true, nil
 		}
 		encoded, err := encodeExpressionJSON(value)
 		if err != nil {
-			return nil, true, fmt.Errorf("function %q: %w", node.Callee, err)
+			return zero, true, fmt.Errorf("function %q: %w", node.Callee, err)
 		}
-		return encoded, true, nil
+		return evaluator.domain.derive(encoded, argument), true, nil
 	case "fromjson":
 		if argc != 1 {
-			return nil, true, fmt.Errorf("function %q requires 1 argument", node.Callee)
+			return zero, true, fmt.Errorf("function %q requires 1 argument", node.Callee)
 		}
-		value, err := evaluator.evaluate(node.Args[0])
+		argument, err := evaluator.evaluate(node.Args[0])
 		if err != nil {
-			return nil, true, err
+			return zero, true, err
+		}
+		value, known := evaluator.domain.value(argument)
+		if !known {
+			return evaluator.domain.unknown(argument), true, nil
 		}
 		text, ok := expressionString(value)
 		if !ok {
-			return nil, true, fmt.Errorf("function %q cannot convert %T to a string", node.Callee, value)
+			return zero, true, fmt.Errorf("function %q cannot convert %T to a string", node.Callee, value)
 		}
 		decoded, err := decodeJSONValue(text)
-		return decoded, true, err
+		if err != nil {
+			return zero, true, err
+		}
+		return evaluator.domain.derive(decoded, argument), true, nil
 	default:
-		return nil, false, nil
+		return zero, false, nil
 	}
+}
+
+func evaluateCaseFunction[T any](evaluator *expressionEvaluator[T], node *actionlint.FuncCallNode, index int) (T, error) {
+	var zero T
+	if index == len(node.Args)-1 {
+		return evaluator.evaluate(node.Args[index])
+	}
+	predicate, err := evaluator.evaluate(node.Args[index])
+	if err != nil {
+		return zero, err
+	}
+	predicateValue, known := evaluator.domain.value(predicate)
+	if !known {
+		selected, err := evaluator.evaluate(node.Args[index+1])
+		if err != nil {
+			return zero, err
+		}
+		remainder, err := evaluateCaseFunction(evaluator, node, index+2)
+		if err != nil {
+			return zero, err
+		}
+		return evaluator.result(evaluator.domain.join(selected, remainder), predicate), nil
+	}
+	selected, ok := predicateValue.(bool)
+	if !ok {
+		return zero, fmt.Errorf("function %q predicate %d resolved to %T, want boolean", node.Callee, index/2+1, predicateValue)
+	}
+	if selected {
+		value, err := evaluator.evaluate(node.Args[index+1])
+		if err != nil {
+			return zero, err
+		}
+		return evaluator.result(value, predicate), nil
+	}
+	remainder, err := evaluateCaseFunction(evaluator, node, index+2)
+	if err != nil {
+		return zero, err
+	}
+	return evaluator.result(remainder, predicate), nil
 }
 
 func expressionAggregateString(value any) (string, bool) {


### PR DESCRIPTION
## Why

The compiler must decide whether a job may receive `github.token` before the job runs. Today, token planning and runtime execution interpret expressions through separate code paths. That means support for operators and functions can work at runtime but still need another field-specific planning fix.

For example:

```yaml
${{ github.server_url == 'https://github.com' && github.token || '' }}
```

Both paths need to agree that:

- GitHub requires the token.
- Origin skips the token branch and must not receive token access.
- An unknown runtime condition must conservatively allow token access if that branch could run.

Maintaining those rules twice caused the repeated reachability fixes discussed in [the expression authority design](https://github.com/buildkite/buildkite-gha/blob/main/docs/plans/expression-authority-planning.md).

## What

Make runtime evaluation and token planning share one implementation of expression traversal, short-circuiting, comparisons, and function argument selection.

Runtime evaluation still produces concrete values. Planning now evaluates the same expression with values that may be known or unknown and records whether a reachable branch needs `github.token`. Validation remains a separate exhaustive pass, so invalid or prohibited references are still rejected even in branches that would not run.

This is the first, behavior-preserving slice of the design. It moves action input defaults onto the shared evaluator; later slices will normalize workflow fields and resolved actions so new expression-bearing fields no longer require separate authority scanners.
