### PR TITLE
PB-2721: Evaluate service credential variables with the job's environment

### DIFF
--- a/docs/plans/environment-resolution-backend.md
+++ b/docs/plans/environment-resolution-backend.md
@@ -52,7 +52,12 @@ Remaining before removing this plan:
   [{"name", "value"}]}`, each sorted by name and never merged server-side
   (client precedence environment > repository > organization); bounds 500
   repository and 1000 organization names, 48 KiB per value, 256 KiB combined,
-  failing closed as 400; token minted with Variables: read only. The client
+  failing closed as 400; token minted with Variables: read only; a separate
+  budget of 10 requests per job per hour (429 with `Retry-After`); 503 with
+  `Retry-After` when GitHub is unavailable. A 404 means the backend lacks the
+  endpoint or the organization opted out of environment resolution, which the
+  client treats as "scopes unavailable": `vars` names no scope defines keep
+  evaluating as empty strings, never as a client-introduced error. The client
   will call it at most once per upload when static analysis finds any `vars`
   reference, whether or not a workflow declares an environment, and fill
   `compiler.VariableSources` before compiling so `jobs.<id>.if` and

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -599,6 +599,12 @@ func resolveCompileContainer(container *workflow.Container, context expression.C
 }
 
 func resolveCompileServices(services []workflow.Service, context expression.CompileContext) ([]workflow.Service, error) {
+	// Credentials are runner-evaluated after the job's environment applies, so
+	// their vars context is not known here. Keep vars residual so the runtime
+	// evaluates them with environment variables laid over the pre-environment
+	// scopes. Every other service field is compile-time and keeps the context.
+	credentialContext := context
+	credentialContext.Vars = nil
 	resolved := make([]workflow.Service, 0, len(services))
 	for _, service := range services {
 		container := service.Container
@@ -612,7 +618,7 @@ func resolveCompileServices(services []workflow.Service, context expression.Comp
 				if err := validateCompileSite(*field, expression.ProfileServiceCredential, expression.ResultString); err != nil {
 					return nil, fmt.Errorf("service %q credentials: %w", service.Name, err)
 				}
-				value, err := reducePartialTemplateString(*field, expression.ProfileServiceCredential, context)
+				value, err := reducePartialTemplateString(*field, expression.ProfileServiceCredential, credentialContext)
 				if err != nil {
 					return nil, fmt.Errorf("service %q credentials: %w", service.Name, err)
 				}

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -4461,7 +4461,7 @@ jobs:
 	}
 	for i, image := range []string{"postgres:16", "postgres:17"} {
 		service := plans[i].Services["database"]
-		if service.Image != image || service.Credentials == nil || service.Credentials.Username != "registry-user" || service.Credentials.Password != "${{ secrets.REGISTRY_PASSWORD }}" || service.Env["INSTANCE"] != strconv.Itoa(i) || !slices.Equal(service.Ports, []string{"5432"}) || len(service.Volumes) != 1 || service.Options == "" || service.Command == "" || service.Entrypoint == "" {
+		if service.Image != image || service.Credentials == nil || service.Credentials.Username != "${{ vars.REGISTRY_USER }}" || service.Credentials.Password != "${{ secrets.REGISTRY_PASSWORD }}" || service.Env["INSTANCE"] != strconv.Itoa(i) || !slices.Equal(service.Ports, []string{"5432"}) || len(service.Volumes) != 1 || service.Options == "" || service.Command == "" || service.Entrypoint == "" {
 			t.Fatalf("compiled service %d = %#v", i, service)
 		}
 		if !slices.Equal(plans[i].ServiceOrder, []string{"database"}) {
@@ -4479,18 +4479,35 @@ jobs:
 
 func TestResolveCompileServicesRejectsVariableIntroducedExpressionSyntax(t *testing.T) {
 	services := []workflow.Service{{
+		Name:      "database",
+		Container: workflow.ServiceContainer{Image: "${{ vars.image }}"},
+	}}
+	_, err := resolveCompileServices(services, expression.CompileContext{Vars: map[string]string{"image": "${{ secrets.ADMIN }}"}})
+	if err == nil || !strings.Contains(err.Error(), "compile-time expression result contains expression syntax") {
+		t.Fatalf("resolveCompileServices() error = %v", err)
+	}
+}
+
+// TestResolveCompileServicesKeepsCredentialVariablesResidual proves service
+// credentials are not reduced with the pre-environment vars: the runtime
+// evaluates them after the job's environment applies.
+func TestResolveCompileServicesKeepsCredentialVariablesResidual(t *testing.T) {
+	services := []workflow.Service{{
 		Name: "database",
 		Container: workflow.ServiceContainer{
-			Image: "postgres:16",
+			Image: "postgres:${{ vars.tag }}",
 			Credentials: &workflow.ContainerCredentials{
-				Username: "registry-user",
-				Password: "${{ vars.password }}",
+				Username: "${{ vars.user }}",
+				Password: "${{ secrets.REGISTRY_PASSWORD }}",
 			},
 		},
 	}}
-	_, err := resolveCompileServices(services, expression.CompileContext{Vars: map[string]string{"password": "${{ secrets.ADMIN }}"}})
-	if err == nil || !strings.Contains(err.Error(), "compile-time expression result contains expression syntax") {
-		t.Fatalf("resolveCompileServices() error = %v", err)
+	resolved, err := resolveCompileServices(services, expression.CompileContext{Vars: map[string]string{"tag": "16", "user": "registry-user"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if container := resolved[0].Container; container.Image != "postgres:16" || container.Credentials.Username != "${{ vars.user }}" {
+		t.Fatalf("resolved service = %#v", container)
 	}
 }
 

--- a/internal/compiler/vars_test.go
+++ b/internal/compiler/vars_test.go
@@ -111,6 +111,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     if: github.event.ref == 'refs/heads/main' && vars.REGION == 'base'
+    services:
+      registry:
+        image: registry:${{ vars.SHARED }}
+        credentials:
+          username: ${{ vars.REGION }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
     steps:
       - run: 'echo ${{ vars.region }} ${{ vars.SHARED }}'
       - run: echo ${{ format('{0}-{1}', github.event.ref, vars.REGION) }}
@@ -142,6 +148,11 @@ jobs:
 	}
 	if mixed := deploy.Steps[1]; mixed.Command != "echo ${{ format('{0}-{1}', 'refs/heads/main', vars.region) }}" || mixed.Condition != "(true && (vars.region == 'base'))" {
 		t.Fatalf("mixed event and vars expressions were reduced with repository values: command=%q condition=%q", mixed.Command, mixed.Condition)
+	}
+	// Service credentials are runner-evaluated too, while the other service
+	// fields are compile-time and do reduce with the repository value.
+	if registry := deploy.Services["registry"]; registry.Image != "registry:shared" || registry.Credentials == nil || registry.Credentials.Username != "${{ vars.REGION }}" {
+		t.Fatalf("service = %#v, want compile-time image and residual credential vars", registry)
 	}
 	// jobs.<id>.if is evaluated before the environment applies, so the same
 	// expression there does reduce with the repository value.

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -1238,6 +1238,25 @@ func TestEvaluateServicesDoesNotHideErrorsBehindEmptyImage(t *testing.T) {
 	}
 }
 
+// TestEvaluateProgramServicesResolvesCredentialVarsWithEnvironment proves a
+// residual credential vars reference reads the job's environment-merged vars
+// context, the value the compiler could not know.
+func TestEvaluateProgramServicesResolvesCredentialVarsWithEnvironment(t *testing.T) {
+	job := plan.Job{
+		RepositoryVars:  map[string]string{"REGISTRY_USER": "repository-user"},
+		EnvironmentVars: map[string]string{"registry_user": "environment-user"},
+	}
+	services, _, err := evaluateProgramServices(testProgramServices(map[string]plan.ServiceContainer{
+		"private": {Image: "registry.example.test/team/app:1", Credentials: &plan.ContainerCredentials{Username: "${{ vars.REGISTRY_USER }}", Password: "${{ secrets.REGISTRY_PASSWORD }}"}},
+	}), expression.Context{Vars: job.Vars(), Secrets: map[string]string{"REGISTRY_PASSWORD": "registry-password"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if credentials := services["private"].Credentials; credentials == nil || credentials.Username != "environment-user" || credentials.Password != "registry-password" {
+		t.Fatalf("credentials = %#v, want the environment value over the repository value", credentials)
+	}
+}
+
 func testProgramServices(services map[string]plan.ServiceContainer) executionprogram.Services {
 	result := executionprogram.Services{Static: make([]executionprogram.Service, 0, len(services))}
 	for _, name := range sortedKeys(services) {


### PR DESCRIPTION
## Why

A service container credential that reads a variable is resolved before the job's environment can override it. With repository variable `REGISTRY_USER=repository-user` and environment variable `REGISTRY_USER=environment-user`, this job would log in as `repository-user`:

```yaml
deploy:
  runs-on: ubuntu-latest
  environment: production
  services:
    registry:
      image: registry.example.test/team/app:1
      credentials:
        username: ${{ vars.REGISTRY_USER }}
        password: ${{ secrets.REGISTRY_PASSWORD }}
```

Repository variables are not read yet, so no build is affected today. The compiler already keeps `vars` residual in every other runner-evaluated position; credentials were the one exception, found in review of #440.

## What

`resolveCompileServices` reduces credentials with an empty `vars` context, so `${{ vars.REGISTRY_USER }}` reaches the job plan unchanged and the runtime evaluates it with environment over repository over organization variables, as [documented](docs/compatibility.md#deployment-environments). The other service fields (`image`, `options`, `command`, `entrypoint`, `env`, `ports`, `volumes`) are compile-time and still reduce with repository variables.

The environment-resolution plan now records the agreed backend contract for repository and organization variables: a separate job-scoped `POST /jobs/{job_id}/github-actions/variables` endpoint (buildkite/buildkite#33752, being reworked to this shape), called once per upload when a workflow references `vars`, with a 404 meaning the scopes are unavailable and unresolved names still evaluating as empty strings. The environments endpoint stays limited to declared environments.
