### PR TITLE
PB-3285: Preserve status conditions after reusable workflow input substitution

### DIFF
--- a/internal/cli/diagnostic_excerpt_test.go
+++ b/internal/cli/diagnostic_excerpt_test.go
@@ -70,6 +70,36 @@ func TestNestedRemoteParseFailureLinksOffendingWorkflow(t *testing.T) {
 	}
 }
 
+func TestNestedReusableFailureRetainsOffendingWorkflowDiagnostic(t *testing.T) {
+	directory := filepath.Join(t.TempDir(), ".github", "workflows")
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	workflows := map[string]string{
+		"caller.yml": "on: push\njobs:\n  call:\n    uses: ./.github/workflows/middle.yml\n",
+		"middle.yml": "on: workflow_call\njobs:\n  nested:\n    uses: ./.github/workflows/leaf.yml\n",
+		"leaf.yml":   "on: workflow_call\njobs:\n  broken:\n    runs-on: ${{ inputs.runner }}\n    steps:\n      - run: true\n",
+	}
+	for name, source := range workflows {
+		if err := os.WriteFile(filepath.Join(directory, name), []byte(source), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	caller := filepath.Join(directory, "caller.yml")
+	validated, validationErr := compiler.Validate(caller, []byte(workflows["caller.yml"]))
+	if validationErr == nil {
+		t.Fatal("invalid nested workflow was accepted")
+	}
+	report := compatibility.InitialProcessingReport(caller, "", false, validated, validationErr)
+	if len(report.Diagnostics) != 1 {
+		t.Fatalf("diagnostics = %#v, want one nested failure", report.Diagnostics)
+	}
+	diagnostic := report.Diagnostics[0]
+	if diagnostic.Location == nil || diagnostic.Location.Path != "./.github/workflows/caller.yml" || diagnostic.Location.Line != 4 || diagnostic.Location.Column != 11 || diagnostic.Message != "reusable-workflow input expression is not statically resolvable" {
+		t.Fatalf("nested diagnostic = %#v", diagnostic)
+	}
+}
+
 func TestTriggerFailureRetainsSourceLink(t *testing.T) {
 	root := t.TempDir()
 	t.Chdir(root)

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -1597,6 +1597,79 @@ jobs:
 	}
 }
 
+func TestCompilePreservesStatusFunctionsAfterReusableInputSubstitution(t *testing.T) {
+	repository := t.TempDir()
+	callerPath := writeWorkflow(t, repository, "caller.yml", `on: push
+jobs:
+  enabled:
+    uses: ./.github/workflows/reusable.yml
+    with:
+      enabled: true
+  disabled:
+    uses: ./.github/workflows/reusable.yml
+    with:
+      enabled: false
+`)
+	writeWorkflow(t, repository, "reusable.yml", `on:
+  workflow_call:
+    inputs:
+      enabled:
+        type: boolean
+        required: true
+jobs:
+  test:
+    if: always() && inputs.enabled
+    runs-on: ubuntu-latest
+    steps:
+      - if: ${{ !cancelled() && inputs.enabled }}
+        run: echo enabled
+      - if: failure() && inputs.enabled == true
+        run: echo failed
+`)
+
+	plans, err := compileUntrustedPlans(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")), "0.0.0-test", testDistributionDigest, "gha-untrusted")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 2 {
+		t.Fatalf("plans = %d, want one job for each reusable call", len(plans))
+	}
+	want := map[string][3]string{
+		"enabled.test":  {"${{ always() && true }}", "${{ !cancelled() && true }}", "${{ failure() && true == true }}"},
+		"disabled.test": {"${{ always() && false }}", "${{ !cancelled() && false }}", "${{ failure() && false == true }}"},
+	}
+	for _, job := range plans {
+		steps := job.Program.Job.Steps
+		got := [3]string{job.Condition, steps[0].Condition.Source, steps[1].Condition.Source}
+		expected, ok := want[job.Workflow.LogicalJobID]
+		if !ok || got != expected {
+			t.Errorf("conditions for %q = %#v, want %#v", job.Workflow.LogicalJobID, got, expected)
+		}
+	}
+}
+
+func TestCompileValidatesResidualReusableInputConditions(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		condition string
+		want      string
+	}{
+		{name: "unsupported function", condition: "unsupported() && inputs.enabled", want: `condition function "unsupported" is unsupported`},
+		{name: "unavailable context", condition: "secrets.TOKEN && inputs.enabled", want: `condition context "secrets" is unsupported`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			repository := t.TempDir()
+			callerPath := writeWorkflow(t, repository, "caller.yml", "on: push\njobs:\n  call:\n    uses: ./.github/workflows/reusable.yml\n    with:\n      enabled: true\n")
+			writeWorkflow(t, repository, "reusable.yml", "on:\n  workflow_call:\n    inputs:\n      enabled: {type: boolean, required: true}\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - if: ${{ "+test.condition+" }}\n        run: true\n")
+
+			_, err := Compile(callerPath, readFile(t, callerPath), readFile(t, smokePath("events", "push.json")))
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Compile() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
 func TestCompileForwardsIndexedStringInputToNestedReusableWorkflow(t *testing.T) {
 	repository := t.TempDir()
 	callerPath := writeWorkflow(t, repository, "caller.yml", `on: push

--- a/internal/compiler/reusable.go
+++ b/internal/compiler/reusable.go
@@ -527,7 +527,9 @@ func (resolver *reusableResolver) resolve(ctx context.Context, current reusableW
 					if finding.Stage == StageWorkflowParsing {
 						return reusableResolution{}, err
 					}
-					message = finding.Message
+					if finding.Message != "" {
+						message = finding.Message
+					}
 					detail = finding.Detail
 				}
 				return reusableResolution{}, &ProcessingFinding{
@@ -1315,6 +1317,17 @@ func replaceSliceInputs(values []string, inputs map[string]any) []string {
 }
 
 func rejectUnresolvedInputExpressions(path string, job workflow.Job, deferredInputs map[string]deferredInput) error {
+	reject := func(line, column int, message string) error {
+		return &ProcessingFinding{
+			Stage: StageGraph, Code: CodeGraphInvalid, Category: "compatibility",
+			Path: path, Line: line, Column: column, Job: job.ID,
+			Message: message,
+			Err:     locatedJobError(path, job, line, column, message),
+		}
+	}
+	rejectJob := func(message string) error {
+		return reject(job.Span.Start.Line, job.Span.Start.Column, message)
+	}
 	jobValues := []string{job.Name}
 	jobRuntimeValues := []string{job.DefaultShell, job.DefaultWorkingDirectory}
 	jobRuntimeValues = appendMapValues(jobRuntimeValues, job.Env)
@@ -1352,7 +1365,7 @@ func rejectUnresolvedInputExpressions(path string, job workflow.Job, deferredInp
 			}
 			for _, value := range row.Values {
 				if containsInputExpression(value.Data) {
-					return locatedJobError(path, job, value.Span.Start.Line, value.Span.Start.Column, "reusable-workflow input expression is not statically resolvable")
+					return reject(value.Span.Start.Line, value.Span.Start.Column, "reusable-workflow input expression is not statically resolvable")
 				}
 			}
 		}
@@ -1360,36 +1373,36 @@ func rejectUnresolvedInputExpressions(path string, job workflow.Job, deferredInp
 			for _, combination := range combinations {
 				for _, value := range combination.Values {
 					if containsInputExpression(value.Data) {
-						return locatedJobError(path, job, value.Span.Start.Line, value.Span.Start.Column, "reusable-workflow input expression is not statically resolvable")
+						return reject(value.Span.Start.Line, value.Span.Start.Column, "reusable-workflow input expression is not statically resolvable")
 					}
 				}
 			}
 		}
 	}
 	if slices.ContainsFunc(jobValues, hasInputExpression) {
-		return jobError(path, job, "reusable-workflow input expression is not statically resolvable")
+		return rejectJob("reusable-workflow input expression is not statically resolvable")
 	}
 	if hasUnresolvedConditionInput(job.If, deferredInputs) {
-		return jobError(path, job, "reusable-workflow input expression is not statically resolvable")
+		return rejectJob("reusable-workflow input expression is not statically resolvable")
 	}
 	for _, value := range jobRuntimeValues {
 		if hasUnresolvedTemplateInput(value, deferredInputs) {
-			return jobError(path, job, "reusable-workflow input expression is not statically resolvable")
+			return rejectJob("reusable-workflow input expression is not statically resolvable")
 		}
 	}
 	for _, step := range job.Steps {
 		if hasInputExpression(step.Uses) {
-			return locatedJobError(path, job, step.Span.Start.Line, step.Span.Start.Column, "reusable-workflow action reference input expression is not statically resolvable")
+			return reject(step.Span.Start.Line, step.Span.Start.Column, "reusable-workflow action reference input expression is not statically resolvable")
 		}
 		if hasUnresolvedConditionInput(step.If, deferredInputs) {
-			return locatedJobError(path, job, step.Span.Start.Line, step.Span.Start.Column, "reusable-workflow input expression is not statically resolvable")
+			return reject(step.Span.Start.Line, step.Span.Start.Column, "reusable-workflow input expression is not statically resolvable")
 		}
 		stepValues := []string{step.Name, step.Run, step.Shell, step.WorkingDirectory, step.ContinueOnErrorExpression, step.TimeoutMinutesExpression}
 		stepValues = appendMapValues(stepValues, step.Env)
 		stepValues = appendMapValues(stepValues, step.With)
 		for _, value := range stepValues {
 			if hasUnresolvedTemplateInput(value, deferredInputs) {
-				return locatedJobError(path, job, step.Span.Start.Line, step.Span.Start.Column, "reusable-workflow input expression is not statically resolvable")
+				return reject(step.Span.Start.Line, step.Span.Start.Column, "reusable-workflow input expression is not statically resolvable")
 			}
 		}
 	}
@@ -1552,10 +1565,20 @@ func replaceStaticInputCondition(value string, inputs map[string]any) string {
 		if !strings.Contains(value, "${{") {
 			usesInputs, err := referencesContext(value, expression.ProfileCompileStepCondition, "inputs", false)
 			if err == nil && usesInputs {
-				return replaceStaticInputs("${{ "+value+" }}", inputs)
+				value = "${{ " + value + " }}"
 			}
 		}
-		return replaceStaticInputs(value, inputs)
+		resolved, err := expression.SubstituteCompileInputs(value, inputs)
+		if err != nil || resolved == value {
+			return value
+		}
+		if reduced, err := reduceCompileSite(resolved, expression.ProfilePartialTemplate, expression.ResultString, expression.CompileContext{}); err == nil {
+			if reduced.Known {
+				return reduced.Value.(string)
+			}
+			return reduced.Source
+		}
+		return resolved
 	}
 	inputName := ""
 	for _, candidate := range match[1:] {


### PR DESCRIPTION
## Why

Reusable workflows fail static graph construction when a condition combines a status function with an input:

```yaml
if: ${{ !cancelled() && inputs.enabled }}
```

Input substitution produces `${{ !cancelled() && true }}`, but partial template reduction rejects the status function and restores the original `inputs.enabled`. The caller then reports only `reusable workflow could not be resolved`.

## What

Preserve the safely substituted residual condition when optional partial reduction cannot evaluate it. The existing job and step condition profiles still reject unsupported functions and contexts.

Nested reusable-workflow failures now keep the actionable callee error in the diagnostic while retaining the parent call-site attribution.

Fixes [PB-3285](https://linear.app/buildkite/issue/PB-3285/preserve-status-function-conditions-after-reusable-workflow-input).
