### PR TITLE
Compile unknown artifact commits with warnings

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1161,7 +1161,9 @@ Alternate repositories, tags, non-event dynamic commits, GitHub Enterprise Serve
 | v6.0.0 | [`b7c566a772e6b6bfb58ed0dc250532a479d7789f`](https://github.com/actions/upload-artifact/tree/b7c566a772e6b6bfb58ed0dc250532a479d7789f) |
 | v7.0.1 | [`043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`](https://github.com/actions/upload-artifact/tree/043fb46d1a93c77aae656e7c1c64a875d1fc6a0a) |
 
-The v1.0.0, v2.3.1, and v3.2.1 commits match the floating legacy major tags used on github.com. Other legacy commits are unsupported, including v3.2.2, which upstream publishes only as a GitHub Enterprise Server security backport and deprecates on github.com. Every admitted release accepts only its declared inputs. Compilation emits `W_UPLOAD_ARTIFACT_LEGACY_RELEASE` for v1 through v3 to recommend v4 or later.
+The v1.0.0, v2.3.1, and v3.2.1 commits match the floating legacy major tags used on github.com. Other known legacy commits are unsupported, including v3.2.2, which upstream publishes only as a GitHub Enterprise Server security backport and deprecates on github.com. Every known admitted release accepts only its declared inputs.
+
+An unknown lowercase 40-hex immutable commit uses the stable v7.0.1 contract as a compatibility fallback. Compilation emits one `W_UPLOAD_ARTIFACT_UNKNOWN_COMMIT_FALLBACK` warning for each distinct unknown commit. The fallback can differ from the commit's upstream manifest, but it does not widen the native adapter or execute upstream JavaScript. Malformed commits remain unsupported. Compilation emits `W_UPLOAD_ARTIFACT_LEGACY_RELEASE` for known v1 through v3 commits to recommend v4 or later.
 
 | Input | Supported values |
 | --- | --- |
@@ -1192,6 +1194,8 @@ For v4.6.2 and later, the adapter sets `artifact-id` and `artifact-digest`; `art
 | v7.0.0 | [`37930b1c2abaa49bbe596cd826c3c89aef350131`](https://github.com/actions/download-artifact/tree/37930b1c2abaa49bbe596cd826c3c89aef350131) |
 | v8.0.0 | [`70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3`](https://github.com/actions/download-artifact/tree/70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3) |
 | v8.0.1 | [`3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c`](https://github.com/actions/download-artifact/tree/3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c) |
+
+An unknown lowercase 40-hex immutable commit uses the stable v8.0.1 contract as a compatibility fallback. Compilation emits one `W_DOWNLOAD_ARTIFACT_UNKNOWN_COMMIT_FALLBACK` warning for each distinct unknown commit. The fallback can differ from the commit's upstream manifest, but it does not widen the native adapter or execute upstream JavaScript. Malformed commits remain unsupported.
 
 | Input | Supported values |
 | --- | --- |

--- a/internal/action/integration/download_artifact.go
+++ b/internal/action/integration/download_artifact.go
@@ -23,16 +23,25 @@ const (
 	DownloadArtifactV801Commit = "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c"
 	// DownloadArtifactCommit is retained as the original v4.3.0 spelling.
 	DownloadArtifactCommit = DownloadArtifactV4Commit
+	// DownloadArtifactFallbackContractRelease identifies the stable contract
+	// used for immutable commits outside the exact admission set.
+	DownloadArtifactFallbackContractRelease = "v8.0.1"
 
 	MaxDownloadArtifactPatternAlternatives = 8
 	MaxDownloadArtifactPatternBytes        = MaxUploadArtifactNameBytes
 )
 
 func validateDownloadArtifactCommit(commit string) error {
-	if slices.Contains(DownloadArtifactCommits(), commit) {
+	if slices.Contains(DownloadArtifactCommits(), commit) || ValidCheckoutSHA(commit) {
 		return nil
 	}
 	return versionError("actions/download-artifact", "native adapter", commit, DownloadArtifactCommits())
+}
+
+// DownloadArtifactUsesFallbackContract reports whether an immutable commit is
+// outside the exact admission set and therefore uses the stable v8 contract.
+func DownloadArtifactUsesFallbackContract(commit string) bool {
+	return ValidCheckoutSHA(commit) && !slices.Contains(DownloadArtifactCommits(), commit)
 }
 
 // DownloadArtifactCommits returns the complete immutable admission set.
@@ -65,7 +74,7 @@ func validateDownloadArtifactInputs(commit string, inputs map[string]string, all
 		return err
 	}
 	allowed := map[string]bool{"name": true, "pattern": true, "path": true, "merge-multiple": true}
-	if commit == DownloadArtifactV8Commit || commit == DownloadArtifactV801Commit {
+	if commit == DownloadArtifactV8Commit || commit == DownloadArtifactV801Commit || DownloadArtifactUsesFallbackContract(commit) {
 		allowed["skip-decompress"] = true
 		allowed["digest-mismatch"] = true
 	}

--- a/internal/action/integration/download_artifact_test.go
+++ b/internal/action/integration/download_artifact_test.go
@@ -5,14 +5,23 @@ import (
 	"testing"
 )
 
-func TestDownloadArtifactExactContract(t *testing.T) {
+func TestDownloadArtifactContracts(t *testing.T) {
 	for _, commit := range DownloadArtifactCommits() {
 		if err := validateDownloadArtifactCommit(commit); err != nil {
 			t.Fatalf("audited commit %s rejected: %v", commit, err)
 		}
 	}
-	if err := validateDownloadArtifactCommit(strings.Repeat("0", 40)); err == nil {
-		t.Fatal("unrecognized commit accepted")
+	unknown := strings.Repeat("0", 40)
+	if err := validateDownloadArtifactCommit(unknown); err != nil || !DownloadArtifactUsesFallbackContract(unknown) {
+		t.Fatalf("unknown immutable commit fallback = %v, %t", err, DownloadArtifactUsesFallbackContract(unknown))
+	}
+	if DownloadArtifactUsesFallbackContract(DownloadArtifactV801Commit) {
+		t.Fatal("known v8.0.1 commit uses fallback contract")
+	}
+	for _, malformed := range []string{"v8", strings.Repeat("A", 40), strings.Repeat("0", 39)} {
+		if err := validateDownloadArtifactCommit(malformed); err == nil {
+			t.Fatalf("malformed commit %q accepted", malformed)
+		}
 	}
 	for _, commit := range DownloadArtifactCommits() {
 		for _, inputs := range []map[string]string{{"name": "payload"}, {"Name": " payload ", "path": "", "merge-multiple": " False "}, {"name": "${{ github.sha }}", "path": "./out/"}} {
@@ -53,6 +62,25 @@ func TestDownloadArtifactExactContract(t *testing.T) {
 				t.Fatal("unsupported v8 mode accepted")
 			}
 		})
+	}
+}
+
+func TestDownloadArtifactFallbackUsesBoundedV8Contract(t *testing.T) {
+	unknown := strings.Repeat("0", 40)
+	if err := ValidateDownloadArtifactInputs(unknown, map[string]string{
+		"name": "payload", "path": "out", "skip-decompress": "false", "digest-mismatch": "error",
+	}); err != nil {
+		t.Fatalf("fallback rejected bounded v8 inputs: %v", err)
+	}
+	for _, inputs := range []map[string]string{
+		{"name": "payload", "path": "../outside"},
+		{"name": "payload", "skip-decompress": "true"},
+		{"name": "payload", "digest-mismatch": "warn"},
+		{"name": "payload", "github-token": "token"},
+	} {
+		if err := ValidateDownloadArtifactInputs(unknown, inputs); err == nil {
+			t.Fatalf("fallback accepted unsafe inputs %#v", inputs)
+		}
 	}
 }
 

--- a/internal/action/integration/upload_artifact.go
+++ b/internal/action/integration/upload_artifact.go
@@ -25,6 +25,13 @@ const (
 	UploadArtifactV5Commit = "330a01c490aca151604b8cf639adc76d48f6c5d4"
 	UploadArtifactV6Commit = "b7c566a772e6b6bfb58ed0dc250532a479d7789f"
 	UploadArtifactV7Commit = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
+	// uploadArtifactV322Commit is a GHES-only legacy security backport that
+	// remains outside the github.com native adapter contract.
+	uploadArtifactV322Commit = "c6a366c94c3e0affe28c06c8df20a878f24da3cf"
+
+	// UploadArtifactFallbackContractRelease identifies the stable contract used
+	// for immutable commits outside the exact admission set.
+	UploadArtifactFallbackContractRelease = "v7.0.1"
 
 	MaxUploadArtifactNameBytes = 255
 	MaxUploadArtifactRoots     = 32
@@ -65,15 +72,33 @@ func uploadArtifactGeneration(commit string) int {
 	return 4
 }
 
+// UploadArtifactUsesFallbackContract reports whether an immutable commit is
+// outside the exact admission set and therefore uses the stable v7 contract.
+func UploadArtifactUsesFallbackContract(commit string) bool {
+	if !ValidCheckoutSHA(commit) || commit == uploadArtifactV322Commit {
+		return false
+	}
+	_, exact := uploadArtifactCommits[commit]
+	return !exact
+}
+
+func uploadArtifactContractCommit(commit string) string {
+	if UploadArtifactUsesFallbackContract(commit) {
+		return UploadArtifactV7Commit
+	}
+	return commit
+}
+
 // UploadArtifactSupportsOutputs reports whether the admitted release declares
 // artifact outputs. Upstream legacy v1 through v3 releases declared none.
 func UploadArtifactSupportsOutputs(commit string) bool {
-	return uploadArtifactGeneration(commit) >= 4
+	return uploadArtifactGeneration(uploadArtifactContractCommit(commit)) >= 4
 }
 
 // UploadArtifactIncludesHiddenByDefault reports whether omission of
 // include-hidden-files retains hidden paths for the admitted release.
 func UploadArtifactIncludesHiddenByDefault(commit string) bool {
+	commit = uploadArtifactContractCommit(commit)
 	return commit == UploadArtifactV1Commit || commit == UploadArtifactV2Commit
 }
 
@@ -87,7 +112,7 @@ func LegacyUploadArtifactRelease(commit string) (string, bool) {
 }
 
 func validateUploadArtifactCommit(commit string) error {
-	if _, ok := uploadArtifactCommits[commit]; !ok {
+	if _, ok := uploadArtifactCommits[commit]; !ok && (!ValidCheckoutSHA(commit) || commit == uploadArtifactV322Commit) {
 		commits := make([]string, 0, len(uploadArtifactCommits))
 		for supported, version := range uploadArtifactCommits {
 			commits = append(commits, version+" ("+supported+")")
@@ -115,7 +140,8 @@ func validateUploadArtifactInputs(commit string, inputs map[string]string, evalu
 	if err := validateUploadArtifactCommit(commit); err != nil {
 		return err
 	}
-	generation := uploadArtifactGeneration(commit)
+	contractCommit := uploadArtifactContractCommit(commit)
+	generation := uploadArtifactGeneration(contractCommit)
 	allowed := map[string]bool{"name": true, "path": true, "if-no-files-found": true, "include-hidden-files": true, "compression-level": true, "overwrite": true, "archive": true, "retention-days": true}
 	seen := map[string]bool{}
 	for _, name := range sortedNames(inputs) {
@@ -127,7 +153,7 @@ func validateUploadArtifactInputs(commit string, inputs map[string]string, evalu
 		if !allowed[lower] {
 			return fmt.Errorf("unknown input %q is unsupported by the bounded upload-artifact adapter", name)
 		}
-		if lower == "archive" && commit != UploadArtifactV7Commit {
+		if lower == "archive" && contractCommit != UploadArtifactV7Commit {
 			return fmt.Errorf("input %q exists only in actions/upload-artifact v7", name)
 		}
 		if uploadArtifactInputIntroduced[lower] > generation {

--- a/internal/action/integration/upload_artifact_test.go
+++ b/internal/action/integration/upload_artifact_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestUploadArtifactCommitsAreExact(t *testing.T) {
+func TestUploadArtifactCommitContracts(t *testing.T) {
 	commits := []string{
 		UploadArtifactV1Commit, UploadArtifactV2Commit, UploadArtifactV3Commit,
 		UploadArtifactCommit, UploadArtifactV5Commit, UploadArtifactV6Commit, UploadArtifactV7Commit,
@@ -15,15 +15,45 @@ func TestUploadArtifactCommitsAreExact(t *testing.T) {
 			t.Fatalf("audited commit %s rejected: %v", commit, err)
 		}
 	}
-	for _, commit := range []string{"bbbca2ddaa5d8feaa63e36b76fdaad77386f024f", strings.Repeat("0", 40)} {
+	unknown := strings.Repeat("0", 40)
+	if err := validateUploadArtifactCommit(unknown); err != nil || !UploadArtifactUsesFallbackContract(unknown) {
+		t.Fatalf("unknown immutable commit fallback = %v, %t", err, UploadArtifactUsesFallbackContract(unknown))
+	}
+	if UploadArtifactUsesFallbackContract(UploadArtifactV7Commit) {
+		t.Fatal("known v7 commit uses fallback contract")
+	}
+	for _, commit := range []string{uploadArtifactV322Commit, "v7", strings.Repeat("A", 40), strings.Repeat("0", 39)} {
 		err := validateUploadArtifactCommit(commit)
 		if err == nil {
-			t.Fatalf("unrecognized commit %s accepted", commit)
+			t.Fatalf("unsupported commit %s accepted", commit)
 		}
 		for _, supported := range commits {
 			if !strings.Contains(err.Error(), supported) {
 				t.Fatalf("unrecognized commit %s error = %v, want audited commit %s", commit, err, supported)
 			}
+		}
+	}
+}
+
+func TestUploadArtifactFallbackUsesBoundedV7Contract(t *testing.T) {
+	unknown := strings.Repeat("0", 40)
+	if err := ValidateUploadArtifactInputs(unknown, map[string]string{
+		"path": "payload/*.zip", "archive": "true", "include-hidden-files": "false",
+		"compression-level": "0", "overwrite": "false",
+	}); err != nil {
+		t.Fatalf("fallback rejected bounded v7 inputs: %v", err)
+	}
+	if !UploadArtifactSupportsOutputs(unknown) || UploadArtifactIncludesHiddenByDefault(unknown) {
+		t.Fatal("fallback did not use v7 outputs and hidden-file default")
+	}
+	for _, inputs := range []map[string]string{
+		{"path": "../outside"},
+		{"path": "payload", "archive": "false"},
+		{"path": "payload", "overwrite": "true"},
+		{"path": "payload", "future-input": "value"},
+	} {
+		if err := ValidateUploadArtifactInputs(unknown, inputs); err == nil {
+			t.Fatalf("fallback accepted unsafe inputs %#v", inputs)
 		}
 	}
 }

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -1609,6 +1609,116 @@ func TestCompileBundleLegacyUploadArtifactWarning(t *testing.T) {
 	}
 }
 
+func TestCompileBundleUnknownUploadArtifactWarningIsDeduplicated(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := filepath.Join(workspace, ".github", "workflows", "artifact.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	unknown := strings.Repeat("0", 40)
+	otherUnknown := strings.Repeat("1", 40)
+	roots := map[string]string{}
+	for _, commit := range []string{unknown, otherUnknown} {
+		root := t.TempDir()
+		writeAction(t, root, "", uploadArtifactTestManifest(commit))
+		roots[commit] = root
+	}
+	compile := func(workflow []byte) Bundle {
+		t.Helper()
+		if err := os.WriteFile(workflowPath, workflow, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		bundle, err := CompileBundleWithOptions(workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, "importer", Options{
+			EventTrust: EventUntrusted,
+			Runners: RunnerPolicy{
+				Labels:          map[string]string{"ubuntu-latest": "hosted"},
+				UntrustedQueues: []string{"hosted"},
+			},
+			ResolveActions: true,
+			ActionSource:   commitActionSource{roots: roots},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return bundle
+	}
+	workflow := []byte("on: push\njobs:\n  upload:\n    runs-on: ubuntu-latest\n    strategy:\n      matrix:\n        target: [one, two]\n    steps:\n      - uses: actions/upload-artifact@" + unknown + "\n        with:\n          path: payload\n          archive: true\n      - uses: actions/upload-artifact@" + unknown + "\n        with:\n          path: again\n      - uses: actions/upload-artifact@" + otherUnknown + "\n        with:\n          path: other\n")
+	bundle := compile(workflow)
+	if len(bundle.Plans) != 2 || len(bundle.IR.Warnings) != 2 {
+		t.Fatalf("plans = %d, warnings = %#v, want one warning per distinct commit across matrix and repeated steps", len(bundle.Plans), bundle.IR.Warnings)
+	}
+	warning := bundle.IR.Warnings[0]
+	if warning.Code != "W_UPLOAD_ARTIFACT_UNKNOWN_COMMIT_FALLBACK" || warning.Path != "./.github/workflows/artifact.yml" || warning.Job != "upload" || warning.Step != 1 || warning.Line == 0 ||
+		!strings.Contains(warning.Message, unknown) || !strings.Contains(warning.Message, actionintegration.UploadArtifactFallbackContractRelease) || !strings.Contains(warning.Message, "does not run the upstream action JavaScript") {
+		t.Fatalf("unknown upload-artifact fallback warning = %#v", warning)
+	}
+	if bundle.IR.Warnings[1].Code != "W_UPLOAD_ARTIFACT_UNKNOWN_COMMIT_FALLBACK" || bundle.IR.Warnings[1].Step != 3 || !strings.Contains(bundle.IR.Warnings[1].Message, otherUnknown) {
+		t.Fatalf("second unknown upload-artifact fallback warning = %#v", bundle.IR.Warnings[1])
+	}
+
+	writeAction(t, workspace, ".github/actions/wrapper", "runs:\n  using: composite\n  steps:\n    - uses: actions/upload-artifact@"+unknown+"\n      with:\n        path: payload\n")
+	workflow = []byte("on: push\njobs:\n  upload:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: ./.github/actions/wrapper\n")
+	bundle = compile(workflow)
+	if len(bundle.IR.Warnings) != 1 || bundle.IR.Warnings[0].Code != "W_UPLOAD_ARTIFACT_UNKNOWN_COMMIT_FALLBACK" || bundle.IR.Warnings[0].Step != 1 || !strings.Contains(bundle.IR.Warnings[0].Message, unknown) {
+		t.Fatalf("nested unknown upload-artifact fallback warnings = %#v", bundle.IR.Warnings)
+	}
+}
+
+func TestCompileBundleUnknownDownloadArtifactWarningIsDeduplicated(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := filepath.Join(workspace, ".github", "workflows", "artifact.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	unknown := strings.Repeat("0", 40)
+	otherUnknown := strings.Repeat("1", 40)
+	roots := map[string]string{}
+	for _, commit := range []string{unknown, otherUnknown} {
+		root := t.TempDir()
+		writeAction(t, root, "", "name: download artifact\nruns:\n  using: node24\n  main: index.js\n")
+		roots[commit] = root
+	}
+	compile := func(workflow []byte) Bundle {
+		t.Helper()
+		if err := os.WriteFile(workflowPath, workflow, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		bundle, err := CompileBundleWithOptions(workflowPath, workflow, pushEvent(t), "0.0.0-test", testDistributionDigest, "importer", Options{
+			EventTrust: EventUntrusted,
+			Runners: RunnerPolicy{
+				Labels:          map[string]string{"ubuntu-latest": "hosted"},
+				UntrustedQueues: []string{"hosted"},
+			},
+			ResolveActions: true,
+			ActionSource:   commitActionSource{roots: roots},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return bundle
+	}
+	workflow := []byte("on: push\njobs:\n  producer:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo payload\n  download:\n    needs: producer\n    runs-on: ubuntu-latest\n    strategy:\n      matrix:\n        target: [one, two]\n    steps:\n      - uses: actions/download-artifact@" + unknown + "\n        with:\n          name: payload\n          skip-decompress: false\n          digest-mismatch: error\n      - uses: actions/download-artifact@" + unknown + "\n        with:\n          name: again\n      - uses: actions/download-artifact@" + otherUnknown + "\n        with:\n          name: other\n")
+	bundle := compile(workflow)
+	if len(bundle.Plans) != 3 || len(bundle.IR.Warnings) != 2 {
+		t.Fatalf("plans = %d, warnings = %#v, want one warning per distinct commit across matrix and repeated steps", len(bundle.Plans), bundle.IR.Warnings)
+	}
+	warning := bundle.IR.Warnings[0]
+	if warning.Code != "W_DOWNLOAD_ARTIFACT_UNKNOWN_COMMIT_FALLBACK" || warning.Path != "./.github/workflows/artifact.yml" || warning.Job != "download" || warning.Step != 1 || warning.Line == 0 ||
+		!strings.Contains(warning.Message, unknown) || !strings.Contains(warning.Message, actionintegration.DownloadArtifactFallbackContractRelease) || !strings.Contains(warning.Message, "verified direct needs producers") || !strings.Contains(warning.Message, "does not run the upstream action JavaScript") {
+		t.Fatalf("unknown download-artifact fallback warning = %#v", warning)
+	}
+	if bundle.IR.Warnings[1].Code != "W_DOWNLOAD_ARTIFACT_UNKNOWN_COMMIT_FALLBACK" || bundle.IR.Warnings[1].Step != 3 || !strings.Contains(bundle.IR.Warnings[1].Message, otherUnknown) {
+		t.Fatalf("second unknown download-artifact fallback warning = %#v", bundle.IR.Warnings[1])
+	}
+
+	writeAction(t, workspace, ".github/actions/wrapper", "runs:\n  using: composite\n  steps:\n    - uses: actions/download-artifact@"+unknown+"\n      with:\n        name: payload\n")
+	workflow = []byte("on: push\njobs:\n  producer:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo payload\n  download:\n    needs: producer\n    runs-on: ubuntu-latest\n    steps:\n      - uses: ./.github/actions/wrapper\n")
+	bundle = compile(workflow)
+	if len(bundle.IR.Warnings) != 1 || bundle.IR.Warnings[0].Code != "W_DOWNLOAD_ARTIFACT_UNKNOWN_COMMIT_FALLBACK" || bundle.IR.Warnings[0].Step != 1 || !strings.Contains(bundle.IR.Warnings[0].Message, unknown) {
+		t.Fatalf("nested unknown download-artifact fallback warnings = %#v", bundle.IR.Warnings)
+	}
+}
+
 func TestNativeCheckoutIgnoresUpstreamTokenDefaultForOrigin(t *testing.T) {
 	workspace, remote := t.TempDir(), t.TempDir()
 	workflowPath := filepath.Join(workspace, ".github", "workflows", "checkout.yml")
@@ -1765,8 +1875,11 @@ func TestUploadArtifactAdapterInputAndCommitBoundary(t *testing.T) {
 		})
 	}
 
-	if _, err := compile(strings.Repeat("b", 40), "        with:\n          path: payload\n"); err == nil || !strings.Contains(err.Error(), actionintegration.UploadArtifactV1Commit) || !strings.Contains(err.Error(), actionintegration.UploadArtifactV2Commit) || !strings.Contains(err.Error(), actionintegration.UploadArtifactV3Commit) || !strings.Contains(err.Error(), actionintegration.UploadArtifactCommit) || !strings.Contains(err.Error(), actionintegration.UploadArtifactV5Commit) || !strings.Contains(err.Error(), actionintegration.UploadArtifactV6Commit) || !strings.Contains(err.Error(), actionintegration.UploadArtifactV7Commit) {
-		t.Fatalf("unsupported upload-artifact commit error = %v", err)
+	if plans, err := compile(strings.Repeat("b", 40), "        with:\n          path: payload\n          archive: true\n"); err != nil || len(plans) != 1 {
+		t.Fatalf("unknown upload-artifact fallback plans = %#v, error = %v", plans, err)
+	}
+	if _, err := compile("c6a366c94c3e0affe28c06c8df20a878f24da3cf", "        with:\n          path: payload\n"); err == nil || !strings.Contains(err.Error(), "does not admit resolved commit") {
+		t.Fatalf("known unsupported upload-artifact commit error = %v", err)
 	}
 
 	matrixWorkflow := []byte("on: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    strategy:\n      matrix:\n        mode: [production, test]\n    steps:\n      - uses: actions/upload-artifact@" + actionintegration.UploadArtifactV6Commit + "\n        if: matrix.mode == 'test'\n        with:\n          name: ${{ github.sha }}\n          path: ./artifacts.tar.gz\n          retention-days: '0'\n")
@@ -1861,8 +1974,8 @@ func TestDownloadArtifactAdapterInputCommitAndNeedsBoundary(t *testing.T) {
 	if _, err := compile(actionintegration.DownloadArtifactCommit, "", "        with:\n          name: payload\n"); err == nil || !strings.Contains(err.Error(), "direct needs producer") {
 		t.Fatalf("needs-free download-artifact error = %v", err)
 	}
-	if _, err := compile(strings.Repeat("b", 40), "    needs: producer\n", "        with:\n          name: payload\n"); err == nil || !strings.Contains(err.Error(), actionintegration.DownloadArtifactCommit) || !strings.Contains(err.Error(), actionintegration.DownloadArtifactV5Commit) {
-		t.Fatalf("unsupported download-artifact commit error = %v", err)
+	if plans, err := compile(strings.Repeat("b", 40), "    needs: producer\n", "        with:\n          name: payload\n          skip-decompress: false\n          digest-mismatch: error\n"); err != nil || len(plans) != 2 {
+		t.Fatalf("unknown download-artifact fallback plans = %#v, error = %v", plans, err)
 	}
 	for name, with := range map[string]string{
 		"raw":             "        with:\n          name: payload\n          skip-decompress: true\n",
@@ -1954,8 +2067,8 @@ func TestDownloadArtifactMutableTagMustResolveToAuditedExactLock(t *testing.T) {
 	}
 
 	resolved.commit = strings.Repeat("b", 40)
-	if _, _, _, _, err := compileActionLocks(t.Context(), t.TempDir(), resolved, []string{"actions/download-artifact@v8"}); err == nil {
-		t.Fatal("mutable v8 tag resolving to an unaudited commit was accepted")
+	if _, locks, _, _, err := compileActionLocks(t.Context(), t.TempDir(), resolved, []string{"actions/download-artifact@v8"}); err != nil || len(locks) != 1 || locks[0].Commit != resolved.commit {
+		t.Fatalf("mutable v8 tag unknown commit fallback locks = %#v, error = %v", locks, err)
 	}
 }
 

--- a/internal/compiler/bundle.go
+++ b/internal/compiler/bundle.go
@@ -101,7 +101,9 @@ func CompileBundlePlansContext(ctx context.Context, path string, source, eventSo
 	}
 	warnedLegacyCheckout := map[string]bool{}
 	warnedUnknownCheckout := map[string]bool{}
+	warnedUnknownUploadArtifact := map[string]bool{}
 	warnedLegacyUploadArtifact := map[string]bool{}
+	warnedUnknownDownloadArtifact := map[string]bool{}
 	for i, job := range plans {
 		locks := make(map[string]plan.ActionLock, len(job.Actions))
 		for _, lock := range job.Actions {
@@ -138,12 +140,34 @@ func CompileBundlePlansContext(ctx context.Context, path string, source, eventSo
 					warning.Step = stepIndex + 1
 					bundle.IR.Warnings = append(bundle.IR.Warnings, warning)
 				case actionintegration.AdapterUploadArtifactBuildkite:
+					if actionintegration.UploadArtifactUsesFallbackContract(lock.Commit) {
+						if warnedUnknownUploadArtifact[lock.Commit] {
+							continue
+						}
+						warnedUnknownUploadArtifact[lock.Commit] = true
+						warning := unknownUploadArtifactCommitWarning(ir.Jobs[i].Steps[stepIndex].Span.Start, lock.Commit)
+						warning.Path = ir.Jobs[i].SourcePath
+						warning.Job = ir.Jobs[i].LogicalJobID
+						warning.Step = stepIndex + 1
+						bundle.IR.Warnings = append(bundle.IR.Warnings, warning)
+						continue
+					}
 					release, legacy := actionintegration.LegacyUploadArtifactRelease(lock.Commit)
 					if !legacy || warnedLegacyUploadArtifact[release] {
 						continue
 					}
 					warnedLegacyUploadArtifact[release] = true
 					bundle.IR.Warnings = append(bundle.IR.Warnings, legacyUploadArtifactWarning(ir.Jobs[i].Steps[stepIndex].Span.Start, release))
+				case actionintegration.AdapterDownloadArtifactBuildkite:
+					if !actionintegration.DownloadArtifactUsesFallbackContract(lock.Commit) || warnedUnknownDownloadArtifact[lock.Commit] {
+						continue
+					}
+					warnedUnknownDownloadArtifact[lock.Commit] = true
+					warning := unknownDownloadArtifactCommitWarning(ir.Jobs[i].Steps[stepIndex].Span.Start, lock.Commit)
+					warning.Path = ir.Jobs[i].SourcePath
+					warning.Job = ir.Jobs[i].LogicalJobID
+					warning.Step = stepIndex + 1
+					bundle.IR.Warnings = append(bundle.IR.Warnings, warning)
 				}
 			}
 		}

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -501,12 +501,32 @@ func unknownCheckoutCommitWarning(position workflow.Position, commit string) War
 	}
 }
 
+func unknownUploadArtifactCommitWarning(position workflow.Position, commit string) Warning {
+	return Warning{
+		Code:   "W_UPLOAD_ARTIFACT_UNKNOWN_COMMIT_FALLBACK",
+		Line:   position.Line,
+		Column: position.Column,
+		Message: fmt.Sprintf("actions/upload-artifact resolved to immutable commit %s, which is outside the exact admission set. The native adapter is using the supported %s contract instead; it still restricts names, paths, archive mode, overwrite, hidden files, sizes, and outputs, and does not run the upstream action JavaScript.",
+			commit, actionintegration.UploadArtifactFallbackContractRelease),
+	}
+}
+
 func legacyUploadArtifactWarning(position workflow.Position, release string) Warning {
 	return Warning{
 		Code:    "W_UPLOAD_ARTIFACT_LEGACY_RELEASE",
 		Line:    position.Line,
 		Column:  position.Column,
 		Message: fmt.Sprintf("actions/upload-artifact %s is emulated by the native adapter with its release contract; upgrade to v4 or later", release),
+	}
+}
+
+func unknownDownloadArtifactCommitWarning(position workflow.Position, commit string) Warning {
+	return Warning{
+		Code:   "W_DOWNLOAD_ARTIFACT_UNKNOWN_COMMIT_FALLBACK",
+		Line:   position.Line,
+		Column: position.Column,
+		Message: fmt.Sprintf("actions/download-artifact resolved to immutable commit %s, which is outside the exact admission set. The native adapter is using the supported %s contract instead; it still restricts selection to artifacts from verified direct needs producers and enforces destination, ZIP, digest, count, and size bounds, and does not run the upstream action JavaScript.",
+			commit, actionintegration.DownloadArtifactFallbackContractRelease),
 	}
 }
 

--- a/internal/runtime/download_artifact_test.go
+++ b/internal/runtime/download_artifact_test.go
@@ -179,11 +179,12 @@ func TestDownloadArtifactSupportsAuditedCommitsAndNonASCIIExactName(t *testing.T
 		Digest: digest, Size: size, FileCount: 1,
 		Producer: plan.NeedProducer{JobID: "11111111-1111-4111-8111-111111111111"},
 	}
-	for _, commit := range actionintegration.DownloadArtifactCommits() {
+	commits := append(actionintegration.DownloadArtifactCommits(), strings.Repeat("0", 40))
+	for _, commit := range commits {
 		t.Run(commit[:7], func(t *testing.T) {
 			workspace := t.TempDir()
 			inputs := map[string]string{"name": " 成果物 ", "path": ""}
-			if commit == actionintegration.DownloadArtifactV8Commit || commit == actionintegration.DownloadArtifactV801Commit {
+			if commit == actionintegration.DownloadArtifactV8Commit || commit == actionintegration.DownloadArtifactV801Commit || actionintegration.DownloadArtifactUsesFallbackContract(commit) {
 				inputs["skip-decompress"] = "False"
 				inputs["digest-mismatch"] = "error"
 			}
@@ -1286,8 +1287,15 @@ func TestDownloadArtifactAdapterBypassesVerifiedUpstreamLifecycle(t *testing.T) 
 	}
 
 	job.Actions[0].Commit = strings.Repeat("b", 40)
-	if _, err := (Runner{Actions: materializer, Artifacts: store}).RunJob(t.Context(), job, workspace); err == nil || !strings.Contains(err.Error(), actionintegration.DownloadArtifactCommit) {
-		t.Fatalf("unsupported runtime commit error = %v", err)
+	job.Steps[0].With = map[string]string{"name": "payload", "path": "fallback-downloaded", "skip-decompress": "false", "digest-mismatch": "error"}
+	fallbackResult, err := (Runner{Actions: materializer, Artifacts: store}).RunJob(t.Context(), job, workspace)
+	if err != nil || fallbackResult.Conclusion != "success" || fallbackResult.Outputs["download_path"] != filepath.Join(workspace, "fallback-downloaded") || store.jobID != artifact.Producer.JobID {
+		t.Fatalf("unknown commit fallback result = %#v, error = %v", fallbackResult, err)
+	}
+
+	job.Actions[0].Commit = strings.Repeat("b", 39)
+	if _, err := (Runner{Actions: materializer, Artifacts: store}).RunJob(t.Context(), job, workspace); err == nil || !strings.Contains(err.Error(), "invalid GitHub identity") {
+		t.Fatalf("malformed runtime commit error = %v", err)
 	}
 }
 

--- a/internal/runtime/upload_artifact_test.go
+++ b/internal/runtime/upload_artifact_test.go
@@ -102,6 +102,7 @@ func TestUploadArtifactRuntimeVersionMatrix(t *testing.T) {
 		{name: "v5.0.0 defaults", commit: actionintegration.UploadArtifactV5Commit, inputs: map[string]string{"path": "./payload"}, wantOutputs: true},
 		{name: "v6.0.0 defaults", commit: actionintegration.UploadArtifactV6Commit, inputs: map[string]string{"path": "./payload", "retention-days": "0"}, wantOutputs: true},
 		{name: "v7.0.1 ZIP", commit: actionintegration.UploadArtifactV7Commit, inputs: map[string]string{"path": "payload", "archive": " true ", "name": "v7"}, wantOutputs: true},
+		{name: "unknown commit v7 fallback", commit: strings.Repeat("0", 40), inputs: map[string]string{"path": "payload", "archive": "true"}, wantOutputs: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			uploader := &captureArtifactUploader{}
@@ -748,8 +749,14 @@ func TestUploadArtifactAdapterBypassesVerifiedUpstreamLifecycle(t *testing.T) {
 	}
 
 	job.Actions[0].Commit = strings.Repeat("b", 40)
-	if _, err := (Runner{Actions: materializer, Artifacts: &captureArtifactUploader{}}).RunJob(t.Context(), job, workspace); err == nil || !strings.Contains(err.Error(), actionintegration.UploadArtifactCommit) {
-		t.Fatalf("unsupported runtime commit error = %v", err)
+	fallbackResult, err := (Runner{Actions: materializer, Artifacts: &captureArtifactUploader{}}).RunJob(t.Context(), job, workspace)
+	if err != nil || fallbackResult.Conclusion != "success" || fallbackResult.Outputs["artifact_id"] == "" || fallbackResult.Outputs["artifact_digest"] == "" {
+		t.Fatalf("unknown commit fallback result = %#v, error = %v", fallbackResult, err)
+	}
+
+	job.Actions[0].Commit = strings.Repeat("b", 39)
+	if _, err := (Runner{Actions: materializer, Artifacts: &captureArtifactUploader{}}).RunJob(t.Context(), job, workspace); err == nil || !strings.Contains(err.Error(), "invalid GitHub identity") {
+		t.Fatalf("malformed runtime commit error = %v", err)
 	}
 }
 


### PR DESCRIPTION
## Why

Moving or newly pinned `actions/upload-artifact` and `actions/download-artifact` refs can resolve to valid immutable SHAs outside their exact admission sets and fail compilation, even though buildkite-gha replaces both actions with bounded native adapters.

## What

Unknown lowercase 40-hex upload commits now use the stable v7.0.1 contract; unknown download commits use v8.0.1. Each adapter emits one source-located warning per distinct SHA. Known commits retain their exact release contracts, known unsupported upload v3.2.2 remains rejected, and malformed identities fail.

Native upload path, mode, size, and output bounds remain unchanged. Downloads remain confined to artifacts from verified direct `needs` producers with existing selector, destination, ZIP, digest, count, and size bounds. Neither adapter runs upstream JavaScript.

Closes PB-3112 and PB-3113. Supersedes #406 and #407 so both changes reach `main` as one commit.
