### PR TITLE
Show checkout-relative error source paths in logs

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -256,7 +256,8 @@ be fetched, the CLI keeps the location without guessing a revision.
 
 Local workflow links use the event's commit only when its file in the checkout's
 Git object database matches the bytes parsed. This includes local reusable
-workflows and early syntax errors. Annotations and generated failure logs keep
+workflows and early syntax errors. Logs and annotations display local source
+paths relative to the checkout when possible. They keep
 the location without a link for edited inputs, unavailable revisions, files
 outside the checkout, or files larger than the 1 MiB verification limit. Changes
 on disk after parsing do not change which source revision the diagnostic links to.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -250,9 +250,11 @@ result.
 For fetched public and private reusable workflows, source locations in
 annotations link to the resolved commit and line in the source repository,
 including nested local calls inside that repository. The link opens only for
-viewers with GitHub access to that repository. Generated failure logs include
-the same URL and a Buildkite `Open source` hyperlink. If the source could not
-be fetched, the CLI keeps the location without guessing a revision.
+viewers with GitHub access to that repository. Generated failure logs make the
+source path and coordinates an OSC 8 terminal hyperlink to the same URL, without
+a separate URL line. Terminals without hyperlink support display the label.
+If the source could not be fetched, the CLI keeps the location without guessing
+a revision.
 
 Local workflow links use the event's commit only when its file in the checkout's
 Git object database matches the bytes parsed. This includes local reusable

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1624,7 +1624,7 @@ func TestProcessingAnnotationResolvesPathsFromBelowCheckoutRoot(t *testing.T) {
 	}
 }
 
