### PR TITLE
Distinguish failing workflow steps from compatibility gaps in job telemetry

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -523,6 +523,12 @@ For an unsuccessful command, they also contain the final 1,024 bytes of
 normalized user-visible error output. `error_message_truncated` says whether
 earlier output was omitted.
 
+Failed runs also carry a failure phase and a code from a fixed set. The code
+separates workflow-authored process exits (`E_STEP_PROCESS_EXIT`) from
+unsupported-feature rejections (`E_UNSUPPORTED_FEATURE`) and runtime integrity
+failures (`E_RUNTIME_INTEGRITY`), so a failing test suite is not counted as a
+compatibility gap.
+
 Buildkite adds organization, pipeline, build, and job identifiers on the
 server. The client does not send workflow or event content, environment
 variables, command text, or secrets as separate properties.

--- a/internal/cli/run_job.go
+++ b/internal/cli/run_job.go
@@ -113,6 +113,8 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 		return 1
 	}
 	if err := gharuntime.ValidateHost(job, runtime.GOOS, runtime.GOARCH); err != nil {
+		details.setFailurePhase(telemetry.FailurePhaseExecution)
+		details.setFailureCode(runtimeFailureCode(err))
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: %v\n", err)
 		return 1
 	}

--- a/internal/cli/run_job.go
+++ b/internal/cli/run_job.go
@@ -292,6 +292,7 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 		failureVisible = result.FailureVisible()
 		if runErr != nil {
 			details.setFailurePhase(telemetry.FailurePhaseExecution)
+			details.setFailureCode(runtimeFailureCode(runErr))
 		}
 	}
 	if result.Conclusion == "" {
@@ -345,6 +346,22 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 		return 1
 	}
 	return 0
+}
+
+// runtimeFailureCode attributes a RunJob error so ordinary workflow failures,
+// such as a test command exiting nonzero, are not counted as compatibility
+// gaps. Unattributed errors return "" and keep the unknown failure code.
+func runtimeFailureCode(err error) telemetry.FailureCode {
+	switch gharuntime.ClassifyFailure(err) {
+	case gharuntime.FailureClassStepProcessExit:
+		return telemetry.FailureCodeStepProcessExit
+	case gharuntime.FailureClassUnsupportedFeature:
+		return telemetry.FailureCodeUnsupportedFeature
+	case gharuntime.FailureClassIntegrity:
+		return telemetry.FailureCodeRuntimeIntegrity
+	default:
+		return ""
+	}
 }
 
 func hasGitHubActionLocks(locks []plan.ActionLock) bool {

--- a/internal/cli/run_job_test.go
+++ b/internal/cli/run_job_test.go
@@ -732,10 +732,30 @@ func TestRunJobTelemetryClassifiesExecutionFailure(t *testing.T) {
 		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
 	}
 	event := <-events
-	if event.FailurePhase != telemetry.FailurePhaseExecution || event.FailureCode != telemetry.FailureCodeUnknown {
+	if event.FailurePhase != telemetry.FailurePhaseExecution || event.FailureCode != telemetry.FailureCodeStepProcessExit {
 		t.Fatalf("telemetry = %#v", event)
 	}
 	if !strings.Contains(event.ErrorMessage, "exit status 7") {
+		t.Fatalf("telemetry error message = %q", event.ErrorMessage)
+	}
+}
+
+func TestRunJobTelemetryClassifiesUnsupportedShell(t *testing.T) {
+	job := cliRunJobPlan()
+	job.Steps[0].Shell = "pwsh"
+	job.Steps[0].Command = "Get-Location"
+	planPath, planDigest := writeCLIJobPlan(t, job)
+	setCLIJobIdentity(t, job, planDigest)
+	events := captureCommandTelemetry(t)
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"run-job", "--plan", planPath}, &stdout, &stderr, "dev", &cliCaptureRunner{}); code != 1 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	event := <-events
+	if event.FailurePhase != telemetry.FailurePhaseExecution || event.FailureCode != telemetry.FailureCodeUnsupportedFeature {
+		t.Fatalf("telemetry = %#v", event)
+	}
+	if !strings.Contains(event.ErrorMessage, "unsupported in the supported runtime subset") {
 		t.Fatalf("telemetry error message = %q", event.ErrorMessage)
 	}
 }

--- a/internal/cli/run_job_test.go
+++ b/internal/cli/run_job_test.go
@@ -760,6 +760,17 @@ func TestRunJobTelemetryClassifiesUnsupportedShell(t *testing.T) {
 	}
 }
 
