### PR TITLE
Run actions from prebuilt public Docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The [compatibility reference](docs/compatibility.md) is the source of truth. Use
 | Good fit | Not currently supported |
 | --- | --- |
 | Linux x86-64 and native macOS arm64 jobs using `bash`, `sh`, `python`, or an installed custom shell | Windows, Linux arm64, or macOS x86-64 |
-| Local and public JavaScript and composite actions; verified Dockerfile actions on Linux | Private actions or private reusable workflows, and Dockerfile actions on macOS |
+| Local and public JavaScript and composite actions; verified Dockerfile and public prebuilt-image actions on Linux | Private actions, private reusable workflows, private container images, and Docker actions on macOS |
 | Static matrices, `needs`, outputs, and local or literal public reusable workflows | Dynamic reusable calls, matrices, and expressions outside the documented subset |
 | Exact-commit checkout, including managed private repository access | GitHub environment secrets, GitHub-issued OIDC claims, or protected queues |
 | Static Buildkite job-accessible secrets, including declared aliases in local reusable workflows | Dynamic secret access or remote reusable-workflow secret forwarding |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -39,7 +39,7 @@ Looking for something else? [Browse open compatibility issues](https://github.co
 | [Shell steps](#commands-and-actions) | 🟡 Supported subset | Linux and macOS `bash`, `sh`, `python`, and custom shell templates. |
 | [Conditions and expressions](#expressions-and-contexts) | 🟡 Supported subset | GitHub-compatible core operators and direct references to selected contexts. |
 | [Reusable workflows](#reusable-workflows) | 🟡 Supported subset | Local and literal public GitHub workflows with static inputs, deferred string inputs from direct needs outputs, and direct job-output mappings. Local calls can inherit or explicitly map Buildkite secret authority. |
-| [Actions](#actions) | 🟡 Supported subset | Local and public JavaScript and composite actions on Linux and macOS; verified Dockerfile actions on Linux only. |
+| [Actions](#actions) | 🟡 Supported subset | Local and public JavaScript and composite actions on Linux and macOS; verified Dockerfile and public prebuilt-image actions on Linux only. |
 | [Checkout, artifacts, and cache](#actions) | 🟡 Supported subset | Only the audited versions and modes listed below. |
 | [`GITHUB_TOKEN`](#github-token) | 🟡 Supported subset | One job-bound token for the event repository. Reusable-workflow jobs use the top-level workflow permissions. |
 | [Other workflow secrets](#other-secrets-and-oidc) | 🟡 Supported subset | Static names in direct jobs and locally inherited or explicitly mapped reusable jobs resolve through the destination job's Buildkite secret authority. |
@@ -599,7 +599,7 @@ A service with a Docker health check must become healthy before steps run. A ser
 
 Cleanup removes the job container, emits masked and bounded service logs, then removes services in declaration order, the network, newly created volumes, and private Docker configuration. Remaining owned resources fail the job. Docker resources are not a security or resource-isolation boundary: the hosted queue must isolate the whole job and enforce host CPU, memory, disk, and network limits. See the [security model](security.md#isolate-the-whole-job).
 
-macOS jobs reject containers, services, Dockerfile actions, and Docker capability.
+macOS jobs reject containers, services, Docker actions, and Docker capability.
 
 ## Step syntax
 
@@ -650,7 +650,7 @@ Use an interpreter installed by an earlier step or included in the job image:
   run: conda info
 ```
 
-A `uses` step may call a supported local or public action. Action inputs under `with` may use supported direct interpolation. `docker://` actions and explicit Docker action entrypoints are rejected.
+A `uses` step may call a supported local or public action. Action inputs under `with` may use supported direct interpolation. Direct workflow `uses: docker://...` actions are rejected; prebuilt-image declarations belong in locked action metadata.
 
 Action steps can call public and local actions:
 
@@ -900,20 +900,56 @@ parts with values supported by their runtime surface.
 | Private action | ❌ Unsupported | No private action source access. |
 | JavaScript action | ✅ Supported | Declares `node16`, `node20`, or `node24`. |
 | Composite action | 🟡 Supported subset | Nested shell steps and locked local or public actions; `bash`, `sh`, `python`, or a custom shell template for `run`; literal `continue-on-error`. |
-| Dockerfile action | 🟡 Supported subset | Verified local or public Dockerfile action on Linux with optional bounded `runs.args`. Rejected on macOS, including through a composite action. |
-| `docker://` action | ❌ Unsupported | Rejected during validation. |
+| Docker action | 🟡 Supported subset | Verified local or public Dockerfile or prebuilt-image action on Linux with optional bounded `runs.args`. Rejected on macOS, including through a composite action. |
+| Direct workflow `uses: docker://...` action | ❌ Unsupported | Rejected during validation. |
 | Top-level action metadata `env` | ➖ Accepted, no effect | Any valid YAML value is discarded. It is not evaluated, injected, retained in plans, or used to request secrets or tokens. |
 
 Mutable public refs are resolved during upload, then locked to a commit. The importer lazily requests one Buildkite action-source token and reuses it across all workflow roots and nested composite actions. This token authenticates only public metadata requests for repositories other than the credential repository; the credential repository and codeload requests remain anonymous. If token issuance is unavailable during rollout, resolution safely falls back to anonymous GitHub API access. Exact lowercase commit SHAs need no GitHub API lookup. Complete source trees are verified again at runtime.
 
 Nested calls from a repository-local composite must be local. Public composites may call local children or other public actions; every child is resolved and locked.
 
+Prebuilt-image actions declare `docker://` in action metadata, not in a
+workflow step:
+
+```yaml
+# action.yml
+name: Check formatting
+inputs:
+  path:
+    default: .
+runs:
+  using: docker
+  image: docker://ghcr.io/example/formatter@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  entrypoint: /usr/local/bin/formatter
+  args:
+    - ${{ inputs.path }}
+```
+
+```yaml
+# .github/workflows/check.yml
+steps:
+  - uses: example/formatter-action@v2
+    with:
+      path: .
+```
+
+The compiler locks the action source that declares the image. At job start,
+the runtime pulls each declared image anonymously through an empty private
+Docker configuration. Action metadata has no registry-credential field, so
+private images and ambient Docker credentials are unsupported. Digest
+references are supported. Mutable tags resolve when the job starts and can
+drift between jobs; use a digest when image immutability matters.
+
+Direct workflow syntax such as `uses: docker://alpine:3.20` remains
+unsupported. It does not have the locked action-source provenance used by
+metadata-declared images.
+
 Dockerfile actions require exact `runs.image: Dockerfile`. Optional `runs.args`
 must be an ordered YAML string array. Each item becomes one argument after the
-image name, without a shell or an entrypoint override. Empty strings,
-whitespace, and shell metacharacters remain literal. Omitted or empty args keep
-the image `CMD`; any non-empty array replaces `CMD` while preserving the image
-`ENTRYPOINT`.
+image name, without a shell. Empty strings, whitespace, and shell metacharacters
+remain literal. Omitted or empty args keep the image `CMD`; any non-empty array
+replaces `CMD` while preserving the image `ENTRYPOINT`. A prebuilt-image
+action's optional `runs.entrypoint` overrides the image `ENTRYPOINT`.
 
 Args may contain literals and direct `inputs.<name>` or `inputs['name']`
 interpolation. Operators, functions, whole or dynamic inputs, and every other
@@ -921,10 +957,10 @@ context are rejected. Invocation inputs and metadata defaults resolve before
 args evaluation. Args remain in digest-bound action metadata and are not stored
 in job plans.
 
-Dockerfile actions cannot declare explicit entrypoints or pre/post lifecycle,
-or request credentials, volumes, arbitrary options, or privileged mode. An arg
-such as `--privileged` remains a container argument; it cannot become a Docker
-option.
+Dockerfile actions cannot declare explicit entrypoints. Docker actions cannot
+declare pre/post lifecycle or request credentials, volumes, arbitrary options,
+or privileged mode. An arg such as `--privileged` remains a container argument;
+it cannot become a Docker option.
 
 Action metadata parsing remains strict for every other unknown top-level field and for unknown nested fields. The inert top-level `env` exception does not replace workflow or action-step environments, populate `runs.env`, or add `GITHUB_TOKEN` authority.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -190,7 +190,7 @@ bk build create --pipeline buildkite/buildkite-gha \
   --env SMOKE_PROBE=hosted --env SMOKE_COMMIT="$commit" --yes
 ```
 
-This suite covers shell jobs, concurrent steps, public and Dockerfile actions, container runtime behavior, summaries, annotations, artifact upload, and artifact roundtrip. Use `COMPATIBILITY_PROOF=<target>` with `COMPATIBILITY_PROOF_COMMIT=<commit>` only when diagnosing one target. The available target names are in [`.buildkite/pipeline.yml`](../.buildkite/pipeline.yml).
+This suite covers shell jobs, concurrent steps, public and Docker actions, container runtime behavior, summaries, annotations, artifact upload, and artifact roundtrip. Use `COMPATIBILITY_PROOF=<target>` with `COMPATIBILITY_PROOF_COMMIT=<commit>` only when diagnosing one target. The available target names are in [`.buildkite/pipeline.yml`](../.buildkite/pipeline.yml).
 
 Some Buildkite APIs are advisory, so a passing job does not prove that the result was persisted. Check those results independently after the build:
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -35,7 +35,7 @@ Steps in one job share:
 - the job's Buildkite identity
 
 A shell step can affect a later action, and an action can affect a later shell
-step. Dockerfile actions, job containers, and service containers add packaging;
+step. Docker actions, job containers, and service containers add packaging;
 they are not security boundaries.
 
 Run untrusted jobs on a queue with:
@@ -61,6 +61,13 @@ credentials the job can receive.
 
 Digests and immutable source locks detect changed code. They do not make code
 trusted or grant credentials.
+
+Prebuilt Docker action metadata can name a public `docker://` image. The action
+source lock protects the image declaration, but a mutable image tag can resolve
+to different content when each job starts. Use an image digest when content
+immutability matters. Image pulls use an empty private Docker configuration and
+never receive action secrets, registry credentials, or ambient Docker
+authority; private images are unsupported.
 
 ### Source and event checks
 

--- a/internal/action/metadata/metadata.go
+++ b/internal/action/metadata/metadata.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -92,6 +93,8 @@ type CompositeStep struct {
 type Runtime string
 
 const runtimeNode20Declaration = "node20"
+
+var dockerImagePattern = regexp.MustCompile(`^(?:(?:[a-z0-9]+(?:[._-][a-z0-9]+)*|\[[0-9a-f:]+\])(?::(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]))?/)?[a-z0-9]+(?:[._-][a-z0-9]+)*(?:/[a-z0-9]+(?:[._-][a-z0-9]+)*)*(?::[A-Za-z0-9_][A-Za-z0-9_.-]{0,127})?(?:@sha256:[0-9a-f]{64})?$`)
 
 const (
 	// MaxNestedActionDepth bounds local action expansion in both compilation and execution.
@@ -385,6 +388,23 @@ func (metadata Metadata) Runtime() (Runtime, error) {
 	}
 }
 
+// DockerImageReference returns the image reference from a prebuilt Docker
+// action declaration. Dockerfile actions and invalid declarations return
+// false.
+func DockerImageReference(image string) (string, bool) {
+	reference, ok := strings.CutPrefix(image, "docker://")
+	if !ok || !ValidDockerImageReference(reference) {
+		return "", false
+	}
+	return reference, true
+}
+
+// ValidDockerImageReference reports whether image is a supported literal
+// Docker image reference.
+func ValidDockerImageReference(image string) bool {
+	return len(image) <= 512 && dockerImagePattern.MatchString(image)
+}
+
 // ValidateEntrypoints confines JavaScript lifecycle programs to the verified
 // source tree and requires each declared entry point to be a regular file.
 // Remote actions may share repository-level build output across action
@@ -392,13 +412,18 @@ func (metadata Metadata) Runtime() (Runtime, error) {
 // Callers should invoke this after Runtime.
 func (metadata Metadata) ValidateEntrypoints(runtime Runtime) error {
 	if runtime == RuntimeDocker {
-		if metadata.Runs.Image != "Dockerfile" {
-			return fmt.Errorf("docker action requires exact runs.image %q", "Dockerfile")
-		}
-		if metadata.Runs.Main != "" || metadata.Runs.Entrypoint != "" ||
-			metadata.Runs.Pre != "" || metadata.Runs.PreIf != "" || metadata.Runs.PreEntrypoint != "" ||
+		if metadata.Runs.Main != "" || metadata.Runs.Pre != "" || metadata.Runs.PreIf != "" || metadata.Runs.PreEntrypoint != "" ||
 			metadata.Runs.Post != "" || metadata.Runs.PostIf != "" || metadata.Runs.PostEntrypoint != "" {
-			return fmt.Errorf("docker action may not declare entrypoint or pre/post lifecycle")
+			return fmt.Errorf("docker action may not declare pre/post lifecycle")
+		}
+		if metadata.Runs.Image != "Dockerfile" {
+			if _, ok := DockerImageReference(metadata.Runs.Image); !ok {
+				return fmt.Errorf("docker action requires runs.image %q or a valid docker:// image reference", "Dockerfile")
+			}
+			return nil
+		}
+		if metadata.Runs.Entrypoint != "" {
+			return fmt.Errorf("dockerfile action may not declare an entrypoint")
 		}
 		dockerfile := filepath.Join(metadata.Path, "Dockerfile")
 		info, err := os.Lstat(dockerfile)

--- a/internal/action/metadata/metadata_test.go
+++ b/internal/action/metadata/metadata_test.go
@@ -66,7 +66,7 @@ func TestValidateDockerEntrypoints(t *testing.T) {
 		ok     bool
 	}{
 		{name: "exact Dockerfile", ok: true},
-		{name: "non Dockerfile image", mutate: func(m *Metadata) { m.Runs.Image = "docker://alpine" }},
+		{name: "invalid image", mutate: func(m *Metadata) { m.Runs.Image = "alpine" }},
 		{name: "entrypoint", mutate: func(m *Metadata) { m.Runs.Entrypoint = "main.sh" }},
 		{name: "args", mutate: func(m *Metadata) { m.Runs.Args = []string{"", " --flag "} }, ok: true},
 		{name: "main", mutate: func(m *Metadata) { m.Runs.Main = "main.sh" }},
@@ -106,6 +106,34 @@ func TestValidateDockerEntrypoints(t *testing.T) {
 			}
 			if (err == nil) != test.ok {
 				t.Fatalf("validation error = %v, want success %v", err, test.ok)
+			}
+		})
+	}
+}
+
+func TestValidatePrebuiltDockerImage(t *testing.T) {
+	tests := []struct {
+		name       string
+		image      string
+		entrypoint string
+		ok         bool
+	}{
+		{name: "tag", image: "docker://alpine:3.20", ok: true},
+		{name: "digest", image: "docker://busybox@sha256:" + strings.Repeat("a", 64), ok: true},
+		{name: "registry port", image: "docker://registry.example.test:5000/team/action:v1", entrypoint: "/entrypoint.sh", ok: true},
+		{name: "missing prefix", image: "alpine:3.20"},
+		{name: "empty reference", image: "docker://"},
+		{name: "tag expression", image: "docker://alpine:${{ inputs.tag }}"},
+		{name: "invalid digest", image: "docker://busybox@sha256:abc"},
+		{name: "uppercase repository", image: "docker://Owner/action:v1"},
+		{name: "too long", image: "docker://" + strings.Repeat("a", 513)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			m := Metadata{Runs: Runs{Using: "docker", Image: test.image, Entrypoint: test.entrypoint}}
+			err := m.ValidateEntrypoints(RuntimeDocker)
+			if (err == nil) != test.ok {
+				t.Fatalf("ValidateEntrypoints() error = %v, want success %v", err, test.ok)
 			}
 		})
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1913,7 +1913,7 @@ func TestProcessingAnnotationLeadsWithTheActionableDiagnostic(t *testing.T) {
 		{
 			name: "Docker provenance",
 			diagnostic: compatibility.Diagnostic{Code: "E_PROFILE",
-				Message: `Job "test" requires Docker without matching compiler provenance. Hosted runs support only verified Dockerfile actions and bounded job or service containers.`},
+				Message: `Job "test" requires Docker without matching compiler provenance. Hosted runs support only verified Docker actions and bounded job or service containers.`},
 			want: `Job "test" requires Docker without matching compiler provenance.`,
 		},
 		{

--- a/internal/cli/hosted.go
+++ b/internal/cli/hosted.go
@@ -320,7 +320,7 @@ func validateUnprivilegedBundle(bundle compiler.Bundle) error {
 				continue
 			}
 			if capability == "docker" && !admittedDockerProvenance(artifact.Job, artifact.Authorization.DockerCapabilitySources) {
-				message := fmt.Sprintf("Job %q requires Docker without matching compiler provenance. Hosted runs support only verified Dockerfile actions and bounded job or service containers.", artifact.Job.Workflow.LogicalJobID)
+				message := fmt.Sprintf("Job %q requires Docker without matching compiler provenance. Hosted runs support only verified Docker actions and bounded job or service containers.", artifact.Job.Workflow.LogicalJobID)
 				addFailure(artifact, message, "", errors.New("unsupported Docker access"))
 				continue
 			}

--- a/internal/cli/hosted_test.go
+++ b/internal/cli/hosted_test.go
@@ -800,7 +800,7 @@ func TestUnprivilegedUploadRejectsDockerWithoutCompilerProvenance(t *testing.T) 
 	}}}}
 	err := validateUnprivilegedBundle(bundle)
 	var finding *compiler.ProcessingFinding
-	want := `Job "unproven-docker" requires Docker without matching compiler provenance. Hosted runs support only verified Dockerfile actions and bounded job or service containers.`
+	want := `Job "unproven-docker" requires Docker without matching compiler provenance. Hosted runs support only verified Docker actions and bounded job or service containers.`
 	if err == nil || !errors.As(err, &finding) || finding.Message != want || finding.Detail != "" {
 		t.Fatalf("validateUnprivilegedBundle() error = %v, want Docker provenance rejection", err)
 	}

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -338,6 +338,9 @@ func (b *actionLockBuilder) add(ctx context.Context, raw string, depth int) (*ac
 	if err := m.ValidateEntrypoints(runtime); err != nil {
 		return nil, err
 	}
+	if image, ok := metadata.DockerImageReference(m.Runs.Image); ok {
+		n.lock.DockerImage = image
+	}
 	if runtime == metadata.RuntimeNode16 || runtime == metadata.RuntimeNode24 {
 		if err := expression.ValidateActionLifecycleCondition(m.Runs.PreIf); err != nil {
 			return nil, fmt.Errorf("pre-if: %w", err)

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -1804,6 +1804,49 @@ func TestCompilePlansDockerfileActionCapabilities(t *testing.T) {
 	}
 }
 
+func TestCompilePlansPrebuiltDockerActionCapabilitiesAndDeterminism(t *testing.T) {
+	remote := t.TempDir()
+	image := "busybox@sha256:" + strings.Repeat("a", 64)
+	writeAction(t, remote, "", `name: remote prebuilt Docker
+runs:
+  using: docker
+  image: docker://`+image+`
+  entrypoint: /bin/echo
+  args: [hello]
+`)
+	workflowPath := filepath.Join("..", "..", "testdata", "dockerfile-action", ".github", "workflows", "docker-action.yml")
+	options := Options{
+		EventTrust: EventUntrusted,
+		Runners: RunnerPolicy{
+			Labels:          map[string]string{"ubuntu-latest": "hosted"},
+			UntrustedQueues: []string{"hosted"},
+		},
+		ResolveActions: true,
+		ActionSource:   &fakeActionSource{root: remote, calls: map[string]int{}},
+	}
+	compile := func() []byte {
+		plans, err := compilePlansForTest(t.Context(), workflowPath, readFile(t, workflowPath+".tmpl"), pushEvent(t), "prebuilt-docker-test", testDistributionDigest, options)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(plans) != 1 || !reflect.DeepEqual(plans[0].RequiredCapabilities, []string{"docker", "network"}) || len(plans[0].Actions) != 1 || plans[0].Actions[0].Source != "github" || plans[0].Actions[0].DockerImage != image {
+			t.Fatalf("prebuilt Docker action plans = %#v", plans)
+		}
+		encoded, err := plan.Encode(plans[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if bytes.Contains(encoded, []byte("/bin/echo")) {
+			t.Fatalf("job plan retained Docker action entrypoint: %s", encoded)
+		}
+		return encoded
+	}
+	first, second := compile(), compile()
+	if !bytes.Equal(first, second) {
+		t.Fatalf("prebuilt Docker action plans are not deterministic:\n%s\n%s", first, second)
+	}
+}
+
 func TestCompileDockerfileActionArgsAreValidatedButNotPlanned(t *testing.T) {
 	workspace := t.TempDir()
 	writeAction(t, workspace, "docker", `name: Docker args

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -329,6 +329,7 @@ func TestCompileBundleRejectsDockerOnDarwin(t *testing.T) {
 	}
 	actionRoot := filepath.Join(workspace, ".github", "actions")
 	writeAction(t, actionRoot, "docker", "runs:\n  using: docker\n  image: Dockerfile\n")
+	writeAction(t, actionRoot, "prebuilt", "runs:\n  using: docker\n  image: docker://alpine:3.20\n")
 	writeAction(t, actionRoot, "composite", "runs:\n  using: composite\n  steps:\n    - uses: ./.github/actions/docker\n")
 	options := Options{
 		EventTrust: EventUntrusted,
@@ -353,8 +354,10 @@ func TestCompileBundleRejectsDockerOnDarwin(t *testing.T) {
 		{name: "job container", runsOn: "macos-15", workload: "    container: node:24\n    steps:\n      - run: true\n", reject: true},
 		{name: "service container", runsOn: "macos-15", workload: "    services:\n      redis:\n        image: redis:7\n    steps:\n      - run: true\n", reject: true},
 		{name: "Dockerfile action", runsOn: "macos-15", workload: "    steps:\n      - uses: ./.github/actions/docker\n", reject: true},
+		{name: "prebuilt Docker action", runsOn: "macos-15", workload: "    steps:\n      - uses: ./.github/actions/prebuilt\n", reject: true},
 		{name: "transitive Dockerfile action", runsOn: "macos-15", workload: "    steps:\n      - uses: ./.github/actions/composite\n", reject: true},
 		{name: "Linux Dockerfile action", runsOn: "ubuntu-latest", workload: "    steps:\n      - uses: ./.github/actions/docker\n"},
+		{name: "Linux prebuilt Docker action", runsOn: "ubuntu-latest", workload: "    steps:\n      - uses: ./.github/actions/prebuilt\n"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/compiler/plan_builder.go
+++ b/internal/compiler/plan_builder.go
@@ -433,6 +433,8 @@ func (b planBuilder) buildActions(instance JobInstance, steps []plan.Step, actio
 	sort.Strings(built.authorization.ProviderTokenReadCapabilitySources)
 	built.authorization.ProviderTokenReadCapabilitySources = slices.Compact(built.authorization.ProviderTokenReadCapabilitySources)
 	if slices.Contains(compiled.capabilities, "docker") {
+		// Keep the established authorization label for source-verified Docker
+		// action metadata, including prebuilt-image declarations.
 		built.authorization.DockerCapabilitySources = append(built.authorization.DockerCapabilitySources, "dockerfile-actions")
 	}
 	return built, nil

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -31,7 +31,6 @@ var logicalJobIDPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+
 var secretNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 var actionLockIDPattern = regexp.MustCompile(`^a-[0-9a-f]{16}$`)
 var commitPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
-var containerImagePattern = regexp.MustCompile(`^(?:(?:[a-z0-9]+(?:[._-][a-z0-9]+)*|\[[0-9a-f:]+\])(?::(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]))?/)?[a-z0-9]+(?:[._-][a-z0-9]+)*(?:/[a-z0-9]+(?:[._-][a-z0-9]+)*)*(?::[A-Za-z0-9_][A-Za-z0-9_.-]{0,127})?(?:@sha256:[0-9a-f]{64})?$`)
 var containerEnvKeyPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 var containerPortPattern = regexp.MustCompile(`^(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(?::(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]))?(?:/(?:tcp|udp))?$`)
 var serviceNamePattern = regexp.MustCompile(`^[a-z_][a-z0-9_-]{0,254}$`)
@@ -41,7 +40,7 @@ var githubWorkflowFilenamePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._
 // ValidContainerImageReference reports whether image is a supported literal
 // Docker image reference.
 func ValidContainerImageReference(image string) bool {
-	return containerImagePattern.MatchString(image)
+	return metadata.ValidDockerImageReference(image)
 }
 
 var githubTokenPermissionAccess = map[string]map[string]bool{
@@ -90,6 +89,7 @@ type ActionLock struct {
 	Commit       string                    `json:"commit,omitempty"`
 	Path         string                    `json:"path,omitempty"`
 	SourceDigest string                    `json:"source_digest"`
+	DockerImage  string                    `json:"docker_image,omitempty"`
 	Children     map[string]ActionSelector `json:"children,omitempty"`
 }
 
@@ -886,6 +886,17 @@ func (job Job) Validate() error {
 		}
 	}
 	if len(job.Actions) != 0 || hasStepActions(job.Steps) {
+		for _, lock := range job.Actions {
+			if lock.DockerImage == "" {
+				continue
+			}
+			if _, ok := capabilities["docker"]; !ok {
+				return fmt.Errorf("prebuilt Docker actions require docker capability")
+			}
+			if _, ok := capabilities["network"]; !ok {
+				return fmt.Errorf("prebuilt Docker actions require network capability")
+			}
+		}
 		if err := validateActionLocks(job); err != nil {
 			return err
 		}
@@ -1252,6 +1263,9 @@ func validateActionLocks(job Job) error {
 		}
 		if !digestPattern.MatchString(lock.SourceDigest) || len(lock.Children) > 1024 {
 			return fmt.Errorf("action lock %q has invalid digest or too many children", lock.ID)
+		}
+		if lock.DockerImage != "" && !ValidContainerImageReference(lock.DockerImage) {
+			return fmt.Errorf("action lock %q has invalid Docker image", lock.ID)
 		}
 		if err := validateLockIdentity(lock); err != nil {
 			return fmt.Errorf("action lock %q: %w", lock.ID, err)

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -477,10 +477,11 @@ func TestSecretMappingsRoundTripAsNamesOnlyAndValidateAuthority(t *testing.T) {
 
 func TestActionLocksRoundTripAndValidateAgainstSchema(t *testing.T) {
 	job := validJob()
+	job.RequiredCapabilities = []string{"docker", "network"}
 	job.Steps = []Step{{ID: "local", Kind: "uses", Uses: "./actions/build", Action: &ActionSelector{Lock: "a-0000000000000001"}}}
 	job.Actions = []ActionLock{{
 		ID: "a-0000000000000001", Source: "workspace", Path: "actions/build",
-		SourceDigest: "sha256:" + strings.Repeat("a", 64),
+		SourceDigest: "sha256:" + strings.Repeat("a", 64), DockerImage: "busybox@sha256:" + strings.Repeat("b", 64),
 	}}
 	encoded, err := Encode(job)
 	if err != nil {
@@ -498,6 +499,26 @@ func TestActionLocksRoundTripAndValidateAgainstSchema(t *testing.T) {
 		t.Fatalf("encoding is not deterministic\nfirst: %s\nsecond: %s", encoded, reencoded)
 	}
 	validateJobPlanSchema(t, encoded)
+
+	for _, test := range []struct {
+		name string
+		edit func(*Job)
+		want string
+	}{
+		{name: "invalid image", edit: func(j *Job) { j.Actions[0].DockerImage = "INVALID" }, want: "invalid Docker image"},
+		{name: "missing docker capability", edit: func(j *Job) { j.RequiredCapabilities = []string{"network"} }, want: "require docker capability"},
+		{name: "missing network capability", edit: func(j *Job) { j.RequiredCapabilities = []string{"docker"} }, want: "require network capability"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			changed := job
+			changed.Actions = append([]ActionLock(nil), job.Actions...)
+			changed.RequiredCapabilities = append([]string(nil), job.RequiredCapabilities...)
+			test.edit(&changed)
+			if err := changed.Validate(); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Validate() error = %v, want %q", err, test.want)
+			}
+		})
+	}
 }
 
 func TestRequiresMiseRoundTripAndSchema(t *testing.T) {

--- a/internal/runtime/action_execution.go
+++ b/internal/runtime/action_execution.go
@@ -352,6 +352,18 @@ func (r *jobRun) prepare(ctx context.Context) (final JobResult, runJobErr error)
 		r.runnerTemp = runnerTemp
 	}
 	actions := newActionLockResolver(job, workspace, r.Actions)
+	prebuiltDocker, err := r.preparePrebuiltDockerActions(runCtx, processor, actions)
+	if err != nil {
+		return tolerateJobSetupFailure(runCtx, job, jobResult, err)
+	}
+	if prebuiltDocker != nil {
+		r.prebuiltDocker = prebuiltDocker
+		defer func() {
+			if err := prebuiltDocker.cleanup(); err != nil {
+				runJobErr = errors.Join(runJobErr, markHardJobFailure(err))
+			}
+		}()
+	}
 	var containerMounts []containerMount
 	if job.Container != nil {
 		// Remote children of workspace composites are already present in the
@@ -2060,11 +2072,8 @@ func (r *jobRun) runActionStep(ctx context.Context, processor *commandProcessor,
 		if !job.HasCapability("docker") {
 			return result, fmt.Errorf("docker action %q requires the plan's docker capability", step.Uses)
 		}
-		if action.Runs.Main != "" || action.Runs.Pre != "" || action.Runs.PreIf != "" || action.Runs.Post != "" || action.Runs.PostIf != "" || action.Runs.PreEntrypoint != "" || action.Runs.PostEntrypoint != "" || action.Runs.Entrypoint != "" {
-			return result, fmt.Errorf("docker action %q uses unsupported entrypoint or pre/post lifecycle", step.Uses)
-		}
-		if action.Runs.Image != "Dockerfile" {
-			return result, fmt.Errorf("docker action image %q is unsupported; the supported runtime subset requires a local Dockerfile", action.Runs.Image)
+		if err := action.ValidateEntrypoints(actionRuntime); err != nil {
+			return result, fmt.Errorf("docker action %q: %w", step.Uses, err)
 		}
 		dockerArgs := make([]string, len(action.Runs.Args))
 		for i, argument := range action.Runs.Args {
@@ -2085,7 +2094,11 @@ func (r *jobRun) runActionStep(ctx context.Context, processor *commandProcessor,
 			sourceDigest = actionLock.SourceDigest
 		}
 		invocationEnv, explicitPATH := environment.docker(dockerEnv, inputs)
-		result, err := r.runDocker(ctx, processor, dockerAction{Name: actionName(action, step), Path: actionPath, SourceRoot: sourceRoot, SourceDigest: sourceDigest, Args: dockerArgs, Workspace: workspace, Env: invocationEnv, explicitPATH: explicitPATH})
+		image, _ := metadata.DockerImageReference(action.Runs.Image)
+		if image != "" && actionLock != nil && actionLock.DockerImage != "" && image != actionLock.DockerImage {
+			return result, fmt.Errorf("docker action %q metadata image %q does not match planned image %q", step.Uses, image, actionLock.DockerImage)
+		}
+		result, err := r.runDocker(ctx, processor, dockerAction{Name: actionName(action, step), Path: actionPath, SourceRoot: sourceRoot, SourceDigest: sourceDigest, Image: image, Entrypoint: action.Runs.Entrypoint, Args: dockerArgs, Workspace: workspace, Env: invocationEnv, explicitPATH: explicitPATH})
 		return result, err
 	}
 	return result, fmt.Errorf("action %q uses unsupported runtime %q", step.Uses, actionRuntime)

--- a/internal/runtime/action_execution.go
+++ b/internal/runtime/action_execution.go
@@ -2095,7 +2095,7 @@ func (r *jobRun) runActionStep(ctx context.Context, processor *commandProcessor,
 		}
 		invocationEnv, explicitPATH := environment.docker(dockerEnv, inputs)
 		image, _ := metadata.DockerImageReference(action.Runs.Image)
-		if image != "" && actionLock != nil && actionLock.DockerImage != "" && image != actionLock.DockerImage {
+		if image != "" && actionLock != nil && image != actionLock.DockerImage {
 			return result, fmt.Errorf("docker action %q metadata image %q does not match planned image %q", step.Uses, image, actionLock.DockerImage)
 		}
 		result, err := r.runDocker(ctx, processor, dockerAction{Name: actionName(action, step), Path: actionPath, SourceRoot: sourceRoot, SourceDigest: sourceDigest, Image: image, Entrypoint: action.Runs.Entrypoint, Args: dockerArgs, Workspace: workspace, Env: invocationEnv, explicitPATH: explicitPATH})

--- a/internal/runtime/actions.go
+++ b/internal/runtime/actions.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -50,14 +51,14 @@ type prebuiltDockerBackend struct {
 	docker string
 	config string
 	env    map[string]string
-	images map[string]bool
+	images map[string]string
 }
 
 func (r *jobRun) preparePrebuiltDockerActions(ctx context.Context, processor *commandProcessor, actions *actionLockResolver) (_ *prebuiltDockerBackend, err error) {
-	images := map[string]bool{}
+	images := map[string]string{}
 	for _, lock := range actions.job.Actions {
 		if lock.DockerImage != "" {
-			images[lock.DockerImage] = true
+			images[lock.DockerImage] = ""
 		}
 	}
 	if len(images) == 0 {
@@ -82,8 +83,29 @@ func (r *jobRun) preparePrebuiltDockerActions(ctx context.Context, processor *co
 		if pullErr := r.pullContainerImage(ctx, processor, env, docker, image); pullErr != nil {
 			return nil, fmt.Errorf("pull prebuilt Docker action image %q: %w", image, pullErr)
 		}
+		imageID, inspectErr := inspectDockerImageID(ctx, env, docker, image)
+		if inspectErr != nil {
+			return nil, fmt.Errorf("inspect prebuilt Docker action image %q: %w", image, inspectErr)
+		}
+		images[image] = imageID
 	}
 	return backend, nil
+}
+
+func inspectDockerImageID(ctx context.Context, env map[string]string, docker, image string) (string, error) {
+	output, err := boundedDockerOutput(ctx, env, docker, "image", "inspect", "--format", "{{.Id}}", image)
+	if err != nil {
+		return "", err
+	}
+	id := strings.TrimSpace(output)
+	digest, ok := strings.CutPrefix(id, "sha256:")
+	if !ok || len(digest) != 64 {
+		return "", fmt.Errorf("docker returned invalid image ID %q", id)
+	}
+	if _, err := hex.DecodeString(digest); err != nil {
+		return "", fmt.Errorf("docker returned invalid image ID %q", id)
+	}
+	return id, nil
 }
 
 func (b *prebuiltDockerBackend) cleanup() error {

--- a/internal/runtime/actions.go
+++ b/internal/runtime/actions.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 
@@ -43,6 +44,53 @@ type actionLockResolver struct {
 	workspace    string
 	materializer ActionMaterializer
 	locks        map[string]*actionLockEntry
+}
+
+type prebuiltDockerBackend struct {
+	docker string
+	config string
+	env    map[string]string
+	images map[string]bool
+}
+
+func (r *jobRun) preparePrebuiltDockerActions(ctx context.Context, processor *commandProcessor, actions *actionLockResolver) (_ *prebuiltDockerBackend, err error) {
+	images := map[string]bool{}
+	for _, lock := range actions.job.Actions {
+		if lock.DockerImage != "" {
+			images[lock.DockerImage] = true
+		}
+	}
+	if len(images) == 0 {
+		return nil, nil
+	}
+	docker, config, env, err := privateDocker(r.Runner)
+	if err != nil {
+		return nil, err
+	}
+	backend := &prebuiltDockerBackend{docker: docker, config: config, env: env, images: images}
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, backend.cleanup())
+		}
+	}()
+	ordered := make([]string, 0, len(images))
+	for image := range images {
+		ordered = append(ordered, image)
+	}
+	sort.Strings(ordered)
+	for _, image := range ordered {
+		if pullErr := r.pullContainerImage(ctx, processor, env, docker, image); pullErr != nil {
+			return nil, fmt.Errorf("pull prebuilt Docker action image %q: %w", image, pullErr)
+		}
+	}
+	return backend, nil
+}
+
+func (b *prebuiltDockerBackend) cleanup() error {
+	if b == nil || b.config == "" {
+		return nil
+	}
+	return removeDockerConfig(b.config)
 }
 
 func newActionLockResolver(job plan.Job, workspace string, materializer ActionMaterializer) *actionLockResolver {

--- a/internal/runtime/job_run.go
+++ b/internal/runtime/job_run.go
@@ -33,6 +33,7 @@ type jobRun struct {
 	explicitJobPATH  bool
 	jobContainer     *jobContainerBackend
 	jobDocker        *jobContainerBackend
+	prebuiltDocker   *prebuiltDockerBackend
 	nodeVerification *managedNodeVerification
 	artifactRegistry *artifactRegistry
 	node16Warnings   *node16DeprecationWarnings

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -23,6 +23,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/buildkite/buildkite-gha/internal/action/metadata"
 	"github.com/buildkite/buildkite-gha/internal/action/source"
 	"github.com/buildkite/buildkite-gha/internal/transport"
 )
@@ -155,6 +156,8 @@ type dockerAction struct {
 	SourceRoot   string
 	SourceDigest string
 	Dockerfile   string
+	Image        string
+	Entrypoint   string
 	Args         []string
 	Workspace    string
 	Env          map[string]string
@@ -291,52 +294,61 @@ func (r *jobRun) runDocker(ctx context.Context, processor *commandProcessor, act
 	if r.jobContainer != nil && (action.Workspace != r.jobContainer.workspace || action.runnerTemp != r.jobContainer.temp) {
 		return result, errors.New("docker action workspace and runner temp must match the job container's owned host paths")
 	}
-	docker := r.Docker
-	if docker == "" {
-		docker, err = exec.LookPath("docker")
-		if err != nil {
-			return result, fmt.Errorf("discover Docker: %w", err)
-		}
-	}
 	if action.Dockerfile != "" && action.Dockerfile != "Dockerfile" {
 		return result, fmt.Errorf("docker action requires fixed Dockerfile")
 	}
-	sourceRoot := action.SourceRoot
-	if sourceRoot == "" {
-		sourceRoot = action.Path
+	prebuilt := action.Image != ""
+	if prebuilt && !metadata.ValidDockerImageReference(action.Image) {
+		return result, fmt.Errorf("docker action has invalid prebuilt image %q", action.Image)
 	}
-	expected := action.SourceDigest
-	if expected == "" {
-		expected, err = source.DigestTree(sourceRoot)
+	var docker, dockerConfig string
+	var dockerEnv map[string]string
+	if prebuilt && r.prebuiltDocker != nil {
+		if !r.prebuiltDocker.images[action.Image] {
+			return result, fmt.Errorf("prebuilt Docker action image %q was not prepared at job start", action.Image)
+		}
+		docker, dockerConfig, dockerEnv = r.prebuiltDocker.docker, r.prebuiltDocker.config, r.prebuiltDocker.env
+	} else {
+		docker, dockerConfig, dockerEnv, err = privateDocker(r.Runner)
 		if err != nil {
-			return result, fmt.Errorf("digest Docker action source: %w", err)
+			return result, err
+		}
+		defer func() { err = errors.Join(err, removeDockerConfig(dockerConfig)) }()
+		if prebuilt {
+			if err := r.pullContainerImage(ctx, processor, dockerEnv, docker, action.Image); err != nil {
+				return result, fmt.Errorf("pull prebuilt Docker action image %q: %w", action.Image, err)
+			}
 		}
 	}
-	stage, err := stageDockerSource(sourceRoot, action.Path, expected)
-	if err != nil {
-		return result, err
-	}
-	defer func() { _ = os.RemoveAll(stage.root) }()
-	dockerConfig, err := os.MkdirTemp("", "buildkite-gha-docker-config-")
-	if err != nil {
-		return result, fmt.Errorf("create private Docker configuration: %w", err)
-	}
-	if err := os.Chmod(dockerConfig, 0o700); err != nil {
-		_ = os.RemoveAll(dockerConfig)
-		return result, err
-	}
-	defer func() { _ = os.RemoveAll(dockerConfig) }()
-	dockerEnv := map[string]string{"DOCKER_CONFIG": dockerConfig}
-	inspection, inspectErr := boundedDockerOutput(ctx, dockerEnv, docker, "buildx", "inspect", "default")
-	driver := dockerBuilderDriver(inspection)
-	if inspectErr != nil || driver != "docker" {
-		if inspectErr != nil {
-			return result, fmt.Errorf("inspect default Docker builder: %w", inspectErr)
+	var stage stagedDockerSource
+	if !prebuilt {
+		sourceRoot := action.SourceRoot
+		if sourceRoot == "" {
+			sourceRoot = action.Path
 		}
-		if driver == "" {
-			return result, fmt.Errorf("could not determine default Docker builder driver from inspect output")
+		expected := action.SourceDigest
+		if expected == "" {
+			expected, err = source.DigestTree(sourceRoot)
+			if err != nil {
+				return result, fmt.Errorf("digest Docker action source: %w", err)
+			}
 		}
-		return result, fmt.Errorf("default Docker builder has non-local driver %q", driver)
+		stage, err = stageDockerSource(sourceRoot, action.Path, expected)
+		if err != nil {
+			return result, err
+		}
+		defer func() { _ = os.RemoveAll(stage.root) }()
+		inspection, inspectErr := boundedDockerOutput(ctx, dockerEnv, docker, "buildx", "inspect", "default")
+		driver := dockerBuilderDriver(inspection)
+		if inspectErr != nil || driver != "docker" {
+			if inspectErr != nil {
+				return result, fmt.Errorf("inspect default Docker builder: %w", inspectErr)
+			}
+			if driver == "" {
+				return result, fmt.Errorf("could not determine default Docker builder driver from inspect output")
+			}
+			return result, fmt.Errorf("default Docker builder has non-local driver %q", driver)
+		}
 	}
 	var nonce [16]byte
 	if _, err := rand.Read(nonce[:]); err != nil {
@@ -344,7 +356,10 @@ func (r *jobRun) runDocker(ctx context.Context, processor *commandProcessor, act
 	}
 	id := hex.EncodeToString(nonce[:])
 	owner := "com.buildkite.gha.owner=" + id
-	image, container := "buildkite-gha-image-"+id, "buildkite-gha-container-"+id
+	image, container := action.Image, "buildkite-gha-container-"+id
+	if !prebuilt {
+		image = "buildkite-gha-image-" + id
+	}
 	built, ran := false, false
 	defer func() {
 		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), r.cleanupTimeout())
@@ -389,10 +404,12 @@ func (r *jobRun) runDocker(ctx context.Context, processor *commandProcessor, act
 		}
 		err = errors.Join(err, markHardJobFailure(cleanupErr))
 	}()
-	buildArgs := []string{"buildx", "build", "--builder", "default", "--load", "--tag", image, "--label", owner, "--file", filepath.Join(stage.action, "Dockerfile"), stage.action}
-	built = true // A failed build may still have created the tagged image.
-	if err := r.runStreaming(ctx, processor, "", dockerEnv, docker, buildArgs...); err != nil {
-		return result, fmt.Errorf("build Docker action %q: %w", action.Name, err)
+	if !prebuilt {
+		buildArgs := []string{"buildx", "build", "--builder", "default", "--load", "--tag", image, "--label", owner, "--file", filepath.Join(stage.action, "Dockerfile"), stage.action}
+		built = true // A failed build may still have created the tagged image.
+		if err := r.runStreaming(ctx, processor, "", dockerEnv, docker, buildArgs...); err != nil {
+			return result, fmt.Errorf("build Docker action %q: %w", action.Name, err)
+		}
 	}
 
 	files, err := newCommandFiles()
@@ -423,6 +440,9 @@ func (r *jobRun) runDocker(ctx context.Context, processor *commandProcessor, act
 		cacheToken = cacheEnv["ACTIONS_RUNTIME_TOKEN"]
 	}
 	args := []string{"run", "--name", container, "--label", owner, "--mount", "type=bind,source=" + files.dir + ",target=/github/file_commands"}
+	if action.Entrypoint != "" {
+		args = append(args, "--entrypoint", action.Entrypoint)
+	}
 	if r.jobDocker != nil {
 		args = append(args, "--network", r.jobDocker.network)
 	}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -301,10 +301,13 @@ func (r *jobRun) runDocker(ctx context.Context, processor *commandProcessor, act
 	if prebuilt && !metadata.ValidDockerImageReference(action.Image) {
 		return result, fmt.Errorf("docker action has invalid prebuilt image %q", action.Image)
 	}
+	runImage := action.Image
 	var docker, dockerConfig string
 	var dockerEnv map[string]string
 	if prebuilt && r.prebuiltDocker != nil {
-		if !r.prebuiltDocker.images[action.Image] {
+		var ok bool
+		runImage, ok = r.prebuiltDocker.images[action.Image]
+		if !ok || runImage == "" {
 			return result, fmt.Errorf("prebuilt Docker action image %q was not prepared at job start", action.Image)
 		}
 		docker, dockerConfig, dockerEnv = r.prebuiltDocker.docker, r.prebuiltDocker.config, r.prebuiltDocker.env
@@ -317,6 +320,10 @@ func (r *jobRun) runDocker(ctx context.Context, processor *commandProcessor, act
 		if prebuilt {
 			if err := r.pullContainerImage(ctx, processor, dockerEnv, docker, action.Image); err != nil {
 				return result, fmt.Errorf("pull prebuilt Docker action image %q: %w", action.Image, err)
+			}
+			runImage, err = inspectDockerImageID(ctx, dockerEnv, docker, action.Image)
+			if err != nil {
+				return result, fmt.Errorf("inspect prebuilt Docker action image %q: %w", action.Image, err)
 			}
 		}
 	}
@@ -356,7 +363,7 @@ func (r *jobRun) runDocker(ctx context.Context, processor *commandProcessor, act
 	}
 	id := hex.EncodeToString(nonce[:])
 	owner := "com.buildkite.gha.owner=" + id
-	image, container := action.Image, "buildkite-gha-container-"+id
+	image, container := runImage, "buildkite-gha-container-"+id
 	if !prebuilt {
 		image = "buildkite-gha-image-" + id
 	}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -266,6 +266,13 @@ if [[ "$1" == buildx && "$2" == build ]]; then
   exit 0
 fi
 
+if [[ "$1" == pull ]]; then
+  [[ $# == 2 ]] || exit 49
+  printf '%s' "$2" > "$state/image-name"
+  [[ "$scenario" != pull-fail ]] || exit 50
+  exit 0
+fi
+
 if [[ "$1" == run ]]; then
 	printf '%s\0' "$@" > "$state/run-argv"
 	if [[ -n "${ACTIONS_RUNTIME_TOKEN:-}" ]]; then
@@ -304,9 +311,11 @@ if [[ "$1" == run ]]; then
       --workdir) workdir="${args[$((i + 1))]}" ;;
     esac
   done
+  printf '%s' "$name" > "$state/container-name"
+  printf '%s' "$owner" > "$state/owner"
   [[ -n "$files" && -n "$workspace" && -n "$runner_temp" && "$workdir" == /github/workspace ]] || exit 33
   [[ -d "$workspace" && -d "$runner_temp" ]] || exit 41
-  [[ "$name" == "$(cat "$state/image-name" | sed 's/-image-/-container-/')" ]] || exit 33
+	[[ "$name" == "$(cat "$state/container-name")" ]] || exit 33
   [[ "$owner" == "$(cat "$state/owner")" && $image_index -gt 0 ]] || exit 39
   printf '%s' "$files" > "$state/command-files-path"
   touch "$state/container"
@@ -616,6 +625,151 @@ func TestRunDockerAppendsExactArgsAfterImage(t *testing.T) {
 	}
 	if slices.Contains(argv[:imageIndex], "--entrypoint") || slices.Contains(argv[:imageIndex], "--privileged") {
 		t.Fatalf("action args became Docker options: %#v", argv)
+	}
+}
+
+func TestRunPrebuiltDockerUsesPulledImageEntrypointAndExactArgs(t *testing.T) {
+	fake := newFakeDocker(t, "success")
+	t.Setenv("DOCKER_CONFIG", filepath.Join(t.TempDir(), "ambient-config"))
+	t.Setenv("DOCKER_HOST", "tcp://ambient.invalid:2375")
+	t.Setenv("DOCKER_CONTEXT", "ambient-context")
+	t.Setenv("BUILDX_BUILDER", "ambient-builder")
+	t.Setenv("BUILDKIT_HOST", "tcp://ambient.invalid:1234")
+	action := fakeDockerAction(t)
+	action.Path, action.SourceRoot, action.SourceDigest = "", "", ""
+	action.Image = "busybox@sha256:" + strings.Repeat("a", 64)
+	action.Entrypoint = "/bin/echo"
+	action.Args = []string{"", "  ", "--privileged", `$(echo no-shell)`}
+	if _, err := (Runner{Docker: fake.path}).runDockerAction(t.Context(), action); err != nil {
+		t.Fatal(err)
+	}
+	calls := fake.calls(t)
+	if len(calls) == 0 || !slices.Equal(calls[0].args, []string{"pull", action.Image}) {
+		t.Fatalf("first Docker call = %#v, want anonymous pull", calls)
+	}
+	if callIndex(calls, "buildx") >= 0 {
+		t.Fatalf("prebuilt action invoked buildx: %#v", calls)
+	}
+	argv := fakeDockerRunArgv(t, fake)
+	imageIndex := slices.Index(argv, action.Image)
+	if imageIndex < 0 || !slices.Equal(argv[imageIndex+1:], action.Args) {
+		t.Fatalf("Docker run argv = %#v, want exact args after image", argv)
+	}
+	entrypoint := slices.Index(argv[:imageIndex], "--entrypoint")
+	if entrypoint < 0 || entrypoint+1 >= imageIndex || argv[entrypoint+1] != action.Entrypoint {
+		t.Fatalf("Docker run argv = %#v, want metadata entrypoint", argv)
+	}
+	for _, call := range calls {
+		if call.config != calls[0].config || !strings.Contains(call.metadata, ";mode=700;entries=0;host=unset;context=unset;builder=unset;buildkit=unset") {
+			t.Fatalf("Docker call did not use one empty private config: %#v", call)
+		}
+	}
+	if _, err := os.Stat(calls[0].config); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("private Docker config remains: %v", err)
+	}
+}
+
+func TestRunJobPullsPrebuiltDockerImageBeforeSteps(t *testing.T) {
+	requireLinuxAMD64(t)
+	fake := newFakeDocker(t, "success")
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/prebuilt.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: prebuilt\n")
+	actionPath := ".github/actions/prebuilt"
+	image := "busybox@sha256:" + strings.Repeat("b", 64)
+	writeFixtureFile(t, workspace, actionPath+"/action.yml", `name: Prebuilt Docker
+inputs:
+  message:
+    default: from-default
+runs:
+  using: docker
+  image: docker://`+image+`
+  entrypoint: /bin/echo
+  args:
+    - ${{ inputs.message }}
+`)
+	lockID := "a-0000000000000001"
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "prebuilt", Kind: "uses", Uses: "./" + actionPath, Action: &plan.ActionSelector{Lock: lockID}}})
+	job.RequiredCapabilities = []string{"docker", "network"}
+	job.Actions = []plan.ActionLock{{ID: lockID, Source: "workspace", Path: actionPath, SourceDigest: digestTree(t, filepath.Join(workspace, actionPath)), DockerImage: image}}
+	result, err := (Runner{Docker: fake.path}).RunJob(t.Context(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	calls := fake.calls(t)
+	pull, run := callIndex(calls, "pull", image), callIndex(calls, "run")
+	if pull < 0 || run < pull {
+		t.Fatalf("prebuilt image was not pulled before execution: %#v", calls)
+	}
+	if calls[pull].config != calls[run].config || !strings.Contains(calls[pull].metadata, ";entries=0;") {
+		t.Fatalf("pull and run did not share an empty private Docker config: %#v", calls)
+	}
+	argv := fakeDockerRunArgv(t, fake)
+	imageIndex := slices.Index(argv, image)
+	if imageIndex < 0 || !slices.Equal(argv[imageIndex+1:], []string{"from-default"}) {
+		t.Fatalf("Docker run argv = %#v, want evaluated default after image", argv)
+	}
+	if _, err := os.Stat(calls[pull].config); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("job private Docker config remains: %v", err)
+	}
+
+	mismatchFake := newFakeDocker(t, "success")
+	mismatched := job
+	mismatched.Actions = append([]plan.ActionLock(nil), job.Actions...)
+	mismatched.Actions[0].DockerImage = "alpine:3.20"
+	secondActionPath := ".github/actions/prebuilt-second"
+	writeFixtureFile(t, workspace, secondActionPath+"/action.yml", `name: Second prebuilt Docker
+runs:
+  using: docker
+  image: docker://`+image+`
+`)
+	secondLockID := "a-0000000000000002"
+	mismatched.Steps = append(mismatched.Steps, plan.Step{ID: "prebuilt-second", Kind: "uses", Uses: "./" + secondActionPath, Action: &plan.ActionSelector{Lock: secondLockID}})
+	mismatched.Actions = append(mismatched.Actions, plan.ActionLock{ID: secondLockID, Source: "workspace", Path: secondActionPath, SourceDigest: digestTree(t, filepath.Join(workspace, secondActionPath)), DockerImage: image})
+	if _, err := (Runner{Docker: mismatchFake.path}).RunJob(t.Context(), mismatched, workspace); err == nil || !strings.Contains(err.Error(), "metadata image \""+image+"\" does not match planned image \"alpine:3.20\"") {
+		t.Fatalf("RunJob() mismatched planned image error = %v", err)
+	}
+	if calls := mismatchFake.calls(t); callIndex(calls, "pull", "alpine:3.20") < 0 || callIndex(calls, "pull", image) < 0 || callIndex(calls, "run") >= 0 {
+		t.Fatalf("mismatched plan Docker calls = %#v, want only planned image pulls", calls)
+	}
+}
+
+func TestRunPrebuiltDockerPullFailureCleansPrivateConfig(t *testing.T) {
+	fake := newFakeDocker(t, "pull-fail")
+	action := fakeDockerAction(t)
+	action.Image = "alpine:3.20"
+	if _, err := (Runner{Docker: fake.path}).runDockerAction(t.Context(), action); err == nil || !strings.Contains(err.Error(), "pull prebuilt Docker action image") {
+		t.Fatalf("runDockerAction() error = %v, want pull failure", err)
+	}
+	calls := fake.calls(t)
+	if len(calls) != 3 {
+		t.Fatalf("Docker pull calls = %#v, want three bounded retries", calls)
+	}
+	if _, err := os.Stat(calls[0].config); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("private Docker config remains after pull failure: %v", err)
+	}
+}
+
+func TestRunPrebuiltDockerFailureCleansOwnedContainer(t *testing.T) {
+	fake := newFakeDocker(t, "run-fail")
+	action := fakeDockerAction(t)
+	action.Image = "alpine:3.20"
+	result, err := (Runner{Docker: fake.path}).runDockerAction(t.Context(), action)
+	if err == nil || !strings.Contains(err.Error(), `run Docker action "fake Docker"`) {
+		t.Fatalf("runDockerAction() error = %v, want run failure", err)
+	}
+	if result.Outputs["container"] != "ran" {
+		t.Fatalf("prebuilt Docker failure effects = %#v", result)
+	}
+	calls := fake.calls(t)
+	if callIndex(calls, "stop", "--time", "2") < 0 || callIndex(calls, "rm", "--force") < 0 {
+		t.Fatalf("prebuilt Docker container cleanup was skipped: %#v", calls)
+	}
+	if callIndex(calls, "image", "rm") >= 0 {
+		t.Fatalf("prebuilt Docker cleanup removed a shared pulled image: %#v", calls)
+	}
+	if _, err := os.Stat(calls[0].config); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("private Docker config remains after run failure: %v", err)
 	}
 }
 
@@ -5207,6 +5361,29 @@ func TestDockerAction(t *testing.T) {
 	}
 	if !strings.Contains(logs.String(), "masked docker probe: ***") {
 		t.Errorf("Docker logs = %q, want masked probe", logs.String())
+	}
+}
+
+func TestPrebuiltDockerAction(t *testing.T) {
+	docker := requireDocker(t)
+	var logs bytes.Buffer
+	result, err := (Runner{Docker: docker, Stdout: &logs, Stderr: &logs}).runDockerAction(t.Context(), dockerAction{
+		Name:       "prebuilt Docker",
+		Image:      "busybox@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028",
+		Entrypoint: "/bin/sh",
+		Args: []string{"-c", `printf 'prebuilt=ran\n' >> "$GITHUB_OUTPUT"
+printf '%s\n' '::add-mask::prebuilt-secret'
+printf '%s\n' 'masked prebuilt probe: prebuilt-secret'`},
+		Workspace: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("runDockerAction() error = %v", err)
+	}
+	if result.Outputs["prebuilt"] != "ran" {
+		t.Fatalf("prebuilt Docker result = %#v", result)
+	}
+	if strings.Contains(logs.String(), "prebuilt-secret") || !strings.Contains(logs.String(), "masked prebuilt probe: ***") {
+		t.Fatalf("prebuilt Docker logs were not masked: %q", logs.String())
 	}
 }
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -273,6 +273,15 @@ if [[ "$1" == pull ]]; then
   exit 0
 fi
 
+if [[ "$1" == image && "$2" == inspect ]]; then
+  [[ $# == 5 && "$3" == --format && "$4" == '{{.Id}}' && "$5" == "$(cat "$state/image-name")" ]] || exit 51
+  [[ "$scenario" != inspect-image-fail ]] || exit 52
+  image_id='sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc'
+  printf '%s' "$image_id" > "$state/image-name"
+  printf '%s\n' "$image_id"
+  exit 0
+fi
+
 if [[ "$1" == run ]]; then
 	printf '%s\0' "$@" > "$state/run-argv"
 	if [[ -n "${ACTIONS_RUNTIME_TOKEN:-}" ]]; then
@@ -651,9 +660,9 @@ func TestRunPrebuiltDockerUsesPulledImageEntrypointAndExactArgs(t *testing.T) {
 		t.Fatalf("prebuilt action invoked buildx: %#v", calls)
 	}
 	argv := fakeDockerRunArgv(t, fake)
-	imageIndex := slices.Index(argv, action.Image)
+	imageIndex := slices.Index(argv, "sha256:"+strings.Repeat("c", 64))
 	if imageIndex < 0 || !slices.Equal(argv[imageIndex+1:], action.Args) {
-		t.Fatalf("Docker run argv = %#v, want exact args after image", argv)
+		t.Fatalf("Docker run argv = %#v, want exact args after pulled image ID", argv)
 	}
 	entrypoint := slices.Index(argv[:imageIndex], "--entrypoint")
 	if entrypoint < 0 || entrypoint+1 >= imageIndex || argv[entrypoint+1] != action.Entrypoint {
@@ -705,9 +714,9 @@ runs:
 		t.Fatalf("pull and run did not share an empty private Docker config: %#v", calls)
 	}
 	argv := fakeDockerRunArgv(t, fake)
-	imageIndex := slices.Index(argv, image)
+	imageIndex := slices.Index(argv, "sha256:"+strings.Repeat("c", 64))
 	if imageIndex < 0 || !slices.Equal(argv[imageIndex+1:], []string{"from-default"}) {
-		t.Fatalf("Docker run argv = %#v, want evaluated default after image", argv)
+		t.Fatalf("Docker run argv = %#v, want evaluated default after pulled image ID", argv)
 	}
 	if _, err := os.Stat(calls[pull].config); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("job private Docker config remains: %v", err)
@@ -732,6 +741,17 @@ runs:
 	if calls := mismatchFake.calls(t); callIndex(calls, "pull", "alpine:3.20") < 0 || callIndex(calls, "pull", image) < 0 || callIndex(calls, "run") >= 0 {
 		t.Fatalf("mismatched plan Docker calls = %#v, want only planned image pulls", calls)
 	}
+
+	unplannedFake := newFakeDocker(t, "success")
+	unplanned := job
+	unplanned.Actions = append([]plan.ActionLock(nil), job.Actions...)
+	unplanned.Actions[0].DockerImage = ""
+	if _, err := (Runner{Docker: unplannedFake.path}).RunJob(t.Context(), unplanned, workspace); err == nil || !strings.Contains(err.Error(), "metadata image \""+image+"\" does not match planned image \"\"") {
+		t.Fatalf("RunJob() unplanned metadata image error = %v", err)
+	}
+	if _, err := os.Stat(unplannedFake.transcript); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("unplanned metadata image Docker transcript exists: %v", err)
+	}
 }
 
 func TestRunPrebuiltDockerPullFailureCleansPrivateConfig(t *testing.T) {
@@ -747,6 +767,22 @@ func TestRunPrebuiltDockerPullFailureCleansPrivateConfig(t *testing.T) {
 	}
 	if _, err := os.Stat(calls[0].config); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("private Docker config remains after pull failure: %v", err)
+	}
+}
+
+func TestRunPrebuiltDockerInspectFailureCleansPrivateConfig(t *testing.T) {
+	fake := newFakeDocker(t, "inspect-image-fail")
+	action := fakeDockerAction(t)
+	action.Image = "alpine:3.20"
+	if _, err := (Runner{Docker: fake.path}).runDockerAction(t.Context(), action); err == nil || !strings.Contains(err.Error(), "inspect prebuilt Docker action image") {
+		t.Fatalf("runDockerAction() error = %v, want image inspection failure", err)
+	}
+	calls := fake.calls(t)
+	if callIndex(calls, "pull", action.Image) < 0 || callIndex(calls, "image", "inspect") < 0 || callIndex(calls, "run") >= 0 {
+		t.Fatalf("Docker calls = %#v, want pull and failed inspection only", calls)
+	}
+	if _, err := os.Stat(calls[0].config); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("private Docker config remains after inspect failure: %v", err)
 	}
 }
 

--- a/schemas/job-plan.schema.json
+++ b/schemas/job-plan.schema.json
@@ -109,7 +109,7 @@
       "properties": {
         "id": {"type": "string", "pattern": "^a-[0-9a-f]{16}$"}, "source": {"enum": ["workspace", "github"]},
         "repository": {"$ref": "#/$defs/repository"}, "requested_ref": {"type": "string", "minLength": 1, "maxLength": 1024, "pattern": "^[^\\x00-\\x1f\\x7f]+$"},
-        "commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"}, "path": {"$ref": "#/$defs/path"}, "source_digest": {"$ref": "#/$defs/digest"},
+        "commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"}, "path": {"$ref": "#/$defs/path"}, "source_digest": {"$ref": "#/$defs/digest"}, "docker_image": {"$ref": "#/$defs/image"},
         "children": {"type": "object", "maxProperties": 1024, "propertyNames": {"minLength": 1, "maxLength": 2048, "pattern": "^[^\\x00-\\x1f\\x7f]+$"}, "additionalProperties": {"$ref": "#/$defs/selector"}}
       },
       "allOf": [


### PR DESCRIPTION
## Why

Action metadata such as:

```yaml
runs:
  using: docker
  image: docker://alpine:3.20
```

is currently rejected because Docker actions require an exact `Dockerfile`. This blocks a common GitHub Actions form that runs one action step in a prebuilt container.

## What

Pull metadata-declared public images anonymously at job start and run them through the existing Linux Docker action path. Metadata `entrypoint` and `args` retain image semantics, digest references work, and mutable tags resolve at job start.

Direct workflow `uses: docker://...`, private images, registry credentials, macOS, and queues without Docker remain unsupported.
