### PR TITLE
Restore pipeline uploads with Buildkite Agent v4

### DIFF
--- a/.buildkite/container-runtime-proof.yml
+++ b/.buildkite/container-runtime-proof.yml
@@ -11,7 +11,7 @@ steps:
       commit="$${COMPATIBILITY_PROOF_COMMIT:-$${SMOKE_COMMIT:-}}"
       scripts/verify-source-checkout "$$commit"
       test -z "$$(git status --porcelain --untracked-files=all)"
-      buildkite-agent pipeline upload --no-interpolation --reject-secrets .buildkite/container-runtime-probe.yml
+      buildkite-agent pipeline upload --no-interpolation .buildkite/container-runtime-probe.yml
 
   - label: ":pipeline: Container runtime continuation loader"
     key: "container-runtime-continuation-loader"

--- a/.buildkite/examples.yml
+++ b/.buildkite/examples.yml
@@ -54,7 +54,7 @@ steps:
       test "$${BUILDKITE_COMMIT:?BUILDKITE_COMMIT is required}" = "$$commit"
       test -f "$$workflow"
 
-      cat <<YAML | buildkite-agent pipeline upload --no-interpolation --reject-secrets
+      cat <<YAML | buildkite-agent pipeline upload --no-interpolation
       agents:
         queue: "hosted"
 

--- a/.buildkite/hosted-docker-proof.yml
+++ b/.buildkite/hosted-docker-proof.yml
@@ -9,7 +9,7 @@ steps:
       commit="$${COMPATIBILITY_PROOF_COMMIT:-$${SMOKE_COMMIT:-}}"
       scripts/verify-source-checkout "$$commit"
       test -z "$$(git status --porcelain --untracked-files=all)"
-      buildkite-agent pipeline upload --no-interpolation --reject-secrets .buildkite/hosted-docker-probe.yml
+      buildkite-agent pipeline upload --no-interpolation .buildkite/hosted-docker-probe.yml
 
   - label: ":pipeline: Hosted Docker continuation loader"
     key: "hosted-docker-continuation-loader"

