### PR TITLE
Expand matrices whose values are known before jobs run

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -544,7 +544,7 @@ selectors that require an incompatible operating system or architecture.
 | --- | --- | --- |
 | `matrix` | 🟡 Supported subset | Literal rows. Authored values and expression-valued definitions can use compile-time `github`, `event`, `vars`, reusable-workflow `inputs`, and `fromJSON` values. |
 | `include`, `exclude` | 🟡 Supported subset | Literal combinations or expressions that resolve to arrays of objects during compilation. |
-| `max-parallel` | 🟡 Supported subset | Literal value. |
+| `max-parallel` | 🟡 Supported subset | Literal value on ordinary job matrices. Reusable-workflow call matrices with more than one instance are rejected because flattening cannot preserve invocation-level parallelism. |
 | `fail-fast` | ➖ Accepted, no effect | A failed matrix entry does not cancel its siblings. |
 
 A strategy can combine parallelism, static matrix values, and exclusions:

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -542,8 +542,8 @@ selectors that require an incompatible operating system or architecture.
 
 | Key | Status | Behavior |
 | --- | --- | --- |
-| `matrix` | 🟡 Supported subset | Literal rows or compile-time `github`, `event`, `vars`, and `fromJSON` values. |
-| `include`, `exclude` | 🟡 Supported subset | Static combinations. |
+| `matrix` | 🟡 Supported subset | Literal rows. Authored values and expression-valued definitions can use compile-time `github`, `event`, `vars`, reusable-workflow `inputs`, and `fromJSON` values. |
+| `include`, `exclude` | 🟡 Supported subset | Literal combinations or expressions that resolve to arrays of objects during compilation. |
 | `max-parallel` | 🟡 Supported subset | Literal value. |
 | `fail-fast` | ➖ Accepted, no effect | A failed matrix entry does not cancel its siblings. |
 
