### PR TITLE
PB-2721: Prove GitHub environment secret delivery against the live backend

### DIFF
--- a/.buildkite/environment-resolution-continuation.yml
+++ b/.buildkite/environment-resolution-continuation.yml
@@ -1,0 +1,45 @@
+agents:
+  queue: "hosted"
+
+steps:
+  - label: ":white_check_mark: Environment secret runtime proof complete"
+    key: "environment-resolution-complete"
+    depends_on:
+      - step: "gha-environment-secret"
+        allow_failure: true
+    timeout_in_minutes: 10
+    retry:
+      automatic: false
+    plugins:
+      - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
+          version: "2026.5.12"
+    command: |
+      set -euo pipefail
+      proof_root="$$(mktemp -d "$${TMPDIR:-/tmp}/buildkite-gha-environment-plan.XXXXXXXX")"
+      trap 'rm -rf -- "$$proof_root"' EXIT
+      buildkite-agent artifact download '.buildkite-gha/plans/*.json' "$$proof_root" --step environment-resolution-importer
+      mapfile -t plans < <(find "$$proof_root" -type f -path '*/.buildkite-gha/plans/*.json' -print)
+      if [[ "$${#plans[@]}" != 1 ]]; then
+        echo "Expected one immutable job plan, found $${#plans[@]}" >&2
+        exit 1
+      fi
+      mise exec -- jq -e '
+        (.secret_mappings | to_entries) as $$mappings
+        | (.required_secrets | type) == "array" and
+          (.required_secrets | length) == 1 and
+          ($$mappings | length) == 1 and
+          ($$mappings[0].key | test("^[A-Za-z_][A-Za-z0-9_]*$$")) and
+          ($$mappings[0].value == ("TEST_" + ($$mappings[0].key | ascii_upcase))) and
+          (.required_secrets[0] == $$mappings[0].value) and
+          (.workflow.logical_job_id == "environment-secret") and
+          (.target.step_key == "gha-environment-secret")
+      ' "$${plans[0]}" >/dev/null
+      echo 'The immutable plan requests exactly one TEST_<UPPERCASE_NAME> secret and maps it to the GitHub environment secret name'
+      outcome="$$(buildkite-agent step get outcome --step gha-environment-secret)"
+      if [[ "$$outcome" != passed ]]; then
+        secret_name="$$(buildkite-agent meta-data get environment-resolution-secret-name)"
+        secret_key="TEST_$${secret_name^^}"
+        echo "The runtime job did not pass. Confirm Buildkite secret $$secret_key exists and its access policy includes this hosted job" >&2
+        exit 1
+      fi
+      echo 'The generated job passed after resolving and delivering the environment-scoped Buildkite secret'

