### PR TITLE
Require documentation for every Go package

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,14 @@ linters:
     - sloglint
     - thelper
     - contextcheck
+    - godoclint
   settings:
+    godoclint:
+      default: none
+      enable:
+        - pkg-doc
+        - single-pkg-doc
+        - require-pkg-doc
     usetesting:
       context-background: true
       context-todo: true

--- a/cmd/buildkite-gha/doc.go
+++ b/cmd/buildkite-gha/doc.go
@@ -1,0 +1,2 @@
+// Command buildkite-gha compiles and runs GitHub Actions workflows on Buildkite.
+package main

--- a/cmd/validate-public-workflow-corpus/doc.go
+++ b/cmd/validate-public-workflow-corpus/doc.go
@@ -1,0 +1,2 @@
+// Command validate-public-workflow-corpus validates the public workflow dataset.
+package main

--- a/cmd/validate-public-workflow-corpus/main.go
+++ b/cmd/validate-public-workflow-corpus/main.go
@@ -1,4 +1,3 @@
-// Command validate-public-workflow-corpus validates the public workflow dataset.
 package main
 
 import (

--- a/internal/action/integration/catalog.go
+++ b/internal/action/integration/catalog.go
@@ -1,5 +1,3 @@
-// Package integration classifies and admits actions with Buildkite-specific
-// execution or service requirements.
 package integration
 
 // Identity is the canonical, resolved portion of an action lock used for

--- a/internal/action/integration/cmd/generate-checkout-profiles/doc.go
+++ b/internal/action/integration/cmd/generate-checkout-profiles/doc.go
@@ -1,0 +1,2 @@
+// Command generate-checkout-profiles snapshots actions/checkout manifests as Go source.
+package main

--- a/internal/action/integration/doc.go
+++ b/internal/action/integration/doc.go
@@ -1,0 +1,2 @@
+// Package integration catalogs actions with Buildkite-specific execution or service requirements.
+package integration

--- a/internal/action/integration/doc.go
+++ b/internal/action/integration/doc.go
@@ -1,2 +1,3 @@
-// Package integration catalogs actions with Buildkite-specific execution or service requirements.
+// Package integration recognizes supported commits of well-known GitHub Actions
+// and records when to use Buildkite's checkout, artifact, or cache handling.
 package integration

--- a/internal/action/metadata/doc.go
+++ b/internal/action/metadata/doc.go
@@ -1,0 +1,2 @@
+// Package metadata loads and validates the supported GitHub Action metadata model.
+package metadata

--- a/internal/action/metadata/metadata.go
+++ b/internal/action/metadata/metadata.go
@@ -1,4 +1,3 @@
-// Package metadata owns the supported local GitHub Action metadata model.
 package metadata
 
 import (

--- a/internal/action/source/doc.go
+++ b/internal/action/source/doc.go
@@ -1,0 +1,2 @@
+// Package source resolves, verifies, and caches public GitHub Action source trees.
+package source

--- a/internal/action/source/source.go
+++ b/internal/action/source/source.go
@@ -1,4 +1,3 @@
-// Package source fetches immutable, public GitHub Action source archives.
 package source
 
 import (

--- a/internal/buildkite/doc.go
+++ b/internal/buildkite/doc.go
@@ -1,0 +1,2 @@
+// Package buildkite translates workflow jobs and triggers into Buildkite pipeline YAML.
+package buildkite

--- a/internal/buildkite/pipeline.go
+++ b/internal/buildkite/pipeline.go
@@ -1,5 +1,3 @@
-// Package buildkite emits deterministic Buildkite pipeline YAML from validated,
-// integration-neutral job descriptions.
 package buildkite
 
 import (

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,4 +1,3 @@
-// Package cli implements the buildkite-gha command-line interface.
 package cli
 
 import (

--- a/internal/cli/doc.go
+++ b/internal/cli/doc.go
@@ -1,0 +1,2 @@
+// Package cli implements the buildkite-gha command-line interface.
+package cli

--- a/internal/compatibility/doc.go
+++ b/internal/compatibility/doc.go
@@ -1,0 +1,2 @@
+// Package compatibility renders human-readable and machine-readable workflow processing reports.
+package compatibility

--- a/internal/compatibility/report.go
+++ b/internal/compatibility/report.go
@@ -1,4 +1,3 @@
-// Package compatibility renders stable human and machine-readable validation reports.
 package compatibility
 
 import (

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -1,4 +1,3 @@
-// Package compiler expands an owned workflow into deterministic workflow JSON IR.
 package compiler
 
 import (

--- a/internal/compiler/doc.go
+++ b/internal/compiler/doc.go
@@ -1,0 +1,2 @@
+// Package compiler validates and expands workflows into deterministic Buildkite pipeline bundles.
+package compiler

--- a/internal/compiler/doc.go
+++ b/internal/compiler/doc.go
@@ -1,2 +1,4 @@
-// Package compiler validates and expands workflows into deterministic Buildkite pipeline bundles.
+// Package compiler reads a GitHub Actions workflow and event, expands reusable
+// workflows and matrices, resolves action source, and produces one job plan per
+// job plus the Buildkite pipeline that runs them.
 package compiler

--- a/internal/expression/action_input_default.go
+++ b/internal/expression/action_input_default.go
@@ -1,6 +1,7 @@
 // Action input default validation and evaluation with GitHub's loose
 // coercion semantics. Deliberately separate from the strict condition
 // family in condition.go.
+
 package expression
 
 import (

--- a/internal/expression/compile.go
+++ b/internal/expression/compile.go
@@ -1,5 +1,6 @@
 // Compile-time expression evaluation: graph-construction substitution and
 // evaluation against the snapshotted CompileContext.
+
 package expression
 
 import (

--- a/internal/expression/condition.go
+++ b/internal/expression/condition.go
@@ -1,5 +1,6 @@
 // Condition validation and strict runtime condition evaluation. The
 // condition* value helpers reject mixed-type comparisons.
+
 package expression
 
 import (

--- a/internal/expression/doc.go
+++ b/internal/expression/doc.go
@@ -1,0 +1,2 @@
+// Package expression parses, analyzes, and evaluates GitHub Actions expressions.
+package expression

--- a/internal/expression/expression.go
+++ b/internal/expression/expression.go
@@ -1,4 +1,3 @@
-// Package expression adapts actionlint's expression parser into owned values.
 package expression
 
 import (

--- a/internal/expression/references.go
+++ b/internal/expression/references.go
@@ -1,6 +1,7 @@
 // Static reference introspection over templates, complete expressions, and
 // conditions. Each predicate deliberately answers one narrow question with
 // an error for unsupported input.
+
 package expression
 
 import (

--- a/internal/expression/runtime.go
+++ b/internal/expression/runtime.go
@@ -1,4 +1,5 @@
 // Direct runtime template evaluation and runtime reference resolution.
+
 package expression
 
 import (

--- a/internal/plan/doc.go
+++ b/internal/plan/doc.go
@@ -1,0 +1,2 @@
+// Package plan defines the integrity-bound job contract between compilation and execution.
+package plan

--- a/internal/plan/doc.go
+++ b/internal/plan/doc.go
@@ -1,3 +1,5 @@
-// Package plan defines the JSON document that the compiler creates and the
-// runtime verifies before running one workflow job.
+// Package plan defines Job, the serialized handoff from compiler to runtime. A
+// Job contains a program.Program plus the workflow and event identity,
+// dependencies, permissions, action locks, and runtime version needed to
+// validate and run it.
 package plan

--- a/internal/plan/doc.go
+++ b/internal/plan/doc.go
@@ -1,2 +1,3 @@
-// Package plan defines the integrity-bound job contract between compilation and execution.
+// Package plan defines the JSON document that the compiler creates and the
+// runtime verifies before running one workflow job.
 package plan

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -1,4 +1,3 @@
-// Package plan owns the job-plan boundary between compilation and execution.
 package plan
 
 import (

--- a/internal/program/doc.go
+++ b/internal/program/doc.go
@@ -1,2 +1,4 @@
-// Package program defines normalized workflow execution and expression authority semantics.
+// Package program describes one executable workflow job: its steps, containers,
+// services, expressions, and the resolved actions invoked by its steps. The
+// compiler stores this description in a job plan for the runtime to execute.
 package program

--- a/internal/program/doc.go
+++ b/internal/program/doc.go
@@ -1,0 +1,2 @@
+// Package program defines normalized workflow execution and expression authority semantics.
+package program

--- a/internal/program/doc.go
+++ b/internal/program/doc.go
@@ -1,4 +1,3 @@
-// Package program describes one executable workflow job: its steps, containers,
-// services, expressions, and the resolved actions invoked by its steps. The
-// compiler stores this description in a job plan for the runtime to execute.
+// Package program defines Program, the executable instructions for one workflow
+// job: its steps, containers, services, expressions, and resolved actions.
 package program

--- a/internal/program/program.go
+++ b/internal/program/program.go
@@ -1,5 +1,3 @@
-// Package program defines the normalized workflow execution model shared by
-// compilation, authority planning, and runtime.
 package program
 
 import (

--- a/internal/runtime/doc.go
+++ b/internal/runtime/doc.go
@@ -1,0 +1,2 @@
+// Package runtime executes compiled GitHub Actions jobs on Buildkite agents.
+package runtime

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1,4 +1,3 @@
-// Package runtime executes explicitly resolved GitHub Actions action steps.
 package runtime
 
 import (

--- a/internal/shell/doc.go
+++ b/internal/shell/doc.go
@@ -1,0 +1,2 @@
+// Package shell parses shell templates and classifies runtime compatibility.
+package shell

--- a/internal/shell/template.go
+++ b/internal/shell/template.go
@@ -1,4 +1,3 @@
-// Package shell owns shell-template parsing and compatibility classification.
 package shell
 
 import (

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -1,4 +1,3 @@
-// Package telemetry emits bounded, best-effort buildkite-gha product events.
 package telemetry
 
 import (

--- a/internal/telemetry/doc.go
+++ b/internal/telemetry/doc.go
@@ -1,2 +1,2 @@
-// Package telemetry emits bounded, best-effort product events without workflow content.
+// Package telemetry emits bounded, best-effort product events.
 package telemetry

--- a/internal/telemetry/doc.go
+++ b/internal/telemetry/doc.go
@@ -1,0 +1,2 @@
+// Package telemetry emits bounded, best-effort product events without workflow content.
+package telemetry

--- a/internal/transport/doc.go
+++ b/internal/transport/doc.go
@@ -1,0 +1,2 @@
+// Package transport defines Buildkite artifact, result, and dynamic-pipeline contracts.
+package transport

--- a/internal/transport/model.go
+++ b/internal/transport/model.go
@@ -1,6 +1,3 @@
-// Package transport owns the Buildkite artifact and dynamic-pipeline
-// contracts. It deliberately depends on a narrow command boundary instead of
-// the Buildkite API so its behavior can be proved without a live build.
 package transport
 
 import (

--- a/internal/useragent/doc.go
+++ b/internal/useragent/doc.go
@@ -1,0 +1,2 @@
+// Package useragent produces validated buildkite-gha HTTP User-Agent tokens.
+package useragent

--- a/internal/useragent/useragent.go
+++ b/internal/useragent/useragent.go
@@ -1,4 +1,3 @@
-// Package useragent identifies buildkite-gha HTTP requests.
 package useragent
 
 const (

--- a/internal/workflow/doc.go
+++ b/internal/workflow/doc.go
@@ -1,0 +1,2 @@
+// Package workflow parses and owns the supported GitHub Actions workflow model.
+package workflow

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -1,4 +1,3 @@
-// Package workflow owns the parsed workflow model used by the compiler.
 package workflow
 
 import "github.com/buildkite/buildkite-gha/internal/expression"

--- a/internal/workflowprocessing/doc.go
+++ b/internal/workflowprocessing/doc.go
@@ -1,0 +1,2 @@
+// Package workflowprocessing defines workflow-processing stages and diagnostic codes.
+package workflowprocessing

--- a/internal/workflowprocessing/stages.go
+++ b/internal/workflowprocessing/stages.go
@@ -1,5 +1,3 @@
-// Package workflowprocessing defines the stable workflow-processing contract shared by
-// compilation, compatibility reporting, and command telemetry.
 package workflowprocessing
 
 // Stage identifies one stable workflow-processing boundary.


### PR DESCRIPTION
## Why

Package documentation was scattered across implementation files, and linting did not prevent new packages from being undocumented. This maintainability change is part of PB-3178.

## What

- Give all 20 current Go packages focused documentation in `doc.go`, including command packages, the code-generation command, and the `workflowprocessing` package introduced by #421.
- Enable `godoclint` with only `pkg-doc`, `single-pkg-doc`, and `require-pkg-doc`, enforcing one valid package comment without imposing exported-symbol documentation rules.
- Keep the repository's generated-file exclusions. The package rules skip test files by default and exempt `main` from the `Package main` wording requirement; command packages use Go's `Command name` form instead.

Verified with `mise run check`, covering formatting, Linux and macOS builds, tests and race tests, Go and shell lint, vet, vulnerability scanning, local smoke checks, and release configuration.