### PR TITLE
Explain rejected workflow tokens and classify setup failures

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -588,7 +588,12 @@ failures (`E_RUNTIME_INTEGRITY`), so a failing test suite is not counted as a
 compatibility gap. Runtime rejections include the same blocker fields when the
 runtime can identify the rejected shell or action reference.
 Secret resolution failures use `E_SECRET_UNAVAILABLE`, making secret
-availability independently measurable.
+availability independently measurable. Workflow-token, OIDC-token, and cache
+credential acquisition failures use `E_WORKFLOW_TOKEN_UNAVAILABLE`,
+`E_OIDC_TOKEN_UNAVAILABLE`, and `E_CACHE_CREDENTIAL_UNAVAILABLE`. When one of
+these failures comes from an Agent API response, `agent_api_http_status`
+contains its numeric HTTP status. Other unclassified failures keep the
+`unknown` code and omit the status.
 
 Buildkite adds organization, pipeline, build, and job identifiers on the
 server. The client does not send workflow or event content, environment

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1302,6 +1302,11 @@ an Origin repository. Native adapters ignore upstream input defaults, so
 
 The top-level workflow's `permissions` set the scope. Token issuance needs a
 Buildkite organization feature and a pipeline setting; both are off by default.
+If either setting is off, the runtime links to the pipeline repository setting.
+If an enabled request is rejected, the runtime instead asks you to check the
+top-level permissions and the Buildkite GitHub App's access to the event
+repository. If those checks do not find the cause, contact Buildkite support
+and include the build URL shown in the error.
 
 Buildkite reads that policy from the pipeline repository at the immutable build
 commit. The workflow must be a simple `.yml` or `.yaml` file directly under

--- a/internal/cli/run_job.go
+++ b/internal/cli/run_job.go
@@ -185,6 +185,7 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 			JobToken:         os.Getenv("BUILDKITE_AGENT_ACCESS_TOKEN"),
 			OrganizationSlug: os.Getenv("BUILDKITE_ORGANIZATION_SLUG"),
 			PipelineSlug:     os.Getenv("BUILDKITE_PIPELINE_SLUG"),
+			BuildURL:         os.Getenv("BUILDKITE_BUILD_URL"),
 			ClientVersion:    clientVersion,
 		})
 		if tokenErr != nil {
@@ -308,6 +309,9 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 		if runErr != nil {
 			details.setFailurePhase(telemetry.FailurePhaseExecution)
 			details.setFailureCode(runtimeFailureCode(runErr))
+			if status, ok := gharuntime.AgentAPIHTTPStatus(runErr); ok {
+				details.setAgentAPIHTTPStatus(status)
+			}
 			setRuntimeBlocker(details, runErr)
 		}
 	}
@@ -382,6 +386,12 @@ func runtimeFailureCode(err error) telemetry.FailureCode {
 		return telemetry.FailureCodeUnsupportedFeature
 	case gharuntime.FailureClassIntegrity:
 		return telemetry.FailureCodeRuntimeIntegrity
+	case gharuntime.FailureClassWorkflowToken:
+		return telemetry.FailureCodeWorkflowToken
+	case gharuntime.FailureClassOIDCToken:
+		return telemetry.FailureCodeOIDCToken
+	case gharuntime.FailureClassCacheCredential:
+		return telemetry.FailureCodeCacheCredential
 	default:
 		return ""
 	}

--- a/internal/cli/run_job_test.go
+++ b/internal/cli/run_job_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -407,6 +408,81 @@ func TestRunJobDisabledWorkflowTokenLinksPipelineSettings(t *testing.T) {
 	}
 }
 
