### PR TITLE
PB-3234: Preserve expanded GHA jobs when compilation fails

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -358,6 +358,14 @@ A top-level workflow that does not declare the effective event is excluded befor
 
 Job-level `uses`, `with`, and `secrets` follow these boundaries.
 
+If compilation fails after the complete job graph expands, upload preserves one
+Buildkite item per expanded job. Jobs with compiler errors fail with their own
+diagnostics, and their dependants are skipped. Independent jobs keep their
+compiled plans and run normally. The items keep their normal labels, keys,
+checks, and `needs` links. A runnable job is never emitted unless every job it
+needs also has a plan. If compilation fails before the complete graph is known,
+upload uses one workflow-level failing item instead.
+
 For a local call with `secrets: inherit`, each flattened callee job requests only the static ordinary secret names referenced by that job or its workflow-authored action inputs. Inheritance is one hop: an omitted nested `secrets: inherit` removes ordinary secret authority from every job below that edge. It does not affect direct caller jobs or `GITHUB_TOKEN`.
 
 Explicit mappings must target aliases declared by the called workflow. Every required alias must receive authority; an unmapped optional alias is empty. Nested mappings compose to the original Buildkite secret name and cannot recover an omitted same-named secret. Plans contain aliases and original names, never values. The runtime retrieves each original once, registers its value with both redactors, then projects it to the callee aliases.
@@ -893,6 +901,8 @@ Use an interpreter installed by an earlier step or included in the job image:
 ```
 
 A `uses` step may call a supported local or public action. Action inputs under `with` may use supported direct interpolation. Direct workflow `uses: docker://...` actions are rejected; prebuilt-image declarations belong in locked action metadata.
+
+Local actions must exist in the event repository when the workflow is compiled. An earlier step cannot create a local action with `actions/checkout`, an artifact download, or a command. Use a public `owner/repository/path@ref` action instead.
 
 Action steps can call public and local actions:
 

--- a/internal/buildkite/pipeline.go
+++ b/internal/buildkite/pipeline.go
@@ -124,7 +124,7 @@ type ApprovalGate struct {
 	Environment string
 }
 