--- a/.buildkite/upload-examples.sh
+++ b/.buildkite/upload-examples.sh
@@ -11,7 +11,7 @@ repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
 upload_pipeline() {
-  buildkite-agent pipeline upload --no-interpolation --reject-secrets
+  buildkite-agent pipeline upload --no-interpolation
 }
 
 if (( $# == 1 )); then

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -458,8 +458,10 @@ for every Buildkite scheduled build.
 After all applicable workflows have been attempted, the command uploads the exact executable, content-addressed plans, and synthetic failure steps in one artifact batch with a concurrency limit of 8. It then runs one:
 
 ```sh
-buildkite-agent pipeline upload --no-interpolation --reject-secrets
+buildkite-agent pipeline upload --no-interpolation
 ```
+
+Buildkite Agent v4 rejects pipeline uploads containing secrets by default.
 
 ### Choose runners and runtimes
 

--- a/internal/cli/upload_test.go
+++ b/internal/cli/upload_test.go
@@ -130,7 +130,7 @@ func TestRunUploadCompilesArtifactsAndUploadsSelfContainedPipeline(t *testing.T)
 		t.Fatalf("temporary artifact root still exists: %v", err)
 	}
 	pipelineCommand := runner.commands[1]
-	wantPipelineArgs := []string{"pipeline", "upload", "--no-interpolation", "--reject-secrets"}
+	wantPipelineArgs := []string{"pipeline", "upload", "--no-interpolation"}
 	if strings.Join(pipelineCommand.args, " ") != strings.Join(wantPipelineArgs, " ") {
 		t.Fatalf("pipeline args = %#v, want %#v", pipelineCommand.args, wantPipelineArgs)
 	}
@@ -572,7 +572,7 @@ func TestRunUploadAggregatesExplicitPathsAtomicallyWithNamespacedJobs(t *testing
 		t.Fatalf("stdout/stderr/commands = %q / %q / %d", stdout.String(), stderr.String(), len(runner.commands))
 	}
 	pipelineCommand := runner.commands[len(runner.commands)-1]
-	if !slices.Equal(pipelineCommand.args, []string{"pipeline", "upload", "--no-interpolation", "--reject-secrets"}) {
+	if !slices.Equal(pipelineCommand.args, []string{"pipeline", "upload", "--no-interpolation"}) {
 		t.Fatalf("aggregate pipeline command = %#v", pipelineCommand)
 	}
 	var pipeline struct {
@@ -1465,7 +1465,7 @@ func TestRunUploadExplainsWhenNoWorkflowsApply(t *testing.T) {
 	var annotation *cliCommand
 	for i := range runner.commands {
 		command := &runner.commands[i]
-		if slices.Equal(command.args, []string{"pipeline", "upload", "--no-interpolation", "--reject-secrets"}) {
+		if slices.Equal(command.args, []string{"pipeline", "upload", "--no-interpolation"}) {
 			pipelineSource = command.stdin
 		}
 		if len(command.args) > 0 && command.args[0] == "annotate" {
@@ -2399,7 +2399,7 @@ func TestRunUploadStoresRuntimeEventOnceForExactImporterJob(t *testing.T) {
 	}
 	var pipeline []byte
 	for _, command := range runner.commands {
-		if slices.Equal(command.args, []string{"pipeline", "upload", "--no-interpolation", "--reject-secrets"}) {
+		if slices.Equal(command.args, []string{"pipeline", "upload", "--no-interpolation"}) {
 			pipeline = command.stdin
 		}
 	}

--- a/internal/transport/boundary.go
+++ b/internal/transport/boundary.go
@@ -168,7 +168,7 @@ func (a Agent) GetMetadataBounded(ctx context.Context, key string, limit int) ([
 }
 
 func (a Agent) UploadPipeline(ctx context.Context, pipeline []byte) error {
-	_, err := a.run(ctx, []string{"pipeline", "upload", "--no-interpolation", "--reject-secrets"}, pipeline)
+	_, err := a.run(ctx, []string{"pipeline", "upload", "--no-interpolation"}, pipeline)
 	return err
 }
 

--- a/internal/transport/model_test.go
+++ b/internal/transport/model_test.go
@@ -224,7 +224,7 @@ func (r *captureRunner) Run(ctx context.Context, dir, name string, args []string
 	return nil, nil
 }
 
-func TestAgentUsesExactProducerAndSafeUploadFlags(t *testing.T) {
+func TestAgentUsesExactProducerAndUploadFlags(t *testing.T) {
 	runner := &captureRunner{}
 	agent := Agent{Runner: runner}
 	if err := agent.DownloadArtifact(t.Context(), "result.json", ".", "gha-producer"); err != nil {
@@ -235,7 +235,7 @@ func TestAgentUsesExactProducerAndSafeUploadFlags(t *testing.T) {
 	}
 	want := []capturedCommand{
 		{name: "buildkite-agent", args: []string{"artifact", "download", "result.json", ".", "--step", "gha-producer"}},
-		{name: "buildkite-agent", args: []string{"pipeline", "upload", "--no-interpolation", "--reject-secrets"}, stdin: "steps: []\n"},
+		{name: "buildkite-agent", args: []string{"pipeline", "upload", "--no-interpolation"}, stdin: "steps: []\n"},
 	}
 	if !reflect.DeepEqual(runner.commands, want) {
 		t.Fatalf("commands = %#v, want %#v", runner.commands, want)
@@ -299,7 +299,7 @@ func TestUploadArtifactsMaterializesContentBeforePipeline(t *testing.T) {
 	}
 	want := []capturedCommand{
 		{dir: resolvedRoot, name: "buildkite-agent", args: []string{"artifact", "upload", ".buildkite-gha/**/*", "--concurrency", "8"}},
-		{name: "buildkite-agent", args: []string{"pipeline", "upload", "--no-interpolation", "--reject-secrets"}, stdin: "steps: []\n"},
+		{name: "buildkite-agent", args: []string{"pipeline", "upload", "--no-interpolation"}, stdin: "steps: []\n"},
 	}
 	if !reflect.DeepEqual(runner.commands, want) {
 		t.Fatalf("commands = %#v, want %#v", runner.commands, want)


### PR DESCRIPTION
## Why

Buildkite Agent v4 removed `pipeline upload --reject-secrets`, causing buildkite-gha uploads and hosted proof pipelines to fail with `flag provided but not defined: -reject-secrets`.

## What

Stop passing `--reject-secrets` when uploading pipelines. Agent v4 rejects pipeline secrets by default, so uploads retain the secure default without the removed flag.

Update the command expectations, direct CI uploads, examples, and CLI documentation. See buildkite/agent#3807.
