### PR TITLE
Run reusable workflows with concurrency groups

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -313,6 +313,7 @@ A top-level workflow that does not declare the effective event is excluded befor
 - Caller-visible aggregate results.
 - Outputs mapped directly from `jobs.<job>.outputs.<name>`.
 - Call-level `if` over caller `github`, `vars`, `inputs`, direct `needs`, and status functions.
+- Workflow-level concurrency in local and public called workflows. Groups may use the called workflow's static inputs. Each static call-matrix instance gets its own workflow gate.
 
 **❌ Unsupported:**
 
@@ -322,7 +323,6 @@ A top-level workflow that does not declare the effective event is excluded befor
 - Compound `needs`-dependent inputs or dynamic matrices.
 - Input defaults that reference `inputs`.
 - Literal or compound output expressions.
-- Top-level concurrency in the called workflow.
 
 Job-level `uses`, `with`, and `secrets` follow these boundaries.
 
@@ -445,9 +445,45 @@ jobs:
     concurrency: deploy-${{ matrix.target }}
 ```
 
+Called workflows keep workflow-level concurrency around all flattened jobs. Inputs can derive the group from a caller matrix:
+
+```yaml
+# .github/workflows/deploy.yml
+on:
+  workflow_call:
+    inputs:
+      target:
+        type: string
+        required: true
+
+concurrency: deploy-${{ inputs.target }}
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    steps: [{run: ./plan}]
+  apply:
+    needs: plan
+    runs-on: ubuntu-latest
+    steps: [{run: ./apply}]
+```
+
+```yaml
+jobs:
+  deploy:
+    strategy:
+      matrix:
+        target: [staging, production]
+    uses: ./.github/workflows/deploy.yml
+    with:
+      target: ${{ matrix.target }}
+```
+
+Nested called workflows keep nested gates. Jobs within one called workflow remain parallel except for their declared `needs` and job-level concurrency. A called-workflow group that depends on a deferred `needs` output is unsupported because Buildkite must create the gate during compilation.
+
 Buildkite queues every waiting entry. It does not replace GitHub's existing pending entry. The `queue` key is unsupported.
 
-Workflow-level literal or expression-resolved `cancel-in-progress: true` emits a warning and does not cancel. Job-level cancellation remains unsupported. Buildkite **Cancel Intermediate Builds** and **Skip Intermediate Builds** settings can approximate same-branch cancellation.
+Workflow-level literal or expression-resolved `cancel-in-progress: true`, including in called workflows, emits a warning and does not cancel. Job-level cancellation remains unsupported. Buildkite's uploaded step contract has no concurrency-group cancellation field; `concurrency_method` controls admission order only. Buildkite **Cancel Intermediate Builds** and **Skip Intermediate Builds** settings can approximate same-branch cancellation.
 
 Cancel the whole Buildkite build rather than one job when a workflow-level concurrency gate is active.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -479,7 +479,7 @@ jobs:
       target: ${{ matrix.target }}
 ```
 
-Nested called workflows keep nested gates. Jobs within one called workflow remain parallel except for their declared `needs` and job-level concurrency. A called-workflow group that depends on a deferred `needs` output is unsupported because Buildkite must create the gate during compilation.
+Nested called workflows keep nested gates. Jobs within one called workflow remain parallel except for their declared `needs` and job-level concurrency. A called-workflow group that depends on a deferred `needs` output is unsupported because Buildkite must create the gate during compilation. Calls with `if` and calls whose prerequisite job uses the same concurrency group as the called workflow are also unsupported because Buildkite cannot preserve GitHub's admission order for those cases.
 
 Buildkite queues every waiting entry. It does not replace GitHub's existing pending entry. The `queue` key is unsupported.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -479,7 +479,7 @@ jobs:
       target: ${{ matrix.target }}
 ```
 
-Nested called workflows keep nested gates. Jobs within one called workflow remain parallel except for their declared `needs` and job-level concurrency. Calls with `if` or `needs` and jobs that reuse their enclosing workflow group are unsupported because Buildkite cannot preserve GitHub's admission order for those cases.
+Nested called workflows keep nested gates. Jobs within one called workflow remain parallel except for their declared `needs` and job-level concurrency. Calls with `if` or `needs`, and jobs or nested called workflows that reuse an enclosing workflow group, are unsupported because Buildkite cannot preserve GitHub's admission order for those cases.
 
 Buildkite queues every waiting entry. It does not replace GitHub's existing pending entry. The `queue` key is unsupported.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -479,7 +479,7 @@ jobs:
       target: ${{ matrix.target }}
 ```
 
-Nested called workflows keep nested gates. Jobs within one called workflow remain parallel except for their declared `needs` and job-level concurrency. A called-workflow group that depends on a deferred `needs` output is unsupported because Buildkite must create the gate during compilation. Calls with `if` and calls whose prerequisite job uses the same concurrency group as the called workflow are also unsupported because Buildkite cannot preserve GitHub's admission order for those cases.
+Nested called workflows keep nested gates. Jobs within one called workflow remain parallel except for their declared `needs` and job-level concurrency. Calls with `if` or `needs` and jobs that reuse their enclosing workflow group are unsupported because Buildkite cannot preserve GitHub's admission order for those cases.
 
 Buildkite queues every waiting entry. It does not replace GitHub's existing pending entry. The `queue` key is unsupported.
 

