### PR TITLE
Compile unknown download-artifact commits with a warning

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1193,6 +1193,8 @@ For v4.6.2 and later, the adapter sets `artifact-id` and `artifact-digest`; `art
 | v8.0.0 | [`70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3`](https://github.com/actions/download-artifact/tree/70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3) |
 | v8.0.1 | [`3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c`](https://github.com/actions/download-artifact/tree/3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c) |
 
+An unknown lowercase 40-hex immutable commit uses the stable v8.0.1 contract as a compatibility fallback. Compilation emits one `W_DOWNLOAD_ARTIFACT_UNKNOWN_COMMIT_FALLBACK` warning for each distinct unknown commit. The fallback can differ from the commit's upstream manifest, but it does not widen the native adapter or execute upstream JavaScript. Malformed commits remain unsupported.
+
 | Input | Supported values |
 | --- | --- |
 | `name` | Exact name, mutually exclusive with `pattern`; runtime expressions are allowed. |

--- a/internal/action/integration/download_artifact.go
+++ b/internal/action/integration/download_artifact.go
@@ -23,16 +23,25 @@ const (
 	DownloadArtifactV801Commit = "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c"
 	// DownloadArtifactCommit is retained as the original v4.3.0 spelling.
 	DownloadArtifactCommit = DownloadArtifactV4Commit
+	// DownloadArtifactFallbackContractRelease identifies the stable contract
+	// used for immutable commits outside the exact admission set.
+	DownloadArtifactFallbackContractRelease = "v8.0.1"
 
 	MaxDownloadArtifactPatternAlternatives = 8
 	MaxDownloadArtifactPatternBytes        = MaxUploadArtifactNameBytes
 )
 
 func validateDownloadArtifactCommit(commit string) error {
-	if slices.Contains(DownloadArtifactCommits(), commit) {
+	if slices.Contains(DownloadArtifactCommits(), commit) || ValidCheckoutSHA(commit) {
 		return nil
 	}
 	return versionError("actions/download-artifact", "native adapter", commit, DownloadArtifactCommits())
+}
+
+// DownloadArtifactUsesFallbackContract reports whether an immutable commit is
+// outside the exact admission set and therefore uses the stable v8 contract.
+func DownloadArtifactUsesFallbackContract(commit string) bool {
+	return ValidCheckoutSHA(commit) && !slices.Contains(DownloadArtifactCommits(), commit)
 }
 
 // DownloadArtifactCommits returns the complete immutable admission set.
@@ -65,7 +74,7 @@ func validateDownloadArtifactInputs(commit string, inputs map[string]string, all
 		return err
 	}
 	allowed := map[string]bool{"name": true, "pattern": true, "path": true, "merge-multiple": true}
-	if commit == DownloadArtifactV8Commit || commit == DownloadArtifactV801Commit {
+	if commit == DownloadArtifactV8Commit || commit == DownloadArtifactV801Commit || DownloadArtifactUsesFallbackContract(commit) {
 		allowed["skip-decompress"] = true
 		allowed["digest-mismatch"] = true
 	}

--- a/internal/action/integration/download_artifact_test.go
+++ b/internal/action/integration/download_artifact_test.go
@@ -5,14 +5,23 @@ import (
 	"testing"
 )
 
-func TestDownloadArtifactExactContract(t *testing.T) {
+func TestDownloadArtifactContracts(t *testing.T) {
 	for _, commit := range DownloadArtifactCommits() {
 		if err := validateDownloadArtifactCommit(commit); err != nil {
 			t.Fatalf("audited commit %s rejected: %v", commit, err)
 		}
 	}
-	if err := validateDownloadArtifactCommit(strings.Repeat("0", 40)); err == nil {
-		t.Fatal("unrecognized commit accepted")
+	unknown := strings.Repeat("0", 40)
+	if err := validateDownloadArtifactCommit(unknown); err != nil || !DownloadArtifactUsesFallbackContract(unknown) {
+		t.Fatalf("unknown immutable commit fallback = %v, %t", err, DownloadArtifactUsesFallbackContract(unknown))
+	}
+	if DownloadArtifactUsesFallbackContract(DownloadArtifactV801Commit) {
+		t.Fatal("known v8.0.1 commit uses fallback contract")
+	}
+	for _, malformed := range []string{"v8", strings.Repeat("A", 40), strings.Repeat("0", 39)} {
+		if err := validateDownloadArtifactCommit(malformed); err == nil {
+			t.Fatalf("malformed commit %q accepted", malformed)
+		}
 	}
 	for _, commit := range DownloadArtifactCommits() {
 		for _, inputs := range []map[string]string{{"name": "payload"}, {"Name": " payload ", "path": "", "merge-multiple": " False "}, {"name": "${{ github.sha }}", "path": "./out/"}} {
@@ -53,6 +62,25 @@ func TestDownloadArtifactExactContract(t *testing.T) {
 				t.Fatal("unsupported v8 mode accepted")
 			}
 		})
+	}
+}
+
+func TestDownloadArtifactFallbackUsesBoundedV8Contract(t *testing.T) {
+	unknown := strings.Repeat("0", 40)
+	if err := ValidateDownloadArtifactInputs(unknown, map[string]string{
+		"name": "payload", "path": "out", "skip-decompress": "false", "digest-mismatch": "error",
+	}); err != nil {
+		t.Fatalf("fallback rejected bounded v8 inputs: %v", err)
+	}
+	for _, inputs := range []map[string]string{
+		{"name": "payload", "path": "../outside"},
+		{"name": "payload", "skip-decompress": "true"},
+		{"name": "payload", "digest-mismatch": "warn"},
+		{"name": "payload", "github-token": "token"},
+	} {
+		if err := ValidateDownloadArtifactInputs(unknown, inputs); err == nil {
+			t.Fatalf("fallback accepted unsafe inputs %#v", inputs)
+		}
 	}
 }
 

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -1609,6 +1609,61 @@ func TestCompileBundleLegacyUploadArtifactWarning(t *testing.T) {
 	}
 }
 
+func TestCompileBundleUnknownDownloadArtifactWarningIsDeduplicated(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := filepath.Join(workspace, ".github", "workflows", "artifact.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	unknown := strings.Repeat("0", 40)
+	otherUnknown := strings.Repeat("1", 40)
+	roots := map[string]string{}
+	for _, commit := range []string{unknown, otherUnknown} {
+		root := t.TempDir()
+		writeAction(t, root, "", "name: download artifact\nruns:\n  using: node24\n  main: index.js\n")
+		roots[commit] = root
+	}
+	compile := func(workflow []byte) Bundle {
+		t.Helper()
+		if err := os.WriteFile(workflowPath, workflow, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		bundle, err := CompileBundleWithOptions(workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, "importer", Options{
+			EventTrust: EventUntrusted,
+			Runners: RunnerPolicy{
+				Labels:          map[string]string{"ubuntu-latest": "hosted"},
+				UntrustedQueues: []string{"hosted"},
+			},
+			ResolveActions: true,
+			ActionSource:   commitActionSource{roots: roots},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return bundle
+	}
+	workflow := []byte("on: push\njobs:\n  producer:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo payload\n  download:\n    needs: producer\n    runs-on: ubuntu-latest\n    strategy:\n      matrix:\n        target: [one, two]\n    steps:\n      - uses: actions/download-artifact@" + unknown + "\n        with:\n          name: payload\n          skip-decompress: false\n          digest-mismatch: error\n      - uses: actions/download-artifact@" + unknown + "\n        with:\n          name: again\n      - uses: actions/download-artifact@" + otherUnknown + "\n        with:\n          name: other\n")
+	bundle := compile(workflow)
+	if len(bundle.Plans) != 3 || len(bundle.IR.Warnings) != 2 {
+		t.Fatalf("plans = %d, warnings = %#v, want one warning per distinct commit across matrix and repeated steps", len(bundle.Plans), bundle.IR.Warnings)
+	}
+	warning := bundle.IR.Warnings[0]
+	if warning.Code != "W_DOWNLOAD_ARTIFACT_UNKNOWN_COMMIT_FALLBACK" || warning.Path != "./.github/workflows/artifact.yml" || warning.Job != "download" || warning.Step != 1 || warning.Line == 0 ||
+		!strings.Contains(warning.Message, unknown) || !strings.Contains(warning.Message, actionintegration.DownloadArtifactFallbackContractRelease) || !strings.Contains(warning.Message, "verified direct needs producers") || !strings.Contains(warning.Message, "does not run the upstream action JavaScript") {
+		t.Fatalf("unknown download-artifact fallback warning = %#v", warning)
+	}
+	if bundle.IR.Warnings[1].Code != "W_DOWNLOAD_ARTIFACT_UNKNOWN_COMMIT_FALLBACK" || bundle.IR.Warnings[1].Step != 3 || !strings.Contains(bundle.IR.Warnings[1].Message, otherUnknown) {
+		t.Fatalf("second unknown download-artifact fallback warning = %#v", bundle.IR.Warnings[1])
+	}
+
+	writeAction(t, workspace, ".github/actions/wrapper", "runs:\n  using: composite\n  steps:\n    - uses: actions/download-artifact@"+unknown+"\n      with:\n        name: payload\n")
+	workflow = []byte("on: push\njobs:\n  producer:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo payload\n  download:\n    needs: producer\n    runs-on: ubuntu-latest\n    steps:\n      - uses: ./.github/actions/wrapper\n")
+	bundle = compile(workflow)
+	if len(bundle.IR.Warnings) != 1 || bundle.IR.Warnings[0].Code != "W_DOWNLOAD_ARTIFACT_UNKNOWN_COMMIT_FALLBACK" || bundle.IR.Warnings[0].Step != 1 || !strings.Contains(bundle.IR.Warnings[0].Message, unknown) {
+		t.Fatalf("nested unknown download-artifact fallback warnings = %#v", bundle.IR.Warnings)
+	}
+}
+
 func TestNativeCheckoutIgnoresUpstreamTokenDefaultForOrigin(t *testing.T) {
 	workspace, remote := t.TempDir(), t.TempDir()
 	workflowPath := filepath.Join(workspace, ".github", "workflows", "checkout.yml")
@@ -1861,8 +1916,8 @@ func TestDownloadArtifactAdapterInputCommitAndNeedsBoundary(t *testing.T) {
 	if _, err := compile(actionintegration.DownloadArtifactCommit, "", "        with:\n          name: payload\n"); err == nil || !strings.Contains(err.Error(), "direct needs producer") {
 		t.Fatalf("needs-free download-artifact error = %v", err)
 	}
-	if _, err := compile(strings.Repeat("b", 40), "    needs: producer\n", "        with:\n          name: payload\n"); err == nil || !strings.Contains(err.Error(), actionintegration.DownloadArtifactCommit) || !strings.Contains(err.Error(), actionintegration.DownloadArtifactV5Commit) {
-		t.Fatalf("unsupported download-artifact commit error = %v", err)
+	if plans, err := compile(strings.Repeat("b", 40), "    needs: producer\n", "        with:\n          name: payload\n          skip-decompress: false\n          digest-mismatch: error\n"); err != nil || len(plans) != 2 {
+		t.Fatalf("unknown download-artifact fallback plans = %#v, error = %v", plans, err)
 	}
 	for name, with := range map[string]string{
 		"raw":             "        with:\n          name: payload\n          skip-decompress: true\n",
@@ -1954,8 +2009,8 @@ func TestDownloadArtifactMutableTagMustResolveToAuditedExactLock(t *testing.T) {
 	}
 
 	resolved.commit = strings.Repeat("b", 40)
-	if _, _, _, _, err := compileActionLocks(t.Context(), t.TempDir(), resolved, []string{"actions/download-artifact@v8"}); err == nil {
-		t.Fatal("mutable v8 tag resolving to an unaudited commit was accepted")
+	if _, locks, _, _, err := compileActionLocks(t.Context(), t.TempDir(), resolved, []string{"actions/download-artifact@v8"}); err != nil || len(locks) != 1 || locks[0].Commit != resolved.commit {
+		t.Fatalf("mutable v8 tag unknown commit fallback locks = %#v, error = %v", locks, err)
 	}
 }
 

--- a/internal/compiler/bundle.go
+++ b/internal/compiler/bundle.go
@@ -102,6 +102,7 @@ func CompileBundlePlansContext(ctx context.Context, path string, source, eventSo
 	warnedLegacyCheckout := map[string]bool{}
 	warnedUnknownCheckout := map[string]bool{}
 	warnedLegacyUploadArtifact := map[string]bool{}
+	warnedUnknownDownloadArtifact := map[string]bool{}
 	for i, job := range plans {
 		locks := make(map[string]plan.ActionLock, len(job.Actions))
 		for _, lock := range job.Actions {
@@ -144,6 +145,16 @@ func CompileBundlePlansContext(ctx context.Context, path string, source, eventSo
 					}
 					warnedLegacyUploadArtifact[release] = true
 					bundle.IR.Warnings = append(bundle.IR.Warnings, legacyUploadArtifactWarning(ir.Jobs[i].Steps[stepIndex].Span.Start, release))
+				case actionintegration.AdapterDownloadArtifactBuildkite:
+					if !actionintegration.DownloadArtifactUsesFallbackContract(lock.Commit) || warnedUnknownDownloadArtifact[lock.Commit] {
+						continue
+					}
+					warnedUnknownDownloadArtifact[lock.Commit] = true
+					warning := unknownDownloadArtifactCommitWarning(ir.Jobs[i].Steps[stepIndex].Span.Start, lock.Commit)
+					warning.Path = ir.Jobs[i].SourcePath
+					warning.Job = ir.Jobs[i].LogicalJobID
+					warning.Step = stepIndex + 1
+					bundle.IR.Warnings = append(bundle.IR.Warnings, warning)
 				}
 			}
 		}

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -510,6 +510,16 @@ func legacyUploadArtifactWarning(position workflow.Position, release string) War
 	}
 }
 
+func unknownDownloadArtifactCommitWarning(position workflow.Position, commit string) Warning {
+	return Warning{
+		Code:   "W_DOWNLOAD_ARTIFACT_UNKNOWN_COMMIT_FALLBACK",
+		Line:   position.Line,
+		Column: position.Column,
+		Message: fmt.Sprintf("actions/download-artifact resolved to immutable commit %s, which is outside the exact admission set. The native adapter is using the supported %s contract instead; it still restricts selection to artifacts from verified direct needs producers and enforces destination, ZIP, digest, count, and size bounds, and does not run the upstream action JavaScript.",
+			commit, actionintegration.DownloadArtifactFallbackContractRelease),
+	}
+}
+
 func reusableWorkflowTokenWarning(position workflow.Position) Warning {
 	return Warning{
 		Code:    "W_REUSABLE_WORKFLOW_TOKEN_USES_ROOT_PERMISSIONS",

--- a/internal/runtime/download_artifact_test.go
+++ b/internal/runtime/download_artifact_test.go
@@ -179,11 +179,12 @@ func TestDownloadArtifactSupportsAuditedCommitsAndNonASCIIExactName(t *testing.T
 		Digest: digest, Size: size, FileCount: 1,
 		Producer: plan.NeedProducer{JobID: "11111111-1111-4111-8111-111111111111"},
 	}
-	for _, commit := range actionintegration.DownloadArtifactCommits() {
+	commits := append(actionintegration.DownloadArtifactCommits(), strings.Repeat("0", 40))
+	for _, commit := range commits {
 		t.Run(commit[:7], func(t *testing.T) {
 			workspace := t.TempDir()
 			inputs := map[string]string{"name": " 成果物 ", "path": ""}
-			if commit == actionintegration.DownloadArtifactV8Commit || commit == actionintegration.DownloadArtifactV801Commit {
+			if commit == actionintegration.DownloadArtifactV8Commit || commit == actionintegration.DownloadArtifactV801Commit || actionintegration.DownloadArtifactUsesFallbackContract(commit) {
 				inputs["skip-decompress"] = "False"
 				inputs["digest-mismatch"] = "error"
 			}
@@ -1286,8 +1287,15 @@ func TestDownloadArtifactAdapterBypassesVerifiedUpstreamLifecycle(t *testing.T) 
 	}
 
 	job.Actions[0].Commit = strings.Repeat("b", 40)
-	if _, err := (Runner{Actions: materializer, Artifacts: store}).RunJob(t.Context(), job, workspace); err == nil || !strings.Contains(err.Error(), actionintegration.DownloadArtifactCommit) {
-		t.Fatalf("unsupported runtime commit error = %v", err)
+	job.Steps[0].With = map[string]string{"name": "payload", "path": "fallback-downloaded", "skip-decompress": "false", "digest-mismatch": "error"}
+	fallbackResult, err := (Runner{Actions: materializer, Artifacts: store}).RunJob(t.Context(), job, workspace)
+	if err != nil || fallbackResult.Conclusion != "success" || fallbackResult.Outputs["download_path"] != filepath.Join(workspace, "fallback-downloaded") || store.jobID != artifact.Producer.JobID {
+		t.Fatalf("unknown commit fallback result = %#v, error = %v", fallbackResult, err)
+	}
+
+	job.Actions[0].Commit = strings.Repeat("b", 39)
+	if _, err := (Runner{Actions: materializer, Artifacts: store}).RunJob(t.Context(), job, workspace); err == nil || !strings.Contains(err.Error(), "invalid GitHub identity") {
+		t.Fatalf("malformed runtime commit error = %v", err)
 	}
 }
 


### PR DESCRIPTION
## Why

A moving or newly pinned `actions/download-artifact` ref can resolve to a valid immutable SHA outside the exact admission set and fail compilation, even though buildkite-gha replaces the action with its producer-bound native adapter.

## What

Unknown lowercase 40-hex commits now use the stable v8.0.1 contract and emit one source-located warning per distinct SHA. Known commits retain their exact contracts, and malformed identities still fail. Downloads remain confined to artifacts from verified direct `needs` producers with the existing selector, destination, ZIP, digest, count, and size bounds; upstream JavaScript never runs.

Closes PB-3113.