@@ -560,7 +560,27 @@ strategy:
         os: ubuntu-24.04
 ```
 
-A job may expand to at most 256 instances. Matrices derived from `needs` or `steps` are unsupported.
+Whole matrices, dimensions, and `include` or `exclude` lists can use static JSON:
+
+```yaml
+strategy:
+  matrix:
+    os: ${{ fromJSON(vars.OPERATING_SYSTEMS) }}
+    include: ${{ fromJSON(inputs.EXTRA_JOBS) }}
+    exclude: ${{ fromJSON(github.event.matrix_exclusions) }}
+```
+
+Static matrices on reusable-workflow calls compose with static matrices in
+called workflows, including nested calls. Each call instance receives its
+concrete `matrix` values and each called workflow receives its declared
+`inputs` before its matrix expands.
+
+A job may expand to at most 256 instances. All matrix values must be available
+before Buildkite pipeline generation. Expressions derived from `needs` outputs
+or `steps` require jobs to run before the final graph can be generated, so they
+remain unsupported. The compiler validates a narrow `needs.<job>.outputs.<name>`
+runtime-matrix shape, but does not upload a continuation pipeline because the
+transport has no authoritative current-attempt and durable idempotency fence.
 
 ### Containers and services
 

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"slices"
+	"sort"
 	"strings"
 	"testing"
 
@@ -410,6 +411,56 @@ func TestCompileBundleNamespacesMaxParallelConcurrency(t *testing.T) {
 		if !strings.Contains(job.ConcurrencyGroup, "/0123456789abcdef/test") {
 			t.Fatalf("matrix concurrency group = %q, want workflow namespace", job.ConcurrencyGroup)
 		}
+	}
+}
+
+func TestCompileBundlePreservesStaticExpressionMatrixFanOutAndFanIn(t *testing.T) {
+	source := []byte(`on: push
+jobs:
+  build:
+    strategy:
+      max-parallel: 1
+      matrix:
+        os: ${{ fromJSON(vars.OSES) }}
+        exclude: ${{ fromJSON(vars.EXCLUDE) }}
+        include: ${{ fromJSON(vars.INCLUDE) }}
+    runs-on: ubuntu-latest
+    steps: [{run: true}]
+  finish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps: [{run: true}]
+`)
+	options := defaultOptions()
+	options.Vars.Bridge = map[string]string{
+		"OSES":    `["linux","darwin"]`,
+		"EXCLUDE": `[{"os":"darwin"}]`,
+		"INCLUDE": `[{"os":"linux","arch":"amd64"},{"os":"darwin","arch":"arm64"}]`,
+	}
+	bundle, err := CompileBundleWithOptions("workflow.yml", source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-importer", options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bundle.Plans) != 3 || len(bundle.GeneratedWorkflow.Jobs) != 3 {
+		t.Fatalf("bundle jobs = plans %d, pipeline %d; want two matrix instances and fan-in", len(bundle.Plans), len(bundle.GeneratedWorkflow.Jobs))
+	}
+	wantMatrices := []map[string]any{
+		{"arch": "amd64", "os": "linux"},
+		{"arch": "arm64", "os": "darwin"},
+	}
+	for i, want := range wantMatrices {
+		if !reflect.DeepEqual(bundle.Plans[i].Job.Matrix, want) {
+			t.Fatalf("plan matrix %d = %#v, want %#v", i, bundle.Plans[i].Job.Matrix, want)
+		}
+		generated := bundle.GeneratedWorkflow.Jobs[i]
+		if generated.Concurrency != 1 || generated.ConcurrencyGroup == "" {
+			t.Fatalf("pipeline max-parallel job %d = concurrency %d, group %q", i, generated.Concurrency, generated.ConcurrencyGroup)
+		}
+	}
+	wantDependencies := []string{bundle.Plans[0].Job.Target.StepKey, bundle.Plans[1].Job.Target.StepKey}
+	sort.Strings(wantDependencies)
+	if !reflect.DeepEqual(bundle.Plans[2].Job.Dependencies, wantDependencies) || !reflect.DeepEqual(bundle.GeneratedWorkflow.Jobs[2].Dependencies, wantDependencies) {
+		t.Fatalf("fan-in = plan %#v, pipeline %#v; want %#v", bundle.Plans[2].Job.Dependencies, bundle.GeneratedWorkflow.Jobs[2].Dependencies, wantDependencies)
 	}
 }
 

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -557,24 +557,64 @@ jobs:
 	}
 }
 
-func TestCompileRejectsRuntimeDependentMatrixInclude(t *testing.T) {
+func TestCompileResolvesStaticMatrixIncludeAndExcludeExpressions(t *testing.T) {
 	source := []byte(`on: push
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
+        exclude: ${{ fromJSON(vars.EXCLUDE) }}
         include: ${{ fromJSON(vars.INCLUDE) }}
     steps:
       - run: true
 `)
-	_, err := Compile("dynamic-include.yml", source, readFile(t, smokePath("events", "push.json")))
-	if err == nil || !strings.Contains(err.Error(), "runtime-dependent matrix include expressions are unsupported") {
-		t.Fatalf("Compile() error = %v, want explicit include expression error", err)
+	options := defaultOptions()
+	options.Vars.Bridge = map[string]string{
+		"EXCLUDE": `[{"os":"macos-latest"}]`,
+		"INCLUDE": `[{"os":"ubuntu-latest","version":24},{"os":"macos-14","version":14}]`,
 	}
-	if !strings.Contains(err.Error(), "dynamic-include.yml:8:18") {
-		t.Fatalf("Compile() error = %v, want source location", err)
+	compiled, err := CompileWithOptions("static-sections.yml", source, readFile(t, smokePath("events", "push.json")), options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ir IR
+	if err := json.Unmarshal(compiled, &ir); err != nil {
+		t.Fatal(err)
+	}
+	want := []map[string]any{
+		{"os": "ubuntu-latest", "version": float64(24)},
+		{"os": "macos-14", "version": float64(14)},
+	}
+	if len(ir.Jobs) != len(want) {
+		t.Fatalf("jobs = %d, want %d", len(ir.Jobs), len(want))
+	}
+	for i := range want {
+		if !reflect.DeepEqual(ir.Jobs[i].Matrix, want[i]) {
+			t.Fatalf("matrix instance %d = %#v, want %#v", i, ir.Jobs[i].Matrix, want[i])
+		}
+	}
+}
+
+func TestCompileBoundsStaticExpressionMatrixExpansion(t *testing.T) {
+	values := make([]string, maxMatrixInstances+1)
+	for i := range values {
+		values[i] = fmt.Sprintf("%q", fmt.Sprint(i))
+	}
+	source := []byte(`on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJSON(vars.MATRIX) }}
+    steps: [{run: true}]
+`)
+	options := defaultOptions()
+	options.Vars.Bridge = map[string]string{"MATRIX": `{"value":[` + strings.Join(values, ",") + `]}`}
+	_, err := CompileWithOptions("bounded-matrix.yml", source, readFile(t, smokePath("events", "push.json")), options)
+	if err == nil || !strings.Contains(err.Error(), fmt.Sprintf("matrix expands beyond %d instances", maxMatrixInstances)) {
+		t.Fatalf("Compile() error = %v, want static matrix instance limit", err)
 	}
 }
 
@@ -1930,18 +1970,103 @@ jobs:
 	}
 }
 
+func TestCompileResolvesStaticExpressionsInNestedReusableMatrices(t *testing.T) {
+	repository := t.TempDir()
+	path := writeWorkflow(t, repository, "caller.yml", `on: push
+jobs:
+  call:
+    strategy:
+      matrix: ${{ fromJSON(vars.CALLS) }}
+    uses: ./.github/workflows/middle.yml
+    with:
+      target: ${{ matrix.target }}
+      arches: '["amd64","arm64"]'
+  finish:
+    needs: call
+    runs-on: ubuntu-latest
+    steps: [{run: true}]
+`)
+	writeWorkflow(t, repository, "middle.yml", `on:
+  workflow_call:
+    inputs:
+      target: {type: string, required: true}
+      arches: {type: string, required: true}
+jobs:
+  leaf:
+    strategy:
+      matrix:
+        arch: ${{ fromJSON(inputs.arches) }}
+        include: ${{ fromJSON('[{"arch":"amd64","native":true}]') }}
+    uses: ./.github/workflows/leaf.yml
+    with:
+      target: ${{ format('{0}-{1}', inputs.target, matrix.arch) }}
+`)
+	writeWorkflow(t, repository, "leaf.yml", `on:
+  workflow_call:
+    inputs:
+      target: {type: string, required: true}
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ${{ inputs.target }}
+`)
+	options := defaultOptions()
+	options.Vars.Bridge = map[string]string{"CALLS": `{"target":["linux","darwin"]}`}
+	result, err := CompileWithOptions(path, readFile(t, path), readFile(t, smokePath("events", "push.json")), options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ir IR
+	if err := json.Unmarshal(result, &ir); err != nil {
+		t.Fatal(err)
+	}
+	if len(ir.Jobs) != 5 {
+		t.Fatalf("jobs = %d, want four composed instances and one fan-in", len(ir.Jobs))
+	}
+	runs := make([]string, 0, 4)
+	for _, job := range ir.Jobs[:4] {
+		runs = append(runs, job.Steps[0].Run)
+	}
+	sort.Strings(runs)
+	wantRuns := []string{"echo darwin-amd64", "echo darwin-arm64", "echo linux-amd64", "echo linux-arm64"}
+	if !reflect.DeepEqual(runs, wantRuns) {
+		t.Fatalf("nested matrix runs = %#v, want %#v", runs, wantRuns)
+	}
+	if got := len(ir.Jobs[4].Needs); got != 4 {
+		t.Fatalf("fan-in dependencies = %d, want 4", got)
+	}
+}
+
 func TestCompileRejectsRuntimeExpressionsLaunderedThroughReusableInputs(t *testing.T) {
-	t.Run("matrix expression", func(t *testing.T) {
+	t.Run("unavailable static matrix value", func(t *testing.T) {
 		repository := t.TempDir()
 		path := writeWorkflow(t, repository, "caller.yml", "on: push\njobs:\n  call:\n    strategy:\n      matrix: ${{ fromJSON(vars.MATRIX) }}\n    uses: ./.github/workflows/reusable.yml\n")
 		writeWorkflow(t, repository, "reusable.yml", "on: workflow_call\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n")
 		_, err := Compile(path, readFile(t, path), readFile(t, smokePath("events", "push.json")))
-		if err == nil || !strings.Contains(err.Error(), "expression-valued reusable-workflow matrices are unsupported") {
-			t.Fatalf("Compile() error = %v, want explicit call-matrix rejection", err)
+		if err == nil || !strings.Contains(err.Error(), `compile-time expression references unavailable value "vars.matrix"`) {
+			t.Fatalf("Compile() error = %v, want unavailable static value rejection", err)
 		}
 	})
 
-	t.Run("matrix value", func(t *testing.T) {
+	t.Run("unavailable github value", func(t *testing.T) {
+		repository := t.TempDir()
+		path := writeWorkflow(t, repository, "caller.yml", `on: push
+jobs:
+  call:
+    strategy:
+      matrix:
+        target: ["${{ github.run_id }}"]
+    uses: ./.github/workflows/reusable.yml
+`)
+		writeWorkflow(t, repository, "reusable.yml", "on: workflow_call\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n")
+		_, err := Compile(path, readFile(t, path), readFile(t, smokePath("events", "push.json")))
+		if err == nil || !strings.Contains(err.Error(), `compile-time expression references unavailable value "github.run_id"`) {
+			t.Fatalf("Compile() error = %v, want unavailable GitHub value rejection", err)
+		}
+	})
+
+	t.Run("static matrix value", func(t *testing.T) {
 		repository := t.TempDir()
 		path := writeWorkflow(t, repository, "caller.yml", `on: push
 jobs:
