### PR TITLE
Allow artifact sizes supported by Buildkite Agent

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1181,7 +1181,9 @@ An unknown lowercase 40-hex immutable commit uses the stable v7.0.1 contract as 
 
 Unsupported path forms include exclusions, symlinks, absolute paths, traversal, braces, extglobs, leading glob comments, and special files. At most 32 path roots may be selected. For v3.2.1 and later, hidden path segments remain excluded unless explicitly enabled.
 
-An artifact may contain at most 10,000 files and 1 GiB of source data. The ZIP must also be no larger than 1 GiB. A job may publish 64 artifacts.
+An artifact may contain at most 10,000 files. `buildkite-gha` does not impose a source or ZIP byte limit; the Buildkite Agent and configured artifact storage enforce their limits. A job may publish 64 artifacts.
+
+Downloads verify the recorded archive size and digest before staging every member. File-count, path, format, and filesystem limits protect extraction; there is no separate fixed expansion-byte policy.
 
 For v4.6.2 and later, the adapter sets `artifact-id` and `artifact-digest`; `artifact-url` is empty because no GitHub run-scoped URL exists. The v1 through v3 releases expose no outputs. Merge, raw upload, overwrite, and effective retention control are unsupported.
 
@@ -1436,7 +1438,7 @@ hosted-toolchains images provide. macOS images are unsupported.
 | Job or step timeout | 360 minutes |
 | Artifacts per job | 64 |
 | Files per uploaded artifact | 10,000 |
-| Uploaded source data or ZIP | 1 GiB |
+| Uploaded source data or ZIP | No `buildkite-gha` limit; subject to Buildkite Agent and storage limits |
 | Job summary | 1 MiB |
 | `hashFiles()` patterns | 255 per call; 1 KiB each; 64 KiB total |
 | `hashFiles()` workspace entries | 100,000 per call |

--- a/internal/runtime/download_artifact.go
+++ b/internal/runtime/download_artifact.go
@@ -5,11 +5,11 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
-	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path"
 	"path/filepath"
@@ -134,8 +134,6 @@ func (r Runner) runDownloadArtifact(ctx context.Context, processor *commandProce
 		return matches[i].Path < matches[j].Path
 	})
 	remainingFiles := transport.MaxResultArtifactFileCount
