### PR TITLE
Allow actions when no GitHub check run ID exists

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -826,7 +826,9 @@ After runner setup, step runtime fields and job outputs can also use
 `RUNNER_TEMP`. Other runner fields and compile-time positions that require
 runner identity are unsupported. Action metadata input defaults may also use
 direct `runner.debug`, which resolves to the string `false` because Buildkite
-has no equivalent step-debug mode.
+has no equivalent step-debug mode. `job.check_run_id` defaults, including the
+static indexed spelling, resolve to an empty string because Buildkite does not
+create a GitHub check run. Other `job` identity fields remain unsupported.
 
 A runtime interpolation can read a verified upstream output directly:
 

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -445,6 +445,26 @@ runs:
 	}
 }
 
+func TestCompileActionInvocationsAcceptsUnavailableCheckRunIDDefaultWithoutAuthority(t *testing.T) {
+	workspace := t.TempDir()
+	writeAction(t, workspace, "check-run", `name: check run
+inputs:
+  check-run-id:
+    default: ${{ job.check_run_id }}
+runs:
+  using: node24
+  main: index.js
+`)
+
+	compiled, err := compileActionInvocations(t.Context(), workspace, nil, "https://github.com", []string{"./check-run"}, []map[string]string{{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if compiled.requiresGitHubToken || len(compiled.requiredSecrets) != 0 {
+		t.Fatalf("check-run default authority = token %t, secrets %#v; want none", compiled.requiresGitHubToken, compiled.requiredSecrets)
+	}
+}
+
 func TestCompileActionInvocationsScopesWorkflowAuthoredSecretsByInputContract(t *testing.T) {
 	workspace := t.TempDir()
 	writeAction(t, workspace, "secrets", `name: secret inputs

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -451,6 +451,8 @@ func TestCompileActionInvocationsAcceptsUnavailableCheckRunIDDefaultWithoutAutho
 inputs:
   check-run-id:
     default: ${{ job.check_run_id }}
+  token:
+    default: ${{ job.check_run_id && github.token || '' }}
 runs:
   using: node24
   main: index.js

--- a/internal/expression/action_input_default.go
+++ b/internal/expression/action_input_default.go
@@ -93,9 +93,9 @@ func isRunnerTempReference(root string, path []string) bool {
 }
 
 // ActionInputDefaultRequiresGitHubToken reports whether a metadata default can
-// reach github.token for the event provider. Defaults involving any other
-// runtime value require the token because those values are not known during
-// compilation.
+// reach github.token for the event provider. A token branch guarded by an
+// unknown runtime value requires the token because that value is not known
+// during compilation.
 func ActionInputDefaultRequiresGitHubToken(template, serverURL string) (bool, error) {
 	referencesToken, err := ReferencesGitHubToken(template)
 	if err != nil || !referencesToken {
@@ -129,8 +129,9 @@ func ActionInputDefaultRequiresGitHubToken(template, serverURL string) (bool, er
 					}
 				}
 			}
-			onlyKnownReferences = strings.EqualFold(root, "github") && len(path) == 1 &&
-				(strings.EqualFold(path[0], "server_url") || strings.EqualFold(path[0], "token"))
+			onlyKnownReferences = isJobCheckRunIDReference(root, path) ||
+				strings.EqualFold(root, "github") && len(path) == 1 &&
+					(strings.EqualFold(path[0], "server_url") || strings.EqualFold(path[0], "token"))
 		})
 		return nil
 	})

--- a/internal/expression/action_input_default.go
+++ b/internal/expression/action_input_default.go
@@ -32,6 +32,9 @@ func validateActionInputDefaultNode(node actionlint.ExprNode) error {
 		if isJobStatusReference(root, path) {
 			return nil
 		}
+		if isJobCheckRunIDReference(root, path) {
+			return nil
+		}
 		if isRunnerTempReference(root, path) {
 			return fmt.Errorf("action input defaults cannot reference runner.temp")
 		}
@@ -79,6 +82,10 @@ func EvaluateActionInputDefault(template string, context Context) (string, error
 func isDirectRunnerDebug(node actionlint.ExprNode, root string, path []string) bool {
 	_, direct := node.(*actionlint.ObjectDerefNode)
 	return direct && strings.EqualFold(root, "runner") && len(path) == 1 && strings.EqualFold(path[0], "debug")
+}
+
+func isJobCheckRunIDReference(root string, path []string) bool {
+	return strings.EqualFold(root, "job") && len(path) == 1 && strings.EqualFold(path[0], "check_run_id")
 }
 
 func isRunnerTempReference(root string, path []string) bool {
@@ -149,6 +156,12 @@ func evaluateActionInputDefaultNode(node actionlint.ExprNode, context Context) (
 				return nil, fmt.Errorf("expression references unavailable job.status")
 			}
 			return context.JobStatus, nil
+		}
+		if isJobCheckRunIDReference(root, path) {
+			// Buildkite creates no GitHub check run. GitHub documents this
+			// property as unavailable on GitHub Enterprise Server; unavailable
+			// properties interpolate as an empty string.
+			return "", nil
 		}
 		if isRunnerTempReference(root, path) {
 			return nil, fmt.Errorf("action input defaults cannot reference runner.temp")

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -326,6 +326,8 @@ func TestActionInputDefaultRequiresGitHubTokenUsesProviderServerURL(t *testing.T
 		{name: "Origin skips GitHub.com token", template: "${{ github.server_url == 'https://github.com' && github.token || '' }}", serverURL: "https://origin.cursor.com"},
 		{name: "Origin reaches reverse guard", template: "${{ github.server_url != 'https://github.com' && github.token || '' }}", serverURL: "https://origin.cursor.com", want: true},
 		{name: "literal false skips token", template: "${{ false && github.token || '' }}", serverURL: "https://origin.cursor.com"},
+		{name: "unavailable check run skips token", template: "${{ job.check_run_id && github.token || '' }}", serverURL: "https://github.com"},
+		{name: "indexed unavailable check run skips token", template: "${{ job['check_run_id'] && github.token || '' }}", serverURL: "https://github.com"},
 		{name: "unknown guard requires token", template: "${{ inputs.use_token && github.token || '' }}", serverURL: "https://origin.cursor.com", want: true},
 		{name: "no token reference", template: "${{ github.server_url }}", serverURL: "https://origin.cursor.com"},
 	} {

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -227,6 +227,9 @@ func TestValidateActionInputDefaultSupportsRestrictedCompoundExpressions(t *test
 		"${{ runner.debug }}",
 		"${{ runner.debug == '1' }}",
 		"${{ job.status }}",
+		"${{ job.check_run_id }}",
+		"${{ job['check_run_id'] }}",
+		"${{ job.check_run_id || 'unavailable' }}",
 		"${{ toJSON(matrix) }}",
 		"${{ true && 'quoted }} braces' || '' }}",
 		"${{ 1 > 0 }}",
@@ -235,7 +238,7 @@ func TestValidateActionInputDefaultSupportsRestrictedCompoundExpressions(t *test
 			t.Errorf("ValidateActionInputDefault(%q) error = %v", template, err)
 		}
 	}
-	for _, template := range []string{"${{ secrets.TOKEN }}", "${{ hashFiles('go.sum') }}", "${{ toJSON(secrets) }}", "${{ github[env.NAME] }}", "${{ runner['debug'] }}", "${{ runner[env.NAME] }}", "${{ runner }}", "${{ runner.debug.extra }}", "${{ runner.name }}", "${{ runner.temp }}", "${{ job.status == 'success' }}", "status-${{ job.status }}"} {
+	for _, template := range []string{"${{ secrets.TOKEN }}", "${{ hashFiles('go.sum') }}", "${{ toJSON(secrets) }}", "${{ github[env.NAME] }}", "${{ runner['debug'] }}", "${{ runner[env.NAME] }}", "${{ runner }}", "${{ runner.debug.extra }}", "${{ runner.name }}", "${{ runner.temp }}", "${{ job[env.NAME] }}", "${{ job.check_run_id.extra }}", "${{ job.name }}", "${{ job.status == 'success' }}", "status-${{ job.status }}"} {
 		if err := ValidateActionInputDefault(template); err == nil {
 			t.Errorf("ValidateActionInputDefault(%q) unexpectedly succeeded", template)
 		}
@@ -354,6 +357,29 @@ func TestEvaluateActionInputDefaultSupportsJobStatus(t *testing.T) {
 	}
 	if _, err := Evaluate("${{ job.status }}", Context{JobStatus: "success"}); err == nil {
 		t.Fatal("Evaluate() accepted action-default-only job.status")
+	}
+}
+
+func TestEvaluateActionInputDefaultTreatsJobCheckRunIDAsUnavailable(t *testing.T) {
+	for _, test := range []struct {
+		template string
+		want     string
+	}{
+		{template: "${{ job.check_run_id }}", want: ""},
+		{template: "${{ job['check_run_id'] }}", want: ""},
+		{template: "${{ JOB.CHECK_RUN_ID || 'unavailable' }}", want: "unavailable"},
+		{template: "id-${{ job.check_run_id }}", want: "id-"},
+	} {
+		got, err := EvaluateActionInputDefault(test.template, Context{})
+		if err != nil || got != test.want {
+			t.Errorf("EvaluateActionInputDefault(%q) = %q, %v; want %q", test.template, got, err, test.want)
+		}
+	}
+	if err := ValidateRuntimeTemplate("${{ job.check_run_id }}"); err == nil {
+		t.Fatal("ValidateRuntimeTemplate() accepted action-default-only job.check_run_id")
+	}
+	if _, err := Evaluate("${{ job.check_run_id }}", Context{}); err == nil {
+		t.Fatal("Evaluate() accepted action-default-only job.check_run_id")
 	}
 }
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -3046,6 +3046,20 @@ func TestResolveActionInputsUsesRunnerDebugDefaultUnlessExplicitlySupplied(t *te
 	}
 }
 
+func TestResolveActionInputsUsesEmptyCheckRunIDDefaultUnlessExplicitlySupplied(t *testing.T) {
+	checkRunIDDefault := "${{ job.check_run_id }}"
+	action := metadata.Metadata{Inputs: map[string]metadata.Input{"check-run-id": {Default: &checkRunIDDefault}}}
+
+	inputs, err := resolveActionInputs(action, nil, expression.Context{})
+	if err != nil || inputs["check-run-id"] != "" {
+		t.Fatalf("check-run-id default = %#v, %v; want empty", inputs, err)
+	}
+	inputs, err = resolveActionInputs(action, map[string]string{"CHECK-RUN-ID": "1234"}, expression.Context{})
+	if err != nil || inputs["check-run-id"] != "1234" {
+		t.Fatalf("explicit check-run-id input = %#v, %v; want 1234", inputs, err)
+	}
+}
+
 func TestStepExpressionContextExposesScopedTokenWithoutMutatingJobContext(t *testing.T) {
 	eval := expression.Context{
 		GitHub:  map[string]any{"actor": "octocat"},


### PR DESCRIPTION
## Why

CodeQL v4 asks GitHub Actions for the current check run ID:

```yaml
check-run-id:
  default: ${{ job.check_run_id }}
```

Buildkite does not create a GitHub check run, so there is no ID to return. We currently reject the action, even though CodeQL treats a missing ID as optional and continues without it.

## What

Treat the missing ID the same way GitHub does when it is unavailable:

```text
${{ job.check_run_id }} → ""
```

This only applies to action input defaults. We do not invent an ID, expose other `job` fields, or request a GitHub token for code that cannot run because the ID is empty.