@@ -1954,9 +2079,16 @@ jobs:
       target: ${{ matrix.target }}
 `)
 		writeWorkflow(t, repository, "reusable.yml", "on:\n  workflow_call:\n    inputs:\n      target:\n        type: string\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo ${{ inputs.target }}\n")
-		_, err := Compile(path, readFile(t, path), readFile(t, smokePath("events", "push.json")))
-		if err == nil || !strings.Contains(err.Error(), "runtime-dependent reusable-workflow matrix value is unsupported") {
-			t.Fatalf("Compile() error = %v, want matrix expression rejection", err)
+		result, err := Compile(path, readFile(t, path), readFile(t, smokePath("events", "push.json")))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var ir IR
+		if err := json.Unmarshal(result, &ir); err != nil {
+			t.Fatal(err)
+		}
+		if len(ir.Jobs) != 1 || ir.Jobs[0].Steps[0].Run != "echo main" {
+			t.Fatalf("resolved reusable matrix value = %#v", ir.Jobs)
 		}
 	})
 
@@ -1988,7 +2120,7 @@ jobs:
 	})
 }
 
-func TestExpandMatrixPreservesRegressedStaticExpressionValues(t *testing.T) {
+func TestExpandMatrixRejectsRuntimeExpressionsInAuthoredValues(t *testing.T) {
 	tests := []struct {
 		name   string
 		source string
@@ -2096,22 +2228,18 @@ jobs:
 			if err != nil {
 				t.Fatal(err)
 			}
-			matrixJobs := 0
+			rejected := false
 			for _, job := range parsed.Jobs {
 				if job.Matrix == nil {
 					continue
 				}
-				matrixJobs++
-				matrices, err := expandMatrix(test.name, job, expression.CompileContext{})
-				if err != nil {
-					t.Fatalf("expandMatrix(%q): %v", job.ID, err)
-				}
-				if len(matrices) == 0 {
-					t.Fatalf("expandMatrix(%q) returned no combinations", job.ID)
+				_, err := expandMatrix(test.name, job, expression.CompileContext{})
+				if err != nil && strings.Contains(err.Error(), "runtime-dependent matrix expressions are unsupported") {
+					rejected = true
 				}
 			}
-			if matrixJobs == 0 {
-				t.Fatal("fixture has no matrix jobs")
+			if !rejected {
+				t.Fatal("runtime-dependent authored matrix value was not rejected")
 			}
 		})
 	}

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -1232,6 +1232,28 @@ jobs:
 	}
 }
 
+func TestCompileRejectsMaxParallelOnReusableWorkflowMatrix(t *testing.T) {
+	repository := t.TempDir()
+	callerPath := writeWorkflow(t, repository, "caller.yml", `on: push
+jobs:
+  delegated:
+    strategy:
+      max-parallel: 1
+      matrix: ${{ fromJSON('{"target":["one","two"]}') }}
+    uses: ./.github/workflows/reusable.yml
+`)
+	writeWorkflow(t, repository, "reusable.yml", `on: workflow_call
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps: [{run: true}]
+`)
+	_, err := Compile(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")))
+	if err == nil || !strings.Contains(err.Error(), "strategy.max-parallel on a reusable-workflow matrix cannot be preserved") {
+		t.Fatalf("Compile() error = %v, want reusable max-parallel rejection", err)
+	}
+}
+
 func TestCompileBindsNestedReusableCallGuardsToCallerNeeds(t *testing.T) {
 	repository := t.TempDir()
 	callerPath := writeWorkflow(t, repository, "caller.yml", `on: push
@@ -2283,6 +2305,25 @@ jobs:
 				t.Fatal("runtime-dependent authored matrix value was not rejected")
 			}
 		})
+	}
+}
+
+func TestValidateLocatesFailingMatrixSectionExpression(t *testing.T) {
+	source := []byte(`on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [linux]
+        include: ${{ fromJSON('[{"os":"linux"}]') }}
+        exclude: ${{ fromJSON('invalid') }}
+    steps: [{run: true}]
+`)
+	_, err := Validate("matrix.yml", source)
+	var finding *ProcessingFinding
+	if !errors.As(err, &finding) || finding.Line != 9 || !strings.Contains(err.Error(), "matrix exclude") {
+		t.Fatalf("Validate() finding = %#v, error = %v; want exclude expression at line 9", finding, err)
 	}
 }
 

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -2038,6 +2038,47 @@ jobs:
 	}
 }
 
