### PR TITLE
Report the compatibility rejection message whole in failure telemetry

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -524,9 +524,12 @@ The plugin value must be a YAML boolean, not a quoted string.
 In Buildkite jobs, the importer and runtime send best-effort completion
 telemetry through the job-authenticated Agent API. Events contain the command,
 outcome, client version, duration, and bounded diagnostic codes and severities.
-For an unsuccessful command, they also contain the final 1,024 bytes of
-normalized user-visible error output. `error_message_truncated` says whether
-earlier output was omitted.
+For an unsuccessful command, they also contain a normalized user-visible error
+message of at most 1,024 bytes. When a workflow diagnostic attributes the
+failure, the message is that diagnostic's text, kept whole so later job output
+cannot displace it. Otherwise it is the final bytes of the command's error
+output. `error_message_truncated` says whether part of the message was
+omitted.
 
 Failed runs also carry a failure phase and a code from a fixed set. The code
 separates workflow-authored process exits (`E_STEP_PROCESS_EXIT`) from

--- a/internal/cli/telemetry.go
+++ b/internal/cli/telemetry.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	buildkitepipeline "github.com/buildkite/buildkite-gha/internal/buildkite"
 	"github.com/buildkite/buildkite-gha/internal/compatibility"
@@ -58,11 +59,12 @@ func telemetryOutcome(code int, conclusion string, contextErr error) telemetry.O
 }
 
 type commandTelemetryDetails struct {
-	failurePhase telemetry.FailurePhase
-	failureCode  telemetry.FailureCode
-	diagnostics  []telemetry.Diagnostic
-	seen         map[string]int
-	errorOutput  boundedTailBuffer
+	failurePhase   telemetry.FailurePhase
+	failureCode    telemetry.FailureCode
+	failureMessage string
+	diagnostics    []telemetry.Diagnostic
+	seen           map[string]int
+	errorOutput    boundedTailBuffer
 }
 
 func (d *commandTelemetryDetails) captureErrors(writer io.Writer) io.Writer {
@@ -104,13 +106,19 @@ func (d *commandTelemetryDetails) addReportDiagnostics(report compatibility.Proc
 }
 
 // observe records a report that ends the command, so its first error also
-// attributes the failure.
+// attributes the failure. The attributing diagnostic's message is kept whole:
+// the stderr tail alone can lose it behind later agent output, such as
+// annotation and pipeline-upload chatter.
 func (d *commandTelemetryDetails) observe(report compatibility.ProcessingReport) {
 	d.addReportDiagnostics(report)
 	for _, diagnostic := range report.Diagnostics {
 		if diagnostic.Level == "error" && d.failureCode == "" && allowlistedTelemetryDiagnosticCode(diagnostic.Code) {
 			d.failurePhase = telemetryPhase(diagnostic.Stage)
 			d.failureCode = telemetry.FailureCode(diagnostic.Code)
+			d.failureMessage = diagnostic.Message
+			if diagnostic.Detail != "" {
+				d.failureMessage += " " + diagnostic.Detail
+			}
 		}
 	}
 }
@@ -162,9 +170,22 @@ func (d *commandTelemetryDetails) forOutcome(outcome telemetry.Outcome) telemetr
 	if code == "" {
 		code = telemetry.FailureCodeUnknown
 	}
+	errorMessage, errorMessageTruncated := string(d.errorOutput.bytes), d.errorOutput.truncated
+	if d.failureMessage != "" {
+		// An attributed failure message names the rejected feature at its
+		// start, so an over-long message keeps its head, not its tail.
+		errorMessage, errorMessageTruncated = d.failureMessage, false
+		if len(errorMessage) > telemetry.MaxErrorMessageBytes {
+			end := telemetry.MaxErrorMessageBytes
+			for end > 0 && !utf8.RuneStart(errorMessage[end]) {
+				end--
+			}
+			errorMessage, errorMessageTruncated = errorMessage[:end], true
+		}
+	}
 	return telemetry.Details{
 		FailurePhase: phase, FailureCode: code, Diagnostics: slices.Clone(d.diagnostics),
-		ErrorMessage: string(d.errorOutput.bytes), ErrorMessageTruncated: d.errorOutput.truncated,
+		ErrorMessage: errorMessage, ErrorMessageTruncated: errorMessageTruncated,
 	}
 }
 

