### PR TITLE
PB-2721: Resolve GitHub repository and organization variables inside Buildkite jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The [compatibility reference](docs/compatibility.md) is the source of truth. Use
 | Local and public JavaScript and composite actions; verified Dockerfile and public prebuilt-image actions on Linux | Private actions, private reusable workflows, private container images, and Docker actions on macOS |
 | Static matrices, `needs`, outputs, and local or literal public reusable workflows | Dynamic reusable calls, matrices, and expressions outside the documented subset |
 | Exact-commit checkout, including managed private repository access | GitHub-issued OIDC claims or protected queues |
-| Deployment environments with required-reviewer approval gates, environment secret names, and environment variables | Repository and organization variables; environment wait timers, branch policies, custom protection rules, or deployment records |
+| Deployment environments with required-reviewer approval gates and environment secret names; repository, organization, and environment variables | Environment wait timers, branch policies, custom protection rules, or deployment records |
 | Static Buildkite job-accessible secrets, including declared aliases in local reusable workflows | Dynamic secret access or remote reusable-workflow secret forwarding |
 | Scoped `GITHUB_TOKEN` and step `github.token` use allowed by Buildkite policy | Ambient token injection or dynamic token access |
 | Buildkite OIDC tokens through host JavaScript and composite actions | OIDC in Docker actions or job containers |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -287,6 +287,10 @@ buildkite-gha compile \
   .github/workflows/ci.yml
 ```
 
+Inside a Buildkite job, the IR includes the resolved
+[repository and organization variables](compatibility.md#repository-and-organization-variables)
+when the workflow references `vars`.
+
 Workflows whose jobs declare a GitHub
 [`environment`](compatibility.md#deployment-environments) need GitHub
 environment access at compile time. Inside a Buildkite job, `upload` and

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -47,6 +47,7 @@ Looking for something else? [Browse open compatibility issues](https://github.co
 | [Other workflow secrets](#other-secrets-and-oidc) | 🟡 Supported subset | Static names in direct jobs and locally inherited or explicitly mapped reusable jobs resolve through the destination job's Buildkite secret authority. |
 | [Job and service containers](#containers-and-services) | 🟡 Supported subset | Linux job containers and broadly compatible service definitions, including explicit registry credentials. |
 | [Environments and snapshots](#deployment-environments) | 🟡 Supported subset | Literal environments on top-level jobs, with required-reviewer approval gates and environment-scoped secret names. Wait timers, branch policies, and custom rules are rejected. Snapshots are accepted with no effect. |
+| [Variables](#repository-and-organization-variables) | 🟡 Supported subset | Repository, organization, and environment `vars` resolve inside a Buildkite job with GitHub's per-position scoping. `run-name` rejects `vars`. |
 | [OIDC](#other-secrets-and-oidc) | 🟡 Supported subset | Host JavaScript and composite actions can request Buildkite OIDC tokens in jobs with `id-token: write`. |
 | [Other platforms](#job-configuration) and [providers](#repositories) | ❌ Unsupported | Windows, Linux arm64, macOS x86-64, GitHub Enterprise Server, and unlisted providers are outside the initial release. |
 | [Other GitHub services](#github-services) | ❌ Unsupported | No general emulation for Releases, Packages, Checks, deployments, or GitHub artifact APIs. |
@@ -192,12 +193,10 @@ non-dispatch event, declared dispatch inputs use their typed zero values rather
 than dispatch-only defaults. A skipped workflow does not synthesize dispatch
 inputs.
 
-GitHub also documents `vars` in its context-availability reference. Only
-[environment variables](#deployment-environments) have a source. Repository
-and organization variables are not read, so a `vars` reference outside a
-declared environment's variables evaluates to an empty string at runtime, and
-compile-time positions such as `runs-on`, `strategy`, `concurrency`, container
-images, and reusable-workflow inputs have no `vars` source at all.
+GitHub also documents `vars` in its context-availability reference, but
+`run-name` has no `vars` source here and a reference is rejected. See
+[Repository and organization variables](#repository-and-organization-variables)
+for every other position.
 
 Buildkite controls when a build starts. The trigger declaration controls whether and under which condition the workflow group participates in that existing build:
 
@@ -636,7 +635,7 @@ that declare environments fail to compile with an error naming the job.
 | Literal `environment` name, with or without `url` | ✅ Supported on top-level workflow jobs. Expression names and reusable-workflow jobs are rejected. |
 | Required reviewers | 🟡 One Buildkite block step per workflow and environment gates the affected jobs. Any user who can unblock the pipeline can approve; GitHub reviewer lists, `prevent_self_review`, and administrator bypass are not enforced. |
 | Environment secrets | 🟡 Referenced secret names defined in the environment resolve to the Buildkite secret `<ENVIRONMENT>_<NAME>`. Other names resolve unchanged. Values stay in Buildkite Secrets; only names are read from GitHub. |
-| Environment variables | 🟡 `${{ vars.NAME }}` resolves in runner-evaluated fields of jobs that declare the environment. Job `if` and compile-time fields never see environment variables, and other names evaluate as empty. See below. |
+| Environment variables | 🟡 `${{ vars.NAME }}` resolves in runner-evaluated fields of jobs that declare the environment, over repository and organization variables. Job `if` and compile-time fields never see environment variables. See [Repository and organization variables](#repository-and-organization-variables). |
 | Wait timers | ❌ Rejected at compile time. |
 | Deployment branch policies | ❌ Rejected at compile time. |
 | Custom deployment protection rules | ❌ Rejected at compile time. |
@@ -652,44 +651,6 @@ Generated keys must be storable in Buildkite Secrets: compilation fails when a
 key would exceed 255 characters or begin with `BK` or `BUILDKITE`, so rename
 such environments or secrets.
 
-Environment variables follow GitHub's scoping. Each job's plan carries its
-declared environment's variables as `environment_vars`, separate from the
-`repository_vars` and `organization_vars` scopes, which stay empty because
-repository and organization variables are not read. The runtime builds the
-`vars` context per position the way GitHub does:
-
-| Position | `vars` context |
-| --- | --- |
-| `jobs.<id>.if` and reusable-workflow call `if` | Repository over organization variables. GitHub evaluates these before the job's environment applies, so environment variables are never visible here and such references currently evaluate as empty. Check environment variables in a step `if`. |
-| Job `env`, `defaults.run`, `outputs`, service credentials, every step field, and action input defaults | Environment over repository over organization variables. |
-| Compile-time fields (`runs-on`, `strategy`, `concurrency`, container images, `environment` names, reusable-workflow inputs) | Repository over organization variables; currently no source, so a reference fails to compile. See [Compile-time expressions](#compile-time-expressions). |
-
-Names match case-insensitively, and a higher scope replaces a lower scope's
-name spelled differently. A name no scope defines evaluates to an empty
-string, as on GitHub; it is not a compile error. Dynamic access such as
-`vars[matrix.name]`, `vars.*`, and `toJSON(vars)` reads the same per-position
-context. Matrix instances share their job's environment variables. Jobs
-without an environment, including every reusable-workflow job, see no
-variables. `GITHUB_TOKEN` and secret authority planning never resolves `vars`:
-a step input such as `${{ vars.ENABLED == 'yes' && github.token || '' }}`
-requests the token whatever the variable's value, and fails under
-`permissions: {}` as it does without variables.
-
-```yaml
-deploy:
-  runs-on: ubuntu-latest
-  environment: production
-  env:
-    AWS_REGION: ${{ vars.AWS_REGION }}
-  steps:
-    - if: vars.TIER == 'gold'
-      run: echo "$AWS_REGION"
-```
-
-Values are plain configuration, not secrets: they are stored in the build's
-job plan artifacts and are visible to anyone who can read build artifacts.
-See [Environment variables](security.md#environment-variables) in the security guide.
-
 The approval gate is a block step with `blocked_state: running`, so ungated
 jobs keep running while approval is pending. The gate appears whenever the
 workflow compiles, even if the gated job's own condition would skip it. Matrix
@@ -699,6 +660,72 @@ a new build for a fresh approval.
 Environment configuration is read once per compile, so changes on GitHub apply
 to the next build. Buildkite OIDC tokens do not carry a GitHub `environment`
 claim.
+
+### Repository and organization variables
+
+`${{ vars.NAME }}` follows GitHub's scoping. Inside a Buildkite job, `upload`
+and `compile` read the event repository's repository and organization
+variables through the job-scoped Agent API (`github-actions/variables`) when
+any applicable workflow, a reusable workflow it calls, or an input default of
+an action it uses references `vars`; workflows without a `vars` reference
+make no request, and neither do events from providers other than GitHub.com.
+One upload makes at most one request, whether or not a workflow declares an
+environment. The
+Buildkite backend reads the variables from GitHub with its own credentials,
+restricted to the pipeline's configured repository, and bounds the response
+(500 repository and 1000 organization names, 48 KiB per value, 256 KiB
+combined). Its rejection, rate limit (10 requests per job per hour), or
+GitHub outage fails the compile of every workflow that references `vars` with
+the backend's error and any `Retry-After` delay; other workflows still upload.
+A backend without the endpoint, or an organization that has opted out,
+returns 404, which leaves both scopes empty rather than failing the compile.
+Outside a Buildkite job, `compile` has no variable source, so the scopes are
+empty.
+
+Each job's plan carries the scopes as `organization_vars`, `repository_vars`,
+and, for jobs that declare an environment, `environment_vars`. The compiler
+and runtime build the `vars` context per position the way GitHub does:
+
+| Position | `vars` context |
+| --- | --- |
+| `jobs.<id>.if` and reusable-workflow call `if` | Repository over organization variables. GitHub evaluates these before the job's environment applies, so environment variables are never visible here. Check environment variables in a step `if`. |
+| Job `env`, `defaults.run`, `outputs`, service credentials, every step field, and action input defaults | Environment over repository over organization variables. |
+| Compile-time fields (`runs-on`, `strategy`, `concurrency`, job names, container images, reusable-workflow inputs) | Repository over organization variables. Without a source, such as `compile` outside a Buildkite job, a reference fails to compile. `environment` names must stay literal. See [Compile-time expressions](#compile-time-expressions). |
+
+Names match case-insensitively, and a higher scope replaces a lower scope's
+name spelled differently. A name no scope defines evaluates to an empty
+string, as on GitHub; it is not a compile error. Dynamic access such as
+`vars[matrix.name]`, `vars.*`, and `toJSON(vars)` reads the same per-position
+context. Matrix instances share their job's environment variables; jobs
+without an environment, including every reusable-workflow job, see repository
+and organization variables only. `GITHUB_TOKEN` and secret authority planning
+never resolves `vars`: a job or step gated by `if: vars.PUBLISH == 'true'`
+keeps its token and secret requests whatever the variable's value, because
+every condition keeps `vars` for the runtime to evaluate, and a step input
+such as `${{ vars.ENABLED == 'yes' && github.token || '' }}` requests the
+token and fails under `permissions: {}` as it does without variables.
+
+```yaml
+deploy:
+  runs-on: ${{ vars.RUNNER }}
+  if: vars.DEPLOY_ENABLED == 'true'
+  environment: production
+  env:
+    AWS_REGION: ${{ vars.AWS_REGION }}
+  steps:
+    - if: vars.TIER == 'gold'
+      run: echo "$AWS_REGION"
+```
+
+Values are plain configuration, not secrets: they are stored in the build's
+job plan artifacts and are visible to anyone who can read build artifacts, and
+`compile --format ir-json` prints both scopes in the IR whenever the workflow
+references `vars`. A value a compile-time field uses also appears wherever
+that field does: a job name or matrix value becomes a step label in the
+pipeline YAML, and a runner label that cannot be mapped is quoted in the
+compile diagnostic. Runtime references, processing reports, and resolution
+errors never carry values. See
+[Variables](security.md#variables) in the security guide.
 
 ### Matrix strategies
 
@@ -942,7 +969,7 @@ Conditions support computed object indexes, numeric array indexes, whole
 | `runner.temp` | ❌ No | ✅ Yes |
 | `needs.<job>.result`, `needs.<job>.outputs.<name>` | ✅ Yes | ✅ Yes |
 | `matrix.<name>` | ✅ Yes | ✅ Yes |
-| `vars.<name>` | 🟡 Evaluates as empty: repository and organization variables are not read | ✅ Yes, for [environment variables](#deployment-environments) |
+| `vars.<name>` | ✅ Yes, [repository and organization variables](#repository-and-organization-variables) | ✅ Yes, environment over repository over organization variables |
 | `inputs.<name>` and computed input indexes | ✅ Yes | ✅ Yes |
 | `steps.<id>.outcome`, `steps.<id>.conclusion`, `steps.<id>.outputs.<name>` | ❌ No | ✅ Yes |
 | `env.<name>` | ❌ No | ✅ Yes |

--- a/docs/plans/environment-resolution-backend.md
+++ b/docs/plans/environment-resolution-backend.md
@@ -4,9 +4,8 @@ Importer jobs resolve
 [deployment environments](../compatibility.md#deployment-environments) through
 Buildkite, which already holds the GitHub App installation. The chosen design
 is option 2 below: a dedicated Agent API snapshot endpoint,
-`POST /jobs/{job_id}/github-actions/environments`, implemented in
-[buildkite/buildkite#33480](https://github.com/buildkite/buildkite/pull/33480).
-There is no feature flag: the endpoint returns no credential or secret value,
+`POST /jobs/{job_id}/github-actions/environments`, implemented on the
+Buildkite backend. There is no feature flag: the endpoint returns no credential or secret value,
 missing GitHub App permissions already fail closed as 400, and an unavailable
 endpoint fails closed as 404. The
 importer posts one batched request per upload naming every distinct
@@ -18,8 +17,7 @@ backend performs the GitHub reads with its own credentials and
 answers with a non-secret JSON snapshot — required reviewers present,
 `prevent_self_review`, wait timer minutes, branch policy present, unsupported
 rule descriptions, secret names, and, when the request sets
-`include_variables`, the environment's variables with plaintext values
-([buildkite/buildkite#33692](https://github.com/buildkite/buildkite/pull/33692)).
+`include_variables`, the environment's variables with plaintext values.
 No GitHub token and no secret value reaches the importer. This client consumes the endpoint automatically in
 `upload` and in `compile` when it runs inside a Buildkite job. It is the only
 environment access path: there is no GitHub token option, so environments are
@@ -41,30 +39,13 @@ Remaining before removing this plan:
   endpoint carries environment-scoped variables only and will not grow
   repository or organization fields.
 - Repository and organization variables come from a separate job-scoped
-  endpoint, `POST /jobs/{job_id}/github-actions/variables`, which
-  [buildkite/buildkite#33752](https://github.com/buildkite/buildkite/pull/33752)
-  is being reworked to provide in place of its first draft, which extended the
-  environments response with top-level `repository_variables` and
-  `organization_variables` and allowed an empty `environment_names`. That draft
-  is withdrawn; this client never consumed those fields. The agreed contract:
-  request `{"repo_url": "https://github.com/owner/repo"}`; response
-  `{"repository_variables": [{"name", "value"}], "organization_variables":
-  [{"name", "value"}]}`, each sorted by name and never merged server-side
-  (client precedence environment > repository > organization); bounds 500
-  repository and 1000 organization names, 48 KiB per value, 256 KiB combined,
-  failing closed as 400; token minted with Variables: read only; a separate
-  budget of 10 requests per job per hour (429 with `Retry-After`); 503 with
-  `Retry-After` when GitHub is unavailable. A 404 means the backend lacks the
-  endpoint or the organization opted out of environment resolution, which the
-  client treats as "scopes unavailable": `vars` names no scope defines keep
-  evaluating as empty strings, never as a client-introduced error. The client
-  will call it at most once per upload when static analysis finds any `vars`
-  reference, whether or not a workflow declares an environment, and fill
-  `compiler.VariableSources` before compiling so `jobs.<id>.if` and
-  compile-time `vars` positions resolve. The job plan already carries separate
-  `organization_vars` and `repository_vars` scopes (empty today), so this needs
-  no plan format change. Environment resolution stays limited to declared
-  environments.
+  endpoint, `POST /jobs/{job_id}/github-actions/variables`, which replaced a
+  withdrawn draft that extended the environments response; this client never
+  consumed those draft fields. The client side is done (see below).
+  Remaining: merge and roll out the backend endpoint, including its
+  Variables: read token scope and the 10-requests-per-job-per-hour budget.
+  Until then the endpoint returns 404 and the client leaves both scopes
+  empty, so `vars` names no scope defines keep evaluating as empty strings.
 - A hosted end-to-end proof of an `upload` resolving an environment and gating
   a deploy job.
 
@@ -135,7 +116,27 @@ environments typically consumes one request — and every resolution failure
 fails the compile, never degrading to an unprotected deployment. The client
 always requests variables and requires the `variables` field, so a backend
 without the extension fails the compile with a decode error rather than
-letting `vars` references resolve as empty. When the
-backend rollout completes and the hosted proof passes, move lasting facts into
+letting `vars` references resolve as empty.
+
+Repository and organization variables use a separate source
+([internal/cli/variables.go](../../internal/cli/variables.go)) over the
+variables endpoint
+([internal/runtime/variable_resolution.go](../../internal/runtime/variable_resolution.go)).
+Static analysis (`compiler.Report.ReferencesVars`) finds `vars` references
+across each workflow and the reusable workflows it calls; when any applicable
+GitHub.com workflow references `vars`, one memoized request per upload sends
+`{"repo_url": "https://github.com/owner/repo"}` and fills
+`compiler.VariableSources` before validation, so `jobs.<id>.if` and
+compile-time fields resolve and every job plan carries `repository_vars` and
+`organization_vars`. A reference that lives only in a resolved action's input
+default (`compiler.ActionsReferenceVars`) is discovered after compilation;
+the same memoized request then runs and the workflow compiles again so its
+plans carry the scopes. The client enforces the contract's bounds (500 and 1000
+names, 48 KiB per value, 256 KiB combined, name syntax, case-insensitive
+uniqueness per scope), treats 404 as empty scopes, and fails the referencing
+workflows on 400, 429, and 503 with the backend message and `Retry-After`
+delay, never echoing a value. Token-authority planning ignores resolved
+values. When the backend rollout completes and the hosted proof passes, move
+lasting facts into
 [deployment environments](../compatibility.md#deployment-environments) and
 remove this plan.

--- a/docs/security.md
+++ b/docs/security.md
@@ -20,7 +20,7 @@ access by itself.
 | `permissions` and `GITHUB_TOKEN` | Top-level workflow permissions and Buildkite's workflow-token policy determine whether Buildkite issues a scoped token. GitHub repository and organization defaults are not inherited. |
 | Repository and environment secrets | Static secret names resolve through Buildkite Secrets when the destination job's identity and Secret access policy allow them. Environment-defined secret names resolve to `<ENVIRONMENT>_<NAME>` Buildkite secrets; event and fork scoping are not inherited. |
 | Environment protection rules | Required reviewers become a Buildkite block step that any user who can unblock the pipeline may approve. Reviewer lists, self-review prevention, wait timers, branch policies, and custom rules are not enforced; unsupported rules fail the compile. |
-| Environment variables | Values are copied into the job plan artifact as `environment_vars`. They are configuration, not secrets: anyone who can read build artifacts can read them. Repository and organization variables are never read. |
+| Repository, organization, and environment variables | The Buildkite backend reads them from GitHub with its own credentials; values are copied into the job plan artifact as `organization_vars`, `repository_vars`, and `environment_vars`. They are configuration, not secrets: anyone who can read build artifacts can read them. |
 | OIDC | Actions use Buildkite-issued tokens and claims. Cloud trust policies must trust Buildkite rather than GitHub. |
 
 The [compatibility reference](compatibility.md) says what works. This page says
@@ -192,20 +192,26 @@ same job identity can also run `buildkite-agent secret get`.
 a declared alias preserves that scoped token boundary; it never requests an
 ordinary Buildkite secret.
 
-### Environment variables
+### Variables
 
-GitHub environment variables (`${{ vars.NAME }}`) are configuration values,
-not secrets. The Buildkite backend reads them from GitHub with its own
-credentials, and the importer copies each declared environment's variables
-into the plans of the jobs that declare it. A plan artifact
-(`.buildkite-gha/plans/<digest>.json`) therefore contains plaintext values,
-readable by anyone who can read the build's artifacts. Store sensitive values
-as environment secrets instead. Values never appear in pipeline YAML, compile
-diagnostics, or processing reports; those name variables only. Repository and
-organization variables are never read, so a job sees only its environment's
-variables, and a name outside them evaluates as empty rather than exposing
-another scope's value. See [deployment
-environments](compatibility.md#deployment-environments).
+GitHub Actions variables (`${{ vars.NAME }}`) are configuration values, not
+secrets. The Buildkite backend reads them from GitHub with its own
+credentials, restricted to the pipeline's configured repository, and the
+importer copies the repository and organization scopes into every job plan
+and each declared environment's variables into the plans of the jobs that
+declare it. A plan artifact (`.buildkite-gha/plans/<digest>.json`) therefore
+contains plaintext values, readable by anyone who can read the build's
+artifacts, and `compile --format ir-json` run inside a job prints both scopes
+to stdout, and so to the job log, whenever the workflow references `vars`.
+Store sensitive values as secrets instead. A value used in a compile-time
+field, such as a job name, matrix
+value, or runner label, also appears where that field does: in the pipeline
+YAML and in a compile diagnostic that quotes the field. Runtime references,
+processing reports, and resolution errors never carry values; they name
+variables only. A job
+sees the scopes GitHub gives each position, and a name no scope defines
+evaluates as empty rather than exposing another repository's value. See [repository and organization
+variables](compatibility.md#repository-and-organization-variables).
 
 ### OIDC
 

--- a/internal/cli/compile.go
+++ b/internal/cli/compile.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/buildkite/buildkite-gha/internal/compatibility"
 	"github.com/buildkite/buildkite-gha/internal/compiler"
 	"github.com/buildkite/buildkite-gha/internal/transport"
 	"github.com/buildkite/buildkite-gha/internal/workflowprocessing"
@@ -47,6 +48,21 @@ func compile(args []string, stdout, stderr io.Writer, clientVersion string, agen
 	// resolves them when it runs inside a Buildkite job and otherwise leaves
 	// workflows that declare environments to fail at compile time.
 	options.EnvironmentSource = environmentSourceFromAgent(clientVersion)
+	// Repository and organization variables likewise resolve only through the
+	// job-scoped Agent API, and only when the workflow references vars.
+	// Compile-time fields read them, so they must be known before validation.
+	variables := variableSourceFromAgent(clientVersion)
+	parsedEvent, parsedEventErr := compiler.ParseEvent(event)
+	workflowReferencesVars := false
+	if variables != nil && parsedEventErr == nil {
+		staticValidation, _ := compiler.ValidateWithOptionsContext(ctx, workflowPath, source, options)
+		workflowReferencesVars = staticValidation.ReferencesVars
+		vars, varsErr := resolveVariableSources(ctx, variables, parsedEvent, workflowReferencesVars)
+		if varsErr != nil {
+			return out.fail(ctx, compatibility.EnvironmentProcessingReport(workflowPath, "", varsErr.Error()), varsErr)
+		}
+		options.Vars = vars
+	}
 	processingReport, ok := validatedProcessingReportWithOptions(ctx, out, workflowPath, "", source, event, true, &options)
 	if !ok {
 		return 1
@@ -72,6 +88,18 @@ func compile(args []string, stdout, stderr io.Writer, clientVersion string, agen
 			return 1
 		}
 		bundle, compileErr := compiler.CompileBundleContext(ctx, workflowPath, source, event, version, digest, "gha-importer", options)
+		if compileErr == nil && parsedEventErr == nil {
+			actionVars, again, varsErr := resolveActionVariables(ctx, variables, parsedEvent, workflowReferencesVars, bundle)
+			if varsErr != nil {
+				processingReport.AddEnvironmentFailure(varsErr.Error())
+				processingReport.Result = "indeterminate"
+				return out.fail(ctx, processingReport, varsErr)
+			}
+			if again {
+				options.Vars = actionVars
+				bundle, compileErr = compiler.CompileBundleContext(ctx, workflowPath, source, event, version, digest, "gha-importer", options)
+			}
+		}
 		processingReport.ApplyEvidence(bundle.Processing)
 		err = compileErr
 		result = bundle.Pipeline

--- a/internal/cli/environments_test.go
+++ b/internal/cli/environments_test.go
@@ -97,12 +97,22 @@ func TestRunCompileResolvesEnvironmentsThroughAgent(t *testing.T) {
 }
 
 // agentEnvironmentsStub serves the Agent API endpoints upload contacts:
-// runner resolution, which reports every requirement unmapped, and
+// runner resolution, which reports every requirement unmapped;
+// github-actions/variables, which is absent (404); and
 // github-actions/environments, which rejects requests without the job token,
 // counts resolution requests, and answers each requested environment with a
 // required-reviewers snapshot naming one DEPLOY_KEY secret. The production
 // environment also defines the AWS_REGION variable.
 func agentEnvironmentsStub(t *testing.T, jobToken string, status int) (*httptest.Server, *int) {
+	t.Helper()
+	// This backend offers no repository or organization variables, so vars
+	// references outside the environment stay empty.
+	return agentStub(t, jobToken, status, func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNotFound) })
+}
+
+// agentStub is agentEnvironmentsStub with a caller-supplied
+// github-actions/variables handler.
+func agentStub(t *testing.T, jobToken string, status int, variables http.HandlerFunc) (*httptest.Server, *int) {
 	t.Helper()
 	requests := new(int)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -120,6 +130,10 @@ func agentEnvironmentsStub(t *testing.T, jobToken string, status int) (*httptest
 				resolutions[i] = map[string]any{"id": requirement.ID, "error": map[string]string{"code": "unmapped_labels", "message": "No compatible runner is configured."}}
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{"resolutions": resolutions})
+			return
+		}
+		if strings.HasSuffix(r.URL.Path, "/github-actions/variables") {
+			variables(w, r)
 			return
 		}
 		*requests++

--- a/internal/cli/hosted.go
+++ b/internal/cli/hosted.go
@@ -204,19 +204,20 @@ func compileHosted(ctx context.Context, workflowPath string, workflowSource, eve
 }
 
 func compileHostedWithActionCache(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runtimeDistributions map[compiler.Platform]string, actionCacheDir string, sharedActionSource compiler.ActionSource, actionAuthentication *actionSourceAuthentication) (hostedCompilation, error) {
-	return compileHostedNamespacedWithActionCache(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, groupLabel, configuredTargets, nil, runtimeDistributions, "", nil, actionCacheDir, sharedActionSource, actionAuthentication, nil)
+	return compileHostedNamespacedWithActionCache(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, groupLabel, configuredTargets, nil, runtimeDistributions, "", nil, actionCacheDir, sharedActionSource, actionAuthentication, nil, compiler.VariableSources{})
 }
 
 func compileHostedNamespaced(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runtimeDistributions map[compiler.Platform]string, stepKeyNamespace string, oidc *plan.OIDCConfiguration, actionAuthentication *actionSourceAuthentication) (hostedCompilation, error) {
-	return compileHostedNamespacedWithActionCache(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, groupLabel, configuredTargets, nil, runtimeDistributions, stepKeyNamespace, oidc, "", nil, actionAuthentication, nil)
+	return compileHostedNamespacedWithActionCache(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, importerStep, groupLabel, configuredTargets, nil, runtimeDistributions, stepKeyNamespace, oidc, "", nil, actionAuthentication, nil, compiler.VariableSources{})
 }
 
-func compileHostedNamespacedWithActionCache(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runnerSelectors []compiler.RunnerSelector, runtimeDistributions map[compiler.Platform]string, stepKeyNamespace string, oidc *plan.OIDCConfiguration, actionCacheDir string, sharedActionSource compiler.ActionSource, actionAuthentication *actionSourceAuthentication, environmentSource compiler.EnvironmentSource) (hostedCompilation, error) {
+func compileHostedNamespacedWithActionCache(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, importerStep, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runnerSelectors []compiler.RunnerSelector, runtimeDistributions map[compiler.Platform]string, stepKeyNamespace string, oidc *plan.OIDCConfiguration, actionCacheDir string, sharedActionSource compiler.ActionSource, actionAuthentication *actionSourceAuthentication, environmentSource compiler.EnvironmentSource, vars compiler.VariableSources) (hostedCompilation, error) {
 	options := hostedOptions(groupLabel, configuredTargets, runtimeDistributions)
 	applyRunnerSelectors(&options, runnerSelectors)
 	options.StepKeyNamespace = stepKeyNamespace
 	options.OIDC = oidc
 	options.EnvironmentSource = environmentSource
+	options.Vars = vars
 	repositorySource := sharedActionSource
 	cleanup := func() {}
 	if repositorySource == nil {

--- a/internal/cli/upload.go
+++ b/internal/cli/upload.go
@@ -81,6 +81,9 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 	if uploadArguments.environmentSource == nil {
 		uploadArguments.environmentSource = environmentSourceFromAgent(uploadArguments.clientVersion)
 	}
+	if uploadArguments.variableSource == nil {
+		uploadArguments.variableSource = variableSourceFromAgent(uploadArguments.clientVersion)
+	}
 	out := newProcessingOutput(ctx, "upload", "text", stderr, stderr, agent)
 	out.plugin = uploadArguments.pluginAcquisition != nil
 	if uploadArguments.telemetry != nil {
@@ -176,13 +179,14 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 	defer cleanupAnonymousSource()
 	sourceSwitch := &repositorySourceSwitch{source: anonymousSource}
 	repositorySource := compiler.MemoizeRepositorySource(sourceSwitch)
-	for _, input := range workflows {
+	for i, input := range workflows {
 		if input.ReusableOnly {
 			continue
 		}
 		validationOptions := hostedOptions("", uploadArguments.runnerTargets, nil)
 		validationOptions.RepositorySource = repositorySource
 		validation, validationErr := compiler.ValidateWithOptionsContext(ctx, input.Path, input.Source, validationOptions)
+		workflows[i].ReferencesVars = validation.ReferencesVars
 		if validation.RuntimeMatrixBoundary {
 			report := compatibility.InitialProcessingReport(input.Path, hostedProfile, false, validation, validationErr)
 			report.Result = "incompatible"
@@ -266,6 +270,7 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 		}
 		workflows[i].RunName = runName
 	}
+	vars := resolveUploadVariables(ctx, uploadArguments.variableSource, workflows, processingReports, effectiveEvent.Event)
 	validations := make([]compiler.Report, len(workflows))
 	validationErrs := make([]error, len(workflows))
 	for i, input := range workflows {
@@ -275,6 +280,7 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 		validationOptions := hostedOptions("", uploadArguments.runnerTargets, nil)
 		validationOptions.StepKeyNamespace = input.StepKeyNamespace
 		validationOptions.RepositorySource = repositorySource
+		validationOptions.Vars = vars
 		validations[i], validationErrs[i] = compiler.ValidateEventWithOptionsContext(ctx, input.Path, input.Source, effectiveEvent.Source, validationOptions)
 	}
 	runnerSelectors, runnerWarnings, err := suggestedRunnerTargets(ctx, validations, uploadArguments.runnerTargets, uploadArguments.clientVersion)
@@ -294,6 +300,7 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 			applyRunnerSelectors(&validationOptions, runnerSelectors)
 			validationOptions.StepKeyNamespace = input.StepKeyNamespace
 			validationOptions.RepositorySource = repositorySource
+			validationOptions.Vars = vars
 			validations[i], validationErrs[i] = compiler.ValidateEventWithOptionsContext(ctx, input.Path, input.Source, effectiveEvent.Source, validationOptions)
 		}
 	}
@@ -326,7 +333,7 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 		if !input.Applicable || processingReportHasErrors(processingReports[i]) {
 			continue
 		}
-		platforms, platformErr := requiredRuntimePlatforms(ctx, input.Path, input.Source, effectiveEvent.Source, "", uploadArguments.runnerTargets, uploadArguments.runnerSelectors, repositorySource, uploadArguments.environmentSource)
+		platforms, platformErr := requiredRuntimePlatforms(ctx, input.Path, input.Source, effectiveEvent.Source, "", uploadArguments.runnerTargets, uploadArguments.runnerSelectors, repositorySource, uploadArguments.environmentSource, vars)
 		if platformErr != nil {
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", platformErr)
 			return 1
@@ -341,7 +348,7 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: plugin: %v\n", acquireErr)
 			return 1
 		}
-		return finishUpload(ctx, uploadArguments, stdout, stderr, version, agent, workflows, effectiveEvent, executablePath, distributionDigest, importerStep, importerJobID, processingReports, out, runtimeDistributions, repositorySource, authentication)
+		return finishUpload(ctx, uploadArguments, stdout, stderr, version, agent, workflows, effectiveEvent, executablePath, distributionDigest, importerStep, importerJobID, processingReports, out, runtimeDistributions, repositorySource, authentication, vars)
 	}
 	requiredDistributionPaths := make(map[compiler.Platform]string, len(requiredPlatforms))
 	for platform := range requiredPlatforms {
@@ -370,10 +377,10 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: runtime distribution for %s is required by the selected workflows\n", platform)
 		return 1
 	}
-	return finishUpload(ctx, uploadArguments, stdout, stderr, version, agent, workflows, effectiveEvent, executablePath, distributionDigest, importerStep, importerJobID, processingReports, out, runtimeDistributions, repositorySource, authentication)
+	return finishUpload(ctx, uploadArguments, stdout, stderr, version, agent, workflows, effectiveEvent, executablePath, distributionDigest, importerStep, importerJobID, processingReports, out, runtimeDistributions, repositorySource, authentication, vars)
 }
 
-func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout, stderr io.Writer, version string, agent transport.Agent, workflows []workflowInput, effectiveEvent effectiveEventSelection, executablePath, distributionDigest, importerStep, importerJobID string, processingReports []compatibility.ProcessingReport, out processingOutput, runtimeDistributions map[compiler.Platform]runtimeDistribution, repositorySource compiler.RepositorySource, authentication *actionSourceAuthentication) int {
+func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout, stderr io.Writer, version string, agent transport.Agent, workflows []workflowInput, effectiveEvent effectiveEventSelection, executablePath, distributionDigest, importerStep, importerJobID string, processingReports []compatibility.ProcessingReport, out processingOutput, runtimeDistributions map[compiler.Platform]runtimeDistribution, repositorySource compiler.RepositorySource, authentication *actionSourceAuthentication, vars compiler.VariableSources) int {
 	runtimeDigests := make(map[compiler.Platform]string, len(runtimeDistributions))
 	for platform, runtimeDistribution := range runtimeDistributions {
 		runtimeDigests[platform] = runtimeDistribution.digest
@@ -426,7 +433,24 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 			failureArtifacts = append(failureArtifacts, artifacts...)
 			continue
 		}
-		preflight, err := compileHostedNamespacedWithActionCache(ctx, input.Path, input.Source, effectiveEvent.Source, version, distributionDigest, bundleCompilerStep, "", uploadArguments.runnerTargets, uploadArguments.runnerSelectors, runtimeDigests, input.StepKeyNamespace, uploadArguments.oidc, "", repositorySource, authentication, uploadArguments.environmentSource)
+		compileWorkflow := func(vars compiler.VariableSources) (hostedCompilation, error) {
+			return compileHostedNamespacedWithActionCache(ctx, input.Path, input.Source, effectiveEvent.Source, version, distributionDigest, bundleCompilerStep, "", uploadArguments.runnerTargets, uploadArguments.runnerSelectors, runtimeDigests, input.StepKeyNamespace, uploadArguments.oidc, "", repositorySource, authentication, uploadArguments.environmentSource, vars)
+		}
+		preflight, err := compileWorkflow(vars)
+		if err == nil {
+			actionVars, again, varsErr := resolveActionVariables(ctx, uploadArguments.variableSource, effectiveEvent.Event, input.ReferencesVars, preflight.Bundle)
+			if varsErr != nil {
+				processingReports[i].AddEnvironmentFailure(varsErr.Error())
+				processingReports[i].Result = "indeterminate"
+				failed, artifacts := failedGeneratedWorkflow(input, effectiveEvent.Event.Event, processingReports[i], out.sourceLinks)
+				generatedWorkflows = append(generatedWorkflows, failed)
+				failureArtifacts = append(failureArtifacts, artifacts...)
+				continue
+			}
+			if again {
+				preflight, err = compileWorkflow(actionVars)
+			}
+		}
 		applyHostedPreflight(&processingReports[i], preflight)
 		if err != nil {
 			processingReports[i].Result = classifyHostedFailure(&processingReports[i], input.Path, err)
@@ -653,8 +677,9 @@ func generatedFailureArtifact(kind, extension, contents string) transport.Artifa
 	return transport.Artifact{Path: path, Digest: digest, Contents: encoded}
 }
 
-func requiredRuntimePlatforms(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runnerSelectors []compiler.RunnerSelector, repositorySource compiler.RepositorySource, environmentSource compiler.EnvironmentSource) (map[compiler.Platform]bool, error) {
+func requiredRuntimePlatforms(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runnerSelectors []compiler.RunnerSelector, repositorySource compiler.RepositorySource, environmentSource compiler.EnvironmentSource, vars compiler.VariableSources) (map[compiler.Platform]bool, error) {
 	options := hostedOptions(groupLabel, configuredTargets, nil)
+	options.Vars = vars
 	applyRunnerSelectors(&options, runnerSelectors)
 	options.RepositorySource = repositorySource
 	options.EnvironmentSource = environmentSource
@@ -686,6 +711,9 @@ type workflowInput struct {
 	TriggerCondition, SkipReason, AnnotationReason  string
 	PathFiltersError                                string
 	ReusableOnly, Applicable                        bool
+	// ReferencesVars records whether the event-independent validation found
+	// any vars reference in the workflow or a reusable workflow it calls.
+	ReferencesVars bool
 }
 
 func resolveWorkflowOperands(operands []string) ([]workflowInput, []string, error) {
@@ -829,6 +857,7 @@ type parsedUploadArgs struct {
 	runnerSelectors          []compiler.RunnerSelector
 	oidc                     *plan.OIDCConfiguration
 	environmentSource        compiler.EnvironmentSource
+	variableSource           variableSource
 	experimentalRunnerUser   bool
 	pluginAcquisition        *pluginRuntimeAcquisition
 	importerPlatform         compiler.Platform

--- a/internal/cli/variables.go
+++ b/internal/cli/variables.go
@@ -1,0 +1,134 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/buildkite/buildkite-gha/internal/compatibility"
+	"github.com/buildkite/buildkite-gha/internal/compiler"
+	gharuntime "github.com/buildkite/buildkite-gha/internal/runtime"
+)
+
+// variableSource resolves a repository's GitHub Actions repository and
+// organization variables into the compiler's pre-environment scopes.
+type variableSource interface {
+	ResolveVariables(ctx context.Context, owner, repository string) (compiler.VariableSources, error)
+}
+
+// variableSourceFromAgent builds the variable source over the job-scoped Agent
+// API endpoint github-actions/variables. The Buildkite backend performs the
+// GitHub reads with its own credentials, restricted to the pipeline's
+// configured repository; no GitHub token reaches the importer. It returns nil
+// when the job's Agent connection is not configured, in which case vars keep
+// their empty pre-environment scopes.
+func variableSourceFromAgent(clientVersion string) variableSource {
+	resolver, err := gharuntime.NewAgentVariableResolver(gharuntime.AgentVariableResolverConfig{
+		Endpoint:      os.Getenv("BUILDKITE_AGENT_ENDPOINT"),
+		JobID:         os.Getenv("BUILDKITE_JOB_ID"),
+		JobToken:      os.Getenv("BUILDKITE_AGENT_ACCESS_TOKEN"),
+		ClientVersion: clientVersion,
+	})
+	if err != nil {
+		return nil
+	}
+	return &agentVariableSource{resolver: resolver, resolved: map[string]agentVariableResolution{}}
+}
+
+// agentVariableSource resolves variables through the Agent API and memoizes
+// every result, including failures, per repository, so one upload of many
+// workflows consumes one request against the backend's per-job budget and
+// retried compiles fail consistently without new requests. A 404 means the
+// backend offers no repository or organization scope; it memoizes as empty
+// scopes so names no scope defines keep evaluating as empty strings.
+type agentVariableSource struct {
+	resolver *gharuntime.AgentVariableResolver
+
+	mu       sync.Mutex
+	resolved map[string]agentVariableResolution
+}
+
+type agentVariableResolution struct {
+	vars compiler.VariableSources
+	err  error
+}
+
+func (a *agentVariableSource) ResolveVariables(ctx context.Context, owner, repository string) (compiler.VariableSources, error) {
+	repo := owner + "/" + repository
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if result, ok := a.resolved[repo]; ok {
+		return result.vars, result.err
+	}
+	snapshot, err := a.resolver.ResolveVariables(ctx, repo)
+	result := agentVariableResolution{}
+	switch {
+	case errors.Is(err, gharuntime.ErrVariablesUnavailable):
+	case err != nil:
+		result.err = fmt.Errorf("variables: %w", err)
+	default:
+		result.vars = compiler.VariableSources{Repository: snapshot.Repository, Organization: snapshot.Organization}
+	}
+	a.resolved[repo] = result
+	return result.vars, result.err
+}
+
+// resolveVariableSources fills the compiler's pre-environment vars scopes for
+// the event repository when the workflows about to compile reference vars.
+// Without a reference there is nothing to resolve, so no request is made and
+// the scopes stay empty. Without a source, such as compile outside a
+// Buildkite job, the scopes also stay empty. Only GitHub.com repositories
+// have GitHub variables, so events from other providers never make a request.
+func resolveVariableSources(ctx context.Context, source variableSource, event compiler.Event, referencesVars bool) (compiler.VariableSources, error) {
+	if source == nil || !referencesVars || event.Provider != "github" {
+		return compiler.VariableSources{}, nil
+	}
+	return source.ResolveVariables(ctx, event.Repository.Owner, event.Repository.Name)
+}
+
+// resolveActionVariables handles a vars reference that only compilation can
+// discover: an input default in a resolved action's metadata. When the
+// workflow itself references no vars, the scopes were never requested, so a
+// bundle whose action programs read vars requests them now, still at most
+// once per upload, and reports whether the caller must compile again so the
+// plans carry the scopes. The workflow references no vars, so compiling again
+// changes nothing but those scopes.
+func resolveActionVariables(ctx context.Context, source variableSource, event compiler.Event, workflowReferencesVars bool, bundle compiler.Bundle) (vars compiler.VariableSources, again bool, err error) {
+	if workflowReferencesVars || source == nil || !compiler.ActionsReferenceVars(bundle) {
+		return compiler.VariableSources{}, false, nil
+	}
+	vars, err = resolveVariableSources(ctx, source, event, true)
+	if err != nil {
+		return compiler.VariableSources{}, false, err
+	}
+	return vars, len(vars.Repository) != 0 || len(vars.Organization) != 0, nil
+}
+
+// resolveUploadVariables resolves the vars scopes once for every applicable
+// workflow that references vars, before validation so compile-time fields
+// see them. A resolution failure fails each workflow that references vars
+// with the backend's error, leaving other workflows to upload; the value
+// scopes never join a diagnostic.
+func resolveUploadVariables(ctx context.Context, source variableSource, workflows []workflowInput, processingReports []compatibility.ProcessingReport, event compiler.Event) compiler.VariableSources {
+	referencesVars := false
+	for i, input := range workflows {
+		if input.Applicable && !processingReportHasErrors(processingReports[i]) && input.ReferencesVars {
+			referencesVars = true
+		}
+	}
+	vars, err := resolveVariableSources(ctx, source, event, referencesVars)
+	if err == nil {
+		return vars
+	}
+	for i, input := range workflows {
+		if !input.Applicable || processingReportHasErrors(processingReports[i]) || !input.ReferencesVars {
+			continue
+		}
+		processingReports[i] = triggerProcessingReport(input.Path, input.Source)
+		processingReports[i].AddEnvironmentFailure(err.Error())
+		processingReports[i].Result = "indeterminate"
+	}
+	return compiler.VariableSources{}
+}

--- a/internal/cli/variables_test.go
+++ b/internal/cli/variables_test.go
@@ -1,0 +1,548 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/buildkite-gha/internal/compiler"
+	"github.com/buildkite/buildkite-gha/internal/plan"
+)
+
+// Distinctive repository and organization variable values prove where they
+// appear: in job plans only, never in the pipeline, output, or diagnostics.
+const (
+	stubRepositoryRegion     = "eu-west-1-repository-stub-value"
+	stubOrganizationRegion   = "us-east-1-organization-stub-value"
+	stubOrganizationRegistry = "ghcr.io/acme-organization-stub-value"
+)
+
+var (
+	stubRepositoryVariables   = map[string]string{"AWS_REGION": stubRepositoryRegion, "REGIONS": `["eu","us"]`, "TARGET": "prod"}
+	stubOrganizationVariables = map[string]string{"AWS_REGION": stubOrganizationRegion, "REGISTRY": stubOrganizationRegistry}
+)
+
+// variablesUploadWorkflow reads vars in compile-time positions, the workflow
+// concurrency group and a matrix, and in a runtime step. It declares no
+// environment.
+const variablesUploadWorkflow = `on: push
+concurrency: deploy-${{ vars.TARGET }}
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        region: ${{ fromJSON(vars.REGIONS) }}
+    steps:
+      - run: echo "${{ vars.AWS_REGION }}" "${{ vars.REGISTRY }}" "${{ matrix.region }}"
+`
+
+// agentVariablesHandler answers github-actions/variables with the stub
+// scopes after checking the job-scoped request, or with status and
+// retryAfter when status is not 200. It counts requests.
+func agentVariablesHandler(t *testing.T, status int, retryAfter string) (http.HandlerFunc, *int) {
+	t.Helper()
+	requests := new(int)
+	return func(w http.ResponseWriter, r *http.Request) {
+		*requests++
+		if r.Method != http.MethodPost || r.URL.Path != "/jobs/11111111-1111-4111-8111-111111111111/github-actions/variables" {
+			t.Errorf("variables request = %s %s", r.Method, r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Token job-secret" {
+			t.Errorf("variables authorization = %q", r.Header.Get("Authorization"))
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode variables request: %v", err)
+		}
+		if !maps.Equal(body, map[string]any{"repo_url": "https://github.com/buildkite/buildkite-gha"}) {
+			t.Errorf("variables request body = %#v", body)
+		}
+		if status != http.StatusOK {
+			if retryAfter != "" {
+				w.Header().Set("Retry-After", retryAfter)
+			}
+			w.WriteHeader(status)
+			return
+		}
+		scope := func(values map[string]string) []map[string]string {
+			entries := make([]map[string]string, 0, len(values))
+			for _, name := range []string{"AWS_REGION", "REGIONS", "REGISTRY", "TARGET"} {
+				if value, ok := values[name]; ok {
+					entries = append(entries, map[string]string{"name": name, "value": value})
+				}
+			}
+			return entries
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"repository_variables":   scope(stubRepositoryVariables),
+			"organization_variables": scope(stubOrganizationVariables),
+		})
+	}, requests
+}
+
+// pushEventPath is the smoke push event, absolute because upload tests enter
+// a temporary checkout.
+func pushEventPath(t *testing.T) string {
+	t.Helper()
+	path, err := filepath.Abs(filepath.Join("..", "..", "testdata", "smoke", "events", "push.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// writeUploadWorkflows writes the workflows into a git checkout, enters it,
+// and returns their repository-relative paths in a stable order.
+func writeUploadWorkflows(t *testing.T, sources map[string]string) []string {
+	t.Helper()
+	repository := writeUploadWorkflowRepository(t, sources)
+	t.Chdir(repository)
+	paths := make([]string, 0, len(sources))
+	for _, name := range []string{"build.yml", "deploy.yml", "plain.yml"} {
+		if _, ok := sources[name]; ok {
+			paths = append(paths, filepath.Join(".github", "workflows", name))
+		}
+	}
+	return paths
+}
+
+func uploadedPlans(t *testing.T, runner *cliCaptureRunner) map[string][]plan.Job {
+	t.Helper()
+	plans := map[string][]plan.Job{}
+	for path, content := range runner.uploaded {
+		if !strings.Contains(path, "/plans/") {
+			continue
+		}
+		job, err := plan.Decode(content)
+		if err != nil {
+			t.Fatalf("decode uploaded plan %s: %v", path, err)
+		}
+		plans[job.Workflow.LogicalJobID] = append(plans[job.Workflow.LogicalJobID], job)
+	}
+	return plans
+}
+
+func assertNoVariableValueLeak(t *testing.T, runner *cliCaptureRunner, stdout, stderr string) {
+	t.Helper()
+	pipeline := string(runner.commands[len(runner.commands)-1].stdin)
+	for _, value := range []string{stubRepositoryRegion, stubOrganizationRegion, stubOrganizationRegistry, stubEnvironmentRegion} {
+		if strings.Contains(pipeline, value) || strings.Contains(stdout, value) || strings.Contains(stderr, value) {
+			t.Fatalf("variable value %q leaked outside job plans:\n%s\n%s\n%s", value, pipeline, stdout, stderr)
+		}
+	}
+	for path, content := range runner.uploaded {
+		// Plans carry the values by design; the distribution is this test
+		// binary, which contains the literals.
+		if strings.Contains(path, "/plans/") || strings.Contains(path, "/distributions/") {
+			continue
+		}
+		for _, value := range []string{stubRepositoryRegion, stubOrganizationRegion, stubOrganizationRegistry, stubEnvironmentRegion} {
+			if bytes.Contains(content, []byte(value)) {
+				t.Fatalf("variable value %q leaked into artifact %s", value, path)
+			}
+		}
+	}
+}
+
+// TestRunUploadResolvesVariablesOncePerUpload exercises the hosted upload
+// path with repository and organization variables: two workflows reading
+// vars produce exactly one job-scoped Agent API request, compile-time fields
+// (the concurrency group and a matrix) resolve from the scopes, every job
+// plan carries both scopes, and the runtime vars context prefers environment
+// over repository over organization values. A workflow without an
+// environment works.
+func TestRunUploadResolvesVariablesOncePerUpload(t *testing.T) {
+	requireImporterHost(t)
+	variables, variableRequests := agentVariablesHandler(t, http.StatusOK, "")
+	agent, environmentRequests := agentStub(t, "job-secret", http.StatusOK, variables)
+	setAgentResolutionEnvironment(t, agent.URL)
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_STEP_KEY", "variables-agent-resolve-importer")
+	eventPath := pushEventPath(t)
+	workflows := writeUploadWorkflows(t, map[string]string{"build.yml": variablesUploadWorkflow, "deploy.yml": environmentUploadWorkflow})
+
+	runner := &cliCaptureRunner{webhookErr: errors.New("metadata must not be read with --event-path")}
+	var stdout, stderr bytes.Buffer
+	if code := run(append([]string{"upload", "--event-path", eventPath}, workflows...), &stdout, &stderr, "dev", runner); code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	if *variableRequests != 1 || *environmentRequests != 1 {
+		t.Fatalf("agent requests = %d variables, %d environments; want 1 and 1", *variableRequests, *environmentRequests)
+	}
+	plans := uploadedPlans(t, runner)
+	if len(plans["build"]) != 2 || len(plans["deploy"]) != 1 || len(plans) != 2 {
+		t.Fatalf("uploaded plans by job = %v", plans)
+	}
+	regions := map[any]bool{}
+	for _, jobs := range plans {
+		for _, job := range jobs {
+			if !maps.Equal(job.RepositoryVars, stubRepositoryVariables) || !maps.Equal(job.OrganizationVars, stubOrganizationVariables) {
+				t.Fatalf("plan %q scopes = repository %#v, organization %#v", job.Workflow.LogicalJobID, job.RepositoryVars, job.OrganizationVars)
+			}
+			regions[job.Matrix["region"]] = true
+		}
+	}
+	if !regions["eu"] || !regions["us"] {
+		t.Fatalf("matrix regions = %v, want the fromJSON(vars.REGIONS) values", regions)
+	}
+	// environment > repository > organization.
+	if got := plans["deploy"][0].Vars(); got["AWS_REGION"] != stubEnvironmentRegion || got["REGISTRY"] != stubOrganizationRegistry || got["TARGET"] != "prod" {
+		t.Fatalf("deploy vars = %#v", got)
+	}
+	if got := plans["build"][0].Vars(); got["AWS_REGION"] != stubRepositoryRegion || got["REGISTRY"] != stubOrganizationRegistry || len(plans["build"][0].EnvironmentVars) != 0 {
+		t.Fatalf("build vars = %#v", got)
+	}
+	assertNoVariableValueLeak(t, runner, stdout.String(), stderr.String())
+}
+
+// TestRunUploadSkipsVariableResolutionWithoutReferences proves a workflow
+// that never reads vars costs no request against the per-job budget.
+func TestRunUploadSkipsVariableResolutionWithoutReferences(t *testing.T) {
+	requireImporterHost(t)
+	agent, _ := agentStub(t, "job-secret", http.StatusOK, func(http.ResponseWriter, *http.Request) {
+		t.Error("variables were requested for a workflow without vars references")
+	})
+	setAgentResolutionEnvironment(t, agent.URL)
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_STEP_KEY", "variables-agent-skip-importer")
+	eventPath := pushEventPath(t)
+	workflows := writeUploadWorkflows(t, map[string]string{"plain.yml": "on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo \"${{ github.sha }}\"\n"})
+
+	runner := &cliCaptureRunner{webhookErr: errors.New("metadata must not be read with --event-path")}
+	var stdout, stderr bytes.Buffer
+	if code := run(append([]string{"upload", "--event-path", eventPath}, workflows...), &stdout, &stderr, "dev", runner); code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	plans := uploadedPlans(t, runner)
+	if len(plans["test"]) != 1 || plans["test"][0].RepositoryVars != nil || plans["test"][0].OrganizationVars != nil {
+		t.Fatalf("uploaded plans = %v", plans)
+	}
+}
+
+// TestRunUploadTreatsAbsentVariableScopesAsEmpty proves a backend without the
+// variables endpoint (404) leaves the scopes empty: runtime references keep
+// evaluating to empty strings and the upload succeeds. Compile-time fields
+// that need a value still fail as they did before.
+func TestRunUploadTreatsAbsentVariableScopesAsEmpty(t *testing.T) {
+	requireImporterHost(t)
+	variables, variableRequests := agentVariablesHandler(t, http.StatusNotFound, "")
+	agent, _ := agentStub(t, "job-secret", http.StatusOK, variables)
+	setAgentResolutionEnvironment(t, agent.URL)
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_STEP_KEY", "variables-agent-absent-importer")
+	eventPath := pushEventPath(t)
+	workflows := writeUploadWorkflows(t, map[string]string{"plain.yml": "on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo \"${{ vars.AWS_REGION }}\"\n"})
+
+	runner := &cliCaptureRunner{webhookErr: errors.New("metadata must not be read with --event-path")}
+	var stdout, stderr bytes.Buffer
+	if code := run(append([]string{"upload", "--event-path", eventPath}, workflows...), &stdout, &stderr, "dev", runner); code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	if *variableRequests != 1 {
+		t.Fatalf("variables requests = %d, want 1", *variableRequests)
+	}
+	plans := uploadedPlans(t, runner)
+	if len(plans["test"]) != 1 || len(plans["test"][0].Vars()) != 0 {
+		t.Fatalf("uploaded plans = %v", plans)
+	}
+}
+
+// TestRunUploadSurfacesVariableResolutionRateLimit proves a 429 fails every
+// workflow that reads vars with the backend's Retry-After delay, after one
+// request, while a workflow without vars references still uploads.
+func TestRunUploadSurfacesVariableResolutionRateLimit(t *testing.T) {
+	requireImporterHost(t)
+	variables, variableRequests := agentVariablesHandler(t, http.StatusTooManyRequests, "3600")
+	agent, _ := agentStub(t, "job-secret", http.StatusOK, variables)
+	setAgentResolutionEnvironment(t, agent.URL)
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_STEP_KEY", "variables-agent-limited-importer")
+	eventPath := pushEventPath(t)
+	workflows := writeUploadWorkflows(t, map[string]string{
+		"build.yml":  variablesUploadWorkflow,
+		"deploy.yml": environmentUploadWorkflow,
+		"plain.yml":  "on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo plain\n",
+	})
+
+	runner := &cliCaptureRunner{webhookErr: errors.New("metadata must not be read with --event-path")}
+	var stdout, stderr bytes.Buffer
+	if code := run(append([]string{"upload", "--event-path", eventPath}, workflows...), &stdout, &stderr, "dev", runner); code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	if *variableRequests != 1 {
+		t.Fatalf("variables requests = %d, want 1 for two workflows reading vars", *variableRequests)
+	}
+	plans := uploadedPlans(t, runner)
+	if len(plans) != 1 || len(plans["test"]) != 1 {
+		t.Fatalf("uploaded plans by job = %v, want only the workflow without vars references", plans)
+	}
+	const want = "[E_ENVIRONMENT] variables: variable resolution requests are rate limited; retry after 3600 seconds"
+	failures := 0
+	for path, content := range runner.uploaded {
+		if strings.HasPrefix(path, ".buildkite-gha/failures/messages/") && strings.Contains(string(content), want) {
+			failures++
+		}
+	}
+	// Both failing workflows carry the same message, so they share one
+	// content-addressed failure artifact.
+	if failures != 1 {
+		t.Fatalf("failure message artifacts with %q = %d, want 1:\n%s", want, failures, stderr.String())
+	}
+	pipeline := string(runner.commands[len(runner.commands)-1].stdin)
+	for _, want := range []string{`label: ":github: workflow · .github/workflows/build.yml"`, `label: ":github: workflow · .github/workflows/deploy.yml"`, `title: "Workflow could not be run"`} {
+		if !strings.Contains(pipeline, want) {
+			t.Fatalf("pipeline missing failed workflow step %s:\n%s", want, pipeline)
+		}
+	}
+}
+
+// TestRunCompileResolvesVariablesThroughAgent exercises compile inside a
+// Buildkite job: vars resolve through the job-scoped Agent API so
+// compile-time fields succeed, a rejection fails the compile, and compile
+// outside a job makes no request and leaves compile-time vars unresolved.
+func TestRunCompileResolvesVariablesThroughAgent(t *testing.T) {
+	variables, variableRequests := agentVariablesHandler(t, http.StatusOK, "")
+	agent, _ := agentStub(t, "job-secret", http.StatusOK, variables)
+	setAgentResolutionEnvironment(t, agent.URL)
+	eventPath := pushEventPath(t)
+	workflow := writeUploadWorkflows(t, map[string]string{"build.yml": variablesUploadWorkflow})[0]
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"compile", "--event-path", eventPath, workflow}, &stdout, &stderr, "dev"); code != 0 {
+		t.Fatalf("Run() code = %d, stderr = %q", code, stderr.String())
+	}
+	if *variableRequests != 1 {
+		t.Fatalf("variables requests = %d, want 1", *variableRequests)
+	}
+	pipeline := stdout.String()
+	for _, want := range []string{"build (region=eu)", "build (region=us)"} {
+		if !strings.Contains(pipeline, want) {
+			t.Fatalf("pipeline missing %q:\n%s", want, pipeline)
+		}
+	}
+	for _, value := range []string{stubRepositoryRegion, stubOrganizationRegion, stubOrganizationRegistry} {
+		if strings.Contains(pipeline, value) || strings.Contains(stderr.String(), value) {
+			t.Fatalf("variable value %q leaked into compile output:\n%s\n%s", value, pipeline, stderr.String())
+		}
+	}
+
+	rejecting, _ := agentVariablesHandler(t, http.StatusBadRequest, "")
+	agent, _ = agentStub(t, "job-secret", http.StatusOK, rejecting)
+	setAgentResolutionEnvironment(t, agent.URL)
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"compile", "--event-path", eventPath, workflow}, &stdout, &stderr, "dev"); code == 0 {
+		t.Fatalf("Run() with rejected resolution succeeded:\n%s", stdout.String())
+	} else if !strings.Contains(stderr.String(), "[E_ENVIRONMENT] variables: the variable resolution request was rejected") {
+		t.Fatalf("stderr = %q, want actionable backend rejection", stderr.String())
+	}
+
+	for _, name := range []string{"BUILDKITE_AGENT_ENDPOINT", "BUILDKITE_JOB_ID", "BUILDKITE_AGENT_ACCESS_TOKEN"} {
+		t.Setenv(name, "")
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"compile", "--event-path", eventPath, workflow}, &stdout, &stderr, "dev"); code == 0 {
+		t.Fatalf("Run() outside a job resolved compile-time vars:\n%s", stdout.String())
+	} else if !strings.Contains(stderr.String(), `compile-time expression references unavailable value "vars.target"`) {
+		t.Fatalf("stderr = %q, want unresolved compile-time vars", stderr.String())
+	}
+}
+
+// actionDefaultWorkflow references no vars itself; its only vars reference is
+// the input default of the local action it uses.
+const actionDefaultWorkflow = "on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: ./.github/actions/region\n"
+
+// regionInputDefaultAction is a JavaScript action whose input default reads
+// vars; regionCompositeConditionAction is a composite action whose only vars
+// reference is a bare step condition, which GitHub evaluates as an expression
+// without ${{ }}.
+const (
+	regionInputDefaultAction       = "name: region\ninputs:\n  region:\n    default: ${{ vars.AWS_REGION }}\nruns:\n  using: node24\n  main: main.js\n"
+	regionCompositeConditionAction = "name: region\nruns:\n  using: composite\n  steps:\n    - if: vars.AWS_REGION == 'eu'\n      run: echo eu\n      shell: bash\n"
+)
+
+// writeRegionAction writes a local action with the given metadata into the
+// current checkout.
+func writeRegionAction(t *testing.T, action string) {
+	t.Helper()
+	root := filepath.Join(".github", "actions", "region")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "action.yml"), []byte(action), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "main.js"), []byte("console.log('must not run')\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestRunUploadResolvesVariablesForActionInputDefaults proves a vars
+// reference that lives only in a resolved action, as an input default or a
+// bare composite step condition, still fills the job plan scopes: compilation discovers it, one request follows, and
+// the plans compiled again carry the scopes. A backend failure on that
+// request fails the workflow the same way as a workflow-level reference.
+func TestRunUploadResolvesVariablesForActionInputDefaults(t *testing.T) {
+	requireImporterHost(t)
+	for _, tc := range []struct {
+		name   string
+		action string
+		status int
+	}{
+		{"input default resolved", regionInputDefaultAction, http.StatusOK},
+		{"composite condition resolved", regionCompositeConditionAction, http.StatusOK},
+		{"rate limited", regionInputDefaultAction, http.StatusTooManyRequests},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			variables, variableRequests := agentVariablesHandler(t, tc.status, "60")
+			agent, _ := agentStub(t, "job-secret", http.StatusOK, variables)
+			setAgentResolutionEnvironment(t, agent.URL)
+			t.Setenv("BUILDKITE", "true")
+			t.Setenv("BUILDKITE_STEP_KEY", "variables-agent-action-importer")
+			eventPath := pushEventPath(t)
+			workflows := writeUploadWorkflows(t, map[string]string{"plain.yml": actionDefaultWorkflow})
+			writeRegionAction(t, tc.action)
+
+			runner := &cliCaptureRunner{webhookErr: errors.New("metadata must not be read with --event-path")}
+			var stdout, stderr bytes.Buffer
+			if code := run(append([]string{"upload", "--event-path", eventPath}, workflows...), &stdout, &stderr, "dev", runner); code != 0 {
+				t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+			}
+			if *variableRequests != 1 {
+				t.Fatalf("variables requests = %d, want 1", *variableRequests)
+			}
+			plans := uploadedPlans(t, runner)
+			if tc.status != http.StatusOK {
+				const want = "[E_ENVIRONMENT] variables: variable resolution requests are rate limited; retry after 60 seconds"
+				failures := 0
+				for path, content := range runner.uploaded {
+					if strings.HasPrefix(path, ".buildkite-gha/failures/messages/") && strings.Contains(string(content), want) {
+						failures++
+					}
+				}
+				if len(plans) != 0 || failures != 1 {
+					t.Fatalf("plans = %v, failure artifacts with %q = %d; want no plans and one failure", plans, want, failures)
+				}
+				return
+			}
+			if len(plans["test"]) != 1 || !maps.Equal(plans["test"][0].RepositoryVars, stubRepositoryVariables) || !maps.Equal(plans["test"][0].OrganizationVars, stubOrganizationVariables) {
+				t.Fatalf("uploaded plans = %#v, want the resolved scopes", plans)
+			}
+			assertNoVariableValueLeak(t, runner, stdout.String(), stderr.String())
+		})
+	}
+}
+
+// TestRunCompileIRJSONCarriesVariableScopes pins the documented exposure of
+// compile --format ir-json: the IR is the compiler's full input, so it prints
+// both resolved scopes to stdout.
+func TestRunCompileIRJSONCarriesVariableScopes(t *testing.T) {
+	variables, _ := agentVariablesHandler(t, http.StatusOK, "")
+	agent, _ := agentStub(t, "job-secret", http.StatusOK, variables)
+	setAgentResolutionEnvironment(t, agent.URL)
+	eventPath := pushEventPath(t)
+	workflow := writeUploadWorkflows(t, map[string]string{"build.yml": variablesUploadWorkflow})[0]
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"compile", "--format", "ir-json", "--event-path", eventPath, workflow}, &stdout, &stderr, "dev"); code != 0 {
+		t.Fatalf("Run() code = %d, stderr = %q", code, stderr.String())
+	}
+	var ir compiler.IR
+	if err := json.Unmarshal(stdout.Bytes(), &ir); err != nil {
+		t.Fatalf("decode IR: %v", err)
+	}
+	if !maps.Equal(ir.RepositoryVars, stubRepositoryVariables) || !maps.Equal(ir.OrganizationVars, stubOrganizationVariables) {
+		t.Fatalf("IR scopes = %#v / %#v, want the resolved scopes", ir.RepositoryVars, ir.OrganizationVars)
+	}
+}
+
+// TestRunCompileResolvesVariablesForActionInputDefaults proves compile inside
+// a Buildkite job also discovers an action-only vars reference and compiles
+// the plans with the scopes.
+func TestRunCompileResolvesVariablesForActionInputDefaults(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status int
+	}{
+		{"resolved", http.StatusOK},
+		{"rate limited", http.StatusTooManyRequests},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			variables, variableRequests := agentVariablesHandler(t, tc.status, "60")
+			agent, _ := agentStub(t, "job-secret", http.StatusOK, variables)
+			setAgentResolutionEnvironment(t, agent.URL)
+			eventPath := pushEventPath(t)
+			workflow := writeUploadWorkflows(t, map[string]string{"plain.yml": actionDefaultWorkflow})[0]
+			writeRegionAction(t, regionInputDefaultAction)
+
+			var stdout, stderr bytes.Buffer
+			code := Run([]string{"compile", "--event-path", eventPath, workflow}, &stdout, &stderr, "dev")
+			if *variableRequests != 1 {
+				t.Fatalf("variables requests = %d, want 1", *variableRequests)
+			}
+			if tc.status != http.StatusOK {
+				const want = "buildkite-gha: compile: variables: variable resolution requests are rate limited; retry after 60 seconds\n"
+				if code != 1 || stdout.Len() != 0 || !strings.Contains(stderr.String(), want) {
+					t.Fatalf("Run() code = %d, stdout = %q, stderr = %q; want 1, no pipeline, and %q", code, stdout.String(), stderr.String(), want)
+				}
+				return
+			}
+			if code != 0 {
+				t.Fatalf("Run() code = %d, stderr = %q", code, stderr.String())
+			}
+			if !strings.Contains(stdout.String(), "gha-importer") || strings.Contains(stdout.String(), stubRepositoryRegion) {
+				t.Fatalf("pipeline = %q", stdout.String())
+			}
+		})
+	}
+}
+
+// TestResolveVariableSourcesSkipsOtherProviders proves events from providers
+// other than GitHub.com never reach the GitHub variables endpoint: their
+// repositories have no GitHub variables, so the scopes stay empty.
+func TestResolveVariableSourcesSkipsOtherProviders(t *testing.T) {
+	source := &agentVariableSource{resolved: map[string]agentVariableResolution{}}
+	event := compiler.Event{Provider: "cursor-origin", Repository: compiler.Repository{Owner: "acme", Name: "app"}}
+	vars, err := resolveVariableSources(t.Context(), source, event, true)
+	if err != nil || len(vars.Repository) != 0 || len(vars.Organization) != 0 || len(source.resolved) != 0 {
+		t.Fatalf("resolveVariableSources() = %#v, %v; resolved = %v", vars, err, source.resolved)
+	}
+}
+
+// TestAgentVariableSourceMemoizesFailures proves one source answers repeated
+// compiles of the same repository from one request, including after a
+// failure, so retries never spend the per-job budget.
+func TestAgentVariableSourceMemoizesFailures(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+	setAgentResolutionEnvironment(t, server.URL)
+	source := variableSourceFromAgent("dev")
+	if source == nil {
+		t.Fatal("variableSourceFromAgent() = nil with a configured Agent connection")
+	}
+	for range 3 {
+		if _, err := source.ResolveVariables(t.Context(), "buildkite", "buildkite-gha"); err == nil || !strings.Contains(err.Error(), "variables: the variable resolution service is temporarily unavailable") {
+			t.Fatalf("ResolveVariables() error = %v", err)
+		}
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d, want 1", requests)
+	}
+	t.Setenv("BUILDKITE_AGENT_ACCESS_TOKEN", "")
+	if variableSourceFromAgent("dev") != nil {
+		t.Fatal("variableSourceFromAgent() != nil without a job token")
+	}
+}

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -161,6 +161,11 @@ type Report struct {
 	Warnings              []Warning
 	Jobs                  []JobInstance
 	RuntimeMatrixBoundary bool
+	// ReferencesVars reports whether any expression in the workflow or a
+	// reusable workflow it calls reads the vars context. Callers resolve
+	// repository and organization variables before compiling only when it is
+	// set, so workflows without vars references cost no resolution request.
+	ReferencesVars        bool
 	RuntimeMatrices       []RuntimeMatrixDescriptor
 	ParsedJobs            []ParsedJob
 	NotEvaluatedJobs      map[string]bool
@@ -761,20 +766,22 @@ func supported(path string, job workflow.Job) error {
 	return nil
 }
 
+// resolveCompileTimeConditions reduces event values in the job and step
+// conditions. Conditions keep vars residual: the runtime evaluates each
+// position with its own scopes from the plan (repository over organization
+// for the job condition, the environment laid over them for steps), and a
+// condition a variable makes false must not prune token or secret authority,
+// which planning computes from the residual condition.
 func resolveCompileTimeConditions(job workflow.Job, context expression.CompileContext, matrix map[string]any) workflow.Job {
 	context.Matrix = matrix
+	context.Vars = nil
 	if resolved, ok := resolveCompileTimeCondition(job.If, expression.ProfileCompileJobCondition, context); ok {
 		job.If = resolved
 	}
-	// Step conditions run after the job's environment applies, so their vars
-	// context is not known here. Keep vars residual so the runtime evaluates
-	// them with environment variables laid over the pre-environment scopes.
-	stepContext := context
-	stepContext.Vars = nil
 	job.Steps = append([]workflow.Step(nil), job.Steps...)
 	for i := range job.Steps {
 		step := &job.Steps[i]
-		if resolved, ok := resolveCompileTimeCondition(step.If, expression.ProfileCompileStepCondition, stepContext); ok {
+		if resolved, ok := resolveCompileTimeCondition(step.If, expression.ProfileCompileStepCondition, context); ok {
 			step.If = resolved
 		}
 	}

--- a/internal/compiler/config.go
+++ b/internal/compiler/config.go
@@ -75,9 +75,12 @@ const (
 
 // VariableSources are the GitHub Actions configuration variables known before
 // any job's environment applies: organization variables, then repository
-// variables, which override them. Environment variables come from
-// Options.EnvironmentSource per job. No caller supplies these sources yet, so
-// the vars context of compile-time fields and jobs.<id>.if is empty.
+// variables, which override them. They form the vars context of compile-time
+// fields and jobs.<id>.if, and every job plan carries them as its
+// organization_vars and repository_vars scopes. Environment variables come
+// from Options.EnvironmentSource per job. Inside a Buildkite job, upload and
+// compile fill these scopes from the job-scoped Agent API; an empty source
+// leaves undefined names evaluating as empty strings.
 type VariableSources struct {
 	Organization map[string]string
 	Repository   map[string]string

--- a/internal/compiler/job_graph_expansion.go
+++ b/internal/compiler/job_graph_expansion.go
@@ -16,6 +16,7 @@ type jobGraphExpansionResult struct {
 	instances             []JobInstance
 	candidates            []JobInstance
 	runtimeMatrixBoundary bool
+	referencesVars        bool
 	runtimeMatrices       []RuntimeMatrixDescriptor
 	jobs                  []ParsedJob
 	notEvaluatedJobs      map[string]bool
@@ -69,7 +70,7 @@ func processingJobs(path string, parsed *workflow.Workflow, resolved []sourcedJo
 func jobGraphExpansionReport(expanded jobGraphExpansionResult, warnings []Warning) Report {
 	return Report{
 		LogicalJobs: len(expanded.jobs), Instances: len(expanded.candidates),
-		Jobs: expanded.candidates, RuntimeMatrixBoundary: expanded.runtimeMatrixBoundary,
+		Jobs: expanded.candidates, RuntimeMatrixBoundary: expanded.runtimeMatrixBoundary, ReferencesVars: expanded.referencesVars,
 		RuntimeMatrices: expanded.runtimeMatrices, ParsedJobs: expanded.jobs, Warnings: append(warnings, expanded.warnings...),
 		NotEvaluatedJobs: expanded.notEvaluatedJobs, NotEvaluatedInstances: expanded.notEvaluatedInstances,
 	}
@@ -78,18 +79,18 @@ func jobGraphExpansionReport(expanded jobGraphExpansionResult, warnings []Warnin
 // expandJobGraph resolves reusable workflow calls, then turns the parsed
 // logical job graph into deterministic JobInstance values and report data.
 func expandJobGraph(ctx context.Context, path string, source []byte, parsed *workflow.Workflow, context expression.CompileContext, options Options) (jobGraphExpansionResult, error) {
-	resolved, warnings, runtimeMatrixBoundary, err := resolveReusableWorkflows(ctx, path, source, parsed, context, options.RepositorySource)
+	resolved, warnings, scan, err := resolveReusableWorkflows(ctx, path, source, parsed, context, options.RepositorySource)
 	if err != nil {
 		notEvaluatedJobs := make(map[string]bool, len(parsed.Jobs))
 		for _, job := range parsed.Jobs {
 			notEvaluatedJobs[job.ID] = true
 		}
-		return jobGraphExpansionResult{jobs: parsedJobs(path, parsed), notEvaluatedJobs: notEvaluatedJobs, runtimeMatrixBoundary: runtimeMatrixBoundary, warnings: warnings}, processingFinding(StageGraph, CodeGraphInvalid, "compatibility", err)
+		return jobGraphExpansionResult{jobs: parsedJobs(path, parsed), notEvaluatedJobs: notEvaluatedJobs, runtimeMatrixBoundary: scan.runtimeMatrixBoundary, referencesVars: scan.referencesVars, warnings: warnings}, processingFinding(StageGraph, CodeGraphInvalid, "compatibility", err)
 	}
 	expansion := jobGraphExpansion{
 		path: path, context: context, options: options,
 		result: jobGraphExpansionResult{
-			jobs: processingJobs(path, parsed, resolved), runtimeMatrixBoundary: runtimeMatrixBoundary, warnings: warnings,
+			jobs: processingJobs(path, parsed, resolved), runtimeMatrixBoundary: scan.runtimeMatrixBoundary, referencesVars: scan.referencesVars, warnings: warnings,
 			notEvaluatedJobs: make(map[string]bool), notEvaluatedInstances: make(map[string]bool),
 		},
 		acceptedIndex:  make(map[string]int, len(resolved)),
@@ -232,13 +233,15 @@ func (e *jobGraphExpansion) expandJobInstances(id string) {
 		instanceContext := jobContext
 		instanceContext.Matrix = matrix
 		instanceContext.Strategy = strategy
-		compileConditionErr := supportedCompileTimeConditions(jobPath, job, jobContext)
+		// Conditions keep vars residual; see resolveCompileTimeConditions.
+		conditionContext := jobContext
+		conditionContext.Vars = nil
+		compileConditionErr := supportedCompileTimeConditions(jobPath, job, conditionContext)
 		if sourced.blockerDetailUnsafe {
 			compileConditionErr = suppressBlockerDetail(compileConditionErr)
 		}
-		instanceJob := resolveCompileTimeConditions(job, jobContext, matrix)
+		instanceJob := resolveCompileTimeConditions(job, conditionContext, matrix)
 		conditionValidationJob := instanceJob
-		conditionContext := jobContext
 		conditionContext.Matrix = matrix
 		if value, err := evaluateCompileSite(instanceJob.If, expression.ProfileCompileJobCondition, expression.ResultBoolean, conditionContext); err == nil && !value.(bool) {
 			instanceJob.If = "false"

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -92,33 +92,41 @@ type reusableResolution struct {
 }
 
 type reusableResolver struct {
-	workspaceRoot         string
-	repositorySource      RepositorySource
-	stack                 []reusableSourceIdentity
-	materialized          []actionsource.Materialized
-	context               expression.CompileContext
-	rootPermissions       *workflow.Permissions
-	expanded              int
-	runtimeMatrixBoundary bool
-	warnings              []Warning
-	warnedCancellation    map[workflow.Position]bool
+	workspaceRoot      string
+	repositorySource   RepositorySource
+	stack              []reusableSourceIdentity
+	materialized       []actionsource.Materialized
+	context            expression.CompileContext
+	rootPermissions    *workflow.Permissions
+	expanded           int
+	scan               workflowScan
+	warnings           []Warning
+	warnedCancellation map[workflow.Position]bool
 }
 
-func resolveReusableWorkflows(ctx context.Context, path string, source []byte, parsed *workflow.Workflow, context expression.CompileContext, repositorySource RepositorySource) ([]sourcedJob, []Warning, bool, error) {
+// workflowScan is what static discovery learns about a workflow and every
+// reusable workflow it reaches, independent of the event: whether a runtime
+// matrix boundary exists and whether any expression reads the vars context.
+type workflowScan struct {
+	runtimeMatrixBoundary bool
+	referencesVars        bool
+}
+
+func resolveReusableWorkflows(ctx context.Context, path string, source []byte, parsed *workflow.Workflow, context expression.CompileContext, repositorySource RepositorySource) ([]sourcedJob, []Warning, workflowScan, error) {
 	digest := "sha256:" + sha256Sum(source)
-	runtimeMatrixBoundary := hasRuntimeMatrixBoundary(parsed)
+	scan := workflowScan{runtimeMatrixBoundary: hasRuntimeMatrixBoundary(parsed), referencesVars: workflowReferencesVars(parsed)}
 	if !hasReusableCall(parsed) {
 		sourcePath := path
 		root := ""
 		if isRepositoryWorkflowPath(path) {
 			repositoryRoot, canonicalPath, err := workflowRepository(path)
 			if err != nil {
-				return nil, nil, runtimeMatrixBoundary, err
+				return nil, nil, scan, err
 			}
 			root = repositoryRoot
 			sourcePath, err = repositoryWorkflowPath(repositoryRoot, canonicalPath)
 			if err != nil {
-				return nil, nil, runtimeMatrixBoundary, err
+				return nil, nil, scan, err
 			}
 		}
 		jobs := make([]sourcedJob, len(parsed.Jobs))
@@ -128,7 +136,7 @@ func resolveReusableWorkflows(ctx context.Context, path string, source []byte, p
 			originalJob := job
 			resolvedJob, err := applyStaticInputs(sourcePath, job, context.Inputs)
 			if err != nil {
-				return nil, nil, runtimeMatrixBoundary, err
+				return nil, nil, scan, err
 			}
 			job = resolvedJob
 			job.Permissions = effectivePermissions(job.Permissions, parsed.Permissions, nil, false)
@@ -141,18 +149,18 @@ func resolveReusableWorkflows(ctx context.Context, path string, source []byte, p
 			replacements[job.ID] = needBinding{members: []string{job.ID}}
 		}
 		if _, err := resolveWorkflowCallOutputs(sourcePath, parsed.CallOutputs, workflowJobs, replacements); err != nil {
-			return nil, nil, runtimeMatrixBoundary, err
+			return nil, nil, scan, err
 		}
-		return jobs, nil, runtimeMatrixBoundary, nil
+		return jobs, nil, scan, nil
 	}
 
 	rootSource, err := localReusableWorkflowSource(path)
 	if err != nil {
-		return nil, nil, runtimeMatrixBoundary, err
+		return nil, nil, scan, err
 	}
 	resolver := reusableResolver{
 		workspaceRoot: rootSource.repositoryRoot, repositorySource: newMemoizedActionSource(repositorySource), stack: []reusableSourceIdentity{rootSource.identity}, context: context,
-		rootPermissions: effectivePermissions(nil, parsed.Permissions, nil, false), runtimeMatrixBoundary: runtimeMatrixBoundary,
+		rootPermissions: effectivePermissions(nil, parsed.Permissions, nil, false), scan: scan,
 		warnedCancellation: make(map[workflow.Position]bool),
 	}
 	defer func() {
@@ -162,7 +170,7 @@ func resolveReusableWorkflows(ctx context.Context, path string, source []byte, p
 	}()
 	resolver.discoverRuntimeMatrixBoundaries(ctx, rootSource, parsed, 0, map[string]int{rootSource.identity.key(): 0})
 	resolution, err := resolver.resolve(ctx, rootSource, digest, parsed, "", "", reusableInputs{values: context.Inputs}, nil, nil, secretAuthority{unrestricted: true}, false, workflow.Position{}, nil, nil, 0)
-	return resolution.jobs, resolver.warnings, resolver.runtimeMatrixBoundary, err
+	return resolution.jobs, resolver.warnings, resolver.scan, err
 }
 
 func hasReusableCall(parsed *workflow.Workflow) bool {
@@ -175,9 +183,9 @@ func hasReusableCall(parsed *workflow.Workflow) bool {
 }
 
 func (resolver *reusableResolver) discoverRuntimeMatrixBoundaries(ctx context.Context, current reusableWorkflowSource, parsed *workflow.Workflow, depth int, scannedAtDepth map[string]int) {
-	resolver.runtimeMatrixBoundary = resolver.runtimeMatrixBoundary || hasRuntimeMatrixBoundary(parsed)
+	resolver.scanWorkflow(parsed)
 	if depth >= MaxReusableWorkflowDepth {
-		resolver.runtimeMatrixBoundary = resolver.runtimeMatrixBoundary || hasReusableCall(parsed)
+		resolver.scan.runtimeMatrixBoundary = resolver.scan.runtimeMatrixBoundary || hasReusableCall(parsed)
 		return
 	}
 	for _, job := range parsed.Jobs {
@@ -186,7 +194,7 @@ func (resolver *reusableResolver) discoverRuntimeMatrixBoundaries(ctx context.Co
 		}
 		calleeSource, source, err := resolver.loadReusableWorkflow(ctx, current, job.Reusable.Uses)
 		if err != nil {
-			resolver.runtimeMatrixBoundary = true
+			resolver.scan.runtimeMatrixBoundary = true
 			continue
 		}
 		calleeDepth := depth + 1
@@ -198,22 +206,28 @@ func (resolver *reusableResolver) discoverRuntimeMatrixBoundaries(ctx context.Co
 		if !scanned && len(scannedAtDepth) >= maxFlattenedJobs {
 			// An incomplete discovery cannot prove that no unvisited callee has a
 			// runtime matrix boundary. Reject before event metadata instead.
-			resolver.runtimeMatrixBoundary = true
+			resolver.scan.runtimeMatrixBoundary = true
 			return
 		}
 		scannedAtDepth[key] = calleeDepth
 		callee, err := parseReusableWorkflow(calleeSource.displayPath, source)
 		if err != nil {
-			resolver.runtimeMatrixBoundary = true
+			resolver.scan.runtimeMatrixBoundary = true
 			continue
 		}
 		resolver.discoverRuntimeMatrixBoundaries(ctx, calleeSource, callee, calleeDepth, scannedAtDepth)
 	}
 }
 
+// scanWorkflow folds one reached workflow's static facts into the scan.
+func (resolver *reusableResolver) scanWorkflow(parsed *workflow.Workflow) {
+	resolver.scan.runtimeMatrixBoundary = resolver.scan.runtimeMatrixBoundary || hasRuntimeMatrixBoundary(parsed)
+	resolver.scan.referencesVars = resolver.scan.referencesVars || workflowReferencesVars(parsed)
+}
+
 func (resolver *reusableResolver) resolve(ctx context.Context, current reusableWorkflowSource, digest string, parsed *workflow.Workflow, namespace, labelPrefix string, inputs reusableInputs, externalNeeds map[string]needBinding, permissionCeiling *workflow.Permissions, secrets secretAuthority, tokenPolicyNarrowed bool, reusableCallPosition workflow.Position, callGuards []sourcedCallGuard, concurrencyGates []WorkflowConcurrencyGate, depth int) (reusableResolution, error) {
 	path := current.displayPath
-	resolver.runtimeMatrixBoundary = resolver.runtimeMatrixBoundary || hasRuntimeMatrixBoundary(parsed)
+	resolver.scanWorkflow(parsed)
 	jobs := make(map[string]workflow.Job, len(parsed.Jobs))
 	for _, job := range parsed.Jobs {
 		jobs[job.ID] = job
@@ -291,10 +305,13 @@ func (resolver *reusableResolver) resolve(ctx context.Context, current reusableW
 		call := job.Reusable
 		calleeGuards := callGuards
 		if strings.TrimSpace(job.If) != "" {
+			// Call guards keep vars residual, like every other condition; see
+			// resolveCompileTimeConditions.
 			conditionContext := resolver.context
 			conditionContext.Inputs = inputs.values
 			conditionContext.Matrix = nil
 			conditionContext.Strategy = nil
+			conditionContext.Vars = nil
 			if err := validateCompileSite(job.If, expression.ProfileCompileCallCondition, expression.ResultBoolean); err != nil {
 				if blockerDetailUnsafe {
 					err = suppressBlockerDetail(err)
@@ -355,7 +372,7 @@ func (resolver *reusableResolver) resolve(ctx context.Context, current reusableW
 		if err != nil {
 			return reusableResolution{}, err
 		}
-		resolver.runtimeMatrixBoundary = resolver.runtimeMatrixBoundary || hasRuntimeMatrixBoundary(callee)
+		resolver.scanWorkflow(callee)
 		if !callee.Callable {
 			return reusableResolution{}, locatedJobError(path, job, call.Span.Start.Line, call.Span.Start.Column, fmt.Sprintf("reusable workflow %q does not declare on.workflow_call", call.Uses))
 		}

--- a/internal/compiler/vars_references.go
+++ b/internal/compiler/vars_references.go
@@ -1,0 +1,247 @@
+package compiler
+
+import (
+	"strings"
+
+	"github.com/buildkite/buildkite-gha/internal/expression"
+	"github.com/buildkite/buildkite-gha/internal/program"
+	"github.com/buildkite/buildkite-gha/internal/workflow"
+)
+
+// workflowReferencesVars reports whether any expression in the parsed workflow
+// reads the vars context, in any position and by any access form: vars.NAME,
+// vars['NAME'], vars[matrix.name], or toJSON(vars). Callers use it to decide
+// whether repository and organization variables must be resolved before
+// compiling, so it inspects every field that can hold an expression rather
+// than only compile-time positions: runtime positions read the same scopes.
+// A field whose expressions do not parse is not a reference; compilation
+// rejects it separately.
+func workflowReferencesVars(parsed *workflow.Workflow) bool {
+	if parsed == nil {
+		return false
+	}
+	if templateReferencesVars(parsed.RunName) || templateReferencesVars(parsed.DefaultShell) || templateReferencesVars(parsed.DefaultWorkingDirectory) {
+		return true
+	}
+	if mapReferencesVars(parsed.Env) || concurrencyReferencesVars(parsed.Concurrency) {
+		return true
+	}
+	for _, input := range parsed.CallInputs {
+		if input.Default != nil && valueReferencesVars(input.Default.Data) {
+			return true
+		}
+	}
+	for _, output := range parsed.CallOutputs {
+		if templateReferencesVars(output.Value) {
+			return true
+		}
+	}
+	for _, job := range parsed.Jobs {
+		if jobReferencesVars(job) {
+			return true
+		}
+	}
+	return false
+}
+
+// ActionsReferenceVars reports whether any resolved action program in the
+// bundle's plans reads the vars context, such as an action.yml input default
+// of ${{ vars.REGION }} or a composite step condition of vars.ENABLED ==
+// 'true'. Action metadata is only known once compilation has resolved the
+// actions, so a workflow whose sole vars reference lives in an action is
+// discovered here rather than by Report.ReferencesVars; callers resolve the
+// scopes and compile again so the plans carry them.
+func ActionsReferenceVars(bundle Bundle) bool {
+	for _, artifact := range bundle.Plans {
+		if artifact.Job.Program == nil {
+			continue
+		}
+		for _, action := range artifact.Job.Program.Actions {
+			found := false
+			_ = action.VisitSites(func(site program.Site) error {
+				found = found || siteReferencesVars(site)
+				return nil
+			})
+			if found {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// siteReferencesVars inspects one program site by its surface: condition
+// surfaces hold bare expressions, every other surface holds a template.
+func siteReferencesVars(site program.Site) bool {
+	switch site.Surface {
+	case program.SurfaceJobCondition, program.SurfaceCallCondition, program.SurfaceStepCondition, program.SurfaceActionLifecycle:
+		return conditionReferencesVars(site.Source)
+	default:
+		return templateReferencesVars(site.Source)
+	}
+}
+
+func jobReferencesVars(job workflow.Job) bool {
+	for _, value := range []string{job.Name, job.Environment, job.ServicesExpression, job.DefaultShell, job.DefaultWorkingDirectory} {
+		if templateReferencesVars(value) {
+			return true
+		}
+	}
+	if conditionReferencesVars(job.If) || mapReferencesVars(job.Env) || mapReferencesVars(job.Outputs) || concurrencyReferencesVars(job.Concurrency) {
+		return true
+	}
+	for _, label := range job.RunsOn {
+		if templateReferencesVars(label) {
+			return true
+		}
+	}
+	if expressionReferencesVars(job.RunsOnExpr) || matrixReferencesVars(job.Matrix) {
+		return true
+	}
+	if job.Reusable != nil {
+		for _, input := range job.Reusable.Inputs {
+			if valueReferencesVars(input.Data) {
+				return true
+			}
+		}
+	}
+	if container := job.Container; container != nil {
+		if templateReferencesVars(container.Image) || mapReferencesVars(container.Env) || sliceReferencesVars(container.Ports) {
+			return true
+		}
+	}
+	for _, service := range job.Services {
+		container := service.Container
+		for _, value := range []string{container.Image, container.Options, container.Command, container.Entrypoint} {
+			if templateReferencesVars(value) {
+				return true
+			}
+		}
+		if mapReferencesVars(container.Env) || sliceReferencesVars(container.Ports) || sliceReferencesVars(container.Volumes) {
+			return true
+		}
+		if credentials := container.Credentials; credentials != nil && (templateReferencesVars(credentials.Username) || templateReferencesVars(credentials.Password)) {
+			return true
+		}
+	}
+	for _, step := range job.Steps {
+		if stepReferencesVars(step) {
+			return true
+		}
+	}
+	return false
+}
+
+func stepReferencesVars(step workflow.Step) bool {
+	for _, value := range []string{step.Name, step.Run, step.Shell, step.WorkingDirectory, step.ContinueOnErrorExpression, step.TimeoutMinutesExpression} {
+		if templateReferencesVars(value) {
+			return true
+		}
+	}
+	return conditionReferencesVars(step.If) || mapReferencesVars(step.Env) || mapReferencesVars(step.With)
+}
+
+func concurrencyReferencesVars(concurrency *workflow.Concurrency) bool {
+	if concurrency == nil {
+		return false
+	}
+	return templateReferencesVars(concurrency.Group) || expressionReferencesVars(concurrency.CancelInProgressExpression)
+}
+
+func matrixReferencesVars(matrix *workflow.Matrix) bool {
+	if matrix == nil {
+		return false
+	}
+	if expressionReferencesVars(matrix.Expression) || expressionReferencesVars(matrix.IncludeExpression) || expressionReferencesVars(matrix.ExcludeExpression) {
+		return true
+	}
+	for _, row := range matrix.Rows {
+		if expressionReferencesVars(row.Expression) {
+			return true
+		}
+		for _, value := range row.Values {
+			if valueReferencesVars(value.Data) {
+				return true
+			}
+		}
+	}
+	for _, combinations := range [][]workflow.MatrixCombination{matrix.Include, matrix.Exclude} {
+		for _, combination := range combinations {
+			for _, value := range combination.Values {
+				if valueReferencesVars(value.Data) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func mapReferencesVars(values map[string]string) bool {
+	for _, value := range values {
+		if templateReferencesVars(value) {
+			return true
+		}
+	}
+	return false
+}
+
+func sliceReferencesVars(values []string) bool {
+	for _, value := range values {
+		if templateReferencesVars(value) {
+			return true
+		}
+	}
+	return false
+}
+
+// valueReferencesVars walks an owned JSON-compatible value for template
+// strings that read vars.
+func valueReferencesVars(value any) bool {
+	switch value := value.(type) {
+	case string:
+		return templateReferencesVars(value)
+	case []any:
+		for _, element := range value {
+			if valueReferencesVars(element) {
+				return true
+			}
+		}
+	case map[string]any:
+		for _, element := range value {
+			if valueReferencesVars(element) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// expressionReferencesVars inspects a parsed bare expression such as a
+// deferred matrix or runs-on expression.
+func expressionReferencesVars(expr *expression.Expression) bool {
+	if expr == nil {
+		return false
+	}
+	return conditionReferencesVars(expr.Text)
+}
+
+// conditionReferencesVars inspects a bare condition, which GitHub evaluates as
+// an expression whether or not it is wrapped in ${{ }}.
+func conditionReferencesVars(value string) bool {
+	if strings.TrimSpace(value) == "" {
+		return false
+	}
+	if !strings.Contains(value, "${{") {
+		value = "${{ " + value + " }}"
+	}
+	return templateReferencesVars(value)
+}
+
+func templateReferencesVars(value string) bool {
+	if !strings.Contains(value, "${{") {
+		return false
+	}
+	found, err := referencesContext(value, expression.ProfilePartialTemplate, "vars", false)
+	return err == nil && found
+}

--- a/internal/compiler/vars_references_test.go
+++ b/internal/compiler/vars_references_test.go
@@ -1,0 +1,266 @@
+package compiler
+
+import (
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/buildkite-gha/internal/plan"
+	"github.com/buildkite/buildkite-gha/internal/program"
+)
+
+// TestValidateReportsVarsReferences proves the validation report tells callers
+// whether a workflow reads the vars context anywhere, in any access form,
+// including inside a reusable workflow it calls. Callers resolve repository
+// and organization variables only when it does.
+func TestValidateReportsVarsReferences(t *testing.T) {
+	for name, test := range map[string]struct {
+		workflow string
+		want     bool
+	}{
+		"no references": {`on: push
+env:
+  GREETING: ${{ github.event_name }}
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - run: echo "${{ github.sha }}" "$VARS" "vars.NOT_AN_EXPRESSION"
+        env:
+          VARS: literal
+`, false},
+		"compile-time matrix": {`on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: ${{ fromJSON(vars.VERSIONS) }}
+    steps: [{run: true}]
+`, true},
+		"compile-time runs-on": {`on: push
+jobs:
+  test:
+    runs-on: ${{ vars.RUNNER }}
+    steps: [{run: true}]
+`, true},
+		"workflow concurrency": {`on: push
+concurrency: deploy-${{ vars.TARGET }}
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps: [{run: true}]
+`, true},
+		"runtime step": {`on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ vars.REGION }}"
+`, true},
+		"bare job condition": {`on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    if: vars.DEPLOY_ENABLED == 'true'
+    steps: [{run: true}]
+`, true},
+		"index access": {`on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ vars['REGION'] }}"
+`, true},
+		"dynamic access": {`on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        name: [A, B]
+    steps:
+      - run: echo "${{ vars[matrix.name] }}"
+`, true},
+		"whole context": {`on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo '${{ toJSON(vars) }}'
+`, true},
+		"service credentials": {`on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      db:
+        image: ghcr.io/acme/db
+        credentials:
+          username: ${{ vars.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+    steps: [{run: true}]
+`, true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			// Compile-time positions fail without the scopes, and that is
+			// exactly when callers need the report to say vars are referenced.
+			report, _ := Validate("vars.yml", []byte(test.workflow))
+			if report.ReferencesVars != test.want {
+				t.Fatalf("ReferencesVars = %v, want %v", report.ReferencesVars, test.want)
+			}
+		})
+	}
+}
+
+// TestResolvedVarsDoNotNarrowAuthorityPlanning proves resolved repository
+// and organization variables reach compile-time fields and the plan without
+// narrowing token or secret authority: a step whose condition a known
+// variable makes false still requests the token and secret it names, because
+// authority planning treats vars as unknown.
+func TestResolvedVarsDoNotNarrowAuthorityPlanning(t *testing.T) {
+	options := Options{
+		EventTrust: EventTrusted,
+		Vars: VariableSources{
+			Organization: map[string]string{"PUBLISH": "false", "RUNNER": "ubuntu-22.04"},
+			Repository:   map[string]string{"publish": "true"},
+		},
+		Runners: RunnerPolicy{Labels: map[string]string{"ubuntu-22.04": "linux"}},
+	}
+	plans, err := compilePlansForTest(t.Context(), "authority.yml", []byte(`on: push
+jobs:
+  release:
+    runs-on: ${{ vars.RUNNER }}
+    if: vars.PUBLISH == 'true'
+    steps:
+      - if: vars.PUBLISH == 'false'
+        run: echo "${{ secrets.GITHUB_TOKEN }}" "${{ secrets.NPM_TOKEN }}"
+`), pushEvent(t), "0.0.0-test", "sha256:"+strings.Repeat("3", 64), options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("plans = %d, want the vars-gated job kept for runtime evaluation", len(plans))
+	}
+	job := plans[0]
+	if job.Target.Queue != "linux" {
+		t.Fatalf("plan queue = %q, want the vars-selected runner", job.Target.Queue)
+	}
+	if job.GitHubToken == nil || !slices.Contains(job.RequiredSecrets, "NPM_TOKEN") {
+		t.Fatalf("known-false vars condition narrowed authority: token %#v, secrets %#v", job.GitHubToken, job.RequiredSecrets)
+	}
+	if !reflect.DeepEqual(job.RepositoryVars, options.Vars.Repository) || !reflect.DeepEqual(job.OrganizationVars, options.Vars.Organization) {
+		t.Fatalf("plan scopes = repository %#v, organization %#v", job.RepositoryVars, job.OrganizationVars)
+	}
+}
+
+// TestKnownFalseVarsConditionsKeepAuthority proves a job condition or a
+// reusable-workflow call guard that a resolved variable makes false neither
+// prunes the job's token authority nor collapses to a literal: vars stay
+// residual in the plan so the runtime evaluates them with the plan's
+// pre-environment scopes, and planning keeps requesting the token.
+func TestKnownFalseVarsConditionsKeepAuthority(t *testing.T) {
+	options := defaultOptions()
+	options.Vars = VariableSources{Repository: map[string]string{"PUBLISH": "false"}}
+	repository := t.TempDir()
+	caller := writeWorkflow(t, repository, "caller.yml", `on: push
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && vars.PUBLISH == 'true'
+    steps:
+      - run: echo "${{ secrets.GITHUB_TOKEN }}"
+  delegated:
+    if: vars.PUBLISH == 'true'
+    uses: ./.github/workflows/reusable.yml
+`)
+	writeWorkflow(t, repository, "reusable.yml", `on: workflow_call
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ secrets.GITHUB_TOKEN }}"
+`)
+	plans, err := compilePlansForTest(t.Context(), caller, readFile(t, caller), pushEvent(t), "0.0.0-test", testDistributionDigest, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 2 {
+		t.Fatalf("plans = %d, want both vars-gated jobs kept for runtime evaluation", len(plans))
+	}
+	for _, job := range plans {
+		if job.GitHubToken == nil {
+			t.Fatalf("job %q: known-false vars condition pruned token authority: %#v", job.Workflow.LogicalJobID, job)
+		}
+		condition := job.Program.Job.Condition.Source
+		for _, guard := range job.Program.Job.Guards {
+			condition += " " + guard.Condition.Source
+		}
+		if !strings.Contains(strings.ToLower(condition), "vars.publish") {
+			t.Fatalf("job %q: vars condition was resolved at compile time: %q", job.Workflow.LogicalJobID, condition)
+		}
+	}
+}
+
+func TestValidateReportsVarsReferencesInCalledReusableWorkflow(t *testing.T) {
+	repository := t.TempDir()
+	callerPath := writeWorkflow(t, repository, "caller.yml", `on: push
+jobs:
+  delegated:
+    uses: ./.github/workflows/reusable.yml
+    with:
+      message: hello
+`)
+	writeWorkflow(t, repository, "reusable.yml", `on:
+  workflow_call:
+    inputs:
+      message:
+        type: string
+        required: true
+jobs:
+  first:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ inputs.message }} ${{ vars.REGION }}"
+`)
+	report, err := Validate(callerPath, readFile(t, callerPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !report.ReferencesVars {
+		t.Fatal("ReferencesVars = false for a caller whose reusable workflow reads vars")
+	}
+}
+
+// TestActionsReferenceVars proves a compiled bundle reports a vars reference
+// that lives only in a resolved action's metadata, so callers can resolve the
+// scopes after compilation discovers it, and stays quiet otherwise.
+func TestActionsReferenceVars(t *testing.T) {
+	site := func(source string) *program.Site { return &program.Site{Source: source} }
+	bundle := func(sources ...string) Bundle {
+		actions := map[string]program.Action{}
+		for i, source := range sources {
+			actions[fmt.Sprintf("action-%d", i)] = program.Action{Inputs: []program.ActionInput{{Name: "region", Default: site(source)}}}
+		}
+		return Bundle{Plans: []PlanArtifact{{Job: plan.Job{}}, {Job: plan.Job{Program: &program.Program{Actions: actions}}}}}
+	}
+	if ActionsReferenceVars(bundle("${{ github.token }}", "literal", "vars.NOT_AN_EXPRESSION")) {
+		t.Fatal("ActionsReferenceVars() = true without a vars reference")
+	}
+	if !ActionsReferenceVars(bundle("${{ github.token }}", "${{ vars.AWS_REGION }}")) {
+		t.Fatal("ActionsReferenceVars() = false with an input default reading vars")
+	}
+	composite := func(condition string) Bundle {
+		action := program.Action{Steps: []program.ActionStep{{Condition: program.Site{Source: condition}, Run: &program.ActionRun{Command: program.Site{Source: "echo ok"}}}}}
+		return Bundle{Plans: []PlanArtifact{{Job: plan.Job{Program: &program.Program{Actions: map[string]program.Action{"composite": action}}}}}}
+	}
+	if !ActionsReferenceVars(composite("vars.ENABLED == 'true'")) {
+		t.Fatal("ActionsReferenceVars() = false with a bare composite step condition reading vars")
+	}
+	if ActionsReferenceVars(composite("github.event_name == 'push'")) {
+		t.Fatal("ActionsReferenceVars() = true with a bare composite step condition that does not read vars")
+	}
+}

--- a/internal/compiler/vars_test.go
+++ b/internal/compiler/vars_test.go
@@ -154,10 +154,11 @@ jobs:
 	if registry := deploy.Services["registry"]; registry.Image != "registry:shared" || registry.Credentials == nil || registry.Credentials.Username != "${{ vars.REGION }}" {
 		t.Fatalf("service = %#v, want compile-time image and residual credential vars", registry)
 	}
-	// jobs.<id>.if is evaluated before the environment applies, so the same
-	// expression there does reduce with the repository value.
-	if deploy.Condition != "true" {
-		t.Fatalf("job condition = %q, want repository value applied", deploy.Condition)
+	// jobs.<id>.if keeps vars residual too: the runtime evaluates it with
+	// VarsBeforeEnvironment, and a value that made it false at compile time
+	// would otherwise prune the job's token and secret authority.
+	if deploy.Condition != "(true && (vars.region == 'base'))" {
+		t.Fatalf("job condition = %q, want vars kept for runtime evaluation", deploy.Condition)
 	}
 }
 

--- a/internal/runtime/variable_resolution.go
+++ b/internal/runtime/variable_resolution.go
@@ -1,0 +1,217 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/buildkite/buildkite-gha/internal/agentapi"
+)
+
+const (
+	// variableResolutionResponseLimit bounds a successful response. The
+	// backend caps repository and organization names and values at 256 KiB
+	// combined, and JSON escaping expands a byte to at most six, so 2 MiB
+	// holds any response it can send.
+	variableResolutionResponseLimit = 2 << 20
+
+	// repositoryVariableCountLimit and organizationVariableCountLimit are
+	// GitHub's maximum numbers of variables per scope.
+	repositoryVariableCountLimit   = 500
+	organizationVariableCountLimit = 1000
+	// variablesByteLimit is the backend's bound on the UTF-8 bytes of
+	// repository and organization variable names and values combined.
+	variablesByteLimit = 256 << 10
+)
+
+// ErrVariablesUnavailable reports that the Agent API offers no repository and
+// organization variable resolution: the backend lacks the endpoint or the
+// organization opted out. Callers keep the vars context empty for names no
+// scope defines, as they did before the endpoint existed.
+var ErrVariablesUnavailable = errors.New("the Agent API does not offer GitHub variable resolution")
+
+// VariablesSnapshot is the Buildkite backend's snapshot of a repository's
+// GitHub Actions variables outside any environment, by scope. Values are
+// plaintext configuration: callers must keep them out of logs and
+// diagnostics. Names are unique case-insensitively within each scope.
+type VariablesSnapshot struct {
+	Repository   map[string]string
+	Organization map[string]string
+}
+
+// AgentVariableResolverConfig carries the current Buildkite job's Agent
+// connection and authentication material.
+type AgentVariableResolverConfig struct {
+	Endpoint      string
+	JobID         string
+	JobToken      string
+	ClientVersion string
+	Client        *http.Client
+}
+
+// AgentVariableResolver resolves repository and organization variables
+// through the job-scoped Agent API endpoint github-actions/variables. The
+// backend performs the GitHub reads with its own credentials, restricted to
+// the pipeline's configured GitHub.com repository.
+type AgentVariableResolver struct {
+	resolveURL string
+	agent      *agentapi.Client
+}
+
+// NewAgentVariableResolver validates the Agent connection configuration.
+func NewAgentVariableResolver(config AgentVariableResolverConfig) (*AgentVariableResolver, error) {
+	client := config.Client
+	if client == nil {
+		// The backend walks paginated GitHub listings for both scopes, so
+		// allow longer than the default Agent API request timeout.
+		client = &http.Client{Timeout: 30 * time.Second}
+	}
+	agent, err := agentapi.New(agentapi.Config{
+		Endpoint: config.Endpoint, JobID: config.JobID, JobToken: config.JobToken,
+		ClientVersion: config.ClientVersion, HTTPClient: client,
+	}, "variable resolution")
+	if err != nil {
+		return nil, err
+	}
+	return &AgentVariableResolver{resolveURL: agent.URL("github-actions/variables"), agent: agent}, nil
+}
+
+// ResolveVariables resolves the repository and organization variables of the
+// given owner/repository in one request. It returns ErrVariablesUnavailable
+// when the Agent API answers 404; every other failure carries the backend's
+// status, and its message or Retry-After delay when present. Error messages
+// name at most a variable, never a value.
+func (c *AgentVariableResolver) ResolveVariables(ctx context.Context, repository string) (VariablesSnapshot, error) {
+	if c == nil {
+		return VariablesSnapshot{}, fmt.Errorf("variable resolver is not configured")
+	}
+	if !validCheckoutRepository(repository) {
+		return VariablesSnapshot{}, fmt.Errorf("variable resolution requires a valid event repository")
+	}
+	body, err := json.Marshal(struct {
+		RepositoryURL string `json:"repo_url"`
+	}{RepositoryURL: "https://github.com/" + repository})
+	if err != nil {
+		return VariablesSnapshot{}, fmt.Errorf("encode variable resolution request: %w", err)
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, c.resolveURL, bytes.NewReader(body))
+	if err != nil {
+		return VariablesSnapshot{}, fmt.Errorf("create variable resolution request: %w", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response, err := c.agent.Do(request)
+	if err != nil {
+		return VariablesSnapshot{}, fmt.Errorf("request variable resolution: %w", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		errorBody, _ := io.ReadAll(io.LimitReader(response.Body, environmentResolutionErrorLimit))
+		return VariablesSnapshot{}, variableResolutionStatusError(response.StatusCode, response.Header.Get("Retry-After"), errorBody)
+	}
+	payload, err := io.ReadAll(io.LimitReader(response.Body, variableResolutionResponseLimit+1))
+	if err != nil {
+		return VariablesSnapshot{}, fmt.Errorf("read variable resolution response: %w", err)
+	}
+	if len(payload) > variableResolutionResponseLimit {
+		return VariablesSnapshot{}, fmt.Errorf("variable resolution response exceeds the %d-byte limit", variableResolutionResponseLimit)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	// Both scopes decode through pointers: the backend always sends both, so
+	// an absent scope is a contract violation, not an empty scope.
+	var decoded struct {
+		Repository   *[]resolvedVariable `json:"repository_variables"`
+		Organization *[]resolvedVariable `json:"organization_variables"`
+	}
+	if err := decoder.Decode(&decoded); err != nil {
+		return VariablesSnapshot{}, fmt.Errorf("decode variable resolution response: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return VariablesSnapshot{}, fmt.Errorf("variable resolution response has trailing data")
+	}
+	if decoded.Repository == nil || decoded.Organization == nil {
+		return VariablesSnapshot{}, fmt.Errorf("variable resolution response omits repository_variables or organization_variables")
+	}
+	total := 0
+	repositoryVariables, err := resolvedVariablesMap("repository", *decoded.Repository, repositoryVariableCountLimit, &total)
+	if err != nil {
+		return VariablesSnapshot{}, fmt.Errorf("invalid variable resolution response: %w", err)
+	}
+	organizationVariables, err := resolvedVariablesMap("organization", *decoded.Organization, organizationVariableCountLimit, &total)
+	if err != nil {
+		return VariablesSnapshot{}, fmt.Errorf("invalid variable resolution response: %w", err)
+	}
+	if total > variablesByteLimit {
+		return VariablesSnapshot{}, fmt.Errorf("repository and organization variables exceed %d bytes; remove or shrink repository or organization variables", variablesByteLimit)
+	}
+	return VariablesSnapshot{Repository: repositoryVariables, Organization: organizationVariables}, nil
+}
+
+type resolvedVariable struct {
+	Name  *string `json:"name"`
+	Value *string `json:"value"`
+}
+
+// resolvedVariablesMap validates one scope's variables against GitHub's
+// bounds, adds their bytes to total, and returns them by name. Errors name
+// the scope and, at most, a variable name; the caller wraps them with the
+// response context.
+func resolvedVariablesMap(scope string, variables []resolvedVariable, countLimit int, total *int) (map[string]string, error) {
+	if len(variables) > countLimit {
+		return nil, fmt.Errorf("%d %s variables exceed GitHub's limit of %d", len(variables), scope, countLimit)
+	}
+	values := make(map[string]string, len(variables))
+	identities := make(map[string]string, len(variables))
+	for _, variable := range variables {
+		if variable.Name == nil || variable.Value == nil {
+			return nil, fmt.Errorf("a variable in the %s scope has no name or value", scope)
+		}
+		if !environmentSecretNamePattern.MatchString(*variable.Name) {
+			return nil, fmt.Errorf("invalid %s variable name", scope)
+		}
+		identity := strings.ToUpper(*variable.Name)
+		if previous, exists := identities[identity]; exists {
+			return nil, fmt.Errorf("%s variable %q repeats %q; GitHub variable names are case-insensitive", scope, *variable.Name, previous)
+		}
+		identities[identity] = *variable.Name
+		if len(*variable.Value) > environmentVariableValueLimit {
+			return nil, fmt.Errorf("%s variable %q exceeds GitHub's %d-byte value limit", scope, *variable.Name, environmentVariableValueLimit)
+		}
+		*total += len(*variable.Name) + len(*variable.Value)
+		values[*variable.Name] = *variable.Value
+	}
+	return values, nil
+}
+
+func variableResolutionStatusError(status int, retryAfter string, body []byte) error {
+	switch status {
+	case http.StatusBadRequest:
+		if message := errorBodyMessage(body); message != "" {
+			return fmt.Errorf("the variable resolution request was rejected: %s", message)
+		}
+		return fmt.Errorf("the variable resolution request was rejected; confirm that Buildkite's GitHub App can read the repository's variables")
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return fmt.Errorf("the variable resolution request was denied")
+	case http.StatusNotFound:
+		return ErrVariablesUnavailable
+	case http.StatusTooManyRequests:
+		retryAfter = strings.TrimSpace(retryAfter)
+		if retryAfterSecondsPattern.MatchString(retryAfter) {
+			return fmt.Errorf("variable resolution requests are rate limited; retry after %s seconds", retryAfter)
+		}
+		return fmt.Errorf("variable resolution requests are rate limited")
+	case http.StatusServiceUnavailable:
+		retryAfter = strings.TrimSpace(retryAfter)
+		if retryAfterSecondsPattern.MatchString(retryAfter) {
+			return fmt.Errorf("the variable resolution service is temporarily unavailable; retry after %s seconds", retryAfter)
+		}
+		return fmt.Errorf("the variable resolution service is temporarily unavailable")
+	default:
+		return fmt.Errorf("the variable resolution service returned HTTP %d", status)
+	}
+}

--- a/internal/runtime/variable_resolution_test.go
+++ b/internal/runtime/variable_resolution_test.go
@@ -1,0 +1,267 @@
+package runtime
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestAgentVariableResolverResolvesBothScopes(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/jobs/"+testCacheJobID+"/github-actions/variables" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if r.Method != http.MethodPost || r.Header.Get("Authorization") != "Token job-secret" || r.Header.Get("Accept") != "application/json" || r.Header.Get("Content-Type") != "application/json" || r.Header.Get("User-Agent") != "buildkite-gha/1.2.3" {
+			t.Errorf("request = %s headers %#v", r.Method, r.Header)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(body) != `{"repo_url":"https://github.com/buildkite/buildkite-gha"}` {
+			t.Errorf("request body = %s", body)
+		}
+		// Scopes arrive separately and sorted by name; the same name may appear
+		// in both, and case differs between scopes. Nothing merges here.
+		_, _ = io.WriteString(w, `{"repository_variables":[{"name":"AWS_REGION","value":"eu-west-1"},{"name":"EMPTY","value":""},{"name":"registry","value":"ghcr.io/team"}],`+
+			`"organization_variables":[{"name":"AWS_REGION","value":"us-east-1"},{"name":"REGISTRY","value":"ghcr.io/acme"},{"name":"cert_pem","value":"-----BEGIN-----\nline\n"}]}`)
+	}))
+	defer server.Close()
+	resolver, err := NewAgentVariableResolver(AgentVariableResolverConfig{Endpoint: server.URL, JobID: testCacheJobID, JobToken: "job-secret", ClientVersion: "1.2.3"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := resolver.ResolveVariables(t.Context(), "buildkite/buildkite-gha")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := VariablesSnapshot{
+		Repository:   map[string]string{"AWS_REGION": "eu-west-1", "EMPTY": "", "registry": "ghcr.io/team"},
+		Organization: map[string]string{"AWS_REGION": "us-east-1", "REGISTRY": "ghcr.io/acme", "cert_pem": "-----BEGIN-----\nline\n"},
+	}
+	if !reflect.DeepEqual(snapshot, want) {
+		t.Fatalf("ResolveVariables() = %#v, want %#v", snapshot, want)
+	}
+}
+
+func TestAgentVariableResolverDecodesEmptyScopes(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"repository_variables":[],"organization_variables":[]}`)
+	}))
+	defer server.Close()
+	resolver, err := NewAgentVariableResolver(AgentVariableResolverConfig{Endpoint: server.URL, JobID: testCacheJobID, JobToken: "job-secret"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := resolver.ResolveVariables(t.Context(), "buildkite/buildkite-gha")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot.Repository) != 0 || len(snapshot.Organization) != 0 {
+		t.Fatalf("ResolveVariables() = %#v, want empty scopes", snapshot)
+	}
+}
+
+func TestAgentVariableResolverRejectsInvalidInputBeforeNetwork(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { requests++ }))
+	defer server.Close()
+	resolver, err := NewAgentVariableResolver(AgentVariableResolverConfig{Endpoint: server.URL, JobID: testCacheJobID, JobToken: "job-secret"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, repository := range []string{"", "other", "../other/repo", "owner/..", "owner/repo/extra", "owner/repo?permission=write"} {
+		if _, err := resolver.ResolveVariables(t.Context(), repository); err == nil {
+			t.Errorf("ResolveVariables(%q) succeeded", repository)
+		}
+	}
+	var unconfigured *AgentVariableResolver
+	if _, err := unconfigured.ResolveVariables(t.Context(), "buildkite/buildkite-gha"); err == nil {
+		t.Error("ResolveVariables() on a nil resolver succeeded")
+	}
+	if requests != 0 {
+		t.Fatalf("network requests = %d, want 0", requests)
+	}
+}
+
+func TestAgentVariableResolverRejectsUnsafeConfiguration(t *testing.T) {
+	valid := AgentVariableResolverConfig{Endpoint: "https://agent.example/v3", JobID: testCacheJobID, JobToken: "job-token"}
+	if _, err := NewAgentVariableResolver(valid); err != nil {
+		t.Fatal(err)
+	}
+	for name, mutate := range map[string]func(*AgentVariableResolverConfig){
+		"missing endpoint":            func(c *AgentVariableResolverConfig) { c.Endpoint = "" },
+		"endpoint credentials":        func(c *AgentVariableResolverConfig) { c.Endpoint = "https://user@agent.example/v3" },
+		"endpoint plaintext hostname": func(c *AgentVariableResolverConfig) { c.Endpoint = "http://localhost/v3" },
+		"invalid job ID":              func(c *AgentVariableResolverConfig) { c.JobID = "../other" },
+		"missing job token":           func(c *AgentVariableResolverConfig) { c.JobToken = "" },
+		"job token header split":      func(c *AgentVariableResolverConfig) { c.JobToken = "secret\r\nOther: value" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := valid
+			mutate(&config)
+			if _, err := NewAgentVariableResolver(config); err == nil {
+				t.Fatalf("NewAgentVariableResolver(%#v) succeeded", config)
+			}
+		})
+	}
+}
+
+// TestAgentVariableResolverStatusErrors proves each backend status maps to the
+// agreed client behavior: 404 is the ErrVariablesUnavailable sentinel so
+// callers keep empty scopes, 400 carries the backend's message, and 429 and
+// 503 carry a numeric Retry-After delay.
+func TestAgentVariableResolverStatusErrors(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		status     int
+		retryAfter string
+		body       string
+		want       string
+	}{
+		{"rejected", http.StatusBadRequest, "", "", "the variable resolution request was rejected; confirm that Buildkite's GitHub App can read the repository's variables"},
+		{"rejected with backend policy message", http.StatusBadRequest, "", `{"message":"GitHub repository and organization variables exceed 262144 bytes; remove or shrink repository or organization variables"}`, "rejected: GitHub repository and organization variables exceed 262144 bytes"},
+		{"rejected with permission message", http.StatusBadRequest, "", `{"message":"GitHub App cannot read repository variables; ensure Variables: read is approved"}`, "rejected: GitHub App cannot read repository variables; ensure Variables: read is approved"},
+		{"rejected with malformed body", http.StatusBadRequest, "", `not json`, "rejected; confirm"},
+		{"rejected with unsafe message", http.StatusBadRequest, "", "{\"message\":\"bad\\nrequest\"}", "rejected: bad request"},
+		{"denied", http.StatusForbidden, "", "", "denied"},
+		{"unavailable endpoint", http.StatusNotFound, "", "", "the Agent API does not offer GitHub variable resolution"},
+		{"rate limited with delay", http.StatusTooManyRequests, "3600", "", "variable resolution requests are rate limited; retry after 3600 seconds"},
+		{"rate limited unsafe header", http.StatusTooManyRequests, "soon", "", "variable resolution requests are rate limited"},
+		{"unavailable with delay", http.StatusServiceUnavailable, "60", "", "the variable resolution service is temporarily unavailable; retry after 60 seconds"},
+		{"unavailable", http.StatusServiceUnavailable, "", "", "the variable resolution service is temporarily unavailable"},
+		{"unexpected status", http.StatusBadGateway, "", "", "HTTP 502"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if test.retryAfter != "" {
+					w.Header().Set("Retry-After", test.retryAfter)
+				}
+				w.WriteHeader(test.status)
+				_, _ = w.Write([]byte(test.body))
+			}))
+			defer server.Close()
+			resolver, err := NewAgentVariableResolver(AgentVariableResolverConfig{Endpoint: server.URL, JobID: testCacheJobID, JobToken: "job-secret"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = resolver.ResolveVariables(t.Context(), "buildkite/buildkite-gha")
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("ResolveVariables() error = %v, want %q", err, test.want)
+			}
+			if test.status == http.StatusTooManyRequests && strings.Contains(test.want, "retry after") && !strings.Contains(err.Error(), test.retryAfter) {
+				t.Fatalf("ResolveVariables() error = %v, want Retry-After %s", err, test.retryAfter)
+			}
+			if unavailable := errors.Is(err, ErrVariablesUnavailable); unavailable != (test.status == http.StatusNotFound) {
+				t.Fatalf("errors.Is(err, ErrVariablesUnavailable) = %v for HTTP %d", unavailable, test.status)
+			}
+		})
+	}
+}
+
+// TestAgentVariableResolverRejectsUntrustedResponses proves the client
+// enforces the backend's bounds itself and never trusts a malformed snapshot.
+// No error message carries a variable value.
+func TestAgentVariableResolverRejectsUntrustedResponses(t *testing.T) {
+	const value = "value-that-must-not-leak"
+	for _, test := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{"malformed JSON", `{"repository_variables":`, "decode"},
+		{"trailing JSON", `{"repository_variables":[],"organization_variables":[]}{}`, "trailing data"},
+		{"missing repository scope", `{"organization_variables":[]}`, "omits repository_variables or organization_variables"},
+		{"null repository scope", `{"repository_variables":null,"organization_variables":[]}`, "omits repository_variables or organization_variables"},
+		{"missing organization scope", `{"repository_variables":[]}`, "omits repository_variables or organization_variables"},
+		{"oversized", `{"repository_variables":[],"organization_variables":[]}` + strings.Repeat(" ", variableResolutionResponseLimit), "exceeds"},
+		{"variable without value", `{"repository_variables":[{"name":"AWS_REGION"}],"organization_variables":[]}`, "invalid variable resolution response: a variable in the repository scope has no name or value"},
+		{"variable without name", `{"repository_variables":[],"organization_variables":[{"value":"` + value + `"}]}`, "invalid variable resolution response: a variable in the organization scope has no name or value"},
+		{"invalid repository variable name", `{"repository_variables":[{"name":"not a name","value":"` + value + `"}],"organization_variables":[]}`, "invalid variable resolution response: invalid repository variable name"},
+		{"invalid organization variable name", `{"repository_variables":[],"organization_variables":[{"name":"1BAD","value":"` + value + `"}]}`, "invalid variable resolution response: invalid organization variable name"},
+		{"case-colliding repository names", `{"repository_variables":[{"name":"Region","value":"` + value + `"},{"name":"REGION","value":"b"}],"organization_variables":[]}`, `invalid variable resolution response: repository variable "REGION" repeats "Region"; GitHub variable names are case-insensitive`},
+		{"too many repository variables", `{"repository_variables":[` + repeatedVariables(repositoryVariableCountLimit+1, 1) + `],"organization_variables":[]}`, "invalid variable resolution response: 501 repository variables exceed GitHub's limit of 500"},
+		{"too many organization variables", `{"repository_variables":[],"organization_variables":[` + repeatedVariables(organizationVariableCountLimit+1, 1) + `]}`, "invalid variable resolution response: 1001 organization variables exceed GitHub's limit of 1000"},
+		{"oversized variable value", `{"repository_variables":[{"name":"BIG","value":"` + strings.Repeat("x", environmentVariableValueLimit+1) + `"}],"organization_variables":[]}`, `invalid variable resolution response: repository variable "BIG" exceeds GitHub's 49152-byte value limit`},
+		// The 256 KiB budget spans both scopes: three maximal values per scope
+		// pass alone but exceed it together.
+		{"oversized combined scopes", `{"repository_variables":[` + repeatedVariables(3, environmentVariableValueLimit) + `],"organization_variables":[` + repeatedVariables(3, environmentVariableValueLimit) + `]}`, "repository and organization variables exceed 262144 bytes"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = io.WriteString(w, test.body)
+			}))
+			defer server.Close()
+			resolver, err := NewAgentVariableResolver(AgentVariableResolverConfig{Endpoint: server.URL, JobID: testCacheJobID, JobToken: "job-secret"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = resolver.ResolveVariables(t.Context(), "buildkite/buildkite-gha")
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("ResolveVariables() error = %v, want %q", err, test.want)
+			}
+			if strings.Contains(err.Error(), value) {
+				t.Fatalf("ResolveVariables() error = %v carries a variable value", err)
+			}
+		})
+	}
+
+	var redirected bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/elsewhere" {
+			redirected = true
+			_, _ = io.WriteString(w, `{"repository_variables":[],"organization_variables":[]}`)
+			return
+		}
+		http.Redirect(w, r, "/elsewhere", http.StatusTemporaryRedirect)
+	}))
+	defer server.Close()
+	resolver, err := NewAgentVariableResolver(AgentVariableResolverConfig{Endpoint: server.URL, JobID: testCacheJobID, JobToken: "job-secret"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resolver.ResolveVariables(t.Context(), "buildkite/buildkite-gha"); err == nil || !strings.Contains(err.Error(), "HTTP 307") || redirected {
+		t.Fatalf("redirect ResolveVariables() error/redirected = %v / %v", err, redirected)
+	}
+}
+
+// TestAgentVariableResolverDecodesMaximalEscapedVariables proves the response
+// budget holds the backend's largest permitted payload — 256 KiB of names and
+// values across both scopes — even when JSON escaping expands every value
+// byte to six.
+func TestAgentVariableResolverDecodesMaximalEscapedVariables(t *testing.T) {
+	// 500 repository and 12 organization variables of 512 bytes each is just
+	// under the 256 KiB combined budget once names are counted.
+	const size = 500
+	variables := func(count int, prefix string) string {
+		entries := make([]string, 0, count)
+		for i := range count {
+			entries = append(entries, `{"name":"`+prefix+strconv.Itoa(i)+`","value":"`+strings.Repeat(`\u0001`, size)+`"}`)
+		}
+		return strings.Join(entries, ",")
+	}
+	body := `{"repository_variables":[` + variables(repositoryVariableCountLimit, "R") + `],"organization_variables":[` + variables(12, "O") + `]}`
+	if len(body) <= 6*size*(repositoryVariableCountLimit+12) {
+		t.Fatalf("test body is %d bytes; want every value byte escaped to six", len(body))
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, body)
+	}))
+	defer server.Close()
+	resolver, err := NewAgentVariableResolver(AgentVariableResolverConfig{Endpoint: server.URL, JobID: testCacheJobID, JobToken: "job-secret"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := resolver.ResolveVariables(t.Context(), "buildkite/buildkite-gha")
+	if err != nil {
+		t.Fatalf("ResolveVariables() = %v", err)
+	}
+	if len(snapshot.Repository) != repositoryVariableCountLimit || len(snapshot.Organization) != 12 || snapshot.Repository["R0"] != strings.Repeat("\x01", size) {
+		t.Fatalf("variables = %d repository, %d organization entries", len(snapshot.Repository), len(snapshot.Organization))
+	}
+}


### PR DESCRIPTION
## Why

Repository and organization variables are not read, so a `vars` reference outside a declared environment evaluates as an empty string, and compile-time positions fail:

```yaml
build:
  runs-on: ${{ vars.RUNNER }}          # compile error: no vars source
  if: vars.DEPLOY_ENABLED == 'true'    # always ""
  steps:
    - run: echo "Region: ${{ vars.AWS_REGION }}"   # prints "Region: "
```

## What

Inside a Buildkite job, `upload` and `compile` ask the job-scoped Agent API variables endpoint for the event repository's variables and use them before compiling:

```
POST /jobs/{job_id}/github-actions/variables
{"repo_url": "https://github.com/octo/app"}

{"repository_variables": [{"name": "RUNNER", "value": "ubuntu-latest"}],
 "organization_variables": [{"name": "AWS_REGION", "value": "eu-west-1"}]}
```

With that response the example above runs on `ubuntu-latest`, keeps or skips the job from `DEPLOY_ENABLED`, and prints `Region: eu-west-1`. Precedence is unchanged from #440 and #447: environment over repository over organization, per position as on GitHub.

Behavior around the request:

| Situation | Result |
| --- | --- |
| No workflow references `vars` | No request. |
| Any applicable workflow (or a reusable workflow it calls) references `vars` | One request per upload, memoized including failures, whether or not an environment is declared. |
| The only `vars` reference is an input default in an action's `action.yml` | Discovered after compilation resolves the action; the same memoized request runs and the workflow compiles again so its plans carry the scopes. |
| Event from a provider other than GitHub.com | No request; scopes stay empty. |
| 404 (backend lacks the endpoint or the organization opted out) | Both scopes empty; undefined names keep evaluating as `""`. No error. |
| 400 / 429 / 503 | Each workflow that references `vars` fails with the backend message and any `Retry-After` delay, for example `[E_ENVIRONMENT] variables: variable resolution requests are rate limited; retry after 3600 seconds`. Other workflows still upload. |
| `compile` outside a Buildkite job | No source; compile-time `vars` references fail as before. |

The client enforces the contract's bounds (500 repository and 1000 organization names, 48 KiB per value, 256 KiB combined, name syntax, case-insensitive uniqueness) and a 2 MiB response limit. Resolution errors never carry values. A value used in a compile-time field appears where that field does (a matrix value becomes a step label in the pipeline YAML); runtime references stay in job plans, as environment variables already do. `GITHUB_TOKEN` and secret authority planning still ignores resolved values, so a condition a variable makes false does not narrow a job's token or secret requests.

Based on `main` after #440 and #447; no stacking. The backend PR must merge and roll out for the scopes to fill; until then the endpoint returns 404 and behavior is unchanged. `run-name` still rejects `vars`; that is a possible follow-up.