+func TestCompilePreservesReusableInputsInNestedAuthoredMatrixValues(t *testing.T) {
+	repository := t.TempDir()
+	path := writeWorkflow(t, repository, "caller.yml", `on: push
+jobs:
+  call:
+    uses: ./.github/workflows/reusable.yml
+    with:
+      enabled: false
+      target: release
+`)
+	writeWorkflow(t, repository, "reusable.yml", `on:
+  workflow_call:
+    inputs:
+      enabled: {type: boolean}
+      target: {type: string}
+jobs:
+  test:
+    strategy:
+      matrix:
+        config:
+          - enabled: ${{ inputs.enabled }}
+            targets:
+              - ${{ inputs.target }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ${{ matrix.config.enabled }}:${{ matrix.config.targets[0] }}
+`)
+	result, err := Compile(path, readFile(t, path), readFile(t, smokePath("events", "push.json")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ir IR
+	if err := json.Unmarshal(result, &ir); err != nil {
+		t.Fatal(err)
+	}
+	wantMatrix := map[string]any{"config": map[string]any{"enabled": false, "targets": []any{"release"}}}
+	if len(ir.Jobs) != 1 || !reflect.DeepEqual(ir.Jobs[0].Matrix, wantMatrix) {
+		t.Fatalf("nested authored matrix inputs = %#v", ir.Jobs)
+	}
+}
+
 func TestCompileRejectsRuntimeExpressionsLaunderedThroughReusableInputs(t *testing.T) {
 	t.Run("unavailable static matrix value", func(t *testing.T) {
 		repository := t.TempDir()
@@ -2884,6 +2925,56 @@ jobs:
 	_, err := Compile(path, readFile(t, path), readFile(t, smokePath("events", "push.json")))
 	if err == nil || !strings.Contains(err.Error(), `deferred reusable-workflow input "enabled" must be string`) {
 		t.Fatalf("Compile() error = %v", err)
+	}
+}
+
+func TestCompileRejectsDeferredReusableInputInMatrixInclude(t *testing.T) {
+	repository := t.TempDir()
+	path := writeWorkflow(t, repository, "caller.yml", `on:
+  workflow_dispatch:
+    inputs:
+      EXTRA:
+        type: string
+        default: '[{"name":"root"}]'
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      extra: ${{ steps.value.outputs.extra }}
+    steps:
+      - id: value
+        run: echo 'extra=[]' >> "$GITHUB_OUTPUT"
+  call:
+    needs: prepare
+    uses: ./.github/workflows/reusable.yml
+    with:
+      EXTRA: ${{ needs.prepare.outputs.extra }}
+`)
+	writeWorkflow(t, repository, "reusable.yml", `on:
+  workflow_call:
+    inputs:
+      EXTRA: {type: string}
+jobs:
+  test:
+    strategy:
+      matrix:
+        include: ${{ fromJSON(inputs.EXTRA) }}
+    runs-on: ubuntu-latest
+    steps: [{run: true}]
+`)
+	var event map[string]any
+	if err := json.Unmarshal(readFile(t, smokePath("events", "push.json")), &event); err != nil {
+		t.Fatal(err)
+	}
+	event["event"] = "workflow_dispatch"
+	event["payload"] = map[string]any{"inputs": map[string]any{"EXTRA": `[{"name":"dispatch"}]`}}
+	eventSource, err := json.Marshal(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Compile(path, readFile(t, path), eventSource)
+	if err == nil || !strings.Contains(err.Error(), "reusable-workflow input expression is not statically resolvable") {
+		t.Fatalf("Compile() error = %v, want deferred matrix include rejection", err)
 	}
 }
 

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -2344,6 +2344,25 @@ jobs:
 	}
 }
 
+func TestValidateLocatesFailingAuthoredMatrixValue(t *testing.T) {
+	source := []byte(`on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - ${{ github.run_id }}
+        include: ${{ fromJSON('[{"target":"linux"}]') }}
+    steps: [{run: true}]
+`)
+	_, err := Validate("matrix.yml", source)
+	var finding *ProcessingFinding
+	if !errors.As(err, &finding) || finding.Line != 8 || !strings.Contains(err.Error(), "github.run_id") {
+		t.Fatalf("Validate() finding = %#v, error = %v; want authored value at line 8", finding, err)
+	}
+}
+
 func TestCompileResolvesGitHubRefNameInMatrixDimension(t *testing.T) {
 	workflow := []byte(`on: push
 jobs:

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -2327,6 +2327,23 @@ jobs:
 	}
 }
 
+func TestValidateRejectsNullMatrixSectionExpression(t *testing.T) {
+	source := []byte(`on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [linux]
+        exclude: ${{ github.event.matrix_exclusions }}
+    steps: [{run: true}]
+`)
+	_, err := Validate("matrix.yml", source)
+	if err == nil || !strings.Contains(err.Error(), "matrix exclude resolved to <nil>, want array") {
+		t.Fatalf("Validate() error = %v, want null exclude rejection", err)
+	}
+}
+
 func TestCompileResolvesGitHubRefNameInMatrixDimension(t *testing.T) {
 	workflow := []byte(`on: push
 jobs:

--- a/internal/compiler/job_graph_expansion.go
+++ b/internal/compiler/job_graph_expansion.go
@@ -150,17 +150,12 @@ func (e *jobGraphExpansion) expandMatrices() {
 		var matrices []map[string]any
 		if deferred {
 			e.result.runtimeMatrixBoundary = true
-			position := job.Matrix.Span.Start
-			if job.Matrix.Expression != nil {
-				position = workflow.Position{Line: job.Matrix.Expression.Span.Start.Line, Column: job.Matrix.Expression.Span.Start.Column}
-			} else if job.Matrix.IncludeExpression != nil {
-				position = workflow.Position{Line: job.Matrix.IncludeExpression.Span.Start.Line, Column: job.Matrix.IncludeExpression.Span.Start.Column}
-			}
+			line, column := matrixErrorPosition(job)
 			if err == nil {
 				e.result.runtimeMatrices = append(e.result.runtimeMatrices, descriptor)
 				err = errors.New("runtime matrix source is valid, but continuation upload is disabled because Buildkite transport has no authoritative current-attempt fence and durable idempotency boundary")
 			}
-			err = locatedJobError(sourced.path, job, position.Line, position.Column, err.Error())
+			err = locatedJobError(sourced.path, job, line, column, err.Error())
 		} else {
 			matrices, err = expandMatrix(sourced.path, job, e.context)
 		}
@@ -190,6 +185,9 @@ func matrixErrorPosition(job workflow.Job) (int, int) {
 	}
 	if job.Matrix.IncludeExpression != nil {
 		return job.Matrix.IncludeExpression.Span.Start.Line, job.Matrix.IncludeExpression.Span.Start.Column
+	}
+	if job.Matrix.ExcludeExpression != nil {
+		return job.Matrix.ExcludeExpression.Span.Start.Line, job.Matrix.ExcludeExpression.Span.Start.Column
 	}
 	return line, column
 }

--- a/internal/compiler/job_graph_expansion.go
+++ b/internal/compiler/job_graph_expansion.go
@@ -185,7 +185,7 @@ func matrixErrorPosition(job workflow.Job, err error) (int, int) {
 	}
 	var positioned matrixPositionError
 	if errors.As(err, &positioned) {
-		return positioned.span.Start.Line, positioned.span.Start.Column
+		return positioned.line, positioned.column
 	}
 	line, column = job.Matrix.Span.Start.Line, job.Matrix.Span.Start.Column
 	if job.Matrix.Expression != nil {

--- a/internal/compiler/job_graph_expansion.go
+++ b/internal/compiler/job_graph_expansion.go
@@ -150,7 +150,7 @@ func (e *jobGraphExpansion) expandMatrices() {
 		var matrices []map[string]any
 		if deferred {
 			e.result.runtimeMatrixBoundary = true
-			line, column := matrixErrorPosition(job)
+			line, column := matrixErrorPosition(job, err)
 			if err == nil {
 				e.result.runtimeMatrices = append(e.result.runtimeMatrices, descriptor)
 				err = errors.New("runtime matrix source is valid, but continuation upload is disabled because Buildkite transport has no authoritative current-attempt fence and durable idempotency boundary")
@@ -164,7 +164,7 @@ func (e *jobGraphExpansion) expandMatrices() {
 			matrices, err = expandMatrix(sourced.path, job, matrixContext)
 		}
 		if err != nil {
-			line, column := matrixErrorPosition(job)
+			line, column := matrixErrorPosition(job, err)
 			e.diagnostics = append(e.diagnostics, &ProcessingFinding{
 				Stage: StageMatrix, Code: CodeMatrixInvalid, Category: "compatibility",
 				Path: sourced.path, Line: line, Column: column, Job: job.ID,
@@ -178,10 +178,14 @@ func (e *jobGraphExpansion) expandMatrices() {
 	}
 }
 
-func matrixErrorPosition(job workflow.Job) (int, int) {
+func matrixErrorPosition(job workflow.Job, err error) (int, int) {
 	line, column := job.Span.Start.Line, job.Span.Start.Column
 	if job.Matrix == nil {
 		return line, column
+	}
+	var positioned matrixPositionError
+	if errors.As(err, &positioned) {
+		return positioned.span.Start.Line, positioned.span.Start.Column
 	}
 	line, column = job.Matrix.Span.Start.Line, job.Matrix.Span.Start.Column
 	if job.Matrix.Expression != nil {

--- a/internal/compiler/job_graph_expansion.go
+++ b/internal/compiler/job_graph_expansion.go
@@ -157,7 +157,11 @@ func (e *jobGraphExpansion) expandMatrices() {
 			}
 			err = locatedJobError(sourced.path, job, line, column, err.Error())
 		} else {
-			matrices, err = expandMatrix(sourced.path, job, e.context)
+			matrixContext := e.context
+			matrixContext.Inputs = sourced.inputs.values
+			matrixContext.Matrix = nil
+			matrixContext.Strategy = nil
+			matrices, err = expandMatrix(sourced.path, job, matrixContext)
 		}
 		if err != nil {
 			line, column := matrixErrorPosition(job)

--- a/internal/compiler/matrix.go
+++ b/internal/compiler/matrix.go
@@ -19,8 +19,8 @@ import (
 const maxMatrixInstances = 256
 
 type matrixPositionError struct {
-	err  error
-	span expression.Span
+	err          error
+	line, column int
 }
 
 func (e matrixPositionError) Error() string { return e.err.Error() }
@@ -112,11 +112,11 @@ func resolveMatrix(matrix *workflow.Matrix, context expression.CompileContext) (
 	if matrix.Expression != nil {
 		value, err := expression.EvaluateCompile(*matrix.Expression, context)
 		if err != nil {
-			return nil, matrixPositionError{err: matrixExpressionError(err), span: matrix.Expression.Span}
+			return nil, matrixPositionError{err: matrixExpressionError(err), line: matrix.Expression.Span.Start.Line, column: matrix.Expression.Span.Start.Column}
 		}
 		object, ok := value.(map[string]any)
 		if !ok {
-			return nil, matrixPositionError{err: fmt.Errorf("matrix expression resolved to %T, want object", value), span: matrix.Expression.Span}
+			return nil, matrixPositionError{err: fmt.Errorf("matrix expression resolved to %T, want object", value), line: matrix.Expression.Span.Start.Line, column: matrix.Expression.Span.Start.Column}
 		}
 		return matrixFromObject(object)
 	}
@@ -129,7 +129,7 @@ func resolveMatrix(matrix *workflow.Matrix, context expression.CompileContext) (
 			for j, matrixValue := range row.Values {
 				value, err := resolveAuthoredMatrixValue(matrixValue.Data, matrixValue.Span, context)
 				if err != nil {
-					return nil, fmt.Errorf("matrix dimension %q: %w", row.Name, matrixExpressionError(err))
+					return nil, matrixPositionError{err: fmt.Errorf("matrix dimension %q: %w", row.Name, matrixExpressionError(err)), line: matrixValue.Span.Start.Line, column: matrixValue.Span.Start.Column}
 				}
 				resolved.Rows[i].Values[j] = matrixValue
 				resolved.Rows[i].Values[j].Data = value
@@ -138,11 +138,11 @@ func resolveMatrix(matrix *workflow.Matrix, context expression.CompileContext) (
 		}
 		value, err := expression.EvaluateCompile(*row.Expression, context)
 		if err != nil {
-			return nil, matrixPositionError{err: fmt.Errorf("matrix dimension %q: %w", row.Name, matrixExpressionError(err)), span: row.Expression.Span}
+			return nil, matrixPositionError{err: fmt.Errorf("matrix dimension %q: %w", row.Name, matrixExpressionError(err)), line: row.Expression.Span.Start.Line, column: row.Expression.Span.Start.Column}
 		}
 		values, ok := value.([]any)
 		if !ok {
-			return nil, matrixPositionError{err: fmt.Errorf("matrix dimension %q resolved to %T, want array", row.Name, value), span: row.Expression.Span}
+			return nil, matrixPositionError{err: fmt.Errorf("matrix dimension %q resolved to %T, want array", row.Name, value), line: row.Expression.Span.Start.Line, column: row.Expression.Span.Start.Column}
 		}
 		resolved.Rows[i].Expression = nil
 		resolved.Rows[i].Values = make([]workflow.Value, len(values))
@@ -153,14 +153,14 @@ func resolveMatrix(matrix *workflow.Matrix, context expression.CompileContext) (
 	var err error
 	if resolved.Include, err = resolveMatrixCombinations("include", matrix.Include, matrix.IncludeExpression, context); err != nil {
 		if matrix.IncludeExpression != nil {
-			return nil, matrixPositionError{err: err, span: matrix.IncludeExpression.Span}
+			return nil, matrixPositionError{err: err, line: matrix.IncludeExpression.Span.Start.Line, column: matrix.IncludeExpression.Span.Start.Column}
 		}
 		return nil, err
 	}
 	resolved.IncludeExpression = nil
 	if resolved.Exclude, err = resolveMatrixCombinations("exclude", matrix.Exclude, matrix.ExcludeExpression, context); err != nil {
 		if matrix.ExcludeExpression != nil {
-			return nil, matrixPositionError{err: err, span: matrix.ExcludeExpression.Span}
+			return nil, matrixPositionError{err: err, line: matrix.ExcludeExpression.Span.Start.Line, column: matrix.ExcludeExpression.Span.Start.Column}
 		}
 		return nil, err
 	}
@@ -178,7 +178,7 @@ func resolveMatrixCombinations(name string, combinations []workflow.MatrixCombin
 				matrixValue := combination.Values[key]
 				value, err := resolveAuthoredMatrixValue(matrixValue.Data, matrixValue.Span, context)
 				if err != nil {
-					return nil, fmt.Errorf("matrix %s: %w", name, matrixExpressionError(err))
+					return nil, matrixPositionError{err: fmt.Errorf("matrix %s: %w", name, matrixExpressionError(err)), line: matrixValue.Span.Start.Line, column: matrixValue.Span.Start.Column}
 				}
 				matrixValue.Data = value
 				resolved[i].Values[key] = matrixValue

--- a/internal/compiler/matrix.go
+++ b/internal/compiler/matrix.go
@@ -261,19 +261,20 @@ func matrixFromObject(object map[string]any) (*workflow.Matrix, error) {
 		matrix.Rows = append(matrix.Rows, row)
 	}
 	var err error
-	if matrix.Include, err = matrixCombinationsFromValue("include", object["include"]); err != nil {
-		return nil, err
+	if value, ok := object["include"]; ok {
+		if matrix.Include, err = matrixCombinationsFromValue("include", value); err != nil {
+			return nil, err
+		}
 	}
-	if matrix.Exclude, err = matrixCombinationsFromValue("exclude", object["exclude"]); err != nil {
-		return nil, err
+	if value, ok := object["exclude"]; ok {
+		if matrix.Exclude, err = matrixCombinationsFromValue("exclude", value); err != nil {
+			return nil, err
+		}
 	}
 	return matrix, nil
 }
 
 func matrixCombinationsFromValue(name string, value any) ([]workflow.MatrixCombination, error) {
-	if value == nil {
-		return nil, nil
-	}
 	items, ok := value.([]any)
 	if !ok {
 		return nil, fmt.Errorf("matrix %s resolved to %T, want array", name, value)

--- a/internal/compiler/matrix.go
+++ b/internal/compiler/matrix.go
@@ -18,14 +18,22 @@ import (
 
 const maxMatrixInstances = 256
 
+type matrixPositionError struct {
+	err  error
+	span expression.Span
+}
+
+func (e matrixPositionError) Error() string { return e.err.Error() }
+func (e matrixPositionError) Unwrap() error { return e.err }
+
 func expandMatrix(path string, job workflow.Job, context expression.CompileContext) ([]map[string]any, error) {
 	if job.Matrix == nil {
 		return []map[string]any{nil}, nil
 	}
 	matrix, err := resolveMatrix(job.Matrix, context)
 	if err != nil {
-		line, column := matrixErrorPosition(job)
-		return nil, locatedJobError(path, job, line, column, err.Error())
+		line, column := matrixErrorPosition(job, err)
+		return nil, locatedJobWrappedError(path, job, line, column, "", err)
 	}
 	matrices, err := expandMatrixDefinition(matrix)
 	if err != nil {
@@ -104,11 +112,11 @@ func resolveMatrix(matrix *workflow.Matrix, context expression.CompileContext) (
 	if matrix.Expression != nil {
 		value, err := expression.EvaluateCompile(*matrix.Expression, context)
 		if err != nil {
-			return nil, matrixExpressionError(err)
+			return nil, matrixPositionError{err: matrixExpressionError(err), span: matrix.Expression.Span}
 		}
 		object, ok := value.(map[string]any)
 		if !ok {
-			return nil, fmt.Errorf("matrix expression resolved to %T, want object", value)
+			return nil, matrixPositionError{err: fmt.Errorf("matrix expression resolved to %T, want object", value), span: matrix.Expression.Span}
 		}
 		return matrixFromObject(object)
 	}
@@ -130,11 +138,11 @@ func resolveMatrix(matrix *workflow.Matrix, context expression.CompileContext) (
 		}
 		value, err := expression.EvaluateCompile(*row.Expression, context)
 		if err != nil {
-			return nil, fmt.Errorf("matrix dimension %q: %w", row.Name, matrixExpressionError(err))
+			return nil, matrixPositionError{err: fmt.Errorf("matrix dimension %q: %w", row.Name, matrixExpressionError(err)), span: row.Expression.Span}
 		}
 		values, ok := value.([]any)
 		if !ok {
-			return nil, fmt.Errorf("matrix dimension %q resolved to %T, want array", row.Name, value)
+			return nil, matrixPositionError{err: fmt.Errorf("matrix dimension %q resolved to %T, want array", row.Name, value), span: row.Expression.Span}
 		}
 		resolved.Rows[i].Expression = nil
 		resolved.Rows[i].Values = make([]workflow.Value, len(values))
@@ -144,10 +152,16 @@ func resolveMatrix(matrix *workflow.Matrix, context expression.CompileContext) (
 	}
 	var err error
 	if resolved.Include, err = resolveMatrixCombinations("include", matrix.Include, matrix.IncludeExpression, context); err != nil {
+		if matrix.IncludeExpression != nil {
+			return nil, matrixPositionError{err: err, span: matrix.IncludeExpression.Span}
+		}
 		return nil, err
 	}
 	resolved.IncludeExpression = nil
 	if resolved.Exclude, err = resolveMatrixCombinations("exclude", matrix.Exclude, matrix.ExcludeExpression, context); err != nil {
+		if matrix.ExcludeExpression != nil {
+			return nil, matrixPositionError{err: err, span: matrix.ExcludeExpression.Span}
+		}
 		return nil, err
 	}
 	resolved.ExcludeExpression = nil

--- a/internal/compiler/matrix.go
+++ b/internal/compiler/matrix.go
@@ -24,13 +24,8 @@ func expandMatrix(path string, job workflow.Job, context expression.CompileConte
 	}
 	matrix, err := resolveMatrix(job.Matrix, context)
 	if err != nil {
-		position := job.Matrix.Span.Start
-		if job.Matrix.Expression != nil {
-			position = workflow.Position{Line: job.Matrix.Expression.Span.Start.Line, Column: job.Matrix.Expression.Span.Start.Column}
-		} else if job.Matrix.IncludeExpression != nil {
-			position = workflow.Position{Line: job.Matrix.IncludeExpression.Span.Start.Line, Column: job.Matrix.IncludeExpression.Span.Start.Column}
-		}
-		return nil, locatedJobError(path, job, position.Line, position.Column, err.Error())
+		line, column := matrixErrorPosition(job)
+		return nil, locatedJobError(path, job, line, column, err.Error())
 	}
 	matrices, err := expandMatrixDefinition(matrix)
 	if err != nil {
@@ -122,7 +117,15 @@ func resolveMatrix(matrix *workflow.Matrix, context expression.CompileContext) (
 	for i, row := range matrix.Rows {
 		resolved.Rows[i] = row
 		if row.Expression == nil {
-			resolved.Rows[i].Values = append([]workflow.Value(nil), row.Values...)
+			resolved.Rows[i].Values = make([]workflow.Value, len(row.Values))
+			for j, matrixValue := range row.Values {
+				value, err := resolveAuthoredMatrixValue(matrixValue.Data, matrixValue.Span, context)
+				if err != nil {
+					return nil, fmt.Errorf("matrix dimension %q: %w", row.Name, matrixExpressionError(err))
+				}
+				resolved.Rows[i].Values[j] = matrixValue
+				resolved.Rows[i].Values[j].Data = value
+			}
 			continue
 		}
 		value, err := expression.EvaluateCompile(*row.Expression, context)
@@ -139,10 +142,81 @@ func resolveMatrix(matrix *workflow.Matrix, context expression.CompileContext) (
 			resolved.Rows[i].Values[j] = workflow.Value{Data: value, Span: row.Span}
 		}
 	}
-	if matrix.IncludeExpression != nil {
-		return nil, fmt.Errorf("runtime-dependent matrix include expressions are unsupported")
+	var err error
+	if resolved.Include, err = resolveMatrixCombinations("include", matrix.Include, matrix.IncludeExpression, context); err != nil {
+		return nil, err
 	}
+	resolved.IncludeExpression = nil
+	if resolved.Exclude, err = resolveMatrixCombinations("exclude", matrix.Exclude, matrix.ExcludeExpression, context); err != nil {
+		return nil, err
+	}
+	resolved.ExcludeExpression = nil
 	return &resolved, nil
+}
+
+func resolveMatrixCombinations(name string, combinations []workflow.MatrixCombination, expr *expression.Expression, context expression.CompileContext) ([]workflow.MatrixCombination, error) {
+	if expr == nil {
+		resolved := make([]workflow.MatrixCombination, len(combinations))
+		for i, combination := range combinations {
+			resolved[i] = combination
+			resolved[i].Values = make(map[string]workflow.Value, len(combination.Values))
+			for _, key := range sortedKeys(combination.Values) {
+				matrixValue := combination.Values[key]
+				value, err := resolveAuthoredMatrixValue(matrixValue.Data, matrixValue.Span, context)
+				if err != nil {
+					return nil, fmt.Errorf("matrix %s: %w", name, matrixExpressionError(err))
+				}
+				matrixValue.Data = value
+				resolved[i].Values[key] = matrixValue
+			}
+		}
+		return resolved, nil
+	}
+	value, err := expression.EvaluateCompile(*expr, context)
+	if err != nil {
+		return nil, fmt.Errorf("matrix %s: %w", name, matrixExpressionError(err))
+	}
+	resolved, err := matrixCombinationsFromValue(name, value)
+	if err != nil {
+		return nil, err
+	}
+	return resolved, nil
+}
+
+func resolveAuthoredMatrixValue(value any, span workflow.Span, context expression.CompileContext) (any, error) {
+	switch value := value.(type) {
+	case string:
+		if !strings.Contains(value, "${{") {
+			return value, nil
+		}
+		if expr, err := expression.Parse(value, span.Start.Line, span.Start.Column); err == nil {
+			return expression.EvaluateCompile(expr, context)
+		}
+		return expression.EvaluateCompileTemplate(value, context)
+	case []any:
+		resolved := make([]any, len(value))
+		for i, item := range value {
+			var err error
+			resolved[i], err = resolveAuthoredMatrixValue(item, span, context)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return resolved, nil
+	case map[string]any:
+		resolved := make(map[string]any, len(value))
+		for _, key := range sortedKeys(value) {
+			item := value[key]
+			var err error
+			resolved[key], err = resolveAuthoredMatrixValue(item, span, context)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return resolved, nil
+	default:
+		return value, nil
+	}
 }
 
 func matrixExpressionError(err error) error {
@@ -257,7 +331,7 @@ func reportableRunnerLabels(job workflow.Job, labels []string) []string {
 	if !strings.HasPrefix(strings.ToLower(body), "matrix.") || strings.ContainsAny(body, " []()|&") {
 		return nil
 	}
-	if job.Matrix.Expression != nil || job.Matrix.IncludeExpression != nil {
+	if job.Matrix.Expression != nil || job.Matrix.IncludeExpression != nil || job.Matrix.ExcludeExpression != nil {
 		return nil
 	}
 	for _, row := range job.Matrix.Rows {

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -334,6 +334,9 @@ func (resolver *reusableResolver) resolve(ctx context.Context, current reusableW
 		if err != nil {
 			return reusableResolution{}, err
 		}
+		if job.MaxParallel != nil && len(matrices) > 1 {
+			return reusableResolution{}, jobError(path, job, "strategy.max-parallel on a reusable-workflow matrix cannot be preserved when the called jobs are flattened")
+		}
 		var members []string
 		var callOutputs []needOutputBinding
 		callNamespaces := make(map[string]struct{}, len(matrices))

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -240,11 +240,6 @@ func (resolver *reusableResolver) resolve(ctx context.Context, current reusableW
 				return reusableResolution{}, err
 			}
 		}
-		if job.Reusable != nil {
-			if err := rejectCallMatrixExpressions(path, job); err != nil {
-				return reusableResolution{}, err
-			}
-		}
 		callNeedBindings := replacementNeeds(job.Needs, replacements)
 		needBindings := callNeedBindings
 		if len(job.Needs) == 0 {
@@ -331,7 +326,11 @@ func (resolver *reusableResolver) resolve(ctx context.Context, current reusableW
 		}
 		calleeDigest := "sha256:" + sha256Sum(source)
 
-		matrices, err := expandMatrix(path, job, expression.CompileContext{})
+		matrixContext := resolver.context
+		matrixContext.Inputs = inputs.values
+		matrixContext.Matrix = nil
+		matrixContext.Strategy = nil
+		matrices, err := expandMatrix(path, job, matrixContext)
 		if err != nil {
 			return reusableResolution{}, err
 		}
@@ -1145,35 +1144,6 @@ func rejectUnresolvedInputExpressions(path string, job workflow.Job, deferredInp
 	return nil
 }
 
-func rejectCallMatrixExpressions(path string, job workflow.Job) error {
-	if job.Matrix == nil {
-		return nil
-	}
-	if job.Matrix.Expression != nil {
-		return locatedJobError(path, job, job.Matrix.Expression.Span.Start.Line, job.Matrix.Expression.Span.Start.Column, "expression-valued reusable-workflow matrices are unsupported")
-	}
-	for _, row := range job.Matrix.Rows {
-		if row.Expression != nil {
-			return locatedJobError(path, job, row.Expression.Span.Start.Line, row.Expression.Span.Start.Column, fmt.Sprintf("expression-valued reusable-workflow matrix dimension %q is unsupported", row.Name))
-		}
-		for _, value := range row.Values {
-			if containsExpression(value.Data) {
-				return locatedJobError(path, job, value.Span.Start.Line, value.Span.Start.Column, "runtime-dependent reusable-workflow matrix value is unsupported")
-			}
-		}
-	}
-	for _, combinations := range [][]workflow.MatrixCombination{job.Matrix.Include, job.Matrix.Exclude} {
-		for _, combination := range combinations {
-			for _, value := range combination.Values {
-				if containsExpression(value.Data) {
-					return locatedJobError(path, job, value.Span.Start.Line, value.Span.Start.Column, "runtime-dependent reusable-workflow matrix value is unsupported")
-				}
-			}
-		}
-	}
-	return nil
-}
-
 func appendMapValues(out []string, values map[string]string) []string {
 	for _, value := range values {
 		out = append(out, value)
@@ -1236,8 +1206,12 @@ func deferredInputPlaceholders(inputs map[string]needBinding) map[string]any {
 
 func cloneMatrixWithInputs(matrix *workflow.Matrix, inputs map[string]any) *workflow.Matrix {
 	out := *matrix
+	out.Expression = cloneMatrixExpressionWithInputs(matrix.Expression, inputs)
+	out.IncludeExpression = cloneMatrixExpressionWithInputs(matrix.IncludeExpression, inputs)
+	out.ExcludeExpression = cloneMatrixExpressionWithInputs(matrix.ExcludeExpression, inputs)
 	out.Rows = append([]workflow.MatrixRow(nil), matrix.Rows...)
 	for i := range out.Rows {
+		out.Rows[i].Expression = cloneMatrixExpressionWithInputs(matrix.Rows[i].Expression, inputs)
 		out.Rows[i].Values = append([]workflow.Value(nil), out.Rows[i].Values...)
 		for j := range out.Rows[i].Values {
 			if text, ok := out.Rows[i].Values[j].Data.(string); ok {
@@ -1247,6 +1221,17 @@ func cloneMatrixWithInputs(matrix *workflow.Matrix, inputs map[string]any) *work
 	}
 	out.Include = cloneMatrixCombinations(matrix.Include, inputs)
 	out.Exclude = cloneMatrixCombinations(matrix.Exclude, inputs)
+	return &out
+}
+
+func cloneMatrixExpressionWithInputs(expr *expression.Expression, inputs map[string]any) *expression.Expression {
+	if expr == nil {
+		return nil
+	}
+	out := *expr
+	if resolved, err := expression.SubstituteCompileInputs(expr.Text, inputs); err == nil {
+		out.Text = resolved
+	}
 	return &out
 }
 

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -1092,6 +1092,12 @@ func rejectUnresolvedInputExpressions(path string, job workflow.Job, deferredInp
 		if job.Matrix.Expression != nil {
 			jobValues = append(jobValues, job.Matrix.Expression.Text)
 		}
+		if job.Matrix.IncludeExpression != nil {
+			jobValues = append(jobValues, job.Matrix.IncludeExpression.Text)
+		}
+		if job.Matrix.ExcludeExpression != nil {
+			jobValues = append(jobValues, job.Matrix.ExcludeExpression.Text)
+		}
 		for _, row := range job.Matrix.Rows {
 			if row.Expression != nil {
 				jobValues = append(jobValues, row.Expression.Text)
@@ -1214,9 +1220,7 @@ func cloneMatrixWithInputs(matrix *workflow.Matrix, inputs map[string]any) *work
 		out.Rows[i].Expression = cloneMatrixExpressionWithInputs(matrix.Rows[i].Expression, inputs)
 		out.Rows[i].Values = append([]workflow.Value(nil), out.Rows[i].Values...)
 		for j := range out.Rows[i].Values {
-			if text, ok := out.Rows[i].Values[j].Data.(string); ok {
-				out.Rows[i].Values[j].Data = replaceStaticInputs(text, inputs)
-			}
+			out.Rows[i].Values[j].Data = resolveAuthoredMatrixInputs(out.Rows[i].Values[j].Data, inputs)
 		}
 	}
 	out.Include = cloneMatrixCombinations(matrix.Include, inputs)
@@ -1241,13 +1245,46 @@ func cloneMatrixCombinations(combinations []workflow.MatrixCombination, inputs m
 		out[i] = combination
 		out[i].Values = make(map[string]workflow.Value, len(combination.Values))
 		for name, value := range combination.Values {
-			if text, ok := value.Data.(string); ok {
-				value.Data = replaceStaticInputs(text, inputs)
-			}
+			value.Data = resolveAuthoredMatrixInputs(value.Data, inputs)
 			out[i].Values[name] = value
 		}
 	}
 	return out
+}
+
+func resolveAuthoredMatrixInputs(value any, inputs map[string]any) any {
+	switch value := value.(type) {
+	case string:
+		resolved, err := expression.SubstituteCompileInputs(value, inputs)
+		if err != nil || resolved == value {
+			return value
+		}
+		if expr, err := expression.Parse(resolved, 1, 1); err == nil {
+			if evaluated, available, err := expression.EvaluateCompileAvailable(expr, expression.CompileContext{}); err == nil && available {
+				if text, ok := evaluated.(string); !ok || !strings.Contains(text, "${{") {
+					return evaluated
+				}
+			}
+		}
+		if evaluated, err := expression.EvaluateAvailableCompileTemplate(resolved, expression.CompileContext{}); err == nil {
+			return evaluated
+		}
+		return value
+	case []any:
+		resolved := make([]any, len(value))
+		for i, item := range value {
+			resolved[i] = resolveAuthoredMatrixInputs(item, inputs)
+		}
+		return resolved
+	case map[string]any:
+		resolved := make(map[string]any, len(value))
+		for _, key := range sortedKeys(value) {
+			resolved[key] = resolveAuthoredMatrixInputs(value[key], inputs)
+		}
+		return resolved
+	default:
+		return value
+	}
 }
 
 func replaceMapInputs(values map[string]string, inputs map[string]any) map[string]string {

--- a/internal/compiler/runtime_matrix.go
+++ b/internal/compiler/runtime_matrix.go
@@ -59,7 +59,7 @@ func hasRuntimeMatrixBoundary(parsed *workflow.Workflow) bool {
 		if job.Matrix == nil {
 			continue
 		}
-		for _, candidate := range []*expression.Expression{job.Matrix.Expression, job.Matrix.IncludeExpression} {
+		for _, candidate := range []*expression.Expression{job.Matrix.Expression, job.Matrix.IncludeExpression, job.Matrix.ExcludeExpression} {
 			if candidate == nil {
 				continue
 			}

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -1529,6 +1529,7 @@ func TestEvaluateCompileSupportsGraphContextsAndFromJSON(t *testing.T) {
 		},
 		Event:  map[string]any{"action": "opened"},
 		Vars:   map[string]string{"RUNNERS": `["ubuntu-24.04","ubuntu-22.04"]`},
+		Inputs: map[string]any{"TARGETS": `["linux","darwin"]`},
 		Matrix: map[string]any{"os": "ubuntu-24.04"},
 	}
 	tests := []struct {
@@ -1541,6 +1542,7 @@ func TestEvaluateCompileSupportsGraphContextsAndFromJSON(t *testing.T) {
 		{expression: "${{ github.base_ref }}", want: "main"},
 		{expression: "${{ github.event.action }}", want: "opened"},
 		{expression: "${{ event.action }}", want: "opened"},
+		{expression: "${{ fromJSON(inputs.TARGETS) }}", want: []any{"linux", "darwin"}},
 		{expression: "${{ matrix.os }}", want: "ubuntu-24.04"},
 		{expression: "${{ vars.MISSING }}", want: nil},
 		{expression: "${{ github.event.number || github.ref }}", want: "refs/pull/42/merge"},
@@ -1579,7 +1581,7 @@ func TestEvaluateCompileSupportsGraphContextsAndFromJSON(t *testing.T) {
 		if err != nil {
 			t.Fatalf("EvaluateCompile(%q) error = %v", test.expression, err)
 		}
-		if got != test.want {
+		if !reflect.DeepEqual(got, test.want) {
 			t.Fatalf("EvaluateCompile(%q) = %#v, want %#v", test.expression, got, test.want)
 		}
 	}

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -206,6 +206,7 @@ type Matrix struct {
 	Include           []MatrixCombination    `json:"include,omitempty"`
 	IncludeExpression *expression.Expression `json:"include_expression,omitempty"`
 	Exclude           []MatrixCombination    `json:"exclude,omitempty"`
+	ExcludeExpression *expression.Expression `json:"exclude_expression,omitempty"`
 	Span              Span                   `json:"span"`
 }
 

--- a/internal/workflow/parse.go
+++ b/internal/workflow/parse.go
@@ -1049,9 +1049,18 @@ func adaptMatrix(path, jobID string, in *actionlint.Matrix, scalars map[Position
 			return nil, err
 		}
 	}
-	out.Exclude, err = adaptMatrixCombinations(path, jobID, "exclude", in.Exclude, scalars)
-	if err != nil {
-		return nil, err
+	if in.Exclude != nil && in.Exclude.Expression != nil {
+		expr, expressionErr := adaptExpression(in.Exclude.Expression)
+		if expressionErr != nil {
+			return nil, locatedError(path, in.Exclude.Expression.Pos, jobID, expressionErr.Error())
+		}
+		out.ExcludeExpression = &expr
+		out.Span.End = Position{Line: expr.Span.End.Line, Column: expr.Span.End.Column}
+	} else {
+		out.Exclude, err = adaptMatrixCombinations(path, jobID, "exclude", in.Exclude, scalars)
+		if err != nil {
+			return nil, err
+		}
 	}
 	for _, combinations := range [][]MatrixCombination{out.Include, out.Exclude} {
 		for _, combination := range combinations {

--- a/internal/workflow/parse_test.go
+++ b/internal/workflow/parse_test.go
@@ -783,6 +783,30 @@ jobs:
 	}
 }
 
+func TestParseRetainsMatrixExcludeExpression(t *testing.T) {
+	parsed, err := Parse("matrix.yml", []byte(`on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        exclude: ${{ fromJSON(vars.EXCLUDE) }}
+    steps:
+      - run: true
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	matrix := parsed.Jobs[0].Matrix
+	if matrix == nil || matrix.ExcludeExpression == nil || matrix.ExcludeExpression.Text != "${{ fromJSON(vars.EXCLUDE) }}" {
+		t.Fatalf("matrix exclude expression = %#v", matrix)
+	}
+	if matrix.ExcludeExpression.Span.Start.Line != 8 || matrix.ExcludeExpression.Span.Start.Column != 18 {
+		t.Fatalf("matrix exclude expression span = %#v", matrix.ExcludeExpression.Span)
+	}
+}
+
 func TestParseOwnsReusableWorkflowCallsAndInputDeclarations(t *testing.T) {
 	source := []byte(`on:
   workflow_call:


### PR DESCRIPTION
## Why

Static matrix data is still rejected in forms such as expression-valued `include` lists and reusable-workflow call matrices:

```yaml
matrix:
  os: ${{ fromJSON(vars.OPERATING_SYSTEMS) }}
  include: ${{ fromJSON(inputs.EXTRA_JOBS) }}
```

These values exist before any job runs, so they do not need runtime pipeline generation.

## What

Resolve whole matrices, dimensions, authored values, and `include` or `exclude` lists from the compile-time `github`, event, vars, and reusable-workflow input snapshots. Static matrices now compose through nested reusable-workflow calls while retaining deterministic fan-out, fan-in, instance keys, and the 256-instance limit. Ordinary job matrices retain `max-parallel`; multi-instance reusable-call matrices with `max-parallel` are rejected because flattened jobs cannot preserve invocation-level parallelism.

Matrices derived from `needs` or step outputs remain rejected. The existing runtime-matrix descriptor stays diagnostic-only; this does not enable continuation uploads.
