### PR TITLE
Configure cache volumes for imported workflow jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ plugins:
       runners:
         - runs-on: ubuntu-latest
           queue: hosted
+          cache:
+            paths:
+              - /home/runner/.gradle/caches
+              - /home/runner/.gradle/wrapper
+            name: gradle-dependencies
+            size: 40g
         - runs-on: macos-14
           queue: macos-sonoma-arm64
 ```
@@ -76,7 +82,8 @@ Hosted runner labels are case-insensitive. Linux labels use the matching Noble
 or Jammy hosted-toolchains image, with or without a configured queue.
 During upload, the Agent API returns complete targets for selectors without an
 explicit mapping. The importer annotates heuristic fallback warnings. See the
-[compatibility guide](docs/compatibility.md#job-configuration).
+[cache-volume configuration](docs/cli.md#configure-generated-job-cache-volumes)
+and [compatibility guide](docs/compatibility.md#job-configuration).
 
 The imported workflows are a dynamic part of the Buildkite pipeline. The plugin creates one aggregate group per successfully compiled, explicitly listed workflow in a single transaction. Workflows that do not declare the selected event become top-level skipped steps. Groups and replacement steps depend on the importer. Each runnable job publishes a provider check named `<workflow> / <job> (<event>)`: a GitHub check for GitHub events or an Origin check for Origin events. This approach lets you keep existing workflows while moving jobs to native Buildkite steps over time.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -352,6 +352,8 @@ volume. A configured name and size apply to that combined volume; otherwise,
 the managed mise name and Buildkite's default size remain unchanged. Jobs with
 neither configuration emit no `cache` attribute.
 
+Runner cache volumes are not supported for workflow jobs that set `container`.
+
 Generated Linux jobs run as `runner`. Configured cache paths are made writable
 by that user after the bootstrap verifies that they target the Buildkite cache
 volume. Prefer narrowly scoped paths.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -320,6 +320,53 @@ The importer reuses its verified executable for jobs on the same platform. It
 downloads the other platform's distribution from the same release only when a
 workflow needs it. Runner mappings apply to generated jobs, not the importer.
 
+### Configure generated-job cache volumes
+
+An explicit runner mapping can attach one Buildkite Hosted cache volume to each
+generated job using that mapping:
+
+```yaml
+plugins:
+  - github-actions#latest:
+      workflow: .github/workflows/ci.yml
+      runners:
+        - runs-on: ubuntu-latest
+          queue: hosted
+          cache:
+            paths:
+              - /home/runner/.gradle/caches
+              - /home/runner/.gradle/wrapper
+            name: gradle-dependencies
+            size: 40g
+```
+
+`cache.paths` is a required, non-empty list of unique, non-empty paths. Paths
+may be relative to the generated job's working directory or absolute. `name`
+and `size` are optional. Names follow Buildkite's 100-character
+letters-numbers-hyphens format and may contain `${BUILDKITE_*}` variables.
+Sizes use `Ng` and must be at least `20g`. Without a name or size, Buildkite
+uses its pipeline-scoped name and 20 GB defaults.
+
+Each Buildkite step supports one cache volume. When a job also needs the
+internally managed mise cache, `buildkite-gha` adds the mise path to the same
+volume. A configured name and size apply to that combined volume; otherwise,
+the managed mise name and Buildkite's default size remain unchanged. Jobs with
+neither configuration emit no `cache` attribute.
+
+Generated Linux jobs run as `runner`. Configured cache paths are made writable
+by that user after the bootstrap verifies that they target the Buildkite cache
+volume. Prefer narrowly scoped paths.
+For example, caching an entire Gradle User Home also persists `init.d` scripts
+and other executable configuration, increasing the impact of cache poisoning.
+Caching only `caches` and `wrapper` reduces that exposure, but a cache-volume
+miss does not provide setup-gradle's archive-cache fallback once the mounted
+`caches` directory exists.
+
+Cache volumes are best-effort accelerators, scoped to the Buildkite pipeline
+and cluster. They commit after successful jobs and are abandoned after failed
+jobs. Do not use them as durable or trusted storage. See [Buildkite cache
+volumes](https://buildkite.com/docs/agent/buildkite-hosted/cache-volumes).
+
 ### Select workflows
 
 Pass every workflow path explicitly:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -340,8 +340,7 @@ plugins:
             size: 40g
 ```
 
-`cache.paths` is a required, non-empty list of unique, non-empty paths. Paths
-may be relative to the generated job's working directory or absolute. `name`
+`cache.paths` is a required, non-empty list of unique absolute paths. `name`
 and `size` are optional. Names follow Buildkite's 100-character
 letters-numbers-hyphens format and may contain `${BUILDKITE_*}` variables.
 Sizes use `Ng` and must be at least `20g`. Without a name or size, Buildkite

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -627,6 +627,9 @@ transport has no authoritative current-attempt and durable idempotency fence.
 
 **🟡 Supported subset.** Linux jobs support job containers and GitHub-compatible services. A typical PostgreSQL service works without Buildkite-specific syntax:
 
