### PR TITLE
Give unsupported Windows runners a support pathway

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -64,6 +64,12 @@ that could be added to the supported platforms. This distinction does not
 change validation: Windows workflows remain unsupported and appear in raw
 corpus results.
 
+If a job requires a platform that its runner mapping does not support,
+[contact Buildkite support](mailto:support@buildkite.com) with the `runs-on`
+label, required operating system and architecture, and a link to the Buildkite
+build. Creating a hosted queue alone does not enable GitHub Actions support
+for that platform. Change to a supported label only if the job can run there.
+
 ## How workflows run on Buildkite
 
 GitHub Actions combines run creation and workload definition in one file. Buildkite keeps them separate.

--- a/internal/cli/processing_report.go
+++ b/internal/cli/processing_report.go
@@ -608,6 +608,7 @@ func renderProcessingDiagnostic(ctx context.Context, diagnostic compatibility.Di
 			detail = strings.ReplaceAll(detail, "&#34;ubuntu-latest&#34;", annotationCode("ubuntu-latest"))
 			const issueURL = "https://github.com/buildkite/buildkite-gha"
 			detail = strings.ReplaceAll(detail, issueURL+" ", `<a href="`+issueURL+`" target="_blank">buildkite/buildkite-gha</a> `)
+			detail = strings.ReplaceAll(detail, "contact support@buildkite.com with", `contact <a href="mailto:support@buildkite.com">support@buildkite.com</a> with`)
 			out.WriteString(detail)
 			out.WriteString("</p>\n")
 		}

