### PR TITLE
Anchor hosted cache validation to a direct mount

### DIFF
--- a/internal/buildkite/experimental_runner_user.go
+++ b/internal/buildkite/experimental_runner_user.go
@@ -28,7 +28,11 @@ func experimentalRunnerUserBootstrap(requiresMise, hostedToolCache bool, cache *
 		`sudo -n --user runner -- test -r "$plan" && ! sudo -n --user runner -- test -w "$plan" || { echo 'buildkite-gha: runner plan permissions are unsafe' >&2; exit 1; }`,
 	}
 	if cache != nil {
-		commands = append(commands, experimentalRunnerCacheOwnershipCommands("/cache/bkcache", cache.Paths)...)
+		cacheAnchor := platformCacheValidationPath("linux/amd64")
+		if requiresMise {
+			cacheAnchor = platformMiseCachePath("linux/amd64")
+		}
+		commands = append(commands, experimentalRunnerCacheOwnershipCommands("/cache/bkcache", cacheAnchor, cache.Paths)...)
 	}
 	if requiresMise {
 		commands = append(commands,
@@ -52,14 +56,17 @@ func experimentalRunnerUserBootstrap(requiresMise, hostedToolCache bool, cache *
 	)
 }
 
-// experimentalRunnerCacheOwnershipCommands accepts both documented links into
-// the cache root and Hosted's direct bind mounts, but not ordinary directories.
-func experimentalRunnerCacheOwnershipCommands(cacheRoot string, paths []string) []string {
+// experimentalRunnerCacheOwnershipCommands uses a compiler-owned cache path as
+// the filesystem anchor, then accepts direct mounts or documented root links.
+func experimentalRunnerCacheOwnershipCommands(cacheRoot, anchor string, paths []string) []string {
 	commands := []string{
 		`for command in mountpoint readlink stat; do command -v "$command" >/dev/null 2>&1 || { echo "buildkite-gha: configured cache paths require $command" >&2; exit 1; }; done`,
 		"cache_root=" + shellQuote(cacheRoot),
-		`test -d "$cache_root" && mountpoint -q -- "$cache_root" || { echo 'buildkite-gha: Buildkite cache volume is unavailable' >&2; exit 1; }`,
-		`cache_device="$(stat -c '%d' -- "$cache_root")" || { echo 'buildkite-gha: Buildkite cache volume is unavailable' >&2; exit 1; }`,
+		"cache_anchor=\"$(readlink -f -- " + shellQuote(anchor) + `)" || { echo 'buildkite-gha: Buildkite cache volume anchor is unavailable' >&2; exit 1; }`,
+		`test -d "$cache_anchor" || { echo 'buildkite-gha: Buildkite cache volume anchor is unavailable' >&2; exit 1; }`,
+		`cache_root_mounted=false; if test -d "$cache_root" && mountpoint -q -- "$cache_root"; then cache_root_mounted=true; fi`,
+		`if ! mountpoint -q -- "$cache_anchor"; then test "$cache_root_mounted" = true || { echo 'buildkite-gha: Buildkite cache volume anchor is not mounted' >&2; exit 1; }; case "$cache_anchor" in "$cache_root"/*) ;; *) echo 'buildkite-gha: Buildkite cache volume anchor is unsafe' >&2; exit 1;; esac; fi`,
+		`cache_device="$(stat -c '%d' -- "$cache_anchor")" || { echo 'buildkite-gha: Buildkite cache volume anchor is unavailable' >&2; exit 1; }`,
 	}
 	for _, path := range paths {
 		commands = append(commands,
@@ -67,7 +74,7 @@ func experimentalRunnerCacheOwnershipCommands(cacheRoot string, paths []string) 
 			`test -d "$cache_target" || { echo 'buildkite-gha: configured cache path is not a directory' >&2; exit 1; }`,
 			`test "$cache_target" != "$cache_root" || { echo 'buildkite-gha: configured cache path is unsafe' >&2; exit 1; }`,
 			`test "$(stat -c '%d' -- "$cache_target")" = "$cache_device" || { echo 'buildkite-gha: configured cache path does not target the Buildkite cache volume' >&2; exit 1; }`,
-			`case "$cache_target" in "$cache_root"/*) ;; *) mountpoint -q -- "$cache_target" || { echo 'buildkite-gha: configured cache path is not a Buildkite cache volume mount' >&2; exit 1; };; esac`,
+			`if ! mountpoint -q -- "$cache_target"; then test "$cache_root_mounted" = true || { echo 'buildkite-gha: configured cache path is not a Buildkite cache volume mount' >&2; exit 1; }; case "$cache_target" in "$cache_root"/*) ;; *) echo 'buildkite-gha: configured cache path is not a Buildkite cache volume mount' >&2; exit 1;; esac; fi`,
 			`chown -R runner:"$runner_group" "$cache_target"`,
 			`chmod -R u+rwX "$cache_target"`,
 		)

--- a/internal/buildkite/experimental_runner_user_test.go
+++ b/internal/buildkite/experimental_runner_user_test.go
@@ -81,19 +81,48 @@ func TestEmitRunnerUserIsDefaultForLinuxOnly(t *testing.T) {
 	}
 }
 
-func TestExperimentalRunnerCacheOwnershipAcceptsHostedVolumePaths(t *testing.T) {
+func TestExperimentalRunnerCacheOwnershipAcceptsDirectHostedVolumePathsWithoutRootMount(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "bkcache")
-	descendant := filepath.Join(root, "buildkite-gha", "mise")
-	directMount := filepath.Join(t.TempDir(), "runner", ".gradle", "caches")
-	for _, path := range []string{descendant, directMount} {
+	anchor := filepath.Join(root, "buildkite-gha", "mise", "linux-amd64")
+	runnerHome := filepath.Join(t.TempDir(), "runner")
+	gradleCaches := filepath.Join(runnerHome, ".gradle", "caches")
+	gradleWrapper := filepath.Join(runnerHome, ".gradle", "wrapper")
+	for _, path := range []string{anchor, gradleCaches, gradleWrapper} {
 		if err := os.MkdirAll(path, 0o700); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	output, err := runExperimentalRunnerCacheOwnership(t, root, []string{directMount, descendant}, root+"\n"+directMount, root+"\n"+directMount+"\n"+descendant)
+	volumePaths := strings.Join([]string{anchor, gradleCaches, gradleWrapper}, "\n")
+	output, err := runExperimentalRunnerCacheOwnership(t, root, anchor, []string{gradleCaches, gradleWrapper}, volumePaths, volumePaths)
 	if err != nil {
 		t.Fatalf("cache validation failed: %v: %s", err, output)
+	}
+}
+
+func TestExperimentalRunnerCacheOwnershipAcceptsDocumentedRootMount(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "bkcache")
+	anchor := filepath.Join(root, "buildkite-gha", "validation", "linux-amd64")
+	if err := os.MkdirAll(anchor, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	output, err := runExperimentalRunnerCacheOwnership(t, root, anchor, []string{anchor}, root, root+"\n"+anchor)
+	if err != nil {
+		t.Fatalf("cache validation failed: %v: %s", err, output)
+	}
+}
+
+func TestExperimentalRunnerCacheOwnershipRejectsOrdinaryAnchor(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "bkcache")
+	anchor := filepath.Join(root, "buildkite-gha", "validation", "linux-amd64")
+	if err := os.MkdirAll(anchor, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	output, err := runExperimentalRunnerCacheOwnership(t, root, anchor, []string{anchor}, "", anchor)
+	if err == nil || !strings.Contains(output, "Buildkite cache volume anchor is not mounted") {
+		t.Fatalf("ordinary anchor validation = %v, %q", err, output)
 	}
 }
 
@@ -142,8 +171,9 @@ func TestExperimentalRunnerCacheOwnershipRejectsUnsafePaths(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			root := filepath.Join(t.TempDir(), "bkcache")
+			anchor := filepath.Join(root, "buildkite-gha", "validation", "linux-amd64")
 			path := test.path(root)
-			dirs := []string{root}
+			dirs := []string{root, anchor}
 			if test.createPath {
 				dirs = append(dirs, path)
 			}
@@ -152,7 +182,9 @@ func TestExperimentalRunnerCacheOwnershipRejectsUnsafePaths(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			output, err := runExperimentalRunnerCacheOwnership(t, root, []string{path}, test.mountpoints(root, path), test.cachePaths(root, path))
+			mountpoints := anchor + "\n" + test.mountpoints(root, path)
+			cachePaths := anchor + "\n" + test.cachePaths(root, path)
+			output, err := runExperimentalRunnerCacheOwnership(t, root, anchor, []string{path}, mountpoints, cachePaths)
 			if err == nil {
 				t.Fatalf("cache validation unexpectedly succeeded: %s", output)
 			}
@@ -163,7 +195,7 @@ func TestExperimentalRunnerCacheOwnershipRejectsUnsafePaths(t *testing.T) {
 	}
 }
 
-func runExperimentalRunnerCacheOwnership(t *testing.T, root string, paths []string, mountpoints, cachePaths string) (string, error) {
+func runExperimentalRunnerCacheOwnership(t *testing.T, root, anchor string, paths []string, mountpoints, cachePaths string) (string, error) {
 	t.Helper()
 	bin := t.TempDir()
 	writeExecutable := func(name, body string) {
@@ -181,7 +213,7 @@ test -d "$target" && printf '%s\n' "$target"`)
 	writeExecutable("chown", "exit 0\n")
 	writeExecutable("chmod", "exit 0\n")
 
-	command := exec.Command("bash", "-c", "set -euo pipefail\nrunner_group=runner\n"+strings.Join(experimentalRunnerCacheOwnershipCommands(root, paths), "\n"))
+	command := exec.Command("bash", "-c", "set -euo pipefail\nrunner_group=runner\n"+strings.Join(experimentalRunnerCacheOwnershipCommands(root, anchor, paths), "\n"))
 	command.Env = append(os.Environ(), "PATH="+bin+":"+os.Getenv("PATH"), "TEST_MOUNTPOINTS="+mountpoints, "TEST_CACHE_PATHS="+cachePaths)
 	output, err := command.CombinedOutput()
 	return string(output), err

--- a/internal/buildkite/pipeline.go
+++ b/internal/buildkite/pipeline.go
@@ -527,7 +527,7 @@ func emitWorkflow(out *bytes.Buffer, pipeline Pipeline, workflow preparedWorkflo
 			_, _ = fmt.Fprintf(out, "%s  queue: %s\n", attributeIndent, yamlScalar(job.Queue))
 		}
 		_, _ = fmt.Fprintf(out, "%scheckout:\n%s  skip: true\n", attributeIndent, attributeIndent)
-		cache := mergedCacheVolume(job.Cache, job.RequiresMise, platform)
+		cache := mergedCacheVolume(job.Cache, job.RequiresMise, platform, experimentalRunnerUser)
 		if cache != nil {
 			_, _ = fmt.Fprintf(out, "%scache:\n", attributeIndent)
 			_, _ = fmt.Fprintf(out, "%s  paths:\n", attributeIndent)
@@ -688,7 +688,11 @@ func platformMiseCachePath(platform string) string {
 	return root + "/mise/" + platformCacheKey(platform)
 }
 
-func mergedCacheVolume(configured *CacheVolume, requiresMise bool, platform string) *CacheVolume {
+func platformCacheValidationPath(platform string) string {
+	return runtimeCacheRoot + "/validation/" + platformCacheKey(platform)
+}
+
+func mergedCacheVolume(configured *CacheVolume, requiresMise bool, platform string, runnerUser bool) *CacheVolume {
 	if configured == nil && !requiresMise {
 		return nil
 	}
@@ -706,6 +710,11 @@ func mergedCacheVolume(configured *CacheVolume, requiresMise bool, platform stri
 		}
 		if cache.Name == "" {
 			cache.Name = runtimeCacheName + "-" + platformCacheKey(platform)
+		}
+	} else if runnerUser {
+		validationPath := platformCacheValidationPath(platform)
+		if !slices.Contains(cache.Paths, validationPath) {
+			cache.Paths = append(cache.Paths, validationPath)
 		}
 	}
 	return cache

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -946,7 +946,7 @@ func TestEmitMergesConfiguredAndManagedCacheVolume(t *testing.T) {
 			t.Fatalf("runner-home cache path %q is not made writable by runner:\n%s", path, step.Command)
 		}
 	}
-	if !strings.Contains(step.Command, `mountpoint -q -- "$cache_root"`) || !strings.Contains(step.Command, `stat -c '%d' -- "$cache_target"`) || !strings.Contains(step.Command, `mountpoint -q -- "$cache_target"`) || !strings.Contains(step.Command, `chown -R runner:"$runner_group" "$cache_target"`) {
+	if !strings.Contains(step.Command, "readlink -f -- '"+platformMiseCachePath("linux/amd64")+"'") || !strings.Contains(step.Command, `stat -c '%d' -- "$cache_target"`) || !strings.Contains(step.Command, `mountpoint -q -- "$cache_target"`) || !strings.Contains(step.Command, `chown -R runner:"$runner_group" "$cache_target"`) {
 		t.Fatalf("cache ownership is not constrained to the Buildkite volume:\n%s", step.Command)
 	}
 }
@@ -972,10 +972,11 @@ func TestEmitConfiguredCacheUsesBuildkiteDefaultsWithoutMise(t *testing.T) {
 	if err := yaml.Unmarshal(output, &document); err != nil {
 		t.Fatal(err)
 	}
-	if len(document.Steps) != 1 || !slices.Equal(document.Steps[0].Cache.Paths, []string{"/home/runner/.cache"}) || document.Steps[0].Cache.Name != "" || document.Steps[0].Cache.Size != "" || strings.Contains(string(output), "BUILDKITE_GHA_MISE_DATA_DIR") {
+	wantPaths := []string{"/home/runner/.cache", platformCacheValidationPath("linux/amd64")}
+	if len(document.Steps) != 1 || !slices.Equal(document.Steps[0].Cache.Paths, wantPaths) || document.Steps[0].Cache.Name != "" || document.Steps[0].Cache.Size != "" || strings.Contains(string(output), "BUILDKITE_GHA_MISE_DATA_DIR") {
 		t.Fatalf("configured cache did not preserve Buildkite defaults:\n%s", output)
 	}
-	if !strings.Contains(string(output), "readlink -f -- '/home/runner/.cache'") {
+	if !strings.Contains(string(output), "readlink -f -- '"+platformCacheValidationPath("linux/amd64")+"'") || !strings.Contains(string(output), "readlink -f -- '/home/runner/.cache'") {
 		t.Fatalf("cache path is not made writable by runner:\n%s", output)
 	}
 }

--- a/internal/cli/plugin_test.go
+++ b/internal/cli/plugin_test.go
@@ -307,8 +307,9 @@ func TestPluginUsesJSONConfigurationAndOnlyRequiredRuntime(t *testing.T) {
 	if len(pipeline.Steps) != 1 {
 		t.Fatalf("workflow groups = %#v", pipeline.Steps)
 	}
+	wantCachePaths := []string{"/home/runner/.gradle/caches", "/home/runner/.gradle/wrapper", "/cache/bkcache/buildkite-gha/validation/linux-amd64"}
 	for _, step := range pipeline.Steps[0].Steps {
-		if step.Agents["queue"] != "hosted" || step.Image != defaultNobleRunnerImage || !slices.Equal(step.Cache.Paths, []string{"/home/runner/.gradle/caches", "/home/runner/.gradle/wrapper"}) || step.Cache.Name != "gradle-cache" || step.Cache.Size != "40g" || !strings.Contains(step.Command, "--hosted-tool-cache") || !strings.Contains(step.Command, "useradd --create-home") || !strings.Contains(step.Command, "chown -R runner") || !strings.Contains(step.Command, "sudo -n --preserve-env --user runner") {
+		if step.Agents["queue"] != "hosted" || step.Image != defaultNobleRunnerImage || !slices.Equal(step.Cache.Paths, wantCachePaths) || step.Cache.Name != "gradle-cache" || step.Cache.Size != "40g" || !strings.Contains(step.Command, "--hosted-tool-cache") || !strings.Contains(step.Command, "useradd --create-home") || !strings.Contains(step.Command, "chown -R runner") || !strings.Contains(step.Command, "sudo -n --preserve-env --user runner") {
 			t.Fatalf("plugin profile was not applied: %#v", step)
 		}
 	}


### PR DESCRIPTION
## Why

[PR #392](https://github.com/buildkite/buildkite-gha/pull/392) assumed `/cache/bkcache` was the mounted cache-volume root. The live v0.35.1 proof in [buildkite-gha-benchmarks build #68](https://buildkite.com/buildkite/buildkite-gha-benchmarks/builds/68) disproved that: Hosted mounted `/dev/vdi` directly at the two configured Gradle paths and the managed mise path, while `/cache/bkcache` itself was not a mountpoint. Bootstrap therefore failed before `run-job`.

## What

Use a compiler-owned exact cache path as the filesystem anchor. Jobs that need mise use the managed mise path already added to the volume. Configured-only Linux runner-user jobs add a private validation path to the same volume.

The anchor must be a direct mountpoint, or a descendant of a verified legacy `/cache/bkcache` mount. Each configured path must be an available directory on the anchor's filesystem device and either an exact mountpoint or a descendant of that verified legacy root. This accepts Hosted's per-path direct mounts while rejecting ordinary directories, unrelated mounts, unavailable paths, and the entire cache root. `BUILDKITE_AGENT_CACHE_PATHS` is not authority, and recursive ownership remains limited to configured targets.

Checks passed:

- `go test ./internal/buildkite ./internal/cli`
- `mise run check`
- `git diff --check`

This requires another patch release followed by the same live benchmark proof. This PR does not release or run that proof.