### PR TITLE
Send readable workflow diagnostics when imports exit zero

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -676,7 +676,17 @@ outcome, client version, duration, and bounded diagnostics. Diagnostics can
 identify a rejected feature with a `blocker` slug and bounded `blocker_detail`,
 such as `runner_label` and `windows-latest`. Distinct rejected values remain
 separate diagnostics even when they share a diagnostic code.
-For an unsuccessful command, they also contain a normalized user-visible error
+
+Workflow diagnostics include their message and detail in `message`, even when
+the importer exits zero after uploading failing steps for rejected workflows.
+Messages are normalized to one line and retain at most their first 1,024 UTF-8 bytes;
+`message_truncated` is true when text was shortened. `workflow_path` identifies
+the root workflow being imported, relative to the checkout when possible.
+Paths over 1,024 bytes or containing invalid UTF-8 or control characters are
+omitted rather than shortened. Deduplication includes the bounded message and
+workflow path, subject to the limit of 20 diagnostics per command.
+
+For an unsuccessful command, events also contain a normalized user-visible error
 message of at most 1,024 bytes. When a workflow diagnostic attributes the
 failure, the message is that diagnostic's text, kept whole so later job output
 cannot displace it. Otherwise it is the final bytes of the command's error
@@ -698,9 +708,9 @@ variables, command text, or secrets as separate properties. Blocker details
 come from workflow-authored configuration. Event-derived runner labels and
 environment expressions are omitted.
 
-Error output can include details already printed in the job log, such as
-workflow paths, action references, expressions, or invalid configuration
-values. Avoid putting secrets in error messages. Disable telemetry when this
-diagnostic context must stay inside the job.
+Diagnostic messages and error output can include details already printed in
+the job log, such as workflow paths, action references, expressions, or invalid
+configuration values. Avoid putting secrets in error messages. Disable
+telemetry when this diagnostic context must stay inside the job.
 
 Set `BUILDKITE_GHA_TELEMETRY_DISABLED=true` to disable telemetry. Missing Agent endpoint, job ID, or job token also disables it. Telemetry failures do not change command results.

--- a/internal/cli/telemetry.go
+++ b/internal/cli/telemetry.go
@@ -18,10 +18,7 @@ import (
 	"github.com/buildkite/buildkite-gha/internal/workflowprocessing"
 )
 
