### PR TITLE
PB-3245: Allow reusable-workflow calls with if when the called workflow declares concurrency

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -347,7 +347,7 @@ A top-level workflow that does not declare the effective event is excluded befor
 - Caller-visible aggregate results.
 - Outputs mapped directly from `jobs.<job>.outputs.<name>`.
 - Call-level `if` over caller `github`, `inputs`, direct `needs`, and status functions.
-- Workflow-level concurrency in local and public called workflows. Groups may use the called workflow's static inputs. Each static call-matrix instance gets its own workflow gate.
+- Workflow-level concurrency in local and public called workflows, including behind a call-level `if`. Groups may use the called workflow's static inputs. Each static call-matrix instance gets its own workflow gate. See [Concurrency](#concurrency).
 
 **❌ Unsupported:**
 
@@ -523,7 +523,15 @@ jobs:
       target: ${{ matrix.target }}
 ```
 
-Nested called workflows keep nested gates. Jobs within one called workflow remain parallel except for their declared `needs` and job-level concurrency. Calls with `if` or `needs`, and jobs or nested called workflows that reuse an enclosing workflow group, are unsupported because Buildkite cannot preserve GitHub's admission order for those cases.
+Nested called workflows keep nested gates. Jobs within one called workflow remain parallel except for their declared `needs` and job-level concurrency. Calls with `needs`, and jobs or nested called workflows that reuse an enclosing workflow group, are unsupported because Buildkite cannot preserve GitHub's admission order for those cases.
+
+A call with `if` keeps the called workflow's gate. Buildkite enters the group during compilation, before the runtime evaluates the condition, so exclusion is never weaker than on GitHub:
+
+| Call condition at compile time | Gate | Diagnostic |
+| --- | --- | --- |
+| True, such as `github.event_name == 'pull_request'` on a pull request | Emitted | None |
+| False, such as the same condition on a push | Omitted; the jobs skip without entering the group, as on GitHub | None |
+| Runtime-dependent, such as `vars.DEPLOY == 'true'` | Emitted; a skipped call still waits for the group and holds it until its jobs finish | `W_REUSABLE_WORKFLOW_CONCURRENCY_ENTERED_BEFORE_CALL_CONDITION` |
 
 Buildkite queues every waiting entry. It does not replace GitHub's existing pending entry. The `queue` key is unsupported.
 

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -1333,7 +1333,80 @@ jobs:
 	}
 }
 
-func TestCompileRejectsGuardedReusableWorkflowConcurrency(t *testing.T) {
+func TestCompileKeepsCalledWorkflowConcurrencyBehindCallCondition(t *testing.T) {
+	repository := t.TempDir()
+	writeWorkflow(t, repository, "build.yml", `on: workflow_call
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps: [{run: true}]
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    steps: [{run: true}]
+`)
+	caller := writeWorkflow(t, repository, "ci.yml", `name: CI
+on: [push, pull_request]
+jobs:
+  python-runtime:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/build.yml
+`)
+	pullRequest := []byte(`{
+  "provider": "github",
+  "event": "pull_request",
+  "repository": {"owner": "buildkite", "name": "buildkite-gha"},
+  "ref": "refs/pull/42/merge",
+  "sha": "1111111111111111111111111111111111111111",
+  "actor": "buildkite-gha-smoke",
+  "payload": {"pull_request": {"base": {"ref": "main"}}}
+}`)
+	cancellation := Warning{
+		Code: "W_WORKFLOW_CONCURRENCY_CANCEL_IN_PROGRESS_IGNORED", Line: 6, Column: 11, Job: "python-runtime",
+		Message: "cancel-in-progress is ignored, so superseded builds keep running. Buildkite handles this as a pipeline setting rather than in the workflow file. Turn on Cancel Intermediate Builds under Settings > Builds. It cancels earlier running builds on the same branch, rather than per concurrency group.",
+	}
+	tests := []struct {
+		name, condition, group string
+		event                  []byte
+		warnings               []Warning
+	}{
+		{name: "condition true keeps the gate", event: pullRequest, condition: "true", group: "CI-refs/pull/42/merge", warnings: []Warning{cancellation}},
+		{name: "condition false omits the gate", event: pushEvent(t), condition: "false"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			bundle, err := CompileBundle(caller, readFile(t, caller), test.event, "0.0.0-test", testDistributionDigest, "gha-importer")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(bundle.IR.Jobs) != 2 {
+				t.Fatalf("compiled jobs = %#v, want both called jobs", bundle.IR.Jobs)
+			}
+			for _, job := range bundle.IR.Jobs {
+				if len(job.CallGuards) != 1 || job.CallGuards[0].Condition != test.condition {
+					t.Fatalf("job %q call guards = %#v, want condition %q", job.Key, job.CallGuards, test.condition)
+				}
+				switch {
+				case test.group == "" && len(job.ConcurrencyGates) != 0:
+					t.Fatalf("job %q gates = %#v, want none for a call that never runs", job.Key, job.ConcurrencyGates)
+				case test.group != "" && (len(job.ConcurrencyGates) != 1 || job.ConcurrencyGates[0].Group != test.group):
+					t.Fatalf("job %q gates = %#v, want group %q", job.Key, job.ConcurrencyGates, test.group)
+				}
+			}
+			if gated := bytes.Contains(bundle.Pipeline, []byte("Start reusable-workflow concurrency")); gated != (test.group != "") {
+				t.Fatalf("pipeline gate emitted = %t, want %t\n%s", gated, test.group != "", bundle.Pipeline)
+			}
+			if !reflect.DeepEqual(bundle.IR.Warnings, test.warnings) {
+				t.Fatalf("warnings = %#v, want %#v", bundle.IR.Warnings, test.warnings)
+			}
+		})
+	}
+}
+
+func TestCompileOmitsCalledWorkflowConcurrencyGateForLiteralFalseCall(t *testing.T) {
 	repository := t.TempDir()
 	writeWorkflow(t, repository, "reusable.yml", `on: workflow_call
 concurrency: deploy
