### PR TITLE
Keep Git object validation consistent

### DIFF
--- a/internal/action/integration/checkout.go
+++ b/internal/action/integration/checkout.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"unicode/utf8"
+
+	"github.com/buildkite/buildkite-gha/internal/git"
 )
 
 const (
@@ -62,7 +64,7 @@ type checkoutInputRule struct {
 var checkoutInputRules = map[string]checkoutInputRule{
 	"repository": {strings.EqualFold},
 	"ref": {func(value, _ string) bool {
-		return value == "" || ValidCheckoutSHA(value) || validCheckoutBranch(value)
+		return value == "" || git.ValidObjectID(value) || validCheckoutBranch(value)
 	}},
 	"fetch-depth": {func(value, _ string) bool {
 		depth, err := strconv.ParseUint(value, 10, 31)
@@ -106,7 +108,7 @@ func checkoutContractForCommit(commit string) (checkoutContract, bool) {
 	if exact {
 		return contract, true
 	}
-	if !ValidCheckoutSHA(commit) {
+	if !git.ValidObjectID(commit) {
 		return checkoutContract{}, false
 	}
 	return checkoutCommitContracts[CheckoutV7Commit], false
@@ -115,7 +117,7 @@ func checkoutContractForCommit(commit string) (checkoutContract, bool) {
 // CheckoutUsesFallbackContract reports whether an immutable commit is absent
 // from the frozen snapshot and therefore uses the stable fallback contract.
 func CheckoutUsesFallbackContract(commit string) bool {
-	if !ValidCheckoutSHA(commit) {
+	if !git.ValidObjectID(commit) {
 		return false
 	}
 	_, exact := checkoutCommitContracts[commit]
@@ -149,7 +151,7 @@ func LegacyCheckoutRelease(commit string) (string, bool) {
 // frozen snapshots retain their exact contract; other valid SHAs use the
 // stable fallback contract.
 func validateCheckoutCommit(commit string) error {
-	if !ValidCheckoutSHA(commit) {
+	if !git.ValidObjectID(commit) {
 		return versionError("actions/checkout", "native adapter", commit, supportedCheckoutContracts())
 	}
 	return nil
@@ -174,7 +176,7 @@ func sortedCheckoutCommits() []string {
 // implemented by the tokenless event-repository checkout adapter.
 func ValidateCheckoutInputs(commit string, inputs map[string]string, repository, sha string) error {
 	contract, exact := checkoutContractForCommit(commit)
-	if !exact && !ValidCheckoutSHA(commit) {
+	if !exact && !git.ValidObjectID(commit) {
 		return versionError("actions/checkout", "native adapter", commit, supportedCheckoutContracts())
 	}
 	names := sortedNames(inputs)
@@ -225,19 +227,6 @@ func validCheckoutBranch(value string) bool {
 	}
 	for _, r := range value {
 		if r < 0x20 || r == 0x7f {
-			return false
-		}
-	}
-	return true
-}
-
-// ValidCheckoutSHA reports whether value is a lowercase 40-hex Git commit ID.
-func ValidCheckoutSHA(value string) bool {
-	if len(value) != 40 {
-		return false
-	}
-	for _, r := range value {
-		if r < '0' || r > '9' && (r < 'a' || r > 'f') {
 			return false
 		}
 	}

--- a/internal/action/integration/download_artifact.go
+++ b/internal/action/integration/download_artifact.go
@@ -9,6 +9,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/bmatcuk/doublestar/v4"
+	"github.com/buildkite/buildkite-gha/internal/git"
 )
 
 const (
@@ -32,7 +33,7 @@ const (
 )
 
 func validateDownloadArtifactCommit(commit string) error {
-	if slices.Contains(DownloadArtifactCommits(), commit) || ValidCheckoutSHA(commit) {
+	if slices.Contains(DownloadArtifactCommits(), commit) || git.ValidObjectID(commit) {
 		return nil
 	}
 	return versionError("actions/download-artifact", "native adapter", commit, DownloadArtifactCommits())
@@ -41,7 +42,7 @@ func validateDownloadArtifactCommit(commit string) error {
 // DownloadArtifactUsesFallbackContract reports whether an immutable commit is
 // outside the exact admission set and therefore uses the stable v8 contract.
 func DownloadArtifactUsesFallbackContract(commit string) bool {
-	return ValidCheckoutSHA(commit) && !slices.Contains(DownloadArtifactCommits(), commit)
+	return git.ValidObjectID(commit) && !slices.Contains(DownloadArtifactCommits(), commit)
 }
 
 // DownloadArtifactCommits returns the complete immutable admission set.

--- a/internal/action/integration/upload_artifact.go
+++ b/internal/action/integration/upload_artifact.go
@@ -10,6 +10,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/bmatcuk/doublestar/v4"
+	"github.com/buildkite/buildkite-gha/internal/git"
 )
 
 const (
@@ -75,7 +76,7 @@ func uploadArtifactGeneration(commit string) int {
 // UploadArtifactUsesFallbackContract reports whether an immutable commit is
 // outside the exact admission set and therefore uses the stable v7 contract.
 func UploadArtifactUsesFallbackContract(commit string) bool {
-	if !ValidCheckoutSHA(commit) || commit == uploadArtifactV322Commit {
+	if !git.ValidObjectID(commit) || commit == uploadArtifactV322Commit {
 		return false
 	}
 	_, exact := uploadArtifactCommits[commit]
@@ -112,7 +113,7 @@ func LegacyUploadArtifactRelease(commit string) (string, bool) {
 }
 
 func validateUploadArtifactCommit(commit string) error {
-	if _, ok := uploadArtifactCommits[commit]; !ok && (!ValidCheckoutSHA(commit) || commit == uploadArtifactV322Commit) {
+	if _, ok := uploadArtifactCommits[commit]; !ok && (!git.ValidObjectID(commit) || commit == uploadArtifactV322Commit) {
 		commits := make([]string, 0, len(uploadArtifactCommits))
 		for supported, version := range uploadArtifactCommits {
 			commits = append(commits, version+" ("+supported+")")

--- a/internal/action/source/action_cache.go
+++ b/internal/action/source/action_cache.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/buildkite/buildkite-gha/internal/git"
 )
 
 type cacheEntry struct {
@@ -271,7 +273,7 @@ func (s *Store) cacheEntries() ([]cacheEntry, []string, error) {
 					partials = append(partials, path)
 					continue
 				}
-				if !commit.IsDir() || !shaRE.MatchString(commit.Name()) {
+				if !commit.IsDir() || !git.ValidObjectID(commit.Name()) {
 					continue
 				}
 				size, sizeErr := cacheEntrySize(path)

--- a/internal/action/source/action_resolution_snapshot.go
+++ b/internal/action/source/action_resolution_snapshot.go
@@ -13,6 +13,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/buildkite/buildkite-gha/internal/git"
 )
 
 const actionResolutionSnapshotSchema = "buildkite-gha-action-resolution-snapshot/v1"
@@ -286,7 +288,7 @@ func loadActionResolutionSnapshotEntry(path string, ref Reference) (Resolved, er
 	var entry actionResolutionSnapshotEntry
 	if !decodeActionResolutionJSON(file, &entry) || entry.Schema != actionResolutionSnapshotSchema ||
 		entry.Owner != strings.ToLower(ref.Owner) || entry.Repository != strings.ToLower(ref.Repository) || entry.Ref != ref.Ref ||
-		(entry.Missing == (entry.Commit != "")) || entry.Commit != "" && !shaRE.MatchString(entry.Commit) {
+		(entry.Missing == (entry.Commit != "")) || entry.Commit != "" && !git.ValidObjectID(entry.Commit) {
 		return Resolved{}, fmt.Errorf("action resolution snapshot entry is invalid"), true
 	}
 	if entry.Missing {

--- a/internal/action/source/mutable_ref_cache.go
+++ b/internal/action/source/mutable_ref_cache.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/buildkite/buildkite-gha/internal/git"
 )
 
 type mutableRefCache struct {
@@ -97,7 +99,7 @@ func (c *mutableRefCache) load(path string, ref Reference, now time.Time) (Resol
 	if decoder.Decode(&entry) != nil || decoder.Decode(&struct{}{}) != io.EOF ||
 		entry.Schema != "buildkite-gha-action-ref-resolution/v1" ||
 		entry.Owner != strings.ToLower(ref.Owner) || entry.Repository != strings.ToLower(ref.Repository) ||
-		entry.Ref != ref.Ref || !shaRE.MatchString(entry.Commit) || entry.ResolvedAt.After(now) ||
+		entry.Ref != ref.Ref || !git.ValidObjectID(entry.Commit) || entry.ResolvedAt.After(now) ||
 		now.Sub(entry.ResolvedAt) >= c.freshness {
 		return Resolved{}, false
 	}

--- a/internal/action/source/source.go
+++ b/internal/action/source/source.go
@@ -27,6 +27,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/buildkite/buildkite-gha/internal/git"
 	"github.com/buildkite/buildkite-gha/internal/useragent"
 )
 
@@ -42,7 +43,6 @@ const (
 var (
 	ownerRE = regexp.MustCompile(`^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$`)
 	repoRE  = regexp.MustCompile(`^(?:[A-Za-z0-9](?:[A-Za-z0-9_.-]{0,98}[A-Za-z0-9])?|\.[A-Za-z0-9](?:[A-Za-z0-9_.-]{0,97}[A-Za-z0-9])?)$`)
-	shaRE   = regexp.MustCompile(`^[0-9a-f]{40}$`)
 )
 
 // Reference is a parsed remote action reference.
@@ -300,7 +300,7 @@ func (r *Resolver) Resolve(ctx context.Context, ref Reference) (Resolved, error)
 		return Resolved{}, err
 	}
 	ref = parsed
-	if shaRE.MatchString(ref.Ref) {
+	if git.ValidObjectID(ref.Ref) {
 		return Resolved{Reference: ref, Commit: ref.Ref}, nil
 	}
 	if r.cfg.resolutionSnapshot != nil {
@@ -358,14 +358,14 @@ func (r *Resolver) resolveCommit(ctx context.Context, ref Reference) (Resolved, 
 	if err := r.get(ctx, repoParts(ref, "commits", ref.Ref), &v); err != nil {
 		return Resolved{}, err
 	}
-	if !shaRE.MatchString(v.SHA) {
+	if !git.ValidObjectID(v.SHA) {
 		return Resolved{}, fmt.Errorf("GitHub returned malformed commit SHA")
 	}
 	return Resolved{Reference: ref, Commit: v.SHA}, nil
 }
 func (r *Resolver) peel(ctx context.Context, ref Reference, typ, sha string) (string, error) {
 	for range 5 {
-		if !shaRE.MatchString(sha) {
+		if !git.ValidObjectID(sha) {
 			return "", fmt.Errorf("GitHub returned malformed object SHA")
 		}
 		if typ == "commit" {
@@ -544,7 +544,7 @@ func NewStoreContext(ctx context.Context, root string, client *http.Client, opts
 
 // Materialize returns the verified repository and selected action identity.
 func (s *Store) Materialize(ctx context.Context, resolved Resolved) (Materialized, error) {
-	if !shaRE.MatchString(resolved.Commit) {
+	if !git.ValidObjectID(resolved.Commit) {
 		return Materialized{}, fmt.Errorf("commit must be lower-case full SHA")
 	}
 	parsed, err := Parse(resolved.Reference.Raw)

--- a/internal/cli/buildkite_event.go
+++ b/internal/cli/buildkite_event.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"bytes"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,6 +11,8 @@ import (
 	"strings"
 	"unicode"
 	"unicode/utf8"
+
+	"github.com/buildkite/buildkite-gha/internal/git"
 )
 
 const githubEventNameEnvironment = "GITHUB_EVENT_NAME"
@@ -29,7 +30,7 @@ func buildkiteEventSource(getenv func(string) string) ([]byte, error) {
 		return nil, fmt.Errorf("BUILDKITE_REPO: %w", err)
 	}
 	sha := getenv("BUILDKITE_COMMIT")
-	if !validBuildkiteCommit(sha) {
+	if !git.ValidObjectID(sha) {
 		return nil, fmt.Errorf("BUILDKITE_COMMIT must be a full lowercase 40-hex commit, not a symbolic ref")
 	}
 	branch, tag, pullRequest := getenv("BUILDKITE_BRANCH"), getenv("BUILDKITE_TAG"), getenv("BUILDKITE_PULL_REQUEST")
@@ -152,11 +153,6 @@ func buildkiteEventSource(getenv func(string) string) ([]byte, error) {
 	return result, nil
 }
 
-func validBuildkiteCommit(commit string) bool {
-	decoded, err := hex.DecodeString(commit)
-	return err == nil && len(decoded) == 20 && commit == strings.ToLower(commit)
-}
-
 // buildkiteWebhookEventSource overlays untrusted trigger data onto the
 // execution identity derived and validated by buildkiteEventSource.
 func buildkiteWebhookEventSource(getenv func(string) string, webhook []byte) ([]byte, error) {
@@ -246,7 +242,7 @@ func validateBuildkiteMergeGroup(snapshot map[string]any, getenv func(string) st
 		return fmt.Errorf("merge_group webhook base_ref does not match BUILDKITE_MERGE_QUEUE_BASE_BRANCH")
 	}
 	baseCommit := getenv("BUILDKITE_MERGE_QUEUE_BASE_COMMIT")
-	if !validBuildkiteCommit(baseCommit) {
+	if !git.ValidObjectID(baseCommit) {
 		return fmt.Errorf("BUILDKITE_MERGE_QUEUE_BASE_COMMIT must be a full lowercase 40-hex commit")
 	}
 	if baseSHA, _ := mergeGroup["base_sha"].(string); baseSHA != baseCommit {

--- a/internal/cli/path_filters.go
+++ b/internal/cli/path_filters.go
@@ -14,6 +14,7 @@ import (
 
 	buildkitepipeline "github.com/buildkite/buildkite-gha/internal/buildkite"
 	"github.com/buildkite/buildkite-gha/internal/compiler"
+	"github.com/buildkite/buildkite-gha/internal/git"
 	"github.com/buildkite/buildkite-gha/internal/workflow"
 )
 
@@ -109,10 +110,10 @@ func pushChangedPaths(event compiler.Event, workflows []workflowInput, checkoutP
 	if deleted || after == zeroGitCommit {
 		return nil, nil, fmt.Errorf("deleted-ref pushes cannot admit path-filtered workflows")
 	}
-	if !validBuildkiteCommit(after) || after != event.SHA {
+	if !git.ValidObjectID(after) || after != event.SHA {
 		return nil, nil, fmt.Errorf("webhook push after commit does not match the Buildkite build")
 	}
-	if created != (before == zeroGitCommit) || !created && !validBuildkiteCommit(before) {
+	if created != (before == zeroGitCommit) || !created && !git.ValidObjectID(before) {
 		return nil, nil, fmt.Errorf("webhook push before commit is inconsistent with ref creation")
 	}
 
@@ -226,7 +227,7 @@ func pushWebhookCommits(payload map[string]any) ([]string, error) {
 			return nil, fmt.Errorf("webhook push contains an invalid commit")
 		}
 		id, _ := commit["id"].(string)
-		if !validBuildkiteCommit(id) || seen[id] {
+		if !git.ValidObjectID(id) || seen[id] {
 			return nil, fmt.Errorf("webhook push contains an invalid or duplicate commit ID")
 		}
 		seen[id] = true
@@ -356,7 +357,7 @@ func pullRequestChangedPaths(event compiler.Event, pullRequestNumber int, baseRe
 	if mergeabilityKnown && !mergeable {
 		return nil, nil, fmt.Errorf("webhook pull request must report a mergeable synthetic merge")
 	}
-	if !validBuildkiteCommit(baseSHA) || !validBuildkiteCommit(headSHA) || !validBuildkiteCommit(mergeSHA) {
+	if !git.ValidObjectID(baseSHA) || !git.ValidObjectID(headSHA) || !git.ValidObjectID(mergeSHA) {
 		return nil, nil, fmt.Errorf("event snapshot requires full lowercase payload.pull_request base, head, and merge commit SHAs")
 	}
 	if headSHA != event.SHA {
@@ -495,7 +496,7 @@ func singleGitCommit(output []byte, label string) (string, error) {
 	if len(commits) != 1 {
 		return "", fmt.Errorf("git returned %d candidates for %s; exactly one is required", len(commits), label)
 	}
-	if !validBuildkiteCommit(commits[0]) {
+	if !git.ValidObjectID(commits[0]) {
 		return "", fmt.Errorf("git returned an invalid %s", label)
 	}
 	return commits[0], nil

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -15,6 +15,7 @@ import (
 
 	buildkitepipeline "github.com/buildkite/buildkite-gha/internal/buildkite"
 	"github.com/buildkite/buildkite-gha/internal/compiler"
+	"github.com/buildkite/buildkite-gha/internal/git"
 	"github.com/buildkite/buildkite-gha/internal/plan"
 	"github.com/buildkite/buildkite-gha/internal/telemetry"
 	"github.com/buildkite/buildkite-gha/internal/transport"
@@ -259,7 +260,7 @@ func pluginWorkflowOperands(configuration pluginConfiguration, getenv func(strin
 		}
 	}
 	workflowSHA := getenv(githubWorkflowSHAEnvironment)
-	if workflowSHA != "" && !validBuildkiteCommit(workflowSHA) {
+	if workflowSHA != "" && !git.ValidObjectID(workflowSHA) {
 		return nil, nil, fmt.Errorf("%s must be a full lowercase 40-hex commit", githubWorkflowSHAEnvironment)
 	}
 	return []string{selectedPath}, &pipelineTriggerWorkflow{Name: workflowName, SHA: workflowSHA}, nil
@@ -406,7 +407,7 @@ func pluginNonEmptyStringList(value any, field string) ([]string, error) {
 }
 
 func normalizePluginCommit(ctx context.Context, checkoutPath string, getenv func(string) string, setenv func(string, string) error, runner transport.Runner) error {
-	if validBuildkiteCommit(getenv("BUILDKITE_COMMIT")) {
+	if git.ValidObjectID(getenv("BUILDKITE_COMMIT")) {
 		return nil
 	}
 	output, err := runner.Run(ctx, checkoutPath, "git", []string{"rev-parse", "HEAD"}, nil)
@@ -414,7 +415,7 @@ func normalizePluginCommit(ctx context.Context, checkoutPath string, getenv func
 		return fmt.Errorf("resolve BUILDKITE_COMMIT from checked-out HEAD: %w", err)
 	}
 	commit := strings.TrimSpace(string(output))
-	if !validBuildkiteCommit(commit) {
+	if !git.ValidObjectID(commit) {
 		return fmt.Errorf("resolve BUILDKITE_COMMIT from checked-out HEAD: git returned an invalid commit")
 	}
 	if err := setenv("BUILDKITE_COMMIT", commit); err != nil {

--- a/internal/compiler/event.go
+++ b/internal/compiler/event.go
@@ -2,7 +2,6 @@ package compiler
 
 import (
 	"bytes"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -11,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/buildkite/buildkite-gha/internal/expression"
+	"github.com/buildkite/buildkite-gha/internal/git"
 	"github.com/buildkite/buildkite-gha/internal/plan"
 	"github.com/buildkite/buildkite-gha/internal/workflow"
 )
@@ -107,7 +107,7 @@ func validateMergeGroupEvent(ref, sha string, payload map[string]any) error {
 	if !strings.HasPrefix(baseRef, "refs/heads/") || strings.TrimPrefix(baseRef, "refs/heads/") == "" {
 		return fmt.Errorf("merge_group event snapshot requires payload.merge_group.base_ref to be a branch ref")
 	}
-	if !validEventCommit(headSHA) || !validEventCommit(baseSHA) {
+	if !git.ValidObjectID(headSHA) || !git.ValidObjectID(baseSHA) {
 		return fmt.Errorf("merge_group event snapshot requires full lowercase payload.merge_group head and base SHAs")
 	}
 	if ref != headRef || sha != headSHA {
@@ -140,15 +140,10 @@ func validateReleaseEvent(ref, sha string, payload map[string]any) error {
 	if ref != "refs/tags/"+tag {
 		return fmt.Errorf("release event snapshot ref must match payload.release.tag_name")
 	}
-	if !validEventCommit(sha) {
+	if !git.ValidObjectID(sha) {
 		return fmt.Errorf("release event snapshot requires a full lowercase sha")
 	}
 	return nil
-}
-
-func validEventCommit(commit string) bool {
-	decoded, err := hex.DecodeString(commit)
-	return err == nil && len(decoded) == 20 && commit == strings.ToLower(commit)
 }
 
 func compileContext(event Event, vars map[string]string, workflowPath, workflowName string) expression.CompileContext {

--- a/internal/compiler/reusable_source.go
+++ b/internal/compiler/reusable_source.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	actionsource "github.com/buildkite/buildkite-gha/internal/action/source"
+	"github.com/buildkite/buildkite-gha/internal/git"
 	"github.com/buildkite/buildkite-gha/internal/workflow"
 )
 
@@ -163,7 +164,7 @@ func (resolver *reusableResolver) loadRemoteReusableWorkflow(ctx context.Context
 	}
 	resolver.materialized = append(resolver.materialized, materialized)
 	commit := resolved.Commit
-	if len(commit) != 40 || strings.Trim(commit, "0123456789abcdef") != "" {
+	if !git.ValidObjectID(commit) {
 		return reusableWorkflowSource{}, nil, fmt.Errorf("resolve public reusable workflow %q: source returned a non-immutable commit", uses)
 	}
 	if len(materialized.SourceDigest) != 71 || !strings.HasPrefix(materialized.SourceDigest, "sha256:") || strings.Trim(materialized.SourceDigest[7:], "0123456789abcdef") != "" {

--- a/internal/git/doc.go
+++ b/internal/git/doc.go
@@ -1,0 +1,2 @@
+// Package git owns shared Git identity validation.
+package git

--- a/internal/git/object_id.go
+++ b/internal/git/object_id.go
@@ -1,0 +1,14 @@
+package git
+
+// ValidObjectID reports whether value is a lowercase 40-hex SHA-1 Git object ID.
+func ValidObjectID(value string) bool {
+	if len(value) != 40 {
+		return false
+	}
+	for _, r := range value {
+		if r < '0' || r > '9' && (r < 'a' || r > 'f') {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/git/object_id_test.go
+++ b/internal/git/object_id_test.go
@@ -1,0 +1,30 @@
+package git
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidObjectID(t *testing.T) {
+	t.Parallel()
+	valid := "0123456789abcdef0123456789abcdef01234567"
+	for _, test := range []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "lowercase SHA-1", value: valid, want: true},
+		{name: "empty"},
+		{name: "short", value: valid[:39]},
+		{name: "long", value: valid + "0"},
+		{name: "uppercase", value: strings.ToUpper(valid)},
+		{name: "non-hex", value: strings.Repeat("g", 40)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ValidObjectID(test.value); got != test.want {
+				t.Fatalf("ValidObjectID(%q) = %t, want %t", test.value, got, test.want)
+			}
+		})
+	}
+}

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -17,6 +17,7 @@ import (
 	"github.com/buildkite/buildkite-gha/internal/action/integration"
 	"github.com/buildkite/buildkite-gha/internal/action/metadata"
 	"github.com/buildkite/buildkite-gha/internal/action/source"
+	"github.com/buildkite/buildkite-gha/internal/git"
 	"github.com/buildkite/buildkite-gha/internal/program"
 )
 
@@ -34,7 +35,6 @@ var targetPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,255}$`)
 var logicalJobIDPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)*$`)
 var secretNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 var actionLockIDPattern = regexp.MustCompile(`^a-[0-9a-f]{16}$`)
-var commitPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
 var containerEnvKeyPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 var containerPortPattern = regexp.MustCompile(`^(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(?::(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]))?(?:/(?:tcp|udp))?$`)
 var serviceNamePattern = regexp.MustCompile(`^[a-z_][a-z0-9_-]{0,254}$`)
@@ -1010,7 +1010,7 @@ func validateRemoteWorkflowSource(workflow Workflow) error {
 		return nil
 	}
 	remote := workflow.Remote
-	if remote.Repository == "" || remote.Repository != strings.ToLower(remote.Repository) || len(remote.Repository) > 140 || remote.RequestedRef == "" || len(remote.RequestedRef) > 1024 || !utf8.ValidString(remote.RequestedRef) || hasControl(remote.RequestedRef) || !commitPattern.MatchString(remote.Commit) || !digestPattern.MatchString(remote.SourceDigest) {
+	if remote.Repository == "" || remote.Repository != strings.ToLower(remote.Repository) || len(remote.Repository) > 140 || remote.RequestedRef == "" || len(remote.RequestedRef) > 1024 || !utf8.ValidString(remote.RequestedRef) || hasControl(remote.RequestedRef) || !git.ValidObjectID(remote.Commit) || !digestPattern.MatchString(remote.SourceDigest) {
 		return fmt.Errorf("job plan remote workflow has invalid immutable source provenance")
 	}
 	ref, err := source.Parse(workflow.Path)
@@ -1484,7 +1484,7 @@ func validateLockIdentity(lock ActionLock) error {
 			return fmt.Errorf("invalid workspace identity")
 		}
 	case "github":
-		if lock.Repository == "" || len(lock.Repository) > 140 || lock.Repository != strings.ToLower(lock.Repository) || lock.RequestedRef == "" || len(lock.RequestedRef) > 1024 || !utf8.ValidString(lock.RequestedRef) || hasControl(lock.RequestedRef) || !commitPattern.MatchString(lock.Commit) || lock.Path != "" && !cleanActionPath(lock.Path) {
+		if lock.Repository == "" || len(lock.Repository) > 140 || lock.Repository != strings.ToLower(lock.Repository) || lock.RequestedRef == "" || len(lock.RequestedRef) > 1024 || !utf8.ValidString(lock.RequestedRef) || hasControl(lock.RequestedRef) || !git.ValidObjectID(lock.Commit) || lock.Path != "" && !cleanActionPath(lock.Path) {
 			return fmt.Errorf("invalid GitHub identity")
 		}
 		r, err := source.Parse(lock.Repository + "@x")

--- a/internal/runtime/actions.go
+++ b/internal/runtime/actions.go
@@ -14,6 +14,7 @@ import (
 	actionintegration "github.com/buildkite/buildkite-gha/internal/action/integration"
 	"github.com/buildkite/buildkite-gha/internal/action/metadata"
 	"github.com/buildkite/buildkite-gha/internal/action/source"
+	"github.com/buildkite/buildkite-gha/internal/git"
 	"github.com/buildkite/buildkite-gha/internal/plan"
 	executionprogram "github.com/buildkite/buildkite-gha/internal/program"
 )
@@ -289,7 +290,7 @@ func (r *actionLockResolver) verifyGitHub(ctx context.Context, entry *actionLock
 	}
 	// Parsing also enforces commit-like reference syntax only structurally, so
 	// insist on a lower-case full SHA independently of RequestedRef.
-	if len(lock.Commit) != 40 || strings.Trim(lock.Commit, "0123456789abcdef") != "" {
+	if !git.ValidObjectID(lock.Commit) {
 		return metadata.Metadata{}, fmt.Errorf("GitHub action commit is not an exact lower-case SHA")
 	}
 	resolved := source.Resolved{Reference: ref, Commit: lock.Commit, SourceDigest: lock.SourceDigest}

--- a/internal/runtime/checkout.go
+++ b/internal/runtime/checkout.go
@@ -13,6 +13,7 @@ import (
 
 	actionintegration "github.com/buildkite/buildkite-gha/internal/action/integration"
 	"github.com/buildkite/buildkite-gha/internal/agentapi"
+	gitutil "github.com/buildkite/buildkite-gha/internal/git"
 	"github.com/buildkite/buildkite-gha/internal/plan"
 	"github.com/buildkite/buildkite-gha/internal/program"
 )
@@ -76,7 +77,7 @@ func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, wo
 	const adapter = "checkout adapter"
 	credentialed := job.HasCapability("provider-token-read") && r.RepositoryCredentials != nil
 	url, credentialHost, validProvider := checkoutRepositoryURL(job.Event.Provider, job.Event.Repository)
-	if !validProvider || !actionintegration.ValidCheckoutSHA(job.Event.SHA) {
+	if !validProvider || !gitutil.ValidObjectID(job.Event.SHA) {
 		return result, fmt.Errorf("%s requires a valid GitHub or Origin event repository and exact SHA; other event sources are unsupported", adapter)
 	}
 	if err := actionintegration.ValidateCheckoutInputs(commit, inputs, job.Event.Repository, job.Event.SHA); err != nil {
@@ -203,7 +204,7 @@ func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, wo
 	}
 	head, err := os.ReadFile(filepath.Join(checkoutDirectory, ".git", "HEAD"))
 	headSHA := strings.TrimSpace(string(head))
-	if err != nil || !actionintegration.ValidCheckoutSHA(headSHA) || actionintegration.ValidCheckoutSHA(checkoutTarget) && headSHA != checkoutTarget {
+	if err != nil || !gitutil.ValidObjectID(headSHA) || gitutil.ValidObjectID(checkoutTarget) && headSHA != checkoutTarget {
 		return result, fmt.Errorf("%s did not produce the requested detached revision", adapter)
 	}
 	setCheckoutOutputs(result.Outputs, commit, checkoutRefOutput(inputs, job.Event.Ref), headSHA)
@@ -471,7 +472,7 @@ func checkoutRefOutput(inputs map[string]string, eventRef string) string {
 	if ref == "" {
 		return eventRef
 	}
-	if actionintegration.ValidCheckoutSHA(ref) {
+	if gitutil.ValidObjectID(ref) {
 		return ""
 	}
 	return ref
@@ -553,7 +554,7 @@ func checkoutSelectedRevision(inputs map[string]string, sha string) (revision st
 	if ref == "" || ref == sha {
 		return sha, false
 	}
-	if actionintegration.ValidCheckoutSHA(ref) {
+	if gitutil.ValidObjectID(ref) {
 		return ref, false
 	}
 	return strings.TrimPrefix(ref, "refs/heads/"), true


### PR DESCRIPTION
## Why

Action resolution and caching, CLI event intake, compiler event validation, plan validation, and runtime checkout all identify immutable Git objects with the same lowercase 40-hex rule. Separate regexes, hex decoding, and checkout-specific helpers made that shared policy easy to change inconsistently.

Central ownership reduces cross-package policy drift and is part of PB-3178.

## What

Add `internal/git.ValidObjectID` as the repository-wide owner of Git object ID syntax. Reuse it from `internal/action/integration`, `internal/action/source`, `internal/cli`, `internal/compiler`, `internal/plan`, and `internal/runtime`, removing the package-local implementations while preserving existing errors, accepted values, and wire formats.
