### PR TITLE
Test workflows with Namespace's GitHub Actions image

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -142,7 +142,7 @@ steps:
         key: "plugin-source-smoke-importer"
         if: build.env("DEMO_SUITE") != "plugin"
         env:
-          BUILDKITE_PLUGIN_CONFIGURATION: '{"workflow":"testdata/smoke/.github/workflows/shell.yml","runners":[{"runs-on":"ubuntu-latest","queue":"hosted"}]}'
+          BUILDKITE_PLUGIN_CONFIGURATION: '{"workflow":"testdata/smoke/.github/workflows/shell.yml","runners":[{"runs-on":"ubuntu-latest","queue":"hosted","image":"public.registry.namespace.systems/namespacelabs.dev/internal/service/githubrunner/container/ubuntu2404@sha256:e4e92abbe1406415902d8e007277a6b3f4294e647745d36f7054bcd7d83c17a8"}]}'
         timeout_in_minutes: 20
         retry:
           automatic: false

--- a/.buildkite/public-actions-proof.yml
+++ b/.buildkite/public-actions-proof.yml
@@ -21,6 +21,7 @@ steps:
       "$$distribution_root/buildkite-gha" upload \
         --event-path testdata/public-actions/events/public-checkout.json \
         --runner-queue ubuntu-latest=hosted \
+        --runner-image ubuntu-latest=public.registry.namespace.systems/namespacelabs.dev/internal/service/githubrunner/container/ubuntu2404@sha256:e4e92abbe1406415902d8e007277a6b3f4294e647745d36f7054bcd7d83c17a8 \
         testdata/public-actions/.github/workflows/public-actions.yml
 
   - label: ":pipeline: Public actions proof continuation loader"


### PR DESCRIPTION
## Why

Check whether imported workflows can run on Namespace's Ubuntu 24.04 GitHub Actions image instead of the current hosted toolchains image.

## What

Pin the Namespace image for the exact-source shell smoke workflow and the public-actions proof. This exercises shell execution plus pinned checkout, Node, Go, Python, and Java setup actions.
