### PR TITLE
PB-3247: Support the runner.environment context

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1011,7 +1011,7 @@ Conditions support computed object indexes, numeric array indexes, whole
 | Context | Job `if` | Step `if` |
 | --- | --- | --- |
 | `github.actor`, `github.base_ref`, `github.event_name`, `github.head_ref`, `github.ref`, `github.ref_name`, `github.ref_type`, `github.repository`, `github.repository_owner`, `github.sha`, `github.workflow_ref`, `github.workflow_sha` | ✅ Yes | ✅ Yes |
-| `runner.os`, `runner.arch` | ✅ Yes | ✅ Yes |
+| `runner.os`, `runner.arch`, `runner.environment` | ✅ Yes | ✅ Yes |
 | `runner.temp` | ❌ No | ✅ Yes |
 | `needs.<job>.result`, `needs.<job>.outputs.<name>` | ✅ Yes | ✅ Yes |
 | `matrix.<name>` | ✅ Yes | ✅ Yes |
@@ -1091,6 +1091,21 @@ another function, remain unsupported. These limits do not apply to access
 rooted at `github.event`.
 
 `runner.os` and `runner.arch` resolve to `Linux`/`X64` or `macOS`/`ARM64`.
+`runner.environment` is always `self-hosted`. GitHub's service assigns
+`github-hosted` only to runners GitHub provisions and `self-hosted` to every
+runner registered by someone else, including managed providers such as Depot,
+Namespace, and actions-runner-controller; the runner never derives it from
+`runs-on` labels. A Buildkite agent is in the same class whether it runs on
+Buildkite hosted agents or your own infrastructure. There is no third value
+and no override: actions such as `github/codeql-action` compare the exact
+strings, so an unknown value would skip their self-hosted cleanup while also
+missing hosted-only behavior. Steps that gate on
+`runner.environment == 'github-hosted'` therefore skip on every queue: the
+compiler and runtime treat the value as known, so an action behind that gate
+is never prepared: job setup does not download its source or pull its prebuilt
+Docker image, its `pre` and `post` hooks never run, and its `github.token`
+default grants no token authority. Review such steps if they select a proxy,
+cache, or credential path that your agents need.
 After runner setup, step runtime fields and job outputs can also use
 `runner.temp`, which resolves to the canonical temporary directory exposed as
 `RUNNER_TEMP`. Other runner fields and compile-time positions that require
@@ -1619,7 +1634,9 @@ The runtime sets `GITHUB_WORKFLOW` to the workflow's top-level `name`. If the wo
 
 Linux labels use the corresponding Noble or Jammy hosted-toolchains image.
 macOS agents must provide tools used by shell steps. These images do not provide GitHub image parity. The runtime
-sets `RUNNER_OS` and `RUNNER_ARCH` to `Linux`/`X64` or `macOS`/`ARM64`.
+sets `RUNNER_OS` and `RUNNER_ARCH` to `Linux`/`X64` or `macOS`/`ARM64`, and
+`RUNNER_ENVIRONMENT` to `self-hosted`. Workflow and step environment entries
+cannot override these values.
 
 `RUNNER_TOOL_CACHE` is job-private unless the Linux job selects an immutable
 image with `/opt/hostedtoolcache`, which the default and configured

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -1040,6 +1040,8 @@ runs:
 		{name: "step", condition: "        if: false\n"},
 		{name: "job", jobIf: "    if: false\n"},
 		{name: "matrix", condition: "        if: matrix.enabled\n"},