+func TestRunJobValidateHostErrorsClassifyAsUnsupported(t *testing.T) {
+	job := plan.Job{RequiredCapabilities: []string{"docker"}}
+	err := gharuntime.ValidateHost(job, "darwin", "arm64")
+	if err == nil {
+		t.Fatal("ValidateHost() = nil, want macOS docker rejection")
+	}
+	if got := runtimeFailureCode(err); got != telemetry.FailureCodeUnsupportedFeature {
+		t.Fatalf("runtimeFailureCode() = %q, want %q for %v", got, telemetry.FailureCodeUnsupportedFeature, err)
+	}
+}
+
 func TestRunJobPublishesBoundedFailureForUnrepresentableOutputs(t *testing.T) {
 	job := cliRunJobPlan()
 	job.Steps[0].Command = `printf 'summary from malformed result\n' >> "$GITHUB_STEP_SUMMARY"`

--- a/internal/cli/telemetry.go
+++ b/internal/cli/telemetry.go
@@ -84,6 +84,12 @@ func (d *commandTelemetryDetails) setFailurePhase(phase telemetry.FailurePhase) 
 	}
 }
 
+func (d *commandTelemetryDetails) setFailureCode(code telemetry.FailureCode) {
+	if d.failureCode == "" && code != "" {
+		d.failureCode = code
+	}
+}
+
 // addReportDiagnostics records a report's diagnostics. Errors a command
 // handles, such as workflows emitted as failing pipeline steps, belong here so
 // they never attribute an unrelated later failure.

--- a/internal/runtime/action_execution.go
+++ b/internal/runtime/action_execution.go
@@ -1348,7 +1348,7 @@ func canonicalRunnerContext(goos, goarch string) (map[string]string, error) {
 	case goos == "darwin" && goarch == "arm64":
 		return map[string]string{"os": "macOS", "arch": "ARM64"}, nil
 	default:
-		return nil, fmt.Errorf("unsupported runner platform %s/%s", goos, goarch)
+		return nil, errUnsupportedf("unsupported runner platform %s/%s", goos, goarch)
 	}
 }
 
