### PR TITLE
Understand each action before planning its token access

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -801,9 +801,9 @@ context listed below, including `token`, with sorted keys and two-space
 indentation.
 
 The compiler treats that call as a token reference, so normal permissions,
-admission, and redaction apply. Composite steps can consume an already
-authorized context, but composite metadata cannot grant token authority. A
-tokenless context is an error.
+admission, and redaction apply. A direct `github.token` reference in composite
+metadata can grant token authority. `toJSON(github)` in composite metadata can
+only consume an already authorized context; a tokenless context is an error.
 
 Job-level fields and action input defaults cannot call `toJSON(github)`. Bare,
 projected, or dynamically indexed `github`, and passing the whole context to
@@ -1098,8 +1098,9 @@ JavaScript and Docker actions with compatible bundled cache clients also receive
 event repository when it:
 
 - statically references `secrets.GITHUB_TOKEN` or `github.token`; or
-- uses an action whose effective input default can reach `github.token` for the
-  event provider.
+- uses an action whose reachable input defaults, lifecycle conditions,
+  composite steps, outputs, or Docker environment can reach `github.token` for
+  the event provider.
 
 A `github.server_url == 'https://github.com'` guard skips the token branch for
 an Origin repository. Native adapters ignore upstream input defaults, so
@@ -1154,8 +1155,8 @@ The server restricts pull requests, merge queues, and their descendants. For oth
 
 The token is not part of the initial job environment. Workflow-authored
 `github.token` references are step-only and use the same token as
-`secrets.GITHUB_TOKEN`. Effective action input defaults can also use it.
-Automatic ambient `GITHUB_TOKEN` is unsupported.
+`secrets.GITHUB_TOKEN`. Reachable action metadata can also use it. Automatic
+ambient `GITHUB_TOKEN` is unsupported.
 
 ### Other secrets and OIDC
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -369,7 +369,9 @@ jobs:
 
 ### Permissions
 
-**🟡 Supported subset.** Permissions matter only when a job statically references `secrets.GITHUB_TOKEN` or `github.token`, or an effective action input default can reach `github.token` for the event provider.
+**🟡 Supported subset.** Permissions matter only when a job statically references
+`secrets.GITHUB_TOKEN` or `github.token`, or reachable action metadata can reach
+`github.token` for the event provider.
 
 A workflow-level permissions map can request repository access:
 

