### PR TITLE
PB-3123: Support ${{ github.workspace }} and run identity expressions

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -933,6 +933,8 @@ The runtime retains this bounded `github` context:
 | `ref_type` | `branch` for branch and pull request refs; `tag` for tag refs. |
 | `action_path` | Composite action directory inside composite steps; empty elsewhere. |
 | `action_repository`, `action_ref` | Remote composite repository and requested ref; empty for local composites and outside composite steps. |
+| `workspace` | The workspace directory: the fixed job-container mount for container jobs, the host checkout directory otherwise. Exposed as `GITHUB_WORKSPACE`. |
+| `run_id`, `run_number`, `run_attempt` | Buildkite build identity: the build ID, the build number, and the retry count plus one. Exposed as `GITHUB_RUN_ID`, `GITHUB_RUN_NUMBER`, and `GITHUB_RUN_ATTEMPT`. Referencing them outside a Buildkite build is an error, and GitHub run URLs or API calls built from them do not resolve because no GitHub Actions run exists. |
 | `token` | Available only in an authorized step expression. |
 | `event` | The immutable, digest-verified event payload, loaded only for jobs that need runtime event access. |
 

--- a/internal/cli/run_job.go
+++ b/internal/cli/run_job.go
@@ -246,6 +246,11 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 		RepositoryCredentials: repositoryCredentials,
 		WorkflowToken:         workflowTokens,
 		OIDCToken:             oidcTokens,
