### PR TITLE
Identify rejected features in buildkite-gha telemetry

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -523,7 +523,10 @@ The plugin value must be a YAML boolean, not a quoted string.
 
 In Buildkite jobs, the importer and runtime send best-effort completion
 telemetry through the job-authenticated Agent API. Events contain the command,
-outcome, client version, duration, and bounded diagnostic codes and severities.
+outcome, client version, duration, and bounded diagnostics. Diagnostics can
+identify a rejected feature with a `blocker` slug and bounded `blocker_detail`,
+such as `runner_label` and `windows-latest`. Distinct rejected values remain
+separate diagnostics even when they share a diagnostic code.
 For an unsuccessful command, they also contain the final 1,024 bytes of
 normalized user-visible error output. `error_message_truncated` says whether
 earlier output was omitted.
@@ -532,11 +535,14 @@ Failed runs also carry a failure phase and a code from a fixed set. The code
 separates workflow-authored process exits (`E_STEP_PROCESS_EXIT`) from
 unsupported-feature rejections (`E_UNSUPPORTED_FEATURE`) and runtime integrity
 failures (`E_RUNTIME_INTEGRITY`), so a failing test suite is not counted as a
-compatibility gap.
+compatibility gap. Runtime rejections include the same blocker fields when the
+runtime can identify the rejected shell or action reference.
 
 Buildkite adds organization, pipeline, build, and job identifiers on the
 server. The client does not send workflow or event content, environment
-variables, command text, or secrets as separate properties.
+variables, command text, or secrets as separate properties. Blocker details
+come from workflow-authored configuration. Event-derived runner labels and
+environment expressions are omitted.
 
 Error output can include details already printed in the job log, such as
 workflow paths, action references, expressions, or invalid configuration

--- a/internal/buildkite/triggers.go
+++ b/internal/buildkite/triggers.go
@@ -92,6 +92,10 @@ func (e *UnsupportedTriggerEventError) Error() string {
 	return fmt.Sprintf("unsupported GitHub trigger event %q", e.Event)
 }
 
+func (e *UnsupportedTriggerEventError) CompatibilityBlocker() (string, string) {
+	return "trigger", e.Event
+}
+
 func unsupportedTriggerEvent(err error) bool {
 	var unsupported *UnsupportedTriggerEventError
 	return errors.As(err, &unsupported)
@@ -109,6 +113,10 @@ func (e *UnsupportedPathFiltersError) Error() string {
 		return fmt.Sprintf("%s path filters are unsupported: %s", e.Event, e.Reason)
 	}
 	return fmt.Sprintf("%s path filters are unsupported: Buildkite if_changed is not equivalent", e.Event)
+}
+
+func (e *UnsupportedPathFiltersError) CompatibilityBlocker() (string, string) {
+	return "trigger", e.Event
 }
 
 // LiveTriggerConditionExpressions uses fields from the Buildkite build that

--- a/internal/cli/run_job.go
+++ b/internal/cli/run_job.go
@@ -122,6 +122,7 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 	if err := gharuntime.ValidateHost(job, runtime.GOOS, runtime.GOARCH); err != nil {
 		details.setFailurePhase(telemetry.FailurePhaseExecution)
 		details.setFailureCode(runtimeFailureCode(err))
+		setRuntimeBlocker(details, err)
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: %v\n", err)
 		return 1
 	}
@@ -307,6 +308,7 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 		if runErr != nil {
 			details.setFailurePhase(telemetry.FailurePhaseExecution)
 			details.setFailureCode(runtimeFailureCode(runErr))
+			setRuntimeBlocker(details, runErr)
 		}
 	}
 	if result.Conclusion == "" {
@@ -375,6 +377,12 @@ func runtimeFailureCode(err error) telemetry.FailureCode {
 		return telemetry.FailureCodeRuntimeIntegrity
 	default:
 		return ""
+	}
+}
+
+func setRuntimeBlocker(details *commandTelemetryDetails, err error) {
+	if blocker, detail, ok := gharuntime.UnsupportedFeature(err); ok {
+		details.setBlocker(blocker, detail)
 	}
 }
 