--- a/internal/cli/upload_test.go
+++ b/internal/cli/upload_test.go
@@ -1655,6 +1655,7 @@ func runnerResolutionServer(t *testing.T, status int, verdicts map[string]map[st
 func TestRunUploadReportsServerRunnerRejectionsInsteadOfLocalPresets(t *testing.T) {
 	requireImporterHost(t)
 	const missingQueueMessage = "The 'Default' cluster has no hosted macOS queue for this runner selector. Create a hosted macOS queue named macos-medium, or map this runner label to an existing queue: https://github.com/buildkite/buildkite-gha/blob/main/docs/compatibility.md"
+	const incompatibleMessage = "This operating system or architecture is not supported by the current GitHub Actions runner mapping. If it requires this platform, contact support@buildkite.com with the runner label and a link to the build to ask about support."
 	repository := writeUploadWorkflowRepository(t, map[string]string{
 		"runners.yml": "name: Runners\non: push\njobs:\n  mac:\n    runs-on: macos-latest\n    steps: [{run: true}]\n  arm:\n    runs-on: ubuntu-24.04-arm\n    steps: [{run: true}]\n  windows:\n    runs-on: windows-latest\n    steps: [{run: true}]\n  linux:\n    runs-on: ubuntu-latest\n    steps: [{run: true}]\n",
 	})
@@ -1664,7 +1665,7 @@ func TestRunUploadReportsServerRunnerRejectionsInsteadOfLocalPresets(t *testing.
 	}
 	server, requests := runnerResolutionServer(t, http.StatusOK, map[string]map[string]any{
 		"macos-latest":     {"error": map[string]any{"code": "missing_queue", "message": missingQueueMessage, "platform": "darwin/arm64", "required_queues": []string{"macos-medium"}}},
-		"ubuntu-24.04-arm": {"error": map[string]any{"code": "incompatible_labels", "message": "No compatible runner is configured."}},
+		"ubuntu-24.04-arm": {"error": map[string]any{"code": "incompatible_labels", "message": incompatibleMessage}},
 		"windows-latest":   {"error": map[string]any{"code": "incompatible_labels", "message": "No compatible runner is configured."}},
 		"ubuntu-latest":    {"target": map[string]string{"queue": "linux-medium", "platform": "linux/amd64", "image": defaultNobleRunnerImage}},
 	})
@@ -1700,10 +1701,10 @@ func TestRunUploadReportsServerRunnerRejectionsInsteadOfLocalPresets(t *testing.
 	if !strings.Contains(message, `Buildkite could not resolve runner label "macos-latest". `+missingQueueMessage) {
 		t.Fatalf("missing_queue rejection was not rendered: %q", message)
 	}
-	if !strings.Contains(message, `Buildkite could not resolve runner label "ubuntu-24.04-arm". No compatible runner is configured. Change runs-on to a Linux or macOS runner label that Buildkite hosted agents support.`) {
+	if !strings.Contains(message, `Buildkite could not resolve runner label "ubuntu-24.04-arm". `+incompatibleMessage) {
 		t.Fatalf("incompatible_labels rejection was not rendered: %q", message)
 	}
-	if !strings.Contains(message, `Windows runners aren't currently supported.`) {
+	if !strings.Contains(message, `Windows runners are not enabled for this workflow.`) {
 		t.Fatalf("local Windows guidance was replaced by the server rejection: %q", message)
 	}
 	if strings.Contains(message, "has no runner-target mapping") || strings.Contains(message, `job "linux"`) {
@@ -1823,7 +1824,7 @@ func TestRunUploadContinuesAfterWorkflowCompilationFailures(t *testing.T) {
 		t.Fatalf("expanded failed workflow = %#v", missing)
 	}
 	firstFailureMessage := failureLogText(failureArtifactForStep(pipeline.Steps[0].Plugins, runner.uploaded, "messages"))
-	if !strings.Contains(firstFailureMessage, `Windows runners aren't currently supported. Imported jobs run on Linux or macOS Buildkite hosted agents. If this job can run on Linux, change "windows-latest" to "ubuntu-latest". If it requires Windows, open an issue in https://github.com/buildkite/buildkite-gha to help us prioritize Windows support.`) ||
+	if !strings.Contains(firstFailureMessage, `Windows runners are not enabled for this workflow. If this job can run on Linux, change "windows-latest" to "ubuntu-latest". If it requires Windows, contact support@buildkite.com with the runner label and a link to the build to ask about Windows support. Creating a hosted Windows queue alone does not enable GitHub Actions support.`) ||
 		!strings.Contains(firstFailureMessage, `Runner label "macos-15" has no runner-target mapping. Configure a mapping for this label or use a mapped runner label.`) ||
 		strings.Count(firstFailureMessage, "detail: Supported runner labels: macos-latest, ubuntu-22.04, ubuntu-24.04, ubuntu-latest.") != 1 {
 		t.Fatalf("multi-diagnostic failure message = %q", firstFailureMessage)

--- a/internal/cli/validate_test.go
+++ b/internal/cli/validate_test.go
@@ -135,10 +135,10 @@ func TestValidatePublishesProcessingDiagnosticsInBuildkite(t *testing.T) {
 		}
 		for _, want := range []string{
 			`<h2 class="h4 mb2">Workflow could not be run</h2>`,
-			`<p><strong>Windows runners aren&#39;t currently supported.</strong></p>`,
-			`Imported jobs run on Linux or macOS Buildkite hosted agents.`,
+			`<p><strong>Windows runners are not enabled for this workflow.</strong></p>`,
 			`If this job can run on Linux, change <code>windows-latest</code> to <code>ubuntu-latest</code>.`,
-			`If it requires Windows, open an issue in <a href="https://github.com/buildkite/buildkite-gha" target="_blank">buildkite/buildkite-gha</a> to help us prioritize Windows support.`,
+			`If it requires Windows, contact <a href="mailto:support@buildkite.com">support@buildkite.com</a> with the runner label and a link to the build to ask about Windows support.`,
+			`Creating a hosted Windows queue alone does not enable GitHub Actions support.`,
 			"Job <code>test</code>",
 		} {
 			if !strings.Contains(string(annotation.stdin), want) {

--- a/internal/compiler/config.go
+++ b/internal/compiler/config.go
@@ -16,6 +16,7 @@ var queuePattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,255}$`)
 var distributionDigestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
 var runtimeImagePattern = regexp.MustCompile(`^[a-z0-9]+(?:[._-][a-z0-9]+)*(?:/[a-z0-9]+(?:[._-][a-z0-9]+)*)+@sha256:[0-9a-f]{64}$`)
 var stepKeyNamespacePattern = regexp.MustCompile(`^[0-9a-f]{16}$`)
+var windowsRunnerLabelPattern = regexp.MustCompile(`(?i)(?:^|[-_./\s])(?:windows|win32|win64)(?:$|[-_./\s\d])`)
 
 // OperatingSystem identifies one supported workflow host operating system.
 type OperatingSystem string
@@ -527,7 +528,7 @@ func runnerRejectionDiagnostic(err error, labels, supported, untrustedQueues []s
 		if label != "" {
 			linuxGuidance = fmt.Sprintf(`If this job can run on Linux, change%s to "ubuntu-latest".`, label)
 		}
-		return "Windows runners aren't currently supported. Imported jobs run on Linux or macOS Buildkite hosted agents. " + linuxGuidance + " If it requires Windows, open an issue in https://github.com/buildkite/buildkite-gha to help us prioritize Windows support.", ""
+		return "Windows runners are not enabled for this workflow. " + linuxGuidance + " If it requires Windows, contact support@buildkite.com with the runner label and a link to the build to ask about Windows support. Creating a hosted Windows queue alone does not enable GitHub Actions support.", ""
 	case reasonUnmappedLabel:
 		return fmt.Sprintf("Runner label%s has no runner-target mapping. Configure a mapping for this label or use a mapped runner label.", label), detail
 	case reasonServerRejected:
@@ -563,11 +564,9 @@ func serverRunnerRejectionDiagnostic(rejection RunnerRejection, label, supported
 	}
 	message = fmt.Sprintf("Buildkite could not resolve %s. ", subject)
 	switch rejection.Code {
-	case RunnerRejectionMissingQueue, RunnerRejectionNoCluster:
+	case RunnerRejectionMissingQueue, RunnerRejectionNoCluster, RunnerRejectionIncompatibleLabels:
 		// The server message may end with a documentation URL; leave it intact.
 		return message + strings.Join(strings.Fields(rejection.Message), " "), ""
-	case RunnerRejectionIncompatibleLabels:
-		return message + sentence(rejection.Message) + " Change runs-on to a Linux or macOS runner label that Buildkite hosted agents support.", supportedDetail
 	default:
 		return message + sentence(rejection.Message) + " Configure a mapping for this selector or use a mapped runner label.", supportedDetail
 	}
@@ -605,7 +604,7 @@ func (policy RunnerPolicy) supportedLabels() []string {
 }
 
 func unsupportedOS(label string) bool {
-	return strings.HasPrefix(label, "windows-") || label == "windows"
+	return windowsRunnerLabelPattern.MatchString(label)
 }
 
 func targetDescription(target RunnerTarget) string {

--- a/internal/compiler/config_test.go
+++ b/internal/compiler/config_test.go
@@ -662,8 +662,12 @@ func TestRunnerRejectionDiagnosticRendersServerRejections(t *testing.T) {
 			name:        "incompatible labels",
 			rejection:   RunnerRejection{Labels: []string{"self-hosted", "arm64"}, Code: RunnerRejectionIncompatibleLabels, Message: "No compatible runner is configured."},
 			labels:      []string{"self-hosted", "arm64"},
-			wantMessage: "Buildkite could not resolve the runs-on labels. No compatible runner is configured. Change runs-on to a Linux or macOS runner label that Buildkite hosted agents support.",
-			wantDetail:  "Supported runner labels: ubuntu-22.04, ubuntu-24.04, ubuntu-latest.",
+			wantMessage: "Buildkite could not resolve the runs-on labels. No compatible runner is configured.",
+		},
+		{
+			name:        "incompatible labels preserves support guidance and trailing URL",
+			rejection:   RunnerRejection{Labels: []string{"ubuntu-24.04-arm"}, Code: RunnerRejectionIncompatibleLabels, Message: "This platform is not supported by the current runner mapping. If it requires this platform, contact support@buildkite.com with the runner label and a link to the build. See https://github.com/buildkite/buildkite-gha/blob/main/docs/compatibility.md"},
+			wantMessage: "Buildkite could not resolve the runs-on labels. This platform is not supported by the current runner mapping. If it requires this platform, contact support@buildkite.com with the runner label and a link to the build. See https://github.com/buildkite/buildkite-gha/blob/main/docs/compatibility.md",
 		},
 		{
 			name:        "legacy unmapped labels keeps mapping guidance",
@@ -731,7 +735,7 @@ func TestRunnerRejectionDiagnosticSeparatesStaticLabelFromAllowlist(t *testing.T
 	}{
 		{
 			label:       "windows-latest",
-			wantMessage: `Windows runners aren't currently supported. Imported jobs run on Linux or macOS Buildkite hosted agents. If this job can run on Linux, change "windows-latest" to "ubuntu-latest". If it requires Windows, open an issue in https://github.com/buildkite/buildkite-gha to help us prioritize Windows support.`,
+			wantMessage: `Windows runners are not enabled for this workflow. If this job can run on Linux, change "windows-latest" to "ubuntu-latest". If it requires Windows, contact support@buildkite.com with the runner label and a link to the build to ask about Windows support. Creating a hosted Windows queue alone does not enable GitHub Actions support.`,
 		},
 		{
 			label:       "macos-latest",
@@ -755,6 +759,31 @@ func TestRunnerRejectionDiagnosticSeparatesStaticLabelFromAllowlist(t *testing.T
 		}
 		if strings.Contains(message, "ubuntu-22.04") {
 			t.Fatalf("runner allowlist leaked into message: %q", message)
+		}
+	}
+}
+
+func TestProviderWindowsRunnerDiagnostics(t *testing.T) {
+	for _, label := range []string{"depot-windows-2025-16", "BLACKSMITH-4VCPU-WINDOWS-2025", "windows/amd64", "self_hosted_win64"} {
+		t.Run(label, func(t *testing.T) {
+			policy := RunnerPolicy{Rejections: []RunnerRejection{{Labels: []string{label}, Code: RunnerRejectionIncompatibleLabels, Message: "Generic server rejection."}}}
+			_, err := policy.Resolve([]string{label}, EventTrusted)
+			message, detail := runnerRejectionDiagnostic(err, nil, []string{"ubuntu-latest"}, nil)
+			for _, want := range []string{"Windows runners are not enabled for this workflow.", `If this job can run on Linux, change runs-on to "ubuntu-latest".`, "contact support@buildkite.com with the runner label and a link to the build"} {
+				if !strings.Contains(message, want) {
+					t.Fatalf("diagnostic = %q, want %q", message, want)
+				}
+			}
+			if detail != "" || strings.Contains(message, label) || strings.Contains(message, "Generic server rejection") {
+				t.Fatalf("diagnostic leaked a resolved label or lost Windows guidance: %q, %q", message, detail)
+			}
+		})
+	}
+	for _, label := range []string{"windowsill", "mywindows-runner", "depot-ubuntu-24.04", "custom-win64bit"} {
+		_, err := (RunnerPolicy{}).Resolve([]string{label}, EventTrusted)
+		message, _ := runnerRejectionDiagnostic(err, []string{label}, nil, nil)
+		if !strings.Contains(message, "has no runner-target mapping") {
+			t.Fatalf("non-Windows label %q misclassified: %q", label, message)
 		}
 	}
 }


### PR DESCRIPTION
## Why

`runs-on: depot-windows-2025-16` receives a generic mapping error, while `windows-latest` gets Windows-specific advice. Neither should imply that creating a Windows hosted queue alone enables the workflow to run.

## What

Recognize Windows tokens in provider labels and show the same support pathway:

> Windows runners are not enabled for this workflow.
>
> If this job can run on Linux, change "depot-windows-2025-16" to "ubuntu-latest".
>
> If it requires Windows, contact support@buildkite.com with the runner label and a link to the build to ask about Windows support.
>
> Creating a hosted Windows queue alone does not enable GitHub Actions support.

Make that email address a clickable link in annotations. Preserve the server's platform-incompatibility explanation without appending generic advice or a misleading local preset list; newer server messages provide the support pathway for other unsupported architectures. Deploy that server guidance before releasing this change.

This adds no Windows execution target or default mapping. Existing authoritative selectors remain authoritative, and labels derived from untrusted event data remain absent from diagnostic prose.
