### PR TITLE
PB-3316: Show skipped GitHub Actions jobs in Buildkite

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1788,10 +1788,10 @@ hosted-toolchains images provide. macOS images are unsupported.
 
 ### Results, retries, and cancellation
 
-- A runtime-skipped Actions job appears successful in Buildkite while publishing a logical `skipped` result for downstream imported jobs.
+- A runtime-skipped Actions job remains successful in Buildkite, appends `(skipped)` to its job label, and publishes a logical `skipped` result for downstream imported jobs.
 - Retry the whole build if a producer result or artifact becomes ambiguous.
 - Cancellation targets the complete process tree: `SIGINT`, `SIGTERM` after 7.5 seconds, then `SIGKILL` after another 2.5 seconds.
-- Summary or annotation publication failure produces a warning and does not change a completed job result.
+- Summary, annotation, or skipped-label publication failure produces a warning and does not change a completed job result.
 
 ### Key limits
 

--- a/internal/cli/cli_test_support_test.go
+++ b/internal/cli/cli_test_support_test.go
@@ -119,6 +119,7 @@ type cliCaptureRunner struct {
 	failAt         int
 	failMetadata   bool
 	failAnnotation bool
+	failStepUpdate bool
 	gitOutput      []byte
 	gitErr         error
 	webhook        []byte
@@ -226,6 +227,9 @@ func (r *cliCaptureRunner) Run(ctx context.Context, dir, name string, args []str
 	}
 	if r.failAnnotation && len(args) > 0 && args[0] == "annotate" {
 		return nil, errors.New("annotation unavailable")
+	}
+	if r.failStepUpdate && len(args) > 1 && args[0] == "step" && args[1] == "update" {
+		return nil, errors.New("step update unavailable")
 	}
 	return nil, nil
 }

--- a/internal/cli/run_job.go
+++ b/internal/cli/run_job.go
@@ -333,6 +333,9 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 		if publication.MetadataMirrorError != nil {
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: warning: result metadata mirror: %v\n", publication.MetadataMirrorError)
 		}
+		if publication.SkippedLabelError != nil {
+			_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: warning: skipped job label: %v\n", publication.SkippedLabelError)
+		}
 		if publication.SummaryAnnotationError != nil {
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: warning: job summary annotation: %v\n", publication.SummaryAnnotationError)
 		}
@@ -345,7 +348,7 @@ func runJobContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 		if secretAnnotationError != nil {
 			_, _ = fmt.Fprintf(stderr, "buildkite-gha: run-job: warning: secret resolution annotation: %v\n", secretAnnotationError)
 		}
-		if err != nil || publication.MetadataMirrorError != nil || publication.SummaryAnnotationError != nil || publication.WarningAnnotationError != nil || publication.ErrorAnnotationError != nil || secretAnnotationError != nil {
+		if err != nil || publication.MetadataMirrorError != nil || publication.SkippedLabelError != nil || publication.SummaryAnnotationError != nil || publication.WarningAnnotationError != nil || publication.ErrorAnnotationError != nil || secretAnnotationError != nil {
 			_, _ = fmt.Fprintln(stdout, "^^^ +++")
 			failureVisible = true
 		}

--- a/internal/cli/run_job_test.go
+++ b/internal/cli/run_job_test.go
@@ -112,6 +112,50 @@ func TestRunJobCallGuardSkipsActionJobBeforePreparingRuntimeMise(t *testing.T) {
 	}
 }
 
