### PR TITLE
Cover expression-based custom runner fallback

### DIFF
--- a/internal/cli/plugin_test.go
+++ b/internal/cli/plugin_test.go
@@ -522,7 +522,7 @@ func TestPluginPublishesMixedRuntimeDistributions(t *testing.T) {
 	requireImporterHost(t)
 	const fullCommit = "0123456789abcdef0123456789abcdef01234567"
 	repository := writeUploadWorkflowRepository(t, map[string]string{
-		"mixed.yml": "on: push\njobs:\n  linux:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo linux\n  configured:\n    needs: linux\n    runs-on: ubuntu-18.04\n    steps:\n      - run: echo configured\n  fallback:\n    needs: linux\n    runs-on: [self-hosted, ubuntu-20.04]\n    steps:\n      - run: echo fallback\n  macos:\n    needs: linux\n    runs-on: macos-26\n    steps:\n      - run: echo macos\n",
+		"mixed.yml": "on: push\njobs:\n  linux:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo linux\n  configured:\n    needs: linux\n    runs-on: ubuntu-18.04\n    steps:\n      - run: echo configured\n  fallback:\n    needs: linux\n    runs-on: [self-hosted, ubuntu-20.04]\n    steps:\n      - run: echo fallback\n  expression:\n    needs: linux\n    strategy:\n      matrix:\n        runner: [custom-linux]\n    runs-on: [self-hosted, \"${{ matrix.runner }}\"]\n    steps:\n      - run: echo expression fallback\n  macos:\n    needs: linux\n    runs-on: macos-26\n    steps:\n      - run: echo macos\n",
 	})
 	t.Chdir(repository)
 	workflowPath := filepath.Join(".github", "workflows", "mixed.yml")
@@ -587,6 +587,15 @@ func TestPluginPublishesMixedRuntimeDistributions(t *testing.T) {
 						"message": "This runner selector is not supported directly; using the linux-medium queue via a heuristic fallback. Configure an explicit runner mapping to use an appropriate Buildkite queue and avoid this fallback: https://github.com/buildkite/buildkite-gha/blob/main/docs/compatibility.md",
 					}},
 				}
+			case slices.Equal(requirement.Selector.Labels, []string{"self-hosted", "custom-linux"}):
+				resolutions[i] = map[string]any{
+					"id":     requirement.ID,
+					"target": map[string]string{"queue": "linux-medium", "platform": "linux/amd64", "image": defaultNobleRunnerImage},
+					"warnings": []map[string]string{{
+						"code":    "runner_label_fallback",
+						"message": "Expression-selected runner labels [self-hosted, custom-linux] are not supported directly; using the linux-medium queue via a heuristic fallback. Configure an explicit runner mapping to use an appropriate Buildkite queue and avoid this fallback: https://github.com/buildkite/buildkite-gha/blob/main/docs/compatibility.md",
+					}},
+				}
 			case slices.Equal(requirement.Selector.Labels, []string{"macos-26"}):
 				resolutions[i] = map[string]any{"id": requirement.ID, "target": map[string]string{"queue": "macos-26-medium", "platform": "darwin/arm64"}}
 			default:
@@ -621,7 +630,7 @@ func TestPluginPublishesMixedRuntimeDistributions(t *testing.T) {
 			break
 		}
 	}
-	if runnerAnnotation == nil || runnerAnnotation.args[8] != "warning" || !strings.Contains(string(runnerAnnotation.stdin), "heuristic fallback") || !strings.Contains(string(runnerAnnotation.stdin), "linux-medium") || !strings.Contains(string(runnerAnnotation.stdin), "docs/compatibility.md") {
+	if runnerAnnotation == nil || runnerAnnotation.args[8] != "warning" || !strings.Contains(string(runnerAnnotation.stdin), "heuristic fallback") || !strings.Contains(string(runnerAnnotation.stdin), "custom-linux") || !strings.Contains(string(runnerAnnotation.stdin), "linux-medium") || !strings.Contains(string(runnerAnnotation.stdin), "docs/compatibility.md") {
 		t.Fatalf("runner resolution annotation = %#v", runnerAnnotation)
 	}
 	darwinDigest := transport.Digest(darwinContents)
@@ -677,7 +686,7 @@ func TestPluginPublishesMixedRuntimeDistributions(t *testing.T) {
 			Command string
 		}{Image: step.Image, Queue: step.Agents["queue"], Command: step.Command}
 	}
