### PR TITLE
Run JavaScript actions when hosted mise overrides its data directory

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -33,7 +33,8 @@ Jobs with JavaScript actions need `mise`. The runtime checks
 Shell-only, native-adapter, and Docker-only jobs do not need it.
 
 When a managed cache is configured, the runtime installs Node there rather
-than reusing system-wide mise installations.
+than reusing system-wide mise installations. The install directory remains
+pinned even when an agent's mise wrapper overrides `MISE_DATA_DIR`.
 
 Managed Node binaries require glibc 2.28 or newer. The Go CLI has no glibc requirement.
 

--- a/internal/runtime/node_runtime.go
+++ b/internal/runtime/node_runtime.go
@@ -97,8 +97,10 @@ func (r Runner) miseEnv() map[string]string {
 	}
 	// Newer mise versions reuse system installs even with --no-config. Keep
 	// that lookup inside our cache so installation and validation share a root.
+	// Pin installs separately because agent wrappers can override MISE_DATA_DIR.
 	return map[string]string{
 		"MISE_DATA_DIR":        r.MiseDataDir,
+		"MISE_INSTALLS_DIR":    filepath.Join(r.MiseDataDir, "installs"),
 		"MISE_SYSTEM_DATA_DIR": r.MiseDataDir,
 	}
 }

--- a/internal/runtime/node_runtime_test.go
+++ b/internal/runtime/node_runtime_test.go
@@ -280,20 +280,33 @@ func TestManagedMiseCacheRefusesSymlinkedRemoval(t *testing.T) {
 }
 
 func TestManagedMiseNodeDoesNotReuseSystemInstallation(t *testing.T) {
-	root := canonicalTempDir(t)
-	dataDir := filepath.Join(root, "cache")
-	systemDir := filepath.Join(root, "system")
-	nodeBytes := fmt.Appendf(nil, "#!/bin/sh\nprintf 'v%s\\n'\n", Node24Version)
-	systemNode := filepath.Join(systemDir, "installs", "node", Node24Version, "bin", "node")
-	writeFixtureFile(t, systemDir, filepath.Join("installs", "node", Node24Version, "bin", "node"), string(nodeBytes))
-	if err := os.Mkdir(dataDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	// Model mise's automatic system fallback when the user installation is absent.
-	mise := filepath.Join(root, "mise")
-	script := fmt.Sprintf(`#!/bin/sh
+	for _, test := range []struct {
+		name    string
+		wrapper bool
+	}{
+		{name: "system fallback"},
+		{name: "wrapper overrides data directory", wrapper: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := canonicalTempDir(t)
+			dataDir := filepath.Join(root, "cache")
+			systemDir := filepath.Join(root, "system")
+			nodeBytes := fmt.Appendf(nil, "#!/bin/sh\nprintf 'v%s\\n'\n", Node24Version)
+			systemNode := filepath.Join(systemDir, "installs", "node", Node24Version, "bin", "node")
+			writeFixtureFile(t, systemDir, filepath.Join("installs", "node", Node24Version, "bin", "node"), string(nodeBytes))
+			if err := os.Mkdir(dataDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			wrapper := ""
+			if test.wrapper {
+				// Hosted macOS wraps mise with an unconditional data directory override.
+				wrapper = fmt.Sprintf("export MISE_DATA_DIR=%q\n", systemDir)
+			}
+			// Model mise's automatic system fallback when the user installation is absent.
+			mise := filepath.Join(root, "mise")
+			script := fmt.Sprintf(`#!/bin/sh
 set -eu
-installation="$MISE_DATA_DIR/installs/node/%s"
+%sinstallation="${MISE_INSTALLS_DIR:-$MISE_DATA_DIR/installs}/node/%s"
 system="${MISE_SYSTEM_DATA_DIR:-%s}/installs/node/%s"
 if [ ! -d "$installation" ] && [ -d "$system" ]; then
   installation="$system"
@@ -309,20 +322,23 @@ case "$2" in
   where) printf '%%s\n' "$installation" ;;
   *) exit 9 ;;
 esac
-`, Node24Version, systemDir, Node24Version, systemNode)
-	if err := os.WriteFile(mise, []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("MISE_SYSTEM_DATA_DIR", systemDir)
-	digest := sha256.Sum256(nodeBytes)
-	runner := newJobRun(Runner{Mise: mise, MiseDataDir: dataDir, nodeDigests: map[int]string{24: hex.EncodeToString(digest[:])}})
-	got, err := runner.discoverNode(t.Context(), 24, "")
-	want := filepath.Join(dataDir, "installs", "node", Node24Version, "bin", "node")
-	if err != nil || got != want {
-		t.Fatalf("discoverNode() = %q, %v; want managed Node %q", got, err, want)
-	}
-	if got, err := os.ReadFile(systemNode); err != nil || !bytes.Equal(got, nodeBytes) {
-		t.Fatalf("system Node changed: %q, %v", got, err)
+`, wrapper, Node24Version, systemDir, Node24Version, systemNode)
+			if err := os.WriteFile(mise, []byte(script), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("MISE_INSTALLS_DIR", filepath.Join(systemDir, "installs"))
+			t.Setenv("MISE_SYSTEM_DATA_DIR", systemDir)
+			digest := sha256.Sum256(nodeBytes)
+			runner := newJobRun(Runner{Mise: mise, MiseDataDir: dataDir, nodeDigests: map[int]string{24: hex.EncodeToString(digest[:])}})
+			got, err := runner.discoverNode(t.Context(), 24, "")
+			want := filepath.Join(dataDir, "installs", "node", Node24Version, "bin", "node")
+			if err != nil || got != want {
+				t.Fatalf("discoverNode() = %q, %v; want managed Node %q", got, err, want)
+			}
+			if got, err := os.ReadFile(systemNode); err != nil || !bytes.Equal(got, nodeBytes) {
+				t.Fatalf("system Node changed: %q, %v", got, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Why

[Mailcatcher's macOS / Ruby 3.3 job](https://buildkite.com/sj26-new-1/mailcatcher/builds/2/list?sid=01a084ec-71af-4cb5-8160-642606bddcf1&tab=output) still failed with `cached Node 24 failed validation: ... path is outside root` after #461 shipped in v0.60.0. The job's executable SHA-256 exactly matches the published v0.60.0 Darwin binary; it was not running an old release.

A diagnostic on the same hosted `macos-medium` queue found `/opt/mise/bin/mise` is this wrapper:

```sh
#!/bin/zsh --no-rcs --no-globalrcs --errexit
export MISE_DATA_DIR=/opt/mise
exec -a "$(basename ${0:a})" /opt/mise/rust-bin/mise "$@"
```

It overwrites the runtime's managed data directory before calling mise 2026.8.12. Consequently, `mise where core:node@24.18.0` returned `/opt/mise/installs/node/24.18.0`, outside the managed cache. #461 isolated system fallback but did not handle this wrapper.

## What

Pin `MISE_INSTALLS_DIR` directly to the managed cache's `installs` directory for installation and lookup. The wrapper can still set its data directory without redirecting Node. Path containment, digest verification, and refusal to delete outside the cache remain unchanged.

The hosted diagnostic confirmed explicit install-directory isolation returns Node inside `/private/tmp/bkcache/buildkite-gha/mise/darwin-arm64/2026.5.12/installs`, with the expected executable digest. Extend the existing system-install regression to reproduce the wrapper override; it fails with the original error before this fix.