+		RunIdentity: gharuntime.RunIdentity{
+			BuildID:     os.Getenv("BUILDKITE_BUILD_ID"),
+			BuildNumber: os.Getenv("BUILDKITE_BUILD_NUMBER"),
+			RetryCount:  os.Getenv("BUILDKITE_RETRY_COUNT"),
+		},
 	}
 	runner.RuntimeExecutable, err = os.Executable()
 	if err != nil {

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -838,8 +838,12 @@ func TestEvaluateStepSupportsRetainedGitHubMembers(t *testing.T) {
 		"ref_name":          "feature",
 		"ref_type":          "branch",
 		"repository_owner":  "buildkite",
+		"run_attempt":       "2",
+		"run_id":            "0198c0c5-2e0f-7c68-8b0c-2e0f7c688b0c",
+		"run_number":        "512",
 		"token":             "ghs_scoped_token",
 		"workflow":          "CI",
+		"workspace":         "/workspace",
 		"event":             map[string]any{"action": "opened", "pull_request": map[string]any{"draft": true}},
 	}}
 	for template, want := range map[string]string{
@@ -850,7 +854,11 @@ func TestEvaluateStepSupportsRetainedGitHubMembers(t *testing.T) {
 		"${{ github.ref_name }}":                                   "feature",
 		"${{ github.ref_type }}":                                   "branch",
 		"${{ github.repository_owner }}":                           "buildkite",
+		"${{ github.run_attempt }}":                                "2",
+		"${{ github.run_id }}":                                     "0198c0c5-2e0f-7c68-8b0c-2e0f7c688b0c",
+		"${{ github.run_number }}":                                 "512",
 		"${{ github.workflow }}":                                   "CI",
+		"${{ github.workspace }}/fake-home":                        "/workspace/fake-home",
 	} {
 		if got, err := EvaluateStep(template, context); err != nil || got != want {
 			t.Errorf("EvaluateStep(%q) = %q, %v; want %q", template, got, err, want)
@@ -871,8 +879,12 @@ func TestEvaluateStepSupportsRetainedGitHubMembers(t *testing.T) {
 		"  \"ref_name\": \"feature\",\n" +
 		"  \"ref_type\": \"branch\",\n" +
 		"  \"repository_owner\": \"buildkite\",\n" +
+		"  \"run_attempt\": \"2\",\n" +
+		"  \"run_id\": \"0198c0c5-2e0f-7c68-8b0c-2e0f7c688b0c\",\n" +
+		"  \"run_number\": \"512\",\n" +
 		"  \"token\": \"ghs_scoped_token\",\n" +
-		"  \"workflow\": \"CI\"\n" +
+		"  \"workflow\": \"CI\",\n" +
+		"  \"workspace\": \"/workspace\"\n" +
 		"}"
 	for _, template := range []string{"${{ toJSON(github) }}", "${{ ToJson(GitHub) }}"} {
 		if got, err := EvaluateStep(template, context); err != nil || got != wantJSON {
@@ -885,8 +897,13 @@ func TestEvaluateStepSupportsRetainedGitHubMembers(t *testing.T) {
 	if got, err := EvaluateStep("${{ github.action_path }}", Context{GitHub: map[string]any{}}); err != nil || got != "" {
 		t.Fatalf("EvaluateStep() action_path outside composite scope = %q, %v; want empty", got, err)
 	}
-	if _, err := EvaluateStep("${{ github.run_id }}", context); err == nil {
-		t.Fatal("EvaluateStep() accepted github.run_id")
+	for _, template := range []string{"${{ github.run_attempt }}", "${{ github.run_id }}", "${{ github.run_number }}", "${{ github.workspace }}"} {
+		if _, err := EvaluateStep(template, Context{GitHub: map[string]any{}}); err == nil || !strings.Contains(err.Error(), "unavailable github value") {
+			t.Errorf("EvaluateStep(%q) without run identity error = %v, want unavailable github value", template, err)
+		}
+	}
+	if _, err := EvaluateStep("${{ github.run_started_at }}", context); err == nil || !strings.Contains(err.Error(), `unsupported runtime github reference "github.run_started_at"`) {
+		t.Fatalf("EvaluateStep() github.run_started_at error = %v, want unsupported reference", err)
 	}
 	if got, err := EvaluateStep("${{ toJSON(github.event) }}", context); err != nil || got != "{\n  \"action\": \"opened\",\n  \"pull_request\": {\n    \"draft\": true\n  }\n}" {
 		t.Fatalf("EvaluateStep() event payload = %q, %v", got, err)

--- a/internal/expression/runtime.go
+++ b/internal/expression/runtime.go
@@ -366,7 +366,7 @@ func validateStepRuntimeExpression(node actionlint.ExprNode, allowHashFiles, all
 					return fmt.Errorf("github.token is unavailable in this field")
 				}
 				return nil
-			case "action_path", "action_ref", "action_repository", "actor", "base_ref", "event_name", "head_ref", "job", "ref", "ref_name", "ref_type", "repository", "repository_owner", "server_url", "sha", "workflow":
+			case "action_path", "action_ref", "action_repository", "actor", "base_ref", "event_name", "head_ref", "job", "ref", "ref_name", "ref_type", "repository", "repository_owner", "run_attempt", "run_id", "run_number", "server_url", "sha", "workflow", "workspace":
 				return nil
 			default:
 				return fmt.Errorf("unsupported runtime github reference %q", referenceName(root, path))
@@ -455,6 +455,19 @@ func validateStepRuntimeExpression(node actionlint.ExprNode, allowHashFiles, all
 	}
 	validator.unsupported = func(actionlint.ExprNode) error { return fmt.Errorf("unsupported runtime expression") }
 	return validator.validate(node)
+}
+
+// requiredGitHubRuntimeValue names github members that must never fall back to
+// null: token because absence means missing authority, and run identity or
+// workspace because a silently empty value would corrupt derived cache keys
+// and paths when the runtime cannot supply them.
+func requiredGitHubRuntimeValue(name string) bool {
+	switch strings.ToLower(name) {
+	case "token", "run_attempt", "run_id", "run_number", "workspace":
+		return true
+	default:
+		return false
+	}
 }
 
 func resolveStepRuntimeRoot(root string, context Context) (any, error) {
@@ -558,7 +571,7 @@ func resolveRuntimeReferenceValue(root string, path []string, context Context, a
 		}
 		value, ok := lookupRuntimeValue(context.GitHub, path)
 		if !ok {
-			if !allowMissing || context.GitHub == nil || strings.EqualFold(path[0], "token") {
+			if !allowMissing || context.GitHub == nil || requiredGitHubRuntimeValue(path[0]) {
 				return "", fmt.Errorf("expression references unavailable github value %q", strings.Join(path, "."))
 			}
 			return nil, nil

--- a/internal/runtime/action_execution.go
+++ b/internal/runtime/action_execution.go
@@ -175,6 +175,9 @@ func (r *jobRun) prepare(ctx context.Context) (final JobResult, runJobErr error)
 		JobStatus:      "success",
 		Runner:         runnerContext,
 	}
+	for name, value := range r.RunIdentity.githubValues() {
+		eval.GitHub[name] = value
+	}
 	for _, name := range sortedKeys(job.Needs) {
 		need := job.Needs[name]
 		if need.Result == "" {
@@ -264,6 +267,13 @@ func (r *jobRun) prepare(ctx context.Context) (final JobResult, runJobErr error)
 	workspace, err = filepath.EvalSymlinks(workspace)
 	if err != nil {
 		return jobResult, fmt.Errorf("canonicalize workspace: %w", err)
+	}
+	// github.workspace resolves to the path the executing steps observe:
+	// container jobs see the fixed job-container mount, host jobs see the
+	// canonical workspace directory.
+	eval.GitHub["workspace"] = workspace
+	if job.Container != nil {
+		eval.GitHub["workspace"] = jobContainerWorkspace
 	}
 	hashRoot, err := os.OpenRoot(workspace)
 	if err != nil {
@@ -435,7 +445,7 @@ func (r *jobRun) prepare(ctx context.Context) (final JobResult, runJobErr error)
 	if r.jobContainer != nil {
 		runnerContext["temp"] = r.jobContainer.containerPath(runnerTemp)
 	}
-	runtimeEnv := standardEnvironment(job, workspace, runnerTemp, toolCache)
+	runtimeEnv := standardEnvironment(job, workspace, runnerTemp, toolCache, r.RunIdentity)
 	jobResult.Env = mergeStepEnvironment(runtimeEnv, jobEnv)
 	if r.jobContainer != nil && !explicitJobPATH {
 		jobResult.Env["PATH"] = r.jobContainer.imagePATH
@@ -1321,7 +1331,7 @@ func workflowDisplayName(job plan.Job) string {
 	return job.Workflow.Path
 }
 
-func standardEnvironment(job plan.Job, workspace, runnerTemp, toolCache string) map[string]string {
+func standardEnvironment(job plan.Job, workspace, runnerTemp, toolCache string, identity RunIdentity) map[string]string {
 	runner, _ := canonicalRunnerContext(goruntime.GOOS, goruntime.GOARCH)
 	workflowName := workflowDisplayName(job)
 	env := map[string]string{
@@ -1340,6 +1350,9 @@ func standardEnvironment(job plan.Job, workspace, runnerTemp, toolCache string) 
 		"RUNNER_ARCH":       runner["arch"],
 		"RUNNER_TEMP":       runnerTemp,
 		"RUNNER_TOOL_CACHE": toolCache,
+	}
+	for name, value := range identity.githubValues() {
+		env["GITHUB_"+strings.ToUpper(name)] = value
 	}
 	if imageOS := runnerImageOS(); imageOS != "" {
 		env["ImageOS"] = imageOS
@@ -1466,6 +1479,9 @@ func isRuntimeContextEnvironment(name string) bool {
 		"GITHUB_JOB",
 		"GITHUB_REF",
 		"GITHUB_REPOSITORY",
+		"GITHUB_RUN_ATTEMPT",
+		"GITHUB_RUN_ID",
+		"GITHUB_RUN_NUMBER",
 		"GITHUB_SERVER_URL",
 		"GITHUB_SHA",
 		"GITHUB_WORKFLOW",
@@ -1876,6 +1892,9 @@ func (r *jobRun) runActionStep(ctx context.Context, processor *commandProcessor,
 		if err != nil {
 			return result, err
 		}
+		if r.jobContainer != nil {
+			workingDirectory = r.jobContainer.hostPath(workingDirectory)
+		}
 		dir, err := stepWorkingDirectory(workspace, workingDirectory)
 		if err != nil {
 			return result, err
@@ -2219,6 +2238,9 @@ func (r *jobRun) runCompositeMetadata(ctx context.Context, processor *commandPro
 				var workingDirectory string
 				workingDirectory, childErr = expression.EvaluateStep(step.WorkingDirectory, eval)
 				if childErr == nil {
+					if r.jobContainer != nil {
+						workingDirectory = r.jobContainer.hostPath(workingDirectory)
+					}
 					dir, childErr = stepWorkingDirectory(workspace, workingDirectory)
 				}
 			}

--- a/internal/runtime/containers.go
+++ b/internal/runtime/containers.go
@@ -79,10 +79,6 @@ func privateDocker(r Runner) (string, string, map[string]string, error) {
 	return docker, config, map[string]string{"DOCKER_CONFIG": config}, nil
 }
 
-func (r Runner) startJobContainer(ctx context.Context, processor *commandProcessor, workspace, temp string, spec *plan.Container, services map[string]plan.ServiceContainer, extra ...containerMount) (_ *jobContainerBackend, err error) {
-	return r.startJobContainerOrdered(ctx, processor, workspace, temp, spec, services, sortedKeys(services), extra...)
-}
-
 func (r Runner) startJobContainerOrdered(ctx context.Context, processor *commandProcessor, workspace, temp string, spec *plan.Container, services map[string]plan.ServiceContainer, serviceOrder []string, extra ...containerMount) (_ *jobContainerBackend, err error) {
 	if spec != nil {
 		if err := validateEnvironmentNames(spec.Env); err != nil {
@@ -632,6 +628,18 @@ func (b *jobContainerBackend) containerPath(path string) string {
 	for _, m := range mounts {
 		if rel, err := filepath.Rel(m.host, path); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && len(m.host) > bestLen {
 			best, bestLen = filepath.ToSlash(filepath.Join(m.target, rel)), len(m.host)
+		}
+	}
+	return best
+}
+
+// hostPath reverses containerPath, mapping a job-container path back to its
+// host equivalent so host-side validation can resolve it.
+func (b *jobContainerBackend) hostPath(path string) string {
+	best, bestLen := path, -1
+	for _, m := range b.mounts {
+		if rel, err := filepath.Rel(m.target, path); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && len(m.target) > bestLen {
+			best, bestLen = filepath.Join(m.host, filepath.FromSlash(rel)), len(m.target)
 		}
 	}
 	return best

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -34,6 +34,12 @@ import (
 	"github.com/buildkite/buildkite-gha/internal/plan"
 )
 
+// startJobContainer is a test convenience that starts services in sorted-key
+// order; production callers supply the evaluated service order directly.
+func (r Runner) startJobContainer(ctx context.Context, processor *commandProcessor, workspace, temp string, spec *plan.Container, services map[string]plan.ServiceContainer, extra ...containerMount) (*jobContainerBackend, error) {
+	return r.startJobContainerOrdered(ctx, processor, workspace, temp, spec, services, sortedKeys(services), extra...)
+}
+
 // fakeJobDocker deliberately goes through a shell and a fresh copy of this test
 // process.  Thus tests exercise exec.Cmd cancellation, pipes, quoting and argv
 // boundaries rather than an in-process mock of Docker.
@@ -629,7 +635,7 @@ func TestRunJobContainerLifecycleAndEnvironment(t *testing.T) {
 	t.Setenv("DOCKER_CONTEXT", "bad")
 	t.Setenv("BUILDX_BUILDER", "bad")
 	t.Setenv("BUILDKIT_HOST", "bad")
-	j := jobContainerPlan(t, workspace, []plan.Step{{ID: "one", Kind: "run", Shell: "sh", WorkingDirectory: "nested", Env: map[string]string{"P": "step"}, Command: `test "$PATH" = /image/bin:/usr/bin; test "$P" = step; test "$PWD" = "$GITHUB_WORKSPACE/nested"; test "${{ runner.temp }}" = /__w/_temp; echo E=ok >> "$GITHUB_ENV"; echo O=out >> "$GITHUB_OUTPUT"; echo /extra >> "$GITHUB_PATH"; echo S=state >> "$GITHUB_STATE"; echo summary >> "$GITHUB_STEP_SUMMARY"`}, {ID: "two", Kind: "run", Shell: "sh", Command: `test "$E" = ok; case "$PATH" in /extra:*) ;; *) exit 8;; esac`}})
+	j := jobContainerPlan(t, workspace, []plan.Step{{ID: "one", Kind: "run", Shell: "sh", WorkingDirectory: "nested", Env: map[string]string{"P": "step"}, Command: `test "$PATH" = /image/bin:/usr/bin; test "$P" = step; test "$PWD" = "$GITHUB_WORKSPACE/nested"; test "${{ runner.temp }}" = /__w/_temp; echo E=ok >> "$GITHUB_ENV"; echo O=out >> "$GITHUB_OUTPUT"; echo /extra >> "$GITHUB_PATH"; echo S=state >> "$GITHUB_STATE"; echo summary >> "$GITHUB_STEP_SUMMARY"`}, {ID: "two", Kind: "run", Shell: "sh", WorkingDirectory: "${{ github.workspace }}/nested", Command: `test "$PWD" = "$GITHUB_WORKSPACE/nested"; test "$E" = ok; case "$PATH" in /extra:*) ;; *) exit 8;; esac`}})
 	j.Env = map[string]string{"P": "job"}
 	j.Container.Env = map[string]string{"P": "container"}
 	j.Outputs = map[string]string{"observed": "${{ steps.one.outputs.O }}"}
@@ -2394,7 +2400,7 @@ func TestRunJobContainerRunsDockerActionsAsSiblings(t *testing.T) {
 		job.Schema = plan.Schema
 		job.RequiredCapabilities = []string{"docker", "network"}
 		job.Container = &plan.Container{Image: "debian:bookworm-slim"}
-		job.Env = map[string]string{"WORKSPACE_CHILD": filepath.Join(workspace, "child")}
+		job.Env = map[string]string{"WORKSPACE_CHILD": filepath.Join(workspace, "child"), "WORKSPACE_EXPR": "${{ github.workspace }}/nested"}
 		job.Actions = []plan.ActionLock{{ID: lockID, Source: "workspace", Path: "actions/docker", SourceDigest: digestTree(t, filepath.Join(workspace, "actions/docker"))}}
 		job.Outputs = map[string]string{"container": "${{ steps.docker.outputs.container }}"}
 		result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Stdout: &logs, Stderr: &logs}).RunJob(t.Context(), job, workspace)
@@ -2414,7 +2420,7 @@ func TestRunJobContainerRunsDockerActionsAsSiblings(t *testing.T) {
 			t.Fatalf("sibling network = %q, want %q", got, network)
 		}
 		joined := strings.Join(calls[run].Args, " ")
-		for _, want := range []string{"source=" + workspace + ",target=/github/workspace", "target=/github/runner_temp", "target=/github/file_commands", "WORKSPACE_CHILD=/github/workspace/child"} {
+		for _, want := range []string{"source=" + workspace + ",target=/github/workspace", "target=/github/runner_temp", "target=/github/file_commands", "WORKSPACE_CHILD=/github/workspace/child", "WORKSPACE_EXPR=/github/workspace/nested"} {
 			if !strings.Contains(joined, want) {
 				t.Fatalf("sibling run missing %q: %#v", want, calls[run].Args)
 			}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -79,7 +79,33 @@ type Runner struct {
 	RepositoryCredentials *AgentRepositoryCredentials
 	WorkflowToken         WorkflowTokenProvider
 	OIDCToken             OIDCTokenProvider
+	RunIdentity           RunIdentity
 	nodeDigests           map[int]string
+}
+
+// RunIdentity identifies the Buildkite build that owns this job run. Empty
+// fields leave the corresponding github run values unavailable.
+type RunIdentity struct {
+	BuildID     string
+	BuildNumber string
+	RetryCount  string
+}
+
+// githubValues maps Buildkite build identity onto the GitHub run identity
+// fields: run_id is the build ID, run_number is the build number, and
+// run_attempt is the retry count plus one.
+func (identity RunIdentity) githubValues() map[string]string {
+	values := map[string]string{}
+	if identity.BuildID != "" {
+		values["run_id"] = identity.BuildID
+	}
+	if identity.BuildNumber != "" {
+		values["run_number"] = identity.BuildNumber
+	}
+	if count, err := strconv.Atoi(identity.RetryCount); err == nil && count >= 0 {
+		values["run_attempt"] = strconv.Itoa(count + 1)
+	}
+	return values
 }
 
 func resolveHostExecutableBeforeWorkflow(configured, fallback, label string) (string, error) {
@@ -464,6 +490,8 @@ func (r *jobRun) runDocker(ctx context.Context, processor *commandProcessor, act
 		siblingPaths = &jobContainerBackend{mounts: []containerMount{
 			{host: action.Workspace, target: "/github/workspace"},
 			{host: action.runnerTemp, target: "/github/runner_temp"},
+			{host: jobContainerWorkspace, target: "/github/workspace"},
+			{host: jobContainerTemp, target: "/github/runner_temp"},
 		}}
 	}
 	for _, name := range sortedKeys(action.Env) {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1132,6 +1132,43 @@ func TestRunJobEvaluatesIndexedWorkflowInputs(t *testing.T) {
 	}
 }
 
+func TestRunJobResolvesWorkspaceAndRunIdentity(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/identity.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: identity\n")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{
+		ID: "check", Kind: "run",
+		Command: `test "$FAKE_HOME" = "$GITHUB_WORKSPACE/fake-home" &&
+test "$RUN_KEY" = key-b5e828e8-7457-013c-9a17-2f01b563f36a-512-2 &&
+test "$GITHUB_RUN_ID" = b5e828e8-7457-013c-9a17-2f01b563f36a &&
+test "$GITHUB_RUN_NUMBER" = 512 &&
+test "$GITHUB_RUN_ATTEMPT" = 2`,
+	}})
+	job.Env = map[string]string{
+		"FAKE_HOME": "${{ github.workspace }}/fake-home",
+		"RUN_KEY":   "key-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}",
+	}
+	var logs bytes.Buffer
+	runner := Runner{Stdout: &logs, Stderr: &logs, RunIdentity: RunIdentity{BuildID: "b5e828e8-7457-013c-9a17-2f01b563f36a", BuildNumber: "512", RetryCount: "1"}}
+	result, err := runner.RunJob(t.Context(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v, logs = %q", result, err, logs.String())
+	}
+}
+
+func TestRunJobRejectsRunIdentityExpressionsWithoutIdentity(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/identity.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: identity\n")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "check", Kind: "run", Command: "true"}})
+	job.Env = map[string]string{"RUN_KEY": "key-${{ github.run_id }}"}
+	var logs bytes.Buffer
+	_, err := (Runner{Stdout: &logs, Stderr: &logs}).RunJob(t.Context(), job, workspace)
+	if err == nil || !strings.Contains(err.Error(), `unavailable github value "run_id"`) {
+		t.Fatalf("RunJob() error = %v, want unavailable run_id", err)
+	}
+}
+
 func TestRunJobDoesNotTolerateDockerActionCleanupFailure(t *testing.T) {
 	requireLinuxAMD64(t)
 	fake := newFakeDocker(t, "leftover")
@@ -3317,7 +3354,7 @@ func TestStepExpressionContextExposesScopedTokenWithoutMutatingJobContext(t *tes
 func TestOriginUsesProviderServerURLWithoutGitHubToken(t *testing.T) {
 	job := plan.Job{Event: plan.Event{Provider: "cursor-origin"}}
 	github := githubContext(job)
-	env := standardEnvironment(job, "/workspace", "/tmp", "/tool-cache")
+	env := standardEnvironment(job, "/workspace", "/tmp", "/tool-cache", RunIdentity{})
 	if github["server_url"] != "https://origin.cursor.com" || env["GITHUB_SERVER_URL"] != "https://origin.cursor.com" {
 		t.Fatalf("Origin server URLs = context %#v, environment %q", github["server_url"], env["GITHUB_SERVER_URL"])
 	}
@@ -3362,7 +3399,7 @@ func TestGitHubContextExposesRuntimeEventIdentity(t *testing.T) {
 				t.Fatalf("EvaluateCondition(%q) = %v, %v", condition, got, err)
 			}
 			if test.name == "release" {
-				env := standardEnvironment(plan.Job{Event: test.event}, "/workspace", "/tmp", "/tool-cache")
+				env := standardEnvironment(plan.Job{Event: test.event}, "/workspace", "/tmp", "/tool-cache", RunIdentity{})
 				if env["GITHUB_EVENT_NAME"] != "release" || env["GITHUB_REF"] != "refs/tags/v1.2.3" || env["GITHUB_SHA"] != strings.Repeat("a", 40) {
 					t.Fatalf("release environment = %#v", env)
 				}
@@ -3382,7 +3419,7 @@ func TestStandardEnvironmentSuppliesProtectedGitHubWorkflow(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			env := standardEnvironment(plan.Job{Workflow: test.workflow}, "/workspace", "/tmp", "/tool-cache")
+			env := standardEnvironment(plan.Job{Workflow: test.workflow}, "/workspace", "/tmp", "/tool-cache", RunIdentity{})
 			if got := env["GITHUB_WORKFLOW"]; got != test.want {
 				t.Fatalf("GITHUB_WORKFLOW = %q, want %q", got, test.want)
 			}


### PR DESCRIPTION
## Why

Workflows that read the workspace path or run identity through expressions fail at job setup:

```yaml
env:
  FAKE_HOME: ${{ github.workspace }}/fake-home
  CACHE_KEY: cache-${{ github.run_id }}-${{ github.run_attempt }}
```

```
buildkite-gha: run-job: evaluate job environment: evaluate "FAKE_HOME": unsupported runtime github reference "github.workspace"
```

These are common in migrated workflows: `github.workspace` for paths, and run identity for unique cache keys and artifact names.

## What

The expressions above now resolve, and the matching environment variables are set:

| Expression | Value |
| --- | --- |
| `github.workspace` | The workspace directory: the fixed job-container mount for container jobs, the host checkout directory otherwise. |
| `github.run_id` | `BUILDKITE_BUILD_ID` |
| `github.run_number` | `BUILDKITE_BUILD_NUMBER` |
| `github.run_attempt` | `BUILDKITE_RETRY_COUNT` plus one, matching GitHub's 1-based attempts. |

`GITHUB_RUN_ID`, `GITHUB_RUN_NUMBER`, and `GITHUB_RUN_ATTEMPT` are exposed to steps and protected from `GITHUB_ENV` spoofing like the other identity variables.

Boundaries:

- Referencing run identity outside a Buildkite build is an error rather than an empty string, so derived cache keys cannot silently collide.
- GitHub run URLs or API calls built from `run_id` do not resolve, because no GitHub Actions run exists.
- Job and step `if:` conditions and compile-time positions still reject these fields.

Also moves the test-only `startJobContainer` helper into the test file: golangci-lint's `unused` check fails on macOS because the linux/amd64 test file that calls it is excluded from analysis.

Linear: [PB-3123](https://linear.app/buildkite/issue/PB-3123/support-githubworkspace-githubrun-id-githubrun-number-and-githubrun)
