### PR TITLE
fix: allow hashFiles in workspaces with more than 100,000 entries

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1091,11 +1091,13 @@ and overlapping patterns hash each path once. Matching is case-insensitive only
 on Windows. An empty match returns an empty string.
 
 On Linux, literal paths use direct lookups. macOS and Windows enumerate directory
-names to preserve platform-specific matching. Wildcard patterns skip directories
-that cannot match a positive pattern; `**` searches recursively below its prefix. Negative
-patterns filter matches but do not prune traversal, since later patterns can
-re-include files. The entry limit counts inspected entries, including nonmatches,
-rather than the size of the workspace.
+names to preserve platform-specific matching. Each positive pattern searches
+below its literal directory prefix, then walks recursively from its first
+wildcard. For example, `packages/service/*.go` searches under `packages/service`,
+while `packages/s*/value` searches under `packages`. Negative patterns filter
+matches but do not prune traversal, since later patterns can re-include files.
+The entry limit counts inspected entries, including nonmatches, rather than the
+size of the workspace.
 
 Each call has an execution budget covering traversal, matching, sorting, hashing,
 and verification. An earlier step or job deadline still applies. Cancellation is

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1090,6 +1090,17 @@ them back. Directory matches include descendants, hidden files match normally,
 and overlapping patterns hash each path once. Matching is case-insensitive only
 on Windows. An empty match returns an empty string.
 
+On Linux, literal paths use direct lookups. macOS and Windows enumerate directory
+names to preserve platform-specific matching. Wildcard patterns skip directories
+that cannot match a positive pattern; `**` searches recursively below its prefix. Negative
+patterns filter matches but do not prune traversal, since later patterns can
+re-include files. The entry limit counts inspected entries, including nonmatches,
+rather than the size of the workspace.
+
+Each call has an execution budget covering traversal, matching, sorting, hashing,
+and verification. An earlier step or job deadline still applies. Cancellation is
+checked between operations; it cannot interrupt a blocked filesystem call.
+
 For each file, `hashFiles()` calculates SHA-256 over its contents. It then hashes
 the concatenated binary digests in lexical path order. GitHub Runner does not
 specify glob traversal order, so a multi-file digest can differ when GitHub's
@@ -1585,7 +1596,8 @@ hosted-toolchains images provide. macOS images are unsupported.
 | Uploaded source data or ZIP | No `buildkite-gha` limit; subject to Buildkite Agent and storage limits |
 | Job summary | 1 MiB |
 | `hashFiles()` patterns | 255 per call; 1 KiB each; 64 KiB total |
-| `hashFiles()` workspace entries | 100,000 per call |
+| `hashFiles()` inspected entries | 1,000,000 per call |
+| `hashFiles()` execution budget | 30 seconds per call |
 | `hashFiles()` matched files | 10,000 per call |
 | `hashFiles()` selected bytes | 1 GiB per call |
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1102,6 +1102,9 @@ size of the workspace.
 Each call has an execution budget covering traversal, matching, sorting, hashing,
 and verification. An earlier step or job deadline still applies. Cancellation is
 checked between operations; it cannot interrupt a blocked filesystem call.
+Entry-limit and execution-budget errors list the positive patterns being searched
+and recommend more specific paths to reduce traversal and hashing. The budget is
+shared across those patterns.
 
 For each file, `hashFiles()` calculates SHA-256 over its contents. It then hashes
 the concatenated binary digests in lexical path order. GitHub Runner does not

--- a/internal/runtime/hash_files.go
+++ b/internal/runtime/hash_files.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/bmatcuk/doublestar/v4"
 )
