### PR TITLE
Compile unknown upload-artifact commits with a warning

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1161,7 +1161,9 @@ Alternate repositories, tags, non-event dynamic commits, GitHub Enterprise Serve
 | v6.0.0 | [`b7c566a772e6b6bfb58ed0dc250532a479d7789f`](https://github.com/actions/upload-artifact/tree/b7c566a772e6b6bfb58ed0dc250532a479d7789f) |
 | v7.0.1 | [`043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`](https://github.com/actions/upload-artifact/tree/043fb46d1a93c77aae656e7c1c64a875d1fc6a0a) |
 
-The v1.0.0, v2.3.1, and v3.2.1 commits match the floating legacy major tags used on github.com. Other legacy commits are unsupported, including v3.2.2, which upstream publishes only as a GitHub Enterprise Server security backport and deprecates on github.com. Every admitted release accepts only its declared inputs. Compilation emits `W_UPLOAD_ARTIFACT_LEGACY_RELEASE` for v1 through v3 to recommend v4 or later.
+The v1.0.0, v2.3.1, and v3.2.1 commits match the floating legacy major tags used on github.com. Other known legacy commits are unsupported, including v3.2.2, which upstream publishes only as a GitHub Enterprise Server security backport and deprecates on github.com. Every known admitted release accepts only its declared inputs.
+
+An unknown lowercase 40-hex immutable commit uses the stable v7.0.1 contract as a compatibility fallback. Compilation emits one `W_UPLOAD_ARTIFACT_UNKNOWN_COMMIT_FALLBACK` warning for each distinct unknown commit. The fallback can differ from the commit's upstream manifest, but it does not widen the native adapter or execute upstream JavaScript. Malformed commits remain unsupported. Compilation emits `W_UPLOAD_ARTIFACT_LEGACY_RELEASE` for known v1 through v3 commits to recommend v4 or later.
 
 | Input | Supported values |
 | --- | --- |

--- a/internal/action/integration/upload_artifact.go
+++ b/internal/action/integration/upload_artifact.go
@@ -26,6 +26,10 @@ const (
 	UploadArtifactV6Commit = "b7c566a772e6b6bfb58ed0dc250532a479d7789f"
 	UploadArtifactV7Commit = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
 
+	// UploadArtifactFallbackContractRelease identifies the stable contract used
+	// for immutable commits outside the exact admission set.
+	UploadArtifactFallbackContractRelease = "v7.0.1"
+
 	MaxUploadArtifactNameBytes = 255
 	MaxUploadArtifactRoots     = 32
 	MaxUploadArtifactPathBytes = 4096
@@ -65,15 +69,33 @@ func uploadArtifactGeneration(commit string) int {
 	return 4
 }
 
+// UploadArtifactUsesFallbackContract reports whether an immutable commit is
+// outside the exact admission set and therefore uses the stable v7 contract.
+func UploadArtifactUsesFallbackContract(commit string) bool {
+	if !ValidCheckoutSHA(commit) {
+		return false
+	}
+	_, exact := uploadArtifactCommits[commit]
+	return !exact
+}
+
+func uploadArtifactContractCommit(commit string) string {
+	if UploadArtifactUsesFallbackContract(commit) {
+		return UploadArtifactV7Commit
+	}
+	return commit
+}
+
 // UploadArtifactSupportsOutputs reports whether the admitted release declares
 // artifact outputs. Upstream legacy v1 through v3 releases declared none.
 func UploadArtifactSupportsOutputs(commit string) bool {
-	return uploadArtifactGeneration(commit) >= 4
+	return uploadArtifactGeneration(uploadArtifactContractCommit(commit)) >= 4
 }
 
 // UploadArtifactIncludesHiddenByDefault reports whether omission of
 // include-hidden-files retains hidden paths for the admitted release.
 func UploadArtifactIncludesHiddenByDefault(commit string) bool {
+	commit = uploadArtifactContractCommit(commit)
 	return commit == UploadArtifactV1Commit || commit == UploadArtifactV2Commit
 }
 
@@ -87,7 +109,7 @@ func LegacyUploadArtifactRelease(commit string) (string, bool) {
 }
 
 func validateUploadArtifactCommit(commit string) error {
-	if _, ok := uploadArtifactCommits[commit]; !ok {
+	if _, ok := uploadArtifactCommits[commit]; !ok && !ValidCheckoutSHA(commit) {
 		commits := make([]string, 0, len(uploadArtifactCommits))
 		for supported, version := range uploadArtifactCommits {
 			commits = append(commits, version+" ("+supported+")")
@@ -115,7 +137,8 @@ func validateUploadArtifactInputs(commit string, inputs map[string]string, evalu
 	if err := validateUploadArtifactCommit(commit); err != nil {
 		return err
 	}
-	generation := uploadArtifactGeneration(commit)
+	contractCommit := uploadArtifactContractCommit(commit)
+	generation := uploadArtifactGeneration(contractCommit)
 	allowed := map[string]bool{"name": true, "path": true, "if-no-files-found": true, "include-hidden-files": true, "compression-level": true, "overwrite": true, "archive": true, "retention-days": true}
 	seen := map[string]bool{}
 	for _, name := range sortedNames(inputs) {
@@ -127,7 +150,7 @@ func validateUploadArtifactInputs(commit string, inputs map[string]string, evalu
 		if !allowed[lower] {
 			return fmt.Errorf("unknown input %q is unsupported by the bounded upload-artifact adapter", name)
 		}
-		if lower == "archive" && commit != UploadArtifactV7Commit {
+		if lower == "archive" && contractCommit != UploadArtifactV7Commit {
 			return fmt.Errorf("input %q exists only in actions/upload-artifact v7", name)
 		}
 		if uploadArtifactInputIntroduced[lower] > generation {

--- a/internal/action/integration/upload_artifact.go
+++ b/internal/action/integration/upload_artifact.go
@@ -25,6 +25,9 @@ const (
 	UploadArtifactV5Commit = "330a01c490aca151604b8cf639adc76d48f6c5d4"
 	UploadArtifactV6Commit = "b7c566a772e6b6bfb58ed0dc250532a479d7789f"
 	UploadArtifactV7Commit = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
+	// uploadArtifactV322Commit is a GHES-only legacy security backport that
+	// remains outside the github.com native adapter contract.
+	uploadArtifactV322Commit = "c6a366c94c3e0affe28c06c8df20a878f24da3cf"
 
 	// UploadArtifactFallbackContractRelease identifies the stable contract used
 	// for immutable commits outside the exact admission set.
@@ -72,7 +75,7 @@ func uploadArtifactGeneration(commit string) int {
 // UploadArtifactUsesFallbackContract reports whether an immutable commit is
 // outside the exact admission set and therefore uses the stable v7 contract.
 func UploadArtifactUsesFallbackContract(commit string) bool {
-	if !ValidCheckoutSHA(commit) {
+	if !ValidCheckoutSHA(commit) || commit == uploadArtifactV322Commit {
 		return false
 	}
 	_, exact := uploadArtifactCommits[commit]
@@ -109,7 +112,7 @@ func LegacyUploadArtifactRelease(commit string) (string, bool) {
 }
 
 func validateUploadArtifactCommit(commit string) error {
-	if _, ok := uploadArtifactCommits[commit]; !ok && !ValidCheckoutSHA(commit) {
+	if _, ok := uploadArtifactCommits[commit]; !ok && (!ValidCheckoutSHA(commit) || commit == uploadArtifactV322Commit) {
 		commits := make([]string, 0, len(uploadArtifactCommits))
 		for supported, version := range uploadArtifactCommits {
 			commits = append(commits, version+" ("+supported+")")

--- a/internal/action/integration/upload_artifact_test.go
+++ b/internal/action/integration/upload_artifact_test.go
@@ -22,10 +22,10 @@ func TestUploadArtifactCommitContracts(t *testing.T) {
 	if UploadArtifactUsesFallbackContract(UploadArtifactV7Commit) {
 		t.Fatal("known v7 commit uses fallback contract")
 	}
-	for _, commit := range []string{"v7", strings.Repeat("A", 40), strings.Repeat("0", 39)} {
+	for _, commit := range []string{uploadArtifactV322Commit, "v7", strings.Repeat("A", 40), strings.Repeat("0", 39)} {
 		err := validateUploadArtifactCommit(commit)
 		if err == nil {
-			t.Fatalf("malformed commit %s accepted", commit)
+			t.Fatalf("unsupported commit %s accepted", commit)
 		}
 		for _, supported := range commits {
 			if !strings.Contains(err.Error(), supported) {

--- a/internal/action/integration/upload_artifact_test.go
+++ b/internal/action/integration/upload_artifact_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestUploadArtifactCommitsAreExact(t *testing.T) {
+func TestUploadArtifactCommitContracts(t *testing.T) {
 	commits := []string{
 		UploadArtifactV1Commit, UploadArtifactV2Commit, UploadArtifactV3Commit,
 		UploadArtifactCommit, UploadArtifactV5Commit, UploadArtifactV6Commit, UploadArtifactV7Commit,
@@ -15,15 +15,45 @@ func TestUploadArtifactCommitsAreExact(t *testing.T) {
 			t.Fatalf("audited commit %s rejected: %v", commit, err)
 		}
 	}
-	for _, commit := range []string{"bbbca2ddaa5d8feaa63e36b76fdaad77386f024f", strings.Repeat("0", 40)} {
+	unknown := strings.Repeat("0", 40)
+	if err := validateUploadArtifactCommit(unknown); err != nil || !UploadArtifactUsesFallbackContract(unknown) {
+		t.Fatalf("unknown immutable commit fallback = %v, %t", err, UploadArtifactUsesFallbackContract(unknown))
+	}
+	if UploadArtifactUsesFallbackContract(UploadArtifactV7Commit) {
+		t.Fatal("known v7 commit uses fallback contract")
+	}
+	for _, commit := range []string{"v7", strings.Repeat("A", 40), strings.Repeat("0", 39)} {
 		err := validateUploadArtifactCommit(commit)
 		if err == nil {
-			t.Fatalf("unrecognized commit %s accepted", commit)
+			t.Fatalf("malformed commit %s accepted", commit)
 		}
 		for _, supported := range commits {
 			if !strings.Contains(err.Error(), supported) {
 				t.Fatalf("unrecognized commit %s error = %v, want audited commit %s", commit, err, supported)
 			}
+		}
+	}
+}
+
+func TestUploadArtifactFallbackUsesBoundedV7Contract(t *testing.T) {
+	unknown := strings.Repeat("0", 40)
+	if err := ValidateUploadArtifactInputs(unknown, map[string]string{
+		"path": "payload/*.zip", "archive": "true", "include-hidden-files": "false",
+		"compression-level": "0", "overwrite": "false",
+	}); err != nil {
+		t.Fatalf("fallback rejected bounded v7 inputs: %v", err)
+	}
+	if !UploadArtifactSupportsOutputs(unknown) || UploadArtifactIncludesHiddenByDefault(unknown) {
+		t.Fatal("fallback did not use v7 outputs and hidden-file default")
+	}
+	for _, inputs := range []map[string]string{
+		{"path": "../outside"},
+		{"path": "payload", "archive": "false"},
+		{"path": "payload", "overwrite": "true"},
+		{"path": "payload", "future-input": "value"},
+	} {
+		if err := ValidateUploadArtifactInputs(unknown, inputs); err == nil {
+			t.Fatalf("fallback accepted unsafe inputs %#v", inputs)
 		}
 	}
 }

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -1823,6 +1823,9 @@ func TestUploadArtifactAdapterInputAndCommitBoundary(t *testing.T) {
 	if plans, err := compile(strings.Repeat("b", 40), "        with:\n          path: payload\n          archive: true\n"); err != nil || len(plans) != 1 {
 		t.Fatalf("unknown upload-artifact fallback plans = %#v, error = %v", plans, err)
 	}
+	if _, err := compile("c6a366c94c3e0affe28c06c8df20a878f24da3cf", "        with:\n          path: payload\n"); err == nil || !strings.Contains(err.Error(), "does not admit resolved commit") {
+		t.Fatalf("known unsupported upload-artifact commit error = %v", err)
+	}
 
 	matrixWorkflow := []byte("on: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    strategy:\n      matrix:\n        mode: [production, test]\n    steps:\n      - uses: actions/upload-artifact@" + actionintegration.UploadArtifactV6Commit + "\n        if: matrix.mode == 'test'\n        with:\n          name: ${{ github.sha }}\n          path: ./artifacts.tar.gz\n          retention-days: '0'\n")
 	if err := os.WriteFile(workflowPath, matrixWorkflow, 0o644); err != nil {

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -1609,6 +1609,61 @@ func TestCompileBundleLegacyUploadArtifactWarning(t *testing.T) {
 	}
 }
 
+func TestCompileBundleUnknownUploadArtifactWarningIsDeduplicated(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := filepath.Join(workspace, ".github", "workflows", "artifact.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	unknown := strings.Repeat("0", 40)
+	otherUnknown := strings.Repeat("1", 40)
+	roots := map[string]string{}
+	for _, commit := range []string{unknown, otherUnknown} {
+		root := t.TempDir()
+		writeAction(t, root, "", uploadArtifactTestManifest(commit))
+		roots[commit] = root
+	}
+	compile := func(workflow []byte) Bundle {
+		t.Helper()
+		if err := os.WriteFile(workflowPath, workflow, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		bundle, err := CompileBundleWithOptions(workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, "importer", Options{
+			EventTrust: EventUntrusted,
+			Runners: RunnerPolicy{
+				Labels:          map[string]string{"ubuntu-latest": "hosted"},
+				UntrustedQueues: []string{"hosted"},
+			},
+			ResolveActions: true,
+			ActionSource:   commitActionSource{roots: roots},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return bundle
+	}
+	workflow := []byte("on: push\njobs:\n  upload:\n    runs-on: ubuntu-latest\n    strategy:\n      matrix:\n        target: [one, two]\n    steps:\n      - uses: actions/upload-artifact@" + unknown + "\n        with:\n          path: payload\n          archive: true\n      - uses: actions/upload-artifact@" + unknown + "\n        with:\n          path: again\n      - uses: actions/upload-artifact@" + otherUnknown + "\n        with:\n          path: other\n")
+	bundle := compile(workflow)
+	if len(bundle.Plans) != 2 || len(bundle.IR.Warnings) != 2 {
+		t.Fatalf("plans = %d, warnings = %#v, want one warning per distinct commit across matrix and repeated steps", len(bundle.Plans), bundle.IR.Warnings)
+	}
+	warning := bundle.IR.Warnings[0]
+	if warning.Code != "W_UPLOAD_ARTIFACT_UNKNOWN_COMMIT_FALLBACK" || warning.Path != "./.github/workflows/artifact.yml" || warning.Job != "upload" || warning.Step != 1 || warning.Line == 0 ||
+		!strings.Contains(warning.Message, unknown) || !strings.Contains(warning.Message, actionintegration.UploadArtifactFallbackContractRelease) || !strings.Contains(warning.Message, "does not run the upstream action JavaScript") {
+		t.Fatalf("unknown upload-artifact fallback warning = %#v", warning)
+	}
+	if bundle.IR.Warnings[1].Code != "W_UPLOAD_ARTIFACT_UNKNOWN_COMMIT_FALLBACK" || bundle.IR.Warnings[1].Step != 3 || !strings.Contains(bundle.IR.Warnings[1].Message, otherUnknown) {
+		t.Fatalf("second unknown upload-artifact fallback warning = %#v", bundle.IR.Warnings[1])
+	}
+
+	writeAction(t, workspace, ".github/actions/wrapper", "runs:\n  using: composite\n  steps:\n    - uses: actions/upload-artifact@"+unknown+"\n      with:\n        path: payload\n")
+	workflow = []byte("on: push\njobs:\n  upload:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: ./.github/actions/wrapper\n")
+	bundle = compile(workflow)
+	if len(bundle.IR.Warnings) != 1 || bundle.IR.Warnings[0].Code != "W_UPLOAD_ARTIFACT_UNKNOWN_COMMIT_FALLBACK" || bundle.IR.Warnings[0].Step != 1 || !strings.Contains(bundle.IR.Warnings[0].Message, unknown) {
+		t.Fatalf("nested unknown upload-artifact fallback warnings = %#v", bundle.IR.Warnings)
+	}
+}
+
 func TestNativeCheckoutIgnoresUpstreamTokenDefaultForOrigin(t *testing.T) {
 	workspace, remote := t.TempDir(), t.TempDir()
 	workflowPath := filepath.Join(workspace, ".github", "workflows", "checkout.yml")
@@ -1765,8 +1820,8 @@ func TestUploadArtifactAdapterInputAndCommitBoundary(t *testing.T) {
 		})
 	}
 
-	if _, err := compile(strings.Repeat("b", 40), "        with:\n          path: payload\n"); err == nil || !strings.Contains(err.Error(), actionintegration.UploadArtifactV1Commit) || !strings.Contains(err.Error(), actionintegration.UploadArtifactV2Commit) || !strings.Contains(err.Error(), actionintegration.UploadArtifactV3Commit) || !strings.Contains(err.Error(), actionintegration.UploadArtifactCommit) || !strings.Contains(err.Error(), actionintegration.UploadArtifactV5Commit) || !strings.Contains(err.Error(), actionintegration.UploadArtifactV6Commit) || !strings.Contains(err.Error(), actionintegration.UploadArtifactV7Commit) {
-		t.Fatalf("unsupported upload-artifact commit error = %v", err)
+	if plans, err := compile(strings.Repeat("b", 40), "        with:\n          path: payload\n          archive: true\n"); err != nil || len(plans) != 1 {
+		t.Fatalf("unknown upload-artifact fallback plans = %#v, error = %v", plans, err)
 	}
 
 	matrixWorkflow := []byte("on: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    strategy:\n      matrix:\n        mode: [production, test]\n    steps:\n      - uses: actions/upload-artifact@" + actionintegration.UploadArtifactV6Commit + "\n        if: matrix.mode == 'test'\n        with:\n          name: ${{ github.sha }}\n          path: ./artifacts.tar.gz\n          retention-days: '0'\n")

--- a/internal/compiler/bundle.go
+++ b/internal/compiler/bundle.go
@@ -101,6 +101,7 @@ func CompileBundlePlansContext(ctx context.Context, path string, source, eventSo
 	}
 	warnedLegacyCheckout := map[string]bool{}
 	warnedUnknownCheckout := map[string]bool{}
+	warnedUnknownUploadArtifact := map[string]bool{}
 	warnedLegacyUploadArtifact := map[string]bool{}
 	for i, job := range plans {
 		locks := make(map[string]plan.ActionLock, len(job.Actions))
@@ -138,6 +139,18 @@ func CompileBundlePlansContext(ctx context.Context, path string, source, eventSo
 					warning.Step = stepIndex + 1
 					bundle.IR.Warnings = append(bundle.IR.Warnings, warning)
 				case actionintegration.AdapterUploadArtifactBuildkite:
+					if actionintegration.UploadArtifactUsesFallbackContract(lock.Commit) {
+						if warnedUnknownUploadArtifact[lock.Commit] {
+							continue
+						}
+						warnedUnknownUploadArtifact[lock.Commit] = true
+						warning := unknownUploadArtifactCommitWarning(ir.Jobs[i].Steps[stepIndex].Span.Start, lock.Commit)
+						warning.Path = ir.Jobs[i].SourcePath
+						warning.Job = ir.Jobs[i].LogicalJobID
+						warning.Step = stepIndex + 1
+						bundle.IR.Warnings = append(bundle.IR.Warnings, warning)
+						continue
+					}
 					release, legacy := actionintegration.LegacyUploadArtifactRelease(lock.Commit)
 					if !legacy || warnedLegacyUploadArtifact[release] {
 						continue

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -501,6 +501,16 @@ func unknownCheckoutCommitWarning(position workflow.Position, commit string) War
 	}
 }
 
+func unknownUploadArtifactCommitWarning(position workflow.Position, commit string) Warning {
+	return Warning{
+		Code:   "W_UPLOAD_ARTIFACT_UNKNOWN_COMMIT_FALLBACK",
+		Line:   position.Line,
+		Column: position.Column,
+		Message: fmt.Sprintf("actions/upload-artifact resolved to immutable commit %s, which is outside the exact admission set. The native adapter is using the supported %s contract instead; it still restricts names, paths, archive mode, overwrite, hidden files, sizes, and outputs, and does not run the upstream action JavaScript.",
+			commit, actionintegration.UploadArtifactFallbackContractRelease),
+	}
+}
+
 func legacyUploadArtifactWarning(position workflow.Position, release string) Warning {
 	return Warning{
 		Code:    "W_UPLOAD_ARTIFACT_LEGACY_RELEASE",

--- a/internal/runtime/upload_artifact_test.go
+++ b/internal/runtime/upload_artifact_test.go
@@ -102,6 +102,7 @@ func TestUploadArtifactRuntimeVersionMatrix(t *testing.T) {
 		{name: "v5.0.0 defaults", commit: actionintegration.UploadArtifactV5Commit, inputs: map[string]string{"path": "./payload"}, wantOutputs: true},
 		{name: "v6.0.0 defaults", commit: actionintegration.UploadArtifactV6Commit, inputs: map[string]string{"path": "./payload", "retention-days": "0"}, wantOutputs: true},
 		{name: "v7.0.1 ZIP", commit: actionintegration.UploadArtifactV7Commit, inputs: map[string]string{"path": "payload", "archive": " true ", "name": "v7"}, wantOutputs: true},
+		{name: "unknown commit v7 fallback", commit: strings.Repeat("0", 40), inputs: map[string]string{"path": "payload", "archive": "true"}, wantOutputs: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			uploader := &captureArtifactUploader{}
@@ -748,8 +749,14 @@ func TestUploadArtifactAdapterBypassesVerifiedUpstreamLifecycle(t *testing.T) {
 	}
 
 	job.Actions[0].Commit = strings.Repeat("b", 40)
-	if _, err := (Runner{Actions: materializer, Artifacts: &captureArtifactUploader{}}).RunJob(t.Context(), job, workspace); err == nil || !strings.Contains(err.Error(), actionintegration.UploadArtifactCommit) {
-		t.Fatalf("unsupported runtime commit error = %v", err)
+	fallbackResult, err := (Runner{Actions: materializer, Artifacts: &captureArtifactUploader{}}).RunJob(t.Context(), job, workspace)
+	if err != nil || fallbackResult.Conclusion != "success" || fallbackResult.Outputs["artifact_id"] == "" || fallbackResult.Outputs["artifact_digest"] == "" {
+		t.Fatalf("unknown commit fallback result = %#v, error = %v", fallbackResult, err)
+	}
+
+	job.Actions[0].Commit = strings.Repeat("b", 39)
+	if _, err := (Runner{Actions: materializer, Artifacts: &captureArtifactUploader{}}).RunJob(t.Context(), job, workspace); err == nil || !strings.Contains(err.Error(), "invalid GitHub identity") {
+		t.Fatalf("malformed runtime commit error = %v", err)
 	}
 }
 


### PR DESCRIPTION
## Why

A moving or newly pinned `actions/upload-artifact` ref can resolve to a valid immutable SHA outside the exact admission set and fail compilation, even though buildkite-gha replaces the action with its bounded native adapter.

## What

Unknown lowercase 40-hex commits now use the stable v7.0.1 contract and emit one source-located warning per distinct SHA. Known commits retain their release-specific contracts, and malformed identities still fail. Native name, path, archive, overwrite, hidden-file, size, and output bounds remain unchanged; upstream JavaScript never runs.

Closes PB-3112.