+func TestRunJobMakesSkippedJobVisibleWithoutFailingIt(t *testing.T) {
+	for _, test := range []struct {
+		name           string
+		failStepUpdate bool
+		wantWarning    bool
+	}{
+		{name: "label updated"},
+		{name: "label update is advisory", failStepUpdate: true, wantWarning: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			job := cliRunJobPlan()
+			job.Condition = "false"
+			job.Program.Job.Steps[0].Run.Command.Source = "exit 99"
+			planPath, planDigest := writeCLIJobPlan(t, job)
+			setCLIJobIdentity(t, job, planDigest)
+			runner := &cliCaptureRunner{failStepUpdate: test.failStepUpdate}
+			var stdout, stderr bytes.Buffer
+
+			if code := run([]string{"run-job", "--plan", planPath}, &stdout, &stderr, "dev", runner); code != 0 {
+				t.Fatalf("run() code = %d, stderr = %q, want successful skipped check", code, stderr.String())
+			}
+			if manifest := publishedCLIManifest(t, runner, job, planDigest); manifest.Result != "skipped" {
+				t.Fatalf("published result = %q, want skipped", manifest.Result)
+			}
+			var updates []cliCommand
+			for _, command := range runner.commands {
+				if len(command.args) > 1 && command.args[0] == "step" && command.args[1] == "update" {
+					updates = append(updates, command)
+				}
+			}
+			wantArgs := []string{"step", "update", "label", " (skipped)", "--append"}
+			if len(updates) != 1 || !slices.Equal(updates[0].args, wantArgs) {
+				t.Fatalf("step updates = %#v, want skipped label", updates)
+			}
+			if got := strings.Contains(stderr.String(), "warning: skipped job label"); got != test.wantWarning {
+				t.Fatalf("stderr = %q, warning present = %v, want %v", stderr.String(), got, test.wantWarning)
+			}
+			if test.wantWarning && !strings.Contains(stdout.String(), "^^^ +++") {
+				t.Fatalf("stdout = %q, want advisory publication warning expanded", stdout.String())
+			}
+		})
+	}
+}
+
 func TestRunJobExecutesBoundPlanAndWritesResult(t *testing.T) {
 	workspace := t.TempDir()
 	workflowSource := []byte("name: cli fixture\n")

--- a/internal/runtime/needs.go
+++ b/internal/runtime/needs.go
@@ -14,6 +14,7 @@ const (
 	jobSummaryAnnotationContext = "buildkite-gha-job-summary"
 	jobWarningAnnotationContext = "buildkite-gha-workflow-warnings"
 	jobErrorAnnotationContext   = "buildkite-gha-workflow-errors"
+	skippedJobLabelSuffix       = " (skipped)"
 )
 
 // ResolveNeeds converts compiler-owned producer identities into the verified
@@ -141,6 +142,11 @@ func PublishJobResult(ctx context.Context, agent transport.Agent, root, workflow
 }
 
 func publishJobAnnotations(ctx context.Context, agent transport.Agent, jobID string, result JobResult, publication *transport.Publication) {
+	if result.Conclusion == "skipped" {
+		if err := agent.EnsureStepLabelSuffix(ctx, skippedJobLabelSuffix); err != nil {
+			publication.SkippedLabelError = fmt.Errorf("mark skipped job: %w", err)
+		}
+	}
 	publishJobSummary(ctx, agent, jobID, result.Summary, publication)
 	if result.WarningAnnotations != "" {
 		if err := agent.AnnotateJob(ctx, jobID, jobWarningAnnotationContext, "warning", result.WarningAnnotations); err != nil {

--- a/internal/transport/boundary.go
+++ b/internal/transport/boundary.go
@@ -172,6 +172,23 @@ func (a Agent) UploadPipeline(ctx context.Context, pipeline []byte) error {
 	return err
 }
 
+// EnsureStepLabelSuffix makes a terminal runtime distinction visible on the
+// current Buildkite step without duplicating it when the step is retried.
+func (a Agent) EnsureStepLabelSuffix(ctx context.Context, suffix string) error {
+	if suffix == "" || !utf8.ValidString(suffix) {
+		return fmt.Errorf("step label suffix must be nonempty valid UTF-8")
+	}
+	label, err := a.run(ctx, []string{"step", "get", "label"}, nil)
+	if err != nil {
+		return err
+	}
+	if strings.HasSuffix(strings.TrimSpace(string(label)), strings.TrimSpace(suffix)) {
+		return nil
+	}
+	_, err = a.run(ctx, []string{"step", "update", "label", suffix, "--append"}, nil)
+	return err
+}
+
 // AnnotateJob publishes Markdown through stdin under a job-scoped context.
 // Reusing the context updates the annotation instead of duplicating it.
 func (a Agent) AnnotateJob(ctx context.Context, jobID, annotationContext, style, body string) error {

--- a/internal/transport/model_test.go
+++ b/internal/transport/model_test.go
@@ -195,6 +195,7 @@ type captureRunner struct {
 	commands []capturedCommand
 	uploaded map[string][]byte
 	failAt   int
+	output   []byte
 }
 
 func (r *captureRunner) Run(ctx context.Context, dir, name string, args []string, stdin []byte) ([]byte, error) {
@@ -221,7 +222,7 @@ func (r *captureRunner) Run(ctx context.Context, dir, name string, args []string
 			return nil, err
 		}
 	}
-	return nil, nil
+	return bytes.Clone(r.output), nil
 }
 
 func TestAgentUsesExactProducerAndUploadFlags(t *testing.T) {
@@ -277,6 +278,35 @@ func TestAgentPublishesBoundedJobAnnotationThroughStdin(t *testing.T) {
 				t.Fatalf("AnnotateJob() error = %v, commands = %#v", err, validationRunner.commands)
 			}
 		})
+	}
+}
+
+func TestAgentEnsuresStepLabelSuffix(t *testing.T) {
+	runner := &captureRunner{}
+	agent := Agent{Runner: runner}
+	if err := agent.EnsureStepLabelSuffix(t.Context(), " (skipped)"); err != nil {
+		t.Fatal(err)
+	}
+	want := []capturedCommand{
+		{name: "buildkite-agent", args: []string{"step", "get", "label"}},
+		{name: "buildkite-agent", args: []string{"step", "update", "label", " (skipped)", "--append"}},
+	}
+	if !reflect.DeepEqual(runner.commands, want) {
+		t.Fatalf("commands = %#v, want %#v", runner.commands, want)
+	}
+	alreadyMarked := &captureRunner{output: []byte(":github: job · e2e (skipped)\n")}
+	if err := (Agent{Runner: alreadyMarked}).EnsureStepLabelSuffix(t.Context(), " (skipped)"); err != nil {
+		t.Fatal(err)
+	}
+	if len(alreadyMarked.commands) != 1 || !reflect.DeepEqual(alreadyMarked.commands[0].args, []string{"step", "get", "label"}) {
+		t.Fatalf("already marked commands = %#v, want no duplicate update", alreadyMarked.commands)
+	}
+
+	for _, suffix := range []string{"", string([]byte{0xff})} {
+		validationRunner := &captureRunner{}
+		if err := (Agent{Runner: validationRunner}).EnsureStepLabelSuffix(t.Context(), suffix); err == nil || len(validationRunner.commands) != 0 {
+			t.Fatalf("EnsureStepLabelSuffix(%q) error = %v, commands = %#v", suffix, err, validationRunner.commands)
+		}
 	}
 }
 

--- a/internal/transport/results.go
+++ b/internal/transport/results.go
@@ -45,6 +45,7 @@ type Publication struct {
 	Path                   string
 	ManifestDigest         string
 	MetadataMirrorError    error
+	SkippedLabelError      error
 	SummaryAnnotationError error
 	WarningAnnotationError error
 	ErrorAnnotationError   error


### PR DESCRIPTION
## Why

A job-level `if:` that evaluates to false correctly skips every GitHub Actions step and reports a successful check, but Buildkite shows an ordinary green job:

```text
job · e2e
```

GitHub shows “This check was skipped” for the same result. Without an equivalent signal, a build can look as though its workload ran when it did not.

[PB-3316](https://linear.app/buildkite/issue/PB-3316/show-skipped-github-actions-jobs-in-buildkite)

## What

After publishing the logical `skipped` result, append the skipped state to the Buildkite label:

```text
job · e2e (skipped)
```

The check remains successful and downstream jobs still receive `needs.e2e.result == 'skipped'`. The update is retry-safe and advisory, so presentation cannot change the job result.