-	remainingArchiveBytes := transport.MaxResultArtifactSizeBytes
-	remainingExpandedBytes := transport.MaxResultArtifactSizeBytes
 	staging, stagingRoot, err := openDownloadStaging(resolvedWorkspace)
 	if err != nil {
 		return result, err
@@ -150,16 +148,13 @@ func (r Runner) runDownloadArtifact(ctx context.Context, processor *commandProce
 		foldedNames: make(map[string]string),
 	}
 	for _, artifact := range matches {
-		if artifact.FileCount <= 0 || artifact.Size <= 0 || artifact.FileCount > remainingFiles || artifact.Size > remainingArchiveBytes {
+		if artifact.FileCount <= 0 || artifact.Size <= 0 || artifact.FileCount > remainingFiles {
 			return result, fmt.Errorf("matched artifacts exceed aggregate download limits")
 		}
-		expanded, err := r.downloadNeedArtifact(ctx, artifact, stage, remainingExpandedBytes)
-		if err != nil {
+		if err := r.downloadNeedArtifact(ctx, artifact, stage); err != nil {
 			return result, err
 		}
 		remainingFiles -= artifact.FileCount
-		remainingArchiveBytes -= artifact.Size
-		remainingExpandedBytes -= expanded
 	}
 	sort.Slice(stage.members, func(i, j int) bool { return downloadPathLess(stage.members[i].name, stage.members[j].name) })
 	if err := installDownloadMembers(ctx, resolvedWorkspace, stagingRoot, destinationRelative, stage.members); err != nil {
@@ -169,14 +164,14 @@ func (r Runner) runDownloadArtifact(ctx context.Context, processor *commandProce
 	return result, nil
 }
 
-func (r Runner) downloadNeedArtifact(ctx context.Context, artifact plan.NeedArtifact, stage *downloadStage, expandedLimit int64) (int64, error) {
+func (r Runner) downloadNeedArtifact(ctx context.Context, artifact plan.NeedArtifact, stage *downloadStage) error {
 	temporary, err := os.MkdirTemp("", "buildkite-gha-download-")
 	if err != nil {
-		return 0, err
+		return err
 	}
 	defer func() { _ = os.RemoveAll(temporary) }()
 	if err := r.Artifacts.DownloadArtifact(ctx, artifact.Path, temporary, artifact.Producer.JobID); err != nil {
-		return 0, fmt.Errorf("download native artifact: %w", err)
+		return fmt.Errorf("download native artifact: %w", err)
 	}
 	archivePath := filepath.Join(temporary, filepath.FromSlash(artifact.Path))
 	regular := 0
@@ -196,57 +191,35 @@ func (r Runner) downloadNeedArtifact(ctx context.Context, artifact plan.NeedArti
 		regular++
 		return nil
 	}); err != nil {
-		return 0, fmt.Errorf("download must contain exactly the expected archive: %w", err)
+		return fmt.Errorf("download must contain exactly the expected archive: %w", err)
 	}
 	if regular != 1 {
-		return 0, fmt.Errorf("download contained %d regular files, want exactly the expected archive", regular)
+		return fmt.Errorf("download contained %d regular files, want exactly the expected archive", regular)
 	}
 	temporaryRoot, err := openPinnedDownloadRoot(temporary)
 	if err != nil {
-		return 0, fmt.Errorf("open downloaded artifact root: %w", err)
+		return fmt.Errorf("open downloaded artifact root: %w", err)
 	}
 	defer func() { _ = temporaryRoot.Close() }()
 	archive, err := temporaryRoot.OpenFile(filepath.FromSlash(artifact.Path), os.O_RDONLY|nonBlockingOpenFlag, 0)
 	if err != nil {
-		return 0, fmt.Errorf("downloaded archive is not the expected regular file")
+		return fmt.Errorf("downloaded archive is not the expected regular file")
 	}
 	defer func() { _ = archive.Close() }()
 	info, err := archive.Stat()
 	if err != nil || !info.Mode().IsRegular() || !os.SameFile(archiveInfo, info) {
-		return 0, fmt.Errorf("downloaded archive is not the expected regular file")
+		return fmt.Errorf("downloaded archive is not the expected regular file")
 	}
 	if info.Size() != artifact.Size {
-		return 0, fmt.Errorf("downloaded archive size mismatch")
+		return fmt.Errorf("downloaded archive size mismatch")
 	}
 	if err := verifyDownloadDigestFile(ctx, archive, artifact.Digest, artifact.Size); err != nil {
-		return 0, err
-	}
-	expanded, err := downloadZIPExpandedSize(archive, artifact.Size, artifact.FileCount, expandedLimit)
-	if err != nil {
-		return 0, err
+		return err
 	}
 	if err := stageDownloadZIPFile(ctx, archive, artifact.Size, artifact.FileCount, stage); err != nil {
-		return 0, err
+		return err
 	}
-	return expanded, nil
-}
-
-func downloadZIPExpandedSize(reader io.ReaderAt, size int64, expectedCount int, limit int64) (int64, error) {
-	z, err := zip.NewReader(reader, size)
-	if err != nil {
-		return 0, fmt.Errorf("open artifact ZIP: %w", err)
-	}
-	if len(z.File) != expectedCount {
-		return 0, fmt.Errorf("artifact ZIP file count mismatch")
-	}
-	var expanded int64
-	for _, file := range z.File {
-		if file.UncompressedSize64 > uint64(limit) || expanded > limit-int64(file.UncompressedSize64) {
-			return 0, fmt.Errorf("matched artifacts exceed aggregate expanded-byte limit")
-		}
-		expanded += int64(file.UncompressedSize64)
-	}
-	return expanded, nil
+	return nil
 }
 
 func verifyDownloadDigestFile(ctx context.Context, f *os.File, digest string, size int64) error {
@@ -254,7 +227,7 @@ func verifyDownloadDigestFile(ctx context.Context, f *os.File, digest string, si
 		return err
 	}
 	h := sha256.New()
-	n, err := io.Copy(h, io.LimitReader(contextReader{ctx: ctx, reader: f}, transport.MaxResultArtifactSizeBytes+1))
+	n, err := io.Copy(h, contextReader{ctx: ctx, reader: f})
 	if err != nil {
 		return err
 	}
@@ -346,7 +319,6 @@ func stageDownloadZIPFile(ctx context.Context, f *os.File, size int64, expectedC
 	}
 	members := make([]downloadMember, 0, len(z.File))
 	foldedNames := make([]string, 0, len(z.File))
-	var expanded int64
 	for _, f := range z.File {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -358,10 +330,9 @@ func stageDownloadZIPFile(ctx context.Context, f *os.File, size int64, expectedC
 		if f.Method != zip.Store && f.Method != zip.Deflate || !f.Mode().IsRegular() || f.FileInfo().IsDir() {
 			return fmt.Errorf("artifact ZIP member %q is not a supported regular file", name)
 		}
-		if f.UncompressedSize64 > uint64(transport.MaxResultArtifactSizeBytes) || expanded > transport.MaxResultArtifactSizeBytes-int64(f.UncompressedSize64) {
-			return fmt.Errorf("artifact expanded bytes exceed 1 GiB")
+		if f.UncompressedSize64 > math.MaxInt64 {
+			return fmt.Errorf("artifact ZIP member %q size is not representable", name)
 		}
-		expanded += int64(f.UncompressedSize64)
 		foldedNames = append(foldedNames, strings.ToLower(name))
 		members = append(members, downloadMember{file: f, name: name, size: int64(f.UncompressedSize64)})
 	}
@@ -419,7 +390,7 @@ func stageDownloadZIPFile(ctx context.Context, f *os.File, size int64, expectedC
 		if err := out.Chmod(0o644); err != nil {
 			return errors.Join(err, out.Close(), in.Close())
 		}
-		n, copyErr := io.Copy(out, io.LimitReader(contextReader{ctx: ctx, reader: in}, member.size+1))
+		n, copyErr := io.Copy(out, contextReader{ctx: ctx, reader: in})
 		info, statErr := out.Stat()
 		err = errors.Join(copyErr, statErr, out.Close(), in.Close())
 		if err != nil {
@@ -470,171 +441,26 @@ func downloadPathLess(left, right string) bool {
 	return len(left) < len(right)
 }
 
+// preflightZIPDirectory relies on archive/zip for ordinary and ZIP64 directory
+// parsing, then applies format and resource guards that do not cap artifact bytes.
 func preflightZIPDirectory(reader io.ReaderAt, size int64) error {
-	const (
-		eocdSize      = 22
-		maxZIPComment = 1<<16 - 1
-		maxZIPExtra   = 64
-		centralHeader = 46
-		localHeader   = 30
-		eocdSignature = 0x06054b50
-		centralSig    = 0x02014b50
-		localSig      = 0x04034b50
-		zip16Sentinel = 1<<16 - 1
-		zip32Sentinel = 1<<32 - 1
-	)
-	if size < eocdSize || size > transport.MaxResultArtifactSizeBytes {
-		return fmt.Errorf("artifact ZIP size is out of bounds")
-	}
-	tailSize := min(size, int64(eocdSize+maxZIPComment))
-	tail := make([]byte, tailSize)
-	if _, err := reader.ReadAt(tail, size-tailSize); err != nil {
+	z, err := zip.NewReader(reader, size)
+	if err != nil {
 		return err
 	}
-	eocd := -1
-	for i := len(tail) - eocdSize; i >= 0; i-- {
-		if binary.LittleEndian.Uint32(tail[i:]) != eocdSignature {
-			continue
-		}
-		comment := int(binary.LittleEndian.Uint16(tail[i+20:]))
-		if i+eocdSize+comment == len(tail) {
-			eocd = i
-			break
-		}
-	}
-	if eocd < 0 {
-		return fmt.Errorf("artifact ZIP end record is missing")
-	}
-	for i := eocd + 1; i <= len(tail)-eocdSize; i++ {
-		if binary.LittleEndian.Uint32(tail[i:]) != eocdSignature {
-			continue
-		}
-		comment := int(binary.LittleEndian.Uint16(tail[i+20:]))
-		if i+eocdSize+comment <= len(tail) {
-			return fmt.Errorf("artifact ZIP has an ambiguous end record")
-		}
-	}
-	record := tail[eocd:]
-	entriesDisk := binary.LittleEndian.Uint16(record[8:])
-	entries := binary.LittleEndian.Uint16(record[10:])
-	centralSize := binary.LittleEndian.Uint32(record[12:])
-	centralOffset := binary.LittleEndian.Uint32(record[16:])
-	if binary.LittleEndian.Uint16(record[4:]) != 0 || binary.LittleEndian.Uint16(record[6:]) != 0 || entriesDisk != entries || entries == zip16Sentinel || centralSize == zip32Sentinel || centralOffset == zip32Sentinel {
-		return fmt.Errorf("multi-disk or ZIP64 artifact is unsupported")
-	}
-	if entries == 0 || int(entries) > transport.MaxResultArtifactFileCount {
+	if len(z.File) == 0 || len(z.File) > transport.MaxResultArtifactFileCount {
 		return fmt.Errorf("artifact ZIP file count is out of bounds")
 	}
-	position, end := int64(centralOffset), int64(centralOffset)+int64(centralSize)
-	eocdOffset := size - tailSize + int64(eocd)
-	if centralSize == zip16Sentinel {
-		if eocdOffset < 20 {
-			return fmt.Errorf("artifact ZIP end record is malformed")
-		}
-		var locator [20]byte
-		if _, err := reader.ReadAt(locator[:], eocdOffset-20); err != nil {
-			return err
-		}
-		if binary.LittleEndian.Uint32(locator[:]) == 0x07064b50 && binary.LittleEndian.Uint32(locator[4:]) == 0 && binary.LittleEndian.Uint32(locator[16:]) == 1 {
-			return fmt.Errorf("ZIP64 artifact is unsupported")
-		}
-	}
-	if position < 0 || end < position || end != eocdOffset {
-		return fmt.Errorf("artifact ZIP central directory is out of bounds")
-	}
-	count := 0
-	metadata := make([]byte, actionintegration.MaxUploadArtifactPathBytes+maxZIPExtra)
-	for position < end {
-		if end-position < centralHeader {
-			return fmt.Errorf("artifact ZIP central directory is malformed")
-		}
-		var header [centralHeader]byte
-		if _, err := reader.ReadAt(header[:], position); err != nil {
-			return err
-		}
-		if binary.LittleEndian.Uint32(header[:]) != centralSig {
-			return fmt.Errorf("artifact ZIP central directory is malformed")
-		}
-		if binary.LittleEndian.Uint32(header[20:]) == zip32Sentinel || binary.LittleEndian.Uint32(header[24:]) == zip32Sentinel || binary.LittleEndian.Uint16(header[34:]) != 0 || binary.LittleEndian.Uint32(header[42:]) == zip32Sentinel {
-			return fmt.Errorf("ZIP64 artifact member is unsupported")
-		}
-		nameSize := int64(binary.LittleEndian.Uint16(header[28:]))
-		extraSize := int64(binary.LittleEndian.Uint16(header[30:]))
-		commentSize := int64(binary.LittleEndian.Uint16(header[32:]))
-		if nameSize > actionintegration.MaxUploadArtifactPathBytes || extraSize > maxZIPExtra || commentSize != 0 {
-			return fmt.Errorf("artifact ZIP central directory metadata exceeds bounds")
-		}
-		metadataPosition, metadataEnd := position+centralHeader, position+centralHeader+nameSize+extraSize
-		if metadataPosition < position || metadataEnd < metadataPosition || metadataEnd > end {
-			return fmt.Errorf("artifact ZIP central directory exceeds bounds")
-		}
-		entryMetadata := metadata[:nameSize+extraSize]
-		if len(entryMetadata) > 0 {
-			if _, err := reader.ReadAt(entryMetadata, metadataPosition); err != nil {
-				return err
-			}
-		}
-		memberName := string(entryMetadata[:nameSize])
-		if !validArtifactMember(memberName) {
+	for _, file := range z.File {
+		if !validArtifactMember(file.Name) {
 			return fmt.Errorf("artifact ZIP member name is unsafe")
 		}
-		if err := preflightZIPExtraFields(entryMetadata[nameSize:]); err != nil {
-			return err
+		if file.Method != zip.Store && file.Method != zip.Deflate || !file.Mode().IsRegular() || file.FileInfo().IsDir() {
+			return fmt.Errorf("artifact ZIP member %q is not a supported regular file", file.Name)
 		}
-
-		localOffset := int64(binary.LittleEndian.Uint32(header[42:]))
-		if localOffset < 0 || int64(centralOffset)-localOffset < localHeader {
-			return fmt.Errorf("artifact ZIP local header is out of bounds")
+		if file.UncompressedSize64 > math.MaxInt64 {
+			return fmt.Errorf("artifact ZIP member %q size is not representable", file.Name)
 		}
-		var local [localHeader]byte
-		if _, err := reader.ReadAt(local[:], localOffset); err != nil {
-			return err
-		}
-		if binary.LittleEndian.Uint32(local[:]) != localSig || binary.LittleEndian.Uint32(local[18:]) == zip32Sentinel || binary.LittleEndian.Uint32(local[22:]) == zip32Sentinel {
-			return fmt.Errorf("ZIP64 or malformed artifact local header is unsupported")
-		}
-		localNameSize := int64(binary.LittleEndian.Uint16(local[26:]))
-		localExtraSize := int64(binary.LittleEndian.Uint16(local[28:]))
-		if localNameSize > actionintegration.MaxUploadArtifactPathBytes || localExtraSize > maxZIPExtra || int64(centralOffset)-localOffset-localHeader < localNameSize+localExtraSize {
-			return fmt.Errorf("artifact ZIP local header metadata exceeds bounds")
-		}
-		localMetadata := metadata[:localNameSize+localExtraSize]
-		if len(localMetadata) > 0 {
-			if _, err := reader.ReadAt(localMetadata, localOffset+localHeader); err != nil {
-				return err
-			}
-		}
-		if string(localMetadata[:localNameSize]) != memberName {
-			return fmt.Errorf("artifact ZIP local and central names differ")
-		}
-		if err := preflightZIPExtraFields(localMetadata[localNameSize:]); err != nil {
-			return err
-		}
-		position += centralHeader + nameSize + extraSize + commentSize
-		count++
-		if count > transport.MaxResultArtifactFileCount || position > end {
-			return fmt.Errorf("artifact ZIP central directory exceeds bounds")
-		}
-	}
-	if position != end || count != int(entries) {
-		return fmt.Errorf("artifact ZIP central directory count mismatch")
-	}
-	return nil
-}
-
-func preflightZIPExtraFields(fields []byte) error {
-	for len(fields) > 0 {
-		if len(fields) < 4 {
-			return fmt.Errorf("artifact ZIP extra field is malformed")
-		}
-		fieldSize := int(binary.LittleEndian.Uint16(fields[2:]))
-		if fieldSize > len(fields)-4 {
-			return fmt.Errorf("artifact ZIP extra field is malformed")
-		}
-		if binary.LittleEndian.Uint16(fields) == 0x0001 {
-			return fmt.Errorf("ZIP64 artifact member is unsupported")
-		}
-		fields = fields[4+fieldSize:]
 	}
 	return nil
 }

--- a/internal/runtime/download_artifact_test.go
+++ b/internal/runtime/download_artifact_test.go
@@ -34,21 +34,6 @@ type downloadStore struct {
 	download    func(context.Context, string) error
 }
 
-type countingReaderAt struct {
-	reader io.ReaderAt
-	reads  []readAtCall
-}
-
-type readAtCall struct {
-	offset int64
-	size   int
-}
-
-func (r *countingReaderAt) ReadAt(p []byte, off int64) (int, error) {
-	r.reads = append(r.reads, readAtCall{offset: off, size: len(p)})
-	return r.reader.ReadAt(p, off)
-}
-
 func (s *downloadStore) UploadArtifactFrom(context.Context, string, string) error { return nil }
 func (s *downloadStore) DownloadArtifact(ctx context.Context, path, destination, jobID string) error {
 	s.path = path
@@ -618,238 +603,6 @@ func TestDownloadArtifactPreflightsCentralDirectoryBeforeZIPAllocation(t *testin
 	}
 }
 
-func TestDownloadArtifactPreflightRejectsPerEntryZIP64(t *testing.T) {
-	for _, test := range []struct {
-		name   string
-		offset int
-		width  int
-	}{
-		{name: "compressed size", offset: 20, width: 4},
-		{name: "uncompressed size", offset: 24, width: 4},
-		{name: "disk start", offset: 34, width: 2},
-		{name: "local header offset", offset: 42, width: 4},
-	} {
-		t.Run(test.name+" sentinel", func(t *testing.T) {
-			name, _, _ := testDownloadZIP(t, "result.txt")
-			contents, err := os.ReadFile(name)
-			if err != nil {
-				t.Fatal(err)
-			}
-			eocd := len(contents) - 22
-			central := int(binary.LittleEndian.Uint32(contents[eocd+16:]))
-			if central < 0 || central+46 > eocd || binary.LittleEndian.Uint32(contents[central:]) != 0x02014b50 {
-				t.Fatal("test ZIP central directory is malformed")
-			}
-			if test.width == 2 {
-				binary.LittleEndian.PutUint16(contents[central+test.offset:], 1<<16-1)
-			} else {
-				binary.LittleEndian.PutUint32(contents[central+test.offset:], 1<<32-1)
-			}
-			if err := os.WriteFile(name, contents, 0o644); err != nil {
-				t.Fatal(err)
-			}
-			f, err := os.Open(name)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if err := preflightZIPDirectory(f, int64(len(contents))); err == nil || !strings.Contains(err.Error(), "ZIP64") {
-				t.Fatalf("per-entry ZIP64 sentinel error = %v", err)
-			}
-			if err := f.Close(); err != nil {
-				t.Fatal(err)
-			}
-		})
-	}
-
-	t.Run("nonzero disk start", func(t *testing.T) {
-		name, _, _ := testDownloadZIP(t, "result.txt")
-		contents, err := os.ReadFile(name)
-		if err != nil {
-			t.Fatal(err)
-		}
-		eocd := len(contents) - 22
-		central := int(binary.LittleEndian.Uint32(contents[eocd+16:]))
-		binary.LittleEndian.PutUint16(contents[central+34:], 1)
-		if err := preflightZIPDirectory(bytes.NewReader(contents), int64(len(contents))); err == nil {
-			t.Fatal("nonzero per-entry disk accepted")
-		}
-	})
-
-	for _, test := range []struct {
-		name  string
-		extra []byte
-		want  string
-	}{
-		{name: "chained ZIP64 extra", extra: []byte{0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00}, want: "ZIP64"},
-		{name: "truncated extra header", extra: []byte{0x02, 0x00, 0x00}, want: "malformed"},
-		{name: "extra size overrun", extra: []byte{0x02, 0x00, 0x04, 0x00, 0x00}, want: "malformed"},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			name := filepath.Join(t.TempDir(), "zip64-extra.zip")
-			out, err := os.Create(name)
-			if err != nil {
-				t.Fatal(err)
-			}
-			zw := zip.NewWriter(out)
-			header := &zip.FileHeader{Name: "result.txt", Method: zip.Store, Extra: test.extra}
-			member, err := zw.CreateHeader(header)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if _, err := member.Write([]byte("payload")); err != nil {
-				t.Fatal(err)
-			}
-			if err := errors.Join(zw.Close(), out.Close()); err != nil {
-				t.Fatal(err)
-			}
-			f, err := os.Open(name)
-			if err != nil {
-				t.Fatal(err)
-			}
-			info, err := f.Stat()
-			if err != nil {
-				t.Fatal(err)
-			}
-			if err := preflightZIPDirectory(f, info.Size()); err == nil || !strings.Contains(err.Error(), test.want) {
-				t.Fatalf("per-entry extra error = %v, want %q", err, test.want)
-			}
-			if err := f.Close(); err != nil {
-				t.Fatal(err)
-			}
-		})
-	}
-}
-
-func TestDownloadArtifactPreflightRejectsLocalZIP64(t *testing.T) {
-	for _, test := range []struct {
-		name   string
-		offset int
-	}{
-		{name: "compressed size", offset: 18},
-		{name: "uncompressed size", offset: 22},
-	} {
-		t.Run(test.name+" sentinel", func(t *testing.T) {
-			name, _, _ := testDownloadZIP(t, "result.txt")
-			contents, err := os.ReadFile(name)
-			if err != nil {
-				t.Fatal(err)
-			}
-			eocd := len(contents) - 22
-			central := int(binary.LittleEndian.Uint32(contents[eocd+16:]))
-			local := int(binary.LittleEndian.Uint32(contents[central+42:]))
-			binary.LittleEndian.PutUint32(contents[local+test.offset:], 1<<32-1)
-			if err := preflightZIPDirectory(bytes.NewReader(contents), int64(len(contents))); err == nil || !strings.Contains(err.Error(), "ZIP64") {
-				t.Fatalf("local ZIP64 sentinel error = %v", err)
-			}
-		})
-	}
-
-	t.Run("extra field", func(t *testing.T) {
-		name := filepath.Join(t.TempDir(), "local-zip64-extra.zip")
-		out, err := os.Create(name)
-		if err != nil {
-			t.Fatal(err)
-		}
-		zw := zip.NewWriter(out)
-		member, err := zw.CreateHeader(&zip.FileHeader{Name: "result.txt", Method: zip.Store, Extra: []byte{0x01, 0x00, 0x00, 0x00}})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if _, err := member.Write([]byte("payload")); err != nil {
-			t.Fatal(err)
-		}
-		if err := errors.Join(zw.Close(), out.Close()); err != nil {
-			t.Fatal(err)
-		}
-		contents, err := os.ReadFile(name)
-		if err != nil {
-			t.Fatal(err)
-		}
-		eocd := len(contents) - 22
-		central := int(binary.LittleEndian.Uint32(contents[eocd+16:]))
-		centralExtra := central + 46 + int(binary.LittleEndian.Uint16(contents[central+28:]))
-		binary.LittleEndian.PutUint16(contents[centralExtra:], 2)
-		if err := preflightZIPDirectory(bytes.NewReader(contents), int64(len(contents))); err == nil || !strings.Contains(err.Error(), "ZIP64") {
-			t.Fatalf("local ZIP64 extra error = %v", err)
-		}
-	})
-}
-
-func TestDownloadArtifactPreflightBoundsCentralMetadata(t *testing.T) {
-	for _, test := range []struct {
-		name    string
-		header  zip.FileHeader
-		wantErr string
-	}{
-		{name: "oversized member name", header: zip.FileHeader{Name: strings.Repeat("x", actionintegration.MaxUploadArtifactPathBytes+1), Method: zip.Store}, wantErr: "metadata"},
-		{name: "member comment", header: zip.FileHeader{Name: "result.txt", Method: zip.Store, Comment: "comment"}, wantErr: "metadata"},
-		{name: "oversized extra", header: zip.FileHeader{Name: "result.txt", Method: zip.Store, Extra: append([]byte{0x02, 0x00, 61, 0x00}, make([]byte, 61)...)}, wantErr: "metadata"},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			name := filepath.Join(t.TempDir(), "metadata.zip")
-			out, err := os.Create(name)
-			if err != nil {
-				t.Fatal(err)
-			}
-			zw := zip.NewWriter(out)
-			member, err := zw.CreateHeader(&test.header)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if _, err := member.Write([]byte("payload")); err != nil {
-				t.Fatal(err)
-			}
-			if err := errors.Join(zw.Close(), out.Close()); err != nil {
-				t.Fatal(err)
-			}
-			contents, err := os.ReadFile(name)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if err := preflightZIPDirectory(bytes.NewReader(contents), int64(len(contents))); err == nil || !strings.Contains(err.Error(), test.wantErr) {
-				t.Fatalf("central metadata error = %v, want %q", err, test.wantErr)
-			}
-		})
-	}
-}
-
-func TestDownloadArtifactPreflightRejectsEOCDZIP64Forms(t *testing.T) {
-	for _, test := range []struct {
-		name   string
-		offset int
-		width  int
-		value  uint32
-	}{
-		{name: "entry count sentinel", offset: 10, width: 2, value: 1<<16 - 1},
-		{name: "directory size with ZIP64 locator", offset: 12, width: 4, value: 1<<16 - 1},
-		{name: "directory size ZIP64 sentinel", offset: 12, width: 4, value: 1<<32 - 1},
-		{name: "directory offset sentinel", offset: 16, width: 4, value: 1<<32 - 1},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			name, _, _ := testDownloadZIP(t, "result.txt")
-			contents, err := os.ReadFile(name)
-			if err != nil {
-				t.Fatal(err)
-			}
-			eocd := len(contents) - 22
-			if test.width == 2 {
-				binary.LittleEndian.PutUint16(contents[eocd+test.offset:], uint16(test.value))
-			} else {
-				binary.LittleEndian.PutUint32(contents[eocd+test.offset:], test.value)
-			}
-			if test.name == "directory size with ZIP64 locator" {
-				locator := contents[eocd-20 : eocd]
-				clear(locator)
-				binary.LittleEndian.PutUint32(locator, 0x07064b50)
-				binary.LittleEndian.PutUint32(locator[16:], 1)
-			}
-			if err := preflightZIPDirectory(bytes.NewReader(contents), int64(len(contents))); err == nil || !strings.Contains(err.Error(), "ZIP64") {
-				t.Fatalf("EOCD ZIP64 error = %v", err)
-			}
-		})
-	}
-}
-
 func TestDownloadArtifactPreflightAcceptsOrdinary65535ByteCentralDirectory(t *testing.T) {
 	name := filepath.Join(t.TempDir(), "ordinary-65535.zip")
 	out, err := os.Create(name)
@@ -891,67 +644,6 @@ func TestDownloadArtifactPreflightAcceptsOrdinary65535ByteCentralDirectory(t *te
 	}
 }
 
-func TestDownloadArtifactPreflightRejectsShortCentralDirectoryResidue(t *testing.T) {
-	name, _, _ := testDownloadZIP(t, "result.txt")
-	contents, err := os.ReadFile(name)
-	if err != nil {
-		t.Fatal(err)
-	}
-	eocd := len(contents) - 22
-	binary.LittleEndian.PutUint32(contents[eocd+12:], 1)
-	binary.LittleEndian.PutUint32(contents[eocd+16:], uint32(eocd-1))
-	reader := &countingReaderAt{reader: bytes.NewReader(contents)}
-	if err := preflightZIPDirectory(reader, int64(len(contents))); err == nil || !strings.Contains(err.Error(), "malformed") {
-		t.Fatalf("short central directory error = %v", err)
-	}
-	if len(reader.reads) != 1 {
-		t.Fatalf("ReaderAt calls = %#v, want only the EOCD tail read", reader.reads)
-	}
-}
-
-func TestDownloadArtifactPreflightUsesBoundedMetadataReads(t *testing.T) {
-	name := filepath.Join(t.TempDir(), "many-extras.zip")
-	out, err := os.Create(name)
-	if err != nil {
-		t.Fatal(err)
-	}
-	zw := zip.NewWriter(out)
-	extra := bytes.Repeat([]byte{0x02, 0x00, 0x00, 0x00}, 10)
-	member, err := zw.CreateHeader(&zip.FileHeader{Name: "result.txt", Method: zip.Store, Extra: extra})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := member.Write([]byte("payload")); err != nil {
-		t.Fatal(err)
-	}
-	if err := errors.Join(zw.Close(), out.Close()); err != nil {
-		t.Fatal(err)
-	}
-	contents, err := os.ReadFile(name)
-	if err != nil {
-		t.Fatal(err)
-	}
-	reader := &countingReaderAt{reader: bytes.NewReader(contents)}
-	if err := preflightZIPDirectory(reader, int64(len(contents))); err != nil {
-		t.Fatal(err)
-	}
-	if len(reader.reads) != 5 {
-		t.Fatalf("ReaderAt calls = %#v, want tail plus bounded central and local header/metadata reads", reader.reads)
-	}
-	eocd := len(contents) - 22
-	central := int64(binary.LittleEndian.Uint32(contents[eocd+16:]))
-	for _, call := range reader.reads[1:3] {
-		if call.offset < central || call.offset+int64(call.size) > int64(eocd) {
-			t.Fatalf("central-directory read %#v is outside [%d, %d)", call, central, eocd)
-		}
-	}
-	for _, call := range reader.reads[3:] {
-		if call.offset < 0 || call.offset+int64(call.size) > central {
-			t.Fatalf("local-header read %#v is outside [0, %d)", call, central)
-		}
-	}
-}
-
 func TestDownloadArtifactExtractionUsesVerifiedArchiveDescriptor(t *testing.T) {
 	name, size, digest := testDownloadZIP(t, "result.txt")
 	f, err := os.Open(name)
@@ -967,10 +659,6 @@ func TestDownloadArtifactExtractionUsesVerifiedArchiveDescriptor(t *testing.T) {
 	}
 	if err := os.WriteFile(name, []byte("replacement"), 0o644); err != nil {
 		t.Fatal(err)
-	}
-	expanded, err := downloadZIPExpandedSize(f, size, 1, transport.MaxResultArtifactSizeBytes)
-	if err != nil || expanded != int64(len("payload")) {
-		t.Fatalf("descriptor-pinned expanded size = %d, %v", expanded, err)
 	}
 	workspace := t.TempDir()
 	if err := extractDownloadZIPFile(t.Context(), f, size, workspace, ".", 1); err != nil {
@@ -1206,7 +894,7 @@ func TestDownloadArtifactRejectsDestinationSymlinkEscape(t *testing.T) {
 	}
 }
 
-func TestDownloadArtifactRejectsUnsupportedMemberAndExpandedSize(t *testing.T) {
+func TestDownloadArtifactRejectsUnsupportedMember(t *testing.T) {
 	for _, test := range []struct {
 		name   string
 		method uint16
@@ -1216,7 +904,6 @@ func TestDownloadArtifactRejectsUnsupportedMemberAndExpandedSize(t *testing.T) {
 		{name: "directory", method: zip.Store, mode: os.ModeDir | 0o755},
 		{name: "symlink", method: zip.Store, mode: os.ModeSymlink | 0o777},
 		{name: "method", method: 99, mode: 0o644},
-		{name: "expanded size", method: zip.Store, mode: 0o644, size: uint64(transport.MaxResultArtifactSizeBytes) + 1},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			filename := filepath.Join(t.TempDir(), "raw.zip")

--- a/internal/runtime/upload_artifact.go
+++ b/internal/runtime/upload_artifact.go
@@ -253,7 +253,7 @@ func verifyUploadZIP(ctx context.Context, path, digest string, size int64) error
 		return err
 	}
 	hash := sha256.New()
-	written, copyErr := io.Copy(hash, io.LimitReader(contextReader{ctx: ctx, reader: file}, transport.MaxResultArtifactSizeBytes+1))
+	written, copyErr := io.Copy(hash, contextReader{ctx: ctx, reader: file})
 	closeErr := file.Close()
 	if copyErr != nil {
 		return errors.Join(copyErr, closeErr)
@@ -277,14 +277,9 @@ func collectUploadFiles(ctx context.Context, workspace string, roots []string, h
 	}
 	var files []archiveFile
 	var archiveBases []string
-	var bytes int64
 	add := func(disk string, info os.FileInfo) error {
 		if err := ctx.Err(); err != nil {
 			return err
-		}
-		bytes += info.Size()
-		if bytes > transport.MaxResultArtifactSizeBytes {
-			return fmt.Errorf("artifact source bytes exceed 1 GiB")
 		}
 		files = append(files, archiveFile{disk: disk, size: info.Size(), info: info})
 		if len(files) > transport.MaxResultArtifactFileCount {
@@ -592,9 +587,6 @@ func writeUploadZIP(ctx context.Context, path, workspace string, files []archive
 	info, e := f.Stat()
 	if e != nil {
 		return "", 0, e
-	}
-	if info.Size() > transport.MaxResultArtifactSizeBytes {
-		return "", 0, fmt.Errorf("final ZIP exceeds 1 GiB")
 	}
 	return hex.EncodeToString(h.Sum(nil)), info.Size(), nil
 }

--- a/internal/runtime/upload_artifact_test.go
+++ b/internal/runtime/upload_artifact_test.go
@@ -656,24 +656,29 @@ func TestUploadArtifactCancellationStopsAgentUpload(t *testing.T) {
 	}
 }
 
-func TestUploadArtifactSourceBounds(t *testing.T) {
+func TestUploadArtifactSourceCollectionHasNoSizePolicy(t *testing.T) {
 	t.Parallel()
 
 	workspace := t.TempDir()
-	tooLarge := filepath.Join(workspace, "too-large")
-	file, err := os.Create(tooLarge)
+	large := filepath.Join(workspace, "large")
+	file, err := os.Create(large)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := file.Truncate(transport.MaxResultArtifactSizeBytes + 1); err != nil {
+	if err := file.Truncate(6 << 30); err != nil {
 		t.Fatal(err)
 	}
 	if err := file.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := collectUploadFiles(t.Context(), workspace, []string{"too-large"}, false); err == nil || !strings.Contains(err.Error(), "source bytes exceed") {
-		t.Fatalf("source-size bound error = %v", err)
+	files, err := collectUploadFiles(t.Context(), workspace, []string{"large"}, false)
+	if err != nil || len(files) != 1 || files[0].size != 6<<30 {
+		t.Fatalf("large source collection = %#v, %v", files, err)
 	}
+}
+
+func TestUploadArtifactSourceFileCountBound(t *testing.T) {
+	t.Parallel()
 
 	many := t.TempDir()
 	if err := os.Mkdir(filepath.Join(many, "files"), 0o755); err != nil {

--- a/internal/transport/model.go
+++ b/internal/transport/model.go
@@ -28,7 +28,6 @@ const (
 	MaxResultArtifactNameBytes = 255
 	MaxResultArtifactIDBytes   = 20
 	MaxResultArtifactFileCount = 10_000
-	MaxResultArtifactSizeBytes = int64(1 << 30)
 )
 
 var (
@@ -102,7 +101,7 @@ func (a ResultArtifact) validate() error {
 	if !digestPattern.MatchString(a.Digest) {
 		return fmt.Errorf("invalid result artifact digest %q", a.Digest)
 	}
-	if a.Size <= 0 || a.Size > MaxResultArtifactSizeBytes {
+	if a.Size <= 0 {
 		return fmt.Errorf("invalid result artifact size %d", a.Size)
 	}
 	if a.FileCount <= 0 || a.FileCount > MaxResultArtifactFileCount {

--- a/internal/transport/model_test.go
+++ b/internal/transport/model_test.go
@@ -124,7 +124,6 @@ func TestResultManifestRejectsMalformedArtifacts(t *testing.T) {
 		{name: "uppercase path digest", mutate: func(a *ResultArtifact) { a.Path = "buildkite-gha/v1/artifacts/" + strings.Repeat("A", 64) + ".zip" }},
 		{name: "invalid digest", mutate: func(a *ResultArtifact) { a.Digest = strings.Repeat("a", 64) }},
 		{name: "zero size", mutate: func(a *ResultArtifact) { a.Size = 0 }},
-		{name: "oversized archive", mutate: func(a *ResultArtifact) { a.Size = MaxResultArtifactSizeBytes + 1 }},
 		{name: "zero files", mutate: func(a *ResultArtifact) { a.FileCount = 0 }},
 		{name: "too many files", mutate: func(a *ResultArtifact) { a.FileCount = MaxResultArtifactFileCount + 1 }},
 	}
@@ -144,6 +143,16 @@ func TestResultManifestRejectsMalformedArtifacts(t *testing.T) {
 	manifest.Artifacts = make([]ResultArtifact, MaxResultArtifacts+1)
 	if _, err := MarshalResultManifest(manifest); err == nil {
 		t.Fatal("MarshalResultManifest() accepted too many artifacts")
+	}
+}
+
+func TestResultManifestAcceptsArtifactSizeWithoutPolicyLimit(t *testing.T) {
+	artifact := resultArtifact("artifact", "1", strings.Repeat("a", 64))
+	artifact.Size = int64(^uint64(0) >> 1)
+	manifest := resultManifest(testJobID, "gha-producer", Digest([]byte("plan")), "success")
+	manifest.Artifacts = []ResultArtifact{artifact}
+	if _, err := MarshalResultManifest(manifest); err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
## Why

Large workflow artifacts fail before reaching Buildkite with:

```
artifact source bytes exceed 1 GiB
```

GitHub's artifact action has no equivalent byte ceiling, and Buildkite Agent already owns artifact storage limits.

## What

Remove buildkite-gha's source, ZIP, manifest, and download expansion byte ceilings. Uploads now defer size policy to Buildkite Agent and the configured storage backend.

Downloads continue to verify the recorded size and digest, bound file counts, validate paths and member types, and stage files before installation. ZIP and ZIP64 parsing now uses Go's standard library without imposing an indirect archive-size limit.

[PB-3140](https://linear.app/buildkite/issue/PB-3140/confirm-the-artifact-size-ceiling-on-large-workflows)
