### PR TITLE
Import GitHub Actions issue and comment workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ and [compatibility guide](docs/compatibility.md#job-configuration).
 
 The imported workflows are a dynamic part of the Buildkite pipeline. The plugin creates one aggregate group per successfully compiled, selected workflow in a single transaction. Workflows that do not declare the selected event become top-level skipped steps. Explicit-selector groups and replacement steps depend on the keyed importer. Each runnable job publishes a provider check named `<workflow> / <job> (<event>)`: a GitHub check for GitHub events or an Origin check for Origin events. This approach lets you keep existing workflows while moving jobs to native Buildkite steps over time.
 
-Buildkite owns build creation and schedule configuration. Within that build, `buildkite-gha` maps push and UI/API builds to `push`, pull requests to `pull_request`, merge queues to `merge_group`, releases to `release`, issues to `issues`, and scheduled builds to `schedule`, then applies the matching `on:` branch, tag, base-branch, activity, and safely evidenced path filters. Explicit event snapshots and authoritative GitHub event metadata can select `workflow_dispatch`. Cross-event workflows are excluded before event-dependent compilation and retained as top-level skipped steps.
+Buildkite owns build creation and schedule configuration. Within that build, `buildkite-gha` maps push and UI/API builds to `push`, pull requests to `pull_request`, merge queues to `merge_group`, releases to `release`, issues to `issues`, and scheduled builds to `schedule`. GitHub Actions Pipeline Triggers also support `issues` and both issue and pull request conversation comments through `issue_comment`. The importer then applies the matching `on:` branch, tag, base-branch, activity, and safely evidenced path filters. Explicit event snapshots and authoritative GitHub event metadata can select `workflow_dispatch`. Cross-event workflows are excluded before event-dependent compilation and retained as top-level skipped steps.
 
 ## Check workflow compatibility
 
@@ -197,7 +197,7 @@ buildkite-gha validate \
   .github/workflows/ci.yml
 ```
 
-`--event` also supports `pull_request`, `merge_group`, `release`, `issues`, `workflow_dispatch`, and `schedule`. Generated release validation uses one stable `published` snapshot, and generated issues validation uses `opened`. These are representative static validations, not proof of every activity. Generated snapshots are not equivalent to real payloads; use `--event-path` when exact payload data matters.
+`--event` also supports `pull_request`, `merge_group`, `release`, `issues`, `issue_comment`, `workflow_dispatch`, and `schedule`. Generated release validation uses one stable `published` snapshot, generated issues validation uses `opened`, and generated issue-comment validation uses `created`. These are representative static validations, not proof of every activity. Generated snapshots are not equivalent to real payloads; use `--event-path` when exact payload data matters.
 
 Use `--all-events` to evaluate every declared supported event separately:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -75,13 +75,14 @@ buildkite-gha validate \
 ```
 
 `--event` supports `push`, `pull_request`, `merge_group`, `release`, `issues`,
-`workflow_dispatch`, and `schedule`. It requires `--profile hosted` and cannot be
-combined with `--event-path`.
+`issue_comment`, `workflow_dispatch`, and `schedule`. It requires
+`--profile hosted` and cannot be combined with `--event-path`.
 
 The generated snapshot contains an example repository and the minimum event
 fields. It is useful for a quick check, but it is not a real payload. The
 release snapshot represents one stable, non-prerelease `published` event. The
-issues snapshot represents `opened`. Use
+issues snapshot represents `opened`, and the issue-comment snapshot represents
+`created`. Use
 `--event-path` when exact refs, activity, repository identity, or payload fields
 matter.
 
@@ -324,14 +325,15 @@ Actions Pipeline Trigger builds. Most users should configure an explicit
 Without an explicit selector, `BUILDKITE_GITHUB_WORKFLOW_PATH` marks a GitHub
 Actions Pipeline Trigger selection. The server also supplies:
 
-- `GITHUB_EVENT_NAME`: `push` or `pull_request`
+- `GITHUB_EVENT_NAME`: `push`, `pull_request`, `issues`, or `issue_comment`
 - `GITHUB_WORKFLOW`: the workflow `name`, or its repository-relative path when
   `name` is absent
 - `GITHUB_WORKFLOW_REF`:
   `<owner>/<repo>/<repository-relative-path>@<event-ref>`
 - `GITHUB_WORKFLOW_SHA`: the full commit used to match the workflow
 - `BUILDKITE_GITHUB_EVENT`: a compatibility duplicate of `GITHUB_EVENT_NAME`
-- `BUILDKITE_GITHUB_ACTION`: the pull request action; push events omit it
+- `BUILDKITE_GITHUB_ACTION`: the pull request, issue, or comment action; push
+  events omit it
 
 The `GITHUB_*` values take precedence when present. The plugin derives the
 selected path from `GITHUB_WORKFLOW_REF`, checks `GITHUB_WORKFLOW` against the
@@ -340,6 +342,11 @@ commit. A malformed preferred value fails instead of falling back.
 For pull requests, `GITHUB_WORKFLOW_REF` and imported jobs' `GITHUB_REF` retain
 `refs/pull/<number>/merge`, while `GITHUB_WORKFLOW_SHA`, `GITHUB_SHA`, and the
 Buildkite checkout use the pull request head commit.
+For `issues` and `issue_comment`, the ref is the current repository default
+branch and the SHA is its server-verified tip. Both identity fields are
+required. The linked payload action and repository must match the Buildkite
+environment, and `issue_comment` accepts both issue and pull request
+conversation comments.
 `BUILDKITE_GITHUB_WORKFLOW_PATH` remains the path fallback because GitHub has no
 `GITHUB_WORKFLOW_PATH`. `BUILDKITE_GITHUB_ACTION` remains the action source
 because GitHub's `GITHUB_ACTION` has a different meaning. An explicit
@@ -484,11 +491,15 @@ The selected snapshot establishes one event for applicability, compilation,
 group conditions, provider-check names, and explicit run-name evaluation. An
 explicit event is never replaced with live Buildkite fields.
 
-Linked webhook data can provide `merge_group`, `release`, and `issues`. Merge
-groups and releases need matching Buildkite refs, commits, and activity. Release
-also needs a valid payload and a tag matching `BUILDKITE_TAG` and
-`BUILDKITE_BRANCH`. The GitHub Code Access App provides immutable server
-provenance and is required for hosted release `GITHUB_TOKEN` issuance.
+Linked webhook data can provide native `merge_group`, `release`, and `issues`
+events. GitHub Actions Pipeline Trigger identity additionally supports `issues`
+and `issue_comment` without native Buildkite issue/comment settings. Merge
+groups and releases need matching Buildkite refs, commits, and
+activity. Release also needs a valid payload and a tag matching `BUILDKITE_TAG`
+and `BUILDKITE_BRANCH`. Issue and comment payloads need a valid action, object
+identity, and repository matching the Buildkite checkout. The GitHub Code
+Access App provides immutable server provenance and is required for hosted
+release `GITHUB_TOKEN` issuance.
 
 See [Names and triggers](compatibility.md#names-and-triggers) for exact matching
 rules and the environment fallback.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -90,7 +90,7 @@ workflow name or fallback path from `GITHUB_WORKFLOW`; the event from
 `GITHUB_EVENT_NAME`; and the commit from `GITHUB_WORKFLOW_SHA`. These values
 must match the repository and checked-out workflow. The Buildkite-prefixed path
 and event remain compatibility fallbacks, while `BUILDKITE_GITHUB_ACTION`
-supplies the pull request action. Explicit plugin selection takes precedence
+supplies the pull request, issue, or comment action. Explicit plugin selection takes precedence
 over server workflow selection. Without either selection, the plugin fails.
 The server-selected importer does not need a step key. The plugin uploads its
 artifacts before the dynamic pipeline and scopes retrieval to the importer job
@@ -212,7 +212,8 @@ Upload selects one effective event, in this order:
 
 The fallback prefers `GITHUB_EVENT_NAME`, then preserves `push`, `pull_request`,
 `workflow_dispatch`, and `schedule` from `BUILDKITE_GITHUB_EVENT` across
-rebuilds. Otherwise:
+rebuilds. It preserves `issues` and `issue_comment` only with complete GitHub
+Actions Pipeline Trigger workflow path, ref, and SHA identity. Otherwise:
 
 | Buildkite source | Effective event |
 | --- | --- |
@@ -223,13 +224,15 @@ rebuilds. Otherwise:
 
 An explicit snapshot does not consult contradictory live event fields. Linked
 merge-group data must match the queue refs and commits. Linked release data must
-match the Buildkite event, action, branch, and tag. Linked issues data provides
-the issue activity and payload.
+match the Buildkite event, action, branch, and tag. Linked issue and comment data
+must match the Buildkite action, default-branch ref, and repository. Comment
+payloads may describe either issue or pull request conversations.
 
 With the GitHub Code Access App, Buildkite resolves a release tag to its peeled
 commit before creating the build. Without it, the plugin resolves Buildkite's
 symbolic `HEAD` from the checkout as a compatibility fallback. The fallback
-cannot infer a merge group, release, or issues event without linked-webhook data.
+cannot infer a merge group, release, issues, or issue-comment event without
+linked-webhook data.
 
 The selected event then controls applicability, event-dependent compilation,
 the group condition, and the provider-check suffix.
@@ -240,7 +243,8 @@ the group condition, and the provider-check suffix.
 | `pull_request` | `branches` and `branches-ignore` match the base branch. Omitted `types` defaults to `opened`, `synchronize`, and `reopened`; explicitly listed activity types must map exactly to a supported Buildkite source action. Matching `paths` and `paths-ignore` can be admitted when the bounded local-diff requirements below are met. |
 | `merge_group` | Native Buildkite merge queue builds only. Enable merge queue builds and Merge groups webhook delivery in the pipeline's GitHub settings. `branches` and `branches-ignore` match the target branch. The only supported activity is `checks_requested`; other types and tag and workflow filters are rejected. `paths` and `paths-ignore` are ignored with a warning, matching GitHub, which does not evaluate path filters for `merge_group` events. The merge group ref and SHA identify the speculative queue commit. |
 | `release` | Native Buildkite release builds only. In the pipeline's GitHub settings, enable **Additional Webhooks** > **Releases** and use **Code** trigger mode. Connect the GitHub Code Access App for immutable server provenance and hosted release `GITHUB_TOKEN` issuance. `types` is required and may contain only `published`, `created`, and `released`; bare `release`, all other activity types, and branch, tag, path, and workflow filters are rejected. Draft `created` deliveries are rejected. The ref is `refs/tags/<tag_name>`. The SHA is the server-resolved peeled commit, or the checked-out commit for the compatibility fallback. |
-| `issues` | Native Buildkite GitHub issue builds only. A bare trigger accepts every GitHub Actions issue activity. Explicit `types` may contain `opened`, `edited`, `deleted`, `transferred`, `pinned`, `unpinned`, `closed`, `reopened`, `assigned`, `unassigned`, `labeled`, `unlabeled`, `locked`, `unlocked`, `milestoned`, `demilestoned`, `typed`, `untyped`, `field_added`, and `field_removed`. Empty or unknown types and branch, tag, path, or workflow filters are rejected. |
+| `issues` | A bare trigger accepts every GitHub Actions issue activity. Explicit `types` may contain `opened`, `edited`, `deleted`, `transferred`, `pinned`, `unpinned`, `closed`, `reopened`, `assigned`, `unassigned`, `labeled`, `unlabeled`, `locked`, `unlocked`, `milestoned`, `demilestoned`, `typed`, `untyped`, `field_added`, and `field_removed`. Empty or unknown types and branch, tag, path, or workflow filters are rejected. In a GitHub Actions Pipeline Trigger build, Buildkite selects workflows and the checkout from the latest verified default-branch SHA; native issue-build settings, branch/path filters, and comment gating do not participate. Existing native Buildkite issue builds remain supported through linked webhook data and retain their own build-creation settings. |
+| `issue_comment` | A bare trigger accepts `created`, `edited`, and `deleted`; explicit `types` may contain those activities. Both issue and pull request conversation comments are supported. Empty or unknown types and branch, tag, path, or workflow filters are rejected. GitHub Actions Pipeline Trigger builds select workflows and the checkout from the latest verified default-branch SHA and do not inherit native command-word, trusted-commenter, PR-only, branch, or path gating. |
 | `workflow_dispatch` | Selected only by an explicit snapshot or authoritative `GITHUB_EVENT_NAME` or `BUILDKITE_GITHUB_EVENT` value. Webhook-style branch, tag, type, and workflow filters are unsupported. |
 | `schedule` | Selected for Buildkite scheduled builds. Buildkite owns cron configuration and does not expose which schedule started a build, so every `on.schedule` workflow is eligible for every Buildkite scheduled build. |
 | `workflow_call` | Defines a reusable-workflow interface. A reusable-only local file is available to callers but does not become a top-level group. |
@@ -1539,7 +1543,7 @@ buildkite-gha validate \
   .github/workflows/ci.yml
 ```
 
-Use `--event push`, `--event pull_request`, `--event merge_group`, `--event release`, `--event issues`, `--event workflow_dispatch`, or `--event schedule` instead of `--event-path` to evaluate the hosted profile with a generated minimal snapshot. The generated release event is a stable `published` event, and the generated issues event is `opened`. Generated snapshots are representative compatibility test inputs, not proof of every activity or equivalents to real payloads. The options are mutually exclusive.
+Use `--event push`, `--event pull_request`, `--event merge_group`, `--event release`, `--event issues`, `--event issue_comment`, `--event workflow_dispatch`, or `--event schedule` instead of `--event-path` to evaluate the hosted profile with a generated minimal snapshot. The generated release event is a stable `published` event, the generated issues event is `opened`, and the generated issue-comment event is `created`. Generated snapshots are representative compatibility test inputs, not proof of every activity or equivalents to real payloads. The options are mutually exclusive.
 
 Use `--all-events` to evaluate every declared supported event separately. Its `processing-report/v3` output preserves the event-independent result and each generated event's v2 report. Aggregate admission means every generated snapshot was admitted; it does not cover other payload shapes. A `context-required` result means compilation and hosted-policy checks passed, but generated inputs cannot measure a supported admission path, such as push or pull-request path filters without linked webhook and local diff evidence. It does not claim admission.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -167,6 +167,8 @@ action execution. In particular:
   prove every supported release activity.
 - Generated issues validation uses `opened`. It does not prove every supported
   issue activity.
+- Generated issue-comment validation uses `created`. It does not prove every
+  supported comment activity or payload shape.
 - Bare and broader release triggers remain incompatible.
 - The action-resolution snapshot pins action revisions only.
 

--- a/internal/buildkite/triggers.go
+++ b/internal/buildkite/triggers.go
@@ -26,6 +26,7 @@ type TriggerConditionExpressions struct {
 	MergeGroupAction      string
 	ReleaseAction         string
 	IssuesAction          string
+	IssueCommentAction    string
 }
 
 // ChangedPathEvaluation records either the available changed paths or why
@@ -50,6 +51,7 @@ type TriggerEventSnapshot struct {
 	MergeGroupAction      *string
 	ReleaseAction         *string
 	IssuesAction          *string
+	IssueCommentAction    *string
 	ChangedPaths          ChangedPathEvaluation
 }
 
@@ -64,6 +66,7 @@ var supportedTriggerEvents = map[string]bool{
 	"merge_group":       true,
 	"release":           true,
 	"issues":            true,
+	"issue_comment":     true,
 }
 
 var supportedIssuesAction = map[string]bool{
@@ -73,6 +76,10 @@ var supportedIssuesAction = map[string]bool{
 	"assigned": true, "unassigned": true, "labeled": true, "unlabeled": true,
 	"locked": true, "unlocked": true, "milestoned": true, "demilestoned": true,
 	"typed": true, "untyped": true,
+}
+
+var supportedIssueCommentAction = map[string]bool{
+	"created": true, "edited": true, "deleted": true,
 }
 
 // SupportedTriggerEvent reports whether the GitHub trigger event maps to a
@@ -132,6 +139,7 @@ func LiveTriggerConditionExpressions(eventPredicate string) TriggerConditionExpr
 		MergeGroupAction:      "build.source_action",
 		ReleaseAction:         "build.source_action",
 		IssuesAction:          "build.source_action",
+		IssueCommentAction:    "build.source_action",
 	}
 }
 
@@ -337,6 +345,10 @@ func TriggerFilterMismatchReason(triggers []workflow.Trigger, event string, snap
 			if snapshot.IssuesAction != nil && trigger.Types != nil && !slices.Contains(trigger.Types, *snapshot.IssuesAction) {
 				return fmt.Sprintf("Issue activity %q does not match this workflow's issues activity filters.", *snapshot.IssuesAction), nil
 			}
+		case "issue_comment":
+			if snapshot.IssueCommentAction != nil && trigger.Types != nil && !slices.Contains(trigger.Types, *snapshot.IssueCommentAction) {
+				return fmt.Sprintf("Issue comment activity %q does not match this workflow's issue_comment activity filters.", *snapshot.IssueCommentAction), nil
+			}
 		}
 		return "", nil
 	}
@@ -379,7 +391,7 @@ func LiveEventPredicate(event string) string {
 		return predicate
 	case "schedule":
 		return "(" + predicate + " || (" + fallbackEvent + ` && build.pull_request.id == null && build.source == "schedule"))`
-	case "merge_group", "release", "issues":
+	case "merge_group", "release", "issues", "issue_comment":
 		return predicate
 	default:
 		return ""
@@ -616,6 +628,30 @@ func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpression
 				return "", false, fmt.Errorf("issues activity type %q cannot be mapped exactly", action)
 			}
 			actions = append(actions, expressions.IssuesAction+` == `+yamlScalar(action))
+		}
+		return expressions.EventPredicate + " && (" + strings.Join(actions, " || ") + ")", true, nil
+	case "issue_comment":
+		if t.Branches != nil || t.BranchesIgnore != nil || t.Tags != nil || t.TagsIgnore != nil || t.Workflows != nil {
+			return "", false, fmt.Errorf("issue_comment has unsupported filters")
+		}
+		if expressions.EventPredicate == "" || expressions.IssueCommentAction == "" {
+			return "", false, fmt.Errorf("issue_comment requires effective event and action expressions")
+		}
+		if expressions.IssueCommentAction == "null" {
+			return "", false, fmt.Errorf("issue_comment event snapshot requires payload.action")
+		}
+		if t.Types == nil {
+			return expressions.EventPredicate, true, nil
+		}
+		if len(t.Types) == 0 {
+			return "", false, fmt.Errorf("issue_comment types is explicitly empty")
+		}
+		actions := make([]string, 0, len(t.Types))
+		for _, action := range t.Types {
+			if !supportedIssueCommentAction[action] {
+				return "", false, fmt.Errorf("issue_comment activity type %q cannot be mapped exactly", action)
+			}
+			actions = append(actions, expressions.IssueCommentAction+` == `+yamlScalar(action))
 		}
 		return expressions.EventPredicate + " && (" + strings.Join(actions, " || ") + ")", true, nil
 	default:

--- a/internal/buildkite/triggers_test.go
+++ b/internal/buildkite/triggers_test.go
@@ -10,7 +10,7 @@ import (
 func TestTranslateTriggerCondition(t *testing.T) {
 	got, err := TranslateTriggerCondition([]workflow.Trigger{
 		{Event: "push", Branches: []string{"main", "releases/**", "!releases/**-alpha", "releases/v[0-9]+"}},
-		{Event: "pull_request"}, {Event: "merge_group", Branches: []string{"main"}}, {Event: "release", Types: []string{"published", "released"}}, {Event: "issues", Types: []string{"opened", "typed"}}, {Event: "workflow_dispatch"}, {Event: "schedule"}, {Event: "workflow_call"},
+		{Event: "pull_request"}, {Event: "merge_group", Branches: []string{"main"}}, {Event: "release", Types: []string{"published", "released"}}, {Event: "issues", Types: []string{"opened", "typed"}}, {Event: "issue_comment", Types: []string{"created", "deleted"}}, {Event: "workflow_dispatch"}, {Event: "schedule"}, {Event: "workflow_call"},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -30,6 +30,11 @@ func TestTranslateTriggerCondition(t *testing.T) {
 			t.Errorf("issues condition missing %q:\n%s", want, got)
 		}
 	}
+	for _, want := range []string{`build.env("BUILDKITE_GITHUB_EVENT") == "issue_comment"`, `build.source_action == "created"`, `build.source_action == "deleted"`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("issue_comment condition missing %q:\n%s", want, got)
+		}
+	}
 }
 
 func TestLiveEventPredicatePreservesNonWebhookMappings(t *testing.T) {
@@ -45,6 +50,7 @@ func TestLiveEventPredicatePreservesNonWebhookMappings(t *testing.T) {
 		{event: "merge_group", wants: []string{`build.env("BUILDKITE_GITHUB_EVENT") == "merge_group"`}, excludes: []string{"build.source"}},
 		{event: "release", wants: []string{`build.env("BUILDKITE_GITHUB_EVENT") == "release"`}, excludes: []string{"build.source"}},
 		{event: "issues", wants: []string{`build.env("BUILDKITE_GITHUB_EVENT") == "issues"`}, excludes: []string{"build.source"}},
+		{event: "issue_comment", wants: []string{`build.env("BUILDKITE_GITHUB_EVENT") == "issue_comment"`}, excludes: []string{"build.source"}},
 	}
 	for _, test := range tests {
 		t.Run(test.event, func(t *testing.T) {
@@ -63,9 +69,6 @@ func TestLiveEventPredicatePreservesNonWebhookMappings(t *testing.T) {
 				t.Errorf("fallback predicate is not grouped: %s", predicate)
 			}
 		})
-	}
-	if predicate := LiveEventPredicate("issue_comment"); predicate != "" {
-		t.Fatalf("unsupported predicate = %q", predicate)
 	}
 }
 
@@ -95,7 +98,7 @@ func TestTranslateTriggerConditionRejectsUnsafeTriggers(t *testing.T) {
 		want     string
 	}{
 		{name: "paths", triggers: []workflow.Trigger{{Event: "push", Paths: []string{"src/**"}}}, want: "path filters are unsupported"},
-		{name: "event", triggers: []workflow.Trigger{{Event: "issue_comment"}}, want: "unsupported GitHub trigger"},
+		{name: "event", triggers: []workflow.Trigger{{Event: "discussion"}}, want: "unsupported GitHub trigger"},
 		{name: "mixed include ignore", triggers: []workflow.Trigger{{Event: "push", Branches: []string{"main"}, BranchesIgnore: []string{"release"}}}, want: "cannot be combined"},
 		{name: "leading negative", triggers: []workflow.Trigger{{Event: "push", Branches: []string{"!release/**"}}}, want: "must follow a positive"},
 		{name: "unsupported PR type", triggers: []workflow.Trigger{{Event: "pull_request", Types: []string{"not-real"}}}, want: "cannot be mapped exactly"},
@@ -114,6 +117,10 @@ func TestTranslateTriggerConditionRejectsUnsafeTriggers(t *testing.T) {
 		{name: "issues tags", triggers: []workflow.Trigger{{Event: "issues", Tags: []string{"v*"}}}, want: "issues has unsupported filters"},
 		{name: "issues paths", triggers: []workflow.Trigger{{Event: "issues", Paths: []string{"src/**"}}}, want: "issues path filters are unsupported"},
 		{name: "issues workflows", triggers: []workflow.Trigger{{Event: "issues", Workflows: []string{"CI"}}}, want: "issues has unsupported filters"},
+		{name: "empty issue comment types", triggers: []workflow.Trigger{{Event: "issue_comment", Types: []string{}}}, want: "issue_comment types is explicitly empty"},
+		{name: "unknown issue comment type", triggers: []workflow.Trigger{{Event: "issue_comment", Types: []string{"not-real"}}}, want: `issue_comment activity type "not-real" cannot be mapped exactly`},
+		{name: "issue comment branches", triggers: []workflow.Trigger{{Event: "issue_comment", Branches: []string{"main"}}}, want: "issue_comment has unsupported filters"},
+		{name: "issue comment paths", triggers: []workflow.Trigger{{Event: "issue_comment", Paths: []string{"src/**"}}}, want: "issue_comment path filters are unsupported"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -231,6 +238,31 @@ func TestTranslateEventTriggerConditionUsesIssuesSnapshot(t *testing.T) {
 	}
 }
 
+func TestTranslateEventTriggerConditionUsesIssueCommentSnapshot(t *testing.T) {
+	action := "edited"
+	condition, applicable, err := TranslateEventTriggerCondition(
+		[]workflow.Trigger{{Event: "issue_comment", Types: []string{"created", "edited"}}},
+		"issue_comment",
+		TriggerConditionExpressions{EventPredicate: `build.source == "webhook"`, IssueCommentAction: `"edited"`},
+		TriggerEventSnapshot{IssueCommentAction: &action},
+	)
+	if err != nil || !applicable {
+		t.Fatalf("condition/applicable/error = %q / %t / %v", condition, applicable, err)
+	}
+	for _, want := range []string{`build.source == "webhook"`, `"edited" == "created"`, `"edited" == "edited"`} {
+		if !strings.Contains(condition, want) {
+			t.Fatalf("issue_comment condition missing %q: %s", want, condition)
+		}
+	}
+	reason, err := TriggerFilterMismatchReason(
+		[]workflow.Trigger{{Event: "issue_comment", Types: []string{"created"}}},
+		"issue_comment", TriggerEventSnapshot{IssueCommentAction: &action},
+	)
+	if err != nil || !strings.Contains(reason, `"edited"`) {
+		t.Fatalf("issue_comment mismatch reason = %q, %v", reason, err)
+	}
+}
+
 func TestTranslateTriggerConditionAcceptsDocumentedIssuesActivityTypes(t *testing.T) {
 	types := []string{
 		"opened", "edited", "deleted", "transferred", "pinned", "unpinned",
@@ -249,6 +281,19 @@ func TestTranslateTriggerConditionAcceptsDocumentedIssuesActivityTypes(t *testin
 	}
 }
 
+func TestTranslateTriggerConditionAcceptsDocumentedIssueCommentActivityTypes(t *testing.T) {
+	types := []string{"created", "edited", "deleted"}
+	condition, err := TranslateTriggerCondition([]workflow.Trigger{{Event: "issue_comment", Types: types}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, activity := range types {
+		if !strings.Contains(condition, `build.source_action == "`+activity+`"`) {
+			t.Errorf("condition missing documented issue_comment activity %q: %s", activity, condition)
+		}
+	}
+}
+
 func TestTranslateTriggerConditionRequiresDirectBuildSource(t *testing.T) {
 	_, err := TranslateTriggerCondition([]workflow.Trigger{{Event: "workflow_call"}})
 	if err == nil || !strings.Contains(err.Error(), "no supported build source") {
@@ -259,13 +304,13 @@ func TestTranslateTriggerConditionRequiresDirectBuildSource(t *testing.T) {
 func TestTranslateTriggerConditionIgnoresUnsupportedEventsBesideSupportedOnes(t *testing.T) {
 	got, err := TranslateTriggerCondition([]workflow.Trigger{
 		{Event: "push"},
-		{Event: "issue_comment", Types: []string{"created"}},
+		{Event: "discussion"},
 		{Event: "pull_request_target", Paths: []string{"src/**"}, Branches: []string{"main"}},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(got, `build.env("BUILDKITE_GITHUB_EVENT") == "push"`) || strings.Contains(got, "issue_comment") || strings.Contains(got, "pull_request_target") {
+	if !strings.Contains(got, `build.env("BUILDKITE_GITHUB_EVENT") == "push"`) || strings.Contains(got, "discussion") || strings.Contains(got, "pull_request_target") {
 		t.Fatalf("condition = %q", got)
 	}
 }
@@ -273,14 +318,14 @@ func TestTranslateTriggerConditionIgnoresUnsupportedEventsBesideSupportedOnes(t 
 func TestValidateTriggerConditionsIgnoresUnsupportedEventsBesideSupportedOnes(t *testing.T) {
 	if err := ValidateTriggerConditions([]workflow.Trigger{
 		{Event: "push"},
-		{Event: "issue_comment", Types: []string{"created"}},
+		{Event: "discussion"},
 		{Event: "pull_request_target", Paths: []string{"src/**"}},
 		{Event: "workflow_run"},
 	}); err != nil {
 		t.Fatalf("ValidateTriggerConditions() error = %v", err)
 	}
-	err := ValidateTriggerConditions([]workflow.Trigger{{Event: "discussion"}, {Event: "issue_comment"}})
-	if err == nil || !strings.Contains(err.Error(), `unsupported GitHub trigger event "discussion"`) || !strings.Contains(err.Error(), `unsupported GitHub trigger event "issue_comment"`) {
+	err := ValidateTriggerConditions([]workflow.Trigger{{Event: "discussion"}, {Event: "pull_request_target"}})
+	if err == nil || !strings.Contains(err.Error(), `unsupported GitHub trigger event "discussion"`) || !strings.Contains(err.Error(), `unsupported GitHub trigger event "pull_request_target"`) {
 		t.Fatalf("ValidateTriggerConditions() error = %v", err)
 	}
 }
@@ -292,7 +337,7 @@ func TestTranslateEventTriggerConditionIgnoresUnsupportedEvents(t *testing.T) {
 		Tag:            "build.tag",
 	}
 	condition, applicable, err := TranslateEventTriggerCondition([]workflow.Trigger{
-		{Event: "push"}, {Event: "issue_comment"}, {Event: "pull_request_target", Paths: []string{"src/**"}},
+		{Event: "push"}, {Event: "discussion"}, {Event: "pull_request_target", Paths: []string{"src/**"}},
 	}, "push", expressions, TriggerEventSnapshot{})
 	if err != nil || !applicable {
 		t.Fatalf("condition/applicable/error = %q / %t / %v", condition, applicable, err)
@@ -301,7 +346,7 @@ func TestTranslateEventTriggerConditionIgnoresUnsupportedEvents(t *testing.T) {
 		t.Fatalf("condition = %q", condition)
 	}
 	condition, applicable, err = TranslateEventTriggerCondition([]workflow.Trigger{
-		{Event: "issue_comment"},
+		{Event: "discussion"},
 	}, "push", expressions, TriggerEventSnapshot{})
 	if err != nil || applicable || condition != "" {
 		t.Fatalf("condition/applicable/error = %q / %t / %v", condition, applicable, err)
@@ -319,9 +364,9 @@ func TestSupportedTriggerEvent(t *testing.T) {
 			t.Errorf("translateTrigger(%q) reports an unsupported event", event)
 		}
 	}
-	_, _, err := translateTrigger(workflow.Trigger{Event: "issue_comment"}, liveTriggerExpressions("issue_comment"), TriggerEventSnapshot{}, true)
-	if SupportedTriggerEvent("issue_comment") || !unsupportedTriggerEvent(err) {
-		t.Errorf("issue_comment must be an unsupported trigger event, error = %v", err)
+	_, _, err := translateTrigger(workflow.Trigger{Event: "discussion"}, liveTriggerExpressions("discussion"), TriggerEventSnapshot{}, true)
+	if !SupportedTriggerEvent("issue_comment") || !unsupportedTriggerEvent(err) {
+		t.Errorf("issue_comment must be supported and discussion must be unsupported, error = %v", err)
 	}
 }
 
@@ -329,7 +374,7 @@ func TestValidateTriggerConditionsAllowsReusableOnlyWorkflow(t *testing.T) {
 	if err := ValidateTriggerConditions([]workflow.Trigger{{Event: "workflow_call"}}); err != nil {
 		t.Fatalf("ValidateTriggerConditions(workflow_call) error = %v", err)
 	}
-	if err := ValidateTriggerConditions([]workflow.Trigger{{Event: "issue_comment"}}); err == nil || !strings.Contains(err.Error(), "unsupported GitHub trigger") {
+	if err := ValidateTriggerConditions([]workflow.Trigger{{Event: "issue_comment"}}); err != nil {
 		t.Fatalf("ValidateTriggerConditions(issue_comment) error = %v", err)
 	}
 }

--- a/internal/cli/buildkite_event.go
+++ b/internal/cli/buildkite_event.go
@@ -121,6 +121,20 @@ func buildkiteEventSource(getenv func(string) string) ([]byte, error) {
 				}
 				payload = map[string]any{"ref": ref}
 			}
+		case "issues", "issue_comment":
+			if githubEvent == "issues" && getenv(pipelineTriggerWorkflowPathEnvironment) == "" &&
+				getenv(githubWorkflowRefEnvironment) == "" && getenv(githubWorkflowSHAEnvironment) == "" {
+				break
+			}
+			if getenv(pipelineTriggerWorkflowPathEnvironment) == "" ||
+				getenv(githubWorkflowRefEnvironment) == "" ||
+				getenv(githubWorkflowSHAEnvironment) == "" {
+				return nil, fmt.Errorf("%s requires GitHub Actions Pipeline Trigger workflow path, ref, and SHA identity", githubEvent)
+			}
+			if getenv(githubWorkflowSHAEnvironment) != sha {
+				return nil, fmt.Errorf("%s does not match BUILDKITE_COMMIT", githubWorkflowSHAEnvironment)
+			}
+			event = githubEvent
 		}
 	}
 	if workflowRef := getenv(githubWorkflowRefEnvironment); workflowRef != "" {
@@ -190,6 +204,11 @@ func buildkiteWebhookEventSource(getenv func(string) string, webhook []byte) ([]
 	}
 	if snapshot["event"] == "release" {
 		if err := validateBuildkiteRelease(snapshot, getenv); err != nil {
+			return nil, err
+		}
+	}
+	if snapshot["event"] == "issues" || snapshot["event"] == "issue_comment" {
+		if err := validateBuildkiteIssueEvent(snapshot, getenv); err != nil {
 			return nil, err
 		}
 	}
@@ -281,6 +300,62 @@ func validateBuildkiteRelease(snapshot map[string]any, getenv func(string) strin
 	}
 	snapshot["ref"] = "refs/tags/" + tag
 	return nil
+}
+
+func validateBuildkiteIssueEvent(snapshot map[string]any, getenv func(string) string) error {
+	event := snapshot["event"].(string)
+	if snapshot["provider"] != "github" {
+		return fmt.Errorf("%s webhook requires a GitHub repository", event)
+	}
+	payload := snapshot["payload"].(map[string]any)
+	action, _ := payload["action"].(string)
+	if action == "" || action != strings.TrimSpace(getenv("BUILDKITE_GITHUB_ACTION")) {
+		return fmt.Errorf("%s webhook payload.action does not match BUILDKITE_GITHUB_ACTION", event)
+	}
+	supported := map[string]bool{
+		"opened": true, "edited": true, "deleted": true, "transferred": true,
+		"field_added": true, "field_removed": true,
+		"pinned": true, "unpinned": true, "closed": true, "reopened": true,
+		"assigned": true, "unassigned": true, "labeled": true, "unlabeled": true,
+		"locked": true, "unlocked": true, "milestoned": true, "demilestoned": true,
+		"typed": true, "untyped": true,
+	}
+	if event == "issue_comment" {
+		supported = map[string]bool{"created": true, "edited": true, "deleted": true}
+	}
+	if !supported[action] {
+		return fmt.Errorf("%s webhook action %q is unsupported", event, action)
+	}
+	issue, ok := payload["issue"].(map[string]any)
+	if !ok || !positiveJSONInteger(issue["number"]) {
+		return fmt.Errorf("%s webhook requires payload.issue.number", event)
+	}
+	if event == "issue_comment" {
+		comment, ok := payload["comment"].(map[string]any)
+		if !ok || !positiveJSONInteger(comment["id"]) {
+			return fmt.Errorf("issue_comment webhook requires payload.comment.id")
+		}
+	}
+	repository, _ := payload["repository"].(map[string]any)
+	fullName, _ := repository["full_name"].(string)
+	provider, owner, name, _, err := parseBuildkiteRepository(getenv("BUILDKITE_REPO"))
+	if err != nil || provider != "github" || !strings.EqualFold(fullName, owner+"/"+name) || !positiveJSONInteger(repository["id"]) {
+		return fmt.Errorf("%s webhook repository does not match BUILDKITE_REPO", event)
+	}
+	ref, _ := snapshot["ref"].(string)
+	if ref != "refs/heads/"+getenv("BUILDKITE_BRANCH") {
+		return fmt.Errorf("%s webhook ref does not match the Buildkite build branch", event)
+	}
+	return nil
+}
+
+func positiveJSONInteger(value any) bool {
+	number, ok := value.(json.Number)
+	if !ok {
+		return false
+	}
+	parsed, err := strconv.ParseInt(number.String(), 10, 64)
+	return err == nil && parsed > 0
 }
 
 func parseWebhookPayload(source []byte) (map[string]any, error) {

--- a/internal/cli/buildkite_event_test.go
+++ b/internal/cli/buildkite_event_test.go
@@ -257,6 +257,26 @@ func TestGeneratedIssuesEventIsCanonicalOpenedIssue(t *testing.T) {
 	}
 }
 
+func TestGeneratedIssueCommentEventIsCanonicalCreatedComment(t *testing.T) {
+	source, err := generatedEventSnapshot("issue_comment")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var snapshot struct {
+		Event   string         `json:"event"`
+		Ref     string         `json:"ref"`
+		Payload map[string]any `json:"payload"`
+	}
+	if err := json.Unmarshal(source, &snapshot); err != nil {
+		t.Fatal(err)
+	}
+	issue := snapshot.Payload["issue"].(map[string]any)
+	comment := snapshot.Payload["comment"].(map[string]any)
+	if snapshot.Event != "issue_comment" || snapshot.Ref != "refs/heads/main" || snapshot.Payload["action"] != "created" || issue["number"] != float64(1) || comment["id"] != float64(1) {
+		t.Fatalf("generated issue comment event = %#v", snapshot)
+	}
+}
+
 func TestBuildkiteEventSourceFailsClosed(t *testing.T) {
 	valid := map[string]string{"BUILDKITE": "true", "BUILDKITE_STEP_KEY": "step", "BUILDKITE_REPO": "https://github.com/a/b", "BUILDKITE_COMMIT": strings.Repeat("a", 40), "BUILDKITE_BRANCH": "main"}
 	for _, test := range []struct{ name, key, value string }{
@@ -279,6 +299,50 @@ func TestBuildkiteEventSourceFailsClosed(t *testing.T) {
 	env["BUILDKITE_PULL_REQUEST"], env["BUILDKITE_TAG"] = "3", "v1"
 	if _, err := buildkiteEventSource(func(key string) string { return env[key] }); err == nil || !strings.Contains(err.Error(), "contradictory") {
 		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestBuildkiteEventSourceRequiresPipelineTriggerIdentityForDefaultBranchEvents(t *testing.T) {
+	env := map[string]string{
+		"BUILDKITE":               "true",
+		"BUILDKITE_STEP_KEY":      "step",
+		"BUILDKITE_REPO":          "https://github.com/acme/widgets",
+		"BUILDKITE_COMMIT":        strings.Repeat("a", 40),
+		"BUILDKITE_BRANCH":        "main",
+		"BUILDKITE_GITHUB_EVENT":  "issue_comment",
+		"BUILDKITE_GITHUB_ACTION": "created",
+	}
+
+	if _, err := buildkiteEventSource(func(key string) string { return env[key] }); err == nil || !strings.Contains(err.Error(), "GitHub Actions Pipeline Trigger") {
+		t.Fatalf("buildkiteEventSource() error = %v, want Pipeline Trigger identity requirement", err)
+	}
+}
+
+func TestBuildkiteWebhookEventSourcePreservesNativeIssues(t *testing.T) {
+	env := map[string]string{
+		"BUILDKITE":               "true",
+		"BUILDKITE_REPO":          "https://github.com/acme/widgets",
+		"BUILDKITE_COMMIT":        strings.Repeat("a", 40),
+		"BUILDKITE_BRANCH":        "main",
+		"BUILDKITE_GITHUB_EVENT":  "issues",
+		"BUILDKITE_GITHUB_ACTION": "opened",
+	}
+	payload := []byte(`{"action":"opened","issue":{"number":42},"repository":{"id":12345,"full_name":"acme/widgets"}}`)
+	source, err := buildkiteWebhookEventSource(func(key string) string { return env[key] }, payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var snapshot map[string]any
+	if err := json.Unmarshal(source, &snapshot); err != nil {
+		t.Fatal(err)
+	}
+	if snapshot["event"] != "issues" || snapshot["ref"] != "refs/heads/main" || snapshot["sha"] != env["BUILDKITE_COMMIT"] {
+		t.Fatalf("native issues snapshot = %#v", snapshot)
+	}
+
+	env[pipelineTriggerWorkflowPathEnvironment] = ".github/workflows/issues.yml"
+	if _, err := buildkiteWebhookEventSource(func(key string) string { return env[key] }, payload); err == nil {
+		t.Fatal("partially specified Pipeline Trigger identity was accepted")
 	}
 }
 
@@ -414,6 +478,77 @@ func TestBuildkiteWebhookEventSourceBindsReleaseIdentity(t *testing.T) {
 			_, err := buildkiteWebhookEventSource(func(key string) string { return changed[key] }, []byte(test.webhook))
 			if err == nil || !strings.Contains(err.Error(), test.want) {
 				t.Fatalf("buildkiteWebhookEventSource() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestBuildkiteWebhookEventSourceBindsIssueAndCommentIdentity(t *testing.T) {
+	commit := strings.Repeat("a", 40)
+	baseEnv := map[string]string{
+		"BUILDKITE": "true", "BUILDKITE_STEP_KEY": "step",
+		"BUILDKITE_REPO":                       "https://github.com/acme/widgets",
+		"BUILDKITE_COMMIT":                     commit,
+		"BUILDKITE_BRANCH":                     "main",
+		pipelineTriggerWorkflowPathEnvironment: ".github/workflows/selected.yml",
+		githubWorkflowSHAEnvironment:           commit,
+	}
+	tests := []struct {
+		name, event, action, payload string
+	}{
+		{
+			name: "issue", event: "issues", action: "field_added",
+			payload: `{"action":"field_added","issue":{"number":42},"repository":{"id":12345,"full_name":"acme/widgets"},"sender":{"login":"octocat"}}`,
+		},
+		{
+			name: "issue comment", event: "issue_comment", action: "edited",
+			payload: `{"action":"edited","issue":{"number":42},"comment":{"id":123456,"body":"updated"},"repository":{"id":12345,"full_name":"acme/widgets"},"sender":{"login":"octocat"}}`,
+		},
+		{
+			name: "pull request conversation comment", event: "issue_comment", action: "created",
+			payload: `{"action":"created","issue":{"number":43,"pull_request":{"url":"https://api.github.com/repos/acme/widgets/pulls/43"}},"comment":{"id":123457,"body":"created"},"repository":{"id":12345,"full_name":"acme/widgets"},"sender":{"login":"octocat"}}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			env := maps.Clone(baseEnv)
+			env["BUILDKITE_GITHUB_EVENT"] = test.event
+			env["BUILDKITE_GITHUB_ACTION"] = test.action
+			env[githubWorkflowRefEnvironment] = "acme/widgets/.github/workflows/selected.yml@refs/heads/main"
+			source, err := buildkiteWebhookEventSource(func(key string) string { return env[key] }, []byte(test.payload))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var snapshot map[string]any
+			if err := json.Unmarshal(source, &snapshot); err != nil {
+				t.Fatal(err)
+			}
+			payload := snapshot["payload"].(map[string]any)
+			if snapshot["event"] != test.event || snapshot["ref"] != "refs/heads/main" || snapshot["sha"] != commit || snapshot["actor"] != "octocat" || payload["action"] != test.action {
+				t.Fatalf("default-branch event snapshot = %#v", snapshot)
+			}
+		})
+	}
+
+	valid := `{"action":"created","issue":{"number":42},"comment":{"id":123456},"repository":{"id":12345,"full_name":"acme/widgets"}}`
+	for _, test := range []struct {
+		name, payload, event, action, branch string
+	}{
+		{name: "action mismatch", payload: valid, event: "issue_comment", action: "edited", branch: "main"},
+		{name: "unknown action", payload: strings.Replace(valid, "created", "published", 1), event: "issue_comment", action: "published", branch: "main"},
+		{name: "missing issue", payload: strings.Replace(valid, `"issue":{"number":42},`, "", 1), event: "issue_comment", action: "created", branch: "main"},
+		{name: "missing comment", payload: strings.Replace(valid, `"comment":{"id":123456},`, "", 1), event: "issue_comment", action: "created", branch: "main"},
+		{name: "wrong repository", payload: strings.Replace(valid, "acme/widgets", "other/widgets", 1), event: "issue_comment", action: "created", branch: "main"},
+		{name: "wrong branch", payload: valid, event: "issue_comment", action: "created", branch: "other"},
+	} {
+		t.Run("rejects "+test.name, func(t *testing.T) {
+			env := maps.Clone(baseEnv)
+			env["BUILDKITE_GITHUB_EVENT"] = test.event
+			env["BUILDKITE_GITHUB_ACTION"] = test.action
+			env["BUILDKITE_BRANCH"] = test.branch
+			env[githubWorkflowRefEnvironment] = "acme/widgets/.github/workflows/selected.yml@refs/heads/main"
+			if _, err := buildkiteWebhookEventSource(func(key string) string { return env[key] }, []byte(test.payload)); err == nil {
+				t.Fatal("unexpected success")
 			}
 		})
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -48,7 +48,7 @@ func TestRunValidateAndCompile(t *testing.T) {
 		tests := []struct {
 			name, trigger, want string
 		}{
-			{name: "unsupported event", trigger: "issue_comment", want: `unsupported GitHub trigger event "issue_comment"`},
+			{name: "unsupported event", trigger: "discussion", want: `unsupported GitHub trigger event "discussion"`},
 			{name: "malformed path filter", trigger: "push:\n    paths: ['!src/**']", want: "must follow a positive pattern"},
 			{name: "mixed branch filters", trigger: "push:\n    branches: [main]\n    branches-ignore: [release]", want: "include and ignore filters cannot be combined"},
 			{name: "pull request tag filter", trigger: "pull_request:\n    tags: [v1]", want: "pull_request tag filters are unsupported"},
@@ -58,6 +58,8 @@ func TestRunValidateAndCompile(t *testing.T) {
 			{name: "release branch filter", trigger: "release:\n    types: [published]\n    branches: [main]", want: "release has unsupported filters"},
 			{name: "unknown issues activity", trigger: "issues:\n    types: [not-real]", want: `issues activity type "not-real" cannot be mapped exactly`},
 			{name: "issues branch filter", trigger: "issues:\n    branches: [main]", want: "issues has unsupported filters"},
+			{name: "unknown issue comment activity", trigger: "issue_comment:\n    types: [not-real]", want: `issue_comment activity type "not-real" cannot be mapped exactly`},
+			{name: "issue comment branch filter", trigger: "issue_comment:\n    branches: [main]", want: "issue_comment has unsupported filters"},
 		}
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
@@ -193,10 +195,10 @@ func TestRunValidateAndCompile(t *testing.T) {
 
 	t.Run("validate hosted profile with generated events", func(t *testing.T) {
 		workflow := filepath.Join(t.TempDir(), "events.yml")
-		if err := os.WriteFile(workflow, []byte("on:\n  push:\n  pull_request:\n  merge_group:\n  release:\n    types: [published, created, released]\n  issues:\n    types: [opened, field_added, field_removed, typed]\n  workflow_dispatch:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
+		if err := os.WriteFile(workflow, []byte("on:\n  push:\n  pull_request:\n  merge_group:\n  release:\n    types: [published, created, released]\n  issues:\n    types: [opened, field_added, field_removed, typed]\n  issue_comment:\n    types: [created, edited, deleted]\n  workflow_dispatch:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
 			t.Fatal(err)
 		}
-		for _, event := range []string{"push", "pull_request", "merge_group", "release", "issues", "workflow_dispatch", "schedule"} {
+		for _, event := range []string{"push", "pull_request", "merge_group", "release", "issues", "issue_comment", "workflow_dispatch", "schedule"} {
 			t.Run(event, func(t *testing.T) {
 				var stdout, stderr bytes.Buffer
 				args := []string{"validate", "--profile", "hosted", "--event", event, "--format", "json", workflow}
@@ -216,7 +218,7 @@ func TestRunValidateAndCompile(t *testing.T) {
 
 	t.Run("validate hosted profile with all generated events", func(t *testing.T) {
 		workflow := filepath.Join(t.TempDir(), "events.yml")
-		if err := os.WriteFile(workflow, []byte("on:\n  push:\n  pull_request:\n  merge_group:\n  release:\n    types: [published, created, released]\n  issues:\n  workflow_dispatch:\n  schedule:\n    - cron: '0 0 * * *'\n  workflow_call:\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
+		if err := os.WriteFile(workflow, []byte("on:\n  push:\n  pull_request:\n  merge_group:\n  release:\n    types: [published, created, released]\n  issues:\n  issue_comment:\n  workflow_dispatch:\n  schedule:\n    - cron: '0 0 * * *'\n  workflow_call:\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
 			t.Fatal(err)
 		}
 		var stdout, stderr bytes.Buffer
@@ -228,10 +230,10 @@ func TestRunValidateAndCompile(t *testing.T) {
 		if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
 			t.Fatal(err)
 		}
-		if report.Schema != compatibility.ProcessingSchemaV3 || report.Result != "admitted" || report.Status != compatibility.Passed || report.Validation.Result != "compilable" || len(report.Evaluations) != 7 {
+		if report.Schema != compatibility.ProcessingSchemaV3 || report.Result != "admitted" || report.Status != compatibility.Passed || report.Validation.Result != "compilable" || len(report.Evaluations) != 8 {
 			t.Fatalf("aggregate report = %#v", report)
 		}
-		for i, event := range []string{"push", "pull_request", "merge_group", "release", "issues", "workflow_dispatch", "schedule"} {
+		for i, event := range []string{"push", "pull_request", "merge_group", "release", "issues", "issue_comment", "workflow_dispatch", "schedule"} {
 			if report.Evaluations[i].Event != event || report.Evaluations[i].Source != "generated" || report.Evaluations[i].Report.Result != "admitted" {
 				t.Fatalf("evaluation %d = %#v", i, report.Evaluations[i])
 			}
@@ -413,7 +415,7 @@ func TestRunValidateAndCompile(t *testing.T) {
 
 	t.Run("validate hosted profile ignores unsupported trigger events beside a supported one", func(t *testing.T) {
 		workflow := filepath.Join(t.TempDir(), "mixed.yml")
-		if err := os.WriteFile(workflow, []byte("on: [push, issue_comment, pull_request_target]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
+		if err := os.WriteFile(workflow, []byte("on: [push, discussion, pull_request_target]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
 			t.Fatal(err)
 		}
 		var stdout, stderr bytes.Buffer
@@ -439,7 +441,7 @@ func TestRunValidateAndCompile(t *testing.T) {
 				messages[event] = message
 			}
 		}
-		for _, event := range []string{"issue_comment", "pull_request_target"} {
+		for _, event := range []string{"discussion", "pull_request_target"} {
 			want := "on." + event + " is ignored, so nothing in this workflow runs from it. The supported triggers declared in this workflow still run: push. Move the jobs this trigger guards to one of those triggers if you need them. If you need " + event + ", log an issue on https://github.com/buildkite/buildkite-gha so we can prioritise it."
 			if messages[event] != want {
 				t.Fatalf("unsupported-trigger message for %s = %q, want %q; report = %#v", event, messages[event], want, report)
@@ -449,7 +451,7 @@ func TestRunValidateAndCompile(t *testing.T) {
 
 	t.Run("validate hosted profile keeps unsupported-trigger warnings in a not-applicable report", func(t *testing.T) {
 		workflow := filepath.Join(t.TempDir(), "cross-event.yml")
-		if err := os.WriteFile(workflow, []byte("on: [pull_request, issue_comment]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
+		if err := os.WriteFile(workflow, []byte("on: [pull_request, discussion]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
 			t.Fatal(err)
 		}
 		var stdout, stderr bytes.Buffer
@@ -2174,7 +2176,7 @@ func TestArgumentParsersRejectRepeatedOptions(t *testing.T) {
 	if _, _, _, _, _, _, err := validateArgs([]string{"--event", "push", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "requires --profile hosted") {
 		t.Fatalf("validateArgs() error = %v, want profile requirement", err)
 	}
-	if _, _, _, _, _, _, err := validateArgs([]string{"--profile", "hosted", "--event", "issue_comment", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "supported events") {
+	if _, _, _, _, _, _, err := validateArgs([]string{"--profile", "hosted", "--event", "discussion", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "supported events") {
 		t.Fatalf("validateArgs() error = %v, want supported event list", err)
 	}
 	if _, _, _, _, _, _, err := validateArgs([]string{"--profile", "hosted", "--all-events", "--event", "push", "workflow.yml"}); err == nil || !strings.Contains(err.Error(), "mutually exclusive") {

--- a/internal/cli/effective_event.go
+++ b/internal/cli/effective_event.go
@@ -86,6 +86,7 @@ func snapshotTriggerState(event compiler.Event) (buildkitepipeline.TriggerCondit
 		MergeGroupAction:      "null",
 		ReleaseAction:         "null",
 		IssuesAction:          "null",
+		IssueCommentAction:    "null",
 	}
 	snapshot := buildkitepipeline.TriggerEventSnapshot{}
 	if branch, ok := strings.CutPrefix(event.Ref, "refs/heads/"); ok {
@@ -105,6 +106,8 @@ func snapshotTriggerState(event compiler.Event) (buildkitepipeline.TriggerCondit
 		snapshot.ReleaseAction = &action
 		expressions.IssuesAction = triggerConditionLiteral(action)
 		snapshot.IssuesAction = &action
+		expressions.IssueCommentAction = triggerConditionLiteral(action)
+		snapshot.IssueCommentAction = &action
 	}
 	if pullRequest, ok := event.Payload["pull_request"].(map[string]any); ok {
 		if base, ok := pullRequest["base"].(map[string]any); ok {

--- a/internal/cli/effective_event_test.go
+++ b/internal/cli/effective_event_test.go
@@ -28,6 +28,7 @@ func TestNewEffectiveEventSeparatesExpressionsAndSnapshot(t *testing.T) {
 		MergeGroupAction:      "null",
 		ReleaseAction:         "null",
 		IssuesAction:          "null",
+		IssueCommentAction:    "null",
 	}
 	branch := "main"
 	wantSnapshot := buildkitepipeline.TriggerEventSnapshot{Branch: &branch}

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -243,8 +243,8 @@ func pluginWorkflowOperands(configuration pluginConfiguration, getenv func(strin
 	if event == "" {
 		return nil, nil, fmt.Errorf("%s or BUILDKITE_GITHUB_EVENT is required", githubEventNameEnvironment)
 	}
-	if event != "push" && event != "pull_request" {
-		return nil, nil, fmt.Errorf("%s or BUILDKITE_GITHUB_EVENT must be push or pull_request", githubEventNameEnvironment)
+	if event != "push" && event != "pull_request" && event != "issues" && event != "issue_comment" {
+		return nil, nil, fmt.Errorf("%s or BUILDKITE_GITHUB_EVENT must be push, pull_request, issues, or issue_comment", githubEventNameEnvironment)
 	}
 
 	workflowName := getenv(githubWorkflowEnvironment)
@@ -262,6 +262,9 @@ func pluginWorkflowOperands(configuration pluginConfiguration, getenv func(strin
 	workflowSHA := getenv(githubWorkflowSHAEnvironment)
 	if workflowSHA != "" && !git.ValidObjectID(workflowSHA) {
 		return nil, nil, fmt.Errorf("%s must be a full lowercase 40-hex commit", githubWorkflowSHAEnvironment)
+	}
+	if (event == "issues" || event == "issue_comment") && (getenv(githubWorkflowRefEnvironment) == "" || workflowSHA == "") {
+		return nil, nil, fmt.Errorf("%s and %s are required for %s", githubWorkflowRefEnvironment, githubWorkflowSHAEnvironment, event)
 	}
 	return []string{selectedPath}, &pipelineTriggerWorkflow{Name: workflowName, SHA: workflowSHA}, nil
 }
@@ -311,6 +314,9 @@ func pipelineTriggerEventRef(event, ref string) bool {
 		number, ok = strings.CutSuffix(number, "/merge")
 		parsed, err := strconv.Atoi(number)
 		return ok && err == nil && parsed > 0 && strconv.Itoa(parsed) == number
+	case "issues", "issue_comment":
+		branch, ok := strings.CutPrefix(ref, "refs/heads/")
+		return ok && branch != ""
 	}
 	return false
 }

--- a/internal/cli/plugin_test.go
+++ b/internal/cli/plugin_test.go
@@ -295,6 +295,90 @@ func TestPluginUsesPipelineTriggerPullRequestIdentity(t *testing.T) {
 	}
 }
 
+func TestPluginUsesPipelineTriggerIssueAndCommentIdentity(t *testing.T) {
+	requireImporterHost(t)
+	tests := []struct {
+		name, event, action, payload string
+	}{
+		{
+			name: "issue", event: "issues", action: "typed",
+			payload: `{"action":"typed","issue":{"number":42,"title":"Issue"},"repository":{"id":12345,"full_name":"buildkite/buildkite-gha"},"sender":{"id":7,"login":"octocat"}}`,
+		},
+		{
+			name: "issue comment", event: "issue_comment", action: "edited",
+			payload: `{"action":"edited","issue":{"number":42},"comment":{"id":123456,"body":"updated"},"repository":{"id":12345,"full_name":"buildkite/buildkite-gha"},"sender":{"id":7,"login":"octocat"}}`,
+		},
+		{
+			name: "pull request conversation comment", event: "issue_comment", action: "created",
+			payload: `{"action":"created","issue":{"number":43,"pull_request":{"url":"https://api.github.com/repos/buildkite/buildkite-gha/pulls/43"}},"comment":{"id":123457,"body":"created"},"repository":{"id":12345,"full_name":"buildkite/buildkite-gha"},"sender":{"id":7,"login":"octocat"}}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			workflow := "name: Selected\non: " + test.event + "\njobs:\n  selected:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo '${{ toJSON(github.event) }}'\n"
+			repository := writeUploadWorkflowRepository(t, map[string]string{
+				"selected.yml": workflow,
+				"other.yml":    strings.Replace(workflow, "name: Selected", "name: Other", 1),
+			})
+			t.Chdir(repository)
+			t.Setenv(pluginConfigurationEnvironment, `{}`)
+			setCLIPluginBuildkiteEnvironment(t, "default-branch-pipeline-trigger-importer")
+			t.Setenv("BUILDKITE_BUILD_CHECKOUT_PATH", repository)
+			t.Setenv("BUILDKITE_JOB_ID", cliTestJobID)
+			t.Setenv("BUILDKITE_GITHUB_ACTION", test.action)
+			setCLIPipelineTriggerEnvironment(t, ".github/workflows/selected.yml", "Selected", test.event, "buildkite/buildkite-gha/.github/workflows/selected.yml@refs/heads/main")
+
+			runner := &cliCaptureRunner{webhook: []byte(test.payload)}
+			var stdout, stderr bytes.Buffer
+			if code := run([]string{"plugin"}, &stdout, &stderr, "dev", runner); code != 0 {
+				t.Fatalf("run() code = %d, stdout = %q, stderr = %q", code, stdout.String(), stderr.String())
+			}
+
+			var pipeline struct {
+				Steps []struct {
+					Group string `yaml:"group"`
+				} `yaml:"steps"`
+			}
+			if err := yaml.Unmarshal(runner.commands[len(runner.commands)-1].stdin, &pipeline); err != nil {
+				t.Fatal(err)
+			}
+			if len(pipeline.Steps) != 1 || pipeline.Steps[0].Group != ":github: workflow · Selected" {
+				t.Fatalf("pipeline steps = %#v, want only the server-selected workflow", pipeline.Steps)
+			}
+
+			var foundPlan, foundPayload bool
+			for path, source := range runner.uploaded {
+				switch {
+				case strings.HasPrefix(path, ".buildkite-gha/plans/") && strings.HasSuffix(path, ".json"):
+					job, err := plan.Decode(source)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if job.Event.Name != test.event || job.Event.Ref != "refs/heads/main" || job.Event.SHA != os.Getenv("BUILDKITE_COMMIT") || job.Event.Actor != "octocat" || !job.Event.PayloadArtifact {
+						t.Fatalf("default-branch plan event = %#v", job.Event)
+					}
+					foundPlan = true
+				case strings.HasPrefix(path, ".buildkite-gha/events/") && strings.HasSuffix(path, ".json"):
+					var got, want map[string]any
+					if err := json.Unmarshal(source, &got); err != nil {
+						t.Fatal(err)
+					}
+					if err := json.Unmarshal([]byte(test.payload), &want); err != nil {
+						t.Fatal(err)
+					}
+					if !reflect.DeepEqual(got, want) {
+						t.Fatalf("event payload = %#v, want %#v", got, want)
+					}
+					foundPayload = true
+				}
+			}
+			if !foundPlan || !foundPayload {
+				t.Fatalf("uploaded artifacts = %#v, want one plan and exact event payload", runner.uploaded)
+			}
+		})
+	}
+}
+
 func TestPluginUsesBuildkitePipelineTriggerCompatibilityIdentity(t *testing.T) {
 	requireImporterHost(t)
 	repository := writeUploadWorkflowRepository(t, map[string]string{
@@ -374,6 +458,8 @@ func TestPluginRejectsMalformedPipelineTriggerEnvironment(t *testing.T) {
 		{name: "preferred workflow ref with mismatched event ref", fullPrefix: true, env: map[string]string{githubWorkflowRefEnvironment: "buildkite/buildkite-gha/.github/workflows/ci.yml@refs/pull/42/merge"}, want: "GITHUB_WORKFLOW_REF event ref", wantCode: 2},
 		{name: "malformed preferred workflow SHA", fullPrefix: true, env: map[string]string{githubWorkflowSHAEnvironment: "HEAD"}, want: "GITHUB_WORKFLOW_SHA must be a full lowercase 40-hex commit", wantCode: 2},
 		{name: "preferred workflow SHA does not match checkout", fullPrefix: true, env: map[string]string{githubWorkflowSHAEnvironment: strings.Repeat("a", 40)}, want: "GITHUB_WORKFLOW_SHA does not match BUILDKITE_COMMIT", wantCode: 1},
+		{name: "issues without preferred workflow ref", fullPrefix: true, env: map[string]string{githubEventNameEnvironment: "issues", githubWorkflowRefEnvironment: ""}, want: "GITHUB_WORKFLOW_REF and GITHUB_WORKFLOW_SHA are required for issues", wantCode: 2},
+		{name: "issue comment without preferred workflow SHA", fullPrefix: true, env: map[string]string{githubEventNameEnvironment: "issue_comment", githubWorkflowSHAEnvironment: ""}, want: "GITHUB_WORKFLOW_REF and GITHUB_WORKFLOW_SHA are required for issue_comment", wantCode: 2},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Setenv(pluginConfigurationEnvironment, `{}`)

--- a/internal/cli/upload_test.go
+++ b/internal/cli/upload_test.go
@@ -768,7 +768,7 @@ func TestRunUploadNamesAggregateGitHubChecksFromWorkflowLabels(t *testing.T) {
 func TestRunUploadNamesGitHubCheckForActiveEvent(t *testing.T) {
 	requireImporterHost(t)
 	workflowPath := filepath.Join(t.TempDir(), "multi-trigger.yml")
-	workflowSource := "name: Active event\non:\n  push:\n  pull_request:\n  merge_group:\n  release:\n    types: [published, created, released]\n  issues:\n    types: [opened, typed]\n  workflow_dispatch:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo ok\n"
+	workflowSource := "name: Active event\non:\n  push:\n  pull_request:\n  merge_group:\n  release:\n    types: [published, created, released]\n  issues:\n    types: [opened, typed]\n  issue_comment:\n    types: [created, edited, deleted]\n  workflow_dispatch:\n  schedule:\n    - cron: '0 0 * * *'\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo ok\n"
 	if err := os.WriteFile(workflowPath, []byte(workflowSource), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -778,17 +778,18 @@ func TestRunUploadNamesGitHubCheckForActiveEvent(t *testing.T) {
 	}
 
 	for _, test := range []struct {
-		name, source, githubEvent, wantEvent, wantCondition string
-		wantFallback                                        string
-		eventPath                                           string
-		webhook                                             []byte
+		name, source, githubEvent, githubAction, wantEvent, wantCondition string
+		wantFallback                                                      string
+		eventPath                                                         string
+		webhook                                                           []byte
 	}{
 		{name: "push fallback", source: "webhook", wantEvent: "push", wantCondition: `build.env("BUILDKITE_GITHUB_EVENT") == "push"`},
 		{name: "rebuilt push", source: "ui", githubEvent: "push", wantEvent: "push", wantCondition: `build.env("BUILDKITE_GITHUB_EVENT") == "push"`},
 		{name: "pull request webhook metadata", source: "webhook", githubEvent: "pull_request", webhook: []byte(`{"action":"opened","pull_request":{"base":{"ref":"main"}}}`), wantEvent: "pull_request", wantCondition: `build.env("BUILDKITE_GITHUB_EVENT") == "pull_request"`},
 		{name: "merge group webhook metadata", source: "webhook", githubEvent: "merge_group", webhook: []byte(`{"action":"checks_requested","merge_group":{"head_ref":"refs/heads/gh-readonly-queue/main/pr-1-deadbeef","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","base_ref":"refs/heads/main","base_sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}}`), wantEvent: "merge_group", wantCondition: `build.env("BUILDKITE_GITHUB_EVENT") == "merge_group"`},
 		{name: "release webhook metadata", source: "webhook", githubEvent: "release", webhook: []byte(`{"action":"published","release":{"tag_name":"v1.2.3","draft":false,"prerelease":false}}`), wantEvent: "release", wantCondition: `build.env("BUILDKITE_GITHUB_EVENT") == "release"`},
-		{name: "issues webhook metadata", source: "webhook", githubEvent: "issues", webhook: []byte(`{"action":"typed","issue":{"number":1}}`), wantEvent: "issues", wantCondition: `build.env("BUILDKITE_GITHUB_EVENT") == "issues"`},
+		{name: "issues webhook metadata", source: "webhook", githubEvent: "issues", githubAction: "typed", webhook: []byte(`{"action":"typed","issue":{"number":1},"repository":{"id":12345,"full_name":"buildkite/buildkite-gha"}}`), wantEvent: "issues", wantCondition: `build.env("BUILDKITE_GITHUB_EVENT") == "issues"`},
+		{name: "issue comment webhook metadata", source: "webhook", githubEvent: "issue_comment", githubAction: "edited", webhook: []byte(`{"action":"edited","issue":{"number":1},"comment":{"id":123456},"repository":{"id":12345,"full_name":"buildkite/buildkite-gha"}}`), wantEvent: "issue_comment", wantCondition: `build.env("BUILDKITE_GITHUB_EVENT") == "issue_comment"`},
 		{name: "UI fallback", source: "ui", wantEvent: "push", wantCondition: `build.env("BUILDKITE_GITHUB_EVENT") == "push"`, wantFallback: `build.source != "schedule"`},
 		{name: "API fallback", source: "api", wantEvent: "push", wantCondition: `build.env("BUILDKITE_GITHUB_EVENT") == "push"`, wantFallback: `build.source != "schedule"`},
 		{name: "schedule fallback", source: "schedule", wantEvent: "schedule", wantCondition: `build.env("BUILDKITE_GITHUB_EVENT") == "schedule"`, wantFallback: `build.source == "schedule"`},
@@ -804,7 +805,12 @@ func TestRunUploadNamesGitHubCheckForActiveEvent(t *testing.T) {
 			t.Setenv("BUILDKITE_PULL_REQUEST", "false")
 			t.Setenv("BUILDKITE_SOURCE", test.source)
 			t.Setenv("BUILDKITE_GITHUB_EVENT", test.githubEvent)
-			t.Setenv("BUILDKITE_GITHUB_ACTION", "")
+			t.Setenv("BUILDKITE_GITHUB_ACTION", test.githubAction)
+			if test.githubEvent == "issues" || test.githubEvent == "issue_comment" {
+				t.Setenv(pipelineTriggerWorkflowPathEnvironment, ".github/workflows/multi-trigger.yml")
+				t.Setenv(githubWorkflowRefEnvironment, "buildkite/buildkite-gha/.github/workflows/multi-trigger.yml@refs/heads/main")
+				t.Setenv(githubWorkflowSHAEnvironment, strings.Repeat("a", 40))
+			}
 			if test.githubEvent == "merge_group" {
 				t.Setenv("BUILDKITE_BRANCH", "gh-readonly-queue/main/pr-1-deadbeef")
 				t.Setenv("BUILDKITE_MERGE_QUEUE_BASE_BRANCH", "main")
@@ -1411,7 +1417,7 @@ func TestRunUploadContinuesAfterWorkflowCompilationFailures(t *testing.T) {
 func TestRunUploadWarnsAboutUnsupportedTriggersOnSkippedWorkflows(t *testing.T) {
 	requireImporterHost(t)
 	workflowPath := filepath.Join(t.TempDir(), "cross-event.yml")
-	if err := os.WriteFile(workflowPath, []byte("on: [pull_request, issue_comment]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
+	if err := os.WriteFile(workflowPath, []byte("on: [pull_request, discussion]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
@@ -1425,7 +1431,7 @@ func TestRunUploadWarnsAboutUnsupportedTriggersOnSkippedWorkflows(t *testing.T) 
 	if code := run([]string{"upload", "--event-path", eventPath, workflowPath}, &stdout, &stderr, "dev", runner); code != 0 {
 		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "W_TRIGGER_EVENT_UNSUPPORTED") || !strings.Contains(stderr.String(), "on.issue_comment") {
+	if !strings.Contains(stderr.String(), "W_TRIGGER_EVENT_UNSUPPORTED") || !strings.Contains(stderr.String(), "on.discussion") {
 		t.Fatalf("skipped workflow upload stderr missing unsupported-trigger warning: %q", stderr.String())
 	}
 }

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -263,7 +263,7 @@ func validateAllEventsSource(ctx context.Context, out processingOutput, workflow
 		declared[trigger.Event] = true
 	}
 	failed := false
-	for _, event := range []string{"push", "pull_request", "merge_group", "release", "issues", "workflow_dispatch", "schedule"} {
+	for _, event := range []string{"push", "pull_request", "merge_group", "release", "issues", "issue_comment", "workflow_dispatch", "schedule"} {
 		if !declared[event] {
 			continue
 		}
@@ -382,8 +382,8 @@ func validateArgs(args []string) (workflowPath, eventPath, eventName, format, pr
 	if eventSeen && profile == "" {
 		return "", "", "", "", "", false, fmt.Errorf("--event requires --profile hosted")
 	}
-	if eventSeen && !slices.Contains([]string{"push", "pull_request", "merge_group", "release", "issues", "workflow_dispatch", "schedule"}, eventName) {
-		return "", "", "", "", "", false, fmt.Errorf("unsupported --event %q; supported events are push, pull_request, merge_group, release, issues, workflow_dispatch, and schedule", eventName)
+	if eventSeen && !slices.Contains([]string{"push", "pull_request", "merge_group", "release", "issues", "issue_comment", "workflow_dispatch", "schedule"}, eventName) {
+		return "", "", "", "", "", false, fmt.Errorf("unsupported --event %q; supported events are push, pull_request, merge_group, release, issues, issue_comment, workflow_dispatch, and schedule", eventName)
 	}
 	if allEvents && (eventPathSeen || eventSeen) {
 		return "", "", "", "", "", false, fmt.Errorf("--all-events is mutually exclusive with --event and --event-path")
@@ -440,11 +440,15 @@ func generatedEventSnapshot(name string) ([]byte, error) {
 	case "issues":
 		event.Payload["action"] = "opened"
 		event.Payload["issue"] = map[string]any{"number": 1}
+	case "issue_comment":
+		event.Payload["action"] = "created"
+		event.Payload["issue"] = map[string]any{"number": 1}
+		event.Payload["comment"] = map[string]any{"id": 1}
 	case "schedule":
 		event.Payload["schedule"] = "0 0 * * *"
 	case "workflow_dispatch":
 	default:
-		return nil, fmt.Errorf("unsupported generated event %q; supported events are push, pull_request, merge_group, release, issues, workflow_dispatch, and schedule", name)
+		return nil, fmt.Errorf("unsupported generated event %q; supported events are push, pull_request, merge_group, release, issues, issue_comment, workflow_dispatch, and schedule", name)
 	}
 	return json.Marshal(event)
 }

--- a/internal/cli/validate_batch.go
+++ b/internal/cli/validate_batch.go
@@ -472,7 +472,7 @@ func loadBatchValidationResult(path, workflow string) (compatibility.ProcessingR
 	seen := make(map[string]bool, len(report.Evaluations))
 	for _, evaluation := range report.Evaluations {
 		if seen[evaluation.Event] || evaluation.Source != "generated" || evaluation.Report.Schema != compatibility.ProcessingSchema ||
-			(evaluation.Event != "push" && evaluation.Event != "pull_request" && evaluation.Event != "merge_group" && evaluation.Event != "release" && evaluation.Event != "issues" && evaluation.Event != "workflow_dispatch" && evaluation.Event != "schedule") {
+			(evaluation.Event != "push" && evaluation.Event != "pull_request" && evaluation.Event != "merge_group" && evaluation.Event != "release" && evaluation.Event != "issues" && evaluation.Event != "issue_comment" && evaluation.Event != "workflow_dispatch" && evaluation.Event != "schedule") {
 			return compatibility.ProcessingReportV3{}, false
 		}
 		seen[evaluation.Event] = true

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -4697,7 +4697,8 @@ jobs:
 func TestCompilerWarningsNameOnlyDeclaredSupportedTriggers(t *testing.T) {
 	parsed := &workflow.Workflow{Triggers: []workflow.Trigger{
 		{Event: "workflow_dispatch"},
-		{Event: "issue_comment", Position: workflow.Position{Line: 4, Column: 3}},
+		{Event: "discussion", Position: workflow.Position{Line: 4, Column: 3}},
+		{Event: "issue_comment"},
 		{Event: "issues"},
 		{Event: "release"},
 		{Event: "push"},
@@ -4709,18 +4710,18 @@ func TestCompilerWarningsNameOnlyDeclaredSupportedTriggers(t *testing.T) {
 	}}
 	warnings := compilerWarnings(parsed, false)
 	want := Warning{
-		Code: "W_TRIGGER_EVENT_UNSUPPORTED", Blocker: "trigger", BlockerDetail: "issue_comment", Line: 4, Column: 3,
-		Message: "on.issue_comment is ignored, so nothing in this workflow runs from it. The supported triggers declared in this workflow still run: issues, merge_group, pull_request, push, release, schedule, workflow_call, workflow_dispatch. Move the jobs this trigger guards to one of those triggers if you need them. If you need issue_comment, log an issue on https://github.com/buildkite/buildkite-gha so we can prioritise it.",
+		Code: "W_TRIGGER_EVENT_UNSUPPORTED", Blocker: "trigger", BlockerDetail: "discussion", Line: 4, Column: 3,
+		Message: "on.discussion is ignored, so nothing in this workflow runs from it. The supported triggers declared in this workflow still run: issue_comment, issues, merge_group, pull_request, push, release, schedule, workflow_call, workflow_dispatch. Move the jobs this trigger guards to one of those triggers if you need them. If you need discussion, log an issue on https://github.com/buildkite/buildkite-gha so we can prioritise it.",
 	}
 	if !reflect.DeepEqual(warnings, []Warning{want}) {
 		t.Fatalf("warnings = %#v, want %#v", warnings, []Warning{want})
 	}
 
-	parsed.Triggers = []workflow.Trigger{{Event: "issue_comment", Position: workflow.Position{Line: 1, Column: 5}}}
+	parsed.Triggers = []workflow.Trigger{{Event: "discussion", Position: workflow.Position{Line: 1, Column: 5}}}
 	warnings = compilerWarnings(parsed, false)
 	want = Warning{
-		Code: "W_TRIGGER_EVENT_UNSUPPORTED", Blocker: "trigger", BlockerDetail: "issue_comment", Line: 1, Column: 5,
-		Message: "on.issue_comment is ignored, so nothing in this workflow runs from it. This workflow declares no supported triggers that still run. If you need issue_comment, log an issue on https://github.com/buildkite/buildkite-gha so we can prioritise it.",
+		Code: "W_TRIGGER_EVENT_UNSUPPORTED", Blocker: "trigger", BlockerDetail: "discussion", Line: 1, Column: 5,
+		Message: "on.discussion is ignored, so nothing in this workflow runs from it. This workflow declares no supported triggers that still run. If you need discussion, log an issue on https://github.com/buildkite/buildkite-gha so we can prioritise it.",
 	}
 	if !reflect.DeepEqual(warnings, []Warning{want}) {
 		t.Fatalf("warnings without supported triggers = %#v, want %#v", warnings, []Warning{want})


### PR DESCRIPTION
## Why

GitHub Actions Pipeline Triggers need to import `on: issues` and `on: issue_comment` workflows from the repository default branch. The plugin currently rejects both server-selected events, and comment triggers are not supported by the importer.

## What

- Accept the server-selected workflow for issue events and both issue and PR conversation comments, preserving the payload, action, default-branch ref, and SHA.
- Match all three comment activities by default, or narrow them with `types: created` / `types: [created, edited]`. Keep the existing default-all issues behavior.
- Require complete workflow identity for Pipeline Trigger events, reject conflicting payload/context, and import only the selected workflow. Preserve existing native Buildkite issue builds as a separate path.
- Include `issue_comment` in CLI validation and compatibility guidance. Empty `types` remains unsupported.

Companion server change: https://github.com/buildkite/buildkite/pull/33799. Make this importer version available before enabling the new server events in the private preview; this does not change build creation for native issue/comment settings.