+		{name: "github-hosted step", condition: "        if: runner.environment == 'github-hosted'\n"},
+		{name: "github-hosted job", jobIf: "    if: runner.environment == 'github-hosted'\n"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			matrix := ""
@@ -1075,6 +1077,12 @@ jobs:
 `)
 	if err == nil || !strings.Contains(err.Error(), "no effective permissions") {
 		t.Fatalf("runtime-dependent action condition error = %v, want conservative token authority", err)
+	}
+	for _, condition := range []string{"runner.environment == 'self-hosted'", "runner.os == 'Linux'"} {
+		_, err := compile("on: push\npermissions: {}\njobs:\n  token:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: ./.github/actions/token\n        if: " + condition + "\n        with:\n          deploy_key: ${{ secrets.DEPLOY_KEY }}\n")
+		if err == nil || !strings.Contains(err.Error(), "no effective permissions") {
+			t.Fatalf("condition %q error = %v, want retained token authority", condition, err)
+		}
 	}
 }
 

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -1406,6 +1406,50 @@ jobs:
 	}
 }
 
+func TestCompileDefersRunnerEnvironmentToRuntime(t *testing.T) {
+	plans, err := compilePlansForTest(t.Context(), "runner-environment.yml", []byte(`on: push
+jobs:
+  node-compat:
+    runs-on: ubuntu-latest
+    if: runner.environment != ''
+    steps:
+      - if: runner.environment == 'github-hosted'
+        run: echo hosted
+        env:
+          RUNNER_KIND: ${{ runner.environment }}
+      - if: runner.environment == 'self-hosted'
+        run: echo self-hosted
+`), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), defaultOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("plans = %#v", plans)
+	}
+	steps := plans[0].Program.Job.Steps
+	if len(steps) != 2 || steps[0].Condition.Source != "runner.environment == 'github-hosted'" || steps[1].Condition.Source != "runner.environment == 'self-hosted'" {
+		t.Fatalf("step conditions were not preserved for runtime evaluation: %#v", steps)
+	}
+	if got := testBindingSources(steps[0].Env)["RUNNER_KIND"]; got != "${{ runner.environment }}" {
+		t.Fatalf("step env RUNNER_KIND = %q, want the runtime expression preserved", got)
+	}
+	if plans[0].Program.Job.Condition.Source != "runner.environment != ''" {
+		t.Fatalf("job condition = %q", plans[0].Program.Job.Condition.Source)
+	}
+
+	_, err = compilePlansForTest(t.Context(), "runner-name.yml", []byte(`on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - if: runner.name == 'x'
+        run: true
+`), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), defaultOptions())
+	if err == nil || !strings.Contains(err.Error(), "runner.environment") {
+		t.Fatalf("Compile() runner.name error = %v, want the supported runner properties listed", err)
+	}
+}
+
 func TestCompileRejectsUnavailableReusableCallConditionContexts(t *testing.T) {
 	for _, contextName := range []string{"matrix.target", "strategy.job-index", "secrets.TOKEN", "env.FLAG", "runner.os", "steps.build.outcome"} {
 		t.Run(contextName, func(t *testing.T) {

--- a/internal/expression/action_input_default.go
+++ b/internal/expression/action_input_default.go
@@ -127,10 +127,10 @@ func actionInputDefaultRequiresGitHubToken(template, serverURL string) (bool, er
 	}
 	requiresToken := false
 	err = visitTemplateExpressions(template, func(expression actionlint.ExprNode) error {
-		analysis, analysisErr := analyzeActionInputDefault(expression, map[string]any{
+		analysis, analysisErr := analyzeActionInputDefault(expression, canonicalAbstractReferences(map[string]any{
 			"github.server_url": serverURL,
 			"job.check_run_id":  "",
-		})
+		}))
 		if analysisErr != nil {
 			// Runtime-dependent evaluation failures previously fell back to
 			// conservative authority. Preserve that behavior while the

--- a/internal/expression/condition.go
+++ b/internal/expression/condition.go
@@ -248,7 +248,7 @@ func validateConditionReference(root string, path []string, scope ConditionScope
 	switch strings.ToLower(root) {
 	case "runner":
 		if len(path) == 1 {
-			if strings.EqualFold(path[0], "os") || strings.EqualFold(path[0], "arch") {
+			if strings.EqualFold(path[0], "os") || strings.EqualFold(path[0], "arch") || strings.EqualFold(path[0], "environment") {
 				return nil
 			}
 			if strings.EqualFold(path[0], "temp") && scope != JobCondition && scope != CallCondition {
@@ -256,9 +256,9 @@ func validateConditionReference(root string, path []string, scope ConditionScope
 			}
 		}
 		if scope == JobCondition {
-			return fmt.Errorf("condition reference %q is unsupported; expected runner.os or runner.arch", reference)
+			return fmt.Errorf("condition reference %q is unsupported; expected runner.os, runner.arch, or runner.environment", reference)
 		}
-		return fmt.Errorf("condition reference %q is unsupported; expected runner.os, runner.arch, or runner.temp", reference)
+		return fmt.Errorf("condition reference %q is unsupported; expected runner.os, runner.arch, runner.environment, or runner.temp", reference)
 	case "github":
 		if len(path) >= 1 && strings.EqualFold(path[0], "event") {
 			return nil

--- a/internal/expression/engine.go
+++ b/internal/expression/engine.go
@@ -819,8 +819,29 @@ func (Engine) Truthy(value any) bool {
 	return githubTruthy(value)
 }
 
+// RunnerEnvironment is the constant runner.environment value. GitHub's service
+// supplies it to the runner (system.runnerEnvironment): github-hosted for
+// runners GitHub provisions, self-hosted for every runner registered by anyone
+// else, regardless of runs-on labels. A Buildkite agent, hosted or
+// self-hosted, is never GitHub-provisioned, so every queue reports
+// self-hosted. Popular actions compare the exact strings, so a third value
+// would match neither branch.
+const RunnerEnvironment = "self-hosted"
+
+// constantReferences are context values that are the same for every queue,
+// event, and job. Abstract analysis always knows them, so a branch guarded on
+// another value is provably unreachable in both planning and the runtime.
+var constantReferences = map[string]any{
+	"runner.environment": RunnerEnvironment,
+}
+
+// canonicalAbstractReferences lower-cases planning-known references and adds
+// the constants every analysis knows. Caller values win over constants.
 func canonicalAbstractReferences(source map[string]any) map[string]any {
-	result := make(map[string]any, len(source))
+	result := make(map[string]any, len(source)+len(constantReferences))
+	for name, value := range constantReferences {
+		result[name] = value
+	}
 	for name, value := range source {
 		result[strings.ToLower(name)] = value
 	}

--- a/internal/expression/engine_test.go
+++ b/internal/expression/engine_test.go
@@ -240,6 +240,68 @@ func TestEngineValidateConditionAttributesEarlySecretReferenceError(t *testing.T
 	}
 }
 
+func TestEngineAnalysisKnowsRunnerEnvironmentWithoutCallerValues(t *testing.T) {
+	engine := NewEngine()
+	for _, test := range []struct {
+		name  string
+		site  Site
+		known bool
+		value any
+		token GitHubTokenEffect
+	}{
+		{
+			name:  "step condition github-hosted is known false",
+			site:  Site{Source: "runner.environment == 'github-hosted'", Profile: ProfileStepCondition, Result: ResultBoolean, Purpose: PurposeExpression},
+			known: true, value: false,
+		},
+		{
+			name:  "job condition self-hosted is known true",
+			site:  Site{Source: "RUNNER.Environment == 'self-hosted'", Profile: ProfileJobCondition, Result: ResultBoolean, Purpose: PurposeExpression},
+			known: true, value: true,
+		},
+		{
+			name: "runner.os stays queue-dependent",
+			site: Site{Source: "runner.os == 'Linux'", Profile: ProfileStepCondition, Result: ResultBoolean, Purpose: PurposeExpression},
+		},
+		{
+			name:  "workflow action input excludes the github-hosted token branch",
+			site:  Site{Source: "${{ runner.environment == 'github-hosted' && github.token || '' }}", Profile: ProfileStepTemplate, Result: ResultString, Purpose: PurposeWorkflowActionInput},
+			known: true, value: "",
+		},
+		{
+			name:  "workflow action input keeps the self-hosted token branch",
+			site:  Site{Source: "${{ runner.environment == 'self-hosted' && github.token || '' }}", Profile: ProfileStepTemplate, Result: ResultString, Purpose: PurposeWorkflowActionInput},
+			token: GitHubTokenDirect,
+		},
+		{
+			name:  "action input default excludes the github-hosted token branch",
+			site:  Site{Source: "${{ runner.environment == 'github-hosted' && github.token || '' }}", Profile: ProfileActionInputDefault, Result: ResultString, Purpose: PurposeExpression},
+			known: true, value: "",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			analysis, err := engine.Analyze(test.site, AbstractValues{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if analysis.Value.Known != test.known || (test.known && analysis.Value.Value != test.value) {
+				t.Fatalf("Analyze() value = %#v, want known=%v value=%#v", analysis.Value, test.known, test.value)
+			}
+			if analysis.Effects.GitHubToken != test.token {
+				t.Fatalf("Analyze() token effects = %v, want %v", analysis.Effects.GitHubToken, test.token)
+			}
+		})
+	}
+	// Action metadata defaults are analyzed outside Engine.Analyze and must
+	// know the same constant.
+	if requires, err := actionInputDefaultRequiresGitHubToken("${{ runner.environment == 'github-hosted' && github.token || '' }}", "https://github.com"); err != nil || requires {
+		t.Fatalf("github-hosted default requires token = %v, %v; want false", requires, err)
+	}
+	if requires, err := actionInputDefaultRequiresGitHubToken("${{ runner.environment == 'self-hosted' && github.token || '' }}", "https://github.com"); err != nil || !requires {
+		t.Fatalf("self-hosted default requires token = %v, %v; want true", requires, err)
+	}
+}
+
 func TestEngineTemplateAnalysisExcludesKnownFalseTokenBranch(t *testing.T) {
 	engine := NewEngine()
 	site := Site{Source: "${{ false && github.token || '' }}", Profile: ProfileStepTemplate, Result: ResultString, Purpose: PurposeWorkflowActionInput}

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -222,6 +222,42 @@ func TestRunnerDirectReferencesWorkAcrossRuntimeEvaluationSurfaces(t *testing.T)
 	}
 }
 
+func TestRunnerEnvironmentIsAvailableOnEveryRuntimeSurface(t *testing.T) {
+	runner := map[string]string{"os": "Linux", "arch": "X64", "environment": "self-hosted"}
+	if got, err := Evaluate("${{ runner.environment }}", Context{Runner: runner}); err != nil || got != "self-hosted" {
+		t.Fatalf("Evaluate() = %q, %v", got, err)
+	}
+	if got, err := EvaluateStep("${{ RUNNER.Environment }}", Context{Runner: runner}); err != nil || got != "self-hosted" {
+		t.Fatalf("EvaluateStep() = %q, %v", got, err)
+	}
+	for _, test := range []struct {
+		condition string
+		want      bool
+	}{
+		{"runner.environment == 'self-hosted'", true},
+		{"runner.environment == 'github-hosted'", false},
+		{"runner.environment != 'github-hosted' && runner.os == 'Linux'", true},
+	} {
+		if got, err := EvaluateCondition(test.condition, ConditionContext{Runner: runner}); err != nil || got != test.want {
+			t.Fatalf("EvaluateCondition(%q) = %v, %v; want %v", test.condition, got, err, test.want)
+		}
+	}
+	for _, scope := range []ConditionScope{JobCondition, StepCondition} {
+		if err := ValidateCondition("runner.environment == 'github-hosted'", scope); err != nil {
+			t.Fatalf("ValidateCondition() scope %v runner.environment = %v", scope, err)
+		}
+	}
+	if err := ValidateCondition("runner.name == 'x'", StepCondition); err == nil || !strings.Contains(err.Error(), "runner.environment") {
+		t.Fatalf("ValidateCondition() runner.name error = %v, want the supported list to name runner.environment", err)
+	}
+	if got, err := EvaluateActionInputDefault("${{ runner.environment == 'github-hosted' && 'hosted' || 'self' }}", Context{Runner: runner}); err != nil || got != "self" {
+		t.Fatalf("EvaluateActionInputDefault() = %q, %v", got, err)
+	}
+	if _, err := Evaluate("${{ runner.environment }}", Context{Runner: map[string]string{"os": "Linux"}}); err == nil {
+		t.Fatal("Evaluate() resolved runner.environment without a runner context value")
+	}
+}
+
 func TestValidateActionInputDefaultSupportsRestrictedCompoundExpressions(t *testing.T) {
 	for _, template := range []string{
 		"${{ github.server_url == 'https://github.com' && github.token || '' }}",

--- a/internal/expression/runtime.go
+++ b/internal/expression/runtime.go
@@ -658,7 +658,7 @@ func resolveRuntimeReferenceValue(root string, path []string, context Context, a
 
 func classifyRuntimeReference(root string, path []string) runtimeReferenceKind {
 	switch {
-	case len(path) == 1 && strings.EqualFold(root, "runner") && (strings.EqualFold(path[0], "os") || strings.EqualFold(path[0], "arch") || strings.EqualFold(path[0], "temp")):
+	case len(path) == 1 && strings.EqualFold(root, "runner") && (strings.EqualFold(path[0], "os") || strings.EqualFold(path[0], "arch") || strings.EqualFold(path[0], "environment") || strings.EqualFold(path[0], "temp")):
 		return runtimeReferenceRunner
 	case len(path) == 4 && strings.EqualFold(root, "job") && strings.EqualFold(path[0], "services") && strings.EqualFold(path[2], "ports"):
 		return runtimeReferenceServicePort

--- a/internal/program/authority_test.go
+++ b/internal/program/authority_test.go
@@ -144,6 +144,32 @@ func TestWorkflowReachabilityKeepsCallerScopedGuardValuesUnknown(t *testing.T) {
 	}
 }
 
+func TestWorkflowReachabilityKnowsRunnerEnvironmentIsSelfHosted(t *testing.T) {
+	condition := func(source string) Site {
+		return Site{Source: source, Surface: SurfaceStepCondition, Result: ResultBoolean, Provenance: ProvenanceWorkflow, Purpose: PurposeExpression}
+	}
+	workflow := Program{Version: Version, Job: Job{
+		Condition: Site{Surface: SurfaceJobCondition, Result: ResultBoolean, Provenance: ProvenanceWorkflow, Purpose: PurposeExpression},
+		Steps: []Step{
+			{Condition: condition("runner.environment == 'github-hosted'")},
+			{Condition: condition("runner.environment == 'self-hosted'")},
+			{Condition: condition("runner.os == 'Linux'")},
+		},
+	}}
+	reachability, err := WorkflowReachability(workflow, expression.AbstractValues{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reachability.Job || reachability.Steps[0] || !reachability.Steps[1] || !reachability.Steps[2] {
+		t.Fatalf("reachability = %#v, want github-hosted step unreachable, self-hosted step reachable, runner.os step unknown", reachability)
+	}
+	workflow.Job.Condition.Source = "runner.environment == 'github-hosted'"
+	reachability, err = WorkflowReachability(workflow, expression.AbstractValues{})
+	if err != nil || reachability.Job || reachability.Steps[1] {
+		t.Fatalf("github-hosted job reachability = %#v, %v; want the whole job unreachable", reachability, err)
+	}
+}
+
 func TestWorkflowReachabilityUsesSharedGuardValues(t *testing.T) {
 	workflow := Program{Version: Version, Job: Job{
 		Guards:    []Guard{{Condition: Site{Source: "vars.ENABLED != 'yes'", Surface: SurfaceCallCondition, Result: ResultBoolean, Provenance: ProvenanceWorkflow, Purpose: PurposeExpression}}},

--- a/internal/runtime/action_execution.go
+++ b/internal/runtime/action_execution.go
@@ -218,6 +218,7 @@ func (r *jobRun) prepare(ctx context.Context) (final JobResult, runJobErr error)
 		return jobResult, fmt.Errorf("analyze workflow reachability: %w", err)
 	}
 	r.reachableSteps = reachability.Steps
+	r.reachableLocks = reachableActionLocks(job, executionJob.Steps, r.reachableSteps)
 	runCtx := ctx
 	cancelJob := func() {}
 	if job.TimeoutMinutes > 0 {
@@ -401,10 +402,11 @@ func (r *jobRun) prepare(ctx context.Context) (final JobResult, runJobErr error)
 	if containerSpec != nil {
 		// Remote children of workspace composites are already present in the
 		// immutable lock graph even when the workspace action itself must remain
-		// lazy. Materialize every remote lock now because bind mounts cannot be
-		// added after the persistent container is created.
+		// lazy. Materialize every reachable remote lock now because bind mounts
+		// cannot be added after the persistent container is created. Locks that
+		// only known-false steps select stay on disk untouched.
 		for _, lock := range job.Actions {
-			if lock.Source != "github" || usesNativeAdapter(lock) {
+			if lock.Source != "github" || usesNativeAdapter(lock) || !r.lockReachable(lock.ID) {
 				continue
 			}
 			action, _, resolveErr := actions.resolve(runCtx, plan.ActionSelector{Lock: lock.ID})
@@ -419,9 +421,9 @@ func (r *jobRun) prepare(ctx context.Context) (final JobResult, runJobErr error)
 				return tolerateJobSetupFailure(runCtx, job, jobResult, fmt.Errorf("prepare action lock %q: %w", lock.ID, entrypointErr))
 			}
 		}
-		for _, step := range executionJob.Steps {
+		for stepIndex, step := range executionJob.Steps {
 			selector, ok := stepActionSelector(step)
-			if step.Kind != "uses" || !ok {
+			if step.Kind != "uses" || !ok || !r.stepReachable(stepIndex) {
 				continue
 			}
 			if source, sourceErr := actions.source(selector); sourceErr != nil {
@@ -519,7 +521,7 @@ func (r *jobRun) runPreActions(ctx, runCtx context.Context) (JobResult, error) {
 			if step.Kind != "uses" {
 				continue
 			}
-			if stepIndex < len(r.reachableSteps) && !r.reachableSteps[stepIndex] {
+			if !r.stepReachable(stepIndex) {
 				continue
 			}
 			selector, ok := stepActionSelector(step)
@@ -1456,6 +1458,7 @@ func standardEnvironment(job plan.Job, workspace, runnerTemp, toolCache string, 
 		"GITHUB_WORKSPACE":    workspace,
 		"RUNNER_OS":           runner["os"],
 		"RUNNER_ARCH":         runner["arch"],
+		"RUNNER_ENVIRONMENT":  runner["environment"],
 		"RUNNER_TEMP":         runnerTemp,
 		"RUNNER_TOOL_CACHE":   toolCache,
 	}
@@ -1471,9 +1474,9 @@ func standardEnvironment(job plan.Job, workspace, runnerTemp, toolCache string, 
 func canonicalRunnerContext(goos, goarch string) (map[string]string, error) {
 	switch {
 	case goos == "linux" && goarch == "amd64":
-		return map[string]string{"os": "Linux", "arch": "X64"}, nil
+		return map[string]string{"os": "Linux", "arch": "X64", "environment": expression.RunnerEnvironment}, nil
 	case goos == "darwin" && goarch == "arm64":
-		return map[string]string{"os": "macOS", "arch": "ARM64"}, nil
+		return map[string]string{"os": "macOS", "arch": "ARM64", "environment": expression.RunnerEnvironment}, nil
 	default:
 		return nil, errUnsupportedf("unsupported runner platform %s/%s", goos, goarch)
 	}
@@ -1597,6 +1600,7 @@ func isRuntimeContextEnvironment(name string) bool {
 		"GITHUB_WORKFLOW_SHA",
 		"GITHUB_WORKSPACE",
 		"RUNNER_ARCH",
+		"RUNNER_ENVIRONMENT",
 		"RUNNER_OS",
 		"RUNNER_TEMP",
 		"RUNNER_TOOL_CACHE":
@@ -1663,7 +1667,8 @@ func (r *jobRun) actionContainerMounts(ctx context.Context, actions *actionLockR
 	for _, lock := range actions.job.Actions {
 		// A native adapter replaces the admitted action's execution entirely,
 		// so its source tree is never mounted or classified for the container.
-		if usesNativeAdapter(lock) {
+		// A lock only known-false steps select is never executed either.
+		if usesNativeAdapter(lock) || !r.lockReachable(lock.ID) {
 			continue
 		}
 		entry := actions.locks[lock.ID]
@@ -2307,6 +2312,50 @@ func evaluatePlanStepWith(step executionprogram.Step, context expression.Context
 		return nil, nil
 	}
 	return executionprogram.EvaluateBindings(step.Invocation.With, executionprogram.EvaluationContext{Expression: context})
+}
+
+// stepReachable reports whether the reachability pass left the step's
+// condition possibly true. Steps the pass did not classify stay reachable.
+func (r *jobRun) stepReachable(stepIndex int) bool {
+	return stepIndex >= len(r.reachableSteps) || r.reachableSteps[stepIndex]
+}
+
+// lockReachable reports whether a reachable step selects the lock, directly
+// or through composite children. Before the reachability pass runs, every
+// lock is reachable.
+func (r *jobRun) lockReachable(lockID string) bool {
+	return r.reachableLocks == nil || r.reachableLocks[lockID]
+}
+
+// reachableActionLocks closes the lock graph over the action steps the
+// reachability pass kept. Job setup consults it so a step whose condition is
+// known false, such as runner.environment == 'github-hosted', never pulls a
+// prebuilt image or materializes a source tree it will not execute.
+func reachableActionLocks(job plan.Job, steps []executionprogram.Step, reachableSteps []bool) map[string]bool {
+	locks := make(map[string]plan.ActionLock, len(job.Actions))
+	for _, lock := range job.Actions {
+		locks[lock.ID] = lock
+	}
+	reachable := make(map[string]bool, len(job.Actions))
+	var visit func(id string)
+	visit = func(id string) {
+		if reachable[id] {
+			return
+		}
+		reachable[id] = true
+		for _, child := range locks[id].Children {
+			visit(child.Lock)
+		}
+	}
+	for stepIndex, step := range steps {
+		if step.Kind != "uses" || stepIndex < len(reachableSteps) && !reachableSteps[stepIndex] {
+			continue
+		}
+		if selector, ok := stepActionSelector(step); ok {
+			visit(selector.Lock)
+		}
+	}
+	return reachable
 }
 
 func stepActionSelector(step executionprogram.Step) (plan.ActionSelector, bool) {

--- a/internal/runtime/actions.go
+++ b/internal/runtime/actions.go
@@ -59,7 +59,7 @@ type prebuiltDockerBackend struct {
 func (r *jobRun) preparePrebuiltDockerActions(ctx context.Context, processor *commandOutputProcessor, actions *actionLockResolver) (_ *prebuiltDockerBackend, err error) {
 	images := map[string]string{}
 	for _, lock := range actions.job.Actions {
-		if lock.DockerImage != "" {
+		if lock.DockerImage != "" && r.lockReachable(lock.ID) {
 			images[lock.DockerImage] = ""
 		}
 	}

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -3045,3 +3045,38 @@ func liveDockerOwnedResources(t *testing.T, docker string) []string {
 	slices.Sort(resources)
 	return resources
 }
+
+// TestGitHubHostedGatedRemoteActionIsNotMaterializedForContainerJob proves a
+// container job, which materializes remote action trees before the container
+// starts, skips the tree of an action gated on runner.environment ==
+// 'github-hosted' and mounts only the reachable sibling.
+func TestGitHubHostedGatedRemoteActionIsNotMaterializedForContainerJob(t *testing.T) {
+	f := newJobDocker(t, "")
+	workspace := t.TempDir()
+	writeFixtureFile(t, workspace, ".github/workflows/container.yml", "name: gated remote container actions\n")
+	remote := t.TempDir()
+	for _, name := range []string{"hosted", "self-hosted"} {
+		writeFixtureFile(t, remote, name+"/action.yml", "name: "+name+"\nruns:\n  using: node24\n  main: main.js\n")
+		writeFixtureFile(t, remote, name+"/main.js", `require("node:fs").appendFileSync(process.env.GITHUB_OUTPUT, "ran=`+name+`\n")
+`)
+	}
+	digest := digestTree(t, remote)
+	hostedID, selfHostedID := remoteLifecycleLockID(1), remoteLifecycleLockID(2)
+	job := runtimePlan(t, workspace, ".github/workflows/container.yml", []runtimeTestStep{
+		{ID: "hosted", Kind: "uses", Uses: remoteLifecycleUses("hosted"), Action: &plan.ActionSelector{Lock: hostedID}, Condition: "runner.environment == 'github-hosted'"},
+		{ID: "self-hosted", Kind: "uses", Uses: remoteLifecycleUses("self-hosted"), Action: &plan.ActionSelector{Lock: selfHostedID}, Condition: "runner.environment == 'self-hosted'"},
+	})
+	job.Schema = plan.Schema
+	job.RequiredCapabilities = []string{"docker", "network"}
+	job.Container = &plan.Container{Image: "debian:bookworm-slim"}
+	job.Actions = []plan.ActionLock{remoteLifecycleLock(hostedID, "hosted", digest, nil), remoteLifecycleLock(selfHostedID, "self-hosted", digest, nil)}
+	job.Outputs = map[string]string{"ran": "${{ steps.self-hosted.outputs.ran }}"}
+	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, ActionRoot: filepath.Join(remote, "self-hosted"), SourceDigest: digest}}
+	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node24: requireNode24(t), Actions: materializer}).runTestJob(t.Context(), job, workspace)
+	if err != nil || result.Outputs["ran"] != "self-hosted" {
+		t.Fatalf("container job result = %#v, error = %v", result, err)
+	}
+	if materializer.calls != 1 {
+		t.Fatalf("remote materialization calls = %d, want 1 for the self-hosted gate only", materializer.calls)
+	}
+}

--- a/internal/runtime/job_run.go
+++ b/internal/runtime/job_run.go
@@ -26,6 +26,7 @@ type jobRun struct {
 	prepared        remotePreparations
 	preFailures     map[int]stepExecution
 	reachableSteps  []bool
+	reachableLocks  map[string]bool
 	runErr          error
 	hardFailure     bool
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -335,6 +335,156 @@ jobs:
 	}
 }
 
+func TestRunnerEnvironmentIsSelfHostedAtRuntime(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	var logs bytes.Buffer
+	job := runtimePlan(t, workspace, workflowPath, []runtimeTestStep{
+		{ID: "hosted", Kind: "run", Condition: "runner.environment == 'github-hosted'", Command: "echo must-not-run"},
+		{ID: "self", Kind: "run", Condition: "runner.environment == 'self-hosted'", Env: map[string]string{"RUNNER_KIND": "${{ runner.environment }}"}, Command: `test "$RUNNER_ENVIRONMENT" = self-hosted && test "$RUNNER_KIND" = self-hosted && echo ran-self-hosted`},
+		{ID: "verify", Kind: "run", Condition: "steps.hosted.conclusion == 'skipped' && steps.self.conclusion == 'success'", Command: "echo verified-conclusions"},
+	})
+	result, err := (Runner{Stdout: &logs, Stderr: &logs}).runTestJob(t.Context(), job, workspace)
+	if err != nil || result.Conclusion != "success" || strings.Contains(logs.String(), "must-not-run") || !strings.Contains(logs.String(), "ran-self-hosted") || !strings.Contains(logs.String(), "verified-conclusions") {
+		t.Fatalf("RunJob() result = %#v, error = %v, logs = %q", result, err, logs.String())
+	}
+}
+
+// A remote action gated on runner.environment == 'github-hosted' must not be
+// materialized or have its pre hook run: the runtime knows the value is
+// self-hosted before any action is prepared. The self-hosted gate proves the
+// same lock still prepares and runs every phase.
+func TestGitHubHostedGatedActionSkipsEveryLifecyclePhase(t *testing.T) {
+	node := requireNode24(t)
+	remote := t.TempDir()
+	writeFixtureFile(t, remote, "root/action.yml", "name: root\nruns:\n  using: node24\n  pre: pre.js\n  main: main.js\n  post: post.js\n")
+	for _, phase := range []string{"pre", "main", "post"} {
+		writeFixtureFile(t, remote, "root/"+phase+".js", fmt.Sprintf("require('node:fs').appendFileSync(process.env.PHASE_LOG, %q)\n", phase+"\n"))
+	}
+	digest := digestTree(t, remote)
+	rootID := remoteLifecycleLockID(1)
+	for _, test := range []struct {
+		condition string
+		calls     int
+		phases    string
+	}{
+		{condition: "runner.environment == 'github-hosted'", calls: 0, phases: ""},
+		{condition: "runner.environment == 'self-hosted'", calls: 1, phases: "pre\nmain\npost\n"},
+	} {
+		t.Run(test.condition, func(t *testing.T) {
+			workspace := t.TempDir()
+			workflowPath := ".github/workflows/test.yml"
+			writeFixtureFile(t, workspace, workflowPath, "name: runner environment lifecycle\n")
+			phaseLog := filepath.Join(t.TempDir(), "phases.log")
+			job := runtimePlan(t, workspace, workflowPath, []runtimeTestStep{{
+				ID: "root", Kind: "uses", Uses: remoteLifecycleUses("root"), Action: &plan.ActionSelector{Lock: rootID},
+				Condition: test.condition, Env: map[string]string{"PHASE_LOG": phaseLog},
+			}})
+			job.RequiredCapabilities = []string{"network"}
+			job.Actions = []plan.ActionLock{remoteLifecycleLock(rootID, "root", digest, nil)}
+			materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}
+			var logs bytes.Buffer
+			result, err := (Runner{Actions: materializer, Node24: node, Stdout: &logs, Stderr: &logs}).runTestJob(t.Context(), job, workspace)
+			if err != nil || result.Conclusion != "success" {
+				t.Fatalf("RunJob() result = %#v, error = %v, logs = %q", result, err, logs.String())
+			}
+			if materializer.calls != test.calls {
+				t.Fatalf("materializations = %d, want %d", materializer.calls, test.calls)
+			}
+			data, err := os.ReadFile(phaseLog)
+			if err != nil && !os.IsNotExist(err) {
+				t.Fatal(err)
+			}
+			if string(data) != test.phases {
+				t.Fatalf("lifecycle phases = %q, want %q", data, test.phases)
+			}
+		})
+	}
+}
+
+// TestGitHubHostedGatedPrebuiltDockerActionIsNotPulled proves job setup
+// consults reachability before pulling prebuilt Docker action images, so an
+// action gated on runner.environment == 'github-hosted' costs no registry
+// traffic while a sibling gated on 'self-hosted' still gets its image.
+func TestGitHubHostedGatedPrebuiltDockerActionIsNotPulled(t *testing.T) {
+	requireLinuxAMD64(t)
+	fake := newFakeDocker(t, "success")
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/prebuilt.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: prebuilt gates\n")
+	hostedImage := "ghcr.io/example/hosted@sha256:" + strings.Repeat("d", 64)
+	selfHostedImage := "ghcr.io/example/self-hosted@sha256:" + strings.Repeat("b", 64)
+	locks := make([]plan.ActionLock, 0, 2)
+	steps := make([]runtimeTestStep, 0, 2)
+	for i, gate := range []struct{ name, environment, image string }{
+		{name: "hosted", environment: "github-hosted", image: hostedImage},
+		{name: "self-hosted", environment: "self-hosted", image: selfHostedImage},
+	} {
+		actionPath := ".github/actions/" + gate.name
+		writeFixtureFile(t, workspace, actionPath+"/action.yml", "name: "+gate.name+"\nruns:\n  using: docker\n  image: docker://"+gate.image+"\n")
+		lockID := fmt.Sprintf("a-%016x", i+1)
+		locks = append(locks, plan.ActionLock{ID: lockID, Source: "workspace", Path: actionPath, SourceDigest: digestTree(t, filepath.Join(workspace, actionPath)), DockerImage: gate.image})
+		steps = append(steps, runtimeTestStep{
+			ID: gate.name, Kind: "uses", Uses: "./" + actionPath, Action: &plan.ActionSelector{Lock: lockID},
+			Condition: "runner.environment == '" + gate.environment + "'",
+		})
+	}
+	job := runtimePlan(t, workspace, workflowPath, steps)
+	job.RequiredCapabilities = []string{"docker", "network"}
+	job.Actions = locks
+	result, err := (Runner{Docker: fake.path}).runTestJob(t.Context(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	calls := fake.calls(t)
+	if callIndex(calls, "pull", hostedImage) >= 0 {
+		t.Fatalf("github-hosted gated image was pulled: %#v", calls)
+	}
+	pull, run := callIndex(calls, "pull", selfHostedImage), callIndex(calls, "run")
+	if pull < 0 || run < pull {
+		t.Fatalf("self-hosted gated image was not pulled before execution: %#v", calls)
+	}
+}
+
+// TestReachableActionLocksClosesOverCompositeChildren proves lock
+// reachability follows composite children and keeps a child shared with a
+// reachable parent even when another parent is known false.
+func TestReachableActionLocksClosesOverCompositeChildren(t *testing.T) {
+	child := func(id string) map[string]plan.ActionSelector {
+		return map[string]plan.ActionSelector{"owner/repo/" + id + "@v1": {Lock: id}}
+	}
+	job := plan.Job{Actions: []plan.ActionLock{
+		{ID: "live", Children: child("shared")},
+		{ID: "dead", Children: map[string]plan.ActionSelector{"s": {Lock: "shared"}, "o": {Lock: "dead-only"}}},
+		{ID: "shared", Children: child("grandchild")},
+		{ID: "grandchild"},
+		{ID: "dead-only"},
+		{ID: "unclassified"},
+	}}
+	steps := []executionprogram.Step{
+		normalizeRuntimeTestStep(runtimeTestStep{ID: "live", Kind: "uses", Uses: "owner/repo/live@v1", Action: &plan.ActionSelector{Lock: "live"}}),
+		normalizeRuntimeTestStep(runtimeTestStep{ID: "dead", Kind: "uses", Uses: "owner/repo/dead@v1", Action: &plan.ActionSelector{Lock: "dead"}}),
+		normalizeRuntimeTestStep(runtimeTestStep{ID: "run", Kind: "run", Command: "true"}),
+		normalizeRuntimeTestStep(runtimeTestStep{ID: "unclassified", Kind: "uses", Uses: "owner/repo/unclassified@v1", Action: &plan.ActionSelector{Lock: "unclassified"}}),
+	}
+	// The reachability pass classified only the first three steps; the fourth
+	// stays reachable by default.
+	got := reachableActionLocks(job, steps, []bool{true, false, true})
+	want := map[string]bool{"live": true, "shared": true, "grandchild": true, "unclassified": true}
+	if !maps.Equal(got, want) {
+		t.Fatalf("reachableActionLocks() = %v, want %v", got, want)
+	}
+	r := &jobRun{}
+	if !r.lockReachable("dead") || !r.stepReachable(1) {
+		t.Fatal("every lock and step must stay reachable before the reachability pass runs")
+	}
+	r.reachableLocks, r.reachableSteps = got, []bool{true, false, true}
+	if r.lockReachable("dead") || r.lockReachable("dead-only") || r.stepReachable(1) || !r.stepReachable(3) {
+		t.Fatalf("reachability lookups = locks dead=%v dead-only=%v, steps 1=%v 3=%v", r.lockReachable("dead"), r.lockReachable("dead-only"), r.stepReachable(1), r.stepReachable(3))
+	}
+}
+
 func TestFailureConditionsAndCancellation(t *testing.T) {
 	workspace := t.TempDir()
 	workflowPath := ".github/workflows/test.yml"
@@ -1428,7 +1578,7 @@ func TestCanonicalRunnerContext(t *testing.T) {
 		{goos: "darwin", goarch: "arm64", os: "macOS", arch: "ARM64"},
 	} {
 		got, err := canonicalRunnerContext(test.goos, test.goarch)
-		if err != nil || got["os"] != test.os || got["arch"] != test.arch {
+		if err != nil || got["os"] != test.os || got["arch"] != test.arch || got["environment"] != "self-hosted" {
 			t.Errorf("canonicalRunnerContext(%s, %s) = %#v, %v", test.goos, test.goarch, got, err)
 		}
 	}
@@ -1451,9 +1601,9 @@ func TestValidateHostRejectsDockerOnDarwin(t *testing.T) {
 }
 
 func TestRunnerEnvironmentIsProtected(t *testing.T) {
-	base := map[string]string{"RUNNER_OS": "Linux", "RUNNER_ARCH": "X64"}
-	got := mergeStepEnvironment(base, map[string]string{"RUNNER_OS": "overridden", "RUNNER_ARCH": "overridden"})
-	if got["RUNNER_OS"] != "Linux" || got["RUNNER_ARCH"] != "X64" {
+	base := map[string]string{"RUNNER_OS": "Linux", "RUNNER_ARCH": "X64", "RUNNER_ENVIRONMENT": "self-hosted"}
+	got := mergeStepEnvironment(base, map[string]string{"RUNNER_OS": "overridden", "RUNNER_ARCH": "overridden", "RUNNER_ENVIRONMENT": "github-hosted"})
+	if got["RUNNER_OS"] != "Linux" || got["RUNNER_ARCH"] != "X64" || got["RUNNER_ENVIRONMENT"] != "self-hosted" {
 		t.Fatalf("runner environment was overridden: %#v", got)
 	}
 }


### PR DESCRIPTION
## Why

Steps that branch on where the runner comes from failed to compile:

```yaml
- name: Isolate compatibility caches
  if: runner.environment == 'self-hosted'
  run: echo "NODE_COMPILE_CACHE=$RUNNER_TEMP/node-compile-cache" >> "$GITHUB_ENV"
```

```
E_EXPRESSION_INVALID job "node-compat": step 2 condition: condition reference "runner.environment" is unsupported; expected runner.os, runner.arch, or runner.temp
```

## What

`runner.environment` is now available in job and step `if`, step `env` and `with`, action input defaults, and as `RUNNER_ENVIRONMENT` in the process environment. It is always `self-hosted`. The step above therefore runs on every queue, and a `== 'github-hosted'` counterpart skips.

Because the value is the same everywhere, the compiler and runtime treat it as known when they decide which steps can run. An action behind `if: runner.environment == 'github-hosted'` is never downloaded or pulled during job setup, its `pre` and `post` hooks never run, and a `github.token` default guarded by that condition grants no token authority. `runner.os` and `runner.arch` still depend on the queue and keep their steps reachable.

No queue or runner mapping changes. `docs/compatibility.md` notes that steps gated on `github-hosted` may select a proxy, cache, or credential path that your agents need, so they deserve a review during migration.

## Why a constant `self-hosted`, and not another value

The official runner does not compute this value. GitHub's service sends it in the job message (`system.runnerEnvironment`) and the runner copies it verbatim ([JobRunner.cs](https://github.com/actions/runner/blob/main/src/Runner.Worker/JobRunner.cs#L165-L172), added in [actions/runner#2518](https://github.com/actions/runner/pull/2518)). GitHub sends `github-hosted` only for runners it provisions, including larger runners, and `self-hosted` for every runner registered by anyone else. Depot, Namespace, Blacksmith, WarpBuild, RunsOn, Ubicloud, and actions-runner-controller all register self-hosted runners, so their jobs see `self-hosted`; none exposes a third value or an override. A Buildkite agent, hosted or not, is in the same class. The value never depends on `runs-on` labels, so mirroring `ubuntu-latest` to `github-hosted` would be wrong upstream too, and it would claim the image parity and automatic machine cleanup that hosted-only branches rely on.

A third value such as `buildkite-agent` was considered and rejected. Popular actions compare the exact strings: `github/codeql-action` defines `isSelfHostedRunner()` as `=== "self-hosted"` and `isGitHubHostedRunner()` as `=== "github-hosted"`, so an unknown value is neither. It would skip the self-hosted database cleanup on a persistent agent, enable automatic dependency installation, and send OS release telemetry, while also skipping the hosted-only tool-cache cleanup. `actions/setup-go` treats anything but `github-hosted` as self-hosted, so the same job would be classified two different ways. Leaving the reference unsupported has the same runtime problem, because actions read the environment variable directly and an unset variable behaves like an unknown value. Workflows that want a Buildkite-specific branch need a Buildkite-specific signal, which is a separate change; today steps do not inherit `BUILDKITE_*` variables by design.