--- a/.buildkite/environment-resolution-proof.yml
+++ b/.buildkite/environment-resolution-proof.yml
@@ -1,0 +1,97 @@
+agents:
+  queue: "hosted"
+
+steps:
+  - label: ":github: Discover environment secret"
+    key: "environment-resolution-discovery"
+    timeout_in_minutes: 10
+    retry:
+      automatic: false
+    plugins:
+      - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
+          version: "2026.5.12"
+    command: |
+      set -euo pipefail
+      commit="$${COMPATIBILITY_PROOF_COMMIT:?COMPATIBILITY_PROOF_COMMIT is required}"
+      scripts/verify-source-checkout "$$commit"
+      snapshot="$$(mktemp "$${TMPDIR:-/tmp}/buildkite-gha-environment-snapshot.XXXXXXXX.json")"
+      trap 'rm -f -- "$$snapshot"' EXIT
+      endpoint="$${BUILDKITE_AGENT_ENDPOINT:?BUILDKITE_AGENT_ENDPOINT is required}"
+      job_id="$${BUILDKITE_JOB_ID:?BUILDKITE_JOB_ID is required}"
+      token="$${BUILDKITE_AGENT_ACCESS_TOKEN:?BUILDKITE_AGENT_ACCESS_TOKEN is required}"
+      printf 'header = "Authorization: Token %s"\n' "$$token" |
+        curl --config - --fail --silent --show-error --max-time 30 \
+          --header 'Accept: application/json' \
+          --header 'Content-Type: application/json' \
+          --data '{"repo_url":"https://github.com/buildkite/buildkite-gha","environment_names":["test"]}' \
+          --output "$$snapshot" \
+          "$${endpoint%/}/jobs/$$job_id/github-actions/environments"
+      unset token
+      mise exec -- jq -e '
+        (.environments | type) == "array" and
+        (.environments | length) == 1 and
+        (.environments[0].name | ascii_downcase) == "test" and
+        .environments[0].required_reviewers == false and
+        .environments[0].prevent_self_review == false and
+        .environments[0].wait_timer_minutes == 0 and
+        .environments[0].branch_policy == false and
+        .environments[0].unsupported_rules == [] and
+        (.environments[0].secret_names | type) == "array"
+      ' "$$snapshot" >/dev/null || {
+        echo 'The test environment snapshot is malformed or has protection that would make this runtime proof unsafe' >&2
+        exit 1
+      }
+      secret_count="$$(mise exec -- jq -r '.environments[0].secret_names | length' "$$snapshot")"
+      if [[ "$$secret_count" != 1 ]]; then
+        echo "Prerequisite missing: GitHub environment test must define exactly one environment secret; found $$secret_count" >&2
+        exit 1
+      fi
+      secret_name="$$(mise exec -- jq -r '.environments[0].secret_names[0]' "$$snapshot")"
+      if [[ ! "$$secret_name" =~ ^[A-Za-z_][A-Za-z0-9_]*$$ ]]; then
+        echo 'The test environment returned an invalid secret name' >&2
+        exit 1
+      fi
+      buildkite-agent meta-data set environment-resolution-secret-name "$$secret_name"
+      secret_key="TEST_$${secret_name^^}"
+      echo "The live test environment is unprotected; the runtime job will request Buildkite secret $$secret_key"
+
+  - label: ":pipeline: Environment secret runtime proof importer"
+    key: "environment-resolution-importer"
+    depends_on: "environment-resolution-discovery"
+    timeout_in_minutes: 10
+    retry:
+      automatic: false
+    plugins:
+      - mise#a5845c5082d3a4fe36dd77ae74973dfc86fc91a2:
+          version: "2026.5.12"
+    command: |
+      set -euo pipefail
+      commit="$${COMPATIBILITY_PROOF_COMMIT:?COMPATIBILITY_PROOF_COMMIT is required}"
+      scripts/verify-source-checkout "$$commit"
+      test -z "$$(git status --porcelain --untracked-files=all)"
+      distribution_root="$$(mktemp -d "$${TMPDIR:-/tmp}/buildkite-gha-environment-resolution.XXXXXXXX")"
+      proof_workflow=
+      trap 'rm -rf -- "$$distribution_root"; [[ -z "$$proof_workflow" ]] || rm -f -- "$$proof_workflow"' EXIT
+      runtime_version="0.0.0-environment-resolution.$$commit"
+      CGO_ENABLED=0 mise exec -- go build -trimpath -buildvcs=false -ldflags "-X main.version=$$runtime_version" -o "$$distribution_root/buildkite-gha" ./cmd/buildkite-gha
+      secret_name="$$(buildkite-agent meta-data get environment-resolution-secret-name)"
+      if [[ ! "$$secret_name" =~ ^[A-Za-z_][A-Za-z0-9_]*$$ ]]; then
+        echo 'The environment secret discovery result is invalid' >&2
+        exit 1
+      fi
+      proof_workflow="$$(mktemp .buildkite/fixtures/.environment-resolution.XXXXXXXX.yml)"
+      sed "s/__ENVIRONMENT_SECRET_NAME__/$$secret_name/g" .buildkite/fixtures/environment-resolution.yml > "$$proof_workflow"
+      if grep -q '__ENVIRONMENT_SECRET_NAME__' "$$proof_workflow"; then
+        echo 'The environment secret placeholder was not replaced' >&2
+        exit 1
+      fi
+      "$$distribution_root/buildkite-gha" upload \
+        --event-path testdata/smoke/events/push.json \
+        --runner-queue ubuntu-latest=hosted \
+        "$$proof_workflow"
+
+  - label: ":pipeline: Environment secret proof continuation loader"
+    key: "environment-resolution-continuation-loader"
+    depends_on: "environment-resolution-importer"
+    allow_dependency_failure: true
+    command: "buildkite-agent pipeline upload .buildkite/environment-resolution-continuation.yml"

--- a/.buildkite/fixtures/environment-resolution.yml
+++ b/.buildkite/fixtures/environment-resolution.yml
@@ -1,0 +1,17 @@
+name: Environment secret runtime proof
+
+on: push
+
+jobs:
+  environment-secret:
+    name: Environment secret delivery
+    runs-on: ubuntu-latest
+    environment: test
+    steps:
+      - name: Verify environment secret delivery
+        env:
+          ENVIRONMENT_SECRET_VALUE: ${{ secrets.__ENVIRONMENT_SECRET_NAME__ }}
+        run: |
+          set -euo pipefail
+          test -n "$ENVIRONMENT_SECRET_VALUE"
+          echo 'The environment secret was delivered without disclosure.'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -16,7 +16,7 @@ steps:
           set -euo pipefail
           proof="$${COMPATIBILITY_PROOF:?COMPATIBILITY_PROOF is required}"
           case "$$proof" in