--- a/internal/cli/telemetry_test.go
+++ b/internal/cli/telemetry_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"unicode/utf8"
 
 	actionintegration "github.com/buildkite/buildkite-gha/internal/action/integration"
 	buildkitepipeline "github.com/buildkite/buildkite-gha/internal/buildkite"
@@ -260,6 +261,56 @@ func TestCommandTelemetryCapturesBoundedErrorTailWithoutChangingOutput(t *testin
 	}
 	if success := details.forOutcome(telemetry.OutcomeSuccess); success.ErrorMessage != "" || success.ErrorMessageTruncated {
 		t.Fatalf("successful telemetry included error output: %#v", success)
+	}
+}
+
+func TestObservedFailureMessageSurvivesLaterErrorOutput(t *testing.T) {
+	details := &commandTelemetryDetails{}
+	writer := details.captureErrors(io.Discard)
+	message := "GitHub environments and environment secrets are unsupported. Remove the environment key from job \"deploy\"."
+	details.observe(compatibility.ProcessingReport{Diagnostics: []compatibility.Diagnostic{
+		{Level: "error", Code: compiler.CodeWorkflowSyntax, Stage: string(compiler.StageWorkflowParsing), Message: message},
+	}})
+	if _, err := writer.Write([]byte(strings.Repeat("annotation and pipeline-upload chatter\n", 100))); err != nil {
+		t.Fatal(err)
+	}
+	got := details.forOutcome(telemetry.OutcomeFailure)
+	if got.ErrorMessage != message || got.ErrorMessageTruncated {
+		t.Fatalf("failure message = %q (truncated %t), want the attributing diagnostic message", got.ErrorMessage, got.ErrorMessageTruncated)
+	}
+	if got.FailureCode != telemetry.FailureCodeWorkflowSyntax {
+		t.Fatalf("failure code = %q", got.FailureCode)
+	}
+}
+
+func TestObservedFailureMessageIncludesDetail(t *testing.T) {
+	details := &commandTelemetryDetails{}
+	details.observe(compatibility.ProcessingReport{Diagnostics: []compatibility.Diagnostic{
+		{Level: "error", Code: compiler.CodeExpressionInvalid, Stage: string(compiler.StageExpressions), Message: "expression is unsupported", Detail: "github.workspace"},
+	}})
+	if got := details.forOutcome(telemetry.OutcomeFailure); got.ErrorMessage != "expression is unsupported github.workspace" {
+		t.Fatalf("failure message = %q, want message with detail", got.ErrorMessage)
+	}
+}
+
+func TestObservedFailureMessageKeepsItsHeadWithinTheTelemetryBound(t *testing.T) {
+	details := &commandTelemetryDetails{}
+	details.observe(compatibility.ProcessingReport{Diagnostics: []compatibility.Diagnostic{
+		{Level: "error", Code: compiler.CodeExpressionInvalid, Stage: string(compiler.StageExpressions),
+			Message: "expression is unsupported", Detail: strings.Repeat("界", telemetry.MaxErrorMessageBytes)},
+	}})
+	got := details.forOutcome(telemetry.OutcomeFailure)
+	if !got.ErrorMessageTruncated {
+		t.Fatal("over-long failure message was not marked truncated")
+	}
+	if len(got.ErrorMessage) > telemetry.MaxErrorMessageBytes {
+		t.Fatalf("failure message = %d bytes, want at most %d", len(got.ErrorMessage), telemetry.MaxErrorMessageBytes)
+	}
+	if !strings.HasPrefix(got.ErrorMessage, "expression is unsupported") {
+		t.Fatalf("failure message = %q, want the head naming the rejected feature", got.ErrorMessage[:64])
+	}
+	if !utf8.ValidString(got.ErrorMessage) {
+		t.Fatal("head-bounded failure message is not valid UTF-8")
 	}
 }
 

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -24,9 +24,13 @@ const (
 	defaultTimeout        = 1500 * time.Millisecond
 	responseDrainLimit    = 32 << 10
 	maxClientVersionBytes = 64
-	maxErrorMessageBytes  = 1024
 	maxDurationMS         = int64(1<<31 - 1)
 	maxDiagnostics        = 20
+
+	// MaxErrorMessageBytes bounds the error message sent on unsuccessful
+	// commands. Over-long messages keep their final bytes, where a failing
+	// command's last error output lands.
+	MaxErrorMessageBytes = 1024
 )
 
 type Command string
