### PR TITLE
Explain why a Buildkite secret may be unavailable

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -531,8 +531,8 @@ earlier output was omitted.
 Failed runs also carry a failure phase and a code from a fixed set. The code
 separates workflow-authored process exits (`E_STEP_PROCESS_EXIT`) from
 unsupported-feature rejections (`E_UNSUPPORTED_FEATURE`) and runtime integrity
-failures (`E_RUNTIME_INTEGRITY`), so a failing test suite is not counted as a
-compatibility gap.
+failures (`E_RUNTIME_INTEGRITY`). Secret resolution failures use
+`E_SECRET_UNAVAILABLE`, making secret availability independently measurable.
 
 Buildkite adds organization, pipeline, build, and job identifiers on the
 server. The client does not send workflow or event content, environment

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1344,7 +1344,8 @@ The compiler records names, not values, in the destination job plan. At
 runtime, the job calls `buildkite-agent secret get NAME` and registers the value
 with both redactors before use. Missing or denied secrets fail without printing
 the secret or Agent error. The job annotation explains how to create or migrate
-the secret and check its access policy.
+the secret, check its access policy, or retry a temporarily unavailable secret
+service.
 
 These are Buildkite destination-job secrets, not GitHub repository,
 environment, event, or fork-scoped secrets. Buildkite Secret access policies