-            shell-upload|concurrent-steps|public-actions|hosted-docker|dockerfile-action|container-runtime|summary-annotation|workflow-annotations|skipped-workflow-annotation|hash-files|upload-artifact|artifact-roundtrip|experimental-runner-user) ;;
+            shell-upload|concurrent-steps|public-actions|hosted-docker|dockerfile-action|container-runtime|summary-annotation|workflow-annotations|skipped-workflow-annotation|hash-files|upload-artifact|artifact-roundtrip|experimental-runner-user|environment-resolution) ;;
             *) echo "Unknown compatibility proof: $$proof" >&2; exit 2 ;;
           esac
           buildkite-agent pipeline upload ".buildkite/$$proof-proof.yml"

--- a/docs/development.md
+++ b/docs/development.md
@@ -204,6 +204,42 @@ bk build create --pipeline buildkite/buildkite-gha \
 
 This suite covers shell jobs, concurrent steps, public and Docker actions, container runtime behavior, summaries, annotations, artifact upload, and artifact roundtrip. Use `COMPATIBILITY_PROOF=<target>` with `COMPATIBILITY_PROOF_COMMIT=<commit>` only when diagnosing one target. The available target names are in [`.buildkite/pipeline.yml`](../.buildkite/pipeline.yml).
 
+Run the deployed GitHub environment secret proof separately:
+
+```sh
+commit=$(git rev-parse HEAD)
+bk build create --pipeline buildkite/buildkite-gha \
+  --branch "$(git branch --show-current)" --commit "$commit" \
+  --env COMPATIBILITY_PROOF=environment-resolution \
+  --env COMPATIBILITY_PROOF_COMMIT="$commit" --yes
+```
+
+The pipeline's GitHub Code Access App installation must have **Actions: read**
+and **Environments: read**, the deployed snapshot endpoint must support
+`include_variables`, and the repository must have an unprotected
+environment named `test` with exactly one environment secret. A non-empty
+Buildkite secret named `TEST_<UPPERCASE_NAME>` must contain the value for that
+GitHub secret name, and its access policy must include the generated hosted job.
+
+The proof first requires an unprotected snapshot, then uploads and runs one
+generated job. It checks that the immutable plan requests
+`TEST_<UPPERCASE_NAME>` and maps it to the workflow secret before requiring the
+workflow's non-empty-value check to pass. The workflow prints only a fixed
+success marker; it never prints, hashes, or transforms the value. The runtime
+retrieves the plan-declared key through `buildkite-agent secret get` and
+registers the value with the Buildkite redactor before running the workflow.
+
+The proof remains on-demand and does not join the consolidated smoke suite. It
+does not assert `${{ vars.* }}` interpolation: the client also reads environment
+variables during upload, but this fixture tests secret delivery only. Proof
+steps remove the temporary binary, snapshot, workflow, and downloaded plan.
+Buildkite retains the plan and distribution artifacts and
+the environment secret name as build metadata under the pipeline's retention
+policy; none contains the secret value. The unprotected environment emits no
+approval block, and environment compilation does not create GitHub deployments.
+If the environment becomes protected, the discovery step fails before upload;
+cancel the build if protection changes after discovery and a block appears.
+
 Some Buildkite APIs are advisory, so a passing job does not prove that the result was persisted. Check those results independently after the build:
 
 ```sh


### PR DESCRIPTION
## Why

Compiling a GitHub environment does not prove that a generated job requests its environment-scoped Buildkite secret or receives the value.

## What

Add an on-demand `COMPATIBILITY_PROOF=environment-resolution` proof against this repository's dedicated, unprotected `test` environment. It refuses upload unless the snapshot is unprotected with exactly one secret, then uploads a generated job and checks:

- the immutable plan maps the GitHub secret name to `TEST_<UPPERCASE_NAME>`
- the production runtime requests that key through `buildkite-agent secret get`
- the workflow receives a non-empty value and prints only a fixed success marker

The proof is excluded from default CI and the consolidated smoke suite. It never prints, hashes, or transforms the secret value. Prerequisites and temporary-file/artifact cleanup are documented in the development guide.

Rebased onto `main`, including merged #417 and #440. Environment variables are read by the production client, but this fixture deliberately tests secret delivery, not `${{ vars.* }}` interpolation. The existing backend rollout plan and compatibility documentation are preserved.

[Build 2087](https://buildkite.com/buildkite/buildkite-gha/builds/2087#01a065f2-6d3f-4c89-b060-936e114ee19f), before the rebase, resolved secret `FOO` and verified the `TEST_FOO` plan mapping, but runtime reported the secret unavailable. Successful runtime delivery still needs a non-empty Buildkite `TEST_FOO` secret accessible to the generated hosted job and a passing proof run.
