### PR TITLE
Name runtime output processing explicitly

### DIFF
--- a/internal/runtime/action_execution.go
+++ b/internal/runtime/action_execution.go
@@ -164,7 +164,7 @@ func (r *jobRun) prepare(ctx context.Context) (final JobResult, runJobErr error)
 	if len(job.NeedSources) != 0 && len(job.Needs) == 0 {
 		return jobResult, fmt.Errorf("job has prerequisite sources but no hydrated prerequisite results")
 	}
-	processor := newCommandProcessor(r.stdout(), r.stderr())
+	processor := newCommandOutputProcessor(r.stdout(), r.stderr())
 	eval := expression.Context{
 		WorkflowInputs: job.Inputs,
 		Matrix:         job.Matrix,
@@ -1231,7 +1231,7 @@ func trimSensitiveSuffix(value string, sensitiveValues []string) string {
 	}
 }
 
-func (r Runner) resolveSecrets(ctx context.Context, processor *commandProcessor, names []string) (map[string]string, error) {
+func (r Runner) resolveSecrets(ctx context.Context, processor *commandOutputProcessor, names []string) (map[string]string, error) {
 	if len(names) == 0 {
 		return nil, nil
 	}
@@ -1255,7 +1255,7 @@ func (r Runner) resolveSecrets(ctx context.Context, processor *commandProcessor,
 	return values, nil
 }
 
-func (r Runner) resolveWorkflowToken(ctx context.Context, processor *commandProcessor, repository, workflow string, permissions map[string]string) (string, error) {
+func (r Runner) resolveWorkflowToken(ctx context.Context, processor *commandOutputProcessor, repository, workflow string, permissions map[string]string) (string, error) {
 	if r.WorkflowToken == nil {
 		return "", fmt.Errorf("GitHub workflow token provider is not configured")
 	}
@@ -1587,7 +1587,7 @@ func isRuntimeContextEnvironment(name string) bool {
 	}
 }
 
-func (r *jobRun) runJobStep(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, step plan.Step, invocationID string, jobEnv, stepEnv map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations) (Result, error) {
+func (r *jobRun) runJobStep(ctx context.Context, processor *commandOutputProcessor, workspace string, job plan.Job, step plan.Step, invocationID string, jobEnv, stepEnv map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations) (Result, error) {
 	return r.runActionStep(ctx, processor, workspace, job, step, invocationID, jobEnv, stepEnv, nil, eval, posts, actions, prepared, nil, nil)
 }
 
@@ -1723,7 +1723,7 @@ func (r *jobRun) actionContainerMounts(ctx context.Context, actions *actionLockR
 	return out, nil
 }
 
-func (r *jobRun) prepareRemoteAction(ctx context.Context, processor *commandProcessor, workspace string, step plan.Step, invocationID string, jobEnv map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations, status *remotePreparationStatus, workflowStep bool, inheritedEvalErr error, inheritedTimeout *remotePreparationTimeout, inheritedEnvOverlay map[string]string) (Result, error) {
+func (r *jobRun) prepareRemoteAction(ctx context.Context, processor *commandOutputProcessor, workspace string, step plan.Step, invocationID string, jobEnv map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations, status *remotePreparationStatus, workflowStep bool, inheritedEvalErr error, inheritedTimeout *remotePreparationTimeout, inheritedEnvOverlay map[string]string) (Result, error) {
 	result := newResult()
 	eval.JobStatus = jobStatusValue(status.unsuccessful, ctx.Err() != nil)
 	if !workflowStep {
@@ -1920,7 +1920,7 @@ func (r *jobRun) prepareRemoteAction(ctx context.Context, processor *commandProc
 	}
 }
 
-func (r *jobRun) runActionStep(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, step plan.Step, invocationID string, jobEnv, stepEnv, evaluatedWith map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations, actionStack []string, inheritedEnvOverlay map[string]string) (Result, error) {
+func (r *jobRun) runActionStep(ctx context.Context, processor *commandOutputProcessor, workspace string, job plan.Job, step plan.Step, invocationID string, jobEnv, stepEnv, evaluatedWith map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations, actionStack []string, inheritedEnvOverlay map[string]string) (Result, error) {
 	if stepEnv == nil {
 		var err error
 		stepEnv, err = executionprogram.EvaluateBindings(step.Execution.Env, executionprogram.EvaluationContext{Expression: eval})
@@ -2127,7 +2127,7 @@ func (r *jobRun) runActionStep(ctx context.Context, processor *commandProcessor,
 	return result, errUnsupportedFeature("action_ref", "", "action %q uses unsupported runtime %q", step.Uses, actionRuntime)
 }
 
-func (r *jobRun) runCompositeMetadata(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, actionPath string, action metadata.Metadata, actionProgram *executionprogram.Action, inputs map[string]string, invocationID string, jobEnv, stepEnv, lifecycleEnvOverlay map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations, actionLock *plan.ActionLock, actionStack []string) (Result, error) {
+func (r *jobRun) runCompositeMetadata(ctx context.Context, processor *commandOutputProcessor, workspace string, job plan.Job, actionPath string, action metadata.Metadata, actionProgram *executionprogram.Action, inputs map[string]string, invocationID string, jobEnv, stepEnv, lifecycleEnvOverlay map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations, actionLock *plan.ActionLock, actionStack []string) (Result, error) {
 	result := newResult()
 	// Keep hashFiles unavailable to composite step metadata while retaining the
 	// context binder for nested JavaScript lifecycle conditions.

--- a/internal/runtime/action_lifecycle.go
+++ b/internal/runtime/action_lifecycle.go
@@ -90,7 +90,7 @@ func (w *node16DeprecationWarnings) record(reference string) {
 	w.actions[reference] = struct{}{}
 }
 
-func (w *node16DeprecationWarnings) emit(processor *commandProcessor) {
+func (w *node16DeprecationWarnings) emit(processor *commandOutputProcessor) {
 	if w == nil || processor == nil {
 		return
 	}

--- a/internal/runtime/actions.go
+++ b/internal/runtime/actions.go
@@ -56,7 +56,7 @@ type prebuiltDockerBackend struct {
 	images map[string]string
 }
 
-func (r *jobRun) preparePrebuiltDockerActions(ctx context.Context, processor *commandProcessor, actions *actionLockResolver) (_ *prebuiltDockerBackend, err error) {
+func (r *jobRun) preparePrebuiltDockerActions(ctx context.Context, processor *commandOutputProcessor, actions *actionLockResolver) (_ *prebuiltDockerBackend, err error) {
 	images := map[string]string{}
 	for _, lock := range actions.job.Actions {
 		if lock.DockerImage != "" {

--- a/internal/runtime/cache_service.go
+++ b/internal/runtime/cache_service.go
@@ -219,7 +219,7 @@ func applyGitHubServerURLOverride(env map[string]string) {
 	}
 }
 
-func (r Runner) cacheActionEnvironment(ctx context.Context, processor *commandProcessor) (map[string]string, error) {
+func (r Runner) cacheActionEnvironment(ctx context.Context, processor *commandOutputProcessor) (map[string]string, error) {
 	if r.Cache == nil {
 		return nil, fmt.Errorf("cache credential provider is not configured")
 	}

--- a/internal/runtime/cache_service_test.go
+++ b/internal/runtime/cache_service_test.go
@@ -659,7 +659,7 @@ fs.writeFileSync(process.env.MARKER, "executed");
 	result := newResult()
 	result.Env["MARKER"] = marker
 	result.Env["ACTIONS_RUNTIME_TOKEN"] = "workflow-token"
-	processor := newCommandProcessor(io.Discard, io.Discard)
+	processor := newCommandOutputProcessor(io.Discard, io.Discard)
 	runner := newJobRun(Runner{Cache: provider, Redactor: &testRedactor{}})
 	if err := runner.runJavaScriptPhase(
 		t.Context(), processor, actionRoot, node,
@@ -734,7 +734,7 @@ func TestCacheRedactorFailureAbortsBeforeExecutionAndScrubsToken(t *testing.T) {
 		return CacheCredentials{ResultsURL: "https://cache.example", Token: token}, nil
 	})
 	var logs bytes.Buffer
-	processor := newCommandProcessor(&logs, &logs)
+	processor := newCommandOutputProcessor(&logs, &logs)
 	result := newResult()
 	result.Env["MARKER"] = marker
 	err := newJobRun(Runner{Cache: provider, Redactor: failingCacheRedactor{token: token}}).runJavaScriptPhase(
@@ -772,7 +772,7 @@ func TestActionRuntimeCacheTokenCommandFileEffectsAreDiscarded(t *testing.T) {
 			result.Paths = []string{"/existing/path"}
 			state := map[string]string{"kept": "action state"}
 			err := newJobRun(Runner{Cache: provider, Redactor: &testRedactor{}}).runJavaScriptPhase(
-				t.Context(), newCommandProcessor(io.Discard, io.Discard), actionRoot, node,
+				t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), actionRoot, node,
 				javaScriptAction{Name: "ordinary", Path: actionRoot, Main: "main.js"}, "main.js", nil, state, &result,
 			)
 			if err == nil || strings.Contains(err.Error(), token) || !strings.Contains(err.Error(), "phase effects were discarded") {

--- a/internal/runtime/checkout.go
+++ b/internal/runtime/checkout.go
@@ -72,7 +72,7 @@ func validCheckoutRepository(repository string) bool {
 	return parts[0] != "." && parts[0] != ".." && parts[1] != "." && parts[1] != ".."
 }
 
-func (r Runner) runCheckout(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, commit string, inputs map[string]string) (Result, error) {
+func (r Runner) runCheckout(ctx context.Context, processor *commandOutputProcessor, workspace string, job plan.Job, commit string, inputs map[string]string) (Result, error) {
 	result := newResult()
 	const adapter = "checkout adapter"
 	credentialed := job.HasCapability("provider-token-read") && r.RepositoryCredentials != nil
@@ -352,7 +352,7 @@ func (w *checkoutSubmoduleStatusWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-func (r Runner) runCheckoutSubmodules(ctx context.Context, processor *commandProcessor, workspace string, git string, env map[string]string, base []string, depth string, recursive, credentialed bool, credentialHost string) error {
+func (r Runner) runCheckoutSubmodules(ctx context.Context, processor *commandOutputProcessor, workspace string, git string, env map[string]string, base []string, depth string, recursive, credentialed bool, credentialHost string) error {
 	policy := append(append([]string{}, base...), "-c", "url.https://github.com/.insteadOf=git@github.com:")
 	run := func(withCredentials bool, args ...string) error {
 		if withCredentials {
@@ -386,7 +386,7 @@ func (r Runner) runCheckoutSubmodules(ctx context.Context, processor *commandPro
 	}
 
 	status := &checkoutSubmoduleStatusWriter{}
-	statusProcessor := newCommandProcessor(status, processor.stderr)
+	statusProcessor := newCommandOutputProcessor(status, processor.stderr)
 	if err := r.runStreaming(ctx, statusProcessor, workspace, env, git, append(policy, statusArgs...)...); err != nil {
 		return fmt.Errorf("git submodule status: %w", err)
 	}
@@ -581,7 +581,7 @@ func repositoryProviderCheckoutCredentialArgs(base []string, agent, host string)
 	)
 }
 
-func (r Runner) runRepositoryProviderCheckoutGit(ctx context.Context, processor *commandProcessor, workspace string, env map[string]string, git string, base, commandArgs []string, credentialHost string) error {
+func (r Runner) runRepositoryProviderCheckoutGit(ctx context.Context, processor *commandOutputProcessor, workspace string, env map[string]string, git string, base, commandArgs []string, credentialHost string) error {
 	credentialEnv, err := r.repositoryProviderCheckoutCredentialEnvironment(processor, env, credentialHost)
 	if err != nil {
 		return err
@@ -593,7 +593,7 @@ func (r Runner) runRepositoryProviderCheckoutGit(ctx context.Context, processor 
 	return processor.scrubError(r.runStreamingCommand(ctx, processor, cmd))
 }
 
-func (r Runner) runRepositoryProviderCheckoutLFS(ctx context.Context, processor *commandProcessor, workspace string, env map[string]string, gitLFS string, commandArgs []string, credentialHost string) error {
+func (r Runner) runRepositoryProviderCheckoutLFS(ctx context.Context, processor *commandOutputProcessor, workspace string, env map[string]string, gitLFS string, commandArgs []string, credentialHost string) error {
 	credentialEnv, err := r.repositoryProviderCheckoutCredentialEnvironment(processor, env, credentialHost)
 	if err != nil {
 		return err
@@ -606,7 +606,7 @@ func (r Runner) runRepositoryProviderCheckoutLFS(ctx context.Context, processor 
 	return processor.scrubError(r.runStreamingCommand(ctx, processor, cmd))
 }
 
-func (r Runner) repositoryProviderCheckoutCredentialEnvironment(processor *commandProcessor, env map[string]string, credentialHost string) (map[string]string, error) {
+func (r Runner) repositoryProviderCheckoutCredentialEnvironment(processor *commandOutputProcessor, env map[string]string, credentialHost string) (map[string]string, error) {
 	credentials := r.RepositoryCredentials
 	if credentials == nil || credentials.Agent == "" || !filepath.IsAbs(credentials.Agent) {
 		return nil, fmt.Errorf("repository-provider credentials were not resolved before workflow execution")

--- a/internal/runtime/checkout_test.go
+++ b/internal/runtime/checkout_test.go
@@ -276,7 +276,7 @@ printf '%s\n' "$*" >> ` + shellTestQuote(gitLog) + `
 	}
 	var logs bytes.Buffer
 	result, err := (Runner{Git: git, RepositoryCredentials: credentials, Stdout: &logs, Stderr: &logs}).runCheckout(
-		t.Context(), newCommandProcessor(&logs, &logs), workspace, job, actionintegration.CheckoutV7Commit, nil,
+		t.Context(), newCommandOutputProcessor(&logs, &logs), workspace, job, actionintegration.CheckoutV7Commit, nil,
 	)
 	if err != nil {
 		t.Fatalf("runCheckout() error = %v, logs = %q", err, logs.String())
@@ -304,7 +304,7 @@ printf '%s\n' "$*" >> ` + shellTestQuote(gitLog) + `
 
 func TestCheckoutAdapterRejectsUnsupportedInputsAndState(t *testing.T) {
 	repository, sha := "buildkite/buildkite-gha", strings.Repeat("a", 40)
-	processor := newCommandProcessor(io.Discard, io.Discard)
+	processor := newCommandOutputProcessor(io.Discard, io.Discard)
 	job := plan.Job{Event: plan.Event{Provider: "github", Repository: repository, SHA: sha}}
 	if _, err := (Runner{}).runCheckout(t.Context(), processor, t.TempDir(), job, actionintegration.CheckoutV7Commit, map[string]string{"token": ""}); err == nil || !strings.Contains(err.Error(), "unsupported") {
 		t.Fatalf("runCheckout() unsupported input error = %v", err)
@@ -464,7 +464,7 @@ esac
 		t.Fatal(err)
 	}
 	job := plan.Job{Event: plan.Event{Provider: "github", Repository: "buildkite/buildkite-gha", SHA: sha}}
-	if _, err := (Runner{Git: git, GitLFS: gitLFS}).runCheckout(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, job, actionintegration.CheckoutV7Commit, map[string]string{"lfs": "true", "submodules": "true"}); err != nil {
+	if _, err := (Runner{Git: git, GitLFS: gitLFS}).runCheckout(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), workspace, job, actionintegration.CheckoutV7Commit, map[string]string{"lfs": "true", "submodules": "true"}); err != nil {
 		t.Fatal(err)
 	}
 	commands, err := os.ReadFile(gitLog)
@@ -493,7 +493,7 @@ func TestCheckoutSubmoduleNativeCommandSequenceAndFlags(t *testing.T) {
 		t.Fatal(err)
 	}
 	runner := Runner{Stdout: io.Discard, Stderr: io.Discard}
-	if err := runner.runCheckoutSubmodules(t.Context(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), git, map[string]string{}, checkoutGitBaseArgs(), "7", true, false, ""); err != nil {
+	if err := runner.runCheckoutSubmodules(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), t.TempDir(), git, map[string]string{}, checkoutGitBaseArgs(), "7", true, false, ""); err != nil {
 		t.Fatal(err)
 	}
 	contents, err := os.ReadFile(logPath)
@@ -532,7 +532,7 @@ exit 0
 			if err := os.WriteFile(git, []byte(script), 0o700); err != nil {
 				t.Fatal(err)
 			}
-			err := (Runner{Stdout: io.Discard, Stderr: io.Discard}).runCheckoutSubmodules(t.Context(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), git, map[string]string{}, checkoutGitBaseArgs(), "0", false, false, "")
+			err := (Runner{Stdout: io.Discard, Stderr: io.Discard}).runCheckoutSubmodules(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), t.TempDir(), git, map[string]string{}, checkoutGitBaseArgs(), "0", false, false, "")
 			if err == nil || !strings.Contains(err.Error(), "invalid state") {
 				t.Fatalf("status prefix %q error = %v", prefix, err)
 			}
@@ -564,7 +564,7 @@ func TestCheckoutSubmodulesUsesNativePorcelain(t *testing.T) {
 			if test.depthOne {
 				depth = "1"
 			}
-			if err := runner.runCheckoutSubmodules(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, "git", map[string]string{"HOME": filepath.Join(workspace, ".no-home"), "GIT_CONFIG_NOSYSTEM": "1", "GIT_CONFIG_GLOBAL": os.DevNull}, base, depth, test.recursive, false, ""); err != nil {
+			if err := runner.runCheckoutSubmodules(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), workspace, "git", map[string]string{"HOME": filepath.Join(workspace, ".no-home"), "GIT_CONFIG_NOSYSTEM": "1", "GIT_CONFIG_GLOBAL": os.DevNull}, base, depth, test.recursive, false, ""); err != nil {
 				t.Fatal(err)
 			}
 			childPath := filepath.Join(workspace, "deps", "child")
@@ -629,7 +629,7 @@ func TestSubmoduleResolvedCredentialsWithoutCapabilityDoNotInvokeHelper(t *testi
 		t.Fatal(err)
 	}
 	runner := Runner{RepositoryCredentials: &AgentRepositoryCredentials{Agent: agent, JobID: testCacheJobID, JobToken: "secret"}, Stdout: io.Discard, Stderr: io.Discard}
-	if err := runner.runCheckoutSubmodules(t.Context(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), git, map[string]string{}, checkoutGitBaseArgs(), "0", false, false, ""); err != nil {
+	if err := runner.runCheckoutSubmodules(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), t.TempDir(), git, map[string]string{}, checkoutGitBaseArgs(), "0", false, false, ""); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(marker); !os.IsNotExist(err) {
@@ -670,7 +670,7 @@ echo job-secret
 	}
 	var logs bytes.Buffer
 	runner := Runner{RepositoryCredentials: &AgentRepositoryCredentials{Agent: agent, JobID: testCacheJobID, JobToken: "job-secret"}, Stdout: &logs, Stderr: &logs}
-	if err := runner.runRepositoryProviderCheckoutGit(t.Context(), newCommandProcessor(&logs, &logs), workspace, map[string]string{}, git, checkoutGitBaseArgs(), []string{"submodule", "update"}, "github.com"); err != nil {
+	if err := runner.runRepositoryProviderCheckoutGit(t.Context(), newCommandOutputProcessor(&logs, &logs), workspace, map[string]string{}, git, checkoutGitBaseArgs(), []string{"submodule", "update"}, "github.com"); err != nil {
 		t.Fatal(err)
 	}
 	input, err := os.ReadFile(inputLog)
@@ -907,7 +907,7 @@ exec ` + shellTestQuote(realGit) + ` "$@"
 	runner := Runner{Stdout: io.Discard, Stderr: io.Discard, InterruptGrace: 20 * time.Millisecond, TerminateGrace: 20 * time.Millisecond}
 	done := make(chan error, 1)
 	go func() {
-		done <- runner.runCheckoutSubmodules(ctx, newCommandProcessor(io.Discard, io.Discard), workspace, wrapper, map[string]string{}, append(checkoutGitBaseArgs(), "-c", "protocol.file.allow=always"), "1", false, false, "")
+		done <- runner.runCheckoutSubmodules(ctx, newCommandOutputProcessor(io.Discard, io.Discard), workspace, wrapper, map[string]string{}, append(checkoutGitBaseArgs(), "-c", "protocol.file.allow=always"), "1", false, false, "")
 	}()
 	deadline := time.Now().Add(5 * time.Second)
 	for {
@@ -955,7 +955,7 @@ exit 0
 	runner := Runner{Stdout: io.Discard, Stderr: io.Discard, InterruptGrace: 20 * time.Millisecond, TerminateGrace: 20 * time.Millisecond}
 	done := make(chan error, 1)
 	go func() {
-		done <- runner.runCheckoutSubmodules(ctx, newCommandProcessor(io.Discard, io.Discard), t.TempDir(), git, map[string]string{}, checkoutGitBaseArgs(), "0", true, false, "")
+		done <- runner.runCheckoutSubmodules(ctx, newCommandOutputProcessor(io.Discard, io.Discard), t.TempDir(), git, map[string]string{}, checkoutGitBaseArgs(), "0", true, false, "")
 	}()
 	deadline := time.Now().Add(5 * time.Second)
 	for {
@@ -985,7 +985,7 @@ func TestCheckoutRejectsInvalidRepositoryBeforeInspectingWorkspace(t *testing.T)
 		t.Fatal(err)
 	}
 	job := plan.Job{Event: plan.Event{Provider: "github", Repository: "owner/..", SHA: strings.Repeat("a", 40)}}
-	processor := newCommandProcessor(io.Discard, io.Discard)
+	processor := newCommandOutputProcessor(io.Discard, io.Discard)
 	if _, err := (Runner{}).runCheckout(t.Context(), processor, workspace, job, actionintegration.CheckoutV7Commit, nil); err == nil || !strings.Contains(err.Error(), "valid GitHub or Origin event repository") {
 		t.Fatalf("checkout repository validation error = %v", err)
 	}
@@ -995,7 +995,7 @@ func TestCheckoutRejectsUnavailableLFSBeforeCreatingPath(t *testing.T) {
 	workspace := t.TempDir()
 	job := plan.Job{Event: plan.Event{Provider: "github", Repository: "buildkite/buildkite-gha", SHA: strings.Repeat("a", 40)}}
 	inputs := map[string]string{"lfs": "true", "path": "sources/application"}
-	if _, err := (Runner{}).runCheckout(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, job, actionintegration.CheckoutV7Commit, inputs); err == nil || !strings.Contains(err.Error(), "requires Git LFS to be resolved") {
+	if _, err := (Runner{}).runCheckout(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), workspace, job, actionintegration.CheckoutV7Commit, inputs); err == nil || !strings.Contains(err.Error(), "requires Git LFS to be resolved") {
 		t.Fatalf("unavailable Git LFS error = %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(workspace, "sources")); !os.IsNotExist(err) {
@@ -1176,7 +1176,7 @@ printf '%s|git-lfs %s|%s core.hooksPath=%s\n' "$PWD" "$*" "$helper" "$hooks" >> 
 		t.Fatal(err)
 	}
 	var logs bytes.Buffer
-	processor := newCommandProcessor(&logs, &logs)
+	processor := newCommandOutputProcessor(&logs, &logs)
 	job := plan.Job{
 		Event:                plan.Event{Provider: "github", Repository: "buildkite/buildkite-gha", Ref: "refs/heads/main", SHA: sha},
 		RequiredCapabilities: []string{"network", "provider-token-read"},
@@ -1351,7 +1351,7 @@ esac
 	}
 	credentials := &AgentRepositoryCredentials{Agent: agent, JobID: testCacheJobID, JobToken: "job-secret"}
 	var logs bytes.Buffer
-	processor := newCommandProcessor(&logs, &logs)
+	processor := newCommandOutputProcessor(&logs, &logs)
 	if _, err := (Runner{Git: git, RepositoryCredentials: credentials, Stdout: &logs, Stderr: &logs}).runCheckout(t.Context(), processor, workspace, job, actionintegration.CheckoutV7Commit, nil); err == nil {
 		t.Fatal("runCheckout() succeeded after repository-provider helper denial")
 	}
@@ -1700,7 +1700,7 @@ func TestRepositoryProviderCheckoutRequiresPreResolvedGit(t *testing.T) {
 		RequiredCapabilities: []string{"provider-token-read"},
 	}
 	credentials := &AgentRepositoryCredentials{Agent: "/usr/bin/buildkite-agent", JobID: testCacheJobID, JobToken: "job-secret"}
-	if _, err := (Runner{Git: "git", RepositoryCredentials: credentials}).runCheckout(t.Context(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), job, actionintegration.CheckoutV7Commit, nil); err == nil || !strings.Contains(err.Error(), "resolved before workflow execution") {
+	if _, err := (Runner{Git: "git", RepositoryCredentials: credentials}).runCheckout(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), t.TempDir(), job, actionintegration.CheckoutV7Commit, nil); err == nil || !strings.Contains(err.Error(), "resolved before workflow execution") {
 		t.Fatalf("runCheckout() unresolved Git error = %v", err)
 	}
 }

--- a/internal/runtime/command_output_processor.go
+++ b/internal/runtime/command_output_processor.go
@@ -20,10 +20,10 @@ const (
 	workflowCommandListEnd           = "</div>\n"
 )
 
-// A command processor turns process output into masked logs and bounded
-// Buildkite annotations. It applies GitHub workflow commands after parsing
-// them in workflow_command.go and keeps masking consistent across streams.
-type commandProcessor struct {
+// A command output processor consumes process output and runner messages. It
+// masks logs, interprets GitHub workflow commands parsed in workflow_command.go,
+// and collects bounded Buildkite annotations consistently across streams.
+type commandOutputProcessor struct {
 	mu              sync.Mutex
 	stdout          io.Writer
 	stderr          io.Writer
@@ -54,13 +54,13 @@ type parsedWorkflowCommand struct {
 	message    string
 }
 
-func newCommandProcessor(stdout, stderr io.Writer) *commandProcessor {
-	return &commandProcessor{stdout: stdout, stderr: stderr}
+func newCommandOutputProcessor(stdout, stderr io.Writer) *commandOutputProcessor {
+	return &commandOutputProcessor{stdout: stdout, stderr: stderr}
 }
 
 var errInvalidWorkflowCommandStopToken = errors.New("invalid ::stop-commands workflow command")
 
-func (p *commandProcessor) process(target io.Writer, line string) error {
+func (p *commandOutputProcessor) process(target io.Writer, line string) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.discard {
@@ -117,19 +117,19 @@ func (p *commandProcessor) process(target io.Writer, line string) error {
 	return nil
 }
 
-func (p *commandProcessor) logSection(name string) {
+func (p *commandOutputProcessor) logSection(name string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.writeLogSectionLocked(p.stdout, name)
 }
 
-func (p *commandProcessor) expandCurrentSection() {
+func (p *commandOutputProcessor) expandCurrentSection() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	_, _ = fmt.Fprintln(p.stdout, "^^^ +++")
 }
 
-func (p *commandProcessor) writeLogSectionLocked(target io.Writer, name string) {
+func (p *commandOutputProcessor) writeLogSectionLocked(target io.Writer, name string) {
 	name = sanitizeLogSectionText(p.maskTextLocked(name))
 	if name != "" {
 		_, _ = fmt.Fprintln(target, "--- "+name)
@@ -172,7 +172,7 @@ func validWorkflowCommandStopToken(token string) bool {
 	return true
 }
 
-func (p *commandProcessor) writeWorkflowCommandMessageLocked(target io.Writer, severity, message string) {
+func (p *commandOutputProcessor) writeWorkflowCommandMessageLocked(target io.Writer, severity, message string) {
 	if message == "" {
 		return
 	}
@@ -181,18 +181,18 @@ func (p *commandProcessor) writeWorkflowCommandMessageLocked(target io.Writer, s
 
 // trustedWarning records a runner-owned warning even after untrusted action
 // output has been suppressed, while preserving the job's registered masks.
-func (p *commandProcessor) trustedWarning(message string) {
+func (p *commandOutputProcessor) trustedWarning(message string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.appendWorkflowCommandLocked(&p.trustedWarnings, workflowWarningAnnotationHeading, parsedWorkflowCommand{message: message})
 	p.writeWorkflowCommandMessageLocked(p.stderr, "warning", message)
 }
 
-func (p *commandProcessor) writeMaskedLineLocked(target io.Writer, line string) {
+func (p *commandOutputProcessor) writeMaskedLineLocked(target io.Writer, line string) {
 	_, _ = fmt.Fprintln(target, p.maskTextLocked(line))
 }
 
-func (p *commandProcessor) writeLiteral(target io.Writer, line string) {
+func (p *commandOutputProcessor) writeLiteral(target io.Writer, line string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if !p.discard {
@@ -200,14 +200,14 @@ func (p *commandProcessor) writeLiteral(target io.Writer, line string) {
 	}
 }
 
-func (p *commandProcessor) maskTextLocked(text string) string {
+func (p *commandOutputProcessor) maskTextLocked(text string) string {
 	for _, mask := range p.masks {
 		text = strings.ReplaceAll(text, mask, "***")
 	}
 	return text
 }
 
-func (p *commandProcessor) appendWorkflowCommandLocked(buffer *workflowCommandAnnotationBuffer, heading string, command parsedWorkflowCommand) {
+func (p *commandOutputProcessor) appendWorkflowCommandLocked(buffer *workflowCommandAnnotationBuffer, heading string, command parsedWorkflowCommand) {
 	annotation := workflowCommandAnnotation{
 		file:     strings.Clone(commandText(command.properties["file"])),
 		title:    strings.Clone(commandText(command.properties["title"])),
@@ -217,7 +217,7 @@ func (p *commandProcessor) appendWorkflowCommandLocked(buffer *workflowCommandAn
 	p.appendWorkflowCommandAnnotationLocked(buffer, heading, annotation)
 }
 
-func (p *commandProcessor) appendWorkflowCommandAnnotationLocked(buffer *workflowCommandAnnotationBuffer, heading string, command workflowCommandAnnotation) {
+func (p *commandOutputProcessor) appendWorkflowCommandAnnotationLocked(buffer *workflowCommandAnnotationBuffer, heading string, command workflowCommandAnnotation) {
 	if buffer.truncated {
 		return
 	}
@@ -233,19 +233,19 @@ func (p *commandProcessor) appendWorkflowCommandAnnotationLocked(buffer *workflo
 	buffer.commands = append(buffer.commands, command)
 }
 
-func (p *commandProcessor) suppress() {
+func (p *commandOutputProcessor) suppress() {
 	p.mu.Lock()
 	p.discard = true
 	p.mu.Unlock()
 }
 
-func (p *commandProcessor) addMask(value string) {
+func (p *commandOutputProcessor) addMask(value string) {
 	p.mu.Lock()
 	p.addMaskLocked(value)
 	p.mu.Unlock()
 }
 
-func (p *commandProcessor) maskValues() []string {
+func (p *commandOutputProcessor) maskValues() []string {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return append([]string(nil), p.masks...)
@@ -259,7 +259,7 @@ type scrubbedCommandError struct {
 func (e scrubbedCommandError) Error() string { return e.message }
 func (e scrubbedCommandError) Unwrap() error { return e.cause }
 
-func (p *commandProcessor) scrubError(err error) error {
+func (p *commandOutputProcessor) scrubError(err error) error {
 	if err == nil {
 		return nil
 	}
@@ -292,7 +292,7 @@ func (p *commandProcessor) scrubError(err error) error {
 	return scrubbedCommandError{cause: err, message: message}
 }
 
-func (p *commandProcessor) workflowCommandAnnotations() (warnings string, warningsTruncated bool, errors string, errorsTruncated bool) {
+func (p *commandOutputProcessor) workflowCommandAnnotations() (warnings string, warningsTruncated bool, errors string, errorsTruncated bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	masks := normalizedMasks(p.masks)
@@ -314,7 +314,7 @@ func (p *commandProcessor) workflowCommandAnnotations() (warnings string, warnin
 	return warnings, warningsTruncated, errors, errorsTruncated
 }
 
-func (p *commandProcessor) addMaskLocked(value string) {
+func (p *commandOutputProcessor) addMaskLocked(value string) {
 	if value == "" {
 		return
 	}
@@ -332,7 +332,7 @@ func (p *commandProcessor) addMaskLocked(value string) {
 	})
 }
 
-func (p *commandProcessor) addMaskValueLocked(value string) {
+func (p *commandOutputProcessor) addMaskValueLocked(value string) {
 	if slices.Contains(p.masks, value) {
 		return
 	}

--- a/internal/runtime/concurrent.go
+++ b/internal/runtime/concurrent.go
@@ -188,7 +188,7 @@ func bindHashFilesContext(ctx context.Context, eval *expression.Context) {
 	}
 }
 
-func (r *jobRun) executePlanStep(jobCtx, runCtx context.Context, processor *commandProcessor, workspace string, job plan.Job, step plan.Step, invocationID string, jobEnv, stepEnv map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations) stepExecution {
+func (r *jobRun) executePlanStep(jobCtx, runCtx context.Context, processor *commandOutputProcessor, workspace string, job plan.Job, step plan.Step, invocationID string, jobEnv, stepEnv map[string]string, eval expression.Context, posts *postRegistry, actions *actionLockResolver, prepared remotePreparations) stepExecution {
 	result, err := r.runJobStep(runCtx, processor, workspace, job, step, invocationID, jobEnv, stepEnv, eval, posts, actions, prepared)
 	return classifyStepExecutionWithControls(jobCtx, runCtx, step, result, err, eval)
 }

--- a/internal/runtime/containers.go
+++ b/internal/runtime/containers.go
@@ -43,7 +43,7 @@ type serviceContainer struct {
 
 type jobContainerBackend struct {
 	runner                    Runner
-	processor                 *commandProcessor
+	processor                 *commandOutputProcessor
 	docker                    string
 	env                       map[string]string
 	config                    string
@@ -79,7 +79,7 @@ func privateDocker(r Runner) (string, string, map[string]string, error) {
 	return docker, config, map[string]string{"DOCKER_CONFIG": config}, nil
 }
 
-func (r Runner) startJobContainerOrdered(ctx context.Context, processor *commandProcessor, workspace, temp string, spec *plan.Container, services map[string]plan.ServiceContainer, serviceOrder []string, extra ...containerMount) (_ *jobContainerBackend, err error) {
+func (r Runner) startJobContainerOrdered(ctx context.Context, processor *commandOutputProcessor, workspace, temp string, spec *plan.Container, services map[string]plan.ServiceContainer, serviceOrder []string, extra ...containerMount) (_ *jobContainerBackend, err error) {
 	if spec != nil {
 		if err := validateEnvironmentNames(spec.Env); err != nil {
 			return nil, fmt.Errorf("job container environment: %w", err)
@@ -375,7 +375,7 @@ func dockerLogin(ctx context.Context, env map[string]string, docker, registry, u
 	return errors.New("docker login failed")
 }
 
-func (r Runner) pullContainerImage(ctx context.Context, processor *commandProcessor, env map[string]string, docker, image string) error {
+func (r Runner) pullContainerImage(ctx context.Context, processor *commandOutputProcessor, env map[string]string, docker, image string) error {
 	var err error
 	for attempt := range 3 {
 		if err = r.runStreaming(ctx, processor, "", env, docker, "pull", image); err == nil {
@@ -542,7 +542,7 @@ func appendPublishedPorts(args, ports []string) []string {
 	return args
 }
 
-func (b *jobContainerBackend) waitForService(ctx context.Context, processor *commandProcessor, serviceID, name string) error {
+func (b *jobContainerBackend) waitForService(ctx context.Context, processor *commandOutputProcessor, serviceID, name string) error {
 	const format = `{{if .State.Health}}{{.State.Health.Status}}{{end}}`
 	delay := 2 * time.Second
 	for {
@@ -579,7 +579,7 @@ func (b *jobContainerBackend) waitForService(ctx context.Context, processor *com
 	}
 }
 
-func (b *jobContainerBackend) serviceDiagnostics(parent context.Context, processor *commandProcessor, name string) {
+func (b *jobContainerBackend) serviceDiagnostics(parent context.Context, processor *commandOutputProcessor, name string) {
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(parent), serviceDiagnosticTimeout)
 	defer cancel()
 	b.emitServiceLogOutput(processor, b.serviceLogOutput(ctx, name))
@@ -590,7 +590,7 @@ func (b *jobContainerBackend) serviceLogOutput(ctx context.Context, name string)
 	return output
 }
 
-func (b *jobContainerBackend) emitServiceLogOutput(processor *commandProcessor, output string) {
+func (b *jobContainerBackend) emitServiceLogOutput(processor *commandOutputProcessor, output string) {
 	for line := range strings.SplitSeq(strings.TrimSuffix(strings.ReplaceAll(output, "\r\n", "\n"), "\n"), "\n") {
 		if line != "" {
 			processor.writeLiteral(processor.stderr, line)
@@ -645,7 +645,7 @@ func (b *jobContainerBackend) hostPath(path string) string {
 	return best
 }
 
-func (b *jobContainerBackend) exec(ctx context.Context, r Runner, processor *commandProcessor, dir string, env map[string]string, name string, argv ...string) error {
+func (b *jobContainerBackend) exec(ctx context.Context, r Runner, processor *commandOutputProcessor, dir string, env map[string]string, name string, argv ...string) error {
 	if err := validateEnvironmentNames(env); err != nil {
 		return err
 	}

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -37,7 +37,7 @@ import (
 
 // startJobContainer is a test convenience that starts services in sorted-key
 // order; production callers supply the evaluated service order directly.
-func (r Runner) startJobContainer(ctx context.Context, processor *commandProcessor, workspace, temp string, spec *plan.Container, services map[string]plan.ServiceContainer, extra ...containerMount) (*jobContainerBackend, error) {
+func (r Runner) startJobContainer(ctx context.Context, processor *commandOutputProcessor, workspace, temp string, spec *plan.Container, services map[string]plan.ServiceContainer, extra ...containerMount) (*jobContainerBackend, error) {
 	return r.startJobContainerOrdered(ctx, processor, workspace, temp, spec, services, sortedKeys(services), extra...)
 }
 
@@ -881,7 +881,7 @@ func TestRunJobContainerServicesLifecycleAndArguments(t *testing.T) {
 
 func TestRunServiceContainerAutoRemoveCleanup(t *testing.T) {
 	f := newJobDocker(t, "service-auto-remove")
-	b, err := (Runner{Docker: f.path}).startJobContainer(t.Context(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Options: "--rm"}})
+	b, err := (Runner{Docker: f.path}).startJobContainer(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Options: "--rm"}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -907,7 +907,7 @@ func TestRunServiceContainerAutoRemoveCleanup(t *testing.T) {
 
 func TestRunServiceContainerAlreadyAutoRemovedCleanup(t *testing.T) {
 	f := newJobDocker(t, "")
-	b, err := (Runner{Docker: f.path}).startJobContainer(t.Context(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Options: "--rm"}})
+	b, err := (Runner{Docker: f.path}).startJobContainer(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Options: "--rm"}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -928,7 +928,7 @@ func TestRunServiceContainerAlreadyAutoRemovedCleanup(t *testing.T) {
 
 func TestRunServiceContainerAutoRemoveBetweenQueryAndStop(t *testing.T) {
 	f := newJobDocker(t, "service-auto-remove-before-stop")
-	b, err := (Runner{Docker: f.path}).startJobContainer(t.Context(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Options: "--rm"}})
+	b, err := (Runner{Docker: f.path}).startJobContainer(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Options: "--rm"}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -991,7 +991,7 @@ func TestRunServiceContainerCompleteArguments(t *testing.T) {
 		Options: `--health-cmd "pg_isready -U postgres" --health-retries 5`,
 		Command: `postgres -c "fsync = off"`, Entrypoint: "docker-entrypoint.sh",
 	}
-	b, err := (Runner{Docker: f.path}).startJobContainer(t.Context(), newCommandProcessor(os.Stdout, os.Stderr), w, tmp, nil, map[string]plan.ServiceContainer{"database": service})
+	b, err := (Runner{Docker: f.path}).startJobContainer(t.Context(), newCommandOutputProcessor(os.Stdout, os.Stderr), w, tmp, nil, map[string]plan.ServiceContainer{"database": service})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1019,7 +1019,7 @@ func TestRunServiceContainerCompleteArguments(t *testing.T) {
 func TestRunServiceContainersUseDeclaredOrderAndEmitSuccessfulLogs(t *testing.T) {
 	f := newJobDocker(t, "service-log-command")
 	var output bytes.Buffer
-	processor := newCommandProcessor(&output, &output)
+	processor := newCommandOutputProcessor(&output, &output)
 	b, err := (Runner{Docker: f.path}).startJobContainerOrdered(
 		t.Context(), processor, t.TempDir(), t.TempDir(), nil,
 		map[string]plan.ServiceContainer{"alpha": {Image: "one"}, "zed": {Image: "two"}}, []string{"zed", "alpha"},
@@ -1053,7 +1053,7 @@ func TestRunServiceContainersUseDeclaredOrderAndEmitSuccessfulLogs(t *testing.T)
 func TestRunServiceContainerRegistryCredentialsUsePasswordStdin(t *testing.T) {
 	f := newJobDocker(t, "fail-login-once")
 	service := plan.ServiceContainer{Image: "registry.example.test/team/postgres:16", Credentials: &plan.ContainerCredentials{Username: "registry-user", Password: "registry-password"}}
-	b, err := (Runner{Docker: f.path}).startJobContainer(t.Context(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": service})
+	b, err := (Runner{Docker: f.path}).startJobContainer(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": service})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1115,7 +1115,7 @@ func TestRunServiceContainerPullsSameImagePerCredentialIdentity(t *testing.T) {
 		"a": {Image: image, Credentials: &plan.ContainerCredentials{Username: "user-a", Password: "password-a"}},
 		"b": {Image: image, Credentials: &plan.ContainerCredentials{Username: "user-b", Password: "password-b"}},
 	}
-	b, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).startJobContainer(t.Context(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), &plan.Container{Image: image}, services)
+	b, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).startJobContainer(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), &plan.Container{Image: image}, services)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1140,7 +1140,7 @@ func TestRunServiceContainerPullsSameImagePerCredentialIdentity(t *testing.T) {
 func TestRunServiceContainerPartialRegistryCredentialsDoNotLogin(t *testing.T) {
 	for _, credentials := range []*plan.ContainerCredentials{{Username: "registry-user"}, {Password: "registry-password"}} {
 		f := newJobDocker(t, "")
-		b, err := (Runner{Docker: f.path}).startJobContainer(t.Context(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "registry.example.test/postgres:16", Credentials: credentials}})
+		b, err := (Runner{Docker: f.path}).startJobContainer(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "registry.example.test/postgres:16", Credentials: credentials}})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1277,7 +1277,7 @@ func TestRunServiceContainerRemovesOnlyNewNamedVolumes(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			b, err := (Runner{Docker: f.path}).startJobContainer(t.Context(), newCommandProcessor(os.Stdout, os.Stderr), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Volumes: []string{test.volume}}})
+			b, err := (Runner{Docker: f.path}).startJobContainer(t.Context(), newCommandOutputProcessor(os.Stdout, os.Stderr), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Volumes: []string{test.volume}}})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1297,7 +1297,7 @@ func TestRunServiceContainerRemovesOnlyNewNamedVolumes(t *testing.T) {
 
 func TestRunServiceContainerReportsLeftoverNamedVolume(t *testing.T) {
 	f := newJobDocker(t, "volume-leftover")
-	b, err := (Runner{Docker: f.path}).startJobContainer(t.Context(), newCommandProcessor(os.Stdout, os.Stderr), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Volumes: []string{"database:/data"}}})
+	b, err := (Runner{Docker: f.path}).startJobContainer(t.Context(), newCommandOutputProcessor(os.Stdout, os.Stderr), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Volumes: []string{"database:/data"}}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1308,7 +1308,7 @@ func TestRunServiceContainerReportsLeftoverNamedVolume(t *testing.T) {
 
 func TestRunServiceContainerReadsBroadDockerPortOutput(t *testing.T) {
 	f := newJobDocker(t, "broad-port")
-	b, err := (Runner{Docker: f.path}).startJobContainer(t.Context(), newCommandProcessor(os.Stdout, os.Stderr), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Ports: []string{"8000-8001:80-81"}, Options: "--publish 8002:82/sctp"}})
+	b, err := (Runner{Docker: f.path}).startJobContainer(t.Context(), newCommandOutputProcessor(os.Stdout, os.Stderr), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Ports: []string{"8000-8001:80-81"}, Options: "--publish 8002:82/sctp"}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1321,7 +1321,7 @@ func TestRunServiceContainerReadsBroadDockerPortOutput(t *testing.T) {
 
 func TestRunServiceContainerOptionNameUsesCreatedReference(t *testing.T) {
 	f := newJobDocker(t, "")
-	b, err := (Runner{Docker: f.path}).startJobContainer(t.Context(), newCommandProcessor(os.Stdout, os.Stderr), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Options: "--name custom-service"}})
+	b, err := (Runner{Docker: f.path}).startJobContainer(t.Context(), newCommandOutputProcessor(os.Stdout, os.Stderr), t.TempDir(), t.TempDir(), nil, map[string]plan.ServiceContainer{"database": {Image: "postgres:16", Options: "--name custom-service"}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1338,7 +1338,7 @@ func TestRunJobContainerServiceFailureDiagnosticsAreMasked(t *testing.T) {
 	f := newJobDocker(t, "service-unhealthy")
 	w, tmp := t.TempDir(), t.TempDir()
 	var output bytes.Buffer
-	p := newCommandProcessor(&output, &output)
+	p := newCommandOutputProcessor(&output, &output)
 	p.addMask("sibling-secret")
 	_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).startJobContainer(t.Context(), p, w, tmp, &plan.Container{Image: "alpine"}, map[string]plan.ServiceContainer{"db": {Image: "postgres"}})
 	if err == nil || !strings.Contains(err.Error(), `service "db"`) || !strings.Contains(err.Error(), `status "unhealthy"`) {
@@ -1397,7 +1397,7 @@ func TestRunJobContainerMalformedServicePortsIncludeMaskedDiagnostics(t *testing
 	f := newJobDocker(t, "malformed-port")
 	w, tmp := t.TempDir(), t.TempDir()
 	var output bytes.Buffer
-	p := newCommandProcessor(&output, &output)
+	p := newCommandOutputProcessor(&output, &output)
 	p.addMask("sibling-secret")
 	_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).startJobContainer(t.Context(), p, w, tmp, nil, map[string]plan.ServiceContainer{"db": {Image: "postgres", Ports: []string{"6379"}}})
 	if err == nil || !strings.Contains(err.Error(), `service "db" has malformed Docker port output`) {
@@ -1411,7 +1411,7 @@ func TestRunJobContainerMalformedServicePortsIncludeMaskedDiagnostics(t *testing
 func TestRunJobContainerLaterServiceCreateFailureCleansExactServices(t *testing.T) {
 	f := newJobDocker(t, "fail-later-service-create")
 	w, tmp := t.TempDir(), t.TempDir()
-	_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).startJobContainer(t.Context(), newCommandProcessor(os.Stdout, os.Stderr), w, tmp, &plan.Container{Image: "alpine"}, map[string]plan.ServiceContainer{"a": {Image: "one"}, "b": {Image: "two"}})
+	_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).startJobContainer(t.Context(), newCommandOutputProcessor(os.Stdout, os.Stderr), w, tmp, &plan.Container{Image: "alpine"}, map[string]plan.ServiceContainer{"a": {Image: "one"}, "b": {Image: "two"}})
 	if err == nil || !strings.Contains(err.Error(), `create service "b"`) {
 		t.Fatalf("error=%v, want second service create failure", err)
 	}
@@ -1438,7 +1438,7 @@ func TestRunJobContainerServiceReadinessCancellationCleansEverything(t *testing.
 	ctx, cancel := context.WithCancel(t.Context())
 	done := make(chan error, 1)
 	go func() {
-		_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).startJobContainer(ctx, newCommandProcessor(os.Stdout, os.Stderr), w, tmp, &plan.Container{Image: "alpine"}, map[string]plan.ServiceContainer{"db": {Image: "postgres"}})
+		_, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0]}).startJobContainer(ctx, newCommandOutputProcessor(os.Stdout, os.Stderr), w, tmp, &plan.Container{Image: "alpine"}, map[string]plan.ServiceContainer{"db": {Image: "postgres"}})
 		done <- err
 	}()
 	deadline := time.Now().Add(10 * time.Second)
@@ -1462,7 +1462,7 @@ func TestRunHostJobServiceReadinessCancellationCleansEverything(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	done := make(chan error, 1)
 	go func() {
-		_, err := (Runner{Docker: f.path}).startJobContainer(ctx, newCommandProcessor(os.Stdout, os.Stderr), w, tmp, nil, map[string]plan.ServiceContainer{"db": {Image: "postgres"}})
+		_, err := (Runner{Docker: f.path}).startJobContainer(ctx, newCommandOutputProcessor(os.Stdout, os.Stderr), w, tmp, nil, map[string]plan.ServiceContainer{"db": {Image: "postgres"}})
 		done <- err
 	}()
 	deadline := time.Now().Add(10 * time.Second)
@@ -1644,7 +1644,7 @@ func startTestBackend(t *testing.T, f fakeJobDocker) (*jobContainerBackend, stri
 	t.Helper()
 	w := t.TempDir()
 	tmp := t.TempDir()
-	b, e := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], InterruptGrace: 20 * time.Millisecond, TerminateGrace: 20 * time.Millisecond}).startJobContainer(t.Context(), newCommandProcessor(os.Stdout, os.Stderr), w, tmp, &plan.Container{Image: "alpine:3.20"}, nil)
+	b, e := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], InterruptGrace: 20 * time.Millisecond, TerminateGrace: 20 * time.Millisecond}).startJobContainer(t.Context(), newCommandOutputProcessor(os.Stdout, os.Stderr), w, tmp, &plan.Container{Image: "alpine:3.20"}, nil)
 	if e != nil {
 		t.Fatal(e)
 	}
@@ -1662,7 +1662,7 @@ func TestRunJobContainerCancellationTargetsProcessTree(t *testing.T) {
 	defer cancel()
 	done := make(chan error, 1)
 	go func() {
-		done <- b.exec(ctx, b.runner, newCommandProcessor(os.Stdout, os.Stderr), w, map[string]string{}, "sh", "-c", `trap '' TERM INT; sleep 30 & echo $! > alive; wait`)
+		done <- b.exec(ctx, b.runner, newCommandOutputProcessor(os.Stdout, os.Stderr), w, map[string]string{}, "sh", "-c", `trap '' TERM INT; sleep 30 & echo $! > alive; wait`)
 	}()
 	var pidb []byte
 	deadline := time.Now().Add(2 * time.Second)
@@ -1711,10 +1711,10 @@ func TestRunJobContainerConcurrentExecUsesUniquePIDFiles(t *testing.T) {
 	d1 := make(chan error, 1)
 	d2 := make(chan error, 1)
 	go func() {
-		d1 <- b.exec(c1, b.runner, newCommandProcessor(os.Stdout, os.Stderr), w, nil, "sh", "-c", "sleep 30")
+		d1 <- b.exec(c1, b.runner, newCommandOutputProcessor(os.Stdout, os.Stderr), w, nil, "sh", "-c", "sleep 30")
 	}()
 	go func() {
-		d2 <- b.exec(t.Context(), b.runner, newCommandProcessor(os.Stdout, os.Stderr), w, nil, "sh", "-c", "sleep .3")
+		d2 <- b.exec(t.Context(), b.runner, newCommandOutputProcessor(os.Stdout, os.Stderr), w, nil, "sh", "-c", "sleep .3")
 	}()
 	time.Sleep(100 * time.Millisecond)
 	x()
@@ -1832,7 +1832,7 @@ func TestJobContainerExecRejectsInvalidEnvironmentNamesBeforeDocker(t *testing.T
 				t.Fatal(err)
 			}
 			backend := jobContainerBackend{docker: docker, container: "job", workspace: t.TempDir(), temp: t.TempDir()}
-			err := backend.exec(t.Context(), Runner{}, newCommandProcessor(io.Discard, io.Discard), backend.workspace, map[string]string{name: "value"}, "true")
+			err := backend.exec(t.Context(), Runner{}, newCommandOutputProcessor(io.Discard, io.Discard), backend.workspace, map[string]string{name: "value"}, "true")
 			if err == nil || !strings.Contains(err.Error(), "invalid environment variable name") {
 				t.Fatalf("exec() error = %v, want invalid environment name", err)
 			}
@@ -2556,7 +2556,7 @@ func TestRunJobContainerSiblingDockerFailureCleansActionAndJobResources(t *testi
 func TestRunDockerRejectsMismatchedJobContainerPaths(t *testing.T) {
 	r := newJobRun(Runner{})
 	r.jobContainer = &jobContainerBackend{workspace: "/owned/workspace", temp: "/owned/temp"}
-	_, err := r.runDocker(t.Context(), newCommandProcessor(nil, nil), dockerAction{Workspace: "/other/workspace", runnerTemp: "/owned/temp"})
+	_, err := r.runDocker(t.Context(), newCommandOutputProcessor(nil, nil), dockerAction{Workspace: "/other/workspace", runnerTemp: "/owned/temp"})
 	if err == nil || !strings.Contains(err.Error(), "must match the job container's owned host paths") {
 		t.Fatalf("mismatched sibling paths error = %v", err)
 	}

--- a/internal/runtime/download_artifact.go
+++ b/internal/runtime/download_artifact.go
@@ -39,7 +39,7 @@ type downloadStage struct {
 	stagedFiles int
 }
 
-func (r Runner) runDownloadArtifact(ctx context.Context, processor *commandProcessor, workspace string, needs map[string]plan.Need, commit string, inputs map[string]string) (result Result, returnErr error) {
+func (r Runner) runDownloadArtifact(ctx context.Context, processor *commandOutputProcessor, workspace string, needs map[string]plan.Need, commit string, inputs map[string]string) (result Result, returnErr error) {
 	result = newResult()
 	defer func() { returnErr = processor.scrubError(returnErr) }()
 	if err := ctx.Err(); err != nil {

--- a/internal/runtime/download_artifact_test.go
+++ b/internal/runtime/download_artifact_test.go
@@ -127,7 +127,7 @@ func TestDownloadArtifactExactNeedAndDirectExtraction(t *testing.T) {
 	archive, size, digest := testDownloadZIP(t, "nested/result.txt")
 	store := &downloadStore{archive: archive}
 	workspace := t.TempDir()
-	processor := newCommandProcessor(io.Discard, io.Discard)
+	processor := newCommandOutputProcessor(io.Discard, io.Discard)
 	need := plan.NeedArtifact{Name: "payload", ID: "42", Path: "buildkite-gha/v1/artifacts/" + strings.Repeat("a", 64) + ".zip", Digest: digest, Size: size, FileCount: 1, Producer: plan.NeedProducer{JobID: "11111111-1111-4111-8111-111111111111"}}
 	result, err := (Runner{Artifacts: store}).runDownloadArtifact(t.Context(), processor, workspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{need}}}, actionintegration.DownloadArtifactCommit, map[string]string{"name": "payload", "path": "out"})
 	if err != nil {
@@ -173,7 +173,7 @@ func TestDownloadArtifactSupportsAuditedCommitsAndNonASCIIExactName(t *testing.T
 				inputs["skip-decompress"] = "False"
 				inputs["digest-mismatch"] = "error"
 			}
-			result, err := (Runner{Artifacts: &downloadStore{archive: archive}}).runDownloadArtifact(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{artifact}}}, commit, inputs)
+			result, err := (Runner{Artifacts: &downloadStore{archive: archive}}).runDownloadArtifact(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), workspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{artifact}}}, commit, inputs)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -196,7 +196,7 @@ func TestNativeArtifactRoundTripTrimsNameAndAcceptsHighCompression(t *testing.T)
 	}
 	uploader := &captureArtifactUploader{}
 	uploadRunner := newJobRun(Runner{Artifacts: uploader})
-	upload, err := uploadRunner.runUploadArtifact(t.Context(), newCommandProcessor(io.Discard, io.Discard), uploadWorkspace, map[string]string{"name": " payload ", "path": "zeros.bin"})
+	upload, err := uploadRunner.runUploadArtifact(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), uploadWorkspace, map[string]string{"name": " payload ", "path": "zeros.bin"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -214,7 +214,7 @@ func TestNativeArtifactRoundTripTrimsNameAndAcceptsHighCompression(t *testing.T)
 		Producer: plan.NeedProducer{JobID: "11111111-1111-4111-8111-111111111111"},
 	}
 	downloadWorkspace := t.TempDir()
-	_, err = (Runner{Artifacts: &downloadStore{archive: archive}}).runDownloadArtifact(t.Context(), newCommandProcessor(io.Discard, io.Discard), downloadWorkspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{artifact}}}, actionintegration.DownloadArtifactV801Commit, map[string]string{"name": " payload "})
+	_, err = (Runner{Artifacts: &downloadStore{archive: archive}}).runDownloadArtifact(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), downloadWorkspace, map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{artifact}}}, actionintegration.DownloadArtifactV801Commit, map[string]string{"name": " payload "})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -237,7 +237,7 @@ func TestDownloadArtifactPatternMergesVerifiedDirectNeeds(t *testing.T) {
 	store := &downloadStore{archives: map[string]string{firstPath: firstArchive, secondPath: secondArchive}}
 	workspace := t.TempDir()
 	result, err := (Runner{Artifacts: store}).runDownloadArtifact(
-		t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace,
+		t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), workspace,
 		map[string]plan.Need{"test": {Artifacts: []plan.NeedArtifact{second, ignored, first}}},
 		actionintegration.DownloadArtifactV5Commit,
 		map[string]string{"pattern": "junit-xml-25-*", "path": "junit-xml", "merge-multiple": "true"},
@@ -270,7 +270,7 @@ func TestDownloadArtifactMultiPrefixDeduplicatesAndOrdersVerifiedProducers(t *te
 	workspace := t.TempDir()
 
 	_, err := (Runner{Artifacts: store}).runDownloadArtifact(
-		t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace,
+		t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), workspace,
 		map[string]plan.Need{"backend": {Artifacts: []plan.NeedArtifact{product}}, "products": {Artifacts: []plan.NeedArtifact{backend}}},
 		actionintegration.DownloadArtifactV5Commit,
 		map[string]string{"pattern": "{junit-results,junit-results-backend,product-junit-results}-*", "path": "junit", "merge-multiple": "true"},
@@ -295,7 +295,7 @@ func TestDownloadArtifactPatternRejectsTooManyMatchesBeforeDownload(t *testing.T
 	}
 	store := &downloadStore{}
 	_, err := (Runner{Artifacts: store}).runDownloadArtifact(
-		t.Context(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(),
+		t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), t.TempDir(),
 		map[string]plan.Need{"producer": {Artifacts: artifacts}}, actionintegration.DownloadArtifactV5Commit,
 		map[string]string{"pattern": "{backend,product}-*", "merge-multiple": "true"},
 	)
@@ -320,7 +320,7 @@ func TestDownloadArtifactPatternStagesCompleteMergeBeforeDestinationMutation(t *
 	t.Run("later artifact name wins overlapping member", func(t *testing.T) {
 		workspace := t.TempDir()
 		store := &downloadStore{archives: map[string]string{firstPath: firstArchive, secondPath: secondArchive}}
-		if _, err := (Runner{Artifacts: store}).runDownloadArtifact(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, needs, actionintegration.DownloadArtifactV5Commit, inputs); err != nil {
+		if _, err := (Runner{Artifacts: store}).runDownloadArtifact(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), workspace, needs, actionintegration.DownloadArtifactV5Commit, inputs); err != nil {
 			t.Fatal(err)
 		}
 		if got, err := os.ReadFile(filepath.Join(workspace, "merged", "result.xml")); err != nil || string(got) != "second" {
@@ -334,7 +334,7 @@ func TestDownloadArtifactPatternStagesCompleteMergeBeforeDestinationMutation(t *
 		invalid.Digest = "sha256:" + strings.Repeat("0", 64)
 		store := &downloadStore{archives: map[string]string{firstPath: firstArchive, secondPath: secondArchive}}
 		_, err := (Runner{Artifacts: store}).runDownloadArtifact(
-			t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace,
+			t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), workspace,
 			map[string]plan.Need{"test": {Artifacts: []plan.NeedArtifact{invalid, first}}},
 			actionintegration.DownloadArtifactV5Commit, inputs,
 		)
@@ -359,7 +359,7 @@ func TestDownloadArtifactPatternRejectsDuplicateNamesAcrossNeeds(t *testing.T) {
 	store := &downloadStore{archives: map[string]string{firstPath: archive, secondPath: archive}}
 
 	_, err := (Runner{Artifacts: store}).runDownloadArtifact(
-		t.Context(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(),
+		t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), t.TempDir(),
 		map[string]plan.Need{"first": {Artifacts: []plan.NeedArtifact{first}}, "second": {Artifacts: []plan.NeedArtifact{second}}},
 		actionintegration.DownloadArtifactV5Commit,
 		map[string]string{"pattern": "*", "merge-multiple": "true"},
@@ -374,7 +374,7 @@ func TestDownloadArtifactPatternRejectsDuplicateNamesAcrossNeeds(t *testing.T) {
 
 func TestDownloadArtifactRejectsMaskedNameWithoutDisclosure(t *testing.T) {
 	const maskedName = "runtime-secret-artifact"
-	processor := newCommandProcessor(io.Discard, io.Discard)
+	processor := newCommandOutputProcessor(io.Discard, io.Discard)
 	processor.addMask(maskedName)
 	_, err := (Runner{}).runDownloadArtifact(t.Context(), processor, t.TempDir(), nil, actionintegration.DownloadArtifactCommit, map[string]string{"name": maskedName})
 	if err == nil || strings.Contains(err.Error(), maskedName) || !strings.Contains(err.Error(), "registered mask") {
@@ -389,7 +389,7 @@ func TestDownloadArtifactScrubsMaskedMemberFromDestinationErrors(t *testing.T) {
 	if err := os.Mkdir(filepath.Join(workspace, maskedMember), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	processor := newCommandProcessor(io.Discard, io.Discard)
+	processor := newCommandOutputProcessor(io.Discard, io.Discard)
 	processor.addMask(maskedMember)
 	artifact := plan.NeedArtifact{
 		Name: "payload", Path: "buildkite-gha/v1/artifacts/" + strings.Repeat("d", 64) + ".zip",
@@ -409,7 +409,7 @@ func TestDownloadArtifactScrubsQuotedMaskedDestinationFromErrors(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(workspace, maskedDestination), []byte("collision"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	processor := newCommandProcessor(io.Discard, io.Discard)
+	processor := newCommandOutputProcessor(io.Discard, io.Discard)
 	processor.addMask(maskedDestination)
 	artifact := plan.NeedArtifact{
 		Name: "payload", Path: "buildkite-gha/v1/artifacts/" + strings.Repeat("e", 64) + ".zip",
@@ -806,7 +806,7 @@ func TestDownloadArtifactCancellationCleansPartialAgentDownload(t *testing.T) {
 		cancel()
 		return ctx.Err()
 	}}
-	_, err := (Runner{Artifacts: store}).runDownloadArtifact(ctx, newCommandProcessor(io.Discard, io.Discard), t.TempDir(), map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{artifact}}}, actionintegration.DownloadArtifactCommit, map[string]string{"name": "payload"})
+	_, err := (Runner{Artifacts: store}).runDownloadArtifact(ctx, newCommandOutputProcessor(io.Discard, io.Discard), t.TempDir(), map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{artifact}}}, actionintegration.DownloadArtifactCommit, map[string]string{"name": "payload"})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("cancellation error = %v", err)
 	}
@@ -830,7 +830,7 @@ func TestDownloadArtifactRejectsManifestAndDownloadMismatch(t *testing.T) {
 			artifact := base
 			store := &downloadStore{archive: archive}
 			test.alter(&artifact, store)
-			_, err := (Runner{Artifacts: store}).runDownloadArtifact(t.Context(), newCommandProcessor(io.Discard, io.Discard), t.TempDir(), map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{artifact}}}, actionintegration.DownloadArtifactCommit, map[string]string{"name": "payload"})
+			_, err := (Runner{Artifacts: store}).runDownloadArtifact(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), t.TempDir(), map[string]plan.Need{"producer": {Artifacts: []plan.NeedArtifact{artifact}}}, actionintegration.DownloadArtifactCommit, map[string]string{"name": "payload"})
 			if err == nil {
 				t.Fatal("mismatched download accepted")
 			}

--- a/internal/runtime/job_run.go
+++ b/internal/runtime/job_run.go
@@ -16,7 +16,7 @@ type jobRun struct {
 	job             plan.Job
 	workspace       string
 	callerWorkspace bool
-	processor       *commandProcessor
+	processor       *commandOutputProcessor
 	eval            expression.Context
 	result          JobResult
 	runtimeEnv      map[string]string

--- a/internal/runtime/oidc_token_service.go
+++ b/internal/runtime/oidc_token_service.go
@@ -163,12 +163,12 @@ type idTokenService struct {
 	listener   net.Listener
 	provider   OIDCTokenProvider
 	redactor   Redactor
-	processor  *commandProcessor
+	processor  *commandOutputProcessor
 	mu         sync.RWMutex
 	authHashes map[[sha256.Size]byte]struct{}
 }
 
-func startIDTokenService(ctx context.Context, provider OIDCTokenProvider, redactor Redactor, processor *commandProcessor) (*idTokenService, error) {
+func startIDTokenService(ctx context.Context, provider OIDCTokenProvider, redactor Redactor, processor *commandOutputProcessor) (*idTokenService, error) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return nil, fmt.Errorf("start actions ID-token service: %w", err)

--- a/internal/runtime/oidc_token_service_test.go
+++ b/internal/runtime/oidc_token_service_test.go
@@ -135,7 +135,7 @@ func (p *testOIDCTokenProvider) OIDCToken(ctx context.Context, audience string) 
 func TestIDTokenServiceWireContract(t *testing.T) {
 	provider := &testOIDCTokenProvider{token: "header.payload.signature", requireLiveContext: true}
 	redactor := &testRedactor{}
-	processor := newCommandProcessor(&bytes.Buffer{}, &bytes.Buffer{})
+	processor := newCommandOutputProcessor(&bytes.Buffer{}, &bytes.Buffer{})
 	service, err := startIDTokenService(t.Context(), provider, redactor, processor)
 	if err != nil {
 		t.Fatal(err)
@@ -182,7 +182,7 @@ func TestIDTokenServicePreservesPermanentMintFailureStatus(t *testing.T) {
 	for _, status := range []int{http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound, http.StatusUnprocessableEntity} {
 		t.Run(http.StatusText(status), func(t *testing.T) {
 			provider := &testOIDCTokenProvider{err: oidcTokenStatusError(status)}
-			service, err := startIDTokenService(t.Context(), provider, &testRedactor{}, newCommandProcessor(&bytes.Buffer{}, &bytes.Buffer{}))
+			service, err := startIDTokenService(t.Context(), provider, &testRedactor{}, newCommandOutputProcessor(&bytes.Buffer{}, &bytes.Buffer{}))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/runtime/process_execution.go
+++ b/internal/runtime/process_execution.go
@@ -25,8 +25,8 @@ const (
 
 // Process execution bridges action invocations to host or container processes.
 // It supplies the explicit environment and file-command paths, streams output
-// through the command processor, and owns cancellation of the process group.
-func (r *jobRun) runProcess(ctx context.Context, processor *commandProcessor, dir string, env map[string]string, result *Result, state map[string]string, name string, args ...string) error {
+// through the command output processor, and owns cancellation of the process group.
+func (r *jobRun) runProcess(ctx context.Context, processor *commandOutputProcessor, dir string, env map[string]string, result *Result, state map[string]string, name string, args ...string) error {
 	var files commandFiles
 	var err error
 	if r.jobContainer != nil {
@@ -68,14 +68,14 @@ func (r *jobRun) runProcess(ctx context.Context, processor *commandProcessor, di
 	return errors.Join(runErr, fileErr)
 }
 
-func (effects fileCommandEffects) reportSummaryUploadFailure(processor *commandProcessor) {
+func (effects fileCommandEffects) reportSummaryUploadFailure(processor *commandOutputProcessor) {
 	if effects.summaryBytes <= maxCommandFileBytes {
 		return
 	}
 	_ = processor.process(processor.stderr, fmt.Sprintf("GITHUB_STEP_SUMMARY upload skipped: content is %d bytes; maximum is %d bytes", effects.summaryBytes, maxCommandFileBytes))
 }
 
-func (r Runner) runStreaming(ctx context.Context, processor *commandProcessor, dir string, env map[string]string, name string, args ...string) error {
+func (r Runner) runStreaming(ctx context.Context, processor *commandOutputProcessor, dir string, env map[string]string, name string, args ...string) error {
 	if err := validateEnvironmentNames(env); err != nil {
 		return err
 	}
@@ -102,7 +102,7 @@ func resolveExecutableInPath(name, path string) (string, error) {
 	return "", &exec.Error{Name: name, Err: exec.ErrNotFound}
 }
 
-func (r Runner) runStreamingCommand(ctx context.Context, processor *commandProcessor, cmd *exec.Cmd) error {
+func (r Runner) runStreamingCommand(ctx context.Context, processor *commandOutputProcessor, cmd *exec.Cmd) error {
 	configureProcessGroup(cmd)
 	stdout, stdoutWriter, err := os.Pipe()
 	if err != nil {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -257,10 +257,10 @@ func (r Runner) runDockerAction(ctx context.Context, action dockerAction) (resul
 		return newResult(), fmt.Errorf("make Docker runner temp writable: %w", e)
 	}
 	action.runnerTemp = temp
-	return newJobRun(r).runDocker(ctx, newCommandProcessor(r.stdout(), r.stderr()), action)
+	return newJobRun(r).runDocker(ctx, newCommandOutputProcessor(r.stdout(), r.stderr()), action)
 }
 
-func (r *jobRun) runDocker(ctx context.Context, processor *commandProcessor, action dockerAction) (result Result, err error) {
+func (r *jobRun) runDocker(ctx context.Context, processor *commandOutputProcessor, action dockerAction) (result Result, err error) {
 	result = newResult()
 	if err := validateEnvironmentNames(action.Env); err != nil {
 		return result, err
@@ -637,7 +637,7 @@ func (w *limitedWriter) Write(p []byte) (int, error) {
 	return w.writer.Write(p)
 }
 
-func (r *jobRun) runJavaScriptPhase(ctx context.Context, processor *commandProcessor, workspace, node string, action javaScriptAction, entry string, stateEnv, stateOut map[string]string, result *Result) error {
+func (r *jobRun) runJavaScriptPhase(ctx context.Context, processor *commandOutputProcessor, workspace, node string, action javaScriptAction, entry string, stateEnv, stateOut map[string]string, result *Result) error {
 	env := mergeStringMaps(result.Env, action.Env, actionInputEnv(action.Inputs))
 	if path, ok := result.Env["PATH"]; ok {
 		env["PATH"] = path

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -2659,7 +2659,7 @@ func TestCancellationTerminatesChildProcessGroup(t *testing.T) {
 	pidFile := filepath.Join(t.TempDir(), "child.pid")
 	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 	defer cancel()
-	err := (Runner{InterruptGrace: 50 * time.Millisecond, TerminateGrace: 50 * time.Millisecond}).runStreaming(ctx, newCommandProcessor(io.Discard, io.Discard), "", map[string]string{"PID_FILE": pidFile}, "sh", "-c", `(trap '' INT TERM; sleep 30) & echo $! > "$PID_FILE"; wait`)
+	err := (Runner{InterruptGrace: 50 * time.Millisecond, TerminateGrace: 50 * time.Millisecond}).runStreaming(ctx, newCommandOutputProcessor(io.Discard, io.Discard), "", map[string]string{"PID_FILE": pidFile}, "sh", "-c", `(trap '' INT TERM; sleep 30) & echo $! > "$PID_FILE"; wait`)
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("runStreaming() error = %v, want deadline", err)
 	}
@@ -2706,7 +2706,7 @@ func TestCancellationEscalatesFromInterruptToTermination(t *testing.T) {
 		cancel()
 	}()
 	runner := Runner{InterruptGrace: 50 * time.Millisecond, TerminateGrace: 500 * time.Millisecond}
-	err := runner.runStreaming(ctx, newCommandProcessor(io.Discard, io.Discard), "", map[string]string{"READY": ready, "SIGNALS": signals}, "bash", "-c", `
+	err := runner.runStreaming(ctx, newCommandOutputProcessor(io.Discard, io.Discard), "", map[string]string{"READY": ready, "SIGNALS": signals}, "bash", "-c", `
 trap 'printf "INT\n" >> "$SIGNALS"' INT
 trap 'printf "TERM\n" >> "$SIGNALS"; exit 0' TERM
 touch "$READY"
@@ -2748,7 +2748,7 @@ func TestCancellationPreservesInterruptGraceForDescendants(t *testing.T) {
 		cancel()
 	}()
 	runner := Runner{InterruptGrace: 2 * time.Second, TerminateGrace: 50 * time.Millisecond}
-	err := runner.runStreaming(ctx, newCommandProcessor(io.Discard, io.Discard), "", map[string]string{"READY": ready, "CHILD_READY": childReady, "CLEANED": cleaned}, "bash", "-c", `
+	err := runner.runStreaming(ctx, newCommandOutputProcessor(io.Discard, io.Discard), "", map[string]string{"READY": ready, "CHILD_READY": childReady, "CLEANED": cleaned}, "bash", "-c", `
 (
   trap 'sleep 0.3; touch "$CLEANED"; exit 0' INT
   touch "$CHILD_READY"
@@ -2790,7 +2790,7 @@ func TestCancellationWaitsForProcessGroupCleanupAfterOutputCloses(t *testing.T) 
 	}()
 	started := time.Now()
 	runner := Runner{InterruptGrace: 50 * time.Millisecond, TerminateGrace: 50 * time.Millisecond}
-	err := runner.runStreaming(ctx, newCommandProcessor(io.Discard, io.Discard), "", map[string]string{"PID_FILE": pidFile, "READY": ready}, "bash", "-c", `
+	err := runner.runStreaming(ctx, newCommandOutputProcessor(io.Discard, io.Discard), "", map[string]string{"PID_FILE": pidFile, "READY": ready}, "bash", "-c", `
 (trap '' INT TERM; exec >/dev/null 2>&1; while :; do sleep 1; done) &
 echo $! > "$PID_FILE"
 trap 'exit 0' INT
@@ -3870,7 +3870,7 @@ func TestConditionInspectionFailureAfterMainFailureStillRunsPostPhase(t *testing
 		Steps:   []plan.Step{{ID: "inspect", Kind: "run", Execution: &executionprogram.Step{Condition: invalidStepCondition}}},
 		Program: &executionprogram.Program{Version: executionprogram.Version},
 	}
-	run.processor = newCommandProcessor(io.Discard, io.Discard)
+	run.processor = newCommandOutputProcessor(io.Discard, io.Discard)
 	run.eval = expression.Context{Env: map[string]string{}, Steps: map[string]expression.StepStatus{}}
 	run.result = JobResult{Conclusion: "failure", Outputs: map[string]string{}, Env: map[string]string{}, State: map[string]string{}}
 	run.runtimeEnv = map[string]string{}
@@ -4738,7 +4738,7 @@ func TestLiveLogMaskingPrefersLongestMatchInEitherRegistrationOrder(t *testing.T
 		{"credential-with-suffix\nsecond-line", "credential"},
 	} {
 		var logs bytes.Buffer
-		processor := newCommandProcessor(&logs, &logs)
+		processor := newCommandOutputProcessor(&logs, &logs)
 		for _, mask := range masks {
 			processor.addMask(mask)
 		}
@@ -4770,7 +4770,7 @@ func TestRunStreamingDrainsOversizedLineAndPreservesMasking(t *testing.T) {
 		t.Fatal(err)
 	}
 	var logs bytes.Buffer
-	processor := newCommandProcessor(&logs, &logs)
+	processor := newCommandOutputProcessor(&logs, &logs)
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 	err = (Runner{}).runStreaming(ctx, processor, "", map[string]string{"GO_WANT_RUNTIME_LONG_LINE": "1"}, executable, "-test.run=^TestLongLineChildProcess$")
@@ -4824,7 +4824,7 @@ func TestProcessEnvironmentIsExplicitAndUsable(t *testing.T) {
 		t.Setenv(name, "http://must-not-leak.invalid")
 	}
 	var logs bytes.Buffer
-	processor := newCommandProcessor(&logs, &logs)
+	processor := newCommandOutputProcessor(&logs, &logs)
 	command := `
 test -n "$PATH" && test -n "$HOME" && test -n "$TMPDIR"
 test "$DECLARED" = visible
@@ -4850,7 +4850,7 @@ func TestRunStreamingRejectsInvalidEnvironmentNamesBeforeExecution(t *testing.T)
 	for _, name := range []string{"", "ALIAS=OTHER", "NUL\x00NAME"} {
 		t.Run(fmt.Sprintf("%q", name), func(t *testing.T) {
 			marker := filepath.Join(t.TempDir(), "ran")
-			err := (Runner{}).runStreaming(t.Context(), newCommandProcessor(io.Discard, io.Discard), "", map[string]string{name: "value"}, "sh", "-c", `touch "$1"`, "sh", marker)
+			err := (Runner{}).runStreaming(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), "", map[string]string{name: "value"}, "sh", "-c", `touch "$1"`, "sh", marker)
 			if err == nil || !strings.Contains(err.Error(), "invalid environment variable name") {
 				t.Fatalf("runStreaming() error = %v, want invalid environment name", err)
 			}
@@ -4860,7 +4860,7 @@ func TestRunStreamingRejectsInvalidEnvironmentNamesBeforeExecution(t *testing.T)
 		})
 	}
 
-	if err := (Runner{}).runStreaming(t.Context(), newCommandProcessor(io.Discard, io.Discard), "", map[string]string{"GITHUB-ACTIONS_NAME.1": "valid"}, "true"); err != nil {
+	if err := (Runner{}).runStreaming(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), "", map[string]string{"GITHUB-ACTIONS_NAME.1": "valid"}, "true"); err != nil {
 		t.Fatalf("valid GitHub Actions environment name was rejected: %v", err)
 	}
 }
@@ -4876,7 +4876,7 @@ func TestRunDockerRejectsInvalidEnvironmentNamesBeforeDocker(t *testing.T) {
 			action := fakeDockerAction(t)
 			action.runnerTemp = t.TempDir()
 			action.Env = map[string]string{name: "value"}
-			_, err := newJobRun(Runner{Docker: docker}).runDocker(t.Context(), newCommandProcessor(io.Discard, io.Discard), action)
+			_, err := newJobRun(Runner{Docker: docker}).runDocker(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), action)
 			if err == nil || !strings.Contains(err.Error(), "invalid environment variable name") {
 				t.Fatalf("runDocker() error = %v, want invalid environment name", err)
 			}
@@ -4889,7 +4889,7 @@ func TestRunDockerRejectsInvalidEnvironmentNamesBeforeDocker(t *testing.T) {
 
 func TestWorkflowCommandsProduceBoundedMaskedJobAnnotations(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	processor := newCommandProcessor(&stdout, &stderr)
+	processor := newCommandOutputProcessor(&stdout, &stderr)
 	_ = processor.process(&stdout, "::warning title=Unsafe <title>,file=cmd%2Cmain.go,line=12,endLine=12,col=3,endColumn=5::late-secret <late-secret-tag> <warning>")
 	_ = processor.process(&stdout, "::add-mask::late-secret")
 	_ = processor.process(&stdout, "::add-mask::<late-secret-tag>")
@@ -4933,7 +4933,7 @@ func TestWorkflowCommandsProduceBoundedMaskedJobAnnotations(t *testing.T) {
 }
 
 func TestWorkflowCommandAnnotationsGroupRowsByFile(t *testing.T) {
-	processor := newCommandProcessor(io.Discard, io.Discard)
+	processor := newCommandOutputProcessor(io.Discard, io.Discard)
 	for _, command := range []string{
 		"::warning file=path/to/first.go,line=2,title=First::first message",
 		"::warning file=second.go,line=7,col=3::second message",
@@ -4963,7 +4963,7 @@ func TestWorkflowCommandAnnotationsGroupRowsByFile(t *testing.T) {
 }
 
 func TestWorkflowCommandAnnotationRetainsOnlyOwnedRenderedFields(t *testing.T) {
-	processor := newCommandProcessor(io.Discard, io.Discard)
+	processor := newCommandOutputProcessor(io.Discard, io.Discard)
 	properties := map[string]string{
 		"file": "main.go", "title": "Lint", "line": "7", "unknown": strings.Repeat("unused", 100_000),
 	}
@@ -5009,7 +5009,7 @@ func TestWorkflowCommandLocationLabels(t *testing.T) {
 
 func TestWorkflowPresentationCommandsUseBuildkiteSections(t *testing.T) {
 	var logs bytes.Buffer
-	processor := newCommandProcessor(&logs, &logs)
+	processor := newCommandOutputProcessor(&logs, &logs)
 	for _, line := range []string{
 		"::add-mask::---",
 		"::add-mask::+++",
@@ -5065,7 +5065,7 @@ func TestRunJobLogsSynchronousStepSectionsAndExpandsFailures(t *testing.T) {
 
 func TestWorkflowCommandStopTokenPreventsAccidentalAnnotations(t *testing.T) {
 	var logs bytes.Buffer
-	processor := newCommandProcessor(&logs, &logs)
+	processor := newCommandOutputProcessor(&logs, &logs)
 	_ = processor.process(&logs, "::stop-commands::workflow-stop-token")
 	_ = processor.process(&logs, "::warning::untrusted warning-shaped output")
 	_ = processor.process(&logs, "::workflow-stop-token::")
@@ -5082,7 +5082,7 @@ func TestWorkflowCommandStopTokenPreventsAccidentalAnnotations(t *testing.T) {
 
 func TestWorkflowCommandStopTokenHandlesCRLFStreams(t *testing.T) {
 	var logs bytes.Buffer
-	processor := newCommandProcessor(&logs, &logs)
+	processor := newCommandOutputProcessor(&logs, &logs)
 	command := `printf '::stop-commands::crlf-stop-token\r\n'
 printf '::warning::untrusted warning-shaped output\r\n'
 printf '::crlf-stop-token::\r\n'
@@ -5105,7 +5105,7 @@ printf 'masked after resume: crlf-secret\r\n'`
 }
 
 func TestRunStreamingScopesWorkflowCommandFailuresToInvocation(t *testing.T) {
-	processor := newCommandProcessor(io.Discard, io.Discard)
+	processor := newCommandOutputProcessor(io.Discard, io.Discard)
 	ready := filepath.Join(t.TempDir(), "clean-ready")
 	release := filepath.Join(t.TempDir(), "release-clean")
 	cleanDone := make(chan error, 1)
@@ -5186,7 +5186,7 @@ func TestRunJobCollectsWarningAndErrorCommandsWithoutChangingConclusion(t *testi
 }
 
 func TestWorkflowCommandAnnotationsAreConcurrentAndUTF8Bounded(t *testing.T) {
-	processor := newCommandProcessor(io.Discard, io.Discard)
+	processor := newCommandOutputProcessor(io.Discard, io.Discard)
 	var group sync.WaitGroup
 	for worker := range 2 {
 		group.Add(1)
@@ -5203,7 +5203,7 @@ func TestWorkflowCommandAnnotationsAreConcurrentAndUTF8Bounded(t *testing.T) {
 		t.Fatalf("concurrent warning annotation count = %d, truncated = %v", strings.Count(warnings, `class="border-top border-gray py2"`), truncated)
 	}
 
-	processor = newCommandProcessor(io.Discard, io.Discard)
+	processor = newCommandOutputProcessor(io.Discard, io.Discard)
 	_ = processor.process(io.Discard, "::warning::"+strings.Repeat("€", maxJobAnnotationBytes))
 	warnings, truncated, _, _ = processor.workflowCommandAnnotations()
 	result := scrubJobResult(JobResult{WarningAnnotations: warnings, warningsTruncated: truncated}, nil)
@@ -5213,7 +5213,7 @@ func TestWorkflowCommandAnnotationsAreConcurrentAndUTF8Bounded(t *testing.T) {
 }
 
 func TestWorkflowCommandAnnotationsNormalizeInvalidUTF8(t *testing.T) {
-	processor := newCommandProcessor(io.Discard, io.Discard)
+	processor := newCommandOutputProcessor(io.Discard, io.Discard)
 	command := `printf '::warning title=bad\377,file=bad\376.go::bad\375\n'`
 	if err := (Runner{}).runStreaming(t.Context(), processor, "", nil, "sh", "-c", command); err != nil {
 		t.Fatalf("runStreaming() error = %v", err)
@@ -5231,7 +5231,7 @@ func TestWorkflowCommandAnnotationsNormalizeInvalidUTF8(t *testing.T) {
 }
 
 func TestWorkflowCommandAnnotationScrubbingPreservesUTF8(t *testing.T) {
-	processor := newCommandProcessor(io.Discard, io.Discard)
+	processor := newCommandOutputProcessor(io.Discard, io.Discard)
 	_ = processor.process(io.Discard, "::warning::café")
 	_ = processor.process(io.Discard, "::warning::masked "+string([]byte{0xC3}))
 	_ = processor.process(io.Discard, "::add-mask::"+string([]byte{0xC3}))
@@ -5244,7 +5244,7 @@ func TestWorkflowCommandAnnotationScrubbingPreservesUTF8(t *testing.T) {
 }
 
 func TestWorkflowCommandMasksCannotCorruptAnnotationMarkup(t *testing.T) {
-	processor := newCommandProcessor(io.Discard, io.Discard)
+	processor := newCommandOutputProcessor(io.Discard, io.Discard)
 	_ = processor.process(io.Discard, "::warning file=table.go,title=tr::structured table text")
 	_ = processor.process(io.Discard, "::add-mask::tr")
 	_ = processor.process(io.Discard, "::add-mask::table")
@@ -5259,7 +5259,7 @@ func TestWorkflowCommandMasksCannotCorruptAnnotationMarkup(t *testing.T) {
 }
 
 func TestWorkflowCommandAnnotationsRemainBoundedAfterMaskExpansion(t *testing.T) {
-	processor := newCommandProcessor(io.Discard, io.Discard)
+	processor := newCommandOutputProcessor(io.Discard, io.Discard)
 	for range 5000 {
 		_ = processor.process(io.Discard, "::warning file=main.go::"+strings.Repeat("x", 100))
 	}
@@ -5535,7 +5535,7 @@ func TestJavaScriptPhaseUsesVerifiedMiseNodeWithoutWorkflowRedirection(t *testin
 	}
 	result := newResult()
 	action := javaScriptAction{Name: "mise", Path: root, Main: "main.js", Env: map[string]string{"MISE_DATA_DIR": "/workflow-controlled"}, nodeMajor: 24}
-	if err := runner.runJavaScriptPhase(t.Context(), newCommandProcessor(io.Discard, io.Discard), root, resolvedNode, action, action.Main, nil, nil, &result); err != nil {
+	if err := runner.runJavaScriptPhase(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), root, resolvedNode, action, action.Main, nil, nil, &result); err != nil {
 		t.Fatal(err)
 	}
 	data, err := os.ReadFile(log)

--- a/internal/runtime/shell_execution.go
+++ b/internal/runtime/shell_execution.go
@@ -13,7 +13,7 @@ import (
 	shellcompat "github.com/buildkite/buildkite-gha/internal/shell"
 )
 
-func (r *jobRun) runWorkflowShellStep(ctx context.Context, processor *commandProcessor, workspace string, job plan.Job, step plan.Step, env map[string]string, eval expression.Context) (Result, error) {
+func (r *jobRun) runWorkflowShellStep(ctx context.Context, processor *commandOutputProcessor, workspace string, job plan.Job, step plan.Step, env map[string]string, eval expression.Context) (Result, error) {
 	result := newResult()
 	script, err := evaluateProgramTyped[string](step.Execution.Run.Command, executionprogram.EvaluationContext{Expression: eval})
 	if err != nil {
@@ -50,7 +50,7 @@ func (r *jobRun) runWorkflowShellStep(ctx context.Context, processor *commandPro
 	return result, err
 }
 
-func (r *jobRun) runCompositeShellStep(ctx context.Context, processor *commandProcessor, workspace string, step *executionprogram.ActionStep, jobEnv map[string]string, eval expression.Context, result *Result) error {
+func (r *jobRun) runCompositeShellStep(ctx context.Context, processor *commandOutputProcessor, workspace string, step *executionprogram.ActionStep, jobEnv map[string]string, eval expression.Context, result *Result) error {
 	env, err := executionprogram.EvaluateBindings(step.Env, executionprogram.EvaluationContext{Expression: eval})
 	if err != nil {
 		return err
@@ -95,7 +95,7 @@ func shellCommand(shell, script string) ([]string, error) {
 	}
 }
 
-func (r *jobRun) runShellProcess(ctx context.Context, processor *commandProcessor, dir string, env map[string]string, result *Result, shell, script string) error {
+func (r *jobRun) runShellProcess(ctx context.Context, processor *commandOutputProcessor, dir string, env map[string]string, result *Result, shell, script string) error {
 	shell = strings.TrimSpace(shell)
 	if shell != "python" && !strings.Contains(shell, "{0}") {
 		args, err := shellCommand(shell, script)

--- a/internal/runtime/upload_artifact.go
+++ b/internal/runtime/upload_artifact.go
@@ -135,7 +135,7 @@ type archiveFile struct {
 	info       os.FileInfo
 }
 
-func (r *jobRun) runUploadArtifactCommit(ctx context.Context, processor *commandProcessor, workspace, commit string, inputs map[string]string) (result Result, returnErr error) {
+func (r *jobRun) runUploadArtifactCommit(ctx context.Context, processor *commandOutputProcessor, workspace, commit string, inputs map[string]string) (result Result, returnErr error) {
 	result = newResult()
 	defer func() { returnErr = processor.scrubError(returnErr) }()
 	if err := ctx.Err(); err != nil {

--- a/internal/runtime/upload_artifact_test.go
+++ b/internal/runtime/upload_artifact_test.go
@@ -34,7 +34,7 @@ type captureArtifactUploader struct {
 	err     error
 }
 
-func (r *jobRun) runUploadArtifact(ctx context.Context, processor *commandProcessor, workspace string, inputs map[string]string) (Result, error) {
+func (r *jobRun) runUploadArtifact(ctx context.Context, processor *commandOutputProcessor, workspace string, inputs map[string]string) (Result, error) {
 	return r.runUploadArtifactCommit(ctx, processor, workspace, actionintegration.UploadArtifactCommit, inputs)
 }
 
@@ -61,7 +61,7 @@ func TestUploadArtifactArchiveAndOutputs(t *testing.T) {
 	writeFixtureFile(t, workspace, "out/.hidden", "secret")
 	uploader := &captureArtifactUploader{}
 	r := newJobRun(Runner{Artifacts: uploader})
-	result, err := r.runUploadArtifact(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "out", "name": "logs", "compression-level": "0"})
+	result, err := r.runUploadArtifact(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "out", "name": "logs", "compression-level": "0"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -107,7 +107,7 @@ func TestUploadArtifactRuntimeVersionMatrix(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			uploader := &captureArtifactUploader{}
 			r := newJobRun(Runner{Artifacts: uploader})
-			result, err := r.runUploadArtifactCommit(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, test.commit, test.inputs)
+			result, err := r.runUploadArtifactCommit(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), workspace, test.commit, test.inputs)
 			if err != nil || len(uploader.uploads) != 1 || len(result.Artifacts) != 1 {
 				t.Fatalf("runtime matrix result = %#v, uploads = %d, error = %v", result, len(uploader.uploads), err)
 			}
@@ -128,7 +128,7 @@ func TestUploadArtifactRuntimeVersionMatrix(t *testing.T) {
 	}
 
 	r := newJobRun(Runner{Artifacts: &captureArtifactUploader{}})
-	if _, err := r.runUploadArtifactCommit(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, actionintegration.UploadArtifactCommit, map[string]string{"path": "payload", "archive": "true"}); err == nil || !strings.Contains(err.Error(), "only in actions/upload-artifact v7") {
+	if _, err := r.runUploadArtifactCommit(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), workspace, actionintegration.UploadArtifactCommit, map[string]string{"path": "payload", "archive": "true"}); err == nil || !strings.Contains(err.Error(), "only in actions/upload-artifact v7") {
 		t.Fatalf("runtime v4 archive mismatch error = %v", err)
 	}
 }
@@ -154,7 +154,7 @@ func TestUploadArtifactLegacyReleaseBehavior(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			uploader := &captureArtifactUploader{}
 			r := newJobRun(Runner{Artifacts: uploader})
-			result, err := r.runUploadArtifactCommit(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, test.commit, test.inputs)
+			result, err := r.runUploadArtifactCommit(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), workspace, test.commit, test.inputs)
 			if err != nil || len(uploader.uploads) != 1 || len(result.Artifacts) != 1 || len(result.Outputs) != 0 {
 				t.Fatalf("legacy upload result = %#v, uploads = %d, error = %v", result, len(uploader.uploads), err)
 			}
@@ -165,13 +165,13 @@ func TestUploadArtifactLegacyReleaseBehavior(t *testing.T) {
 	}
 
 	r := newJobRun(Runner{Artifacts: &captureArtifactUploader{}})
-	if _, err := r.runUploadArtifactCommit(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, actionintegration.UploadArtifactV1Commit, map[string]string{"name": "missing", "path": "missing"}); err == nil || !strings.Contains(err.Error(), "No files were found") {
+	if _, err := r.runUploadArtifactCommit(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), workspace, actionintegration.UploadArtifactV1Commit, map[string]string{"name": "missing", "path": "missing"}); err == nil || !strings.Contains(err.Error(), "No files were found") {
 		t.Fatalf("v1 missing path error = %v", err)
 	}
 
 	uploader := &captureArtifactUploader{}
 	r = newJobRun(Runner{Artifacts: uploader})
-	result, err := r.runUploadArtifactCommit(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, actionintegration.UploadArtifactV1Commit, map[string]string{"name": "empty", "path": "empty"})
+	result, err := r.runUploadArtifactCommit(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), workspace, actionintegration.UploadArtifactV1Commit, map[string]string{"name": "empty", "path": "empty"})
 	if err != nil || len(uploader.uploads) != 1 || len(result.Artifacts) != 1 || result.Artifacts[0].FileCount != 0 || len(readUploadZIP(t, uploader.uploads[0].data)) != 0 {
 		t.Fatalf("v1 empty directory result = %#v, uploads = %d, error = %v", result, len(uploader.uploads), err)
 	}
@@ -185,7 +185,7 @@ func TestUploadArtifactBoundedGlobAndAdvisoryRetention(t *testing.T) {
 	var stdout bytes.Buffer
 	uploader := &captureArtifactUploader{}
 	r := newJobRun(Runner{Artifacts: uploader})
-	result, err := r.runUploadArtifact(t.Context(), newCommandProcessor(&stdout, io.Discard), workspace, map[string]string{
+	result, err := r.runUploadArtifact(t.Context(), newCommandOutputProcessor(&stdout, io.Discard), workspace, map[string]string{
 		"path": "tests/*.log", "retention-days": "7",
 	})
 	if err != nil {
@@ -201,7 +201,7 @@ func TestUploadArtifactBoundedGlobAndAdvisoryRetention(t *testing.T) {
 	if err := os.Mkdir(filepath.Join(workspace, "tests", "directory.log"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := r.runUploadArtifact(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, map[string]string{
+	if _, err := r.runUploadArtifact(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), workspace, map[string]string{
 		"path": "tests/*.log", "name": "directory-match",
 	}); err != nil {
 		t.Fatal(err)
@@ -225,7 +225,7 @@ func TestUploadArtifactNormalizesFailurePathDirectories(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			uploader := &captureArtifactUploader{}
 			r := newJobRun(Runner{Artifacts: uploader})
-			_, err := r.runUploadArtifactCommit(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, actionintegration.UploadArtifactV6Commit, map[string]string{
+			_, err := r.runUploadArtifactCommit(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), workspace, actionintegration.UploadArtifactV6Commit, map[string]string{
 				"name": test.name, "path": test.path,
 			})
 			if err != nil {
@@ -240,7 +240,7 @@ func TestUploadArtifactNormalizesFailurePathDirectories(t *testing.T) {
 	writeFixtureFile(t, workspace, "report.txt", "not a directory")
 	uploader := &captureArtifactUploader{}
 	r := newJobRun(Runner{Artifacts: uploader})
-	if _, err := r.runUploadArtifactCommit(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, actionintegration.UploadArtifactV6Commit, map[string]string{
+	if _, err := r.runUploadArtifactCommit(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), workspace, actionintegration.UploadArtifactV6Commit, map[string]string{
 		"name": "directory-only", "path": "report.txt/", "if-no-files-found": "error",
 	}); err == nil || !strings.Contains(err.Error(), "No files were found") || len(uploader.uploads) != 0 {
 		t.Fatalf("trailing-slash file match error = %v, uploads = %d", err, len(uploader.uploads))
@@ -293,7 +293,7 @@ func TestUploadArtifactCanIncludeHiddenFiles(t *testing.T) {
 	writeFixtureFile(t, workspace, "out/.hidden", "included")
 	uploader := &captureArtifactUploader{}
 	r := newJobRun(Runner{Artifacts: uploader})
-	if _, err := r.runUploadArtifact(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "out", "include-hidden-files": "TRUE"}); err != nil {
+	if _, err := r.runUploadArtifact(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "out", "include-hidden-files": "TRUE"}); err != nil {
 		t.Fatal(err)
 	}
 	if got := readUploadZIP(t, uploader.uploads[0].data); !reflect.DeepEqual(got, map[string]string{".hidden": "included"}) {
@@ -365,7 +365,7 @@ func TestUploadArtifactArchiveRootUsesOnlyMatchedRoots(t *testing.T) {
 	writeFixtureFile(t, workspace, "out/result.txt", "matched")
 	uploader := &captureArtifactUploader{}
 	r := newJobRun(Runner{Artifacts: uploader})
-	if _, err := r.runUploadArtifact(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "out\nmissing"}); err != nil {
+	if _, err := r.runUploadArtifact(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "out\nmissing"}); err != nil {
 		t.Fatal(err)
 	}
 	if got := readUploadZIP(t, uploader.uploads[0].data); !reflect.DeepEqual(got, map[string]string{"result.txt": "matched"}) {
@@ -380,7 +380,7 @@ func TestUploadArtifactDoesNotStageInContainerWritableRunnerTemp(t *testing.T) {
 	uploader := &captureArtifactUploader{}
 	r := newJobRun(Runner{Artifacts: uploader})
 	r.runnerTemp = sharedRunnerTemp
-	if _, err := r.runUploadArtifact(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "result.txt"}); err != nil {
+	if _, err := r.runUploadArtifact(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "result.txt"}); err != nil {
 		t.Fatal(err)
 	}
 	if len(uploader.uploads) != 1 {
@@ -404,7 +404,7 @@ func TestUploadArtifactNoFilesModes(t *testing.T) {
 	for _, mode := range []string{"warn", "ignore"} {
 		t.Run(mode, func(t *testing.T) {
 			var stdout, stderr bytes.Buffer
-			processor := newCommandProcessor(&stdout, &stderr)
+			processor := newCommandOutputProcessor(&stdout, &stderr)
 			r := newJobRun(Runner{})
 			result, err := r.runUploadArtifact(t.Context(), processor, t.TempDir(), map[string]string{"path": "missing", "if-no-files-found": mode})
 			if err != nil || len(result.Outputs) != 0 || len(result.Artifacts) != 0 || len(r.artifactRegistry.names) != 0 {
@@ -423,7 +423,7 @@ func TestUploadArtifactNoFilesModes(t *testing.T) {
 		})
 	}
 	var stdout bytes.Buffer
-	processor := newCommandProcessor(&stdout, io.Discard)
+	processor := newCommandOutputProcessor(&stdout, io.Discard)
 	r := newJobRun(Runner{})
 	if _, err := r.runUploadArtifact(t.Context(), processor, t.TempDir(), map[string]string{"path": "missing", "if-no-files-found": "error"}); err == nil || err.Error() != message {
 		t.Fatalf("if-no-files-found error = %v", err)
@@ -436,7 +436,7 @@ func TestUploadArtifactNoFilesModes(t *testing.T) {
 
 func TestUploadArtifactScrubsExpressionDerivedPathsFromErrors(t *testing.T) {
 	const maskedPath = "runtime-secret-path"
-	processor := newCommandProcessor(io.Discard, io.Discard)
+	processor := newCommandOutputProcessor(io.Discard, io.Discard)
 	processor.addMask(maskedPath)
 	r := newJobRun(Runner{})
 	if _, err := r.runUploadArtifact(t.Context(), processor, t.TempDir(), map[string]string{
@@ -448,7 +448,7 @@ func TestUploadArtifactScrubsExpressionDerivedPathsFromErrors(t *testing.T) {
 	const quotedMask = `runtime"secret`
 	workspace := t.TempDir()
 	writeFixtureFile(t, workspace, quotedMask, "masked")
-	processor = newCommandProcessor(io.Discard, io.Discard)
+	processor = newCommandOutputProcessor(io.Discard, io.Discard)
 	processor.addMask(quotedMask)
 	if _, err := r.runUploadArtifact(t.Context(), processor, workspace, map[string]string{"path": quotedMask}); err == nil || strings.Contains(err.Error(), quotedMask) || strings.Contains(err.Error(), `runtime\"secret`) || !strings.Contains(err.Error(), "***") {
 		t.Fatalf("quoted masked path error = %v", err)
@@ -463,7 +463,7 @@ func TestUploadArtifactRejectsSymlinksMasksAndDuplicateNamesBeforeUpload(t *test
 	}
 	uploader := &captureArtifactUploader{}
 	r := newJobRun(Runner{Artifacts: uploader})
-	processor := newCommandProcessor(io.Discard, io.Discard)
+	processor := newCommandOutputProcessor(io.Discard, io.Discard)
 	if _, err := r.runUploadArtifact(t.Context(), processor, workspace, map[string]string{"path": "link/file"}); err == nil || !strings.Contains(err.Error(), "symlink") {
 		t.Fatalf("symlink error = %v", err)
 	}
@@ -471,7 +471,7 @@ func TestUploadArtifactRejectsSymlinksMasksAndDuplicateNamesBeforeUpload(t *test
 	if _, err := r.runUploadArtifact(t.Context(), processor, workspace, map[string]string{"path": "real/file", "name": "prefix-secret"}); err == nil || !strings.Contains(err.Error(), "registered mask") {
 		t.Fatalf("masked-name error = %v", err)
 	}
-	processor = newCommandProcessor(io.Discard, io.Discard)
+	processor = newCommandOutputProcessor(io.Discard, io.Discard)
 	if _, err := r.runUploadArtifact(t.Context(), processor, workspace, map[string]string{"path": "real/file", "name": "same"}); err != nil {
 		t.Fatal(err)
 	}
@@ -485,7 +485,7 @@ func TestUploadArtifactUploadFailureReleasesName(t *testing.T) {
 	writeFixtureFile(t, workspace, "file", "x")
 	uploader := &captureArtifactUploader{err: errors.New("upload failed")}
 	r := newJobRun(Runner{Artifacts: uploader})
-	if _, err := r.runUploadArtifact(t.Context(), newCommandProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "file"}); err == nil {
+	if _, err := r.runUploadArtifact(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "file"}); err == nil {
 		t.Fatal("upload failure was ignored")
 	}
 	if len(r.artifactRegistry.names) != 0 {
@@ -519,7 +519,7 @@ func TestUploadArtifactCancellationStopsEveryArchiveStage(t *testing.T) {
 	}
 	uploader := &captureArtifactUploader{}
 	r := newJobRun(Runner{Artifacts: uploader})
-	if _, err := r.runUploadArtifact(ctx, newCommandProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "payload"}); !errors.Is(err, context.Canceled) || len(uploader.uploads) != 0 {
+	if _, err := r.runUploadArtifact(ctx, newCommandOutputProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "payload"}); !errors.Is(err, context.Canceled) || len(uploader.uploads) != 0 {
 		t.Fatalf("adapter cancellation = %v, uploads = %d", err, len(uploader.uploads))
 	}
 
@@ -637,7 +637,7 @@ func TestUploadArtifactCancellationStopsAgentUpload(t *testing.T) {
 	r := newJobRun(Runner{Artifacts: cancellationArtifactUploader{started: started}})
 	done := make(chan error, 1)
 	go func() {
-		_, err := r.runUploadArtifact(ctx, newCommandProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "payload"})
+		_, err := r.runUploadArtifact(ctx, newCommandOutputProcessor(io.Discard, io.Discard), workspace, map[string]string{"path": "payload"})
 		done <- err
 	}()
 	select {


### PR DESCRIPTION
## Why

`commandProcessor` can read as though it executes commands, but its responsibility is consuming process output: masking logs, interpreting GitHub workflow commands, and collecting Buildkite annotations.

## What

Rename it to `commandOutputProcessor`, including its file, constructor, runtime call sites, and test references. Update the top-level documentation to state that it consumes both process output and runner messages. Behavior is unchanged.

This is part of PB-3178.
