### PR TITLE
Fix release trigger tests after event-file support

### DIFF
--- a/internal/cli/release_pipeline_trigger_test.go
+++ b/internal/cli/release_pipeline_trigger_test.go
@@ -83,7 +83,7 @@ func TestPluginReleasePipelineTrigger(t *testing.T) {
 					}
 					resultPath := filepath.Join(t.TempDir(), "result.json")
 					stderr.Reset()
-					if code := run([]string{"run-job", "--plan", planPath, "--result", resultPath}, &stdout, &stderr, "dev", &cliCaptureRunner{dataByPath: runner.uploaded}); code != 0 {
+					if code := run([]string{"run-job", "--plan", planPath, "--artifact-producer", cliTestJobID, "--result", resultPath}, &stdout, &stderr, "dev", &cliCaptureRunner{dataByPath: runner.uploaded}); code != 0 {
 						t.Fatalf("run-job = %d: %s", code, &stderr)
 					}
 					marker, err := os.ReadFile(resultPath)


### PR DESCRIPTION
## Why

Current `main` fails all three release Pipeline Trigger marker cases with `event payload artifact requires an importer job producer` ([build 2240](https://buildkite.com/buildkite/buildkite-gha/builds/2240)). The tests introduced in #469 invoke `run-job` directly without a producer ID. After #454 enabled `GITHUB_EVENT_PATH`, linked-webhook plans retain a payload artifact even when their expression values are resolved during compilation.

## What

Pass `--artifact-producer` with the importer job ID, matching the generated command. The existing regression still compiles the selected release workflow, hydrates the original payload, runs the job, and verifies its emitted tag marker for `published`, `created`, and `released`. Payload-producer validation and product code are unchanged.

This extracts only the release-test correction already present in #470, so restoring current-main validation does not require merging merge-group support. It targets `main` directly and has no feature dependency on #470. No merge, release, or deployment is included; release readiness still requires this fix to land and current-main CI to pass through the normal gates.
