### PR TITLE
PB-2902 Tell users which hosted queue a runner label needs

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -602,8 +602,25 @@ declares that the selector runs on Linux x86-64, except for the known macOS
 labels, which select Darwin arm64 and reject images. For every other selector,
 the job-scoped Agent API owns compatibility and returns the complete queue,
 platform, and immutable Linux image. The importer applies that target verbatim
-and publishes returned fallback warnings as annotations. The server rejects
-selectors that require an incompatible operating system or architecture.
+and publishes returned fallback warnings as annotations.
+
+When the Agent API rejects a selector, the importer reports the server's
+reason at the job's `runs-on` in the workflow diagnostics annotation instead
+of falling back to a built-in preset, so a cluster without the expected hosted
+queue fails before pipeline upload with the cluster and queue named:
+
+| Rejection | Meaning |
+| --- | --- |
+| `missing_queue` | The labels are compatible, but the job's cluster has none of the hosted queues they need. Create the named queue or configure an explicit runner mapping. |
+| `incompatible_labels` | The labels require an operating system or architecture hosted agents do not provide. |
+| `no_cluster` | The job is not in a cluster, so no hosted queue can be selected. |
+
+Windows labels keep the local Windows guidance. Unknown rejection codes render
+the server message with generic mapping guidance. Explicit mappings are not
+checked against the cluster yet.
+
+If the Agent API cannot be reached, the importer warns on stderr, adds a
+warning annotation, and falls back to the built-in presets.
 
 Explicit mappings can also attach one [Buildkite Hosted cache
 volume](cli.md#configure-generated-job-cache-volumes) to generated jobs. This

--- a/internal/cli/cli_test_support_test.go
+++ b/internal/cli/cli_test_support_test.go
@@ -25,8 +25,11 @@ const (
 )
 
 func TestMain(m *testing.M) {
-	_ = os.Unsetenv("BUILDKITE")
-	_ = os.Unsetenv("BUILDKITE_JOB_ID")
+	// Ordinary CLI tests must never reach the ambient Agent API that a
+	// Buildkite job inherits; tests that need it set these explicitly.
+	for _, name := range []string{"BUILDKITE", "BUILDKITE_JOB_ID", "BUILDKITE_AGENT_ENDPOINT", "BUILDKITE_AGENT_ACCESS_TOKEN"} {
+		_ = os.Unsetenv(name)
+	}
 	os.Exit(m.Run())
 }
 

--- a/internal/cli/environments_test.go
+++ b/internal/cli/environments_test.go
@@ -97,7 +97,8 @@ func TestRunCompileResolvesEnvironmentsThroughAgent(t *testing.T) {
 }
 
 // agentEnvironmentsStub serves the Agent API endpoints upload contacts:
-// runner resolution, which reports every requirement unmapped;
+// runner resolution, which maps every requirement to the hosted Linux queue
+// (a server rejection would fail the job before environments are resolved);
 // github-actions/variables, which is absent (404); and
 // github-actions/environments, which rejects requests without the job token,
 // counts resolution requests, and answers each requested environment with a
@@ -127,7 +128,7 @@ func agentStub(t *testing.T, jobToken string, status int, variables http.Handler
 			}
 			resolutions := make([]map[string]any, len(body.Requirements))
 			for i, requirement := range body.Requirements {
-				resolutions[i] = map[string]any{"id": requirement.ID, "error": map[string]string{"code": "unmapped_labels", "message": "No compatible runner is configured."}}
+				resolutions[i] = map[string]any{"id": requirement.ID, "target": map[string]string{"queue": "linux-medium", "platform": "linux/amd64", "image": defaultNobleRunnerImage}}
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{"resolutions": resolutions})
 			return

--- a/internal/cli/hosted.go
+++ b/internal/cli/hosted.go
@@ -178,9 +178,10 @@ func hostedOptions(groupLabel string, configuredTargets map[string]compiler.Runn
 	return options
 }
 
-func applyRunnerSelectors(options *compiler.Options, selectors []compiler.RunnerSelector) {
-	options.Runners.Selectors = selectors
-	for _, selector := range selectors {
+func applyRunnerResolution(options *compiler.Options, resolution agentRunnerResolution) {
+	options.Runners.Selectors = resolution.selectors
+	options.Runners.Rejections = resolution.rejections
+	for _, selector := range resolution.selectors {
 		if selector.Target.Queue != "" && !slices.Contains(options.Runners.UntrustedQueues, selector.Target.Queue) {
 			options.Runners.UntrustedQueues = append(options.Runners.UntrustedQueues, selector.Target.Queue)
 		}
@@ -204,16 +205,16 @@ func compileHosted(ctx context.Context, workflowPath string, workflowSource, eve
 }
 
 func compileHostedWithActionCache(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runtimeDistributions map[compiler.Platform]string, actionCacheDir string, sharedActionSource compiler.ActionSource, actionAuthentication *actionSourceAuthentication) (hostedCompilation, error) {
-	return compileHostedNamespacedWithActionCache(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, groupLabel, configuredTargets, nil, runtimeDistributions, "", nil, actionCacheDir, sharedActionSource, actionAuthentication, nil, compiler.VariableSources{})
+	return compileHostedNamespacedWithActionCache(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, groupLabel, configuredTargets, agentRunnerResolution{}, runtimeDistributions, "", nil, actionCacheDir, sharedActionSource, actionAuthentication, nil, compiler.VariableSources{})
 }
 
 func compileHostedNamespaced(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runtimeDistributions map[compiler.Platform]string, stepKeyNamespace string, oidc *plan.OIDCConfiguration, actionAuthentication *actionSourceAuthentication) (hostedCompilation, error) {
-	return compileHostedNamespacedWithActionCache(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, groupLabel, configuredTargets, nil, runtimeDistributions, stepKeyNamespace, oidc, "", nil, actionAuthentication, nil, compiler.VariableSources{})
+	return compileHostedNamespacedWithActionCache(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, groupLabel, configuredTargets, agentRunnerResolution{}, runtimeDistributions, stepKeyNamespace, oidc, "", nil, actionAuthentication, nil, compiler.VariableSources{})
 }
 
-func compileHostedNamespacedWithActionCache(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runnerSelectors []compiler.RunnerSelector, runtimeDistributions map[compiler.Platform]string, stepKeyNamespace string, oidc *plan.OIDCConfiguration, actionCacheDir string, sharedActionSource compiler.ActionSource, actionAuthentication *actionSourceAuthentication, environmentSource compiler.EnvironmentSource, vars compiler.VariableSources) (hostedCompilation, error) {
+func compileHostedNamespacedWithActionCache(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runnerResolution agentRunnerResolution, runtimeDistributions map[compiler.Platform]string, stepKeyNamespace string, oidc *plan.OIDCConfiguration, actionCacheDir string, sharedActionSource compiler.ActionSource, actionAuthentication *actionSourceAuthentication, environmentSource compiler.EnvironmentSource, vars compiler.VariableSources) (hostedCompilation, error) {
 	options := hostedOptions(groupLabel, configuredTargets, runtimeDistributions)
-	applyRunnerSelectors(&options, runnerSelectors)
+	applyRunnerResolution(&options, runnerResolution)
 	options.StepKeyNamespace = stepKeyNamespace
 	options.OIDC = oidc
 	options.EnvironmentSource = environmentSource

--- a/internal/cli/plugin_test.go
+++ b/internal/cli/plugin_test.go
@@ -55,7 +55,7 @@ func TestPluginTelemetryReportsUnprovenActionRuntime(t *testing.T) {
 			}
 			resolutions := make([]map[string]any, len(body.Requirements))
 			for i, requirement := range body.Requirements {
-				resolutions[i] = map[string]any{"id": requirement.ID, "error": map[string]string{"code": "unmapped_labels", "message": "No compatible runner is configured."}}
+				resolutions[i] = map[string]any{"id": requirement.ID, "target": map[string]string{"queue": "linux-medium", "platform": "linux/amd64", "image": defaultNobleRunnerImage}}
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{"resolutions": resolutions})
 			return

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -225,6 +225,24 @@ func (o processingOutput) annotateRunnerResolutionWarnings(parent context.Contex
 	}
 }
 
+// annotateRunnerResolutionUnavailable reports that the Agent API could not
+// resolve runner labels, so this import used the built-in presets. Those
+// presets can target a queue the cluster lacks, and the resulting pipeline
+// upload failure would otherwise have no visible cause.
+func (o processingOutput) annotateRunnerResolutionUnavailable(parent context.Context, cause error) {
+	if o.annotationJob == "" || cause == nil {
+		return
+	}
+	body := "#### Runner resolution was unavailable\n\n" +
+		"Buildkite could not resolve <code>runs-on</code> labels against this cluster's hosted queues (" + annotationHTML(cause.Error()) + "). " +
+		"This build used the built-in runner presets instead. If a job fails to upload because its queue does not exist, retry the build or configure an explicit runner mapping.\n"
+	ctx, cancel := context.WithTimeout(parent, processingAnnotationTimeout)
+	defer cancel()
+	if err := o.agent.AnnotateJob(ctx, o.annotationJob, runnerResolutionContext, "warning", body); err != nil {
+		_, _ = fmt.Fprintf(o.stderr, "buildkite-gha: %s: warning: runner resolution annotation: %v\n", o.command, err)
+	}
+}
+
 func skippedWorkflowsAnnotation(event string, allSkipped bool, workflows []skippedWorkflow, buildURL string) string {
 	if len(workflows) == 0 || buildURL == "" {
 		return ""

--- a/internal/cli/runner_resolution.go
+++ b/internal/cli/runner_resolution.go
@@ -11,12 +11,25 @@ import (
 	gharuntime "github.com/buildkite/buildkite-gha/internal/runtime"
 )
 
-func suggestedRunnerTargets(ctx context.Context, reports []compiler.Report, configuredTargets map[string]compiler.RunnerTarget, clientVersion string) ([]compiler.RunnerSelector, []gharuntime.RunnerWarning, error) {
+// agentRunnerResolution is the Agent API's verdict on every runs-on selector
+// that no explicit runners mapping covers. Selectors and rejections both
+// override the built-in presets; warnings accompany heuristic selectors.
+type agentRunnerResolution struct {
+	selectors  []compiler.RunnerSelector
+	rejections []compiler.RunnerRejection
+	warnings   []gharuntime.RunnerWarning
+}
+
+func (r agentRunnerResolution) empty() bool {
+	return len(r.selectors) == 0 && len(r.rejections) == 0
+}
+
+func suggestedRunnerTargets(ctx context.Context, reports []compiler.Report, configuredTargets map[string]compiler.RunnerTarget, clientVersion string) (agentRunnerResolution, error) {
 	endpoint := os.Getenv("BUILDKITE_AGENT_ENDPOINT")
 	jobID := os.Getenv("BUILDKITE_JOB_ID")
 	jobToken := os.Getenv("BUILDKITE_AGENT_ACCESS_TOKEN")
 	if endpoint == "" || jobID == "" || jobToken == "" {
-		return nil, nil, nil
+		return agentRunnerResolution{}, nil
 	}
 	resolver, err := gharuntime.NewAgentRunnerResolver(gharuntime.AgentRunnerResolverConfig{
 		Endpoint:      endpoint,
@@ -25,52 +38,66 @@ func suggestedRunnerTargets(ctx context.Context, reports []compiler.Report, conf
 		ClientVersion: clientVersion,
 	})
 	if err != nil {
-		return nil, nil, err
+		return agentRunnerResolution{}, err
 	}
 	requirements := uniqueRunnerRequirements(reports, configuredTargets)
-	suggestions, err := resolver.Resolve(ctx, requirements)
+	suggestions, rejections, err := resolver.Resolve(ctx, requirements)
 	if err != nil {
-		return nil, nil, err
+		return agentRunnerResolution{}, err
 	}
 	byID := make(map[string]gharuntime.RunnerRequirement, len(requirements))
 	for _, requirement := range requirements {
 		byID[requirement.ID] = requirement
 	}
-	selectors := make([]compiler.RunnerSelector, 0, len(suggestions))
-	var warnings []gharuntime.RunnerWarning
+	resolution := agentRunnerResolution{selectors: make([]compiler.RunnerSelector, 0, len(suggestions))}
 	for _, suggestion := range suggestions {
-		requirement := byID[suggestion.ID]
-		labels := make([]string, len(requirement.Labels))
-		seenLabels := make(map[string]bool, len(requirement.Labels))
-		validLabels := len(requirement.Labels) != 0
-		for i, label := range requirement.Labels {
-			labels[i] = strings.ToLower(strings.TrimSpace(label))
-			if labels[i] == "" || seenLabels[labels[i]] {
-				validLabels = false
-			}
-			seenLabels[labels[i]] = true
-		}
-		if !validLabels {
+		labels, ok := normalizedRunnerLabels(byID[suggestion.ID].Labels)
+		if !ok {
 			continue
 		}
 		if !runnerQueuePattern.MatchString(suggestion.Queue) {
-			return nil, nil, fmt.Errorf("runner resolution response contains an invalid target")
+			return agentRunnerResolution{}, fmt.Errorf("runner resolution response contains an invalid target")
 		}
 		platform, err := compiler.ParsePlatform(suggestion.Platform)
 		if err != nil {
-			return nil, nil, fmt.Errorf("runner resolution response contains an invalid target: %w", err)
+			return agentRunnerResolution{}, fmt.Errorf("runner resolution response contains an invalid target: %w", err)
 		}
 		if platform == compiler.PlatformLinuxAMD64 && !runnerImagePattern.MatchString(suggestion.Image) {
-			return nil, nil, fmt.Errorf("runner resolution response contains an invalid target image")
+			return agentRunnerResolution{}, fmt.Errorf("runner resolution response contains an invalid target image")
 		}
 		if platform == compiler.PlatformDarwinARM64 && suggestion.Image != "" {
-			return nil, nil, fmt.Errorf("runner resolution response contains an invalid target image")
+			return agentRunnerResolution{}, fmt.Errorf("runner resolution response contains an invalid target image")
 		}
 		target := compiler.RunnerTarget{Queue: suggestion.Queue, Platform: platform, Image: suggestion.Image}
-		selectors = append(selectors, compiler.RunnerSelector{Labels: labels, Target: target})
-		warnings = append(warnings, suggestion.Warnings...)
+		resolution.selectors = append(resolution.selectors, compiler.RunnerSelector{Labels: labels, Target: target})
+		resolution.warnings = append(resolution.warnings, suggestion.Warnings...)
 	}
-	return selectors, warnings, nil
+	for _, rejection := range rejections {
+		labels, ok := normalizedRunnerLabels(byID[rejection.ID].Labels)
+		if !ok {
+			continue
+		}
+		resolution.rejections = append(resolution.rejections, compiler.RunnerRejection{Labels: labels, Code: rejection.Code, Message: rejection.Message})
+	}
+	return resolution, nil
+}
+
+// normalizedRunnerLabels lowercases one selector and reports whether it is a
+// well-formed non-empty set of distinct labels.
+func normalizedRunnerLabels(raw []string) ([]string, bool) {
+	if len(raw) == 0 {
+		return nil, false
+	}
+	labels := make([]string, len(raw))
+	seen := make(map[string]bool, len(raw))
+	for i, label := range raw {
+		labels[i] = strings.ToLower(strings.TrimSpace(label))
+		if labels[i] == "" || seen[labels[i]] {
+			return nil, false
+		}
+		seen[labels[i]] = true
+	}
+	return labels, true
 }
 
 func uniqueRunnerRequirements(reports []compiler.Report, configuredTargets map[string]compiler.RunnerTarget) []gharuntime.RunnerRequirement {

--- a/internal/cli/upload.go
+++ b/internal/cli/upload.go
@@ -283,28 +283,32 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 		validationOptions.Vars = vars
 		validations[i], validationErrs[i] = compiler.ValidateEventWithOptionsContext(ctx, input.Path, input.Source, effectiveEvent.Source, validationOptions)
 	}
-	runnerSelectors, runnerWarnings, err := suggestedRunnerTargets(ctx, validations, uploadArguments.runnerTargets, uploadArguments.clientVersion)
+	runnerResolution, err := suggestedRunnerTargets(ctx, validations, uploadArguments.runnerTargets, uploadArguments.clientVersion)
 	if err != nil {
 		if ctx.Err() != nil {
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", ctx.Err())
 			return 1
 		}
+		// The built-in presets keep the import moving, but they may target a
+		// queue this cluster lacks, so the degradation must be visible.
+		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: warning: runner resolution unavailable (%v); using built-in runner presets\n", err)
+		out.annotateRunnerResolutionUnavailable(ctx, err)
 	}
-	if len(runnerSelectors) != 0 {
-		uploadArguments.runnerSelectors = runnerSelectors
+	if !runnerResolution.empty() {
+		uploadArguments.runnerResolution = runnerResolution
 		for i, input := range workflows {
 			if !input.Applicable || processingReportHasErrors(processingReports[i]) {
 				continue
 			}
 			validationOptions := hostedOptions("", uploadArguments.runnerTargets, nil)
-			applyRunnerSelectors(&validationOptions, runnerSelectors)
+			applyRunnerResolution(&validationOptions, runnerResolution)
 			validationOptions.StepKeyNamespace = input.StepKeyNamespace
 			validationOptions.RepositorySource = repositorySource
 			validationOptions.Vars = vars
 			validations[i], validationErrs[i] = compiler.ValidateEventWithOptionsContext(ctx, input.Path, input.Source, effectiveEvent.Source, validationOptions)
 		}
 	}
-	out.annotateRunnerResolutionWarnings(ctx, runnerWarnings)
+	out.annotateRunnerResolutionWarnings(ctx, runnerResolution.warnings)
 	for i, input := range workflows {
 		if !input.Applicable || processingReportHasErrors(processingReports[i]) {
 			continue
@@ -333,7 +337,7 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 		if !input.Applicable || processingReportHasErrors(processingReports[i]) {
 			continue
 		}
-		platforms, platformErr := requiredRuntimePlatforms(ctx, input.Path, input.Source, effectiveEvent.Source, "", uploadArguments.runnerTargets, uploadArguments.runnerSelectors, repositorySource, uploadArguments.environmentSource, vars)
+		platforms, platformErr := requiredRuntimePlatforms(ctx, input.Path, input.Source, effectiveEvent.Source, "", uploadArguments.runnerTargets, uploadArguments.runnerResolution, repositorySource, uploadArguments.environmentSource, vars)
 		if platformErr != nil {
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", platformErr)
 			return 1
@@ -434,7 +438,7 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 			continue
 		}
 		compileWorkflow := func(vars compiler.VariableSources) (hostedCompilation, error) {
-			return compileHostedNamespacedWithActionCache(ctx, input.Path, input.Source, effectiveEvent.Source, version, distributionDigest, bundleCompilerStep, "", uploadArguments.runnerTargets, uploadArguments.runnerSelectors, runtimeDigests, input.StepKeyNamespace, uploadArguments.oidc, "", repositorySource, authentication, uploadArguments.environmentSource, vars)
+			return compileHostedNamespacedWithActionCache(ctx, input.Path, input.Source, effectiveEvent.Source, version, distributionDigest, bundleCompilerStep, "", uploadArguments.runnerTargets, uploadArguments.runnerResolution, runtimeDigests, input.StepKeyNamespace, uploadArguments.oidc, "", repositorySource, authentication, uploadArguments.environmentSource, vars)
 		}
 		preflight, err := compileWorkflow(vars)
 		if err == nil {
@@ -677,10 +681,10 @@ func generatedFailureArtifact(kind, extension, contents string) transport.Artifa
 	return transport.Artifact{Path: path, Digest: digest, Contents: encoded}
 }
 
-func requiredRuntimePlatforms(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runnerSelectors []compiler.RunnerSelector, repositorySource compiler.RepositorySource, environmentSource compiler.EnvironmentSource, vars compiler.VariableSources) (map[compiler.Platform]bool, error) {
+func requiredRuntimePlatforms(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runnerResolution agentRunnerResolution, repositorySource compiler.RepositorySource, environmentSource compiler.EnvironmentSource, vars compiler.VariableSources) (map[compiler.Platform]bool, error) {
 	options := hostedOptions(groupLabel, configuredTargets, nil)
 	options.Vars = vars
-	applyRunnerSelectors(&options, runnerSelectors)
+	applyRunnerResolution(&options, runnerResolution)
 	options.RepositorySource = repositorySource
 	options.EnvironmentSource = environmentSource
 	preflight, err := compiler.CompileWithOptionsContext(ctx, workflowPath, workflowSource, eventSource, options)
@@ -854,7 +858,7 @@ type parsedUploadArgs struct {
 	clientVersion            string
 	runtimeDistributionPaths map[compiler.Platform]string
 	runnerTargets            map[string]compiler.RunnerTarget
-	runnerSelectors          []compiler.RunnerSelector
+	runnerResolution         agentRunnerResolution
 	oidc                     *plan.OIDCConfiguration
 	environmentSource        compiler.EnvironmentSource
 	variableSource           variableSource

--- a/internal/cli/upload_test.go
+++ b/internal/cli/upload_test.go
@@ -1389,7 +1389,7 @@ func runnerResolutionServer(t *testing.T, status int, verdicts map[string]map[st
 
 func TestRunUploadReportsServerRunnerRejectionsInsteadOfLocalPresets(t *testing.T) {
 	requireImporterHost(t)
-	const missingQueueMessage = "The 'Default' cluster has no hosted macOS queue for this runner selector. Create a hosted macOS queue named macos-medium in the cluster, or configure an explicit runner mapping to an existing queue: https://github.com/buildkite/buildkite-gha/blob/main/docs/compatibility.md"
+	const missingQueueMessage = "The 'Default' cluster has no hosted macOS queue for this runner selector. Create a hosted macOS queue named macos-medium, or map this runner label to an existing queue: https://github.com/buildkite/buildkite-gha/blob/main/docs/compatibility.md"
 	repository := writeUploadWorkflowRepository(t, map[string]string{
 		"runners.yml": "name: Runners\non: push\njobs:\n  mac:\n    runs-on: macos-latest\n    steps: [{run: true}]\n  arm:\n    runs-on: ubuntu-24.04-arm\n    steps: [{run: true}]\n  windows:\n    runs-on: windows-latest\n    steps: [{run: true}]\n  linux:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
 	})
@@ -1398,7 +1398,7 @@ func TestRunUploadReportsServerRunnerRejectionsInsteadOfLocalPresets(t *testing.
 		t.Fatal(err)
 	}
 	server, requests := runnerResolutionServer(t, http.StatusOK, map[string]map[string]any{
-		"macos-latest":     {"error": map[string]any{"code": "missing_queue", "message": missingQueueMessage, "cluster": "Default", "platform": "darwin/arm64", "required_queues": []string{"macos-medium"}}},
+		"macos-latest":     {"error": map[string]any{"code": "missing_queue", "message": missingQueueMessage, "platform": "darwin/arm64", "required_queues": []string{"macos-medium"}}},
 		"ubuntu-24.04-arm": {"error": map[string]any{"code": "incompatible_labels", "message": "No compatible runner is configured."}},
 		"windows-latest":   {"error": map[string]any{"code": "incompatible_labels", "message": "No compatible runner is configured."}},
 		"ubuntu-latest":    {"target": map[string]string{"queue": "linux-medium", "platform": "linux/amd64", "image": defaultNobleRunnerImage}},

--- a/internal/cli/upload_test.go
+++ b/internal/cli/upload_test.go
@@ -6,6 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"html"
+	"maps"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1338,6 +1341,158 @@ jobs:
 	message := failureArtifactForStep(step.Plugins, runner.uploaded, "messages")
 	if step.Group != "" || step.Label != ":github: workflow · Rebase needed" || !isGeneratedFailureCommand(step.Command) || !strings.Contains(string(message), `job "label-rebase-needed": concurrency cancel-in-progress is unsupported`) || !step.Checkout.Skip {
 		t.Fatalf("job cancellation failure step = %#v", step)
+	}
+}
+
+// runnerResolutionServer serves the Agent API runner resolution endpoint with a
+// fixed verdict per selector; unlisted selectors get a legacy unmapped_labels
+// rejection. It also accepts telemetry posts so the CLI can run unchanged.
+func runnerResolutionServer(t *testing.T, status int, verdicts map[string]map[string]any) (*httptest.Server, *int) {
+	t.Helper()
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/github-actions/runners") {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		requests++
+		if status != http.StatusOK {
+			w.WriteHeader(status)
+			return
+		}
+		var body struct {
+			Requirements []struct {
+				ID       string `json:"id"`
+				Selector struct {
+					Labels []string `json:"labels"`
+				} `json:"selector"`
+			} `json:"requirements"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode runner requirements: %v", err)
+		}
+		resolutions := make([]map[string]any, len(body.Requirements))
+		for i, requirement := range body.Requirements {
+			resolution := map[string]any{"id": requirement.ID}
+			if verdict, ok := verdicts[strings.Join(requirement.Selector.Labels, ",")]; ok {
+				maps.Copy(resolution, verdict)
+			} else {
+				resolution["error"] = map[string]string{"code": "unmapped_labels", "message": "No compatible runner is configured."}
+			}
+			resolutions[i] = resolution
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"resolutions": resolutions})
+	}))
+	t.Cleanup(server.Close)
+	return server, &requests
+}
+
+func TestRunUploadReportsServerRunnerRejectionsInsteadOfLocalPresets(t *testing.T) {
+	requireImporterHost(t)
+	const missingQueueMessage = "The 'Default' cluster has no hosted macOS queue for this runner selector. Create a hosted macOS queue named macos-medium in the cluster, or configure an explicit runner mapping to an existing queue: https://github.com/buildkite/buildkite-gha/blob/main/docs/compatibility.md"
+	repository := writeUploadWorkflowRepository(t, map[string]string{
+		"runners.yml": "name: Runners\non: push\njobs:\n  mac:\n    runs-on: macos-latest\n    steps: [{run: true}]\n  arm:\n    runs-on: ubuntu-24.04-arm\n    steps: [{run: true}]\n  windows:\n    runs-on: windows-latest\n    steps: [{run: true}]\n  linux:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
+	})
+	eventPath, err := filepath.Abs(filepath.Join("..", "..", "testdata", "smoke", "events", "push.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	server, requests := runnerResolutionServer(t, http.StatusOK, map[string]map[string]any{
+		"macos-latest":     {"error": map[string]any{"code": "missing_queue", "message": missingQueueMessage, "cluster": "Default", "platform": "darwin/arm64", "required_queues": []string{"macos-medium"}}},
+		"ubuntu-24.04-arm": {"error": map[string]any{"code": "incompatible_labels", "message": "No compatible runner is configured."}},
+		"windows-latest":   {"error": map[string]any{"code": "incompatible_labels", "message": "No compatible runner is configured."}},
+		"ubuntu-latest":    {"target": map[string]string{"queue": "linux-medium", "platform": "linux/amd64", "image": defaultNobleRunnerImage}},
+	})
+	t.Chdir(repository)
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_JOB_ID", cliTestJobID)
+	t.Setenv("BUILDKITE_STEP_KEY", "server-rejection-importer")
+	t.Setenv("BUILDKITE_AGENT_ENDPOINT", server.URL+"/v3")
+	t.Setenv("BUILDKITE_AGENT_ACCESS_TOKEN", "job-token")
+	t.Setenv("BUILDKITE_GHA_TELEMETRY_DISABLED", "true")
+	runner := &cliCaptureRunner{}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"upload", "--event-path", eventPath, ".github/workflows/runners.yml"}, &stdout, &stderr, "dev", runner); code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	if *requests != 1 || strings.Contains(stderr.String(), "runner resolution unavailable") {
+		t.Fatalf("runner resolution requests = %d, stderr = %q", *requests, stderr.String())
+	}
+	var pipeline struct {
+		Steps []struct {
+			Label   string             `yaml:"label"`
+			Command string             `yaml:"command"`
+			Plugins failureStepPlugins `yaml:"plugins"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(runner.commands[len(runner.commands)-1].stdin, &pipeline); err != nil {
+		t.Fatal(err)
+	}
+	if len(pipeline.Steps) != 1 || pipeline.Steps[0].Label != ":github: workflow · Runners" || !isGeneratedFailureCommand(pipeline.Steps[0].Command) {
+		t.Fatalf("pipeline = %#v", pipeline.Steps)
+	}
+	message := string(failureArtifactForStep(pipeline.Steps[0].Plugins, runner.uploaded, "messages"))
+	if !strings.Contains(message, `Buildkite could not resolve runner label "macos-latest". `+missingQueueMessage) {
+		t.Fatalf("missing_queue rejection was not rendered: %q", message)
+	}
+	if !strings.Contains(message, `Buildkite could not resolve runner label "ubuntu-24.04-arm". No compatible runner is configured. Change runs-on to a Linux or macOS runner label that Buildkite hosted agents support.`) {
+		t.Fatalf("incompatible_labels rejection was not rendered: %q", message)
+	}
+	if !strings.Contains(message, `Windows runners aren't currently supported.`) {
+		t.Fatalf("local Windows guidance was replaced by the server rejection: %q", message)
+	}
+	if strings.Contains(message, "has no runner-target mapping") || strings.Contains(message, `job "linux"`) {
+		t.Fatalf("unexpected failure content: %q", message)
+	}
+	annotation := string(failureArtifactForStep(pipeline.Steps[0].Plugins, runner.uploaded, "annotations"))
+	if !strings.Contains(annotation, "no hosted macOS queue") || !strings.Contains(annotation, "macos-medium") {
+		t.Fatalf("failure annotation = %q", annotation)
+	}
+}
+
+func TestRunUploadWarnsWhenRunnerResolutionIsUnavailable(t *testing.T) {
+	requireImporterHost(t)
+	repository := writeUploadWorkflowRepository(t, map[string]string{
+		"mac.yml": "name: Mac\non: push\njobs:\n  mac:\n    runs-on: macos-latest\n    steps: [{run: true}]\n",
+	})
+	eventPath, err := filepath.Abs(filepath.Join("..", "..", "testdata", "smoke", "events", "push.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	server, requests := runnerResolutionServer(t, http.StatusServiceUnavailable, nil)
+	darwinPath := filepath.Join(t.TempDir(), "buildkite-gha-darwin")
+	if err := os.WriteFile(darwinPath, []byte{0xcf, 0xfa, 0xed, 0xfe, 0x0c, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repository)
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_JOB_ID", cliTestJobID)
+	t.Setenv("BUILDKITE_STEP_KEY", "resolver-unavailable-importer")
+	t.Setenv("BUILDKITE_AGENT_ENDPOINT", server.URL+"/v3")
+	t.Setenv("BUILDKITE_AGENT_ACCESS_TOKEN", "job-token")
+	t.Setenv("BUILDKITE_GHA_TELEMETRY_DISABLED", "true")
+	runner := &cliCaptureRunner{}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"upload", "--event-path", eventPath, "--runtime-distribution", "darwin/arm64=" + darwinPath, ".github/workflows/mac.yml"}, &stdout, &stderr, "dev", runner); code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	if *requests != 1 || !strings.Contains(stderr.String(), "buildkite-gha: upload: warning: runner resolution unavailable (runner resolution service returned HTTP 503); using built-in runner presets") {
+		t.Fatalf("runner resolution requests = %d, stderr = %q", *requests, stderr.String())
+	}
+	var annotation *cliCommand
+	for i := range runner.commands {
+		command := &runner.commands[i]
+		if len(command.args) >= 9 && command.args[0] == "annotate" && command.args[6] == runnerResolutionContext {
+			annotation = command
+			break
+		}
+	}
+	if annotation == nil || annotation.args[8] != "warning" || !strings.Contains(string(annotation.stdin), "Runner resolution was unavailable") || !strings.Contains(string(annotation.stdin), "HTTP 503") || !strings.Contains(string(annotation.stdin), "built-in runner presets") {
+		t.Fatalf("runner resolution annotation = %#v", annotation)
+	}
+	pipeline := string(runner.commands[len(runner.commands)-1].stdin)
+	if !strings.Contains(pipeline, `queue: "macos-medium"`) || strings.Contains(pipeline, "buildkite-gha-failure") {
+		t.Fatalf("pipeline did not fall back to the macos-medium preset: %s", pipeline)
 	}
 }
 

--- a/internal/compiler/config.go
+++ b/internal/compiler/config.go
@@ -105,18 +105,40 @@ type RunnerSelector struct {
 	Target RunnerTarget
 }
 
+// RunnerRejection records that the Buildkite Agent API refused one complete
+// runs-on selector. Code is server-owned and open-ended; Message is the
+// server's explanation and never quotes runner labels.
+type RunnerRejection struct {
+	Labels  []string
+	Code    string
+	Message string
+}
+
+// Agent API rejection codes the compiler renders with dedicated guidance.
+// Unknown codes render the server message with generic mapping guidance.
+const (
+	RunnerRejectionIncompatibleLabels = "incompatible_labels"
+	RunnerRejectionMissingQueue       = "missing_queue"
+	RunnerRejectionNoCluster          = "no_cluster"
+	RunnerRejectionUnmappedLabels     = "unmapped_labels"
+)
+
 // RunnerPolicy maps every accepted runner label to a Buildkite queue and
 // execution platform. An empty Linux queue uses Buildkite's default agent
 // targeting. Darwin always requires an explicit queue. Multi-label targets are
-// resolved by Selectors first, then accepted only when every label maps to the
-// same complete target. Untrusted events are additionally restricted to
-// UntrustedQueues unless the default is explicitly allowed.
+// resolved by Selectors first, refused by Rejections second, then accepted
+// only when every label maps to the same complete target. A Rejection wins
+// over per-label presets so a server-side cause such as a missing hosted
+// queue is reported instead of a target that cannot be scheduled. Untrusted
+// events are additionally restricted to UntrustedQueues unless the default is
+// explicitly allowed.
 type RunnerPolicy struct {
 	// Labels retains the Linux/amd64 label-to-queue shorthand used by direct
 	// compiler callers. New multi-platform policy should use Targets.
 	Labels                     map[string]string
 	Targets                    map[string]RunnerTarget
 	Selectors                  []RunnerSelector
+	Rejections                 []RunnerRejection
 	UntrustedQueues            []string
 	AllowUntrustedDefaultQueue bool
 }
@@ -213,6 +235,18 @@ func (options Options) validate() error {
 		}
 		selectors[key] = selector.Target
 	}
+	for _, rejection := range options.Runners.Rejections {
+		key, err := runnerSelectorKey(rejection.Labels)
+		if err != nil {
+			return err
+		}
+		if _, ok := selectors[key]; ok {
+			return fmt.Errorf("runner selector is both resolved and rejected")
+		}
+		if strings.TrimSpace(rejection.Code) == "" || strings.TrimSpace(rejection.Message) == "" {
+			return fmt.Errorf("runner rejection requires a code and message")
+		}
+	}
 	for _, queue := range options.Runners.UntrustedQueues {
 		if !queuePattern.MatchString(queue) {
 			return fmt.Errorf("untrusted queue allowlist contains invalid queue %q", queue)
@@ -301,14 +335,17 @@ const (
 	reasonConflictingTarget = "labels resolve to conflicting targets"
 	reasonUntrustedDefault  = "untrusted event cannot use Buildkite default agent targeting"
 	reasonUntrustedQueue    = "untrusted event cannot target the resolved queue"
+	reasonServerRejected    = "runner selector was rejected by the Buildkite Agent API"
 )
 
 // runnerPolicyRejection pairs a rejected runs-on resolution with its reason.
 // Reports may render reason but never the detailed error, which quotes the
-// resolved label.
+// resolved label. server is set when the Agent API refused the selector; its
+// message is server-authored and safe to render.
 type runnerPolicyRejection struct {
 	reason string
 	label  string
+	server *RunnerRejection
 	err    error
 }
 
@@ -321,6 +358,13 @@ func rejectRunner(reason, format string, args ...any) error {
 
 func rejectRunnerLabel(reason, label, format string, args ...any) error {
 	return &runnerPolicyRejection{reason: reason, label: label, err: fmt.Errorf(format, args...)}
+}
+
+func rejectRunnerByServer(rejection RunnerRejection) error {
+	return &runnerPolicyRejection{
+		reason: reasonServerRejected, server: &rejection,
+		err: fmt.Errorf("runner selector %q was rejected by the Buildkite Agent API (%s): %s", strings.Join(rejection.Labels, ", "), rejection.Code, rejection.Message),
+	}
 }
 
 // Resolve returns the target selected by labels under this policy and trust
@@ -348,6 +392,17 @@ func (policy RunnerPolicy) resolve(labels []string, trust EventTrust) (RunnerTar
 		key, err := runnerSelectorKey(selector.Labels)
 		if err == nil && key == selectorKey {
 			return policy.enforceRunnerTrust(selector.Target, trust)
+		}
+	}
+	for _, rejection := range policy.Rejections {
+		key, err := runnerSelectorKey(rejection.Labels)
+		if err != nil || key != selectorKey {
+			continue
+		}
+		// The local Windows guidance is more specific than a server
+		// incompatibility message, so let the per-label loop report it.
+		if !slices.ContainsFunc(normalizedLabels, unsupportedOS) {
+			return RunnerTarget{}, rejectRunnerByServer(rejection)
 		}
 	}
 	var target RunnerTarget
@@ -452,6 +507,11 @@ func runnerRejectionDiagnostic(err error, labels, supported, untrustedQueues []s
 		return "Windows runners aren't currently supported. Imported jobs run on Linux or macOS Buildkite hosted agents. " + linuxGuidance + " If it requires Windows, open an issue in https://github.com/buildkite/buildkite-gha to help us prioritize Windows support.", ""
 	case reasonUnmappedLabel:
 		return fmt.Sprintf("Runner label%s has no runner-target mapping. Configure a mapping for this label or use a mapped runner label.", label), detail
+	case reasonServerRejected:
+		if rejection.server != nil {
+			return serverRunnerRejectionDiagnostic(*rejection.server, label, detail)
+		}
+		return "Runner target is unsupported. Use a configured Linux or macOS runner target.", detail
 	case reasonConflictingQueues, reasonConflictingTarget:
 		return "runs-on labels map to conflicting runner targets. Use labels that map to one runner target.", detail
 	case reasonUntrustedDefault:
@@ -466,6 +526,37 @@ func runnerRejectionDiagnostic(err error, labels, supported, untrustedQueues []s
 	default:
 		return "Runner target is unsupported. Use a configured Linux or macOS runner target.", detail
 	}
+}
+
+// serverRunnerRejectionDiagnostic renders an Agent API rejection. The server
+// message is rendered verbatim because it names the cause the workflow author
+// cannot see locally, such as the cluster and the missing hosted queue. Codes
+// whose message already carries a remedy add no local guidance; unknown codes
+// keep the generic mapping guidance so newer servers degrade gracefully.
+func serverRunnerRejectionDiagnostic(rejection RunnerRejection, label, supportedDetail string) (message, detail string) {
+	subject := "the runs-on labels"
+	if label != "" {
+		subject = "runner label" + label
+	}
+	message = fmt.Sprintf("Buildkite could not resolve %s. ", subject)
+	switch rejection.Code {
+	case RunnerRejectionMissingQueue, RunnerRejectionNoCluster:
+		// The server message may end with a documentation URL; leave it intact.
+		return message + strings.Join(strings.Fields(rejection.Message), " "), ""
+	case RunnerRejectionIncompatibleLabels:
+		return message + sentence(rejection.Message) + " Change runs-on to a Linux or macOS runner label that Buildkite hosted agents support.", supportedDetail
+	default:
+		return message + sentence(rejection.Message) + " Configure a mapping for this selector or use a mapped runner label.", supportedDetail
+	}
+}
+
+// sentence normalizes server prose so local guidance can follow it.
+func sentence(text string) string {
+	text = strings.Join(strings.Fields(text), " ")
+	if text == "" || strings.HasSuffix(text, ".") || strings.HasSuffix(text, "!") || strings.HasSuffix(text, "?") {
+		return text
+	}
+	return text + "."
 }
 
 func runnerRejectionBlockerDetail(err error, reportableLabels []string) string {

--- a/internal/compiler/config_test.go
+++ b/internal/compiler/config_test.go
@@ -514,6 +514,140 @@ func TestRunnerPolicySelectorTargetDoesNotChangeOverlappingLabelTarget(t *testin
 	}
 }
 
+func TestRunnerPolicyServerRejectionWinsOverLocalPreset(t *testing.T) {
+	preset := RunnerTarget{Queue: "macos-medium", Platform: PlatformDarwinARM64}
+	missingQueue := RunnerRejection{
+		Labels:  []string{"macos-latest"},
+		Code:    RunnerRejectionMissingQueue,
+		Message: "Cluster 'Default' has no hosted macOS queue. Create a hosted queue named macos-medium, or add a runners mapping from macos-latest to an existing queue.",
+	}
+	policy := RunnerPolicy{
+		Targets:    map[string]RunnerTarget{"macos-latest": preset, "ubuntu-latest": {Platform: PlatformLinuxAMD64}},
+		Rejections: []RunnerRejection{missingQueue, {Labels: []string{"windows-latest"}, Code: RunnerRejectionIncompatibleLabels, Message: "No compatible runner is configured."}},
+	}
+	_, err := policy.resolve([]string{"macOS-latest"}, EventTrusted)
+	var rejection *runnerPolicyRejection
+	if !errors.As(err, &rejection) || rejection.reason != reasonServerRejected || rejection.server == nil || rejection.server.Code != RunnerRejectionMissingQueue {
+		t.Fatalf("resolve(macOS-latest) error = %#v, want server rejection over the macos-medium preset", err)
+	}
+	if !strings.Contains(err.Error(), "missing_queue") || !strings.Contains(err.Error(), "no hosted macOS queue") {
+		t.Fatalf("detailed error = %q", err)
+	}
+	if got, err := policy.resolve([]string{"ubuntu-latest"}, EventTrusted); err != nil || got.Platform != PlatformLinuxAMD64 {
+		t.Fatalf("unrejected preset = %#v, %v", got, err)
+	}
+	// A multi-label selector that merely shares a label with a rejection still
+	// falls through to per-label resolution.
+	if _, err := policy.resolve([]string{"macos-latest", "self-hosted"}, EventTrusted); !errors.As(err, &rejection) || rejection.reason != reasonUnmappedLabel {
+		t.Fatalf("overlapping selector error = %#v, want per-label rejection", err)
+	}
+	// The local Windows guidance is more specific than the server's.
+	if _, err := policy.resolve([]string{"windows-latest"}, EventTrusted); !errors.As(err, &rejection) || rejection.reason != reasonUnsupportedOS {
+		t.Fatalf("windows-latest error = %#v, want local unsupported-OS rejection", err)
+	}
+	if _, err := (RunnerPolicy{Selectors: []RunnerSelector{{Labels: []string{"macos-latest"}, Target: preset}}, Rejections: []RunnerRejection{missingQueue}}).resolve([]string{"macos-latest"}, EventTrusted); err != nil {
+		t.Fatalf("selector should win over rejection: %v", err)
+	}
+}
+
+func TestOptionsValidateRejectsMalformedRunnerRejections(t *testing.T) {
+	target := RunnerTarget{Queue: "macos-medium", Platform: PlatformDarwinARM64}
+	tests := []struct {
+		name   string
+		policy RunnerPolicy
+		want   string
+	}{
+		{name: "duplicate labels", policy: RunnerPolicy{Targets: map[string]RunnerTarget{"ubuntu-latest": {Platform: PlatformLinuxAMD64}}, Rejections: []RunnerRejection{{Labels: []string{"a", "a"}, Code: "x", Message: "y"}}}, want: "duplicate label"},
+		{name: "resolved and rejected", policy: RunnerPolicy{Selectors: []RunnerSelector{{Labels: []string{"macos-latest"}, Target: target}}, Rejections: []RunnerRejection{{Labels: []string{"macos-latest"}, Code: "x", Message: "y"}}}, want: "both resolved and rejected"},
+		{name: "blank message", policy: RunnerPolicy{Targets: map[string]RunnerTarget{"ubuntu-latest": {Platform: PlatformLinuxAMD64}}, Rejections: []RunnerRejection{{Labels: []string{"macos-latest"}, Code: "x", Message: " "}}}, want: "requires a code and message"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := (Options{EventTrust: EventTrusted, Runners: test.policy}).validate()
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Options.validate() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestRunnerRejectionDiagnosticRendersServerRejections(t *testing.T) {
+	supported := []string{"ubuntu-22.04", "ubuntu-24.04", "ubuntu-latest"}
+	tests := []struct {
+		name        string
+		rejection   RunnerRejection
+		labels      []string
+		wantMessage string
+		wantDetail  string
+	}{
+		{
+			name:        "missing queue names the cluster and remedy without altering the trailing URL",
+			rejection:   RunnerRejection{Labels: []string{"macos-latest"}, Code: RunnerRejectionMissingQueue, Message: "The 'Default' cluster has no hosted macOS queue for this runner selector. Create a hosted macOS queue named macos-14-medium or macos-medium in the cluster, or configure an explicit runner mapping to an existing queue: https://github.com/buildkite/buildkite-gha/blob/main/docs/compatibility.md"},
+			labels:      []string{"macos-latest"},
+			wantMessage: `Buildkite could not resolve runner label "macos-latest". The 'Default' cluster has no hosted macOS queue for this runner selector. Create a hosted macOS queue named macos-14-medium or macos-medium in the cluster, or configure an explicit runner mapping to an existing queue: https://github.com/buildkite/buildkite-gha/blob/main/docs/compatibility.md`,
+		},
+		{
+			name:        "no cluster without reportable labels",
+			rejection:   RunnerRejection{Labels: []string{"macos-latest"}, Code: RunnerRejectionNoCluster, Message: "This job is not in a cluster, so no hosted queue can be selected."},
+			wantMessage: "Buildkite could not resolve the runs-on labels. This job is not in a cluster, so no hosted queue can be selected.",
+		},
+		{
+			name:        "incompatible labels",
+			rejection:   RunnerRejection{Labels: []string{"self-hosted", "arm64"}, Code: RunnerRejectionIncompatibleLabels, Message: "No compatible runner is configured."},
+			labels:      []string{"self-hosted", "arm64"},
+			wantMessage: "Buildkite could not resolve the runs-on labels. No compatible runner is configured. Change runs-on to a Linux or macOS runner label that Buildkite hosted agents support.",
+			wantDetail:  "Supported runner labels: ubuntu-22.04, ubuntu-24.04, ubuntu-latest.",
+		},
+		{
+			name:        "legacy unmapped labels keeps mapping guidance",
+			rejection:   RunnerRejection{Labels: []string{"macos-15"}, Code: RunnerRejectionUnmappedLabels, Message: "No compatible runner is configured."},
+			labels:      []string{"macos-15"},
+			wantMessage: `Buildkite could not resolve runner label "macos-15". No compatible runner is configured. Configure a mapping for this selector or use a mapped runner label.`,
+			wantDetail:  "Supported runner labels: ubuntu-22.04, ubuntu-24.04, ubuntu-latest.",
+		},
+		{
+			name:        "unknown future code degrades to mapping guidance",
+			rejection:   RunnerRejection{Labels: []string{"macos-15"}, Code: "queue_platform_mismatch", Message: "The mapped queue runs Linux."},
+			labels:      []string{"macos-15"},
+			wantMessage: `Buildkite could not resolve runner label "macos-15". The mapped queue runs Linux. Configure a mapping for this selector or use a mapped runner label.`,
+			wantDetail:  "Supported runner labels: ubuntu-22.04, ubuntu-24.04, ubuntu-latest.",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			message, detail := runnerRejectionDiagnostic(rejectRunnerByServer(test.rejection), test.labels, supported, nil)
+			if message != test.wantMessage || detail != test.wantDetail {
+				t.Fatalf("runnerRejectionDiagnostic() = %q, %q\nwant %q, %q", message, detail, test.wantMessage, test.wantDetail)
+			}
+			if strings.Contains(message, "has no runner-target mapping") {
+				t.Fatalf("server rejection rendered the local unmapped-label message: %q", message)
+			}
+		})
+	}
+}
+
+func TestCompileReportsServerRejectionAtRunsOn(t *testing.T) {
+	workflow := []byte("on: push\njobs:\n  test:\n    runs-on: macos-latest\n    steps:\n      - run: true\n")
+	options := Options{
+		EventTrust: EventTrusted,
+		Runners: RunnerPolicy{
+			Targets: map[string]RunnerTarget{"macos-latest": {Queue: "macos-medium", Platform: PlatformDarwinARM64}},
+			Rejections: []RunnerRejection{{
+				Labels: []string{"macos-latest"}, Code: RunnerRejectionMissingQueue,
+				Message: "Cluster 'Default' has no hosted macOS queue. Create a hosted queue named macos-medium.",
+			}},
+		},
+	}
+	_, err := CompileWithOptions("policy.yml", workflow, pushEvent(t), options)
+	var finding *ProcessingFinding
+	if !errors.As(err, &finding) || finding.Blocker != "runner_label" || finding.BlockerDetail != "macos-latest" || finding.Job != "test" || finding.Line != 3 {
+		t.Fatalf("CompileWithOptions() error = %v, finding = %+v, want runs-on finding for macos-latest", err, finding)
+	}
+	if !strings.Contains(finding.Message, "Cluster 'Default' has no hosted macOS queue") || strings.Contains(finding.Message, "has no runner-target mapping") || finding.Detail != "" {
+		t.Fatalf("finding message/detail = %q / %q", finding.Message, finding.Detail)
+	}
+}
+
 func TestRunnerRejectionDiagnosticFallsBackWhenUnclassified(t *testing.T) {
 	message, detail := runnerRejectionDiagnostic(errors.New("boom"), nil, nil, nil)
 	if message != "Runner target is unsupported. Use a configured Linux or macOS runner target." || detail != "" {

--- a/internal/compiler/config_test.go
+++ b/internal/compiler/config_test.go
@@ -582,9 +582,9 @@ func TestRunnerRejectionDiagnosticRendersServerRejections(t *testing.T) {
 	}{
 		{
 			name:        "missing queue names the cluster and remedy without altering the trailing URL",
-			rejection:   RunnerRejection{Labels: []string{"macos-latest"}, Code: RunnerRejectionMissingQueue, Message: "The 'Default' cluster has no hosted macOS queue for this runner selector. Create a hosted macOS queue named macos-14-medium or macos-medium in the cluster, or configure an explicit runner mapping to an existing queue: https://github.com/buildkite/buildkite-gha/blob/main/docs/compatibility.md"},
+			rejection:   RunnerRejection{Labels: []string{"macos-latest"}, Code: RunnerRejectionMissingQueue, Message: "The 'Default' cluster has no hosted macOS queue for this runner selector. Create a hosted macOS queue named macos-14-medium or macos-medium, or map this runner label to an existing queue: https://github.com/buildkite/buildkite-gha/blob/main/docs/compatibility.md"},
 			labels:      []string{"macos-latest"},
-			wantMessage: `Buildkite could not resolve runner label "macos-latest". The 'Default' cluster has no hosted macOS queue for this runner selector. Create a hosted macOS queue named macos-14-medium or macos-medium in the cluster, or configure an explicit runner mapping to an existing queue: https://github.com/buildkite/buildkite-gha/blob/main/docs/compatibility.md`,
+			wantMessage: `Buildkite could not resolve runner label "macos-latest". The 'Default' cluster has no hosted macOS queue for this runner selector. Create a hosted macOS queue named macos-14-medium or macos-medium, or map this runner label to an existing queue: https://github.com/buildkite/buildkite-gha/blob/main/docs/compatibility.md`,
 		},
 		{
 			name:        "no cluster without reportable labels",

--- a/internal/runtime/runner_resolution.go
+++ b/internal/runtime/runner_resolution.go
@@ -13,7 +13,10 @@ import (
 	"github.com/buildkite/buildkite-gha/internal/agentapi"
 )
 
-const runnerResolutionResponseLimit = 64 << 10
+// A maximum batch of 100 missing_queue rejections whose messages each name a
+// long cluster name stays far below this cap, so oversized responses indicate
+// a misbehaving server rather than a legitimately verbose diagnostic.
+const runnerResolutionResponseLimit = 1 << 20
 const runnerResolutionBatchLimit = 100
 
 type RunnerRequirement struct {

--- a/internal/runtime/runner_resolution.go
+++ b/internal/runtime/runner_resolution.go
@@ -34,6 +34,15 @@ type RunnerWarning struct {
 	Message string
 }
 
+// RunnerRejection is the Agent API's refusal to resolve one requirement. Code
+// is an open set owned by the server; callers must tolerate codes they do not
+// recognize and render Message, which the server keeps free of runner labels.
+type RunnerRejection struct {
+	ID      string
+	Code    string
+	Message string
+}
+
 type AgentRunnerResolverConfig struct {
 	Endpoint      string
 	JobID         string
@@ -60,23 +69,28 @@ func NewAgentRunnerResolver(config AgentRunnerResolverConfig) (*AgentRunnerResol
 	}, nil
 }
 
-func (c *AgentRunnerResolver) Resolve(ctx context.Context, requirements []RunnerRequirement) ([]RunnerSuggestion, error) {
+// Resolve returns the server's target for every requirement it accepted and
+// its rejection for every requirement it refused. Each requirement appears in
+// exactly one of the two results.
+func (c *AgentRunnerResolver) Resolve(ctx context.Context, requirements []RunnerRequirement) ([]RunnerSuggestion, []RunnerRejection, error) {
 	if c == nil {
-		return nil, fmt.Errorf("runner resolver is not configured")
+		return nil, nil, fmt.Errorf("runner resolver is not configured")
 	}
 	var suggestions []RunnerSuggestion
+	var rejections []RunnerRejection
 	for start := 0; start < len(requirements); start += runnerResolutionBatchLimit {
 		end := min(start+runnerResolutionBatchLimit, len(requirements))
-		resolved, err := c.resolveBatch(ctx, requirements[start:end])
+		resolved, rejected, err := c.resolveBatch(ctx, requirements[start:end])
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		suggestions = append(suggestions, resolved...)
+		rejections = append(rejections, rejected...)
 	}
-	return suggestions, nil
+	return suggestions, rejections, nil
 }
 
-func (c *AgentRunnerResolver) resolveBatch(ctx context.Context, requirements []RunnerRequirement) ([]RunnerSuggestion, error) {
+func (c *AgentRunnerResolver) resolveBatch(ctx context.Context, requirements []RunnerRequirement) ([]RunnerSuggestion, []RunnerRejection, error) {
 	type selector struct {
 		Labels []string `json:"labels"`
 	}
@@ -90,35 +104,35 @@ func (c *AgentRunnerResolver) resolveBatch(ctx context.Context, requirements []R
 	expected := make(map[string]bool, len(requirements))
 	for i, input := range requirements {
 		if input.ID == "" || expected[input.ID] {
-			return nil, fmt.Errorf("runner requirements require unique non-empty IDs")
+			return nil, nil, fmt.Errorf("runner requirements require unique non-empty IDs")
 		}
 		expected[input.ID] = true
 		body.Requirements[i] = requirement{ID: input.ID, Selector: selector{Labels: input.Labels}}
 	}
 	encoded, err := json.Marshal(body)
 	if err != nil {
-		return nil, fmt.Errorf("encode runner resolution request: %w", err)
+		return nil, nil, fmt.Errorf("encode runner resolution request: %w", err)
 	}
 	request, err := http.NewRequestWithContext(ctx, http.MethodPost, c.resolveURL, bytes.NewReader(encoded))
 	if err != nil {
-		return nil, fmt.Errorf("create runner resolution request: %w", err)
+		return nil, nil, fmt.Errorf("create runner resolution request: %w", err)
 	}
 	request.Header.Set("Content-Type", "application/json")
 	response, err := c.agent.Do(request)
 	if err != nil {
-		return nil, fmt.Errorf("request runner resolution: %w", err)
+		return nil, nil, fmt.Errorf("request runner resolution: %w", err)
 	}
 	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
 		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, runnerResolutionResponseLimit))
-		return nil, fmt.Errorf("runner resolution service returned HTTP %d", response.StatusCode)
+		return nil, nil, fmt.Errorf("runner resolution service returned HTTP %d", response.StatusCode)
 	}
 	payload, err := io.ReadAll(io.LimitReader(response.Body, runnerResolutionResponseLimit+1))
 	if err != nil {
-		return nil, fmt.Errorf("read runner resolution response: %w", err)
+		return nil, nil, fmt.Errorf("read runner resolution response: %w", err)
 	}
 	if len(payload) > runnerResolutionResponseLimit {
-		return nil, fmt.Errorf("runner resolution response exceeds the %d-byte limit", runnerResolutionResponseLimit)
+		return nil, nil, fmt.Errorf("runner resolution response exceeds the %d-byte limit", runnerResolutionResponseLimit)
 	}
 	var decoded struct {
 		Resolutions []struct {
@@ -140,35 +154,42 @@ func (c *AgentRunnerResolver) resolveBatch(ctx context.Context, requirements []R
 	}
 	decoder := json.NewDecoder(bytes.NewReader(payload))
 	if err := decoder.Decode(&decoded); err != nil {
-		return nil, fmt.Errorf("decode runner resolution response: %w", err)
+		return nil, nil, fmt.Errorf("decode runner resolution response: %w", err)
 	}
 	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
-		return nil, fmt.Errorf("runner resolution response has trailing data")
+		return nil, nil, fmt.Errorf("runner resolution response has trailing data")
 	}
 	if len(decoded.Resolutions) != len(requirements) {
-		return nil, fmt.Errorf("runner resolution response has an unexpected number of resolutions")
+		return nil, nil, fmt.Errorf("runner resolution response has an unexpected number of resolutions")
 	}
 	seen := make(map[string]bool, len(decoded.Resolutions))
 	suggestions := make([]RunnerSuggestion, 0, len(decoded.Resolutions))
+	var rejections []RunnerRejection
 	for _, resolution := range decoded.Resolutions {
 		hasTarget := resolution.Target != nil
 		hasError := resolution.Error != nil
 		if !expected[resolution.ID] || seen[resolution.ID] || hasTarget == hasError {
-			return nil, fmt.Errorf("runner resolution response is invalid")
+			return nil, nil, fmt.Errorf("runner resolution response is invalid")
 		}
 		seen[resolution.ID] = true
 		if resolution.Target != nil {
 			suggestion := RunnerSuggestion{ID: resolution.ID, Queue: resolution.Target.Queue, Platform: resolution.Target.Platform, Image: resolution.Target.Image}
 			for _, warning := range resolution.Warnings {
 				if strings.TrimSpace(warning.Code) == "" || strings.TrimSpace(warning.Message) == "" {
-					return nil, fmt.Errorf("runner resolution response contains an invalid warning")
+					return nil, nil, fmt.Errorf("runner resolution response contains an invalid warning")
 				}
 				suggestion.Warnings = append(suggestion.Warnings, RunnerWarning{Code: warning.Code, Message: warning.Message})
 			}
 			suggestions = append(suggestions, suggestion)
-		} else if len(resolution.Warnings) != 0 {
-			return nil, fmt.Errorf("runner resolution response contains warnings without a target")
+			continue
 		}
+		if len(resolution.Warnings) != 0 {
+			return nil, nil, fmt.Errorf("runner resolution response contains warnings without a target")
+		}
+		if strings.TrimSpace(resolution.Error.Code) == "" || strings.TrimSpace(resolution.Error.Message) == "" {
+			return nil, nil, fmt.Errorf("runner resolution response contains an invalid error")
+		}
+		rejections = append(rejections, RunnerRejection{ID: resolution.ID, Code: resolution.Error.Code, Message: resolution.Error.Message})
 	}
-	return suggestions, nil
+	return suggestions, rejections, nil
 }

--- a/internal/runtime/runner_resolution_test.go
+++ b/internal/runtime/runner_resolution_test.go
@@ -76,7 +76,7 @@ func TestAgentRunnerResolverRetainsServerRejectionsAndRejectsMalformedErrors(t *
 	}{
 		{
 			name:  "missing queue with unknown fields",
-			error: map[string]any{"code": "missing_queue", "message": "Cluster 'Default' has no hosted macOS queue.", "cluster": "Default", "platform": "darwin/arm64", "required_queues": []string{"macos-medium"}},
+			error: map[string]any{"code": "missing_queue", "message": "Cluster 'Default' has no hosted macOS queue.", "platform": "darwin/arm64", "required_queues": []string{"macos-medium"}},
 			want:  RunnerRejection{ID: "r1", Code: "missing_queue", Message: "Cluster 'Default' has no hosted macOS queue."},
 		},
 		{

--- a/internal/runtime/runner_resolution_test.go
+++ b/internal/runtime/runner_resolution_test.go
@@ -54,11 +54,59 @@ func TestAgentRunnerResolverBatchesRequirementsIgnoresUnknownFieldsAndReturnsSug
 		requirements[i] = RunnerRequirement{ID: fmt.Sprintf("r%d", i), Labels: []string{"ubuntu-latest"}}
 	}
 	requirements[100].Labels = []string{"ubuntu-18.04"}
-	suggestions, err := resolver.Resolve(t.Context(), requirements)
+	suggestions, rejections, err := resolver.Resolve(t.Context(), requirements)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if requests != 2 || len(suggestions) != 1 || suggestions[0].ID != "r100" || suggestions[0].Queue != "linux-medium" || suggestions[0].Platform != "linux/amd64" || suggestions[0].Image != "registry.example.com/ubuntu@sha256:"+strings.Repeat("0", 64) || len(suggestions[0].Warnings) != 1 || suggestions[0].Warnings[0] != (RunnerWarning{Code: "runner_label_fallback", Message: "Runner labels [ubuntu-18.04] are not supported directly; using the linux-medium queue via a heuristic fallback. Configure an explicit runner mapping to use an appropriate Buildkite queue and avoid this fallback."}) {
 		t.Fatalf("requests/suggestions = %d / %#v", requests, suggestions)
+	}
+	if len(rejections) != 100 || rejections[0] != (RunnerRejection{ID: "r0", Code: "unmapped_labels", Message: "No compatible runner is configured."}) || rejections[99].ID != "r99" {
+		t.Fatalf("rejections = %d / %#v", len(rejections), rejections[:min(2, len(rejections))])
+	}
+}
+
+func TestAgentRunnerResolverRetainsServerRejectionsAndRejectsMalformedErrors(t *testing.T) {
+	const jobID = "11111111-1111-4111-8111-111111111111"
+	tests := []struct {
+		name    string
+		error   map[string]any
+		want    RunnerRejection
+		wantErr string
+	}{
+		{
+			name:  "missing queue with unknown fields",
+			error: map[string]any{"code": "missing_queue", "message": "Cluster 'Default' has no hosted macOS queue.", "cluster": "Default", "platform": "darwin/arm64", "required_queues": []string{"macos-medium"}},
+			want:  RunnerRejection{ID: "r1", Code: "missing_queue", Message: "Cluster 'Default' has no hosted macOS queue."},
+		},
+		{
+			name:  "unknown future code",
+			error: map[string]any{"code": "queue_platform_mismatch", "message": "Queue targets Linux."},
+			want:  RunnerRejection{ID: "r1", Code: "queue_platform_mismatch", Message: "Queue targets Linux."},
+		},
+		{name: "blank code", error: map[string]any{"code": " ", "message": "x"}, wantErr: "invalid error"},
+		{name: "missing message", error: map[string]any{"code": "missing_queue"}, wantErr: "invalid error"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_ = json.NewEncoder(w).Encode(map[string]any{"resolutions": []map[string]any{{"id": "r1", "error": test.error}}})
+			}))
+			defer server.Close()
+			resolver, err := NewAgentRunnerResolver(AgentRunnerResolverConfig{Endpoint: server.URL + "/v3", JobID: jobID, JobToken: "job-token", ClientVersion: "1.2.3", Client: server.Client()})
+			if err != nil {
+				t.Fatal(err)
+			}
+			suggestions, rejections, err := resolver.Resolve(t.Context(), []RunnerRequirement{{ID: "r1", Labels: []string{"macos-latest"}}})
+			if test.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+					t.Fatalf("Resolve() error = %v, want %q", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil || len(suggestions) != 0 || len(rejections) != 1 || rejections[0] != test.want {
+				t.Fatalf("Resolve() = %#v, %#v, %v", suggestions, rejections, err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Why

A workflow with `runs-on: macos-latest` in a cluster that has no hosted macOS queue currently gets a misleading diagnostic, or none at all. The Agent API already says why the label cannot be resolved, but the importer drops that answer and falls back to the built-in `macos-medium` preset:

```
# What the importer shows today (server said: no hosted macOS queue)
Runner label "macos-latest" has no runner-target mapping. Configure a mapping for this label or use a mapped runner label.

# …or, when the preset is used, the build dies later at pipeline upload with no pointer to the job:
buildkite-gha: upload: upload pipeline: … Queue 'macos-medium' does not exist in the 'Default' cluster
```

If the resolver request itself fails (for example HTTP 503), the importer silently uses the presets with no message.

## What

Server rejections are kept and win over the local presets. They render at the job's `runs-on` in the existing workflow diagnostics annotation, before anything is uploaded:

```
Buildkite could not resolve runner label "macos-latest". The 'Default' cluster has no hosted macOS queue for this runner selector. Create a hosted macOS queue named macos-medium, or map this runner label to an existing queue: https://github.com/buildkite/buildkite-gha/blob/main/docs/compatibility.md
```

| Server code | Rendered as |
| --- | --- |
| `missing_queue`, `no_cluster` | Server message verbatim (it names the cluster, queue, and remedy) |
| `incompatible_labels` | Server message + "Change runs-on to a Linux or macOS runner label that Buildkite hosted agents support." |
| `unmapped_labels` (legacy) or unknown | Server message + generic mapping guidance and the supported-label list |

Windows labels keep the existing local Windows guidance, which is more specific than the server's incompatibility message.

When the resolver transport fails, the importer now warns and annotates instead of degrading silently, then continues with the presets:

```
buildkite-gha: upload: warning: runner resolution unavailable (runner resolution service returned HTTP 503); using built-in runner presets
```

## Compatibility

- Companion server change: buildkite/buildkite#33658 (splits `unmapped_labels` into `incompatible_labels`, `missing_queue`, `no_cluster`). Either side can ship first: this client renders unknown codes and the legacy `unmapped_labels` with generic guidance, and the old client ignores the new codes.
- The decoder reads only `error.code` and `error.message` (both now required to be non-empty) and tolerates the server's other fields (`platform`, `required_queues`).
- The runner resolution response cap is 1 MiB, up from 64 KiB, so a maximum batch of `missing_queue` diagnostics naming a long cluster name is never discarded wholesale.
- `TestMain` in `internal/cli` unsets `BUILDKITE_AGENT_ENDPOINT` and `BUILDKITE_AGENT_ACCESS_TOKEN` so ordinary CLI tests cannot resolve runners against the ambient Agent API when the suite runs inside a Buildkite job.
- `validate --profile hosted` (no Agent API) and explicit `runners:` mappings are unchanged. Validating explicit mappings against the cluster (`queue_not_found`, `queue_platform_mismatch`) is deferred to a follow-up.

Linear: PB-2902