@@ -1348,13 +1421,78 @@ jobs:
     if: false
     uses: ./.github/workflows/reusable.yml
 `)
-	_, err := CompileBundle(caller, readFile(t, caller), pushEvent(t), "0.0.0-test", testDistributionDigest, "gha-importer")
-	if err == nil || !strings.Contains(err.Error(), "called-workflow concurrency is unsupported for guarded reusable-workflow calls") {
-		t.Fatalf("CompileBundle() error = %v, want guarded concurrency rejection", err)
+	bundle, err := CompileBundle(caller, readFile(t, caller), pushEvent(t), "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bundle.IR.Jobs) != 1 || len(bundle.IR.Jobs[0].ConcurrencyGates) != 0 || bundle.IR.Jobs[0].CallGuards[0].Condition != "false" {
+		t.Fatalf("compiled jobs = %#v, want an ungated job that skips at runtime", bundle.IR.Jobs)
+	}
+	if len(bundle.IR.Warnings) != 0 || bytes.Contains(bundle.Pipeline, []byte("concurrency_group:")) {
+		t.Fatalf("warnings = %#v, pipeline:\n%s", bundle.IR.Warnings, bundle.Pipeline)
 	}
 }
 
-func TestCompileRejectsNestedReusableWorkflowConcurrencyUnderGuard(t *testing.T) {
+func TestCompileWarnsWhenRuntimeCallConditionKeepsCalledWorkflowConcurrency(t *testing.T) {
+	repository := t.TempDir()
+	writeWorkflow(t, repository, "deploy.yml", `on:
+  workflow_call:
+    inputs:
+      target: {type: string, required: true}
+concurrency:
+  group: deploy-${{ inputs.target }}
+  cancel-in-progress: true
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps: [{run: true}]
+`)
+	caller := writeWorkflow(t, repository, "caller.yml", `on: push
+jobs:
+  deploy:
+    if: vars.DEPLOY == 'true'
+    strategy:
+      matrix:
+        target: [production, staging]
+    uses: ./.github/workflows/deploy.yml
+    with:
+      target: ${{ matrix.target }}
+`)
+	bundle, err := CompileBundle(caller, readFile(t, caller), pushEvent(t), "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bundle.IR.Jobs) != 2 {
+		t.Fatalf("compiled jobs = %#v, want one per matrix target", bundle.IR.Jobs)
+	}
+	for _, job := range bundle.IR.Jobs {
+		target := job.Inputs["target"].(string)
+		if len(job.ConcurrencyGates) != 1 || job.ConcurrencyGates[0].Group != "deploy-"+target {
+			t.Fatalf("job %q gates = %#v, want the called-workflow gate", job.Key, job.ConcurrencyGates)
+		}
+		if len(job.CallGuards) != 1 || job.CallGuards[0].Condition != "(vars.deploy == 'true')" {
+			t.Fatalf("job %q call guards = %#v, want the residual vars condition", job.Key, job.CallGuards)
+		}
+	}
+	want := []Warning{
+		{
+			Code: "W_REUSABLE_WORKFLOW_CONCURRENCY_ENTERED_BEFORE_CALL_CONDITION", Line: 8, Column: 11, Job: "deploy",
+			Message: `The call condition depends on runtime values, so Buildkite enters the concurrency group of reusable workflow "./.github/workflows/deploy.yml" before it knows whether the call runs. When the condition is false, the skipped jobs still wait for the group and hold it until they finish. GitHub never enters the group for a skipped call. Write the condition with github, inputs, or event values only, which resolve during compilation, if the wait matters.`,
+		},
+		{
+			Code: "W_WORKFLOW_CONCURRENCY_CANCEL_IN_PROGRESS_IGNORED", Line: 8, Column: 11, Job: "deploy",
+			Message: "cancel-in-progress is ignored, so superseded builds keep running. Buildkite handles this as a pipeline setting rather than in the workflow file. Turn on Cancel Intermediate Builds under Settings > Builds. It cancels earlier running builds on the same branch, rather than per concurrency group.",
+		},
+	}
+	if !reflect.DeepEqual(bundle.IR.Warnings, want) {
+		t.Fatalf("warnings = %#v, want one of each per call site", bundle.IR.Warnings)
+	}
+	if count := bytes.Count(bundle.Pipeline, []byte("Start reusable-workflow concurrency")); count != 2 {
+		t.Fatalf("pipeline reusable gates = %d, want one per matrix target\n%s", count, bundle.Pipeline)
+	}
+}
+
+func TestCompileInheritsCallConditionForNestedCalledWorkflowConcurrency(t *testing.T) {
 	repository := t.TempDir()
 	writeWorkflow(t, repository, "middle.yml", `on: workflow_call
 jobs:
