### PR TITLE
PB-3247: Support runner.environment at runtime

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -10,6 +10,7 @@ buildkite-gha requires Buildkite agent v3.129 or newer.
 The released plugin supports Linux x86-64 and native macOS arm64 importers and
 jobs. It sets the matching `runner.os` and `runner.arch` values. Runner labels
 select a platform; they do not promise GitHub image, toolchain, or Xcode parity.
+It sets `runner.environment` to `self-hosted` on every platform.
 
 Generated Linux jobs use a dedicated `runner` user and need `buildkite-gha`
 v0.13.7 or newer. Use `experimental-runner-user: false` temporarily if an image
@@ -1026,7 +1027,7 @@ Conditions support computed object indexes, numeric array indexes, whole
 | Context | Job `if` | Step `if` |
 | --- | --- | --- |
 | `github.actor`, `github.base_ref`, `github.event_name`, `github.head_ref`, `github.ref`, `github.ref_name`, `github.ref_type`, `github.repository`, `github.repository_owner`, `github.sha`, `github.workflow_ref`, `github.workflow_sha` | ✅ Yes | ✅ Yes |
-| `runner.os`, `runner.arch` | ✅ Yes | ✅ Yes |
+| `runner.os`, `runner.arch`, `runner.environment` | ✅ Yes | ✅ Yes |
 | `runner.temp` | ❌ No | ✅ Yes |
 | `needs.<job>.result`, `needs.<job>.outputs.<name>` | ✅ Yes | ✅ Yes |
 | `matrix.<name>` | ✅ Yes | ✅ Yes |
@@ -1106,6 +1107,10 @@ another function, remain unsupported. These limits do not apply to access
 rooted at `github.event`.
 
 `runner.os` and `runner.arch` resolve to `Linux`/`X64` or `macOS`/`ARM64`.
+`runner.environment` resolves to `self-hosted`. GitHub assigns this value to
+runners registered outside GitHub, including managed providers. Buildkite
+agents are in the same class whether they use hosted agents or your own
+infrastructure.
 After runner setup, step runtime fields and job outputs can also use
 `runner.temp`, which resolves to the canonical temporary directory exposed as
 `RUNNER_TEMP`. Other runner fields and compile-time positions that require
@@ -1642,7 +1647,9 @@ The runtime sets `GITHUB_WORKFLOW` to the workflow's top-level `name`. If the wo
 
 Linux labels use the corresponding Noble or Jammy hosted-toolchains image.
 macOS agents must provide tools used by shell steps. These images do not provide GitHub image parity. The runtime
-sets `RUNNER_OS` and `RUNNER_ARCH` to `Linux`/`X64` or `macOS`/`ARM64`.
+sets `RUNNER_OS` and `RUNNER_ARCH` to `Linux`/`X64` or `macOS`/`ARM64`, and
+`RUNNER_ENVIRONMENT` to `self-hosted`. Workflow and step environment entries
+cannot override these values.
 
 `RUNNER_TOOL_CACHE` is job-private unless the Linux job selects an immutable
 image with `/opt/hostedtoolcache`, which the default and configured

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -1406,6 +1406,50 @@ jobs:
 	}
 }
 
