### PR TITLE
Run workflows on pull request reviews and inline comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ and [compatibility guide](docs/compatibility.md#job-configuration).
 
 The imported workflows are a dynamic part of the Buildkite pipeline. The plugin creates one aggregate group per successfully compiled, selected workflow in a single transaction. Workflows that do not declare the selected event become top-level skipped steps. Explicit-selector groups and replacement steps depend on the keyed importer. Each runnable job publishes a provider check named `<workflow> / <job> (<event>)`: a GitHub check for GitHub events or an Origin check for Origin events. This approach lets you keep existing workflows while moving jobs to native Buildkite steps over time.
 
-Buildkite owns build creation and schedule configuration. Within that build, `buildkite-gha` maps push and UI/API builds to `push`, pull requests to `pull_request`, merge queues to `merge_group`, releases to `release`, issues to `issues`, and scheduled builds to `schedule`. GitHub Actions Pipeline Triggers also support `issues` and both issue and pull request conversation comments through `issue_comment`. The importer then applies the matching `on:` branch, tag, base-branch, activity, and safely evidenced path filters. Explicit event snapshots and authoritative GitHub event metadata can select `workflow_dispatch`. Cross-event workflows are excluded before event-dependent compilation and retained as top-level skipped steps.
+Buildkite owns build creation and schedule configuration. Within that build, `buildkite-gha` maps push and UI/API builds to `push`, pull requests to `pull_request`, merge queues to `merge_group`, releases to `release`, issues to `issues`, and scheduled builds to `schedule`. GitHub Actions Pipeline Triggers also support `issues`, issue and PR conversation comments through `issue_comment`, and same-repository PR reviews and inline comments through `pull_request_review` and `pull_request_review_comment`. The importer then applies the matching `on:` filters supported by each event. Explicit event snapshots and authoritative GitHub event metadata can select `workflow_dispatch`. Cross-event workflows are excluded before event-dependent compilation and retained as top-level skipped steps.
 
 ## Check workflow compatibility
 
@@ -197,7 +197,7 @@ buildkite-gha validate \
   .github/workflows/ci.yml
 ```
 
-`--event` also supports `pull_request`, `merge_group`, `release`, `issues`, `issue_comment`, `workflow_dispatch`, and `schedule`. Generated release validation uses one stable `published` snapshot, generated issues validation uses `opened`, and generated issue-comment validation uses `created`. These are representative static validations, not proof of every activity. Generated snapshots are not equivalent to real payloads; use `--event-path` when exact payload data matters.
+`--event` also supports `pull_request`, `merge_group`, `release`, `issues`, `issue_comment`, `pull_request_review`, `pull_request_review_comment`, `workflow_dispatch`, and `schedule`. Generated release validation uses one stable `published` snapshot, issues uses `opened`, review uses `submitted`, and both comment events use `created`. These are representative static validations, not proof of every activity. Generated snapshots are not equivalent to real payloads; use `--event-path` when exact payload data matters.
 
 Use `--all-events` to evaluate every declared supported event separately:
 

--- a/cmd/validate-public-workflow-corpus/main.go
+++ b/cmd/validate-public-workflow-corpus/main.go
@@ -33,14 +33,16 @@ const (
 )
 
 var supportedEvents = map[string]bool{
-	"push":              true,
-	"pull_request":      true,
-	"merge_group":       true,
-	"release":           true,
-	"issues":            true,
-	"issue_comment":     true,
-	"workflow_dispatch": true,
-	"schedule":          true,
+	"push":                        true,
+	"pull_request":                true,
+	"pull_request_review":         true,
+	"pull_request_review_comment": true,
+	"merge_group":                 true,
+	"release":                     true,
+	"issues":                      true,
+	"issue_comment":               true,
+	"workflow_dispatch":           true,
+	"schedule":                    true,
 }
 
 var supportedWorkflowResults = map[string]bool{

--- a/cmd/validate-public-workflow-corpus/main_test.go
+++ b/cmd/validate-public-workflow-corpus/main_test.go
@@ -259,6 +259,9 @@ func TestTallyReports(t *testing.T) {
 			{Event: "issue_comment", Source: "generated", Report: validation},
 		},
 	}
+	for _, event := range []string{"pull_request_review", "pull_request_review_comment"} {
+		report.Evaluations = append(report.Evaluations, compatibility.EventEvaluation{Event: event, Source: "generated", Report: validation})
+	}
 	contents, err := json.Marshal(report)
 	if err != nil {
 		t.Fatal(err)
@@ -297,6 +300,11 @@ func TestTallyReports(t *testing.T) {
 	}
 	if tally.ByFinding["E_EXAMPLE"] != 1 || tally.ByRepo["E_EXAMPLE"] != 1 || tally.Evaluations["push"] != 1 || tally.Evaluations["issue_comment"] != 1 {
 		t.Fatalf("diagnostic tally = %#v", tally)
+	}
+	for _, event := range []string{"pull_request_review", "pull_request_review_comment"} {
+		if tally.Evaluations[event] != 1 {
+			t.Fatalf("missing %s evaluation: %#v", event, tally.Evaluations)
+		}
 	}
 	if tally.WorkflowResults["admitted"] != 1 || tally.WorkflowResults["context-required"] != 1 {
 		t.Fatalf("workflow result tally = %#v", tally.WorkflowResults)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -78,14 +78,15 @@ buildkite-gha validate \
 ```
 
 `--event` supports `push`, `pull_request`, `merge_group`, `release`, `issues`,
-`issue_comment`, `workflow_dispatch`, and `schedule`. It requires
+`issue_comment`, `pull_request_review`, `pull_request_review_comment`,
+`workflow_dispatch`, and `schedule`. It requires
 `--profile hosted` and cannot be combined with `--event-path`.
 
 The generated snapshot contains an example repository and the minimum event
 fields. It is useful for a quick check, but it is not a real payload. The
 release snapshot represents one stable, non-prerelease `published` event. The
-issues snapshot represents `opened`, and the issue-comment snapshot represents
-`created`. Use
+issues snapshot represents `opened`, review represents `submitted`, and both
+comment events represent `created`. Use
 `--event-path` when exact refs, activity, repository identity, or payload fields
 matter.
 
@@ -332,7 +333,8 @@ Actions Pipeline Trigger builds. Most users should configure an explicit
 Without an explicit selector, `BUILDKITE_GITHUB_WORKFLOW_PATH` marks a GitHub
 Actions Pipeline Trigger selection. The server also supplies:
 
-- `GITHUB_EVENT_NAME`: `push`, `pull_request`, `issues`, or `issue_comment`
+- `GITHUB_EVENT_NAME`: `push`, `pull_request`, `issues`, `issue_comment`,
+  `pull_request_review`, or `pull_request_review_comment`
 - `GITHUB_WORKFLOW`: the workflow `name`, or its repository-relative path when
   `name` is absent
 - `GITHUB_WORKFLOW_REF`:
@@ -349,6 +351,11 @@ commit. A malformed preferred value fails instead of falling back.
 For pull requests, `GITHUB_WORKFLOW_REF` and imported jobs' `GITHUB_REF` retain
 `refs/pull/<number>/merge`, while `GITHUB_WORKFLOW_SHA`, `GITHUB_SHA`, and the
 Buildkite checkout use the pull request head commit.
+Review and inline review-comment events use the same PR-head contract. They
+require both workflow identity fields and the original `buildkite:webhook`
+payload. The PR number, head SHA, head/base branches, activity, and all three
+repository identities must agree with the build. Missing payloads (including
+rebuilds without retained webhook data) fail closed, not as synthetic PR events.
 For `issues` and `issue_comment`, the ref is the current repository default
 branch and the SHA is its server-verified tip. Both identity fields are
 required. The linked payload action and repository must match the Buildkite

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -229,6 +229,9 @@ merge-group data must match the queue refs and commits. Linked release data must
 match the Buildkite event, action, branch, and tag. Linked issue and comment data
 must match the Buildkite action, default-branch ref, and repository. Comment
 payloads may describe either issue or pull request conversations.
+Review events require the original linked payload and matching immutable workflow
+identity, PR number, head SHA, head/base branches, and repository identities.
+They cannot fall back to a synthetic event on rebuilds without that payload.
 
 With the GitHub Code Access App, Buildkite resolves a release tag to its peeled
 commit before creating the build. Without it, the plugin resolves Buildkite's
@@ -247,12 +250,31 @@ the group condition, and the provider-check suffix.
 | `release` | Native Buildkite release builds only. In the pipeline's GitHub settings, enable **Additional Webhooks** > **Releases** and use **Code** trigger mode. Connect the GitHub Code Access App for immutable server provenance and hosted release `GITHUB_TOKEN` issuance. `types` is required and may contain only `published`, `created`, and `released`; bare `release`, all other activity types, and branch, tag, path, and workflow filters are rejected. Draft `created` deliveries are rejected. The ref is `refs/tags/<tag_name>`. The SHA is the server-resolved peeled commit, or the checked-out commit for the compatibility fallback. |
 | `issues` | Omitted `types` or `types: []` accepts every GitHub Actions issue activity. Nonempty `types` may contain `opened`, `edited`, `deleted`, `transferred`, `pinned`, `unpinned`, `closed`, `reopened`, `assigned`, `unassigned`, `labeled`, `unlabeled`, `locked`, `unlocked`, `milestoned`, `demilestoned`, `typed`, `untyped`, `field_added`, and `field_removed`. Unknown types and branch, tag, path, or workflow filters are rejected. In a GitHub Actions Pipeline Trigger build, Buildkite selects workflows and the checkout from the latest verified default-branch SHA; native issue-build settings, branch/path filters, and comment gating do not participate. Existing native Buildkite issue builds remain supported through linked webhook data and retain their own build-creation settings. |
 | `issue_comment` | Omitted `types` or `types: []` accepts `created`, `edited`, and `deleted`; nonempty `types` may contain those activities. Both issue and pull request conversation comments are supported. Unknown types and branch, tag, path, or workflow filters are rejected. GitHub Actions Pipeline Trigger builds select workflows and the checkout from the latest verified default-branch SHA and do not inherit native command-word, trusted-commenter, PR-only, branch, or path gating. |
+| `pull_request_review` | Pipeline Triggers support `submitted`, `edited`, and `dismissed`, all by default. Nonempty `types` selects activities, not review states. Use `if: github.event.review.state == 'approved'` on a job or step for approval-only execution. |
+| `pull_request_review_comment` | Pipeline Triggers support inline diff-comment `created`, `edited`, and `deleted` activities, all by default. These are distinct from submitted reviews and `issue_comment` conversation comments. |
 | `workflow_dispatch` | Selected only by an explicit snapshot or authoritative `GITHUB_EVENT_NAME` or `BUILDKITE_GITHUB_EVENT` value. Webhook-style branch, tag, type, and workflow filters are unsupported. |
 | `schedule` | Selected for Buildkite scheduled builds. Buildkite owns cron configuration and does not expose which schedule started a build, so every `on.schedule` workflow is eligible for every Buildkite scheduled build. |
 | `workflow_call` | Defines a reusable-workflow interface. A reusable-only local file is available to callers but does not become a top-level group. |
 | Any other event | No Buildkite build source exists, so the trigger can never start a build. It is ignored with a `W_TRIGGER_EVENT_UNSUPPORTED` warning when the workflow also declares a supported event. A workflow declaring only unsupported events fails event-independent validation and is a skipped step in an uploaded pipeline. |
 
 Supported `pull_request` activity types are `assigned`, `unassigned`, `labeled`, `unlabeled`, `opened`, `edited`, `closed`, `reopened`, `synchronize`, `converted_to_draft`, `locked`, `unlocked`, `enqueued`, `dequeued`, `milestoned`, `demilestoned`, `ready_for_review`, `review_requested`, `review_request_removed`, `auto_merge_enabled`, and `auto_merge_disabled`.
+
+Both review events accept scalar, array, and map `on` declarations, including
+empty maps and `types: []` for all activities. Unknown types and branch, tag,
+path, and workflow filters are rejected. The workflow and checkout use the PR
+head SHA, not the synthetic merge commit or an older reviewed commit; the event
+ref remains `refs/pull/<number>/merge`. There is no default-branch-only workflow
+requirement. Use `github.event.pull_request.head.ref` and `.base.ref` for branch
+conditions. CI-skip commit directives do not suppress these events.
+
+Review support requires the companion Buildkite backend and a runtime newer than
+v0.59.0 containing this implementation. Existing dedicated repository hooks must
+subscribe to both review events; deploying the backend does not backfill hooks.
+Fork PRs are unsupported. Same-repository review builds retain the PR
+`contents:read` token ceiling even for approving reviews; Buildkite secret and
+queue policies still apply. The original linked webhook is required, so rebuilds
+without retained payloads fail explicitly. See the
+[server-selected event contract](cli.md#private-preview-pipeline-trigger-selection).
 
 GitHub defines seven release activities: `published`, `unpublished`, `created`, `edited`, `deleted`, `prereleased`, and `released`. A bare `on: release` selects all seven, so it cannot map exactly to Buildkite's three delivered activities and is unsupported.
 
@@ -1693,7 +1715,7 @@ buildkite-gha validate \
   .github/workflows/ci.yml
 ```
 
-Use `--event push`, `--event pull_request`, `--event merge_group`, `--event release`, `--event issues`, `--event issue_comment`, `--event workflow_dispatch`, or `--event schedule` instead of `--event-path` to evaluate the hosted profile with a generated minimal snapshot. The generated release event is a stable `published` event, the generated issues event is `opened`, and the generated issue-comment event is `created`. Generated snapshots are representative compatibility test inputs, not proof of every activity or equivalents to real payloads. The options are mutually exclusive.
+Use `--event push`, `--event pull_request`, `--event merge_group`, `--event release`, `--event issues`, `--event issue_comment`, `--event pull_request_review`, `--event pull_request_review_comment`, `--event workflow_dispatch`, or `--event schedule` instead of `--event-path` to evaluate the hosted profile with a generated minimal snapshot. The generated release event is a stable `published` event, issues is `opened`, review is `submitted`, and both comment events are `created`. Generated snapshots are representative compatibility test inputs, not proof of every activity or equivalents to real payloads. The options are mutually exclusive.
 
 Use `--all-events` to evaluate every declared supported event separately. Its `processing-report/v3` output preserves the event-independent result and each generated event's v2 report. Aggregate admission means every generated snapshot was admitted; it does not cover other payload shapes. A `context-required` result means compilation and hosted-policy checks passed, but generated inputs cannot measure a supported admission path, such as push or pull-request path filters without linked webhook and local diff evidence. It does not claim admission.
 

--- a/internal/buildkite/triggers.go
+++ b/internal/buildkite/triggers.go
@@ -17,16 +17,17 @@ const maxSkipReasonLength = 70
 // TriggerConditionExpressions supplies the trusted Buildkite expressions used
 // to select one effective event and apply its supported trigger filters.
 type TriggerConditionExpressions struct {
-	EventPredicate        string
-	Branch                string
-	Tag                   string
-	PullRequestBaseBranch string
-	PullRequestAction     string
-	MergeGroupBaseBranch  string
-	MergeGroupAction      string
-	ReleaseAction         string
-	IssuesAction          string
-	IssueCommentAction    string
+	EventPredicate          string
+	Branch                  string
+	Tag                     string
+	PullRequestBaseBranch   string
+	PullRequestAction       string
+	MergeGroupBaseBranch    string
+	MergeGroupAction        string
+	ReleaseAction           string
+	IssuesAction            string
+	IssueCommentAction      string
+	PullRequestReviewAction string
 }
 
 // ChangedPathEvaluation records either the available changed paths or why
@@ -43,30 +44,33 @@ func (e ChangedPathEvaluation) available() bool {
 // TriggerEventSnapshot supplies observed effective-event values used to match
 // trigger filters and explain mismatches.
 type TriggerEventSnapshot struct {
-	Branch                *string
-	Tag                   *string
-	PullRequestBaseBranch *string
-	PullRequestAction     *string
-	MergeGroupBaseBranch  *string
-	MergeGroupAction      *string
-	ReleaseAction         *string
-	IssuesAction          *string
-	IssueCommentAction    *string
-	ChangedPaths          ChangedPathEvaluation
+	Branch                  *string
+	Tag                     *string
+	PullRequestBaseBranch   *string
+	PullRequestAction       *string
+	MergeGroupBaseBranch    *string
+	MergeGroupAction        *string
+	ReleaseAction           *string
+	IssuesAction            *string
+	IssueCommentAction      *string
+	PullRequestReviewAction *string
+	ChangedPaths            ChangedPathEvaluation
 }
 
 // supportedTriggerEvents is the single source of truth for GitHub trigger
 // events that map to a Buildkite build source.
 var supportedTriggerEvents = map[string]bool{
-	"workflow_call":     true,
-	"workflow_dispatch": true,
-	"schedule":          true,
-	"push":              true,
-	"pull_request":      true,
-	"merge_group":       true,
-	"release":           true,
-	"issues":            true,
-	"issue_comment":     true,
+	"workflow_call":               true,
+	"workflow_dispatch":           true,
+	"schedule":                    true,
+	"push":                        true,
+	"pull_request":                true,
+	"merge_group":                 true,
+	"release":                     true,
+	"issues":                      true,
+	"issue_comment":               true,
+	"pull_request_review":         true,
+	"pull_request_review_comment": true,
 }
 
 var supportedIssuesAction = map[string]bool{
@@ -130,16 +134,17 @@ func (e *UnsupportedPathFiltersError) CompatibilityBlocker() (string, string) {
 // supplied the effective event snapshot.
 func LiveTriggerConditionExpressions(eventPredicate string) TriggerConditionExpressions {
 	return TriggerConditionExpressions{
-		EventPredicate:        eventPredicate,
-		Branch:                "build.branch",
-		Tag:                   "build.tag",
-		PullRequestBaseBranch: "build.pull_request.base_branch",
-		PullRequestAction:     "build.source_action",
-		MergeGroupBaseBranch:  "build.merge_queue.base_branch",
-		MergeGroupAction:      "build.source_action",
-		ReleaseAction:         "build.source_action",
-		IssuesAction:          "build.source_action",
-		IssueCommentAction:    "build.source_action",
+		EventPredicate:          eventPredicate,
+		Branch:                  "build.branch",
+		Tag:                     "build.tag",
+		PullRequestBaseBranch:   "build.pull_request.base_branch",
+		PullRequestAction:       "build.source_action",
+		MergeGroupBaseBranch:    "build.merge_queue.base_branch",
+		MergeGroupAction:        "build.source_action",
+		ReleaseAction:           "build.source_action",
+		IssuesAction:            "build.source_action",
+		IssueCommentAction:      "build.source_action",
+		PullRequestReviewAction: "build.source_action",
 	}
 }
 
@@ -349,6 +354,10 @@ func TriggerFilterMismatchReason(triggers []workflow.Trigger, event string, snap
 			if snapshot.IssueCommentAction != nil && len(trigger.Types) != 0 && !slices.Contains(trigger.Types, *snapshot.IssueCommentAction) {
 				return fmt.Sprintf("Issue comment activity %q does not match this workflow's issue_comment activity filters.", *snapshot.IssueCommentAction), nil
 			}
+		case "pull_request_review", "pull_request_review_comment":
+			if snapshot.PullRequestReviewAction != nil && len(trigger.Types) != 0 && !slices.Contains(trigger.Types, *snapshot.PullRequestReviewAction) {
+				return fmt.Sprintf("Review activity %q does not match this workflow's %s activity filters.", *snapshot.PullRequestReviewAction, event), nil
+			}
 		}
 		if (trigger.Paths != nil || trigger.PathsIgnore != nil) && (event == "pull_request" || event == "push" && snapshot.Tag == nil) && snapshot.ChangedPaths.available() {
 			matches, err := pathFiltersMatch(snapshot.ChangedPaths.Paths, trigger.Paths, trigger.PathsIgnore)
@@ -384,7 +393,7 @@ func LiveEventPredicate(event string) string {
 	predicate := "(" + githubEvent + " == " + yamlScalar(event) + " || (" + githubEventMissing + " && " + buildkiteGitHubEvent + " == " + yamlScalar(event) + "))"
 	fallbackEvent := "(" + githubEventMissing + " && (" + buildkiteGitHubEvent + " == null"
 	unsupportedEvent := ""
-	for _, supported := range []string{"push", "pull_request", "workflow_dispatch", "schedule"} {
+	for _, supported := range []string{"push", "pull_request", "workflow_dispatch", "schedule", "pull_request_review", "pull_request_review_comment"} {
 		if unsupportedEvent != "" {
 			unsupportedEvent += " && "
 		}
@@ -400,7 +409,7 @@ func LiveEventPredicate(event string) string {
 		return predicate
 	case "schedule":
 		return "(" + predicate + " || (" + fallbackEvent + ` && build.pull_request.id == null && build.source == "schedule"))`
-	case "merge_group", "release", "issues", "issue_comment":
+	case "merge_group", "release", "issues", "issue_comment", "pull_request_review", "pull_request_review_comment":
 		return predicate
 	default:
 		return ""
@@ -642,6 +651,27 @@ func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpression
 			actions = append(actions, expressions.IssuesAction+` == `+yamlScalar(action))
 		}
 		return expressions.EventPredicate + " && (" + strings.Join(actions, " || ") + ")", true, nil
+	case "pull_request_review", "pull_request_review_comment":
+		if t.Branches != nil || t.BranchesIgnore != nil || t.Tags != nil || t.TagsIgnore != nil || t.Workflows != nil {
+			return "", false, fmt.Errorf("%s has unsupported filters", t.Event)
+		}
+		if expressions.EventPredicate == "" || expressions.PullRequestReviewAction == "" || expressions.PullRequestReviewAction == "null" {
+			return "", false, fmt.Errorf("%s requires effective event and action expressions", t.Event)
+		}
+		if snapshot.PullRequestReviewAction != nil && !SupportedPullRequestReviewAction(t.Event, *snapshot.PullRequestReviewAction) {
+			return "", false, fmt.Errorf("%s activity type %q cannot be mapped exactly", t.Event, *snapshot.PullRequestReviewAction)
+		}
+		if len(t.Types) == 0 {
+			return expressions.EventPredicate, true, nil
+		}
+		actions := make([]string, 0, len(t.Types))
+		for _, action := range t.Types {
+			if !SupportedPullRequestReviewAction(t.Event, action) {
+				return "", false, fmt.Errorf("%s activity type %q cannot be mapped exactly", t.Event, action)
+			}
+			actions = append(actions, expressions.PullRequestReviewAction+` == `+yamlScalar(action))
+		}
+		return expressions.EventPredicate + " && (" + strings.Join(actions, " || ") + ")", true, nil
 	case "issue_comment":
 		if t.Branches != nil || t.BranchesIgnore != nil || t.Tags != nil || t.TagsIgnore != nil || t.Workflows != nil {
 			return "", false, fmt.Errorf("issue_comment has unsupported filters")
@@ -665,6 +695,18 @@ func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpression
 		return expressions.EventPredicate + " && (" + strings.Join(actions, " || ") + ")", true, nil
 	default:
 		return "", false, &UnsupportedTriggerEventError{Event: t.Event}
+	}
+}
+
+// SupportedPullRequestReviewAction reports the documented activity set for review events.
+func SupportedPullRequestReviewAction(event, action string) bool {
+	switch event {
+	case "pull_request_review":
+		return action == "submitted" || action == "edited" || action == "dismissed"
+	case "pull_request_review_comment":
+		return action == "created" || action == "edited" || action == "deleted"
+	default:
+		return false
 	}
 }
 

--- a/internal/cli/buildkite_event.go
+++ b/internal/cli/buildkite_event.go
@@ -12,6 +12,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	buildkitepipeline "github.com/buildkite/buildkite-gha/internal/buildkite"
 	"github.com/buildkite/buildkite-gha/internal/git"
 )
 
@@ -121,7 +122,7 @@ func buildkiteEventSource(getenv func(string) string) ([]byte, error) {
 				}
 				payload = map[string]any{"ref": ref}
 			}
-		case "issues", "issue_comment":
+		case "issues", "issue_comment", "pull_request_review", "pull_request_review_comment":
 			if githubEvent == "issues" && getenv(pipelineTriggerWorkflowPathEnvironment) == "" &&
 				getenv(githubWorkflowRefEnvironment) == "" && getenv(githubWorkflowSHAEnvironment) == "" {
 				break
@@ -209,6 +210,11 @@ func buildkiteWebhookEventSource(getenv func(string) string, webhook []byte) ([]
 	}
 	if snapshot["event"] == "issues" || snapshot["event"] == "issue_comment" {
 		if err := validateBuildkiteIssueEvent(snapshot, getenv); err != nil {
+			return nil, err
+		}
+	}
+	if snapshot["event"] == "pull_request_review" || snapshot["event"] == "pull_request_review_comment" {
+		if err := validateBuildkiteReviewEvent(snapshot, getenv); err != nil {
 			return nil, err
 		}
 	}
@@ -345,6 +351,49 @@ func validateBuildkiteIssueEvent(snapshot map[string]any, getenv func(string) st
 	ref, _ := snapshot["ref"].(string)
 	if ref != "refs/heads/"+getenv("BUILDKITE_BRANCH") {
 		return fmt.Errorf("%s webhook ref does not match the Buildkite build branch", event)
+	}
+	return nil
+}
+
+func validateBuildkiteReviewEvent(snapshot map[string]any, getenv func(string) string) error {
+	event := snapshot["event"].(string)
+	payload := snapshot["payload"].(map[string]any)
+	action, _ := payload["action"].(string)
+	if !buildkitepipeline.SupportedPullRequestReviewAction(event, action) || action != getenv("BUILDKITE_GITHUB_ACTION") {
+		return fmt.Errorf("%s webhook action is unsupported or does not match BUILDKITE_GITHUB_ACTION", event)
+	}
+	key := "review"
+	if event == "pull_request_review_comment" {
+		key = "comment"
+	}
+	object, _ := payload[key].(map[string]any)
+	if !positiveJSONInteger(object["id"]) {
+		return fmt.Errorf("%s webhook requires payload.%s.id", event, key)
+	}
+	pr, _ := payload["pull_request"].(map[string]any)
+	if !positiveJSONInteger(pr["number"]) || fmt.Sprint(pr["number"]) != getenv("BUILDKITE_PULL_REQUEST") {
+		return fmt.Errorf("%s webhook pull request number does not match BUILDKITE_PULL_REQUEST", event)
+	}
+	if snapshot["ref"] != "refs/pull/"+getenv("BUILDKITE_PULL_REQUEST")+"/merge" {
+		return fmt.Errorf("%s workflow ref does not match BUILDKITE_PULL_REQUEST", event)
+	}
+	head, _ := pr["head"].(map[string]any)
+	base, _ := pr["base"].(map[string]any)
+	if head["sha"] != snapshot["sha"] || head["ref"] != getenv("BUILDKITE_BRANCH") || base["ref"] != getenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH") {
+		return fmt.Errorf("%s webhook head SHA or branches do not match the Buildkite build", event)
+	}
+	provider, owner, name, _, err := parseBuildkiteRepository(getenv("BUILDKITE_REPO"))
+	if err != nil || provider != "github" {
+		return fmt.Errorf("%s webhook requires a GitHub repository", event)
+	}
+	repository, _ := payload["repository"].(map[string]any)
+	headRepository, _ := head["repo"].(map[string]any)
+	baseRepository, _ := base["repo"].(map[string]any)
+	for _, repo := range []map[string]any{repository, headRepository, baseRepository} {
+		fullName, _ := repo["full_name"].(string)
+		if !strings.EqualFold(fullName, owner+"/"+name) {
+			return fmt.Errorf("%s webhook requires the build repository for repository, PR head, and PR base; forks are unsupported", event)
+		}
 	}
 	return nil
 }

--- a/internal/cli/effective_event.go
+++ b/internal/cli/effective_event.go
@@ -50,6 +50,13 @@ func loadEffectiveEventSource(ctx context.Context, eventPath string, agent trans
 		source, err := buildkiteWebhookEventSource(os.Getenv, webhook)
 		return source, effectiveEventFromWebhook, err
 	case errors.Is(metadataErr, transport.ErrMetadataUnavailable):
+		event, err := buildkiteGitHubEventName(os.Getenv)
+		if err != nil {
+			return nil, "", err
+		}
+		if event == "pull_request_review" || event == "pull_request_review_comment" {
+			return nil, "", fmt.Errorf("%s requires the original buildkite:webhook payload; rebuilds without it are unsupported", event)
+		}
 		source, err := buildkiteEventSource(os.Getenv)
 		return source, effectiveEventFromBuild, err
 	default:
@@ -77,16 +84,17 @@ func newEffectiveEvent(source []byte, origin effectiveEventOrigin) (effectiveEve
 
 func snapshotTriggerState(event compiler.Event) (buildkitepipeline.TriggerConditionExpressions, buildkitepipeline.TriggerEventSnapshot) {
 	expressions := buildkitepipeline.TriggerConditionExpressions{
-		EventPredicate:        "true",
-		Branch:                "null",
-		Tag:                   "null",
-		PullRequestBaseBranch: "null",
-		PullRequestAction:     "null",
-		MergeGroupBaseBranch:  "null",
-		MergeGroupAction:      "null",
-		ReleaseAction:         "null",
-		IssuesAction:          "null",
-		IssueCommentAction:    "null",
+		EventPredicate:          "true",
+		Branch:                  "null",
+		Tag:                     "null",
+		PullRequestBaseBranch:   "null",
+		PullRequestAction:       "null",
+		MergeGroupBaseBranch:    "null",
+		MergeGroupAction:        "null",
+		ReleaseAction:           "null",
+		IssuesAction:            "null",
+		IssueCommentAction:      "null",
+		PullRequestReviewAction: "null",
 	}
 	snapshot := buildkitepipeline.TriggerEventSnapshot{}
 	if branch, ok := strings.CutPrefix(event.Ref, "refs/heads/"); ok {
@@ -108,6 +116,8 @@ func snapshotTriggerState(event compiler.Event) (buildkitepipeline.TriggerCondit
 		snapshot.IssuesAction = &action
 		expressions.IssueCommentAction = triggerConditionLiteral(action)
 		snapshot.IssueCommentAction = &action
+		expressions.PullRequestReviewAction = triggerConditionLiteral(action)
+		snapshot.PullRequestReviewAction = &action
 	}
 	if pullRequest, ok := event.Payload["pull_request"].(map[string]any); ok {
 		if base, ok := pullRequest["base"].(map[string]any); ok {

--- a/internal/cli/effective_event_test.go
+++ b/internal/cli/effective_event_test.go
@@ -19,16 +19,17 @@ func TestNewEffectiveEventSeparatesExpressionsAndSnapshot(t *testing.T) {
 		t.Fatal(err)
 	}
 	wantExpressions := buildkitepipeline.TriggerConditionExpressions{
-		EventPredicate:        "true",
-		Branch:                `"main"`,
-		Tag:                   "null",
-		PullRequestBaseBranch: "null",
-		PullRequestAction:     "null",
-		MergeGroupBaseBranch:  "null",
-		MergeGroupAction:      "null",
-		ReleaseAction:         "null",
-		IssuesAction:          "null",
-		IssueCommentAction:    "null",
+		EventPredicate:          "true",
+		Branch:                  `"main"`,
+		Tag:                     "null",
+		PullRequestBaseBranch:   "null",
+		PullRequestAction:       "null",
+		MergeGroupBaseBranch:    "null",
+		MergeGroupAction:        "null",
+		ReleaseAction:           "null",
+		IssuesAction:            "null",
+		IssueCommentAction:      "null",
+		PullRequestReviewAction: "null",
 	}
 	branch := "main"
 	wantSnapshot := buildkitepipeline.TriggerEventSnapshot{Branch: &branch}

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -243,8 +243,8 @@ func pluginWorkflowOperands(configuration pluginConfiguration, getenv func(strin
 	if event == "" {
 		return nil, nil, fmt.Errorf("%s or BUILDKITE_GITHUB_EVENT is required", githubEventNameEnvironment)
 	}
-	if event != "push" && event != "pull_request" && event != "issues" && event != "issue_comment" {
-		return nil, nil, fmt.Errorf("%s or BUILDKITE_GITHUB_EVENT must be push, pull_request, issues, or issue_comment", githubEventNameEnvironment)
+	if event != "push" && event != "pull_request" && event != "issues" && event != "issue_comment" && event != "pull_request_review" && event != "pull_request_review_comment" {
+		return nil, nil, fmt.Errorf("%s or BUILDKITE_GITHUB_EVENT must be push, pull_request, issues, issue_comment, pull_request_review, or pull_request_review_comment", githubEventNameEnvironment)
 	}
 
 	workflowName := getenv(githubWorkflowEnvironment)
@@ -263,7 +263,7 @@ func pluginWorkflowOperands(configuration pluginConfiguration, getenv func(strin
 	if workflowSHA != "" && !git.ValidObjectID(workflowSHA) {
 		return nil, nil, fmt.Errorf("%s must be a full lowercase 40-hex commit", githubWorkflowSHAEnvironment)
 	}
-	if (event == "issues" || event == "issue_comment") && (getenv(githubWorkflowRefEnvironment) == "" || workflowSHA == "") {
+	if (event == "issues" || event == "issue_comment" || event == "pull_request_review" || event == "pull_request_review_comment") && (getenv(githubWorkflowRefEnvironment) == "" || workflowSHA == "") {
 		return nil, nil, fmt.Errorf("%s and %s are required for %s", githubWorkflowRefEnvironment, githubWorkflowSHAEnvironment, event)
 	}
 	return []string{selectedPath}, &pipelineTriggerWorkflow{Name: workflowName, SHA: workflowSHA}, nil
@@ -306,7 +306,7 @@ func pipelineTriggerEventRef(event, ref string) bool {
 				return value != ""
 			}
 		}
-	case "pull_request":
+	case "pull_request", "pull_request_review", "pull_request_review_comment":
 		number, ok := strings.CutPrefix(ref, "refs/pull/")
 		if !ok {
 			return false

--- a/internal/cli/review_event_test.go
+++ b/internal/cli/review_event_test.go
@@ -1,0 +1,174 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	buildkitepipeline "github.com/buildkite/buildkite-gha/internal/buildkite"
+	"github.com/buildkite/buildkite-gha/internal/compiler"
+	"github.com/buildkite/buildkite-gha/internal/plan"
+	"github.com/buildkite/buildkite-gha/internal/transport"
+	"github.com/buildkite/buildkite-gha/internal/workflow"
+)
+
+func reviewWebhook(event, action, sha string) []byte {
+	object := `"review":{"id":901,"state":"approved","commit_id":"` + strings.Repeat("c", 40) + `"}`
+	if event == "pull_request_review_comment" {
+		object = `"comment":{"id":902,"path":"src/example.go","body":"inline comment"}`
+	}
+	return []byte(fmt.Sprintf(`{"action":%q,%s,"repository":{"id":123,"full_name":"buildkite/buildkite-gha"},"sender":{"login":"reviewer"},"pull_request":{"number":42,"head":{"sha":%q,"ref":"feature/review","repo":{"full_name":"buildkite/buildkite-gha"}},"base":{"ref":"release","repo":{"full_name":"buildkite/buildkite-gha"}},"mergeable":false,"merge_commit_sha":%q}}`, action, object, sha, strings.Repeat("b", 40)))
+}
+
+func setReviewEnvironment(t *testing.T, event, action string) {
+	t.Helper()
+	setCLIPluginBuildkiteEnvironment(t, "review-pipeline-trigger")
+	t.Setenv("BUILDKITE_PULL_REQUEST", "42")
+	t.Setenv("BUILDKITE_BRANCH", "feature/review")
+	t.Setenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH", "release")
+	t.Setenv("BUILDKITE_GITHUB_ACTION", action)
+	setCLIPipelineTriggerEnvironment(t, ".github/workflows/selected.yml", "Selected", event, "buildkite/buildkite-gha/.github/workflows/selected.yml@refs/pull/42/merge")
+}
+
+func TestPluginReviewEvents(t *testing.T) {
+	requireImporterHost(t)
+	for _, event := range []string{"pull_request_review", "pull_request_review_comment"} {
+		t.Run(event, func(t *testing.T) {
+			action := "submitted"
+			if event == "pull_request_review_comment" {
+				action = "created"
+			}
+			source := "name: Selected\non: " + event + "\njobs:\n  selected:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo '${{ toJSON(github.event) }}'\n"
+			repository := writeUploadWorkflowRepository(t, map[string]string{"selected.yml": source, "other.yml": source})
+			t.Chdir(repository)
+			t.Setenv(pluginConfigurationEnvironment, `{}`)
+			setReviewEnvironment(t, event, action)
+			t.Setenv("BUILDKITE_BUILD_CHECKOUT_PATH", repository)
+			t.Setenv("BUILDKITE_JOB_ID", cliTestJobID)
+			runner := &cliCaptureRunner{webhook: reviewWebhook(event, action, os.Getenv("BUILDKITE_COMMIT"))}
+			var stdout, stderr bytes.Buffer
+			if code := run([]string{"plugin"}, &stdout, &stderr, "dev", runner); code != 0 {
+				t.Fatalf("plugin = %d: %s %s", code, &stdout, &stderr)
+			}
+			plans, payloads := 0, 0
+			for path, data := range runner.uploaded {
+				if strings.HasPrefix(path, ".buildkite-gha/plans/") && strings.HasSuffix(path, ".json") {
+					job, err := plan.Decode(data)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if job.Event.Name != event || job.Event.Ref != "refs/pull/42/merge" || job.Event.SHA != os.Getenv("BUILDKITE_COMMIT") || job.Event.Actor != "reviewer" || !job.Event.PayloadArtifact {
+						t.Fatalf("incoherent event: %#v", job.Event)
+					}
+					plans++
+				}
+				if strings.HasPrefix(path, ".buildkite-gha/events/") && strings.HasSuffix(path, ".json") {
+					var got, want any
+					if err := json.Unmarshal(data, &got); err != nil {
+						t.Fatal(err)
+					}
+					if err := json.Unmarshal(runner.webhook, &want); err != nil {
+						t.Fatal(err)
+					}
+					if !reflect.DeepEqual(got, want) {
+						t.Fatalf("review payload changed: %s", data)
+					}
+					payloads++
+				}
+			}
+			if plans != 1 || payloads != 1 {
+				t.Fatalf("plans=%d payloads=%d; want only selected workflow", plans, payloads)
+			}
+			t.Setenv("BUILDKITE_SOURCE", "ui")
+			_, _, err := loadEffectiveEventSource(t.Context(), "", transport.Agent{Runner: &cliCaptureRunner{}})
+			if err == nil || !strings.Contains(err.Error(), "original buildkite:webhook") {
+				t.Fatalf("missing rebuild payload error = %v", err)
+			}
+		})
+	}
+}
+
+func TestReviewTriggerActivities(t *testing.T) {
+	for event, activities := range map[string][]string{
+		"pull_request_review":         {"submitted", "edited", "dismissed"},
+		"pull_request_review_comment": {"created", "edited", "deleted"},
+	} {
+		for _, declaration := range []string{event, "[push, " + event + "]", "{" + event + ": null}", "{" + event + ": {}}", "{" + event + ": {types: []}}", "{" + event + ": {types: [edited]}}", "{" + event + ": {types: edited}}"} {
+			t.Run(declaration, func(t *testing.T) {
+				parsed, err := workflow.Parse("review.yml", []byte("on: "+declaration+"\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"))
+				if err != nil {
+					t.Fatal(err)
+				}
+				for _, action := range activities {
+					effective, err := newEffectiveEvent([]byte(fmt.Sprintf(`{"provider":"github","event":%q,"repository":{"owner":"buildkite","name":"buildkite-gha"},"ref":"refs/pull/42/merge","sha":%q,"actor":"reviewer","payload":{"action":%q}}`, event, strings.Repeat("a", 40), action)), effectiveEventFromPath)
+					if err != nil {
+						t.Fatal(err)
+					}
+					selection, err := selectWorkflowTrigger(parsed.Triggers, effective)
+					if err != nil || !selection.Applicable {
+						t.Fatalf("selection=%#v error=%v", selection, err)
+					}
+					wantMismatch := strings.Contains(declaration, "edited") && action != "edited"
+					if (selection.AnnotationReason != "") != wantMismatch {
+						t.Fatalf("%s: selection=%#v", action, selection)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestReviewWebhookIdentity(t *testing.T) {
+	for _, event := range []string{"pull_request_review", "pull_request_review_comment"} {
+		t.Run(event, func(t *testing.T) {
+			setReviewEnvironment(t, event, "edited")
+			sha := os.Getenv("BUILDKITE_COMMIT")
+			payload := reviewWebhook(event, "edited", sha)
+			source, err := buildkiteWebhookEventSource(os.Getenv, payload)
+			if err != nil {
+				t.Fatal(err)
+			}
+			parsed, err := compiler.ParseEvent(source)
+			if err != nil || parsed.Event != event || parsed.SHA != sha || parsed.Ref != "refs/pull/42/merge" {
+				t.Fatalf("event=%#v error=%v", parsed, err)
+			}
+			for name, broken := range map[string][]byte{
+				"fork":            bytes.Replace(payload, []byte(`"repo":{"full_name":"buildkite/buildkite-gha"}`), []byte(`"repo":{"full_name":"other/fork"}`), 1),
+				"base repository": bytes.Replace(payload, []byte(`"base":{"ref":"release","repo":{"full_name":"buildkite/buildkite-gha"}}`), []byte(`"base":{"ref":"release","repo":{"full_name":"other/base"}}`), 1),
+				"repository":      bytes.Replace(payload, []byte(`"repository":{"id":123,"full_name":"buildkite/buildkite-gha"}`), []byte(`"repository":{"id":123,"full_name":"other/repository"}`), 1),
+				"number":          bytes.Replace(payload, []byte(`"number":42`), []byte(`"number":43`), 1),
+				"head sha":        bytes.Replace(payload, []byte(sha), []byte(strings.Repeat("d", 40)), 1),
+				"action":          bytes.Replace(payload, []byte(`"action":"edited"`), []byte(`"action":"opened"`), 1),
+				"object":          bytes.Replace(payload, []byte(`"id":90`), []byte(`"wrong":90`), 1),
+			} {
+				if _, err := buildkiteWebhookEventSource(os.Getenv, broken); err == nil {
+					t.Errorf("accepted %s mismatch", name)
+				}
+			}
+		})
+	}
+}
+
+func TestReviewFiltersFailClosed(t *testing.T) {
+	for _, event := range []string{"pull_request_review", "pull_request_review_comment"} {
+		for name, trigger := range map[string]workflow.Trigger{
+			"branch":       {Event: event, Branches: []string{"release"}},
+			"path":         {Event: event, Paths: []string{"src/**"}},
+			"tag":          {Event: event, TagsIgnore: []string{"v*"}},
+			"unknown type": {Event: event, Types: []string{"approved"}},
+		} {
+			if _, err := buildkitepipeline.TranslateTriggerCondition([]workflow.Trigger{trigger}); err == nil {
+				t.Errorf("%s accepted %s", event, name)
+			}
+		}
+		for _, predicate := range []string{"push", "pull_request"} {
+			if !strings.Contains(buildkitepipeline.LiveEventPredicate(predicate), `build.env("BUILDKITE_GITHUB_EVENT") != "`+event+`"`) {
+				t.Errorf("%s compatibility fallback does not exclude %s", predicate, event)
+			}
+		}
+	}
+}

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -263,7 +263,7 @@ func validateAllEventsSource(ctx context.Context, out processingOutput, workflow
 		declared[trigger.Event] = true
 	}
 	failed := false
-	for _, event := range []string{"push", "pull_request", "merge_group", "release", "issues", "issue_comment", "workflow_dispatch", "schedule"} {
+	for _, event := range []string{"push", "pull_request", "merge_group", "release", "issues", "issue_comment", "pull_request_review", "pull_request_review_comment", "workflow_dispatch", "schedule"} {
 		if !declared[event] {
 			continue
 		}
@@ -382,8 +382,8 @@ func validateArgs(args []string) (workflowPath, eventPath, eventName, format, pr
 	if eventSeen && profile == "" {
 		return "", "", "", "", "", false, fmt.Errorf("--event requires --profile hosted")
 	}
-	if eventSeen && !slices.Contains([]string{"push", "pull_request", "merge_group", "release", "issues", "issue_comment", "workflow_dispatch", "schedule"}, eventName) {
-		return "", "", "", "", "", false, fmt.Errorf("unsupported --event %q; supported events are push, pull_request, merge_group, release, issues, issue_comment, workflow_dispatch, and schedule", eventName)
+	if eventSeen && !slices.Contains([]string{"push", "pull_request", "merge_group", "release", "issues", "issue_comment", "pull_request_review", "pull_request_review_comment", "workflow_dispatch", "schedule"}, eventName) {
+		return "", "", "", "", "", false, fmt.Errorf("unsupported --event %q; supported events are push, pull_request, merge_group, release, issues, issue_comment, pull_request_review, pull_request_review_comment, workflow_dispatch, and schedule", eventName)
 	}
 	if allEvents && (eventPathSeen || eventSeen) {
 		return "", "", "", "", "", false, fmt.Errorf("--all-events is mutually exclusive with --event and --event-path")
@@ -411,7 +411,7 @@ func generatedEventSnapshot(name string) ([]byte, error) {
 	switch name {
 	case "push":
 		event.Payload["ref"] = event.Ref
-	case "pull_request":
+	case "pull_request", "pull_request_review", "pull_request_review_comment":
 		event.Ref = "refs/pull/1/merge"
 		event.Payload["action"] = "opened"
 		event.Payload["number"] = 1
@@ -419,6 +419,14 @@ func generatedEventSnapshot(name string) ([]byte, error) {
 			"number": 1,
 			"base":   map[string]any{"ref": "main"},
 			"head":   map[string]any{"ref": "example"},
+		}
+		switch name {
+		case "pull_request_review":
+			event.Payload["action"] = "submitted"
+			event.Payload["review"] = map[string]any{"id": 2, "state": "approved"}
+		case "pull_request_review_comment":
+			event.Payload["action"] = "created"
+			event.Payload["comment"] = map[string]any{"id": 3, "path": "example.go"}
 		}
 	case "merge_group":
 		event.Ref = "refs/heads/gh-readonly-queue/main/pr-1-deadbeef"
@@ -448,7 +456,7 @@ func generatedEventSnapshot(name string) ([]byte, error) {
 		event.Payload["schedule"] = "0 0 * * *"
 	case "workflow_dispatch":
 	default:
-		return nil, fmt.Errorf("unsupported generated event %q; supported events are push, pull_request, merge_group, release, issues, issue_comment, workflow_dispatch, and schedule", name)
+		return nil, fmt.Errorf("unsupported generated event %q; supported events are push, pull_request, merge_group, release, issues, issue_comment, pull_request_review, pull_request_review_comment, workflow_dispatch, and schedule", name)
 	}
 	return json.Marshal(event)
 }

--- a/internal/cli/validate_batch.go
+++ b/internal/cli/validate_batch.go
@@ -472,7 +472,7 @@ func loadBatchValidationResult(path, workflow string) (compatibility.ProcessingR
 	seen := make(map[string]bool, len(report.Evaluations))
 	for _, evaluation := range report.Evaluations {
 		if seen[evaluation.Event] || evaluation.Source != "generated" || evaluation.Report.Schema != compatibility.ProcessingSchema ||
-			(evaluation.Event != "push" && evaluation.Event != "pull_request" && evaluation.Event != "merge_group" && evaluation.Event != "release" && evaluation.Event != "issues" && evaluation.Event != "issue_comment" && evaluation.Event != "workflow_dispatch" && evaluation.Event != "schedule") {
+			(evaluation.Event != "push" && evaluation.Event != "pull_request" && evaluation.Event != "merge_group" && evaluation.Event != "release" && evaluation.Event != "issues" && evaluation.Event != "issue_comment" && evaluation.Event != "pull_request_review" && evaluation.Event != "pull_request_review_comment" && evaluation.Event != "workflow_dispatch" && evaluation.Event != "schedule") {
 			return compatibility.ProcessingReportV3{}, false
 		}
 		seen[evaluation.Event] = true

--- a/internal/cli/validate_batch_test.go
+++ b/internal/cli/validate_batch_test.go
@@ -38,8 +38,9 @@ func TestValidateBatchWritesAndResumesAtomicReports(t *testing.T) {
 		{ID: "one", Repository: "owner/one", Path: ".github/workflows/ci.yml", Hash: strings.Repeat("1", 64), Source: filepath.Join(root, "one.yml")},
 		{ID: "two", Repository: "owner/two", Path: ".github/workflows/test.yml", Hash: strings.Repeat("2", 64), Source: filepath.Join(root, "two.yml")},
 	}
-	workflow := []byte("on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo ok\n")
-	for _, record := range records {
+	events := []string{"pull_request_review", "pull_request_review_comment"}
+	for i, record := range records {
+		workflow := []byte("on: [push, " + events[i] + "]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo ok\n")
 		if err := os.WriteFile(record.Source, workflow, 0o600); err != nil {
 			t.Fatal(err)
 		}
@@ -62,6 +63,13 @@ func TestValidateBatchWritesAndResumesAtomicReports(t *testing.T) {
 		contents, err := os.ReadFile(path)
 		if err != nil || json.Unmarshal(contents, &report) != nil || report.Schema != compatibility.ProcessingSchemaV3 || report.Profile != hostedProfile {
 			t.Fatalf("report %q is invalid: %v\n%s", path, err, contents)
+		}
+		wantEvent := events[0]
+		if report.Workflow == records[1].Source {
+			wantEvent = events[1]
+		}
+		if len(report.Evaluations) != 2 || report.Evaluations[0].Event != "push" || report.Evaluations[1].Event != wantEvent || report.Evaluations[1].Report.Result != "admitted" {
+			t.Fatalf("report %q lost review evaluation: %#v", path, report.Evaluations)
 		}
 	}
 

--- a/internal/compatibility/report_test.go
+++ b/internal/compatibility/report_test.go
@@ -131,6 +131,9 @@ func TestProcessingReportV3PreservesPerEventOutcomes(t *testing.T) {
 		EventEvaluation{Event: "pull_request", Source: "generated", Report: pullRequest},
 		EventEvaluation{Event: "issues", Source: "generated", Report: push},
 	)
+	for _, event := range []string{"merge_group", "release", "issue_comment", "pull_request_review", "pull_request_review_comment", "workflow_dispatch", "schedule"} {
+		report.Evaluations = append(report.Evaluations, EventEvaluation{Event: event, Source: "generated", Report: push})
+	}
 
 	var encoded bytes.Buffer
 	if err := WriteProcessingV3(&encoded, "json", report); err != nil {
@@ -140,7 +143,7 @@ func TestProcessingReportV3PreservesPerEventOutcomes(t *testing.T) {
 	if err := json.Unmarshal(encoded.Bytes(), &decoded); err != nil {
 		t.Fatal(err)
 	}
-	if decoded.Schema != ProcessingSchemaV3 || decoded.Result != "incompatible" || decoded.Status != Failed || len(decoded.Evaluations) != 3 || decoded.Evaluations[0].Report.Result != "admitted" || decoded.Evaluations[1].Report.Result != "incompatible" {
+	if decoded.Schema != ProcessingSchemaV3 || decoded.Result != "incompatible" || decoded.Status != Failed || len(decoded.Evaluations) != 10 || decoded.Evaluations[0].Report.Result != "admitted" || decoded.Evaluations[1].Report.Result != "incompatible" {
 		t.Fatalf("decoded report = %#v", decoded)
 	}
 	v2Source, err := os.ReadFile(filepath.Join("..", "..", "schemas", "processing-report-v2.schema.json"))

--- a/internal/workflow/parse.go
+++ b/internal/workflow/parse.go
@@ -216,7 +216,7 @@ func Parse(path string, source []byte) (*Workflow, error) {
 	return owned, nil
 }
 
-// GitHub treats empty issues/issue_comment types as omitted. The pinned
+// GitHub treats empty issue and review event types as omitted. The pinned
 // actionlint parser already returns nil Types for these sequences, but also
 // reports an error. Accept only that diagnostic at each verified empty sequence,
 // leaving the source and all other diagnostics (including alias errors) intact.
@@ -226,7 +226,7 @@ func emptyIssueTypesDiagnostics(document *yaml.Node) []expectedActionlintDiagnos
 	}
 	on := mappingValue(document.Content[0], "on")
 	var diagnostics []expectedActionlintDiagnostic
-	for _, event := range []string{"issues", "issue_comment"} {
+	for _, event := range []string{"issues", "issue_comment", "pull_request_review", "pull_request_review_comment"} {
 		types := mappingValue(mappingValue(on, event), "types")
 		if types != nil && types.Kind == yaml.SequenceNode && len(types.Content) == 0 {
 			diagnostics = append(diagnostics, expectedActionlintDiagnostic{

--- a/schemas/processing-report-v3.schema.json
+++ b/schemas/processing-report-v3.schema.json
@@ -14,13 +14,13 @@
     "validation": {"$ref": "processing-report-v2.schema.json"},
     "evaluations": {
       "type": "array",
-      "maxItems": 7,
+      "maxItems": 10,
       "items": {
         "type": "object",
         "additionalProperties": false,
         "required": ["event", "event_source", "report"],
         "properties": {
-          "event": {"enum": ["push", "pull_request", "merge_group", "release", "issues", "workflow_dispatch", "schedule"]},
+          "event": {"enum": ["push", "pull_request", "merge_group", "release", "issues", "issue_comment", "pull_request_review", "pull_request_review_comment", "workflow_dispatch", "schedule"]},
           "event_source": {"const": "generated"},
           "report": {"$ref": "processing-report-v2.schema.json"}
         }


### PR DESCRIPTION
## Why

`on: pull_request_review` and `on: pull_request_review_comment` cannot run through GitHub Actions Pipeline Triggers in v0.59.0, even if the backend accepts the webhook. They are common gaps in the [never-runs corpus report](https://slopcannon.tail952194.ts.net/simone/gha-plugin-what-to-build-next/#never-runs).

## What

Support review `submitted`/`edited`/`dismissed` and inline-comment `created`/`edited`/`deleted`, all by default, with exact `types` matching and scalar/array/map declarations. Approval remains a job/step condition such as `if: github.event.review.state == 'approved'`; branch/path/tag filters remain unsupported for these events.

Server-selected, selector-free/keyless imports validate the original webhook against the build's PR number, activity, head/base branches, repositories, and immutable workflow identity. Workflow and checkout use the PR head, while the event ref remains `refs/pull/N/merge`; neither synthetic merge nor reviewed `commit_id` supplies checkout authority. Forks are rejected, and companion backend builds retain the PR `contents:read` token ceiling even after approval.

Release and select this runtime **before backend review-event enablement/use**. Existing repository hooks need manual subscription upgrades; there is no backfill. Rebuilds without the original linked webhook fail explicitly rather than synthesizing review payloads. No durable-provenance or general path-filter changes are included.

Local signed webhook → receipt → Build → keyless importer → generated-job execution passed for approved review, inline comment, and changes-requested review, including conditional output. GitHub API responses **and checkout were simulated fixtures**; the local server, agent, artifacts, and runtime were real. This is not live GitHub/production or native-checkout proof; hosted user isolation was not exercised (`experimental-runner-user: false`).

[Companion backend PR](https://github.com/buildkite/buildkite/pull/33994) · [Implementation and verification thread](https://ampcode.com/threads/T-4178546a-36ab-40cb-bff8-ac7a87edba58).
