### PR TITLE
Make workflow warnings explain outcomes and fixes

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -483,7 +483,7 @@ Nested called workflows keep nested gates. Jobs within one called workflow remai
 
 Buildkite queues every waiting entry. It does not replace GitHub's existing pending entry. The `queue` key is unsupported.
 
-Workflow-level literal or expression-resolved `cancel-in-progress: true`, including in called workflows, emits a warning and does not cancel. Job-level cancellation remains unsupported. Buildkite's uploaded step contract has no concurrency-group cancellation field; `concurrency_method` controls admission order only. Buildkite **Cancel Intermediate Builds** and **Skip Intermediate Builds** settings can approximate same-branch cancellation.
+Workflow-level literal or expression-resolved `cancel-in-progress: true`, including in called workflows, emits a warning and does not cancel, so superseded builds keep running. Job-level cancellation remains unsupported. To cancel earlier running builds on the same branch, turn on [Cancel Intermediate Builds](https://buildkite.com/docs/pipelines/configure/canceling-builds#cancel-running-intermediate-builds) under pipeline **Settings > Builds**. This setting applies by branch, not by concurrency group.
 
 Cancel the whole Buildkite build rather than one job when a workflow-level concurrency gate is active.
 
@@ -1057,7 +1057,7 @@ Pre conditions use the status and action-scoped environment available when prepa
 | v7.0.0 corpus pin | [`9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0`](https://github.com/actions/checkout/tree/9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0) |
 | v7.0.1 | [`3d3c42e5aac5ba805825da76410c181273ba90b1`](https://github.com/actions/checkout/tree/3d3c42e5aac5ba805825da76410c181273ba90b1) |
 
-Mutable refs work only while they resolve to the upstream `main` snapshot or a known release above. Every admitted commit uses the native adapter; the upstream JavaScript doesn't run. Each admitted release accepts only the inputs it declares, so earlier releases reject later inputs. Other pre-v3.7.0 commits and unknown commits are unsupported. Compilation emits `W_CHECKOUT_LEGACY_RELEASE` for v1.2.0 and v2.8.0 to nudge an upgrade to v4 or later. Maintainers can update the v4-and-later snapshot with `go generate ./internal/action/integration`; this doesn't widen release admission.
+Mutable refs work only while they resolve to the upstream `main` snapshot or a known release above. Every admitted commit uses the native adapter; the upstream JavaScript doesn't run. Each admitted release accepts only the inputs it declares, so earlier releases reject later inputs. Other pre-v3.7.0 commits and unknown commits are unsupported. Compilation warns that v1.2.0 and v2.8.0 do not set the `ref` and `commit` outputs added in v4.2.0. It also warns that v1.2.0 defaults to full history when `fetch-depth` is omitted. Upgrade only if these differences matter. Maintainers can update the v4-and-later snapshot with `go generate ./internal/action/integration`; this doesn't widen release admission.
 
 The adapter checks out a detached commit or static branch from the event repository at the workspace root or a clean top-level directory. It uses Buildkite repository-provider Git credentials when the job provides them; otherwise, it fetches anonymously. Credentials are scoped to each fetch command and verified submodule fetch command and are never persisted.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -483,7 +483,9 @@ Nested called workflows keep nested gates. Jobs within one called workflow remai
 
 Buildkite queues every waiting entry. It does not replace GitHub's existing pending entry. The `queue` key is unsupported.
 
-Workflow-level literal or expression-resolved `cancel-in-progress: true`, including in called workflows, emits a warning and does not cancel, so superseded builds keep running. Job-level cancellation remains unsupported. To cancel earlier running builds on the same branch, turn on [Cancel Intermediate Builds](https://buildkite.com/docs/pipelines/configure/canceling-builds#cancel-running-intermediate-builds) under pipeline **Settings > Builds**. This setting applies by branch, not by concurrency group.
+When workflow-level `cancel-in-progress` is `true`, Buildkite warns and leaves superseded builds running. The same behavior applies when an expression resolves to `true` and when a called workflow sets it. Job-level `cancel-in-progress` is unsupported.
+
+To cancel earlier running builds on the same branch, turn on [Cancel Intermediate Builds](https://buildkite.com/docs/pipelines/configure/canceling-builds#cancel-running-intermediate-builds) under pipeline **Settings > Builds**. This setting works by branch, not by concurrency group.
 
 Cancel the whole Buildkite build rather than one job when a workflow-level concurrency gate is active.
 
@@ -1057,7 +1059,11 @@ Pre conditions use the status and action-scoped environment available when prepa
 | v7.0.0 corpus pin | [`9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0`](https://github.com/actions/checkout/tree/9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0) |
 | v7.0.1 | [`3d3c42e5aac5ba805825da76410c181273ba90b1`](https://github.com/actions/checkout/tree/3d3c42e5aac5ba805825da76410c181273ba90b1) |
 
-Mutable refs work only while they resolve to the upstream `main` snapshot or a known release above. Every admitted commit uses the native adapter; the upstream JavaScript doesn't run. Each admitted release accepts only the inputs it declares, so earlier releases reject later inputs. Other pre-v3.7.0 commits and unknown commits are unsupported. Compilation warns that v1.2.0 and v2.8.0 do not set the `ref` and `commit` outputs added in v4.2.0. It also warns that v1.2.0 defaults to full history when `fetch-depth` is omitted. Upgrade only if these differences matter. Maintainers can update the v4-and-later snapshot with `go generate ./internal/action/integration`; this doesn't widen release admission.
+References such as `main` and `master` work only when they resolve to a supported release or commit from upstream `main`. Buildkite checks out the repository without running the action's JavaScript. Each release accepts only the inputs available in that release. Earlier releases reject later inputs. Other commits before v3.7.0 and unknown commits are unsupported.
+
+Buildkite runs v1.2.0 like v1 and v2.8.0 like v2, and warns about their differences from v4 and later. Neither release sets the `ref` or `commit` outputs added in v4.2.0. v1.2.0 also fetches full history by default when `fetch-depth` is omitted. Upgrade only if your workflow needs those outputs or different v1 history behavior. Otherwise, keep the current version.
+
+Maintainers can update supported v4-and-later commits with `go generate ./internal/action/integration`. This does not add support for more numbered releases.
 
 The adapter checks out a detached commit or static branch from the event repository at the workspace root or a clean top-level directory. It uses Buildkite repository-provider Git credentials when the job provides them; otherwise, it fetches anonymously. Credentials are scoped to each fetch command and verified submodule fetch command and are never persisted.
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -408,15 +408,22 @@ func TestRunValidateAndCompile(t *testing.T) {
 		if report.Result != "admitted" {
 			t.Fatalf("mixed trigger report = %#v", report)
 		}
-		warned := false
+		messages := map[string]string{}
 		for _, diagnostic := range report.Diagnostics {
 			if diagnostic.Level == "error" {
 				t.Fatalf("unexpected error diagnostic %#v", diagnostic)
 			}
-			warned = warned || diagnostic.Code == "W_TRIGGER_EVENT_UNSUPPORTED"
+			if diagnostic.Code == "W_TRIGGER_EVENT_UNSUPPORTED" {
+				message := annotationDiagnosticMessage(diagnostic)
+				event := strings.TrimPrefix(strings.Fields(message)[0], "on.")
+				messages[event] = message
+			}
 		}
-		if !warned {
-			t.Fatalf("mixed trigger report missing unsupported-trigger warning: %#v", report)
+		for _, event := range []string{"issues", "pull_request_target"} {
+			want := "on." + event + " is ignored, so nothing in this workflow runs from it. The supported triggers declared in this workflow still run: push. Move the jobs this trigger guards to one of those triggers if you need them. If you need " + event + ", log an issue on https://github.com/buildkite/buildkite-gha so we can prioritise it."
+			if messages[event] != want {
+				t.Fatalf("unsupported-trigger message for %s = %q, want %q; report = %#v", event, messages[event], want, report)
+			}
 		}
 	})
 
@@ -1351,14 +1358,14 @@ jobs:
 		t.Fatal(err)
 	}
 	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
+	wantMessage := "cancel-in-progress is ignored, so superseded builds keep running. Buildkite handles this as a pipeline setting rather than in the workflow file. Turn on Cancel Intermediate Builds under Settings > Builds. It cancels earlier running builds on the same branch, rather than per concurrency group."
 	assertWarning := func(t *testing.T, command, output string) {
 		t.Helper()
 		for _, want := range []string{
 			"buildkite-gha: " + command + ": warning:",
 			workflowPath + ":4:23:",
 			"[W_WORKFLOW_CONCURRENCY_CANCEL_IN_PROGRESS_IGNORED]",
-			"cancel-in-progress is not enforced",
-			"Buildkite pipeline settings",
+			wantMessage,
 		} {
 			if !strings.Contains(output, want) {
 				t.Fatalf("stderr = %q, want %q", output, want)
@@ -1377,7 +1384,7 @@ jobs:
 		for _, want := range []string{
 			"! [W_WORKFLOW_CONCURRENCY_CANCEL_IN_PROGRESS_IGNORED]",
 			workflowPath + ":4:23:",
-			"cancel-in-progress is not enforced",
+			wantMessage,
 		} {
 			if !strings.Contains(stdout.String(), want) {
 				t.Fatalf("stdout = %q, want %q", stdout.String(), want)
@@ -1397,7 +1404,7 @@ jobs:
 		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 			t.Fatal(err)
 		}
-		if len(report.Diagnostics) != 1 || report.Diagnostics[0].Level != "warning" || report.Diagnostics[0].Code != "W_WORKFLOW_CONCURRENCY_CANCEL_IN_PROGRESS_IGNORED" || !strings.Contains(report.Diagnostics[0].Message, workflowPath+":4:23:") {
+		if len(report.Diagnostics) != 1 || report.Diagnostics[0].Level != "warning" || report.Diagnostics[0].Code != "W_WORKFLOW_CONCURRENCY_CANCEL_IN_PROGRESS_IGNORED" || report.Diagnostics[0].Message != workflowPath+":4:23: "+wantMessage {
 			t.Fatalf("report diagnostics = %#v", report.Diagnostics)
 		}
 	})
@@ -1414,7 +1421,7 @@ jobs:
 		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 			t.Fatal(err)
 		}
-		if len(report.Diagnostics) != 1 || report.Diagnostics[0].Level != "warning" || report.Diagnostics[0].Code != "W_WORKFLOW_CONCURRENCY_CANCEL_IN_PROGRESS_IGNORED" || !strings.Contains(report.Diagnostics[0].Message, workflowPath+":4:23:") {
+		if len(report.Diagnostics) != 1 || report.Diagnostics[0].Level != "warning" || report.Diagnostics[0].Code != "W_WORKFLOW_CONCURRENCY_CANCEL_IN_PROGRESS_IGNORED" || report.Diagnostics[0].Message != workflowPath+":4:23: "+wantMessage {
 			t.Fatalf("profile report diagnostics = %#v", report.Diagnostics)
 		}
 	})
@@ -1856,6 +1863,27 @@ func TestProcessingAnnotationDoesNotRepeatDiagnosticLocation(t *testing.T) {
 	}
 	if !strings.Contains(body, "warning message") {
 		t.Fatalf("annotation = %q", body)
+	}
+}
+
+func TestProcessingAnnotationRendersJobPermissionWarningGuidance(t *testing.T) {
+	report := compatibility.NewProcessingReport(".github/workflows/ci.yml", "hosted")
+	report.ApplyWarnings(report.Workflow, []compiler.Warning{{
+		Code: "W_JOB_GITHUB_TOKEN_USES_WORKFLOW_PERMISSIONS", Path: report.Workflow, Line: 5, Column: 3, Job: "build",
+		Message: "Job-level permissions are ignored for GITHUB_TOKEN. The top-level workflow permissions apply instead. This job's token has contents: read. Move this job's permissions block to the workflow top level. If you need per-job permissions, log an issue on https://github.com/buildkite/buildkite-gha so we can prioritise it.",
+	}})
+	_, body := processingAnnotation(report, sourceLinkContext{})
+	want := `<h2 class="h4 mb2">GitHub Actions workflow diagnostics</h2>
+<p><code>.github/workflows/ci.yml</code></p>
+<p><strong>Job-level permissions are ignored for GITHUB_TOKEN.</strong></p>
+<p><code>.github/workflows/ci.yml:5:3</code> · Job <code>build</code></p>
+<p>The top-level workflow permissions apply instead.</p>
+<p>This job&#39;s token has contents: read.</p>
+<p>Move this job&#39;s permissions block to the workflow top level.</p>
+<p>If you need per-job permissions, log an issue on <a href="https://github.com/buildkite/buildkite-gha" target="_blank">buildkite/buildkite-gha</a> so we can prioritise it.</p>
+`
+	if body != want {
+		t.Fatalf("annotation = %q, want %q", body, want)
 	}
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1867,7 +1867,16 @@ func TestProcessingAnnotationDoesNotRepeatDiagnosticLocation(t *testing.T) {
 }
 
 func TestProcessingAnnotationRendersJobPermissionWarningGuidance(t *testing.T) {
-	report := compatibility.NewProcessingReport(".github/workflows/ci.yml", "hosted")
+	repository := t.TempDir()
+	workflowPath := filepath.Join(repository, ".github", "workflows", "ci.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(workflowPath, []byte("on: push\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BUILDKITE_BUILD_CHECKOUT_PATH", repository)
+	report := compatibility.NewProcessingReport(workflowPath, "hosted")
 	report.ApplyWarnings(report.Workflow, []compiler.Warning{{
 		Code: "W_JOB_GITHUB_TOKEN_USES_WORKFLOW_PERMISSIONS", Path: report.Workflow, Line: 5, Column: 3, Job: "build",
 		Message: "Job-level permissions are ignored for GITHUB_TOKEN. The top-level workflow permissions apply instead. This job's token has contents: read. Move this job's permissions block to the workflow top level. If you need per-job permissions, log an issue on https://github.com/buildkite/buildkite-gha so we can prioritise it.",

--- a/internal/cli/compile.go
+++ b/internal/cli/compile.go
@@ -90,7 +90,11 @@ func compile(args []string, stdout, stderr io.Writer, clientVersion string, agen
 
 func writeCompilerWarnings(stderr io.Writer, command, path string, warnings []compiler.Warning) {
 	for _, warning := range warnings {
-		_, _ = fmt.Fprintf(stderr, "buildkite-gha: %s: warning: %s:%d:%d: [%s] %s\n", command, path, warning.Line, warning.Column, warning.Code, warning.Message)
+		warningPath := warning.Path
+		if warningPath == "" {
+			warningPath = path
+		}
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: %s: warning: %s:%d:%d: [%s] %s\n", command, warningPath, warning.Line, warning.Column, warning.Code, warning.Message)
 	}
 }
 

--- a/internal/compatibility/processing_compiler.go
+++ b/internal/compatibility/processing_compiler.go
@@ -93,9 +93,14 @@ func InitialProcessingReport(path, profile string, eventEvaluated bool, report c
 // ApplyWarnings adds compiler warnings to the processing report.
 func (r *ProcessingReport) ApplyWarnings(path string, warnings []compiler.Warning) {
 	for _, warning := range warnings {
+		warningPath := warning.Path
+		if warningPath == "" {
+			warningPath = path
+		}
 		r.Diagnostics = append(r.Diagnostics, Diagnostic{
 			Level: "warning", Code: warning.Code, Category: "compatibility", Stage: stageExpressions,
-			Message: fmt.Sprintf("%s:%d:%d: %s", path, warning.Line, warning.Column, warning.Message), Location: sourceLocation(path, warning.Line, warning.Column),
+			Message:  fmt.Sprintf("%s:%d:%d: %s", warningPath, warning.Line, warning.Column, warning.Message),
+			Location: sourceLocation(warningPath, warning.Line, warning.Column), Job: warning.Job, Step: warning.Step,
 		})
 	}
 }

--- a/internal/compatibility/report_test.go
+++ b/internal/compatibility/report_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/buildkite/buildkite-gha/internal/compiler"
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
@@ -265,5 +266,22 @@ func TestProcessingReportAggregatesIdenticalMatrixDiagnostics(t *testing.T) {
 	report.Finalize()
 	if len(report.Diagnostics) != 1 || report.Diagnostics[0].Instance != "" || report.Diagnostics[0].Job != "test" {
 		t.Fatalf("aggregated diagnostics = %#v", report.Diagnostics)
+	}
+}
+
+func TestApplyWarningsPreservesCompilerAttribution(t *testing.T) {
+	report := NewProcessingReport(".github/workflows/caller.yml", "hosted")
+	report.ApplyWarnings(report.Workflow, []compiler.Warning{{
+		Code: "W_CHECKOUT_LEGACY_RELEASE", Path: ".github/workflows/reusable.yml", Line: 12, Column: 9,
+		Job: "call.build", Step: 2, Message: "actions/checkout v2.8.0 behaves like v2.",
+	}})
+	want := Diagnostic{
+		Level: "warning", Code: "W_CHECKOUT_LEGACY_RELEASE", Category: "compatibility", Stage: "expression-validation",
+		Message:  ".github/workflows/reusable.yml:12:9: actions/checkout v2.8.0 behaves like v2.",
+		Location: &SourceLocation{Path: ".github/workflows/reusable.yml", Line: 12, Column: 9},
+		Job:      "call.build", Step: 2,
+	}
+	if len(report.Diagnostics) != 1 || !sameDiagnostic(report.Diagnostics[0], want) {
+		t.Fatalf("diagnostics = %#v, want %#v", report.Diagnostics, []Diagnostic{want})
 	}
 }

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -1356,7 +1356,7 @@ func TestCompileBundleLegacyCheckoutWarning(t *testing.T) {
 	}
 	compile := func(steps string) Bundle {
 		t.Helper()
-		workflow := []byte("on: push\njobs:\n  checkout:\n    runs-on: ubuntu-latest\n    steps:\n" + steps)
+		workflow := []byte("on: push\njobs:\n  checkout:\n    runs-on: ubuntu-latest\n    strategy:\n      matrix:\n        target: [one, two]\n    steps:\n" + steps)
 		if err := os.WriteFile(workflowPath, workflow, 0o644); err != nil {
 			t.Fatal(err)
 		}
@@ -1380,9 +1380,11 @@ func TestCompileBundleLegacyCheckoutWarning(t *testing.T) {
 		"        with:\n          path: again\n" +
 		"      - uses: actions/checkout@" + actionintegration.CheckoutV2Commit + "\n" +
 		"        with:\n          path: legacy\n")
-	if len(bundle.IR.Warnings) != 2 ||
-		bundle.IR.Warnings[0].Code != "W_CHECKOUT_LEGACY_RELEASE" || !strings.Contains(bundle.IR.Warnings[0].Message, "v1.2.0") || bundle.IR.Warnings[0].Line == 0 ||
-		bundle.IR.Warnings[1].Code != "W_CHECKOUT_LEGACY_RELEASE" || !strings.Contains(bundle.IR.Warnings[1].Message, "v2.8.0") {
+	if len(bundle.Plans) != 2 || len(bundle.IR.Warnings) != 2 ||
+		bundle.IR.Warnings[0].Code != "W_CHECKOUT_LEGACY_RELEASE" || bundle.IR.Warnings[0].Path != "./.github/workflows/checkout.yml" || bundle.IR.Warnings[0].Job != "checkout" || bundle.IR.Warnings[0].Step != 1 || bundle.IR.Warnings[0].Line == 0 ||
+		bundle.IR.Warnings[0].Message != "actions/checkout v1.2.0 behaves like v1. It does not set the ref and commit outputs, which actions/checkout added in v4.2.0. It also defaults to full history when fetch-depth is omitted. Upgrade to actions/checkout v4 or later if either difference matters." ||
+		bundle.IR.Warnings[1].Code != "W_CHECKOUT_LEGACY_RELEASE" || bundle.IR.Warnings[1].Path != "./.github/workflows/checkout.yml" || bundle.IR.Warnings[1].Job != "checkout" || bundle.IR.Warnings[1].Step != 3 ||
+		bundle.IR.Warnings[1].Message != "actions/checkout v2.8.0 behaves like v2. It does not set the ref and commit outputs, which actions/checkout added in v4.2.0. Upgrade to actions/checkout v4 or later if a later step reads either output." {
 		t.Fatalf("legacy checkout warnings = %#v", bundle.IR.Warnings)
 	}
 

--- a/internal/compiler/bundle.go
+++ b/internal/compiler/bundle.go
@@ -117,7 +117,11 @@ func CompileBundlePlansContext(ctx context.Context, path string, source, eventSo
 					continue
 				}
 				warnedLegacyCheckout[release] = true
-				bundle.IR.Warnings = append(bundle.IR.Warnings, legacyCheckoutWarning(ir.Jobs[i].Steps[stepIndex].Span.Start, release))
+				warning := legacyCheckoutWarning(ir.Jobs[i].Steps[stepIndex].Span.Start, release, actionintegration.CheckoutDefaultsToFullHistory(lock.Commit))
+				warning.Path = ir.Jobs[i].SourcePath
+				warning.Job = ir.Jobs[i].LogicalJobID
+				warning.Step = stepIndex + 1
+				bundle.IR.Warnings = append(bundle.IR.Warnings, warning)
 			case actionintegration.AdapterUploadArtifactBuildkite:
 				release, legacy := actionintegration.LegacyUploadArtifactRelease(lock.Commit)
 				if !legacy || warnedLegacyUploadArtifact[release] {
@@ -140,10 +144,15 @@ func CompileBundlePlansContext(ctx context.Context, path string, source, eventSo
 		}
 		if (ir.Jobs[i].jobPermissionsIgnored || jobPermissionsIgnored(job.GitHubToken.Permissions, ir.Jobs[i].Permissions)) && !warnedJobPermissions {
 			position := ir.Jobs[i].Source.Start
+			path := ir.Jobs[i].SourcePath
 			if ir.Jobs[i].jobPermissionsIgnored && ir.Jobs[i].reusableCall.Line != 0 {
 				position = ir.Jobs[i].reusableCall
+				path = ir.Workflow.Path
 			}
-			bundle.IR.Warnings = append(bundle.IR.Warnings, jobWorkflowTokenWarning(position))
+			warning := jobWorkflowTokenWarning(position, job.GitHubToken.Permissions)
+			warning.Path = path
+			warning.Job = ir.Jobs[i].LogicalJobID
+			bundle.IR.Warnings = append(bundle.IR.Warnings, warning)
 			warnedJobPermissions = true
 		}
 	}

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -725,7 +725,10 @@ jobs:
 	if bundle.IR.Workflow.ConcurrencyGroup != "Deployment-refs/heads/main" || len(bundle.IR.Jobs) != 4 {
 		t.Fatalf("concurrency IR = workflow %q jobs %#v", bundle.IR.Workflow.ConcurrencyGroup, bundle.IR.Jobs)
 	}
-	if len(bundle.IR.Warnings) != 1 || bundle.IR.Warnings[0].Code != "W_WORKFLOW_CONCURRENCY_CANCEL_IN_PROGRESS_IGNORED" || bundle.IR.Warnings[0].Line != 5 || bundle.IR.Warnings[0].Column != 23 {
+	if len(bundle.IR.Warnings) != 1 || bundle.IR.Warnings[0] != (Warning{
+		Code: "W_WORKFLOW_CONCURRENCY_CANCEL_IN_PROGRESS_IGNORED", Line: 5, Column: 23,
+		Message: "cancel-in-progress is ignored, so superseded builds keep running. Buildkite handles this as a pipeline setting rather than in the workflow file. Turn on Cancel Intermediate Builds under Settings > Builds. It cancels earlier running builds on the same branch, rather than per concurrency group.",
+	}) {
 		t.Fatalf("concurrency warnings = %#v", bundle.IR.Warnings)
 	}
 	repository := bundle.IR.Event.Repository
@@ -1067,7 +1070,10 @@ jobs:
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(bundle.IR.Warnings) != 1 || bundle.IR.Warnings[0].Code != "W_WORKFLOW_CONCURRENCY_CANCEL_IN_PROGRESS_IGNORED" || !strings.Contains(bundle.IR.Warnings[0].Message, "no concurrency-group cancellation contract") {
+	if len(bundle.IR.Warnings) != 1 || bundle.IR.Warnings[0] != (Warning{
+		Code: "W_WORKFLOW_CONCURRENCY_CANCEL_IN_PROGRESS_IGNORED", Line: 4, Column: 11, Job: "call",
+		Message: "cancel-in-progress is ignored, so superseded builds keep running. Buildkite handles this as a pipeline setting rather than in the workflow file. Turn on Cancel Intermediate Builds under Settings > Builds. It cancels earlier running builds on the same branch, rather than per concurrency group.",
+	}) {
 		t.Fatalf("called workflow warnings = %#v", bundle.IR.Warnings)
 	}
 }
@@ -1491,9 +1497,13 @@ func TestCompileBundleGitHubTokenIgnoresJobPermissions(t *testing.T) {
 			source := []byte(`on: push
 permissions:
   contents: write
+  issues: read
 jobs:
   token:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [1, 2]
 ` + test.jobPermissions + `    env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps: [{run: true}]
@@ -1503,13 +1513,15 @@ jobs:
 				t.Fatal(err)
 			}
 			job := bundle.Plans[0].Job
-			if job.GitHubToken == nil || !reflect.DeepEqual(job.GitHubToken.Permissions, map[string]string{"contents": "write"}) {
+			if len(bundle.Plans) != 2 || job.GitHubToken == nil || !reflect.DeepEqual(job.GitHubToken.Permissions, map[string]string{"contents": "write", "issues": "read"}) {
 				t.Fatalf("GITHUB_TOKEN = %#v, want workflow permissions", job.GitHubToken)
 			}
 			if job.IDTokenPermission != test.idToken {
 				t.Fatalf("ID token permission = %q, want %q", job.IDTokenPermission, test.idToken)
 			}
-			if len(bundle.IR.Warnings) != 1 || bundle.IR.Warnings[0].Code != "W_JOB_GITHUB_TOKEN_USES_WORKFLOW_PERMISSIONS" {
+			if len(bundle.IR.Warnings) != 1 || bundle.IR.Warnings[0].Code != "W_JOB_GITHUB_TOKEN_USES_WORKFLOW_PERMISSIONS" ||
+				bundle.IR.Warnings[0].Path != "./.github/workflows/workflow.yml" || bundle.IR.Warnings[0].Job != "token" ||
+				bundle.IR.Warnings[0].Message != "Job-level permissions are ignored for GITHUB_TOKEN. The top-level workflow permissions apply instead. This job's token has contents: write, issues: read. Move this job's permissions block to the workflow top level. If you need per-job permissions, log an issue on https://github.com/buildkite/buildkite-gha so we can prioritise it." {
 				t.Fatalf("warnings = %#v, want ignored job permissions warning", bundle.IR.Warnings)
 			}
 		})

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -44,8 +44,11 @@ type WorkflowConcurrencyGate struct {
 // Warning is one source-located, non-fatal compatibility diagnostic.
 type Warning struct {
 	Code    string `json:"code"`
+	Path    string `json:"path,omitempty"`
 	Line    int    `json:"line"`
 	Column  int    `json:"column"`
+	Job     string `json:"job,omitempty"`
+	Step    int    `json:"step,omitempty"`
 	Message string `json:"message"`
 }
 
@@ -410,35 +413,67 @@ func workflowTokenPolicyEvidence(path string, parsed *workflow.Workflow) (string
 
 func compilerWarnings(parsed *workflow.Workflow, cancelInProgress bool) []Warning {
 	var warnings []Warning
+	supported := make(map[string]bool, len(parsed.Triggers))
+	for _, trigger := range parsed.Triggers {
+		if buildkitepipeline.SupportedTriggerEvent(trigger.Event) {
+			supported[trigger.Event] = true
+		}
+	}
+	supportedNames := make([]string, 0, len(supported))
+	for event := range supported {
+		supportedNames = append(supportedNames, event)
+	}
+	sort.Strings(supportedNames)
 	for _, trigger := range parsed.Triggers {
 		if buildkitepipeline.SupportedTriggerEvent(trigger.Event) {
 			continue
 		}
+		message := fmt.Sprintf("on.%s is ignored, so nothing in this workflow runs from it.", trigger.Event)
+		if len(supportedNames) == 0 {
+			message += " This workflow declares no supported triggers that still run."
+		} else {
+			message += " The supported triggers declared in this workflow still run: " + strings.Join(supportedNames, ", ") + "."
+			message += " Move the jobs this trigger guards to one of those triggers if you need them."
+		}
+		message += fmt.Sprintf(" If you need %s, log an issue on https://github.com/buildkite/buildkite-gha so we can prioritise it.", trigger.Event)
 		warnings = append(warnings, Warning{
 			Code:    "W_TRIGGER_EVENT_UNSUPPORTED",
 			Line:    trigger.Position.Line,
 			Column:  trigger.Position.Column,
-			Message: fmt.Sprintf("on.%s has no Buildkite build source; this trigger is ignored and never starts a build", trigger.Event),
+			Message: message,
 		})
 	}
 	if parsed.Concurrency != nil && cancelInProgress {
-		position := parsed.Concurrency.CancelInProgressPosition
-		warnings = append(warnings, Warning{
-			Code:    "W_WORKFLOW_CONCURRENCY_CANCEL_IN_PROGRESS_IGNORED",
-			Line:    position.Line,
-			Column:  position.Column,
-			Message: "workflow concurrency cancel-in-progress is not enforced; Buildkite pipeline settings can approximate it for same-branch builds",
-		})
+		warnings = append(warnings, workflowCancellationWarning(parsed.Concurrency.CancelInProgressPosition))
 	}
 	return warnings
 }
 
-func legacyCheckoutWarning(position workflow.Position, release string) Warning {
+func workflowCancellationWarning(position workflow.Position) Warning {
+	return Warning{
+		Code:    "W_WORKFLOW_CONCURRENCY_CANCEL_IN_PROGRESS_IGNORED",
+		Line:    position.Line,
+		Column:  position.Column,
+		Message: "cancel-in-progress is ignored, so superseded builds keep running. Buildkite handles this as a pipeline setting rather than in the workflow file. Turn on Cancel Intermediate Builds under Settings > Builds. It cancels earlier running builds on the same branch, rather than per concurrency group.",
+	}
+}
+
+func legacyCheckoutWarning(position workflow.Position, release string, defaultsToFullHistory bool) Warning {
+	generation := "v2"
+	if defaultsToFullHistory {
+		generation = "v1"
+	}
+	message := fmt.Sprintf("actions/checkout %s behaves like %s. It does not set the ref and commit outputs, which actions/checkout added in v4.2.0.", release, generation)
+	if defaultsToFullHistory {
+		message += " It also defaults to full history when fetch-depth is omitted. Upgrade to actions/checkout v4 or later if either difference matters."
+	} else {
+		message += " Upgrade to actions/checkout v4 or later if a later step reads either output."
+	}
 	return Warning{
 		Code:    "W_CHECKOUT_LEGACY_RELEASE",
 		Line:    position.Line,
 		Column:  position.Column,
-		Message: fmt.Sprintf("actions/checkout %s is emulated by the native adapter with its release contract; upgrade to v4 or later", release),
+		Message: message,
 	}
 }
 
@@ -460,12 +495,21 @@ func reusableWorkflowTokenWarning(position workflow.Position) Warning {
 	}
 }
 
-func jobWorkflowTokenWarning(position workflow.Position) Warning {
+func jobWorkflowTokenWarning(position workflow.Position, permissions map[string]string) Warning {
+	names := make([]string, 0, len(permissions))
+	for name := range permissions {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	effective := make([]string, 0, len(names))
+	for _, name := range names {
+		effective = append(effective, strings.ReplaceAll(name, "_", "-")+": "+permissions[name])
+	}
 	return Warning{
 		Code:    "W_JOB_GITHUB_TOKEN_USES_WORKFLOW_PERMISSIONS",
 		Line:    position.Line,
 		Column:  position.Column,
-		Message: "job-level repository permissions are ignored for hosted GITHUB_TOKEN; the top-level requesting workflow permissions apply",
+		Message: "Job-level permissions are ignored for GITHUB_TOKEN. The top-level workflow permissions apply instead. This job's token has " + strings.Join(effective, ", ") + ". Move this job's permissions block to the workflow top level. If you need per-job permissions, log an issue on https://github.com/buildkite/buildkite-gha so we can prioritise it.",
 	}
 }
 

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -4528,3 +4528,35 @@ jobs:
 		t.Fatalf("error = %v", err)
 	}
 }
+
+func TestCompilerWarningsNameOnlyDeclaredSupportedTriggers(t *testing.T) {
+	parsed := &workflow.Workflow{Triggers: []workflow.Trigger{
+		{Event: "workflow_dispatch"},
+		{Event: "issues", Position: workflow.Position{Line: 4, Column: 3}},
+		{Event: "release"},
+		{Event: "push"},
+		{Event: "merge_group"},
+		{Event: "schedule"},
+		{Event: "pull_request"},
+		{Event: "workflow_call"},
+		{Event: "push"},
+	}}
+	warnings := compilerWarnings(parsed, false)
+	want := Warning{
+		Code: "W_TRIGGER_EVENT_UNSUPPORTED", Line: 4, Column: 3,
+		Message: "on.issues is ignored, so nothing in this workflow runs from it. The supported triggers declared in this workflow still run: merge_group, pull_request, push, release, schedule, workflow_call, workflow_dispatch. Move the jobs this trigger guards to one of those triggers if you need them. If you need issues, log an issue on https://github.com/buildkite/buildkite-gha so we can prioritise it.",
+	}
+	if !reflect.DeepEqual(warnings, []Warning{want}) {
+		t.Fatalf("warnings = %#v, want %#v", warnings, []Warning{want})
+	}
+
+	parsed.Triggers = []workflow.Trigger{{Event: "issues", Position: workflow.Position{Line: 1, Column: 5}}}
+	warnings = compilerWarnings(parsed, false)
+	want = Warning{
+		Code: "W_TRIGGER_EVENT_UNSUPPORTED", Line: 1, Column: 5,
+		Message: "on.issues is ignored, so nothing in this workflow runs from it. This workflow declares no supported triggers that still run. If you need issues, log an issue on https://github.com/buildkite/buildkite-gha so we can prioritise it.",
+	}
+	if !reflect.DeepEqual(warnings, []Warning{want}) {
+		t.Fatalf("warnings without supported triggers = %#v, want %#v", warnings, []Warning{want})
+	}
+}

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -404,10 +404,9 @@ func (resolver *reusableResolver) resolve(ctx context.Context, current reusableW
 				calleeConcurrencyGates = append(append([]WorkflowConcurrencyGate(nil), concurrencyGates...), WorkflowConcurrencyGate{ID: callNamespace, Group: group})
 				if cancelInProgress && !resolver.warnedCancellation[calleeCallPosition] {
 					resolver.warnedCancellation[calleeCallPosition] = true
-					resolver.warnings = append(resolver.warnings, Warning{
-						Code: "W_WORKFLOW_CONCURRENCY_CANCEL_IN_PROGRESS_IGNORED", Line: calleeCallPosition.Line, Column: calleeCallPosition.Column,
-						Message: fmt.Sprintf("called workflow %q concurrency cancel-in-progress is not enforced; Buildkite has no concurrency-group cancellation contract", call.Uses),
-					})
+					warning := workflowCancellationWarning(calleeCallPosition)
+					warning.Job = job.ID
+					resolver.warnings = append(resolver.warnings, warning)
 				}
 			}
 			resolver.stack = append(resolver.stack, calleeSource.identity)


### PR DESCRIPTION
## Why

Workflow warnings identify ignored or approximated GitHub Actions behavior, but do not always say what happens or how to respond. For example, a job-level `permissions` warning does not report the token's effective permissions, and the `cancel-in-progress` warning does not name the Buildkite setting that replaces it.

Closes PB-3015
Closes PB-3023
Closes PB-3027
Closes PB-3024

## What

- Report effective top-level `GITHUB_TOKEN` permissions and show how to move or request per-job permissions.
- Explain the output and history differences for legacy `actions/checkout` releases without recommending an unnecessary upgrade.
- Point `cancel-in-progress` users to **Cancel Intermediate Builds** under **Settings > Builds** and explain its branch-level behavior.
- List only the supported triggers declared beside each ignored trigger.

Compiler warnings retain source, job, and step attribution through compatibility reports, including matrix-deduplicated annotations.

## Preview

<h3>Job-level permissions</h3>
<h2 class="h4 mb2">GitHub Actions workflow diagnostics</h2>
<p><code>.github/workflows/ci.yml</code></p>
<p><strong>Job-level permissions are ignored for GITHUB_TOKEN.</strong></p>
<p><code>.github/workflows/ci.yml:5:3</code> · Job <code>build</code></p>
<p>The top-level workflow permissions apply instead.</p>
<p>This job&#39;s token has contents: read.</p>
<p>Move this job&#39;s permissions block to the workflow top level.</p>
<p>If you need per-job permissions, log an issue on <a href="https://github.com/buildkite/buildkite-gha" target="_blank">buildkite/buildkite-gha</a> so we can prioritise it.</p>

<hr>

<h3>Legacy checkout releases</h3>
<h2 class="h4 mb2">GitHub Actions workflow diagnostics</h2>
<p><code>.github/workflows/checkout.yml</code></p>
<p><strong>actions/checkout v1.2.0 behaves like v1.</strong></p>
<p><code>.github/workflows/checkout.yml:9:7</code> · Job <code>checkout</code> · Step 1</p>
<p>It does not set the ref and commit outputs, which actions/checkout added in v4.2.0.</p>
<p>It also defaults to full history when fetch-depth is omitted.</p>
<p>Upgrade to actions/checkout v4 or later if either difference matters.</p>
<p><strong>actions/checkout v2.8.0 behaves like v2.</strong></p>
<p><code>.github/workflows/checkout.yml:13:7</code> · Job <code>checkout</code> · Step 3</p>
<p>It does not set the ref and commit outputs, which actions/checkout added in v4.2.0.</p>
<p>Upgrade to actions/checkout v4 or later if a later step reads either output.</p>

<hr>

<h3>Workflow cancellation</h3>
<h2 class="h4 mb2">GitHub Actions workflow diagnostics</h2>
<p><code>concurrency.yml</code></p>
<p><strong>cancel-in-progress is ignored, so superseded builds keep running.</strong></p>
<p><code>concurrency.yml:5:23</code></p>
<p>Buildkite handles this as a pipeline setting rather than in the workflow file.</p>
<p>Turn on Cancel Intermediate Builds under Settings &gt; Builds.</p>
<p>It cancels earlier running builds on the same branch, rather than per concurrency group.</p>

<hr>

<h3>Unsupported trigger</h3>
<h2 class="h4 mb2">GitHub Actions workflow diagnostics</h2>
<p><code>.github/workflows/ci.yml</code></p>
<p><strong>on.issues is ignored, so nothing in this workflow runs from it.</strong></p>
<p><code>.github/workflows/ci.yml:4:3</code></p>
<p>The supported triggers declared in this workflow still run: merge_group, pull_request, push, release, schedule, workflow_call, workflow_dispatch.</p>
<p>Move the jobs this trigger guards to one of those triggers if you need them.</p>
<p>If you need issues, log an issue on <a href="https://github.com/buildkite/buildkite-gha" target="_blank">buildkite/buildkite-gha</a> so we can prioritise it.</p>