+func TestRunJobRejectedWorkflowTokenGuidanceAndTelemetry(t *testing.T) {
+	const (
+		jobToken     = "job-token-must-not-leak"
+		responseData = "provider-response-must-not-leak"
+		buildURL     = "https://buildkite.com/acme-inc/my-pipeline/builds/42"
+	)
+	events := make(chan telemetry.Properties, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Token "+jobToken {
+			t.Errorf("Authorization = %q", r.Header.Get("Authorization"))
+		}
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/github_workflow_access_token"):
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = io.WriteString(w, responseData)
+		case strings.HasSuffix(r.URL.Path, "/posthog/events"):
+			var received struct {
+				Properties telemetry.Properties `json:"properties"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&received); err != nil {
+				t.Errorf("decode telemetry event: %v", err)
+			}
+			events <- received.Properties
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	job := cliRunJobPlan()
+	job.Workflow.Path = ".github/workflows/ci.yml"
+	job.Event.Repository = "buildkite/buildkite-gha"
+	job.RequiredCapabilities = []string{"provider-token-write"}
+	job.GitHubToken = &plan.GitHubToken{Workflow: "ci.yml", Permissions: map[string]string{"contents": "read"}}
+	planPath, planDigest := writeCLIJobPlan(t, job)
+	setCLIJobIdentity(t, job, planDigest)
+	truePath, err := exec.LookPath("true")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BUILDKITE_AGENT_ENDPOINT", server.URL)
+	t.Setenv("BUILDKITE_AGENT_ACCESS_TOKEN", jobToken)
+	t.Setenv("BUILDKITE_GHA_AGENT", truePath)
+	t.Setenv("BUILDKITE_BUILD_URL", buildURL)
+	t.Setenv("BUILDKITE_GHA_TELEMETRY_DISABLED", "")
+
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"run-job", "--plan", planPath}, &stdout, &stderr, "dev", &cliCaptureRunner{}); code != 1 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	for _, want := range []string{"top-level permissions", "Buildkite GitHub App", "contact Buildkite support", buildURL} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Errorf("stderr = %q, want %q", stderr.String(), want)
+		}
+	}
+	for _, secret := range []string{jobToken, responseData} {
+		if strings.Contains(stderr.String(), secret) {
+			t.Errorf("stderr contains secret %q", secret)
+		}
+	}
+	event := <-events
+	if event.FailurePhase != telemetry.FailurePhaseExecution || event.FailureCode != telemetry.FailureCodeWorkflowToken || event.AgentAPIHTTPStatus != http.StatusBadRequest {
+		t.Fatalf("telemetry = %#v", event)
+	}
+	if !strings.Contains(event.ErrorMessage, "top-level permissions") || !strings.Contains(event.ErrorMessage, buildURL) {
+		t.Errorf("telemetry error message = %q", event.ErrorMessage)
+	}
+	for _, secret := range []string{jobToken, responseData} {
+		if strings.Contains(event.ErrorMessage, secret) {
+			t.Errorf("telemetry error message contains secret %q", secret)
+		}
+	}
+}
+
 func TestRunJobAnnotatesUnavailableBuildkiteSecretWithMigrationGuidance(t *testing.T) {
 	job := cliRunJobPlan()
 	job.RequiredCapabilities = []string{"secrets"}
@@ -781,6 +857,55 @@ func TestRunJobValidateHostErrorsClassifyAsUnsupported(t *testing.T) {
 	}
 	if got := runtimeFailureCode(errors.Join(err, context.Canceled)); got != telemetry.FailureCodeUnsupportedFeature {
 		t.Fatalf("runtimeFailureCode() = %q, want %q when cancellation is joined with an unrelated failure", got, telemetry.FailureCodeUnsupportedFeature)
+	}
+}
+
+func TestRuntimeFailureCodeClassifiesTokenAndCacheServices(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, "response data must not escape")
+	}))
+	defer server.Close()
+
+	githubTokens, err := gharuntime.NewAgentGitHubTokens(gharuntime.AgentGitHubTokenConfig{
+		Endpoint: server.URL, JobID: cliTestJobID, JobToken: "job-token",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, workflowErr := githubTokens.WorkflowToken(t.Context(), "buildkite/buildkite-gha", "ci.yml", map[string]string{"contents": "read"})
+	oidcTokens, err := gharuntime.NewAgentOIDCTokens(gharuntime.AgentOIDCTokenConfig{
+		Endpoint: server.URL, JobID: cliTestJobID, JobToken: "job-token",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, oidcErr := oidcTokens.OIDCToken(t.Context(), "audience")
+	cacheCredentials, err := gharuntime.NewAgentCacheCredentials(gharuntime.AgentCacheConfig{
+		Endpoint: server.URL, JobID: cliTestJobID, JobToken: "job-token", ResultsURL: server.URL,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, cacheErr := cacheCredentials.Credentials(t.Context())
+
+	for _, test := range []struct {
+		name string
+		err  error
+		want telemetry.FailureCode
+	}{
+		{name: "workflow token", err: workflowErr, want: telemetry.FailureCodeWorkflowToken},
+		{name: "OIDC token", err: oidcErr, want: telemetry.FailureCodeOIDCToken},
+		{name: "cache credential", err: cacheErr, want: telemetry.FailureCodeCacheCredential},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if test.err == nil {
+				t.Fatal("service request succeeded")
+			}
+			if got := runtimeFailureCode(test.err); got != test.want {
+				t.Fatalf("runtimeFailureCode() = %q, want %q for %v", got, test.want, test.err)
+			}
+		})
 	}
 }
 

--- a/internal/cli/telemetry.go
+++ b/internal/cli/telemetry.go
@@ -65,6 +65,7 @@ type commandTelemetryDetails struct {
 	failureMessage string
 	blocker        string
 	blockerDetail  string
+	agentAPIStatus int
 	diagnostics    []telemetry.Diagnostic
 	seen           map[telemetryDiagnosticKey]int
 	errorOutput    boundedTailBuffer
@@ -96,6 +97,12 @@ func (d *commandTelemetryDetails) setFailurePhase(phase telemetry.FailurePhase) 
 func (d *commandTelemetryDetails) setFailureCode(code telemetry.FailureCode) {
 	if d.failureCode == "" && code != "" {
 		d.failureCode = code
+	}
+}
+
+func (d *commandTelemetryDetails) setAgentAPIHTTPStatus(status int) {
+	if d.agentAPIStatus == 0 {
+		d.agentAPIStatus = status
 	}
 }
 
@@ -204,11 +211,15 @@ func (d *commandTelemetryDetails) forOutcome(outcome telemetry.Outcome) telemetr
 		FailurePhase: phase, FailureCode: code, Diagnostics: slices.Clone(d.diagnostics),
 		Blocker: d.blocker, BlockerDetail: d.blockerDetail,
 		ErrorMessage: errorMessage, ErrorMessageTruncated: errorMessageTruncated,
+		AgentAPIHTTPStatus: d.agentAPIStatus,
 	}
 }
 
 func (d *commandTelemetryDetails) telemetryDetails() telemetry.Details {
-	return telemetry.Details{FailurePhase: d.failurePhase, FailureCode: d.failureCode, Diagnostics: slices.Clone(d.diagnostics), Blocker: d.blocker, BlockerDetail: d.blockerDetail}
+	return telemetry.Details{
+		FailurePhase: d.failurePhase, FailureCode: d.failureCode, Diagnostics: slices.Clone(d.diagnostics),
+		Blocker: d.blocker, BlockerDetail: d.blockerDetail, AgentAPIHTTPStatus: d.agentAPIStatus,
+	}
 }
 
 func telemetrySeverity(level string) (telemetry.Severity, bool) {

--- a/internal/runtime/action_execution.go
+++ b/internal/runtime/action_execution.go
@@ -1261,7 +1261,7 @@ func (r Runner) resolveWorkflowToken(ctx context.Context, processor *commandProc
 	}
 	token, err := r.WorkflowToken.WorkflowToken(ctx, repository, workflow, permissions)
 	if err != nil {
-		return "", err
+		return "", markJobSetupFailure(FailureClassWorkflowToken, err)
 	}
 	if len(token) > 16<<10 || !githubInstallationTokenPattern.MatchString(token) {
 		return "", fmt.Errorf("GitHub workflow token provider returned an invalid token")

--- a/internal/runtime/cache_service.go
+++ b/internal/runtime/cache_service.go
@@ -82,7 +82,8 @@ func NewAgentCacheCredentials(config AgentCacheConfig) (*AgentCacheCredentials, 
 	}, nil
 }
 
-func (c *AgentCacheCredentials) Credentials(ctx context.Context) (CacheCredentials, error) {
+func (c *AgentCacheCredentials) Credentials(ctx context.Context) (credentials CacheCredentials, err error) {
+	defer func() { err = markJobSetupFailure(FailureClassCacheCredential, err) }()
 	if c == nil {
 		return CacheCredentials{}, fmt.Errorf("cache credentials are not configured")
 	}
@@ -148,18 +149,20 @@ func validCredentialServiceURL(u *url.URL) bool {
 }
 
 func cacheCredentialStatusError(status int) error {
+	message := ""
 	switch status {
 	case http.StatusUnauthorized, http.StatusForbidden:
-		return fmt.Errorf("cache credential request was denied")
+		message = "cache credential request was denied"
 	case http.StatusNotFound:
-		return fmt.Errorf("cache credential service is not enabled for this organization")
+		message = "cache credential service is not enabled for this organization"
 	case http.StatusUnprocessableEntity:
-		return fmt.Errorf("cache credential request rejected the current build provenance")
+		message = "cache credential request rejected the current build provenance"
 	case http.StatusTooManyRequests:
-		return fmt.Errorf("cache credential service is rate limited")
+		message = "cache credential service is rate limited"
 	default:
-		return fmt.Errorf("cache credential service returned HTTP %d", status)
+		message = fmt.Sprintf("cache credential service returned HTTP %d", status)
 	}
+	return newJobSetupHTTPFailure(FailureClassCacheCredential, status, message)
 }
 
 func isCacheServiceEnvironment(name string) bool {
@@ -225,7 +228,7 @@ func (r Runner) cacheActionEnvironment(ctx context.Context, processor *commandPr
 	}
 	credentials, err := r.Cache.Credentials(ctx)
 	if err != nil {
-		return nil, err
+		return nil, markJobSetupFailure(FailureClassCacheCredential, err)
 	}
 	resultsURL, err := normalizeCacheResultsURL(credentials.ResultsURL)
 	if err != nil {

--- a/internal/runtime/cache_service_test.go
+++ b/internal/runtime/cache_service_test.go
@@ -159,6 +159,17 @@ func TestAgentCacheCredentialsRejectsRedirectsAndUntrustedResponses(t *testing.T
 			if err == nil || !strings.Contains(err.Error(), test.want) || strings.Contains(err.Error(), secret) {
 				t.Fatalf("Credentials() error = %v, want %q without response body", err, test.want)
 			}
+			if ClassifyFailure(err) != FailureClassCacheCredential {
+				t.Fatalf("ClassifyFailure() = %q, want %q", ClassifyFailure(err), FailureClassCacheCredential)
+			}
+			status, ok := AgentAPIHTTPStatus(err)
+			if test.status >= 200 && test.status < 300 {
+				if ok || status != 0 {
+					t.Fatalf("AgentAPIHTTPStatus() = %d, %t for HTTP %d", status, ok, test.status)
+				}
+			} else if !ok || status != test.status {
+				t.Fatalf("AgentAPIHTTPStatus() = %d, %t, want %d, true", status, ok, test.status)
+			}
 		})
 	}
 
@@ -195,6 +206,10 @@ func TestAgentCacheCredentialsHonorsCancellation(t *testing.T) {
 	}
 	if _, err := provider.Credentials(ctx); !errors.Is(err, context.Canceled) {
 		t.Fatalf("Credentials() error = %v, want cancellation", err)
+	} else if ClassifyFailure(err) != FailureClassUnknown {
+		t.Fatalf("ClassifyFailure() = %q, want %q", ClassifyFailure(err), FailureClassUnknown)
+	} else if status, ok := AgentAPIHTTPStatus(err); ok || status != 0 {
+		t.Fatalf("AgentAPIHTTPStatus() = %d, %t, want 0, false", status, ok)
 	}
 }
 
@@ -681,6 +696,26 @@ fs.writeFileSync(process.env.MARKER, "executed");
 	}
 	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("strict cache action executed or marker stat failed: %v", err)
+	}
+}
+
+func TestCacheActionPreservesCredentialFailure(t *testing.T) {
+	provider := cacheCredentialProviderFunc(func(context.Context) (CacheCredentials, error) {
+		return CacheCredentials{}, cacheCredentialStatusError(http.StatusUnprocessableEntity)
+	})
+	result := newResult()
+	err := newJobRun(Runner{Cache: provider, Redactor: &testRedactor{}}).runJavaScriptPhase(
+		t.Context(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), "node",
+		javaScriptAction{Name: "cache", Main: "main.js", Cache: true}, "main.js", nil, nil, &result,
+	)
+	if err == nil || !strings.Contains(err.Error(), "current build provenance") {
+		t.Fatalf("runJavaScriptPhase() error = %v", err)
+	}
+	if ClassifyFailure(err) != FailureClassCacheCredential {
+		t.Fatalf("ClassifyFailure() = %q, want %q", ClassifyFailure(err), FailureClassCacheCredential)
+	}
+	if status, ok := AgentAPIHTTPStatus(err); !ok || status != http.StatusUnprocessableEntity {
+		t.Fatalf("AgentAPIHTTPStatus() = %d, %t, want %d, true", status, ok, http.StatusUnprocessableEntity)
 	}
 }
 

--- a/internal/runtime/failure_class.go
+++ b/internal/runtime/failure_class.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os/exec"
@@ -24,12 +25,20 @@ const (
 	// FailureClassIntegrity means a runtime integrity or cleanup verification
 	// failed.
 	FailureClassIntegrity FailureClass = "integrity"
+	// FailureClassWorkflowToken means the runtime could not acquire the job's
+	// GitHub workflow token.
+	FailureClassWorkflowToken FailureClass = "workflow_token"
+	// FailureClassOIDCToken means an action could not acquire an OIDC token.
+	FailureClassOIDCToken FailureClass = "oidc_token"
+	// FailureClassCacheCredential means the runtime could not acquire an
+	// action's cache credential.
+	FailureClassCacheCredential FailureClass = "cache_credential"
 )
 
 // ClassifyFailure reports the most specific class found in a RunJob error
-// chain. Unsupported features outrank integrity failures, which outrank step
-// process exits, so a compatibility signal is never hidden by an ordinary
-// workflow failure joined into the same error.
+// chain. Unsupported features and setup failures outrank integrity failures
+// and step process exits, so a specific runtime signal is never hidden by an
+// ordinary workflow failure joined into the same error.
 func ClassifyFailure(err error) FailureClass {
 	var unsupported *unsupportedFeatureError
 	if errors.As(err, &unsupported) {
@@ -42,6 +51,10 @@ func ClassifyFailure(err error) FailureClass {
 	if errors.As(err, &unsupportedRuntime) {
 		return FailureClassUnsupportedFeature
 	}
+	var setup *jobSetupFailure
+	if errors.As(err, &setup) {
+		return setup.class
+	}
 	if isHardJobFailure(err) {
 		return FailureClassIntegrity
 	}
@@ -50,6 +63,40 @@ func ClassifyFailure(err error) FailureClass {
 		return FailureClassStepProcessExit
 	}
 	return FailureClassUnknown
+}
+
+type jobSetupFailure struct {
+	class      FailureClass
+	httpStatus int
+	err        error
+}
+
+func (e *jobSetupFailure) Error() string { return e.err.Error() }
+func (e *jobSetupFailure) Unwrap() error { return e.err }
+
+func markJobSetupFailure(class FailureClass, err error) error {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	var marked *jobSetupFailure
+	if errors.As(err, &marked) {
+		return err
+	}
+	return &jobSetupFailure{class: class, err: err}
+}
+
+func newJobSetupHTTPFailure(class FailureClass, status int, message string) error {
+	return &jobSetupFailure{class: class, httpStatus: status, err: errors.New(message)}
+}
+
+// AgentAPIHTTPStatus returns the upstream Agent API status retained by a
+// classified runtime setup failure.
+func AgentAPIHTTPStatus(err error) (int, bool) {
+	var setup *jobSetupFailure
+	if !errors.As(err, &setup) || setup.httpStatus == 0 {
+		return 0, false
+	}
+	return setup.httpStatus, true
 }
 
 type stepProcessExitError struct {

--- a/internal/runtime/failure_class_test.go
+++ b/internal/runtime/failure_class_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"os/exec"
@@ -16,6 +17,9 @@ func TestClassifyFailurePrecedence(t *testing.T) {
 	stepExit := markStepProcessExit(fmt.Errorf("step %q: %w", "test", exit))
 	unsupported := errUnsupportedf("shell %q is unsupported in the supported runtime subset", "pwsh")
 	hard := markHardJobFailure(errors.New("owned Docker resources remain after cleanup"))
+	workflowToken := newJobSetupHTTPFailure(FailureClassWorkflowToken, 400, "workflow token rejected")
+	oidcToken := newJobSetupHTTPFailure(FailureClassOIDCToken, 403, "OIDC token denied")
+	cacheCredential := newJobSetupHTTPFailure(FailureClassCacheCredential, 422, "cache credential rejected")
 	cases := []struct {
 		name string
 		err  error
@@ -28,6 +32,10 @@ func TestClassifyFailurePrecedence(t *testing.T) {
 		{"tolerated step exit", &toleratedJobFailure{err: stepExit}, FailureClassStepProcessExit},
 		{"unsupported", unsupported, FailureClassUnsupportedFeature},
 		{"unsupported runtime", fmt.Errorf("action %q: %w", "./action", &metadata.UnsupportedRuntimeError{Runtime: "future"}), FailureClassUnsupportedFeature},
+		{"workflow token", workflowToken, FailureClassWorkflowToken},
+		{"OIDC token", oidcToken, FailureClassOIDCToken},
+		{"cache credential", cacheCredential, FailureClassCacheCredential},
+		{"setup failure outranks step exit", errors.Join(stepExit, oidcToken), FailureClassOIDCToken},
 		{"integrity", hard, FailureClassIntegrity},
 		{"integrity outranks step exit", errors.Join(stepExit, hard), FailureClassIntegrity},
 		{"unsupported outranks integrity", errors.Join(hard, unsupported), FailureClassUnsupportedFeature},
@@ -36,6 +44,25 @@ func TestClassifyFailurePrecedence(t *testing.T) {
 	for _, tc := range cases {
 		if got := ClassifyFailure(tc.err); got != tc.want {
 			t.Errorf("ClassifyFailure(%s) = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestJobSetupFailurePreservesStatusAndCancellation(t *testing.T) {
+	err := fmt.Errorf("prepare token: %w", newJobSetupHTTPFailure(FailureClassWorkflowToken, 404, "not enabled"))
+	if status, ok := AgentAPIHTTPStatus(err); !ok || status != 404 {
+		t.Fatalf("AgentAPIHTTPStatus() = %d, %t, want 404, true", status, ok)
+	}
+	if status, ok := AgentAPIHTTPStatus(errors.New("unrelated")); ok || status != 0 {
+		t.Fatalf("unrelated AgentAPIHTTPStatus() = %d, %t, want 0, false", status, ok)
+	}
+	for _, cancellation := range []error{context.Canceled, context.DeadlineExceeded} {
+		marked := markJobSetupFailure(FailureClassWorkflowToken, fmt.Errorf("request token: %w", cancellation))
+		if ClassifyFailure(marked) != FailureClassUnknown {
+			t.Errorf("cancellation classified as %q", ClassifyFailure(marked))
+		}
+		if status, ok := AgentAPIHTTPStatus(marked); ok || status != 0 {
+			t.Errorf("cancellation AgentAPIHTTPStatus() = %d, %t", status, ok)
 		}
 	}
 }

--- a/internal/runtime/github_token_service.go
+++ b/internal/runtime/github_token_service.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 
@@ -20,6 +21,7 @@ const githubTokenResponseLimit = 64 << 10
 var githubInstallationTokenPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
 var retryAfterSecondsPattern = regexp.MustCompile(`^[0-9]{1,10}$`)
 var buildkiteSlugPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
+var buildkiteBuildPathPattern = regexp.MustCompile(`^/[a-z0-9][a-z0-9-]*/[a-z0-9][a-z0-9-]*/builds/[1-9][0-9]*/?$`)
 
 // WorkflowTokenProvider mints one repository-scoped credential with the exact
 // plan-declared permissions accepted by the Buildkite backend.
@@ -42,6 +44,7 @@ type AgentGitHubTokenConfig struct {
 	JobToken         string
 	OrganizationSlug string
 	PipelineSlug     string
+	BuildURL         string
 	ClientVersion    string
 	Client           *http.Client
 }
@@ -52,6 +55,7 @@ type AgentGitHubTokens struct {
 	actionSourceURL    string
 	workflowURL        string
 	repositorySettings string
+	buildURL           string
 	agent              *agentapi.Client
 }
 
@@ -67,11 +71,13 @@ func NewAgentGitHubTokens(config AgentGitHubTokenConfig) (*AgentGitHubTokens, er
 		actionSourceURL:    agent.URL("github_action_source_access_token"),
 		workflowURL:        agent.URL("github_workflow_access_token"),
 		repositorySettings: pipelineRepositorySettingsURL(config.OrganizationSlug, config.PipelineSlug),
+		buildURL:           safeBuildkiteBuildURL(config.BuildURL),
 		agent:              agent,
 	}, nil
 }
 
-func (c *AgentGitHubTokens) WorkflowToken(ctx context.Context, repository, workflow string, permissions map[string]string) (string, error) {
+func (c *AgentGitHubTokens) WorkflowToken(ctx context.Context, repository, workflow string, permissions map[string]string) (token string, err error) {
+	defer func() { err = markJobSetupFailure(FailureClassWorkflowToken, err) }()
 	if c == nil {
 		return "", fmt.Errorf("GitHub workflow token provider is not configured")
 	}
@@ -122,7 +128,7 @@ func (c *AgentGitHubTokens) mint(ctx context.Context, mintURL, repository, workf
 	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
 		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, githubTokenResponseLimit))
-		return "", githubTokenStatusError(response.StatusCode, response.Header.Get("Retry-After"), purpose, c.repositorySettings)
+		return "", githubTokenStatusError(response.StatusCode, response.Header.Get("Retry-After"), purpose, c.repositorySettings, c.buildURL)
 	}
 	payload, err := io.ReadAll(io.LimitReader(response.Body, githubTokenResponseLimit+1))
 	if err != nil {
@@ -155,12 +161,30 @@ func pipelineRepositorySettingsURL(organization, pipeline string) string {
 	return "https://buildkite.com/" + organization + "/" + pipeline + "/settings/repository"
 }
 
-func githubTokenStatusError(status int, retryAfter, purpose, repositorySettings string) error {
+func safeBuildkiteBuildURL(value string) string {
+	u, err := url.Parse(value)
+	if err != nil || u.Scheme != "https" || u.Host != "buildkite.com" || u.User != nil || u.RawQuery != "" || u.Fragment != "" || u.RawPath != "" || !buildkiteBuildPathPattern.MatchString(u.Path) {
+		return ""
+	}
+	return u.String()
+}
+
+func githubTokenStatusError(status int, retryAfter, purpose, repositorySettings, buildURL string) error {
 	credential := "GitHub " + purpose + " token"
 	switch status {
 	case http.StatusBadRequest:
+		if purpose == "workflow" {
+			message := "GitHub workflow token request was rejected. Check the workflow's top-level permissions and confirm that the Buildkite GitHub App can access the event repository. If both are correct, contact Buildkite support and include this build's URL"
+			if buildURL != "" {
+				message += ": " + buildURL
+			}
+			return newJobSetupHTTPFailure(FailureClassWorkflowToken, status, message)
+		}
 		return fmt.Errorf("%s request was rejected", credential)
 	case http.StatusUnauthorized, http.StatusForbidden:
+		if purpose == "workflow" {
+			return newJobSetupHTTPFailure(FailureClassWorkflowToken, status, credential+" request was denied")
+		}
 		return fmt.Errorf("%s request was denied", credential)
 	case http.StatusNotFound:
 		if purpose == "workflow" {
@@ -168,16 +192,28 @@ func githubTokenStatusError(status int, retryAfter, purpose, repositorySettings 
 			if repositorySettings != "" {
 				message += ": " + repositorySettings
 			}
-			return errors.New(message)
+			return newJobSetupHTTPFailure(FailureClassWorkflowToken, status, message)
 		}
 		return fmt.Errorf("GitHub action source access tokens are not enabled for this organization")
 	case http.StatusServiceUnavailable:
 		retryAfter = strings.TrimSpace(retryAfter)
 		if retryAfterSecondsPattern.MatchString(retryAfter) {
-			return fmt.Errorf("%s service is temporarily unavailable; retry after %s seconds", credential, retryAfter)
+			message := fmt.Sprintf("%s service is temporarily unavailable; retry after %s seconds", credential, retryAfter)
+			if purpose == "workflow" {
+				return newJobSetupHTTPFailure(FailureClassWorkflowToken, status, message)
+			}
+			return errors.New(message)
 		}
-		return fmt.Errorf("%s service is temporarily unavailable", credential)
+		message := credential + " service is temporarily unavailable"
+		if purpose == "workflow" {
+			return newJobSetupHTTPFailure(FailureClassWorkflowToken, status, message)
+		}
+		return errors.New(message)
 	default:
-		return fmt.Errorf("%s service returned HTTP %d", credential, status)
+		message := fmt.Sprintf("%s service returned HTTP %d", credential, status)
+		if purpose == "workflow" {
+			return newJobSetupHTTPFailure(FailureClassWorkflowToken, status, message)
+		}
+		return errors.New(message)
 	}
 }

--- a/internal/runtime/github_token_service_test.go
+++ b/internal/runtime/github_token_service_test.go
@@ -220,6 +220,17 @@ func TestAgentGitHubTokensRejectsRedirectsAndUntrustedResponses(t *testing.T) {
 			if err == nil || !strings.Contains(err.Error(), test.want) || strings.Contains(err.Error(), secret) {
 				t.Fatalf("WorkflowToken() error = %v, want %q without response data", err, test.want)
 			}
+			if ClassifyFailure(err) != FailureClassWorkflowToken {
+				t.Fatalf("ClassifyFailure() = %q, want %q", ClassifyFailure(err), FailureClassWorkflowToken)
+			}
+			status, ok := AgentAPIHTTPStatus(err)
+			if test.status >= 200 && test.status < 300 {
+				if ok || status != 0 {
+					t.Fatalf("AgentAPIHTTPStatus() = %d, %t for HTTP %d", status, ok, test.status)
+				}
+			} else if !ok || status != test.status {
+				t.Fatalf("AgentAPIHTTPStatus() = %d, %t, want %d, true", status, ok, test.status)
+			}
 		})
 	}
 
@@ -239,6 +250,71 @@ func TestAgentGitHubTokensRejectsRedirectsAndUntrustedResponses(t *testing.T) {
 	}
 	if _, err := provider.WorkflowToken(t.Context(), "buildkite/buildkite-gha", "ci.yml", map[string]string{"contents": "read"}); err == nil || !strings.Contains(err.Error(), "HTTP 307") || redirected {
 		t.Fatalf("redirect WorkflowToken() error/redirected = %v / %v", err, redirected)
+	}
+}
+
+func TestAgentGitHubTokensRejectedWorkflowTokenGuidance(t *testing.T) {
+	const responseData = "provider response must not escape"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, responseData)
+	}))
+	defer server.Close()
+
+	for _, test := range []struct {
+		name     string
+		buildURL string
+		wantURL  bool
+	}{
+		{name: "safe build URL", buildURL: "https://buildkite.com/acme-inc/my-pipeline/builds/42", wantURL: true},
+		{name: "missing build URL"},
+		{name: "unsafe build URL", buildURL: "https://attacker.invalid/builds/job-token"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			provider, err := NewAgentGitHubTokens(AgentGitHubTokenConfig{
+				Endpoint: server.URL, JobID: testCacheJobID, JobToken: "job-token", BuildURL: test.buildURL,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = provider.WorkflowToken(t.Context(), "buildkite/buildkite-gha", "ci.yml", map[string]string{"contents": "read"})
+			if err == nil {
+				t.Fatal("WorkflowToken() succeeded")
+			}
+			message := err.Error()
+			for _, want := range []string{"top-level permissions", "Buildkite GitHub App", "event repository", "contact Buildkite support", "this build's URL"} {
+				if !strings.Contains(message, want) {
+					t.Errorf("WorkflowToken() error = %q, want %q", message, want)
+				}
+			}
+			if strings.Contains(message, "enable") || strings.Contains(message, "pipeline's repository settings") || strings.Contains(message, responseData) {
+				t.Errorf("WorkflowToken() error contains unsafe or incorrect guidance: %q", message)
+			}
+			if got := strings.Contains(message, test.buildURL) && test.buildURL != ""; got != test.wantURL {
+				t.Errorf("WorkflowToken() error contains build URL = %t, want %t: %q", got, test.wantURL, message)
+			}
+		})
+	}
+}
+
+func TestAgentGitHubTokensKeepsActionSourceFailureUnclassified(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer server.Close()
+	provider, err := NewAgentGitHubTokens(AgentGitHubTokenConfig{Endpoint: server.URL, JobID: testCacheJobID, JobToken: "job-token"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = provider.ActionSourceToken(t.Context(), "actions/checkout")
+	if err == nil || err.Error() != "GitHub action source token request was rejected" {
+		t.Fatalf("ActionSourceToken() error = %v", err)
+	}
+	if ClassifyFailure(err) != FailureClassUnknown {
+		t.Fatalf("ClassifyFailure() = %q, want %q", ClassifyFailure(err), FailureClassUnknown)
+	}
+	if status, ok := AgentAPIHTTPStatus(err); ok || status != 0 {
+		t.Fatalf("AgentAPIHTTPStatus() = %d, %t, want 0, false", status, ok)
 	}
 }
 
@@ -303,6 +379,10 @@ func TestAgentGitHubTokensHonorsCancellation(t *testing.T) {
 	}
 	if _, err := provider.WorkflowToken(ctx, "buildkite/buildkite-gha", "ci.yml", map[string]string{"contents": "read"}); !errors.Is(err, context.Canceled) {
 		t.Fatalf("WorkflowToken() error = %v, want cancellation", err)
+	} else if ClassifyFailure(err) != FailureClassUnknown {
+		t.Fatalf("ClassifyFailure() = %q, want %q", ClassifyFailure(err), FailureClassUnknown)
+	} else if status, ok := AgentAPIHTTPStatus(err); ok || status != 0 {
+		t.Fatalf("AgentAPIHTTPStatus() = %d, %t, want 0, false", status, ok)
 	}
 }
 

--- a/internal/runtime/oidc_token_service.go
+++ b/internal/runtime/oidc_token_service.go
@@ -69,7 +69,8 @@ func NewAgentOIDCTokens(config AgentOIDCTokenConfig) (*AgentOIDCTokens, error) {
 	}, nil
 }
 
-func (c *AgentOIDCTokens) OIDCToken(ctx context.Context, audience string) (string, error) {
+func (c *AgentOIDCTokens) OIDCToken(ctx context.Context, audience string) (token string, err error) {
+	defer func() { err = markJobSetupFailure(FailureClassOIDCToken, err) }()
 	if c == nil {
 		return "", fmt.Errorf("OIDC token provider is not configured")
 	}
@@ -123,13 +124,6 @@ func (c *AgentOIDCTokens) OIDCToken(ctx context.Context, audience string) (strin
 	return decoded.Token, nil
 }
 
-type oidcTokenHTTPError struct {
-	status  int
-	message string
-}
-
-func (e *oidcTokenHTTPError) Error() string { return e.message }
-
 func oidcTokenStatusError(status int) error {
 	message := ""
 	switch status {
@@ -144,7 +138,7 @@ func oidcTokenStatusError(status int) error {
 	default:
 		message = fmt.Sprintf("OIDC token service returned HTTP %d", status)
 	}
-	return &oidcTokenHTTPError{status: status, message: message}
+	return newJobSetupHTTPFailure(FailureClassOIDCToken, status, message)
 }
 
 func isIDTokenEnvironment(name string) bool {
@@ -165,7 +159,26 @@ type idTokenService struct {
 	redactor   Redactor
 	processor  *commandProcessor
 	mu         sync.RWMutex
-	authHashes map[[sha256.Size]byte]struct{}
+	authHashes map[[sha256.Size]byte]*idTokenInvocation
+}
+
+type idTokenInvocation struct {
+	mu      sync.Mutex
+	failure error
+}
+
+func (i *idTokenInvocation) recordFailure(err error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.failure == nil {
+		i.failure = err
+	}
+}
+
+func (i *idTokenInvocation) failureError() error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.failure
 }
 
 func startIDTokenService(ctx context.Context, provider OIDCTokenProvider, redactor Redactor, processor *commandProcessor) (*idTokenService, error) {
@@ -173,7 +186,7 @@ func startIDTokenService(ctx context.Context, provider OIDCTokenProvider, redact
 	if err != nil {
 		return nil, fmt.Errorf("start actions ID-token service: %w", err)
 	}
-	service := &idTokenService{listener: listener, provider: provider, redactor: redactor, processor: processor, authHashes: map[[sha256.Size]byte]struct{}{}}
+	service := &idTokenService{listener: listener, provider: provider, redactor: redactor, processor: processor, authHashes: map[[sha256.Size]byte]*idTokenInvocation{}}
 	service.server = &http.Server{
 		Handler:           service,
 		ReadHeaderTimeout: 5 * time.Second,
@@ -189,7 +202,7 @@ func (s *idTokenService) Close(parent context.Context) error {
 	return s.server.Shutdown(ctx)
 }
 
-func (s *idTokenService) actionEnvironment(ctx context.Context, baseEnv map[string]string) (map[string]string, func(), error) {
+func (s *idTokenService) actionEnvironment(ctx context.Context, baseEnv map[string]string) (map[string]string, func() error, error) {
 	secret := make([]byte, 32)
 	if _, err := rand.Read(secret); err != nil {
 		return nil, nil, fmt.Errorf("create actions ID-token request credential: %w", err)
@@ -201,12 +214,14 @@ func (s *idTokenService) actionEnvironment(ctx context.Context, baseEnv map[stri
 		return nil, nil, s.processor.scrubError(err)
 	}
 	s.mu.Lock()
-	s.authHashes[hash] = struct{}{}
+	invocation := &idTokenInvocation{}
+	s.authHashes[hash] = invocation
 	s.mu.Unlock()
-	revoke := func() {
+	revoke := func() error {
 		s.mu.Lock()
 		delete(s.authHashes, hash)
 		s.mu.Unlock()
+		return invocation.failureError()
 	}
 	env := map[string]string{
 		"ACTIONS_ID_TOKEN_REQUEST_URL":   "http://" + s.listener.Addr().String() + "/idtoken?api-version=2",
@@ -214,7 +229,7 @@ func (s *idTokenService) actionEnvironment(ctx context.Context, baseEnv map[stri
 	}
 	host, _, err := net.SplitHostPort(s.listener.Addr().String())
 	if err != nil {
-		revoke()
+		_ = revoke()
 		return nil, nil, fmt.Errorf("parse actions ID-token listener: %w", err)
 	}
 	for _, name := range []string{"NO_PROXY", "no_proxy"} {
@@ -235,8 +250,13 @@ func (s *idTokenService) ServeHTTP(w http.ResponseWriter, request *http.Request)
 	presentedHash := sha256.Sum256([]byte(presented))
 	s.mu.RLock()
 	matched := 0
-	for authHash := range s.authHashes {
-		matched |= subtle.ConstantTimeCompare(presentedHash[:], authHash[:])
+	var invocation *idTokenInvocation
+	for authHash, candidate := range s.authHashes {
+		match := subtle.ConstantTimeCompare(presentedHash[:], authHash[:])
+		matched |= match
+		if match == 1 {
+			invocation = candidate
+		}
 	}
 	s.mu.RUnlock()
 	if presented == "" || matched != 1 {
@@ -245,14 +265,15 @@ func (s *idTokenService) ServeHTTP(w http.ResponseWriter, request *http.Request)
 	}
 	token, err := s.provider.OIDCToken(request.Context(), request.URL.Query().Get("audience"))
 	if err != nil {
+		err = markJobSetupFailure(FailureClassOIDCToken, err)
 		status := http.StatusBadGateway
-		var statusErr *oidcTokenHTTPError
-		if errors.As(err, &statusErr) {
-			switch statusErr.status {
+		if upstreamStatus, ok := AgentAPIHTTPStatus(err); ok {
+			switch upstreamStatus {
 			case http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound, http.StatusUnprocessableEntity:
-				status = statusErr.status
+				status = upstreamStatus
 			}
 		}
+		invocation.recordFailure(err)
 		http.Error(w, "could not mint actions ID token", status)
 		return
 	}

--- a/internal/runtime/oidc_token_service_test.go
+++ b/internal/runtime/oidc_token_service_test.go
@@ -88,6 +88,7 @@ func TestAgentOIDCTokensRejectsAuthFailuresAndMalformedResponses(t *testing.T) {
 		body   string
 		want   string
 	}{
+		{"rejected", http.StatusBadRequest, secret, "rejected"},
 		{"unauthorized", http.StatusUnauthorized, secret, "denied"},
 		{"forbidden", http.StatusForbidden, secret, "denied"},
 		{"malformed", http.StatusOK, `{"token":`, "decode"},
@@ -110,7 +111,39 @@ func TestAgentOIDCTokensRejectsAuthFailuresAndMalformedResponses(t *testing.T) {
 			if err == nil || !strings.Contains(err.Error(), test.want) || strings.Contains(err.Error(), secret) {
 				t.Fatalf("OIDCToken() error = %v, want %q without response body", err, test.want)
 			}
+			if ClassifyFailure(err) != FailureClassOIDCToken {
+				t.Fatalf("ClassifyFailure() = %q, want %q", ClassifyFailure(err), FailureClassOIDCToken)
+			}
+			status, ok := AgentAPIHTTPStatus(err)
+			if test.status >= 200 && test.status < 300 {
+				if ok || status != 0 {
+					t.Fatalf("AgentAPIHTTPStatus() = %d, %t for HTTP %d", status, ok, test.status)
+				}
+			} else if !ok || status != test.status {
+				t.Fatalf("AgentAPIHTTPStatus() = %d, %t, want %d, true", status, ok, test.status)
+			}
 		})
+	}
+}
+
+func TestAgentOIDCTokensHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	provider, err := NewAgentOIDCTokens(AgentOIDCTokenConfig{
+		Endpoint: "https://agent.invalid/v3", JobID: testCacheJobID, JobToken: "job-token",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = provider.OIDCToken(ctx, "audience")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("OIDCToken() error = %v, want cancellation", err)
+	}
+	if ClassifyFailure(err) != FailureClassUnknown {
+		t.Fatalf("ClassifyFailure() = %q, want %q", ClassifyFailure(err), FailureClassUnknown)
+	}
+	if status, ok := AgentAPIHTTPStatus(err); ok || status != 0 {
+		t.Fatalf("AgentAPIHTTPStatus() = %d, %t, want 0, false", status, ok)
 	}
 }
 
@@ -145,7 +178,7 @@ func TestIDTokenServiceWireContract(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer revoke()
+	defer func() { _ = revoke() }()
 	unauthorized, err := http.Get(env["ACTIONS_ID_TOKEN_REQUEST_URL"] + "&audience=denied")
 	if err != nil {
 		t.Fatal(err)
@@ -191,7 +224,6 @@ func TestIDTokenServicePreservesPermanentMintFailureStatus(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer revoke()
 			request, err := http.NewRequest(http.MethodGet, env["ACTIONS_ID_TOKEN_REQUEST_URL"], nil)
 			if err != nil {
 				t.Fatal(err)
@@ -204,6 +236,13 @@ func TestIDTokenServicePreservesPermanentMintFailureStatus(t *testing.T) {
 			_ = response.Body.Close()
 			if response.StatusCode != status || len(provider.audiences) != 1 {
 				t.Fatalf("request = HTTP %d with %d mint calls, want HTTP %d with one call", response.StatusCode, len(provider.audiences), status)
+			}
+			failure := revoke()
+			if ClassifyFailure(failure) != FailureClassOIDCToken {
+				t.Fatalf("ClassifyFailure() = %q, want %q", ClassifyFailure(failure), FailureClassOIDCToken)
+			}
+			if upstreamStatus, ok := AgentAPIHTTPStatus(failure); !ok || upstreamStatus != status {
+				t.Fatalf("AgentAPIHTTPStatus() = %d, %t, want %d, true", upstreamStatus, ok, status)
 			}
 		})
 	}
@@ -287,6 +326,37 @@ if (process.env.no_proxy !== "lower.example,127.0.0.1") throw new Error("no_prox
 	}
 	if string(contents) != provider.token || len(provider.audiences) != 1 || provider.audiences[0] != "sts.amazonaws.com" {
 		t.Fatalf("token/audiences = %q / %#v", contents, provider.audiences)
+	}
+}
+
+func TestNodeActionPreservesOIDCTokenFailure(t *testing.T) {
+	node := requireNode24(t)
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/oidc-failure.yml"
+	actionPath := ".github/actions/oidc-failure"
+	writeFixtureFile(t, workspace, workflowPath, "name: OIDC failure\n")
+	writeFixtureFile(t, workspace, actionPath+"/action.yml", "name: OIDC failure\nruns:\n  using: node24\n  main: main.js\n")
+	writeOIDCUtilsContractShim(t, workspace, actionPath)
+	writeFixtureFile(t, workspace, actionPath+"/main.js", `
+const core = require("@actions/core");
+(async () => await core.getIDToken("sts.amazonaws.com"))().catch(error => { console.error(error); process.exitCode = 1; });
+`)
+	lockID := "a-0123456789abcdef"
+	job := runtimePlan(t, workspace, workflowPath, []plan.Step{{
+		ID: "oidc", Kind: "uses", Uses: "./" + actionPath, Action: &plan.ActionSelector{Lock: lockID},
+	}})
+	job.IDTokenPermission = "write"
+	job.Actions = []plan.ActionLock{{ID: lockID, Source: "workspace", Path: actionPath, SourceDigest: digestTree(t, filepath.Join(workspace, actionPath))}}
+	provider := &testOIDCTokenProvider{err: oidcTokenStatusError(http.StatusForbidden)}
+	result, err := (Runner{Node24: node, OIDCToken: provider, Redactor: &testRedactor{}}).runTestJob(t.Context(), job, workspace)
+	if err == nil || result.Conclusion != "failure" {
+		t.Fatalf("RunJob() = %#v, %v", result, err)
+	}
+	if ClassifyFailure(err) != FailureClassOIDCToken {
+		t.Fatalf("ClassifyFailure() = %q, want %q for %v", ClassifyFailure(err), FailureClassOIDCToken, err)
+	}
+	if status, ok := AgentAPIHTTPStatus(err); !ok || status != http.StatusForbidden {
+		t.Fatalf("AgentAPIHTTPStatus() = %d, %t, want %d, true", status, ok, http.StatusForbidden)
 	}
 }
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -652,7 +652,7 @@ func (w *limitedWriter) Write(p []byte) (int, error) {
 	return w.writer.Write(p)
 }
 
-func (r *jobRun) runJavaScriptPhase(ctx context.Context, processor *commandProcessor, workspace, node string, action javaScriptAction, entry string, stateEnv, stateOut map[string]string, result *Result) error {
+func (r *jobRun) runJavaScriptPhase(ctx context.Context, processor *commandProcessor, workspace, node string, action javaScriptAction, entry string, stateEnv, stateOut map[string]string, result *Result) (runErr error) {
 	env := mergeStringMaps(result.Env, action.Env, actionInputEnv(action.Inputs))
 	if path, ok := result.Env["PATH"]; ok {
 		env["PATH"] = path
@@ -685,11 +685,16 @@ func (r *jobRun) runJavaScriptPhase(ctx context.Context, processor *commandProce
 		cacheToken = cacheEnv["ACTIONS_RUNTIME_TOKEN"]
 	}
 	if r.idTokenService != nil && r.jobContainer == nil {
-		idTokenEnv, revoke, err := r.idTokenService.actionEnvironment(ctx, env)
+		idTokenEnv, finish, err := r.idTokenService.actionEnvironment(ctx, env)
 		if err != nil {
 			return fmt.Errorf("configure actions ID-token service: %w", err)
 		}
-		defer revoke()
+		defer func() {
+			failure := finish()
+			if runErr != nil {
+				runErr = errors.Join(runErr, failure)
+			}
+		}()
 		env = mergeStringMaps(env, idTokenEnv)
 	}
 	entrypoint := filepath.Join(action.Path, entry)

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -87,6 +87,9 @@ const (
 	FailureCodeUnsupportedFeature FailureCode = "E_UNSUPPORTED_FEATURE"
 	FailureCodeRuntimeIntegrity   FailureCode = "E_RUNTIME_INTEGRITY"
 	FailureCodeSecretUnavailable  FailureCode = "E_SECRET_UNAVAILABLE"
+	FailureCodeWorkflowToken      FailureCode = "E_WORKFLOW_TOKEN_UNAVAILABLE"
+	FailureCodeOIDCToken          FailureCode = "E_OIDC_TOKEN_UNAVAILABLE"
+	FailureCodeCacheCredential    FailureCode = "E_CACHE_CREDENTIAL_UNAVAILABLE"
 )
 
 type Severity string
@@ -111,6 +114,7 @@ type Details struct {
 	Diagnostics           []Diagnostic
 	Blocker               string
 	BlockerDetail         string
+	AgentAPIHTTPStatus    int
 }
 
 type Properties struct {
@@ -125,6 +129,7 @@ type Properties struct {
 	Diagnostics           []Diagnostic `json:"diagnostics,omitempty"`
 	Blocker               string       `json:"blocker,omitempty"`
 	BlockerDetail         string       `json:"blocker_detail,omitempty"`
+	AgentAPIHTTPStatus    int          `json:"agent_api_http_status,omitempty"`
 }
 
 type Config struct {
@@ -205,6 +210,9 @@ func (c *Client) EmitContext(ctx context.Context, command Command, outcome Outco
 	if details.FailureCode != "" && !validFailureCode(details.FailureCode) {
 		return fmt.Errorf("invalid telemetry failure code")
 	}
+	if details.AgentAPIHTTPStatus != 0 && (details.AgentAPIHTTPStatus < 100 || details.AgentAPIHTTPStatus > 599) {
+		return fmt.Errorf("invalid telemetry Agent API HTTP status")
+	}
 	diagnostics, err := boundedDiagnostics(details.Diagnostics)
 	if err != nil {
 		return err
@@ -230,7 +238,7 @@ func (c *Client) EmitContext(ctx context.Context, command Command, outcome Outco
 			Command: command, Outcome: outcome, ClientVersion: c.clientVersion, DurationMS: durationMS,
 			FailurePhase: details.FailurePhase, FailureCode: details.FailureCode,
 			ErrorMessage: errorMessage, ErrorMessageTruncated: errorMessageTruncated, Diagnostics: diagnostics,
-			Blocker: blocker, BlockerDetail: blockerDetail,
+			Blocker: blocker, BlockerDetail: blockerDetail, AgentAPIHTTPStatus: details.AgentAPIHTTPStatus,
 		},
 	})
 	if err != nil {
@@ -274,7 +282,8 @@ func validFailureCode(code FailureCode) bool {
 		FailureCodeMatrixInvalid, FailureCodeExpressionInvalid, FailureCodeActionDiscovery,
 		FailureCodeActionResolution, FailureCodePlanConstruction, FailureCodePipelineGeneration,
 		FailureCodeEnvironment, FailureCodeProfile, FailureCodeStepProcessExit,
-		FailureCodeUnsupportedFeature, FailureCodeRuntimeIntegrity, FailureCodeSecretUnavailable:
+		FailureCodeUnsupportedFeature, FailureCodeRuntimeIntegrity, FailureCodeSecretUnavailable,
+		FailureCodeWorkflowToken, FailureCodeOIDCToken, FailureCodeCacheCredential:
 		return true
 	default:
 		return false

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -50,6 +50,7 @@ func TestClientEmitsCommandCompletedEvent(t *testing.T) {
 	if err := client.Emit(CommandRunJob, OutcomeFailure, duration, Details{
 		FailurePhase:          FailurePhaseParsing,
 		FailureCode:           FailureCodeWorkflowSyntax,
+		AgentAPIHTTPStatus:    http.StatusUnprocessableEntity,
 		ErrorMessage:          "  buildkite-gha: run-job:\ninvalid workflow\tvalue  ",
 		ErrorMessageTruncated: true,
 		Blocker:               "shell",
@@ -67,7 +68,8 @@ func TestClientEmitsCommandCompletedEvent(t *testing.T) {
 	want := Properties{
 		Command: CommandRunJob, Outcome: OutcomeFailure, ClientVersion: "1.2.3", DurationMS: 1234,
 		FailurePhase: FailurePhaseParsing, FailureCode: FailureCodeWorkflowSyntax,
-		ErrorMessage: "buildkite-gha: run-job: invalid workflow value", ErrorMessageTruncated: true,
+		AgentAPIHTTPStatus: http.StatusUnprocessableEntity,
+		ErrorMessage:       "buildkite-gha: run-job: invalid workflow value", ErrorMessageTruncated: true,
 		Blocker: "shell", BlockerDetail: "pwsh",
 		Diagnostics: []Diagnostic{{
 			Code: string(FailureCodeExpressionInvalid), Severity: SeverityError,
@@ -224,6 +226,11 @@ func TestPropertiesAreBounded(t *testing.T) {
 	if err := client.Emit(CommandRunJob, OutcomeFailure, 0, Details{FailurePhase: FailurePhaseUnknown, FailureCode: FailureCode("arbitrary")}); err == nil {
 		t.Fatal("Emit() accepted an unknown failure code")
 	}
+	for _, status := range []int{-1, 99, 600} {
+		if err := client.Emit(CommandRunJob, OutcomeFailure, 0, Details{AgentAPIHTTPStatus: status}); err == nil {
+			t.Errorf("Emit() accepted Agent API HTTP status %d", status)
+		}
+	}
 }
 
 func TestErrorMessageIsNormalizedAndUTF8Bounded(t *testing.T) {
@@ -247,7 +254,10 @@ func TestErrorMessageIsNormalizedAndUTF8Bounded(t *testing.T) {
 }
 
 func TestRuntimeClassificationCodesAreFailureCodesOnly(t *testing.T) {
-	for _, code := range []FailureCode{FailureCodeStepProcessExit, FailureCodeUnsupportedFeature, FailureCodeRuntimeIntegrity, FailureCodeSecretUnavailable} {
+	for _, code := range []FailureCode{
+		FailureCodeStepProcessExit, FailureCodeUnsupportedFeature, FailureCodeRuntimeIntegrity, FailureCodeSecretUnavailable,
+		FailureCodeWorkflowToken, FailureCodeOIDCToken, FailureCodeCacheCredential,
+	} {
 		if !validFailureCode(code) {
 			t.Errorf("validFailureCode(%q) = false", code)
 		}


### PR DESCRIPTION
## Why

A rejected workflow-token request currently reports only:

```
GitHub workflow token request was rejected
```

HTTP 400 means token enablement succeeded but permissions, workflow policy, build provenance, or GitHub App repository access may still reject the request. The same failure reaches command telemetry as `failure_code: unknown`, without the Agent API status needed to distinguish it from the existing HTTP 404 enablement gate.

## What

HTTP 400 errors now ask users to check top-level workflow permissions and Buildkite GitHub App access to the event repository, then contact Buildkite support with the sanitized build URL. HTTP 404 keeps the pipeline repository-setting guidance. Provider response bodies remain private.

Workflow-token, OIDC-token, and cache-credential acquisition failures now carry stable telemetry codes and an optional numeric `agent_api_http_status`. Cancellation, action-source-token errors, unrelated failures, and the existing `E_SECRET_UNAVAILABLE` classification keep their current behavior.

Fixes [PB-3172](https://linear.app/buildkite/issue/PB-3172/bugfix-rejected-workflow-token-annotation-names-no-cause-and-no) and [PB-3173](https://linear.app/buildkite/issue/PB-3173/classify-job-setup-failures-in-telemetry).