@@ -334,10 +338,10 @@ func boundedErrorMessage(message string) (string, bool) {
 		return character
 	}, strings.ToValidUTF8(message, "�"))
 	message = strings.Join(strings.Fields(message), " ")
-	if len(message) <= maxErrorMessageBytes {
+	if len(message) <= MaxErrorMessageBytes {
 		return message, false
 	}
-	start := len(message) - maxErrorMessageBytes
+	start := len(message) - MaxErrorMessageBytes
 	for !utf8.RuneStart(message[start]) {
 		start++
 	}

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -216,13 +216,13 @@ func TestPropertiesAreBounded(t *testing.T) {
 }
 
 func TestErrorMessageIsNormalizedAndUTF8Bounded(t *testing.T) {
-	message := "earlier output\n\t" + strings.Repeat("界", maxErrorMessageBytes) + "\n immediate failure"
+	message := "earlier output\n\t" + strings.Repeat("界", MaxErrorMessageBytes) + "\n immediate failure"
 	bounded, truncated := boundedErrorMessage(message)
 	if !truncated {
 		t.Fatal("boundedErrorMessage() did not report truncation")
 	}
-	if len(bounded) > maxErrorMessageBytes {
-		t.Fatalf("boundedErrorMessage() returned %d bytes, want at most %d", len(bounded), maxErrorMessageBytes)
+	if len(bounded) > MaxErrorMessageBytes {
+		t.Fatalf("boundedErrorMessage() returned %d bytes, want at most %d", len(bounded), MaxErrorMessageBytes)
 	}
 	if !utf8.ValidString(bounded) {
 		t.Fatalf("boundedErrorMessage() returned invalid UTF-8: %q", bounded)


### PR DESCRIPTION
## Why

When a workflow is rejected as incompatible, the failure telemetry event should carry the rejection message. Today it often does not. Sixteen compatibility failures in the last 30 days were unreadable.

The event's `error_message` is the final 1,024 bytes of the command's error output. The rejection line is printed early, and the annotation and pipeline-upload output that follows it fills the 1,024-byte window, so the message that names the rejected feature is pushed out before the event is sent:

```
# error_message today: the tail is agent output, the rejection is gone
…annotation and pipeline-upload output… buildkite-gha: upload: workflow can not be uploaded
```

This is not fixed by raising or removing the 1,024-byte limit. The backend applies the same bound when it logs the message, and a larger window still fills with whatever is printed last.

## What

When a workflow diagnostic already attributes the failure — the same rule that sets `failure_code` — send that diagnostic's message and detail as `error_message`, whole:

```
# error_message now
GitHub environments and environment secrets are unsupported. Remove the environment key from job "deploy". …
```

A message longer than 1,024 bytes keeps its start, which names the rejected feature, and sets `error_message_truncated`. Failures without an attributing diagnostic keep the current behavior: the final 1,024 bytes of error output.

Fixes [PB-3141](https://linear.app/buildkite/issue/PB-3141/fix-compatibility-error-message-truncation-in-buildkite-gha-logs).

`mise run check` passes. One pre-existing test failure in sandboxes with global git commit signing (`TestRunUploadAppliesPullRequestPathFiltersFromGitDiff`) reproduces on `main` and is unrelated; it passes with `GIT_CONFIG_GLOBAL=/dev/null`.
