### PR TITLE
PB-3249: Explain why matrices derived from job outputs are not expanded and detect valid include matrices after input substitution

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -811,9 +811,28 @@ concrete `matrix` values and each called workflow receives its declared
 A job may expand to at most 256 instances. All matrix values must be available
 before Buildkite pipeline generation. Expressions derived from `needs` outputs
 or `steps` require jobs to run before the final graph can be generated, so they
-remain unsupported. The compiler validates a narrow `needs.<job>.outputs.<name>`
-runtime-matrix shape, but does not upload a continuation pipeline because the
-transport has no authoritative current-attempt and durable idempotency fence.
+remain unsupported:
+
+```yaml
+build:
+  needs: plan
+  runs-on: ${{ matrix.runner }}
+  strategy:
+    matrix:
+      include: ${{ fromJSON(needs.plan.outputs.matrix) }}
+```
+
+```
+E_MATRIX_INVALID matrix values come from a job output that exists only after that job runs; buildkite-gha cannot expand this matrix yet (https://github.com/buildkite/buildkite-gha/issues/130)
+  detail: the matrix reference is valid, but expanding it needs a second pipeline upload after the producing job finishes, which buildkite-gha does not perform yet
+```
+
+The compiler recognizes exactly `fromJSON(needs.<job>.outputs.<name>)` as the
+whole `matrix` or the whole `include` list, and the `detail` line says whether
+the reference itself is valid or why it is not. Support is tracked in
+[issue #130](https://github.com/buildkite/buildkite-gha/issues/130). Until
+then, move the expansion into the workflow: list the combinations statically,
+or read them from `inputs` or the event payload with `fromJSON`.
 
 ### Containers and services
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1289,6 +1289,60 @@ func TestProcessingReportRedactsEventDerivedMatrixKeys(t *testing.T) {
 	}
 }
 
