### PR TITLE
Keep shell execution consistent across runtime modes

### DIFF
--- a/internal/runtime/action_execution.go
+++ b/internal/runtime/action_execution.go
@@ -24,7 +24,6 @@ import (
 	"github.com/buildkite/buildkite-gha/internal/expression"
 	"github.com/buildkite/buildkite-gha/internal/plan"
 	executionprogram "github.com/buildkite/buildkite-gha/internal/program"
-	shellcompat "github.com/buildkite/buildkite-gha/internal/shell"
 	"github.com/buildkite/buildkite-gha/internal/transport"
 )
 
@@ -1933,43 +1932,7 @@ func (r *jobRun) runActionStep(ctx context.Context, processor *commandProcessor,
 	environment := r.invocationEnvironment(jobEnv, stepEnv)
 	result := newResult()
 	if step.Kind == "run" {
-		script, err := evaluateProgramTyped[string](step.Execution.Run.Command, executionprogram.EvaluationContext{Expression: eval})
-		if err != nil {
-			return result, err
-		}
-		shellSite := step.Execution.Run.Shell
-		if shellSite.Source == "" {
-			shellSite = job.Program.Job.Defaults.Shell
-		}
-		shell, err := evaluateProgramTyped[string](shellSite, executionprogram.EvaluationContext{Expression: eval})
-		if err != nil {
-			return result, err
-		}
-		if shell == "" {
-			if r.jobContainer != nil {
-				shell = "sh"
-			} else {
-				shell = "bash"
-			}
-		}
-		workingDirectorySite := step.Execution.Run.WorkingDirectory
-		if workingDirectorySite.Source == "" {
-			workingDirectorySite = job.Program.Job.Defaults.WorkingDirectory
-		}
-		workingDirectory, err := evaluateProgramTyped[string](workingDirectorySite, executionprogram.EvaluationContext{Expression: eval})
-		if err != nil {
-			return result, err
-		}
-		if r.jobContainer != nil {
-			workingDirectory = r.jobContainer.hostPath(workingDirectory)
-		}
-		dir, err := stepWorkingDirectory(workspace, workingDirectory)
-		if err != nil {
-			return result, err
-		}
-		runEnv := environment.process()
-		err = r.runShellProcess(ctx, processor, dir, runEnv, &result, shell, script)
-		return result, err
+		return r.runWorkflowShellStep(ctx, processor, workspace, job, step, environment.process(), eval)
 	}
 
 	var action metadata.Metadata
@@ -2271,29 +2234,7 @@ func (r *jobRun) runCompositeMetadata(ctx context.Context, processor *commandPro
 		case strings.TrimSpace(step.Run) == "":
 			childErr = fmt.Errorf("composite action step %d has no run command", i+1)
 		default:
-			var script, dir string
-			var env map[string]string
-			env, childErr = executionprogram.EvaluateBindings(executionStep.Env, executionprogram.EvaluationContext{Expression: eval})
-			if childErr == nil {
-				script, childErr = evaluateProgramString(executionStep.Run.Command, eval)
-			}
-			if childErr == nil {
-				workingDirectory, evalErr := evaluateProgramString(executionStep.WorkingDirectory, eval)
-				childErr = evalErr
-				if childErr == nil {
-					if r.jobContainer != nil {
-						workingDirectory = r.jobContainer.hostPath(workingDirectory)
-					}
-					dir, childErr = stepWorkingDirectory(workspace, workingDirectory)
-				}
-			}
-			if childErr == nil {
-				shell, evalErr := evaluateProgramString(executionStep.Shell, eval)
-				childErr = evalErr
-				if childErr == nil {
-					childErr = r.runShellProcess(ctx, processor, dir, mergeStepEnvironment(childJobEnv, env), &stepResult, shell, script)
-				}
-			}
+			childErr = r.runCompositeShellStep(ctx, processor, workspace, executionStep, childJobEnv, eval, &stepResult)
 		}
 		mergeInto(result.Env, stepResult.Env)
 		if stepResult.pathBaseSet {
@@ -2432,104 +2373,6 @@ func needStatuses(needs map[string]plan.Need) map[string]expression.NeedStatus {
 		statuses[name] = expression.NeedStatus{Outputs: outputs, Result: need.Result}
 	}
 	return statuses
-}
-
-func shellCommand(shell, script string) ([]string, error) {
-	switch strings.TrimSpace(shell) {
-	case "", "bash":
-		return []string{"bash", "--noprofile", "--norc", "-e", "-o", "pipefail", "-c", script}, nil
-	case "sh":
-		return []string{"sh", "-e", "-c", script}, nil
-	default:
-		if err := shellcompat.ValidateCompatibility(shell); err != nil {
-			return nil, errUnsupportedFeature("shell", "", "%s", err)
-		}
-		return nil, errUnsupportedFeature("shell", "", "shell %q is unsupported in the supported runtime subset", shell)
-	}
-}
-
-func (r *jobRun) runShellProcess(ctx context.Context, processor *commandProcessor, dir string, env map[string]string, result *Result, shell, script string) error {
-	shell = strings.TrimSpace(shell)
-	if shell != "python" && !strings.Contains(shell, "{0}") {
-		args, err := shellCommand(shell, script)
-		if err != nil {
-			return err
-		}
-		return r.runProcess(ctx, processor, dir, env, result, nil, args[0], args[1:]...)
-	}
-
-	args := []string{"python", "{0}"}
-	if shell != "python" {
-		if err := shellcompat.ValidateCompatibility(shell); err != nil {
-			return errUnsupportedFeature("shell", "", "%s", err)
-		}
-		var err error
-		args, err = shellcompat.ParseTemplate(shell)
-		if err != nil {
-			return err
-		}
-	}
-	extension := shellScriptExtension(args[0])
-	parent := ""
-	if r.jobContainer != nil {
-		parent = r.runnerTemp
-	}
-	file, err := os.CreateTemp(parent, "buildkite-gha-shell-*"+extension)
-	if err != nil {
-		return fmt.Errorf("create shell script: %w", err)
-	}
-	path := file.Name()
-	defer func(path string) { _ = os.Remove(path) }(path)
-	if _, err := file.WriteString(script); err != nil {
-		return errors.Join(fmt.Errorf("write shell script: %w", err), file.Close())
-	}
-	if err := file.Close(); err != nil {
-		return fmt.Errorf("close shell script: %w", err)
-	}
-	if r.jobContainer != nil {
-		// Job containers may declare any USER, so the mounted script must be
-		// readable without assuming a shared host UID or GID.
-		if err := os.Chmod(path, 0o644); err != nil {
-			return fmt.Errorf("make shell script container-readable: %w", err)
-		}
-		path = r.jobContainer.containerPath(path)
-	}
-	for i := 1; i < len(args); i++ {
-		args[i] = strings.ReplaceAll(args[i], "{0}", path)
-	}
-	if r.jobContainer == nil {
-		command, err := resolveExecutableInPath(args[0], env["PATH"])
-		if err != nil {
-			return err
-		}
-		args[0] = command
-	}
-	return r.runProcess(ctx, processor, dir, env, result, nil, args[0], args[1:]...)
-}
-
-func shellScriptExtension(command string) string {
-	switch strings.ToLower(command) {
-	case "bash", "sh":
-		return ".sh"
-	case "python":
-		return ".py"
-	default:
-		return ""
-	}
-}
-
-// stepWorkingDirectory resolves a run step's working directory and requires it
-// to exist. Failing here names the directory instead of surfacing the child
-// process's chdir failure as a misleading "fork/exec <shell>" error.
-func stepWorkingDirectory(root, path string) (string, error) {
-	resolved, err := workspacePath(root, path)
-	if err != nil {
-		return "", err
-	}
-	if info, statErr := os.Stat(resolved); statErr != nil || !info.IsDir() {
-		return "", fmt.Errorf("working directory %q does not exist in the workspace", path)
-	}
-	return resolved, nil
 }
 
 func workspacePath(root, path string) (string, error) {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -6178,6 +6178,18 @@ func TestShellStepsMissingWorkingDirectoryFailClearly(t *testing.T) {
 	}
 }
 
+func TestCompositeShellWorkingDirectoryFailurePrecedesShellEvaluation(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	writeFixtureFile(t, workspace, ".github/actions/composite/action.yml", "name: composite\nruns:\n  using: composite\n  steps:\n    - shell: ${{ fromJSON('invalid') }}\n      working-directory: missing\n      run: true\n")
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "composite", Kind: "uses", Uses: "./.github/actions/composite"}})
+	_, err := (Runner{}).runTestJob(t.Context(), job, workspace)
+	if err == nil || !strings.Contains(err.Error(), `working directory "missing" does not exist`) || strings.Contains(err.Error(), "fromJSON") {
+		t.Fatalf("RunJob() error = %v, want only the prior working-directory failure", err)
+	}
+}
+
 func TestNestedCompositeEvaluatesEnvironmentOnceAndIsolatesStepScopes(t *testing.T) {
 	workspace := canonicalTempDir(t)
 	workflowPath := ".github/workflows/test.yml"

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -6144,13 +6144,37 @@ runs:
 	}
 }
 
