### PR TITLE
Support pull_request_target workflows from trusted default-branch source

### DIFF
--- a/cmd/validate-public-workflow-corpus/main.go
+++ b/cmd/validate-public-workflow-corpus/main.go
@@ -35,6 +35,7 @@ const (
 var supportedEvents = map[string]bool{
 	"push":                        true,
 	"pull_request":                true,
+	"pull_request_target":         true,
 	"pull_request_review":         true,
 	"pull_request_review_comment": true,
 	"merge_group":                 true,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -78,7 +78,7 @@ buildkite-gha validate \
   .github/workflows/ci.yml
 ```
 
-`--event` supports `push`, `pull_request`, `merge_group`, `release`, `deployment`, `deployment_status`, `create`, `delete`, `label`, `issues`,
+`--event` supports `push`, `pull_request`, `pull_request_target`, `merge_group`, `release`, `deployment`, `deployment_status`, `create`, `delete`, `label`, `issues`,
 `issue_comment`, `pull_request_review`, `pull_request_review_comment`,
 `workflow_dispatch`, and `schedule`. It requires
 `--profile hosted` and cannot be combined with `--event-path`.
@@ -379,7 +379,7 @@ Actions Pipeline Trigger builds. Most users should configure an explicit
 Without an explicit selector, `BUILDKITE_GITHUB_WORKFLOW_PATH` marks a GitHub
 Actions Pipeline Trigger selection. The server also supplies:
 
-- `GITHUB_EVENT_NAME`: `push`, `pull_request`, `issues`, `issue_comment`,
+- `GITHUB_EVENT_NAME`: `push`, `pull_request`, `pull_request_target`, `issues`, `issue_comment`,
   `pull_request_review`, `pull_request_review_comment`, `release`, `merge_group`,
   `deployment`, `deployment_status`, `create`, `delete`, or `label`
 - `GITHUB_WORKFLOW`: the workflow `name`, or its repository-relative path when
@@ -395,9 +395,13 @@ The `GITHUB_*` values take precedence when present. The plugin derives the
 selected path from `GITHUB_WORKFLOW_REF`, checks `GITHUB_WORKFLOW` against the
 checked-out file, and requires `GITHUB_WORKFLOW_SHA` to match the checkout
 commit. A malformed preferred value fails instead of falling back.
-For pull requests, `GITHUB_WORKFLOW_REF` and imported jobs' `GITHUB_REF` retain
+For `pull_request`, `GITHUB_WORKFLOW_REF` and imported jobs' `GITHUB_REF` retain
 `refs/pull/<number>/merge`, while `GITHUB_WORKFLOW_SHA`, `GITHUB_SHA`, and the
 Buildkite checkout use the pull request head commit.
+For `pull_request_target`, the workflow ref and SHA identify the server-selected
+default branch and commit. Both fields, the original linked payload, and a clean
+matching checkout are required; explicit plugin workflow selectors are rejected.
+See [target semantics and limitations](compatibility.md#trusted-default-branch-pr-workflows).
 Review and inline review-comment events use the same PR-head contract. They
 require both workflow identity fields and the original `buildkite:webhook`
 payload. The PR number, head SHA, head/base branches, activity, and all three

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -309,6 +309,7 @@ the group condition, and the provider-check suffix.
 | --- | --- |
 | `push` | `branches`, `branches-ignore`, `tags`, and `tags-ignore`, including ordered negative patterns in an include list. Branch and tag filters select their corresponding ref kind. Matching `paths` and `paths-ignore` can be admitted for linked GitHub branch pushes when the bounded local-diff requirements below are met. |
 | `pull_request` | `branches` and `branches-ignore` match the base branch. Omitted `types` defaults to `opened`, `synchronize`, and `reopened`; explicitly listed activity types must map exactly to a supported Buildkite source action. Matching `paths` and `paths-ignore` can be admitted when the bounded local-diff requirements below are met. |
+| `pull_request_target` | [Trusted default-branch PR workflows](#trusted-default-branch-pr-workflows). The same activities and branch/path filters as `pull_request`, but workflow source and default checkout use the base repository's resolved default branch, not the PR base or head. |
 | `merge_group` | Pipeline Triggers with a compatible server, and native Buildkite merge queue builds. Native builds require merge queue builds and Merge groups webhook delivery in the pipeline's GitHub settings. `branches` and `branches-ignore` match the base branch. Omitted `types` or `types: []` selects the only supported activity, `checks_requested`; other types and tag and workflow filters are rejected. `destroyed` is not a workflow event. `paths` and `paths-ignore` are ignored with a warning, matching GitHub, which does not evaluate path filters for `merge_group` events. The ref and SHA identify the speculative queue head, not the base commit. A push to a queue ref is still a push. |
 | `release` | Pipeline Triggers and native Buildkite release builds. Native builds require **Additional Webhooks** > **Releases** and **Code** trigger mode. Pipeline Triggers require a compatible server and the GitHub Code Access App to select the workflow at the immutable peeled tag commit. `types` is required and may contain only `published`, `created`, and `released`; bare `release`, all other activity types, and branch, tag, path, and workflow filters are rejected. All draft deliveries are rejected; publishing a prerelease with `published` is supported, unlike the `prereleased` activity. The ref is `refs/tags/<tag_name>`. The SHA is the server-resolved peeled commit, or the checked-out commit for the native compatibility fallback. Existing hosted release `GITHUB_TOKEN` policy is unchanged. |
 | `deployment`, `deployment_status` | Pipeline Triggers with a compatible server, or explicit event snapshots. Bare, array, null, and empty-map declarations are supported; activity types and event filters are not. Workflows and checkout use the deployment commit. The ref identifies its branch or tag and is empty for SHA-only deployments. Status states `error`, `failure`, `in_progress`, `queued`, `pending`, `success`, and `waiting` are supported ([GitHub status enum](https://docs.github.com/en/graphql/reference/enums#deploymentstatusstate)); `inactive` cannot run a workflow. The genuine payload exposes `github.event.deployment` and `github.event.deployment_status`, including environment, state, `environment_url`, `log_url`, and `target_url` when present. Use job/step conditions on these values, not `types` or environment filters. No deployment creation or environment orchestration is added. |
@@ -343,6 +344,42 @@ without retained payloads fail explicitly. See the
 [server-selected event contract](cli.md#private-preview-pipeline-trigger-selection).
 
 GitHub defines seven release activities: `published`, `unpublished`, `created`, `edited`, `deleted`, `prereleased`, and `released`. A bare `on: release` selects all seven, so it cannot map exactly to Buildkite's three delivered activities and is unsupported.
+
+#### Trusted default-branch PR workflows
+
+`pull_request_target` supports same-repository and fork PRs through a compatible
+Pipeline Trigger backend. GitHub delivers a `pull_request` webhook, not a
+separate target hook. The server independently selects ordinary PR workflows
+from the head and target workflows from the base repository's default branch.
+Install the compatible runtime before enabling backend dispatch.
+
+Following [current GitHub.com behavior](https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target),
+target workflow source, local reusable workflows, and default checkout use the
+selected default-branch commit. This can differ from the PR base branch.
+`github.ref` names that default branch and `github.sha` is its immutable selected
+SHA. `github.head_ref`, `github.base_ref`, and the original event payload retain
+the PR's actual identity. Moving a ref after selection does not move execution.
+Merge conflicts do not suppress target events; `closed` requires explicit
+`types: [closed]`, and `github.event.pull_request.merged` distinguishes a merge.
+Branch filters still match the PR base; CI-skip directives do not suppress target
+events. Explicitly empty `types` is unsupported.
+
+These are bounded semantics, not full GitHub parity:
+
+- The server pins the default branch at processing time. The PR webhook does not
+  contain GitHub's event-time default SHA. A redelivery can resolve a newer tip.
+- Imports require the original linked webhook and server-selected path/ref/SHA,
+  without plugin workflow overrides. Missing repository identity fails closed.
+- The importer verifies a clean checkout of the selected SHA and matching origin
+  before reading source. Dirty, untracked or ignored files, index overrides,
+  sparse checkouts, and submodules are unsupported for target imports.
+- Path filters require complete existing local PR base/head history and the
+  bounds below. The importer does not fetch missing PR objects. Unlike ordinary
+  PR imports, the checkout and workflow must match the selected default SHA,
+  while the diff remains `base...head`.
+- GitHub's unpublished security-sensitive branch-name suppression rules are not
+  reproduced. Buildkite token, secret, environment and cache policies differ;
+  see [target security boundaries](security.md#target-pr-workflows).
 
 For push and pull-request path filters, once the workflow and checkout are
 verified against the webhook commit, non-path exclusions retain their branch
@@ -396,7 +433,8 @@ on:
 Before upload, the importer compares the pull request merge base with its head
 in the local checkout (`base...head`). The linked webhook must provide full
 base and head commit SHAs with one common merge base verified as an ancestor
-of both commits. The checkout and filtered workflow must match the PR head.
+of both commits. The checkout and filtered workflow must match the PR head for
+`pull_request`, or the selected default commit for `pull_request_target`.
 The comparison uses those pinned commits, not the current base-branch tip.
 
 Buildkite builds the PR head, not GitHub's synthetic merge. Path evaluation

--- a/docs/security.md
+++ b/docs/security.md
@@ -211,6 +211,33 @@ For non-pull-request builds, a user who can create a build at any commit may
 choose code that requests the workflow's allowed permissions. Enable write
 tokens only when those build-creation paths are trusted.
 
+### Target PR workflows
+
+`pull_request_target` selects trusted default-branch source, but the PR payload
+remains untrusted. Do not interpolate titles, bodies or refs into shell commands,
+or execute downloaded PR artifacts, dependencies or scripts with secrets. Use
+isolated, ephemeral agents; agent hooks and concurrent checkout writers remain
+trusted. A matching environment variable or local origin URL is not an attestation
+against a compromised agent.
+
+The native checkout adapter blocks a fork's payload head and merge SHAs. Target
+jobs retain the digest-verified event artifact so this guard uses repository IDs,
+not a caller's claim that a PR is same-repository. Existing restrictions also
+reject another repository, `refs/pull/*`, and `allow-unsafe-pr-checkout: true`.
+Same-repository PR SHAs and ordinary base-repository branch overrides remain
+allowed, as in GitHub's default fork-specific guard. This does not prevent a
+workflow author from fetching and executing arbitrary code outside checkout.
+
+Target builds keep Buildkite's PR `contents:read` token ceiling; they do not gain
+GitHub's default read/write token. With the companion backend, cache credentials
+are read-only even for same-repository target PRs. Scope remains the configured
+Buildkite pipeline default branch; GitHub's write-capable `cache-mode` opt-out is
+not supported. No GitHub secrets or fork approval policy are imported. Existing
+Buildkite Secret policies and environment protection checks still apply.
+
+See [supported target semantics](compatibility.md#trusted-default-branch-pr-workflows)
+and GitHub Security Lab's [pwn request guidance](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/).
+
 ### Workflow secrets
 
 Workflow secrets are Buildkite secrets available to the destination job. They

--- a/internal/buildkite/triggers.go
+++ b/internal/buildkite/triggers.go
@@ -67,6 +67,7 @@ var supportedTriggerEvents = map[string]bool{
 	"schedule":                    true,
 	"push":                        true,
 	"pull_request":                true,
+	"pull_request_target":         true,
 	"merge_group":                 true,
 	"release":                     true,
 	"deployment":                  true,
@@ -250,7 +251,7 @@ func ValidateTriggerConditions(triggers []workflow.Trigger) error {
 			continue
 		}
 		var pathFilters *UnsupportedPathFiltersError
-		if errors.As(err, &pathFilters) && (pathFilters.Event == "push" || pathFilters.Event == "pull_request") && pathFilters.Reason == "" {
+		if errors.As(err, &pathFilters) && (pathFilters.Event == "push" || pathFilters.Event == "pull_request" || pathFilters.Event == "pull_request_target") && pathFilters.Reason == "" {
 			continue
 		}
 		findings = append(findings, err)
@@ -355,14 +356,14 @@ func TriggerFilterMismatchReason(triggers []workflow.Trigger, event string, snap
 					return fmt.Sprintf("Tag %q does not match this workflow's push tag filters.", *snapshot.Tag), nil
 				}
 			}
-		case "pull_request":
+		case "pull_request", "pull_request_target":
 			if snapshot.PullRequestBaseBranch != nil {
 				matches, err := refFilterMatches(*snapshot.PullRequestBaseBranch, trigger.Branches, trigger.BranchesIgnore)
 				if err != nil {
-					return "", fmt.Errorf("pull_request branches: %w", err)
+					return "", fmt.Errorf("%s branches: %w", event, err)
 				}
 				if !matches {
-					return fmt.Sprintf("Base branch %q does not match this workflow's pull_request branch filters.", *snapshot.PullRequestBaseBranch), nil
+					return fmt.Sprintf("Base branch %q does not match this workflow's %s branch filters.", *snapshot.PullRequestBaseBranch, event), nil
 				}
 			}
 			if snapshot.PullRequestAction != nil {
@@ -375,7 +376,7 @@ func TriggerFilterMismatchReason(triggers []workflow.Trigger, event string, snap
 					matched = matched || action == *snapshot.PullRequestAction
 				}
 				if !matched {
-					return fmt.Sprintf("Pull request activity %q does not match this workflow's pull_request activity filters.", *snapshot.PullRequestAction), nil
+					return fmt.Sprintf("Pull request activity %q does not match this workflow's %s activity filters.", *snapshot.PullRequestAction, event), nil
 				}
 			}
 		case "merge_group":
@@ -415,7 +416,7 @@ func TriggerFilterMismatchReason(triggers []workflow.Trigger, event string, snap
 				return fmt.Sprintf("Review activity %q does not match this workflow's %s activity filters.", *snapshot.PullRequestReviewAction, event), nil
 			}
 		}
-		if (trigger.Paths != nil || trigger.PathsIgnore != nil) && (event == "pull_request" || event == "push" && snapshot.Tag == nil) && snapshot.ChangedPaths.available() {
+		if (trigger.Paths != nil || trigger.PathsIgnore != nil) && (event == "pull_request" || event == "pull_request_target" || event == "push" && snapshot.Tag == nil) && snapshot.ChangedPaths.available() {
 			matches, err := pathFiltersMatch(snapshot.ChangedPaths.Paths, trigger.Paths, trigger.PathsIgnore)
 			if err != nil {
 				return "", err
@@ -449,7 +450,7 @@ func LiveEventPredicate(event string) string {
 	predicate := "(" + githubEvent + " == " + yamlScalar(event) + " || (" + githubEventMissing + " && " + buildkiteGitHubEvent + " == " + yamlScalar(event) + "))"
 	fallbackEvent := "(" + githubEventMissing + " && (" + buildkiteGitHubEvent + " == null"
 	unsupportedEvent := ""
-	for _, supported := range []string{"push", "pull_request", "workflow_dispatch", "schedule", "pull_request_review", "pull_request_review_comment"} {
+	for _, supported := range []string{"push", "pull_request", "pull_request_target", "workflow_dispatch", "schedule", "pull_request_review", "pull_request_review_comment"} {
 		if unsupportedEvent != "" {
 			unsupportedEvent += " && "
 		}
@@ -465,7 +466,7 @@ func LiveEventPredicate(event string) string {
 		return predicate
 	case "schedule":
 		return "(" + predicate + " || (" + fallbackEvent + ` && build.pull_request.id == null && build.source == "schedule"))`
-	case "merge_group", "release", "issues", "issue_comment", "pull_request_review", "pull_request_review_comment", "deployment", "deployment_status", "create", "delete", "label":
+	case "merge_group", "release", "issues", "issue_comment", "pull_request_target", "pull_request_review", "pull_request_review_comment", "deployment", "deployment_status", "create", "delete", "label":
 		return predicate
 	default:
 		return ""
@@ -484,7 +485,7 @@ func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpression
 	}
 	pathFilters := t.Paths != nil || t.PathsIgnore != nil
 	if pathFilters && t.Event != "merge_group" {
-		if t.Event != "push" && t.Event != "pull_request" {
+		if t.Event != "push" && t.Event != "pull_request" && t.Event != "pull_request_target" {
 			return "", false, triggerFilterError(t, &UnsupportedPathFiltersError{Event: t.Event}, "paths", "paths-ignore")
 		}
 		if _, err := pathFiltersMatch(nil, t.Paths, t.PathsIgnore); err != nil {
@@ -575,27 +576,27 @@ func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpression
 			}
 		}
 		return strings.Join(parts, " && "), true, nil
-	case "pull_request":
+	case "pull_request", "pull_request_target":
 		if t.Tags != nil || t.TagsIgnore != nil || t.Workflows != nil {
 			return "", false, unsupportedEventFilter(t, "tags", "tags-ignore", "workflows")
 		}
 		if expressions.EventPredicate == "" || expressions.PullRequestAction == "" {
-			return "", false, fmt.Errorf("pull_request requires effective event and action expressions")
+			return "", false, fmt.Errorf("%s requires effective event and action expressions", t.Event)
 		}
 		if expressions.PullRequestAction == "null" {
-			return "", false, fmt.Errorf("pull_request event snapshot requires payload.action")
+			return "", false, fmt.Errorf("%s event snapshot requires payload.action", t.Event)
 		}
 		parts := []string{expressions.EventPredicate}
 		hasBranchFilter := t.Branches != nil || t.BranchesIgnore != nil
 		if hasBranchFilter && expressions.PullRequestBaseBranch == "" {
-			return "", false, triggerFilterError(t, fmt.Errorf("pull_request branch filters require a base branch expression"), "branches", "branches-ignore")
+			return "", false, triggerFilterError(t, fmt.Errorf("%s branch filters require a base branch expression", t.Event), "branches", "branches-ignore")
 		}
 		if hasBranchFilter && expressions.PullRequestBaseBranch == "null" {
-			return "", false, triggerFilterError(t, fmt.Errorf("pull_request branch filters require payload.pull_request.base.ref"), "branches", "branches-ignore")
+			return "", false, triggerFilterError(t, fmt.Errorf("%s branch filters require payload.pull_request.base.ref", t.Event), "branches", "branches-ignore")
 		}
 		b, hasBranchFilter, err := refFilters(expressions.PullRequestBaseBranch, t.Branches, t.BranchesIgnore)
 		if err != nil {
-			return "", false, triggerFilterError(t, fmt.Errorf("pull_request branches: %w", err), "branches", "branches-ignore")
+			return "", false, triggerFilterError(t, fmt.Errorf("%s branches: %w", t.Event, err), "branches", "branches-ignore")
 		}
 		if hasBranchFilter {
 			parts = append(parts, b)
@@ -605,12 +606,12 @@ func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpression
 			types = []string{"opened", "synchronize", "reopened"}
 		}
 		if len(types) == 0 {
-			return "", false, triggerFilterError(t, fmt.Errorf("pull_request types is explicitly empty"), "types")
+			return "", false, triggerFilterError(t, fmt.Errorf("%s types is explicitly empty", t.Event), "types")
 		}
 		var actions []string
 		for _, a := range types {
 			if !supportedPullRequestAction[a] {
-				return "", false, triggerFilterError(t, fmt.Errorf("pull_request activity type %q cannot be mapped exactly", a), "types")
+				return "", false, triggerFilterError(t, fmt.Errorf("%s activity type %q cannot be mapped exactly", t.Event, a), "types")
 			}
 			actions = append(actions, expressions.PullRequestAction+` == `+yamlScalar(a))
 		}
@@ -622,7 +623,7 @@ func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpression
 			if snapshot.PullRequestBaseBranch != nil {
 				matches, err := refFilterMatches(*snapshot.PullRequestBaseBranch, t.Branches, t.BranchesIgnore)
 				if err != nil {
-					return "", false, triggerFilterError(t, fmt.Errorf("pull_request branches: %w", err), "branches", "branches-ignore")
+					return "", false, triggerFilterError(t, fmt.Errorf("%s branches: %w", t.Event, err), "branches", "branches-ignore")
 				}
 				if !matches {
 					return strings.Join(parts, " && "), true, nil
@@ -633,7 +634,7 @@ func translateTrigger(t workflow.Trigger, expressions TriggerConditionExpression
 			}
 			matches, err := pathFiltersMatch(snapshot.ChangedPaths.Paths, t.Paths, t.PathsIgnore)
 			if err != nil {
-				return "", false, triggerFilterError(t, fmt.Errorf("pull_request paths: %w", err), "paths", "paths-ignore")
+				return "", false, triggerFilterError(t, fmt.Errorf("%s paths: %w", t.Event, err), "paths", "paths-ignore")
 			}
 			if !matches {
 				return "", false, nil

--- a/internal/buildkite/triggers_test.go
+++ b/internal/buildkite/triggers_test.go
@@ -423,12 +423,12 @@ func TestTranslateTriggerConditionIgnoresUnsupportedEventsBesideSupportedOnes(t 
 	got, err := TranslateTriggerCondition([]workflow.Trigger{
 		{Event: "push"},
 		{Event: "discussion"},
-		{Event: "pull_request_target", Paths: []string{"src/**"}, Branches: []string{"main"}},
+		{Event: "workflow_run", Paths: []string{"src/**"}, Branches: []string{"main"}},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(got, `build.env("BUILDKITE_GITHUB_EVENT") == "push"`) || strings.Contains(got, "discussion") || strings.Contains(got, "pull_request_target") {
+	if !strings.Contains(got, `build.env("BUILDKITE_GITHUB_EVENT") == "push"`) || strings.Contains(got, "discussion") || strings.Contains(got, "workflow_run") {
 		t.Fatalf("condition = %q", got)
 	}
 }
@@ -437,13 +437,13 @@ func TestValidateTriggerConditionsIgnoresUnsupportedEventsBesideSupportedOnes(t 
 	if err := ValidateTriggerConditions([]workflow.Trigger{
 		{Event: "push"},
 		{Event: "discussion"},
-		{Event: "pull_request_target", Paths: []string{"src/**"}},
+		{Event: "workflow_run", Paths: []string{"src/**"}},
 		{Event: "workflow_run"},
 	}); err != nil {
 		t.Fatalf("ValidateTriggerConditions() error = %v", err)
 	}
-	err := ValidateTriggerConditions([]workflow.Trigger{{Event: "discussion"}, {Event: "pull_request_target"}})
-	if err == nil || !strings.Contains(err.Error(), `unsupported GitHub trigger event "discussion"`) || !strings.Contains(err.Error(), `unsupported GitHub trigger event "pull_request_target"`) {
+	err := ValidateTriggerConditions([]workflow.Trigger{{Event: "discussion"}, {Event: "workflow_run"}})
+	if err == nil || !strings.Contains(err.Error(), `unsupported GitHub trigger event "discussion"`) || !strings.Contains(err.Error(), `unsupported GitHub trigger event "workflow_run"`) {
 		t.Fatalf("ValidateTriggerConditions() error = %v", err)
 	}
 }
@@ -455,7 +455,7 @@ func TestTranslateEventTriggerConditionIgnoresUnsupportedEvents(t *testing.T) {
 		Tag:            "build.tag",
 	}
 	condition, applicable, err := TranslateEventTriggerCondition([]workflow.Trigger{
-		{Event: "push"}, {Event: "discussion"}, {Event: "pull_request_target", Paths: []string{"src/**"}},
+		{Event: "push"}, {Event: "discussion"}, {Event: "workflow_run", Paths: []string{"src/**"}},
 	}, "push", expressions, TriggerEventSnapshot{})
 	if err != nil || !applicable {
 		t.Fatalf("condition/applicable/error = %q / %t / %v", condition, applicable, err)

--- a/internal/cli/buildkite_event.go
+++ b/internal/cli/buildkite_event.go
@@ -123,7 +123,7 @@ func buildkiteEventSource(getenv func(string) string) ([]byte, error) {
 				}
 				payload = map[string]any{"ref": ref}
 			}
-		case "issues", "issue_comment", "pull_request_review", "pull_request_review_comment", "release", "merge_group", "deployment", "deployment_status", "create", "delete", "label":
+		case "issues", "issue_comment", "pull_request_target", "pull_request_review", "pull_request_review_comment", "release", "merge_group", "deployment", "deployment_status", "create", "delete", "label":
 			if (githubEvent == "issues" || githubEvent == "release" || githubEvent == "merge_group") && getenv(pipelineTriggerWorkflowPathEnvironment) == "" &&
 				getenv(githubWorkflowRefEnvironment) == "" && getenv(githubWorkflowSHAEnvironment) == "" {
 				break
@@ -162,6 +162,15 @@ func buildkiteEventSource(getenv func(string) string) ([]byte, error) {
 	repository := map[string]any{"owner": owner, "name": name, "clone_url": cloneURL}
 	if defaultBranch := strings.TrimSpace(getenv("BUILDKITE_PIPELINE_DEFAULT_BRANCH")); defaultBranch != "" {
 		repository["default_branch"] = defaultBranch
+	}
+	if event == "pull_request_target" {
+		if githubEvent != getenv("BUILDKITE_GITHUB_EVENT") || ref != "refs/heads/"+branch || tag != "" || pullRequest == "" || pullRequest == "false" {
+			return nil, fmt.Errorf("pull_request_target workflow ref or PR identity does not match the Buildkite build")
+		}
+		// Ingestion resolved the default branch. The payload and pipeline settings
+		// can describe older or unrelated defaults, and must not select execution.
+		repository["default_branch"] = branch
+		payload = map[string]any{}
 	}
 	if event == "create" || event == "delete" || event == "label" {
 		if pullRequest != "" && pullRequest != "false" || branch != plan.EventRefName(ref) ||
@@ -246,6 +255,11 @@ func buildkiteWebhookEventSource(getenv func(string) string, webhook []byte) ([]
 	}
 	if snapshot["event"] == "pull_request_review" || snapshot["event"] == "pull_request_review_comment" {
 		if err := validateBuildkiteReviewEvent(snapshot, getenv); err != nil {
+			return nil, err
+		}
+	}
+	if snapshot["event"] == "pull_request_target" {
+		if err := validateBuildkitePullRequestTarget(snapshot, getenv); err != nil {
 			return nil, err
 		}
 	}
@@ -447,6 +461,39 @@ func validateBuildkiteReviewEvent(snapshot map[string]any, getenv func(string) s
 		if !strings.EqualFold(fullName, owner+"/"+name) {
 			return fmt.Errorf("%s webhook requires the build repository for repository, PR head, and PR base; forks are unsupported", event)
 		}
+	}
+	return nil
+}
+
+func validateBuildkitePullRequestTarget(snapshot map[string]any, getenv func(string) string) error {
+	payload := snapshot["payload"].(map[string]any)
+	pr, _ := payload["pull_request"].(map[string]any)
+	if !positiveJSONInteger(pr["number"]) || pr["number"] != payload["number"] || fmt.Sprint(pr["number"]) != getenv("BUILDKITE_PULL_REQUEST") {
+		return fmt.Errorf("pull_request_target webhook number does not match BUILDKITE_PULL_REQUEST")
+	}
+	if action, _ := payload["action"].(string); action == "" || action != getenv("BUILDKITE_GITHUB_ACTION") {
+		return fmt.Errorf("pull_request_target webhook action does not match BUILDKITE_GITHUB_ACTION")
+	}
+	provider, owner, name, _, err := parseBuildkiteRepository(getenv("BUILDKITE_REPO"))
+	repository, _ := payload["repository"].(map[string]any)
+	base, _ := pr["base"].(map[string]any)
+	baseRepository, _ := base["repo"].(map[string]any)
+	if err != nil || provider != "github" || !positiveJSONInteger(repository["id"]) || repository["id"] != baseRepository["id"] ||
+		!strings.EqualFold(nestedString(payload, "repository", "full_name"), owner+"/"+name) ||
+		!strings.EqualFold(nestedString(pr, "base", "repo", "full_name"), owner+"/"+name) {
+		return fmt.Errorf("pull_request_target webhook base repository identity does not match BUILDKITE_REPO")
+	}
+	if !git.ValidObjectID(nestedString(pr, "base", "sha")) || !git.ValidObjectID(nestedString(pr, "head", "sha")) ||
+		nestedString(pr, "head", "ref") == "" || nestedString(pr, "base", "ref") == "" || nestedString(pr, "base", "ref") != getenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH") {
+		return fmt.Errorf("pull_request_target webhook requires head/base SHAs and matching base branch")
+	}
+	headProvider, headOwner, headName, _, err := parseBuildkiteRepository(getenv("BUILDKITE_PULL_REQUEST_REPO"))
+	head, _ := pr["head"].(map[string]any)
+	headRepository, _ := head["repo"].(map[string]any)
+	if err != nil || headProvider != "github" || !positiveJSONInteger(headRepository["id"]) ||
+		strings.EqualFold(headOwner+"/"+headName, owner+"/"+name) != (headRepository["id"] == repository["id"]) ||
+		!strings.EqualFold(nestedString(pr, "head", "repo", "full_name"), headOwner+"/"+headName) {
+		return fmt.Errorf("pull_request_target webhook head repository does not match BUILDKITE_PULL_REQUEST_REPO")
 	}
 	return nil
 }

--- a/internal/cli/buildkite_event_test.go
+++ b/internal/cli/buildkite_event_test.go
@@ -353,7 +353,7 @@ func TestBuildkiteWebhookEventSourceUsesPayloadButPreservesExecutionIdentity(t *
 		"BUILDKITE_COMMIT":       strings.Repeat("a", 40),
 		"BUILDKITE_BRANCH":       "executed-branch",
 		"BUILDKITE_BUILD_AUTHOR": "Build Author",
-		"BUILDKITE_GITHUB_EVENT": "pull_request_target",
+		"BUILDKITE_GITHUB_EVENT": "discussion",
 	}
 	webhook := []byte("{\"ref\":\"refs/heads/trigger-branch\",\"after\":\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"repository\":{\"full_name\":\"other/trigger\"},\"sender\":{\"login\":\"octocat\"},\"nested\":{\"complete\":true}}")
 	source, err := buildkiteWebhookEventSource(func(key string) string { return env[key] }, webhook)
@@ -366,7 +366,7 @@ func TestBuildkiteWebhookEventSourceUsesPayloadButPreservesExecutionIdentity(t *
 	}
 	payload := snapshot["payload"].(map[string]any)
 	repository := snapshot["repository"].(map[string]any)
-	if snapshot["event"] != "pull_request_target" || snapshot["actor"] != "octocat" ||
+	if snapshot["event"] != "discussion" || snapshot["actor"] != "octocat" ||
 		snapshot["sha"] != strings.Repeat("a", 40) || snapshot["ref"] != "refs/heads/executed-branch" ||
 		repository["owner"] != "buildkite" || repository["name"] != "buildkite-gha" ||
 		payload["after"] != strings.Repeat("b", 40) || payload["nested"].(map[string]any)["complete"] != true {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -461,7 +461,7 @@ func TestRunValidateAndCompile(t *testing.T) {
 
 	t.Run("validate hosted profile ignores unsupported trigger events beside a supported one", func(t *testing.T) {
 		workflow := filepath.Join(t.TempDir(), "mixed.yml")
-		if err := os.WriteFile(workflow, []byte("on: [push, discussion, pull_request_target]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
+		if err := os.WriteFile(workflow, []byte("on: [push, discussion, workflow_run]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n"), 0o600); err != nil {
 			t.Fatal(err)
 		}
 		var stdout, stderr bytes.Buffer
@@ -487,7 +487,7 @@ func TestRunValidateAndCompile(t *testing.T) {
 				messages[event] = message
 			}
 		}
-		for _, event := range []string{"discussion", "pull_request_target"} {
+		for _, event := range []string{"discussion", "workflow_run"} {
 			want := "on." + event + " is ignored, so nothing in this workflow runs from it. The supported triggers declared in this workflow still run: push. Move the jobs this trigger guards to one of those triggers if you need them. If you need " + event + ", log an issue on https://github.com/buildkite/buildkite-gha so we can prioritise it."
 			if messages[event] != want {
 				t.Fatalf("unsupported-trigger message for %s = %q, want %q; report = %#v", event, messages[event], want, report)

--- a/internal/cli/effective_event.go
+++ b/internal/cli/effective_event.go
@@ -54,7 +54,7 @@ func loadEffectiveEventSource(ctx context.Context, eventPath string, agent trans
 		if err != nil {
 			return nil, "", err
 		}
-		if event == "label" || event == "create" || event == "delete" || event == "deployment" || event == "deployment_status" || event == "pull_request_review" || event == "pull_request_review_comment" || ((event == "release" || event == "merge_group") && os.Getenv(pipelineTriggerWorkflowPathEnvironment) != "") {
+		if event == "pull_request_target" || event == "label" || event == "create" || event == "delete" || event == "deployment" || event == "deployment_status" || event == "pull_request_review" || event == "pull_request_review_comment" || ((event == "release" || event == "merge_group") && os.Getenv(pipelineTriggerWorkflowPathEnvironment) != "") {
 			return nil, "", fmt.Errorf("%s requires the original buildkite:webhook payload; rebuilds without it are unsupported", event)
 		}
 		source, err := buildkiteEventSource(os.Getenv)
@@ -172,7 +172,7 @@ func selectWorkflowTrigger(triggers []workflow.Trigger, event effectiveEventSele
 
 func pathFilterContextRequired(err error) bool {
 	var pathFilters *buildkitepipeline.UnsupportedPathFiltersError
-	return errors.As(err, &pathFilters) && (pathFilters.Event == "push" || pathFilters.Event == "pull_request") && pathFilters.Reason == ""
+	return errors.As(err, &pathFilters) && (pathFilters.Event == "push" || pathFilters.Event == "pull_request" || pathFilters.Event == "pull_request_target") && pathFilters.Reason == ""
 }
 
 func triggerConditionLiteral(value string) string {

--- a/internal/cli/path_filters.go
+++ b/internal/cli/path_filters.go
@@ -32,7 +32,7 @@ func gitRootCommand(checkoutPath string) *exec.Cmd {
 }
 
 func populateChangedPaths(snapshot *buildkitepipeline.TriggerEventSnapshot, event compiler.Event, origin effectiveEventOrigin, workflows []workflowInput, checkoutPath string) {
-	if event.Event != "pull_request" && event.Event != "push" {
+	if event.Event != "pull_request" && event.Event != "pull_request_target" && event.Event != "push" {
 		return
 	}
 	if event.Event == "push" && snapshot.Tag != nil {
@@ -342,8 +342,12 @@ func pullRequestChangedPaths(event compiler.Event, pullRequestNumber int, baseRe
 	if !git.ValidObjectID(baseSHA) || !git.ValidObjectID(headSHA) {
 		return nil, nil, fmt.Errorf("event snapshot requires full lowercase payload.pull_request base and head commit SHAs")
 	}
-	if headSHA != event.SHA {
+	if event.Event != "pull_request_target" && headSHA != event.SHA {
 		return nil, nil, fmt.Errorf("pull request head SHA does not match the checked-out event SHA")
+	}
+	sourceRevision := "head"
+	if event.Event == "pull_request_target" {
+		sourceRevision = "default"
 	}
 	rootBytes, err := gitRootCommand(checkoutPath).Output()
 	if err != nil {
@@ -357,8 +361,8 @@ func pullRequestChangedPaths(event compiler.Event, pullRequestNumber int, baseRe
 		return nil, nil, fmt.Errorf("pull request head commit is unavailable in the local checkout")
 	}
 	checkoutSHA, err := gitCommand(root, "rev-parse", "--verify", "HEAD^{commit}").Output()
-	if err != nil || strings.TrimSpace(string(checkoutSHA)) != headSHA {
-		return nil, nil, fmt.Errorf("pull request head SHA does not match the local checkout")
+	if err != nil || strings.TrimSpace(string(checkoutSHA)) != event.SHA {
+		return nil, nil, fmt.Errorf("pull request %s SHA does not match the local checkout", sourceRevision)
 	}
 	workflowErrors := make(map[string]string)
 	for i, input := range workflows {
@@ -369,9 +373,9 @@ func pullRequestChangedPaths(event compiler.Event, pullRequestNumber int, baseRe
 			workflowErrors[input.CanonicalPath] = fmt.Sprintf("workflow %q is not provider-backed and cannot use pull request path filters", input.CanonicalPath)
 			continue
 		}
-		headSource, err := gitCommand(root, "cat-file", "blob", headSHA+":"+input.CanonicalPath).Output()
-		if err != nil || !bytes.Equal(headSource, input.Source) {
-			workflowErrors[input.CanonicalPath] = fmt.Sprintf("workflow %q does not match the pull request head commit", input.CanonicalPath)
+		workflowSource, err := gitCommand(root, "cat-file", "blob", event.SHA+":"+input.CanonicalPath).Output()
+		if err != nil || !bytes.Equal(workflowSource, input.Source) {
+			workflowErrors[input.CanonicalPath] = fmt.Sprintf("workflow %q does not match the pull request %s commit", input.CanonicalPath, sourceRevision)
 			continue
 		}
 		workflows[i].PathFiltersIdentityVerified = true

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -69,6 +69,12 @@ func pluginContext(ctx context.Context, args []string, stdout, stderr io.Writer,
 		_, _ = fmt.Fprintf(stderr, "buildkite-gha: plugin: %s does not match BUILDKITE_COMMIT after checkout: %q != %q\n", githubWorkflowSHAEnvironment, serverSelectedWorkflow.SHA, os.Getenv("BUILDKITE_COMMIT"))
 		return 1
 	}
+	if event, _ := buildkiteGitHubEventName(os.Getenv); event == "pull_request_target" {
+		if err := verifyTargetCheckout(checkoutPath, serverSelectedWorkflow.SHA, os.Getenv("BUILDKITE_REPO")); err != nil {
+			_, _ = fmt.Fprintf(stderr, "buildkite-gha: plugin: %v\n", err)
+			return 1
+		}
+	}
 	return uploadParsedContext(ctx, parsedUploadArgs{
 		workflowOperands:         workflowOperands,
 		explicitWorkflowPaths:    true,
@@ -234,6 +240,9 @@ type pipelineTriggerWorkflow struct {
 
 func pluginWorkflowOperands(configuration pluginConfiguration, getenv func(string) string) ([]string, *pipelineTriggerWorkflow, error) {
 	if len(configuration.Workflows) != 0 {
+		if event, _ := buildkiteGitHubEventName(getenv); event == "pull_request_target" {
+			return nil, nil, fmt.Errorf("pull_request_target requires the server-selected workflow, without workflow or workflows overrides")
+		}
 		return configuration.Workflows, nil, nil
 	}
 	compatibilityPath := getenv(pipelineTriggerWorkflowPathEnvironment)
@@ -256,8 +265,8 @@ func pluginWorkflowOperands(configuration pluginConfiguration, getenv func(strin
 	if event == "" {
 		return nil, nil, fmt.Errorf("%s or BUILDKITE_GITHUB_EVENT is required", githubEventNameEnvironment)
 	}
-	if event != "label" && event != "create" && event != "delete" && event != "push" && event != "pull_request" && event != "issues" && event != "issue_comment" && event != "pull_request_review" && event != "pull_request_review_comment" && event != "release" && event != "merge_group" && event != "deployment" && event != "deployment_status" {
-		return nil, nil, fmt.Errorf("%s or BUILDKITE_GITHUB_EVENT must be push, pull_request, issues, issue_comment, pull_request_review, pull_request_review_comment, release, merge_group, deployment, deployment_status, create, delete, or label", githubEventNameEnvironment)
+	if event != "label" && event != "create" && event != "delete" && event != "push" && event != "pull_request" && event != "pull_request_target" && event != "issues" && event != "issue_comment" && event != "pull_request_review" && event != "pull_request_review_comment" && event != "release" && event != "merge_group" && event != "deployment" && event != "deployment_status" {
+		return nil, nil, fmt.Errorf("%s or BUILDKITE_GITHUB_EVENT must be push, pull_request, pull_request_target, issues, issue_comment, pull_request_review, pull_request_review_comment, release, merge_group, deployment, deployment_status, create, delete, or label", githubEventNameEnvironment)
 	}
 
 	workflowName := getenv(githubWorkflowEnvironment)
@@ -276,8 +285,11 @@ func pluginWorkflowOperands(configuration pluginConfiguration, getenv func(strin
 	if workflowSHA != "" && !git.ValidObjectID(workflowSHA) {
 		return nil, nil, fmt.Errorf("%s must be a full lowercase 40-hex commit", githubWorkflowSHAEnvironment)
 	}
-	if (event == "label" || event == "create" || event == "delete" || event == "issues" || event == "issue_comment" || event == "pull_request_review" || event == "pull_request_review_comment" || event == "release" || event == "merge_group" || event == "deployment" || event == "deployment_status") && (getenv(githubWorkflowRefEnvironment) == "" || workflowSHA == "") {
+	if (event == "pull_request_target" || event == "label" || event == "create" || event == "delete" || event == "issues" || event == "issue_comment" || event == "pull_request_review" || event == "pull_request_review_comment" || event == "release" || event == "merge_group" || event == "deployment" || event == "deployment_status") && (getenv(githubWorkflowRefEnvironment) == "" || workflowSHA == "") {
 		return nil, nil, fmt.Errorf("%s and %s are required for %s", githubWorkflowRefEnvironment, githubWorkflowSHAEnvironment, event)
+	}
+	if event == "pull_request_target" && selectedPath != compatibilityPath {
+		return nil, nil, fmt.Errorf("%s path does not match %s", githubWorkflowRefEnvironment, pipelineTriggerWorkflowPathEnvironment)
 	}
 	return []string{selectedPath}, &pipelineTriggerWorkflow{Name: workflowName, SHA: workflowSHA}, nil
 }
@@ -332,7 +344,7 @@ func pipelineTriggerEventRef(event, ref string) bool {
 		number, ok = strings.CutSuffix(number, "/merge")
 		parsed, err := strconv.Atoi(number)
 		return ok && err == nil && parsed > 0 && strconv.Itoa(parsed) == number
-	case "issues", "issue_comment", "merge_group", "delete", "label":
+	case "issues", "issue_comment", "merge_group", "delete", "label", "pull_request_target":
 		branch, ok := strings.CutPrefix(ref, "refs/heads/")
 		return ok && branch != ""
 	case "release":
@@ -447,6 +459,49 @@ func normalizePluginCommit(ctx context.Context, checkoutPath string, getenv func
 	}
 	if err := setenv("BUILDKITE_COMMIT", commit); err != nil {
 		return fmt.Errorf("set resolved BUILDKITE_COMMIT: %w", err)
+	}
+	return nil
+}
+
+// Target imports read workflows, local reusable workflows and action source
+// from this tree. Checking only BUILDKITE_COMMIT would allow a head checkout or
+// dirty local action to masquerade as the server's trusted default revision.
+// Hooks and concurrent writers remain part of the trusted agent boundary.
+func verifyTargetCheckout(checkoutPath, sha, repository string) error {
+	rootBytes, err := gitRootCommand(checkoutPath).Output()
+	if err != nil || !git.ValidObjectID(sha) {
+		return fmt.Errorf("pull_request_target requires the selected Git checkout")
+	}
+	root := strings.TrimSpace(string(rootBytes))
+	head, err := gitCommand(root, "rev-parse", "--verify", "HEAD^{commit}").Output()
+	if err != nil || strings.TrimSpace(string(head)) != sha {
+		return fmt.Errorf("pull_request_target checkout HEAD does not match GITHUB_WORKFLOW_SHA")
+	}
+	remote, err := gitCommand(root, "remote", "get-url", "origin").Output()
+	provider, owner, name, _, parseErr := parseBuildkiteRepository(strings.TrimSpace(string(remote)))
+	wantProvider, wantOwner, wantName, _, wantErr := parseBuildkiteRepository(repository)
+	if err != nil || parseErr != nil || wantErr != nil || provider != "github" || provider != wantProvider || !strings.EqualFold(owner+"/"+name, wantOwner+"/"+wantName) {
+		return fmt.Errorf("pull_request_target checkout origin does not match BUILDKITE_REPO")
+	}
+	// Reject index flags that could hide changes from diff (sparse checkout,
+	// assume-unchanged), and submodules whose worktrees have separate identity.
+	entries, err := gitCommand(root, "ls-files", "-v", "--stage", "-z").Output()
+	if err != nil {
+		return fmt.Errorf("pull_request_target cannot inspect checkout index")
+	}
+	for entry := range strings.SplitSeq(strings.TrimSuffix(string(entries), "\x00"), "\x00") {
+		if !strings.HasPrefix(entry, "H ") || strings.HasPrefix(entry, "H 160000 ") {
+			return fmt.Errorf("pull_request_target requires a complete checkout without index overrides or submodules")
+		}
+	}
+	if err := gitCommand(root, "-c", "core.fsmonitor=false", "diff", "--exit-code", "--no-ext-diff", "--no-textconv", sha, "--").Run(); err != nil {
+		return fmt.Errorf("pull_request_target requires an unchanged checkout of GITHUB_WORKFLOW_SHA")
+	}
+	// Without --exclude-standard this includes ignored files. They too can be
+	// consumed as local actions, scripts, or reusable workflows.
+	untracked, err := gitCommand(root, "ls-files", "--others", "-z").Output()
+	if err != nil || len(untracked) != 0 {
+		return fmt.Errorf("pull_request_target requires a clean checkout without untracked or ignored files")
 	}
 	return nil
 }

--- a/internal/cli/pull_request_target_test.go
+++ b/internal/cli/pull_request_target_test.go
@@ -1,0 +1,297 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/buildkite-gha/internal/compiler"
+	"github.com/buildkite/buildkite-gha/internal/plan"
+	"go.yaml.in/yaml/v4"
+)
+
+// The three revisions deliberately disagree. The PR targets release, not the
+// default branch trunk; both PR revisions contain different executable source.
+func targetFixture(t *testing.T, headRepo, filters string) (root, trusted, base, head string, webhook []byte) {
+	t.Helper()
+	root = writeUploadWorkflowRepository(t, map[string]string{
+		"ci.yml":       "name: Target\non:\n  pull_request_target:\n" + filters + "jobs:\n  direct:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo TRUSTED_DEFAULT\n        env:\n          HEAD_REF: ${{ github.head_ref }}\n          BASE_REF: ${{ github.base_ref }}\n          PR: ${{ github.event.number }}\n      - uses: ./.github/actions/sentinel\n  call:\n    uses: ./.github/workflows/reusable.yml\n",
+		"reusable.yml": "on: workflow_call\njobs:\n  child:\n    runs-on: ubuntu-latest\n    steps: [{run: echo TRUSTED_REUSABLE}]\n",
+	})
+	write := func(path, value string) {
+		t.Helper()
+		path = filepath.Join(root, path)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(value), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	git := func(args ...string) string { return targetGit(t, root, args...) }
+	git("config", "user.email", "sentinel@example.com")
+	git("config", "user.name", "Sentinel")
+	git("remote", "add", "origin", "https://github.com/buildkite/buildkite-gha.git")
+	write(".github/actions/sentinel/action.yml", "name: sentinel\nruns:\n  using: composite\n  steps:\n    - run: echo TRUSTED_ACTION\n      shell: bash\n")
+	git("add", ".")
+	git("commit", "-qm", "trusted default source")
+	trusted = git("rev-parse", "HEAD")
+	git("branch", "trunk")
+	write("release.txt", "base-only change\n")
+	for _, path := range []string{".github/workflows/ci.yml", ".github/workflows/reusable.yml", ".github/actions/sentinel/action.yml"} {
+		contents, err := os.ReadFile(filepath.Join(root, path))
+		if err != nil {
+			t.Fatal(err)
+		}
+		write(path, strings.ReplaceAll(string(contents), "TRUSTED_", "BASE_"))
+	}
+	git("add", ".")
+	git("commit", "-qm", "release base")
+	base = git("rev-parse", "HEAD")
+	git("branch", "release")
+	write("src/pr.txt", "head-only change\n")
+	write(".github/workflows/ci.yml", "on: pull_request_target\njobs:\n  stolen:\n    runs-on: ubuntu-latest\n    steps: [{run: echo UNTRUSTED_HEAD}]\n")
+	write(".github/workflows/reusable.yml", "on: workflow_call\njobs:\n  stolen:\n    runs-on: ubuntu-latest\n    steps: [{run: echo UNTRUSTED_REUSABLE}]\n")
+	write(".github/actions/sentinel/action.yml", "name: sentinel\nruns:\n  using: composite\n  steps:\n    - run: echo UNTRUSTED_ACTION\n      shell: bash\n")
+	git("add", ".")
+	git("commit", "-qm", "untrusted head")
+	head = git("rev-parse", "HEAD")
+	// Simulate a default ref moving after dispatch without moving execution.
+	git("update-ref", "refs/heads/trunk", head)
+	git("checkout", "--detach", trusted)
+	t.Chdir(root)
+	setCLIPluginBuildkiteEnvironment(t, "target-importer")
+	t.Setenv(pluginConfigurationEnvironment, `{}`)
+	t.Setenv("BUILDKITE_JOB_ID", cliTestJobID)
+	t.Setenv("BUILDKITE_BUILD_CHECKOUT_PATH", root)
+	t.Setenv("BUILDKITE_COMMIT", trusted)
+	t.Setenv("BUILDKITE_BRANCH", "trunk")
+	t.Setenv("BUILDKITE_PIPELINE_DEFAULT_BRANCH", "stale-pipeline-default")
+	t.Setenv("BUILDKITE_PULL_REQUEST", "42")
+	t.Setenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH", "release")
+	t.Setenv("BUILDKITE_PULL_REQUEST_REPO", "https://github.com/"+headRepo+".git")
+	setCLIPipelineTriggerEnvironment(t, ".github/workflows/ci.yml", "Target", "pull_request_target", "buildkite/buildkite-gha/.github/workflows/ci.yml@refs/heads/trunk")
+	t.Setenv("BUILDKITE_GITHUB_ACTION", "opened")
+	webhook = []byte(`{"action":"opened","number":42,"repository":{"id":123,"full_name":"buildkite/buildkite-gha","default_branch":"stale-webhook-default"},"pull_request":{"number":42,"title":"$(echo UNTRUSTED_TITLE)","mergeable":false,"merged":false,"base":{"ref":"release","sha":"` + base + `","repo":{"id":123,"full_name":"buildkite/buildkite-gha"}},"head":{"ref":"feature","sha":"` + head + `","repo":{"id":456,"full_name":"` + headRepo + `"}}}}`)
+	if headRepo == "buildkite/buildkite-gha" {
+		webhook = bytes.Replace(webhook, []byte(`"id":456`), []byte(`"id":123`), 1)
+	}
+	return
+}
+
+func targetGit(t *testing.T, root string, args ...string) string {
+	t.Helper()
+	output, err := exec.Command("git", append([]string{"-C", root}, args...)...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v: %s", args, err, output)
+	}
+	return strings.TrimSpace(string(output))
+}
+
+func TestPluginPullRequestTargetTrustedSource(t *testing.T) {
+	requireImporterHost(t)
+	for _, headRepo := range []string{"contributor/fork", "buildkite/buildkite-gha"} {
+		t.Run(headRepo, func(t *testing.T) {
+			_, trusted, _, head, webhook := targetFixture(t, headRepo, "    branches: [release]\n    paths: ['src/**']\n")
+			runner := &cliCaptureRunner{webhook: webhook}
+			var stdout, stderr bytes.Buffer
+			if code := run([]string{"plugin"}, &stdout, &stderr, "dev", runner); code != 0 || !strings.Contains(stdout.String(), "Uploaded 2 jobs") {
+				t.Fatalf("plugin: %d\n%s\n%s", code, &stdout, &stderr)
+			}
+			plans := 0
+			var encodedPlans []byte
+			for path, contents := range runner.uploaded {
+				if !strings.HasPrefix(path, ".buildkite-gha/plans/") {
+					continue
+				}
+				job, err := plan.Decode(contents)
+				if err != nil {
+					t.Fatal(err)
+				}
+				plans++
+				encodedPlans = append(encodedPlans, contents...)
+				if !job.Event.PayloadArtifact {
+					t.Fatal("target plan omitted checkout guard payload")
+				}
+				if job.Event.Name != "pull_request_target" || job.Event.Ref != "refs/heads/trunk" || job.Event.SHA != trusted || job.Event.Repository != "buildkite/buildkite-gha" || job.Event.HeadRef != "feature" || job.Event.BaseRef != "release" {
+					t.Fatalf("incorrect execution identity: %#v", job.Event)
+				}
+			}
+			if plans != 2 {
+				t.Fatalf("plans = %d", plans)
+			}
+			for _, marker := range []string{"TRUSTED_DEFAULT", "TRUSTED_ACTION", "TRUSTED_REUSABLE", "feature", "release"} {
+				if !bytes.Contains(encodedPlans, []byte(marker)) {
+					t.Errorf("plans omit %s", marker)
+				}
+			}
+			for _, marker := range []string{"UNTRUSTED_HEAD", "UNTRUSTED_ACTION", "UNTRUSTED_REUSABLE", "BASE_DEFAULT", "BASE_ACTION", "BASE_REUSABLE"} {
+				if bytes.Contains(encodedPlans, []byte(marker)) {
+					t.Errorf("plans executed %s", marker)
+				}
+			}
+			source, err := buildkiteWebhookEventSource(os.Getenv, webhook)
+			if err != nil {
+				t.Fatal(err)
+			}
+			event, err := compiler.ParseEvent(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if event.Repository.DefaultBranch != "trunk" || nestedString(event.Payload, "pull_request", "head", "sha") != head || nestedString(event.Payload, "pull_request", "head", "repo", "full_name") != headRepo || nestedInt(event.Payload, "number") != 42 {
+				t.Fatalf("PR data was replaced by default-checkout identity: %#v", event)
+			}
+		})
+	}
+}
+
+func TestPullRequestTargetRejectsIdentityAndCheckoutSubstitution(t *testing.T) {
+	for _, mutation := range []string{"head checkout", "dirty workflow", "dirty action", "ignored action", "index override", "wrong origin", "missing payload", "wrong path", "wrong SHA", "wrong ref", "wrong base repository", "wrong base ID", "missing base", "wrong head repository", "missing head ID", "forged head ID", "wrong number", "wrong action", "conflicting event"} {
+		t.Run(mutation, func(t *testing.T) {
+			root, _, _, head, webhook := targetFixture(t, "contributor/fork", "")
+			var payload map[string]any
+			if err := json.Unmarshal(webhook, &payload); err != nil {
+				t.Fatal(err)
+			}
+			pr := payload["pull_request"].(map[string]any)
+			switch mutation {
+			case "head checkout":
+				targetGit(t, root, "checkout", "--detach", head)
+			case "dirty workflow", "dirty action", "ignored action", "index override":
+				path := ".github/actions/sentinel/action.yml"
+				if mutation == "dirty workflow" {
+					path = ".github/workflows/ci.yml"
+				}
+				if mutation == "ignored action" {
+					path = ".github/actions/sentinel/generated.sh"
+					if err := os.WriteFile(filepath.Join(root, ".git/info/exclude"), []byte("generated.sh\n"), 0o600); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if mutation == "index override" {
+					targetGit(t, root, "update-index", "--assume-unchanged", path)
+				}
+				if err := os.WriteFile(filepath.Join(root, path), []byte("UNTRUSTED_LOCAL"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			case "wrong origin":
+				targetGit(t, root, "remote", "set-url", "origin", "https://github.com/contributor/fork.git")
+			case "missing payload":
+			case "wrong path":
+				t.Setenv(pipelineTriggerWorkflowPathEnvironment, ".github/workflows/reusable.yml")
+			case "wrong SHA":
+				t.Setenv(githubWorkflowSHAEnvironment, head)
+			case "wrong ref":
+				t.Setenv(githubWorkflowRefEnvironment, "buildkite/buildkite-gha/.github/workflows/ci.yml@refs/pull/42/merge")
+			case "wrong base repository":
+				pr["base"].(map[string]any)["repo"].(map[string]any)["full_name"] = "attacker/fork"
+			case "wrong base ID":
+				pr["base"].(map[string]any)["repo"].(map[string]any)["id"] = 789
+			case "missing base":
+				delete(pr, "base")
+			case "wrong head repository":
+				pr["head"].(map[string]any)["repo"].(map[string]any)["full_name"] = "attacker/other"
+			case "missing head ID":
+				delete(pr["head"].(map[string]any)["repo"].(map[string]any), "id")
+			case "forged head ID":
+				pr["head"].(map[string]any)["repo"].(map[string]any)["id"] = 123
+			case "wrong number":
+				payload["number"] = 41
+			case "wrong action":
+				payload["action"] = "closed"
+			case "conflicting event":
+				t.Setenv("BUILDKITE_GITHUB_EVENT", "pull_request")
+			}
+			webhook, err := json.Marshal(payload)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if mutation == "missing payload" {
+				webhook = nil
+			}
+			runner := &cliCaptureRunner{webhook: webhook}
+			var stdout, stderr bytes.Buffer
+			if code := run([]string{"plugin"}, &stdout, &stderr, "dev", runner); code == 0 || strings.Contains(stdout.String(), "Uploaded") {
+				t.Fatalf("accepted %s: %d\n%s\n%s", mutation, code, &stdout, &stderr)
+			}
+			for path := range runner.uploaded {
+				if strings.HasPrefix(path, ".buildkite-gha/plans/") {
+					t.Fatalf("uploaded executable plan after %s", mutation)
+				}
+			}
+		})
+	}
+}
+
+func TestPluginPullRequestTargetActivitiesAndPathFilters(t *testing.T) {
+	for _, test := range []struct {
+		name, action, filters string
+		wantJobs              bool
+	}{
+		{"opened default", "opened", "", true},
+		{"reopened default", "reopened", "", true},
+		{"synchronize default", "synchronize", "", true},
+		{"closed excluded by default", "closed", "", false},
+		{"closed merged", "closed", "    types: [closed]\n", true},
+		{"edited base", "edited", "    types: [edited]\n    branches: [release]\n", true},
+		{"filters use PR base not default", "opened", "    branches: [trunk]\n    paths: ['src/**']\n", false},
+		{"paths exclude base-only changes", "opened", "    paths: ['release.txt']\n", false},
+		{"paths ignore all PR changes", "opened", "    paths-ignore: ['src/**', '.github/**']\n", false},
+		{"paths ordered negative", "opened", "    paths: ['src/**', '!src/pr.txt']\n", false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, _, _, webhook := targetFixture(t, "contributor/fork", test.filters)
+			webhook = bytes.Replace(webhook, []byte(`"action":"opened"`), []byte(`"action":"`+test.action+`"`), 1)
+			if test.action == "closed" {
+				webhook = bytes.Replace(webhook, []byte(`"merged":false`), []byte(`"merged":true`), 1)
+			}
+			t.Setenv("BUILDKITE_GITHUB_ACTION", test.action)
+			runner := &cliCaptureRunner{webhook: webhook}
+			var stdout, stderr bytes.Buffer
+			if code := run([]string{"plugin"}, &stdout, &stderr, "dev", runner); code != 0 {
+				t.Fatalf("plugin: %d\n%s\n%s", code, &stdout, &stderr)
+			}
+			plans := 0
+			for path := range runner.uploaded {
+				if strings.HasPrefix(path, ".buildkite-gha/plans/") {
+					plans++
+				}
+			}
+			want := 0
+			if test.wantJobs {
+				want = 2
+			}
+			// Branch/activity filters are deferred to Buildkite condition evaluation;
+			// path exclusions omit plans. Assert the actual false condition rather
+			// than mistaking an uploaded (but gated) plan for an executed job.
+			falseCondition := ""
+			if test.name == "closed excluded by default" {
+				falseCondition = `("closed" == "opened" || "closed" == "synchronize" || "closed" == "reopened")`
+			}
+			if test.name == "filters use PR base not default" {
+				falseCondition = `"release" =~ /^trunk$/`
+			}
+			if falseCondition != "" {
+				want = 2
+				var pipeline struct {
+					Steps []struct {
+						Condition string `yaml:"if"`
+					} `yaml:"steps"`
+				}
+				if err := yaml.Unmarshal(runner.commands[len(runner.commands)-1].stdin, &pipeline); err != nil {
+					t.Fatal(err)
+				}
+				if len(pipeline.Steps) != 1 || !strings.Contains(pipeline.Steps[0].Condition, falseCondition) {
+					t.Fatalf("missing false filter %q: %#v", falseCondition, pipeline)
+				}
+			}
+			if plans != want {
+				t.Fatalf("plans = %d, want %d\n%s\n%s", plans, want, &stdout, &stderr)
+			}
+		})
+	}
+}

--- a/internal/cli/pull_request_target_test.go
+++ b/internal/cli/pull_request_target_test.go
@@ -18,6 +18,13 @@ import (
 // default branch trunk; both PR revisions contain different executable source.
 func targetFixture(t *testing.T, headRepo, filters string) (root, trusted, base, head string, webhook []byte) {
 	t.Helper()
+	// These tests capture uploads without executing the Linux job runtime.
+	// Supply its existing binary fixture when the importer host is macOS.
+	linuxRuntime := filepath.Join(t.TempDir(), "linux-runtime")
+	if err := os.WriteFile(linuxRuntime, pluginTestLinuxExecutable(), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(pluginDevLinuxRuntimeEnvironment, linuxRuntime)
 	root = writeUploadWorkflowRepository(t, map[string]string{
 		"ci.yml":       "name: Target\non:\n  pull_request_target:\n" + filters + "jobs:\n  direct:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo TRUSTED_DEFAULT\n        env:\n          HEAD_REF: ${{ github.head_ref }}\n          BASE_REF: ${{ github.base_ref }}\n          PR: ${{ github.event.number }}\n      - uses: ./.github/actions/sentinel\n  call:\n    uses: ./.github/workflows/reusable.yml\n",
 		"reusable.yml": "on: workflow_call\njobs:\n  child:\n    runs-on: ubuntu-latest\n    steps: [{run: echo TRUSTED_REUSABLE}]\n",
@@ -93,7 +100,6 @@ func targetGit(t *testing.T, root string, args ...string) string {
 }
 
 func TestPluginPullRequestTargetTrustedSource(t *testing.T) {
-	requireImporterHost(t)
 	for _, headRepo := range []string{"contributor/fork", "buildkite/buildkite-gha"} {
 		t.Run(headRepo, func(t *testing.T) {
 			_, trusted, _, head, webhook := targetFixture(t, headRepo, "    branches: [release]\n    paths: ['src/**']\n")

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -263,7 +263,7 @@ func validateAllEventsSource(ctx context.Context, out processingOutput, workflow
 		declared[trigger.Event] = true
 	}
 	failed := false
-	for _, event := range []string{"push", "pull_request", "merge_group", "release", "deployment", "deployment_status", "create", "delete", "label", "issues", "issue_comment", "pull_request_review", "pull_request_review_comment", "workflow_dispatch", "schedule"} {
+	for _, event := range []string{"push", "pull_request", "pull_request_target", "merge_group", "release", "deployment", "deployment_status", "create", "delete", "label", "issues", "issue_comment", "pull_request_review", "pull_request_review_comment", "workflow_dispatch", "schedule"} {
 		if !declared[event] {
 			continue
 		}
@@ -382,8 +382,8 @@ func validateArgs(args []string) (workflowPath, eventPath, eventName, format, pr
 	if eventSeen && profile == "" {
 		return "", "", "", "", "", false, fmt.Errorf("--event requires --profile hosted")
 	}
-	if eventSeen && !slices.Contains([]string{"push", "pull_request", "merge_group", "release", "deployment", "deployment_status", "create", "delete", "label", "issues", "issue_comment", "pull_request_review", "pull_request_review_comment", "workflow_dispatch", "schedule"}, eventName) {
-		return "", "", "", "", "", false, fmt.Errorf("unsupported --event %q; supported events are push, pull_request, merge_group, release, deployment, deployment_status, create, delete, label, issues, issue_comment, pull_request_review, pull_request_review_comment, workflow_dispatch, and schedule", eventName)
+	if eventSeen && !slices.Contains([]string{"push", "pull_request", "pull_request_target", "merge_group", "release", "deployment", "deployment_status", "create", "delete", "label", "issues", "issue_comment", "pull_request_review", "pull_request_review_comment", "workflow_dispatch", "schedule"}, eventName) {
+		return "", "", "", "", "", false, fmt.Errorf("unsupported --event %q; supported events are push, pull_request, pull_request_target, merge_group, release, deployment, deployment_status, create, delete, label, issues, issue_comment, pull_request_review, pull_request_review_comment, workflow_dispatch, and schedule", eventName)
 	}
 	if allEvents && (eventPathSeen || eventSeen) {
 		return "", "", "", "", "", false, fmt.Errorf("--all-events is mutually exclusive with --event and --event-path")
@@ -421,8 +421,10 @@ func generatedEventSnapshot(name string) ([]byte, error) {
 		}
 	case "push":
 		event.Payload["ref"] = event.Ref
-	case "pull_request", "pull_request_review", "pull_request_review_comment":
-		event.Ref = "refs/pull/1/merge"
+	case "pull_request", "pull_request_target", "pull_request_review", "pull_request_review_comment":
+		if name != "pull_request_target" {
+			event.Ref = "refs/pull/1/merge"
+		}
 		event.Payload["action"] = "opened"
 		event.Payload["number"] = 1
 		event.Payload["pull_request"] = map[string]any{
@@ -473,7 +475,7 @@ func generatedEventSnapshot(name string) ([]byte, error) {
 		event.Payload["schedule"] = "0 0 * * *"
 	case "workflow_dispatch":
 	default:
-		return nil, fmt.Errorf("unsupported generated event %q; supported events are push, pull_request, merge_group, release, deployment, deployment_status, create, delete, label, issues, issue_comment, pull_request_review, pull_request_review_comment, workflow_dispatch, and schedule", name)
+		return nil, fmt.Errorf("unsupported generated event %q; supported events are push, pull_request, pull_request_target, merge_group, release, deployment, deployment_status, create, delete, label, issues, issue_comment, pull_request_review, pull_request_review_comment, workflow_dispatch, and schedule", name)
 	}
 	return json.Marshal(event)
 }

--- a/internal/cli/validate_batch.go
+++ b/internal/cli/validate_batch.go
@@ -472,7 +472,7 @@ func loadBatchValidationResult(path, workflow string) (compatibility.ProcessingR
 	seen := make(map[string]bool, len(report.Evaluations))
 	for _, evaluation := range report.Evaluations {
 		if seen[evaluation.Event] || evaluation.Source != "generated" || evaluation.Report.Schema != compatibility.ProcessingSchema ||
-			(evaluation.Event != "label" && evaluation.Event != "create" && evaluation.Event != "delete" && evaluation.Event != "push" && evaluation.Event != "pull_request" && evaluation.Event != "merge_group" && evaluation.Event != "release" && evaluation.Event != "deployment" && evaluation.Event != "deployment_status" && evaluation.Event != "issues" && evaluation.Event != "issue_comment" && evaluation.Event != "pull_request_review" && evaluation.Event != "pull_request_review_comment" && evaluation.Event != "workflow_dispatch" && evaluation.Event != "schedule") {
+			(evaluation.Event != "label" && evaluation.Event != "create" && evaluation.Event != "delete" && evaluation.Event != "push" && evaluation.Event != "pull_request" && evaluation.Event != "pull_request_target" && evaluation.Event != "merge_group" && evaluation.Event != "release" && evaluation.Event != "deployment" && evaluation.Event != "deployment_status" && evaluation.Event != "issues" && evaluation.Event != "issue_comment" && evaluation.Event != "pull_request_review" && evaluation.Event != "pull_request_review_comment" && evaluation.Event != "workflow_dispatch" && evaluation.Event != "schedule") {
 			return compatibility.ProcessingReportV3{}, false
 		}
 		seen[evaluation.Event] = true

--- a/internal/compiler/plan_builder.go
+++ b/internal/compiler/plan_builder.go
@@ -711,7 +711,10 @@ func (b planBuilder) lowerPlanJob(instance JobInstance, workflowProgram program.
 		Actions:              actions.locks,
 	}
 	job.Event.PayloadFile = b.options.EventFile
-	job.Event.PayloadArtifact = actions.requiresEventPayload || job.Event.PayloadFile
+	// The native checkout adapter needs the genuine PR repository IDs and SHAs
+	// to enforce pull_request_target's fork checkout guard, even when the workflow
+	// never reads github.event. The artifact is still digest-bound to this plan.
+	job.Event.PayloadArtifact = actions.requiresEventPayload || job.Event.PayloadFile || job.Event.Name == "pull_request_target"
 	job.RequiresMise = &actions.requiresMise
 	return job
 }

--- a/internal/runtime/checkout.go
+++ b/internal/runtime/checkout.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"maps"
 	"os"
@@ -82,6 +83,9 @@ func (r Runner) runCheckout(ctx context.Context, processor *commandOutputProcess
 	}
 	if err := actionintegration.ValidateCheckoutInputs(commit, inputs, job.Event.Repository, job.Event.SHA); err != nil {
 		return result, fmt.Errorf("%s: %w", adapter, err)
+	}
+	if err := validateTargetCheckout(job.Event, inputs); err != nil {
+		return result, err
 	}
 	inputs = checkoutInputsWithReleaseDefaults(commit, inputs)
 	lfs := checkoutInputTrue(checkoutInput(inputs, "lfs"))
@@ -209,6 +213,42 @@ func (r Runner) runCheckout(ctx context.Context, processor *commandOutputProcess
 	}
 	setCheckoutOutputs(result.Outputs, commit, checkoutRefOutput(inputs, job.Event.Ref), headSHA)
 	return result, nil
+}
+
+// Mirror checkout's fork-PR guard. Repository overrides and refs/pull refs are
+// already rejected by the adapter's bounded input contract. Explicit opt-out
+// remains unsupported; this is not a sandbox for user-authored git commands.
+func validateTargetCheckout(event plan.Event, inputs map[string]string) error {
+	if event.Name != "pull_request_target" {
+		return nil
+	}
+	if event.Payload == nil {
+		return fmt.Errorf("target checkout requires the verified PR payload")
+	}
+	payload := *event.Payload
+	pr, _ := payload["pull_request"].(map[string]any)
+	repository, _ := payload["repository"].(map[string]any)
+	head, _ := pr["head"].(map[string]any)
+	headRepository, _ := head["repo"].(map[string]any)
+	baseID, _ := repository["id"].(json.Number)
+	headID, _ := headRepository["id"].(json.Number)
+	baseNumber, baseErr := baseID.Int64()
+	headNumber, headErr := headID.Int64()
+	headSHA, _ := head["sha"].(string)
+	if baseErr != nil || headErr != nil || baseNumber <= 0 || headNumber <= 0 || !gitutil.ValidObjectID(headSHA) {
+		return fmt.Errorf("target checkout requires valid PR repository IDs and head SHA")
+	}
+	if baseNumber == headNumber {
+		return nil
+	}
+	selected, branch := checkoutSelectedRevision(inputs, event.SHA)
+	if branch {
+		return nil
+	}
+	if selected == head["sha"] || selected == pr["merge_commit_sha"] {
+		return fmt.Errorf("target checkout of a fork PR head or merge SHA is unsafe; use the default checkout")
+	}
+	return nil
 }
 
 func setCheckoutOutputs(outputs map[string]string, commit, ref, headSHA string) {

--- a/internal/runtime/checkout_test.go
+++ b/internal/runtime/checkout_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -23,6 +24,53 @@ import (
 	"github.com/buildkite/buildkite-gha/internal/plan"
 	executionprogram "github.com/buildkite/buildkite-gha/internal/program"
 )
+
+func TestTargetCheckoutGuard(t *testing.T) {
+	for _, test := range []struct {
+		name, event, ref, headID string
+		missingPayload, denied   bool
+	}{
+		{"default fork checkout", "pull_request_target", "", "2", false, false},
+		{"explicit fork head", "pull_request_target", strings.Repeat("b", 40), "2", false, true},
+		{"explicit fork merge", "pull_request_target", strings.Repeat("c", 40), "2", false, true},
+		{"same repository head", "pull_request_target", strings.Repeat("b", 40), "1", false, false},
+		{"same repository merge", "pull_request_target", strings.Repeat("c", 40), "1", false, false},
+		{"base repository branch", "pull_request_target", "feature", "2", false, false},
+		{"unrelated commit", "pull_request_target", strings.Repeat("d", 40), "2", false, false},
+		{"ordinary PR unchanged", "pull_request", strings.Repeat("b", 40), "2", false, false},
+		{"missing payload", "pull_request_target", "", "2", true, true},
+		{"missing head ID", "pull_request_target", strings.Repeat("b", 40), "", false, true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			payload := map[string]any{
+				"repository": map[string]any{"id": json.Number("1")},
+				"pull_request": map[string]any{
+					"merge_commit_sha": strings.Repeat("c", 40),
+					"head":             map[string]any{"sha": strings.Repeat("b", 40), "repo": map[string]any{"id": json.Number(test.headID)}},
+				},
+			}
+			event := plan.Event{Provider: "github", Name: test.event, Repository: "acme/repo", SHA: strings.Repeat("a", 40), Payload: &payload}
+			if test.missingPayload {
+				event.Payload = nil
+			}
+			inputs := map[string]string{"ref": test.ref}
+			if err := validateTargetCheckout(event, inputs); (err != nil) != test.denied {
+				t.Fatalf("checkout guard: %v, denied=%v", err, test.denied)
+			}
+			if test.denied {
+				workspace := t.TempDir()
+				_, err := (Runner{}).runCheckout(t.Context(), newCommandOutputProcessor(io.Discard, io.Discard), workspace, plan.Job{Event: event}, actionintegration.CheckoutV7Commit, inputs)
+				if err == nil {
+					t.Fatal("adapter bypassed guard")
+				}
+				entries, _ := os.ReadDir(workspace)
+				if len(entries) != 0 {
+					t.Fatal("checkout performed work before rejection")
+				}
+			}
+		})
+	}
+}
 
 func TestAnonymousCheckoutAdapterPopulatesVerifiedWorkspace(t *testing.T) {
 	workspace := t.TempDir()
@@ -148,6 +196,40 @@ esac
 	if got, err := os.ReadFile(filepath.Join(workspace, ".git", "HEAD")); err != nil || strings.TrimSpace(string(got)) != sha {
 		t.Fatalf("checkout HEAD = %q, %v", got, err)
 	}
+
+	// A target PR retains head/base context without changing no-ref checkout or
+	// the subsequently verified local action source. This executes the adapter
+	// and local action using a fake Git process, not a live GitHub checkout.
+	job.Event.Name = "pull_request_target"
+	job.Event.Ref, job.Event.HeadRef, job.Event.BaseRef = "refs/heads/main", "feature", "release"
+	prPayload := map[string]any{
+		"repository":   map[string]any{"id": json.Number("1")},
+		"pull_request": map[string]any{"head": map[string]any{"sha": strings.Repeat("b", 40), "repo": map[string]any{"id": json.Number("2")}}},
+	}
+	job.Event.Payload = &prPayload
+	prBytes, err := json.Marshal(prPayload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalPayloadDigest := job.Event.PayloadDigest
+	job.Event.PayloadDigest = fmt.Sprintf("sha256:%x", sha256.Sum256(prBytes))
+	if err := os.Remove(gitLog); err != nil {
+		t.Fatal(err)
+	}
+	result, err = (Runner{Git: git, Actions: materializer}).runTestJob(t.Context(), job, t.TempDir())
+	if err != nil || result.Conclusion != "success" || result.Env["CHECKOUT_CHAIN"] != "ok" {
+		t.Fatalf("target checkout/local action = %#v, %v", result, err)
+	}
+	logBytes, err = os.ReadFile(gitLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(logBytes), "checkout --detach "+sha) || strings.Contains(string(logBytes), "refs/pull/") || strings.Contains(string(logBytes), "origin feature") {
+		t.Fatalf("target checkout used PR identity: %s", logBytes)
+	}
+	job.Event.Name, job.Event.HeadRef, job.Event.BaseRef = "push", "", ""
+	job.Event.Payload = nil
+	job.Event.PayloadDigest = originalPayloadDigest
 
 	job.Program.Job.Steps[0].Invocation.With = testProgramBindingsPurpose(map[string]string{"ref": "${{ needs.configure.outputs.sha }}"}, executionprogram.SurfaceStepTemplate, executionprogram.PurposeActionInput)
 	job.Needs = map[string]plan.Need{"configure": {Result: "success", Outputs: map[string]string{"sha": strings.Repeat("b", 40)}}}


### PR DESCRIPTION
## Why

`on: pull_request_target` cannot currently run through GitHub Actions Pipeline Triggers. Treating it as an ordinary PR event would select attacker-controlled workflow and action source.

## What

Support target imports from the backend-selected immutable default-branch commit, while preserving the original PR payload and head/base context. For a PR targeting `release` in a repository whose default is `main`, workflow source and default checkout use the selected `main` commit; branch filters still match `release`, and paths compare PR base to head.

Require matching server workflow identity, linked payload and clean Git source before compilation. Retain the verified payload for native checkout's fork head/merge SHA guard. Existing token, secret, environment and action-source policies remain in force.

This is bounded support, not full GitHub parity: the backend pins at processing time, path filters require existing local PR history, and target imports reject dirty/sparse/submodule checkouts. PR write tokens and unsafe-checkout/cache-write opt-outs are not added. The compatibility and security guides spell out these limits.

Release this runtime before the companion backend enables target dispatch. The backend must deny target cache writes, including same-repository PRs. Local fixtures exercise distinct default/base/head source and moved refs; no live GitHub or hosted Buildkite end-to-end proof is claimed.

Companion backend: https://github.com/buildkite/buildkite/pull/34172