@@ -1368,15 +1506,98 @@ jobs:
     runs-on: ubuntu-latest
     steps: [{run: true}]
 `)
+	tests := []struct {
+		name, condition string
+		gated           bool
+		warnings        int
+	}{
+		{name: "known true", condition: "github.ref == 'refs/heads/main'", gated: true},
+		{name: "known false", condition: "github.ref == 'refs/heads/release'", gated: false},
+		{name: "runtime", condition: "vars.DEPLOY == 'true'", gated: true, warnings: 1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			caller := writeWorkflow(t, repository, "caller.yml", "on: push\njobs:\n  call:\n    if: "+test.condition+"\n    uses: ./.github/workflows/middle.yml\n")
+			bundle, err := CompileBundle(caller, readFile(t, caller), pushEvent(t), "0.0.0-test", testDistributionDigest, "gha-importer")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(bundle.IR.Jobs) != 1 || (len(bundle.IR.Jobs[0].ConcurrencyGates) != 0) != test.gated {
+				t.Fatalf("compiled jobs = %#v, want gated %t", bundle.IR.Jobs, test.gated)
+			}
+			if len(bundle.IR.Warnings) != test.warnings {
+				t.Fatalf("warnings = %#v, want %d", bundle.IR.Warnings, test.warnings)
+			}
+			if test.warnings == 1 && (bundle.IR.Warnings[0].Code != "W_REUSABLE_WORKFLOW_CONCURRENCY_ENTERED_BEFORE_CALL_CONDITION" || bundle.IR.Warnings[0].Line != 5 || bundle.IR.Warnings[0].Job != "nested") {
+				t.Fatalf("warning = %#v, want the root call position and the nested call job", bundle.IR.Warnings[0])
+			}
+		})
+	}
+}
+
+func TestCompileKeepsEnclosingGateWhenNestedCallConditionIsFalse(t *testing.T) {
+	repository := t.TempDir()
+	writeWorkflow(t, repository, "inner.yml", `on: workflow_call
+concurrency: inner
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps: [{run: true}]
+`)
+	writeWorkflow(t, repository, "outer.yml", `on: workflow_call
+concurrency: outer
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps: [{run: true}]
+  inner:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/inner.yml
+`)
 	caller := writeWorkflow(t, repository, "caller.yml", `on: push
 jobs:
   call:
-    if: github.ref == 'refs/heads/main'
-    uses: ./.github/workflows/middle.yml
+    uses: ./.github/workflows/outer.yml
+`)
+	bundle, err := CompileBundle(caller, readFile(t, caller), pushEvent(t), "0.0.0-test", testDistributionDigest, "gha-importer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bundle.IR.Jobs) != 2 {
+		t.Fatalf("compiled jobs = %#v, want both flattened jobs", bundle.IR.Jobs)
+	}
+	for _, job := range bundle.IR.Jobs {
+		if len(job.ConcurrencyGates) != 1 || job.ConcurrencyGates[0].Group != "outer" {
+			t.Fatalf("job %q gates = %#v, want only the enclosing gate", job.Key, job.ConcurrencyGates)
+		}
+	}
+	if count := bytes.Count(bundle.Pipeline, []byte("Start reusable-workflow concurrency")); count != 1 {
+		t.Fatalf("pipeline reusable gates = %d, want the outer gate only\n%s", count, bundle.Pipeline)
+	}
+}
+
+func TestCompileStillRejectsGuardedReusableWorkflowConcurrencyWithPrerequisite(t *testing.T) {
+	repository := t.TempDir()
+	writeWorkflow(t, repository, "reusable.yml", `on: workflow_call
+concurrency: deploy
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps: [{run: true}]
+`)
+	caller := writeWorkflow(t, repository, "caller.yml", `on: push
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps: [{run: true}]
+  call:
+    if: false
+    needs: prepare
+    uses: ./.github/workflows/reusable.yml
 `)
 	_, err := CompileBundle(caller, readFile(t, caller), pushEvent(t), "0.0.0-test", testDistributionDigest, "gha-importer")
-	if err == nil || !strings.Contains(err.Error(), "called-workflow concurrency is unsupported for guarded reusable-workflow calls") {
-		t.Fatalf("CompileBundle() error = %v, want inherited guarded concurrency rejection", err)
+	if err == nil || !strings.Contains(err.Error(), "called-workflow concurrency is unsupported for reusable-workflow calls with prerequisites") {
+		t.Fatalf("CompileBundle() error = %v, want concurrency prerequisite rejection even for a call that never runs", err)
 	}
 }
 

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -512,6 +512,15 @@ func workflowCancellationWarning(position workflow.Position) Warning {
 	}
 }
 
+func guardedReusableConcurrencyWarning(position workflow.Position, calleePath string) Warning {
+	return Warning{
+		Code:    "W_REUSABLE_WORKFLOW_CONCURRENCY_ENTERED_BEFORE_CALL_CONDITION",
+		Line:    position.Line,
+		Column:  position.Column,
+		Message: fmt.Sprintf("The call condition depends on runtime values, so Buildkite enters the concurrency group of reusable workflow %q before it knows whether the call runs. When the condition is false, the skipped jobs still wait for the group and hold it until they finish. GitHub never enters the group for a skipped call. Write the condition with github, inputs, or event values only, which resolve during compilation, if the wait matters.", calleePath),
+	}
+}
+
 func legacyCheckoutWarning(position workflow.Position, release string, defaultsToFullHistory bool) Warning {
 	generation := "v2"
 	if defaultsToFullHistory {

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 
 	actionsource "github.com/buildkite/buildkite-gha/internal/action/source"
@@ -59,9 +60,26 @@ type secretBinding struct {
 }
 
 type sourcedCallGuard struct {
-	condition    string
+	condition string
+	// known reports that condition reduced to the constant value during
+	// compilation, so the runtime outcome of this guard is already decided.
+	known, value bool
 	inputs       reusableInputs
 	needBindings map[string]needBinding
+}
+
+// staticCallGuardValue reports whether a guard chain is decided during
+// compilation. The chain is false when any guard is known false and true when
+// every guard is known true; otherwise the runtime decides.
+func staticCallGuardValue(guards []sourcedCallGuard) (known, value bool) {
+	known = true
+	for _, guard := range guards {
+		if guard.known && !guard.value {
+			return true, false
+		}
+		known = known && guard.known
+	}
+	return known, known
 }
 
 type reusableInputs struct {
@@ -111,6 +129,9 @@ type reusableResolver struct {
 	scan               workflowScan
 	warnings           []Warning
 	warnedCancellation map[workflow.Position]bool
+	// warnedGuardedConcurrency records the root call positions whose
+	// runtime-decided guard already produced a concurrency wait warning.
+	warnedGuardedConcurrency map[workflow.Position]bool
 }
 
 // workflowScan is what static discovery learns about a workflow and every
@@ -170,7 +191,8 @@ func resolveReusableWorkflows(ctx context.Context, path string, source []byte, p
 	resolver := reusableResolver{
 		workspaceRoot: rootSource.repositoryRoot, repositorySource: newMemoizedActionSource(repositorySource), stack: []reusableSourceIdentity{rootSource.identity}, context: context,
 		rootPermissions: effectivePermissions(nil, parsed.Permissions, nil, false), scan: scan,
-		warnedCancellation: make(map[workflow.Position]bool),
+		warnedCancellation:       make(map[workflow.Position]bool),
+		warnedGuardedConcurrency: make(map[workflow.Position]bool),
 	}
 	defer func() {
 		for _, materialized := range resolver.materialized {
@@ -334,19 +356,21 @@ func (resolver *reusableResolver) resolve(ctx context.Context, current reusableW
 				}
 				return reusableResolution{}, locatedJobWrappedError(path, job, job.Span.Start.Line, job.Span.Start.Column, "reduce reusable-workflow call condition", err)
 			}
-			condition := reduced.Source
-			if reduced.Known {
-				condition = fmt.Sprint(reduced.Value)
+			guard := sourcedCallGuard{
+				condition: reduced.Source, inputs: cloneReusableInputs(inputs), needBindings: cloneNeedBindings(callNeedBindings),
 			}
-			if err := validateCompileSite(condition, expression.ProfileCallCondition, expression.ResultBoolean); err != nil {
+			if reduced.Known {
+				guard.known = true
+				guard.value, _ = reduced.Value.(bool)
+				guard.condition = strconv.FormatBool(guard.value)
+			}
+			if err := validateCompileSite(guard.condition, expression.ProfileCallCondition, expression.ResultBoolean); err != nil {
 				if blockerDetailUnsafe {
 					err = suppressBlockerDetail(err)
 				}
 				return reusableResolution{}, locatedJobWrappedError(path, job, job.Span.Start.Line, job.Span.Start.Column, "reusable-workflow call condition", err)
 			}
-			calleeGuards = append(cloneSourcedCallGuards(callGuards), sourcedCallGuard{
-				condition: condition, inputs: cloneReusableInputs(inputs), needBindings: cloneNeedBindings(callNeedBindings),
-			})
+			calleeGuards = append(cloneSourcedCallGuards(callGuards), guard)
 		}
 		if depth >= MaxReusableWorkflowDepth {
 			return reusableResolution{}, locatedJobError(path, job, call.Span.Start.Line, call.Span.Start.Column, fmt.Sprintf("reusable-workflow nesting exceeds maximum depth %d", MaxReusableWorkflowDepth))
@@ -444,9 +468,6 @@ func (resolver *reusableResolver) resolve(ctx context.Context, current reusableW
 			}
 			calleeConcurrencyGates := concurrencyGates
 			if callee.Concurrency != nil {
-				if len(calleeGuards) != 0 {
-					return reusableResolution{}, locatedJobError(path, job, call.Span.Start.Line, call.Span.Start.Column, "called-workflow concurrency is unsupported for guarded reusable-workflow calls")
-				}
 				concurrencyContext := resolver.context
 				concurrencyContext.Inputs = callInputs.values
 				concurrencyContext.Matrix = nil
@@ -462,12 +483,28 @@ func (resolver *reusableResolver) resolve(ctx context.Context, current reusableW
 				if len(needs) != 0 {
 					return reusableResolution{}, locatedJobError(path, job, call.Span.Start.Line, call.Span.Start.Column, "called-workflow concurrency is unsupported for reusable-workflow calls with prerequisites")
 				}
-				calleeConcurrencyGates = append(append([]WorkflowConcurrencyGate(nil), concurrencyGates...), WorkflowConcurrencyGate{ID: callNamespace, Group: group})
-				if cancelInProgress && !resolver.warnedCancellation[calleeCallPosition] {
-					resolver.warnedCancellation[calleeCallPosition] = true
-					warning := workflowCancellationWarning(calleeCallPosition)
-					warning.Job = job.ID
-					resolver.warnings = append(resolver.warnings, warning)
+				// A call guard that is already false never runs the called
+				// workflow, so GitHub never enters its group; the skipped jobs
+				// must not wait for or hold the gate. Every other guard keeps
+				// the gate: Buildkite enters the group before the runtime
+				// evaluates the guard, which is never weaker than GitHub's
+				// mutual exclusion, and a runtime-decided guard warns about
+				// the wait a skipped call may still incur.
+				guardKnown, guardValue := staticCallGuardValue(calleeGuards)
+				if !guardKnown || guardValue {
+					calleeConcurrencyGates = append(append([]WorkflowConcurrencyGate(nil), concurrencyGates...), WorkflowConcurrencyGate{ID: callNamespace, Group: group})
+					if !guardKnown && !resolver.warnedGuardedConcurrency[calleeCallPosition] {
+						resolver.warnedGuardedConcurrency[calleeCallPosition] = true
+						warning := guardedReusableConcurrencyWarning(calleeCallPosition, calleeSource.displayPath)
+						warning.Job = job.ID
+						resolver.warnings = append(resolver.warnings, warning)
+					}
+					if cancelInProgress && !resolver.warnedCancellation[calleeCallPosition] {
+						resolver.warnedCancellation[calleeCallPosition] = true
+						warning := workflowCancellationWarning(calleeCallPosition)
+						warning.Job = job.ID
+						resolver.warnings = append(resolver.warnings, warning)
+					}
 				}
 			}
 			resolver.stack = append(resolver.stack, calleeSource.identity)
@@ -802,7 +839,8 @@ func cloneSourcedCallGuards(guards []sourcedCallGuard) []sourcedCallGuard {
 	cloned := make([]sourcedCallGuard, len(guards))
 	for i, guard := range guards {
 		cloned[i] = sourcedCallGuard{
-			condition: guard.condition, inputs: cloneReusableInputs(guard.inputs), needBindings: cloneNeedBindings(guard.needBindings),
+			condition: guard.condition, known: guard.known, value: guard.value,
+			inputs: cloneReusableInputs(guard.inputs), needBindings: cloneNeedBindings(guard.needBindings),
 		}
 	}
 	return cloned


### PR DESCRIPTION
## Why

A reusable-workflow call with an `if` fails to compile when the called workflow declares `concurrency`, and the whole selected workflow becomes a failing replacement step:

```yaml
# .github/workflows/ci.yml
jobs:
  python-runtime:
    if: github.event_name == 'pull_request'
    uses: ./.github/workflows/build-exe-for-python-sdk.yml

