### PR TITLE
Prevent agent test failures and clarify architecture ownership

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -50,6 +50,10 @@ if ! command -v gh >/dev/null; then
   exit 1
 fi
 
+# Orb system configuration requires commit signing but does not provide its
+# signing key. Tests create temporary repositories, so override it globally.
+git config --global commit.gpgsign false
+
 echo "Installing mise if needed..."
 if [[ ! -x "$mise_bin" ]]; then
   curl -fsSL https://mise.run | sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,16 @@ product but not the subsystem.
 | `Support unavailable action check run IDs` | `Allow actions when no GitHub check run ID exists` |
 | `Improve provider-token authority planning` | `Avoid requesting a GitHub token for branches that cannot run` |
 
+## Architecture
+
+- Read package documentation before assigning ownership. Name packages and
+  files for their full responsibility rather than generic activity.
+- Before changing expression evaluation, lifecycle ordering, or token
+  authority, read [Expression authority](docs/expression-authority.md). Define
+  each execution position once so planning and runtime cannot drift.
+- When a feature needs Buildkite server support, confirm the server contract
+  and rollout order before implementing the CLI side.
+
 ## Cursor Cloud specific instructions
 
 This is a single Go CLI product (`buildkite-gha`). There are **no long-running


### PR DESCRIPTION
## Why

Orb tests that create temporary Git repositories inherit required commit signing without an available key, so `mise run check` fails with `No signing key is available for this commit`. Recent work also repeatedly needed corrections for generic package names, duplicated planning/runtime semantics, and Buildkite server contracts that were still changing.

## What

Orb setup now disables commit signing in its global Git configuration so temporary repositories work without per-command overrides. `AGENTS.md` adds three focused architecture prompts: use package docs to place and name code, consult the expression-authority contract before semantic changes, and confirm server contracts and rollout order before implementing CLI support. This is part of PB-3178.
