### PR TITLE
Upload importer artifacts in one batch

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -295,7 +295,7 @@ buildkite-gha compile \
 buildkite-gha upload .github/workflows/ci.yml
 ```
 
-The importer must run on Linux/amd64 or Darwin/arm64 with `BUILDKITE=true` and `BUILDKITE_STEP_KEY`.
+The importer must run on Linux/amd64 or Darwin/arm64 with Buildkite agent v3.129 or newer, `BUILDKITE=true`, and `BUILDKITE_STEP_KEY`.
 
 The hidden, zero-argument `buildkite-gha plugin` entry point reads plugin
 configuration from `BUILDKITE_PLUGIN_CONFIGURATION`. It accepts:
@@ -450,7 +450,7 @@ but cannot grant admission. Malformed event data stops the import.
 Buildkite owns schedule identity, so every `on.schedule` workflow is eligible
 for every Buildkite scheduled build.
 
-After all applicable workflows have been attempted, the command uploads the exact executable, content-addressed plans, and synthetic failure steps before running one:
+After all applicable workflows have been attempted, the command uploads the exact executable, content-addressed plans, and synthetic failure steps in one artifact batch with a concurrency limit of 8. It then runs one:
 
 ```sh
 buildkite-agent pipeline upload --no-interpolation --reject-secrets

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -5,6 +5,8 @@
 This page is the production contract for the `hosted` profile used by `upload`
 and the Buildkite plugin. If a feature is not listed, treat it as unsupported.
 
+buildkite-gha requires Buildkite agent v3.129 or newer.
+
 The released plugin supports Linux x86-64 and native macOS arm64 importers and
 jobs. It sets the matching `runner.os` and `runner.arch` values. Runner labels
 select a platform; they do not promise GitHub image, toolchain, or Xcode parity.
@@ -772,7 +774,7 @@ Outputs, environment changes, and failures become visible at the covering wait. 
 | Debug and matcher commands | ➖ Accepted, no effect | Consumed without presentation behavior. |
 | `notice`, command echo control, other legacy commands | ❌ Unsupported | Not implemented. |
 
-Job-scoped annotations, including step summaries and generated workflow failure diagnostics, require Buildkite agent v3.112 or newer. The total job summary is limited to 1 MiB.
+The total job summary is limited to 1 MiB.
 
 ## Expressions and contexts
 