-func TestRunStepMissingWorkingDirectoryFailsClearly(t *testing.T) {
-	workspace := t.TempDir()
-	workflowPath := ".github/workflows/test.yml"
-	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
-	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{ID: "run", Kind: "run", Shell: "sh", Command: "true", WorkingDirectory: "missing"}})
-	if _, err := (Runner{}).runTestJob(t.Context(), job, workspace); err == nil || !strings.Contains(err.Error(), `working directory "missing" does not exist`) {
-		t.Fatalf("RunJob() error = %v, want missing working directory diagnostic", err)
+func TestShellStepsMissingWorkingDirectoryFailClearly(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		steps []plan.Step
+		setup func(*testing.T, string)
+	}{
+		{
+			name:  "workflow",
+			steps: []plan.Step{{ID: "run", Kind: "run", Shell: "sh", Command: "true", WorkingDirectory: "missing"}},
+		},
+		{
+			name:  "composite",
+			steps: []plan.Step{{ID: "composite", Kind: "uses", Uses: "./.github/actions/composite"}},
+			setup: func(t *testing.T, workspace string) {
+				t.Helper()
+				writeFixtureFile(t, workspace, ".github/actions/composite/action.yml", "name: composite\nruns:\n  using: composite\n  steps:\n    - shell: sh\n      working-directory: missing\n      run: true\n")
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			workspace := t.TempDir()
+			workflowPath := ".github/workflows/test.yml"
+			writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+			if test.setup != nil {
+				test.setup(t, workspace)
+			}
+			job := runtimePlan(t, workspace, workflowPath, test.steps)
+			if _, err := (Runner{}).runTestJob(t.Context(), job, workspace); err == nil || !strings.Contains(err.Error(), `working directory "missing" does not exist`) {
+				t.Fatalf("RunJob() error = %v, want missing working directory diagnostic", err)
+			}
+		})
 	}
 }
 

