### PR TITLE
Skip missing configured workflows

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -305,10 +305,13 @@ configuration from `BUILDKITE_PLUGIN_CONFIGURATION`. It accepts:
 - plugin-owned `version`, `source-ref`, and `minimum-release-age` fields
 - the Boolean `experimental-runner-user` field
 
-Each workflow path must be a regular, tracked `.yml` or `.yaml` file inside the
-repository. Directories and globs are rejected. The optional `oidc` object
-accepts non-empty `claims`, `aws-session-tags`, and `subject-claim` values.
-Unknown fields and invalid values fail before upload.
+Missing or untracked workflow paths warn and are skipped. If every configured
+path is missing or untracked, the plugin succeeds without uploading a pipeline.
+Every present path must be a regular, tracked `.yml` or `.yaml` file inside the
+repository. Directories, tracked files missing from the checkout, symlinks, and
+globs are rejected. The optional `oidc` object accepts non-empty `claims`,
+`aws-session-tags`, and `subject-claim` values. Unknown fields and invalid values
+fail before upload.
 
 The plugin resolves relative workflow paths from `BUILDKITE_BUILD_CHECKOUT_PATH`,
 not the command hook's working directory.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -80,15 +80,18 @@ Steps remain inside one job because they share a workspace, environment files, a
 ### Aggregate workflow upload
 
 The plugin accepts either one `workflow` path or a non-empty `workflows` array.
-Each path must be a regular, tracked `.yml` or `.yaml` file inside the
-repository. Directories, missing or untracked files, outside paths, symlinks,
-and globs fail. A custom importer may upload one explicit regular workflow from
-outside the repository.
+Missing or untracked paths warn and are skipped, so removing a workflow does not
+require a simultaneous pipeline configuration change. If every configured path
+is missing or untracked, the importer succeeds without uploading a pipeline.
+Every present path must be a regular, tracked `.yml` or `.yaml` file inside the
+repository. Directories, tracked files missing from the checkout, outside paths,
+symlinks, and globs fail. A custom importer may upload one explicit regular
+workflow from outside the repository.
 
 Before assigning workflow identities and job keys, upload canonicalizes, sorts,
 and deduplicates the paths.
 
-All runnable workflows use one artifact and pipeline transaction:
+All remaining runnable workflows use one artifact and pipeline transaction:
 
 - A compiled workflow becomes a group labeled `:github: workflow ·
   <workflow-name>`. An unnamed workflow uses its canonical path. A resolved,
@@ -120,9 +123,10 @@ with a failing top-level step. The step:
 - limits the check summary to 65,535 bytes
 - exits with status 1
 
-Other workflows continue compiling. Parse, event-input, admission, artifact,
-and upload failures still abort the complete transaction. Upload never publishes
-a partial pipeline.
+Other workflows continue compiling. Missing or untracked configured paths are
+omitted before the transaction. Invalid path states, parse, event-input,
+admission, artifact, and upload failures still abort the complete transaction.
+Upload never publishes a partial pipeline.
 
 If a workflow has both a compiler error and a skip reason, the compiler error
 takes precedence.