-func TestProcessingAnnotationResolvesCompilerLocationsFromCheckoutRoot(t *testing.T) {
+func TestProcessingDiagnosticsResolveCompilerLocationsFromCheckoutRoot(t *testing.T) {
 	repository := t.TempDir()
 	workingDirectory := filepath.Join(repository, ".github")
 	workflowDirectory := filepath.Join(workingDirectory, "workflows")
@@ -1650,6 +1650,12 @@ func TestProcessingAnnotationResolvesCompilerLocationsFromCheckoutRoot(t *testin
 	want := `<a href="https://github.com/owner/repo/blob/` + sha + `/.github/workflows/build-security.yml#L35"><code>.github/workflows/build-security.yml:35:13</code></a>`
 	if !strings.Contains(body, want) {
 		t.Fatalf("annotation = %q, want %q", body, want)
+	}
+	messages, _ := processingLog(t.Context(), report, sourceLinks, "Workflow diagnostics")
+	log := strings.Join(messages, "\n")
+	wantLog := "\x1b\\.github/workflows/build-security.yml:35:13\x1b]8;;\x1b\\"
+	if !strings.Contains(log, wantLog) || strings.Contains(log, ".github/.github/") {
+		t.Fatalf("log lost checkout-relative source location: %q", log)
 	}
 }
 
@@ -1679,6 +1685,11 @@ func TestProcessingDiagnosticsRetainNestedWorkflowSourceRoot(t *testing.T) {
 	_, summary := processingAnnotationWithin(t.Context(), report, sourceLinks, workflowCheckSummaryLimit, workflowCheckSummaryNotice, false)
 	if !strings.Contains(annotation, `href="`+wantLink+`"`) || !strings.Contains(summary, `href="`+wantLink+`"`) {
 		t.Fatalf("nested workflow location was not retained: annotation=%q summary=%q", annotation, summary)
+	}
+	messages, _ := processingLog(t.Context(), report, sourceLinks, "Workflow diagnostics")
+	wantLog := "\x1b]8;;" + wantLink + "\x1b\\nested/.github/workflows/build-security.yml:35:13\x1b]8;;\x1b\\"
+	if log := strings.Join(messages, "\n"); !strings.Contains(log, wantLog) {
+		t.Fatalf("log lost nested workflow source: %q", log)
 	}
 }
 

--- a/internal/cli/diagnostic_excerpt_test.go
+++ b/internal/cli/diagnostic_excerpt_test.go
@@ -255,7 +255,7 @@ func TestPluginProcessingFiltersUnknownRuntimeAndUsesNeutralWarningHeading(t *te
 		t.Fatal(err)
 	}
 	got := output.String()
-	if !strings.Contains(got, "Source: ci.yml:4:3") || strings.Contains(got, "Error source:") {
+	if !strings.Contains(got, "ci.yml:4:3") || strings.Contains(got, "Source:") || strings.Contains(got, "Error source:") {
 		t.Fatalf("warning source has misleading severity: %q", got)
 	}
 	if !strings.Contains(got, "Workflow diagnostics") || strings.Contains(got, "failed") || strings.Contains(got, "hidden") || strings.Contains(got, "^^^ +++") || strings.Contains(got, "Compilation:") {
@@ -281,7 +281,7 @@ func TestProcessingLogSanitizesTerminalControls(t *testing.T) {
 			t.Errorf("processing log retained unsafe sequence %q: %q", sequence, got)
 		}
 	}
-	for _, want := range []string{"Error: bad[31m message.", "More context.", "detail]8;;https://evil.example", "job=job[2J", "action=action", "Error source: path]8;;https:/evil.example:1"} {
+	for _, want := range []string{"Error: bad[31m message.", "More context.", "detail]8;;https://evil.example", "job=job[2J", "action=action", "path]8;;https:/evil.example:1"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("processing log lost ordinary text %q: %q", want, got)
 		}

--- a/internal/cli/diagnostic_excerpt_test.go
+++ b/internal/cli/diagnostic_excerpt_test.go
@@ -20,7 +20,8 @@ func TestTriggerFailureLinksFilterAfterLicenseHeader(t *testing.T) {
 	root := t.TempDir()
 	t.Chdir(root)
 	t.Setenv("BUILDKITE_BUILD_CHECKOUT_PATH", root)
-	const path = "pr-reviewed.yml"
+	const displayPath = "pr-reviewed.yml"
+	path := filepath.Join(root, displayPath)
 	// The rejected filter is at 21:5, not the review event or the selected PR trigger.
 	source := []byte(strings.Repeat("# License header\n", 15) + "\nname: Reviewed\non:\n  pull_request_review:\n    types: [submitted, edited, dismissed]\n    branches:\n      - private-branch\n  pull_request:\n    types: [opened]\n    branches: [trunk]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hello\n")
 	if err := os.WriteFile(path, source, 0o600); err != nil {
@@ -45,7 +46,7 @@ func TestTriggerFailureLinksFilterAfterLicenseHeader(t *testing.T) {
 			_, artifacts := generatedFailure(t.Context(), report, sourceLinkContext{serverURL: "https://github.com", repository: "owner/project", sha: sha})
 			for _, artifact := range artifacts {
 				text := string(artifact.Contents)
-				if !strings.Contains(text, path+":21:5") || !strings.Contains(text, "/blob/"+sha+"/"+path+"#L21") || !strings.Contains(text, "pull_request_review does not support the branches filter") {
+				if !strings.Contains(text, displayPath+":21:5") || !strings.Contains(text, "/blob/"+sha+"/"+displayPath+"#L21") || !strings.Contains(text, "pull_request_review does not support the branches filter") || strings.Contains(text, root) {
 					t.Errorf("diagnostic lost filter position: %s", text)
 				}
 				if !strings.Contains(text, "21 |     branches:\n     |     ^^^^^^^^") || !strings.Contains(text, "move the check into a job or step condition") || strings.Contains(text, "private-branch") {
@@ -280,7 +281,7 @@ func TestProcessingLogSanitizesTerminalControls(t *testing.T) {
 			t.Errorf("processing log retained unsafe sequence %q: %q", sequence, got)
 		}
 	}
-	for _, want := range []string{"Error: bad[31m message.", "More context.", "detail]8;;https://evil.example", "job=job[2J", "action=action", "Error source: path]8;;https://evil.example:1"} {
+	for _, want := range []string{"Error: bad[31m message.", "More context.", "detail]8;;https://evil.example", "job=job[2J", "action=action", "Error source: path]8;;https:/evil.example:1"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("processing log lost ordinary text %q: %q", want, got)
 		}

--- a/internal/cli/diagnostic_excerpt_test.go
+++ b/internal/cli/diagnostic_excerpt_test.go
@@ -46,11 +46,21 @@ func TestTriggerFailureLinksFilterAfterLicenseHeader(t *testing.T) {
 			_, artifacts := generatedFailure(t.Context(), report, sourceLinkContext{serverURL: "https://github.com", repository: "owner/project", sha: sha})
 			for _, artifact := range artifacts {
 				text := string(artifact.Contents)
-				if !strings.Contains(text, displayPath+":21:5") || !strings.Contains(text, "/blob/"+sha+"/"+displayPath+"#L21") || !strings.Contains(text, "pull_request_review does not support the branches filter") || strings.Contains(text, root) {
-					t.Errorf("diagnostic lost filter position: %s", text)
+				for _, want := range []string{
+					displayPath + ":21:5",
+					"/blob/" + sha + "/" + displayPath + "#L21",
+					"pull_request_review does not support the branches filter",
+					"21 |     branches:\n     |     ^^^^^^^^",
+					"move the check into a job or step condition",
+				} {
+					if !strings.Contains(text, want) {
+						t.Errorf("diagnostic missing %q: %s", want, text)
+					}
 				}
-				if !strings.Contains(text, "21 |     branches:\n     |     ^^^^^^^^") || !strings.Contains(text, "move the check into a job or step condition") || strings.Contains(text, "private-branch") {
-					t.Errorf("diagnostic lost safe filter explanation: %s", text)
+				for _, unwanted := range []string{root, "private-branch"} {
+					if strings.Contains(text, unwanted) {
+						t.Errorf("diagnostic exposed %q: %s", unwanted, text)
+					}
 				}
 			}
 		})

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -271,7 +271,11 @@ func processingLog(ctx context.Context, report compatibility.ProcessingReport, s
 			if diagnostic.Level == "warning" {
 				sourceLabel = "Source: "
 			}
-			message += "\n  \x1b[36m" + sourceLabel + terminalText(location.Path)
+			path := location.Path
+			if source := sourceLinks.sources[path]; source.Repository == "" {
+				path, _ = processingAnnotationWorkflowPath(path, sourceLinks.workflowSourceRoot)
+			}
+			message += "\n  \x1b[36m" + sourceLabel + terminalText(path)
 			if location.Line > 0 {
 				message += fmt.Sprintf(":%d", location.Line)
 				if location.Column > 0 {

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -225,7 +225,10 @@ func processingLog(ctx context.Context, report compatibility.ProcessingReport, s
 	if sourceLinks.localLinks == nil {
 		sourceLinks.localLinks = make(map[string]string)
 	}
-	workflowPath, _ := processingAnnotationWorkflowPath(report.Workflow, "")
+	workflowPath, workflowLinkable := processingAnnotationWorkflowPath(report.Workflow, "")
+	if workflowLinkable {
+		sourceLinks.workflowSourceRoot = processingWorkflowSourceRoot(report.Workflow)
+	}
 	messages := []string{
 		"\x1b[1;31m" + heading + "\x1b[0m",
 		"\x1b[1;36mWorkflow: " + terminalText(workflowPath) + "\x1b[0m",

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -267,25 +267,21 @@ func processingLog(ctx context.Context, report compatibility.ProcessingReport, s
 		}
 		if diagnostic.Location != nil {
 			location := diagnostic.Location
-			sourceLabel := "Error source: "
-			if diagnostic.Level == "warning" {
-				sourceLabel = "Source: "
-			}
 			path := location.Path
 			if source := sourceLinks.sources[path]; source.Repository == "" {
 				path, _ = processingAnnotationWorkflowPath(path, sourceLinks.workflowSourceRoot)
 			}
-			message += "\n  \x1b[36m" + sourceLabel + terminalText(path)
+			label := terminalText(path)
 			if location.Line > 0 {
-				message += fmt.Sprintf(":%d", location.Line)
+				label += fmt.Sprintf(":%d", location.Line)
 				if location.Column > 0 {
-					message += fmt.Sprintf(":%d", location.Column)
+					label += fmt.Sprintf(":%d", location.Column)
 				}
 			}
-			message += "\x1b[0m"
 			if link := sourceLinks.sourceLink(ctx, location.Path, location.Line); link != "" {
-				message += "\n  " + link + " \x1b]1339;url='" + link + "';content='Open source'\a"
+				label = "\x1b]8;;" + link + "\x1b\\" + label + "\x1b]8;;\x1b\\"
 			}
+			message += "\n  \x1b[36m" + label + "\x1b[0m"
 		}
 		if excerpt := sourceLinks.excerpt(diagnostic); excerpt != "" {
 			message += "\n\x1b[36m" + terminalText(excerpt) + "\x1b[0m"

--- a/internal/cli/upload_test.go
+++ b/internal/cli/upload_test.go
@@ -74,15 +74,15 @@ func TestGeneratedFailureLinksOnlyTheParsedLocalRevision(t *testing.T) {
 			}
 			_, artifacts := generatedFailure(t.Context(), report, sourceLinkContext{serverURL: "https://github.com", repository: "owner/repo", sha: test.revision})
 			log, annotation := string(artifacts[0].Contents), string(artifacts[1].Contents)
-			if !strings.Contains(log, "Error source: ci.yml:") || !strings.Contains(annotation, "ci.yml:") {
+			if !strings.Contains(log, "ci.yml:") || !strings.Contains(annotation, "ci.yml:") {
 				t.Fatalf("lost location: log=%q annotation=%q", log, annotation)
 			}
 			target := "https://github.com/owner/repo/blob/" + sha + "/ci.yml#L"
 			if test.linked {
-				if !strings.Contains(log, "\x1b]1339;url='"+target) || !strings.Contains(annotation, `href="`+target) {
+				if !strings.Contains(log, "\x1b]8;;"+target) || !strings.Contains(annotation, `href="`+target) {
 					t.Fatalf("lost verified link: log=%q annotation=%q", log, annotation)
 				}
-			} else if strings.Contains(log, "\x1b]1339;") || strings.Contains(annotation, "href=") {
+			} else if strings.Contains(log, "\x1b]8;") || strings.Contains(annotation, "href=") {
 				t.Fatalf("linked unverified content: log=%q annotation=%q", log, annotation)
 			}
 		})
@@ -142,8 +142,8 @@ func TestGeneratedFailureLinksFetchedRevisionInsteadOfCallerOrTag(t *testing.T) 
 	caller := sourceLinkContext{serverURL: "https://github.example.com", repository: "caller/project", sha: strings.Repeat("b", 40)}
 	_, artifacts := generatedFailure(t.Context(), report, caller)
 	message, annotation := string(artifacts[0].Contents), string(artifacts[1].Contents)
-	if !strings.Contains(message, "\n  "+target+" \x1b]1339;url='"+target+"';content='Open source'\a") {
-		t.Fatalf("log lacks safe hyperlink and plain URL: %q", message)
+	if !strings.Contains(message, "\x1b]8;;"+target+"\x1b\\"+display+":35:5\x1b]8;;\x1b\\") || strings.Count(message, target) != 1 || strings.Contains(message, "Open source") || strings.Contains(message, "Error source:") {
+		t.Fatalf("log lacks a single linked source label: %q", message)
 	}
 	if !strings.Contains(annotation, `<a href="`+target+`"><code>`+html.EscapeString(display)+`:35:5</code></a>`) {
 		t.Fatalf("annotation lost remote source link: %s", annotation)
@@ -151,7 +151,7 @@ func TestGeneratedFailureLinksFetchedRevisionInsteadOfCallerOrTag(t *testing.T) 
 	for _, invalid := range []string{"", "v2"} {
 		report.Sources[display] = compiler.WorkflowSourceReference{Repository: "owner/shared", Path: ".github/workflows/build's.yml", Commit: invalid}
 		_, artifacts = generatedFailure(t.Context(), report, caller)
-		if strings.Contains(string(artifacts[0].Contents), "\x1b]1339;") || strings.Contains(string(artifacts[1].Contents), "href=") {
+		if strings.Contains(string(artifacts[0].Contents), "\x1b]8;") || strings.Contains(string(artifacts[1].Contents), "href=") {
 			t.Fatalf("invented source link for revision %q: %s", invalid, artifacts)
 		}
 	}
@@ -180,15 +180,15 @@ func TestGeneratedFailureRetainsWorkflowAndDiagnosticSources(t *testing.T) {
 	message = strings.NewReplacer("\x1b[1;31m", "", "\x1b[1;36m", "", "\x1b[36m", "", "\x1b[0m", "").Replace(message)
 	for _, want := range []string{
 		"Workflow: .github/workflows/ci.yml",
-		"Error: Local action could not be found.\n  Check that the action directory exists. {job=build.test, instance=test-linux, action=./.github/actions/check, step=2}\n  Error source: .github/workflows/build.yml:35:5\n  detail: action.yml is missing",
-		"Error: Another job was rejected {job=publish}\n  Error source: .github/workflows/publish.yml:19",
+		"Error: Local action could not be found.\n  Check that the action directory exists. {job=build.test, instance=test-linux, action=./.github/actions/check, step=2}\n  .github/workflows/build.yml:35:5\n  detail: action.yml is missing",
+		"Error: Another job was rejected {job=publish}\n  .github/workflows/publish.yml:19",
 		"Error: Source unavailable",
 	} {
 		if !strings.Contains(message, want) {
 			t.Errorf("failure log missing %q: %s", want, message)
 		}
 	}
-	if strings.Count(message, "Error source:") != 2 || strings.Contains(message, ":19:0") {
+	if strings.Contains(message, "Error source:") || strings.Contains(message, ":19:0") {
 		t.Errorf("failure log invents source coordinates: %s", message)
 	}
 	for _, diagnostic := range report.Diagnostics {


### PR DESCRIPTION
## Changes

Don't show the entire path to the file error in CI, show it relative to the repo instead.