--- a/internal/runtime/shell_execution.go
+++ b/internal/runtime/shell_execution.go
@@ -42,7 +42,11 @@ func (r *jobRun) runWorkflowShellStep(ctx context.Context, processor *commandPro
 	if err != nil {
 		return result, err
 	}
-	err = r.runShellStep(ctx, processor, workspace, workingDirectory, env, &result, shell, script)
+	dir, err := r.shellWorkingDirectory(workspace, workingDirectory)
+	if err != nil {
+		return result, err
+	}
+	err = r.runShellProcess(ctx, processor, dir, env, &result, shell, script)
 	return result, err
 }
 
@@ -59,22 +63,22 @@ func (r *jobRun) runCompositeShellStep(ctx context.Context, processor *commandPr
 	if err != nil {
 		return err
 	}
+	dir, err := r.shellWorkingDirectory(workspace, workingDirectory)
+	if err != nil {
+		return err
+	}
 	shell, err := evaluateProgramString(step.Shell, eval)
 	if err != nil {
 		return err
 	}
-	return r.runShellStep(ctx, processor, workspace, workingDirectory, mergeStepEnvironment(jobEnv, env), result, shell, script)
+	return r.runShellProcess(ctx, processor, dir, mergeStepEnvironment(jobEnv, env), result, shell, script)
 }
 