--- a/internal/cli/cli_test_support_test.go
+++ b/internal/cli/cli_test_support_test.go
@@ -184,14 +184,35 @@ func (r *cliCaptureRunner) Run(ctx context.Context, dir, name string, args []str
 		return nil, os.WriteFile(path, contents, 0o600)
 	}
 	if len(args) >= 3 && args[0] == "artifact" && args[1] == "upload" {
-		contents, err := os.ReadFile(filepath.Join(dir, filepath.FromSlash(args[2])))
-		if err != nil {
-			return nil, err
-		}
 		if r.uploaded == nil {
 			r.uploaded = map[string][]byte{}
 		}
-		r.uploaded[args[2]] = contents
+		if args[2] == ".buildkite-gha/**/*" {
+			err := filepath.WalkDir(filepath.Join(dir, ".buildkite-gha"), func(path string, entry os.DirEntry, err error) error {
+				if err != nil || entry.IsDir() {
+					return err
+				}
+				relative, err := filepath.Rel(dir, path)
+				if err != nil {
+					return err
+				}
+				contents, err := os.ReadFile(path)
+				if err != nil {
+					return err
+				}
+				r.uploaded[filepath.ToSlash(relative)] = contents
+				return nil
+			})
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			contents, err := os.ReadFile(filepath.Join(dir, filepath.FromSlash(args[2])))
+			if err != nil {
+				return nil, err
+			}
+			r.uploaded[args[2]] = contents
+		}
 	}
 	if r.failMetadata && len(args) >= 2 && args[0] == "meta-data" && args[1] == "set" {
 		return nil, errors.New("metadata unavailable")

--- a/internal/cli/upload_test.go
+++ b/internal/cli/upload_test.go
@@ -114,19 +114,22 @@ func TestRunUploadCompilesArtifactsAndUploadsSelfContainedPipeline(t *testing.T)
 	if !strings.Contains(stdout.String(), "Uploaded 3 jobs") || stderr.Len() != 0 {
 		t.Fatalf("stdout = %q, stderr = %q", stdout.String(), stderr.String())
 	}
-	if len(runner.commands) != 5 {
-		t.Fatalf("commands = %#v, want distribution, three plans, and pipeline", runner.commands)
+	if len(runner.commands) != 2 {
+		t.Fatalf("commands = %#v, want one artifact batch and pipeline", runner.commands)
 	}
 	root := runner.commands[0].dir
-	for i, command := range runner.commands[:4] {
-		if command.dir != root || command.name != "buildkite-agent" || len(command.args) != 3 || command.args[0] != "artifact" || command.args[1] != "upload" {
-			t.Fatalf("artifact command %d = %#v", i, command)
-		}
+	artifactCommand := runner.commands[0]
+	wantArtifactArgs := []string{"artifact", "upload", ".buildkite-gha/**/*", "--concurrency", "8"}
+	if artifactCommand.name != "buildkite-agent" || !slices.Equal(artifactCommand.args, wantArtifactArgs) {
+		t.Fatalf("artifact command = %#v, want cwd %q and args %#v", artifactCommand, root, wantArtifactArgs)
+	}
+	if len(runner.uploaded) != 4 {
+		t.Fatalf("uploaded artifacts = %#v, want distribution and three plans", runner.uploaded)
 	}
 	if _, err := os.Stat(root); !os.IsNotExist(err) {
 		t.Fatalf("temporary artifact root still exists: %v", err)
 	}
-	pipelineCommand := runner.commands[4]
+	pipelineCommand := runner.commands[1]
 	wantPipelineArgs := []string{"pipeline", "upload", "--no-interpolation", "--reject-secrets"}
 	if strings.Join(pipelineCommand.args, " ") != strings.Join(wantPipelineArgs, " ") {
 		t.Fatalf("pipeline args = %#v, want %#v", pipelineCommand.args, wantPipelineArgs)
@@ -565,7 +568,7 @@ func TestRunUploadAggregatesExplicitPathsAtomicallyWithNamespacedJobs(t *testing
 	if code := run(args, &stdout, &stderr, "dev", runner); code != 0 {
 		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "Uploaded 14 jobs from 6 workflows") || stderr.Len() != 0 || len(runner.commands) != 16 {
+	if !strings.Contains(stdout.String(), "Uploaded 14 jobs from 6 workflows") || stderr.Len() != 0 || len(runner.commands) != 2 {
 		t.Fatalf("stdout/stderr/commands = %q / %q / %d", stdout.String(), stderr.String(), len(runner.commands))
 	}
 	pipelineCommand := runner.commands[len(runner.commands)-1]
@@ -1911,7 +1914,7 @@ func TestRunUploadSkipsReusableOnlyMatchButCompilesItThroughCaller(t *testing.T)
 	}, &stdout, &stderr, "dev", runner); code != 0 {
 		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "Uploaded 1 jobs from 2 workflows") || len(runner.commands) != 3 {
+	if !strings.Contains(stdout.String(), "Uploaded 1 jobs from 2 workflows") || len(runner.commands) != 2 {
 		t.Fatalf("stdout/commands = %q / %d", stdout.String(), len(runner.commands))
 	}
 	var pipeline struct {
@@ -2399,8 +2402,8 @@ func TestRunUploadCompilesConcurrentSmokePipeline(t *testing.T) {
 	if !strings.Contains(stdout.String(), "Uploaded 2 jobs") || stderr.Len() != 0 {
 		t.Fatalf("stdout = %q, stderr = %q", stdout.String(), stderr.String())
 	}
-	if len(runner.commands) != 4 {
-		t.Fatalf("commands = %#v, want distribution, two plans, and pipeline", runner.commands)
+	if len(runner.commands) != 2 {
+		t.Fatalf("commands = %#v, want one artifact batch and pipeline", runner.commands)
 	}
 
 	var pipeline struct {
@@ -2416,7 +2419,7 @@ func TestRunUploadCompilesConcurrentSmokePipeline(t *testing.T) {
 			} `yaml:"steps"`
 		} `yaml:"steps"`
 	}
-	if err := yaml.Unmarshal(runner.commands[3].stdin, &pipeline); err != nil {
+	if err := yaml.Unmarshal(runner.commands[1].stdin, &pipeline); err != nil {
 		t.Fatalf("uploaded pipeline YAML: %v", err)
 	}
 	if len(pipeline.Steps) != 1 || pipeline.Steps[0].DependsOn != "concurrent-steps-importer" || len(pipeline.Steps[0].Steps) != 2 {
@@ -2460,8 +2463,8 @@ func TestRunUploadJavaScriptActionRequiresRuntimeMiseWithoutTransport(t *testing
 	if code := run([]string{"upload", "--event-path", eventPath, "--runtime-queue", "hosted", workflowPath}, &stdout, &stderr, "dev", runner); code != 0 {
 		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
 	}
-	if len(runner.commands) != 3 {
-		t.Fatalf("commands = %d, want distribution, plan, and pipeline", len(runner.commands))
+	if len(runner.commands) != 2 {
+		t.Fatalf("commands = %d, want one artifact batch and pipeline", len(runner.commands))
 	}
 	for path := range runner.uploaded {
 		if strings.Contains(path, "/runtimes/") || strings.Contains(path, "/tools/mise/") {
@@ -2480,7 +2483,7 @@ func TestRunUploadJavaScriptActionRequiresRuntimeMiseWithoutTransport(t *testing
 			} `yaml:"steps"`
 		} `yaml:"steps"`
 	}
-	if err := yaml.Unmarshal(runner.commands[2].stdin, &pipeline); err != nil {
+	if err := yaml.Unmarshal(runner.commands[1].stdin, &pipeline); err != nil {
 		t.Fatalf("parse uploaded pipeline: %v", err)
 	}
 	if len(pipeline.Steps) != 1 || len(pipeline.Steps[0].Steps) != 1 {
@@ -2550,12 +2553,12 @@ func TestRunUploadFailsClosedBeforePipeline(t *testing.T) {
 	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
 	t.Setenv("BUILDKITE", "true")
 	t.Setenv("BUILDKITE_STEP_KEY", "shell-upload-importer")
-	runner := &cliCaptureRunner{failAt: 2}
+	runner := &cliCaptureRunner{failAt: 1}
 	var stdout, stderr bytes.Buffer
 	if code := run([]string{"upload", workflowPath, "--event-path", eventPath, "--runtime-queue", "hosted"}, &stdout, &stderr, "dev", runner); code != 1 {
 		t.Fatalf("run() code = %d, want 1", code)
 	}
-	if len(runner.commands) != 2 || !strings.Contains(stderr.String(), "upload artifact") {
+	if len(runner.commands) != 1 || !strings.Contains(stderr.String(), "upload artifacts") {
 		t.Fatalf("commands = %#v, stderr = %q", runner.commands, stderr.String())
 	}
 }

--- a/internal/transport/boundary.go
+++ b/internal/transport/boundary.go
@@ -18,6 +18,8 @@ const (
 	maxAnnotationBodyBytes         = 1024 * 1024
 	maxAnnotationContextCharacters = 100
 	maxAgentErrorBytes             = 64 * 1024
+	importerArtifactPattern        = ".buildkite-gha/**/*"
+	importerArtifactConcurrency    = "8"
 )
 
 // ErrMetadataUnavailable means Buildkite confirmed that reserved webhook
@@ -233,7 +235,6 @@ func UploadArtifacts(ctx context.Context, agent Agent, root string, artifacts []
 		return fmt.Errorf("open artifact root: %w", err)
 	}
 	defer func() { _ = rootFS.Close() }()
-	materialized := make(map[string]string, len(artifacts))
 	for _, artifact := range artifacts {
 		path, err := writeMaterialized(rootFS, absoluteRoot, artifact.Path, artifact.Contents)
 		if err != nil {
@@ -242,18 +243,25 @@ func UploadArtifacts(ctx context.Context, agent Agent, root string, artifacts []
 		if err := verifyMaterialized(path, artifact.Contents, artifact.Digest); err != nil {
 			return fmt.Errorf("verify artifact %q before upload: %w", artifact.Path, err)
 		}
-		materialized[artifact.Path] = path
 	}
-	for _, artifact := range artifacts {
-		if err := verifyMaterialized(materialized[artifact.Path], artifact.Contents, artifact.Digest); err != nil {
-			return fmt.Errorf("verify artifact %q at upload: %w", artifact.Path, err)
-		}
-		if err := agent.UploadArtifactFrom(ctx, absoluteRoot, artifact.Path); err != nil {
-			return fmt.Errorf("upload artifact %q: %w", artifact.Path, err)
-		}
+	if err := uploadMaterializedArtifacts(ctx, agent, absoluteRoot, artifacts); err != nil {
+		return err
 	}
 	if err := agent.UploadPipeline(ctx, pipeline); err != nil {
 		return fmt.Errorf("%w: %w", ErrPipelineUpload, err)
+	}
+	return nil
+}
+
+func uploadMaterializedArtifacts(ctx context.Context, agent Agent, absoluteRoot string, artifacts []Artifact) error {
+	for _, artifact := range artifacts {
+		path := filepath.Join(absoluteRoot, filepath.FromSlash(artifact.Path))
+		if err := verifyMaterialized(path, artifact.Contents, artifact.Digest); err != nil {
+			return fmt.Errorf("verify artifact %q at upload: %w", artifact.Path, err)
+		}
+	}
+	if _, err := agent.runInDir(ctx, absoluteRoot, []string{"artifact", "upload", importerArtifactPattern, "--concurrency", importerArtifactConcurrency}, nil); err != nil {
+		return fmt.Errorf("upload artifacts: %w", err)
 	}
 	return nil
 }
@@ -268,8 +276,10 @@ func cloneArtifacts(artifacts []Artifact) []Artifact {
 }
 
 func validateArtifact(artifact Artifact) error {
-	path := filepath.FromSlash(artifact.Path)
-	if artifact.Path == "" || !filepath.IsLocal(path) || filepath.ToSlash(filepath.Clean(path)) != artifact.Path {
+	if !strings.HasPrefix(artifact.Path, ".buildkite-gha/") {
+		return fmt.Errorf("invalid artifact path %q", artifact.Path)
+	}
+	if _, err := filepath.Localize(artifact.Path); err != nil {
 		return fmt.Errorf("invalid artifact path %q", artifact.Path)
 	}
 	if !digestPattern.MatchString(artifact.Digest) || Digest(artifact.Contents) != artifact.Digest {

--- a/internal/transport/model_test.go
+++ b/internal/transport/model_test.go
@@ -184,17 +184,33 @@ type capturedCommand struct {
 
 type captureRunner struct {
 	commands []capturedCommand
+	uploaded map[string][]byte
 	failAt   int
-	afterRun func(int)
 }
 
-func (r *captureRunner) Run(_ context.Context, dir, name string, args []string, stdin []byte) ([]byte, error) {
+func (r *captureRunner) Run(ctx context.Context, dir, name string, args []string, stdin []byte) ([]byte, error) {
 	r.commands = append(r.commands, capturedCommand{dir: dir, name: name, args: append([]string(nil), args...), stdin: string(stdin)})
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
 	if r.failAt != 0 && len(r.commands) == r.failAt {
 		return nil, errors.New("injected failure")
 	}
-	if r.afterRun != nil {
-		r.afterRun(len(r.commands))
+	if reflect.DeepEqual(args, []string{"artifact", "upload", ".buildkite-gha/**/*", "--concurrency", "8"}) {
+		r.uploaded = map[string][]byte{}
+		if err := filepath.WalkDir(filepath.Join(dir, ".buildkite-gha"), func(path string, entry os.DirEntry, err error) error {
+			if err != nil || entry.IsDir() {
+				return err
+			}
+			relative, err := filepath.Rel(dir, path)
+			if err != nil {
+				return err
+			}
+			r.uploaded[filepath.ToSlash(relative)], err = os.ReadFile(path)
+			return err
+		}); err != nil {
+			return nil, err
+		}
 	}
 	return nil, nil
 }
@@ -265,26 +281,59 @@ func TestUploadArtifactsMaterializesContentBeforePipeline(t *testing.T) {
 	if err := UploadArtifacts(t.Context(), Agent{Runner: runner}, root, []Artifact{plan, distribution}, []byte("steps: []\n")); err != nil {
 		t.Fatal(err)
 	}
-	if len(runner.commands) != 3 {
-		t.Fatalf("commands = %#v, want two artifacts then pipeline", runner.commands)
+	if len(runner.commands) != 2 {
+		t.Fatalf("commands = %#v, want one artifact batch then pipeline", runner.commands)
 	}
 	resolvedRoot, err := filepath.EvalSymlinks(root)
 	if err != nil {
 		t.Fatal(err)
 	}
 	want := []capturedCommand{
-		{dir: resolvedRoot, name: "buildkite-agent", args: []string{"artifact", "upload", distribution.Path}},
-		{dir: resolvedRoot, name: "buildkite-agent", args: []string{"artifact", "upload", plan.Path}},
+		{dir: resolvedRoot, name: "buildkite-agent", args: []string{"artifact", "upload", ".buildkite-gha/**/*", "--concurrency", "8"}},
 		{name: "buildkite-agent", args: []string{"pipeline", "upload", "--no-interpolation", "--reject-secrets"}, stdin: "steps: []\n"},
 	}
 	if !reflect.DeepEqual(runner.commands, want) {
 		t.Fatalf("commands = %#v, want %#v", runner.commands, want)
+	}
+	wantUploaded := map[string][]byte{plan.Path: plan.Contents, distribution.Path: distribution.Contents}
+	if !reflect.DeepEqual(runner.uploaded, wantUploaded) {
+		t.Fatalf("uploaded bytes = %#v, want %#v", runner.uploaded, wantUploaded)
 	}
 	for _, artifact := range []Artifact{plan, distribution} {
 		contents, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(artifact.Path)))
 		if err != nil || !bytes.Equal(contents, artifact.Contents) {
 			t.Fatalf("materialized %q = %q, %v", artifact.Path, contents, err)
 		}
+	}
+}
+
+func TestUploadArtifactsCancellationDoesNotUploadPipeline(t *testing.T) {
+	artifact := Artifact{Path: ".buildkite-gha/plans/plan.json", Contents: []byte("plan")}
+	artifact.Digest = Digest(artifact.Contents)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	runner := &captureRunner{}
+	err := UploadArtifacts(ctx, Agent{Runner: runner}, t.TempDir(), []Artifact{artifact}, []byte("steps: []\n"))
+	if !errors.Is(err, context.Canceled) || len(runner.commands) != 1 || runner.commands[0].args[0] != "artifact" {
+		t.Fatalf("UploadArtifacts() error = %v, commands = %#v", err, runner.commands)
+	}
+}
+
+func TestUploadMaterializedArtifactsIntegrityFailureDoesNotInvokeAgent(t *testing.T) {
+	root := t.TempDir()
+	artifact := Artifact{Path: ".buildkite-gha/plans/plan.json", Contents: []byte("plan")}
+	artifact.Digest = Digest(artifact.Contents)
+	path := filepath.Join(root, filepath.FromSlash(artifact.Path))
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("tampered"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runner := &captureRunner{}
+	err := uploadMaterializedArtifacts(t.Context(), Agent{Runner: runner}, root, []Artifact{artifact})
+	if err == nil || !strings.Contains(err.Error(), "verify artifact") || len(runner.commands) != 0 {
+		t.Fatalf("uploadMaterializedArtifacts() error = %v, commands = %#v", err, runner.commands)
 	}
 }
 


### PR DESCRIPTION
## Why

The importer currently starts one `buildkite-agent artifact upload` process for every executable, plan, and generated failure artifact. A workflow with many jobs therefore starts many agent processes before it can upload its pipeline.

## What

Materialize and verify every importer artifact under the private artifact root, then upload them together:

```sh
buildkite-agent artifact upload ".buildkite-gha/**/*" --concurrency 8
```

The pipeline remains last and is not uploaded after artifact failure, cancellation, or an integrity failure. This path now requires Buildkite agent v3.129 or newer.