--- a/internal/buildkite/pipeline.go
+++ b/internal/buildkite/pipeline.go
@@ -247,6 +247,13 @@ func Emit(pipeline Pipeline) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
+		if workflow.ConcurrencyGate != nil {
+			for _, gate := range gates {
+				if gate.Group == workflow.ConcurrencyGate.Group {
+					return nil, fmt.Errorf("reusable-workflow concurrency gate %q shares group with enclosing workflow gate", gate.ID)
+				}
+			}
+		}
 		for gateIndex := range gates {
 			gate := &gates[gateIndex]
 			gateNamespace := pipeline.CompilerStep + "\x00" + gate.ID
@@ -536,6 +543,15 @@ func prepareReusableConcurrencyGates(jobs []Job) ([]preparedConcurrencyGate, err
 			}
 			gates[index].Members = append(gates[index].Members, job.Key)
 			parentID = declared.ID
+		}
+	}
+	for _, gate := range gates {
+		for parentID := gate.ParentID; parentID != ""; {
+			parent := gates[indexes[parentID]]
+			if parent.Group == gate.Group {
+				return nil, fmt.Errorf("reusable-workflow concurrency gate %q shares group with enclosing gate %q", gate.ID, parent.ID)
+			}
+			parentID = parent.ParentID
 		}
 	}
 	for _, gate := range gates {

--- a/internal/buildkite/pipeline.go
+++ b/internal/buildkite/pipeline.go
@@ -503,7 +503,9 @@ func emitWorkflow(out *bytes.Buffer, pipeline Pipeline, workflow preparedWorkflo
 func prepareReusableConcurrencyGates(jobs []Job) ([]preparedConcurrencyGate, error) {
 	var gates []preparedConcurrencyGate
 	indexes := make(map[string]int)
+	jobsByKey := make(map[string]Job, len(jobs))
 	for _, job := range jobs {
+		jobsByKey[job.Key] = job
 		parentID := ""
 		seen := make(map[string]bool, len(job.ConcurrencyGates))
 		for _, declared := range job.ConcurrencyGates {
@@ -527,6 +529,28 @@ func prepareReusableConcurrencyGates(jobs []Job) ([]preparedConcurrencyGate, err
 			}
 			gates[index].Members = append(gates[index].Members, job.Key)
 			parentID = declared.ID
+		}
+	}
+	for _, gate := range gates {
+		members := make(map[string]bool, len(gate.Members))
+		seen := make(map[string]bool)
+		var prerequisites []string
+		for _, key := range gate.Members {
+			members[key] = true
+			prerequisites = append(prerequisites, jobsByKey[key].Dependencies...)
+		}
+		for len(prerequisites) != 0 {
+			key := prerequisites[0]
+			prerequisites = prerequisites[1:]
+			if members[key] || seen[key] {
+				continue
+			}
+			seen[key] = true
+			job := jobsByKey[key]
+			if job.Concurrency > 0 && job.ConcurrencyGroup == gate.Group {
+				return nil, fmt.Errorf("reusable-workflow concurrency gate %q shares group with prerequisite job %q", gate.ID, key)
+			}
+			prerequisites = append(prerequisites, job.Dependencies...)
 		}
 	}
 	return gates, nil

--- a/internal/buildkite/pipeline.go
+++ b/internal/buildkite/pipeline.go
@@ -222,6 +222,13 @@ func Emit(pipeline Pipeline) ([]byte, error) {
 			}
 			usedDigests[job.PlanDigest] = job.Key
 		}
+		if workflow.ConcurrencyGate != nil {
+			for _, job := range jobs {
+				if job.Concurrency > 0 && job.ConcurrencyGroup == workflow.ConcurrencyGate.Group {
+					return nil, fmt.Errorf("workflow concurrency gate shares group with member job %q", job.Key)
+				}
+			}
+		}
 		prepared[i] = preparedWorkflow{Workflow: workflow, Jobs: jobs, Grouped: aggregate || workflow.GroupLabel != "", Aggregate: aggregate}
 		if workflow.ConcurrencyGate != nil {
 			gateNamespace := pipeline.CompilerStep
@@ -533,34 +540,25 @@ func prepareReusableConcurrencyGates(jobs []Job) ([]preparedConcurrencyGate, err
 	}
 	for _, gate := range gates {
 		members := make(map[string]bool, len(gate.Members))
-		seen := make(map[string]bool)
-		var prerequisites []string
 		for _, key := range gate.Members {
-			members[key] = true
-			prerequisites = append(prerequisites, jobsByKey[key].Dependencies...)
-		}
-		for len(prerequisites) != 0 {
-			key := prerequisites[0]
-			prerequisites = prerequisites[1:]
-			if members[key] || seen[key] {
-				continue
-			}
-			seen[key] = true
 			job := jobsByKey[key]
 			if job.Concurrency > 0 && job.ConcurrencyGroup == gate.Group {
-				return nil, fmt.Errorf("reusable-workflow concurrency gate %q shares group with prerequisite job %q", gate.ID, key)
+				return nil, fmt.Errorf("reusable-workflow concurrency gate %q shares group with member job %q", gate.ID, key)
 			}
-			prerequisites = append(prerequisites, job.Dependencies...)
+			members[key] = true
+		}
+		for _, key := range gate.Members {
+			for _, dependency := range jobsByKey[key].Dependencies {
+				if !members[dependency] {
+					return nil, fmt.Errorf("reusable-workflow concurrency gate %q has an external prerequisite", gate.ID)
+				}
+			}
 		}
 	}
 	return gates, nil
 }
 
 func reusableGateOpenDependencies(workflow preparedWorkflow, gate preparedConcurrencyGate, openKeys map[string]string, compilerStep string) []dependency {
-	member := make(map[string]bool, len(gate.Members))
-	for _, key := range gate.Members {
-		member[key] = true
-	}
 	seen := make(map[string]bool)
 	var dependencies []dependency
 	add := func(step string, allowFailure bool) {
@@ -576,17 +574,6 @@ func reusableGateOpenDependencies(workflow preparedWorkflow, gate preparedConcur
 		add(workflow.GateOpenKey, false)
 	case !workflow.Aggregate:
 		add(compilerStep, false)
-	}
-	jobs := make(map[string]Job, len(workflow.Jobs))
-	for _, job := range workflow.Jobs {
-		jobs[job.Key] = job
-	}
-	for _, key := range gate.Members {
-		for _, jobDependency := range jobs[key].Dependencies {
-			if !member[jobDependency] {
-				add(jobDependency, true)
-			}
-		}
 	}
 	return dependencies
 }

--- a/internal/buildkite/pipeline.go
+++ b/internal/buildkite/pipeline.go
@@ -74,9 +74,10 @@ type Failure struct {
 	Summary        string
 }
 
-// ConcurrencyGate serializes an entire generated workflow while allowing the
-// jobs between its opening and closing steps to run in parallel.
+// ConcurrencyGate serializes one workflow scope while allowing its jobs to run
+// in parallel. ID identifies called-workflow scopes; the root scope leaves it empty.
 type ConcurrencyGate struct {
+	ID    string
 	Group string
 	Queue string
 }
@@ -115,6 +116,7 @@ type Job struct {
 	SoftFail           bool
 	ConcurrencyGroup   string
 	Concurrency        int
+	ConcurrencyGates   []ConcurrencyGate
 }
 
 // PlanPath returns the fixed local path for a content-addressed job plan.
@@ -234,6 +236,25 @@ func Emit(pipeline Pipeline) ([]byte, error) {
 				usedKeys[gateKey] = "workflow concurrency gate"
 			}
 		}
+		gates, err := prepareReusableConcurrencyGates(jobs)
+		if err != nil {
+			return nil, err
+		}
+		for gateIndex := range gates {
+			gate := &gates[gateIndex]
+			gateNamespace := pipeline.CompilerStep + "\x00" + gate.ID
+			if aggregate {
+				gateNamespace += "\x00" + workflow.GroupKey
+			}
+			gate.OpenKey, gate.CloseKey = concurrencyGateKeys(gateNamespace, gate.Group, jobs)
+			for _, gateKey := range []string{gate.OpenKey, gate.CloseKey} {
+				if owner, exists := usedKeys[gateKey]; exists {
+					return nil, fmt.Errorf("reusable-workflow concurrency key %q collides with %s", gateKey, owner)
+				}
+				usedKeys[gateKey] = "reusable-workflow concurrency gate"
+			}
+		}
+		prepared[i].ReusableConcurrencyGates = gates
 	}
 	var out bytes.Buffer
 	out.WriteString("steps:\n")
@@ -251,6 +272,13 @@ type preparedWorkflow struct {
 	Grouped                   bool
 	Aggregate                 bool
 	GateOpenKey, GateCloseKey string
+	ReusableConcurrencyGates  []preparedConcurrencyGate
+}
+
+type preparedConcurrencyGate struct {
+	ConcurrencyGate
+	ParentID, OpenKey, CloseKey string
+	Members                     []string
 }
 
 func emitWorkflow(out *bytes.Buffer, pipeline Pipeline, workflow preparedWorkflow) error {
@@ -318,11 +346,43 @@ func emitWorkflow(out *bytes.Buffer, pipeline Pipeline, workflow preparedWorkflo
 	}
 	attributeIndent := stepIndent + "  "
 	if workflow.ConcurrencyGate != nil {
+		// Keep each opening marker immediately before its dependency-blocked
+		// closing marker. Their ordered queue positions hold the group before a
+		// later build or sibling scope can enter it.
 		dependencies := []dependency{{Step: pipeline.CompilerStep}}
 		if workflow.Aggregate {
 			dependencies = nil
 		}
 		emitConcurrencyGateStep(out, stepIndent, attributeIndent, ":github: Start workflow concurrency", workflow.GateOpenKey, workflow.ConcurrencyGate, dependencies)
+		dependencies = make([]dependency, 0, len(workflow.Jobs)+len(workflow.ReusableConcurrencyGates)+1)
+		if !workflow.Aggregate {
+			dependencies = append(dependencies, dependency{Step: pipeline.CompilerStep})
+		}
+		for _, job := range workflow.Jobs {
+			dependencies = append(dependencies, dependency{Step: job.Key, AllowFailure: true})
+		}
+		for _, gate := range workflow.ReusableConcurrencyGates {
+			if gate.ParentID == "" {
+				dependencies = append(dependencies, dependency{Step: gate.CloseKey, AllowFailure: true})
+			}
+		}
+		emitConcurrencyGateStep(out, stepIndent, attributeIndent, ":github: Finish workflow concurrency", workflow.GateCloseKey, workflow.ConcurrencyGate, dependencies)
+	}
+	gateOpenKeys := make(map[string]string, len(workflow.ReusableConcurrencyGates))
+	for _, gate := range workflow.ReusableConcurrencyGates {
+		dependencies := reusableGateOpenDependencies(workflow, gate, gateOpenKeys, pipeline.CompilerStep)
+		emitConcurrencyGateStep(out, stepIndent, attributeIndent, ":github: Start reusable-workflow concurrency", gate.OpenKey, &gate.ConcurrencyGate, dependencies)
+		gateOpenKeys[gate.ID] = gate.OpenKey
+		dependencies = make([]dependency, 0, len(gate.Members)+len(workflow.ReusableConcurrencyGates))
+		for _, member := range gate.Members {
+			dependencies = append(dependencies, dependency{Step: member, AllowFailure: true})
+		}
+		for _, child := range workflow.ReusableConcurrencyGates {
+			if child.ParentID == gate.ID {
+				dependencies = append(dependencies, dependency{Step: child.CloseKey, AllowFailure: true})
+			}
+		}
+		emitConcurrencyGateStep(out, stepIndent, attributeIndent, ":github: Finish reusable-workflow concurrency", gate.CloseKey, &gate.ConcurrencyGate, dependencies)
 	}
 	for _, job := range workflow.Jobs {
 		platform := job.Platform
@@ -424,7 +484,7 @@ func emitWorkflow(out *bytes.Buffer, pipeline Pipeline, workflow preparedWorkflo
 		if !workflow.Aggregate {
 			_, _ = fmt.Fprintf(out, "%sdepends_on:\n", attributeIndent)
 			_, _ = fmt.Fprintf(out, "%s  - step: %s\n%s    allow_failure: false\n", attributeIndent, yamlScalar(pipeline.CompilerStep), attributeIndent)
-		} else if workflow.GateOpenKey != "" || len(job.Dependencies) != 0 {
+		} else if workflow.GateOpenKey != "" || len(job.Dependencies) != 0 || len(job.ConcurrencyGates) != 0 {
 			_, _ = fmt.Fprintf(out, "%sdepends_on:\n", attributeIndent)
 		}
 		if workflow.GateOpenKey != "" {
@@ -433,18 +493,78 @@ func emitWorkflow(out *bytes.Buffer, pipeline Pipeline, workflow preparedWorkflo
 		for _, dependency := range job.Dependencies {
 			_, _ = fmt.Fprintf(out, "%s  - step: %s\n%s    allow_failure: true\n", attributeIndent, yamlScalar(dependency), attributeIndent)
 		}
-	}
-	if workflow.ConcurrencyGate != nil {
-		dependencies := make([]dependency, 0, len(workflow.Jobs)+1)
-		if !workflow.Aggregate {
-			dependencies = append(dependencies, dependency{Step: pipeline.CompilerStep})
+		for _, gate := range job.ConcurrencyGates {
+			_, _ = fmt.Fprintf(out, "%s  - step: %s\n%s    allow_failure: false\n", attributeIndent, yamlScalar(gateOpenKeys[gate.ID]), attributeIndent)
 		}
-		for _, job := range workflow.Jobs {
-			dependencies = append(dependencies, dependency{Step: job.Key, AllowFailure: true})
-		}
-		emitConcurrencyGateStep(out, stepIndent, attributeIndent, ":github: Finish workflow concurrency", workflow.GateCloseKey, workflow.ConcurrencyGate, dependencies)
 	}
 	return nil
+}
+
+func prepareReusableConcurrencyGates(jobs []Job) ([]preparedConcurrencyGate, error) {
+	var gates []preparedConcurrencyGate
+	indexes := make(map[string]int)
+	for _, job := range jobs {
+		parentID := ""
+		seen := make(map[string]bool, len(job.ConcurrencyGates))
+		for _, declared := range job.ConcurrencyGates {
+			if declared.ID == "" || declared.Group == "" || len(declared.Group) > maxConcurrencyGroupLength {
+				return nil, fmt.Errorf("job %q has invalid reusable-workflow concurrency gate", job.Key)
+			}
+			if seen[declared.ID] {
+				return nil, fmt.Errorf("job %q repeats reusable-workflow concurrency gate %q", job.Key, declared.ID)
+			}
+			seen[declared.ID] = true
+			index, exists := indexes[declared.ID]
+			if !exists {
+				index = len(gates)
+				indexes[declared.ID] = index
+				gates = append(gates, preparedConcurrencyGate{
+					ConcurrencyGate: ConcurrencyGate{ID: declared.ID, Group: declared.Group, Queue: job.Queue},
+					ParentID:        parentID,
+				})
+			} else if gates[index].Group != declared.Group || gates[index].ParentID != parentID {
+				return nil, fmt.Errorf("reusable-workflow concurrency gate %q has inconsistent membership", declared.ID)
+			}
+			gates[index].Members = append(gates[index].Members, job.Key)
+			parentID = declared.ID
+		}
+	}
+	return gates, nil
+}
+
+func reusableGateOpenDependencies(workflow preparedWorkflow, gate preparedConcurrencyGate, openKeys map[string]string, compilerStep string) []dependency {
+	member := make(map[string]bool, len(gate.Members))
+	for _, key := range gate.Members {
+		member[key] = true
+	}
+	seen := make(map[string]bool)
+	var dependencies []dependency
+	add := func(step string, allowFailure bool) {
+		if step != "" && !seen[step] {
+			seen[step] = true
+			dependencies = append(dependencies, dependency{Step: step, AllowFailure: allowFailure})
+		}
+	}
+	switch {
+	case gate.ParentID != "":
+		add(openKeys[gate.ParentID], false)
+	case workflow.GateOpenKey != "":
+		add(workflow.GateOpenKey, false)
+	case !workflow.Aggregate:
+		add(compilerStep, false)
+	}
+	jobs := make(map[string]Job, len(workflow.Jobs))
+	for _, job := range workflow.Jobs {
+		jobs[job.Key] = job
+	}
+	for _, key := range gate.Members {
+		for _, jobDependency := range jobs[key].Dependencies {
+			if !member[jobDependency] {
+				add(jobDependency, true)
+			}
+		}
+	}
+	return dependencies
 }
 
 func emitWorkflowCheck(out *bytes.Buffer, indent, provider string, workflow preparedWorkflow, checkKey, jobLabel, title, summary string) {

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -763,6 +763,22 @@ func TestEmitWrapsNestedReusableWorkflowConcurrencyGates(t *testing.T) {
 	}
 }
 
+func TestEmitRejectsReusableConcurrencyGroupSharedWithPrerequisite(t *testing.T) {
+	group := "buildkite-gha/concurrency/deploy"
+	_, err := Emit(Pipeline{
+		CompilerStep:       "importer",
+		DistributionDigest: testDigest("distribution"),
+		Jobs: []Job{
+			{Key: "prepare", Label: "Prepare", Queue: "linux", PlanDigest: testDigest("prepare"), Concurrency: 1, ConcurrencyGroup: group},
+			{Key: "approve", Label: "Approve", Queue: "linux", PlanDigest: testDigest("approve"), Dependencies: []string{"prepare"}},
+			{Key: "deploy", Label: "Deploy", Queue: "linux", PlanDigest: testDigest("deploy"), Dependencies: []string{"approve"}, ConcurrencyGates: []ConcurrencyGate{{ID: "call", Group: group}}},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), `shares group with prerequisite job "prepare"`) {
+		t.Fatalf("Emit() error = %v, want shared prerequisite group rejection", err)
+	}
+}
+
 func TestEmitUsesDefaultAgentTargetingWhenQueueIsEmpty(t *testing.T) {
 	output, err := Emit(Pipeline{
 		CompilerStep:       "importer",

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -811,6 +811,40 @@ func TestEmitRejectsConcurrencyGroupSharedWithMemberJob(t *testing.T) {
 	}
 }
 
+func TestEmitRejectsConcurrencyGroupSharedWithEnclosingGate(t *testing.T) {
+	group := "buildkite-gha/concurrency/deploy"
+	tests := []struct {
+		name     string
+		pipeline Pipeline
+		want     string
+	}{
+		{
+			name: "workflow",
+			pipeline: Pipeline{
+				CompilerStep: "importer", DistributionDigest: testDigest("distribution"), ConcurrencyGate: &ConcurrencyGate{Group: group},
+				Jobs: []Job{{Key: "deploy", Label: "Deploy", Queue: "linux", PlanDigest: testDigest("workflow-gate"), ConcurrencyGates: []ConcurrencyGate{{ID: "call", Group: group}}}},
+			},
+			want: `concurrency gate "call" shares group with enclosing workflow gate`,
+		},
+		{
+			name: "nested reusable workflow",
+			pipeline: Pipeline{
+				CompilerStep: "importer", DistributionDigest: testDigest("distribution"),
+				Jobs: []Job{{Key: "deploy", Label: "Deploy", Queue: "linux", PlanDigest: testDigest("nested-gate"), ConcurrencyGates: []ConcurrencyGate{{ID: "outer", Group: group}, {ID: "inner", Group: group}}}},
+			},
+			want: `concurrency gate "inner" shares group with enclosing gate "outer"`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := Emit(test.pipeline)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Emit() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
 func TestEmitUsesDefaultAgentTargetingWhenQueueIsEmpty(t *testing.T) {
 	output, err := Emit(Pipeline{
 		CompilerStep:       "importer",

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -718,8 +718,8 @@ func TestEmitWrapsNestedReusableWorkflowConcurrencyGates(t *testing.T) {
 		DistributionDigest: testDigest("distribution"),
 		Jobs: []Job{
 			{Key: "prepare", Label: "Prepare", Queue: "linux", PlanDigest: testDigest("prepare")},
-			{Key: "outer_start", Label: "Outer start", Queue: "linux", PlanDigest: testDigest("outer-start"), Dependencies: []string{"prepare"}, ConcurrencyGates: []ConcurrencyGate{outer}},
-			{Key: "inner", Label: "Inner", Queue: "mac", PlanDigest: testDigest("inner"), Dependencies: []string{"outer_start"}, ConcurrencyGates: []ConcurrencyGate{outer, inner}},
+			{Key: "outer_start", Label: "Outer start", Queue: "linux", PlanDigest: testDigest("outer-start"), ConcurrencyGates: []ConcurrencyGate{outer}},
+			{Key: "inner", Label: "Inner", Queue: "mac", PlanDigest: testDigest("inner"), ConcurrencyGates: []ConcurrencyGate{outer, inner}},
 			{Key: "outer_finish", Label: "Outer finish", Queue: "linux", PlanDigest: testDigest("outer-finish"), Dependencies: []string{"inner"}, ConcurrencyGates: []ConcurrencyGate{outer}},
 		},
 	}
@@ -749,10 +749,10 @@ func TestEmitWrapsNestedReusableWorkflowConcurrencyGates(t *testing.T) {
 	}
 	outerOpen, outerClose := document.Steps[0], document.Steps[1]
 	innerOpen, innerClose := document.Steps[2], document.Steps[3]
-	if outerOpen.ConcurrencyGroup != outer.Group || outerOpen.Agents["queue"] != "linux" || len(outerOpen.DependsOn) != 2 || outerOpen.DependsOn[1].Step != "prepare" || !outerOpen.DependsOn[1].AllowFailure {
+	if outerOpen.ConcurrencyGroup != outer.Group || outerOpen.Agents["queue"] != "mac" || len(outerOpen.DependsOn) != 1 || outerOpen.DependsOn[0].Step != "importer" || outerOpen.DependsOn[0].AllowFailure {
 		t.Fatalf("outer opening gate = %#v", outerOpen)
 	}
-	if innerOpen.ConcurrencyGroup != inner.Group || innerOpen.Agents["queue"] != "mac" || len(innerOpen.DependsOn) != 2 || innerOpen.DependsOn[0].Step != outerOpen.Key || innerOpen.DependsOn[0].AllowFailure || innerOpen.DependsOn[1].Step != "outer_start" || !innerOpen.DependsOn[1].AllowFailure {
+	if innerOpen.ConcurrencyGroup != inner.Group || innerOpen.Agents["queue"] != "mac" || len(innerOpen.DependsOn) != 1 || innerOpen.DependsOn[0].Step != outerOpen.Key || innerOpen.DependsOn[0].AllowFailure {
 		t.Fatalf("inner opening gate = %#v", innerOpen)
 	}
 	if innerClose.ConcurrencyGroup != inner.Group || len(innerClose.DependsOn) != 1 || innerClose.DependsOn[0].Step != "inner" || !innerClose.DependsOn[0].AllowFailure {
@@ -763,19 +763,51 @@ func TestEmitWrapsNestedReusableWorkflowConcurrencyGates(t *testing.T) {
 	}
 }
 
-func TestEmitRejectsReusableConcurrencyGroupSharedWithPrerequisite(t *testing.T) {
-	group := "buildkite-gha/concurrency/deploy"
+func TestEmitRejectsReusableConcurrencyWithExternalPrerequisite(t *testing.T) {
 	_, err := Emit(Pipeline{
 		CompilerStep:       "importer",
 		DistributionDigest: testDigest("distribution"),
 		Jobs: []Job{
-			{Key: "prepare", Label: "Prepare", Queue: "linux", PlanDigest: testDigest("prepare"), Concurrency: 1, ConcurrencyGroup: group},
-			{Key: "approve", Label: "Approve", Queue: "linux", PlanDigest: testDigest("approve"), Dependencies: []string{"prepare"}},
-			{Key: "deploy", Label: "Deploy", Queue: "linux", PlanDigest: testDigest("deploy"), Dependencies: []string{"approve"}, ConcurrencyGates: []ConcurrencyGate{{ID: "call", Group: group}}},
+			{Key: "prepare", Label: "Prepare", Queue: "linux", PlanDigest: testDigest("prepare")},
+			{Key: "deploy", Label: "Deploy", Queue: "linux", PlanDigest: testDigest("deploy"), Dependencies: []string{"prepare"}, ConcurrencyGates: []ConcurrencyGate{{ID: "call", Group: "buildkite-gha/concurrency/deploy"}}},
 		},
 	})
-	if err == nil || !strings.Contains(err.Error(), `shares group with prerequisite job "prepare"`) {
-		t.Fatalf("Emit() error = %v, want shared prerequisite group rejection", err)
+	if err == nil || !strings.Contains(err.Error(), `concurrency gate "call" has an external prerequisite`) {
+		t.Fatalf("Emit() error = %v, want external prerequisite rejection", err)
+	}
+}
+
+func TestEmitRejectsConcurrencyGroupSharedWithMemberJob(t *testing.T) {
+	group := "buildkite-gha/concurrency/deploy"
+	tests := []struct {
+		name     string
+		pipeline Pipeline
+		want     string
+	}{
+		{
+			name: "workflow",
+			pipeline: Pipeline{
+				CompilerStep: "importer", DistributionDigest: testDigest("distribution"), ConcurrencyGate: &ConcurrencyGate{Group: group},
+				Jobs: []Job{{Key: "deploy", Label: "Deploy", Queue: "linux", PlanDigest: testDigest("workflow-deploy"), Concurrency: 1, ConcurrencyGroup: group}},
+			},
+			want: `workflow concurrency gate shares group with member job "deploy"`,
+		},
+		{
+			name: "reusable workflow",
+			pipeline: Pipeline{
+				CompilerStep: "importer", DistributionDigest: testDigest("distribution"),
+				Jobs: []Job{{Key: "deploy", Label: "Deploy", Queue: "linux", PlanDigest: testDigest("reusable-deploy"), Concurrency: 1, ConcurrencyGroup: group, ConcurrencyGates: []ConcurrencyGate{{ID: "call", Group: group}}}},
+			},
+			want: `reusable-workflow concurrency gate "call" shares group with member job "deploy"`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := Emit(test.pipeline)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Emit() error = %v, want %q", err, test.want)
+			}
+		})
 	}
 }
 

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -586,7 +586,7 @@ func TestEmitAggregateWorkflowConcurrencyDependencies(t *testing.T) {
 		t.Fatalf("aggregate concurrency group = %#v\n%s", document.Steps, output)
 	}
 	openKey, closeKey := concurrencyGateKeys("importer\x00workflow-ci", pipeline.Workflows[0].ConcurrencyGate.Group, pipeline.Workflows[0].Jobs)
-	open, producer, consumer, close := document.Steps[0].Steps[0], document.Steps[0].Steps[1], document.Steps[0].Steps[2], document.Steps[0].Steps[3]
+	open, close, producer, consumer := document.Steps[0].Steps[0], document.Steps[0].Steps[1], document.Steps[0].Steps[2], document.Steps[0].Steps[3]
 	if open.Key != openKey || len(open.DependsOn) != 0 {
 		t.Fatalf("aggregate opening gate = %#v", open)
 	}
@@ -676,7 +676,7 @@ func TestEmitWrapsJobsInWorkflowConcurrencyGate(t *testing.T) {
 		t.Fatalf("steps = %#v\n%s", document.Steps, output)
 	}
 	openKey, closeKey := concurrencyGateKeys(pipeline.CompilerStep, pipeline.ConcurrencyGate.Group, pipeline.Jobs)
-	open, producer, consumer, close := document.Steps[0], document.Steps[1], document.Steps[2], document.Steps[3]
+	open, close, producer, consumer := document.Steps[0], document.Steps[1], document.Steps[2], document.Steps[3]
 	if open.Key != openKey || open.Concurrency != 1 || open.ConcurrencyGroup != pipeline.ConcurrencyGate.Group || len(open.DependsOn) != 1 || open.DependsOn[0].Step != "importer" || open.DependsOn[0].AllowFailure {
 		t.Fatalf("opening gate = %#v", open)
 	}
@@ -707,6 +707,59 @@ func TestEmitWrapsJobsInWorkflowConcurrencyGate(t *testing.T) {
 		if !dependency.AllowFailure {
 			t.Fatalf("closing gate has strict generated dependency: %#v", close.DependsOn)
 		}
+	}
+}
+
+func TestEmitWrapsNestedReusableWorkflowConcurrencyGates(t *testing.T) {
+	outer := ConcurrencyGate{ID: "call", Group: "buildkite-gha/concurrency/outer"}
+	inner := ConcurrencyGate{ID: "call-inner", Group: "buildkite-gha/concurrency/inner"}
+	pipeline := Pipeline{
+		CompilerStep:       "importer",
+		DistributionDigest: testDigest("distribution"),
+		Jobs: []Job{
+			{Key: "prepare", Label: "Prepare", Queue: "linux", PlanDigest: testDigest("prepare")},
+			{Key: "outer_start", Label: "Outer start", Queue: "linux", PlanDigest: testDigest("outer-start"), Dependencies: []string{"prepare"}, ConcurrencyGates: []ConcurrencyGate{outer}},
+			{Key: "inner", Label: "Inner", Queue: "mac", PlanDigest: testDigest("inner"), Dependencies: []string{"outer_start"}, ConcurrencyGates: []ConcurrencyGate{outer, inner}},
+			{Key: "outer_finish", Label: "Outer finish", Queue: "linux", PlanDigest: testDigest("outer-finish"), Dependencies: []string{"inner"}, ConcurrencyGates: []ConcurrencyGate{outer}},
+		},
+	}
+	output, err := Emit(pipeline)
+	if err != nil {
+		t.Fatal(err)
+	}
+	type emittedDependency struct {
+		Step         string `yaml:"step"`
+		AllowFailure bool   `yaml:"allow_failure"`
+	}
+	type emittedStep struct {
+		Label            string              `yaml:"label"`
+		Key              string              `yaml:"key"`
+		ConcurrencyGroup string              `yaml:"concurrency_group"`
+		DependsOn        []emittedDependency `yaml:"depends_on"`
+		Agents           map[string]string   `yaml:"agents"`
+	}
+	var document struct {
+		Steps []emittedStep `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(output, &document); err != nil {
+		t.Fatal(err)
+	}
+	if len(document.Steps) != 8 {
+		t.Fatalf("nested reusable gate steps = %d, want 8\n%s", len(document.Steps), output)
+	}
+	outerOpen, outerClose := document.Steps[0], document.Steps[1]
+	innerOpen, innerClose := document.Steps[2], document.Steps[3]
+	if outerOpen.ConcurrencyGroup != outer.Group || outerOpen.Agents["queue"] != "linux" || len(outerOpen.DependsOn) != 2 || outerOpen.DependsOn[1].Step != "prepare" || !outerOpen.DependsOn[1].AllowFailure {
+		t.Fatalf("outer opening gate = %#v", outerOpen)
+	}
+	if innerOpen.ConcurrencyGroup != inner.Group || innerOpen.Agents["queue"] != "mac" || len(innerOpen.DependsOn) != 2 || innerOpen.DependsOn[0].Step != outerOpen.Key || innerOpen.DependsOn[0].AllowFailure || innerOpen.DependsOn[1].Step != "outer_start" || !innerOpen.DependsOn[1].AllowFailure {
+		t.Fatalf("inner opening gate = %#v", innerOpen)
+	}
+	if innerClose.ConcurrencyGroup != inner.Group || len(innerClose.DependsOn) != 1 || innerClose.DependsOn[0].Step != "inner" || !innerClose.DependsOn[0].AllowFailure {
+		t.Fatalf("inner closing gate = %#v", innerClose)
+	}
+	if outerClose.ConcurrencyGroup != outer.Group || len(outerClose.DependsOn) != 4 || outerClose.DependsOn[3].Step != innerClose.Key || !outerClose.DependsOn[3].AllowFailure {
+		t.Fatalf("outer closing gate = %#v", outerClose)
 	}
 }
 

--- a/internal/compiler/bundle.go
+++ b/internal/compiler/bundle.go
@@ -208,6 +208,11 @@ func GenerateBundlePipeline(bundle Bundle, compilerDistributionDigest, compilerS
 			RequiresMise:       job.NeedsMise(),
 			SoftFail:           job.ContinueOnError,
 		}
+		for _, gate := range ir.Jobs[i].ConcurrencyGates {
+			jobs[i].ConcurrencyGates = append(jobs[i].ConcurrencyGates, buildkitepipeline.ConcurrencyGate{
+				ID: gate.ID, Group: buildkiteConcurrencyGroup(ir.Event.Repository, gate.Group),
+			})
+		}
 		if ir.Jobs[i].Platform == PlatformLinuxAMD64 {
 			jobs[i].RuntimeImage = ir.Jobs[i].RuntimeImage
 			if jobs[i].RuntimeImage == "" {

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -1038,6 +1038,82 @@ jobs:
 	}
 }
 
+func TestCompileRejectsReusableWorkflowConcurrencySharedWithPrerequisite(t *testing.T) {
+	repository := t.TempDir()
+	writeWorkflow(t, repository, "reusable.yml", `on: workflow_call
+concurrency: deploy
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps: [{run: true}]
+`)
+	caller := writeWorkflow(t, repository, "caller.yml", `on: push
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    concurrency: DEPLOY
+    steps: [{run: true}]
+  approve:
+    needs: prepare
+    runs-on: ubuntu-latest
+    steps: [{run: true}]
+  call:
+    needs: approve
+    uses: ./.github/workflows/reusable.yml
+`)
+	_, err := CompileBundle(caller, readFile(t, caller), pushEvent(t), "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err == nil || !strings.Contains(err.Error(), `shares group with prerequisite job "gha-prepare"`) {
+		t.Fatalf("CompileBundle() error = %v, want shared prerequisite group rejection", err)
+	}
+}
+
+func TestCompileRejectsGuardedReusableWorkflowConcurrency(t *testing.T) {
+	repository := t.TempDir()
+	writeWorkflow(t, repository, "reusable.yml", `on: workflow_call
+concurrency: deploy
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps: [{run: true}]
+`)
+	caller := writeWorkflow(t, repository, "caller.yml", `on: push
+jobs:
+  call:
+    if: false
+    uses: ./.github/workflows/reusable.yml
+`)
+	_, err := CompileBundle(caller, readFile(t, caller), pushEvent(t), "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err == nil || !strings.Contains(err.Error(), "called-workflow concurrency is unsupported for guarded reusable-workflow calls") {
+		t.Fatalf("CompileBundle() error = %v, want guarded concurrency rejection", err)
+	}
+}
+
+func TestCompileRejectsNestedReusableWorkflowConcurrencyUnderGuard(t *testing.T) {
+	repository := t.TempDir()
+	writeWorkflow(t, repository, "middle.yml", `on: workflow_call
+jobs:
+  nested:
+    uses: ./.github/workflows/reusable.yml
+`)
+	writeWorkflow(t, repository, "reusable.yml", `on: workflow_call
+concurrency: deploy
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps: [{run: true}]
+`)
+	caller := writeWorkflow(t, repository, "caller.yml", `on: push
+jobs:
+  call:
+    if: github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/middle.yml
+`)
+	_, err := CompileBundle(caller, readFile(t, caller), pushEvent(t), "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err == nil || !strings.Contains(err.Error(), "called-workflow concurrency is unsupported for guarded reusable-workflow calls") {
+		t.Fatalf("CompileBundle() error = %v, want inherited guarded concurrency rejection", err)
+	}
+}
+
 func TestCompileBundleDeclaresSecretCapabilityAndNames(t *testing.T) {
 	source := []byte("name: secrets\non: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    env:\n      TOKEN: ${{ secrets['deploy_token'] }}\n    steps:\n      - run: echo \\\"${{ secrets.CANARY }}\\\"\n")
 	event := readFile(t, smokePath("events", "push.json"))

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -695,11 +695,11 @@ jobs:
 		t.Fatalf("pipeline steps = %#v\n%s", document.Steps, bundle.Pipeline)
 	}
 	wantWorkflowGroup := buildkiteConcurrencyGroup(repository, bundle.IR.Workflow.ConcurrencyGroup)
-	if document.Steps[0].Concurrency != 1 || document.Steps[0].ConcurrencyGroup != wantWorkflowGroup || document.Steps[5].Concurrency != 1 || document.Steps[5].ConcurrencyGroup != wantWorkflowGroup {
-		t.Fatalf("workflow gate groups = %#v / %#v, want %q", document.Steps[0], document.Steps[5], wantWorkflowGroup)
+	if document.Steps[0].Concurrency != 1 || document.Steps[0].ConcurrencyGroup != wantWorkflowGroup || document.Steps[1].Concurrency != 1 || document.Steps[1].ConcurrencyGroup != wantWorkflowGroup {
+		t.Fatalf("workflow gate groups = %#v / %#v, want %q", document.Steps[0], document.Steps[1], wantWorkflowGroup)
 	}
 	openKey := document.Steps[0].Key
-	for _, step := range document.Steps[1:5] {
+	for _, step := range document.Steps[2:6] {
 		if step.Concurrency != 1 || step.ConcurrencyGroup != wantJobGroups[step.Key] {
 			t.Fatalf("generated job concurrency = %#v, want %q", step, wantJobGroups[step.Key])
 		}
@@ -707,12 +707,12 @@ jobs:
 			t.Fatalf("generated job gate dependency = %#v", step.DependsOn)
 		}
 	}
-	if len(document.Steps[5].DependsOn) != 5 {
-		t.Fatalf("closing gate dependencies = %#v", document.Steps[5].DependsOn)
+	if len(document.Steps[1].DependsOn) != 5 {
+		t.Fatalf("closing gate dependencies = %#v", document.Steps[1].DependsOn)
 	}
-	for _, dependency := range document.Steps[5].DependsOn[1:] {
+	for _, dependency := range document.Steps[1].DependsOn[1:] {
 		if !dependency.AllowFailure {
-			t.Fatalf("closing gate dependency is strict: %#v", document.Steps[5].DependsOn)
+			t.Fatalf("closing gate dependency is strict: %#v", document.Steps[1].DependsOn)
 		}
 	}
 }
@@ -900,10 +900,92 @@ jobs:
 	}
 }
 
-func TestCompileRejectsCalledWorkflowConcurrency(t *testing.T) {
+func TestCompileWrapsNestedReusableWorkflowMatricesInConcurrencyGates(t *testing.T) {
+	repository := t.TempDir()
+	writeWorkflow(t, repository, "inner.yml", `on:
+  workflow_call:
+    inputs:
+      target: {type: string, required: true}
+concurrency: inner-${{ inputs.target }}
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    concurrency: job-${{ inputs.target }}
+    steps: [{run: true}]
+  test:
+    runs-on: ubuntu-latest
+    steps: [{run: true}]
+`)
+	writeWorkflow(t, repository, "outer.yml", `on:
+  workflow_call:
+    inputs:
+      target: {type: string, required: true}
+concurrency: outer-${{ inputs.target }}
+jobs:
+  inner:
+    uses: ./.github/workflows/inner.yml
+    with:
+      target: ${{ inputs.target }}
+`)
+	caller := writeWorkflow(t, repository, "caller.yml", `on: push
+concurrency: root
+jobs:
+  call:
+    strategy:
+      matrix:
+        target: [production, staging]
+    uses: ./.github/workflows/outer.yml
+    with:
+      target: ${{ matrix.target }}
+`)
+	bundle, err := CompileBundle(caller, readFile(t, caller), pushEvent(t), "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bundle.IR.Jobs) != 4 || len(bundle.Plans) != 4 {
+		t.Fatalf("compiled jobs/plans = %d/%d, want 4/4", len(bundle.IR.Jobs), len(bundle.Plans))
+	}
+	gateIDs := make(map[string]string)
+	for i, job := range bundle.IR.Jobs {
+		if len(job.ConcurrencyGates) != 2 {
+			t.Fatalf("job %q gates = %#v, want nested gates", job.Key, job.ConcurrencyGates)
+		}
+		target := job.Inputs["target"].(string)
+		if job.ConcurrencyGates[0].Group != "outer-"+target || job.ConcurrencyGates[1].Group != "inner-"+target {
+			t.Fatalf("job %q gates = %#v, want target %q", job.Key, job.ConcurrencyGates, target)
+		}
+		if strings.HasSuffix(job.LogicalJobID, ".build") && job.ConcurrencyGroup != "job-"+target {
+			t.Fatalf("job %q concurrency = %q, want target %q", job.Key, job.ConcurrencyGroup, target)
+		}
+		for _, gate := range job.ConcurrencyGates {
+			if group, exists := gateIDs[gate.ID]; exists && group != gate.Group {
+				t.Fatalf("gate %q has groups %q and %q", gate.ID, group, gate.Group)
+			}
+			gateIDs[gate.ID] = gate.Group
+		}
+		if bytes.Contains(bundle.Plans[i].Contents, []byte("workflow_concurrency_gates")) {
+			t.Fatalf("job %q plan contains pipeline-only concurrency metadata", job.Key)
+		}
+	}
+	if len(gateIDs) != 4 {
+		t.Fatalf("reusable concurrency gates = %#v, want two per matrix call", gateIDs)
+	}
+	if count := bytes.Count(bundle.Pipeline, []byte("concurrency_group:")); count != 12 {
+		t.Fatalf("pipeline concurrency steps = %d, want root, reusable gate, and job groups\n%s", count, bundle.Pipeline)
+	}
+	firstPipeline := append([]byte(nil), bundle.Pipeline...)
+	second, err := CompileBundle(caller, readFile(t, caller), pushEvent(t), "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err != nil || !bytes.Equal(firstPipeline, second.Pipeline) {
+		t.Fatalf("recompiled pipeline is not deterministic: %v", err)
+	}
+}
+
+func TestCompileWarnsWhenCalledWorkflowRequestsCancellation(t *testing.T) {
 	repository := t.TempDir()
 	writeWorkflow(t, repository, "reusable.yml", `on: workflow_call
-concurrency: reusable
+concurrency:
+  group: reusable
+  cancel-in-progress: true
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -914,9 +996,45 @@ jobs:
   call:
     uses: ./.github/workflows/reusable.yml
 `)
+	bundle, err := CompileBundle(caller, readFile(t, caller), pushEvent(t), "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bundle.IR.Warnings) != 1 || bundle.IR.Warnings[0].Code != "W_WORKFLOW_CONCURRENCY_CANCEL_IN_PROGRESS_IGNORED" || !strings.Contains(bundle.IR.Warnings[0].Message, "no concurrency-group cancellation contract") {
+		t.Fatalf("called workflow warnings = %#v", bundle.IR.Warnings)
+	}
+}
+
+func TestCompileRejectsDeferredReusableWorkflowConcurrencyInput(t *testing.T) {
+	repository := t.TempDir()
+	writeWorkflow(t, repository, "reusable.yml", `on:
+  workflow_call:
+    inputs:
+      target: {type: string, required: true}
+concurrency: deploy-${{ inputs.target }}
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps: [{run: true}]
+`)
+	caller := writeWorkflow(t, repository, "caller.yml", `on: push
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      target: ${{ steps.target.outputs.value }}
+    steps:
+      - id: target
+        run: echo value=production >> "$GITHUB_OUTPUT"
+  call:
+    needs: prepare
+    uses: ./.github/workflows/reusable.yml
+    with:
+      target: ${{ needs.prepare.outputs.target }}
+`)
 	_, err := CompileBundle(caller, readFile(t, caller), pushEvent(t), "0.0.0-test", testDistributionDigest, "gha-importer")
-	if err == nil || !strings.Contains(err.Error(), "workflow concurrency in a called reusable workflow is unsupported") {
-		t.Fatalf("CompileBundle() error = %v, want called workflow concurrency rejection", err)
+	if err == nil || !strings.Contains(err.Error(), "concurrency group cannot be resolved at compile time") {
+		t.Fatalf("CompileBundle() error = %v, want deferred concurrency rejection", err)
 	}
 }
 

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -1038,7 +1038,7 @@ jobs:
 	}
 }
 
-func TestCompileRejectsReusableWorkflowConcurrencySharedWithPrerequisite(t *testing.T) {
+func TestCompileRejectsReusableWorkflowConcurrencyWithPrerequisite(t *testing.T) {
 	repository := t.TempDir()
 	writeWorkflow(t, repository, "reusable.yml", `on: workflow_call
 concurrency: deploy
@@ -1051,7 +1051,6 @@ jobs:
 jobs:
   prepare:
     runs-on: ubuntu-latest
-    concurrency: DEPLOY
     steps: [{run: true}]
   approve:
     needs: prepare
@@ -1062,8 +1061,8 @@ jobs:
     uses: ./.github/workflows/reusable.yml
 `)
 	_, err := CompileBundle(caller, readFile(t, caller), pushEvent(t), "0.0.0-test", testDistributionDigest, "gha-importer")
-	if err == nil || !strings.Contains(err.Error(), `shares group with prerequisite job "gha-prepare"`) {
-		t.Fatalf("CompileBundle() error = %v, want shared prerequisite group rejection", err)
+	if err == nil || !strings.Contains(err.Error(), "called-workflow concurrency is unsupported for reusable-workflow calls with prerequisites") {
+		t.Fatalf("CompileBundle() error = %v, want concurrency prerequisite rejection", err)
 	}
 }
 

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -33,6 +33,13 @@ type IR struct {
 	Jobs      []JobInstance     `json:"jobs"`
 }
 
+// WorkflowConcurrencyGate is one statically resolved called-workflow
+// concurrency scope inherited by a flattened job.
+type WorkflowConcurrencyGate struct {
+	ID    string `json:"id"`
+	Group string `json:"group"`
+}
+
 // Warning is one source-located, non-fatal compatibility diagnostic.
 type Warning struct {
 	Code    string `json:"code"`
@@ -62,40 +69,41 @@ type WorkflowSource struct {
 
 // JobInstance is one statically expanded job in the owned IR.
 type JobInstance struct {
-	Key                     string                   `json:"key"`
-	LogicalJobID            string                   `json:"logical_job_id"`
-	Label                   string                   `json:"label"`
-	Needs                   []string                 `json:"needs,omitempty"`
-	NeedGroups              map[string][]string      `json:"need_groups,omitempty"`
-	NeedOutputs             map[string][]NeedOutput  `json:"need_outputs,omitempty"`
-	CallGuards              []CallGuard              `json:"call_guards,omitempty"`
-	RunsOn                  []string                 `json:"runs_on"`
-	Queue                   string                   `json:"queue"`
-	Platform                Platform                 `json:"-"`
-	RuntimeImage            string                   `json:"runtime_image,omitempty"`
-	Matrix                  map[string]any           `json:"matrix,omitempty"`
-	Inputs                  map[string]any           `json:"inputs,omitempty"`
-	DeferredInputs          map[string]DeferredInput `json:"deferred_inputs,omitempty"`
-	FailFast                *bool                    `json:"fail_fast,omitempty"`
-	MaxParallel             *int                     `json:"max_parallel,omitempty"`
-	ConcurrencyGroup        string                   `json:"concurrency_group,omitempty"`
-	Steps                   []workflow.Step          `json:"steps"`
-	Env                     map[string]string        `json:"env,omitempty"`
-	Permissions             map[string]string        `json:"permissions,omitempty"`
-	If                      string                   `json:"if,omitempty"`
-	ContinueOnError         bool                     `json:"continue_on_error,omitempty"`
-	TimeoutMinutes          float64                  `json:"timeout_minutes,omitempty"`
-	DefaultShell            string                   `json:"default_shell,omitempty"`
-	DefaultWorkingDirectory string                   `json:"default_working_directory,omitempty"`
-	Outputs                 map[string]string        `json:"outputs,omitempty"`
-	Container               *workflow.Container      `json:"container,omitempty"`
-	Services                []workflow.Service       `json:"services,omitempty"`
-	ServicesExpression      string                   `json:"services_expression,omitempty"`
-	SourcePath              string                   `json:"source_path"`
-	SourceDigest            string                   `json:"source_digest"`
-	RemoteWorkflow          *RemoteWorkflowSource    `json:"remote_workflow,omitempty"`
-	RepositoryRoot          string                   `json:"-"`
-	Source                  workflow.Span            `json:"source"`
+	Key                     string                    `json:"key"`
+	LogicalJobID            string                    `json:"logical_job_id"`
+	Label                   string                    `json:"label"`
+	Needs                   []string                  `json:"needs,omitempty"`
+	NeedGroups              map[string][]string       `json:"need_groups,omitempty"`
+	NeedOutputs             map[string][]NeedOutput   `json:"need_outputs,omitempty"`
+	CallGuards              []CallGuard               `json:"call_guards,omitempty"`
+	RunsOn                  []string                  `json:"runs_on"`
+	Queue                   string                    `json:"queue"`
+	Platform                Platform                  `json:"-"`
+	RuntimeImage            string                    `json:"runtime_image,omitempty"`
+	Matrix                  map[string]any            `json:"matrix,omitempty"`
+	Inputs                  map[string]any            `json:"inputs,omitempty"`
+	DeferredInputs          map[string]DeferredInput  `json:"deferred_inputs,omitempty"`
+	FailFast                *bool                     `json:"fail_fast,omitempty"`
+	MaxParallel             *int                      `json:"max_parallel,omitempty"`
+	ConcurrencyGroup        string                    `json:"concurrency_group,omitempty"`
+	ConcurrencyGates        []WorkflowConcurrencyGate `json:"workflow_concurrency_gates,omitempty"`
+	Steps                   []workflow.Step           `json:"steps"`
+	Env                     map[string]string         `json:"env,omitempty"`
+	Permissions             map[string]string         `json:"permissions,omitempty"`
+	If                      string                    `json:"if,omitempty"`
+	ContinueOnError         bool                      `json:"continue_on_error,omitempty"`
+	TimeoutMinutes          float64                   `json:"timeout_minutes,omitempty"`
+	DefaultShell            string                    `json:"default_shell,omitempty"`
+	DefaultWorkingDirectory string                    `json:"default_working_directory,omitempty"`
+	Outputs                 map[string]string         `json:"outputs,omitempty"`
+	Container               *workflow.Container       `json:"container,omitempty"`
+	Services                []workflow.Service        `json:"services,omitempty"`
+	ServicesExpression      string                    `json:"services_expression,omitempty"`
+	SourcePath              string                    `json:"source_path"`
+	SourceDigest            string                    `json:"source_digest"`
+	RemoteWorkflow          *RemoteWorkflowSource     `json:"remote_workflow,omitempty"`
+	RepositoryRoot          string                    `json:"-"`
+	Source                  workflow.Span             `json:"source"`
 	secretAuthority         secretAuthority
 	tokenPolicyNarrowed     bool
 	jobPermissionsIgnored   bool
@@ -324,7 +332,7 @@ func compile(ctx context.Context, path string, source, eventSource []byte, optio
 		},
 		Event:    event,
 		Vars:     vars,
-		Warnings: compilerWarnings(parsed, cancelInProgress),
+		Warnings: append(compilerWarnings(parsed, cancelInProgress), expanded.warnings...),
 		Execution: ExecutionBoundary{
 			Supported: true,
 			Reason:    "run-job rejects unsupported shells and local actions",

--- a/internal/compiler/job_graph_expansion.go
+++ b/internal/compiler/job_graph_expansion.go
@@ -20,6 +20,7 @@ type jobGraphExpansionResult struct {
 	jobs                  []ParsedJob
 	notEvaluatedJobs      map[string]bool
 	notEvaluatedInstances map[string]bool
+	warnings              []Warning
 }
 
 // jobGraphExpansion carries state while a flattened logical job graph is
@@ -69,7 +70,7 @@ func jobGraphExpansionReport(expanded jobGraphExpansionResult, warnings []Warnin
 	return Report{
 		LogicalJobs: len(expanded.jobs), Instances: len(expanded.candidates),
 		Jobs: expanded.candidates, RuntimeMatrixBoundary: expanded.runtimeMatrixBoundary,
-		RuntimeMatrices: expanded.runtimeMatrices, ParsedJobs: expanded.jobs, Warnings: warnings,
+		RuntimeMatrices: expanded.runtimeMatrices, ParsedJobs: expanded.jobs, Warnings: append(warnings, expanded.warnings...),
 		NotEvaluatedJobs: expanded.notEvaluatedJobs, NotEvaluatedInstances: expanded.notEvaluatedInstances,
 	}
 }
@@ -77,18 +78,18 @@ func jobGraphExpansionReport(expanded jobGraphExpansionResult, warnings []Warnin
 // expandJobGraph resolves reusable workflow calls, then turns the parsed
 // logical job graph into deterministic JobInstance values and report data.
 func expandJobGraph(ctx context.Context, path string, source []byte, parsed *workflow.Workflow, context expression.CompileContext, options Options) (jobGraphExpansionResult, error) {
-	resolved, runtimeMatrixBoundary, err := resolveReusableWorkflows(ctx, path, source, parsed, context, options.RepositorySource)
+	resolved, warnings, runtimeMatrixBoundary, err := resolveReusableWorkflows(ctx, path, source, parsed, context, options.RepositorySource)
 	if err != nil {
 		notEvaluatedJobs := make(map[string]bool, len(parsed.Jobs))
 		for _, job := range parsed.Jobs {
 			notEvaluatedJobs[job.ID] = true
 		}
-		return jobGraphExpansionResult{jobs: parsedJobs(path, parsed), notEvaluatedJobs: notEvaluatedJobs, runtimeMatrixBoundary: runtimeMatrixBoundary}, processingFinding(StageGraph, CodeGraphInvalid, "compatibility", err)
+		return jobGraphExpansionResult{jobs: parsedJobs(path, parsed), notEvaluatedJobs: notEvaluatedJobs, runtimeMatrixBoundary: runtimeMatrixBoundary, warnings: warnings}, processingFinding(StageGraph, CodeGraphInvalid, "compatibility", err)
 	}
 	expansion := jobGraphExpansion{
 		path: path, context: context, options: options,
 		result: jobGraphExpansionResult{
-			jobs: processingJobs(path, parsed, resolved), runtimeMatrixBoundary: runtimeMatrixBoundary,
+			jobs: processingJobs(path, parsed, resolved), runtimeMatrixBoundary: runtimeMatrixBoundary, warnings: warnings,
 			notEvaluatedJobs: make(map[string]bool), notEvaluatedInstances: make(map[string]bool),
 		},
 		acceptedIndex:  make(map[string]int, len(resolved)),
@@ -344,6 +345,7 @@ func newJobCandidate(sourced sourcedJob, job workflow.Job, matrix map[string]any
 		ContinueOnError: job.ContinueOnError, TimeoutMinutes: job.TimeoutMinutes,
 		DefaultShell: job.DefaultShell, DefaultWorkingDirectory: job.DefaultWorkingDirectory,
 		Outputs: cloneMap(job.Outputs), Container: job.Container, Services: services,
+		ConcurrencyGates:   append([]WorkflowConcurrencyGate(nil), sourced.concurrencyGates...),
 		ServicesExpression: job.ServicesExpression, SourcePath: sourced.path, SourceDigest: sourced.digest,
 		RemoteWorkflow: cloneRemoteWorkflowSource(sourced.remote), RepositoryRoot: sourced.root, Source: job.Span,
 		secretAuthority: sourced.secretAuthority, tokenPolicyNarrowed: sourced.tokenPolicyNarrowed,

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -394,6 +394,9 @@ func (resolver *reusableResolver) resolve(ctx context.Context, current reusableW
 				if err != nil {
 					return reusableResolution{}, err
 				}
+				if len(needs) != 0 {
+					return reusableResolution{}, locatedJobError(path, job, call.Span.Start.Line, call.Span.Start.Column, "called-workflow concurrency is unsupported for reusable-workflow calls with prerequisites")
+				}
 				calleeConcurrencyGates = append(append([]WorkflowConcurrencyGate(nil), concurrencyGates...), WorkflowConcurrencyGate{ID: callNamespace, Group: group})
 				if cancelInProgress && !resolver.warnedCancellation[calleeCallPosition] {
 					resolver.warnedCancellation[calleeCallPosition] = true

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -379,6 +379,9 @@ func (resolver *reusableResolver) resolve(ctx context.Context, current reusableW
 			}
 			calleeConcurrencyGates := concurrencyGates
 			if callee.Concurrency != nil {
+				if len(calleeGuards) != 0 {
+					return reusableResolution{}, locatedJobError(path, job, call.Span.Start.Line, call.Span.Start.Column, "called-workflow concurrency is unsupported for guarded reusable-workflow calls")
+				}
 				concurrencyContext := resolver.context
 				concurrencyContext.Inputs = callInputs.values
 				concurrencyContext.Matrix = nil

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -41,6 +41,7 @@ type sourcedJob struct {
 	jobPermissionsIgnored bool
 	reusableCall          workflow.Position
 	callGuards            []sourcedCallGuard
+	concurrencyGates      []WorkflowConcurrencyGate
 }
 
 type secretAuthority struct {
@@ -95,9 +96,11 @@ type reusableResolver struct {
 	rootPermissions       *workflow.Permissions
 	expanded              int
 	runtimeMatrixBoundary bool
+	warnings              []Warning
+	warnedCancellation    map[workflow.Position]bool
 }
 
-func resolveReusableWorkflows(ctx context.Context, path string, source []byte, parsed *workflow.Workflow, context expression.CompileContext, repositorySource RepositorySource) ([]sourcedJob, bool, error) {
+func resolveReusableWorkflows(ctx context.Context, path string, source []byte, parsed *workflow.Workflow, context expression.CompileContext, repositorySource RepositorySource) ([]sourcedJob, []Warning, bool, error) {
 	digest := "sha256:" + sha256Sum(source)
 	runtimeMatrixBoundary := hasRuntimeMatrixBoundary(parsed)
 	if !hasReusableCall(parsed) {
@@ -106,12 +109,12 @@ func resolveReusableWorkflows(ctx context.Context, path string, source []byte, p
 		if isRepositoryWorkflowPath(path) {
 			repositoryRoot, canonicalPath, err := workflowRepository(path)
 			if err != nil {
-				return nil, runtimeMatrixBoundary, err
+				return nil, nil, runtimeMatrixBoundary, err
 			}
 			root = repositoryRoot
 			sourcePath, err = repositoryWorkflowPath(repositoryRoot, canonicalPath)
 			if err != nil {
-				return nil, runtimeMatrixBoundary, err
+				return nil, nil, runtimeMatrixBoundary, err
 			}
 		}
 		jobs := make([]sourcedJob, len(parsed.Jobs))
@@ -120,7 +123,7 @@ func resolveReusableWorkflows(ctx context.Context, path string, source []byte, p
 		for i, job := range parsed.Jobs {
 			resolvedJob, err := applyStaticInputs(sourcePath, job, context.Inputs)
 			if err != nil {
-				return nil, runtimeMatrixBoundary, err
+				return nil, nil, runtimeMatrixBoundary, err
 			}
 			job = resolvedJob
 			job.Permissions = effectivePermissions(job.Permissions, parsed.Permissions, nil, false)
@@ -133,18 +136,19 @@ func resolveReusableWorkflows(ctx context.Context, path string, source []byte, p
 			replacements[job.ID] = needBinding{members: []string{job.ID}}
 		}
 		if _, err := resolveWorkflowCallOutputs(sourcePath, parsed.CallOutputs, workflowJobs, replacements); err != nil {
-			return nil, runtimeMatrixBoundary, err
+			return nil, nil, runtimeMatrixBoundary, err
 		}
-		return jobs, runtimeMatrixBoundary, nil
+		return jobs, nil, runtimeMatrixBoundary, nil
 	}
 
 	rootSource, err := localReusableWorkflowSource(path)
 	if err != nil {
-		return nil, runtimeMatrixBoundary, err
+		return nil, nil, runtimeMatrixBoundary, err
 	}
 	resolver := reusableResolver{
 		workspaceRoot: rootSource.repositoryRoot, repositorySource: newMemoizedActionSource(repositorySource), stack: []reusableSourceIdentity{rootSource.identity}, context: context,
 		rootPermissions: effectivePermissions(nil, parsed.Permissions, nil, false), runtimeMatrixBoundary: runtimeMatrixBoundary,
+		warnedCancellation: make(map[workflow.Position]bool),
 	}
 	defer func() {
 		for _, materialized := range resolver.materialized {
@@ -152,8 +156,8 @@ func resolveReusableWorkflows(ctx context.Context, path string, source []byte, p
 		}
 	}()
 	resolver.discoverRuntimeMatrixBoundaries(ctx, rootSource, parsed, 0, map[string]int{rootSource.identity.key(): 0})
-	resolution, err := resolver.resolve(ctx, rootSource, digest, parsed, "", "", reusableInputs{values: context.Inputs}, nil, nil, secretAuthority{unrestricted: true}, false, workflow.Position{}, nil, 0)
-	return resolution.jobs, resolver.runtimeMatrixBoundary, err
+	resolution, err := resolver.resolve(ctx, rootSource, digest, parsed, "", "", reusableInputs{values: context.Inputs}, nil, nil, secretAuthority{unrestricted: true}, false, workflow.Position{}, nil, nil, 0)
+	return resolution.jobs, resolver.warnings, resolver.runtimeMatrixBoundary, err
 }
 
 func hasReusableCall(parsed *workflow.Workflow) bool {
@@ -202,7 +206,7 @@ func (resolver *reusableResolver) discoverRuntimeMatrixBoundaries(ctx context.Co
 	}
 }
 
-func (resolver *reusableResolver) resolve(ctx context.Context, current reusableWorkflowSource, digest string, parsed *workflow.Workflow, namespace, labelPrefix string, inputs reusableInputs, externalNeeds map[string]needBinding, permissionCeiling *workflow.Permissions, secrets secretAuthority, tokenPolicyNarrowed bool, reusableCallPosition workflow.Position, callGuards []sourcedCallGuard, depth int) (reusableResolution, error) {
+func (resolver *reusableResolver) resolve(ctx context.Context, current reusableWorkflowSource, digest string, parsed *workflow.Workflow, namespace, labelPrefix string, inputs reusableInputs, externalNeeds map[string]needBinding, permissionCeiling *workflow.Permissions, secrets secretAuthority, tokenPolicyNarrowed bool, reusableCallPosition workflow.Position, callGuards []sourcedCallGuard, concurrencyGates []WorkflowConcurrencyGate, depth int) (reusableResolution, error) {
 	path := current.displayPath
 	resolver.runtimeMatrixBoundary = resolver.runtimeMatrixBoundary || hasRuntimeMatrixBoundary(parsed)
 	jobs := make(map[string]workflow.Job, len(parsed.Jobs))
@@ -274,7 +278,8 @@ func (resolver *reusableResolver) resolve(ctx context.Context, current reusableW
 				Job: job, path: path, digest: digest, root: resolver.workspaceRoot, remote: cloneRemoteWorkflowSource(current.remote), inputs: cloneReusableInputs(inputs),
 				secretAuthority: cloneSecretAuthority(secrets), needBindings: needBindings,
 				tokenPolicyNarrowed: jobTokenPolicyNarrowed, jobPermissionsIgnored: jobPermissionsIgnored, reusableCall: reusableCallPosition,
-				callGuards: cloneSourcedCallGuards(callGuards),
+				callGuards:       cloneSourcedCallGuards(callGuards),
+				concurrencyGates: append([]WorkflowConcurrencyGate(nil), concurrencyGates...),
 			})
 			replacements[id] = needBinding{members: []string{job.ID}}
 			continue
@@ -326,9 +331,6 @@ func (resolver *reusableResolver) resolve(ctx context.Context, current reusableW
 		if err != nil {
 			return reusableResolution{}, err
 		}
-		if callee.Concurrency != nil {
-			return reusableResolution{}, fmt.Errorf("%s:%d:%d: workflow concurrency in a called reusable workflow is unsupported", calleeSource.displayPath, callee.Concurrency.Span.Start.Line, callee.Concurrency.Span.Start.Column)
-		}
 		calleeDigest := "sha256:" + sha256Sum(source)
 
 		matrices, err := expandMatrix(path, job, expression.CompileContext{})
@@ -375,8 +377,31 @@ func (resolver *reusableResolver) resolve(ctx context.Context, current reusableW
 			if depth == 0 {
 				calleeCallPosition = call.Span.Start
 			}
+			calleeConcurrencyGates := concurrencyGates
+			if callee.Concurrency != nil {
+				concurrencyContext := resolver.context
+				concurrencyContext.Inputs = callInputs.values
+				concurrencyContext.Matrix = nil
+				concurrencyContext.Strategy = nil
+				group, err := resolveConcurrency(calleeSource.displayPath, "", callee.Concurrency, concurrencyContext, nil)
+				if err != nil {
+					return reusableResolution{}, err
+				}
+				cancelInProgress, err := resolveWorkflowCancellation(calleeSource.displayPath, callee.Concurrency, concurrencyContext)
+				if err != nil {
+					return reusableResolution{}, err
+				}
+				calleeConcurrencyGates = append(append([]WorkflowConcurrencyGate(nil), concurrencyGates...), WorkflowConcurrencyGate{ID: callNamespace, Group: group})
+				if cancelInProgress && !resolver.warnedCancellation[calleeCallPosition] {
+					resolver.warnedCancellation[calleeCallPosition] = true
+					resolver.warnings = append(resolver.warnings, Warning{
+						Code: "W_WORKFLOW_CONCURRENCY_CANCEL_IN_PROGRESS_IGNORED", Line: calleeCallPosition.Line, Column: calleeCallPosition.Column,
+						Message: fmt.Sprintf("called workflow %q concurrency cancel-in-progress is not enforced; Buildkite has no concurrency-group cancellation contract", call.Uses),
+					})
+				}
+			}
 			resolver.stack = append(resolver.stack, calleeSource.identity)
-			calleeResolution, err := resolver.resolve(ctx, calleeSource, calleeDigest, callee, callNamespace, callLabel, callInputs, needBindings, calleePermissionCeiling, calleeSecrets, jobTokenPolicyNarrowed, calleeCallPosition, calleeGuards, depth+1)
+			calleeResolution, err := resolver.resolve(ctx, calleeSource, calleeDigest, callee, callNamespace, callLabel, callInputs, needBindings, calleePermissionCeiling, calleeSecrets, jobTokenPolicyNarrowed, calleeCallPosition, calleeGuards, calleeConcurrencyGates, depth+1)
 			resolver.stack = resolver.stack[:len(resolver.stack)-1]
 			if err != nil {
 				message := "reusable workflow could not be resolved"

--- a/internal/compiler/reusable_remote_test.go
+++ b/internal/compiler/reusable_remote_test.go
@@ -147,6 +147,40 @@ jobs:
 	}
 }
 
+func TestCompilePublicReusableWorkflowConcurrency(t *testing.T) {
+	callerRoot := t.TempDir()
+	callerPath := writeWorkflow(t, callerRoot, "caller.yml", `on: push
+jobs:
+  delegated:
+    uses: owner/workflows/.github/workflows/deploy.yml@v1
+    with:
+      target: production
+`)
+	remoteRoot := t.TempDir()
+	writeWorkflow(t, remoteRoot, "deploy.yml", `on:
+  workflow_call:
+    inputs:
+      target: {type: string, required: true}
+concurrency: deploy-${{ inputs.target }}
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps: [{run: true}]
+`)
+	options := defaultOptions()
+	options.RepositorySource = MemoizeRepositorySource(newFakeReusableRepositorySource(t, map[string]string{"owner/workflows": remoteRoot}))
+	bundle, err := CompileBundleWithOptions(callerPath, readFile(t, callerPath), pushEvent(t), "0.0.0-test", testDistributionDigest, "gha-importer", options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bundle.IR.Jobs) != 1 || len(bundle.IR.Jobs[0].ConcurrencyGates) != 1 || bundle.IR.Jobs[0].ConcurrencyGates[0].Group != "deploy-production" {
+		t.Fatalf("public reusable concurrency = %#v", bundle.IR.Jobs)
+	}
+	if count := strings.Count(string(bundle.Pipeline), "concurrency_group:"); count != 2 {
+		t.Fatalf("public reusable concurrency gates = %d, want 2\n%s", count, bundle.Pipeline)
+	}
+}
+
 func TestCompileRejectsSecretInheritanceIntoRemoteReusableWorkflows(t *testing.T) {
 	for _, test := range []struct {
 		name   string

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -1390,6 +1390,19 @@ func TestNestedMatrixReferencesAreSupported(t *testing.T) {
 	}
 }
 
+func TestEvaluateCompileTemplateResolvesReusableWorkflowConcurrencyInputs(t *testing.T) {
+	context := CompileContext{Inputs: map[string]any{"target": "production"}}
+	got, err := EvaluateCompileTemplate("deploy-${{ inputs.target }}", context)
+	if err != nil || got != "deploy-production" {
+		t.Fatalf("EvaluateCompileTemplate() = %q, %v", got, err)
+	}
+	for _, template := range []string{"${{ needs.prepare.result }}", "${{ strategy.job-index }}"} {
+		if _, err := EvaluateCompileTemplate(template, context); err == nil {
+			t.Errorf("EvaluateCompileTemplate(%q) accepted a runtime-only concurrency value", template)
+		}
+	}
+}
+
 func TestEvaluateConditionSupportsBracketFormGitHubReferences(t *testing.T) {
 	for condition, want := range map[string]bool{
 		"github['event_name'] == 'push'":       true,

--- a/internal/workflow/parse_test.go
+++ b/internal/workflow/parse_test.go
@@ -407,6 +407,25 @@ jobs:
 	}
 }
 
+func TestParseOwnsReusableWorkflowConcurrency(t *testing.T) {
+	parsed, err := Parse("reusable.yml", []byte(`on:
+  workflow_call:
+    inputs:
+      target: {type: string, required: true}
+concurrency: deploy-${{ inputs.target }}
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps: [{run: true}]
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !parsed.Callable || parsed.Concurrency == nil || parsed.Concurrency.Group != "deploy-${{ inputs.target }}" {
+		t.Fatalf("reusable workflow concurrency = callable %t, %#v", parsed.Callable, parsed.Concurrency)
+	}
+}
+
 func TestParseOwnsWorkflowLiteralCancellation(t *testing.T) {
 	for _, test := range []struct {
 		name, source string


### PR DESCRIPTION
## Why

A reusable workflow with static concurrency is currently rejected, including matrix calls such as:

```yaml
jobs:
  deploy:
    strategy:
      matrix:
        target: [staging, production]
    uses: ./.github/workflows/deploy.yml
    with:
      target: ${{ matrix.target }}
```

when `deploy.yml` declares:

```yaml
concurrency: deploy-${{ inputs.target }}
```

## What

Flattened local and public reusable workflows now keep a workflow concurrency gate for each static call-matrix instance. Nested calls keep nested gates, sibling jobs remain parallel, job-level groups still apply per matrix instance, and groups remain repository-scoped and case-insensitive.

Calls with `if` or `needs`, and jobs or nested called workflows that reuse an enclosing workflow group, are rejected because Buildkite cannot preserve GitHub's admission order for those cases.

`cancel-in-progress: true` still warns without canceling. Buildkite pipeline uploads do not expose an authoritative concurrency-group cancellation field, so this PR does not invent one or approximate job cancellation.