-	var linux, configured, fallback, macos struct {
+	var linux, configured, fallback, expression, macos struct {
 		Image   string
 		Queue   string
 		Command string
@@ -690,6 +699,8 @@ func TestPluginPublishesMixedRuntimeDistributions(t *testing.T) {
 			configured = step
 		case strings.HasSuffix(key, "-fallback"):
 			fallback = step
+		case strings.Contains(key, "-expression-"):
+			expression = step
 		case strings.HasSuffix(key, "-macos"):
 			macos = step
 		}
@@ -702,6 +713,9 @@ func TestPluginPublishesMixedRuntimeDistributions(t *testing.T) {
 	}
 	if fallback.Queue != "linux-medium" || fallback.Image != defaultNobleRunnerImage || !strings.Contains(fallback.Command, "--hosted-tool-cache") || !strings.Contains(fallback.Command, strings.TrimPrefix(cliTestRuntimeDigest(), "sha256:")) {
 		t.Fatalf("fallback Linux pipeline step = %#v", fallback)
+	}
+	if expression.Queue != "linux-medium" || expression.Image != defaultNobleRunnerImage || !strings.Contains(expression.Command, "--hosted-tool-cache") || !strings.Contains(expression.Command, strings.TrimPrefix(cliTestRuntimeDigest(), "sha256:")) {
+		t.Fatalf("expression fallback Linux pipeline step = %#v", expression)
 	}
 	if macos.Queue != "macos-26-medium" || macos.Image != "" || strings.Contains(macos.Command, "--hosted-tool-cache") || !strings.Contains(macos.Command, strings.TrimPrefix(darwinDigest, "sha256:")) {
 		t.Fatalf("Darwin pipeline step = %#v", macos)

--- a/internal/compiler/config_test.go
+++ b/internal/compiler/config_test.go
@@ -308,6 +308,39 @@ jobs:
 	}
 }
 
+func TestCompileAppliesRunnerSelectorToExpressionResolvedLabels(t *testing.T) {
+	workflow := []byte(`on: push
+jobs:
+  test:
+    runs-on: ${{ fromJSON(vars.RUNNER_LABELS) }}
+    steps:
+      - run: true
+`)
+	target := RunnerTarget{
+		Queue:    "linux-medium",
+		Platform: PlatformLinuxAMD64,
+		Image:    "example.com/toolchains/noble@sha256:" + strings.Repeat("0", 64),
+	}
+	compiled, err := CompileWithOptions("expression-runner.yml", workflow, pushEvent(t), Options{
+		EventTrust: EventTrusted,
+		Vars:       VariableSources{Bridge: map[string]string{"RUNNER_LABELS": `["self-hosted","custom-linux"]`}},
+		Runners: RunnerPolicy{Selectors: []RunnerSelector{{
+			Labels: []string{"self-hosted", "custom-linux"},
+			Target: target,
+		}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ir IR
+	if err := json.Unmarshal(compiled, &ir); err != nil {
+		t.Fatal(err)
+	}
+	if len(ir.Jobs) != 1 || !slices.Equal(ir.Jobs[0].RunsOn, []string{"self-hosted", "custom-linux"}) || ir.Jobs[0].Queue != target.Queue || ir.Jobs[0].RuntimeImage != target.Image {
+		t.Fatalf("expression-selected runner = %#v", ir.Jobs)
+	}
+}
+
 func TestRunsOnPolicyFailsClosedWithLocatedDiagnostics(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
## Why

PB-3080 covers heuristic fallback for literal custom runner labels, but not labels produced by expressions such as:

```yaml
runs-on: [self-hosted, "${{ matrix.runner }}"]
```

Without that coverage, expression evaluation and Agent runner resolution could drift independently.

## What

Cover expression-resolved multi-label selectors at the compiler boundary and through plugin upload. The plugin test confirms the resolved labels reach the Agent API, select the returned Ubuntu queue and image, and produce the heuristic-fallback warning.

Related to PB-3080.