--- a/internal/action/metadata/metadata.go
+++ b/internal/action/metadata/metadata.go
@@ -17,7 +17,8 @@ import (
 
 // Metadata is the supported subset of a local action.yml or action.yaml file.
 type Metadata struct {
-	Path string `yaml:"-"`
+	Path       string `yaml:"-"`
+	SourcePath string `yaml:"-"`
 	// SourceRoot is the verified tree whose digest binds this action. For a
 	// workspace action it is Path; for a materialized GitHub action it is the
 	// repository root.
@@ -150,7 +151,11 @@ func Load(root, path string) (Metadata, error) {
 		return Metadata{}, fmt.Errorf("local action %q has no action.yml or action.yaml", path)
 	}
 
-	metadata := Metadata{Path: actionPath}
+	sourcePath, err := filepath.Rel(root, metadataPath)
+	if err != nil {
+		return Metadata{}, fmt.Errorf("locate action metadata: %w", err)
+	}
+	metadata := Metadata{Path: actionPath, SourcePath: filepath.ToSlash(sourcePath)}
 	var document yaml.Node
 	documentDecoder := yaml.NewDecoder(bytes.NewReader(source))
 	if err := documentDecoder.Decode(&document); err != nil {

--- a/internal/cli/hosted.go
+++ b/internal/cli/hosted.go
@@ -430,7 +430,7 @@ func githubTokenAdmissionDiagnostic(artifact compiler.PlanArtifact, reason strin
 		if len(quoted) > 1 {
 			actionLabel = "actions"
 		}
-		causes = append(causes, actionLabel+" "+strings.Join(quoted, ", ")+" defaults an input to github.token")
+		causes = append(causes, actionLabel+" "+strings.Join(quoted, ", ")+" requires github.token in its metadata")
 	}
 	if len(causes) == 0 {
 		causes = append(causes, "the compiled job requests a workflow token")

--- a/internal/cli/hosted_test.go
+++ b/internal/cli/hosted_test.go
@@ -177,10 +177,10 @@ runs:
 	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 		t.Fatal(err)
 	}
-	if len(report.Diagnostics) != 3 {
-		t.Fatalf("diagnostics = %#v, want three independent action failures", report.Diagnostics)
+	if len(report.Diagnostics) != 4 {
+		t.Fatalf("diagnostics = %#v, want four independent action failures", report.Diagnostics)
 	}
-	wantResults := map[int]string{1: compatibility.Passed, 2: compatibility.Failed}
+	wantResults := map[int]string{1: compatibility.Failed, 2: compatibility.Failed}
 	missingFailures := 0
 	for _, result := range report.Actions {
 		switch result.Job {

--- a/internal/compiler/action_program.go
+++ b/internal/compiler/action_program.go
@@ -1,0 +1,110 @@
+package compiler
+
+import (
+	"fmt"
+
+	"github.com/buildkite/buildkite-gha/internal/action/metadata"
+	"github.com/buildkite/buildkite-gha/internal/program"
+)
+
+func lowerActionProgram(node *actionNode) program.Action {
+	location := program.Location{File: node.metadata.SourcePath, Field: "action"}
+	action := program.Action{Name: node.metadata.Name, Source: node.lock.Source, Location: location}
+	for _, name := range sortedKeys(node.metadata.Inputs) {
+		definition := node.metadata.Inputs[name]
+		input := program.ActionInput{Name: name, Required: definition.Required}
+		if definition.Default != nil {
+			site := actionSite(*definition.Default, program.SurfaceActionInputDefault, location, "action.inputs."+name+".default")
+			input.Default = &site
+		}
+		action.Inputs = append(action.Inputs, input)
+	}
+	if node.native {
+		action.Runtime = program.ActionRuntimeNative
+		return action
+	}
+	switch node.runtime {
+	case metadata.RuntimeNode16, metadata.RuntimeNode24:
+		action.Runtime = program.ActionRuntimeJavaScript
+		nodeMajor := 24
+		if node.runtime == metadata.RuntimeNode16 {
+			nodeMajor = 16
+		}
+		action.JavaScript = &program.JavaScriptAction{
+			NodeMajor:     nodeMajor,
+			Pre:           node.metadata.Runs.Pre,
+			PreCondition:  actionSite(node.metadata.Runs.PreIf, program.SurfaceActionLifecycle, location, "action.runs.pre-if"),
+			Main:          node.metadata.Runs.Main,
+			Post:          node.metadata.Runs.Post,
+			PostCondition: actionSite(node.metadata.Runs.PostIf, program.SurfaceActionLifecycle, location, "action.runs.post-if"),
+		}
+	case metadata.RuntimeComposite:
+		action.Runtime = program.ActionRuntimeComposite
+		action.Composite = &program.CompositeAction{Steps: make([]program.CompositeStep, len(node.metadata.Runs.Steps))}
+		for i, step := range node.metadata.Runs.Steps {
+			field := fmt.Sprintf("action.runs.steps[%d]", i)
+			lowered := program.CompositeStep{
+				ID:              step.ID,
+				Name:            actionSite(step.Name, program.SurfaceCompositeTemplate, location, field+".name"),
+				Condition:       actionSite(step.If, program.SurfaceStepCondition, location, field+".if"),
+				ContinueOnError: step.ContinueOnError,
+				Env:             actionBindings(step.Env, program.SurfaceCompositeTemplate, location, field+".env"),
+			}
+			if step.Run != "" {
+				lowered.Run = &program.Run{
+					Command:          actionSite(step.Run, program.SurfaceCompositeTemplate, location, field+".run"),
+					Shell:            actionSite(step.Shell, program.SurfaceCompositeTemplate, location, field+".shell"),
+					WorkingDirectory: actionSite(step.WorkingDirectory, program.SurfaceCompositeTemplate, location, field+".working-directory"),
+				}
+			}
+			if step.Uses != "" {
+				lock := ""
+				if selector, ok := node.lock.Children[step.Uses]; ok {
+					lock = selector.Lock
+				}
+				lowered.Invocation = &program.Invocation{
+					Uses: actionSite(step.Uses, program.SurfaceRuntimeTemplate, location, field+".uses"),
+					With: actionBindings(step.With, program.SurfaceCompositeTemplate, location, field+".with"),
+					Lock: lock,
+				}
+			}
+			action.Composite.Steps[i] = lowered
+		}
+		for _, name := range sortedKeys(node.metadata.Outputs) {
+			action.Outputs = append(action.Outputs, program.Binding{
+				Name:  name,
+				Value: actionSite(node.metadata.Outputs[name].Value, program.SurfaceCompositeTemplate, location, "action.outputs."+name),
+			})
+		}
+	case metadata.RuntimeDocker:
+		action.Runtime = program.ActionRuntimeDocker
+		action.Docker = &program.DockerAction{
+			Arguments: make([]program.Site, len(node.metadata.Runs.Args)),
+			Env:       actionBindings(node.metadata.Runs.Env, program.SurfaceRuntimeTemplate, location, "action.runs.env"),
+		}
+		for i, argument := range node.metadata.Runs.Args {
+			action.Docker.Arguments[i] = actionSite(argument, program.SurfaceDockerArgument, location, fmt.Sprintf("action.runs.args[%d]", i))
+		}
+	}
+	return action
+}
+
+func actionBindings(values map[string]string, surface program.Surface, location program.Location, field string) []program.Binding {
+	if values == nil {
+		return nil
+	}
+	bindings := make([]program.Binding, 0, len(values))
+	for _, name := range sortedKeys(values) {
+		bindings = append(bindings, program.Binding{Name: name, Value: actionSite(values[name], surface, location, field+"."+name)})
+	}
+	return bindings
+}
+
+func actionSite(source string, surface program.Surface, location program.Location, field string) program.Site {
+	location.Field = field
+	result := program.ResultString
+	if surface == program.SurfaceStepCondition || surface == program.SurfaceActionLifecycle {
+		result = program.ResultBoolean
+	}
+	return program.Site{Source: source, Surface: surface, Result: result, Provenance: program.ProvenanceAction, Purpose: program.PurposeExpression, Location: location}
+}

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -272,6 +272,13 @@ func compileActionPrograms(ctx context.Context, workspace string, actionSource A
 				planning = contexts[i]
 				planning.ServerURL = serverURL
 			}
+			// Remote pre hooks all run before workflow action mains, and every
+			// executable phase may append to GITHUB_ENV. Across multiple roots,
+			// no root can safely prune authority using the initial environment.
+			if len(roots) > 1 {
+				planning.Environment = nil
+				planning.EnvironmentLayers = nil
+			}
 			requirements, err := program.InventoryActionAuthority(programs, invocations[i], planning)
 			if err != nil {
 				return actionCompilation{}, fmt.Errorf("compile action %q: %w", refs[i], err)

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -272,12 +272,12 @@ func compileActionPrograms(ctx context.Context, workspace string, actionSource A
 				planning = contexts[i]
 				planning.ServerURL = serverURL
 			}
-			// Remote pre hooks all run before workflow action mains, and every
-			// executable phase may append to GITHUB_ENV. Across multiple roots,
-			// no root can safely prune authority using the initial environment.
-			if len(roots) > 1 {
-				planning.Environment = nil
-				planning.EnvironmentLayers = nil
+			// Earlier workflow steps and action phases may append to GITHUB_ENV.
+			// Forget inherited values, but retain this step's explicit env layer:
+			// it is reapplied at runtime and overrides inherited mutations.
+			planning.Environment = nil
+			if len(planning.EnvironmentLayers) != 0 {
+				planning.EnvironmentLayers = planning.EnvironmentLayers[len(planning.EnvironmentLayers)-1:]
 			}
 			requirements, err := program.InventoryActionAuthority(programs, invocations[i], planning)
 			if err != nil {

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -265,6 +265,11 @@ func compileActionPrograms(ctx context.Context, workspace string, actionSource A
 	requiredSecrets := map[string]bool{}
 	var githubTokenActions []string
 	if suppliedInputs != nil {
+		anyPreparationPhase := false
+		for _, root := range roots {
+			anyPreparationPhase = anyPreparationPhase || program.ActionPreparesExecutablePhase(programs, root.lock.ID)
+		}
+		preparationEnvironmentMutable := false
 		for i, root := range roots {
 			invocations[i].Lock = root.lock.ID
 			planning := program.ActionAuthorityContext{ServerURL: serverURL}
@@ -272,13 +277,8 @@ func compileActionPrograms(ctx context.Context, workspace string, actionSource A
 				planning = contexts[i]
 				planning.ServerURL = serverURL
 			}
-			// Earlier workflow steps and action phases may append to GITHUB_ENV.
-			// Forget inherited values, but retain this step's explicit env layer:
-			// it is reapplied at runtime and overrides inherited mutations.
-			planning.Environment = nil
-			if len(planning.EnvironmentLayers) != 0 {
-				planning.EnvironmentLayers = planning.EnvironmentLayers[len(planning.EnvironmentLayers)-1:]
-			}
+			planning.PreparationEnvironmentMutable = planning.PreparationEnvironmentMutable || preparationEnvironmentMutable
+			planning.MainEnvironmentMutable = planning.MainEnvironmentMutable || anyPreparationPhase || i > 0
 			requirements, err := program.InventoryActionAuthority(programs, invocations[i], planning)
 			if err != nil {
 				return actionCompilation{}, fmt.Errorf("compile action %q: %w", refs[i], err)
@@ -290,6 +290,7 @@ func compileActionPrograms(ctx context.Context, workspace string, actionSource A
 			for _, name := range requirements.Secrets {
 				requiredSecrets[name] = true
 			}
+			preparationEnvironmentMutable = preparationEnvironmentMutable || program.ActionPreparesExecutablePhase(programs, root.lock.ID)
 		}
 	}
 	secretNames := sortedKeys(requiredSecrets)

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -18,6 +18,7 @@ import (
 	"github.com/buildkite/buildkite-gha/internal/action/source"
 	"github.com/buildkite/buildkite-gha/internal/expression"
 	"github.com/buildkite/buildkite-gha/internal/plan"
+	"github.com/buildkite/buildkite-gha/internal/program"
 )
 
 // RepositorySource resolves and materializes tokenless public GitHub repositories.
@@ -86,11 +87,7 @@ type actionCompilation struct {
 	githubTokenActions  []string
 	requiresMise        bool
 	requiresGitHubToken bool
-}
-
-type actionRequirements struct {
-	githubToken     bool
-	requiredSecrets map[string]bool
+	programs            map[string]program.Action
 }
 
 // validateActionResolutions resolves each independent root invocation before
@@ -215,11 +212,22 @@ func compileActionLocks(ctx context.Context, workspace string, actionSource Acti
 }
 
 func compileActionInvocations(ctx context.Context, workspace string, actionSource ActionSource, serverURL string, refs []string, suppliedInputs []map[string]string) (actionCompilation, error) {
+	invocations := make([]program.ActionInvocation, len(refs))
+	for i, inputs := range suppliedInputs {
+		invocations[i].Inputs = actionBindings(inputs, program.SurfaceStepTemplate, program.Location{}, "action.with")
+	}
+	return compileActionPrograms(ctx, workspace, actionSource, serverURL, refs, suppliedInputs, invocations, nil)
+}
+
+func compileActionPrograms(ctx context.Context, workspace string, actionSource ActionSource, serverURL string, refs []string, suppliedInputs []map[string]string, invocations []program.ActionInvocation, contexts []program.ActionAuthorityContext) (actionCompilation, error) {
 	if workspace == "" {
 		return actionCompilation{}, fmt.Errorf("workflow path must identify a repository root")
 	}
 	if suppliedInputs != nil && len(suppliedInputs) != len(refs) {
 		return actionCompilation{}, fmt.Errorf("action references and supplied inputs have different lengths")
+	}
+	if len(invocations) != len(refs) || contexts != nil && len(contexts) != len(refs) {
+		return actionCompilation{}, fmt.Errorf("action references and planning contexts have different lengths")
 	}
 	abs, err := filepath.Abs(workspace)
 	if err != nil {
@@ -242,8 +250,10 @@ func compileActionInvocations(ctx context.Context, workspace string, actionSourc
 		selectors = append(selectors, plan.ActionSelector{Lock: n.lock.ID})
 	}
 	locks := make([]plan.ActionLock, 0, len(b.nodes))
+	programs := make(map[string]program.Action, len(b.nodes))
 	for _, n := range b.nodes {
 		locks = append(locks, n.lock)
+		programs[n.lock.ID] = lowerActionProgram(n)
 	}
 	sort.Slice(locks, func(i, j int) bool { return locks[i].ID < locks[j].ID })
 	caps := make([]string, 0, len(b.caps))
@@ -256,15 +266,21 @@ func compileActionInvocations(ctx context.Context, workspace string, actionSourc
 	var githubTokenActions []string
 	if suppliedInputs != nil {
 		for i, root := range roots {
-			requirements, err := root.inspectInvocation(suppliedInputs[i], true, serverURL)
+			invocations[i].Lock = root.lock.ID
+			planning := program.ActionAuthorityContext{ServerURL: serverURL}
+			if contexts != nil {
+				planning = contexts[i]
+				planning.ServerURL = serverURL
+			}
+			requirements, err := program.InventoryActionAuthority(programs, invocations[i], planning)
 			if err != nil {
 				return actionCompilation{}, fmt.Errorf("compile action %q: %w", refs[i], err)
 			}
-			requiresGitHubToken = requiresGitHubToken || requirements.githubToken
-			if requirements.githubToken {
+			requiresGitHubToken = requiresGitHubToken || requirements.GitHubToken
+			if requirements.GitHubToken {
 				githubTokenActions = append(githubTokenActions, refs[i])
 			}
-			for name := range requirements.requiredSecrets {
+			for _, name := range requirements.Secrets {
 				requiredSecrets[name] = true
 			}
 		}
@@ -278,6 +294,7 @@ func compileActionInvocations(ctx context.Context, workspace string, actionSourc
 		githubTokenActions:  githubTokenActions,
 		requiresMise:        b.requiresMise,
 		requiresGitHubToken: requiresGitHubToken,
+		programs:            programs,
 	}, nil
 }
 
@@ -359,6 +376,12 @@ func (b *actionLockBuilder) add(ctx context.Context, raw string, depth int) (*ac
 			if err != nil {
 				return nil, &actionChildError{child: step.Uses, err: err}
 			}
+			descriptor, _ := actionintegration.Lookup(actionintegration.Identity{Source: child.lock.Source, Repository: child.lock.Repository, Path: child.lock.Path})
+			if descriptor.Adapter == actionintegration.AdapterUploadArtifactBuildkite {
+				if err := actionintegration.ValidateUploadArtifactInputs(child.lock.Commit, step.With); err != nil {
+					return nil, &actionChildError{child: step.Uses, err: fmt.Errorf("bounded upload-artifact adapter: %w", err)}
+				}
+			}
 			if n.lock.Children == nil {
 				n.lock.Children = map[string]plan.ActionSelector{}
 				n.children = map[string]*actionNode{}
@@ -368,107 +391,6 @@ func (b *actionLockBuilder) add(ctx context.Context, raw string, depth int) (*ac
 		}
 	}
 	return n, nil
-}
-
-func (n *actionNode) inspectInvocation(supplied map[string]string, workflowAuthored bool, serverURL string) (actionRequirements, error) {
-	requirements := actionRequirements{requiredSecrets: map[string]bool{}}
-	for _, suppliedName := range sortedKeys(supplied) {
-		value := supplied[suppliedName]
-		referencesEvent, err := expression.TemplateReferencesGitHubEvent(value)
-		if err != nil {
-			return actionRequirements{}, fmt.Errorf("action input %q: %w", suppliedName, err)
-		}
-		if referencesEvent {
-			return actionRequirements{}, fmt.Errorf("action input %q: github.event cannot be retained in a job plan", suppliedName)
-		}
-		names, err := expression.SecretReferences(value)
-		if err != nil {
-			return actionRequirements{}, fmt.Errorf("action input %q: %w", suppliedName, err)
-		}
-		var referencesToken bool
-		if workflowAuthored {
-			referencesToken, err = expression.ReferencesStepGitHubToken(value)
-		} else {
-			referencesToken, err = expression.ReferencesCompositeStepGitHubToken(value)
-		}
-		if err != nil {
-			return actionRequirements{}, fmt.Errorf("action input %q: %w", suppliedName, err)
-		}
-		if !workflowAuthored && len(names) != 0 {
-			return actionRequirements{}, fmt.Errorf("action input %q: composite action metadata cannot grant secret authority", suppliedName)
-		}
-		if !workflowAuthored && referencesToken {
-			return actionRequirements{}, fmt.Errorf("action input %q: composite action metadata cannot grant github.token authority", suppliedName)
-		}
-		requirements.githubToken = requirements.githubToken || referencesToken
-		input, declared := n.metadata.Inputs[strings.ToLower(suppliedName)]
-		for _, name := range names {
-			if declared && !input.Required && name != "GITHUB_TOKEN" {
-				continue
-			}
-			requirements.requiredSecrets[name] = true
-		}
-	}
-	if n.native {
-		return requirements, nil
-	}
-	for _, name := range sortedKeys(n.metadata.Inputs) {
-		input := n.metadata.Inputs[name]
-		if input.Default == nil || hasActionInput(supplied, name) {
-			continue
-		}
-		if err := expression.ValidateActionInputDefault(*input.Default); err != nil {
-			return actionRequirements{}, fmt.Errorf("action input %q default: %w", name, err)
-		}
-		referencesToken, err := expression.ActionInputDefaultRequiresGitHubToken(*input.Default, serverURL)
-		if err != nil {
-			return actionRequirements{}, fmt.Errorf("action input %q default: %w", name, err)
-		}
-		requirements.githubToken = requirements.githubToken || referencesToken
-	}
-	if n.runtime == metadata.RuntimeDocker {
-		for i, argument := range n.metadata.Runs.Args {
-			if err := expression.ValidateDockerActionArg(argument); err != nil {
-				return actionRequirements{}, fmt.Errorf("docker action argument %d: %w", i+1, err)
-			}
-		}
-	}
-	if n.runtime != metadata.RuntimeComposite {
-		return requirements, nil
-	}
-	for i, step := range n.metadata.Runs.Steps {
-		if step.Uses == "" {
-			continue
-		}
-		child := n.children[step.Uses]
-		if child == nil {
-			return actionRequirements{}, fmt.Errorf("composite action step %d child %q is missing", i+1, step.Uses)
-		}
-		descriptor, _ := actionintegration.Lookup(actionintegration.Identity{Source: child.lock.Source, Repository: child.lock.Repository, Path: child.lock.Path})
-		if descriptor.Adapter == actionintegration.AdapterUploadArtifactBuildkite {
-			if err := actionintegration.ValidateUploadArtifactInputs(child.lock.Commit, step.With); err != nil {
-				return actionRequirements{}, fmt.Errorf("composite action step %d child %q: bounded upload-artifact adapter: %w", i+1, step.Uses, err)
-			}
-		}
-		childRequirements, err := child.inspectInvocation(step.With, false, serverURL)
-		if err != nil {
-			return actionRequirements{}, fmt.Errorf("composite action step %d child %q: %w", i+1, step.Uses, err)
-		}
-		requirements.githubToken = requirements.githubToken || childRequirements.githubToken
-		for name := range childRequirements.requiredSecrets {
-			requirements.requiredSecrets[name] = true
-		}
-	}
-	return requirements, nil
-}
-
-func hasActionInput(inputs map[string]string, name string) bool {
-	for candidate := range inputs {
-		if strings.EqualFold(candidate, name) {
-			return true
-		}
-	}
-	return false
 }
 
 func (b *actionLockBuilder) describe(ctx context.Context, raw string) (string, plan.ActionLock, string, string, error) {

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -265,11 +265,27 @@ func compileActionPrograms(ctx context.Context, workspace string, actionSource A
 	requiredSecrets := map[string]bool{}
 	var githubTokenActions []string
 	if suppliedInputs != nil {
-		anyPreparationPhase := false
-		for _, root := range roots {
-			anyPreparationPhase = anyPreparationPhase || program.ActionPreparesExecutablePhase(programs, root.lock.ID)
-		}
+		preparationMutability := make([]bool, len(roots))
 		preparationEnvironmentMutable := false
+		for i, root := range roots {
+			preparation := program.ActionAuthorityContext{}
+			if contexts != nil {
+				preparation = contexts[i]
+			}
+			preparation.ServerURL = serverURL
+			preparation.PreparationEnvironmentMutable = preparation.PreparationEnvironmentMutable || preparationEnvironmentMutable
+			invocation := invocations[i]
+			invocation.Lock = root.lock.ID
+			invocation.Condition = program.Site{Source: "false"}
+			requirements, err := program.InventoryActionAuthority(programs, invocation, preparation)
+			if err != nil {
+				return actionCompilation{}, fmt.Errorf("compile action %q preparation: %w", refs[i], err)
+			}
+			preparationMutability[i] = requirements.PreparationEnvironmentMutable
+			preparationEnvironmentMutable = preparationEnvironmentMutable || requirements.PreparationEnvironmentMutable
+		}
+		anyPreparationPhase := preparationEnvironmentMutable
+		preparationEnvironmentMutable = false
 		for i, root := range roots {
 			invocations[i].Lock = root.lock.ID
 			planning := program.ActionAuthorityContext{ServerURL: serverURL}
@@ -278,7 +294,7 @@ func compileActionPrograms(ctx context.Context, workspace string, actionSource A
 				planning.ServerURL = serverURL
 			}
 			planning.PreparationEnvironmentMutable = planning.PreparationEnvironmentMutable || preparationEnvironmentMutable
-			planning.MainEnvironmentMutable = planning.MainEnvironmentMutable || anyPreparationPhase || i > 0
+			planning.MainEnvironmentMutable = planning.MainEnvironmentMutable || anyPreparationPhase
 			requirements, err := program.InventoryActionAuthority(programs, invocations[i], planning)
 			if err != nil {
 				return actionCompilation{}, fmt.Errorf("compile action %q: %w", refs[i], err)
@@ -290,7 +306,7 @@ func compileActionPrograms(ctx context.Context, workspace string, actionSource A
 			for _, name := range requirements.Secrets {
 				requiredSecrets[name] = true
 			}
-			preparationEnvironmentMutable = preparationEnvironmentMutable || program.ActionPreparesExecutablePhase(programs, root.lock.ID)
+			preparationEnvironmentMutable = preparationEnvironmentMutable || preparationMutability[i]
 		}
 	}
 	secretNames := sortedKeys(requiredSecrets)

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -1155,6 +1155,12 @@ func TestCompileActionLocksDoesNotValidateUnusedNativeLifecycle(t *testing.T) {
 	}
 }
 
+func TestUsesNativeActionAdapterNormalizesReferenceCase(t *testing.T) {
+	if !usesNativeActionAdapter("Actions/Checkout@v4") {
+		t.Fatal("mixed-case checkout reference did not select the native adapter")
+	}
+}
+
 func TestCompileActionLocksAllowsOnlyAuditedCacheCommits(t *testing.T) {
 	workspace, remote := t.TempDir(), t.TempDir()
 	for _, path := range []string{"", "restore", "save"} {

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -618,7 +618,10 @@ runs:
 		t.Context(), workspace, nil, "https://github.com",
 		[]string{"./mutator", "./guarded"}, []map[string]string{{}, {}},
 		[]program.ActionInvocation{{}, {}},
-		[]program.ActionAuthorityContext{{Environment: map[string]string{"FLAG": "false"}}, {Environment: map[string]string{"FLAG": "false"}}},
+		[]program.ActionAuthorityContext{
+			{Environment: map[string]string{"FLAG": "false"}},
+			{Environment: map[string]string{"FLAG": "false"}, MainEnvironmentMutable: true},
+		},
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -648,6 +651,43 @@ runs:
 	}
 	if compiled.requiresGitHubToken {
 		t.Fatal("single-root planning forgot an environment no earlier phase can mutate")
+	}
+}
+
+func TestCompileActionProgramsRetainsEnvironmentWhenDeclaredPreIsKnownSkipped(t *testing.T) {
+	workspace, remote := t.TempDir(), t.TempDir()
+	writeAction(t, workspace, "guarded", `name: guarded
+runs:
+  using: composite
+  steps:
+    - if: env.FLAG == 'true'
+      shell: sh
+      run: echo ${{ github.token }}
+`)
+	writeAction(t, remote, "", `name: skipped pre
+runs:
+  using: node24
+  pre: pre.js
+  pre-if: false
+  main: index.js
+`)
+	if err := os.WriteFile(filepath.Join(remote, "pre.js"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(remote, "index.js"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	compiled, err := compileActionPrograms(
+		t.Context(), workspace, &fakeActionSource{root: remote, calls: map[string]int{}}, "https://github.com",
+		[]string{"./guarded", "owner/action@v1"}, []map[string]string{{}, {}},
+		[]program.ActionInvocation{{}, {}},
+		[]program.ActionAuthorityContext{{Environment: map[string]string{"FLAG": "false"}}, {Environment: map[string]string{"FLAG": "false"}}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if compiled.requiresGitHubToken {
+		t.Fatal("known-skipped remote pre phase made the environment mutable")
 	}
 }
 

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -616,7 +616,7 @@ runs:
 `)
 	compiled, err := compileActionPrograms(
 		t.Context(), workspace, nil, "https://github.com",
-		[]string{"./guarded", "./mutator"}, []map[string]string{{}, {}},
+		[]string{"./mutator", "./guarded"}, []map[string]string{{}, {}},
 		[]program.ActionInvocation{{}, {}},
 		[]program.ActionAuthorityContext{{Environment: map[string]string{"FLAG": "false"}}, {Environment: map[string]string{"FLAG": "false"}}},
 	)
@@ -628,7 +628,7 @@ runs:
 	}
 }
 
-func TestCompileActionProgramsForgetsInheritedEnvironmentForSingleRoot(t *testing.T) {
+func TestCompileActionProgramsRetainsEnvironmentForFirstRootWithoutPreparation(t *testing.T) {
 	workspace := t.TempDir()
 	writeAction(t, workspace, "guarded", `name: guarded
 runs:
@@ -646,8 +646,8 @@ runs:
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !compiled.requiresGitHubToken {
-		t.Fatal("single-root planning trusted environment that an earlier phase can mutate")
+	if compiled.requiresGitHubToken {
+		t.Fatal("single-root planning forgot an environment no earlier phase can mutate")
 	}
 }
 

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -628,6 +628,55 @@ runs:
 	}
 }
 
+func TestCompileActionProgramsForgetsInheritedEnvironmentForSingleRoot(t *testing.T) {
+	workspace := t.TempDir()
+	writeAction(t, workspace, "guarded", `name: guarded
+runs:
+  using: composite
+  steps:
+    - if: env.FLAG == 'true'
+      shell: sh
+      run: echo ${{ github.token }}
+`)
+	compiled, err := compileActionPrograms(
+		t.Context(), workspace, nil, "https://github.com",
+		[]string{"./guarded"}, []map[string]string{{}}, []program.ActionInvocation{{}},
+		[]program.ActionAuthorityContext{{Environment: map[string]string{"FLAG": "false"}}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !compiled.requiresGitHubToken {
+		t.Fatal("single-root planning trusted environment that an earlier phase can mutate")
+	}
+}
+
+func TestCompileActionProgramsRetainsExplicitStepEnvironment(t *testing.T) {
+	workspace := t.TempDir()
+	writeAction(t, workspace, "guarded", `name: guarded
+runs:
+  using: composite
+  steps:
+    - if: env.FLAG == 'true'
+      shell: sh
+      run: echo ${{ github.token }}
+`)
+	compiled, err := compileActionPrograms(
+		t.Context(), workspace, nil, "https://github.com",
+		[]string{"./guarded"}, []map[string]string{{}}, []program.ActionInvocation{{}},
+		[]program.ActionAuthorityContext{{EnvironmentLayers: [][]program.Binding{
+			{{Name: "FLAG", Value: program.Site{Source: "true"}}},
+			{{Name: "FLAG", Value: program.Site{Source: "false"}}},
+		}}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if compiled.requiresGitHubToken {
+		t.Fatal("explicit step environment did not prune a known-false token branch")
+	}
+}
+
 func TestCompileActionInvocationsRejectsRetainedEventPayload(t *testing.T) {
 	workspace := t.TempDir()
 	writeAction(t, workspace, "event", `name: event input

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/buildkite/buildkite-gha/internal/action/metadata"
 	"github.com/buildkite/buildkite-gha/internal/action/source"
 	"github.com/buildkite/buildkite-gha/internal/plan"
+	"github.com/buildkite/buildkite-gha/internal/program"
 )
 
 type fakeActionSource struct {
@@ -445,6 +446,51 @@ runs:
 	}
 }
 
+func TestCompileActionInvocationsNormalizesResolvedActionManifest(t *testing.T) {
+	workspace := t.TempDir()
+	writeAction(t, workspace, "javascript", `name: normalized JavaScript
+inputs:
+  required:
+    required: true
+  optional:
+    default: ${{ github.actor }}
+runs:
+  using: node24
+  pre: pre.js
+  pre-if: inputs.optional != ''
+  main: index.js
+  post: post.js
+  post-if: always()
+`)
+	for _, name := range []string{"pre.js", "index.js", "post.js"} {
+		if err := os.WriteFile(filepath.Join(workspace, "javascript", name), []byte(""), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	compiled, err := compileActionInvocations(t.Context(), workspace, nil, "https://github.com", []string{"./javascript"}, []map[string]string{{"required": "value"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(compiled.selectors) != 1 || len(compiled.programs) != 1 {
+		t.Fatalf("normalized actions = %#v, selectors = %#v", compiled.programs, compiled.selectors)
+	}
+	action := compiled.programs[compiled.selectors[0].Lock]
+	if action.Name != "normalized JavaScript" || action.Source != "workspace" || action.Runtime != program.ActionRuntimeJavaScript || action.JavaScript == nil {
+		t.Fatalf("normalized action = %#v", action)
+	}
+	if action.JavaScript.NodeMajor != 24 || action.JavaScript.Pre != "pre.js" || action.JavaScript.Main != "index.js" || action.JavaScript.Post != "post.js" ||
+		action.JavaScript.PreCondition.Source != "inputs.optional != ''" || action.JavaScript.PostCondition.Source != "always()" {
+		t.Fatalf("normalized JavaScript lifecycle = %#v", action.JavaScript)
+	}
+	if len(action.Inputs) != 2 || action.Inputs[0].Name != "optional" || action.Inputs[0].Default == nil || action.Inputs[0].Default.Source != "${{ github.actor }}" ||
+		action.Inputs[1].Name != "required" || !action.Inputs[1].Required {
+		t.Fatalf("normalized inputs = %#v", action.Inputs)
+	}
+	if action.Location.File == "" || action.Inputs[0].Default.Provenance != program.ProvenanceAction {
+		t.Fatalf("normalized provenance = %#v, location = %#v", action.Inputs[0].Default, action.Location)
+	}
+}
+
 func TestCompileActionInvocationsScopesWorkflowAuthoredSecretsByInputContract(t *testing.T) {
 	workspace := t.TempDir()
 	writeAction(t, workspace, "secrets", `name: secret inputs
@@ -525,7 +571,7 @@ runs:
 	}
 }
 
-func TestCompileActionInvocationsRejectsGitHubTokenAuthorityFromCompositeMetadata(t *testing.T) {
+func TestCompileActionInvocationsGrantsDirectGitHubTokenAuthorityFromCompositeMetadata(t *testing.T) {
 	workspace := t.TempDir()
 	writeAction(t, workspace, "child", `name: child
 inputs:
@@ -544,9 +590,12 @@ runs:
         token: ${{ github.token }}-${{ toJSON(github) }}
 `)
 
-	_, err := compileActionInvocations(t.Context(), workspace, nil, "https://github.com", []string{"./parent"}, []map[string]string{nil})
-	if err == nil || !strings.Contains(err.Error(), "composite action metadata cannot grant github.token authority") {
-		t.Fatalf("composite metadata token error = %v", err)
+	compiled, err := compileActionInvocations(t.Context(), workspace, nil, "https://github.com", []string{"./parent"}, []map[string]string{nil})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !compiled.requiresGitHubToken {
+		t.Fatal("direct composite-authored github.token did not grant token authority")
 	}
 }
 

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -927,7 +927,7 @@ jobs:
     steps:
       - uses: ./.github/actions/token
 `)
-	if err == nil || !strings.Contains(err.Error(), "action input default that references github.token") || !strings.Contains(err.Error(), "no effective permissions") {
+	if err == nil || !strings.Contains(err.Error(), "action that references github.token in its metadata") || !strings.Contains(err.Error(), "no effective permissions") {
 		t.Fatalf("compilePlansForTest() error = %v, want empty permission rejection", err)
 	}
 }

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -599,6 +599,35 @@ runs:
 	}
 }
 
+func TestCompileActionProgramsForgetsEnvironmentAcrossWorkflowActionRoots(t *testing.T) {
+	workspace := t.TempDir()
+	writeAction(t, workspace, "guarded", `name: guarded
+runs:
+  using: composite
+  steps:
+    - if: env.FLAG == 'true'
+      shell: sh
+      run: echo ${{ github.token }}
+`)
+	writeAction(t, workspace, "mutator", `name: mutator
+runs:
+  using: node24
+  main: index.js
+`)
+	compiled, err := compileActionPrograms(
+		t.Context(), workspace, nil, "https://github.com",
+		[]string{"./guarded", "./mutator"}, []map[string]string{{}, {}},
+		[]program.ActionInvocation{{}, {}},
+		[]program.ActionAuthorityContext{{Environment: map[string]string{"FLAG": "false"}}, {Environment: map[string]string{"FLAG": "false"}}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !compiled.requiresGitHubToken {
+		t.Fatal("cross-root GITHUB_ENV mutation did not keep the guarded token path reachable")
+	}
+}
+
 func TestCompileActionInvocationsRejectsRetainedEventPayload(t *testing.T) {
 	workspace := t.TempDir()
 	writeAction(t, workspace, "event", `name: event input

--- a/internal/compiler/plan_builder.go
+++ b/internal/compiler/plan_builder.go
@@ -582,7 +582,7 @@ func (b planBuilder) authorizePlanSecrets(instance JobInstance, workflowProgram 
 		policyWorkflow = filepath.Base(instance.SourcePath)
 	}
 	if len(b.ir.Workflow.WorkflowTokenPermissions) == 0 {
-		reference := "an action input default that references github.token"
+		reference := "an action that references github.token in its metadata"
 		if referencesGitHubTokenSecret {
 			reference = "secrets.GITHUB_TOKEN"
 		} else if referencesGitHubToken {

--- a/internal/compiler/plan_builder.go
+++ b/internal/compiler/plan_builder.go
@@ -373,8 +373,7 @@ func (b planBuilder) buildActions(instance JobInstance, workflowProgram program.
 	contexts := make([]program.ActionAuthorityContext, len(actionIndexes))
 	immutableActionSteps := make(map[int]bool)
 	for i, stepIndex := range actionIndexes {
-		ref, err := actionsource.Parse(actionRefs[i])
-		if err == nil && actionintegration.UsesNativeAdapter(actionintegration.Identity{Source: "github", Repository: ref.Owner + "/" + ref.Repository, Path: ref.Path}) {
+		if usesNativeActionAdapter(actionRefs[i]) {
 			immutableActionSteps[stepIndex] = true
 		}
 	}
@@ -434,6 +433,16 @@ func (b planBuilder) buildActions(instance JobInstance, workflowProgram program.
 		built.authorization.DockerCapabilitySources = append(built.authorization.DockerCapabilitySources, "dockerfile-actions")
 	}
 	return built, nil
+}
+
+func usesNativeActionAdapter(raw string) bool {
+	ref, err := actionsource.Parse(raw)
+	if err != nil {
+		return false
+	}
+	return actionintegration.UsesNativeAdapter(actionintegration.Identity{
+		Source: "github", Repository: strings.ToLower(ref.Owner + "/" + ref.Repository), Path: strings.ToLower(ref.Path),
+	})
 }
 
 func (b planBuilder) validateActionAdapter(instance JobInstance, stepIndex int, lock plan.ActionLock, built *builtPlanActions) error {

--- a/internal/compiler/plan_builder.go
+++ b/internal/compiler/plan_builder.go
@@ -378,10 +378,17 @@ func (b planBuilder) buildActions(instance JobInstance, workflowProgram program.
 			unknownInputs[strings.ToLower(name)] = true
 		}
 		environment := [][]program.Binding{workflowProgram.Job.Env, step.Env}
+		environmentMutable, err := program.WorkflowEnvironmentMutableBefore(workflowProgram.Job.Steps, stepIndex, program.ActionAuthorityContext{
+			WorkflowInputs: instance.Inputs, UnknownWorkflowInputs: unknownInputs,
+			Matrix: instance.Matrix, EnvironmentLayers: [][]program.Binding{workflowProgram.Job.Env},
+		})
+		if err != nil {
+			return built, fmt.Errorf("build plan for job %q: plan action environment: %w", instance.LogicalJobID, err)
+		}
 		contexts[i] = program.ActionAuthorityContext{
 			WorkflowInputs: instance.Inputs, UnknownWorkflowInputs: unknownInputs,
 			Matrix: instance.Matrix, EnvironmentLayers: environment,
-			MainEnvironmentMutable: stepIndex > 0,
+			MainEnvironmentMutable: environmentMutable,
 		}
 	}
 	compiled, err := compileActionPrograms(b.ctx, instance.RepositoryRoot, b.actionSource, plan.EventServerURL(b.ir.Event.Provider), actionRefs, actionInputs, invocations, contexts)

--- a/internal/compiler/plan_builder.go
+++ b/internal/compiler/plan_builder.go
@@ -378,7 +378,11 @@ func (b planBuilder) buildActions(instance JobInstance, workflowProgram program.
 			unknownInputs[strings.ToLower(name)] = true
 		}
 		environment := [][]program.Binding{workflowProgram.Job.Env, step.Env}
-		contexts[i] = program.ActionAuthorityContext{WorkflowInputs: instance.Inputs, UnknownWorkflowInputs: unknownInputs, Matrix: instance.Matrix, EnvironmentLayers: environment}
+		contexts[i] = program.ActionAuthorityContext{
+			WorkflowInputs: instance.Inputs, UnknownWorkflowInputs: unknownInputs,
+			Matrix: instance.Matrix, EnvironmentLayers: environment,
+			MainEnvironmentMutable: stepIndex > 0,
+		}
 	}
 	compiled, err := compileActionPrograms(b.ctx, instance.RepositoryRoot, b.actionSource, plan.EventServerURL(b.ir.Event.Provider), actionRefs, actionInputs, invocations, contexts)
 	if err != nil {

--- a/internal/compiler/plan_builder.go
+++ b/internal/compiler/plan_builder.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	actionintegration "github.com/buildkite/buildkite-gha/internal/action/integration"
+	actionsource "github.com/buildkite/buildkite-gha/internal/action/source"
 	"github.com/buildkite/buildkite-gha/internal/expression"
 	"github.com/buildkite/buildkite-gha/internal/plan"
 	"github.com/buildkite/buildkite-gha/internal/program"
@@ -370,6 +371,13 @@ func (b planBuilder) buildActions(instance JobInstance, workflowProgram program.
 	}
 	invocations := make([]program.ActionInvocation, len(actionIndexes))
 	contexts := make([]program.ActionAuthorityContext, len(actionIndexes))
+	immutableActionSteps := make(map[int]bool)
+	for i, stepIndex := range actionIndexes {
+		ref, err := actionsource.Parse(actionRefs[i])
+		if err == nil && actionintegration.UsesNativeAdapter(actionintegration.Identity{Source: "github", Repository: ref.Owner + "/" + ref.Repository, Path: ref.Path}) {
+			immutableActionSteps[stepIndex] = true
+		}
+	}
 	for i, stepIndex := range actionIndexes {
 		step := workflowProgram.Job.Steps[stepIndex]
 		invocations[i] = program.ActionInvocation{Inputs: step.Invocation.With, Condition: step.Condition}
@@ -381,7 +389,7 @@ func (b planBuilder) buildActions(instance JobInstance, workflowProgram program.
 		environmentMutable, err := program.WorkflowEnvironmentMutableBefore(workflowProgram.Job.Steps, stepIndex, program.ActionAuthorityContext{
 			WorkflowInputs: instance.Inputs, UnknownWorkflowInputs: unknownInputs,
 			Matrix: instance.Matrix, EnvironmentLayers: [][]program.Binding{workflowProgram.Job.Env},
-		})
+		}, immutableActionSteps)
 		if err != nil {
 			return built, fmt.Errorf("build plan for job %q: plan action environment: %w", instance.LogicalJobID, err)
 		}

--- a/internal/compiler/plan_builder.go
+++ b/internal/compiler/plan_builder.go
@@ -35,6 +35,7 @@ type planBuilder struct {
 
 type builtPlanActions struct {
 	locks               []plan.ActionLock
+	programs            map[string]program.Action
 	capabilities        []string
 	authorization       PlanAuthorization
 	requiredSecrets     []string
@@ -121,7 +122,7 @@ func (b planBuilder) buildPlan(instance JobInstance, runtimeDistributionDigest s
 	workflowProgram := lowerWorkflowProgram(instance)
 	steps := projectPlanSteps(workflowProgram.Job.Steps)
 	actionIndexes, actionRefs, actionInputs := programActionInvocations(workflowProgram.Job.Steps)
-	actions, err := b.buildActions(instance, steps, actionIndexes, actionRefs, actionInputs)
+	actions, err := b.buildActions(instance, workflowProgram, steps, actionIndexes, actionRefs, actionInputs)
 	if err != nil {
 		return plan.Job{}, PlanAuthorization{}, nil, err
 	}
@@ -348,7 +349,7 @@ func (b planBuilder) reducePlanInstanceEventExpressions(instance JobInstance) (J
 	return instance, nil
 }
 
-func (b planBuilder) buildActions(instance JobInstance, steps []plan.Step, actionIndexes []int, actionRefs []string, actionInputs []map[string]string) (builtPlanActions, error) {
+func (b planBuilder) buildActions(instance JobInstance, workflowProgram program.Program, steps []plan.Step, actionIndexes []int, actionRefs []string, actionInputs []map[string]string) (builtPlanActions, error) {
 	built := builtPlanActions{requiresMise: len(actionRefs) != 0, resolved: b.options.ResolveActions}
 	if len(actionRefs) != 0 && !built.resolved {
 		built.resolved = true
@@ -367,11 +368,24 @@ func (b planBuilder) buildActions(instance JobInstance, steps []plan.Step, actio
 		built.capabilities = capabilities
 		return built, nil
 	}
-	compiled, err := compileActionInvocations(b.ctx, instance.RepositoryRoot, b.actionSource, plan.EventServerURL(b.ir.Event.Provider), actionRefs, actionInputs)
+	invocations := make([]program.ActionInvocation, len(actionIndexes))
+	contexts := make([]program.ActionAuthorityContext, len(actionIndexes))
+	for i, stepIndex := range actionIndexes {
+		step := workflowProgram.Job.Steps[stepIndex]
+		invocations[i] = program.ActionInvocation{Inputs: step.Invocation.With, Condition: step.Condition}
+		unknownInputs := make(map[string]bool, len(instance.DeferredInputs))
+		for name := range instance.DeferredInputs {
+			unknownInputs[strings.ToLower(name)] = true
+		}
+		environment := [][]program.Binding{workflowProgram.Job.Env, step.Env}
+		contexts[i] = program.ActionAuthorityContext{WorkflowInputs: instance.Inputs, UnknownWorkflowInputs: unknownInputs, Matrix: instance.Matrix, EnvironmentLayers: environment}
+	}
+	compiled, err := compileActionPrograms(b.ctx, instance.RepositoryRoot, b.actionSource, plan.EventServerURL(b.ir.Event.Provider), actionRefs, actionInputs, invocations, contexts)
 	if err != nil {
 		return built, fmt.Errorf("build plan for job %q: %w", instance.LogicalJobID, err)
 	}
 	built.requiresMise = compiled.requiresMise
+	built.programs = compiled.programs
 	built.requiresGitHubToken = compiled.requiresGitHubToken
 	built.requiredSecrets = compiled.requiredSecrets
 	built.authorization.GitHubTokenActions = append([]string(nil), compiled.githubTokenActions...)

--- a/internal/expression/abstract.go
+++ b/internal/expression/abstract.go
@@ -141,3 +141,153 @@ func analyzeActionInputDefault(node actionlint.ExprNode, knownReferences map[str
 	}
 	return evaluator.evaluate(node)
 }
+
+// AnalyzeActionInputDefault evaluates an action input default with retained
+// planning values and records authority reachable through unknown branches.
+func AnalyzeActionInputDefault(template string, knownReferences map[string]any) (Analysis, error) {
+	if err := ValidateActionInputDefault(template); err != nil {
+		return Analysis{}, err
+	}
+	return analyzeRuntimeTemplate(template, func(node actionlint.ExprNode) (Analysis, error) {
+		return analyzeActionInputDefault(node, normalizeKnownReferences(knownReferences))
+	})
+}
+
+// AnalyzeStepTemplate evaluates a workflow or composite step template with
+// retained planning values. wholeGitHub records the provenance of toJSON(github).
+func AnalyzeStepTemplate(template string, knownReferences map[string]any, wholeGitHub GitHubTokenEffect) (Analysis, error) {
+	knownReferences = normalizeKnownReferences(knownReferences)
+	return analyzeRuntimeTemplate(template, func(node actionlint.ExprNode) (Analysis, error) {
+		if err := validateStepRuntimeExpression(node, true, true, nil); err != nil {
+			return Analysis{}, err
+		}
+		return analyzeRuntimeNode(node, stepRuntimeSurface, knownReferences, wholeGitHub)
+	})
+}
+
+// AnalyzeCondition evaluates a validated condition with retained planning
+// values. Runtime-dependent values remain unknown.
+func AnalyzeCondition(source string, knownReferences map[string]any, wholeGitHub GitHubTokenEffect) (Analysis, error) {
+	if err := ValidateCondition(source, StepCondition); err != nil {
+		return Analysis{}, err
+	}
+	return analyzeCondition(source, knownReferences, wholeGitHub)
+}
+
+// AnalyzeActionLifecycleCondition evaluates pre-if or post-if with retained
+// planning values while preserving unknown runtime state.
+func AnalyzeActionLifecycleCondition(source string, knownReferences map[string]any) (Analysis, error) {
+	if err := ValidateActionLifecycleCondition(source); err != nil {
+		return Analysis{}, err
+	}
+	return analyzeCondition(source, knownReferences, GitHubTokenCompositeContext)
+}
+
+func analyzeCondition(source string, knownReferences map[string]any, wholeGitHub GitHubTokenEffect) (Analysis, error) {
+	node, empty, err := parseCondition(source)
+	if err != nil {
+		return Analysis{}, err
+	}
+	if empty {
+		return knownAnalysis(true), nil
+	}
+	analysis, err := analyzeRuntimeNode(node, conditionSurface, normalizeKnownReferences(knownReferences), wholeGitHub)
+	if err != nil || !analysis.Value.Known {
+		return analysis, err
+	}
+	return derivedAnalysis(githubTruthy(analysis.Value.Value), analysis), nil
+}
+
+func analyzeRuntimeNode(node actionlint.ExprNode, surface evaluationSurface, knownReferences map[string]any, wholeGitHub GitHubTokenEffect) (Analysis, error) {
+	evaluator := newAbstractEvaluator(surface)
+	evaluator.resolve = func(root string, path []string) (Analysis, error) {
+		name := strings.ToLower(referenceName(root, path))
+		if name == "github.token" {
+			return Analysis{Effects: Effects{GitHubToken: GitHubTokenDirect}}, nil
+		}
+		if value, ok := knownReferences[name]; ok {
+			return knownAnalysis(value), nil
+		}
+		return Analysis{}, nil
+	}
+	evaluator.resolveRoot = func(root string) (Analysis, error) {
+		name := strings.ToLower(root)
+		if value, ok := knownReferences[name]; ok {
+			return knownAnalysis(value), nil
+		}
+		if name == "github" {
+			return Analysis{Effects: Effects{GitHubToken: wholeGitHub}}, nil
+		}
+		return Analysis{}, nil
+	}
+	evaluator.unsupported = func(actionlint.ExprNode) error { return fmt.Errorf("unsupported runtime expression") }
+	evaluator.logicalError = func(kind actionlint.LogicalOpNodeKind) error {
+		return fmt.Errorf("unsupported runtime logical operator %s", kind)
+	}
+	evaluator.call = func(evaluator *expressionEvaluator[Analysis], call *actionlint.FuncCallNode) (Analysis, error) {
+		if value, recognized, err := evaluatePureFunction(evaluator, call); recognized {
+			return value, err
+		}
+		switch strings.ToLower(call.Callee) {
+		case "hashfiles", "success", "failure", "cancelled", "always":
+			return Analysis{}, nil
+		default:
+			return Analysis{}, fmt.Errorf("unsupported runtime function %q", call.Callee)
+		}
+	}
+	return evaluator.evaluate(node)
+}
+
+func analyzeRuntimeTemplate(template string, analyze func(actionlint.ExprNode) (Analysis, error)) (Analysis, error) {
+	const open = "${{"
+	remaining := template
+	var result strings.Builder
+	analysis := knownAnalysis("")
+	for {
+		start := strings.Index(remaining, open)
+		if start < 0 {
+			if analysis.Value.Known {
+				result.WriteString(remaining)
+				analysis.Value.Value = result.String()
+			}
+			return analysis, nil
+		}
+		if analysis.Value.Known {
+			result.WriteString(remaining[:start])
+		}
+		source := remaining[start+len(open):]
+		_, consumed, lexErr := actionlint.LexExpression(source)
+		if lexErr != nil {
+			return Analysis{}, fmt.Errorf("invalid expression: %w", lexErr)
+		}
+		node, parseErr := actionlint.NewExprParser().Parse(actionlint.NewExprLexer(source[:consumed]))
+		if parseErr != nil {
+			return Analysis{}, fmt.Errorf("invalid expression: %w", parseErr)
+		}
+		value, err := analyze(node)
+		if err != nil {
+			return Analysis{}, err
+		}
+		analysis.Effects.GitHubToken |= value.Effects.GitHubToken
+		if analysis.Value.Known && value.Value.Known {
+			if value.Value.Value != nil {
+				text, ok := expressionString(value.Value.Value)
+				if !ok {
+					return Analysis{}, fmt.Errorf("template expression resolved to %T, want a scalar", value.Value.Value)
+				}
+				result.WriteString(text)
+			}
+		} else {
+			analysis.Value = AbstractValue{}
+		}
+		remaining = source[consumed:]
+	}
+}
+
+func normalizeKnownReferences(references map[string]any) map[string]any {
+	known := make(map[string]any, len(references))
+	for name, value := range references {
+		known[strings.ToLower(name)] = value
+	}
+	return known
+}

--- a/internal/expression/abstract.go
+++ b/internal/expression/abstract.go
@@ -156,12 +156,20 @@ func AnalyzeActionInputDefault(template string, knownReferences map[string]any) 
 // AnalyzeStepTemplate evaluates a workflow or composite step template with
 // retained planning values. wholeGitHub records the provenance of toJSON(github).
 func AnalyzeStepTemplate(template string, knownReferences map[string]any, wholeGitHub GitHubTokenEffect) (Analysis, error) {
+	if err := ValidateStepTemplate(template); err != nil {
+		return Analysis{}, err
+	}
 	knownReferences = normalizeKnownReferences(knownReferences)
 	return analyzeRuntimeTemplate(template, func(node actionlint.ExprNode) (Analysis, error) {
-		if err := validateStepRuntimeExpression(node, true, true, nil); err != nil {
-			return Analysis{}, err
-		}
 		return analyzeRuntimeNode(node, stepRuntimeSurface, knownReferences, wholeGitHub)
+	})
+}
+
+// ValidateStepTemplate verifies every branch of a workflow or composite step
+// template without resolving runtime-dependent values.
+func ValidateStepTemplate(template string) error {
+	return visitTemplateExpressions(template, func(node actionlint.ExprNode) error {
+		return validateStepRuntimeExpression(node, true, true, nil)
 	})
 }
 

--- a/internal/expression/abstract.go
+++ b/internal/expression/abstract.go
@@ -131,6 +131,9 @@ func analyzeActionInputDefault(node actionlint.ExprNode, knownReferences map[str
 		if value, ok := knownReferences[strings.ToLower(referenceName(root, path))]; ok {
 			return knownAnalysis(value), nil
 		}
+		if value, ok := knownObjectReference(knownReferences, root, path); ok {
+			return knownAnalysis(value), nil
+		}
 		return Analysis{}, nil
 	}
 	evaluator.call = func(evaluator *expressionEvaluator[Analysis], node *actionlint.FuncCallNode) (Analysis, error) {
@@ -182,6 +185,15 @@ func AnalyzeCondition(source string, knownReferences map[string]any, wholeGitHub
 	return analyzeCondition(source, knownReferences, wholeGitHub)
 }
 
+// AnalyzeCompositeActionCondition evaluates a composite action's step
+// condition with its action-authored expression surface.
+func AnalyzeCompositeActionCondition(source string, knownReferences map[string]any) (Analysis, error) {
+	if err := validateCondition(source, compositeActionCondition, nil, false); err != nil {
+		return Analysis{}, err
+	}
+	return analyzeCondition(source, knownReferences, GitHubTokenCompositeContext)
+}
+
 // AnalyzeActionLifecycleCondition evaluates pre-if or post-if with retained
 // planning values while preserving unknown runtime state.
 func AnalyzeActionLifecycleCondition(source string, knownReferences map[string]any) (Analysis, error) {
@@ -216,6 +228,9 @@ func analyzeRuntimeNode(node actionlint.ExprNode, surface evaluationSurface, kno
 		if value, ok := knownReferences[name]; ok {
 			return knownAnalysis(value), nil
 		}
+		if value, ok := knownObjectReference(knownReferences, root, path); ok {
+			return knownAnalysis(value), nil
+		}
 		return Analysis{}, nil
 	}
 	evaluator.resolveRoot = func(root string) (Analysis, error) {
@@ -244,6 +259,21 @@ func analyzeRuntimeNode(node actionlint.ExprNode, surface evaluationSurface, kno
 		}
 	}
 	return evaluator.evaluate(node)
+}
+
+func knownObjectReference(knownReferences map[string]any, root string, path []string) (any, bool) {
+	value, ok := knownReferences[strings.ToLower(root)]
+	if !ok {
+		return nil, false
+	}
+	for _, name := range path {
+		object, objectOK := value.(map[string]any)
+		if !objectOK {
+			return nil, false
+		}
+		value = object[strings.ToLower(name)]
+	}
+	return value, true
 }
 
 func analyzeRuntimeTemplate(template string, analyze func(actionlint.ExprNode) (Analysis, error)) (Analysis, error) {

--- a/internal/expression/abstract.go
+++ b/internal/expression/abstract.go
@@ -188,7 +188,7 @@ func AnalyzeCondition(source string, knownReferences map[string]any, wholeGitHub
 // AnalyzeCompositeActionCondition evaluates a composite action's step
 // condition with its action-authored expression surface.
 func AnalyzeCompositeActionCondition(source string, knownReferences map[string]any) (Analysis, error) {
-	if err := validateCondition(source, compositeActionCondition, nil, false); err != nil {
+	if err := ValidateCompositeActionCondition(source); err != nil {
 		return Analysis{}, err
 	}
 	return analyzeCondition(source, knownReferences, GitHubTokenCompositeContext)

--- a/internal/expression/condition.go
+++ b/internal/expression/condition.go
@@ -42,6 +42,10 @@ const (
 	// actionLifecycleCondition is evaluated for action pre-if and post-if
 	// metadata. It has its own context policy and no implicit success guard.
 	actionLifecycleCondition
+	// compositeActionCondition is evaluated for a composite action's step if.
+	// It admits action-authored token and aggregate-input access without
+	// broadening workflow-authored step conditions.
+	compositeActionCondition
 )
 
 // ValidateCondition verifies that a job or step condition uses only expression
@@ -257,7 +261,7 @@ func validateConditionReference(root string, path []string, scope ConditionScope
 			case "actor", "base_ref", "event_name", "head_ref", "ref", "ref_name", "ref_type", "repository", "repository_owner", "sha":
 				return nil
 			case "token":
-				if scope == StepCondition || scope == actionLifecycleCondition {
+				if scope == actionLifecycleCondition || scope == compositeActionCondition {
 					return nil
 				}
 			}
@@ -345,7 +349,11 @@ func validateConditionAccessNode(validator *semanticValidator, node actionlint.E
 			return validator.validate(node.Index)
 		}
 		return fmt.Errorf("unsupported condition access expression")
-	case "matrix", "needs", "inputs":
+	case "matrix", "needs":
+	case "inputs":
+		if _, whole := node.(*actionlint.VariableNode); whole && scope != compositeActionCondition {
+			return fmt.Errorf("whole condition context %q is unsupported", root)
+		}
 	case "vars":
 		if _, whole := node.(*actionlint.VariableNode); whole {
 			return fmt.Errorf("whole condition context %q is unsupported", root)

--- a/internal/expression/condition.go
+++ b/internal/expression/condition.go
@@ -256,6 +256,10 @@ func validateConditionReference(root string, path []string, scope ConditionScope
 			switch strings.ToLower(path[0]) {
 			case "actor", "base_ref", "event_name", "head_ref", "ref", "ref_name", "ref_type", "repository", "repository_owner", "sha":
 				return nil
+			case "token":
+				if scope == actionLifecycleCondition {
+					return nil
+				}
 			}
 		}
 		return fmt.Errorf("condition reference %q is unavailable at runtime; supported github properties are actor, base_ref, event_name, head_ref, ref, ref_name, ref_type, repository, repository_owner, and sha", reference)

--- a/internal/expression/condition.go
+++ b/internal/expression/condition.go
@@ -257,7 +257,7 @@ func validateConditionReference(root string, path []string, scope ConditionScope
 			case "actor", "base_ref", "event_name", "head_ref", "ref", "ref_name", "ref_type", "repository", "repository_owner", "sha":
 				return nil
 			case "token":
-				if scope == actionLifecycleCondition {
+				if scope == StepCondition || scope == actionLifecycleCondition {
 					return nil
 				}
 			}

--- a/internal/expression/condition.go
+++ b/internal/expression/condition.go
@@ -345,12 +345,8 @@ func validateConditionAccessNode(validator *semanticValidator, node actionlint.E
 			return validator.validate(node.Index)
 		}
 		return fmt.Errorf("unsupported condition access expression")
-	case "matrix", "needs":
+	case "matrix", "needs", "inputs":
 	case "vars":
-		if _, whole := node.(*actionlint.VariableNode); whole {
-			return fmt.Errorf("whole condition context %q is unsupported", root)
-		}
-	case "inputs":
 		if _, whole := node.(*actionlint.VariableNode); whole {
 			return fmt.Errorf("whole condition context %q is unsupported", root)
 		}

--- a/internal/expression/condition.go
+++ b/internal/expression/condition.go
@@ -86,6 +86,12 @@ func ValidateActionLifecycleCondition(source string) error {
 	return validateCondition(source, actionLifecycleCondition, nil, false)
 }
 
+// ValidateCompositeActionCondition verifies a composite action's step
+// condition without broadening workflow-authored step conditions.
+func ValidateCompositeActionCondition(source string) error {
+	return validateCondition(source, compositeActionCondition, nil, false)
+}
+
 func validateLifecycleDelimiters(source string) error {
 	condition := strings.TrimSpace(source)
 	if strings.HasPrefix(condition, "${{") != strings.HasSuffix(condition, "}}") {

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -1162,6 +1162,7 @@ func TestValidateActionLifecycleCondition(t *testing.T) {
 		"steps.build.conclusion == 'success' && runner.os == 'Linux'",
 		"inputs.cache == true && hashFiles('Cargo.lock') != ''",
 		"inputs['cache'] == true",
+		"github.token != ''",
 	} {
 		if err := ValidateActionLifecycleCondition(condition); err != nil {
 			t.Errorf("ValidateActionLifecycleCondition(%q) error = %v", condition, err)

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -203,9 +203,11 @@ func TestRunnerDirectReferencesWorkAcrossRuntimeEvaluationSurfaces(t *testing.T)
 	}
 }
 
-func TestValidateStepConditionSupportsGitHubToken(t *testing.T) {
-	if err := ValidateCondition("github.token != ''", StepCondition); err != nil {
-		t.Fatal(err)
+func TestValidateStepConditionRejectsActionOnlyContexts(t *testing.T) {
+	for _, condition := range []string{"github.token != ''", "toJSON(inputs) != '{}'"} {
+		if err := ValidateCondition(condition, StepCondition); err == nil {
+			t.Errorf("ValidateCondition(%q) accepted an action-only context", condition)
+		}
 	}
 }
 

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -203,6 +203,12 @@ func TestRunnerDirectReferencesWorkAcrossRuntimeEvaluationSurfaces(t *testing.T)
 	}
 }
 
+func TestValidateStepConditionSupportsGitHubToken(t *testing.T) {
+	if err := ValidateCondition("github.token != ''", StepCondition); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestValidateActionInputDefaultSupportsRestrictedCompoundExpressions(t *testing.T) {
 	for _, template := range []string{
 		"${{ github.server_url == 'https://github.com' && github.token || '' }}",

--- a/internal/program/action_authority.go
+++ b/internal/program/action_authority.go
@@ -373,7 +373,7 @@ func (p *actionAuthorityPlanner) inspectComposite(action Action, mainInputs, pre
 		if err := p.inspect(step.Invocation.Lock, step.Invocation.With, step.Invocation.With, mainKnown, childMainScope, childPreparationScope, childStableScope, stepReachable, preparationReachable, preparationEnvironmentToken, false); err != nil {
 			return fmt.Errorf("composite action step %d child %q: %w", i+1, step.Invocation.Uses.Source, err)
 		}
-		if stepReachable {
+		if stepReachable && p.actions[step.Invocation.Lock].Runtime != ActionRuntimeNative {
 			mainKnown = withoutKnownEnvironment(mainKnown)
 		}
 		if preparationReachable && p.preparationEnvironmentChanges != preparationChanges {
@@ -484,11 +484,21 @@ func actionPhaseKnownReferences(context ActionAuthorityContext, mutable bool) (m
 	if !mutable {
 		return workflowKnownReferences(context)
 	}
-	context.Environment = nil
-	if len(context.EnvironmentLayers) != 0 {
-		context.EnvironmentLayers = context.EnvironmentLayers[len(context.EnvironmentLayers)-1:]
+	known, err := workflowKnownReferences(context)
+	if err != nil {
+		return nil, err
 	}
-	return workflowKnownReferences(context)
+	stable := withoutKnownEnvironment(known)
+	if len(context.EnvironmentLayers) == 0 {
+		return stable, nil
+	}
+	for _, binding := range context.EnvironmentLayers[len(context.EnvironmentLayers)-1] {
+		name := "env." + strings.ToLower(binding.Name)
+		if value, ok := known[name]; ok {
+			stable[name] = value
+		}
+	}
+	return stable, nil
 }
 
 // WorkflowEnvironmentMutableBefore reports whether an earlier workflow step

--- a/internal/program/action_authority.go
+++ b/internal/program/action_authority.go
@@ -508,9 +508,12 @@ func WorkflowEnvironmentMutableBefore(steps []Step, before int, context ActionAu
 		if analysis.Value.Known && analysis.Value.Value != true {
 			continue
 		}
+		if step.Kind == "wait-all" && len(background) != 0 {
+			return true, nil
+		}
 		if step.Kind == "wait" || step.Kind == "cancel" {
 			for _, target := range step.Targets {
-				if background[target] {
+				if background[strings.ToLower(target)] {
 					return true, nil
 				}
 			}
@@ -520,7 +523,7 @@ func WorkflowEnvironmentMutableBefore(steps []Step, before int, context ActionAu
 			continue
 		}
 		if step.Background {
-			background[step.ID] = true
+			background[strings.ToLower(step.ID)] = true
 			continue
 		}
 		return true, nil

--- a/internal/program/action_authority.go
+++ b/internal/program/action_authority.go
@@ -31,6 +31,7 @@ func InventoryActionAuthority(actions map[string]Action, invocation ActionInvoca
 	if err != nil {
 		return Authority{}, err
 	}
+	planner.workflowInputScope = known
 	mainReachable := true
 	if invocation.Condition.Source != "" {
 		analysis, err := expression.AnalyzeCondition(invocation.Condition.Source, known, expression.GitHubTokenWorkflowContext)
@@ -59,15 +60,17 @@ func InventoryActionAuthority(actions map[string]Action, invocation ActionInvoca
 }
 
 type actionAuthorityPlanner struct {
-	actions     map[string]Action
-	secrets     map[string]struct{}
-	githubToken bool
-	active      map[string]bool
+	actions            map[string]Action
+	secrets            map[string]struct{}
+	githubToken        bool
+	active             map[string]bool
+	workflowInputScope map[string]any
 }
 
 type effectiveActionInputs struct {
 	values      map[string]any
 	unknown     map[string]bool
+	omitted     map[string]bool
 	githubToken bool
 }
 
@@ -115,10 +118,10 @@ func (p *actionAuthorityPlanner) inspect(lock string, mainSupplied, preparationS
 		}
 		preReachable := false
 		if action.JavaScript.Pre != "" && (prepareAction || mainReachable) {
-			known := mainScope
+			known := workflowInputReferences(mainScope, p.workflowInputScope)
 			inputs := mainInputs
 			if prepareAction {
-				known = preparationScope
+				known = workflowInputReferences(preparationScope, p.workflowInputScope)
 				inputs = preparationInputs
 				p.githubToken = p.githubToken || preparationEnvironmentToken
 			}
@@ -142,7 +145,7 @@ func (p *actionAuthorityPlanner) inspect(lock string, mainSupplied, preparationS
 			p.githubToken = p.githubToken || preReachable && inputs.githubToken
 		}
 		if action.JavaScript.Post != "" && (mainReachable || preReachable) {
-			known := withoutKnownEnvironment(mainScope)
+			known := workflowInputReferences(withoutKnownEnvironment(mainScope), p.workflowInputScope)
 			analysis, err := expression.AnalyzeActionLifecycleCondition(action.JavaScript.PostCondition.Source, known)
 			if err != nil {
 				if validationErr := expression.ValidateActionLifecycleCondition(action.JavaScript.PostCondition.Source); validationErr != nil {
@@ -162,7 +165,7 @@ func (p *actionAuthorityPlanner) inspect(lock string, mainSupplied, preparationS
 		if action.Docker == nil {
 			return fmt.Errorf("action program %q has no Docker execution", lock)
 		}
-		known := actionInputReferences(mainScope, mainInputs.values, mainInputs.unknown)
+		known := actionInputReferences(mainScope, mainInputs.values, mainInputs.unknown, mainInputs.omitted)
 		for _, binding := range action.Docker.Env {
 			if err := p.inspectMetadataTemplate(binding.Value, known, mainReachable); err != nil {
 				return err
@@ -186,7 +189,7 @@ func (p *actionAuthorityPlanner) inspect(lock string, mainSupplied, preparationS
 }
 
 func (p *actionAuthorityPlanner) resolveInputs(action Action, supplied []Binding, scope map[string]any, workflowAuthored, resolveDefaults bool) (effectiveActionInputs, error) {
-	resolved := effectiveActionInputs{values: map[string]any{}, unknown: map[string]bool{}}
+	resolved := effectiveActionInputs{values: map[string]any{}, unknown: map[string]bool{}, omitted: map[string]bool{}}
 	definitions := make(map[string]ActionInput, len(action.Inputs))
 	for _, input := range action.Inputs {
 		definitions[input.Name] = input
@@ -234,10 +237,11 @@ func (p *actionAuthorityPlanner) resolveInputs(action Action, supplied []Binding
 		if input.Default == nil {
 			if !input.Required {
 				resolved.values[input.Name] = ""
+				resolved.omitted[input.Name] = true
 			}
 			continue
 		}
-		known = actionInputReferences(scope, resolved.values, resolved.unknown)
+		known = actionInputReferences(scope, resolved.values, resolved.unknown, resolved.omitted)
 		analysis, err := expression.AnalyzeActionInputDefault(input.Default.Source, known)
 		if err != nil {
 			serverURL, _ := known["github.server_url"].(string)
@@ -284,8 +288,8 @@ func (p *actionAuthorityPlanner) inventorySupplied(binding Binding, definition A
 }
 
 func (p *actionAuthorityPlanner) inspectComposite(action Action, mainInputs, preparationInputs effectiveActionInputs, mainScope, preparationScope map[string]any, mainReachable, preparationReachable bool) error {
-	mainKnown := actionInputReferences(mainScope, mainInputs.values, mainInputs.unknown)
-	preparationKnown := actionInputReferences(preparationScope, preparationInputs.values, preparationInputs.unknown)
+	mainKnown := actionInputReferences(mainScope, mainInputs.values, mainInputs.unknown, mainInputs.omitted)
+	preparationKnown := actionInputReferences(preparationScope, preparationInputs.values, preparationInputs.unknown, preparationInputs.omitted)
 	for i, step := range action.Composite.Steps {
 		condition, err := expression.AnalyzeCondition(step.Condition.Source, mainKnown, expression.GitHubTokenCompositeContext)
 		if err != nil {
@@ -403,8 +407,9 @@ func workflowKnownReferences(context ActionAuthorityContext) (map[string]any, er
 		matrix := make(map[string]any, len(context.Matrix))
 		for name, value := range context.Matrix {
 			name = strings.ToLower(name)
+			value = normalizeKnownValue(value)
 			matrix[name] = value
-			known["matrix."+name] = value
+			retainKnownReferences(known, "matrix."+name, value)
 		}
 		known["matrix"] = matrix
 	}
@@ -436,7 +441,35 @@ func workflowKnownReferences(context ActionAuthorityContext) (map[string]any, er
 	return known, nil
 }
 
-func actionInputReferences(scope, inputs map[string]any, unknown map[string]bool) map[string]any {
+func normalizeKnownValue(value any) any {
+	switch value := value.(type) {
+	case map[string]any:
+		normalized := make(map[string]any, len(value))
+		for name, child := range value {
+			normalized[strings.ToLower(name)] = normalizeKnownValue(child)
+		}
+		return normalized
+	case []any:
+		normalized := make([]any, len(value))
+		for i, child := range value {
+			normalized[i] = normalizeKnownValue(child)
+		}
+		return normalized
+	default:
+		return value
+	}
+}
+
+func retainKnownReferences(known map[string]any, prefix string, value any) {
+	known[prefix] = value
+	if object, ok := value.(map[string]any); ok {
+		for name, child := range object {
+			retainKnownReferences(known, prefix+"."+name, child)
+		}
+	}
+}
+
+func actionInputReferences(scope, inputs map[string]any, unknown, omitted map[string]bool) map[string]any {
 	known := make(map[string]any, len(scope)+len(inputs)+1)
 	for name, value := range scope {
 		if name != "inputs" && !strings.HasPrefix(name, "inputs.") {
@@ -447,7 +480,28 @@ func actionInputReferences(scope, inputs map[string]any, unknown map[string]bool
 		known["inputs."+strings.ToLower(name)] = value
 	}
 	if len(unknown) == 0 && inputs != nil {
-		known["inputs"] = inputs
+		aggregate := make(map[string]any, len(inputs)-len(omitted))
+		for name, value := range inputs {
+			if !omitted[name] {
+				aggregate[name] = value
+			}
+		}
+		known["inputs"] = aggregate
+	}
+	return known
+}
+
+func workflowInputReferences(scope, workflowScope map[string]any) map[string]any {
+	known := make(map[string]any, len(scope))
+	for name, value := range scope {
+		if name != "inputs" && !strings.HasPrefix(name, "inputs.") {
+			known[name] = value
+		}
+	}
+	for name, value := range workflowScope {
+		if name == "inputs" || strings.HasPrefix(name, "inputs.") {
+			known[name] = value
+		}
 	}
 	return known
 }

--- a/internal/program/action_authority.go
+++ b/internal/program/action_authority.go
@@ -9,12 +9,14 @@ import (
 )
 
 type ActionAuthorityContext struct {
-	ServerURL             string
-	WorkflowInputs        map[string]any
-	UnknownWorkflowInputs map[string]bool
-	Matrix                map[string]any
-	Environment           map[string]string
-	EnvironmentLayers     [][]Binding
+	ServerURL                     string
+	WorkflowInputs                map[string]any
+	UnknownWorkflowInputs         map[string]bool
+	Matrix                        map[string]any
+	Environment                   map[string]string
+	EnvironmentLayers             [][]Binding
+	MainEnvironmentMutable        bool
+	PreparationEnvironmentMutable bool
 }
 
 type ActionInvocation struct {
@@ -31,10 +33,22 @@ func InventoryActionAuthority(actions map[string]Action, invocation ActionInvoca
 	if err != nil {
 		return Authority{}, err
 	}
+	mainKnown, err := actionPhaseKnownReferences(context, context.MainEnvironmentMutable)
+	if err != nil {
+		return Authority{}, err
+	}
+	preparationKnown, err := actionPhaseKnownReferences(context, context.PreparationEnvironmentMutable)
+	if err != nil {
+		return Authority{}, err
+	}
+	stableKnown, err := actionPhaseKnownReferences(context, true)
+	if err != nil {
+		return Authority{}, err
+	}
 	planner.workflowInputScope = known
 	mainReachable := true
 	if invocation.Condition.Source != "" {
-		analysis, err := expression.AnalyzeCondition(invocation.Condition.Source, known, expression.GitHubTokenWorkflowContext)
+		analysis, err := expression.AnalyzeCondition(invocation.Condition.Source, mainKnown, expression.GitHubTokenWorkflowContext)
 		if err != nil {
 			if validationErr := expression.ValidateCondition(invocation.Condition.Source, expression.StepCondition); validationErr != nil {
 				return Authority{}, err
@@ -48,7 +62,7 @@ func InventoryActionAuthority(actions map[string]Action, invocation ActionInvoca
 			mainReachable, _ = analysis.Value.Value.(bool)
 		}
 	}
-	if err := planner.inspect(invocation.Lock, invocation.Inputs, invocation.Inputs, known, known, mainReachable, true, false, true); err != nil {
+	if err := planner.inspect(invocation.Lock, invocation.Inputs, invocation.Inputs, mainKnown, preparationKnown, stableKnown, mainReachable, true, false, true); err != nil {
 		return Authority{}, err
 	}
 	authority := Authority{GitHubToken: planner.githubToken, Secrets: make([]string, 0, len(planner.secrets))}
@@ -74,7 +88,7 @@ type effectiveActionInputs struct {
 	githubToken bool
 }
 
-func (p *actionAuthorityPlanner) inspect(lock string, mainSupplied, preparationSupplied []Binding, mainScope, preparationScope map[string]any, mainReachable, preparationReachable, preparationEnvironmentToken, workflowAuthored bool) error {
+func (p *actionAuthorityPlanner) inspect(lock string, mainSupplied, preparationSupplied []Binding, mainScope, preparationScope, stableScope map[string]any, mainReachable, preparationReachable, preparationEnvironmentToken, workflowAuthored bool) error {
 	action, ok := p.actions[lock]
 	if !ok {
 		return fmt.Errorf("action program %q is missing", lock)
@@ -145,7 +159,7 @@ func (p *actionAuthorityPlanner) inspect(lock string, mainSupplied, preparationS
 			p.githubToken = p.githubToken || preReachable && inputs.githubToken
 		}
 		if action.JavaScript.Post != "" && (mainReachable || preReachable) {
-			known := workflowInputReferences(withoutKnownEnvironment(mainScope), p.workflowInputScope)
+			known := workflowInputReferences(retainStableEnvironment(mainScope, stableScope), p.workflowInputScope)
 			analysis, err := expression.AnalyzeActionLifecycleCondition(action.JavaScript.PostCondition.Source, known)
 			if err != nil {
 				if validationErr := expression.ValidateActionLifecycleCondition(action.JavaScript.PostCondition.Source); validationErr != nil {
@@ -182,7 +196,7 @@ func (p *actionAuthorityPlanner) inspect(lock string, mainSupplied, preparationS
 			return fmt.Errorf("action program %q has no composite execution", lock)
 		}
 		p.githubToken = p.githubToken || prepareAction && (preparationEnvironmentToken || preparationInputs.githubToken)
-		return p.inspectComposite(action, mainInputs, preparationInputs, mainScope, preparationScope, mainReachable, prepareAction)
+		return p.inspectComposite(action, mainInputs, preparationInputs, mainScope, preparationScope, stableScope, mainReachable, prepareAction)
 	default:
 		return fmt.Errorf("action program %q has unsupported runtime %q", lock, action.Runtime)
 	}
@@ -242,6 +256,11 @@ func (p *actionAuthorityPlanner) resolveInputs(action Action, supplied []Binding
 			continue
 		}
 		known = actionInputReferences(scope, resolved.values, resolved.unknown, resolved.omitted)
+		for _, later := range action.Inputs {
+			if _, exists := resolved.values[later.Name]; !exists && !resolved.unknown[later.Name] {
+				known["inputs."+later.Name] = ""
+			}
+		}
 		analysis, err := expression.AnalyzeActionInputDefault(input.Default.Source, known)
 		if err != nil {
 			serverURL, _ := known["github.server_url"].(string)
@@ -287,15 +306,12 @@ func (p *actionAuthorityPlanner) inventorySupplied(binding Binding, definition A
 	return nil
 }
 
-func (p *actionAuthorityPlanner) inspectComposite(action Action, mainInputs, preparationInputs effectiveActionInputs, mainScope, preparationScope map[string]any, mainReachable, preparationReachable bool) error {
+func (p *actionAuthorityPlanner) inspectComposite(action Action, mainInputs, preparationInputs effectiveActionInputs, mainScope, preparationScope, stableScope map[string]any, mainReachable, preparationReachable bool) error {
 	mainKnown := actionInputReferences(mainScope, mainInputs.values, mainInputs.unknown, mainInputs.omitted)
 	preparationKnown := actionInputReferences(preparationScope, preparationInputs.values, preparationInputs.unknown, preparationInputs.omitted)
 	for i, step := range action.Composite.Steps {
-		condition, err := expression.AnalyzeCondition(step.Condition.Source, mainKnown, expression.GitHubTokenCompositeContext)
+		condition, err := expression.AnalyzeCompositeActionCondition(step.Condition.Source, mainKnown)
 		if err != nil {
-			if validationErr := expression.ValidateCondition(step.Condition.Source, expression.StepCondition); validationErr != nil {
-				return fmt.Errorf("composite action step %d condition: %w", i+1, err)
-			}
 			requiresToken, fallbackErr := expression.ConditionReferencesGitHubToken(step.Condition.Source)
 			if fallbackErr != nil {
 				return fmt.Errorf("composite action step %d condition: %w", i+1, err)
@@ -319,7 +335,7 @@ func (p *actionAuthorityPlanner) inspectComposite(action Action, mainInputs, pre
 		}
 		if step.Invocation == nil {
 			if stepReachable && step.Run != nil {
-				mainKnown = withoutKnownEnvironment(mainKnown)
+				mainKnown = retainStableEnvironment(mainKnown, stableScope)
 			}
 			continue
 		}
@@ -336,15 +352,18 @@ func (p *actionAuthorityPlanner) inspectComposite(action Action, mainInputs, pre
 		if err != nil {
 			return fmt.Errorf("composite action step %d preparation environment: %w", i+1, err)
 		}
-		if err := p.inspect(step.Invocation.Lock, step.Invocation.With, step.Invocation.With, childMainScope, childPreparationScope, stepReachable, preparationReachable, preparationEnvironmentToken, false); err != nil {
+		childStableScope, _, err := overlayActionEnvironment(stableScope, step.Env)
+		if err != nil {
+			return fmt.Errorf("composite action step %d stable environment: %w", i+1, err)
+		}
+		if err := p.inspect(step.Invocation.Lock, step.Invocation.With, step.Invocation.With, childMainScope, childPreparationScope, childStableScope, stepReachable, preparationReachable, preparationEnvironmentToken, false); err != nil {
 			return fmt.Errorf("composite action step %d child %q: %w", i+1, step.Invocation.Uses.Source, err)
 		}
 		if stepReachable {
-			mainKnown = withoutKnownEnvironment(mainKnown)
+			mainKnown = retainStableEnvironment(mainKnown, stableScope)
 		}
-		child := p.actions[step.Invocation.Lock]
-		if preparationReachable && child.Source == "github" && (child.Runtime == ActionRuntimeComposite || child.JavaScript != nil && child.JavaScript.Pre != "") {
-			preparationKnown = withoutKnownEnvironment(preparationKnown)
+		if preparationReachable && ActionPreparesExecutablePhase(p.actions, step.Invocation.Lock) {
+			preparationKnown = retainStableEnvironment(preparationKnown, stableScope)
 		}
 	}
 	for _, output := range action.Outputs {
@@ -395,10 +414,16 @@ func (p *actionAuthorityPlanner) inspectMetadataTemplate(site Site, known map[st
 
 func workflowKnownReferences(context ActionAuthorityContext) (map[string]any, error) {
 	known := map[string]any{"github.server_url": context.ServerURL}
+	workflowInputs := make(map[string]any, len(context.WorkflowInputs))
 	for name, value := range context.WorkflowInputs {
-		if !context.UnknownWorkflowInputs[strings.ToLower(name)] {
-			known["inputs."+strings.ToLower(name)] = value
+		name = strings.ToLower(name)
+		if !context.UnknownWorkflowInputs[name] {
+			known["inputs."+name] = value
+			workflowInputs[name] = value
 		}
+	}
+	if len(context.UnknownWorkflowInputs) == 0 && context.WorkflowInputs != nil {
+		known["inputs"] = workflowInputs
 	}
 	for name, value := range context.Environment {
 		known["env."+strings.ToLower(name)] = value
@@ -439,6 +464,37 @@ func workflowKnownReferences(context ActionAuthorityContext) (map[string]any, er
 		}
 	}
 	return known, nil
+}
+
+func actionPhaseKnownReferences(context ActionAuthorityContext, mutable bool) (map[string]any, error) {
+	if !mutable {
+		return workflowKnownReferences(context)
+	}
+	context.Environment = nil
+	if len(context.EnvironmentLayers) != 0 {
+		context.EnvironmentLayers = context.EnvironmentLayers[len(context.EnvironmentLayers)-1:]
+	}
+	return workflowKnownReferences(context)
+}
+
+// ActionPreparesExecutablePhase reports whether remote preparation can execute
+// a JavaScript pre phase in this action graph.
+func ActionPreparesExecutablePhase(actions map[string]Action, lock string) bool {
+	action, ok := actions[lock]
+	if !ok || action.Source != "github" {
+		return false
+	}
+	if action.JavaScript != nil {
+		return action.JavaScript.Pre != ""
+	}
+	if action.Composite != nil {
+		for _, step := range action.Composite.Steps {
+			if step.Invocation != nil && ActionPreparesExecutablePhase(actions, step.Invocation.Lock) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func normalizeKnownValue(value any) any {
@@ -541,6 +597,16 @@ func withoutKnownEnvironment(known map[string]any) map[string]any {
 	result := make(map[string]any, len(known))
 	for name, value := range known {
 		if !strings.HasPrefix(name, "env.") {
+			result[name] = value
+		}
+	}
+	return result
+}
+
+func retainStableEnvironment(known, stable map[string]any) map[string]any {
+	result := withoutKnownEnvironment(known)
+	for name, value := range stable {
+		if strings.HasPrefix(name, "env.") {
 			result[name] = value
 		}
 	}

--- a/internal/program/action_authority.go
+++ b/internal/program/action_authority.go
@@ -35,9 +35,15 @@ func InventoryActionAuthority(actions map[string]Action, invocation ActionInvoca
 	if invocation.Condition.Source != "" {
 		analysis, err := expression.AnalyzeCondition(invocation.Condition.Source, known, expression.GitHubTokenWorkflowContext)
 		if err != nil {
-			return Authority{}, err
-		}
-		if analysis.Value.Known {
+			if validationErr := expression.ValidateCondition(invocation.Condition.Source, expression.StepCondition); validationErr != nil {
+				return Authority{}, err
+			}
+			requiresToken, fallbackErr := expression.ConditionReferencesGitHubToken(invocation.Condition.Source)
+			if fallbackErr != nil {
+				return Authority{}, err
+			}
+			planner.githubToken = planner.githubToken || requiresToken
+		} else if analysis.Value.Known {
 			mainReachable, _ = analysis.Value.Value.(bool)
 		}
 	}
@@ -115,18 +121,36 @@ func (p *actionAuthorityPlanner) inspect(lock string, mainSupplied, preparationS
 			known := preparationScope
 			analysis, err := expression.AnalyzeActionLifecycleCondition(action.JavaScript.PreCondition.Source, known)
 			if err != nil {
-				return fmt.Errorf("action pre-if: %w", err)
+				if validationErr := expression.ValidateActionLifecycleCondition(action.JavaScript.PreCondition.Source); validationErr != nil {
+					return fmt.Errorf("action pre-if: %w", err)
+				}
+				requiresToken, fallbackErr := expression.ConditionReferencesGitHubToken(action.JavaScript.PreCondition.Source)
+				if fallbackErr != nil {
+					return fmt.Errorf("action pre-if: %w", err)
+				}
+				preReachable = true
+				p.githubToken = p.githubToken || requiresToken
+			} else {
+				preReachable = !analysis.Value.Known || analysis.Value.Value == true
+				p.githubToken = p.githubToken || authorityEffectsRequireToken(analysis.Effects)
 			}
-			preReachable = !analysis.Value.Known || analysis.Value.Value == true
-			p.githubToken = p.githubToken || preReachable && preparationInputs.githubToken || authorityEffectsRequireToken(analysis.Effects)
+			p.githubToken = p.githubToken || preReachable && preparationInputs.githubToken
 		}
 		if action.JavaScript.Post != "" && (mainReachable || preReachable) {
 			known := withoutKnownEnvironment(mainScope)
 			analysis, err := expression.AnalyzeActionLifecycleCondition(action.JavaScript.PostCondition.Source, known)
 			if err != nil {
-				return fmt.Errorf("action post-if: %w", err)
+				if validationErr := expression.ValidateActionLifecycleCondition(action.JavaScript.PostCondition.Source); validationErr != nil {
+					return fmt.Errorf("action post-if: %w", err)
+				}
+				requiresToken, fallbackErr := expression.ConditionReferencesGitHubToken(action.JavaScript.PostCondition.Source)
+				if fallbackErr != nil {
+					return fmt.Errorf("action post-if: %w", err)
+				}
+				p.githubToken = p.githubToken || requiresToken
+			} else {
+				p.githubToken = p.githubToken || authorityEffectsRequireToken(analysis.Effects)
 			}
-			p.githubToken = p.githubToken || authorityEffectsRequireToken(analysis.Effects)
 		}
 		return nil
 	case ActionRuntimeDocker:
@@ -177,7 +201,16 @@ func (p *actionAuthorityPlanner) resolveInputs(action Action, supplied []Binding
 		}
 		analysis, err := expression.AnalyzeStepTemplate(binding.Value.Source, known, wholeGitHub)
 		if err != nil {
-			return effectiveActionInputs{}, fmt.Errorf("action input %q: %w", binding.Name, err)
+			if validationErr := expression.ValidateStepTemplate(binding.Value.Source); validationErr != nil {
+				return effectiveActionInputs{}, fmt.Errorf("action input %q: %w", binding.Name, err)
+			}
+			requiresToken, fallbackErr := stepTemplateReferencesGitHubToken(binding.Value.Source, workflowAuthored)
+			if fallbackErr != nil {
+				return effectiveActionInputs{}, fmt.Errorf("action input %q: %w", binding.Name, err)
+			}
+			resolved.githubToken = resolved.githubToken || requiresToken
+			resolved.unknown[name] = true
+			continue
 		}
 		resolved.githubToken = resolved.githubToken || authorityEffectsRequireToken(analysis.Effects)
 		if analysis.Value.Known {
@@ -251,7 +284,15 @@ func (p *actionAuthorityPlanner) inspectComposite(action Action, mainInputs, pre
 	for i, step := range action.Composite.Steps {
 		condition, err := expression.AnalyzeCondition(step.Condition.Source, mainKnown, expression.GitHubTokenCompositeContext)
 		if err != nil {
-			return fmt.Errorf("composite action step %d condition: %w", i+1, err)
+			if validationErr := expression.ValidateCondition(step.Condition.Source, expression.StepCondition); validationErr != nil {
+				return fmt.Errorf("composite action step %d condition: %w", i+1, err)
+			}
+			requiresToken, fallbackErr := expression.ConditionReferencesGitHubToken(step.Condition.Source)
+			if fallbackErr != nil {
+				return fmt.Errorf("composite action step %d condition: %w", i+1, err)
+			}
+			p.githubToken = p.githubToken || mainReachable && requiresToken
+			condition = expression.Analysis{}
 		}
 		stepReachable := mainReachable && (!condition.Value.Known || condition.Value.Value == true)
 		p.githubToken = p.githubToken || mainReachable && authorityEffectsRequireToken(condition.Effects)
@@ -330,7 +371,17 @@ func (p *actionAuthorityPlanner) inspectMetadataTemplate(site Site, known map[st
 	}
 	analysis, err := expression.AnalyzeStepTemplate(site.Source, known, expression.GitHubTokenCompositeContext)
 	if err != nil {
-		return err
+		if validationErr := expression.ValidateStepTemplate(site.Source); validationErr != nil {
+			return err
+		}
+		requiresToken, fallbackErr := expression.ReferencesCompositeStepGitHubToken(site.Source)
+		if fallbackErr != nil {
+			return err
+		}
+		if reachable && requiresToken {
+			p.githubToken = true
+		}
+		return nil
 	}
 	if reachable && authorityEffectsRequireToken(analysis.Effects) {
 		p.githubToken = true
@@ -356,7 +407,14 @@ func workflowKnownReferences(context ActionAuthorityContext) (map[string]any, er
 		for _, binding := range layer {
 			analysis, err := expression.AnalyzeStepTemplate(binding.Value.Source, known, expression.GitHubTokenWorkflowContext)
 			if err != nil {
-				return nil, fmt.Errorf("environment %q: %w", binding.Name, err)
+				if validationErr := expression.ValidateStepTemplate(binding.Value.Source); validationErr != nil {
+					return nil, fmt.Errorf("environment %q: %w", binding.Name, err)
+				}
+				if _, fallbackErr := expression.ReferencesStepGitHubToken(binding.Value.Source); fallbackErr != nil {
+					return nil, fmt.Errorf("environment %q: %w", binding.Name, err)
+				}
+				values[strings.ToLower(binding.Name)] = expression.AbstractValue{}
+				continue
 			}
 			values[strings.ToLower(binding.Name)] = analysis.Value
 		}
@@ -397,7 +455,16 @@ func overlayActionEnvironment(scope map[string]any, bindings []Binding) (map[str
 	for _, binding := range bindings {
 		analysis, err := expression.AnalyzeStepTemplate(binding.Value.Source, scope, expression.GitHubTokenCompositeContext)
 		if err != nil {
-			return nil, false, err
+			if validationErr := expression.ValidateStepTemplate(binding.Value.Source); validationErr != nil {
+				return nil, false, err
+			}
+			requiresToken, fallbackErr := expression.ReferencesCompositeStepGitHubToken(binding.Value.Source)
+			if fallbackErr != nil {
+				return nil, false, err
+			}
+			githubToken = githubToken || requiresToken
+			delete(result, "env."+strings.ToLower(binding.Name))
+			continue
 		}
 		githubToken = githubToken || authorityEffectsRequireToken(analysis.Effects)
 		name := "env." + strings.ToLower(binding.Name)
@@ -422,4 +489,11 @@ func withoutKnownEnvironment(known map[string]any) map[string]any {
 
 func authorityEffectsRequireToken(effects expression.Effects) bool {
 	return effects.GitHubToken&(expression.GitHubTokenDirect|expression.GitHubTokenWorkflowContext) != 0
+}
+
+func stepTemplateReferencesGitHubToken(source string, workflowAuthored bool) (bool, error) {
+	if workflowAuthored {
+		return expression.ReferencesStepGitHubToken(source)
+	}
+	return expression.ReferencesCompositeStepGitHubToken(source)
 }

--- a/internal/program/action_authority.go
+++ b/internal/program/action_authority.go
@@ -62,7 +62,7 @@ func InventoryActionAuthority(actions map[string]Action, invocation ActionInvoca
 			mainReachable, _ = analysis.Value.Value.(bool)
 		}
 	}
-	if err := planner.inspect(invocation.Lock, invocation.Inputs, invocation.Inputs, mainKnown, preparationKnown, stableKnown, mainReachable, true, false, true); err != nil {
+	if err := planner.inspect(invocation.Lock, invocation.Inputs, invocation.Inputs, mainKnown, mainKnown, preparationKnown, stableKnown, mainReachable, true, false, true); err != nil {
 		return Authority{}, err
 	}
 	authority := Authority{
@@ -92,7 +92,7 @@ type effectiveActionInputs struct {
 	githubToken bool
 }
 
-func (p *actionAuthorityPlanner) inspect(lock string, mainSupplied, preparationSupplied []Binding, mainScope, preparationScope, stableScope map[string]any, mainReachable, preparationReachable, preparationEnvironmentToken, workflowAuthored bool) error {
+func (p *actionAuthorityPlanner) inspect(lock string, mainSupplied, preparationSupplied []Binding, mainInputScope, mainScope, preparationScope, stableScope map[string]any, mainReachable, preparationReachable, preparationEnvironmentToken, workflowAuthored bool) error {
 	action, ok := p.actions[lock]
 	if !ok {
 		return fmt.Errorf("action program %q is missing", lock)
@@ -114,7 +114,7 @@ func (p *actionAuthorityPlanner) inspect(lock string, mainSupplied, preparationS
 	}
 
 	resolveDefaults := action.Runtime != ActionRuntimeNative
-	mainInputs, err := p.resolveInputs(action, mainSupplied, mainScope, workflowAuthored, resolveDefaults)
+	mainInputs, err := p.resolveInputs(action, mainSupplied, mainInputScope, workflowAuthored, resolveDefaults)
 	if err != nil {
 		return err
 	}
@@ -255,7 +255,7 @@ func (p *actionAuthorityPlanner) resolveInputs(action Action, supplied []Binding
 		}
 		if input.Default == nil {
 			if !input.Required {
-				resolved.values[input.Name] = ""
+				resolved.values[input.Name] = nil
 				resolved.omitted[input.Name] = true
 			}
 			continue
@@ -366,14 +366,14 @@ func (p *actionAuthorityPlanner) inspectComposite(action Action, mainInputs, pre
 			return fmt.Errorf("composite action step %d stable environment: %w", i+1, err)
 		}
 		preparationWasMutable := p.preparationEnvironmentMutable
-		if err := p.inspect(step.Invocation.Lock, step.Invocation.With, step.Invocation.With, childMainScope, childPreparationScope, childStableScope, stepReachable, preparationReachable, preparationEnvironmentToken, false); err != nil {
+		if err := p.inspect(step.Invocation.Lock, step.Invocation.With, step.Invocation.With, mainKnown, childMainScope, childPreparationScope, childStableScope, stepReachable, preparationReachable, preparationEnvironmentToken, false); err != nil {
 			return fmt.Errorf("composite action step %d child %q: %w", i+1, step.Invocation.Uses.Source, err)
 		}
 		if stepReachable {
-			mainKnown = retainStableEnvironment(mainKnown, stableScope)
+			mainKnown = withoutKnownEnvironment(mainKnown)
 		}
 		if preparationReachable && p.preparationEnvironmentMutable != preparationWasMutable {
-			preparationKnown = retainStableEnvironment(preparationKnown, stableScope)
+			preparationKnown = withoutKnownEnvironment(preparationKnown)
 		}
 	}
 	for _, output := range action.Outputs {

--- a/internal/program/action_authority.go
+++ b/internal/program/action_authority.go
@@ -114,11 +114,16 @@ func (p *actionAuthorityPlanner) inspect(lock string, mainSupplied, preparationS
 			return fmt.Errorf("action program %q has no JavaScript lifecycle", lock)
 		}
 		preReachable := false
-		if prepareAction && action.JavaScript.Pre != "" {
-			p.githubToken = p.githubToken || preparationEnvironmentToken
+		if action.JavaScript.Pre != "" && (prepareAction || mainReachable) {
+			known := mainScope
+			inputs := mainInputs
+			if prepareAction {
+				known = preparationScope
+				inputs = preparationInputs
+				p.githubToken = p.githubToken || preparationEnvironmentToken
+			}
 			// The current runtime evaluates lifecycle conditions with reusable-
 			// workflow inputs, not the action's resolved inputs.
-			known := preparationScope
 			analysis, err := expression.AnalyzeActionLifecycleCondition(action.JavaScript.PreCondition.Source, known)
 			if err != nil {
 				if validationErr := expression.ValidateActionLifecycleCondition(action.JavaScript.PreCondition.Source); validationErr != nil {
@@ -134,7 +139,7 @@ func (p *actionAuthorityPlanner) inspect(lock string, mainSupplied, preparationS
 				preReachable = !analysis.Value.Known || analysis.Value.Value == true
 				p.githubToken = p.githubToken || authorityEffectsRequireToken(analysis.Effects)
 			}
-			p.githubToken = p.githubToken || preReachable && preparationInputs.githubToken
+			p.githubToken = p.githubToken || preReachable && inputs.githubToken
 		}
 		if action.JavaScript.Post != "" && (mainReachable || preReachable) {
 			known := withoutKnownEnvironment(mainScope)
@@ -399,8 +404,14 @@ func workflowKnownReferences(context ActionAuthorityContext) (map[string]any, er
 	for name, value := range context.Environment {
 		known["env."+strings.ToLower(name)] = value
 	}
-	for name, value := range context.Matrix {
-		known["matrix."+strings.ToLower(name)] = value
+	if context.Matrix != nil {
+		matrix := make(map[string]any, len(context.Matrix))
+		for name, value := range context.Matrix {
+			name = strings.ToLower(name)
+			matrix[name] = value
+			known["matrix."+name] = value
+		}
+		known["matrix"] = matrix
 	}
 	for _, layer := range context.EnvironmentLayers {
 		values := make(map[string]expression.AbstractValue, len(layer))

--- a/internal/program/action_authority.go
+++ b/internal/program/action_authority.go
@@ -41,9 +41,14 @@ func InventoryActionAuthority(actions map[string]Action, invocation ActionInvoca
 	if err != nil {
 		return Authority{}, err
 	}
-	stableKnown, err := actionPhaseKnownReferences(context, true)
-	if err != nil {
-		return Authority{}, err
+	stableKnown := withoutKnownEnvironment(mainKnown)
+	if len(context.EnvironmentLayers) != 0 {
+		for _, binding := range context.EnvironmentLayers[len(context.EnvironmentLayers)-1] {
+			name := "env." + strings.ToLower(binding.Name)
+			if value, ok := mainKnown[name]; ok {
+				stableKnown[name] = value
+			}
+		}
 	}
 	planner.workflowInputScope = known
 	mainReachable := true

--- a/internal/program/action_authority.go
+++ b/internal/program/action_authority.go
@@ -301,11 +301,6 @@ func (p *actionAuthorityPlanner) inspectComposite(action Action, mainInputs, pre
 		}
 		stepReachable := mainReachable && (!condition.Value.Known || condition.Value.Value == true)
 		p.githubToken = p.githubToken || mainReachable && authorityEffectsRequireToken(condition.Effects)
-		for _, site := range []Site{step.Name} {
-			if err := p.inspectMetadataTemplate(site, mainKnown, stepReachable); err != nil {
-				return fmt.Errorf("composite action step %d: %w", i+1, err)
-			}
-		}
 		for _, binding := range step.Env {
 			if err := p.inspectMetadataTemplate(binding.Value, mainKnown, stepReachable); err != nil {
 				return fmt.Errorf("composite action step %d environment %q: %w", i+1, binding.Name, err)

--- a/internal/program/action_authority.go
+++ b/internal/program/action_authority.go
@@ -347,7 +347,7 @@ func (p *actionAuthorityPlanner) inspectComposite(action Action, mainInputs, pre
 		}
 		if step.Invocation == nil {
 			if stepReachable && step.Run != nil {
-				mainKnown = retainStableEnvironment(mainKnown, stableScope)
+				mainKnown = withoutKnownEnvironment(mainKnown)
 			}
 			continue
 		}
@@ -484,28 +484,19 @@ func actionPhaseKnownReferences(context ActionAuthorityContext, mutable bool) (m
 	if !mutable {
 		return workflowKnownReferences(context)
 	}
-	known, err := workflowKnownReferences(context)
-	if err != nil {
-		return nil, err
-	}
-	stable := withoutKnownEnvironment(known)
+	context.Environment = nil
 	if len(context.EnvironmentLayers) == 0 {
-		return stable, nil
+		return workflowKnownReferences(context)
 	}
-	for _, binding := range context.EnvironmentLayers[len(context.EnvironmentLayers)-1] {
-		name := "env." + strings.ToLower(binding.Name)
-		if value, ok := known[name]; ok {
-			stable[name] = value
-		}
-	}
-	return stable, nil
+	context.EnvironmentLayers = context.EnvironmentLayers[len(context.EnvironmentLayers)-1:]
+	return workflowKnownReferences(context)
 }
 
 // WorkflowEnvironmentMutableBefore reports whether an earlier workflow step
 // can execute and append to GITHUB_ENV before the selected step.
-func WorkflowEnvironmentMutableBefore(steps []Step, before int, context ActionAuthorityContext) (bool, error) {
+func WorkflowEnvironmentMutableBefore(steps []Step, before int, context ActionAuthorityContext, immutableInvocations map[int]bool) (bool, error) {
 	background := map[string]bool{}
-	for _, step := range steps[:before] {
+	for i, step := range steps[:before] {
 		stepContext := context
 		stepContext.EnvironmentLayers = append(append([][]Binding(nil), context.EnvironmentLayers...), step.Env)
 		known, err := workflowKnownReferences(stepContext)
@@ -534,6 +525,9 @@ func WorkflowEnvironmentMutableBefore(steps []Step, before int, context ActionAu
 			continue
 		}
 		if step.Run == nil && step.Invocation == nil {
+			continue
+		}
+		if step.Invocation != nil && immutableInvocations[i] {
 			continue
 		}
 		if step.Background {

--- a/internal/program/action_authority.go
+++ b/internal/program/action_authority.go
@@ -202,7 +202,14 @@ func (p *actionAuthorityPlanner) resolveInputs(action Action, supplied []Binding
 		known = actionInputReferences(scope, resolved.values, resolved.unknown)
 		analysis, err := expression.AnalyzeActionInputDefault(input.Default.Source, known)
 		if err != nil {
-			return effectiveActionInputs{}, fmt.Errorf("action input %q default: %w", input.Name, err)
+			serverURL, _ := known["github.server_url"].(string)
+			requiresToken, fallbackErr := expression.ActionInputDefaultRequiresGitHubToken(input.Default.Source, serverURL)
+			if fallbackErr != nil {
+				return effectiveActionInputs{}, fmt.Errorf("action input %q default: %w", input.Name, err)
+			}
+			resolved.githubToken = resolved.githubToken || requiresToken
+			resolved.unknown[input.Name] = true
+			continue
 		}
 		resolved.githubToken = resolved.githubToken || authorityEffectsRequireToken(analysis.Effects)
 		if analysis.Value.Known {

--- a/internal/program/action_authority.go
+++ b/internal/program/action_authority.go
@@ -65,7 +65,10 @@ func InventoryActionAuthority(actions map[string]Action, invocation ActionInvoca
 	if err := planner.inspect(invocation.Lock, invocation.Inputs, invocation.Inputs, mainKnown, preparationKnown, stableKnown, mainReachable, true, false, true); err != nil {
 		return Authority{}, err
 	}
-	authority := Authority{GitHubToken: planner.githubToken, Secrets: make([]string, 0, len(planner.secrets))}
+	authority := Authority{
+		GitHubToken: planner.githubToken, PreparationEnvironmentMutable: planner.preparationEnvironmentMutable,
+		Secrets: make([]string, 0, len(planner.secrets)),
+	}
 	for name := range planner.secrets {
 		authority.Secrets = append(authority.Secrets, name)
 	}
@@ -74,11 +77,12 @@ func InventoryActionAuthority(actions map[string]Action, invocation ActionInvoca
 }
 
 type actionAuthorityPlanner struct {
-	actions            map[string]Action
-	secrets            map[string]struct{}
-	githubToken        bool
-	active             map[string]bool
-	workflowInputScope map[string]any
+	actions                       map[string]Action
+	secrets                       map[string]struct{}
+	githubToken                   bool
+	active                        map[string]bool
+	workflowInputScope            map[string]any
+	preparationEnvironmentMutable bool
 }
 
 type effectiveActionInputs struct {
@@ -157,6 +161,7 @@ func (p *actionAuthorityPlanner) inspect(lock string, mainSupplied, preparationS
 				p.githubToken = p.githubToken || authorityEffectsRequireToken(analysis.Effects)
 			}
 			p.githubToken = p.githubToken || preReachable && inputs.githubToken
+			p.preparationEnvironmentMutable = p.preparationEnvironmentMutable || prepareAction && preReachable
 		}
 		if action.JavaScript.Post != "" && (mainReachable || preReachable) {
 			known := workflowInputReferences(retainStableEnvironment(mainScope, stableScope), p.workflowInputScope)
@@ -312,6 +317,9 @@ func (p *actionAuthorityPlanner) inspectComposite(action Action, mainInputs, pre
 	for i, step := range action.Composite.Steps {
 		condition, err := expression.AnalyzeCompositeActionCondition(step.Condition.Source, mainKnown)
 		if err != nil {
+			if validationErr := expression.ValidateCompositeActionCondition(step.Condition.Source); validationErr != nil {
+				return fmt.Errorf("composite action step %d condition: %w", i+1, err)
+			}
 			requiresToken, fallbackErr := expression.ConditionReferencesGitHubToken(step.Condition.Source)
 			if fallbackErr != nil {
 				return fmt.Errorf("composite action step %d condition: %w", i+1, err)
@@ -352,17 +360,19 @@ func (p *actionAuthorityPlanner) inspectComposite(action Action, mainInputs, pre
 		if err != nil {
 			return fmt.Errorf("composite action step %d preparation environment: %w", i+1, err)
 		}
-		childStableScope, _, err := overlayActionEnvironment(stableScope, step.Env)
+		stableKnown := actionInputReferences(stableScope, mainInputs.values, mainInputs.unknown, mainInputs.omitted)
+		childStableScope, _, err := overlayActionEnvironment(stableKnown, step.Env)
 		if err != nil {
 			return fmt.Errorf("composite action step %d stable environment: %w", i+1, err)
 		}
+		preparationWasMutable := p.preparationEnvironmentMutable
 		if err := p.inspect(step.Invocation.Lock, step.Invocation.With, step.Invocation.With, childMainScope, childPreparationScope, childStableScope, stepReachable, preparationReachable, preparationEnvironmentToken, false); err != nil {
 			return fmt.Errorf("composite action step %d child %q: %w", i+1, step.Invocation.Uses.Source, err)
 		}
 		if stepReachable {
 			mainKnown = retainStableEnvironment(mainKnown, stableScope)
 		}
-		if preparationReachable && ActionPreparesExecutablePhase(p.actions, step.Invocation.Lock) {
+		if preparationReachable && p.preparationEnvironmentMutable != preparationWasMutable {
 			preparationKnown = retainStableEnvironment(preparationKnown, stableScope)
 		}
 	}
@@ -477,24 +487,29 @@ func actionPhaseKnownReferences(context ActionAuthorityContext, mutable bool) (m
 	return workflowKnownReferences(context)
 }
 
-// ActionPreparesExecutablePhase reports whether remote preparation can execute
-// a JavaScript pre phase in this action graph.
-func ActionPreparesExecutablePhase(actions map[string]Action, lock string) bool {
-	action, ok := actions[lock]
-	if !ok || action.Source != "github" {
-		return false
+// WorkflowEnvironmentMutableBefore reports whether an earlier workflow step
+// can execute and append to GITHUB_ENV before the selected step.
+func WorkflowEnvironmentMutableBefore(steps []Step, before int, context ActionAuthorityContext) (bool, error) {
+	known, err := workflowKnownReferences(context)
+	if err != nil {
+		return false, err
 	}
-	if action.JavaScript != nil {
-		return action.JavaScript.Pre != ""
-	}
-	if action.Composite != nil {
-		for _, step := range action.Composite.Steps {
-			if step.Invocation != nil && ActionPreparesExecutablePhase(actions, step.Invocation.Lock) {
-				return true
+	for _, step := range steps[:before] {
+		if step.Run == nil && step.Invocation == nil {
+			continue
+		}
+		analysis, err := expression.AnalyzeCondition(step.Condition.Source, known, expression.GitHubTokenWorkflowContext)
+		if err != nil {
+			if validationErr := expression.ValidateCondition(step.Condition.Source, expression.StepCondition); validationErr != nil {
+				return false, err
 			}
+			return true, nil
+		}
+		if !analysis.Value.Known || analysis.Value.Value == true {
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 func normalizeKnownValue(value any) any {

--- a/internal/program/action_authority.go
+++ b/internal/program/action_authority.go
@@ -83,6 +83,7 @@ type actionAuthorityPlanner struct {
 	active                        map[string]bool
 	workflowInputScope            map[string]any
 	preparationEnvironmentMutable bool
+	preparationEnvironmentChanges int
 }
 
 type effectiveActionInputs struct {
@@ -161,7 +162,10 @@ func (p *actionAuthorityPlanner) inspect(lock string, mainSupplied, preparationS
 				p.githubToken = p.githubToken || authorityEffectsRequireToken(analysis.Effects)
 			}
 			p.githubToken = p.githubToken || preReachable && inputs.githubToken
-			p.preparationEnvironmentMutable = p.preparationEnvironmentMutable || prepareAction && preReachable
+			if prepareAction && preReachable {
+				p.preparationEnvironmentMutable = true
+				p.preparationEnvironmentChanges++
+			}
 		}
 		if action.JavaScript.Post != "" && (mainReachable || preReachable) {
 			known := workflowInputReferences(retainStableEnvironment(mainScope, stableScope), p.workflowInputScope)
@@ -263,7 +267,7 @@ func (p *actionAuthorityPlanner) resolveInputs(action Action, supplied []Binding
 		known = actionInputReferences(scope, resolved.values, resolved.unknown, resolved.omitted)
 		for _, later := range action.Inputs {
 			if _, exists := resolved.values[later.Name]; !exists && !resolved.unknown[later.Name] {
-				known["inputs."+later.Name] = ""
+				known["inputs."+later.Name] = nil
 			}
 		}
 		analysis, err := expression.AnalyzeActionInputDefault(input.Default.Source, known)
@@ -365,14 +369,14 @@ func (p *actionAuthorityPlanner) inspectComposite(action Action, mainInputs, pre
 		if err != nil {
 			return fmt.Errorf("composite action step %d stable environment: %w", i+1, err)
 		}
-		preparationWasMutable := p.preparationEnvironmentMutable
+		preparationChanges := p.preparationEnvironmentChanges
 		if err := p.inspect(step.Invocation.Lock, step.Invocation.With, step.Invocation.With, mainKnown, childMainScope, childPreparationScope, childStableScope, stepReachable, preparationReachable, preparationEnvironmentToken, false); err != nil {
 			return fmt.Errorf("composite action step %d child %q: %w", i+1, step.Invocation.Uses.Source, err)
 		}
 		if stepReachable {
 			mainKnown = withoutKnownEnvironment(mainKnown)
 		}
-		if preparationReachable && p.preparationEnvironmentMutable != preparationWasMutable {
+		if preparationReachable && p.preparationEnvironmentChanges != preparationChanges {
 			preparationKnown = withoutKnownEnvironment(preparationKnown)
 		}
 	}

--- a/internal/program/action_authority.go
+++ b/internal/program/action_authority.go
@@ -110,7 +110,9 @@ func (p *actionAuthorityPlanner) inspect(lock string, mainSupplied, preparationS
 		preReachable := false
 		if prepareAction && action.JavaScript.Pre != "" {
 			p.githubToken = p.githubToken || preparationEnvironmentToken
-			known := actionInputReferences(preparationScope, preparationInputs.values, preparationInputs.unknown)
+			// The current runtime evaluates lifecycle conditions with reusable-
+			// workflow inputs, not the action's resolved inputs.
+			known := preparationScope
 			analysis, err := expression.AnalyzeActionLifecycleCondition(action.JavaScript.PreCondition.Source, known)
 			if err != nil {
 				return fmt.Errorf("action pre-if: %w", err)
@@ -119,7 +121,7 @@ func (p *actionAuthorityPlanner) inspect(lock string, mainSupplied, preparationS
 			p.githubToken = p.githubToken || preReachable && preparationInputs.githubToken || authorityEffectsRequireToken(analysis.Effects)
 		}
 		if action.JavaScript.Post != "" && (mainReachable || preReachable) {
-			known := withoutKnownEnvironment(actionInputReferences(mainScope, mainInputs.values, mainInputs.unknown))
+			known := withoutKnownEnvironment(mainScope)
 			analysis, err := expression.AnalyzeActionLifecycleCondition(action.JavaScript.PostCondition.Source, known)
 			if err != nil {
 				return fmt.Errorf("action post-if: %w", err)
@@ -147,7 +149,7 @@ func (p *actionAuthorityPlanner) inspect(lock string, mainSupplied, preparationS
 		if action.Composite == nil {
 			return fmt.Errorf("action program %q has no composite execution", lock)
 		}
-		p.githubToken = p.githubToken || prepareAction && preparationEnvironmentToken
+		p.githubToken = p.githubToken || prepareAction && (preparationEnvironmentToken || preparationInputs.githubToken)
 		return p.inspectComposite(action, mainInputs, preparationInputs, mainScope, preparationScope, mainReachable, prepareAction)
 	default:
 		return fmt.Errorf("action program %q has unsupported runtime %q", lock, action.Runtime)
@@ -188,7 +190,13 @@ func (p *actionAuthorityPlanner) resolveInputs(action Action, supplied []Binding
 		return resolved, nil
 	}
 	for _, input := range action.Inputs {
-		if _, exists := resolved.values[input.Name]; exists || resolved.unknown[input.Name] || input.Default == nil {
+		if _, exists := resolved.values[input.Name]; exists || resolved.unknown[input.Name] {
+			continue
+		}
+		if input.Default == nil {
+			if !input.Required {
+				resolved.values[input.Name] = ""
+			}
 			continue
 		}
 		known = actionInputReferences(scope, resolved.values, resolved.unknown)

--- a/internal/program/action_authority.go
+++ b/internal/program/action_authority.go
@@ -490,13 +490,13 @@ func actionPhaseKnownReferences(context ActionAuthorityContext, mutable bool) (m
 // WorkflowEnvironmentMutableBefore reports whether an earlier workflow step
 // can execute and append to GITHUB_ENV before the selected step.
 func WorkflowEnvironmentMutableBefore(steps []Step, before int, context ActionAuthorityContext) (bool, error) {
-	known, err := workflowKnownReferences(context)
-	if err != nil {
-		return false, err
-	}
+	background := map[string]bool{}
 	for _, step := range steps[:before] {
-		if step.Run == nil && step.Invocation == nil {
-			continue
+		stepContext := context
+		stepContext.EnvironmentLayers = append(append([][]Binding(nil), context.EnvironmentLayers...), step.Env)
+		known, err := workflowKnownReferences(stepContext)
+		if err != nil {
+			return false, err
 		}
 		analysis, err := expression.AnalyzeCondition(step.Condition.Source, known, expression.GitHubTokenWorkflowContext)
 		if err != nil {
@@ -505,9 +505,25 @@ func WorkflowEnvironmentMutableBefore(steps []Step, before int, context ActionAu
 			}
 			return true, nil
 		}
-		if !analysis.Value.Known || analysis.Value.Value == true {
-			return true, nil
+		if analysis.Value.Known && analysis.Value.Value != true {
+			continue
 		}
+		if step.Kind == "wait" || step.Kind == "cancel" {
+			for _, target := range step.Targets {
+				if background[target] {
+					return true, nil
+				}
+			}
+			continue
+		}
+		if step.Run == nil && step.Invocation == nil {
+			continue
+		}
+		if step.Background {
+			background[step.ID] = true
+			continue
+		}
+		return true, nil
 	}
 	return false, nil
 }

--- a/internal/program/action_authority.go
+++ b/internal/program/action_authority.go
@@ -1,0 +1,410 @@
+package program
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/buildkite/buildkite-gha/internal/expression"
+)
+
+type ActionAuthorityContext struct {
+	ServerURL             string
+	WorkflowInputs        map[string]any
+	UnknownWorkflowInputs map[string]bool
+	Matrix                map[string]any
+	Environment           map[string]string
+	EnvironmentLayers     [][]Binding
+}
+
+type ActionInvocation struct {
+	Lock      string
+	Inputs    []Binding
+	Condition Site
+}
+
+// InventoryActionAuthority abstractly executes normalized action lifecycle
+// structure and returns the workflow authority that reachable phases require.
+func InventoryActionAuthority(actions map[string]Action, invocation ActionInvocation, context ActionAuthorityContext) (Authority, error) {
+	planner := actionAuthorityPlanner{actions: actions, secrets: map[string]struct{}{}, active: map[string]bool{}}
+	known, err := workflowKnownReferences(context)
+	if err != nil {
+		return Authority{}, err
+	}
+	mainReachable := true
+	if invocation.Condition.Source != "" {
+		analysis, err := expression.AnalyzeCondition(invocation.Condition.Source, known, expression.GitHubTokenWorkflowContext)
+		if err != nil {
+			return Authority{}, err
+		}
+		if analysis.Value.Known {
+			mainReachable, _ = analysis.Value.Value.(bool)
+		}
+	}
+	if err := planner.inspect(invocation.Lock, invocation.Inputs, invocation.Inputs, known, known, mainReachable, true, false, true); err != nil {
+		return Authority{}, err
+	}
+	authority := Authority{GitHubToken: planner.githubToken, Secrets: make([]string, 0, len(planner.secrets))}
+	for name := range planner.secrets {
+		authority.Secrets = append(authority.Secrets, name)
+	}
+	sort.Strings(authority.Secrets)
+	return authority, nil
+}
+
+type actionAuthorityPlanner struct {
+	actions     map[string]Action
+	secrets     map[string]struct{}
+	githubToken bool
+	active      map[string]bool
+}
+
+type effectiveActionInputs struct {
+	values      map[string]any
+	unknown     map[string]bool
+	githubToken bool
+}
+
+func (p *actionAuthorityPlanner) inspect(lock string, mainSupplied, preparationSupplied []Binding, mainScope, preparationScope map[string]any, mainReachable, preparationReachable, preparationEnvironmentToken, workflowAuthored bool) error {
+	action, ok := p.actions[lock]
+	if !ok {
+		return fmt.Errorf("action program %q is missing", lock)
+	}
+	if p.active[lock] {
+		return fmt.Errorf("action program graph contains a cycle at %q", lock)
+	}
+	p.active[lock] = true
+	defer delete(p.active, lock)
+	if action.Runtime != ActionRuntimeNative {
+		for _, input := range action.Inputs {
+			if input.Default == nil {
+				continue
+			}
+			if err := expression.ValidateActionInputDefault(input.Default.Source); err != nil {
+				return fmt.Errorf("action input %q default: %w", input.Name, err)
+			}
+		}
+	}
+
+	resolveDefaults := action.Runtime != ActionRuntimeNative
+	mainInputs, err := p.resolveInputs(action, mainSupplied, mainScope, workflowAuthored, resolveDefaults)
+	if err != nil {
+		return err
+	}
+	preparationInputs, err := p.resolveInputs(action, preparationSupplied, preparationScope, workflowAuthored, resolveDefaults)
+	if err != nil {
+		return err
+	}
+	if mainReachable && mainInputs.githubToken {
+		p.githubToken = true
+	}
+	prepareAction := preparationReachable && action.Source == "github"
+
+	switch action.Runtime {
+	case ActionRuntimeNative:
+		return nil
+	case ActionRuntimeJavaScript:
+		if action.JavaScript == nil {
+			return fmt.Errorf("action program %q has no JavaScript lifecycle", lock)
+		}
+		preReachable := false
+		if prepareAction && action.JavaScript.Pre != "" {
+			p.githubToken = p.githubToken || preparationEnvironmentToken
+			known := actionInputReferences(preparationScope, preparationInputs.values, preparationInputs.unknown)
+			analysis, err := expression.AnalyzeActionLifecycleCondition(action.JavaScript.PreCondition.Source, known)
+			if err != nil {
+				return fmt.Errorf("action pre-if: %w", err)
+			}
+			preReachable = !analysis.Value.Known || analysis.Value.Value == true
+			p.githubToken = p.githubToken || preReachable && preparationInputs.githubToken || authorityEffectsRequireToken(analysis.Effects)
+		}
+		if action.JavaScript.Post != "" && (mainReachable || preReachable) {
+			known := withoutKnownEnvironment(actionInputReferences(mainScope, mainInputs.values, mainInputs.unknown))
+			analysis, err := expression.AnalyzeActionLifecycleCondition(action.JavaScript.PostCondition.Source, known)
+			if err != nil {
+				return fmt.Errorf("action post-if: %w", err)
+			}
+			p.githubToken = p.githubToken || authorityEffectsRequireToken(analysis.Effects)
+		}
+		return nil
+	case ActionRuntimeDocker:
+		if action.Docker == nil {
+			return fmt.Errorf("action program %q has no Docker execution", lock)
+		}
+		known := actionInputReferences(mainScope, mainInputs.values, mainInputs.unknown)
+		for _, binding := range action.Docker.Env {
+			if err := p.inspectMetadataTemplate(binding.Value, known, mainReachable); err != nil {
+				return err
+			}
+		}
+		for i, argument := range action.Docker.Arguments {
+			if err := expression.ValidateDockerActionArg(argument.Source); err != nil {
+				return fmt.Errorf("docker action argument %d: %w", i+1, err)
+			}
+		}
+		return nil
+	case ActionRuntimeComposite:
+		if action.Composite == nil {
+			return fmt.Errorf("action program %q has no composite execution", lock)
+		}
+		p.githubToken = p.githubToken || prepareAction && preparationEnvironmentToken
+		return p.inspectComposite(action, mainInputs, preparationInputs, mainScope, preparationScope, mainReachable, prepareAction)
+	default:
+		return fmt.Errorf("action program %q has unsupported runtime %q", lock, action.Runtime)
+	}
+}
+
+func (p *actionAuthorityPlanner) resolveInputs(action Action, supplied []Binding, scope map[string]any, workflowAuthored, resolveDefaults bool) (effectiveActionInputs, error) {
+	resolved := effectiveActionInputs{values: map[string]any{}, unknown: map[string]bool{}}
+	definitions := make(map[string]ActionInput, len(action.Inputs))
+	for _, input := range action.Inputs {
+		definitions[input.Name] = input
+	}
+	known := scope
+	for _, binding := range supplied {
+		name := strings.ToLower(binding.Name)
+		if _, exists := resolved.values[name]; exists || resolved.unknown[name] {
+			return effectiveActionInputs{}, fmt.Errorf("action inputs contain duplicate case-insensitive name %q", name)
+		}
+		if err := p.inventorySupplied(binding, definitions[name], workflowAuthored); err != nil {
+			return effectiveActionInputs{}, err
+		}
+		wholeGitHub := expression.GitHubTokenCompositeContext
+		if workflowAuthored {
+			wholeGitHub = expression.GitHubTokenWorkflowContext
+		}
+		analysis, err := expression.AnalyzeStepTemplate(binding.Value.Source, known, wholeGitHub)
+		if err != nil {
+			return effectiveActionInputs{}, fmt.Errorf("action input %q: %w", binding.Name, err)
+		}
+		resolved.githubToken = resolved.githubToken || authorityEffectsRequireToken(analysis.Effects)
+		if analysis.Value.Known {
+			resolved.values[name] = analysis.Value.Value
+		} else {
+			resolved.unknown[name] = true
+		}
+	}
+	if !resolveDefaults {
+		return resolved, nil
+	}
+	for _, input := range action.Inputs {
+		if _, exists := resolved.values[input.Name]; exists || resolved.unknown[input.Name] || input.Default == nil {
+			continue
+		}
+		known = actionInputReferences(scope, resolved.values, resolved.unknown)
+		analysis, err := expression.AnalyzeActionInputDefault(input.Default.Source, known)
+		if err != nil {
+			return effectiveActionInputs{}, fmt.Errorf("action input %q default: %w", input.Name, err)
+		}
+		resolved.githubToken = resolved.githubToken || authorityEffectsRequireToken(analysis.Effects)
+		if analysis.Value.Known {
+			resolved.values[input.Name] = analysis.Value.Value
+		} else {
+			resolved.unknown[input.Name] = true
+		}
+	}
+	return resolved, nil
+}
+
+func (p *actionAuthorityPlanner) inventorySupplied(binding Binding, definition ActionInput, workflowAuthored bool) error {
+	referencesEvent, err := expression.TemplateReferencesGitHubEvent(binding.Value.Source)
+	if err != nil {
+		return err
+	}
+	if referencesEvent {
+		return fmt.Errorf("action input %q: github.event cannot be retained in a job plan", binding.Name)
+	}
+	names, err := expression.SecretReferences(binding.Value.Source)
+	if err != nil {
+		return err
+	}
+	if !workflowAuthored && len(names) != 0 {
+		return fmt.Errorf("action input %q: composite action metadata cannot grant secret authority", binding.Name)
+	}
+	for _, name := range names {
+		if definition.Name != "" && !definition.Required && name != "GITHUB_TOKEN" {
+			continue
+		}
+		p.secrets[name] = struct{}{}
+	}
+	return nil
+}
+
+func (p *actionAuthorityPlanner) inspectComposite(action Action, mainInputs, preparationInputs effectiveActionInputs, mainScope, preparationScope map[string]any, mainReachable, preparationReachable bool) error {
+	mainKnown := actionInputReferences(mainScope, mainInputs.values, mainInputs.unknown)
+	preparationKnown := actionInputReferences(preparationScope, preparationInputs.values, preparationInputs.unknown)
+	for i, step := range action.Composite.Steps {
+		condition, err := expression.AnalyzeCondition(step.Condition.Source, mainKnown, expression.GitHubTokenCompositeContext)
+		if err != nil {
+			return fmt.Errorf("composite action step %d condition: %w", i+1, err)
+		}
+		stepReachable := mainReachable && (!condition.Value.Known || condition.Value.Value == true)
+		p.githubToken = p.githubToken || mainReachable && authorityEffectsRequireToken(condition.Effects)
+		for _, site := range []Site{step.Name} {
+			if err := p.inspectMetadataTemplate(site, mainKnown, stepReachable); err != nil {
+				return fmt.Errorf("composite action step %d: %w", i+1, err)
+			}
+		}
+		for _, binding := range step.Env {
+			if err := p.inspectMetadataTemplate(binding.Value, mainKnown, stepReachable); err != nil {
+				return fmt.Errorf("composite action step %d environment %q: %w", i+1, binding.Name, err)
+			}
+		}
+		if step.Run != nil {
+			for _, site := range []Site{step.Run.Command, step.Run.Shell, step.Run.WorkingDirectory} {
+				if err := p.inspectMetadataTemplate(site, mainKnown, stepReachable); err != nil {
+					return fmt.Errorf("composite action step %d: %w", i+1, err)
+				}
+			}
+		}
+		if step.Invocation == nil {
+			if stepReachable && step.Run != nil {
+				mainKnown = withoutKnownEnvironment(mainKnown)
+			}
+			continue
+		}
+		for _, binding := range step.Invocation.With {
+			if err := p.inspectMetadataTemplate(binding.Value, mainKnown, stepReachable); err != nil {
+				return fmt.Errorf("composite action step %d input %q: %w", i+1, binding.Name, err)
+			}
+		}
+		childMainScope, _, err := overlayActionEnvironment(mainKnown, step.Env)
+		if err != nil {
+			return fmt.Errorf("composite action step %d environment: %w", i+1, err)
+		}
+		childPreparationScope, preparationEnvironmentToken, err := overlayActionEnvironment(preparationKnown, step.Env)
+		if err != nil {
+			return fmt.Errorf("composite action step %d preparation environment: %w", i+1, err)
+		}
+		if err := p.inspect(step.Invocation.Lock, step.Invocation.With, step.Invocation.With, childMainScope, childPreparationScope, stepReachable, preparationReachable, preparationEnvironmentToken, false); err != nil {
+			return fmt.Errorf("composite action step %d child %q: %w", i+1, step.Invocation.Uses.Source, err)
+		}
+		if stepReachable {
+			mainKnown = withoutKnownEnvironment(mainKnown)
+		}
+		child := p.actions[step.Invocation.Lock]
+		if preparationReachable && child.Source == "github" && (child.Runtime == ActionRuntimeComposite || child.JavaScript != nil && child.JavaScript.Pre != "") {
+			preparationKnown = withoutKnownEnvironment(preparationKnown)
+		}
+	}
+	for _, output := range action.Outputs {
+		if err := p.inspectMetadataTemplate(output.Value, mainKnown, mainReachable); err != nil {
+			return fmt.Errorf("composite output %q: %w", output.Name, err)
+		}
+	}
+	return nil
+}
+
+func (p *actionAuthorityPlanner) inspectMetadataTemplate(site Site, known map[string]any, reachable bool) error {
+	if site.Source == "" {
+		return nil
+	}
+	referencesEvent, err := expression.TemplateReferencesGitHubEvent(site.Source)
+	if err != nil {
+		return err
+	}
+	if referencesEvent {
+		return fmt.Errorf("github.event cannot be retained in a job plan")
+	}
+	names, err := expression.SecretReferences(site.Source)
+	if err != nil {
+		return err
+	}
+	if len(names) != 0 {
+		return fmt.Errorf("composite action metadata cannot grant secret authority")
+	}
+	analysis, err := expression.AnalyzeStepTemplate(site.Source, known, expression.GitHubTokenCompositeContext)
+	if err != nil {
+		return err
+	}
+	if reachable && authorityEffectsRequireToken(analysis.Effects) {
+		p.githubToken = true
+	}
+	return nil
+}
+
+func workflowKnownReferences(context ActionAuthorityContext) (map[string]any, error) {
+	known := map[string]any{"github.server_url": context.ServerURL}
+	for name, value := range context.WorkflowInputs {
+		if !context.UnknownWorkflowInputs[strings.ToLower(name)] {
+			known["inputs."+strings.ToLower(name)] = value
+		}
+	}
+	for name, value := range context.Environment {
+		known["env."+strings.ToLower(name)] = value
+	}
+	for name, value := range context.Matrix {
+		known["matrix."+strings.ToLower(name)] = value
+	}
+	for _, layer := range context.EnvironmentLayers {
+		values := make(map[string]expression.AbstractValue, len(layer))
+		for _, binding := range layer {
+			analysis, err := expression.AnalyzeStepTemplate(binding.Value.Source, known, expression.GitHubTokenWorkflowContext)
+			if err != nil {
+				return nil, fmt.Errorf("environment %q: %w", binding.Name, err)
+			}
+			values[strings.ToLower(binding.Name)] = analysis.Value
+		}
+		for name, value := range values {
+			name = "env." + name
+			if value.Known {
+				known[name] = value.Value
+			} else {
+				delete(known, name)
+			}
+		}
+	}
+	return known, nil
+}
+
+func actionInputReferences(scope, inputs map[string]any, unknown map[string]bool) map[string]any {
+	known := make(map[string]any, len(scope)+len(inputs)+1)
+	for name, value := range scope {
+		if name != "inputs" && !strings.HasPrefix(name, "inputs.") {
+			known[name] = value
+		}
+	}
+	for name, value := range inputs {
+		known["inputs."+strings.ToLower(name)] = value
+	}
+	if len(unknown) == 0 && inputs != nil {
+		known["inputs"] = inputs
+	}
+	return known
+}
+
+func overlayActionEnvironment(scope map[string]any, bindings []Binding) (map[string]any, bool, error) {
+	result := make(map[string]any, len(scope)+len(bindings))
+	githubToken := false
+	for name, value := range scope {
+		result[name] = value
+	}
+	for _, binding := range bindings {
+		analysis, err := expression.AnalyzeStepTemplate(binding.Value.Source, scope, expression.GitHubTokenCompositeContext)
+		if err != nil {
+			return nil, false, err
+		}
+		githubToken = githubToken || authorityEffectsRequireToken(analysis.Effects)
+		name := "env." + strings.ToLower(binding.Name)
+		if analysis.Value.Known {
+			result[name] = analysis.Value.Value
+		} else {
+			delete(result, name)
+		}
+	}
+	return result, githubToken, nil
+}
+
+func withoutKnownEnvironment(known map[string]any) map[string]any {
+	result := make(map[string]any, len(known))
+	for name, value := range known {
+		if !strings.HasPrefix(name, "env.") {
+			result[name] = value
+		}
+	}
+	return result
+}
+
+func authorityEffectsRequireToken(effects expression.Effects) bool {
+	return effects.GitHubToken&(expression.GitHubTokenDirect|expression.GitHubTokenWorkflowContext) != 0
+}

--- a/internal/program/action_authority_test.go
+++ b/internal/program/action_authority_test.go
@@ -223,17 +223,111 @@ func TestInventoryActionAuthorityRetainsNestedMatrixReferences(t *testing.T) {
 	}
 }
 
-func TestInventoryActionAuthorityKeepsRuntimeDependentDefaultErrorsConservative(t *testing.T) {
-	defaultValue := testActionSite("${{ inputs.enabled && fromJSON('bad') && github.token || '' }}")
+func TestInventoryActionAuthorityTreatsMissingConcreteMatrixMemberAsNull(t *testing.T) {
 	actions := map[string]Action{
-		"root": {Source: "workspace", Runtime: ActionRuntimeComposite, Inputs: []ActionInput{{Name: "token", Default: &defaultValue}}, Composite: &CompositeAction{}},
+		"root": {Source: "workspace", Runtime: ActionRuntimeComposite, Inputs: []ActionInput{{Name: "token"}}, Composite: &CompositeAction{}},
+	}
+	authority, err := InventoryActionAuthority(actions, ActionInvocation{
+		Lock: "root", Inputs: []Binding{{Name: "token", Value: testWorkflowSite("${{ matrix.missing && github.token || '' }}")}},
+	}, ActionAuthorityContext{Matrix: map[string]any{"present": true}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if authority.GitHubToken {
+		t.Fatal("missing concrete matrix member retained GitHub token authority")
+	}
+}
+
+func TestInventoryActionAuthorityRetainsWorkflowInputAggregate(t *testing.T) {
+	actions := map[string]Action{
+		"root": {Source: "workspace", Runtime: ActionRuntimeComposite, Inputs: []ActionInput{{Name: "token"}}, Composite: &CompositeAction{}},
+	}
+	authority, err := InventoryActionAuthority(actions, ActionInvocation{
+		Lock: "root", Inputs: []Binding{{Name: "token", Value: testWorkflowSite("${{ inputs[matrix.key] && github.token || '' }}")}},
+	}, ActionAuthorityContext{WorkflowInputs: map[string]any{"publish": false}, Matrix: map[string]any{"key": "publish"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if authority.GitHubToken {
+		t.Fatal("known-false computed workflow input retained GitHub token authority")
+	}
+}
+
+func TestInventoryActionAuthorityTreatsLaterAbsentInputAsEmptyInDefault(t *testing.T) {
+	token := testActionSite("${{ inputs.enabled && github.token || '' }}")
+	actions := map[string]Action{
+		"root": {
+			Source: "workspace", Runtime: ActionRuntimeComposite,
+			Inputs: []ActionInput{{Name: "token", Default: &token}, {Name: "enabled"}}, Composite: &CompositeAction{},
+		},
 	}
 	authority, err := InventoryActionAuthority(actions, ActionInvocation{Lock: "root"}, ActionAuthorityContext{})
 	if err != nil {
 		t.Fatal(err)
 	}
+	if authority.GitHubToken {
+		t.Fatal("later absent input kept a known-false default token branch reachable")
+	}
+}
+
+func TestInventoryActionAuthorityKeepsRuntimeDependentDefaultErrorsConservative(t *testing.T) {
+	defaultValue := testActionSite("${{ inputs.enabled && fromJSON('bad') && github.token || '' }}")
+	actions := map[string]Action{
+		"root": {Source: "workspace", Runtime: ActionRuntimeComposite, Inputs: []ActionInput{{Name: "enabled"}, {Name: "token", Default: &defaultValue}}, Composite: &CompositeAction{}},
+	}
+	authority, err := InventoryActionAuthority(actions, ActionInvocation{
+		Lock: "root", Inputs: []Binding{{Name: "enabled", Value: testWorkflowSite("${{ inputs.enabled }}")}},
+	}, ActionAuthorityContext{UnknownWorkflowInputs: map[string]bool{"enabled": true}})
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !authority.GitHubToken {
 		t.Fatal("runtime-dependent default error did not retain conservative token authority")
+	}
+}
+
+func TestInventoryActionAuthorityRetainsStableInvocationEnvironmentForPost(t *testing.T) {
+	actions := map[string]Action{
+		"root": {Source: "github", Runtime: ActionRuntimeJavaScript, JavaScript: &JavaScriptAction{
+			Main: "index.js", Post: "post.js", PostCondition: testActionSite("env.FLAG == 'true' && github.token != ''"),
+		}},
+	}
+	authority, err := InventoryActionAuthority(actions, ActionInvocation{Lock: "root"}, ActionAuthorityContext{
+		EnvironmentLayers: [][]Binding{
+			{{Name: "FLAG", Value: testWorkflowSite("true")}},
+			{{Name: "FLAG", Value: testWorkflowSite("false")}},
+		},
+		MainEnvironmentMutable: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if authority.GitHubToken {
+		t.Fatal("post condition forgot the stable invocation environment")
+	}
+}
+
+func TestInventoryActionAuthorityRetainsPreparationEnvironmentAfterCompositeWithoutPre(t *testing.T) {
+	actions := map[string]Action{
+		"root": {
+			Source: "github", Runtime: ActionRuntimeComposite,
+			Composite: &CompositeAction{Steps: []CompositeStep{
+				{Invocation: &Invocation{Lock: "composite", Uses: testActionSite("owner/composite@v1")}},
+				{Invocation: &Invocation{Lock: "pre", Uses: testActionSite("owner/pre@v1")}},
+			}},
+		},
+		"composite": {Source: "github", Runtime: ActionRuntimeComposite, Composite: &CompositeAction{}},
+		"pre": {
+			Source: "github", Runtime: ActionRuntimeJavaScript,
+			JavaScript: &JavaScriptAction{Pre: "pre.js", PreCondition: testActionSite("env.FLAG == 'true' && github.token != ''"), Main: "index.js"},
+		},
+	}
+	authority, err := InventoryActionAuthority(actions, ActionInvocation{Lock: "root"}, ActionAuthorityContext{Environment: map[string]string{"FLAG": "false"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if authority.GitHubToken {
+		t.Fatal("remote composite without a pre phase erased the preparation environment")
 	}
 }
 

--- a/internal/program/action_authority_test.go
+++ b/internal/program/action_authority_test.go
@@ -361,6 +361,24 @@ func TestInventoryActionAuthorityForgetsStepEnvironmentDependingOnMutableInherit
 	}
 }
 
+func TestInventoryActionAuthorityRetainsStepEnvironmentResolvedBeforeFirstAction(t *testing.T) {
+	actions := map[string]Action{
+		"root": {Source: "github", Runtime: ActionRuntimeJavaScript, JavaScript: &JavaScriptAction{
+			Main: "index.js", Post: "post.js", PostCondition: testActionSite("env.FLAG == 'true' && github.token != ''"),
+		}},
+	}
+	authority, err := InventoryActionAuthority(actions, ActionInvocation{Lock: "root"}, ActionAuthorityContext{EnvironmentLayers: [][]Binding{
+		{{Name: "BASE", Value: testWorkflowSite("false")}},
+		{{Name: "FLAG", Value: testWorkflowSite("${{ env.BASE }}")}},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if authority.GitHubToken {
+		t.Fatal("post condition forgot the step environment resolved before the first action ran")
+	}
+}
+
 func TestInventoryActionAuthorityEvaluatesChildStableEnvironmentWithParentInputs(t *testing.T) {
 	actions := map[string]Action{
 		"root": {

--- a/internal/program/action_authority_test.go
+++ b/internal/program/action_authority_test.go
@@ -285,6 +285,24 @@ func TestInventoryActionAuthorityTreatsLaterAbsentInputAsEmptyInDefault(t *testi
 	}
 }
 
+func TestInventoryActionAuthorityTreatsLaterDefaultedInputAsNullDuringEarlierDefault(t *testing.T) {
+	token := testActionSite("${{ toJSON(inputs.z_later) == 'null' && github.token || '' }}")
+	later := testActionSite("later")
+	actions := map[string]Action{
+		"root": {
+			Source: "workspace", Runtime: ActionRuntimeComposite,
+			Inputs: []ActionInput{{Name: "a_token", Default: &token}, {Name: "z_later", Default: &later}}, Composite: &CompositeAction{},
+		},
+	}
+	authority, err := InventoryActionAuthority(actions, ActionInvocation{Lock: "root"}, ActionAuthorityContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !authority.GitHubToken {
+		t.Fatal("later defaulted input did not behave as null while resolving an earlier default")
+	}
+}
+
 func TestInventoryActionAuthorityKeepsRuntimeDependentDefaultErrorsConservative(t *testing.T) {
 	defaultValue := testActionSite("${{ inputs.enabled && fromJSON('bad') && github.token || '' }}")
 	actions := map[string]Action{
@@ -616,6 +634,37 @@ func TestInventoryActionAuthorityPreparesOnlyFieldsUsedByChildLifecycle(t *testi
 				t.Fatalf("GitHub token authority = %v, want %v", authority.GitHubToken, test.wantToken)
 			}
 		})
+	}
+}
+
+func TestInventoryActionAuthorityForgetsNestedPreparationEnvironmentAfterEveryPre(t *testing.T) {
+	actions := map[string]Action{
+		"root": {
+			Source: "github", Runtime: ActionRuntimeComposite,
+			Composite: &CompositeAction{Steps: []CompositeStep{
+				{Invocation: &Invocation{Lock: "first", Uses: testActionSite("owner/first@v1")}},
+				{Env: []Binding{{Name: "FLAG", Value: testActionSite("false")}}, Invocation: &Invocation{Lock: "nested", Uses: testActionSite("owner/nested@v1")}},
+			}},
+		},
+		"first": {Source: "github", Runtime: ActionRuntimeJavaScript, JavaScript: &JavaScriptAction{Pre: "pre.js", Main: "index.js"}},
+		"nested": {
+			Source: "github", Runtime: ActionRuntimeComposite,
+			Composite: &CompositeAction{Steps: []CompositeStep{
+				{Invocation: &Invocation{Lock: "mutator", Uses: testActionSite("owner/mutator@v1")}},
+				{Invocation: &Invocation{Lock: "guarded", Uses: testActionSite("owner/guarded@v1")}},
+			}},
+		},
+		"mutator": {Source: "github", Runtime: ActionRuntimeJavaScript, JavaScript: &JavaScriptAction{Pre: "pre.js", Main: "index.js"}},
+		"guarded": {Source: "github", Runtime: ActionRuntimeJavaScript, JavaScript: &JavaScriptAction{
+			Pre: "pre.js", PreCondition: testActionSite("env.FLAG == 'true' && github.token != ''"), Main: "index.js",
+		}},
+	}
+	authority, err := InventoryActionAuthority(actions, ActionInvocation{Lock: "root", Condition: testWorkflowSite("false")}, ActionAuthorityContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !authority.GitHubToken {
+		t.Fatal("an earlier nested pre did not make the later preparation environment conservative")
 	}
 }
 

--- a/internal/program/action_authority_test.go
+++ b/internal/program/action_authority_test.go
@@ -394,6 +394,30 @@ func TestWorkflowEnvironmentMutableBeforeUsesStepEnvironmentAndBackgroundBarrier
 	if !mutable {
 		t.Fatal("background barrier did not make committed environment mutable")
 	}
+	waitAll := []Step{
+		{ID: "Mixed-Case", Background: true, Run: &Run{Command: testWorkflowSite("echo background")}},
+		{Kind: "wait-all"},
+		{Run: &Run{Command: testWorkflowSite("echo target")}},
+	}
+	mutable, err = WorkflowEnvironmentMutableBefore(waitAll, 2, ActionAuthorityContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !mutable {
+		t.Fatal("wait-all did not make committed background environment mutable")
+	}
+	caseInsensitiveTarget := []Step{
+		waitAll[0],
+		{Kind: "wait", Targets: []string{"mixed-case"}},
+		waitAll[2],
+	}
+	mutable, err = WorkflowEnvironmentMutableBefore(caseInsensitiveTarget, 2, ActionAuthorityContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !mutable {
+		t.Fatal("case-insensitive background target did not commit mutable environment")
+	}
 }
 
 func TestInventoryActionAuthorityRetainsPreparationEnvironmentAfterCompositeWithoutPre(t *testing.T) {

--- a/internal/program/action_authority_test.go
+++ b/internal/program/action_authority_test.go
@@ -340,7 +340,7 @@ func TestInventoryActionAuthorityRetainsStableInvocationEnvironmentForPost(t *te
 	}
 }
 
-func TestInventoryActionAuthorityEvaluatesStableInvocationEnvironmentBeforeMainMutation(t *testing.T) {
+func TestInventoryActionAuthorityForgetsStepEnvironmentDependingOnMutableInheritedEnvironment(t *testing.T) {
 	actions := map[string]Action{
 		"root": {Source: "github", Runtime: ActionRuntimeJavaScript, JavaScript: &JavaScriptAction{
 			Main: "index.js", Post: "post.js", PostCondition: testActionSite("env.FLAG == 'true' && github.token != ''"),
@@ -356,8 +356,8 @@ func TestInventoryActionAuthorityEvaluatesStableInvocationEnvironmentBeforeMainM
 	if err != nil {
 		t.Fatal(err)
 	}
-	if authority.GitHubToken {
-		t.Fatal("post condition forgot the invocation environment resolved before main ran")
+	if !authority.GitHubToken {
+		t.Fatal("step environment depending on a mutable inherited value pruned a token path")
 	}
 }
 
@@ -426,12 +426,26 @@ func TestWorkflowEnvironmentMutableBeforeSkipsKnownFalseSteps(t *testing.T) {
 		{Condition: testWorkflowSite("matrix.enabled"), Run: &Run{Command: testWorkflowSite("echo skipped")}},
 		{Run: &Run{Command: testWorkflowSite("echo target")}},
 	}
-	mutable, err := WorkflowEnvironmentMutableBefore(steps, 1, ActionAuthorityContext{Matrix: map[string]any{"enabled": false}})
+	mutable, err := WorkflowEnvironmentMutableBefore(steps, 1, ActionAuthorityContext{Matrix: map[string]any{"enabled": false}}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if mutable {
 		t.Fatal("known-false earlier workflow step made environment mutable")
+	}
+}
+
+func TestWorkflowEnvironmentMutableBeforeSkipsImmutableInvocation(t *testing.T) {
+	steps := []Step{
+		{Invocation: &Invocation{Uses: testWorkflowSite("actions/checkout@v4")}},
+		{Run: &Run{Command: testWorkflowSite("echo target")}},
+	}
+	mutable, err := WorkflowEnvironmentMutableBefore(steps, 1, ActionAuthorityContext{}, map[int]bool{0: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mutable {
+		t.Fatal("immutable invocation made the environment mutable")
 	}
 }
 
@@ -442,7 +456,7 @@ func TestWorkflowEnvironmentMutableBeforeUsesStepEnvironmentAndBackgroundBarrier
 		{Env: stepEnv, Condition: testWorkflowSite("env.ENABLED == 'true'"), Run: &Run{Command: testWorkflowSite("echo foreground")}},
 		{Run: &Run{Command: testWorkflowSite("echo target")}},
 	}
-	mutable, err := WorkflowEnvironmentMutableBefore(foreground, 1, ActionAuthorityContext{EnvironmentLayers: [][]Binding{jobEnv}})
+	mutable, err := WorkflowEnvironmentMutableBefore(foreground, 1, ActionAuthorityContext{EnvironmentLayers: [][]Binding{jobEnv}}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -454,7 +468,7 @@ func TestWorkflowEnvironmentMutableBeforeUsesStepEnvironmentAndBackgroundBarrier
 		{ID: "background", Background: true, Run: &Run{Command: testWorkflowSite("echo background")}},
 		{Run: &Run{Command: testWorkflowSite("echo target")}},
 	}
-	mutable, err = WorkflowEnvironmentMutableBefore(background, 1, ActionAuthorityContext{})
+	mutable, err = WorkflowEnvironmentMutableBefore(background, 1, ActionAuthorityContext{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -466,7 +480,7 @@ func TestWorkflowEnvironmentMutableBeforeUsesStepEnvironmentAndBackgroundBarrier
 		{Kind: "wait", Targets: []string{"background"}},
 		{Run: &Run{Command: testWorkflowSite("echo target")}},
 	}
-	mutable, err = WorkflowEnvironmentMutableBefore(barrier, 2, ActionAuthorityContext{})
+	mutable, err = WorkflowEnvironmentMutableBefore(barrier, 2, ActionAuthorityContext{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -478,7 +492,7 @@ func TestWorkflowEnvironmentMutableBeforeUsesStepEnvironmentAndBackgroundBarrier
 		{Kind: "wait-all"},
 		{Run: &Run{Command: testWorkflowSite("echo target")}},
 	}
-	mutable, err = WorkflowEnvironmentMutableBefore(waitAll, 2, ActionAuthorityContext{})
+	mutable, err = WorkflowEnvironmentMutableBefore(waitAll, 2, ActionAuthorityContext{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -490,7 +504,7 @@ func TestWorkflowEnvironmentMutableBeforeUsesStepEnvironmentAndBackgroundBarrier
 		{Kind: "wait", Targets: []string{"mixed-case"}},
 		waitAll[2],
 	}
-	mutable, err = WorkflowEnvironmentMutableBefore(caseInsensitiveTarget, 2, ActionAuthorityContext{})
+	mutable, err = WorkflowEnvironmentMutableBefore(caseInsensitiveTarget, 2, ActionAuthorityContext{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -706,6 +720,25 @@ func TestInventoryActionAuthorityForgetsEnvironmentAfterExecutableStep(t *testin
 	}
 	if !authority.GitHubToken {
 		t.Fatal("a preceding executable step did not make the later environment guard conservative")
+	}
+}
+
+func TestInventoryActionAuthorityForgetsExplicitEnvironmentAfterCompositeRun(t *testing.T) {
+	actions := map[string]Action{
+		"root": {
+			Source: "workspace", Runtime: ActionRuntimeComposite,
+			Composite: &CompositeAction{Steps: []CompositeStep{
+				{Run: &Run{Command: testActionSite("echo FLAG=true >> $GITHUB_ENV")}},
+				{Condition: testActionSite("env.FLAG == 'true'"), Run: &Run{Command: testActionSite("echo ${{ github.token }}")}},
+			}},
+		},
+	}
+	authority, err := InventoryActionAuthority(actions, ActionInvocation{Lock: "root"}, ActionAuthorityContext{EnvironmentLayers: [][]Binding{{{Name: "FLAG", Value: testWorkflowSite("false")}}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !authority.GitHubToken {
+		t.Fatal("composite run restored an explicit environment value after it could be overwritten")
 	}
 }
 

--- a/internal/program/action_authority_test.go
+++ b/internal/program/action_authority_test.go
@@ -124,6 +124,20 @@ func TestInventoryActionAuthorityTreatsOmittedOptionalInputAsEmpty(t *testing.T)
 	}
 }
 
+func TestInventoryActionAuthorityKeepsRuntimeDependentDefaultErrorsConservative(t *testing.T) {
+	defaultValue := testActionSite("${{ inputs.enabled && fromJSON('bad') && github.token || '' }}")
+	actions := map[string]Action{
+		"root": {Source: "workspace", Runtime: ActionRuntimeComposite, Inputs: []ActionInput{{Name: "token", Default: &defaultValue}}, Composite: &CompositeAction{}},
+	}
+	authority, err := InventoryActionAuthority(actions, ActionInvocation{Lock: "root"}, ActionAuthorityContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !authority.GitHubToken {
+		t.Fatal("runtime-dependent default error did not retain conservative token authority")
+	}
+}
+
 func TestInventoryActionAuthorityDoesNotGrantWholeGitHubContextFromCompositeMetadata(t *testing.T) {
 	actions := map[string]Action{
 		"root": {

--- a/internal/program/action_authority_test.go
+++ b/internal/program/action_authority_test.go
@@ -170,6 +170,21 @@ func TestInventoryActionAuthorityTreatsOmittedOptionalInputAsEmpty(t *testing.T)
 	}
 }
 
+func TestInventoryActionAuthorityTreatsOmittedOptionalInputAsNull(t *testing.T) {
+	actions := map[string]Action{
+		"root": {Source: "workspace", Runtime: ActionRuntimeComposite, Inputs: []ActionInput{{Name: "publish"}}, Composite: &CompositeAction{Steps: []CompositeStep{{
+			Condition: testActionSite("toJSON(inputs.publish) == 'null'"), Run: &Run{Command: testActionSite("echo ${{ github.token }}")},
+		}}}},
+	}
+	authority, err := InventoryActionAuthority(actions, ActionInvocation{Lock: "root"}, ActionAuthorityContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !authority.GitHubToken {
+		t.Fatal("omitted optional input did not behave as null when referenced directly")
+	}
+}
+
 func TestInventoryActionAuthorityKeepsOmittedOptionalInputOutOfAggregate(t *testing.T) {
 	actions := map[string]Action{
 		"root": {Source: "workspace", Runtime: ActionRuntimeComposite, Inputs: []ActionInput{{Name: "publish"}}, Composite: &CompositeAction{Steps: []CompositeStep{{
@@ -328,6 +343,31 @@ func TestInventoryActionAuthorityEvaluatesChildStableEnvironmentWithParentInputs
 	}
 	if authority.GitHubToken {
 		t.Fatal("child post condition did not evaluate stable environment with parent action inputs")
+	}
+}
+
+func TestInventoryActionAuthorityResolvesChildInputsBeforeChildEnvironment(t *testing.T) {
+	actions := map[string]Action{
+		"root": {
+			Source: "workspace", Runtime: ActionRuntimeComposite,
+			Composite: &CompositeAction{Steps: []CompositeStep{{
+				Env:        []Binding{{Name: "FLAG", Value: testActionSite("false")}},
+				Invocation: &Invocation{Lock: "child", Uses: testActionSite("./child"), With: []Binding{{Name: "enabled", Value: testActionSite("${{ env.FLAG }}")}}},
+			}}},
+		},
+		"child": {
+			Source: "workspace", Runtime: ActionRuntimeComposite, Inputs: []ActionInput{{Name: "enabled"}},
+			Composite: &CompositeAction{Steps: []CompositeStep{{
+				Condition: testActionSite("inputs.enabled == 'true'"), Run: &Run{Command: testActionSite("echo ${{ github.token }}")},
+			}}},
+		},
+	}
+	authority, err := InventoryActionAuthority(actions, ActionInvocation{Lock: "root"}, ActionAuthorityContext{Environment: map[string]string{"FLAG": "true"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !authority.GitHubToken {
+		t.Fatal("child input used the child environment instead of the parent environment")
 	}
 }
 
@@ -596,6 +636,29 @@ func TestInventoryActionAuthorityForgetsEnvironmentAfterExecutableStep(t *testin
 	}
 	if !authority.GitHubToken {
 		t.Fatal("a preceding executable step did not make the later environment guard conservative")
+	}
+}
+
+func TestInventoryActionAuthorityForgetsParentEnvironmentAfterChildAction(t *testing.T) {
+	actions := map[string]Action{
+		"root": {
+			Source: "workspace", Runtime: ActionRuntimeComposite,
+			Composite: &CompositeAction{Steps: []CompositeStep{
+				{Invocation: &Invocation{Lock: "child", Uses: testActionSite("./child")}},
+				{Condition: testActionSite("env.FLAG == 'true'"), Run: &Run{Command: testActionSite("echo ${{ github.token }}")}},
+			}},
+		},
+		"child": {
+			Source: "workspace", Runtime: ActionRuntimeComposite,
+			Composite: &CompositeAction{Steps: []CompositeStep{{Run: &Run{Command: testActionSite("echo FLAG=true >> $GITHUB_ENV")}}}},
+		},
+	}
+	authority, err := InventoryActionAuthority(actions, ActionInvocation{Lock: "root"}, ActionAuthorityContext{Environment: map[string]string{"FLAG": "false"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !authority.GitHubToken {
+		t.Fatal("a child action could not override the parent environment for a later sibling")
 	}
 }
 

--- a/internal/program/action_authority_test.go
+++ b/internal/program/action_authority_test.go
@@ -81,6 +81,49 @@ func TestInventoryActionAuthorityIncludesRemotePreWhenMainIsSkipped(t *testing.T
 	}
 }
 
+func TestInventoryActionAuthorityUsesWorkflowInputsForLifecycleConditions(t *testing.T) {
+	token := testActionSite("${{ github.token }}")
+	actions := map[string]Action{
+		"root": {
+			Source: "github", Runtime: ActionRuntimeJavaScript, Inputs: []ActionInput{{Name: "publish"}, {Name: "token", Default: &token}},
+			JavaScript: &JavaScriptAction{Pre: "pre.js", PreCondition: testActionSite("inputs.publish == 'true'"), Main: "index.js"},
+		},
+	}
+	authority, err := InventoryActionAuthority(actions, ActionInvocation{Lock: "root", Condition: testWorkflowSite("false"), Inputs: []Binding{{Name: "publish", Value: testWorkflowSite("false")}}}, ActionAuthorityContext{WorkflowInputs: map[string]any{"publish": "true"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !authority.GitHubToken {
+		t.Fatal("workflow input used by pre-if did not grant GitHub token authority")
+	}
+}
+
+func TestInventoryActionAuthorityIncludesRemoteCompositePreparationInputs(t *testing.T) {
+	actions := map[string]Action{
+		"root": {Source: "github", Runtime: ActionRuntimeComposite, Inputs: []ActionInput{{Name: "token"}}, Composite: &CompositeAction{}},
+	}
+	authority, err := InventoryActionAuthority(actions, ActionInvocation{Lock: "root", Condition: testWorkflowSite("false"), Inputs: []Binding{{Name: "token", Value: testWorkflowSite("${{ github.token }}")}}}, ActionAuthorityContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !authority.GitHubToken {
+		t.Fatal("remote composite preparation input did not grant GitHub token authority")
+	}
+}
+
+func TestInventoryActionAuthorityTreatsOmittedOptionalInputAsEmpty(t *testing.T) {
+	actions := map[string]Action{
+		"root": {Source: "workspace", Runtime: ActionRuntimeComposite, Inputs: []ActionInput{{Name: "publish"}}, Composite: &CompositeAction{Steps: []CompositeStep{{Condition: testActionSite("inputs.publish == 'true'"), Run: &Run{Command: testActionSite("echo ${{ github.token }}")}}}}},
+	}
+	authority, err := InventoryActionAuthority(actions, ActionInvocation{Lock: "root"}, ActionAuthorityContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if authority.GitHubToken {
+		t.Fatal("omitted optional input kept an unreachable token branch alive")
+	}
+}
+
 func TestInventoryActionAuthorityDoesNotGrantWholeGitHubContextFromCompositeMetadata(t *testing.T) {
 	actions := map[string]Action{
 		"root": {

--- a/internal/program/action_authority_test.go
+++ b/internal/program/action_authority_test.go
@@ -138,6 +138,62 @@ func TestInventoryActionAuthorityKeepsRuntimeDependentDefaultErrorsConservative(
 	}
 }
 
+func TestInventoryActionAuthorityKeepsRuntimeDependentSuppliedInputErrorsConservative(t *testing.T) {
+	actions := map[string]Action{
+		"root": {Source: "workspace", Runtime: ActionRuntimeComposite, Inputs: []ActionInput{{Name: "value"}}, Composite: &CompositeAction{}},
+	}
+	authority, err := InventoryActionAuthority(actions, ActionInvocation{
+		Lock: "root", Inputs: []Binding{{Name: "value", Value: testWorkflowSite("${{ inputs.enabled && fromJSON('bad') || '' }}")}},
+	}, ActionAuthorityContext{UnknownWorkflowInputs: map[string]bool{"enabled": true}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if authority.GitHubToken {
+		t.Fatal("runtime-dependent tokenless supplied input requested token authority")
+	}
+}
+
+func TestInventoryActionAuthorityKeepsRuntimeDependentCompositeAnalysisConservative(t *testing.T) {
+	actions := map[string]Action{
+		"root": {
+			Source: "workspace", Runtime: ActionRuntimeComposite, Inputs: []ActionInput{{Name: "enabled"}},
+			Composite: &CompositeAction{Steps: []CompositeStep{{
+				Condition: testActionSite("inputs.enabled && fromJSON('bad')"),
+				Run:       &Run{Command: testActionSite("echo ${{ github.token }}")},
+			}}},
+		},
+	}
+	authority, err := InventoryActionAuthority(actions, ActionInvocation{
+		Lock: "root", Inputs: []Binding{{Name: "enabled", Value: testWorkflowSite("${{ inputs.enabled }}")}},
+	}, ActionAuthorityContext{UnknownWorkflowInputs: map[string]bool{"enabled": true}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !authority.GitHubToken {
+		t.Fatal("runtime-dependent composite condition did not keep token branch reachable")
+	}
+}
+
+func TestInventoryActionAuthorityKeepsRuntimeDependentMetadataTokenConservative(t *testing.T) {
+	actions := map[string]Action{
+		"root": {
+			Source: "workspace", Runtime: ActionRuntimeComposite, Inputs: []ActionInput{{Name: "enabled"}},
+			Composite: &CompositeAction{Steps: []CompositeStep{{Run: &Run{
+				Command: testActionSite("echo ${{ inputs.enabled && fromJSON('bad') && github.token || '' }}"),
+			}}}},
+		},
+	}
+	authority, err := InventoryActionAuthority(actions, ActionInvocation{
+		Lock: "root", Inputs: []Binding{{Name: "enabled", Value: testWorkflowSite("${{ inputs.enabled }}")}},
+	}, ActionAuthorityContext{UnknownWorkflowInputs: map[string]bool{"enabled": true}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !authority.GitHubToken {
+		t.Fatal("runtime-dependent metadata error did not retain conservative token authority")
+	}
+}
+
 func TestInventoryActionAuthorityDoesNotGrantWholeGitHubContextFromCompositeMetadata(t *testing.T) {
 	actions := map[string]Action{
 		"root": {

--- a/internal/program/action_authority_test.go
+++ b/internal/program/action_authority_test.go
@@ -356,6 +356,46 @@ func TestWorkflowEnvironmentMutableBeforeSkipsKnownFalseSteps(t *testing.T) {
 	}
 }
 
+func TestWorkflowEnvironmentMutableBeforeUsesStepEnvironmentAndBackgroundBarriers(t *testing.T) {
+	jobEnv := []Binding{{Name: "ENABLED", Value: testWorkflowSite("false")}}
+	stepEnv := []Binding{{Name: "ENABLED", Value: testWorkflowSite("true")}}
+	foreground := []Step{
+		{Env: stepEnv, Condition: testWorkflowSite("env.ENABLED == 'true'"), Run: &Run{Command: testWorkflowSite("echo foreground")}},
+		{Run: &Run{Command: testWorkflowSite("echo target")}},
+	}
+	mutable, err := WorkflowEnvironmentMutableBefore(foreground, 1, ActionAuthorityContext{EnvironmentLayers: [][]Binding{jobEnv}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !mutable {
+		t.Fatal("step environment did not make an earlier foreground step reachable")
+	}
+
+	background := []Step{
+		{ID: "background", Background: true, Run: &Run{Command: testWorkflowSite("echo background")}},
+		{Run: &Run{Command: testWorkflowSite("echo target")}},
+	}
+	mutable, err = WorkflowEnvironmentMutableBefore(background, 1, ActionAuthorityContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mutable {
+		t.Fatal("unawaited background step made environment immediately mutable")
+	}
+	barrier := []Step{
+		background[0],
+		{Kind: "wait", Targets: []string{"background"}},
+		{Run: &Run{Command: testWorkflowSite("echo target")}},
+	}
+	mutable, err = WorkflowEnvironmentMutableBefore(barrier, 2, ActionAuthorityContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !mutable {
+		t.Fatal("background barrier did not make committed environment mutable")
+	}
+}
+
 func TestInventoryActionAuthorityRetainsPreparationEnvironmentAfterCompositeWithoutPre(t *testing.T) {
 	actions := map[string]Action{
 		"root": {

--- a/internal/program/action_authority_test.go
+++ b/internal/program/action_authority_test.go
@@ -1,0 +1,159 @@
+package program
+
+import "testing"
+
+func TestInventoryActionAuthorityNarrowsActionDefaultsByProvider(t *testing.T) {
+	value := testActionSite("${{ github.server_url == 'https://github.com' && github.token || '' }}")
+	actions := map[string]Action{
+		"root": {Source: "workspace", Runtime: ActionRuntimeJavaScript, Inputs: []ActionInput{{Name: "token", Default: &value}}, JavaScript: &JavaScriptAction{Main: "index.js"}},
+	}
+	for _, test := range []struct {
+		name      string
+		serverURL string
+		wantToken bool
+	}{
+		{name: "GitHub", serverURL: "https://github.com", wantToken: true},
+		{name: "Origin", serverURL: "https://origin.cursor.com"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			authority, err := InventoryActionAuthority(actions, ActionInvocation{Lock: "root"}, ActionAuthorityContext{ServerURL: test.serverURL})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if authority.GitHubToken != test.wantToken {
+				t.Fatalf("GitHub token authority = %v, want %v", authority.GitHubToken, test.wantToken)
+			}
+		})
+	}
+}
+
+func TestInventoryActionAuthorityFollowsCompositeReachability(t *testing.T) {
+	actions := map[string]Action{
+		"root": {
+			Source:  "workspace",
+			Runtime: ActionRuntimeComposite,
+			Inputs:  []ActionInput{{Name: "enabled"}},
+			Composite: &CompositeAction{Steps: []CompositeStep{{
+				Condition: testActionSite("inputs.enabled == 'true'"),
+				Run:       &Run{Command: testActionSite("echo ${{ github.token }}")},
+			}}},
+		},
+	}
+	for _, test := range []struct {
+		name      string
+		input     string
+		context   ActionAuthorityContext
+		wantToken bool
+	}{
+		{name: "known false", input: "${{ false }}"},
+		{name: "known true", input: "${{ true }}", wantToken: true},
+		{name: "unknown", input: "${{ matrix.enabled }}", wantToken: true},
+		{name: "known matrix false", input: "${{ matrix.enabled }}", context: ActionAuthorityContext{Matrix: map[string]any{"enabled": false}}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			authority, err := InventoryActionAuthority(actions, ActionInvocation{Lock: "root", Inputs: []Binding{{Name: "enabled", Value: testWorkflowSite(test.input)}}}, test.context)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if authority.GitHubToken != test.wantToken {
+				t.Fatalf("GitHub token authority = %v, want %v", authority.GitHubToken, test.wantToken)
+			}
+		})
+	}
+}
+
+func TestInventoryActionAuthorityIncludesRemotePreWhenMainIsSkipped(t *testing.T) {
+	value := testActionSite("${{ github.token }}")
+	actions := map[string]Action{
+		"root": {
+			Source:     "github",
+			Runtime:    ActionRuntimeJavaScript,
+			Inputs:     []ActionInput{{Name: "token", Default: &value}},
+			JavaScript: &JavaScriptAction{Pre: "pre.js", Main: "index.js"},
+		},
+	}
+	authority, err := InventoryActionAuthority(actions, ActionInvocation{Lock: "root", Condition: testWorkflowSite("false")}, ActionAuthorityContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !authority.GitHubToken {
+		t.Fatal("remote pre-if did not grant GitHub token authority when the main step was skipped")
+	}
+}
+
+func TestInventoryActionAuthorityDoesNotGrantWholeGitHubContextFromCompositeMetadata(t *testing.T) {
+	actions := map[string]Action{
+		"root": {
+			Source:    "workspace",
+			Runtime:   ActionRuntimeComposite,
+			Composite: &CompositeAction{Steps: []CompositeStep{{Run: &Run{Command: testActionSite("echo ${{ toJSON(github) }}")}}}},
+		},
+	}
+	authority, err := InventoryActionAuthority(actions, ActionInvocation{Lock: "root"}, ActionAuthorityContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if authority.GitHubToken {
+		t.Fatal("composite-authored toJSON(github) granted GitHub token authority")
+	}
+}
+
+func TestInventoryActionAuthorityPreparesOnlyFieldsUsedByChildLifecycle(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		pre       string
+		wantToken bool
+	}{
+		{name: "child without pre"},
+		{name: "child with pre", pre: "pre.js", wantToken: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			actions := map[string]Action{
+				"root": {
+					Source:  "github",
+					Runtime: ActionRuntimeComposite,
+					Composite: &CompositeAction{Steps: []CompositeStep{{
+						Env:        []Binding{{Name: "TOKEN", Value: testActionSite("${{ github.token }}")}},
+						Invocation: &Invocation{Lock: "child", Uses: testActionSite("owner/child@v1")},
+					}}},
+				},
+				"child": {Source: "github", Runtime: ActionRuntimeJavaScript, JavaScript: &JavaScriptAction{Pre: test.pre, Main: "index.js"}},
+			}
+			authority, err := InventoryActionAuthority(actions, ActionInvocation{Lock: "root", Condition: testWorkflowSite("false")}, ActionAuthorityContext{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if authority.GitHubToken != test.wantToken {
+				t.Fatalf("GitHub token authority = %v, want %v", authority.GitHubToken, test.wantToken)
+			}
+		})
+	}
+}
+
+func TestInventoryActionAuthorityForgetsEnvironmentAfterExecutableStep(t *testing.T) {
+	actions := map[string]Action{
+		"root": {
+			Source:  "workspace",
+			Runtime: ActionRuntimeComposite,
+			Composite: &CompositeAction{Steps: []CompositeStep{
+				{Run: &Run{Command: testActionSite("echo FLAG=true >> $GITHUB_ENV")}},
+				{Condition: testActionSite("env.FLAG == 'true'"), Run: &Run{Command: testActionSite("echo ${{ github.token }}")}},
+			}},
+		},
+	}
+	authority, err := InventoryActionAuthority(actions, ActionInvocation{Lock: "root"}, ActionAuthorityContext{Environment: map[string]string{"FLAG": "false"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !authority.GitHubToken {
+		t.Fatal("a preceding executable step did not make the later environment guard conservative")
+	}
+}
+
+func testActionSite(source string) Site {
+	return Site{Source: source, Provenance: ProvenanceAction}
+}
+
+func testWorkflowSite(source string) Site {
+	return Site{Source: source, Provenance: ProvenanceWorkflow}
+}

--- a/internal/program/action_authority_test.go
+++ b/internal/program/action_authority_test.go
@@ -307,6 +307,55 @@ func TestInventoryActionAuthorityRetainsStableInvocationEnvironmentForPost(t *te
 	}
 }
 
+func TestInventoryActionAuthorityEvaluatesChildStableEnvironmentWithParentInputs(t *testing.T) {
+	actions := map[string]Action{
+		"root": {
+			Source: "workspace", Runtime: ActionRuntimeComposite, Inputs: []ActionInput{{Name: "enabled"}},
+			Composite: &CompositeAction{Steps: []CompositeStep{{
+				Env:        []Binding{{Name: "FLAG", Value: testActionSite("${{ inputs.enabled }}")}},
+				Invocation: &Invocation{Lock: "child", Uses: testActionSite("./child")},
+			}}},
+		},
+		"child": {Source: "workspace", Runtime: ActionRuntimeJavaScript, JavaScript: &JavaScriptAction{
+			Main: "index.js", Post: "post.js", PostCondition: testActionSite("env.FLAG == 'true' && github.token != ''"),
+		}},
+	}
+	authority, err := InventoryActionAuthority(actions, ActionInvocation{
+		Lock: "root", Inputs: []Binding{{Name: "enabled", Value: testWorkflowSite("false")}},
+	}, ActionAuthorityContext{MainEnvironmentMutable: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if authority.GitHubToken {
+		t.Fatal("child post condition did not evaluate stable environment with parent action inputs")
+	}
+}
+
+func TestInventoryActionAuthorityRejectsInvalidCompositeConditionAfterAnalysisError(t *testing.T) {
+	actions := map[string]Action{
+		"root": {Source: "workspace", Runtime: ActionRuntimeComposite, Composite: &CompositeAction{Steps: []CompositeStep{{
+			Condition: testActionSite("secrets.UNSUPPORTED != ''"), Run: &Run{Command: testActionSite("echo ok")},
+		}}}},
+	}
+	if _, err := InventoryActionAuthority(actions, ActionInvocation{Lock: "root"}, ActionAuthorityContext{}); err == nil {
+		t.Fatal("invalid composite condition passed token-only fallback")
+	}
+}
+
+func TestWorkflowEnvironmentMutableBeforeSkipsKnownFalseSteps(t *testing.T) {
+	steps := []Step{
+		{Condition: testWorkflowSite("matrix.enabled"), Run: &Run{Command: testWorkflowSite("echo skipped")}},
+		{Run: &Run{Command: testWorkflowSite("echo target")}},
+	}
+	mutable, err := WorkflowEnvironmentMutableBefore(steps, 1, ActionAuthorityContext{Matrix: map[string]any{"enabled": false}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mutable {
+		t.Fatal("known-false earlier workflow step made environment mutable")
+	}
+}
+
 func TestInventoryActionAuthorityRetainsPreparationEnvironmentAfterCompositeWithoutPre(t *testing.T) {
 	actions := map[string]Action{
 		"root": {

--- a/internal/program/action_authority_test.go
+++ b/internal/program/action_authority_test.go
@@ -257,6 +257,36 @@ func TestInventoryActionAuthorityDoesNotGrantWholeGitHubContextFromCompositeMeta
 	}
 }
 
+func TestInventoryActionAuthorityIncludesCompositeConditionToken(t *testing.T) {
+	actions := map[string]Action{
+		"root": {Source: "workspace", Runtime: ActionRuntimeComposite, Composite: &CompositeAction{Steps: []CompositeStep{{
+			Condition: testActionSite("github.token != ''"), Run: &Run{Command: testActionSite("echo ok")},
+		}}}},
+	}
+	authority, err := InventoryActionAuthority(actions, ActionInvocation{Lock: "root"}, ActionAuthorityContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !authority.GitHubToken {
+		t.Fatal("composite condition did not grant GitHub token authority")
+	}
+}
+
+func TestInventoryActionAuthorityIgnoresUnevaluatedCompositeName(t *testing.T) {
+	actions := map[string]Action{
+		"root": {Source: "workspace", Runtime: ActionRuntimeComposite, Composite: &CompositeAction{Steps: []CompositeStep{{
+			Name: testActionSite("${{ github.token }}"), Run: &Run{Command: testActionSite("echo ok")},
+		}}}},
+	}
+	authority, err := InventoryActionAuthority(actions, ActionInvocation{Lock: "root"}, ActionAuthorityContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if authority.GitHubToken {
+		t.Fatal("unevaluated composite name granted GitHub token authority")
+	}
+}
+
 func TestInventoryActionAuthorityPreparesOnlyFieldsUsedByChildLifecycle(t *testing.T) {
 	for _, test := range []struct {
 		name      string

--- a/internal/program/action_authority_test.go
+++ b/internal/program/action_authority_test.go
@@ -170,6 +170,59 @@ func TestInventoryActionAuthorityTreatsOmittedOptionalInputAsEmpty(t *testing.T)
 	}
 }
 
+func TestInventoryActionAuthorityKeepsOmittedOptionalInputOutOfAggregate(t *testing.T) {
+	actions := map[string]Action{
+		"root": {Source: "workspace", Runtime: ActionRuntimeComposite, Inputs: []ActionInput{{Name: "publish"}}, Composite: &CompositeAction{Steps: []CompositeStep{{
+			Condition: testActionSite(`!contains(toJSON(inputs), '"publish"')`), Run: &Run{Command: testActionSite("echo ${{ github.token }}")},
+		}}}},
+	}
+	authority, err := InventoryActionAuthority(actions, ActionInvocation{Lock: "root"}, ActionAuthorityContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !authority.GitHubToken {
+		t.Fatal("omitted optional input appeared in aggregate inputs")
+	}
+}
+
+func TestInventoryActionAuthorityUsesWorkflowInputsForNestedLifecycle(t *testing.T) {
+	token := testActionSite("${{ github.token }}")
+	actions := map[string]Action{
+		"root": {
+			Source: "workspace", Runtime: ActionRuntimeComposite, Inputs: []ActionInput{{Name: "publish"}},
+			Composite: &CompositeAction{Steps: []CompositeStep{{Invocation: &Invocation{Lock: "child", Uses: testActionSite("owner/child@v1")}}}},
+		},
+		"child": {
+			Source: "github", Runtime: ActionRuntimeJavaScript, Inputs: []ActionInput{{Name: "token", Default: &token}},
+			JavaScript: &JavaScriptAction{Pre: "pre.js", PreCondition: testActionSite("inputs.publish == 'true'"), Main: "index.js"},
+		},
+	}
+	authority, err := InventoryActionAuthority(actions, ActionInvocation{
+		Lock: "root", Inputs: []Binding{{Name: "publish", Value: testWorkflowSite("false")}},
+	}, ActionAuthorityContext{WorkflowInputs: map[string]any{"publish": "true"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !authority.GitHubToken {
+		t.Fatal("nested lifecycle condition did not use workflow inputs")
+	}
+}
+
+func TestInventoryActionAuthorityRetainsNestedMatrixReferences(t *testing.T) {
+	actions := map[string]Action{
+		"root": {Source: "workspace", Runtime: ActionRuntimeComposite, Inputs: []ActionInput{{Name: "token"}}, Composite: &CompositeAction{}},
+	}
+	authority, err := InventoryActionAuthority(actions, ActionInvocation{
+		Lock: "root", Inputs: []Binding{{Name: "token", Value: testWorkflowSite("${{ matrix.config.publish && github.token || '' }}")}},
+	}, ActionAuthorityContext{Matrix: map[string]any{"config": map[string]any{"publish": false}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if authority.GitHubToken {
+		t.Fatal("known-false nested matrix value retained GitHub token authority")
+	}
+}
+
 func TestInventoryActionAuthorityKeepsRuntimeDependentDefaultErrorsConservative(t *testing.T) {
 	defaultValue := testActionSite("${{ inputs.enabled && fromJSON('bad') && github.token || '' }}")
 	actions := map[string]Action{

--- a/internal/program/action_authority_test.go
+++ b/internal/program/action_authority_test.go
@@ -81,6 +81,52 @@ func TestInventoryActionAuthorityIncludesRemotePreWhenMainIsSkipped(t *testing.T
 	}
 }
 
+func TestInventoryActionAuthorityIncludesInlineJavaScriptPre(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		actions map[string]Action
+	}{
+		{
+			name: "workspace action",
+			actions: map[string]Action{
+				"root": {Source: "workspace", Runtime: ActionRuntimeJavaScript, JavaScript: &JavaScriptAction{Pre: "pre.js", PreCondition: testActionSite("github.token != ''"), Main: "index.js"}},
+			},
+		},
+		{
+			name: "remote child of workspace composite",
+			actions: map[string]Action{
+				"root":  {Source: "workspace", Runtime: ActionRuntimeComposite, Composite: &CompositeAction{Steps: []CompositeStep{{Invocation: &Invocation{Lock: "child", Uses: testActionSite("owner/child@v1")}}}}},
+				"child": {Source: "github", Runtime: ActionRuntimeJavaScript, JavaScript: &JavaScriptAction{Pre: "pre.js", PreCondition: testActionSite("github.token != ''"), Main: "index.js"}},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			authority, err := InventoryActionAuthority(test.actions, ActionInvocation{Lock: "root"}, ActionAuthorityContext{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !authority.GitHubToken {
+				t.Fatal("inline JavaScript pre-if did not grant GitHub token authority")
+			}
+		})
+	}
+}
+
+func TestInventoryActionAuthorityRetainsConcreteMatrixAggregate(t *testing.T) {
+	actions := map[string]Action{
+		"root": {Source: "workspace", Runtime: ActionRuntimeComposite, Inputs: []ActionInput{{Name: "token"}}, Composite: &CompositeAction{}},
+	}
+	authority, err := InventoryActionAuthority(actions, ActionInvocation{
+		Lock: "root", Inputs: []Binding{{Name: "token", Value: testWorkflowSite(`${{ contains(toJSON(matrix), '"publish": true') && github.token || '' }}`)}},
+	}, ActionAuthorityContext{Matrix: map[string]any{"publish": false}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if authority.GitHubToken {
+		t.Fatal("known-false matrix aggregate retained GitHub token authority")
+	}
+}
+
 func TestInventoryActionAuthorityUsesWorkflowInputsForLifecycleConditions(t *testing.T) {
 	token := testActionSite("${{ github.token }}")
 	actions := map[string]Action{

--- a/internal/program/action_authority_test.go
+++ b/internal/program/action_authority_test.go
@@ -340,6 +340,27 @@ func TestInventoryActionAuthorityRetainsStableInvocationEnvironmentForPost(t *te
 	}
 }
 
+func TestInventoryActionAuthorityEvaluatesStableInvocationEnvironmentBeforeMainMutation(t *testing.T) {
+	actions := map[string]Action{
+		"root": {Source: "github", Runtime: ActionRuntimeJavaScript, JavaScript: &JavaScriptAction{
+			Main: "index.js", Post: "post.js", PostCondition: testActionSite("env.FLAG == 'true' && github.token != ''"),
+		}},
+	}
+	authority, err := InventoryActionAuthority(actions, ActionInvocation{Lock: "root"}, ActionAuthorityContext{
+		EnvironmentLayers: [][]Binding{
+			{{Name: "BASE", Value: testWorkflowSite("false")}},
+			{{Name: "FLAG", Value: testWorkflowSite("${{ env.BASE }}")}},
+		},
+		MainEnvironmentMutable: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if authority.GitHubToken {
+		t.Fatal("post condition forgot the invocation environment resolved before main ran")
+	}
+}
+
 func TestInventoryActionAuthorityEvaluatesChildStableEnvironmentWithParentInputs(t *testing.T) {
 	actions := map[string]Action{
 		"root": {
@@ -708,6 +729,26 @@ func TestInventoryActionAuthorityForgetsParentEnvironmentAfterChildAction(t *tes
 	}
 	if !authority.GitHubToken {
 		t.Fatal("a child action could not override the parent environment for a later sibling")
+	}
+}
+
+func TestInventoryActionAuthorityRetainsEnvironmentAfterNativeChild(t *testing.T) {
+	actions := map[string]Action{
+		"root": {
+			Source: "workspace", Runtime: ActionRuntimeComposite,
+			Composite: &CompositeAction{Steps: []CompositeStep{
+				{Invocation: &Invocation{Lock: "native", Uses: testActionSite("buildkite/native")}},
+				{Condition: testActionSite("env.FLAG == 'true'"), Run: &Run{Command: testActionSite("echo ${{ github.token }}")}},
+			}},
+		},
+		"native": {Source: "native", Runtime: ActionRuntimeNative},
+	}
+	authority, err := InventoryActionAuthority(actions, ActionInvocation{Lock: "root"}, ActionAuthorityContext{Environment: map[string]string{"FLAG": "false"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if authority.GitHubToken {
+		t.Fatal("native child discarded an environment value it cannot change")
 	}
 }
 

--- a/internal/program/authority.go
+++ b/internal/program/authority.go
@@ -14,8 +14,9 @@ type AuthorityOptions struct {
 // Authority is the workflow-authored secret inventory retained by the current
 // plan contract.
 type Authority struct {
-	Secrets     []string
-	GitHubToken bool
+	Secrets                       []string
+	GitHubToken                   bool
+	PreparationEnvironmentMutable bool
 }
 
 // InventoryAuthority validates and inventories every compiler-owned site in

--- a/internal/program/program.go
+++ b/internal/program/program.go
@@ -6,16 +6,20 @@ package program
 type Surface string
 
 const (
-	SurfaceJobCondition      Surface = "job-condition"
-	SurfaceStepCondition     Surface = "step-condition"
-	SurfaceJobEnvironment    Surface = "job-environment"
-	SurfaceJobDefault        Surface = "job-default"
-	SurfaceJobOutput         Surface = "job-output"
-	SurfaceStepTemplate      Surface = "step-template"
-	SurfaceStepControl       Surface = "step-control"
-	SurfaceRuntimeTemplate   Surface = "runtime-template"
-	SurfaceServiceCredential Surface = "service-credential"
-	SurfaceServiceMap        Surface = "service-map"
+	SurfaceJobCondition       Surface = "job-condition"
+	SurfaceStepCondition      Surface = "step-condition"
+	SurfaceJobEnvironment     Surface = "job-environment"
+	SurfaceJobDefault         Surface = "job-default"
+	SurfaceJobOutput          Surface = "job-output"
+	SurfaceStepTemplate       Surface = "step-template"
+	SurfaceStepControl        Surface = "step-control"
+	SurfaceRuntimeTemplate    Surface = "runtime-template"
+	SurfaceServiceCredential  Surface = "service-credential"
+	SurfaceServiceMap         Surface = "service-map"
+	SurfaceActionInputDefault Surface = "action-input-default"
+	SurfaceActionLifecycle    Surface = "action-lifecycle-condition"
+	SurfaceCompositeTemplate  Surface = "composite-template"
+	SurfaceDockerArgument     Surface = "docker-argument"
 )
 
 // ResultType records the value shape required by an expression site.
@@ -28,11 +32,13 @@ const (
 	ResultObject  ResultType = "object"
 )
 
-// Provenance records who authored an expression. Action metadata gains its own
-// provenance when resolved actions are normalized in the next delivery slice.
+// Provenance records who authored an expression.
 type Provenance string
 
-const ProvenanceWorkflow Provenance = "workflow"
+const (
+	ProvenanceWorkflow Provenance = "workflow"
+	ProvenanceAction   Provenance = "action"
+)
 
 // Purpose identifies sites with an authority exception. Supplied action inputs
 // may delegate ordinary-secret inventory to resolved action metadata.
@@ -165,6 +171,121 @@ type Job struct {
 
 type Program struct {
 	Job Job
+}
+
+type ActionRuntime string
+
+const (
+	ActionRuntimeNative     ActionRuntime = "native"
+	ActionRuntimeJavaScript ActionRuntime = "javascript"
+	ActionRuntimeComposite  ActionRuntime = "composite"
+	ActionRuntimeDocker     ActionRuntime = "docker"
+)
+
+type ActionInput struct {
+	Name     string
+	Required bool
+	Default  *Site
+}
+
+type JavaScriptAction struct {
+	NodeMajor     int
+	Pre           string
+	PreCondition  Site
+	Main          string
+	Post          string
+	PostCondition Site
+}
+
+type DockerAction struct {
+	Arguments []Site
+	Env       []Binding
+}
+
+type CompositeStep struct {
+	ID              string
+	Name            Site
+	Condition       Site
+	ContinueOnError bool
+	Env             []Binding
+	Run             *Run
+	Invocation      *Invocation
+}
+
+type CompositeAction struct {
+	Steps []CompositeStep
+}
+
+// Action is the immutable execution model derived from one resolved action
+// manifest. Source locks retain repository identity and tree verification.
+type Action struct {
+	Name       string
+	Source     string
+	Runtime    ActionRuntime
+	Inputs     []ActionInput
+	Outputs    []Binding
+	JavaScript *JavaScriptAction
+	Composite  *CompositeAction
+	Docker     *DockerAction
+	Location   Location
+}
+
+// VisitSites walks every action-authored expression site in lifecycle order.
+func (a Action) VisitSites(visit func(Site) error) error {
+	for _, input := range a.Inputs {
+		if input.Default != nil {
+			if err := visitSite(*input.Default, visit); err != nil {
+				return err
+			}
+		}
+	}
+	if a.JavaScript != nil {
+		if err := visitSite(a.JavaScript.PreCondition, visit); err != nil {
+			return err
+		}
+		if err := visitSite(a.JavaScript.PostCondition, visit); err != nil {
+			return err
+		}
+	}
+	if a.Docker != nil {
+		for _, argument := range a.Docker.Arguments {
+			if err := visitSite(argument, visit); err != nil {
+				return err
+			}
+		}
+		if err := visitBindings(a.Docker.Env, visit); err != nil {
+			return err
+		}
+	}
+	if a.Composite != nil {
+		for _, step := range a.Composite.Steps {
+			if err := visitSite(step.Condition, visit); err != nil {
+				return err
+			}
+			if err := visitSite(step.Name, visit); err != nil {
+				return err
+			}
+			if err := visitBindings(step.Env, visit); err != nil {
+				return err
+			}
+			if step.Run != nil {
+				for _, site := range []Site{step.Run.Command, step.Run.Shell, step.Run.WorkingDirectory} {
+					if err := visitSite(site, visit); err != nil {
+						return err
+					}
+				}
+			}
+			if step.Invocation != nil {
+				if err := visitSite(step.Invocation.Uses, visit); err != nil {
+					return err
+				}
+				if err := visitBindings(step.Invocation.With, visit); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return visitBindings(a.Outputs, visit)
 }
 
 // VisitSites walks every expression-bearing field once in execution order.


### PR DESCRIPTION
## Why

The compiler still treats each resolved `action.yml` as a bag of unrelated fields. That makes token planning depend on remembering every place an expression can appear. For example:

```yaml
runs:
  using: composite
  steps:
    - if: inputs.publish == 'true'
      uses: ./publish
      with:
        token: ${{ github.token }}
```

Whether this needs a token depends on the parent input, the step condition, and whether a remote child runs a `pre` hook before the workflow step itself. Adding support one field at a time is how we keep getting `github.token` papercuts.

This is the third slice of the [expression authority planning design](https://github.com/buildkite/buildkite-gha/blob/main/docs/plans/expression-authority-planning.md), stacked on #367.

## What

The compiler now converts every resolved action manifest into one normalized action program. That program contains its ordered inputs and defaults, JavaScript lifecycle, composite steps and outputs, Docker expressions, source locations, and immutable child-action links.

Token planning then walks that program instead of scanning metadata fields. It uses known workflow inputs, matrix values, environment values, provider URL, conditions, and remote `pre`/`post` behavior. Unknown branches remain conservative, and environment values become unknown after an executable step can change `GITHUB_ENV`.

For example, a default such as `${{ github.server_url == 'https://github.com' && github.token || '' }}` requires a token on GitHub but not on Origin. A composite `if: inputs.publish == 'true'` skips a token-bearing branch when the supplied input is known false, while an unknown input still requests the token safely.

This PR deliberately keeps the current job-plan and runtime wire format. The next stacked slice, #371, carries these normalized programs in the plan and starts moving resolved action execution onto the compiler’s description.

