### PR TITLE
Accept hosted cache bind mounts for runner user

### DIFF
--- a/internal/buildkite/experimental_runner_user.go
+++ b/internal/buildkite/experimental_runner_user.go
@@ -28,16 +28,7 @@ func experimentalRunnerUserBootstrap(requiresMise, hostedToolCache bool, cache *
 		`sudo -n --user runner -- test -r "$plan" && ! sudo -n --user runner -- test -w "$plan" || { echo 'buildkite-gha: runner plan permissions are unsafe' >&2; exit 1; }`,
 	}
 	if cache != nil {
-		commands = append(commands, `command -v readlink >/dev/null 2>&1 || { echo 'buildkite-gha: configured cache paths require readlink' >&2; exit 1; }`)
-		for _, path := range cache.Paths {
-			commands = append(commands,
-				"cache_target=\"$(readlink -f -- "+shellQuote(path)+`)" || { echo 'buildkite-gha: configured cache path is unavailable' >&2; exit 1; }`,
-				`case "$cache_target" in /cache/bkcache/*) ;; *) echo 'buildkite-gha: configured cache path does not target the Buildkite cache volume' >&2; exit 1;; esac`,
-				`test -d "$cache_target" || { echo 'buildkite-gha: configured cache path is not a directory' >&2; exit 1; }`,
-				`chown -R runner:"$runner_group" "$cache_target"`,
-				`chmod -R u+rwX "$cache_target"`,
-			)
-		}
+		commands = append(commands, experimentalRunnerCacheOwnershipCommands("/cache/bkcache", cache.Paths)...)
 	}
 	if requiresMise {
 		commands = append(commands,
@@ -59,6 +50,29 @@ func experimentalRunnerUserBootstrap(requiresMise, hostedToolCache bool, cache *
 		`sudo -n --user runner -- env HOME='/home/runner' TMPDIR='/tmp/buildkite-gha-runner' sh -c 'test "$(id -un)" = runner; test "$(id -u)" -ne 0; test "$HOME" = /home/runner; test -w "$TMPDIR"; sudo -n true'`,
 		`if [ -S /var/run/docker.sock ]; then sudo -n --user runner -- test -w /var/run/docker.sock || { echo 'buildkite-gha: runner cannot access the Docker socket' >&2; exit 1; }; fi`,
 	)
+}
+
+// experimentalRunnerCacheOwnershipCommands accepts both documented links into
+// the cache root and Hosted's direct bind mounts, but not ordinary directories.
+func experimentalRunnerCacheOwnershipCommands(cacheRoot string, paths []string) []string {
+	commands := []string{
+		`for command in mountpoint readlink stat; do command -v "$command" >/dev/null 2>&1 || { echo "buildkite-gha: configured cache paths require $command" >&2; exit 1; }; done`,
+		"cache_root=" + shellQuote(cacheRoot),
+		`test -d "$cache_root" && mountpoint -q -- "$cache_root" || { echo 'buildkite-gha: Buildkite cache volume is unavailable' >&2; exit 1; }`,
+		`cache_device="$(stat -c '%d' -- "$cache_root")" || { echo 'buildkite-gha: Buildkite cache volume is unavailable' >&2; exit 1; }`,
+	}
+	for _, path := range paths {
+		commands = append(commands,
+			"cache_target=\"$(readlink -f -- "+shellQuote(path)+`)" || { echo 'buildkite-gha: configured cache path is unavailable' >&2; exit 1; }`,
+			`test -d "$cache_target" || { echo 'buildkite-gha: configured cache path is not a directory' >&2; exit 1; }`,
+			`test "$cache_target" != "$cache_root" || { echo 'buildkite-gha: configured cache path is unsafe' >&2; exit 1; }`,
+			`test "$(stat -c '%d' -- "$cache_target")" = "$cache_device" || { echo 'buildkite-gha: configured cache path does not target the Buildkite cache volume' >&2; exit 1; }`,
+			`case "$cache_target" in "$cache_root"/*) ;; *) mountpoint -q -- "$cache_target" || { echo 'buildkite-gha: configured cache path is not a Buildkite cache volume mount' >&2; exit 1; };; esac`,
+			`chown -R runner:"$runner_group" "$cache_target"`,
+			`chmod -R u+rwX "$cache_target"`,
+		)
+	}
+	return commands
 }
 
 func experimentalRunnerUserCommand(runJob string) string {

--- a/internal/buildkite/experimental_runner_user_test.go
+++ b/internal/buildkite/experimental_runner_user_test.go
@@ -176,6 +176,8 @@ func runExperimentalRunnerCacheOwnership(t *testing.T, root string, paths []stri
 printf '%s\n' "$TEST_MOUNTPOINTS" | grep -Fx -- "$target" >/dev/null`)
 	writeExecutable("stat", `for argument do target="$argument"; done
 if printf '%s\n' "$TEST_CACHE_PATHS" | grep -Fx -- "$target" >/dev/null; then printf '2049\n'; else printf '1\n'; fi`)
+	writeExecutable("readlink", `for argument do target="$argument"; done
+test -d "$target" && printf '%s\n' "$target"`)
 	writeExecutable("chown", "exit 0\n")
 	writeExecutable("chmod", "exit 0\n")
 

--- a/internal/buildkite/experimental_runner_user_test.go
+++ b/internal/buildkite/experimental_runner_user_test.go
@@ -1,6 +1,9 @@
 package buildkite
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -76,4 +79,108 @@ func TestEmitRunnerUserIsDefaultForLinuxOnly(t *testing.T) {
 	if strings.Contains(string(output), "useradd") || strings.Contains(string(output), "sudo -n") {
 		t.Fatalf("opt-out pipeline selected runner user:\n%s", output)
 	}
+}
+
+func TestExperimentalRunnerCacheOwnershipAcceptsHostedVolumePaths(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "bkcache")
+	descendant := filepath.Join(root, "buildkite-gha", "mise")
+	directMount := filepath.Join(t.TempDir(), "runner", ".gradle", "caches")
+	for _, path := range []string{descendant, directMount} {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	output, err := runExperimentalRunnerCacheOwnership(t, root, []string{directMount, descendant}, root+"\n"+directMount, root+"\n"+directMount+"\n"+descendant)
+	if err != nil {
+		t.Fatalf("cache validation failed: %v: %s", err, output)
+	}
+}
+
+func TestExperimentalRunnerCacheOwnershipRejectsUnsafePaths(t *testing.T) {
+	tests := []struct {
+		name        string
+		path        func(root string) string
+		createPath  bool
+		mountpoints func(root, path string) string
+		cachePaths  func(root, path string) string
+		want        string
+	}{
+		{
+			name:        "ordinary directory on cache filesystem",
+			path:        func(string) string { return filepath.Join(t.TempDir(), "ordinary") },
+			createPath:  true,
+			mountpoints: func(root, _ string) string { return root },
+			cachePaths:  func(root, path string) string { return root + "\n" + path },
+			want:        "configured cache path is not a Buildkite cache volume mount",
+		},
+		{
+			name:        "mount on another filesystem",
+			path:        func(string) string { return filepath.Join(t.TempDir(), "other-volume") },
+			createPath:  true,
+			mountpoints: func(root, path string) string { return root + "\n" + path },
+			cachePaths:  func(root, _ string) string { return root },
+			want:        "configured cache path does not target the Buildkite cache volume",
+		},
+		{
+			name:        "entire cache root",
+			path:        func(root string) string { return root },
+			createPath:  true,
+			mountpoints: func(root, _ string) string { return root },
+			cachePaths:  func(root, _ string) string { return root },
+			want:        "configured cache path is unsafe",
+		},
+		{
+			name:        "unavailable path",
+			path:        func(string) string { return filepath.Join(t.TempDir(), "missing", "cache") },
+			mountpoints: func(root, _ string) string { return root },
+			cachePaths:  func(root, _ string) string { return root },
+			want:        "configured cache path is unavailable",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := filepath.Join(t.TempDir(), "bkcache")
+			path := test.path(root)
+			dirs := []string{root}
+			if test.createPath {
+				dirs = append(dirs, path)
+			}
+			for _, dir := range dirs {
+				if err := os.MkdirAll(dir, 0o700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			output, err := runExperimentalRunnerCacheOwnership(t, root, []string{path}, test.mountpoints(root, path), test.cachePaths(root, path))
+			if err == nil {
+				t.Fatalf("cache validation unexpectedly succeeded: %s", output)
+			}
+			if !strings.Contains(output, test.want) {
+				t.Fatalf("cache validation output = %q, want %q", output, test.want)
+			}
+		})
+	}
+}
+
+func runExperimentalRunnerCacheOwnership(t *testing.T, root string, paths []string, mountpoints, cachePaths string) (string, error) {
+	t.Helper()
+	bin := t.TempDir()
+	writeExecutable := func(name, body string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(bin, name), []byte("#!/bin/sh\n"+body), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeExecutable("mountpoint", `for argument do target="$argument"; done
+printf '%s\n' "$TEST_MOUNTPOINTS" | grep -Fx -- "$target" >/dev/null`)
+	writeExecutable("stat", `for argument do target="$argument"; done
+if printf '%s\n' "$TEST_CACHE_PATHS" | grep -Fx -- "$target" >/dev/null; then printf '2049\n'; else printf '1\n'; fi`)
+	writeExecutable("chown", "exit 0\n")
+	writeExecutable("chmod", "exit 0\n")
+
+	command := exec.Command("bash", "-c", "set -euo pipefail\nrunner_group=runner\n"+strings.Join(experimentalRunnerCacheOwnershipCommands(root, paths), "\n"))
+	command.Env = append(os.Environ(), "PATH="+bin+":"+os.Getenv("PATH"), "TEST_MOUNTPOINTS="+mountpoints, "TEST_CACHE_PATHS="+cachePaths)
+	output, err := command.CombinedOutput()
+	return string(output), err
 }

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -946,7 +946,7 @@ func TestEmitMergesConfiguredAndManagedCacheVolume(t *testing.T) {
 			t.Fatalf("runner-home cache path %q is not made writable by runner:\n%s", path, step.Command)
 		}
 	}
-	if !strings.Contains(step.Command, `case "$cache_target" in /cache/bkcache/*)`) || !strings.Contains(step.Command, `chown -R runner:"$runner_group" "$cache_target"`) {
+	if !strings.Contains(step.Command, `mountpoint -q -- "$cache_root"`) || !strings.Contains(step.Command, `stat -c '%d' -- "$cache_target"`) || !strings.Contains(step.Command, `mountpoint -q -- "$cache_target"`) || !strings.Contains(step.Command, `chown -R runner:"$runner_group" "$cache_target"`) {
 		t.Fatalf("cache ownership is not constrained to the Buildkite volume:\n%s", step.Command)
 	}
 }


### PR DESCRIPTION
## Why

`buildkite/buildkite-gha-benchmarks` build 66 ran buildkite-gha v0.33.0 with Gradle cache paths under `/home/runner` and the managed mise path under `/cache/bkcache`. Buildkite Hosted mounted the same `/dev/vdi` cache filesystem directly at all three paths, but runner-user bootstrap required `readlink -f` to resolve every path lexically beneath `/cache/bkcache`. It rejected the first valid Gradle bind mount before `run-job`.

## What

Validate the filesystem topology instead of the configured string. Bootstrap now establishes `/cache/bkcache` as a real mount, records its filesystem device, and requires every canonical cache target to be an available directory on that same filesystem. Targets outside `/cache/bkcache` must also be mount points, accepting Hosted's direct bind mounts while rejecting ordinary directories and unrelated mounts.

Recursive runner ownership remains limited to validated cache targets; `BUILDKITE_AGENT_CACHE_PATHS` is not treated as proof. macOS and managed mise-only behavior are unchanged, and the documented cache contract does not change.

Focused tests model direct bind mounts and managed paths without privileged mounts, and cover ordinary-directory, different-filesystem, cache-root, and unavailable-path rejection. `mise run check` passes.

After merge, this needs a patch release and a live rerun of the benchmark workload to prove the Hosted hook topology end to end.