-// Failure replaces a failed aggregate workflow with one synthetic command step.
+// Failure describes diagnostics displayed by a synthetic failing command step.
 type Failure struct {
 	AnnotationPath string
 	MessagePath    string
@@ -160,9 +160,14 @@ func MiseDataDir(platforms ...string) string {
 
 // Job describes one expanded workflow job after queue policy has been applied.
 type Job struct {
-	Key                string
-	Label              string
-	CheckLabel         string
+	Key        string
+	Label      string
+	CheckLabel string
+	// Failure and SkipReason represent a job whose workflow could not be
+	// prepared. Other jobs in the workflow may remain runnable when they do not
+	// depend on a failed preparation path.
+	Failure            *Failure
+	SkipReason         string
 	Queue              string
 	Platform           string
 	DistributionDigest string
@@ -246,7 +251,8 @@ func Emit(pipeline Pipeline) ([]byte, error) {
 			if workflow.Event == "" {
 				return nil, fmt.Errorf("workflow %q requires an event name", workflow.GroupKey)
 			}
-			if workflow.Failure == nil && workflow.Condition == "" && workflow.SkipReason == "" {
+			preparationOnly := preparationJobsOnly(workflow.Jobs)
+			if workflow.Failure == nil && workflow.Condition == "" && workflow.SkipReason == "" && !preparationOnly {
 				return nil, fmt.Errorf("workflow %q requires a trigger condition or skip reason", workflow.GroupKey)
 			}
 			if workflow.Failure == nil && workflow.Condition != "" && workflow.SkipReason != "" {
@@ -325,10 +331,12 @@ func Emit(pipeline Pipeline) ([]byte, error) {
 				}
 				checkLabels[checkLabel] = job.Key
 			}
-			if owner, exists := usedDigests[job.PlanDigest]; exists {
-				return nil, fmt.Errorf("jobs %q and %q share plan digest %s", owner, job.Key, job.PlanDigest)
+			if job.Failure == nil && job.SkipReason == "" {
+				if owner, exists := usedDigests[job.PlanDigest]; exists {
+					return nil, fmt.Errorf("jobs %q and %q share plan digest %s", owner, job.Key, job.PlanDigest)
+				}
+				usedDigests[job.PlanDigest] = job.Key
 			}
-			usedDigests[job.PlanDigest] = job.Key
 		}
 		if workflow.ConcurrencyGate != nil {
 			for _, job := range jobs {
@@ -414,22 +422,7 @@ func emitWorkflow(out *bytes.Buffer, pipeline Pipeline, workflow preparedWorkflo
 		if workflow.Condition != "" {
 			_, _ = fmt.Fprintf(out, "    if: %s\n", yamlScalar(workflow.Condition))
 		}
-		out.WriteString("    plugins:\n")
-		out.WriteString("      - artifacts#v1.9.4:\n")
-		_, _ = fmt.Fprintf(out, "          step: %s\n", yamlScalar(artifactProducer))
-		out.WriteString("          download:\n")
-		_, _ = fmt.Fprintf(out, "            - from: %s\n", yamlScalar(failure.MessagePath))
-		out.WriteString("              to: .buildkite-gha-failure-message.txt\n")
-		_, _ = fmt.Fprintf(out, "            - from: %s\n", yamlScalar(failure.AnnotationPath))
-		out.WriteString("              to: .buildkite-gha-failure-annotation.html\n")
-		commands := []string{
-			"cat .buildkite-gha-failure-message.txt",
-			"buildkite-agent annotate --scope=job --style=error < .buildkite-gha-failure-annotation.html",
-			"exit 1",
-		}
-		command := strings.Join(commands, "\n")
-		_, _ = fmt.Fprintf(out, "    command: %s\n", yamlScalar(command))
-		out.WriteString("    retry:\n      manual:\n        allowed: false\n")
+		emitFailureBody(out, "    ", artifactProducer, *failure, 1)
 		emitWorkflowCheck(out, "    ", pipeline.EventProvider, workflow, workflow.GroupKey, "", "Workflow could not be run", failure.Summary)
 		if pipeline.CompilerStep != "" {
 			_, _ = fmt.Fprintf(out, "    depends_on: %s\n", yamlScalar(pipeline.CompilerStep))
@@ -515,6 +508,32 @@ func emitWorkflow(out *bytes.Buffer, pipeline Pipeline, workflow preparedWorkflo
 		emitConcurrencyGateStep(out, stepIndent, attributeIndent, ":github: Finish reusable-workflow concurrency", gate.CloseKey, &gate.ConcurrencyGate, dependencies)
 	}
 	for _, job := range workflow.Jobs {
+		if job.Failure != nil || job.SkipReason != "" {
+			_, _ = fmt.Fprintf(out, "%s- label: %s\n", stepIndent, yamlScalar(":github: job · "+job.Label))
+			_, _ = fmt.Fprintf(out, "%skey: %s\n", attributeIndent, yamlScalar(job.Key))
+			checkLabel := job.CheckLabel
+			if checkLabel == "" {
+				checkLabel = job.Label
+			}
+			if job.Failure != nil {
+				exitStatus := 1
+				if job.SoftFail {
+					exitStatus = ContinueOnErrorExitStatus
+				}
+				emitFailureBody(out, attributeIndent, artifactProducer, *job.Failure, exitStatus)
+				emitWorkflowCheck(out, attributeIndent, pipeline.EventProvider, workflow, job.Key, checkLabel, "Job could not be run", job.Failure.Summary)
+				if job.SoftFail {
+					_, _ = fmt.Fprintf(out, "%ssoft_fail:\n%s  - exit_status: %d\n", attributeIndent, attributeIndent, ContinueOnErrorExitStatus)
+				}
+			} else {
+				_, _ = fmt.Fprintf(out, "%sskip: %s\n", attributeIndent, yamlScalar(job.SkipReason))
+				out.WriteString(attributeIndent + "type: command\n")
+				emitWorkflowCheck(out, attributeIndent, pipeline.EventProvider, workflow, job.Key, checkLabel, "", "")
+			}
+			_, _ = fmt.Fprintf(out, "%scheckout:\n%s  skip: true\n", attributeIndent, attributeIndent)
+			emitJobDependencies(out, attributeIndent, workflow, job, gateOpenKeys, pipeline.CompilerStep)
+			continue
+		}
 		platform := job.Platform
 		if platform == "" {
 			platform = "linux/amd64"
@@ -630,24 +649,7 @@ func emitWorkflow(out *bytes.Buffer, pipeline Pipeline, workflow preparedWorkflo
 			_, _ = fmt.Fprintf(out, "%sconcurrency: %d\n", attributeIndent, job.Concurrency)
 			_, _ = fmt.Fprintf(out, "%sconcurrency_group: %s\n", attributeIndent, yamlScalar(job.ConcurrencyGroup))
 		}
-		if !workflow.Aggregate {
-			_, _ = fmt.Fprintf(out, "%sdepends_on:\n", attributeIndent)
-			_, _ = fmt.Fprintf(out, "%s  - step: %s\n%s    allow_failure: false\n", attributeIndent, yamlScalar(pipeline.CompilerStep), attributeIndent)
-		} else if workflow.GateOpenKey != "" || len(job.Dependencies) != 0 || len(job.ConcurrencyGates) != 0 || job.ApprovalGate != "" {
-			_, _ = fmt.Fprintf(out, "%sdepends_on:\n", attributeIndent)
-		}
-		if workflow.GateOpenKey != "" {
-			_, _ = fmt.Fprintf(out, "%s  - step: %s\n%s    allow_failure: false\n", attributeIndent, yamlScalar(workflow.GateOpenKey), attributeIndent)
-		}
-		for _, dependency := range job.Dependencies {
-			_, _ = fmt.Fprintf(out, "%s  - step: %s\n%s    allow_failure: true\n", attributeIndent, yamlScalar(dependency), attributeIndent)
-		}
-		for _, gate := range job.ConcurrencyGates {
-			_, _ = fmt.Fprintf(out, "%s  - step: %s\n%s    allow_failure: false\n", attributeIndent, yamlScalar(gateOpenKeys[gate.ID]), attributeIndent)
-		}
-		if job.ApprovalGate != "" {
-			_, _ = fmt.Fprintf(out, "%s  - step: %s\n%s    allow_failure: false\n", attributeIndent, yamlScalar(job.ApprovalGate), attributeIndent)
-		}
+		emitJobDependencies(out, attributeIndent, workflow, job, gateOpenKeys, pipeline.CompilerStep)
 	}
 	// Approval gates are emitted after the jobs so no generated step follows a
 	// block step. A block step implicitly holds every later step that lacks an
@@ -669,6 +671,46 @@ func emitWorkflow(out *bytes.Buffer, pipeline Pipeline, workflow preparedWorkflo
 		_, _ = fmt.Fprintf(out, "%s  - step: %s\n%s    allow_failure: false\n", attributeIndent, yamlScalar(pipeline.CompilerStep), attributeIndent)
 	}
 	return nil
+}
+
+func emitFailureBody(out *bytes.Buffer, indent, artifactProducer string, failure Failure, exitStatus int) {
+	out.WriteString(indent + "plugins:\n")
+	out.WriteString(indent + "  - artifacts#v1.9.4:\n")
+	_, _ = fmt.Fprintf(out, "%s      step: %s\n", indent, yamlScalar(artifactProducer))
+	out.WriteString(indent + "      download:\n")
+	_, _ = fmt.Fprintf(out, "%s        - from: %s\n", indent, yamlScalar(failure.MessagePath))
+	out.WriteString(indent + "          to: .buildkite-gha-failure-message.txt\n")
+	_, _ = fmt.Fprintf(out, "%s        - from: %s\n", indent, yamlScalar(failure.AnnotationPath))
+	out.WriteString(indent + "          to: .buildkite-gha-failure-annotation.html\n")
+	command := strings.Join([]string{
+		"cat .buildkite-gha-failure-message.txt",
+		"buildkite-agent annotate --scope=job --style=error < .buildkite-gha-failure-annotation.html",
+		fmt.Sprintf("exit %d", exitStatus),
+	}, "\n")
+	_, _ = fmt.Fprintf(out, "%scommand: %s\n", indent, yamlScalar(command))
+	_, _ = fmt.Fprintf(out, "%sretry:\n%s  manual:\n%s    allowed: false\n", indent, indent, indent)
+}
+
+func emitJobDependencies(out *bytes.Buffer, indent string, workflow preparedWorkflow, job Job, gateOpenKeys map[string]string, compilerStep string) {
+	runnable := job.Failure == nil && job.SkipReason == ""
+	if !workflow.Aggregate {
+		_, _ = fmt.Fprintf(out, "%sdepends_on:\n", indent)
+		_, _ = fmt.Fprintf(out, "%s  - step: %s\n%s    allow_failure: false\n", indent, yamlScalar(compilerStep), indent)
+	} else if (workflow.GateOpenKey != "" && runnable) || len(job.Dependencies) != 0 || len(job.ConcurrencyGates) != 0 || job.ApprovalGate != "" {
+		_, _ = fmt.Fprintf(out, "%sdepends_on:\n", indent)
+	}
+	if workflow.GateOpenKey != "" && runnable {
+		_, _ = fmt.Fprintf(out, "%s  - step: %s\n%s    allow_failure: false\n", indent, yamlScalar(workflow.GateOpenKey), indent)
+	}
+	for _, dependency := range job.Dependencies {
+		_, _ = fmt.Fprintf(out, "%s  - step: %s\n%s    allow_failure: true\n", indent, yamlScalar(dependency), indent)
+	}
+	for _, gate := range job.ConcurrencyGates {
+		_, _ = fmt.Fprintf(out, "%s  - step: %s\n%s    allow_failure: false\n", indent, yamlScalar(gateOpenKeys[gate.ID]), indent)
+	}
+	if job.ApprovalGate != "" {
+		_, _ = fmt.Fprintf(out, "%s  - step: %s\n%s    allow_failure: false\n", indent, yamlScalar(job.ApprovalGate), indent)
+	}
 }
 
 func prepareReusableConcurrencyGates(jobs []Job) ([]preparedConcurrencyGate, error) {
@@ -903,10 +945,12 @@ func orderJobs(compilerStep string, input []Job) ([]Job, error) {
 		if _, exists := jobs[job.Key]; exists {
 			return nil, fmt.Errorf("duplicate generated step key %q", job.Key)
 		}
-		if other, exists := digests[job.PlanDigest]; exists {
-			return nil, fmt.Errorf("jobs %q and %q share plan digest %s", other, job.Key, job.PlanDigest)
+		if job.Failure == nil && job.SkipReason == "" {
+			if other, exists := digests[job.PlanDigest]; exists {
+				return nil, fmt.Errorf("jobs %q and %q share plan digest %s", other, job.Key, job.PlanDigest)
+			}
+			digests[job.PlanDigest] = job.Key
 		}
-		digests[job.PlanDigest] = job.Key
 		job.Dependencies = append([]string(nil), job.Dependencies...)
 		sort.Strings(job.Dependencies)
 		for i, dependency := range job.Dependencies {
@@ -955,6 +999,18 @@ func validateJob(compilerStep string, job Job) error {
 	if !validStepKey(job.Key) || job.Key == compilerStep {
 		return fmt.Errorf("invalid generated step key %q", job.Key)
 	}
+	preparationResult := job.Failure != nil || job.SkipReason != ""
+	if job.Failure != nil && job.SkipReason != "" {
+		return fmt.Errorf("job %q cannot have both failure and skip results", job.Key)
+	}
+	if job.Failure != nil {
+		if err := validateFailure(*job.Failure); err != nil {
+			return fmt.Errorf("job %q failure: %w", job.Key, err)
+		}
+	}
+	if utf8.RuneCountInString(job.SkipReason) > maxSkipReasonLength {
+		return fmt.Errorf("job %q skip reason exceeds %d characters", job.Key, maxSkipReasonLength)
+	}
 	if job.Cache != nil {
 		if err := ValidateCacheVolume(*job.Cache); err != nil {
 			return fmt.Errorf("job %q has invalid cache configuration: %w", job.Key, err)
@@ -966,8 +1022,12 @@ func validateJob(compilerStep string, job Job) error {
 	if job.Queue != "" && !identifierPattern.MatchString(job.Queue) {
 		return fmt.Errorf("job %q has invalid queue %q", job.Key, job.Queue)
 	}
-	if _, err := PlanPath(job.PlanDigest); err != nil {
-		return fmt.Errorf("job %q: %w", job.Key, err)
+	if !preparationResult {
+		if _, err := PlanPath(job.PlanDigest); err != nil {
+			return fmt.Errorf("job %q: %w", job.Key, err)
+		}
+	} else if job.PlanDigest != "" || job.Queue != "" || job.Platform != "" || job.DistributionDigest != "" || job.RuntimeImage != "" || job.EventPayload || job.ApprovalGate != "" || job.RequiresMise || job.Cache != nil || job.Concurrency != 0 || job.ConcurrencyGroup != "" || len(job.ConcurrencyGates) != 0 {
+		return fmt.Errorf("job %q preparation result cannot include runnable job configuration", job.Key)
 	}
 	if job.Concurrency < 0 {
 		return fmt.Errorf("job %q has invalid concurrency %d", job.Key, job.Concurrency)
@@ -987,6 +1047,29 @@ func validateJob(compilerStep string, job Job) error {
 		return fmt.Errorf("job %q has invalid approval gate %q", job.Key, job.ApprovalGate)
 	}
 	return nil
+}
+
+func validateFailure(failure Failure) error {
+	if !validArtifactPath(failure.AnnotationPath) {
+		return fmt.Errorf("requires a valid annotation artifact path")
+	}
+	if !validArtifactPath(failure.MessagePath) {
+		return fmt.Errorf("requires a valid message artifact path")
+	}
+	if failure.Summary == "" {
+		return fmt.Errorf("requires a provider check summary")
+	}
+	return nil
+}
+
+func preparationJobsOnly(jobs []Job) bool {
+	preparation := 0
+	for _, job := range jobs {
+		if job.Failure != nil || job.SkipReason != "" {
+			preparation++
+		}
+	}
+	return preparation != 0 && preparation == len(jobs)
 }
 
 func validStepKey(key string) bool {

--- a/internal/buildkite/pipeline_test.go
+++ b/internal/buildkite/pipeline_test.go
@@ -239,6 +239,33 @@ func TestEmitMarksToleratedJobsAsSoftFailures(t *testing.T) {
 	}
 }
 
+func TestEmitMarksToleratedPreparationFailuresAsSoftFailures(t *testing.T) {
+	output, err := Emit(Pipeline{
+		CompilerStep: "importer",
+		Jobs: []Job{{
+			Key: "report", Label: "Report", SoftFail: true,
+			Failure: &Failure{AnnotationPath: "annotation", MessagePath: "message", Summary: "could not compile"},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document struct {
+		Steps []struct {
+			Command  string `yaml:"command"`
+			SoftFail []struct {
+				ExitStatus int `yaml:"exit_status"`
+			} `yaml:"soft_fail"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(output, &document); err != nil {
+		t.Fatal(err)
+	}
+	if len(document.Steps) != 1 || !strings.HasSuffix(document.Steps[0].Command, "exit 78") || len(document.Steps[0].SoftFail) != 1 || document.Steps[0].SoftFail[0].ExitStatus != ContinueOnErrorExitStatus {
+		t.Fatalf("preparation failure pipeline = %s", output)
+	}
+}
+
 func TestEmitAggregateWorkflowGroups(t *testing.T) {
 	output, err := Emit(Pipeline{
 		CompilerStep:       "importer",
@@ -616,6 +643,95 @@ exit 1` || !step.Checkout.Skip {
 	}
 }
 
+func TestEmitAggregateExpandedJobPreparationFailures(t *testing.T) {
+	failure := func(name string) *Failure {
+		return &Failure{
+			AnnotationPath: ".buildkite-gha/failures/annotations/" + name + ".html",
+			MessagePath:    ".buildkite-gha/failures/messages/" + name + ".txt",
+			Summary:        name + " could not be compiled",
+		}
+	}
+	output, err := Emit(Pipeline{
+		CompilerStep: "importer", EventProvider: "github",
+		Workflows: []Workflow{{
+			GroupLabel: "Reusable CI", CheckName: "Reusable CI", GroupKey: "workflow-reusable", Event: "push",
+			Jobs: []Job{
+				{Key: "detect", Label: "call / Detect", CheckLabel: "call.detect", SkipReason: "Not run because another job in this workflow could not be compiled"},
+				{Key: "generator", Label: "call / Generator", CheckLabel: "call.generator", Dependencies: []string{"detect"}, Failure: failure("generator")},
+				{Key: "upload", Label: "call / Upload", CheckLabel: "call.upload", Dependencies: []string{"detect", "generator"}, Failure: failure("upload")},
+				{Key: "final", Label: "call / Final", CheckLabel: "call.final", Dependencies: []string{"detect", "generator", "upload"}, SkipReason: "Not run because a prerequisite job could not be compiled"},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	type dependency struct {
+		Step         string `yaml:"step"`
+		AllowFailure bool   `yaml:"allow_failure"`
+	}
+	var document struct {
+		Steps []struct {
+			Group     string `yaml:"group"`
+			DependsOn string `yaml:"depends_on"`
+			Steps     []struct {
+				Key       string       `yaml:"key"`
+				Skip      string       `yaml:"skip"`
+				Command   string       `yaml:"command"`
+				DependsOn []dependency `yaml:"depends_on"`
+				Plugins   []map[string]struct {
+					Download []struct {
+						From string `yaml:"from"`
+					} `yaml:"download"`
+				} `yaml:"plugins"`
+				Notify []struct {
+					GitHubCheck struct {
+						Name   string `yaml:"name"`
+						Output struct {
+							Title string `yaml:"title"`
+						} `yaml:"output"`
+					} `yaml:"github_check"`
+				} `yaml:"notify"`
+			} `yaml:"steps"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(output, &document); err != nil {
+		t.Fatal(err)
+	}
+	if len(document.Steps) != 1 || document.Steps[0].Group != ":github: workflow · Reusable CI" || document.Steps[0].DependsOn != "importer" || len(document.Steps[0].Steps) != 4 {
+		t.Fatalf("expanded preparation workflow = %#v\n%s", document.Steps, output)
+	}
+	detect, generator, upload, final := document.Steps[0].Steps[0], document.Steps[0].Steps[1], document.Steps[0].Steps[2], document.Steps[0].Steps[3]
+	if detect.Key != "detect" || detect.Skip == "" || detect.Command != "" || len(detect.Plugins) != 0 || detect.Notify[0].GitHubCheck.Name != "Reusable CI / call.detect (push)" {
+		t.Fatalf("independent skipped job = %#v", detect)
+	}
+	if generator.Key != "generator" || !strings.Contains(generator.Command, "exit 1") || len(generator.Plugins) != 1 || len(generator.DependsOn) != 1 || generator.DependsOn[0] != (dependency{Step: "detect", AllowFailure: true}) || generator.Notify[0].GitHubCheck.Output.Title != "Job could not be run" {
+		t.Fatalf("generator failure = %#v", generator)
+	}
+	if upload.Key != "upload" || len(upload.DependsOn) != 2 || upload.DependsOn[1] != (dependency{Step: "generator", AllowFailure: true}) || final.Key != "final" || final.Skip == "" || len(final.DependsOn) != 3 {
+		t.Fatalf("dependent preparation jobs = %#v / %#v", upload, final)
+	}
+	if strings.Contains(string(output), "run-job") || strings.Contains(string(output), "Prepare GitHub Actions runtime") {
+		t.Fatalf("preparation failure pipeline contains runnable job command:\n%s", output)
+	}
+}
+
+func TestEmitAllowsIndependentRunnableAndPreparationResultJobsTogether(t *testing.T) {
+	_, err := Emit(Pipeline{
+		CompilerStep: "importer", DistributionDigest: testDigest("distribution"), EventProvider: "github",
+		Workflows: []Workflow{{
+			GroupLabel: "CI", GroupKey: "workflow-ci", Event: "push", Condition: "true",
+			Jobs: []Job{
+				{Key: "runnable", Label: "Runnable", PlanDigest: testDigest("plan")},
+				{Key: "blocked", Label: "Blocked", SkipReason: "Workflow compilation failed"},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Emit() error = %v", err)
+	}
+}
+
 func TestEmitAggregateWorkflowConcurrencyDependencies(t *testing.T) {
 	pipeline := Pipeline{
 		CompilerStep:       "importer",
@@ -677,6 +793,47 @@ func TestEmitAggregateWorkflowConcurrencyDependencies(t *testing.T) {
 				t.Fatalf("aggregate child %q retains importer dependency: %#v", step.Key, step.DependsOn)
 			}
 		}
+	}
+}
+
+func TestPreparationResultsDoNotWaitForWorkflowConcurrency(t *testing.T) {
+	pipeline := Pipeline{
+		CompilerStep: "importer", DistributionDigest: testDigest("distribution"), EventProvider: "github",
+		Workflows: []Workflow{{
+			GroupLabel: "CI", GroupKey: "workflow-ci", Event: "push", Condition: "true",
+			ConcurrencyGate: &ConcurrencyGate{Group: "buildkite-gha/concurrency/ci"},
+			Jobs: []Job{
+				{Key: "failed", Label: "Failed", Failure: &Failure{AnnotationPath: "annotation", MessagePath: "message", Summary: "could not compile"}},
+				{Key: "runnable", Label: "Runnable", PlanDigest: testDigest("runnable")},
+			},
+		}},
+	}
+	output, err := Emit(pipeline)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document struct {
+		Steps []struct {
+			Steps []struct {
+				Key       string `yaml:"key"`
+				DependsOn []struct {
+					Step string `yaml:"step"`
+				} `yaml:"depends_on"`
+			} `yaml:"steps"`
+		} `yaml:"steps"`
+	}
+	if err := yaml.Unmarshal(output, &document); err != nil {
+		t.Fatal(err)
+	}
+	openKey, _ := concurrencyGateKeys("importer\x00workflow-ci", pipeline.Workflows[0].ConcurrencyGate.Group, pipeline.Workflows[0].Jobs)
+	dependencies := map[string][]string{}
+	for _, step := range document.Steps[0].Steps {
+		for _, dependency := range step.DependsOn {
+			dependencies[step.Key] = append(dependencies[step.Key], dependency.Step)
+		}
+	}
+	if slices.Contains(dependencies["failed"], openKey) || !slices.Contains(dependencies["runnable"], openKey) {
+		t.Fatalf("workflow concurrency dependencies = %#v\n%s", dependencies, output)
 	}
 }
 

--- a/internal/cli/environments_test.go
+++ b/internal/cli/environments_test.go
@@ -413,31 +413,62 @@ func uploadedPlanVars(t *testing.T, content []byte) map[string]string {
 	return job.EnvironmentVars
 }
 
-// TestRunUploadAgentResolutionFailureFailsClosed proves a disabled or failing
-// Agent API environments endpoint fails the upload with an actionable error
-// instead of degrading to an unprotected deployment.
-func TestRunUploadAgentResolutionFailureFailsClosed(t *testing.T) {
+// TestRunUploadAgentResolutionFailurePreservesExpandedJobs proves a disabled
+// or failing Agent API environments endpoint becomes a scoped failed job while
+// an independent job retains its runnable plan. The deployment never degrades
+// to an unprotected runnable job.
+func TestRunUploadAgentResolutionFailurePreservesExpandedJobs(t *testing.T) {
 	requireImporterHost(t)
 	agent, _ := agentEnvironmentsStub(t, "job-secret", http.StatusNotFound)
 	setAgentResolutionEnvironment(t, agent.URL)
 	t.Setenv("BUILDKITE", "true")
 	t.Setenv("BUILDKITE_STEP_KEY", "environment-agent-fail-importer")
 	workflow := filepath.Join(t.TempDir(), "deploy.yml")
-	if err := os.WriteFile(workflow, []byte(environmentUploadWorkflow), 0o600); err != nil {
+	source := `on: push
+jobs:
+  safe:
+    runs-on: ubuntu-latest
+    steps: [{run: echo safe}]
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+    steps: [{run: echo deploy}]
+`
+	if err := os.WriteFile(workflow, []byte(source), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	eventPath := filepath.Join("..", "..", "testdata", "smoke", "events", "push.json")
 
 	runner := &cliCaptureRunner{webhookErr: errors.New("metadata must not be read with --event-path")}
 	var stdout, stderr bytes.Buffer
-	if code := run([]string{"upload", "--event-path", eventPath, workflow}, &stdout, &stderr, "dev", runner); code == 0 {
-		t.Fatal("run() with failing environment resolution succeeded")
+	if code := run([]string{"upload", "--event-path", eventPath, workflow}, &stdout, &stderr, "dev", runner); code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
 	}
-	if want := "the Agent API does not offer GitHub environment resolution"; !strings.Contains(stderr.String(), want) {
-		t.Fatalf("stderr = %q, want %q", stderr.String(), want)
+	var plans int
+	var failureMessage string
+	for path, contents := range runner.uploaded {
+		switch {
+		case strings.Contains(path, "/plans/"):
+			plans++
+			job, err := plan.Decode(contents)
+			if err != nil || job.Workflow.LogicalJobID != "safe" {
+				t.Fatalf("independent plan = %#v, %v", job, err)
+			}
+		case strings.Contains(path, "/failures/messages/"):
+			failureMessage += string(contents)
+		}
 	}
-	if strings.Contains(stderr.String(), "token") {
-		t.Fatalf("stderr = %q, must not suggest a GitHub token", stderr.String())
+	if plans != 1 || !strings.Contains(failureMessage, "the Agent API does not offer GitHub environment resolution") {
+		t.Fatalf("plans = %d, failure message = %q", plans, failureMessage)
+	}
+	pipeline := string(runner.commands[len(runner.commands)-1].stdin)
+	for _, want := range []string{":github: job · safe", ":github: job · deploy", "run-job", ".buildkite-gha/failures/messages/"} {
+		if !strings.Contains(pipeline, want) {
+			t.Fatalf("pipeline missing %q:\n%s", want, pipeline)
+		}
+	}
+	if strings.Contains(stderr.String(), "token") || strings.Contains(failureMessage, "token") {
+		t.Fatalf("diagnostics must not suggest a GitHub token: stderr = %q, failure = %q", stderr.String(), failureMessage)
 	}
 }
 

--- a/internal/cli/hosted.go
+++ b/internal/cli/hosted.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -16,6 +15,7 @@ import (
 
 	actionintegration "github.com/buildkite/buildkite-gha/internal/action/integration"
 	actionsource "github.com/buildkite/buildkite-gha/internal/action/source"
+	buildkitepipeline "github.com/buildkite/buildkite-gha/internal/buildkite"
 	"github.com/buildkite/buildkite-gha/internal/compiler"
 	"github.com/buildkite/buildkite-gha/internal/plan"
 	gharuntime "github.com/buildkite/buildkite-gha/internal/runtime"
@@ -34,9 +34,10 @@ var runnerQueuePattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,255}$`)
 var runnerImagePattern = regexp.MustCompile(`^[a-z0-9]+(?:[._-][a-z0-9]+)*(?:/[a-z0-9]+(?:[._-][a-z0-9]+)*)+@sha256:[0-9a-f]{64}$`)
 
 type hostedCompilation struct {
-	Bundle     compiler.Bundle
-	HasActions bool
-	Admitted   bool
+	Bundle           compiler.Bundle
+	JobGraphComplete bool
+	HasActions       bool
+	Admitted         bool
 }
 
 type hostedFailureKind string
@@ -237,34 +238,60 @@ func compileHostedNamespacedWithActionCache(ctx context.Context, workflowPath st
 	}
 	defer cleanup()
 	options.RepositorySource = repositorySource
-	preflight, err := compiler.CompileWithOptionsContext(ctx, workflowPath, workflowSource, eventSource, options)
-	if err != nil {
-		return hostedCompilation{}, hostedError(hostedEvaluationFailure, err)
-	}
-	var ir compiler.IR
-	if err := json.Unmarshal(preflight, &ir); err != nil {
-		return hostedCompilation{}, hostedError(hostedEvaluationFailure, fmt.Errorf("decode compiler preflight: %w", err))
-	}
-	hasActions := irUsesActions(ir)
-	if hasActions {
-		options.ResolveActions = true
-		options.ActionSource = repositorySource
-	}
+	options.ResolveActions = true
+	options.ActionSource = repositorySource
 	bundle, err := compiler.CompileBundlePlansContext(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, options)
+	hasActions := irUsesActions(bundle.IR)
+	compiled := hostedCompilation{Bundle: bundle, JobGraphComplete: bundle.IR.JobGraphComplete, HasActions: hasActions}
 	if err != nil {
-		return hostedCompilation{Bundle: bundle, HasActions: hasActions}, hostedError(hostedEvaluationFailure, err)
+		if compiler.ErrorHasUnscopedFailure(err) {
+			compiled.Bundle = failedPartialBundle(bundle)
+			return compiled, hostedError(hostedEvaluationFailure, err)
+		}
+		if !bundle.IR.JobGraphComplete || len(bundle.Plans) == 0 {
+			return compiled, hostedError(hostedEvaluationFailure, err)
+		}
+		if !hasActions && bundleUsesActions(bundle) {
+			compiled.Bundle = failedPartialBundle(bundle)
+			return compiled, hostedError(hostedEvaluationFailure, errors.Join(err, errors.New("compilation introduced actions absent from the expanded workflow")))
+		}
+		if admissionErr := validateUnprivilegedBundle(bundle); admissionErr != nil {
+			compiled.Bundle = failedPartialBundle(bundle)
+			return compiled, hostedError(hostedEvaluationFailure, errors.Join(err, admissionErr))
+		}
+		generated, generationErr := compiler.GeneratePlannedWorkflow(bundle, options)
+		if generationErr != nil {
+			compiled.Bundle = failedPartialBundle(bundle)
+			return compiled, hostedError(hostedEvaluationFailure, errors.Join(err, generationErr))
+		}
+		bundle.GeneratedWorkflow = generated
+		compiled.Bundle = bundle
+		compiled.Admitted = true
+		return compiled, hostedError(hostedEvaluationFailure, err)
 	}
 	if err := validateUnprivilegedBundle(bundle); err != nil {
-		return hostedCompilation{Bundle: bundle, HasActions: hasActions}, hostedError(hostedAdmissionFailure, err)
+		return compiled, hostedError(hostedAdmissionFailure, err)
 	}
 	bundle, err = compiler.GenerateBundlePipeline(bundle, distributionDigest, importerStep, options)
 	if err != nil {
-		return hostedCompilation{Bundle: bundle, HasActions: hasActions, Admitted: true}, hostedError(hostedEvaluationFailure, err)
+		compiled.Bundle = bundle
+		compiled.Admitted = true
+		return compiled, hostedError(hostedEvaluationFailure, err)
 	}
-	if !hasActions && bundleUsesActions(bundle) {
-		return hostedCompilation{Bundle: bundle, HasActions: hasActions, Admitted: true}, hostedError(hostedEvaluationFailure, fmt.Errorf("final compilation introduced actions absent from preflight"))
+	compiled.Bundle = bundle
+	compiled.Admitted = true
+	return compiled, nil
+}
+
+func failedPartialBundle(bundle compiler.Bundle) compiler.Bundle {
+	bundle.Plans = nil
+	bundle.EventArtifact = nil
+	bundle.GeneratedWorkflow = buildkitepipeline.Workflow{}
+	bundle.JobOutcomes = make(map[string]compiler.JobOutcome, len(bundle.IR.Jobs))
+	for _, instance := range bundle.IR.Jobs {
+		bundle.JobOutcomes[instance.Key] = compiler.JobFailed
 	}
-	return hostedCompilation{Bundle: bundle, HasActions: hasActions, Admitted: true}, nil
+	return bundle
 }
 
 func newHostedActionSource(ctx context.Context, actionCacheDir, clientVersion string, resolverOptions, storeOptions []actionsource.Option) (compiler.ActionSource, func(), error) {

--- a/internal/cli/hosted_test.go
+++ b/internal/cli/hosted_test.go
@@ -17,10 +17,12 @@ import (
 
 	actionintegration "github.com/buildkite/buildkite-gha/internal/action/integration"
 	actionsource "github.com/buildkite/buildkite-gha/internal/action/source"
+	buildkitepipeline "github.com/buildkite/buildkite-gha/internal/buildkite"
 	"github.com/buildkite/buildkite-gha/internal/compatibility"
 	"github.com/buildkite/buildkite-gha/internal/compiler"
 	"github.com/buildkite/buildkite-gha/internal/plan"
 	"github.com/buildkite/buildkite-gha/internal/program"
+	"github.com/buildkite/buildkite-gha/internal/transport"
 	"go.yaml.in/yaml/v4"
 )
 
@@ -118,11 +120,77 @@ func TestHostedPreflightCompilesPublicReusableWorkflowWithSharedSource(t *testin
 	if err != nil {
 		t.Fatal(err)
 	}
-	if compiled.HasActions || len(compiled.Bundle.Plans) != 1 || compiled.Bundle.Plans[0].Job.Workflow.Remote == nil || compiled.Bundle.Plans[0].Job.Workflow.Remote.Commit != strings.Repeat("a", 40) {
+	if !compiled.JobGraphComplete || compiled.HasActions || len(compiled.Bundle.Plans) != 1 || compiled.Bundle.Plans[0].Job.Workflow.Remote == nil || compiled.Bundle.Plans[0].Job.Workflow.Remote.Commit != strings.Repeat("a", 40) {
 		t.Fatalf("hosted remote workflow result = %#v", compiled)
 	}
 	if source.calls != 1 {
 		t.Fatalf("repository source calls = %d, want one across hosted preflight and plans", source.calls)
+	}
+}
+
+func TestHostedPreflightDoesNotMarkPartialJobGraphComplete(t *testing.T) {
+	workflowPath := filepath.Join(t.TempDir(), ".github", "workflows", "partial.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	workflow := []byte(`on: push
+jobs:
+  known:
+    runs-on: ubuntu-latest
+    steps: [{run: true}]
+  unknown:
+    strategy:
+      matrix: ${{ github.ref }}
+    runs-on: ubuntu-latest
+    steps: [{run: true}]
+`)
+	if err := os.WriteFile(workflowPath, workflow, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	event, err := os.ReadFile(filepath.Join("..", "..", "testdata", "smoke", "events", "push.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := "sha256:" + strings.Repeat("d", 64)
+	compiled, err := compileHostedWithActionCache(t.Context(), workflowPath, workflow, event, "0.0.0-test", digest, "importer", "", nil, map[compiler.Platform]string{compiler.PlatformLinuxAMD64: digest}, "", nil, nil)
+	if err == nil {
+		t.Fatal("compileHostedWithActionCache() unexpectedly succeeded")
+	}
+	if compiled.JobGraphComplete || len(compiled.Bundle.IR.Jobs) != 1 || compiled.Bundle.IR.Jobs[0].LogicalJobID != "known" {
+		t.Fatalf("partial hosted compilation = %#v", compiled)
+	}
+}
+
+func TestHostedPreflightFailsClosedWhenEventArtifactCannotBeBuilt(t *testing.T) {
+	workflowPath := filepath.Join(t.TempDir(), ".github", "workflows", "event.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	workflow := []byte(`on: push
+jobs:
+  whole-event:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo '${{ toJSON(github.event) }}'
+`)
+	if err := os.WriteFile(workflowPath, workflow, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	event, err := json.Marshal(map[string]any{
+		"provider": "github", "event": "push", "ref": "refs/heads/main", "sha": strings.Repeat("1", 40), "actor": "octocat",
+		"repository": map[string]string{"owner": "buildkite", "name": "buildkite-gha", "clone_url": "https://github.com/buildkite/buildkite-gha.git", "default_branch": "main"},
+		"payload":    map[string]string{"body": strings.Repeat("x", plan.MaxEventPayloadBytes+1)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := "sha256:" + strings.Repeat("d", 64)
+	compiled, err := compileHostedWithActionCache(t.Context(), workflowPath, workflow, event, "0.0.0-test", digest, "importer", "", nil, map[compiler.Platform]string{compiler.PlatformLinuxAMD64: digest}, "", nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "event payload artifact exceeds") {
+		t.Fatalf("compileHostedWithActionCache() error = %v", err)
+	}
+	if !compiled.JobGraphComplete || len(compiled.Bundle.Plans) != 0 || compiled.Bundle.JobOutcomes[compiled.Bundle.IR.Jobs[0].Key] != compiler.JobFailed {
+		t.Fatalf("event artifact failure retained runnable work: %#v", compiled)
 	}
 }
 
@@ -199,7 +267,7 @@ runs:
 		t.Fatalf("actions = %#v, want both missing invocations failed", report.Actions)
 	}
 	for _, diagnostic := range report.Diagnostics {
-		if diagnostic.Instance == "" || diagnostic.Step == 0 || diagnostic.Code != compiler.CodeActionResolution || !strings.Contains(diagnostic.Message, `Action "`) || !strings.Contains(diagnostic.Message, "unsupported") {
+		if diagnostic.Instance == "" || diagnostic.Step == 0 || diagnostic.Action == "" || diagnostic.Code != compiler.CodeActionResolution {
 			t.Fatalf("diagnostic lacks invocation identity: %#v", diagnostic)
 		}
 	}
@@ -707,6 +775,49 @@ func TestUnprivilegedUploadRejectsCapabilities(t *testing.T) {
 		var finding *compiler.ProcessingFinding
 		if err == nil || !errors.As(err, &finding) || finding.Message != test.want || finding.Detail != "" {
 			t.Fatalf("validateUnprivilegedBundle(%q) error = %v, want capability rejection", capability, err)
+		}
+	}
+}
+
+func TestFailedPartialBundleRemovesEveryRunnableArtifact(t *testing.T) {
+	bundle := compiler.Bundle{
+		IR: compiler.IR{Jobs: []compiler.JobInstance{
+			{Key: "safe", LogicalJobID: "safe"},
+			{Key: "rejected", LogicalJobID: "rejected"},
+		}},
+		Plans:             []compiler.PlanArtifact{{Job: plan.Job{Target: plan.Target{StepKey: "safe"}}}},
+		EventArtifact:     &transport.Artifact{Path: "event"},
+		GeneratedWorkflow: buildkitepipeline.Workflow{Jobs: []buildkitepipeline.Job{{Key: "safe", PlanDigest: "sha256:" + strings.Repeat("1", 64)}}},
+		JobOutcomes: map[string]compiler.JobOutcome{
+			"safe": compiler.JobPlanned, "rejected": compiler.JobFailed,
+		},
+	}
+
+	failed := failedPartialBundle(bundle)
+	if len(failed.Plans) != 0 || failed.EventArtifact != nil || len(failed.GeneratedWorkflow.Jobs) != 0 {
+		t.Fatalf("failed partial bundle retained runnable artifacts: %#v", failed)
+	}
+	for _, instance := range failed.IR.Jobs {
+		if failed.JobOutcomes[instance.Key] != compiler.JobFailed {
+			t.Fatalf("outcome for %q = %q, want failed", instance.Key, failed.JobOutcomes[instance.Key])
+		}
+	}
+}
+
+func TestPreparationAdmissionFailureDiscardsIndependentPlan(t *testing.T) {
+	compilation := hostedCompilation{JobGraphComplete: true, Bundle: compiler.Bundle{
+		IR:          compiler.IR{Jobs: []compiler.JobInstance{{Key: "safe"}, {Key: "rejected"}}},
+		Plans:       []compiler.PlanArtifact{{Job: plan.Job{Target: plan.Target{StepKey: "safe"}}}},
+		JobOutcomes: map[string]compiler.JobOutcome{"safe": compiler.JobPlanned, "rejected": compiler.JobFailed},
+	}}
+	admissionErr := errors.New("rejected capability")
+	failed, err := failClosedForPreparationAdmission(compilation, errors.New("missing macOS runtime"), admissionErr)
+	if err == nil || !strings.Contains(err.Error(), admissionErr.Error()) || len(failed.Bundle.Plans) != 0 {
+		t.Fatalf("failClosedForPreparationAdmission() = %#v, %v", failed, err)
+	}
+	for _, outcome := range failed.Bundle.JobOutcomes {
+		if outcome != compiler.JobFailed {
+			t.Fatalf("fail-closed outcome = %q", outcome)
 		}
 	}
 }

--- a/internal/cli/runtime_distribution_test.go
+++ b/internal/cli/runtime_distribution_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/buildkite/buildkite-gha/internal/compiler"
+	"github.com/buildkite/buildkite-gha/internal/plan"
 	"github.com/buildkite/buildkite-gha/internal/transport"
 )
 
@@ -80,6 +81,107 @@ func TestDarwinUploadRequiresLinuxDistributionForLinuxWorkflow(t *testing.T) {
 	}
 	if len(runner.uploaded) != 0 {
 		t.Fatalf("missing runtime reached artifact upload: %#v", runner.uploaded)
+	}
+}
+
+func TestRequiredRuntimePlatformsExcludesFailedJobDependencyClosure(t *testing.T) {
+	workflowPath := filepath.Join(t.TempDir(), "mixed.yml")
+	source := []byte(`on: push
+jobs:
+  safe:
+    runs-on: ubuntu-latest
+    steps: [{run: echo safe}]
+  deploy:
+    runs-on: macos-latest
+    environment: production
+    steps: [{run: echo deploy}]
+  blocked:
+    needs: deploy
+    runs-on: macos-latest
+    steps: [{run: echo blocked}]
+`)
+	if err := os.WriteFile(workflowPath, source, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	event, err := os.ReadFile(filepath.Join("..", "..", "testdata", "smoke", "events", "push.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	targets := map[string]compiler.RunnerTarget{
+		"ubuntu-latest": {Queue: "linux", Platform: compiler.PlatformLinuxAMD64},
+		"macos-latest":  {Queue: "macos", Platform: compiler.PlatformDarwinARM64},
+	}
+	platforms, admissionErr, err := requiredRuntimePlatforms(t.Context(), workflowPath, source, event, "dev", "sha256:"+strings.Repeat("1", 64), "", targets, agentRunnerResolution{}, nil, nil, compiler.VariableSources{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if admissionErr != nil {
+		t.Fatal(admissionErr)
+	}
+	if !platforms[compiler.PlatformLinuxAMD64] || platforms[compiler.PlatformDarwinARM64] || len(platforms) != 1 {
+		t.Fatalf("required runtime platforms = %#v", platforms)
+	}
+}
+
+func TestRequiredRuntimePlatformsExcludesLaterActionFailure(t *testing.T) {
+	workflowPath := filepath.Join(t.TempDir(), ".github", "workflows", "mixed.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	source := []byte(`on: push
+jobs:
+  safe:
+    runs-on: ubuntu-latest
+    steps: [{run: echo safe}]
+  broken:
+    runs-on: macos-latest
+    steps:
+      - uses: ./.github/actions/missing
+`)
+	if err := os.WriteFile(workflowPath, source, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	event, err := os.ReadFile(filepath.Join("..", "..", "testdata", "smoke", "events", "push.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	targets := map[string]compiler.RunnerTarget{
+		"ubuntu-latest": {Queue: "linux", Platform: compiler.PlatformLinuxAMD64},
+		"macos-latest":  {Queue: "macos", Platform: compiler.PlatformDarwinARM64},
+	}
+	platforms, admissionErr, err := requiredRuntimePlatforms(t.Context(), workflowPath, source, event, "dev", "sha256:"+strings.Repeat("1", 64), "", targets, agentRunnerResolution{}, nil, nil, compiler.VariableSources{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if admissionErr != nil {
+		t.Fatal(admissionErr)
+	}
+	if !platforms[compiler.PlatformLinuxAMD64] || platforms[compiler.PlatformDarwinARM64] || len(platforms) != 1 {
+		t.Fatalf("required runtime platforms = %#v", platforms)
+	}
+}
+
+func TestRequiredRuntimePlatformsFailsClosedBeforePartialAdmission(t *testing.T) {
+	bundle := compiler.Bundle{
+		IR: compiler.IR{Jobs: []compiler.JobInstance{
+			{Key: "safe", Platform: compiler.PlatformLinuxAMD64},
+			{Key: "rejected", Platform: compiler.PlatformDarwinARM64},
+		}},
+		JobOutcomes: map[string]compiler.JobOutcome{"safe": compiler.JobPlanned, "rejected": compiler.JobPlanned},
+		Plans: []compiler.PlanArtifact{
+			{Job: plan.Job{Target: plan.Target{StepKey: "safe"}}},
+			{Job: plan.Job{Workflow: plan.Workflow{LogicalJobID: "rejected"}, Target: plan.Target{StepKey: "rejected"}, RequiredCapabilities: []string{"privileged-container"}}},
+		},
+	}
+	platforms, admissionErr, err := runtimePlatformsForBundle(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if admissionErr == nil {
+		t.Fatal("requiredRuntimePlatforms() admission error = nil")
+	}
+	if len(platforms) != 0 {
+		t.Fatalf("partial admission requested runtime platforms = %#v, want fail-closed empty set", platforms)
 	}
 }
 

--- a/internal/cli/upload.go
+++ b/internal/cli/upload.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -14,6 +13,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sort"
 	"strings"
 	"syscall"
@@ -333,15 +333,17 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 	importerDistribution := runtimeDistribution{contents: executableContents, digest: distributionDigest}
 	seedUploadEnvironmentResolutions(ctx, uploadArguments.environmentSource, workflows, validations, processingReports, effectiveEvent.Event)
 	requiredPlatforms := make(map[compiler.Platform]bool, 2)
+	preparationAdmissionFailures := make([]error, len(workflows))
 	for i, input := range workflows {
 		if !input.Applicable || processingReportHasErrors(processingReports[i]) {
 			continue
 		}
-		platforms, platformErr := requiredRuntimePlatforms(ctx, input.Path, input.Source, effectiveEvent.Source, "", uploadArguments.runnerTargets, uploadArguments.runnerResolution, repositorySource, uploadArguments.environmentSource, vars)
+		platforms, admissionErr, platformErr := requiredRuntimePlatforms(ctx, input.Path, input.Source, effectiveEvent.Source, version, distributionDigest, "", uploadArguments.runnerTargets, uploadArguments.runnerResolution, repositorySource, uploadArguments.environmentSource, vars)
 		if platformErr != nil {
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: %v\n", platformErr)
 			return 1
 		}
+		preparationAdmissionFailures[i] = admissionErr
 		for platform := range platforms {
 			requiredPlatforms[platform] = true
 		}
@@ -352,7 +354,7 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: plugin: %v\n", acquireErr)
 			return 1
 		}
-		return finishUpload(ctx, uploadArguments, stdout, stderr, version, agent, workflows, effectiveEvent, executablePath, distributionDigest, importerStep, importerJobID, processingReports, out, runtimeDistributions, repositorySource, authentication, vars)
+		return finishUpload(ctx, uploadArguments, stdout, stderr, version, agent, workflows, effectiveEvent, executablePath, distributionDigest, importerStep, importerJobID, processingReports, out, runtimeDistributions, repositorySource, authentication, vars, preparationAdmissionFailures)
 	}
 	requiredDistributionPaths := make(map[compiler.Platform]string, len(requiredPlatforms))
 	for platform := range requiredPlatforms {
@@ -381,10 +383,10 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: upload: runtime distribution for %s is required by the selected workflows\n", platform)
 		return 1
 	}
-	return finishUpload(ctx, uploadArguments, stdout, stderr, version, agent, workflows, effectiveEvent, executablePath, distributionDigest, importerStep, importerJobID, processingReports, out, runtimeDistributions, repositorySource, authentication, vars)
+	return finishUpload(ctx, uploadArguments, stdout, stderr, version, agent, workflows, effectiveEvent, executablePath, distributionDigest, importerStep, importerJobID, processingReports, out, runtimeDistributions, repositorySource, authentication, vars, preparationAdmissionFailures)
 }
 
-func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout, stderr io.Writer, version string, agent transport.Agent, workflows []workflowInput, effectiveEvent effectiveEventSelection, executablePath, distributionDigest, importerStep, importerJobID string, processingReports []compatibility.ProcessingReport, out processingOutput, runtimeDistributions map[compiler.Platform]runtimeDistribution, repositorySource compiler.RepositorySource, authentication *actionSourceAuthentication, vars compiler.VariableSources) int {
+func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout, stderr io.Writer, version string, agent transport.Agent, workflows []workflowInput, effectiveEvent effectiveEventSelection, executablePath, distributionDigest, importerStep, importerJobID string, processingReports []compatibility.ProcessingReport, out processingOutput, runtimeDistributions map[compiler.Platform]runtimeDistribution, repositorySource compiler.RepositorySource, authentication *actionSourceAuthentication, vars compiler.VariableSources, preparationAdmissionFailures []error) int {
 	runtimeDigests := make(map[compiler.Platform]string, len(runtimeDistributions))
 	for platform, runtimeDistribution := range runtimeDistributions {
 		runtimeDigests[platform] = runtimeDistribution.digest
@@ -441,18 +443,28 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 			return compileHostedNamespacedWithActionCache(ctx, input.Path, input.Source, effectiveEvent.Source, version, distributionDigest, bundleCompilerStep, "", uploadArguments.runnerTargets, uploadArguments.runnerResolution, runtimeDigests, input.StepKeyNamespace, uploadArguments.oidc, "", repositorySource, authentication, uploadArguments.environmentSource, vars)
 		}
 		preflight, err := compileWorkflow(vars)
-		if err == nil {
+		preflight, err = failClosedForPreparationAdmission(preflight, err, preparationAdmissionFailures[i])
+		if err == nil || len(preflight.Bundle.Plans) != 0 {
 			actionVars, again, varsErr := resolveActionVariables(ctx, uploadArguments.variableSource, effectiveEvent.Event, input.ReferencesVars, preflight.Bundle)
 			if varsErr != nil {
 				processingReports[i].AddEnvironmentFailure(varsErr.Error())
 				processingReports[i].Result = "indeterminate"
-				failed, artifacts := failedGeneratedWorkflow(input, effectiveEvent.Event.Event, processingReports[i], out.sourceLinks)
+				preflight.Bundle = failedPartialBundle(preflight.Bundle)
+				failed, artifacts := failedExpandedGeneratedWorkflow(input, effectiveEvent.Event.Event, processingReports[i], out.sourceLinks, preflight.Bundle, false)
 				generatedWorkflows = append(generatedWorkflows, failed)
 				failureArtifacts = append(failureArtifacts, artifacts...)
+				jobCount += len(failed.Jobs)
 				continue
 			}
 			if again {
+				first := preflight
+				firstErr := err
 				preflight, err = compileWorkflow(actionVars)
+				if !preflight.JobGraphComplete || !sameExpandedJobGraph(first.Bundle.IR, preflight.Bundle.IR) {
+					first.Bundle = failedPartialBundle(first.Bundle)
+					preflight = first
+					err = errors.Join(firstErr, err, errors.New("action-variable recompilation did not preserve the expanded job graph"))
+				}
 			}
 		}
 		applyHostedPreflight(&processingReports[i], preflight)
@@ -461,8 +473,22 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 			var failure *hostedFailure
 			if errors.As(err, &failure) && failure.Kind == hostedEvaluationFailure {
 				failed, artifacts := failedGeneratedWorkflow(input, effectiveEvent.Event.Event, processingReports[i], out.sourceLinks)
+				if preflight.JobGraphComplete && len(preflight.Bundle.IR.Jobs) != 0 {
+					failed, artifacts = failedExpandedGeneratedWorkflow(input, effectiveEvent.Event.Event, processingReports[i], out.sourceLinks, preflight.Bundle, true)
+				}
 				generatedWorkflows = append(generatedWorkflows, failed)
 				failureArtifacts = append(failureArtifacts, artifacts...)
+				runnablePlans := runnablePlanArtifacts(preflight.Bundle)
+				planArtifacts = append(planArtifacts, runnablePlans...)
+				if len(runnablePlans) != 0 && preflight.Bundle.EventArtifact != nil {
+					if eventArtifact != nil && (eventArtifact.Path != preflight.Bundle.EventArtifact.Path || eventArtifact.Digest != preflight.Bundle.EventArtifact.Digest || !bytes.Equal(eventArtifact.Contents, preflight.Bundle.EventArtifact.Contents)) {
+						_, _ = fmt.Fprintln(stderr, "buildkite-gha: upload: compiled workflows produced different event payload artifacts")
+						return 1
+					}
+					artifact := *preflight.Bundle.EventArtifact
+					eventArtifact = &artifact
+				}
+				jobCount += len(failed.Jobs)
 				continue
 			}
 			_ = out.write(ctx, processingReports[i])
@@ -611,6 +637,42 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 	return 0
 }
 
+func failClosedForPreparationAdmission(compilation hostedCompilation, compileErr, admissionErr error) (hostedCompilation, error) {
+	if admissionErr == nil {
+		return compilation, compileErr
+	}
+	compilation.Bundle = failedPartialBundle(compilation.Bundle)
+	return compilation, hostedError(hostedEvaluationFailure, errors.Join(compileErr, admissionErr))
+}
+
+func sameExpandedJobGraph(left, right compiler.IR) bool {
+	if !left.JobGraphComplete || !right.JobGraphComplete || len(left.Jobs) != len(right.Jobs) {
+		return false
+	}
+	for i := range left.Jobs {
+		if left.Jobs[i].Key != right.Jobs[i].Key || !slices.Equal(left.Jobs[i].Needs, right.Jobs[i].Needs) {
+			return false
+		}
+	}
+	return true
+}
+
+func runnablePlanArtifacts(bundle compiler.Bundle) []compiler.PlanArtifact {
+	runnable := make(map[string]bool, len(bundle.GeneratedWorkflow.Jobs))
+	for _, job := range bundle.GeneratedWorkflow.Jobs {
+		if job.Failure == nil && job.SkipReason == "" {
+			runnable[job.Key] = true
+		}
+	}
+	artifacts := make([]compiler.PlanArtifact, 0, len(runnable))
+	for _, artifact := range bundle.Plans {
+		if runnable[artifact.Job.Target.StepKey] {
+			artifacts = append(artifacts, artifact)
+		}
+	}
+	return artifacts
+}
+
 func processingReportHasErrors(report compatibility.ProcessingReport) bool {
 	for _, diagnostic := range report.Diagnostics {
 		if diagnostic.Level == "error" {
@@ -626,6 +688,93 @@ func failedGeneratedWorkflow(input workflowInput, event string, report compatibi
 		checkName = input.CanonicalPath
 	}
 	label := workflowGroupLabel(checkName, input.RunName)
+	failure, artifacts := generatedFailure(report, sourceLinks)
+	workflow := buildkitepipeline.Workflow{
+		GroupLabel: label,
+		CheckName:  checkName,
+		GroupKey:   "gha-workflow-" + input.Identity,
+		Event:      event,
+		Failure:    failure,
+	}
+	return workflow, artifacts
+}
+
+func failedExpandedGeneratedWorkflow(input workflowInput, event string, report compatibility.ProcessingReport, sourceLinks sourceLinkContext, bundle compiler.Bundle, keepRunnable bool) (buildkitepipeline.Workflow, []transport.Artifact) {
+	ir := bundle.IR
+	checkName := ir.Workflow.Name
+	if checkName == "" {
+		checkName = input.CanonicalPath
+	}
+	workflow := buildkitepipeline.Workflow{
+		GroupLabel: workflowGroupLabel(checkName, ir.Workflow.RunName),
+		CheckName:  checkName,
+		GroupKey:   "gha-workflow-" + input.Identity,
+		Event:      event,
+		Condition:  input.TriggerCondition,
+		Jobs:       compiler.ExpandedWorkflowJobs(ir),
+	}
+	runnable := make(map[string]buildkitepipeline.Job, len(bundle.GeneratedWorkflow.Jobs))
+	if keepRunnable {
+		workflow.ConcurrencyGate = bundle.GeneratedWorkflow.ConcurrencyGate
+		workflow.ApprovalGates = bundle.GeneratedWorkflow.ApprovalGates
+		for _, job := range bundle.GeneratedWorkflow.Jobs {
+			runnable[job.Key] = job
+		}
+	}
+	artifacts := make([]transport.Artifact, 0, 2*len(ir.Jobs))
+	for i, instance := range ir.Jobs {
+		switch bundle.JobOutcomes[instance.Key] {
+		case compiler.JobPlanned:
+			if job, exists := runnable[instance.Key]; exists {
+				workflow.Jobs[i] = job
+				continue
+			}
+			failure, generated := generatedFailure(report, sourceLinks)
+			workflow.Jobs[i].Failure = failure
+			workflow.Jobs[i].SoftFail = instance.ContinueOnError
+			artifacts = append(artifacts, generated...)
+		case compiler.JobFailed:
+			jobReport := processingReportForExpandedJob(report, instance)
+			if !processingReportHasErrors(jobReport) {
+				jobReport = report
+			}
+			failure, generated := generatedFailure(jobReport, sourceLinks)
+			workflow.Jobs[i].Failure = failure
+			workflow.Jobs[i].SoftFail = instance.ContinueOnError
+			artifacts = append(artifacts, generated...)
+		case compiler.JobBlocked:
+			workflow.Jobs[i].SkipReason = "Not run because a prerequisite job could not be compiled"
+		default:
+			workflow.Jobs[i].SkipReason = "Not run because no safe compiled plan was available"
+		}
+	}
+	return workflow, artifacts
+}
+
+func processingReportForExpandedJob(report compatibility.ProcessingReport, instance compiler.JobInstance) compatibility.ProcessingReport {
+	filtered := report
+	filtered.Jobs = nil
+	for _, result := range report.Jobs {
+		if result.Instance == instance.Key || result.Instance == "" && result.ID == instance.LogicalJobID {
+			filtered.Jobs = append(filtered.Jobs, result)
+		}
+	}
+	filtered.Actions = nil
+	for _, action := range report.Actions {
+		if action.Job == instance.Key {
+			filtered.Actions = append(filtered.Actions, action)
+		}
+	}
+	filtered.Diagnostics = nil
+	for _, diagnostic := range report.Diagnostics {
+		if diagnostic.Instance == instance.Key || diagnostic.Instance == "" && (diagnostic.Job == "" || diagnostic.Job == instance.LogicalJobID || diagnostic.Job == instance.Key) {
+			filtered.Diagnostics = append(filtered.Diagnostics, diagnostic)
+		}
+	}
+	return filtered
+}
+
+func generatedFailure(report compatibility.ProcessingReport, sourceLinks sourceLinkContext) (*buildkitepipeline.Failure, []transport.Artifact) {
 	report.Diagnostics = append([]compatibility.Diagnostic(nil), report.Diagnostics...)
 	report.Finalize()
 	messages := make([]string, 0, len(report.Diagnostics))
@@ -653,18 +802,12 @@ func failedGeneratedWorkflow(input workflowInput, event string, report compatibi
 	_, checkSummary := processingAnnotationWithin(report, sourceLinks, workflowCheckSummaryLimit, workflowCheckSummaryNotice, false)
 	messageArtifact := generatedFailureArtifact("messages", ".txt", "\x1b[31m"+strings.Join(messages, "\n")+"\x1b[0m\n")
 	annotationArtifact := generatedFailureArtifact("annotations", ".html", annotation)
-	workflow := buildkitepipeline.Workflow{
-		GroupLabel: label,
-		CheckName:  checkName,
-		GroupKey:   "gha-workflow-" + input.Identity,
-		Event:      event,
-		Failure: &buildkitepipeline.Failure{
-			AnnotationPath: annotationArtifact.Path,
-			MessagePath:    messageArtifact.Path,
-			Summary:        checkSummary,
-		},
+	failure := &buildkitepipeline.Failure{
+		AnnotationPath: annotationArtifact.Path,
+		MessagePath:    messageArtifact.Path,
+		Summary:        checkSummary,
 	}
-	return workflow, []transport.Artifact{messageArtifact, annotationArtifact}
+	return failure, []transport.Artifact{messageArtifact, annotationArtifact}
 }
 
 func workflowGroupLabel(workflowName, runName string) string {
@@ -681,29 +824,34 @@ func generatedFailureArtifact(kind, extension, contents string) transport.Artifa
 	return transport.Artifact{Path: path, Digest: digest, Contents: encoded}
 }
 
-func requiredRuntimePlatforms(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runnerResolution agentRunnerResolution, repositorySource compiler.RepositorySource, environmentSource compiler.EnvironmentSource, vars compiler.VariableSources) (map[compiler.Platform]bool, error) {
-	options := hostedOptions(groupLabel, configuredTargets, nil)
+func requiredRuntimePlatforms(ctx context.Context, workflowPath string, workflowSource, eventSource []byte, version, distributionDigest, groupLabel string, configuredTargets map[string]compiler.RunnerTarget, runnerResolution agentRunnerResolution, repositorySource compiler.RepositorySource, environmentSource compiler.EnvironmentSource, vars compiler.VariableSources) (map[compiler.Platform]bool, error, error) {
+	runtimeDigests := map[compiler.Platform]string{
+		compiler.PlatformLinuxAMD64:  distributionDigest,
+		compiler.PlatformDarwinARM64: distributionDigest,
+	}
+	options := hostedOptions(groupLabel, configuredTargets, runtimeDigests)
 	options.Vars = vars
 	applyRunnerResolution(&options, runnerResolution)
 	options.RepositorySource = repositorySource
+	options.ResolveActions = true
+	options.ActionSource = repositorySource
 	options.EnvironmentSource = environmentSource
-	preflight, err := compiler.CompileWithOptionsContext(ctx, workflowPath, workflowSource, eventSource, options)
-	if err != nil {
-		return nil, err
-	}
-	var ir compiler.IR
-	if err := json.Unmarshal(preflight, &ir); err != nil {
-		return nil, fmt.Errorf("decode compiler preflight: %w", err)
-	}
+	bundle, _ := compiler.CompileBundlePlansContext(ctx, workflowPath, workflowSource, eventSource, version, distributionDigest, options)
+	return runtimePlatformsForBundle(bundle)
+}
+
+func runtimePlatformsForBundle(bundle compiler.Bundle) (map[compiler.Platform]bool, error, error) {
 	platforms := make(map[compiler.Platform]bool, 2)
-	for _, job := range ir.Jobs {
-		target, err := options.Runners.Resolve(job.RunsOn, options.EventTrust)
-		if err != nil {
-			return nil, fmt.Errorf("resolve runtime platform for job %q: %w", job.LogicalJobID, err)
-		}
-		platforms[target.Platform] = true
+	if err := validateUnprivilegedBundle(bundle); err != nil {
+		return platforms, err, nil
 	}
-	return platforms, nil
+	for _, job := range bundle.IR.Jobs {
+		if bundle.JobOutcomes[job.Key] != compiler.JobPlanned {
+			continue
+		}
+		platforms[job.Platform] = true
+	}
+	return platforms, nil, nil
 }
 
 type workflowInput struct {

--- a/internal/cli/upload_test.go
+++ b/internal/cli/upload_test.go
@@ -1221,6 +1221,89 @@ func TestFailedGeneratedWorkflowIncludesWarnings(t *testing.T) {
 	}
 }
 
+func TestFailedExpandedGeneratedWorkflowKeepsJobGraphAndScopesDiagnostics(t *testing.T) {
+	ir := compiler.IR{
+		Workflow: compiler.WorkflowSource{Name: "Reusable CI"},
+		Jobs: []compiler.JobInstance{
+			{Key: "gha-detect", LogicalJobID: "call.detect", Label: "call / Detect"},
+			{Key: "gha-generator", LogicalJobID: "call.generator", Label: "call / Generator", Needs: []string{"gha-detect"}},
+			{Key: "gha-upload", LogicalJobID: "call.upload", Label: "call / Upload", Needs: []string{"gha-detect", "gha-generator"}},
+			{Key: "gha-final", LogicalJobID: "call.final", Label: "call / Final", Needs: []string{"gha-detect", "gha-generator", "gha-upload"}},
+		},
+	}
+	report := compatibility.NewProcessingReport("owner/repo/.github/workflows/reusable.yml@v1", "hosted")
+	report.Diagnostics = append(report.Diagnostics,
+		compatibility.Diagnostic{Level: "error", Code: compiler.CodeActionResolution, Message: "generator action is unavailable", Job: "call.generator", Instance: "gha-generator", Step: 1},
+		compatibility.Diagnostic{Level: "error", Code: compiler.CodeActionResolution, Message: "generator child is unavailable", Job: "call.generator", Instance: "gha-generator", Step: 2},
+		compatibility.Diagnostic{Level: "error", Code: compiler.CodeActionResolution, Message: "upload action is unavailable", Job: "call.upload", Instance: "gha-upload", Step: 1},
+	)
+
+	bundle := compiler.Bundle{
+		IR: ir,
+		JobOutcomes: map[string]compiler.JobOutcome{
+			"gha-detect": compiler.JobPlanned, "gha-generator": compiler.JobFailed,
+			"gha-upload": compiler.JobFailed, "gha-final": compiler.JobBlocked,
+		},
+		GeneratedWorkflow: buildkitepipeline.Workflow{Jobs: []buildkitepipeline.Job{{
+			Key: "gha-detect", Label: "call / Detect", CheckLabel: "call.detect", PlanDigest: "sha256:" + strings.Repeat("1", 64),
+		}}},
+	}
+	workflow, artifacts := failedExpandedGeneratedWorkflow(workflowInput{CanonicalPath: ".github/workflows/caller.yml", Identity: "caller", TriggerCondition: "true"}, "push", report, sourceLinkContext{}, bundle, true)
+	if workflow.Failure != nil || workflow.Condition != "true" || workflow.GroupLabel != "Reusable CI" || len(workflow.Jobs) != 4 || len(artifacts) != 4 {
+		t.Fatalf("expanded failure workflow = %#v, artifacts = %#v", workflow, artifacts)
+	}
+	detect, generator, upload, final := workflow.Jobs[0], workflow.Jobs[1], workflow.Jobs[2], workflow.Jobs[3]
+	if detect.Key != "gha-detect" || detect.SkipReason != "" || detect.Failure != nil || detect.PlanDigest == "" {
+		t.Fatalf("independent job = %#v", detect)
+	}
+	if generator.Failure == nil || !reflect.DeepEqual(generator.Dependencies, []string{"gha-detect"}) || upload.Failure == nil || !reflect.DeepEqual(upload.Dependencies, []string{"gha-detect", "gha-generator"}) {
+		t.Fatalf("direct failures = %#v / %#v", generator, upload)
+	}
+	if final.Failure != nil || final.SkipReason != "Not run because a prerequisite job could not be compiled" || !reflect.DeepEqual(final.Dependencies, []string{"gha-detect", "gha-generator", "gha-upload"}) {
+		t.Fatalf("blocked dependent = %#v", final)
+	}
+	contents := make(map[string]string, len(artifacts))
+	for _, artifact := range artifacts {
+		contents[artifact.Path] = string(artifact.Contents)
+	}
+	generatorMessage := contents[generator.Failure.MessagePath]
+	uploadMessage := contents[upload.Failure.MessagePath]
+	if !strings.Contains(generatorMessage, "generator action is unavailable") || !strings.Contains(generatorMessage, "generator child is unavailable") || strings.Contains(generatorMessage, "upload action is unavailable") {
+		t.Fatalf("generator diagnostics = %q", generatorMessage)
+	}
+	if !strings.Contains(uploadMessage, "upload action is unavailable") || strings.Contains(uploadMessage, "generator action is unavailable") {
+		t.Fatalf("upload diagnostics = %q", uploadMessage)
+	}
+}
+
+func TestFailedExpandedGeneratedWorkflowFallsBackForUnmatchedDiagnostic(t *testing.T) {
+	ir := compiler.IR{Workflow: compiler.WorkflowSource{Name: "CI"}, Jobs: []compiler.JobInstance{{Key: "gha-test", LogicalJobID: "test", Label: "test"}}}
+	report := compatibility.NewProcessingReport("ci.yml", "hosted")
+	report.Diagnostics = append(report.Diagnostics, compatibility.Diagnostic{Level: "error", Code: "E_TEST", Message: "compiler failed", Job: "unmatched"})
+	bundle := compiler.Bundle{IR: ir, JobOutcomes: map[string]compiler.JobOutcome{"gha-test": compiler.JobFailed}}
+	workflow, artifacts := failedExpandedGeneratedWorkflow(workflowInput{CanonicalPath: "ci.yml", Identity: "ci", TriggerCondition: "true"}, "push", report, sourceLinkContext{}, bundle, true)
+	if len(workflow.Jobs) != 1 || workflow.Jobs[0].Failure == nil || workflow.Jobs[0].Failure.Summary == "" {
+		t.Fatalf("workflow = %#v", workflow)
+	}
+	if _, err := buildkitepipeline.Emit(buildkitepipeline.Pipeline{CompilerStep: "importer", EventProvider: "github", Workflows: []buildkitepipeline.Workflow{workflow}}); err != nil {
+		t.Fatalf("Emit() error = %v, artifacts = %#v", err, artifacts)
+	}
+}
+
+func TestFailedExpandedGeneratedWorkflowDegradesPlannedJobWithoutGeneratedPlan(t *testing.T) {
+	ir := compiler.IR{Workflow: compiler.WorkflowSource{Name: "CI"}, Jobs: []compiler.JobInstance{{Key: "gha-test", LogicalJobID: "test", Label: "test"}}}
+	report := compatibility.NewProcessingReport("ci.yml", "hosted")
+	report.Diagnostics = append(report.Diagnostics, compatibility.Diagnostic{Level: "error", Code: "E_PIPELINE", Message: "pipeline generation failed"})
+	bundle := compiler.Bundle{IR: ir, JobOutcomes: map[string]compiler.JobOutcome{"gha-test": compiler.JobPlanned}}
+	workflow, _ := failedExpandedGeneratedWorkflow(workflowInput{CanonicalPath: "ci.yml", Identity: "ci", TriggerCondition: "true"}, "push", report, sourceLinkContext{}, bundle, true)
+	if len(workflow.Jobs) != 1 || workflow.Jobs[0].Failure == nil {
+		t.Fatalf("workflow = %#v", workflow)
+	}
+	if _, err := buildkitepipeline.Emit(buildkitepipeline.Pipeline{CompilerStep: "importer", EventProvider: "github", Workflows: []buildkitepipeline.Workflow{workflow}}); err != nil {
+		t.Fatalf("Emit() error = %v", err)
+	}
+}
+
 func TestFailedGeneratedWorkflowKeepsLargeDiagnosticsOutOfCommand(t *testing.T) {
 	message := strings.Repeat("large diagnostic ", 16*1024)
 	report := compatibility.NewProcessingReport("ci.yml", "hosted")
@@ -1537,9 +1620,10 @@ func TestRunUploadContinuesAfterWorkflowCompilationFailures(t *testing.T) {
 			Command string             `yaml:"command"`
 			Plugins failureStepPlugins `yaml:"plugins"`
 			Steps   []struct {
-				Label   string `yaml:"label"`
-				Key     string `yaml:"key"`
-				Command string `yaml:"command"`
+				Label   string             `yaml:"label"`
+				Key     string             `yaml:"key"`
+				Command string             `yaml:"command"`
+				Plugins failureStepPlugins `yaml:"plugins"`
 			} `yaml:"steps"`
 		} `yaml:"steps"`
 	}
@@ -1549,11 +1633,12 @@ func TestRunUploadContinuesAfterWorkflowCompilationFailures(t *testing.T) {
 	if len(pipeline.Steps) != 3 {
 		t.Fatalf("aggregate pipeline groups = %#v", pipeline.Steps)
 	}
-	wantFailureLabels := []string{":github: workflow · Invalid", ":github: workflow · Missing action"}
-	for i, step := range pipeline.Steps[:2] {
-		if step.Group != "" || len(step.Steps) != 0 || step.Label != wantFailureLabels[i] || !isGeneratedFailureCommand(step.Command) {
-			t.Fatalf("failed workflow step %d = %#v", i, step)
-		}
+	if invalid := pipeline.Steps[0]; invalid.Group != "" || len(invalid.Steps) != 0 || invalid.Label != ":github: workflow · Invalid" || !isGeneratedFailureCommand(invalid.Command) {
+		t.Fatalf("failed workflow step 0 = %#v", invalid)
+	}
+	missing := pipeline.Steps[1]
+	if missing.Group != ":github: workflow · Missing action" || missing.Label != "" || missing.Command != "" || len(missing.Steps) != 1 || missing.Steps[0].Label != ":github: job · action" || !isGeneratedFailureCommand(missing.Steps[0].Command) {
+		t.Fatalf("expanded failed workflow = %#v", missing)
 	}
 	firstFailureMessage := string(failureArtifactForStep(pipeline.Steps[0].Plugins, runner.uploaded, "messages"))
 	if !strings.Contains(firstFailureMessage, `Windows runners aren't currently supported. Imported jobs run on Linux or macOS Buildkite hosted agents. If this job can run on Linux, change "windows-latest" to "ubuntu-latest". If it requires Windows, open an issue in https://github.com/buildkite/buildkite-gha to help us prioritize Windows support.`) ||
@@ -1561,12 +1646,145 @@ func TestRunUploadContinuesAfterWorkflowCompilationFailures(t *testing.T) {
 		strings.Count(firstFailureMessage, "detail: Supported runner labels: macos-latest, ubuntu-22.04, ubuntu-24.04, ubuntu-latest.") != 1 {
 		t.Fatalf("multi-diagnostic failure message = %q", firstFailureMessage)
 	}
-	actionFailureAnnotation := string(failureArtifactForStep(pipeline.Steps[1].Plugins, runner.uploaded, "annotations"))
-	if !strings.Contains(actionFailureAnnotation, `Resolve local action &#34;missing-action&#34;`) || !strings.Contains(actionFailureAnnotation, "no such file or directory") {
+	actionFailureAnnotation := string(failureArtifactForStep(missing.Steps[0].Plugins, runner.uploaded, "annotations"))
+	if !strings.Contains(actionFailureAnnotation, `Local action &#34;./missing-action&#34; is unavailable during compilation.`) || !strings.Contains(actionFailureAnnotation, "Local actions must already exist in the event repository") || strings.Contains(actionFailureAnnotation, "no such file or directory") || strings.Contains(actionFailureAnnotation, "lstat") {
 		t.Fatalf("action failure annotation = %q", actionFailureAnnotation)
 	}
 	if pipeline.Steps[2].Group != ":github: workflow · Success" || len(pipeline.Steps[2].Steps) != 1 || pipeline.Steps[2].Steps[0].Key == "" || !strings.Contains(pipeline.Steps[2].Steps[0].Command, `run-job --plan "$plan"`) || !strings.Contains(pipeline.Steps[2].Steps[0].Command, "--user runner") {
 		t.Fatalf("successful workflow group = %#v", pipeline.Steps[2])
+	}
+}
+
+func TestRunUploadRepresentsFourExpandedReusableJobsAfterActionResolutionFailure(t *testing.T) {
+	requireImporterHost(t)
+	repository := writeUploadWorkflowRepository(t, map[string]string{
+		"caller.yml": "name: Reusable CI\non: push\njobs:\n  call:\n    uses: ./.github/workflows/reusable.yml\n",
+		"reusable.yml": `on: workflow_call
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    concurrency: detect-${{ github.ref }}
+    outputs:
+      marker: ${{ steps.marker.outputs.value }}
+    steps:
+      - id: marker
+        run: echo "value=independent" >> "$GITHUB_OUTPUT"
+  generator:
+    needs: detect
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/missing-generator
+      - uses: ./.github/actions/missing-generator-child
+  upload:
+    needs: [detect, generator]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/missing-upload
+  final:
+    needs: [detect, generator, upload]
+    runs-on: ubuntu-latest
+    steps: [{run: true}]
+`,
+	})
+	eventPath, err := filepath.Abs(filepath.Join("..", "..", "testdata", "smoke", "events", "push.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repository)
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_JOB_ID", cliTestJobID)
+	t.Setenv("BUILDKITE_STEP_KEY", "reusable-failure-importer")
+	runner := &cliCaptureRunner{}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"upload", "--event-path", eventPath, ".github/workflows/caller.yml"}, &stdout, &stderr, "dev", runner); code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	type dependency struct {
+		Step         string `yaml:"step"`
+		AllowFailure bool   `yaml:"allow_failure"`
+	}
+	var pipeline struct {
+		Steps []struct {
+			Group string `yaml:"group"`
+			Steps []struct {
+				Label            string             `yaml:"label"`
+				Key              string             `yaml:"key"`
+				Skip             string             `yaml:"skip"`
+				Command          string             `yaml:"command"`
+				Plugins          failureStepPlugins `yaml:"plugins"`
+				DependsOn        []dependency       `yaml:"depends_on"`
+				Agents           map[string]string  `yaml:"agents"`
+				Image            string             `yaml:"image"`
+				Concurrency      int                `yaml:"concurrency"`
+				ConcurrencyGroup string             `yaml:"concurrency_group"`
+				Notify           []map[string]any   `yaml:"notify"`
+			} `yaml:"steps"`
+		} `yaml:"steps"`
+	}
+	pipelineYAML := runner.commands[len(runner.commands)-1].stdin
+	if err := yaml.Unmarshal(pipelineYAML, &pipeline); err != nil {
+		t.Fatal(err)
+	}
+	if len(pipeline.Steps) != 1 || pipeline.Steps[0].Group != ":github: workflow · Reusable CI" || len(pipeline.Steps[0].Steps) != 4 || !strings.Contains(stdout.String(), "Uploaded 4 jobs from 1 workflows") {
+		t.Fatalf("reusable failure pipeline = %#v, stdout = %q\n%s", pipeline.Steps, stdout.String(), pipelineYAML)
+	}
+	jobs := make(map[string]struct {
+		key, skip, command string
+		plugins            failureStepPlugins
+		dependencies       []dependency
+	})
+	for _, step := range pipeline.Steps[0].Steps {
+		jobs[step.Label] = struct {
+			key, skip, command string
+			plugins            failureStepPlugins
+			dependencies       []dependency
+		}{step.Key, step.Skip, step.Command, step.Plugins, step.DependsOn}
+		if step.Label != ":github: job · call / detect" && (step.Agents != nil || step.Image != "" || strings.Contains(step.Command, "run-job")) {
+			t.Fatalf("preparation result retained runnable configuration: %#v", step)
+		}
+	}
+	detect := jobs[":github: job · call / detect"]
+	generator := jobs[":github: job · call / generator"]
+	upload := jobs[":github: job · call / upload"]
+	final := jobs[":github: job · call / final"]
+	if detect.key == "" || detect.skip != "" || !strings.Contains(detect.command, "run-job") || len(detect.plugins) != 0 {
+		t.Fatalf("detect representation = %#v", detect)
+	}
+	if generator.key == "" || !isGeneratedFailureCommand(generator.command) || len(generator.plugins) != 1 || len(generator.dependencies) != 1 || generator.dependencies[0] != (dependency{Step: detect.key, AllowFailure: true}) {
+		t.Fatalf("generator representation = %#v", generator)
+	}
+	if upload.key == "" || !isGeneratedFailureCommand(upload.command) || len(upload.plugins) != 1 || len(upload.dependencies) != 2 || upload.dependencies[1] != (dependency{Step: generator.key, AllowFailure: true}) {
+		t.Fatalf("upload representation = %#v", upload)
+	}
+	if final.key == "" || final.skip != "Not run because a prerequisite job could not be compiled" || len(final.dependencies) != 3 || final.dependencies[2] != (dependency{Step: upload.key, AllowFailure: true}) {
+		t.Fatalf("final representation = %#v", final)
+	}
+	generatorMessage := string(failureArtifactForStep(generator.plugins, runner.uploaded, "messages"))
+	uploadMessage := string(failureArtifactForStep(upload.plugins, runner.uploaded, "messages"))
+	if strings.Count(generatorMessage, "[E_ACTION_RESOLUTION]") != 2 || strings.Contains(generatorMessage, "missing-upload") || strings.Count(uploadMessage, "[E_ACTION_RESOLUTION]") != 1 || strings.Contains(uploadMessage, "missing-generator") {
+		t.Fatalf("scoped failure messages = generator %q, upload %q", generatorMessage, uploadMessage)
+	}
+	var independentPlans int
+	for path, contents := range runner.uploaded {
+		if !strings.HasPrefix(path, ".buildkite-gha/plans/") {
+			continue
+		}
+		independentPlans++
+		job, err := plan.Decode(contents)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if job.Target.StepKey != detect.key || len(job.Dependencies) != 0 || job.Outputs["marker"] != "${{ steps.marker.outputs.value }}" {
+			t.Fatalf("independent plan = %#v", job)
+		}
+	}
+	if independentPlans != 1 || pipeline.Steps[0].Steps[0].Concurrency != 1 || pipeline.Steps[0].Steps[0].ConcurrencyGroup == "" {
+		t.Fatalf("independent plan count = %d, detect concurrency = %d/%q", independentPlans, pipeline.Steps[0].Steps[0].Concurrency, pipeline.Steps[0].Steps[0].ConcurrencyGroup)
+	}
+	for _, step := range pipeline.Steps[0].Steps {
+		if len(step.Notify) != 1 {
+			t.Fatalf("job %q provider checks = %#v", step.Label, step.Notify)
+		}
 	}
 }
 

--- a/internal/cli/variables_test.go
+++ b/internal/cli/variables_test.go
@@ -442,6 +442,42 @@ func TestRunUploadResolvesVariablesForActionInputDefaults(t *testing.T) {
 	}
 }
 
+func TestRunUploadRecompilesIndependentPartialPlanWithActionVariables(t *testing.T) {
+	requireImporterHost(t)
+	variables, variableRequests := agentVariablesHandler(t, http.StatusOK, "")
+	agent, _ := agentStub(t, "job-secret", http.StatusOK, variables)
+	setAgentResolutionEnvironment(t, agent.URL)
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_STEP_KEY", "variables-partial-importer")
+	eventPath := pushEventPath(t)
+	workflow := writeUploadWorkflows(t, map[string]string{"build.yml": `on: push
+jobs:
+  safe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/region
+  broken:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/missing
+`})[0]
+	writeRegionAction(t, regionInputDefaultAction)
+
+	runner := &cliCaptureRunner{webhookErr: errors.New("metadata must not be read with --event-path")}
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"upload", "--event-path", eventPath, workflow}, &stdout, &stderr, "dev", runner); code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	if *variableRequests != 1 {
+		t.Fatalf("variables requests = %d, want 1", *variableRequests)
+	}
+	plans := uploadedPlans(t, runner)
+	if len(plans["safe"]) != 1 || len(plans["broken"]) != 0 || !maps.Equal(plans["safe"][0].RepositoryVars, stubRepositoryVariables) || !maps.Equal(plans["safe"][0].OrganizationVars, stubOrganizationVariables) {
+		t.Fatalf("uploaded plans = %#v", plans)
+	}
+	assertNoVariableValueLeak(t, runner, stdout.String(), stderr.String())
+}
+
 // TestRunCompileIRJSONCarriesVariableScopes pins the documented exposure of
 // compile --format ir-json: the IR is the compiler's full input, so it prints
 // both resolved scopes to stdout.

--- a/internal/compiler/actions.go
+++ b/internal/compiler/actions.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"path"
 	"path/filepath"
 	"sort"
@@ -146,6 +147,20 @@ func actionResolutionMessage(reference string, err error) (message, detail, acti
 	if message, detail, ok := actionintegration.UnsupportedVersionDiagnostic(action, err); ok {
 		return message, detail, action
 	}
+	reason := strings.TrimPrefix(err.Error(), fmt.Sprintf("compile action %q: ", action))
+	localPath, localAction := strings.CutPrefix(action, "./")
+	missingLocalAction := localAction && errors.Is(err, os.ErrNotExist) && strings.HasPrefix(reason, fmt.Sprintf("resolve local action %q: ", localPath))
+	if missingLocalAction {
+		reportedAction := action
+		if path, internal := strings.CutPrefix(action, "./__BUILDER_CHECKOUT_DIR__/"); internal {
+			reportedAction = "./" + path
+		}
+		detail := ""
+		if reference != action {
+			detail = fmt.Sprintf("The local action is referenced by composite action %q.", reference)
+		}
+		return fmt.Sprintf("Local action %q is unavailable during compilation. Local actions must already exist in the event repository; Buildkite cannot resolve one created by an earlier step, such as actions/checkout with path. Check in the action and reference its repository path, or use a public owner/repository/path@ref action. Buildkite reports this error on the affected expanded job, skips jobs that depend on it, and may run independently compiled jobs.", reportedAction), detail, reportedAction
+	}
 	var runtimeErr *metadata.UnsupportedRuntimeError
 	if errors.As(err, &runtimeErr) {
 		runtime := fmt.Sprintf("runtime %q", runtimeErr.Runtime)
@@ -157,7 +172,6 @@ func actionResolutionMessage(reference string, err error) (message, detail, acti
 		}
 		return fmt.Sprintf("Action %q uses %s, which is unsupported. Use an action release that supports Node.js 16, 20, or 24.", action, runtime), "", action
 	}
-	reason := strings.TrimPrefix(err.Error(), fmt.Sprintf("compile action %q: ", action))
 	if strings.HasPrefix(reason, "resolve action reference: ") || strings.HasPrefix(reason, "download action source: ") {
 		return fmt.Sprintf("Action %q could not be resolved: %s", action, reason[strings.Index(reason, ": ")+2:]), "", action
 	}

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/buildkite/buildkite-gha/internal/action/metadata"
 	"github.com/buildkite/buildkite-gha/internal/action/source"
 	"github.com/buildkite/buildkite-gha/internal/plan"
+	"github.com/buildkite/buildkite-gha/internal/workflow"
 )
 
 type fakeActionSource struct {
@@ -212,6 +213,66 @@ func TestActionResolutionMessageDistinguishesResolutionFailure(t *testing.T) {
 	want := `Action "owner/action@v1" could not be resolved: tag v1 was not found`
 	if got, detail, action := actionResolutionMessage("owner/action@v1", err); got != want || detail != "" || action != "owner/action@v1" {
 		t.Fatalf("actionResolutionMessage() = %q, %q, %q; want %q, empty detail, %q", got, detail, action, want, "owner/action@v1")
+	}
+}
+
+func TestActionResolutionMessageExplainsActionCreatedByEarlierStep(t *testing.T) {
+	reference := "slsa-framework/slsa-github-generator/.github/actions/generate-builder@v2.1.0"
+	action := "./__BUILDER_CHECKOUT_DIR__/.github/actions/privacy-check"
+	err := &actionChildError{
+		child: action,
+		err:   fmt.Errorf("compile action %q: resolve local action %q: %w", action, strings.TrimPrefix(action, "./"), os.ErrNotExist),
+	}
+	wantAction := "./.github/actions/privacy-check"
+	want := `Local action "./.github/actions/privacy-check" is unavailable during compilation. Local actions must already exist in the event repository; Buildkite cannot resolve one created by an earlier step, such as actions/checkout with path. Check in the action and reference its repository path, or use a public owner/repository/path@ref action. Buildkite reports this error on the affected expanded job, skips jobs that depend on it, and may run independently compiled jobs.`
+	wantDetail := `The local action is referenced by composite action "slsa-framework/slsa-github-generator/.github/actions/generate-builder@v2.1.0".`
+	if got, detail, resolvedAction := actionResolutionMessage(reference, err); got != want || detail != wantDetail || resolvedAction != wantAction {
+		t.Fatalf("actionResolutionMessage() = %q, %q, %q; want %q, %q, %q", got, detail, resolvedAction, want, wantDetail, wantAction)
+	}
+}
+
+func TestActionResolutionMessageRetainsMissingLocalActionPath(t *testing.T) {
+	action := "./vendor/.github/actions/privacy-check"
+	err := fmt.Errorf("compile action %q: resolve local action %q: %w", action, strings.TrimPrefix(action, "./"), os.ErrNotExist)
+	message, _, reportedAction := actionResolutionMessage(action, err)
+	if reportedAction != action || !strings.Contains(message, action) {
+		t.Fatalf("actionResolutionMessage() = %q, action %q; want original action path", message, reportedAction)
+	}
+}
+
+func TestActionResolutionMessageDoesNotMisclassifyMissingEntrypoint(t *testing.T) {
+	action := "./.github/actions/checked-in"
+	err := fmt.Errorf("compile action %q: JavaScript action main entry point %q: %w", action, "dist/index.js", os.ErrNotExist)
+	message, _, reportedAction := actionResolutionMessage(action, err)
+	if reportedAction != action || !strings.Contains(message, `JavaScript action main entry point "dist/index.js"`) || strings.Contains(message, "created by an earlier step") {
+		t.Fatalf("actionResolutionMessage() = %q, action %q; want missing entry point diagnostic", message, reportedAction)
+	}
+}
+
+func TestValidateActionResolutionsAttributesMissingCalledWorkflowAction(t *testing.T) {
+	reference := "./__BUILDER_CHECKOUT_DIR__/.github/actions/secure-download-artifact"
+	ir := IR{
+		Event: Event{Provider: "github"},
+		Jobs: []JobInstance{{
+			Key: "gha-call-remote-upload-assets", LogicalJobID: "call-remote.upload-assets",
+			SourcePath:     "slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0",
+			RepositoryRoot: t.TempDir(),
+			Steps:          []workflow.Step{{Kind: "uses", Uses: reference, Span: workflow.Span{Start: workflow.Position{Line: 281, Column: 15}}}},
+		}},
+	}
+	evidence, err := validateActionResolutions(t.Context(), ir, Options{})
+	if err == nil || len(evidence.Actions) != 1 || evidence.Actions[0].Passed {
+		t.Fatalf("validateActionResolutions() evidence = %#v, error = %v", evidence, err)
+	}
+	var finding *ProcessingFinding
+	if !errors.As(err, &finding) {
+		t.Fatalf("validateActionResolutions() error = %v, want processing finding", err)
+	}
+	if finding.Path != ir.Jobs[0].SourcePath || finding.Line != 281 || finding.Column != 15 || finding.Job != "call-remote.upload-assets" || finding.Instance != "gha-call-remote-upload-assets" || finding.Action != "./.github/actions/secure-download-artifact" || finding.Step != 1 {
+		t.Fatalf("missing local action attribution = %#v", finding)
+	}
+	if !strings.Contains(finding.Message, "created by an earlier step") || strings.Contains(finding.Message, "__BUILDER_CHECKOUT_DIR__") || strings.Contains(finding.Message, ir.Jobs[0].RepositoryRoot) || strings.Contains(finding.Message, "lstat") {
+		t.Fatalf("missing local action message = %q", finding.Message)
 	}
 }
 

--- a/internal/compiler/bundle.go
+++ b/internal/compiler/bundle.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"strings"
@@ -40,11 +41,21 @@ type PlanAuthorization struct {
 type Bundle struct {
 	IR                IR
 	Plans             []PlanArtifact
+	JobOutcomes       map[string]JobOutcome
 	EventArtifact     *transport.Artifact
 	Pipeline          []byte
 	GeneratedWorkflow buildkitepipeline.Workflow
 	Processing        ProcessingEvidence
 }
+
+// JobOutcome is the compiler-owned preparation result for one expanded job.
+type JobOutcome string
+
+const (
+	JobPlanned JobOutcome = "planned"
+	JobFailed  JobOutcome = "failed"
+	JobBlocked JobOutcome = "blocked"
+)
 
 // CompileBundle compiles an unattested event snapshot with the default runner
 // policy, which rejects unsupported runner labels.
@@ -77,40 +88,67 @@ func CompileBundlePlansContext(ctx context.Context, path string, source, eventSo
 	if !strings.HasPrefix(compilerDistributionDigest, "sha256:") {
 		return Bundle{}, fmt.Errorf("compiler distribution digest is required")
 	}
-	ir, err := compile(ctx, path, source, eventSource, options)
-	if err != nil {
-		return Bundle{IR: ir}, err
+	ir, compileErr := compile(ctx, path, source, eventSource, options)
+	if compileErr != nil && !ir.JobGraphComplete {
+		return Bundle{IR: ir}, compileErr
 	}
-	ir, err = reducePlanEventExpressions(ir)
-	if err != nil {
-		return Bundle{IR: ir}, err
-	}
+	ir, reductionErr := reducePlanEventExpressions(ir)
 	options.ActionSource = newMemoizedActionSource(options.ActionSource)
-	evidence, err := validateActionResolutions(ctx, ir, options)
+	directFailures := failedInstancesFromError(compileErr)
+	for key := range failedInstancesFromError(reductionErr) {
+		directFailures[key] = true
+	}
+	if ErrorHasUnscopedFailure(compileErr) || ErrorHasUnscopedFailure(reductionErr) {
+		for _, instance := range ir.Jobs {
+			directFailures[instance.Key] = true
+		}
+	}
+	failed := failedDependencyClosure(ir, maps.Clone(directFailures))
+	planningIR := irWithoutJobs(ir, failed)
+	evidence, actionErr := validateActionResolutions(ctx, planningIR, options)
 	bundle := Bundle{IR: ir, Processing: evidence}
-	if err != nil {
-		return bundle, err
+	if actionErr != nil {
+		actionFailureFound := false
+		for _, action := range evidence.Actions {
+			if !action.Passed {
+				directFailures[action.Instance] = true
+				actionFailureFound = true
+			}
+		}
+		if !actionFailureFound {
+			for _, instance := range planningIR.Jobs {
+				directFailures[instance.Key] = true
+			}
+		}
+		failed = failedDependencyClosure(ir, maps.Clone(directFailures))
+		planningIR = irWithoutJobs(ir, failed)
 	}
-	plans, authorizations, planEvaluations, err := compilePlansWithAuthorization(ctx, ir, compilerVersion, compilerDistributionDigest, options)
+	plans, authorizations, planEvaluations, planErr := compilePlansWithAuthorization(ctx, planningIR, compilerVersion, compilerDistributionDigest, options)
 	bundle.Processing.Plans = planEvaluations
-	if err != nil {
-		return bundle, err
+	bundle.JobOutcomes = jobOutcomes(ir, directFailures, failed, planEvaluations)
+	if len(authorizations) != len(plans) {
+		return bundle, processingFinding(StagePlans, CodePlanConstruction, "compatibility", fmt.Errorf("compiler produced %d plans and %d authorizations", len(plans), len(authorizations)))
 	}
-	if len(plans) != len(ir.Jobs) || len(authorizations) != len(plans) {
-		return bundle, processingFinding(StagePlans, CodePlanConstruction, "compatibility", fmt.Errorf("compiler produced %d plans and %d authorizations for %d job instances", len(plans), len(authorizations), len(ir.Jobs)))
+	instances := make(map[string]JobInstance, len(ir.Jobs))
+	for _, instance := range ir.Jobs {
+		instances[instance.Key] = instance
 	}
 	warnedLegacyCheckout := map[string]bool{}
 	warnedUnknownCheckout := map[string]bool{}
 	warnedUnknownUploadArtifact := map[string]bool{}
 	warnedLegacyUploadArtifact := map[string]bool{}
 	warnedUnknownDownloadArtifact := map[string]bool{}
-	for i, job := range plans {
+	for _, job := range plans {
+		instance, exists := instances[job.Target.StepKey]
+		if !exists {
+			return bundle, processingFinding(StagePlans, CodePlanConstruction, "compatibility", fmt.Errorf("plan target %q has no expanded job instance", job.Target.StepKey))
+		}
 		locks := make(map[string]plan.ActionLock, len(job.Actions))
 		for _, lock := range job.Actions {
 			locks[lock.ID] = lock
 		}
 		for stepIndex, step := range job.ExecutionJob().Steps {
-			if step.Invocation == nil || step.Invocation.Lock == "" || stepIndex >= len(ir.Jobs[i].Steps) {
+			if step.Invocation == nil || step.Invocation.Lock == "" || stepIndex >= len(instance.Steps) {
 				continue
 			}
 			for _, lock := range reachableActionLocks(locks, step.Invocation.Lock) {
@@ -122,9 +160,9 @@ func CompileBundlePlansContext(ctx context.Context, path string, source, eventSo
 							continue
 						}
 						warnedUnknownCheckout[lock.Commit] = true
-						warning := unknownCheckoutCommitWarning(ir.Jobs[i].Steps[stepIndex].Span.Start, lock.Commit)
-						warning.Path = ir.Jobs[i].SourcePath
-						warning.Job = ir.Jobs[i].LogicalJobID
+						warning := unknownCheckoutCommitWarning(instance.Steps[stepIndex].Span.Start, lock.Commit)
+						warning.Path = instance.SourcePath
+						warning.Job = instance.LogicalJobID
 						warning.Step = stepIndex + 1
 						bundle.IR.Warnings = append(bundle.IR.Warnings, warning)
 						continue
@@ -134,9 +172,9 @@ func CompileBundlePlansContext(ctx context.Context, path string, source, eventSo
 						continue
 					}
 					warnedLegacyCheckout[release] = true
-					warning := legacyCheckoutWarning(ir.Jobs[i].Steps[stepIndex].Span.Start, release, actionintegration.CheckoutDefaultsToFullHistory(lock.Commit))
-					warning.Path = ir.Jobs[i].SourcePath
-					warning.Job = ir.Jobs[i].LogicalJobID
+					warning := legacyCheckoutWarning(instance.Steps[stepIndex].Span.Start, release, actionintegration.CheckoutDefaultsToFullHistory(lock.Commit))
+					warning.Path = instance.SourcePath
+					warning.Job = instance.LogicalJobID
 					warning.Step = stepIndex + 1
 					bundle.IR.Warnings = append(bundle.IR.Warnings, warning)
 				case actionintegration.AdapterUploadArtifactBuildkite:
@@ -145,9 +183,9 @@ func CompileBundlePlansContext(ctx context.Context, path string, source, eventSo
 							continue
 						}
 						warnedUnknownUploadArtifact[lock.Commit] = true
-						warning := unknownUploadArtifactCommitWarning(ir.Jobs[i].Steps[stepIndex].Span.Start, lock.Commit)
-						warning.Path = ir.Jobs[i].SourcePath
-						warning.Job = ir.Jobs[i].LogicalJobID
+						warning := unknownUploadArtifactCommitWarning(instance.Steps[stepIndex].Span.Start, lock.Commit)
+						warning.Path = instance.SourcePath
+						warning.Job = instance.LogicalJobID
 						warning.Step = stepIndex + 1
 						bundle.IR.Warnings = append(bundle.IR.Warnings, warning)
 						continue
@@ -157,15 +195,15 @@ func CompileBundlePlansContext(ctx context.Context, path string, source, eventSo
 						continue
 					}
 					warnedLegacyUploadArtifact[release] = true
-					bundle.IR.Warnings = append(bundle.IR.Warnings, legacyUploadArtifactWarning(ir.Jobs[i].Steps[stepIndex].Span.Start, release))
+					bundle.IR.Warnings = append(bundle.IR.Warnings, legacyUploadArtifactWarning(instance.Steps[stepIndex].Span.Start, release))
 				case actionintegration.AdapterDownloadArtifactBuildkite:
 					if !actionintegration.DownloadArtifactUsesFallbackContract(lock.Commit) || warnedUnknownDownloadArtifact[lock.Commit] {
 						continue
 					}
 					warnedUnknownDownloadArtifact[lock.Commit] = true
-					warning := unknownDownloadArtifactCommitWarning(ir.Jobs[i].Steps[stepIndex].Span.Start, lock.Commit)
-					warning.Path = ir.Jobs[i].SourcePath
-					warning.Job = ir.Jobs[i].LogicalJobID
+					warning := unknownDownloadArtifactCommitWarning(instance.Steps[stepIndex].Span.Start, lock.Commit)
+					warning.Path = instance.SourcePath
+					warning.Job = instance.LogicalJobID
 					warning.Step = stepIndex + 1
 					bundle.IR.Warnings = append(bundle.IR.Warnings, warning)
 				}
@@ -174,24 +212,25 @@ func CompileBundlePlansContext(ctx context.Context, path string, source, eventSo
 	}
 	warnedReusablePermissions := false
 	warnedJobPermissions := false
-	for i, job := range plans {
+	for _, job := range plans {
 		if job.GitHubToken == nil {
 			continue
 		}
-		if ir.Jobs[i].tokenPolicyNarrowed && !warnedReusablePermissions {
-			bundle.IR.Warnings = append(bundle.IR.Warnings, reusableWorkflowTokenWarning(ir.Jobs[i].reusableCall))
+		instance := instances[job.Target.StepKey]
+		if instance.tokenPolicyNarrowed && !warnedReusablePermissions {
+			bundle.IR.Warnings = append(bundle.IR.Warnings, reusableWorkflowTokenWarning(instance.reusableCall))
 			warnedReusablePermissions = true
 		}
-		if (ir.Jobs[i].jobPermissionsIgnored || jobPermissionsIgnored(job.GitHubToken.Permissions, ir.Jobs[i].Permissions)) && !warnedJobPermissions {
-			position := ir.Jobs[i].Source.Start
-			path := ir.Jobs[i].SourcePath
-			if ir.Jobs[i].jobPermissionsIgnored && ir.Jobs[i].reusableCall.Line != 0 {
-				position = ir.Jobs[i].reusableCall
+		if (instance.jobPermissionsIgnored || jobPermissionsIgnored(job.GitHubToken.Permissions, instance.Permissions)) && !warnedJobPermissions {
+			position := instance.Source.Start
+			path := instance.SourcePath
+			if instance.jobPermissionsIgnored && instance.reusableCall.Line != 0 {
+				position = instance.reusableCall
 				path = ir.Workflow.Path
 			}
 			warning := jobWorkflowTokenWarning(position, job.GitHubToken.Permissions)
 			warning.Path = path
-			warning.Job = ir.Jobs[i].LogicalJobID
+			warning.Job = instance.LogicalJobID
 			bundle.IR.Warnings = append(bundle.IR.Warnings, warning)
 			warnedJobPermissions = true
 		}
@@ -199,24 +238,25 @@ func CompileBundlePlansContext(ctx context.Context, path string, source, eventSo
 
 	artifacts := make([]PlanArtifact, len(plans))
 	for i, job := range plans {
-		if job.Target.StepKey != ir.Jobs[i].Key || job.Target.Queue != ir.Jobs[i].Queue {
-			return bundle, processingFinding(StagePlans, CodePlanConstruction, "compatibility", fmt.Errorf("plan %d target %q/%q does not match job instance %q/%q", i, job.Target.StepKey, job.Target.Queue, ir.Jobs[i].Key, ir.Jobs[i].Queue))
+		instance := instances[job.Target.StepKey]
+		if job.Target.Queue != instance.Queue {
+			return bundle, processingFinding(StagePlans, CodePlanConstruction, "compatibility", fmt.Errorf("plan %d target %q/%q does not match job instance queue %q", i, job.Target.StepKey, job.Target.Queue, instance.Queue))
 		}
-		expectedRuntimeDigest := options.RuntimeDistributions[ir.Jobs[i].Platform]
-		if expectedRuntimeDigest == "" && ir.Jobs[i].Platform == PlatformLinuxAMD64 {
+		expectedRuntimeDigest := options.RuntimeDistributions[instance.Platform]
+		if expectedRuntimeDigest == "" && instance.Platform == PlatformLinuxAMD64 {
 			expectedRuntimeDigest = compilerDistributionDigest
 		}
 		if job.Runtime == nil || job.Runtime.DistributionDigest != expectedRuntimeDigest {
-			return bundle, processingFinding(StagePlans, CodePlanConstruction, "compatibility", fmt.Errorf("plan %d runtime distribution does not match job platform %s", i, ir.Jobs[i].Platform))
+			return bundle, processingFinding(StagePlans, CodePlanConstruction, "compatibility", fmt.Errorf("plan %d runtime distribution does not match job platform %s", i, instance.Platform))
 		}
 		contents, err := plan.Encode(job)
 		if err != nil {
-			return bundle, &ProcessingFinding{Stage: StagePlans, Code: CodePlanConstruction, Category: "compatibility", Job: job.Workflow.LogicalJobID, Instance: ir.Jobs[i].Key, Err: fmt.Errorf("encode plan for job %q: %w", job.Workflow.LogicalJobID, err)}
+			return bundle, &ProcessingFinding{Stage: StagePlans, Code: CodePlanConstruction, Category: "compatibility", Job: job.Workflow.LogicalJobID, Instance: instance.Key, Err: fmt.Errorf("encode plan for job %q: %w", job.Workflow.LogicalJobID, err)}
 		}
 		digest := transport.Digest(contents)
 		planPath, err := buildkitepipeline.PlanPath(digest)
 		if err != nil {
-			return bundle, &ProcessingFinding{Stage: StagePlans, Code: CodePlanConstruction, Category: "compatibility", Job: job.Workflow.LogicalJobID, Instance: ir.Jobs[i].Key, Err: fmt.Errorf("locate plan for job %q: %w", job.Workflow.LogicalJobID, err)}
+			return bundle, &ProcessingFinding{Stage: StagePlans, Code: CodePlanConstruction, Category: "compatibility", Job: job.Workflow.LogicalJobID, Instance: instance.Key, Err: fmt.Errorf("locate plan for job %q: %w", job.Workflow.LogicalJobID, err)}
 		}
 		artifacts[i] = PlanArtifact{Job: job, Digest: digest, Path: planPath, Contents: contents, Authorization: authorizations[i]}
 	}
@@ -243,8 +283,136 @@ func CompileBundlePlansContext(ctx context.Context, path string, source, eventSo
 		bundle.EventArtifact = &transport.Artifact{Path: path, Digest: digest, Contents: contents}
 		break
 	}
-	bundle.Processing.PlansConstructed = true
-	return bundle, nil
+	if actionErr == nil && planErr == nil && len(bundle.Plans) == len(ir.Jobs) {
+		bundle.Processing.PlansConstructed = true
+	}
+	return bundle, errors.Join(compileErr, reductionErr, actionErr, planErr)
+}
+
+func jobOutcomes(ir IR, directFailures, excluded map[string]bool, evaluations []JobEvaluation) map[string]JobOutcome {
+	outcomes := make(map[string]JobOutcome, len(ir.Jobs))
+	for key := range excluded {
+		outcomes[key] = JobBlocked
+	}
+	for key := range directFailures {
+		outcomes[key] = JobFailed
+	}
+	for _, evaluation := range evaluations {
+		switch {
+		case !evaluation.Evaluated:
+			outcomes[evaluation.Instance] = JobBlocked
+		case evaluation.Passed:
+			outcomes[evaluation.Instance] = JobPlanned
+		default:
+			outcomes[evaluation.Instance] = JobFailed
+		}
+	}
+	for _, instance := range ir.Jobs {
+		if _, exists := outcomes[instance.Key]; !exists {
+			outcomes[instance.Key] = JobBlocked
+		}
+	}
+	return outcomes
+}
+
+func failedInstancesFromError(err error) map[string]bool {
+	failed := make(map[string]bool)
+	var visit func(error)
+	visit = func(err error) {
+		if err == nil {
+			return
+		}
+		if finding, ok := err.(*ProcessingFinding); ok {
+			if finding.Instance != "" {
+				failed[finding.Instance] = true
+			}
+			return
+		}
+		if joined, ok := err.(interface{ Unwrap() []error }); ok {
+			for _, child := range joined.Unwrap() {
+				visit(child)
+			}
+			return
+		}
+		if wrapped, ok := err.(interface{ Unwrap() error }); ok {
+			visit(wrapped.Unwrap())
+		}
+	}
+	visit(err)
+	return failed
+}
+
+// ErrorHasUnscopedFailure reports whether err contains a compiler failure that
+// cannot be assigned to one expanded job instance.
+func ErrorHasUnscopedFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	if finding, ok := err.(*ProcessingFinding); ok {
+		return finding.Instance == ""
+	}
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		for _, child := range joined.Unwrap() {
+			if ErrorHasUnscopedFailure(child) {
+				return true
+			}
+		}
+		return false
+	}
+	if wrapped, ok := err.(interface{ Unwrap() error }); ok {
+		return ErrorHasUnscopedFailure(wrapped.Unwrap())
+	}
+	return true
+}
+
+// JobsOutsideFailureClosure returns jobs that neither failed with an
+// instance-scoped compiler error nor depend on one. An unscoped error leaves
+// no safe candidates.
+func JobsOutsideFailureClosure(ir IR, err error) []JobInstance {
+	failed := failedDependencyClosure(ir, failedInstancesFromError(err))
+	if ErrorHasUnscopedFailure(err) {
+		failed = make(map[string]bool, len(ir.Jobs))
+		for _, instance := range ir.Jobs {
+			failed[instance.Key] = true
+		}
+	}
+	return irWithoutJobs(ir, failed).Jobs
+}
+
+func failedDependencyClosure(ir IR, failed map[string]bool) map[string]bool {
+	if len(failed) == 0 {
+		return failed
+	}
+	for changed := true; changed; {
+		changed = false
+		for _, instance := range ir.Jobs {
+			if failed[instance.Key] {
+				continue
+			}
+			for _, dependency := range instance.Needs {
+				if failed[dependency] {
+					failed[instance.Key] = true
+					changed = true
+					break
+				}
+			}
+		}
+	}
+	return failed
+}
+
+func irWithoutJobs(ir IR, removed map[string]bool) IR {
+	if len(removed) == 0 {
+		return ir
+	}
+	jobs := ir.Jobs
+	ir.Jobs = make([]JobInstance, 0, len(jobs)-len(removed))
+	for _, instance := range jobs {
+		if !removed[instance.Key] {
+			ir.Jobs = append(ir.Jobs, instance)
+		}
+	}
+	return ir
 }
 
 func reachableActionLocks(locks map[string]plan.ActionLock, root string) []plan.ActionLock {
@@ -286,75 +454,9 @@ func GenerateBundlePipeline(bundle Bundle, compilerDistributionDigest, compilerS
 	if len(artifacts) != len(ir.Jobs) {
 		return bundle, processingFinding(StagePipeline, CodePipelineGeneration, "compatibility", fmt.Errorf("compiler has %d plans for %d job instances", len(artifacts), len(ir.Jobs)))
 	}
-	jobs := make([]buildkitepipeline.Job, len(artifacts))
-	for i, artifact := range artifacts {
-		job := artifact.Job
-		jobs[i] = buildkitepipeline.Job{
-			Key:                ir.Jobs[i].Key,
-			Label:              ir.Jobs[i].Label,
-			CheckLabel:         instanceCheckLabel(ir.Jobs[i]),
-			Queue:              ir.Jobs[i].Queue,
-			Platform:           ir.Jobs[i].Platform.String(),
-			DistributionDigest: job.RuntimeDistributionDigest(),
-			PlanDigest:         artifact.Digest,
-			EventPayload:       job.Event.PayloadArtifact,
-			Dependencies:       append([]string(nil), ir.Jobs[i].Needs...),
-			RequiresMise:       job.NeedsMise(),
-			Cache:              ir.Jobs[i].Cache,
-			SoftFail:           job.ContinueOnError,
-		}
-		for _, gate := range ir.Jobs[i].ConcurrencyGates {
-			jobs[i].ConcurrencyGates = append(jobs[i].ConcurrencyGates, buildkitepipeline.ConcurrencyGate{
-				ID: gate.ID, Group: buildkiteConcurrencyGroup(ir.Event.Repository, gate.Group),
-			})
-		}
-		if ir.Jobs[i].Platform == PlatformLinuxAMD64 {
-			jobs[i].RuntimeImage = ir.Jobs[i].RuntimeImage
-			if jobs[i].RuntimeImage == "" {
-				jobs[i].RuntimeImage = options.RuntimeImage
-			}
-		}
-		if ir.Jobs[i].ConcurrencyGroup != "" {
-			jobs[i].Concurrency = 1
-			jobs[i].ConcurrencyGroup = buildkiteConcurrencyGroup(ir.Event.Repository, ir.Jobs[i].ConcurrencyGroup)
-		} else if ir.Jobs[i].MaxParallel != nil {
-			jobs[i].Concurrency = *ir.Jobs[i].MaxParallel
-			workflowScope := strings.TrimPrefix(ir.Workflow.Digest, "sha256:")
-			if options.StepKeyNamespace != "" {
-				workflowScope += "/" + options.StepKeyNamespace
-			}
-			jobs[i].ConcurrencyGroup = "buildkite-gha/" + workflowScope + "/" + ir.Jobs[i].LogicalJobID
-		}
-	}
-	var approvalGates []buildkitepipeline.ApprovalGate
-	gateKeys := make(map[string]string)
-	for i := range ir.Jobs {
-		if !ir.Jobs[i].EnvironmentApproval {
-			continue
-		}
-		environment := ir.Jobs[i].Environment
-		// GitHub environment names are case-insensitive, so case variants
-		// share one gate; the label keeps the first authored spelling.
-		identity := strings.ToLower(environment)
-		key, exists := gateKeys[identity]
-		if !exists {
-			key = environmentGateKey(options.StepKeyNamespace, environment)
-			gateKeys[identity] = key
-			approvalGates = append(approvalGates, buildkitepipeline.ApprovalGate{Key: key, Environment: environment})
-		}
-		jobs[i].ApprovalGate = key
-	}
-	var concurrencyGate *buildkitepipeline.ConcurrencyGate
-	if ir.Workflow.ConcurrencyGroup != "" {
-		concurrencyGate = &buildkitepipeline.ConcurrencyGate{
-			Group: buildkiteConcurrencyGroup(ir.Event.Repository, ir.Workflow.ConcurrencyGroup),
-			Queue: jobs[0].Queue,
-		}
-	}
-	generatedWorkflow := buildkitepipeline.Workflow{
-		ConcurrencyGate: concurrencyGate,
-		ApprovalGates:   approvalGates,
-		Jobs:            jobs,
+	generatedWorkflow, err := GeneratePlannedWorkflow(bundle, options)
+	if err != nil {
+		return bundle, processingFinding(StagePipeline, CodePipelineGeneration, "compatibility", err)
 	}
 	pipeline, err := buildkitepipeline.Emit(buildkitepipeline.Pipeline{
 		CompilerStep:    compilerStep,
@@ -370,6 +472,122 @@ func GenerateBundlePipeline(bundle Bundle, compilerDistributionDigest, compilerS
 	bundle.GeneratedWorkflow = generatedWorkflow
 	bundle.Processing.PipelineGenerated = true
 	return bundle, nil
+}
+
+// GeneratePlannedWorkflow projects every successfully compiled plan into its
+// runnable Buildkite job. It rejects a plan whose dependency has no plan, so a
+// partial workflow cannot consume outputs or artifacts from a failed path.
+func GeneratePlannedWorkflow(bundle Bundle, options Options) (buildkitepipeline.Workflow, error) {
+	ir, artifacts := bundle.IR, bundle.Plans
+	instances := make(map[string]JobInstance, len(ir.Jobs))
+	for _, instance := range ir.Jobs {
+		instances[instance.Key] = instance
+	}
+	planned := make(map[string]bool, len(artifacts))
+	for _, artifact := range artifacts {
+		key := artifact.Job.Target.StepKey
+		if planned[key] {
+			return buildkitepipeline.Workflow{}, fmt.Errorf("compiler has duplicate plan for job instance %q", key)
+		}
+		if _, exists := instances[key]; !exists {
+			return buildkitepipeline.Workflow{}, fmt.Errorf("plan target %q has no expanded job instance", key)
+		}
+		planned[key] = true
+	}
+	jobs := make([]buildkitepipeline.Job, len(artifacts))
+	for i, artifact := range artifacts {
+		instance := instances[artifact.Job.Target.StepKey]
+		for _, dependency := range instance.Needs {
+			if !planned[dependency] {
+				return buildkitepipeline.Workflow{}, fmt.Errorf("planned job %q depends on job %q without a plan", instance.Key, dependency)
+			}
+		}
+		job := artifact.Job
+		jobs[i] = buildkitepipeline.Job{
+			Key:                instance.Key,
+			Label:              instance.Label,
+			CheckLabel:         instanceCheckLabel(instance),
+			Queue:              instance.Queue,
+			Platform:           instance.Platform.String(),
+			DistributionDigest: job.RuntimeDistributionDigest(),
+			PlanDigest:         artifact.Digest,
+			EventPayload:       job.Event.PayloadArtifact,
+			Dependencies:       append([]string(nil), instance.Needs...),
+			RequiresMise:       job.NeedsMise(),
+			Cache:              instance.Cache,
+			SoftFail:           job.ContinueOnError,
+		}
+		for _, gate := range instance.ConcurrencyGates {
+			jobs[i].ConcurrencyGates = append(jobs[i].ConcurrencyGates, buildkitepipeline.ConcurrencyGate{
+				ID: gate.ID, Group: buildkiteConcurrencyGroup(ir.Event.Repository, gate.Group),
+			})
+		}
+		if instance.Platform == PlatformLinuxAMD64 {
+			jobs[i].RuntimeImage = instance.RuntimeImage
+			if jobs[i].RuntimeImage == "" {
+				jobs[i].RuntimeImage = options.RuntimeImage
+			}
+		}
+		if instance.ConcurrencyGroup != "" {
+			jobs[i].Concurrency = 1
+			jobs[i].ConcurrencyGroup = buildkiteConcurrencyGroup(ir.Event.Repository, instance.ConcurrencyGroup)
+		} else if instance.MaxParallel != nil {
+			jobs[i].Concurrency = *instance.MaxParallel
+			workflowScope := strings.TrimPrefix(ir.Workflow.Digest, "sha256:")
+			if options.StepKeyNamespace != "" {
+				workflowScope += "/" + options.StepKeyNamespace
+			}
+			jobs[i].ConcurrencyGroup = "buildkite-gha/" + workflowScope + "/" + instance.LogicalJobID
+		}
+	}
+	var approvalGates []buildkitepipeline.ApprovalGate
+	gateKeys := make(map[string]string)
+	for i := range jobs {
+		instance := instances[jobs[i].Key]
+		if !instance.EnvironmentApproval {
+			continue
+		}
+		environment := instance.Environment
+		// GitHub environment names are case-insensitive, so case variants
+		// share one gate; the label keeps the first authored spelling.
+		identity := strings.ToLower(environment)
+		key, exists := gateKeys[identity]
+		if !exists {
+			key = environmentGateKey(options.StepKeyNamespace, environment)
+			gateKeys[identity] = key
+			approvalGates = append(approvalGates, buildkitepipeline.ApprovalGate{Key: key, Environment: environment})
+		}
+		jobs[i].ApprovalGate = key
+	}
+	var concurrencyGate *buildkitepipeline.ConcurrencyGate
+	if ir.Workflow.ConcurrencyGroup != "" && len(jobs) != 0 {
+		concurrencyGate = &buildkitepipeline.ConcurrencyGate{
+			Group: buildkiteConcurrencyGroup(ir.Event.Repository, ir.Workflow.ConcurrencyGroup),
+			Queue: jobs[0].Queue,
+		}
+	}
+	return buildkitepipeline.Workflow{
+		ConcurrencyGate: concurrencyGate,
+		ApprovalGates:   approvalGates,
+		Jobs:            jobs,
+	}, nil
+}
+
+// ExpandedWorkflowJobs projects stable presentation identity and dependencies
+// from an expanded IR without adding executable plan configuration. Upload uses
+// these skeletons to represent per-job preparation failures without running a
+// partial workflow.
+func ExpandedWorkflowJobs(ir IR) []buildkitepipeline.Job {
+	jobs := make([]buildkitepipeline.Job, len(ir.Jobs))
+	for i, instance := range ir.Jobs {
+		jobs[i] = buildkitepipeline.Job{
+			Key:          instance.Key,
+			Label:        instance.Label,
+			CheckLabel:   instanceCheckLabel(instance),
+			Dependencies: append([]string(nil), instance.Needs...),
+		}
+	}
+	return jobs
 }
 
 func buildkiteConcurrencyGroup(repository Repository, group string) string {

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -154,6 +154,199 @@ func TestBundlePlansPermitAdmissionBeforePipelineGeneration(t *testing.T) {
 	}
 }
 
+func TestCompileBundlePlansKeepsOnlyJobsOutsideFailedActionDependencyClosure(t *testing.T) {
+	root := t.TempDir()
+	workflowPath := filepath.Join(root, ".github", "workflows", "partial.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	source := []byte(`on: push
+jobs:
+  independent:
+    runs-on: ubuntu-latest
+    outputs:
+      value: ${{ steps.value.outputs.result }}
+    steps:
+      - id: value
+        run: echo "result=safe" >> "$GITHUB_OUTPUT"
+  broken:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/missing
+  blocked:
+    needs: broken
+    runs-on: ubuntu-latest
+    steps: [{run: true}]
+`)
+	if err := os.WriteFile(workflowPath, source, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	bundle, err := CompileBundlePlansContext(t.Context(), workflowPath, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, defaultOptions())
+	if err == nil {
+		t.Fatal("CompileBundlePlansContext() unexpectedly succeeded")
+	}
+	if len(bundle.IR.Jobs) != 3 || len(bundle.Plans) != 1 || bundle.Plans[0].Job.Workflow.LogicalJobID != "independent" || len(bundle.Plans[0].Job.Dependencies) != 0 || bundle.Plans[0].Job.Outputs["value"] != "${{ steps.value.outputs.result }}" {
+		t.Fatalf("partial bundle = jobs %#v, plans %#v", bundle.IR.Jobs, bundle.Plans)
+	}
+	generated, err := GeneratePlannedWorkflow(bundle, defaultOptions())
+	if err != nil || len(generated.Jobs) != 1 || generated.Jobs[0].Key != bundle.Plans[0].Job.Target.StepKey {
+		t.Fatalf("GeneratePlannedWorkflow() = %#v, %v", generated, err)
+	}
+
+	unsafe := bundle
+	unsafe.IR.Jobs = append([]JobInstance(nil), bundle.IR.Jobs...)
+	for i := range unsafe.IR.Jobs {
+		if unsafe.IR.Jobs[i].Key == generated.Jobs[0].Key {
+			unsafe.IR.Jobs[i].Needs = []string{"gha-broken"}
+		}
+	}
+	if _, err := GeneratePlannedWorkflow(unsafe, defaultOptions()); err == nil || !strings.Contains(err.Error(), "without a plan") {
+		t.Fatalf("GeneratePlannedWorkflow() unsafe dependency error = %v", err)
+	}
+}
+
+func TestCompileBundlePlansKeepsJobsOutsideFailedExpressionDependencyClosure(t *testing.T) {
+	root := t.TempDir()
+	workflowPath := filepath.Join(root, ".github", "workflows", "partial.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	source := []byte(`on: push
+jobs:
+  independent:
+    runs-on: ubuntu-latest
+    steps: [{run: echo safe}]
+  broken:
+    runs-on: ubuntu-latest
+    steps:
+      - shell: cmd
+        run: echo unsupported
+  blocked:
+    needs: broken
+    runs-on: ubuntu-latest
+    steps: [{run: echo blocked}]
+`)
+	if err := os.WriteFile(workflowPath, source, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	bundle, err := CompileBundlePlansContext(t.Context(), workflowPath, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, defaultOptions())
+	if err == nil || !strings.Contains(err.Error(), "shell") {
+		t.Fatalf("CompileBundlePlansContext() error = %v, want shell failure", err)
+	}
+	if len(bundle.IR.Jobs) != 3 || len(bundle.Plans) != 1 || bundle.Plans[0].Job.Workflow.LogicalJobID != "independent" {
+		t.Fatalf("partial bundle = jobs %#v, plans %#v", bundle.IR.Jobs, bundle.Plans)
+	}
+}
+
+func TestCompileBundlePlansOwnsMatrixInstanceOutcomes(t *testing.T) {
+	root := t.TempDir()
+	workflowPath := filepath.Join(root, ".github", "workflows", "matrix.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	source := []byte(`on: push
+jobs:
+  test:
+    strategy:
+      matrix:
+        shell: [bash, cmd]
+    runs-on: ubuntu-latest
+    steps:
+      - shell: ${{ matrix.shell }}
+        run: echo test
+`)
+	if err := os.WriteFile(workflowPath, source, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	bundle, err := CompileBundlePlansContext(t.Context(), workflowPath, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, defaultOptions())
+	if err == nil {
+		t.Fatal("CompileBundlePlansContext() unexpectedly succeeded")
+	}
+	var planned, failed int
+	for _, instance := range bundle.IR.Jobs {
+		switch bundle.JobOutcomes[instance.Key] {
+		case JobPlanned:
+			planned++
+		case JobFailed:
+			failed++
+		default:
+			t.Fatalf("matrix instance %q outcome = %q", instance.Key, bundle.JobOutcomes[instance.Key])
+		}
+	}
+	if planned != 1 || failed != 1 || len(bundle.Plans) != 1 {
+		t.Fatalf("matrix outcomes = %#v, plans = %d", bundle.JobOutcomes, len(bundle.Plans))
+	}
+}
+
+func TestCompileBundlePlansCombinesStageFailuresWithoutBlockingIndependentJob(t *testing.T) {
+	root := t.TempDir()
+	workflowPath := filepath.Join(root, ".github", "workflows", "stages.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	source := []byte(`on: push
+jobs:
+  safe:
+    runs-on: ubuntu-latest
+    steps: [{run: echo safe}]
+  bad-shell:
+    runs-on: ubuntu-latest
+    steps:
+      - shell: cmd
+        run: echo bad
+  bad-action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/missing
+`)
+	if err := os.WriteFile(workflowPath, source, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	bundle, err := CompileBundlePlansContext(t.Context(), workflowPath, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, defaultOptions())
+	if err == nil || !strings.Contains(err.Error(), "shell") || !strings.Contains(err.Error(), `action "./.github/actions/missing"`) {
+		t.Fatalf("CompileBundlePlansContext() error = %v", err)
+	}
+	counts := map[JobOutcome]int{}
+	for _, outcome := range bundle.JobOutcomes {
+		counts[outcome]++
+	}
+	if counts[JobPlanned] != 1 || counts[JobFailed] != 2 || len(bundle.Plans) != 1 {
+		t.Fatalf("stage outcomes = %#v, plans = %d", bundle.JobOutcomes, len(bundle.Plans))
+	}
+}
+
+func TestCompileBundlePlansKeepsJobsOutsideFailedEnvironmentDependencyClosure(t *testing.T) {
+	root := t.TempDir()
+	workflowPath := filepath.Join(root, ".github", "workflows", "partial.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	source := []byte(`on: push
+jobs:
+  independent:
+    runs-on: ubuntu-latest
+    steps: [{run: echo safe}]
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+    steps: [{run: echo deploy}]
+  blocked:
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps: [{run: echo blocked}]
+`)
+	if err := os.WriteFile(workflowPath, source, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	bundle, err := CompileBundlePlansContext(t.Context(), workflowPath, source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, defaultOptions())
+	if err == nil || !strings.Contains(err.Error(), "environment") {
+		t.Fatalf("CompileBundlePlansContext() error = %v, want environment failure", err)
+	}
+	if !bundle.IR.JobGraphComplete || len(bundle.IR.Jobs) != 3 || len(bundle.Plans) != 1 || bundle.Plans[0].Job.Workflow.LogicalJobID != "independent" {
+		t.Fatalf("partial bundle = jobs %#v, plans %#v", bundle.IR.Jobs, bundle.Plans)
+	}
+}
+
 func TestCompileBundlePreservesExplicitQueuePolicy(t *testing.T) {
 	workflow := []byte("on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n")
 	bundle, err := CompileBundleWithOptions("workflow.yml", workflow, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-importer", Options{

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -35,6 +35,10 @@ type IR struct {
 	RepositoryVars   map[string]string `json:"repository_vars,omitempty"`
 	Execution        ExecutionBoundary `json:"execution"`
 	Jobs             []JobInstance     `json:"jobs"`
+	// JobGraphComplete distinguishes a complete expanded graph from the
+	// partial instances retained when expansion fails. It is process-local
+	// evidence and is not part of serialized compiler output.
+	JobGraphComplete bool `json:"-"`
 }
 
 // VarsBeforeEnvironment is the vars context GitHub evaluates before any job's
@@ -310,7 +314,7 @@ func CompileWithOptions(path string, source, eventSource []byte, options Options
 // CompileWithOptionsContext compiles a workflow and permits cancellation while
 // resolving public reusable-workflow source.
 func CompileWithOptionsContext(ctx context.Context, path string, source, eventSource []byte, options Options) ([]byte, error) {
-	ir, err := compile(ctx, path, source, eventSource, options)
+	ir, err := CompileIRWithOptionsContext(ctx, path, source, eventSource, options)
 	if err != nil {
 		return nil, err
 	}
@@ -322,6 +326,14 @@ func CompileWithOptionsContext(ctx context.Context, path string, source, eventSo
 		return nil, fmt.Errorf("encode compiler IR: %w", err)
 	}
 	return out.Bytes(), nil
+}
+
+// CompileIRWithOptionsContext returns the owned compiler IR even when a
+// failure occurs after static job expansion. Callers may use that partial
+// result for diagnostics and may compile unaffected jobs separately. Every
+// retained plan still requires normal admission before execution.
+func CompileIRWithOptionsContext(ctx context.Context, path string, source, eventSource []byte, options Options) (IR, error) {
+	return compile(ctx, path, source, eventSource, options)
 }
 
 func compile(ctx context.Context, path string, source, eventSource []byte, options Options) (IR, error) {
@@ -350,7 +362,8 @@ func compile(ctx context.Context, path string, source, eventSource []byte, optio
 	cancelInProgress, cancellationErr := resolveWorkflowCancellation(path, parsed.Concurrency, context)
 	cancellationErr = processingFinding(StageExpressions, CodeExpressionInvalid, "compatibility", cancellationErr)
 	expanded, expandErr := expandJobGraph(ctx, path, source, parsed, context, options)
-	if expandErr == nil {
+	jobGraphComplete := expandErr == nil
+	if jobGraphComplete {
 		expandErr = resolveJobEnvironments(ctx, expanded.instances, event, options)
 	}
 	digest := sha256.Sum256(source)
@@ -368,7 +381,7 @@ func compile(ctx context.Context, path string, source, eventSource []byte, optio
 			Supported: true,
 			Reason:    "run-job rejects unsupported shells and local actions",
 		},
-		Jobs: expanded.instances,
+		Jobs: expanded.instances, JobGraphComplete: jobGraphComplete,
 	}
 	return ir, errors.Join(runNameErr, concurrencyErr, cancellationErr, expandErr)
 }


### PR DESCRIPTION
## Why

When a workflow's complete job graph was available but a later compiler stage failed, upload replaced the workflow with one synthetic Buildkite failure step. This hid the expanded GitHub Actions jobs, their dependencies, and which jobs contained errors.

The motivating regression was a four-job SLSA reusable workflow whose runtime-created local actions could not be resolved during compilation.

[PB-3234](https://linear.app/buildkite/issue/PB-3234/preserve-one-buildkite-step-per-expanded-gha-job-when-compilation)

## What

Preserve one Buildkite item per expanded GitHub Actions job whenever the complete graph is known before a later compiler failure:

- jobs with compiler errors become scoped synthetic failures
- their transitive dependants are skipped
- independently valid jobs keep their compiled plans and run normally

The compiler owns each expanded job's planned, failed, or blocked outcome. Runnable partial plans are recompiled after action variable resolution, admitted before upload, and emitted only when every declared dependency also has a plan. Graph drift, partial admission failure, and pipeline-generation invariant failure discard every runnable artifact and emit fail-closed job results instead. Failures before expansion completes still use one workflow-level failure item.

The items retain stable labels, keys, provider checks, and `needs` links. Runnable jobs also retain workflow, reusable-workflow, environment approval, job concurrency, output, and artifact behavior. Synthetic preparation results do not wait for workflow concurrency gates.

As a secondary change, missing runtime-created local actions identify the affected workflow, job, and action without internal placeholders or raw filesystem errors, and explain that these actions must exist before compilation.
