### PR TITLE
Stop missing GitHub token references in workflow fields

### DIFF
--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -1812,7 +1812,7 @@ jobs:
 
 func TestRequiredSecretsDoesNotInterpretConditionLiteralsAsTemplates(t *testing.T) {
 	instance := JobInstance{If: "'${{ github.token }} ${{ secrets.DEPLOY }} ${{ github.event.action }}' == runner.os"}
-	secrets, _, _, referencesToken, err := requiredSecrets(instance, nil, false)
+	secrets, _, _, referencesToken, err := requiredSecrets(lowerWorkflowProgram(instance), instance.secretAuthority, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/compiler/plan_builder.go
+++ b/internal/compiler/plan_builder.go
@@ -15,6 +15,7 @@ import (
 	actionintegration "github.com/buildkite/buildkite-gha/internal/action/integration"
 	"github.com/buildkite/buildkite-gha/internal/expression"
 	"github.com/buildkite/buildkite-gha/internal/plan"
+	"github.com/buildkite/buildkite-gha/internal/program"
 	"github.com/buildkite/buildkite-gha/internal/workflow"
 )
 
@@ -117,11 +118,15 @@ func (b planBuilder) buildPlan(instance JobInstance, runtimeDistributionDigest s
 	if runtimeDistributionDigest == "" {
 		return plan.Job{}, PlanAuthorization{}, nil, fmt.Errorf("build plan for job %q: no runtime distribution configured for %s", instance.LogicalJobID, instance.Platform)
 	}
-	steps, actionIndexes, actionRefs, actionInputs := lowerPlanSteps(instance.Steps)
+	workflowProgram := lowerWorkflowProgram(instance)
+	steps := projectPlanSteps(workflowProgram.Job.Steps)
+	actionIndexes, actionRefs, actionInputs := programActionInvocations(workflowProgram.Job.Steps)
 	actions, err := b.buildActions(instance, steps, actionIndexes, actionRefs, actionInputs)
 	if err != nil {
 		return plan.Job{}, PlanAuthorization{}, nil, err
 	}
+	bindProgramActionSelectors(&workflowProgram, steps)
+	steps = projectPlanSteps(workflowProgram.Job.Steps)
 	if err := addContainerCapabilities(instance, actionRefs, &actions); err != nil {
 		return plan.Job{}, PlanAuthorization{}, nil, err
 	}
@@ -137,7 +142,7 @@ func (b planBuilder) buildPlan(instance JobInstance, runtimeDistributionDigest s
 	if err != nil {
 		return plan.Job{}, PlanAuthorization{}, nil, err
 	}
-	secrets, secretMappings, githubToken, err := b.authorizePlanSecrets(instance, &actions)
+	secrets, secretMappings, githubToken, err := b.authorizePlanSecrets(instance, workflowProgram, &actions)
 	if err != nil {
 		return plan.Job{}, PlanAuthorization{}, nil, err
 	}
@@ -149,7 +154,7 @@ func (b planBuilder) buildPlan(instance JobInstance, runtimeDistributionDigest s
 	if instance.Platform == PlatformDarwinARM64 && slices.Contains(actions.capabilities, "docker") {
 		return plan.Job{}, PlanAuthorization{}, nil, fmt.Errorf("%s:%d:%d: job %q requires Docker, which is unavailable on darwin/arm64", instance.SourcePath, instance.Source.Start.Line, instance.Source.Start.Column, instance.LogicalJobID)
 	}
-	job := b.lowerPlanJob(instance, runtimeDistributionDigest, steps, actions, needSources, buildPlanNeedOutputs(instance), deferredInputs, callGuards, secrets, secretMappings, githubToken)
+	job := b.lowerPlanJob(instance, workflowProgram, runtimeDistributionDigest, steps, actions, needSources, buildPlanNeedOutputs(instance), deferredInputs, callGuards, secrets, secretMappings, githubToken)
 	if err := job.Validate(); err != nil {
 		return plan.Job{}, PlanAuthorization{}, nil, fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err)
 	}
@@ -341,46 +346,6 @@ func (b planBuilder) reducePlanInstanceEventExpressions(instance JobInstance) (J
 		instance.Services[i].Container = container
 	}
 	return instance, nil
-}
-
-func lowerPlanSteps(source []workflow.Step) ([]plan.Step, []int, []string, []map[string]string) {
-	steps := make([]plan.Step, len(source))
-	var actionIndexes []int
-	var actionRefs []string
-	var actionInputs []map[string]string
-	usedIDs := make(map[string]struct{}, len(source))
-	for _, step := range source {
-		if step.ID != "" {
-			usedIDs[strings.ToLower(step.ID)] = struct{}{}
-		}
-	}
-	for i, step := range source {
-		id := step.ID
-		if id == "" {
-			id = fmt.Sprintf("step-%d", i+1)
-			for suffix := 2; ; suffix++ {
-				if _, exists := usedIDs[strings.ToLower(id)]; !exists {
-					break
-				}
-				id = fmt.Sprintf("step-%d-%d", i+1, suffix)
-			}
-			usedIDs[strings.ToLower(id)] = struct{}{}
-		}
-		span := planSpan(step.Span)
-		steps[i] = plan.Step{
-			ID: id, Name: step.Name, Kind: step.Kind, Background: step.Background, Targets: append([]string(nil), step.Targets...), Command: step.Run, Uses: step.Uses,
-			Shell: step.Shell, WorkingDirectory: step.WorkingDirectory,
-			Env: cloneMap(step.Env), With: cloneMap(step.With), Condition: step.If,
-			ContinueOnError: step.ContinueOnError, ContinueOnErrorExpression: step.ContinueOnErrorExpression,
-			TimeoutMinutes: step.TimeoutMinutes, TimeoutMinutesExpression: step.TimeoutMinutesExpression, Source: &span,
-		}
-		if step.Kind == "uses" {
-			actionIndexes = append(actionIndexes, i)
-			actionRefs = append(actionRefs, step.Uses)
-			actionInputs = append(actionInputs, step.With)
-		}
-	}
-	return steps, actionIndexes, actionRefs, actionInputs
 }
 
 func (b planBuilder) buildActions(instance JobInstance, steps []plan.Step, actionIndexes []int, actionRefs []string, actionInputs []map[string]string) (builtPlanActions, error) {
@@ -588,8 +553,8 @@ func buildPlanCallGuards(instance JobInstance, planDigests map[string]string) ([
 	return callGuards, nil
 }
 
-func (b planBuilder) authorizePlanSecrets(instance JobInstance, actions *builtPlanActions) ([]string, map[string]string, *plan.GitHubToken, error) {
-	secrets, mappings, tokenAliases, referencesGitHubToken, err := requiredSecrets(instance, actions.requiredSecrets, actions.inputsInspected)
+func (b planBuilder) authorizePlanSecrets(instance JobInstance, workflowProgram program.Program, actions *builtPlanActions) ([]string, map[string]string, *plan.GitHubToken, error) {
+	secrets, mappings, tokenAliases, referencesGitHubToken, err := requiredSecrets(workflowProgram, instance.secretAuthority, actions.requiredSecrets, actions.inputsInspected)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err)
 	}
@@ -618,7 +583,8 @@ func (b planBuilder) authorizePlanSecrets(instance JobInstance, actions *builtPl
 	return secrets, mappings, &plan.GitHubToken{Workflow: policyWorkflow, Permissions: cloneMap(b.ir.Workflow.WorkflowTokenPermissions), Aliases: tokenAliases}, nil
 }
 
-func (b planBuilder) lowerPlanJob(instance JobInstance, runtimeDistributionDigest string, steps []plan.Step, actions builtPlanActions, needSources map[string][]plan.NeedSource, needOutputs map[string][]plan.NeedOutput, deferredInputs map[string]plan.DeferredInput, callGuards []plan.CallGuard, secrets []string, secretMappings map[string]string, githubToken *plan.GitHubToken) plan.Job {
+func (b planBuilder) lowerPlanJob(instance JobInstance, workflowProgram program.Program, runtimeDistributionDigest string, steps []plan.Step, actions builtPlanActions, needSources map[string][]plan.NeedSource, needOutputs map[string][]plan.NeedOutput, deferredInputs map[string]plan.DeferredInput, callGuards []plan.CallGuard, secrets []string, secretMappings map[string]string, githubToken *plan.GitHubToken) plan.Job {
+	programJob := workflowProgram.Job
 	job := plan.Job{
 		Schema: plan.Schema,
 		Compiler: plan.Compiler{
@@ -652,33 +618,42 @@ func (b planBuilder) lowerPlanJob(instance JobInstance, runtimeDistributionDiges
 		NeedSources:             needSources,
 		NeedOutputs:             needOutputs,
 		CallGuards:              callGuards,
-		Env:                     instance.Env,
-		Condition:               instance.If,
-		ContinueOnError:         instance.ContinueOnError,
-		TimeoutMinutes:          instance.TimeoutMinutes,
-		DefaultShell:            instance.DefaultShell,
-		DefaultWorkingDirectory: instance.DefaultWorkingDirectory,
-		Outputs:                 instance.Outputs,
+		Env:                     programBindingMap(programJob.Env),
+		Condition:               programJob.Condition.Source,
+		ContinueOnError:         programJob.ContinueOnError,
+		TimeoutMinutes:          programJob.TimeoutMinutes,
+		DefaultShell:            programJob.Defaults.Shell.Source,
+		DefaultWorkingDirectory: programJob.Defaults.WorkingDirectory.Source,
+		Outputs:                 programBindingMap(programJob.Outputs),
 		Steps:                   steps,
 		Actions:                 actions.locks,
-		ServicesExpression:      instance.ServicesExpression,
 	}
 	job.RequiresMise = &actions.requiresMise
-	if instance.Container != nil {
-		job.Container = &plan.Container{Image: instance.Container.Image, Env: cloneMap(instance.Container.Env), Ports: append([]string(nil), instance.Container.Ports...)}
+	if programJob.Container != nil {
+		job.Container = &plan.Container{
+			Image: programJob.Container.Image.Source,
+			Env:   programBindingMap(programJob.Container.Env),
+			Ports: programSiteSources(programJob.Container.Ports),
+		}
 	}
-	if len(instance.Services) != 0 {
-		job.Services = make(map[string]plan.ServiceContainer, len(instance.Services))
-		job.ServiceOrder = make([]string, 0, len(instance.Services))
+	if programJob.Services.Dynamic != nil {
+		job.ServicesExpression = programJob.Services.Dynamic.Source
 	}
-	for _, service := range instance.Services {
+	if len(programJob.Services.Static) != 0 {
+		job.Services = make(map[string]plan.ServiceContainer, len(programJob.Services.Static))
+		job.ServiceOrder = make([]string, 0, len(programJob.Services.Static))
+	}
+	for _, service := range programJob.Services.Static {
 		container := plan.ServiceContainer{
-			Image: service.Container.Image, Env: cloneMap(service.Container.Env), Ports: append([]string(nil), service.Container.Ports...),
-			Volumes: append([]string(nil), service.Container.Volumes...), Options: service.Container.Options,
-			Command: service.Container.Command, Entrypoint: service.Container.Entrypoint,
+			Image: service.Container.Image.Source, Env: programBindingMap(service.Container.Env), Ports: programSiteSources(service.Container.Ports),
+			Volumes: programSiteSources(service.Container.Volumes), Options: service.Container.Options.Source,
+			Command: service.Container.Command.Source, Entrypoint: service.Container.Entrypoint.Source,
 		}
 		if service.Container.Credentials != nil {
-			container.Credentials = &plan.ContainerCredentials{Username: service.Container.Credentials.Username, Password: service.Container.Credentials.Password}
+			container.Credentials = &plan.ContainerCredentials{
+				Username: service.Container.Credentials.Username.Source,
+				Password: service.Container.Credentials.Password.Source,
+			}
 		}
 		job.Services[service.Name] = container
 		job.ServiceOrder = append(job.ServiceOrder, service.Name)
@@ -705,150 +680,34 @@ func planConstructionFinding(instance JobInstance, err error) error {
 	}
 }
 
-func requiredSecrets(instance JobInstance, actionRequired []string, actionInputsInspected bool) ([]string, map[string]string, []string, bool, error) {
-	found := map[string]string{}
-	referencesGitHubToken := false
-	collectTokenSecretAliases := func(value string) error {
-		names, err := expression.SecretReferences(value)
-		if err != nil {
-			return err
-		}
-		for _, name := range names {
-			binding, ok := instance.secretAuthority.resolve(name)
-			if strings.EqualFold(name, "GITHUB_TOKEN") || ok && binding.token {
-				found[name] = name
-			}
-		}
-		return nil
-	}
-	collect := func(value string, stepRuntime bool) error {
-		referencesEvent, err := expression.TemplateReferencesGitHubEvent(value)
-		if err != nil {
-			return err
-		}
-		if referencesEvent {
-			return fmt.Errorf("github.event cannot be retained in a job plan")
-		}
-		names, err := expression.SecretReferences(value)
-		if err != nil {
-			return err
-		}
-		for _, name := range names {
-			found[name] = name
-		}
-		var referencesToken bool
-		if stepRuntime {
-			referencesToken, err = expression.ReferencesStepGitHubToken(value)
-		} else {
-			referencesToken, err = expression.ReferencesGitHubToken(value)
-		}
-		if err != nil {
-			return err
-		}
-		if referencesToken {
-			referencesGitHubToken = true
-		}
-		return nil
-	}
-	checkCondition := func(value string) error {
-		referencesEvent, err := expression.ReferencesGitHubEvent(value)
-		if err != nil {
-			return err
-		}
-		if referencesEvent {
-			return fmt.Errorf("github.event cannot be retained in a job plan")
-		}
-		names, err := expression.ConditionSecretReferences(value)
-		if err != nil {
-			return err
-		}
-		for _, name := range names {
-			found[name] = name
-		}
-		referencesToken, err := expression.ConditionReferencesGitHubToken(value)
-		if err != nil {
-			return err
-		}
-		if referencesToken {
-			referencesGitHubToken = true
-		}
-		return nil
-	}
-	if err := checkCondition(instance.If); err != nil {
+func requiredSecrets(workflowProgram program.Program, bindings secretAuthority, actionRequired []string, actionInputsInspected bool) ([]string, map[string]string, []string, bool, error) {
+	authority, err := program.InventoryAuthority(workflowProgram, program.AuthorityOptions{ActionInputsInspected: actionInputsInspected})
+	if err != nil {
 		return nil, nil, nil, false, err
 	}
-	for _, value := range []string{instance.DefaultShell, instance.DefaultWorkingDirectory} {
-		if err := collect(value, false); err != nil {
-			return nil, nil, nil, false, err
-		}
+	found := make(map[string]string, len(authority.Secrets)+len(actionRequired))
+	for _, name := range authority.Secrets {
+		found[name] = name
 	}
-	for _, values := range []map[string]string{instance.Env, instance.Outputs} {
-		for _, name := range sortedValueKeys(values) {
-			if err := collect(values[name], false); err != nil {
-				return nil, nil, nil, false, err
+	if actionInputsInspected {
+		err = workflowProgram.VisitSites(func(site program.Site) error {
+			if site.Purpose != program.PurposeActionInput {
+				return nil
 			}
-		}
-	}
-	for _, step := range instance.Steps {
-		if err := checkCondition(step.If); err != nil {
-			return nil, nil, nil, false, err
-		}
-		for _, value := range []string{step.Name, step.Run, step.Shell, step.WorkingDirectory, step.ContinueOnErrorExpression, step.TimeoutMinutesExpression} {
-			if err := collect(value, true); err != nil {
-				return nil, nil, nil, false, err
+			names, err := expression.SecretReferences(site.Source)
+			if err != nil {
+				return err
 			}
-		}
-		if err := collect(step.Uses, false); err != nil {
-			return nil, nil, nil, false, err
-		}
-		valuesToInspect := []map[string]string{step.Env}
-		if step.Kind != "uses" || !actionInputsInspected {
-			valuesToInspect = append(valuesToInspect, step.With)
-		} else {
-			for _, name := range sortedValueKeys(step.With) {
-				if err := collectTokenSecretAliases(step.With[name]); err != nil {
-					return nil, nil, nil, false, err
+			for _, name := range names {
+				binding, ok := bindings.resolve(name)
+				if strings.EqualFold(name, "GITHUB_TOKEN") || ok && binding.token {
+					found[name] = name
 				}
 			}
-		}
-		for _, values := range valuesToInspect {
-			for _, name := range sortedValueKeys(values) {
-				if err := collect(values[name], true); err != nil {
-					return nil, nil, nil, false, err
-				}
-			}
-		}
-	}
-	if instance.Container != nil {
-		for _, value := range append([]string{instance.Container.Image}, instance.Container.Ports...) {
-			if err := collect(value, false); err != nil {
-				return nil, nil, nil, false, err
-			}
-		}
-		for _, name := range sortedValueKeys(instance.Container.Env) {
-			if err := collect(instance.Container.Env[name], false); err != nil {
-				return nil, nil, nil, false, err
-			}
-		}
-	}
-	for _, service := range instance.Services {
-		for _, value := range append([]string{service.Container.Image}, service.Container.Ports...) {
-			if err := collect(value, false); err != nil {
-				return nil, nil, nil, false, err
-			}
-		}
-		for _, name := range sortedValueKeys(service.Container.Env) {
-			if err := collect(service.Container.Env[name], false); err != nil {
-				return nil, nil, nil, false, err
-			}
-		}
-		if service.Container.Credentials != nil {
-			if err := collect(service.Container.Credentials.Username, false); err != nil {
-				return nil, nil, nil, false, err
-			}
-			if err := collect(service.Container.Credentials.Password, false); err != nil {
-				return nil, nil, nil, false, err
-			}
+			return nil
+		})
+		if err != nil {
+			return nil, nil, nil, false, err
 		}
 	}
 	for _, name := range actionRequired {
@@ -862,7 +721,7 @@ func requiredSecrets(instance JobInstance, actionRequired []string, actionInputs
 			tokenAliases = append(tokenAliases, alias)
 			continue
 		}
-		binding, ok := instance.secretAuthority.resolve(alias)
+		binding, ok := bindings.resolve(alias)
 		if !ok {
 			continue
 		}
@@ -871,7 +730,7 @@ func requiredSecrets(instance JobInstance, actionRequired []string, actionInputs
 			continue
 		}
 		sources[binding.source] = struct{}{}
-		if !instance.secretAuthority.unrestricted {
+		if !bindings.unrestricted {
 			mappings[alias] = binding.source
 		}
 	}
@@ -880,14 +739,7 @@ func requiredSecrets(instance JobInstance, actionRequired []string, actionInputs
 	if len(mappings) == 0 {
 		mappings = nil
 	}
-	return names, mappings, tokenAliases, referencesGitHubToken, nil
-}
-
-func planSpan(span workflow.Span) plan.Span {
-	return plan.Span{
-		Start: plan.Position{Line: span.Start.Line, Column: span.Start.Column},
-		End:   plan.Position{Line: span.End.Line, Column: span.End.Column},
-	}
+	return names, mappings, tokenAliases, authority.GitHubToken, nil
 }
 
 func planRemoteWorkflowSource(source *RemoteWorkflowSource) *plan.RemoteWorkflowSource {

--- a/internal/compiler/workflow_program.go
+++ b/internal/compiler/workflow_program.go
@@ -1,0 +1,253 @@
+package compiler
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/buildkite/buildkite-gha/internal/plan"
+	"github.com/buildkite/buildkite-gha/internal/program"
+	"github.com/buildkite/buildkite-gha/internal/workflow"
+)
+
+func lowerWorkflowProgram(instance JobInstance) program.Program {
+	jobLocation := programLocation(instance.SourcePath, "job", instance.Source)
+	result := program.Program{Job: program.Job{
+		Condition:       workflowSite(instance.If, program.SurfaceJobCondition, program.ResultBoolean, jobLocation, "job.if"),
+		ContinueOnError: instance.ContinueOnError,
+		TimeoutMinutes:  instance.TimeoutMinutes,
+		Env:             workflowBindings(instance.Env, program.SurfaceJobEnvironment, jobLocation, "job.env", program.PurposeExpression),
+		Defaults: program.Defaults{
+			Shell:            workflowSite(instance.DefaultShell, program.SurfaceJobDefault, program.ResultString, jobLocation, "job.defaults.run.shell"),
+			WorkingDirectory: workflowSite(instance.DefaultWorkingDirectory, program.SurfaceJobDefault, program.ResultString, jobLocation, "job.defaults.run.working-directory"),
+		},
+		Outputs: workflowBindings(instance.Outputs, program.SurfaceJobOutput, jobLocation, "job.outputs", program.PurposeExpression),
+	}}
+	if len(instance.CallGuards) != 0 {
+		result.Job.Guards = make([]program.Guard, len(instance.CallGuards))
+		for i, guard := range instance.CallGuards {
+			field := fmt.Sprintf("job.call-guards[%d].if", i)
+			result.Job.Guards[i] = program.Guard{Condition: workflowSite(guard.Condition, program.SurfaceJobCondition, program.ResultBoolean, jobLocation, field)}
+		}
+	}
+	if instance.Container != nil {
+		result.Job.Container = &program.Container{
+			Image: workflowSite(instance.Container.Image, program.SurfaceRuntimeTemplate, program.ResultString, jobLocation, "job.container.image"),
+			Env:   workflowBindings(instance.Container.Env, program.SurfaceRuntimeTemplate, jobLocation, "job.container.env", program.PurposeExpression),
+			Ports: workflowSites(instance.Container.Ports, program.SurfaceRuntimeTemplate, program.ResultString, jobLocation, "job.container.ports"),
+		}
+	}
+	if len(instance.Services) != 0 {
+		result.Job.Services.Static = make([]program.Service, len(instance.Services))
+		for i, service := range instance.Services {
+			field := fmt.Sprintf("job.services.%s", service.Name)
+			location := programLocation(instance.SourcePath, field, service.Container.Span)
+			container := service.Container
+			lowered := program.ServiceContainer{
+				Image:      workflowSite(container.Image, program.SurfaceRuntimeTemplate, program.ResultString, location, field+".image"),
+				Env:        workflowBindings(container.Env, program.SurfaceRuntimeTemplate, location, field+".env", program.PurposeExpression),
+				Ports:      workflowSites(container.Ports, program.SurfaceRuntimeTemplate, program.ResultString, location, field+".ports"),
+				Volumes:    workflowSites(container.Volumes, program.SurfaceRuntimeTemplate, program.ResultString, location, field+".volumes"),
+				Options:    workflowSite(container.Options, program.SurfaceRuntimeTemplate, program.ResultString, location, field+".options"),
+				Command:    workflowSite(container.Command, program.SurfaceRuntimeTemplate, program.ResultString, location, field+".command"),
+				Entrypoint: workflowSite(container.Entrypoint, program.SurfaceRuntimeTemplate, program.ResultString, location, field+".entrypoint"),
+			}
+			if container.Credentials != nil {
+				lowered.Credentials = &program.ContainerCredentials{
+					Username: workflowSite(container.Credentials.Username, program.SurfaceServiceCredential, program.ResultString, location, field+".credentials.username"),
+					Password: workflowSite(container.Credentials.Password, program.SurfaceServiceCredential, program.ResultString, location, field+".credentials.password"),
+				}
+			}
+			result.Job.Services.Static[i] = program.Service{Name: service.Name, Container: lowered}
+		}
+	}
+	if instance.ServicesExpression != "" {
+		site := workflowSite(instance.ServicesExpression, program.SurfaceServiceMap, program.ResultObject, jobLocation, "job.services")
+		result.Job.Services.Dynamic = &site
+	}
+	result.Job.Steps = lowerWorkflowSteps(instance.SourcePath, instance.Steps)
+	return result
+}
+
+func lowerWorkflowSteps(sourcePath string, source []workflow.Step) []program.Step {
+	steps := make([]program.Step, len(source))
+	usedIDs := make(map[string]struct{}, len(source))
+	for _, step := range source {
+		if step.ID != "" {
+			usedIDs[strings.ToLower(step.ID)] = struct{}{}
+		}
+	}
+	for i, step := range source {
+		id := step.ID
+		if id == "" {
+			id = fmt.Sprintf("step-%d", i+1)
+			for suffix := 2; ; suffix++ {
+				if _, exists := usedIDs[strings.ToLower(id)]; !exists {
+					break
+				}
+				id = fmt.Sprintf("step-%d-%d", i+1, suffix)
+			}
+			usedIDs[strings.ToLower(id)] = struct{}{}
+		}
+		field := fmt.Sprintf("job.steps[%d]", i)
+		location := programLocation(sourcePath, field, step.Span)
+		steps[i] = program.Step{
+			ID:         id,
+			Kind:       step.Kind,
+			Background: step.Background,
+			Targets:    append([]string(nil), step.Targets...),
+			Source:     location,
+			Env:        workflowBindings(step.Env, program.SurfaceStepTemplate, location, field+".env", program.PurposeExpression),
+			Condition:  workflowSite(step.If, program.SurfaceStepCondition, program.ResultBoolean, location, field+".if"),
+			ContinueOnError: program.BoolControl{
+				Literal: step.ContinueOnError,
+			},
+			TimeoutMinutes: program.NumberControl{
+				Literal: step.TimeoutMinutes,
+			},
+			Name: workflowSite(step.Name, program.SurfaceStepTemplate, program.ResultString, location, field+".name"),
+		}
+		if step.ContinueOnErrorExpression != "" {
+			site := workflowSite(step.ContinueOnErrorExpression, program.SurfaceStepControl, program.ResultBoolean, location, field+".continue-on-error")
+			steps[i].ContinueOnError.Expression = &site
+		}
+		if step.TimeoutMinutesExpression != "" {
+			site := workflowSite(step.TimeoutMinutesExpression, program.SurfaceStepControl, program.ResultNumber, location, field+".timeout-minutes")
+			steps[i].TimeoutMinutes.Expression = &site
+		}
+		switch step.Kind {
+		case "run":
+			steps[i].Run = &program.Run{
+				Command:          workflowSite(step.Run, program.SurfaceStepTemplate, program.ResultString, location, field+".run"),
+				Shell:            workflowSite(step.Shell, program.SurfaceStepTemplate, program.ResultString, location, field+".shell"),
+				WorkingDirectory: workflowSite(step.WorkingDirectory, program.SurfaceStepTemplate, program.ResultString, location, field+".working-directory"),
+			}
+		case "uses":
+			steps[i].Invocation = &program.Invocation{
+				Uses: workflowSite(step.Uses, program.SurfaceRuntimeTemplate, program.ResultString, location, field+".uses"),
+				With: workflowBindings(step.With, program.SurfaceStepTemplate, location, field+".with", program.PurposeActionInput),
+			}
+		}
+	}
+	return steps
+}
+
+func projectPlanSteps(source []program.Step) []plan.Step {
+	steps := make([]plan.Step, len(source))
+	for i, step := range source {
+		steps[i] = plan.Step{
+			ID: step.ID, Name: step.Name.Source, Kind: step.Kind, Background: step.Background, Targets: append([]string(nil), step.Targets...),
+			Env: programBindingMap(step.Env), Condition: step.Condition.Source,
+			ContinueOnError: step.ContinueOnError.Literal, TimeoutMinutes: step.TimeoutMinutes.Literal,
+			Source: &plan.Span{
+				Start: plan.Position{Line: step.Source.Start.Line, Column: step.Source.Start.Column},
+				End:   plan.Position{Line: step.Source.End.Line, Column: step.Source.End.Column},
+			},
+		}
+		if step.ContinueOnError.Expression != nil {
+			steps[i].ContinueOnErrorExpression = step.ContinueOnError.Expression.Source
+		}
+		if step.TimeoutMinutes.Expression != nil {
+			steps[i].TimeoutMinutesExpression = step.TimeoutMinutes.Expression.Source
+		}
+		if step.Run != nil {
+			steps[i].Command = step.Run.Command.Source
+			steps[i].Shell = step.Run.Shell.Source
+			steps[i].WorkingDirectory = step.Run.WorkingDirectory.Source
+		}
+		if step.Invocation != nil {
+			steps[i].Uses = step.Invocation.Uses.Source
+			steps[i].With = programBindingMap(step.Invocation.With)
+			if step.Invocation.Lock != "" {
+				steps[i].Action = &plan.ActionSelector{Lock: step.Invocation.Lock}
+			}
+		}
+	}
+	return steps
+}
+
+func programActionInvocations(steps []program.Step) ([]int, []string, []map[string]string) {
+	var indexes []int
+	var references []string
+	var inputs []map[string]string
+	for i, step := range steps {
+		if step.Invocation == nil {
+			continue
+		}
+		indexes = append(indexes, i)
+		references = append(references, step.Invocation.Uses.Source)
+		inputs = append(inputs, programBindingMap(step.Invocation.With))
+	}
+	return indexes, references, inputs
+}
+
+func bindProgramActionSelectors(target *program.Program, steps []plan.Step) {
+	for i := range target.Job.Steps {
+		if target.Job.Steps[i].Invocation != nil && steps[i].Action != nil {
+			target.Job.Steps[i].Invocation.Lock = steps[i].Action.Lock
+		}
+	}
+}
+
+func workflowBindings(values map[string]string, surface program.Surface, location program.Location, field string, purpose program.Purpose) []program.Binding {
+	if values == nil {
+		return nil
+	}
+	bindings := make([]program.Binding, 0, len(values))
+	for _, name := range sortedValueKeys(values) {
+		bindings = append(bindings, program.Binding{
+			Name:  name,
+			Value: workflowSiteWithPurpose(values[name], surface, program.ResultString, location, field+"."+name, purpose),
+		})
+	}
+	return bindings
+}
+
+func workflowSites(values []string, surface program.Surface, result program.ResultType, location program.Location, field string) []program.Site {
+	if values == nil {
+		return nil
+	}
+	sites := make([]program.Site, len(values))
+	for i, value := range values {
+		sites[i] = workflowSite(value, surface, result, location, fmt.Sprintf("%s[%d]", field, i))
+	}
+	return sites
+}
+
+func workflowSite(source string, surface program.Surface, result program.ResultType, location program.Location, field string) program.Site {
+	return workflowSiteWithPurpose(source, surface, result, location, field, program.PurposeExpression)
+}
+
+func workflowSiteWithPurpose(source string, surface program.Surface, result program.ResultType, location program.Location, field string, purpose program.Purpose) program.Site {
+	location.Field = field
+	return program.Site{Source: source, Surface: surface, Result: result, Provenance: program.ProvenanceWorkflow, Purpose: purpose, Location: location}
+}
+
+func programLocation(path, field string, span workflow.Span) program.Location {
+	return program.Location{
+		File: path, Field: field,
+		Start: program.Position{Line: span.Start.Line, Column: span.Start.Column},
+		End:   program.Position{Line: span.End.Line, Column: span.End.Column},
+	}
+}
+
+func programBindingMap(bindings []program.Binding) map[string]string {
+	if bindings == nil {
+		return nil
+	}
+	values := make(map[string]string, len(bindings))
+	for _, binding := range bindings {
+		values[binding.Name] = binding.Value.Source
+	}
+	return values
+}
+
+func programSiteSources(sites []program.Site) []string {
+	if sites == nil {
+		return nil
+	}
+	values := make([]string, len(sites))
+	for i, site := range sites {
+		values[i] = site.Source
+	}
+	return values
+}

--- a/internal/compiler/workflow_program_test.go
+++ b/internal/compiler/workflow_program_test.go
@@ -1,0 +1,138 @@
+package compiler
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/buildkite/buildkite-gha/internal/program"
+	"github.com/buildkite/buildkite-gha/internal/workflow"
+)
+
+func TestWorkflowProgramInventoriesEveryExecutionField(t *testing.T) {
+	span := workflow.Span{Start: workflow.Position{Line: 10, Column: 3}, End: workflow.Position{Line: 30, Column: 1}}
+	instance := JobInstance{
+		SourcePath:              "workflow.yml",
+		Source:                  span,
+		CallGuards:              []CallGuard{{Condition: "guard"}},
+		If:                      "job-if",
+		Env:                     map[string]string{"Z": "job-env-z", "A": "job-env-a"},
+		DefaultShell:            "job-shell",
+		DefaultWorkingDirectory: "job-directory",
+		Container: &workflow.Container{
+			Image: "container-image", Env: map[string]string{"C": "container-env"}, Ports: []string{"container-port"}, Span: span,
+		},
+		Services: []workflow.Service{{Name: "db", Container: workflow.ServiceContainer{
+			Image: "service-image", Env: map[string]string{"S": "service-env"}, Ports: []string{"service-port"}, Volumes: []string{"service-volume"},
+			Options: "service-options", Command: "service-command", Entrypoint: "service-entrypoint", Span: span,
+			Credentials: &workflow.ContainerCredentials{Username: "service-user", Password: "service-password"},
+		}}},
+		ServicesExpression: "service-map",
+		Steps: []workflow.Step{
+			{Kind: "run", Name: "run-name", Env: map[string]string{"R": "run-env"}, If: "run-if", ContinueOnErrorExpression: "run-continue", TimeoutMinutesExpression: "run-timeout", Run: "run-command", Shell: "run-shell", WorkingDirectory: "run-directory", Span: span},
+			{Kind: "uses", ID: "action", Name: "action-name", Env: map[string]string{"E": "action-env"}, If: "action-if", Uses: "owner/action@v1", With: map[string]string{"input": "action-input"}, Span: span},
+		},
+		Outputs: map[string]string{"result": "job-output"},
+	}
+
+	workflowProgram := lowerWorkflowProgram(instance)
+	var got []string
+	err := workflowProgram.VisitSites(func(site program.Site) error {
+		got = append(got, site.Location.Field+"|"+string(site.Surface)+"|"+string(site.Result)+"|"+string(site.Purpose))
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"job.call-guards[0].if|job-condition|boolean|expression",
+		"job.if|job-condition|boolean|expression",
+		"job.env.A|job-environment|string|expression",
+		"job.env.Z|job-environment|string|expression",
+		"job.defaults.run.shell|job-default|string|expression",
+		"job.defaults.run.working-directory|job-default|string|expression",
+		"job.container.image|runtime-template|string|expression",
+		"job.container.env.C|runtime-template|string|expression",
+		"job.container.ports[0]|runtime-template|string|expression",
+		"job.services.db.image|runtime-template|string|expression",
+		"job.services.db.credentials.username|service-credential|string|expression",
+		"job.services.db.credentials.password|service-credential|string|expression",
+		"job.services.db.env.S|runtime-template|string|expression",
+		"job.services.db.ports[0]|runtime-template|string|expression",
+		"job.services.db.volumes[0]|runtime-template|string|expression",
+		"job.services.db.options|runtime-template|string|expression",
+		"job.services.db.command|runtime-template|string|expression",
+		"job.services.db.entrypoint|runtime-template|string|expression",
+		"job.services|service-map|object|expression",
+		"job.steps[0].env.R|step-template|string|expression",
+		"job.steps[0].if|step-condition|boolean|expression",
+		"job.steps[0].continue-on-error|step-control|boolean|expression",
+		"job.steps[0].timeout-minutes|step-control|number|expression",
+		"job.steps[0].name|step-template|string|expression",
+		"job.steps[0].run|step-template|string|expression",
+		"job.steps[0].shell|step-template|string|expression",
+		"job.steps[0].working-directory|step-template|string|expression",
+		"job.steps[1].env.E|step-template|string|expression",
+		"job.steps[1].if|step-condition|boolean|expression",
+		"job.steps[1].name|step-template|string|expression",
+		"job.steps[1].uses|runtime-template|string|expression",
+		"job.steps[1].with.input|step-template|string|action-input",
+		"job.outputs.result|job-output|string|expression",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("program sites:\n got: %#v\nwant: %#v", got, want)
+	}
+	if workflowProgram.Job.Steps[0].ID != "step-1" || workflowProgram.Job.Steps[1].ID != "action" {
+		t.Fatalf("normalized step IDs = %q, %q", workflowProgram.Job.Steps[0].ID, workflowProgram.Job.Steps[1].ID)
+	}
+
+	instance.Env["A"] = "mutated"
+	instance.Steps[0].Env["R"] = "mutated"
+	instance.Services[0].Container.Ports[0] = "mutated"
+	if workflowProgram.Job.Env[0].Value.Source != "job-env-a" || workflowProgram.Job.Steps[0].Env[0].Value.Source != "run-env" || workflowProgram.Job.Services.Static[0].Container.Ports[0].Source != "service-port" {
+		t.Fatal("normalized program aliases mutable JobInstance data")
+	}
+}
+
+func TestWorkflowProgramProjectsLegacyPlanSteps(t *testing.T) {
+	span := workflow.Span{Start: workflow.Position{Line: 3, Column: 5}, End: workflow.Position{Line: 8, Column: 1}}
+	instance := JobInstance{SourcePath: "workflow.yml", Steps: []workflow.Step{
+		{Kind: "run", Name: "name", Run: "echo hi", Shell: "bash", WorkingDirectory: "src", Env: map[string]string{}, If: "success()", ContinueOnErrorExpression: "${{ matrix.experimental }}", TimeoutMinutes: 5, Span: span},
+		{Kind: "uses", Uses: "owner/action@v1", With: map[string]string{"name": "value"}, Span: span},
+	}}
+	workflowProgram := lowerWorkflowProgram(instance)
+	steps := projectPlanSteps(workflowProgram.Job.Steps)
+	indexes, references, inputs := programActionInvocations(workflowProgram.Job.Steps)
+	if len(steps) != 2 || steps[0].ID != "step-1" || steps[0].Command != "echo hi" || steps[0].Shell != "bash" || steps[0].WorkingDirectory != "src" || steps[0].Condition != "success()" || steps[0].ContinueOnErrorExpression != "${{ matrix.experimental }}" || steps[0].TimeoutMinutes != 5 {
+		t.Fatalf("projected run step = %#v", steps[0])
+	}
+	if len(indexes) != 1 || indexes[0] != 1 || !reflect.DeepEqual(references, []string{"owner/action@v1"}) || !reflect.DeepEqual(inputs, []map[string]string{{"name": "value"}}) {
+		t.Fatalf("projected invocation metadata = %#v, %#v, %#v", indexes, references, inputs)
+	}
+	if steps[0].Env == nil || steps[1].With["name"] != "value" || steps[0].Source.Start.Line != 3 {
+		t.Fatalf("projected step details = %#v", steps)
+	}
+}
+
+func TestProgramOwnedSecretInventory(t *testing.T) {
+	instance := JobInstance{
+		secretAuthority: secretAuthority{unrestricted: true},
+		If:              "secrets.CONDITION != ''",
+		Env:             map[string]string{"VALUE": "${{ secrets.JOB_ENV }}"},
+		Outputs:         map[string]string{"value": "${{ secrets.JOB_OUTPUT }}"},
+		Services: []workflow.Service{{Name: "db", Container: workflow.ServiceContainer{
+			Image: "postgres", Command: "start --token=${{ github.token }}",
+		}}},
+		Steps: []workflow.Step{
+			{Kind: "run", Run: "echo ${{ secrets.RUN }}", Name: "${{ toJSON(github) }}"},
+			{Kind: "uses", Uses: "owner/action@v1", With: map[string]string{"ignored": "${{ secrets.INSPECTED_INPUT }}"}},
+		},
+	}
+	secrets, mappings, aliases, token, err := requiredSecrets(lowerWorkflowProgram(instance), instance.secretAuthority, []string{"ACTION_DEFAULT"}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"ACTION_DEFAULT", "CONDITION", "JOB_ENV", "JOB_OUTPUT", "RUN"}
+	if !reflect.DeepEqual(secrets, want) || len(mappings) != 0 || len(aliases) != 0 || !token {
+		t.Fatalf("requiredSecrets() = %#v, %#v, %#v, %v; want %#v, nil, nil, true", secrets, mappings, aliases, token, want)
+	}
+}

--- a/internal/program/authority.go
+++ b/internal/program/authority.go
@@ -1,0 +1,91 @@
+package program
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/buildkite/buildkite-gha/internal/expression"
+)
+
+type AuthorityOptions struct {
+	ActionInputsInspected bool
+}
+
+// Authority is the workflow-authored secret inventory retained by the current
+// plan contract.
+type Authority struct {
+	Secrets     []string
+	GitHubToken bool
+}
+
+// InventoryAuthority validates and inventories every compiler-owned site in
+// the normalized program. Ordinary secrets remain exhaustive for compatibility.
+func InventoryAuthority(workflow Program, options AuthorityOptions) (Authority, error) {
+	found := map[string]struct{}{}
+	authority := Authority{}
+	err := workflow.VisitSites(func(site Site) error {
+		if options.ActionInputsInspected && site.Purpose == PurposeActionInput {
+			return nil
+		}
+		if site.Surface == SurfaceJobCondition || site.Surface == SurfaceStepCondition {
+			return inventoryConditionAuthority(site.Source, found, &authority)
+		}
+		referencesEvent, err := expression.TemplateReferencesGitHubEvent(site.Source)
+		if err != nil {
+			return err
+		}
+		if referencesEvent {
+			return fmt.Errorf("github.event cannot be retained in a job plan")
+		}
+		names, err := expression.SecretReferences(site.Source)
+		if err != nil {
+			return err
+		}
+		for _, name := range names {
+			found[name] = struct{}{}
+		}
+		var referencesToken bool
+		if site.Surface == SurfaceStepTemplate || site.Surface == SurfaceStepControl {
+			referencesToken, err = expression.ReferencesStepGitHubToken(site.Source)
+		} else {
+			referencesToken, err = expression.ReferencesGitHubToken(site.Source)
+		}
+		if err != nil {
+			return err
+		}
+		authority.GitHubToken = authority.GitHubToken || referencesToken
+		return nil
+	})
+	if err != nil {
+		return Authority{}, err
+	}
+	authority.Secrets = make([]string, 0, len(found))
+	for name := range found {
+		authority.Secrets = append(authority.Secrets, name)
+	}
+	sort.Strings(authority.Secrets)
+	return authority, nil
+}
+
+func inventoryConditionAuthority(source string, found map[string]struct{}, authority *Authority) error {
+	referencesEvent, err := expression.ReferencesGitHubEvent(source)
+	if err != nil {
+		return err
+	}
+	if referencesEvent {
+		return fmt.Errorf("github.event cannot be retained in a job plan")
+	}
+	names, err := expression.ConditionSecretReferences(source)
+	if err != nil {
+		return err
+	}
+	for _, name := range names {
+		found[name] = struct{}{}
+	}
+	referencesToken, err := expression.ConditionReferencesGitHubToken(source)
+	if err != nil {
+		return err
+	}
+	authority.GitHubToken = authority.GitHubToken || referencesToken
+	return nil
+}

--- a/internal/program/evaluate.go
+++ b/internal/program/evaluate.go
@@ -1,0 +1,58 @@
+package program
+
+import (
+	"fmt"
+
+	"github.com/buildkite/buildkite-gha/internal/expression"
+)
+
+// EvaluationContext supplies both template and condition contexts because
+// conditions carry failure and cancellation state that templates do not.
+type EvaluationContext struct {
+	Expression expression.Context
+	Condition  expression.ConditionContext
+}
+
+// EvaluateSite applies the concrete runtime semantics selected by a site.
+// The normalized interpreter and the legacy runtime can therefore be tested
+// against the same expression inputs before the plan-schema cutover.
+func EvaluateSite(site Site, context EvaluationContext) (any, error) {
+	switch site.Surface {
+	case SurfaceJobCondition, SurfaceStepCondition:
+		return expression.EvaluateCondition(site.Source, context.Condition)
+	case SurfaceJobEnvironment:
+		return expression.EvaluateJobEnvironment(site.Source, context.Expression)
+	case SurfaceJobDefault:
+		return expression.EvaluateJobDefault(site.Source, context.Expression)
+	case SurfaceJobOutput:
+		return expression.EvaluateJobOutput(site.Source, context.Expression)
+	case SurfaceStepTemplate:
+		return expression.EvaluateStep(site.Source, context.Expression)
+	case SurfaceStepControl:
+		return expression.EvaluateStepControl(site.Source, context.Expression)
+	case SurfaceRuntimeTemplate, SurfaceServiceCredential:
+		return expression.Evaluate(site.Source, context.Expression)
+	case SurfaceServiceMap:
+		return expression.EvaluateObject(site.Source, context.Expression)
+	default:
+		return nil, fmt.Errorf("unsupported expression surface %q", site.Surface)
+	}
+}
+
+// EvaluateBindings evaluates ordered bindings and retains deterministic error
+// ownership. Later bindings do not run after an earlier failure.
+func EvaluateBindings(bindings []Binding, context EvaluationContext) (map[string]string, error) {
+	values := make(map[string]string, len(bindings))
+	for _, binding := range bindings {
+		value, err := EvaluateSite(binding.Value, context)
+		if err != nil {
+			return nil, fmt.Errorf("evaluate %q: %w", binding.Name, err)
+		}
+		text, ok := value.(string)
+		if !ok {
+			return nil, fmt.Errorf("evaluate %q produced %T, want string", binding.Name, value)
+		}
+		values[binding.Name] = text
+	}
+	return values, nil
+}

--- a/internal/program/evaluate.go
+++ b/internal/program/evaluate.go
@@ -1,6 +1,7 @@
 package program
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/buildkite/buildkite-gha/internal/expression"
@@ -17,25 +18,57 @@ type EvaluationContext struct {
 // The normalized interpreter and the legacy runtime can therefore be tested
 // against the same expression inputs before the plan-schema cutover.
 func EvaluateSite(site Site, context EvaluationContext) (any, error) {
+	var value any
+	var err error
 	switch site.Surface {
 	case SurfaceJobCondition, SurfaceStepCondition:
-		return expression.EvaluateCondition(site.Source, context.Condition)
+		value, err = expression.EvaluateCondition(site.Source, context.Condition)
 	case SurfaceJobEnvironment:
-		return expression.EvaluateJobEnvironment(site.Source, context.Expression)
+		value, err = expression.EvaluateJobEnvironment(site.Source, context.Expression)
 	case SurfaceJobDefault:
-		return expression.EvaluateJobDefault(site.Source, context.Expression)
+		value, err = expression.EvaluateJobDefault(site.Source, context.Expression)
 	case SurfaceJobOutput:
-		return expression.EvaluateJobOutput(site.Source, context.Expression)
+		value, err = expression.EvaluateJobOutput(site.Source, context.Expression)
 	case SurfaceStepTemplate:
-		return expression.EvaluateStep(site.Source, context.Expression)
+		value, err = expression.EvaluateStep(site.Source, context.Expression)
 	case SurfaceStepControl:
-		return expression.EvaluateStepControl(site.Source, context.Expression)
+		value, err = expression.EvaluateStepControl(site.Source, context.Expression)
 	case SurfaceRuntimeTemplate, SurfaceServiceCredential:
-		return expression.Evaluate(site.Source, context.Expression)
+		value, err = expression.Evaluate(site.Source, context.Expression)
 	case SurfaceServiceMap:
-		return expression.EvaluateObject(site.Source, context.Expression)
+		value, err = expression.EvaluateObject(site.Source, context.Expression)
 	default:
 		return nil, fmt.Errorf("unsupported expression surface %q", site.Surface)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if !matchesResultType(value, site.Result) {
+		return nil, fmt.Errorf("expression produced %T, want %s", value, site.Result)
+	}
+	return value, nil
+}
+
+func matchesResultType(value any, result ResultType) bool {
+	switch result {
+	case ResultString:
+		_, ok := value.(string)
+		return ok
+	case ResultBoolean:
+		_, ok := value.(bool)
+		return ok
+	case ResultNumber:
+		switch value.(type) {
+		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64, json.Number:
+			return true
+		default:
+			return false
+		}
+	case ResultObject:
+		_, ok := value.([]expression.ObjectEntry)
+		return ok
+	default:
+		return false
 	}
 }
 

--- a/internal/program/evaluate_test.go
+++ b/internal/program/evaluate_test.go
@@ -19,22 +19,23 @@ func TestConcreteAdapterUsesEachSiteSurface(t *testing.T) {
 	for _, test := range []struct {
 		name    string
 		surface program.Surface
+		result  program.ResultType
 		source  string
 		want    any
 	}{
-		{name: "job condition", surface: program.SurfaceJobCondition, source: "matrix.enabled", want: true},
-		{name: "step condition", surface: program.SurfaceStepCondition, source: "matrix.enabled", want: true},
-		{name: "job environment", surface: program.SurfaceJobEnvironment, source: "${{ matrix.enabled }}", want: "true"},
-		{name: "job default", surface: program.SurfaceJobDefault, source: "${{ env.VALUE }}", want: "resolved"},
-		{name: "job output", surface: program.SurfaceJobOutput, source: "${{ env.VALUE }}", want: "resolved"},
-		{name: "step template", surface: program.SurfaceStepTemplate, source: "value-${{ matrix.enabled }}", want: "value-true"},
-		{name: "step control", surface: program.SurfaceStepControl, source: "${{ matrix.minutes }}", want: 5},
-		{name: "runtime template", surface: program.SurfaceRuntimeTemplate, source: "${{ needs.build.outputs.services }}", want: `{"db":{"image":"postgres"}}`},
-		{name: "service credential", surface: program.SurfaceServiceCredential, source: "${{ env.VALUE }}", want: "resolved"},
-		{name: "service map", surface: program.SurfaceServiceMap, source: "${{ fromJSON(needs.build.outputs.services) }}", want: []expression.ObjectEntry{{Name: "db", Value: map[string]any{"image": "postgres"}}}},
+		{name: "job condition", surface: program.SurfaceJobCondition, result: program.ResultBoolean, source: "matrix.enabled", want: true},
+		{name: "step condition", surface: program.SurfaceStepCondition, result: program.ResultBoolean, source: "matrix.enabled", want: true},
+		{name: "job environment", surface: program.SurfaceJobEnvironment, result: program.ResultString, source: "${{ matrix.enabled }}", want: "true"},
+		{name: "job default", surface: program.SurfaceJobDefault, result: program.ResultString, source: "${{ env.VALUE }}", want: "resolved"},
+		{name: "job output", surface: program.SurfaceJobOutput, result: program.ResultString, source: "${{ env.VALUE }}", want: "resolved"},
+		{name: "step template", surface: program.SurfaceStepTemplate, result: program.ResultString, source: "value-${{ matrix.enabled }}", want: "value-true"},
+		{name: "step control", surface: program.SurfaceStepControl, result: program.ResultNumber, source: "${{ matrix.minutes }}", want: 5},
+		{name: "runtime template", surface: program.SurfaceRuntimeTemplate, result: program.ResultString, source: "${{ needs.build.outputs.services }}", want: `{"db":{"image":"postgres"}}`},
+		{name: "service credential", surface: program.SurfaceServiceCredential, result: program.ResultString, source: "${{ env.VALUE }}", want: "resolved"},
+		{name: "service map", surface: program.SurfaceServiceMap, result: program.ResultObject, source: "${{ fromJSON(needs.build.outputs.services) }}", want: []expression.ObjectEntry{{Name: "db", Value: map[string]any{"image": "postgres"}}}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := program.EvaluateSite(program.Site{Source: test.source, Surface: test.surface}, context)
+			got, err := program.EvaluateSite(program.Site{Source: test.source, Surface: test.surface, Result: test.result}, context)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -45,10 +46,19 @@ func TestConcreteAdapterUsesEachSiteSurface(t *testing.T) {
 	}
 }
 
+func TestConcreteAdapterRejectsMismatchedResultType(t *testing.T) {
+	for _, result := range []program.ResultType{program.ResultBoolean, program.ResultNumber} {
+		_, err := program.EvaluateSite(program.Site{Source: "${{ 'true' }}", Surface: program.SurfaceStepControl, Result: result}, program.EvaluationContext{})
+		if err == nil || err.Error() != "expression produced string, want "+string(result) {
+			t.Errorf("EvaluateSite() error = %v, want %s mismatch", err, result)
+		}
+	}
+}
+
 func TestEvaluateBindingsPreservesOrderAtFailure(t *testing.T) {
 	bindings := []program.Binding{
-		{Name: "first", Value: program.Site{Source: "${{ unsupported.first }}", Surface: program.SurfaceStepTemplate}},
-		{Name: "second", Value: program.Site{Source: "${{ unsupported.second }}", Surface: program.SurfaceStepTemplate}},
+		{Name: "first", Value: program.Site{Source: "${{ unsupported.first }}", Surface: program.SurfaceStepTemplate, Result: program.ResultString}},
+		{Name: "second", Value: program.Site{Source: "${{ unsupported.second }}", Surface: program.SurfaceStepTemplate, Result: program.ResultString}},
 	}
 	_, err := program.EvaluateBindings(bindings, program.EvaluationContext{})
 	if err == nil || err.Error() != `evaluate "first": unsupported runtime expression "unsupported.first"` {

--- a/internal/program/evaluate_test.go
+++ b/internal/program/evaluate_test.go
@@ -1,0 +1,57 @@
+package program_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/buildkite/buildkite-gha/internal/expression"
+	"github.com/buildkite/buildkite-gha/internal/program"
+)
+
+func TestConcreteAdapterUsesEachSiteSurface(t *testing.T) {
+	expressionContext := expression.Context{
+		Env:    map[string]string{"VALUE": "resolved"},
+		Matrix: map[string]any{"enabled": true, "minutes": 5},
+		Needs:  map[string]expression.NeedStatus{"build": {Outputs: map[string]string{"services": `{"db":{"image":"postgres"}}`}}},
+	}
+	conditionContext := expression.ConditionContext{Matrix: expressionContext.Matrix}
+	context := program.EvaluationContext{Expression: expressionContext, Condition: conditionContext}
+	for _, test := range []struct {
+		name    string
+		surface program.Surface
+		source  string
+		want    any
+	}{
+		{name: "job condition", surface: program.SurfaceJobCondition, source: "matrix.enabled", want: true},
+		{name: "step condition", surface: program.SurfaceStepCondition, source: "matrix.enabled", want: true},
+		{name: "job environment", surface: program.SurfaceJobEnvironment, source: "${{ matrix.enabled }}", want: "true"},
+		{name: "job default", surface: program.SurfaceJobDefault, source: "${{ env.VALUE }}", want: "resolved"},
+		{name: "job output", surface: program.SurfaceJobOutput, source: "${{ env.VALUE }}", want: "resolved"},
+		{name: "step template", surface: program.SurfaceStepTemplate, source: "value-${{ matrix.enabled }}", want: "value-true"},
+		{name: "step control", surface: program.SurfaceStepControl, source: "${{ matrix.minutes }}", want: 5},
+		{name: "runtime template", surface: program.SurfaceRuntimeTemplate, source: "${{ needs.build.outputs.services }}", want: `{"db":{"image":"postgres"}}`},
+		{name: "service credential", surface: program.SurfaceServiceCredential, source: "${{ env.VALUE }}", want: "resolved"},
+		{name: "service map", surface: program.SurfaceServiceMap, source: "${{ fromJSON(needs.build.outputs.services) }}", want: []expression.ObjectEntry{{Name: "db", Value: map[string]any{"image": "postgres"}}}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := program.EvaluateSite(program.Site{Source: test.source, Surface: test.surface}, context)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("EvaluateSite() = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestEvaluateBindingsPreservesOrderAtFailure(t *testing.T) {
+	bindings := []program.Binding{
+		{Name: "first", Value: program.Site{Source: "${{ unsupported.first }}", Surface: program.SurfaceStepTemplate}},
+		{Name: "second", Value: program.Site{Source: "${{ unsupported.second }}", Surface: program.SurfaceStepTemplate}},
+	}
+	_, err := program.EvaluateBindings(bindings, program.EvaluationContext{})
+	if err == nil || err.Error() != `evaluate "first": unsupported runtime expression "unsupported.first"` {
+		t.Fatalf("EvaluateBindings() error = %v", err)
+	}
+}

--- a/internal/program/program.go
+++ b/internal/program/program.go
@@ -1,0 +1,304 @@
+// Package program defines the normalized workflow execution model shared by
+// compilation, authority planning, and, after the plan-schema cutover, runtime.
+package program
+
+// Surface selects the expression semantics for one execution site.
+type Surface string
+
+const (
+	SurfaceJobCondition      Surface = "job-condition"
+	SurfaceStepCondition     Surface = "step-condition"
+	SurfaceJobEnvironment    Surface = "job-environment"
+	SurfaceJobDefault        Surface = "job-default"
+	SurfaceJobOutput         Surface = "job-output"
+	SurfaceStepTemplate      Surface = "step-template"
+	SurfaceStepControl       Surface = "step-control"
+	SurfaceRuntimeTemplate   Surface = "runtime-template"
+	SurfaceServiceCredential Surface = "service-credential"
+	SurfaceServiceMap        Surface = "service-map"
+)
+
+// ResultType records the value shape required by an expression site.
+type ResultType string
+
+const (
+	ResultString  ResultType = "string"
+	ResultBoolean ResultType = "boolean"
+	ResultNumber  ResultType = "number"
+	ResultObject  ResultType = "object"
+)
+
+// Provenance records who authored an expression. Action metadata gains its own
+// provenance when resolved actions are normalized in the next delivery slice.
+type Provenance string
+
+const ProvenanceWorkflow Provenance = "workflow"
+
+// Purpose identifies sites with an authority exception. Supplied action inputs
+// may delegate ordinary-secret inventory to resolved action metadata.
+type Purpose string
+
+const (
+	PurposeExpression  Purpose = "expression"
+	PurposeActionInput Purpose = "action-input"
+)
+
+type Position struct {
+	Line   int
+	Column int
+}
+
+// Location retains the workflow source and stable normalized field path used
+// for diagnostics and coverage tests.
+type Location struct {
+	File  string
+	Field string
+	Start Position
+	End   Position
+}
+
+// Site is one expression or template evaluated at a defined execution point.
+type Site struct {
+	Source     string
+	Surface    Surface
+	Result     ResultType
+	Provenance Provenance
+	Purpose    Purpose
+	Location   Location
+}
+
+type Binding struct {
+	Name  string
+	Value Site
+}
+
+type BoolControl struct {
+	Literal    bool
+	Expression *Site
+}
+
+type NumberControl struct {
+	Literal    float64
+	Expression *Site
+}
+
+type Defaults struct {
+	Shell            Site
+	WorkingDirectory Site
+}
+
+type Container struct {
+	Image Site
+	Env   []Binding
+	Ports []Site
+}
+
+type ContainerCredentials struct {
+	Username Site
+	Password Site
+}
+
+type ServiceContainer struct {
+	Image       Site
+	Credentials *ContainerCredentials
+	Env         []Binding
+	Ports       []Site
+	Volumes     []Site
+	Options     Site
+	Command     Site
+	Entrypoint  Site
+}
+
+type Service struct {
+	Name      string
+	Container ServiceContainer
+}
+
+type Services struct {
+	Static  []Service
+	Dynamic *Site
+}
+
+type Run struct {
+	Command          Site
+	Shell            Site
+	WorkingDirectory Site
+}
+
+type Invocation struct {
+	Uses Site
+	With []Binding
+	Lock string
+}
+
+type Step struct {
+	ID              string
+	Kind            string
+	Background      bool
+	Targets         []string
+	Source          Location
+	Env             []Binding
+	Condition       Site
+	ContinueOnError BoolControl
+	TimeoutMinutes  NumberControl
+	Name            Site
+	Run             *Run
+	Invocation      *Invocation
+}
+
+type Guard struct {
+	Condition Site
+}
+
+type Job struct {
+	Guards          []Guard
+	Condition       Site
+	ContinueOnError bool
+	TimeoutMinutes  float64
+	Env             []Binding
+	Defaults        Defaults
+	Container       *Container
+	Services        Services
+	Steps           []Step
+	Outputs         []Binding
+}
+
+type Program struct {
+	Job Job
+}
+
+// VisitSites walks every expression-bearing field once in execution order.
+// Validation and ordinary-secret inventory deliberately use this exhaustive
+// walk rather than following runtime guards.
+func (p Program) VisitSites(visit func(Site) error) error {
+	for _, guard := range p.Job.Guards {
+		if err := visitSite(guard.Condition, visit); err != nil {
+			return err
+		}
+	}
+	if err := visitSite(p.Job.Condition, visit); err != nil {
+		return err
+	}
+	if err := visitBindings(p.Job.Env, visit); err != nil {
+		return err
+	}
+	if err := visitSite(p.Job.Defaults.Shell, visit); err != nil {
+		return err
+	}
+	if err := visitSite(p.Job.Defaults.WorkingDirectory, visit); err != nil {
+		return err
+	}
+	if p.Job.Container != nil {
+		if err := visitContainer(*p.Job.Container, visit); err != nil {
+			return err
+		}
+	}
+	for _, service := range p.Job.Services.Static {
+		if err := visitServiceContainer(service.Container, visit); err != nil {
+			return err
+		}
+	}
+	if p.Job.Services.Dynamic != nil {
+		if err := visitSite(*p.Job.Services.Dynamic, visit); err != nil {
+			return err
+		}
+	}
+	for _, step := range p.Job.Steps {
+		if err := visitBindings(step.Env, visit); err != nil {
+			return err
+		}
+		if err := visitSite(step.Condition, visit); err != nil {
+			return err
+		}
+		if step.ContinueOnError.Expression != nil {
+			if err := visitSite(*step.ContinueOnError.Expression, visit); err != nil {
+				return err
+			}
+		}
+		if step.TimeoutMinutes.Expression != nil {
+			if err := visitSite(*step.TimeoutMinutes.Expression, visit); err != nil {
+				return err
+			}
+		}
+		if err := visitSite(step.Name, visit); err != nil {
+			return err
+		}
+		if step.Run != nil {
+			for _, site := range []Site{step.Run.Command, step.Run.Shell, step.Run.WorkingDirectory} {
+				if err := visitSite(site, visit); err != nil {
+					return err
+				}
+			}
+		}
+		if step.Invocation != nil {
+			if err := visitSite(step.Invocation.Uses, visit); err != nil {
+				return err
+			}
+			if err := visitBindings(step.Invocation.With, visit); err != nil {
+				return err
+			}
+		}
+	}
+	return visitBindings(p.Job.Outputs, visit)
+}
+
+func visitContainer(container Container, visit func(Site) error) error {
+	if err := visitSite(container.Image, visit); err != nil {
+		return err
+	}
+	if err := visitBindings(container.Env, visit); err != nil {
+		return err
+	}
+	for _, port := range container.Ports {
+		if err := visitSite(port, visit); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func visitServiceContainer(container ServiceContainer, visit func(Site) error) error {
+	if err := visitSite(container.Image, visit); err != nil {
+		return err
+	}
+	if container.Credentials != nil {
+		if err := visitSite(container.Credentials.Username, visit); err != nil {
+			return err
+		}
+		if err := visitSite(container.Credentials.Password, visit); err != nil {
+			return err
+		}
+	}
+	if err := visitBindings(container.Env, visit); err != nil {
+		return err
+	}
+	for _, sites := range [][]Site{container.Ports, container.Volumes} {
+		for _, site := range sites {
+			if err := visitSite(site, visit); err != nil {
+				return err
+			}
+		}
+	}
+	for _, site := range []Site{container.Options, container.Command, container.Entrypoint} {
+		if err := visitSite(site, visit); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func visitBindings(bindings []Binding, visit func(Site) error) error {
+	for _, binding := range bindings {
+		if err := visitSite(binding.Value, visit); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func visitSite(site Site, visit func(Site) error) error {
+	if site.Source == "" {
+		return nil
+	}
+	return visit(site)
+}


### PR DESCRIPTION
Stacked on #365; review this PR after that foundation.

## Why

The compiler currently has to remember every place an expression can appear: job environment variables and outputs, step conditions and commands, action inputs, containers, services, and more. It then separately copies those fields into the runtime plan.

For example, both of these references need the same token authority even though they live in different parts of a workflow:

```yaml
env:
  API_TOKEN: ${{ github.token }}

steps:
  - uses: owner/action@v1
    with:
      token: ${{ github.token }}
```

Today, adding another expression-bearing field means updating parsing, token and secret scanning, plan construction, and runtime handling independently. Missing one produces the recurring field-by-field fixes described in [the expression authority design](https://github.com/buildkite/buildkite-gha/blob/main/docs/plans/expression-authority-planning.md).

## What

Lower each expanded workflow job into one normalized execution program before resolving actions and authorizing secrets. The program records where each expression came from, which expression rules apply, what type it must produce, and where it runs. It covers job and step conditions, environments, defaults, containers, services, typed controls, commands, action calls, and outputs.

Secret and token planning now walks that program instead of maintaining a separate field list. This also covers less common service fields such as commands and entrypoints; for example, a `github.token` reference in a service command can no longer be omitted from authority planning.

This is slice 2 of the design. It deliberately projects the normalized program back into the existing plan format, so the runtime contract does not change yet. Resolved action metadata comes in the next slice, followed by the final plan-schema cutover.
