### PR TITLE
Compile unknown immutable checkout commits with a warning

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1098,7 +1098,7 @@ An explicit input is accepted only when the exact snapshotted contract declares 
 | `github-server-url` | When declared by the commit: omitted, empty, or `https://github.com`. Otherwise omitted. |
 | `allow-unsafe-pr-checkout` | When declared by the commit: omitted or `false`. Otherwise omitted. |
 
-The `ref` and `commit` outputs are available only for commits whose action manifest declares them. Upstream added both outputs in v4.2.0.
+The `ref` and `commit` outputs are available when the selected exact or fallback contract declares them. Exact contracts follow each commit's action manifest; the v7.0.1 fallback exposes both outputs. Upstream added both outputs in v4.2.0.
 
 The `false` value and omission do not run submodule commands. The `true` value runs native Git for direct children, and `recursive` includes nested children. Relative URLs and `fetch-depth` follow native Git behavior. Public and private GitHub submodules are supported under the job's repository access; external HTTPS submodules are anonymous. `git@github.com:` URLs are rewritten to HTTPS. Other SSH and non-HTTPS transports are unsupported.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1063,15 +1063,17 @@ Pre conditions use the status and action-scoped environment available when prepa
 | v7.0.0 corpus pin | [`9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0`](https://github.com/actions/checkout/tree/9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0) |
 | v7.0.1 | [`3d3c42e5aac5ba805825da76410c181273ba90b1`](https://github.com/actions/checkout/tree/3d3c42e5aac5ba805825da76410c181273ba90b1) |
 
-Mutable refs work only while they resolve to a commit in the frozen snapshots. Every admitted commit uses the native adapter; the upstream JavaScript doesn't run. Each commit retains the inputs, full-history default, and outputs declared by its upstream contract. For example, early v2 commits reject later v2 inputs, and v4.0 and v4.1 commits don't expose the `ref` and `commit` outputs. Commits absent from the snapshots and manifests with unsupported output contracts remain unsupported. Compilation emits `W_CHECKOUT_LEGACY_RELEASE` for v1.2.0 and v2.8.0 to nudge an upgrade to v4 or later.
+Every resolved immutable commit uses the native adapter; the upstream JavaScript doesn't run. Commits in the frozen snapshots retain their exact inputs, full-history default, and outputs. For example, early v2 commits reject later v2 inputs, and v4.0 and v4.1 commits don't expose the `ref` and `commit` outputs.
 
-Maintainers can refresh the frozen refs and per-commit profiles with `go generate ./internal/action/integration`. Regeneration admits only commits reachable from the selected upstream tags and branches at that time; it doesn't blanket-admit future commits.
+An immutable commit absent from the snapshots uses the stable v7.0.1 contract as a compatibility fallback. Compilation emits one `W_CHECKOUT_UNKNOWN_COMMIT_FALLBACK` warning for each distinct unknown commit. This higher-risk fallback can differ from the commit's upstream manifest, but it doesn't widen the native adapter: repository, ref, path, credentials, and every other input still use the restrictions below. Known snapshotted commits never use the fallback. Compilation emits `W_CHECKOUT_LEGACY_RELEASE` for v1.2.0 and v2.8.0 to nudge an upgrade to v4 or later.
+
+Maintainers can refresh the frozen refs and per-commit profiles with `go generate ./internal/action/integration`. Regeneration gives exact profiles only to commits reachable from the selected upstream tags and branches at that time. Other valid resolved SHAs continue to use the fallback.
 
 Buildkite runs v1.2.0 like v1 and v2.8.0 like v2, and warns about their differences from v4 and later. Neither release sets the `ref` or `commit` outputs added in v4.2.0. v1.2.0 also fetches full history by default when `fetch-depth` is omitted. Upgrade only if your workflow needs those outputs or different v1 history behavior. Otherwise, keep the current version.
 
 The adapter checks out a detached commit or static branch from the event repository at the workspace root or a clean nested directory. It uses Buildkite repository-provider Git credentials when the job provides them; otherwise, it fetches anonymously. Credentials are scoped to the Git commands that fetch repository, LFS, or submodule data and are never persisted.
 
-An explicit input is accepted only when the snapshotted manifest for that commit declares it. The following value restrictions then apply:
+An explicit input is accepted only when the exact snapshotted contract declares it, or when the v7.0.1 fallback contract declares it for an unknown commit. The following value restrictions then apply:
 
 | Input | Supported values |
 | --- | --- |

--- a/internal/action/integration/admission_test.go
+++ b/internal/action/integration/admission_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestUnsupportedActionVersionsSeparateGuidanceFromAdmissionDetail(t *testing.T) {
-	commit := strings.Repeat("0", 40)
+	commit := strings.Repeat("z", 40)
 	tests := []struct {
 		name      string
 		reference string

--- a/internal/action/integration/catalog_test.go
+++ b/internal/action/integration/catalog_test.go
@@ -38,7 +38,7 @@ func TestLookupMatchesKnownCanonicalActions(t *testing.T) {
 }
 
 func TestAdmitEnforcesCatalogCommitPolicy(t *testing.T) {
-	invalidCommit := strings.Repeat("0", 40)
+	invalidCommit := strings.Repeat("z", 40)
 	for _, test := range []struct {
 		name     string
 		identity Identity

--- a/internal/action/integration/checkout.go
+++ b/internal/action/integration/checkout.go
@@ -25,6 +25,10 @@ const (
 	CheckoutV6Commit        = "d23441a48e516b6c34aea4fa41551a30e30af803"
 	CheckoutV7InitialCommit = "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
 	CheckoutV7Commit        = "3d3c42e5aac5ba805825da76410c181273ba90b1"
+
+	// CheckoutFallbackContractRelease identifies the stable contract used for
+	// immutable commits absent from the frozen per-commit snapshot.
+	CheckoutFallbackContractRelease = "v7.0.1"
 )
 
 var checkoutCommits = map[string]string{
@@ -97,17 +101,39 @@ func (c checkoutContract) declaresInput(name string) bool {
 	return strings.Contains(","+c.inputs+",", ","+name+",")
 }
 
-// CheckoutSupportsOutputs reports whether the admitted release declares the
-// ref and commit outputs, added upstream in v4.2.0.
-func CheckoutSupportsOutputs(commit string) bool {
-	contract, ok := checkoutCommitContracts[commit]
-	return ok && contract.refOutput && contract.commitOutput
+func checkoutContractForCommit(commit string) (checkoutContract, bool) {
+	contract, exact := checkoutCommitContracts[commit]
+	if exact {
+		return contract, true
+	}
+	if !ValidCheckoutSHA(commit) {
+		return checkoutContract{}, false
+	}
+	return checkoutCommitContracts[CheckoutV7Commit], false
 }
 
-// CheckoutDefaultsToFullHistory reports whether the admitted release fetched
-// full history when fetch-depth was omitted, as v1's runner plugin did.
+// CheckoutUsesFallbackContract reports whether an immutable commit is absent
+// from the frozen snapshot and therefore uses the stable fallback contract.
+func CheckoutUsesFallbackContract(commit string) bool {
+	if !ValidCheckoutSHA(commit) {
+		return false
+	}
+	_, exact := checkoutCommitContracts[commit]
+	return !exact
+}
+
+// CheckoutSupportsOutputs reports whether the selected exact or fallback
+// contract declares the ref and commit outputs, added upstream in v4.2.0.
+func CheckoutSupportsOutputs(commit string) bool {
+	contract, _ := checkoutContractForCommit(commit)
+	return contract.refOutput && contract.commitOutput
+}
+
+// CheckoutDefaultsToFullHistory reports whether the selected exact or fallback
+// contract fetches full history when fetch-depth is omitted.
 func CheckoutDefaultsToFullHistory(commit string) bool {
-	return checkoutCommitContracts[commit].fullHistory
+	contract, _ := checkoutContractForCommit(commit)
+	return contract.fullHistory
 }
 
 // LegacyCheckoutRelease reports the admitted release label for the v1 and v2
@@ -119,15 +145,20 @@ func LegacyCheckoutRelease(commit string) (string, bool) {
 	return "", false
 }
 
-// validateCheckoutCommit admits commits with contracts captured from frozen
-// upstream release and main snapshots. Mutable references are resolved before
-// this check, so changes after the snapshots are rejected until regeneration.
+// validateCheckoutCommit admits immutable commits. Commits captured by the
+// frozen snapshots retain their exact contract; other valid SHAs use the
+// stable fallback contract.
 func validateCheckoutCommit(commit string) error {
-	if _, ok := checkoutCommitContracts[commit]; !ok {
-		supported := append(sortedCheckoutCommits(), "frozen upstream release and main snapshots (main "+checkoutMainSnapshotCommit+")")
-		return versionError("actions/checkout", "native adapter", commit, supported)
+	if !ValidCheckoutSHA(commit) {
+		return versionError("actions/checkout", "native adapter", commit, supportedCheckoutContracts())
 	}
 	return nil
+}
+
+func supportedCheckoutContracts() []string {
+	return append(sortedCheckoutCommits(),
+		"frozen upstream release and main snapshots (main "+checkoutMainSnapshotCommit+")",
+		"other lowercase 40-hex immutable commits via the "+CheckoutFallbackContractRelease+" fallback contract")
 }
 
 func sortedCheckoutCommits() []string {
@@ -142,9 +173,9 @@ func sortedCheckoutCommits() []string {
 // ValidateCheckoutInputs enforces the release-specific input contract
 // implemented by the tokenless event-repository checkout adapter.
 func ValidateCheckoutInputs(commit string, inputs map[string]string, repository, sha string) error {
-	contract, ok := checkoutCommitContracts[commit]
-	if !ok {
-		return versionError("actions/checkout", "native adapter", commit, append(sortedCheckoutCommits(), "frozen upstream release and main snapshots (main "+checkoutMainSnapshotCommit+")"))
+	contract, exact := checkoutContractForCommit(commit)
+	if !exact && !ValidCheckoutSHA(commit) {
+		return versionError("actions/checkout", "native adapter", commit, supportedCheckoutContracts())
 	}
 	names := sortedNames(inputs)
 	seen := make(map[string]bool, len(names))

--- a/internal/action/integration/checkout_test.go
+++ b/internal/action/integration/checkout_test.go
@@ -22,9 +22,16 @@ func TestCheckoutCommitAdmission(t *testing.T) {
 	if err := validateCheckoutCommit("de0fac2e4500dabe0009e67214ff5f5447ce83dd"); err != nil {
 		t.Fatalf("upstream main commit rejected: %v", err)
 	}
-	for _, commit := range []string{strings.Repeat("0", 40)} {
+	unknown := strings.Repeat("0", 40)
+	if err := validateCheckoutCommit(unknown); err != nil || !CheckoutUsesFallbackContract(unknown) {
+		t.Fatalf("unknown immutable checkout commit fallback = %v, %t", err, CheckoutUsesFallbackContract(unknown))
+	}
+	if CheckoutUsesFallbackContract(CheckoutV7Commit) {
+		t.Fatal("snapshotted checkout commit uses fallback contract")
+	}
+	for _, commit := range []string{"v8", strings.Repeat("A", 40), strings.Repeat("z", 40)} {
 		if err := validateCheckoutCommit(commit); err == nil || !strings.Contains(err.Error(), "does not admit") || !strings.Contains(err.Error(), CheckoutV7Commit) || !strings.Contains(err.Error(), checkoutMainSnapshotCommit) {
-			t.Fatalf("unrecognized checkout commit %s error = %v", commit, err)
+			t.Fatalf("non-immutable checkout commit %s error = %v", commit, err)
 		}
 	}
 }
@@ -193,6 +200,31 @@ func TestValidateCheckoutInputsUsesPerCommitContract(t *testing.T) {
 			}
 			if !test.wantAccepted && (err == nil || !strings.Contains(err.Error(), "unsupported by this actions/checkout release")) {
 				t.Fatalf("ValidateCheckoutInputs() = %v, want contract rejection", err)
+			}
+		})
+	}
+}
+
+func TestValidateCheckoutInputsUsesBoundedFallbackContract(t *testing.T) {
+	unknown := strings.Repeat("0", 40)
+	repository, sha := "buildkite/buildkite-gha", strings.Repeat("a", 40)
+	if err := ValidateCheckoutInputs(unknown, map[string]string{
+		"repository": "buildkite/buildkite-gha",
+		"ref":        sha,
+		"path":       "sources/app",
+		"filter":     "blob:none",
+	}, repository, sha); err != nil {
+		t.Fatalf("fallback contract rejected bounded current inputs: %v", err)
+	}
+	for name, inputs := range map[string]map[string]string{
+		"token":               {"token": ""},
+		"foreign repository":  {"repository": "other/repository"},
+		"unsafe path":         {"path": "../outside"},
+		"persist credentials": {"persist-credentials": "true"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := ValidateCheckoutInputs(unknown, inputs, repository, sha); err == nil || !strings.Contains(err.Error(), "unsupported") {
+				t.Fatalf("fallback contract accepted %#v: %v", inputs, err)
 			}
 		})
 	}

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -1265,6 +1265,14 @@ func TestCheckoutAdapterInputBoundary(t *testing.T) {
 	if _, err := compile(actionintegration.CheckoutV1Commit, "        with:\n          persist-credentials: false\n"); err == nil || !strings.Contains(err.Error(), "explicit input \"persist-credentials\" is unsupported by this actions/checkout release") {
 		t.Fatalf("v1.2.0 later-contract input error = %v", err)
 	}
+
+	unknown := strings.Repeat("0", 40)
+	if _, err := compile(unknown, "        with:\n          path: sources/app\n          filter: blob:none\n"); err != nil {
+		t.Fatalf("unknown checkout fallback inputs: %v", err)
+	}
+	if _, err := compile(unknown, "        with:\n          path: ../outside\n"); err == nil || !strings.Contains(err.Error(), "checkout adapter") {
+		t.Fatalf("unknown checkout fallback path error = %v", err)
+	}
 }
 
 func TestCheckoutAdapterCommitBoundary(t *testing.T) {
@@ -1298,8 +1306,8 @@ func TestCheckoutAdapterCommitBoundary(t *testing.T) {
 	unknown := strings.Repeat("0", 40)
 	writeAction(t, remote, "", checkoutTestManifest(unknown))
 	actionSource := &fakeActionSource{root: remote, commit: unknown, calls: map[string]int{}}
-	if _, _, _, _, err := compileActionLocks(t.Context(), workspace, actionSource, []string{"actions/checkout@v7"}); err == nil || !strings.Contains(err.Error(), "does not admit") {
-		t.Fatalf("unknown checkout commit error = %v", err)
+	if _, locks, _, _, err := compileActionLocks(t.Context(), workspace, actionSource, []string{"actions/checkout@v7"}); err != nil || len(locks) != 1 || locks[0].Commit != unknown {
+		t.Fatalf("unknown checkout fallback locks = %#v, error = %v", locks, err)
 	}
 }
 
@@ -1398,6 +1406,47 @@ func TestCompileBundleLegacyCheckoutWarning(t *testing.T) {
 	bundle = compile("      - uses: actions/checkout@" + actionintegration.CheckoutV4Commit + "\n")
 	if len(bundle.IR.Warnings) != 0 {
 		t.Fatalf("warnings = %#v, want none", bundle.IR.Warnings)
+	}
+}
+
+func TestCompileBundleUnknownCheckoutCommitWarningIsDeduplicated(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := filepath.Join(workspace, ".github", "workflows", "checkout.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	unknown := strings.Repeat("0", 40)
+	otherUnknown := strings.Repeat("1", 40)
+	root := t.TempDir()
+	writeAction(t, root, "", checkoutTestManifest(unknown))
+	otherRoot := t.TempDir()
+	writeAction(t, otherRoot, "", checkoutTestManifest(otherUnknown))
+	workflow := []byte("on: push\njobs:\n  checkout:\n    runs-on: ubuntu-latest\n    strategy:\n      matrix:\n        target: [one, two]\n    steps:\n      - uses: actions/checkout@" + unknown + "\n      - uses: actions/checkout@" + unknown + "\n        with:\n          path: again\n      - uses: actions/checkout@" + otherUnknown + "\n        with:\n          path: other\n")
+	if err := os.WriteFile(workflowPath, workflow, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	bundle, err := CompileBundleWithOptions(workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, "importer", Options{
+		EventTrust: EventUntrusted,
+		Runners: RunnerPolicy{
+			Labels:          map[string]string{"ubuntu-latest": "hosted"},
+			UntrustedQueues: []string{"hosted"},
+		},
+		ResolveActions: true,
+		ActionSource:   commitActionSource{roots: map[string]string{unknown: root, otherUnknown: otherRoot}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bundle.Plans) != 2 || len(bundle.IR.Warnings) != 2 {
+		t.Fatalf("plans = %d, warnings = %#v, want one warning per distinct commit across matrix and repeated steps", len(bundle.Plans), bundle.IR.Warnings)
+	}
+	warning := bundle.IR.Warnings[0]
+	if warning.Code != "W_CHECKOUT_UNKNOWN_COMMIT_FALLBACK" || warning.Path != "./.github/workflows/checkout.yml" || warning.Job != "checkout" || warning.Step != 1 || warning.Line == 0 ||
+		!strings.Contains(warning.Message, unknown) || !strings.Contains(warning.Message, actionintegration.CheckoutFallbackContractRelease) || !strings.Contains(warning.Message, "does not run the upstream action JavaScript") {
+		t.Fatalf("unknown checkout fallback warning = %#v", warning)
+	}
+	if bundle.IR.Warnings[1].Code != "W_CHECKOUT_UNKNOWN_COMMIT_FALLBACK" || bundle.IR.Warnings[1].Step != 3 || !strings.Contains(bundle.IR.Warnings[1].Message, otherUnknown) {
+		t.Fatalf("second unknown checkout fallback warning = %#v", bundle.IR.Warnings[1])
 	}
 }
 

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -1448,6 +1448,27 @@ func TestCompileBundleUnknownCheckoutCommitWarningIsDeduplicated(t *testing.T) {
 	if bundle.IR.Warnings[1].Code != "W_CHECKOUT_UNKNOWN_COMMIT_FALLBACK" || bundle.IR.Warnings[1].Step != 3 || !strings.Contains(bundle.IR.Warnings[1].Message, otherUnknown) {
 		t.Fatalf("second unknown checkout fallback warning = %#v", bundle.IR.Warnings[1])
 	}
+
+	writeAction(t, workspace, ".github/actions/wrapper", "runs:\n  using: composite\n  steps:\n    - uses: actions/checkout@"+unknown+"\n")
+	workflow = []byte("on: push\njobs:\n  checkout:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: ./.github/actions/wrapper\n")
+	if err := os.WriteFile(workflowPath, workflow, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	bundle, err = CompileBundleWithOptions(workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, "importer", Options{
+		EventTrust: EventUntrusted,
+		Runners: RunnerPolicy{
+			Labels:          map[string]string{"ubuntu-latest": "hosted"},
+			UntrustedQueues: []string{"hosted"},
+		},
+		ResolveActions: true,
+		ActionSource:   commitActionSource{roots: map[string]string{unknown: root}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bundle.IR.Warnings) != 1 || bundle.IR.Warnings[0].Code != "W_CHECKOUT_UNKNOWN_COMMIT_FALLBACK" || bundle.IR.Warnings[0].Step != 1 || !strings.Contains(bundle.IR.Warnings[0].Message, unknown) {
+		t.Fatalf("nested unknown checkout fallback warnings = %#v", bundle.IR.Warnings)
+	}
 }
 
 func TestCompileBundleLegacyUploadArtifactWarning(t *testing.T) {

--- a/internal/compiler/bundle.go
+++ b/internal/compiler/bundle.go
@@ -109,39 +109,40 @@ func CompileBundlePlansContext(ctx context.Context, path string, source, eventSo
 			if step.Action == nil || stepIndex >= len(ir.Jobs[i].Steps) {
 				continue
 			}
-			lock := locks[step.Action.Lock]
-			descriptor, _ := actionintegration.Lookup(actionintegration.Identity{Source: lock.Source, Repository: lock.Repository, Path: lock.Path})
-			switch descriptor.Adapter {
-			case actionintegration.AdapterCheckoutExactEventSHA:
-				if actionintegration.CheckoutUsesFallbackContract(lock.Commit) {
-					if warnedUnknownCheckout[lock.Commit] {
+			for _, lock := range reachableActionLocks(locks, step.Action.Lock) {
+				descriptor, _ := actionintegration.Lookup(actionintegration.Identity{Source: lock.Source, Repository: lock.Repository, Path: lock.Path})
+				switch descriptor.Adapter {
+				case actionintegration.AdapterCheckoutExactEventSHA:
+					if actionintegration.CheckoutUsesFallbackContract(lock.Commit) {
+						if warnedUnknownCheckout[lock.Commit] {
+							continue
+						}
+						warnedUnknownCheckout[lock.Commit] = true
+						warning := unknownCheckoutCommitWarning(ir.Jobs[i].Steps[stepIndex].Span.Start, lock.Commit)
+						warning.Path = ir.Jobs[i].SourcePath
+						warning.Job = ir.Jobs[i].LogicalJobID
+						warning.Step = stepIndex + 1
+						bundle.IR.Warnings = append(bundle.IR.Warnings, warning)
 						continue
 					}
-					warnedUnknownCheckout[lock.Commit] = true
-					warning := unknownCheckoutCommitWarning(ir.Jobs[i].Steps[stepIndex].Span.Start, lock.Commit)
+					release, legacy := actionintegration.LegacyCheckoutRelease(lock.Commit)
+					if !legacy || warnedLegacyCheckout[release] {
+						continue
+					}
+					warnedLegacyCheckout[release] = true
+					warning := legacyCheckoutWarning(ir.Jobs[i].Steps[stepIndex].Span.Start, release, actionintegration.CheckoutDefaultsToFullHistory(lock.Commit))
 					warning.Path = ir.Jobs[i].SourcePath
 					warning.Job = ir.Jobs[i].LogicalJobID
 					warning.Step = stepIndex + 1
 					bundle.IR.Warnings = append(bundle.IR.Warnings, warning)
-					continue
+				case actionintegration.AdapterUploadArtifactBuildkite:
+					release, legacy := actionintegration.LegacyUploadArtifactRelease(lock.Commit)
+					if !legacy || warnedLegacyUploadArtifact[release] {
+						continue
+					}
+					warnedLegacyUploadArtifact[release] = true
+					bundle.IR.Warnings = append(bundle.IR.Warnings, legacyUploadArtifactWarning(ir.Jobs[i].Steps[stepIndex].Span.Start, release))
 				}
-				release, legacy := actionintegration.LegacyCheckoutRelease(lock.Commit)
-				if !legacy || warnedLegacyCheckout[release] {
-					continue
-				}
-				warnedLegacyCheckout[release] = true
-				warning := legacyCheckoutWarning(ir.Jobs[i].Steps[stepIndex].Span.Start, release, actionintegration.CheckoutDefaultsToFullHistory(lock.Commit))
-				warning.Path = ir.Jobs[i].SourcePath
-				warning.Job = ir.Jobs[i].LogicalJobID
-				warning.Step = stepIndex + 1
-				bundle.IR.Warnings = append(bundle.IR.Warnings, warning)
-			case actionintegration.AdapterUploadArtifactBuildkite:
-				release, legacy := actionintegration.LegacyUploadArtifactRelease(lock.Commit)
-				if !legacy || warnedLegacyUploadArtifact[release] {
-					continue
-				}
-				warnedLegacyUploadArtifact[release] = true
-				bundle.IR.Warnings = append(bundle.IR.Warnings, legacyUploadArtifactWarning(ir.Jobs[i].Steps[stepIndex].Span.Start, release))
 			}
 		}
 	}
@@ -196,6 +197,28 @@ func CompileBundlePlansContext(ctx context.Context, path string, source, eventSo
 	bundle.Plans = artifacts
 	bundle.Processing.PlansConstructed = true
 	return bundle, nil
+}
+
+func reachableActionLocks(locks map[string]plan.ActionLock, root string) []plan.ActionLock {
+	var reachable []plan.ActionLock
+	visited := map[string]bool{}
+	var visit func(string)
+	visit = func(id string) {
+		if visited[id] {
+			return
+		}
+		visited[id] = true
+		lock, ok := locks[id]
+		if !ok {
+			return
+		}
+		reachable = append(reachable, lock)
+		for _, uses := range sortedKeys(lock.Children) {
+			visit(lock.Children[uses].Lock)
+		}
+	}
+	visit(root)
+	return reachable
 }
 
 func jobPermissionsIgnored(workflowPermissions, effectivePermissions map[string]string) bool {

--- a/internal/compiler/bundle.go
+++ b/internal/compiler/bundle.go
@@ -98,6 +98,7 @@ func CompileBundlePlansContext(ctx context.Context, path string, source, eventSo
 		return bundle, processingFinding(StagePlans, CodePlanConstruction, "compatibility", fmt.Errorf("compiler produced %d plans and %d authorizations for %d job instances", len(plans), len(authorizations), len(ir.Jobs)))
 	}
 	warnedLegacyCheckout := map[string]bool{}
+	warnedUnknownCheckout := map[string]bool{}
 	warnedLegacyUploadArtifact := map[string]bool{}
 	for i, job := range plans {
 		locks := make(map[string]plan.ActionLock, len(job.Actions))
@@ -112,6 +113,18 @@ func CompileBundlePlansContext(ctx context.Context, path string, source, eventSo
 			descriptor, _ := actionintegration.Lookup(actionintegration.Identity{Source: lock.Source, Repository: lock.Repository, Path: lock.Path})
 			switch descriptor.Adapter {
 			case actionintegration.AdapterCheckoutExactEventSHA:
+				if actionintegration.CheckoutUsesFallbackContract(lock.Commit) {
+					if warnedUnknownCheckout[lock.Commit] {
+						continue
+					}
+					warnedUnknownCheckout[lock.Commit] = true
+					warning := unknownCheckoutCommitWarning(ir.Jobs[i].Steps[stepIndex].Span.Start, lock.Commit)
+					warning.Path = ir.Jobs[i].SourcePath
+					warning.Job = ir.Jobs[i].LogicalJobID
+					warning.Step = stepIndex + 1
+					bundle.IR.Warnings = append(bundle.IR.Warnings, warning)
+					continue
+				}
 				release, legacy := actionintegration.LegacyCheckoutRelease(lock.Commit)
 				if !legacy || warnedLegacyCheckout[release] {
 					continue

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 
+	actionintegration "github.com/buildkite/buildkite-gha/internal/action/integration"
 	actionsource "github.com/buildkite/buildkite-gha/internal/action/source"
 	buildkitepipeline "github.com/buildkite/buildkite-gha/internal/buildkite"
 	"github.com/buildkite/buildkite-gha/internal/expression"
@@ -474,6 +475,16 @@ func legacyCheckoutWarning(position workflow.Position, release string, defaultsT
 		Line:    position.Line,
 		Column:  position.Column,
 		Message: message,
+	}
+}
+
+func unknownCheckoutCommitWarning(position workflow.Position, commit string) Warning {
+	return Warning{
+		Code:   "W_CHECKOUT_UNKNOWN_COMMIT_FALLBACK",
+		Line:   position.Line,
+		Column: position.Column,
+		Message: fmt.Sprintf("actions/checkout resolved to immutable commit %s, which is absent from the frozen per-commit snapshot. The native adapter is using the supported %s contract instead; it still restricts repository, ref, path, credentials, and other inputs, and does not run the upstream action JavaScript.",
+			commit, actionintegration.CheckoutFallbackContractRelease),
 	}
 }
 

--- a/internal/runtime/checkout_test.go
+++ b/internal/runtime/checkout_test.go
@@ -160,11 +160,18 @@ esac
 
 	job.Actions[0].Commit = strings.Repeat("0", 40)
 	unknownWorkspace := t.TempDir()
-	if _, err := (Runner{Git: git, Actions: materializer}).RunJob(t.Context(), job, unknownWorkspace); err == nil || !strings.Contains(err.Error(), "does not admit") {
-		t.Fatalf("unknown checkout commit error = %v", err)
+	if _, err := (Runner{Git: git, Actions: materializer}).RunJob(t.Context(), job, unknownWorkspace); err != nil {
+		t.Fatalf("unknown checkout fallback error = %v", err)
+	}
+	if err := os.Remove(gitLog); err != nil {
+		t.Fatal(err)
+	}
+	job.Actions[0].Commit = strings.Repeat("z", 40)
+	if _, err := (Runner{Git: git, Actions: materializer}).RunJob(t.Context(), job, t.TempDir()); err == nil || !strings.Contains(err.Error(), "invalid GitHub identity") {
+		t.Fatalf("malformed checkout commit error = %v", err)
 	}
 	if _, err := os.Stat(gitLog); !os.IsNotExist(err) {
-		t.Fatalf("Git ran before unknown checkout commit rejection: %v", err)
+		t.Fatalf("Git ran before malformed checkout commit rejection: %v", err)
 	}
 
 	job.Actions[0].Commit = actionintegration.CheckoutV7Commit
@@ -382,6 +389,7 @@ func TestCheckoutOutputsMatchReleaseContract(t *testing.T) {
 		{name: "v4.1.7 before outputs", commit: "692973e3d937129bcbf40652eb9f2f61becf3332", want: map[string]string{}},
 		{name: "v4.2.0 with outputs", commit: "d632683dd7b4114ad314bca15554477dd762a938", want: map[string]string{"ref": "refs/heads/main", "commit": strings.Repeat("a", 40)}},
 		{name: "current v4", commit: actionintegration.CheckoutV4Commit, want: map[string]string{"ref": "refs/heads/main", "commit": strings.Repeat("a", 40)}},
+		{name: "unknown commit uses fallback outputs", commit: strings.Repeat("0", 40), want: map[string]string{"ref": "refs/heads/main", "commit": strings.Repeat("a", 40)}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			outputs := map[string]string{}
@@ -406,6 +414,7 @@ func TestCheckoutInputsWithReleaseDefaults(t *testing.T) {
 		{name: "v1 keeps explicit depth", commit: actionintegration.CheckoutV1Commit, inputs: map[string]string{"Fetch-Depth": "5"}, want: map[string]string{"Fetch-Depth": "5"}},
 		{name: "v2 keeps shallow default", commit: actionintegration.CheckoutV2Commit, inputs: nil, want: nil},
 		{name: "v4 keeps shallow default", commit: actionintegration.CheckoutV4Commit, inputs: map[string]string{"ref": "main"}, want: map[string]string{"ref": "main"}},
+		{name: "unknown commit uses fallback default", commit: strings.Repeat("0", 40), inputs: nil, want: nil},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			if got := checkoutInputsWithReleaseDefaults(test.commit, test.inputs); !maps.Equal(got, test.want) {
@@ -1750,7 +1759,7 @@ func TestCompositeCheckoutPreservesDynamicRefProvenance(t *testing.T) {
 	}
 }
 
-func TestProviderTokenReadPreflightRejectsAnyUnknownCheckoutCommit(t *testing.T) {
+func TestProviderTokenReadPreflightAcceptsUnknownImmutableCheckoutCommit(t *testing.T) {
 	validID, parentID, unknownID := "a-0000000000000001", "a-0000000000000002", "a-0000000000000003"
 	job := plan.Job{
 		Steps: []plan.Step{
@@ -1763,8 +1772,12 @@ func TestProviderTokenReadPreflightRejectsAnyUnknownCheckoutCommit(t *testing.T)
 			{ID: unknownID, Source: "github", Repository: "actions/checkout", Commit: strings.Repeat("0", 40)},
 		},
 	}
+	if found, err := validateJobCheckoutAdapters(job); err != nil || !found {
+		t.Fatalf("validateJobCheckoutAdapters() = %t, %v, want fallback admission", found, err)
+	}
+	job.Actions[2].Commit = strings.Repeat("z", 40)
 	if found, err := validateJobCheckoutAdapters(job); err == nil || found || !strings.Contains(err.Error(), "does not admit") {
-		t.Fatalf("validateJobCheckoutAdapters() = %t, %v, want unknown commit rejection", found, err)
+		t.Fatalf("validateJobCheckoutAdapters() = %t, %v, want malformed commit rejection", found, err)
 	}
 }
 


### PR DESCRIPTION
## Why

A workflow can pin or resolve `actions/checkout` to a valid immutable SHA that landed after the frozen contract snapshot. Today that checkout fails compilation even though the native adapter does not execute upstream JavaScript:

```yaml
- uses: actions/checkout@<unknown-immutable-sha>
```

This follow-up deliberately accepts more compatibility risk: an unknown commit's real inputs, defaults, or outputs may differ from the fallback contract.

## What

Unknown lowercase 40-hex checkout commits now compile against the latest stable snapshotted contract, v7.0.1. Known snapshot commits keep their exact per-commit contracts.

Compilation emits `W_CHECKOUT_UNKNOWN_COMMIT_FALLBACK` once per distinct resolved SHA, including the selected fallback and the compatibility caveat. The native adapter's security bounds are unchanged: it still limits repository, ref, path, credentials, token handling, and every supported input value, and never runs checkout's JavaScript.

`mise run check` passes in full, including Linux and macOS builds, unit and race tests, vet, vulnerability scanning, local smoke tests, release checks, and Go and shell linting.

Fixes [PB-3102](https://linear.app/buildkite/issue/PB-3102/compile-unknown-immutable-checkout-commits-with-a-bounded-fallback).