@@ -24,7 +25,8 @@ const (
 	maxHashFilePatternBytesTotal = 64 << 10
 	maxHashFileMatches           = 10_000
 	maxHashFileBytes             = 1 << 30
-	maxHashFileEntries           = 100_000
+	maxHashFileEntries           = 1_000_000
+	maxHashFileDuration          = 30 * time.Second
 )
 
 type hashFilesLimits struct {
@@ -34,6 +36,7 @@ type hashFilesLimits struct {
 	matches             int
 	bytes               int64
 	entries             int
+	duration            time.Duration
 	beforeOpen          func(string)
 	beforeDirectoryOpen func(string)
 	afterFileHash       func(string)
@@ -42,7 +45,7 @@ type hashFilesLimits struct {
 var defaultHashFilesLimits = hashFilesLimits{
 	patterns: maxHashFilePatterns, patternBytes: maxHashFilePatternBytes,
 	totalPatternBytes: maxHashFilePatternBytesTotal, matches: maxHashFileMatches,
-	bytes: maxHashFileBytes, entries: maxHashFileEntries,
+	bytes: maxHashFileBytes, entries: maxHashFileEntries, duration: maxHashFileDuration,
 }
 
 type hashFilePattern struct {
@@ -70,14 +73,30 @@ func hashWorkspaceFilesWithLimits(ctx context.Context, workspace string, sources
 	return hashWorkspaceRootFilesWithLimits(ctx, root, sources, limits, caseInsensitive)
 }
 
-func hashWorkspaceRootFilesWithLimits(ctx context.Context, root *os.Root, sources []string, limits hashFilesLimits, caseInsensitive bool) (string, error) {
+func hashWorkspaceRootFilesWithLimits(ctx context.Context, root *os.Root, sources []string, limits hashFilesLimits, caseInsensitive bool) (digest string, retErr error) {
+	parent := ctx
+	if limits.duration > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, limits.duration)
+		defer cancel()
+	}
+	defer func() {
+		if err := ctx.Err(); err != nil {
+			digest = ""
+			if parent.Err() != nil {
+				retErr = parent.Err()
+			} else {
+				retErr = fmt.Errorf("hashFiles exceeded its %s execution limit: %w", limits.duration, err)
+			}
+		}
+	}()
 	patterns, err := parseHashFilePatterns(sources, limits)
 	if err != nil {
 		return "", err
 	}
 	var selected []string
 	directories := make(map[string]fs.FileInfo)
-	err = walkHashFilesRoot(ctx, root, limits.entries, limits.beforeDirectoryOpen, directories, func(name string, entry fs.DirEntry) error {
+	err = walkHashFilesRoot(ctx, root, limits.entries, limits.beforeDirectoryOpen, directories, patterns, caseInsensitive, func(name string, entry fs.DirEntry) error {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
@@ -204,7 +223,63 @@ func hashWorkspaceFile(ctx context.Context, root *os.Root, directoryInfo fs.File
 	return fileHash.Sum(nil), read, nil
 }
 
-func walkHashFilesRoot(ctx context.Context, root *os.Root, limit int, beforeOpen func(string), directories map[string]fs.FileInfo, visit func(string, fs.DirEntry) error) error {
+// hashFileSearchChildren returns literal children to inspect, or requests directory
+// enumeration when a positive pattern needs a wildcard. Negations cannot prune:
+// a later positive pattern may re-include an excluded descendant.
+func hashFileSearchChildren(patterns []hashFilePattern, directory string, caseInsensitive bool) ([]string, bool) {
+	var parts []string
+	if directory != "." {
+		parts = strings.Split(directory, "/")
+	}
+	names := make(map[string]bool)
+	for _, pattern := range patterns {
+		if pattern.negative {
+			continue
+		}
+		if strings.Contains(pattern.pattern, `\/`) {
+			return nil, true // Escaped separators need whole-pattern matching.
+		}
+		segments := strings.Split(pattern.pattern, "/")
+		possible := true
+		for i, part := range parts {
+			if i >= len(segments) || segments[i] == "**" {
+				// Directory matches include descendants. Keep globstar traversal
+				// conservative rather than guessing which depth will match.
+				return nil, true
+			}
+			segment := segments[i]
+			if caseInsensitive {
+				segment, part = strings.ToLower(segment), strings.ToLower(part)
+			}
+			if matched, _ := doublestar.Match(segment, part); !matched {
+				possible = false
+				break
+			}
+		}
+		if !possible {
+			continue
+		}
+		if len(parts) >= len(segments) {
+			return nil, true
+		}
+		segment := segments[len(parts)]
+		// Enumerate escaped patterns too: matching remains owned by doublestar.
+		// macOS volumes commonly fold case even though hashFiles matching does
+		// not. Enumerate to retain the actual spelling on those filesystems.
+		if caseInsensitive || runtime.GOOS == "darwin" || runtime.GOOS == "windows" || strings.ContainsAny(segment, "*?[\\") {
+			return nil, true
+		}
+		names[segment] = true
+	}
+	result := make([]string, 0, len(names))
+	for name := range names {
+		result = append(result, name)
+	}
+	sort.Strings(result)
+	return result, false
+}
+
+func walkHashFilesRoot(ctx context.Context, root *os.Root, limit int, beforeOpen func(string), directories map[string]fs.FileInfo, patterns []hashFilePattern, caseInsensitive bool, visit func(string, fs.DirEntry) error) error {
 	const readBatch = 256
 	entriesRead := 0
 	rootInfo, err := root.Lstat(".")
@@ -217,6 +292,10 @@ func walkHashFilesRoot(ctx context.Context, root *os.Root, limit int, beforeOpen
 		if err := ctx.Err(); err != nil {
 			return err
 		}
+		names, enumerate := hashFileSearchChildren(patterns, directory, caseInsensitive)
+		if !enumerate && len(names) == 0 {
+			return nil
+		}
 		handle, err := current.Open(".")
 		if err != nil {
 			return fmt.Errorf("open hashFiles directory %q: %w", directory, err)
@@ -228,11 +307,30 @@ func walkHashFilesRoot(ctx context.Context, root *os.Root, limit int, beforeOpen
 		}
 		var entries []fs.DirEntry
 		for {
-			batch, readErr := handle.ReadDir(readBatch)
+			var batch []fs.DirEntry
+			var readErr error
+			if enumerate {
+				batch, readErr = handle.ReadDir(readBatch)
+			} else {
+				for _, name := range names {
+					if err := ctx.Err(); err != nil {
+						return errors.Join(err, handle.Close())
+					}
+					info, err := current.Lstat(name)
+					if errors.Is(err, fs.ErrNotExist) {
+						continue
+					}
+					if err != nil {
+						return errors.Join(fmt.Errorf("inspect hashFiles path %q: %w", path.Join(directory, name), err), handle.Close())
+					}
+					batch = append(batch, fs.FileInfoToDirEntry(info))
+				}
+				readErr = io.EOF
+			}
 			for _, entry := range batch {
 				entriesRead++
 				if entriesRead > limit {
-					return errors.Join(fmt.Errorf("hashFiles workspace has more than %d entries", limit), handle.Close())
+					return errors.Join(fmt.Errorf("hashFiles traversal inspected more than %d entries", limit), handle.Close())
 				}
 				entries = append(entries, entry)
 			}
@@ -260,6 +358,10 @@ func walkHashFilesRoot(ctx context.Context, root *os.Root, limit int, beforeOpen
 				return err
 			}
 			if entry.IsDir() {
+				children, scan := hashFileSearchChildren(patterns, name, caseInsensitive)
+				if !scan && len(children) == 0 {
+					continue
+				}
 				before, err := current.Lstat(entry.Name())
 				if err != nil || before.Mode()&os.ModeSymlink != 0 || !before.IsDir() {
 					return fmt.Errorf("hashFiles directory %q changed before traversal", name)

--- a/internal/runtime/hash_files.go
+++ b/internal/runtime/hash_files.go
@@ -223,53 +223,56 @@ func hashWorkspaceFile(ctx context.Context, root *os.Root, directoryInfo fs.File
 	return fileHash.Sum(nil), read, nil
 }
 
-// hashFileSearchChildren returns literal children to inspect, or requests directory
-// enumeration when a positive pattern needs a wildcard. Negations cannot prune:
-// a later positive pattern may re-include an excluded descendant.
-func hashFileSearchChildren(patterns []hashFilePattern, directory string, caseInsensitive bool) ([]string, bool) {
-	var parts []string
-	if directory != "." {
-		parts = strings.Split(directory, "/")
-	}
-	names := make(map[string]bool)
+// hashFileSearchPrefixes derives literal search paths using the same library as
+// matching. Below the first wildcard, traverse conservatively: character classes
+// can consume separators, so matching individual components is not equivalent.
+func hashFileSearchPrefixes(patterns []hashFilePattern, caseInsensitive bool) []string {
+	var prefixes []string
 	for _, pattern := range patterns {
 		if pattern.negative {
 			continue
 		}
-		if strings.Contains(pattern.pattern, `\/`) {
-			return nil, true // Escaped separators need whole-pattern matching.
+		base, rest := doublestar.SplitPattern(pattern.pattern)
+		if !strings.ContainsAny(rest, "*?[\\") {
+			base = path.Join(base, rest)
 		}
-		segments := strings.Split(pattern.pattern, "/")
-		possible := true
-		for i, part := range parts {
-			if i >= len(segments) || segments[i] == "**" {
-				// Directory matches include descendants. Keep globstar traversal
-				// conservative rather than guessing which depth will match.
-				return nil, true
-			}
-			segment := segments[i]
-			if caseInsensitive {
-				segment, part = strings.ToLower(segment), strings.ToLower(part)
-			}
-			if matched, _ := doublestar.Match(segment, part); !matched {
-				possible = false
-				break
-			}
+		// SplitPattern unescapes metacharacters in the base, but leaves other
+		// escapes intact. Let whole-pattern matching handle those paths.
+		if base == "." || strings.Contains(base, `\`) {
+			return []string{"."}
 		}
-		if !possible {
-			continue
+		if caseInsensitive {
+			base = strings.ToLower(base)
 		}
-		if len(parts) >= len(segments) {
+		prefixes = append(prefixes, base)
+	}
+	return prefixes
+}
+
+func hashFileSearchChildren(prefixes []string, directory string, caseInsensitive bool) ([]string, bool) {
+	if caseInsensitive {
+		directory = strings.ToLower(directory)
+	}
+	names := make(map[string]bool)
+	for _, prefix := range prefixes {
+		if prefix == "." || directory == prefix || strings.HasPrefix(directory, prefix+"/") {
 			return nil, true
 		}
-		segment := segments[len(parts)]
-		// Enumerate escaped patterns too: matching remains owned by doublestar.
+		rest := prefix
+		if directory != "." {
+			var ok bool
+			rest, ok = strings.CutPrefix(prefix, directory+"/")
+			if !ok {
+				continue
+			}
+		}
 		// macOS volumes commonly fold case even though hashFiles matching does
 		// not. Enumerate to retain the actual spelling on those filesystems.
-		if caseInsensitive || runtime.GOOS == "darwin" || runtime.GOOS == "windows" || strings.ContainsAny(segment, "*?[\\") {
+		if caseInsensitive || runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
 			return nil, true
 		}
-		names[segment] = true
+		name, _, _ := strings.Cut(rest, "/")
+		names[name] = true
 	}
 	result := make([]string, 0, len(names))
 	for name := range names {
@@ -281,18 +284,18 @@ func hashFileSearchChildren(patterns []hashFilePattern, directory string, caseIn
 
 func walkHashFilesRoot(ctx context.Context, root *os.Root, limit int, beforeOpen func(string), directories map[string]fs.FileInfo, patterns []hashFilePattern, caseInsensitive bool, visit func(string, fs.DirEntry) error) error {
 	const readBatch = 256
+	prefixes := hashFileSearchPrefixes(patterns, caseInsensitive)
 	entriesRead := 0
 	rootInfo, err := root.Lstat(".")
 	if err != nil {
 		return fmt.Errorf("inspect hashFiles workspace: %w", err)
 	}
 	directories["."] = rootInfo
-	var walk func(string, *os.Root, fs.FileInfo) error
-	walk = func(directory string, current *os.Root, currentInfo fs.FileInfo) error {
+	var walk func(string, *os.Root, fs.FileInfo, []string, bool) error
+	walk = func(directory string, current *os.Root, currentInfo fs.FileInfo, names []string, enumerate bool) error {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		names, enumerate := hashFileSearchChildren(patterns, directory, caseInsensitive)
 		if !enumerate && len(names) == 0 {
 			return nil
 		}
@@ -358,7 +361,7 @@ func walkHashFilesRoot(ctx context.Context, root *os.Root, limit int, beforeOpen
 				return err
 			}
 			if entry.IsDir() {
-				children, scan := hashFileSearchChildren(patterns, name, caseInsensitive)
+				children, scan := hashFileSearchChildren(prefixes, name, caseInsensitive)
 				if !scan && len(children) == 0 {
 					continue
 				}
@@ -379,7 +382,7 @@ func walkHashFilesRoot(ctx context.Context, root *os.Root, limit int, beforeOpen
 					return fmt.Errorf("hashFiles directory %q changed before traversal", name)
 				}
 				directories[name] = before
-				walkErr := walk(name, childRoot, before)
+				walkErr := walk(name, childRoot, before, children, scan)
 				if closeErr := childRoot.Close(); walkErr != nil || closeErr != nil {
 					return errors.Join(walkErr, closeErr)
 				}
@@ -387,7 +390,8 @@ func walkHashFilesRoot(ctx context.Context, root *os.Root, limit int, beforeOpen
 		}
 		return nil
 	}
-	return walk(".", root, rootInfo)
+	names, enumerate := hashFileSearchChildren(prefixes, ".", caseInsensitive)
+	return walk(".", root, rootInfo, names, enumerate)
 }
 
 func verifyHashFileDirectories(ctx context.Context, root *os.Root, directories map[string]fs.FileInfo, name string) error {

--- a/internal/runtime/hash_files.go
+++ b/internal/runtime/hash_files.go
@@ -75,6 +75,7 @@ func hashWorkspaceFilesWithLimits(ctx context.Context, workspace string, sources
 
 func hashWorkspaceRootFilesWithLimits(ctx context.Context, root *os.Root, sources []string, limits hashFilesLimits, caseInsensitive bool) (digest string, retErr error) {
 	parent := ctx
+	var patterns []hashFilePattern
 	if limits.duration > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, limits.duration)
@@ -86,7 +87,7 @@ func hashWorkspaceRootFilesWithLimits(ctx context.Context, root *os.Root, source
 			if parent.Err() != nil {
 				retErr = parent.Err()
 			} else {
-				retErr = fmt.Errorf("hashFiles exceeded its %s execution limit: %w", limits.duration, err)
+				retErr = fmt.Errorf("hashFiles exceeded its %s execution limit (%w) while searching %s", limits.duration, err, hashFilesBudgetHint(patterns))
 			}
 		}
 	}()
@@ -223,6 +224,16 @@ func hashWorkspaceFile(ctx context.Context, root *os.Root, directoryInfo fs.File
 	return fileHash.Sum(nil), read, nil
 }
 
+func hashFilesBudgetHint(patterns []hashFilePattern) string {
+	var positive []string
+	for _, pattern := range patterns {
+		if !pattern.negative {
+			positive = append(positive, pattern.pattern)
+		}
+	}
+	return fmt.Sprintf("positive patterns %q; use more specific paths to reduce traversal and hashing", positive)
+}
+
 // hashFileSearchPrefixes derives literal search paths using the same library as
 // matching. Below the first wildcard, traverse conservatively: character classes
 // can consume separators, so matching individual components is not equivalent.
@@ -333,7 +344,7 @@ func walkHashFilesRoot(ctx context.Context, root *os.Root, limit int, beforeOpen
 			for _, entry := range batch {
 				entriesRead++
 				if entriesRead > limit {
-					return errors.Join(fmt.Errorf("hashFiles traversal inspected more than %d entries", limit), handle.Close())
+					return errors.Join(fmt.Errorf("hashFiles traversal inspected more than %d entries while searching %s", limit, hashFilesBudgetHint(patterns)), handle.Close())
 				}
 				entries = append(entries, entry)
 			}

--- a/internal/runtime/hash_files_test.go
+++ b/internal/runtime/hash_files_test.go
@@ -37,6 +37,7 @@ func TestHashWorkspaceFilesConformance(t *testing.T) {
 	}{
 		{name: "known digest and stable order", patterns: []string{"*.txt"}, contents: []string{"alpha", "bravo"}},
 		{name: "multiple patterns", patterns: []string{"a.txt", "nested/*.txt"}, contents: []string{"alpha", "charlie", "skip"}},
+		{name: "literal search order", patterns: []string{"b.txt", "a.txt", "b.txt"}, contents: []string{"alpha", "bravo"}},
 		{name: "ordered negation", patterns: []string{"**", "!nested/**"}, contents: []string{"dot-directory", "hidden", "alpha", "bravo", "braces"}},
 		{name: "ordered re-inclusion", patterns: []string{"**", "!nested/**", "nested/c.txt"}, contents: []string{"dot-directory", "hidden", "alpha", "bravo", "braces", "charlie"}},
 		{name: "later exclusion", patterns: []string{"nested/c.txt", "!nested/**"}},
@@ -283,7 +284,7 @@ func TestHashWorkspaceFilesEnforcesEveryBound(t *testing.T) {
 		{name: "total pattern length", patterns: []string{"one", "two"}, limits: withHashLimits(base, func(l *hashFilesLimits) { l.totalPatternBytes = 5 }), want: "exceed 5 total bytes"},
 		{name: "matched files", patterns: []string{"*"}, limits: withHashLimits(base, func(l *hashFilesLimits) { l.matches = 1 }), want: "more than 1 files"},
 		{name: "hashed bytes", patterns: []string{"*"}, limits: withHashLimits(base, func(l *hashFilesLimits) { l.bytes = 2 }), want: "selected bytes exceed 2"},
-		{name: "workspace entries", patterns: []string{"missing"}, limits: withHashLimits(base, func(l *hashFilesLimits) { l.entries = 1 }), want: "more than 1 entries"},
+		{name: "workspace entries", patterns: []string{"missing*"}, limits: withHashLimits(base, func(l *hashFilesLimits) { l.entries = 1 }), want: "more than 1 entries"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := hashWorkspaceFilesWithLimits(t.Context(), workspace, test.patterns, test.limits, false)
@@ -301,8 +302,103 @@ func TestHashWorkspaceFilesBoundsSingleDirectoryEnumeration(t *testing.T) {
 	}
 	limits := defaultHashFilesLimits
 	limits.entries = 10
-	if _, err := hashWorkspaceFilesWithLimits(t.Context(), workspace, []string{"missing"}, limits, false); err == nil || !strings.Contains(err.Error(), "more than 10 entries") {
+	if _, err := hashWorkspaceFilesWithLimits(t.Context(), workspace, []string{"missing*"}, limits, false); err == nil || !strings.Contains(err.Error(), "more than 10 entries") {
 		t.Fatalf("single-directory entry bound error = %v", err)
+	}
+}
+
+func TestHashWorkspaceFilesPrunesUnrelatedEntries(t *testing.T) {
+	workspace := t.TempDir()
+	writeFixtureFile(t, workspace, "packages/service/value", "value")
+	for i := range 30 {
+		writeFixtureFile(t, workspace, fmt.Sprintf("unrelated-%02d", i), "ignored")
+		writeFixtureFile(t, workspace, fmt.Sprintf("packages/other/entry-%02d", i), "ignored")
+	}
+	for _, patterns := range [][]string{
+		{"packages/service/value"},
+		{"packages/service/*"},
+		{"packages/s*/value"},
+		{"packages/s*/**"},
+		{"packages/service/", "!packages/**", "packages/service/value"},
+	} {
+		limits := defaultHashFilesLimits
+		limits.entries = 5
+		if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+			limits.entries = 40 // These platforms enumerate to preserve path spelling.
+		}
+		limits.beforeDirectoryOpen = func(name string) {
+			if name == "packages/other" {
+				t.Fatal("opened an unrelated subtree")
+			}
+		}
+		got, err := hashWorkspaceFilesWithLimits(t.Context(), workspace, patterns, limits, false)
+		if err != nil || got != githubHash("value") {
+			t.Fatalf("hashFiles(%v) = %q, %v", patterns, got, err)
+		}
+	}
+	limits := defaultHashFilesLimits
+	limits.entries = 1
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+		limits.entries = 40
+	}
+	for _, patterns := range [][]string{{"missing"}, {"!**"}, {"# comment"}} {
+		if got, err := hashWorkspaceFilesWithLimits(t.Context(), workspace, patterns, limits, false); err != nil || got != "" {
+			t.Fatalf("hashFiles(%v) = %q, %v", patterns, got, err)
+		}
+	}
+}
+
+func TestHashWorkspaceFilesPruningPreservesMatches(t *testing.T) {
+	workspace := t.TempDir()
+	for _, name := range []string{"root", "a/value", "a/nested/value", "b/value", "b/deep/c/value", "c/other", ".hidden/value", "literal/{name}"} {
+		writeFixtureFile(t, workspace, name, name)
+	}
+	for _, pattern := range []string{"a", "a/", "a/*", "*/value", "[ab]/value", "**/value", "a/**/value", "*/**/c/*", ".hidden", "literal/{name}", "A/VALUE", `a\/value`} {
+		for _, insensitive := range []bool{false, true} {
+			got, err := hashWorkspaceFilesWithLimits(t.Context(), workspace, []string{pattern}, defaultHashFilesLimits, insensitive)
+			// An excluded broad positive forces a full walk while leaving the
+			// selected set unchanged, providing an oracle for traversal pruning.
+			want, wantErr := hashWorkspaceFilesWithLimits(t.Context(), workspace, []string{"**", "!**", pattern}, defaultHashFilesLimits, insensitive)
+			if err != nil || wantErr != nil || got != want {
+				t.Fatalf("pattern %q (insensitive %v): %q, %v; full walk %q, %v", pattern, insensitive, got, err, want, wantErr)
+			}
+		}
+	}
+}
+
+func TestHashWorkspaceFilesExecutionBudget(t *testing.T) {
+	workspace := t.TempDir()
+	writeFixtureFile(t, workspace, "nested/value", "value")
+	for _, phase := range []string{"traversal", "hashing", "verification"} {
+		t.Run(phase, func(t *testing.T) {
+			limits := defaultHashFilesLimits
+			limits.duration = 20 * time.Millisecond
+			pause := func(string) { time.Sleep(2 * limits.duration) }
+			switch phase {
+			case "traversal":
+				limits.beforeDirectoryOpen = pause
+			case "hashing":
+				limits.beforeOpen = pause
+			case "verification":
+				limits.afterFileHash = pause
+			}
+			got, err := hashWorkspaceFilesWithLimits(t.Context(), workspace, []string{"nested/value"}, limits, false)
+			if got != "" || !errors.Is(err, context.DeadlineExceeded) || !strings.Contains(err.Error(), "hashFiles exceeded its 20ms execution limit") {
+				t.Fatalf("budget result = %q, %v", got, err)
+			}
+		})
+	}
+	for _, expired := range []bool{false, true} {
+		ctx, cancel := context.WithCancel(t.Context())
+		if expired {
+			cancel()
+			ctx, cancel = context.WithTimeout(t.Context(), -time.Second)
+		}
+		cancel()
+		_, err := hashWorkspaceFiles(ctx, workspace, []string{"missing"})
+		if !errors.Is(err, ctx.Err()) || strings.Contains(err.Error(), "execution limit") {
+			t.Fatalf("parent cancellation = %v, want %v", err, ctx.Err())
+		}
 	}
 }
 

--- a/internal/runtime/hash_files_test.go
+++ b/internal/runtime/hash_files_test.go
@@ -396,9 +396,13 @@ func TestHashWorkspaceFilesExecutionBudget(t *testing.T) {
 			case "verification":
 				limits.afterFileHash = pause
 			}
-			got, err := hashWorkspaceFilesWithLimits(t.Context(), workspace, []string{"nested/value"}, limits, false)
+			got, err := hashWorkspaceFilesWithLimits(t.Context(), workspace, []string{"nested/value", "!nested/skip", "other/*.txt"}, limits, false)
 			if got != "" || !errors.Is(err, context.DeadlineExceeded) || !strings.Contains(err.Error(), "hashFiles exceeded its 20ms execution limit") {
 				t.Fatalf("budget result = %q, %v", got, err)
+			}
+			wantHint := `positive patterns ["nested/value" "other/*.txt"]; use more specific paths to reduce traversal and hashing`
+			if !strings.Contains(err.Error(), wantHint) {
+				t.Fatalf("budget error = %v, want %q", err, wantHint)
 			}
 		})
 	}
@@ -413,6 +417,19 @@ func TestHashWorkspaceFilesExecutionBudget(t *testing.T) {
 		if !errors.Is(err, ctx.Err()) || strings.Contains(err.Error(), "execution limit") {
 			t.Fatalf("parent cancellation = %v, want %v", err, ctx.Err())
 		}
+	}
+}
+
+func TestHashWorkspaceFilesEntryBudgetDiagnostic(t *testing.T) {
+	workspace := t.TempDir()
+	writeFixtureFile(t, workspace, "nested/value", "value")
+	writeFixtureFile(t, workspace, "other/value.txt", "value")
+	limits := defaultHashFilesLimits
+	limits.entries = 1
+	got, err := hashWorkspaceFilesWithLimits(t.Context(), workspace, []string{"nested/*", "!nested/skip", "other/*.txt"}, limits, false)
+	want := `hashFiles traversal inspected more than 1 entries while searching positive patterns ["nested/*" "other/*.txt"]; use more specific paths to reduce traversal and hashing`
+	if got != "" || err == nil || err.Error() != want {
+		t.Fatalf("entry budget result = %q, %v; want %q", got, err, want)
 	}
 }
 

--- a/internal/runtime/hash_files_test.go
+++ b/internal/runtime/hash_files_test.go
@@ -317,8 +317,7 @@ func TestHashWorkspaceFilesPrunesUnrelatedEntries(t *testing.T) {
 	for _, patterns := range [][]string{
 		{"packages/service/value"},
 		{"packages/service/*"},
-		{"packages/s*/value"},
-		{"packages/s*/**"},
+		{"packages/service/**"},
 		{"packages/service/", "!packages/**", "packages/service/value"},
 	} {
 		limits := defaultHashFilesLimits
@@ -353,7 +352,7 @@ func TestHashWorkspaceFilesPruningPreservesMatches(t *testing.T) {
 	for _, name := range []string{"root", "a/value", "a/nested/value", "b/value", "b/deep/c/value", "c/other", ".hidden/value", "literal/{name}"} {
 		writeFixtureFile(t, workspace, name, name)
 	}
-	for _, pattern := range []string{"a", "a/", "a/*", "*/value", "[ab]/value", "**/value", "a/**/value", "*/**/c/*", ".hidden", "literal/{name}", "A/VALUE", `a\/value`} {
+	for _, pattern := range []string{"a", "a/", "a/*", "*/value", "[ab]/value", "**/value", "a/**/value", "*/**/c/*", ".hidden", "literal/{name}", "A/VALUE", `a\/value`, "a[/]value", "a[!x]value", "a[.-0]value"} {
 		for _, insensitive := range []bool{false, true} {
 			got, err := hashWorkspaceFilesWithLimits(t.Context(), workspace, []string{pattern}, defaultHashFilesLimits, insensitive)
 			// An excluded broad positive forces a full walk while leaving the
@@ -363,6 +362,21 @@ func TestHashWorkspaceFilesPruningPreservesMatches(t *testing.T) {
 				t.Fatalf("pattern %q (insensitive %v): %q, %v; full walk %q, %v", pattern, insensitive, got, err, want, wantErr)
 			}
 		}
+	}
+}
+
+func TestHashWorkspaceFilesCharacterClassesAcrossDirectories(t *testing.T) {
+	for _, prefix := range []string{"", "packages/", "literal{}/"} {
+		t.Run(prefix, func(t *testing.T) {
+			workspace := t.TempDir()
+			writeFixtureFile(t, workspace, prefix+"a/value", "value")
+			for _, pattern := range []string{"a[/]value", "a[!x]value", "a[.-0]value"} {
+				got, err := hashWorkspaceFiles(t.Context(), workspace, []string{prefix + pattern})
+				if err != nil || got != githubHash("value") {
+					t.Fatalf("hashFiles(%q) = %q, %v; want %q", prefix+pattern, got, err, githubHash("value"))
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Why

`hashFiles('packages/service/package-lock.json')` currently scans the entire workspace and fails after 100,000 entries, even when only one file is needed. Unrelated dependency directories can therefore prevent cache-key generation.

## What

Search from each positive pattern's literal prefix, derived once with doublestar's `SplitPattern`, and use direct literal lookups on Linux. macOS and Windows enumerate names to preserve matching behavior. Walk recursively below the first wildcard, then apply the original whole-pattern matcher so character classes, exclusions, and later re-inclusion retain their behavior.

For example, `packages/service/*.go` searches under `packages/service`; `packages/s*/value` searches under `packages`. This avoids a separate component parser that could disagree with matching when a character class consumes `/`.

| Limit | Before | After |
| --- | --- | --- |
| Inspected entries per call | 100,000 | 1,000,000 |
| Dedicated execution budget | None | 30 seconds |

The budget covers traversal through final verification and respects earlier parent deadlines. Entry-limit and timeout errors list the positive patterns and suggest more specific paths to reduce work. Cancellation remains cooperative and cannot interrupt a blocked filesystem call. Lexical hash ordering, workspace confinement, symlink rejection, and file-replacement checks remain intact.
