### PR TITLE
Add a runtime proof for hashFiles

### DIFF
--- a/.buildkite/hash-files-proof.yml
+++ b/.buildkite/hash-files-proof.yml
@@ -1,0 +1,21 @@
+agents:
+  queue: "hosted"
+
+steps:
+  - label: ":pipeline: hashFiles proof importer"
+    key: "hash-files-importer"
+    plugins:
+      - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
+          version: "2026.5.12"
+    command: |
+      set -euo pipefail
+      commit="$${COMPATIBILITY_PROOF_COMMIT:?COMPATIBILITY_PROOF_COMMIT is required}"
+      scripts/verify-source-checkout "$$commit"
+      distribution_root="$$(mktemp -d "$${TMPDIR:-/tmp}/buildkite-gha-hash-files.XXXXXXXX")"
+      trap 'rm -rf -- "$$distribution_root"' EXIT
+      revision="$$(git rev-parse HEAD)"
+      CGO_ENABLED=0 mise exec -- go build -trimpath -buildvcs=false -ldflags "-X main.revision=$$revision" -o "$$distribution_root/buildkite-gha" ./cmd/buildkite-gha
+      "$$distribution_root/buildkite-gha" upload \
+        --event-path testdata/smoke/events/push.json \
+        --runner-queue ubuntu-latest=hosted \
+        testdata/smoke/.github/workflows/hash-files.yml

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -16,7 +16,7 @@ steps:
           set -euo pipefail
           proof="$${COMPATIBILITY_PROOF:?COMPATIBILITY_PROOF is required}"
           case "$$proof" in
-            shell-upload|concurrent-steps|public-actions|hosted-docker|dockerfile-action|container-runtime|summary-annotation|workflow-annotations|skipped-workflow-annotation|upload-artifact|artifact-roundtrip|experimental-runner-user) ;;
+            shell-upload|concurrent-steps|public-actions|hosted-docker|dockerfile-action|container-runtime|summary-annotation|workflow-annotations|skipped-workflow-annotation|hash-files|upload-artifact|artifact-roundtrip|experimental-runner-user) ;;
             *) echo "Unknown compatibility proof: $$proof" >&2; exit 2 ;;
           esac
           buildkite-agent pipeline upload ".buildkite/$$proof-proof.yml"

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -502,8 +502,8 @@ func TestCompileBundleCompilesSmokeCorpus(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(workflows) != 12 {
-		t.Fatalf("smoke workflows = %d, want 12", len(workflows))
+	if len(workflows) != 13 {
+		t.Fatalf("smoke workflows = %d, want 13", len(workflows))
 	}
 	event := readFile(t, smokePath("events", "push.json"))
 	for _, path := range workflows {

--- a/internal/compiler/smoke_manifest_test.go
+++ b/internal/compiler/smoke_manifest_test.go
@@ -46,7 +46,7 @@ func TestSmokeManifestInventory(t *testing.T) {
 		t.Fatalf("schema = %q", manifest.Schema)
 	}
 
-	wantOrder := []string{"smoke-shell", "smoke-concurrent", "smoke-ci", "smoke-artifact", "smoke-artifact-multi-prefix", "example-basic", "example-artifacts", "example-advanced", "plugin-demo-cache", "public-actions", "dockerfile-action", "container-runtime", "summary-annotation", "workflow-command-annotations", "upload-artifact", "cache-v6", "cache-v5", "cache-v2-compatibility", "cache-v2-admission", "unsupported-job-container", "unsupported-service-container"}
+	wantOrder := []string{"smoke-shell", "smoke-concurrent", "smoke-ci", "smoke-artifact", "smoke-artifact-multi-prefix", "example-basic", "example-artifacts", "example-advanced", "plugin-demo-cache", "public-actions", "dockerfile-action", "container-runtime", "summary-annotation", "workflow-command-annotations", "hash-files", "upload-artifact", "cache-v6", "cache-v5", "cache-v2-compatibility", "cache-v2-admission", "unsupported-job-container", "unsupported-service-container"}
 	if len(manifest.Fixtures) != len(wantOrder) {
 		t.Fatalf("fixtures = %d, want %d", len(manifest.Fixtures), len(wantOrder))
 	}

--- a/testdata/smoke/.github/workflows/hash-files.yml
+++ b/testdata/smoke/.github/workflows/hash-files.yml
@@ -1,0 +1,33 @@
+name: hashFiles proof
+
+on:
+  push:
+
+permissions: {}
+
+jobs:
+  hash-files:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create hash inputs
+        shell: bash
+        run: |
+          mkdir -p hash-files/ignored
+          printf alpha > hash-files/a.lock
+          printf bravo > hash-files/b.lock
+          printf ignored > hash-files/ignored/c.lock
+
+      - name: Verify hashFiles
+        if: hashFiles('hash-files/**/*.lock', '!hash-files/ignored/**') != ''
+        shell: bash
+        env:
+          MATCHED_HASH: ${{ hashFiles('hash-files/**/*.lock', '!hash-files/ignored/**') }}
+          MISSING_HASH: ${{ hashFiles('hash-files/**/*.missing') }}
+        run: |
+          test "$MATCHED_HASH" = 90d39555bb3c223e12f5a375c3011d2462fe2e1e36b8416a0b623d5831a9b4f3
+          test -z "$MISSING_HASH"
+          touch hash-files/verified
+
+      - name: Require condition match
+        shell: bash
+        run: test -f hash-files/verified

--- a/testdata/smoke/README.md
+++ b/testdata/smoke/README.md
@@ -17,6 +17,8 @@ workflow is executable:
    output, environment-file, masking, summary, and post-action events.
 4. `artifact.yml` adds GitHub artifact-action compatibility and verifies one
    payload in both consumer matrix instances.
+5. `hash-files.yml` verifies matched and empty hashes, ordered exclusions, and
+   step condition evaluation against files created by an earlier step.
 
 `manifest.json` is the authoritative, ordered compatibility inventory for
 these workflows and the related behavior-oriented proof fixtures. Every

--- a/testdata/smoke/manifest.json
+++ b/testdata/smoke/manifest.json
@@ -128,6 +128,15 @@
       "action_preflight": "none"
     },
     {
+      "id": "hash-files",
+      "workflow": "testdata/smoke/.github/workflows/hash-files.yml",
+      "event": "testdata/smoke/events/push.json",
+      "expectation": "compile-pass",
+      "evidence": "Expression and runtime tests cover hashing, glob ordering, empty matches, and step conditions.",
+      "note": "Run the hash-files compatibility proof for end-to-end hosted runtime evidence.",
+      "action_preflight": "none"
+    },
+    {
       "id": "upload-artifact",
       "workflow": "testdata/smoke/.github/workflows/upload-artifact.yml",
       "event": "testdata/smoke/events/push.json",


### PR DESCRIPTION
## Why

`hashFiles()` has unit and runtime coverage, but no checked-in workflow that can prove the feature through the hosted importer and runner.

## What

Add a smoke workflow that creates files, verifies a known multi-file hash, ordered exclusion, empty matches, and step-condition evaluation. Add an on-demand `COMPATIBILITY_PROOF=hash-files` pipeline target that builds the exact branch source and uploads that workflow.