+func TestCompileDefersRunnerEnvironmentToRuntime(t *testing.T) {
+	plans, err := compilePlansForTest(t.Context(), "runner-environment.yml", []byte(`on: push
+jobs:
+  node-compat:
+    runs-on: ubuntu-latest
+    if: runner.environment != ''
+    steps:
+      - if: runner.environment == 'github-hosted'
+        run: echo hosted
+        env:
+          RUNNER_KIND: ${{ runner.environment }}
+      - if: runner.environment == 'self-hosted'
+        run: echo self-hosted
+`), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), defaultOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("plans = %#v", plans)
+	}
+	steps := plans[0].Program.Job.Steps
+	if len(steps) != 2 || steps[0].Condition.Source != "runner.environment == 'github-hosted'" || steps[1].Condition.Source != "runner.environment == 'self-hosted'" {
+		t.Fatalf("step conditions were not preserved for runtime evaluation: %#v", steps)
+	}
+	if got := testBindingSources(steps[0].Env)["RUNNER_KIND"]; got != "${{ runner.environment }}" {
+		t.Fatalf("step env RUNNER_KIND = %q, want the runtime expression preserved", got)
+	}
+	if plans[0].Program.Job.Condition.Source != "runner.environment != ''" {
+		t.Fatalf("job condition = %q", plans[0].Program.Job.Condition.Source)
+	}
+
+	_, err = compilePlansForTest(t.Context(), "runner-name.yml", []byte(`on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - if: runner.name == 'x'
+        run: true
+`), readFile(t, smokePath("events", "push.json")), "0.1.0", "sha256:"+strings.Repeat("a", 64), defaultOptions())
+	if err == nil || !strings.Contains(err.Error(), "runner.environment") {
+		t.Fatalf("Compile() runner.name error = %v, want the supported runner properties listed", err)
+	}
+}
+
 func TestCompileRejectsUnavailableReusableCallConditionContexts(t *testing.T) {
 	for _, contextName := range []string{"matrix.target", "strategy.job-index", "secrets.TOKEN", "env.FLAG", "runner.os", "steps.build.outcome"} {
 		t.Run(contextName, func(t *testing.T) {

--- a/internal/expression/condition.go
+++ b/internal/expression/condition.go
@@ -248,7 +248,7 @@ func validateConditionReference(root string, path []string, scope ConditionScope
 	switch strings.ToLower(root) {
 	case "runner":
 		if len(path) == 1 {
-			if strings.EqualFold(path[0], "os") || strings.EqualFold(path[0], "arch") {
+			if strings.EqualFold(path[0], "os") || strings.EqualFold(path[0], "arch") || strings.EqualFold(path[0], "environment") {
 				return nil
 			}
 			if strings.EqualFold(path[0], "temp") && scope != JobCondition && scope != CallCondition {
@@ -256,9 +256,9 @@ func validateConditionReference(root string, path []string, scope ConditionScope
 			}
 		}
 		if scope == JobCondition {
-			return fmt.Errorf("condition reference %q is unsupported; expected runner.os or runner.arch", reference)
+			return fmt.Errorf("condition reference %q is unsupported; expected runner.os, runner.arch, or runner.environment", reference)
 		}
-		return fmt.Errorf("condition reference %q is unsupported; expected runner.os, runner.arch, or runner.temp", reference)
+		return fmt.Errorf("condition reference %q is unsupported; expected runner.os, runner.arch, runner.environment, or runner.temp", reference)
 	case "github":
 		if len(path) >= 1 && strings.EqualFold(path[0], "event") {
 			return nil

--- a/internal/expression/engine.go
+++ b/internal/expression/engine.go
@@ -819,6 +819,9 @@ func (Engine) Truthy(value any) bool {
 	return githubTruthy(value)
 }
 
+// RunnerEnvironment is the runner.environment value for Buildkite agents.
+const RunnerEnvironment = "self-hosted"
+
 func canonicalAbstractReferences(source map[string]any) map[string]any {
 	result := make(map[string]any, len(source))
 	for name, value := range source {

--- a/internal/expression/engine_test.go
+++ b/internal/expression/engine_test.go
@@ -240,6 +240,28 @@ func TestEngineValidateConditionAttributesEarlySecretReferenceError(t *testing.T
 	}
 }
 
+func TestEngineAnalysisDefersRunnerEnvironmentToRuntime(t *testing.T) {
+	engine := NewEngine()
+	condition, err := engine.Analyze(Site{
+		Source:  "runner.environment == 'github-hosted'",
+		Profile: ProfileStepCondition,
+		Result:  ResultBoolean,
+		Purpose: PurposeExpression,
+	}, AbstractValues{})
+	if err != nil || condition.Value.Known {
+		t.Fatalf("Analyze() condition = %#v, %v; want runtime-dependent", condition, err)
+	}
+	token, err := engine.Analyze(Site{
+		Source:  "${{ runner.environment == 'github-hosted' && github.token || '' }}",
+		Profile: ProfileStepTemplate,
+		Result:  ResultString,
+		Purpose: PurposeWorkflowActionInput,
+	}, AbstractValues{})
+	if err != nil || token.Effects.GitHubToken != GitHubTokenDirect {
+		t.Fatalf("Analyze() token effects = %v, %v; want conservative authority", token.Effects.GitHubToken, err)
+	}
+}
+
 func TestEngineTemplateAnalysisExcludesKnownFalseTokenBranch(t *testing.T) {
 	engine := NewEngine()
 	site := Site{Source: "${{ false && github.token || '' }}", Profile: ProfileStepTemplate, Result: ResultString, Purpose: PurposeWorkflowActionInput}

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -222,6 +222,42 @@ func TestRunnerDirectReferencesWorkAcrossRuntimeEvaluationSurfaces(t *testing.T)
 	}
 }
 
+func TestRunnerEnvironmentIsAvailableOnEveryRuntimeSurface(t *testing.T) {
+	runner := map[string]string{"os": "Linux", "arch": "X64", "environment": "self-hosted"}
+	if got, err := Evaluate("${{ runner.environment }}", Context{Runner: runner}); err != nil || got != "self-hosted" {
+		t.Fatalf("Evaluate() = %q, %v", got, err)
+	}
+	if got, err := EvaluateStep("${{ RUNNER.Environment }}", Context{Runner: runner}); err != nil || got != "self-hosted" {
+		t.Fatalf("EvaluateStep() = %q, %v", got, err)
+	}
+	for _, test := range []struct {
+		condition string
+		want      bool
+	}{
+		{"runner.environment == 'self-hosted'", true},
+		{"runner.environment == 'github-hosted'", false},
+		{"runner.environment != 'github-hosted' && runner.os == 'Linux'", true},
+	} {
+		if got, err := EvaluateCondition(test.condition, ConditionContext{Runner: runner}); err != nil || got != test.want {
+			t.Fatalf("EvaluateCondition(%q) = %v, %v; want %v", test.condition, got, err, test.want)
+		}
+	}
+	for _, scope := range []ConditionScope{JobCondition, StepCondition} {
+		if err := ValidateCondition("runner.environment == 'github-hosted'", scope); err != nil {
+			t.Fatalf("ValidateCondition() scope %v runner.environment = %v", scope, err)
+		}
+	}
+	if err := ValidateCondition("runner.name == 'x'", StepCondition); err == nil || !strings.Contains(err.Error(), "runner.environment") {
+		t.Fatalf("ValidateCondition() runner.name error = %v, want the supported list to name runner.environment", err)
+	}
+	if got, err := EvaluateActionInputDefault("${{ runner.environment == 'github-hosted' && 'hosted' || 'self' }}", Context{Runner: runner}); err != nil || got != "self" {
+		t.Fatalf("EvaluateActionInputDefault() = %q, %v", got, err)
+	}
+	if _, err := Evaluate("${{ runner.environment }}", Context{Runner: map[string]string{"os": "Linux"}}); err == nil {
+		t.Fatal("Evaluate() resolved runner.environment without a runner context value")
+	}
+}
+
 func TestValidateActionInputDefaultSupportsRestrictedCompoundExpressions(t *testing.T) {
 	for _, template := range []string{
 		"${{ github.server_url == 'https://github.com' && github.token || '' }}",

--- a/internal/expression/runtime.go
+++ b/internal/expression/runtime.go
@@ -658,7 +658,7 @@ func resolveRuntimeReferenceValue(root string, path []string, context Context, a
 
 func classifyRuntimeReference(root string, path []string) runtimeReferenceKind {
 	switch {
-	case len(path) == 1 && strings.EqualFold(root, "runner") && (strings.EqualFold(path[0], "os") || strings.EqualFold(path[0], "arch") || strings.EqualFold(path[0], "temp")):
+	case len(path) == 1 && strings.EqualFold(root, "runner") && (strings.EqualFold(path[0], "os") || strings.EqualFold(path[0], "arch") || strings.EqualFold(path[0], "environment") || strings.EqualFold(path[0], "temp")):
 		return runtimeReferenceRunner
 	case len(path) == 4 && strings.EqualFold(root, "job") && strings.EqualFold(path[0], "services") && strings.EqualFold(path[2], "ports"):
 		return runtimeReferenceServicePort

--- a/internal/runtime/action_execution.go
+++ b/internal/runtime/action_execution.go
@@ -1456,6 +1456,7 @@ func standardEnvironment(job plan.Job, workspace, runnerTemp, toolCache string, 
 		"GITHUB_WORKSPACE":    workspace,
 		"RUNNER_OS":           runner["os"],
 		"RUNNER_ARCH":         runner["arch"],
+		"RUNNER_ENVIRONMENT":  runner["environment"],
 		"RUNNER_TEMP":         runnerTemp,
 		"RUNNER_TOOL_CACHE":   toolCache,
 	}
@@ -1471,9 +1472,9 @@ func standardEnvironment(job plan.Job, workspace, runnerTemp, toolCache string, 
 func canonicalRunnerContext(goos, goarch string) (map[string]string, error) {
 	switch {
 	case goos == "linux" && goarch == "amd64":
-		return map[string]string{"os": "Linux", "arch": "X64"}, nil
+		return map[string]string{"os": "Linux", "arch": "X64", "environment": expression.RunnerEnvironment}, nil
 	case goos == "darwin" && goarch == "arm64":
-		return map[string]string{"os": "macOS", "arch": "ARM64"}, nil
+		return map[string]string{"os": "macOS", "arch": "ARM64", "environment": expression.RunnerEnvironment}, nil
 	default:
 		return nil, errUnsupportedf("unsupported runner platform %s/%s", goos, goarch)
 	}
@@ -1597,6 +1598,7 @@ func isRuntimeContextEnvironment(name string) bool {
 		"GITHUB_WORKFLOW_SHA",
 		"GITHUB_WORKSPACE",
 		"RUNNER_ARCH",
+		"RUNNER_ENVIRONMENT",
 		"RUNNER_OS",
 		"RUNNER_TEMP",
 		"RUNNER_TOOL_CACHE":

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -335,6 +335,22 @@ jobs:
 	}
 }
 
+func TestRunnerEnvironmentIsSelfHostedAtRuntime(t *testing.T) {
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/test.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: runtime test\n")
+	var logs bytes.Buffer
+	job := runtimePlan(t, workspace, workflowPath, []runtimeTestStep{
+		{ID: "hosted", Kind: "run", Condition: "runner.environment == 'github-hosted'", Command: "echo must-not-run"},
+		{ID: "self", Kind: "run", Condition: "runner.environment == 'self-hosted'", Env: map[string]string{"RUNNER_KIND": "${{ runner.environment }}"}, Command: `test "$RUNNER_ENVIRONMENT" = self-hosted && test "$RUNNER_KIND" = self-hosted && echo ran-self-hosted`},
+		{ID: "verify", Kind: "run", Condition: "steps.hosted.conclusion == 'skipped' && steps.self.conclusion == 'success'", Command: "echo verified-conclusions"},
+	})
+	result, err := (Runner{Stdout: &logs, Stderr: &logs}).runTestJob(t.Context(), job, workspace)
+	if err != nil || result.Conclusion != "success" || strings.Contains(logs.String(), "must-not-run") || !strings.Contains(logs.String(), "ran-self-hosted") || !strings.Contains(logs.String(), "verified-conclusions") {
+		t.Fatalf("RunJob() result = %#v, error = %v, logs = %q", result, err, logs.String())
+	}
+}
+
 func TestFailureConditionsAndCancellation(t *testing.T) {
 	workspace := t.TempDir()
 	workflowPath := ".github/workflows/test.yml"
@@ -1428,7 +1444,7 @@ func TestCanonicalRunnerContext(t *testing.T) {
 		{goos: "darwin", goarch: "arm64", os: "macOS", arch: "ARM64"},
 	} {
 		got, err := canonicalRunnerContext(test.goos, test.goarch)
-		if err != nil || got["os"] != test.os || got["arch"] != test.arch {
+		if err != nil || got["os"] != test.os || got["arch"] != test.arch || got["environment"] != "self-hosted" {
 			t.Errorf("canonicalRunnerContext(%s, %s) = %#v, %v", test.goos, test.goarch, got, err)
 		}
 	}
@@ -1451,9 +1467,9 @@ func TestValidateHostRejectsDockerOnDarwin(t *testing.T) {
 }
 
 func TestRunnerEnvironmentIsProtected(t *testing.T) {
-	base := map[string]string{"RUNNER_OS": "Linux", "RUNNER_ARCH": "X64"}
-	got := mergeStepEnvironment(base, map[string]string{"RUNNER_OS": "overridden", "RUNNER_ARCH": "overridden"})
-	if got["RUNNER_OS"] != "Linux" || got["RUNNER_ARCH"] != "X64" {
+	base := map[string]string{"RUNNER_OS": "Linux", "RUNNER_ARCH": "X64", "RUNNER_ENVIRONMENT": "self-hosted"}
+	got := mergeStepEnvironment(base, map[string]string{"RUNNER_OS": "overridden", "RUNNER_ARCH": "overridden", "RUNNER_ENVIRONMENT": "github-hosted"})
+	if got["RUNNER_OS"] != "Linux" || got["RUNNER_ARCH"] != "X64" || got["RUNNER_ENVIRONMENT"] != "self-hosted" {
 		t.Fatalf("runner environment was overridden: %#v", got)
 	}
 }


### PR DESCRIPTION
## Why

Workflows that branch on the runner environment fail to compile:

```yaml
if: runner.environment == 'self-hosted'
```

```text
condition reference "runner.environment" is unsupported
```

## What

Support `runner.environment` in valid expression and runtime surfaces and set both it and `RUNNER_ENVIRONMENT` to `self-hosted`.

This PR deliberately leaves the value runtime-dependent during static analysis. It does not prune action preparation or change `github.token` authority decisions; those changes are separated into a follow-up.
