### PR TITLE
Keep Agent API clients consistent

### DIFF
--- a/internal/agentapi/client.go
+++ b/internal/agentapi/client.go
@@ -1,0 +1,128 @@
+// Package agentapi provides the authenticated HTTP boundary to the
+// job-scoped Buildkite Agent API.
+package agentapi
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/buildkite/buildkite-gha/internal/useragent"
+)
+
+// Config carries the current job's Agent API connection and authentication
+// material.
+type Config struct {
+	Endpoint      string
+	JobID         string
+	JobToken      string
+	ClientVersion string
+	HTTPClient    *http.Client
+}
+
+// Client sends authenticated requests to one job-scoped Agent API.
+type Client struct {
+	jobURL    *url.URL
+	jobToken  string
+	userAgent string
+	client    *http.Client
+}
+
+// New constructs a job-scoped client. The service name identifies the calling
+// integration in configuration errors.
+func New(config Config, service string) (*Client, error) {
+	if !ValidJobID(config.JobID) {
+		return nil, fmt.Errorf("%s Agent job ID is required", service)
+	}
+	jobURL, err := url.Parse(config.Endpoint)
+	if err != nil || !validEndpoint(jobURL) {
+		return nil, fmt.Errorf("safe %s Agent endpoint using HTTPS or loopback HTTP is required", service)
+	}
+	if config.JobToken == "" || strings.ContainsAny(config.JobToken, "\r\n") {
+		return nil, fmt.Errorf("%s Agent job token is required", service)
+	}
+	jobURL.Path = strings.TrimRight(jobURL.Path, "/") + "/jobs/" + config.JobID
+	jobURL.RawPath = ""
+
+	client := config.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 15 * time.Second}
+	}
+	bounded := *client
+	bounded.Jar = nil
+	bounded.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	if bounded.Timeout == 0 {
+		bounded.Timeout = 15 * time.Second
+	}
+	return &Client{
+		jobURL: jobURL, jobToken: config.JobToken,
+		userAgent: useragent.FromVersion(config.ClientVersion), client: &bounded,
+	}, nil
+}
+
+// URL returns an endpoint below this client's job-scoped Agent API root.
+func (c *Client) URL(path string) string {
+	endpoint := *c.jobURL
+	endpoint.Path = strings.TrimRight(endpoint.Path, "/") + "/" + strings.TrimLeft(path, "/")
+	return endpoint.String()
+}
+
+// Do adds the Agent API authentication and standard request headers before
+// sending request with the bounded HTTP client.
+func (c *Client) Do(request *http.Request) (*http.Response, error) {
+	if !c.owns(request) {
+		return nil, fmt.Errorf("agent API request is outside the configured job endpoint")
+	}
+	request.Header.Set("Authorization", "Token "+c.jobToken)
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("User-Agent", c.userAgent)
+	return c.client.Do(request)
+}
+
+func (c *Client) owns(request *http.Request) bool {
+	if c == nil || request == nil || request.URL == nil || request.URL.Opaque != "" || request.URL.User != nil ||
+		request.URL.Scheme != c.jobURL.Scheme || request.URL.Host != c.jobURL.Host ||
+		request.Host != "" && request.Host != c.jobURL.Host {
+		return false
+	}
+	jobPath := strings.TrimRight(path.Clean(c.jobURL.Path), "/")
+	requestPath := path.Clean(request.URL.Path)
+	return requestPath == jobPath || strings.HasPrefix(requestPath, jobPath+"/")
+}
+
+func validEndpoint(u *url.URL) bool {
+	if u == nil || u.Host == "" || u.Hostname() == "" || u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+		return false
+	}
+	if u.Scheme == "https" {
+		return true
+	}
+	if u.Scheme != "http" {
+		return false
+	}
+	ip := net.ParseIP(u.Hostname())
+	return ip != nil && ip.IsLoopback()
+}
+
+// ValidJobID reports whether value is a canonical lowercase Buildkite job UUID.
+func ValidJobID(value string) bool {
+	if len(value) != 36 {
+		return false
+	}
+	for index, character := range []byte(value) {
+		if index == 8 || index == 13 || index == 18 || index == 23 {
+			if character != '-' {
+				return false
+			}
+			continue
+		}
+		if character < '0' || character > '9' && character < 'a' || character > 'f' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/agentapi/client_test.go
+++ b/internal/agentapi/client_test.go
@@ -1,0 +1,108 @@
+package agentapi
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const testJobID = "11111111-2222-3333-8444-555555555555"
+
+func TestClientBuildsAuthenticatedJobRequests(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/v3/jobs/"+testJobID+"/service/path" {
+			t.Errorf("request path = %q", request.URL.Path)
+		}
+		if request.Header.Get("Authorization") != "Token job-token" || request.Header.Get("Accept") != "application/json" || request.Header.Get("User-Agent") != "buildkite-gha/1.2.3" {
+			t.Errorf("request headers = %#v", request.Header)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := New(Config{Endpoint: server.URL + "/v3", JobID: testJobID, JobToken: "job-token", ClientVersion: "1.2.3", HTTPClient: server.Client()}, "test")
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodPost, client.URL("service/path"), http.NoBody)
+	if err != nil {
+		t.Fatalf("NewRequestWithContext() error = %v", err)
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		t.Fatalf("do() error = %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusNoContent {
+		t.Fatalf("response status = %d", response.StatusCode)
+	}
+}
+
+func TestClientRejectsUnsafeConnectionConfiguration(t *testing.T) {
+	validEndpoint := "https://agent.example/v3"
+	tests := map[string]struct {
+		endpoint string
+		jobID    string
+		token    string
+	}{
+		"missing endpoint":     {jobID: testJobID, token: "job-token"},
+		"endpoint credentials": {endpoint: "https://user@agent.example/v3", jobID: testJobID, token: "job-token"},
+		"endpoint query":       {endpoint: validEndpoint + "?redirect=other", jobID: testJobID, token: "job-token"},
+		"plaintext hostname":   {endpoint: "http://localhost/v3", jobID: testJobID, token: "job-token"},
+		"invalid job ID":       {endpoint: validEndpoint, jobID: "../other", token: "job-token"},
+		"missing token":        {endpoint: validEndpoint, jobID: testJobID},
+		"token header split":   {endpoint: validEndpoint, jobID: testJobID, token: "secret\r\nOther: value"},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := New(Config{Endpoint: test.endpoint, JobID: test.jobID, JobToken: test.token}, "test"); err == nil {
+				t.Fatal("New() accepted unsafe configuration")
+			}
+		})
+	}
+}
+
+func TestClientDoesNotAuthenticateRequestsOutsideJobEndpoint(t *testing.T) {
+	received := make(chan *http.Request, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, request *http.Request) {
+		received <- request
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := New(Config{Endpoint: server.URL + "/v3", JobID: testJobID, JobToken: "job-secret", HTTPClient: server.Client()}, "test")
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	other := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, request *http.Request) {
+		received <- request
+	}))
+	t.Cleanup(other.Close)
+
+	tests := map[string]string{
+		"different origin": other.URL + "/v3/jobs/" + testJobID + "/service",
+		"different job":    server.URL + "/v3/jobs/00000000-0000-4000-8000-000000000000/service",
+		"parent path":      server.URL + "/v3/service",
+		"path traversal":   client.URL("../other-job/service"),
+	}
+	for name, target := range tests {
+		t.Run(name, func(t *testing.T) {
+			request, err := http.NewRequestWithContext(t.Context(), http.MethodPost, target, http.NoBody)
+			if err != nil {
+				t.Fatalf("NewRequestWithContext() error = %v", err)
+			}
+			response, err := client.Do(request)
+			if response != nil {
+				_ = response.Body.Close()
+			}
+			if err == nil || !strings.Contains(err.Error(), "outside the configured job endpoint") {
+				t.Fatalf("Do() error = %v", err)
+			}
+			select {
+			case request := <-received:
+				t.Fatalf("outside request reached server with authorization %q", request.Header.Get("Authorization"))
+			default:
+			}
+		})
+	}
+}

