### PR TITLE
Avoid outside-root Node failures when running JavaScript actions

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -32,6 +32,9 @@ Jobs with JavaScript actions need `mise`. The runtime checks
 `BUILDKITE_GHA_MISE`, then `PATH`, then downloads a verified managed copy.
 Shell-only, native-adapter, and Docker-only jobs do not need it.
 
+When a managed cache is configured, the runtime installs Node there rather
+than reusing system-wide mise installations.
+
 Managed Node binaries require glibc 2.28 or newer. The Go CLI has no glibc requirement.
 
 ## Validate a workflow

--- a/internal/runtime/node_runtime.go
+++ b/internal/runtime/node_runtime.go
@@ -95,7 +95,12 @@ func (r Runner) miseEnv() map[string]string {
 	if r.MiseDataDir == "" {
 		return nil
 	}
-	return map[string]string{"MISE_DATA_DIR": r.MiseDataDir}
+	// Newer mise versions reuse system installs even with --no-config. Keep
+	// that lookup inside our cache so installation and validation share a root.
+	return map[string]string{
+		"MISE_DATA_DIR":        r.MiseDataDir,
+		"MISE_SYSTEM_DATA_DIR": r.MiseDataDir,
+	}
 }
 
 func (r *jobRun) installAndVerifyMiseNode(ctx context.Context, major int, mise string) (string, error) {

--- a/internal/runtime/node_runtime_test.go
+++ b/internal/runtime/node_runtime_test.go
@@ -279,6 +279,53 @@ func TestManagedMiseCacheRefusesSymlinkedRemoval(t *testing.T) {
 	}
 }
 
+func TestManagedMiseNodeDoesNotReuseSystemInstallation(t *testing.T) {
+	root := canonicalTempDir(t)
+	dataDir := filepath.Join(root, "cache")
+	systemDir := filepath.Join(root, "system")
+	nodeBytes := fmt.Appendf(nil, "#!/bin/sh\nprintf 'v%s\\n'\n", Node24Version)
+	systemNode := filepath.Join(systemDir, "installs", "node", Node24Version, "bin", "node")
+	writeFixtureFile(t, systemDir, filepath.Join("installs", "node", Node24Version, "bin", "node"), string(nodeBytes))
+	if err := os.Mkdir(dataDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Model mise's automatic system fallback when the user installation is absent.
+	mise := filepath.Join(root, "mise")
+	script := fmt.Sprintf(`#!/bin/sh
+set -eu
+installation="$MISE_DATA_DIR/installs/node/%s"
+system="${MISE_SYSTEM_DATA_DIR:-%s}/installs/node/%s"
+if [ ! -d "$installation" ] && [ -d "$system" ]; then
+  installation="$system"
+fi
+case "$2" in
+  install)
+    if [ ! -d "$installation" ]; then
+      mkdir -p "$installation/bin"
+      cp %q "$installation/bin/node"
+      chmod 0755 "$installation/bin/node"
+    fi
+    ;;
+  where) printf '%%s\n' "$installation" ;;
+  *) exit 9 ;;
+esac
+`, Node24Version, systemDir, Node24Version, systemNode)
+	if err := os.WriteFile(mise, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("MISE_SYSTEM_DATA_DIR", systemDir)
+	digest := sha256.Sum256(nodeBytes)
+	runner := newJobRun(Runner{Mise: mise, MiseDataDir: dataDir, nodeDigests: map[int]string{24: hex.EncodeToString(digest[:])}})
+	got, err := runner.discoverNode(t.Context(), 24, "")
+	want := filepath.Join(dataDir, "installs", "node", Node24Version, "bin", "node")
+	if err != nil || got != want {
+		t.Fatalf("discoverNode() = %q, %v; want managed Node %q", got, err, want)
+	}
+	if got, err := os.ReadFile(systemNode); err != nil || !bytes.Equal(got, nodeBytes) {
+		t.Fatalf("system Node changed: %q, %v", got, err)
+	}
+}
+
 func TestJavaScriptPhaseUsesVerifiedMiseNodeWithoutWorkflowRedirection(t *testing.T) {
 	root := canonicalTempDir(t)
 	log := filepath.Join(root, "node-args")


### PR DESCRIPTION
## Why

sj26 reported [Mailcatcher build 2](https://buildkite.com/sj26-new-1/mailcatcher/builds/2/list?sid=01a08369-6015-46d2-8eaf-0a0ef796f210&tab=output) failing before `ruby/setup-ruby@v1` could run, while the [matching GitHub Actions job](https://github.com/sj26/mailcatcher/actions/runs/33640231144/job/100281159939?pr=593) passed:

```text
cached Node 24 failed validation: validate mise-resolved core:node@24.18.0 installation: path is outside root
refusing to remove Node installation: path is outside root
```

Newer mise versions can reuse a system-wide Node installation even with `--no-config` and a separate `MISE_DATA_DIR`. This reproduces both error lines: the installation falls outside the cache that buildkite-gha validates and may remove. The private build logs were inaccessible, so the failed agent's exact mise version and resolved path remain unconfirmed.

## What

Set `MISE_SYSTEM_DATA_DIR` to the managed cache alongside `MISE_DATA_DIR` for Node installation and lookup. A preinstalled system Node no longer diverts JavaScript actions outside that cache; digest checks, symlink rejection, and deletion boundaries remain unchanged.

The regression covers an existing system Node with an empty managed cache and ensures the system installation stays untouched. Real mise checks confirmed the behavior with 2026.8.14 and compatibility with the minimum 2026.5.12.