@@ -1360,11 +1360,11 @@ func ValidateHost(job plan.Job, goos, goarch string) error {
 	if goos == "darwin" {
 		switch {
 		case job.HasCapability("docker"):
-			return fmt.Errorf("docker capability is unsupported on macOS runners")
+			return errUnsupportedf("docker capability is unsupported on macOS runners")
 		case job.Container != nil:
-			return fmt.Errorf("job containers are unsupported on macOS runners")
+			return errUnsupportedf("job containers are unsupported on macOS runners")
 		case len(job.Services) != 0:
-			return fmt.Errorf("services are unsupported on macOS runners")
+			return errUnsupportedf("services are unsupported on macOS runners")
 		}
 	}
 	return nil
@@ -1925,7 +1925,7 @@ func (r *jobRun) runActionStep(ctx context.Context, processor *commandProcessor,
 		}
 	} else {
 		if !strings.HasPrefix(step.Uses, "./") {
-			return result, fmt.Errorf("remote action %q is unsupported in the supported runtime subset", step.Uses)
+			return result, errUnsupportedf("remote action %q is unsupported in the supported runtime subset", step.Uses)
 		}
 		if err := verifyWorkflow(job, workspace); err != nil {
 			return result, err
@@ -2061,7 +2061,7 @@ func (r *jobRun) runActionStep(ctx context.Context, processor *commandProcessor,
 		return composite, err
 	case metadata.RuntimeDocker:
 		if goruntime.GOOS == "darwin" {
-			return result, fmt.Errorf("docker action %q is unsupported on macOS runners", step.Uses)
+			return result, errUnsupportedf("docker action %q is unsupported on macOS runners", step.Uses)
 		}
 		if !job.HasCapability("docker") {
 			return result, fmt.Errorf("docker action %q requires the plan's docker capability", step.Uses)
@@ -2095,7 +2095,7 @@ func (r *jobRun) runActionStep(ctx context.Context, processor *commandProcessor,
 		result, err := r.runDocker(ctx, processor, dockerAction{Name: actionName(action, step), Path: actionPath, SourceRoot: sourceRoot, SourceDigest: sourceDigest, Image: image, Entrypoint: action.Runs.Entrypoint, Args: dockerArgs, Workspace: workspace, Env: invocationEnv, explicitPATH: explicitPATH})
 		return result, err
 	}
-	return result, fmt.Errorf("action %q uses unsupported runtime %q", step.Uses, actionRuntime)
+	return result, errUnsupportedf("action %q uses unsupported runtime %q", step.Uses, actionRuntime)
 }
 
 func (r *jobRun) runCompositeMetadata(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, actionPath string, action metadata.Metadata, inputs map[string]string, invocationID string, jobEnv, stepEnv, lifecycleEnvOverlay map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations, actionLock *plan.ActionLock, actionStack []string) (Result, error) {
@@ -2384,7 +2384,7 @@ func shellCommand(shell, script string) ([]string, error) {
 	case "sh":
 		return []string{"sh", "-e", "-c", script}, nil
 	default:
-		return nil, fmt.Errorf("shell %q is unsupported in the supported runtime subset", shell)
+		return nil, errUnsupportedf("shell %q is unsupported in the supported runtime subset", shell)
 	}
 }
 
@@ -2455,7 +2455,7 @@ func parseShellTemplate(shell string) ([]string, error) {
 	command := strings.ToLower(filepath.Base(args[0]))
 	switch command {
 	case "pwsh", "pwsh.exe", "cmd", "cmd.exe", "powershell", "powershell.exe", "msys2", "msys2.cmd", "msys2.exe":
-		return nil, fmt.Errorf("shell %q is unsupported in the supported runtime subset", shell)
+		return nil, errUnsupportedf("shell %q is unsupported in the supported runtime subset", shell)
 	}
 	hasPlaceholder := false
 	for _, arg := range args[1:] {

--- a/internal/runtime/failure_class.go
+++ b/internal/runtime/failure_class.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+
+	"github.com/buildkite/buildkite-gha/internal/action/metadata"
 )
 
 // FailureClass attributes a RunJob error for telemetry so ordinary workflow
@@ -31,6 +33,13 @@ const (
 func ClassifyFailure(err error) FailureClass {
 	var unsupported *unsupportedFeatureError
 	if errors.As(err, &unsupported) {
+		return FailureClassUnsupportedFeature
+	}
+	// metadata.Runtime() rejects unsupported runs.using values with its own
+	// typed error; recognize it so those rejections classify without wrapping
+	// at every call site.
+	var unsupportedRuntime *metadata.UnsupportedRuntimeError
+	if errors.As(err, &unsupportedRuntime) {
 		return FailureClassUnsupportedFeature
 	}
 	if isHardJobFailure(err) {

--- a/internal/runtime/failure_class.go
+++ b/internal/runtime/failure_class.go
@@ -1,0 +1,82 @@
+package runtime
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+)
+
+// FailureClass attributes a RunJob error for telemetry so ordinary workflow
+// failures are not counted as compatibility gaps.
+type FailureClass string
+
+const (
+	// FailureClassUnknown covers errors the runtime cannot attribute.
+	FailureClassUnknown FailureClass = "unknown"
+	// FailureClassStepProcessExit means a workflow-authored process ran and
+	// exited nonzero: the job failed, not the compatibility runtime.
+	FailureClassStepProcessExit FailureClass = "step_process_exit"
+	// FailureClassUnsupportedFeature means the supported runtime subset
+	// rejected a feature the workflow asked for.
+	FailureClassUnsupportedFeature FailureClass = "unsupported_feature"
+	// FailureClassIntegrity means a runtime integrity or cleanup verification
+	// failed.
+	FailureClassIntegrity FailureClass = "integrity"
+)
+
+// ClassifyFailure reports the most specific class found in a RunJob error
+// chain. Unsupported features outrank integrity failures, which outrank step
+// process exits, so a compatibility signal is never hidden by an ordinary
+// workflow failure joined into the same error.
+func ClassifyFailure(err error) FailureClass {
+	var unsupported *unsupportedFeatureError
+	if errors.As(err, &unsupported) {
+		return FailureClassUnsupportedFeature
+	}
+	if isHardJobFailure(err) {
+		return FailureClassIntegrity
+	}
+	var exit *stepProcessExitError
+	if errors.As(err, &exit) {
+		return FailureClassStepProcessExit
+	}
+	return FailureClassUnknown
+}
+
+type stepProcessExitError struct {
+	err error
+}
+
+func (e *stepProcessExitError) Error() string { return e.err.Error() }
+func (e *stepProcessExitError) Unwrap() error { return e.err }
+
+// markStepProcessExit marks an error whose chain shows a step payload process
+// exiting nonzero. Errors without an exec.ExitError, such as cancellations and
+// launch failures, pass through unchanged.
+func markStepProcessExit(err error) error {
+	if err == nil {
+		return nil
+	}
+	var exit *exec.ExitError
+	if !errors.As(err, &exit) {
+		return err
+	}
+	var marked *stepProcessExitError
+	if errors.As(err, &marked) {
+		return err
+	}
+	return &stepProcessExitError{err: err}
+}
+
+type unsupportedFeatureError struct {
+	err error
+}
+
+func (e *unsupportedFeatureError) Error() string { return e.err.Error() }
+func (e *unsupportedFeatureError) Unwrap() error { return e.err }
+
+// errUnsupportedf builds a rejection error for a feature outside the supported
+// runtime subset.
+func errUnsupportedf(format string, args ...any) error {
+	return &unsupportedFeatureError{err: fmt.Errorf(format, args...)}
+}

--- a/internal/runtime/failure_class_test.go
+++ b/internal/runtime/failure_class_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"testing"
 
+	"github.com/buildkite/buildkite-gha/internal/action/metadata"
 	"github.com/buildkite/buildkite-gha/internal/plan"
 )
 
@@ -26,6 +27,7 @@ func TestClassifyFailurePrecedence(t *testing.T) {
 		{"wrapped step exit", fmt.Errorf("run-job: %w", stepExit), FailureClassStepProcessExit},
 		{"tolerated step exit", &toleratedJobFailure{err: stepExit}, FailureClassStepProcessExit},
 		{"unsupported", unsupported, FailureClassUnsupportedFeature},
+		{"unsupported runtime", fmt.Errorf("action %q: %w", "./action", &metadata.UnsupportedRuntimeError{Runtime: "future"}), FailureClassUnsupportedFeature},
 		{"integrity", hard, FailureClassIntegrity},
 		{"integrity outranks step exit", errors.Join(stepExit, hard), FailureClassIntegrity},
 		{"unsupported outranks integrity", errors.Join(hard, unsupported), FailureClassUnsupportedFeature},
@@ -79,6 +81,22 @@ func TestRunJobClassifiesUnsupportedShell(t *testing.T) {
 	workflowPath := ".github/workflows/shell.yml"
 	writeFixtureFile(t, workspace, workflowPath, "name: shell\n")
 	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "shell", Kind: "run", Shell: "pwsh", Command: "Get-Location"}})
+	var logs bytes.Buffer
+	result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(t.Context(), job, workspace)
+	if err == nil || result.Conclusion != "failure" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	if got := ClassifyFailure(err); got != FailureClassUnsupportedFeature {
+		t.Fatalf("ClassifyFailure() = %q, want %q for %v", got, FailureClassUnsupportedFeature, err)
+	}
+}
+
+func TestRunJobClassifiesUnsupportedActionRuntime(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/action.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: action\n")
+	writeFixtureFile(t, workspace, "action/action.yml", "name: future\nruns:\n  using: future\n  main: main.js\n")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "future", Kind: "uses", Uses: "./action"}})
 	var logs bytes.Buffer
 	result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(t.Context(), job, workspace)
 	if err == nil || result.Conclusion != "failure" {

--- a/internal/runtime/failure_class_test.go
+++ b/internal/runtime/failure_class_test.go
@@ -1,0 +1,100 @@
+package runtime
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os/exec"
+	"testing"
+
+	"github.com/buildkite/buildkite-gha/internal/plan"
+)
+
+func TestClassifyFailurePrecedence(t *testing.T) {
+	exit := exitError(t)
+	stepExit := markStepProcessExit(fmt.Errorf("step %q: %w", "test", exit))
+	unsupported := errUnsupportedf("shell %q is unsupported in the supported runtime subset", "pwsh")
+	hard := markHardJobFailure(errors.New("owned Docker resources remain after cleanup"))
+	cases := []struct {
+		name string
+		err  error
+		want FailureClass
+	}{
+		{"nil", nil, FailureClassUnknown},
+		{"plain", errors.New("boom"), FailureClassUnknown},
+		{"step exit", stepExit, FailureClassStepProcessExit},
+		{"wrapped step exit", fmt.Errorf("run-job: %w", stepExit), FailureClassStepProcessExit},
+		{"tolerated step exit", &toleratedJobFailure{err: stepExit}, FailureClassStepProcessExit},
+		{"unsupported", unsupported, FailureClassUnsupportedFeature},
+		{"integrity", hard, FailureClassIntegrity},
+		{"integrity outranks step exit", errors.Join(stepExit, hard), FailureClassIntegrity},
+		{"unsupported outranks integrity", errors.Join(hard, unsupported), FailureClassUnsupportedFeature},
+		{"unsupported outranks step exit", errors.Join(stepExit, unsupported), FailureClassUnsupportedFeature},
+	}
+	for _, tc := range cases {
+		if got := ClassifyFailure(tc.err); got != tc.want {
+			t.Errorf("ClassifyFailure(%s) = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestMarkStepProcessExitRequiresExitError(t *testing.T) {
+	if err := markStepProcessExit(nil); err != nil {
+		t.Fatalf("markStepProcessExit(nil) = %v", err)
+	}
+	launch := errors.New("process /bin/missing: executable file not found")
+	if got := markStepProcessExit(launch); got != launch {
+		t.Fatalf("markStepProcessExit(launch failure) = %v, want unchanged", got)
+	}
+	exit := fmt.Errorf("process /bin/sh: %w", exitError(t))
+	marked := markStepProcessExit(exit)
+	if ClassifyFailure(marked) != FailureClassStepProcessExit {
+		t.Fatalf("markStepProcessExit(exit) classify = %q", ClassifyFailure(marked))
+	}
+	if again := markStepProcessExit(marked); again != marked {
+		t.Fatalf("markStepProcessExit is not idempotent: %v", again)
+	}
+	if !errors.As(marked, new(*exec.ExitError)) {
+		t.Fatalf("marked error lost the exit error chain: %v", marked)
+	}
+}
+
+func TestRunJobClassifiesStepProcessExit(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/failing.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: failing\n")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "fail", Kind: "run", Command: "exit 7"}})
+	var logs bytes.Buffer
+	result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(t.Context(), job, workspace)
+	if err == nil || result.Conclusion != "failure" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	if got := ClassifyFailure(err); got != FailureClassStepProcessExit {
+		t.Fatalf("ClassifyFailure() = %q, want %q for %v", got, FailureClassStepProcessExit, err)
+	}
+}
+
+func TestRunJobClassifiesUnsupportedShell(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/shell.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: shell\n")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "shell", Kind: "run", Shell: "pwsh", Command: "Get-Location"}})
+	var logs bytes.Buffer
+	result, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(t.Context(), job, workspace)
+	if err == nil || result.Conclusion != "failure" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	if got := ClassifyFailure(err); got != FailureClassUnsupportedFeature {
+		t.Fatalf("ClassifyFailure() = %q, want %q for %v", got, FailureClassUnsupportedFeature, err)
+	}
+}
+
+func exitError(t *testing.T) *exec.ExitError {
+	t.Helper()
+	err := exec.Command("sh", "-c", "exit 7").Run()
+	var exit *exec.ExitError
+	if !errors.As(err, &exit) {
+		t.Fatalf("sh exit error = %v", err)
+	}
+	return exit
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -503,7 +503,7 @@ func (r *jobRun) runDocker(ctx context.Context, processor *commandProcessor, act
 	ran = true
 	runErr := r.runStreaming(ctx, processor, "", dockerRunEnv, docker, args...)
 	if runErr != nil {
-		runErr = fmt.Errorf("run Docker action %q: %w", action.Name, runErr)
+		runErr = markStepProcessExit(fmt.Errorf("run Docker action %q: %w", action.Name, runErr))
 	}
 	effects, fileErr := files.apply(&result, nil)
 	effects.reportSummaryUploadFailure(processor)
@@ -810,6 +810,7 @@ func (r *jobRun) runProcess(ctx context.Context, processor *commandProcessor, di
 	} else {
 		runErr = r.runStreaming(ctx, processor, dir, env, name, args...)
 	}
+	runErr = markStepProcessExit(runErr)
 	effects, fileErr := files.apply(result, state)
 	effects.reportSummaryUploadFailure(processor)
 	if fileErr == nil && (effects.pathSet || len(effects.paths) > 0) {
@@ -1035,7 +1036,7 @@ func (r *jobRun) discoverNode(ctx context.Context, major int, explicit string) (
 	}
 	tool := nodeTool(major)
 	if tool == "" {
-		return "", fmt.Errorf("unsupported Node runtime major %d", major)
+		return "", errUnsupportedf("unsupported Node runtime major %d", major)
 	}
 	if r.Mise == "" {
 		return "", fmt.Errorf("mise is required to run JavaScript actions; no pinned runtime path was configured")
@@ -1252,7 +1253,7 @@ func pathWithinDirectory(relative string) bool {
 
 func verifyManagedNodeExecutable(ctx context.Context, major int, path, want string) error {
 	if want == "" {
-		return fmt.Errorf("unsupported Node runtime major %d", major)
+		return errUnsupportedf("unsupported Node runtime major %d", major)
 	}
 	file, err := os.Open(path)
 	if err != nil {

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -78,6 +78,9 @@ const (
 	FailureCodePipelineGeneration FailureCode = "E_PIPELINE_GENERATION"
 	FailureCodeEnvironment        FailureCode = "E_ENVIRONMENT"
 	FailureCodeProfile            FailureCode = "E_PROFILE"
+	FailureCodeStepProcessExit    FailureCode = "E_STEP_PROCESS_EXIT"
+	FailureCodeUnsupportedFeature FailureCode = "E_UNSUPPORTED_FEATURE"
+	FailureCodeRuntimeIntegrity   FailureCode = "E_RUNTIME_INTEGRITY"
 )
 
 type Severity string
@@ -253,7 +256,8 @@ func validFailureCode(code FailureCode) bool {
 	case FailureCodeUnknown, FailureCodeWorkflowSyntax, FailureCodeEventInvalid, FailureCodeGraphInvalid,
 		FailureCodeMatrixInvalid, FailureCodeExpressionInvalid, FailureCodeActionDiscovery,
 		FailureCodeActionResolution, FailureCodePlanConstruction, FailureCodePipelineGeneration,
-		FailureCodeEnvironment, FailureCodeProfile:
+		FailureCodeEnvironment, FailureCodeProfile, FailureCodeStepProcessExit,
+		FailureCodeUnsupportedFeature, FailureCodeRuntimeIntegrity:
 		return true
 	default:
 		return false

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -235,6 +235,17 @@ func TestErrorMessageIsNormalizedAndUTF8Bounded(t *testing.T) {
 	}
 }
 
+func TestRuntimeClassificationCodesAreFailureCodesOnly(t *testing.T) {
+	for _, code := range []FailureCode{FailureCodeStepProcessExit, FailureCodeUnsupportedFeature, FailureCodeRuntimeIntegrity} {
+		if !validFailureCode(code) {
+			t.Errorf("validFailureCode(%q) = false", code)
+		}
+		if _, ok := diagnosticSeverity(string(code)); ok {
+			t.Errorf("diagnosticSeverity(%q) accepted a failure-only code as a diagnostic", code)
+		}
+	}
+}
+
 func TestDiagnosticsEnforceSeverityAndDeduplicateByCode(t *testing.T) {
 	errorCodes := []string{
 		string(FailureCodeWorkflowSyntax), string(FailureCodeEventInvalid), string(FailureCodeGraphInvalid),


### PR DESCRIPTION
## Why

Every failed `run-job` reports the same telemetry, so a customer's failing test suite is indistinguishable from a real compatibility gap. Both of these emit `failure_phase=execution, failure_code=unknown` today:

```yaml
- run: make test          # exits 1: the customer's CI failing, not our bug
- run: Get-Location
  shell: pwsh             # rejected by the supported runtime subset: a compatibility gap
```

That makes the `unknown` bucket, which dominates failed `run_job` events, useless for ranking compatibility work.

## What

Failed `run-job` events now carry one of three codes on the existing `failure_code` enum, or stay `unknown`:

| Failure | Before | After |
| --- | --- | --- |
| `run: make test` exits 1 | `unknown` | `E_STEP_PROCESS_EXIT` |
| `shell: pwsh`, unsupported action runtime, macOS docker/services, unsupported Node major | `unknown` | `E_UNSUPPORTED_FEATURE` |
| Runtime integrity and cleanup verification failures | `unknown` | `E_RUNTIME_INTEGRITY` |
| Anything else | `unknown` | `unknown` |

The runtime marks step-payload process exits and supported-subset rejections in the error chain and exports `ClassifyFailure`; `run-job` maps the class to the code. Classification is deliberately conservative: a failure is only attributed to the workflow when its error chain proves a workflow-authored process exited nonzero, so compatibility signals are never hidden in the customer bucket. No new event fields, no workflow content or secrets; codes remain a fixed client-validated set.

Partially addresses [PB-3055](https://linear.app/buildkite/issue/PB-3055) and [PB-3068](https://linear.app/buildkite/issue/PB-3068) without closing either: it separates ordinary step exits from runtime unsupported-feature and integrity failures, but does not add `blocker`/`failure_intent` detail fields, retry-intent signals, or classification at the remaining compile-side rejection sites (unsupported OS, unmapped runner labels).