--- a/internal/runtime/cache_service.go
+++ b/internal/runtime/cache_service.go
@@ -11,9 +11,8 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
-	"time"
 
-	"github.com/buildkite/buildkite-gha/internal/useragent"
+	"github.com/buildkite/buildkite-gha/internal/agentapi"
 )
 
 const (
@@ -59,19 +58,17 @@ type AgentCacheConfig struct {
 // API endpoint.
 type AgentCacheCredentials struct {
 	mintURL    string
-	jobToken   string
 	resultsURL string
-	userAgent  string
-	client     *http.Client
+	agent      *agentapi.Client
 }
 
 func NewAgentCacheCredentials(config AgentCacheConfig) (*AgentCacheCredentials, error) {
-	mintURL, err := agentCacheMintURL(config.Endpoint, config.JobID)
+	agent, err := agentapi.New(agentapi.Config{
+		Endpoint: config.Endpoint, JobID: config.JobID, JobToken: config.JobToken,
+		ClientVersion: config.ClientVersion, HTTPClient: config.Client,
+	}, "cache")
 	if err != nil {
 		return nil, err
-	}
-	if config.JobToken == "" || strings.ContainsAny(config.JobToken, "\r\n") {
-		return nil, fmt.Errorf("cache Agent job token is required")
 	}
 	if config.ResultsURL == "" {
 		config.ResultsURL = defaultCacheResultsURL
@@ -80,19 +77,8 @@ func NewAgentCacheCredentials(config AgentCacheConfig) (*AgentCacheCredentials, 
 	if err != nil {
 		return nil, err
 	}
-	client := config.Client
-	if client == nil {
-		client = &http.Client{Timeout: 15 * time.Second}
-	}
-	bounded := *client
-	bounded.Jar = nil
-	bounded.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
-	if bounded.Timeout == 0 {
-		bounded.Timeout = 15 * time.Second
-	}
 	return &AgentCacheCredentials{
-		mintURL: mintURL, jobToken: config.JobToken, resultsURL: resultsURL,
-		userAgent: useragent.FromVersion(config.ClientVersion), client: &bounded,
+		mintURL: agent.URL("ghac_tokens"), resultsURL: resultsURL, agent: agent,
 	}, nil
 }
 
@@ -104,10 +90,7 @@ func (c *AgentCacheCredentials) Credentials(ctx context.Context) (CacheCredentia
 	if err != nil {
 		return CacheCredentials{}, fmt.Errorf("create cache credential request: %w", err)
 	}
-	request.Header.Set("Authorization", "Token "+c.jobToken)
-	request.Header.Set("Accept", "application/json")
-	request.Header.Set("User-Agent", c.userAgent)
-	response, err := c.client.Do(request)
+	response, err := c.agent.Do(request)
 	if err != nil {
 		return CacheCredentials{}, fmt.Errorf("request cache credential: %w", err)
 	}
@@ -140,19 +123,6 @@ func (c *AgentCacheCredentials) Credentials(ctx context.Context) (CacheCredentia
 	return CacheCredentials{ResultsURL: c.resultsURL, Token: body.Token}, nil
 }
 
-func agentCacheMintURL(endpoint, jobID string) (string, error) {
-	if !validBuildkiteJobID(jobID) {
-		return "", fmt.Errorf("cache Agent job ID is required")
-	}
-	u, err := url.Parse(endpoint)
-	if err != nil || !validCredentialServiceURL(u) {
-		return "", fmt.Errorf("safe cache Agent endpoint using HTTPS or loopback HTTP is required")
-	}
-	u.Path = strings.TrimRight(u.Path, "/") + "/jobs/" + jobID + "/ghac_tokens"
-	u.RawPath = ""
-	return u.String(), nil
-}
-
 func normalizeCacheResultsURL(value string) (string, error) {
 	u, err := url.Parse(value)
 	if err != nil || !validCredentialServiceURL(u) || u.Path != "" && u.Path != "/" {
@@ -175,24 +145,6 @@ func validCredentialServiceURL(u *url.URL) bool {
 	}
 	ip := net.ParseIP(u.Hostname())
 	return ip != nil && ip.IsLoopback()
-}
-
-func validBuildkiteJobID(value string) bool {
-	if len(value) != 36 {
-		return false
-	}
-	for index, character := range []byte(value) {
-		if index == 8 || index == 13 || index == 18 || index == 23 {
-			if character != '-' {
-				return false
-			}
-			continue
-		}
-		if character < '0' || character > '9' && character < 'a' || character > 'f' {
-			return false
-		}
-	}
-	return true
 }
 
 func cacheCredentialStatusError(status int) error {

--- a/internal/runtime/checkout.go
+++ b/internal/runtime/checkout.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	actionintegration "github.com/buildkite/buildkite-gha/internal/action/integration"
+	"github.com/buildkite/buildkite-gha/internal/agentapi"
 	"github.com/buildkite/buildkite-gha/internal/plan"
 	"github.com/buildkite/buildkite-gha/internal/program"
 )
@@ -37,7 +38,7 @@ func resolveAgentRepositoryCredentialsBeforeWorkflow(credentials *AgentRepositor
 	if credentials == nil {
 		return nil, nil
 	}
-	if !validBuildkiteJobID(credentials.JobID) {
+	if !agentapi.ValidJobID(credentials.JobID) {
 		return nil, fmt.Errorf("repository-provider credentials require the current Buildkite job ID")
 	}
 	if credentials.JobToken == "" || strings.ContainsAny(credentials.JobToken, "\r\n") {

--- a/internal/runtime/github_token_service.go
+++ b/internal/runtime/github_token_service.go
@@ -8,13 +8,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"regexp"
 	"strings"
-	"time"
 
+	"github.com/buildkite/buildkite-gha/internal/agentapi"
 	"github.com/buildkite/buildkite-gha/internal/plan"
-	"github.com/buildkite/buildkite-gha/internal/useragent"
 )
 
 const githubTokenResponseLimit = 64 << 10
@@ -54,40 +52,22 @@ type AgentGitHubTokens struct {
 	actionSourceURL    string
 	workflowURL        string
 	repositorySettings string
-	jobToken           string
-	userAgent          string
-	client             *http.Client
+	agent              *agentapi.Client
 }
 
 func NewAgentGitHubTokens(config AgentGitHubTokenConfig) (*AgentGitHubTokens, error) {
-	actionSourceURL, err := agentGitHubTokenURL(config.Endpoint, config.JobID, "github_action_source_access_token")
+	agent, err := agentapi.New(agentapi.Config{
+		Endpoint: config.Endpoint, JobID: config.JobID, JobToken: config.JobToken,
+		ClientVersion: config.ClientVersion, HTTPClient: config.Client,
+	}, "GitHub token")
 	if err != nil {
 		return nil, err
-	}
-	workflowURL, err := agentGitHubTokenURL(config.Endpoint, config.JobID, "github_workflow_access_token")
-	if err != nil {
-		return nil, err
-	}
-	if config.JobToken == "" || strings.ContainsAny(config.JobToken, "\r\n") {
-		return nil, fmt.Errorf("GitHub token Agent job token is required")
-	}
-	client := config.Client
-	if client == nil {
-		client = &http.Client{Timeout: 15 * time.Second}
-	}
-	bounded := *client
-	bounded.Jar = nil
-	bounded.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
-	if bounded.Timeout == 0 {
-		bounded.Timeout = 15 * time.Second
 	}
 	return &AgentGitHubTokens{
-		actionSourceURL:    actionSourceURL,
-		workflowURL:        workflowURL,
+		actionSourceURL:    agent.URL("github_action_source_access_token"),
+		workflowURL:        agent.URL("github_workflow_access_token"),
 		repositorySettings: pipelineRepositorySettingsURL(config.OrganizationSlug, config.PipelineSlug),
-		jobToken:           config.JobToken,
-		userAgent:          useragent.FromVersion(config.ClientVersion),
-		client:             &bounded,
+		agent:              agent,
 	}, nil
 }
 
@@ -134,11 +114,8 @@ func (c *AgentGitHubTokens) mint(ctx context.Context, mintURL, repository, workf
 	if err != nil {
 		return "", fmt.Errorf("create GitHub %s token request: %w", purpose, err)
 	}
-	request.Header.Set("Authorization", "Token "+c.jobToken)
-	request.Header.Set("Accept", "application/json")
 	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("User-Agent", c.userAgent)
-	response, err := c.client.Do(request)
+	response, err := c.agent.Do(request)
 	if err != nil {
 		return "", fmt.Errorf("request GitHub %s token: %w", purpose, err)
 	}
@@ -169,19 +146,6 @@ func (c *AgentGitHubTokens) mint(ctx context.Context, mintURL, repository, workf
 		return "", fmt.Errorf("GitHub %s token response contains an invalid token", purpose)
 	}
 	return decoded.Token, nil
-}
-
-func agentGitHubTokenURL(endpoint, jobID, endpointName string) (string, error) {
-	if !validBuildkiteJobID(jobID) {
-		return "", fmt.Errorf("GitHub token Agent job ID is required")
-	}
-	u, err := url.Parse(endpoint)
-	if err != nil || !validCredentialServiceURL(u) {
-		return "", fmt.Errorf("safe GitHub token Agent endpoint using HTTPS or loopback HTTP is required")
-	}
-	u.Path = strings.TrimRight(u.Path, "/") + "/jobs/" + jobID + "/" + endpointName
-	u.RawPath = ""
-	return u.String(), nil
 }
 
 func pipelineRepositorySettingsURL(organization, pipeline string) string {

--- a/internal/runtime/oidc_token_service.go
+++ b/internal/runtime/oidc_token_service.go
@@ -13,14 +13,13 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"net/url"
 	"regexp"
 	"strings"
 	"sync"
 	"time"
 	"unicode/utf8"
 
-	"github.com/buildkite/buildkite-gha/internal/useragent"
+	"github.com/buildkite/buildkite-gha/internal/agentapi"
 )
 
 const oidcTokenResponseLimit = 64 << 10
@@ -46,41 +45,27 @@ type AgentOIDCTokenConfig struct {
 
 // AgentOIDCTokens mints job-bound Buildkite OIDC tokens through the Agent API.
 type AgentOIDCTokens struct {
-	mintURL   string
-	jobToken  string
-	claims    []string
-	awsTags   []string
-	subject   string
-	userAgent string
-	client    *http.Client
+	mintURL string
+	claims  []string
+	awsTags []string
+	subject string
+	agent   *agentapi.Client
 }
 
 func NewAgentOIDCTokens(config AgentOIDCTokenConfig) (*AgentOIDCTokens, error) {
-	mintURL, err := agentOIDCTokenURL(config.Endpoint, config.JobID)
+	agent, err := agentapi.New(agentapi.Config{
+		Endpoint: config.Endpoint, JobID: config.JobID, JobToken: config.JobToken,
+		ClientVersion: config.ClientVersion, HTTPClient: config.Client,
+	}, "OIDC token")
 	if err != nil {
 		return nil, err
 	}
-	if config.JobToken == "" || strings.ContainsAny(config.JobToken, "\r\n") {
-		return nil, fmt.Errorf("OIDC token Agent job token is required")
-	}
-	client := config.Client
-	if client == nil {
-		client = &http.Client{Timeout: 15 * time.Second}
-	}
-	bounded := *client
-	bounded.Jar = nil
-	bounded.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
-	if bounded.Timeout == 0 {
-		bounded.Timeout = 15 * time.Second
-	}
 	return &AgentOIDCTokens{
-		mintURL:   mintURL,
-		jobToken:  config.JobToken,
-		claims:    append([]string(nil), config.Claims...),
-		awsTags:   append([]string(nil), config.AWSSessionTags...),
-		subject:   config.SubjectClaim,
-		userAgent: useragent.FromVersion(config.ClientVersion),
-		client:    &bounded,
+		mintURL: agent.URL("oidc/tokens"),
+		claims:  append([]string(nil), config.Claims...),
+		awsTags: append([]string(nil), config.AWSSessionTags...),
+		subject: config.SubjectClaim,
+		agent:   agent,
 	}, nil
 }
 
@@ -104,11 +89,8 @@ func (c *AgentOIDCTokens) OIDCToken(ctx context.Context, audience string) (strin
 	if err != nil {
 		return "", fmt.Errorf("create OIDC token request: %w", err)
 	}
-	request.Header.Set("Authorization", "Token "+c.jobToken)
-	request.Header.Set("Accept", "application/json")
 	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("User-Agent", c.userAgent)
-	response, err := c.client.Do(request)
+	response, err := c.agent.Do(request)
 	if err != nil {
 		return "", fmt.Errorf("request OIDC token: %w", err)
 	}
@@ -139,19 +121,6 @@ func (c *AgentOIDCTokens) OIDCToken(ctx context.Context, audience string) (strin
 		return "", fmt.Errorf("OIDC token response contains an invalid token")
 	}
 	return decoded.Token, nil
-}
-
-func agentOIDCTokenURL(endpoint, jobID string) (string, error) {
-	if !validBuildkiteJobID(jobID) {
-		return "", fmt.Errorf("OIDC token Agent job ID is required")
-	}
-	u, err := url.Parse(endpoint)
-	if err != nil || !validCredentialServiceURL(u) {
-		return "", fmt.Errorf("safe OIDC token Agent endpoint using HTTPS or loopback HTTP is required")
-	}
-	u.Path = strings.TrimRight(u.Path, "/") + "/jobs/" + jobID + "/oidc/tokens"
-	u.RawPath = ""
-	return u.String(), nil
 }
 
 type oidcTokenHTTPError struct {

--- a/internal/runtime/runner_resolution.go
+++ b/internal/runtime/runner_resolution.go
@@ -8,11 +8,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
-	"time"
 
-	"github.com/buildkite/buildkite-gha/internal/useragent"
+	"github.com/buildkite/buildkite-gha/internal/agentapi"
 )
 
 const runnerResolutionResponseLimit = 64 << 10
@@ -46,32 +44,19 @@ type AgentRunnerResolverConfig struct {
 
 type AgentRunnerResolver struct {
 	resolveURL string
-	jobToken   string
-	userAgent  string
-	client     *http.Client
+	agent      *agentapi.Client
 }
 
 func NewAgentRunnerResolver(config AgentRunnerResolverConfig) (*AgentRunnerResolver, error) {
-	resolveURL, err := agentRunnerResolutionURL(config.Endpoint, config.JobID)
+	agent, err := agentapi.New(agentapi.Config{
+		Endpoint: config.Endpoint, JobID: config.JobID, JobToken: config.JobToken,
+		ClientVersion: config.ClientVersion, HTTPClient: config.Client,
+	}, "runner resolution")
 	if err != nil {
 		return nil, err
 	}
-	if config.JobToken == "" || strings.ContainsAny(config.JobToken, "\r\n") {
-		return nil, fmt.Errorf("runner resolution Agent job token is required")
-	}
-	client := config.Client
-	if client == nil {
-		client = &http.Client{Timeout: 15 * time.Second}
-	}
-	bounded := *client
-	bounded.Jar = nil
-	bounded.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
-	if bounded.Timeout == 0 {
-		bounded.Timeout = 15 * time.Second
-	}
 	return &AgentRunnerResolver{
-		resolveURL: resolveURL, jobToken: config.JobToken,
-		userAgent: useragent.FromVersion(config.ClientVersion), client: &bounded,
+		resolveURL: agent.URL("github-actions/runners"), agent: agent,
 	}, nil
 }
 
@@ -118,11 +103,8 @@ func (c *AgentRunnerResolver) resolveBatch(ctx context.Context, requirements []R
 	if err != nil {
 		return nil, fmt.Errorf("create runner resolution request: %w", err)
 	}
-	request.Header.Set("Authorization", "Token "+c.jobToken)
-	request.Header.Set("Accept", "application/json")
 	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("User-Agent", c.userAgent)
-	response, err := c.client.Do(request)
+	response, err := c.agent.Do(request)
 	if err != nil {
 		return nil, fmt.Errorf("request runner resolution: %w", err)
 	}
@@ -189,17 +171,4 @@ func (c *AgentRunnerResolver) resolveBatch(ctx context.Context, requirements []R
 		}
 	}
 	return suggestions, nil
-}
-
-func agentRunnerResolutionURL(endpoint, jobID string) (string, error) {
-	if !validBuildkiteJobID(jobID) {
-		return "", fmt.Errorf("runner resolution Agent job ID is required")
-	}
-	u, err := url.Parse(endpoint)
-	if err != nil || !validCredentialServiceURL(u) {
-		return "", fmt.Errorf("safe runner resolution Agent endpoint using HTTPS or loopback HTTP is required")
-	}
-	u.Path = strings.TrimRight(u.Path, "/") + "/jobs/" + jobID + "/github-actions/runners"
-	u.RawPath = ""
-	return u.String(), nil
 }


### PR DESCRIPTION
## Why

Cache credentials, GitHub tokens, OIDC tokens, and runner resolution all connect to the job-scoped Buildkite Agent API, but each client repeated the same endpoint and credential validation, HTTP hardening, authentication, and user-agent setup. Changes to this shared policy had to be synchronized across four service implementations. This is part of PB-3178.

Central ownership reduces drift in security-sensitive defaults and gives future Agent API integrations one established boundary to reuse across the repository.

## What

- Add a dedicated `internal/agentapi` package for safe job URL construction, job and token validation, timeout and redirect policy, and standard request headers.
- Keep `internal/transport` focused on artifact and result transport over public `buildkite-agent` commands rather than mixing in the live HTTP API boundary.
- Reuse the client from cache credentials, GitHub tokens, OIDC tokens, and runner resolution while leaving each service's payloads, responses, errors, and public configuration unchanged.
- Cover the shared boundary's authenticated request construction and unsafe configuration rejection directly.

## Verification

`GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false mise run check`