# .github/workflows/build-exe-for-python-sdk.yml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

```
called-workflow concurrency is unsupported for guarded reusable-workflow calls
```

The rejection came from 70435a425f2a4479271c2d758d77cd0f351a5366 together with two cases that really are unsafe: calls with `needs`, and prerequisites that share the called workflow's group (which deadlocks the ordered Buildkite gate). Guards have neither problem. The gate's start and finish steps open and close correctly when the flattened jobs skip at runtime, so keeping the gate is never weaker than GitHub's mutual exclusion.

## What

The call compiles and keeps the called workflow's concurrency gate. The condition decides what happens to the gate:

| Call condition at compile time | Gate | Diagnostic |
| --- | --- | --- |
| True (the example on a pull request) | Emitted, as before for unguarded calls | None |
| False (the example on a push, or `if: false`) | Omitted; the jobs skip without entering the group, as on GitHub | None |
| Runtime-dependent (`vars.DEPLOY == 'true'`) | Emitted; a skipped call still waits for the group and holds it until its jobs finish | New warning `W_REUSABLE_WORKFLOW_CONCURRENCY_ENTERED_BEFORE_CALL_CONDITION` |

Omitting the gate for a condition that is already false matters when the group is shared, such as `deploy-production`: otherwise every push build's skipped jobs would queue behind a running deploy from another build before they could skip.

Dropping the gate with a warning was considered and rejected: it would silently remove mutual exclusion for a call that can run, for example two production deploys at once.

Calls with `needs` stay rejected, including under a false condition, so validation stays exhaustive. Docs: `docs/compatibility.md`.

Linear: PB-3245
