### PR TITLE
Design a bounded fix for composite action GitHub tokens

### DIFF
--- a/docs/plans/expression-authority-planning.md
+++ b/docs/plans/expression-authority-planning.md
@@ -83,7 +83,9 @@ action compilation:
    authorized context but cannot add authority. Only direct `github.token`
    sets the summary bit.
 4. Propagate the bit through the already resolved, depth-bounded action DAG.
-   Attribute authority to the selected root action in plan authorization.
+   Attribute authority to the selected root action in plan authorization, and
+   update diagnostics to describe resolved action metadata rather than claiming
+   every attributed action defaults an input to `github.token`.
 5. Apply the summary only when the event provider is GitHub. Origin remains
    tokenless: provider-guarded references evaluate to empty, while an
    unguarded reference fails at runtime instead of receiving the wrong
@@ -141,6 +143,7 @@ Exceeding this ceiling should stop implementation and trigger design review.
    silently losing the marker.
 8. Hosted validation requires immutable action resolution before claiming this
    compatibility. Existing plan validation, redaction, and backend provenance
-   tests remain green.
+   tests remain green. Compiler and admission diagnostics identify token-bearing
+   resolved action metadata without misreporting it as an input default.
 
 Run targeted compiler and runtime tests, then `mise run check`.

--- a/docs/plans/expression-authority-planning.md
+++ b/docs/plans/expression-authority-planning.md
@@ -126,9 +126,9 @@ Exceeding this ceiling should stop implementation and trigger design review.
    `DEFAULT_GITHUB_TOKEN` successfully.
 2. Explicit `fallback: cargo-install` and `if: false` still grant. Tests name
    these as intentional conservative over-authorization.
-3. The same action on Origin compiles without token authority. Its provider-
-   guarded token expression evaluates to empty; an unguarded expression fails
-   without calling a token provider.
+3. The same unguarded action fixture on Origin compiles without token authority
+   and fails at runtime without calling a token provider. A separate fixture
+   guarded by `github.server_url == 'https://github.com'` evaluates to empty.
 4. Existing effective input-default cases remain exact: an explicit input
    suppresses its default, ordered defaults work, and the GitHub provider guard
    stays tokenless on Origin.

--- a/docs/plans/expression-authority-planning.md
+++ b/docs/plans/expression-authority-planning.md
@@ -1,243 +1,146 @@
-# Expression authority planning
+# Composite action token authority
 
 ## Problem
 
-The compiler and runtime do not use one representation of expression-bearing
-execution. The compiler inventories workflow fields in
-`requiredSecrets`, inspects action metadata in `inspectInvocation`, and
-reconstructs enough runtime behavior to decide whether a job can receive
-`github.token`. The runtime reloads action metadata and independently evaluates
-input defaults, lifecycle conditions, composite steps, and outputs.
+At commit `8cc2c8598944076af96ea45e3700725beb172ae5`,
+`taiki-e/install-action@v2` contains this composite run-step environment value:
 
