### PR TITLE
fix: underline offending line and fix line linking

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -264,7 +264,13 @@ on disk after parsing do not change which source revision the diagnostic links t
 Annotations and generated failure logs include a real configuration excerpt
 where safe: literal action/workflow references in `uses`, standard Ubuntu,
 Windows, or macOS `runs-on` labels, and built-in step `shell` names. Excerpts
-retain the parsed line numbers and mark the offending line with `>`.
+retain the parsed line numbers, mark the offending line with `>`, and underline
+the reference, runner label, or shell with `^`.
+Standalone trigger filter keys, such as `branches:` and `types:`, also appear
+with an underline. Filter values and inline filter declarations are omitted.
+Rejected filters, invalid filter patterns, and unsupported activity types link
+to their filter key. Errors without a corresponding field retain the event
+declaration location.
 Only eligible adjacent lines are included. Scripts, `env`, `with`, comments,
 expressions, aliases, malformed YAML, and other unclassified content are omitted.
 Capture is limited to 240 bytes per line and 16 KiB per workflow; excerpts are

--- a/internal/buildkite/triggers.go
+++ b/internal/buildkite/triggers.go
@@ -119,6 +119,16 @@ func unsupportedTriggerEvent(err error) bool {
 	return errors.As(err, &unsupported)
 }
 
+// TriggerError retains the declaration responsible for a translation failure.
+// The original error remains available for unsupported-event/filter handling.
+type TriggerError struct {
+	Position workflow.Position
+	Err      error
+}
+
+func (e *TriggerError) Error() string { return e.Err.Error() }
+func (e *TriggerError) Unwrap() error { return e.Err }
+
 // UnsupportedPathFiltersError reports a trigger that cannot be translated
 // without changing its path-filter semantics.
 type UnsupportedPathFiltersError struct {
@@ -428,7 +438,12 @@ func LiveEventPredicate(event string) string {
 	}
 }
 