--- a/internal/cli/run_job.go
+++ b/internal/cli/run_job.go
@@ -366,11 +366,11 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 // such as a test command exiting nonzero, are not counted as compatibility
 // gaps. Unattributed errors return "" and keep the unknown failure code.
 func runtimeFailureCode(err error) telemetry.FailureCode {
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return ""
-	}
 	var secretError *gharuntime.SecretResolutionError
 	if errors.As(err, &secretError) {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return ""
+		}
 		return telemetry.FailureCodeSecretUnavailable
 	}
 	switch gharuntime.ClassifyFailure(err) {

--- a/internal/cli/run_job.go
+++ b/internal/cli/run_job.go
@@ -366,6 +366,9 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 // such as a test command exiting nonzero, are not counted as compatibility
 // gaps. Unattributed errors return "" and keep the unknown failure code.
 func runtimeFailureCode(err error) telemetry.FailureCode {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return ""
+	}
 	var secretError *gharuntime.SecretResolutionError
 	if errors.As(err, &secretError) {
 		return telemetry.FailureCodeSecretUnavailable

--- a/internal/cli/run_job.go
+++ b/internal/cli/run_job.go
@@ -366,6 +366,10 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 // such as a test command exiting nonzero, are not counted as compatibility
 // gaps. Unattributed errors return "" and keep the unknown failure code.
 func runtimeFailureCode(err error) telemetry.FailureCode {
+	var secretError *gharuntime.SecretResolutionError
+	if errors.As(err, &secretError) {
+		return telemetry.FailureCodeSecretUnavailable
+	}
 	switch gharuntime.ClassifyFailure(err) {
 	case gharuntime.FailureClassStepProcessExit:
 		return telemetry.FailureCodeStepProcessExit
@@ -505,12 +509,13 @@ func publishSecretResolutionAnnotation(parent context.Context, agent transport.A
 	if !errors.As(runErr, &secretError) {
 		return nil
 	}
-	body := fmt.Sprintf(`#### Missing secret
+	body := fmt.Sprintf(`#### Secret unavailable
 
 This job could not retrieve the Buildkite secret %s.
 
 1. <a href="https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets" target="_blank">Create or migrate the secret into Buildkite</a>.
 1. If the secret already exists, <a href="https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets/access-policies" target="_blank">grant this job access with its access policy</a>.
+1. If the secret and its access policy are correct, retry the job. The Buildkite secret service may be temporarily unavailable.
 
 > ℹ️ GitHub does not expose an existing secret's value after creation. Copy or rotate the value manually. GitHub repository and environment secrets are not available directly to this job.
 `, annotationCode(secretError.Name))

--- a/internal/cli/run_job_test.go
+++ b/internal/cli/run_job_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -774,6 +775,15 @@ func TestRunJobValidateHostErrorsClassifyAsUnsupported(t *testing.T) {
 	}
 	if got := runtimeFailureCode(err); got != telemetry.FailureCodeUnsupportedFeature {
 		t.Fatalf("runtimeFailureCode() = %q, want %q for %v", got, telemetry.FailureCodeUnsupportedFeature, err)
+	}
+}
+
+func TestRunJobCancellationDoesNotClassifySecretUnavailable(t *testing.T) {
+	secretError := &gharuntime.SecretResolutionError{Name: "EXAMPLE_SECRET", Err: errors.New("request failed")}
+	for _, cancellation := range []error{context.Canceled, context.DeadlineExceeded} {
+		if got := runtimeFailureCode(errors.Join(secretError, cancellation)); got != "" {
+			t.Errorf("runtimeFailureCode(%v) = %q, want no failure code", cancellation, got)
+		}
 	}
 }
 

--- a/internal/cli/run_job_test.go
+++ b/internal/cli/run_job_test.go
@@ -418,13 +418,18 @@ func TestRunJobAnnotatesUnavailableBuildkiteSecretWithMigrationGuidance(t *testi
 	}
 	t.Setenv("BUILDKITE_GHA_AGENT", agentPath)
 	runner := &cliCaptureRunner{}
+	events := captureCommandTelemetry(t)
 	var stdout, stderr bytes.Buffer
 
 	if code := run([]string{"run-job", "--plan", planPath}, &stdout, &stderr, "dev", runner); code != 1 {
 		t.Fatalf("run() code = %d, stderr = %q, want 1", code, stderr.String())
 	}
-	if !strings.Contains(stderr.String(), `resolve secret "EXAMPLE_SECRET": buildkite Agent secret request failed`) {
+	if !strings.Contains(stderr.String(), `resolve secret "EXAMPLE_SECRET": secret is unavailable; it may not exist, this job may not have access, or the Buildkite secret service may be temporarily unavailable`) {
 		t.Fatalf("stderr = %q, want secret resolution failure", stderr.String())
+	}
+	event := <-events
+	if event.FailurePhase != telemetry.FailurePhaseExecution || event.FailureCode != telemetry.FailureCodeSecretUnavailable {
+		t.Fatalf("telemetry = %#v", event)
 	}
 	var annotations []cliCommand
 	for _, command := range runner.commands {
@@ -438,18 +443,16 @@ func TestRunJobAnnotatesUnavailableBuildkiteSecretWithMigrationGuidance(t *testi
 	}
 	body := string(annotations[0].stdin)
 	for _, want := range []string{
-		"#### Missing secret",
+		"#### Secret unavailable",
 		"Buildkite secret <code>EXAMPLE_SECRET</code>",
 		`<a href="https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets" target="_blank">Create or migrate the secret into Buildkite</a>`,
 		`<a href="https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets/access-policies" target="_blank">grant this job access with its access policy</a>`,
+		"retry the job. The Buildkite secret service may be temporarily unavailable",
 		"> ℹ️ GitHub does not expose an existing secret's value after creation",
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("annotation = %q, want %q", body, want)
 		}
-	}
-	if strings.Contains(body, "Retry the job") {
-		t.Errorf("annotation = %q, does not want retry guidance", body)
 	}
 	if last := runner.commands[len(runner.commands)-1]; len(last.args) == 0 || last.args[0] != "annotate" {
 		t.Fatalf("last command = %#v, want guidance annotation after authoritative publication", last)

--- a/internal/cli/run_job_test.go
+++ b/internal/cli/run_job_test.go
@@ -776,9 +776,12 @@ func TestRunJobValidateHostErrorsClassifyAsUnsupported(t *testing.T) {
 	if got := runtimeFailureCode(err); got != telemetry.FailureCodeUnsupportedFeature {
 		t.Fatalf("runtimeFailureCode() = %q, want %q for %v", got, telemetry.FailureCodeUnsupportedFeature, err)
 	}
+	if got := runtimeFailureCode(errors.Join(err, context.Canceled)); got != telemetry.FailureCodeUnsupportedFeature {
+		t.Fatalf("runtimeFailureCode() = %q, want %q when cancellation is joined with an unrelated failure", got, telemetry.FailureCodeUnsupportedFeature)
+	}
 }
 
-func TestRunJobCancellationDoesNotClassifySecretUnavailable(t *testing.T) {
+func TestRunJobCanceledSecretDoesNotClassifyUnavailable(t *testing.T) {
 	secretError := &gharuntime.SecretResolutionError{Name: "EXAMPLE_SECRET", Err: errors.New("request failed")}
 	for _, cancellation := range []error{context.Canceled, context.DeadlineExceeded} {
 		if got := runtimeFailureCode(errors.Join(secretError, cancellation)); got != "" {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1490,7 +1490,7 @@ func TestAgentSecretsDoesNotReturnCommandOutputOnFailure(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, err := (AgentSecrets{Executable: agent}).ResolveSecret(t.Context(), "DENIED")
-	if err == nil || strings.Contains(err.Error(), "stdout-secret") || strings.Contains(err.Error(), "stderr-secret") || !strings.Contains(err.Error(), "secret request failed") {
+	if err == nil || strings.Contains(err.Error(), "stdout-secret") || strings.Contains(err.Error(), "stderr-secret") || !strings.Contains(err.Error(), "secret is unavailable") {
 		t.Fatalf("ResolveSecret() error = %v", err)
 	}
 }

--- a/internal/runtime/secrets.go
+++ b/internal/runtime/secrets.go
@@ -120,7 +120,7 @@ func (r AgentSecrets) ResolveSecret(ctx context.Context, name string) (string, e
 	command.Stdout = &output
 	command.Stderr = io.Discard
 	if err := command.Run(); err != nil {
-		return "", errors.New("buildkite Agent secret request failed")
+		return "", errors.New("secret is unavailable; it may not exist, this job may not have access, or the Buildkite secret service may be temporarily unavailable")
 	}
 	if output.exceeded {
 		return "", fmt.Errorf("buildkite Agent secret response exceeds %d bytes", maxSecretBytes)

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -81,6 +81,7 @@ const (
 	FailureCodeStepProcessExit    FailureCode = "E_STEP_PROCESS_EXIT"
 	FailureCodeUnsupportedFeature FailureCode = "E_UNSUPPORTED_FEATURE"
 	FailureCodeRuntimeIntegrity   FailureCode = "E_RUNTIME_INTEGRITY"
+	FailureCodeSecretUnavailable  FailureCode = "E_SECRET_UNAVAILABLE"
 )
 
 type Severity string
@@ -257,7 +258,7 @@ func validFailureCode(code FailureCode) bool {
 		FailureCodeMatrixInvalid, FailureCodeExpressionInvalid, FailureCodeActionDiscovery,
 		FailureCodeActionResolution, FailureCodePlanConstruction, FailureCodePipelineGeneration,
 		FailureCodeEnvironment, FailureCodeProfile, FailureCodeStepProcessExit,
-		FailureCodeUnsupportedFeature, FailureCodeRuntimeIntegrity:
+		FailureCodeUnsupportedFeature, FailureCodeRuntimeIntegrity, FailureCodeSecretUnavailable:
 		return true
 	default:
 		return false

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -236,7 +236,7 @@ func TestErrorMessageIsNormalizedAndUTF8Bounded(t *testing.T) {
 }
 
 func TestRuntimeClassificationCodesAreFailureCodesOnly(t *testing.T) {
-	for _, code := range []FailureCode{FailureCodeStepProcessExit, FailureCodeUnsupportedFeature, FailureCodeRuntimeIntegrity} {
+	for _, code := range []FailureCode{FailureCodeStepProcessExit, FailureCodeUnsupportedFeature, FailureCodeRuntimeIntegrity, FailureCodeSecretUnavailable} {
 		if !validFailureCode(code) {
 			t.Errorf("validFailureCode(%q) = false", code)
 		}


### PR DESCRIPTION
## Why

A secret resolution failure currently looks like an internal Buildkite failure even when the secret is missing or its access policy denies the job:

```
buildkite-gha: run-job: resolve secret "CONVEX_DEPLOY_KEY": buildkite Agent secret request failed
```

The job annotation compounds the ambiguity by calling every Agent failure a “Missing secret”, while telemetry records it as `unknown`.

## What

Explain the safe possibilities without exposing the Agent's free-form error output:

```
buildkite-gha: run-job: resolve secret "CONVEX_DEPLOY_KEY": secret is unavailable; it may not exist, this job may not have access, or the Buildkite secret service may be temporarily unavailable
```

Rename the annotation to “Secret unavailable” and direct the reader to create or migrate the secret, check its access policy, or retry when configuration is correct. Report these failures as `E_SECRET_UNAVAILABLE` so they are independently measurable instead of grouped under unknown runtime failures.

The current Agent/API contract does not safely distinguish missing secrets from denied access or service failures. This PR does not parse or expose Agent stderr; finer attribution requires a stable, sanitized upstream error contract.

Related to [PB-3159](https://linear.app/buildkite/issue/PB-3159/say-whose-fault-it-is-when-secret-resolution-fails-at-job-runtime).
