### PR TITLE
Make merge queue and release trigger errors actionable

### DIFF
--- a/internal/buildkite/triggers.go
+++ b/internal/buildkite/triggers.go
@@ -538,7 +538,7 @@ func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpression
 			}
 			for _, activity := range t.Types {
 				if activity != "checks_requested" {
-					return "", false, fmt.Errorf("merge_group activity type %q cannot be mapped exactly", activity)
+					return "", false, fmt.Errorf("merge_group type %q is unsupported. checks_requested is the only merge queue activity currently mapped. Set types: [checks_requested]. If you need another merge_group type, open an issue in https://github.com/buildkite/buildkite-gha so we can prioritize it", activity)
 				}
 			}
 		}
@@ -554,7 +554,7 @@ func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpression
 			return "", false, fmt.Errorf("release event snapshot requires payload.action")
 		}
 		if t.Types == nil {
-			return "", false, fmt.Errorf("release requires explicit types because bare release includes unsupported GitHub activities")
+			return "", false, fmt.Errorf("on: release needs a types list. A bare release covers every release event, while the currently supported types are exactly published, created, and released. Use on: {release: {types: [published]}}. If you need another release type, open an issue in https://github.com/buildkite/buildkite-gha so we can prioritize it")
 		}
 		if len(t.Types) == 0 {
 			return "", false, fmt.Errorf("release types is explicitly empty")

--- a/internal/buildkite/triggers_test.go
+++ b/internal/buildkite/triggers_test.go
@@ -74,9 +74,9 @@ func TestTranslateTriggerConditionRejectsUnsafeTriggers(t *testing.T) {
 		{name: "mixed include ignore", triggers: []workflow.Trigger{{Event: "push", Branches: []string{"main"}, BranchesIgnore: []string{"release"}}}, want: "cannot be combined"},
 		{name: "leading negative", triggers: []workflow.Trigger{{Event: "push", Branches: []string{"!release/**"}}}, want: "must follow a positive"},
 		{name: "unsupported PR type", triggers: []workflow.Trigger{{Event: "pull_request", Types: []string{"not-real"}}}, want: "cannot be mapped exactly"},
-		{name: "unsupported merge group type", triggers: []workflow.Trigger{{Event: "merge_group", Types: []string{"destroyed"}}}, want: "cannot be mapped exactly"},
+		{name: "unsupported merge group type", triggers: []workflow.Trigger{{Event: "merge_group", Types: []string{"destroyed"}}}, want: `merge_group type "destroyed" is unsupported`},
 		{name: "merge group paths", triggers: []workflow.Trigger{{Event: "merge_group", Paths: []string{"src/**"}}}, want: "path filters are unsupported"},
-		{name: "bare release", triggers: []workflow.Trigger{{Event: "release"}}, want: "requires explicit types"},
+		{name: "bare release", triggers: []workflow.Trigger{{Event: "release"}}, want: "on: release needs a types list"},
 		{name: "release unpublished", triggers: []workflow.Trigger{{Event: "release", Types: []string{"unpublished"}}}, want: "cannot be mapped exactly"},
 		{name: "release edited", triggers: []workflow.Trigger{{Event: "release", Types: []string{"edited"}}}, want: "cannot be mapped exactly"},
 		{name: "release deleted", triggers: []workflow.Trigger{{Event: "release", Types: []string{"deleted"}}}, want: "cannot be mapped exactly"},
@@ -89,6 +89,33 @@ func TestTranslateTriggerConditionRejectsUnsafeTriggers(t *testing.T) {
 			_, err := TranslateTriggerCondition(test.triggers)
 			if err == nil || !strings.Contains(err.Error(), test.want) {
 				t.Errorf("TranslateTriggerCondition(%v) error = %v, want %q", test.triggers, err, test.want)
+			}
+		})
+	}
+}
+
+func TestTranslateTriggerConditionReportsActionableTriggerErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		trigger workflow.Trigger
+		want    string
+	}{
+		{
+			name:    "unsupported merge group type",
+			trigger: workflow.Trigger{Event: "merge_group", Types: []string{"destroyed"}},
+			want:    `merge_group type "destroyed" is unsupported. checks_requested is the only merge queue activity currently mapped. Set types: [checks_requested]. If you need another merge_group type, open an issue in https://github.com/buildkite/buildkite-gha so we can prioritize it`,
+		},
+		{
+			name:    "bare release",
+			trigger: workflow.Trigger{Event: "release"},
+			want:    `on: release needs a types list. A bare release covers every release event, while the currently supported types are exactly published, created, and released. Use on: {release: {types: [published]}}. If you need another release type, open an issue in https://github.com/buildkite/buildkite-gha so we can prioritize it`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := TranslateTriggerCondition([]workflow.Trigger{test.trigger})
+			if err == nil || err.Error() != test.want {
+				t.Fatalf("TranslateTriggerCondition() error = %q, want %q", err, test.want)
 			}
 		})
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -53,7 +53,7 @@ func TestRunValidateAndCompile(t *testing.T) {
 			{name: "mixed branch filters", trigger: "push:\n    branches: [main]\n    branches-ignore: [release]", want: "include and ignore filters cannot be combined"},
 			{name: "pull request tag filter", trigger: "pull_request:\n    tags: [v1]", want: "pull_request tag filters are unsupported"},
 			{name: "pull request activity", trigger: "pull_request:\n    types: [auto_merge_enabled, submitted]", want: `activity type "submitted" cannot be mapped exactly`},
-			{name: "bare release", trigger: "release", want: "release requires explicit types"},
+			{name: "bare release", trigger: "release", want: "on: release needs a types list"},
 			{name: "unsupported release activity", trigger: "release:\n    types: [edited]", want: `release activity type "edited" cannot be mapped exactly`},
 			{name: "release branch filter", trigger: "release:\n    types: [published]\n    branches: [main]", want: "release has unsupported filters"},
 		}

