### PR TITLE
PB-3247: Skip actions unreachable on Buildkite agents

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1111,6 +1111,11 @@ rooted at `github.event`.
 runners registered outside GitHub, including managed providers. Buildkite
 agents are in the same class whether they use hosted agents or your own
 infrastructure.
+The compiler also treats this value as constant. An action behind
+`runner.environment == 'github-hosted'` is unreachable, so job setup does not
+download its source, pull its image, mount it, or run its `pre` and `post`
+hooks. A `github.token` reference that is reachable only through that condition
+does not grant token authority.
 After runner setup, step runtime fields and job outputs can also use
 `runner.temp`, which resolves to the canonical temporary directory exposed as
 `RUNNER_TEMP`. Other runner fields and compile-time positions that require

--- a/internal/compiler/actions_test.go
+++ b/internal/compiler/actions_test.go
@@ -1044,6 +1044,8 @@ runs:
 		{name: "step", condition: "        if: false\n"},
 		{name: "job", jobIf: "    if: false\n"},
 		{name: "matrix", condition: "        if: matrix.enabled\n"},
+		{name: "github-hosted step", condition: "        if: runner.environment == 'github-hosted'\n"},
+		{name: "github-hosted job", jobIf: "    if: runner.environment == 'github-hosted'\n"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			matrix := ""
@@ -1079,6 +1081,12 @@ jobs:
 `)
 	if err == nil || !strings.Contains(err.Error(), "no effective permissions") {
 		t.Fatalf("runtime-dependent action condition error = %v, want conservative token authority", err)
+	}
+	for _, condition := range []string{"runner.environment == 'self-hosted'", "runner.os == 'Linux'"} {
+		_, err := compile("on: push\npermissions: {}\njobs:\n  token:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: ./.github/actions/token\n        if: " + condition + "\n        with:\n          deploy_key: ${{ secrets.DEPLOY_KEY }}\n")
+		if err == nil || !strings.Contains(err.Error(), "no effective permissions") {
+			t.Fatalf("condition %q error = %v, want retained token authority", condition, err)
+		}
 	}
 }
 

--- a/internal/expression/action_input_default.go
+++ b/internal/expression/action_input_default.go
@@ -127,10 +127,10 @@ func actionInputDefaultRequiresGitHubToken(template, serverURL string) (bool, er
 	}
 	requiresToken := false
 	err = visitTemplateExpressions(template, func(expression actionlint.ExprNode) error {
-		analysis, analysisErr := analyzeActionInputDefault(expression, map[string]any{
+		analysis, analysisErr := analyzeActionInputDefault(expression, canonicalAbstractReferences(map[string]any{
 			"github.server_url": serverURL,
 			"job.check_run_id":  "",
-		})
+		}))
 		if analysisErr != nil {
 			// Runtime-dependent evaluation failures previously fell back to
 			// conservative authority. Preserve that behavior while the

--- a/internal/expression/engine.go
+++ b/internal/expression/engine.go
@@ -823,10 +823,11 @@ func (Engine) Truthy(value any) bool {
 const RunnerEnvironment = "self-hosted"
 
 func canonicalAbstractReferences(source map[string]any) map[string]any {
-	result := make(map[string]any, len(source))
+	result := make(map[string]any, len(source)+1)
 	for name, value := range source {
 		result[strings.ToLower(name)] = value
 	}
+	result["runner.environment"] = RunnerEnvironment
 	return result
 }
 

--- a/internal/expression/engine_test.go
+++ b/internal/expression/engine_test.go
@@ -240,16 +240,11 @@ func TestEngineValidateConditionAttributesEarlySecretReferenceError(t *testing.T
 	}
 }
 
-func TestEngineAnalysisDefersRunnerEnvironmentToRuntime(t *testing.T) {
+func TestEngineAnalysisTreatsRunnerEnvironmentAsConstant(t *testing.T) {
 	engine := NewEngine()
-	condition, err := engine.Analyze(Site{
-		Source:  "runner.environment == 'github-hosted'",
-		Profile: ProfileStepCondition,
-		Result:  ResultBoolean,
-		Purpose: PurposeExpression,
-	}, AbstractValues{})
-	if err != nil || condition.Value.Known {
-		t.Fatalf("Analyze() condition = %#v, %v; want runtime-dependent", condition, err)
+	condition, err := engine.Analyze(Site{Source: "runner.environment == 'github-hosted'", Profile: ProfileStepCondition, Result: ResultBoolean, Purpose: PurposeExpression}, AbstractValues{References: map[string]any{"runner.environment": "github-hosted"}})
+	if err != nil || !condition.Value.Known || condition.Value.Value != false {
+		t.Fatalf("Analyze() condition = %#v, %v; want known false", condition, err)
 	}
 	token, err := engine.Analyze(Site{
 		Source:  "${{ runner.environment == 'github-hosted' && github.token || '' }}",
@@ -257,8 +252,14 @@ func TestEngineAnalysisDefersRunnerEnvironmentToRuntime(t *testing.T) {
 		Result:  ResultString,
 		Purpose: PurposeWorkflowActionInput,
 	}, AbstractValues{})
-	if err != nil || token.Effects.GitHubToken != GitHubTokenDirect {
-		t.Fatalf("Analyze() token effects = %v, %v; want conservative authority", token.Effects.GitHubToken, err)
+	if err != nil || !token.Value.Known || token.Value.Value != "" || token.Effects.GitHubToken != 0 {
+		t.Fatalf("Analyze() token branch = %#v, %v; want known empty value without authority", token, err)
+	}
+	if requires, err := actionInputDefaultRequiresGitHubToken("${{ runner.environment == 'github-hosted' && github.token || '' }}", "https://github.com"); err != nil || requires {
+		t.Fatalf("github-hosted default requires token = %v, %v; want false", requires, err)
+	}
+	if requires, err := actionInputDefaultRequiresGitHubToken("${{ runner.environment == 'self-hosted' && github.token || '' }}", "https://github.com"); err != nil || !requires {
+		t.Fatalf("self-hosted default requires token = %v, %v; want true", requires, err)
 	}
 }
 

--- a/internal/program/authority_test.go
+++ b/internal/program/authority_test.go
@@ -144,6 +144,32 @@ func TestWorkflowReachabilityKeepsCallerScopedGuardValuesUnknown(t *testing.T) {
 	}
 }
 
+func TestWorkflowReachabilityKnowsRunnerEnvironmentIsSelfHosted(t *testing.T) {
+	condition := func(source string) Site {
+		return Site{Source: source, Surface: SurfaceStepCondition, Result: ResultBoolean, Provenance: ProvenanceWorkflow, Purpose: PurposeExpression}
+	}
+	workflow := Program{Version: Version, Job: Job{
+		Condition: Site{Surface: SurfaceJobCondition, Result: ResultBoolean, Provenance: ProvenanceWorkflow, Purpose: PurposeExpression},
+		Steps: []Step{
+			{Condition: condition("runner.environment == 'github-hosted'")},
+			{Condition: condition("runner.environment == 'self-hosted'")},
+			{Condition: condition("runner.os == 'Linux'")},
+		},
+	}}
+	reachability, err := WorkflowReachability(workflow, expression.AbstractValues{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reachability.Job || reachability.Steps[0] || !reachability.Steps[1] || !reachability.Steps[2] {
+		t.Fatalf("reachability = %#v, want github-hosted step unreachable, self-hosted step reachable, runner.os step unknown", reachability)
+	}
+	workflow.Job.Condition.Source = "runner.environment == 'github-hosted'"
+	reachability, err = WorkflowReachability(workflow, expression.AbstractValues{})
+	if err != nil || reachability.Job || reachability.Steps[1] {
+		t.Fatalf("github-hosted job reachability = %#v, %v; want the whole job unreachable", reachability, err)
+	}
+}
+
 func TestWorkflowReachabilityUsesSharedGuardValues(t *testing.T) {
 	workflow := Program{Version: Version, Job: Job{
 		Guards:    []Guard{{Condition: Site{Source: "vars.ENABLED != 'yes'", Surface: SurfaceCallCondition, Result: ResultBoolean, Provenance: ProvenanceWorkflow, Purpose: PurposeExpression}}},

--- a/internal/runtime/action_execution.go
+++ b/internal/runtime/action_execution.go
@@ -218,6 +218,7 @@ func (r *jobRun) prepare(ctx context.Context) (final JobResult, runJobErr error)
 		return jobResult, fmt.Errorf("analyze workflow reachability: %w", err)
 	}
 	r.reachableSteps = reachability.Steps
+	r.reachableLocks = reachableActionLocks(job, executionJob.Steps, r.reachableSteps)
 	runCtx := ctx
 	cancelJob := func() {}
 	if job.TimeoutMinutes > 0 {
@@ -401,10 +402,10 @@ func (r *jobRun) prepare(ctx context.Context) (final JobResult, runJobErr error)
 	if containerSpec != nil {
 		// Remote children of workspace composites are already present in the
 		// immutable lock graph even when the workspace action itself must remain
-		// lazy. Materialize every remote lock now because bind mounts cannot be
-		// added after the persistent container is created.
+		// lazy. Materialize every reachable remote lock now because bind mounts
+		// cannot be added after the persistent container is created.
 		for _, lock := range job.Actions {
-			if lock.Source != "github" || usesNativeAdapter(lock) {
+			if lock.Source != "github" || usesNativeAdapter(lock) || !r.lockReachable(lock.ID) {
 				continue
 			}
 			action, _, resolveErr := actions.resolve(runCtx, plan.ActionSelector{Lock: lock.ID})
@@ -419,9 +420,9 @@ func (r *jobRun) prepare(ctx context.Context) (final JobResult, runJobErr error)
 				return tolerateJobSetupFailure(runCtx, job, jobResult, fmt.Errorf("prepare action lock %q: %w", lock.ID, entrypointErr))
 			}
 		}
-		for _, step := range executionJob.Steps {
+		for stepIndex, step := range executionJob.Steps {
 			selector, ok := stepActionSelector(step)
-			if step.Kind != "uses" || !ok {
+			if step.Kind != "uses" || !ok || !r.stepReachable(stepIndex) {
 				continue
 			}
 			if source, sourceErr := actions.source(selector); sourceErr != nil {
@@ -519,7 +520,7 @@ func (r *jobRun) runPreActions(ctx, runCtx context.Context) (JobResult, error) {
 			if step.Kind != "uses" {
 				continue
 			}
-			if stepIndex < len(r.reachableSteps) && !r.reachableSteps[stepIndex] {
+			if !r.stepReachable(stepIndex) {
 				continue
 			}
 			selector, ok := stepActionSelector(step)
@@ -1665,7 +1666,7 @@ func (r *jobRun) actionContainerMounts(ctx context.Context, actions *actionLockR
 	for _, lock := range actions.job.Actions {
 		// A native adapter replaces the admitted action's execution entirely,
 		// so its source tree is never mounted or classified for the container.
-		if usesNativeAdapter(lock) {
+		if usesNativeAdapter(lock) || !r.lockReachable(lock.ID) {
 			continue
 		}
 		entry := actions.locks[lock.ID]
@@ -2309,6 +2310,44 @@ func evaluatePlanStepWith(step executionprogram.Step, context expression.Context
 		return nil, nil
 	}
 	return executionprogram.EvaluateBindings(step.Invocation.With, executionprogram.EvaluationContext{Expression: context})
+}
+
+// stepReachable defaults to reachable when a planning pass did not classify
+// the step.
+func (r *jobRun) stepReachable(stepIndex int) bool {
+	return stepIndex >= len(r.reachableSteps) || r.reachableSteps[stepIndex]
+}
+
+func (r *jobRun) lockReachable(lockID string) bool {
+	return r.reachableLocks == nil || r.reachableLocks[lockID]
+}
+
+// reachableActionLocks closes the lock graph over reachable action steps.
+func reachableActionLocks(job plan.Job, steps []executionprogram.Step, reachableSteps []bool) map[string]bool {
+	locks := make(map[string]plan.ActionLock, len(job.Actions))
+	for _, lock := range job.Actions {
+		locks[lock.ID] = lock
+	}
+	reachable := make(map[string]bool, len(job.Actions))
+	var visit func(id string)
+	visit = func(id string) {
+		if reachable[id] {
+			return
+		}
+		reachable[id] = true
+		for _, child := range locks[id].Children {
+			visit(child.Lock)
+		}
+	}
+	for stepIndex, step := range steps {
+		if step.Kind != "uses" || stepIndex < len(reachableSteps) && !reachableSteps[stepIndex] {
+			continue
+		}
+		if selector, ok := stepActionSelector(step); ok {
+			visit(selector.Lock)
+		}
+	}
+	return reachable
 }
 
 func stepActionSelector(step executionprogram.Step) (plan.ActionSelector, bool) {

--- a/internal/runtime/actions.go
+++ b/internal/runtime/actions.go
@@ -59,7 +59,7 @@ type prebuiltDockerBackend struct {
 func (r *jobRun) preparePrebuiltDockerActions(ctx context.Context, processor *commandOutputProcessor, actions *actionLockResolver) (_ *prebuiltDockerBackend, err error) {
 	images := map[string]string{}
 	for _, lock := range actions.job.Actions {
-		if lock.DockerImage != "" {
+		if lock.DockerImage != "" && r.lockReachable(lock.ID) {
 			images[lock.DockerImage] = ""
 		}
 	}

--- a/internal/runtime/containers_test.go
+++ b/internal/runtime/containers_test.go
@@ -3045,3 +3045,34 @@ func liveDockerOwnedResources(t *testing.T, docker string) []string {
 	slices.Sort(resources)
 	return resources
 }
+
+func TestGitHubHostedGatedRemoteActionIsNotMaterializedForContainerJob(t *testing.T) {
+	f := newJobDocker(t, "")
+	workspace := t.TempDir()
+	writeFixtureFile(t, workspace, ".github/workflows/container.yml", "name: gated remote container actions\n")
+	remote := t.TempDir()
+	for _, name := range []string{"hosted", "self-hosted"} {
+		writeFixtureFile(t, remote, name+"/action.yml", "name: "+name+"\nruns:\n  using: node24\n  main: main.js\n")
+		writeFixtureFile(t, remote, name+"/main.js", `require("node:fs").appendFileSync(process.env.GITHUB_OUTPUT, "ran=`+name+`\n")
+`)
+	}
+	digest := digestTree(t, remote)
+	hostedID, selfHostedID := remoteLifecycleLockID(1), remoteLifecycleLockID(2)
+	job := runtimePlan(t, workspace, ".github/workflows/container.yml", []runtimeTestStep{
+		{ID: "hosted", Kind: "uses", Uses: remoteLifecycleUses("hosted"), Action: &plan.ActionSelector{Lock: hostedID}, Condition: "runner.environment == 'github-hosted'"},
+		{ID: "self-hosted", Kind: "uses", Uses: remoteLifecycleUses("self-hosted"), Action: &plan.ActionSelector{Lock: selfHostedID}, Condition: "runner.environment == 'self-hosted'"},
+	})
+	job.Schema = plan.Schema
+	job.RequiredCapabilities = []string{"docker", "network"}
+	job.Container = &plan.Container{Image: "debian:bookworm-slim"}
+	job.Actions = []plan.ActionLock{remoteLifecycleLock(hostedID, "hosted", digest, nil), remoteLifecycleLock(selfHostedID, "self-hosted", digest, nil)}
+	job.Outputs = map[string]string{"ran": "${{ steps.self-hosted.outputs.ran }}"}
+	materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, ActionRoot: filepath.Join(remote, "self-hosted"), SourceDigest: digest}}
+	result, err := (Runner{Docker: f.path, RuntimeExecutable: os.Args[0], Node24: requireNode24(t), Actions: materializer}).runTestJob(t.Context(), job, workspace)
+	if err != nil || result.Outputs["ran"] != "self-hosted" {
+		t.Fatalf("container job result = %#v, error = %v", result, err)
+	}
+	if materializer.calls != 1 {
+		t.Fatalf("remote materialization calls = %d, want 1 for the self-hosted gate only", materializer.calls)
+	}
+}

--- a/internal/runtime/job_run.go
+++ b/internal/runtime/job_run.go
@@ -26,6 +26,7 @@ type jobRun struct {
 	prepared        remotePreparations
 	preFailures     map[int]stepExecution
 	reachableSteps  []bool
+	reachableLocks  map[string]bool
 	runErr          error
 	hardFailure     bool
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -351,6 +351,126 @@ func TestRunnerEnvironmentIsSelfHostedAtRuntime(t *testing.T) {
 	}
 }
 
+func TestGitHubHostedGatedActionSkipsEveryLifecyclePhase(t *testing.T) {
+	node := requireNode24(t)
+	remote := t.TempDir()
+	writeFixtureFile(t, remote, "root/action.yml", "name: root\nruns:\n  using: node24\n  pre: pre.js\n  main: main.js\n  post: post.js\n")
+	for _, phase := range []string{"pre", "main", "post"} {
+		writeFixtureFile(t, remote, "root/"+phase+".js", fmt.Sprintf("require('node:fs').appendFileSync(process.env.PHASE_LOG, %q)\n", phase+"\n"))
+	}
+	digest := digestTree(t, remote)
+	rootID := remoteLifecycleLockID(1)
+	for _, test := range []struct {
+		condition string
+		calls     int
+		phases    string
+	}{
+		{condition: "runner.environment == 'github-hosted'", calls: 0, phases: ""},
+		{condition: "runner.environment == 'self-hosted'", calls: 1, phases: "pre\nmain\npost\n"},
+	} {
+		t.Run(test.condition, func(t *testing.T) {
+			workspace := t.TempDir()
+			workflowPath := ".github/workflows/test.yml"
+			writeFixtureFile(t, workspace, workflowPath, "name: runner environment lifecycle\n")
+			phaseLog := filepath.Join(t.TempDir(), "phases.log")
+			job := runtimePlan(t, workspace, workflowPath, []runtimeTestStep{{
+				ID: "root", Kind: "uses", Uses: remoteLifecycleUses("root"), Action: &plan.ActionSelector{Lock: rootID},
+				Condition: test.condition, Env: map[string]string{"PHASE_LOG": phaseLog},
+			}})
+			job.RequiredCapabilities = []string{"network"}
+			job.Actions = []plan.ActionLock{remoteLifecycleLock(rootID, "root", digest, nil)}
+			materializer := &fakeActionMaterializer{result: source.Materialized{RepositoryRoot: remote, SourceDigest: digest}}
+			result, err := (Runner{Actions: materializer, Node24: node}).runTestJob(t.Context(), job, workspace)
+			if err != nil || result.Conclusion != "success" {
+				t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+			}
+			if materializer.calls != test.calls {
+				t.Fatalf("materializations = %d, want %d", materializer.calls, test.calls)
+			}
+			data, err := os.ReadFile(phaseLog)
+			if err != nil && !os.IsNotExist(err) {
+				t.Fatal(err)
+			}
+			if string(data) != test.phases {
+				t.Fatalf("lifecycle phases = %q, want %q", data, test.phases)
+			}
+		})
+	}
+}
+
+func TestGitHubHostedGatedPrebuiltDockerActionIsNotPulled(t *testing.T) {
+	requireLinuxAMD64(t)
+	fake := newFakeDocker(t, "success")
+	workspace := t.TempDir()
+	workflowPath := ".github/workflows/prebuilt.yml"
+	writeFixtureFile(t, workspace, workflowPath, "name: prebuilt gates\n")
+	hostedImage := "ghcr.io/example/hosted@sha256:" + strings.Repeat("d", 64)
+	selfHostedImage := "ghcr.io/example/self-hosted@sha256:" + strings.Repeat("b", 64)
+	locks := make([]plan.ActionLock, 0, 2)
+	steps := make([]runtimeTestStep, 0, 2)
+	for i, gate := range []struct{ name, environment, image string }{
+		{name: "hosted", environment: "github-hosted", image: hostedImage},
+		{name: "self-hosted", environment: "self-hosted", image: selfHostedImage},
+	} {
+		actionPath := ".github/actions/" + gate.name
+		writeFixtureFile(t, workspace, actionPath+"/action.yml", "name: "+gate.name+"\nruns:\n  using: docker\n  image: docker://"+gate.image+"\n")
+		lockID := fmt.Sprintf("a-%016x", i+1)
+		locks = append(locks, plan.ActionLock{ID: lockID, Source: "workspace", Path: actionPath, SourceDigest: digestTree(t, filepath.Join(workspace, actionPath)), DockerImage: gate.image})
+		steps = append(steps, runtimeTestStep{
+			ID: gate.name, Kind: "uses", Uses: "./" + actionPath, Action: &plan.ActionSelector{Lock: lockID},
+			Condition: "runner.environment == '" + gate.environment + "'",
+		})
+	}
+	job := runtimePlan(t, workspace, workflowPath, steps)
+	job.RequiredCapabilities = []string{"docker", "network"}
+	job.Actions = locks
+	result, err := (Runner{Docker: fake.path}).runTestJob(t.Context(), job, workspace)
+	if err != nil || result.Conclusion != "success" {
+		t.Fatalf("RunJob() result = %#v, error = %v", result, err)
+	}
+	calls := fake.calls(t)
+	if callIndex(calls, "pull", hostedImage) >= 0 {
+		t.Fatalf("github-hosted gated image was pulled: %#v", calls)
+	}
+	pull, run := callIndex(calls, "pull", selfHostedImage), callIndex(calls, "run")
+	if pull < 0 || run < pull {
+		t.Fatalf("self-hosted gated image was not pulled before execution: %#v", calls)
+	}
+}
+
+func TestReachableActionLocksClosesOverCompositeChildren(t *testing.T) {
+	child := func(id string) map[string]plan.ActionSelector {
+		return map[string]plan.ActionSelector{"owner/repo/" + id + "@v1": {Lock: id}}
+	}
+	job := plan.Job{Actions: []plan.ActionLock{
+		{ID: "live", Children: child("shared")},
+		{ID: "dead", Children: map[string]plan.ActionSelector{"s": {Lock: "shared"}, "o": {Lock: "dead-only"}}},
+		{ID: "shared", Children: child("grandchild")},
+		{ID: "grandchild"},
+		{ID: "dead-only"},
+		{ID: "unclassified"},
+	}}
+	steps := []executionprogram.Step{
+		normalizeRuntimeTestStep(runtimeTestStep{ID: "live", Kind: "uses", Uses: "owner/repo/live@v1", Action: &plan.ActionSelector{Lock: "live"}}),
+		normalizeRuntimeTestStep(runtimeTestStep{ID: "dead", Kind: "uses", Uses: "owner/repo/dead@v1", Action: &plan.ActionSelector{Lock: "dead"}}),
+		normalizeRuntimeTestStep(runtimeTestStep{ID: "run", Kind: "run", Command: "true"}),
+		normalizeRuntimeTestStep(runtimeTestStep{ID: "unclassified", Kind: "uses", Uses: "owner/repo/unclassified@v1", Action: &plan.ActionSelector{Lock: "unclassified"}}),
+	}
+	got := reachableActionLocks(job, steps, []bool{true, false, true})
+	want := map[string]bool{"live": true, "shared": true, "grandchild": true, "unclassified": true}
+	if !maps.Equal(got, want) {
+		t.Fatalf("reachableActionLocks() = %v, want %v", got, want)
+	}
+	r := &jobRun{}
+	if !r.lockReachable("dead") || !r.stepReachable(1) {
+		t.Fatal("every lock and step must stay reachable before the reachability pass runs")
+	}
+	r.reachableLocks, r.reachableSteps = got, []bool{true, false, true}
+	if r.lockReachable("dead") || r.lockReachable("dead-only") || r.stepReachable(1) || !r.stepReachable(3) {
+		t.Fatalf("reachability lookups = locks dead=%v dead-only=%v, steps 1=%v 3=%v", r.lockReachable("dead"), r.lockReachable("dead-only"), r.stepReachable(1), r.stepReachable(3))
+	}
+}
+
 func TestFailureConditionsAndCancellation(t *testing.T) {
 	workspace := t.TempDir()
 	workflowPath := ".github/workflows/test.yml"


### PR DESCRIPTION
## Why

After `runner.environment` is available at runtime, job setup can still prepare an action that cannot run:

```yaml
- if: runner.environment == 'github-hosted'
  uses: owner/action@v1
```

Likewise, `${{ runner.environment == 'github-hosted' && github.token || '' }}` conservatively grants token authority even though Buildkite agents report `self-hosted`.

## What

Treat `runner.environment` as a planning-time constant. Known `github-hosted` branches no longer download or mount action source, pull action images, run `pre` or `post` hooks, or grant unreachable `github.token` authority. Reachable actions and queue-dependent values such as `runner.os` remain conservative.

This follows the runtime support merged in #466.