-This makes credential planning depend on duplicated knowledge of:
-
-- every expression-bearing field
-- each field's expression surface and provenance
-- ordered input resolution
-- lazy operator and function semantics
-- action preparation, main, and post ordering
-
-[PR #339](https://github.com/buildkite/buildkite-gha/pull/339) demonstrates the
-cost. Supporting `github.token` in composite metadata required separate
-reachability logic for inputs, conditions, pure functions, nested actions, and
-preparation. Review repeatedly found cases where planning and execution reached
-different branches or fields.
-
-The security contract requires conservative but precise planning. A known-false
-or provider-inapplicable branch must not grant token authority. A branch that
-depends on an unknown runtime value may grant it. Composite metadata cannot
-grant ordinary secret authority, and whole-context `github` serialization has
-different authority rules from direct `github.token` access.
-
-## Proposed approach
-
-Use one expression semantic core and one normalized execution program for both
-planning and runtime.
-
-### Abstract expression evaluation
-
-Extend the existing semantic evaluator with an abstract value domain:
-
-```go
-type AbstractValue struct {
-	Known bool
-	Value any
-}
-
-type Analysis struct {
-	Value   AbstractValue
-	Effects Effects
-}
-
-type Validation struct {
-	SecretReferences []string
-}
+```yaml
+inputs:
+  fallback:
+    default: cargo-binstall
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        DEFAULT_GITHUB_TOKEN: ${{ inputs.fallback == 'cargo-binstall' && github.token || '' }}
+      run: bash --noprofile --norc "${GITHUB_ACTION_PATH:?}/main.sh"
+      if: runner.os != 'Windows'
 ```
 
-Concrete and abstract evaluation share expression-tree traversal, operator
-semantics, coercion, and function argument selection. Abstract context values
-are either known or unknown. Unknown branches join their possible effects;
-known short-circuits discard effects from branches runtime cannot evaluate.
-Implement these as explicit concrete and abstract domains behind the shared
-traversal, not by passing unknown sentinel values through concrete `any` value
-helpers.
+The minimal workflow supplies only the required `tool` input:
 
-Reachable authority effects retain provenance. At minimum, distinguish:
-
-- direct `github.token`
-- workflow-authored `toJSON(github)`
-- composite-authored `toJSON(github)`
-
-Validation remains an exhaustive pass over every AST branch. Unsupported
-syntax and prohibited authority must fail even when concrete or abstract
-evaluation would skip the branch. It also inventories statically named ordinary
-secrets independently of reachable effects. `Unknown` means a valid runtime
-dependency, not an evaluation or validation failure.
-
-Keep ordinary secret behavior unchanged during this migration. Validation
-inventories statically named workflow secrets even when a known branch skips
-their expressions; authority policy retains all existing filters, including the
-exception for a secret used only by a declared optional action input, which
-resolves as empty unless required elsewhere. Prohibited composite secret
-references remain errors in unreachable branches. Reachability only narrows
-effects whose existing contract requires it, including `github.token`. Any
-later change to ordinary-secret reachability needs a separate compatibility and
-security decision.
-
-The abstract domain must satisfy both soundness and useful precision:
-
-```text
-concrete effects ⊆ abstract effects
-fully known abstract effects = concrete effects
-effects(refined context) ⊆ effects(less-known context)
+```yaml
+permissions:
+  contents: read
+jobs:
+  repro:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
 ```
 
-The first property prevents missed authority. The other two prevent an
-implementation that always requests every credential from satisfying the
-soundness check while violating known-false and provider guard boundaries.
+Hosted validation resolves and admits this workflow on current `origin/main`,
+but the plan has no `github_token` or `provider-token-write` capability.
+`inspectInvocation` inspects workflow-authored `with` values, effective action
+input defaults, and nested `uses` inputs. It does not inspect a composite run
+step's `env`. Runtime later evaluates that field and fails because
+`github.token` is unavailable.
 
-### Normalized execution program
+The fix must preserve these boundaries:
 
-After reusable-workflow expansion and action resolution, lower each job and its
-resolved action graph into an immutable execution program. Keep the parsed
-workflow model as source-oriented compiler input. The normalized program owns
-runtime expression sites and their control flow.
+- The plan requests token authority before runtime; runtime metadata cannot
+  mint unplanned credentials.
+- Top-level workflow permissions and backend provenance policy remain the
+  authority ceiling. The token stays job-bound and non-ambient.
+- Action metadata can already request token authority through an effective
+  input default. It still cannot request ordinary Buildkite secrets.
+- Origin jobs do not request a GitHub token. A GitHub-only provider guard can
+  evaluate to empty without one.
+- Unsupported expressions, empty effective permissions, unresolved hosted
+  actions, and invalid plans fail closed.
 
-Each expression site records:
+PRs #375 and #388 are failed experiments, not implementation sources. Their
+main lesson is negative: reproducing expression reachability and action
+lifecycle execution in the compiler creates a second runtime.
 
-- source expression or template
-- fixed expression surface
-- expected result type
-- workflow or action-metadata provenance
-- source location for diagnostics
+## Options
 
-Represent lifecycle behavior structurally rather than attaching phase labels
-to a flat field list. The program needs operations equivalent to:
+| Option | Approach | Tradeoff |
+| --- | --- | --- |
+| 1. Grant every resolved action | On a GitHub event, any job containing a resolved, non-native action receives token authority. | About 20 production lines and no metadata semantics, but grossly over-authorizes tokenless JavaScript, Docker, and composite actions. A mutable action ref can begin receiving the job token without even declaring a token expression. Reject. |
+| 2. Summarize direct metadata references | While building the immutable action graph, mark each action that contains a direct `github.token` reference in a runtime-evaluated metadata field. Propagate the bit from nested actions to each selected root. On GitHub events, a marked root requests normal job token authority. | Deliberately over-authorizes known-false steps, non-selected input branches, and unreachable nested actions, but only when resolved metadata already contains a direct token access. It avoids condition, input, and lifecycle simulation. Recommend. |
+| 3. Register compatible action releases | Add a capability to the action integration registry for known `taiki-e/install-action` commits. | Small and precise for one audited commit, but every upstream release can regress until registered. It fixes an action, not the compatibility class. Keep only as an emergency fallback. |
+| 4. Derive exact invocation reachability | Evaluate input defaults, caller inputs, step conditions, provider guards, nested preparation, outputs, and lifecycle phases abstractly during compilation. | Least over-authorization in theory, but duplicates runtime behavior and recreates the failure mode this design must avoid. It also exceeds the scope of this compatibility fix. Reject. |
 
-- evaluate a typed or template expression
-- guard a sequence of operations
-- resolve ordered action inputs and defaults
-- invoke an action
-- register a post action
-- enter preparation, main, and post phases
+## Recommendation
 
-The shared program interpreter has two adapters:
+Implement option 2 as a conservative capability summary owned by resolved
+action compilation:
 
-- the planning adapter supplies abstract context values and collects authority
-- the runtime adapter supplies concrete values and performs action or command
-  execution
+1. Inspect only metadata fields that runtime can evaluate with direct
+   `github.token`: composite step `run`, `env`, `with`, and
+   `working-directory`; composite outputs; and supported `runs.env` fields.
+   Reuse the existing expression parser and direct-reference validation. Do
+   not interpret `if`, `&&`, `||`, `case()`, status, or lifecycle ordering.
+2. Exclude action input defaults from the new summary. Keep the existing
+   effective-default path, including explicit overrides, ordered defaults,
+   `job.check_run_id`, and `github.server_url` narrowing.
+3. Preserve the composite `toJSON(github)` rule: it can consume an already
+   authorized context but cannot add authority. Only direct `github.token`
+   sets the summary bit.
+4. Propagate the bit through the already resolved, depth-bounded action DAG.
+   Attribute authority to the selected root action in plan authorization.
+5. Apply the summary only when the event provider is GitHub. Origin remains
+   tokenless: provider-guarded references evaluate to empty, while an
+   unguarded reference fails at runtime instead of receiving the wrong
+   provider's credential.
 
-This keeps lifecycle ordering in one module while allowing planning and runtime
-to perform different effects at its seams.
+This changes precision, not the authority ceiling. A false positive can mint a
+token that runtime does not use, and because authority is job-wide another
+action in the same job can consume it. However, the marked resolved action
+already contains metadata capable of consuming that same token, and token
+issuance still requires effective workflow permissions, default-off Buildkite
+configuration, and backend admission. The conservative false positives are:
 
-Commands and workflow-command mutations are not predictable during planning.
-The planning adapter treats their outputs, environment changes, and state as
-unknown, then joins later authority conservatively. The operation graph remains
-finite and retains the existing workflow, job, step, and nested-action limits.
+- `fallback: cargo-install` still grants for `taiki-e/install-action@v2`.
+- A known-false composite step still grants.
+- A provider guard still grants on GitHub, even when another known operand is
+  false.
+- A token-bearing nested composite still grants when its invocation is
+  runtime-unreachable.
 
-Resolved action programs are stored by action lock ID in the job plan. Source
-locks continue to bind repositories, commits, paths, and tree digests. Runtime
-continues to verify source content and executable entrypoints, but does not
-reload metadata to derive a second execution model. Plan validation requires
-every action program and child invocation to reference an existing lock, and
-the encoded program remains covered by the job-plan digest.
+These are explicit compatibility tradeoffs. Do not add exceptions to recover
+precision; an exception is the start of another lifecycle evaluator.
 
-Reusable workflows continue to flatten before plan construction. Their
-expanded jobs then use the same normalization path as direct jobs, eliminating
-separate authority treatment for called-workflow fields.
+## Expected diff ceiling
 
-## Scope
+For the implementation change after this design note:
 
-This work centralizes expression reachability, field ownership, and action
-lifecycle ordering. It does not:
+- At most 120 production lines in action metadata/compiler ownership.
+- At most 250 test and documentation lines.
+- At most 400 changed lines total, excluding a copied upstream metadata
+  fixture if one is necessary.
+- No plan schema, runtime, expression evaluator, or backend API changes.
 
-- broaden supported expression syntax or contexts
-- change workflow-token permission policy
-- allow dynamic or whole-context secret access
-- make private actions or reusable workflows available
-- replace immutable source verification
-- use runtime-only token minting as an authorization decision
+Exceeding this ceiling should stop implementation and trigger design review.
 
-On-demand token resolution may later avoid minting an authorized but unused
-token. It cannot replace plan-level authority, capability, or permission
-decisions.
+## Acceptance tests
 
-## Delivery slices
+1. A minimal resolved fixture matching `taiki-e/install-action@v2` compiles a
+   GitHub job with `github_token`, `provider-token-write`, `contents: read`, and
+   root-action authorization attribution. Runtime evaluates
+   `DEFAULT_GITHUB_TOKEN` successfully.
+2. Explicit `fallback: cargo-install` and `if: false` still grant. Tests name
+   these as intentional conservative over-authorization.
+3. The same action on Origin compiles without token authority. Its provider-
+   guarded token expression evaluates to empty; an unguarded expression fails
+   without calling a token provider.
+4. Existing effective input-default cases remain exact: an explicit input
+   suppresses its default, ordered defaults work, and the GitHub provider guard
+   stays tokenless on Origin.
+5. A root composite inherits the marker from a nested token-bearing composite.
+   A graph without a direct token reference remains tokenless.
+6. Composite `toJSON(github)` alone remains tokenless. Composite ordinary
+   secret references remain rejected and never add secret authority.
+7. A token-bearing action with empty effective permissions fails compilation.
+   Invalid or unsupported metadata expressions fail validation rather than
+   silently losing the marker.
+8. Hosted validation requires immutable action resolution before claiming this
+   compatibility. Existing plan validation, redaction, and backend provenance
+   tests remain green.
 
-### 1. Share concrete and abstract expression semantics
-
-Add the abstract value and effect domain under `internal/expression`. Run it
-through the existing semantic evaluator's traversal and pure-function
-implementation. Preserve all exported evaluation behavior and diagnostics.
-
-Move token reachability and known-condition cases onto abstract evaluation.
-Keep existing compiler field inventories temporarily. Delete replaced
-token-specific AST recursion once expression and compiler tests pass unchanged.
-
-This slice is a behavior-preserving architectural refactor. It removes one
-source of semantic drift but does not claim complete field coverage.
-
-### 2. Normalize workflow execution fields
-
-Add the normalized program model and lower expanded `JobInstance` values into
-it before plan authorization. Include job and step conditions, defaults,
-environment, outputs, services, containers, typed controls, and action
-invocations.
-
-Use test-only differential fixtures to compare legacy runtime results with the
-program runtime adapter. Do not add production fallback between representations.
-
-### 3. Normalize resolved actions
-
-Lower action input declarations, ordered defaults, lifecycle conditions,
-composite steps, outputs, and child selectors into action programs keyed by
-lock ID. Model preparation separately from main-step reachability, including
-environment evaluation before JavaScript `pre-if`, composite child preparation,
-conditional post registration, and reverse post execution.
-
-Derive action authority by abstractly executing this program. Runtime executes
-the same program with the concrete adapter.
-
-### 4. Cut over the plan contract
-
-Bump the plan schema and require normalized execution programs. Reject plans
-that combine normalized authority data with legacy raw execution fields.
-
-Delete:
-
-- `requiredSecrets` field enumeration
-- `inspectInvocation` lifecycle simulation
-- token-specific reachability walkers
-- runtime action-metadata interpretation
-
-Keep source digest and entrypoint verification independent of the normalized
-metadata contract.
-
-## Verification
-
-Test the expression module through its concrete and abstract interfaces:
-
-- property and fuzz tests for `concrete effects ⊆ abstract effects`
-- exact effect equality for fully known contexts
-- monotonic effect narrowing as unknown values become known
-- known, unknown, and unavailable context values
-- `&&`, `||`, `case()`, and pure-function argument laziness
-- direct token and whole-context provenance
-- exhaustive validation of unreachable prohibited references
-
-Test the normalized program through both adapters:
-
-- every supported workflow expression surface
-- GitHub and Origin provider guards
-- ordered defaults and forwarded inputs
-- nested composite preparation, main, output, and post behavior
-- reusable-workflow expansion and deferred inputs
-- tokenless jobs and authorized-but-runtime-skipped token paths
-- plan encoding, validation, and action source verification
-
-Run `mise run check` for every slice. Run the GitHub-hosted expression
-differential oracle when expression semantics change.
-
-The architectural acceptance test is that adding an expression-bearing
-operation defines its surface and execution position once. Planning and runtime
-must inherit it without adding another field-specific authority scanner.
+Run targeted compiler and runtime tests, then `mise run check`.


### PR DESCRIPTION
## Why

`taiki-e/install-action@v2` evaluates a token from a composite run step:

```yaml
env:
  DEFAULT_GITHUB_TOKEN: ${{ inputs.fallback == 'cargo-binstall' && github.token || '' }}
```

The compiler resolves and admits the action without token authority, so runtime evaluation fails. Two earlier attempts to model exact expression and lifecycle reachability became too complex and repeatedly drifted from runtime behavior.

## What

Replace the broad expression-authority plan with a bounded design: summarize direct `github.token` references at the immutable resolved-action boundary and conservatively propagate that capability through nested composites.

The plan documents the intentional over-authorization tradeoff, preserves provider and ordinary-secret boundaries, rejects action-specific exceptions and duplicate lifecycle evaluation, caps the expected implementation diff, and defines acceptance tests before coding begins.