--- a/internal/cli/run_job_test.go
+++ b/internal/cli/run_job_test.go
@@ -758,6 +758,9 @@ func TestRunJobTelemetryClassifiesUnsupportedShell(t *testing.T) {
 	if event.FailurePhase != telemetry.FailurePhaseExecution || event.FailureCode != telemetry.FailureCodeUnsupportedFeature {
 		t.Fatalf("telemetry = %#v", event)
 	}
+	if event.Blocker != "shell" || event.BlockerDetail != "pwsh" {
+		t.Fatalf("telemetry blocker = %q / %q", event.Blocker, event.BlockerDetail)
+	}
 	if !strings.Contains(event.ErrorMessage, `shell "pwsh" is unsupported`) {
 		t.Fatalf("telemetry error message = %q", event.ErrorMessage)
 	}

--- a/internal/cli/run_job_test.go
+++ b/internal/cli/run_job_test.go
@@ -758,7 +758,7 @@ func TestRunJobTelemetryClassifiesUnsupportedShell(t *testing.T) {
 	if event.FailurePhase != telemetry.FailurePhaseExecution || event.FailureCode != telemetry.FailureCodeUnsupportedFeature {
 		t.Fatalf("telemetry = %#v", event)
 	}
-	if event.Blocker != "shell" || event.BlockerDetail != "pwsh" {
+	if event.Blocker != "shell" || event.BlockerDetail != "" {
 		t.Fatalf("telemetry blocker = %q / %q", event.Blocker, event.BlockerDetail)
 	}
 	if !strings.Contains(event.ErrorMessage, `shell "pwsh" is unsupported`) {

--- a/internal/cli/telemetry.go
+++ b/internal/cli/telemetry.go
@@ -58,11 +58,17 @@ func telemetryOutcome(code int, conclusion string, contextErr error) telemetry.O
 }
 
 type commandTelemetryDetails struct {
-	failurePhase telemetry.FailurePhase
-	failureCode  telemetry.FailureCode
-	diagnostics  []telemetry.Diagnostic
-	seen         map[string]int
-	errorOutput  boundedTailBuffer
+	failurePhase  telemetry.FailurePhase
+	failureCode   telemetry.FailureCode
+	blocker       string
+	blockerDetail string
+	diagnostics   []telemetry.Diagnostic
+	seen          map[telemetryDiagnosticKey]int
+	errorOutput   boundedTailBuffer
+}
+
+type telemetryDiagnosticKey struct {
+	code, blocker, blockerDetail string
 }
 
 func (d *commandTelemetryDetails) captureErrors(writer io.Writer) io.Writer {
@@ -99,7 +105,10 @@ func (d *commandTelemetryDetails) addReportDiagnostics(report compatibility.Proc
 		if !ok || !allowlistedTelemetryDiagnosticCode(diagnostic.Code) {
 			continue
 		}
-		d.addDiagnostic(diagnostic.Code, severity)
+		d.addDiagnostic(diagnostic.Code, severity, diagnostic.Blocker, diagnostic.BlockerDetail)
+		if diagnostic.Level == "error" {
+			d.setBlocker(diagnostic.Blocker, diagnostic.BlockerDetail)
+		}
 	}
 }
 
@@ -118,7 +127,7 @@ func (d *commandTelemetryDetails) observe(report compatibility.ProcessingReport)
 func (d *commandTelemetryDetails) addWarnings(warnings []compiler.Warning) {
 	for _, warning := range warnings {
 		if allowlistedTelemetryDiagnosticCode(warning.Code) {
-			d.addDiagnostic(warning.Code, telemetry.SeverityWarning)
+			d.addDiagnostic(warning.Code, telemetry.SeverityWarning, "", "")
 		}
 	}
 }
@@ -127,14 +136,15 @@ func (d *commandTelemetryDetails) addWarnings(warnings []compiler.Warning) {
 // never proven. Upload keeps this in telemetry rather than the processing
 // report, where it would annotate every import that uses actions.
 func (d *commandTelemetryDetails) addActionRuntimeUnknown() {
-	d.addDiagnostic("W_ACTION_RUNTIME_UNKNOWN", telemetry.SeverityWarning)
+	d.addDiagnostic("W_ACTION_RUNTIME_UNKNOWN", telemetry.SeverityWarning, "", "")
 }
 
-func (d *commandTelemetryDetails) addDiagnostic(code string, severity telemetry.Severity) {
+func (d *commandTelemetryDetails) addDiagnostic(code string, severity telemetry.Severity, blocker, blockerDetail string) {
 	if d.seen == nil {
-		d.seen = make(map[string]int)
+		d.seen = make(map[telemetryDiagnosticKey]int)
 	}
-	if index, exists := d.seen[code]; exists {
+	key := telemetryDiagnosticKey{code: code, blocker: blocker, blockerDetail: blockerDetail}
+	if index, exists := d.seen[key]; exists {
 		if severity == telemetry.SeverityError {
 			d.diagnostics[index].Severity = severity
 		}
@@ -143,13 +153,19 @@ func (d *commandTelemetryDetails) addDiagnostic(code string, severity telemetry.
 	if len(d.diagnostics) == maxCommandTelemetryDiagnostics {
 		return
 	}
-	d.seen[code] = len(d.diagnostics)
-	d.diagnostics = append(d.diagnostics, telemetry.Diagnostic{Code: code, Severity: severity})
+	d.seen[key] = len(d.diagnostics)
+	d.diagnostics = append(d.diagnostics, telemetry.Diagnostic{Code: code, Severity: severity, Blocker: blocker, BlockerDetail: blockerDetail})
+}
+
+func (d *commandTelemetryDetails) setBlocker(blocker, detail string) {
+	if d.blocker == "" && blocker != "" {
+		d.blocker, d.blockerDetail = blocker, detail
+	}
 }
 
 func (d *commandTelemetryDetails) forOutcome(outcome telemetry.Outcome) telemetry.Details {
 	if outcome == telemetry.OutcomeSuccess || outcome == telemetry.OutcomeSkipped {
-		return telemetry.Details{Diagnostics: slices.Clone(d.diagnostics)}
+		return telemetry.Details{Diagnostics: slices.Clone(d.diagnostics), Blocker: d.blocker, BlockerDetail: d.blockerDetail}
 	}
 	phase, code := d.failurePhase, d.failureCode
 	if phase == "" {
@@ -164,12 +180,13 @@ func (d *commandTelemetryDetails) forOutcome(outcome telemetry.Outcome) telemetr
 	}
 	return telemetry.Details{
 		FailurePhase: phase, FailureCode: code, Diagnostics: slices.Clone(d.diagnostics),
+		Blocker: d.blocker, BlockerDetail: d.blockerDetail,
 		ErrorMessage: string(d.errorOutput.bytes), ErrorMessageTruncated: d.errorOutput.truncated,
 	}
 }
 
 func (d *commandTelemetryDetails) telemetryDetails() telemetry.Details {
-	return telemetry.Details{FailurePhase: d.failurePhase, FailureCode: d.failureCode, Diagnostics: slices.Clone(d.diagnostics)}
+	return telemetry.Details{FailurePhase: d.failurePhase, FailureCode: d.failureCode, Diagnostics: slices.Clone(d.diagnostics), Blocker: d.blocker, BlockerDetail: d.blockerDetail}
 }
 
 func telemetrySeverity(level string) (telemetry.Severity, bool) {

--- a/internal/cli/telemetry.go
+++ b/internal/cli/telemetry.go
@@ -127,7 +127,7 @@ func (d *commandTelemetryDetails) observe(report compatibility.ProcessingReport)
 func (d *commandTelemetryDetails) addWarnings(warnings []compiler.Warning) {
 	for _, warning := range warnings {
 		if allowlistedTelemetryDiagnosticCode(warning.Code) {
-			d.addDiagnostic(warning.Code, telemetry.SeverityWarning, "", "")
+			d.addDiagnostic(warning.Code, telemetry.SeverityWarning, warning.Blocker, warning.BlockerDetail)
 		}
 	}
 }
@@ -206,7 +206,7 @@ func allowlistedTelemetryDiagnosticCode(code string) bool {
 		compiler.CodeMatrixInvalid, compiler.CodeExpressionInvalid, compiler.CodeActionDiscovery,
 		compiler.CodeActionResolution, compiler.CodePlanConstruction, compiler.CodePipelineGeneration,
 		compiler.CodeEnvironment, "E_PROFILE", "W_ACTION_RUNTIME_UNKNOWN",
-		"W_WORKFLOW_CONCURRENCY_CANCEL_IN_PROGRESS_IGNORED":
+		"W_WORKFLOW_CONCURRENCY_CANCEL_IN_PROGRESS_IGNORED", "W_TRIGGER_EVENT_UNSUPPORTED":
 		return true
 	default:
 		return false

--- a/internal/cli/telemetry_test.go
+++ b/internal/cli/telemetry_test.go
@@ -131,6 +131,8 @@ func TestCommandTelemetryDetailsCollectTypedDiagnostics(t *testing.T) {
 	details.observe(compatibility.ProcessingReport{Diagnostics: []compatibility.Diagnostic{
 		{Level: "error", Code: compiler.CodeWorkflowSyntax, Stage: string(compiler.StageWorkflowParsing), Message: "must not be uploaded"},
 		{Level: "error", Code: compiler.CodeWorkflowSyntax, Stage: string(compiler.StageWorkflowParsing), Message: "different sensitive text"},
+		{Level: "error", Code: compiler.CodeExpressionInvalid, Stage: string(compiler.StageExpressions), Blocker: "runner_label", BlockerDetail: "windows-latest", Message: "must not be uploaded"},
+		{Level: "error", Code: compiler.CodeExpressionInvalid, Stage: string(compiler.StageExpressions), Blocker: "runner_label", BlockerDetail: "macos-10", Message: "must not be uploaded"},
 		{Level: "warning", Code: "W_ACTION_RUNTIME_UNKNOWN", Stage: string(compiler.StageAdmission), Message: "must not be uploaded"},
 		{Level: "error", Code: "E_FUTURE_UNALLOWLISTED", Stage: string(compiler.StageGraph), Message: "must not be uploaded"},
 	}})
@@ -138,8 +140,13 @@ func TestCommandTelemetryDetailsCollectTypedDiagnostics(t *testing.T) {
 	if got.FailurePhase != "parsing" || got.FailureCode != "E_WORKFLOW_SYNTAX" {
 		t.Fatalf("failure details = %#v", got)
 	}
+	if got.Blocker != "runner_label" || got.BlockerDetail != "windows-latest" {
+		t.Fatalf("blocker = %q / %q", got.Blocker, got.BlockerDetail)
+	}
 	want := []telemetry.Diagnostic{
 		{Code: compiler.CodeWorkflowSyntax, Severity: telemetry.SeverityError},
+		{Code: compiler.CodeExpressionInvalid, Severity: telemetry.SeverityError, Blocker: "runner_label", BlockerDetail: "windows-latest"},
+		{Code: compiler.CodeExpressionInvalid, Severity: telemetry.SeverityError, Blocker: "runner_label", BlockerDetail: "macos-10"},
 		{Code: "W_ACTION_RUNTIME_UNKNOWN", Severity: telemetry.SeverityWarning},
 	}
 	if !reflect.DeepEqual(got.Diagnostics, want) {

--- a/internal/cli/telemetry_test.go
+++ b/internal/cli/telemetry_test.go
@@ -154,6 +154,20 @@ func TestCommandTelemetryDetailsCollectTypedDiagnostics(t *testing.T) {
 	}
 }
 
+func TestTriggerFailureTelemetryIncludesTrigger(t *testing.T) {
+	for _, triggerErr := range []error{
+		&buildkitepipeline.UnsupportedTriggerEventError{Event: "workflow_run"},
+		&buildkitepipeline.UnsupportedPathFiltersError{Event: "push", Reason: "history unavailable"},
+	} {
+		details := &commandTelemetryDetails{}
+		details.observe(triggerFailureProcessingReport(workflowInput{Path: "workflow.yml", Source: []byte("on: push\n")}, triggerErr))
+		got := details.telemetryDetails()
+		if got.Blocker != "trigger" || got.BlockerDetail == "" || len(got.Diagnostics) != 1 || got.Diagnostics[0].Blocker != "trigger" || got.Diagnostics[0].BlockerDetail != got.BlockerDetail {
+			t.Fatalf("trigger telemetry = %#v", got)
+		}
+	}
+}
+
 func TestUnprovenActionRuntimeIgnoresNativeAdapters(t *testing.T) {
 	bundleWith := func(locks ...plan.ActionLock) compiler.Bundle {
 		return compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: plan.Job{

--- a/internal/cli/telemetry_test.go
+++ b/internal/cli/telemetry_test.go
@@ -168,6 +168,21 @@ func TestTriggerFailureTelemetryIncludesTrigger(t *testing.T) {
 	}
 }
 
+func TestUnsupportedTriggerWarningTelemetryIncludesTrigger(t *testing.T) {
+	details := &commandTelemetryDetails{}
+	details.addWarnings([]compiler.Warning{{
+		Code: "W_TRIGGER_EVENT_UNSUPPORTED", Blocker: "trigger", BlockerDetail: "workflow_run",
+	}})
+	got := details.telemetryDetails()
+	want := []telemetry.Diagnostic{{
+		Code: "W_TRIGGER_EVENT_UNSUPPORTED", Severity: telemetry.SeverityWarning,
+		Blocker: "trigger", BlockerDetail: "workflow_run",
+	}}
+	if !reflect.DeepEqual(got.Diagnostics, want) {
+		t.Fatalf("diagnostics = %#v, want %#v", got.Diagnostics, want)
+	}
+}
+
 func TestUnprovenActionRuntimeIgnoresNativeAdapters(t *testing.T) {
 	bundleWith := func(locks ...plan.ActionLock) compiler.Bundle {
 		return compiler.Bundle{Plans: []compiler.PlanArtifact{{Job: plan.Job{

--- a/internal/compatibility/processing_compiler.go
+++ b/internal/compatibility/processing_compiler.go
@@ -341,10 +341,6 @@ func diagnosticFromError(defaultPath, stage, code, category string, err error) D
 			}
 		}
 	}
-	if diagnostic.Blocker == "" && diagnostic.Action != "" {
-		diagnostic.Blocker = "action_ref"
-		diagnostic.BlockerDetail = diagnostic.Action
-	}
 	if diagnostic.Blocker == "" {
 		var blocker interface {
 			CompatibilityBlocker() (string, string)

--- a/internal/compatibility/processing_compiler.go
+++ b/internal/compatibility/processing_compiler.go
@@ -322,17 +322,6 @@ func diagnosticFromError(defaultPath, stage, code, category string, err error) D
 		diagnostic.Action = finding.Action
 		diagnostic.Step = finding.Step
 	}
-	if diagnostic.Blocker == "" {
-		var blocker interface {
-			CompatibilityBlocker() (string, string)
-		}
-		if errors.As(err, &blocker) {
-			diagnostic.Blocker, diagnostic.BlockerDetail = blocker.CompatibilityBlocker()
-		}
-	}
-	if diagnostic.Blocker == "" && diagnostic.Code == compiler.CodeExpressionInvalid {
-		diagnostic.Blocker = "expression"
-	}
 	if diagnostic.Location == nil && defaultPath != "" && stage != "" && stage != stageEventValidation {
 		diagnostic.Location = sourceLocation(defaultPath, 1, 1)
 	}
@@ -355,6 +344,17 @@ func diagnosticFromError(defaultPath, stage, code, category string, err error) D
 	if diagnostic.Blocker == "" && diagnostic.Action != "" {
 		diagnostic.Blocker = "action_ref"
 		diagnostic.BlockerDetail = diagnostic.Action
+	}
+	if diagnostic.Blocker == "" {
+		var blocker interface {
+			CompatibilityBlocker() (string, string)
+		}
+		if errors.As(err, &blocker) {
+			diagnostic.Blocker, diagnostic.BlockerDetail = blocker.CompatibilityBlocker()
+		}
+	}
+	if diagnostic.Blocker == "" && diagnostic.Code == compiler.CodeExpressionInvalid {
+		diagnostic.Blocker = "expression"
 	}
 	return diagnostic
 }

--- a/internal/compatibility/processing_compiler.go
+++ b/internal/compatibility/processing_compiler.go
@@ -1,6 +1,7 @@
 package compatibility
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -320,6 +321,14 @@ func diagnosticFromError(defaultPath, stage, code, category string, err error) D
 		diagnostic.Instance = finding.Instance
 		diagnostic.Action = finding.Action
 		diagnostic.Step = finding.Step
+	}
+	if diagnostic.Blocker == "" {
+		var blocker interface {
+			CompatibilityBlocker() (string, string)
+		}
+		if errors.As(err, &blocker) {
+			diagnostic.Blocker, diagnostic.BlockerDetail = blocker.CompatibilityBlocker()
+		}
 	}
 	if diagnostic.Blocker == "" && diagnostic.Code == compiler.CodeExpressionInvalid {
 		diagnostic.Blocker = "expression"

--- a/internal/compatibility/processing_compiler.go
+++ b/internal/compatibility/processing_compiler.go
@@ -102,6 +102,7 @@ func (r *ProcessingReport) ApplyWarnings(path string, warnings []compiler.Warnin
 			Level: "warning", Code: warning.Code, Category: "compatibility", Stage: stageExpressions,
 			Message:  fmt.Sprintf("%s:%d:%d: %s", warningPath, warning.Line, warning.Column, warning.Message),
 			Location: sourceLocation(warningPath, warning.Line, warning.Column), Job: warning.Job, Step: warning.Step,
+			Blocker: warning.Blocker, BlockerDetail: warning.BlockerDetail,
 		})
 	}
 }

--- a/internal/compatibility/processing_compiler.go
+++ b/internal/compatibility/processing_compiler.go
@@ -314,10 +314,15 @@ func diagnosticFromError(defaultPath, stage, code, category string, err error) D
 		Message: message, Detail: detail, Location: location,
 	}
 	if finding != nil {
+		diagnostic.Blocker = finding.Blocker
+		diagnostic.BlockerDetail = finding.BlockerDetail
 		diagnostic.Job = finding.Job
 		diagnostic.Instance = finding.Instance
 		diagnostic.Action = finding.Action
 		diagnostic.Step = finding.Step
+	}
+	if diagnostic.Blocker == "" && diagnostic.Code == compiler.CodeExpressionInvalid {
+		diagnostic.Blocker = "expression"
 	}
 	if diagnostic.Location == nil && defaultPath != "" && stage != "" && stage != stageEventValidation {
 		diagnostic.Location = sourceLocation(defaultPath, 1, 1)
@@ -337,6 +342,10 @@ func diagnosticFromError(defaultPath, stage, code, category string, err error) D
 				diagnostic.Action = before
 			}
 		}
+	}
+	if diagnostic.Blocker == "" && diagnostic.Action != "" {
+		diagnostic.Blocker = "action_ref"
+		diagnostic.BlockerDetail = diagnostic.Action
 	}
 	return diagnostic
 }

--- a/internal/compatibility/report.go
+++ b/internal/compatibility/report.go
@@ -28,17 +28,21 @@ type SourceLocation struct {
 
 // Diagnostic is one actionable compatibility finding.
 type Diagnostic struct {
-	Level    string          `json:"level"`
-	Code     string          `json:"code"`
-	Category string          `json:"category,omitempty"`
-	Stage    string          `json:"stage,omitempty"`
-	Message  string          `json:"message"`
-	Detail   string          `json:"detail,omitempty"`
-	Location *SourceLocation `json:"location,omitempty"`
-	Job      string          `json:"job,omitempty"`
-	Instance string          `json:"instance,omitempty"`
-	Action   string          `json:"action,omitempty"`
-	Step     int             `json:"step,omitempty"`
+	Level    string `json:"level"`
+	Code     string `json:"code"`
+	Category string `json:"category,omitempty"`
+	Stage    string `json:"stage,omitempty"`
+	// Blocker attribution is forwarded to telemetry but excluded from the
+	// versioned processing-report schema.
+	Blocker       string          `json:"-"`
+	BlockerDetail string          `json:"-"`
+	Message       string          `json:"message"`
+	Detail        string          `json:"detail,omitempty"`
+	Location      *SourceLocation `json:"location,omitempty"`
+	Job           string          `json:"job,omitempty"`
+	Instance      string          `json:"instance,omitempty"`
+	Action        string          `json:"action,omitempty"`
+	Step          int             `json:"step,omitempty"`
 }
 
 // ProcessingStage is one required workflow-processing boundary.
@@ -197,8 +201,8 @@ func compactDiagnostics(diagnostics []Diagnostic) []Diagnostic {
 		return diagnostics
 	}
 	type diagnosticKey struct {
-		level, code, category, stage, message, detail, job, action, location string
-		step                                                                 int
+		level, code, category, stage, blocker, blockerDetail, message, detail, job, action, location string
+		step                                                                                         int
 	}
 	type matrixDiagnostic struct {
 		index     int
@@ -209,7 +213,8 @@ func compactDiagnostics(diagnostics []Diagnostic) []Diagnostic {
 	for _, diagnostic := range diagnostics {
 		key := diagnosticKey{
 			level: diagnostic.Level, code: diagnostic.Code, category: diagnostic.Category,
-			stage: diagnostic.Stage, message: diagnostic.Message, detail: diagnostic.Detail, job: diagnostic.Job,
+			stage: diagnostic.Stage, blocker: diagnostic.Blocker, blockerDetail: diagnostic.BlockerDetail,
+			message: diagnostic.Message, detail: diagnostic.Detail, job: diagnostic.Job,
 			action: diagnostic.Action, step: diagnostic.Step,
 		}
 		if diagnostic.Location != nil {
@@ -244,7 +249,7 @@ func compactDiagnostics(diagnostics []Diagnostic) []Diagnostic {
 }
 
 func sameDiagnostic(left, right Diagnostic) bool {
-	return left.Level == right.Level && left.Code == right.Code && left.Category == right.Category && left.Stage == right.Stage && left.Message == right.Message && left.Detail == right.Detail && left.Job == right.Job && left.Instance == right.Instance && left.Action == right.Action && left.Step == right.Step && sameLocation(left.Location, right.Location)
+	return left.Level == right.Level && left.Code == right.Code && left.Category == right.Category && left.Stage == right.Stage && left.Blocker == right.Blocker && left.BlockerDetail == right.BlockerDetail && left.Message == right.Message && left.Detail == right.Detail && left.Job == right.Job && left.Instance == right.Instance && left.Action == right.Action && left.Step == right.Step && sameLocation(left.Location, right.Location)
 }
 
 func sameLocation(left, right *SourceLocation) bool {

--- a/internal/compatibility/report_test.go
+++ b/internal/compatibility/report_test.go
@@ -288,10 +288,17 @@ func TestApplyWarningsPreservesCompilerAttribution(t *testing.T) {
 	}
 }
 
+type nestedBlockerError struct{}
+
+func (*nestedBlockerError) Error() string { return "unsupported action lifecycle condition" }
+func (*nestedBlockerError) CompatibilityBlocker() (string, string) {
+	return "expression", "secrets.TOKEN"
+}
+
 func TestDiagnosticPreservesStructuredBlockerAndActionFallback(t *testing.T) {
 	diagnostic := diagnosticFromError("ci.yml", stageResolution, compiler.CodeActionResolution, "action-resolution", &compiler.ProcessingFinding{
 		Stage: compiler.StageResolution, Code: compiler.CodeActionResolution, Category: "action-resolution",
-		Action: "actions/checkout@v99", Err: fmt.Errorf("unsupported action"),
+		Action: "actions/checkout@v99", Err: &nestedBlockerError{},
 	})
 	if diagnostic.Blocker != "action_ref" || diagnostic.BlockerDetail != "actions/checkout@v99" {
 		t.Fatalf("diagnostic blocker = %q / %q", diagnostic.Blocker, diagnostic.BlockerDetail)

--- a/internal/compatibility/report_test.go
+++ b/internal/compatibility/report_test.go
@@ -295,10 +295,11 @@ func (*nestedBlockerError) CompatibilityBlocker() (string, string) {
 	return "expression", "secrets.TOKEN"
 }
 
-func TestDiagnosticPreservesStructuredBlockerAndActionFallback(t *testing.T) {
+func TestDiagnosticPreservesExplicitWorkflowRootActionBlocker(t *testing.T) {
 	diagnostic := diagnosticFromError("ci.yml", stageResolution, compiler.CodeActionResolution, "action-resolution", &compiler.ProcessingFinding{
 		Stage: compiler.StageResolution, Code: compiler.CodeActionResolution, Category: "action-resolution",
-		Action: "actions/checkout@v99", Err: &nestedBlockerError{},
+		Blocker: "action_ref", BlockerDetail: "actions/checkout@v99",
+		Action: "./downloaded-child", Err: &nestedBlockerError{},
 	})
 	if diagnostic.Blocker != "action_ref" || diagnostic.BlockerDetail != "actions/checkout@v99" {
 		t.Fatalf("diagnostic blocker = %q / %q", diagnostic.Blocker, diagnostic.BlockerDetail)

--- a/internal/compatibility/report_test.go
+++ b/internal/compatibility/report_test.go
@@ -3,6 +3,7 @@ package compatibility
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -284,5 +285,23 @@ func TestApplyWarningsPreservesCompilerAttribution(t *testing.T) {
 	}
 	if len(report.Diagnostics) != 1 || !sameDiagnostic(report.Diagnostics[0], want) {
 		t.Fatalf("diagnostics = %#v, want %#v", report.Diagnostics, []Diagnostic{want})
+	}
+}
+
+func TestDiagnosticPreservesStructuredBlockerAndActionFallback(t *testing.T) {
+	diagnostic := diagnosticFromError("ci.yml", stageResolution, compiler.CodeActionResolution, "action-resolution", &compiler.ProcessingFinding{
+		Stage: compiler.StageResolution, Code: compiler.CodeActionResolution, Category: "action-resolution",
+		Action: "actions/checkout@v99", Err: fmt.Errorf("unsupported action"),
+	})
+	if diagnostic.Blocker != "action_ref" || diagnostic.BlockerDetail != "actions/checkout@v99" {
+		t.Fatalf("diagnostic blocker = %q / %q", diagnostic.Blocker, diagnostic.BlockerDetail)
+	}
+
+	diagnostic = diagnosticFromError("ci.yml", stageExpressions, compiler.CodeExpressionInvalid, "compatibility", &compiler.ProcessingFinding{
+		Stage: compiler.StageExpressions, Code: compiler.CodeExpressionInvalid, Category: "compatibility",
+		Blocker: "runner_label", BlockerDetail: "windows-latest", Err: fmt.Errorf("unsupported runner"),
+	})
+	if diagnostic.Blocker != "runner_label" || diagnostic.BlockerDetail != "windows-latest" {
+		t.Fatalf("diagnostic blocker = %q / %q", diagnostic.Blocker, diagnostic.BlockerDetail)
 	}
 }

--- a/internal/compatibility/report_test.go
+++ b/internal/compatibility/report_test.go
@@ -305,3 +305,25 @@ func TestDiagnosticPreservesStructuredBlockerAndActionFallback(t *testing.T) {
 		t.Fatalf("diagnostic blocker = %q / %q", diagnostic.Blocker, diagnostic.BlockerDetail)
 	}
 }
+
+func TestProcessingReportPreservesReusableCallConditionBlocker(t *testing.T) {
+	repository := t.TempDir()
+	workflows := filepath.Join(repository, ".github", "workflows")
+	if err := os.MkdirAll(workflows, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	callerPath := filepath.Join(workflows, "caller.yml")
+	caller := []byte("on: push\njobs:\n  delegated:\n    if: secrets.TOKEN\n    uses: ./.github/workflows/reusable.yml\n")
+	if err := os.WriteFile(callerPath, caller, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workflows, "reusable.yml"), []byte("on: workflow_call\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	compilerReport, processingErr := compiler.Validate(callerPath, caller)
+	report := InitialProcessingReport(callerPath, "hosted", false, compilerReport, processingErr)
+	if len(report.Diagnostics) != 1 || report.Diagnostics[0].Blocker != "expression" || report.Diagnostics[0].BlockerDetail != "secrets.TOKEN" {
+		t.Fatalf("reusable call diagnostics = %#v", report.Diagnostics)
+	}
+}

--- a/internal/compatibility/report_test.go
+++ b/internal/compatibility/report_test.go
@@ -275,13 +275,14 @@ func TestApplyWarningsPreservesCompilerAttribution(t *testing.T) {
 	report := NewProcessingReport(".github/workflows/caller.yml", "hosted")
 	report.ApplyWarnings(report.Workflow, []compiler.Warning{{
 		Code: "W_CHECKOUT_LEGACY_RELEASE", Path: ".github/workflows/reusable.yml", Line: 12, Column: 9,
-		Job: "call.build", Step: 2, Message: "actions/checkout v2.8.0 behaves like v2.",
+		Job: "call.build", Step: 2, Blocker: "trigger", BlockerDetail: "workflow_run",
+		Message: "actions/checkout v2.8.0 behaves like v2.",
 	}})
 	want := Diagnostic{
 		Level: "warning", Code: "W_CHECKOUT_LEGACY_RELEASE", Category: "compatibility", Stage: "expression-validation",
 		Message:  ".github/workflows/reusable.yml:12:9: actions/checkout v2.8.0 behaves like v2.",
 		Location: &SourceLocation{Path: ".github/workflows/reusable.yml", Line: 12, Column: 9},
-		Job:      "call.build", Step: 2,
+		Job:      "call.build", Step: 2, Blocker: "trigger", BlockerDetail: "workflow_run",
 	}
 	if len(report.Diagnostics) != 1 || !sameDiagnostic(report.Diagnostics[0], want) {
 		t.Fatalf("diagnostics = %#v, want %#v", report.Diagnostics, []Diagnostic{want})

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -118,6 +118,7 @@ func validateActionResolutions(ctx context.Context, ir IR, options Options) (Pro
 			message, detail, action := actionResolutionMessage(step.Uses, err)
 			diagnostics = append(diagnostics, &ProcessingFinding{
 				Stage: StageResolution, Code: CodeActionResolution, Category: "action-resolution",
+				Blocker: "action_ref", BlockerDetail: step.Uses,
 				Path: instance.SourcePath, Line: position.Line, Column: position.Column,
 				Job: instance.LogicalJobID, Instance: instance.Key, Action: action, Step: i + 1,
 				Message: message, Detail: detail,

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -116,9 +116,13 @@ func validateActionResolutions(ctx context.Context, ir IR, options Options) (Pro
 			}
 			position := step.Span.Start
 			message, detail, action := actionResolutionMessage(step.Uses, err)
+			blockerDetail := step.Uses
+			if len(instance.Inputs) != 0 {
+				blockerDetail = ""
+			}
 			diagnostics = append(diagnostics, &ProcessingFinding{
 				Stage: StageResolution, Code: CodeActionResolution, Category: "action-resolution",
-				Blocker: "action_ref", BlockerDetail: step.Uses,
+				Blocker: "action_ref", BlockerDetail: blockerDetail,
 				Path: instance.SourcePath, Line: position.Line, Column: position.Column,
 				Job: instance.LogicalJobID, Instance: instance.Key, Action: action, Step: i + 1,
 				Message: message, Detail: detail,

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -117,7 +117,7 @@ func validateActionResolutions(ctx context.Context, ir IR, options Options) (Pro
 			position := step.Span.Start
 			message, detail, action := actionResolutionMessage(step.Uses, err)
 			blockerDetail := step.Uses
-			if len(instance.Inputs) != 0 {
+			if instance.BlockerDetailUnsafe {
 				blockerDetail = ""
 			}
 			diagnostics = append(diagnostics, &ProcessingFinding{

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -718,11 +718,13 @@ func supported(path string, job workflow.Job) error {
 	ids := make(map[string]struct{}, len(job.Steps))
 	for i, step := range job.Steps {
 		if step.Kind == "uses" && strings.HasPrefix(strings.ToLower(step.Uses), "docker://") {
-			return attributedProcessingFinding(
-				StageGraph, CodeGraphInvalid, "compatibility", path, step.Span.Start.Line, step.Span.Start.Column,
-				job.ID, "", step.Uses, i+1,
-				locatedJobError(path, job, step.Span.Start.Line, step.Span.Start.Column, actionsource.UnsupportedContainerActionReason),
-			)
+			return &ProcessingFinding{
+				Stage: StageGraph, Code: CodeGraphInvalid, Category: "compatibility",
+				Blocker: "action_ref", BlockerDetail: step.Uses,
+				Path: path, Line: step.Span.Start.Line, Column: step.Span.Start.Column,
+				Job: job.ID, Action: step.Uses, Step: i + 1,
+				Err: locatedJobError(path, job, step.Span.Start.Line, step.Span.Start.Column, actionsource.UnsupportedContainerActionReason),
+			}
 		}
 		if step.ID != "" {
 			id := strings.ToLower(step.ID)

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -44,13 +44,15 @@ type WorkflowConcurrencyGate struct {
 
 // Warning is one source-located, non-fatal compatibility diagnostic.
 type Warning struct {
-	Code    string `json:"code"`
-	Path    string `json:"path,omitempty"`
-	Line    int    `json:"line"`
-	Column  int    `json:"column"`
-	Job     string `json:"job,omitempty"`
-	Step    int    `json:"step,omitempty"`
-	Message string `json:"message"`
+	Code          string `json:"code"`
+	Blocker       string `json:"blocker,omitempty"`
+	BlockerDetail string `json:"blocker_detail,omitempty"`
+	Path          string `json:"path,omitempty"`
+	Line          int    `json:"line"`
+	Column        int    `json:"column"`
+	Job           string `json:"job,omitempty"`
+	Step          int    `json:"step,omitempty"`
+	Message       string `json:"message"`
 }
 
 // ExecutionBoundary makes the compile-only boundary explicit.
@@ -443,10 +445,12 @@ func compilerWarnings(parsed *workflow.Workflow, cancelInProgress bool) []Warnin
 		}
 		message += fmt.Sprintf(" If you need %s, log an issue on https://github.com/buildkite/buildkite-gha so we can prioritise it.", trigger.Event)
 		warnings = append(warnings, Warning{
-			Code:    "W_TRIGGER_EVENT_UNSUPPORTED",
-			Line:    trigger.Position.Line,
-			Column:  trigger.Position.Column,
-			Message: message,
+			Code:          "W_TRIGGER_EVENT_UNSUPPORTED",
+			Blocker:       "trigger",
+			BlockerDetail: trigger.Event,
+			Line:          trigger.Position.Line,
+			Column:        trigger.Position.Column,
+			Message:       message,
 		})
 	}
 	if parsed.Concurrency != nil && cancelInProgress {

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -108,6 +108,7 @@ type JobInstance struct {
 	SourcePath              string                    `json:"source_path"`
 	SourceDigest            string                    `json:"source_digest"`
 	RemoteWorkflow          *RemoteWorkflowSource     `json:"remote_workflow,omitempty"`
+	BlockerDetailUnsafe     bool                      `json:"blocker_detail_unsafe,omitempty"`
 	RepositoryRoot          string                    `json:"-"`
 	Source                  workflow.Span             `json:"source"`
 	secretAuthority         secretAuthority

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -806,7 +806,7 @@ func validateConditions(path string, job workflow.Job, validate func(string, exp
 		if position.Line == 0 {
 			position = job.Span.Start
 		}
-		diagnostics = append(diagnostics, locatedJobError(path, job, position.Line, position.Column, fmt.Sprintf("job condition: %v", err)))
+		diagnostics = append(diagnostics, locatedJobWrappedError(path, job, position.Line, position.Column, "job condition", err))
 	}
 	for i, step := range job.Steps {
 		if err := validate(step.If, expression.StepCondition); err != nil {
@@ -818,7 +818,7 @@ func validateConditions(path string, job workflow.Job, validate func(string, exp
 			if step.ID != "" {
 				label = fmt.Sprintf("step %q", step.ID)
 			}
-			diagnostics = append(diagnostics, locatedJobError(path, job, position.Line, position.Column, fmt.Sprintf("%s condition: %v", label, err)))
+			diagnostics = append(diagnostics, locatedJobWrappedError(path, job, position.Line, position.Column, label+" condition", err))
 		}
 	}
 	return errors.Join(diagnostics...)

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -4703,7 +4703,7 @@ func TestCompilerWarningsNameOnlyDeclaredSupportedTriggers(t *testing.T) {
 	}}
 	warnings := compilerWarnings(parsed, false)
 	want := Warning{
-		Code: "W_TRIGGER_EVENT_UNSUPPORTED", Line: 4, Column: 3,
+		Code: "W_TRIGGER_EVENT_UNSUPPORTED", Blocker: "trigger", BlockerDetail: "issue_comment", Line: 4, Column: 3,
 		Message: "on.issue_comment is ignored, so nothing in this workflow runs from it. The supported triggers declared in this workflow still run: issues, merge_group, pull_request, push, release, schedule, workflow_call, workflow_dispatch. Move the jobs this trigger guards to one of those triggers if you need them. If you need issue_comment, log an issue on https://github.com/buildkite/buildkite-gha so we can prioritise it.",
 	}
 	if !reflect.DeepEqual(warnings, []Warning{want}) {
@@ -4713,7 +4713,7 @@ func TestCompilerWarningsNameOnlyDeclaredSupportedTriggers(t *testing.T) {
 	parsed.Triggers = []workflow.Trigger{{Event: "issue_comment", Position: workflow.Position{Line: 1, Column: 5}}}
 	warnings = compilerWarnings(parsed, false)
 	want = Warning{
-		Code: "W_TRIGGER_EVENT_UNSUPPORTED", Line: 1, Column: 5,
+		Code: "W_TRIGGER_EVENT_UNSUPPORTED", Blocker: "trigger", BlockerDetail: "issue_comment", Line: 1, Column: 5,
 		Message: "on.issue_comment is ignored, so nothing in this workflow runs from it. This workflow declares no supported triggers that still run. If you need issue_comment, log an issue on https://github.com/buildkite/buildkite-gha so we can prioritise it.",
 	}
 	if !reflect.DeepEqual(warnings, []Warning{want}) {

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -913,6 +913,7 @@ func TestBlockerFieldsChangedTracksInputSubstitutionSurfaces(t *testing.T) {
 	}{
 		{name: "job condition", change: func(job *workflow.Job) { job.If = "false" }, want: true},
 		{name: "runner", change: func(job *workflow.Job) { job.RunsOn = []string{"private"} }, want: true},
+		{name: "matrix", change: func(job *workflow.Job) { job.Matrix = &workflow.Matrix{} }, want: true},
 		{name: "action", change: func(job *workflow.Job) { job.Steps[0].Uses = "owner/other@v1" }, want: true},
 		{name: "shell", change: func(job *workflow.Job) { job.Steps[0].Shell = "pwsh" }, want: true},
 		{name: "unrelated run command", change: func(job *workflow.Job) { job.Steps[0].Run = "echo changed" }},
@@ -927,6 +928,50 @@ func TestBlockerFieldsChangedTracksInputSubstitutionSurfaces(t *testing.T) {
 				t.Fatalf("blockerFieldsChanged() = %t, want %t", got, test.want)
 			}
 		})
+	}
+}
+
+func TestCompileDoesNotAttributeReusableInputThroughRunnerMatrix(t *testing.T) {
+	repository := t.TempDir()
+	callerPath := writeWorkflow(t, repository, "caller.yml", `on: push
+jobs:
+  delegated:
+    uses: ./.github/workflows/reusable.yml
+    with:
+      runner: ${{ github.event.runner }}
+`)
+	writeWorkflow(t, repository, "reusable.yml", `on:
+  workflow_call:
+    inputs:
+      runner:
+        type: string
+        required: true
+jobs:
+  test:
+    strategy:
+      matrix:
+        runner:
+          - ${{ inputs.runner }}
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - run: true
+`)
+	eventSource := pushEvent(t)
+	event := bytes.Replace(eventSource, []byte(`"payload": {`), []byte(`"payload": {"runner": "windows-secret",`), 1)
+	if bytes.Equal(event, eventSource) {
+		t.Fatal("event payload was not updated")
+	}
+
+	_, err := compileUntrustedPlans(callerPath, readFile(t, callerPath), event, "0.0.0-test", testDistributionDigest, "gha-untrusted")
+	if err == nil {
+		t.Fatal("compileUntrustedPlans() succeeded")
+	}
+	var finding *ProcessingFinding
+	if !errors.As(err, &finding) {
+		t.Fatalf("compileUntrustedPlans() error = %T %v, want ProcessingFinding", err, err)
+	}
+	if finding.Blocker != "runner_label" || finding.BlockerDetail != "" {
+		t.Fatalf("finding blocker = %q / %q, want runner_label with no detail: %v", finding.Blocker, finding.BlockerDetail, err)
 	}
 }
 

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -283,9 +283,10 @@ func TestCompileIsByteIdenticalAndCoversSmokeCorpus(t *testing.T) {
 func TestCompilePreflightsUnsupportedConditionsWithLocation(t *testing.T) {
 	eventSource := readFile(t, smokePath("events", "push.json"))
 	for _, test := range []struct {
-		name   string
-		source string
-		want   string
+		name          string
+		source        string
+		want          string
+		blockerDetail string
 	}{
 		{
 			name: "job hash function",
@@ -297,7 +298,8 @@ jobs:
     steps:
       - run: true
 `,
-			want: `conditions.yml:5:9: job "test": job condition: condition function "hashFiles" is unavailable in job conditions`,
+			want:          `conditions.yml:5:9: job "test": job condition: condition function "hashFiles" is unavailable in job conditions`,
+			blockerDetail: `hashFiles('go.sum') != ''`,
 		},
 		{
 			name: "anonymous step context",
@@ -309,7 +311,8 @@ jobs:
       - if: secrets.TOKEN
         run: true
 `,
-			want: `conditions.yml:6:13: job "test": step 1 condition: condition context "secrets" is unsupported`,
+			want:          `conditions.yml:6:13: job "test": step 1 condition: condition context "secrets" is unsupported`,
+			blockerDetail: `secrets.TOKEN`,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -331,6 +334,10 @@ jobs:
 					err := compile()
 					if err == nil || !strings.Contains(err.Error(), test.want) {
 						t.Fatalf("error = %v, want %q", err, test.want)
+					}
+					var finding *ProcessingFinding
+					if !errors.As(err, &finding) || finding.Blocker != "expression" || finding.BlockerDetail != test.blockerDetail {
+						t.Fatalf("condition blocker = %#v, want expression / %q", finding, test.blockerDetail)
 					}
 				})
 			}

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -283,10 +283,9 @@ func TestCompileIsByteIdenticalAndCoversSmokeCorpus(t *testing.T) {
 func TestCompilePreflightsUnsupportedConditionsWithLocation(t *testing.T) {
 	eventSource := readFile(t, smokePath("events", "push.json"))
 	for _, test := range []struct {
-		name          string
-		source        string
-		want          string
-		blockerDetail string
+		name   string
+		source string
+		want   string
 	}{
 		{
 			name: "job hash function",
@@ -298,8 +297,7 @@ jobs:
     steps:
       - run: true
 `,
-			want:          `conditions.yml:5:9: job "test": job condition: condition function "hashFiles" is unavailable in job conditions`,
-			blockerDetail: `hashFiles('go.sum') != ''`,
+			want: `conditions.yml:5:9: job "test": job condition: condition function "hashFiles" is unavailable in job conditions`,
 		},
 		{
 			name: "anonymous step context",
@@ -311,8 +309,7 @@ jobs:
       - if: secrets.TOKEN
         run: true
 `,
-			want:          `conditions.yml:6:13: job "test": step 1 condition: condition context "secrets" is unsupported`,
-			blockerDetail: `secrets.TOKEN`,
+			want: `conditions.yml:6:13: job "test": step 1 condition: condition context "secrets" is unsupported`,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -334,10 +331,6 @@ jobs:
 					err := compile()
 					if err == nil || !strings.Contains(err.Error(), test.want) {
 						t.Fatalf("error = %v, want %q", err, test.want)
-					}
-					var finding *ProcessingFinding
-					if !errors.As(err, &finding) || finding.Blocker != "expression" || finding.BlockerDetail != test.blockerDetail {
-						t.Fatalf("condition blocker = %#v, want expression / %q", finding, test.blockerDetail)
 					}
 				})
 			}

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -901,6 +901,35 @@ jobs:
 	}
 }
 
+func TestBlockerFieldsChangedTracksInputSubstitutionSurfaces(t *testing.T) {
+	base := workflow.Job{
+		If: "true", RunsOn: []string{"ubuntu-latest"}, DefaultShell: "bash",
+		Steps: []workflow.Step{{If: "true", Uses: "owner/action@v1", Shell: "bash", Run: "echo unchanged"}},
+	}
+	tests := []struct {
+		name   string
+		change func(*workflow.Job)
+		want   bool
+	}{
+		{name: "job condition", change: func(job *workflow.Job) { job.If = "false" }, want: true},
+		{name: "runner", change: func(job *workflow.Job) { job.RunsOn = []string{"private"} }, want: true},
+		{name: "action", change: func(job *workflow.Job) { job.Steps[0].Uses = "owner/other@v1" }, want: true},
+		{name: "shell", change: func(job *workflow.Job) { job.Steps[0].Shell = "pwsh" }, want: true},
+		{name: "unrelated run command", change: func(job *workflow.Job) { job.Steps[0].Run = "echo changed" }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			changed := base
+			changed.RunsOn = slices.Clone(base.RunsOn)
+			changed.Steps = slices.Clone(base.Steps)
+			test.change(&changed)
+			if got := blockerFieldsChanged(base, changed); got != test.want {
+				t.Fatalf("blockerFieldsChanged() = %t, want %t", got, test.want)
+			}
+		})
+	}
+}
+
 func TestCompileProjectsOnlyDeclaredReusableWorkflowOutputs(t *testing.T) {
 	repository := t.TempDir()
 	callerPath := writeWorkflow(t, repository, "caller.yml", `on: push

--- a/internal/compiler/config.go
+++ b/internal/compiler/config.go
@@ -314,6 +314,7 @@ const (
 // resolved label.
 type runnerPolicyRejection struct {
 	reason string
+	label  string
 	err    error
 }
 
@@ -322,6 +323,10 @@ func (e *runnerPolicyRejection) Unwrap() error { return e.err }
 
 func rejectRunner(reason, format string, args ...any) error {
 	return &runnerPolicyRejection{reason: reason, err: fmt.Errorf(format, args...)}
+}
+
+func rejectRunnerLabel(reason, label, format string, args ...any) error {
+	return &runnerPolicyRejection{reason: reason, label: label, err: fmt.Errorf(format, args...)}
 }
 
 // Resolve returns the target selected by labels under this policy and trust
@@ -339,7 +344,7 @@ func (policy RunnerPolicy) resolve(labels []string, trust EventTrust) (RunnerTar
 	for i, label := range labels {
 		normalized := strings.ToLower(strings.TrimSpace(label))
 		if _, duplicate := seen[normalized]; duplicate {
-			return RunnerTarget{}, rejectRunner(reasonDuplicateLabel, "runs-on contains duplicate runner label %q", label)
+			return RunnerTarget{}, rejectRunnerLabel(reasonDuplicateLabel, label, "runs-on contains duplicate runner label %q", label)
 		}
 		seen[normalized] = struct{}{}
 		normalizedLabels[i] = normalized
@@ -356,7 +361,7 @@ func (policy RunnerPolicy) resolve(labels []string, trust EventTrust) (RunnerTar
 	for i, label := range labels {
 		normalized := normalizedLabels[i]
 		if unsupportedOS(normalized) {
-			return RunnerTarget{}, rejectRunner(reasonUnsupportedOS, "unsupported operating system runner label %q", label)
+			return RunnerTarget{}, rejectRunnerLabel(reasonUnsupportedOS, label, "unsupported operating system runner label %q", label)
 		}
 		mapped, ok := policy.Targets[normalized]
 		if !ok {
@@ -380,7 +385,7 @@ func (policy RunnerPolicy) resolve(labels []string, trust EventTrust) (RunnerTar
 			}
 		}
 		if !ok {
-			return RunnerTarget{}, rejectRunner(reasonUnmappedLabel, "runner label %q is not mapped by policy", label)
+			return RunnerTarget{}, rejectRunnerLabel(reasonUnmappedLabel, label, "runner label %q is not mapped by policy", label)
 		}
 		if resolved && !RunnerTargetsEqual(target, mapped) {
 			if target.Queue != mapped.Queue && target.Platform == mapped.Platform && target.Image == mapped.Image && cachesEqual(target.Cache, mapped.Cache) {
@@ -467,6 +472,17 @@ func runnerRejectionDiagnostic(err error, labels, supported, untrustedQueues []s
 	default:
 		return "Runner target is unsupported. Use a configured Linux or macOS runner target.", detail
 	}
+}
+
+func runnerRejectionBlockerDetail(err error, reportableLabels []string) string {
+	var rejection *runnerPolicyRejection
+	if errors.As(err, &rejection) && rejection.label != "" && slices.Contains(reportableLabels, rejection.label) {
+		return rejection.label
+	}
+	if len(reportableLabels) == 1 {
+		return reportableLabels[0]
+	}
+	return ""
 }
 
 func (policy RunnerPolicy) supportedLabels() []string {

--- a/internal/compiler/config_test.go
+++ b/internal/compiler/config_test.go
@@ -377,6 +377,60 @@ func TestRunsOnPolicyFailsClosedWithLocatedDiagnostics(t *testing.T) {
 	}
 }
 
+func TestEventDerivedRunnerLabelsOmitBlockerDetail(t *testing.T) {
+	tests := []struct {
+		name     string
+		workflow []byte
+		event    []byte
+	}{
+		{
+			name: "workflow dispatch input",
+			workflow: []byte(`on:
+  workflow_dispatch:
+    inputs:
+      runner:
+        type: string
+jobs:
+  test:
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - run: true
+`),
+			event: bytes.Replace(readFile(t, smokePath("events", "workflow_dispatch.json")), []byte(`"inputs": {}`), []byte(`"inputs": {"runner": "windows-secret"}`), 1),
+		},
+		{
+			name: "matrix value",
+			workflow: []byte(`on: push
+jobs:
+  test:
+    strategy:
+      matrix:
+        runner:
+          - ${{ github.event.runner }}
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - run: true
+`),
+			event: bytes.Replace(pushEvent(t), []byte(`"payload": {`), []byte(`"payload": {"runner": "windows-secret",`), 1),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := CompileWithOptions("policy.yml", test.workflow, test.event, Options{
+				EventTrust: EventTrusted,
+				Runners:    RunnerPolicy{Labels: map[string]string{"ubuntu-latest": "linux"}},
+			})
+			if err == nil {
+				t.Fatal("CompileWithOptions() error = nil, want runner policy rejection")
+			}
+			var finding *ProcessingFinding
+			if !errors.As(err, &finding) || finding.Blocker != "runner_label" || finding.BlockerDetail != "" {
+				t.Fatalf("processing blocker = %#v, want runner_label with no detail", finding)
+			}
+		})
+	}
+}
+
 func TestValidateEventRetainsResolvedRunsOnWhenRunnerPolicyRejectsIt(t *testing.T) {
 	workflow := []byte("on: push\njobs:\n  test:\n    runs-on: macos-26\n    steps:\n      - run: true\n")
 	report, err := ValidateEventWithOptions("policy.yml", workflow, pushEvent(t), Options{

--- a/internal/compiler/config_test.go
+++ b/internal/compiler/config_test.go
@@ -343,14 +343,15 @@ jobs:
 
 func TestRunsOnPolicyFailsClosedWithLocatedDiagnostics(t *testing.T) {
 	tests := []struct {
-		name   string
-		runsOn string
-		vars   map[string]string
-		labels map[string]string
-		want   string
+		name          string
+		runsOn        string
+		vars          map[string]string
+		labels        map[string]string
+		want          string
+		blockerDetail string
 	}{
-		{name: "unsupported operating system", runsOn: "windows-latest", labels: map[string]string{"windows-latest": "windows"}, want: `unsupported operating system runner label "windows-latest"`},
-		{name: "unmapped label", runsOn: "ubuntu-20.04", labels: map[string]string{"ubuntu-24.04": "linux"}, want: `runner label "ubuntu-20.04" is not mapped by policy`},
+		{name: "unsupported operating system", runsOn: "windows-latest", labels: map[string]string{"windows-latest": "windows"}, want: `unsupported operating system runner label "windows-latest"`, blockerDetail: "windows-latest"},
+		{name: "unmapped label", runsOn: "ubuntu-20.04", labels: map[string]string{"ubuntu-24.04": "linux"}, want: `runner label "ubuntu-20.04" is not mapped by policy`, blockerDetail: "ubuntu-20.04"},
 		{name: "unresolved expression", runsOn: "${{ vars.RUNNER }}", labels: map[string]string{"ubuntu-24.04": "linux"}, want: `unavailable value "vars.runner"`},
 		{name: "conflicting labels", runsOn: "[self-hosted, linux]", labels: map[string]string{"self-hosted": "one", "linux": "two"}, want: "runner labels resolve to conflicting queues"},
 	}
@@ -364,6 +365,12 @@ func TestRunsOnPolicyFailsClosedWithLocatedDiagnostics(t *testing.T) {
 			})
 			if err == nil || !strings.Contains(err.Error(), test.want) || !strings.Contains(err.Error(), "policy.yml:") {
 				t.Fatalf("CompileWithOptions() error = %v, want located %q", err, test.want)
+			}
+			if test.blockerDetail != "" {
+				var finding *ProcessingFinding
+				if !errors.As(err, &finding) || finding.Blocker != "runner_label" || finding.BlockerDetail != test.blockerDetail {
+					t.Fatalf("processing blocker = %#v, want runner_label/%s", finding, test.blockerDetail)
+				}
 			}
 		})
 	}

--- a/internal/compiler/config_test.go
+++ b/internal/compiler/config_test.go
@@ -351,6 +351,7 @@ func TestRunsOnPolicyFailsClosedWithLocatedDiagnostics(t *testing.T) {
 		blockerDetail string
 	}{
 		{name: "unsupported operating system", runsOn: "windows-latest", labels: map[string]string{"windows-latest": "windows"}, want: `unsupported operating system runner label "windows-latest"`, blockerDetail: "windows-latest"},
+		{name: "unsupported operating system among labels", runsOn: "[self-hosted, windows-latest]", labels: map[string]string{"self-hosted": "linux"}, want: `unsupported operating system runner label "windows-latest"`, blockerDetail: "windows-latest"},
 		{name: "unmapped label", runsOn: "ubuntu-20.04", labels: map[string]string{"ubuntu-24.04": "linux"}, want: `runner label "ubuntu-20.04" is not mapped by policy`, blockerDetail: "ubuntu-20.04"},
 		{name: "unresolved expression", runsOn: "${{ vars.RUNNER }}", labels: map[string]string{"ubuntu-24.04": "linux"}, want: `unavailable value "vars.runner"`},
 		{name: "conflicting labels", runsOn: "[self-hosted, linux]", labels: map[string]string{"self-hosted": "one", "linux": "two"}, want: "runner labels resolve to conflicting queues"},

--- a/internal/compiler/job_graph_expansion.go
+++ b/internal/compiler/job_graph_expansion.go
@@ -281,13 +281,9 @@ func (e *jobGraphExpansion) expandJobInstances(id string) {
 			if err != nil {
 				reportableLabels := reportableRunnerLabels(job, labels)
 				message, detail := runnerRejectionDiagnostic(err, reportableLabels, e.options.Runners.supportedLabels(), e.options.Runners.UntrustedQueues)
-				blockerDetail := ""
-				if len(reportableLabels) == 1 {
-					blockerDetail = reportableLabels[0]
-				}
 				e.diagnostics = append(e.diagnostics, &ProcessingFinding{
 					Stage: StageExpressions, Code: CodeExpressionInvalid, Category: "compatibility",
-					Blocker: "runner_label", BlockerDetail: blockerDetail,
+					Blocker: "runner_label", BlockerDetail: runnerRejectionBlockerDetail(err, reportableLabels),
 					Path: jobPath, Line: runsOnPosition(job).Line, Column: runsOnPosition(job).Column,
 					Job: job.ID, Instance: key, Message: message, Detail: detail,
 					Err: locatedJobError(jobPath, job, runsOnPosition(job).Line, runsOnPosition(job).Column, err.Error()),

--- a/internal/compiler/job_graph_expansion.go
+++ b/internal/compiler/job_graph_expansion.go
@@ -279,9 +279,15 @@ func (e *jobGraphExpansion) expandJobInstances(id string) {
 		if runsOnErr == nil {
 			target, err = e.options.Runners.resolve(labels, e.options.EventTrust)
 			if err != nil {
-				message, detail := runnerRejectionDiagnostic(err, reportableRunnerLabels(job, labels), e.options.Runners.supportedLabels(), e.options.Runners.UntrustedQueues)
+				reportableLabels := reportableRunnerLabels(job, labels)
+				message, detail := runnerRejectionDiagnostic(err, reportableLabels, e.options.Runners.supportedLabels(), e.options.Runners.UntrustedQueues)
+				blockerDetail := ""
+				if len(reportableLabels) == 1 {
+					blockerDetail = reportableLabels[0]
+				}
 				e.diagnostics = append(e.diagnostics, &ProcessingFinding{
 					Stage: StageExpressions, Code: CodeExpressionInvalid, Category: "compatibility",
+					Blocker: "runner_label", BlockerDetail: blockerDetail,
 					Path: jobPath, Line: runsOnPosition(job).Line, Column: runsOnPosition(job).Column,
 					Job: job.ID, Instance: key, Message: message, Detail: detail,
 					Err: locatedJobError(jobPath, job, runsOnPosition(job).Line, runsOnPosition(job).Column, err.Error()),

--- a/internal/compiler/job_graph_expansion.go
+++ b/internal/compiler/job_graph_expansion.go
@@ -115,6 +115,9 @@ func (e *jobGraphExpansion) acceptJobs(resolved []sourcedJob) {
 		e.acceptedIndex[job.ID] = len(e.accepted)
 		e.accepted = append(e.accepted, sourced)
 		if err := supported(sourced.path, job); err != nil {
+			if sourced.blockerDetailUnsafe {
+				err = suppressBlockerDetail(err)
+			}
 			e.diagnostics = append(e.diagnostics, err)
 			e.failedJobs[job.ID] = true
 		}
@@ -230,6 +233,9 @@ func (e *jobGraphExpansion) expandJobInstances(id string) {
 		instanceContext.Matrix = matrix
 		instanceContext.Strategy = strategy
 		compileConditionErr := supportedCompileTimeConditions(jobPath, job, jobContext)
+		if sourced.blockerDetailUnsafe {
+			compileConditionErr = suppressBlockerDetail(compileConditionErr)
+		}
 		instanceJob := resolveCompileTimeConditions(job, jobContext, matrix)
 		conditionValidationJob := instanceJob
 		conditionContext := jobContext
@@ -265,6 +271,9 @@ func (e *jobGraphExpansion) expandJobInstances(id string) {
 			e.diagnostics = append(e.diagnostics, attributedProcessingFinding(StageExpressions, CodeExpressionInvalid, "compatibility", jobPath, 0, 0, job.ID, key, "", 0, compileConditionErr))
 			valid = false
 		} else if err := supportedConditions(jobPath, conditionValidationJob); err != nil {
+			if sourced.blockerDetailUnsafe {
+				err = suppressBlockerDetail(err)
+			}
 			e.diagnostics = append(e.diagnostics, attributedProcessingFinding(StageExpressions, CodeExpressionInvalid, "compatibility", jobPath, 0, 0, job.ID, key, "", 0, err))
 			valid = false
 		}
@@ -280,6 +289,9 @@ func (e *jobGraphExpansion) expandJobInstances(id string) {
 			target, err = e.options.Runners.resolve(labels, e.options.EventTrust)
 			if err != nil {
 				reportableLabels := reportableRunnerLabels(job, labels)
+				if sourced.blockerDetailUnsafe {
+					reportableLabels = nil
+				}
 				message, detail := runnerRejectionDiagnostic(err, reportableLabels, e.options.Runners.supportedLabels(), e.options.Runners.UntrustedQueues)
 				e.diagnostics = append(e.diagnostics, &ProcessingFinding{
 					Stage: StageExpressions, Code: CodeExpressionInvalid, Category: "compatibility",

--- a/internal/compiler/job_graph_expansion.go
+++ b/internal/compiler/job_graph_expansion.go
@@ -370,7 +370,8 @@ func newJobCandidate(sourced sourcedJob, job workflow.Job, matrix map[string]any
 		Outputs: cloneMap(job.Outputs), Container: job.Container, Services: services,
 		ConcurrencyGates:   append([]WorkflowConcurrencyGate(nil), sourced.concurrencyGates...),
 		ServicesExpression: job.ServicesExpression, SourcePath: sourced.path, SourceDigest: sourced.digest,
-		RemoteWorkflow: cloneRemoteWorkflowSource(sourced.remote), RepositoryRoot: sourced.root, Source: job.Span,
+		RemoteWorkflow: cloneRemoteWorkflowSource(sourced.remote), BlockerDetailUnsafe: sourced.blockerDetailUnsafe,
+		RepositoryRoot: sourced.root, Source: job.Span,
 		secretAuthority: sourced.secretAuthority, tokenPolicyNarrowed: sourced.tokenPolicyNarrowed,
 		jobPermissionsIgnored: sourced.jobPermissionsIgnored, reusableCall: sourced.reusableCall,
 	}

--- a/internal/compiler/matrix.go
+++ b/internal/compiler/matrix.go
@@ -344,15 +344,39 @@ func reportableRunnerLabels(job workflow.Job, labels []string) []string {
 	if !strings.HasPrefix(strings.ToLower(body), "matrix.") || strings.ContainsAny(body, " []()|&") {
 		return nil
 	}
-	if job.Matrix.Expression != nil || job.Matrix.IncludeExpression != nil || job.Matrix.ExcludeExpression != nil {
+	if matrixContainsExpressions(job.Matrix) {
 		return nil
 	}
-	for _, row := range job.Matrix.Rows {
+	return labels
+}
+
+func matrixContainsExpressions(matrix *workflow.Matrix) bool {
+	if matrix == nil {
+		return false
+	}
+	if matrix.Expression != nil || matrix.IncludeExpression != nil || matrix.ExcludeExpression != nil {
+		return true
+	}
+	for _, row := range matrix.Rows {
 		if row.Expression != nil {
-			return nil
+			return true
+		}
+		for _, value := range row.Values {
+			if containsExpression(value.Data) {
+				return true
+			}
 		}
 	}
-	return labels
+	for _, combinations := range [][]workflow.MatrixCombination{matrix.Include, matrix.Exclude} {
+		for _, combination := range combinations {
+			for _, value := range combination.Values {
+				if containsExpression(value.Data) {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 func runsOnPosition(job workflow.Job) workflow.Position {

--- a/internal/compiler/plan_builder.go
+++ b/internal/compiler/plan_builder.go
@@ -186,12 +186,14 @@ func (b planBuilder) validateShellCompatibility(instance JobInstance, workflowPr
 			return
 		}
 		if err := shellcompat.ValidateCompatibility(resolved); err != nil {
+			command, _ := shellcompat.UnsupportedCommand(err)
 			owner := fmt.Sprintf("job %q", instance.LogicalJobID)
 			if step != 0 {
 				owner += fmt.Sprintf(" step %d", step)
 			}
 			diagnostics = append(diagnostics, &ProcessingFinding{
 				Stage: StagePlans, Code: CodePlanConstruction, Category: "compatibility",
+				Blocker: "shell", BlockerDetail: command,
 				Path: site.Location.File, Line: site.Location.Start.Line, Column: site.Location.Start.Column,
 				Job: instance.LogicalJobID, Instance: instance.Key, Step: step, Message: err.Error(),
 				Err: fmt.Errorf("%s:%d:%d: %s: %w", site.Location.File, site.Location.Start.Line, site.Location.Start.Column, owner, err),

--- a/internal/compiler/plan_builder.go
+++ b/internal/compiler/plan_builder.go
@@ -108,6 +108,10 @@ func reducePlanEventExpressions(ir IR) (IR, error) {
 	ir.Jobs = append([]JobInstance(nil), ir.Jobs...)
 	var diagnostics []error
 	for i, instance := range ir.Jobs {
+		if err := builder.validateShellCompatibility(instance, lowerWorkflowProgram(instance)); err != nil {
+			diagnostics = append(diagnostics, planConstructionFinding(instance, err))
+			continue
+		}
 		reduced, err := builder.reducePlanInstanceEventExpressions(instance)
 		if err != nil {
 			diagnostics = append(diagnostics, planConstructionFinding(instance, err))
@@ -123,9 +127,6 @@ func (b planBuilder) buildPlan(instance JobInstance, runtimeDistributionDigest s
 		return plan.Job{}, PlanAuthorization{}, nil, fmt.Errorf("build plan for job %q: no runtime distribution configured for %s", instance.LogicalJobID, instance.Platform)
 	}
 	workflowProgram := lowerWorkflowProgram(instance)
-	if err := b.validateShellCompatibility(instance, workflowProgram); err != nil {
-		return plan.Job{}, PlanAuthorization{}, nil, err
-	}
 	actions, err := b.buildActions(instance, &workflowProgram)
 	if err != nil {
 		return plan.Job{}, PlanAuthorization{}, nil, err
@@ -187,6 +188,9 @@ func (b planBuilder) validateShellCompatibility(instance JobInstance, workflowPr
 		}
 		if err := shellcompat.ValidateCompatibility(resolved); err != nil {
 			command, _ := shellcompat.UnsupportedCommand(err)
+			if strings.Contains(site.Source, "${{") {
+				command = ""
+			}
 			owner := fmt.Sprintf("job %q", instance.LogicalJobID)
 			if step != 0 {
 				owner += fmt.Sprintf(" step %d", step)

--- a/internal/compiler/plan_builder.go
+++ b/internal/compiler/plan_builder.go
@@ -109,11 +109,17 @@ func reducePlanEventExpressions(ir IR) (IR, error) {
 	var diagnostics []error
 	for i, instance := range ir.Jobs {
 		if err := builder.validateShellCompatibility(instance, lowerWorkflowProgram(instance)); err != nil {
+			if len(instance.Inputs) != 0 {
+				err = suppressBlockerDetail(err)
+			}
 			diagnostics = append(diagnostics, planConstructionFinding(instance, err))
 			continue
 		}
 		reduced, err := builder.reducePlanInstanceEventExpressions(instance)
 		if err != nil {
+			if len(instance.Inputs) != 0 {
+				err = suppressBlockerDetail(err)
+			}
 			diagnostics = append(diagnostics, planConstructionFinding(instance, err))
 			continue
 		}

--- a/internal/compiler/plan_builder.go
+++ b/internal/compiler/plan_builder.go
@@ -109,7 +109,7 @@ func reducePlanEventExpressions(ir IR) (IR, error) {
 	var diagnostics []error
 	for i, instance := range ir.Jobs {
 		if err := builder.validateShellCompatibility(instance, lowerWorkflowProgram(instance)); err != nil {
-			if len(instance.Inputs) != 0 {
+			if instance.BlockerDetailUnsafe {
 				err = suppressBlockerDetail(err)
 			}
 			diagnostics = append(diagnostics, planConstructionFinding(instance, err))
@@ -117,7 +117,7 @@ func reducePlanEventExpressions(ir IR) (IR, error) {
 		}
 		reduced, err := builder.reducePlanInstanceEventExpressions(instance)
 		if err != nil {
-			if len(instance.Inputs) != 0 {
+			if instance.BlockerDetailUnsafe {
 				err = suppressBlockerDetail(err)
 			}
 			diagnostics = append(diagnostics, planConstructionFinding(instance, err))

--- a/internal/compiler/processing.go
+++ b/internal/compiler/processing.go
@@ -36,16 +36,18 @@ const (
 // ProcessingFinding carries stable attribution independently of its rendered
 // error text. Err remains wrapped so errors.Is and errors.As keep working.
 type ProcessingFinding struct {
-	Stage    ProcessingStage
-	Code     string
-	Category string
-	Path     string
-	Line     int
-	Column   int
-	Job      string
-	Instance string
-	Action   string
-	Step     int
+	Stage         ProcessingStage
+	Code          string
+	Category      string
+	Blocker       string
+	BlockerDetail string
+	Path          string
+	Line          int
+	Column        int
+	Job           string
+	Instance      string
+	Action        string
+	Step          int
 	// Message replaces Err's text in the rendered report. Set it whenever Err
 	// can quote event-derived data, so that data cannot reach the report.
 	Message string
@@ -92,11 +94,25 @@ func attributedProcessingFinding(stage ProcessingStage, code, category, path str
 		}
 		return errors.Join(wrapped...)
 	}
+	blocker, blockerDetail := compatibilityBlocker(err)
 	return &ProcessingFinding{
 		Stage: stage, Code: code, Category: category,
+		Blocker: blocker, BlockerDetail: blockerDetail,
 		Path: path, Line: line, Column: column, Job: job, Instance: instance, Action: action, Step: step,
 		Err: err,
 	}
+}
+
+type compatibilityBlockerError interface {
+	CompatibilityBlocker() (string, string)
+}
+
+func compatibilityBlocker(err error) (string, string) {
+	var blocker compatibilityBlockerError
+	if errors.As(err, &blocker) {
+		return blocker.CompatibilityBlocker()
+	}
+	return "", ""
 }
 
 // ActionEvaluation records an attempted immutable resolution by invocation.

--- a/internal/compiler/processing.go
+++ b/internal/compiler/processing.go
@@ -62,6 +62,52 @@ type ProcessingFinding struct {
 func (e *ProcessingFinding) Error() string { return e.Err.Error() }
 func (e *ProcessingFinding) Unwrap() error { return e.Err }
 
+type blockerDetailSuppressedError struct {
+	blocker string
+	err     error
+}
+
+func (e *blockerDetailSuppressedError) Error() string { return e.err.Error() }
+func (e *blockerDetailSuppressedError) Unwrap() error { return e.err }
+func (e *blockerDetailSuppressedError) CompatibilityBlocker() (string, string) {
+	return e.blocker, ""
+}
+
+func suppressBlockerDetail(err error) error {
+	if err == nil {
+		return nil
+	}
+	if finding, ok := err.(*ProcessingFinding); ok {
+		copy := *finding
+		copy.BlockerDetail = ""
+		if copy.Blocker == "" {
+			var blocker interface {
+				CompatibilityBlocker() (string, string)
+			}
+			if errors.As(copy.Err, &blocker) {
+				copy.Blocker, _ = blocker.CompatibilityBlocker()
+			}
+		}
+		return &copy
+	}
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		children := joined.Unwrap()
+		wrapped := make([]error, 0, len(children))
+		for _, child := range children {
+			wrapped = append(wrapped, suppressBlockerDetail(child))
+		}
+		return errors.Join(wrapped...)
+	}
+	var blocker interface {
+		CompatibilityBlocker() (string, string)
+	}
+	if !errors.As(err, &blocker) {
+		return err
+	}
+	kind, _ := blocker.CompatibilityBlocker()
+	return &blockerDetailSuppressedError{blocker: kind, err: err}
+}
+
 func processingFinding(stage ProcessingStage, code, category string, err error) error {
 	return attributedProcessingFinding(stage, code, category, "", 0, 0, "", "", "", 0, err)
 }

--- a/internal/compiler/processing.go
+++ b/internal/compiler/processing.go
@@ -94,25 +94,11 @@ func attributedProcessingFinding(stage ProcessingStage, code, category, path str
 		}
 		return errors.Join(wrapped...)
 	}
-	blocker, blockerDetail := compatibilityBlocker(err)
 	return &ProcessingFinding{
 		Stage: stage, Code: code, Category: category,
-		Blocker: blocker, BlockerDetail: blockerDetail,
 		Path: path, Line: line, Column: column, Job: job, Instance: instance, Action: action, Step: step,
 		Err: err,
 	}
-}
-
-type compatibilityBlockerError interface {
-	CompatibilityBlocker() (string, string)
-}
-
-func compatibilityBlocker(err error) (string, string) {
-	var blocker compatibilityBlockerError
-	if errors.As(err, &blocker) {
-		return blocker.CompatibilityBlocker()
-	}
-	return "", ""
 }
 
 // ActionEvaluation records an attempted immutable resolution by invocation.

--- a/internal/compiler/processing.go
+++ b/internal/compiler/processing.go
@@ -36,10 +36,12 @@ const (
 // ProcessingFinding carries stable attribution independently of its rendered
 // error text. Err remains wrapped so errors.Is and errors.As keep working.
 type ProcessingFinding struct {
-	Stage         ProcessingStage
-	Code          string
-	Category      string
-	Blocker       string
+	Stage    ProcessingStage
+	Code     string
+	Category string
+	Blocker  string
+	// BlockerDetail is opt-in telemetry attribution. Set it only from original
+	// workflow syntax or values proven to depend solely on workflow literals.
 	BlockerDetail string
 	Path          string
 	Line          int

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -42,6 +42,7 @@ type sourcedJob struct {
 	tokenPolicyNarrowed   bool
 	jobPermissionsIgnored bool
 	reusableCall          workflow.Position
+	blockerDetailUnsafe   bool
 	callGuards            []sourcedCallGuard
 	concurrencyGates      []WorkflowConcurrencyGate
 }
@@ -237,10 +238,12 @@ func (resolver *reusableResolver) resolve(ctx context.Context, current reusableW
 				job.Permissions.Scopes["id-token"] = idTokenPermission
 			}
 		}
+		originalJob := job
 		job, err = applyStaticInputs(path, job, inputs.values)
 		if err != nil {
 			return reusableResolution{}, err
 		}
+		blockerDetailUnsafe := blockerFieldsChanged(originalJob, job)
 		if parsed.Callable {
 			if err := rejectUnresolvedInputExpressions(path, job, inputs.deferred); err != nil {
 				return reusableResolution{}, err
@@ -275,8 +278,9 @@ func (resolver *reusableResolver) resolve(ctx context.Context, current reusableW
 				Job: job, path: path, digest: digest, root: resolver.workspaceRoot, remote: cloneRemoteWorkflowSource(current.remote), inputs: cloneReusableInputs(inputs),
 				secretAuthority: cloneSecretAuthority(secrets), needBindings: needBindings,
 				tokenPolicyNarrowed: jobTokenPolicyNarrowed, jobPermissionsIgnored: jobPermissionsIgnored, reusableCall: reusableCallPosition,
-				callGuards:       cloneSourcedCallGuards(callGuards),
-				concurrencyGates: append([]WorkflowConcurrencyGate(nil), concurrencyGates...),
+				blockerDetailUnsafe: blockerDetailUnsafe,
+				callGuards:          cloneSourcedCallGuards(callGuards),
+				concurrencyGates:    append([]WorkflowConcurrencyGate(nil), concurrencyGates...),
 			})
 			replacements[id] = needBinding{members: []string{job.ID}}
 			continue
@@ -290,10 +294,16 @@ func (resolver *reusableResolver) resolve(ctx context.Context, current reusableW
 			conditionContext.Matrix = nil
 			conditionContext.Strategy = nil
 			if err := validateCompileSite(job.If, expression.ProfileCompileCallCondition, expression.ResultBoolean); err != nil {
+				if blockerDetailUnsafe {
+					err = suppressBlockerDetail(err)
+				}
 				return reusableResolution{}, locatedJobWrappedError(path, job, job.Span.Start.Line, job.Span.Start.Column, "reusable-workflow call condition", err)
 			}
 			reduced, err := reduceCompileSite(job.If, expression.ProfileCompileCallCondition, expression.ResultBoolean, conditionContext)
 			if err != nil {
+				if blockerDetailUnsafe {
+					err = suppressBlockerDetail(err)
+				}
 				return reusableResolution{}, locatedJobWrappedError(path, job, job.Span.Start.Line, job.Span.Start.Column, "reduce reusable-workflow call condition", err)
 			}
 			condition := reduced.Source
@@ -301,6 +311,9 @@ func (resolver *reusableResolver) resolve(ctx context.Context, current reusableW
 				condition = fmt.Sprint(reduced.Value)
 			}
 			if err := validateCompileSite(condition, expression.ProfileCallCondition, expression.ResultBoolean); err != nil {
+				if blockerDetailUnsafe {
+					err = suppressBlockerDetail(err)
+				}
 				return reusableResolution{}, locatedJobWrappedError(path, job, job.Span.Start.Line, job.Span.Start.Column, "reusable-workflow call condition", err)
 			}
 			calleeGuards = append(cloneSourcedCallGuards(callGuards), sourcedCallGuard{
@@ -1076,6 +1089,25 @@ func applyStaticInputs(path string, job workflow.Job, inputs map[string]any) (wo
 		step.With = replaceMapInputs(step.With, inputs)
 	}
 	return job, nil
+}
+
+func blockerFieldsChanged(before, after workflow.Job) bool {
+	if before.If != after.If || before.DefaultShell != after.DefaultShell || !slices.Equal(before.RunsOn, after.RunsOn) || expressionText(before.RunsOnExpr) != expressionText(after.RunsOnExpr) {
+		return true
+	}
+	for i := range before.Steps {
+		if before.Steps[i].If != after.Steps[i].If || before.Steps[i].Uses != after.Steps[i].Uses || before.Steps[i].Shell != after.Steps[i].Shell {
+			return true
+		}
+	}
+	return false
+}
+
+func expressionText(value *expression.Expression) string {
+	if value == nil {
+		return ""
+	}
+	return value.Text
 }
 
 func staticTimeoutMinutes(value any) (float64, bool) {

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -125,6 +125,7 @@ func resolveReusableWorkflows(ctx context.Context, path string, source []byte, p
 		workflowJobs := make(map[string]workflow.Job, len(parsed.Jobs))
 		replacements := make(map[string]needBinding, len(parsed.Jobs))
 		for i, job := range parsed.Jobs {
+			originalJob := job
 			resolvedJob, err := applyStaticInputs(sourcePath, job, context.Inputs)
 			if err != nil {
 				return nil, nil, runtimeMatrixBoundary, err
@@ -135,7 +136,7 @@ func resolveReusableWorkflows(ctx context.Context, path string, source []byte, p
 			for _, need := range job.Needs {
 				bindings[need] = needBinding{members: []string{need}}
 			}
-			jobs[i] = sourcedJob{Job: job, path: sourcePath, digest: digest, root: root, inputs: reusableInputs{values: cloneAnyMap(context.Inputs)}, secretAuthority: secretAuthority{unrestricted: true}, needBindings: bindings}
+			jobs[i] = sourcedJob{Job: job, path: sourcePath, digest: digest, root: root, inputs: reusableInputs{values: cloneAnyMap(context.Inputs)}, secretAuthority: secretAuthority{unrestricted: true}, needBindings: bindings, blockerDetailUnsafe: blockerFieldsChanged(originalJob, job) || matrixContainsExpressions(job.Matrix)}
 			workflowJobs[job.ID] = job
 			replacements[job.ID] = needBinding{members: []string{job.ID}}
 		}
@@ -244,7 +245,7 @@ func (resolver *reusableResolver) resolve(ctx context.Context, current reusableW
 		if err != nil {
 			return reusableResolution{}, err
 		}
-		blockerDetailUnsafe := blockerFieldsChanged(originalJob, job)
+		blockerDetailUnsafe := blockerFieldsChanged(originalJob, job) || matrixContainsExpressions(job.Matrix)
 		if parsed.Callable {
 			if err := rejectUnresolvedInputExpressions(path, job, inputs.deferred); err != nil {
 				return reusableResolution{}, err

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -290,18 +290,18 @@ func (resolver *reusableResolver) resolve(ctx context.Context, current reusableW
 			conditionContext.Matrix = nil
 			conditionContext.Strategy = nil
 			if err := validateCompileSite(job.If, expression.ProfileCompileCallCondition, expression.ResultBoolean); err != nil {
-				return reusableResolution{}, jobError(path, job, fmt.Sprintf("reusable-workflow call condition: %v", err))
+				return reusableResolution{}, locatedJobWrappedError(path, job, job.Span.Start.Line, job.Span.Start.Column, "reusable-workflow call condition", err)
 			}
 			reduced, err := reduceCompileSite(job.If, expression.ProfileCompileCallCondition, expression.ResultBoolean, conditionContext)
 			if err != nil {
-				return reusableResolution{}, jobError(path, job, fmt.Sprintf("reduce reusable-workflow call condition: %v", err))
+				return reusableResolution{}, locatedJobWrappedError(path, job, job.Span.Start.Line, job.Span.Start.Column, "reduce reusable-workflow call condition", err)
 			}
 			condition := reduced.Source
 			if reduced.Known {
 				condition = fmt.Sprint(reduced.Value)
 			}
 			if err := validateCompileSite(condition, expression.ProfileCallCondition, expression.ResultBoolean); err != nil {
-				return reusableResolution{}, jobError(path, job, fmt.Sprintf("reusable-workflow call condition: %v", err))
+				return reusableResolution{}, locatedJobWrappedError(path, job, job.Span.Start.Line, job.Span.Start.Column, "reusable-workflow call condition", err)
 			}
 			calleeGuards = append(cloneSourcedCallGuards(callGuards), sourcedCallGuard{
 				condition: condition, inputs: cloneReusableInputs(inputs), needBindings: cloneNeedBindings(callNeedBindings),

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"slices"
 	"sort"
@@ -1092,7 +1093,7 @@ func applyStaticInputs(path string, job workflow.Job, inputs map[string]any) (wo
 }
 
 func blockerFieldsChanged(before, after workflow.Job) bool {
-	if before.If != after.If || before.DefaultShell != after.DefaultShell || !slices.Equal(before.RunsOn, after.RunsOn) || expressionText(before.RunsOnExpr) != expressionText(after.RunsOnExpr) {
+	if before.If != after.If || before.DefaultShell != after.DefaultShell || !slices.Equal(before.RunsOn, after.RunsOn) || expressionText(before.RunsOnExpr) != expressionText(after.RunsOnExpr) || !reflect.DeepEqual(before.Matrix, after.Matrix) {
 		return true
 	}
 	for i := range before.Steps {

--- a/internal/compiler/shell_test.go
+++ b/internal/compiler/shell_test.go
@@ -59,7 +59,7 @@ jobs:
       - shell: ${{ matrix.shell }}
         run: Write-Output test
 `,
-			wantReportedCommand: "powershell",
+			wantReportedCommand: "",
 			wantLine:            9,
 			wantStep:            1,
 		},
@@ -84,13 +84,15 @@ jobs:
 				t.Fatalf("finding blocker = %q / %q", finding.Blocker, finding.BlockerDetail)
 			}
 			for _, want := range []string{
-				`shell "` + test.wantReportedCommand + `" is unsupported`,
 				"Use bash, sh, python, or a valid custom shell template whose command is available on PATH",
 				"https://github.com/buildkite/buildkite-gha",
 			} {
 				if !strings.Contains(finding.Message, want) {
 					t.Fatalf("finding message = %q, want %q", finding.Message, want)
 				}
+			}
+			if !strings.Contains(finding.Message, "is unsupported") {
+				t.Fatalf("finding message = %q, want unsupported shell", finding.Message)
 			}
 		})
 	}
@@ -124,6 +126,9 @@ jobs:
 	}
 	if !strings.Contains(finding.Message, `shell "pwsh" is unsupported`) {
 		t.Fatalf("finding message = %q", finding.Message)
+	}
+	if finding.Blocker != "shell" || finding.BlockerDetail != "" {
+		t.Fatalf("finding blocker = %q / %q, want shell with no detail", finding.Blocker, finding.BlockerDetail)
 	}
 }
 

--- a/internal/compiler/shell_test.go
+++ b/internal/compiler/shell_test.go
@@ -132,6 +132,47 @@ jobs:
 	}
 }
 
+func TestCompilePlansDoNotAttributeReusableInputShellValues(t *testing.T) {
+	repository := t.TempDir()
+	callerPath := writeWorkflow(t, repository, "caller.yml", `on: push
+jobs:
+  delegated:
+    uses: ./.github/workflows/reusable.yml
+    with:
+      shell: ${{ github.event.shell }}
+`)
+	writeWorkflow(t, repository, "reusable.yml", `on:
+  workflow_call:
+    inputs:
+      shell:
+        type: string
+        required: true
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - shell: ${{ inputs.shell }}
+        run: Write-Output test
+`)
+	eventSource := pushEvent(t)
+	event := bytes.Replace(eventSource, []byte(`"payload": {`), []byte(`"payload": {"shell": "pwsh",`), 1)
+	if bytes.Equal(event, eventSource) {
+		t.Fatal("event payload was not updated")
+	}
+
+	_, err := compileUntrustedPlans(callerPath, readFile(t, callerPath), event, "0.0.0-test", testDistributionDigest, "gha-untrusted")
+	if err == nil {
+		t.Fatal("compileUntrustedPlans() succeeded")
+	}
+	var finding *ProcessingFinding
+	if !errors.As(err, &finding) {
+		t.Fatalf("compileUntrustedPlans() error = %T %v, want ProcessingFinding", err, err)
+	}
+	if finding.Blocker != "shell" || finding.BlockerDetail != "" {
+		t.Fatalf("finding blocker = %q / %q, want shell with no detail", finding.Blocker, finding.BlockerDetail)
+	}
+}
+
 func TestCompilePlansAcceptCustomShellTemplates(t *testing.T) {
 	workflow := []byte(`on: push
 jobs:

--- a/internal/compiler/shell_test.go
+++ b/internal/compiler/shell_test.go
@@ -80,6 +80,9 @@ jobs:
 			if finding.Job != "test" || finding.Instance == "" || finding.Step != test.wantStep {
 				t.Fatalf("finding ownership = %#v", finding)
 			}
+			if finding.Blocker != "shell" || finding.BlockerDetail != test.wantReportedCommand {
+				t.Fatalf("finding blocker = %q / %q", finding.Blocker, finding.BlockerDetail)
+			}
 			for _, want := range []string{
 				`shell "` + test.wantReportedCommand + `" is unsupported`,
 				"Use bash, sh, python, or a valid custom shell template whose command is available on PATH",

--- a/internal/expression/condition.go
+++ b/internal/expression/condition.go
@@ -3,6 +3,7 @@
 package expression
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -55,9 +56,9 @@ func validateCallCondition(source string) error {
 func validateCompileCallCondition(source string, context CompileContext) error {
 	node, empty, err := parseCondition(source)
 	if err != nil || empty {
-		return err
+		return conditionBlocker(source, err)
 	}
-	return validateCompileConditionNode(node, CallCondition, context, nil)
+	return conditionBlocker(source, validateCompileConditionNode(node, CallCondition, context, nil))
 }
 
 // validateActionLifecycleCondition verifies an action pre-if or post-if
@@ -84,18 +85,40 @@ func validateLifecycleDelimiters(source string) error {
 func validateCompileConditionWithMatrix(source string, scope ConditionScope, context CompileContext, matrix map[string]any) error {
 	node, empty, err := parseCondition(source)
 	if err != nil || empty {
-		return err
+		return conditionBlocker(source, err)
 	}
 	context.Matrix = matrix
-	return validateCompileConditionNode(node, scope, context, matrix)
+	return conditionBlocker(source, validateCompileConditionNode(node, scope, context, matrix))
 }
 
 func validateCondition(source string, scope ConditionScope) error {
 	node, empty, err := parseCondition(source)
 	if err != nil || empty {
+		return conditionBlocker(source, err)
+	}
+	return conditionBlocker(source, validateConditionNode(node, scope))
+}
+
+type conditionBlockerError struct {
+	detail string
+	err    error
+}
+
+func (e *conditionBlockerError) Error() string { return e.err.Error() }
+func (e *conditionBlockerError) Unwrap() error { return e.err }
+func (e *conditionBlockerError) CompatibilityBlocker() (string, string) {
+	return "expression", e.detail
+}
+
+func conditionBlocker(source string, err error) error {
+	if err == nil {
+		return nil
+	}
+	var blocker *conditionBlockerError
+	if errors.As(err, &blocker) {
 		return err
 	}
-	return validateConditionNode(node, scope)
+	return &conditionBlockerError{detail: strings.TrimSpace(source), err: err}
 }
 
 func validateConditionNode(node actionlint.ExprNode, scope ConditionScope) error {

--- a/internal/expression/engine.go
+++ b/internal/expression/engine.go
@@ -335,6 +335,10 @@ func (Engine) Validate(site Site) (Validation, error) {
 		secrets, err = secretReferences(site.Source)
 	}
 	if err != nil {
+		switch profile.semantics {
+		case semanticsCompileCondition, semanticsCondition, semanticsActionLifecycle:
+			err = conditionBlocker(site.Source, err)
+		}
 		return Validation{}, siteError(site, err)
 	}
 	switch profile.semantics {

--- a/internal/expression/engine.go
+++ b/internal/expression/engine.go
@@ -359,6 +359,7 @@ func (Engine) Validate(site Site) (Validation, error) {
 		if err == nil && !empty {
 			err = validateCompileConditionNode(node, profile.condition, CompileContext{}, nil)
 		}
+		err = conditionBlocker(site.Source, err)
 	case semanticsReusableInput:
 		err = visitTemplateExpressions(site.Source, validateReusableInputDefaultNode)
 	case semanticsRunName:

--- a/internal/expression/engine_test.go
+++ b/internal/expression/engine_test.go
@@ -2,6 +2,7 @@ package expression
 
 import (
 	"encoding/json"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -221,6 +222,20 @@ func TestEngineProfileScopesAreDistinctAndAuthoritative(t *testing.T) {
 	_, err = engine.Validate(Site{Source: "${{ hashFiles('file') }}", Profile: ProfilePartialTemplate, Result: ResultString, Purpose: PurposeExpression})
 	if err == nil || !strings.Contains(err.Error(), `expression function "hashFiles" is unavailable in this profile`) {
 		t.Fatalf("declarative function policy error = %v", err)
+	}
+}
+
+func TestEngineValidateConditionAttributesEarlySecretReferenceError(t *testing.T) {
+	const source = "secrets[env.NAME]"
+	_, err := (Engine{}).Validate(Site{Source: source, Profile: ProfileCompileJobCondition, Result: ResultBoolean})
+	var blocker interface {
+		CompatibilityBlocker() (string, string)
+	}
+	if !errors.As(err, &blocker) {
+		t.Fatalf("Validate() error = %v, want compatibility blocker", err)
+	}
+	if kind, detail := blocker.CompatibilityBlocker(); kind != "expression" || detail != source {
+		t.Fatalf("compatibility blocker = %q / %q", kind, detail)
 	}
 }
 

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -2,6 +2,7 @@ package expression
 
 import (
 	"encoding/json"
+	"errors"
 	"math"
 	"reflect"
 	"strings"
@@ -737,6 +738,15 @@ func TestValidateConditionRejectsUnsupportedRuntimeExpressions(t *testing.T) {
 			err := ValidateCondition(test.source, test.scope)
 			if err == nil || !strings.Contains(err.Error(), test.want) {
 				t.Fatalf("ValidateCondition() error = %v, want %q", err, test.want)
+			}
+			var blocker interface {
+				CompatibilityBlocker() (string, string)
+			}
+			if !errors.As(err, &blocker) {
+				t.Fatalf("ValidateCondition() error has no compatibility blocker: %v", err)
+			}
+			if kind, detail := blocker.CompatibilityBlocker(); kind != "expression" || detail != test.source {
+				t.Fatalf("compatibility blocker = %q / %q", kind, detail)
 			}
 		})
 	}

--- a/internal/runtime/action_execution.go
+++ b/internal/runtime/action_execution.go
@@ -2422,7 +2422,8 @@ func shellCommand(shell, script string) ([]string, error) {
 			command, _ := shellcompat.UnsupportedCommand(err)
 			return nil, errUnsupportedFeature("shell", command, "%s", err)
 		}
-		return nil, errUnsupportedFeature("shell", strings.TrimSpace(shell), "shell %q is unsupported in the supported runtime subset", shell)
+		command, _ := shellcompat.Command(shell)
+		return nil, errUnsupportedFeature("shell", command, "shell %q is unsupported in the supported runtime subset", shell)
 	}
 }
 

--- a/internal/runtime/action_execution.go
+++ b/internal/runtime/action_execution.go
@@ -2138,7 +2138,7 @@ func (r *jobRun) runActionStep(ctx context.Context, processor *commandProcessor,
 		result, err := r.runDocker(ctx, processor, dockerAction{Name: actionName(action, step), Path: actionPath, SourceRoot: sourceRoot, SourceDigest: sourceDigest, Image: image, Entrypoint: action.Runs.Entrypoint, Args: dockerArgs, Workspace: workspace, Env: invocationEnv, explicitPATH: explicitPATH})
 		return result, err
 	}
-	return result, errUnsupportedf("action %q uses unsupported runtime %q", step.Uses, actionRuntime)
+	return result, errUnsupportedFeature("action_ref", step.Uses, "action %q uses unsupported runtime %q", step.Uses, actionRuntime)
 }
 
 func (r *jobRun) runCompositeMetadata(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, actionPath string, action metadata.Metadata, actionProgram *executionprogram.Action, inputs map[string]string, invocationID string, jobEnv, stepEnv, lifecycleEnvOverlay map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations, actionLock *plan.ActionLock, actionStack []string) (Result, error) {
@@ -2419,9 +2419,10 @@ func shellCommand(shell, script string) ([]string, error) {
 		return []string{"sh", "-e", "-c", script}, nil
 	default:
 		if err := shellcompat.ValidateCompatibility(shell); err != nil {
-			return nil, errUnsupportedf("%s", err)
+			command, _ := shellcompat.UnsupportedCommand(err)
+			return nil, errUnsupportedFeature("shell", command, "%s", err)
 		}
-		return nil, errUnsupportedf("shell %q is unsupported in the supported runtime subset", shell)
+		return nil, errUnsupportedFeature("shell", strings.TrimSpace(shell), "shell %q is unsupported in the supported runtime subset", shell)
 	}
 }
 
@@ -2438,7 +2439,8 @@ func (r *jobRun) runShellProcess(ctx context.Context, processor *commandProcesso
 	args := []string{"python", "{0}"}
 	if shell != "python" {
 		if err := shellcompat.ValidateCompatibility(shell); err != nil {
-			return errUnsupportedf("%s", err)
+			command, _ := shellcompat.UnsupportedCommand(err)
+			return errUnsupportedFeature("shell", command, "%s", err)
 		}
 		var err error
 		args, err = shellcompat.ParseTemplate(shell)

--- a/internal/runtime/action_execution.go
+++ b/internal/runtime/action_execution.go
@@ -2138,7 +2138,7 @@ func (r *jobRun) runActionStep(ctx context.Context, processor *commandProcessor,
 		result, err := r.runDocker(ctx, processor, dockerAction{Name: actionName(action, step), Path: actionPath, SourceRoot: sourceRoot, SourceDigest: sourceDigest, Image: image, Entrypoint: action.Runs.Entrypoint, Args: dockerArgs, Workspace: workspace, Env: invocationEnv, explicitPATH: explicitPATH})
 		return result, err
 	}
-	return result, errUnsupportedFeature("action_ref", step.Uses, "action %q uses unsupported runtime %q", step.Uses, actionRuntime)
+	return result, errUnsupportedFeature("action_ref", "", "action %q uses unsupported runtime %q", step.Uses, actionRuntime)
 }
 
 func (r *jobRun) runCompositeMetadata(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, actionPath string, action metadata.Metadata, actionProgram *executionprogram.Action, inputs map[string]string, invocationID string, jobEnv, stepEnv, lifecycleEnvOverlay map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations, actionLock *plan.ActionLock, actionStack []string) (Result, error) {
@@ -2419,11 +2419,9 @@ func shellCommand(shell, script string) ([]string, error) {
 		return []string{"sh", "-e", "-c", script}, nil
 	default:
 		if err := shellcompat.ValidateCompatibility(shell); err != nil {
-			command, _ := shellcompat.UnsupportedCommand(err)
-			return nil, errUnsupportedFeature("shell", command, "%s", err)
+			return nil, errUnsupportedFeature("shell", "", "%s", err)
 		}
-		command, _ := shellcompat.Command(shell)
-		return nil, errUnsupportedFeature("shell", command, "shell %q is unsupported in the supported runtime subset", shell)
+		return nil, errUnsupportedFeature("shell", "", "shell %q is unsupported in the supported runtime subset", shell)
 	}
 }
 
@@ -2440,8 +2438,7 @@ func (r *jobRun) runShellProcess(ctx context.Context, processor *commandProcesso
 	args := []string{"python", "{0}"}
 	if shell != "python" {
 		if err := shellcompat.ValidateCompatibility(shell); err != nil {
-			command, _ := shellcompat.UnsupportedCommand(err)
-			return errUnsupportedFeature("shell", command, "%s", err)
+			return errUnsupportedFeature("shell", "", "%s", err)
 		}
 		var err error
 		args, err = shellcompat.ParseTemplate(shell)

--- a/internal/runtime/failure_class.go
+++ b/internal/runtime/failure_class.go
@@ -78,7 +78,9 @@ func markStepProcessExit(err error) error {
 }
 
 type unsupportedFeatureError struct {
-	err error
+	blocker string
+	detail  string
+	err     error
 }
 
 func (e *unsupportedFeatureError) Error() string { return e.err.Error() }
@@ -88,4 +90,18 @@ func (e *unsupportedFeatureError) Unwrap() error { return e.err }
 // runtime subset.
 func errUnsupportedf(format string, args ...any) error {
 	return &unsupportedFeatureError{err: fmt.Errorf(format, args...)}
+}
+
+func errUnsupportedFeature(blocker, detail, format string, args ...any) error {
+	return &unsupportedFeatureError{blocker: blocker, detail: detail, err: fmt.Errorf(format, args...)}
+}
+
+// UnsupportedFeature reports the structured feature rejected by a runtime
+// error, when the rejection site can identify one safely.
+func UnsupportedFeature(err error) (string, string, bool) {
+	var unsupported *unsupportedFeatureError
+	if errors.As(err, &unsupported) && unsupported.blocker != "" {
+		return unsupported.blocker, unsupported.detail, true
+	}
+	return "", "", false
 }

--- a/internal/runtime/failure_class_test.go
+++ b/internal/runtime/failure_class_test.go
@@ -91,6 +91,14 @@ func TestRunJobClassifiesUnsupportedShell(t *testing.T) {
 	}
 }
 
+func TestUnsupportedShellReportsOnlyExecutable(t *testing.T) {
+	_, err := shellCommand(`Rscript --vanilla "event value"`, "true")
+	blocker, detail, ok := UnsupportedFeature(err)
+	if !ok || blocker != "shell" || detail != "rscript" {
+		t.Fatalf("UnsupportedFeature() = %q, %q, %t, want shell, rscript, true", blocker, detail, ok)
+	}
+}
+
 func TestRunJobClassifiesUnsupportedActionRuntime(t *testing.T) {
 	workspace := t.TempDir()
 	workflowPath := ".github/workflows/action.yml"

--- a/internal/runtime/failure_class_test.go
+++ b/internal/runtime/failure_class_test.go
@@ -91,11 +91,11 @@ func TestRunJobClassifiesUnsupportedShell(t *testing.T) {
 	}
 }
 
-func TestUnsupportedShellReportsOnlyExecutable(t *testing.T) {
+func TestUnsupportedShellOmitsUnprovenExecutable(t *testing.T) {
 	_, err := shellCommand(`Rscript --vanilla "event value"`, "true")
 	blocker, detail, ok := UnsupportedFeature(err)
-	if !ok || blocker != "shell" || detail != "rscript" {
-		t.Fatalf("UnsupportedFeature() = %q, %q, %t, want shell, rscript, true", blocker, detail, ok)
+	if !ok || blocker != "shell" || detail != "" {
+		t.Fatalf("UnsupportedFeature() = %q, %q, %t, want shell with no detail", blocker, detail, ok)
 	}
 }
 

--- a/internal/shell/template.go
+++ b/internal/shell/template.go
@@ -25,10 +25,31 @@ func compatibilityError(shell, command string) error {
 	command = normalizeCommand(command)
 	switch command {
 	case "pwsh", "pwsh.exe", "cmd", "cmd.exe", "powershell", "powershell.exe", "msys2", "msys2.cmd", "msys2.exe":
-		return fmt.Errorf("shell %q is unsupported. PowerShell and Windows shells cannot run in buildkite-gha. Use bash, sh, python, or a valid custom shell template whose command is available on PATH, or file a compatibility issue at https://github.com/buildkite/buildkite-gha", shell)
+		return &UnsupportedError{Shell: shell, Command: command}
 	default:
 		return nil
 	}
+}
+
+// UnsupportedError reports the normalized executable for a shell rejected by
+// the runtime without retaining possibly event-derived template arguments.
+type UnsupportedError struct {
+	Shell   string
+	Command string
+}
+
+func (e *UnsupportedError) Error() string {
+	return fmt.Sprintf("shell %q is unsupported. PowerShell and Windows shells cannot run in buildkite-gha. Use bash, sh, python, or a valid custom shell template whose command is available on PATH, or file a compatibility issue at https://github.com/buildkite/buildkite-gha", e.Shell)
+}
+
+// UnsupportedCommand returns the normalized executable rejected by shell
+// compatibility validation.
+func UnsupportedCommand(err error) (string, bool) {
+	var unsupported *UnsupportedError
+	if errors.As(err, &unsupported) {
+		return unsupported.Command, true
+	}
+	return "", false
 }
 
 func normalizeCommand(command string) string {

--- a/internal/shell/template.go
+++ b/internal/shell/template.go
@@ -13,12 +13,21 @@ import (
 // contain event-derived values. Malformed templates remain ParseTemplate's
 // responsibility.
 func ValidateCompatibility(shell string) error {
-	args, err := splitTemplate(shell)
-	if err != nil || len(args) == 0 || args[0] == "" {
+	command, ok := Command(shell)
+	if !ok {
 		return nil
 	}
-	command := normalizeCommand(args[0])
 	return compatibilityError(command, command)
+}
+
+// Command returns the normalized executable from a shell value without
+// retaining its arguments.
+func Command(shell string) (string, bool) {
+	args, err := splitTemplate(shell)
+	if err != nil || len(args) == 0 || args[0] == "" {
+		return "", false
+	}
+	return normalizeCommand(args[0]), true
 }
 
 func compatibilityError(shell, command string) error {

--- a/internal/shell/template.go
+++ b/internal/shell/template.go
@@ -13,21 +13,12 @@ import (
 // contain event-derived values. Malformed templates remain ParseTemplate's
 // responsibility.
 func ValidateCompatibility(shell string) error {
-	command, ok := Command(shell)
-	if !ok {
-		return nil
-	}
-	return compatibilityError(command, command)
-}
-
-// Command returns the normalized executable from a shell value without
-// retaining its arguments.
-func Command(shell string) (string, bool) {
 	args, err := splitTemplate(shell)
 	if err != nil || len(args) == 0 || args[0] == "" {
-		return "", false
+		return nil
 	}
-	return normalizeCommand(args[0]), true
+	command := normalizeCommand(args[0])
+	return compatibilityError(command, command)
 }
 
 func compatibilityError(shell, command string) error {

--- a/internal/shell/template_test.go
+++ b/internal/shell/template_test.go
@@ -67,10 +67,3 @@ func TestValidateCompatibilityClassifiesUnsupportedCommands(t *testing.T) {
 		})
 	}
 }
-
-func TestCommandOmitsShellArguments(t *testing.T) {
-	command, ok := Command(`/usr/bin/Rscript --vanilla "event value"`)
-	if !ok || command != "rscript" {
-		t.Fatalf("Command() = %q, %t, want rscript, true", command, ok)
-	}
-}

--- a/internal/shell/template_test.go
+++ b/internal/shell/template_test.go
@@ -67,3 +67,10 @@ func TestValidateCompatibilityClassifiesUnsupportedCommands(t *testing.T) {
 		})
 	}
 }
+
+func TestCommandOmitsShellArguments(t *testing.T) {
+	command, ok := Command(`/usr/bin/Rscript --vanilla "event value"`)
+	if !ok || command != "rscript" {
+		t.Fatalf("Command() = %q, %t, want rscript, true", command, ok)
+	}
+}

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -340,7 +340,7 @@ func diagnosticSeverity(code string) (Severity, bool) {
 		string(FailureCodeActionResolution), string(FailureCodePlanConstruction), string(FailureCodePipelineGeneration),
 		string(FailureCodeEnvironment), string(FailureCodeProfile):
 		return SeverityError, true
-	case "W_ACTION_RUNTIME_UNKNOWN", "W_WORKFLOW_CONCURRENCY_CANCEL_IN_PROGRESS_IGNORED":
+	case "W_ACTION_RUNTIME_UNKNOWN", "W_WORKFLOW_CONCURRENCY_CANCEL_IN_PROGRESS_IGNORED", "W_TRIGGER_EVENT_UNSUPPORTED":
 		return SeverityWarning, true
 	default:
 		return "", false

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -4,6 +4,7 @@ package telemetry
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -320,10 +321,13 @@ func boundedBlocker(blocker, detail string) (string, string, error) {
 	}, strings.ToValidUTF8(detail, "�"))
 	detail = strings.Join(strings.Fields(detail), " ")
 	if len(detail) > maxBlockerDetailBytes {
-		detail = detail[:maxBlockerDetailBytes]
+		digest := sha256.Sum256([]byte(detail))
+		suffix := fmt.Sprintf("…#%x", digest[:6])
+		detail = detail[:maxBlockerDetailBytes-len(suffix)]
 		for !utf8.ValidString(detail) {
 			detail = detail[:len(detail)-1]
 		}
+		detail += suffix
 	}
 	return blocker, detail, nil
 }

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -25,6 +25,7 @@ const (
 	responseDrainLimit    = 32 << 10
 	maxClientVersionBytes = 64
 	maxErrorMessageBytes  = 1024
+	maxBlockerDetailBytes = 1024
 	maxDurationMS         = int64(1<<31 - 1)
 	maxDiagnostics        = 20
 )
@@ -91,8 +92,10 @@ const (
 )
 
 type Diagnostic struct {
-	Code     string   `json:"code"`
-	Severity Severity `json:"severity"`
+	Code          string   `json:"code"`
+	Severity      Severity `json:"severity"`
+	Blocker       string   `json:"blocker,omitempty"`
+	BlockerDetail string   `json:"blocker_detail,omitempty"`
 }
 
 type Details struct {
@@ -101,6 +104,8 @@ type Details struct {
 	ErrorMessage          string
 	ErrorMessageTruncated bool
 	Diagnostics           []Diagnostic
+	Blocker               string
+	BlockerDetail         string
 }
 
 type Properties struct {
@@ -113,6 +118,8 @@ type Properties struct {
 	ErrorMessage          string       `json:"error_message,omitempty"`
 	ErrorMessageTruncated bool         `json:"error_message_truncated,omitempty"`
 	Diagnostics           []Diagnostic `json:"diagnostics,omitempty"`
+	Blocker               string       `json:"blocker,omitempty"`
+	BlockerDetail         string       `json:"blocker_detail,omitempty"`
 }
 
 type Config struct {
@@ -197,6 +204,10 @@ func (c *Client) EmitContext(ctx context.Context, command Command, outcome Outco
 	if err != nil {
 		return err
 	}
+	blocker, blockerDetail, err := boundedBlocker(details.Blocker, details.BlockerDetail)
+	if err != nil {
+		return err
+	}
 	errorMessage, errorMessageTruncated := boundedErrorMessage(details.ErrorMessage)
 	errorMessageTruncated = errorMessage != "" && (errorMessageTruncated || details.ErrorMessageTruncated)
 	durationMS := duration.Milliseconds()
@@ -214,6 +225,7 @@ func (c *Client) EmitContext(ctx context.Context, command Command, outcome Outco
 			Command: command, Outcome: outcome, ClientVersion: c.clientVersion, DurationMS: durationMS,
 			FailurePhase: details.FailurePhase, FailureCode: details.FailureCode,
 			ErrorMessage: errorMessage, ErrorMessageTruncated: errorMessageTruncated, Diagnostics: diagnostics,
+			Blocker: blocker, BlockerDetail: blockerDetail,
 		},
 	})
 	if err != nil {
@@ -265,23 +277,55 @@ func validFailureCode(code FailureCode) bool {
 }
 
 func boundedDiagnostics(in []Diagnostic) ([]Diagnostic, error) {
-	seen := make(map[string]bool, min(len(in), maxDiagnostics))
+	seen := make(map[Diagnostic]bool, min(len(in), maxDiagnostics))
 	out := make([]Diagnostic, 0, min(len(in), maxDiagnostics))
 	for _, diagnostic := range in {
 		severity, ok := diagnosticSeverity(diagnostic.Code)
 		if !ok || diagnostic.Severity != severity {
 			return nil, fmt.Errorf("invalid telemetry diagnostic")
 		}
-		if seen[diagnostic.Code] {
+		blocker, blockerDetail, err := boundedBlocker(diagnostic.Blocker, diagnostic.BlockerDetail)
+		if err != nil {
+			return nil, err
+		}
+		diagnostic.Blocker, diagnostic.BlockerDetail = blocker, blockerDetail
+		if seen[diagnostic] {
 			continue
 		}
-		seen[diagnostic.Code] = true
+		seen[diagnostic] = true
 		out = append(out, diagnostic)
 		if len(out) == maxDiagnostics {
 			break
 		}
 	}
 	return out, nil
+}
+
+func boundedBlocker(blocker, detail string) (string, string, error) {
+	switch blocker {
+	case "":
+		if detail != "" {
+			return "", "", fmt.Errorf("telemetry blocker detail requires a blocker")
+		}
+		return "", "", nil
+	case "runner_label", "environment", "shell", "action_ref", "expression", "trigger":
+	default:
+		return "", "", fmt.Errorf("invalid telemetry blocker")
+	}
+	detail = strings.Map(func(character rune) rune {
+		if unicode.IsControl(character) {
+			return ' '
+		}
+		return character
+	}, strings.ToValidUTF8(detail, "�"))
+	detail = strings.Join(strings.Fields(detail), " ")
+	if len(detail) > maxBlockerDetailBytes {
+		detail = detail[:maxBlockerDetailBytes]
+		for !utf8.ValidString(detail) {
+			detail = detail[:len(detail)-1]
+		}
+	}
+	return blocker, detail, nil
 }
 
 func diagnosticSeverity(code string) (Severity, bool) {

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -264,7 +264,7 @@ func TestDiagnosticsEnforceSeverityAndDeduplicateByCode(t *testing.T) {
 		string(FailureCodeActionResolution), string(FailureCodePlanConstruction), string(FailureCodePipelineGeneration),
 		string(FailureCodeEnvironment), string(FailureCodeProfile),
 	}
-	warningCodes := []string{"W_ACTION_RUNTIME_UNKNOWN", "W_WORKFLOW_CONCURRENCY_CANCEL_IN_PROGRESS_IGNORED"}
+	warningCodes := []string{"W_ACTION_RUNTIME_UNKNOWN", "W_WORKFLOW_CONCURRENCY_CANCEL_IN_PROGRESS_IGNORED", "W_TRIGGER_EVENT_UNSUPPORTED"}
 	input := make([]Diagnostic, 0, len(errorCodes)+len(warningCodes)+2)
 	for _, code := range errorCodes {
 		input = append(input, Diagnostic{Code: code, Severity: SeverityError})

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -286,16 +286,22 @@ func TestDiagnosticsEnforceSeverityAndDeduplicateByCode(t *testing.T) {
 }
 
 func TestDiagnosticsPreserveDistinctBlockersForOneCode(t *testing.T) {
+	common := strings.Repeat("x", maxBlockerDetailBytes)
 	input := []Diagnostic{
-		{Code: string(FailureCodeExpressionInvalid), Severity: SeverityError, Blocker: "runner_label", BlockerDetail: "windows-latest"},
-		{Code: string(FailureCodeExpressionInvalid), Severity: SeverityError, Blocker: "runner_label", BlockerDetail: "macos-10"},
+		{Code: string(FailureCodeExpressionInvalid), Severity: SeverityError, Blocker: "expression", BlockerDetail: common + "first"},
+		{Code: string(FailureCodeExpressionInvalid), Severity: SeverityError, Blocker: "expression", BlockerDetail: common + "second"},
 	}
 	bounded, err := boundedDiagnostics(input)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(bounded, input) {
-		t.Fatalf("bounded diagnostics = %#v, want %#v", bounded, input)
+	if len(bounded) != 2 || bounded[0].BlockerDetail == bounded[1].BlockerDetail {
+		t.Fatalf("bounded diagnostics collapsed distinct details: %#v", bounded)
+	}
+	for _, diagnostic := range bounded {
+		if len(diagnostic.BlockerDetail) > maxBlockerDetailBytes || !strings.Contains(diagnostic.BlockerDetail, "…#") {
+			t.Fatalf("bounded diagnostic detail = %q", diagnostic.BlockerDetail)
+		}
 	}
 }
 

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -52,6 +52,12 @@ func TestClientEmitsCommandCompletedEvent(t *testing.T) {
 		FailureCode:           FailureCodeWorkflowSyntax,
 		ErrorMessage:          "  buildkite-gha: run-job:\ninvalid workflow\tvalue  ",
 		ErrorMessageTruncated: true,
+		Blocker:               "shell",
+		BlockerDetail:         "pwsh",
+		Diagnostics: []Diagnostic{{
+			Code: string(FailureCodeExpressionInvalid), Severity: SeverityError,
+			Blocker: "runner_label", BlockerDetail: "windows-latest",
+		}},
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -62,6 +68,11 @@ func TestClientEmitsCommandCompletedEvent(t *testing.T) {
 		Command: CommandRunJob, Outcome: OutcomeFailure, ClientVersion: "1.2.3", DurationMS: 1234,
 		FailurePhase: FailurePhaseParsing, FailureCode: FailureCodeWorkflowSyntax,
 		ErrorMessage: "buildkite-gha: run-job: invalid workflow value", ErrorMessageTruncated: true,
+		Blocker: "shell", BlockerDetail: "pwsh",
+		Diagnostics: []Diagnostic{{
+			Code: string(FailureCodeExpressionInvalid), Severity: SeverityError,
+			Blocker: "runner_label", BlockerDetail: "windows-latest",
+		}},
 	}
 	if !reflect.DeepEqual(request.Properties, want) {
 		t.Fatalf("properties = %#v, want %#v", request.Properties, want)
@@ -271,6 +282,30 @@ func TestDiagnosticsEnforceSeverityAndDeduplicateByCode(t *testing.T) {
 	}
 	if _, err := boundedDiagnostics([]Diagnostic{{Code: "CUSTOMER_VALUE", Severity: SeverityError}}); err == nil {
 		t.Fatal("boundedDiagnostics() accepted non-allowlisted code")
+	}
+}
+
+func TestDiagnosticsPreserveDistinctBlockersForOneCode(t *testing.T) {
+	input := []Diagnostic{
+		{Code: string(FailureCodeExpressionInvalid), Severity: SeverityError, Blocker: "runner_label", BlockerDetail: "windows-latest"},
+		{Code: string(FailureCodeExpressionInvalid), Severity: SeverityError, Blocker: "runner_label", BlockerDetail: "macos-10"},
+	}
+	bounded, err := boundedDiagnostics(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(bounded, input) {
+		t.Fatalf("bounded diagnostics = %#v, want %#v", bounded, input)
+	}
+}
+
+func TestBlockerDetailsAreNormalizedAndBounded(t *testing.T) {
+	blocker, detail, err := boundedBlocker("shell", "  pwsh\n"+strings.Repeat("界", maxBlockerDetailBytes))
+	if err != nil || blocker != "shell" || len(detail) > maxBlockerDetailBytes || !utf8.ValidString(detail) || !strings.HasPrefix(detail, "pwsh ") {
+		t.Fatalf("boundedBlocker() = %q, %q, %v", blocker, detail, err)
+	}
+	if _, _, err := boundedBlocker("customer-value", "detail"); err == nil {
+		t.Fatal("boundedBlocker() accepted an unknown blocker")
 	}
 }
 

--- a/internal/workflow/parse.go
+++ b/internal/workflow/parse.go
@@ -545,7 +545,14 @@ func validateRawContainer(path string, node *yaml.Node, service bool) (rawServic
 func adaptJob(path string, in *actionlint.Job, scalars map[Position]any, concurrency map[Position]stepConcurrency, serviceContainers map[string]rawServiceContainer) (Job, error) {
 	out := Job{ID: in.ID.Value, Span: pointSpan(in.Pos)}
 	if in.Environment != nil {
-		return Job{}, fmt.Errorf("%s:%d:%d: GitHub environments and environment secrets are unsupported. Remove the environment key from job %q. Approvals, deployment records, and protection rules are unavailable. Move environment secrets into Buildkite secrets and reference them by name. If you need GitHub environments, open an issue in https://github.com/buildkite/buildkite-gha so we can prioritize support", path, in.Environment.Pos.Line, in.Environment.Pos.Col, in.ID.Value)
+		detail := ""
+		if in.Environment.Name != nil && !strings.Contains(in.Environment.Name.Value, "${{") {
+			detail = in.Environment.Name.Value
+		}
+		return Job{}, &unsupportedEnvironmentError{
+			detail: detail,
+			err:    fmt.Errorf("%s:%d:%d: GitHub environments and environment secrets are unsupported. Remove the environment key from job %q. Approvals, deployment records, and protection rules are unavailable. Move environment secrets into Buildkite secrets and reference them by name. If you need GitHub environments, open an issue in https://github.com/buildkite/buildkite-gha so we can prioritize support", path, in.Environment.Pos.Line, in.Environment.Pos.Col, in.ID.Value),
+		}
 	}
 	ownedConcurrency, err := adaptConcurrency(path, in.ID.Value, in.Concurrency)
 	if err != nil {
@@ -809,6 +816,17 @@ func adaptJob(path string, in *actionlint.Job, scalars map[Position]any, concurr
 		return Job{}, err
 	}
 	return out, nil
+}
+
+type unsupportedEnvironmentError struct {
+	detail string
+	err    error
+}
+
+func (e *unsupportedEnvironmentError) Error() string { return e.err.Error() }
+func (e *unsupportedEnvironmentError) Unwrap() error { return e.err }
+func (e *unsupportedEnvironmentError) CompatibilityBlocker() (string, string) {
+	return "environment", e.detail
 }
 
 func adaptConcurrency(path, jobID string, in *actionlint.Concurrency) (*Concurrency, error) {

--- a/internal/workflow/parse_test.go
+++ b/internal/workflow/parse_test.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -144,6 +145,15 @@ func TestParseRejectsGitHubEnvironment(t *testing.T) {
 	want := `environment.yml:4:5: GitHub environments and environment secrets are unsupported. Remove the environment key from job "deploy". Approvals, deployment records, and protection rules are unavailable. Move environment secrets into Buildkite secrets and reference them by name. If you need GitHub environments, open an issue in https://github.com/buildkite/buildkite-gha so we can prioritize support`
 	if err == nil || err.Error() != want {
 		t.Fatalf("Parse() error = %q, want %q", err, want)
+	}
+	var blocker interface {
+		CompatibilityBlocker() (string, string)
+	}
+	if !errors.As(err, &blocker) {
+		t.Fatalf("Parse() error has no compatibility blocker: %v", err)
+	}
+	if kind, detail := blocker.CompatibilityBlocker(); kind != "environment" || detail != "production" {
+		t.Fatalf("compatibility blocker = %q / %q", kind, detail)
 	}
 }
 


### PR DESCRIPTION
## Why

Telemetry currently reports diagnostics such as `{"code":"E_EXPRESSION_INVALID","severity":"error"}`. It cannot distinguish an unsupported `windows-latest` runner from another expression failure, so compatibility gaps cannot be ranked by the feature users attempted to use.

## What

Add bounded `blocker` and `blocker_detail` properties to command telemetry and individual diagnostics. Rejections identify runner labels, environments, shells, action references, expressions, and triggers. Details are opt-in: they contain only original workflow syntax or values proven to depend on workflow literals, excluding runtime, event, secret, provider, downloaded-action, and provenance-unknown reusable-input values. Preserve distinct rejected values that share a diagnostic code.

Fixes [PB-3055](https://linear.app/buildkite/issue/PB-3055/emit-the-rejected-feature-on-buildkite-gha-diagnostics-so-telemetry).