-func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpressions, snapshot TriggerEventSnapshot, selected bool) (string, bool, error) {
+func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpressions, snapshot TriggerEventSnapshot, selected bool) (condition string, contributes bool, err error) {
+	defer func() {
+		if err != nil && t.Position.Line > 0 {
+			err = &TriggerError{Position: t.Position, Err: err}
+		}
+	}()
 	if !SupportedTriggerEvent(t.Event) {
 		return "", false, &UnsupportedTriggerEventError{Event: t.Event}
 	}

--- a/internal/buildkite/triggers.go
+++ b/internal/buildkite/triggers.go
@@ -129,6 +129,40 @@ type TriggerError struct {
 func (e *TriggerError) Error() string { return e.Err.Error() }
 func (e *TriggerError) Unwrap() error { return e.Err }
 
+func configuredTriggerFilter(t workflow.Trigger, names ...string) string {
+	values := map[string][]string{
+		"branches": t.Branches, "branches-ignore": t.BranchesIgnore,
+		"tags": t.Tags, "tags-ignore": t.TagsIgnore,
+		"paths": t.Paths, "paths-ignore": t.PathsIgnore,
+		"types": t.Types, "workflows": t.Workflows,
+	}
+	for _, name := range names {
+		if values[name] != nil {
+			return name
+		}
+	}
+	return ""
+}
+
+func triggerFilterError(t workflow.Trigger, err error, names ...string) error {
+	position := t.Position
+	for _, name := range names {
+		if span, ok := t.FilterSpans[name]; ok {
+			position = span.Start
+			break
+		}
+	}
+	return &TriggerError{Position: position, Err: err}
+}
+
+func unsupportedEventFilter(t workflow.Trigger, names ...string) error {
+	if len(names) == 0 {
+		names = []string{"branches", "branches-ignore", "tags", "tags-ignore", "workflows"}
+	}
+	name := configuredTriggerFilter(t, names...)
+	return triggerFilterError(t, fmt.Errorf("%s does not support the %s filter; remove this filter or move the check into a job or step condition using the event payload", t.Event, name), name)
+}
+
 // UnsupportedPathFiltersError reports a trigger that cannot be translated
 // without changing its path-filter semantics.
 type UnsupportedPathFiltersError struct {
@@ -440,7 +474,8 @@ func LiveEventPredicate(event string) string {
 
 func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpressions, snapshot TriggerEventSnapshot, selected bool) (condition string, contributes bool, err error) {
 	defer func() {
-		if err != nil && t.Position.Line > 0 {
+		var located *TriggerError
+		if err != nil && t.Position.Line > 0 && !errors.As(err, &located) {
 			err = &TriggerError{Position: t.Position, Err: err}
 		}
 	}()
@@ -450,10 +485,10 @@ func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpression
 	pathFilters := t.Paths != nil || t.PathsIgnore != nil
 	if pathFilters && t.Event != "merge_group" {
 		if t.Event != "push" && t.Event != "pull_request" {
-			return "", false, &UnsupportedPathFiltersError{Event: t.Event}
+			return "", false, triggerFilterError(t, &UnsupportedPathFiltersError{Event: t.Event}, "paths", "paths-ignore")
 		}
 		if _, err := pathFiltersMatch(nil, t.Paths, t.PathsIgnore); err != nil {
-			return "", false, fmt.Errorf("%s paths: %w", t.Event, err)
+			return "", false, triggerFilterError(t, fmt.Errorf("%s paths: %w", t.Event, err), "paths", "paths-ignore")
 		}
 	}
 	switch t.Event {
@@ -461,7 +496,7 @@ func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpression
 		return "", false, nil
 	case "deployment", "deployment_status", "create", "delete":
 		if hasWebhookFilters(t) {
-			return "", false, fmt.Errorf("%s has unsupported filters; use job or step conditions on github.event", t.Event)
+			return "", false, unsupportedEventFilter(t, "types", "branches", "branches-ignore", "tags", "tags-ignore", "paths", "paths-ignore", "workflows")
 		}
 		if expressions.EventPredicate == "" {
 			return "", false, fmt.Errorf("%s requires an effective event predicate", t.Event)
@@ -469,7 +504,7 @@ func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpression
 		return expressions.EventPredicate, true, nil
 	case "workflow_dispatch":
 		if hasWebhookFilters(t) {
-			return "", false, fmt.Errorf("workflow_dispatch has unsupported webhook filters")
+			return "", false, unsupportedEventFilter(t, "types", "branches", "branches-ignore", "tags", "tags-ignore", "paths", "paths-ignore", "workflows")
 		}
 		if expressions.EventPredicate == "" {
 			return "", false, fmt.Errorf("workflow_dispatch requires an effective event predicate")
@@ -477,7 +512,7 @@ func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpression
 		return expressions.EventPredicate, true, nil
 	case "schedule":
 		if hasWebhookFilters(t) {
-			return "", false, fmt.Errorf("schedule has unsupported webhook filters")
+			return "", false, unsupportedEventFilter(t, "types", "branches", "branches-ignore", "tags", "tags-ignore", "paths", "paths-ignore", "workflows")
 		}
 		// Buildkite does not expose the identity of the schedule that created a
 		// build. Cron ownership therefore stays in Buildkite, and every scheduled
@@ -488,7 +523,7 @@ func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpression
 		return expressions.EventPredicate, true, nil
 	case "push":
 		if t.Types != nil || t.Workflows != nil {
-			return "", false, fmt.Errorf("push has unsupported filters")
+			return "", false, unsupportedEventFilter(t, "types", "workflows")
 		}
 		if expressions.EventPredicate == "" || expressions.Branch == "" || expressions.Tag == "" {
 			return "", false, fmt.Errorf("push requires effective event, branch, and tag expressions")
@@ -499,11 +534,11 @@ func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpression
 		parts := []string{expressions.EventPredicate}
 		branch, hasBranchFilter, err := refFilters(expressions.Branch, t.Branches, t.BranchesIgnore)
 		if err != nil {
-			return "", false, fmt.Errorf("push branches: %w", err)
+			return "", false, triggerFilterError(t, fmt.Errorf("push branches: %w", err), "branches", "branches-ignore")
 		}
 		tag, hasTagFilter, err := refFilters(expressions.Tag, t.Tags, t.TagsIgnore)
 		if err != nil {
-			return "", false, fmt.Errorf("push tags: %w", err)
+			return "", false, triggerFilterError(t, fmt.Errorf("push tags: %w", err), "tags", "tags-ignore")
 		}
 		switch {
 		case hasBranchFilter && hasTagFilter:
@@ -521,7 +556,7 @@ func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpression
 				} else if hasBranchFilter {
 					branchMatches, err = refFilterMatches(*snapshot.Branch, t.Branches, t.BranchesIgnore)
 					if err != nil {
-						return "", false, fmt.Errorf("push branches: %w", err)
+						return "", false, triggerFilterError(t, fmt.Errorf("push branches: %w", err), "branches", "branches-ignore")
 					}
 				}
 				if !branchMatches {
@@ -529,11 +564,11 @@ func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpression
 				}
 			}
 			if !snapshot.ChangedPaths.available() {
-				return "", false, &UnsupportedPathFiltersError{Event: t.Event, Reason: snapshot.ChangedPaths.UnavailableReason}
+				return "", false, triggerFilterError(t, &UnsupportedPathFiltersError{Event: t.Event, Reason: snapshot.ChangedPaths.UnavailableReason}, "paths", "paths-ignore")
 			}
 			matches, err := pathFiltersMatch(snapshot.ChangedPaths.Paths, t.Paths, t.PathsIgnore)
 			if err != nil {
-				return "", false, fmt.Errorf("push paths: %w", err)
+				return "", false, triggerFilterError(t, fmt.Errorf("push paths: %w", err), "paths", "paths-ignore")
 			}
 			if !matches {
 				return "", false, nil
@@ -542,7 +577,7 @@ func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpression
 		return strings.Join(parts, " && "), true, nil
 	case "pull_request":
 		if t.Tags != nil || t.TagsIgnore != nil || t.Workflows != nil {
-			return "", false, fmt.Errorf("pull_request tag filters are unsupported")
+			return "", false, unsupportedEventFilter(t, "tags", "tags-ignore", "workflows")
 		}
 		if expressions.EventPredicate == "" || expressions.PullRequestAction == "" {
 			return "", false, fmt.Errorf("pull_request requires effective event and action expressions")
@@ -553,14 +588,14 @@ func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpression
 		parts := []string{expressions.EventPredicate}
 		hasBranchFilter := t.Branches != nil || t.BranchesIgnore != nil
 		if hasBranchFilter && expressions.PullRequestBaseBranch == "" {
-			return "", false, fmt.Errorf("pull_request branch filters require a base branch expression")
+			return "", false, triggerFilterError(t, fmt.Errorf("pull_request branch filters require a base branch expression"), "branches", "branches-ignore")
 		}
 		if hasBranchFilter && expressions.PullRequestBaseBranch == "null" {
-			return "", false, fmt.Errorf("pull_request branch filters require payload.pull_request.base.ref")
+			return "", false, triggerFilterError(t, fmt.Errorf("pull_request branch filters require payload.pull_request.base.ref"), "branches", "branches-ignore")
 		}
 		b, hasBranchFilter, err := refFilters(expressions.PullRequestBaseBranch, t.Branches, t.BranchesIgnore)
 		if err != nil {
-			return "", false, fmt.Errorf("pull_request branches: %w", err)
+			return "", false, triggerFilterError(t, fmt.Errorf("pull_request branches: %w", err), "branches", "branches-ignore")
 		}
 		if hasBranchFilter {
 			parts = append(parts, b)
@@ -570,12 +605,12 @@ func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpression
 			types = []string{"opened", "synchronize", "reopened"}
 		}
 		if len(types) == 0 {
-			return "", false, fmt.Errorf("pull_request types is explicitly empty")
+			return "", false, triggerFilterError(t, fmt.Errorf("pull_request types is explicitly empty"), "types")
 		}
 		var actions []string
 		for _, a := range types {
 			if !supportedPullRequestAction[a] {
-				return "", false, fmt.Errorf("pull_request activity type %q cannot be mapped exactly", a)
+				return "", false, triggerFilterError(t, fmt.Errorf("pull_request activity type %q cannot be mapped exactly", a), "types")
 			}
 			actions = append(actions, expressions.PullRequestAction+` == `+yamlScalar(a))
 		}
@@ -587,18 +622,18 @@ func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpression
 			if snapshot.PullRequestBaseBranch != nil {
 				matches, err := refFilterMatches(*snapshot.PullRequestBaseBranch, t.Branches, t.BranchesIgnore)
 				if err != nil {
-					return "", false, fmt.Errorf("pull_request branches: %w", err)
+					return "", false, triggerFilterError(t, fmt.Errorf("pull_request branches: %w", err), "branches", "branches-ignore")
 				}
 				if !matches {
 					return strings.Join(parts, " && "), true, nil
 				}
 			}
 			if !snapshot.ChangedPaths.available() {
-				return "", false, &UnsupportedPathFiltersError{Event: t.Event, Reason: snapshot.ChangedPaths.UnavailableReason}
+				return "", false, triggerFilterError(t, &UnsupportedPathFiltersError{Event: t.Event, Reason: snapshot.ChangedPaths.UnavailableReason}, "paths", "paths-ignore")
 			}
 			matches, err := pathFiltersMatch(snapshot.ChangedPaths.Paths, t.Paths, t.PathsIgnore)
 			if err != nil {
-				return "", false, fmt.Errorf("pull_request paths: %w", err)
+				return "", false, triggerFilterError(t, fmt.Errorf("pull_request paths: %w", err), "paths", "paths-ignore")
 			}
 			if !matches {
 				return "", false, nil
@@ -607,7 +642,7 @@ func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpression
 		return strings.Join(parts, " && "), true, nil
 	case "merge_group":
 		if t.Tags != nil || t.TagsIgnore != nil || t.Workflows != nil {
-			return "", false, fmt.Errorf("merge_group has unsupported filters")
+			return "", false, unsupportedEventFilter(t, "tags", "tags-ignore", "workflows")
 		}
 		if expressions.EventPredicate == "" || expressions.MergeGroupAction == "" {
 			return "", false, fmt.Errorf("merge_group requires effective event and action expressions")
@@ -621,11 +656,11 @@ func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpression
 		parts := []string{expressions.EventPredicate, expressions.MergeGroupAction + ` == "checks_requested"`}
 		hasBranchFilter := t.Branches != nil || t.BranchesIgnore != nil
 		if hasBranchFilter && (expressions.MergeGroupBaseBranch == "" || expressions.MergeGroupBaseBranch == "null") {
-			return "", false, fmt.Errorf("merge_group branch filters require payload.merge_group.base_ref")
+			return "", false, triggerFilterError(t, fmt.Errorf("merge_group branch filters require payload.merge_group.base_ref"), "branches", "branches-ignore")
 		}
 		branch, hasBranchFilter, err := refFilters(expressions.MergeGroupBaseBranch, t.Branches, t.BranchesIgnore)
 		if err != nil {
-			return "", false, fmt.Errorf("merge_group branches: %w", err)
+			return "", false, triggerFilterError(t, fmt.Errorf("merge_group branches: %w", err), "branches", "branches-ignore")
 		}
 		if hasBranchFilter {
 			parts = append(parts, branch)
@@ -633,14 +668,14 @@ func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpression
 		if t.Types != nil {
 			for _, activity := range t.Types {
 				if activity != "checks_requested" {
-					return "", false, fmt.Errorf("merge_group type %q is unsupported. checks_requested is the only merge queue activity currently mapped. Set types: [checks_requested]. If you need another merge_group type, open an issue in https://github.com/buildkite/buildkite-gha so we can prioritize it", activity)
+					return "", false, triggerFilterError(t, fmt.Errorf("merge_group type %q is unsupported. checks_requested is the only merge queue activity currently mapped. Set types: [checks_requested]. If you need another merge_group type, open an issue in https://github.com/buildkite/buildkite-gha so we can prioritize it", activity), "types")
 				}
 			}
 		}
 		return strings.Join(parts, " && "), true, nil
 	case "release":
 		if t.Branches != nil || t.BranchesIgnore != nil || t.Tags != nil || t.TagsIgnore != nil || t.Paths != nil || t.PathsIgnore != nil || t.Workflows != nil {
-			return "", false, fmt.Errorf("release has unsupported filters")
+			return "", false, unsupportedEventFilter(t)
 		}
 		if expressions.EventPredicate == "" || expressions.ReleaseAction == "" {
 			return "", false, fmt.Errorf("release requires effective event and action expressions")
@@ -652,19 +687,19 @@ func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpression
 			return "", false, fmt.Errorf("on: release needs a types list. A bare release covers every release event, while the currently supported types are exactly published, created, and released. Use on: {release: {types: [published]}}. If you need another release type, open an issue in https://github.com/buildkite/buildkite-gha so we can prioritize it")
 		}
 		if len(t.Types) == 0 {
-			return "", false, fmt.Errorf("release types is explicitly empty")
+			return "", false, triggerFilterError(t, fmt.Errorf("release types is explicitly empty"), "types")
 		}
 		actions := make([]string, 0, len(t.Types))
 		for _, action := range t.Types {
 			if action != "published" && action != "created" && action != "released" {
-				return "", false, fmt.Errorf("release activity type %q cannot be mapped exactly", action)
+				return "", false, triggerFilterError(t, fmt.Errorf("release activity type %q cannot be mapped exactly", action), "types")
 			}
 			actions = append(actions, expressions.ReleaseAction+` == `+yamlScalar(action))
 		}
 		return expressions.EventPredicate + " && (" + strings.Join(actions, " || ") + ")", true, nil
 	case "label":
 		if t.Branches != nil || t.BranchesIgnore != nil || t.Tags != nil || t.TagsIgnore != nil || t.Workflows != nil {
-			return "", false, fmt.Errorf("label has unsupported filters")
+			return "", false, unsupportedEventFilter(t)
 		}
 		if expressions.EventPredicate == "" || expressions.LabelAction == "" || expressions.LabelAction == "null" {
 			return "", false, fmt.Errorf("label requires effective event and action expressions")
@@ -675,14 +710,14 @@ func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpression
 		actions := make([]string, 0, len(t.Types))
 		for _, action := range t.Types {
 			if action != "created" && action != "edited" && action != "deleted" {
-				return "", false, fmt.Errorf("label activity type %q cannot be mapped exactly", action)
+				return "", false, triggerFilterError(t, fmt.Errorf("label activity type %q cannot be mapped exactly", action), "types")
 			}
 			actions = append(actions, expressions.LabelAction+` == `+yamlScalar(action))
 		}
 		return expressions.EventPredicate + " && (" + strings.Join(actions, " || ") + ")", true, nil
 	case "issues":
 		if t.Branches != nil || t.BranchesIgnore != nil || t.Tags != nil || t.TagsIgnore != nil || t.Workflows != nil {
-			return "", false, fmt.Errorf("issues has unsupported filters")
+			return "", false, unsupportedEventFilter(t)
 		}
 		if expressions.EventPredicate == "" || expressions.IssuesAction == "" {
 			return "", false, fmt.Errorf("issues requires effective event and action expressions")
@@ -696,14 +731,14 @@ func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpression
 		actions := make([]string, 0, len(t.Types))
 		for _, action := range t.Types {
 			if !supportedIssuesAction[action] {
-				return "", false, fmt.Errorf("issues activity type %q cannot be mapped exactly", action)
+				return "", false, triggerFilterError(t, fmt.Errorf("issues activity type %q cannot be mapped exactly", action), "types")
 			}
 			actions = append(actions, expressions.IssuesAction+` == `+yamlScalar(action))
 		}
 		return expressions.EventPredicate + " && (" + strings.Join(actions, " || ") + ")", true, nil
 	case "pull_request_review", "pull_request_review_comment":
 		if t.Branches != nil || t.BranchesIgnore != nil || t.Tags != nil || t.TagsIgnore != nil || t.Workflows != nil {
-			return "", false, fmt.Errorf("%s has unsupported filters", t.Event)
+			return "", false, unsupportedEventFilter(t)
 		}
 		if expressions.EventPredicate == "" || expressions.PullRequestReviewAction == "" || expressions.PullRequestReviewAction == "null" {
 			return "", false, fmt.Errorf("%s requires effective event and action expressions", t.Event)
@@ -717,14 +752,14 @@ func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpression
 		actions := make([]string, 0, len(t.Types))
 		for _, action := range t.Types {
 			if !SupportedPullRequestReviewAction(t.Event, action) {
-				return "", false, fmt.Errorf("%s activity type %q cannot be mapped exactly", t.Event, action)
+				return "", false, triggerFilterError(t, fmt.Errorf("%s activity type %q cannot be mapped exactly", t.Event, action), "types")
 			}
 			actions = append(actions, expressions.PullRequestReviewAction+` == `+yamlScalar(action))
 		}
 		return expressions.EventPredicate + " && (" + strings.Join(actions, " || ") + ")", true, nil
 	case "issue_comment":
 		if t.Branches != nil || t.BranchesIgnore != nil || t.Tags != nil || t.TagsIgnore != nil || t.Workflows != nil {
-			return "", false, fmt.Errorf("issue_comment has unsupported filters")
+			return "", false, unsupportedEventFilter(t)
 		}
 		if expressions.EventPredicate == "" || expressions.IssueCommentAction == "" {
 			return "", false, fmt.Errorf("issue_comment requires effective event and action expressions")
@@ -738,7 +773,7 @@ func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpression
 		actions := make([]string, 0, len(t.Types))
 		for _, action := range t.Types {
 			if !supportedIssueCommentAction[action] {
-				return "", false, fmt.Errorf("issue_comment activity type %q cannot be mapped exactly", action)
+				return "", false, triggerFilterError(t, fmt.Errorf("issue_comment activity type %q cannot be mapped exactly", action), "types")
 			}
 			actions = append(actions, expressions.IssueCommentAction+` == `+yamlScalar(action))
 		}

--- a/internal/buildkite/triggers_test.go
+++ b/internal/buildkite/triggers_test.go
@@ -1,11 +1,52 @@
 package buildkite
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/buildkite/buildkite-gha/internal/workflow"
 )
+
+func TestTriggerFilterErrorLocations(t *testing.T) {
+	for _, test := range []struct {
+		event, filter, value, message string
+	}{
+		{"pull_request_review", "branches", "[main]", "does not support the branches filter"},
+		{"issue_comment", "branches-ignore", "[main]", "does not support the branches-ignore filter"},
+		{"merge_group", "tags-ignore", "[v1]", "does not support the tags-ignore filter"},
+		{"pull_request", "workflows", "[CI]", "does not support the workflows filter"},
+		{"push", "types", "[created]", "does not support the types filter"},
+		{"release", "branches", "[main]", "does not support the branches filter"},
+		{"deployment", "types", "[created]", "does not support the types filter"},
+		{"push", "branches-ignore", "['!main']", "cannot be negated"},
+		{"push", "tags", "['!v1']", "must follow a positive"},
+		{"pull_request", "paths-ignore", "['!src/**']", "cannot be negated"},
+		{"issues", "paths", "['src/**']", "path filters are unsupported"},
+		{"release", "types", "[edited]", "cannot be mapped exactly"},
+		{"merge_group", "types", "[destroyed]", "checks_requested is the only"},
+	} {
+		t.Run(test.event+"/"+test.filter, func(t *testing.T) {
+			// Quoted, inline declarations still locate the key without exposing values.
+			source := "# header\non:\n  " + test.event + ":\n    '" + test.filter + "': " + test.value + "\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"
+			parsed, err := workflow.Parse("workflow.yml", []byte(source))
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = ValidateTriggerConditions(parsed.Triggers)
+			var located *TriggerError
+			if !errors.As(err, &located) || located.Position != (workflow.Position{Line: 4, Column: 5}) || !strings.Contains(err.Error(), test.message) {
+				t.Fatalf("error = %v, location = %#v", err, located)
+			}
+			if test.event == "issues" && test.filter == "paths" {
+				var unsupported *UnsupportedPathFiltersError
+				if !errors.As(err, &unsupported) {
+					t.Fatal("lost typed path-filter error")
+				}
+			}
+		})
+	}
+}
 
 func TestUnfilteredWebhookTriggerConditions(t *testing.T) {
 	for _, event := range []string{"deployment", "deployment_status", "create", "delete"} {
@@ -133,21 +174,21 @@ func TestTranslateTriggerConditionRejectsUnsafeTriggers(t *testing.T) {
 		{name: "leading negative", triggers: []workflow.Trigger{{Event: "push", Branches: []string{"!release/**"}}}, want: "must follow a positive"},
 		{name: "unsupported PR type", triggers: []workflow.Trigger{{Event: "pull_request", Types: []string{"not-real"}}}, want: "cannot be mapped exactly"},
 		{name: "unsupported merge group type", triggers: []workflow.Trigger{{Event: "merge_group", Types: []string{"destroyed"}}}, want: `merge_group type "destroyed" is unsupported`},
-		{name: "merge group tags", triggers: []workflow.Trigger{{Event: "merge_group", Tags: []string{"v*"}}}, want: "unsupported filters"},
+		{name: "merge group tags", triggers: []workflow.Trigger{{Event: "merge_group", Tags: []string{"v*"}}}, want: "does not support the tags filter"},
 		{name: "bare release", triggers: []workflow.Trigger{{Event: "release"}}, want: "on: release needs a types list"},
 		{name: "release unpublished", triggers: []workflow.Trigger{{Event: "release", Types: []string{"unpublished"}}}, want: "cannot be mapped exactly"},
 		{name: "release edited", triggers: []workflow.Trigger{{Event: "release", Types: []string{"edited"}}}, want: "cannot be mapped exactly"},
 		{name: "release deleted", triggers: []workflow.Trigger{{Event: "release", Types: []string{"deleted"}}}, want: "cannot be mapped exactly"},
 		{name: "release prereleased", triggers: []workflow.Trigger{{Event: "release", Types: []string{"prereleased"}}}, want: "cannot be mapped exactly"},
-		{name: "release branch filter", triggers: []workflow.Trigger{{Event: "release", Types: []string{"published"}, Branches: []string{"main"}}}, want: "unsupported filters"},
+		{name: "release branch filter", triggers: []workflow.Trigger{{Event: "release", Types: []string{"published"}, Branches: []string{"main"}}}, want: "does not support the branches filter"},
 		{name: "release paths", triggers: []workflow.Trigger{{Event: "release", Types: []string{"published"}, Paths: []string{"src/**"}}}, want: "path filters are unsupported"},
 		{name: "unknown issues type", triggers: []workflow.Trigger{{Event: "issues", Types: []string{"not-real"}}}, want: `issues activity type "not-real" cannot be mapped exactly`},
-		{name: "issues branches", triggers: []workflow.Trigger{{Event: "issues", Branches: []string{"main"}}}, want: "issues has unsupported filters"},
-		{name: "issues tags", triggers: []workflow.Trigger{{Event: "issues", Tags: []string{"v*"}}}, want: "issues has unsupported filters"},
+		{name: "issues branches", triggers: []workflow.Trigger{{Event: "issues", Branches: []string{"main"}}}, want: "issues does not support the branches filter"},
+		{name: "issues tags", triggers: []workflow.Trigger{{Event: "issues", Tags: []string{"v*"}}}, want: "issues does not support the tags filter"},
 		{name: "issues paths", triggers: []workflow.Trigger{{Event: "issues", Paths: []string{"src/**"}}}, want: "issues path filters are unsupported"},
-		{name: "issues workflows", triggers: []workflow.Trigger{{Event: "issues", Workflows: []string{"CI"}}}, want: "issues has unsupported filters"},
+		{name: "issues workflows", triggers: []workflow.Trigger{{Event: "issues", Workflows: []string{"CI"}}}, want: "issues does not support the workflows filter"},
 		{name: "unknown issue comment type", triggers: []workflow.Trigger{{Event: "issue_comment", Types: []string{"not-real"}}}, want: `issue_comment activity type "not-real" cannot be mapped exactly`},
-		{name: "issue comment branches", triggers: []workflow.Trigger{{Event: "issue_comment", Branches: []string{"main"}}}, want: "issue_comment has unsupported filters"},
+		{name: "issue comment branches", triggers: []workflow.Trigger{{Event: "issue_comment", Branches: []string{"main"}}}, want: "issue_comment does not support the branches filter"},
 		{name: "issue comment paths", triggers: []workflow.Trigger{{Event: "issue_comment", Paths: []string{"src/**"}}}, want: "issue_comment path filters are unsupported"},
 	}
 	for _, test := range tests {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -115,15 +115,15 @@ func TestRunValidateAndCompile(t *testing.T) {
 			{name: "unsupported event", trigger: "discussion", want: `unsupported GitHub trigger event "discussion"`},
 			{name: "malformed path filter", trigger: "push:\n    paths: ['!src/**']", want: "must follow a positive pattern"},
 			{name: "mixed branch filters", trigger: "push:\n    branches: [main]\n    branches-ignore: [release]", want: "include and ignore filters cannot be combined"},
-			{name: "pull request tag filter", trigger: "pull_request:\n    tags: [v1]", want: "pull_request tag filters are unsupported"},
+			{name: "pull request tag filter", trigger: "pull_request:\n    tags: [v1]", want: "pull_request does not support the tags filter"},
 			{name: "pull request activity", trigger: "pull_request:\n    types: [auto_merge_enabled, submitted]", want: `activity type "submitted" cannot be mapped exactly`},
 			{name: "bare release", trigger: "release", want: "on: release needs a types list"},
 			{name: "unsupported release activity", trigger: "release:\n    types: [edited]", want: `release activity type "edited" cannot be mapped exactly`},
-			{name: "release branch filter", trigger: "release:\n    types: [published]\n    branches: [main]", want: "release has unsupported filters"},
+			{name: "release branch filter", trigger: "release:\n    types: [published]\n    branches: [main]", want: "release does not support the branches filter"},
 			{name: "unknown issues activity", trigger: "issues:\n    types: [not-real]", want: `issues activity type "not-real" cannot be mapped exactly`},
-			{name: "issues branch filter", trigger: "issues:\n    branches: [main]", want: "issues has unsupported filters"},
+			{name: "issues branch filter", trigger: "issues:\n    branches: [main]", want: "issues does not support the branches filter"},
 			{name: "unknown issue comment activity", trigger: "issue_comment:\n    types: [not-real]", want: `issue_comment activity type "not-real" cannot be mapped exactly`},
-			{name: "issue comment branch filter", trigger: "issue_comment:\n    branches: [main]", want: "issue_comment has unsupported filters"},
+			{name: "issue comment branch filter", trigger: "issue_comment:\n    branches: [main]", want: "issue_comment does not support the branches filter"},
 		}
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {

--- a/internal/cli/diagnostic_excerpt_test.go
+++ b/internal/cli/diagnostic_excerpt_test.go
@@ -177,7 +177,7 @@ func TestDiagnosticExcerptsUseCapturedInputOnBothSurfaces(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, artifacts := generatedFailure(t.Context(), report, sourceLinkContext{})
-	const excerpt = "> 6 |       - uses: ./.github/actions/missing"
+	const excerpt = "> 6 |       - uses: ./.github/actions/missing\n    |               ^^^^^^^^^^^^^^^^^^^^^^^^^"
 	if !strings.Contains(string(artifacts[0].Contents), excerpt) || !strings.Contains(string(artifacts[1].Contents), "<pre><code>"+html.EscapeString(excerpt)+"</code></pre>") {
 		t.Fatalf("missing original excerpt: %s", artifacts)
 	}

--- a/internal/cli/diagnostic_excerpt_test.go
+++ b/internal/cli/diagnostic_excerpt_test.go
@@ -10,9 +10,48 @@ import (
 	"testing"
 
 	actionsource "github.com/buildkite/buildkite-gha/internal/action/source"
+	buildkitepipeline "github.com/buildkite/buildkite-gha/internal/buildkite"
 	"github.com/buildkite/buildkite-gha/internal/compatibility"
 	"github.com/buildkite/buildkite-gha/internal/compiler"
+	"github.com/buildkite/buildkite-gha/internal/workflow"
 )
+
+func TestTriggerFailureLinksDeclarationAfterLicenseHeader(t *testing.T) {
+	root := t.TempDir()
+	t.Chdir(root)
+	t.Setenv("BUILDKITE_BUILD_CHECKOUT_PATH", root)
+	const path = "pr-reviewed.yml"
+	// The rejected trigger is at 19:3, not the file start or the selected PR trigger.
+	source := []byte(strings.Repeat("# License header\n", 15) + "\nname: Reviewed\non:\n  pull_request_review:\n    types: [submitted, edited, dismissed]\n    branches: [trunk]\n  pull_request:\n    types: [opened]\n    branches: [trunk]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hello\n")
+	if err := os.WriteFile(path, source, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fixture := compatibility.NewProcessingReport(path, "")
+	sha := commitDiagnosticSources(t, root, &fixture)
+	parsed, err := workflow.Parse(path, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	validated, validationErr := compiler.Validate(path, source)
+	_, _, translationErr := buildkitepipeline.TranslateEventTriggerCondition(parsed.Triggers, "pull_request", buildkitepipeline.LiveTriggerConditionExpressions("true"), buildkitepipeline.TriggerEventSnapshot{})
+	if validationErr == nil || translationErr == nil {
+		t.Fatal("unsupported review filters were accepted")
+	}
+	for name, report := range map[string]compatibility.ProcessingReport{
+		"validation":  compatibility.InitialProcessingReport(path, "", false, validated, validationErr),
+		"translation": triggerFailureProcessingReport(workflowInput{Path: path, Source: source}, translationErr),
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, artifacts := generatedFailure(t.Context(), report, sourceLinkContext{serverURL: "https://github.com", repository: "owner/project", sha: sha})
+			for _, artifact := range artifacts {
+				text := string(artifact.Contents)
+				if !strings.Contains(text, path+":19:3") || !strings.Contains(text, "/blob/"+sha+"/"+path+"#L19") || !strings.Contains(text, "pull_request_review has unsupported filters") {
+					t.Errorf("diagnostic lost trigger position: %s", text)
+				}
+			}
+		})
+	}
+}
 
 func TestNestedRemoteParseFailureLinksOffendingWorkflow(t *testing.T) {
 	root := t.TempDir()

--- a/internal/cli/diagnostic_excerpt_test.go
+++ b/internal/cli/diagnostic_excerpt_test.go
@@ -16,13 +16,13 @@ import (
 	"github.com/buildkite/buildkite-gha/internal/workflow"
 )
 
-func TestTriggerFailureLinksDeclarationAfterLicenseHeader(t *testing.T) {
+func TestTriggerFailureLinksFilterAfterLicenseHeader(t *testing.T) {
 	root := t.TempDir()
 	t.Chdir(root)
 	t.Setenv("BUILDKITE_BUILD_CHECKOUT_PATH", root)
 	const path = "pr-reviewed.yml"
-	// The rejected trigger is at 19:3, not the file start or the selected PR trigger.
-	source := []byte(strings.Repeat("# License header\n", 15) + "\nname: Reviewed\non:\n  pull_request_review:\n    types: [submitted, edited, dismissed]\n    branches: [trunk]\n  pull_request:\n    types: [opened]\n    branches: [trunk]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hello\n")
+	// The rejected filter is at 21:5, not the review event or the selected PR trigger.
+	source := []byte(strings.Repeat("# License header\n", 15) + "\nname: Reviewed\non:\n  pull_request_review:\n    types: [submitted, edited, dismissed]\n    branches:\n      - private-branch\n  pull_request:\n    types: [opened]\n    branches: [trunk]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hello\n")
 	if err := os.WriteFile(path, source, 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -45,8 +45,11 @@ func TestTriggerFailureLinksDeclarationAfterLicenseHeader(t *testing.T) {
 			_, artifacts := generatedFailure(t.Context(), report, sourceLinkContext{serverURL: "https://github.com", repository: "owner/project", sha: sha})
 			for _, artifact := range artifacts {
 				text := string(artifact.Contents)
-				if !strings.Contains(text, path+":19:3") || !strings.Contains(text, "/blob/"+sha+"/"+path+"#L19") || !strings.Contains(text, "pull_request_review has unsupported filters") {
-					t.Errorf("diagnostic lost trigger position: %s", text)
+				if !strings.Contains(text, path+":21:5") || !strings.Contains(text, "/blob/"+sha+"/"+path+"#L21") || !strings.Contains(text, "pull_request_review does not support the branches filter") {
+					t.Errorf("diagnostic lost filter position: %s", text)
+				}
+				if !strings.Contains(text, "21 |     branches:\n     |     ^^^^^^^^") || !strings.Contains(text, "move the check into a job or step condition") || strings.Contains(text, "private-branch") {
+					t.Errorf("diagnostic lost safe filter explanation: %s", text)
 				}
 			}
 		})

--- a/internal/cli/validate_test.go
+++ b/internal/cli/validate_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -187,9 +188,11 @@ func TestValidatePublishesActionableTriggerDiagnostics(t *testing.T) {
 		workflow       string
 		wantMessage    string
 		wantAnnotation []string
+		line, column   int
 	}{
 		{
 			name: "unsupported merge group type",
+			line: 2, column: 3,
 			workflow: "on:\n  merge_group:\n    types: [destroyed]\n" +
 				"jobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo ok\n",
 			wantMessage: `merge_group type "destroyed" is unsupported. checks_requested is the only merge queue activity currently mapped. Set types: [checks_requested]. If you need another merge_group type, open an issue in https://github.com/buildkite/buildkite-gha so we can prioritize it`,
@@ -200,7 +203,8 @@ func TestValidatePublishesActionableTriggerDiagnostics(t *testing.T) {
 			},
 		},
 		{
-			name:        "bare release",
+			name: "bare release",
+			line: 1, column: 5,
 			workflow:    "on: release\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo ok\n",
 			wantMessage: `on: release needs a types list. A bare release covers every release event, while the currently supported types are exactly published, created, and released. Use on: {release: {types: [published]}}. If you need another release type, open an issue in https://github.com/buildkite/buildkite-gha so we can prioritize it`,
 			wantAnnotation: []string{
@@ -229,15 +233,15 @@ func TestValidatePublishesActionableTriggerDiagnostics(t *testing.T) {
 				t.Fatalf("diagnostics = %#v, want message %q", report.Diagnostics, test.wantMessage)
 			}
 			location := report.Diagnostics[0].Location
-			if location == nil || location.Path != workflowPath || location.Line != 1 || location.Column != 1 {
-				t.Fatalf("diagnostic location = %#v, want %s:1:1", location, workflowPath)
+			if location == nil || location.Path != workflowPath || location.Line != test.line || location.Column != test.column {
+				t.Fatalf("diagnostic location = %#v, want %s:%d:%d", location, workflowPath, test.line, test.column)
 			}
 			if len(runner.commands) != 1 || runner.commands[0].args[8] != "error" {
 				t.Fatalf("commands = %#v, want one error annotation", runner.commands)
 			}
 			annotation := string(runner.commands[0].stdin)
 			for _, want := range append(test.wantAnnotation,
-				`<code>`+workflowPath+`:1:1</code>`,
+				fmt.Sprintf("<code>%s:%d:%d</code>", workflowPath, test.line, test.column),
 				`open an issue in <a href="https://github.com/buildkite/buildkite-gha" target="_blank">buildkite/buildkite-gha</a> so we can prioritize it`,
 			) {
 				if !strings.Contains(annotation, want) {

--- a/internal/cli/validate_test.go
+++ b/internal/cli/validate_test.go
@@ -192,7 +192,7 @@ func TestValidatePublishesActionableTriggerDiagnostics(t *testing.T) {
 	}{
 		{
 			name: "unsupported merge group type",
-			line: 2, column: 3,
+			line: 3, column: 5,
 			workflow: "on:\n  merge_group:\n    types: [destroyed]\n" +
 				"jobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo ok\n",
 			wantMessage: `merge_group type "destroyed" is unsupported. checks_requested is the only merge queue activity currently mapped. Set types: [checks_requested]. If you need another merge_group type, open an issue in https://github.com/buildkite/buildkite-gha so we can prioritize it`,

--- a/internal/compatibility/processing_compiler.go
+++ b/internal/compatibility/processing_compiler.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/buildkite/buildkite-gha/internal/buildkite"
 	"github.com/buildkite/buildkite-gha/internal/compiler"
 	"github.com/buildkite/buildkite-gha/internal/workflowprocessing"
 )
@@ -305,6 +306,10 @@ func diagnosticFromError(defaultPath string, stage workflowprocessing.Stage, cod
 				message = match[4]
 			}
 		}
+	}
+	var trigger *buildkite.TriggerError
+	if errors.As(err, &trigger) && defaultPath != "" {
+		location = sourceLocation(defaultPath, trigger.Position.Line, trigger.Position.Column)
 	}
 	diagnostic := Diagnostic{
 		Level: "error", Code: code, Category: category, Stage: stage,

--- a/internal/workflow/diagnostic_source.go
+++ b/internal/workflow/diagnostic_source.go
@@ -23,7 +23,8 @@ var (
 
 // DiagnosticSource retains only configuration lines eligible for display.
 type DiagnosticSource struct {
-	lines map[int]string
+	lines      map[int]string
+	underlines map[int]string
 }
 
 // CaptureDiagnosticSource retains a deliberately narrow set of safe workflow
@@ -42,9 +43,10 @@ func CaptureDiagnosticSource(source []byte) *DiagnosticSource {
 	}
 	physical := bytes.Split(source, []byte{'\n'})
 	type candidate struct {
-		key  string
-		node *yaml.Node
-		step bool
+		key     string
+		node    *yaml.Node
+		step    bool
+		keyOnly bool
 	}
 	var candidates []candidate
 	add := func(key string, node *yaml.Node, valid func(string) bool, step bool) {
@@ -52,6 +54,21 @@ func CaptureDiagnosticSource(source []byte) *DiagnosticSource {
 			return
 		}
 		candidates = append(candidates, candidate{key: key, node: node, step: step})
+	}
+
+	for _, event := range orderedMappingValues(mappingEntries(root)["on"]) {
+		if event.Kind != yaml.MappingNode || event.Style != 0 || event.Alias != nil || event.Anchor != "" {
+			continue
+		}
+		for i := 0; i+1 < len(event.Content); i += 2 {
+			key := event.Content[i]
+			switch key.Value {
+			case "branches", "branches-ignore", "tags", "tags-ignore", "paths", "paths-ignore", "types", "workflows":
+				if key.Kind == yaml.ScalarNode && key.Style == 0 && key.Alias == nil && key.Anchor == "" {
+					candidates = append(candidates, candidate{key: key.Value, node: key, keyOnly: true})
+				}
+			}
+		}
 	}
 
 	for _, job := range orderedMappingValues(mappingEntries(root)["jobs"]) {
@@ -76,6 +93,7 @@ func CaptureDiagnosticSource(source []byte) *DiagnosticSource {
 	}
 	sort.Slice(candidates, func(i, j int) bool { return candidates[i].node.Line < candidates[j].node.Line })
 	eligible := make(map[int]string)
+	underlines := make(map[int]string)
 	copied := 0
 	for _, candidate := range candidates {
 		line := candidate.node.Line
@@ -83,16 +101,29 @@ func CaptureDiagnosticSource(source []byte) *DiagnosticSource {
 			continue
 		}
 		raw := bytes.TrimSuffix(physical[line-1], []byte{'\r'})
-		if len(raw) > maxDiagnosticLineSize || !physicalField(raw, candidate.key, candidate.node.Value, candidate.step) || copied+len(raw) > maxDiagnosticCopySize {
+		value := candidate.node.Value
+		if candidate.keyOnly {
+			if strings.TrimSpace(string(raw)) != candidate.key+":" {
+				continue
+			}
+			value = ""
+		}
+		if len(raw) > maxDiagnosticLineSize || !physicalField(raw, candidate.key, value, candidate.step) || copied+len(raw) > maxDiagnosticCopySize {
 			continue
 		}
 		eligible[line] = strings.Clone(string(raw))
+		if candidate.keyOnly {
+			underlines[line] = strings.Repeat(" ", candidate.node.Column-1) + strings.Repeat("^", len(candidate.key))
+		} else {
+			start := candidate.node.Column - 1
+			underlines[line] = strings.Repeat(" ", start) + strings.Repeat("^", len(bytes.TrimRight(raw[start:], " ")))
+		}
 		copied += len(raw)
 	}
 	if len(eligible) == 0 {
 		return nil
 	}
-	return &DiagnosticSource{lines: eligible}
+	return &DiagnosticSource{lines: eligible, underlines: underlines}
 }
 
 func orderedMappingValues(node *yaml.Node) []*yaml.Node {
@@ -170,6 +201,9 @@ func (source *DiagnosticSource) Excerpt(line int) string {
 			marker = ">"
 		}
 		fmt.Fprintf(&excerpt, "%s %*d | %s", marker, width, number, text)
+		if number == line && source.underlines[number] != "" {
+			fmt.Fprintf(&excerpt, "\n  %*s | %s", width, "", source.underlines[number])
+		}
 		if number != last {
 			excerpt.WriteByte('\n')
 		}

--- a/internal/workflow/diagnostic_source_test.go
+++ b/internal/workflow/diagnostic_source_test.go
@@ -12,7 +12,7 @@ func TestCaptureDiagnosticSourceExcerpt(t *testing.T) {
 	if captured == nil {
 		t.Fatal("CaptureDiagnosticSource returned nil")
 	}
-	want := "  6 |       - uses: actions/checkout@v4\n> 7 |       - shell: bash"
+	want := "  6 |       - uses: actions/checkout@v4\n> 7 |       - shell: bash\n    |                ^^^^"
 	if got := captured.Excerpt(7); got != want {
 		t.Fatalf("Excerpt(7) = %q, want %q", got, want)
 	}
@@ -22,7 +22,7 @@ func TestCaptureDiagnosticSourceExcerpt(t *testing.T) {
 	for i := range source {
 		source[i] = 'x'
 	}
-	if got := captured.Excerpt(4); got != "> 4 |     runs-on: 'ubuntu-24.04-arm64'" {
+	if got := captured.Excerpt(4); got != "> 4 |     runs-on: 'ubuntu-24.04-arm64'\n    |              ^^^^^^^^^^^^^^^^^^^^" {
 		t.Fatalf("captured source changed with input: %q", got)
 	}
 	var nilSource *DiagnosticSource
@@ -31,8 +31,26 @@ func TestCaptureDiagnosticSourceExcerpt(t *testing.T) {
 	}
 }
 
+func TestCaptureDiagnosticSourceFilterUnderline(t *testing.T) {
+	source := []byte("on:\r\n  pull_request_review:\r\n    branches-ignore:\r\n      - private-branch\r\n")
+	captured := CaptureDiagnosticSource(source)
+	want := "> 3 |     branches-ignore:\n    |     ^^^^^^^^^^^^^^^"
+	if got := captured.Excerpt(3); got != want {
+		t.Fatalf("filter excerpt = %q, want %q", got, want)
+	}
+	if got := captured.Excerpt(4); got != "" {
+		t.Fatalf("filter value was retained: %q", got)
+	}
+}
+
 func TestCaptureDiagnosticSourceRejectsUnsafeLines(t *testing.T) {
 	tests := map[string]string{
+		"inline filter":         "on:\n  pull_request_review:\n    branches: [private-branch]\n",
+		"filter comment":        "on:\n  pull_request_review:\n    branches: # private\n      - trunk\n",
+		"quoted filter key":     "on:\n  pull_request_review:\n    'branches':\n      - trunk\n",
+		"filter alias":          "on:\n  pull_request_review: &review\n    branches:\n      - trunk\n  pull_request: *review\n",
+		"filter in script":      "jobs:\n  x:\n    steps:\n      - run: |\n          branches:\n",
+		"unknown filter":        "on:\n  pull_request_review:\n    private-key:\n      - trunk\n",
 		"comment":               "jobs:\n  x:\n    runs-on: ubuntu-latest # token\n",
 		"credentials":           "jobs:\n  x:\n    uses: owner/repo@v1 password=secret\n",
 		"HTML in uses":          "jobs:\n  x:\n    uses: owner/repo@v1<!-- secret -->\n",

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -52,6 +52,7 @@ func (w Workflow) ReusableOnly() bool {
 type Trigger struct {
 	Event          string           `json:"event"`
 	Position       Position         `json:"position"`
+	FilterSpans    map[string]Span  `json:"-"`
 	Types          []string         `json:"types,omitempty"`
 	Branches       []string         `json:"branches,omitempty"`
 	BranchesIgnore []string         `json:"branches_ignore,omitempty"`

--- a/internal/workflow/parse.go
+++ b/internal/workflow/parse.go
@@ -64,6 +64,22 @@ func Parse(path string, source []byte) (*Workflow, error) {
 
 	owned := &Workflow{}
 	owned.Triggers = adaptTriggers(parsed.On)
+	// The raw mapping also retains keys such as types and workflows, whose
+	// positions are not preserved by actionlint's event model.
+	events := mappingEntries(mappingEntries(document.Content[0])["on"])
+	for i := range owned.Triggers {
+		trigger := &owned.Triggers[i]
+		node := events[trigger.Event]
+		if node == nil || node.Kind != yaml.MappingNode {
+			continue
+		}
+		trigger.FilterSpans = make(map[string]Span)
+		for j := 0; j+1 < len(node.Content); j += 2 {
+			key := node.Content[j]
+			position := Position{Line: key.Line, Column: key.Column}
+			trigger.FilterSpans[key.Value] = Span{Start: position, End: position}
+		}
+	}
 	if parsed.Name != nil {
 		owned.Name = parsed.Name.Value
 	}


### PR DESCRIPTION
## Description

Errors such as `pull_request_review` has unsupported filters don’t identify which filter failed. Source links can also point to the event declaration rather than the offending field.

## Changes

Identify rejected trigger filters and invalid activity types, link to their configuration, and underline safe excerpts in logs and annotations:

```sh
Error: pull_request_review does not support the branches filter;
remove this filter or move the check into a job or step condition using the event payload

Error source: .github/workflows/pr-reviewed.yml:21:5

> 21 |     branches:
     |     ^^^^^^^^
```

The same underlining applies to eligible `uses`, `runs-on`, and `shell` excerpts. Filter values and other potentially sensitive content remain excluded. Validation behavior is unchanged.