--- a/internal/cli/validate_test.go
+++ b/internal/cli/validate_test.go
@@ -128,6 +128,76 @@ func TestValidatePublishesProcessingDiagnosticsInBuildkite(t *testing.T) {
 	})
 }
 
+func TestValidatePublishesActionableTriggerDiagnostics(t *testing.T) {
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_JOB_ID", cliTestJobID)
+
+	tests := []struct {
+		name           string
+		workflow       string
+		wantMessage    string
+		wantAnnotation []string
+	}{
+		{
+			name: "unsupported merge group type",
+			workflow: "on:\n  merge_group:\n    types: [destroyed]\n" +
+				"jobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo ok\n",
+			wantMessage: `merge_group type "destroyed" is unsupported. checks_requested is the only merge queue activity currently mapped. Set types: [checks_requested]. If you need another merge_group type, open an issue in https://github.com/buildkite/buildkite-gha so we can prioritize it`,
+			wantAnnotation: []string{
+				`<p><strong>merge_group type &#34;destroyed&#34; is unsupported.</strong></p>`,
+				`checks_requested is the only merge queue activity currently mapped.`,
+				`Set types: [checks_requested].`,
+			},
+		},
+		{
+			name:        "bare release",
+			workflow:    "on: release\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo ok\n",
+			wantMessage: `on: release needs a types list. A bare release covers every release event, while the currently supported types are exactly published, created, and released. Use on: {release: {types: [published]}}. If you need another release type, open an issue in https://github.com/buildkite/buildkite-gha so we can prioritize it`,
+			wantAnnotation: []string{
+				`<p><strong>on: release needs a types list.</strong></p>`,
+				`A bare release covers every release event, while the currently supported types are exactly published, created, and released.`,
+				`Use on: {release: {types: [published]}}.`,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			workflowPath := filepath.Join(t.TempDir(), "workflow.yml")
+			if err := os.WriteFile(workflowPath, []byte(test.workflow), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			runner := &cliCaptureRunner{}
+			var stdout, stderr bytes.Buffer
+			if code := run([]string{"validate", "--format", "json", workflowPath}, &stdout, &stderr, "dev", runner); code != 1 {
+				t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+			}
+			var report compatibility.ProcessingReport
+			if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+				t.Fatal(err)
+			}
+			if len(report.Diagnostics) != 1 || report.Diagnostics[0].Message != test.wantMessage {
+				t.Fatalf("diagnostics = %#v, want message %q", report.Diagnostics, test.wantMessage)
+			}
+			location := report.Diagnostics[0].Location
+			if location == nil || location.Path != workflowPath || location.Line != 1 || location.Column != 1 {
+				t.Fatalf("diagnostic location = %#v, want %s:1:1", location, workflowPath)
+			}
+			if len(runner.commands) != 1 || runner.commands[0].args[8] != "error" {
+				t.Fatalf("commands = %#v, want one error annotation", runner.commands)
+			}
+			annotation := string(runner.commands[0].stdin)
+			for _, want := range append(test.wantAnnotation,
+				`<code>`+workflowPath+`:1:1</code>`,
+				`open an issue in <a href="https://github.com/buildkite/buildkite-gha" target="_blank">buildkite/buildkite-gha</a> so we can prioritize it`,
+			) {
+				if !strings.Contains(annotation, want) {
+					t.Fatalf("annotation = %q, want %q", annotation, want)
+				}
+			}
+		})
+	}
+}
+
 func TestValidateActionCacheRequiresHostedProfile(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	if code := Run([]string{"validate", "--action-cache-dir", t.TempDir(), "workflow.yml"}, &stdout, &stderr, "dev"); code != 2 || !strings.Contains(stderr.String(), "requires --profile hosted") {


### PR DESCRIPTION
## Why

Unsupported trigger annotations explain mapping limits without leading with a working fix. For example:

```yaml
on:
  merge_group:
    types: [destroyed]
```

currently reports `merge_group activity type "destroyed" cannot be mapped exactly`. Bare `on: release` similarly omits a valid `types` configuration.

Closes PB-3020
Closes PB-3018

## What

- Unsupported `merge_group` types now point to `types: [checks_requested]`, the only merge queue activity currently mapped.
- Bare release triggers now lead with the required `types` fix, name the three supported types, and show `on: {release: {types: [published]}}`.
- Both diagnostics retain workflow source attribution and link to the repository issue route for unsupported types.

## Preview

<h3>Unsupported merge queue activity</h3>
<article data-buildkite-annotation-style="error">
<h2 class="h4 mb2">Workflow could not be run</h2>
<p><code>.github/workflows/ci.yml</code></p>
<p><strong>merge_group type &#34;destroyed&#34; is unsupported.</strong></p>
<p><code>.github/workflows/ci.yml:1:1</code></p>
<p>checks_requested is the only merge queue activity currently mapped.</p>
<p>Set types: [checks_requested].</p>
<p>If you need another merge_group type, open an issue in <a href="https://github.com/buildkite/buildkite-gha" target="_blank">buildkite/buildkite-gha</a> so we can prioritize it</p>
</article>

<h3>Bare release trigger</h3>
<article data-buildkite-annotation-style="error">
<h2 class="h4 mb2">Workflow could not be run</h2>
<p><code>.github/workflows/ci.yml</code></p>
<p><strong>on: release needs a types list.</strong></p>
<p><code>.github/workflows/ci.yml:1:1</code></p>
<p>A bare release covers every release event, while the currently supported types are exactly published, created, and released.</p>
<p>Use on: {release: {types: [published]}}.</p>
<p>If you need another release type, open an issue in <a href="https://github.com/buildkite/buildkite-gha" target="_blank">buildkite/buildkite-gha</a> so we can prioritize it</p>
</article>