-const (
-	maxCommandTelemetryDiagnostics = 20
-	maxCommandErrorCaptureBytes    = 64 << 10
-)
+const maxCommandErrorCaptureBytes = 64 << 10
 
 func emitCommandTelemetry(ctx context.Context, command telemetry.Command, outcome telemetry.Outcome, version string, duration time.Duration, details telemetry.Details) {
 	client, err := telemetry.New(telemetry.Config{
@@ -66,7 +63,6 @@ type commandTelemetryDetails struct {
 	blocker        string
 	blockerDetail  string
 	diagnostics    []telemetry.Diagnostic
-	seen           map[telemetry.Diagnostic]bool
 	errorOutput    boundedTailBuffer
 }
 
@@ -155,17 +151,9 @@ func (d *commandTelemetryDetails) addActionRuntimeUnknown() {
 }
 
 func (d *commandTelemetryDetails) addDiagnostic(diagnostic telemetry.Diagnostic) {
-	if d.seen == nil {
-		d.seen = make(map[telemetry.Diagnostic]bool)
+	if diagnostics, err := telemetry.BoundedDiagnostics(append(d.diagnostics, diagnostic)); err == nil {
+		d.diagnostics = diagnostics
 	}
-	if d.seen[diagnostic] {
-		return
-	}
-	if len(d.diagnostics) == maxCommandTelemetryDiagnostics {
-		return
-	}
-	d.seen[diagnostic] = true
-	d.diagnostics = append(d.diagnostics, diagnostic)
 }
 
 func (d *commandTelemetryDetails) setBlocker(blocker, detail string) {

--- a/internal/cli/telemetry.go
+++ b/internal/cli/telemetry.go
@@ -66,12 +66,8 @@ type commandTelemetryDetails struct {
 	blocker        string
 	blockerDetail  string
 	diagnostics    []telemetry.Diagnostic
-	seen           map[telemetryDiagnosticKey]int
+	seen           map[telemetry.Diagnostic]bool
 	errorOutput    boundedTailBuffer
-}
-
-type telemetryDiagnosticKey struct {
-	code, blocker, blockerDetail string
 }
 
 func (d *commandTelemetryDetails) captureErrors(writer io.Writer) io.Writer {
@@ -103,12 +99,24 @@ func (d *commandTelemetryDetails) setFailureCode(code telemetry.FailureCode) {
 // handles, such as workflows emitted as failing pipeline steps, belong here so
 // they never attribute an unrelated later failure.
 func (d *commandTelemetryDetails) addReportDiagnostics(report compatibility.ProcessingReport) {
+	var workflowPath string
+	if report.Workflow != "" {
+		workflowPath, _ = processingAnnotationWorkflowPath(report.Workflow, "")
+	}
 	for _, diagnostic := range report.Diagnostics {
 		severity, ok := telemetrySeverity(diagnostic.Level)
 		if !ok || !allowlistedTelemetryDiagnosticCode(diagnostic.Code) {
 			continue
 		}
-		d.addDiagnostic(diagnostic.Code, severity, diagnostic.Blocker, diagnostic.BlockerDetail)
+		message := diagnostic.Message
+		if diagnostic.Detail != "" {
+			message += " " + diagnostic.Detail
+		}
+		d.addDiagnostic(telemetry.Diagnostic{
+			Code: diagnostic.Code, Severity: severity,
+			Blocker: diagnostic.Blocker, BlockerDetail: diagnostic.BlockerDetail,
+			Message: message, WorkflowPath: workflowPath,
+		})
 		if diagnostic.Level == "error" {
 			d.setBlocker(diagnostic.Blocker, diagnostic.BlockerDetail)
 		}
@@ -133,37 +141,31 @@ func (d *commandTelemetryDetails) observe(report compatibility.ProcessingReport)
 	}
 }
 
-func (d *commandTelemetryDetails) addWarnings(warnings []compiler.Warning) {
-	for _, warning := range warnings {
-		if allowlistedTelemetryDiagnosticCode(warning.Code) {
-			d.addDiagnostic(warning.Code, telemetry.SeverityWarning, warning.Blocker, warning.BlockerDetail)
-		}
-	}
+func (d *commandTelemetryDetails) addWarnings(workflowPath string, warnings []compiler.Warning) {
+	report := compatibility.NewProcessingReport(workflowPath, "")
+	report.ApplyWarnings(workflowPath, warnings)
+	d.addReportDiagnostics(report)
 }
 
 // addActionRuntimeUnknown records admitted actions whose runtime behavior was
 // never proven. Upload keeps this in telemetry rather than the processing
 // report, where it would annotate every import that uses actions.
 func (d *commandTelemetryDetails) addActionRuntimeUnknown() {
-	d.addDiagnostic("W_ACTION_RUNTIME_UNKNOWN", telemetry.SeverityWarning, "", "")
+	d.addDiagnostic(telemetry.Diagnostic{Code: "W_ACTION_RUNTIME_UNKNOWN", Severity: telemetry.SeverityWarning})
 }
 
-func (d *commandTelemetryDetails) addDiagnostic(code string, severity telemetry.Severity, blocker, blockerDetail string) {
+func (d *commandTelemetryDetails) addDiagnostic(diagnostic telemetry.Diagnostic) {
 	if d.seen == nil {
-		d.seen = make(map[telemetryDiagnosticKey]int)
+		d.seen = make(map[telemetry.Diagnostic]bool)
 	}
-	key := telemetryDiagnosticKey{code: code, blocker: blocker, blockerDetail: blockerDetail}
-	if index, exists := d.seen[key]; exists {
-		if severity == telemetry.SeverityError {
-			d.diagnostics[index].Severity = severity
-		}
+	if d.seen[diagnostic] {
 		return
 	}
 	if len(d.diagnostics) == maxCommandTelemetryDiagnostics {
 		return
 	}
-	d.seen[key] = len(d.diagnostics)
-	d.diagnostics = append(d.diagnostics, telemetry.Diagnostic{Code: code, Severity: severity, Blocker: blocker, BlockerDetail: blockerDetail})
+	d.seen[diagnostic] = true
+	d.diagnostics = append(d.diagnostics, diagnostic)
 }
 
 func (d *commandTelemetryDetails) setBlocker(blocker, detail string) {

--- a/internal/cli/telemetry_test.go
+++ b/internal/cli/telemetry_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"sync"
@@ -128,14 +129,74 @@ func TestCommandCompletionTelemetryFailureDoesNotChangeExit(t *testing.T) {
 	}
 }
 
+func TestSuccessfulImportTelemetryIncludesWorkflowDiagnostics(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("BUILDKITE_BUILD_CHECKOUT_PATH", root)
+	events := make(chan map[string]json.RawMessage, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var event struct {
+			Properties map[string]json.RawMessage `json:"properties"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&event); err != nil {
+			t.Error(err)
+		}
+		events <- event.Properties
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+	t.Setenv("BUILDKITE_AGENT_ENDPOINT", server.URL)
+	t.Setenv("BUILDKITE_JOB_ID", cliTestJobID)
+	t.Setenv("BUILDKITE_AGENT_ACCESS_TOKEN", "telemetry-token")
+	t.Setenv("BUILDKITE_GHA_TELEMETRY_DISABLED", "")
+
+	details := &commandTelemetryDetails{}
+	for _, name := range []string{"docs.yml", "test.yml", "docs.yml"} {
+		details.addReportDiagnostics(compatibility.ProcessingReport{
+			Workflow: filepath.Join(root, ".github", "workflows", name),
+			Diagnostics: []compatibility.Diagnostic{{
+				Level: "error", Code: compiler.CodePipelineGeneration,
+				Message: "Push filters could not be evaluated.", Detail: "Missing\nwebhook history.",
+				Location: &compatibility.SourceLocation{Path: "reusable.yml", Line: 3},
+			}},
+		})
+	}
+	details.addReportDiagnostics(compatibility.NewProcessingReport("valid.yml", ""))
+	emitCommandTelemetry(t.Context(), telemetry.CommandPluginImport, telemetry.OutcomeSuccess, "dev", 0, details.forOutcome(telemetry.OutcomeSuccess))
+	var properties map[string]json.RawMessage
+	select {
+	case properties = <-events:
+	default:
+		t.Fatal("successful import did not send telemetry")
+	}
+	if string(properties["outcome"]) != `"success"` {
+		t.Fatalf("outcome = %s", properties["outcome"])
+	}
+	for _, field := range []string{"failure_phase", "failure_code", "error_message", "error_message_truncated"} {
+		if _, exists := properties[field]; exists {
+			t.Fatalf("successful import sent %s", field)
+		}
+	}
+	var diagnostics []telemetry.Diagnostic
+	if err := json.Unmarshal(properties["diagnostics"], &diagnostics); err != nil {
+		t.Fatal(err)
+	}
+	want := []telemetry.Diagnostic{
+		{Code: compiler.CodePipelineGeneration, Severity: telemetry.SeverityError, Message: "Push filters could not be evaluated. Missing webhook history.", WorkflowPath: ".github/workflows/docs.yml"},
+		{Code: compiler.CodePipelineGeneration, Severity: telemetry.SeverityError, Message: "Push filters could not be evaluated. Missing webhook history.", WorkflowPath: ".github/workflows/test.yml"},
+	}
+	if !reflect.DeepEqual(diagnostics, want) {
+		t.Fatalf("diagnostics = %#v, want %#v", diagnostics, want)
+	}
+}
+
 func TestCommandTelemetryDetailsCollectTypedDiagnostics(t *testing.T) {
 	details := &commandTelemetryDetails{}
 	details.observe(compatibility.ProcessingReport{Diagnostics: []compatibility.Diagnostic{
-		{Level: "error", Code: compiler.CodeWorkflowSyntax, Stage: compiler.StageWorkflowParsing, Message: "must not be uploaded"},
-		{Level: "error", Code: compiler.CodeWorkflowSyntax, Stage: compiler.StageWorkflowParsing, Message: "different sensitive text"},
-		{Level: "error", Code: compiler.CodeExpressionInvalid, Stage: compiler.StageExpressions, Blocker: "runner_label", BlockerDetail: "windows-latest", Message: "must not be uploaded"},
-		{Level: "error", Code: compiler.CodeExpressionInvalid, Stage: compiler.StageExpressions, Blocker: "runner_label", BlockerDetail: "macos-10", Message: "must not be uploaded"},
-		{Level: "warning", Code: "W_ACTION_RUNTIME_UNKNOWN", Stage: compiler.StageAdmission, Message: "must not be uploaded"},
+		{Level: "error", Code: compiler.CodeWorkflowSyntax, Stage: compiler.StageWorkflowParsing, Message: "invalid workflow"},
+		{Level: "error", Code: compiler.CodeWorkflowSyntax, Stage: compiler.StageWorkflowParsing, Message: "invalid job"},
+		{Level: "error", Code: compiler.CodeExpressionInvalid, Stage: compiler.StageExpressions, Blocker: "runner_label", BlockerDetail: "windows-latest", Message: "unsupported runner"},
+		{Level: "error", Code: compiler.CodeExpressionInvalid, Stage: compiler.StageExpressions, Blocker: "runner_label", BlockerDetail: "macos-10", Message: "unsupported runner"},
+		{Level: "warning", Code: "W_ACTION_RUNTIME_UNKNOWN", Stage: compiler.StageAdmission, Message: "unproven action"},
 		{Level: "error", Code: "E_FUTURE_UNALLOWLISTED", Stage: compiler.StageGraph, Message: "must not be uploaded"},
 	}})
 	got := details.telemetryDetails()
@@ -146,10 +207,11 @@ func TestCommandTelemetryDetailsCollectTypedDiagnostics(t *testing.T) {
 		t.Fatalf("blocker = %q / %q", got.Blocker, got.BlockerDetail)
 	}
 	want := []telemetry.Diagnostic{
-		{Code: compiler.CodeWorkflowSyntax, Severity: telemetry.SeverityError},
-		{Code: compiler.CodeExpressionInvalid, Severity: telemetry.SeverityError, Blocker: "runner_label", BlockerDetail: "windows-latest"},
-		{Code: compiler.CodeExpressionInvalid, Severity: telemetry.SeverityError, Blocker: "runner_label", BlockerDetail: "macos-10"},
-		{Code: "W_ACTION_RUNTIME_UNKNOWN", Severity: telemetry.SeverityWarning},
+		{Code: compiler.CodeWorkflowSyntax, Severity: telemetry.SeverityError, Message: "invalid workflow"},
+		{Code: compiler.CodeWorkflowSyntax, Severity: telemetry.SeverityError, Message: "invalid job"},
+		{Code: compiler.CodeExpressionInvalid, Severity: telemetry.SeverityError, Blocker: "runner_label", BlockerDetail: "windows-latest", Message: "unsupported runner"},
+		{Code: compiler.CodeExpressionInvalid, Severity: telemetry.SeverityError, Blocker: "runner_label", BlockerDetail: "macos-10", Message: "unsupported runner"},
+		{Code: "W_ACTION_RUNTIME_UNKNOWN", Severity: telemetry.SeverityWarning, Message: "unproven action"},
 	}
 	if !reflect.DeepEqual(got.Diagnostics, want) {
 		t.Fatalf("diagnostics = %#v, want %#v", got.Diagnostics, want)
@@ -172,13 +234,19 @@ func TestTriggerFailureTelemetryIncludesTrigger(t *testing.T) {
 
 func TestUnsupportedTriggerWarningTelemetryIncludesTrigger(t *testing.T) {
 	details := &commandTelemetryDetails{}
-	details.addWarnings([]compiler.Warning{{
+	warnings := []compiler.Warning{{
 		Code: "W_TRIGGER_EVENT_UNSUPPORTED", Blocker: "trigger", BlockerDetail: "workflow_run",
-	}})
+		Message: "Unsupported trigger", Path: "reusable.yml", Line: 2, Column: 3,
+	}}
+	details.addWarnings("workflow.yml", warnings)
+	report := compatibility.NewProcessingReport("workflow.yml", "")
+	report.ApplyWarnings("workflow.yml", warnings)
+	details.addReportDiagnostics(report)
 	got := details.telemetryDetails()
 	want := []telemetry.Diagnostic{{
 		Code: "W_TRIGGER_EVENT_UNSUPPORTED", Severity: telemetry.SeverityWarning,
 		Blocker: "trigger", BlockerDetail: "workflow_run",
+		Message: "reusable.yml:2:3: Unsupported trigger", WorkflowPath: "workflow.yml",
 	}}
 	if !reflect.DeepEqual(got.Diagnostics, want) {
 		t.Fatalf("diagnostics = %#v, want %#v", got.Diagnostics, want)
@@ -226,7 +294,7 @@ func TestHandledReportErrorsDoNotAttributeCommandFailure(t *testing.T) {
 	if got.FailurePhase != telemetry.FailurePhaseUnknown || got.FailureCode != telemetry.FailureCodeUnknown {
 		t.Fatalf("handled error attributed a later failure: %#v", got)
 	}
-	want := []telemetry.Diagnostic{{Code: compiler.CodeExpressionInvalid, Severity: telemetry.SeverityError}}
+	want := []telemetry.Diagnostic{{Code: compiler.CodeExpressionInvalid, Severity: telemetry.SeverityError, Message: "emitted as a failing step"}}
 	if !reflect.DeepEqual(got.Diagnostics, want) {
 		t.Fatalf("diagnostics = %#v, want %#v", got.Diagnostics, want)
 	}

--- a/internal/cli/telemetry_test.go
+++ b/internal/cli/telemetry_test.go
@@ -218,6 +218,29 @@ func TestCommandTelemetryDetailsCollectTypedDiagnostics(t *testing.T) {
 	}
 }
 
+func TestCommandTelemetryDiagnosticLimitUsesWireIdentity(t *testing.T) {
+	details := &commandTelemetryDetails{}
+	common := strings.Repeat("x", 1024)
+	for i := range 20 {
+		details.addReportDiagnostics(compatibility.ProcessingReport{Diagnostics: []compatibility.Diagnostic{{
+			Level: "error", Code: compiler.CodeWorkflowSyntax, Message: common + strings.Repeat("y", i+1),
+		}}})
+	}
+	want := []telemetry.Diagnostic{{Code: compiler.CodeWorkflowSyntax, Severity: telemetry.SeverityError, Message: common, MessageTruncated: true}}
+	for i := range 20 {
+		message := strings.Repeat("distinct ", i+1) + "error"
+		details.addReportDiagnostics(compatibility.ProcessingReport{Diagnostics: []compatibility.Diagnostic{{
+			Level: "error", Code: compiler.CodeWorkflowSyntax, Message: message,
+		}}})
+		if i < 19 {
+			want = append(want, telemetry.Diagnostic{Code: compiler.CodeWorkflowSyntax, Severity: telemetry.SeverityError, Message: message})
+		}
+	}
+	if got := details.forOutcome(telemetry.OutcomeSuccess).Diagnostics; !reflect.DeepEqual(got, want) {
+		t.Fatalf("diagnostics = %#v, want %#v", got, want)
+	}
+}
+
 func TestTriggerFailureTelemetryIncludesTrigger(t *testing.T) {
 	for _, triggerErr := range []error{
 		&buildkitepipeline.UnsupportedTriggerEventError{Event: "workflow_run"},

--- a/internal/cli/upload.go
+++ b/internal/cli/upload.go
@@ -446,7 +446,7 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 			parsed, _ := compiler.ParseWorkflow(input.Path, input.Source)
 			writeCompilerWarnings(stderr, "upload", input.CanonicalPath, parsed.Warnings)
 			if uploadArguments.telemetry != nil {
-				uploadArguments.telemetry.addWarnings(parsed.Warnings)
+				uploadArguments.telemetry.addWarnings(input.Path, parsed.Warnings)
 			}
 			continue
 		}
@@ -546,7 +546,7 @@ func finishUpload(ctx context.Context, uploadArguments parsedUploadArgs, stdout,
 		processingReports[i].Result = "admitted"
 		writeCompilerWarnings(stderr, "upload", input.CanonicalPath, bundle.IR.Warnings)
 		if uploadArguments.telemetry != nil {
-			uploadArguments.telemetry.addWarnings(bundle.IR.Warnings)
+			uploadArguments.telemetry.addWarnings(input.Path, bundle.IR.Warnings)
 			if bundleRunsUnprovenActions(bundle) {
 				uploadArguments.telemetry.addActionRuntimeUnknown()
 			}

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -21,12 +21,13 @@ import (
 const (
 	EventCommandCompleted = "pipelines:buildkite_gha:command_completed"
 
-	defaultTimeout        = 1500 * time.Millisecond
-	responseDrainLimit    = 32 << 10
-	maxClientVersionBytes = 64
-	maxBlockerDetailBytes = 1024
-	maxDurationMS         = int64(1<<31 - 1)
-	maxDiagnostics        = 20
+	defaultTimeout         = 1500 * time.Millisecond
+	responseDrainLimit     = 32 << 10
+	maxClientVersionBytes  = 64
+	maxBlockerDetailBytes  = 1024
+	maxDiagnosticTextBytes = 1024
+	maxDurationMS          = int64(1<<31 - 1)
+	maxDiagnostics         = 20
 
 	// MaxErrorMessageBytes bounds the error message sent on unsuccessful
 	// commands. Over-long messages keep their final bytes, where a failing
@@ -97,10 +98,13 @@ const (
 )
 
 type Diagnostic struct {
-	Code          string   `json:"code"`
-	Severity      Severity `json:"severity"`
-	Blocker       string   `json:"blocker,omitempty"`
-	BlockerDetail string   `json:"blocker_detail,omitempty"`
+	Code             string   `json:"code"`
+	Severity         Severity `json:"severity"`
+	Blocker          string   `json:"blocker,omitempty"`
+	BlockerDetail    string   `json:"blocker_detail,omitempty"`
+	Message          string   `json:"message,omitempty"`
+	MessageTruncated bool     `json:"message_truncated,omitempty"`
+	WorkflowPath     string   `json:"workflow_path,omitempty"`
 }
 
 type Details struct {
@@ -282,7 +286,7 @@ func validFailureCode(code FailureCode) bool {
 }
 
 func boundedDiagnostics(in []Diagnostic) ([]Diagnostic, error) {
-	seen := make(map[Diagnostic]bool, min(len(in), maxDiagnostics))
+	seen := make(map[Diagnostic]int, min(len(in), maxDiagnostics))
 	out := make([]Diagnostic, 0, min(len(in), maxDiagnostics))
 	for _, diagnostic := range in {
 		severity, ok := diagnosticSeverity(diagnostic.Code)
@@ -294,10 +298,29 @@ func boundedDiagnostics(in []Diagnostic) ([]Diagnostic, error) {
 			return nil, err
 		}
 		diagnostic.Blocker, diagnostic.BlockerDetail = blocker, blockerDetail
-		if seen[diagnostic] {
+		diagnostic.Message = normalizedTelemetryText(diagnostic.Message)
+		if len(diagnostic.Message) > maxDiagnosticTextBytes {
+			end := maxDiagnosticTextBytes
+			for !utf8.RuneStart(diagnostic.Message[end]) {
+				end--
+			}
+			diagnostic.Message = strings.TrimSpace(diagnostic.Message[:end])
+			diagnostic.MessageTruncated = true
+		}
+		if diagnostic.Message == "" {
+			diagnostic.MessageTruncated = false
+		}
+		// A shortened or normalized path could name a different workflow.
+		if len(diagnostic.WorkflowPath) > maxDiagnosticTextBytes || !utf8.ValidString(diagnostic.WorkflowPath) || strings.ContainsFunc(diagnostic.WorkflowPath, unicode.IsControl) {
+			diagnostic.WorkflowPath = ""
+		}
+		identity := diagnostic
+		identity.MessageTruncated = false
+		if index, exists := seen[identity]; exists {
+			out[index].MessageTruncated = out[index].MessageTruncated || diagnostic.MessageTruncated
 			continue
 		}
-		seen[diagnostic] = true
+		seen[identity] = len(out)
 		out = append(out, diagnostic)
 		if len(out) == maxDiagnostics {
 			break
@@ -317,13 +340,7 @@ func boundedBlocker(blocker, detail string) (string, string, error) {
 	default:
 		return "", "", fmt.Errorf("invalid telemetry blocker")
 	}
-	detail = strings.Map(func(character rune) rune {
-		if unicode.IsControl(character) {
-			return ' '
-		}
-		return character
-	}, strings.ToValidUTF8(detail, "�"))
-	detail = strings.Join(strings.Fields(detail), " ")
+	detail = normalizedTelemetryText(detail)
 	if len(detail) > maxBlockerDetailBytes {
 		digest := sha256.Sum256([]byte(detail))
 		suffix := fmt.Sprintf("…#%x", digest[:6])
@@ -378,14 +395,18 @@ func boundedClientVersion(version string) string {
 	return version
 }
 
-func boundedErrorMessage(message string) (string, bool) {
+func normalizedTelemetryText(message string) string {
 	message = strings.Map(func(character rune) rune {
 		if unicode.IsControl(character) {
 			return ' '
 		}
 		return character
 	}, strings.ToValidUTF8(message, "�"))
-	message = strings.Join(strings.Fields(message), " ")
+	return strings.Join(strings.Fields(message), " ")
+}
+
+func boundedErrorMessage(message string) (string, bool) {
+	message = normalizedTelemetryText(message)
 	if len(message) <= MaxErrorMessageBytes {
 		return message, false
 	}

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -209,7 +209,7 @@ func (c *Client) EmitContext(ctx context.Context, command Command, outcome Outco
 	if details.FailureCode != "" && !validFailureCode(details.FailureCode) {
 		return fmt.Errorf("invalid telemetry failure code")
 	}
-	diagnostics, err := boundedDiagnostics(details.Diagnostics)
+	diagnostics, err := BoundedDiagnostics(details.Diagnostics)
 	if err != nil {
 		return err
 	}
@@ -285,7 +285,9 @@ func validFailureCode(code FailureCode) bool {
 	}
 }
 
-func boundedDiagnostics(in []Diagnostic) ([]Diagnostic, error) {
+// BoundedDiagnostics normalizes diagnostic text and deduplicates by wire identity
+// before applying the diagnostic count limit. It does not modify in.
+func BoundedDiagnostics(in []Diagnostic) ([]Diagnostic, error) {
 	seen := make(map[Diagnostic]int, min(len(in), maxDiagnostics))
 	out := make([]Diagnostic, 0, min(len(in), maxDiagnostics))
 	for _, diagnostic := range in {

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -322,11 +322,11 @@ func BoundedDiagnostics(in []Diagnostic) ([]Diagnostic, error) {
 			out[index].MessageTruncated = out[index].MessageTruncated || diagnostic.MessageTruncated
 			continue
 		}
+		if len(out) == maxDiagnostics {
+			continue
+		}
 		seen[identity] = len(out)
 		out = append(out, diagnostic)
-		if len(out) == maxDiagnostics {
-			break
-		}
 	}
 	return out, nil
 }

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -273,15 +273,15 @@ func TestDiagnosticsEnforceSeverityAndDeduplicateByCode(t *testing.T) {
 		input = append(input, Diagnostic{Code: code, Severity: SeverityWarning})
 	}
 	input = append(input, input[0], input[len(errorCodes)])
-	bounded, err := boundedDiagnostics(input)
+	bounded, err := BoundedDiagnostics(input)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(bounded) != len(errorCodes)+len(warningCodes) {
 		t.Fatalf("diagnostics = %d, want %d unique codes", len(bounded), len(errorCodes)+len(warningCodes))
 	}
-	if _, err := boundedDiagnostics([]Diagnostic{{Code: "CUSTOMER_VALUE", Severity: SeverityError}}); err == nil {
-		t.Fatal("boundedDiagnostics() accepted non-allowlisted code")
+	if _, err := BoundedDiagnostics([]Diagnostic{{Code: "CUSTOMER_VALUE", Severity: SeverityError}}); err == nil {
+		t.Fatal("BoundedDiagnostics() accepted non-allowlisted code")
 	}
 }
 
@@ -291,7 +291,7 @@ func TestDiagnosticsPreserveDistinctBlockersForOneCode(t *testing.T) {
 		{Code: string(FailureCodeExpressionInvalid), Severity: SeverityError, Blocker: "expression", BlockerDetail: common + "first"},
 		{Code: string(FailureCodeExpressionInvalid), Severity: SeverityError, Blocker: "expression", BlockerDetail: common + "second"},
 	}
-	bounded, err := boundedDiagnostics(input)
+	bounded, err := BoundedDiagnostics(input)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -330,9 +330,9 @@ func TestDiagnosticTextBounds(t *testing.T) {
 		{name: "preserve flag", message: "already shortened", truncated: true, wantMessage: "already shortened", wantTruncated: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := boundedDiagnostics([]Diagnostic{{Code: string(FailureCodePipelineGeneration), Severity: SeverityError, Message: test.message, MessageTruncated: test.truncated, WorkflowPath: test.path}})
+			got, err := BoundedDiagnostics([]Diagnostic{{Code: string(FailureCodePipelineGeneration), Severity: SeverityError, Message: test.message, MessageTruncated: test.truncated, WorkflowPath: test.path}})
 			if err != nil || len(got) != 1 {
-				t.Fatalf("boundedDiagnostics() = %#v, %v", got, err)
+				t.Fatalf("BoundedDiagnostics() = %#v, %v", got, err)
 			}
 			if got[0].Message != test.wantMessage || got[0].WorkflowPath != test.wantPath || got[0].MessageTruncated != test.wantTruncated {
 				t.Fatalf("diagnostic = %#v", got[0])
@@ -348,18 +348,18 @@ func TestDiagnosticsDeduplicateByWireIdentity(t *testing.T) {
 	otherMessage.Message = "another filter failed"
 	duplicate.Message = " filter\nfailed "
 	duplicate.MessageTruncated = true
-	got, err := boundedDiagnostics([]Diagnostic{first, otherPath, otherMessage, duplicate})
+	got, err := BoundedDiagnostics([]Diagnostic{first, otherPath, otherMessage, duplicate})
 	first.MessageTruncated = true
 	want := []Diagnostic{first, otherPath, otherMessage}
 	if err != nil || !reflect.DeepEqual(got, want) {
-		t.Fatalf("boundedDiagnostics() = %#v, %v; want %#v", got, err, want)
+		t.Fatalf("BoundedDiagnostics() = %#v, %v; want %#v", got, err, want)
 	}
 
 	// Truncation can make previously distinct messages identical to the API.
 	first.Message, first.MessageTruncated = strings.Repeat("x", 1024), false
 	duplicate = first
 	duplicate.Message += " extra"
-	got, err = boundedDiagnostics([]Diagnostic{first, duplicate})
+	got, err = BoundedDiagnostics([]Diagnostic{first, duplicate})
 	if err != nil || len(got) != 1 || !got[0].MessageTruncated {
 		t.Fatalf("post-truncation diagnostics = %#v, %v", got, err)
 	}
@@ -410,8 +410,8 @@ func TestDiagnosticsRejectMismatchedSeverity(t *testing.T) {
 		{Code: string(FailureCodeWorkflowSyntax), Severity: SeverityWarning},
 		{Code: "W_ACTION_RUNTIME_UNKNOWN", Severity: SeverityError},
 	} {
-		if _, err := boundedDiagnostics([]Diagnostic{diagnostic}); err == nil {
-			t.Fatalf("boundedDiagnostics(%#v) accepted mismatched severity", diagnostic)
+		if _, err := BoundedDiagnostics([]Diagnostic{diagnostic}); err == nil {
+			t.Fatalf("BoundedDiagnostics(%#v) accepted mismatched severity", diagnostic)
 		}
 	}
 }

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -315,6 +315,96 @@ func TestBlockerDetailsAreNormalizedAndBounded(t *testing.T) {
 	}
 }
 
+func TestDiagnosticTextBounds(t *testing.T) {
+	for _, test := range []struct {
+		name, message, path, wantMessage, wantPath string
+		truncated, wantTruncated                   bool
+	}{
+		{name: "normalize", message: " \xff\nproblem\u0085 details\t", path: "two  spaces.yml", wantMessage: "� problem details", wantPath: "two  spaces.yml"},
+		{name: "exact bound", message: strings.Repeat("é", 512), path: strings.Repeat("é", 512), wantMessage: strings.Repeat("é", 512), wantPath: strings.Repeat("é", 512)},
+		{name: "retain head", message: "cause " + strings.Repeat("界", 340) + " tail", wantMessage: "cause " + strings.Repeat("界", 339), wantTruncated: true},
+		{name: "overlong path", message: "problem", path: strings.Repeat("é", 512) + "x", wantMessage: "problem"},
+		{name: "control in path", message: "problem", path: "private\u0085file.yml", wantMessage: "problem"},
+		{name: "invalid path encoding", message: "problem", path: "invalid\xff.yml", wantMessage: "problem"},
+		{name: "empty message clears flag", message: "\n\t", truncated: true},
+		{name: "preserve flag", message: "already shortened", truncated: true, wantMessage: "already shortened", wantTruncated: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := boundedDiagnostics([]Diagnostic{{Code: string(FailureCodePipelineGeneration), Severity: SeverityError, Message: test.message, MessageTruncated: test.truncated, WorkflowPath: test.path}})
+			if err != nil || len(got) != 1 {
+				t.Fatalf("boundedDiagnostics() = %#v, %v", got, err)
+			}
+			if got[0].Message != test.wantMessage || got[0].WorkflowPath != test.wantPath || got[0].MessageTruncated != test.wantTruncated {
+				t.Fatalf("diagnostic = %#v", got[0])
+			}
+		})
+	}
+}
+
+func TestDiagnosticsDeduplicateByWireIdentity(t *testing.T) {
+	first := Diagnostic{Code: string(FailureCodePipelineGeneration), Severity: SeverityError, Message: "filter failed", WorkflowPath: "first.yml"}
+	otherPath, otherMessage, duplicate := first, first, first
+	otherPath.WorkflowPath = "second.yml"
+	otherMessage.Message = "another filter failed"
+	duplicate.Message = " filter\nfailed "
+	duplicate.MessageTruncated = true
+	got, err := boundedDiagnostics([]Diagnostic{first, otherPath, otherMessage, duplicate})
+	first.MessageTruncated = true
+	want := []Diagnostic{first, otherPath, otherMessage}
+	if err != nil || !reflect.DeepEqual(got, want) {
+		t.Fatalf("boundedDiagnostics() = %#v, %v; want %#v", got, err, want)
+	}
+
+	// Truncation can make previously distinct messages identical to the API.
+	first.Message, first.MessageTruncated = strings.Repeat("x", 1024), false
+	duplicate = first
+	duplicate.Message += " extra"
+	got, err = boundedDiagnostics([]Diagnostic{first, duplicate})
+	if err != nil || len(got) != 1 || !got[0].MessageTruncated {
+		t.Fatalf("post-truncation diagnostics = %#v, %v", got, err)
+	}
+}
+
+func TestClientEmitsDiagnosticTextWithinServerRequestLimit(t *testing.T) {
+	var body []byte
+	client, err := New(Config{Endpoint: "https://agent.example/v3", JobID: testJobID, JobToken: "token", Client: &http.Client{Transport: roundTripperFunc(func(request *http.Request) (*http.Response, error) {
+		body, _ = io.ReadAll(request.Body)
+		return &http.Response{StatusCode: http.StatusAccepted, Body: io.NopCloser(strings.NewReader(""))}, nil
+	})}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	diagnostics := make([]Diagnostic, 21)
+	for i := range diagnostics {
+		diagnostics[i] = Diagnostic{
+			Code: string(FailureCodeExpressionInvalid), Severity: SeverityError,
+			Blocker: "expression", BlockerDetail: strings.Repeat("<", 1024),
+			Message: strings.Repeat("<", 1025), WorkflowPath: strconv.Itoa(i) + strings.Repeat("<", 1022),
+		}
+	}
+	if err := client.Emit(CommandPluginImport, OutcomeSuccess, 0, Details{Diagnostics: diagnostics}); err != nil {
+		t.Fatal(err)
+	}
+	if len(body) <= 360_000 || len(body) > 512*1024 {
+		t.Fatalf("request length = %d", len(body))
+	}
+	var event struct {
+		Properties struct {
+			Diagnostics []map[string]any `json:"diagnostics"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(body, &event); err != nil {
+		t.Fatal(err)
+	}
+	if len(event.Properties.Diagnostics) != 20 {
+		t.Fatalf("sent %d diagnostics", len(event.Properties.Diagnostics))
+	}
+	first := event.Properties.Diagnostics[0]
+	if first["message"] != strings.Repeat("<", 1024) || first["message_truncated"] != true || first["workflow_path"] != "0"+strings.Repeat("<", 1022) {
+		t.Fatalf("wire diagnostic = %#v", first)
+	}
+}
+
 func TestDiagnosticsRejectMismatchedSeverity(t *testing.T) {
 	for _, diagnostic := range []Diagnostic{
 		{Code: string(FailureCodeWorkflowSyntax), Severity: SeverityWarning},

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -363,6 +363,21 @@ func TestDiagnosticsDeduplicateByWireIdentity(t *testing.T) {
 	if err != nil || len(got) != 1 || !got[0].MessageTruncated {
 		t.Fatalf("post-truncation diagnostics = %#v, %v", got, err)
 	}
+
+	// After the budget fills, ignore new identities but still merge duplicate flags.
+	input := []Diagnostic{first}
+	for i := range 20 {
+		other := first
+		other.WorkflowPath = strconv.Itoa(i) + ".yml"
+		input = append(input, other)
+	}
+	input = append(input, duplicate, first)
+	want = append([]Diagnostic(nil), input[:20]...)
+	want[0].MessageTruncated = true
+	got, err = BoundedDiagnostics(input)
+	if err != nil || !reflect.DeepEqual(got, want) {
+		t.Fatalf("full-budget diagnostics = %#v, %v; want %#v", got, err, want)
+	}
 }
 
 func TestClientEmitsDiagnosticTextWithinServerRequestLimit(t *testing.T) {


### PR DESCRIPTION
## Description

An import can exit zero after uploading failing steps for rejected workflows. Its telemetry includes diagnostic codes, but not the text or workflow paths needed to investigate them:

```json
{
  "outcome": "success",
  "diagnostics": [
    { "code": "E_PIPELINE_GENERATION", "severity": "error" }
  ]
}
```

## Changes

Include readable messages, diagnostic details, and root workflow paths regardless of command outcome:

```json
{
  "outcome": "success",
  "diagnostics": [
    {
      "code": "E_PIPELINE_GENERATION",
      "severity": "error",
      "message": "Push filters could not be evaluated. Missing webhook history.",
      "workflow_path": ".github/workflows/docs.yml"
    }
  ]
}
```

Messages retain their first 1,024 UTF-8 bytes, with `message_truncated: true` when shortened. Paths are checkout-relative when possible and omitted if they cannot be sent intact within the limit.

