### PR TITLE
PB-3264: Keep a needs-derived matrix from hiding repository variables or blocking upload

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -144,9 +144,13 @@ with a failing top-level step. The step:
 - limits the check summary to 65,535 bytes
 - exits with status 1
 
-Other workflows continue compiling. Missing or untracked configured paths are
-omitted before the transaction. Invalid path states, parse, event-input,
-admission, artifact, and upload failures still abort the complete transaction.
+Other workflows continue compiling. A matrix derived from `needs` outputs,
+including one inside a called reusable workflow, fails only its own workflow
+after the event and repository variables resolve, so it never reports `vars`
+values as unavailable or blocks other workflows. Missing or untracked
+configured paths are omitted before the transaction. Invalid path states,
+parse, event-input, admission, artifact, and upload failures still abort the
+complete transaction.
 Upload never publishes a partial pipeline.
 
 If a workflow has both a compiler error and a skip reason, the compiler error

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -633,7 +632,12 @@ func TestRunValidateAndCompile(t *testing.T) {
 	})
 }
 
-func TestCommandsKeepValidatedRuntimeMatrixIncompatibleWithoutUpload(t *testing.T) {
+// TestCommandsKeepValidatedRuntimeMatrixIncompatible proves a needs-derived
+// matrix stays an ordinary incompatibility: validate and compile exit 1 with
+// the diagnostic and never emit a runtime-matrix artifact, and upload reports
+// the workflow as a failed check inside the uploaded pipeline instead of
+// aborting before the event and repository variables are known.
+func TestCommandsKeepValidatedRuntimeMatrixIncompatible(t *testing.T) {
 	workflow := filepath.Join(t.TempDir(), "dynamic.yml")
 	if err := os.WriteFile(workflow, []byte(`on: push
 jobs:
@@ -665,13 +669,8 @@ jobs:
 		{name: "validate", args: []string{"validate", "--format", "json", workflow}},
 		{name: "compile pipeline", args: []string{"compile", "--event-path", eventPath, workflow}},
 		{name: "compile IR", args: []string{"compile", "--format", "ir-json", "--event-path", eventPath, workflow}},
-		{name: "upload", args: []string{"upload", "--event-path", eventPath, workflow}},
-		{name: "upload before event metadata", args: []string{"upload", workflow}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			if test.args[0] == "upload" {
-				requireImporterHost(t)
-			}
 			var stdout, stderr bytes.Buffer
 			runner := &cliCaptureRunner{}
 			if code := run(test.args, &stdout, &stderr, "dev", runner); code != 1 {
@@ -690,254 +689,33 @@ jobs:
 		})
 	}
 
-	invalidWorkflow := filepath.Join(t.TempDir(), "invalid-dynamic.yml")
-	if err := os.WriteFile(invalidWorkflow, []byte(`on: push
-jobs:
-  producer:
-    runs-on: ubuntu-latest
-    steps:
-      - run: true
-  generated:
-    needs: producer
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include: ${{ fromJSON(needs.producer.outputs.missing) }}
-    steps:
-      - run: true
-`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	t.Run("invalid boundary before event metadata", func(t *testing.T) {
+	t.Run("upload", func(t *testing.T) {
 		requireImporterHost(t)
 		var stdout, stderr bytes.Buffer
-		runner := &cliCaptureRunner{}
-		if code := run([]string{"upload", invalidWorkflow}, &stdout, &stderr, "dev", runner); code != 1 {
+		runner := &cliCaptureRunner{webhookErr: errors.New("metadata must not be read with --event-path")}
+		if code := run([]string{"upload", "--event-path", eventPath, workflow}, &stdout, &stderr, "dev", runner); code != 0 {
 			t.Fatalf("run() code = %d, stdout = %q, stderr = %q", code, stdout.String(), stderr.String())
 		}
-		if len(runner.commands) != 0 {
-			t.Fatalf("invalid runtime matrix boundary made Buildkite calls: %#v", runner.commands)
+		output := stdout.String() + stderr.String()
+		for _, want := range []string{"Result: incompatible", "[E_MATRIX_INVALID]", "Uploaded 0 jobs from 1 workflows"} {
+			if !strings.Contains(output, want) {
+				t.Fatalf("upload output missing %q:\n%s", want, output)
+			}
 		}
-		if !strings.Contains(stderr.String(), "Result: incompatible") || !strings.Contains(stderr.String(), "[E_MATRIX_INVALID]") {
-			t.Fatalf("upload stderr = %q", stderr.String())
+		if strings.Contains(output, "runtime_matrices") || strings.Contains(output, compiler.RuntimeMatrixSchemaV1) {
+			t.Fatalf("upload emitted a runtime matrix artifact: %q", output)
 		}
-	})
-
-	repository := t.TempDir()
-	workflowDirectory := filepath.Join(repository, ".github", "workflows")
-	if err := os.MkdirAll(workflowDirectory, 0o700); err != nil {
-		t.Fatal(err)
-	}
-	graphFailureWorkflow := filepath.Join(workflowDirectory, "dynamic-with-graph-failure.yml")
-	if err := os.WriteFile(graphFailureWorkflow, []byte(`on: push
-jobs:
-  producer:
-    runs-on: ubuntu-latest
-    outputs:
-      include: ${{ steps.matrix.outputs.include }}
-    steps:
-      - id: matrix
-        run: true
-  generated:
-    needs: producer
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include: ${{ fromJSON(needs.producer.outputs.include) }}
-    steps:
-      - run: true
-  missing-reusable:
-    uses: ./.github/workflows/missing.yml
-`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	t.Run("exact boundary survives an earlier graph failure", func(t *testing.T) {
-		requireImporterHost(t)
-		var stdout, stderr bytes.Buffer
-		runner := &cliCaptureRunner{}
-		if code := run([]string{"upload", graphFailureWorkflow}, &stdout, &stderr, "dev", runner); code != 1 {
-			t.Fatalf("run() code = %d, stdout = %q, stderr = %q", code, stdout.String(), stderr.String())
+		var pipelineUploads int
+		for _, command := range runner.commands {
+			if slices.Equal(command.args, []string{"pipeline", "upload", "--no-interpolation"}) {
+				pipelineUploads++
+				if !strings.Contains(string(command.stdin), `title: "Workflow could not be run"`) {
+					t.Fatalf("uploaded pipeline does not carry the failed workflow check:\n%s", command.stdin)
+				}
+			}
 		}
-		if len(runner.commands) != 0 {
-			t.Fatalf("runtime matrix boundary with graph failure made Buildkite calls: %#v", runner.commands)
-		}
-		if !strings.Contains(stderr.String(), "Result: incompatible") || !strings.Contains(stderr.String(), "[E_GRAPH_INVALID]") {
-			t.Fatalf("upload stderr = %q", stderr.String())
-		}
-	})
-
-	reusableBoundaryWorkflow := filepath.Join(workflowDirectory, "reusable-boundary-with-graph-failure.yml")
-	if err := os.WriteFile(reusableBoundaryWorkflow, []byte(`on: push
-jobs:
-  a-invalid-reusable:
-    uses: ./.github/workflows/not-callable-order.yml
-  z-runtime-matrix:
-    uses: ./.github/workflows/runtime-matrix.yml
-`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(workflowDirectory, "not-callable-order.yml"), []byte(`on: push
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - run: true
-`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(workflowDirectory, "runtime-matrix.yml"), []byte(`on: workflow_call
-jobs:
-  producer:
-    runs-on: ubuntu-latest
-    outputs:
-      include: ${{ steps.matrix.outputs.include }}
-    steps:
-      - id: matrix
-        run: true
-  generated:
-    needs: producer
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include: ${{ fromJSON(needs.producer.outputs.include) }}
-    steps:
-      - run: true
-`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	t.Run("reusable boundary discovery does not depend on fail-fast order", func(t *testing.T) {
-		requireImporterHost(t)
-		var stdout, stderr bytes.Buffer
-		runner := &cliCaptureRunner{}
-		if code := run([]string{"upload", reusableBoundaryWorkflow}, &stdout, &stderr, "dev", runner); code != 1 {
-			t.Fatalf("run() code = %d, stdout = %q, stderr = %q", code, stdout.String(), stderr.String())
-		}
-		if len(runner.commands) != 0 {
-			t.Fatalf("reusable runtime matrix boundary with graph failure made Buildkite calls: %#v", runner.commands)
-		}
-		if !strings.Contains(stderr.String(), "Result: incompatible") || !strings.Contains(stderr.String(), "[E_GRAPH_INVALID]") {
-			t.Fatalf("upload stderr = %q", stderr.String())
-		}
-	})
-
-	sharedBoundaryWorkflow := filepath.Join(workflowDirectory, "shared-boundary-with-depth-failure.yml")
-	if err := os.WriteFile(sharedBoundaryWorkflow, []byte(`on: push
-jobs:
-  a-deep:
-    uses: ./.github/workflows/deep-1.yml
-  z-shared:
-    uses: ./.github/workflows/shared.yml
-`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	for i, next := range []string{"deep-2.yml", "deep-3.yml", "shared.yml"} {
-		name := fmt.Sprintf("deep-%d.yml", i+1)
-		if err := os.WriteFile(filepath.Join(workflowDirectory, name), fmt.Appendf(nil, `on: workflow_call
-jobs:
-  delegated:
-    uses: ./.github/workflows/%s
-`, next), 0o600); err != nil {
-			t.Fatal(err)
-		}
-	}
-	if err := os.WriteFile(filepath.Join(workflowDirectory, "shared.yml"), []byte(`on: workflow_call
-jobs:
-  delegated:
-    uses: ./.github/workflows/runtime-matrix.yml
-`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	t.Run("shared boundary is rescanned when reached at a shallower depth", func(t *testing.T) {
-		requireImporterHost(t)
-		var stdout, stderr bytes.Buffer
-		runner := &cliCaptureRunner{}
-		if code := run([]string{"upload", sharedBoundaryWorkflow}, &stdout, &stderr, "dev", runner); code != 1 {
-			t.Fatalf("run() code = %d, stdout = %q, stderr = %q", code, stdout.String(), stderr.String())
-		}
-		if len(runner.commands) != 0 {
-			t.Fatalf("shared runtime matrix boundary with graph failure made Buildkite calls: %#v", runner.commands)
-		}
-		if !strings.Contains(stderr.String(), "Result: incompatible") || !strings.Contains(stderr.String(), "[E_GRAPH_INVALID]") || !strings.Contains(stderr.String(), "job a-deep: failed") {
-			t.Fatalf("upload stderr = %q", stderr.String())
-		}
-	})
-
-	depthBoundaryWorkflow := filepath.Join(workflowDirectory, "depth-boundary-with-graph-failure.yml")
-	if err := os.WriteFile(depthBoundaryWorkflow, []byte(`on: push
-jobs:
-  a-invalid-reusable:
-    uses: ./.github/workflows/not-callable-order.yml
-  z-deep:
-    uses: ./.github/workflows/depth-1.yml
-`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	for i, next := range []string{"depth-2.yml", "depth-3.yml", "depth-4.yml", "runtime-matrix.yml"} {
-		name := fmt.Sprintf("depth-%d.yml", i+1)
-		if err := os.WriteFile(filepath.Join(workflowDirectory, name), fmt.Appendf(nil, `on: workflow_call
-jobs:
-  delegated:
-    uses: ./.github/workflows/%s
-`, next), 0o600); err != nil {
-			t.Fatal(err)
-		}
-	}
-	t.Run("depth-limited reusable discovery stops before event metadata", func(t *testing.T) {
-		requireImporterHost(t)
-		var stdout, stderr bytes.Buffer
-		runner := &cliCaptureRunner{}
-		if code := run([]string{"upload", depthBoundaryWorkflow}, &stdout, &stderr, "dev", runner); code != 1 {
-			t.Fatalf("run() code = %d, stdout = %q, stderr = %q", code, stdout.String(), stderr.String())
-		}
-		if len(runner.commands) != 0 {
-			t.Fatalf("depth-limited runtime matrix discovery made Buildkite calls: %#v", runner.commands)
-		}
-		if !strings.Contains(stderr.String(), "Result: incompatible") || !strings.Contains(stderr.String(), "[E_GRAPH_INVALID]") || !strings.Contains(stderr.String(), "job a-invalid-reusable: failed") {
-			t.Fatalf("upload stderr = %q", stderr.String())
-		}
-	})
-
-	malformedBoundaryWorkflow := filepath.Join(workflowDirectory, "malformed-boundary-with-graph-failure.yml")
-	if err := os.WriteFile(malformedBoundaryWorkflow, []byte(`on: push
-jobs:
-  a-not-callable:
-    uses: ./.github/workflows/not-callable.yml
-  z-malformed:
-    uses: ./.github/workflows/malformed-runtime-matrix.yml
-`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(workflowDirectory, "not-callable.yml"), []byte(`on: push
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - run: true
-`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(workflowDirectory, "malformed-runtime-matrix.yml"), []byte(`on: workflow_call
-jobs:
-  generated:
-    strategy:
-      matrix:
-        include: ${{ fromJSON(needs.producer.outputs.include) }}
-    invalid: [
-`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	t.Run("incomplete reusable discovery stops before event metadata", func(t *testing.T) {
-		requireImporterHost(t)
-		var stdout, stderr bytes.Buffer
-		runner := &cliCaptureRunner{}
-		if code := run([]string{"upload", malformedBoundaryWorkflow}, &stdout, &stderr, "dev", runner); code != 1 {
-			t.Fatalf("run() code = %d, stdout = %q, stderr = %q", code, stdout.String(), stderr.String())
-		}
-		if len(runner.commands) != 0 {
-			t.Fatalf("incomplete runtime matrix discovery made Buildkite calls: %#v", runner.commands)
-		}
-		if !strings.Contains(stderr.String(), "Result: incompatible") || !strings.Contains(stderr.String(), "[E_GRAPH_INVALID]") || !strings.Contains(stderr.String(), "job a-not-callable: failed") {
-			t.Fatalf("upload stderr = %q", stderr.String())
+		if pipelineUploads != 1 {
+			t.Fatalf("pipeline uploads = %d, want 1: %#v", pipelineUploads, runner.commands)
 		}
 	})
 }

--- a/internal/cli/upload.go
+++ b/internal/cli/upload.go
@@ -183,16 +183,15 @@ func uploadParsedContext(ctx context.Context, uploadArguments parsedUploadArgs, 
 		if input.ReusableOnly {
 			continue
 		}
+		// This event-independent pass only scans the workflow graph, including
+		// reusable callees, for variable references. It has no event payload
+		// and no variable source, so its findings are placeholder artifacts;
+		// the event validation below reports every workflow with the real
+		// event and resolved variables.
 		validationOptions := hostedOptions("", uploadArguments.runnerTargets, nil)
 		validationOptions.RepositorySource = repositorySource
-		validation, validationErr := compiler.ValidateWithOptionsContext(ctx, input.Path, input.Source, validationOptions)
+		validation, _ := compiler.ValidateWithOptionsContext(ctx, input.Path, input.Source, validationOptions)
 		workflows[i].ReferencesVars = validation.ReferencesVars
-		if validation.RuntimeMatrixBoundary {
-			report := compatibility.InitialProcessingReport(input.Path, hostedProfile, false, validation, validationErr)
-			report.Result = "incompatible"
-			_ = out.write(ctx, report)
-			return 1
-		}
 	}
 	if eventPath == "" {
 		eventSource, eventOrigin, eventLoadErr = loadEffectiveEventSource(ctx, eventPath, agent)

--- a/internal/cli/variables_test.go
+++ b/internal/cli/variables_test.go
@@ -295,6 +295,82 @@ func TestRunUploadTreatsAbsentVariableScopesAsEmpty(t *testing.T) {
 	}
 }
 
+// TestRunUploadResolvesVariablesWhenAnotherWorkflowHasRuntimeMatrix proves a
+// workflow whose reusable callee derives its matrix from a job output does not
+// stop the upload before variables are resolved. The plain workflow's
+// `vars.*` runner fallback resolves through the agent and uploads, while the
+// runtime-matrix workflow becomes a failed check with the matrix diagnostic
+// instead of a spurious "unavailable value vars.*" error for the whole upload.
+func TestRunUploadResolvesVariablesWhenAnotherWorkflowHasRuntimeMatrix(t *testing.T) {
+	requireImporterHost(t)
+	variables, variableRequests := agentEmptyVariablesHandler(t, http.StatusOK)
+	agent, _ := agentStub(t, "job-secret", http.StatusOK, variables)
+	setAgentResolutionEnvironment(t, agent.URL)
+	t.Setenv("BUILDKITE", "true")
+	t.Setenv("BUILDKITE_STEP_KEY", "variables-runtime-matrix-importer")
+	eventPath := pushEventPath(t)
+	workflows := writeUploadWorkflows(t, map[string]string{
+		"build.yml": `on: push
+jobs:
+  lint:
+    runs-on: ${{ vars.CI_FAILOVER_LINUX || 'ubuntu-latest' }}
+    steps:
+      - run: true
+  build:
+    uses: ./.github/workflows/runtime-matrix.yml
+`,
+		"plain.yml": undefinedVariablesWorkflow,
+	})
+	if err := os.WriteFile(filepath.Join(".github", "workflows", "runtime-matrix.yml"), []byte(`on: workflow_call
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - id: matrix
+        run: echo 'matrix=[{"runner":"ubuntu-latest"}]' >> "$GITHUB_OUTPUT"
+  build:
+    needs: plan
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    steps:
+      - run: true
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := &cliCaptureRunner{webhookErr: errors.New("metadata must not be read with --event-path")}
+	var stdout, stderr bytes.Buffer
+	if code := run(append([]string{"upload", "--event-path", eventPath}, workflows...), &stdout, &stderr, "dev", runner); code != 0 {
+		t.Fatalf("run() code = %d, stderr = %q", code, stderr.String())
+	}
+	if *variableRequests != 1 {
+		t.Fatalf("variables requests = %d, want 1", *variableRequests)
+	}
+	output := stdout.String() + stderr.String()
+	if strings.Contains(output, "vars.") {
+		t.Fatalf("upload reported a variables error although variables resolved:\n%s", output)
+	}
+	for _, want := range []string{"[E_MATRIX_INVALID]", "runtime-matrix.yml", "Uploaded 1 jobs from 2 workflows"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("upload output missing %q:\n%s", want, output)
+		}
+	}
+	plans := uploadedPlans(t, runner)
+	if len(plans) != 1 || len(plans["test"]) != 1 {
+		t.Fatalf("uploaded plans by job = %v, want only the plain workflow", plans)
+	}
+	pipeline := string(runner.commands[len(runner.commands)-1].stdin)
+	for _, want := range []string{defaultNobleRunnerImage, `label: ":github: workflow · .github/workflows/build.yml"`, `title: "Workflow could not be run"`} {
+		if !strings.Contains(pipeline, want) {
+			t.Fatalf("pipeline missing %q:\n%s", want, pipeline)
+		}
+	}
+}
+
 // TestRunUploadSurfacesVariableResolutionRateLimit proves a 429 fails every
 // workflow that reads vars with the backend's Retry-After delay, after one
 // request, while a workflow without vars references still uploads.

--- a/internal/compiler/runtime_matrix_boundary_test.go
+++ b/internal/compiler/runtime_matrix_boundary_test.go
@@ -1,0 +1,152 @@
+package compiler
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestValidateReportsRuntimeMatrixBoundaryDespiteGraphFailures proves the
+// event-independent scan still finds a needs-derived matrix when an earlier
+// job in the same graph fails, whatever the fail-fast order, the reusable
+// depth, or how a shared reusable workflow is reached. Callers read the flag
+// from the report even when validation returns an error.
+func TestValidateReportsRuntimeMatrixBoundaryDespiteGraphFailures(t *testing.T) {
+	repository := t.TempDir()
+	runtimeMatrix := `on: workflow_call
+jobs:
+  producer:
+    runs-on: ubuntu-latest
+    outputs:
+      include: ${{ steps.matrix.outputs.include }}
+    steps:
+      - id: matrix
+        run: true
+  generated:
+    needs: producer
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include: ${{ fromJSON(needs.producer.outputs.include) }}
+    steps:
+      - run: true
+`
+	writeWorkflow(t, repository, "runtime-matrix.yml", runtimeMatrix)
+	writeWorkflow(t, repository, "not-callable.yml", `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+`)
+	writeWorkflow(t, repository, "shared.yml", `on: workflow_call
+jobs:
+  delegated:
+    uses: ./.github/workflows/runtime-matrix.yml
+`)
+	for i, next := range []string{"deep-2.yml", "deep-3.yml", "shared.yml"} {
+		writeWorkflow(t, repository, fmt.Sprintf("deep-%d.yml", i+1), fmt.Sprintf(`on: workflow_call
+jobs:
+  delegated:
+    uses: ./.github/workflows/%s
+`, next))
+	}
+	for i, next := range []string{"depth-2.yml", "depth-3.yml", "depth-4.yml", "runtime-matrix.yml"} {
+		writeWorkflow(t, repository, fmt.Sprintf("depth-%d.yml", i+1), fmt.Sprintf(`on: workflow_call
+jobs:
+  delegated:
+    uses: ./.github/workflows/%s
+`, next))
+	}
+	writeWorkflow(t, repository, "malformed-runtime-matrix.yml", `on: workflow_call
+jobs:
+  generated:
+    strategy:
+      matrix:
+        include: ${{ fromJSON(needs.producer.outputs.include) }}
+    invalid: [
+`)
+
+	for name, test := range map[string]struct {
+		caller      string
+		wantFailure string
+	}{
+		"exact boundary survives an earlier graph failure": {
+			caller: `on: push
+jobs:
+  producer:
+    runs-on: ubuntu-latest
+    outputs:
+      include: ${{ steps.matrix.outputs.include }}
+    steps:
+      - id: matrix
+        run: true
+  generated:
+    needs: producer
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include: ${{ fromJSON(needs.producer.outputs.include) }}
+    steps:
+      - run: true
+  missing-reusable:
+    uses: ./.github/workflows/missing.yml
+`,
+			wantFailure: "missing-reusable",
+		},
+		"reusable boundary discovery does not depend on fail-fast order": {
+			caller: `on: push
+jobs:
+  a-invalid-reusable:
+    uses: ./.github/workflows/not-callable.yml
+  z-runtime-matrix:
+    uses: ./.github/workflows/runtime-matrix.yml
+`,
+			wantFailure: "a-invalid-reusable",
+		},
+		"shared boundary is rescanned when reached at a shallower depth": {
+			caller: `on: push
+jobs:
+  a-deep:
+    uses: ./.github/workflows/deep-1.yml
+  z-shared:
+    uses: ./.github/workflows/shared.yml
+`,
+			wantFailure: "a-deep",
+		},
+		"depth-limited reusable discovery still reports the boundary": {
+			caller: `on: push
+jobs:
+  a-invalid-reusable:
+    uses: ./.github/workflows/not-callable.yml
+  z-deep:
+    uses: ./.github/workflows/depth-1.yml
+`,
+			wantFailure: "a-invalid-reusable",
+		},
+		"incomplete reusable discovery still reports the boundary": {
+			caller: `on: push
+jobs:
+  a-not-callable:
+    uses: ./.github/workflows/not-callable.yml
+  z-malformed:
+    uses: ./.github/workflows/malformed-runtime-matrix.yml
+`,
+			wantFailure: "a-not-callable",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			callerPath := writeWorkflow(t, repository, strings.ReplaceAll(name, " ", "-")+".yml", test.caller)
+			report, err := Validate(callerPath, readFile(t, callerPath))
+			if err == nil {
+				t.Fatalf("Validate() error = nil, want a graph failure; report = %#v", report)
+			}
+			if !strings.Contains(err.Error(), fmt.Sprintf("job %q", test.wantFailure)) {
+				t.Fatalf("Validate() error = %v, want a graph failure for job %q", err, test.wantFailure)
+			}
+			if !report.RuntimeMatrixBoundary {
+				t.Fatalf("RuntimeMatrixBoundary = false after graph failure %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

After #458 (v0.60.0), buildkite-playground/deepseek-harness still failed every `upload` with:

```
[E_EXPRESSION_INVALID] job "lint": runs-on expression cannot be resolved at compile time:
compile-time expression references unavailable value "vars.dsh_ci_failover_linux"
```

The repository's `ci.yml` calls `build-exe-for-python-sdk.yml`, whose `build` job uses `include: ${{ fromJSON(needs.plan.outputs.matrix) }}`. `upload` scans the workflow graph once before it reads the event or fetches repository variables. When that scan found the needs-derived matrix, it published the scan's own report and exited 1. That scan has no variable source, so every `vars.*` reference in the workflow was reported as unavailable, the variable resolution added in #458 never ran, and no other workflow uploaded either.

## What

The scan now only records whether the workflow references `vars`. The event-scoped path then resolves variables and treats the needs-derived matrix like any other compilation failure: that workflow becomes a failed `Workflow could not be run` check inside the uploaded pipeline, and the other workflows upload.

Before (upload exits 1, nothing uploaded):

```
x [E_MATRIX_INVALID] matrix could not be expanded or validated (./.github/workflows/runtime-matrix.yml:15:18)
x [E_EXPRESSION_INVALID] job "lint": runs-on expression cannot be resolved at compile time:
  compile-time expression references unavailable value "vars.ci_failover_linux" (./.github/workflows/build.yml:4:14)
```

After (one variables request, upload exits 0):

```
x [E_MATRIX_INVALID] matrix could not be expanded or validated (./.github/workflows/runtime-matrix.yml:15:18)
Uploaded 1 jobs from 2 workflows
```

`validate` and `compile` still exit 1 for the runtime matrix. The boundary-detection tests that asserted the old early exit move to the compiler, where `Report.RuntimeMatrixBoundary` is computed.

Fixes PB-3264. Related: PB-3246, PB-3249, PB-3262.