-func (r *jobRun) runShellStep(ctx context.Context, processor *commandProcessor, workspace, workingDirectory string, env map[string]string, result *Result, shell, script string) error {
+func (r *jobRun) shellWorkingDirectory(workspace, workingDirectory string) (string, error) {
 	if r.jobContainer != nil {
 		workingDirectory = r.jobContainer.hostPath(workingDirectory)
 	}
-	dir, err := stepWorkingDirectory(workspace, workingDirectory)
-	if err != nil {
-		return err
-	}
-	return r.runShellProcess(ctx, processor, dir, env, result, shell, script)
+	return stepWorkingDirectory(workspace, workingDirectory)
 }
 
 func shellCommand(shell, script string) ([]string, error) {

--- a/internal/runtime/shell_execution.go
+++ b/internal/runtime/shell_execution.go
@@ -1,0 +1,176 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/buildkite/buildkite-gha/internal/expression"
+	"github.com/buildkite/buildkite-gha/internal/plan"
+	executionprogram "github.com/buildkite/buildkite-gha/internal/program"
+	shellcompat "github.com/buildkite/buildkite-gha/internal/shell"
+)
+
+func (r *jobRun) runWorkflowShellStep(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, step plan.Step, env map[string]string, eval expression.Context) (Result, error) {
+	result := newResult()
+	script, err := evaluateProgramTyped[string](step.Execution.Run.Command, executionprogram.EvaluationContext{Expression: eval})
+	if err != nil {
+		return result, err
+	}
+	shellSite := step.Execution.Run.Shell
+	if shellSite.Source == "" {
+		shellSite = job.Program.Job.Defaults.Shell
+	}
+	shell, err := evaluateProgramTyped[string](shellSite, executionprogram.EvaluationContext{Expression: eval})
+	if err != nil {
+		return result, err
+	}
+	if shell == "" {
+		if r.jobContainer != nil {
+			shell = "sh"
+		} else {
+			shell = "bash"
+		}
+	}
+	workingDirectorySite := step.Execution.Run.WorkingDirectory
+	if workingDirectorySite.Source == "" {
+		workingDirectorySite = job.Program.Job.Defaults.WorkingDirectory
+	}
+	workingDirectory, err := evaluateProgramTyped[string](workingDirectorySite, executionprogram.EvaluationContext{Expression: eval})
+	if err != nil {
+		return result, err
+	}
+	err = r.runShellStep(ctx, processor, workspace, workingDirectory, env, &result, shell, script)
+	return result, err
+}
+
+func (r *jobRun) runCompositeShellStep(ctx context.Context, processor *commandProcessor, workspace string, step *executionprogram.ActionStep, jobEnv map[string]string, eval expression.Context, result *Result) error {
+	env, err := executionprogram.EvaluateBindings(step.Env, executionprogram.EvaluationContext{Expression: eval})
+	if err != nil {
+		return err
+	}
+	script, err := evaluateProgramString(step.Run.Command, eval)
+	if err != nil {
+		return err
+	}
+	workingDirectory, err := evaluateProgramString(step.WorkingDirectory, eval)
+	if err != nil {
+		return err
+	}
+	shell, err := evaluateProgramString(step.Shell, eval)
+	if err != nil {
+		return err
+	}
+	return r.runShellStep(ctx, processor, workspace, workingDirectory, mergeStepEnvironment(jobEnv, env), result, shell, script)
+}
+
+func (r *jobRun) runShellStep(ctx context.Context, processor *commandProcessor, workspace, workingDirectory string, env map[string]string, result *Result, shell, script string) error {
+	if r.jobContainer != nil {
+		workingDirectory = r.jobContainer.hostPath(workingDirectory)
+	}
+	dir, err := stepWorkingDirectory(workspace, workingDirectory)
+	if err != nil {
+		return err
+	}
+	return r.runShellProcess(ctx, processor, dir, env, result, shell, script)
+}
+
+func shellCommand(shell, script string) ([]string, error) {
+	switch strings.TrimSpace(shell) {
+	case "", "bash":
+		return []string{"bash", "--noprofile", "--norc", "-e", "-o", "pipefail", "-c", script}, nil
+	case "sh":
+		return []string{"sh", "-e", "-c", script}, nil
+	default:
+		if err := shellcompat.ValidateCompatibility(shell); err != nil {
+			return nil, errUnsupportedFeature("shell", "", "%s", err)
+		}
+		return nil, errUnsupportedFeature("shell", "", "shell %q is unsupported in the supported runtime subset", shell)
+	}
+}
+
+func (r *jobRun) runShellProcess(ctx context.Context, processor *commandProcessor, dir string, env map[string]string, result *Result, shell, script string) error {
+	shell = strings.TrimSpace(shell)
+	if shell != "python" && !strings.Contains(shell, "{0}") {
+		args, err := shellCommand(shell, script)
+		if err != nil {
+			return err
+		}
+		return r.runProcess(ctx, processor, dir, env, result, nil, args[0], args[1:]...)
+	}
+
+	args := []string{"python", "{0}"}
+	if shell != "python" {
+		if err := shellcompat.ValidateCompatibility(shell); err != nil {
+			return errUnsupportedFeature("shell", "", "%s", err)
+		}
+		var err error
+		args, err = shellcompat.ParseTemplate(shell)
+		if err != nil {
+			return err
+		}
+	}
+	extension := shellScriptExtension(args[0])
+	parent := ""
+	if r.jobContainer != nil {
+		parent = r.runnerTemp
+	}
+	file, err := os.CreateTemp(parent, "buildkite-gha-shell-*"+extension)
+	if err != nil {
+		return fmt.Errorf("create shell script: %w", err)
+	}
+	path := file.Name()
+	defer func(path string) { _ = os.Remove(path) }(path)
+	if _, err := file.WriteString(script); err != nil {
+		return errors.Join(fmt.Errorf("write shell script: %w", err), file.Close())
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close shell script: %w", err)
+	}
+	if r.jobContainer != nil {
+		// Job containers may declare any USER, so the mounted script must be
+		// readable without assuming a shared host UID or GID.
+		if err := os.Chmod(path, 0o644); err != nil {
+			return fmt.Errorf("make shell script container-readable: %w", err)
+		}
+		path = r.jobContainer.containerPath(path)
+	}
+	for i := 1; i < len(args); i++ {
+		args[i] = strings.ReplaceAll(args[i], "{0}", path)
+	}
+	if r.jobContainer == nil {
+		command, err := resolveExecutableInPath(args[0], env["PATH"])
+		if err != nil {
+			return err
+		}
+		args[0] = command
+	}
+	return r.runProcess(ctx, processor, dir, env, result, nil, args[0], args[1:]...)
+}
+
+func shellScriptExtension(command string) string {
+	switch strings.ToLower(command) {
+	case "bash", "sh":
+		return ".sh"
+	case "python":
+		return ".py"
+	default:
+		return ""
+	}
+}
+
+// stepWorkingDirectory resolves a run step's working directory and requires it
+// to exist. Failing here names the directory instead of surfacing the child
+// process's chdir failure as a misleading "fork/exec <shell>" error.
+func stepWorkingDirectory(root, path string) (string, error) {
+	resolved, err := workspacePath(root, path)
+	if err != nil {
+		return "", err
+	}
+	if info, statErr := os.Stat(resolved); statErr != nil || !info.IsDir() {
+		return "", fmt.Errorf("working directory %q does not exist in the workspace", path)
+	}
+	return resolved, nil
+}


### PR DESCRIPTION
## Why

Workflow `run` steps and nested composite-action shell steps split the same execution policy across one of the runtime's largest files: expression resolution, working-directory validation, job-container path translation, and shell process launch. Changes to shell execution required reconstructing both paths and made drift between runtime modes easier.

A single ownership boundary reduces the context needed to improve host and job-container execution, increasing velocity for future runtime work. This is part of PB-3178.

## What

- Move shell command construction, temporary-script handling, working-directory validation, and process launch into `shell_execution.go`.
- Route workflow and composite shell steps through that boundary while preserving their existing defaults and expression-evaluation order.
- Cover the shared missing-working-directory contract for both workflow and composite steps.

The refactor does not change runtime behavior, plan or result wire formats, Agent API clients, or workflow-command processing.