+func TestProcessingReportExplainsNeedsDerivedMatrix(t *testing.T) {
+	workflowPath := filepath.Join(t.TempDir(), "runtime-matrix.yml")
+	if err := os.WriteFile(workflowPath, []byte(`on: push
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+    steps:
+      - id: plan
+        run: echo 'matrix=[]' >> "$GITHUB_OUTPUT"
+  build:
+    needs: plan
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    steps:
+      - run: true
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"validate", "--format", "json", workflowPath}, &stdout, &stderr, "dev"); code != 1 {
+		t.Fatalf("Run() code = %d, want 1; stderr = %q", code, stderr.String())
+	}
+	var report compatibility.ProcessingReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Diagnostics) != 1 {
+		t.Fatalf("diagnostics = %#v", report.Diagnostics)
+	}
+	diagnostic := report.Diagnostics[0]
+	if diagnostic.Code != compiler.CodeMatrixInvalid || diagnostic.Job != "build" || diagnostic.Location == nil || diagnostic.Location.Line != 15 || diagnostic.Location.Column != 18 {
+		t.Fatalf("diagnostic = %#v", diagnostic)
+	}
+	if !strings.Contains(diagnostic.Message, "matrix values come from a job output") || !strings.Contains(diagnostic.Message, "https://github.com/buildkite/buildkite-gha/issues/130") {
+		t.Fatalf("message = %q", diagnostic.Message)
+	}
+	if !strings.Contains(diagnostic.Detail, "needs a second pipeline upload after the producing job finishes") {
+		t.Fatalf("detail = %q", diagnostic.Detail)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"validate", workflowPath}, &stdout, &stderr, "dev"); code != 1 {
+		t.Fatalf("Run() text code = %d, want 1; stderr = %q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "[E_MATRIX_INVALID] matrix values come from a job output") || !strings.Contains(stdout.String(), "\n  detail: the matrix reference is valid") {
+		t.Fatalf("text report = %q", stdout.String())
+	}
+}
+
 func TestProcessingReportRetainsReusableCalleeJobsAfterFailure(t *testing.T) {
 	root := t.TempDir()
 	workflowRoot := filepath.Join(root, ".github", "workflows")

--- a/internal/compiler/bundle_test.go
+++ b/internal/compiler/bundle_test.go
@@ -126,7 +126,7 @@ jobs:
       - run: echo "${{ matrix.steps }}"
 `)
 	bundle, err := CompileBundle("runtime-matrix.yml", source, readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-importer")
-	if err == nil || !strings.Contains(err.Error(), "continuation upload is disabled") {
+	if err == nil || !strings.Contains(err.Error(), "needs a second pipeline upload") {
 		t.Fatalf("CompileBundle() error = %v", err)
 	}
 	if len(bundle.Plans) != 0 || len(bundle.Pipeline) != 0 {

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -3811,7 +3811,7 @@ jobs:
       - run: true
 `)
 	report, err := Validate("failed-prerequisite.yml", source)
-	if err == nil || !strings.Contains(err.Error(), "runtime matrix source is valid, but continuation upload is disabled") {
+	if err == nil || !strings.Contains(err.Error(), "needs a second pipeline upload after the producing job finishes") {
 		t.Fatalf("Validate() error = %v", err)
 	}
 	if strings.Contains(err.Error(), "has no expanded instances") {
@@ -3846,7 +3846,7 @@ jobs:
       - run: echo "${{ matrix.artifact_key }}"
 `)
 	report, err := Validate(".github/workflows/ci-backend.yml", source)
-	if err == nil || !strings.Contains(err.Error(), "continuation upload is disabled") {
+	if err == nil || !strings.Contains(err.Error(), "needs a second pipeline upload") {
 		t.Fatalf("Validate() error = %v", err)
 	}
 	if len(report.RuntimeMatrices) != 1 {
@@ -3885,7 +3885,7 @@ jobs:
 `)
 
 	report, err := Validate(callerPath, readFile(t, callerPath))
-	if err == nil || !strings.Contains(err.Error(), "continuation upload is disabled") {
+	if err == nil || !strings.Contains(err.Error(), "needs a second pipeline upload") {
 		t.Fatalf("Validate() error = %v", err)
 	}
 	if len(report.RuntimeMatrices) != 1 {
@@ -3894,6 +3894,88 @@ jobs:
 	descriptor := report.RuntimeMatrices[0]
 	if descriptor.Job != "delegated.generated" || descriptor.ProducerJob != "delegated.producer" || descriptor.ProducerStepKey != "gha-delegated-producer" || descriptor.ProducerOutput != "include" || descriptor.SourcePath != "./.github/workflows/reusable.yml" {
 		t.Fatalf("reusable runtime matrix descriptor = %#v", descriptor)
+	}
+}
+
+// TestValidateRecognizesRuntimeMatrixIncludeAfterInputSubstitution covers a
+// called workflow that receives inputs: input substitution clones the matrix
+// and must not turn the absent static include and exclude lists into a
+// reason to reject an otherwise valid needs-derived include matrix.
+func TestValidateRecognizesRuntimeMatrixIncludeAfterInputSubstitution(t *testing.T) {
+	repository := t.TempDir()
+	callerPath := writeWorkflow(t, repository, "caller.yml", `on: push
+jobs:
+  delegated:
+    uses: ./.github/workflows/reusable.yml
+    with:
+      targets: linux
+`)
+	writeWorkflow(t, repository, "reusable.yml", `on:
+  workflow_call:
+    inputs:
+      targets:
+        type: string
+        required: true
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+    steps:
+      - id: plan
+        run: echo 'matrix=[]' >> "$GITHUB_OUTPUT"
+        env:
+          TARGETS: ${{ inputs.targets }}
+  build:
+    needs: plan
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    steps:
+      - run: echo "${{ matrix.target }}"
+`)
+	report, err := Validate(callerPath, readFile(t, callerPath))
+	if err == nil || !strings.Contains(err.Error(), runtimeMatrixDeferredReason) || strings.Contains(err.Error(), "complete matrix definition") {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	if len(report.RuntimeMatrices) != 1 || report.RuntimeMatrices[0].Job != "delegated.build" || report.RuntimeMatrices[0].Shape != RuntimeMatrixShapeInclude {
+		t.Fatalf("runtime matrix descriptors = %#v", report.RuntimeMatrices)
+	}
+	var finding *ProcessingFinding
+	if !errors.As(err, &finding) || finding.Code != CodeMatrixInvalid || finding.Message != runtimeMatrixDeferredMessage || finding.Detail != runtimeMatrixDeferredReason || finding.Blocker != "expression" || finding.Job != "delegated.build" || finding.Line != 23 || finding.Column != 18 {
+		t.Fatalf("runtime matrix finding = %#v", finding)
+	}
+}
+
+func TestValidateReportsWhyRuntimeMatrixIncludeIsIncomplete(t *testing.T) {
+	source := []byte(`on: push
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+    steps:
+      - id: plan
+        run: echo 'matrix=[]' >> "$GITHUB_OUTPUT"
+  build:
+    needs: plan
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        include: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    steps:
+      - run: true
+`)
+	report, err := Validate("mixed.yml", source)
+	var finding *ProcessingFinding
+	if !errors.As(err, &finding) || finding.Message != runtimeMatrixDeferredMessage || finding.Detail != "runtime matrix include output must be the complete matrix definition" {
+		t.Fatalf("Validate() error = %v, finding = %#v", err, finding)
+	}
+	if len(report.RuntimeMatrices) != 0 || !report.RuntimeMatrixBoundary {
+		t.Fatalf("report = %#v", report)
 	}
 }
 
@@ -3932,7 +4014,7 @@ jobs:
 `)
 
 	report, err := Validate(callerPath, readFile(t, callerPath))
-	if err == nil || !strings.Contains(err.Error(), "continuation upload is disabled") {
+	if err == nil || !strings.Contains(err.Error(), "needs a second pipeline upload") {
 		t.Fatalf("Validate() error = %v", err)
 	}
 	if len(report.RuntimeMatrices) != 1 {

--- a/internal/compiler/job_graph_expansion.go
+++ b/internal/compiler/job_graph_expansion.go
@@ -158,9 +158,20 @@ func (e *jobGraphExpansion) expandMatrices() {
 			line, column := matrixErrorPosition(job, err)
 			if err == nil {
 				e.result.runtimeMatrices = append(e.result.runtimeMatrices, descriptor)
-				err = errors.New("runtime matrix source is valid, but continuation upload is disabled because Buildkite transport has no authoritative current-attempt fence and durable idempotency boundary")
+				err = errors.New(runtimeMatrixDeferredReason)
 			}
-			err = locatedJobError(sourced.path, job, line, column, err.Error())
+			// The reason quotes only job and output identifiers from the
+			// workflow, never event data, so it can travel in Detail.
+			e.diagnostics = append(e.diagnostics, &ProcessingFinding{
+				Stage: StageMatrix, Code: CodeMatrixInvalid, Category: "compatibility",
+				Blocker: "expression",
+				Path:    sourced.path, Line: line, Column: column, Job: job.ID,
+				Message: runtimeMatrixDeferredMessage, Detail: err.Error(),
+				Err: locatedJobError(sourced.path, job, line, column, err.Error()),
+			})
+			e.failedMatrices[id] = true
+			e.failedJobs[id] = true
+			continue
 		} else {
 			matrixContext := e.context
 			matrixContext.Inputs = sourced.inputs.values

--- a/internal/compiler/runtime_matrix.go
+++ b/internal/compiler/runtime_matrix.go
@@ -32,6 +32,15 @@ const (
 	runtimeMatrixMaxSourceCoordinate = 1_000_000
 )
 
+// runtimeMatrixDeferredMessage is the report text for a matrix whose values
+// come from a job output. It names the gap and where its progress is tracked.
+const runtimeMatrixDeferredMessage = "matrix values come from a job output that exists only after that job runs; buildkite-gha cannot expand this matrix yet (https://github.com/buildkite/buildkite-gha/issues/130)"
+
+// runtimeMatrixDeferredReason explains why a valid needs-derived matrix is
+// still rejected: expanding it needs a second pipeline upload after the
+// producing job finishes, which buildkite-gha does not perform yet.
+const runtimeMatrixDeferredReason = "the matrix reference is valid, but expanding it needs a second pipeline upload after the producing job finishes, which buildkite-gha does not perform yet"
+
 var runtimeMatrixLogicalJobPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+(?:[.][A-Za-z0-9_-]+)*$`)
 var runtimeMatrixStepKeyPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,255}$`)
 var runtimeMatrixDigestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
@@ -90,7 +99,7 @@ func describeRuntimeMatrix(job workflow.Job, sourcePath, sourceDigest string, ne
 	if err != nil {
 		return RuntimeMatrixDescriptor{}, false, nil
 	}
-	if shape == RuntimeMatrixShapeInclude && (len(job.Matrix.Rows) != 0 || job.Matrix.Include != nil || job.Matrix.Exclude != nil) {
+	if shape == RuntimeMatrixShapeInclude && (len(job.Matrix.Rows) != 0 || len(job.Matrix.Include) != 0 || len(job.Matrix.Exclude) != 0 || job.Matrix.ExcludeExpression != nil) {
 		return RuntimeMatrixDescriptor{}, true, errors.New("runtime matrix include output must be the complete matrix definition")
 	}
 


### PR DESCRIPTION
## Why

A matrix computed by an earlier job is rejected without saying why:

```yaml
build:
  needs: plan
  runs-on: ${{ matrix.runner }}
  strategy:
    matrix:
      include: ${{ fromJSON(needs.plan.outputs.matrix) }}
```

```
x [E_MATRIX_INVALID] matrix could not be expanded or validated (build-exe-for-python-sdk.yml:158:18)
```

Worse, when the workflow received inputs (`workflow_dispatch`, or a reusable call with `with`), a valid `include` matrix of this shape was misclassified as "include output must be the complete matrix definition": input substitution turned the absent static `include` and `exclude` lists into empty non-nil slices.

## What

```
x [E_MATRIX_INVALID] matrix values come from a job output that exists only after that job runs; buildkite-gha cannot expand this matrix yet (https://github.com/buildkite/buildkite-gha/issues/130)
  detail: the matrix reference is valid, but expanding it needs a second pipeline upload after the producing job finishes, which buildkite-gha does not perform yet
```

The `detail` line carries the exact reason: the one above when the reference is valid, or the specific shape problem otherwise. The reason quotes only job and output identifiers from the workflow, never event data. The empty-slice check is fixed so the valid case is recognized after input substitution. `docs/compatibility.md` shows the example, the diagnostic, and the workarounds.

This PR does not implement the second upload. That work is PB-3262, which also owns the design notes an earlier revision of this PR carried in `docs/plans/runtime-matrix-continuation.md`; the two resolved review threads on that file refer to text that now lives with PB-3262.