--- a/internal/cli/plugin_test.go
+++ b/internal/cli/plugin_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -410,6 +411,61 @@ func TestPluginUploadsPluralWorkflowList(t *testing.T) {
 	}
 	if len(pipeline.Steps) != 2 {
 		t.Fatalf("workflow groups = %#v", pipeline.Steps)
+	}
+}
+
+func TestPluginSkipsMissingWorkflowFromPluralList(t *testing.T) {
+	requireImporterHost(t)
+	repository := writeUploadWorkflowRepository(t, map[string]string{
+		"ci.yml": "name: CI\non: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
+	})
+	configuration, err := json.Marshal(map[string]any{
+		"workflows": []string{".github/workflows/ci.yml", ".github/workflows/deploy.yml"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(pluginConfigurationEnvironment, string(configuration))
+	setCLIPluginBuildkiteEnvironment(t, "plugin-missing-workflow")
+	t.Setenv("BUILDKITE_BUILD_CHECKOUT_PATH", repository)
+	runner := &cliCaptureRunner{}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"plugin"}, &stdout, &stderr, "dev", runner); code != 0 {
+		t.Fatalf("run() code = %d, want 0; stdout = %q; stderr = %q", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Uploaded 1 job") || !strings.Contains(stderr.String(), `warning: workflow path ".github/workflows/deploy.yml" is missing or untracked; skipping`) {
+		t.Fatalf("stdout/stderr = %q / %q", stdout.String(), stderr.String())
+	}
+	if len(runner.commands) == 0 {
+		t.Fatal("present workflow was not uploaded")
+	}
+}
+
+func TestPluginSucceedsWhenAllConfiguredWorkflowsWereRemoved(t *testing.T) {
+	requireImporterHost(t)
+	repository := writeUploadWorkflowRepository(t, map[string]string{
+		"deploy.yml": "name: Deploy\non: push\njobs:\n  deploy:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
+	})
+	if output, err := exec.Command("git", "-C", repository, "rm", "-f", ".github/workflows/deploy.yml").CombinedOutput(); err != nil {
+		t.Fatalf("remove tracked workflow: %v: %s", err, output)
+	}
+	configuration, err := json.Marshal(map[string]any{"workflow": ".github/workflows/deploy.yml"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(pluginConfigurationEnvironment, string(configuration))
+	setCLIPluginBuildkiteEnvironment(t, "plugin-removed-workflow")
+	t.Setenv("BUILDKITE_BUILD_CHECKOUT_PATH", repository)
+	runner := &cliCaptureRunner{}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"plugin"}, &stdout, &stderr, "dev", runner); code != 0 {
+		t.Fatalf("run() code = %d, want 0; stdout = %q; stderr = %q", code, stdout.String(), stderr.String())
+	}
+	if stdout.Len() != 0 || !strings.Contains(stderr.String(), `warning: workflow path ".github/workflows/deploy.yml" is missing or untracked; skipping`) || !strings.Contains(stderr.String(), "all configured workflow paths are missing or untracked; there is nothing to upload") {
+		t.Fatalf("stdout/stderr = %q / %q", stdout.String(), stderr.String())
+	}
+	if len(runner.commands) != 0 || len(runner.uploaded) != 0 {
+		t.Fatalf("all-missing selection reached Buildkite: commands %#v, uploads %#v", runner.commands, runner.uploaded)
 	}
 }
 

--- a/internal/cli/upload.go
+++ b/internal/cli/upload.go
@@ -698,7 +698,7 @@ func expandExplicitWorkflowPaths(operands []string, checkoutPath string) ([]work
 		}
 		entries := bytes.Split(output, []byte{0})
 		tracked := len(entries) == 2 && string(entries[0]) == canonical && len(entries[1]) == 0
-		if !tracked && strings.ContainsAny(operand, "*?[") {
+		if !tracked && errors.Is(statErr, os.ErrNotExist) && strings.ContainsAny(operand, "*?[") {
 			return nil, nil, fmt.Errorf("workflow list entries must be explicit paths; glob pattern %q is not allowed", operand)
 		}
 		extension := filepath.Ext(canonical)

--- a/internal/cli/upload.go
+++ b/internal/cli/upload.go
@@ -91,15 +91,27 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 		}
 	}
 	var workflows []workflowInput
+	var skippedWorkflowPaths []string
 	var err error
 	if uploadArguments.explicitWorkflowPaths {
-		workflows, err = expandExplicitWorkflowPaths(workflowOperands, uploadArguments.checkoutPath)
+		workflows, skippedWorkflowPaths, err = expandExplicitWorkflowPaths(workflowOperands, uploadArguments.checkoutPath)
 	} else {
-		workflows, err = resolveWorkflowOperands(workflowOperands)
+		workflows, skippedWorkflowPaths, err = resolveWorkflowOperands(workflowOperands)
 	}
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", err)
 		return 1
+	}
+	if !uploadArguments.explicitWorkflowPaths && len(skippedWorkflowPaths) != 0 {
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: workflow path %q is not tracked by git\n", skippedWorkflowPaths[0])
+		return 1
+	}
+	for _, path := range skippedWorkflowPaths {
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: warning: workflow path %q is missing or untracked; skipping\n", path)
+	}
+	if len(workflows) == 0 {
+		_, _ = fmt.Fprintln(stderr, "buildkite-gha: upload: warning: all configured workflow paths are missing or untracked; there is nothing to upload")
+		return 0
 	}
 	runnableWorkflowCount := 0
 	for i := range workflows {
@@ -619,20 +631,20 @@ type workflowInput struct {
 	ReusableOnly, Applicable                        bool
 }
 
-func resolveWorkflowOperands(operands []string) ([]workflowInput, error) {
+func resolveWorkflowOperands(operands []string) ([]workflowInput, []string, error) {
 	if len(operands) != 1 {
 		return expandExplicitWorkflowPaths(operands, "")
 	}
 	path, err := filepath.Abs(operands[0])
 	if err != nil {
-		return nil, fmt.Errorf("resolve workflow path %q: %w", operands[0], err)
+		return nil, nil, fmt.Errorf("resolve workflow path %q: %w", operands[0], err)
 	}
 	if err := requireRegularWorkflowFile(path, operands[0]); err != nil {
 		return expandExplicitWorkflowPaths(operands, "")
 	}
 	extension := filepath.Ext(path)
 	if extension != ".yml" && extension != ".yaml" {
-		return nil, fmt.Errorf("workflow path %q must end in .yml or .yaml", operands[0])
+		return nil, nil, fmt.Errorf("workflow path %q must end in .yml or .yaml", operands[0])
 	}
 	canonical := filepath.ToSlash(filepath.Clean(operands[0]))
 	if rootBytes, rootErr := exec.Command("git", "rev-parse", "--show-toplevel").Output(); rootErr == nil {
@@ -641,22 +653,24 @@ func resolveWorkflowOperands(operands []string) ([]workflowInput, error) {
 			canonical = filepath.ToSlash(filepath.Clean(relative))
 		}
 	}
-	return workflowInputs([]workflowInput{{Path: path, CanonicalPath: canonical}}, false)
+	inputs, err := workflowInputs([]workflowInput{{Path: path, CanonicalPath: canonical}}, false)
+	return inputs, nil, err
 }
 
-func expandExplicitWorkflowPaths(operands []string, checkoutPath string) ([]workflowInput, error) {
+func expandExplicitWorkflowPaths(operands []string, checkoutPath string) ([]workflowInput, []string, error) {
 	if len(operands) == 0 {
-		return nil, fmt.Errorf("workflow path is required")
+		return nil, nil, fmt.Errorf("workflow path is required")
 	}
 	rootBytes, err := gitRootCommand(checkoutPath).Output()
 	if err != nil {
 		if checkoutPath != "" {
-			return nil, fmt.Errorf("locate git repository from BUILDKITE_BUILD_CHECKOUT_PATH %q: %w", checkoutPath, err)
+			return nil, nil, fmt.Errorf("locate git repository from BUILDKITE_BUILD_CHECKOUT_PATH %q: %w", checkoutPath, err)
 		}
-		return nil, fmt.Errorf("locate checked-out git repository: %w", err)
+		return nil, nil, fmt.Errorf("locate checked-out git repository: %w", err)
 	}
 	root := filepath.Clean(strings.TrimSpace(string(rootBytes)))
 	matches := make([]workflowInput, 0, len(operands))
+	skipped := make([]string, 0)
 	for _, operand := range operands {
 		inputPath := operand
 		if checkoutPath != "" && !filepath.IsAbs(inputPath) {
@@ -664,36 +678,44 @@ func expandExplicitWorkflowPaths(operands []string, checkoutPath string) ([]work
 		}
 		absolute, err := filepath.Abs(inputPath)
 		if err != nil {
-			return nil, fmt.Errorf("resolve workflow path %q: %w", operand, err)
+			return nil, nil, fmt.Errorf("resolve workflow path %q: %w", operand, err)
 		}
 		relative, err := filepath.Rel(root, absolute)
 		if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
-			return nil, fmt.Errorf("workflow path %q is outside the checked-out git repository", operand)
+			return nil, nil, fmt.Errorf("workflow path %q is outside the checked-out git repository", operand)
 		}
 		canonical := filepath.ToSlash(filepath.Clean(relative))
 		info, statErr := os.Lstat(absolute)
 		if statErr == nil && !info.Mode().IsRegular() {
-			return nil, requireRegularWorkflowFile(absolute, operand)
+			return nil, nil, requireRegularWorkflowFile(absolute, operand)
+		}
+		if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+			return nil, nil, requireRegularWorkflowFile(absolute, operand)
 		}
 		output, gitErr := exec.Command("git", "-C", root, "ls-files", "-z", "--", ":(top,literal)"+canonical).Output()
+		if gitErr != nil {
+			return nil, nil, fmt.Errorf("inspect workflow path %q in git index: %w", operand, gitErr)
+		}
 		entries := bytes.Split(output, []byte{0})
-		tracked := gitErr == nil && len(entries) == 2 && string(entries[0]) == canonical && len(entries[1]) == 0
+		tracked := len(entries) == 2 && string(entries[0]) == canonical && len(entries[1]) == 0
 		if !tracked && strings.ContainsAny(operand, "*?[") {
-			return nil, fmt.Errorf("workflow list entries must be explicit paths; glob pattern %q is not allowed", operand)
+			return nil, nil, fmt.Errorf("workflow list entries must be explicit paths; glob pattern %q is not allowed", operand)
 		}
 		extension := filepath.Ext(canonical)
 		if extension != ".yml" && extension != ".yaml" {
-			return nil, fmt.Errorf("workflow path %q must end in .yml or .yaml", operand)
+			return nil, nil, fmt.Errorf("workflow path %q must end in .yml or .yaml", operand)
 		}
 		if !tracked {
-			return nil, fmt.Errorf("workflow path %q is not tracked by git", operand)
+			skipped = append(skipped, operand)
+			continue
 		}
 		if err := requireRegularWorkflowFile(absolute, operand); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		matches = append(matches, workflowInput{Path: filepath.Join(root, filepath.FromSlash(canonical)), CanonicalPath: canonical})
 	}
-	return workflowInputs(matches, true)
+	inputs, err := workflowInputs(matches, true)
+	return inputs, skipped, err
 }
 
 func requireRegularWorkflowFile(path, displayPath string) error {

--- a/internal/cli/upload_test.go
+++ b/internal/cli/upload_test.go
@@ -379,6 +379,10 @@ func TestExpandExplicitWorkflowPathsCanonicalizesTrackedPaths(t *testing.T) {
 	if err := os.WriteFile(untrackedPath, []byte(workflowSource), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	untrackedMetacharacterPath := filepath.Join(workflowDirectory, "untracked[1].yml")
+	if err := os.WriteFile(untrackedMetacharacterPath, []byte(workflowSource), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	outsidePath := filepath.Join(t.TempDir(), "outside.yml")
 	if err := os.WriteFile(outsidePath, []byte(workflowSource), 0o600); err != nil {
 		t.Fatal(err)
@@ -415,8 +419,8 @@ func TestExpandExplicitWorkflowPathsCanonicalizesTrackedPaths(t *testing.T) {
 	if err != nil || len(leadingDashSkipped) != 0 || len(leadingDash) != 2 || leadingDash[0].CanonicalPath != "-leading.yml" {
 		t.Fatalf("leading-dash explicit path = %#v, %v", leadingDash, err)
 	}
-	selected, skipped, err := expandExplicitWorkflowPaths([]string{filepath.Join(".github", "workflows", "missing.yml"), untrackedPath, aPath}, "")
-	if err != nil || len(selected) != 1 || selected[0].CanonicalPath != ".github/workflows/a.yml" || !reflect.DeepEqual(skipped, []string{filepath.Join(".github", "workflows", "missing.yml"), untrackedPath}) {
+	selected, skipped, err := expandExplicitWorkflowPaths([]string{filepath.Join(".github", "workflows", "missing.yml"), untrackedPath, untrackedMetacharacterPath, aPath}, "")
+	if err != nil || len(selected) != 1 || selected[0].CanonicalPath != ".github/workflows/a.yml" || !reflect.DeepEqual(skipped, []string{filepath.Join(".github", "workflows", "missing.yml"), untrackedPath, untrackedMetacharacterPath}) {
 		t.Fatalf("missing and untracked selection = %#v, skipped %#v, error %v", selected, skipped, err)
 	}
 

--- a/internal/cli/upload_test.go
+++ b/internal/cli/upload_test.go
@@ -387,15 +387,15 @@ func TestExpandExplicitWorkflowPathsCanonicalizesTrackedPaths(t *testing.T) {
 
 	aPath := filepath.Join(".github", "workflows", "a.yml")
 	bPath := filepath.Join(".github", "workflows", "b.yaml")
-	first, err := expandExplicitWorkflowPaths([]string{filepath.Join(repository, bPath), "./" + aPath, aPath}, "")
+	first, firstSkipped, err := expandExplicitWorkflowPaths([]string{filepath.Join(repository, bPath), "./" + aPath, aPath}, "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	second, err := expandExplicitWorkflowPaths([]string{aPath, filepath.Join(repository, bPath)}, "")
+	second, secondSkipped, err := expandExplicitWorkflowPaths([]string{aPath, filepath.Join(repository, bPath)}, "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(first, second) || len(first) != 2 || first[0].CanonicalPath != ".github/workflows/a.yml" || first[1].CanonicalPath != ".github/workflows/b.yaml" {
+	if len(firstSkipped) != 0 || len(secondSkipped) != 0 || !reflect.DeepEqual(first, second) || len(first) != 2 || first[0].CanonicalPath != ".github/workflows/a.yml" || first[1].CanonicalPath != ".github/workflows/b.yaml" {
 		t.Fatalf("canonical explicit inputs = %#v and %#v", first, second)
 	}
 	for _, input := range first {
@@ -403,17 +403,21 @@ func TestExpandExplicitWorkflowPathsCanonicalizesTrackedPaths(t *testing.T) {
 			t.Fatalf("explicit workflow identity = %#v", input)
 		}
 	}
-	metacharacter, err := expandExplicitWorkflowPaths([]string{filepath.Join(".github", "workflows", "workflow[1].yml"), aPath}, "")
-	if err != nil || len(metacharacter) != 2 || metacharacter[1].CanonicalPath != ".github/workflows/workflow[1].yml" {
+	metacharacter, metacharacterSkipped, err := expandExplicitWorkflowPaths([]string{filepath.Join(".github", "workflows", "workflow[1].yml"), aPath}, "")
+	if err != nil || len(metacharacterSkipped) != 0 || len(metacharacter) != 2 || metacharacter[1].CanonicalPath != ".github/workflows/workflow[1].yml" {
 		t.Fatalf("literal metacharacter list = %#v, %v", metacharacter, err)
 	}
 	operands, _, err := uploadArgs([]string{"--", "-leading.yml", aPath})
 	if err != nil {
 		t.Fatal(err)
 	}
-	leadingDash, err := expandExplicitWorkflowPaths(operands, "")
-	if err != nil || len(leadingDash) != 2 || leadingDash[0].CanonicalPath != "-leading.yml" {
+	leadingDash, leadingDashSkipped, err := expandExplicitWorkflowPaths(operands, "")
+	if err != nil || len(leadingDashSkipped) != 0 || len(leadingDash) != 2 || leadingDash[0].CanonicalPath != "-leading.yml" {
 		t.Fatalf("leading-dash explicit path = %#v, %v", leadingDash, err)
+	}
+	selected, skipped, err := expandExplicitWorkflowPaths([]string{filepath.Join(".github", "workflows", "missing.yml"), untrackedPath, aPath}, "")
+	if err != nil || len(selected) != 1 || selected[0].CanonicalPath != ".github/workflows/a.yml" || !reflect.DeepEqual(skipped, []string{filepath.Join(".github", "workflows", "missing.yml"), untrackedPath}) {
+		t.Fatalf("missing and untracked selection = %#v, skipped %#v, error %v", selected, skipped, err)
 	}
 
 	for _, test := range []struct {
@@ -423,15 +427,13 @@ func TestExpandExplicitWorkflowPathsCanonicalizesTrackedPaths(t *testing.T) {
 	}{
 		{name: "mixed glob and literal", operands: []string{filepath.Join(".github", "workflows", "*.yml"), aPath}, want: "glob pattern"},
 		{name: "multiple globs", operands: []string{filepath.Join(".github", "workflows", "*.yml"), filepath.Join(".github", "workflows", "*.yaml")}, want: "glob pattern"},
-		{name: "missing", operands: []string{filepath.Join(".github", "workflows", "missing.yml"), aPath}, want: "not tracked by git"},
-		{name: "untracked", operands: []string{untrackedPath, aPath}, want: "not tracked by git"},
 		{name: "directory", operands: []string{workflowDirectory, aPath}, want: "directory"},
 		{name: "outside repository", operands: []string{outsidePath, aPath}, want: "outside the checked-out git repository"},
 		{name: "non-workflow extension", operands: []string{notePath, aPath}, want: "must end in .yml or .yaml"},
 		{name: "symlink", operands: []string{symlinkPath, aPath}, want: "symbolic link"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			if _, err := expandExplicitWorkflowPaths(test.operands, ""); err == nil || !strings.Contains(err.Error(), test.want) {
+			if _, _, err := expandExplicitWorkflowPaths(test.operands, ""); err == nil || !strings.Contains(err.Error(), test.want) {
 				t.Fatalf("expandExplicitWorkflowPaths(%q) error = %v, want %q", test.operands, err, test.want)
 			}
 		})
@@ -447,7 +449,7 @@ func TestExpandExplicitWorkflowPathsExplainsTrackedFileMissingFromCheckout(t *te
 		t.Fatal(err)
 	}
 	t.Chdir(repository)
-	_, err := expandExplicitWorkflowPaths([]string{workflowPath}, "")
+	_, _, err := expandExplicitWorkflowPaths([]string{workflowPath}, "")
 	if err == nil || !strings.Contains(err.Error(), "tracked by git but missing from the checkout") || !strings.Contains(err.Error(), "sparse-checkout") {
 		t.Fatalf("expandExplicitWorkflowPaths() error = %v", err)
 	}
@@ -510,16 +512,20 @@ func TestRunUploadRejectsWorkflowSelectorsBeforeBuildkite(t *testing.T) {
 	t.Chdir(repository)
 	t.Setenv("BUILDKITE", "true")
 	t.Setenv("BUILDKITE_STEP_KEY", "invalid-list-importer")
-	for _, operands := range [][]string{
-		{"*"},
-		{filepath.Join(".github", "workflows", "*.yml")},
-		{filepath.Join(".github", "workflows", "*.yml"), filepath.Join(".github", "workflows", "a.yml")},
+	for _, test := range []struct {
+		operands []string
+		want     string
+	}{
+		{operands: []string{"*"}, want: "glob pattern"},
+		{operands: []string{filepath.Join(".github", "workflows", "*.yml")}, want: "glob pattern"},
+		{operands: []string{filepath.Join(".github", "workflows", "*.yml"), filepath.Join(".github", "workflows", "a.yml")}, want: "glob pattern"},
+		{operands: []string{filepath.Join(".github", "workflows", "missing.yml"), filepath.Join(".github", "workflows", "a.yml")}, want: "not tracked by git"},
 	} {
 		runner := &cliCaptureRunner{}
 		var stdout, stderr bytes.Buffer
-		args := append([]string{"upload"}, operands...)
-		if code := run(args, &stdout, &stderr, "dev", runner); code != 1 || !strings.Contains(stderr.String(), "glob pattern") {
-			t.Fatalf("run(%q) code/stderr = %d / %q", operands, code, stderr.String())
+		args := append([]string{"upload"}, test.operands...)
+		if code := run(args, &stdout, &stderr, "dev", runner); code != 1 || !strings.Contains(stderr.String(), test.want) {
+			t.Fatalf("run(%q) code/stderr = %d / %q", test.operands, code, stderr.String())
 		}
 		if stdout.Len() != 0 || len(runner.commands) != 0 || len(runner.uploaded) != 0 {
 			t.Fatalf("invalid workflow selector reached Buildkite: stdout %q, commands %#v, uploads %#v", stdout.String(), runner.commands, runner.uploaded)
@@ -539,9 +545,12 @@ func TestRunUploadAggregatesExplicitPathsAtomicallyWithNamespacedJobs(t *testing
 		filepath.Join(workflowDirectory, "shell.yml"),
 	}
 	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
-	inputs, err := expandExplicitWorkflowPaths(workflowPaths, "")
+	inputs, skipped, err := expandExplicitWorkflowPaths(workflowPaths, "")
 	if err != nil {
 		t.Fatal(err)
+	}
+	if len(skipped) != 0 {
+		t.Fatalf("skipped workflow paths = %#v", skipped)
 	}
 	t.Setenv("BUILDKITE", "true")
 	t.Setenv("BUILDKITE_STEP_KEY", "aggregate-importer")


### PR DESCRIPTION
## Why

Pipelines can list every GitHub Actions workflow once, but removing one of those workflows currently fails every subsequent build until the pipeline configuration changes too.

## What

Skip missing or untracked paths from plugin workflow lists with a warning. If every configured workflow is absent, succeed without uploading a pipeline. Keep invalid and unsafe path states fatal, preserve direct `upload` behavior, and document that the remaining workflows still upload atomically.
