### PR TITLE
PB-3246: Resolve compile-time vars references to empty strings when the repository defines no variables

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -722,9 +722,13 @@ combined). Its rejection, rate limit (10 requests per job per hour), or
 GitHub outage fails the compile of every workflow that references `vars` with
 the backend's error and any `Retry-After` delay; other workflows still upload.
 A backend without the endpoint, or an organization that has opted out,
-returns 404, which leaves both scopes empty rather than failing the compile.
-Outside a Buildkite job, `compile` has no variable source, so the scopes are
-empty.
+returns 404, which resolves both scopes as empty rather than failing the
+compile. A repository and organization that define no variables resolve the
+same way. Either way every `vars` name evaluates to an empty string, in
+compile-time fields too, so `runs-on: ${{ vars.FAILOVER_RUNNER ||
+'ubuntu-latest' }}` selects `ubuntu-latest`. Outside a Buildkite job,
+`compile` has no variable source: runtime references evaluate to empty
+strings, and compile-time fields that reference `vars` fail to compile.
 
 Each job's plan carries the scopes as `organization_vars`, `repository_vars`,
 and, for jobs that declare an environment, `environment_vars`. The compiler

--- a/internal/cli/variables.go
+++ b/internal/cli/variables.go
@@ -41,8 +41,9 @@ func variableSourceFromAgent(clientVersion string) variableSource {
 // every result, including failures, per repository, so one upload of many
 // workflows consumes one request against the backend's per-job budget and
 // retried compiles fail consistently without new requests. A 404 means the
-// backend offers no repository or organization scope; it memoizes as empty
-// scopes so names no scope defines keep evaluating as empty strings.
+// backend offers no repository or organization scope; it memoizes as resolved
+// empty scopes so names no scope defines evaluate as empty strings in
+// compile-time fields as well as at runtime.
 type agentVariableSource struct {
 	resolver *gharuntime.AgentVariableResolver
 
@@ -66,10 +67,11 @@ func (a *agentVariableSource) ResolveVariables(ctx context.Context, owner, repos
 	result := agentVariableResolution{}
 	switch {
 	case errors.Is(err, gharuntime.ErrVariablesUnavailable):
+		result.vars = compiler.VariableSources{Resolved: true}
 	case err != nil:
 		result.err = fmt.Errorf("variables: %w", err)
 	default:
-		result.vars = compiler.VariableSources{Repository: snapshot.Repository, Organization: snapshot.Organization}
+		result.vars = compiler.VariableSources{Repository: snapshot.Repository, Organization: snapshot.Organization, Resolved: true}
 	}
 	a.resolved[repo] = result
 	return result.vars, result.err

--- a/internal/cli/variables_test.go
+++ b/internal/cli/variables_test.go
@@ -227,31 +227,71 @@ func TestRunUploadSkipsVariableResolutionWithoutReferences(t *testing.T) {
 	}
 }
 
-// TestRunUploadTreatsAbsentVariableScopesAsEmpty proves a backend without the
-// variables endpoint (404) leaves the scopes empty: runtime references keep
-// evaluating to empty strings and the upload succeeds. Compile-time fields
-// that need a value still fail as they did before.
+// undefinedVariablesWorkflow reads a variable no scope defines in a
+// compile-time field with a literal fallback, as failover runner selection
+// does, and in a runtime step.
+const undefinedVariablesWorkflow = `on: push
+jobs:
+  test:
+    runs-on: ${{ vars.CI_FAILOVER_LINUX || 'ubuntu-latest' }}
+    steps:
+      - run: echo "${{ vars.AWS_REGION }}"
+`
+
+// agentEmptyVariablesHandler answers github-actions/variables with status
+// and, for 200, a repository and organization that define no variables. It
+// counts requests.
+func agentEmptyVariablesHandler(t *testing.T, status int) (http.HandlerFunc, *int) {
+	t.Helper()
+	requests := new(int)
+	return func(w http.ResponseWriter, r *http.Request) {
+		*requests++
+		if r.Method != http.MethodPost || !strings.HasSuffix(r.URL.Path, "/github-actions/variables") {
+			t.Errorf("variables request = %s %s", r.Method, r.URL.Path)
+		}
+		if status != http.StatusOK {
+			w.WriteHeader(status)
+			return
+		}
+		_, _ = w.Write([]byte(`{"repository_variables":[],"organization_variables":[]}`))
+	}, requests
+}
+
+// TestRunUploadTreatsAbsentVariableScopesAsEmpty proves that a backend
+// without the variables endpoint (404) and a repository that defines no
+// variables (200 with empty scopes) both resolve every vars reference to an
+// empty string, in compile-time fields and at runtime, so the upload succeeds
+// with the literal fallback runner. Without a source the same compile-time
+// reference fails; TestRunCompileResolvesVariablesThroughAgent covers it.
 func TestRunUploadTreatsAbsentVariableScopesAsEmpty(t *testing.T) {
 	requireImporterHost(t)
-	variables, variableRequests := agentVariablesHandler(t, http.StatusNotFound, "")
-	agent, _ := agentStub(t, "job-secret", http.StatusOK, variables)
-	setAgentResolutionEnvironment(t, agent.URL)
-	t.Setenv("BUILDKITE", "true")
-	t.Setenv("BUILDKITE_STEP_KEY", "variables-agent-absent-importer")
-	eventPath := pushEventPath(t)
-	workflows := writeUploadWorkflows(t, map[string]string{"plain.yml": "on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo \"${{ vars.AWS_REGION }}\"\n"})
+	for name, status := range map[string]int{"endpoint absent": http.StatusNotFound, "scopes empty": http.StatusOK} {
+		t.Run(name, func(t *testing.T) {
+			variables, variableRequests := agentEmptyVariablesHandler(t, status)
+			agent, _ := agentStub(t, "job-secret", http.StatusOK, variables)
+			setAgentResolutionEnvironment(t, agent.URL)
+			t.Setenv("BUILDKITE", "true")
+			t.Setenv("BUILDKITE_STEP_KEY", "variables-agent-absent-importer")
+			eventPath := pushEventPath(t)
+			workflows := writeUploadWorkflows(t, map[string]string{"plain.yml": undefinedVariablesWorkflow})
 
-	runner := &cliCaptureRunner{webhookErr: errors.New("metadata must not be read with --event-path")}
-	var stdout, stderr bytes.Buffer
-	if code := run(append([]string{"upload", "--event-path", eventPath}, workflows...), &stdout, &stderr, "dev", runner); code != 0 {
-		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
-	}
-	if *variableRequests != 1 {
-		t.Fatalf("variables requests = %d, want 1", *variableRequests)
-	}
-	plans := uploadedPlans(t, runner)
-	if len(plans["test"]) != 1 || len(plans["test"][0].Vars()) != 0 {
-		t.Fatalf("uploaded plans = %v", plans)
+			runner := &cliCaptureRunner{webhookErr: errors.New("metadata must not be read with --event-path")}
+			var stdout, stderr bytes.Buffer
+			if code := run(append([]string{"upload", "--event-path", eventPath}, workflows...), &stdout, &stderr, "dev", runner); code != 0 {
+				t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+			}
+			if *variableRequests != 1 {
+				t.Fatalf("variables requests = %d, want 1", *variableRequests)
+			}
+			plans := uploadedPlans(t, runner)
+			if len(plans["test"]) != 1 || len(plans["test"][0].Vars()) != 0 {
+				t.Fatalf("uploaded plans = %v", plans)
+			}
+			pipeline := string(runner.commands[len(runner.commands)-1].stdin)
+			if !strings.Contains(pipeline, defaultNobleRunnerImage) {
+				t.Fatalf("pipeline did not select the literal fallback runner ubuntu-latest:\n%s", pipeline)
+			}
+		})
 	}
 }
 

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -285,7 +285,7 @@ func ValidateEventWithOptionsContext(ctx context.Context, path string, source, e
 		}, errors.Join(parseErr, eventErr, optionsErr)
 	}
 	event.Trust = options.EventTrust
-	context := compileContext(event, plan.MergeVars(options.Vars.Organization, options.Vars.Repository), path, parsed.Name)
+	context := compileContext(event, options.Vars.CompileTimeVars(), path, parsed.Name)
 	context.Inputs = workflowDispatchInputs(parsed, event)
 	_, runNameErr := resolveWorkflowRunName(path, parsed, context)
 	_, concurrencyErr := resolveConcurrency(path, "", parsed.Concurrency, context, nil)
@@ -354,7 +354,7 @@ func compile(ctx context.Context, path string, source, eventSource []byte, optio
 	}
 	event.Trust = options.EventTrust
 	organizationVars, repositoryVars := cloneMap(options.Vars.Organization), cloneMap(options.Vars.Repository)
-	context := compileContext(event, plan.MergeVars(organizationVars, repositoryVars), path, parsed.Name)
+	context := compileContext(event, options.Vars.CompileTimeVars(), path, parsed.Name)
 	context.Inputs = workflowDispatchInputs(parsed, event)
 	runName, runNameErr := resolveWorkflowRunName(path, parsed, context)
 	workflowConcurrencyGroup, concurrencyErr := resolveConcurrency(path, "", parsed.Concurrency, context, nil)

--- a/internal/compiler/config.go
+++ b/internal/compiler/config.go
@@ -84,6 +84,25 @@ const (
 type VariableSources struct {
 	Organization map[string]string
 	Repository   map[string]string
+	// Resolved reports that a variable source answered for the event
+	// repository, so an empty scope means the repository defines no variable
+	// rather than that no source was consulted. Compile-time fields resolve a
+	// name no scope defines to an empty string only when Resolved is true;
+	// without a source, such as compile outside a Buildkite job, the
+	// reference fails to compile. Runner-evaluated positions never need this
+	// distinction: their vars context is the job plan's scopes.
+	Resolved bool
+}
+
+// CompileTimeVars is the vars context of compile-time fields: repository over
+// organization variables. It is nil when no source resolved the scopes and a
+// non-nil, possibly empty, map when one did.
+func (sources VariableSources) CompileTimeVars() map[string]string {
+	merged := plan.MergeVars(sources.Organization, sources.Repository)
+	if merged == nil && sources.Resolved {
+		merged = map[string]string{}
+	}
+	return merged
 }
 
 // CacheVolume is one Buildkite Hosted cache volume attached to a runner target.

--- a/internal/compiler/config_test.go
+++ b/internal/compiler/config_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"maps"
 	"reflect"
 	"slices"
 	"strings"
@@ -339,6 +340,72 @@ jobs:
 	}
 	if len(ir.Jobs) != 1 || !slices.Equal(ir.Jobs[0].RunsOn, []string{"self-hosted", "custom-linux"}) || ir.Jobs[0].Queue != target.Queue || ir.Jobs[0].RuntimeImage != target.Image {
 		t.Fatalf("expression-selected runner = %#v", ir.Jobs)
+	}
+}
+
+// TestResolvedEmptyVariableScopesEvaluateAsEmptyStrings proves the difference
+// between "no variable source" and "a source that defines no variable": the
+// same runs-on fallback expression fails to compile without a source and
+// falls back to its literal when a source resolved empty scopes, as it does
+// on GitHub for a repository without that variable.
+func TestResolvedEmptyVariableScopesEvaluateAsEmptyStrings(t *testing.T) {
+	workflow := []byte(`on: push
+jobs:
+  test:
+    name: build-${{ vars.CI_FAILOVER_LINUX }}
+    runs-on: ${{ vars.CI_FAILOVER_LINUX || 'ubuntu-24.04' }}
+    steps:
+      - run: true
+`)
+	compile := func(vars VariableSources) (IR, error) {
+		compiled, err := CompileWithOptions("fallback.yml", workflow, pushEvent(t), Options{
+			EventTrust: EventTrusted,
+			Vars:       vars,
+			Runners:    RunnerPolicy{Labels: map[string]string{"ubuntu-24.04": "linux"}},
+		})
+		if err != nil {
+			return IR{}, err
+		}
+		var ir IR
+		if err := json.Unmarshal(compiled, &ir); err != nil {
+			t.Fatal(err)
+		}
+		return ir, nil
+	}
+
+	if _, err := compile(VariableSources{}); err == nil || !strings.Contains(err.Error(), `unavailable value "vars.ci_failover_linux"`) {
+		t.Fatalf("CompileWithOptions() without a variable source error = %v, want unavailable value", err)
+	}
+	for name, vars := range map[string]VariableSources{
+		"resolved nil scopes":   {Resolved: true},
+		"resolved empty scopes": {Resolved: true, Organization: map[string]string{}, Repository: map[string]string{}},
+		"resolved other names":  {Resolved: true, Repository: map[string]string{"OTHER": "value"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ir, err := compile(vars)
+			if err != nil {
+				t.Fatalf("CompileWithOptions() = %v", err)
+			}
+			if len(ir.Jobs) != 1 || ir.Jobs[0].Label != "build-" || !slices.Equal(ir.Jobs[0].RunsOn, []string{"ubuntu-24.04"}) || ir.Jobs[0].Queue != "linux" {
+				t.Fatalf("compiled job = %#v, want the literal fallback runner and an empty variable in the name", ir.Jobs)
+			}
+		})
+	}
+}
+
+func TestVariableSourcesCompileTimeVars(t *testing.T) {
+	if vars := (VariableSources{}).CompileTimeVars(); vars != nil {
+		t.Fatalf("CompileTimeVars() without a source = %#v, want nil", vars)
+	}
+	if vars := (VariableSources{Repository: map[string]string{}}).CompileTimeVars(); vars != nil {
+		t.Fatalf("CompileTimeVars() with unresolved empty scopes = %#v, want nil", vars)
+	}
+	if vars := (VariableSources{Resolved: true}).CompileTimeVars(); vars == nil || len(vars) != 0 {
+		t.Fatalf("CompileTimeVars() with resolved empty scopes = %#v, want an empty map", vars)
+	}
+	vars := VariableSources{Resolved: true, Organization: map[string]string{"REGION": "org", "Registry": "ghcr"}, Repository: map[string]string{"region": "repo"}}.CompileTimeVars()
+	if !maps.Equal(vars, map[string]string{"region": "repo", "Registry": "ghcr"}) {
+		t.Fatalf("CompileTimeVars() = %#v, want repository over organization with case-insensitive override", vars)
 	}
 }
 


### PR DESCRIPTION
## Why

A `runs-on` that falls back when a repository variable is missing failed to compile inside a Buildkite job, even though the Agent API answered that the repository defines no variables (or that the endpoint is not available yet):

```yaml
runs-on: ${{ vars.DSH_CI_FAILOVER_LINUX || 'dsh-ubuntu-24-04-16core' }}
```

```
E_EXPRESSION_INVALID job "node-24": runs-on expression cannot be resolved at compile time: compile-time expression references unavailable value "vars.dsh_ci_failover_linux"
```

Runtime fields already treated such names as empty strings; compile-time fields did not, which contradicted `docs/compatibility.md`.

## What

When the variables source answered (200 with empty scopes, or 404 because the endpoint is not rolled out), compile-time `vars` references now evaluate to the empty string, so the example above selects `dsh-ubuntu-24-04-16core`. Without a source (`compile` outside a Buildkite job) compile-time `vars` references still fail, as before.

The change distinguishes "no source answered" from "source answered with nothing": `VariableSources` records whether scopes were resolved and hands the compiler an empty map instead of `nil` in the second case.