+Runner-mapped Buildkite cache volumes are not supported for jobs that set
+`container`.
+
 ```yaml
 services:
   postgres:

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -535,6 +535,11 @@ platform, and immutable Linux image. The importer applies that target verbatim
 and publishes returned fallback warnings as annotations. The server rejects
 selectors that require an incompatible operating system or architecture.
 
+Explicit mappings can also attach one [Buildkite Hosted cache
+volume](cli.md#configure-generated-job-cache-volumes) to generated jobs. This
+configuration is outside the GitHub workflow and does not change workflow
+syntax or action inputs.
+
 `validate --profile hosted` has no job-scoped API and admits only the local
 `macos-latest` preset.
 

--- a/internal/buildkite/experimental_runner_user.go
+++ b/internal/buildkite/experimental_runner_user.go
@@ -6,7 +6,7 @@ package buildkite
 const experimentalRunnerHome = "/home/runner"
 const experimentalRunnerTemp = "/tmp/buildkite-gha-runner"
 
-func experimentalRunnerUserBootstrap(requiresMise, hostedToolCache bool) []string {
+func experimentalRunnerUserBootstrap(requiresMise, hostedToolCache bool, cache *CacheVolume) []string {
 	commands := []string{
 		`test "$(id -u)" -eq 0 || { echo 'buildkite-gha: runner user bootstrap requires root' >&2; exit 1; }`,
 		`for command in getent useradd usermod install sudo; do command -v "$command" >/dev/null 2>&1 || { echo "buildkite-gha: runner user bootstrap requires $command" >&2; exit 1; }; done`,
@@ -26,6 +26,18 @@ func experimentalRunnerUserBootstrap(requiresMise, hostedToolCache bool) []strin
 		`chmod 0440 "$plan"`,
 		`sudo -n --user runner -- test -x "$distribution" && ! sudo -n --user runner -- test -w "$distribution" || { echo 'buildkite-gha: runner runtime permissions are unsafe' >&2; exit 1; }`,
 		`sudo -n --user runner -- test -r "$plan" && ! sudo -n --user runner -- test -w "$plan" || { echo 'buildkite-gha: runner plan permissions are unsafe' >&2; exit 1; }`,
+	}
+	if cache != nil {
+		commands = append(commands, `command -v readlink >/dev/null 2>&1 || { echo 'buildkite-gha: configured cache paths require readlink' >&2; exit 1; }`)
+		for _, path := range cache.Paths {
+			commands = append(commands,
+				"cache_target=\"$(readlink -f -- "+shellQuote(path)+`)" || { echo 'buildkite-gha: configured cache path is unavailable' >&2; exit 1; }`,
+				`case "$cache_target" in /cache/bkcache/*) ;; *) echo 'buildkite-gha: configured cache path does not target the Buildkite cache volume' >&2; exit 1;; esac`,
+				`test -d "$cache_target" || { echo 'buildkite-gha: configured cache path is not a directory' >&2; exit 1; }`,
+				`chown -R runner:"$runner_group" "$cache_target"`,
+				`chmod -R u+rwX "$cache_target"`,
+			)
+		}
 	}
 	if requiresMise {
 		commands = append(commands,

--- a/internal/buildkite/pipeline.go
+++ b/internal/buildkite/pipeline.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"unicode"
 	"unicode/utf8"
 )
 
@@ -37,6 +38,49 @@ var identifierPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,255}$`)
 var digestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
 var runtimeImagePattern = regexp.MustCompile(`^[a-z0-9]+(?:[._-][a-z0-9]+)*(?:/[a-z0-9]+(?:[._-][a-z0-9]+)*)+@sha256:[0-9a-f]{64}$`)
 var uuidPattern = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+var cacheNamePattern = regexp.MustCompile(`^[A-Za-z0-9](?:[A-Za-z0-9-]{0,98}[A-Za-z0-9])?$`)
+var cacheNameVariablePattern = regexp.MustCompile(`\$\{BUILDKITE_[A-Z0-9_]+\}`)
+var cacheSizePattern = regexp.MustCompile(`^[0-9]+g$`)
+
+// CacheVolume is one Buildkite Hosted cache volume attached to a generated job.
+type CacheVolume struct {
+	Paths []string
+	Name  string
+	Size  string
+}
+
+// ValidateCacheVolume validates Buildkite's map-form cache volume contract.
+func ValidateCacheVolume(cache CacheVolume) error {
+	if len(cache.Paths) == 0 {
+		return fmt.Errorf("cache paths must be a non-empty array of non-empty strings")
+	}
+	seen := make(map[string]struct{}, len(cache.Paths))
+	for i, path := range cache.Paths {
+		if strings.TrimSpace(path) == "" || strings.IndexFunc(path, unicode.IsControl) >= 0 {
+			return fmt.Errorf("cache paths entry %d must be a non-empty string", i)
+		}
+		if _, duplicate := seen[path]; duplicate {
+			return fmt.Errorf("cache path %q may only be configured once", path)
+		}
+		seen[path] = struct{}{}
+	}
+	if cache.Name != "" {
+		literalShape := cacheNameVariablePattern.ReplaceAllString(cache.Name, "a")
+		if len(cache.Name) > 100 || strings.Contains(literalShape, "$") || !cacheNamePattern.MatchString(literalShape) {
+			return fmt.Errorf("cache name must be at most 100 characters, use only letters, numbers, hyphens, and ${BUILDKITE_*} variables, and start and end with a letter, number, or variable")
+		}
+	}
+	if cache.Size != "" {
+		if !cacheSizePattern.MatchString(cache.Size) {
+			return fmt.Errorf("cache size must be at least 20 gigabytes in Ng format")
+		}
+		gigabytes := strings.TrimLeft(strings.TrimSuffix(cache.Size, "g"), "0")
+		if len(gigabytes) < 2 || (len(gigabytes) == 2 && gigabytes < "20") {
+			return fmt.Errorf("cache size must be at least 20 gigabytes in Ng format")
+		}
+	}
+	return nil
+}
 
 // Pipeline is the validated input required to emit generated compatibility jobs.
 type Pipeline struct {
@@ -112,6 +156,7 @@ type Job struct {
 	PlanDigest         string
 	Dependencies       []string
 	RequiresMise       bool
+	Cache              *CacheVolume
 	SoftFail           bool
 	ConcurrencyGroup   string
 	Concurrency        int
@@ -380,7 +425,7 @@ func emitWorkflow(out *bytes.Buffer, pipeline Pipeline, workflow preparedWorkflo
 				`if command -v sha256sum >/dev/null 2>&1; then actual_plan_digest="$(sha256sum "$plan" | awk '{print "sha256:" $1}')"; elif command -v shasum >/dev/null 2>&1; then actual_plan_digest="$(shasum -a 256 "$plan" | awk '{print "sha256:" $1}')"; else echo 'buildkite-gha: no SHA-256 tool available' >&2; exit 1; fi`,
 				"test \"$actual_plan_digest\" = "+shellQuote(job.PlanDigest),
 			)
-			commands = append(commands, experimentalRunnerUserBootstrap(job.RequiresMise, runtimeImage != "")...)
+			commands = append(commands, experimentalRunnerUserBootstrap(job.RequiresMise, runtimeImage != "", job.Cache)...)
 			runJob = "BUILDKITE_GHA_PLAN_DIGEST=" + shellQuote(job.PlanDigest) + ` "$distribution" run-job --plan "$plan"`
 		}
 		if runtimeImage != "" {
@@ -404,11 +449,19 @@ func emitWorkflow(out *bytes.Buffer, pipeline Pipeline, workflow preparedWorkflo
 			_, _ = fmt.Fprintf(out, "%s  queue: %s\n", attributeIndent, yamlScalar(job.Queue))
 		}
 		_, _ = fmt.Fprintf(out, "%scheckout:\n%s  skip: true\n", attributeIndent, attributeIndent)
-		if job.RequiresMise {
+		cache := mergedCacheVolume(job.Cache, job.RequiresMise, platform)
+		if cache != nil {
 			_, _ = fmt.Fprintf(out, "%scache:\n", attributeIndent)
 			_, _ = fmt.Fprintf(out, "%s  paths:\n", attributeIndent)
-			_, _ = fmt.Fprintf(out, "%s    - %s\n", attributeIndent, yamlScalar(platformMiseCachePath(platform)))
-			_, _ = fmt.Fprintf(out, "%s  name: %s\n", attributeIndent, yamlScalar(runtimeCacheName+"-"+platformCacheKey(platform)))
+			for _, path := range cache.Paths {
+				_, _ = fmt.Fprintf(out, "%s    - %s\n", attributeIndent, yamlScalar(path))
+			}
+			if cache.Name != "" {
+				_, _ = fmt.Fprintf(out, "%s  name: %s\n", attributeIndent, yamlScalar(cache.Name))
+			}
+			if cache.Size != "" {
+				_, _ = fmt.Fprintf(out, "%s  size: %s\n", attributeIndent, yamlScalar(cache.Size))
+			}
 		}
 		if job.SoftFail {
 			_, _ = fmt.Fprintf(out, "%ssoft_fail:\n%s  - exit_status: %d\n", attributeIndent, attributeIndent, ContinueOnErrorExitStatus)
@@ -482,6 +535,35 @@ func platformMiseCachePath(platform string) string {
 		root = darwinRuntimeCacheRoot
 	}
 	return root + "/mise/" + platformCacheKey(platform)
+}
+
+func mergedCacheVolume(configured *CacheVolume, requiresMise bool, platform string) *CacheVolume {
+	if configured == nil && !requiresMise {
+		return nil
+	}
+	cache := &CacheVolume{}
+	if configured != nil {
+		cache.Paths = append(cache.Paths, configured.Paths...)
+		cache.Name = configured.Name
+		cache.Size = configured.Size
+	}
+	if requiresMise {
+		misePath := platformMiseCachePath(platform)
+		found := false
+		for _, path := range cache.Paths {
+			if path == misePath {
+				found = true
+				break
+			}
+		}
+		if !found {
+			cache.Paths = append(cache.Paths, misePath)
+		}
+		if cache.Name == "" {
+			cache.Name = runtimeCacheName + "-" + platformCacheKey(platform)
+		}
+	}
+	return cache
 }
 
 type dependency struct {
@@ -618,6 +700,11 @@ func orderJobs(compilerStep string, input []Job) ([]Job, error) {
 func validateJob(compilerStep string, job Job) error {
 	if !validStepKey(job.Key) || job.Key == compilerStep {
 		return fmt.Errorf("invalid generated step key %q", job.Key)
+	}
+	if job.Cache != nil {
+		if err := ValidateCacheVolume(*job.Cache); err != nil {
+			return fmt.Errorf("job %q has invalid cache configuration: %w", job.Key, err)
+		}
 	}
 	if job.Label == "" {
 		return fmt.Errorf("job %q requires a label", job.Key)

--- a/internal/buildkite/pipeline.go
+++ b/internal/buildkite/pipeline.go
@@ -59,6 +59,9 @@ func ValidateCacheVolume(cache CacheVolume) error {
 		if strings.TrimSpace(path) == "" || strings.IndexFunc(path, unicode.IsControl) >= 0 {
 			return fmt.Errorf("cache paths entry %d must be a non-empty string", i)
 		}
+		if !filepath.IsAbs(path) {
+			return fmt.Errorf("cache path %q must be absolute", path)
+		}
 		if _, duplicate := seen[path]; duplicate {
 			return fmt.Errorf("cache path %q may only be configured once", path)
 		}

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -955,7 +955,7 @@ func TestEmitConfiguredCacheUsesBuildkiteDefaultsWithoutMise(t *testing.T) {
 	output, err := Emit(Pipeline{
 		CompilerStep:       "importer",
 		DistributionDigest: testDigest("distribution"),
-		Jobs:               []Job{{Key: "shell", Label: "Shell", PlanDigest: testDigest("plan"), Cache: &CacheVolume{Paths: []string{".cache"}}}},
+		Jobs:               []Job{{Key: "shell", Label: "Shell", PlanDigest: testDigest("plan"), Cache: &CacheVolume{Paths: []string{"/home/runner/.cache"}}}},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -972,11 +972,11 @@ func TestEmitConfiguredCacheUsesBuildkiteDefaultsWithoutMise(t *testing.T) {
 	if err := yaml.Unmarshal(output, &document); err != nil {
 		t.Fatal(err)
 	}
-	if len(document.Steps) != 1 || !slices.Equal(document.Steps[0].Cache.Paths, []string{".cache"}) || document.Steps[0].Cache.Name != "" || document.Steps[0].Cache.Size != "" || strings.Contains(string(output), "BUILDKITE_GHA_MISE_DATA_DIR") {
+	if len(document.Steps) != 1 || !slices.Equal(document.Steps[0].Cache.Paths, []string{"/home/runner/.cache"}) || document.Steps[0].Cache.Name != "" || document.Steps[0].Cache.Size != "" || strings.Contains(string(output), "BUILDKITE_GHA_MISE_DATA_DIR") {
 		t.Fatalf("configured cache did not preserve Buildkite defaults:\n%s", output)
 	}
-	if !strings.Contains(string(output), "readlink -f -- '.cache'") {
-		t.Fatalf("relative cache path is not made writable by runner:\n%s", output)
+	if !strings.Contains(string(output), "readlink -f -- '/home/runner/.cache'") {
+		t.Fatalf("cache path is not made writable by runner:\n%s", output)
 	}
 }
 

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -773,6 +773,78 @@ func TestEmitActionRuntimeRequirement(t *testing.T) {
 	}
 }
 
+func TestEmitMergesConfiguredAndManagedCacheVolume(t *testing.T) {
+	output, err := Emit(Pipeline{
+		CompilerStep:       "importer",
+		DistributionDigest: testDigest("distribution"),
+		Jobs: []Job{{
+			Key: "action", Label: "Action", Queue: "hosted", PlanDigest: testDigest("plan"), RequiresMise: true,
+			Cache: &CacheVolume{Paths: []string{"/home/runner/.gradle/caches", "/home/runner/.gradle/wrapper"}, Name: "dependencies", Size: "40g"},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document struct {
+		Steps []struct {
+			Command string `yaml:"command"`
+			Cache   struct {
+				Paths []string `yaml:"paths"`
+				Name  string   `yaml:"name"`
+				Size  string   `yaml:"size"`
+			} `yaml:"cache"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(output, &document); err != nil {
+		t.Fatal(err)
+	}
+	if len(document.Steps) != 1 {
+		t.Fatalf("steps = %#v", document.Steps)
+	}
+	step := document.Steps[0]
+	wantPaths := []string{"/home/runner/.gradle/caches", "/home/runner/.gradle/wrapper", platformMiseCachePath("linux/amd64")}
+	if !slices.Equal(step.Cache.Paths, wantPaths) || step.Cache.Name != "dependencies" || step.Cache.Size != "40g" {
+		t.Fatalf("merged cache = %#v, want paths %#v with configured name and size", step.Cache, wantPaths)
+	}
+	for _, path := range []string{"/home/runner/.gradle/caches", "/home/runner/.gradle/wrapper"} {
+		if !strings.Contains(step.Command, "readlink -f -- '"+path+"'") {
+			t.Fatalf("runner-home cache path %q is not made writable by runner:\n%s", path, step.Command)
+		}
+	}
+	if !strings.Contains(step.Command, `case "$cache_target" in /cache/bkcache/*)`) || !strings.Contains(step.Command, `chown -R runner:"$runner_group" "$cache_target"`) {
+		t.Fatalf("cache ownership is not constrained to the Buildkite volume:\n%s", step.Command)
+	}
+}
+
+func TestEmitConfiguredCacheUsesBuildkiteDefaultsWithoutMise(t *testing.T) {
+	output, err := Emit(Pipeline{
+		CompilerStep:       "importer",
+		DistributionDigest: testDigest("distribution"),
+		Jobs:               []Job{{Key: "shell", Label: "Shell", PlanDigest: testDigest("plan"), Cache: &CacheVolume{Paths: []string{".cache"}}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document struct {
+		Steps []struct {
+			Cache struct {
+				Paths []string `yaml:"paths"`
+				Name  string   `yaml:"name"`
+				Size  string   `yaml:"size"`
+			} `yaml:"cache"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(output, &document); err != nil {
+		t.Fatal(err)
+	}
+	if len(document.Steps) != 1 || !slices.Equal(document.Steps[0].Cache.Paths, []string{".cache"}) || document.Steps[0].Cache.Name != "" || document.Steps[0].Cache.Size != "" || strings.Contains(string(output), "BUILDKITE_GHA_MISE_DATA_DIR") {
+		t.Fatalf("configured cache did not preserve Buildkite defaults:\n%s", output)
+	}
+	if !strings.Contains(string(output), "readlink -f -- '.cache'") {
+		t.Fatalf("relative cache path is not made writable by runner:\n%s", output)
+	}
+}
+
 func TestEmitDarwinActionRuntimeUsesNativePlatformCache(t *testing.T) {
 	output, err := Emit(Pipeline{
 		CompilerStep: "importer",

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	buildkitepipeline "github.com/buildkite/buildkite-gha/internal/buildkite"
 	"github.com/buildkite/buildkite-gha/internal/compiler"
 	"github.com/buildkite/buildkite-gha/internal/plan"
 	"github.com/buildkite/buildkite-gha/internal/telemetry"
@@ -148,7 +149,7 @@ func parsePluginConfiguration(source string) (pluginConfiguration, error) {
 			}
 			for key := range runner {
 				switch key {
-				case "runs-on", "queue", "image":
+				case "runs-on", "queue", "image", "cache":
 				default:
 					return pluginConfiguration{}, fmt.Errorf("runner %d contains unknown field %q", index, key)
 				}
@@ -173,6 +174,13 @@ func parsePluginConfiguration(source string) (pluginConfiguration, error) {
 			if err != nil {
 				return pluginConfiguration{}, fmt.Errorf("runner %d: %w", index, err)
 			}
+			if cacheValue, configured := runner["cache"]; configured {
+				cache, err := parsePluginCacheVolume(cacheValue)
+				if err != nil {
+					return pluginConfiguration{}, fmt.Errorf("runner %d: %w", index, err)
+				}
+				target.Cache = cache
+			}
 			if _, duplicate := targets[label]; duplicate {
 				return pluginConfiguration{}, fmt.Errorf("runner label %q may only be configured once", label)
 			}
@@ -187,6 +195,46 @@ func parsePluginConfiguration(source string) (pluginConfiguration, error) {
 		}
 	}
 	return pluginConfiguration{Workflows: workflows, ExperimentalRunnerUser: experimentalRunnerUser, OIDC: oidc, runnerTargets: targets}, nil
+}
+
+func parsePluginCacheVolume(value any) (*compiler.CacheVolume, error) {
+	cacheObject, ok := value.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("cache must be a JSON object")
+	}
+	for key := range cacheObject {
+		switch key {
+		case "paths", "name", "size":
+		default:
+			return nil, fmt.Errorf("cache contains unknown field %q", key)
+		}
+	}
+	paths, configured := cacheObject["paths"]
+	if !configured {
+		return nil, fmt.Errorf("cache paths is required")
+	}
+	cache := &compiler.CacheVolume{}
+	var err error
+	cache.Paths, err = pluginNonEmptyStringList(paths, "cache paths")
+	if err != nil {
+		return nil, err
+	}
+	if name, configured := cacheObject["name"]; configured {
+		cache.Name, ok = name.(string)
+		if !ok || cache.Name == "" {
+			return nil, fmt.Errorf("cache name must be a non-empty string")
+		}
+	}
+	if size, configured := cacheObject["size"]; configured {
+		cache.Size, ok = size.(string)
+		if !ok || cache.Size == "" {
+			return nil, fmt.Errorf("cache size must be a non-empty string")
+		}
+	}
+	if err := buildkitepipeline.ValidateCacheVolume(*cache); err != nil {
+		return nil, err
+	}
+	return cache, nil
 }
 
 func parsePluginOIDCConfiguration(value any) (*plan.OIDCConfiguration, error) {

--- a/internal/cli/plugin_test.go
+++ b/internal/cli/plugin_test.go
@@ -157,7 +157,7 @@ func TestParsePluginConfiguration(t *testing.T) {
     "subject-claim": "pipeline_id"
   },
   "runners": [
-    {"runs-on":"ubuntu-latest","queue":"hosted","image":"` + image + `"},
+    {"runs-on":"ubuntu-latest","queue":"hosted","image":"` + image + `","cache":{"paths":["/home/runner/.gradle/caches","/home/runner/.gradle/wrapper"],"name":"gradle-${BUILDKITE_BRANCH}","size":"40g"}},
     {"runs-on":"macos-14","queue":"macos-sonoma-arm64"}
   ]
 }`)
@@ -170,7 +170,7 @@ func TestParsePluginConfiguration(t *testing.T) {
 	if configuration.OIDC == nil || !slices.Equal(configuration.OIDC.Claims, []string{"organization_id", "future_server_claim"}) || !slices.Equal(configuration.OIDC.AWSSessionTags, []string{"organization_slug", "pipeline_id"}) || configuration.OIDC.SubjectClaim != "pipeline_id" {
 		t.Fatalf("OIDC configuration = %#v", configuration.OIDC)
 	}
-	if got := configuration.runnerTargets["ubuntu-latest"]; got != (compiler.RunnerTarget{Queue: "hosted", Platform: compiler.PlatformLinuxAMD64, Image: image}) {
+	if got := configuration.runnerTargets["ubuntu-latest"]; got.Queue != "hosted" || got.Platform != compiler.PlatformLinuxAMD64 || got.Image != image || got.Cache == nil || !slices.Equal(got.Cache.Paths, []string{"/home/runner/.gradle/caches", "/home/runner/.gradle/wrapper"}) || got.Cache.Name != "gradle-${BUILDKITE_BRANCH}" || got.Cache.Size != "40g" {
 		t.Fatalf("Linux target = %#v", got)
 	}
 	if got := configuration.runnerTargets["macos-14"]; got != (compiler.RunnerTarget{Queue: "macos-sonoma-arm64", Platform: compiler.PlatformDarwinARM64}) {
@@ -225,6 +225,15 @@ func TestParsePluginConfiguration(t *testing.T) {
 		{name: "null image", source: `{"workflow":"ci.yml","runners":[{"runs-on":"ubuntu-latest","queue":"hosted","image":null}]}`, want: "immutable registry"},
 		{name: "mutable image", source: `{"workflow":"ci.yml","runners":[{"runs-on":"ubuntu-latest","queue":"hosted","image":"ubuntu:latest"}]}`, want: "immutable registry"},
 		{name: "Darwin image", source: `{"workflow":"ci.yml","runners":[{"runs-on":"macos-14","queue":"macos","image":"` + image + `"}]}`, want: "unsupported on darwin/arm64"},
+		{name: "null cache", source: `{"workflow":"ci.yml","runners":[{"runs-on":"ubuntu-latest","queue":"hosted","cache":null}]}`, want: "cache must be a JSON object"},
+		{name: "unknown cache field", source: `{"workflow":"ci.yml","runners":[{"runs-on":"ubuntu-latest","queue":"hosted","cache":{"paths":[".cache"],"scope":"branch"}}]}`, want: "cache contains unknown field"},
+		{name: "missing cache paths", source: `{"workflow":"ci.yml","runners":[{"runs-on":"ubuntu-latest","queue":"hosted","cache":{"name":"dependencies"}}]}`, want: "cache paths is required"},
+		{name: "empty cache paths", source: `{"workflow":"ci.yml","runners":[{"runs-on":"ubuntu-latest","queue":"hosted","cache":{"paths":[]}}]}`, want: "cache paths must be a non-empty array"},
+		{name: "duplicate cache path", source: `{"workflow":"ci.yml","runners":[{"runs-on":"ubuntu-latest","queue":"hosted","cache":{"paths":[".cache",".cache"]}}]}`, want: "may only be configured once"},
+		{name: "invalid cache name", source: `{"workflow":"ci.yml","runners":[{"runs-on":"ubuntu-latest","queue":"hosted","cache":{"paths":[".cache"],"name":"bad_name"}}]}`, want: "cache name must be"},
+		{name: "arbitrary cache name variable", source: `{"workflow":"ci.yml","runners":[{"runs-on":"ubuntu-latest","queue":"hosted","cache":{"paths":[".cache"],"name":"${HOME}-cache"}}]}`, want: "cache name must be"},
+		{name: "undersized cache", source: `{"workflow":"ci.yml","runners":[{"runs-on":"ubuntu-latest","queue":"hosted","cache":{"paths":[".cache"],"size":"19g"}}]}`, want: "at least 20 gigabytes"},
+		{name: "invalid cache size unit", source: `{"workflow":"ci.yml","runners":[{"runs-on":"ubuntu-latest","queue":"hosted","cache":{"paths":[".cache"],"size":"20GB"}}]}`, want: "Ng format"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			if _, err := parsePluginConfiguration(test.source); err == nil || !strings.Contains(err.Error(), test.want) {
@@ -250,8 +259,8 @@ func TestPluginUsesJSONConfigurationAndOnlyRequiredRuntime(t *testing.T) {
 			"aws-session-tags": []string{"pipeline_id"},
 			"subject-claim":    "pipeline_id",
 		},
-		"runners": []map[string]string{
-			{"runs-on": "ubuntu-latest", "queue": "hosted"},
+		"runners": []map[string]any{
+			{"runs-on": "ubuntu-latest", "queue": "hosted", "cache": map[string]any{"paths": []string{"/home/runner/.gradle/caches", "/home/runner/.gradle/wrapper"}, "name": "gradle-cache", "size": "40g"}},
 		},
 	})
 	if err != nil {
@@ -283,6 +292,11 @@ func TestPluginUsesJSONConfigurationAndOnlyRequiredRuntime(t *testing.T) {
 				Image   string            `yaml:"image"`
 				Agents  map[string]string `yaml:"agents"`
 				Command string            `yaml:"command"`
+				Cache   struct {
+					Paths []string `yaml:"paths"`
+					Name  string   `yaml:"name"`
+					Size  string   `yaml:"size"`
+				} `yaml:"cache"`
 			} `yaml:"steps"`
 		} `yaml:"steps"`
 	}
@@ -293,7 +307,7 @@ func TestPluginUsesJSONConfigurationAndOnlyRequiredRuntime(t *testing.T) {
 		t.Fatalf("workflow groups = %#v", pipeline.Steps)
 	}
 	for _, step := range pipeline.Steps[0].Steps {
-		if step.Agents["queue"] != "hosted" || step.Image != defaultNobleRunnerImage || !strings.Contains(step.Command, "--hosted-tool-cache") || !strings.Contains(step.Command, "useradd --create-home") || !strings.Contains(step.Command, "sudo -n --preserve-env --user runner") {
+		if step.Agents["queue"] != "hosted" || step.Image != defaultNobleRunnerImage || !slices.Equal(step.Cache.Paths, []string{"/home/runner/.gradle/caches", "/home/runner/.gradle/wrapper"}) || step.Cache.Name != "gradle-cache" || step.Cache.Size != "40g" || !strings.Contains(step.Command, "--hosted-tool-cache") || !strings.Contains(step.Command, "useradd --create-home") || !strings.Contains(step.Command, "chown -R runner") || !strings.Contains(step.Command, "sudo -n --preserve-env --user runner") {
 			t.Fatalf("plugin profile was not applied: %#v", step)
 		}
 	}

--- a/internal/cli/plugin_test.go
+++ b/internal/cli/plugin_test.go
@@ -229,11 +229,12 @@ func TestParsePluginConfiguration(t *testing.T) {
 		{name: "unknown cache field", source: `{"workflow":"ci.yml","runners":[{"runs-on":"ubuntu-latest","queue":"hosted","cache":{"paths":[".cache"],"scope":"branch"}}]}`, want: "cache contains unknown field"},
 		{name: "missing cache paths", source: `{"workflow":"ci.yml","runners":[{"runs-on":"ubuntu-latest","queue":"hosted","cache":{"name":"dependencies"}}]}`, want: "cache paths is required"},
 		{name: "empty cache paths", source: `{"workflow":"ci.yml","runners":[{"runs-on":"ubuntu-latest","queue":"hosted","cache":{"paths":[]}}]}`, want: "cache paths must be a non-empty array"},
-		{name: "duplicate cache path", source: `{"workflow":"ci.yml","runners":[{"runs-on":"ubuntu-latest","queue":"hosted","cache":{"paths":[".cache",".cache"]}}]}`, want: "may only be configured once"},
-		{name: "invalid cache name", source: `{"workflow":"ci.yml","runners":[{"runs-on":"ubuntu-latest","queue":"hosted","cache":{"paths":[".cache"],"name":"bad_name"}}]}`, want: "cache name must be"},
-		{name: "arbitrary cache name variable", source: `{"workflow":"ci.yml","runners":[{"runs-on":"ubuntu-latest","queue":"hosted","cache":{"paths":[".cache"],"name":"${HOME}-cache"}}]}`, want: "cache name must be"},
-		{name: "undersized cache", source: `{"workflow":"ci.yml","runners":[{"runs-on":"ubuntu-latest","queue":"hosted","cache":{"paths":[".cache"],"size":"19g"}}]}`, want: "at least 20 gigabytes"},
-		{name: "invalid cache size unit", source: `{"workflow":"ci.yml","runners":[{"runs-on":"ubuntu-latest","queue":"hosted","cache":{"paths":[".cache"],"size":"20GB"}}]}`, want: "Ng format"},
+		{name: "relative cache path", source: `{"workflow":"ci.yml","runners":[{"runs-on":"ubuntu-latest","queue":"hosted","cache":{"paths":[".cache"]}}]}`, want: "must be absolute"},
+		{name: "duplicate cache path", source: `{"workflow":"ci.yml","runners":[{"runs-on":"ubuntu-latest","queue":"hosted","cache":{"paths":["/cache","/cache"]}}]}`, want: "may only be configured once"},
+		{name: "invalid cache name", source: `{"workflow":"ci.yml","runners":[{"runs-on":"ubuntu-latest","queue":"hosted","cache":{"paths":["/cache"],"name":"bad_name"}}]}`, want: "cache name must be"},
+		{name: "arbitrary cache name variable", source: `{"workflow":"ci.yml","runners":[{"runs-on":"ubuntu-latest","queue":"hosted","cache":{"paths":["/cache"],"name":"${HOME}-cache"}}]}`, want: "cache name must be"},
+		{name: "undersized cache", source: `{"workflow":"ci.yml","runners":[{"runs-on":"ubuntu-latest","queue":"hosted","cache":{"paths":["/cache"],"size":"19g"}}]}`, want: "at least 20 gigabytes"},
+		{name: "invalid cache size unit", source: `{"workflow":"ci.yml","runners":[{"runs-on":"ubuntu-latest","queue":"hosted","cache":{"paths":["/cache"],"size":"20GB"}}]}`, want: "Ng format"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			if _, err := parsePluginConfiguration(test.source); err == nil || !strings.Contains(err.Error(), test.want) {

--- a/internal/cli/runner_resolution.go
+++ b/internal/cli/runner_resolution.go
@@ -100,7 +100,7 @@ func runnerSelectorIsConfigured(labels []string, configuredTargets map[string]co
 	var target compiler.RunnerTarget
 	for i, label := range labels {
 		configured, ok := configuredTargets[strings.ToLower(strings.TrimSpace(label))]
-		if !ok || (i != 0 && configured != target) {
+		if !ok || (i != 0 && !compiler.RunnerTargetsEqual(configured, target)) {
 			return false
 		}
 		target = configured

--- a/internal/cli/runner_resolution_test.go
+++ b/internal/cli/runner_resolution_test.go
@@ -8,14 +8,17 @@ import (
 
 func TestRunnerSelectorIsConfigured(t *testing.T) {
 	linux := compiler.RunnerTarget{Queue: "linux", Platform: compiler.PlatformLinuxAMD64}
+	cachedLinux := compiler.RunnerTarget{Queue: "linux", Platform: compiler.PlatformLinuxAMD64, Cache: &compiler.CacheVolume{Paths: []string{"/home/runner/.cache"}, Name: "dependencies", Size: "40g"}}
+	equivalentCachedLinux := compiler.RunnerTarget{Queue: "linux", Platform: compiler.PlatformLinuxAMD64, Cache: &compiler.CacheVolume{Paths: []string{"/home/runner/.cache"}, Name: "dependencies", Size: "40g"}}
 	other := compiler.RunnerTarget{Queue: "other", Platform: compiler.PlatformLinuxAMD64}
-	targets := map[string]compiler.RunnerTarget{"ubuntu-18.04": linux, "self-hosted": linux, "other": other}
+	targets := map[string]compiler.RunnerTarget{"ubuntu-18.04": linux, "self-hosted": linux, "cached": cachedLinux, "equivalent-cached": equivalentCachedLinux, "other": other}
 	for _, test := range []struct {
 		labels []string
 		want   bool
 	}{
 		{labels: []string{"Ubuntu-18.04"}, want: true},
 		{labels: []string{"self-hosted", "ubuntu-18.04"}, want: true},
+		{labels: []string{"cached", "equivalent-cached"}, want: true},
 		{labels: []string{"self-hosted", "missing"}},
 		{labels: []string{"self-hosted", "other"}},
 		{labels: nil},

--- a/internal/compiler/bundle.go
+++ b/internal/compiler/bundle.go
@@ -206,6 +206,7 @@ func GenerateBundlePipeline(bundle Bundle, compilerDistributionDigest, compilerS
 			PlanDigest:         artifact.Digest,
 			Dependencies:       append([]string(nil), ir.Jobs[i].Needs...),
 			RequiresMise:       job.NeedsMise(),
+			Cache:              ir.Jobs[i].Cache,
 			SoftFail:           job.ContinueOnError,
 		}
 		if ir.Jobs[i].Platform == PlatformLinuxAMD64 {

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -90,6 +90,19 @@ jobs:
 	}
 }
 
+func TestCompileBundleRejectsRunnerCacheForJobContainer(t *testing.T) {
+	options := defaultOptions()
+	options.Runners.Labels = nil
+	options.Runners.Targets = map[string]RunnerTarget{
+		"ubuntu-latest": {Platform: PlatformLinuxAMD64, Cache: &CacheVolume{Paths: []string{"/home/runner/.cache"}}},
+	}
+	source := []byte("on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    container: node:24\n    steps: [{run: true}]\n")
+	_, err := CompileBundleWithOptions("containers.yml", source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-importer", options)
+	if err == nil || !strings.Contains(err.Error(), "runner cache volumes are unsupported for jobs with a container") {
+		t.Fatalf("CompileBundleWithOptions() error = %v, want runner cache container rejection", err)
+	}
+}
+
 func TestCompileBundleDoesNotActivateValidatedRuntimeMatrixWithoutFencing(t *testing.T) {
 	source := []byte(`on: push
 jobs:

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -73,6 +73,7 @@ type JobInstance struct {
 	Queue                   string                   `json:"queue"`
 	Platform                Platform                 `json:"-"`
 	RuntimeImage            string                   `json:"runtime_image,omitempty"`
+	Cache                   *CacheVolume             `json:"-"`
 	Matrix                  map[string]any           `json:"matrix,omitempty"`
 	Inputs                  map[string]any           `json:"inputs,omitempty"`
 	DeferredInputs          map[string]DeferredInput `json:"deferred_inputs,omitempty"`

--- a/internal/compiler/config.go
+++ b/internal/compiler/config.go
@@ -4,9 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 
+	buildkitepipeline "github.com/buildkite/buildkite-gha/internal/buildkite"
 	"github.com/buildkite/buildkite-gha/internal/plan"
 )
 
@@ -80,12 +82,16 @@ type VariableSources struct {
 	Buildkite map[string]string
 }
 
+// CacheVolume is one Buildkite Hosted cache volume attached to a runner target.
+type CacheVolume = buildkitepipeline.CacheVolume
+
 // RunnerTarget atomically selects one Buildkite queue, execution platform, and
-// optional immutable runtime image.
+// optional immutable runtime image and cache volume.
 type RunnerTarget struct {
 	Queue    string
 	Platform Platform
 	Image    string
+	Cache    *CacheVolume
 }
 
 // RunnerSelector maps one complete runs-on selector to a target without
@@ -194,7 +200,7 @@ func (options Options) validate() error {
 		if err := validateRunnerTarget(make(map[string]RunnerTarget), strings.Join(selector.Labels, ", "), selector.Target); err != nil {
 			return err
 		}
-		if existing, ok := selectors[key]; ok && existing != selector.Target {
+		if existing, ok := selectors[key]; ok && !runnerTargetsEqual(existing, selector.Target) {
 			return fmt.Errorf("runner selector has conflicting target mappings")
 		}
 		selectors[key] = selector.Target
@@ -255,12 +261,24 @@ func validateRunnerTarget(labels map[string]RunnerTarget, label string, target R
 	if target.Platform == PlatformDarwinARM64 && target.Image != "" {
 		return fmt.Errorf("runner label %q cannot select a runtime image on darwin/arm64", label)
 	}
+	if target.Cache != nil {
+		if err := buildkitepipeline.ValidateCacheVolume(*target.Cache); err != nil {
+			return fmt.Errorf("runner label %q has invalid cache configuration: %w", label, err)
+		}
+	}
 	normalized := strings.ToLower(strings.TrimSpace(label))
-	if existing, ok := labels[normalized]; ok && existing != target {
+	if existing, ok := labels[normalized]; ok && !runnerTargetsEqual(existing, target) {
 		return fmt.Errorf("runner label %q has conflicting target mappings", label)
 	}
 	labels[normalized] = target
 	return nil
+}
+
+func runnerTargetsEqual(first, second RunnerTarget) bool {
+	if first.Queue != second.Queue || first.Platform != second.Platform || first.Image != second.Image {
+		return false
+	}
+	return cachesEqual(first.Cache, second.Cache)
 }
 
 func (sources VariableSources) snapshot() map[string]string {
@@ -363,8 +381,8 @@ func (policy RunnerPolicy) resolve(labels []string, trust EventTrust) (RunnerTar
 		if !ok {
 			return RunnerTarget{}, rejectRunner(reasonUnmappedLabel, "runner label %q is not mapped by policy", label)
 		}
-		if resolved && target != mapped {
-			if target.Platform == mapped.Platform && target.Image == mapped.Image {
+		if resolved && !runnerTargetsEqual(target, mapped) {
+			if target.Queue != mapped.Queue && target.Platform == mapped.Platform && target.Image == mapped.Image && cachesEqual(target.Cache, mapped.Cache) {
 				return RunnerTarget{}, rejectRunner(reasonConflictingQueues, "runner labels resolve to conflicting queues %q and %q", target.Queue, mapped.Queue)
 			}
 			return RunnerTarget{}, rejectRunner(reasonConflictingTarget, "runner labels resolve to conflicting targets %q and %q", targetDescription(target), targetDescription(mapped))
@@ -474,7 +492,17 @@ func targetDescription(target RunnerTarget) string {
 	if target.Image != "" {
 		description += "#" + target.Image
 	}
+	if target.Cache != nil {
+		description += "#cache=" + target.Cache.Name + ":" + target.Cache.Size + ":" + strings.Join(target.Cache.Paths, ",")
+	}
 	return description
+}
+
+func cachesEqual(first, second *CacheVolume) bool {
+	if first == nil || second == nil {
+		return first == nil && second == nil
+	}
+	return first.Name == second.Name && first.Size == second.Size && slices.Equal(first.Paths, second.Paths)
 }
 
 func contains(values []string, wanted string) bool {

--- a/internal/compiler/config.go
+++ b/internal/compiler/config.go
@@ -200,7 +200,7 @@ func (options Options) validate() error {
 		if err := validateRunnerTarget(make(map[string]RunnerTarget), strings.Join(selector.Labels, ", "), selector.Target); err != nil {
 			return err
 		}
-		if existing, ok := selectors[key]; ok && !runnerTargetsEqual(existing, selector.Target) {
+		if existing, ok := selectors[key]; ok && !RunnerTargetsEqual(existing, selector.Target) {
 			return fmt.Errorf("runner selector has conflicting target mappings")
 		}
 		selectors[key] = selector.Target
@@ -267,14 +267,15 @@ func validateRunnerTarget(labels map[string]RunnerTarget, label string, target R
 		}
 	}
 	normalized := strings.ToLower(strings.TrimSpace(label))
-	if existing, ok := labels[normalized]; ok && !runnerTargetsEqual(existing, target) {
+	if existing, ok := labels[normalized]; ok && !RunnerTargetsEqual(existing, target) {
 		return fmt.Errorf("runner label %q has conflicting target mappings", label)
 	}
 	labels[normalized] = target
 	return nil
 }
 
-func runnerTargetsEqual(first, second RunnerTarget) bool {
+// RunnerTargetsEqual reports whether two complete runner mappings are equivalent.
+func RunnerTargetsEqual(first, second RunnerTarget) bool {
 	if first.Queue != second.Queue || first.Platform != second.Platform || first.Image != second.Image {
 		return false
 	}
@@ -381,7 +382,7 @@ func (policy RunnerPolicy) resolve(labels []string, trust EventTrust) (RunnerTar
 		if !ok {
 			return RunnerTarget{}, rejectRunner(reasonUnmappedLabel, "runner label %q is not mapped by policy", label)
 		}
-		if resolved && !runnerTargetsEqual(target, mapped) {
+		if resolved && !RunnerTargetsEqual(target, mapped) {
 			if target.Queue != mapped.Queue && target.Platform == mapped.Platform && target.Image == mapped.Image && cachesEqual(target.Cache, mapped.Cache) {
 				return RunnerTarget{}, rejectRunner(reasonConflictingQueues, "runner labels resolve to conflicting queues %q and %q", target.Queue, mapped.Queue)
 			}

--- a/internal/compiler/job_graph_expansion.go
+++ b/internal/compiler/job_graph_expansion.go
@@ -288,6 +288,9 @@ func (e *jobGraphExpansion) expandJobInstances(id string) {
 					Err: locatedJobError(jobPath, job, runsOnPosition(job).Line, runsOnPosition(job).Column, err.Error()),
 				})
 				valid = false
+			} else if target.Cache != nil && instanceJob.Container != nil {
+				e.diagnostics = append(e.diagnostics, attributedProcessingFinding(StageExpressions, CodeExpressionInvalid, "compatibility", jobPath, job.Span.Start.Line, job.Span.Start.Column, job.ID, key, "", 0, jobError(jobPath, job, "runner cache volumes are unsupported for jobs with a container")))
+				valid = false
 			}
 		}
 		concurrencyGroup, concurrencyErr := resolveConcurrency(jobPath, job.ID, job.Concurrency, jobContext, matrix)

--- a/internal/compiler/job_graph_expansion.go
+++ b/internal/compiler/job_graph_expansion.go
@@ -310,6 +310,7 @@ func (e *jobGraphExpansion) expandJobInstances(id string) {
 		instance.Queue = target.Queue
 		instance.Platform = target.Platform
 		instance.RuntimeImage = target.Image
+		instance.Cache = target.Cache
 		instance.ConcurrencyGroup = concurrencyGroup
 		if e.bindInstanceDependencies(sourced, job, key, &instance) {
 			jobFailed = true


### PR DESCRIPTION
## Why

Imported jobs cannot currently persist runner-local dependency directories such as `/home/runner/.gradle/caches` without changing the public GitHub workflow. Generated JavaScript-action jobs may already use the one cache volume Buildkite allows for the managed mise runtime.

## What

Runner mappings can now add absolute paths plus an optional cache name and size:

```yaml
runners:
  - runs-on: ubuntu-latest
    queue: hosted
    cache:
      paths:
        - /home/runner/.gradle/caches
        - /home/runner/.gradle/wrapper
      name: gradle-dependencies
      size: 40g
```

Generated jobs merge these paths with any managed mise cache path into one Buildkite cache volume. Jobs without either cache retain their existing pipeline shape. Linux bootstrap verifies configured paths resolve inside `/cache/bkcache` before making them writable by the generated `runner` user. Cache mappings are rejected for workflow job containers, where the host volume is not mounted.